### PR TITLE
Edit to webgl_panorama_equirectangular.html to enable mousewheel zoom in more browsers

### DIFF
--- a/examples/webgl_panorama_equirectangular.html
+++ b/examples/webgl_panorama_equirectangular.html
@@ -72,6 +72,7 @@
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 				document.addEventListener( 'mouseup', onDocumentMouseUp, false );
 				document.addEventListener( 'mousewheel', onDocumentMouseWheel, false );
+				document.addEventListener( 'DOMMouseScroll', onDocumentMouseWheel, false);
 
 			}
 
@@ -107,7 +108,26 @@
 
 			function onDocumentMouseWheel( event ) {
 
-				fov -= event.wheelDeltaY * 0.05;
+				// WebKit
+
+				if ( event.wheelDeltaY ) {
+
+					fov -= event.wheelDeltaY * 0.05;
+
+				// Opera / Explorer 9
+
+				} else if ( event.wheelDelta ) {
+
+					fov -= event.wheelDelta * 0.05;
+
+				// Firefox
+
+				} else if ( event.detail ) {
+
+					fov += event.detail * 1.0;
+
+				}
+
 				camera.projectionMatrix = THREE.Matrix4.makePerspective( fov, window.innerWidth / window.innerHeight, 1, 1100 );
 				render();
 


### PR DESCRIPTION
Added the same onDocumentMouseWheel() function and event handlers as in canvas_geometry_panorama_fisheye.html so that mousewheel zooming works on Firefox 4 and other browsers. 
