### PR TITLE
Unrolled a loop in the shadowmap fragment shader

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5398,6 +5398,66 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		].join("\n");
 
+    var shadowString = "";
+    for ( var shadowIndex = 0; shadowIndex < parameters.maxShadows; shadowIndex++ ) {
+        shadowString +=
+        "shadowCoord = vShadowCoord[ "+shadowIndex+" ].xyz / vShadowCoord[ "+shadowIndex+" ].w;\n\
+        inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );\n\
+        inFrustum = all( inFrustumVec );\n\
+        #ifdef SHADOWMAP_CASCADE\n\
+        inFrustumCount += int( inFrustum );\n\
+        frustumTestVec = bvec3( inFrustum, inFrustumCount == 1, shadowCoord.z <= 1.0 );\n\
+        #else\n\
+        frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );\n\
+        #endif\n\
+        frustumTest = all( frustumTestVec );\n\
+        if ( frustumTest ) {\n\
+        shadowCoord.z += shadowBias[ "+shadowIndex+" ];\n\
+        #ifdef SHADOWMAP_SOFT\n\
+        float shadow = 0.0;\n\
+        const float shadowDelta = 1.0 / 9.0;\n\
+        float xPixelOffset = 1.0 / shadowMapSize[ "+shadowIndex+" ].x;\n\
+        float yPixelOffset = 1.0 / shadowMapSize[ "+shadowIndex+" ].y;\n\
+        float dx0 = -1.25 * xPixelOffset;\n\
+        float dy0 = -1.25 * yPixelOffset;\n\
+        float dx1 = 1.25 * xPixelOffset;\n\
+        float dy1 = 1.25 * yPixelOffset;\n\
+        fDepth = unpackDepth( texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy + vec2( dx0, dy0 ) ) );\n\
+        if ( fDepth < shadowCoord.z ) shadow += shadowDelta;\n\
+        fDepth = unpackDepth( texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy + vec2( 0.0, dy0 ) ) );\n\
+        if ( fDepth < shadowCoord.z ) shadow += shadowDelta;\n\
+        fDepth = unpackDepth( texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy + vec2( dx1, dy0 ) ) );\n\
+        if ( fDepth < shadowCoord.z ) shadow += shadowDelta;\n\
+        fDepth = unpackDepth( texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy + vec2( dx0, 0.0 ) ) );\n\
+        if ( fDepth < shadowCoord.z ) shadow += shadowDelta;\n\
+        fDepth = unpackDepth( texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy ) );\n\
+        if ( fDepth < shadowCoord.z ) shadow += shadowDelta;\n\
+        fDepth = unpackDepth( texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy + vec2( dx1, 0.0 ) ) );\n\
+        if ( fDepth < shadowCoord.z ) shadow += shadowDelta;\n\
+        fDepth = unpackDepth( texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy + vec2( dx0, dy1 ) ) );\n\
+        if ( fDepth < shadowCoord.z ) shadow += shadowDelta;\n\
+        fDepth = unpackDepth( texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy + vec2( 0.0, dy1 ) ) );\n\
+        if ( fDepth < shadowCoord.z ) shadow += shadowDelta;\n\
+        fDepth = unpackDepth( texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy + vec2( dx1, dy1 ) ) );\n\
+        if ( fDepth < shadowCoord.z ) shadow += shadowDelta;\n\
+        shadowColor = shadowColor * vec3( ( 1.0 - shadowDarkness[ "+shadowIndex+" ] * shadow ) );\n\
+        #else\n\
+        vec4 rgbaDepth;\n\
+        rgbaDepth = texture2D( shadowMap[ "+shadowIndex+" ], shadowCoord.xy );\n\
+        float fDepth = unpackDepth( rgbaDepth );\n\
+        if ( fDepth < shadowCoord.z )\n\
+           shadowColor = shadowColor * vec3( 1.0 - shadowDarkness[ "+shadowIndex+" ] );\n\
+        #endif\n\
+        }\n\
+        #ifdef SHADOWMAP_DEBUG\n\
+        #ifdef SHADOWMAP_CASCADE\n\
+        if ( inFrustum && inFrustumCount == 1 ) gl_FragColor.xyz *= frustumColors[ "+shadowIndex+" ];\n\
+        #else\n\
+        if ( inFrustum ) gl_FragColor.xyz *= frustumColors[ "+shadowIndex+" ];\n\
+        #endif\n\
+        #endif\n";
+    }
+    fragmentShader = fragmentShader.replace( "SHADOWMAP_STRING", shadowString );
 		_gl.attachShader( program, getShader( "fragment", prefix_fragment + fragmentShader ) );
 		_gl.attachShader( program, getShader( "vertex", prefix_vertex + vertexShader ) );
 

--- a/src/renderers/WebGLShaders.js
+++ b/src/renderers/WebGLShaders.js
@@ -883,7 +883,24 @@ THREE.ShaderChunk = {
 
 			"float fDepth;",
 			"vec3 shadowColor = vec3( 1.0 );",
+        "vec3 shadowCoord;",
+        "bvec4 inFrustumVec;",
+        "bool inFrustum;",
 
+        "#ifdef SHADOWMAP_CASCADE",
+
+            "bvec3 frustumTestVec;",
+
+        "#else",
+
+            "bvec2 frustumTestVec;",
+
+        "#endif",
+
+        "bool frustumTest;",
+
+        "SHADOWMAP_STRING",
+/*
 			"for( int i = 0; i < MAX_SHADOWS; i ++ ) {",
 
 				"vec3 shadowCoord = vShadowCoord[ i ].xyz / vShadowCoord[ i ].w;",
@@ -945,7 +962,7 @@ THREE.ShaderChunk = {
 						"shadow /= 9.0;",
 
 						*/
-
+/*
 						"const float shadowDelta = 1.0 / 9.0;",
 
 						"float xPixelOffset = 1.0 / shadowMapSize[ i ].x;",
@@ -986,7 +1003,7 @@ THREE.ShaderChunk = {
 						"shadowColor = shadowColor * vec3( ( 1.0 - shadowDarkness[ i ] * shadow ) );",
 
 					"#else",
-
+/*
 						"vec4 rgbaDepth = texture2D( shadowMap[ i ], shadowCoord.xy );",
 						"float fDepth = unpackDepth( rgbaDepth );",
 
@@ -1020,7 +1037,7 @@ THREE.ShaderChunk = {
 				"#endif",
 
 			"}",
-
+*/
 			"#ifdef GAMMA_OUTPUT",
 
 				"shadowColor *= shadowColor;",


### PR DESCRIPTION
As per our previous conversation, this is the PlayBook specific work-around that we came up with to fix the fact that indexed sampler arrays are not supported on the PlayBook.

In general, this change makes it so that samples that use shadows work as expected.

I'm not sure if this is at all useful for you, but we figured we'd share it anyways. :)
