### PR TITLE
Immediate Rendering callback

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3636,7 +3636,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 						setObjectFaces( object );
 
 						program = setProgram( _cameraLight, lights, fog, _depthMaterial, object );
-						object.render( function( object ) { renderBufferImmediate( object, program, _depthMaterial.shading ); } );
+						if ( object.immediateRenderCallback ) {
+							object.immediateRenderCallback( program, _gl, _frustum );
+						}
+						else {
+							object.render( function( object ) { renderBufferImmediate( object, program, _depthMaterial.shading ); } );
+						}
 
 					}
 
@@ -3814,7 +3819,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 					setObjectFaces( object );
 
 					program = setProgram( camera, lights, fog, scene.overrideMaterial, object );
-					object.render( function( object ) { renderBufferImmediate( object, program, scene.overrideMaterial.shading ); } );
+					if ( object.immediateRenderCallback ) {
+							object.immediateRenderCallback( program, _gl, _frustum );
+						}
+						else {
+							object.render( function( object ) { renderBufferImmediate( object, program, _depthMaterial.shading ); } );
+						}
 
 				}
 
@@ -3876,7 +3886,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 						setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
 						program = setProgram( camera, lights, fog, material, object );
-						object.render( function( object ) { renderBufferImmediate( object, program, material.shading ); } );
+						if ( object.immediateRenderCallback ) {
+							object.immediateRenderCallback( program, _gl, _frustum );
+						}
+						else {
+							object.render( function( object ) { renderBufferImmediate( object, program, _depthMaterial.shading ); } );
+						}
 
 					}
 
@@ -3939,7 +3954,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 						setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
 						program = setProgram( camera, lights, fog, material, object );
-						object.render( function( object ) { renderBufferImmediate( object, program, material.shading ); } );
+						if ( object.immediateRenderCallback ) {
+							object.immediateRenderCallback( program, _gl, _frustum );
+						}
+						else {
+							object.render( function( object ) { renderBufferImmediate( object, program, _depthMaterial.shading ); } );
+						}
 
 					}
 
@@ -4275,7 +4295,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				geometry = object.geometry;
 				addBuffer( scene.__webglObjects, geometry, object );
 
-			} else if ( THREE.MarchingCubes !== undefined && object instanceof THREE.MarchingCubes ) {
+			} else if ( THREE.MarchingCubes !== undefined && object instanceof THREE.MarchingCubes || object.immediateRenderCallback ) {
 
 				addBufferImmediate( scene.__webglObjectsImmediate, object );
 
@@ -4480,7 +4500,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			removeInstancesDirect( scene.__webglSprites, object );
 
-		} else if ( object instanceof THREE.MarchingCubes ) {
+		} else if ( object instanceof THREE.MarchingCubes || object.immediateRenderCallback ) {
 
 			removeInstances( scene.__webglObjectsImmediate, object );
 


### PR DESCRIPTION
Added "lower level" immediate rendering functionality. The existing mechanism requires modification of the WebGLRenderer for different objects. The new implementation leaves the current MarchingCubes immediate renderer intact but checks for existence of a immediateRenderCallback member function of the object. If found, that object is added to the scene.__webglObjectsImmediate array. The program, webgl context, and frustum are currently passed into the callback, putting al rendering responsibility at the implementing object. This may break the Three.js abstraction somewhat, but allows "power users" to do some funky webgl stuff while still relying on the Three.js framework for the rest of the scene...
