### PR TITLE
Fixed: in-frame adding and removing same objects from scene leads to missing objects

### DIFF
--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -50,6 +50,16 @@ THREE.Scene.prototype.addChildRecurse = function ( child ) {
 
 			this.objects.push( child );
 			this.__objectsAdded.push( child );
+			
+			// check if previously removed
+			
+			var i = this.__objectsRemoved.indexOf( child );
+			
+			if ( i !== -1 ) {
+				
+				this.__objectsRemoved.splice( i, 1 );
+				
+			}
 
 		}
 
@@ -91,6 +101,15 @@ THREE.Scene.prototype.removeChildRecurse = function ( child ) {
 			this.objects.splice( i, 1 );
 			this.__objectsRemoved.push( child );
 
+			// check if previously added
+
+			var ai = this.__objectsAdded.indexOf( child );
+			
+			if ( ai !== -1 ) {
+				
+				this.__objectsAdded.splice( ai, 1 );
+				
+			}
 		}
 
 	}


### PR DESCRIPTION
I experienced the problem by writing a chunk based terrain generator. 
While moving over the terrain lots of chunks gets removed and added to the scene and sometimes there was a missing chunk.
The Problem is caused by first adding and then removing objects in the renderer. To keep a proper order of that it has to be removed in the scene from the __objectsRemoved array when added again.

I added the same check for removing objects as well. It's not really necessary there but might speed it up a little when the same objects are first added and then immediately removed.
