### PR TITLE
Same as in 2.62: Model-Exporter: Coordinates scaled in the exporter and ...

### DIFF
--- a/utils/exporters/blender/2.63/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.63/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -953,7 +953,7 @@ def generate_ascii_model(meshes, morphs,
     materials_string = ",\n\n".join(materials)
 
     model_string = TEMPLATE_MODEL_ASCII % {
-    "scale" : option_scale,
+    "scale" : 1,
 
     "uvs"       : generate_uvs(uvs, option_uv_coords),
     "normals"   : generate_normals(normals, option_normals),


### PR DESCRIPTION
...again scaled inverted in the JSONLoader.
