### PR TITLE
* fix TrackballControls.js so that key events intercepted by the Trackba...

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -281,9 +281,12 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	function keydown( event ) {
 
+		event.preventDefault();
+		event.stopPropagation();
+
 		if ( _this.enabled === false ) return;
 
-		window.removeEventListener( 'keydown', keydown );
+		_this.domElement.removeEventListener( 'keydown', keydown );
 
 		_prevState = _state;
 
@@ -307,17 +310,32 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	}
 
+    function keypressed( event ) {
+  
+		event.preventDefault();
+		event.stopPropagation();    		
+    
+
+    }
 	function keyup( event ) {
+
+		event.preventDefault();
+		event.stopPropagation();
 
 		if ( _this.enabled === false ) return;
 
 		_state = _prevState;
 
-		window.addEventListener( 'keydown', keydown, false );
+		_this.domElement.addEventListener( 'keydown', keydown, false );
 
 	}
 
 	function mousedown( event ) {
+
+
+		if (_this.domElement.focus) {
+       _this.domElement.focus();
+		}
 
 		if ( _this.enabled === false ) return;
 
@@ -351,10 +369,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	function mousemove( event ) {
 
-		if ( _this.enabled === false ) return;
-
-		event.preventDefault();
-		event.stopPropagation();
+		if ( ! _this.enabled ) return;
 
 		if ( _state === STATE.ROTATE && !_this.noRotate ) {
 
@@ -493,6 +508,12 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	}
 
+	// see http://www.dbp-consulting.com/tutorials/canvas/CanvasKeyEvents.html
+	// this.domElement.setAttribute('tabindex','0');
+  if ( this.domElement.focus) {
+	   this.domElement.focus();
+  }
+
 	this.domElement.addEventListener( 'contextmenu', function ( event ) { event.preventDefault(); }, false );
 
 	this.domElement.addEventListener( 'mousedown', mousedown, false );
@@ -504,8 +525,9 @@ THREE.TrackballControls = function ( object, domElement ) {
 	this.domElement.addEventListener( 'touchend', touchend, false );
 	this.domElement.addEventListener( 'touchmove', touchmove, false );
 
-	window.addEventListener( 'keydown', keydown, false );
-	window.addEventListener( 'keyup', keyup, false );
+	this.domElement.addEventListener( 'keydown', keydown, false );
+	this.domElement.addEventListener( 'keyup', keyup, false );
+	this.domElement.addEventListener( 'keypressed', keypressed, false );
 
 	this.handleResize();
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -369,7 +369,9 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	function mousemove( event ) {
 
-		if ( ! _this.enabled ) return;
+		if (  _this.enabled === false) return;
+		event.preventDefault();
+		event.stopPropagation();
 
 		if ( _state === STATE.ROTATE && !_this.noRotate ) {
 

--- a/examples/misc_controls_trackball - in small div.html
+++ b/examples/misc_controls_trackball - in small div.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - trackball controls</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #000;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+				font-weight: bold;
+
+				background-color: #fff;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			#info {
+				color:#000;
+				position: absolute;
+				top: 0px; width: 100%;
+				padding: 5px;
+
+			}
+			#controlarea {
+				text-align:left;
+				position: relative;
+				 width: 100%;
+				padding: 5px;	
+				border: 5px;		
+			}
+
+			a {
+				color: red;
+			}
+		</style>
+	</head>
+
+	<body>
+		
+		
+		<div id="container" tabindex="0" style="width:600px;height:200px">
+
+		</div>
+	
+		<div id="info">
+			<a href="http://threejs.org" target="_blank">three.js</a> - trackball controls example</br>
+			MOVE mouse &amp; press LEFT/A: rotate, MIDDLE/S: zoom, RIGHT/D: pan
+		</div>	
+
+		<div id="controlarea">
+This test that the  THREE.TrackballControls processes the key-event correctly and do not propagate key event
+when the controlled domElement ( parent of the canvas) has focus.
+			<ul>
+				<li>set the focus to one input field below 
+				<li>press the left mouse button inside the WebGl view and start twiddling about to rotate the view
+				<li>while moving the mouse with the left button pressed, press the "D" key to pan the view		
+				<li>verify that the input field are not garbaged with unwanted characters.
+			</ul>
+			<input value="some value" >
+			<textarea id="mytextarea">
+			</textarea>
+		<div>
+
+
+
+		<script src="../build/three.min.js"></script>
+
+		<script src="js/controls/TrackballControls.js"></script>
+
+		<script src="js/Detector.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script>
+
+	window.onload=function() {
+
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var container, stats;
+
+			var camera, controls, scene, renderer;
+
+			var cross;
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.getElementById( 'container' );
+
+				camera = new THREE.PerspectiveCamera( 60, container.clientWidth / container.clientHeight, 1, 1000 );
+				camera.position.z = 500;
+
+				controls = new THREE.TrackballControls( camera , container);
+
+				controls.rotateSpeed = 1.0;
+				controls.zoomSpeed = 1.2;
+				controls.panSpeed = 0.8;
+
+				controls.noZoom = false;
+				controls.noPan = false;
+
+				controls.staticMoving = true;
+				controls.dynamicDampingFactor = 0.3;
+
+				controls.keys = [ 65, 83, 68 ];
+
+				controls.addEventListener( 'change', render );
+
+				// world
+
+				scene = new THREE.Scene();
+				scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
+
+				var geometry = new THREE.CylinderGeometry( 0, 10, 30, 4, 1 );
+				var material =  new THREE.MeshLambertMaterial( { color:0xffffff, shading: THREE.FlatShading } );
+
+				for ( var i = 0; i < 500; i ++ ) {
+
+					var mesh = new THREE.Mesh( geometry, material );
+					mesh.position.x = ( Math.random() - 0.5 ) * 1000;
+					mesh.position.y = ( Math.random() - 0.5 ) * 1000;
+					mesh.position.z = ( Math.random() - 0.5 ) * 1000;
+					mesh.updateMatrix();
+					mesh.matrixAutoUpdate = false;
+					scene.add( mesh );
+
+				}
+
+
+				// lights
+
+				light = new THREE.DirectionalLight( 0xffffff );
+				light.position.set( 1, 1, 1 );
+				scene.add( light );
+
+				light = new THREE.DirectionalLight( 0x002288 );
+				light.position.set( -1, -1, -1 );
+				scene.add( light );
+
+				light = new THREE.AmbientLight( 0x222222 );
+				scene.add( light );
+
+
+				// renderer
+
+				renderer = new THREE.WebGLRenderer( { antialias: false } );
+				renderer.setClearColor( scene.fog.color, 1 );
+				renderer.setSize( container.clientWidth, container.clientHeight );
+
+				container.appendChild( renderer.domElement );
+
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '0px';
+				stats.domElement.style.zIndex = 100;
+				container.appendChild( stats.domElement );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function onWindowResize() {
+			
+				camera.aspect = container.clientWidth / container.clientHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( container.clientWidth, container.clientHeight );
+
+				controls.handleResize();
+
+				render();
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+				controls.update();
+
+			}
+
+			function render() {
+
+				renderer.render( scene, camera );
+				stats.update();
+
+			}
+
+}
+
+		</script>
+
+	</body>
+</html>

--- a/examples/misc_controls_trackball -with command line.html
+++ b/examples/misc_controls_trackball -with command line.html
@@ -1,70 +1,76 @@
 <!DOCTYPE html>
+
 <html lang="en">
+
 	<head>
 		<title>three.js webgl - trackball controls</title>
+
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+
 		<style>
-			body {
-				color: #000;
-				font-family:Monospace;
-				font-size:13px;
-				text-align:center;
-				font-weight: bold;
-
-				background-color: #fff;
-				margin: 0px;
-				overflow: hidden;
-			}
-
-			#info {
-				color:#000;
-				position: absolute;
-				top: 0px; width: 100%;
-				padding: 5px;
-
-			}
-			#controlarea {
-				text-align:left;
-				position: relative;
-				 width: 100%;
-				padding: 5px;	
-				border: 5px;		
-			}
-
-			a {
-				color: red;
-			}
+		 html {
+			height: 100%;
+			min-height: 100%;
+			margin: 0 0 0 0 ;
+			overflow: hidden;
+		}
+		body {
+			height: 100%;
+			min-height: 100%;
+			margin: 0 0 0 0 ;
+		}
+		#footer {
+		
+			position: absolute;
+			width: 100%;
+			height: 30px;
+			bottom: 0;
+			left: 0;
+			margin:0;
+			padding:0;
+		}
+		#info {
+			position: absolute;
+			width: 100%;
+			top: 0;
+			text-align: center;
+			font-family: monospace;
+			font-size: 12;
+			font-weight: bold;
+		}
 		</style>
 	</head>
 
 	<body>
