### PR TITLE
Fixed normal to RGB encoding

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -134,7 +134,7 @@ THREE.ImageUtils = {
 				var idx = ( y * width + x ) * 4;
 
 				output[ idx ] = ( ( normal[ 0 ] + 1.0 ) / 2.0 * 255 ) | 0;
-				output[ idx + 1 ] = ( ( normal[ 1 ] + 1.0 / 2.0 ) * 255 ) | 0;
+				output[ idx + 1 ] = ( ( normal[ 1 ] + 1.0 ) / 2.0 * 255 ) | 0;
 				output[ idx + 2 ] = ( normal[ 2 ] * 255 ) | 0;
 				output[ idx + 3 ] = 255;
 


### PR DESCRIPTION
The X and Y parts of calculated normal vector are in +-1 range. So to transform them to 0-255 range, you have to add 1, divide by 2 and multiply by 255.

Also, the `| 0` in the ends is a bit confusing at first. `Math.floor()` is more readable (but maybe slower).
