### PR TITLE
ColladaLoader does not handle image elements in library_effects, effect, profile_COMMON

### DIFF
--- a/src/extras/loaders/ColladaLoader.js
+++ b/src/extras/loaders/ColladaLoader.js
@@ -3226,6 +3226,12 @@ THREE.ColladaLoader = function () {
 					this.parseNewparam( child );
 					break;
 
+				case 'image':
+
+					var _image = ( new _Image() ).parse( child );
+					images[ _image.id ] = _image;
+					break;
+
 				case 'extra':
 					break;
 


### PR DESCRIPTION
Adds image child element support to the effect profile_COMMON element. In addition to the library_images top level element Textures can appear in library effects and referenced by a surface. 
