### PR TITLE
Added note about install location for Linux

### DIFF
--- a/utils/exporters/blender/README.md
+++ b/utils/exporters/blender/README.md
@@ -6,7 +6,7 @@ Assumes Blender version 2.60.
 
 ## Installation
 
-Copy the io_mesh_threejs folder to the scripts/addons folder. The full path is OS-dependent (see below).
+Copy the io_mesh_threejs folder to the scripts/addons folder. If it doesn't exist, create it. The full path is OS-dependent (see below).
 
 Once that is done, you need to activate the plugin. Open Blender preferences, look for
 Addons, search for `three`, enable the checkbox next to the `Import-Export: three.js format` entry.
@@ -24,6 +24,12 @@ Should look like this:
 Depends on where blender.app is. Assuming you copied it to your Applications folder:
 
     /Applications/Blender/blender.app/Contents/MacOS/2.60/scripts/addons
+
+### Linux
+
+By default, this should look like:
+
+    /home/USERNAME/.blender/2.60/scripts/addons
 
 ## Usage
 


### PR DESCRIPTION
I found this out while installing three.js's blender export script. Hope this helps somebody!

See [source](http://wiki.blender.org/index.php/Doc:2.6/Manual/Extensions/Python/Add-Ons).
