### PR TITLE
Negative face index in obj models

### DIFF
--- a/utils/exporters/obj/convert_obj_three.py
+++ b/utils/exporters/obj/convert_obj_three.py
@@ -536,16 +536,29 @@ def parse_obj(fname):
                 uv_index = []
                 normal_index = []
 
+                
+                # Precompute vert / normal / uv lists
+                # for negative index lookup
+                vertlen = len(vertices) + 1
+                normlen = len(normals) + 1
+                uvlen = len(uvs) + 1
+
                 for v in chunks[1:]:
                     vertex = parse_vertex(v)
                     if vertex['v']:
+                        if vertex['v'] < 0:
+                            vertex['v'] += vertlen
                         vertex_index.append(vertex['v'])
                     if vertex['t']:
+                        if vertex['t'] < 0:
+                            vertex['t'] += uvlen
                         uv_index.append(vertex['t'])
                     if vertex['n']:
+                        if vertex['n'] < 0:
+                            vertex['n'] += normlen
                         normal_index.append(vertex['n'])
 
-                faces.append({
+                d = {
                     'vertex':vertex_index,
                     'uv':uv_index,
                     'normal':normal_index,
@@ -554,7 +567,8 @@ def parse_obj(fname):
                     'group':group,
                     'object':object,
                     'smooth':smooth,
-                    })
+                    }
+                faces.append(d)
 
             # Group
             if chunks[0] == "g" and len(chunks) == 2:

--- a/utils/exporters/obj/convert_obj_three.py
+++ b/utils/exporters/obj/convert_obj_three.py
@@ -557,8 +557,7 @@ def parse_obj(fname):
                         if vertex['n'] < 0:
                             vertex['n'] += normlen
                         normal_index.append(vertex['n'])
-
-                d = {
+                faces.append({
                     'vertex':vertex_index,
                     'uv':uv_index,
                     'normal':normal_index,
@@ -567,8 +566,7 @@ def parse_obj(fname):
                     'group':group,
                     'object':object,
                     'smooth':smooth,
-                    }
-                faces.append(d)
+                    })
 
             # Group
             if chunks[0] == "g" and len(chunks) == 2:


### PR DESCRIPTION
OBJ model format allows face indexes to be specified w/ negative numbers, indicating a relative lookup of the vertex.

With:
v 0 0 0
v 1 1 1

f -1 0 1 translates to f 1 0 1

This pull request changes the obj converter to recognize this.
