### PR TITLE
Adding "THREE.typeface_js = self._typeface_js;" to allow font usage from NPM modules.

### DIFF
--- a/src/extras/FontUtils.js
+++ b/src/extras/FontUtils.js
@@ -457,3 +457,4 @@ THREE.FontUtils.generateShapes = function( text, parameters ) {
 
 // To use the typeface.js face files, hook up the API
 self._typeface_js = { faces: THREE.FontUtils.faces, loadFace: THREE.FontUtils.loadFace };
+THREE.typeface_js = self._typeface_js;


### PR DESCRIPTION
self._typeface_js is assigned to on line: 

https://github.com/mrdoob/three.js/blob/master/src/extras/FontUtils.js#L459

If you initialize THREE within an npm module self is the module itself and is not easily accessible outside of that module.  In the linked to discussion with @mrdoob it was decided that it would be best to assign _typeface_js to THREE.typeface_js so that it can be accessed anywhere THREE is accessable.

https://github.com/mrdoob/three.js/pull/3306#commitcomment-2994347

This is what is done in this PR.
