### PR TITLE
Updated the Max exporter and JSON Loader to take into account emissive property

### DIFF
--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -233,6 +233,7 @@ THREE.Loader.prototype = {
 
 		}
 
+
 		if ( m.transparent !== undefined || m.opacity < 1.0 ) {
 
 			mpars.transparent = m.transparent;
@@ -311,6 +312,10 @@ THREE.Loader.prototype = {
 
 			mpars.ambient = rgb2hex( m.colorAmbient );
 
+		}
+
+		if (m.emissive !== undefined) {
+		    mpars.emissive = rgb2hex(m.emissive);		    
 		}
 
 		// modifiers

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -312,9 +312,6 @@ THREE.Loader.prototype = {
 			mpars.ambient = rgb2hex( m.colorAmbient );
 
 		}
-                if (m.emissive !== undefined) {
-		    mpars.emissive = rgb2hex(m.emissive);		    
-		}
 
 		// modifiers
 

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -312,6 +312,9 @@ THREE.Loader.prototype = {
 			mpars.ambient = rgb2hex( m.colorAmbient );
 
 		}
+                if (m.emissive !== undefined) {
+		    mpars.emissive = rgb2hex(m.emissive);		    
+		}
 
 		// modifiers
 

--- a/utils/exporters/max/ThreeJSExporter.ms
+++ b/utils/exporters/max/ThreeJSExporter.ms
@@ -483,15 +483,24 @@ rollout ThreeJSExporter "ThreeJSExporter"
 				DumpColor mat.diffuse  "colorDiffuse"
 				DumpColor mat.ambient  "colorAmbient"
 				DumpColor mat.specular "colorSpecular"
-				DumpColor mat.selfIllumColor  "colorEmissive"
+				
+				sICol = mat.selfIllumColor
+				-- check if the self Illumination color is black
+				if(mat.selfIllumColor  == (color 0 0 0) ) then				
+				(					
+					al = mat.diffuse.a
+					sICol = mat.diffuse * (mat.selfIllumAmount /100)
+					sICol.a = al					
+				)
+				DumpColor sICol "emissive"
 								
 				t = mat.opacity / 100
 				s = mat.glossiness
-				il = mat.selfIllumAmount /100
+				
 
 				Format "\"transparency\"  : %,\n" t to:ostream
 				Format "\"specularCoef\"  : %,\n" s to:ostream
-				Format "\"Emissive\"  : %,\n" il to:ostream
+				
 				
 				-- maps
 

--- a/utils/exporters/max/ThreeJSExporter.ms
+++ b/utils/exporters/max/ThreeJSExporter.ms
@@ -483,13 +483,16 @@ rollout ThreeJSExporter "ThreeJSExporter"
 				DumpColor mat.diffuse  "colorDiffuse"
 				DumpColor mat.ambient  "colorAmbient"
 				DumpColor mat.specular "colorSpecular"
-
+				DumpColor mat.selfIllumColor  "colorEmissive"
+								
 				t = mat.opacity / 100
 				s = mat.glossiness
+				il = mat.selfIllumAmount /100
 
 				Format "\"transparency\"  : %,\n" t to:ostream
 				Format "\"specularCoef\"  : %,\n" s to:ostream
-
+				Format "\"Emissive\"  : %,\n" il to:ostream
+				
 				-- maps
 
 				DumpMap mat.diffuseMap  "mapDiffuse"


### PR DESCRIPTION
Taking into account the selfIllumination material property in Max which seems to map to the emissive property in three.js
