### PR TITLE
Adopt THREE.Math.degToRad/radToDeg across the code base & examples.

### DIFF
--- a/examples/canvas_geometry_hierarchy.html
+++ b/examples/canvas_geometry_hierarchy.html
@@ -59,8 +59,8 @@
 					mesh.position.x = Math.random() * 2000 - 1000;
 					mesh.position.y = Math.random() * 2000 - 1000;
 					mesh.position.z = Math.random() * 2000 - 1000;
-					mesh.rotation.x = Math.random() * 360 * ( Math.PI / 180 );
-					mesh.rotation.y = Math.random() * 360 * ( Math.PI / 180 );
+					mesh.rotation.x = Math.random() * 2 * Math.PI;
+					mesh.rotation.y = Math.random() * 2 * Math.PI;
 					mesh.matrixAutoUpdate = false;
 					mesh.updateMatrix();
 					group.add( mesh );
@@ -122,9 +122,10 @@
 				camera.position.y += ( - mouseY - camera.position.y ) * .05;
 				camera.lookAt( scene.position );
 
-				group.rotation.x = Math.sin( Date.now() * 0.0007 ) * 0.5;
-				group.rotation.y = Math.sin( Date.now() * 0.0003 ) * 0.5;
-				group.rotation.z = Math.sin( Date.now() * 0.0002 ) * 0.5;
+				var currentSeconds = Date.now();
+				group.rotation.x = Math.sin( currentSeconds * 0.0007 ) * 0.5;
+				group.rotation.y = Math.sin( currentSeconds * 0.0003 ) * 0.5;
+				group.rotation.z = Math.sin( currentSeconds * 0.0002 ) * 0.5;
 
 				renderer.render( scene, camera );
 

--- a/examples/canvas_geometry_panorama.html
+++ b/examples/canvas_geometry_panorama.html
@@ -208,8 +208,8 @@
 			function render() {
 
 				lat = Math.max( - 85, Math.min( 85, lat ) );
-				phi = ( 90 - lat ) * Math.PI / 180;
-				theta = lon * Math.PI / 180;
+				phi = THREE.Math.degToRad( 90 - lat );
+				theta = THREE.Math.degToRad( lon );
 
 				target.x = 500 * Math.sin( phi ) * Math.cos( theta );
 				target.y = 500 * Math.cos( phi );

--- a/examples/canvas_geometry_panorama_fisheye.html
+++ b/examples/canvas_geometry_panorama_fisheye.html
@@ -236,8 +236,8 @@
 			function render() {
 
 				lat = Math.max( - 85, Math.min( 85, lat ) );
-				phi = ( 90 - lat ) * Math.PI / 180;
-				theta = lon * Math.PI / 180;
+				phi = THREE.Math.degToRad( 90 - lat );
+				theta = THREE.Math.degToRad( lon );
 
 				target.x = 500 * Math.sin( phi ) * Math.cos( theta );
 				target.y = 500 * Math.cos( phi );

--- a/examples/canvas_interactive_cubes.html
+++ b/examples/canvas_interactive_cubes.html
@@ -61,9 +61,9 @@
 					object.scale.y = Math.random() * 2 + 1;
 					object.scale.z = Math.random() * 2 + 1;
 
-					object.rotation.x = ( Math.random() * 360 ) * Math.PI / 180;
-					object.rotation.y = ( Math.random() * 360 ) * Math.PI / 180;
-					object.rotation.z = ( Math.random() * 360 ) * Math.PI / 180;
+					object.rotation.x = Math.random() * 2 * Math.PI;
+					object.rotation.y = Math.random() * 2 * Math.PI;
+					object.rotation.z = Math.random() * 2 * Math.PI;
 
 					scene.add( object );
 
@@ -163,11 +163,11 @@
 
 			function render() {
 
-				theta += 0.2;
+				theta += 0.1;
 
-				camera.position.x = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.y = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.z = radius * Math.cos( theta * Math.PI / 360 );
+				camera.position.x = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.y = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.z = radius * Math.cos( THREE.Math.degToRad( theta ) );
 				camera.lookAt( scene.position );
 
 				renderer.render( scene, camera );

--- a/examples/canvas_interactive_cubes_tween.html
+++ b/examples/canvas_interactive_cubes_tween.html
@@ -58,9 +58,9 @@
 					object.scale.x = Math.random() * 2 + 1;
 					object.scale.y = Math.random() * 2 + 1;
 					object.scale.z = Math.random() * 2 + 1;
-					object.rotation.x = ( Math.random() * 360 ) * Math.PI / 180;
-					object.rotation.y = ( Math.random() * 360 ) * Math.PI / 180;
-					object.rotation.z = ( Math.random() * 360 ) * Math.PI / 180;
+					object.rotation.x = Math.random() * 2 * Math.PI;
+					object.rotation.y = Math.random() * 2 * Math.PI;
+					object.rotation.z = Math.random() * 2 * Math.PI;
 					scene.add( object );
 
 				}
@@ -114,9 +114,9 @@
 					.easing( TWEEN.Easing.Elastic.Out).start();
 
 					new TWEEN.Tween( intersects[ 0 ].object.rotation ).to( {
-						x: ( Math.random() * 360 ) * Math.PI / 180,
-						y: ( Math.random() * 360 ) * Math.PI / 180,
-						z: ( Math.random() * 360 ) * Math.PI / 180 }, 2000 )
+						x: Math.random() * 2 * Math.PI,
+						y: Math.random() * 2 * Math.PI,
+						z: Math.random() * 2 * Math.PI }, 2000 )
 					.easing( TWEEN.Easing.Elastic.Out).start();
 
 				}
