### PR TITLE
Support texture border color clamping

### DIFF
--- a/examples/webgl_texture_clamping.html
+++ b/examples/webgl_texture_clamping.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - texture clamping</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				background:#fff;
+				padding:0;
+				margin:0;
+				font-weight: bold;
+				overflow:hidden;
+			}
+		</style>
+	</head>
+	<body>
+
+		<script src="../build/custom/Three.js"></script>
+
+		<script src="js/Stats.js"></script>
+
+		<script>
+
+			var stats;
+
+			var camera, scene, renderer;
+
+			var mouseX = 0;
+
+			document.addEventListener( 'mousemove', onDocumentMouseMove, false );
+
+			init();
+			animate();
+
+			function createPlane( x, y, width, height, uvs, materialParams ) {
+
+				var plane = new THREE.PlaneGeometry( width, height );
+
+				var layerUvs = [];
+				var uv = 0;
+				for ( var i = 0; i < uvs.length / 2; i++ ) {
+					layerUvs.push( new THREE.UV( uvs[uv++], uvs[uv++] ) );
+				}
+				for ( var layer = 0; layer < 2; layer++ ) {
+					plane.faceVertexUvs[layer] = [ layerUvs ];
+				}
+
+				var mesh = new THREE.Mesh( plane, new THREE.MeshBasicMaterial( materialParams ) );
+				mesh.position.x = x;
+				mesh.position.y = y;
+				return mesh;
+
+			}
+
+			function init() {
+
+				var container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.set( 0, 0, 200 );
+
+				scene = new THREE.Scene();
+				scene.add( camera );
+
+				var map = THREE.ImageUtils.loadTexture( "textures/ash_uvgrid01.jpg" );
+				var lightMap = THREE.ImageUtils.loadTexture( "textures/water.jpg" );
+
+				var uvs = [ -0.325,-0.2, -0.325,1.2, 1.325,1.2, 1.325,-0.2 ];
+				scene.add( createPlane( -80, -60, 160, 120, uvs, { map: map, lightMap: lightMap, borderClampColor: 0xC1D0DE } ) );
+				scene.add( createPlane( -80, 60, 160, 120, uvs, { map: map, lightMap: lightMap } ) );
+				uvs = [ -0.625,-0.5, -0.625,1.5, 1.625,1.5, 1.625,-0.5 ];
+				scene.add( createPlane( 80, -60, 160, 120, uvs, { map: map, borderClampColor: 0xF0DDBB } ) );
+				scene.add( createPlane( 80, 60, 160, 120, uvs, { map: map } ) );
+
+				renderer = new THREE.WebGLRenderer( { antialias: true, clearColor: 0x000000, clearAlpha: 1 } );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				container.appendChild( renderer.domElement );
+
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '0px';
+				stats.domElement.style.zIndex = 100;
+				container.appendChild( stats.domElement );
+
+			}
+
+			function onDocumentMouseMove(event) {
+
+				mouseX = ( event.clientX / window.innerWidth );
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
+				camera.rotation.z = mouseX * Math.PI;
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -9,6 +9,8 @@
  *
  *  lightMap: new THREE.Texture( <Image> ),
  *
+ *  borderClampColor: <hex>,
+ *
  *  envMap: new THREE.TextureCube( [posx, negx, posy, negy, posz, negz] ),
  *  combine: THREE.Multiply,
  *  reflectivity: <float>,
@@ -39,6 +41,7 @@ THREE.MeshBasicMaterial = function ( parameters ) {
 	this.map = parameters.map !== undefined ? parameters.map : null;
 
 	this.lightMap = parameters.lightMap !== undefined ? parameters.lightMap : null;
+	this.borderClampColor = parameters.borderClampColor !== undefined ? new THREE.Color( parameters.borderClampColor ) : null;
 
 	this.envMap = parameters.envMap !== undefined ? parameters.envMap : null;
 	this.combine = parameters.combine !== undefined ? parameters.combine : THREE.MultiplyOperation;

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -11,6 +11,8 @@
  *
  *  lightMap: new THREE.Texture( <Image> ),
  *
+ *  borderClampColor: <hex>,
+ *
  *  envMap: new THREE.TextureCube( [posx, negx, posy, negy, posz, negz] ),
  *  combine: THREE.Multiply,
  *  reflectivity: <float>,
@@ -42,6 +44,8 @@ THREE.MeshLambertMaterial = function ( parameters ) {
 	this.map = parameters.map !== undefined ? parameters.map : null;
 
 	this.lightMap = parameters.lightMap !== undefined ? parameters.lightMap : null;
+
+	this.borderClampColor = parameters.borderClampColor !== undefined ? new THREE.Color( parameters.borderClampColor ) : null;
 
 	this.envMap = parameters.envMap !== undefined ? parameters.envMap : null;
 	this.combine = parameters.combine !== undefined ? parameters.combine : THREE.MultiplyOperation;

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -13,6 +13,8 @@
  *
  *  lightMap: new THREE.Texture( <Image> ),
  *
+ *  borderClampColor: <hex>,
+ *
  *  envMap: new THREE.TextureCube( [posx, negx, posy, negy, posz, negz] ),
  *  combine: THREE.Multiply,
  *  reflectivity: <float>,
@@ -49,6 +51,8 @@ THREE.MeshPhongMaterial = function ( parameters ) {
 	this.map = parameters.map !== undefined ? parameters.map : null;
 
 	this.lightMap = parameters.lightMap !== undefined ? parameters.lightMap : null;
+
+	this.borderClampColor = parameters.borderClampColor !== undefined ? new THREE.Color( parameters.borderClampColor ) : null;
 
 	this.envMap = parameters.envMap !== undefined ? parameters.envMap : null;
 	this.combine = parameters.combine !== undefined ? parameters.combine : THREE.MultiplyOperation;

--- a/src/materials/ParticleBasicMaterial.js
+++ b/src/materials/ParticleBasicMaterial.js
@@ -7,6 +7,8 @@
  *  opacity: <float>,
  *  map: new THREE.Texture( <Image> ),
  *
+ *  borderClampColor: <hex>,
+ *
  *  size: <float>,
  *
  *  blending: THREE.NormalBlending,
@@ -27,6 +29,8 @@ THREE.ParticleBasicMaterial = function ( parameters ) {
 	this.color = parameters.color !== undefined ? new THREE.Color( parameters.color ) : new THREE.Color( 0xffffff );
 
 	this.map = parameters.map !== undefined ? parameters.map : null;
+
+	this.borderClampColor = parameters.borderClampColor !== undefined ? new THREE.Color( parameters.borderClampColor ) : null;
 
 	this.size = parameters.size !== undefined ? parameters.size : 1;
 	this.sizeAttenuation = parameters.sizeAttenuation !== undefined ? parameters.sizeAttenuation : true;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3890,6 +3890,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		parameters = {
 
 			map: !!material.map, envMap: !!material.envMap, lightMap: !!material.lightMap,
+			borderClampColor: !!material.borderClampColor,
 			vertexColors: material.vertexColors,
 			fog: fog, useFog: material.fog,
 			sizeAttenuation: material.sizeAttenuation,
@@ -4173,6 +4174,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 		}
 
 		uniforms.lightMap.texture = material.lightMap;
+		if ( material.borderClampColor )
+			uniforms.borderClampColor.value = material.borderClampColor;
 
 		uniforms.envMap.texture = material.envMap;
 		uniforms.flipEnvMap.value = ( material.envMap instanceof THREE.WebGLRenderTargetCube ) ? 1 : -1;
@@ -4894,6 +4897,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		program = _gl.createProgram();
 
+		if (parameters.borderClampColor && !_gl.getExtension("OES_standard_derivatives")) {
+			parameters.borderClampColor = false;
+			console.warn("Disabling borderClampColor, not supported");
+		}
+
 		var prefix_vertex = [
 
 			_supportsVertexTextures ? "#define VERTEX_TEXTURES" : "",
@@ -4989,6 +4997,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			parameters.map ? "#define USE_MAP" : "",
 			parameters.envMap ? "#define USE_ENVMAP" : "",
 			parameters.lightMap ? "#define USE_LIGHTMAP" : "",
+			parameters.borderClampColor ? "#define USE_BORDER_CLAMP_COLOR" : "",
 			parameters.vertexColors ? "#define USE_COLOR" : "",
 
 			parameters.metal ? "#define METAL" : "",


### PR DESCRIPTION
This adds a new borderClampColor parameter to materials. If this is defined, then the 'map' and 'lightMap' textures will be clamped to that color when their UV is outside of the 0..1 range.

This allows you to do things like "letterbox" 16:9 video texture image onto a 4:3 aspect ratio quad face, by adjusting the UVs so the texture is letterboxed and the untextured borders are solid colored.
