### PR TITLE
Bug where depth buffer may not be cleared

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3178,6 +3178,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
+		// Ensure depth buffer writing is enabled so it can be cleared on next render
+
+		this.setDepthTest( true );
+		setDepthWrite( true );
+
 		//_gl.finish();
 
 	};


### PR DESCRIPTION
If the last object to be rendered on a render cycle sets depth writing to false, then on the next render cycle the call to clear the depth buffer isn't able to write the clear value to the buffer. This results in strange ghosting effects.

For some reason, I saw this issue on Firefox but not on Chrome. My guess is that between animation frames Chrome either clears the buffers for you or sets things like glDepthMask back to default.