@@ -149,11 +149,11 @@
 
 				TWEEN.update();
 
-				theta += 0.2;
+				theta += 0.1;
 
-				camera.position.x = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.y = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.z = radius * Math.cos( theta * Math.PI / 360 );
+				camera.position.x = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.y = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.z = radius * Math.cos( THREE.Math.degToRad( theta ) );
 				camera.lookAt( scene.position );
 
 				renderer.render( scene, camera );

--- a/examples/canvas_interactive_particles.html
+++ b/examples/canvas_interactive_particles.html
@@ -135,11 +135,11 @@
 
 				// rotate camera
 
-				theta += 0.2;
+				theta += 0.1;
 
-				camera.position.x = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.y = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.z = radius * Math.cos( theta * Math.PI / 360 );
+				camera.position.x = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.y = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.z = radius * Math.cos( THREE.Math.degToRad( theta ) );
 				camera.lookAt( scene.position );
 
 				// find intersections

--- a/examples/css3d_panorama.html
+++ b/examples/css3d_panorama.html
@@ -192,8 +192,8 @@
 
 				lon +=  0.1;
 				lat = Math.max( - 85, Math.min( 85, lat ) );
-				phi = ( 90 - lat ) * Math.PI / 180;
-				theta = lon * Math.PI / 180;
+				phi = THREE.Math.degToRad( 90 - lat );
+				theta = THREE.Math.degToRad( lon );
 
 				target.x = Math.sin( phi ) * Math.cos( theta );
 				target.y = Math.cos( phi );

--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -231,8 +231,8 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 			if( this.lookVertical ) this.lat -= this.mouseY * actualLookSpeed; // * this.invertVertical?-1:1;
 
 			this.lat = Math.max( - 85, Math.min( 85, this.lat ) );
-			this.phi = ( 90 - this.lat ) * Math.PI / 180;
-			this.theta = this.lon * Math.PI / 180;
+			this.phi = THREE.Math.degToRad( 90 - this.lat );
+			this.theta = THREE.Math.degToRad( this.lon );
 
 			var targetPosition = this.target,
 				position = this.object.position;
@@ -255,9 +255,9 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 		if( this.lookVertical ) this.lat -= this.mouseY * actualLookSpeed * verticalLookRatio;
 
 		this.lat = Math.max( - 85, Math.min( 85, this.lat ) );
-		this.phi = ( 90 - this.lat ) * Math.PI / 180;
+		this.phi = THREE.Math.degToRad( 90 - this.lat );
 
