### PR TITLE
made lensflares work in webglrenderer2

### DIFF
--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -1321,7 +1321,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			_lightsNeedUpdate = true;
 			renderer.resetState();
 
-			plugins[ i ].render( scene, camera, renderer.getCurrentWidth(), renderer.getCurrentWidth() );
+			plugins[ i ].render( scene, camera, renderer.getCurrentWidth(), renderer.getCurrentHeight() );
 
 			// reset state after plugin (anything could have changed)
 


### PR DESCRIPTION
This fixes the annoying bug in webglrenderer2 that made lensflares unable to work.
