### PR TITLE
Add range to Ray.intersectObject()

### DIFF
--- a/src/core/Ray.js
+++ b/src/core/Ray.js
@@ -2,11 +2,12 @@
  * @author mr.doob / http://mrdoob.com/
  */
 
-THREE.Ray = function ( origin, direction, range ) {
+THREE.Ray = function ( origin, direction, near, far ) {
 
 	this.origin = origin || new THREE.Vector3();
 	this.direction = direction || new THREE.Vector3();
-	this.range = range || -1;
+	this.near = near || 0;
+	this.far = far || Infinity;
 
 	var precision = 0.0001;
 
@@ -46,9 +47,10 @@ THREE.Ray = function ( origin, direction, range ) {
 			// Checking range, note that distance may be actually greater then this.range,
 			// because we also consider object.scale.x
 			
-			if ( this.range >= 0 ) {
-				distance = vector.sub( this.origin, object.matrixWorld.getPosition() ).length();
-				if ( distance > object.scale.x + this.range ) return [];
+			if ( this.far < Infinity || this.near > 0 ) {
+				distance = vector.sub(this.origin, object.matrixWorld.getPosition()).length();
+				if ( distance > object.scale.x + this.far ) return [];
+				if ( distance < -object.scale.x + this.near ) return [];
 			}
 			
 			distance = distanceFromIntersection( this.origin, this.direction, object.matrixWorld.getPosition() );
@@ -79,10 +81,11 @@ THREE.Ray = function ( origin, direction, range ) {
 			var distance;
 
 			// Checking distance to origin
-			if (this.range >= 0) {
+			if ( this.far < Infinity || this.near > 0 ) {
 			
 				distance = vector.sub( object.matrixWorld.getPosition(), this.origin ).length();
-				if ( distance > scaledRadius + this.range ) return intersects;
+				if ( distance > scaledRadius + this.far ) return intersects;
+				if ( distance < -scaledRadius + this.near ) return intersects;
 				
 			}
 			
@@ -139,8 +142,10 @@ THREE.Ray = function ( origin, direction, range ) {
 
 					intersectPoint.add( originCopy, directionCopy.multiplyScalar( scalar ) );
 
-					// Check for range
-					if ( ( this.range >= 0 ) && ( vector.sub( this.origin, intersectPoint ).lengthSq() > rangeSq ) ) continue;
+					// Checking distance to origin (would be calculated anyway)
+					distance = originCopy.distanceTo( intersectPoint );
+					if ( distance > this.far ) continue;
+					if ( distance < this.near ) continue;
 
 					if ( face instanceof THREE.Face3 ) {
 
@@ -152,7 +157,7 @@ THREE.Ray = function ( origin, direction, range ) {
 
 							intersect = {
 
-								distance: originCopy.distanceTo( intersectPoint ),
+								distance: distance,
 								point: intersectPoint.clone(),
 								face: face,
 								object: object
@@ -174,7 +179,7 @@ THREE.Ray = function ( origin, direction, range ) {
 
 							intersect = {
 
-								distance: originCopy.distanceTo( intersectPoint ),
+								distance: distance,
 								point: intersectPoint.clone(),
 								face: face,
 								object: object


### PR DESCRIPTION
Added this.range parameter. Range check could be done manually afterwards. But when interested in whether a projectile (=ray) has hit a moving mesh or not, a lot of time is wasted on checking the mesh faces should the mesh still be out of range. If no range is specified, behaviour remains the same.
