### PR TITLE
Fix trailing commas into WebGLShaders.js

### DIFF
--- a/src/renderers/WebGLShaders.js
+++ b/src/renderers/WebGLShaders.js
@@ -250,7 +250,7 @@ THREE.ShaderChunk = {
 
 			"uniform sampler2D map;",
 
-		"#endif",
+		"#endif"
 
 	].join("\n"),
 
@@ -1393,7 +1393,7 @@ THREE.ShaderChunk = {
 
 		"#endif",
 
-		"gl_Position = projectionMatrix * mvPosition;",
+		"gl_Position = projectionMatrix * mvPosition;"
 
 	].join("\n"),
 
@@ -1463,7 +1463,7 @@ THREE.ShaderChunk = {
 
 		"#endif",
 
-		"vec3 transformedNormal = normalMatrix * objectNormal;",
+		"vec3 transformedNormal = normalMatrix * objectNormal;"
 
 	].join("\n"),
 
@@ -1715,7 +1715,7 @@ THREE.ShaderChunk = {
 
 		"#endif"
 
-	].join("\n"),
+	].join("\n")
 
 
 };
@@ -1876,7 +1876,7 @@ THREE.UniformsLib = {
 		"shadowBias" : { type: "fv1", value: [] },
 		"shadowDarkness": { type: "fv1", value: [] },
 
-		"shadowMatrix" : { type: "m4v", value: [] },
+		"shadowMatrix" : { type: "m4v", value: [] }
 
 	}
 


### PR DESCRIPTION
We use Closure Compiler from Google to compress three.js and we have some errors on WebGLShaders.js file, here is the commit that fix it.

Beside the fact that no IE support WebGL i think it's nice to clean that.

Thx for your nice lib.

```
src/renderers/WebGLShaders.js:255: ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
    ].join("\n"),
     ^

src/renderers/WebGLShaders.js:1398: ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
    ].join("\n"),
     ^

src/renderers/WebGLShaders.js:1468: ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
    ].join("\n"),
     ^

src/renderers/WebGLShaders.js:1721: ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
};
 ^

src/renderers/WebGLShaders.js:1881: ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
    }
     ^

5 error(s), 0 warning(s)
```
