### PR TITLE
World to Local

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -263,6 +263,20 @@ THREE.Object3D.prototype = {
 
 		}
 
+	},
+
+	worldToLocal: function ( vector ) {
+
+		if ( !this.__inverseMatrixWorld ) this.__inverseMatrixWorld = new THREE.Matrix4();
+
+		return this.__inverseMatrixWorld.getInverse( this.matrixWorld ).multiplyVector3( vector );
+
+	},
+
+	localToWorld: function ( vector ) {
+
+		return this.matrixWorld.multiplyVector3( vector );
+
 	}
 
 };


### PR DESCRIPTION
As per commit notes.

There should be the convenience methods for switching between the scene/world/global/absolute coordinates to the local/child/relative coordinates with Object3D, which is part of the scene graph, rather than the Vector class.

Hopefully helps resolves issues: #1752, #1043, 025fb6243afed67811ee514e5dc11b382336c67c and baf0f65e1db76cc95e3d1a3cf759861b807fa177
