### PR TITLE
Frustum culling when parent mesh is scaled

### DIFF
--- a/src/core/Frustum.js
+++ b/src/core/Frustum.js
@@ -44,7 +44,20 @@ THREE.Frustum.prototype.contains = function ( object ) {
 	var distance,
 	planes = this.planes,
 	matrix = object.matrixWorld,
-	radius = - object.geometry.boundingSphere.radius * Math.max( object.scale.x, Math.max( object.scale.y, object.scale.z ) );
+	parent = object,
+	scaleX, scaleY, scaleZ;
+	
+	// accumulate the scaling factors of the object's ancestors 
+	scaleX = scaleY = scaleZ = 1;
+	while ( parent ) {
+		scaleX *= parent.scale.x;
+		scaleY *= parent.scale.y;
+		scaleZ *= parent.scale.z;
+		
+		parent = parent.parent; 
+	}
+	
+	var radius = - object.geometry.boundingSphere.radius * Math.max( scaleX, Math.max( scaleY, scaleZ ) );
 
 	for ( var i = 0; i < 6; i ++ ) {
 
@@ -56,4 +69,3 @@ THREE.Frustum.prototype.contains = function ( object ) {
 	return true;
 
 };
-


### PR DESCRIPTION
This is a slightly modified version of gero3's proposal for issue #448 at:

https://github.com/mrdoob/three.js/issues/448#issuecomment-1887476

It's the trivial solution. Do you think it will be cheaper to lazily update the child meshes upon scaling operations on their parents? I'm not sure if the trade off in performance and complexity will be beneficial.

If there are any conventions or guidelines I missed - please correct me.
