### PR TITLE
Fixed vector typo in Boid example.

### DIFF
--- a/examples/canvas_geometry_birds.html
+++ b/examples/canvas_geometry_birds.html
@@ -62,7 +62,7 @@
 				this.setWorldSize = function ( width, height, depth ) {
 
 					_width = width;
-					_height = height;vector
+					_height = height;
 					_depth = depth;
 
 				}


### PR DESCRIPTION
Fixes a minor and non-error generating typo in the `Boid` example code.
