### PR TITLE
Fixed bug in Phong shader when using normal maps with derivative tangent...

### DIFF
--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -190,7 +190,17 @@
 				var parameters = { fragmentShader: shader.fragmentShader, vertexShader: shader.vertexShader, uniforms: uniforms, lights: true, fog: false };
 				var material1 = new THREE.ShaderMaterial( parameters );
 
-				var material2 = new THREE.MeshPhongMaterial( { color: diffuse, specular: specular, ambient: ambient, shininess: shininess, envMap: reflectionCube, combine: THREE.MixOperation, reflectivity: 0.1 } );
+				var material2 = new THREE.MeshPhongMaterial( {
+					color: diffuse,
+					specular: specular,
+					ambient: ambient,
+					shininess: shininess,
+					normalMap: uniforms[ "tNormal" ].value,
+					normalScale: uniforms[ "uNormalScale" ].value,
+					envMap: reflectionCube,
+					combine: THREE.MixOperation,
+					reflectivity: 0.1
+				} );
 
 				//
 

--- a/src/renderers/WebGLShaders.js
+++ b/src/renderers/WebGLShaders.js
@@ -863,7 +863,7 @@ THREE.ShaderChunk = {
 
 		"#ifdef USE_NORMALMAP",
 
-			"normal = perturbNormal2Arb( -viewPosition, normal );",
+			"normal = perturbNormal2Arb( -vViewPosition, normal );",
 
 		"#elif defined( USE_BUMPMAP )",
 


### PR DESCRIPTION
...s

Also, since we did not have an example of using derivative tangents with normal maps with `MeshPhongMaterial`, I incorporated an example into `webgl_materials_normalmap.html`.
