### PR TITLE
make THREE.VTKLoader more robust

### DIFF
--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -68,11 +68,15 @@ THREE.VTKLoader.prototype = {
 
 		var pattern, result;
 
-		// float float float
+		pattern = /POINTS[\s]+([\d]+)/g
+		result = pattern.exec( data );
+		var numV = parseInt(result[1]);
+		pattern = /([\+|\-]?[\d]+[\.]?[\d|\-|e]*)[ ]+([\+|\-]?[\d]+[\.]?[\d|\-|e]*)[ ]+([\+|\-]?[\d]+[\.]?[\d|\-|e]*)/g;
 
-		pattern = /([\+|\-]?[\d]+[\.][\d|\-|e]+)[ ]+([\+|\-]?[\d]+[\.][\d|\-|e]+)[ ]+([\+|\-]?[\d]+[\.][\d|\-|e]+)/g;
+		// float/int  float/int  float/int
+		while ( numV--) {
 
-		while ( ( result = pattern.exec( data ) ) != null ) {
+			result = pattern.exec( data );
 
 			// ["1.0 2.0 3.0", "1.0", "2.0", "3.0"]
 


### PR DESCRIPTION
Sometimes the mesh coordinates are stored as integers, not floats, which busts regular expressions.

I had to change the regexp for vertices (it may need some more love though) and make sure  that we parse only vertices and not triangles.
