### PR TITLE
Modified scene loader to allow objects to specify matrix directly

### DIFF
--- a/src/extras/loaders/SceneLoader.js
+++ b/src/extras/loaders/SceneLoader.js
@@ -159,6 +159,7 @@ THREE.SceneLoader.prototype.createScene = function ( json, callbackFinished, url
 						r = o.rotation;
 						q = o.quaternion;
 						s = o.scale;
+						m = o.matrix;
 
 						// turn off quaternions, for the moment
 
@@ -181,20 +182,33 @@ THREE.SceneLoader.prototype.createScene = function ( json, callbackFinished, url
 
 						object = new THREE.Mesh( geometry, material );
 						object.name = dd;
-						object.position.set( p[0], p[1], p[2] );
-
-						if ( q ) {
-
-							object.quaternion.set( q[0], q[1], q[2], q[3] );
-							object.useQuaternion = true;
-
+						
+						if ( m ) {
+							
+							object.matrixAutoUpdate = false;
+							object.matrix.set( m[0], m[1], m[2], m[3],
+											   m[4], m[5], m[6], m[7],
+											   m[8], m[9], m[10], m[11],
+											   m[12], m[13], m[14], m[15]);
+							
 						} else {
-
-							object.rotation.set( r[0], r[1], r[2] );
-
+							
+							object.position.set( p[0], p[1], p[2] );
+	
+							if ( q ) {
+	
+								object.quaternion.set( q[0], q[1], q[2], q[3] );
+								object.useQuaternion = true;
+	
+							} else {
+	
+								object.rotation.set( r[0], r[1], r[2] );
+	
+							}
+	
+							object.scale.set( s[0], s[1], s[2] );
+							
 						}
-
-						object.scale.set( s[0], s[1], s[2] );
 
 						object.visible = o.visible;
 						object.doubleSided = o.doubleSided;


### PR DESCRIPTION
Scene object had to look like this before:

```
"cube1" : {
    "geometry" : "cube",
    "materials": [ "lambert_red" ],
    "position" : [ 0, 0, 0 ],
    "rotation" : [ 0, -0.3, 0 ],
    "scale"    : [ 1, 1, 1 ],
    "visible"  : true
},
```

Now they can look like this:

```
"Text-Geometry-primitive-0": {
   "geometry": "Text-Geometry-primitive-0",
   "visible": true,
   "materials": ["ERTransparent06"],
   "matrix": [0.9542901,-0.2923984,-0.06191673,-0.07395048,0.06913101,0.01439428,0.9975038,0.130682,-0.2907773,-0.9561883,0.03395012,0.002342688,0,0,0,1]
},
```

When the `matrix` attribute is present, the others are ignored and `matrixAutoUpdate` is set to false.
