### PR TITLE
Support custom BufferGeometry attributes in WebGLRenderer.

### DIFF
--- a/examples/webgl_buffergeometry_custom_attributes_particles.html
+++ b/examples/webgl_buffergeometry_custom_attributes_particles.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - buffer geometry custom attributes [particles]</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #ffffff;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+				font-weight: bold;
+
+				background-color: #000000;
+				margin: 0px;
+				overflow: hidden;
+			}
+			#info {
+				color: #fff;
+				background-color: rgba( 0, 0, 0, 0.75 );
+				position: relative;
+				top: 0px; width: 100%;
+				padding: 5px;
+				z-index:100;
+				width:33em;
+				margin:0 auto -2em;
+			}
+			a { color: #ff0000 }
+		</style>
+	</head>
+
+	<body>
+		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - buffergeometry custom attributes example - particles</div>
+		<div id="container"></div>
+
+		<script src="../build/three.min.js"></script>
+		<script src="../src/renderers/WebGLRenderer.js"></script>
+
+		<script src="js/Detector.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script type="x-shader/x-vertex" id="vertexshader">
+
+			uniform float amplitude;
+			attribute float size;
+			attribute vec3 customColor;
+
+			varying vec3 vColor;
+
+			void main() {
+
+				vColor = customColor;
+
+				vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+
+				//gl_PointSize = size;
+				gl_PointSize = size * ( 300.0 / length( mvPosition.xyz ) );
+
+				gl_Position = projectionMatrix * mvPosition;
+
+			}
+
+		</script>
+
+		<script type="x-shader/x-fragment" id="fragmentshader">
+
+			uniform vec3 color;
+			uniform sampler2D texture;
+
+			varying vec3 vColor;
+
+			void main() {
+
+				gl_FragColor = vec4( color * vColor, 1.0 );
+				gl_FragColor = gl_FragColor * texture2D( texture, gl_PointCoord );
+
+			}
+
+		</script>
+
+
+		<script>
+
+		if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+		var renderer, scene, camera, stats;
+
+		var sphere, uniforms, geometry;
+
+		var noise = [];
+		var values_size;
+		//500000
+		var particles = 100000;
+
+		var WIDTH = window.innerWidth;
+		var HEIGHT = window.innerHeight;
+
+		init();
+		animate();
+
+		function init() {
+
+			camera = new THREE.PerspectiveCamera( 40, WIDTH / HEIGHT, 1, 10000 );
+			camera.position.z = 300;
+
+			scene = new THREE.Scene();
+
+			var attributes = {
+
+				size: {	type: 'f', value: null },
+				customColor: { type: 'c', value: null }
+
+			};
+
+			uniforms = {
+
+				amplitude: { type: "f", value: 1.0 },
+				color:     { type: "c", value: new THREE.Color( 0xffffff ) },
+				texture:   { type: "t", value: THREE.ImageUtils.loadTexture( "textures/sprites/spark1.png" ) },
+
+			};
+
+			var shaderMaterial = new THREE.ShaderMaterial( {
+
+				uniforms: 		uniforms,
+				attributes:     attributes,
+				vertexShader:   document.getElementById( 'vertexshader' ).textContent,
+				fragmentShader: document.getElementById( 'fragmentshader' ).textContent,
+
+				blending: 		THREE.AdditiveBlending,
+				depthTest: 		false,
+				transparent:	true
+
+			});
+
+
+			var radius = 200;
+
+			geometry = new THREE.BufferGeometry();
+			geometry.dynamic = true;
+			geometry.attributes = {
+
+				position: {
+					itemSize: 3,
+					array: new Float32Array( particles * 3 ),
+					numItems: particles * 3
+				},
+				customColor: {
+					itemSize: 3,
+					array: new Float32Array( particles * 3 ),
+					numItems: particles * 3
+				},
+				size: {
+					itemSize: 1,
+					array: new Float32Array( particles ),
+					numItems: particles * 1
+				},
+
+			}
+
+
+			values_size = geometry.attributes.size.array;
+			var positions = geometry.attributes.position.array;
+			var values_color = geometry.attributes.customColor.array;
+
+			sphere = new THREE.ParticleSystem( geometry, shaderMaterial );
+
+			sphere.dynamic = true;
+			//sphere.sortParticles = true;
+
+			var color = new THREE.Color( 0xffaa00 );;
+
+			for( var v = 0; v < particles; v++ ) {
+
+				values_size[ v ] = 10;
+
+				positions[ v * 3 + 0 ] = (Math.random() * 2 - 1) * radius;
+				positions[ v * 3 + 1 ] = (Math.random() * 2 - 1) * radius;
+				positions[ v * 3 + 2 ] = (Math.random() * 2 - 1) * radius;
+
+				if ( positions[ v * 3 + 0 ] < 0 )
+					color.setHSL( 0.5 + 0.1 * ( v / particles ), 0.7, 0.1 );
+				else
+					color.setHSL( 0.0 + 0.1 * ( v / particles ), 0.9, 0.1 );
+
+				values_color[ v * 3 + 0 ] = color.r;
+				values_color[ v * 3 + 1 ] = color.g;
+				values_color[ v * 3 + 2 ] = color.b;
+
+			}
+
+			scene.add( sphere );
+
+			renderer = new THREE.WebGLRenderer( { clearColor: 0x000000, clearAlpha: 1 } );
+			renderer.setSize( WIDTH, HEIGHT );
+
+			var container = document.getElementById( 'container' );
+			container.appendChild( renderer.domElement );
+
+			stats = new Stats();
+			stats.domElement.style.position = 'absolute';
+			stats.domElement.style.top = '0px';
+			container.appendChild( stats.domElement );
+
+			//
+
+			window.addEventListener( 'resize', onWindowResize, false );
+
+		}
+
+		function onWindowResize() {
+
+			camera.aspect = window.innerWidth / window.innerHeight;
+			camera.updateProjectionMatrix();
+
+			renderer.setSize( window.innerWidth, window.innerHeight );
+
+		}
+
+		function animate() {
+
+			requestAnimationFrame( animate );
+
+			render();
+			stats.update();
+
+		}
+
+		function render() {
+
+			var time = Date.now() * 0.005;
+
+			sphere.rotation.z = 0.01 * time;
+
+			for( var i = 0; i < particles; i++ ) {
+
+				values_size[ i ] = 14 + 13 * Math.sin( 0.1 * i + time );
+
+			}
+
+			geometry.attributes.size.needsUpdate = true;
+
+			renderer.render( scene, camera );
+
+		}
+
+
+	</script>
+
+</body>
+
+</html>

--- a/examples/webgl_buffergeometry_custom_attributes_particles.html
+++ b/examples/webgl_buffergeometry_custom_attributes_particles.html
@@ -138,7 +138,7 @@
 			var radius = 200;
 
 			geometry = new THREE.BufferGeometry();
-			geometry.dynamic = true;
+			// geometry.dynamic = true;
 			geometry.attributes = {
 
 				position: {
@@ -154,7 +154,8 @@
 				size: {
 					itemSize: 1,
 					array: new Float32Array( particles ),
-					numItems: particles * 1
+					numItems: particles * 1,
+					dynamic: true
 				},
 
 			}
@@ -166,7 +167,6 @@
 
 			sphere = new THREE.ParticleSystem( geometry, shaderMaterial );
 
-			sphere.dynamic = true;
 			//sphere.sortParticles = true;
 
 			var color = new THREE.Color( 0xffaa00 );;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4511,7 +4511,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			geometry = object.geometry;
 
-			if ( geometry instanceof THREE.BufferGeometry ) {
+			if ( geometry === undefined ) {
+
+				// fail silently for now
+
+			} else if ( geometry instanceof THREE.BufferGeometry ) {
 
 				initDirectBuffers( geometry );
 
@@ -4519,36 +4523,32 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				material = object.material;
 
-				if ( geometry instanceof THREE.Geometry ) {
+				if ( geometry.geometryGroups === undefined ) {
 
-					if ( geometry.geometryGroups === undefined ) {
+					sortFacesByMaterial( geometry, material );
 
-						sortFacesByMaterial( geometry, material );
+				}
 
-					}
+				// create separate VBOs per geometry chunk
 
-					// create separate VBOs per geometry chunk
+				for ( g in geometry.geometryGroups ) {
 
-					for ( g in geometry.geometryGroups ) {
+					geometryGroup = geometry.geometryGroups[ g ];
 
-						geometryGroup = geometry.geometryGroups[ g ];
+					// initialise VBO on the first access
 
-						// initialise VBO on the first access
+					if ( ! geometryGroup.__webglVertexBuffer ) {
 
-						if ( ! geometryGroup.__webglVertexBuffer ) {
+						createMeshBuffers( geometryGroup );
+						initMeshBuffers( geometryGroup, object );
 
-							createMeshBuffers( geometryGroup );
-							initMeshBuffers( geometryGroup, object );
-
-							geometry.verticesNeedUpdate = true;
-							geometry.morphTargetsNeedUpdate = true;
-							geometry.elementsNeedUpdate = true;
-							geometry.uvsNeedUpdate = true;
-							geometry.normalsNeedUpdate = true;
-							geometry.tangentsNeedUpdate = true;
-							geometry.colorsNeedUpdate = true;
-
-						}
+						geometry.verticesNeedUpdate = true;
+						geometry.morphTargetsNeedUpdate = true;
+						geometry.elementsNeedUpdate = true;
+						geometry.uvsNeedUpdate = true;
+						geometry.normalsNeedUpdate = true;
+						geometry.tangentsNeedUpdate = true;
+						geometry.colorsNeedUpdate = true;
 
 					}
 
@@ -4571,16 +4571,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( ! geometry.__webglVertexBuffer ) {
 
-					if ( geometry instanceof THREE.Geometry ) {
+					createLineBuffers( geometry );
+					initLineBuffers( geometry, object );
 
-						createLineBuffers( geometry );
-						initLineBuffers( geometry, object );
-
-						geometry.verticesNeedUpdate = true;
-						geometry.colorsNeedUpdate = true;
-						geometry.lineDistancesNeedUpdate = true;
-
-					}
+					geometry.verticesNeedUpdate = true;
+					geometry.colorsNeedUpdate = true;
+					geometry.lineDistancesNeedUpdate = true;
 
 				}
 
@@ -4588,15 +4584,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( ! geometry.__webglVertexBuffer ) {
 
-					if ( geometry instanceof THREE.Geometry ) {
+					createParticleBuffers( geometry );
+					initParticleBuffers( geometry, object );
 
-						createParticleBuffers( geometry );
-						initParticleBuffers( geometry, object );
+					geometry.verticesNeedUpdate = true;
+					geometry.colorsNeedUpdate = true;
 
-						geometry.verticesNeedUpdate = true;
-						geometry.colorsNeedUpdate = true;
-
-					}
 				}
 
 			}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3238,54 +3238,80 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var attributes = geometry.attributes;
 
-		var index = attributes[ "index" ];
-		var position = attributes[ "position" ];
-		var normal = attributes[ "normal" ];
-		var uv = attributes[ "uv" ];
-		var color = attributes[ "color" ];
-		var tangent = attributes[ "tangent" ];
+		var attributeName, attributeItem;
 
-		if ( geometry.elementsNeedUpdate && index !== undefined ) {
+		for ( attributeName in attributes ) {
 
-			_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, index.buffer );
-			_gl.bufferData( _gl.ELEMENT_ARRAY_BUFFER, index.array, hint );
+			attributeItem = attributes[ attributeName ];
 
-		}
+			if ( ! attributeItem.needsUpdate ) continue;
 
-		if ( geometry.verticesNeedUpdate && position !== undefined ) {
+			// console.log( attributeName );
 
-			_gl.bindBuffer( _gl.ARRAY_BUFFER, position.buffer );
-			_gl.bufferData( _gl.ARRAY_BUFFER, position.array, hint );
+			if ( attributeName === 'index' ) {
 
-		}
+				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attributeItem.buffer );
+				_gl.bufferData( _gl.ELEMENT_ARRAY_BUFFER, attributeItem.array, hint );
 
-		if ( geometry.normalsNeedUpdate && normal !== undefined ) {
+			} else {
 
-			_gl.bindBuffer( _gl.ARRAY_BUFFER, normal.buffer );
-			_gl.bufferData( _gl.ARRAY_BUFFER, normal.array, hint );
+				_gl.bindBuffer( _gl.ARRAY_BUFFER, attributeItem.buffer );
+				_gl.bufferData( _gl.ARRAY_BUFFER, attributeItem.array, hint );
+
+			}
+
+			attributeItem.needsUpdate = false;
 
 		}
 
-		if ( geometry.uvsNeedUpdate && uv !== undefined ) {
+		// var index = attributes[ "index" ];
+		// var position = attributes[ "position" ];
+		// var normal = attributes[ "normal" ];
+		// var uv = attributes[ "uv" ];
+		// var color = attributes[ "color" ];
+		// var tangent = attributes[ "tangent" ];
 
-			_gl.bindBuffer( _gl.ARRAY_BUFFER, uv.buffer );
-			_gl.bufferData( _gl.ARRAY_BUFFER, uv.array, hint );
+		// if ( geometry.elementsNeedUpdate && index !== undefined ) {
 
-		}
+		// 	_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, index.buffer );
+		// 	_gl.bufferData( _gl.ELEMENT_ARRAY_BUFFER, index.array, hint );
 
-		if ( geometry.colorsNeedUpdate && color !== undefined ) {
+		// }
 
-			_gl.bindBuffer( _gl.ARRAY_BUFFER, color.buffer );
-			_gl.bufferData( _gl.ARRAY_BUFFER, color.array, hint );
+		// if ( geometry.verticesNeedUpdate && position !== undefined ) {
 
-		}
+		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, position.buffer );
+		// 	_gl.bufferData( _gl.ARRAY_BUFFER, position.array, hint );
 
-		if ( geometry.tangentsNeedUpdate && tangent !== undefined ) {
+		// }
 
-			_gl.bindBuffer( _gl.ARRAY_BUFFER, tangent.buffer );
-			_gl.bufferData( _gl.ARRAY_BUFFER, tangent.array, hint );
+		// if ( geometry.normalsNeedUpdate && normal !== undefined ) {
 
-		}
+		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, normal.buffer );
+		// 	_gl.bufferData( _gl.ARRAY_BUFFER, normal.array, hint );
+
+		// }
+
+		// if ( geometry.uvsNeedUpdate && uv !== undefined ) {
+
+		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, uv.buffer );
+		// 	_gl.bufferData( _gl.ARRAY_BUFFER, uv.array, hint );
+
+		// }
+
+		// if ( geometry.colorsNeedUpdate && color !== undefined ) {
+
+		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, color.buffer );
+		// 	_gl.bufferData( _gl.ARRAY_BUFFER, color.array, hint );
+
+		// }
+
+		// if ( geometry.tangentsNeedUpdate && tangent !== undefined ) {
+
+		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, tangent.buffer );
+		// 	_gl.bufferData( _gl.ARRAY_BUFFER, tangent.array, hint );
+
+		// }
 
 		if ( dispose ) {
 
@@ -4601,14 +4627,14 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( geometry instanceof THREE.Geometry ) {
 
-            createLineBuffers( geometry );
-            initLineBuffers( geometry, object );
+						createLineBuffers( geometry );
+						initLineBuffers( geometry, object );
 
-            geometry.verticesNeedUpdate = true;
-            geometry.colorsNeedUpdate = true;
-            geometry.lineDistancesNeedUpdate = true;
+						geometry.verticesNeedUpdate = true;
+						geometry.colorsNeedUpdate = true;
+						geometry.lineDistancesNeedUpdate = true;
 
-          } else if ( geometry instanceof THREE.BufferGeometry ) {
+					} else if ( geometry instanceof THREE.BufferGeometry ) {
 
 						initDirectBuffers( geometry );
 
@@ -4728,20 +4754,22 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( geometry instanceof THREE.BufferGeometry ) {
 
-				if ( geometry.verticesNeedUpdate || geometry.elementsNeedUpdate ||
-					 geometry.uvsNeedUpdate || geometry.normalsNeedUpdate ||
-					 geometry.colorsNeedUpdate || geometry.tangentsNeedUpdate ) {
+				setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
 
-					setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
+				// if ( geometry.verticesNeedUpdate || geometry.elementsNeedUpdate ||
+				// 	 geometry.uvsNeedUpdate || geometry.normalsNeedUpdate ||
+				// 	 geometry.colorsNeedUpdate || geometry.tangentsNeedUpdate ) {
 
-				}
+				// 	setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
 
-				geometry.verticesNeedUpdate = false;
-				geometry.elementsNeedUpdate = false;
-				geometry.uvsNeedUpdate = false;
-				geometry.normalsNeedUpdate = false;
-				geometry.colorsNeedUpdate = false;
-				geometry.tangentsNeedUpdate = false;
+				// }
+
+				// geometry.verticesNeedUpdate = false;
+				// geometry.elementsNeedUpdate = false;
+				// geometry.uvsNeedUpdate = false;
+				// geometry.normalsNeedUpdate = false;
+				// geometry.colorsNeedUpdate = false;
+				// geometry.tangentsNeedUpdate = false;
 
 			} else {
 
@@ -4805,49 +4833,53 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		} else if ( object instanceof THREE.Line ) {
 
-      if ( geometry instanceof THREE.BufferGeometry ) {
+			if ( geometry instanceof THREE.BufferGeometry ) {
 
-				if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate ) {
+				setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
 
-					setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
+				// if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate ) {
+
+				// 	setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
+
+				// }
+
+				// geometry.verticesNeedUpdate = false;
+				// geometry.colorsNeedUpdate = false;
+
+			} else {
+
+				material = getBufferMaterial( object, geometry );
+
+				customAttributesDirty = material.attributes && areCustomAttributesDirty( material );
+
+				if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate || geometry.lineDistancesNeedUpdate || customAttributesDirty ) {
+
+					setLineBuffers( geometry, _gl.DYNAMIC_DRAW );
 
 				}
 
 				geometry.verticesNeedUpdate = false;
 				geometry.colorsNeedUpdate = false;
+				geometry.lineDistancesNeedUpdate = false;
 
-			} else {
+				material.attributes && clearCustomAttributes( material );
 
-        material = getBufferMaterial( object, geometry );
-
-        customAttributesDirty = material.attributes && areCustomAttributesDirty( material );
-
-        if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate || geometry.lineDistancesNeedUpdate || customAttributesDirty ) {
-
-          setLineBuffers( geometry, _gl.DYNAMIC_DRAW );
-
-        }
-
-        geometry.verticesNeedUpdate = false;
-        geometry.colorsNeedUpdate = false;
-        geometry.lineDistancesNeedUpdate = false;
-
-        material.attributes && clearCustomAttributes( material );
-
-      }
+			}
 
 		} else if ( object instanceof THREE.ParticleSystem ) {
 
 			if ( geometry instanceof THREE.BufferGeometry ) {
 
-				if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate ) {
+				setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
 
-					setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
+				// if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate ) {
 
-				}
+				// 	setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
 
-				geometry.verticesNeedUpdate = false;
-				geometry.colorsNeedUpdate = false;
+				// }
+
+				// geometry.verticesNeedUpdate = false;
+				// geometry.colorsNeedUpdate = false;
 
 			} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3398,11 +3398,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( material.visible === false ) return;
 
