### PR TITLE
convert_obj_three.py

### DIFF
--- a/utils/exporters/obj/convert_obj_three.py
+++ b/utils/exporters/obj/convert_obj_three.py
@@ -372,6 +372,8 @@ def parse_mtl(fname):
                 identifier = chunks[1]
                 if not identifier in materials:
                     materials[identifier] = {}
+            else:
+                continue
 
             # Diffuse color
             # Kd 1.000 1.000 1.000


### PR DESCRIPTION
when exporting a simple .obj file (with no material) to three format, parse_mtl function can fail ('indentifier' is undefined), crashing the script.

just added a couple of lines to fix that.
