### PR TITLE
Added support for main pass plugins in WebGLRenderer

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -72,6 +72,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 	// custom render plugins
 
 	this.renderPluginsPre = [];
+	this.renderPlugins = [];
 	this.renderPluginsPost = [];
 
 	// info
@@ -286,6 +287,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		plugin.init( this );
 		this.renderPluginsPost.push( plugin );
+
+	};
+
+	this.addPlugin = function ( plugin ) {
+
+		plugin.init( this );
+		this.renderPlugins.push( plugin );
 
 	};
 
@@ -3481,6 +3489,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 			this.clear( this.autoClearColor, this.autoClearDepth, this.autoClearStencil );
 
 		}
+
+		// custom render plugins (main pass)
+
+		renderPlugins( this.renderPlugins, scene, camera );
 
 		// set matrices for regular objects (frustum culled)
 


### PR DESCRIPTION
Hi,

i wanted to use 3D Sprites (useScreenCoordinates=false) combined with blended particles, such as used in some particles example, and encountered some problems:

As I understood, blending is not compatible with the [z-buffer](http://www.sjbaker.org/steve/omniv/alpha_sorting.html), which means that _Sprites_ need to be rendered before _Particles_ (or other blended objects). Since currently _Sprites_ are rendered in the _post-plugin_ pass, removing all _post-plugins_ and adding the _SpritePlugin_ to the pre-plugins was one solution. It works, unless _autoClear_ is set off, and done manually, since else the clear is done _after_ the plugin rendering.
The main problem is, when some _EffectComposer_ is used to add some postprocessing effect (preventing of course the forced autoClear in the _RenderPass_), this didn't work cleanly. The problem is that the _setRenderTarget_ is again done after the rendering of the _pre-plugins_, which means that bypassing this, is not possible in a clean way IMHO.

My patch adds a possible hook for plugins (similar to the existing pre/post), to render plugins after the _setRenderTarget_ and the _clear_, but before other objects. In my case I moved the SpritePlugin from the post-plugin pass to this main pass, and it works fine with _blending_ and postprocessing effects.

If there are better approaches to solve this, please let me know. This commit may nevertheless add some future possibilities for plugins...

Cheers,
Daniel
