### PR TITLE
Add texture-combining of an RGB(A) and a Luminance/RGB(A) texture

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -7,9 +7,12 @@ THREE.ImageUtils = {
 
 	crossOrigin: '',
 
-	loadTexture: function ( path, mapping, callback ) {
+	loadTexture: function ( path, mapping, callback, format ) {
 
-		var image = new Image(), texture = new THREE.Texture( image, mapping );
+		format = format !== undefined ? format : THREE.RGBAFormat;
+
+		var image = new Image(), texture = new THREE.Texture( image, mapping,
+			undefined, undefined, undefined, undefined, format );
 
 		image.onload = function () { texture.needsUpdate = true; if ( callback ) callback( this ); };
 		image.crossOrigin = this.crossOrigin;

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -37,6 +37,7 @@ THREE.MeshBasicMaterial = function ( parameters ) {
 	this.color = parameters.color !== undefined ? new THREE.Color( parameters.color ) : new THREE.Color( 0xffffff );
 
 	this.map = parameters.map !== undefined ? parameters.map : null;
+	this.mapAlpha = parameters.mapAlpha !== undefined ? parameters.mapAlpha : null;
 
 	this.lightMap = parameters.lightMap !== undefined ? parameters.lightMap : null;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4038,7 +4038,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		parameters = {
 
-			map: !!material.map, envMap: !!material.envMap, lightMap: !!material.lightMap,
+			map: !!material.map, mapAlpha: !!material.mapAlpha, envMap: !!material.envMap, lightMap: !!material.lightMap,
 			vertexColors: material.vertexColors,
 			fog: fog, useFog: material.fog,
 			sizeAttenuation: material.sizeAttenuation,
@@ -4323,6 +4323,14 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( material.map ) {
 
 			uniforms.offsetRepeat.value.set( material.map.offset.x, material.map.offset.y, material.map.repeat.x, material.map.repeat.y );
+
+		}
+
+		uniforms.mapAlpha.texture = material.mapAlpha;
+
+		if ( material.mapAlpha ) {
+
+			uniforms.offsetRepeat.value.set( material.mapAlpha.offset.x, material.mapAlpha.offset.y, material.mapAlpha.repeat.x, material.mapAlpha.repeat.y );
 
 		}
 
@@ -4677,6 +4685,18 @@ THREE.WebGLRenderer = function ( parameters ) {
 					_this.setTexture( texture, value );
 
 				}
+
+			// single THREE.Texture where 1st channel is used for alpha
+
+			} else if( type === "ta" ) {
+
+				_gl.uniform1i( location, value );
+
+				texture = uniform.texture;
+
+				if ( !texture ) continue;
+
+				_this.setTexture( texture, value );
 
 			// array of THREE.Texture (2d)
 
@@ -5185,6 +5205,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			( parameters.useFog && parameters.fog instanceof THREE.FogExp2 ) ? "#define FOG_EXP2" : "",
 
 			parameters.map ? "#define USE_MAP" : "",
+			parameters.mapAlpha ? "#define USE_MAP_ALPHA" : "",
 			parameters.envMap ? "#define USE_ENVMAP" : "",
 			parameters.lightMap ? "#define USE_LIGHTMAP" : "",
 			parameters.vertexColors ? "#define USE_COLOR" : "",

--- a/src/renderers/WebGLShaders.js
+++ b/src/renderers/WebGLShaders.js
@@ -177,6 +177,16 @@ THREE.ShaderChunk = {
 
 	].join("\n"),
 
+	map_alpha_pars_fragment: [
+
+		"#ifdef USE_MAP_ALPHA",
+
+			"uniform sampler2D mapAlpha;",
+
+		"#endif"
+
+	].join("\n"),
+
 	map_vertex: [
 
 		"#ifdef USE_MAP",
@@ -203,6 +213,18 @@ THREE.ShaderChunk = {
 				"gl_FragColor = gl_FragColor * texture2D( map, vUv );",
 
 			"#endif",
+
+		"#endif"
+
+	].join("\n"),
+
+
+	map_alpha_fragment: [
+
+		"#ifdef USE_MAP_ALPHA",
+
+			"vec4 mask = texture2D( mapAlpha, vUv );",
+			"gl_FragColor = vec4(gl_FragColor.rgb, mask.r);",
 
 		"#endif"
 
@@ -1020,11 +1042,12 @@ THREE.UniformsLib = {
 		"opacity" : { type: "f", value: 1.0 },
 
 		"map" : { type: "t", value: 0, texture: null },
+		"mapAlpha" : { type: "ta", value: 1, texture: null },
 		"offsetRepeat" : { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
 
-		"lightMap" : { type: "t", value: 2, texture: null },
+		"lightMap" : { type: "t", value: 3, texture: null },
 
-		"envMap" : { type: "t", value: 1, texture: null },
+		"envMap" : { type: "t", value: 2, texture: null },
 		"flipEnvMap" : { type: "f", value: -1 },
 		"useRefract" : { type: "i", value: 0 },
 		"reflectivity" : { type: "f", value: 1.0 },
@@ -1206,6 +1229,7 @@ THREE.ShaderLib = {
 
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "map_pars_fragment" ],
+			THREE.ShaderChunk[ "map_alpha_pars_fragment" ],
 			THREE.ShaderChunk[ "lightmap_pars_fragment" ],
 			THREE.ShaderChunk[ "envmap_pars_fragment" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
@@ -1216,6 +1240,7 @@ THREE.ShaderLib = {
 				"gl_FragColor = vec4( diffuse, opacity );",
 
 				THREE.ShaderChunk[ "map_fragment" ],
+				THREE.ShaderChunk[ "map_alpha_fragment" ],
 				THREE.ShaderChunk[ "alphatest_fragment" ],
 				THREE.ShaderChunk[ "lightmap_fragment" ],
 				THREE.ShaderChunk[ "color_fragment" ],


### PR DESCRIPTION
Add texture-combining of an RGB(A) and a Luminance/RGB(A) texture to MeshBasicMaterial.

Introduced new field "mapAlpha" that specifies a texture to use as the alpha channel.
Extended loadTexture() for custom texture formats, e.g. THREE.Luminance.

Usually, the alpha channel is embedded in the graphics used as texture. This patch allows setting a second texture "mapAlpha", and the basic shader has been extended to use the first channel from this texture as the alpha channel. As I use grayscale PNG images as mask, I extended the load image function to accept a format parameter.

Example:

```
zmesh = new THREE.Mesh( geom, new THREE.MeshBasicMaterial({
    map: THREE.ImageUtils.loadTexture( "image.jpg" ),
    mapAlpha: THREE.ImageUtils.loadTexture( "mask.png", {}, function(){}, THREE.LuminanceFormat ),
}));
```
