### PR TITLE
More consistent intendation in blender export output.

### DIFF
--- a/utils/exporters/blender/2.63/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.63/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -85,13 +85,13 @@ TEMPLATE_SCENE_ASCII = """\
 
 "metadata" :
 {
-    "formatVersion" : 3.1,
-    "sourceFile"    : "%(fname)s",
-    "generatedBy"   : "Blender 2.63 Exporter",
-    "objects"       : %(nobjects)s,
-    "geometries"    : %(ngeometries)s,
-    "materials"     : %(nmaterials)s,
-    "textures"      : %(ntextures)s
+	"formatVersion" : 3.1,
+	"sourceFile"    : "%(fname)s",
+	"generatedBy"   : "Blender 2.63 Exporter",
+	"objects"       : %(nobjects)s,
+	"geometries"    : %(ngeometries)s,
+	"materials"     : %(nmaterials)s,
+	"textures"      : %(ntextures)s
 },
 
 "type" : "scene",
@@ -101,16 +101,16 @@ TEMPLATE_SCENE_ASCII = """\
 
 "transform" :
 {
-    "position"  : %(position)s,
-    "rotation"  : %(rotation)s,
-    "scale"     : %(scale)s
+	"position"  : %(position)s,
+	"rotation"  : %(rotation)s,
+	"scale"     : %(scale)s
 },
 
 "defaults" :
 {
-    "bgcolor" : %(bgcolor)s,
-    "bgalpha" : %(bgalpha)f,
-    "camera"  : %(defcamera)s
+	"bgcolor" : %(bgcolor)s,
+	"bgalpha" : %(bgalpha)f,
+	"camera"  : %(defcamera)s
 }
 
 }
@@ -124,91 +124,91 @@ TEMPLATE_SECTION = """
 """
 
 TEMPLATE_OBJECT = """\
-    %(object_id)s : {
-        "geometry"  : %(geometry_id)s,
-        "groups"    : [ %(group_id)s ],
-        "materials" : [ %(material_id)s ],
-        "position"  : %(position)s,
-        "rotation"  : %(rotation)s,
-        "quaternion": %(quaternion)s,
-        "scale"     : %(scale)s,
-        "visible"       : %(visible)s,
-        "castShadow"    : %(castShadow)s,
-        "receiveShadow" : %(receiveShadow)s,
-        "doubleSided"   : %(doubleSided)s
-    }"""
+	%(object_id)s : {
+		"geometry"  : %(geometry_id)s,
+		"groups"    : [ %(group_id)s ],
+		"materials" : [ %(material_id)s ],
+		"position"  : %(position)s,
+		"rotation"  : %(rotation)s,
+		"quaternion": %(quaternion)s,
+		"scale"     : %(scale)s,
+		"visible"       : %(visible)s,
+		"castShadow"    : %(castShadow)s,
+		"receiveShadow" : %(receiveShadow)s,
+		"doubleSided"   : %(doubleSided)s
+	}"""
 
 TEMPLATE_EMPTY = """\
-    %(object_id)s : {
-        "groups"    : [ %(group_id)s ],
-        "position"  : %(position)s,
-        "rotation"  : %(rotation)s,
-        "quaternion": %(quaternion)s,
-        "scale"     : %(scale)s
-    }"""
+	%(object_id)s : {
+		"groups"    : [ %(group_id)s ],
+		"position"  : %(position)s,
+		"rotation"  : %(rotation)s,
+		"quaternion": %(quaternion)s,
+		"scale"     : %(scale)s
+	}"""
 
 TEMPLATE_GEOMETRY_LINK = """\
-    %(geometry_id)s : {
-        "type" : "ascii",
-        "url"  : %(model_file)s
-    }"""
+	%(geometry_id)s : {
+		"type" : "ascii",
+		"url"  : %(model_file)s
+	}"""
 
 TEMPLATE_GEOMETRY_EMBED = """\
-    %(geometry_id)s : {
-        "type" : "embedded",
-        "id"  : %(embed_id)s
-    }"""
+	%(geometry_id)s : {
+		"type" : "embedded",
+		"id"  : %(embed_id)s
+	}"""
 
 TEMPLATE_TEXTURE = """\
-    %(texture_id)s : {
-        "url": %(texture_file)s%(extras)s
-    }"""
+	%(texture_id)s : {
+		"url": %(texture_file)s%(extras)s
+	}"""
 
 TEMPLATE_MATERIAL_SCENE = """\
-    %(material_id)s : {
-        "type": %(type)s,
-        "parameters": { %(parameters)s }
-    }"""
+	%(material_id)s : {
+		"type": %(type)s,
+		"parameters": { %(parameters)s }
+	}"""
 
 TEMPLATE_CAMERA_PERSPECTIVE = """\
-    %(camera_id)s : {
-        "type"  : "perspective",
-        "fov"   : %(fov)f,
-        "aspect": %(aspect)f,
-        "near"  : %(near)f,
-        "far"   : %(far)f,
-        "position": %(position)s,
-        "target"  : %(target)s
-    }"""
+	%(camera_id)s : {
+		"type"  : "perspective",
+		"fov"   : %(fov)f,
+		"aspect": %(aspect)f,
+		"near"  : %(near)f,
+		"far"   : %(far)f,
+		"position": %(position)s,
+		"target"  : %(target)s
+	}"""
 
 TEMPLATE_CAMERA_ORTHO = """\
