### PR TITLE
Allow for late initialization in NPM Three module by remembering self.

### DIFF
--- a/utils/npm/footer.js
+++ b/utils/npm/footer.js
@@ -6,6 +6,7 @@
 if (typeof exports !== 'undefined') {
   if (typeof module !== 'undefined' && module.exports) {
     exports = module.exports = THREE;
+    THREE.self = self;
   }
   exports.THREE = THREE;
 } else {

--- a/utils/npm/header.js
+++ b/utils/npm/header.js
@@ -1,6 +1,6 @@
 
 var window = window || {};
-var self = self || {};
+var self = self || window;
 
 // High-resulution counter: emulate window.performance.now() for THREE.CLOCK
 if( window.performance === undefined ) {


### PR DESCRIPTION
Self should default to window rather than {} in the NPM module header (header.js).

We want to remember self as Three.self in the NPM module footer (footer.js) to allow for late initialization of Three internals within the same context as Three itself.  This is particularly important for loading Font specifications (*.typeface.js).
