### PR TITLE
Orthographic picking function for THREE.Projector.js

### DIFF
--- a/src/core/Projector.js
+++ b/src/core/Projector.js
@@ -36,39 +36,34 @@ THREE.Projector = function() {
 
 	this.projectVector = function ( vector, camera ) {
 		
-        _projScreenMatrix.multiply( camera.projectionMatrix, camera.matrixWorldInverse );
+		_projScreenMatrix.multiply( camera.projectionMatrix, camera.matrixWorldInverse );
 		_projScreenMatrix.multiplyVector3( vector );
 
 		return vector;
 	};
 
-	this.unprojectVector = function ( vector, camera, ray ) {
-        var end, dir, t;
-
-        //if ( camera instanceof THREE.OrthographicCamera ) {
-        
-            vector.z = -1.0;
-            end = new THREE.Vector3( vector.x, vector.y, 1.0);        
-            
-        //}
+	this.unprojectVector = function ( vector, camera ) {
 
 		_projScreenMatrix.multiply( camera.matrixWorld, THREE.Matrix4.makeInvert( camera.projectionMatrix ) );
 		_projScreenMatrix.multiplyVector3( vector );
 
-       // if ( camera instanceof THREE.OrthographicCamera ) {
-
-            _projScreenMatrix.multiplyVector3( end );
-
-            dir = new THREE.Vector3();
-            dir.sub( end, vector );
-            dir.normalize();
-        
-            ray.origin = vector;
-            ray.direction = dir;
-       // }
-
 		return vector;
+	};
 
+	this.pickingRay = function ( vector, camera ) {
+		var end, dir, ray, t;
+
+		vector.z = -1.0;
+		end = new THREE.Vector3( vector.x, vector.y, 1.0 );
+
+		this.unprojectVector( vector, camera );
+		this.unprojectVector( end, camera );
+
+		dir = new THREE.Vector3();
+		dir.sub( end, vector );
+		dir.normalize();
+
+		return new THREE.Ray( vector, dir );
 	};
 
 	this.projectObjects = function ( scene, camera, sort ) {

--- a/src/core/Projector.js
+++ b/src/core/Projector.js
@@ -42,20 +42,20 @@ THREE.Projector = function() {
 		return vector;
 	};
 
-	this.unprojectVector = function ( vector, camera ) {
+	this.unprojectVector = function ( vector, camera, ray ) {
         var end, dir, t;
 
-        if ( camera instanceof THREE.OrthographicCamera ) {
+        //if ( camera instanceof THREE.OrthographicCamera ) {
         
-            vector.z = 0.0;
+            vector.z = -1.0;
             end = new THREE.Vector3( vector.x, vector.y, 1.0);        
-        
-        }
+            
+        //}
 
 		_projScreenMatrix.multiply( camera.matrixWorld, THREE.Matrix4.makeInvert( camera.projectionMatrix ) );
 		_projScreenMatrix.multiplyVector3( vector );
 
-        if ( camera instanceof THREE.OrthographicCamera ) {
+       // if ( camera instanceof THREE.OrthographicCamera ) {
 
             _projScreenMatrix.multiplyVector3( end );
 
@@ -63,13 +63,9 @@ THREE.Projector = function() {
             dir.sub( end, vector );
             dir.normalize();
         
-            t = vector.y / - ( dir.y );
-
-            vector.set( vector.x + t * dir.x,
-                        vector.y + t * dir.y,
-                        vector.z + t * dir.z );
-        
-        }
+            ray.origin = vector;
+            ray.direction = dir;
+       // }
 
 		return vector;
 

--- a/src/core/Projector.js
+++ b/src/core/Projector.js
@@ -56,7 +56,7 @@ THREE.Projector = function() {
 	 * Translates a 2D point from NDC to a THREE.Ray
 	 * that can be used for picking.
 	 * @vector - THREE.Vector3 that represents 2D point
-	 * @camera - camera
+	 * @camera - THREE.Camera
 	 */
 	this.pickingRay = function ( vector, camera ) {
 

--- a/src/core/Projector.js
+++ b/src/core/Projector.js
@@ -35,18 +35,41 @@ THREE.Projector = function() {
 
 
 	this.projectVector = function ( vector, camera ) {
-
-		_projScreenMatrix.multiply( camera.projectionMatrix, camera.matrixWorldInverse );
+		
+        _projScreenMatrix.multiply( camera.projectionMatrix, camera.matrixWorldInverse );
 		_projScreenMatrix.multiplyVector3( vector );
 
 		return vector;
-
 	};
 
 	this.unprojectVector = function ( vector, camera ) {
+        var end, dir, t;
+
+        if ( camera instanceof THREE.OrthographicCamera ) {
+        
+            vector.z = 0.0;
+            end = new THREE.Vector3( vector.x, vector.y, 1.0);        
+        
+        }
 
 		_projScreenMatrix.multiply( camera.matrixWorld, THREE.Matrix4.makeInvert( camera.projectionMatrix ) );
 		_projScreenMatrix.multiplyVector3( vector );
+
+        if ( camera instanceof THREE.OrthographicCamera ) {
+
+            _projScreenMatrix.multiplyVector3( end );
+
+            dir = new THREE.Vector3();
+            dir.sub( end, vector );
+            dir.normalize();
+        
+            t = vector.y / - ( dir.y );
+
+            vector.set( vector.x + t * dir.x,
+                        vector.y + t * dir.y,
+                        vector.z + t * dir.z );
+        
+        }
 
 		return vector;
 

--- a/src/core/Projector.js
+++ b/src/core/Projector.js
@@ -35,11 +35,12 @@ THREE.Projector = function() {
 
 
 	this.projectVector = function ( vector, camera ) {
-		
+
 		_projScreenMatrix.multiply( camera.projectionMatrix, camera.matrixWorldInverse );
 		_projScreenMatrix.multiplyVector3( vector );
 
 		return vector;
+		
 	};
 
 	this.unprojectVector = function ( vector, camera ) {
@@ -48,22 +49,31 @@ THREE.Projector = function() {
 		_projScreenMatrix.multiplyVector3( vector );
 
 		return vector;
+		
 	};
 
+	/**
+	 * Translates a 2D point from NDC to a THREE.Ray
+	 * that can be used for picking.
+	 * @vector - THREE.Vector3 that represents 2D point
+	 * @camera - camera
+	 */
 	this.pickingRay = function ( vector, camera ) {
-		var end, dir, ray, t;
 
+		var end, ray, t;
+
+		// set two vectors with opposing z values
 		vector.z = -1.0;
 		end = new THREE.Vector3( vector.x, vector.y, 1.0 );
 
 		this.unprojectVector( vector, camera );
 		this.unprojectVector( end, camera );
 
-		dir = new THREE.Vector3();
-		dir.sub( end, vector );
-		dir.normalize();
+		// find direction from vector to end
+		end.subSelf( vector ).normalize();
 
-		return new THREE.Ray( vector, dir );
+		return new THREE.Ray( vector, end );
+		
 	};
 
 	this.projectObjects = function ( scene, camera, sort ) {


### PR DESCRIPTION
There was discussion over altering the `unprojectVector` function to work for orthographic projection. However, the solution really needs to have access to a `THREE.Ray`. In order to preserve the functionality of `unprojectVector` I added a method called `pickingRay` which returns a `THREE.Ray` that can be used to find intersects. The best part is that it works for both perspective projection and orthographic projection. I'll add an example that uses it, but for now it could look like this.

```
ray = projector.pickingRay( mouse2D.clone(), camera );
intersects = ray.intersectScene( scene );
```

vs.

```
mouse3D = projector.unprojectVector( mouse2D.clone(), camera );
ray.direction = mouse3D.subSelf( camera.position ).normalize(); // doesn't work for orthographic projection
```
