### PR TITLE
Fix for issue #1914

### DIFF
--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -113,7 +113,7 @@ THREE.SceneUtils = {
 
 			object = new THREE.LOD();
 
-		} else if ( source instanceof THREE.MarchingCubes ) {
+		} else if ( THREE.MarchingCubes && source instanceof THREE.MarchingCubes ) {
 
 			object = new THREE.MarchingCubes( source.resolution, source.material );
 			object.field.set( source.field );


### PR DESCRIPTION
Calling SceneUtils.cloneObject fails when adding an
Object3D with compiled JS file as THREE.MarchingCubes
hasn't been defined.
