### PR TITLE
Making unfreeze (Q key) give back the control of the camera rotation

### DIFF
--- a/src/extras/controls/FirstPersonControls.js
+++ b/src/extras/controls/FirstPersonControls.js
@@ -143,7 +143,7 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 			case 82: /*R*/ this.moveUp = true; break;
 			case 70: /*F*/ this.moveDown = true; break;
 
-			case 81: this.freeze = !this.freeze; break;
+			case 81: this.freeze = !this.freeze; break; /*Q*/
 
 		}
 
@@ -177,6 +177,7 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 		var now = new Date().getTime();
 		this.tdiff = ( now - this.lastUpdate ) / 1000;
 		this.lastUpdate = now;
+		var actualLookSpeed = 0;
 
 		if ( !this.freeze ) {
 
@@ -205,7 +206,7 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 			if ( this.moveUp ) this.object.translateY( actualMoveSpeed );
 			if ( this.moveDown ) this.object.translateY( - actualMoveSpeed );
 
-			var actualLookSpeed = this.tdiff * this.lookSpeed;
+			actualLookSpeed = this.tdiff * this.lookSpeed;
 
 			if ( !this.activeLook ) {
 


### PR DESCRIPTION
Hi,
Making unfreeze (Q key) give back the control of the camera rotation (with the mouse).

This can be seen on the [minecraft](http://mrdoob.github.com/three.js/examples/webgl_geometry_minecraft_ao.html) example: press Q, and then press Q back. You will be able to move around with the keys, but the mouse will not change camera view.

Cheers,
- Daniel
