### PR TITLE
Testing what Three.js would look like if it adopted the THREE.extend pattern across the whole library

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -45,6 +45,28 @@ String.prototype.trim = String.prototype.trim || function () {
 
 };
 
+// based on http://stackoverflow.com/a/12317051
+THREE.extend = function ( target, other ) {
+
+	target = target || {};
+
+	for (var prop in other) {
+
+		if ( typeof other[prop] === 'object' ) {
+
+			target[prop] = THREE.extend( target[prop], other[prop] );
+
+		} else {
+
+			target[prop] = other[prop];
+
+		}
+
+	}
+
+	return target;
+
+};
 
 // http://paulirish.com/2011/requestanimationframe-for-smart-animating/
 // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -20,97 +20,100 @@ THREE.PerspectiveCamera = function ( fov, aspect, near, far ) {
 THREE.PerspectiveCamera.prototype = Object.create( THREE.Camera.prototype );
 
 
-/**
- * Uses Focal Length (in mm) to estimate and set FOV
- * 35mm (fullframe) camera is used if frame size is not specified;
- * Formula based on http://www.bobatkins.com/photography/technical/field_of_view.html
- */
+THREE.extend( THREE.PerspectiveCamera.prototype, {
 
-THREE.PerspectiveCamera.prototype.setLens = function ( focalLength, frameHeight ) {
+	/**
+	 * Uses Focal Length (in mm) to estimate and set FOV
+	 * 35mm (fullframe) camera is used if frame size is not specified;
+	 * Formula based on http://www.bobatkins.com/photography/technical/field_of_view.html
+	 */
 
-	if ( frameHeight === undefined ) frameHeight = 24;
+	setLens: function ( focalLength, frameHeight ) {
 
-	this.fov = 2 * THREE.Math.radToDeg( Math.atan( frameHeight / ( focalLength * 2 ) ) );
-	this.updateProjectionMatrix();
+		if ( frameHeight === undefined ) frameHeight = 24;
 
-}
+		this.fov = 2 * THREE.Math.radToDeg( Math.atan( frameHeight / ( focalLength * 2 ) ) );
+		this.updateProjectionMatrix();
 
-
-/**
- * Sets an offset in a larger frustum. This is useful for multi-window or
- * multi-monitor/multi-machine setups.
- *
- * For example, if you have 3x2 monitors and each monitor is 1920x1080 and
- * the monitors are in grid like this
- *
- *   +---+---+---+
- *   | A | B | C |
- *   +---+---+---+
- *   | D | E | F |
- *   +---+---+---+
- *
- * then for each monitor you would call it like this
- *
- *   var w = 1920;
- *   var h = 1080;
- *   var fullWidth = w * 3;
- *   var fullHeight = h * 2;
- *
- *   --A--
- *   camera.setOffset( fullWidth, fullHeight, w * 0, h * 0, w, h );
- *   --B--
- *   camera.setOffset( fullWidth, fullHeight, w * 1, h * 0, w, h );
- *   --C--
- *   camera.setOffset( fullWidth, fullHeight, w * 2, h * 0, w, h );
- *   --D--
- *   camera.setOffset( fullWidth, fullHeight, w * 0, h * 1, w, h );
- *   --E--
- *   camera.setOffset( fullWidth, fullHeight, w * 1, h * 1, w, h );
- *   --F--
- *   camera.setOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );
- *
- *   Note there is no reason monitors have to be the same size or in a grid.
- */
-
-THREE.PerspectiveCamera.prototype.setViewOffset = function ( fullWidth, fullHeight, x, y, width, height ) {
-
-	this.fullWidth = fullWidth;
-	this.fullHeight = fullHeight;
-	this.x = x;
-	this.y = y;
-	this.width = width;
-	this.height = height;
-
-	this.updateProjectionMatrix();
-
-};
+	},
 
 
-THREE.PerspectiveCamera.prototype.updateProjectionMatrix = function () {
+	/**
+	 * Sets an offset in a larger frustum. This is useful for multi-window or
+	 * multi-monitor/multi-machine setups.
+	 *
+	 * For example, if you have 3x2 monitors and each monitor is 1920x1080 and
+	 * the monitors are in grid like this
+	 *
+	 *   +---+---+---+
+	 *   | A | B | C |
+	 *   +---+---+---+
+	 *   | D | E | F |
+	 *   +---+---+---+
+	 *
+	 * then for each monitor you would call it like this
+	 *
+	 *   var w = 1920;
+	 *   var h = 1080;
+	 *   var fullWidth = w * 3;
+	 *   var fullHeight = h * 2;
+	 *
+	 *   --A--
+	 *   camera.setOffset( fullWidth, fullHeight, w * 0, h * 0, w, h );
+	 *   --B--
+	 *   camera.setOffset( fullWidth, fullHeight, w * 1, h * 0, w, h );
+	 *   --C--
+	 *   camera.setOffset( fullWidth, fullHeight, w * 2, h * 0, w, h );
+	 *   --D--
+	 *   camera.setOffset( fullWidth, fullHeight, w * 0, h * 1, w, h );
+	 *   --E--
+	 *   camera.setOffset( fullWidth, fullHeight, w * 1, h * 1, w, h );
+	 *   --F--
+	 *   camera.setOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );
+	 *
+	 *   Note there is no reason monitors have to be the same size or in a grid.
+	 */
 
-	if ( this.fullWidth ) {
+	setViewOffset: function ( fullWidth, fullHeight, x, y, width, height ) {
 
-		var aspect = this.fullWidth / this.fullHeight;
-		var top = Math.tan( THREE.Math.degToRad( this.fov * 0.5 ) ) * this.near;
-		var bottom = -top;
-		var left = aspect * bottom;
-		var right = aspect * top;
-		var width = Math.abs( right - left );
-		var height = Math.abs( top - bottom );
+		this.fullWidth = fullWidth;
+		this.fullHeight = fullHeight;
+		this.x = x;
+		this.y = y;
+		this.width = width;
+		this.height = height;
 
-		this.projectionMatrix.makeFrustum(
-			left + this.x * width / this.fullWidth,
-			left + ( this.x + this.width ) * width / this.fullWidth,
-			top - ( this.y + this.height ) * height / this.fullHeight,
-			top - this.y * height / this.fullHeight,
-			this.near,
-			this.far
-		);
+		this.updateProjectionMatrix();
 
-	} else {
+	},
 
-		this.projectionMatrix.makePerspective( this.fov, this.aspect, this.near, this.far );
+	updateProjectionMatrix: function () {
+
+		if ( this.fullWidth ) {
+
+			var aspect = this.fullWidth / this.fullHeight;
+			var top = Math.tan( THREE.Math.degToRad( this.fov * 0.5 ) ) * this.near;
+			var bottom = -top;
+			var left = aspect * bottom;
+			var right = aspect * top;
+			var width = Math.abs( right - left );
+			var height = Math.abs( top - bottom );
+
+			this.projectionMatrix.makeFrustum(
+				left + this.x * width / this.fullWidth,
+				left + ( this.x + this.width ) * width / this.fullWidth,
+				top - ( this.y + this.height ) * height / this.fullHeight,
+				top - this.y * height / this.fullHeight,
+				this.near,
+				this.far
+			);
+
+		} else {
+
+			this.projectionMatrix.makePerspective( this.fov, this.aspect, this.near, this.far );
+
+		}
 
 	}
 
-};
+} );

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -14,52 +14,55 @@ THREE.Clock = function ( autoStart ) {
 
 };
 
-THREE.Clock.prototype.start = function () {
+THREE.Clock.prototype = {
 
-	this.startTime = Date.now();
-	this.oldTime = this.startTime;
+	start: function () {
 
-	this.running = true;
+		this.startTime = Date.now();
+		this.oldTime = this.startTime;
 
-};
+		this.running = true;
 
-THREE.Clock.prototype.stop = function () {
+	},
 
-	this.getElapsedTime();
+	stop: function () {
 
-	this.running = false;
+		this.getElapsedTime();
 
-};
+		this.running = false;
 
-THREE.Clock.prototype.getElapsedTime = function () {
+	},
 
-	this.getDelta();
+	getElapsedTime: function () {
 
-	return this.elapsedTime;
+		this.getDelta();
 
-};
+		return this.elapsedTime;
 
+	},
 
-THREE.Clock.prototype.getDelta = function () {
+	getDelta: function () {
 
-	var diff = 0;
+		var diff = 0;
 
-	if ( this.autoStart && ! this.running ) {
+		if ( this.autoStart && ! this.running ) {
 
-		this.start();
+			this.start();
+
+		}
+
+		if ( this.running ) {
+
+			var newTime = Date.now();
+			diff = 0.001 * ( newTime - this.oldTime );
+			this.oldTime = newTime;
+
+			this.elapsedTime += diff;
+
+		}
+
+		return diff;
 
 	}
-
-	if ( this.running ) {
-
-		var newTime = Date.now();
-		diff = 0.001 * ( newTime - this.oldTime );
-		this.oldTime = newTime;
-
-		this.elapsedTime += diff;
-
-	}
-
-	return diff;
 
 };

--- a/src/extras/ColorUtils.js
+++ b/src/extras/ColorUtils.js
@@ -4,20 +4,21 @@
 
 THREE.ColorUtils = {
 
-	adjustHSV : function ( color, h, s, v ) {
+	adjustHSV: function() {
 
-		var hsv = THREE.ColorUtils.__hsv;
+		var hsv = { h: 0, s: 0, v: 0 };
 
-		color.getHSV( hsv );
+		return function ( color, h, s, v ) {
+		
+			color.getHSV( hsv );
 
-		hsv.h = THREE.Math.clamp( hsv.h + h, 0, 1 );
-		hsv.s = THREE.Math.clamp( hsv.s + s, 0, 1 );
-		hsv.v = THREE.Math.clamp( hsv.v + v, 0, 1 );
+			hsv.h = THREE.Math.clamp( hsv.h + h, 0, 1 );
+			hsv.s = THREE.Math.clamp( hsv.s + s, 0, 1 );
+			hsv.v = THREE.Math.clamp( hsv.v + v, 0, 1 );
 
-		color.setHSV( hsv.h, hsv.s, hsv.v );
+			color.setHSV( hsv.h, hsv.s, hsv.v );
 
-	}
+		};
+	}()
 
 };
-
-THREE.ColorUtils.__hsv = { h: 0, s: 0, v: 0 };

--- a/src/extras/animation/Animation.js
+++ b/src/extras/animation/Animation.js
@@ -24,363 +24,357 @@ THREE.Animation = function ( root, name, interpolationType ) {
 
 };
 
-THREE.Animation.prototype.play = function ( loop, startTimeMS ) {
 
-	if ( this.isPlaying === false ) {
+THREE.extend( THREE.Animation.prototype, {
 
-		this.isPlaying = true;
-		this.loop = loop !== undefined ? loop : true;
-		this.currentTime = startTimeMS !== undefined ? startTimeMS : 0;
+	play: function ( loop, startTimeMS ) {
 
-		// reset key cache
+		if ( this.isPlaying === false ) {
 
-		var h, hl = this.hierarchy.length,
-			object;
+			this.isPlaying = true;
+			this.loop = loop !== undefined ? loop : true;
+			this.currentTime = startTimeMS !== undefined ? startTimeMS : 0;
 
-		for ( h = 0; h < hl; h ++ ) {
+			// reset key cache
 
-			object = this.hierarchy[ h ];
+			var h, hl = this.hierarchy.length,
+				object;
 
-			if ( this.interpolationType !== THREE.AnimationHandler.CATMULLROM_FORWARD ) {
+			for ( h = 0; h < hl; h ++ ) {
 
-				object.useQuaternion = true;
+				object = this.hierarchy[ h ];
+
+				if ( this.interpolationType !== THREE.AnimationHandler.CATMULLROM_FORWARD ) {
+
+					object.useQuaternion = true;
+
+				}
+
+				object.matrixAutoUpdate = true;
+
+				if ( object.animationCache === undefined ) {
+
+					object.animationCache = {};
+					object.animationCache.prevKey = { pos: 0, rot: 0, scl: 0 };
+					object.animationCache.nextKey = { pos: 0, rot: 0, scl: 0 };
+					object.animationCache.originalMatrix = object instanceof THREE.Bone ? object.skinMatrix : object.matrix;
+
+				}
+
+				var prevKey = object.animationCache.prevKey;
+				var nextKey = object.animationCache.nextKey;
+
+				prevKey.pos = this.data.hierarchy[ h ].keys[ 0 ];
+				prevKey.rot = this.data.hierarchy[ h ].keys[ 0 ];
+				prevKey.scl = this.data.hierarchy[ h ].keys[ 0 ];
+
+				nextKey.pos = this.getNextKeyWith( "pos", h, 1 );
+				nextKey.rot = this.getNextKeyWith( "rot", h, 1 );
+				nextKey.scl = this.getNextKeyWith( "scl", h, 1 );
 
 			}
 
-			object.matrixAutoUpdate = true;
-
-			if ( object.animationCache === undefined ) {
-
-				object.animationCache = {};
-				object.animationCache.prevKey = { pos: 0, rot: 0, scl: 0 };
-				object.animationCache.nextKey = { pos: 0, rot: 0, scl: 0 };
-				object.animationCache.originalMatrix = object instanceof THREE.Bone ? object.skinMatrix : object.matrix;
-
-			}
-
-			var prevKey = object.animationCache.prevKey;
-			var nextKey = object.animationCache.nextKey;
-
-			prevKey.pos = this.data.hierarchy[ h ].keys[ 0 ];
-			prevKey.rot = this.data.hierarchy[ h ].keys[ 0 ];
-			prevKey.scl = this.data.hierarchy[ h ].keys[ 0 ];
-
-			nextKey.pos = this.getNextKeyWith( "pos", h, 1 );
-			nextKey.rot = this.getNextKeyWith( "rot", h, 1 );
-			nextKey.scl = this.getNextKeyWith( "scl", h, 1 );
+			this.update( 0 );
 
 		}
 
-		this.update( 0 );
-
-	}
-
-	this.isPaused = false;
-
-	THREE.AnimationHandler.addToUpdate( this );
-
-};
-
-
-THREE.Animation.prototype.pause = function() {
-
-	if ( this.isPaused === true ) {
+		this.isPaused = false;
 
 		THREE.AnimationHandler.addToUpdate( this );
 
-	} else {
+	},
 
+	pause: function() {
+
+		if ( this.isPaused === true ) {
+
+			THREE.AnimationHandler.addToUpdate( this );
+
+		} else {
+
+			THREE.AnimationHandler.removeFromUpdate( this );
+
+		}
+
+		this.isPaused = !this.isPaused;
+
+	},
+
+	stop: function() {
+
+		this.isPlaying = false;
+		this.isPaused  = false;
 		THREE.AnimationHandler.removeFromUpdate( this );
 
-	}
+	},
 
-	this.isPaused = !this.isPaused;
+	update: function ( deltaTimeMS ) {
 
-};
+		// early out
 
-
-THREE.Animation.prototype.stop = function() {
-
-	this.isPlaying = false;
-	this.isPaused  = false;
-	THREE.AnimationHandler.removeFromUpdate( this );
-
-};
+		if ( this.isPlaying === false ) return;
 
 
-THREE.Animation.prototype.update = function ( deltaTimeMS ) {
+		// vars
 
-	// early out
-
-	if ( this.isPlaying === false ) return;
-
-
-	// vars
-
-	var types = [ "pos", "rot", "scl" ];
-	var type;
-	var scale;
-	var vector;
-	var prevXYZ, nextXYZ;
-	var prevKey, nextKey;
-	var object;
-	var animationCache;
-	var frame;
-	var JIThierarchy = this.data.JIT.hierarchy;
-	var currentTime, unloopedCurrentTime;
-	var currentPoint, forwardPoint, angle;
+		var types = [ "pos", "rot", "scl" ];
+		var type;
+		var scale;
+		var vector;
+		var prevXYZ, nextXYZ;
+		var prevKey, nextKey;
+		var object;
+		var animationCache;
+		var frame;
+		var JIThierarchy = this.data.JIT.hierarchy;
+		var currentTime, unloopedCurrentTime;
+		var currentPoint, forwardPoint, angle;
 
 
-	this.currentTime += deltaTimeMS * this.timeScale;
+		this.currentTime += deltaTimeMS * this.timeScale;
 
-	unloopedCurrentTime = this.currentTime;
-	currentTime = this.currentTime = this.currentTime % this.data.length;
-	frame = parseInt( Math.min( currentTime * this.data.fps, this.data.length * this.data.fps ), 10 );
+		unloopedCurrentTime = this.currentTime;
+		currentTime = this.currentTime = this.currentTime % this.data.length;
+		frame = parseInt( Math.min( currentTime * this.data.fps, this.data.length * this.data.fps ), 10 );
 
 
-	for ( var h = 0, hl = this.hierarchy.length; h < hl; h ++ ) {
+		for ( var h = 0, hl = this.hierarchy.length; h < hl; h ++ ) {
 
-		object = this.hierarchy[ h ];
-		animationCache = object.animationCache;
+			object = this.hierarchy[ h ];
+			animationCache = object.animationCache;
 
-		// loop through pos/rot/scl
+			// loop through pos/rot/scl
 
-		for ( var t = 0; t < 3; t ++ ) {
+			for ( var t = 0; t < 3; t ++ ) {
 
-			// get keys
+				// get keys
 
-			type    = types[ t ];
-			prevKey = animationCache.prevKey[ type ];
-			nextKey = animationCache.nextKey[ type ];
+				type    = types[ t ];
+				prevKey = animationCache.prevKey[ type ];
+				nextKey = animationCache.nextKey[ type ];
 
-			// switch keys?
+				// switch keys?
 
-			if ( nextKey.time <= unloopedCurrentTime ) {
+				if ( nextKey.time <= unloopedCurrentTime ) {
 
-				// did we loop?
+					// did we loop?
 
-				if ( currentTime < unloopedCurrentTime ) {
+					if ( currentTime < unloopedCurrentTime ) {
 
-					if ( this.loop ) {
+						if ( this.loop ) {
 
-						prevKey = this.data.hierarchy[ h ].keys[ 0 ];
-						nextKey = this.getNextKeyWith( type, h, 1 );
+							prevKey = this.data.hierarchy[ h ].keys[ 0 ];
+							nextKey = this.getNextKeyWith( type, h, 1 );
 
-						while( nextKey.time < currentTime ) {
+							while( nextKey.time < currentTime ) {
 
-							prevKey = nextKey;
-							nextKey = this.getNextKeyWith( type, h, nextKey.index + 1 );
+								prevKey = nextKey;
+								nextKey = this.getNextKeyWith( type, h, nextKey.index + 1 );
+
+							}
+
+						} else {
+
+							this.stop();
+							return;
 
 						}
 
 					} else {
 
-						this.stop();
-						return;
+						do {
+
+							prevKey = nextKey;
+							nextKey = this.getNextKeyWith( type, h, nextKey.index + 1 );
+
+						} while( nextKey.time < currentTime )
 
 					}
 
-				} else {
-
-					do {
-
-						prevKey = nextKey;
-						nextKey = this.getNextKeyWith( type, h, nextKey.index + 1 );
-
-					} while( nextKey.time < currentTime )
+					animationCache.prevKey[ type ] = prevKey;
+					animationCache.nextKey[ type ] = nextKey;
 
 				}
 
-				animationCache.prevKey[ type ] = prevKey;
-				animationCache.nextKey[ type ] = nextKey;
 
-			}
+				object.matrixAutoUpdate = true;
+				object.matrixWorldNeedsUpdate = true;
 
-
-			object.matrixAutoUpdate = true;
-			object.matrixWorldNeedsUpdate = true;
-
-			scale = ( currentTime - prevKey.time ) / ( nextKey.time - prevKey.time );
-			prevXYZ = prevKey[ type ];
-			nextXYZ = nextKey[ type ];
+				scale = ( currentTime - prevKey.time ) / ( nextKey.time - prevKey.time );
+				prevXYZ = prevKey[ type ];
+				nextXYZ = nextKey[ type ];
 
 
-			// check scale error
+				// check scale error
 
-			if ( scale < 0 || scale > 1 ) {
+				if ( scale < 0 || scale > 1 ) {
 
-				console.log( "THREE.Animation.update: Warning! Scale out of bounds:" + scale + " on bone " + h );
-				scale = scale < 0 ? 0 : 1;
+					console.log( "THREE.Animation.update: Warning! Scale out of bounds:" + scale + " on bone " + h );
+					scale = scale < 0 ? 0 : 1;
 
-			}
+				}
 
-			// interpolate
+				// interpolate
 
-			if ( type === "pos" ) {
+				if ( type === "pos" ) {
 
-				vector = object.position;
+					vector = object.position;
 
-				if ( this.interpolationType === THREE.AnimationHandler.LINEAR ) {
+					if ( this.interpolationType === THREE.AnimationHandler.LINEAR ) {
+
+						vector.x = prevXYZ[ 0 ] + ( nextXYZ[ 0 ] - prevXYZ[ 0 ] ) * scale;
+						vector.y = prevXYZ[ 1 ] + ( nextXYZ[ 1 ] - prevXYZ[ 1 ] ) * scale;
+						vector.z = prevXYZ[ 2 ] + ( nextXYZ[ 2 ] - prevXYZ[ 2 ] ) * scale;
+
+					} else if ( this.interpolationType === THREE.AnimationHandler.CATMULLROM ||
+							    this.interpolationType === THREE.AnimationHandler.CATMULLROM_FORWARD ) {
+
+						this.points[ 0 ] = this.getPrevKeyWith( "pos", h, prevKey.index - 1 )[ "pos" ];
+						this.points[ 1 ] = prevXYZ;
+						this.points[ 2 ] = nextXYZ;
+						this.points[ 3 ] = this.getNextKeyWith( "pos", h, nextKey.index + 1 )[ "pos" ];
+
+						scale = scale * 0.33 + 0.33;
+
+						currentPoint = this.interpolateCatmullRom( this.points, scale );
+
+						vector.x = currentPoint[ 0 ];
+						vector.y = currentPoint[ 1 ];
+						vector.z = currentPoint[ 2 ];
+
+						if ( this.interpolationType === THREE.AnimationHandler.CATMULLROM_FORWARD ) {
+
+							forwardPoint = this.interpolateCatmullRom( this.points, scale * 1.01 );
+
+							this.target.set( forwardPoint[ 0 ], forwardPoint[ 1 ], forwardPoint[ 2 ] );
+							this.target.sub( vector );
+							this.target.y = 0;
+							this.target.normalize();
+
+							angle = Math.atan2( this.target.x, this.target.z );
+							object.rotation.set( 0, angle, 0 );
+
+						}
+
+					}
+
+				} else if ( type === "rot" ) {
+
+					THREE.Quaternion.slerp( prevXYZ, nextXYZ, object.quaternion, scale );
+
+				} else if ( type === "scl" ) {
+
+					vector = object.scale;
 
 					vector.x = prevXYZ[ 0 ] + ( nextXYZ[ 0 ] - prevXYZ[ 0 ] ) * scale;
 					vector.y = prevXYZ[ 1 ] + ( nextXYZ[ 1 ] - prevXYZ[ 1 ] ) * scale;
 					vector.z = prevXYZ[ 2 ] + ( nextXYZ[ 2 ] - prevXYZ[ 2 ] ) * scale;
 
-				} else if ( this.interpolationType === THREE.AnimationHandler.CATMULLROM ||
-						    this.interpolationType === THREE.AnimationHandler.CATMULLROM_FORWARD ) {
-
-					this.points[ 0 ] = this.getPrevKeyWith( "pos", h, prevKey.index - 1 )[ "pos" ];
-					this.points[ 1 ] = prevXYZ;
-					this.points[ 2 ] = nextXYZ;
-					this.points[ 3 ] = this.getNextKeyWith( "pos", h, nextKey.index + 1 )[ "pos" ];
-
-					scale = scale * 0.33 + 0.33;
-
-					currentPoint = this.interpolateCatmullRom( this.points, scale );
-
-					vector.x = currentPoint[ 0 ];
-					vector.y = currentPoint[ 1 ];
-					vector.z = currentPoint[ 2 ];
-
-					if ( this.interpolationType === THREE.AnimationHandler.CATMULLROM_FORWARD ) {
-
-						forwardPoint = this.interpolateCatmullRom( this.points, scale * 1.01 );
-
-						this.target.set( forwardPoint[ 0 ], forwardPoint[ 1 ], forwardPoint[ 2 ] );
-						this.target.sub( vector );
-						this.target.y = 0;
-						this.target.normalize();
-
-						angle = Math.atan2( this.target.x, this.target.z );
-						object.rotation.set( 0, angle, 0 );
-
-					}
-
 				}
-
-			} else if ( type === "rot" ) {
-
-				THREE.Quaternion.slerp( prevXYZ, nextXYZ, object.quaternion, scale );
-
-			} else if ( type === "scl" ) {
-
-				vector = object.scale;
-
-				vector.x = prevXYZ[ 0 ] + ( nextXYZ[ 0 ] - prevXYZ[ 0 ] ) * scale;
-				vector.y = prevXYZ[ 1 ] + ( nextXYZ[ 1 ] - prevXYZ[ 1 ] ) * scale;
-				vector.z = prevXYZ[ 2 ] + ( nextXYZ[ 2 ] - prevXYZ[ 2 ] ) * scale;
 
 			}
 
 		}
 
-	}
+	},
 
-};
+	interpolateCatmullRom: function ( points, scale ) {
 
-// Catmull-Rom spline
+		var c = [], v3 = [],
+		point, intPoint, weight, w2, w3,
+		pa, pb, pc, pd;
 
-THREE.Animation.prototype.interpolateCatmullRom = function ( points, scale ) {
+		point = ( points.length - 1 ) * scale;
+		intPoint = Math.floor( point );
+		weight = point - intPoint;
 
-	var c = [], v3 = [],
-	point, intPoint, weight, w2, w3,
-	pa, pb, pc, pd;
+		c[ 0 ] = intPoint === 0 ? intPoint : intPoint - 1;
+		c[ 1 ] = intPoint;
+		c[ 2 ] = intPoint > points.length - 2 ? intPoint : intPoint + 1;
+		c[ 3 ] = intPoint > points.length - 3 ? intPoint : intPoint + 2;
 
-	point = ( points.length - 1 ) * scale;
-	intPoint = Math.floor( point );
-	weight = point - intPoint;
+		pa = points[ c[ 0 ] ];
+		pb = points[ c[ 1 ] ];
+		pc = points[ c[ 2 ] ];
+		pd = points[ c[ 3 ] ];
 
-	c[ 0 ] = intPoint === 0 ? intPoint : intPoint - 1;
-	c[ 1 ] = intPoint;
-	c[ 2 ] = intPoint > points.length - 2 ? intPoint : intPoint + 1;
-	c[ 3 ] = intPoint > points.length - 3 ? intPoint : intPoint + 2;
+		w2 = weight * weight;
+		w3 = weight * w2;
 
-	pa = points[ c[ 0 ] ];
-	pb = points[ c[ 1 ] ];
-	pc = points[ c[ 2 ] ];
-	pd = points[ c[ 3 ] ];
+		v3[ 0 ] = this.interpolate( pa[ 0 ], pb[ 0 ], pc[ 0 ], pd[ 0 ], weight, w2, w3 );
+		v3[ 1 ] = this.interpolate( pa[ 1 ], pb[ 1 ], pc[ 1 ], pd[ 1 ], weight, w2, w3 );
+		v3[ 2 ] = this.interpolate( pa[ 2 ], pb[ 2 ], pc[ 2 ], pd[ 2 ], weight, w2, w3 );
 
-	w2 = weight * weight;
-	w3 = weight * w2;
+		return v3;
 
-	v3[ 0 ] = this.interpolate( pa[ 0 ], pb[ 0 ], pc[ 0 ], pd[ 0 ], weight, w2, w3 );
-	v3[ 1 ] = this.interpolate( pa[ 1 ], pb[ 1 ], pc[ 1 ], pd[ 1 ], weight, w2, w3 );
-	v3[ 2 ] = this.interpolate( pa[ 2 ], pb[ 2 ], pc[ 2 ], pd[ 2 ], weight, w2, w3 );
+	},
 
-	return v3;
+	interpolate: function ( p0, p1, p2, p3, t, t2, t3 ) {
 
-};
+		var v0 = ( p2 - p0 ) * 0.5,
+			v1 = ( p3 - p1 ) * 0.5;
 
-THREE.Animation.prototype.interpolate = function ( p0, p1, p2, p3, t, t2, t3 ) {
+		return ( 2 * ( p1 - p2 ) + v0 + v1 ) * t3 + ( - 3 * ( p1 - p2 ) - 2 * v0 - v1 ) * t2 + v0 * t + p1;
 
-	var v0 = ( p2 - p0 ) * 0.5,
-		v1 = ( p3 - p1 ) * 0.5;
+	},
 
-	return ( 2 * ( p1 - p2 ) + v0 + v1 ) * t3 + ( - 3 * ( p1 - p2 ) - 2 * v0 - v1 ) * t2 + v0 * t + p1;
+	getNextKeyWith: function ( type, h, key ) {
 
-};
+		var keys = this.data.hierarchy[ h ].keys;
 
+		if ( this.interpolationType === THREE.AnimationHandler.CATMULLROM ||
+			 this.interpolationType === THREE.AnimationHandler.CATMULLROM_FORWARD ) {
 
+			key = key < keys.length - 1 ? key : keys.length - 1;
 
-// Get next key with
+		} else {
 
-THREE.Animation.prototype.getNextKeyWith = function ( type, h, key ) {
-
-	var keys = this.data.hierarchy[ h ].keys;
-
-	if ( this.interpolationType === THREE.AnimationHandler.CATMULLROM ||
-		 this.interpolationType === THREE.AnimationHandler.CATMULLROM_FORWARD ) {
-
-		key = key < keys.length - 1 ? key : keys.length - 1;
-
-	} else {
-
-		key = key % keys.length;
-
-	}
-
-	for ( ; key < keys.length; key++ ) {
-
-		if ( keys[ key ][ type ] !== undefined ) {
-
-			return keys[ key ];
+			key = key % keys.length;
 
 		}
 
-	}
+		for ( ; key < keys.length; key++ ) {
 
-	return this.data.hierarchy[ h ].keys[ 0 ];
+			if ( keys[ key ][ type ] !== undefined ) {
 
-};
+				return keys[ key ];
 
-// Get previous key with
-
-THREE.Animation.prototype.getPrevKeyWith = function ( type, h, key ) {
-
-	var keys = this.data.hierarchy[ h ].keys;
-
-	if ( this.interpolationType === THREE.AnimationHandler.CATMULLROM ||
-		 this.interpolationType === THREE.AnimationHandler.CATMULLROM_FORWARD ) {
-
-		key = key > 0 ? key : 0;
-
-	} else {
-
-		key = key >= 0 ? key : key + keys.length;
-
-	}
-
-
-	for ( ; key >= 0; key -- ) {
-
-		if ( keys[ key ][ type ] !== undefined ) {
-
-			return keys[ key ];
+			}
 
 		}
 
+		return this.data.hierarchy[ h ].keys[ 0 ];
+
+	},
+
+	getPrevKeyWith: function ( type, h, key ) {
+
+		var keys = this.data.hierarchy[ h ].keys;
+
+		if ( this.interpolationType === THREE.AnimationHandler.CATMULLROM ||
+			 this.interpolationType === THREE.AnimationHandler.CATMULLROM_FORWARD ) {
+
+			key = key > 0 ? key : 0;
+
+		} else {
+
+			key = key >= 0 ? key : key + keys.length;
+
+		}
+
+
+		for ( ; key >= 0; key -- ) {
+
+			if ( keys[ key ][ type ] !== undefined ) {
+
+				return keys[ key ];
+
+			}
+
+		}
+
+		return this.data.hierarchy[ h ].keys[ keys.length - 1 ];
+
 	}
 
-	return this.data.hierarchy[ h ].keys[ keys.length - 1 ];
-
-};
+});

--- a/src/extras/animation/KeyFrameAnimation.js
+++ b/src/extras/animation/KeyFrameAnimation.js
@@ -51,373 +51,361 @@ THREE.KeyFrameAnimation = function( root, data, JITCompile ) {
 
 };
 
-// Play
+THREE.extend( THREE.KeyFrameAnimation.prototype, {
 
-THREE.KeyFrameAnimation.prototype.play = function( loop, startTimeMS ) {
+	play: function( loop, startTimeMS ) {
 
-	if( !this.isPlaying ) {
+		if( !this.isPlaying ) {
 
-		this.isPlaying = true;
-		this.loop = loop !== undefined ? loop : true;
-		this.currentTime = startTimeMS !== undefined ? startTimeMS : 0;
-		this.startTimeMs = startTimeMS;
-		this.startTime = 10000000;
-		this.endTime = -this.startTime;
+			this.isPlaying = true;
+			this.loop = loop !== undefined ? loop : true;
+			this.currentTime = startTimeMS !== undefined ? startTimeMS : 0;
+			this.startTimeMs = startTimeMS;
+			this.startTime = 10000000;
+			this.endTime = -this.startTime;
 
 
-		// reset key cache
+			// reset key cache
 
-		var h, hl = this.hierarchy.length,
-			object,
-			node;
+			var h, hl = this.hierarchy.length,
+				object,
+				node;
 
-		for ( h = 0; h < hl; h++ ) {
+			for ( h = 0; h < hl; h++ ) {
 
-			object = this.hierarchy[ h ];
-			node = this.data.hierarchy[ h ];
-			object.useQuaternion = true;
+				object = this.hierarchy[ h ];
+				node = this.data.hierarchy[ h ];
+				object.useQuaternion = true;
 
-			if ( node.animationCache === undefined ) {
+				if ( node.animationCache === undefined ) {
 
-				node.animationCache = {};
-				node.animationCache.prevKey = null;
-				node.animationCache.nextKey = null;
-				node.animationCache.originalMatrix = object instanceof THREE.Bone ? object.skinMatrix : object.matrix;
+					node.animationCache = {};
+					node.animationCache.prevKey = null;
+					node.animationCache.nextKey = null;
+					node.animationCache.originalMatrix = object instanceof THREE.Bone ? object.skinMatrix : object.matrix;
+
+				}
+
+				var keys = this.data.hierarchy[h].keys;
+
+				if (keys.length) {
+
+					node.animationCache.prevKey = keys[ 0 ];
+					node.animationCache.nextKey = keys[ 1 ];
+
+					this.startTime = Math.min( keys[0].time, this.startTime );
+					this.endTime = Math.max( keys[keys.length - 1].time, this.endTime );
+
+				}
 
 			}
 
-			var keys = this.data.hierarchy[h].keys;
-
-			if (keys.length) {
-
-				node.animationCache.prevKey = keys[ 0 ];
-				node.animationCache.nextKey = keys[ 1 ];
-
-				this.startTime = Math.min( keys[0].time, this.startTime );
-				this.endTime = Math.max( keys[keys.length - 1].time, this.endTime );
-
-			}
+			this.update( 0 );
 
 		}
 
-		this.update( 0 );
-
-	}
-
-	this.isPaused = false;
-
-	THREE.AnimationHandler.addToUpdate( this );
-
-};
-
-
-
-// Pause
-
-THREE.KeyFrameAnimation.prototype.pause = function() {
-
-	if( this.isPaused ) {
+		this.isPaused = false;
 
 		THREE.AnimationHandler.addToUpdate( this );
 
-	} else {
+	},
 
-		THREE.AnimationHandler.removeFromUpdate( this );
+	pause: function() {
 
-	}
+		if( this.isPaused ) {
 
-	this.isPaused = !this.isPaused;
+			THREE.AnimationHandler.addToUpdate( this );
 
-};
+		} else {
 
-
-// Stop
-
-THREE.KeyFrameAnimation.prototype.stop = function() {
-
-	this.isPlaying = false;
-	this.isPaused  = false;
-	THREE.AnimationHandler.removeFromUpdate( this );
-
-
-	// reset JIT matrix and remove cache
-
-	for ( var h = 0; h < this.data.hierarchy.length; h++ ) {
-        
-        var obj = this.hierarchy[ h ];
-		var node = this.data.hierarchy[ h ];
-
-		if ( node.animationCache !== undefined ) {
-
-			var original = node.animationCache.originalMatrix;
-
-			if( obj instanceof THREE.Bone ) {
-
-				original.copy( obj.skinMatrix );
-				obj.skinMatrix = original;
-
-			} else {
-
-				original.copy( obj.matrix );
-				obj.matrix = original;
-
-			}
-
-			delete node.animationCache;
+			THREE.AnimationHandler.removeFromUpdate( this );
 
 		}
 
-	}
+		this.isPaused = !this.isPaused;
 
-};
+	},
 
+	stop: function() {
 
-// Update
-
-THREE.KeyFrameAnimation.prototype.update = function( deltaTimeMS ) {
-
-	// early out
-
-	if( !this.isPlaying ) return;
+		this.isPlaying = false;
+		this.isPaused  = false;
+		THREE.AnimationHandler.removeFromUpdate( this );
 
 
-	// vars
+		// reset JIT matrix and remove cache
 
-	var prevKey, nextKey;
-	var object;
-	var node;
-	var frame;
-	var JIThierarchy = this.data.JIT.hierarchy;
-	var currentTime, unloopedCurrentTime;
-	var looped;
+		for ( var h = 0; h < this.data.hierarchy.length; h++ ) {
+	        
+	        var obj = this.hierarchy[ h ];
+			var node = this.data.hierarchy[ h ];
+
+			if ( node.animationCache !== undefined ) {
+
+				var original = node.animationCache.originalMatrix;
+
+				if( obj instanceof THREE.Bone ) {
+
+					original.copy( obj.skinMatrix );
+					obj.skinMatrix = original;
+
+				} else {
+
+					original.copy( obj.matrix );
+					obj.matrix = original;
+
+				}
+
+				delete node.animationCache;
+
+			}
+
+		}
+
+	},
+
+	update: function( deltaTimeMS ) {
+
+		// early out
+
+		if( !this.isPlaying ) return;
 
 
-	// update
+		// vars
 
-	this.currentTime += deltaTimeMS * this.timeScale;
+		var prevKey, nextKey;
+		var object;
+		var node;
+		var frame;
+		var JIThierarchy = this.data.JIT.hierarchy;
+		var currentTime, unloopedCurrentTime;
+		var looped;
 
-	unloopedCurrentTime = this.currentTime;
-	currentTime         = this.currentTime = this.currentTime % this.data.length;
 
-	// if looped around, the current time should be based on the startTime
-	if ( currentTime < this.startTimeMs ) {
+		// update
 
-		currentTime = this.currentTime = this.startTimeMs + currentTime;
+		this.currentTime += deltaTimeMS * this.timeScale;
 
-	}
+		unloopedCurrentTime = this.currentTime;
+		currentTime         = this.currentTime = this.currentTime % this.data.length;
 
-	frame               = parseInt( Math.min( currentTime * this.data.fps, this.data.length * this.data.fps ), 10 );
-	looped 				= currentTime < unloopedCurrentTime;
+		// if looped around, the current time should be based on the startTime
+		if ( currentTime < this.startTimeMs ) {
 
-	if ( looped && !this.loop ) {
+			currentTime = this.currentTime = this.startTimeMs + currentTime;
 
-		// Set the animation to the last keyframes and stop
-		for ( var h = 0, hl = this.hierarchy.length; h < hl; h++ ) {
+		}
 
-			var keys = this.data.hierarchy[h].keys,
-				sids = this.data.hierarchy[h].sids,
-				end = keys.length-1,
-				obj = this.hierarchy[h];
+		frame               = parseInt( Math.min( currentTime * this.data.fps, this.data.length * this.data.fps ), 10 );
+		looped 				= currentTime < unloopedCurrentTime;
 
-			if ( keys.length ) {
+		if ( looped && !this.loop ) {
 
-				for ( var s = 0; s < sids.length; s++ ) {
+			// Set the animation to the last keyframes and stop
+			for ( var h = 0, hl = this.hierarchy.length; h < hl; h++ ) {
 
-					var sid = sids[ s ],
-						prev = this.getPrevKeyWith( sid, h, end );
+				var keys = this.data.hierarchy[h].keys,
+					sids = this.data.hierarchy[h].sids,
+					end = keys.length-1,
+					obj = this.hierarchy[h];
 
-					if ( prev ) {
-						prev.apply( sid );
+				if ( keys.length ) {
+
+					for ( var s = 0; s < sids.length; s++ ) {
+
+						var sid = sids[ s ],
+							prev = this.getPrevKeyWith( sid, h, end );
+
+						if ( prev ) {
+							prev.apply( sid );
+
+						}
 
 					}
+
+					this.data.hierarchy[h].node.updateMatrix();
+					obj.matrixWorldNeedsUpdate = true;
+
+				}
+
+			}
+
+			this.stop();
+			return;
+
+		}
+
+		// check pre-infinity
+		if ( currentTime < this.startTime ) {
+
+			return;
+
+		}
+
+		// update
+
+		for ( var h = 0, hl = this.hierarchy.length; h < hl; h++ ) {
+
+			object = this.hierarchy[ h ];
+			node = this.data.hierarchy[ h ];
+
+			var keys = node.keys,
+				animationCache = node.animationCache;
+
+			// use JIT?
+
+			if ( this.JITCompile && JIThierarchy[ h ][ frame ] !== undefined ) {
+
+				if( object instanceof THREE.Bone ) {
+
+					object.skinMatrix = JIThierarchy[ h ][ frame ];
+					object.matrixWorldNeedsUpdate = false;
+
+				} else {
+
+					object.matrix = JIThierarchy[ h ][ frame ];
+					object.matrixWorldNeedsUpdate = true;
+
+				}
+
+			// use interpolation
+
+			} else if ( keys.length ) {
+
+				// make sure so original matrix and not JIT matrix is set
+
+				if ( this.JITCompile && animationCache ) {
+
+					if( object instanceof THREE.Bone ) {
+
+						object.skinMatrix = animationCache.originalMatrix;
+
+					} else {
+
+						object.matrix = animationCache.originalMatrix;
+
+					}
+
+				}
+
+				prevKey = animationCache.prevKey;
+				nextKey = animationCache.nextKey;
+
+				if ( prevKey && nextKey ) {
+
+					// switch keys?
+
+					if ( nextKey.time <= unloopedCurrentTime ) {
+
+						// did we loop?
+
+						if ( looped && this.loop ) {
+
+							prevKey = keys[ 0 ];
+							nextKey = keys[ 1 ];
+
+							while ( nextKey.time < currentTime ) {
+
+								prevKey = nextKey;
+								nextKey = keys[ prevKey.index + 1 ];
+
+							}
+
+						} else if ( !looped ) {
+
+							var lastIndex = keys.length - 1;
+
+							while ( nextKey.time < currentTime && nextKey.index !== lastIndex ) {
+
+								prevKey = nextKey;
+								nextKey = keys[ prevKey.index + 1 ];
+
+							}
+
+						}
+
+						animationCache.prevKey = prevKey;
+						animationCache.nextKey = nextKey;
+
+					}
+	                if(nextKey.time >= currentTime)
+	                    prevKey.interpolate( nextKey, currentTime );
+	                else
+	                    prevKey.interpolate( nextKey, nextKey.time);
 
 				}
 
 				this.data.hierarchy[h].node.updateMatrix();
-				obj.matrixWorldNeedsUpdate = true;
-
-			}
-
-		}
-
-		this.stop();
-		return;
-
-	}
-
-	// check pre-infinity
-	if ( currentTime < this.startTime ) {
-
-		return;
-
-	}
-
-	// update
-
-	for ( var h = 0, hl = this.hierarchy.length; h < hl; h++ ) {
-
-		object = this.hierarchy[ h ];
-		node = this.data.hierarchy[ h ];
-
-		var keys = node.keys,
-			animationCache = node.animationCache;
-
-		// use JIT?
-
-		if ( this.JITCompile && JIThierarchy[ h ][ frame ] !== undefined ) {
-
-			if( object instanceof THREE.Bone ) {
-
-				object.skinMatrix = JIThierarchy[ h ][ frame ];
-				object.matrixWorldNeedsUpdate = false;
-
-			} else {
-
-				object.matrix = JIThierarchy[ h ][ frame ];
 				object.matrixWorldNeedsUpdate = true;
 
 			}
 
-		// use interpolation
+		}
 
-		} else if ( keys.length ) {
+		// update JIT?
 
-			// make sure so original matrix and not JIT matrix is set
+		if ( this.JITCompile ) {
 
-			if ( this.JITCompile && animationCache ) {
+			if ( JIThierarchy[ 0 ][ frame ] === undefined ) {
 
-				if( object instanceof THREE.Bone ) {
+				this.hierarchy[ 0 ].updateMatrixWorld( true );
 
-					object.skinMatrix = animationCache.originalMatrix;
+				for ( var h = 0; h < this.hierarchy.length; h++ ) {
 
-				} else {
+					if( this.hierarchy[ h ] instanceof THREE.Bone ) {
 
-					object.matrix = animationCache.originalMatrix;
+						JIThierarchy[ h ][ frame ] = this.hierarchy[ h ].skinMatrix.clone();
 
-				}
+					} else {
 
-			}
-
-			prevKey = animationCache.prevKey;
-			nextKey = animationCache.nextKey;
-
-			if ( prevKey && nextKey ) {
-
-				// switch keys?
-
-				if ( nextKey.time <= unloopedCurrentTime ) {
-
-					// did we loop?
-
-					if ( looped && this.loop ) {
-
-						prevKey = keys[ 0 ];
-						nextKey = keys[ 1 ];
-
-						while ( nextKey.time < currentTime ) {
-
-							prevKey = nextKey;
-							nextKey = keys[ prevKey.index + 1 ];
-
-						}
-
-					} else if ( !looped ) {
-
-						var lastIndex = keys.length - 1;
-
-						while ( nextKey.time < currentTime && nextKey.index !== lastIndex ) {
-
-							prevKey = nextKey;
-							nextKey = keys[ prevKey.index + 1 ];
-
-						}
+						JIThierarchy[ h ][ frame ] = this.hierarchy[ h ].matrix.clone();
 
 					}
 
-					animationCache.prevKey = prevKey;
-					animationCache.nextKey = nextKey;
-
-				}
-                if(nextKey.time >= currentTime)
-                    prevKey.interpolate( nextKey, currentTime );
-                else
-                    prevKey.interpolate( nextKey, nextKey.time);
-
-			}
-
-			this.data.hierarchy[h].node.updateMatrix();
-			object.matrixWorldNeedsUpdate = true;
-
-		}
-
-	}
-
-	// update JIT?
-
-	if ( this.JITCompile ) {
-
-		if ( JIThierarchy[ 0 ][ frame ] === undefined ) {
-
-			this.hierarchy[ 0 ].updateMatrixWorld( true );
-
-			for ( var h = 0; h < this.hierarchy.length; h++ ) {
-
-				if( this.hierarchy[ h ] instanceof THREE.Bone ) {
-
-					JIThierarchy[ h ][ frame ] = this.hierarchy[ h ].skinMatrix.clone();
-
-				} else {
-
-					JIThierarchy[ h ][ frame ] = this.hierarchy[ h ].matrix.clone();
-
 				}
 
 			}
 
 		}
 
-	}
+	},
 
-};
+	getNextKeyWith: function( sid, h, key ) {
 
-// Get next key with
+		var keys = this.data.hierarchy[ h ].keys;
+		key = key % keys.length;
 
-THREE.KeyFrameAnimation.prototype.getNextKeyWith = function( sid, h, key ) {
+		for ( ; key < keys.length; key++ ) {
 
-	var keys = this.data.hierarchy[ h ].keys;
-	key = key % keys.length;
+			if ( keys[ key ].hasTarget( sid ) ) {
 
-	for ( ; key < keys.length; key++ ) {
+				return keys[ key ];
 
-		if ( keys[ key ].hasTarget( sid ) ) {
-
-			return keys[ key ];
+			}
 
 		}
 
-	}
+		return keys[ 0 ];
 
-	return keys[ 0 ];
+	},
 
-};
+	getPrevKeyWith: function( sid, h, key ) {
 
-// Get previous key with
+		var keys = this.data.hierarchy[ h ].keys;
+		key = key >= 0 ? key : key + keys.length;
 
-THREE.KeyFrameAnimation.prototype.getPrevKeyWith = function( sid, h, key ) {
+		for ( ; key >= 0; key-- ) {
 
-	var keys = this.data.hierarchy[ h ].keys;
-	key = key >= 0 ? key : key + keys.length;
+			if ( keys[ key ].hasTarget( sid ) ) {
 
-	for ( ; key >= 0; key-- ) {
+				return keys[ key ];
 
-		if ( keys[ key ].hasTarget( sid ) ) {
-
-			return keys[ key ];
+			}
 
 		}
 
+		return keys[ keys.length - 1 ];
+
 	}
 
-	return keys[ keys.length - 1 ];
-
-};
+});

--- a/src/extras/cameras/CombinedCamera.js
+++ b/src/extras/cameras/CombinedCamera.js
@@ -236,4 +236,4 @@ THREE.extend( THREE.CombinedCamera.prototype, {
 
 	}
 
-};
+} );

--- a/src/extras/cameras/CombinedCamera.js
+++ b/src/extras/cameras/CombinedCamera.js
@@ -35,203 +35,205 @@ THREE.CombinedCamera = function ( width, height, fov, near, far, orthoNear, orth
 
 THREE.CombinedCamera.prototype = Object.create( THREE.Camera.prototype );
 
-THREE.CombinedCamera.prototype.toPerspective = function () {
+THREE.extend( THREE.CombinedCamera.prototype, {
 
-	// Switches to the Perspective Camera
+	toPerspective: function () {
 
-	this.near = this.cameraP.near;
-	this.far = this.cameraP.far;
+		// Switches to the Perspective Camera
 
-	this.cameraP.fov =  this.fov / this.zoom ;
+		this.near = this.cameraP.near;
+		this.far = this.cameraP.far;
 
-	this.cameraP.updateProjectionMatrix();
+		this.cameraP.fov =  this.fov / this.zoom ;
 
-	this.projectionMatrix = this.cameraP.projectionMatrix;
+		this.cameraP.updateProjectionMatrix();
 
-	this.inPerspectiveMode = true;
-	this.inOrthographicMode = false;
+		this.projectionMatrix = this.cameraP.projectionMatrix;
 
-};
+		this.inPerspectiveMode = true;
+		this.inOrthographicMode = false;
 
-THREE.CombinedCamera.prototype.toOrthographic = function () {
+	},
 
-	// Switches to the Orthographic camera estimating viewport from Perspective
+	toOrthographic: function () {
 
-	var fov = this.fov;
-	var aspect = this.cameraP.aspect;
-	var near = this.cameraP.near;
-	var far = this.cameraP.far;
+		// Switches to the Orthographic camera estimating viewport from Perspective
 
-	// The size that we set is the mid plane of the viewing frustum
+		var fov = this.fov;
+		var aspect = this.cameraP.aspect;
+		var near = this.cameraP.near;
+		var far = this.cameraP.far;
 
-	var hyperfocus = ( near + far ) / 2;
+		// The size that we set is the mid plane of the viewing frustum
 
-	var halfHeight = Math.tan( fov / 2 ) * hyperfocus;
-	var planeHeight = 2 * halfHeight;
-	var planeWidth = planeHeight * aspect;
-	var halfWidth = planeWidth / 2;
+		var hyperfocus = ( near + far ) / 2;
 
-	halfHeight /= this.zoom;
-	halfWidth /= this.zoom;
+		var halfHeight = Math.tan( fov / 2 ) * hyperfocus;
+		var planeHeight = 2 * halfHeight;
+		var planeWidth = planeHeight * aspect;
+		var halfWidth = planeWidth / 2;
 
-	this.cameraO.left = -halfWidth;
-	this.cameraO.right = halfWidth;
-	this.cameraO.top = halfHeight;
-	this.cameraO.bottom = -halfHeight;
+		halfHeight /= this.zoom;
+		halfWidth /= this.zoom;
 
-	// this.cameraO.left = -farHalfWidth;
-	// this.cameraO.right = farHalfWidth;
-	// this.cameraO.top = farHalfHeight;
-	// this.cameraO.bottom = -farHalfHeight;
+		this.cameraO.left = -halfWidth;
+		this.cameraO.right = halfWidth;
+		this.cameraO.top = halfHeight;
+		this.cameraO.bottom = -halfHeight;
 
-	// this.cameraO.left = this.left / this.zoom;
-	// this.cameraO.right = this.right / this.zoom;
-	// this.cameraO.top = this.top / this.zoom;
-	// this.cameraO.bottom = this.bottom / this.zoom;
+		// this.cameraO.left = -farHalfWidth;
+		// this.cameraO.right = farHalfWidth;
+		// this.cameraO.top = farHalfHeight;
+		// this.cameraO.bottom = -farHalfHeight;
 
-	this.cameraO.updateProjectionMatrix();
+		// this.cameraO.left = this.left / this.zoom;
+		// this.cameraO.right = this.right / this.zoom;
+		// this.cameraO.top = this.top / this.zoom;
+		// this.cameraO.bottom = this.bottom / this.zoom;
 
-	this.near = this.cameraO.near;
-	this.far = this.cameraO.far;
-	this.projectionMatrix = this.cameraO.projectionMatrix;
+		this.cameraO.updateProjectionMatrix();
 
-	this.inPerspectiveMode = false;
-	this.inOrthographicMode = true;
+		this.near = this.cameraO.near;
+		this.far = this.cameraO.far;
+		this.projectionMatrix = this.cameraO.projectionMatrix;
 
-};
+		this.inPerspectiveMode = false;
+		this.inOrthographicMode = true;
 
-
-THREE.CombinedCamera.prototype.setSize = function( width, height ) {
-
-	this.cameraP.aspect = width / height;
-	this.left = -width / 2;
-	this.right = width / 2
-	this.top = height / 2;
-	this.bottom = -height / 2;
-
-};
+	},
 
 
-THREE.CombinedCamera.prototype.setFov = function( fov ) {
+	setSize: function( width, height ) {
 
-	this.fov = fov;
+		this.cameraP.aspect = width / height;
+		this.left = -width / 2;
+		this.right = width / 2
+		this.top = height / 2;
+		this.bottom = -height / 2;
 
-	if ( this.inPerspectiveMode ) {
+	},
 
-		this.toPerspective();
 
-	} else {
+	setFov: function( fov ) {
 
-		this.toOrthographic();
+		this.fov = fov;
+
+		if ( this.inPerspectiveMode ) {
+
+			this.toPerspective();
+
+		} else {
+
+			this.toOrthographic();
+
+		}
+
+	},
+
+	// For mantaining similar API with PerspectiveCamera
+
+	updateProjectionMatrix: function() {
+
+		if ( this.inPerspectiveMode ) {
+
+			this.toPerspective();
+
+		} else {
+
+			this.toPerspective();
+			this.toOrthographic();
+
+		}
+
+	},
+
+	/*
+	* Uses Focal Length (in mm) to estimate and set FOV
+	* 35mm (fullframe) camera is used if frame size is not specified;
+	* Formula based on http://www.bobatkins.com/photography/technical/field_of_view.html
+	*/
+	setLens: function ( focalLength, frameHeight ) {
+
+		if ( frameHeight === undefined ) frameHeight = 24;
+
+		var fov = 2 * THREE.Math.radToDeg( Math.atan( frameHeight / ( focalLength * 2 ) ) );
+
+		this.setFov( fov );
+
+		return fov;
+	},
+
+	setZoom: function( zoom ) {
+
+		this.zoom = zoom;
+
+		if ( this.inPerspectiveMode ) {
+
+			this.toPerspective();
+
+		} else {
+
+			this.toOrthographic();
+
+		}
+
+	},
+
+	toFrontView: function() {
+
+		this.rotation.x = 0;
+		this.rotation.y = 0;
+		this.rotation.z = 0;
+
+		// should we be modifing the matrix instead?
+
+		this.rotationAutoUpdate = false;
+
+	},
+
+	toBackView: function() {
+
+		this.rotation.x = 0;
+		this.rotation.y = Math.PI;
+		this.rotation.z = 0;
+		this.rotationAutoUpdate = false;
+
+	},
+
+	toLeftView: function() {
+
+		this.rotation.x = 0;
+		this.rotation.y = - Math.PI / 2;
+		this.rotation.z = 0;
+		this.rotationAutoUpdate = false;
+
+	},
+
+	toRightView: function() {
+
+		this.rotation.x = 0;
+		this.rotation.y = Math.PI / 2;
+		this.rotation.z = 0;
+		this.rotationAutoUpdate = false;
+
+	},
+
+	toTopView: function() {
+
+		this.rotation.x = - Math.PI / 2;
+		this.rotation.y = 0;
+		this.rotation.z = 0;
+		this.rotationAutoUpdate = false;
+
+	},
+
+	toBottomView: function() {
+
+		this.rotation.x = Math.PI / 2;
+		this.rotation.y = 0;
+		this.rotation.z = 0;
+		this.rotationAutoUpdate = false;
 
 	}
 
 };
-
-// For mantaining similar API with PerspectiveCamera
-
-THREE.CombinedCamera.prototype.updateProjectionMatrix = function() {
-
-	if ( this.inPerspectiveMode ) {
-
-		this.toPerspective();
-
-	} else {
-
-		this.toPerspective();
-		this.toOrthographic();
-
-	}
-
-};
-
-/*
-* Uses Focal Length (in mm) to estimate and set FOV
-* 35mm (fullframe) camera is used if frame size is not specified;
-* Formula based on http://www.bobatkins.com/photography/technical/field_of_view.html
-*/
-THREE.CombinedCamera.prototype.setLens = function ( focalLength, frameHeight ) {
-
-	if ( frameHeight === undefined ) frameHeight = 24;
-
-	var fov = 2 * THREE.Math.radToDeg( Math.atan( frameHeight / ( focalLength * 2 ) ) );
-
-	this.setFov( fov );
-
-	return fov;
-};
-
-
-THREE.CombinedCamera.prototype.setZoom = function( zoom ) {
-
-	this.zoom = zoom;
-
-	if ( this.inPerspectiveMode ) {
-
-		this.toPerspective();
-
-	} else {
-
-		this.toOrthographic();
-
-	}
-
-};
-
-THREE.CombinedCamera.prototype.toFrontView = function() {
-
-	this.rotation.x = 0;
-	this.rotation.y = 0;
-	this.rotation.z = 0;
-
-	// should we be modifing the matrix instead?
-
-	this.rotationAutoUpdate = false;
-
-};
-
-THREE.CombinedCamera.prototype.toBackView = function() {
-
-	this.rotation.x = 0;
-	this.rotation.y = Math.PI;
-	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
-
-};
-
-THREE.CombinedCamera.prototype.toLeftView = function() {
-
-	this.rotation.x = 0;
-	this.rotation.y = - Math.PI / 2;
-	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
-
-};
-
-THREE.CombinedCamera.prototype.toRightView = function() {
-
-	this.rotation.x = 0;
-	this.rotation.y = Math.PI / 2;
-	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
-
-};
-
-THREE.CombinedCamera.prototype.toTopView = function() {
-
-	this.rotation.x = - Math.PI / 2;
-	this.rotation.y = 0;
-	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
-
-};
-
-THREE.CombinedCamera.prototype.toBottomView = function() {
-
-	this.rotation.x = Math.PI / 2;
-	this.rotation.y = 0;
-	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
-
-};
-

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -265,7 +265,7 @@ THREE.extend( THREE.Curve.prototype, {
 
 	}
 
-};
+} );
 
 /**************************************************************
  *	Line
@@ -307,7 +307,7 @@ THREE.extend( THREE.LineCurve.prototype, {
 
 	}
 
-};
+} );
 
 /**************************************************************
  *	Quadratic Bezier curve

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -41,225 +41,229 @@ THREE.Curve = function () {
 
 // Virtual base class method to overwrite and implement in subclasses
 //	- t [0 .. 1]
+THREE.extend( THREE.Curve.prototype, {
 
-THREE.Curve.prototype.getPoint = function ( t ) {
+	getPoint: function ( t ) {
 
-	console.log( "Warning, getPoint() not implemented!" );
-	return null;
+		console.log( "Warning, getPoint() not implemented!" );
+		return null;
 
-};
+	},
 
-// Get point at relative position in curve according to arc length
-// - u [0 .. 1]
+	// Get point at relative position in curve according to arc length
+	// - u [0 .. 1]
 
-THREE.Curve.prototype.getPointAt = function ( u ) {
+	getPointAt: function ( u ) {
 
-	var t = this.getUtoTmapping( u );
-	return this.getPoint( t );
+		var t = this.getUtoTmapping( u );
+		return this.getPoint( t );
 
-};
+	},
 
-// Get sequence of points using getPoint( t )
+	// Get sequence of points using getPoint( t )
 
-THREE.Curve.prototype.getPoints = function ( divisions ) {
+	getPoints: function ( divisions ) {
 
-	if ( !divisions ) divisions = 5;
+		if ( !divisions ) divisions = 5;
 
-	var d, pts = [];
+		var d, pts = [];
 
-	for ( d = 0; d <= divisions; d ++ ) {
+		for ( d = 0; d <= divisions; d ++ ) {
 
-		pts.push( this.getPoint( d / divisions ) );
-
-	}
-
-	return pts;
-
-};
-
-// Get sequence of points using getPointAt( u )
-
-THREE.Curve.prototype.getSpacedPoints = function ( divisions ) {
-
-	if ( !divisions ) divisions = 5;
-
-	var d, pts = [];
-
-	for ( d = 0; d <= divisions; d ++ ) {
-
-		pts.push( this.getPointAt( d / divisions ) );
-
-	}
-
-	return pts;
-
-};
-
-// Get total curve arc length
-
-THREE.Curve.prototype.getLength = function () {
-
-	var lengths = this.getLengths();
-	return lengths[ lengths.length - 1 ];
-
-};
-
-// Get list of cumulative segment lengths
-
-THREE.Curve.prototype.getLengths = function ( divisions ) {
-
-	if ( !divisions ) divisions = (this.__arcLengthDivisions) ? (this.__arcLengthDivisions): 200;
-
-	if ( this.cacheArcLengths
-		&& ( this.cacheArcLengths.length == divisions + 1 )
-		&& !this.needsUpdate) {
-
-		//console.log( "cached", this.cacheArcLengths );
-		return this.cacheArcLengths;
-
-	}
-
-	this.needsUpdate = false;
-
-	var cache = [];
-	var current, last = this.getPoint( 0 );
-	var p, sum = 0;
-
-	cache.push( 0 );
-
-	for ( p = 1; p <= divisions; p ++ ) {
-
-		current = this.getPoint ( p / divisions );
-		sum += current.distanceTo( last );
-		cache.push( sum );
-		last = current;
-
-	}
-
-	this.cacheArcLengths = cache;
-
-	return cache; // { sums: cache, sum:sum }; Sum is in the last element.
-
-};
-
-
-THREE.Curve.prototype.updateArcLengths = function() {
-	this.needsUpdate = true;
-	this.getLengths();
-};
-
-// Given u ( 0 .. 1 ), get a t to find p. This gives you points which are equi distance
-
-THREE.Curve.prototype.getUtoTmapping = function ( u, distance ) {
-
-	var arcLengths = this.getLengths();
-
-	var i = 0, il = arcLengths.length;
-
-	var targetArcLength; // The targeted u distance value to get
-
-	if ( distance ) {
-
-		targetArcLength = distance;
-
-	} else {
-
-		targetArcLength = u * arcLengths[ il - 1 ];
-
-	}
-
-	//var time = Date.now();
-
-	// binary search for the index with largest value smaller than target u distance
-
-	var low = 0, high = il - 1, comparison;
-
-	while ( low <= high ) {
-
-		i = Math.floor( low + ( high - low ) / 2 ); // less likely to overflow, though probably not issue here, JS doesn't really have integers, all numbers are floats
-
-		comparison = arcLengths[ i ] - targetArcLength;
-
-		if ( comparison < 0 ) {
-
-			low = i + 1;
-			continue;
-
-		} else if ( comparison > 0 ) {
-
-			high = i - 1;
-			continue;
-
-		} else {
-
-			high = i;
-			break;
-
-			// DONE
+			pts.push( this.getPoint( d / divisions ) );
 
 		}
 
-	}
+		return pts;
 
-	i = high;
+	},
 
-	//console.log('b' , i, low, high, Date.now()- time);
+	// Get sequence of points using getPointAt( u )
 
-	if ( arcLengths[ i ] == targetArcLength ) {
+	getSpacedPoints: function ( divisions ) {
 
-		var t = i / ( il - 1 );
+		if ( !divisions ) divisions = 5;
+
+		var d, pts = [];
+
+		for ( d = 0; d <= divisions; d ++ ) {
+
+			pts.push( this.getPointAt( d / divisions ) );
+
+		}
+
+		return pts;
+
+	},
+
+	// Get total curve arc length
+
+	getLength: function () {
+
+		var lengths = this.getLengths();
+		return lengths[ lengths.length - 1 ];
+
+	},
+
+	// Get list of cumulative segment lengths
+
+	getLengths: function ( divisions ) {
+
+		if ( !divisions ) divisions = (this.__arcLengthDivisions) ? (this.__arcLengthDivisions): 200;
+
+		if ( this.cacheArcLengths
+			&& ( this.cacheArcLengths.length == divisions + 1 )
+			&& !this.needsUpdate) {
+
+			//console.log( "cached", this.cacheArcLengths );
+			return this.cacheArcLengths;
+
+		}
+
+		this.needsUpdate = false;
+
+		var cache = [];
+		var current, last = this.getPoint( 0 );
+		var p, sum = 0;
+
+		cache.push( 0 );
+
+		for ( p = 1; p <= divisions; p ++ ) {
+
+			current = this.getPoint ( p / divisions );
+			sum += current.distanceTo( last );
+			cache.push( sum );
+			last = current;
+
+		}
+
+		this.cacheArcLengths = cache;
+
+		return cache; // { sums: cache, sum:sum }; Sum is in the last element.
+
+	},
+
+
+	updateArcLengths: function() {
+
+		this.needsUpdate = true;
+		this.getLengths();
+
+	},
+
+	// Given u ( 0 .. 1 ), get a t to find p. This gives you points which are equi distance
+
+	getUtoTmapping: function ( u, distance ) {
+
+		var arcLengths = this.getLengths();
+
+		var i = 0, il = arcLengths.length;
+
+		var targetArcLength; // The targeted u distance value to get
+
+		if ( distance ) {
+
+			targetArcLength = distance;
+
+		} else {
+
+			targetArcLength = u * arcLengths[ il - 1 ];
+
+		}
+
+		//var time = Date.now();
+
+		// binary search for the index with largest value smaller than target u distance
+
+		var low = 0, high = il - 1, comparison;
+
+		while ( low <= high ) {
+
+			i = Math.floor( low + ( high - low ) / 2 ); // less likely to overflow, though probably not issue here, JS doesn't really have integers, all numbers are floats
+
+			comparison = arcLengths[ i ] - targetArcLength;
+
+			if ( comparison < 0 ) {
+
+				low = i + 1;
+				continue;
+
+			} else if ( comparison > 0 ) {
+
+				high = i - 1;
+				continue;
+
+			} else {
+
+				high = i;
+				break;
+
+				// DONE
+
+			}
+
+		}
+
+		i = high;
+
+		//console.log('b' , i, low, high, Date.now()- time);
+
+		if ( arcLengths[ i ] == targetArcLength ) {
+
+			var t = i / ( il - 1 );
+			return t;
+
+		}
+
+		// we could get finer grain at lengths, or use simple interpolatation between two points
+
+		var lengthBefore = arcLengths[ i ];
+	    var lengthAfter = arcLengths[ i + 1 ];
+
+	    var segmentLength = lengthAfter - lengthBefore;
+
+	    // determine where we are between the 'before' and 'after' points
+
+	    var segmentFraction = ( targetArcLength - lengthBefore ) / segmentLength;
+
+	    // add that fractional amount to t
+
+	    var t = ( i + segmentFraction ) / ( il -1 );
+
 		return t;
 
+	},
+
+	// Returns a unit vector tangent at t
+	// In case any sub curve does not implement its tangent derivation,
+	// 2 points a small delta apart will be used to find its gradient
+	// which seems to give a reasonable approximation
+
+	getTangent: function( t ) {
+
+		var delta = 0.0001;
+		var t1 = t - delta;
+		var t2 = t + delta;
+
+		// Capping in case of danger
+
+		if ( t1 < 0 ) t1 = 0;
+		if ( t2 > 1 ) t2 = 1;
+
+		var pt1 = this.getPoint( t1 );
+		var pt2 = this.getPoint( t2 );
+
+		var vec = pt2.clone().sub(pt1);
+		return vec.normalize();
+
+	},
+
+	getTangentAt: function ( u ) {
+
+		var t = this.getUtoTmapping( u );
+		return this.getTangent( t );
+
 	}
-
-	// we could get finer grain at lengths, or use simple interpolatation between two points
-
-	var lengthBefore = arcLengths[ i ];
-    var lengthAfter = arcLengths[ i + 1 ];
-
-    var segmentLength = lengthAfter - lengthBefore;
-
-    // determine where we are between the 'before' and 'after' points
-
-    var segmentFraction = ( targetArcLength - lengthBefore ) / segmentLength;
-
-    // add that fractional amount to t
-
-    var t = ( i + segmentFraction ) / ( il -1 );
-
-	return t;
-
-};
-
-// Returns a unit vector tangent at t
-// In case any sub curve does not implement its tangent derivation,
-// 2 points a small delta apart will be used to find its gradient
-// which seems to give a reasonable approximation
-
-THREE.Curve.prototype.getTangent = function( t ) {
-
-	var delta = 0.0001;
-	var t1 = t - delta;
-	var t2 = t + delta;
-
-	// Capping in case of danger
-
-	if ( t1 < 0 ) t1 = 0;
-	if ( t2 > 1 ) t2 = 1;
-
-	var pt1 = this.getPoint( t1 );
-	var pt2 = this.getPoint( t2 );
-
-	var vec = pt2.clone().sub(pt1);
-	return vec.normalize();
-
-};
-
-
-THREE.Curve.prototype.getTangentAt = function ( u ) {
-
-	var t = this.getUtoTmapping( u );
-	return this.getTangent( t );
 
 };
 
@@ -276,28 +280,32 @@ THREE.LineCurve = function ( v1, v2 ) {
 
 THREE.LineCurve.prototype = Object.create( THREE.Curve.prototype );
 
-THREE.LineCurve.prototype.getPoint = function ( t ) {
+THREE.extend( THREE.LineCurve.prototype, {
 
-	var point = this.v2.clone().sub(this.v1);
-	point.multiplyScalar( t ).add( this.v1 );
+	getPoint: function ( t ) {
 
-	return point;
+		var point = this.v2.clone().sub(this.v1);
+		point.multiplyScalar( t ).add( this.v1 );
 
-};
+		return point;
 
-// Line curve is linear, so we can overwrite default getPointAt
+	},
 
-THREE.LineCurve.prototype.getPointAt = function ( u ) {
+	// Line curve is linear, so we can overwrite default getPointAt
 
-	return this.getPoint( u );
+	getPointAt: function ( u ) {
 
-};
+		return this.getPoint( u );
 
-THREE.LineCurve.prototype.getTangent = function( t ) {
+	},
 
-	var tangent = this.v2.clone().sub(this.v1);
+	getTangent: function( t ) {
 
-	return tangent.normalize();
+		var tangent = this.v2.clone().sub(this.v1);
+
+		return tangent.normalize();
+
+	}
 
 };
 

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -324,34 +324,36 @@ THREE.QuadraticBezierCurve = function ( v0, v1, v2 ) {
 
 THREE.QuadraticBezierCurve.prototype = Object.create( THREE.Curve.prototype );
 
+THREE.extend( THREE.QuadraticBezierCurve.prototype, {
 
-THREE.QuadraticBezierCurve.prototype.getPoint = function ( t ) {
+	getPoint: function ( t ) {
 
-	var tx, ty;
+		var tx, ty;
 
-	tx = THREE.Shape.Utils.b2( t, this.v0.x, this.v1.x, this.v2.x );
-	ty = THREE.Shape.Utils.b2( t, this.v0.y, this.v1.y, this.v2.y );
+		tx = THREE.Shape.Utils.b2( t, this.v0.x, this.v1.x, this.v2.x );
+		ty = THREE.Shape.Utils.b2( t, this.v0.y, this.v1.y, this.v2.y );
 
-	return new THREE.Vector2( tx, ty );
+		return new THREE.Vector2( tx, ty );
 
-};
+	},
 
+	getTangent: function( t ) {
 
-THREE.QuadraticBezierCurve.prototype.getTangent = function( t ) {
+		var tx, ty;
 
-	var tx, ty;
+		tx = THREE.Curve.Utils.tangentQuadraticBezier( t, this.v0.x, this.v1.x, this.v2.x );
+		ty = THREE.Curve.Utils.tangentQuadraticBezier( t, this.v0.y, this.v1.y, this.v2.y );
 
-	tx = THREE.Curve.Utils.tangentQuadraticBezier( t, this.v0.x, this.v1.x, this.v2.x );
-	ty = THREE.Curve.Utils.tangentQuadraticBezier( t, this.v0.y, this.v1.y, this.v2.y );
+		// returns unit vector
 
-	// returns unit vector
+		var tangent = new THREE.Vector2( tx, ty );
+		tangent.normalize();
 
-	var tangent = new THREE.Vector2( tx, ty );
-	tangent.normalize();
+		return tangent;
 
-	return tangent;
+	}
 
-};
+} );
 
 
 /**************************************************************
@@ -369,30 +371,35 @@ THREE.CubicBezierCurve = function ( v0, v1, v2, v3 ) {
 
 THREE.CubicBezierCurve.prototype = Object.create( THREE.Curve.prototype );
 
-THREE.CubicBezierCurve.prototype.getPoint = function ( t ) {
 
-	var tx, ty;
+THREE.extend( THREE.CubicBezierCurve.prototype, {
 
-	tx = THREE.Shape.Utils.b3( t, this.v0.x, this.v1.x, this.v2.x, this.v3.x );
-	ty = THREE.Shape.Utils.b3( t, this.v0.y, this.v1.y, this.v2.y, this.v3.y );
+	getPoint: function ( t ) {
 
-	return new THREE.Vector2( tx, ty );
+		var tx, ty;
 
-};
+		tx = THREE.Shape.Utils.b3( t, this.v0.x, this.v1.x, this.v2.x, this.v3.x );
+		ty = THREE.Shape.Utils.b3( t, this.v0.y, this.v1.y, this.v2.y, this.v3.y );
 
-THREE.CubicBezierCurve.prototype.getTangent = function( t ) {
+		return new THREE.Vector2( tx, ty );
 
-	var tx, ty;
+	},
 
-	tx = THREE.Curve.Utils.tangentCubicBezier( t, this.v0.x, this.v1.x, this.v2.x, this.v3.x );
-	ty = THREE.Curve.Utils.tangentCubicBezier( t, this.v0.y, this.v1.y, this.v2.y, this.v3.y );
+	getTangent: function( t ) {
 
-	var tangent = new THREE.Vector2( tx, ty );
-	tangent.normalize();
+		var tx, ty;
 
-	return tangent;
+		tx = THREE.Curve.Utils.tangentCubicBezier( t, this.v0.x, this.v1.x, this.v2.x, this.v3.x );
+		ty = THREE.Curve.Utils.tangentCubicBezier( t, this.v0.y, this.v1.y, this.v2.y, this.v3.y );
 
-};
+		var tangent = new THREE.Vector2( tx, ty );
+		tangent.normalize();
+
+		return tangent;
+
+	}
+
+} );
 
 
 /**************************************************************

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -271,4 +271,4 @@ THREE.extend( THREE.CurvePath.prototype, {
 
 	}
 
-};
+} );

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -18,308 +18,257 @@ THREE.CurvePath = function () {
 
 THREE.CurvePath.prototype = Object.create( THREE.Curve.prototype );
 
-THREE.CurvePath.prototype.add = function ( curve ) {
+THREE.extend( THREE.CurvePath.prototype, {
 
-	this.curves.push( curve );
+	add: function ( curve ) {
 
-};
+		this.curves.push( curve );
 
-THREE.CurvePath.prototype.checkConnection = function() {
-	// TODO
-	// If the ending of curve is not connected to the starting
-	// or the next curve, then, this is not a real path
-};
+	},
 
-THREE.CurvePath.prototype.closePath = function() {
-	// TODO Test
-	// and verify for vector3 (needs to implement equals)
-	// Add a line curve if start and end of lines are not connected
-	var startPoint = this.curves[0].getPoint(0);
-	var endPoint = this.curves[this.curves.length-1].getPoint(1);
-	
-	if (!startPoint.equals(endPoint)) {
-		this.curves.push( new THREE.LineCurve(endPoint, startPoint) );
-	}
-	
-};
+	checkConnection: function() {
+		// TODO
+		// If the ending of curve is not connected to the starting
+		// or the next curve, then, this is not a real path
+	},
 
-// To get accurate point with reference to
-// entire path distance at time t,
-// following has to be done:
-
-// 1. Length of each sub path have to be known
-// 2. Locate and identify type of curve
-// 3. Get t for the curve
-// 4. Return curve.getPointAt(t')
-
-THREE.CurvePath.prototype.getPoint = function( t ) {
-
-	var d = t * this.getLength();
-	var curveLengths = this.getCurveLengths();
-	var i = 0, diff, curve;
-
-	// To think about boundaries points.
-
-	while ( i < curveLengths.length ) {
-
-		if ( curveLengths[ i ] >= d ) {
-
-			diff = curveLengths[ i ] - d;
-			curve = this.curves[ i ];
-
-			var u = 1 - diff / curve.getLength();
-
-			return curve.getPointAt( u );
-
-			break;
+	closePath: function() {
+		// TODO Test
+		// and verify for vector3 (needs to implement equals)
+		// Add a line curve if start and end of lines are not connected
+		var startPoint = this.curves[0].getPoint(0);
+		var endPoint = this.curves[this.curves.length-1].getPoint(1);
+		
+		if (!startPoint.equals(endPoint)) {
+			this.curves.push( new THREE.LineCurve(endPoint, startPoint) );
 		}
+		
+	},
 
-		i ++;
+	// To get accurate point with reference to
+	// entire path distance at time t,
+	// following has to be done:
 
-	}
+	// 1. Length of each sub path have to be known
+	// 2. Locate and identify type of curve
+	// 3. Get t for the curve
+	// 4. Return curve.getPointAt(t')
 
-	return null;
+	getPoint: function( t ) {
 
-	// loop where sum != 0, sum > d , sum+1 <d
+		var d = t * this.getLength();
+		var curveLengths = this.getCurveLengths();
+		var i = 0, diff, curve;
 
-};
+		// To think about boundaries points.
 
-/*
-THREE.CurvePath.prototype.getTangent = function( t ) {
-};*/
+		while ( i < curveLengths.length ) {
 
+			if ( curveLengths[ i ] >= d ) {
 
-// We cannot use the default THREE.Curve getPoint() with getLength() because in
-// THREE.Curve, getLength() depends on getPoint() but in THREE.CurvePath
-// getPoint() depends on getLength
+				diff = curveLengths[ i ] - d;
+				curve = this.curves[ i ];
 
-THREE.CurvePath.prototype.getLength = function() {
+				var u = 1 - diff / curve.getLength();
 
-	var lens = this.getCurveLengths();
-	return lens[ lens.length - 1 ];
+				return curve.getPointAt( u );
 
-};
+				break;
+			}
 
-// Compute lengths and cache them
-// We cannot overwrite getLengths() because UtoT mapping uses it.
-
-THREE.CurvePath.prototype.getCurveLengths = function() {
-
-	// We use cache values if curves and cache array are same length
-
-	if ( this.cacheLengths && this.cacheLengths.length == this.curves.length ) {
-
-		return this.cacheLengths;
-
-	};
-
-	// Get length of subsurve
-	// Push sums into cached array
-
-	var lengths = [], sums = 0;
-	var i, il = this.curves.length;
-
-	for ( i = 0; i < il; i ++ ) {
-
-		sums += this.curves[ i ].getLength();
-		lengths.push( sums );
-
-	}
-
-	this.cacheLengths = lengths;
-
-	return lengths;
-
-};
-
-
-
-// Returns min and max coordinates, as well as centroid
-
-THREE.CurvePath.prototype.getBoundingBox = function () {
-
-	var points = this.getPoints();
-
-	var maxX, maxY, maxZ;
-	var minX, minY, minZ;
-
-	maxX = maxY = Number.NEGATIVE_INFINITY;
-	minX = minY = Number.POSITIVE_INFINITY;
-
-	var p, i, il, sum;
-
-	var v3 = points[0] instanceof THREE.Vector3;
-
-	sum = v3 ? new THREE.Vector3() : new THREE.Vector2();
-
-	for ( i = 0, il = points.length; i < il; i ++ ) {
-
-		p = points[ i ];
-
-		if ( p.x > maxX ) maxX = p.x;
-		else if ( p.x < minX ) minX = p.x;
-
-		if ( p.y > maxY ) maxY = p.y;
-		else if ( p.y < minY ) minY = p.y;
-
-		if ( v3 ) {
-
-			if ( p.z > maxZ ) maxZ = p.z;
-			else if ( p.z < minZ ) minZ = p.z;
+			i ++;
 
 		}
 
-		sum.add( p );
+		return null;
+
+		// loop where sum != 0, sum > d , sum+1 <d
+
+	},
+
+	/*
+	THREE.CurvePath.prototype.getTangent = function( t ) {
+	};*/
+
+
+	// We cannot use the default THREE.Curve getPoint() with getLength() because in
+	// THREE.Curve, getLength() depends on getPoint() but in THREE.CurvePath
+	// getPoint() depends on getLength
+
+	getLength: function() {
+
+		var lens = this.getCurveLengths();
+		return lens[ lens.length - 1 ];
+
+	},
+
+	// Compute lengths and cache them
+	// We cannot overwrite getLengths() because UtoT mapping uses it.
+
+	getCurveLengths: function() {
+
+		// We use cache values if curves and cache array are same length
+
+		if ( this.cacheLengths && this.cacheLengths.length == this.curves.length ) {
+
+			return this.cacheLengths;
+
+		};
+
+		// Get length of subsurve
+		// Push sums into cached array
+
+		var lengths = [], sums = 0;
+		var i, il = this.curves.length;
+
+		for ( i = 0; i < il; i ++ ) {
+
+			sums += this.curves[ i ].getLength();
+			lengths.push( sums );
+
+		}
+
+		this.cacheLengths = lengths;
+
+		return lengths;
+
+	},
+
+	// Returns min and max coordinates, as well as centroid
+
+	getBoundingBox: function () {
+
+		return new THREE.Box3().setFromPoints( this.getPoints() );
+
+	},
+
+	/**************************************************************
+	 *	Create Geometries Helpers
+	 **************************************************************/
+
+	/// Generate geometry from path points (for Line or ParticleSystem objects)
+
+	createPointsGeometry: function( divisions ) {
+
+		var pts = this.getPoints( divisions, true );
+		return this.createGeometry( pts );
+
+	},
+
+	// Generate geometry from equidistance sampling along the path
+
+	createSpacedPointsGeometry: function( divisions ) {
+
+		var pts = this.getSpacedPoints( divisions, true );
+		return this.createGeometry( pts );
+
+	},
+
+	createGeometry: function( points ) {
+
+		var geometry = new THREE.Geometry();
+
+		for ( var i = 0; i < points.length; i ++ ) {
+
+			geometry.vertices.push( new THREE.Vector3( points[ i ].x, points[ i ].y, points[ i ].z || 0) );
+
+		}
+
+		return geometry;
+
+	},
+
+
+	/**************************************************************
+	 *	Bend / Wrap Helper Methods
+	 **************************************************************/
+
+	// Wrap path / Bend modifiers?
+
+	addWrapPath: function ( bendpath ) {
+
+		this.bends.push( bendpath );
+
+	},
+
+	getTransformedPoints: function( segments, bends ) {
+
+		var oldPts = this.getPoints( segments ); // getPoints getSpacedPoints
+		var i, il;
+
+		if ( !bends ) {
+
+			bends = this.bends;
+
+		}
+
+		for ( i = 0, il = bends.length; i < il; i ++ ) {
+
+			oldPts = this.getWrapPoints( oldPts, bends[ i ] );
+
+		}
+
+		return oldPts;
+
+	},
+
+	getTransformedSpacedPoints: function( segments, bends ) {
+
+		var oldPts = this.getSpacedPoints( segments );
+
+		var i, il;
+
+		if ( !bends ) {
+
+			bends = this.bends;
+
+		}
+
+		for ( i = 0, il = bends.length; i < il; i ++ ) {
+
+			oldPts = this.getWrapPoints( oldPts, bends[ i ] );
+
+		}
+
+		return oldPts;
+
+	},
+
+	// This returns getPoints() bend/wrapped around the contour of a path.
+	// Read http://www.planetclegg.com/projects/WarpingTextToSplines.html
+
+	getWrapPoints: function ( oldPts, path ) {
+
+		var bounds = this.getBoundingBox();
+
+		var i, il, p, oldX, oldY, xNorm;
+
+		for ( i = 0, il = oldPts.length; i < il; i ++ ) {
+
+			p = oldPts[ i ];
+
+			oldX = p.x;
+			oldY = p.y;
+
+			xNorm = oldX / bounds.maxX;
+
+			// If using actual distance, for length > path, requires line extrusions
+			//xNorm = path.getUtoTmapping(xNorm, oldX); // 3 styles. 1) wrap stretched. 2) wrap stretch by arc length 3) warp by actual distance
+
+			xNorm = path.getUtoTmapping( xNorm, oldX );
+
+			// check for out of bounds?
+
+			var pathPt = path.getPoint( xNorm );
+			var normal = path.getNormalVector( xNorm ).multiplyScalar( oldY );
+
+			p.x = pathPt.x + normal.x;
+			p.y = pathPt.y + normal.y;
+
+		}
+
+		return oldPts;
 
 	}
 
-	var ret = {
-
-		minX: minX,
-		minY: minY,
-		maxX: maxX,
-		maxY: maxY,
-		centroid: sum.divideScalar( il )
-
-	};
-
-	if ( v3 ) {
-
-		ret.maxZ = maxZ;
-		ret.minZ = minZ;
-
-	}
-
-	return ret;
-
 };
-
-/**************************************************************
- *	Create Geometries Helpers
- **************************************************************/
-
-/// Generate geometry from path points (for Line or ParticleSystem objects)
-
-THREE.CurvePath.prototype.createPointsGeometry = function( divisions ) {
-
-	var pts = this.getPoints( divisions, true );
-	return this.createGeometry( pts );
-
-};
-
-// Generate geometry from equidistance sampling along the path
-
-THREE.CurvePath.prototype.createSpacedPointsGeometry = function( divisions ) {
-
-	var pts = this.getSpacedPoints( divisions, true );
-	return this.createGeometry( pts );
-
-};
-
-THREE.CurvePath.prototype.createGeometry = function( points ) {
-
-	var geometry = new THREE.Geometry();
-
-	for ( var i = 0; i < points.length; i ++ ) {
-
-		geometry.vertices.push( new THREE.Vector3( points[ i ].x, points[ i ].y, points[ i ].z || 0) );
-
-	}
-
-	return geometry;
-
-};
-
-
-/**************************************************************
- *	Bend / Wrap Helper Methods
- **************************************************************/
-
-// Wrap path / Bend modifiers?
-
-THREE.CurvePath.prototype.addWrapPath = function ( bendpath ) {
-
-	this.bends.push( bendpath );
-
-};
-
-THREE.CurvePath.prototype.getTransformedPoints = function( segments, bends ) {
-
-	var oldPts = this.getPoints( segments ); // getPoints getSpacedPoints
-	var i, il;
-
-	if ( !bends ) {
-
-		bends = this.bends;
-
-	}
-
-	for ( i = 0, il = bends.length; i < il; i ++ ) {
-
-		oldPts = this.getWrapPoints( oldPts, bends[ i ] );
-
-	}
-
-	return oldPts;
-
-};
-
-THREE.CurvePath.prototype.getTransformedSpacedPoints = function( segments, bends ) {
-
-	var oldPts = this.getSpacedPoints( segments );
-
-	var i, il;
-
-	if ( !bends ) {
-
-		bends = this.bends;
-
-	}
-
-	for ( i = 0, il = bends.length; i < il; i ++ ) {
-
-		oldPts = this.getWrapPoints( oldPts, bends[ i ] );
-
-	}
-
-	return oldPts;
-
-};
-
-// This returns getPoints() bend/wrapped around the contour of a path.
-// Read http://www.planetclegg.com/projects/WarpingTextToSplines.html
-
-THREE.CurvePath.prototype.getWrapPoints = function ( oldPts, path ) {
-
-	var bounds = this.getBoundingBox();
-
-	var i, il, p, oldX, oldY, xNorm;
-
-	for ( i = 0, il = oldPts.length; i < il; i ++ ) {
-
-		p = oldPts[ i ];
-
-		oldX = p.x;
-		oldY = p.y;
-
-		xNorm = oldX / bounds.maxX;
-
-		// If using actual distance, for length > path, requires line extrusions
-		//xNorm = path.getUtoTmapping(xNorm, oldX); // 3 styles. 1) wrap stretched. 2) wrap stretch by arc length 3) warp by actual distance
-
-		xNorm = path.getUtoTmapping( xNorm, oldX );
-
-		// check for out of bounds?
-
-		var pathPt = path.getPoint( xNorm );
-		var normal = path.getNormalVector( xNorm ).multiplyScalar( oldY );
-
-		p.x = pathPt.x + normal.x;
-		p.y = pathPt.y + normal.y;
-
-	}
-
-	return oldPts;
-
-};
-

--- a/src/extras/core/Gyroscope.js
+++ b/src/extras/core/Gyroscope.js
@@ -10,51 +10,54 @@ THREE.Gyroscope = function () {
 
 THREE.Gyroscope.prototype = Object.create( THREE.Object3D.prototype );
 
-THREE.Gyroscope.prototype.updateMatrixWorld = function ( force ) {
+THREE.extend( THREE.Gyroscope.prototype, {
 
-	this.matrixAutoUpdate && this.updateMatrix();
+	updateMatrixWorld: function ( force ) {
 
-	// update matrixWorld
+		this.matrixAutoUpdate && this.updateMatrix();
 
-	if ( this.matrixWorldNeedsUpdate || force ) {
+		// update matrixWorld
 
-		if ( this.parent ) {
+		if ( this.matrixWorldNeedsUpdate || force ) {
 
-			this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
+			if ( this.parent ) {
 
-			this.matrixWorld.decompose( this.translationWorld, this.rotationWorld, this.scaleWorld );
-			this.matrix.decompose( this.translationObject, this.rotationObject, this.scaleObject );
+				this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
 
-			this.matrixWorld.compose( this.translationWorld, this.rotationObject, this.scaleWorld );
+				this.matrixWorld.decompose( this.translationWorld, this.rotationWorld, this.scaleWorld );
+				this.matrix.decompose( this.translationObject, this.rotationObject, this.scaleObject );
+
+				this.matrixWorld.compose( this.translationWorld, this.rotationObject, this.scaleWorld );
 
 
-		} else {
+			} else {
 
-			this.matrixWorld.copy( this.matrix );
+				this.matrixWorld.copy( this.matrix );
+
+			}
+
+
+			this.matrixWorldNeedsUpdate = false;
+
+			force = true;
 
 		}
 
+		// update children
 
-		this.matrixWorldNeedsUpdate = false;
+		for ( var i = 0, l = this.children.length; i < l; i ++ ) {
 
-		force = true;
+			this.children[ i ].updateMatrixWorld( force );
 
-	}
+		}
 
-	// update children
+	},
 
-	for ( var i = 0, l = this.children.length; i < l; i ++ ) {
+	translationWorld: new THREE.Vector3(),
+	translationObject: new THREE.Vector3(),
+	rotationWorld: new THREE.Quaternion(),
+	rotationObject: new THREE.Quaternion(),
+	scaleWorld: new THREE.Vector3(),
+	scaleObject: new THREE.Vector3()
 
-		this.children[ i ].updateMatrixWorld( force );
-
-	}
-
-};
-
-THREE.Gyroscope.prototype.translationWorld = new THREE.Vector3();
-THREE.Gyroscope.prototype.translationObject = new THREE.Vector3();
-THREE.Gyroscope.prototype.rotationWorld = new THREE.Quaternion();
-THREE.Gyroscope.prototype.rotationObject = new THREE.Quaternion();
-THREE.Gyroscope.prototype.scaleWorld = new THREE.Vector3();
-THREE.Gyroscope.prototype.scaleObject = new THREE.Vector3();
-
+});

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -31,524 +31,523 @@ THREE.PathActions = {
 	ELLIPSE: 'ellipse'
 };
 
-// TODO Clean up PATH API
+THREE.extend( THREE.Path.prototype, {
 
-// Create path using straight lines to connect all points
-// - vectors: array of Vector2
+	// TODO Clean up PATH API
 
-THREE.Path.prototype.fromPoints = function ( vectors ) {
+	// Create path using straight lines to connect all points
+	// - vectors: array of Vector2
 
-	this.moveTo( vectors[ 0 ].x, vectors[ 0 ].y );
+	fromPoints: function ( vectors ) {
 
-	for ( var v = 1, vlen = vectors.length; v < vlen; v ++ ) {
+		this.moveTo( vectors[ 0 ].x, vectors[ 0 ].y );
 
-		this.lineTo( vectors[ v ].x, vectors[ v ].y );
+		for ( var v = 1, vlen = vectors.length; v < vlen; v ++ ) {
 
-	};
+			this.lineTo( vectors[ v ].x, vectors[ v ].y );
 
-};
+		};
 
-// startPath() endPath()?
+	},
 
-THREE.Path.prototype.moveTo = function ( x, y ) {
+	// startPath() endPath()?
 
-	var args = Array.prototype.slice.call( arguments );
-	this.actions.push( { action: THREE.PathActions.MOVE_TO, args: args } );
+	moveTo: function ( x, y ) {
 
-};
+		var args = Array.prototype.slice.call( arguments );
+		this.actions.push( { action: THREE.PathActions.MOVE_TO, args: args } );
 
-THREE.Path.prototype.lineTo = function ( x, y ) {
+	},
 
-	var args = Array.prototype.slice.call( arguments );
+	lineTo: function ( x, y ) {
 
-	var lastargs = this.actions[ this.actions.length - 1 ].args;
+		var args = Array.prototype.slice.call( arguments );
 
-	var x0 = lastargs[ lastargs.length - 2 ];
-	var y0 = lastargs[ lastargs.length - 1 ];
+		var lastargs = this.actions[ this.actions.length - 1 ].args;
 
-	var curve = new THREE.LineCurve( new THREE.Vector2( x0, y0 ), new THREE.Vector2( x, y ) );
-	this.curves.push( curve );
+		var x0 = lastargs[ lastargs.length - 2 ];
+		var y0 = lastargs[ lastargs.length - 1 ];
 
-	this.actions.push( { action: THREE.PathActions.LINE_TO, args: args } );
+		var curve = new THREE.LineCurve( new THREE.Vector2( x0, y0 ), new THREE.Vector2( x, y ) );
+		this.curves.push( curve );
 
-};
+		this.actions.push( { action: THREE.PathActions.LINE_TO, args: args } );
 
-THREE.Path.prototype.quadraticCurveTo = function( aCPx, aCPy, aX, aY ) {
+	},
 
-	var args = Array.prototype.slice.call( arguments );
+	quadraticCurveTo: function( aCPx, aCPy, aX, aY ) {
 
-	var lastargs = this.actions[ this.actions.length - 1 ].args;
+		var args = Array.prototype.slice.call( arguments );
 
-	var x0 = lastargs[ lastargs.length - 2 ];
-	var y0 = lastargs[ lastargs.length - 1 ];
+		var lastargs = this.actions[ this.actions.length - 1 ].args;
 
-	var curve = new THREE.QuadraticBezierCurve( new THREE.Vector2( x0, y0 ),
-												new THREE.Vector2( aCPx, aCPy ),
+		var x0 = lastargs[ lastargs.length - 2 ];
+		var y0 = lastargs[ lastargs.length - 1 ];
+
+		var curve = new THREE.QuadraticBezierCurve( new THREE.Vector2( x0, y0 ),
+													new THREE.Vector2( aCPx, aCPy ),
+													new THREE.Vector2( aX, aY ) );
+		this.curves.push( curve );
+
+		this.actions.push( { action: THREE.PathActions.QUADRATIC_CURVE_TO, args: args } );
+
+	},
+
+	bezierCurveTo: function( aCP1x, aCP1y, aCP2x, aCP2y, aX, aY ) {
+
+		var args = Array.prototype.slice.call( arguments );
+
+		var lastargs = this.actions[ this.actions.length - 1 ].args;
+
+		var x0 = lastargs[ lastargs.length - 2 ];
+		var y0 = lastargs[ lastargs.length - 1 ];
+
+		var curve = new THREE.CubicBezierCurve( new THREE.Vector2( x0, y0 ),
+												new THREE.Vector2( aCP1x, aCP1y ),
+												new THREE.Vector2( aCP2x, aCP2y ),
 												new THREE.Vector2( aX, aY ) );
-	this.curves.push( curve );
+		this.curves.push( curve );
 
-	this.actions.push( { action: THREE.PathActions.QUADRATIC_CURVE_TO, args: args } );
+		this.actions.push( { action: THREE.PathActions.BEZIER_CURVE_TO, args: args } );
 
-};
+	},
 
-THREE.Path.prototype.bezierCurveTo = function( aCP1x, aCP1y,
-                                               aCP2x, aCP2y,
-                                               aX, aY ) {
+	splineThru: function( pts /*Array of Vector*/ ) {
 
-	var args = Array.prototype.slice.call( arguments );
+		var args = Array.prototype.slice.call( arguments );
+		var lastargs = this.actions[ this.actions.length - 1 ].args;
 
-	var lastargs = this.actions[ this.actions.length - 1 ].args;
+		var x0 = lastargs[ lastargs.length - 2 ];
+		var y0 = lastargs[ lastargs.length - 1 ];
+	//---
+		var npts = [ new THREE.Vector2( x0, y0 ) ];
+		Array.prototype.push.apply( npts, pts );
 
-	var x0 = lastargs[ lastargs.length - 2 ];
-	var y0 = lastargs[ lastargs.length - 1 ];
+		var curve = new THREE.SplineCurve( npts );
+		this.curves.push( curve );
 
-	var curve = new THREE.CubicBezierCurve( new THREE.Vector2( x0, y0 ),
-											new THREE.Vector2( aCP1x, aCP1y ),
-											new THREE.Vector2( aCP2x, aCP2y ),
-											new THREE.Vector2( aX, aY ) );
-	this.curves.push( curve );
+		this.actions.push( { action: THREE.PathActions.CSPLINE_THRU, args: args } );
 
-	this.actions.push( { action: THREE.PathActions.BEZIER_CURVE_TO, args: args } );
+	},
 
-};
+	// FUTURE: Change the API or follow canvas API?
 
-THREE.Path.prototype.splineThru = function( pts /*Array of Vector*/ ) {
+	arc: function ( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
 
-	var args = Array.prototype.slice.call( arguments );
-	var lastargs = this.actions[ this.actions.length - 1 ].args;
+		var lastargs = this.actions[ this.actions.length - 1].args;
+		var x0 = lastargs[ lastargs.length - 2 ];
+		var y0 = lastargs[ lastargs.length - 1 ];
 
-	var x0 = lastargs[ lastargs.length - 2 ];
-	var y0 = lastargs[ lastargs.length - 1 ];
-//---
-	var npts = [ new THREE.Vector2( x0, y0 ) ];
-	Array.prototype.push.apply( npts, pts );
+		this.absarc(aX + x0, aY + y0, aRadius,
+			aStartAngle, aEndAngle, aClockwise );
+		
+	 },
 
-	var curve = new THREE.SplineCurve( npts );
-	this.curves.push( curve );
+	absarc: function ( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
 
-	this.actions.push( { action: THREE.PathActions.CSPLINE_THRU, args: args } );
+		this.absellipse(aX, aY, aRadius, aRadius, aStartAngle, aEndAngle, aClockwise);
 
-};
+	},
+	 
+	ellipse: function ( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise ) {
 
-// FUTURE: Change the API or follow canvas API?
+		var lastargs = this.actions[ this.actions.length - 1].args;
+		var x0 = lastargs[ lastargs.length - 2 ];
+		var y0 = lastargs[ lastargs.length - 1 ];
 
-THREE.Path.prototype.arc = function ( aX, aY, aRadius,
-									  aStartAngle, aEndAngle, aClockwise ) {
+		this.absellipse(aX + x0, aY + y0, xRadius, yRadius,
+			aStartAngle, aEndAngle, aClockwise );
 
-	var lastargs = this.actions[ this.actions.length - 1].args;
-	var x0 = lastargs[ lastargs.length - 2 ];
-	var y0 = lastargs[ lastargs.length - 1 ];
+	},
 
-	this.absarc(aX + x0, aY + y0, aRadius,
-		aStartAngle, aEndAngle, aClockwise );
-	
- };
+	absellipse: function ( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise ) {
 
- THREE.Path.prototype.absarc = function ( aX, aY, aRadius,
-									  aStartAngle, aEndAngle, aClockwise ) {
-	this.absellipse(aX, aY, aRadius, aRadius, aStartAngle, aEndAngle, aClockwise);
- };
- 
-THREE.Path.prototype.ellipse = function ( aX, aY, xRadius, yRadius,
-									  aStartAngle, aEndAngle, aClockwise ) {
+		var args = Array.prototype.slice.call( arguments );
+		var curve = new THREE.EllipseCurve( aX, aY, xRadius, yRadius,
+										aStartAngle, aEndAngle, aClockwise );
+		this.curves.push( curve );
 
-	var lastargs = this.actions[ this.actions.length - 1].args;
-	var x0 = lastargs[ lastargs.length - 2 ];
-	var y0 = lastargs[ lastargs.length - 1 ];
+		var lastPoint = curve.getPoint(aClockwise ? 1 : 0);
+		args.push(lastPoint.x);
+		args.push(lastPoint.y);
 
-	this.absellipse(aX + x0, aY + y0, xRadius, yRadius,
-		aStartAngle, aEndAngle, aClockwise );
+		this.actions.push( { action: THREE.PathActions.ELLIPSE, args: args } );
 
- };
- 
+	},
 
-THREE.Path.prototype.absellipse = function ( aX, aY, xRadius, yRadius,
-									  aStartAngle, aEndAngle, aClockwise ) {
+	getSpacedPoints: function ( divisions, closedPath ) {
 
-	var args = Array.prototype.slice.call( arguments );
-	var curve = new THREE.EllipseCurve( aX, aY, xRadius, yRadius,
-									aStartAngle, aEndAngle, aClockwise );
-	this.curves.push( curve );
+		if ( ! divisions ) divisions = 40;
 
-	var lastPoint = curve.getPoint(aClockwise ? 1 : 0);
-	args.push(lastPoint.x);
-	args.push(lastPoint.y);
+		var points = [];
 
-	this.actions.push( { action: THREE.PathActions.ELLIPSE, args: args } );
+		for ( var i = 0; i < divisions; i ++ ) {
 
- };
+			points.push( this.getPoint( i / divisions ) );
 
-THREE.Path.prototype.getSpacedPoints = function ( divisions, closedPath ) {
-
-	if ( ! divisions ) divisions = 40;
-
-	var points = [];
-
-	for ( var i = 0; i < divisions; i ++ ) {
-
-		points.push( this.getPoint( i / divisions ) );
-
-		//if( !this.getPoint( i / divisions ) ) throw "DIE";
-
-	}
-
-	// if ( closedPath ) {
-	//
-	// 	points.push( points[ 0 ] );
-	//
-	// }
-
-	return points;
-
-};
-
-/* Return an array of vectors based on contour of the path */
-
-THREE.Path.prototype.getPoints = function( divisions, closedPath ) {
-
-	if (this.useSpacedPoints) {
-		console.log('tata');
-		return this.getSpacedPoints( divisions, closedPath );
-	}
-
-	divisions = divisions || 12;
-
-	var points = [];
-
-	var i, il, item, action, args;
-	var cpx, cpy, cpx2, cpy2, cpx1, cpy1, cpx0, cpy0,
-		laste, j,
-		t, tx, ty;
-
-	for ( i = 0, il = this.actions.length; i < il; i ++ ) {
-
-		item = this.actions[ i ];
-
-		action = item.action;
-		args = item.args;
-
-		switch( action ) {
-
-		case THREE.PathActions.MOVE_TO:
-
-			points.push( new THREE.Vector2( args[ 0 ], args[ 1 ] ) );
-
-			break;
-
-		case THREE.PathActions.LINE_TO:
-
-			points.push( new THREE.Vector2( args[ 0 ], args[ 1 ] ) );
-
-			break;
-
-		case THREE.PathActions.QUADRATIC_CURVE_TO:
-
-			cpx  = args[ 2 ];
-			cpy  = args[ 3 ];
-
-			cpx1 = args[ 0 ];
-			cpy1 = args[ 1 ];
-
-			if ( points.length > 0 ) {
-
-				laste = points[ points.length - 1 ];
-
-				cpx0 = laste.x;
-				cpy0 = laste.y;
-
-			} else {
-
-				laste = this.actions[ i - 1 ].args;
-
-				cpx0 = laste[ laste.length - 2 ];
-				cpy0 = laste[ laste.length - 1 ];
-
-			}
-
-			for ( j = 1; j <= divisions; j ++ ) {
-
-				t = j / divisions;
-
-				tx = THREE.Shape.Utils.b2( t, cpx0, cpx1, cpx );
-				ty = THREE.Shape.Utils.b2( t, cpy0, cpy1, cpy );
-
-				points.push( new THREE.Vector2( tx, ty ) );
-
-		  	}
-
-			break;
-
-		case THREE.PathActions.BEZIER_CURVE_TO:
-
-			cpx  = args[ 4 ];
-			cpy  = args[ 5 ];
-
-			cpx1 = args[ 0 ];
-			cpy1 = args[ 1 ];
-
-			cpx2 = args[ 2 ];
-			cpy2 = args[ 3 ];
-
-			if ( points.length > 0 ) {
-
-				laste = points[ points.length - 1 ];
-
-				cpx0 = laste.x;
-				cpy0 = laste.y;
-
-			} else {
-
-				laste = this.actions[ i - 1 ].args;
-
-				cpx0 = laste[ laste.length - 2 ];
-				cpy0 = laste[ laste.length - 1 ];
-
-			}
-
-
-			for ( j = 1; j <= divisions; j ++ ) {
-
-				t = j / divisions;
-
-				tx = THREE.Shape.Utils.b3( t, cpx0, cpx1, cpx2, cpx );
-				ty = THREE.Shape.Utils.b3( t, cpy0, cpy1, cpy2, cpy );
-
-				points.push( new THREE.Vector2( tx, ty ) );
-
-			}
-
-			break;
-
-		case THREE.PathActions.CSPLINE_THRU:
-
-			laste = this.actions[ i - 1 ].args;
-
-			var last = new THREE.Vector2( laste[ laste.length - 2 ], laste[ laste.length - 1 ] );
-			var spts = [ last ];
-
-			var n = divisions * args[ 0 ].length;
-
-			spts = spts.concat( args[ 0 ] );
-
-			var spline = new THREE.SplineCurve( spts );
-
-			for ( j = 1; j <= n; j ++ ) {
-
-				points.push( spline.getPointAt( j / n ) ) ;
-
-			}
-
-			break;
-
-		case THREE.PathActions.ARC:
-
-			var aX = args[ 0 ], aY = args[ 1 ],
-				aRadius = args[ 2 ],
-				aStartAngle = args[ 3 ], aEndAngle = args[ 4 ],
-				aClockwise = !!args[ 5 ];
-
-			var deltaAngle = aEndAngle - aStartAngle;
-			var angle;
-			var tdivisions = divisions * 2;
-
-			for ( j = 1; j <= tdivisions; j ++ ) {
-
-				t = j / tdivisions;
-
-				if ( ! aClockwise ) {
-
-					t = 1 - t;
-
-				}
-
-				angle = aStartAngle + t * deltaAngle;
-
-				tx = aX + aRadius * Math.cos( angle );
-				ty = aY + aRadius * Math.sin( angle );
-
-				//console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
-
-				points.push( new THREE.Vector2( tx, ty ) );
-
-			}
-
-			//console.log(points);
-
-		  break;
-		  
-		case THREE.PathActions.ELLIPSE:
-
-			var aX = args[ 0 ], aY = args[ 1 ],
-				xRadius = args[ 2 ],
-				yRadius = args[ 3 ],
-				aStartAngle = args[ 4 ], aEndAngle = args[ 5 ],
-				aClockwise = !!args[ 6 ];
-
-
-			var deltaAngle = aEndAngle - aStartAngle;
-			var angle;
-			var tdivisions = divisions * 2;
-
-			for ( j = 1; j <= tdivisions; j ++ ) {
-
-				t = j / tdivisions;
-
-				if ( ! aClockwise ) {
-
-					t = 1 - t;
-
-				}
-
-				angle = aStartAngle + t * deltaAngle;
-
-				tx = aX + xRadius * Math.cos( angle );
-				ty = aY + yRadius * Math.sin( angle );
-
-				//console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
-
-				points.push( new THREE.Vector2( tx, ty ) );
-
-			}
-
-			//console.log(points);
-
-		  break;
-
-		} // end switch
-
-	}
-
-
-
-	// Normalize to remove the closing point by default.
-	var lastPoint = points[ points.length - 1];
-	var EPSILON = 0.0000000001;
-	if ( Math.abs(lastPoint.x - points[ 0 ].x) < EPSILON &&
-             Math.abs(lastPoint.y - points[ 0 ].y) < EPSILON)
-		points.splice( points.length - 1, 1);
-	if ( closedPath ) {
-
-		points.push( points[ 0 ] );
-
-	}
-
-	return points;
-
-};
-
-// Breaks path into shapes
-
-THREE.Path.prototype.toShapes = function() {
-
-	var i, il, item, action, args;
-
-	var subPaths = [], lastPath = new THREE.Path();
-
-	for ( i = 0, il = this.actions.length; i < il; i ++ ) {
-
-		item = this.actions[ i ];
-
-		args = item.args;
-		action = item.action;
-
-		if ( action == THREE.PathActions.MOVE_TO ) {
-
-			if ( lastPath.actions.length != 0 ) {
-
-				subPaths.push( lastPath );
-				lastPath = new THREE.Path();
-
-			}
+			//if( !this.getPoint( i / divisions ) ) throw "DIE";
 
 		}
 
-		lastPath[ action ].apply( lastPath, args );
+		// if ( closedPath ) {
+		//
+		// 	points.push( points[ 0 ] );
+		//
+		// }
 
-	}
+		return points;
 
-	if ( lastPath.actions.length != 0 ) {
+	},
 
-		subPaths.push( lastPath );
+	/* Return an array of vectors based on contour of the path */
 
-	}
+	getPoints: function( divisions, closedPath ) {
 
-	// console.log(subPaths);
+		if (this.useSpacedPoints) {
+			console.log('tata');
+			return this.getSpacedPoints( divisions, closedPath );
+		}
 
-	if ( subPaths.length == 0 ) return [];
+		divisions = divisions || 12;
 
-	var tmpPath, tmpShape, shapes = [];
+		var points = [];
 
-	var holesFirst = !THREE.Shape.Utils.isClockWise( subPaths[ 0 ].getPoints() );
-	// console.log("Holes first", holesFirst);
+		var i, il, item, action, args;
+		var cpx, cpy, cpx2, cpy2, cpx1, cpy1, cpx0, cpy0,
+			laste, j,
+			t, tx, ty;
 
-	if ( subPaths.length == 1) {
-		tmpPath = subPaths[0];
-		tmpShape = new THREE.Shape();
-		tmpShape.actions = tmpPath.actions;
-		tmpShape.curves = tmpPath.curves;
-		shapes.push( tmpShape );
+		for ( i = 0, il = this.actions.length; i < il; i ++ ) {
+
+			item = this.actions[ i ];
+
+			action = item.action;
+			args = item.args;
+
+			switch( action ) {
+
+			case THREE.PathActions.MOVE_TO:
+
+				points.push( new THREE.Vector2( args[ 0 ], args[ 1 ] ) );
+
+				break;
+
+			case THREE.PathActions.LINE_TO:
+
+				points.push( new THREE.Vector2( args[ 0 ], args[ 1 ] ) );
+
+				break;
+
+			case THREE.PathActions.QUADRATIC_CURVE_TO:
+
+				cpx  = args[ 2 ];
+				cpy  = args[ 3 ];
+
+				cpx1 = args[ 0 ];
+				cpy1 = args[ 1 ];
+
+				if ( points.length > 0 ) {
+
+					laste = points[ points.length - 1 ];
+
+					cpx0 = laste.x;
+					cpy0 = laste.y;
+
+				} else {
+
+					laste = this.actions[ i - 1 ].args;
+
+					cpx0 = laste[ laste.length - 2 ];
+					cpy0 = laste[ laste.length - 1 ];
+
+				}
+
+				for ( j = 1; j <= divisions; j ++ ) {
+
+					t = j / divisions;
+
+					tx = THREE.Shape.Utils.b2( t, cpx0, cpx1, cpx );
+					ty = THREE.Shape.Utils.b2( t, cpy0, cpy1, cpy );
+
+					points.push( new THREE.Vector2( tx, ty ) );
+
+			  	}
+
+				break;
+
+			case THREE.PathActions.BEZIER_CURVE_TO:
+
+				cpx  = args[ 4 ];
+				cpy  = args[ 5 ];
+
+				cpx1 = args[ 0 ];
+				cpy1 = args[ 1 ];
+
+				cpx2 = args[ 2 ];
+				cpy2 = args[ 3 ];
+
+				if ( points.length > 0 ) {
+
+					laste = points[ points.length - 1 ];
+
+					cpx0 = laste.x;
+					cpy0 = laste.y;
+
+				} else {
+
+					laste = this.actions[ i - 1 ].args;
+
+					cpx0 = laste[ laste.length - 2 ];
+					cpy0 = laste[ laste.length - 1 ];
+
+				}
+
+
+				for ( j = 1; j <= divisions; j ++ ) {
+
+					t = j / divisions;
+
+					tx = THREE.Shape.Utils.b3( t, cpx0, cpx1, cpx2, cpx );
+					ty = THREE.Shape.Utils.b3( t, cpy0, cpy1, cpy2, cpy );
+
+					points.push( new THREE.Vector2( tx, ty ) );
+
+				}
+
+				break;
+
+			case THREE.PathActions.CSPLINE_THRU:
+
+				laste = this.actions[ i - 1 ].args;
+
+				var last = new THREE.Vector2( laste[ laste.length - 2 ], laste[ laste.length - 1 ] );
+				var spts = [ last ];
+
+				var n = divisions * args[ 0 ].length;
+
+				spts = spts.concat( args[ 0 ] );
+
+				var spline = new THREE.SplineCurve( spts );
+
+				for ( j = 1; j <= n; j ++ ) {
+
+					points.push( spline.getPointAt( j / n ) ) ;
+
+				}
+
+				break;
+
+			case THREE.PathActions.ARC:
+
+				var aX = args[ 0 ], aY = args[ 1 ],
+					aRadius = args[ 2 ],
+					aStartAngle = args[ 3 ], aEndAngle = args[ 4 ],
+					aClockwise = !!args[ 5 ];
+
+				var deltaAngle = aEndAngle - aStartAngle;
+				var angle;
+				var tdivisions = divisions * 2;
+
+				for ( j = 1; j <= tdivisions; j ++ ) {
+
+					t = j / tdivisions;
+
+					if ( ! aClockwise ) {
+
+						t = 1 - t;
+
+					}
+
+					angle = aStartAngle + t * deltaAngle;
+
+					tx = aX + aRadius * Math.cos( angle );
+					ty = aY + aRadius * Math.sin( angle );
+
+					//console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
+
+					points.push( new THREE.Vector2( tx, ty ) );
+
+				}
+
+				//console.log(points);
+
+			  break;
+			  
+			case THREE.PathActions.ELLIPSE:
+
+				var aX = args[ 0 ], aY = args[ 1 ],
+					xRadius = args[ 2 ],
+					yRadius = args[ 3 ],
+					aStartAngle = args[ 4 ], aEndAngle = args[ 5 ],
+					aClockwise = !!args[ 6 ];
+
+
+				var deltaAngle = aEndAngle - aStartAngle;
+				var angle;
+				var tdivisions = divisions * 2;
+
+				for ( j = 1; j <= tdivisions; j ++ ) {
+
+					t = j / tdivisions;
+
+					if ( ! aClockwise ) {
+
+						t = 1 - t;
+
+					}
+
+					angle = aStartAngle + t * deltaAngle;
+
+					tx = aX + xRadius * Math.cos( angle );
+					ty = aY + yRadius * Math.sin( angle );
+
+					//console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
+
+					points.push( new THREE.Vector2( tx, ty ) );
+
+				}
+
+				//console.log(points);
+
+			  break;
+
+			} // end switch
+
+		}
+
+
+
+		// Normalize to remove the closing point by default.
+		var lastPoint = points[ points.length - 1];
+		var EPSILON = 0.0000000001;
+		if ( Math.abs(lastPoint.x - points[ 0 ].x) < EPSILON &&
+	             Math.abs(lastPoint.y - points[ 0 ].y) < EPSILON)
+			points.splice( points.length - 1, 1);
+		if ( closedPath ) {
+
+			points.push( points[ 0 ] );
+
+		}
+
+		return points;
+
+	},
+
+	// Breaks path into shapes
+
+	toShapes: function() {
+
+		var i, il, item, action, args;
+
+		var subPaths = [], lastPath = new THREE.Path();
+
+		for ( i = 0, il = this.actions.length; i < il; i ++ ) {
+
+			item = this.actions[ i ];
+
+			args = item.args;
+			action = item.action;
+
+			if ( action == THREE.PathActions.MOVE_TO ) {
+
+				if ( lastPath.actions.length != 0 ) {
+
+					subPaths.push( lastPath );
+					lastPath = new THREE.Path();
+
+				}
+
+			}
+
+			lastPath[ action ].apply( lastPath, args );
+
+		}
+
+		if ( lastPath.actions.length != 0 ) {
+
+			subPaths.push( lastPath );
+
+		}
+
+		// console.log(subPaths);
+
+		if ( subPaths.length == 0 ) return [];
+
+		var tmpPath, tmpShape, shapes = [];
+
+		var holesFirst = !THREE.Shape.Utils.isClockWise( subPaths[ 0 ].getPoints() );
+		// console.log("Holes first", holesFirst);
+
+		if ( subPaths.length == 1) {
+			tmpPath = subPaths[0];
+			tmpShape = new THREE.Shape();
+			tmpShape.actions = tmpPath.actions;
+			tmpShape.curves = tmpPath.curves;
+			shapes.push( tmpShape );
+			return shapes;
+		};
+
+		if ( holesFirst ) {
+
+			tmpShape = new THREE.Shape();
+
+			for ( i = 0, il = subPaths.length; i < il; i ++ ) {
+
+				tmpPath = subPaths[ i ];
+
+				if ( THREE.Shape.Utils.isClockWise( tmpPath.getPoints() ) ) {
+
+					tmpShape.actions = tmpPath.actions;
+					tmpShape.curves = tmpPath.curves;
+
+					shapes.push( tmpShape );
+					tmpShape = new THREE.Shape();
+
+					//console.log('cw', i);
+
+				} else {
+
+					tmpShape.holes.push( tmpPath );
+
+					//console.log('ccw', i);
+
+				}
+
+			}
+
+		} else {
+
+			// Shapes first
+
+			for ( i = 0, il = subPaths.length; i < il; i ++ ) {
+
+				tmpPath = subPaths[ i ];
+
+				if ( THREE.Shape.Utils.isClockWise( tmpPath.getPoints() ) ) {
+
+
+					if ( tmpShape ) shapes.push( tmpShape );
+
+					tmpShape = new THREE.Shape();
+					tmpShape.actions = tmpPath.actions;
+					tmpShape.curves = tmpPath.curves;
+
+				} else {
+
+					tmpShape.holes.push( tmpPath );
+
+				}
+
+			}
+
+			shapes.push( tmpShape );
+
+		}
+
+		//console.log("shape", shapes);
+
 		return shapes;
-	};
 
-	if ( holesFirst ) {
+	},
 
-		tmpShape = new THREE.Shape();
-
-		for ( i = 0, il = subPaths.length; i < il; i ++ ) {
-
-			tmpPath = subPaths[ i ];
-
-			if ( THREE.Shape.Utils.isClockWise( tmpPath.getPoints() ) ) {
-
-				tmpShape.actions = tmpPath.actions;
-				tmpShape.curves = tmpPath.curves;
-
-				shapes.push( tmpShape );
-				tmpShape = new THREE.Shape();
-
-				//console.log('cw', i);
-
-			} else {
-
-				tmpShape.holes.push( tmpPath );
-
-				//console.log('ccw', i);
-
-			}
-
-		}
-
-	} else {
-
-		// Shapes first
-
-		for ( i = 0, il = subPaths.length; i < il; i ++ ) {
-
-			tmpPath = subPaths[ i ];
-
-			if ( THREE.Shape.Utils.isClockWise( tmpPath.getPoints() ) ) {
-
-
-				if ( tmpShape ) shapes.push( tmpShape );
-
-				tmpShape = new THREE.Shape();
-				tmpShape.actions = tmpPath.actions;
-				tmpShape.curves = tmpPath.curves;
-
-			} else {
-
-				tmpShape.holes.push( tmpPath );
-
-			}
-
-		}
-
-		shapes.push( tmpShape );
-
-	}
-
-	//console.log("shape", shapes);
-
-	return shapes;
-
-};
+} );

--- a/src/extras/core/Shape.js
+++ b/src/extras/core/Shape.js
@@ -18,104 +18,107 @@ THREE.Shape = function ( ) {
 
 THREE.Shape.prototype = Object.create( THREE.Path.prototype );
 
-// Convenience method to return ExtrudeGeometry
+THREE.extend( THREE.Shape.prototype, {
 
-THREE.Shape.prototype.extrude = function ( options ) {
+	// Convenience method to return ExtrudeGeometry
 
-	var extruded = new THREE.ExtrudeGeometry( this, options );
-	return extruded;
+	extrude: function ( options ) {
 
-};
+		var extruded = new THREE.ExtrudeGeometry( this, options );
+		return extruded;
 
-// Convenience method to return ShapeGeometry
+	},
 
-THREE.Shape.prototype.makeGeometry = function ( options ) {
+	// Convenience method to return ShapeGeometry
 
-	var geometry = new THREE.ShapeGeometry( this, options );
-	return geometry;
+	makeGeometry: function ( options ) {
 
-};
+		var geometry = new THREE.ShapeGeometry( this, options );
+		return geometry;
 
-// Get points of holes
+	},
 
-THREE.Shape.prototype.getPointsHoles = function ( divisions ) {
+	// Get points of holes
 
-	var i, il = this.holes.length, holesPts = [];
+	getPointsHoles: function ( divisions ) {
 
-	for ( i = 0; i < il; i ++ ) {
+		var i, il = this.holes.length, holesPts = [];
 
-		holesPts[ i ] = this.holes[ i ].getTransformedPoints( divisions, this.bends );
+		for ( i = 0; i < il; i ++ ) {
+
+			holesPts[ i ] = this.holes[ i ].getTransformedPoints( divisions, this.bends );
+
+		}
+
+		return holesPts;
+
+	},
+
+	// Get points of holes (spaced by regular distance)
+
+	getSpacedPointsHoles: function ( divisions ) {
+
+		var i, il = this.holes.length, holesPts = [];
+
+		for ( i = 0; i < il; i ++ ) {
+
+			holesPts[ i ] = this.holes[ i ].getTransformedSpacedPoints( divisions, this.bends );
+
+		}
+
+		return holesPts;
+
+	},
+
+	// Get points of shape and holes (keypoints based on segments parameter)
+
+	extractAllPoints: function ( divisions ) {
+
+		return {
+
+			shape: this.getTransformedPoints( divisions ),
+			holes: this.getPointsHoles( divisions )
+
+		};
+
+	},
+
+	extractPoints: function ( divisions ) {
+
+		if (this.useSpacedPoints) {
+			return this.extractAllSpacedPoints(divisions);
+		}
+
+		return this.extractAllPoints(divisions);
+
+	},
+
+	//
+	// THREE.Shape.prototype.extractAllPointsWithBend = function ( divisions, bend ) {
+	//
+	// 	return {
+	//
+	// 		shape: this.transform( bend, divisions ),
+	// 		holes: this.getPointsHoles( divisions, bend )
+	//
+	// 	};
+	//
+	// };
+
+	// Get points of shape and holes (spaced by regular distance)
+
+	extractAllSpacedPoints: function ( divisions ) {
+
+		return {
+
+			shape: this.getTransformedSpacedPoints( divisions ),
+			holes: this.getSpacedPointsHoles( divisions )
+
+		};
 
 	}
 
-	return holesPts;
-
-};
-
-// Get points of holes (spaced by regular distance)
-
-THREE.Shape.prototype.getSpacedPointsHoles = function ( divisions ) {
-
-	var i, il = this.holes.length, holesPts = [];
-
-	for ( i = 0; i < il; i ++ ) {
-
-		holesPts[ i ] = this.holes[ i ].getTransformedSpacedPoints( divisions, this.bends );
-
-	}
-
-	return holesPts;
-
-};
-
-
-// Get points of shape and holes (keypoints based on segments parameter)
-
-THREE.Shape.prototype.extractAllPoints = function ( divisions ) {
-
-	return {
-
-		shape: this.getTransformedPoints( divisions ),
-		holes: this.getPointsHoles( divisions )
-
-	};
-
-};
-
-THREE.Shape.prototype.extractPoints = function ( divisions ) {
-
-	if (this.useSpacedPoints) {
-		return this.extractAllSpacedPoints(divisions);
-	}
-
-	return this.extractAllPoints(divisions);
-
-};
-
-//
-// THREE.Shape.prototype.extractAllPointsWithBend = function ( divisions, bend ) {
-//
-// 	return {
-//
-// 		shape: this.transform( bend, divisions ),
-// 		holes: this.getPointsHoles( divisions, bend )
-//
-// 	};
-//
-// };
-
-// Get points of shape and holes (spaced by regular distance)
-
-THREE.Shape.prototype.extractAllSpacedPoints = function ( divisions ) {
-
-	return {
-
-		shape: this.getTransformedSpacedPoints( divisions ),
-		holes: this.getSpacedPointsHoles( divisions )
-
-	};
-
-};
+} );
 
 /**************************************************************
  *	Utils

--- a/src/extras/geometries/ExtrudeGeometry.js
+++ b/src/extras/geometries/ExtrudeGeometry.js
@@ -56,447 +56,345 @@ THREE.ExtrudeGeometry = function ( shapes, options ) {
 
 THREE.ExtrudeGeometry.prototype = Object.create( THREE.Geometry.prototype );
 
-THREE.ExtrudeGeometry.prototype.addShapeList = function ( shapes, options ) {
-	var sl = shapes.length;
+THREE.extend( THREE.ExtrudeGeometry.prototype, {
 
-	for ( var s = 0; s < sl; s ++ ) {
-		var shape = shapes[ s ];
-		this.addShape( shape, options );
-	}
-};
+	addShapeList: function ( shapes, options ) {
+		var sl = shapes.length;
 
-THREE.ExtrudeGeometry.prototype.addShape = function ( shape, options ) {
+		for ( var s = 0; s < sl; s ++ ) {
+			var shape = shapes[ s ];
+			this.addShape( shape, options );
+		}
+	},
 
-	var amount = options.amount !== undefined ? options.amount : 100;
+	addShape: function ( shape, options ) {
 
-	var bevelThickness = options.bevelThickness !== undefined ? options.bevelThickness : 6; // 10
-	var bevelSize = options.bevelSize !== undefined ? options.bevelSize : bevelThickness - 2; // 8
-	var bevelSegments = options.bevelSegments !== undefined ? options.bevelSegments : 3;
+		var amount = options.amount !== undefined ? options.amount : 100;
 
-	var bevelEnabled = options.bevelEnabled !== undefined ? options.bevelEnabled : true; // false
+		var bevelThickness = options.bevelThickness !== undefined ? options.bevelThickness : 6; // 10
+		var bevelSize = options.bevelSize !== undefined ? options.bevelSize : bevelThickness - 2; // 8
+		var bevelSegments = options.bevelSegments !== undefined ? options.bevelSegments : 3;
 
-	var curveSegments = options.curveSegments !== undefined ? options.curveSegments : 12;
+		var bevelEnabled = options.bevelEnabled !== undefined ? options.bevelEnabled : true; // false
 
-	var steps = options.steps !== undefined ? options.steps : 1;
+		var curveSegments = options.curveSegments !== undefined ? options.curveSegments : 12;
 
-	var extrudePath = options.extrudePath;
-	var extrudePts, extrudeByPath = false;
+		var steps = options.steps !== undefined ? options.steps : 1;
 
-	var material = options.material;
-	var extrudeMaterial = options.extrudeMaterial;
+		var extrudePath = options.extrudePath;
+		var extrudePts, extrudeByPath = false;
 
-	// Use default WorldUVGenerator if no UV generators are specified.
-	var uvgen = options.UVGenerator !== undefined ? options.UVGenerator : THREE.ExtrudeGeometry.WorldUVGenerator;
+		var material = options.material;
+		var extrudeMaterial = options.extrudeMaterial;
 
-	var shapebb = this.shapebb;
-	//shapebb = shape.getBoundingBox();
+		// Use default WorldUVGenerator if no UV generators are specified.
+		var uvgen = options.UVGenerator !== undefined ? options.UVGenerator : THREE.ExtrudeGeometry.WorldUVGenerator;
+
+		var shapebb = this.shapebb;
+		//shapebb = shape.getBoundingBox();
 
 
 
-	var splineTube, binormal, normal, position2;
-	if ( extrudePath ) {
+		var splineTube, binormal, normal, position2;
+		if ( extrudePath ) {
 
-		extrudePts = extrudePath.getSpacedPoints( steps );
+			extrudePts = extrudePath.getSpacedPoints( steps );
 
-		extrudeByPath = true;
-		bevelEnabled = false; // bevels not supported for path extrusion
+			extrudeByPath = true;
+			bevelEnabled = false; // bevels not supported for path extrusion
 
-		// SETUP TNB variables
+			// SETUP TNB variables
 
-		// Reuse TNB from TubeGeomtry for now.
-		// TODO1 - have a .isClosed in spline?
+			// Reuse TNB from TubeGeomtry for now.
+			// TODO1 - have a .isClosed in spline?
 
-		splineTube = options.frames !== undefined ? options.frames : new THREE.TubeGeometry.FrenetFrames(extrudePath, steps, false);
+			splineTube = options.frames !== undefined ? options.frames : new THREE.TubeGeometry.FrenetFrames(extrudePath, steps, false);
 
-		// console.log(splineTube, 'splineTube', splineTube.normals.length, 'steps', steps, 'extrudePts', extrudePts.length);
+			// console.log(splineTube, 'splineTube', splineTube.normals.length, 'steps', steps, 'extrudePts', extrudePts.length);
 
-		binormal = new THREE.Vector3();
-		normal = new THREE.Vector3();
-		position2 = new THREE.Vector3();
+			binormal = new THREE.Vector3();
+			normal = new THREE.Vector3();
+			position2 = new THREE.Vector3();
 
-	}
+		}
 
-	// Safeguards if bevels are not enabled
+		// Safeguards if bevels are not enabled
 
-	if ( ! bevelEnabled ) {
+		if ( ! bevelEnabled ) {
 
-		bevelSegments = 0;
-		bevelThickness = 0;
-		bevelSize = 0;
+			bevelSegments = 0;
+			bevelThickness = 0;
+			bevelSize = 0;
 
-	}
+		}
 
-	// Variables initalization
+		// Variables initalization
 
-	var ahole, h, hl; // looping of holes
-	var scope = this;
-	var bevelPoints = [];
+		var ahole, h, hl; // looping of holes
+		var scope = this;
+		var bevelPoints = [];
 
-	var shapesOffset = this.vertices.length;
+		var shapesOffset = this.vertices.length;
 
-	var shapePoints = shape.extractPoints( curveSegments );
+		var shapePoints = shape.extractPoints( curveSegments );
 
-	var vertices = shapePoints.shape;
-	var holes = shapePoints.holes;
+		var vertices = shapePoints.shape;
+		var holes = shapePoints.holes;
 
-	var reverse = !THREE.Shape.Utils.isClockWise( vertices ) ;
+		var reverse = !THREE.Shape.Utils.isClockWise( vertices ) ;
 
-	if ( reverse ) {
+		if ( reverse ) {
 
-		vertices = vertices.reverse();
+			vertices = vertices.reverse();
 
-		// Maybe we should also check if holes are in the opposite direction, just to be safe ...
+			// Maybe we should also check if holes are in the opposite direction, just to be safe ...
 
-		for ( h = 0, hl = holes.length; h < hl; h ++ ) {
+			for ( h = 0, hl = holes.length; h < hl; h ++ ) {
+
+				ahole = holes[ h ];
+
+				if ( THREE.Shape.Utils.isClockWise( ahole ) ) {
+
+					holes[ h ] = ahole.reverse();
+
+				}
+
+			}
+
+			reverse = false; // If vertices are in order now, we shouldn't need to worry about them again (hopefully)!
+
+		}
+
+
+		var faces = THREE.Shape.Utils.triangulateShape ( vertices, holes );
+
+		/* Vertices */
+
+		var contour = vertices; // vertices has all points but contour has only points of circumference
+
+		for ( h = 0, hl = holes.length;  h < hl; h ++ ) {
 
 			ahole = holes[ h ];
 
-			if ( THREE.Shape.Utils.isClockWise( ahole ) ) {
+			vertices = vertices.concat( ahole );
 
-				holes[ h ] = ahole.reverse();
+		}
+
+
+		function scalePt2 ( pt, vec, size ) {
+
+			if ( !vec ) console.log( "die" );
+
+			return vec.clone().multiplyScalar( size ).add( pt );
+
+		}
+
+		var b, bs, t, z,
+			vert, vlen = vertices.length,
+			face, flen = faces.length,
+			cont, clen = contour.length;
+
+
+		// Find directions for point movement
+
+		var RAD_TO_DEGREES = 180 / Math.PI;
+
+
+		function getBevelVec( pt_i, pt_j, pt_k ) {
+
+			// Algorithm 2
+
+			return getBevelVec2( pt_i, pt_j, pt_k );
+
+		}
+
+		function getBevelVec1( pt_i, pt_j, pt_k ) {
+
+			var anglea = Math.atan2( pt_j.y - pt_i.y, pt_j.x - pt_i.x );
+			var angleb = Math.atan2( pt_k.y - pt_i.y, pt_k.x - pt_i.x );
+
+			if ( anglea > angleb ) {
+
+				angleb += Math.PI * 2;
 
 			}
 
-		}
-
-		reverse = false; // If vertices are in order now, we shouldn't need to worry about them again (hopefully)!
-
-	}
+			var anglec = ( anglea + angleb ) / 2;
 
 
-	var faces = THREE.Shape.Utils.triangulateShape ( vertices, holes );
+			//console.log('angle1', anglea * RAD_TO_DEGREES,'angle2', angleb * RAD_TO_DEGREES, 'anglec', anglec *RAD_TO_DEGREES);
 
-	/* Vertices */
+			var x = - Math.cos( anglec );
+			var y = - Math.sin( anglec );
 
-	var contour = vertices; // vertices has all points but contour has only points of circumference
+			var vec = new THREE.Vector2( x, y ); //.normalize();
 
-	for ( h = 0, hl = holes.length;  h < hl; h ++ ) {
-
-		ahole = holes[ h ];
-
-		vertices = vertices.concat( ahole );
-
-	}
-
-
-	function scalePt2 ( pt, vec, size ) {
-
-		if ( !vec ) console.log( "die" );
-
-		return vec.clone().multiplyScalar( size ).add( pt );
-
-	}
-
-	var b, bs, t, z,
-		vert, vlen = vertices.length,
-		face, flen = faces.length,
-		cont, clen = contour.length;
-
-
-	// Find directions for point movement
-
-	var RAD_TO_DEGREES = 180 / Math.PI;
-
-
-	function getBevelVec( pt_i, pt_j, pt_k ) {
-
-		// Algorithm 2
-
-		return getBevelVec2( pt_i, pt_j, pt_k );
-
-	}
-
-	function getBevelVec1( pt_i, pt_j, pt_k ) {
-
-		var anglea = Math.atan2( pt_j.y - pt_i.y, pt_j.x - pt_i.x );
-		var angleb = Math.atan2( pt_k.y - pt_i.y, pt_k.x - pt_i.x );
-
-		if ( anglea > angleb ) {
-
-			angleb += Math.PI * 2;
+			return vec;
 
 		}
 
-		var anglec = ( anglea + angleb ) / 2;
+		function getBevelVec2( pt_i, pt_j, pt_k ) {
 
+			var a = THREE.ExtrudeGeometry.__v1,
+				b = THREE.ExtrudeGeometry.__v2,
+				v_hat = THREE.ExtrudeGeometry.__v3,
+				w_hat = THREE.ExtrudeGeometry.__v4,
+				p = THREE.ExtrudeGeometry.__v5,
+				q = THREE.ExtrudeGeometry.__v6,
+				v, w,
+				v_dot_w_hat, q_sub_p_dot_w_hat,
+				s, intersection;
 
-		//console.log('angle1', anglea * RAD_TO_DEGREES,'angle2', angleb * RAD_TO_DEGREES, 'anglec', anglec *RAD_TO_DEGREES);
+			// good reading for line-line intersection
+			// http://sputsoft.com/blog/2010/03/line-line-intersection.html
 
-		var x = - Math.cos( anglec );
-		var y = - Math.sin( anglec );
+			// define a as vector j->i
+			// define b as vectot k->i
 
-		var vec = new THREE.Vector2( x, y ); //.normalize();
+			a.set( pt_i.x - pt_j.x, pt_i.y - pt_j.y );
+			b.set( pt_i.x - pt_k.x, pt_i.y - pt_k.y );
 
-		return vec;
+			// get unit vectors
 
-	}
+			v = a.normalize();
+			w = b.normalize();
 
-	function getBevelVec2( pt_i, pt_j, pt_k ) {
+			// normals from pt i
 
-		var a = THREE.ExtrudeGeometry.__v1,
-			b = THREE.ExtrudeGeometry.__v2,
-			v_hat = THREE.ExtrudeGeometry.__v3,
-			w_hat = THREE.ExtrudeGeometry.__v4,
-			p = THREE.ExtrudeGeometry.__v5,
-			q = THREE.ExtrudeGeometry.__v6,
-			v, w,
-			v_dot_w_hat, q_sub_p_dot_w_hat,
-			s, intersection;
+			v_hat.set( -v.y, v.x );
+			w_hat.set( w.y, -w.x );
 
-		// good reading for line-line intersection
-		// http://sputsoft.com/blog/2010/03/line-line-intersection.html
+			// pts from i
 
-		// define a as vector j->i
-		// define b as vectot k->i
+			p.copy( pt_i ).add( v_hat );
+			q.copy( pt_i ).add( w_hat );
 
-		a.set( pt_i.x - pt_j.x, pt_i.y - pt_j.y );
-		b.set( pt_i.x - pt_k.x, pt_i.y - pt_k.y );
+			if ( p.equals( q ) ) {
 
-		// get unit vectors
-
-		v = a.normalize();
-		w = b.normalize();
-
-		// normals from pt i
-
-		v_hat.set( -v.y, v.x );
-		w_hat.set( w.y, -w.x );
-
-		// pts from i
-
-		p.copy( pt_i ).add( v_hat );
-		q.copy( pt_i ).add( w_hat );
-
-		if ( p.equals( q ) ) {
-
-			//console.log("Warning: lines are straight");
-			return w_hat.clone();
-
-		}
-
-		// Points from j, k. helps prevents points cross overover most of the time
-
-		p.copy( pt_j ).add( v_hat );
-		q.copy( pt_k ).add( w_hat );
-
-		v_dot_w_hat = v.dot( w_hat );
-		q_sub_p_dot_w_hat = q.sub( p ).dot( w_hat );
-
-		// We should not reach these conditions
-
-		if ( v_dot_w_hat === 0 ) {
-
-			console.log( "Either infinite or no solutions!" );
-
-			if ( q_sub_p_dot_w_hat === 0 ) {
-
-				console.log( "Its finite solutions." );
-
-			} else {
-
-				console.log( "Too bad, no solutions." );
+				//console.log("Warning: lines are straight");
+				return w_hat.clone();
 
 			}
 
+			// Points from j, k. helps prevents points cross overover most of the time
+
+			p.copy( pt_j ).add( v_hat );
+			q.copy( pt_k ).add( w_hat );
+
+			v_dot_w_hat = v.dot( w_hat );
+			q_sub_p_dot_w_hat = q.sub( p ).dot( w_hat );
+
+			// We should not reach these conditions
+
+			if ( v_dot_w_hat === 0 ) {
+
+				console.log( "Either infinite or no solutions!" );
+
+				if ( q_sub_p_dot_w_hat === 0 ) {
+
+					console.log( "Its finite solutions." );
+
+				} else {
+
+					console.log( "Too bad, no solutions." );
+
+				}
+
+			}
+
+			s = q_sub_p_dot_w_hat / v_dot_w_hat;
+
+			if ( s < 0 ) {
+
+				// in case of emergecy, revert to algorithm 1.
+
+				return getBevelVec1( pt_i, pt_j, pt_k );
+
+			}
+
+			intersection = v.multiplyScalar( s ).add( p );
+
+			return intersection.sub( pt_i ).clone(); // Don't normalize!, otherwise sharp corners become ugly
+
 		}
 
-		s = q_sub_p_dot_w_hat / v_dot_w_hat;
+		var contourMovements = [];
 
-		if ( s < 0 ) {
-
-			// in case of emergecy, revert to algorithm 1.
-
-			return getBevelVec1( pt_i, pt_j, pt_k );
-
-		}
-
-		intersection = v.multiplyScalar( s ).add( p );
-
-		return intersection.sub( pt_i ).clone(); // Don't normalize!, otherwise sharp corners become ugly
-
-	}
-
-	var contourMovements = [];
-
-	for ( var i = 0, il = contour.length, j = il - 1, k = i + 1; i < il; i ++, j ++, k ++ ) {
-
-		if ( j === il ) j = 0;
-		if ( k === il ) k = 0;
-
-		//  (j)---(i)---(k)
-		// console.log('i,j,k', i, j , k)
-
-		var pt_i = contour[ i ];
-		var pt_j = contour[ j ];
-		var pt_k = contour[ k ];
-
-		contourMovements[ i ]= getBevelVec( contour[ i ], contour[ j ], contour[ k ] );
-
-	}
-
-	var holesMovements = [], oneHoleMovements, verticesMovements = contourMovements.concat();
-
-	for ( h = 0, hl = holes.length; h < hl; h ++ ) {
-
-		ahole = holes[ h ];
-
-		oneHoleMovements = [];
-
-		for ( i = 0, il = ahole.length, j = il - 1, k = i + 1; i < il; i ++, j ++, k ++ ) {
+		for ( var i = 0, il = contour.length, j = il - 1, k = i + 1; i < il; i ++, j ++, k ++ ) {
 
 			if ( j === il ) j = 0;
 			if ( k === il ) k = 0;
 
 			//  (j)---(i)---(k)
-			oneHoleMovements[ i ]= getBevelVec( ahole[ i ], ahole[ j ], ahole[ k ] );
+			// console.log('i,j,k', i, j , k)
+
+			var pt_i = contour[ i ];
+			var pt_j = contour[ j ];
+			var pt_k = contour[ k ];
+
+			contourMovements[ i ]= getBevelVec( contour[ i ], contour[ j ], contour[ k ] );
 
 		}
 
-		holesMovements.push( oneHoleMovements );
-		verticesMovements = verticesMovements.concat( oneHoleMovements );
-
-	}
-
-
-	// Loop bevelSegments, 1 for the front, 1 for the back
-
-	for ( b = 0; b < bevelSegments; b ++ ) {
-	//for ( b = bevelSegments; b > 0; b -- ) {
-
-		t = b / bevelSegments;
-		z = bevelThickness * ( 1 - t );
-
-		//z = bevelThickness * t;
-		bs = bevelSize * ( Math.sin ( t * Math.PI/2 ) ) ; // curved
-		//bs = bevelSize * t ; // linear
-
-		// contract shape
-
-		for ( i = 0, il = contour.length; i < il; i ++ ) {
-
-			vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
-			//vert = scalePt( contour[ i ], contourCentroid, bs, false );
-			v( vert.x, vert.y,  - z );
-
-		}
-
-		// expand holes
-
-		for ( h = 0, hl = holes.length; h < hl; h++ ) {
-
-			ahole = holes[ h ];
-			oneHoleMovements = holesMovements[ h ];
-
-			for ( i = 0, il = ahole.length; i < il; i++ ) {
-
-				vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
-				//vert = scalePt( ahole[ i ], holesCentroids[ h ], bs, true );
-
-				v( vert.x, vert.y,  -z );
-
-			}
-
-		}
-
-	}
-
-	bs = bevelSize;
-
-	// Back facing vertices
-
-	for ( i = 0; i < vlen; i ++ ) {
-
-		vert = bevelEnabled ? scalePt2( vertices[ i ], verticesMovements[ i ], bs ) : vertices[ i ];
-
-		if ( !extrudeByPath ) {
-
-			v( vert.x, vert.y, 0 );
-
-		} else {
-
-			// v( vert.x, vert.y + extrudePts[ 0 ].y, extrudePts[ 0 ].x );
-
-			normal.copy( splineTube.normals[0] ).multiplyScalar(vert.x);
-			binormal.copy( splineTube.binormals[0] ).multiplyScalar(vert.y);
-
-			position2.copy( extrudePts[0] ).add(normal).add(binormal);
-
-			v( position2.x, position2.y, position2.z );
-
-		}
-
-	}
-
-	// Add stepped vertices...
-	// Including front facing vertices
-
-	var s;
-
-	for ( s = 1; s <= steps; s ++ ) {
-
-		for ( i = 0; i < vlen; i ++ ) {
-
-			vert = bevelEnabled ? scalePt2( vertices[ i ], verticesMovements[ i ], bs ) : vertices[ i ];
-
-			if ( !extrudeByPath ) {
-
-				v( vert.x, vert.y, amount / steps * s );
-
-			} else {
-
-				// v( vert.x, vert.y + extrudePts[ s - 1 ].y, extrudePts[ s - 1 ].x );
-
-				normal.copy( splineTube.normals[s] ).multiplyScalar( vert.x );
-				binormal.copy( splineTube.binormals[s] ).multiplyScalar( vert.y );
-
-				position2.copy( extrudePts[s] ).add( normal ).add( binormal );
-
-				v( position2.x, position2.y, position2.z );
-
-			}
-
-		}
-
-	}
-
-
-	// Add bevel segments planes
-
-	//for ( b = 1; b <= bevelSegments; b ++ ) {
-	for ( b = bevelSegments - 1; b >= 0; b -- ) {
-
-		t = b / bevelSegments;
-		z = bevelThickness * ( 1 - t );
-		//bs = bevelSize * ( 1-Math.sin ( ( 1 - t ) * Math.PI/2 ) );
-		bs = bevelSize * Math.sin ( t * Math.PI/2 ) ;
-
-		// contract shape
-
-		for ( i = 0, il = contour.length; i < il; i ++ ) {
-
-			vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
-			v( vert.x, vert.y,  amount + z );
-
-		}
-
-		// expand holes
+		var holesMovements = [], oneHoleMovements, verticesMovements = contourMovements.concat();
 
 		for ( h = 0, hl = holes.length; h < hl; h ++ ) {
 
 			ahole = holes[ h ];
-			oneHoleMovements = holesMovements[ h ];
 
-			for ( i = 0, il = ahole.length; i < il; i ++ ) {
+			oneHoleMovements = [];
 
-				vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
+			for ( i = 0, il = ahole.length, j = il - 1, k = i + 1; i < il; i ++, j ++, k ++ ) {
 
-				if ( !extrudeByPath ) {
+				if ( j === il ) j = 0;
+				if ( k === il ) k = 0;
 
-					v( vert.x, vert.y,  amount + z );
+				//  (j)---(i)---(k)
+				oneHoleMovements[ i ]= getBevelVec( ahole[ i ], ahole[ j ], ahole[ k ] );
 
-				} else {
+			}
 
-					v( vert.x, vert.y + extrudePts[ steps - 1 ].y, extrudePts[ steps - 1 ].x + z );
+			holesMovements.push( oneHoleMovements );
+			verticesMovements = verticesMovements.concat( oneHoleMovements );
+
+		}
+
+
+		// Loop bevelSegments, 1 for the front, 1 for the back
+
+		for ( b = 0; b < bevelSegments; b ++ ) {
+		//for ( b = bevelSegments; b > 0; b -- ) {
+
+			t = b / bevelSegments;
+			z = bevelThickness * ( 1 - t );
+
+			//z = bevelThickness * t;
+			bs = bevelSize * ( Math.sin ( t * Math.PI/2 ) ) ; // curved
+			//bs = bevelSize * t ; // linear
+
+			// contract shape
+
+			for ( i = 0, il = contour.length; i < il; i ++ ) {
+
+				vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
+				//vert = scalePt( contour[ i ], contourCentroid, bs, false );
+				v( vert.x, vert.y,  - z );
+
+			}
+
+			// expand holes
+
+			for ( h = 0, hl = holes.length; h < hl; h++ ) {
+
+				ahole = holes[ h ];
+				oneHoleMovements = holesMovements[ h ];
+
+				for ( i = 0, il = ahole.length; i < il; i++ ) {
+
+					vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
+					//vert = scalePt( ahole[ i ], holesCentroids[ h ], bs, true );
+
+					v( vert.x, vert.y,  -z );
 
 				}
 
@@ -504,162 +402,268 @@ THREE.ExtrudeGeometry.prototype.addShape = function ( shape, options ) {
 
 		}
 
-	}
+		bs = bevelSize;
 
-	/* Faces */
+		// Back facing vertices
 
-	// Top and bottom faces
+		for ( i = 0; i < vlen; i ++ ) {
 
-	buildLidFaces();
+			vert = bevelEnabled ? scalePt2( vertices[ i ], verticesMovements[ i ], bs ) : vertices[ i ];
 
-	// Sides faces
+			if ( !extrudeByPath ) {
 
-	buildSideFaces();
+				v( vert.x, vert.y, 0 );
 
+			} else {
 
-	/////  Internal functions
+				// v( vert.x, vert.y + extrudePts[ 0 ].y, extrudePts[ 0 ].x );
 
-	function buildLidFaces() {
+				normal.copy( splineTube.normals[0] ).multiplyScalar(vert.x);
+				binormal.copy( splineTube.binormals[0] ).multiplyScalar(vert.y);
 
-		if ( bevelEnabled ) {
+				position2.copy( extrudePts[0] ).add(normal).add(binormal);
 
-			var layer = 0 ; // steps + 1
-			var offset = vlen * layer;
-
-			// Bottom faces
-
-			for ( i = 0; i < flen; i ++ ) {
-
-				face = faces[ i ];
-				f3( face[ 2 ]+ offset, face[ 1 ]+ offset, face[ 0 ] + offset, true );
+				v( position2.x, position2.y, position2.z );
 
 			}
-
-			layer = steps + bevelSegments * 2;
-			offset = vlen * layer;
-
-			// Top faces
-
-			for ( i = 0; i < flen; i ++ ) {
-
-				face = faces[ i ];
-				f3( face[ 0 ] + offset, face[ 1 ] + offset, face[ 2 ] + offset, false );
-
-			}
-
-		} else {
-
-			// Bottom faces
-
-			for ( i = 0; i < flen; i++ ) {
-
-				face = faces[ i ];
-				f3( face[ 2 ], face[ 1 ], face[ 0 ], true );
-
-			}
-
-			// Top faces
-
-			for ( i = 0; i < flen; i ++ ) {
-
-				face = faces[ i ];
-				f3( face[ 0 ] + vlen * steps, face[ 1 ] + vlen * steps, face[ 2 ] + vlen * steps, false );
-
-			}
-		}
-
-	}
-
-	// Create faces for the z-sides of the shape
-
-	function buildSideFaces() {
-
-		var layeroffset = 0;
-		sidewalls( contour, layeroffset );
-		layeroffset += contour.length;
-
-		for ( h = 0, hl = holes.length;  h < hl; h ++ ) {
-
-			ahole = holes[ h ];
-			sidewalls( ahole, layeroffset );
-
-			//, true
-			layeroffset += ahole.length;
 
 		}
 
-	}
+		// Add stepped vertices...
+		// Including front facing vertices
 
-	function sidewalls( contour, layeroffset ) {
+		var s;
 
-		var j, k;
-		i = contour.length;
+		for ( s = 1; s <= steps; s ++ ) {
 
-		while ( --i >= 0 ) {
+			for ( i = 0; i < vlen; i ++ ) {
 
-			j = i;
-			k = i - 1;
-			if ( k < 0 ) k = contour.length - 1;
+				vert = bevelEnabled ? scalePt2( vertices[ i ], verticesMovements[ i ], bs ) : vertices[ i ];
 
-			//console.log('b', i,j, i-1, k,vertices.length);
+				if ( !extrudeByPath ) {
 
-			var s = 0, sl = steps  + bevelSegments * 2;
+					v( vert.x, vert.y, amount / steps * s );
 
-			for ( s = 0; s < sl; s ++ ) {
+				} else {
 
-				var slen1 = vlen * s;
-				var slen2 = vlen * ( s + 1 );
+					// v( vert.x, vert.y + extrudePts[ s - 1 ].y, extrudePts[ s - 1 ].x );
 
-				var a = layeroffset + j + slen1,
-					b = layeroffset + k + slen1,
-					c = layeroffset + k + slen2,
-					d = layeroffset + j + slen2;
+					normal.copy( splineTube.normals[s] ).multiplyScalar( vert.x );
+					binormal.copy( splineTube.binormals[s] ).multiplyScalar( vert.y );
 
-				f4( a, b, c, d, contour, s, sl, j, k );
+					position2.copy( extrudePts[s] ).add( normal ).add( binormal );
+
+					v( position2.x, position2.y, position2.z );
+
+				}
 
 			}
+
+		}
+
+
+		// Add bevel segments planes
+
+		//for ( b = 1; b <= bevelSegments; b ++ ) {
+		for ( b = bevelSegments - 1; b >= 0; b -- ) {
+
+			t = b / bevelSegments;
+			z = bevelThickness * ( 1 - t );
+			//bs = bevelSize * ( 1-Math.sin ( ( 1 - t ) * Math.PI/2 ) );
+			bs = bevelSize * Math.sin ( t * Math.PI/2 ) ;
+
+			// contract shape
+
+			for ( i = 0, il = contour.length; i < il; i ++ ) {
+
+				vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
+				v( vert.x, vert.y,  amount + z );
+
+			}
+
+			// expand holes
+
+			for ( h = 0, hl = holes.length; h < hl; h ++ ) {
+
+				ahole = holes[ h ];
+				oneHoleMovements = holesMovements[ h ];
+
+				for ( i = 0, il = ahole.length; i < il; i ++ ) {
+
+					vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
+
+					if ( !extrudeByPath ) {
+
+						v( vert.x, vert.y,  amount + z );
+
+					} else {
+
+						v( vert.x, vert.y + extrudePts[ steps - 1 ].y, extrudePts[ steps - 1 ].x + z );
+
+					}
+
+				}
+
+			}
+
+		}
+
+		/* Faces */
+
+		// Top and bottom faces
+
+		buildLidFaces();
+
+		// Sides faces
+
+		buildSideFaces();
+
+
+		/////  Internal functions
+
+		function buildLidFaces() {
+
+			if ( bevelEnabled ) {
+
+				var layer = 0 ; // steps + 1
+				var offset = vlen * layer;
+
+				// Bottom faces
+
+				for ( i = 0; i < flen; i ++ ) {
+
+					face = faces[ i ];
+					f3( face[ 2 ]+ offset, face[ 1 ]+ offset, face[ 0 ] + offset, true );
+
+				}
+
+				layer = steps + bevelSegments * 2;
+				offset = vlen * layer;
+
+				// Top faces
+
+				for ( i = 0; i < flen; i ++ ) {
+
+					face = faces[ i ];
+					f3( face[ 0 ] + offset, face[ 1 ] + offset, face[ 2 ] + offset, false );
+
+				}
+
+			} else {
+
+				// Bottom faces
+
+				for ( i = 0; i < flen; i++ ) {
+
+					face = faces[ i ];
+					f3( face[ 2 ], face[ 1 ], face[ 0 ], true );
+
+				}
+
+				// Top faces
+
+				for ( i = 0; i < flen; i ++ ) {
+
+					face = faces[ i ];
+					f3( face[ 0 ] + vlen * steps, face[ 1 ] + vlen * steps, face[ 2 ] + vlen * steps, false );
+
+				}
+			}
+
+		}
+
+		// Create faces for the z-sides of the shape
+
+		function buildSideFaces() {
+
+			var layeroffset = 0;
+			sidewalls( contour, layeroffset );
+			layeroffset += contour.length;
+
+			for ( h = 0, hl = holes.length;  h < hl; h ++ ) {
+
+				ahole = holes[ h ];
+				sidewalls( ahole, layeroffset );
+
+				//, true
+				layeroffset += ahole.length;
+
+			}
+
+		}
+
+		function sidewalls( contour, layeroffset ) {
+
+			var j, k;
+			i = contour.length;
+
+			while ( --i >= 0 ) {
+
+				j = i;
+				k = i - 1;
+				if ( k < 0 ) k = contour.length - 1;
+
+				//console.log('b', i,j, i-1, k,vertices.length);
+
+				var s = 0, sl = steps  + bevelSegments * 2;
+
+				for ( s = 0; s < sl; s ++ ) {
+
+					var slen1 = vlen * s;
+					var slen2 = vlen * ( s + 1 );
+
+					var a = layeroffset + j + slen1,
+						b = layeroffset + k + slen1,
+						c = layeroffset + k + slen2,
+						d = layeroffset + j + slen2;
+
+					f4( a, b, c, d, contour, s, sl, j, k );
+
+				}
+			}
+
+		}
+
+
+		function v( x, y, z ) {
+
+			scope.vertices.push( new THREE.Vector3( x, y, z ) );
+
+		}
+
+		function f3( a, b, c, isBottom ) {
+
+			a += shapesOffset;
+			b += shapesOffset;
+			c += shapesOffset;
+
+			// normal, color, material
+			scope.faces.push( new THREE.Face3( a, b, c, null, null, material ) );
+
+			var uvs = isBottom ? uvgen.generateBottomUV( scope, shape, options, a, b, c ) : uvgen.generateTopUV( scope, shape, options, a, b, c );
+
+	 		scope.faceVertexUvs[ 0 ].push( uvs );
+
+		}
+
+		function f4( a, b, c, d, wallContour, stepIndex, stepsLength, contourIndex1, contourIndex2 ) {
+
+			a += shapesOffset;
+			b += shapesOffset;
+			c += shapesOffset;
+			d += shapesOffset;
+
+	 		scope.faces.push( new THREE.Face4( a, b, c, d, null, null, extrudeMaterial ) );
+
+	 		var uvs = uvgen.generateSideWallUV( scope, shape, wallContour, options, a, b, c, d,
+	 		                                    stepIndex, stepsLength, contourIndex1, contourIndex2 );
+	 		scope.faceVertexUvs[ 0 ].push( uvs );
+
 		}
 
 	}
-
-
-	function v( x, y, z ) {
-
-		scope.vertices.push( new THREE.Vector3( x, y, z ) );
-
-	}
-
-	function f3( a, b, c, isBottom ) {
-
-		a += shapesOffset;
-		b += shapesOffset;
-		c += shapesOffset;
-
-		// normal, color, material
-		scope.faces.push( new THREE.Face3( a, b, c, null, null, material ) );
-
-		var uvs = isBottom ? uvgen.generateBottomUV( scope, shape, options, a, b, c ) : uvgen.generateTopUV( scope, shape, options, a, b, c );
-
- 		scope.faceVertexUvs[ 0 ].push( uvs );
-
-	}
-
-	function f4( a, b, c, d, wallContour, stepIndex, stepsLength, contourIndex1, contourIndex2 ) {
-
-		a += shapesOffset;
-		b += shapesOffset;
-		c += shapesOffset;
-		d += shapesOffset;
-
- 		scope.faces.push( new THREE.Face4( a, b, c, d, null, null, extrudeMaterial ) );
-
- 		var uvs = uvgen.generateSideWallUV( scope, shape, wallContour, options, a, b, c, d,
- 		                                    stepIndex, stepsLength, contourIndex1, contourIndex2 );
- 		scope.faceVertexUvs[ 0 ].push( uvs );
-
-	}
-
-};
+	
+} );
 
 THREE.ExtrudeGeometry.WorldUVGenerator = {
 

--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -41,43 +41,50 @@ THREE.ArrowHelper = function ( dir, origin, length, hex ) {
 
 THREE.ArrowHelper.prototype = Object.create( THREE.Object3D.prototype );
 
-THREE.ArrowHelper.prototype.setDirection = function ( dir ) {
+THREE.extend( THREE.ArrowHelper.prototype, {
 
-    var d = THREE.ArrowHelper.__v1.copy( dir ).normalize();
+	setDirection: function() {
 
-    if ( d.y > 0.999 ) {
+		var v1 = new THREE.Vector3(),
+			v2 = new THREE.Vector3(),
+			q1 = new THREE.Quaternion();
 
-        this.rotation.set( 0, 0, 0 );
- 
-    } else if ( d.y < - 0.999 ) {
+		return function ( dir ) {
 
-        this.rotation.set( Math.PI, 0, 0 );
+		    var d = v1.copy( dir ).normalize();
 
-    } else {
+		    if ( d.y > 0.999 ) {
 
-	    var axis = THREE.ArrowHelper.__v2.set( d.z, 0, - d.x ).normalize();
-	    var radians = Math.acos( d.y );
-	    var quaternion = THREE.ArrowHelper.__q1.setFromAxisAngle( axis, radians );
+		        this.rotation.set( 0, 0, 0 );
+		 
+		    } else if ( d.y < - 0.999 ) {
 
-	    this.rotation.setEulerFromQuaternion( quaternion, this.eulerOrder );
+		        this.rotation.set( Math.PI, 0, 0 );
+
+		    } else {
+
+			    var axis = v2.set( d.z, 0, - d.x ).normalize();
+			    var radians = Math.acos( d.y );
+			    var quaternion = q1.setFromAxisAngle( axis, radians );
+
+			    this.rotation.setEulerFromQuaternion( quaternion, this.eulerOrder );
+
+			}
+		};
+
+	}(),
+
+	setLength: function ( length ) {
+
+		this.scale.set( length, length, length );
+
+	},
+
+	setColor: function ( hex ) {
+
+		this.line.material.color.setHex( hex );
+		this.cone.material.color.setHex( hex );
 
 	}
 
-};
-
-THREE.ArrowHelper.prototype.setLength = function ( length ) {
-
-	this.scale.set( length, length, length );
-
-};
-
-THREE.ArrowHelper.prototype.setColor = function ( hex ) {
-
-	this.line.material.color.setHex( hex );
-	this.cone.material.color.setHex( hex );
-
-};
-
-THREE.ArrowHelper.__v1 = new THREE.Vector3();
-THREE.ArrowHelper.__v2 = new THREE.Vector3();
-THREE.ArrowHelper.__q1 = new THREE.Quaternion();
+} );

--- a/src/extras/helpers/CameraHelper.js
+++ b/src/extras/helpers/CameraHelper.js
@@ -103,78 +103,86 @@ THREE.CameraHelper = function ( camera ) {
 
 THREE.CameraHelper.prototype = Object.create( THREE.Line.prototype );
 
-THREE.CameraHelper.prototype.update = function () {
+THREE.extend( THREE.CameraHelper.prototype, {
 
-	var scope = this;
+	update: function() {
 
-	var w = 1, h = 1;
+		var projector = new THREE.Projector(),
+			v = new THREE.Vector3(),
+			c = new THREE.Camera();
 
-	// we need just camera projection matrix
-	// world matrix must be identity
+		return function () {
 
-	THREE.CameraHelper.__c.projectionMatrix.copy( this.camera.projectionMatrix );
+			var scope = this;
 
-	// center / target
+			var w = 1, h = 1;
 
-	setPoint( "c", 0, 0, -1 );
-	setPoint( "t", 0, 0,  1 );
+			// we need just camera projection matrix
+			// world matrix must be identity
 
-	// near
+			c.projectionMatrix.copy( this.camera.projectionMatrix );
 
-	setPoint( "n1", -w, -h, -1 );
-	setPoint( "n2",  w, -h, -1 );
-	setPoint( "n3", -w,  h, -1 );
-	setPoint( "n4",  w,  h, -1 );
+			// center / target
 
-	// far
+			setPoint( "c", 0, 0, -1 );
+			setPoint( "t", 0, 0,  1 );
 
-	setPoint( "f1", -w, -h, 1 );
-	setPoint( "f2",  w, -h, 1 );
-	setPoint( "f3", -w,  h, 1 );
-	setPoint( "f4",  w,  h, 1 );
+			// near
 
-	// up
+			setPoint( "n1", -w, -h, -1 );
+			setPoint( "n2",  w, -h, -1 );
+			setPoint( "n3", -w,  h, -1 );
+			setPoint( "n4",  w,  h, -1 );
 
-	setPoint( "u1",  w * 0.7, h * 1.1, -1 );
-	setPoint( "u2", -w * 0.7, h * 1.1, -1 );
-	setPoint( "u3",        0, h * 2,   -1 );
+			// far
 
-	// cross
+			setPoint( "f1", -w, -h, 1 );
+			setPoint( "f2",  w, -h, 1 );
+			setPoint( "f3", -w,  h, 1 );
+			setPoint( "f4",  w,  h, 1 );
 
-	setPoint( "cf1", -w,  0, 1 );
-	setPoint( "cf2",  w,  0, 1 );
-	setPoint( "cf3",  0, -h, 1 );
-	setPoint( "cf4",  0,  h, 1 );
+			// up
 
-	setPoint( "cn1", -w,  0, -1 );
-	setPoint( "cn2",  w,  0, -1 );
-	setPoint( "cn3",  0, -h, -1 );
-	setPoint( "cn4",  0,  h, -1 );
+			setPoint( "u1",  w * 0.7, h * 1.1, -1 );
+			setPoint( "u2", -w * 0.7, h * 1.1, -1 );
+			setPoint( "u3",        0, h * 2,   -1 );
 
-	function setPoint( point, x, y, z ) {
+			// cross
 
-		THREE.CameraHelper.__v.set( x, y, z );
-		THREE.CameraHelper.__projector.unprojectVector( THREE.CameraHelper.__v, THREE.CameraHelper.__c );
+			setPoint( "cf1", -w,  0, 1 );
+			setPoint( "cf2",  w,  0, 1 );
+			setPoint( "cf3",  0, -h, 1 );
+			setPoint( "cf4",  0,  h, 1 );
 
-		var points = scope.pointMap[ point ];
+			setPoint( "cn1", -w,  0, -1 );
+			setPoint( "cn2",  w,  0, -1 );
+			setPoint( "cn3",  0, -h, -1 );
+			setPoint( "cn4",  0,  h, -1 );
 
-		if ( points !== undefined ) {
+			function setPoint( point, x, y, z ) {
 
-			for ( var i = 0, il = points.length; i < il; i ++ ) {
+				v.set( x, y, z );
+				projector.unprojectVector( v, c );
 
-				scope.geometry.vertices[ points[ i ] ].copy( THREE.CameraHelper.__v );
+				var points = scope.pointMap[ point ];
+
+				if ( points !== undefined ) {
+
+					for ( var i = 0, il = points.length; i < il; i ++ ) {
+
+						scope.geometry.vertices[ points[ i ] ].copy( v );
+
+					}
+
+				}
 
 			}
 
-		}
+			this.geometry.verticesNeedUpdate = true;
 
-	}
+		};
 
-	this.geometry.verticesNeedUpdate = true;
+	}()
 
-};
-
-THREE.CameraHelper.__projector = new THREE.Projector();
-THREE.CameraHelper.__v = new THREE.Vector3();
-THREE.CameraHelper.__c = new THREE.Camera();
+} );
 

--- a/src/extras/objects/LensFlare.js
+++ b/src/extras/objects/LensFlare.js
@@ -22,59 +22,61 @@ THREE.LensFlare = function ( texture, size, distance, blending, color ) {
 
 THREE.LensFlare.prototype = Object.create( THREE.Object3D.prototype );
 
+THREE.extend( THREE.LensFlare.prototype, {
+	/*
+	 * Add: adds another flare
+	 */
 
-/*
- * Add: adds another flare
- */
+	add: function ( texture, size, distance, blending, color, opacity ) {
 
-THREE.LensFlare.prototype.add = function ( texture, size, distance, blending, color, opacity ) {
+		if( size === undefined ) size = -1;
+		if( distance === undefined ) distance = 0;
+		if( opacity === undefined ) opacity = 1;
+		if( color === undefined ) color = new THREE.Color( 0xffffff );
+		if( blending === undefined ) blending = THREE.NormalBlending;
 
-	if( size === undefined ) size = -1;
-	if( distance === undefined ) distance = 0;
-	if( opacity === undefined ) opacity = 1;
-	if( color === undefined ) color = new THREE.Color( 0xffffff );
-	if( blending === undefined ) blending = THREE.NormalBlending;
+		distance = Math.min( distance, Math.max( 0, distance ) );
 
-	distance = Math.min( distance, Math.max( 0, distance ) );
+		this.lensFlares.push( { texture: texture, 			// THREE.Texture
+			                    size: size, 				// size in pixels (-1 = use texture.width)
+			                    distance: distance, 		// distance (0-1) from light source (0=at light source)
+			                    x: 0, y: 0, z: 0,			// screen position (-1 => 1) z = 0 is ontop z = 1 is back
+			                    scale: 1, 					// scale
+			                    rotation: 1, 				// rotation
+			                    opacity: opacity,			// opacity
+								color: color,				// color
+			                    blending: blending } );		// blending
 
-	this.lensFlares.push( { texture: texture, 			// THREE.Texture
-		                    size: size, 				// size in pixels (-1 = use texture.width)
-		                    distance: distance, 		// distance (0-1) from light source (0=at light source)
-		                    x: 0, y: 0, z: 0,			// screen position (-1 => 1) z = 0 is ontop z = 1 is back
-		                    scale: 1, 					// scale
-		                    rotation: 1, 				// rotation
-		                    opacity: opacity,			// opacity
-							color: color,				// color
-		                    blending: blending } );		// blending
-
-};
+	},
 
 
-/*
- * Update lens flares update positions on all flares based on the screen position
- * Set myLensFlare.customUpdateCallback to alter the flares in your project specific way.
- */
+	/*
+	 * Update lens flares update positions on all flares based on the screen position
+	 * Set myLensFlare.customUpdateCallback to alter the flares in your project specific way.
+	 */
 
-THREE.LensFlare.prototype.updateLensFlares = function () {
+	updateLensFlares: function () {
 
-	var f, fl = this.lensFlares.length;
-	var flare;
-	var vecX = -this.positionScreen.x * 2;
-	var vecY = -this.positionScreen.y * 2;
+		var f, fl = this.lensFlares.length;
+		var flare;
+		var vecX = -this.positionScreen.x * 2;
+		var vecY = -this.positionScreen.y * 2;
 
-	for( f = 0; f < fl; f ++ ) {
+		for( f = 0; f < fl; f ++ ) {
 
-		flare = this.lensFlares[ f ];
+			flare = this.lensFlares[ f ];
 
-		flare.x = this.positionScreen.x + vecX * flare.distance;
-		flare.y = this.positionScreen.y + vecY * flare.distance;
+			flare.x = this.positionScreen.x + vecX * flare.distance;
+			flare.y = this.positionScreen.y + vecY * flare.distance;
 
-		flare.wantedRotation = flare.x * Math.PI * 0.25;
-		flare.rotation += ( flare.wantedRotation - flare.rotation ) * 0.25;
+			flare.wantedRotation = flare.x * Math.PI * 0.25;
+			flare.rotation += ( flare.wantedRotation - flare.rotation ) * 0.25;
+
+		}
 
 	}
 
-};
+});
 
 
 

--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -428,4 +428,4 @@ THREE.extend( THREE.JSONLoader.prototype, {
 
 	}
 
-};
+} );

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -39,86 +39,90 @@ THREE.Material = function () {
 
 };
 
-THREE.Material.prototype.setValues = function ( values ) {
+THREE.Material.prototype = {
 
-	if ( values === undefined ) return;
+	setValues: function ( values ) {
 
-	for ( var key in values ) {
+		if ( values === undefined ) return;
 
-		var newValue = values[ key ];
+		for ( var key in values ) {
 
-		if ( newValue === undefined ) {
+			var newValue = values[ key ];
 
-			console.warn( 'THREE.Material: \'' + key + '\' parameter is undefined.' );
-			continue;
+			if ( newValue === undefined ) {
 
-		}
+				console.warn( 'THREE.Material: \'' + key + '\' parameter is undefined.' );
+				continue;
 
-		if ( key in this ) {
+			}
 
-			var currentValue = this[ key ];
+			if ( key in this ) {
 
-			if ( currentValue instanceof THREE.Color && newValue instanceof THREE.Color ) {
+				var currentValue = this[ key ];
 
-				currentValue.copy( newValue );
+				if ( currentValue instanceof THREE.Color && newValue instanceof THREE.Color ) {
 
-			} else if ( currentValue instanceof THREE.Color ) {
+					currentValue.copy( newValue );
 
-				currentValue.set( newValue );
+				} else if ( currentValue instanceof THREE.Color ) {
 
-			} else if ( currentValue instanceof THREE.Vector3 && newValue instanceof THREE.Vector3 ) {
+					currentValue.set( newValue );
 
-				currentValue.copy( newValue );
+				} else if ( currentValue instanceof THREE.Vector3 && newValue instanceof THREE.Vector3 ) {
 
-			} else {
+					currentValue.copy( newValue );
 
-				this[ key ] = newValue;
+				} else {
+
+					this[ key ] = newValue;
+
+				}
 
 			}
 
 		}
 
+	},
+
+	clone: function ( material ) {
+
+		if ( material === undefined ) material = new THREE.Material();
+
+		material.name = this.name;
+
+		material.side = this.side;
+
+		material.opacity = this.opacity;
+		material.transparent = this.transparent;
+
+		material.blending = this.blending;
+
+		material.blendSrc = this.blendSrc;
+		material.blendDst = this.blendDst;
+		material.blendEquation = this.blendEquation;
+
+		material.depthTest = this.depthTest;
+		material.depthWrite = this.depthWrite;
+
+		material.polygonOffset = this.polygonOffset;
+		material.polygonOffsetFactor = this.polygonOffsetFactor;
+		material.polygonOffsetUnits = this.polygonOffsetUnits;
+
+		material.alphaTest = this.alphaTest;
+
+		material.overdraw = this.overdraw;
+
+		material.visible = this.visible;
+
+		return material;
+
+	},
+
+	dispose: function () {
+
+		this.dispatchEvent( { type: 'dispose' } );
+
 	}
-
-};
-
-THREE.Material.prototype.clone = function ( material ) {
-
-	if ( material === undefined ) material = new THREE.Material();
-
-	material.name = this.name;
-
-	material.side = this.side;
-
-	material.opacity = this.opacity;
-	material.transparent = this.transparent;
-
-	material.blending = this.blending;
-
-	material.blendSrc = this.blendSrc;
-	material.blendDst = this.blendDst;
-	material.blendEquation = this.blendEquation;
-
-	material.depthTest = this.depthTest;
-	material.depthWrite = this.depthWrite;
-
-	material.polygonOffset = this.polygonOffset;
-	material.polygonOffsetFactor = this.polygonOffsetFactor;
-	material.polygonOffsetUnits = this.polygonOffsetUnits;
-
-	material.alphaTest = this.alphaTest;
-
-	material.overdraw = this.overdraw;
-
-	material.visible = this.visible;
-
-	return material;
-
-};
-
-THREE.Material.prototype.dispose = function () {
-
-	this.dispatchEvent( { type: 'dispose' } );
 
 };
 

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -15,50 +15,21 @@ THREE.LOD = function () {
 
 THREE.LOD.prototype = Object.create( THREE.Object3D.prototype );
 
-THREE.LOD.prototype.addLevel = function ( object3D, visibleAtDistance ) {
+THREE.extend( THREE.LOD.prototype, {
 
-	if ( visibleAtDistance === undefined ) {
+	addLevel: function ( object3D, visibleAtDistance ) {
 
-		visibleAtDistance = 0;
+		if ( visibleAtDistance === undefined ) {
 
-	}
-
-	visibleAtDistance = Math.abs( visibleAtDistance );
-
-	for ( var l = 0; l < this.LODs.length; l ++ ) {
-
-		if ( visibleAtDistance < this.LODs[ l ].visibleAtDistance ) {
-
-			break;
+			visibleAtDistance = 0;
 
 		}
 
-	}
+		visibleAtDistance = Math.abs( visibleAtDistance );
 
-	this.LODs.splice( l, 0, { visibleAtDistance: visibleAtDistance, object3D: object3D } );
-	this.add( object3D );
+		for ( var l = 0; l < this.LODs.length; l ++ ) {
 
-};
-
-THREE.LOD.prototype.update = function ( camera ) {
-
-	if ( this.LODs.length > 1 ) {
-
-		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
-
-		var inverse  = camera.matrixWorldInverse;
-		var distance = -( inverse.elements[2] * this.matrixWorld.elements[12] + inverse.elements[6] * this.matrixWorld.elements[13] + inverse.elements[10] * this.matrixWorld.elements[14] + inverse.elements[14] );
-
-		this.LODs[ 0 ].object3D.visible = true;
-
-		for ( var l = 1; l < this.LODs.length; l ++ ) {
-
-			if( distance >= this.LODs[ l ].visibleAtDistance ) {
-
-				this.LODs[ l - 1 ].object3D.visible = false;
-				this.LODs[ l     ].object3D.visible = true;
-
-			} else {
+			if ( visibleAtDistance < this.LODs[ l ].visibleAtDistance ) {
 
 				break;
 
@@ -66,18 +37,51 @@ THREE.LOD.prototype.update = function ( camera ) {
 
 		}
 
-		for( ; l < this.LODs.length; l ++ ) {
+		this.LODs.splice( l, 0, { visibleAtDistance: visibleAtDistance, object3D: object3D } );
+		this.add( object3D );
 
-			this.LODs[ l ].object3D.visible = false;
+	},
+
+	update: function ( camera ) {
+
+		if ( this.LODs.length > 1 ) {
+
+			camera.matrixWorldInverse.getInverse( camera.matrixWorld );
+
+			var inverse  = camera.matrixWorldInverse;
+			var distance = -( inverse.elements[2] * this.matrixWorld.elements[12] + inverse.elements[6] * this.matrixWorld.elements[13] + inverse.elements[10] * this.matrixWorld.elements[14] + inverse.elements[14] );
+
+			this.LODs[ 0 ].object3D.visible = true;
+
+			for ( var l = 1; l < this.LODs.length; l ++ ) {
+
+				if( distance >= this.LODs[ l ].visibleAtDistance ) {
+
+					this.LODs[ l - 1 ].object3D.visible = false;
+					this.LODs[ l     ].object3D.visible = true;
+
+				} else {
+
+					break;
+
+				}
+
+			}
+
+			for( ; l < this.LODs.length; l ++ ) {
+
+				this.LODs[ l ].object3D.visible = false;
+
+			}
 
 		}
 
+	},
+
+	clone: function () {
+
+		// TODO
+
 	}
 
-};
-
-THREE.LOD.prototype.clone = function () {
-
-	// TODO
-
-};
+} );

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -28,46 +28,50 @@ THREE.Mesh = function ( geometry, material ) {
 
 THREE.Mesh.prototype = Object.create( THREE.Object3D.prototype );
 
-THREE.Mesh.prototype.updateMorphTargets = function () {
+THREE.extend( THREE.Mesh.prototype, {
 
-	if ( this.geometry.morphTargets.length > 0 ) {
+	updateMorphTargets: function () {
 
-		this.morphTargetBase = -1;
-		this.morphTargetForcedOrder = [];
-		this.morphTargetInfluences = [];
-		this.morphTargetDictionary = {};
+		if ( this.geometry.morphTargets.length > 0 ) {
 
-		for ( var m = 0, ml = this.geometry.morphTargets.length; m < ml; m ++ ) {
+			this.morphTargetBase = -1;
+			this.morphTargetForcedOrder = [];
+			this.morphTargetInfluences = [];
+			this.morphTargetDictionary = {};
 
-			this.morphTargetInfluences.push( 0 );
-			this.morphTargetDictionary[ this.geometry.morphTargets[ m ].name ] = m;
+			for ( var m = 0, ml = this.geometry.morphTargets.length; m < ml; m ++ ) {
+
+				this.morphTargetInfluences.push( 0 );
+				this.morphTargetDictionary[ this.geometry.morphTargets[ m ].name ] = m;
+
+			}
 
 		}
 
+	},
+
+	getMorphTargetIndexByName: function ( name ) {
+
+		if ( this.morphTargetDictionary[ name ] !== undefined ) {
+
+			return this.morphTargetDictionary[ name ];
+
+		}
+
+		console.log( "THREE.Mesh.getMorphTargetIndexByName: morph target " + name + " does not exist. Returning 0." );
+
+		return 0;
+
+	},
+
+	clone: function ( object ) {
+
+		if ( object === undefined ) object = new THREE.Mesh( this.geometry, this.material );
+
+		THREE.Object3D.prototype.clone.call( this, object );
+
+		return object;
+
 	}
 
-};
-
-THREE.Mesh.prototype.getMorphTargetIndexByName = function ( name ) {
-
-	if ( this.morphTargetDictionary[ name ] !== undefined ) {
-
-		return this.morphTargetDictionary[ name ];
-
-	}
-
-	console.log( "THREE.Mesh.getMorphTargetIndexByName: morph target " + name + " does not exist. Returning 0." );
-
-	return 0;
-
-};
-
-THREE.Mesh.prototype.clone = function ( object ) {
-
-	if ( object === undefined ) object = new THREE.Mesh( this.geometry, this.material );
-
-	THREE.Object3D.prototype.clone.call( this, object );
-
-	return object;
-
-};
+});

--- a/test/unit/unittests_sources.html
+++ b/test/unit/unittests_sources.html
@@ -12,6 +12,7 @@
   <!-- add ThreeJS sources to test below -->
 
   <script src="../../src/Three.js"></script>
+  <script src="../../src/math/Quaternion.js"></script>
   <script src="../../src/math/Math.js"></script>
   <script src="../../src/math/Vector2.js"></script>
   <script src="../../src/math/Vector3.js"></script>
@@ -25,7 +26,6 @@
   <script src="../../src/math/Matrix3.js"></script>
   <script src="../../src/math/Matrix4.js"></script>
   <script src="../../src/math/Color.js"></script>
-  <script src="../../src/math/Quaternion.js"></script>
   <script src="../../src/math/Frustum.js"></script>
 
   <!-- add class-based unit tests below -->


### PR DESCRIPTION
I've applied the THREE.extent pattern across a large part of the library just to see what it would look like.  I just did this as a thought experiment, so this isn't a very serious PR, I expect it to get rejected and I am okay with that.

Benefits:
- Consistent class declarations, one can use the pattern `{ method1: function() {...}, method2: function() {...} }` in all situations now.
- three.min.js shrunk by ~1% because of less duplication of the pattern `THREE.ClassName.prototype.method = function() {...}`.

Downsides:
- three.js grew by 4% because the pattern  `{ method1: function() {...}, method2: function() {...} }` requires one additional level of tab indentation over the pattern `THREE.ClassName.prototype.method = function() {...}`.
- Possibly slower to initialize the library because classes have to be processed via THREE.extend, but I wasn't able to determine if this is the case.

I don't think that THREE.extend() will hard for others to understand if it is applied across the whole library in a consistent fashion.  I think the challenge comes if it is only applied in some cases and not in others, then one has to explain both patterns to new comers rather than just one style.

This was just an experiment so I don't mind if this PR isn't accepted.  I was just playing around this morning.
