### PR TITLE
vector convenience methods to switch context

### DIFF
--- a/src/core/Vector3.js
+++ b/src/core/Vector3.js
@@ -296,5 +296,16 @@ THREE.Vector3.prototype = {
 		return ( this.lengthSq() < 0.0001 /* almostZero */ );
 
 	}
-
+	
+	
+	fromObjectSpace: function (obj){
+		return object.matrixWorld.multiplyVector3(this.clone());
+	}
+	
+	
+	toObjectSpace: function (obj){
+		var mat = new THREE.Matrix4();
+		mat.getInverse(obj.matrix);	
+		return mat.multiplyVector3(this.clone());
+	}
 };


### PR DESCRIPTION
i've added 2 convenience methods to move from obj coordinates to world coords and vice versa
