### PR TITLE
Added basic support for IE10 in CSS3DRenderer

### DIFF
--- a/examples/css3d_periodictable.html
+++ b/examples/css3d_periodictable.html
@@ -115,6 +115,7 @@
 			<button id="sphere">SPHERE</button>
 			<button id="helix">HELIX</button>
 			<button id="grid">GRID</button>
+       </div>
 
 		<script>
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -24,7 +24,7 @@ THREE.CSS3DSprite.prototype = Object.create( THREE.CSS3DObject.prototype );
 
 //
 
-THREE.CSS3DRenderer = function () {
+THREE.CSS3DRenderer = function (el) {
 
 	console.log( 'THREE.CSS3DRenderer (dk)', THREE.REVISION );
 
@@ -33,19 +33,15 @@ THREE.CSS3DRenderer = function () {
 	var _projector = new THREE.Projector();
 	var _tmpMatrix = new THREE.Matrix4();
 
-	this.init = function() {
+	this.init = function(el) {
 
-		this.domElement = document.createElement( 'div' );
-		this.domElement.style.overflow = 'hidden';
+		// attach to existing element or create a new one
+		this.domElement = el || document.createElement( 'div' );
 
-		// TODO: Shouldn't it be possible to remove cameraElement?
-		this.cameraElement = document.createElement( 'div' );
-		this.domElement.appendChild( this.cameraElement );
-
-		setStyle( this.domElement, 'perspectiveOrigin', '50% 50%');
+		//this.domElement.style.overflow = 'hidden';
+		setStyle( this.domElement, 'perspectiveOrigin', '50% 50% 0');
+		setStyle( this.domElement, 'transformOrigin', '50% 50% 0');
 		setStyle( this.domElement, 'transformStyle', 'preserve-3d');
-		setStyle( this.cameraElement, 'transformStyle', 'preserve-3d');
-
 	};
 
 	this.setSize = function ( width, height ) {
@@ -58,12 +54,6 @@ THREE.CSS3DRenderer = function () {
 
 		this.domElement.style.width = width + 'px';
 		this.domElement.style.height = height + 'px';
-
-		if ( this.cameraElement ) {
-			this.cameraElement.style.width = width + 'px';
-			this.cameraElement.style.height = height + 'px';
-		}
-
 	};
 
 	var epsilon = function ( value ) {
@@ -72,7 +62,9 @@ THREE.CSS3DRenderer = function () {
 
 	};
 
+	// apply prefixed styles to dom element
 	var setStyle = function ( el, name, value, prefixes ) {
+
 		prefixes = prefixes || ["Webkit","Moz","O","Ms"];
 		var n=prefixes.length;
 		while(n--) {
@@ -80,6 +72,7 @@ THREE.CSS3DRenderer = function () {
 			el.style[prefix+name.charAt(0 ).toUpperCase()+name.slice(1)] = value;
 			el.style[name] = value;
 		}
+
 	};
 
 	var getCameraCSSMatrix = function ( matrix ) {
@@ -135,7 +128,7 @@ THREE.CSS3DRenderer = function () {
 
 		var elements = matrix.elements;
 
-		return 'translate3d(-50%,-50%,0) matrix3d(' +
+		return 'matrix3d(' +
 			epsilon( elements[ 0 ] ) + ',' +
 			epsilon( elements[ 1 ] ) + ',' +
 			epsilon( elements[ 2 ] ) + ',' +
@@ -162,35 +155,9 @@ THREE.CSS3DRenderer = function () {
 
 		setStyle( this.domElement, 'perspective', fov + "px");
 
-		var viewMatrix = new THREE.Matrix4();
-
 		var objects = _projector.projectScene( scene, camera, false ).objects;
 
-		if( true ) {
-			var style = "translate3d(0,0," + fov + "px)" + getCameraCSSMatrix( camera.matrixWorldInverse ) + " translate3d(" + _widthHalf + "px," + _heightHalf + "px, 0)";
-
-			setStyle( this.cameraElement, 'transform', style);
-
-//			// Create view matrix by getting computed style and turning the result
-//			// back into a new THREE.Matrix4
-//			var computedStyle = window.getComputedStyle(this.cameraElement, null);
-//			var css_transform = computedStyle.getPropertyValue( '-webkit-transform' ) ||
-//								computedStyle.getPropertyValue( '-moz-transform' ) ||
-//								computedStyle.getPropertyValue( '-o-transform' ) ||
-//								computedStyle.getPropertyValue( '-ms-transform' ) ||
-//								computedStyle.getPropertyValue( '-transform' );
-//
-//			viewMatrix.set.apply( viewMatrix, css_transform.replace('matrix3d(', '' ).replace(')', '' ).split(',' ).map(function(n){return Number(n);}));
-//
-//			viewMatrix.transpose();
-
-		} else {
-
-			//viewMatrix.copy( camera.matrixWorldInverse );
-
-			viewMatrix = getSceneMatrix( camera.matrixWorldInverse );
-			viewMatrix.transpose();
-		}
+		var camera_css_matrix = getCameraCSSMatrix( camera.matrixWorldInverse );
 
 		for ( var i = 0, il = objects.length; i < il; i ++ ) {
 
@@ -214,31 +181,25 @@ THREE.CSS3DRenderer = function () {
 					_tmpMatrix.elements[ 11 ] = 0;
 					_tmpMatrix.elements[ 15 ] = 1;
 
-					//_tmpMatrix = _tmpMatrix.multiply( viewMatrix );
-					//_tmpMatrix.multiplyMatrices(_tmpMatrix, viewMatrix  );
-
 				} else {
 
-					_tmpMatrix.identity();
-					_tmpMatrix.multiply( object.matrixWorld );
-//
-//					_tmpMatrix.translate({x:0, y: 0, z: fov});
-//					_tmpMatrix.translate({x:-_widthHalf, y: -_heightHalf, z: 0});
-//					_tmpMatrix.multiply( viewMatrix );
-//					_tmpMatrix.translate({x:_widthHalf, y: _heightHalf, z: 0});
-//					_tmpMatrix.multiply( object.matrixWorld );
+					_tmpMatrix.copy( object.matrixWorld  );
 
 				}
 
-				//setStyle(element, 'backfaceVisibility', 'hidden');
-				//setStyle(element, 'transformOrigin', '0 0');
-				setStyle(element, 'transform', getObjectCSSMatrix( _tmpMatrix ));
+				var style =
+					"translate3d(-50%, -50%, 0)" +
+					"translate3d(" + _widthHalf + "px," + _heightHalf + "px, "+fov+"px)" +
+					camera_css_matrix +
+					getObjectCSSMatrix( _tmpMatrix ) +
+					"";
 
-				var container = this.cameraElement; //this.domElement;
+				setStyle(element, 'transform', style);
+				setStyle(element, 'transformOrigin', "50% 50% 0");
+
+				var container = this.domElement;
 				if ( element.parentNode !== container ) {
-
 					container.appendChild( element );
-
 				}
 
 			}
@@ -247,7 +208,7 @@ THREE.CSS3DRenderer = function () {
 
 	};
 
-	this.init();
+	this.init(el);
 
 
 


### PR DESCRIPTION
Due to the lack of preserve-3d support in IE10, nested 3D transforms do not work as expected. I've updated the CSS3DRenderer and removed the camera DOM element and added the requisite transforms directly to the object elements.

Depth sorting is the key missing piece (in IE). Otherwise, in my tests, all of the examples are working well.
