### PR TITLE
Working lookat() also when useQuaternion = true

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -24,7 +24,15 @@ THREE.Camera.prototype.lookAt = function ( vector ) {
 
 	if ( this.rotationAutoUpdate === true ) {
 
-		this.rotation.setEulerFromRotationMatrix( this.matrix, this.eulerOrder );
+		if ( this.useQuaternion === false )  {
+			
+			this.rotation.setEulerFromRotationMatrix( this.matrix, this.eulerOrder );
+			
+		} else {
+			
+			this.quaternion.setFromRotationMatrix( this.matrix );
+			
+		}
 
 	}
 

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -30,7 +30,7 @@ THREE.Camera.prototype.lookAt = function ( vector ) {
 			
 		} else {
 			
-			this.quaternion.setFromRotationMatrix( this.matrix );
+			this.quaternion.copy(this.matrix.decompose()[1]);
 			
 		}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -120,7 +120,7 @@ THREE.Object3D.prototype = {
 
 			} else {
 
-				this.quaternion.setFromRotationMatrix( this.matrix );
+				this.quaternion.copy(this.matrix.decompose()[1]);
 
 			}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -114,7 +114,15 @@ THREE.Object3D.prototype = {
 
 		if ( this.rotationAutoUpdate ) {
 
-			this.rotation.setEulerFromRotationMatrix( this.matrix, this.eulerOrder );
+			if ( this.useQuaternion === false )  {
+
+				this.rotation.setEulerFromRotationMatrix( this.matrix, this.eulerOrder );
+
+			} else {
+
+				this.quaternion.setFromRotationMatrix( this.matrix );
+
+			}
 
 		}
 


### PR DESCRIPTION
Background: I used camera.lookat(scene.position), which worked fine with FirstPersonControls. Changed to FlyControls, and it stopped working. Reason being that useQuaternion = true and lookat did not update the quaternion. 
