### PR TITLE
Webglrenderer2: update f53b275 bc94173

### DIFF
--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -858,7 +858,7 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 			}
 
-    }
+		}
 
 	};
 

--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -154,6 +154,9 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 	this.getPrecision = renderer.getPrecision;
 	this.getContext = renderer.getContext;
 	this.supportsVertexTextures = renderer.supportsVertexTextures;
+	this.supportsFloatTextures = renderer.supportsFloatTextures;
+	this.supportsStandardDerivatives = renderer.supportsStandardDerivatives;
+	this.supportsCompressedTextureS3TC = renderer.supportsCompressedTextureS3TC;
 	this.getMaxAnisotropy  = renderer.getMaxAnisotropy;
 	this.setSize = renderer.setSize;
 	this.setViewport = renderer.setViewport;

--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -829,7 +829,36 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 			}
 
-		}
+		} else if ( object instanceof THREE.Line ) {
+
+			if ( updateBuffers ) {
+
+				// vertices
+
+				var position = geometry.attributes[ "position" ];
+				var positionSize = position.itemSize;
+				renderer.setFloatAttribute(attributes.position , position.buffer, positionSize, 0);
+
+				// colors
+
+				var color = geometry.attributes[ "color" ];
+
+				if ( attributes.color >= 0 && color ) {
+
+					var colorSize = color.itemSize;
+					renderer.setFloatAttribute(attributes.color , color.buffer, colorSize, 0);
+
+				}
+
+				// render lines
+				renderer.drawLineStrip(position.numItems / 3);
+
+				_this.info.render.calls ++;
+				_this.info.render.points += position.numItems;
+
+			}
+
+    }
 
 	};
 
@@ -1769,17 +1798,26 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 				}
 
 			} else if ( object instanceof THREE.Line ) {
-
+				
+				
 				geometry = object.geometry;
 
 				if ( ! geometry.__webglVertexBuffer ) {
 
-					lineRenderer.createBuffers( geometry );
-					lineRenderer.initBuffers( geometry, object );
+					if ( geometry instanceof THREE.Geometry ) {
 
-					geometry.verticesNeedUpdate = true;
-					geometry.colorsNeedUpdate = true;
-					geometry.lineDistancesNeedUpdate = true;
+						lineRenderer.createBuffers( geometry );
+						lineRenderer.initBuffers( geometry, object );
+
+						geometry.verticesNeedUpdate = true;
+						geometry.colorsNeedUpdate = true;
+						geometry.lineDistancesNeedUpdate = true;
+
+					} else if ( geometry instanceof THREE.BufferGeometry ) {
+
+						initDirectBuffers( geometry );
+
+					}
 
 				}
 
@@ -1971,23 +2009,38 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 			material.attributes && clearCustomAttributes( material );
 
 		} else if ( object instanceof THREE.Line ) {
+			
+			if ( geometry instanceof THREE.BufferGeometry ) {
 
-			material = getBufferMaterial( object, geometry );
+				if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate ) {
 
-			customAttributesDirty = material.attributes && areCustomAttributesDirty( material );
+					setDirectBuffers( geometry,  !geometry.dynamic );
 
-			if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate || geometry.lineDistancesNeedUpdate || customAttributesDirty ) {
+				}
 
-				lineRenderer.setBuffers( geometry);
+				geometry.verticesNeedUpdate = false;
+				geometry.colorsNeedUpdate = false;
+
+			} else {
+
+				material = getBufferMaterial( object, geometry );
+	
+				customAttributesDirty = material.attributes && areCustomAttributesDirty( material );
+	
+				if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate || geometry.lineDistancesNeedUpdate || customAttributesDirty ) {
+	
+					lineRenderer.setBuffers( geometry);
+	
+				}
+	
+				geometry.verticesNeedUpdate = false;
+				geometry.colorsNeedUpdate = false;
+				geometry.lineDistancesNeedUpdate = false;
+	
+				material.attributes && clearCustomAttributes( material );
 
 			}
-
-			geometry.verticesNeedUpdate = false;
-			geometry.colorsNeedUpdate = false;
-			geometry.lineDistancesNeedUpdate = false;
-
-			material.attributes && clearCustomAttributes( material );
-
+			
 		} else if ( object instanceof THREE.ParticleSystem ) {
 
 			if ( geometry instanceof THREE.BufferGeometry ) {

--- a/src/renderers/webgl/LowLevelRenderer.js
+++ b/src/renderers/webgl/LowLevelRenderer.js
@@ -242,6 +242,24 @@ THREE.WebGLRenderer2.LowLevelRenderer = function(parameters){
 		return _supportsVertexTextures;
 
 	};
+	
+	function supportsFloatTextures() {
+
+		return _glExtensionTextureFloat;
+
+	};
+
+	function supportsStandardDerivatives() {
+
+		return _glExtensionStandardDerivatives;
+
+	};
+
+	function supportsCompressedTextureS3TC() {
+
+		return _glExtensionCompressedTextureS3TC;
+
+	};
 
 	function getMaxAnisotropy() {
 
@@ -1441,6 +1459,9 @@ THREE.WebGLRenderer2.LowLevelRenderer = function(parameters){
 	this.getCurrentWidth = getCurrentWidth;
 	this.getCurrentHeight = getCurrentHeight;
 	this.supportsVertexTextures = supportsVertexTextures;
+	this.supportsFloatTextures = supportsFloatTextures;
+	this.supportsStandardDerivatives = supportsStandardDerivatives;
+	this.supportsCompressedTextureS3TC = supportsCompressedTextureS3TC;
 	this.getMaxAnisotropy  = getMaxAnisotropy;
 	
 	this.setRenderTarget = setRenderTarget;


### PR DESCRIPTION
Make Webglrenderer2 consistent with webglrenderer again:
- f53b275 : Added support for THREE.Lines as bufferGeometry
- bc94173 : Exposed more supports tests
