### PR TITLE
Update docs/api/core/Vector3.html

### DIFF
--- a/docs/api/core/Vector3.html
+++ b/docs/api/core/Vector3.html
@@ -177,7 +177,7 @@
 
 		<h3>.isZero() [page:Boolean]</h3>
 		<div>
-		Checks if length of this vector is within small epsilon (*0.0001*).
+		Checks if length of this vector is within small epsilon (*0.01*).
 		</div>
 
 		<h3>.clone() [page:Vector3]</h3>


### PR DESCRIPTION
isZero actually checks the squared length against the "small epsilon".
0.0001 = 0.01² so the function will return true for a length < 0.01.

By the way if there is a good reason for a so limited accuracy it should be given here in the doc (or maybe even in the code).
