### PR TITLE
Fix JSON scale for skinned meshes

### DIFF
--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -98,7 +98,7 @@ THREE.JSONLoader.prototype.createModel = function ( json, callback, texturePath 
 
 	parseModel( scale );
 
-	parseSkin();
+	parseSkin( scale );
 	parseMorphing( scale );
 
 	geometry.computeCentroids();
@@ -326,9 +326,9 @@ THREE.JSONLoader.prototype.createModel = function ( json, callback, texturePath 
 
 	};
 
-	function parseSkin() {
+	function parseSkin(scale) {
 
-		var i, l, x, y, z, w, a, b, c, d;
+		var i, j, l, m, x, y, z, w, a, b, c, d, pos;
 
 		if ( json.skinWeights ) {
 
@@ -360,8 +360,39 @@ THREE.JSONLoader.prototype.createModel = function ( json, callback, texturePath 
 
 		}
 
-		geometry.bones = json.bones;
-		geometry.animation = json.animation;
+		if ( json.bones ) {
+
+			geometry.bones = json.bones;
+
+			for ( i = 0, l = geometry.bones.length; i < l; ++ i ) {
+
+				pos = geometry.bones[ i ].pos;
+				pos[ 0 ] *= scale;
+				pos[ 1 ] *= scale;
+				pos[ 2 ] *= scale;
+
+			}
+
+		}
+
+		if ( json.animation ) {
+
+			geometry.animation = json.animation;
+
+			for ( i = 0, l = geometry.animation.hierarchy.length; i < l; ++ i ) {
+
+				for ( j = 0, m = geometry.animation.hierarchy[ i ].keys.length; j < m; ++ j ) {
+
+					pos = geometry.animation.hierarchy[ i ].keys[ j ].pos;
+					pos[ 0 ] *= scale;
+					pos[ 1 ] *= scale;
+					pos[ 2 ] *= scale;
+
+				}
+
+			}
+
+		}
 
 	};
 


### PR DESCRIPTION
I mentioned this problem in #2603. To recap, using json `scale` parameter breaks skinned animation.

To reproduce the issue:
1. Add `"scale": 3.0,` (or other scale value apart from 1.0) to examples/obj/buffalo.js
2. Fire up webgl_animation_skinning.html
3. Watch how the animation is broken

Looks like bone and keyframe positions need to be scaled, not just vertices. This patch does that for the JSON loader.
