### PR TITLE
Fix ambient light illumination of textures.

### DIFF
--- a/src/extras/ShaderUtils.js
+++ b/src/extras/ShaderUtils.js
@@ -284,7 +284,7 @@ THREE.ShaderUtils = {
 
 					"#endif",
 
-					"gl_FragColor.xyz = gl_FragColor.xyz * totalDiffuse + totalSpecular + ambientLightColor * uAmbientColor;",
+					"gl_FragColor.xyz = gl_FragColor.xyz * (totalDiffuse + totalSpecular + ambientLightColor * uAmbientColor);",
 
 					"if ( enableReflection ) {",
 

--- a/src/renderers/WebGLShaders.js
+++ b/src/renderers/WebGLShaders.js
@@ -444,7 +444,7 @@ THREE.ShaderChunk = {
 
 		"#endif",
 
-		"gl_FragColor.xyz = gl_FragColor.xyz * totalDiffuse + totalSpecular + ambientLightColor * ambient;"
+		"gl_FragColor.xyz = gl_FragColor.xyz * (totalDiffuse + totalSpecular + ambientLightColor * ambient);"
 
 	].join("\n"),
 


### PR DESCRIPTION
Because of the lack of parens, the texture color was being ignored for
specular and ambient light sources.  Instead you'd just see the light color.
