### PR TITLE
webgl_interactives_voxel: multiple blocks + loadsave json + larger grid - a few bugs

### DIFF
--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -65,10 +65,10 @@
 				info.style.width = '100%';
 				info.style.textAlign = 'center';
 				info.style['z-index'] = '1';
-				info.innerHTML = '<a href="http://github.com/mrdoob/three.js" target="_blank">three.js</a> - voxel painter - webgl<br /><strong>click</strong>: add voxel, <strong>alt + click</strong>: remove voxel, <strong>shift + click</strong>: rotate, <a href="javascript:save();">save .png</a> current color: <div id="currentColor"></div>';
+				info.innerHTML = '<a href="http://github.com/mrdoob/three.js" target="_blank">three.js</a> - voxel painter - webgl<br /><strong>click</strong>: add voxel, <strong>alt + click</strong>: remove voxel, <strong>shift + click</strong>: rotate, <strong>drop json</strong>: load map file<br/><a href="javascript:savePNG();">save .png</a>, <a href="javascript:saveJSON();">save .json</a>, current color: <div id="currentColor"></div>';
 				container.appendChild( info );
 
-				camera = new THREE.Camera( 40, window.innerWidth / window.innerHeight, 1, 10000 );
+				camera = new THREE.Camera( 30, window.innerWidth / window.innerHeight, 1, 10000 );
 				camera.position.y = 800;
 				camera.target.position.y = 200;
 
@@ -141,7 +141,32 @@
 				document.addEventListener( 'mousedown', onDocumentMouseDown, false );
 				document.addEventListener( 'keydown', onDocumentKeyDown, false );
 				document.addEventListener( 'keyup', onDocumentKeyUp, false );
+				document.addEventListener( 'drop', onDrop, false);
+				document.addEventListener( 'dragover', onDragOver, false);
 
