### PR TITLE
Make three.js autoscale texture to max size of WebGL hardware

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -167,6 +167,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	_gl = initGL();
 
+	_maxTextureSize = _gl.getParameter(_gl.TEXTURE_SIZE);
+	_maxCubemapSize = _gl.getParameter(_gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+
 	setDefaultGLState();
 
 	initSprites();
@@ -5519,6 +5522,29 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	};
 
+	function clampToMaxSize ( image, maxSize ) {
+
+		if ( image.width <= maxSize && image.height <= maxSize ) {
+
+			return image;
+
+		}
+
+		// Warning: Scaling through the canvas will only work with images that use
+		// premultiplied alpha.
+		var maxDimension = Math.max( image.width, image.height );
+		var newWidth = Math.floor( image.width * maxSize / maxDimension );
+		var newHeight = Math.floor( image.height * maxSize / maxDimension );
+
+		var canvas = document.createElement( 'canvas' );
+		canvas.width = newWidth;
+		canvas.height = newHeight;
+		var ctx = canvas.getContext( "2d" );
+		ctx.drawImage( image,	0, 0, image.width, image.height, 0, 0, newWidth, newHeight );
+		return canvas;
+
+	}
+
 	function setCubeTexture ( texture, slot ) {
 
 		if ( texture.image.length === 6 ) {
@@ -5538,7 +5564,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				for ( var i = 0; i < 6; i ++ ) {
 
-					_gl.texImage2D( _gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, _gl.RGBA, _gl.RGBA, _gl.UNSIGNED_BYTE, texture.image[ i ] );
+					_gl.texImage2D( _gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, _gl.RGBA, _gl.RGBA, _gl.UNSIGNED_BYTE, clampToMaxSize( texture.image[ i ], _maxCubemapSize ) );
 
 				}
 


### PR DESCRIPTION
This is just a sample, it's up to you if you think it's a good patch.

The issue is there are max sizes on various hardware for textures and cubemaps. Because of bugs in OSX Intel OpenGL drivers both Chrome and Firefox limit the largest cubemap size to 512x512 on that hardware.

So, if you run this sample 
http://mrdoob.github.com/three.js/examples/webgl_materials_cars_anaglyph.html

It will fail on any current Macbook Air because the cubemaps are too large.

One solution is to shrink the original cubemaps. Another is to shrink them at runtime which is what this patch does. It would probably be good to do the same for regular textures but unfortunately it's not that simple. If the textures do not use pre-multiplied alpha then you can't use the canvas tag to scale the textures without losing data. One way to handle that might be to track pixelStorei UNPACK_PREMULTIPLY_ALPHA_WEBGL and fail if it's false and if the texture size is too large.

Anyway, this patch should make that sample run on a Intel Macbook Air.

PS: If you want to test on a Macbook Pro or you can run gfxCardStatys
http://codykrieger.com/gfxCardStatus which will let you force your mbp into Intel mode and see the problem. Note: After forcing integrated only you need to re-start the browser.
