### PR TITLE
Fixed bug with triangles or polylist shared input offsets into primitives array 

### DIFF
--- a/src/extras/loaders/ColladaLoader.js
+++ b/src/extras/loaders/ColladaLoader.js
@@ -2240,12 +2240,14 @@ THREE.ColladaLoader = function () {
 		var i = 0, j, k, p = primitive.p, inputs = primitive.inputs;
 		var input, index, idx32;
 		var source, numParams;
-		var vcIndex = 0, vcount = 3;
+		var vcIndex = 0, vcount = 3, maxOffset = 0;
 		var texture_sets = [];
 
 		for ( j = 0; j < inputs.length; j ++ ) {
 
 			input = inputs[ j ];
+			var offset = input.offset + 1;
+			maxOffset = (maxOffset < offset)? offset : maxOffset;
 
 			switch ( input.semantic ) {
 
@@ -2277,7 +2279,7 @@ THREE.ColladaLoader = function () {
 					input = inputs[ k ];
 					source = sources[ input.source ];
 
-					index = p[ i + ( j * inputs.length ) + input.offset ];
+					index = p[ i + ( j * maxOffset ) + input.offset ];
 					numParams = source.accessor.params.length;
 					idx32 = index * numParams;
 
@@ -2389,7 +2391,7 @@ THREE.ColladaLoader = function () {
 
 			}
 
-			i += inputs.length * vcount;
+			i += maxOffset * vcount;
 
 		}
 


### PR DESCRIPTION
primitive input array offset can have a shared value. The loader assumed inputs.length as an
index. Changed the loader to use a max offset value. An example of shared offsets is the input
semantic TEXTANGENT and TEXBINORMAL sharing offset values.
Ex.

```
 <triangles material="_1_-_Default" count="192">
      <input semantic="VERTEX" source="#geom-Box03-vertices" offset="0"/>
      <input semantic="NORMAL" source="#geom-Box03-normals" offset="1"/>
      <input semantic="TEXCOORD" source="#geom-Box03-map1" offset="2" set="1"/>
      <input semantic="TEXTANGENT" source="#geom-Box03-map1-textangents" offset="3" set="1"/>
      <input semantic="TEXBINORMAL" source="#geom-Box03-map1-texbinormals" offset="3" set="1"/>
      <p>26 0 42 0 2 1 1 1 27 2 44 2 27 2 44...</p>
</triangles>
```
