### PR TITLE
Add a useful --unminified parameter to the build.py

### DIFF
--- a/utils/build.py
+++ b/utils/build.py
@@ -351,7 +351,7 @@ def makeDebug(text):
 	return text
 
 
-def buildLib(files, debug, filename):
+def buildLib(files, debug, unminified, filename):
 
 	text = merge(files)
 
@@ -370,7 +370,10 @@ def buildLib(files, debug, filename):
 	print "Compiling", filename
 	print "=" * 40
 
-	output(addHeader(compress(text), filename), folder + filename)
+	if not unminified:
+		text = compress(text)
+	
+	output(addHeader(text, filename), folder + filename)
 
 
 def buildIncludes(files, filename):
@@ -393,6 +396,7 @@ def parse_args():
 		parser.add_argument('--svg', help='Build ThreeSVG.js', action='store_true')
 		parser.add_argument('--dom', help='Build ThreeDOM.js', action='store_true')
 		parser.add_argument('--debug', help='Generate debug versions', action='store_const', const=True, default=False)
+		parser.add_argument('--unminified', help='Generate unminified versions', action='store_const', const=True, default=False)
 		parser.add_argument('--all', help='Build all Three.js versions', action='store_true')
 
 		args = parser.parse_args()
@@ -407,6 +411,7 @@ def parse_args():
 		parser.add_option('--svg', dest='svg', help='Build ThreeSVG.js', action='store_true')
 		parser.add_option('--dom', dest='dom', help='Build ThreeDOM.js', action='store_true')
 		parser.add_option('--debug', dest='debug', help='Generate debug versions', action='store_const', const=True, default=False)
+		parser.add_option('--unminified', help='Generate unminified versions', action='store_const', const=True, default=False)
 		parser.add_option('--all', dest='all', help='Build all Three.js versions', action='store_true')
 
 		args, remainder = parser.parse_args()
@@ -423,6 +428,7 @@ def main(argv=None):
 
 	args = parse_args()
 	debug = args.debug
+	unminified = args.unminified
 
 	config = [
 	['Three', 'includes', COMMON_FILES + EXTRAS_FILES, args.common],
@@ -435,7 +441,7 @@ def main(argv=None):
 
 	for fname_lib, fname_inc, files, enabled in config:
 		if enabled or args.all:
-			buildLib(files, debug, fname_lib)
+			buildLib(files, debug, unminified, fname_lib)
 			if args.includes:
 				buildIncludes(files, fname_inc)
 

--- a/utils/build.xml
+++ b/utils/build.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="THREE.JS" basedir="." default="build">
+	<property name="build_dir" value="./" description="THREE.js build directory" />
+	<property name="build_py" value="${build_dir}/build.py" description="THREE.js 'build.py' file" />
+	<property name="python_dir" value="" description="Python directory, leave empty if in classpath or don't forget ending slash" />
+
+    <target name="build" description="Build all THREE.js">
+    	<exec executable="${python_dir}python">
+    	    <arg value="${build_py}"/>
+    	    <arg value="--all"/>
+    	  </exec>
+    </target>
+	
+    <target name="common" description="Build THREE.js commons">
+    	<exec executable="${python_dir}python">
+    	    <arg value="${build_py}"/>
+    	    <arg value="--common"/>
+    	    <arg value="--includes"/>
+    	  </exec>
+    </target>
+
+	<target name="debug" description="Build debug THREE.js">
+    	<exec executable="${python_dir}python">
+    	    <arg value="${build_py}"/>
+    	    <arg value="--all"/>
+    	    <arg value="--debug"/>
+    	  </exec>
+    </target>
+	
+    <target name="unminified" description="Build debug THREE.js">
+    	<exec executable="${python_dir}python">
+    	    <arg value="${build_py}"/>
+    	    <arg value="--all"/>
+    	    <arg value="--unminified"/>
+    	  </exec>
+    </target>
+</project>


### PR DESCRIPTION
Hi MrDoob,

I humbly request to you to pull these two tiny modifications / improvements to your build process.

Add --unminified optional parameter to the build.py, useful when developing without being required to modify the build script itself 
unminified output is a great way to learn what happens inside THREE.js engine when debugging
- it does not change the default build process

Add an Ant build.xml file : another way to launch different pre-configured builds

Regards,

Stephane

PS : this is my very first GitHub Pull Request so forgive me if I made a mistake or did not go through the good process
