### PR TITLE
Bug limiting number of point/directional lights has been fixed and is out on stable browser builds.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -7,19 +7,6 @@
 
 THREE.WebGLRenderer = function ( parameters ) {
 
-	// Currently you can use just up to 4 directional / point lights total.
-	// Chrome barfs on shader linking when there are more than 4 lights :(
-
-	// The problem comes from shader using too many varying vectors.
-
-	// This is not GPU limitation as the same shader works ok in Firefox
-	// and Chrome with "--use-gl=desktop" flag.
-
-	// Difference comes from Chrome on Windows using by default ANGLE,
-	// thus going DirectX9 route (while FF uses OpenGL).
-
-	// See http://code.google.com/p/chromium/issues/detail?id=63491
-
 	var _this = this,
 	_gl, _programs = [],
 	_currentProgram = null,
@@ -2310,7 +2297,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		// heuristics to create shader parameters according to lights in the scene
 		// (not to blow over maxLights budget)
 
-		maxLightCount = allocateLights( lights, 4 );
+		maxLightCount = allocateLights( lights, 79 );
 
 		maxBones = allocateBones( object );
 


### PR DESCRIPTION
Changing limit of 4 lights per scene to 79 lights (current Chrome & FF5 limit).
Bug previously referenced by WebGLRenderer and reported at http://code.google.com/p/chromium/issues/detail?id=63491 has been resolved by the ANGLE team: http://code.google.com/p/angleproject/issues/detail?id=74
