### PR TITLE
add Vector3.projectOnUnit, Vector3.projectOnVector and Vector3.reflect

### DIFF
--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -520,6 +520,42 @@ THREE.extend( THREE.Vector3.prototype, {
 
 	},
 
+
+	project: function( normal ) {
+
+		var cosTheta = this.dot( normal );
+		return this.copy( normal ).multiplyScalar( cosTheta );
+
+	},
+	
+	ortho: function () {
+
+		var v1 = new THREE.Vector3();
+
+		return function( normal ) {
+
+			v1.copy( this ).project( normal );
+
+			return this.sub( v1 );
+
+		}
+
+	}(),
+
+	reflect: function () {
+
+		var v1 = new THREE.Vector3();
+
+		return function ( normal ) {
+
+		    v1.copy( this ).ortho( normal ).multiplyScalar( -2 );
+
+		    return this.add( v1 );
+
+		}
+
+	}(),
+
 	angleTo: function ( v ) {
 
 		return Math.acos( this.dot( v ) / this.length() / v.length() );

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -523,8 +523,8 @@ THREE.extend( THREE.Vector3.prototype, {
 
 	project: function( normal ) {
 
-		var cosTheta = this.dot( normal );
-		return this.copy( normal ).multiplyScalar( cosTheta );
+		var d = this.dot( normal );
+		return this.copy( normal ).multiplyScalar( d );
 
 	},
 	

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -520,35 +520,20 @@ THREE.extend( THREE.Vector3.prototype, {
 
 	},
 
+	projectOn: function( unitNormal ) {
 
-	projectOn: function( normal ) {
-
-		var d = this.dot( normal );
-		return this.copy( normal ).multiplyScalar( d );
+		var d = this.dot( unitNormal );
+		return this.copy( unitNormal ).multiplyScalar( d );
 
 	},
-	
-	orthoTo: function () {
-
-		var v1 = new THREE.Vector3();
-
-		return function( normal ) {
-
-			v1.copy( this ).projectOn( normal );
-
-			return this.sub( v1 );
-
-		}
-
-	}(),
 
 	reflect: function () {
 
 		var v1 = new THREE.Vector3();
 
-		return function ( normal ) {
+		return function ( unitNormal ) {
 
-		    v1.copy( this ).projectOn( normal ).multiplyScalar( 2 );
+		    v1.copy( this ).projectOn( unitNormal ).multiplyScalar( 2 );
 
 		    return this.subVectors( v1, this );
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -520,13 +520,6 @@ THREE.extend( THREE.Vector3.prototype, {
 
 	},
 
-	projectOnUnit: function( unitNormal ) {
-
-		var d = this.dot( unitNormal );
-		return this.copy( unitNormal ).multiplyScalar( d );
-
-	},
-
 	projectOnVector: function () {
 
 		var v1 = new THREE.Vector3();
@@ -534,9 +527,24 @@ THREE.extend( THREE.Vector3.prototype, {
 		return function( vector ) {
 
 			v1.copy( vector ).normalize();
-			return this.projectOnUnit( v1 );
+			var d = this.dot( v1 );
+			return this.copy( v1 ).multiplyScalar( d );
 
 		};
+
+	}(),
+
+	projectOnPlane: function () {
+
+		var v1 = new THREE.Vector3();
+
+		return function( planeNormal ) {
+
+			v1.copy( this ).projectOnVector( planeNormal );
+
+			return this.sub( v1 );
+
+		}
 
 	}(),
 
@@ -544,9 +552,9 @@ THREE.extend( THREE.Vector3.prototype, {
 
 		var v1 = new THREE.Vector3();
 
-		return function ( unitNormal ) {
+		return function ( vector ) {
 
-		    v1.copy( this ).projectOnUnit( unitNormal ).multiplyScalar( 2 );
+		    v1.copy( this ).projectOnVector( vector ).multiplyScalar( 2 );
 
 		    return this.subVectors( v1, this );
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -521,20 +521,20 @@ THREE.extend( THREE.Vector3.prototype, {
 	},
 
 
-	project: function( normal ) {
+	projectOn: function( normal ) {
 
 		var d = this.dot( normal );
 		return this.copy( normal ).multiplyScalar( d );
 
 	},
 	
-	ortho: function () {
+	orthoTo: function () {
 
 		var v1 = new THREE.Vector3();
 
 		return function( normal ) {
 
-			v1.copy( this ).project( normal );
+			v1.copy( this ).projectOn( normal );
 
 			return this.sub( v1 );
 
@@ -548,7 +548,7 @@ THREE.extend( THREE.Vector3.prototype, {
 
 		return function ( normal ) {
 
-		    v1.copy( this ).project( normal ).multiplyScalar( 2 );
+		    v1.copy( this ).projectOn( normal ).multiplyScalar( 2 );
 
 		    return this.subVectors( v1, this );
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -548,9 +548,9 @@ THREE.extend( THREE.Vector3.prototype, {
 
 		return function ( normal ) {
 
-		    v1.copy( this ).ortho( normal ).multiplyScalar( -2 );
+		    v1.copy( this ).project( normal ).multiplyScalar( 2 );
 
-		    return this.add( v1 );
+		    return this.subVectors( v1, this );
 
 		}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -520,12 +520,25 @@ THREE.extend( THREE.Vector3.prototype, {
 
 	},
 
-	projectOn: function( unitNormal ) {
+	projectOnUnit: function( unitNormal ) {
 
 		var d = this.dot( unitNormal );
 		return this.copy( unitNormal ).multiplyScalar( d );
 
 	},
+
+	projectOnVector: function () {
+
+		var v1 = new THREE.Vector3();
+
+		return function( vector ) {
+
+			v1.copy( vector ).normalize();
+			return this.projectOnUnit( v1 );
+
+		};
+
+	}(),
 
 	reflect: function () {
 
@@ -533,7 +546,7 @@ THREE.extend( THREE.Vector3.prototype, {
 
 		return function ( unitNormal ) {
 
-		    v1.copy( this ).projectOn( unitNormal ).multiplyScalar( 2 );
+		    v1.copy( this ).projectOnUnit( unitNormal ).multiplyScalar( 2 );
 
 		    return this.subVectors( v1, this );
 

--- a/test/unit/math/Vector3.js
+++ b/test/unit/math/Vector3.js
@@ -257,24 +257,6 @@ test( "projectOn", function() {
 
 });
 
-test( "orthoTo", function() {
-	var a = new THREE.Vector3( 1, 0, 0 );
-	var b = new THREE.Vector3();
-	var normal = new THREE.Vector3( 1, 0, 0 );
-
-	ok( b.copy( a ).orthoTo( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
-
-	a.set( 0, 1, 0 );
-	ok( b.copy( a ).orthoTo( normal ).equals( new THREE.Vector3( 0, 1, 0 ) ), "Passed!" );
-
-	a.set( 0, 0, -1 );
-	ok( b.copy( a ).orthoTo( normal ).equals( new THREE.Vector3( 0, 0, -1 ) ), "Passed!" );
-
-	a.set( -1, 0, 0 );
-	ok( b.copy( a ).orthoTo( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
-
-});
-
 test( "reflect", function() {
 	var a = new THREE.Vector3( 1, 0, 0 );
 	var normal = new THREE.Vector3( 1, 0, 0 );

--- a/test/unit/math/Vector3.js
+++ b/test/unit/math/Vector3.js
@@ -239,21 +239,21 @@ test( "setLength", function() {
 
 });
 
-test( "projectOn", function() {
+test( "projectOnUnit", function() {
 	var a = new THREE.Vector3( 1, 0, 0 );
 	var b = new THREE.Vector3();
 	var normal = new THREE.Vector3( 1, 0, 0 );
 
-	ok( b.copy( a ).projectOn( normal ).equals( new THREE.Vector3( 1, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOnUnit( normal ).equals( new THREE.Vector3( 1, 0, 0 ) ), "Passed!" );
 
 	a.set( 0, 1, 0 );
-	ok( b.copy( a ).projectOn( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOnUnit( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 
 	a.set( 0, 0, -1 );
-	ok( b.copy( a ).projectOn( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOnUnit( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 
 	a.set( -1, 0, 0 );
-	ok( b.copy( a ).projectOn( normal ).equals( new THREE.Vector3( -1, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOnUnit( normal ).equals( new THREE.Vector3( -1, 0, 0 ) ), "Passed!" );
 
 });
 

--- a/test/unit/math/Vector3.js
+++ b/test/unit/math/Vector3.js
@@ -239,39 +239,39 @@ test( "setLength", function() {
 
 });
 
-test( "project", function() {
+test( "projectOn", function() {
 	var a = new THREE.Vector3( 1, 0, 0 );
 	var b = new THREE.Vector3();
 	var normal = new THREE.Vector3( 1, 0, 0 );
 
-	ok( b.copy( a ).project( normal ).equals( new THREE.Vector3( 1, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOn( normal ).equals( new THREE.Vector3( 1, 0, 0 ) ), "Passed!" );
 
 	a.set( 0, 1, 0 );
-	ok( b.copy( a ).project( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOn( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 
 	a.set( 0, 0, -1 );
-	ok( b.copy( a ).project( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOn( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 
 	a.set( -1, 0, 0 );
-	ok( b.copy( a ).project( normal ).equals( new THREE.Vector3( -1, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOn( normal ).equals( new THREE.Vector3( -1, 0, 0 ) ), "Passed!" );
 
 });
 
-test( "ortho", function() {
+test( "orthoTo", function() {
 	var a = new THREE.Vector3( 1, 0, 0 );
 	var b = new THREE.Vector3();
 	var normal = new THREE.Vector3( 1, 0, 0 );
 
-	ok( b.copy( a ).ortho( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).orthoTo( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 
 	a.set( 0, 1, 0 );
-	ok( b.copy( a ).ortho( normal ).equals( new THREE.Vector3( 0, 1, 0 ) ), "Passed!" );
+	ok( b.copy( a ).orthoTo( normal ).equals( new THREE.Vector3( 0, 1, 0 ) ), "Passed!" );
 
 	a.set( 0, 0, -1 );
-	ok( b.copy( a ).ortho( normal ).equals( new THREE.Vector3( 0, 0, -1 ) ), "Passed!" );
+	ok( b.copy( a ).orthoTo( normal ).equals( new THREE.Vector3( 0, 0, -1 ) ), "Passed!" );
 
 	a.set( -1, 0, 0 );
-	ok( b.copy( a ).ortho( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).orthoTo( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 
 });
 

--- a/test/unit/math/Vector3.js
+++ b/test/unit/math/Vector3.js
@@ -239,6 +239,57 @@ test( "setLength", function() {
 
 });
 
+test( "project", function() {
+	var a = new THREE.Vector3( 1, 0, 0 );
+	var b = new THREE.Vector3();
+	var normal = new THREE.Vector3( 1, 0, 0 );
+
+	ok( b.copy( a ).project( normal ).equals( new THREE.Vector3( 1, 0, 0 ) ), "Passed!" );
+
+	a.set( 0, 1, 0 );
+	ok( b.copy( a ).project( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+
+	a.set( 0, 0, -1 );
+	ok( b.copy( a ).project( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+
+	a.set( -1, 0, 0 );
+	ok( b.copy( a ).project( normal ).equals( new THREE.Vector3( -1, 0, 0 ) ), "Passed!" );
+
+});
+
+test( "ortho", function() {
+	var a = new THREE.Vector3( 1, 0, 0 );
+	var b = new THREE.Vector3();
+	var normal = new THREE.Vector3( 1, 0, 0 );
+
+	ok( b.copy( a ).ortho( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+
+	a.set( 0, 1, 0 );
+	ok( b.copy( a ).ortho( normal ).equals( new THREE.Vector3( 0, 1, 0 ) ), "Passed!" );
+
+	a.set( 0, 0, -1 );
+	ok( b.copy( a ).ortho( normal ).equals( new THREE.Vector3( 0, 0, -1 ) ), "Passed!" );
+
+	a.set( -1, 0, 0 );
+	ok( b.copy( a ).ortho( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+
+});
+
+test( "reflect", function() {
+	var a = new THREE.Vector3( 1, 0, 0 );
+	var normal = new THREE.Vector3( 1, 0, 0 );
+	var b = new THREE.Vector3( 0, 0, 0 );
+
+	ok( b.copy( a ).reflect( normal ).equals( new THREE.Vector3( 1, 0, 0 ) ), "Passed!" );
+
+	a.set( 1, -1, 0 );
+	ok( b.copy( a ).reflect( normal ).equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
+
+	a.set( 1, -1, 0 );
+	normal.set( 0, -1, 0 )
+	ok( b.copy( a ).reflect(  normal ).equals( new THREE.Vector3( -1, -1, 0 ) ), "Passed!" );
+});
+
 test( "lerp/clone", function() {
 	var a = new THREE.Vector3( x, 0, z );
 	var b = new THREE.Vector3( 0, -y, 0 );

--- a/test/unit/math/Vector3.js
+++ b/test/unit/math/Vector3.js
@@ -239,21 +239,39 @@ test( "setLength", function() {
 
 });
 
-test( "projectOnUnit", function() {
+test( "projectOnVector", function() {
+	var a = new THREE.Vector3( 1, 0, 0 );
+	var b = new THREE.Vector3();
+	var normal = new THREE.Vector3( 10, 0, 0 );
+
+	ok( b.copy( a ).projectOnVector( normal ).equals( new THREE.Vector3( 1, 0, 0 ) ), "Passed!" );
+
+	a.set( 0, 1, 0 );
+	ok( b.copy( a ).projectOnVector( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+
+	a.set( 0, 0, -1 );
+	ok( b.copy( a ).projectOnVector( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+
+	a.set( -1, 0, 0 );
+	ok( b.copy( a ).projectOnVector( normal ).equals( new THREE.Vector3( -1, 0, 0 ) ), "Passed!" );
+
+});
+
+test( "projectOnPlane", function() {
 	var a = new THREE.Vector3( 1, 0, 0 );
 	var b = new THREE.Vector3();
 	var normal = new THREE.Vector3( 1, 0, 0 );
 
-	ok( b.copy( a ).projectOnUnit( normal ).equals( new THREE.Vector3( 1, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOnPlane( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 
 	a.set( 0, 1, 0 );
-	ok( b.copy( a ).projectOnUnit( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOnPlane( normal ).equals( new THREE.Vector3( 0, 1, 0 ) ), "Passed!" );
 
 	a.set( 0, 0, -1 );
-	ok( b.copy( a ).projectOnUnit( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOnPlane( normal ).equals( new THREE.Vector3( 0, 0, -1 ) ), "Passed!" );
 
 	a.set( -1, 0, 0 );
-	ok( b.copy( a ).projectOnUnit( normal ).equals( new THREE.Vector3( -1, 0, 0 ) ), "Passed!" );
+	ok( b.copy( a ).projectOnPlane( normal ).equals( new THREE.Vector3( 0, 0, 0 ) ), "Passed!" );
 
 });
 


### PR DESCRIPTION
Updated based on discussion below.

Based on the request here #3009 for a Vector3.reflect function, I have added 3 related functions:

`Vector3.projectOnUnit( unitNormal )`, projects the current vector onto the normal based on the theory outlined here: http://en.wikipedia.org/wiki/Vector_projection

`Vector3.projectOnVector( vector )`, projects the current vector onto the vector  based on the theory outlined here: http://en.wikipedia.org/wiki/Vector_projection

`Vector3.reflect( unitNormal )` reflects the current vector given the current implied plane normal.  It utilises ortho() above.

Wrote a bunch of unit tests and they all pass.
