### PR TITLE
2x faster Geometry.mergeVertices()

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -620,7 +620,7 @@ THREE.Geometry.prototype = {
 		for ( i = 0, il = this.vertices.length; i < il; i ++ ) {
 
 			v = this.vertices[ i ];
-			key = [ Math.round( v.x * precision ), Math.round( v.y * precision ), Math.round( v.z * precision ) ].join( '_' );
+			key = (( v.x * precision ) | 0 ) + '_' + (( v.y * precision ) | 0 ) + '_' + (( v.z * precision ) | 0 );
 
 			if ( verticesMap[ key ] === undefined ) {
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -620,7 +620,7 @@ THREE.Geometry.prototype = {
 		for ( i = 0, il = this.vertices.length; i < il; i ++ ) {
 
 			v = this.vertices[ i ];
-			key = (( v.x * precision ) | 0 ) + '_' + (( v.y * precision ) | 0 ) + '_' + (( v.z * precision ) | 0 );
+			key = Math.round( v.x * precision ) + '_' + Math.round( v.y * precision ) + '_' + Math.round( v.z * precision );
 
 			if ( verticesMap[ key ] === undefined ) {
 


### PR DESCRIPTION
In my profiling I found that `Geometry.mergeVertices()` was a major bottleneck.  I was able to narrow down the performance issue to a single line:

``` javascript
key = [ Math.round( v.x * precision ), Math.round( v.y * precision ),
  Math.round( v.z * precision ) ].join( '_' );
```

I have replaced that line with this:

``` javascript
key = Math.round( v.x * precision ) + '_' + Math.round( v.y * precision ) +
   '_' + Math.round( v.z * precision );
```

According to jsperf, this new version is 4x faster than the previous version on Chrome and 25% faster on Firefox and 2x faster on IE 10:

http://jsperf.com/mergevertices-core

The new version avoids creating an array, and also uses inline string concatenation rather than `.join()`.

This results in an overall speed up of `Geometry.mergeVertices()`of 2x in my larger scale profiling results.

EDIT: I did use bitwise truncation but I think that @WestLangley wouldn't approve in that I limited the range of the floating point vertex positions.  As such I went back to Math.round() as it still gets most of the performance increase without sacrificing anything.
