### PR TITLE
force mimetype in colladaloader - see #2447

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -61,6 +61,7 @@ THREE.ColladaLoader = function () {
 		if ( document.implementation && document.implementation.createDocument ) {
 
 			var request = new XMLHttpRequest();
+			request.overrideMimeType && request.overrideMimeType('model/vnd.collada+xml');
 
 			request.onreadystatechange = function() {
 


### PR DESCRIPTION
- Collada Loader depends on rare mimetype config
- see details in https://github.com/mrdoob/three.js/issues/2447
