### PR TITLE
npm package + IE 10 incompatibility fix (window is a const variable).

### DIFF
--- a/utils/npm/header.js
+++ b/utils/npm/header.js
@@ -1,20 +1,20 @@
 
-var window = window || {};
+var THREE_window = window || {};
 var self = self || {};
 
 // High-resulution counter: emulate window.performance.now() for THREE.CLOCK
-if( window.performance === undefined ) {
+if( THREE_window.performance === undefined ) {
 
-	window.performance = { };
+	THREE_window.performance = { };
 
 }
 
-if( window.performance.now === undefined ) {
+if( THREE_window.performance.now === undefined ) {
 
 	// check if we are in a Node.js environment
 	if( ( process !== undefined ) && ( process.hrtime !== undefined ) ) {
 
-		window.performance.now = function () {
+		THREE_window.performance.now = function () {
 
 			var time = process.hrtime();
 			return ( time[0] + time[1] / 1e9 ) * 1000;
@@ -25,7 +25,7 @@ if( window.performance.now === undefined ) {
 	// if not Node.js revert to using the Date class
 	else {
 
-		window.performance.now = function() {
+		THREE_window.performance.now = function() {
 
 			return new Date().getTime();
 


### PR DESCRIPTION
The NPM three package (http://npmjs.org/package/three) was not loading properly on Internet Explorer 10 because the variable "window" is now const and can not be modified.  Thus I have changed the header to not redefine window but rather use the made up variable THREE_window during the intialization sequence.

This works on Firefox, Chome and Internet Explorer 10.  I have not tested on other versions of Internet Explorer.

The tag for this commit incorrect says ie11, when it is really ei10.
