### PR TITLE
Enable easy transform baking via GeometryUtils.bakeObjectTransformIntoGeometry().

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -95,8 +95,8 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 
 		intersectionPlanes['YZ'].rotation.set( 0, Math.PI/2, 0 );
 		intersectionPlanes['XZ'].rotation.set( -Math.PI/2, 0, 0 );
-		bakeTransformations(intersectionPlanes['YZ']);
-		bakeTransformations(intersectionPlanes['XZ']);
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry(intersectionPlanes['YZ']);
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry(intersectionPlanes['XZ']);
 
 	}
 
@@ -182,7 +182,7 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( yellow, 0.25 ) );
 		mesh.position.set( 0.15, 0.15, 0 );
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'TXY';
 		displayAxes['translate'].add( mesh );
 		pickerAxes['translate'].add( mesh.clone() );
@@ -190,7 +190,7 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( cyan, 0.25 ) );
 		mesh.position.set( 0, 0.15, 0.15 );
 		mesh.rotation.y = Math.PI/2;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'TYZ';
 		displayAxes['translate'].add( mesh );
 		pickerAxes['translate'].add( mesh.clone() );
@@ -198,7 +198,7 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( magenta, 0.25 ) );
 		mesh.position.set( 0.15, 0, 0.15 );
 		mesh.rotation.x = Math.PI/2;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'TXZ';
 		displayAxes['translate'].add( mesh );
 		pickerAxes['translate'].add( mesh.clone() );
@@ -208,20 +208,20 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( red ) );
 		mesh.position.x = 1.1;
 		mesh.rotation.z = -Math.PI/2;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'TX';
 		displayAxes['translate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( green ) );
 		mesh.position.y = 1.1;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'TY';
 		displayAxes['translate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( blue ) );
 		mesh.position.z = 1.1;
 		mesh.rotation.x = Math.PI/2;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'TZ';
 		displayAxes['translate'].add( mesh );
 
@@ -230,20 +230,20 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( red ) );
 		mesh.position.x = 0.7;
 		mesh.rotation.z = -Math.PI/2;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'TX';
 		pickerAxes['translate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( green ) );
 		mesh.position.y = 0.7;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'TY';
 		pickerAxes['translate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( blue ) );
 		mesh.position.z = 0.7;
 		mesh.rotation.x = Math.PI/2;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'TZ';
 		pickerAxes['translate'].add( mesh );
 
@@ -258,21 +258,21 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( red ) );
 		mesh.position.set( 1.05, 0, 0 );
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'SX';
 		displayAxes['scale'].add( mesh );
 		pickerAxes['scale'].add( mesh.clone() );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( green ) );
 		mesh.position.set( 0, 1.05, 0 );
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'SY';
 		displayAxes['scale'].add( mesh );
 		pickerAxes['scale'].add( mesh.clone() );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( blue ) );
 		mesh.position.set( 0, 0, 1.05 );
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'SZ';
 		displayAxes['scale'].add( mesh );
 		pickerAxes['scale'].add( mesh.clone() );
@@ -317,20 +317,20 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( red ) );
 		mesh.rotation.z = -Math.PI/2;
 		mesh.rotation.y = -Math.PI/2;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'RX';
 		pickerAxes['rotate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( green ) );
 		mesh.rotation.z = Math.PI;
 		mesh.rotation.x = -Math.PI/2;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'RY';
 		pickerAxes['rotate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( blue ) );
 		mesh.rotation.z = -Math.PI/2;
-		bakeTransformations( mesh );
+		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
 		mesh.name = 'RZ';
 		pickerAxes['rotate'].add( mesh );
 
@@ -935,17 +935,6 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 
 		if ( scope.active.search( name ) != -1 ) return true;
 		else return false;
-
-	}
-
-	function bakeTransformations( object ) {
-
-		var tempGeometry = new THREE.Geometry();
-		THREE.GeometryUtils.merge( tempGeometry, object );
-		object.setGeometry( tempGeometry );
-		object.position.set( 0, 0, 0 );
-		object.rotation.set( 0, 0, 0 );
-		object.scale.set( 1, 1, 1 );
 
 	}
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -95,8 +95,8 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 
 		intersectionPlanes['YZ'].rotation.set( 0, Math.PI/2, 0 );
 		intersectionPlanes['XZ'].rotation.set( -Math.PI/2, 0, 0 );
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry(intersectionPlanes['YZ']);
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry(intersectionPlanes['XZ']);
+		intersectionPlanes['YZ'].bakeTransform();
+		intersectionPlanes['XZ'].bakeTransform();
 
 	}
 
@@ -182,7 +182,7 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( yellow, 0.25 ) );
 		mesh.position.set( 0.15, 0.15, 0 );
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'TXY';
 		displayAxes['translate'].add( mesh );
 		pickerAxes['translate'].add( mesh.clone() );
@@ -190,7 +190,7 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( cyan, 0.25 ) );
 		mesh.position.set( 0, 0.15, 0.15 );
 		mesh.rotation.y = Math.PI/2;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'TYZ';
 		displayAxes['translate'].add( mesh );
 		pickerAxes['translate'].add( mesh.clone() );
@@ -198,7 +198,7 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( magenta, 0.25 ) );
 		mesh.position.set( 0.15, 0, 0.15 );
 		mesh.rotation.x = Math.PI/2;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'TXZ';
 		displayAxes['translate'].add( mesh );
 		pickerAxes['translate'].add( mesh.clone() );
