### PR TITLE
Make Loader respect transparent property on normal mapped materials.

### DIFF
--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -420,6 +420,12 @@ THREE.Loader.prototype = {
 			var parameters = { fragmentShader: shader.fragmentShader, vertexShader: shader.vertexShader, uniforms: uniforms, lights: true, fog: true };
 			var material = new THREE.ShaderMaterial( parameters );
 
+			if ( mpars.transparent ) {
+
+				material.transparent = true;
+
+			}
+
 		} else {
 
 			var material = new THREE[ mtype ]( mpars );


### PR DESCRIPTION
Noticed that my model which has a png texture with alpha channel got broken (no alpha) when updating to latest `dev` branch. After a little digging, I found out the cause is e5759e5a56a6460. However, that actually revealed a bug: loading a normal mapped material does not respect the `transparent` property. This patch should fix that.

As an aside, it has now been several times that loading normal mapped materials has bitten me fro various reasons. In the past I've on several occasions patched my version of three.js to ignore the Loader's special case for normal maps and just let it use Phong (which also has normal maps these days). This has proven much more robust as Phong hasn't yet failed me. Also, Phong is much more maintained whereas the special normal map shader seems to get less attention. Thus, I would propose using Phong in loader with normal mapped materials.
