### PR TITLE
Deprecated Matrix4.crossVector()

### DIFF
--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -109,11 +109,6 @@
 		Applies this matrix to *v*.
 		</div>
 
-		<h3>.crossVector( [page:Vector4 a] ) [page:Vector4]</h3>
-		<div>
-		Computes the cross product between this matrix and the [page:Vector4] parameter *a*.
-		</div>
-
 		<h3>.determinant() [page:Float]</h3>
 		<div>
 		Computes determinant of this matrix.<br />

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -425,18 +425,10 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	crossVector: function ( a ) {
+	crossVector: function ( vector ) {
 
-		var te = this.elements;
-		var v = new THREE.Vector4();
-
-		v.x = te[0] * a.x + te[4] * a.y + te[8] * a.z + te[12] * a.w;
-		v.y = te[1] * a.x + te[5] * a.y + te[9] * a.z + te[13] * a.w;
-		v.z = te[2] * a.x + te[6] * a.y + te[10] * a.z + te[14] * a.w;
-
-		v.w = ( a.w ) ? te[3] * a.x + te[7] * a.y + te[11] * a.z + te[15] * a.w : 1;
-
-		return v;
+		console.warn( 'DEPRECATED: Matrix4\'s .crossVector() has been removed. Use vector.applyMatrix4( matrix ) instead.' );
+		return vector.applyMatrix4( this );
 
 	},
 


### PR DESCRIPTION
`Matrix4.crossVector()` appears to be left over from an earlier time. 

It is no longer needed, as we now have `Vector*.applyMatrix4( matrix )`.
