### PR TITLE
Fixed bug where last group in OBJ was not added.

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -418,6 +418,9 @@ THREE.OBJLoader.prototype = {
 
 		}
 
+		// add the last group
+		meshN( undefined, undefined );
+
 		return group;
 
 	}


### PR DESCRIPTION
Previously groups were only added when it reaches the group line, e.g. "g new_group".  This meant the last group in the file was not present.

I'm not sure how you do testing - but below is a simple obj file that demonstrates the problem.  The object will be empty when loading into the editor without the fix.

8<-----------------------
v -50 0 0
v 50 0 0
v 0.0 50 0.0
g single_triangle
f 3 1 2
----------------------->8
