### PR TITLE
Fixed vertex normals of CylinderGeometry

### DIFF
--- a/src/extras/geometries/CylinderGeometry.js
+++ b/src/extras/geometries/CylinderGeometry.js
@@ -44,26 +44,42 @@ THREE.CylinderGeometry = function ( radiusTop, radiusBottom, height, segmentsRad
 
 	}
 
-	for ( y = 0; y < segmentsY; y ++ ) {
+	var tanTheta = ( radiusBottom - radiusTop ) / height;
+	var na, nb;
 
-		for ( x = 0; x < segmentsX; x ++ ) {
+	for ( x = 0; x < segmentsX; x ++ ) {
+
+		if ( radiusTop !== 0 ) {
+
+			na = this.vertices[ vertices[ 0 ][ x ] ].position.clone();
+			nb = this.vertices[ vertices[ 0 ][ x + 1 ] ].position.clone();
+
+		} else {
+
+			na = this.vertices[ vertices[ 1 ][ x ] ].position.clone();
+			nb = this.vertices[ vertices[ 1 ][ x + 1 ] ].position.clone();
+
+		}
+		
+		na.setY( Math.sqrt( na.x * na.x + na.z * na.z ) * tanTheta ).normalize();
+		nb.setY( Math.sqrt( nb.x * nb.x + nb.z * nb.z ) * tanTheta ).normalize();
+
+		for ( y = 0; y < segmentsY; y ++ ) {
 
 			var v1 = vertices[ y ][ x ];
 			var v2 = vertices[ y + 1 ][ x ];
 			var v3 = vertices[ y + 1 ][ x + 1 ];
 			var v4 = vertices[ y ][ x + 1 ];
 
-			// FIXME: These normals aren't right for cones.
-
-			var n1 = this.vertices[ v1 ].position.clone().setY( 0 ).normalize();
-			var n2 = this.vertices[ v2 ].position.clone().setY( 0 ).normalize();
-			var n3 = this.vertices[ v3 ].position.clone().setY( 0 ).normalize();
-			var n4 = this.vertices[ v4 ].position.clone().setY( 0 ).normalize();
-
 			var uv1 = uvs[ y ][ x ].clone();
 			var uv2 = uvs[ y + 1 ][ x ].clone();
 			var uv3 = uvs[ y + 1 ][ x + 1 ].clone();
 			var uv4 = uvs[ y ][ x + 1 ].clone();
+
+			var n1 = na.clone();
+			var n2 = na.clone();
+			var n3 = nb.clone();
+			var n4 = nb.clone();
 
 			this.faces.push( new THREE.Face4( v1, v2, v3, v4, [ n1, n2, n3, n4 ] ) );
 			this.faceVertexUvs[ 0 ].push( [ uv1, uv2, uv3, uv4 ] );


### PR DESCRIPTION
The vertex normals were wrong for cones. 

This pull request fixed it by calculating the angle of the cone, as shown in the following figure.

![](http://i.imgur.com/jU6HG.png)