-    %(camera_id)s: {
-        "type"  : "ortho",
-        "left"  : %(left)f,
-        "right" : %(right)f,
-        "top"   : %(top)f,
-        "bottom": %(bottom)f,
-        "near"  : %(near)f,
-        "far"   : %(far)f,
-        "position": %(position)s,
-        "target"  : %(target)s
-    }"""
+	%(camera_id)s : {
+		"type"  : "ortho",
+		"left"  : %(left)f,
+		"right" : %(right)f,
+		"top"   : %(top)f,
+		"bottom": %(bottom)f,
+		"near"  : %(near)f,
+		"far"   : %(far)f,
+		"position": %(position)s,
+		"target"  : %(target)s
+	}"""
 
 TEMPLATE_LIGHT_DIRECTIONAL = """\
-    %(light_id)s: {
-        "type"    	 : "directional",
-        "direction"	 : %(direction)s,
-        "color" 	 : %(color)d,
-        "intensity"	 : %(intensity).2f
-    }"""
+	%(light_id)s : {
+		"type"       : "directional",
+		"direction"  : %(direction)s,
+		"color"      : %(color)d,
+		"intensity"  : %(intensity).2f
+	}"""
 
 TEMPLATE_LIGHT_POINT = """\
-    %(light_id)s: {
-        "type"	     : "point",
-        "position"   : %(position)s,
-        "color"      : %(color)d,
-        "intensity"	 : %(intensity).3f
-    }"""
+	%(light_id)s : {
+		"type"       : "point",
+		"position"   : %(position)s,
+		"color"      : %(color)d,
+		"intensity"  : %(intensity).3f
+	}"""
 
 TEMPLATE_VEC4 = '[ %g, %g, %g, %g ]'
 TEMPLATE_VEC3 = '[ %g, %g, %g ]'
@@ -223,19 +223,19 @@ TEMPLATE_HEX = "0x%06x"
 TEMPLATE_FILE_ASCII = """\
 {
 
-    "metadata" :
-    {
-        "formatVersion" : 3.1,
-        "generatedBy"   : "Blender 2.63 Exporter",
-        "vertices"      : %(nvertex)d,
-        "faces"         : %(nface)d,
-        "normals"       : %(nnormal)d,
-        "colors"        : %(ncolor)d,
-        "uvs"           : [%(nuvs)s],
-        "materials"     : %(nmaterial)d,
-        "morphTargets"  : %(nmorphTarget)d,
-        "bones"         : %(nbone)d
-    },
+	"metadata" :
+	{
+		"formatVersion" : 3.1,
+		"generatedBy"   : "Blender 2.63 Exporter",
+		"vertices"      : %(nvertex)d,
+		"faces"         : %(nface)d,
+		"normals"       : %(nnormal)d,
+		"colors"        : %(ncolor)d,
+		"uvs"           : [%(nuvs)s],
+		"materials"     : %(nmaterial)d,
+		"morphTargets"  : %(nmorphTarget)d,
+		"bones"         : %(nbone)d
+	},
 
 %(model)s
 
@@ -243,29 +243,29 @@ TEMPLATE_FILE_ASCII = """\
 """
 
 TEMPLATE_MODEL_ASCII = """\
-    "scale" : %(scale)f,
+	"scale" : %(scale)f,
 
-    "materials": [%(materials)s],
+	"materials" : [%(materials)s],
 
-    "vertices": [%(vertices)s],
+	"vertices" : [%(vertices)s],
 
-    "morphTargets": [%(morphTargets)s],
+	"morphTargets" : [%(morphTargets)s],
 
-    "normals": [%(normals)s],
+	"normals" : [%(normals)s],
 
-    "colors": [%(colors)s],
+	"colors" : [%(colors)s],
 
-    "uvs": [%(uvs)s],
+	"uvs" : [%(uvs)s],
 
-    "faces": [%(faces)s],
+	"faces" : [%(faces)s],
 
-    "bones" : [%(bones)s],
+	"bones" : [%(bones)s],
 
-    "skinIndices" : [%(indices)s],
+	"skinIndices" : [%(indices)s],
 
-    "skinWeights" : [%(weights)s],
+	"skinWeights" : [%(weights)s],
 
-    "animation" : {%(animation)s}
+	"animation" : {%(animation)s}
 """
 
 TEMPLATE_VERTEX = "%g,%g,%g"
@@ -1104,7 +1104,7 @@ def generate_materials(mtl, materials, draw_type):
             mtl[m]['wireframe'] = True
             mtl[m]['DbgColor'] = 0xff0000
 
-        mtl_raw = ",\n".join(['\t"%s" : %s' % (n, value2string(v)) for n,v in sorted(mtl[m].items())])
+        mtl_raw = ",\n".join(['\t\t"%s" : %s' % (n, value2string(v)) for n,v in sorted(mtl[m].items())])
         mtl_string = "\t{\n%s\n\t}" % mtl_raw
         mtl_array.append([index, mtl_string])
 


### PR DESCRIPTION
Blender exporter mixes spaces and tabs in output (and has some other whitespace inconsistencies). I normalized it to use tabs (not spaces because tabs are used in three.js sources, tabs are less bytes etc.).

Only the 2.63 version was done, but I can do the other too, if this pleases.
