### PR TITLE
utils/python_server.sh uses the right module for each python version

### DIFF
--- a/utils/servers/python_server.sh
+++ b/utils/servers/python_server.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 
 cd `dirname $0`/../../
-python -m SimpleHTTPServer
+
+ret=`python -c 'import sys; print("%i" % (sys.version_info[0]))'`
+if [ $ret -eq 2 ]; then 
+	# Python 2
+    python -m SimpleHTTPServer
+else 
+	# Python 3
+    python -m http.server
+fi
+


### PR DESCRIPTION
I working on archlinux and its default python version is 3. I modified the python_server.sh script in order to run it independently from the python version used.
I thought it can be useful for others too.
