### PR TITLE
Fix bug in DirectionalLightHelper

### DIFF
--- a/src/extras/helpers/DirectionalLightHelper.js
+++ b/src/extras/helpers/DirectionalLightHelper.js
@@ -73,11 +73,6 @@ THREE.DirectionalLightHelper = function ( light, sphereSize ) {
 		this.targetLine.properties.isGizmo = true;
 
 	}
-	else {
-
-		this.targetSphere = null;
-
-	}
 
 	//
 

--- a/src/extras/helpers/DirectionalLightHelper.js
+++ b/src/extras/helpers/DirectionalLightHelper.js
@@ -73,6 +73,11 @@ THREE.DirectionalLightHelper = function ( light, sphereSize ) {
 		this.targetLine.properties.isGizmo = true;
 
 	}
+	else {
+
+		this.targetSphere = null;
+
+	}
 
 	//
 
@@ -99,16 +104,21 @@ THREE.DirectionalLightHelper.prototype.update = function () {
 	this.lightSphere.material.color.copy( this.color );
 	this.lightRays.material.color.copy( this.color );
 
-	this.targetSphere.material.color.copy( this.color );
-	this.targetLine.material.color.copy( this.color );
+	// Only update targetSphere and targetLine if available
+	if ( this.targetSphere ) {
 
-	// update target line vertices
+		this.targetSphere.material.color.copy( this.color );
+		this.targetLine.material.color.copy( this.color );
 
-	this.targetLine.geometry.vertices[ 0 ].copy( this.light.position );
-	this.targetLine.geometry.vertices[ 1 ].copy( this.light.target.position );
+		// update target line vertices
 
-	this.targetLine.geometry.computeLineDistances();
-	this.targetLine.geometry.verticesNeedUpdate = true;
+		this.targetLine.geometry.vertices[ 0 ].copy( this.light.position );
+		this.targetLine.geometry.vertices[ 1 ].copy( this.light.target.position );
+
+		this.targetLine.geometry.computeLineDistances();
+		this.targetLine.geometry.verticesNeedUpdate = true;
+
+	}
 
 }
 

--- a/src/extras/helpers/SpotLightHelper.js
+++ b/src/extras/helpers/SpotLightHelper.js
@@ -92,6 +92,11 @@ THREE.SpotLightHelper = function ( light, sphereSize ) {
 		this.targetLine.properties.isGizmo = true;
 
 	}
+	else {
+
+		this.targetSphere = null;
+
+	}
 
 	//
 
@@ -127,15 +132,20 @@ THREE.SpotLightHelper.prototype.update = function () {
 	this.lightRays.material.color.copy( this.color );
 	this.lightCone.material.color.copy( this.color );
 
-	this.targetSphere.material.color.copy( this.color );
-	this.targetLine.material.color.copy( this.color );
+	// Only update targetSphere and targetLine if available
+	if ( this.targetSphere ) {
 
-	// update target line vertices
+		this.targetSphere.material.color.copy( this.color );
+		this.targetLine.material.color.copy( this.color );
 
-	this.targetLine.geometry.vertices[ 0 ].copy( this.light.position );
-	this.targetLine.geometry.vertices[ 1 ].copy( this.light.target.position );
+		// update target line vertices
 
-	this.targetLine.geometry.computeLineDistances();
-	this.targetLine.geometry.verticesNeedUpdate = true;
+		this.targetLine.geometry.vertices[ 0 ].copy( this.light.position );
+		this.targetLine.geometry.vertices[ 1 ].copy( this.light.target.position );
+
+		this.targetLine.geometry.computeLineDistances();
+		this.targetLine.geometry.verticesNeedUpdate = true;
+	
+	}
 
 };

--- a/src/extras/helpers/SpotLightHelper.js
+++ b/src/extras/helpers/SpotLightHelper.js
@@ -92,11 +92,6 @@ THREE.SpotLightHelper = function ( light, sphereSize ) {
 		this.targetLine.properties.isGizmo = true;
 
 	}
-	else {
-
-		this.targetSphere = null;
-
-	}
 
 	//
 


### PR DESCRIPTION
If light.target.properties.targetInverse is false, no targetLine and
targetSphere is created, we can't update their values on update()!

---

I'm trying to use the DirectionalLightHelper to visualise my directional light.

But when I call update() on the helper, my program crashes.

DirectionalLightHelper:114

```
this.targetSphere.material.color.copy( this.color );
```

this.targetSphere is null/undefined!

It should be initialized at DirectionalLightHelper:67

```
this.targetSphere = new THREE.Mesh( targetGeo, targetMaterial );
```

but is not because of DirectionalLightHelper:62

```
if ( light.target.properties.targetInverse ) {
```

I'm using the default target (a Object3D at position [0,0,0]) for my directional light.

Am I missing something, or is update() missing a null/undefined check for this.targetSphere?
