### PR TITLE
Hairy stuff in allocateLights()

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -6767,8 +6767,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			// these are not really correct
 
-			maxSpotLights = maxPointLights;
-			maxHemiLights = maxDirLights;
+			if ( spotLights )
+				maxSpotLights = maxPointLights;
+
+			if ( hemiLights )
+				maxHemiLights = maxDirLights;
 
 		}
 


### PR DESCRIPTION
I have a relatively large number of point lights in my project, each accompanied by a shadow-only spot light. (I use a manager to dynamically turn off some of the lights and shadows to keep the shaders compiling and performance good). There are no visible spot lights in the scene, but I get loads of WebGL warnings in Chrome's console about various spot light arrays being zero-sized.

I dug into this and found out the reason for this is in `allocateLights()` (https://github.com/mrdoob/three.js/blob/master/src/renderers/WebGLRenderer.js#L6741), which assigns max numbers to spot and hemi lights even when there is none.

This patch corrects the case when there are zero of those lights, but the whole section seems very fishy (as the comment there states), so perhaps this would a be a good opportunity to correct the behavior completely.