+			}
+
+			function onDragOver(event) {
+				event.preventDefault();
+				event.stopPropagation();
+			}
+
+			function onDrop(event) {
+				console.log("kkk")
+				event.preventDefault();
+				event.stopPropagation();
+
+				for(var i = 0; i < event.dataTransfer.files.length; i++){
+					var file	= event.dataTransfer.files[i];
+					var reader	= new FileReader();
+					reader.onload = function (event){
+						var dataUri	= event.target.result;
+						var base64	= dataUri.match(/[^,]*,(.*)/)[1];
+						
+						console.log("dataUri", base64)
+					};
+					reader.readAsDataURL(file);
+				}
 			}
 
 			function getRealIntersector( intersects ) {
@@ -255,8 +280,36 @@
 			
 			function loadJSON() {
 
-				alert('try to load');
-				// TODO delete all cubes and push the new one
+				// delete all cubes
+				var children	= scene.children.slice(0);
+
+				for( var i = 0; i < children.length; i++ ) {
+
+					if( children[i] instanceof THREE.Mesh === false ) continue;
+					if( children[i].geometry instanceof THREE.CubeGeometry === false ) continue;
+					if( children[i] === rollOverMesh ) continue;
+
+					scene.removeChild( children[i] );
+
+				}				
+
+				// push new cubes
+				var items	= [{"x":3,"y":0,"z":4,"t":0},{"x":3,"y":0,"z":2,"t":0},{"x":3,"y":0,"z":-5,"t":0},{"x":7,"y":0,"z":4,"t":2},{"x":6,"y":0,"z":4,"t":2},{"x":5,"y":0,"z":4,"t":2},{"x":4,"y":0,"z":4,"t":2},{"x":-2,"y":0,"z":6,"t":0},{"x":-3,"y":0,"z":6,"t":0},{"x":-4,"y":0,"z":6,"t":0},{"x":-5,"y":0,"z":5,"t":0},{"x":-5,"y":0,"z":6,"t":0},{"x":-1,"y":0,"z":6,"t":0},{"x":0,"y":0,"z":6,"t":0},{"x":1,"y":0,"z":6,"t":0},{"x":-7,"y":0,"z":-9,"t":0},{"x":-7,"y":0,"z":-8,"t":0},{"x":-7,"y":0,"z":-4,"t":0},{"x":-7,"y":0,"z":-3,"t":0},{"x":0,"y":0,"z":-3,"t":0},{"x":0,"y":0,"z":-2,"t":0},{"x":0,"y":0,"z":-1,"t":0},{"x":0,"y":0,"z":0,"t":0},{"x":1,"y":0,"z":0,"t":0},{"x":2,"y":0,"z":0,"t":0},{"x":3,"y":0,"z":0,"t":0},{"x":4,"y":0,"z":0,"t":0},{"x":1,"y":0,"z":-1,"t":0},{"x":2,"y":0,"z":-1,"t":0},{"x":3,"y":0,"z":-1,"t":0},{"x":4,"y":0,"z":-1,"t":0},{"x":1,"y":0,"z":-2,"t":0},{"x":2,"y":0,"z":-2,"t":0},{"x":3,"y":0,"z":-2,"t":0},{"x":4,"y":0,"z":-2,"t":0},{"x":1,"y":0,"z":-3,"t":0},{"x":2,"y":0,"z":-3,"t":0},{"x":3,"y":0,"z":-3,"t":0},{"x":4,"y":0,"z":-3,"t":0},{"x":-6,"y":0,"z":-3,"t":0},{"x":-6,"y":1,"z":-3,"t":0},{"x":-7,"y":1,"z":-4,"t":0},{"x":-7,"y":1,"z":-3,"t":0},{"x":-7,"y":1,"z":-8,"t":0},{"x":-7,"y":1,"z":-9,"t":0},{"x":-7,"y":3,"z":-8,"t":0},{"x":-7,"y":2,"z":-8,"t":0},{"x":-7,"y":0,"z":-10,"t":0},{"x":-7,"y":1,"z":-10,"t":0},{"x":-7,"y":2,"z":-9,"t":0},{"x":-7,"y":3,"z":-9,"t":0},{"x":-7,"y":2,"z":-10,"t":0},{"x":-7,"y":3,"z":-10,"t":0},{"x":-7,"y":2,"z":-4,"t":0},{"x":-7,"y":3,"z":-4,"t":0},{"x":-7,"y":2,"z":-3,"t":0},{"x":-6,"y":2,"z":-3,"t":0},{"x":-7,"y":3,"z":-3,"t":0},{"x":-6,"y":3,"z":-3,"t":0},{"x":-7,"y":0,"z":-5,"t":1},{"x":-7,"y":1,"z":-5,"t":1},{"x":-7,"y":2,"z":-5,"t":1},{"x":-7,"y":3,"z":-5,"t":1},{"x":-7,"y":3,"z":-6,"t":1},{"x":-7,"y":3,"z":-7,"t":1}];
+
+				for( var i = 0; i < items.length; i++ ){
+					var item = items[i];
+
+					var mesh = new THREE.Mesh( cubeGeo, cubeMaterials[item.t] );
+					mesh.position.x = item.x * 50 + 25;
+					mesh.position.y = item.y * 50 + 25;
+					mesh.position.z = item.z * 50 + 25;
+					mesh.matrixAutoUpdate = true;
+					mesh.updateMatrix();
+					scene.addObject( mesh );
+					
+				}
+
+				
 
 			}
 
@@ -289,7 +342,7 @@
 				}
 			}
 
