### PR TITLE
Release DOM image after WebGL texture creation so as to not double memory

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5201,9 +5201,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			setTextureParameters( _gl.TEXTURE_2D, texture, texture.image );
 
-			texture.image = null; // release DOM image to not double image memmory use
-			
 			texture.needsUpdate = false;
+			if (texture.onupdated) {texture.onupdated(texture);}
 
 		} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5202,7 +5202,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			setTextureParameters( _gl.TEXTURE_2D, texture, texture.image );
 
 			texture.needsUpdate = false;
-			if (texture.onupdated) {texture.onupdated(texture);}
+			if (texture.onUpdated) {texture.onUpdated (texture);}
 
 		} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5201,6 +5201,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			setTextureParameters( _gl.TEXTURE_2D, texture, texture.image );
 
+			texture.image = null; // release DOM image to not double image memmory use
+			
 			texture.needsUpdate = false;
 
 		} else {
@@ -5235,6 +5237,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				setTextureParameters( _gl.TEXTURE_CUBE_MAP, texture, texture.image[ 0 ] );
 
+				for ( var i = 0; i < 6; i ++ ) {
+
+					texture.image[ i ] = null; // release DOM image to not double image memmory use
+
+				}
+				
 				texture.needsUpdate = false;
 
 			} else {


### PR DESCRIPTION
Release DOM image after WebGL texture creation so as to not double memory use from images
