### PR TITLE
Updated EventTarget.dispatchEvent to coexist better with other libraries

### DIFF
--- a/src/core/EventTarget.js
+++ b/src/core/EventTarget.js
@@ -24,9 +24,9 @@ THREE.EventTarget = function () {
 
 	this.dispatchEvent = function ( event ) {
 
-		for ( var listener in listeners[ event.type ] ) {
+		for ( var i = 0; i < listeners[ event.type ].length; i++ ) {
 
-			listeners[ event.type ][ listener ]( event );
+			listeners[ event.type ][ i ]( event );
 
 		}
 


### PR DESCRIPTION
EventTarget.dispatchEvent was choking when the Array class contained inherited properties (i.e. methods introduced by other third party libraries). Changed the method to use a sequential for loop instead of a for...in loop to avoid the issue.
