### PR TITLE
Fixed issue #1261, THREE.IcosahedronGeometry @ bad loop variable.

### DIFF
--- a/src/extras/geometries/IcosahedronGeometry.js
+++ b/src/extras/geometries/IcosahedronGeometry.js
@@ -68,7 +68,7 @@ THREE.IcosahedronGeometry = function ( subdivisions ) {
 
 	// subdivide faces to refine the triangles
 
-	for ( var i = 0; i < this.subdivisions; i ++ ) {
+	for ( var s = 0; s < this.subdivisions; s ++ ) {
 
 		tempFaces = new THREE.Geometry();
 


### PR DESCRIPTION
See https://github.com/mrdoob/three.js/issues/1261.

Signed-off-by: Thibaut Despoulain thibaut.despoulain@bkcore.com
