### PR TITLE
ColladaLoader only creates lambert materials

### DIFF
--- a/examples/models/monster.dae
+++ b/examples/models/monster.dae
@@ -1380,10 +1380,10 @@
               </texture>
             </diffuse>
             <specular>
-              <color>0.9 0.9 0.9 1</color>
+              <color>0.1 0.1 0.1 1</color>
             </specular>
             <shininess>
-              <float>0.415939</float>
+              <float>20</float>
             </shininess>
             <reflective>
               <color>0 0 0 1</color>

--- a/src/extras/loaders/ColladaLoader.js
+++ b/src/extras/loaders/ColladaLoader.js
@@ -2935,17 +2935,9 @@ THREE.ColladaLoader = function () {
 
 							}
 
-						} else {
+						} else if ( prop == 'diffuse' || !transparent ) {
 
-							if ( prop == 'diffuse' ) {
-
-								props[ 'color' ] = cot.color.getHex();
-
-							} else if ( !transparent ) {
-
-								props[ prop ] = cot.color.getHex();
-
-							}
+							props[ prop ] = cot.color.getHex();
 
 						}
 
@@ -2979,27 +2971,27 @@ THREE.ColladaLoader = function () {
 		}
 
 		props[ 'shading' ] = preferredShading;
-		this.material = new THREE.MeshLambertMaterial( props );
 
 		switch ( this.type ) {
 
 			case 'constant':
-			case 'lambert':
+
+				props.color = props.emission;
+				this.material = new THREE.MeshBasicMaterial( props );
 				break;
 
 			case 'phong':
 			case 'blinn':
 
+				props.color = props.diffuse;
+				this.material = new THREE.MeshPhongMaterial( props );
+				break;
+
+			case 'lambert':
 			default:
 
-				/*
-				if ( !transparent ) {
-
-				//	this.material = new THREE.MeshPhongMaterial(props);
-
-				}
-				*/
-
+				props.color = props.diffuse;
+				this.material = new THREE.MeshLambertMaterial( props );
 				break;
 
 		}


### PR DESCRIPTION
Fixed ColladaLoader to create phong and constant materials when appropriate. The monster DAE was supposed to be using blinn shading, but its specular and shininess values made it look pretty bad. I updated them to make it look similar to the way it used to with lambert shading.
