### PR TITLE
Basic ColorConverter in js/examples/math for HSV and other color formats.

### DIFF
--- a/examples/js/math/ColorConverter.js
+++ b/examples/js/math/ColorConverter.js
@@ -46,26 +46,20 @@ THREE.ColorConverter = {
 
 	},
 
-	toHSV: function () {
+	toHSV: function( color ) {
 
-		var hsv = { h: 0, s: 0, v: 0 };
+		var hsl = color.getHSL();
 
-		return function( color ) {
+		// based on https://gist.github.com/xpansive/1337890#file-index-js
+		hsl.s *= ( hsl.l < 0.5 ) ? hsl.l : ( 1 - hsl.l );
 
-			var hsl = color.getHSL();
-
-			// based on https://gist.github.com/xpansive/1337890#file-index-js
-			hsl.s *= ( hsl.l < 0.5 ) ? hsl.l : ( 1 - hsl.l );
-
-			hsv.h = hsl.h;
-			hsv.s = 2 * hsl.s / ( hsl.l + hsl.s );
-			hsv.v = hsl.l + hsl.s;
-			
-			return hsv;
-			
-		}
+		return {
+			h: hsl.h,
+			s: 2 * hsl.s / ( hsl.l + hsl.s ),
+			v: hsl.l + hsl.s
+		};
 		
-	}(),
+	},
 
 	fromStyle: function ( color, style ) {
 

--- a/examples/js/math/ColorConverter.js
+++ b/examples/js/math/ColorConverter.js
@@ -2,81 +2,81 @@
  * @author bhouston / http://exocortex.com/
  */
 
-THREE.ColorConverter = function () {
+THREE.ColorConverter = {
 
-	return this;
+	fromRGB: function ( color, r, g, b ) {
 
-};
+		return color.setRGB( r, g, b );
 
-// these are all static functions that we are extending ColorConverter directly rather than its prorotype.
-THREE.ColorConverter.fromRGB = function ( color, r, g, b ) {
+	},
 
-	return color.setRGB( r, g, b );
+	fromHex: function ( color, hex ) {
 
-};
+		return color.setHex( hex );
 
-THREE.ColorConverter.fromHex = function ( color, hex ) {
+	},
 
-	return color.setHex( hex );
+	toHex: function ( color ) {
 
-};
+		return color.getHex();
 
-THREE.ColorConverter.toHex = function ( color ) {
+	},
+	 
+	toHexString: function ( color ) {
 
-	return color.getHex();
+		return color.getHexString( color );
 
-};
- 
-THREE.ColorConverter.toHexString = function ( color ) {
+	},
 
-	return color.getHexString( color );
+	fromHSL: function ( color, h, s, l ) {
 
-};
+		return color.setHSL( h, s, l );
+	},
 
-THREE.ColorConverter.fromHSL = function ( color, h, s, l ) {
+	toHSL: function ( color ) {
 
-	return color.setHSL( h, s, l );
-};
+		return color.getHSL( color );
 
-THREE.ColorConverter.toHSL = function ( color ) {
+	},
 
-	return color.getHSL( color );
+	fromHSV: function ( color, h, s, v ) {
 
-};
+		// https://gist.github.com/xpansive/1337890#file-index-js
+		return color.setHSL( h, ( s * v ) / ( ( h = ( 2 - s ) * v ) < 1 ? h : ( 2 - h ) ), h * 0.5 );
 
-THREE.ColorConverter.fromHSV = function ( color, h, s, v ) {
+	},
 
-	return color.setHSL( h, ( s * v ) / ( ( h = ( 2 - s ) * v ) < 1 ? h : ( 2 - h ) ), h * 0.5 ); // https://gist.github.com/xpansive/1337890#file-index-js
+	toHSV: function () {
 
-};
+		var hsv = { h: 0, s: 0, v: 0 };
 
-THREE.ColorConverter.toHSV = function () { // based on https://gist.github.com/xpansive/1337890#file-index-js
+		return function( color ) {
 
-	var hsv = { h: 0, s: 0, v: 0 };
+			var hsl = color.getHSL();
 
-	return function( color ) {
+			// based on https://gist.github.com/xpansive/1337890#file-index-js
+			hsl.s *= ( hsl.l < 0.5 ) ? hsl.l : ( 1 - hsl.l );
 
-		var hsl = color.getHSL();
-
-		hsl.s *= ( hsl.l < 0.5 ) ? hsl.l : ( 1 - hsl.l );
-
-		hsv.h = hsl.h;
-		hsv.s = 2 * hsl.s / ( hsl.l + hsl.s );
-		hsv.v = hsl.l + hsl.s;
+			hsv.h = hsl.h;
+			hsv.s = 2 * hsl.s / ( hsl.l + hsl.s );
+			hsv.v = hsl.l + hsl.s;
+			
+			return hsv;
+			
+		}
 		
-		return hsv;
-		
+	}(),
+
+	fromStyle: function ( color, style ) {
+
+		return color.setStyle( style );
+
+	},
+
+	toStyle: function ( color ) {
+
+		return color.getStyle( color );
+
 	}
-}();
-
-THREE.ColorConverter.fromStyle = function ( color, style ) {
-
-	return color.setStyle( style );
-
-};
-
-THREE.ColorConverter.toStyle = function ( color ) {
-
-	return color.getStyle( color );
 
 };

--- a/examples/js/math/ColorConverter.js
+++ b/examples/js/math/ColorConverter.js
@@ -1,0 +1,82 @@
+/**
+ * @author bhouston / http://exocortex.com/
+ */
+
+THREE.ColorConverter = function () {
+
+	return this;
+
+};
+
+// these are all static functions that we are extending ColorConverter directly rather than its prorotype.
+THREE.ColorConverter.fromRGB = function ( color, r, g, b ) {
+
+	return color.setRGB( r, g, b );
+
+};
+
+THREE.ColorConverter.fromHex = function ( color, hex ) {
+
+	return color.setHex( hex );
+
+};
+
+THREE.ColorConverter.toHex = function ( color ) {
+
+	return color.getHex();
+
+};
+ 
+THREE.ColorConverter.toHexString = function ( color ) {
+
+	return color.getHexString( color );
+
+};
+
+THREE.ColorConverter.fromHSL = function ( color, h, s, l ) {
+
+	return color.setHSL( h, s, l );
+};
+
+THREE.ColorConverter.toHSL = function ( color ) {
+
+	return color.getHSL( color );
+
+};
+
+THREE.ColorConverter.fromHSV = function ( color, h, s, v ) {
+
+	return color.setHSL( h, ( s * v ) / ( ( h = ( 2 - s ) * v ) < 1 ? h : ( 2 - h ) ), h * 0.5 ); // https://gist.github.com/xpansive/1337890#file-index-js
+
+};
+
+THREE.ColorConverter.toHSV = function () { // based on https://gist.github.com/xpansive/1337890#file-index-js
+
+	var hsv = { h: 0, s: 0, v: 0 };
+
+	return function( color ) {
+
+		var hsl = color.getHSL();
+
+		hsl.s *= ( hsl.l < 0.5 ) ? hsl.l : ( 1 - hsl.l );
+
+		hsv.h = hsl.h;
+		hsv.s = 2 * hsl.s / ( hsl.l + hsl.s );
+		hsv.v = hsl.l + hsl.s;
+		
+		return hsv;
+		
+	}
+}();
+
+THREE.ColorConverter.fromStyle = function ( color, style ) {
+
+	return color.setStyle( style );
+
+};
+
+THREE.ColorConverter.toStyle = function ( color ) {
+
+	return color.getStyle( color );
+
+};

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -351,6 +351,12 @@ THREE.extend( THREE.Color.prototype, {
 
 	},
 
+	equals: function ( c ) {
+
+		return ( c.r === this.r ) && ( c.g === this.g ) && ( c.b === this.b );
+
+	},
+
 	clone: function () {
 
 		return new THREE.Color().setRGB( this.r, this.g, this.b );

--- a/test/unit/math/ColorConverter.js
+++ b/test/unit/math/ColorConverter.js
@@ -1,0 +1,35 @@
+module( "ColorConverter" );
+
+
+test( "fromRGB", function(){
+    var c1 = new THREE.Color();
+    var c2 = new THREE.Color().setRGB( 0, 0.5, 1 );
+    THREE.ColorConverter.fromRGB( c1, 0, 0.5, 1 );
+    ok( c1.equals( c2 ), "Ok" );
+});
+
+test( "fromHex/toHex", function(){
+    var c1 = new THREE.Color();
+    var c2 = new THREE.Color().setHex( 0x11aaff );
+    THREE.ColorConverter.fromHex( c1, 0x11aaff );
+    ok( c1.equals( c2 ), "Ok" );
+    var hex = THREE.ColorConverter.toHex( c1 );
+    ok( hex === 0x11aaff, "Ok" );
+});
+
+test( "fromHSV/toHSV", function(){
+    var c1 = new THREE.Color();
+   var c2 = new THREE.Color().setHSL( 0.25, 0.5, 0.75 );
+    var hsv = THREE.ColorConverter.toHSV( c2 );
+    THREE.ColorConverter.fromHSV( c1, hsv.h, hsv.s, hsv.v );
+    ok( c1.equals( c2 ), "Ok" );
+});
+
+test( "fromHSL/toHSL", function(){
+    var c1 = new THREE.Color();
+    var c2 = new THREE.Color().setHSL( 0.25, 0.5, 0.75 );
+    var hsl = THREE.ColorConverter.toHSL( c2 );
+    THREE.ColorConverter.fromHSL( c1, hsl.h, hsl.s, hsl.l );
+    ok( c1.equals( c2 ), "Ok" );
+});
+

--- a/test/unit/math/Line3.js
+++ b/test/unit/math/Line3.js
@@ -55,7 +55,6 @@ test( "closestPointToPoint/closestPointToPointParameter", function() {
 	// nearby the ray
 	ok( a.closestPointToPointParameter( zero3.clone(), false ) == -1, "Passed!" );
 	var b2 = a.closestPointToPoint( zero3.clone(), false );
-	console.log( b2 );
 	ok( b2.distanceTo( new THREE.Vector3( 1, 1, 0 ) ) < 0.0001, "Passed!" );
 
 	// nearby the ray

--- a/test/unit/unittests_sources.html
+++ b/test/unit/unittests_sources.html
@@ -28,6 +28,7 @@
   <script src="../../src/math/Sphere.js"></script>
   <script src="../../src/math/Math.js"></script>  
   <script src="../../src/math/Triangle.js"></script>
+  <script src="../../examples/js/math/ColorConverter.js"></script>
 
   <!-- add class-based unit tests below -->
 
@@ -47,6 +48,7 @@
   <script src="math/Matrix4.js"></script>
   <script src="math/Frustum.js"></script>
   <script src="math/Color.js"></script>
+  <script src="math/ColorConverter.js"></script>
 
 </body>
 </html>

--- a/test/unit/unittests_three-math.html
+++ b/test/unit/unittests_three-math.html
@@ -12,6 +12,7 @@
   <!-- add ThreeJS sources to test below -->
 
   <script src="../../build/three-math.js"></script>
+  <script src="../../examples/js/math/ColorConverter.js"></script>
 
   <!-- add class-based unit tests below -->
 
@@ -30,6 +31,7 @@
   <script src="math/Matrix3.js"></script>
   <script src="math/Matrix4.js"></script>
   <script src="math/Frustum.js"></script>
-
+  <script src="math/ColorConverter.js"></script>
+  
 </body>
 </html>

--- a/test/unit/unittests_three.html
+++ b/test/unit/unittests_three.html
@@ -12,6 +12,7 @@
   <!-- add ThreeJS sources to test below -->
 
   <script src="../../build/three.js"></script>
+  <script src="../../examples/js/math/ColorConverter.js"></script>
 
   <!-- add class-based unit tests below -->
 
@@ -30,6 +31,7 @@
   <script src="math/Matrix3.js"></script>
   <script src="math/Matrix4.js"></script>
   <script src="math/Frustum.js"></script>
-
+  <script src="math/ColorConverter.js"></script>
+  
 </body>
 </html>

--- a/test/unit/unittests_three.min.html
+++ b/test/unit/unittests_three.min.html
@@ -12,6 +12,7 @@
   <!-- add ThreeJS sources to test below -->
 
   <script src="../../build/three.min.js"></script>
+  <script src="../../examples/js/math/ColorConverter.js"></script>
 
   <!-- add class-based unit tests below -->
 
@@ -30,6 +31,7 @@
   <script src="math/Matrix3.js"></script>
   <script src="math/Matrix4.js"></script>
   <script src="math/Frustum.js"></script>
-
+  <script src="math/ColorConverter.js"></script>
+  
 </body>
 </html>


### PR DESCRIPTION
This is an initial implementation of the idea discussed here:

https://github.com/mrdoob/three.js/issues/3092

I've written the ColorConverter class along with tests.  I've also added Color.equals() as I needed it for the unit tests.

It supports HSV, the format being removed from Color.

ColorConverter can serve as the basis for the various additional color spaces that @zz85 is interested in adding.
