### PR TITLE
Remove documentation for getRotationFromMatrix() in Vector3

### DIFF
--- a/docs/api/math/Vector3.html
+++ b/docs/api/math/Vector3.html
@@ -155,11 +155,6 @@
 		Sets this vector extracting position from matrix transform.
 		</div>
 
-		<h3>.getRotationFromMatrix( [page:Matrix4 m] ) [page:Vector3]</h3>
-		<div>
-		Sets this vector extracting Euler angles rotation from matrix transform.
-		</div>
-
 		<h3>.getScaleFromMatrix( [page:Matrix4 m] ) [page:Vector3]</h3>
 		<div>
 		Sets this vector extracting scale from matrix transform.


### PR DESCRIPTION
getRotationFromMatrix() isn't defined anymore for Vector3, but is still in the docs
