### PR TITLE
little fix in webgl_performance.html

### DIFF
--- a/examples/webgl_performance.html
+++ b/examples/webgl_performance.html
@@ -82,7 +82,6 @@
 				renderer = new THREE.WebGLRenderer( { preserveDrawingBuffer: true } );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.sortObjects = false;
-				renderer.autoClearColor = false;
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();


### PR DESCRIPTION
It looks like the background is never cleared. It was cleared in r44. it is leaving a trail.

removing renderer.autoClearColor = false; fix it. not sure if the bug is in the example or in the webglrenderer

http://mrdoob.github.com/three.js/examples/webgl_performance.html
