### PR TITLE
Added precision qualifiers to resolve shader compilation errors on mobile devices.

### DIFF
--- a/examples/js/ShaderExtras.js
+++ b/examples/js/ShaderExtras.js
@@ -114,7 +114,7 @@ THREE.ShaderExtras = {
 			"uniform float cKernel[ KERNEL_SIZE ];",
 
 			"uniform sampler2D tDiffuse;",
-			"uniform vec2 uImageIncrement;",
+			"uniform highp vec2 uImageIncrement;",
 
 			"varying vec2 vUv;",
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5392,8 +5392,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 			parameters.shadowMapDebug ? "#define SHADOWMAP_DEBUG" : "",
 			parameters.shadowMapCascade ? "#define SHADOWMAP_CASCADE" : "",
 
-			"uniform mat4 viewMatrix;",
-			"uniform vec3 cameraPosition;",
+			"uniform highp mat4 viewMatrix;",
+			"uniform highp vec3 cameraPosition;",
 			""
 
 		].join("\n");


### PR DESCRIPTION
You guys recently added "precision mediump float" to your fragment shaders. This caused several shaders to no longer compile on mobile devices. The reason is that highp is still intrinsically being specified for several vertex shader uniforms which are now also being used in the fragment shader as medium. This conflict causes the compilation issue.

There are essentially 3 possible solutions to this problem:
1. Change the fragment shader precision back to highp which was likely done for a good reason.
2. Change the vertex shader precision for the uniforms in question to mediump.
3. Change the fragment shader precision for the uniforms in question to highp. (this is what is being done in the attached code fragments)
