### PR TITLE
Added Matrix3.getNormalMatrix( m ) and Vector3.transformDirection( m )

### DIFF
--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -166,7 +166,6 @@ THREE.extend( THREE.Matrix3.prototype, {
 
 	},
 
-
 	transpose: function () {
 
 		var tmp, m = this.elements;
@@ -179,6 +178,15 @@ THREE.extend( THREE.Matrix3.prototype, {
 
 	},
 
+	getNormalMatrix: function ( m ) {
+
+		// input: THREE.Matrix4
+
+		this.getInverse( m ).transpose();
+
+		return this;
+
+	},
 
 	transposeIntoArray: function ( r ) {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -297,6 +297,25 @@ THREE.extend( THREE.Vector3.prototype, {
 
 	}(),
 
+	transformDirection: function ( m ) {
+
+		// input: THREE.Matrix4 affine matrix
+		// vector interpreted as a direction
+
+		var x = this.x, y = this.y, z = this.z;
+
+		var e = m.elements;
+
+		this.x = e[0] * x + e[4] * y + e[8]  * z;
+		this.y = e[1] * x + e[5] * y + e[9]  * z;
+		this.z = e[2] * x + e[6] * y + e[10] * z;
+
+		this.normalize();
+
+		return this;
+
+	},
+
 	divide: function ( v ) {
 
 		this.x /= v.x;


### PR DESCRIPTION
`Matrix3.getNormalMatrix( m`) computes the Normal Matrix from the affine matrix `m`.

Usage looks like this:

```
var normalMatrix = new THREE.Matrix3().getNormalMatrix( m );
normal.applyMatrix3( normalMatrix ).normalize();
```

`Vector3.transformDirection( m )` applies matrix `m` to the vector, but treats the vector as a direction in the calculation. It replaces `Matrix4.rotateAxis( v )`, which will be removed eventually.
