### PR TITLE
Deprecate Matrix4.getPosition() and replace all usages in core lib.

### DIFF
--- a/examples/js/renderers/WebGLDeferredRenderer.js
+++ b/examples/js/renderers/WebGLDeferredRenderer.js
@@ -40,6 +40,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	var positionVS = new THREE.Vector3();
 	var directionVS = new THREE.Vector3();
+	var tempVS = new THREE.Vector3();
 
 	var rightVS = new THREE.Vector3();
 	var normalVS = new THREE.Vector3();
@@ -330,12 +331,12 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 			lightProxy.scale.set( 1, 1, 1 ).multiplyScalar( distance );
 			uniforms[ "lightRadius" ].value = distance;
 
-			positionVS.copy( light.matrixWorld.getPosition() );
+			positionVS.getPositionFromMatrix( light.matrixWorld );
 			positionVS.applyMatrix4( camera.matrixWorldInverse );
 
 			uniforms[ "lightPositionVS" ].value.copy( positionVS );
 
-			lightProxy.position.copy( light.matrixWorld.getPosition() );
+			lightProxy.position.getPositionFromMatrix( light.matrixWorld );
 
 		} else {
 
@@ -422,11 +423,12 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		var viewMatrix = camera.matrixWorldInverse;
 		var modelMatrix = light.matrixWorld;
 
-		positionVS.copy( modelMatrix.getPosition() );
+		positionVS.getPositionFromMatrix( modelMatrix );
 		positionVS.applyMatrix4( viewMatrix );
 
-		directionVS.copy( modelMatrix.getPosition() );
-		directionVS.sub( light.target.matrixWorld.getPosition() );
+		directionVS.getPositionFromMatrix( modelMatrix );
+		tempVS.getPositionFromMatrix( light.target.matrixWorld );
+		directionVS.sub( tempVS );
 		directionVS.normalize();
 		viewMatrix.rotateAxis( directionVS );
 
@@ -495,8 +497,9 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		var light = lightProxy.properties.originalLight;
 		var uniforms = lightProxy.material.uniforms;
 
-		directionVS.copy( light.matrixWorld.getPosition() );
-		directionVS.sub( light.target.matrixWorld.getPosition() );
+		directionVS.getPositionFromMatrix( light.matrixWorld );
+		tempVS.getPositionFromMatrix( light.target.matrixWorld );
+		directionVS.sub( tempVS );
 		directionVS.normalize();
 		camera.matrixWorldInverse.rotateAxis( directionVS );
 
@@ -561,7 +564,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		var light = lightProxy.properties.originalLight;
 		var uniforms = lightProxy.material.uniforms;
 
-		directionVS.copy( light.matrixWorld.getPosition() );
+		directionVS.getPositionFromMatrix( light.matrixWorld );
 		directionVS.normalize();
 		camera.matrixWorldInverse.rotateAxis( directionVS );
 
@@ -630,7 +633,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		var modelMatrix = light.matrixWorld;
 		var viewMatrix = camera.matrixWorldInverse;
 
-		positionVS.copy( modelMatrix.getPosition() );
+		positionVS.getPositionFromMatrix( modelMatrix );
 		positionVS.applyMatrix4( viewMatrix );
 
 		uniforms[ "lightPositionVS" ].value.copy( positionVS );

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -25,6 +25,7 @@
 	var localRay = new THREE.Ray();
 	var facePlane = new THREE.Plane();
 	var intersectPoint = new THREE.Vector3();
+	var matrixPosition = new THREE.Vector3();
 
 	var inverseMatrix = new THREE.Matrix4();
 
@@ -38,7 +39,8 @@
 
 		if ( object instanceof THREE.Particle ) {
 
-			var distance = raycaster.ray.distanceToPoint( object.matrixWorld.getPosition() );
+			matrixPosition.getPositionFromMatrix( object.matrixWorld );
+			var distance = raycaster.ray.distanceToPoint( matrixPosition );
 
 			if ( distance > object.scale.x ) {
 
@@ -58,8 +60,9 @@
 		} else if ( object instanceof THREE.Mesh ) {
 
 			// Checking boundingSphere distance to ray
+			matrixPosition.getPositionFromMatrix( object.matrixWorld );
 			sphere.set(
-				object.matrixWorld.getPosition(),
+				matrixPosition,
 				object.geometry.boundingSphere.radius * object.matrixWorld.getMaxScaleOnAxis() );
 
 			if ( ! raycaster.ray.isIntersectionSphere( sphere ) ) {

--- a/src/extras/renderers/plugins/ShadowMapPlugin.js
+++ b/src/extras/renderers/plugins/ShadowMapPlugin.js
@@ -12,7 +12,9 @@ THREE.ShadowMapPlugin = function () {
 	_projScreenMatrix = new THREE.Matrix4(),
 
 	_min = new THREE.Vector3(),
-	_max = new THREE.Vector3();
+	_max = new THREE.Vector3(),
+
+	_matrixPosition = new THREE.Vector3();
 
 	this.init = function ( renderer ) {
 
@@ -197,7 +199,8 @@ THREE.ShadowMapPlugin = function () {
 			shadowCamera = light.shadowCamera;
 
 			shadowCamera.position.getPositionFromMatrix( light.matrixWorld );
-			shadowCamera.lookAt( light.target.matrixWorld.getPosition() );
+			_matrixPosition.getPositionFromMatrix( light.target.matrixWorld );
+			shadowCamera.lookAt( _matrixPosition );
 			shadowCamera.updateMatrixWorld();
 
 			shadowCamera.matrixWorldInverse.getInverse( shadowCamera.matrixWorld );

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -512,6 +512,8 @@ THREE.extend( THREE.Matrix4.prototype, {
 
 		return function () {
 
+			console.warn( 'DEPRECATED: Matrix4\'s .getPosition() has been removed. Use Vector3.getPositionFromMatrix( matrix ) instead.' );
+
 			var te = this.elements;
 			return v1.set( te[12], te[13], te[14] );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4177,7 +4177,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 						} else {
 
-							_vector3.copy( object.matrixWorld.getPosition() );
+							_vector3.getPositionFromMatrix( object.matrixWorld );
 							_vector3.applyProjection( _projScreenMatrix );
 
 							webglObject.z = _vector3.z;
@@ -5387,8 +5387,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( p_uniforms.cameraPosition !== null ) {
 
-					var position = camera.matrixWorld.getPosition();
-					_gl.uniform3f( p_uniforms.cameraPosition, position.x, position.y, position.z );
+					_vector3.getPositionFromMatrix( camera.matrixWorld );
+					_gl.uniform3f( p_uniforms.cameraPosition, _vector3.x, _vector3.y, _vector3.z );
 
 				}
 
@@ -5989,8 +5989,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( ! light.visible ) continue;
 
-				_direction.copy( light.matrixWorld.getPosition() );
-				_direction.sub( light.target.matrixWorld.getPosition() );
+				_direction.getPositionFromMatrix( light.matrixWorld );
+				_vector3.getPositionFromMatrix( light.target.matrixWorld );
+				_direction.sub( _vector3 );
 				_direction.normalize();
 
 				// skip lights with undefined direction
@@ -6034,7 +6035,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				position = light.matrixWorld.getPosition();
+				position = _vector3;
+				position.getPositionFromMatrix( light.matrixWorld );
 
 				pointPositions[ pointOffset ]     = position.x;
 				pointPositions[ pointOffset + 1 ] = position.y;
@@ -6062,7 +6064,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				position = light.matrixWorld.getPosition();
+				position = _vector3;
+				position.getPositionFromMatrix( light.matrixWorld );
 
 				spotPositions[ spotOffset ]     = position.x;
 				spotPositions[ spotOffset + 1 ] = position.y;
@@ -6071,7 +6074,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 				spotDistances[ spotLength ] = distance;
 
 				_direction.copy( position );
-				_direction.sub( light.target.matrixWorld.getPosition() );
+				_vector3.getPositionFromMatrix( light.target.matrixWorld );
+				_direction.sub( _vector3 );
 				_direction.normalize();
 
 				spotDirections[ spotOffset ]     = _direction.x;
@@ -6089,7 +6093,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( ! light.visible ) continue;
 
-				_direction.copy( light.matrixWorld.getPosition() );
+				_direction.getPositionFromMatrix( light.matrixWorld );
 				_direction.normalize();
 
 				// skip lights with undefined direction

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -6035,12 +6035,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				position = _vector3;
-				position.getPositionFromMatrix( light.matrixWorld );
+				_vector3.getPositionFromMatrix( light.matrixWorld );
 
-				pointPositions[ pointOffset ]     = position.x;
-				pointPositions[ pointOffset + 1 ] = position.y;
-				pointPositions[ pointOffset + 2 ] = position.z;
+				pointPositions[ pointOffset ]     = _vector3.x;
+				pointPositions[ pointOffset + 1 ] = _vector3.y;
+				pointPositions[ pointOffset + 2 ] = _vector3.z;
 
 				pointDistances[ pointLength ] = distance;
 
@@ -6064,16 +6063,15 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				position = _vector3;
-				position.getPositionFromMatrix( light.matrixWorld );
+				_vector3.getPositionFromMatrix( light.matrixWorld );
 
-				spotPositions[ spotOffset ]     = position.x;
-				spotPositions[ spotOffset + 1 ] = position.y;
-				spotPositions[ spotOffset + 2 ] = position.z;
+				spotPositions[ spotOffset ]     = _vector3.x;
+				spotPositions[ spotOffset + 1 ] = _vector3.y;
+				spotPositions[ spotOffset + 2 ] = _vector3.z;
 
 				spotDistances[ spotLength ] = distance;
 
-				_direction.copy( position );
+				_direction.copy( _vector3 );
 				_vector3.getPositionFromMatrix( light.target.matrixWorld );
 				_direction.sub( _vector3 );
 				_direction.normalize();

--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -2507,9 +2507,8 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 				if ( p_uniforms.cameraPosition !== null ) {
 
-					var position = _vector3;
-					position.getPositionFromMatrix( camera.matrixWorld );
-					renderer.uniform3f( p_uniforms.cameraPosition, position.x, position.y, position.z );
+					_vector3.getPositionFromMatrix( camera.matrixWorld );
+					renderer.uniform3f( p_uniforms.cameraPosition, _vector3.x, _vector3.y, _vector3.z );
 
 				}
 
@@ -3156,12 +3155,11 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 				}
 
-				position = _vector3;
-				position.getPositionFromMatrix( light.matrixWorld );
+				_vector3.getPositionFromMatrix( light.matrixWorld );
 
-				pointPositions[ pointOffset ]     = position.x;
-				pointPositions[ pointOffset + 1 ] = position.y;
-				pointPositions[ pointOffset + 2 ] = position.z;
+				pointPositions[ pointOffset ]     = _vector3.x;
+				pointPositions[ pointOffset + 1 ] = _vector3.y;
+				pointPositions[ pointOffset + 2 ] = _vector3.z;
 
 				pointDistances[ pointLength ] = distance;
 
@@ -3185,16 +3183,15 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 				}
 
-				position = _vector3;
-				position.getPositionFromMatrix( light.matrixWorld );
+				_vector3.getPositionFromMatrix( light.matrixWorld );
 
-				spotPositions[ spotOffset ]     = position.x;
-				spotPositions[ spotOffset + 1 ] = position.y;
-				spotPositions[ spotOffset + 2 ] = position.z;
+				spotPositions[ spotOffset ]     = _vector3.x;
+				spotPositions[ spotOffset + 1 ] = _vector3.y;
+				spotPositions[ spotOffset + 2 ] = _vector3.z;
 
 				spotDistances[ spotLength ] = distance;
 
-				_direction.copy( position );
+				_direction.copy( _vector3 );
 				_vector3.getPositionFromMatrix( light.target.matrixWorld );
 				_direction.sub( _vector3 );
 				_direction.normalize();

--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -1304,7 +1304,7 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 						} else {
 
-							_vector3.copy( object.matrixWorld.getPosition() );
+							_vector3.getPositionFromMatrix( object.matrixWorld );
 							_vector3.applyProjection(_projScreenMatrix);
 
 							webglObject.z = _vector3.z;
@@ -2507,7 +2507,8 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 				if ( p_uniforms.cameraPosition !== null ) {
 
-					var position = camera.matrixWorld.getPosition();
+					var position = _vector3;
+					position.getPositionFromMatrix( camera.matrixWorld );
 					renderer.uniform3f( p_uniforms.cameraPosition, position.x, position.y, position.z );
 
 				}
@@ -3109,8 +3110,9 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 				if ( ! light.visible ) continue;
 
-				_direction.copy( light.matrixWorld.getPosition() );
-				_direction.sub( light.target.matrixWorld.getPosition() );
+				_direction.getPositionFromMatrix( light.matrixWorld );
+				_vector3.getPositionFromMatrix( light.target.matrixWorld );					
+				_direction.sub( _vector3 );
 				_direction.normalize();
 
 				// skip lights with undefined direction
@@ -3154,7 +3156,8 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 				}
 
-				position = light.matrixWorld.getPosition();
+				position = _vector3;
+				position.getPositionFromMatrix( light.matrixWorld );
 
 				pointPositions[ pointOffset ]     = position.x;
 				pointPositions[ pointOffset + 1 ] = position.y;
@@ -3182,7 +3185,8 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 				}
 
-				position = light.matrixWorld.getPosition();
+				position = _vector3;
+				position.getPositionFromMatrix( light.matrixWorld );
 
 				spotPositions[ spotOffset ]     = position.x;
 				spotPositions[ spotOffset + 1 ] = position.y;
@@ -3191,7 +3195,8 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 				spotDistances[ spotLength ] = distance;
 
 				_direction.copy( position );
-				_direction.sub( light.target.matrixWorld.getPosition() );
+				_vector3.getPositionFromMatrix( light.target.matrixWorld );
+				_direction.sub( _vector3 );
 				_direction.normalize();
 
 				spotDirections[ spotOffset ]     = _direction.x;
@@ -3209,7 +3214,7 @@ THREE.WebGLRenderer = THREE.WebGLRenderer2 = function ( parameters ) {
 
 				if ( ! light.visible ) continue;
 
-				_direction.copy( light.matrixWorld.getPosition() );
+				_direction.getPositionFromMatrix( light.matrixWorld );
 				_direction.normalize();
 
 				// skip lights with undefined direction


### PR DESCRIPTION
I saw this bug from @WestLangley:

https://github.com/mrdoob/three.js/issues/2967

In response I decided to do the work to fully deprecate Matrix4.getPosition() by removing it from usage and also adding a proper deprecated log message.

@WestLangley, can you verify I didn't make any mistakes while implemented your feature request?
