### PR TITLE
Added setContextStyle to Color.js

### DIFF
--- a/src/core/Color.js
+++ b/src/core/Color.js
@@ -157,9 +157,9 @@ THREE.Color.prototype = {
 
 		var color = /^rgb\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\)$/i.exec(contextStyle);
 
-		this.r = parseInt(color[1], 10);
-		this.g = parseInt(color[2], 10);
-		this.b = parseInt(color[3], 10);
+		this.r = parseInt(color[1], 10) / 255;
+		this.g = parseInt(color[2], 10) / 255;
+		this.b = parseInt(color[3], 10) / 255;
 
 		return this;
 

--- a/src/core/Color.js
+++ b/src/core/Color.js
@@ -153,6 +153,18 @@ THREE.Color.prototype = {
 
 	},
 
+	setContextStyle: function ( contextStyle ) {
+
+		var color = /^rgb\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\)$/i.exec(contextStyle);
+
+		this.r = parseInt(color[1], 10);
+		this.g = parseInt(color[2], 10);
+		this.b = parseInt(color[3], 10);
+
+		return this;
+
+	},
+
 	lerpSelf: function ( color, alpha ) {
 
 		this.r += ( color.r - this.r ) * alpha;


### PR DESCRIPTION
Color.js provides a method for getting a CSS context style from a color, but didn't provide one for setting it.
