### PR TITLE
Light targets do not auto update their matrix

### DIFF
--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -178,7 +178,6 @@
 				spotLight.shadowMapHeight = SHADOW_MAP_HEIGHT;
 
 				scene.add( spotLight );
-				scene.add( spotLight.target );
 
 				directionalLight2 = new THREE.PointLight( 0xff9900, 0.25 );
 				directionalLight2.position.set( 0.5, -1, 0.5 );

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -32,6 +32,12 @@ THREE.Scene.prototype.addObject = function ( object ) {
 
 		}
 
+		if ( object.target && object.target.parent === undefined ) {
+
+			this.add( object.target );
+
+		}
+
 	} else if ( !( object instanceof THREE.Camera || object instanceof THREE.Bone ) ) {
 
 		if ( this.__objects.indexOf( object ) === - 1 ) {


### PR DESCRIPTION
We recently got caught up on a bug in code like this:

``` javascript
var light = new THREE.DirectionalLight(0xffffff);
light.position.set(1, 1, 1);
light.target.position.set(0, 1, 0);

scene.add(light);
```

The light was not responding to changes in the position of its target. The very subtle problem is that you either have to do:
`scene.add(light.target)`
or
`light.updateWorldMatrix()`
(even though `matrixAutoUpdate` is set to true for the target).

Looking at pasted code in issues like #1425 and #1405, it seems like other people are getting caught by this as well. This commit makes the scene automatically add the light target for you so its matrix will automatically get updated as expected.