-		
-		
-		<div id="container" tabindex="0" style="width:600px;height:200px">
-
-		</div>
-	
 		<div id="info">
-			<a href="http://threejs.org" target="_blank">three.js</a> - trackball controls example</br>
-			MOVE mouse &amp; press LEFT/A: rotate, MIDDLE/S: zoom, RIGHT/D: pan
-		</div>	
-
-		<div id="controlarea">
-This test that the  THREE.TrackballControls processes the key-event correctly and do not propagate key event
-when the controlled domElement ( parent of the canvas) has focus.
-			<ul>
+				<a href="http://threejs.org" target="_blank">three.js</a> - trackball controls example<br/>
+				MOVE mouse &amp; press LEFT/A: rotate, MIDDLE/S: zoom, RIGHT/D: pan
+				<br/>
+				This test that the  THREE.TrackballControls processes the key-event correctly and do not propagate key event
+				when the controlled domElement ( parent of the canvas) has focus.
+				<ul style="text-align:left" >
 				<li>set the focus to one input field below 
 				<li>press the left mouse button inside the WebGl view and start twiddling about to rotate the view
 				<li>while moving the mouse with the left button pressed, press the "D" key to pan the view		
 				<li>verify that the input field are not garbaged with unwanted characters.
-			</ul>
-			<input value="some value" >
-			<textarea id="mytextarea">
-			</textarea>
-		<div>
+				</ul>					
+		</div>		
+ 			
+		<div id="container" tabindex="0" >
+		
+		</div>
+
+		<div id="footer">
+				<input value="> <type some command here >" style="width:100%;" >
+
+				
+		</div>
 
 
+<!---
+	
+-->
 
 		<script src="../build/three.min.js"></script>
 
