### PR TITLE
Fix for using multiple AudioObjects

### DIFF
--- a/examples/js/AudioObject.js
+++ b/examples/js/AudioObject.js
@@ -38,7 +38,7 @@ THREE.AudioObject = function ( url, volume, playbackRate, loop ) {
 
 		try {
 
-			this.context = new webkitAudioContext();
+			THREE.AudioObject.prototype.context = new webkitAudioContext();
 
 		} catch( error ) {
 


### PR DESCRIPTION
Hi,

the AudioContext in file AudioObject.js was probably meant to be a static member (prototype.context), so I changed the initialization accordingly. This prevents multiple contexts to be registered in the document. According to spec we should only have one, Chrome seems to support up to 4.

Greetings
lqdchrm
