### PR TITLE
Update build/three.js

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -8806,7 +8806,7 @@ THREE.Loader.prototype = {
 
 	extractUrlBase: function ( url ) {
 
-		var parts = url.split( '/' );
+		var parts = url.toString().split( '/' );
 		parts.pop();
 		return ( parts.length < 1 ? '.' : parts.join( '/' ) ) + '/';
 


### PR DESCRIPTION
corrected bug : Type Error : url.split is not a function
