### PR TITLE
[Redo] Vector3.getScaleFromMatrix should return Vector-Object

### DIFF
--- a/src/core/Vector3.js
+++ b/src/core/Vector3.js
@@ -490,6 +490,7 @@ THREE.Vector3.prototype = {
 		this.y = sy;
 		this.z = sz;
 
+		return this;
 	},
 
 	equals: function ( v ) {


### PR DESCRIPTION
as discussed in #2114

@mrdoob: good so?
