### PR TITLE
Changed material.overdraw from a boolean to a number

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -29,7 +29,7 @@ THREE.Material = function () {
 
 	this.alphaTest = 0;
 
-	this.overdraw = false; // Boolean for fixing antialiasing gaps in CanvasRenderer
+	this.overdraw = 0; // Overdrawn pixels (typically between 0 and 1) for fixing antialiasing gaps in CanvasRenderer
 
 	this.visible = true;
 
@@ -73,6 +73,11 @@ THREE.Material.prototype = {
 
 					currentValue.copy( newValue );
 
+				} else if ( key == 'overdraw') {
+				
+						// ensure overdraw is backwards-compatable with legacy boolean type
+						this[ key ] = Number(newValue);
+								
 				} else {
 
 					this[ key ] = newValue;

--- a/src/renderers/CanvasRenderer.js
+++ b/src/renderers/CanvasRenderer.js
@@ -321,9 +321,9 @@ THREE.CanvasRenderer = function ( parameters ) {
 
 				if ( material.overdraw === true ) {
 
-					expand( _v1.positionScreen, _v2.positionScreen );
-					expand( _v2.positionScreen, _v3.positionScreen );
-					expand( _v3.positionScreen, _v1.positionScreen );
+					expand( _v1.positionScreen, _v2.positionScreen, material.overdraw );
+					expand( _v2.positionScreen, _v3.positionScreen, material.overdraw );
+					expand( _v3.positionScreen, _v1.positionScreen, material.overdraw );
 
 				}
 
@@ -356,14 +356,14 @@ THREE.CanvasRenderer = function ( parameters ) {
 				_v5.positionScreen.copy( _v2.positionScreen );
 				_v6.positionScreen.copy( _v4.positionScreen );
 
-				if ( material.overdraw === true ) {
+				if ( material.overdraw > 0 ) {
 
-					expand( _v1.positionScreen, _v2.positionScreen );
-					expand( _v2.positionScreen, _v4.positionScreen );
-					expand( _v4.positionScreen, _v1.positionScreen );
+					expand( _v1.positionScreen, _v2.positionScreen, material.overdraw );
+					expand( _v2.positionScreen, _v4.positionScreen, material.overdraw );
+					expand( _v4.positionScreen, _v1.positionScreen, material.overdraw );
 
-					expand( _v3.positionScreen, _v5.positionScreen );
-					expand( _v3.positionScreen, _v6.positionScreen );
+					expand( _v3.positionScreen, _v5.positionScreen, material.overdraw );
+					expand( _v3.positionScreen, _v6.positionScreen, material.overdraw );
 
 				}
 
@@ -1191,14 +1191,14 @@ THREE.CanvasRenderer = function ( parameters ) {
 
 		// Hide anti-alias gaps
 
-		function expand( v1, v2 ) {
+		function expand( v1, v2, pixels ) {
 
 			var x = v2.x - v1.x, y = v2.y - v1.y,
 			det = x * x + y * y, idet;
 
 			if ( det === 0 ) return;
 
-			idet = 1 / Math.sqrt( det );
+			idet = pixels / Math.sqrt( det );
 
 			x *= idet; y *= idet;
 


### PR DESCRIPTION
The previous boolean type for material.overdraw allowed for either a 0 or a 1 pixel overdraw for fixing antialiasing gaps in CanvasRenderer. I've found the best value to be 0.35, though this may be browser/gpu specific. The change should be backwards compatible.

Demo (line 345 is where material created):

overdraw = 0 (default, previously false) shows diagonal lines
http://neilscratch.highermedia.us/three_js/canvas_numeric_overdraw.html

overdraw = 1 (previously true) is too much 
http://neilscratch.highermedia.us/three_js/canvas_numeric_overdraw.html#1

overdraw = 0.35 is just right
http://neilscratch.highermedia.us/three_js/canvas_numeric_overdraw.html#0.35

(Forgive sloppy code of above demo. Hastily extracted from another project)