-		this.theta = this.lon * Math.PI / 180;
+		this.theta = THREE.Math.degToRad( this.lon );
 
 		if ( this.constrainVertical ) {
 

--- a/examples/js/controls/PathControls.js
+++ b/examples/js/controls/PathControls.js
@@ -41,8 +41,7 @@ THREE.PathControls = function ( object, domElement ) {
 	this.phi = 0;
 	this.theta = 0;
 
-	var PI2 = Math.PI * 2,
-		PI180 = Math.PI / 180;
+	var PI2 = Math.PI * 2;
 
 	this.viewHalfX = 0;
 	this.viewHalfY = 0;
@@ -81,8 +80,8 @@ THREE.PathControls = function ( object, domElement ) {
 		this.lon = Math.max( 0, Math.min( 360, this.lon ) );
 		this.lat = Math.max( - 85, Math.min( 85, this.lat ) );
 
-		this.phi = ( 90 - this.lat ) * PI180;
-		this.theta = this.lon * PI180;
+		this.phi = THREE.Math.degToRad( 90 - this.lat );
+		this.theta = THREE.Math.degToRad( this.lon );
 
 		this.phi = normalize_angle_rad( this.phi );
 

--- a/examples/js/effects/AnaglyphEffect.js
+++ b/examples/js/effects/AnaglyphEffect.js
@@ -117,7 +117,7 @@ THREE.AnaglyphEffect = function ( renderer, width, height ) {
 			var projectionMatrix = camera.projectionMatrix.clone();
 			var eyeSep = focalLength / 30 * 0.5;
 			var eyeSepOnProjection = eyeSep * _near / focalLength;
-			var ymax = _near * Math.tan( _fov * Math.PI / 360 );
+			var ymax = _near * Math.tan( THREE.Math.degToRad( _fov * 0.5 ) );
 			var xmin, xmax;
 
 			// translate xOffset

--- a/examples/js/effects/ParallaxBarrierEffect.js
+++ b/examples/js/effects/ParallaxBarrierEffect.js
@@ -118,7 +118,7 @@ THREE.ParallaxBarrierEffect = function ( renderer ) {
 			var projectionMatrix = camera.projectionMatrix.clone();
 			var eyeSep = focalLength / 30 * 0.5;
 			var eyeSepOnProjection = eyeSep * _near / focalLength;
-			var ymax = _near * Math.tan( _fov * Math.PI / 360 );
+			var ymax = _near * Math.tan( THREE.Math.degToRad( _fov * 0.5 ) );
 			var xmin, xmax;
 
 			// translate xOffset

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -52,8 +52,6 @@ THREE.ColladaLoader = function () {
 	var colladaUp = 'Y';
 	var upConversion = null;
 
-	var TO_RADIANS = Math.PI / 180;
-
 	function load ( url, readyCallback, progressCallback ) {
 
 		var length = 0;
@@ -1920,7 +1918,7 @@ THREE.ColladaLoader = function () {
 
 			case 'rotate':
 
-				this.angle = this.data[3] * TO_RADIANS;
+				this.angle = THREE.Math.degToRad( this.data[3] );
 
 			case 'translate':
 
@@ -2101,7 +2099,7 @@ THREE.ColladaLoader = function () {
 
 					case 'ANGLE':
 
-						this.angle = data * TO_RADIANS;
+						this.angle = THREE.Math.degToRad( data );
 						break;
 
 					default:
@@ -2109,7 +2107,7 @@ THREE.ColladaLoader = function () {
 						this.obj.x = data[ 0 ];
 						this.obj.y = data[ 1 ];
 						this.obj.z = data[ 2 ];
-						this.angle = data[ 3 ] * TO_RADIANS;
+						this.angle = THREE.Math.degToRad( data[ 3 ] );
 						break;
 
 				}

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -139,7 +139,7 @@ THREE.CSS3DRenderer = function () {
 
 	this.render = function ( scene, camera ) {
 
-		var fov = 0.5 / Math.tan( camera.fov * Math.PI / 360 ) * _height;
+		var fov = 0.5 / Math.tan( THREE.Math.degToRad( camera.fov * 0.5 ) ) * _height;
 
 		this.domElement.style.WebkitPerspective = fov + "px";
 		this.domElement.style.MozPerspective = fov + "px";

--- a/examples/webgl_geometry_extrude_uvs2.html
+++ b/examples/webgl_geometry_extrude_uvs2.html
@@ -66,8 +66,7 @@
 	function updateRotation() {
 		rX = (rX + 3600) % 360;
 		rY = (rY + 3600) % 360;
-		var torad = Math.PI / 180.0;
-		testMesh.rotation.set(rY *torad, 0, rX *torad);
+		testMesh.rotation.set( THREE.Math.degToRad( rY ), 0, THREE.Math.degToRad( rX ) );
 	}
 
 	function render() {

--- a/examples/webgl_geometry_hierarchy.html
+++ b/examples/webgl_geometry_hierarchy.html
@@ -60,8 +60,8 @@
 					mesh.position.y = Math.random() * 2000 - 1000;
 					mesh.position.z = Math.random() * 2000 - 1000;
 
-					mesh.rotation.x = Math.random() * 360 * ( Math.PI / 180 );
-					mesh.rotation.y = Math.random() * 360 * ( Math.PI / 180 );
+					mesh.rotation.x = Math.random() * 2 * Math.PI;
+					mesh.rotation.y = Math.random() * 2 * Math.PI;
 
 					mesh.matrixAutoUpdate = false;
 					mesh.updateMatrix();

--- a/examples/webgl_interactive_cubes.html
+++ b/examples/webgl_interactive_cubes.html
@@ -65,9 +65,9 @@
 					object.position.y = Math.random() * 800 - 400;
 					object.position.z = Math.random() * 800 - 400;
 
-					object.rotation.x = ( Math.random() * 360 ) * Math.PI / 180;
-					object.rotation.y = ( Math.random() * 360 ) * Math.PI / 180;
-					object.rotation.z = ( Math.random() * 360 ) * Math.PI / 180;
+					object.rotation.x = Math.random() * 2 * Math.PI;
+					object.rotation.y = Math.random() * 2 * Math.PI;
+					object.rotation.z = Math.random() * 2 * Math.PI;
 
 					object.scale.x = Math.random() + 0.5;
 					object.scale.y = Math.random() + 0.5;
@@ -132,11 +132,11 @@
 
 			function render() {
 
-				theta += 0.2;
+				theta += 0.1;
 
-				camera.position.x = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.y = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.z = radius * Math.cos( theta * Math.PI / 360 );
+				camera.position.x = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.y = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.z = radius * Math.cos( THREE.Math.degToRad( theta ) );
 
 				camera.lookAt( scene.position );
 

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -114,9 +114,9 @@
 
 					var rotation = new THREE.Vector3();
 
-					rotation.x = ( Math.random() * 2 * Math.PI );
-					rotation.y = ( Math.random() * 2 * Math.PI );
-					rotation.z = ( Math.random() * 2 * Math.PI );
+					rotation.x = Math.random() * 2 * Math.PI;
+					rotation.y = Math.random() * 2 * Math.PI;
+					rotation.z = Math.random() * 2 * Math.PI;
 
 					var scale = new THREE.Vector3();
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -83,9 +83,9 @@
 					object.position.y = Math.random() * 600 - 300;
 					object.position.z = Math.random() * 800 - 400;
 
-					object.rotation.x = ( Math.random() * 360 ) * Math.PI / 180;
-					object.rotation.y = ( Math.random() * 360 ) * Math.PI / 180;
-					object.rotation.z = ( Math.random() * 360 ) * Math.PI / 180;
+					object.rotation.x = Math.random() * 2 * Math.PI;
+					object.rotation.y = Math.random() * 2 * Math.PI;
+					object.rotation.z = Math.random() * 2 * Math.PI;
 
 					object.scale.x = Math.random() * 2 + 1;
 					object.scale.y = Math.random() * 2 + 1;

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -33,7 +33,7 @@
 			var projector, plane, cube;
 			var mouse2D, mouse3D, raycaster,
 			rollOveredFace, isShiftDown = false,
-			theta = 45, isCtrlDown = false;
+			theta = 45 * 0.5, isCtrlDown = false;
 
 			var rollOverMesh, rollOverMaterial, voxelPosition = new THREE.Vector3(), tmpVec = new THREE.Vector3();
 			var cubeGeo, cubeMaterial;
@@ -272,7 +272,7 @@
 
 				if ( isShiftDown ) {
 
-					theta += mouse2D.x * 3;
+					theta += mouse2D.x * 1.5;
 
 				}
 
@@ -292,8 +292,8 @@
 
 				}
 
-				camera.position.x = 1400 * Math.sin( theta * Math.PI / 360 );
-				camera.position.z = 1400 * Math.cos( theta * Math.PI / 360 );
+				camera.position.x = 1400 * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.z = 1400 * Math.cos( THREE.Math.degToRad( theta ) );
 
 				camera.lookAt( scene.position );
 

--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -216,7 +216,7 @@
 				}
 
 				object.lensFlares[ 2 ].y += 0.025;
-				object.lensFlares[ 3 ].rotation = object.positionScreen.x * 0.5 + 45 * Math.PI / 180;
+				object.lensFlares[ 3 ].rotation = object.positionScreen.x * 0.5 + THREE.Math.degToRad( 45 );
 
 			}
 

--- a/examples/webgl_materials_cubemap_dynamic2.html
+++ b/examples/webgl_materials_cubemap_dynamic2.html
@@ -170,8 +170,8 @@
 				lon += .15;
 
 				lat = Math.max( - 85, Math.min( 85, lat ) );
-				phi = ( 90 - lat ) * Math.PI / 180;
-				theta = lon * Math.PI / 180;
+				phi = THREE.Math.degToRad( 90 - lat );
+				theta = THREE.Math.degToRad( lon );
 
 				sphere.position.x = Math.sin( time * 0.001 ) * 30;
 				sphere.position.y = Math.sin( time * 0.0011 ) * 30;

--- a/examples/webgl_morphnormals.html
+++ b/examples/webgl_morphnormals.html
@@ -195,10 +195,10 @@
 
 			function render() {
 
-				theta += 0.2;
+				theta += 0.1;
 
-				camera.position.x = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.z = radius * Math.cos( theta * Math.PI / 360 );
+				camera.position.x = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.z = radius * Math.cos( THREE.Math.degToRad( theta ) );
 
 				camera.lookAt( camera.target );
 

--- a/examples/webgl_morphtargets_horse.html
+++ b/examples/webgl_morphtargets_horse.html
@@ -118,10 +118,10 @@
 
 			function render() {
 
-				theta += 0.2;
+				theta += 0.1;
 
-				camera.position.x = radius * Math.sin( theta * Math.PI / 360 );
-				camera.position.z = radius * Math.cos( theta * Math.PI / 360 );
+				camera.position.x = radius * Math.sin( THREE.Math.degToRad( theta ) );
+				camera.position.z = radius * Math.cos( THREE.Math.degToRad( theta ) );
 
 				camera.lookAt( camera.target );
 

--- a/examples/webgl_panorama_equirectangular.html
+++ b/examples/webgl_panorama_equirectangular.html
@@ -157,8 +157,8 @@
 			function render() {
 
 				lat = Math.max( - 85, Math.min( 85, lat ) );
-				phi = ( 90 - lat ) * Math.PI / 180;
-				theta = lon * Math.PI / 180;
+				phi = THREE.Math.degToRad( 90 - lat );
+				theta = THREE.Math.degToRad( lon );
 
 				camera.target.x = 500 * Math.sin( phi ) * Math.cos( theta );
 				camera.target.y = 500 * Math.cos( phi );

--- a/examples/webgl_performance.html
+++ b/examples/webgl_performance.html
@@ -66,8 +66,8 @@
 						mesh.position.x = Math.random() * 8000 - 4000;
 						mesh.position.y = Math.random() * 8000 - 4000;
 						mesh.position.z = Math.random() * 8000 - 4000;
-						mesh.rotation.x = Math.random() * 360 * ( Math.PI / 180 );
-						mesh.rotation.y = Math.random() * 360 * ( Math.PI / 180 );
+						mesh.rotation.x = Math.random() * 2 * Math.PI;
+						mesh.rotation.y = Math.random() * 2 * Math.PI;
 						mesh.scale.x = mesh.scale.y = mesh.scale.z = Math.random() * 50 + 100;
 
 						objects.push( mesh );

--- a/examples/webgl_performance_doublesided.html
+++ b/examples/webgl_performance_doublesided.html
@@ -105,8 +105,8 @@
 					mesh.position.y = Math.random() * 10000 - 5000;
 					mesh.position.z = Math.random() * 10000 - 5000;
 
-					mesh.rotation.x = Math.random() * 360 * ( Math.PI / 180 );
-					mesh.rotation.y = Math.random() * 360 * ( Math.PI / 180 );
+					mesh.rotation.x = Math.random() * 2 * Math.PI;
+					mesh.rotation.y = Math.random() * 2 * Math.PI;
 					mesh.scale.x = mesh.scale.y = mesh.scale.z = Math.random() * 50 + 100;
 
 					mesh.matrixAutoUpdate = false;

--- a/examples/webgl_performance_static.html
+++ b/examples/webgl_performance_static.html
@@ -62,8 +62,8 @@
 						mesh.position.x = Math.random() * 10000 - 5000;
 						mesh.position.y = Math.random() * 10000 - 5000;
 						mesh.position.z = Math.random() * 10000 - 5000;
-						mesh.rotation.x = Math.random() * 360 * ( Math.PI / 180 );
-						mesh.rotation.y = Math.random() * 360 * ( Math.PI / 180 );
+						mesh.rotation.x = Math.random() * 2 * Math.PI;
+						mesh.rotation.y = Math.random() * 2 * Math.PI;
 						mesh.scale.x = mesh.scale.y = mesh.scale.z = Math.random() * 50 + 100;
 						mesh.matrixAutoUpdate = false;
 						mesh.updateMatrix();

--- a/examples/webgl_sandbox.html
+++ b/examples/webgl_sandbox.html
@@ -128,7 +128,7 @@
 					mesh.position.z = Math.random() * 10000 - 5000;
 
 					//mesh.rotation.x = Math.random() * 360 * ( Math.PI / 180 );
-					mesh.rotation.y = Math.random() * 360 * ( Math.PI / 180 );
+					mesh.rotation.y = Math.random() * 2 * Math.PI;
 
 					mesh.scale.x = mesh.scale.y = mesh.scale.z = Math.random() * 4 + 1;
 

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -30,7 +30,7 @@ THREE.PerspectiveCamera.prototype.setLens = function ( focalLength, frameHeight 
 
 	if ( frameHeight === undefined ) frameHeight = 24;
 
-	this.fov = 2 * Math.atan( frameHeight / ( focalLength * 2 ) ) * ( 180 / Math.PI );
+	this.fov = 2 * THREE.Math.radToDeg( Math.atan( frameHeight / ( focalLength * 2 ) ) );
 	this.updateProjectionMatrix();
 
 }
@@ -91,7 +91,7 @@ THREE.PerspectiveCamera.prototype.updateProjectionMatrix = function () {
 	if ( this.fullWidth ) {
 
 		var aspect = this.fullWidth / this.fullHeight;
-		var top = Math.tan( this.fov * Math.PI / 360 ) * this.near;
+		var top = Math.tan( THREE.Math.degToRad( this.fov * 0.5 ) ) * this.near;
 		var bottom = -top;
 		var left = aspect * bottom;
 		var right = aspect * top;

--- a/src/extras/cameras/CombinedCamera.js
+++ b/src/extras/cameras/CombinedCamera.js
@@ -154,7 +154,7 @@ THREE.CombinedCamera.prototype.setLens = function ( focalLength, frameHeight ) {
 
 	if ( frameHeight === undefined ) frameHeight = 24;
 
-	var fov = 2 * Math.atan( frameHeight / ( focalLength * 2 ) ) * ( 180 / Math.PI );
+	var fov = 2 * THREE.Math.radToDeg( Math.atan( frameHeight / ( focalLength * 2 ) ) );
 
 	this.setFov( fov );
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -226,7 +226,7 @@ THREE.Box3.prototype = {
 
 	},
 
-	boundingSphere: function ( optionalTarget ) {
+	getBoundingSphere: function ( optionalTarget ) {
 
 		var result = optionalTarget || new THREE.Sphere();
 		

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -226,6 +226,17 @@ THREE.Box3.prototype = {
 
 	},
 
+	boundingSphere: function ( optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Sphere();
+		
+		result.center = this.center();
+		result.radius = this.size( THREE.Box3.__v0 ).length() * 0.5;;
+
+		return result;
+
+	},
+
 	intersect: function ( box ) {
 
 		this.min.maxSelf( box.min );

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -67,13 +67,13 @@ THREE.Math = {
 
 	},
 
-	degreesToRadians: function ( degrees ) {
+	degToRad: function ( degrees ) {
 
 		return degrees * THREE.Math.__d2r;
 
 	},
 
-	radiansToDegrees: function ( radians ) {
+	radToDeg: function ( radians ) {
 
 		return radians * THREE.Math.__r2d;
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -1014,7 +1014,7 @@ THREE.Matrix4.prototype = {
 
 	makePerspective: function ( fov, aspect, near, far ) {
 
-		var ymax = near * Math.tan( fov * Math.PI / 360 );
+		var ymax = near * Math.tan( THREE.Math.degToRad( fov * 0.5 ) );
 		var ymin = - ymax;
 		var xmin = ymin * aspect;
 		var xmax = ymax * aspect;

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -85,7 +85,7 @@ THREE.Sphere.prototype = {
 
 	},
 
-	boundingBox: function ( optionalTarget ) {
+	getBoundingBox: function ( optionalTarget ) {
 
 		var box = optionalTarget || new THREE.Box3();
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -85,7 +85,7 @@ THREE.Sphere.prototype = {
 
 	},
 
-	bounds: function ( optionalTarget ) {
+	boundingBox: function ( optionalTarget ) {
 
 		var box = optionalTarget || new THREE.Box3();
 

--- a/test/math/Box3.js
+++ b/test/math/Box3.js
@@ -208,14 +208,14 @@ test( "isIntersectionBox", function() {
 	ok( ! b.isIntersectionBox( c ), "Passed!" );
 });
 
-test( "boundingSphere", function() {
+test( "getBoundingSphere", function() {
 	var a = new THREE.Box3( zero3, zero3 );
 	var b = new THREE.Box3( zero3, one3 );
 	var c = new THREE.Box3( one3.clone().negate(), one3 );
 
-	ok( a.boundingSphere().equals( new THREE.Sphere( zero3, 0 ) ), "Passed!" );
-	ok( b.boundingSphere().equals( new THREE.Sphere( one3.clone().multiplyScalar( 0.5 ), Math.sqrt( 3 ) * 0.5 ) ), "Passed!" );
-	ok( c.boundingSphere().equals( new THREE.Sphere( zero3, Math.sqrt( 12 ) * 0.5 ) ), "Passed!" );
+	ok( a.getBoundingSphere().equals( new THREE.Sphere( zero3, 0 ) ), "Passed!" );
+	ok( b.getBoundingSphere().equals( new THREE.Sphere( one3.clone().multiplyScalar( 0.5 ), Math.sqrt( 3 ) * 0.5 ) ), "Passed!" );
+	ok( c.getBoundingSphere().equals( new THREE.Sphere( zero3, Math.sqrt( 12 ) * 0.5 ) ), "Passed!" );
 });
 
 test( "intersect", function() {

--- a/test/math/Box3.js
+++ b/test/math/Box3.js
@@ -208,6 +208,16 @@ test( "isIntersectionBox", function() {
 	ok( ! b.isIntersectionBox( c ), "Passed!" );
 });
 
+test( "boundingSphere", function() {
+	var a = new THREE.Box3( zero3, zero3 );
+	var b = new THREE.Box3( zero3, one3 );
+	var c = new THREE.Box3( one3.clone().negate(), one3 );
+
+	ok( a.boundingSphere().equals( new THREE.Sphere( zero3, 0 ) ), "Passed!" );
+	ok( b.boundingSphere().equals( new THREE.Sphere( one3.clone().multiplyScalar( 0.5 ), Math.sqrt( 3 ) * 0.5 ) ), "Passed!" );
+	ok( c.boundingSphere().equals( new THREE.Sphere( zero3, Math.sqrt( 12 ) * 0.5 ) ), "Passed!" );
+});
+
 test( "intersect", function() {
 	var a = new THREE.Box3( zero3, zero3 );
 	var b = new THREE.Box3( zero3, one3 );

--- a/test/math/Sphere.js
+++ b/test/math/Sphere.js
@@ -67,13 +67,13 @@ test( "clampPoint", function() {
 	ok( a.clampPoint( new THREE.Vector3( 1, 1, -3 ) ).equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
 });
 
-test( "bounds", function() {
+test( "boundingBox", function() {
 	var a = new THREE.Sphere( one3, 1 );
 
-	ok( a.bounds().equals( new THREE.Box3( zero3, two3 ) ), "Passed!" );
+	ok( a.boundingBox().equals( new THREE.Box3( zero3, two3 ) ), "Passed!" );
 
 	a.set( zero3, 0 )
-	ok( a.bounds().equals( new THREE.Box3( zero3, zero3 ) ), "Passed!" );
+	ok( a.boundingBox().equals( new THREE.Box3( zero3, zero3 ) ), "Passed!" );
 });
 
 test( "transform", function() {
@@ -83,7 +83,7 @@ test( "transform", function() {
 	var t1 = new THREE.Vector3( 1, -2, 1 );
 	m.makeTranslation( t1 );
 
-	ok( a.clone().transform( m ).bounds().equals( a.bounds().transform( m ) ), "Passed!" );
+	ok( a.clone().transform( m ).boundingBox().equals( a.boundingBox().transform( m ) ), "Passed!" );
 });
 
 test( "translate", function() {

--- a/test/math/Sphere.js
+++ b/test/math/Sphere.js
@@ -67,13 +67,13 @@ test( "clampPoint", function() {
 	ok( a.clampPoint( new THREE.Vector3( 1, 1, -3 ) ).equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
 });
 
-test( "boundingBox", function() {
+test( "getBoundingBox", function() {
 	var a = new THREE.Sphere( one3, 1 );
 
-	ok( a.boundingBox().equals( new THREE.Box3( zero3, two3 ) ), "Passed!" );
+	ok( a.getBoundingBox().equals( new THREE.Box3( zero3, two3 ) ), "Passed!" );
 
 	a.set( zero3, 0 )
-	ok( a.boundingBox().equals( new THREE.Box3( zero3, zero3 ) ), "Passed!" );
+	ok( a.getBoundingBox().equals( new THREE.Box3( zero3, zero3 ) ), "Passed!" );
 });
 
 test( "transform", function() {
@@ -83,7 +83,7 @@ test( "transform", function() {
 	var t1 = new THREE.Vector3( 1, -2, 1 );
 	m.makeTranslation( t1 );
 
-	ok( a.clone().transform( m ).boundingBox().equals( a.boundingBox().transform( m ) ), "Passed!" );
+	ok( a.clone().transform( m ).getBoundingBox().equals( a.getBoundingBox().transform( m ) ), "Passed!" );
 });
 
 test( "translate", function() {


### PR DESCRIPTION
This is a low priority change, just making some code more self-explanatory, simpler to read and spreading best practices throughout the example code.

(1) First off I shortened THREE.Math.degreesToRadians/radiansToDegrees to degToRad/radToDeg as I figured the short name would be preferred by ThreeJS maintainers.  I personally prefer the long version but I am okay with the short version.

(2) I have changed patterns in the code and the examples such as this:

```
phi = ( 90 - lat ) * Math.PI / 180;
theta = lon * Math.PI / 180;
```

to this:

```
phi = THREE.Math.degToRad( 90 - lat );
theta = THREE.Math.degToRad( lon );
```

(2) I've tested each example that I have modified.  Also, all unit tests pass.

(3) There were some cases such as this:

```
mesh.rotation.y = Math.random() * 360 * ( Math.PI / 180 );
```

that I instead changed to the following as it was both simpler/faster to stay in radians:

```
mesh.rotation.x = Math.random() * 2 * Math.PI;
```