-			function save() {
+			function savePNG() {
 
 				window.open( renderer.domElement.toDataURL('image/png'), 'mywindow' );
 

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -50,7 +50,8 @@
 				info.style.top = '10px';
 				info.style.width = '100%';
 				info.style.textAlign = 'center';
-				info.innerHTML = '<a href="http://github.com/mrdoob/three.js" target="_blank">three.js</a> - voxel painter - webgl<br /><strong>click</strong>: add voxel, <strong>control + click</strong>: remove voxel, <strong>shift + click</strong>: rotate, <a href="javascript:save();return false;">save .png</a>';
+				info.style['z-index'] = '1';
+				info.innerHTML = '<a href="http://github.com/mrdoob/three.js" target="_blank">three.js</a> - voxel painter - webgl<br /><strong>click</strong>: add voxel, <strong>control + click</strong>: remove voxel, <strong>shift + click</strong>: rotate, <a href="javascript:save();">save .png</a>';
 				container.appendChild( info );
 
 				camera = new THREE.Camera( 40, window.innerWidth / window.innerHeight, 1, 10000 );
@@ -104,7 +105,10 @@
 				directionalLight.position.normalize();
 				scene.addLight( directionalLight );
 
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer = new THREE.WebGLRenderer({
+					antialias		: true,
+					preserveDrawingBuffer	: true
+				});
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -43,7 +43,13 @@
 				new THREE.Color().setRGB(1, 0, 0),
 				new THREE.Color().setRGB(0, 1, 0),
 				new THREE.Color().setRGB(0, 0, 1),	
-				new THREE.Color().setRGB(1, 1, 0)	
+				new THREE.Color().setRGB(1, 1, 0),
+				new THREE.Color().setRGB(1, 0, 1),
+				new THREE.Color().setRGB(0, 1, 1),	
+				new THREE.Color().setRGB(1, 0.5, 0.5),	
+				new THREE.Color().setRGB(1, 0.5, 1),	
+				new THREE.Color().setRGB(0.5, 0.5, 1),	
+				new THREE.Color().setRGB(0.5, 0.5, 0.5),	
 			];
 			var cubeType	= 0;
 
@@ -65,7 +71,7 @@
 				info.style.width = '100%';
 				info.style.textAlign = 'center';
 				info.style['z-index'] = '1';
-				info.innerHTML = '<a href="http://github.com/mrdoob/three.js" target="_blank">three.js</a> - voxel painter - webgl<br /><strong>click</strong>: add voxel, <strong>alt + click</strong>: remove voxel, <strong>shift + click</strong>: rotate, <strong>drop json</strong>: load map file<br/><a href="javascript:savePNG();">save .png</a>, <a href="javascript:saveJSON();">save .json</a>, current color: <div id="currentColor"></div>';
+				info.innerHTML = '<a href="http://github.com/mrdoob/three.js" target="_blank">three.js</a> - voxel painter - webgl<br /><strong>click</strong>: add voxel, <strong>alt + click</strong>: remove voxel, <strong>shift + click</strong>: rotate<br/><strong>0 to 9 keys</strong>: change color, <strong>drop json</strong>: load map file, <a href="javascript:savePNG();">save .png</a>, <a href="javascript:saveJSON();">save .json</a>, current color: <div id="currentColor"></div>';
 				container.appendChild( info );
 
 				camera = new THREE.Camera( 30, window.innerWidth / window.innerHeight, 1, 10000 );
@@ -98,7 +104,9 @@
 
 				// grid
 
-				plane = new THREE.Mesh( new THREE.PlaneGeometry( 1000, 1000, 20, 20 ), new THREE.MeshBasicMaterial( { color: 0x555555, wireframe: true } ) );
+				var planeW	= 50;
+				var planeH	= 50;
+				plane = new THREE.Mesh( new THREE.PlaneGeometry( planeW*50, planeH*50, planeW, planeH ), new THREE.MeshBasicMaterial( { color: 0x555555, wireframe: true } ) );
 				plane.rotation.x = - 90 * Math.PI / 180;
 				scene.addObject( plane );
 
@@ -111,17 +119,7 @@
 				scene.addLight( ambientLight );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff );
