### PR TITLE
Fix for specular highlight in normal map shader

### DIFF
--- a/src/extras/ShaderUtils.js
+++ b/src/extras/ShaderUtils.js
@@ -304,9 +304,9 @@ THREE.ShaderUtils = {
 				"void main() {",
 
 					"vec4 mPosition = objectMatrix * vec4( position, 1.0 );",
-					"vViewPosition = cameraPosition - mPosition.xyz;",
 
 					"vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
+					"vViewPosition = -mvPosition.xyz;",
 					"vNormal = normalize( normalMatrix * normal );",
 
 					// tangent and binormal vectors


### PR DESCRIPTION
I noticed that specular highlights from a static light on a normal-mapped surface move when the camera rotates. This was because the ray from the vertex to the camera was in world space, not in camera space.
