### PR TITLE
npm build script can be used on linux/unix environment

### DIFF
--- a/utils/build/build_all.sh
+++ b/utils/build/build_all.sh
@@ -7,3 +7,4 @@ python build.py --include css3d --minify --output ../../build/three-css3d.min.js
 python build.py --include webgl --minify --output ../../build/three-webgl.min.js
 python build.py --include extras --externs externs/extras.js --minify --output ../../build/three-extras.min.js
 python build.py --include math --output ../../build/three-math.js
+python build.py --include math --minify --output ../../build/three-math.min.js

--- a/utils/npm/README.md
+++ b/utils/npm/README.md
@@ -2,11 +2,12 @@ To build the npm modules:
 
 1. install nodejs.
 2. install npm (if it was not installed with nodejs)
-3. determine the version of THREE that you want to publish (usually it is specified in src/Three.js as the REVISION)
-4. increment the fix number above what was previously published if you are re-publishing an existing Three.js version.
-5. add "-dev" to the version number if this is a development branch.
-6. run the follow to build both the three and three-math node modules
+3. install npm module dependencies (see utils/build/package.json)
+4. determine the version of THREE that you want to publish (usually it is specified in src/Three.js as the REVISION)
+5. increment the fix number above what was previously published if you are re-publishing an existing Three.js version.
+6. add "-dev" to the version number if this is a development branch.
+7. run the follow to build both the three and three-math node modules
  * node build.js 0.54.3-dev
-7. npm publish node_module/three
-8. npm publish node_module/three-math
+8. npm publish node_module/three
+9. npm publish node_module/three-math
 

--- a/utils/npm/build.js
+++ b/utils/npm/build.js
@@ -84,9 +84,14 @@ var buildModule = function ( name, version ) {
 	copyFile( readmeFileName, outputReadmeFileName );
 }
 
-// TODO: make this non-Windows specific.
-var cmdExe = "cmd.exe";
-var args = [ "/c", "build_all.bat" ];
+var cmdExe, args;
+if (process.platform === 'win32' || process.platform === 'win64') {
+	cmdExe = "cmd.exe";
+	args = [ "/c", "build_all.bat" ];
+} else {
+	cmdExe = './build_all.sh';
+	args = [];
+}
 var opts = { "cwd": "../build" };
 var buildAll = cp.spawn( cmdExe, args, opts );
 


### PR DESCRIPTION
utils/npm/build.js works now on linux.
- The script detects OS and changes the build command (./build.sh vs cmd.exe /c build.bat)
- Now build.sh builds also a minified version of the three-math file
- updated README with more information
