### PR TITLE
Fixed vertex normals and UVs for CircleGeometry

### DIFF
--- a/src/extras/geometries/CircleGeometry.js
+++ b/src/extras/geometries/CircleGeometry.js
@@ -27,11 +27,11 @@ THREE.CircleGeometry = function ( radius, segments, thetaStart, thetaLength ) {
 		vertex.y = radius * Math.sin( segment );
 
 		this.vertices.push( vertex );
-		uvs.push( new THREE.Vector2( ( vertex.x / radius + 1 ) / 2, - ( vertex.y / radius + 1 ) / 2 + 1 ) );
+		uvs.push( new THREE.Vector2( ( vertex.x / radius + 1 ) / 2, ( vertex.y / radius + 1 ) / 2 ) );
 
 	}
 
-	var n = new THREE.Vector3( 0, 0, -1 );
+	var n = new THREE.Vector3( 0, 0, 1 );
 
 	for ( i = 1; i <= segments; i ++ ) {
 


### PR DESCRIPTION
UVs were upside down and vertex normals needed a sign flip. Looks good now.

![Screen Shot 2013-04-08 at 1 56 01 AM](https://f.cloud.github.com/assets/1000017/350236/168322c2-a011-11e2-8c3a-70c2715f00b6.png)
