### PR TITLE
Frustum culling when the parent mesh is scaled

### DIFF
--- a/src/core/Frustum.js
+++ b/src/core/Frustum.js
@@ -44,7 +44,8 @@ THREE.Frustum.prototype.contains = function ( object ) {
 	var distance,
 	planes = this.planes,
 	matrix = object.matrixWorld,
-	radius = - object.geometry.boundingSphere.radius * Math.max( object.scale.x, Math.max( object.scale.y, object.scale.z ) );
+	scale = new THREE.Vector3( matrix.getColumnX().length(), matrix.getColumnY().length(), matrix.getColumnZ().length() ),
+	radius = - object.geometry.boundingSphere.radius * Math.max( scale.x, Math.max( scale.y, scale.z ) );
 
 	for ( var i = 0; i < 6; i ++ ) {
 


### PR DESCRIPTION
Another attempt at #448, following @mrdoob's guidance at  https://github.com/mrdoob/three.js/issues/448#issuecomment-3331280

The main difference is the use of `.matrix.getColumnX()` (and equivalents) for:
- Using an existing interface
- Column getters are optimized to avoid the overhead of Vector3 instantiation
- Keep the code concise.
