### PR TITLE
SceneLoader: Handling of object hierarchies

### DIFF
--- a/src/loaders/SceneLoader.js
+++ b/src/loaders/SceneLoader.js
@@ -173,11 +173,10 @@ THREE.SceneLoader.prototype.parse = function ( json, callbackFinished, url ) {
 			// check by id if child has already been handled,
 			// if not, create new object
 
-			if ( result.objects[ objID ] === undefined ) {
+            var object = result.objects[ objID ];
+            var objJSON = children[ objID ];
 
-				var objJSON = children[ objID ];
-
-				var object = null;
+			if ( object === undefined ) {
 
 				// meshes
 
@@ -505,15 +504,16 @@ THREE.SceneLoader.prototype.parse = function ( json, callbackFinished, url ) {
 
 					}
 
-					if ( objJSON.children !== undefined ) {
-
-						handle_children( object, objJSON.children );
-
-					}
-
 				}
 
 			}
+
+            if ( object !== undefined && objJSON.children !== undefined )
+            {
+
+                handle_children( object, objJSON.children );
+
+            }
 
 		}
 

--- a/src/loaders/SceneLoader.js
+++ b/src/loaders/SceneLoader.js
@@ -729,6 +729,24 @@ THREE.SceneLoader.prototype.parse = function ( json, callbackFinished, url ) {
 
 	};
 
+    function traverse_json_hierarchy( objJSON, callback ) {
+
+        callback( objJSON );
+
+        if ( objJSON.children !== undefined ) {
+
+            var objChildID;
+
+            for ( objChildID in objJSON.children ) {
+
+                traverse_json_hierarchy( objJSON.children[ objChildID ], callback );
+
+            }
+
+        }
+
+    };
+
 	// first go synchronous elements
 
 	// fogs
@@ -780,21 +798,23 @@ THREE.SceneLoader.prototype.parse = function ( json, callbackFinished, url ) {
 
 	// count how many hierarchies will be loaded asynchronously
 
-	var objID, objJSON;
+	var objID;
 
 	for ( objID in data.objects ) {
 
-		objJSON = data.objects[ objID ];
+        traverse_json_hierarchy( data.objects[ objID ], function ( objJSON ) {
 
-		if ( objJSON.type && ( objJSON.type in this.hierarchyHandlerMap ) ) {
+            if ( objJSON.type && ( objJSON.type in scope.hierarchyHandlerMap ) ) {
 
-			counter_models += 1;
+                counter_models += 1;
 
-			scope.onLoadStart();
+                scope.onLoadStart();
 
-		}
+            }
 
-	}
+        });
+
+    }
 
 	total_models = counter_models;
 


### PR DESCRIPTION
SceneLoader.js did not handle object hierarchies correctly. This pull contains two commits which fix the issue.

Commit 1: The recursive call inside handle_children was only done once after an object was completely loaded. This does not work, if there are asynchronously loaded children. Consequently those were missing in the rendered scene.

Commit 2: counter_models was not updated correctly for models loaded by a HierarchyHandler. The count of children was missing. This lead to a negative number later on. Models loaded afterwards were missing.

I succesfully tested the fix with two modified test_scene.js files which you can get at https://gist.github.com/ZuBsPaCe/5464258 . One of them is based on an example in issue https://github.com/mrdoob/three.js/issues/2276 . Unfortunately I cannot host them myself easily.

This is my first pull request, yay! :) Please tell me if I missed something.

Thank for you for your great project!
