### PR TITLE
Added emissive property for lambert and phong shading

### DIFF
--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -34,6 +34,7 @@ THREE.MeshBasicMaterial = function ( parameters ) {
 
 	parameters = parameters || {};
 
+	// color property represents emissive for MeshBasicMaterial
 	this.color = parameters.color !== undefined ? new THREE.Color( parameters.color ) : new THREE.Color( 0xffffff );
 
 	this.map = parameters.map !== undefined ? parameters.map : null;

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -5,6 +5,7 @@
  * parameters = {
  *  color: <hex>,
  *  ambient: <hex>,
+ *  emissive: <hex>,
  *  opacity: <float>,
  *
  *  map: new THREE.Texture( <Image> ),
@@ -36,8 +37,10 @@ THREE.MeshLambertMaterial = function ( parameters ) {
 
 	parameters = parameters || {};
 
+	// color property represents diffuse for MeshLambertMaterial
 	this.color = parameters.color !== undefined ? new THREE.Color( parameters.color ) : new THREE.Color( 0xffffff );
 	this.ambient = parameters.ambient !== undefined ? new THREE.Color( parameters.ambient ) : new THREE.Color( 0xffffff );
+	this.emissive = parameters.emissive !== undefined ? new THREE.Color( parameters.emissive ) : new THREE.Color( 0x000000 );
 
 	this.wrapAround = parameters.wrapAround !== undefined ? parameters.wrapAround: false;
 	this.wrapRGB = new THREE.Vector3( 1, 1, 1 );

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -5,6 +5,7 @@
  * parameters = {
  *  color: <hex>,
  *  ambient: <hex>,
+ *  emissive: <hex>,
  *  specular: <hex>,
  *  shininess: <float>,
  *  opacity: <float>,
@@ -38,8 +39,10 @@ THREE.MeshPhongMaterial = function ( parameters ) {
 
 	parameters = parameters || {};
 
+	// color property represents diffuse for MeshPhongMaterial
 	this.color = parameters.color !== undefined ? new THREE.Color( parameters.color ) : new THREE.Color( 0xffffff );
 	this.ambient = parameters.ambient !== undefined ? new THREE.Color( parameters.ambient ) : new THREE.Color( 0xffffff );
+	this.emissive = parameters.emissive !== undefined ? new THREE.Color( parameters.emissive ) : new THREE.Color( 0x000000 );
 	this.specular = parameters.specular !== undefined ? new THREE.Color( parameters.specular ) : new THREE.Color( 0x111111 );
 	this.shininess = parameters.shininess !== undefined ? parameters.shininess : 30;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4571,11 +4571,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( _this.gammaInput ) {
 
 			uniforms.ambient.value.copyGammaToLinear( material.ambient );
+			uniforms.emissive.value.copyGammaToLinear( material.emissive );
 			uniforms.specular.value.copyGammaToLinear( material.specular );
 
 		} else {
 
 			uniforms.ambient.value = material.ambient;
+			uniforms.emissive.value = material.emissive;
 			uniforms.specular.value = material.specular;
 
 		}
@@ -4593,10 +4595,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( _this.gammaInput ) {
 
 			uniforms.ambient.value.copyGammaToLinear( material.ambient );
+			uniforms.emissive.value.copyGammaToLinear( material.emissive );
 
 		} else {
 
 			uniforms.ambient.value = material.ambient;
+			uniforms.emissive.value = material.emissive;
 
 		}
 

--- a/src/renderers/WebGLShaders.js
+++ b/src/renderers/WebGLShaders.js
@@ -266,6 +266,7 @@ THREE.ShaderChunk = {
 
 		"uniform vec3 ambient;",
 		"uniform vec3 diffuse;",
+		"uniform vec3 emissive;",
 
 		"uniform vec3 ambientLightColor;",
 
@@ -294,11 +295,11 @@ THREE.ShaderChunk = {
 
 	lights_lambert_vertex: [
 
-		"vLightFront = vec3( 0.0 );",
+		"vLightFront = vec3( emissive );",
 
 		"#ifdef DOUBLE_SIDED",
 
-			"vLightBack = vec3( 0.0 );",
+			"vLightBack = vec3( emissive );",
 
 		"#endif",
 
@@ -663,11 +664,11 @@ THREE.ShaderChunk = {
 
 		"#ifdef METAL",
 
-			"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * ambient + totalSpecular );",
+			"gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor * ambient + totalSpecular );",
 
 		"#else",
 
-			"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * ambient ) + totalSpecular;",
+			"gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor * ambient ) + totalSpecular;",
 
 		"#endif"
 
@@ -1387,6 +1388,7 @@ THREE.ShaderLib = {
 
 			{
 				"ambient"  : { type: "c", value: new THREE.Color( 0x050505 ) },
+				"emissive"  : { type: "c", value: new THREE.Color( 0x000000 ) },
 				"wrapRGB"  : { type: "v3", value: new THREE.Vector3( 1, 1, 1 ) }
 			}
 
@@ -1501,6 +1503,7 @@ THREE.ShaderLib = {
 
 			{
 				"ambient"  : { type: "c", value: new THREE.Color( 0x050505 ) },
+				"emissive" : { type: "c", value: new THREE.Color( 0x000000 ) },
 				"specular" : { type: "c", value: new THREE.Color( 0x111111 ) },
 				"shininess": { type: "f", value: 30 },
 				"wrapRGB"  : { type: "v3", value: new THREE.Vector3( 1, 1, 1 ) }
@@ -1559,6 +1562,7 @@ THREE.ShaderLib = {
 			"uniform float opacity;",
 
 			"uniform vec3 ambient;",
+			"uniform vec3 emissive;",
 			"uniform vec3 specular;",
 			"uniform float shininess;",
 


### PR DESCRIPTION
Following discussion for #1426, I added emissive lighting. I tested by adding terms like `emissive: 0x008800` to various lambert and phong materials in the examples and they all looked good to me. Also played around with adding / removing lights from the scene and the materials seemed to respond appropriately.
