### PR TITLE
Add optional parameter, scaleByViewport, to Sprite.js

### DIFF
--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -23,7 +23,8 @@ THREE.Sprite = function( parameters ) {
 	this.useScreenCoordinates = parameters.useScreenCoordinates !== undefined ? parameters.useScreenCoordinates : true;
 	this.mergeWith3D = parameters.mergeWith3D !== undefined ? parameters.mergeWith3D : !this.useScreenCoordinates;
 	this.affectedByDistance = parameters.affectedByDistance !== undefined ? parameters.affectedByDistance : !this.useScreenCoordinates;
-	this.alignment = parameters.alignment instanceof THREE.Vector2 ? parameters.alignment : THREE.SpriteAlignment.center;
+	this.scaleByViewport = parameters.scaleByViewport !== undefined ? parameters.scaleByViewport : !this.affectedByDistance;
+  this.alignment = parameters.alignment instanceof THREE.Vector2 ? parameters.alignment : THREE.SpriteAlignment.center;
 
 	this.rotation3d = this.rotation;
 	this.rotation = 0;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3631,7 +3631,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					}
 
-					size = object.map.image.width / ( object.affectedByDistance ? 1 : _viewportHeight );
+					size = object.map.image.width / ( object.scaleByViewport ? _viewportHeight : 1 );
 					scale[ 0 ] = size * invAspect * object.scale.x;
 					scale[ 1 ] = size * object.scale.y;
 


### PR DESCRIPTION
Adds the parameter scaleByViewport to Sprite.js. If true size = imageWidth / viewportHeight. If false size = imageWidth / 1.0. 

This functionality was previously coupled with the affectedByDistance parameter. scaleByViewport's default is based on affectedByDistance so previous apps won't see a difference.
