### PR TITLE
Update Color documentation

### DIFF
--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -10,20 +10,21 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-		Represents a color. See also [page:ColorUtils].
+		Represents a color.
 		</div>
 
 
 		<h2>Example</h2>
-
+		<code>var color = new THREE.Color();</code>
 		<code>var color = new THREE.Color( 0xff0000 );</code>
+		<code>var color = new THREE.Color("rgb(255,0,0)");</code>
 
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Integer hex])</h3>
+		<h3>[name]( value )</h3>
 		<div>
-		hex — initial color in hexadecimal<br />
+		value — optional argument that sets initial color.  Can be a hexadecimal or a CSS-style string, for example, "rgb(250, 0,0)", "rgb(100%,0%,0%)", "#ff0000", "#f00", or "red"
 		</div>
 
 		<h2>Properties</h2>
@@ -106,21 +107,75 @@
 		<div>
 		Sets this color from a hexadecimal value.
 		</div>
-
-		<h3>.getContextStyle() [page:String]</h3>
+		
+		<h3>.setStyle( [page:String style] ) [page:this]</h3>
 		<div>
-		Returns the value of this color in CSS context style.<br />
-		Example: rgb(r, g, b)
-		</div>
-
-		<h3>.setContextStyle( [page:String contextStyle] ) [page:this]</h3>
-		<div>
-		contextStyle — Color in CSS context style format.<br />
+		style — color as a CSS-style string, for example, "rgb(250, 0,0)", "rgb(100%,0%,0%)", "#ff0000", "#f00", or "red"
 		</div>
 		<div>
-		Sets this color from a CSS context style string.
+		Sets this color	from a CSS-style string.		
+		</div>
+		
+		<h3>.getStyle() [page:String]</h3>
+		<div>
+		Returns the value of this color as a CSS-style string. Example: rgb(255,0,0)
+		</div>
+		
+		<h3>.setHSL( [page:Float h], [page:Float s], [page:Float l] ) [page:this]</h3>
+		<div>
+		h — hue value between 0.0 and 1.0
+		s — saturation value between 0.0 and 1.0
+		l — lightness value between 0.0 and 1.0		
+		</div>
+		<div>
+		Sets color from hsl
+		</div>
+		
+		<h3>.getHSL() [page:Object hsl]</h3>
+		<div>
+		Returns an object with properties h, s, and l.	
+		</div>
+		
+		<h3>.offsetHSL( [page:Float h], [page:Float s], [page:Float l] ) [page:this]</h3>
+		<div>
+		Adds given h, s, and l to this color's existing h, s, and l values.
+		</div>
+		
+		<h3>.add ( [page:Color color] ) [page:this]</h3>
+		<div>
+		Adds rgb values of given color to rgb values of this color
+		</div>
+		
+		<h3>.addColors( [page:Color color1], [page:Color color2] ) [page:this]</h3>
+		<div>
+		Sets this color to the sum of color1 and color2
+		</div>
+		
+		<h3>.addScalar( [page:Number s] ) [page:this]</h3>
+		<div>
+		Adds s to the rgb values of this color
+		</div>
+		
+		<h3>.multiply( [page:Color color] ) [page:this]</h3>
+		<div>
+		Multiplies this color's rgb values by given color's rgb values
 		</div>
 
+		<h3>.multiplyScalar( [page:Number s] ) [page:this]</h3>
+		<div>
+		Multiplies this color's rgb values by s
+		</div>
+		
+		<h3>.lerp( [page:Color color], alpha ) [page:this]</h3>
+		<div>
+		todo	
+		</div>
+		
+		<h3>.equals( [page:Color c] ) [page:this]</h3>
+		<div>
+		Compares this color and c and returns true if they are the same, false otherwise.
+		</div>
+		
 		<h3>.clone() [page:Color]</h3>
 		<div>
 		Clones this color.

--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -123,8 +123,8 @@
 		
 		<h3>.setHSL( [page:Float h], [page:Float s], [page:Float l] ) [page:this]</h3>
 		<div>
-		h — hue value between 0.0 and 1.0
-		s — saturation value between 0.0 and 1.0
+		h — hue value between 0.0 and 1.0 <br />
+		s — saturation value between 0.0 and 1.0 <br />
 		l — lightness value between 0.0 and 1.0		
 		</div>
 		<div>


### PR DESCRIPTION
updated documentation for constructor argument

added documentation for undocumented methods: add, addColor, addScalar, multiply, multiplyScalar, equal, lerp, getStyle, setStyle, setHSL, offsetHSL, getHSL.

removed documentation for methods that don't exist: getContextStyle, setContextStyle 

removed reference to ColorUtils, which no longer exists.
