### PR TITLE
Expanded Collision for meshes to include Face4 faces

### DIFF
--- a/src/extras/physics/CollisionUtils.js
+++ b/src/extras/physics/CollisionUtils.js
@@ -40,30 +40,7 @@ THREE.CollisionUtils.MeshAABB = function( m ) {
 
 THREE.CollisionUtils.MeshColliderWBox = function( m ) {
 
-	var mv = m.geometry.vertices;
-	var mvl = mv.length;
-	var mf = m.geometry.faces;
-	var mfl = mf.length;
-
-	var vertices = [];
-	var faces = [];
-	var normals = [];
-
-	for( var i = 0; i < mvl; i++ ) {
-
-		vertices.push( new THREE.Vector3( mv[ i ].position.x, mv[ i ].position.y, mv[ i ].position.z ) );
-
-	}
-
-	for( var i = 0; i < mfl; i++ ) {
-
-		faces.push( mf[ i ].a, mf[ i ].b, mf[ i ].c );
-		normals.push( new THREE.Vector3( mf[ i ].normal.x, mf[ i ].normal.y, mf[ i ].normal.z ) );
-
-	}
-
-	var mc = new THREE.MeshCollider( vertices, faces, normals, THREE.CollisionUtils.MeshOBB( m ) );
-	mc.mesh = m;
+	var mc = new THREE.MeshCollider( m, THREE.CollisionUtils.MeshOBB( m ) );
 
 	return mc;
 

--- a/src/extras/physics/Collisions.js
+++ b/src/extras/physics/Collisions.js
@@ -28,13 +28,11 @@ THREE.BoxCollider = function( min, max ) {
 
 };
 
-THREE.MeshCollider = function( vertices, faces, normals, box ) {
+THREE.MeshCollider = function( mesh, box ) {
 
-	this.vertices = vertices;
-	this.faces = faces;
-	this.normals = normals;
+	this.mesh = mesh;
 	this.box = box;
-	this.numFaces = this.faces.length;
+	this.numFaces = this.mesh.geometry.faces.length;
 
 	this.normal = new THREE.Vector3();
 
@@ -144,23 +142,49 @@ THREE.CollisionSystem.prototype.rayMesh = function( r, me ) {
 
 	var d = Number.MAX_VALUE;
 
-	for( var i = 0; i < me.numFaces/3; i++ ) {
+	for( var i = 0; i < me.numFaces; i++ ) {
+        var face = me.mesh.geometry.faces[i];
+		var p0 = me.mesh.geometry.vertices[ face.a ].position;
+		var p1 = me.mesh.geometry.vertices[ face.b ].position;
+		var p2 = me.mesh.geometry.vertices[ face.c ].position;
+        var p3 = face instanceof THREE.Face4 ? me.mesh.geometry.vertices[ face.d ].position : null;
 
-		var t = i * 3;
+        if (face instanceof THREE.Face3) {
+            var nd = this.rayTriangle( rt, p0, p1, p2, d, this.collisionNormal );
 
-		var p0 = me.vertices[ me.faces[ t + 0 ] ];
-		var p1 = me.vertices[ me.faces[ t + 1 ] ];
-		var p2 = me.vertices[ me.faces[ t + 2 ] ];
+            if( nd < d ) {
 
-		var nd = this.rayTriangle( rt, p0, p1, p2, d, this.collisionNormal );
+                d = nd;
+                me.normal.copy( this.collisionNormal );
+                me.normal.normalize();
 
-		if( nd < d ) {
+            }
+        
+        }
+        
+        else if (face instanceof THREE.Face4) {
+            
+            var nd = this.rayTriangle( rt, p0, p1, p2, d, this.collisionNormal );
+            
+            if( nd < d ) {
 
-			d = nd;
-			me.normal.copy( this.collisionNormal );
-			me.normal.normalize();
+                d = nd;
+                me.normal.copy( this.collisionNormal );
+                me.normal.normalize();
 
-		}
+            }
+            
+            nd = this.rayTriangle( rt, p1, p2, p3, d, this.collisionNormal );
+            
+            if( nd < d ) {
+
+                d = nd;
+                me.normal.copy( this.collisionNormal );
+                me.normal.normalize();
+
+            }
+
+        }
 
 	}
 

--- a/src/extras/physics/Collisions.js
+++ b/src/extras/physics/Collisions.js
@@ -167,7 +167,7 @@ THREE.CollisionSystem.prototype.rayMesh = function( r, me ) {
         
         else if (face instanceof THREE.Face4) {
             
-            var nd = this.rayTriangle( rt, p0, p1, p2, d, this.collisionNormal );
+            var nd = this.rayTriangle( rt, p0, p1, p3, d, this.collisionNormal );
             
             if( nd < d ) {
 

--- a/src/extras/physics/Collisions.js
+++ b/src/extras/physics/Collisions.js
@@ -101,11 +101,12 @@ THREE.CollisionSystem.prototype.rayCastNearest = function( ray ) {
 
 	while( cs[ i ] instanceof THREE.MeshCollider ) {
 
-		var d = this.rayMesh( ray, cs[ i ] );
+        var dist_index = this.rayMesh ( ray, cs[ i ] );
 
-		if( d < Number.MAX_VALUE ) {
+		if( dist_index.dist < Number.MAX_VALUE ) {
 
-			cs[ i ].distance = d;
+			cs[ i ].distance = dist_index.dist;
+            cs[ i ].faceIndex = dist_index.faceIndex;
 			break;
 
 		}
@@ -141,12 +142,13 @@ THREE.CollisionSystem.prototype.rayMesh = function( r, me ) {
 	var rt = this.makeRayLocal( r, me.mesh );
 
 	var d = Number.MAX_VALUE;
+    var nearestface;
 
 	for( var i = 0; i < me.numFaces; i++ ) {
         var face = me.mesh.geometry.faces[i];
-		var p0 = me.mesh.geometry.vertices[ face.a ].position;
-		var p1 = me.mesh.geometry.vertices[ face.b ].position;
-		var p2 = me.mesh.geometry.vertices[ face.c ].position;
+        var p0 = me.mesh.geometry.vertices[ face.a ].position;
+        var p1 = me.mesh.geometry.vertices[ face.b ].position;
+        var p2 = me.mesh.geometry.vertices[ face.c ].position;
         var p3 = face instanceof THREE.Face4 ? me.mesh.geometry.vertices[ face.d ].position : null;
 
         if (face instanceof THREE.Face3) {
@@ -155,6 +157,7 @@ THREE.CollisionSystem.prototype.rayMesh = function( r, me ) {
             if( nd < d ) {
 
                 d = nd;
+                nearestface = i;
                 me.normal.copy( this.collisionNormal );
                 me.normal.normalize();
 
@@ -169,6 +172,7 @@ THREE.CollisionSystem.prototype.rayMesh = function( r, me ) {
             if( nd < d ) {
 
                 d = nd;
+                nearestface = i;
                 me.normal.copy( this.collisionNormal );
                 me.normal.normalize();
 
@@ -179,6 +183,7 @@ THREE.CollisionSystem.prototype.rayMesh = function( r, me ) {
             if( nd < d ) {
 
                 d = nd;
+                nearestface = i;
                 me.normal.copy( this.collisionNormal );
                 me.normal.normalize();
 
@@ -188,7 +193,7 @@ THREE.CollisionSystem.prototype.rayMesh = function( r, me ) {
 
 	}
 
-	return d;
+	return {dist: d, faceIndex: nearestface};
 
 };
 


### PR DESCRIPTION
- removed duplication of faces, vertices, and normals; MeshCollider works directly on source mesh (was this very loose coupling there for a reason?)
- Face4 intersection is done through 2 rayTriangle calls -> todo: make rayQuad function?
- in addition to distance, raycastNearest returns index of the face the ray collides with (handy to use as uniform in fragmentshaders to e.g. color the "hit" face differently)
