### PR TITLE
Polished Box3, Sphere and Plane classes for threejs/core

### DIFF
--- a/src/core/Box2.js
+++ b/src/core/Box2.js
@@ -177,7 +177,24 @@ THREE.Box2.prototype = {
 
 	clampPoint: function ( point ) {
 
-		return new THREE.Vector2().copy( point ).maxSelf( this.min ).minSelf( this.max );
+		var p = new THREE.Vector2().copy( point );
+
+		// this requires less if's then a point.minSelf( this.max ).maxSelf( this.min )
+		if( p.x < this.min.x ) {
+			p.x = this.min.x;
+		}
+		else if( p.x > this.max.x ) {
+			p.x = this.max.x;
+		}
+
+		if( p.y < this.min.y ) {
+			p.y = this.min.y;
+		}
+		else if( p.y > this.max.y ) {
+			p.y = this.max.y;
+		}
+
+		return p;
 	},
 
 	distanceToPoint: function ( point ) {

--- a/src/core/Box2.js
+++ b/src/core/Box2.js
@@ -1,0 +1,220 @@
+/**
+ * @author bhouston / http://exocortex.com
+ */
+
+THREE.Box2 = function ( min, max ) {
+
+	if( ! min && ! max ) {			
+		this.min = new THREE.Vector2();
+		this.max = new THREE.Vector2();
+		this.makeEmpty();
+	}
+	else {
+		this.min = min || new THREE.Vector2();
+		this.max = max || new THREE.Vector2().copy( this.min );		// This is done on purpose so you can make a box using a single point and then expand it.
+	}
+};
+
+THREE.Box2.prototype = {
+
+	constructor: THREE.Box2,
+
+	set: function ( min, max ) {
+
+		this.min = min;
+		this.max = max;
+
+		return this;
+	},
+
+	setFromPoints: function ( points ) {
+
+		if( points.length > 0 ) {
+
+			var p = points[0];
+			this.min.copy( p );
+			this.max.copy( p );
+
+			for( var i = 1, numPoints = points.length; i < numPoints; i ++ ) {
+
+				p = points[ v ];
+
+				if ( p.x < this.min.x ) {
+					this.min.x = p.x;
+				}
+				else if ( p.x > this.max.x ) {
+					this.max.x = p.x;
+				}
+
+				if ( p.y < this.min.y ) {
+					this.min.y = p.y;
+				}
+				else if ( p.y > this.max.y ) {
+					this.max.y = p.y;
+				}
+			}
+		}
+		else {
+			this.makeEmpty();
+		}
+
+		return this;
+	},
+
+	setFromCenterAndSize: function ( center, size ) {
+
+		var halfSize = new THREE.Vector2().copy( size ).multiplyScalar( 0.5 );
+		this.min.copy( center ).subSelf( halfSize );
+		this.max.copy( center ).addSelf( halfSize );
+
+		return box;	
+	},
+
+	copy: function ( box ) {
+
+		this.min.copy( box.min );
+		this.max.copy( box.max );
+
+		return this;
+	},
+
+	makeEmpty: function () {
+
+		this.min.x = this.min.y = Number.MAX_VALUE;
+		this.max.x = this.max.y = -Number.MAX_VALUE;
+
+		return this;
+	},
+
+	empty: function () {
+
+		// this is a more robust check for empty than ( volume <= 0 ) because volume can get positive with two negative axes
+		return 
+			( this.max.x < this.min.x ) ||
+			( this.max.y < this.min.y );
+	},
+
+	volume: function () {
+
+		return 
+			( this.max.x - this.min.x ) *
+			( this.max.y - this.min.y );
+	},
+
+	center: function () {
+
+		return new THREE.Vector2().add( this.min, this.max ).multiplyScalar( 0.5 );
+	},
+
+	size: function () {
+
+		return new THREE.Vector2().sub( this.max, this.min );
+	},
+
+	expandByPoint: function ( point ) {
+
+		this.min.minSelf( point );		
+		this.max.maxSelf( point );
+
+		return this;
+	},
+
+	expandByVector: function ( vector ) {
+
+		this.min.subSelf( vector );
+		this.max.addSelf( vector );
+
+		return this;
+	},
+
+	expandByScalar: function ( scalar ) {
+
+		this.min.addScalar( -scalar );
+		this.max.addScalar( scalar );
+		
+		return this;
+	},
+
+	containsPoint: function ( point ) {
+		if( 
+			( this.min.x <= point.x ) && ( point.x <= this.max.x ) &&
+			( this.min.y <= point.y ) && ( point.y <= this.max.y )
+			) {
+			return true;
+		}
+		return false;
+	},
+
+	containsBox: function ( box ) {
+		if( 
+			( this.min.x <= box.min.x ) && ( box.max.x <= this.max.x ) &&
+			( this.min.y <= box.min.y ) && ( box.max.y <= this.max.y )
+			) {
+			return true;
+		}
+		return false;
+	},
+
+	isIntersection: function ( box ) {
+		// using 6 splitting planes to rule out intersections.
+		if( 
+			( this.max.x < box.min.x ) || ( box.min.x > this.max.x ) ||
+			( this.max.y < box.min.y ) || ( box.min.y > this.max.y )
+			) {
+			return false;
+		}
+		return true;
+	},
+
+	getParameter: function ( point ) {
+		// This can potentially have a divide by zero if the box
+		// has a size dimension of 0.
+		return new THREE.Vector2(
+			( point.x - this.min.x ) / ( this.max.x - this.min.x ),
+			( point.y - this.min.y ) / ( this.max.y - this.min.y )
+			);
+	},
+
+	clampPoint: function ( point ) {
+
+		return new THREE.Vector2().copy( point ).maxSelf( this.min ).minSelf( this.max );
+	},
+
+	distanceToPoint: function ( point ) {
+
+		return this.clampPoint( point ).subSelf( point ).length();
+	},
+
+	intersect: function ( box ) {
+
+		this.min.maxSelf( box.min );
+		this.max.minSelf( box.max );
+		
+		return this;
+	},
+
+	union: function ( box ) {
+
+		this.min.minSelf( box.min );
+		this.max.maxSelf( box.max );
+
+		return this;
+	},
+
+	translate: function ( offset ) {
+
+		this.min.addSelf( offset );
+		this.max.addSelf( offset );
+
+		return this;
+	},
+
+	scale: function ( factor ) {
+
+		var sizeDeltaHalf = this.size().multiplyScalar( ( 1 - factor )  * 0.5 );
+		this.expandByVector( sizeDeltaHalf );
+
+		return this;
+	}
+	
+};

--- a/src/core/Box2.js
+++ b/src/core/Box2.js
@@ -63,7 +63,7 @@ THREE.Box2.prototype = {
 
 	setFromCenterAndSize: function ( center, size ) {
 
-		var halfSize = new THREE.Vector2().copy( size ).multiplyScalar( 0.5 );
+		var halfSize = THREE.Box2.__v1.copy( size ).multiplyScalar( 0.5 );
 		this.min.copy( center ).subSelf( halfSize );
 		this.max.copy( center ).addSelf( halfSize );
 
@@ -218,3 +218,5 @@ THREE.Box2.prototype = {
 	}
 	
 };
+
+THREE.Box2.__v1 = new THREE.Vector2();

--- a/src/core/Box2.js
+++ b/src/core/Box2.js
@@ -177,24 +177,7 @@ THREE.Box2.prototype = {
 
 	clampPoint: function ( point ) {
 
-		var p = new THREE.Vector2().copy( point );
-
-		// this requires less if's then a point.minSelf( this.max ).maxSelf( this.min )
-		if( p.x < this.min.x ) {
-			p.x = this.min.x;
-		}
-		else if( p.x > this.max.x ) {
-			p.x = this.max.x;
-		}
-
-		if( p.y < this.min.y ) {
-			p.y = this.min.y;
-		}
-		else if( p.y > this.max.y ) {
-			p.y = this.max.y;
-		}
-
-		return p;
+		return new THREE.Vector2().copy( point ).clampSelf( this.min, this.max );
 	},
 
 	distanceToPoint: function ( point ) {

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -79,8 +79,10 @@
 	};
 
 	THREE.Box3.prototype.extendByPoint = function ( point ) {
-		this.min.minSelf( point );
+
+		this.min.minSelf( point );		
 		this.max.maxSelf( point );
+
 		return this;
 	};
 
@@ -88,6 +90,7 @@
 
 		this.min.subSelf( vector );
 		this.max.addSelf( vector );
+
 		return this;
 	};
 
@@ -95,6 +98,7 @@
 
 		this.min.addScalar( -scalar );
 		this.max.addScalar( scalar );
+		
 		return this;
 	};
 
@@ -110,7 +114,6 @@
 	};
 
 	THREE.Box3.prototype.containsBox = function ( box ) {
-		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
 		if( 
 			( this.min.x <= box.min.x ) && ( box.max.x <= this.max.x ) &&
 			( this.min.y <= box.min.y ) && ( box.max.y <= this.max.y ) &&
@@ -122,8 +125,6 @@
 	};
 
 	THREE.Box3.prototype.isIntersection = function ( box ) {
-		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
-
 		// using 6 splitting planes to rule out intersections.
 		if( 
 			( this.max.x < box.min.x ) || ( box.min.x > this.max.x ) ||
@@ -136,11 +137,8 @@
 	};
 
 	THREE.Box3.prototype.getParameter = function ( point ) {
-		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
-
-		// This assumption can lead to a divide by zero if the box is actually empty.
-		// Suggestions?  I don't want to check for empty as it is a speed hit, but maybe
-		// it is necessary.
+		// This can potentially have a divide by zero if the box
+		// has a size dimension of 0.
 		return new THREE.Vector3(
 			( point.x - this.min.x ) / ( this.max.x - this.min.x ),
 			( point.y - this.min.y ) / ( this.max.y - this.min.y ),
@@ -150,7 +148,7 @@
 
 	THREE.Box3.prototype.clampPoint = function ( point ) {
 
-		return point.maxSelf( this.min ).minSelf( this.max );
+		return new THREE.Vector3().copy( point ).maxSelf( this.min ).minSelf( this.max );
 	};
 
 	THREE.Box3.prototype.distanceToPoint = function ( point ) {

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -19,7 +19,7 @@
 	THREE.Box3.fromPoints = function ( points ) {
 
 		var boundingBox = new THREE.Box3();
-		for( var i = 0; i < points.length; i ++ ) {
+		for( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {
 			boundingBox.extendByPoint( points[i] );
 		}
 

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -2,116 +2,118 @@
  * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
  */
 
-( function ( THREE ) {
+THREE.Box3 = function ( min, max ) {
 
-	THREE.Box3 = function ( min, max ) {
+	// TODO: Is this valid JavaScript to check if the parameters are specified?
+	if( ! min && ! max ) {			
+		this.makeEmpty();
+	}
+	else {
+		this.min = min || new THREE.Vector3();
+		this.max = max || this.min;		// This is done on purpose so you can make a box using a single point and then expand it.
+	}
+};
 
-		// TODO: Is this valid JavaScript to check if the parameters are specified?
-		if( ! min && ! max ) {			
-			this.makeEmpty();
-		}
-		else {
-			this.min = min || new THREE.Vector3();
-			this.max = max || this.min;		// This is done on purpose so you can make a box using a single point and then expand it.
-		}
-	};
+THREE.Box3.fromPoints = function ( points ) {
 
-	THREE.Box3.fromPoints = function ( points ) {
+	var boundingBox = new THREE.Box3();
+	for( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {
+		boundingBox.extendByPoint( points[i] );
+	}
 
-		var boundingBox = new THREE.Box3();
-		for( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {
-			boundingBox.extendByPoint( points[i] );
-		}
+	return boundingBox;
+};
 
-		return boundingBox;
-	};
+THREE.Box3.fromCenterAndSize = function ( center, size ) {
 
-	THREE.Box3.fromCenterAndSize = function ( center, size ) {
+	var halfSize = new THREE.Vector3().copy( size ).multiplyScalar( 0.5 );
+	var box = new THREE.Box3( center, center );
+	box.min.subSelf( halfSize );
+	box.min.addSelf( halfSize );
 
-		var halfSize = new THREE.Vector3().copy( size ).multiplyScalar( 0.5 );
-		var box = new THREE.Box3( center, center );
-		box.min.subSelf( halfSize );
-		box.min.addSelf( halfSize );
+	return box;	
+};
 
-		return box;	
-	};
+THREE.Box3.prototype = {
 
-	THREE.Box3.prototype.set = function ( min, max ) {
+	constructor: THREE.Box3,
+
+	set: function ( min, max ) {
 
 		this.min = min;
 		this.max = max;
 
 		return this;
-	};
+	},
 
-	THREE.Box3.prototype.copy = function ( box ) {
+	copy: function ( box ) {
 
 		this.min = box.min;
 		this.max = box.max;
 
 		return this;
-	};
+	},
 
-	THREE.Box3.prototype.makeEmpty = function () {
+	makeEmpty: function () {
 
 		this.min.x = this.min.y = this.min.z = Number.MAX_VALUE;
 		this.max.x = this.max.y = this.max.z = -Number.MAX_VALUE;
 
 		return this;
-	};
+	},
 
-	THREE.Box3.prototype.empty = function () {
+	empty: function () {
 
 		// this is a more robust check for empty than ( volume <= 0 ) because volume can get positive with two negative axes
 		return 
 			( this.max.x < this.min.x ) ||
 			( this.max.y < this.min.y ) ||
 			( this.max.z < this.min.z );
-	};
+	},
 
-	THREE.Box3.prototype.volume = function () {
+	volume: function () {
 
 		return 
 			( this.max.x - this.min.x ) *
 			( this.max.y - this.min.y ) *
 			( this.max.z - this.min.z );
-	};
+	},
 
-	THREE.Box3.prototype.center = function () {
+	center: function () {
 
 		return new THREE.Vector3().add( this.min, this.max ).multiplyScalar( 0.5 );
-	};
+	},
 
-	THREE.Box3.prototype.size = function () {
+	size: function () {
 
 		return new THREE.Vector3().sub( this.max, this.min );
-	};
+	},
 
-	THREE.Box3.prototype.expandByPoint = function ( point ) {
+	expandByPoint: function ( point ) {
 
 		this.min.minSelf( point );		
 		this.max.maxSelf( point );
 
 		return this;
-	};
+	},
 
-	THREE.Box3.prototype.expandByVector = function ( vector ) {
+	expandByVector: function ( vector ) {
 
 		this.min.subSelf( vector );
 		this.max.addSelf( vector );
 
 		return this;
-	};
+	},
 
-	THREE.Box3.prototype.expandByScalar = function ( scalar ) {
+	expandByScalar: function ( scalar ) {
 
 		this.min.addScalar( -scalar );
 		this.max.addScalar( scalar );
 		
 		return this;
-	};
+	},
 
-	THREE.Box3.prototype.containsPoint = function ( point ) {
+	containsPoint: function ( point ) {
 		if( 
 			( this.min.x <= point.x ) && ( point.x <= this.max.x ) &&
 			( this.min.y <= point.y ) && ( point.y <= this.max.y ) &&
@@ -120,9 +122,9 @@
 			return true;
 		}
 		return false;
-	};
+	},
 
-	THREE.Box3.prototype.containsBox = function ( box ) {
+	containsBox: function ( box ) {
 		if( 
 			( this.min.x <= box.min.x ) && ( box.max.x <= this.max.x ) &&
 			( this.min.y <= box.min.y ) && ( box.max.y <= this.max.y ) &&
@@ -131,9 +133,9 @@
 			return true;
 		}
 		return false;
-	};
+	},
 
-	THREE.Box3.prototype.isIntersection = function ( box ) {
+	isIntersection: function ( box ) {
 		// using 6 splitting planes to rule out intersections.
 		if( 
 			( this.max.x < box.min.x ) || ( box.min.x > this.max.x ) ||
@@ -143,9 +145,9 @@
 			return false;
 		}
 		return true;
-	};
+	},
 
-	THREE.Box3.prototype.getParameter = function ( point ) {
+	getParameter: function ( point ) {
 		// This can potentially have a divide by zero if the box
 		// has a size dimension of 0.
 		return new THREE.Vector3(
@@ -153,48 +155,48 @@
 			( point.y - this.min.y ) / ( this.max.y - this.min.y ),
 			( point.z - this.min.z ) / ( this.max.z - this.min.z )
 			);
-	};
+	},
 
-	THREE.Box3.prototype.clampPoint = function ( point ) {
+	clampPoint: function ( point ) {
 
 		return new THREE.Vector3().copy( point ).maxSelf( this.min ).minSelf( this.max );
-	};
+	},
 
-	THREE.Box3.prototype.distanceToPoint = function ( point ) {
+	distanceToPoint: function ( point ) {
 
 		return this.clampPoint( point ).subSelf( point ).length();
-	};
+	},
 
-	THREE.Box3.prototype.intersect = function ( box ) {
+	intersect: function ( box ) {
 
 		this.min.maxSelf( box.min );
 		this.max.minSelf( box.max );
 		
 		return this;
-	};
+	},
 
-	THREE.Box3.prototype.union = function ( box ) {
+	union: function ( box ) {
 
 		this.min.minSelf( box.min );
 		this.max.maxSelf( box.max );
 
 		return this;
-	};
+	},
 
-	THREE.Box3.prototype.translate = function ( offset ) {
+	translate: function ( offset ) {
 
 		this.min.addSelf( offset );
 		this.max.addSelf( offset );
 
 		return this;
-	};
+	},
 
-	THREE.Box3.prototype.scale = function ( factor ) {
+	scale: function ( factor ) {
 
 		var sizeDeltaHalf = this.size().multiplyScalar( ( 1 - factor )  * 0.5 );
 		this.expandByVector( sizeDeltaHalf );
 
 		return this;
-	};
-
-}( THREE ) );
+	}
+	
+};

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -4,7 +4,6 @@
 
 THREE.Box3 = function ( min, max ) {
 
-	// TODO: Is this valid JavaScript to check if the parameters are specified?
 	if( ! min && ! max ) {			
 		this.min = new THREE.Vector3();
 		this.max = new THREE.Vector3();

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -190,7 +190,31 @@ THREE.Box3.prototype = {
 
 	clampPoint: function ( point ) {
 
-		return new THREE.Vector3().copy( point ).maxSelf( this.min ).minSelf( this.max );
+		var p = new THREE.Vector3().copy( point );
+
+		// this requires less if's then a point.minSelf( this.max ).maxSelf( this.min )
+		if( p.x < this.min.x ) {
+			p.x = this.min.x;
+		}
+		else if( p.x > this.max.x ) {
+			p.x = this.max.x;
+		}
+
+		if( p.y < this.min.y ) {
+			p.y = this.min.y;
+		}
+		else if( p.y > this.max.y ) {
+			p.y = this.max.y;
+		}
+
+		if( p.z < this.min.z ) {
+			p.z = this.min.z;
+		}
+		else if( p.z > this.max.z ) {
+			p.z = this.max.z;
+		}
+
+		return p;
 	},
 
 	distanceToPoint: function ( point ) {

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -70,7 +70,7 @@ THREE.Box3.prototype = {
 
 	setFromCenterAndSize: function ( center, size ) {
 
-		var halfSize = new THREE.Vector3().copy( size ).multiplyScalar( 0.5 );
+		var halfSize = THREE.Box3.__v1.copy( size ).multiplyScalar( 0.5 );
 		this.min.copy( center ).subSelf( halfSize );
 		this.max.copy( center ).addSelf( halfSize );
 
@@ -231,3 +231,5 @@ THREE.Box3.prototype = {
 	}
 	
 };
+
+THREE.Box3.__v1 = new THREE.Vector3();

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -1,0 +1,167 @@
+/**
+ * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
+ */
+
+( function ( THREE ) {
+
+	THREE.Box3 = function ( min, max ) {
+
+		this.min = min || new THREE.Vector3();
+		this.max = max || new THREE.Vector3();
+
+	};
+
+	THREE.Box3.prototype.set = function ( min, max ) {
+
+		this.min = min;
+		this.max = max;
+
+		return this;
+	};
+
+	THREE.Box3.prototype.empty = function () {
+		// this is a more robust check for empty than ( volume <= 0 ) because volume can get positive with two negative axes
+		return 
+			(( this.max.x - this.min.x ) <= 0 ) ||
+			(( this.max.y - this.min.y ) <= 0 ) ||
+			(( this.max.z - this.min.z ) <= 0 );
+	};
+
+	THREE.Box3.prototype.volume = function () {
+		return 
+			( this.max.x - this.min.x ) *
+			( this.max.y - this.min.y ) *
+			( this.max.z - this.min.z );
+	};
+
+	THREE.Box3.prototype.center = function () {
+		var c = new THREE.Vector3();
+		return c.add( this.min, this.max ).multiplyScalar( 0.5 );
+	};
+
+	THREE.Box3.prototype.size = function () {
+		var s = new THREE.Vector3();
+		return s.sub( this.max, this.min );
+	};
+
+	THREE.Box3.prototype.extendByPoint = function ( point ) {
+		// TODO: replace by THREE.Vector3.min/max methods when they exist
+		this.min.x = Math.min( this.min.x, point.x );
+		this.min.y = Math.min( this.min.y, point.y );
+		this.min.z = Math.min( this.min.z, point.z );
+		this.max.x = Math.max( this.max.x, point.x );
+		this.max.y = Math.max( this.max.y, point.y );
+		this.max.z = Math.max( this.max.z, point.z );
+		return this;
+	};
+
+	THREE.Box3.prototype.extendByBox = function ( box ) {
+		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
+		// TODO: replace by THREE.Vector3.min/max methods when they exist
+		this.min.x = Math.min( this.min.x, box.min.x );
+		this.min.y = Math.min( this.min.y, box.min.y );
+		this.min.z = Math.min( this.min.z, box.min.z );
+		this.max.x = Math.max( this.max.x, box.max.x );
+		this.max.y = Math.max( this.max.y, box.max.y );
+		this.max.z = Math.max( this.max.z, box.max.z );
+		return this;
+	};
+
+	THREE.Box3.prototype.expandByVector = function ( vector ) {
+		this.min.subSelf( vector );
+		this.max.addSelf( vector );
+		return this;
+	};
+
+	THREE.Box3.prototype.expandByScalar = function ( scalar ) {
+		this.min.x -= scalar;
+		this.min.y -= scalar;
+		this.min.z -= scalar;
+		this.max.x += scalar;
+		this.max.y += scalar;
+		this.max.z += scalar;
+		return this;
+	};
+
+	THREE.Box3.prototype.containsPoint = function ( point ) {
+		if( 
+			( this.min.x <= point.x ) && ( point.x <= this.max.x ) &&
+			( this.min.y <= point.y ) && ( point.y <= this.max.y ) &&
+			( this.min.z <= point.z ) && ( point.z <= this.max.z )
+			) {
+			return true;
+		}
+		return false;
+	};
+
+	THREE.Box3.prototype.containsBox = function ( box ) {
+		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
+		if( 
+			( this.min.x <= box.min.x ) && ( box.max.x <= this.max.x ) &&
+			( this.min.y <= box.min.y ) && ( box.max.y <= this.max.y ) &&
+			( this.min.z <= box.min.z ) && ( box.max.z <= this.max.z )
+			) {
+			return true;
+		}
+		return false;
+	};
+
+	THREE.Box3.prototype.isIntersection = function ( box ) {
+		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
+		// using 6 splitting planes to rule out intersections.
+		if( 
+			( this.max.x < box.min.x ) || ( box.min.x > this.max.x ) ||
+			( this.max.y < box.min.y ) || ( box.min.y > this.max.y ) ||
+			( this.max.z < box.min.z ) || ( box.min.z > this.max.z )
+			) {
+			return false;
+		}
+		return true;
+	};
+
+	THREE.Box3.prototype.getParameter = function ( point ) {
+		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
+		// This assumption can lead to a divide by zero if the box is actually empty.
+		// Suggestions?  I don't want to check for empty as it is a speed hit, but maybe
+		// it is necessary.
+		return new THREE.Vector3(
+			( point.x - this.min.x ) / ( this.max.x - this.min.x ),
+			( point.y - this.min.y ) / ( this.max.y - this.min.y ),
+			( point.z - this.min.z ) / ( this.max.z - this.min.z )
+			);
+	};
+
+	THREE.Box3.prototype.clampPoint = function ( point ) {
+		// TODO: replace by THREE.Vector3.min/max methods when they exist
+		return new THREE.Vector3(
+			Math.min( Math.max( this.min.x, point.x ), this.max.x ),
+			Math.min( Math.max( this.min.y, point.y ), this.max.y ),
+			Math.min( Math.max( this.min.z, point.z ), this.max.z )
+			);
+	};
+
+	THREE.Box3.prototype.distanceToPoint = function ( point ) {
+		return this.clampPoint( point ).subSelf( point ).length();
+	};
+
+	THREE.Box3.prototype.intersect = function ( box ) {
+		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
+		this.min = this.clampPoint( box.min );
+		this.max = this.clampPoint( box.max );
+		return this;
+	};
+
+	THREE.Box3.prototype.union = function ( box ) {
+		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
+		this.extendByPoint( box.min );
+		this.extendByPoint( box.max );
+		return this;
+	};
+
+	THREE.Box3.prototype.translate = function ( offset ) {
+		this.min.addSelf( offset );
+		this.max.addSelf( offset );
+		return this;
+	};
+
+}( THREE ) );

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -26,6 +26,16 @@
 		return boundingBox;
 	};
 
+	THREE.Box3.fromCenterAndSize = function ( center, size ) {
+
+		var halfSize = new THREE.Vector3().copy( size ).multiplyScalar( 0.5 );
+		var box = new THREE.Box3( center, center );
+		box.min.subSelf( halfSize );
+		box.min.addSelf( halfSize );
+
+		return box;	
+	};
+
 	THREE.Box3.prototype.set = function ( min, max ) {
 
 		this.min = min;
@@ -53,7 +63,6 @@
 	THREE.Box3.prototype.empty = function () {
 
 		// this is a more robust check for empty than ( volume <= 0 ) because volume can get positive with two negative axes
-
 		return 
 			( this.max.x < this.min.x ) ||
 			( this.max.y < this.min.y ) ||
@@ -78,7 +87,7 @@
 		return new THREE.Vector3().sub( this.max, this.min );
 	};
 
-	THREE.Box3.prototype.extendByPoint = function ( point ) {
+	THREE.Box3.prototype.expandByPoint = function ( point ) {
 
 		this.min.minSelf( point );		
 		this.max.maxSelf( point );
@@ -176,6 +185,14 @@
 
 		this.min.addSelf( offset );
 		this.max.addSelf( offset );
+
+		return this;
+	};
+
+	THREE.Box3.prototype.scale = function ( factor ) {
+
+		var sizeDeltaHalf = this.size().multiplyScalar( ( 1 - factor )  * 0.5 );
+		this.expandByVector( sizeDeltaHalf );
 
 		return this;
 	};

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -79,8 +79,8 @@ THREE.Box3.prototype = {
 
 	copy: function ( box ) {
 
-		this.min = box.min;
-		this.max = box.max;
+		this.min.copy( box.min );
+		this.max.copy( box.max );
 
 		return this;
 	},

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -14,26 +14,6 @@ THREE.Box3 = function ( min, max ) {
 	}
 };
 
-THREE.Box3.fromPoints = function ( points ) {
-
-	var boundingBox = new THREE.Box3();
-	for( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {
-		boundingBox.extendByPoint( points[i] );
-	}
-
-	return boundingBox;
-};
-
-THREE.Box3.fromCenterAndSize = function ( center, size ) {
-
-	var halfSize = new THREE.Vector3().copy( size ).multiplyScalar( 0.5 );
-	var box = new THREE.Box3( center, center );
-	box.min.subSelf( halfSize );
-	box.min.addSelf( halfSize );
-
-	return box;	
-};
-
 THREE.Box3.prototype = {
 
 	constructor: THREE.Box3,
@@ -44,6 +24,26 @@ THREE.Box3.prototype = {
 		this.max = max;
 
 		return this;
+	},
+
+	setFromPoints: function ( points ) {
+
+		this.makeEmpty();
+		
+		for( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {
+			this.expandByPoint( points[i] );
+		}
+
+		return this;
+	};
+
+	setFromCenterAndSize: function ( center, size ) {
+
+		var halfSize = new THREE.Vector3().copy( size ).multiplyScalar( 0.5 );
+		this.min.copy( center ).subSelf( halfSize );
+		this.max.copy( center ).addSelf( halfSize );
+
+		return box;	
 	},
 
 	copy: function ( box ) {

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -52,25 +52,15 @@
 	};
 
 	THREE.Box3.prototype.extendByPoint = function ( point ) {
-		// TODO: replace by THREE.Vector3.min/max methods when they exist
-		this.min.x = Math.min( this.min.x, point.x );
-		this.min.y = Math.min( this.min.y, point.y );
-		this.min.z = Math.min( this.min.z, point.z );
-		this.max.x = Math.max( this.max.x, point.x );
-		this.max.y = Math.max( this.max.y, point.y );
-		this.max.z = Math.max( this.max.z, point.z );
+		this.min.minSelf( point );
+		this.max.maxSelf( point );
 		return this;
 	};
 
 	THREE.Box3.prototype.extendByBox = function ( box ) {
 		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
-		// TODO: replace by THREE.Vector3.min/max methods when they exist
-		this.min.x = Math.min( this.min.x, box.min.x );
-		this.min.y = Math.min( this.min.y, box.min.y );
-		this.min.z = Math.min( this.min.z, box.min.z );
-		this.max.x = Math.max( this.max.x, box.max.x );
-		this.max.y = Math.max( this.max.y, box.max.y );
-		this.max.z = Math.max( this.max.z, box.max.z );
+		this.min.minSelf( box.min );
+		this.max.maxSelf( box.max );
 		return this;
 	};
 
@@ -135,12 +125,7 @@
 	};
 
 	THREE.Box3.prototype.clampPoint = function ( point ) {
-		// TODO: replace by THREE.Vector3.min/max methods when they exist
-		return new THREE.Vector3(
-			Math.min( Math.max( this.min.x, point.x ), this.max.x ),
-			Math.min( Math.max( this.min.y, point.y ), this.max.y ),
-			Math.min( Math.max( this.min.z, point.z ), this.max.z )
-			);
+		return point.maxSelf( this.min ).minSelf( this.max );
 	};
 
 	THREE.Box3.prototype.distanceToPoint = function ( point ) {

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -6,9 +6,24 @@
 
 	THREE.Box3 = function ( min, max ) {
 
-		this.min = min || new THREE.Vector3();
-		this.max = max || this.min;		// This is done on purpose so you can make a box using a single point and then expand it.
+		// TODO: Is this valid JavaScript to check if the parameters are specified?
+		if( ! min && ! max ) {			
+			this.makeEmpty();
+		}
+		else {
+			this.min = min || new THREE.Vector3();
+			this.max = max || this.min;		// This is done on purpose so you can make a box using a single point and then expand it.
+		}
+	};
 
+	THREE.Box3.fromPoints = function ( points ) {
+
+		var boundingBox = new THREE.Box3();
+		for( var i = 0; i < points.length; i ++ ) {
+			boundingBox.extendByPoint( points[i] );
+		}
+
+		return boundingBox;
 	};
 
 	THREE.Box3.prototype.set = function ( min, max ) {
@@ -27,16 +42,26 @@
 		return this;
 	};
 
+	THREE.Box3.prototype.makeEmpty = function () {
+
+		this.min.x = this.min.y = this.min.z = Number.MAX_VALUE;
+		this.max.x = this.max.y = this.max.z = -Number.MAX_VALUE;
+
+		return this;
+	};
 
 	THREE.Box3.prototype.empty = function () {
+
 		// this is a more robust check for empty than ( volume <= 0 ) because volume can get positive with two negative axes
+
 		return 
-			(( this.max.x - this.min.x ) <= 0 ) ||
-			(( this.max.y - this.min.y ) <= 0 ) ||
-			(( this.max.z - this.min.z ) <= 0 );
+			( this.max.x < this.min.x ) ||
+			( this.max.y < this.min.y ) ||
+			( this.max.z < this.min.z );
 	};
 
 	THREE.Box3.prototype.volume = function () {
+
 		return 
 			( this.max.x - this.min.x ) *
 			( this.max.y - this.min.y ) *
@@ -44,10 +69,12 @@
 	};
 
 	THREE.Box3.prototype.center = function () {
+
 		return new THREE.Vector3().add( this.min, this.max ).multiplyScalar( 0.5 );
 	};
 
 	THREE.Box3.prototype.size = function () {
+
 		return new THREE.Vector3().sub( this.max, this.min );
 	};
 
@@ -57,20 +84,15 @@
 		return this;
 	};
 
-	THREE.Box3.prototype.extendByBox = function ( box ) {
-		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
-		this.min.minSelf( box.min );
-		this.max.maxSelf( box.max );
-		return this;
-	};
-
 	THREE.Box3.prototype.expandByVector = function ( vector ) {
+
 		this.min.subSelf( vector );
 		this.max.addSelf( vector );
 		return this;
 	};
 
 	THREE.Box3.prototype.expandByScalar = function ( scalar ) {
+
 		this.min.addScalar( -scalar );
 		this.max.addScalar( scalar );
 		return this;
@@ -101,6 +123,7 @@
 
 	THREE.Box3.prototype.isIntersection = function ( box ) {
 		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
+
 		// using 6 splitting planes to rule out intersections.
 		if( 
 			( this.max.x < box.min.x ) || ( box.min.x > this.max.x ) ||
@@ -114,6 +137,7 @@
 
 	THREE.Box3.prototype.getParameter = function ( point ) {
 		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
+
 		// This assumption can lead to a divide by zero if the box is actually empty.
 		// Suggestions?  I don't want to check for empty as it is a speed hit, but maybe
 		// it is necessary.
@@ -125,30 +149,36 @@
 	};
 
 	THREE.Box3.prototype.clampPoint = function ( point ) {
+
 		return point.maxSelf( this.min ).minSelf( this.max );
 	};
 
 	THREE.Box3.prototype.distanceToPoint = function ( point ) {
+
 		return this.clampPoint( point ).subSelf( point ).length();
 	};
 
 	THREE.Box3.prototype.intersect = function ( box ) {
-		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
-		this.min = this.clampPoint( box.min );
-		this.max = this.clampPoint( box.max );
+
+		this.min.maxSelf( box.min );
+		this.max.minSelf( box.max );
+		
 		return this;
 	};
 
 	THREE.Box3.prototype.union = function ( box ) {
-		// Assumption: for speed purposes, we assume that the box is not empty, e.g. box.min < box.max
-		this.extendByPoint( box.min );
-		this.extendByPoint( box.max );
+
+		this.min.minSelf( box.min );
+		this.max.maxSelf( box.max );
+
 		return this;
 	};
 
 	THREE.Box3.prototype.translate = function ( offset ) {
+
 		this.min.addSelf( offset );
 		this.max.addSelf( offset );
+
 		return this;
 	};
 

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -29,10 +29,40 @@ THREE.Box3.prototype = {
 
 	setFromPoints: function ( points ) {
 
-		this.makeEmpty();
-		
-		for( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {
-			this.expandByPoint( points[i] );
+		if( points.length > 0 ) {
+
+			var p = points[0];
+			this.min.copy( p );
+			this.max.copy( p );
+
+			for( var i = 1, numPoints = points.length; i < numPoints; i ++ ) {
+
+				p = points[ v ];
+
+				if ( p.x < this.min.x ) {
+					this.min.x = p.x;
+				}
+				else if ( p.x > this.max.x ) {
+					this.max.x = p.x;
+				}
+
+				if ( p.y < this.min.y ) {
+					this.min.y = p.y;
+				}
+				else if ( p.y > this.max.y ) {
+					this.max.y = p.y;
+				}
+
+				if ( p.z < this.min.z ) {
+					this.min.z = p.z;
+				}
+				else if ( p.z > this.max.z ) {
+					this.max.z = p.z;
+				}
+			}
+		}
+		else {
+			this.makeEmpty();
 		}
 
 		return this;

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -7,7 +7,7 @@
 	THREE.Box3 = function ( min, max ) {
 
 		this.min = min || new THREE.Vector3();
-		this.max = max || new THREE.Vector3();
+		this.max = max || this.min;		// This is done on purpose so you can make a box using a single point and then expand it.
 
 	};
 
@@ -18,6 +18,15 @@
 
 		return this;
 	};
+
+	THREE.Box3.prototype.copy = function ( box ) {
+
+		this.min = box.min;
+		this.max = box.max;
+
+		return this;
+	};
+
 
 	THREE.Box3.prototype.empty = function () {
 		// this is a more robust check for empty than ( volume <= 0 ) because volume can get positive with two negative axes
@@ -35,13 +44,11 @@
 	};
 
 	THREE.Box3.prototype.center = function () {
-		var c = new THREE.Vector3();
-		return c.add( this.min, this.max ).multiplyScalar( 0.5 );
+		return new THREE.Vector3().add( this.min, this.max ).multiplyScalar( 0.5 );
 	};
 
 	THREE.Box3.prototype.size = function () {
-		var s = new THREE.Vector3();
-		return s.sub( this.max, this.min );
+		return new THREE.Vector3().sub( this.max, this.min );
 	};
 
 	THREE.Box3.prototype.extendByPoint = function ( point ) {
@@ -74,12 +81,8 @@
 	};
 
 	THREE.Box3.prototype.expandByScalar = function ( scalar ) {
-		this.min.x -= scalar;
-		this.min.y -= scalar;
-		this.min.z -= scalar;
-		this.max.x += scalar;
-		this.max.y += scalar;
-		this.max.z += scalar;
+		this.min.addScalar( -scalar );
+		this.max.addScalar( scalar );
 		return this;
 	};
 

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -1,5 +1,5 @@
 /**
- * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
+ * @author bhouston / http://exocortex.com
  */
 
 THREE.Box3 = function ( min, max ) {

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -190,31 +190,7 @@ THREE.Box3.prototype = {
 
 	clampPoint: function ( point ) {
 
-		var p = new THREE.Vector3().copy( point );
-
-		// this requires less if's then a point.minSelf( this.max ).maxSelf( this.min )
-		if( p.x < this.min.x ) {
-			p.x = this.min.x;
-		}
-		else if( p.x > this.max.x ) {
-			p.x = this.max.x;
-		}
-
-		if( p.y < this.min.y ) {
-			p.y = this.min.y;
-		}
-		else if( p.y > this.max.y ) {
-			p.y = this.max.y;
-		}
-
-		if( p.z < this.min.z ) {
-			p.z = this.min.z;
-		}
-		else if( p.z > this.max.z ) {
-			p.z = this.max.z;
-		}
-
-		return p;
+		return new THREE.Vector3().copy( point ).clampSelf( this.min, this.max );
 	},
 
 	distanceToPoint: function ( point ) {

--- a/src/core/Box3.js
+++ b/src/core/Box3.js
@@ -6,11 +6,13 @@ THREE.Box3 = function ( min, max ) {
 
 	// TODO: Is this valid JavaScript to check if the parameters are specified?
 	if( ! min && ! max ) {			
+		this.min = new THREE.Vector3();
+		this.max = new THREE.Vector3();
 		this.makeEmpty();
 	}
 	else {
 		this.min = min || new THREE.Vector3();
-		this.max = max || this.min;		// This is done on purpose so you can make a box using a single point and then expand it.
+		this.max = max || new THREE.Vector3().copy( this.min );		// This is done on purpose so you can make a box using a single point and then expand it.
 	}
 };
 
@@ -35,7 +37,7 @@ THREE.Box3.prototype = {
 		}
 
 		return this;
-	};
+	},
 
 	setFromCenterAndSize: function ( center, size ) {
 

--- a/src/core/Frustum.js
+++ b/src/core/Frustum.js
@@ -1,18 +1,19 @@
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author alteredq / http://alteredqualia.com/
+ * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
  */
 
 THREE.Frustum = function ( ) {
 
 	this.planes = [
 
-		new THREE.Vector4(),
-		new THREE.Vector4(),
-		new THREE.Vector4(),
-		new THREE.Vector4(),
-		new THREE.Vector4(),
-		new THREE.Vector4()
+		new THREE.Plane(),
+		new THREE.Plane(),
+		new THREE.Plane(),
+		new THREE.Plane(),
+		new THREE.Plane(),
+		new THREE.Plane()
 
 	];
 
@@ -29,18 +30,15 @@ THREE.Frustum.prototype.setFromMatrix = function ( m ) {
 	var me8 = me[8], me9 = me[9], me10 = me[10], me11 = me[11];
 	var me12 = me[12], me13 = me[13], me14 = me[14], me15 = me[15];
 
-	planes[ 0 ].set( me3 - me0, me7 - me4, me11 - me8, me15 - me12 );
-	planes[ 1 ].set( me3 + me0, me7 + me4, me11 + me8, me15 + me12 );
-	planes[ 2 ].set( me3 + me1, me7 + me5, me11 + me9, me15 + me13 );
-	planes[ 3 ].set( me3 - me1, me7 - me5, me11 - me9, me15 - me13 );
-	planes[ 4 ].set( me3 - me2, me7 - me6, me11 - me10, me15 - me14 );
-	planes[ 5 ].set( me3 + me2, me7 + me6, me11 + me10, me15 + me14 );
+	planes[ 0 ].setComponents( me3 - me0, me7 - me4, me11 - me8, me15 - me12 );
+	planes[ 1 ].setComponents( me3 + me0, me7 + me4, me11 + me8, me15 + me12 );
+	planes[ 2 ].setComponents( me3 + me1, me7 + me5, me11 + me9, me15 + me13 );
+	planes[ 3 ].setComponents( me3 - me1, me7 - me5, me11 - me9, me15 - me13 );
+	planes[ 4 ].setComponents( me3 - me2, me7 - me6, me11 - me10, me15 - me14 );
+	planes[ 5 ].setComponents( me3 + me2, me7 + me6, me11 + me10, me15 + me14 );
 
 	for ( var i = 0; i < 6; i ++ ) {
-
-		plane = planes[ i ];
-		plane.divideScalar( Math.sqrt( plane.x * plane.x + plane.y * plane.y + plane.z * plane.z ) );
-
+		planes[ i ].normalize();
 	}
 
 };
@@ -50,12 +48,12 @@ THREE.Frustum.prototype.contains = function ( object ) {
 	var distance = 0.0;
 	var planes = this.planes;
 	var matrix = object.matrixWorld;
-	var me = matrix.elements;
+	var matrixPosition = matrix.getPosition();
 	var radius = - object.geometry.boundingSphere.radius * matrix.getMaxScaleOnAxis();
 
 	for ( var i = 0; i < 6; i ++ ) {
 
-		distance = planes[ i ].x * me[12] + planes[ i ].y * me[13] + planes[ i ].z * me[14] + planes[ i ].w;
+		distance = planes[ i ].distanceToPoint( matrixPosition );
 		if ( distance <= radius ) return false;
 
 	}

--- a/src/core/Frustum.js
+++ b/src/core/Frustum.js
@@ -1,7 +1,7 @@
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author alteredq / http://alteredqualia.com/
- * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
+ * @author bhouston / http://exocortex.com
  */
 
 THREE.Frustum = function ( ) {

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -4,7 +4,7 @@
  * @author alteredq / http://alteredqualia.com/
  * @author mikael emtinger / http://gomo.se/
  * @author zz85 / http://www.lab4games.net/zz85/blog
- * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
+ * @author bhouston / http://exocortex.com
  */
 
 THREE.Geometry = function () {

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -577,12 +577,12 @@ THREE.Geometry.prototype = {
 
 	computeBoundingBox: function () {
 
-		this.boundingBox = THREE.Box3.fromPoints( this.vertices );
+		this.boundingBox = new THREE.Box3().setFromPoints( this.vertices );
 	},
 
 	computeBoundingSphere: function () {
 
-		this.boundingSphere = THREE.Sphere.fromCenterAndPoints( new THREE.Vector3(), this.vertices );
+		this.boundingSphere = new THREE.Sphere().setFromCenterAndPoints( new THREE.Vector3(), this.vertices );
 	},
 
 	/*

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -4,6 +4,7 @@
  * @author alteredq / http://alteredqualia.com/
  * @author mikael emtinger / http://gomo.se/
  * @author zz85 / http://www.lab4games.net/zz85/blog
+ * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
  */
 
 THREE.Geometry = function () {
@@ -576,82 +577,12 @@ THREE.Geometry.prototype = {
 
 	computeBoundingBox: function () {
 
-		if ( ! this.boundingBox ) {
-
-			this.boundingBox = { min: new THREE.Vector3(), max: new THREE.Vector3() };
-
-		}
-
-		if ( this.vertices.length > 0 ) {
-
-			var position, firstPosition = this.vertices[ 0 ];
-
-			this.boundingBox.min.copy( firstPosition );
-			this.boundingBox.max.copy( firstPosition );
-
-			var min = this.boundingBox.min,
-				max = this.boundingBox.max;
-
-			for ( var v = 1, vl = this.vertices.length; v < vl; v ++ ) {
-
-				position = this.vertices[ v ];
-
-				if ( position.x < min.x ) {
-
-					min.x = position.x;
-
-				} else if ( position.x > max.x ) {
-
-					max.x = position.x;
-
-				}
-
-				if ( position.y < min.y ) {
-
-					min.y = position.y;
-
-				} else if ( position.y > max.y ) {
-
-					max.y = position.y;
-
-				}
-
-				if ( position.z < min.z ) {
-
-					min.z = position.z;
-
-				} else if ( position.z > max.z ) {
-
-					max.z = position.z;
-
-				}
-
-			}
-
-		} else {
-
-			this.boundingBox.min.set( 0, 0, 0 );
-			this.boundingBox.max.set( 0, 0, 0 );
-
-		}
-
+		this.boundingBox = THREE.Box3.fromPoints( this.vertices );
 	},
 
 	computeBoundingSphere: function () {
 
-		var maxRadiusSq = 0;
-
-		if ( this.boundingSphere === null ) this.boundingSphere = { radius: 0 };
-
-		for ( var i = 0, l = this.vertices.length; i < l; i ++ ) {
-
-			var radiusSq = this.vertices[ i ].lengthSq();
-			if ( radiusSq > maxRadiusSq ) maxRadiusSq = radiusSq;
-
-		}
-
-		this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
-
+		this.boundingSphere = THREE.Sphere.fromCenterAndPoints( new THREE.Vector3(), this.vertices );
 	},
 
 	/*

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -39,8 +39,8 @@ THREE.Plane.prototype = {
 
 	setFromCoplanarPoints: function ( a, b, c ) {
 
-		var normal = new THREE.Vector3().sub( b, a ).cross(
-			new THREE.Vector3().sub( c, a ) );
+		var normal = THREE.Plane3.__v1.sub( b, a ).cross(
+			THREE.Plane3.__v2.sub( c, a ) );
 
 		// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
 		this.setFromNormalAndCoplanarPoint( normal, a );
@@ -51,7 +51,7 @@ THREE.Plane.prototype = {
 	copy: function ( plane ) {
 
 		this.normal.copy( plane.normal );
-		this.constant = plane.constant.clone();
+		this.constant = new Number( plane.constant );
 
 		return this;
 	},
@@ -119,3 +119,6 @@ THREE.Plane.prototype = {
 	}
 
 };
+
+THREE.Plane.__v1 = new THREE.Vector3();
+THREE.Plane.__v2 = new THREE.Vector3();

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -1,0 +1,93 @@
+/**
+ * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
+ */
+
+( function ( THREE ) {
+
+	THREE.Plane = function ( normal, constant ) {
+		// TODO: ensure that normal is of length 1 and if it isn't readjust both normal and constant?
+		this.normal = normal || new THREE.Vector3();
+		this.constant = constant || 0;
+
+	};
+
+	THREE.Plane.prototype.set = function ( normal, constant ) {
+
+		// TODO: ensure that normal is of length 1 and if it isn't readjust both normal and constant?
+		this.normal = normal;
+		this.constant = constant;
+
+		return this;
+	};
+
+	THREE.Plane.prototype.setComponents = function ( x, y, z, w ) {
+
+		// TODO: ensure that normal is of length 1 and if it isn't readjust both normal and constant?
+		this.normal.x = x;
+		this.normal.y = y;
+		this.normal.z = z;
+		this.constant = w;
+
+		return this;
+	};
+
+	THREE.Plane.prototype.flip = function () {
+
+		// Note: can also be flipped by inverting constant, but I like constant to stay positive generally.
+		this.normal.negate();
+
+		return this;
+	};
+
+	THREE.Plane.prototype.normalize = function () {
+
+		// Note: will lead to a divide by zero if the plane is invalid.
+		var inverseNormalLength = 1.0 / this.normal.length()
+		this.normal.multipleByScalar( inverseNormalLength );
+		this.constant *= inverseNormalLength;
+
+		return this;
+	};
+
+	THREE.Plane.prototype.distanceToPoint = function ( point ) {
+
+		return this.normal.dot( point ) + this.constant;
+	};
+
+	THREE.Plane.prototype.projectPoint = function ( point ) {		
+
+		var perpendicularMagnitude = this.distanceToPoint( point );
+
+		return new THREE.Vector3(
+			point.x - this.normal.x * perpendicularMagnitude,
+			point.y - this.normal.y * perpendicularMagnitude,
+			point.z - this.normal.z * perpendicularMagnitude
+			);
+	};
+
+	THREE.Plane.prototype.orthoPoint = function ( point ) {		
+
+		var perpendicularMagnitude = this.distanceToPoint( point );
+
+		return new THREE.Vector3(
+			this.normal.x * perpendicularMagnitude,
+			this.normal.y * perpendicularMagnitude,
+			this.normal.z * perpendicularMagnitude
+			);
+	};
+
+	THREE.Plane.prototype.intersectsLine = function ( startPoint, endPoint ) {	
+
+		// Note: this tests if a line intersects the plane, not whether it (or its end-points) are coplanar with it.
+		var startSign = this.distanceToPoint( startPoint );
+		var endSign = this.distanceToPoint( endPoint );
+
+		return ( startSign < 0 && endSign > 0 ) || ( endSign < 0 && startSign > 0 );
+	};
+
+	THREE.Plane.prototype.coplanarPoint = function () {		
+		
+		return this.projectPoint( new THREE.Vector3( 0,0,0 ) );
+	};
+
+}( THREE ) );

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -9,26 +9,6 @@ THREE.Plane = function ( normal, constant ) {
 
 };
 
-THREE.Plane.fromNormalAndCoplanarPoint = function ( normal, point ) {
-	// NOTE: This function doens't support optional parameters like the constructor.
-
-	return new THREE.Plane( 
-		normal,
-		- point.dot( normal )
-		);
-};
-
-THREE.Plane.fromCoplanarPoints = function ( a, b, c ) {
-	// NOTE: This function doens't support optional parameters like the constructor.
-
-	var normal = new THREE.Vector3().sub( b, a ).cross(
-		new THREE.Vector3().sub( c, a ) );
-
-	// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
-
-	return THREE.Plane.fromNormalAndCoplanarPoint( normal, a );
-};
-
 THREE.Plane.prototype = {
 
 	constructor: THREE.Plane,
@@ -46,6 +26,27 @@ THREE.Plane.prototype = {
 		this.normal.set( x, y, z );
 		this.constant = w;
 
+		return this;
+	},
+
+	setFromNormalAndCoplanarPoint: function ( normal, point ) {
+		// NOTE: This function doens't support optional parameters like the constructor.
+
+		this.normal = normal;
+		this.constant = - point.dot( normal );
+
+		return this;
+	},
+
+	setFromCoplanarPoints: function ( a, b, c ) {
+		// NOTE: This function doens't support optional parameters like the constructor.
+
+		var normal = new THREE.Vector3().sub( b, a ).cross(
+			new THREE.Vector3().sub( c, a ) );
+
+		// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
+		this.setFromNormalAndCoplanarPoint( normal, a );
+		
 		return this;
 	},
 

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -63,14 +63,8 @@
 	};
 
 	THREE.Plane.prototype.projectPoint = function ( point ) {		
-
-		var perpendicularMagnitude = this.distanceToPoint( point );
-
-		return new THREE.Vector3( 
-			point.x - this.normal.x * perpendicularMagnitude,
-			point.y - this.normal.y * perpendicularMagnitude,
-			point.z - this.normal.z * perpendicularMagnitude
-			);
+		
+		return new THREE.Vector3().copy( point ).sub( this.orthoPoint( point ) );
 	};
 
 	THREE.Plane.prototype.orthoPoint = function ( point ) {		
@@ -91,7 +85,7 @@
 
 	THREE.Plane.prototype.coplanarPoint = function () {		
 		
-		return this.projectPoint( new THREE.Vector3( 0, 0, 0 ) );
+		return this.projectPoint( new THREE.Vector3() );
 	};
 
 }( THREE ) );

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -110,7 +110,15 @@
 
 	THREE.Plane.prototype.coplanarPoint = function () {		
 		
-		return new THREE.Vector3().copy( this.normal ).multiplyByScalar( - this.constant );
+		return new THREE.Vector3().copy( this.normal ).multiplyScalar( - this.constant );
+	};
+
+	THREE.Plane.prototype.translate = function ( offset ) {
+
+		// TODO: test this.
+		this.constant =	- offset.dot( normal );
+
+		return this;
 	};
 
 }( THREE ) );

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -4,16 +4,37 @@
 
 ( function ( THREE ) {
 
+	var zeroPoint = new THREE.Vector3();
+
 	THREE.Plane = function ( normal, constant ) {
-		// TODO: ensure that normal is of length 1 and if it isn't readjust both normal and constant?
+
 		this.normal = normal || new THREE.Vector3();
 		this.constant = constant || 0;
 
 	};
 
+	THREE.Plane.fromNormalAndCoplanarPoint = function ( normal, point ) {
+		// NOTE: This function doens't support optional parameters like the constructor.
+
+		return new THREE.Plane( 
+			normal,
+			- point.dot( normal )
+			);
+	};
+
+	THREE.Plane.fromCoplanarPoints = function ( a, b, c ) {
+		// NOTE: This function doens't support optional parameters like the constructor.
+
+		var normal = new THREE.Vector3().sub( b, a ).cross(
+			new THREE.Vector3().sub( c, a ) );
+
+		// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
+
+		return THREE.Plane.fromNormalAndCoplanarPoint( normal, a );
+	};
+
 	THREE.Plane.prototype.set = function ( normal, constant ) {
 
-		// TODO: ensure that normal is of length 1 and if it isn't readjust both normal and constant?
 		this.normal = normal;
 		this.constant = constant;
 
@@ -22,10 +43,7 @@
 
 	THREE.Plane.prototype.setComponents = function ( x, y, z, w ) {
 
-		// TODO: ensure that normal is of length 1 and if it isn't readjust both normal and constant?
-		this.normal.x = x;
-		this.normal.y = y;
-		this.normal.z = z;
+		this.normal.set( x, y, z );
 		this.constant = w;
 
 		return this;
@@ -50,7 +68,7 @@
 	THREE.Plane.prototype.normalize = function () {
 
 		// Note: will lead to a divide by zero if the plane is invalid.
-		var inverseNormalLength = 1.0 / this.normal.length()
+		var inverseNormalLength = 1.0 / this.normal.length();
 		this.normal.multipleByScalar( inverseNormalLength );
 		this.constant *= inverseNormalLength;
 
@@ -62,7 +80,14 @@
 		return this.normal.dot( point ) + this.constant;
 	};
 
+	THREE.Sphere.prototype.distanceToSphere = function ( sphere ) {
+
+		return this.distanceToPoint( sphere.center ) - sphere.radius;
+	};
+
 	THREE.Plane.prototype.projectPoint = function ( point ) {		
+		
+		// TODO: optimize this by expanding and simplifying
 		
 		return new THREE.Vector3().copy( point ).sub( this.orthoPoint( point ) );
 	};
@@ -85,7 +110,7 @@
 
 	THREE.Plane.prototype.coplanarPoint = function () {		
 		
-		return this.projectPoint( new THREE.Vector3() );
+		return new THREE.Vector3().copy( this.normal ).multiplyByScalar( - this.constant );
 	};
 
 }( THREE ) );

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -2,70 +2,70 @@
  * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
  */
 
-( function ( THREE ) {
+THREE.Plane = function ( normal, constant ) {
 
-	var zeroPoint = new THREE.Vector3();
+	this.normal = normal || new THREE.Vector3();
+	this.constant = constant || 0;
 
-	THREE.Plane = function ( normal, constant ) {
+};
 
-		this.normal = normal || new THREE.Vector3();
-		this.constant = constant || 0;
+THREE.Plane.fromNormalAndCoplanarPoint = function ( normal, point ) {
+	// NOTE: This function doens't support optional parameters like the constructor.
 
-	};
+	return new THREE.Plane( 
+		normal,
+		- point.dot( normal )
+		);
+};
 
-	THREE.Plane.fromNormalAndCoplanarPoint = function ( normal, point ) {
-		// NOTE: This function doens't support optional parameters like the constructor.
+THREE.Plane.fromCoplanarPoints = function ( a, b, c ) {
+	// NOTE: This function doens't support optional parameters like the constructor.
 
-		return new THREE.Plane( 
-			normal,
-			- point.dot( normal )
-			);
-	};
+	var normal = new THREE.Vector3().sub( b, a ).cross(
+		new THREE.Vector3().sub( c, a ) );
 
-	THREE.Plane.fromCoplanarPoints = function ( a, b, c ) {
-		// NOTE: This function doens't support optional parameters like the constructor.
+	// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
 
-		var normal = new THREE.Vector3().sub( b, a ).cross(
-			new THREE.Vector3().sub( c, a ) );
+	return THREE.Plane.fromNormalAndCoplanarPoint( normal, a );
+};
 
-		// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
+THREE.Plane.prototype = {
 
-		return THREE.Plane.fromNormalAndCoplanarPoint( normal, a );
-	};
+	constructor: THREE.Plane,
 
-	THREE.Plane.prototype.set = function ( normal, constant ) {
+	set: function ( normal, constant ) {
 
 		this.normal = normal;
 		this.constant = constant;
 
 		return this;
-	};
+	},
 
-	THREE.Plane.prototype.setComponents = function ( x, y, z, w ) {
+	setComponents: function ( x, y, z, w ) {
 
 		this.normal.set( x, y, z );
 		this.constant = w;
 
 		return this;
-	};
+	},
 
-	THREE.Plane.prototype.copy = function ( plane ) {
+	copy: function ( plane ) {
 
 		this.normal = plane.normal;
 		this.constant = plane.constant;
 
 		return this;
-	};
+	},
 
-	THREE.Plane.prototype.flip = function () {
+	flip: function () {
 
 		// Note: can also be flipped by inverting constant, but I like constant to stay positive generally.
 		this.normal.negate();
 
 		return this;
-	};
+	},
 
-	THREE.Plane.prototype.normalize = function () {
+	normalize: function () {
 
 		// Note: will lead to a divide by zero if the plane is invalid.
 		var inverseNormalLength = 1.0 / this.normal.length();
@@ -73,52 +73,52 @@
 		this.constant *= inverseNormalLength;
 
 		return this;
-	};
+	},
 
-	THREE.Plane.prototype.distanceToPoint = function ( point ) {
+	distanceToPoint: function ( point ) {
 
 		return this.normal.dot( point ) + this.constant;
-	};
+	},
 
-	THREE.Sphere.prototype.distanceToSphere = function ( sphere ) {
+	distanceToSphere: function ( sphere ) {
 
 		return this.distanceToPoint( sphere.center ) - sphere.radius;
-	};
+	},
 
-	THREE.Plane.prototype.projectPoint = function ( point ) {		
+	projectPoint: function ( point ) {		
 		
 		// TODO: optimize this by expanding and simplifying
 		
 		return new THREE.Vector3().copy( point ).sub( this.orthoPoint( point ) );
-	};
+	},
 
-	THREE.Plane.prototype.orthoPoint = function ( point ) {		
+	orthoPoint: function ( point ) {		
 
 		var perpendicularMagnitude = this.distanceToPoint( point );
 
 		return new THREE.Vector3().copy( this.normal ).multipleByScalar( perpendicularMagnitude );
-	};
+	},
 
-	THREE.Plane.prototype.intersectsLine = function ( startPoint, endPoint ) {	
+	intersectsLine: function ( startPoint, endPoint ) {	
 
 		// Note: this tests if a line intersects the plane, not whether it (or its end-points) are coplanar with it.
 		var startSign = this.distanceToPoint( startPoint );
 		var endSign = this.distanceToPoint( endPoint );
 
 		return ( startSign < 0 && endSign > 0 ) || ( endSign < 0 && startSign > 0 );
-	};
+	},
 
-	THREE.Plane.prototype.coplanarPoint = function () {		
+	coplanarPoint: function () {		
 		
 		return new THREE.Vector3().copy( this.normal ).multiplyScalar( - this.constant );
-	};
+	},
 
-	THREE.Plane.prototype.translate = function ( offset ) {
+	translate: function ( offset ) {
 
 		// TODO: test this.
 		this.constant =	- offset.dot( normal );
 
 		return this;
-	};
+	}
 
-}( THREE ) );
+};

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -51,7 +51,7 @@ THREE.Plane.prototype = {
 	copy: function ( plane ) {
 
 		this.normal.copy( plane.normal );
-		this.constant = new Number( plane.constant );
+		this.constant = plane.constant;
 
 		return this;
 	},
@@ -85,9 +85,7 @@ THREE.Plane.prototype = {
 
 	projectPoint: function ( point ) {		
 		
-		// TODO: optimize this by expanding and simplifying
-		
-		return new THREE.Vector3().copy( point ).sub( this.orthoPoint( point ) );
+		return this.orthoPoint( point ).subSelf( point ).negate();
 	},
 
 	orthoPoint: function ( point ) {		

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -1,5 +1,5 @@
 /**
- * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
+ * @author bhouston / http://exocortex.com
  */
 
 THREE.Plane = function ( normal, constant ) {

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -50,8 +50,8 @@ THREE.Plane.prototype = {
 
 	copy: function ( plane ) {
 
-		this.normal = plane.normal;
-		this.constant = plane.constant;
+		this.normal.copy( plane.normal );
+		this.constant = plane.constant.clone();
 
 		return this;
 	},

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -70,7 +70,7 @@ THREE.Plane.prototype = {
 
 		// Note: will lead to a divide by zero if the plane is invalid.
 		var inverseNormalLength = 1.0 / this.normal.length();
-		this.normal.multipleByScalar( inverseNormalLength );
+		this.normal.multiplyScalar( inverseNormalLength );
 		this.constant *= inverseNormalLength;
 
 		return this;
@@ -97,7 +97,7 @@ THREE.Plane.prototype = {
 
 		var perpendicularMagnitude = this.distanceToPoint( point );
 
-		return new THREE.Vector3().copy( this.normal ).multipleByScalar( perpendicularMagnitude );
+		return new THREE.Vector3().copy( this.normal ).multiplyScalar( perpendicularMagnitude );
 	},
 
 	intersectsLine: function ( startPoint, endPoint ) {	

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -30,7 +30,6 @@ THREE.Plane.prototype = {
 	},
 
 	setFromNormalAndCoplanarPoint: function ( normal, point ) {
-		// NOTE: This function doens't support optional parameters like the constructor.
 
 		this.normal = normal;
 		this.constant = - point.dot( normal );
@@ -39,7 +38,6 @@ THREE.Plane.prototype = {
 	},
 
 	setFromCoplanarPoints: function ( a, b, c ) {
-		// NOTE: This function doens't support optional parameters like the constructor.
 
 		var normal = new THREE.Vector3().sub( b, a ).cross(
 			new THREE.Vector3().sub( c, a ) );
@@ -60,7 +58,6 @@ THREE.Plane.prototype = {
 
 	flip: function () {
 
-		// Note: can also be flipped by inverting constant, but I like constant to stay positive generally.
 		this.normal.negate();
 
 		return this;
@@ -116,7 +113,6 @@ THREE.Plane.prototype = {
 
 	translate: function ( offset ) {
 
-		// TODO: test this.
 		this.constant =	- offset.dot( normal );
 
 		return this;

--- a/src/core/Plane.js
+++ b/src/core/Plane.js
@@ -31,6 +31,14 @@
 		return this;
 	};
 
+	THREE.Plane.prototype.copy = function ( plane ) {
+
+		this.normal = plane.normal;
+		this.constant = plane.constant;
+
+		return this;
+	};
+
 	THREE.Plane.prototype.flip = function () {
 
 		// Note: can also be flipped by inverting constant, but I like constant to stay positive generally.
@@ -58,7 +66,7 @@
 
 		var perpendicularMagnitude = this.distanceToPoint( point );
 
-		return new THREE.Vector3(
+		return new THREE.Vector3( 
 			point.x - this.normal.x * perpendicularMagnitude,
 			point.y - this.normal.y * perpendicularMagnitude,
 			point.z - this.normal.z * perpendicularMagnitude
@@ -69,11 +77,7 @@
 
 		var perpendicularMagnitude = this.distanceToPoint( point );
 
-		return new THREE.Vector3(
-			this.normal.x * perpendicularMagnitude,
-			this.normal.y * perpendicularMagnitude,
-			this.normal.z * perpendicularMagnitude
-			);
+		return new THREE.Vector3().copy( this.normal ).multipleByScalar( perpendicularMagnitude );
 	};
 
 	THREE.Plane.prototype.intersectsLine = function ( startPoint, endPoint ) {	
@@ -87,7 +91,7 @@
 
 	THREE.Plane.prototype.coplanarPoint = function () {		
 		
-		return this.projectPoint( new THREE.Vector3( 0,0,0 ) );
+		return this.projectPoint( new THREE.Vector3( 0, 0, 0 ) );
 	};
 
 }( THREE ) );

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -67,15 +67,15 @@ THREE.Sphere.prototype = {
 
 		var deltaLengthSq = this.center.distanceToSquared( point );
 
+		var result = new THREE.Vector3().copy( point );
+
 		if( deltaLengthSq > ( this.radius * this.radius ) ) {
 
-			var delta = new THREE.Vector3().sub( point, center ).normalize();
-			delta.multiplyScalar( this.radius ).addSelf( this.center );
-
-			return delta;
+			result.subSelf( center ).normalize();
+			result.multiplyScalar( this.radius ).addSelf( this.center );
 		}
 
-		return point;
+		return result;
 	},
 
 	bounds: function () {

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -6,7 +6,7 @@
 
 	var sphereVolumeConstant = Math.PI * 4 / 3;
 	var square = function( x ) { return x*x; }
-	var cube = function( x ) { return x*x; }
+	var cube = function( x ) { return x*x*x; }
 
 	THREE.Sphere = function ( center, radius ) {
 
@@ -16,9 +16,8 @@
 	};
 
 	THREE.Sphere.fromCenterAndPoints = function ( center, points ) {
-		var maxRadiusSq = 0;
-		var delta = new THREE.Vector3().copy( center );
 
+		var maxRadiusSq = 0;
 		for ( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {			
 			var radiusSq = center.distanceToSquared( points[i] );
 			maxRadiusSq = Math.max( maxRadiusSq, radiusSq );
@@ -71,7 +70,7 @@
 		if( deltaLengthSq > square( this.radius ) ) {
 
 			var delta = new THREE.Vector3().sub( point, center ).normalize();
-			delta.multiplyByScalar( this.radius ).addSelf( this.center );
+			delta.multiplyScalar( this.radius ).addSelf( this.center );
 
 			return delta;
 		}
@@ -90,6 +89,13 @@
 	THREE.Sphere.prototype.translate = function ( offset ) {
 
 		this.center.addSelf( this.offset );
+		
+		return this;
+	};
+
+	THREE.Sphere.prototype.scale = function ( factor ) {
+
+		this.radius *= factor;
 		
 		return this;
 	};

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -1,5 +1,5 @@
 /**
- * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
+ * @author bhouston / http://exocortex.com
  */
 
 THREE.Sphere = function ( center, radius ) {

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -4,6 +4,10 @@
 
 ( function ( THREE ) {
 
+	var sphereVolumeConstant = Math.PI * 4 / 3;
+	var square = function( x ) { return x*x; }
+	var cube = function( x ) { return x*x; }
+
 	THREE.Sphere = function ( center, radius ) {
 
 		this.center = center || new THREE.Vector3();
@@ -27,22 +31,20 @@
 		return this;
 	};
 
-
 	THREE.Sphere.prototype.empty = function () {
 
 		return ( this.radius <= 0 );
 
 	};
 
-
 	THREE.Sphere.prototype.volume = function () {
 
-		return Math.PI * 4 / 3 * this.radius * this.radius * this.radius;
+		return sphereVolumeConstant * cube( this.radius );
 	};
 
 	THREE.Sphere.prototype.containsPoint = function ( point ) {
 
-		return ( point.distanceToSquared( this.center ) <= this.radius * this.radius );
+		return ( point.distanceToSquared( this.center ) <= square( this.radius ) );
 	};
 
 	THREE.Sphere.prototype.distanceToPoint = function ( point ) {
@@ -54,7 +56,7 @@
 
 		var deltaLengthSq = this.center.distanceToSquared( point );
 
-		if( deltaLengthSq > ( this.radius*this.radius ) ) {
+		if( deltaLengthSq > square( this.radius ) ) {
 
 			var delta = new THREE.Vector3().sub( point, center ).normalize();
 			delta.multiplyByScalar( this.radius ).addSelf( this.center );

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -38,7 +38,7 @@ THREE.Sphere.prototype = {
 	copy: function ( sphere ) {
 
 		this.center.copy( sphere.center );
-		this.radius = sphere.radius.clone();
+		this.radius = sphere.radius;
 
 		return this;
 	},

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -38,36 +38,28 @@
 	THREE.Sphere.prototype.volume = function () {
 
 		return Math.PI * 4 / 3 * this.radius * this.radius * this.radius;
-
 	};
 
 	THREE.Sphere.prototype.containsPoint = function ( point ) {
 
-		var distanceSq = new THREE.VEctor3().sub( point, this.center ).lengthSq();
-
-		return ( distanceSq <= this.radius * this.radius );
+		return ( point.distanceToSquared( this.center ) <= this.radius * this.radius );
 	};
 
 	THREE.Sphere.prototype.distanceToPoint = function ( point ) {
 
-		var distanceSq = new THREE.Vector3().sub( point, this.center ).length();
-
-		return ( distanceSq - this.radius );
+		return ( point.distanceTo( this.center ) - this.radius );
 	};
 
 	THREE.Sphere.prototype.clampPoint = function ( point ) {
 
-		// NOTE: There is likely a more optimal way of doing this.
-
-		var delta = new THREE.Vector3().sub( point, this.center );
-
-		var deltaLengthSq = delta.lengthSq();
+		var deltaLengthSq = this.center.distanceToSquared( point );
 
 		if( deltaLengthSq > ( this.radius*this.radius ) ) {
 
-			delta.normalize().multiplyByScalar( this.radius ).addSelf( this.center );
-			return delta;
+			var delta = new THREE.Vector3().sub( point, center ).normalize();
+			delta.multiplyByScalar( this.radius ).addSelf( this.center );
 
+			return delta;
 		}
 
 		return point;

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -2,72 +2,69 @@
  * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
  */
 
-( function ( THREE ) {
+THREE.Sphere = function ( center, radius ) {
 
-	var sphereVolumeConstant = Math.PI * 4 / 3;
-	var square = function( x ) { return x*x; }
-	var cube = function( x ) { return x*x*x; }
+	this.center = center || new THREE.Vector3();
+	this.radius = radius || 0;
 
-	THREE.Sphere = function ( center, radius ) {
+};
 
-		this.center = center || new THREE.Vector3();
-		this.radius = radius || 0;
+THREE.Sphere.fromCenterAndPoints = function ( center, points ) {
 
-	};
+	var maxRadiusSq = 0;
+	for ( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {			
+		var radiusSq = center.distanceToSquared( points[i] );
+		maxRadiusSq = Math.max( maxRadiusSq, radiusSq );
+	}
 
-	THREE.Sphere.fromCenterAndPoints = function ( center, points ) {
+	return new THREE.Sphere( center, Math.sqrt( maxRadiusSq ) );
+};
 
-		var maxRadiusSq = 0;
-		for ( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {			
-			var radiusSq = center.distanceToSquared( points[i] );
-			maxRadiusSq = Math.max( maxRadiusSq, radiusSq );
-		}
+THREE.Sphere.prototype = {
 
-		return new THREE.Sphere( center, Math.sqrt( maxRadiusSq ) );
-	};
+	constructor: THREE.Sphere,
 
-	THREE.Sphere.prototype.set = function ( center, radius ) {
+	set: function ( center, radius ) {
 
 		this.center = center;
 		this.radius = radius;
 
 		return this;
-	};
+	},
 
-	THREE.Sphere.prototype.copy = function ( sphere ) {
+	copy: function ( sphere ) {
 
 		this.center = sphere.center;
 		this.radius = sphere.radius;
 
 		return this;
-	};
+	},
 
-	THREE.Sphere.prototype.empty = function () {
+	empty: function () {
 
 		return ( this.radius <= 0 );
+	},
 
-	};
+	volume: function () {
 
-	THREE.Sphere.prototype.volume = function () {
+		return Math.PI * 4 / 3 * ( this.radius * this.radius * this.radius );
+	},
 
-		return sphereVolumeConstant * cube( this.radius );
-	};
+	containsPoint: function ( point ) {
 
-	THREE.Sphere.prototype.containsPoint = function ( point ) {
+		return ( point.distanceToSquared( this.center ) <= ( this.radius * this.radius ) );
+	},
 
-		return ( point.distanceToSquared( this.center ) <= square( this.radius ) );
-	};
-
-	THREE.Sphere.prototype.distanceToPoint = function ( point ) {
+	distanceToPoint: function ( point ) {
 
 		return ( point.distanceTo( this.center ) - this.radius );
-	};
+	},
 
-	THREE.Sphere.prototype.clampPoint = function ( point ) {
+	clampPoint: function ( point ) {
 
 		var deltaLengthSq = this.center.distanceToSquared( point );
 
-		if( deltaLengthSq > square( this.radius ) ) {
+		if( deltaLengthSq > ( this.radius * this.radius ) ) {
 
 			var delta = new THREE.Vector3().sub( point, center ).normalize();
 			delta.multiplyScalar( this.radius ).addSelf( this.center );
@@ -76,28 +73,28 @@
 		}
 
 		return point;
-	};
+	},
 
-	THREE.Sphere.prototype.bounds = function () {
+	bounds: function () {
 
 		var box =  new THREE.Box3( this.center, this.center );
 		box.expandByScalar( this.radius );
 
 		return box;
-	};
+	},
 
-	THREE.Sphere.prototype.translate = function ( offset ) {
+	translate: function ( offset ) {
 
 		this.center.addSelf( this.offset );
 		
 		return this;
-	};
+	},
 
-	THREE.Sphere.prototype.scale = function ( factor ) {
+	scale: function ( factor ) {
 
 		this.radius *= factor;
 		
 		return this;
-	};
+	}
 
-}( THREE ) );
+};

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -15,6 +15,18 @@
 
 	};
 
+	THREE.Sphere.fromCenterAndPoints = function ( center, points ) {
+		var maxRadiusSq = 0;
+		var delta = new THREE.Vector3().copy( center );
+
+		for ( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {			
+			var radiusSq = center.distanceToSquared( points[i] );
+			maxRadiusSq = Math.max( maxRadiusSq, radiusSq );
+		}
+
+		return new THREE.Sphere( center, Math.sqrt( maxRadiusSq ) );
+	};
+
 	THREE.Sphere.prototype.set = function ( center, radius ) {
 
 		this.center = center;

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -19,6 +19,15 @@
 		return this;
 	};
 
+	THREE.Sphere.prototype.copy = function ( sphere ) {
+
+		this.center = sphere.center;
+		this.radius = sphere.radius;
+
+		return this;
+	};
+
+
 	THREE.Sphere.prototype.empty = function () {
 
 		return ( this.radius <= 0 );
@@ -28,33 +37,29 @@
 
 	THREE.Sphere.prototype.volume = function () {
 
-		// NOTE: would love to replace r*r*r with a helper cube(r), but may be much slower
 		return Math.PI * 4 / 3 * this.radius * this.radius * this.radius;
 
 	};
 
 	THREE.Sphere.prototype.containsPoint = function ( point ) {
 
-		var delta = new THREE.VEctor3();
-		var distanceSq = delta.sub( point, this.center ).lengthSq();
+		var distanceSq = new THREE.VEctor3().sub( point, this.center ).lengthSq();
 
 		return ( distanceSq <= this.radius * this.radius );
 	};
 
 	THREE.Sphere.prototype.distanceToPoint = function ( point ) {
 
-		var delta = new THREE.VEctor3();
-		var distanceSq = delta.sub( point, this.center ).length();
+		var distanceSq = new THREE.Vector3().sub( point, this.center ).length();
 
-		return ( distanceSq - this.radius  );
+		return ( distanceSq - this.radius );
 	};
 
 	THREE.Sphere.prototype.clampPoint = function ( point ) {
 
 		// NOTE: There is likely a more optimal way of doing this.
 
-		var delta = new THREE.VEctor3();
-		delta.sub( point, this.center );
+		var delta = new THREE.Vector3().sub( point, this.center );
 
 		var deltaLengthSq = delta.lengthSq();
 
@@ -70,7 +75,7 @@
 
 	THREE.Sphere.prototype.bounds = function () {
 
-		var box =  new THREE.Box3( this.center );
+		var box =  new THREE.Box3( this.center, this.center );
 		box.expandByScalar( this.radius );
 
 		return box;
@@ -78,7 +83,7 @@
 
 	THREE.Sphere.prototype.translate = function ( offset ) {
 
-		this.center.add( this.center, this.offset );
+		this.center.addSelf( this.offset );
 		
 		return this;
 	};

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -9,17 +9,6 @@ THREE.Sphere = function ( center, radius ) {
 
 };
 
-THREE.Sphere.fromCenterAndPoints = function ( center, points ) {
-
-	var maxRadiusSq = 0;
-	for ( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {			
-		var radiusSq = center.distanceToSquared( points[i] );
-		maxRadiusSq = Math.max( maxRadiusSq, radiusSq );
-	}
-
-	return new THREE.Sphere( center, Math.sqrt( maxRadiusSq ) );
-};
-
 THREE.Sphere.prototype = {
 
 	constructor: THREE.Sphere,
@@ -28,6 +17,20 @@ THREE.Sphere.prototype = {
 
 		this.center = center;
 		this.radius = radius;
+
+		return this;
+	},
+
+	setFromCenterAndPoints: function ( center, points ) {
+
+		var maxRadiusSq = 0;
+		for ( var i = 0, numPoints = points.length; i < numPoints; i ++ ) {			
+			var radiusSq = center.distanceToSquared( points[i] );
+			maxRadiusSq = Math.max( maxRadiusSq, radiusSq );
+		}
+
+		this.center = center;
+		this.radius = Math.sqrt( maxRadiusSq );
 
 		return this;
 	},

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -1,0 +1,86 @@
+/**
+ * @author Ben Houston / ben@exocortex.com / http://github.com/bhouston
+ */
+
+( function ( THREE ) {
+
+	THREE.Sphere = function ( center, radius ) {
+
+		this.center = center || new THREE.Vector3();
+		this.radius = radius || 0;
+
+	};
+
+	THREE.Sphere.prototype.set = function ( center, radius ) {
+
+		this.center = center;
+		this.radius = radius;
+
+		return this;
+	};
+
+	THREE.Sphere.prototype.empty = function () {
+
+		return ( this.radius <= 0 );
+
+	};
+
+
+	THREE.Sphere.prototype.volume = function () {
+
+		// NOTE: would love to replace r*r*r with a helper cube(r), but may be much slower
+		return Math.PI * 4 / 3 * this.radius * this.radius * this.radius;
+
+	};
+
+	THREE.Sphere.prototype.containsPoint = function ( point ) {
+
+		var delta = new THREE.VEctor3();
+		var distanceSq = delta.sub( point, this.center ).lengthSq();
+
+		return ( distanceSq <= this.radius * this.radius );
+	};
+
+	THREE.Sphere.prototype.distanceToPoint = function ( point ) {
+
+		var delta = new THREE.VEctor3();
+		var distanceSq = delta.sub( point, this.center ).length();
+
+		return ( distanceSq - this.radius  );
+	};
+
+	THREE.Sphere.prototype.clampPoint = function ( point ) {
+
+		// NOTE: There is likely a more optimal way of doing this.
+
+		var delta = new THREE.VEctor3();
+		delta.sub( point, this.center );
+
+		var deltaLengthSq = delta.lengthSq();
+
+		if( deltaLengthSq > ( this.radius*this.radius ) ) {
+
+			delta.normalize().multiplyByScalar( this.radius ).addSelf( this.center );
+			return delta;
+
+		}
+
+		return point;
+	};
+
+	THREE.Sphere.prototype.bounds = function () {
+
+		var box =  new THREE.Box3( this.center );
+		box.expandByScalar( this.radius );
+
+		return box;
+	};
+
+	THREE.Sphere.prototype.translate = function ( offset ) {
+
+		this.center.add( this.center, this.offset );
+		
+		return this;
+	};
+
+}( THREE ) );

--- a/src/core/Sphere.js
+++ b/src/core/Sphere.js
@@ -37,8 +37,8 @@ THREE.Sphere.prototype = {
 
 	copy: function ( sphere ) {
 
-		this.center = sphere.center;
-		this.radius = sphere.radius;
+		this.center.copy( sphere.center );
+		this.radius = sphere.radius.clone();
 
 		return this;
 	},

--- a/src/core/Vector2.js
+++ b/src/core/Vector2.js
@@ -96,6 +96,53 @@ THREE.Vector2.prototype = {
 
 	},
 
+	minSelf: function ( v ) {
+
+		if( this.x > min.x ) {
+			this.x = min.x;
+		}
+		if( this.y > min.y ) {
+			this.y = min.y;
+		}
+
+		return this;
+
+	},
+
+	maxSelf: function ( v ) {
+
+		if( this.x < max.x ) {
+			this.x = max.x;
+		}
+		if( this.y < max.y ) {
+			this.y = max.y;
+		}
+
+		return this;
+
+	},
+
+	clampSelf: function ( min, max ) {
+
+		// This function assumes min < max, if this assumption isn't true it will not operate correctly
+
+		if( this.x < min.x ) {
+			this.x = min.x;
+		}
+		else if( this.x > max.x ) {
+			this.x = max.x;
+		}
+
+		if( this.y < min.y ) {
+			this.y = min.y;
+		}
+		else if( this.y > max.y ) {
+			this.y = max.y;
+		}
+
+		return this;
+	},
+
 	negate: function() {
 
 		return this.multiplyScalar( - 1 );

--- a/src/core/Vector3.js
+++ b/src/core/Vector3.js
@@ -174,6 +174,25 @@ THREE.Vector3.prototype = {
 
 	},
 
+	minSelf: function ( v ) {
+
+		this.x = Math.min( this.x, v.x );
+		this.y = Math.min( this.y, v.y );
+		this.z = Math.min( this.z, v.z );
+
+		return this;
+
+	},
+
+	maxSelf: function ( v ) {
+
+		this.x = Math.max( this.x, v.x );
+		this.y = Math.max( this.y, v.y );
+		this.z = Math.max( this.z, v.z );
+
+		return this;
+
+	},
 
 	negate: function() {
 

--- a/src/core/Vector3.js
+++ b/src/core/Vector3.js
@@ -176,9 +176,15 @@ THREE.Vector3.prototype = {
 
 	minSelf: function ( v ) {
 
-		this.x = Math.min( this.x, v.x );
-		this.y = Math.min( this.y, v.y );
-		this.z = Math.min( this.z, v.z );
+		if( this.x > min.x ) {
+			this.x = min.x;
+		}
+		if( this.y > min.y ) {
+			this.y = min.y;
+		}
+		if( this.z > min.z ) {
+			this.z = min.z;
+		}
 
 		return this;
 
@@ -186,12 +192,46 @@ THREE.Vector3.prototype = {
 
 	maxSelf: function ( v ) {
 
-		this.x = Math.max( this.x, v.x );
-		this.y = Math.max( this.y, v.y );
-		this.z = Math.max( this.z, v.z );
+		if( this.x < max.x ) {
+			this.x = max.x;
+		}
+		if( this.y < max.y ) {
+			this.y = max.y;
+		}
+		if( this.z < max.z ) {
+			this.z = max.z;
+		}
 
 		return this;
 
+	},
+
+	clampSelf: function ( min, max ) {
+
+		// This function assumes min < max, if this assumption isn't true it will not operate correctly
+
+		if( this.x < min.x ) {
+			this.x = min.x;
+		}
+		else if( this.x > max.x ) {
+			this.x = max.x;
+		}
+
+		if( this.y < min.y ) {
+			this.y = min.y;
+		}
+		else if( this.y > max.y ) {
+			this.y = max.y;
+		}
+
+		if( this.z < min.z ) {
+			this.z = min.z;
+		}
+		else if( this.z > max.z ) {
+			this.z = max.z;
+		}
+
+		return this;
 	},
 
 	negate: function() {

--- a/src/core/Vector4.js
+++ b/src/core/Vector4.js
@@ -118,6 +118,78 @@ THREE.Vector4.prototype = {
 
 	},
 
+	minSelf: function ( v ) {
+
+		if( this.x > min.x ) {
+			this.x = min.x;
+		}
+		if( this.y > min.y ) {
+			this.y = min.y;
+		}
+		if( this.z > min.z ) {
+			this.z = min.z;
+		}
+		if( this.w > min.w ) {
+			this.w = min.w;
+		}
+
+		return this;
+
+	},
+
+	maxSelf: function ( v ) {
+
+		if( this.x < max.x ) {
+			this.x = max.x;
+		}
+		if( this.y < max.y ) {
+			this.y = max.y;
+		}
+		if( this.z < max.z ) {
+			this.z = max.z;
+		}
+		if( this.w < max.w ) {
+			this.w = max.w;
+		}
+
+		return this;
+
+	},
+
+	clampSelf: function ( min, max ) {
+
+		// This function assumes min < max, if this assumption isn't true it will not operate correctly
+
+		if( this.x < min.x ) {
+			this.x = min.x;
+		}
+		else if( this.x > max.x ) {
+			this.x = max.x;
+		}
+
+		if( this.y < min.y ) {
+			this.y = min.y;
+		}
+		else if( this.y > max.y ) {
+			this.y = max.y;
+		}
+
+		if( this.z < min.z ) {
+			this.z = min.z;
+		}
+		else if( this.z > max.z ) {
+			this.z = max.z;
+		}
+
+		if( this.w < min.w ) {
+			this.w = min.w;
+		}
+		else if( this.w > max.w ) {
+			this.w = max.w;
+		}
+
+		return this;
+	},
 
 	negate: function() {
 

--- a/utils/includes/common.json
+++ b/utils/includes/common.json
@@ -13,6 +13,7 @@
 	"../src/core/Plane.js",
 	"../src/core/Ray.js",
 	"../src/core/Rectangle.js",
+	"../src/core/Sphere.js",
 	"../src/core/Math.js",
 	"../src/core/Object3D.js",
 	"../src/core/Projector.js",

--- a/utils/includes/common.json
+++ b/utils/includes/common.json
@@ -1,5 +1,6 @@
 [
 	"../src/Three.js",
+	"../src/core/Box3.js",
 	"../src/core/Clock.js",
 	"../src/core/Color.js",
 	"../src/core/Vector2.js",

--- a/utils/includes/common.json
+++ b/utils/includes/common.json
@@ -1,11 +1,11 @@
 [
 	"../src/Three.js",
-	"../src/core/Box3.js",
 	"../src/core/Clock.js",
 	"../src/core/Color.js",
 	"../src/core/Vector2.js",
 	"../src/core/Vector3.js",
 	"../src/core/Vector4.js",
+	"../src/core/Box3.js",
 	"../src/core/Matrix3.js",
 	"../src/core/Matrix4.js",
 	"../src/core/EventTarget.js",

--- a/utils/includes/common.json
+++ b/utils/includes/common.json
@@ -10,6 +10,7 @@
 	"../src/core/Matrix4.js",
 	"../src/core/EventTarget.js",
 	"../src/core/Frustum.js",
+	"../src/core/Plane.js",
 	"../src/core/Ray.js",
 	"../src/core/Rectangle.js",
 	"../src/core/Math.js",

--- a/utils/includes/common.json
+++ b/utils/includes/common.json
@@ -5,6 +5,7 @@
 	"../src/core/Vector2.js",
 	"../src/core/Vector3.js",
 	"../src/core/Vector4.js",
+	"../src/core/Box2.js",
 	"../src/core/Box3.js",
 	"../src/core/Matrix3.js",
 	"../src/core/Matrix4.js",


### PR DESCRIPTION
This PR addresses these GitHub issues:
#2709 - Box3 class specification (Axis Aligned Bounding Box)
#2708 - Sphere class specifications
#2706 - Plane class specifications
#2715 - Vector3.minSelf, maxSelf - simplifies bounding box calculations in various places.

The new classes work and I integrated them into both Frustum.js and Geometry.js.

In integrating Box3 and Sphere into Geometry for boundingBox and boundingSphere respectively, I did so in a way that didn't change the JavaScript data structures used -- there is still a radius on boundingSphere and there is still min/max on boundingBox.  It is just that these two member properties (boundingBox and boundingSphere) are now proper classes.

I have made an effort to copy the existing style in Threejs with naming conventions as well as code organization.  I believe these classes look like they belong in Threejs.

Code reviewed by @chandlerprall (via IRC) and @wvl (off list) 
