### PR TITLE
Loading reflective and refractive materials in ColladaLoader.js

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -40,7 +40,11 @@ THREE.ColladaLoader = function () {
 
 		subdivideFaces: true,
 
-		upAxis: 'Y'
+		upAxis: 'Y',
+		
+		// For reflective or refractive materials we'll use this cubemap
+		defaultEnvMap: null
+		
 	};
 
 	// TODO: support unit conversion as well
@@ -3033,6 +3037,7 @@ THREE.ColladaLoader = function () {
 
 				case 'shininess':
 				case 'reflectivity':
+				case 'index_of_refraction':
 				case 'transparency':
 
 					var f = evaluateXPath( child, './/dae:float' );
@@ -3119,9 +3124,18 @@ THREE.ColladaLoader = function () {
 					break;
 
 				case 'shininess':
-				case 'reflectivity':
-
 					props[ prop ] = this[ prop ];
+					break;
+					
+				case 'reflectivity':
+					props[ prop ] = this[ prop ];
+					if(props[ prop ] > 0.0) props['envMap'] = options.defaultEnvMap;
+					props['combine'] = THREE.MixOperation;	//mix regular shading with reflective component
+					break;
+					
+				case 'index_of_refraction':
+					props[ 'refractionRatio' ] = this[ prop ]; //TODO: "index_of_refraction" becomes "refractionRatio" in shader, but I'm not sure if the two are actually comparable
+					if(this[ prop ] != 1.0) props['envMap'] = options.defaultEnvMap;
 					break;
 
 				case 'transparency':


### PR DESCRIPTION
I added some basic support to ColladaLoader.js for loading reflective and refractive materials. There's a new options.defaultEnvMap property on the ColladaLoader that specifies a cubemap to be used for all reflective or refractive materials loaded.

One unresolved issue is the conversion between Collada's "index_of_refraction" and Three.js's "refractionRatio". I'm not sure if they're equivalent or not.

Also, it's not a problem with ColladaLoader, but reflection and refraction in a single material will not currently work. It must be one or the other. This seems to be an issue with the built-in Three.js shader.
