### PR TITLE
Improves/extends whitespace parsing in OBJLoader

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -76,7 +76,7 @@ THREE.OBJLoader.prototype = {
 
 		// v float float float
 
-		pattern = /v( [\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)/g;
+		pattern = /v( +[\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)/g;
 
 		while ( ( result = pattern.exec( data ) ) != null ) {
 
@@ -93,7 +93,7 @@ THREE.OBJLoader.prototype = {
 
 		// vn float float float
 
-		pattern = /vn( [\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)/g;
+		pattern = /vn( +[\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)/g;
 
 		while ( ( result = pattern.exec( data ) ) != null ) {
 
@@ -109,7 +109,7 @@ THREE.OBJLoader.prototype = {
 
 		// vt float float
 
-		pattern = /vt( [\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)/g;
+		pattern = /vt( +[\d|\.|\+|\-|e]+)( [\d|\.|\+|\-|e]+)/g;
 
 		while ( ( result = pattern.exec( data ) ) != null ) {
 
@@ -134,7 +134,7 @@ THREE.OBJLoader.prototype = {
 
 			// f vertex vertex vertex ...
 
-			pattern = /f( [\d]+)( [\d]+)( [\d]+)( [\d]+)?/g;
+			pattern = /f( +[\d]+)( [\d]+)( [\d]+)( [\d]+)?/g;
 
 			while ( ( result = pattern.exec( object ) ) != null ) {
 
@@ -163,7 +163,7 @@ THREE.OBJLoader.prototype = {
 
 			// f vertex/uv vertex/uv vertex/uv ...
 
-			pattern = /f( ([\d]+)\/([\d]+))( ([\d]+)\/([\d]+))( ([\d]+)\/([\d]+))( ([\d]+)\/([\d]+))?/g;
+			pattern = /f( +([\d]+)\/([\d]+))( ([\d]+)\/([\d]+))( ([\d]+)\/([\d]+))( ([\d]+)\/([\d]+))?/g;
 
 			while ( ( result = pattern.exec( object ) ) != null ) {
 
@@ -205,7 +205,7 @@ THREE.OBJLoader.prototype = {
 
 			// f vertex/uv/normal vertex/uv/normal vertex/uv/normal ...
 
-			pattern = /f( ([\d]+)\/([\d]+)\/([\d]+))( ([\d]+)\/([\d]+)\/([\d]+))( ([\d]+)\/([\d]+)\/([\d]+))( ([\d]+)\/([\d]+)\/([\d]+))?/g;
+			pattern = /f( +([\d]+)\/([\d]+)\/([\d]+))( ([\d]+)\/([\d]+)\/([\d]+))( ([\d]+)\/([\d]+)\/([\d]+))( ([\d]+)\/([\d]+)\/([\d]+))?/g;
 
 			while ( ( result = pattern.exec( object ) ) != null ) {
 
@@ -259,7 +259,7 @@ THREE.OBJLoader.prototype = {
 
 			// f vertex//normal vertex//normal vertex//normal ...
 
-			pattern = /f( ([\d]+)\/\/([\d]+))( ([\d]+)\/\/([\d]+))( ([\d]+)\/\/([\d]+))( ([\d]+)\/\/([\d]+))?/g;
+			pattern = /f( +([\d]+)\/\/([\d]+))( ([\d]+)\/\/([\d]+))( ([\d]+)\/\/([\d]+))( ([\d]+)\/\/([\d]+))?/g;
 
 			while ( ( result = pattern.exec( object ) ) != null ) {
 


### PR DESCRIPTION
I had the issue that some of my OBJ-files weren't loaded by the OBJLoader provided in the examples. Parsing the file crashed with this exception:

```
Uncaught TypeError: Cannot read property 'x' of undefined Three.js:13
THREE.Vector3.addSelf (Three.js:13)
THREE.Geometry.computeCentroids (Three.js:91)
THREE.OBJLoader.parse (OBJLoader.js:295)
xhr.onreadystatechange (OBJLoader.js:21)
```

I traced the error to the OBJLoader and my OBJ files. The obj files were exported by 3ds Max Wavefront OBJ Exporter and slightly differ in format:

Where the loader expected:

```
v 0.4500 1.5256 0.6595
```

they were:

```
v  0.4500 1.5256 0.6595
```

Note the extra space. This threw off the regular expressions, the vertices weren't parsed and the computeCentroid failed. This commit changes the regular impression to accomodate this variance.
