### PR TITLE
Sourcemaps

### DIFF
--- a/utils/build.py
+++ b/utils/build.py
@@ -10,63 +10,63 @@ import tempfile
 
 def main(argv=None):
 
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--include', action='append', required=True)
-  parser.add_argument('--externs', action='append', default=['externs/common.js'])
-  parser.add_argument('--minify', action='store_true', default=False)
-  parser.add_argument('--output', default='../build/three.js')
-  parser.add_argument('--sourcemaps', action='store_true', default=False)
+	parser = argparse.ArgumentParser()
+	parser.add_argument('--include', action='append', required=True)
+	parser.add_argument('--externs', action='append', default=['externs/common.js'])
+	parser.add_argument('--minify', action='store_true', default=False)
+	parser.add_argument('--output', default='../build/three.js')
+	parser.add_argument('--sourcemaps', action='store_true', default=False)
 
-  args = parser.parse_args()
+	args = parser.parse_args()
 
-  output = args.output
+	output = args.output
 
-  # merge
+	# merge
 
-  print(' * Building ' + output)
+	print(' * Building ' + output)
 
-  # enable sourcemaps support
+	# enable sourcemaps support
 
-  if args.sourcemaps:
-    sourcemap = '../build/three.js.map'
-    sourcemapping = '\n//@ sourceMappingURL=' + sourcemap
-    sourcemapargs = ' --create_source_map ' + sourcemap + ' --source_map_format=V3'
-  else:
-    sourcemap = sourcemapping = sourcemapargs = ''
+	if args.sourcemaps:
+		sourcemap = '../build/three.js.map'
+		sourcemapping = '\n//@ sourceMappingURL=' + sourcemap
+		sourcemapargs = ' --create_source_map ' + sourcemap + ' --source_map_format=V3'
+	else:
+		sourcemap = sourcemapping = sourcemapargs = ''
 
-  fd, path = tempfile.mkstemp()
-  tmp = open(path, 'w')
-  sources = []
+	fd, path = tempfile.mkstemp()
+	tmp = open(path, 'w')
+	sources = []
 
-  for include in args.include:
-    with open('includes/' + include + '.json','r') as f: files = json.load(f)
-    for filename in files:
-      sources.append(filename)
-      with open(filename, 'r') as f: tmp.write(f.read())
+	for include in args.include:
+		with open('includes/' + include + '.json','r') as f: files = json.load(f)
+		for filename in files:
+			sources.append(filename)
+			with open(filename, 'r') as f: tmp.write(f.read())
 
-  tmp.close()
+	tmp.close()
 
-  # save
+	# save
 
-  if args.minify is False:
-      shutil.copy(path, output)
-      os.chmod(output, 0o664); # temp files would usually get 0600
+	if args.minify is False:
+			shutil.copy(path, output)
+			os.chmod(output, 0o664); # temp files would usually get 0600
 
-  else:
+	else:
 
-    externs = ' --externs '.join(args.externs)
-    source = ' '.join(sources)
-    cmd = 'java -jar compiler/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --externs %s --jscomp_off=checkTypes --language_in=ECMASCRIPT5_STRICT --js %s --js_output_file %s %s' % (externs, source, output, sourcemapargs)
-    os.system(cmd)
+		externs = ' --externs '.join(args.externs)
+		source = ' '.join(sources)
+		cmd = 'java -jar compiler/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --externs %s --jscomp_off=checkTypes --language_in=ECMASCRIPT5_STRICT --js %s --js_output_file %s %s' % (externs, source, output, sourcemapargs)
+		os.system(cmd)
 
-    # header
+		# header
 
-    with open(output,'r') as f: text = f.read()
-    with open(output,'w') as f: f.write('// three.js - http://github.com/mrdoob/three.js\n' + text + sourcemapping)
+		with open(output,'r') as f: text = f.read()
+		with open(output,'w') as f: f.write('// three.js - http://github.com/mrdoob/three.js\n' + text + sourcemapping)
 
-  os.close(fd)
-  os.remove(path)
+	os.close(fd)
+	os.remove(path)
 
 
 if __name__ == "__main__":
-  main()
+	main()

--- a/utils/build.py
+++ b/utils/build.py
@@ -28,7 +28,7 @@ def main(argv=None):
 	# enable sourcemaps support
 
 	if args.sourcemaps:
-		sourcemap = '../build/three.js.map'
+		sourcemap = output + '.map'
 		sourcemapping = '\n//@ sourceMappingURL=' + sourcemap
 		sourcemapargs = ' --create_source_map ' + sourcemap + ' --source_map_format=V3'
 	else:


### PR DESCRIPTION
As mentioned in #2465 adding closure sourcemaps support to build.py

Use `--sourcemaps` flag with build.py to enable source maps

A `three.js.map` will be added to `builds/`

The minified script will be appended with sourceMappingURL to link to the .map files.

Instead of compiling from concatenated sources, I've made the script compile from respective individual source - this allows the minified source to link to the original source files.

<img src="http://i.imgur.com/PbS0i.png" />

Enable sourcemaps in your browser, and breakpoints can be set on the unminified source. 

If this is useful, maybe node.js build script could support sourcemaps with uglifyjs2
