### PR TITLE
Allow material to control offset and repeat.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5267,10 +5267,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 		}
 
 		// uv repeat and offset setting priorities
-		//	1. color map
-		//	2. specular map
-		//	3. normal map
-		//	4. bump map
+		//  1. material override
+		//	2. color map
+		//	3. specular map
+		//	4. normal map
+		//	5. bump map
 
 		var uvScaleMap;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5274,9 +5274,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var uvScaleMap;
 
-    if ( material.offset && material.repeat ) {
+		if ( material.uvScaleMap ) {
 
-    	uvScaleMap = material;
+			uvScaleMap = material.uvScaleMap;
 
 		} else if ( material.map ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5274,7 +5274,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var uvScaleMap;
 
-		if ( material.map ) {
+    if ( material.offset && material.repeat ) {
+
+    	uvScaleMap = material;
+
+		} else if ( material.map ) {
 
 			uvScaleMap = material.map;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5273,29 +5273,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 		//	4. normal map
 		//	5. bump map
 
-		var uvScaleMap;
-
-		if ( material.uvScaleMap ) {
-
-			uvScaleMap = material.uvScaleMap;
-
-		} else if ( material.map ) {
-
-			uvScaleMap = material.map;
-
-		} else if ( material.specularMap ) {
-
-			uvScaleMap = material.specularMap;
-
-		} else if ( material.normalMap ) {
-
-			uvScaleMap = material.normalMap;
-
-		} else if ( material.bumpMap ) {
-
-			uvScaleMap = material.bumpMap;
-
-		}
+		var uvScaleMap =
+				material.uvScaleMap ||
+				material.map ||
+				material.specularMap ||
+				material.normalMap ||
+				material.bumpMap;
 
 		if ( uvScaleMap !== undefined ) {
 


### PR DESCRIPTION
I'm making a 2D game which uses lots of sprites. I animate the sprites by switching between subregions of the texture with the "offset" and "repeat" parameters. Each sprite needs to be animated independently. However, I don't want to clone the whole texture for each instance of a sprite.

This change allows the user to assign "offset" and "repeat" values to a Material (where they really belong, I think) instead of a Texture.
