### PR TITLE
fix cancelRequestAnimationFrame polyfill

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -23,7 +23,7 @@ if ( ! self.Int32Array ) {
     for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
         window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
         window.cancelAnimationFrame = window[vendors[x]+'CancelAnimationFrame'] 
-                                   || window[vendors[x]+'RequestCancelAnimationFrame'];
+                                   || window[vendors[x]+'CancelRequestAnimationFrame'];
     }
  
     if (!window.requestAnimationFrame)


### PR DESCRIPTION
`requestCancelAnimationFrame` doesn't seem to exist outside of Paul Irish's Gist (https://gist.github.com/1579671#gistcomment-77809).

It should be `cancelRequestAnimationFrame` (https://bugs.webkit.org/show_bug.cgi?id=74231)
