### PR TITLE
Simplified Object3D.updateMatrix() via utilizing Matrix4.compose()

### DIFF
--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -175,19 +175,19 @@
 		Based on [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm].
 		</div>
 
-		<h3>.setRotationFromEuler( [page:Vector3 v], [page:String order] ) [page:Matrix4]</h3>
+		<h3>.makeRotationFromEuler( [page:Vector3 v], [page:String order] ) [page:Matrix4]</h3>
 		<div>
 		v — Rotation vector.
 		order — The order of rotations. Eg. "XYZ".
 		</div>
 		<div>
-		Sets the rotation submatrix of this matrix to the rotation specified by Euler angles.<br />
+		Sets the rotation submatrix of this matrix to the rotation specified by Euler angles, the rest of the matrix is identity.<br />
 		Default order is *"XYZ"*.
 		</div>
 
-		<h3>.setRotationFromQuaternion( [page:Quaternion q] ) [page:Matrix4]</h3>
+		<h3>.makeRotationFromQuaternion( [page:Quaternion q] ) [page:Matrix4]</h3>
 		<div>
-		Sets the rotation submatrix of this matrix to the rotation specified by *q*.
+		Sets the rotation submatrix of this matrix to the rotation specified by *q*. The rest of the matrix is identity.
 		</div>
 
 		<h3>.scale( [page:Vector3 v] ) [page:Matrix4]</h3>

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -195,9 +195,14 @@
 		Multiplies the columns of this matrix by vector *v*.
 		</div>
 
-		<h3>.compose( [page:Vector3 translation], [page:Quaternion rotation], [page:Vector3 scale] ) [page:Matrix4]</h3>
+		<h3>.makeFromPositionQuaternionScale( [page:Vector3 translation], [page:Quaternion rotation], [page:Vector3 scale] ) [page:Matrix4]</h3>
 		<div>
 		Sets this matrix to the transformation composed of *translation*, *rotation* and *scale*.
+		</div>
+
+		<h3>.makeFromPositionEulerScale( [page:Vector3 translation], [page:Vector3 rotation], eulerOrder, [page:Vector3 scale] ) [page:Matrix4]</h3>
+		<div>
+		Sets this matrix to the transformation composed of *translation*, *rotation* (as euler angle triple and order) and *scale*.
 		</div>
 
 		<h3>.decompose( [page:Vector3 translation], [page:Quaternion rotation], [page:Vector3 scale] ) [page:Array]</h3>

--- a/examples/misc_lookat.html
+++ b/examples/misc_lookat.html
@@ -68,7 +68,7 @@
 				scene.add( sphere );
 
 				var geometry = new THREE.CylinderGeometry( 0, 10, 100, 3 );
-				geometry.applyMatrix( new THREE.Matrix4().setRotationFromEuler( new THREE.Vector3( Math.PI / 2, Math.PI, 0 ) ) );
+				geometry.applyMatrix( new THREE.Matrix4().makeRotationFromEuler( new THREE.Vector3( Math.PI / 2, Math.PI, 0 ) ) );
 
 				var material = new THREE.MeshNormalMaterial();
 

--- a/examples/webgl_ribbons.html
+++ b/examples/webgl_ribbons.html
@@ -143,7 +143,7 @@
 					// manually create local matrix
 
 					ribbon.matrix.setPosition( ribbon.position );
