### PR TITLE
Fixed editor drag/drop import files in Chrome and Firefox (#3028)

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -155,14 +155,14 @@
 			sidebar.setBottom( '0px' );
 			document.body.appendChild( sidebar.dom );
 
-            document.addEventListener( 'dragover', function ( event ) {
+			document.addEventListener( 'dragover', function ( event ) {
             
-                event.stopPropagation();
-                event.preventDefault();
+				event.stopPropagation();
+				event.preventDefault();
                 
-                event.dataTransfer.dropEffect = 'copy';
+				event.dataTransfer.dropEffect = 'copy';
             
-            }, false );
+			}, false );
 
 			document.addEventListener( 'drop', function ( event ) {
 
@@ -179,7 +179,7 @@
 
 			}, false );
 
-            var addFileObject = function ( data, filename ) {
+			var addFileObject = function ( data, filename ) {
             
 				if ( data.metadata === undefined ) { // 2.0
 
@@ -429,7 +429,7 @@
 
 				}
 
-			}
+			};
 
 			// create default scene
 

--- a/editor/index.html
+++ b/editor/index.html
@@ -166,7 +166,7 @@
 
 			document.addEventListener( 'drop', function ( event ) {
 
-                event.stopPropagation();
+				event.stopPropagation();
 				event.preventDefault();
 
 				var file = event.dataTransfer.files[ 0 ];

--- a/editor/index.html
+++ b/editor/index.html
@@ -313,7 +313,7 @@
 								worker.onmessage = function ( event ) {
 
 									event.data.metadata = { 'format': 2 };
-                                    addFileObject( event.data, filename );
+									addFileObject( event.data, filename );
 
 								};
 

--- a/editor/index.html
+++ b/editor/index.html
@@ -155,8 +155,18 @@
 			sidebar.setBottom( '0px' );
 			document.body.appendChild( sidebar.dom );
 
+            document.addEventListener( 'dragover', function ( event ) {
+            
+                event.stopPropagation();
+                event.preventDefault();
+                
+                event.dataTransfer.dropEffect = 'copy';
+            
+            }, false );
+
 			document.addEventListener( 'drop', function ( event ) {
 
+                event.stopPropagation();
 				event.preventDefault();
 
 				var file = event.dataTransfer.files[ 0 ];
@@ -168,6 +178,62 @@
 				parseFile( file, filename, extension );
 
 			}, false );
+
+            var addFileObject = function ( data, filename ) {
+            
+				if ( data.metadata === undefined ) { // 2.0
+
+					data.metadata = { type: 'geometry' };
+
+				}
+
+				if ( data.metadata.type === undefined ) { // 3.0
+
+					data.metadata.type = 'geometry';
+
+				}
+
+				if ( data.metadata.type === 'geometry' ) {
+
+					var loader = new THREE.JSONLoader();
+
+					loader.createModel( data, function ( geometry ) {
+
+						geometry.sourceType = "ascii";
+						geometry.sourceFile = filename;
+
+						var mesh = new THREE.Mesh( geometry, createDummyMaterial() );
+						mesh.name = filename;
+
+						signals.objectAdded.dispatch( mesh );
+						signals.objectSelected.dispatch( mesh );
+
+					} );
+
+				} else if ( data.metadata.type === 'scene' ) {
+
+					new THREE.SceneLoader().parse( data, function ( result ) {
+
+						result.scene.name = filename;
+
+						var resetScene = true;
+
+						if ( resetScene ) {
+
+							signals.sceneAdded.dispatch( result.scene, result.currentCamera );
+
+						} else {
+
+							signals.objectAdded.dispatch( result.scene );
+							signals.objectSelected.dispatch( result.scene );
+
+						}
+
+					}, '' );
+
+				}
+            
+            };
 
 			var parseFile = function ( file, filename, extension ) {
 
@@ -247,7 +313,7 @@
 								worker.onmessage = function ( event ) {
 
 									event.data.metadata = { 'format': 2 };
-									parseFile( JSON.stringify( event.data ), extension );
+                                    addFileObject( event.data, filename );
 
 								};
 
@@ -269,58 +335,8 @@
 								return;
 
 							}
-
-							if ( data.metadata === undefined ) { // 2.0
-
-								data.metadata = { type: 'geometry' };
-
-							}
-
-							if ( data.metadata.type === undefined ) { // 3.0
-
-								data.metadata.type = 'geometry';
-
-							}
-
-							if ( data.metadata.type === 'geometry' ) {
-
-								var loader = new THREE.JSONLoader();
-
-								loader.createModel( data, function ( geometry ) {
-
-									geometry.sourceType = "ascii";
-									geometry.sourceFile = file.name;
-
-									var mesh = new THREE.Mesh( geometry, createDummyMaterial() );
-									mesh.name = filename;
-
-									signals.objectAdded.dispatch( mesh );
-									signals.objectSelected.dispatch( mesh );
-
-								} );
-
-							} else if ( data.metadata.type === 'scene' ) {
-
-								new THREE.SceneLoader().parse( data, function ( result ) {
-
-									result.scene.name = filename;
-
-									var resetScene = true;
-
-									if ( resetScene ) {
-
-										signals.sceneAdded.dispatch( result.scene, result.currentCamera );
-
-									} else {
-
-										signals.objectAdded.dispatch( result.scene );
-										signals.objectSelected.dispatch( result.scene );
-
-									}
-
-								}, '' );
-
-							}
+							
+							addFileObject( data, filename );
 
 						}, false );
 						reader.readAsText( file );


### PR DESCRIPTION
The DOM event `dragover` needs to be handled as well as `drag`.

The Worker callback's invocation of `parseFile` provided incorrect arguments. To address this, I've extracted the logic that adds a data object to the scene into its own function: `addFileObject`.

This works as expected on Google Chrome 24.0.1312.57 and Firefox 18.0.1 on Linux (Ubuntu 12.04).

I believe this closes #3028.
