### PR TITLE
Fix collada loader when examples are viewed through server.

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -74,6 +74,13 @@ THREE.ColladaLoader = function () {
 							readyCallbackFunc = readyCallback;
 							parse( request.responseXML, undefined, url );
 
+						} else if ( request.responseText ) {
+
+							readyCallbackFunc = readyCallback;
+							var xmlParser = new DOMParser();
+							var responseXML = xmlParser.parseFromString( request.responseText, "application/xml" );
+							parse( responseXML, undefined, url );
+
 						} else {
 
 							console.error( "ColladaLoader: Empty or non-existing file (" + url + ")" );


### PR DESCRIPTION
The following examples where broken on mrdoob.github.com and when
viewed through a local python web server. file:// worked.

http://mrdoob.github.com/three.js/examples/webgl_loader_collada.html
http://mrdoob.github.com/three.js/examples/webgl_loader_collada_keyframe.html
http://mrdoob.github.com/three.js/examples/webgl_loader_json_blender.html

Reason was request.responseXML being null for some reason in the ColladaLoader. First I tried adding `request.setRequestHeader('Content-Type',  'application/xml');`, but that didn't help, so I resorted to parsing the `request.responseText`, which contained the payload.

Tested on Firefox and Chrome (both failed first, now fine).

Note: webgl_loader_json_blender.html also complains about the following on http://mrdoob.github.com/three.js/examples/webgl_loader_json_blender.html, so this might not be enough to fix that one on the server (local and python server work though, so probably missing the src-folder?).

```
GET http://mrdoob.github.com/three.js/src/loaders/GeometryLoader.js 404 (Not Found) webgl_loader_json_blender.html:35
GET http://mrdoob.github.com/three.js/src/loaders/LoadingMonitor.js 404 (Not Found) webgl_loader_json_blender.html:35
```
