### PR TITLE
Fixed potential bugs in z-sorting, frustum culling, and ray intersection

### DIFF
--- a/src/core/Frustum.js
+++ b/src/core/Frustum.js
@@ -49,7 +49,7 @@ THREE.Frustum.prototype.contains = function ( object ) {
 
 	for ( var i = 0; i < 6; i ++ ) {
 
-		distance = planes[ i ].x * matrix.n14 + planes[ i ].y * matrix.n24 + planes[ i ].z * matrix.n34 + planes[ i ].w;
+		distance = planes[ i ].x * object.cog.x + planes[ i ].y * object.cog.y + planes[ i ].z * object.cog.z + planes[ i ].w;
 		if ( distance <= radius ) return false;
 
 	}

--- a/src/core/Frustum.js
+++ b/src/core/Frustum.js
@@ -43,9 +43,7 @@ THREE.Frustum.prototype.contains = function ( object ) {
 
 	var distance,
 	planes = this.planes,
-	matrix = object.matrixWorld,
-	scale = THREE.Frustum.__v1.set( matrix.getColumnX().length(), matrix.getColumnY().length(), matrix.getColumnZ().length() ),
-	radius = - object.geometry.boundingSphere.radius * Math.max( scale.x, Math.max( scale.y, scale.z ) );
+	radius = - object.geometry.boundingSphere.radius * object.boundRadiusScale;
 
 	for ( var i = 0; i < 6; i ++ ) {
 

--- a/src/core/Frustum.js
+++ b/src/core/Frustum.js
@@ -47,7 +47,7 @@ THREE.Frustum.prototype.contains = function ( object ) {
 
 	for ( var i = 0; i < 6; i ++ ) {
 
-		distance = planes[ i ].x * object.cog.x + planes[ i ].y * object.cog.y + planes[ i ].z * object.cog.z + planes[ i ].w;
+		distance = planes[ i ].x * object.center.x + planes[ i ].y * object.center.y + planes[ i ].z * object.center.z + planes[ i ].w;
 		if ( distance <= radius ) return false;
 
 	}

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -544,7 +544,9 @@ THREE.Geometry.prototype = {
 
 	computeBoundingSphere: function () {
 
-		if ( ! this.boundingSphere ) this.boundingSphere = { radius: 0 };
+		if ( ! this.boundingBox ) this.computeBoundingBox();
+
+		if ( ! this.boundingSphere ) this.boundingSphere = { radius: 0, position: new THREE.Vector3() };
 
 		var radius, maxRadius = 0;
 
@@ -555,7 +557,9 @@ THREE.Geometry.prototype = {
 
 		}
 
-		this.boundingSphere.radius = maxRadius;
+		this.boundingSphere.position.add( this.boundingBox.min, this.boundingBox.max ).multiplyScalar( 0.5 );
+		radius = this.boundingSphere.position.length();
+		this.boundingSphere.radius = maxRadius - radius;
 
 	},
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -224,6 +224,7 @@ THREE.Object3D.prototype = {
 
 			this.matrix.scale( this.scale );
 			this.boundRadiusScale = Math.max( this.scale.x, Math.max( this.scale.y, this.scale.z ) );
+			if ( this.parent ) this.boundRadiusScale *= this.parent.boundRadiusScale;
 
 		}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -19,6 +19,7 @@ THREE.Object3D = function () {
 	this.rotation = new THREE.Vector3();
 	this.eulerOrder = 'XYZ';
 	this.scale = new THREE.Vector3( 1, 1, 1 );
+	this.scaleWorld = new THREE.Vector3( 1, 1, 1 );
 
 	this.doubleSided = false;
 	this.flipSided = false;
@@ -223,11 +224,20 @@ THREE.Object3D.prototype = {
 		if ( this.scale.x !== 1 || this.scale.y !== 1 || this.scale.z !== 1 ) {
 
 			this.matrix.scale( this.scale );
-			this.boundRadiusScale = Math.max( this.scale.x, Math.max( this.scale.y, this.scale.z ) );
-			if ( this.parent ) this.boundRadiusScale *= this.parent.boundRadiusScale;
 
 		}
 
+		if ( this.parent ) {
+
+			this.scaleWorld.multiply( this.scale, this.parent.scale );
+
+		} else {
+
+			this.scaleWorld.copy( this.scale );
+
+		}
+
+		this.boundRadiusScale = Math.max( this.scaleWorld.x, Math.max( this.scaleWorld.y, this.scaleWorld.z ) );
 		this.matrixWorldNeedsUpdate = true;
 
 	},

--- a/src/core/Ray.js
+++ b/src/core/Ray.js
@@ -74,9 +74,8 @@ THREE.Ray = function ( origin, direction ) {
 			// Checking boundingSphere
 
 			var distance = distanceFromIntersection( this.origin, this.direction, object.cog );
-			var scale = THREE.Frustum.__v1.set( object.matrixWorld.getColumnX().length(), object.matrixWorld.getColumnY().length(), object.matrixWorld.getColumnZ().length() );
 
-			if ( distance > object.geometry.boundingSphere.radius * Math.max( scale.x, Math.max( scale.y, scale.z ) ) ) {
+			if ( distance > object.geometry.boundingSphere.radius * object.boundRadiusScale ) {
 
 				return intersects;
 

--- a/src/core/Ray.js
+++ b/src/core/Ray.js
@@ -73,7 +73,7 @@ THREE.Ray = function ( origin, direction ) {
 
 			// Checking boundingSphere
 
-			var distance = distanceFromIntersection( this.origin, this.direction, object.cog );
+			var distance = distanceFromIntersection( this.origin, this.direction, object.center );
 
 			if ( distance > object.geometry.boundingSphere.radius * object.boundRadiusScale ) {
 

--- a/src/core/Ray.js
+++ b/src/core/Ray.js
@@ -73,7 +73,7 @@ THREE.Ray = function ( origin, direction ) {
 
 			// Checking boundingSphere
 
-			var distance = distanceFromIntersection( this.origin, this.direction, object.matrixWorld.getPosition() );
+			var distance = distanceFromIntersection( this.origin, this.direction, object.cog );
 			var scale = THREE.Frustum.__v1.set( object.matrixWorld.getColumnX().length(), object.matrixWorld.getColumnY().length(), object.matrixWorld.getColumnZ().length() );
 
 			if ( distance > object.geometry.boundingSphere.radius * Math.max( scale.x, Math.max( scale.y, scale.z ) ) ) {

--- a/src/extras/geometries/PolyhedronGeometry.js
+++ b/src/extras/geometries/PolyhedronGeometry.js
@@ -130,7 +130,7 @@ THREE.PolyhedronGeometry = function ( vertices, faces, radius, detail ) {
 
 	}
 
-	this.boundingSphere = { radius: radius };
+	this.boundingSphere = { radius: radius, position: new THREE.Vector3() };
 
 };
 

--- a/src/extras/geometries/SphereGeometry.js
+++ b/src/extras/geometries/SphereGeometry.js
@@ -88,7 +88,7 @@ THREE.SphereGeometry = function ( radius, segmentsWidth, segmentsHeight, phiStar
 	this.computeCentroids();
 	this.computeFaceNormals();
 
-	this.boundingSphere = { radius: radius };
+	this.boundingSphere = { radius: radius, position: new THREE.Vector3() };
 
 };
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -10,6 +10,7 @@ THREE.Mesh = function ( geometry, material ) {
 
 	this.geometry = geometry;
 	this.material = ( material !== undefined ) ? material : new THREE.MeshBasicMaterial( { color: Math.random() * 0xffffff, wireframe: true } );
+	this.cog = new THREE.Vector3();
 
 	if ( this.geometry ) {
 
@@ -64,5 +65,13 @@ THREE.Mesh.prototype.getMorphTargetIndexByName = function( name ) {
 
 	console.log( "THREE.Mesh.getMorphTargetIndexByName: morph target " + name + " does not exist. Returning 0." );
 	return 0;
+
+}
+
+THREE.Mesh.prototype.updateMatrixWorld = function( force ) {
+
+	THREE.Object3D.prototype.updateMatrixWorld.call( this, force );
+
+	this.matrixWorld.multiplyVector3( this.cog.copy( this.geometry.boundingSphere.position ) );
 
 }

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -10,7 +10,7 @@ THREE.Mesh = function ( geometry, material ) {
 
 	this.geometry = geometry;
 	this.material = ( material !== undefined ) ? material : new THREE.MeshBasicMaterial( { color: Math.random() * 0xffffff, wireframe: true } );
-	this.cog = new THREE.Vector3();
+	this.center = new THREE.Vector3();
 
 	if ( this.geometry ) {
 
@@ -72,6 +72,6 @@ THREE.Mesh.prototype.updateMatrixWorld = function( force ) {
 
 	THREE.Object3D.prototype.updateMatrixWorld.call( this, force );
 
-	this.matrixWorld.multiplyVector3( this.cog.copy( this.geometry.boundingSphere.position ) );
+	this.matrixWorld.multiplyVector3( this.center.copy( this.geometry.boundingSphere.position ) );
 
 }

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3344,7 +3344,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 						} else {
 
-							_vector3.copy( object.position );
+							_vector3.copy( object.cog );
 							_projScreenMatrix.multiplyVector3( _vector3 );
 
 							webglObject.z = _vector3.z;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3344,7 +3344,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 						} else {
 
-							_vector3.copy( object.cog );
+							_vector3.copy( object.center ? object.center : object.matrixWorld.getPosition() );
 							_projScreenMatrix.multiplyVector3( _vector3 );
 
 							webglObject.z = _vector3.z;


### PR DESCRIPTION
Following discussion from issue #1459.

I implemented the bounding sphere position and in my tests it seems to fix the sorting/culling issues I was finding. Please take a look and let me know your thoughts.

I chose to cache the bounding sphere's position in world space as `Mesh.cog` (center-of-geometry) for better performance. I think that the COG is a useful value in a lot of situations. For instance, you could have a camera center on any given Mesh by calling `camera.lookAt( mesh.cog )`.

I also noticed that `boundRadiusScale` was not being used anywhere in the code. So I updated it to replace world matrix decompositions in `Frustum` and `Ray`. This should be more performant as well as more accurate since the decomposition isn't guaranteed to give you the correct scale value.
