### PR TITLE
Octahedron subdivisions to default to 0.

### DIFF
--- a/src/extras/geometries/OctahedronGeometry.js
+++ b/src/extras/geometries/OctahedronGeometry.js
@@ -13,7 +13,7 @@ THREE.OctahedronGeometry = function ( radius, detail ) {
 
 	THREE.Geometry.call( this );
 
-	detail = isFinite(detail) ? detail : 3; // allow a zero value
+	detail = detail || 0;
 
 	var that = this; // ugly scope hack
 


### PR DESCRIPTION
Just realised that if created with no extra parameters a programmer would expect an Octahedron class to make an octahedron. It is common sense that an unspecified level of detail should be equivalent to zero, please include this minor update.
