### PR TITLE
Extend simplification + EMCAScript5 compatibility

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -48,19 +48,9 @@ String.prototype.trim = String.prototype.trim || function () {
 // based on http://stackoverflow.com/a/12317051
 THREE.extend = function ( target, other ) {
 
-	target = target || {};
-
 	for (var prop in other) {
 
-		if ( typeof other[prop] === 'object' ) {
-
-			target[prop] = THREE.extend( target[prop], other[prop] );
-
-		} else {
-
-			target[prop] = other[prop];
-
-		}
+		target[prop] = other[prop];
 
 	}
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -45,16 +45,16 @@ String.prototype.trim = String.prototype.trim || function () {
 
 };
 
-// based on http://stackoverflow.com/a/12317051
-THREE.extend = function ( target, other ) {
+// based on https://github.com/documentcloud/underscore/blob/bf657be243a075b5e72acc8a83e6f12a564d8f55/underscore.js#L767
+THREE.extend = function ( obj, source ) {
 
-	for (var prop in other) {
+	for (var prop in source) {
 
-		target[prop] = other[prop];
+		obj[prop] = source[prop];
 
 	}
 
-	return target;
+	return obj;
 
 };
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -51,18 +51,23 @@ THREE.extend = function ( obj, source ) {
 	// ECMAScript5 compatibility based on: http://www.nczonline.net/blog/2012/12/11/are-your-mixins-ecmascript-5-compatible/
 	if ( Object.keys ) {
 
-        Object.keys( source ).forEach( 
-			function ( prop ) {
-					Object.defineProperty( obj, prop, Object.getOwnPropertyDescriptor( source, prop ) );
-				}
-			);
+		var keys = Object.keys( source );
+
+		for (var i = 0, il = keys.length; i < il; i++) {
+
+			var prop = keys[i];
+			Object.defineProperty( obj, prop, Object.getOwnPropertyDescriptor( source, prop ) );
+
+		}
 
     }
     else {
 
+		var safeHasOwnProperty = {}.hasOwnProperty;
+
 		for ( var prop in source ) {
 
-			if ( source.hasOwnProperty( prop ) ) {
+			if ( safeHasOwnProperty.call( source, prop ) ) {
 
 				obj[prop] = source[prop];
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -48,9 +48,27 @@ String.prototype.trim = String.prototype.trim || function () {
 // based on https://github.com/documentcloud/underscore/blob/bf657be243a075b5e72acc8a83e6f12a564d8f55/underscore.js#L767
 THREE.extend = function ( obj, source ) {
 
-	for (var prop in source) {
+	// ECMAScript5 compatibility based on: http://www.nczonline.net/blog/2012/12/11/are-your-mixins-ecmascript-5-compatible/
+	if ( Object.keys ) {
 
-		obj[prop] = source[prop];
+        Object.keys( source ).forEach( 
+			function ( prop ) {
+					Object.defineProperty( obj, prop, Object.getOwnPropertyDescriptor( source, prop ) );
+				}
+			);
+
+    }
+    else {
+
+		for ( var prop in source ) {
+
+			if ( source.hasOwnProperty( prop ) ) {
+
+				obj[prop] = source[prop];
+
+            }
+
+		}
 
 	}
 


### PR DESCRIPTION
This PR contains these changes to THREE.extend:
- EMCAScrip5 compatibility in response to this comment from @gero3: https://github.com/mrdoob/three.js/pull/2947#issuecomment-12501828
- Only new properties defined are copied across via checking hasOwnProperty().
- This is no longer hierarchical/recursive as that paradigm is very rarely used anywhere, and it isn't used at all in Three.js.

Examples and unit tests still work.
