### PR TITLE
typo fixes in morphNormals docs

### DIFF
--- a/docs/api/core/Geometry.html
+++ b/docs/api/core/Geometry.html
@@ -102,9 +102,9 @@
 		Morph colors can match either number and order of faces (face colors) or number of vertices (vertex colors).
 		</div>
 
-		<h3>.[page:Array morphColors]</h3>
+		<h3>.[page:Array morphNormals]</h3>
 		<div>
-		Array of morph normals. Morph Normals have similar structure as morph targets, each normal set is a Javascript object:
+		Array of morph normals. Morph normals have similar structure as morph targets, each normal set is a Javascript object:
 		<code>morphNormal = { name: "NormalName", normals: [ new THREE.Vector3(), ... ] }</code>
 		</div>
 


### PR DESCRIPTION
looks like the morphColors block was copy-pasted but not fully edited.
