### PR TITLE
Bug where depth buffer may not be cleared

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -244,8 +244,14 @@ THREE.WebGLRenderer = function ( parameters ) {
 		var bits = 0;
 
 		if ( color === undefined || color ) bits |= _gl.COLOR_BUFFER_BIT;
-		if ( depth === undefined || depth ) bits |= _gl.DEPTH_BUFFER_BIT;
 		if ( stencil === undefined || stencil ) bits |= _gl.STENCIL_BUFFER_BIT;
+
+		if ( depth === undefined || depth ) {
+
+			setDepthWrite( true );
+			bits |= _gl.DEPTH_BUFFER_BIT;
+
+		}
 
 		_gl.clear( bits );
 


### PR DESCRIPTION
If the last object to be rendered on a render cycle sets depth writing to false, then on the next render cycle the call to clear the depth buffer isn't able to write the clear value to the buffer. This results in strange ghosting effects.

For some reason, I saw this issue on Firefox but not on Chrome. My guess is that between animation frames Chrome either clears the buffers for you or sets things like glDepthMask back to default.
