### PR TITLE
SpotLight.angle and SpotlightHelper cone size bug fixes

### DIFF
--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -67,8 +67,8 @@ scene.add( spotLight );</code>
 	
 		<h3>.[page:Float angle]</h3>
 		<div>
-			Maximum extent of the spotlight, in radians, from its direction.<br />
-			Default — *Math.PI/2*.
+			Maximum extent of the spotlight, in radians, from its direction. Should be no more than *Math.PI/2*.<br />
+			Default — *Math.PI/3*.
 		</div>
 	
 		<h3>.[page:Float exponent]</h3>

--- a/examples/webgl_loader_ctm.html
+++ b/examples/webgl_loader_ctm.html
@@ -99,7 +99,7 @@
 				var ambient = new THREE.AmbientLight( 0x080808 );
 				//scene.add( ambient );
 
-				var light = new THREE.SpotLight( 0xffeedd, 1.2, 650, 2.5, 3 );
+				var light = new THREE.SpotLight( 0xffeedd, 1.2, 650, Math.PI/2, 3 );
 				light.position.set( 0, -100, 500 );
 
 				light.castShadow = true;

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -170,7 +170,7 @@
 				ambientLight = new THREE.AmbientLight( 0x555555 );
 				scene.add( ambientLight );
 
-				spotLight = new THREE.SpotLight( 0xffffff, 1, 0, Math.PI, 1 );
+				spotLight = new THREE.SpotLight( 0xffffff, 1, 0, Math.PI/2, 1 );
 				spotLight.position.set( 0, 1800, 1500 );
 				spotLight.target.position.set( 0, 0, 0 );
 				spotLight.castShadow = true;

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -316,7 +316,7 @@
 				pointLight.position.set( 0, 0, 0 );
 				scene.add( pointLight );
 
-				sunLight = new THREE.SpotLight( 0xffffff, sunIntensity, 0, Math.PI, 1 );
+				sunLight = new THREE.SpotLight( 0xffffff, sunIntensity, 0, Math.PI/2, 1 );
 				sunLight.position.set( 1000, 2000, 1000 );
 
 				sunLight.castShadow = true;

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -103,7 +103,7 @@
 				var ambient = new THREE.AmbientLight( 0x444444 );
 				scene.add( ambient );
 
-				light = new THREE.SpotLight( 0xffffff, 1, 0, Math.PI, 1 );
+				light = new THREE.SpotLight( 0xffffff, 1, 0, Math.PI/2, 1 );
 				light.position.set( 0, 1500, 1000 );
 				light.target.position.set( 0, 0, 0 );
 

--- a/src/extras/helpers/SpotLightHelper.js
+++ b/src/extras/helpers/SpotLightHelper.js
@@ -1,7 +1,8 @@
 /**
  * @author alteredq / http://alteredqualia.com/
  * @author mrdoob / http://mrdoob.com/
- */
+ * @author WestLangley / http://github.com/WestLangley
+*/
 
 THREE.SpotLightHelper = function ( light, sphereSize ) {
 
@@ -31,7 +32,7 @@ THREE.SpotLightHelper = function ( light, sphereSize ) {
 	this.lightCone.position = this.light.position;
 
 	var coneLength = light.distance ? light.distance : 10000;
-	var coneWidth = coneLength * Math.tan( light.angle * 0.5 ) * 2;
+	var coneWidth = coneLength * Math.tan( light.angle );
 
 	this.lightCone.scale.set( coneWidth, coneWidth, coneLength );
 	this.lightCone.lookAt( this.light.target.position );
@@ -45,7 +46,7 @@ THREE.SpotLightHelper.prototype = Object.create( THREE.Object3D.prototype );
 THREE.SpotLightHelper.prototype.update = function () {
 
 	var coneLength = this.light.distance ? this.light.distance : 10000;
-	var coneWidth = coneLength * Math.tan( this.light.angle * 0.5 ) * 2;
+	var coneWidth = coneLength * Math.tan( this.light.angle );
 
 	this.lightCone.scale.set( coneWidth, coneWidth, coneLength );
 	this.lightCone.lookAt( this.light.target.position );

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -11,7 +11,7 @@ THREE.SpotLight = function ( hex, intensity, distance, angle, exponent ) {
 
 	this.intensity = ( intensity !== undefined ) ? intensity : 1;
 	this.distance = ( distance !== undefined ) ? distance : 0;
-	this.angle = ( angle !== undefined ) ? angle : Math.PI / 2;
+	this.angle = ( angle !== undefined ) ? angle : Math.PI / 3;
 	this.exponent = ( exponent !== undefined ) ? exponent : 10;
 
 	this.castShadow = false;


### PR DESCRIPTION
1. Fixed SpotlightHelper cone size, which was incorrectly calculated. Now the helper's cone matches the spotlight's extent.
2. There has apparently been confusion as to the meaning of `SpotLight.angle`. The definition in the docs is correct: "Maximum extent of the spotlight, in radians, from its direction." This means that the maximum reasonable value for `angle` is `Math.PI/2`. Larger values were used in the examples. I fixed the examples as needed.
3. Spotlights throw light backwards (see image below). I did not fix this in the shaders; it is not an issue if `SpotLight.angle <= Math.PI/2`.
4. I changed the default `SpotLight.angle` to `Math.PI/3`, so it casts light more like a spotlight would. I would prefer to have set the default to `Math.PI/4`, which may have been the original intention, but decided to use `Math.PI/3`, a less drastic change.

![Screen Shot 2013-04-09 at 8 56 52 PM](https://f.cloud.github.com/assets/1000017/360084/4b77526a-a17d-11e2-9c2c-9b8d6e5dbf85.png)
