### PR TITLE
Fix Fog and FogExp2 documentation

### DIFF
--- a/docs/api/scenes/Fog.html
+++ b/docs/api/scenes/Fog.html
@@ -15,12 +15,15 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [page:Integer hex], [page:Float near], [page:Float far] )</h3>
-
+		<div>The hex parameter is passed to the [page:Color] constructor to set the color property.  Hex can be a hexadecimal integer or a CSS-style string.</div>
 
 		<h2>Properties</h2>
 
-		<h3>.[page:Integer hex]</h3>
-		<div>Fog color in hexadecimal. Example: 0x000000 will render far away objects black.</div>
+		<h3>.[page:String name]</h3>
+		<div>Default is the empty string.</div>
+
+		<h3>.[page:Color color]</h3>
+		<div>Fog color.  Example: If set to black, far away objects will be rendered black.</div>
 
 		<h3>.[page:Float near]</h3>
 		<div>The minimum distance to start applying fog. Objects that are less than 'near' units from the active camera won't be affected by fog.</div>
@@ -29,7 +32,11 @@
 		<h3>.[page:Float far]</h3>
 		<div>The maximum distance at which fog stops being calculated and applied. Objects that are more than 'far' units away from the active camera won't be affected by fog.</div>
 		<div>Default is 1000.</div>
+		
+		<h2>Methods</h2>
 
+		<h3>.clone() [page:Fog]</h3>
+		<div>Returns a copy of this.</div>
 
 		<h2>Source</h2>
 

--- a/docs/api/scenes/FogExp2.html
+++ b/docs/api/scenes/FogExp2.html
@@ -9,22 +9,30 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">This class contains the parameters that define linear fog, i.e., that grows exponentially denser with the distance.</div>
+		<div class="desc">This class contains the parameters that define exponential fog, i.e., that grows exponentially denser with the distance.</div>
 
 
 		<h2>Constructor</h2>
 
 		<h3>[name]( [page:Integer hex], [page:Float density])</h3>
 
-
+		<div>The hex parameter is passed to the [page:Color] constructor to set the color property.  Hex can be a hexadecimal integer or a CSS-style string.</div>
 		<h2>Properties</h2>
 
-		<h3>.[page:Integer hex]</h3>
-		<div>Fog color in hexadecimal. Example: 0x000000 will render far away objects black.</div>
+		<h3>.[page:String name]</h3>
+		<div>Default is the empty string.</div>
+
+		<h3>.[page:Color hex]</h3>
+		<div>Fog color. Example: If set to black, far away objects will be rendered black.</div>
 
 		<h3>.[page:Float density]</h3>
 		<div>Defines how fast the fog will grow dense.</div>
 		<div>Default is 0.00025.</div>
+
+		<h2>Methods</h2>
+		
+		<h3>.clone() [page:FogExp2]</h3>
+		<div>Returns a copy of this.</div>
 
 
 		<h2>Source</h2>


### PR DESCRIPTION
Corrected color property documentation and added an explanation of the difference between the hex parameter and the color property.  Also added documentation for the clone method and the name property.  I didn't put much of a description for the name property because I don't know what it's for.
