### PR TITLE
Fix color parameter documentation for LineBasicMaterial

### DIFF
--- a/docs/api/materials/LineBasicMaterial.html
+++ b/docs/api/materials/LineBasicMaterial.html
@@ -21,8 +21,8 @@ fog — Define whether the material color is affected by global fog settings. De
 
 <h2>Properties</h2>
 
-<h3>.[page:Color color]</h3>
-<div>Default is white.</div>
+<h3>.[page:Integer color]</h3>
+<div>Sets the color of the line. Default is 0xffffff.</div>
 
 <h3>.[page:Float linewidth]</h3>
 <div>Controls line thickness. Default is 1.</div>


### PR DESCRIPTION
Changed datatype from Color to Integer, reworded documentation of parameters to be more descriptive and in line with descriptions below it.