@@ -208,20 +208,20 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( red ) );
 		mesh.position.x = 1.1;
 		mesh.rotation.z = -Math.PI/2;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'TX';
 		displayAxes['translate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( green ) );
 		mesh.position.y = 1.1;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'TY';
 		displayAxes['translate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( blue ) );
 		mesh.position.z = 1.1;
 		mesh.rotation.x = Math.PI/2;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'TZ';
 		displayAxes['translate'].add( mesh );
 
@@ -230,20 +230,20 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( red ) );
 		mesh.position.x = 0.7;
 		mesh.rotation.z = -Math.PI/2;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'TX';
 		pickerAxes['translate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( green ) );
 		mesh.position.y = 0.7;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'TY';
 		pickerAxes['translate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( blue ) );
 		mesh.position.z = 0.7;
 		mesh.rotation.x = Math.PI/2;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'TZ';
 		pickerAxes['translate'].add( mesh );
 
@@ -258,21 +258,21 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( red ) );
 		mesh.position.set( 1.05, 0, 0 );
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'SX';
 		displayAxes['scale'].add( mesh );
 		pickerAxes['scale'].add( mesh.clone() );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( green ) );
 		mesh.position.set( 0, 1.05, 0 );
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'SY';
 		displayAxes['scale'].add( mesh );
 		pickerAxes['scale'].add( mesh.clone() );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( blue ) );
 		mesh.position.set( 0, 0, 1.05 );
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'SZ';
 		displayAxes['scale'].add( mesh );
 		pickerAxes['scale'].add( mesh.clone() );
@@ -317,20 +317,20 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 		mesh = new THREE.Mesh( geometry, HandleMaterial( red ) );
 		mesh.rotation.z = -Math.PI/2;
 		mesh.rotation.y = -Math.PI/2;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'RX';
 		pickerAxes['rotate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( green ) );
 		mesh.rotation.z = Math.PI;
 		mesh.rotation.x = -Math.PI/2;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'RY';
 		pickerAxes['rotate'].add( mesh );
 
 		mesh = new THREE.Mesh( geometry, HandleMaterial( blue ) );
 		mesh.rotation.z = -Math.PI/2;
-		THREE.GeometryUtils.bakeObjectTransformIntoGeometry( mesh );
+		mesh.bakeTransform();
 		mesh.name = 'RZ';
 		pickerAxes['rotate'].add( mesh );
 

--- a/src/extras/GeometryUtils.js
+++ b/src/extras/GeometryUtils.js
@@ -555,23 +555,6 @@ THREE.GeometryUtils = {
 
 	},
 
-	bakeObjectTransformIntoGeometry: function ( object ) {
-
-		// NOTE: this does not bake the transform into the children of this object
-
-		// this is a trick to bake the transform in the resulting merged geometry.
-		var tempGeometry = new THREE.Geometry();
-		THREE.GeometryUtils.merge( tempGeometry, object );
-		object.setGeometry( tempGeometry );
-
-		// reset transform to identify after baking.
-		object.position.set( 0, 0, 0 );
-		object.rotation.set( 0, 0, 0 );
-		object.quaternion.set( 0, 0, 0, 1 );
-		object.scale.set( 1, 1, 1 );
-
-	},
-
 	setMaterialIndex: function ( geometry, index, startFace, endFace ){
 
 		var faces = geometry.faces;

--- a/src/extras/GeometryUtils.js
+++ b/src/extras/GeometryUtils.js
@@ -555,6 +555,23 @@ THREE.GeometryUtils = {
 
 	},
 
+	bakeObjectTransformIntoGeometry: function ( object ) {
+
+		// NOTE: this does not bake the transform into the children of this object
+
+		// this is a trick to bake the transform in the resulting merged geometry.
+		var tempGeometry = new THREE.Geometry();
+		THREE.GeometryUtils.merge( tempGeometry, object );
+		object.setGeometry( tempGeometry );
+
+		// reset transform to identify after baking.
+		object.position.set( 0, 0, 0 );
+		object.rotation.set( 0, 0, 0 );
+		object.quaternion.set( 0, 0, 0, 1 );
+		object.scale.set( 1, 1, 1 );
+
+	},
+
 	setMaterialIndex: function ( geometry, index, startFace, endFace ){
 
 		var faces = geometry.faces;

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -94,3 +94,26 @@ THREE.Mesh.prototype.clone = function ( object ) {
 	return object;
 
 };
+
+THREE.Mesh.prototype.bakeTransform = function () {
+
+	// NOTE: this does not bake transform into child nodes
+
+	// this is a trick to bake the transform in the resulting merged geometry.
+	var tempGeometry = new THREE.Geometry();
+	THREE.GeometryUtils.merge( tempGeometry, this );
+	this.setGeometry( tempGeometry );
+
+	/*this.updateMatrix();
+	this.updateMatrixWorld();
+	this.geometry.applyMatrix( this.matrix );*/
+
+	// reset transform to identify after baking.
+	this.position.set( 0, 0, 0 );
+	this.rotation.set( 0, 0, 0 );
+	this.quaternion.set( 0, 0, 0, 1 );
+	this.scale.set( 1, 1, 1 );
+	this.matrix.identity();
+	this.updateMatrixWorld( true );
+
+};


### PR DESCRIPTION
This is a useful function and it was hidden inside TransformControls.js

Alternative names for this function:
- `GeometryUtils.bakeTransform( object )`, but I wanted it to be clear this operated on object and backed the transform into the geometry.
- `Object3D.bakeTransform()`, nice location but the issue is that this function requires a geometry to work properly, so I thought putting it here could lead to issues.

Baking of transforms is frequently used in preparing assets for games and also for creating complex objects that share a single origin (such as the TransformControl.)

It is best to have this in a central location were we can ensure that it is correct.
