### PR TITLE
Fix extractUrlbase() when url has no slashes.

### DIFF
--- a/src/extras/loaders/Loader.js
+++ b/src/extras/loaders/Loader.js
@@ -59,7 +59,7 @@ THREE.Loader.prototype = {
 
 		var chunks = url.split( "/" );
 		chunks.pop();
-		return chunks.join( "/" );
+		return chunks.length < 1 ? "." : chunks.join( "/" );
 
 	},
 


### PR DESCRIPTION
It was returning empty string for a url like "model.js",
and since this is used as the default texture_path, it was causing
texture images to not be loaded by the JSONLoader.