-		var program, attributes, linewidth, primitives, a, attribute;
+		var program, programAttributes, linewidth, primitives, a, attribute, geometryAttributes;
+		var attributeItem, attributeName, attributePointer;
 
 		program = setProgram( camera, lights, fog, material, object );
 
-		attributes = program.attributes;
+		programAttributes = program.attributes;
+		geometryAttributes = geometry.attributes;
 
 		var updateBuffers = false,
 			wireframeBit = material.wireframe ? 1 : 0,
@@ -3425,7 +3427,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( object instanceof THREE.Mesh ) {
 
-			var index = geometry.attributes[ "index" ];
+			var index = geometryAttributes[ "index" ];
 
 			// indexed triangles
 
@@ -3445,68 +3447,21 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( updateBuffers ) {
 
-						// vertices
+						for ( attributeName in geometryAttributes ) {
 
-						var position = geometry.attributes[ "position" ];
-						var positionSize = position.itemSize;
+							if ( attributeName === 'index' ) continue;
 
-						_gl.bindBuffer( _gl.ARRAY_BUFFER, position.buffer );
-						enableAttribute( attributes.position );
-						_gl.vertexAttribPointer( attributes.position, positionSize, _gl.FLOAT, false, 0, startIndex * positionSize * 4 ); // 4 bytes per Float32
+							attributePointer = programAttributes[ attributeName ];
+							attributeItem = geometryAttributes[ attributeName ];
+							attributeSize = attributeItem.itemSize;
 
-						// normals
+							if ( attributePointer >= 0 ) {
 
-						var normal = geometry.attributes[ "normal" ];
+								_gl.bindBuffer( _gl.ARRAY_BUFFER, attributeItem.buffer );
+								enableAttribute( attributePointer );
+								_gl.vertexAttribPointer( attributePointer, attributeSize, _gl.FLOAT, false, 0, startIndex * attributeSize * 4 ); // 4 bytes per Float32
 
-						if ( attributes.normal >= 0 && normal ) {
-
-							var normalSize = normal.itemSize;
-
-							_gl.bindBuffer( _gl.ARRAY_BUFFER, normal.buffer );
-							enableAttribute( attributes.normal );
-							_gl.vertexAttribPointer( attributes.normal, normalSize, _gl.FLOAT, false, 0, startIndex * normalSize * 4 );
-
-						}
-
-						// uvs
-
-						var uv = geometry.attributes[ "uv" ];
-
-						if ( attributes.uv >= 0 && uv ) {
-
-							var uvSize = uv.itemSize;
-
-							_gl.bindBuffer( _gl.ARRAY_BUFFER, uv.buffer );
-							enableAttribute( attributes.uv );
-							_gl.vertexAttribPointer( attributes.uv, uvSize, _gl.FLOAT, false, 0, startIndex * uvSize * 4 );
-
-						}
-
-						// colors
-
-						var color = geometry.attributes[ "color" ];
-
-						if ( attributes.color >= 0 && color ) {
-
-							var colorSize = color.itemSize;
-
-							_gl.bindBuffer( _gl.ARRAY_BUFFER, color.buffer );
-							enableAttribute( attributes.color );
-							_gl.vertexAttribPointer( attributes.color, colorSize, _gl.FLOAT, false, 0, startIndex * colorSize * 4 );
-
-						}
-
-						// tangents
-
-						var tangent = geometry.attributes[ "tangent" ];
-
-						if ( attributes.tangent >= 0 && tangent ) {
-
-							var tangentSize = tangent.itemSize;
-
-							_gl.bindBuffer( _gl.ARRAY_BUFFER, tangent.buffer );
-							enableAttribute( attributes.tangent );
-							_gl.vertexAttribPointer( attributes.tangent, tangentSize, _gl.FLOAT, false, 0, startIndex * tangentSize * 4 );
+							}
 
 						}
 
@@ -3532,72 +3487,29 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( updateBuffers ) {
 
-					// vertices
+					var attributeItem, attributeName, attributePointer;
 
-					var position = geometry.attributes[ "position" ];
-					var positionSize = position.itemSize;
+					for ( attributeName in geometryAttributes ) {
 
-					_gl.bindBuffer( _gl.ARRAY_BUFFER, position.buffer );
-					enableAttribute( attributes.position );
-					_gl.vertexAttribPointer( attributes.position, positionSize, _gl.FLOAT, false, 0, 0 );
+						if ( attributeName === 'index') continue;
 
-					// normals
+						attributePointer = programAttributes[ attributeName ];
+						attributeItem = geometryAttributes[ attributeName ];
+						attributeSize = attributeItem.itemSize;
 
-					var normal = geometry.attributes[ "normal" ];
+						if ( attributePointer >= 0 ) {
 
-					if ( attributes.normal >= 0 && normal ) {
+							_gl.bindBuffer( _gl.ARRAY_BUFFER, attributeItem.buffer );
+							enableAttribute( attributePointer );
+							_gl.vertexAttribPointer( attributePointer, attributeSize, _gl.FLOAT, false, 0, 0 );
 
-						var normalSize = normal.itemSize;
-
-						_gl.bindBuffer( _gl.ARRAY_BUFFER, normal.buffer );
-						enableAttribute( attributes.normal );
-						_gl.vertexAttribPointer( attributes.normal, normalSize, _gl.FLOAT, false, 0, 0 );
-
-					}
-
-					// uvs
-
-					var uv = geometry.attributes[ "uv" ];
-
-					if ( attributes.uv >= 0 && uv ) {
-
-						var uvSize = uv.itemSize;
-
-						_gl.bindBuffer( _gl.ARRAY_BUFFER, uv.buffer );
-						enableAttribute( attributes.uv );
-						_gl.vertexAttribPointer( attributes.uv, uvSize, _gl.FLOAT, false, 0, 0 );
-
-					}
-
-					// colors
-
-					var color = geometry.attributes[ "color" ];
-
-					if ( attributes.color >= 0 && color ) {
-
-						var colorSize = color.itemSize;
-
-						_gl.bindBuffer( _gl.ARRAY_BUFFER, color.buffer );
-						enableAttribute( attributes.color );
-						_gl.vertexAttribPointer( attributes.color, colorSize, _gl.FLOAT, false, 0, 0 );
-
-					}
-
-					// tangents
-
-					var tangent = geometry.attributes[ "tangent" ];
-
-					if ( attributes.tangent >= 0 && tangent ) {
-
-						var tangentSize = tangent.itemSize;
-
-						_gl.bindBuffer( _gl.ARRAY_BUFFER, tangent.buffer );
-						enableAttribute( attributes.tangent );
-						_gl.vertexAttribPointer( attributes.tangent, tangentSize, _gl.FLOAT, false, 0, 0 );
+						}
 
 					}
 
 				}
+
+				var position = geometry.attributes[ "position" ];
 
 				// render non-indexed triangles
 
@@ -3615,28 +3527,25 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( updateBuffers ) {
 
-				// vertices
+				for ( attributeName in geometryAttributes ) {
 
-				var position = geometry.attributes[ "position" ];
-				var positionSize = position.itemSize;
+					if ( attributeName === 'index') continue;
 
-				_gl.bindBuffer( _gl.ARRAY_BUFFER, position.buffer );
-				enableAttribute( attributes.position );
-				_gl.vertexAttribPointer( attributes.position, positionSize, _gl.FLOAT, false, 0, 0 );
+					attributePointer = programAttributes[ attributeName ];
+					attributeItem = geometryAttributes[ attributeName ];
+					attributeSize = attributeItem.itemSize;
 
-				// colors
+					if ( attributePointer >= 0 ) {
 
-				var color = geometry.attributes[ "color" ];
+						_gl.bindBuffer( _gl.ARRAY_BUFFER, attributeItem.buffer );
+						enableAttribute( attributePointer );
+						_gl.vertexAttribPointer( attributePointer, attributeSize, _gl.FLOAT, false, 0, 0 );
 
-				if ( attributes.color >= 0 && color ) {
-
-					var colorSize = color.itemSize;
-
-					_gl.bindBuffer( _gl.ARRAY_BUFFER, color.buffer );
-					enableAttribute( attributes.color );
-					_gl.vertexAttribPointer( attributes.color, colorSize, _gl.FLOAT, false, 0, 0 );
+					}
 
 				}
+
+				var position = geometryAttributes[ "position" ];
 
 				// render particles
 
@@ -3651,32 +3560,29 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( updateBuffers ) {
 
-				// vertices
+				for ( attributeName in geometryAttributes ) {
 
-				var position = geometry.attributes[ "position" ];
-				var positionSize = position.itemSize;
+					if ( attributeName === 'index') continue;
 
-				_gl.bindBuffer( _gl.ARRAY_BUFFER, position.buffer );
-				enableAttribute( attributes.position );
-				_gl.vertexAttribPointer( attributes.position, positionSize, _gl.FLOAT, false, 0, 0 );
+					attributePointer = programAttributes[ attributeName ];
+					attributeItem = geometryAttributes[ attributeName ];
+					attributeSize = attributeItem.itemSize;
 
-				// colors
+					if ( attributePointer >= 0 ) {
 
-				var color = geometry.attributes[ "color" ];
+						_gl.bindBuffer( _gl.ARRAY_BUFFER, attributeItem.buffer );
+						enableAttribute( attributePointer );
+						_gl.vertexAttribPointer( attributePointer, attributeSize, _gl.FLOAT, false, 0, 0 );
 
-				if ( attributes.color >= 0 && color ) {
-
-					var colorSize = color.itemSize;
-
-					_gl.bindBuffer( _gl.ARRAY_BUFFER, color.buffer );
-					enableAttribute( attributes.color );
-					_gl.vertexAttribPointer( attributes.color, colorSize, _gl.FLOAT, false, 0, 0 );
+					}
 
 				}
 
 				// render lines
 
 				setLineWidth( material.linewidth );
+
+				var position = geometryAttributes[ "position" ];
 
 				_gl.drawArrays( _gl.LINE_STRIP, 0, position.numItems / 3 );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3244,29 +3244,27 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			attributeItem = attributes[ attributeName ];
 
-			if ( ! attributeItem.needsUpdate ) continue;
+			if ( attributeItem.needsUpdate ) {
 
-			if ( attributeName === 'index' ) {
+				if ( attributeName === 'index' ) {
 
-				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attributeItem.buffer );
-				_gl.bufferData( _gl.ELEMENT_ARRAY_BUFFER, attributeItem.array, hint );
+					_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attributeItem.buffer );
+					_gl.bufferData( _gl.ELEMENT_ARRAY_BUFFER, attributeItem.array, hint );
 
-			} else {
+				} else {
 
-				_gl.bindBuffer( _gl.ARRAY_BUFFER, attributeItem.buffer );
-				_gl.bufferData( _gl.ARRAY_BUFFER, attributeItem.array, hint );
+					_gl.bindBuffer( _gl.ARRAY_BUFFER, attributeItem.buffer );
+					_gl.bufferData( _gl.ARRAY_BUFFER, attributeItem.array, hint );
+
+				}
+
+				attributeItem.needsUpdate = false;
 
 			}
 
-			attributeItem.needsUpdate = false;
+			if ( dispose && ! attributeItem.dynamic ) {
 
-		}
-
-		if ( dispose ) {
-
-			for ( var i in geometry.attributes ) {
-
-				delete geometry.attributes[ i ].array;
+				delete attributeItem.array;
 
 			}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3246,8 +3246,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( ! attributeItem.needsUpdate ) continue;
 
-			// console.log( attributeName );
-
 			if ( attributeName === 'index' ) {
 
 				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attributeItem.buffer );
@@ -3263,55 +3261,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 			attributeItem.needsUpdate = false;
 
 		}
-
-		// var index = attributes[ "index" ];
-		// var position = attributes[ "position" ];
-		// var normal = attributes[ "normal" ];
-		// var uv = attributes[ "uv" ];
-		// var color = attributes[ "color" ];
-		// var tangent = attributes[ "tangent" ];
-
-		// if ( geometry.elementsNeedUpdate && index !== undefined ) {
-
-		// 	_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, index.buffer );
-		// 	_gl.bufferData( _gl.ELEMENT_ARRAY_BUFFER, index.array, hint );
-
-		// }
-
-		// if ( geometry.verticesNeedUpdate && position !== undefined ) {
-
-		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, position.buffer );
-		// 	_gl.bufferData( _gl.ARRAY_BUFFER, position.array, hint );
-
-		// }
-
-		// if ( geometry.normalsNeedUpdate && normal !== undefined ) {
-
-		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, normal.buffer );
-		// 	_gl.bufferData( _gl.ARRAY_BUFFER, normal.array, hint );
-
-		// }
-
-		// if ( geometry.uvsNeedUpdate && uv !== undefined ) {
-
-		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, uv.buffer );
-		// 	_gl.bufferData( _gl.ARRAY_BUFFER, uv.array, hint );
-
-		// }
-
-		// if ( geometry.colorsNeedUpdate && color !== undefined ) {
-
-		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, color.buffer );
-		// 	_gl.bufferData( _gl.ARRAY_BUFFER, color.array, hint );
-
-		// }
-
-		// if ( geometry.tangentsNeedUpdate && tangent !== undefined ) {
-
-		// 	_gl.bindBuffer( _gl.ARRAY_BUFFER, tangent.buffer );
-		// 	_gl.bufferData( _gl.ARRAY_BUFFER, tangent.array, hint );
-
-		// }
 
 		if ( dispose ) {
 
@@ -4756,21 +4705,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
 
-				// if ( geometry.verticesNeedUpdate || geometry.elementsNeedUpdate ||
-				// 	 geometry.uvsNeedUpdate || geometry.normalsNeedUpdate ||
-				// 	 geometry.colorsNeedUpdate || geometry.tangentsNeedUpdate ) {
-
-				// 	setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
-
-				// }
-
-				// geometry.verticesNeedUpdate = false;
-				// geometry.elementsNeedUpdate = false;
-				// geometry.uvsNeedUpdate = false;
-				// geometry.normalsNeedUpdate = false;
-				// geometry.colorsNeedUpdate = false;
-				// geometry.tangentsNeedUpdate = false;
-
 			} else {
 
 				// check all geometry groups
@@ -4837,15 +4771,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
 
-				// if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate ) {
-
-				// 	setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
-
-				// }
-
-				// geometry.verticesNeedUpdate = false;
-				// geometry.colorsNeedUpdate = false;
-
 			} else {
 
 				material = getBufferMaterial( object, geometry );
@@ -4871,15 +4796,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 			if ( geometry instanceof THREE.BufferGeometry ) {
 
 				setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
-
-				// if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate ) {
-
-				// 	setDirectBuffers( geometry, _gl.DYNAMIC_DRAW, !geometry.dynamic );
-
-				// }
-
-				// geometry.verticesNeedUpdate = false;
-				// geometry.colorsNeedUpdate = false;
 
 			} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3399,7 +3399,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( material.visible === false ) return;
 
 		var program, programAttributes, linewidth, primitives, a, attribute, geometryAttributes;
-		var attributeItem, attributeName, attributePointer;
+		var attributeItem, attributeName, attributePointer, attributeSize;
 
 		program = setProgram( camera, lights, fog, material, object );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -268,19 +268,19 @@ THREE.WebGLRenderer = function ( parameters ) {
 		return _glExtensionTextureFloat;
 
 	};
-	
+
 	this.supportsStandardDerivatives = function () {
 
 		return _glExtensionStandardDerivatives;
 
 	};
-	
+
 	this.supportsCompressedTextureS3TC = function () {
 
 		return _glExtensionCompressedTextureS3TC;
 
 	};
-	
+
 	this.getMaxAnisotropy  = function () {
 
 		return _maxAnisotropy;
@@ -3487,8 +3487,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( updateBuffers ) {
 
-					var attributeItem, attributeName, attributePointer;
-
 					for ( attributeName in geometryAttributes ) {
 
 						if ( attributeName === 'index') continue;
@@ -3529,8 +3527,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				for ( attributeName in geometryAttributes ) {
 
-					if ( attributeName === 'index') continue;
-
 					attributePointer = programAttributes[ attributeName ];
 					attributeItem = geometryAttributes[ attributeName ];
 					attributeSize = attributeItem.itemSize;
@@ -3562,8 +3558,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				for ( attributeName in geometryAttributes ) {
 
-					if ( attributeName === 'index') continue;
-
 					attributePointer = programAttributes[ attributeName ];
 					attributeItem = geometryAttributes[ attributeName ];
 					attributeSize = attributeItem.itemSize;
@@ -3591,7 +3585,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
-    }
+    	}
 
 	};
 
@@ -7380,17 +7374,17 @@ THREE.WebGLRenderer = function ( parameters ) {
 			console.log( 'THREE.WebGLRenderer: S3TC compressed textures not supported.' );
 
 		}
-		
+
 		if ( _gl.getShaderPrecisionFormat === undefined ) {
-			
-			_gl.getShaderPrecisionFormat = function() { 
-				
+
+			_gl.getShaderPrecisionFormat = function() {
+
 				return {
 					"rangeMin"  : 1,
 					"rangeMax"  : 1,
 					"precision" : 1
 				};
-				
+
 			}
 		}
 

--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -105,7 +105,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	_usedTextureUnits = 0,
 
-	// GL state 
+	// GL state
 
 	_viewportX = 0,
 	_viewportY = 0,
@@ -601,7 +601,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 
 			}
-			
+
 			renderer.setDynamicArrayBuffer( object.__webglNormalBuffer, object.normalArray);
 			renderer.setFloatAttribute(program.attributes.normal, object.__webglNormalBuffer, 3, 0);
 
@@ -630,11 +630,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( material.visible === false ) return;
 
-		var program, attributes, linewidth, primitives, a, attribute;
+		var program, programAttributes, linewidth, primitives, a, attribute, geometryAttributes;
+		var attributeItem, attributeName, attributePointer;
 
 		program = setProgram( camera, lights, fog, material, object );
 
-		attributes = program.attributes;
+		programAttributes = program.attributes;
+		geometryAttributes = geometry.attributes;
 
 		var updateBuffers = false,
 			wireframeBit = material.wireframe ? 1 : 0,
@@ -657,7 +659,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( object instanceof THREE.Mesh ) {
 
-			var index = geometry.attributes[ "index" ];
+			var index = geometryAttributes[ "index" ];
 
 			// indexed triangles
 
@@ -677,60 +679,25 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( updateBuffers ) {
 
-						// vertices
+						for ( attributeName in geometryAttributes ) {
 
-						var position = geometry.attributes[ "position" ];
-						var positionSize = position.itemSize;
-						renderer.setFloatAttribute(attributes.position , position.buffer, positionSize, startIndex * positionSize * 4);
+							if ( attributeName === 'index' ) continue;
 
-						// normals
+							attributePointer = programAttributes[ attributeName ];
+							attributeItem = geometryAttributes[ attributeName ];
+							attributeSize = attributeItem.itemSize;
 
-						var normal = geometry.attributes[ "normal" ];
+							if ( attributePointer >= 0 ) {
 
-						if ( attributes.normal >= 0 && normal ) {
+								renderer.setFloatAttribute( attributePointer , attributeItem.buffer, attributeSize, startIndex * attributeSize * 4 );
 
-							var normalSize = normal.itemSize;
-							renderer.setFloatAttribute(attributes.normal , normal.buffer, normalSize, startIndex * normalSize * 4);
-
-						}
-
-						// uvs
-
-						var uv = geometry.attributes[ "uv" ];
-
-						if ( attributes.uv >= 0 && uv ) {
-
-							var uvSize = uv.itemSize;
-							renderer.setFloatAttribute(attributes.uv , uv.buffer, uvSize, startIndex * uvSize * 4);
+							}
 
 						}
-
-						// colors
-
-						var color = geometry.attributes[ "color" ];
-
-						if ( attributes.color >= 0 && color ) {
-
-							var colorSize = color.itemSize;
-							renderer.setFloatAttribute(attributes.color , color.buffer, colorSize, startIndex * colorSize * 4);
-
-						}
-
-						// tangents
-
-						var tangent = geometry.attributes[ "tangent" ];
-
-						if ( attributes.tangent >= 0 && tangent ) {
-
-							var tangentSize = tangent.itemSize;
-							renderer.setFloatAttribute(attributes.tangent , tangent.buffer, tangentSize, startIndex * tangentSize * 4);
-
-						}
-
 					}
 
 					// render indexed triangles
-					
+
 					renderer.drawTriangleElements(index.buffer, offsets[ i ].count, offsets[ i ].start * 2);
 
 					_this.info.render.calls ++;
@@ -745,59 +712,26 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( updateBuffers ) {
 
-					// vertices
+					for ( attributeName in geometryAttributes ) {
 
-					var position = geometry.attributes[ "position" ];
-					var positionSize = position.itemSize;
-					renderer.setFloatAttribute(attributes.position , position.buffer, positionSize, 0);
+						attributePointer = programAttributes[ attributeName ];
+						attributeItem = geometryAttributes[ attributeName ];
+						attributeSize = attributeItem.itemSize;
 
-					// normals
+						if ( attributePointer >= 0 ) {
 
-					var normal = geometry.attributes[ "normal" ];
+							renderer.setFloatAttribute( attributePointer , attributeItem.buffer, attributeSize, 0 );
 
-					if ( attributes.normal >= 0 && normal ) {
-
-						var normalSize = normal.itemSize;
-						renderer.setFloatAttribute(attributes.normal , normal.buffer, normalSize, 0);
-
-					}
-
-					// uvs
-
-					var uv = geometry.attributes[ "uv" ];
-
-					if ( attributes.uv >= 0 && uv ) {
-
-						var uvSize = uv.itemSize;
-						renderer.setFloatAttribute(attributes.uv , uv.buffer, uvSize, 0);
-
-					}
-
-					// colors
-
-					var color = geometry.attributes[ "color" ];
-
-					if ( attributes.color >= 0 && color ) {
-
-						var colorSize = color.itemSize;
-						renderer.setFloatAttribute(attributes.color , color.buffer, colorSize, 0);
-
-					}
-
-					// tangents
-
-					var tangent = geometry.attributes[ "tangent" ];
-
-					if ( attributes.tangent >= 0 && tangent ) {
-
-						var tangentSize = tangent.itemSize;
-						renderer.setFloatAttribute(attributes.tangent , tangent.buffer, tangentSize, 0);
+						}
 
 					}
 
 				}
 
+				var position = geometry.attributes[ "position" ];
+
 				// render non-indexed triangles
+
 				renderer.drawTriangles( position.numItems / 3)
 
 				_this.info.render.calls ++;
@@ -812,22 +746,21 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( updateBuffers ) {
 
-				// vertices
+				for ( attributeName in geometryAttributes ) {
 
-				var position = geometry.attributes[ "position" ];
-				var positionSize = position.itemSize;
-				renderer.setFloatAttribute(attributes.position , position.buffer, positionSize, 0);
+					attributePointer = programAttributes[ attributeName ];
+					attributeItem = geometryAttributes[ attributeName ];
+					attributeSize = attributeItem.itemSize;
 
-				// colors
+					if ( attributePointer >= 0 ) {
 
-				var color = geometry.attributes[ "color" ];
+						renderer.setFloatAttribute( attributePointer , attributeItem.buffer, attributeSize, 0 );
 
-				if ( attributes.color >= 0 && color ) {
-
-					var colorSize = color.itemSize;
-					renderer.setFloatAttribute(attributes.color , color.buffer, colorSize, 0);
+					}
 
 				}
+
+				var position = geometryAttributes[ "position" ];
 
 				// render particles
 				renderer.drawPoints(position.numItems / 3);
@@ -841,22 +774,21 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( updateBuffers ) {
 
-				// vertices
+				for ( attributeName in geometryAttributes ) {
 
-				var position = geometry.attributes[ "position" ];
-				var positionSize = position.itemSize;
-				renderer.setFloatAttribute(attributes.position , position.buffer, positionSize, 0);
+					attributePointer = programAttributes[ attributeName ];
+					attributeItem = geometryAttributes[ attributeName ];
+					attributeSize = attributeItem.itemSize;
 
-				// colors
+					if ( attributePointer >= 0 ) {
 
-				var color = geometry.attributes[ "color" ];
+						renderer.setFloatAttribute( attributePointer , attributeItem.buffer, attributeSize, 0 );
 
-				if ( attributes.color >= 0 && color ) {
-
-					var colorSize = color.itemSize;
-					renderer.setFloatAttribute(attributes.color , color.buffer, colorSize, 0);
+					}
 
 				}
+
+				var position = geometryAttributes[ "position" ];
 
 				// render lines
 				renderer.setLineWidth( material.linewidth );
@@ -3109,7 +3041,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				if ( ! light.visible ) continue;
 
 				_direction.getPositionFromMatrix( light.matrixWorld );
-				_vector3.getPositionFromMatrix( light.target.matrixWorld );					
+				_vector3.getPositionFromMatrix( light.target.matrixWorld );
 				_direction.sub( _vector3 );
 				_direction.normalize();
 

--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -486,54 +486,31 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var attributes = geometry.attributes;
 
-		var index = attributes[ "index" ];
-		var position = attributes[ "position" ];
-		var normal = attributes[ "normal" ];
-		var uv = attributes[ "uv" ];
-		var color = attributes[ "color" ];
-		var tangent = attributes[ "tangent" ];
+		var attributeName, attributeItem;
 
-		if ( geometry.elementsNeedUpdate && index !== undefined ) {
+		for ( attributeName in attributes ) {
 
-			renderer.setDynamicIndexBuffer(	index.buffer, index.array);
+			attributeItem = attributes[ attributeName ];
 
-		}
+			if ( attributeItem.needsUpdate ) {
 
-		if ( geometry.verticesNeedUpdate && position !== undefined ) {
+				if ( attributeName === 'index' ) {
 
-			renderer.setDynamicArrayBuffer( position.buffer,  position.array);
+					renderer.setDynamicIndexBuffer(	attributeItem.buffer, attributeItem.array );
 
-		}
+				} else {
 
-		if ( geometry.normalsNeedUpdate && normal !== undefined ) {
+					renderer.setDynamicArrayBuffer( attributeItem.buffer,  attributeItem.array );
 
-			renderer.setDynamicArrayBuffer( normal.buffer,  normal.array);
+				}
 
-		}
+				attributeItem.needsUpdate = false;
 
-		if ( geometry.uvsNeedUpdate && uv !== undefined ) {
+			}
 
-			renderer.setDynamicArrayBuffer( uv.buffer,  uv.array);
+			if ( dispose && ! attributeItem.dynamic ) {
 
-		}
-
-		if ( geometry.colorsNeedUpdate && color !== undefined ) {
-
-			renderer.setDynamicArrayBuffer( color.buffer,  color.array);
-
-		}
-
-		if ( geometry.tangentsNeedUpdate && tangent !== undefined ) {
-
-			renderer.setDynamicArrayBuffer( tangent.buffer, tangent.array);
-
-		}
-
-		if ( dispose ) {
-
-			for ( var i in geometry.attributes ) {
-
-				delete geometry.attributes[ i ].array;
+				delete attributeItem.array;
 
 			}
 

--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -631,7 +631,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( material.visible === false ) return;
 
 		var program, programAttributes, linewidth, primitives, a, attribute, geometryAttributes;
-		var attributeItem, attributeName, attributePointer;
+		var attributeItem, attributeName, attributePointer, attributeSize;
 
 		program = setProgram( camera, lights, fog, material, object );
 


### PR DESCRIPTION
As discussed in #3017, adding custom attribute support to `BufferGeometry`.

This should also fix #3084

Some points about this custom attribues
1. You add a new item entry to `bufferGeometry.attributes`
   eg.

```
bufferGeometry.attributes['hello'] = {
    itemSize: 3,
    array: new Float32Array( number * 3 ),
    numItems: number * 3
}
```
1. You populate the FloatArray of course
2. You need to make sure your `Material` have that attribute, just like how Custom Attributes work for the usual geometry.

```
mesh.attributes.['hello'] = { type: 'c', value: null };
```

In the usual meshes, material attributes holds the data values, but BufferGeometry holds the Array here. WebGL Renderer still goes to the material attributes for creating attribute pointers, so passing a null value here should do.

More side notes
- want examples? Could add a `webgl_buffergeometry_custom_attributes`
- Not sure how updating would work
- This PR actually reduces 100 lines of code. Could make it go lower too
- Can port this to WebGLRenderer2 
