### PR TITLE
Fixed zoom increment to normalize responsiveness across various inputs

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -428,7 +428,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		}
 
-		_zoomStart.y += ( 1 / delta ) * 0.05;
+		_zoomStart.y += delta * 0.01;
 
 	}
 


### PR DESCRIPTION
Some zoom inputs, such as multitouch trackpads, trigger the mousewheel event at higher frequencies but smaller increments. The zoom delta was inverted (I'm not sure why) which would cause these inputs to be exponentially more sensitive and generally unusable. This tweak should make zoom responsiveness more regular across various inputs.
