### PR TITLE
Material without Blending 

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -43,3 +43,4 @@ THREE.AdditiveBlending = 1;
 THREE.SubtractiveBlending = 2;
 THREE.MultiplyBlending = 3;
 THREE.AdditiveAlphaBlending = 4;
+THREE.NoBlending = 5;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5174,8 +5174,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			switch ( blending ) {
 
+				case THREE.NoBlending:
+                    _gl.disable( _gl.BLEND );
+                    break;
+                    
 				case THREE.AdditiveBlending:
 
+                    _gl.enable( _gl.BLEND );
 					_gl.blendEquation( _gl.FUNC_ADD );
 					_gl.blendFunc( _gl.SRC_ALPHA, _gl.ONE );
 
@@ -5184,7 +5189,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				case THREE.SubtractiveBlending:
 
 					// TODO: Find blendFuncSeparate() combination
-
+                    _gl.enable( _gl.BLEND );
 					_gl.blendEquation( _gl.FUNC_ADD );
 					_gl.blendFunc( _gl.ZERO, _gl.ONE_MINUS_SRC_COLOR );
 
@@ -5193,7 +5198,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				case THREE.MultiplyBlending:
 
 					// TODO: Find blendFuncSeparate() combination
-
+                    _gl.enable( _gl.BLEND );
 					_gl.blendEquation( _gl.FUNC_ADD );
 					_gl.blendFunc( _gl.ZERO, _gl.SRC_COLOR );
 
@@ -5201,6 +5206,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				default:
 
+                    _gl.enable( _gl.BLEND );
 					_gl.blendEquationSeparate( _gl.FUNC_ADD, _gl.FUNC_ADD );
 					_gl.blendFuncSeparate( _gl.SRC_ALPHA, _gl.ONE_MINUS_SRC_ALPHA, _gl.ONE, _gl.ONE_MINUS_SRC_ALPHA );
 


### PR DESCRIPTION
While using a RGBA render target to store some data for my SSAO code i found that blending was always enabled and leaded to weird rendering.

I added a THREE.NoBlending to Material.js that disable blending in WebGLRenderer.js (it may be a bit optimized with "cache" member).

Great job with ThreeJS it is very helpfull.