-				directionalLight.position.x = Math.random() - 0.5;
-				directionalLight.position.y = Math.random() - 0.5;
-				directionalLight.position.z = Math.random() - 0.5;
-				directionalLight.position.normalize();
-				scene.addLight( directionalLight );
-
-				var directionalLight = new THREE.DirectionalLight( 0x808080 );
-				directionalLight.position.x = Math.random() - 0.5;
-				directionalLight.position.y = Math.random() - 0.5;
-				directionalLight.position.z = Math.random() - 0.5;
-				directionalLight.position.normalize();
+				directionalLight.position.set(1,1,1).normalize();
 				scene.addLight( directionalLight );
 
 				renderer = new THREE.WebGLRenderer({
@@ -151,17 +149,21 @@
 			}
 
 			function onDrop(event) {
+
 				event.preventDefault();
 
 				for(var i = 0; i < event.dataTransfer.files.length; i++){
+
 					var file	= event.dataTransfer.files[i];
 					var reader	= new FileReader();
+
 					reader.onload = function (event){
 						var dataUri	= event.target.result;
 						var base64	= dataUri.match(/[^,]*,(.*)/)[1];
 						var json	= window.atob(base64);
 						loadJSON( json )
 					};
+
 					reader.readAsDataURL(file);
 				}
 			}
@@ -255,8 +257,11 @@
 
 				var children	= scene.children;
 				var voxels	= [];
+
 				for( var i = 0; i < children.length; i++ ) {
+
 					var child	= children[i];
+
 					if( child instanceof THREE.Mesh === false )			continue;
 					if( child.geometry instanceof THREE.CubeGeometry === false )	continue;
 					if( child === rollOverMesh )					continue;
@@ -267,6 +272,7 @@
 						z	: (child.position.z - 25) / 50,
 						t	: child.materials[0]._cubeType
 					});
+
 				}
 				
 				// open a window with the json
@@ -302,6 +308,7 @@
 					mesh.position.z = voxel.z * 50 + 25;
 					mesh.matrixAutoUpdate = true;
 					mesh.updateMatrix();
+
 					scene.addObject( mesh );
 					
 				}
@@ -315,13 +322,16 @@
 					case 16: isShiftDown = true; break;
 					case 18: isAltDown = true; break;
 
-					case 'S'.charCodeAt(0): saveJSON();	break;
-					case 'L'.charCodeAt(0): loadJSON();	break;
-
 					case '0'.charCodeAt(0): setCubeType(0);	break;
 					case '1'.charCodeAt(0): setCubeType(1);	break;
 					case '2'.charCodeAt(0): setCubeType(2);	break;
 					case '3'.charCodeAt(0): setCubeType(3);	break;
+					case '4'.charCodeAt(0): setCubeType(4);	break;
+					case '5'.charCodeAt(0): setCubeType(5);	break;
+					case '6'.charCodeAt(0): setCubeType(6);	break;
+					case '7'.charCodeAt(0): setCubeType(7);	break;
+					case '8'.charCodeAt(0): setCubeType(8);	break;
+					case '9'.charCodeAt(0): setCubeType(9);	break;
 
 				}
 

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -10,6 +10,13 @@
 				margin: 0px;
 				overflow: hidden;
 			}
+			#currentColor {
+				display		: inline-block;
+				width		: 15px;
+				height		: 15px;
+				background-color: #F660AB;
+				border		: solid 2px black;
+			}
 
 			#oldie { background-color: #ddd !important }
 		</style>
@@ -31,10 +38,17 @@
 			var projector, plane, cube;
 			var mouse2D, mouse3D, ray,
 			rollOveredFace, isShiftDown = false,
-			theta = 45, isCtrlDown = false;
+			theta = 45, isAltDown = false;
+			var cubeColors	= [
+				new THREE.Color().setRGB(1, 0, 0),
+				new THREE.Color().setRGB(0, 1, 0),
+				new THREE.Color().setRGB(0, 0, 1),	
+				new THREE.Color().setRGB(1, 1, 0)	
+			];
+			var cubeType	= 0;
 
 			var rollOverMesh, rollOverMaterial, voxelPosition = new THREE.Vector3(), tmpVec = new THREE.Vector3();
-			var cubeGeo, cubeMaterial;
+			var cubeGeo, cubeMaterials = [];
 			var i, intersector;
 
 			init();
@@ -51,7 +65,7 @@
 				info.style.width = '100%';
 				info.style.textAlign = 'center';
 				info.style['z-index'] = '1';
