### PR TITLE
SceneLoader incorrectly references last known geometry options in hierarchy loading

### DIFF
--- a/src/loaders/SceneLoader.js
+++ b/src/loaders/SceneLoader.js
@@ -185,11 +185,11 @@ THREE.SceneLoader.prototype.parse = function ( json, callbackFinished, url ) {
 
 					var loaderParameters = {};
 
-					for ( var parType in g ) {
+					for ( var parType in o ) {
 
 						if ( parType !== "type" && parType !== "url" ) {
 
-							loaderParameters[ parType ] = g[ parType ];
+							loaderParameters[ parType ] = o[ parType ];
 
 						}
 


### PR DESCRIPTION
The last loaded geometry mapping is used by mistake causing undefined behaviour when using `loaderParams`.

I noticed this while implementing a custom loader, I was seeing strange information in `loaderParams` from the other geometry instances in my scene.

If no geometry was loaded, this bug would also cause `undefined` errors.

This appears to be an isolated error, not really causing much harm in most cases.

My best guess at what information was actually desired has been committed here; but I suggest alteredq (the last known author for this area of the code) to double check and maybe clarify its true intention.
