### PR TITLE
Fix color parameter documentation for LineBasicMaterial

### DIFF
--- a/docs/api/materials/LineBasicMaterial.html
+++ b/docs/api/materials/LineBasicMaterial.html
@@ -20,9 +20,9 @@ fog — Define whether the material color is affected by global fog settings. De
 </div>
 
 <h2>Properties</h2>
-
-<h3>.[page:Color color]</h3>
-<div>An instance of [page:Color THREE.Color]. Default is a white (0xffffff) instance.</div>
+  
+<h3>.[page:Integer hex]</h3>
+<div>Line color in hexidecimal. Default is 0xffffff.</div>
 
 <h3>.[page:Float linewidth]</h3>
 <div>Controls line thickness. Default is 1.</div>


### PR DESCRIPTION
Docs for LineBasicMaterial were incorrectly specifying that configuration parameter color should be an instance of Color when it should be hexadecimal color. Method documentation in src/materials/LineBasicMaterial.js shows that the parameter is hex and the code creates an instance of Color for you.
