### PR TITLE
Partially broken webgl_materials_shaders.html

### DIFF
--- a/examples/webgl_materials_shaders.html
+++ b/examples/webgl_materials_shaders.html
@@ -165,13 +165,9 @@
 
 				}
 
-				if ( render_canvas ) {
-
-					canvasRenderer = new THREE.CanvasRenderer();
-					canvasRenderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-					container.appendChild( canvasRenderer.domElement );
-
-				}
+				canvasRenderer = new THREE.CanvasRenderer();
+				canvasRenderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
+				container.appendChild( canvasRenderer.domElement );
 
 				//
 


### PR DESCRIPTION
I noticed that if I have WebGL, trying to switch to canvas renderer in webgl_materials_shaders.html example throws an exception. The cause is that CanvasRenderer is never created if WebGL is enabled. This patch fixes it by always creating it. Though the canvas is dead slow even on Chrome. :(
