### PR TITLE
Added mouseBtnReverse and mouseBtnForward parameters to FirstPersonCamera.js

### DIFF
--- a/src/extras/cameras/FirstPersonCamera.js
+++ b/src/extras/cameras/FirstPersonCamera.js
@@ -40,6 +40,8 @@ THREE.FirstPersonCamera = function ( parameters ) {
 	this.noFly = false;
 	this.lookVertical = true;
 	this.autoForward = false;
+        this.mouseBtnForward = true;
+        this.mouseBtnReverse = true;
 
 	this.activeLook = true;
 
@@ -65,6 +67,9 @@ THREE.FirstPersonCamera = function ( parameters ) {
 
 		if ( parameters.autoForward !== undefined ) this.autoForward = parameters.autoForward;
 
+		if ( parameters.mouseBtnForward !== undefined ) this.mouseBtnForward = parameters.mouseBtnForward;
+		if ( parameters.mouseBtnReverse !== undefined ) this.mouseBtnReverse = parameters.mouseBtnReverse;
+		
 		if ( parameters.activeLook !== undefined ) this.activeLook = parameters.activeLook;
 
 		if ( parameters.heightSpeed !== undefined ) this.heightSpeed = parameters.heightSpeed;
@@ -110,8 +115,8 @@ THREE.FirstPersonCamera = function ( parameters ) {
 
 			switch ( event.button ) {
 
-				case 0: this.moveForward = true; break;
-				case 2: this.moveBackward = true; break;
+				case 0: this.moveForward = this.mouseBtnForward; break;
+				case 2: this.moveBackward = this.mouseBtnReverse; break;
 
 			}
 


### PR DESCRIPTION
Added mouseBtnForward and mouseBtnReverse parameters, which allow for specifying whether mouse buttons impact camera movement.

Currently, a left-click of the mouse also causes the camera to move forward (same effect as pressing the 'W' key).  This behavior is not always desirable, as one might want to be clicking on things in the scene, but want the camera to remain in the same place. 

I setup the defaults as:
        this.mouseBtnForward = true;
        this.mouseBtnReverse = true;

which doesn't change the current behavior, but one can set these parameters to false, if camera movement isn't desired.
