### PR TITLE
Line3.js was missing from common.json (was only in math.json)

### DIFF
--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -5,6 +5,7 @@
 	"src/math/Vector2.js",
 	"src/math/Vector3.js",
 	"src/math/Vector4.js",
+	"src/math/Line3.js",
 	"src/math/Box2.js",
 	"src/math/Box3.js",
 	"src/math/Matrix3.js",


### PR DESCRIPTION
I didn't add Line3.js to common.json so it wasn't included in the three.js, three.min.js builds.
