### PR TITLE
Make the noFly param in FirstPersonControls work by constraining the Y axis

### DIFF
--- a/src/extras/controls/FirstPersonControls.js
+++ b/src/extras/controls/FirstPersonControls.js
@@ -7,6 +7,7 @@
 THREE.FirstPersonControls = function ( object, domElement ) {
 
 	this.object = object;
+	this.objectPosition = object.position.clone();
 	this.target = new THREE.Vector3( 0, 0, 0 );
 
 	this.domElement = ( domElement !== undefined ) ? domElement : document;
@@ -258,6 +259,11 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 
 		this.object.lookAt( targetPosition );
 
+		if ( this.noFly ) {
+
+			position.y = this.objectPosition.y;
+
+		}
 	};
 
 


### PR DESCRIPTION
I needed this for my game, so the FPS controller didn't fly above/below the ground. There was already a noFly parameter, but it wasn't used. My (perhaps naive) solution was to store the original camera position and reset the Y at the end of the update function.
