### PR TITLE
Make CSS3DRenderer respect CSS3DSprite scale

### DIFF
--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -170,6 +170,7 @@ THREE.CSS3DRenderer = function () {
 					_tmpMatrix.copy( camera.matrixWorldInverse );
 					_tmpMatrix.transpose();
 					_tmpMatrix.extractPosition( object.matrixWorld );
+					_tmpMatrix.scale( object.scale );
 
 					_tmpMatrix.elements[ 3 ] = 0;
 					_tmpMatrix.elements[ 7 ] = 0;


### PR DESCRIPTION
I think CSS3DRenderer should only ignore CSS3DSprite's rotation and not its scale. I'm not good with these Matrix stuff, so while this seems to work for me, there might be a better way.
