### PR TITLE
Initial adoption of closures in the math library.  All unit tests pass.  All examples work that I tested.

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -46,6 +46,28 @@ String.prototype.trim = String.prototype.trim || function () {
 };
 
 
+THREE.extend = function ( target, other ) {
+
+	target = target || {};
+
+	for (var prop in other) {
+
+		if ( typeof other[prop] === 'object' ) {
+
+			target[prop] = THREE.extend( target[prop], other[prop] );
+
+		} else {
+
+			target[prop] = other[prop];
+
+		}
+
+	}
+
+	return target;
+	
+};
+
 // http://paulirish.com/2011/requestanimationframe-for-smart-animating/
 // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
 

--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -9,7 +9,7 @@ THREE.Box2 = function ( min, max ) {
 
 };
 
-THREE.Box2.prototype = {
+THREE.extend( THREE.Box2.prototype, {
 
 	constructor: THREE.Box2,
 
@@ -259,4 +259,4 @@ THREE.Box2.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -67,15 +67,21 @@ THREE.Box2.prototype = {
 
 	},
 
-	setFromCenterAndSize: function ( center, size ) {
+	setFromCenterAndSize: function() {
 
-		var halfSize = THREE.Box2.__v1.copy( size ).multiplyScalar( 0.5 );
-		this.min.copy( center ).sub( halfSize );
-		this.max.copy( center ).add( halfSize );
+		var v1 = new THREE.Vector2();
+		
+		return function ( center, size ) {
 
-		return this;
+			var halfSize = v1.copy( size ).multiplyScalar( 0.5 );
+			this.min.copy( center ).sub( halfSize );
+			this.max.copy( center ).add( halfSize );
 
-	},
+			return this;
+
+		};
+
+	}(),
 
 	copy: function ( box ) {
 
@@ -201,12 +207,18 @@ THREE.Box2.prototype = {
 
 	},
 
-	distanceToPoint: function ( point ) {
+	distanceToPoint: function() {
 
-		var clampedPoint = THREE.Box2.__v1.copy( point ).clamp( this.min, this.max );
-		return clampedPoint.sub( point ).length();
+		var v1 = new THREE.Vector2();
+		
+		return function ( point ) {
 
-	},
+			var clampedPoint = v1.copy( point ).clamp( this.min, this.max );
+			return clampedPoint.sub( point ).length();
+
+		};
+
+	}(),
 
 	intersect: function ( box ) {
 
@@ -248,5 +260,3 @@ THREE.Box2.prototype = {
 	}
 
 };
-
-THREE.Box2.__v1 = new THREE.Vector2();

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -9,7 +9,7 @@ THREE.Box3 = function ( min, max ) {
 
 };
 
-THREE.Box3.prototype = {
+THREE.extend( THREE.Box3.prototype, {
 
 	constructor: THREE.Box3,
 
@@ -328,4 +328,4 @@ THREE.Box3.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -77,16 +77,22 @@ THREE.Box3.prototype = {
 
 	},
 
-	setFromCenterAndSize: function ( center, size ) {
+	setFromCenterAndSize: function() {
 
-		var halfSize = THREE.Box3.__v1.copy( size ).multiplyScalar( 0.5 );
+		var v1 = new THREE.Vector3();
+		
+		return function ( center, size ) {
 
-		this.min.copy( center ).sub( halfSize );
-		this.max.copy( center ).add( halfSize );
+			var halfSize = v1.copy( size ).multiplyScalar( 0.5 );
 
-		return this;
+			this.min.copy( center ).sub( halfSize );
+			this.max.copy( center ).add( halfSize );
 
-	},
+			return this;
+
+		};
+
+	}(),
 
 	copy: function ( box ) {
 
@@ -215,27 +221,39 @@ THREE.Box3.prototype = {
 	clampPoint: function ( point, optionalTarget ) {
 
 		var result = optionalTarget || new THREE.Vector3();
-		return new THREE.Vector3().copy( point ).clamp( this.min, this.max );
+		return result.copy( point ).clamp( this.min, this.max );
 
 	},
 
-	distanceToPoint: function ( point ) {
+	distanceToPoint: function() {
 
-		var clampedPoint = THREE.Box3.__v1.copy( point ).clamp( this.min, this.max );
-		return clampedPoint.sub( point ).length();
+		var v1 = new THREE.Vector3();
+		
+		return function ( point ) {
 
-	},
+			var clampedPoint = v1.copy( point ).clamp( this.min, this.max );
+			return clampedPoint.sub( point ).length();
 
-	getBoundingSphere: function ( optionalTarget ) {
+		};
 
-		var result = optionalTarget || new THREE.Sphere();
+	}(),
 
-		result.center = this.center();
-		result.radius = this.size( THREE.Box3.__v0 ).length() * 0.5;
+	getBoundingSphere: function() {
 
-		return result;
+		var v1 = new THREE.Vector3();
+		
+		return function ( optionalTarget ) {
 
-	},
+			var result = optionalTarget || new THREE.Sphere();
+
+			result.center = this.center();
+			result.radius = this.size( v1 ).length() * 0.5;
+
+			return result;
+
+		};
+
+	}(),
 
 	intersect: function ( box ) {
 
@@ -255,27 +273,39 @@ THREE.Box3.prototype = {
 
 	},
 
-	transform: function ( matrix ) {
+	transform: function() {
 
-		// NOTE: I am using a binary pattern to specify all 2^3 combinations below
-		var newPoints = [
-			THREE.Box3.__v0.set( this.min.x, this.min.y, this.min.z ).applyMatrix4( matrix ),
-			THREE.Box3.__v0.set( this.min.x, this.min.y, this.min.z ).applyMatrix4( matrix ), // 000
-			THREE.Box3.__v1.set( this.min.x, this.min.y, this.max.z ).applyMatrix4( matrix ), // 001
-			THREE.Box3.__v2.set( this.min.x, this.max.y, this.min.z ).applyMatrix4( matrix ), // 010
-			THREE.Box3.__v3.set( this.min.x, this.max.y, this.max.z ).applyMatrix4( matrix ), // 011
-			THREE.Box3.__v4.set( this.max.x, this.min.y, this.min.z ).applyMatrix4( matrix ), // 100
-			THREE.Box3.__v5.set( this.max.x, this.min.y, this.max.z ).applyMatrix4( matrix ), // 101
-			THREE.Box3.__v6.set( this.max.x, this.max.y, this.min.z ).applyMatrix4( matrix ), // 110
-			THREE.Box3.__v7.set( this.max.x, this.max.y, this.max.z ).applyMatrix4( matrix )  // 111
-		];
+		var points = [
+			new THREE.Vector3(),
+			new THREE.Vector3(),
+			new THREE.Vector3(),
+			new THREE.Vector3(),
+			new THREE.Vector3(),
+			new THREE.Vector3(),
+			new THREE.Vector3(),
+			new THREE.Vector3()
+			];
 
-		this.makeEmpty();
-		this.setFromPoints( newPoints );
+		return function ( matrix ) {
 
-		return this;
+			// NOTE: I am using a binary pattern to specify all 2^3 combinations below
+			points[0].set( this.min.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 000
+			points[1].set( this.min.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 001
+			points[2].set( this.min.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 010
+			points[3].set( this.min.x, this.max.y, this.max.z ).applyMatrix4( matrix ); // 011
+			points[4].set( this.max.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 100
+			points[5].set( this.max.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 101
+			points[6].set( this.max.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 110
+			points[7].set( this.max.x, this.max.y, this.max.z ).applyMatrix4( matrix );  // 111
+			
+			this.makeEmpty();
+			this.setFromPoints( points );
 
-	},
+			return this;
+
+		};
+
+	}(),
 
 	translate: function ( offset ) {
 
@@ -299,12 +329,3 @@ THREE.Box3.prototype = {
 	}
 
 };
-
-THREE.Box3.__v0 = new THREE.Vector3();
-THREE.Box3.__v1 = new THREE.Vector3();
-THREE.Box3.__v2 = new THREE.Vector3();
-THREE.Box3.__v3 = new THREE.Vector3();
-THREE.Box3.__v4 = new THREE.Vector3();
-THREE.Box3.__v5 = new THREE.Vector3();
-THREE.Box3.__v6 = new THREE.Vector3();
-THREE.Box3.__v7 = new THREE.Vector3();

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -10,7 +10,7 @@ THREE.Color = function ( value ) {
 
 };
 
-THREE.Color.prototype = {
+THREE.extend( THREE.Color.prototype, {
 
 	constructor: THREE.Color,
 
@@ -390,7 +390,7 @@ THREE.Color.prototype = {
 
 	}
 
-};
+} );
 
 THREE.ColorKeywords = { "aliceblue": 0xF0F8FF, "antiquewhite": 0xFAEBD7, "aqua": 0x00FFFF, "aquamarine": 0x7FFFD4, "azure": 0xF0FFFF,
 "beige": 0xF5F5DC, "bisque": 0xFFE4C4, "black": 0x000000, "blanchedalmond": 0xFFEBCD, "blue": 0x0000FF, "blueviolet": 0x8A2BE2,

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -19,7 +19,7 @@ THREE.Frustum = function ( p0, p1, p2, p3, p4, p5 ) {
 
 };
 
-THREE.Frustum.prototype = {
+THREE.extend( THREE.Frustum.prototype, {
 
 	set: function ( p0, p1, p2, p3, p4, p5 ) {
 
@@ -140,4 +140,4 @@ THREE.Frustum.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -67,19 +67,28 @@ THREE.Math = {
 
 	},
 
-	degToRad: function ( degrees ) {
+	degToRad: function() {
 
-		return degrees * THREE.Math.__d2r;
+		var degreeToRadiansFactor = Math.PI / 180;
 
-	},
+		return function ( degrees ) {
 
-	radToDeg: function ( radians ) {
+			return degrees * degreeToRadiansFactor;
 
-		return radians * THREE.Math.__r2d;
+		};
 
-	}
+	}(),
+
+	radToDeg: function() {
+		
+		var radianToDegreesFactor = 180 / Math.PI;
+
+		return function ( radians ) {
+
+			return radians * radianToDegreesFactor;
+
+		};
+
+	}()
 
 };
-
-THREE.Math.__d2r =  Math.PI / 180;
-THREE.Math.__r2d =  180 / Math.PI;

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -70,27 +70,31 @@ THREE.Matrix3.prototype = {
 
 	},
 
-	multiplyVector3Array: function ( a ) {
+	multiplyVector3Array: function() {
 
-		var tmp = THREE.Matrix3.__v1;
+		var v1 = new THREE.Vector3();
+		
+		return function ( a ) {
 
-		for ( var i = 0, il = a.length; i < il; i += 3 ) {
+			for ( var i = 0, il = a.length; i < il; i += 3 ) {
 
-			tmp.x = a[ i ];
-			tmp.y = a[ i + 1 ];
-			tmp.z = a[ i + 2 ];
+				v1.x = a[ i ];
+				v1.y = a[ i + 1 ];
+				v1.z = a[ i + 2 ];
 
-			tmp.applyMatrix3(this);
+				v1.applyMatrix3(this);
 
-			a[ i ]     = tmp.x;
-			a[ i + 1 ] = tmp.y;
-			a[ i + 2 ] = tmp.z;
+				a[ i ]     = v1.x;
+				a[ i + 1 ] = v1.y;
+				a[ i + 2 ] = v1.z;
 
-		}
+			}
 
-		return a;
+			return a;
 
-	},
+		};
+
+	}(),
 
 	multiplyScalar: function ( s ) {
 
@@ -211,5 +215,3 @@ THREE.Matrix3.prototype = {
 	}
 
 };
-
-THREE.Matrix3.__v1 = new THREE.Vector3();

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -17,7 +17,7 @@ THREE.Matrix3 = function ( n11, n12, n13, n21, n22, n23, n31, n32, n33 ) {
 	);
 };
 
-THREE.Matrix3.prototype = {
+THREE.extend( THREE.Matrix3.prototype, {
 
 	constructor: THREE.Matrix3,
 
@@ -214,4 +214,4 @@ THREE.Matrix3.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -13,16 +13,15 @@
 
 THREE.Matrix4 = function ( n11, n12, n13, n14, n21, n22, n23, n24, n31, n32, n33, n34, n41, n42, n43, n44 ) {
 
-	this.elements = new Float32Array( 16 );
+	var te = this.elements = new Float32Array( 16 );
 
-	this.set(
+	// TODO: if n11 is undefined, then just set to identity, otherwise copy all other values into matrix
+	//   we should not support semi specification of Matrix4, it is just weird.
 
-		( n11 !== undefined ) ? n11 : 1, n12 || 0, n13 || 0, n14 || 0,
-		n21 || 0, ( n22 !== undefined ) ? n22 : 1, n23 || 0, n24 || 0,
-		n31 || 0, n32 || 0, ( n33 !== undefined ) ? n33 : 1, n34 || 0,
-		n41 || 0, n42 || 0, n43 || 0, ( n44 !== undefined ) ? n44 : 1
-
-	);
+	te[0] = ( n11 !== undefined ) ? n11 : 1; te[4] = n12 || 0; te[8] = n13 || 0; te[12] = n14 || 0;
+	te[1] = n21 || 0; te[5] = ( n22 !== undefined ) ? n22 : 1; te[9] = n23 || 0; te[13] = n24 || 0;
+	te[2] = n31 || 0; te[6] = n32 || 0; te[10] = ( n33 !== undefined ) ? n33 : 1; te[14] = n34 || 0;
+	te[3] = n41 || 0; te[7] = n42 || 0; te[11] = n43 || 0; te[15] = ( n44 !== undefined ) ? n44 : 1;
 
 };
 
@@ -212,41 +211,45 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	lookAt: function ( eye, target, up ) {
+	lookAt: function() {
 
-		var te = this.elements;
+		var x = new THREE.Vector3(),
+			y = new THREE.Vector3(),
+			z = new THREE.Vector3();
+		
+		return function ( eye, target, up ) {
 
-		var x = THREE.Matrix4.__v1;
-		var y = THREE.Matrix4.__v2;
-		var z = THREE.Matrix4.__v3;
+			var te = this.elements;
+		
+			z.subVectors( eye, target ).normalize();
 
-		z.subVectors( eye, target ).normalize();
+			if ( z.length() === 0 ) {
 
-		if ( z.length() === 0 ) {
+				z.z = 1;
 
-			z.z = 1;
+			}
 
-		}
-
-		x.crossVectors( up, z ).normalize();
-
-		if ( x.length() === 0 ) {
-
-			z.x += 0.0001;
 			x.crossVectors( up, z ).normalize();
 
-		}
+			if ( x.length() === 0 ) {
 
-		y.crossVectors( z, x );
+				z.x += 0.0001;
+				x.crossVectors( up, z ).normalize();
+
+			}
+
+			y.crossVectors( z, x );
 
 
-		te[0] = x.x; te[4] = y.x; te[8] = z.x;
-		te[1] = x.y; te[5] = y.y; te[9] = z.y;
-		te[2] = x.z; te[6] = y.z; te[10] = z.z;
+			te[0] = x.x; te[4] = y.x; te[8] = z.x;
+			te[1] = x.y; te[5] = y.y; te[9] = z.y;
+			te[2] = x.z; te[6] = y.z; te[10] = z.z;
 
-		return this;
+			return this;
 
-	},
+		};
+
+	}(),
 
 	multiply: function ( m, n ) {
 
@@ -343,27 +346,31 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	multiplyVector3Array: function ( a ) {
+	multiplyVector3Array: function() {
 
-		var tmp = THREE.Matrix4.__v1;
+		var v1 = new THREE.Vector3();
+		
+		return function ( a ) {
 
-		for ( var i = 0, il = a.length; i < il; i += 3 ) {
+			for ( var i = 0, il = a.length; i < il; i += 3 ) {
 
-			tmp.x = a[ i ];
-			tmp.y = a[ i + 1 ];
-			tmp.z = a[ i + 2 ];
+				v1.x = a[ i ];
+				v1.y = a[ i + 1 ];
+				v1.z = a[ i + 2 ];
 
-			tmp.applyProjection( this );
+				v1.applyProjection( this );
 
-			a[ i ]     = tmp.x;
-			a[ i + 1 ] = tmp.y;
-			a[ i + 2 ] = tmp.z;
+				a[ i ]     = v1.x;
+				a[ i + 1 ] = v1.y;
+				a[ i + 2 ] = v1.z;
 
-		}
+			}
 
-		return a;
+			return a;
 
-	},
+		};
+
+	}(),
 
 	rotateAxis: function ( v ) {
 
@@ -501,12 +508,18 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	getPosition: function () {
+	getPosition: function() {
 
-		var te = this.elements;
-		return THREE.Matrix4.__v1.set( te[12], te[13], te[14] );
+		var v1 = new THREE.Vector3();
+		
+		return function () {
 
-	},
+			var te = this.elements;
+			return v1.set( te[12], te[13], te[14] );
+
+		};
+
+	}(),
 
 	setPosition: function ( v ) {
 
@@ -520,26 +533,44 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	getColumnX: function () {
+	getColumnX: function() {
 
-		var te = this.elements;
-		return THREE.Matrix4.__v1.set( te[0], te[1], te[2] );
+		var v1 = new THREE.Vector3();
+		
+		return function () {
 
-	},
+			var te = this.elements;
+			return v1.set( te[0], te[1], te[2] );
 
-	getColumnY: function () {
+		};
 
-		var te = this.elements;
-		return THREE.Matrix4.__v1.set( te[4], te[5], te[6] );
+	}(),
 
-	},
+	getColumnY: function() {
+
+		var v1 = new THREE.Vector3();
+		
+		return function () {
+
+			var te = this.elements;
+			return v1.set( te[4], te[5], te[6] );
+
+		};
+
+	}(),
 
 	getColumnZ: function() {
 
-		var te = this.elements;
-		return THREE.Matrix4.__v1.set( te[8], te[9], te[10] );
+		var v1 = new THREE.Vector3();
+		
+		return function() {
 
-	},
+			var te = this.elements;
+			return v1.set( te[8], te[9], te[10] );
+
+		};
+
+	}(),
 
 	getInverse: function ( m, throwOnInvertible ) {
 
@@ -596,75 +627,84 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	compose: function ( translation, rotation, scale ) {
+	compose: function() {
 
-		var te = this.elements;
-		var mRotation = THREE.Matrix4.__m1;
-		var mScale = THREE.Matrix4.__m2;
+		var mRotation = new THREE.Matrix4(),
+			mScale = new THREE.Matrix4();
+		
+		return function ( translation, rotation, scale ) {
 
-		mRotation.identity();
-		mRotation.setRotationFromQuaternion( rotation );
+			var te = this.elements;
+			
+			mRotation.identity();
+			mRotation.setRotationFromQuaternion( rotation );
 
-		mScale.makeScale( scale.x, scale.y, scale.z );
+			mScale.makeScale( scale.x, scale.y, scale.z );
 
-		this.multiplyMatrices( mRotation, mScale );
+			this.multiplyMatrices( mRotation, mScale );
 
-		te[12] = translation.x;
-		te[13] = translation.y;
-		te[14] = translation.z;
+			te[12] = translation.x;
+			te[13] = translation.y;
+			te[14] = translation.z;
 
-		return this;
+			return this;
 
-	},
+		};
 
-	decompose: function ( translation, rotation, scale ) {
+	}(),
 
-		var te = this.elements;
+	decompose: function() {
 
-		// grab the axis vectors
-		var x = THREE.Matrix4.__v1;
-		var y = THREE.Matrix4.__v2;
-		var z = THREE.Matrix4.__v3;
+		var x = new THREE.Vector3(),
+			y = new THREE.Vector3(),
+			z = new THREE.Vector3();
+		
+		return function ( translation, rotation, scale ) {
 
-		x.set( te[0], te[1], te[2] );
-		y.set( te[4], te[5], te[6] );
-		z.set( te[8], te[9], te[10] );
+			var te = this.elements;
 
-		translation = ( translation instanceof THREE.Vector3 ) ? translation : new THREE.Vector3();
-		rotation = ( rotation instanceof THREE.Quaternion ) ? rotation : new THREE.Quaternion();
-		scale = ( scale instanceof THREE.Vector3 ) ? scale : new THREE.Vector3();
+			// grab the axis vectors		
+			x.set( te[0], te[1], te[2] );
+			y.set( te[4], te[5], te[6] );
+			z.set( te[8], te[9], te[10] );
 
-		scale.x = x.length();
-		scale.y = y.length();
-		scale.z = z.length();
+			translation = ( translation instanceof THREE.Vector3 ) ? translation : new THREE.Vector3();
+			rotation = ( rotation instanceof THREE.Quaternion ) ? rotation : new THREE.Quaternion();
+			scale = ( scale instanceof THREE.Vector3 ) ? scale : new THREE.Vector3();
 
-		translation.x = te[12];
-		translation.y = te[13];
-		translation.z = te[14];
+			scale.x = x.length();
+			scale.y = y.length();
+			scale.z = z.length();
 
-		// scale the rotation part
+			translation.x = te[12];
+			translation.y = te[13];
+			translation.z = te[14];
 
-		var matrix = THREE.Matrix4.__m1;
+			// scale the rotation part
 
-		matrix.copy( this );
+			var matrix = THREE.Matrix4.__m1;
 
-		matrix.elements[0] /= scale.x;
-		matrix.elements[1] /= scale.x;
-		matrix.elements[2] /= scale.x;
+			matrix.copy( this );
 
-		matrix.elements[4] /= scale.y;
-		matrix.elements[5] /= scale.y;
-		matrix.elements[6] /= scale.y;
+			matrix.elements[0] /= scale.x;
+			matrix.elements[1] /= scale.x;
+			matrix.elements[2] /= scale.x;
 
-		matrix.elements[8] /= scale.z;
-		matrix.elements[9] /= scale.z;
-		matrix.elements[10] /= scale.z;
+			matrix.elements[4] /= scale.y;
+			matrix.elements[5] /= scale.y;
+			matrix.elements[6] /= scale.y;
 
-		rotation.setFromRotationMatrix( matrix );
+			matrix.elements[8] /= scale.z;
+			matrix.elements[9] /= scale.z;
+			matrix.elements[10] /= scale.z;
 
-		return [ translation, rotation, scale ];
+			rotation.setFromRotationMatrix( matrix );
 
-	},
+			return [ translation, rotation, scale ];
+
+		};
+
+	}(),
 
 	extractPosition: function ( m ) {
 
@@ -679,34 +719,36 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	extractRotation: function ( m ) {
+	extractRotation: function() {
 
-		var te = this.elements;
-		var me = m.elements;
+		var v1 = new THREE.Vector3();
+		
+		return function ( m ) {
 
-		var vector = THREE.Matrix4.__v1;
+			var te = this.elements;
+			var me = m.elements;
 
-		var scaleX = 1 / vector.set( me[0], me[1], me[2] ).length();
-		var scaleY = 1 / vector.set( me[4], me[5], me[6] ).length();
-		var scaleZ = 1 / vector.set( me[8], me[9], me[10] ).length();
+			var scaleX = 1 / v1.set( me[0], me[1], me[2] ).length();
+			var scaleY = 1 / v1.set( me[4], me[5], me[6] ).length();
+			var scaleZ = 1 / v1.set( me[8], me[9], me[10] ).length();
 
-		te[0] = me[0] * scaleX;
-		te[1] = me[1] * scaleX;
-		te[2] = me[2] * scaleX;
+			te[0] = me[0] * scaleX;
+			te[1] = me[1] * scaleX;
+			te[2] = me[2] * scaleX;
 
-		te[4] = me[4] * scaleY;
-		te[5] = me[5] * scaleY;
-		te[6] = me[6] * scaleY;
+			te[4] = me[4] * scaleY;
+			te[5] = me[5] * scaleY;
+			te[6] = me[6] * scaleY;
 
-		te[8] = me[8] * scaleZ;
-		te[9] = me[9] * scaleZ;
-		te[10] = me[10] * scaleZ;
+			te[8] = me[8] * scaleZ;
+			te[9] = me[9] * scaleZ;
+			te[10] = me[10] * scaleZ;
 
-		return this;
+			return this;
 
-	},
+		};
 
-	//
+	}(),
 
 	translate: function ( v ) {
 
@@ -904,8 +946,6 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	//
-
 	makeTranslation: function ( x, y, z ) {
 
 		this.set(
@@ -1077,10 +1117,3 @@ THREE.Matrix4.prototype = {
 	}
 
 };
-
-THREE.Matrix4.__v1 = new THREE.Vector3();
-THREE.Matrix4.__v2 = new THREE.Vector3();
-THREE.Matrix4.__v3 = new THREE.Vector3();
-
-THREE.Matrix4.__m1 = new THREE.Matrix4();
-THREE.Matrix4.__m2 = new THREE.Matrix4();

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -25,7 +25,7 @@ THREE.Matrix4 = function ( n11, n12, n13, n14, n21, n22, n23, n24, n31, n32, n33
 
 };
 
-THREE.Matrix4.prototype = {
+THREE.extend( THREE.Matrix4.prototype, {
 
 	constructor: THREE.Matrix4,
 
@@ -657,7 +657,8 @@ THREE.Matrix4.prototype = {
 
 		var x = new THREE.Vector3(),
 			y = new THREE.Vector3(),
-			z = new THREE.Vector3();
+			z = new THREE.Vector3(),
+			matrix = new THREE.Matrix4();
 		
 		return function ( translation, rotation, scale ) {
 
@@ -681,9 +682,7 @@ THREE.Matrix4.prototype = {
 			translation.z = te[14];
 
 			// scale the rotation part
-
-			var matrix = THREE.Matrix4.__m1;
-
+		
 			matrix.copy( this );
 
 			matrix.elements[0] /= scale.x;
@@ -1116,4 +1115,4 @@ THREE.Matrix4.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -9,7 +9,7 @@ THREE.Plane = function ( normal, constant ) {
 
 };
 
-THREE.Plane.prototype = {
+THREE.extend( THREE.Plane.prototype, {
 
 	constructor: THREE.Plane,
 
@@ -219,4 +219,4 @@ THREE.Plane.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -14,7 +14,7 @@ THREE.Quaternion = function( x, y, z, w ) {
 
 };
 
-THREE.Quaternion.prototype = {
+THREE.extend( THREE.Quaternion.prototype, {
 
 	constructor: THREE.Quaternion,
 
@@ -339,7 +339,7 @@ THREE.Quaternion.prototype = {
 
 	}
 
-}
+} );
 
 THREE.Quaternion.slerp = function ( qa, qb, qm, t ) {
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -9,7 +9,7 @@ THREE.Ray = function ( origin, direction ) {
 
 };
 
-THREE.Ray.prototype = {
+THREE.extend( THREE.Ray.prototype, {
 
 	constructor: THREE.Ray,
 
@@ -39,13 +39,19 @@ THREE.Ray.prototype = {
 
 	},
 
-	recast: function ( t ) {
+	recast: function() {
 
-		this.origin.copy( this.at( t, THREE.Ray.__v1 ) );
+		var v1 = new THREE.Vector3();
 
-		return this;
+		return function ( t ) {
 
-	},
+			this.origin.copy( this.at( t, v1 ) );
+
+			return this;
+
+		};
+
+	}(),
 
 	closestPointToPoint: function ( point, optionalTarget ) {
 
@@ -157,4 +163,4 @@ THREE.Ray.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -57,14 +57,20 @@ THREE.Ray.prototype = {
 
 	},
 
-	distanceToPoint: function ( point ) {
+	distanceToPoint: function() {
 
-		var directionDistance = THREE.Ray.__v1.subVectors( point, this.origin ).dot( this.direction );
-		THREE.Ray.__v1.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
+		var v1 = new THREE.Vector3();
 
-		return THREE.Ray.__v1.distanceTo( point );
+		return function ( point ) {
 
-	},
+			var directionDistance = v1.subVectors( point, this.origin ).dot( this.direction );
+			v1.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
+
+			return v1.distanceTo( point );
+
+		};
+
+	}(),
 
 	isIntersectionSphere: function( sphere ) {
 
@@ -152,6 +158,3 @@ THREE.Ray.prototype = {
 	}
 
 };
-
-THREE.Ray.__v1 = new THREE.Vector3();
-THREE.Ray.__v2 = new THREE.Vector3();

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -10,7 +10,7 @@ THREE.Sphere = function ( center, radius ) {
 
 };
 
-THREE.Sphere.prototype = {
+THREE.extend( THREE.Sphere.prototype, {
 
 	constructor: THREE.Sphere,
 
@@ -133,4 +133,4 @@ THREE.Sphere.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -92,7 +92,7 @@ THREE.Triangle.containsPoint = function() {
 
 }();
 
-THREE.Triangle.prototype = {
+THREE.extend( THREE.Triangle.prototype, {
 
 	constructor: THREE.Triangle,
 
@@ -187,4 +187,4 @@ THREE.Triangle.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -11,67 +11,86 @@ THREE.Triangle = function ( a, b, c ) {
 
 };
 
-THREE.Triangle.normal = function( a, b, c, optionalTarget ) {
+THREE.Triangle.normal = function() {
 
-	var result = optionalTarget || new THREE.Vector3();
+	var v0 = new THREE.Vector3();
 
-	result.subVectors( c, b );
-	THREE.Triangle.__v0.subVectors( a, b );
-	result.cross( THREE.Triangle.__v0 );
+	return function( a, b, c, optionalTarget ) {
 
-	var resultLengthSq = result.lengthSq();
-	if( resultLengthSq > 0 ) {
+		var result = optionalTarget || new THREE.Vector3();
 
-		return result.multiplyScalar( 1 / Math.sqrt( resultLengthSq ) );
+		result.subVectors( c, b );
+		v0.subVectors( a, b );
+		result.cross( v0 );
 
-	}
+		var resultLengthSq = result.lengthSq();
+		if( resultLengthSq > 0 ) {
 
-	return result.set( 0, 0, 0 );
+			return result.multiplyScalar( 1 / Math.sqrt( resultLengthSq ) );
 
-};
+		}
+
+		return result.set( 0, 0, 0 );
+
+	};
+
+}();
 
 // static/instance method to calculate barycoordinates
 // based on: http://www.blackpawn.com/texts/pointinpoly/default.html
-THREE.Triangle.barycoordFromPoint = function ( point, a, b, c, optionalTarget ) {
+THREE.Triangle.barycoordFromPoint = function() {
 
-	THREE.Triangle.__v0.subVectors( c, a );
-	THREE.Triangle.__v1.subVectors( b, a );
-	THREE.Triangle.__v2.subVectors( point, a );
+	var v0 = new THREE.Vector3(),
+		v1 = new THREE.Vector3(),
+		v2 = new THREE.Vector3();
 
-	var dot00 = THREE.Triangle.__v0.dot( THREE.Triangle.__v0 );
-	var dot01 = THREE.Triangle.__v0.dot( THREE.Triangle.__v1 );
-	var dot02 = THREE.Triangle.__v0.dot( THREE.Triangle.__v2 );
-	var dot11 = THREE.Triangle.__v1.dot( THREE.Triangle.__v1 );
-	var dot12 = THREE.Triangle.__v1.dot( THREE.Triangle.__v2 );
+	return function ( point, a, b, c, optionalTarget ) {
 
-	var denom = ( dot00 * dot11 - dot01 * dot01 );
+		v0.subVectors( c, a );
+		v1.subVectors( b, a );
+		v2.subVectors( point, a );
 
-	var result = optionalTarget || new THREE.Vector3();
+		var dot00 = v0.dot( v0 );
+		var dot01 = v0.dot( v1 );
+		var dot02 = v0.dot( v2 );
+		var dot11 = v1.dot( v1 );
+		var dot12 = v1.dot( v2 );
 
-	// colinear or singular triangle
-	if( denom == 0 ) {
-		// arbitrary location outside of triangle?
-		// not sure if this is the best idea, maybe should be returning undefined
-		return result.set( -2, -1, -1 );
-	}
+		var denom = ( dot00 * dot11 - dot01 * dot01 );
 
-	var invDenom = 1 / denom;
-	var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
-	var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
+		var result = optionalTarget || new THREE.Vector3();
 
-	// barycoordinates must always sum to 1
-	return result.set( 1 - u - v, v, u );
+		// colinear or singular triangle
+		if( denom == 0 ) {
+			// arbitrary location outside of triangle?
+			// not sure if this is the best idea, maybe should be returning undefined
+			return result.set( -2, -1, -1 );
+		}
 
-};
+		var invDenom = 1 / denom;
+		var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
+		var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
 
-THREE.Triangle.containsPoint = function ( point, a, b, c ) {
+		// barycoordinates must always sum to 1
+		return result.set( 1 - u - v, v, u );
 
-	// NOTE: need to use __v3 here because __v0, __v1 and __v2 are used in barycoordFromPoint.
-	var result = THREE.Triangle.barycoordFromPoint( point, a, b, c, THREE.Triangle.__v3 );
+	};
 
-	return ( result.x >= 0 ) && ( result.y >= 0 ) && ( ( result.x + result.y ) <= 1 );
+}();
 
-};
+THREE.Triangle.containsPoint = function() {
+
+	var v1 = new THREE.Vector3();
+
+	return function ( point, a, b, c ) {
+
+		var result = THREE.Triangle.barycoordFromPoint( point, a, b, c, v1 );
+
+		return ( result.x >= 0 ) && ( result.y >= 0 ) && ( ( result.x + result.y ) <= 1 );
+
+	};
+
+}();
 
 THREE.Triangle.prototype = {
 
@@ -107,14 +126,21 @@ THREE.Triangle.prototype = {
 
 	},
 
-	area: function () {
+	area: function() {
 
-		THREE.Triangle.__v0.subVectors( this.c, this.b );
-		THREE.Triangle.__v1.subVectors( this.a, this.b );
+		var v0 = new THREE.Vector3(),
+			v1 = new THREE.Vector3();
+		
+		return function () {
 
-		return THREE.Triangle.__v0.cross( THREE.Triangle.__v1 ).length() * 0.5;
+			v0.subVectors( this.c, this.b );
+			v1.subVectors( this.a, this.b );
 
-	},
+			return v0.cross( v1 ).length() * 0.5;
+
+		};
+
+	}(),
 
 	midpoint: function ( optionalTarget ) {
 
@@ -162,8 +188,3 @@ THREE.Triangle.prototype = {
 	}
 
 };
-
-THREE.Triangle.__v0 = new THREE.Vector3();
-THREE.Triangle.__v1 = new THREE.Vector3();
-THREE.Triangle.__v2 = new THREE.Vector3();
-THREE.Triangle.__v3 = new THREE.Vector3();

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -12,7 +12,7 @@ THREE.Vector2 = function ( x, y ) {
 
 };
 
-THREE.Vector2.prototype = {
+THREE.extend( THREE.Vector2.prototype, {
 
 	constructor: THREE.Vector2,
 
@@ -301,4 +301,4 @@ THREE.Vector2.prototype = {
 
 	}
 
-};
+} );

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -15,8 +15,7 @@ THREE.Vector3 = function ( x, y, z ) {
 
 };
 
-
-THREE.Vector3.prototype = {
+THREE.extend( THREE.Vector3.prototype, {
 
 	constructor: THREE.Vector3,
 
@@ -741,5 +740,4 @@ THREE.Vector3.prototype = {
 
 	}
 
-};
-
+} );

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -268,25 +268,37 @@ THREE.Vector3.prototype = {
 
 	},
 
-	applyEuler: function ( v, eulerOrder ) {
+	applyEuler: function() {
 
-		var quaternion = THREE.Vector3.__q1.setFromEuler( v, eulerOrder );
+		var q1 = new THREE.Quaternion();
+		
+		return function ( v, eulerOrder ) {
 
-		this.applyQuaternion( quaternion );
+			var quaternion = q1.setFromEuler( v, eulerOrder );
 
-		return this;
+			this.applyQuaternion( quaternion );
 
-	},
+			return this;
 
-	applyAxisAngle: function ( axis, angle ) {
+		};
 
-		var quaternion = THREE.Vector3.__q1.setFromAxisAngle( axis, angle );
+	}(),
 
-		this.applyQuaternion( quaternion );
+	applyAxisAngle: function() {
 
-		return this;
+		var q1 = new THREE.Quaternion();
+		
+		return function ( axis, angle ) {
 
-	},
+			var quaternion = q1.setFromAxisAngle( axis, angle );
+
+			this.applyQuaternion( quaternion );
+
+			return this;
+
+		};
+
+	}(),
 
 	divide: function ( v ) {
 
@@ -731,4 +743,3 @@ THREE.Vector3.prototype = {
 
 };
 
-THREE.Vector3.__q1 = new THREE.Quaternion();

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -15,7 +15,7 @@ THREE.Vector4 = function ( x, y, z, w ) {
 
 };
 
-THREE.Vector4.prototype = {
+THREE.extend( THREE.Vector4.prototype, {
 
 	constructor: THREE.Vector4,
 
@@ -553,4 +553,4 @@ THREE.Vector4.prototype = {
 
 	}
 
-};
+} );

--- a/test/unit/unittests_sources.html
+++ b/test/unit/unittests_sources.html
@@ -12,21 +12,21 @@
   <!-- add ThreeJS sources to test below -->
 
   <script src="../../src/Three.js"></script>
-  <script src="../../src/math/Math.js"></script>
+  <script src="../../src/math/Color.js"></script>
+  <script src="../../src/math/Quaternion.js"></script>
   <script src="../../src/math/Vector2.js"></script>
   <script src="../../src/math/Vector3.js"></script>
   <script src="../../src/math/Vector4.js"></script>
   <script src="../../src/math/Box2.js"></script>
   <script src="../../src/math/Box3.js"></script>
-  <script src="../../src/math/Plane.js"></script>
-  <script src="../../src/math/Ray.js"></script>
-  <script src="../../src/math/Sphere.js"></script>
-  <script src="../../src/math/Triangle.js"></script>
   <script src="../../src/math/Matrix3.js"></script>
   <script src="../../src/math/Matrix4.js"></script>
-  <script src="../../src/math/Color.js"></script>
-  <script src="../../src/math/Quaternion.js"></script>
+  <script src="../../src/math/Ray.js"></script>
   <script src="../../src/math/Frustum.js"></script>
+  <script src="../../src/math/Plane.js"></script>
+  <script src="../../src/math/Sphere.js"></script>
+  <script src="../../src/math/Math.js"></script>
+  <script src="../../src/math/Triangle.js"></script>
 
   <!-- add class-based unit tests below -->
 


### PR DESCRIPTION
I've implemented JavaScript closures across the whole math library to remove the need for declaration of public static variables for GC optimization purposes as proposed in issue #2936.

 did have to switch to extending the prototypes of the math classes rather than just replacing their prototypes.  I had to do this because instances of a type created within closures of that type are created before the prototype is set, thus they were incomplete types.  For example, if inside `THREE.Matrix4.prototype = { ... [in here].... }` you had a closure that created a `var m1 = THREE.Matrix4()` variable, it wouldn't yet have its prototype set because only after it has completed executing all the code in the `{ ...[in here]... }` block does it set it to `Matrix4.prototype`.  By extending the prototype, even variables created inside the `{...[in here]...}` block eventually get full prototypes before they are used in their methods.

I added THREE.extends to handle extending prototypes, I based it on the code here: 

http://stackoverflow.com/a/12317051

I tested about 20 examples at random and they all worked.  All unit tests pass as well.

Both `webgl_performance.html` and `webgl_performance_static.html` perform at the same speed, no slowdowns on my PC.
