### PR TITLE
Restored solid line colors to AxisHelper

### DIFF
--- a/src/extras/helpers/AxisHelper.js
+++ b/src/extras/helpers/AxisHelper.js
@@ -5,26 +5,42 @@
 
 THREE.AxisHelper = function ( size ) {
 
+	THREE.Object3D.call( this );
+
 	size = size || 1;
 
-	var geometry = new THREE.Geometry();
+	var lineGeometry, line;
 
-	geometry.vertices.push(
-		new THREE.Vector3(), new THREE.Vector3( size, 0, 0 ),
-		new THREE.Vector3(), new THREE.Vector3( 0, size, 0 ),
-		new THREE.Vector3(), new THREE.Vector3( 0, 0, size )
-	);
+	// x
 
-	geometry.colors.push(
-		new THREE.Color( 0xff0000 ), new THREE.Color( 0xffaa00 ),
-		new THREE.Color( 0x00ff00 ), new THREE.Color( 0xaaff00 ),
-		new THREE.Color( 0x0000ff ), new THREE.Color( 0x00aaff )
-	);
+	lineGeometry = new THREE.Geometry();
+	lineGeometry.vertices.push( new THREE.Vector3() );
+	lineGeometry.vertices.push( new THREE.Vector3( size, 0, 0 ) );
 
-	var material = new THREE.LineBasicMaterial( { vertexColors: THREE.VertexColors } );
+	line = new THREE.Line( lineGeometry, new THREE.LineBasicMaterial( { color : 0xff0000 } ) );
+	line.matrixAutoUpdate = false;
+	this.add( line );
 
-	THREE.Line.call( this, geometry, material, THREE.LinePieces );
+	// y
+
+	lineGeometry = new THREE.Geometry();
+	lineGeometry.vertices.push( new THREE.Vector3() );
+	lineGeometry.vertices.push( new THREE.Vector3( 0, size, 0 ) );
+	
+	line = new THREE.Line( lineGeometry, new THREE.LineBasicMaterial( { color : 0x00ff00 } ) );
+	line.matrixAutoUpdate = false;
+	this.add( line );
+
+	// z
+
+	lineGeometry = new THREE.Geometry();
+	lineGeometry.vertices.push( new THREE.Vector3() );
+	lineGeometry.vertices.push( new THREE.Vector3( 0, 0, size ) );
+	
+	line = new THREE.Line( lineGeometry, new THREE.LineBasicMaterial( { color : 0x0000ff } ) );
+	line.matrixAutoUpdate = false;
+	this.add( line );
 
 };
 
-THREE.AxisHelper.prototype = Object.create( THREE.Line.prototype );
+THREE.AxisHelper.prototype = Object.create( THREE.Object3D.prototype );


### PR DESCRIPTION
I also make judicious use of `matrixAutoUpdate = false`.

There are several reasons for this change
1. `CanvasRenderer` does not support `vertexColors`, so the axes were rendered white. This made them difficult to see on white backgrounds. Also, it became difficult to tell the axes apart if the camera position and orientation changed.
2. In the case of `WebGLRenderer`, the varying colors were used to give the user some sense of relative location when the user zoomed in or out. Quite frankly, this did not work very well, IMHO.

So, I propose that this change be implemented -- restoring solid colors to the axes.
