### PR TITLE
added listener option when trackball is modified

### DIFF
--- a/src/extras/controls/TrackballControls.js
+++ b/src/extras/controls/TrackballControls.js
@@ -33,6 +33,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	this.keys = [ 65 /*A*/, 83 /*S*/, 68 /*D*/ ];
 
+	this.onModification = 0;
+
 	// internals
 
 	this.target = new THREE.Vector3( 0, 0, 0 );
@@ -341,6 +343,9 @@ THREE.TrackballControls = function ( object, domElement ) {
 			_panEnd = _this.getMouseOnScreen( event.clientX, event.clientY );
 
 		}
+
+		if (_this.onModification!=0)
+			_this.onModification();
 
 	};
 


### PR DESCRIPTION
Hi,

I'm quite a newbie wrt three.js.

I'm trying to perform on-demand rendering with a trackball controller i.e. only render when the point of view is selected, see an example here:
http://www.creatis.insa-lyon.fr/~valette/three.js/examples/bunny.html

The simple solution was to add a onModification attribute which stores a callback when needed. This function is called in the mousemove() function of THREE.TrackballControls.

Is this a good solution?

Thanks
