### PR TITLE
Dev

### DIFF
--- a/src/extras/loaders/ColladaLoader.js
+++ b/src/extras/loaders/ColladaLoader.js
@@ -735,13 +735,15 @@ THREE.ColladaLoader = function () {
 					for ( j = 0; j < instance_materials.length; j ++ ) {
 
 						var inst_material = instance_materials[j];
-						var effect_id = materials[inst_material.target].instance_effect.url;
+						var mat = materials[instance_material.target];
+						var effect_id = mat.instance_effect.url;
 						var shader = effects[effect_id].shader;
 
 						shader.material.opacity = !shader.material.opacity ? 1 : shader.material.opacity;
 						used_materials[inst_material.symbol] = num_materials;
 						used_materials_array.push(shader.material)
 						first_material = shader.material;
+						first_material.name = mat.name == null || mat.name === '' ? mat.id : mat.name;
 						num_materials ++;
 
 					}

--- a/src/extras/loaders/ColladaLoader.js
+++ b/src/extras/loaders/ColladaLoader.js
@@ -2230,7 +2230,13 @@ THREE.ColladaLoader = function () {
 
 		this.geometry3js.computeCentroids();
 		this.geometry3js.computeFaceNormals();
-		this.geometry3js.computeVertexNormals();
+		
+		if ( geom.calcNormals ) {
+			
+			this.geometry3js.computeVertexNormals();
+			
+		}
+		
 		this.geometry3js.computeBoundingBox();
 
 		return this;
@@ -2325,13 +2331,38 @@ THREE.ColladaLoader = function () {
 
 			var face = null, faces = [], uv, uvArr;
 
+			if ( ns.length == 0 ) {
+				
+				// check the vertices source
+				input = this.vertices.input.NORMAL;
+
+				if ( input ) {
+
+					source = sources[ input.source ];
+					numParams = source.accessor.params.length;
+
+					for ( var ndx = 0, len = vs.length; ndx < len; ndx++ ) {
+
+						ns.push( getConvertedVec3( source.data, vs[ ndx ] * numParams ) );
+
+					}
+
+				}
+				else {
+					
+					geom.calcNormals = true;
+					
+				}
+
+			}
+
 			if ( vcount === 3 ) {
 
-				faces.push( new THREE.Face3( vs[0], vs[1], vs[2], [ ns[0], ns[1], ns[2] ], cs.length ? cs : new THREE.Color() ) );
+				faces.push( new THREE.Face3( vs[0], vs[1], vs[2], ns, cs.length ? cs : new THREE.Color() ) );
 
 			} else if ( vcount === 4 ) {
-
-				faces.push( new THREE.Face4( vs[0], vs[1], vs[2], vs[3], [ ns[0], ns[1], ns[2], ns[3] ], cs.length ? cs : new THREE.Color() ) );
+				
+				faces.push( new THREE.Face4( vs[0], vs[1], vs[2], vs[3], ns, cs.length ? cs : new THREE.Color() ) );
 
 			} else if ( vcount > 4 && options.subdivideFaces ) {
 

--- a/src/extras/loaders/ColladaLoader.js
+++ b/src/extras/loaders/ColladaLoader.js
@@ -2231,9 +2231,10 @@ THREE.ColladaLoader = function () {
 		this.geometry3js.computeCentroids();
 		this.geometry3js.computeFaceNormals();
 		
-		if ( geom.calcNormals ) {
+		if ( this.geometry3js.calcNormals ) {
 			
 			this.geometry3js.computeVertexNormals();
+			delete this.geometry3js.calcNormals;
 			
 		}
 		


### PR DESCRIPTION
This request fixes an issue with the collada loader that occurs when the collada file specifies normals in the vertices element instead of the polylist. It also uses the vertex normals provided by the collada file first and foremost instead of always calculating the vertex normals for each geometry. In other words, it will only calculate vertex normals if they aren't provided by the collada file.
