### PR TITLE
Fixed bug in `Vector3.angleTo` and added unit test

### DIFF
--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -564,7 +564,7 @@ THREE.extend( THREE.Vector3.prototype, {
 
 	angleTo: function ( v ) {
 
-		return Math.acos( this.dot( v ) / this.length() / v.length() );
+		return Math.acos( Math.min ( 1, this.dot( v ) / this.length() / v.length() ) );
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -564,17 +564,11 @@ THREE.extend( THREE.Vector3.prototype, {
 
 	angleTo: function ( v ) {
 
-		// clamp, to handle numerical problems
-
-		function clamp( x ) {
-
-			return Math.min( Math.max( x, -1 ), 1 );
-
-		}
-
 		var theta = this.dot( v ) / ( this.length() * v.length() );
 
-		return Math.acos( clamp ( theta ) );
+		// clamp, to handle numerical problems
+
+		return Math.acos( THREE.Math.clamp ( theta, -1, 1 ) );
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -564,7 +564,17 @@ THREE.extend( THREE.Vector3.prototype, {
 
 	angleTo: function ( v ) {
 
-		return Math.acos( Math.min ( 1, this.dot( v ) / this.length() / v.length() ) );
+		// clamp, to handle numerical problems
+
+		function clamp( x ) {
+
+			return Math.min( Math.max( x, -1 ), 1 );
+
+		}
+
+		var theta = this.dot( v ) / ( this.length() * v.length() );
+
+		return Math.acos( clamp ( theta ) );
 
 	},
 

--- a/test/unit/math/Vector3.js
+++ b/test/unit/math/Vector3.js
@@ -292,8 +292,10 @@ test( "reflect", function() {
 
 test( "angleTo", function() {
 	var a = new THREE.Vector3( 0, -0.18851655680720186, 0.9820700116639124 );
+	var b = new THREE.Vector3( 0, 0.18851655680720186, -0.9820700116639124 );
 
-	equal( a.angleTo( a ),  0 );
+	equal( a.angleTo( a ), 0 );
+	equal( a.angleTo( b ), Math.PI );
 
 	var x = new THREE.Vector3( 1, 0, 0 );
 	var y = new THREE.Vector3( 0, 1, 0 );

--- a/test/unit/math/Vector3.js
+++ b/test/unit/math/Vector3.js
@@ -290,6 +290,22 @@ test( "reflect", function() {
 	ok( b.copy( a ).reflect(  normal ).equals( new THREE.Vector3( -1, -1, 0 ) ), "Passed!" );
 });
 
+test( "angleTo", function() {
+	var a = new THREE.Vector3( 0, -0.18851655680720186, 0.9820700116639124 );
+
+	equal( a.angleTo( a ),  0 );
+
+	var x = new THREE.Vector3( 1, 0, 0 );
+	var y = new THREE.Vector3( 0, 1, 0 );
+	var z = new THREE.Vector3( 0, 0, 1 );
+
+	equal( x.angleTo( y ), Math.PI / 2 );
+	equal( x.angleTo( z ), Math.PI / 2 );
+	equal( z.angleTo( x ), Math.PI / 2 );
+
+	ok( Math.abs( x.angleTo( new THREE.Vector3( 1, 1, 0 ) ) - ( Math.PI / 4 ) < 0.0000001 ) );
+});
+
 test( "lerp/clone", function() {
 	var a = new THREE.Vector3( x, 0, z );
 	var b = new THREE.Vector3( 0, -y, 0 );

--- a/test/unit/math/Vector3.js
+++ b/test/unit/math/Vector3.js
@@ -286,7 +286,7 @@ test( "reflect", function() {
 	ok( b.copy( a ).reflect( normal ).equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
 
 	a.set( 1, -1, 0 );
-	normal.set( 0, -1, 0 )
+	normal.set( 0, -1, 0 );
 	ok( b.copy( a ).reflect(  normal ).equals( new THREE.Vector3( -1, -1, 0 ) ), "Passed!" );
 });
 
@@ -303,7 +303,7 @@ test( "angleTo", function() {
 	equal( x.angleTo( z ), Math.PI / 2 );
 	equal( z.angleTo( x ), Math.PI / 2 );
 
-	ok( Math.abs( x.angleTo( new THREE.Vector3( 1, 1, 0 ) ) - ( Math.PI / 4 ) < 0.0000001 ) );
+	ok( Math.abs( x.angleTo( new THREE.Vector3( 1, 1, 0 ) ) - ( Math.PI / 4 ) ) < 0.0000001 );
 });
 
 test( "lerp/clone", function() {


### PR DESCRIPTION
For some identical vectors, the `angleTo` function was returning `NaN` because, due to the numerical imprecision of floating point numbers, the argument to `Math.acos` was something like `1.000000000001`, which is undefined.

I added a unit test for this and other uses of `Vector3.angleTo`.
