### PR TITLE
THREE.geometry : change __dirtyVertices to verticesNeedUpdate field

### DIFF
--- a/examples/webgl_geometry_dynamic.html
+++ b/examples/webgl_geometry_dynamic.html
@@ -151,7 +151,7 @@
 				//geometry.computeFaceNormals();
 				//geometry.computeVertexNormals();
 
-				mesh.geometry.__dirtyVertices = true;
+				mesh.geometry.verticesNeedUpdate = true;
 				//mesh.geometry.__dirtyNormals = true;
 
 				controls.update( delta );

--- a/examples/webgl_particles_dynamic.html
+++ b/examples/webgl_particles_dynamic.html
@@ -450,7 +450,7 @@
 
 					}
 
-					mesh.geometry.__dirtyVertices = true;
+					mesh.geometry.verticesNeedUpdate = true;
 
 				}
 

--- a/examples/webgl_particles_shapes.html
+++ b/examples/webgl_particles_shapes.html
@@ -629,7 +629,7 @@
 
 				delta = speed * clock.getDelta();
 
-				particleCloud.geometry.__dirtyVertices = true;
+				particleCloud.geometry.verticesNeedUpdate = true;
 
 				attributes.size.needsUpdate = true;
 				attributes.pcolor.needsUpdate = true;

--- a/examples/webgl_ribbons.html
+++ b/examples/webgl_ribbons.html
@@ -278,8 +278,8 @@
 
 				}
 
-				geometry.__dirtyVertices = true;
-				geometry2.__dirtyVertices = true;
+				geometry.verticesNeedUpdate = true;
+				geometry2.verticesNeedUpdate = true;
 
 				for( i = 0; i < nribbons; i++ ) {
 

--- a/src/extras/helpers/CameraHelper.js
+++ b/src/extras/helpers/CameraHelper.js
@@ -169,7 +169,7 @@ THREE.CameraHelper.prototype.update = function ( camera ) {
 
 	}
 
-	this.lineGeometry.__dirtyVertices = true;
+	this.lineGeometry.verticesNeedUpdate = true;
 
 };
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -836,7 +836,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		sortArray = geometry.__sortArray,
 
-		dirtyVertices = geometry.__dirtyVertices,
+		dirtyVertices = geometry.verticesNeedUpdate,
 		dirtyElements = geometry.__dirtyElements,
 		dirtyColors = geometry.__dirtyColors,
 
@@ -1154,7 +1154,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		vertexArray = geometry.__vertexArray,
 		colorArray = geometry.__colorArray,
 
-		dirtyVertices = geometry.__dirtyVertices,
+		dirtyVertices = geometry.verticesNeedUpdate,
 		dirtyColors = geometry.__dirtyColors,
 
 		customAttributes = geometry.__webglCustomAttributesList,
@@ -1308,7 +1308,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		vertexArray = geometry.__vertexArray,
 		colorArray = geometry.__colorArray,
 
-		dirtyVertices = geometry.__dirtyVertices,
+		dirtyVertices = geometry.verticesNeedUpdate,
 		dirtyColors = geometry.__dirtyColors;
 
 		if ( dirtyVertices ) {
@@ -1422,7 +1422,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		geometry = object.geometry, // this is shared for all chunks
 
-		dirtyVertices = geometry.__dirtyVertices,
+		dirtyVertices = geometry.verticesNeedUpdate,
 		dirtyElements = geometry.__dirtyElements,
 		dirtyUvs = geometry.__dirtyUvs,
 		dirtyNormals = geometry.__dirtyNormals,
@@ -3813,7 +3813,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 							createMeshBuffers( geometryGroup );
 							initMeshBuffers( geometryGroup, object );
 
-							geometry.__dirtyVertices = true;
+							geometry.verticesNeedUpdate = true;
 							geometry.__dirtyMorphTargets = true;
 							geometry.__dirtyElements = true;
 							geometry.__dirtyUvs = true;
@@ -3836,7 +3836,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 					createRibbonBuffers( geometry );
 					initRibbonBuffers( geometry );
 
-					geometry.__dirtyVertices = true;
+					geometry.verticesNeedUpdate = true;
 					geometry.__dirtyColors = true;
 
 				}
@@ -3850,7 +3850,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 					createLineBuffers( geometry );
 					initLineBuffers( geometry, object );
 
