### PR TITLE
Fix MIME type request in sample code. Fixes #3292

### DIFF
--- a/docs/manual/introduction/Creating-a-scene.html
+++ b/docs/manual/introduction/Creating-a-scene.html
@@ -27,7 +27,7 @@
 				&lt;style&gt;canvas { width: 100%; height: 100% }&lt;/style&gt;
 			&lt;/head&gt;
 			&lt;body&gt;
-				&lt;script src="https://raw.github.com/mrdoob/three.js/master/build/three.js"&gt;&lt;/script&gt;
+				&lt;script src="https://rawgithub.com/mrdoob/three.js/master/build/three.js"&gt;&lt;/script&gt;
 				&lt;script&gt;
 					// Our Javascript will go here.
 				&lt;/script&gt;
@@ -121,7 +121,7 @@
 				&lt;style&gt;canvas { width: 100%; height: 100% }&lt;/style&gt;
 			&lt;/head&gt;
 			&lt;body&gt;
-				&lt;script src="https://raw.github.com/mrdoob/three.js/master/build/three.js"&gt;&lt;/script&gt;
+				&lt;script src="https://rawgithub.com/mrdoob/three.js/master/build/three.js"&gt;&lt;/script&gt;
 				&lt;script&gt;
 					var scene = new THREE.Scene();
 					var camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 1000);


### PR DESCRIPTION
rawgithub.com and raw.github.com serve files with different MIME types.  Chrome doesn't treat the MIME type served from raw.github.com as executable JavaScript, so the sample code provided in Creating-a-scene.html fails.  This patch changes the requested URL to make the sample code run correctly in all browsers.
