### PR TITLE
fix accidential global created in Matrix3.compose and Matrix4.compose unit tests

### DIFF
--- a/test/unit/math/Matrix3.js
+++ b/test/unit/math/Matrix3.js
@@ -191,7 +191,7 @@ test( "transpose", function() {
 	ok( matrixEquals3( a, b ), "Passed!" );
 
 	b = new THREE.Matrix3( 0, 1, 2, 3, 4, 5, 6, 7, 8 );
-	c = b.clone().transpose();
+	var c = b.clone().transpose();
 	ok( ! matrixEquals3( b, c ), "Passed!" ); 
 	c.transpose();
 	ok( matrixEquals3( b, c ), "Passed!" ); 

--- a/test/unit/math/Matrix4.js
+++ b/test/unit/math/Matrix4.js
@@ -211,7 +211,7 @@ test( "transpose", function() {
 	ok( matrixEquals4( a, b ), "Passed!" );
 
 	b = new THREE.Matrix4( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 );
-	c = b.clone().transpose();
+	var c = b.clone().transpose();
 	ok( ! matrixEquals4( b, c ), "Passed!" ); 
 	c.transpose();
 	ok( matrixEquals4( b, c ), "Passed!" ); 


### PR DESCRIPTION
Nothing major. The unit tests were failing because a global variable was created by accident in the unit test itself for Matrix3/4.compose. This commit fixes that very minor error.
