### PR TITLE
Added support for object groups in the SceneLoader. "groups" is a new pr...

### DIFF
--- a/src/loaders/SceneLoader.js
+++ b/src/loaders/SceneLoader.js
@@ -111,7 +111,8 @@ THREE.SceneLoader.prototype.parse = function ( json, callbackFinished, url ) {
 		cameras: {},
 		lights: {},
 		fogs: {},
-		empties: {}
+		empties: {},
+		groups: {}
 
 	};
 
@@ -481,6 +482,23 @@ THREE.SceneLoader.prototype.parse = function ( json, callbackFinished, url ) {
 
 			}
 
+			if ( objJSON.groups !== undefined ) {
+
+				for ( var i = 0; i < objJSON.groups.length; i ++ ) {
+
+					var groupID = objJSON.groups[i];
+
+					if ( result.groups[groupID] === undefined ) {
+
+						result.groups[groupID] = [];
+
+					}
+
+					result.groups[groupID].push(objID);
+
+				}
+
+			}
 		}
 
 	};


### PR DESCRIPTION
Added support for object groups in the SceneLoader. "groups" is a new property in the SceneLoader result object..

Ex:

```
input {
  //...
  "objects" : {
    "Object.1" : {
      "groups"    : [ "Group.A" ],
      //...
    },
    "Object.2" : {
      "groups"    : [ "Group.A", "Group.B" ],
      //...
    },
    "Object.3" : {
      "groups"    : [ "Group.B" ],
      //...
    }
  }
}
```

```
result {
  //...
  groups: {
    'Group.A': [ 'Object.1', 'Object.2' ],
    'Group.B': [ 'Object.2', 'Object.3' ]
  },
  //...
}
```
