### PR TITLE
Update examples/webgl_custom_attributes_particles3.html

### DIFF
--- a/examples/webgl_custom_attributes_particles3.html
+++ b/examples/webgl_custom_attributes_particles3.html
@@ -270,7 +270,7 @@
 			for( var i = 0; i < attributes.size.value.length; i ++ ) {
 
 				if ( i < vc1 )
-					attributes.size.value[ i ] = 26 + 32 * Math.sin( 0.1 * i + 0.6 * time );
+					attributes.size.value[ i ] = Math.max(0, 26 + 32 * Math.sin( 0.1 * i + 0.6 * time ));
 
 
 			}


### PR DESCRIPTION
The result for attributes.size.value[i] can be negative which in turn makes gl_PointSize negative. As an example if Math.sin(...) returns -1 then you'll get -6 as a result.

The specification specifically states:"If the value written to gl_PointSize is less than or equal to zero, results are undefined". In fact it is causing such a problem on our platform.
 