-					geometry.__dirtyVertices = true;
+					geometry.verticesNeedUpdate = true;
 					geometry.__dirtyColors = true;
 
 				}
@@ -3864,7 +3864,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 					createParticleBuffers( geometry );
 					initParticleBuffers( geometry, object );
 
-					geometry.__dirtyVertices = true;
+					geometry.verticesNeedUpdate = true;
 					geometry.__dirtyColors = true;
 
 				}
@@ -3959,7 +3959,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			if ( geometry instanceof THREE.BufferGeometry ) {
 
 				/*
-				if ( geometry.__dirtyVertices || geometry.__dirtyElements ||
+				if ( geometry.verticesNeedUpdate || geometry.__dirtyElements ||
 					 geometry.__dirtyUvs || geometry.__dirtyNormals ||
 					 geometry.__dirtyColors  ) {
 
@@ -3969,7 +3969,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 				*/
 
-				geometry.__dirtyVertices = false;
+				geometry.verticesNeedUpdate = false;
 				geometry.__dirtyElements = false;
 				geometry.__dirtyUvs = false;
 				geometry.__dirtyNormals = false;
@@ -3987,7 +3987,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					customAttributesDirty = material.attributes && areCustomAttributesDirty( material );
 
-					if ( geometry.__dirtyVertices || geometry.__dirtyMorphTargets || geometry.__dirtyElements ||
+					if ( geometry.verticesNeedUpdate || geometry.__dirtyMorphTargets || geometry.__dirtyElements ||
 						 geometry.__dirtyUvs || geometry.__dirtyNormals ||
 						 geometry.__dirtyColors || geometry.__dirtyTangents || customAttributesDirty ) {
 
@@ -3997,7 +3997,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				geometry.__dirtyVertices = false;
+				geometry.verticesNeedUpdate = false;
 				geometry.__dirtyMorphTargets = false;
 				geometry.__dirtyElements = false;
 				geometry.__dirtyUvs = false;
@@ -4011,13 +4011,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		} else if ( object instanceof THREE.Ribbon ) {
 
-			if ( geometry.__dirtyVertices || geometry.__dirtyColors ) {
+			if ( geometry.verticesNeedUpdate || geometry.__dirtyColors ) {
 
 				setRibbonBuffers( geometry, _gl.DYNAMIC_DRAW );
 
 			}
 
-			geometry.__dirtyVertices = false;
+			geometry.verticesNeedUpdate = false;
 			geometry.__dirtyColors = false;
 
 		} else if ( object instanceof THREE.Line ) {
@@ -4026,13 +4026,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			customAttributesDirty = material.attributes && areCustomAttributesDirty( material );
 
-			if ( geometry.__dirtyVertices ||  geometry.__dirtyColors || customAttributesDirty ) {
+			if ( geometry.verticesNeedUpdate ||  geometry.__dirtyColors || customAttributesDirty ) {
 
 				setLineBuffers( geometry, _gl.DYNAMIC_DRAW );
 
 			}
 
-			geometry.__dirtyVertices = false;
+			geometry.verticesNeedUpdate = false;
 			geometry.__dirtyColors = false;
 
 			material.attributes && clearCustomAttributes( material );
@@ -4043,13 +4043,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			customAttributesDirty = material.attributes && areCustomAttributesDirty( material );
 
-			if ( geometry.__dirtyVertices || geometry.__dirtyColors || object.sortParticles || customAttributesDirty ) {
+			if ( geometry.verticesNeedUpdate || geometry.__dirtyColors || object.sortParticles || customAttributesDirty ) {
 
 				setParticleBuffers( geometry, _gl.DYNAMIC_DRAW, object );
 
 			}
 
-			geometry.__dirtyVertices = false;
+			geometry.verticesNeedUpdate = false;
 			geometry.__dirtyColors = false;
 
 			material.attributes && clearCustomAttributes( material );


### PR DESCRIPTION
Here is a simple name change for geometry : __dirtyVertices becomes verticesNeedUpdate.

The rationale is:
- clean the API (#697)
- avoid the double underscore, which can be problematic when using the library with other javascript code (as an example, the qooxdoo minifier interprets underscored properties as private properties, and renames them)

This is just a first step, more properties should be changed, as explained in #697

This modification was generated automatically using this script on .js code:
<code> find . -name "*.js" -print | xargs sed -i 's/__dirtyVertices/verticesNeedUpdate/g' </code>
