### PR TITLE
Window performance fix

### DIFF
--- a/utils/npm/header.js
+++ b/utils/npm/header.js
@@ -9,7 +9,7 @@ if( window.performance === undefined ) {
 
 }
 
-if( window.performance.now === undefined ) {
+if( ( window.performance.now === undefined ) && ( process !== undefined ) && ( process.hrtime !== undefined ) ) {
 
 	window.performance.now = function () {
 

--- a/utils/npm/header.js
+++ b/utils/npm/header.js
@@ -9,13 +9,28 @@ if( window.performance === undefined ) {
 
 }
 
-if( ( window.performance.now === undefined ) && ( process !== undefined ) && ( process.hrtime !== undefined ) ) {
+if( window.performance.now === undefined ) {
 
-	window.performance.now = function () {
+	// check if we are in a Node.js environment
+	if( ( process !== undefined ) && ( process.hrtime !== undefined ) ) {
 
-		var time = process.hrtime();
-		return ( time[0] + time[1] / 1e9 ) * 1000;
+		window.performance.now = function () {
 
-	};
+			var time = process.hrtime();
+			return ( time[0] + time[1] / 1e9 ) * 1000;
+
+		};
+
+	}
+	// if not Node.js revert to using the Date class
+	else {
+
+		window.performance.now = function() {
+
+			return new Date().getTime();
+
+		};
+
+	}
 
 }


### PR DESCRIPTION
This piece of code here:

https://github.com/mrdoob/three.js/blob/master/utils/npm/header.js#L16

Makes the assumption that if `window.performance` or `window.performance.now` doesn't exist that `process.hrtime()` does exist.  This is not necessarily the case.  Some browsers just don't yet support `windows.performance` I understand or someone may screw up `windows.performance` so that it no longer exists.

My suggested fix is to use `new Date().getTime();` when `process.httime()` doesn't exist.
