### PR TITLE
Restore previously selected option when updating a drop-down list.

### DIFF
--- a/editor/js/UI.js
+++ b/editor/js/UI.js
@@ -309,6 +309,7 @@ UI.Select.prototype.setMultiple = function ( boolean ) {
 };
 
 UI.Select.prototype.setOptions = function ( options ) {
+  var selected = this.dom.value;
 
 	while ( this.dom.children.length > 0 ) {
 
@@ -324,6 +325,8 @@ UI.Select.prototype.setOptions = function ( options ) {
 		this.dom.appendChild( option );
 
 	}
+
+  this.dom.value = selected;
 
 	return this;
 


### PR DESCRIPTION
This patch fixes a bug in the editor. Steps to reproduce:

1) Create a new scene with two objects named A and B in it.
2) Select B
3) Set B's parent to A
4) Pan the view. As you pan you will notice that B's parent is reset to Scene.
