### PR TITLE
Cloning sprites throws a 404 error

### DIFF
--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -90,10 +90,9 @@ THREE.SceneUtils = {
 
 		} else if ( source instanceof THREE.Sprite ) {
 
-			object = new THREE.Sprite( {} );
+			object = new THREE.Sprite( { map: source.map } );
 
 			object.color.copy( source.color );
-			object.map = source.map;
 			object.blending = source.blending;
 
 			object.useScreenCoordinates = source.useScreenCoordinates;


### PR DESCRIPTION
Cloning sprite throws a 404 error that the file name undefined was not found. To reproduce just make a texture, apply it to a sprite, and clone that sprite:

``` javascript
var texture = THREE.ImageUtils.loadTexture( "sprite2.jpg" );
// same issue with the below line as well    
// var texture = new THREE.Texture( canvas, new THREE.UVMapping(), THREE.ClampToEdgeWrapping, THREE.ClampToEdgeWrapping, THREE.NearestFilter, THREE.LinearMipMapLinearFilter );

var sprite = new THREE.Sprite( { map: texture, useScreenCoordinates: false, color: 0xffffff } );
var clonedSprite = THREE.SceneUtils.cloneObject( sprite ) ;
```

As the sprite is generated without map defined, the new sprite object assumes that the map property is a url (as it isn't instanceof THREE.Texture, but typeof undefined). 

As with the current way sprites are created, it requires map to be defined, so when cloning the object, it needs to be defined right during creation.

Note that it currently functions correctly in the sense that it displays the texture as you would expect (as it does change the map to correct one, but by then the request for the undefined has been created), so it ends up throwing the 404 error.
