### PR TITLE
Switch build system from Python/Java to pure JavaScript/Node/NPM.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 .project
 utils/npm/node_modules/*
+utils/build/node_modules/*

--- a/utils/build/README.md
+++ b/utils/build/README.md
@@ -1,0 +1,6 @@
+To build three.js:
+
+1. install nodejs (which also includes npm): http://nodejs.org/
+2. run "npm install" from the command line in the directory /three.js/util to install the requires node modules for the build.js script.
+3. run your choice of the various build*.bat or build*.sh files to build three.js
+

--- a/utils/build/build.bat
+++ b/utils/build/build.bat
@@ -1,2 +1,2 @@
-python build.py --include common --include extras --output ../../build/three.js
-python build.py --include common --include extras --minify --output ../../build/three.min.js
+node build.js --include common --include extras --output ../../build/three.js
+node build.js --include common --include extras --minify --output ../../build/three.min.js

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -1,11 +1,22 @@
-var fs = require("fs");
-var path = require("path");
-var argparse =  require( "argparse" );
-var uglify = require("uglify-js2");
-var spawn = require('child_process').spawn;
+var fs, path, argparse, uglify, spawn;
+try {
+    fs = require("fs");
+    path = require("path");
+    argparse =  require( "argparse" );
+    uglify = require("uglify-js2");
+    spawn = require('child_process').spawn;
+}
+catch( e ) {
+    console.log( "!!!" );
+    console.log( "!!! Please run 'npm install' to install dependencies prior to running build.js" );
+    console.log( "!!!" );
+    console.log( e );
+}
 
 function main(){
+
     "use strict";
+    
     var parser = new argparse.ArgumentParser();
     parser.addArgument(['--include'], {"action":'append', 'required':true});
     parser.addArgument(['--externs'], {"action":'append', "defaultValue":['./externs/common.js']});
@@ -48,15 +59,16 @@ function main(){
         });
         
         
-        fs.writeFileSync(output,result.code + sourcemapping,'utf8');
+        fs.writeFileSync(output,'// three.js - http://github.com/mrdoob/three.js\n' + result.code + sourcemapping,'utf8');
         
-
         if (args.sourcemaps){
             fs.writeFileSync(sourcemap,result.map,'utf8');
         }
     
     }
+
 }
+
 main();
 
 

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-python build.py --include common --include extras --output ../../build/three.js
-python build.py --include common --include extras --minify --output ../../build/three.min.js
+node build.js --include common --include extras --output ../../build/three.js
+node build.js --include common --include extras --minify --output ../../build/three.min.js

--- a/utils/build/build.xml
+++ b/utils/build/build.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="THREE.JS" basedir="." default="build">
 	<property name="build_dir" value="./" description="THREE.js build directory" />
-	<property name="build_py" value="${build_dir}/build.py" description="THREE.js 'build.py' file" />
-	<property name="python_dir" value="" description="Python directory, leave empty if in classpath or don't forget ending slash" />
+	<property name="build_js" value="${build_dir}/build.js" description="THREE.js 'build.js' file" />
+	<property name="nodejs_dir" value="" description="Python directory, leave empty if in classpath or don't forget ending slash" />
 
     <target name="build" description="Build all THREE.js">
-    	<exec executable="${python_dir}python">
-    	    <arg value="${build_py}"/>
+    	<exec executable="${nodejs_dir}node">
+    	    <arg value="${build_js}"/>
     	    <arg value="--all"/>
     	  </exec>
     </target>
 	
     <target name="common" description="Build THREE.js commons">
-    	<exec executable="${python_dir}python">
-    	    <arg value="${build_py}"/>
+    	<exec executable="${nodejs_dir}node">
+    	    <arg value="${build_js}"/>
     	    <arg value="--common"/>
     	    <arg value="--includes"/>
     	  </exec>
     </target>
 
 	<target name="debug" description="Build debug THREE.js">
-    	<exec executable="${python_dir}python">
-    	    <arg value="${build_py}"/>
+    	<exec executable="${nodejs_dir}node">
+    	    <arg value="${build_js}"/>
     	    <arg value="--all"/>
     	    <arg value="--debug"/>
     	  </exec>
     </target>
 	
     <target name="minified" description="Build minified THREE.js">
-    	<exec executable="${python_dir}python">
-    	    <arg value="${build_py}"/>
+    	<exec executable="${nodejs_dir}node">
+    	    <arg value="${build_js}"/>
     	    <arg value="--all"/>
     	    <arg value="--minified"/>
     	  </exec>

--- a/utils/build/build2.sh
+++ b/utils/build/build2.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-python build.py --include common2 --include extras --output ../../build/three.js
-python build.py --include common2 --include extras --minify --output ../../build/three.min.js
+node build.js --include common2 --include extras --output ../../build/three.js
+node build.js --include common2 --include extras --minify --output ../../build/three.min.js

--- a/utils/build/build_all.bat
+++ b/utils/build/build_all.bat
@@ -1,8 +1,8 @@
-python build.py --include common --include extras --output ../../build/three.js
-python build.py --include common --include extras --minify --output ../../build/three.min.js
-python build.py --include canvas --minify --output ../../build/three-canvas.min.js
-python build.py --include css3d --minify --output ../../build/three-css3d.min.js
-python build.py --include webgl --minify --output ../../build/three-webgl.min.js
-python build.py --include extras --externs externs/extras.js --minify --output ../../build/three-extras.min.js
-python build.py --include math --output ../../build/three-math.js
-python build.py --include math --minify --output ../../build/three-math.min.js
+node build.js --include common --include extras --output ../../build/three.js
+node build.js --include common --include extras --minify --output ../../build/three.min.js
+node build.js --include canvas --minify --output ../../build/three-canvas.min.js
+node build.js --include css3d --minify --output ../../build/three-css3d.min.js
+node build.js --include webgl --minify --output ../../build/three-webgl.min.js
+node build.js --include extras --externs externs/extras.js --minify --output ../../build/three-extras.min.js
+node build.js --include math --output ../../build/three-math.js
+node build.js --include math --minify --output ../../build/three-math.min.js

--- a/utils/build/build_all.sh
+++ b/utils/build/build_all.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-python build.py --include common --include extras --output ../../build/three.js
-python build.py --include common --include extras --minify --output ../../build/three.min.js
-python build.py --include canvas --minify --output ../../build/three-canvas.min.js
-python build.py --include css3d --minify --output ../../build/three-css3d.min.js
-python build.py --include webgl --minify --output ../../build/three-webgl.min.js
-python build.py --include extras --externs externs/extras.js --minify --output ../../build/three-extras.min.js
-python build.py --include math --output ../../build/three-math.js
+node build.js --include common --include extras --output ../../build/three.js
+node build.js --include common --include extras --minify --output ../../build/three.min.js
+node build.js --include canvas --minify --output ../../build/three-canvas.min.js
+node build.js --include css3d --minify --output ../../build/three-css3d.min.js
+node build.js --include webgl --minify --output ../../build/three-webgl.min.js
+node build.js --include extras --externs externs/extras.js --minify --output ../../build/three-extras.min.js
+node build.js --include math --output ../../build/three-math.js

--- a/utils/build/build_debug.bat
+++ b/utils/build/build_debug.bat
@@ -1,1 +1,1 @@
-python build.py --include common --include extras --output ../../build/three.min.js
+node build.js --include common --include extras --output ../../build/three.min.js

--- a/utils/build/build_debug.sh
+++ b/utils/build/build_debug.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python build.py --include common --include extras --output ../../build/three.min.js
+node build.js --include common --include extras --output ../../build/three.min.js

--- a/utils/build/build_max.bat
+++ b/utils/build/build_max.bat
@@ -1,1 +1,1 @@
-python build.py --include common --include extras --include examples --externs externs/examples.js --minify --output ../../build/three.max.js
+node build.js --include common --include extras --include examples --externs externs/examples.js --minify --output ../../build/three.max.js

--- a/utils/build/package.json
+++ b/utils/build/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "three.js",
-    "description": "JavaScript 3D library",
-    "version": "50dev",
+    "name": "three-util",
+    "description": "Build System for the Three.js JavaScript 3D library",
+    "version": "0.1.1",
     "homepage" : "http://mrdoob.github.com/three.js/",
     "author": "three.js contributors",
     "help": {
@@ -17,8 +17,10 @@
         "type" : "git",
          "url" : "git://github.com/mrdoob/three.js.git"
     },
+
     "licenses": [{
         "type": "The MIT License",
         "url": "https://raw.github.com/mrdoob/three.js/master/LICENSE"
     }]
+    
 }


### PR DESCRIPTION
As per the discussion here:

https://github.com/mrdoob/three.js/commit/9b8db498c8579763bf2dc7eebf4d40f9c891ac85#commitcomment-2471094

I have removed the Python-based build.py and the Java-based Closure compiler. I have also switched all build_._ scripts to call "node build.js" instead of "python build.py."

This unifies Three.js so that both its library and its build system are written in JavaScript.  It does not significant change the results as we were not using the advanced features of the Google Closure Compiler.  See here for size comparison between the Closure Compiler and Uglify2:

https://github.com/mrdoob/three.js/commit/9b8db498c8579763bf2dc7eebf4d40f9c891ac85#commitcomment-2471573

I have modified build.js to give better error messages when "npm install" hasn't been run and I have added a README.md explaining how to get the build system up and running:

https://github.com/bhouston/three.js/blob/c2928a71c3981031ecafa71e8de1eb6e2ad9e62f/utils/README.md

I am okay if this get's rejected, but I do think it is a simplification of the build system.

All examples still run without errors.
