### PR TITLE
Fix WebGL build bug

### DIFF
--- a/utils/build.py
+++ b/utils/build.py
@@ -283,6 +283,7 @@ WEBGL_FILES = [
 'materials/MeshShaderMaterial.js',
 'materials/ParticleBasicMaterial.js',
 'textures/Texture.js',
+'textures/DataTexture.js',
 'objects/Particle.js',
 'objects/ParticleSystem.js',
 'objects/Line.js',


### PR DESCRIPTION
Hey,

Looks like when adding the DataTexture to the main build it got left out of the WebGL build. I didn't see any references to THREE.DataTexture in the other renderers so hopefully this fixes it.
