### PR TITLE
Per-face materials now loaded when JSON object dropped into editor.

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -255,12 +255,12 @@
 
 								var loader = new THREE.JSONLoader();
 
-								loader.createModel( data, function ( geometry ) {
+								loader.createModel( data, function ( geometry, materials ) {
 
 									geometry.sourceType = "ascii";
 									geometry.sourceFile = file.name;
 
-									var mesh = new THREE.Mesh( geometry, createDummyMaterial() );
+									var mesh = new THREE.Mesh( geometry, new THREE.MeshFaceMaterial( materials ) );
 									mesh.name = filename;
 
 									signals.objectAdded.dispatch( mesh );


### PR DESCRIPTION
`JSONLoader` was changed to provide loaded `materials` as a second argument to the callback. I just wired this through to the created mesh appropriately and now dropping JSON files into the editor works properly for the models I've been working with.
