### PR TITLE
Change to ImageUtils

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -31,8 +31,10 @@ THREE.ImageUtils = {
 			images[ i ].onload = function () {
 
 				images.loadCount += 1;
-				if ( images.loadCount === 6 ) texture.needsUpdate = true;
-				if ( callback ) callback( this );
+				if ( images.loadCount === 6 ) {
+					texture.needsUpdate = true;
+					if ( callback ) callback( this );
+				}
 
 			};
 


### PR DESCRIPTION
Hey I was trying to utilize the callbacks in the loadTexture and loadTextureCube functions located in the ImageUtils file so that my rendering didn't start until all textures are loaded and I noticed it didn't quite work all the time when I used the loadTextureCube. I am not sure why the callback is called for each face of the cube but this seems to work fine for me and it allows me to make sure that everything is loaded before rendering.