-				info.innerHTML = '<a href="http://github.com/mrdoob/three.js" target="_blank">three.js</a> - voxel painter - webgl<br /><strong>click</strong>: add voxel, <strong>control + click</strong>: remove voxel, <strong>shift + click</strong>: rotate, <a href="javascript:save();">save .png</a>';
+				info.innerHTML = '<a href="http://github.com/mrdoob/three.js" target="_blank">three.js</a> - voxel painter - webgl<br /><strong>click</strong>: add voxel, <strong>alt + click</strong>: remove voxel, <strong>shift + click</strong>: rotate, <a href="javascript:save();">save .png</a> current color: <div id="currentColor"></div>';
 				container.appendChild( info );
 
 				camera = new THREE.Camera( 40, window.innerWidth / window.innerHeight, 1, 10000 );
@@ -71,8 +85,13 @@
 				// cubes
 
 				cubeGeo = new THREE.CubeGeometry( 50, 50, 50 );
-				cubeMaterial = new THREE.MeshLambertMaterial( { color: 0x00ff80, shading: THREE.FlatShading, map: THREE.ImageUtils.loadTexture( "textures/square-outline-textured.png" ) } );
-				cubeMaterial.color.setHSV( 0.1, 0.7, 1.0 );
+				for( i = 0; i < cubeColors.length; i++ ) {
+					cubeMaterials[i] = new THREE.MeshLambertMaterial( { color: 0x00ff80, shading: THREE.FlatShading, map: THREE.ImageUtils.loadTexture( "textures/square-outline-textured.png" ) } );
+					cubeMaterials[i].color.copy( cubeColors[i] );
+					cubeMaterials[i]._cubeType	= i;
+				}
+				setCubeType(cubeType);
+
 				// picking
 
 				projector = new THREE.Projector();
@@ -176,7 +195,7 @@
 
 					// delete cube
 
