### PR TITLE
Added support for Line in Raycaster.intersectObject

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -34,6 +34,10 @@
 
 	};
 
+	var v0 = new THREE.Vector3(), v1 = new THREE.Vector3(), v2 = new THREE.Vector3();
+
+	// http://www.blackpawn.com/texts/pointinpoly/default.html
+
 	var intersectObject = function ( object, raycaster, intersects ) {
 
 		if ( object instanceof THREE.Particle ) {
@@ -157,9 +161,145 @@
 				} );
 
 			}
+		} else if ( object instanceof THREE.Line ) {
+			if( object.geometry.vertices.length == 2 ) { // only works with minimal lines (i.e. between 2 points) for now, feel free to extend :) 
+				var v0 = object.geometry.vertices[0];
+				var v1 = object.geometry.vertices[1];
+				var lineDirection = v1.clone().sub( v0 );
+				var rayOfLine = new THREE.Ray( v0, lineDirection );
+				
+				var distanceToRay = raycaster.ray.distanceToRay( rayOfLine );
+				if( distanceToRay <= raycaster.precision ) {
+					var nearestPointOnLine = getNearestPointOnLine( raycaster.ray, v0, v1, lineDirection );
+					var diffOrigins = nearestPointOnLine.clone().sub( raycaster.ray.origin ); 
+					distanceToRay = diffOrigins.cross( raycaster.ray.direction ).length() / raycaster.ray.direction.length();
 
+					if( distanceToRay <= raycaster.precision ) {
+						var distance = raycaster.ray.origin.distanceTo( nearestPointOnLine );
+						if ( raycaster.near <= distance && distance <= raycaster.far )
+							intersects.push( {
+		
+								distance: distance,
+								point: nearestPointOnLine,
+								object: object
+		
+							} );
+					}
+				}
+			}
+		}
+	};
+
+	// ---- helper functions for line intersection test
+
+	/***
+	 * getNearestPointOnLine 
+	 * 
+	 * returns the point on the line from @param v0 to @param v1 that is nearest to the @param ray.
+	 * 	       @param lineDirection is the vector from @param v0 to @param v1 , i.e. v1.clone().sub( v0 ).
+	 *         @param lineDirection could be calculated within getNearestPointOnLine and is only passed for performance benefits,
+	 *         because it has already been calculated when getNearestPointOnLine is being called.
+	 * 
+	 */
+	
+	var getNearestPointOnLine = function( ray, v0, v1, lineDirection ) {
+//		getNearestPointOnLine resolves the equation (ray.origin + m * ray.direction - v0  - n * lineDirection) * lineDirection == 0
+		// --- helper functions for getNearestPointOnLine
+		
+		/***
+		 * assignDimension
+		 * 
+		 *  ... checks if the dimension @param dim of @param vec is a suitable dimension 
+		 *  (for resolving the getNearestPointOnLine-equation, see at getNearestPointOnLine), i.e. if @param vec[ @param dim] != 0.
+		 *      
+		 * In this case, assignDimension stores @param dim in the next free dimension container (which is @param dimFirst, iff ! @param dimFirst[0]
+		 * and @param dimSecond otherwise).  
+		 * 
+		 * returns nothing
+		 */
+		
+		var assignDimension = function( vec, dim, dimFirst, dimSecond ) {
+			if( vec[dim] != 0 ) {
+				if( !dimFirst[0] )
+					dimFirst[0] = dim;
+				else
+					dimSecond[0] = dim;
+			}
+		};
+		
+		/***
+		 * returnSuitableMDimension 
+		 * 
+		 * returns dim iff dim is a suitable dimension to calculate m and
+		 * 		   null otherwise
+		 */
+		
+		var returnSuitableMDimension = function( dim, ray, lineDirection ) {
+			return lineDirection[dim] == 0 && ray.direction[dim] != 0 ? dim : null;  
+		}
+		
+		var assert = function( expr, msg ) {
+//			Didn't know what to do with my assert-statements when contriubting this code, so I commented them out.
+			console.assert( expr, msg );
 		}
 
+		var m, n;
+		
+		var diffOrigins = ray.origin.clone().sub(v0);
+		var dimFirst = [null], dimSecond =  [null];
+		assignDimension( lineDirection, "x", dimFirst, dimSecond );
+		assignDimension( lineDirection, "y", dimFirst, dimSecond );
+		if( !dimSecond[0])
+			assignDimension( lineDirection, "z", dimFirst, dimSecond );
+		
+		assert( dimFirst[0] );
+		
+		if( !dimSecond[0]) {
+			var dimM = returnSuitableMDimension("x", ray, lineDirection )
+				    || returnSuitableMDimension("y", ray, lineDirection )
+				    || returnSuitableMDimension("z", ray, lineDirection )
+				    ;
+			
+			if( dimM ) {
+				m = -diffOrigins[dimM]/ray.direction[dimM];
+			} else {
+				m = 1;
+			}
+		} else {					
+			var div = ray.direction[dimSecond[0]] * lineDirection[dimFirst[0]] - ray.direction[dimFirst[0]] * lineDirection[dimSecond[0]];
+			if( div == 0 && dimSecond[0] == "y" && lineDirection.z != 0 ) {
+				dimSecond[0] = "z";
+				div = ray.direction[dimSecond[0]] * lineDirection[dimFirst[0]] - ray.direction[dimFirst[0]] * lineDirection[dimSecond[0]];
+			}
+			
+			var diffDir = (diffOrigins[dimFirst[0]] * lineDirection[dimSecond[0]] - diffOrigins[dimSecond[0]] * lineDirection[dimFirst[0]]);
+			if (div != 0 ) {
+				m = diffDir / div;
+			} else {
+				assert( diffDir == 0 );
+				m = 1;
+			} 
+		}
+	
+		n = (diffOrigins[dimFirst[0]] + m * ray.direction[dimFirst[0]]) / lineDirection[dimFirst[0]];
+		
+		// If n == 0 the nearest point on the line is v0.
+		// If n == 1 the nearest point on the line is v1.
+		// If 0 < n < 1, the nearest point on the line is between v0 and v1.
+		// In all these cases, the distance between the ray and the valid section of the line (i.e. between v0 and v1) is the 
+		// calculated distance between the ray and the (infinite) line.
+	
+		if( 0 <= n && n <= 1 ) {
+			return lineDirection.clone().multiplyScalar(n).add(v0);
+	
+		} else {
+			if( 1 < n ) { // if 1 < n the nearest point is after v1 => the nearest point of the valid section of the line is v1
+				return v1;
+			} else {
+				assert( n < 0 ); // if n < 0 the nearest point is before v0 => the nearest point of the valid section of the line is v0
+				return v0;
+			}
+		}
 	};
 
 	var intersectDescendants = function ( object, raycaster, intersects ) {

--- a/test/unit/core/Raycaster.js
+++ b/test/unit/core/Raycaster.js
@@ -1,0 +1,30 @@
+/**
+ * @author RaiNova / mailto:RNova@gmx.net
+ */
+
+module( "Raycaster" );
+
+test( "intersectObject", function() {
+	var createSimpleLine = function ( v0, v1 ) {
+		var geometry = new THREE.Geometry();
+		geometry.vertices.push( v0 );
+		geometry.vertices.push( v1 );
+		return new THREE.Line( geometry );
+	};
+
+	var o0 = new THREE.Vector3( 1, 2, 3 );
+	
+	var a = new THREE.Raycaster( new THREE.Vector3(0,0,0), new THREE.Vector3(1,2,0).normalize(), .1, 10000 );
+
+	var intersects = a.intersectObject( createSimpleLine( new THREE.Vector3(1,2,0), o0) );
+	ok( intersects.length == 1, "Passed!" );
+
+	intersects = a.intersectObject( createSimpleLine( o0, new THREE.Vector3(1,2,-3)) );
+	ok( intersects.length == 1, "Passed!" );
+
+	intersects = a.intersectObject( createSimpleLine( o0, new THREE.Vector3(2, 4, 0)) );
+	ok( intersects.length == 1, "Passed!" );
+
+	intersects = a.intersectObject( createSimpleLine( o0, new THREE.Vector3(2, 4, 1)) );
+	ok( intersects.length == 0, "Passed!" );
+});

--- a/test/unit/math/Ray.js
+++ b/test/unit/math/Ray.js
@@ -85,6 +85,33 @@ test( "distanceToPoint", function() {
 	ok( c == 0, "Passed!" );
 });
 
+test("distanceToRay", function () {
+	var o0 = new THREE.Vector3( 1, 2, 3 );
+	var d0 = new THREE.Vector3( 4, 5, 6 );
+	var ray0 = new THREE.Ray( o0, d0 );
+
+	var o1 = new THREE.Vector3( 7, 8, 9 );
+	var d1 = new THREE.Vector3( 8, 10, 12 );
+	
+	var ray01 = new THREE.Ray( o0, d1 );
+	var ray1 = new THREE.Ray( o1, d1 );
+
+	var d = ray0.distanceToRay( ray01 );
+	ok(d==0,"Passed!");
+	ok(ray01.distanceToRay( ray0 ) == 0,"Passed!");
+	
+	d = ray0.distanceToRay( ray1 );
+	var ddo = o1.clone().sub(o0);
+	var dd = o1.length();
+	ok(d<=dd,"Passed!");
+	ok(d==ray1.distanceToRay( ray0 ),"Passed!");
+	
+	d1.z = 0; // so d1 is no more parallel to d0
+	d = ray0.distanceToRay( ray01 );
+	ok(d==0,"Passed!");
+	ok(ray01.distanceToRay( ray0 ) == 0,"Passed!");
+});
+
 test( "isIntersectionSphere", function() {
 	var a = new THREE.Ray( one3, new THREE.Vector3( 0, 0, 1 ) );
 	var b = new THREE.Sphere( zero3, 0.5 );

--- a/test/unit/unittests_sources.html
+++ b/test/unit/unittests_sources.html
@@ -27,6 +27,15 @@
   <script src="../../src/math/Color.js"></script>
   <script src="../../src/math/Quaternion.js"></script>
   <script src="../../src/math/Frustum.js"></script>
+  <script src="../../src/core/EventDispatcher.js"></script>
+  <script src="../../src/core/Geometry.js"></script>
+  <script src="../../src/core/Object3D.js"></script>
+  <script src="../../src/core/Raycaster.js"></script>
+  <script src="../../src/materials/Material.js"></script>
+  <script src="../../src/materials/LineBasicMaterial.js"></script>
+  <script src="../../src/objects/Line.js"></script>
+  <script src="../../src/objects/Mesh.js"></script>
+  <script src="../../src/objects/Particle.js"></script>
 
   <!-- add class-based unit tests below -->
 
@@ -44,6 +53,7 @@
   <script src="math/Matrix3.js"></script>
   <script src="math/Matrix4.js"></script>
   <script src="math/Frustum.js"></script>
+  <script src="core/Raycaster.js"></script>
   
 </body>
 </html>


### PR DESCRIPTION
Fixed call to no-more-existing multiplyMatrix4 in Ray.transfrom.
Fixed some open ends regarding *Self.
Added support for Line in Raycaster.intersectObject.

Sorry for submitting a pull request to the master branch.
I do this the first time with kids fighting in the background :)

Cheers
Rai