-					ribbon.matrixRotationWorld.setRotationFromEuler( ribbon.rotation );
+					ribbon.matrixRotationWorld.makeRotationFromEuler( ribbon.rotation );
 
 					ribbon.matrix.elements[ 0 ] = ribbon.matrixRotationWorld.elements[ 0 ];
 					ribbon.matrix.elements[ 4 ] = ribbon.matrixRotationWorld.elements[ 4 ];

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -319,11 +319,14 @@ THREE.Object3D.prototype = {
 		// if we are not using a quaternion directly, convert Euler rotation to this.quaternion.
 		if ( this.useQuaternion === false )  {
 
-			this.quaternion.setFromEuler( this.rotation, this.eulerOrder );
+			this.matrix.makeFromPositionEulerScale( this.position, this.rotation, this.eulerOrder, this.scale );
 
 		} 
+		else {
 		
-		this.matrix.compose( this.position, this.quaternion, this.scale );
+			this.matrix.makeFromPositionQuaternionScale( this.position, this.quaternion, this.scale );
+
+		}
 
 		this.matrixWorldNeedsUpdate = true;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -316,23 +316,14 @@ THREE.Object3D.prototype = {
 
 	updateMatrix: function () {
 
-		this.matrix.setPosition( this.position );
-
+		// if we are not using a quaternion directly, convert Euler rotation to this.quaternion.
 		if ( this.useQuaternion === false )  {
 
-			this.matrix.setRotationFromEuler( this.rotation, this.eulerOrder );
+			this.quaternion.setFromEuler( this.rotation, this.eulerOrder );
 
-		} else {
-
-			this.matrix.setRotationFromQuaternion( this.quaternion );
-
-		}
-
-		if ( this.scale.x !== 1 || this.scale.y !== 1 || this.scale.z !== 1 ) {
-
-			this.matrix.scale( this.scale );
-
-		}
+		} 
+		
+		this.matrix.compose( this.position, this.quaternion, this.scale );
 
 		this.matrixWorldNeedsUpdate = true;
 

--- a/src/extras/core/Gyroscope.js
+++ b/src/extras/core/Gyroscope.js
@@ -25,7 +25,7 @@ THREE.Gyroscope.prototype.updateMatrixWorld = function ( force ) {
 			this.matrixWorld.decompose( this.translationWorld, this.rotationWorld, this.scaleWorld );
 			this.matrix.decompose( this.translationObject, this.rotationObject, this.scaleObject );
 
-			this.matrixWorld.compose( this.translationWorld, this.rotationObject, this.scaleWorld );
+			this.matrixWorld.makeFromPositionQuaternionScale( this.translationWorld, this.rotationObject, this.scaleWorld );
 
 
 		} else {

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -894,11 +894,31 @@ THREE.Matrix4.prototype = {
 
 THREE.extend( THREE.Matrix4.prototype, {
 
-	compose: function ( position, quaternion, scale ) {
+	makeFromPositionQuaternionScale: function ( position, quaternion, scale ) {
 
 		var te = this.elements;
 
 		this.makeRotationFromQuaternion( quaternion );
+	
+		if ( scale.x !== 1 || scale.y !== 1 || scale.z !== 1 ) {
+
+			this.scale( scale );
+
+		}
+		
+		te[12] = position.x;
+		te[13] = position.y;
+		te[14] = position.z;
+
+		return this;
+
+	},
+
+	makeFromPositionEulerScale: function ( position, rotation, eulerOrder, scale ) {
+
+		var te = this.elements;
+
+		this.makeRotationFromEuler( rotation, eulerOrder );
 	
 		if ( scale.x !== 1 || scale.y !== 1 || scale.z !== 1 ) {
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -903,11 +903,9 @@ THREE.extend( THREE.Matrix4.prototype, {
 
 			var te = this.elements;
 
-			mRotation.identity();
-			mRotation.setRotationFromQuaternion( quaternion );
-
+			mRotation.makeRotationFromQuaternion( quaternion );
+		
 			mScale.makeScale( scale.x, scale.y, scale.z );
-
 			this.multiplyMatrices( mRotation, mScale );
 
 			te[12] = position.x;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -894,29 +894,25 @@ THREE.Matrix4.prototype = {
 
 THREE.extend( THREE.Matrix4.prototype, {
 
-	compose: function() {
+	compose: function ( position, quaternion, scale ) {
 
-		var mRotation = new THREE.Matrix4();
-		var mScale = new THREE.Matrix4();
+		var te = this.elements;
 
-		return function ( position, quaternion, scale ) {
+		this.makeRotationFromQuaternion( quaternion );
+	
+		if ( scale.x !== 1 || scale.y !== 1 || scale.z !== 1 ) {
 
-			var te = this.elements;
+			this.scale( scale );
 
-			mRotation.makeRotationFromQuaternion( quaternion );
+		}
 		
-			mScale.makeScale( scale.x, scale.y, scale.z );
-			this.multiplyMatrices( mRotation, mScale );
+		te[12] = position.x;
+		te[13] = position.y;
+		te[14] = position.z;
 
-			te[12] = position.x;
-			te[13] = position.y;
-			te[14] = position.z;
+		return this;
 
-			return this;
-
-		};
-
-	}(),
+	},
 
 	decompose: function() {
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -119,6 +119,14 @@ THREE.Matrix4.prototype = {
 
 	}(),
 
+	setRotationFromEuler: function ( v, order ) {
+
+		console.warn( 'DEPRECATED: Matrix4\'s .setRotationFromEuler() has been deprecated in favor of makeRotationFromEuler.  Please update your code.' );
+		
+		return this.makeRotationFromEuler( v, order );
+
+	},
+
 	makeRotationFromEuler: function ( v, order ) {
 
 		var te = this.elements;
@@ -238,6 +246,14 @@ THREE.Matrix4.prototype = {
 		te[15] = 1;
 
 		return this;
+
+	},
+
+	setRotationFromQuaternion: function ( q ) {
+
+		console.warn( 'DEPRECATED: Matrix4\'s .setRotationFromQuaternion() has been deprecated in favor of makeRotationFromQuaternion.  Please update your code.' );
+		
+		return this.makeRotationFromQuaternion( q );
 
 	},
 
@@ -893,6 +909,14 @@ THREE.Matrix4.prototype = {
 };
 
 THREE.extend( THREE.Matrix4.prototype, {
+
+	compose: function ( position, quaternion, scale ) {
+
+		console.warn( 'DEPRECATED: Matrix4\'s .compose() has been deprecated in favor of makeFromPositionQuaternionScale.  Please update your code.' );
+		
+		return this.makeFromPositionQuaternionScale( position, quaternion, scale );
+
+	},
 
 	makeFromPositionQuaternionScale: function ( position, quaternion, scale ) {
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -920,18 +920,9 @@ THREE.extend( THREE.Matrix4.prototype, {
 
 	makeFromPositionQuaternionScale: function ( position, quaternion, scale ) {
 
-		var te = this.elements;
-
 		this.makeRotationFromQuaternion( quaternion );
-	
-		var sx = scale.x, sy = scale.y, sz = scale.z;
-		te[0] *= sx; te[4] *= sy; te[8] *= sz;
-		te[1] *= sx; te[5] *= sy; te[9] *= sz;
-		te[2] *= sx; te[6] *= sy; te[10] *= sz;
-		
-		te[12] = position.x;
-		te[13] = position.y;
-		te[14] = position.z;
+		this.scale( scale );
+		this.setPosition( position );
 
 		return this;
 
@@ -939,18 +930,9 @@ THREE.extend( THREE.Matrix4.prototype, {
 
 	makeFromPositionEulerScale: function ( position, rotation, eulerOrder, scale ) {
 
-		var te = this.elements;
-
 		this.makeRotationFromEuler( rotation, eulerOrder );
-	
-		var sx = scale.x, sy = scale.y, sz = scale.z;
-		te[0] *= sx; te[4] *= sy; te[8] *= sz;
-		te[1] *= sx; te[5] *= sy; te[9] *= sz;
-		te[2] *= sx; te[6] *= sy; te[10] *= sz;
-		
-		te[12] = position.x;
-		te[13] = position.y;
-		te[14] = position.z;
+		this.scale( scale );
+		this.setPosition( position );
 
 		return this;
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -119,7 +119,7 @@ THREE.Matrix4.prototype = {
 
 	}(),
 
-	setRotationFromEuler: function ( v, order ) {
+	makeRotationFromEuler: function ( v, order ) {
 
 		var te = this.elements;
 
@@ -226,11 +226,22 @@ THREE.Matrix4.prototype = {
 
 		}
 
+		// last column
+		te[3] = 0;
+		te[7] = 0;
+		te[11] = 0;
+
+		// bottom row
+		te[12] = 0;
+		te[13] = 0;
+		te[14] = 0;
+		te[15] = 1;
+
 		return this;
 
 	},
 
-	setRotationFromQuaternion: function ( q ) {
+	makeRotationFromQuaternion: function ( q ) {
 
 		var te = this.elements;
 
@@ -251,6 +262,17 @@ THREE.Matrix4.prototype = {
 		te[2] = xz - wy;
 		te[6] = yz + wx;
 		te[10] = 1 - ( xx + yy );
+
+		// last column
+		te[3] = 0;
+		te[7] = 0;
+		te[11] = 0;
+
+		// bottom row
+		te[12] = 0;
+		te[13] = 0;
+		te[14] = 0;
+		te[15] = 1;
 
 		return this;
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -924,11 +924,10 @@ THREE.extend( THREE.Matrix4.prototype, {
 
 		this.makeRotationFromQuaternion( quaternion );
 	
-		if ( scale.x !== 1 || scale.y !== 1 || scale.z !== 1 ) {
-
-			this.scale( scale );
-
-		}
+		var sx = scale.x, sy = scale.y, sz = scale.z;
+		te[0] *= sx; te[4] *= sy; te[8] *= sz;
+		te[1] *= sx; te[5] *= sy; te[9] *= sz;
+		te[2] *= sx; te[6] *= sy; te[10] *= sz;
 		
 		te[12] = position.x;
 		te[13] = position.y;
@@ -944,11 +943,10 @@ THREE.extend( THREE.Matrix4.prototype, {
 
 		this.makeRotationFromEuler( rotation, eulerOrder );
 	
-		if ( scale.x !== 1 || scale.y !== 1 || scale.z !== 1 ) {
-
-			this.scale( scale );
-
-		}
+		var sx = scale.x, sy = scale.y, sz = scale.z;
+		te[0] *= sx; te[4] *= sy; te[8] *= sz;
+		te[1] *= sx; te[5] *= sy; te[9] *= sz;
+		te[2] *= sx; te[6] *= sy; te[10] *= sz;
 		
 		te[12] = position.x;
 		te[13] = position.y;

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -24,7 +24,7 @@ THREE.Sprite.prototype.updateMatrix = function () {
 
 	this.rotation3d.set( 0, 0, this.rotation );
 	this.quaterion.setFromEuler( this.rotation3d, this.eulerOrder );
-	this.matrix.compose( this.position, this.quaternion, this.scale );
+	this.matrix.makeFromPositionQuaternionScale( this.position, this.quaternion, this.scale );
 
 	this.matrixWorldNeedsUpdate = true;
 

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -22,16 +22,9 @@ THREE.Sprite.prototype = Object.create( THREE.Object3D.prototype );
 
 THREE.Sprite.prototype.updateMatrix = function () {
 
-	this.matrix.setPosition( this.position );
-
 	this.rotation3d.set( 0, 0, this.rotation );
-	this.matrix.setRotationFromEuler( this.rotation3d );
-
-	if ( this.scale.x !== 1 || this.scale.y !== 1 ) {
-
-		this.matrix.scale( this.scale );
-
-	}
+	this.quaterion.setFromEuler( this.rotation3d, this.eulerOrder );
+	this.matrix.compose( this.position, this.quaternion, this.scale );
 
 	this.matrixWorldNeedsUpdate = true;
 

--- a/test/unit/math/Quaternion.js
+++ b/test/unit/math/Quaternion.js
@@ -111,7 +111,7 @@ test( "setFromEuler/setFromRotationMatrix", function() {
 	// ensure euler conversion for Quaternion matches that of Matrix4
 	for( var i = 0; i < orders.length; i ++ ) {
 		var q = new THREE.Quaternion().setFromEuler( eulerAngles, orders[i] );
-		var m = new THREE.Matrix4().setRotationFromEuler( eulerAngles, orders[i] );
+		var m = new THREE.Matrix4().makeRotationFromEuler( eulerAngles, orders[i] );
 		var q2 = new THREE.Quaternion().setFromRotationMatrix( m );
 
 		ok( qSub( q, q2 ).length() < 0.001, "Passed!" );
@@ -161,9 +161,9 @@ test( "multiplyQuaternions/multiply", function() {
 
 	var q = new THREE.Quaternion().multiplyQuaternions( q1, q2 ).multiply( q3 );
 
-	var m1 = new THREE.Matrix4().setRotationFromEuler( angles[0], "XYZ" );
-	var m2 = new THREE.Matrix4().setRotationFromEuler( angles[1], "XYZ" );
-	var m3 = new THREE.Matrix4().setRotationFromEuler( angles[2], "XYZ" );
+	var m1 = new THREE.Matrix4().makeRotationFromEuler( angles[0], "XYZ" );
+	var m2 = new THREE.Matrix4().makeRotationFromEuler( angles[1], "XYZ" );
+	var m3 = new THREE.Matrix4().makeRotationFromEuler( angles[2], "XYZ" );
 
 	var m = new THREE.Matrix4().multiplyMatrices( m1, m2 ).multiply( m3 );
 
@@ -180,7 +180,7 @@ test( "multiplyVector3", function() {
 	for( var i = 0; i < orders.length; i ++ ) {
 		for( var j = 0; j < angles.length; j ++ ) {
 			var q = new THREE.Quaternion().setFromEuler( angles[j], orders[i] );
-			var m = new THREE.Matrix4().setRotationFromEuler( angles[j], orders[i] );
+			var m = new THREE.Matrix4().makeRotationFromEuler( angles[j], orders[i] );
 
 			var v0 = new THREE.Vector3(1, 0, 0);
 			var qv = v0.clone().applyQuaternion( q );


### PR DESCRIPTION
Object3D.updateMatrix() was creating a matrix by putting together position, rotation (either Euler or Quaternion) and scale.  This functionality is already available in Matrix4.compose().  Thus I have simplified Object3D.updateMatrix to use Matrix4.compose.  This will ensure we only have one method that performs the composition, and we can focus on optimizing only one code path rather than two.

Also I have modified and renamed Matrix4.setRotationFromQuaternion and Matrix4.setRotationFromEuler to be "make" functions as they were destructive of scale.  I have modified them to be fully destructive by setting the rest of the matrix to identity.

I also optimized Matrix4.compose() significantly as it is now critical to Object3D.updateMatrix() performance.

I have updated the documentation and examples as applicable.
