### PR TITLE
Added Vector3.applyEuler() and Vector3.applyAxisAngle

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -346,3 +346,5 @@ THREE.Quaternion.slerp = function ( qa, qb, qm, t ) {
 	return qm.copy( qa ).slerp( qb, t );
 
 }
+
+THREE.Vector3.__q1 = new THREE.Quaternion(); // to be moved to Vector3.js

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -252,6 +252,26 @@ THREE.Vector3.prototype = {
 
 	},
 
+	applyEuler: function ( v, eulerOrder ) {
+
+		var quaternion = THREE.Vector3.__q1.setFromEuler( v, eulerOrder );
+
+		this.applyQuaternion( quaternion );
+
+		return this;
+
+	},
+
+	applyAxisAngle: function ( axis, angle ) {
+
+		var quaternion = THREE.Vector3.__q1.setFromAxisAngle( axis, angle );
+
+		this.applyQuaternion( quaternion );
+
+		return this;
+
+	},
+
 	divide: function ( v ) {
 
 		this.x /= v.x;


### PR DESCRIPTION
We now have all four rotation representations represented in the form of Vector3.apply*();

Caveat: I had trouble getting this to build, as I needed to declare within `Vector3.js` the following:

```
THREE.Vector3.__q1 = new THREE.Quaternion();
```

But due to the build order, it was forward-referencing `Quaternion`. Not good.., so I declared it in `Quaternion.js`, instead. I know we don't want to do that. This needs to be fixed, somehow.

I think the solution is to change the build order, but that can be a Catch-22...

I'd appreciate help with this one. :-)
