### PR TITLE
Don't use for in to iterate arrays.

### DIFF
--- a/src/core/EventTarget.js
+++ b/src/core/EventTarget.js
@@ -22,15 +22,23 @@ THREE.EventTarget = function () {
 
 	};
 
+
 	this.dispatchEvent = function ( event ) {
 
-		for ( var listener in listeners[ event.type ] ) {
+		var listener, i, length, ref;
 
-			listeners[ event.type ][ listener ]( event );
+		ref = listeners[ event.type ];
+		
+		for (i = 0, length = ref.length; i < length; i++) {
+		
+			listener = ref[ i ];
+		
+			listener( event );
 
 		}
 
 	};
+
 
 	this.removeEventListener = function ( type, listener ) {
 


### PR DESCRIPTION
This allows three.js to work with projects where Array.prototype has been extended with additional methods.
