### PR TITLE
Fix sceneloader not working with embedded models.

### DIFF
--- a/src/extras/loaders/SceneLoader.js
+++ b/src/extras/loaders/SceneLoader.js
@@ -577,6 +577,9 @@ THREE.SceneLoader.prototype.createScene = function ( json, callbackFinished, url
 
 			var modelJson = data.embeds[ g.id ],
 				texture_path = "";
+			
+			// Pass metadata along to jsonLoader so it knows the format version.
+			modelJson.metadata = data.metadata;
 
 			if ( modelJson ) {
 


### PR DESCRIPTION
When sceneloader passes an embedded model over to jsonLoader, the model didn't have any metadata so jsonLoader rightly freaked out about it looking like an old format.

The metadata belonging to the scene now gets added to the embedded model before passing it along to jsonLoader.
