### PR TITLE
Typo in webgl_loader_ctm example

### DIFF
--- a/examples/webgl_loader_ctm.html
+++ b/examples/webgl_loader_ctm.html
@@ -141,7 +141,7 @@
 
 				}
 
-				var useWorker = true
+				var useWorker = true,
 					useBuffers = true;
 
 				var loader = new THREE.CTMLoader( renderer.context );


### PR DESCRIPTION
fixed typo in webgl_loader_ctm example
