### PR TITLE
Fix ArrowHelper so it can point downwards (+ some optimization)

### DIFF
--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -43,7 +43,7 @@ THREE.ArrowHelper.prototype = Object.create( THREE.Object3D.prototype );
 
 THREE.ArrowHelper.prototype.setDirection = function ( dir ) {
 
-    var d = dir.clone().normalize();
+    var d = THREE.ArrowHelper.__v1.copy( dir ).normalize();
 
     if ( d.y > 0.99999 ) {
 
@@ -60,20 +60,18 @@ THREE.ArrowHelper.prototype.setDirection = function ( dir ) {
 
     else {
 
-	    var axis = THREE.ArrowHelper.__v1.set( d.z, 0, - d.x );
+	    var axis = THREE.ArrowHelper.__v2.set( d.z, 0, - d.x );
 
 	    var radians = Math.acos( d.y );
 
-	    var matrix = THREE.ArrowHelper.__m1.makeRotationAxis( axis.normalize(), radians );
+	    var quat = THREE.ArrowHelper.__q1.setFromAxisAngle( axis.normalize(), radians );
 
-	    this.rotation.setEulerFromRotationMatrix( matrix, this.eulerOrder );
+	    this.rotation.setEulerFromQuaternion( quat, this.eulerOrder );
 
 	}
 
 };
 
-THREE.ArrowHelper.__v1 = new THREE.Vector3();
-THREE.ArrowHelper.__m1 = new THREE.Matrix4();
 THREE.ArrowHelper.prototype.setLength = function ( length ) {
 
 	this.scale.set( length, length, length );
@@ -87,7 +85,6 @@ THREE.ArrowHelper.prototype.setColor = function ( hex ) {
 
 };
 
-THREE.ArrowHelper.__m0 = new THREE.Matrix4();
-THREE.ArrowHelper.__v0 = new THREE.Vector3();
-THREE.ArrowHelper.__vYAxis = new THREE.Vector3( 0, 1, 0 );
-THREE.ArrowHelper.__vYAxisNeg = new THREE.Vector3( 0, -1, 0 );
+THREE.ArrowHelper.__v1 = new THREE.Vector3();
+THREE.ArrowHelper.__v2 = new THREE.Vector3();
+THREE.ArrowHelper.__q1 = new THREE.Quaternion();

--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -45,19 +45,16 @@ THREE.ArrowHelper.prototype.setDirection = function ( dir ) {
 
     var d = THREE.ArrowHelper.__v1.copy( dir ).normalize();
 
-    if ( d.y > 0.99999 ) {
+    if ( d.y > 0.999 ) {
 
         this.rotation.set( 0, 0, 0 );
  
     }
-
-    else if ( d.y < - 0.99999 ) {
+    else if ( d.y < - 0.999 ) {
 
         this.rotation.set( Math.PI, 0, 0 );
-        return;
 
     }
-
     else {
 
 	    var axis = THREE.ArrowHelper.__v2.set( d.z, 0, - d.x );

--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -49,20 +49,16 @@ THREE.ArrowHelper.prototype.setDirection = function ( dir ) {
 
         this.rotation.set( 0, 0, 0 );
  
-    }
-    else if ( d.y < - 0.999 ) {
+    } else if ( d.y < - 0.999 ) {
 
         this.rotation.set( Math.PI, 0, 0 );
 
-    }
-    else {
+    } else {
 
-	    var axis = THREE.ArrowHelper.__v2.set( d.z, 0, - d.x );
-
+	    var axis = THREE.ArrowHelper.__v2.set( d.z, 0, - d.x ).normalize();
 	    var radians = Math.acos( d.y );
-
-	    var quat = THREE.ArrowHelper.__q1.setFromAxisAngle( axis.normalize(), radians );
-
+	    var quat = THREE.ArrowHelper.__q1.setFromAxisAngle( axis, radians );
+	    
 	    this.rotation.setEulerFromQuaternion( quat, this.eulerOrder );
 
 	}

--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -42,13 +42,31 @@ THREE.ArrowHelper.prototype = Object.create( THREE.Object3D.prototype );
 
 THREE.ArrowHelper.prototype.setDirection = function ( dir ) {
 
-	var axis = new THREE.Vector3( 0, 1, 0 ).crossSelf( dir );
+	var matrix = THREE.ArrowHelper.__m0;
+	var yAxis = THREE.ArrowHelper.__vYAxis;
+	var yAxisNeg = THREE.ArrowHelper.__vYAxisNeg;
 
-	var radians = Math.acos( new THREE.Vector3( 0, 1, 0 ).dot( dir.clone().normalize() ) );
+	var axis = dir.clone().normalize();
 
-	this.matrix = new THREE.Matrix4().makeRotationAxis( axis.normalize(), radians );
+	if( axis.distanceTo( yAxis ) < 0.001 ) {
 
-	this.rotation.setEulerFromRotationMatrix( this.matrix, this.eulerOrder );
+		matrix.identity();
+
+	}
+	else if( axis.distanceTo( yAxisNeg ) < 0.001 ) {
+
+		matrix.makeRotationZ( Math.PI );
+
+	}
+	else {
+
+		var perpendicularAxis = THREE.ArrowHelper.__v0.copy( yAxis ).crossSelf( axis );
+		var radians = Math.acos( yAxis.dot( axis ) );
+		matrix.makeRotationAxis( perpendicularAxis.normalize(), radians );
+
+	}
+
+	this.rotation.setEulerFromRotationMatrix( matrix, this.eulerOrder );
 
 };
 
@@ -64,3 +82,8 @@ THREE.ArrowHelper.prototype.setColor = function ( hex ) {
 	this.cone.material.color.setHex( hex );
 
 };
+
+THREE.ArrowHelper.__m0 = new THREE.Matrix4();
+THREE.ArrowHelper.__v0 = new THREE.Vector3();
+THREE.ArrowHelper.__vYAxis = new THREE.Vector3( 0, 1, 0 );
+THREE.ArrowHelper.__vYAxisNeg = new THREE.Vector3( 0, -1, 0 );

--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -1,6 +1,7 @@
 /**
  * @author WestLangley / http://github.com/WestLangley
  * @author zz85 / https://github.com/zz85
+ * @author bhouston / https://exocortex.com
  *
  * Creates an arrow for visualizing directions
  *
@@ -42,34 +43,37 @@ THREE.ArrowHelper.prototype = Object.create( THREE.Object3D.prototype );
 
 THREE.ArrowHelper.prototype.setDirection = function ( dir ) {
 
-	var matrix = THREE.ArrowHelper.__m0;
-	var yAxis = THREE.ArrowHelper.__vYAxis;
-	var yAxisNeg = THREE.ArrowHelper.__vYAxisNeg;
+    var d = dir.clone().normalize();
 
-	var axis = dir.clone().normalize();
+    if ( d.y > 0.99999 ) {
 
-	if( axis.distanceTo( yAxis ) < 0.001 ) {
+        this.rotation.set( 0, 0, 0 );
+ 
+    }
 
-		matrix.identity();
+    else if ( d.y < - 0.99999 ) {
+
+        this.rotation.set( Math.PI, 0, 0 );
+        return;
+
+    }
+
+    else {
+
+	    var axis = THREE.ArrowHelper.__v1.set( d.z, 0, - d.x );
+
+	    var radians = Math.acos( d.y );
+
+	    var matrix = THREE.ArrowHelper.__m1.makeRotationAxis( axis.normalize(), radians );
+
+	    this.rotation.setEulerFromRotationMatrix( matrix, this.eulerOrder );
 
 	}
-	else if( axis.distanceTo( yAxisNeg ) < 0.001 ) {
-
-		matrix.makeRotationZ( Math.PI );
-
-	}
-	else {
-
-		var perpendicularAxis = THREE.ArrowHelper.__v0.copy( yAxis ).crossSelf( axis );
-		var radians = Math.acos( yAxis.dot( axis ) );
-		matrix.makeRotationAxis( perpendicularAxis.normalize(), radians );
-
-	}
-
-	this.rotation.setEulerFromRotationMatrix( matrix, this.eulerOrder );
 
 };
 
+THREE.ArrowHelper.__v1 = new THREE.Vector3();
+THREE.ArrowHelper.__m1 = new THREE.Matrix4();
 THREE.ArrowHelper.prototype.setLength = function ( length ) {
 
 	this.scale.set( length, length, length );

--- a/test/unit/math/Matrix4.js
+++ b/test/unit/math/Matrix4.js
@@ -217,6 +217,42 @@ test( "transpose", function() {
 	ok( matrixEquals4( b, c ), "Passed!" ); 
 });
 
+// this function is a duplicate of that in ArrowHelper.
+var makeBasis = function ( axis ) {
+
+	var matrix = new THREE.Matrix4();
+
+	if( axis.distanceTo( new THREE.Vector3( 0, 1, 0 ) ) < 0.001 ) {
+		matrix.identity();
+	}
+	else if( axis.distanceTo( new THREE.Vector3( 0, -1, 0 ) ) < 0.001 ) {
+		matrix.makeRotationZ( Math.PI );
+	}
+	else {
+		var perpendicularAxis = new THREE.Vector3( 0, 1, 0 ).crossSelf( axis );
+		perpendicularAxis.normalize();
+		var radians = Math.acos( new THREE.Vector3( 0, 1, 0 ).dot( perpendicularAxis ) );
+		matrix.makeRotationAxis( perpendicularAxis, radians );
+	}
+
+	return matrix;
+}
+
+test( "makeBasis", function() {
+	var axes = [
+		new THREE.Vector3( 1, 0, 0 ), new THREE.Vector3( 0, 1, 0 ), new THREE.Vector3( 0, 0, 1 ),
+		new THREE.Vector3( -1, 0, 0 ), new THREE.Vector3( 0, -1, 0 ), new THREE.Vector3( 0, 0, -1 )
+	];
+
+	var v = new THREE.Vector3( 0, 1, 0 );
+	for( var i = 0, il = axes.length; i < il; i ++ ) {
+		var v0 = axes[i];
+		var m = makeBasis( v0 );
+		var v1 = m.multiplyVector3( v.clone() );
+		ok( v1.distanceTo( v0 ) < 0.001, "Passed!" );
+	}
+});
+
 test( "clone", function() {
 	var a = new THREE.Matrix4( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 );
 	var b = a.clone();

--- a/test/unit/math/Matrix4.js
+++ b/test/unit/math/Matrix4.js
@@ -217,42 +217,6 @@ test( "transpose", function() {
 	ok( matrixEquals4( b, c ), "Passed!" ); 
 });
 
-// this function is a duplicate of that in ArrowHelper.
-var makeBasis = function ( axis ) {
-
-	var matrix = new THREE.Matrix4();
-
-	if( axis.distanceTo( new THREE.Vector3( 0, 1, 0 ) ) < 0.001 ) {
-		matrix.identity();
-	}
-	else if( axis.distanceTo( new THREE.Vector3( 0, -1, 0 ) ) < 0.001 ) {
-		matrix.makeRotationZ( Math.PI );
-	}
-	else {
-		var perpendicularAxis = new THREE.Vector3( 0, 1, 0 ).crossSelf( axis );
-		perpendicularAxis.normalize();
-		var radians = Math.acos( new THREE.Vector3( 0, 1, 0 ).dot( perpendicularAxis ) );
-		matrix.makeRotationAxis( perpendicularAxis, radians );
-	}
-
-	return matrix;
-}
-
-test( "makeBasis", function() {
-	var axes = [
-		new THREE.Vector3( 1, 0, 0 ), new THREE.Vector3( 0, 1, 0 ), new THREE.Vector3( 0, 0, 1 ),
-		new THREE.Vector3( -1, 0, 0 ), new THREE.Vector3( 0, -1, 0 ), new THREE.Vector3( 0, 0, -1 )
-	];
-
-	var v = new THREE.Vector3( 0, 1, 0 );
-	for( var i = 0, il = axes.length; i < il; i ++ ) {
-		var v0 = axes[i];
-		var m = makeBasis( v0 );
-		var v1 = m.multiplyVector3( v.clone() );
-		ok( v1.distanceTo( v0 ) < 0.001, "Passed!" );
-	}
-});
-
 test( "clone", function() {
 	var a = new THREE.Matrix4( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 );
 	var b = a.clone();


### PR DESCRIPTION
While debugging normals during geometry creation I noticed that ArrowHelper wasn't able to point downwards (0,-1,0).  This PR fixes this issue and also optimizes ArrowHelper based on a suggestions from @WestLangley here: https://github.com/mrdoob/three.js/pull/2845#issuecomment-11725063

Tested lights in /editor/index.html and the /examples that referenced ArrowHelper directly.  Seems to all works.