@@ -76,6 +82,8 @@ when the controlled domElement ( parent of the canvas) has focus.
 		<script>
 
 	window.onload=function() {
+
+		var footerHeight = 30;
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
@@ -163,15 +171,16 @@ when the controlled domElement ( parent of the canvas) has focus.
 				//
 
 				window.addEventListener( 'resize', onWindowResize, false );
-
+				onWindowResize();
 			}
 
 			function onWindowResize() {
 			
-				camera.aspect = container.clientWidth / container.clientHeight;
+				camera.aspect =  window.innerWidth / ( window.innerHeight - footerHeight);
 				camera.updateProjectionMatrix();
 
-				renderer.setSize( container.clientWidth, container.clientHeight );
+				// renderer.setPosition(0,0);
+				renderer.setSize( window.innerWidth, window.innerHeight- footerHeight )
 
 				controls.handleResize();
 


### PR DESCRIPTION
I would like to propose a fix for THREE.TrackballControls to prevent a annoying side effect with key events.

Imagine that we have a ThreeJS WebGL view that only fits a portion of the HTML page and that the rest of the page contains other html elements such as textarea or input fields.

``` .html
    <div id="container" style="width:100px;height:100px"></div>

    <textarea><textarea>
    <input value='foo'></input>

    <script> ... 

        container = document.getElementById( 'container' );
        camera = new THREE.PerspectiveCamera( 60, container.clientWidth / container.clientHeight, 1, 1000 );

        controls = new THREE.TrackballControls( camera , container);   
        ...
        renderer = new THREE.WebGLRenderer( { antialias: false } );
        renderer.setSize( container.clientWidth, container.clientHeight );


        container.appendChild( renderer.domElement );

        ...

    </script>
```

Imaging that the user gives the focus to the textarea element and then start twiddling the trackball on the 3D view, and presses the "D" or "S" key to activate the pan only or zoom only mode.

In the current version, the key event will not be captured by the TrackballControls event handler and unwanted characters will appear in the input textarea.

 this can be fix this way:
- give the focus artifically to the domElement when the user press the mouse on the 3D view
- install key event handler on the domElement instead of the window object
- stop event propagation and default processing when key event are received.
  
  A sample html file has been provided to demonstrate the issue and check the proposed fix.
