### PR TITLE
Simple Frustum bug fix: "clone" and "constructor" should be real copies.

### DIFF
--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -4,8 +4,8 @@
 
 THREE.Box2 = function ( min, max ) {
 
-	this.min = min !== undefined ? min.clone() : new THREE.Vector2( Infinity, Infinity );
-	this.max = max !== undefined ? max.clone() : new THREE.Vector2( -Infinity, -Infinity );
+	this.min = ( min !== undefined ) ? min : new THREE.Vector2( Infinity, Infinity );
+	this.max = ( max !== undefined ) ? max : new THREE.Vector2( -Infinity, -Infinity );
 
 };
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -4,8 +4,8 @@
 
 THREE.Box3 = function ( min, max ) {
 
-	this.min = min !== undefined ? min.clone() : new THREE.Vector3( Infinity, Infinity, Infinity );
-	this.max = max !== undefined ? max.clone() : new THREE.Vector3( -Infinity, -Infinity, -Infinity );
+	this.min = ( min !== undefined ) ? min : new THREE.Vector3( Infinity, Infinity, Infinity );
+	this.max = ( max !== undefined ) ? max : new THREE.Vector3( -Infinity, -Infinity, -Infinity );
 
 };
 

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -8,12 +8,12 @@ THREE.Frustum = function ( p0, p1, p2, p3, p4, p5 ) {
 
 	this.planes = [
 
-		( p0 !== undefined ) ? p0 : new THREE.Plane(),
-		( p1 !== undefined ) ? p1 : new THREE.Plane(),
-		( p2 !== undefined ) ? p2 : new THREE.Plane(),
-		( p3 !== undefined ) ? p3 : new THREE.Plane(),
-		( p4 !== undefined ) ? p4 : new THREE.Plane(),
-		( p5 !== undefined ) ? p5 : new THREE.Plane()
+		( p0 !== undefined ) ? p0.clone() : new THREE.Plane(),
+		( p1 !== undefined ) ? p1.clone() : new THREE.Plane(),
+		( p2 !== undefined ) ? p2.clone() : new THREE.Plane(),
+		( p3 !== undefined ) ? p3.clone() : new THREE.Plane(),
+		( p4 !== undefined ) ? p4.clone() : new THREE.Plane(),
+		( p5 !== undefined ) ? p5.clone() : new THREE.Plane()
 
 	];
 
@@ -136,9 +136,7 @@ THREE.Frustum.prototype = {
 
 	clone: function () {
 
-		var planes = this.planes;
-
-		return new THREE.Frustum( planes[0], planes[1], planes[2], planes[3], planes[4], planes[5] );
+		return new THREE.Frustum().copy( this );
 
 	}
 

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -8,12 +8,12 @@ THREE.Frustum = function ( p0, p1, p2, p3, p4, p5 ) {
 
 	this.planes = [
 
-		( p0 !== undefined ) ? p0.clone() : new THREE.Plane(),
-		( p1 !== undefined ) ? p1.clone() : new THREE.Plane(),
-		( p2 !== undefined ) ? p2.clone() : new THREE.Plane(),
-		( p3 !== undefined ) ? p3.clone() : new THREE.Plane(),
-		( p4 !== undefined ) ? p4.clone() : new THREE.Plane(),
-		( p5 !== undefined ) ? p5.clone() : new THREE.Plane()
+		( p0 !== undefined ) ? p0 : new THREE.Plane(),
+		( p1 !== undefined ) ? p1 : new THREE.Plane(),
+		( p2 !== undefined ) ? p2 : new THREE.Plane(),
+		( p3 !== undefined ) ? p3 : new THREE.Plane(),
+		( p4 !== undefined ) ? p4 : new THREE.Plane(),
+		( p5 !== undefined ) ? p5 : new THREE.Plane()
 
 	];
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -4,8 +4,8 @@
 
 THREE.Plane = function ( normal, constant ) {
 
-	this.normal = normal !== undefined ? normal.clone() : new THREE.Vector3( 1, 0, 0 );
-	this.constant = constant !== undefined ? constant : 0;
+	this.normal = ( normal !== undefined ) ? normal : new THREE.Vector3( 1, 0, 0 );
+	this.constant = ( constant !== undefined ) ? constant : 0;
 
 };
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -4,9 +4,8 @@
 
 THREE.Ray = function ( origin, direction ) {
 
-
-	this.origin = origin !== undefined ? origin.clone() : new THREE.Vector3();
-	this.direction = direction !== undefined ? direction.clone() : new THREE.Vector3();
+	this.origin = ( origin !== undefined ) ? origin : new THREE.Vector3();
+	this.direction = ( direction !== undefined ) ? direction : new THREE.Vector3();
 
 };
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -5,8 +5,8 @@
 
 THREE.Sphere = function ( center, radius ) {
 
-	this.center = center === undefined ? new THREE.Vector3() : center.clone();
-	this.radius = radius === undefined ? 0 : radius;
+	this.center = ( center !== undefined ) ? center : new THREE.Vector3();
+	this.radius = ( radius !== undefined ) ? radius : 0;
 
 };
 

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -5,17 +5,9 @@
 
 THREE.Triangle = function ( a, b, c ) {
 
-	this.a = new THREE.Vector3();
-	this.b = new THREE.Vector3();
-	this.c = new THREE.Vector3();
-
-	if( a !== undefined && b !== undefined && c !== undefined ) {
-
-		this.a.copy( a );
-		this.b.copy( b );
-		this.c.copy( c );
-
-	}
+	this.a = ( a !== undefined ) ? a : new THREE.Vector3();
+	this.b = ( b !== undefined ) ? b : new THREE.Vector3();
+	this.c = ( c !== undefined ) ? c : new THREE.Vector3();
 
 };
 

--- a/test/unit/math/Box2.js
+++ b/test/unit/math/Box2.js
@@ -9,17 +9,17 @@ test( "constructor", function() {
 	ok( a.min.equals( posInf2 ), "Passed!" );
 	ok( a.max.equals( negInf2 ), "Passed!" );
 
-	a = new THREE.Box2( zero2, zero2 );
+	a = new THREE.Box2( zero2.clone(), zero2.clone() );
 	ok( a.min.equals( zero2 ), "Passed!" );
 	ok( a.max.equals( zero2 ), "Passed!" );
 
-	a = new THREE.Box2( zero2, one2 );
+	a = new THREE.Box2( zero2.clone(), one2.clone() );
 	ok( a.min.equals( zero2 ), "Passed!" );
 	ok( a.max.equals( one2 ), "Passed!" );
 });
 
 test( "copy", function() {
-	var a = new THREE.Box2( zero2, one2 );
+	var a = new THREE.Box2( zero2.clone(), one2.clone() );
 	var b = new THREE.Box2().copy( a );
 	ok( b.min.equals( zero2 ), "Passed!" );
 	ok( b.max.equals( one2 ), "Passed!" );
@@ -44,7 +44,7 @@ test( "empty/makeEmpty", function() {
 
 	ok( a.empty(), "Passed!" );
 
-	var a = new THREE.Box2( zero2, one2 );
+	var a = new THREE.Box2( zero2.clone(), one2.clone() );
 	ok( ! a.empty(), "Passed!" );
 
 	a.makeEmpty();
@@ -52,7 +52,7 @@ test( "empty/makeEmpty", function() {
 });
 
 test( "center", function() {
-	var a = new THREE.Box2( zero2, zero2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
 
 	ok( a.center().equals( zero2 ), "Passed!" );
 
@@ -62,16 +62,16 @@ test( "center", function() {
 });
 
 test( "size", function() {
-	var a = new THREE.Box2( zero2, zero2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
 
 	ok( a.size().equals( zero2 ), "Passed!" );
 
-	a = new THREE.Box2( zero2, one2 );
+	a = new THREE.Box2( zero2.clone(), one2.clone() );
 	ok( a.size().equals( one2 ), "Passed!" );
 });
 
 test( "expandByPoint", function() {
-	var a = new THREE.Box2( zero2, zero2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
 
 	a.expandByPoint( zero2 );
 	ok( a.size().equals( zero2 ), "Passed!" );
@@ -85,7 +85,7 @@ test( "expandByPoint", function() {
 });
 
 test( "expandByVector", function() {
-	var a = new THREE.Box2( zero2, zero2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
 
 	a.expandByVector( zero2 );
 	ok( a.size().equals( zero2 ), "Passed!" );
@@ -96,7 +96,7 @@ test( "expandByVector", function() {
 });
 
 test( "expandByScalar", function() {
-	var a = new THREE.Box2( zero2, zero2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
 
 	a.expandByScalar( 0 );
 	ok( a.size().equals( zero2 ), "Passed!" );
@@ -107,7 +107,7 @@ test( "expandByScalar", function() {
 });
 
 test( "containsPoint", function() {
-	var a = new THREE.Box2( zero2, zero2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
 
 	ok( a.containsPoint( zero2 ), "Passed!" );
 	ok( ! a.containsPoint( one2 ), "Passed!" );
@@ -119,9 +119,9 @@ test( "containsPoint", function() {
 });
 
 test( "containsBox", function() {
-	var a = new THREE.Box2( zero2, zero2 );
-	var b = new THREE.Box2( zero2, one2 );
-	var c = new THREE.Box2( one2.clone().negate(), one2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
+	var b = new THREE.Box2( zero2.clone(), one2.clone() );
+	var c = new THREE.Box2( one2.clone().negate(), one2.clone() );
 
 	ok( a.containsBox( a ), "Passed!" );
 	ok( ! a.containsBox( b ), "Passed!" );
@@ -133,8 +133,8 @@ test( "containsBox", function() {
 });
 
 test( "getParameter", function() {
-	var a = new THREE.Box2( zero2, one2 );
-	var b = new THREE.Box2( one2.clone().negate(), one2 );
+	var a = new THREE.Box2( zero2.clone(), one2.clone() );
+	var b = new THREE.Box2( one2.clone().negate(), one2.clone() );
 
 	ok( a.getParameter( new THREE.Vector2( 0, 0 ) ).equals( new THREE.Vector2( 0, 0 ) ), "Passed!" );
 	ok( a.getParameter( new THREE.Vector2( 1, 1 ) ).equals( new THREE.Vector2( 1, 1 ) ), "Passed!" );
@@ -145,8 +145,8 @@ test( "getParameter", function() {
 });
 
 test( "clampPoint", function() {
-	var a = new THREE.Box2( zero2, zero2 );
-	var b = new THREE.Box2( one2.clone().negate(), one2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
+	var b = new THREE.Box2( one2.clone().negate(), one2.clone() );
 
 	ok( a.clampPoint( new THREE.Vector2( 0, 0 ) ).equals( new THREE.Vector2( 0, 0 ) ), "Passed!" );
 	ok( a.clampPoint( new THREE.Vector2( 1, 1 ) ).equals( new THREE.Vector2( 0, 0 ) ), "Passed!" );
@@ -160,8 +160,8 @@ test( "clampPoint", function() {
 });
 
 test( "distanceToPoint", function() {
-	var a = new THREE.Box2( zero2, zero2 );
-	var b = new THREE.Box2( one2.clone().negate(), one2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
+	var b = new THREE.Box2( one2.clone().negate(), one2.clone() );
 
 	ok( a.distanceToPoint( new THREE.Vector2( 0, 0 ) ) == 0, "Passed!" );
 	ok( a.distanceToPoint( new THREE.Vector2( 1, 1 ) ) == Math.sqrt( 2 ), "Passed!" );
@@ -175,8 +175,8 @@ test( "distanceToPoint", function() {
 });
 
 test( "distanceToPoint", function() {
-	var a = new THREE.Box2( zero2, zero2 );
-	var b = new THREE.Box2( one2.clone().negate(), one2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
+	var b = new THREE.Box2( one2.clone().negate(), one2.clone() );
 
 	ok( a.distanceToPoint( new THREE.Vector2( 0, 0 ) ) == 0, "Passed!" );
 	ok( a.distanceToPoint( new THREE.Vector2( 1, 1 ) ) == Math.sqrt( 2 ), "Passed!" );
@@ -190,9 +190,9 @@ test( "distanceToPoint", function() {
 });
 
 test( "isIntersectionBox", function() {
-	var a = new THREE.Box2( zero2, zero2 );
-	var b = new THREE.Box2( zero2, one2 );
-	var c = new THREE.Box2( one2.clone().negate(), one2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
+	var b = new THREE.Box2( zero2.clone(), one2.clone() );
+	var c = new THREE.Box2( one2.clone().negate(), one2.clone() );
 
 	ok( a.isIntersectionBox( a ), "Passed!" );
 	ok( a.isIntersectionBox( b ), "Passed!" );
@@ -209,9 +209,9 @@ test( "isIntersectionBox", function() {
 });
 
 test( "intersect", function() {
-	var a = new THREE.Box2( zero2, zero2 );
-	var b = new THREE.Box2( zero2, one2 );
-	var c = new THREE.Box2( one2.clone().negate(), one2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
+	var b = new THREE.Box2( zero2.clone(), one2.clone() );
+	var c = new THREE.Box2( one2.clone().negate(), one2.clone() );
 
 	ok( a.clone().intersect( a ).equals( a ), "Passed!" );
 	ok( a.clone().intersect( b ).equals( a ), "Passed!" );
@@ -222,9 +222,9 @@ test( "intersect", function() {
 });
 
 test( "union", function() {
-	var a = new THREE.Box2( zero2, zero2 );
-	var b = new THREE.Box2( zero2, one2 );
-	var c = new THREE.Box2( one2.clone().negate(), one2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
+	var b = new THREE.Box2( zero2.clone(), one2.clone() );
+	var c = new THREE.Box2( one2.clone().negate(), one2.clone() );
 
 	ok( a.clone().union( a ).equals( a ), "Passed!" );
 	ok( a.clone().union( b ).equals( b ), "Passed!" );
@@ -233,10 +233,10 @@ test( "union", function() {
 });
 
 test( "translate", function() {
-	var a = new THREE.Box2( zero2, zero2 );
-	var b = new THREE.Box2( zero2, one2 );
-	var c = new THREE.Box2( one2.clone().negate(), one2 );
-	var d = new THREE.Box2( one2.clone().negate(), zero2 );
+	var a = new THREE.Box2( zero2.clone(), zero2.clone() );
+	var b = new THREE.Box2( zero2.clone(), one2.clone() );
+	var c = new THREE.Box2( one2.clone().negate(), one2.clone() );
+	var d = new THREE.Box2( one2.clone().negate(), zero2.clone() );
 
 	ok( a.clone().translate( one2 ).equals( new THREE.Box2( one2, one2 ) ), "Passed!" );
 	ok( a.clone().translate( one2 ).translate( one2.clone().negate() ).equals( a ), "Passed!" );

--- a/test/unit/math/Box3.js
+++ b/test/unit/math/Box3.js
@@ -9,17 +9,17 @@ test( "constructor", function() {
 	ok( a.min.equals( posInf3 ), "Passed!" );
 	ok( a.max.equals( negInf3 ), "Passed!" );
 
-	a = new THREE.Box3( zero3, zero3 );
+	a = new THREE.Box3( zero3.clone(), zero3.clone() );
 	ok( a.min.equals( zero3 ), "Passed!" );
 	ok( a.max.equals( zero3 ), "Passed!" );
 
-	a = new THREE.Box3( zero3, one3 );
+	a = new THREE.Box3( zero3.clone(), one3.clone() );
 	ok( a.min.equals( zero3 ), "Passed!" );
 	ok( a.max.equals( one3 ), "Passed!" );
 });
 
 test( "copy", function() {
-	var a = new THREE.Box3( zero3, one3 );
+	var a = new THREE.Box3( zero3.clone(), one3.clone() );
 	var b = new THREE.Box3().copy( a );
 	ok( b.min.equals( zero3 ), "Passed!" );
 	ok( b.max.equals( one3 ), "Passed!" );
@@ -44,7 +44,7 @@ test( "empty/makeEmpty", function() {
 
 	ok( a.empty(), "Passed!" );
 
-	var a = new THREE.Box3( zero3, one3 );
+	var a = new THREE.Box3( zero3.clone(), one3.clone() );
 	ok( ! a.empty(), "Passed!" );
 
 	a.makeEmpty();
@@ -52,26 +52,26 @@ test( "empty/makeEmpty", function() {
 });
 
 test( "center", function() {
-	var a = new THREE.Box3( zero3, zero3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
 
 	ok( a.center().equals( zero3 ), "Passed!" );
 
-	a = new THREE.Box3( zero3, one3 );
+	a = new THREE.Box3( zero3.clone(), one3.clone() );
 	var midpoint = one3.clone().multiplyScalar( 0.5 );
 	ok( a.center().equals( midpoint ), "Passed!" );
 });
 
 test( "size", function() {
-	var a = new THREE.Box3( zero3, zero3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
 
 	ok( a.size().equals( zero3 ), "Passed!" );
 
-	a = new THREE.Box3( zero3, one3 );
+	a = new THREE.Box3( zero3.clone(), one3.clone() );
 	ok( a.size().equals( one3 ), "Passed!" );
 });
 
 test( "expandByPoint", function() {
-	var a = new THREE.Box3( zero3, zero3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
 
 	a.expandByPoint( zero3 );
 	ok( a.size().equals( zero3 ), "Passed!" );
@@ -85,7 +85,7 @@ test( "expandByPoint", function() {
 });
 
 test( "expandByVector", function() {
-	var a = new THREE.Box3( zero3, zero3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
 
 	a.expandByVector( zero3 );
 	ok( a.size().equals( zero3 ), "Passed!" );
@@ -96,7 +96,7 @@ test( "expandByVector", function() {
 });
 
 test( "expandByScalar", function() {
-	var a = new THREE.Box3( zero3, zero3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
 
 	a.expandByScalar( 0 );
 	ok( a.size().equals( zero3 ), "Passed!" );
@@ -107,7 +107,7 @@ test( "expandByScalar", function() {
 });
 
 test( "containsPoint", function() {
-	var a = new THREE.Box3( zero3, zero3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
 
 	ok( a.containsPoint( zero3 ), "Passed!" );
 	ok( ! a.containsPoint( one3 ), "Passed!" );
@@ -119,9 +119,9 @@ test( "containsPoint", function() {
 });
 
 test( "containsBox", function() {
-	var a = new THREE.Box3( zero3, zero3 );
-	var b = new THREE.Box3( zero3, one3 );
-	var c = new THREE.Box3( one3.clone().negate(), one3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( zero3.clone(), one3.clone() );
+	var c = new THREE.Box3( one3.clone().negate(), one3.clone() );
 
 	ok( a.containsBox( a ), "Passed!" );
 	ok( ! a.containsBox( b ), "Passed!" );
@@ -133,8 +133,8 @@ test( "containsBox", function() {
 });
 
 test( "getParameter", function() {
-	var a = new THREE.Box3( zero3, one3 );
-	var b = new THREE.Box3( one3.clone().negate(), one3 );
+	var a = new THREE.Box3( zero3.clone(), one3.clone() );
+	var b = new THREE.Box3( one3.clone().negate(), one3.clone() );
 
 	ok( a.getParameter( new THREE.Vector3( 0, 0, 0 ) ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 	ok( a.getParameter( new THREE.Vector3( 1, 1, 1 ) ).equals( new THREE.Vector3( 1, 1, 1 ) ), "Passed!" );
@@ -145,8 +145,8 @@ test( "getParameter", function() {
 });
 
 test( "clampPoint", function() {
-	var a = new THREE.Box3( zero3, zero3 );
-	var b = new THREE.Box3( one3.clone().negate(), one3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( one3.clone().negate(), one3.clone() );
 
 	ok( a.clampPoint( new THREE.Vector3( 0, 0, 0 ) ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 	ok( a.clampPoint( new THREE.Vector3( 1, 1, 1 ) ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
@@ -160,8 +160,8 @@ test( "clampPoint", function() {
 });
 
 test( "distanceToPoint", function() {
-	var a = new THREE.Box3( zero3, zero3  );
-	var b = new THREE.Box3( one3.clone().negate(), one3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( one3.clone().negate(), one3.clone() );
 
 	ok( a.distanceToPoint( new THREE.Vector3( 0, 0, 0 ) ) == 0, "Passed!" );
 	ok( a.distanceToPoint( new THREE.Vector3( 1, 1, 1 ) ) == Math.sqrt( 3 ), "Passed!" );
@@ -175,8 +175,8 @@ test( "distanceToPoint", function() {
 });
 
 test( "distanceToPoint", function() {
-	var a = new THREE.Box3( zero3, zero3  );
-	var b = new THREE.Box3( one3.clone().negate(), one3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( one3.clone().negate(), one3.clone() );
 
 	ok( a.distanceToPoint( new THREE.Vector3( 0, 0, 0 ) ) == 0, "Passed!" );
 	ok( a.distanceToPoint( new THREE.Vector3( 1, 1, 1 ) ) == Math.sqrt( 3 ), "Passed!" );
@@ -190,9 +190,9 @@ test( "distanceToPoint", function() {
 });
 
 test( "isIntersectionBox", function() {
-	var a = new THREE.Box3( zero3, zero3 );
-	var b = new THREE.Box3( zero3, one3 );
-	var c = new THREE.Box3( one3.clone().negate(), one3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( zero3.clone(), one3.clone() );
+	var c = new THREE.Box3( one3.clone().negate(), one3.clone() );
 
 	ok( a.isIntersectionBox( a ), "Passed!" );
 	ok( a.isIntersectionBox( b ), "Passed!" );
@@ -209,9 +209,9 @@ test( "isIntersectionBox", function() {
 });
 
 test( "getBoundingSphere", function() {
-	var a = new THREE.Box3( zero3, zero3 );
-	var b = new THREE.Box3( zero3, one3 );
-	var c = new THREE.Box3( one3.clone().negate(), one3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( zero3.clone(), one3.clone() );
+	var c = new THREE.Box3( one3.clone().negate(), one3.clone() );
 
 	ok( a.getBoundingSphere().equals( new THREE.Sphere( zero3, 0 ) ), "Passed!" );
 	ok( b.getBoundingSphere().equals( new THREE.Sphere( one3.clone().multiplyScalar( 0.5 ), Math.sqrt( 3 ) * 0.5 ) ), "Passed!" );
@@ -219,9 +219,9 @@ test( "getBoundingSphere", function() {
 });
 
 test( "intersect", function() {
-	var a = new THREE.Box3( zero3, zero3 );
-	var b = new THREE.Box3( zero3, one3 );
-	var c = new THREE.Box3( one3.clone().negate(), one3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( zero3.clone(), one3.clone() );
+	var c = new THREE.Box3( one3.clone().negate(), one3.clone() );
 
 	ok( a.clone().intersect( a ).equals( a ), "Passed!" );
 	ok( a.clone().intersect( b ).equals( a ), "Passed!" );
@@ -232,9 +232,9 @@ test( "intersect", function() {
 });
 
 test( "union", function() {
-	var a = new THREE.Box3( zero3, zero3 );
-	var b = new THREE.Box3( zero3, one3 );
-	var c = new THREE.Box3( one3.clone().negate(), one3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( zero3.clone(), one3.clone() );
+	var c = new THREE.Box3( one3.clone().negate(), one3.clone() );
 
 	ok( a.clone().union( a ).equals( a ), "Passed!" );
 	ok( a.clone().union( b ).equals( b ), "Passed!" );
@@ -249,10 +249,10 @@ var compareBox = function ( a, b, threshold ) {
 };
 
 test( "transform", function() {
-	var a = new THREE.Box3( zero3, zero3 );
-	var b = new THREE.Box3( zero3, one3 );
-	var c = new THREE.Box3( one3.clone().negate(), one3 );
-	var d = new THREE.Box3( one3.clone().negate(), zero3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( zero3.clone(), one3.clone() );
+	var c = new THREE.Box3( one3.clone().negate(), one3.clone() );
+	var d = new THREE.Box3( one3.clone().negate(), zero3.clone() );
 
 	var m = new THREE.Matrix4();
 
@@ -265,10 +265,10 @@ test( "transform", function() {
 });
 
 test( "translate", function() {
-	var a = new THREE.Box3( zero3, zero3 );
-	var b = new THREE.Box3( zero3, one3 );
-	var c = new THREE.Box3( one3.clone().negate(), one3 );
-	var d = new THREE.Box3( one3.clone().negate(), zero3 );
+	var a = new THREE.Box3( zero3.clone(), zero3.clone() );
+	var b = new THREE.Box3( zero3.clone(), one3.clone() );
+	var c = new THREE.Box3( one3.clone().negate(), one3.clone() );
+	var d = new THREE.Box3( one3.clone().negate(), zero3.clone() );
 
 	ok( a.clone().translate( one3 ).equals( new THREE.Box3( one3, one3 ) ), "Passed!" );
 	ok( a.clone().translate( one3 ).translate( one3.clone().negate() ).equals( a ), "Passed!" );

--- a/test/unit/math/Frustum.js
+++ b/test/unit/math/Frustum.js
@@ -42,6 +42,9 @@ test( "constructor", function() {
 	ok( a.planes[3].equals( p3 ), "Passed!" );
 	ok( a.planes[4].equals( p4 ), "Passed!" );
 	ok( a.planes[5].equals( p5 ), "Passed!" );
+
+	p0.copy( p1 );
+	ok( ! a.planes[0].equals( p0 ), "Passed!" );
 });
 
 test( "copy", function() {
@@ -151,6 +154,6 @@ test( "clone", function() {
 	ok( a.planes[5].equals( p5 ), "Passed!" );
 
 	// ensure it is a true copy by modifying source
-	b.planes[0] = p1;
+	b.planes[0].copy( p1 );
 	ok( a.planes[0].equals( p0 ), "Passed!" );
 });

--- a/test/unit/math/Frustum.js
+++ b/test/unit/math/Frustum.js
@@ -42,9 +42,6 @@ test( "constructor", function() {
 	ok( a.planes[3].equals( p3 ), "Passed!" );
 	ok( a.planes[4].equals( p4 ), "Passed!" );
 	ok( a.planes[5].equals( p5 ), "Passed!" );
-
-	p0.copy( p1 );
-	ok( ! a.planes[0].equals( p0 ), "Passed!" );
 });
 
 test( "copy", function() {
@@ -154,6 +151,6 @@ test( "clone", function() {
 	ok( a.planes[5].equals( p5 ), "Passed!" );
 
 	// ensure it is a true copy by modifying source
-	b.planes[0].copy( p1 );
-	ok( a.planes[0].equals( p0 ), "Passed!" );
+	a.planes[0].copy( p1 );
+	ok( b.planes[0].equals( p0 ), "Passed!" );
 });

--- a/test/unit/math/Plane.js
+++ b/test/unit/math/Plane.js
@@ -18,13 +18,13 @@ test( "constructor", function() {
 	ok( a.normal.z == 0, "Passed!" );
 	ok( a.constant == 0, "Passed!" );
 
-	a = new THREE.Plane( one3, 0 );
+	a = new THREE.Plane( one3.clone(), 0 );
 	ok( a.normal.x == 1, "Passed!" );
 	ok( a.normal.y == 1, "Passed!" );
 	ok( a.normal.z == 1, "Passed!" );
 	ok( a.constant == 0, "Passed!" );
 
-	a = new THREE.Plane( one3, 1 );
+	a = new THREE.Plane( one3.clone(), 1 );
 	ok( a.normal.x == 1, "Passed!" );
 	ok( a.normal.y == 1, "Passed!" );
 	ok( a.normal.z == 1, "Passed!" );

--- a/test/unit/math/Ray.js
+++ b/test/unit/math/Ray.js
@@ -9,13 +9,13 @@ test( "constructor/equals", function() {
 	ok( a.origin.equals( zero3 ), "Passed!" );
 	ok( a.direction.equals( zero3 ), "Passed!" );
 
-	a = new THREE.Ray( two3, one3 );
+	a = new THREE.Ray( two3.clone(), one3.clone() );
 	ok( a.origin.equals( two3 ), "Passed!" );
 	ok( a.direction.equals( one3 ), "Passed!" );
 });
 
 test( "copy/equals", function() {
-	var a = new THREE.Ray( zero3, one3 );
+	var a = new THREE.Ray( zero3.clone(), one3.clone() );
 	var b = new THREE.Ray().copy( a );
 	ok( b.origin.equals( zero3 ), "Passed!" );
 	ok( b.direction.equals( one3 ), "Passed!" );
@@ -36,7 +36,7 @@ test( "set", function() {
 });
 
 test( "at", function() {
-	var a = new THREE.Ray( one3, new THREE.Vector3( 0, 0, 1 ) );
+	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
 	ok( a.at( 0 ).equals( one3 ), "Passed!" );
 	ok( a.at( -1 ).equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
@@ -44,7 +44,7 @@ test( "at", function() {
 });
 
 test( "recast/clone", function() {
-	var a = new THREE.Ray( one3, new THREE.Vector3( 0, 0, 1 ) );
+	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
 	ok( a.recast( 0 ).equals( a ), "Passed!" );
 
@@ -62,7 +62,7 @@ test( "recast/clone", function() {
 });
 
 test( "closestPointToPoint", function() {
-	var a = new THREE.Ray( one3, new THREE.Vector3( 0, 0, 1 ) );
+	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
 	// nearby the ray
 	var b = a.closestPointToPoint( zero3 );
@@ -74,7 +74,7 @@ test( "closestPointToPoint", function() {
 });
 
 test( "distanceToPoint", function() {
-	var a = new THREE.Ray( one3, new THREE.Vector3( 0, 0, 1 ) );
+	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
 	// nearby the ray
 	var b = a.distanceToPoint( zero3 );
@@ -86,7 +86,7 @@ test( "distanceToPoint", function() {
 });
 
 test( "isIntersectionSphere", function() {
-	var a = new THREE.Ray( one3, new THREE.Vector3( 0, 0, 1 ) );
+	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 	var b = new THREE.Sphere( zero3, 0.5 );
 	var c = new THREE.Sphere( zero3, 1.5 );
 	var d = new THREE.Sphere( one3, 0.1 );
@@ -101,7 +101,7 @@ test( "isIntersectionSphere", function() {
 });
 
 test( "isIntersectionPlane", function() {
-	var a = new THREE.Ray( one3, new THREE.Vector3( 0, 0, 1 ) );
+	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
 	// parallel plane behind
 	var b = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), one3.clone().sub( new THREE.Vector3( 0, 0, -1 ) ) );
@@ -125,7 +125,7 @@ test( "isIntersectionPlane", function() {
 });
 
 test( "intersectPlane", function() {
-	var a = new THREE.Ray( one3, new THREE.Vector3( 0, 0, 1 ) );
+	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
 	// parallel plane behind
 	var b = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), new THREE.Vector3( 1, 1, -1 ) );
@@ -150,12 +150,12 @@ test( "intersectPlane", function() {
 
 
 test( "transform", function() {
-	var a = new THREE.Ray( one3, new THREE.Vector3( 0, 0, 1 ) );
+	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 	var m = new THREE.Matrix4().identity();
 
 	ok( a.clone().transform( m ).equals( a ), "Passed!" );
 
-	a = new THREE.Ray( zero3, new THREE.Vector3( 0, 0, 1 ) );
+	a = new THREE.Ray( zero3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 	m.rotateByAxis( new THREE.Vector3( 0, 0, 1 ), Math.PI );
 	ok( a.clone().transform( m ).equals( a ), "Passed!" );
 


### PR DESCRIPTION
Unlike the constructors and clone methods of other math classes, the Frustum constructor and clone did not do proper copies of their parameters, leading to multiple Frustums referencing the same set of planes.

There was a bug in the Frustum clone unit test that allow for the bug in clone to get through the unit tests.  I've also expanded the constructor unit test to catch this type of issue in the future.
