### PR TITLE
Small patch to OBJLoader to remove extra whitespaces from lines in OBJ f...

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -153,6 +153,7 @@ THREE.OBJLoader.prototype = {
 		for ( var i = 0; i < lines.length; i ++ ) {
 
 			var line = lines[ i ];
+			line = line.replace( /\s+/g, ' ' ); 	// remove extra whitespaces if more than 1 whitespace between vertices on a line
 			line = line.trim();
 
 			var result;

--- a/examples/js/loaders/OBJMTLLoader.js
+++ b/examples/js/loaders/OBJMTLLoader.js
@@ -287,6 +287,7 @@ THREE.OBJMTLLoader.prototype = {
 		for ( var i = 0; i < lines.length; i ++ ) {
 
 			var line = lines[ i ];
+			line = line.replace( /\s+/g, ' ' ); 	// remove extra whitespaces if more than 1 whitespace between vertices on a line
 			line = line.trim();
 
 			// temporary variable storing pattern matching result


### PR DESCRIPTION
Some OBJ files tested have more than 1 whitespace between vertices/faces on each line. Files with different whitespace lengths typically load fine Blender, Max, Maya, etc. Based on my understanding of the specification, longer whitespace is acceptable. 

Examples of different spacing on vertices:

```
 v -3.0 1.8 0.0
 v  -3.0  1.8  0.0
 v   -3.0   1.8   0.0
```

This small fix add a line.replace function to remove extra whitespace so these OBJ files load correctly in three.js. Note the proceeding line.trim() function only removes whitespace at the beginning and end of the line:

``` javascript
var line = lines[ i ];
line = line.replace( /\s+/g, ' ' );     
line = line.trim();
```
