### PR TITLE
Sphere.bounds()->Sphere.boundingBox(), +Box3.boundingSphere(), +unit tests

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -226,7 +226,7 @@ THREE.Box3.prototype = {
 
 	},
 
-	boundingSphere: function ( optionalTarget ) {
+	getBoundingSphere: function ( optionalTarget ) {
 
 		var result = optionalTarget || new THREE.Sphere();
 		

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -226,6 +226,17 @@ THREE.Box3.prototype = {
 
 	},
 
+	boundingSphere: function ( optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Sphere();
+		
+		result.center = this.center();
+		result.radius = this.size( THREE.Box3.__v0 ).length() * 0.5;;
+
+		return result;
+
+	},
+
 	intersect: function ( box ) {
 
 		this.min.maxSelf( box.min );

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -85,7 +85,7 @@ THREE.Sphere.prototype = {
 
 	},
 
-	boundingBox: function ( optionalTarget ) {
+	getBoundingBox: function ( optionalTarget ) {
 
 		var box = optionalTarget || new THREE.Box3();
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -85,7 +85,7 @@ THREE.Sphere.prototype = {
 
 	},
 
-	bounds: function ( optionalTarget ) {
+	boundingBox: function ( optionalTarget ) {
 
 		var box = optionalTarget || new THREE.Box3();
 

--- a/test/math/Box3.js
+++ b/test/math/Box3.js
@@ -208,14 +208,14 @@ test( "isIntersectionBox", function() {
 	ok( ! b.isIntersectionBox( c ), "Passed!" );
 });
 
-test( "boundingSphere", function() {
+test( "getBoundingSphere", function() {
 	var a = new THREE.Box3( zero3, zero3 );
 	var b = new THREE.Box3( zero3, one3 );
 	var c = new THREE.Box3( one3.clone().negate(), one3 );
 
-	ok( a.boundingSphere().equals( new THREE.Sphere( zero3, 0 ) ), "Passed!" );
-	ok( b.boundingSphere().equals( new THREE.Sphere( one3.clone().multiplyScalar( 0.5 ), Math.sqrt( 3 ) * 0.5 ) ), "Passed!" );
-	ok( c.boundingSphere().equals( new THREE.Sphere( zero3, Math.sqrt( 12 ) * 0.5 ) ), "Passed!" );
+	ok( a.getBoundingSphere().equals( new THREE.Sphere( zero3, 0 ) ), "Passed!" );
+	ok( b.getBoundingSphere().equals( new THREE.Sphere( one3.clone().multiplyScalar( 0.5 ), Math.sqrt( 3 ) * 0.5 ) ), "Passed!" );
+	ok( c.getBoundingSphere().equals( new THREE.Sphere( zero3, Math.sqrt( 12 ) * 0.5 ) ), "Passed!" );
 });
 
 test( "intersect", function() {

--- a/test/math/Box3.js
+++ b/test/math/Box3.js
@@ -208,6 +208,16 @@ test( "isIntersectionBox", function() {
 	ok( ! b.isIntersectionBox( c ), "Passed!" );
 });
 
+test( "boundingSphere", function() {
+	var a = new THREE.Box3( zero3, zero3 );
+	var b = new THREE.Box3( zero3, one3 );
+	var c = new THREE.Box3( one3.clone().negate(), one3 );
+
+	ok( a.boundingSphere().equals( new THREE.Sphere( zero3, 0 ) ), "Passed!" );
+	ok( b.boundingSphere().equals( new THREE.Sphere( one3.clone().multiplyScalar( 0.5 ), Math.sqrt( 3 ) * 0.5 ) ), "Passed!" );
+	ok( c.boundingSphere().equals( new THREE.Sphere( zero3, Math.sqrt( 12 ) * 0.5 ) ), "Passed!" );
+});
+
 test( "intersect", function() {
 	var a = new THREE.Box3( zero3, zero3 );
 	var b = new THREE.Box3( zero3, one3 );

--- a/test/math/Sphere.js
+++ b/test/math/Sphere.js
@@ -67,13 +67,13 @@ test( "clampPoint", function() {
 	ok( a.clampPoint( new THREE.Vector3( 1, 1, -3 ) ).equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
 });
 
-test( "bounds", function() {
+test( "boundingBox", function() {
 	var a = new THREE.Sphere( one3, 1 );
 
-	ok( a.bounds().equals( new THREE.Box3( zero3, two3 ) ), "Passed!" );
+	ok( a.boundingBox().equals( new THREE.Box3( zero3, two3 ) ), "Passed!" );
 
 	a.set( zero3, 0 )
-	ok( a.bounds().equals( new THREE.Box3( zero3, zero3 ) ), "Passed!" );
+	ok( a.boundingBox().equals( new THREE.Box3( zero3, zero3 ) ), "Passed!" );
 });
 
 test( "transform", function() {
@@ -83,7 +83,7 @@ test( "transform", function() {
 	var t1 = new THREE.Vector3( 1, -2, 1 );
 	m.makeTranslation( t1 );
 
-	ok( a.clone().transform( m ).bounds().equals( a.bounds().transform( m ) ), "Passed!" );
+	ok( a.clone().transform( m ).boundingBox().equals( a.boundingBox().transform( m ) ), "Passed!" );
 });
 
 test( "translate", function() {

--- a/test/math/Sphere.js
+++ b/test/math/Sphere.js
@@ -67,13 +67,13 @@ test( "clampPoint", function() {
 	ok( a.clampPoint( new THREE.Vector3( 1, 1, -3 ) ).equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
 });
 
-test( "boundingBox", function() {
+test( "getBoundingBox", function() {
 	var a = new THREE.Sphere( one3, 1 );
 
-	ok( a.boundingBox().equals( new THREE.Box3( zero3, two3 ) ), "Passed!" );
+	ok( a.getBoundingBox().equals( new THREE.Box3( zero3, two3 ) ), "Passed!" );
 
 	a.set( zero3, 0 )
-	ok( a.boundingBox().equals( new THREE.Box3( zero3, zero3 ) ), "Passed!" );
+	ok( a.getBoundingBox().equals( new THREE.Box3( zero3, zero3 ) ), "Passed!" );
 });
 
 test( "transform", function() {
@@ -83,7 +83,7 @@ test( "transform", function() {
 	var t1 = new THREE.Vector3( 1, -2, 1 );
 	m.makeTranslation( t1 );
 
-	ok( a.clone().transform( m ).boundingBox().equals( a.boundingBox().transform( m ) ), "Passed!" );
+	ok( a.clone().transform( m ).getBoundingBox().equals( a.getBoundingBox().transform( m ) ), "Passed!" );
 });
 
 test( "translate", function() {


### PR DESCRIPTION
I renamed Sphere.bounds() to Sphere.boundingBox() as I now think that the term "bounds" by itself is ambigious / unclear.

I also created a Box3.boundingSphere().

I needed both of these in some code I am writing and they are very commonly used so I figured I'd throw them in the core math library.

I also wrote unit tests for them to ensure that they work properly.
