### PR TITLE
Fixed Blender exporter's scene+embed mode

### DIFF
--- a/utils/exporters/blender/2.62/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.62/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -1659,7 +1659,7 @@ def generate_embeds(data):
 
         for e in data["embeds"]:
 
-            embed = '"emb_%s": {%s}' % (e, data["embeds"][e])
+            embed = '"emb_%s": %s' % (e, data["embeds"][e])
             chunks.append(embed)
 
         return ",\n\n".join(chunks)
@@ -1840,7 +1840,7 @@ def save(operator, context, filepath = "",
                                                         option_animation,
                                                         option_frame_step)
 
-                        embeds[name] = model_string
+                        embeds[name] = text
 
                     else:
 


### PR DESCRIPTION
After exporting a few scenes in the Blender exporter and getting "deprecated format" errors, I investigated and found that the SceneLoader calls JSONLoader for the embedded meshes, which expects each embedded object to have a metadata object.

The two-line change I've done here modifies the exporter to include the metadata in the embedded mesh output.
