### PR TITLE
Lower level immediate rendering functionality

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3541,7 +3541,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 						setObjectFaces( object );
 
 						program = setProgram( _cameraLight, lights, fog, _depthMaterial, object );
-						object.render( function( object ) { renderBufferImmediate( object, program, _depthMaterial.shading ); } );
+						if ( object.immediateRenderCallback ) {
+							object.immediateRenderCallback( program, _gl, _frustum );
+						}
+						else {
+							object.render( function( object ) { renderBufferImmediate( object, program, _depthMaterial.shading ); } );
+						}
 
 					}
 
@@ -3717,8 +3722,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 					setObjectFaces( object );
 
 					program = setProgram( camera, lights, fog, scene.overrideMaterial, object );
-					object.render( function( object ) { renderBufferImmediate( object, program, scene.overrideMaterial.shading ); } );
-
+					if ( object.immediateRenderCallback ) {
+						object.immediateRenderCallback( program, _gl, _frustum );
+					}
+					else {
+						object.render( function( object ) { renderBufferImmediate( object, program, scene.overrideMaterial.shading ); } );
+					}
 				}
 
 			}
@@ -3777,7 +3786,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 						setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
 						program = setProgram( camera, lights, fog, material, object );
-						object.render( function( object ) { renderBufferImmediate( object, program, material.shading ); } );
+						if ( object.immediateRenderCallback ) {
+							object.immediateRenderCallback( program, _gl, _frustum );
+						}
+						else {
+							object.render( function( object ) { renderBufferImmediate( object, program, material.shading ); } );
+						}
 
 					}
 
@@ -3838,7 +3852,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 						setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
 						program = setProgram( camera, lights, fog, material, object );
-						object.render( function( object ) { renderBufferImmediate( object, program, material.shading ); } );
+						if ( object.immediateRenderCallback ) {
+							object.immediateRenderCallback( program, _gl, _frustum );
+						}
+						else {
+							object.render( function( object ) { renderBufferImmediate( object, program, material.shading ); } );
+						}
 
 					}
 
@@ -4167,7 +4186,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				addBuffer( scene.__webglObjects, geometry, object );
 
-			} else if ( THREE.MarchingCubes !== undefined && object instanceof THREE.MarchingCubes ) {
+			} else if ( THREE.MarchingCubes !== undefined && object instanceof THREE.MarchingCubes || object.immediateRenderCallback ) {
 
 				addBufferImmediate( scene.__webglObjectsImmediate, object );
 
@@ -4375,7 +4394,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			removeInstancesDirect( scene.__webglSprites, object );
 
-		} else if ( object instanceof THREE.MarchingCubes ) {
+		} else if ( object instanceof THREE.MarchingCubes || object.immediateRenderCallback ) {
 
 			removeInstances( scene.__webglObjectsImmediate, object );
 


### PR DESCRIPTION
Added "lower level" immediate rendering functionality (as per my issue #548). 
The existing mechanism requires modification of the `WebGLRenderer` for different objects and does not scale well for different entities requiring different vbos/attributes/uniforms and webgl state.
This patch leaves the current `MarchingCubes` immediate renderer intact but checks for existence of a `immediateRenderCallback` member function of the object. If found, that object is added to the `scene.__webglObjectsImmediate` array.
The program, webgl context, and frustum are currently passed into the callback, putting all rendering responsibility at the implementing object. This may break the Three.js abstraction somewhat, but allows "power users" to do some funky webgl stuff on specific objects while still relying on the Three.js framework for the rest of the scene.
