### PR TITLE
Added custom attributes to the list of WebGL buffers to be deleted 

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -601,6 +601,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
+		if (geometryGroup.__webglCustomAttributes) {
+			for (objId in geometryGroup.__webglCustomAttributes) {
+				_gl.deleteBuffer(geometryGroup.__webglCustomAttributes[objId].buffer);
+			}
+		}
 		_this.info.memory.geometries --;
 
 	};


### PR DESCRIPTION
Loop round the __webglCustomAttributes and delete the buffers when deleting a Mesh's buffers
