### PR TITLE
Fixed a normalization issue for the PlayBook platform.

### DIFF
--- a/src/renderers/WebGLShaders.js
+++ b/src/renderers/WebGLShaders.js
@@ -1283,7 +1283,7 @@ THREE.ShaderLib = {
 			"void main() {",
 
 				"vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
-				"vNormal = normalize( normalMatrix * normal );",
+				"vNormal = normalMatrix * normal;",
 
 				"gl_Position = projectionMatrix * mvPosition;",
 


### PR DESCRIPTION
Our current drivers have an issue with normalizing a vec3 in the vertex shader. There are two solutions two possible workarounds for this issue.
1.  This normalize seems needless as the normal will need to be re-normalized in the fragment shader anyways. Plus this code doesn't seem to use the normalized vector in the vertex shader. (this is the submitted solution)
2.  If this is necessary, we don't seem to have a problem with normalizing vec4s in our vertex shader. So something like: vNormal = normalize( vec4( normalMatrix \* normal, 1.0) ).xyz would work on the PlayBook platform. Although in this case you might be better off placing this code in a platform specific block.

Note: With our latest unreleased drivers, this issue is fixed. I have no explicit ETA yet for these drivers though, thus the need for the workaround.
