### PR TITLE
Rename FPCamera to FirstPersonCamera.

### DIFF
--- a/examples/canvas_sandbox.html
+++ b/examples/canvas_sandbox.html
@@ -90,7 +90,7 @@
 		<script type="text/javascript" src="../src/extras/ShaderUtils.js"></script>
 		<script type="text/javascript" src="../src/extras/animation/AnimationHandler.js"></script>
 		<script type="text/javascript" src="../src/extras/animation/Animation.js"></script>
-		<script type="text/javascript" src="../src/extras/cameras/FPCamera.js"></script>
+		<script type="text/javascript" src="../src/extras/cameras/FirstPersonCamera.js"></script>
 		<script type="text/javascript" src="../src/extras/cameras/PathCamera.js"></script>
 		<script type="text/javascript" src="../src/extras/cameras/FlyCamera.js"></script>
 		<script type="text/javascript" src="../src/extras/cameras/RollCamera.js"></script>

--- a/examples/misc_sound.html
+++ b/examples/misc_sound.html
@@ -70,7 +70,7 @@
 				scene  = new THREE.Scene();
 				scene.fog = new THREE.FogExp2( 0x000000, 0.0035 );
 
-				camera = new THREE.FPCamera( {
+				camera = new THREE.FirstPersonCamera( {
 					fov: 50, aspect: window.innerWidth / window.innerHeight, near: 1, far: 10000,
 					movementSpeed: 70, lookSpeed: 0.05, noFly: true, lookVertical: false
 				} );

--- a/examples/misc_ubiquity_test.html
+++ b/examples/misc_ubiquity_test.html
@@ -91,7 +91,7 @@
 		<script type="text/javascript" src="../src/extras/ShaderUtils.js"></script>
 		<script type="text/javascript" src="../src/extras/animation/AnimationHandler.js"></script>
 		<script type="text/javascript" src="../src/extras/animation/Animation.js"></script>
-		<script type="text/javascript" src="../src/extras/cameras/FPCamera.js"></script>
+		<script type="text/javascript" src="../src/extras/cameras/FirstPersonCamera.js"></script>
 		<script type="text/javascript" src="../src/extras/cameras/PathCamera.js"></script>
 		<script type="text/javascript" src="../src/extras/cameras/FlyCamera.js"></script>
 		<script type="text/javascript" src="../src/extras/cameras/RollCamera.js"></script>

--- a/examples/webgl_geometry_dynamic.html
+++ b/examples/webgl_geometry_dynamic.html
@@ -70,7 +70,7 @@
 
 				container = document.getElementById( 'container' );
 
-				camera = new THREE.FPCamera( {
+				camera = new THREE.FirstPersonCamera( {
 
 					fov: 60, aspect: window.innerWidth / window.innerHeight, near: 1, far: 20000,
 					movementSpeed: 500, lookSpeed: 0.1, noFly: false, lookVertical: true

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -75,7 +75,7 @@
 
 				container = document.getElementById( 'container' );
 
-				camera = new THREE.FPCamera( {
+				camera = new THREE.FirstPersonCamera( {
 
 					fov: 60, aspect: window.innerWidth / window.innerHeight, near: 1, far: 20000,
 					movementSpeed: 1000, lookSpeed: 0.125, noFly: false, lookVertical: true

--- a/examples/webgl_geometry_minecraft_ao.html
+++ b/examples/webgl_geometry_minecraft_ao.html
@@ -83,7 +83,7 @@
 
 				container = document.getElementById( 'container' );
 
-				camera = new THREE.FPCamera( {
+				camera = new THREE.FirstPersonCamera( {
 
 					fov: 50, aspect: window.innerWidth / window.innerHeight, near: 1, far: 20000,
 					constrainVertical: true, verticalMin: 1.1, verticalMax: 2.2,

--- a/examples/webgl_geometry_terrain.html
+++ b/examples/webgl_geometry_terrain.html
@@ -67,7 +67,7 @@
 
 				container = document.getElementById( 'container' );
 
-				camera = new THREE.FPCamera( {
+				camera = new THREE.FirstPersonCamera( {
 
 					fov: 60, aspect: window.innerWidth / window.innerHeight, near: 1, far: 20000,
 					movementSpeed: 1000, lookSpeed: 0.1, noFly: false, lookVertical: true

--- a/examples/webgl_geometry_terrain_fog.html
+++ b/examples/webgl_geometry_terrain_fog.html
@@ -66,7 +66,7 @@
 
 				container = document.getElementById( 'container' );
 
-				camera = new THREE.FPCamera( {
+				camera = new THREE.FirstPersonCamera( {
 
 					fov: 60, aspect: window.innerWidth / window.innerHeight, near: 1, far: 10000,
 					movementSpeed: 150, lookSpeed: 0.1, noFly: false, lookVertical: true

--- a/examples/webgl_sandbox.html
+++ b/examples/webgl_sandbox.html
@@ -109,7 +109,7 @@
 		<script type="text/javascript" src="../src/extras/ShaderUtils.js"></script>
 		<script type="text/javascript" src="../src/extras/animation/AnimationHandler.js"></script>
 		<script type="text/javascript" src="../src/extras/animation/Animation.js"></script>
-		<script type="text/javascript" src="../src/extras/cameras/FPCamera.js"></script>
+		<script type="text/javascript" src="../src/extras/cameras/FirstPersonCamera.js"></script>
 		<script type="text/javascript" src="../src/extras/cameras/PathCamera.js"></script>
 		<script type="text/javascript" src="../src/extras/cameras/FlyCamera.js"></script>
 		<script type="text/javascript" src="../src/extras/cameras/RollCamera.js"></script>

--- a/src/extras/cameras/FirstPersonCamera.js
+++ b/src/extras/cameras/FirstPersonCamera.js
@@ -30,7 +30,7 @@
  * }
  */
 
-THREE.FPCamera = function ( parameters ) {
+THREE.FirstPersonCamera = function ( parameters ) {
 
 	THREE.Camera.call( this, parameters.fov, parameters.aspect, parameters.near, parameters.far, parameters.target );
 
@@ -307,12 +307,12 @@ THREE.FPCamera = function ( parameters ) {
 };
 
 
-THREE.FPCamera.prototype = new THREE.Camera();
-THREE.FPCamera.prototype.constructor = THREE.FPCamera;
-THREE.FPCamera.prototype.supr = THREE.Camera.prototype;
+THREE.FirstPersonCamera.prototype = new THREE.Camera();
+THREE.FirstPersonCamera.prototype.constructor = THREE.FirstPersonCamera;
+THREE.FirstPersonCamera.prototype.supr = THREE.Camera.prototype;
 
 
-THREE.FPCamera.prototype.translate = function ( distance, axis ) {
+THREE.FirstPersonCamera.prototype.translate = function ( distance, axis ) {
 
 	this.matrix.rotateAxis( axis );
 

--- a/src/extras/cameras/QuakeCamera.js
+++ b/src/extras/cameras/QuakeCamera.js
@@ -1,7 +1,7 @@
 /**
  * @author chriskillpack / http://chriskillpack.com/
  *
- * QuakeCamera has been renamed FPCamera. This property exists for backwards
+ * QuakeCamera has been renamed FirstPersonCamera. This property exists for backwards
  * compatibility only.
  */
-THREE.QuakeCamera = THREE.FPCamera;
+THREE.QuakeCamera = THREE.FirstPersonCamera;

--- a/utils/build.py
+++ b/utils/build.py
@@ -89,7 +89,7 @@ EXTRAS_FILES = [
 'extras/ShaderUtils.js',
 'extras/animation/AnimationHandler.js',
 'extras/animation/Animation.js',
-'extras/cameras/FPCamera.js',
+'extras/cameras/FirstPersonCamera.js',
 'extras/cameras/PathCamera.js',
 'extras/cameras/FlyCamera.js',
 'extras/cameras/RollCamera.js',


### PR DESCRIPTION
As we discussed: rename FPCamera to FirstPersonCamera.

I decided not to add an alias for FPCamera as the window on when you could use it is pretty short. Thoughts?
