### PR TITLE
Small cleanup

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4514,12 +4514,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				object.__webglMorphTargetInfluences = new Float32Array( _this.maxMorphTargets );
 
-				for ( var i = 0, il = _this.maxMorphTargets; i < il; i ++ ) {
-
-					object.__webglMorphTargetInfluences[ i ] = 0;
-
-				}
-
 			}
 
 		}


### PR DESCRIPTION
This is unnessecary code as a typed array automatically gets set to zero whezn its created with a length parameter. see

http://www.khronos.org/registry/typedarray/specs/latest/#7
