### PR TITLE
Fix issue #835 setRotationFromMatrix

### DIFF
--- a/src/core/Vector3.js
+++ b/src/core/Vector3.js
@@ -271,25 +271,37 @@ THREE.Vector3.prototype = {
 
 	},
 
-	setRotationFromMatrix: function ( m ) {
-
-		var cosY = Math.cos( this.y );
-
-		this.y = Math.asin( m.n13 );
-
-		if ( Math.abs( cosY ) > 0.00001 ) {
-
-			this.x = Math.atan2( - m.n23 / cosY, m.n33 / cosY );
-			this.z = Math.atan2( - m.n12 / cosY, m.n11 / cosY );
-
-		} else {
-
-			this.x = 0;
-			this.z = Math.atan2( m.n21, m.n22 );
-
-		}
-
-	},
+	setRotationFromMatrix: function(m, order) {
+                    if(order == 'XYZ'){
+                        if (Math.abs(m.n13) != 1) {
+                            this.y = Math.asin(m.n13);
+                            var cosY = Math.cos(this.y);
+                            if (cosY >= 0) {
+                                this.x = Math.atan2(-m.n23, m.n33);
+                                this.z = Math.atan2(-m.n12, m.n11);
+                            }
+                            else {
+                                this.x = Math.atan2(m.n23, -m.n33);
+                                this.z = Math.atan2(m.n12, -m.n11);
+                            }
+                
+                        }
+                        else {
+                            this.z = 0;
+                            if (m.n13 == -1) {
+                                this.y = -Math.PI / 2;
+                                this.x = -Math.atan2(m.n21, m.n22);
+                            }
+                            else {
+                                this.y = Math.PI / 2;
+                                this.x = Math.atan2(m.n21, m.n22);
+                            }
+                        }
+                    }
+                    else{
+                        throw 'Unsupported Euler order';
+                    }
+        },
 
 	isZero: function () {
 


### PR DESCRIPTION
I fix THREE.Vector3.setRotationFromMatrix function, to be able to calculate correct results for 'XYZ' euler order. I think that it is necessary to call this function with two parameters the matrix and order, because as one can find in theory (http://bit.ly/rOQGR) there is multiple correct solution for this transformation base on the correct Euler order 

Working example of function is here:
http://jsfiddle.net/ch3sn3k/cDTJV/

As you may notices sometimes input and result field with angles differs but this is caused by multiple result of this task. It means that function pass the test only if source rotation matrix and new rotation matrix (created based on new angles) equals.