-					if ( isCtrlDown ) {
+					if ( isAltDown ) {
 
 						if ( intersector.object != plane ) {
 
@@ -191,7 +210,7 @@
 						intersector = getRealIntersector( intersects );
 						setVoxelPosition( intersector );
 
-						var voxel = new THREE.Mesh( cubeGeo, cubeMaterial );
+						var voxel = new THREE.Mesh( cubeGeo, cubeMaterials[cubeType] );
 						voxel.position.copy( voxelPosition );
 						voxel.matrixAutoUpdate = false;
 						voxel.updateMatrix();
@@ -201,13 +220,60 @@
 
 				}
 			}
+			
+			function setCubeType(type) {
+
+				cubeType = type;
+
+				document.getElementById("currentColor").style.backgroundColor	= cubeColors[cubeType].getContextStyle();
+
+			}
+			
+			function saveJSON() {
+
+console.log("scene", scene);
+
+				var children	= scene.children;
+				var items	= [];
+				for( var i = 0; i < children.length; i++ ) {
+					var child	= children[i];
+					if( child instanceof THREE.Mesh === false )			continue;
+					if( child.geometry instanceof THREE.CubeGeometry === false )	continue;
+					if( child === rollOverMesh )					continue;
+
+					items.push({
+						x	: (child.position.x - 25) / 50,
+						y	: (child.position.y - 25) / 50,
+						z	: (child.position.z - 25) / 50,
+						type	: child.materials[0]._cubeType
+					});
+				}
+				
+				console.log("items");
+				console.dir(items);
+			}
+			
+			function loadJSON() {
+
+				alert('try to load');
+				// TODO delete all cubes and push the new one
+
+			}
 
 			function onDocumentKeyDown( event ) {
 
 				switch( event.keyCode ) {
 
 					case 16: isShiftDown = true; break;
-					case 17: isCtrlDown = true; break;
+					case 18: isAltDown = true; break;
+
+					case 'S'.charCodeAt(0): saveJSON();	break;
+					case 'L'.charCodeAt(0): loadJSON();	break;
+
+					case '0'.charCodeAt(0): setCubeType(0);	break;
+					case '1'.charCodeAt(0): setCubeType(1);	break;
+					case '2'.charCodeAt(0): setCubeType(2);	break;
+					case '3'.charCodeAt(0): setCubeType(3);	break;
 
 				}
 
@@ -218,7 +284,7 @@
 				switch( event.keyCode ) {
 
 					case 16: isShiftDown = false; break;
-					case 17: isCtrlDown = false; break;
+					case 18: isAltDown = false; break;
 
 				}
 			}

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -148,13 +148,10 @@
 
 			function onDragOver(event) {
 				event.preventDefault();
-				event.stopPropagation();
 			}
 
 			function onDrop(event) {
-				console.log("kkk")
 				event.preventDefault();
-				event.stopPropagation();
 
 				for(var i = 0; i < event.dataTransfer.files.length; i++){
 					var file	= event.dataTransfer.files[i];
@@ -162,8 +159,8 @@
 					reader.onload = function (event){
 						var dataUri	= event.target.result;
 						var base64	= dataUri.match(/[^,]*,(.*)/)[1];
-						
-						console.log("dataUri", base64)
+						var json	= window.atob(base64);
+						loadJSON( json )
 					};
 					reader.readAsDataURL(file);
 				}
@@ -257,14 +254,14 @@
 			function saveJSON() {
 
 				var children	= scene.children;
-				var items	= [];
+				var voxels	= [];
 				for( var i = 0; i < children.length; i++ ) {
 					var child	= children[i];
 					if( child instanceof THREE.Mesh === false )			continue;
 					if( child.geometry instanceof THREE.CubeGeometry === false )	continue;
 					if( child === rollOverMesh )					continue;
 
-					items.push({
+					voxels.push({
 						x	: (child.position.x - 25) / 50,
 						y	: (child.position.y - 25) / 50,
 						z	: (child.position.z - 25) / 50,
@@ -273,12 +270,12 @@
 				}
 				
 				// open a window with the json
-				var dataUri	= "data:application/json;charset=utf-8,"+JSON.stringify(items);
+				var dataUri	= "data:application/json;charset=utf-8,"+JSON.stringify(voxels);
 				window.open( dataUri, 'mywindow' );
 
 			}
 			
-			function loadJSON() {
+			function loadJSON(mapJSON) {
 
 				// delete all cubes
 				var children	= scene.children.slice(0);
@@ -294,22 +291,20 @@
 				}				
 
 				// push new cubes
-				var items	= [{"x":3,"y":0,"z":4,"t":0},{"x":3,"y":0,"z":2,"t":0},{"x":3,"y":0,"z":-5,"t":0},{"x":7,"y":0,"z":4,"t":2},{"x":6,"y":0,"z":4,"t":2},{"x":5,"y":0,"z":4,"t":2},{"x":4,"y":0,"z":4,"t":2},{"x":-2,"y":0,"z":6,"t":0},{"x":-3,"y":0,"z":6,"t":0},{"x":-4,"y":0,"z":6,"t":0},{"x":-5,"y":0,"z":5,"t":0},{"x":-5,"y":0,"z":6,"t":0},{"x":-1,"y":0,"z":6,"t":0},{"x":0,"y":0,"z":6,"t":0},{"x":1,"y":0,"z":6,"t":0},{"x":-7,"y":0,"z":-9,"t":0},{"x":-7,"y":0,"z":-8,"t":0},{"x":-7,"y":0,"z":-4,"t":0},{"x":-7,"y":0,"z":-3,"t":0},{"x":0,"y":0,"z":-3,"t":0},{"x":0,"y":0,"z":-2,"t":0},{"x":0,"y":0,"z":-1,"t":0},{"x":0,"y":0,"z":0,"t":0},{"x":1,"y":0,"z":0,"t":0},{"x":2,"y":0,"z":0,"t":0},{"x":3,"y":0,"z":0,"t":0},{"x":4,"y":0,"z":0,"t":0},{"x":1,"y":0,"z":-1,"t":0},{"x":2,"y":0,"z":-1,"t":0},{"x":3,"y":0,"z":-1,"t":0},{"x":4,"y":0,"z":-1,"t":0},{"x":1,"y":0,"z":-2,"t":0},{"x":2,"y":0,"z":-2,"t":0},{"x":3,"y":0,"z":-2,"t":0},{"x":4,"y":0,"z":-2,"t":0},{"x":1,"y":0,"z":-3,"t":0},{"x":2,"y":0,"z":-3,"t":0},{"x":3,"y":0,"z":-3,"t":0},{"x":4,"y":0,"z":-3,"t":0},{"x":-6,"y":0,"z":-3,"t":0},{"x":-6,"y":1,"z":-3,"t":0},{"x":-7,"y":1,"z":-4,"t":0},{"x":-7,"y":1,"z":-3,"t":0},{"x":-7,"y":1,"z":-8,"t":0},{"x":-7,"y":1,"z":-9,"t":0},{"x":-7,"y":3,"z":-8,"t":0},{"x":-7,"y":2,"z":-8,"t":0},{"x":-7,"y":0,"z":-10,"t":0},{"x":-7,"y":1,"z":-10,"t":0},{"x":-7,"y":2,"z":-9,"t":0},{"x":-7,"y":3,"z":-9,"t":0},{"x":-7,"y":2,"z":-10,"t":0},{"x":-7,"y":3,"z":-10,"t":0},{"x":-7,"y":2,"z":-4,"t":0},{"x":-7,"y":3,"z":-4,"t":0},{"x":-7,"y":2,"z":-3,"t":0},{"x":-6,"y":2,"z":-3,"t":0},{"x":-7,"y":3,"z":-3,"t":0},{"x":-6,"y":3,"z":-3,"t":0},{"x":-7,"y":0,"z":-5,"t":1},{"x":-7,"y":1,"z":-5,"t":1},{"x":-7,"y":2,"z":-5,"t":1},{"x":-7,"y":3,"z":-5,"t":1},{"x":-7,"y":3,"z":-6,"t":1},{"x":-7,"y":3,"z":-7,"t":1}];
+				var voxels	= JSON.parse(mapJSON);
 
-				for( var i = 0; i < items.length; i++ ){
-					var item = items[i];
+				for( var i = 0; i < voxels.length; i++ ){
+					var voxel = voxels[i];
 
-					var mesh = new THREE.Mesh( cubeGeo, cubeMaterials[item.t] );
-					mesh.position.x = item.x * 50 + 25;
-					mesh.position.y = item.y * 50 + 25;
-					mesh.position.z = item.z * 50 + 25;
+					var mesh = new THREE.Mesh( cubeGeo, cubeMaterials[voxel.t] );
+					mesh.position.x = voxel.x * 50 + 25;
+					mesh.position.y = voxel.y * 50 + 25;
+					mesh.position.z = voxel.z * 50 + 25;
 					mesh.matrixAutoUpdate = true;
 					mesh.updateMatrix();
 					scene.addObject( mesh );
 					
 				}
-
-				
 
 			}
 

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -231,8 +231,6 @@
 			
 			function saveJSON() {
 
-console.log("scene", scene);
-
 				var children	= scene.children;
 				var items	= [];
 				for( var i = 0; i < children.length; i++ ) {
@@ -245,12 +243,14 @@ console.log("scene", scene);
 						x	: (child.position.x - 25) / 50,
 						y	: (child.position.y - 25) / 50,
 						z	: (child.position.z - 25) / 50,
-						type	: child.materials[0]._cubeType
+						t	: child.materials[0]._cubeType
 					});
 				}
 				
-				console.log("items");
-				console.dir(items);
+				// open a window with the json
+				var dataUri	= "data:application/json;charset=utf-8,"+JSON.stringify(items);
+				window.open( dataUri, 'mywindow' );
+
 			}
 			
 			function loadJSON() {


### PR DESCRIPTION
Hi

I did some work on webgl_interactive_voxel for a game im making. here is some changes. It allow multiples type of blocks and the ability to save/load in json. An important feature because you can load and re-edit a map, or load it in others projects

What do you think ?

Features added:
- added possibility to have multiple blocks color
  - 10 of them via 0-9 keys
- added load/save the map in json
  - save = open a window with json
  - load = drop a json file on the editor
- added larger grid to edit reasonable sized maps

bugs fix: 
- fix in save png (clickable link + preserveDrawingBuffer in WebGLRenderer)
- fix in keys handling: replace ctrl button by alt button (ctrl+button trigger contextmenu)
- removed random light
