### PR TITLE
Added utilities to help setup static geometry efficiently.

### DIFF
--- a/src/extras/GeometryUtils.js
+++ b/src/extras/GeometryUtils.js
@@ -475,6 +475,9 @@ THREE.GeometryUtils = {
 
 				triA.color.copy( face.color );
 				triB.color.copy( face.color );
+				
+				triA.normal.copy( face.normal );
+				triB.normal.copy( face.normal );
 
 				triA.materialIndex = face.materialIndex;
 				triB.materialIndex = face.materialIndex;
@@ -497,6 +500,18 @@ THREE.GeometryUtils = {
 					triB.vertexColors[ 1 ] = face.vertexColors[ 2 ].clone();
 					triB.vertexColors[ 2 ] = face.vertexColors[ 3 ].clone();
 
+				}
+				
+				if ( face.vertexNormals.length === 4 ) {
+					
+					triA.vertexNormals[ 0 ] = face.vertexNormals[ 0 ].clone();
+					triA.vertexNormals[ 1 ] = face.vertexNormals[ 1 ].clone();
+					triA.vertexNormals[ 2 ] = face.vertexNormals[ 3 ].clone();
+
+					triB.vertexNormals[ 0 ] = face.vertexNormals[ 1 ].clone();
+					triB.vertexNormals[ 1 ] = face.vertexNormals[ 2 ].clone();
+					triB.vertexNormals[ 2 ] = face.vertexNormals[ 3 ].clone();
+					
 				}
 
 				faces.push( triA, triB );
@@ -558,8 +573,6 @@ THREE.GeometryUtils = {
 		geometry.faceVertexUvs = faceVertexUvs;
 
 		geometry.computeCentroids();
-		geometry.computeFaceNormals();
-		geometry.computeVertexNormals();
 
 		if ( geometry.hasTangents ) geometry.computeTangents();
 

--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -35,6 +35,237 @@ THREE.SceneUtils = {
 		scene.remove( child );
 		parent.add( child );
 
+	},
+	
+	/** Combines node and all of its children in their world position into one uber-geometry that is destinationMesh. 
+	 * deduplicateMaterials may be useful after running this where there is scope for material-sharing. */
+	mergeMeshesRecursive: function ( destinationMesh, node ) {
+
+		var geometry = destinationMesh.geometry,
+			materials = destinationMesh.material.materials;
+
+		function merge( node ) {
+
+			if ( node instanceof THREE.Mesh ) {
+
+				THREE.GeometryUtils.merge( geometry, node, materials.length, true );
+
+				if ( node.material instanceof THREE.MeshFaceMaterial ) {
+
+					materials.push.apply( materials, node.material.materials );
+
+				}
+				else {
+
+					materials.push( node.material );
+
+				}
+
+			}
+
+		}
+
+		node.updateMatrixWorld();
+
+		merge(node);
+
+		var descendents = node.getDescendants();
+
+		for ( var i = 0, l = descendents.length; i < l; i++ ) {
+
+			merge( descendents[ i ] );
+
+		}
+	},
+
+	/** Remove all duplicate materials from a mesh that is using a MeshFaceMaterial and modify the mesh's geometry's
+	 * faces to share materials where possible. */
+	deduplicateMaterials: function ( mesh ) {
+
+		function makePropertyHash( material ) {
+
+			//TODO: Can we just use Object.keys ? https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/keys
+			//Sort properties for hash stability - ECMAScript doesn't actually guarantee property ordering at all
+			var properties = [];
+
+			for ( var propertyName in material ) {
+
+				//Properties never worth comparing to check for duplicates
+				if ( propertyName === 'id' ||
+					propertyName === 'name' ||
+					propertyName === 'mipmaps' ) continue;
+
+				if ( material.hasOwnProperty( propertyName ) ) {
+
+					properties.push( propertyName );
+
+				}
+
+			}
+
+			properties.sort();
+
+			var str = '';
+
+			for ( var i = 0, l = properties.length ; i < l ; i++ ) {
+
+				propertyName = properties[ i ];
+
+				str += '|' + propertyName + '=';
+
+				var propertyValue = material[ propertyName ];
+
+				switch ( typeof propertyValue ) {
+
+					case 'undefined':
+					case 'string':
+					case 'number':
+					case 'boolean':
+					case 'function':
+
+						str += propertyValue;
+
+						break;
+
+					case 'object':
+
+						if ( propertyValue === null ) {
+
+							str += 'null';
+
+						}
+						else if ( propertyValue instanceof THREE.Color ) {
+
+							str += propertyValue.getHex();
+
+						}
+						else if ( propertyValue instanceof Image ) {
+
+							str += propertyValue.src;
+
+						}
+						else if ( propertyValue instanceof THREE.Texture ) {
+
+							//Downloaded images are nicely predictable, but recurse to check other parameters are not unique
+							if ( propertyValue && propertyValue.image && propertyValue.image.src ) {
+
+								str += makePropertyHash( propertyValue );
+
+							}
+							else {
+
+								str += propertyValue.id;
+
+							}
+
+						}
+						else if ( propertyValue instanceof THREE.Vector3 ) {
+
+							str += propertyValue.x + ',' + propertyValue.y + ',' + propertyValue.z;
+
+						}
+						else if ( propertyValue instanceof THREE.Vector2 ) {
+
+							str += propertyValue.x + ',' + propertyValue.y;
+
+						}
+						//Why are these awkward quasi-classes and not just numerical enumerations?
+						else if ( propertyValue instanceof THREE.UVMapping ) {
+
+							str += 'UVMapping';
+
+						}
+						else if ( propertyValue instanceof THREE.CubeReflectionMapping ) {
+
+							str += 'CubeReflectionMapping';
+
+						}
+						else if ( propertyValue instanceof THREE.CubeRefractionMapping ) {
+
+							str += 'CubeRefractionMapping';
+
+						}
+						else if ( propertyValue instanceof THREE.SphericalReflectionMapping ) {
+
+							str += 'SphericalReflectionMapping';
+
+						}
+						else if ( propertyValue instanceof THREE.SphericalRefractionMapping ) {
+
+							str += 'SphericalRefractionMapping';
+
+						}
+						else {
+							switch ( propertyName ) {
+
+								case 'uniforms':
+								case 'defines':
+								case 'attributes':
+
+									str += JSON.stringify( propertyValue );
+
+									break;
+
+								default:
+
+									// Don't know how to handle this
+									throw "deduplicateMaterials: Unhandled property " + propertyName + " : " + propertyValue;
+
+							}
+
+						}
+
+						break;
+				}
+
+			}
+
+			return str;
+
+		}
+
+		var materialsIn = mesh.material.materials,
+			materialsIdMap = {},
+			materialsIndexMap = [],
+			materialsOut = [];
+
+		for ( var i = 0, l = materialsIn.length; i < l; i++ ) {
+
+			var material = materialsIn[ i ];
+
+			var materialHash = makePropertyHash( material );
+
+			if ( materialHash in materialsIdMap ) {
+
+				materialsIndexMap[ i ] = materialsIdMap[ materialHash ];
+
+			}
+			else {
+
+//				console.log("Material " + materialsOut.length + ": " + materialHash);
+				materialsIndexMap[ i ] = materialsOut.length;
+				materialsIdMap[ materialHash ] = materialsOut.length;
+				materialsOut.push( material );
+
+			}
+
+		}
+
+		var faces = mesh.geometry.faces, 
+			face;
+
+		for ( var i = 0, l = faces.length; i < l; i++ ) {
+
+			face = faces[i];
+
+			face.materialIndex = materialsIndexMap[ face.materialIndex ];
+
+		}
+
+//		console.log("deduplicateMaterials from " + materialsIn.length + " down to " + materialsOut.length);
+
+		mesh.material.materials = materialsOut;
+
 	}
 
 };

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4394,80 +4394,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	};
 
-	// Geometry splitting
-
-	function sortFacesByMaterial ( geometry, material ) {
-
-		var f, fl, face, materialIndex, vertices,
-			groupHash, hash_map = {};
-
-		var numMorphTargets = geometry.morphTargets.length;
-		var numMorphNormals = geometry.morphNormals.length;
-
-		var usesFaceMaterial = material instanceof THREE.MeshFaceMaterial;
-
-		geometry.geometryGroups = {};
-
-		for ( f = 0, fl = geometry.faces.length; f < fl; f ++ ) {
-
-			face = geometry.faces[ f ];
-			materialIndex = usesFaceMaterial ? face.materialIndex : 0;
-
-			if ( hash_map[ materialIndex ] === undefined ) {
-
-				hash_map[ materialIndex ] = { 'hash': materialIndex, 'counter': 0 };
-
-			}
-
-			groupHash = hash_map[ materialIndex ].hash + '_' + hash_map[ materialIndex ].counter;
-
-			if ( geometry.geometryGroups[ groupHash ] === undefined ) {
-
-				geometry.geometryGroups[ groupHash ] = { 'faces3': [], 'faces4': [], 'materialIndex': materialIndex, 'vertices': 0, 'numMorphTargets': numMorphTargets, 'numMorphNormals': numMorphNormals };
-
-			}
-
-			vertices = face instanceof THREE.Face3 ? 3 : 4;
-
-			if ( geometry.geometryGroups[ groupHash ].vertices + vertices > 65535 ) {
-
-				hash_map[ materialIndex ].counter += 1;
-				groupHash = hash_map[ materialIndex ].hash + '_' + hash_map[ materialIndex ].counter;
-
-				if ( geometry.geometryGroups[ groupHash ] === undefined ) {
-
-					geometry.geometryGroups[ groupHash ] = { 'faces3': [], 'faces4': [], 'materialIndex': materialIndex, 'vertices': 0, 'numMorphTargets': numMorphTargets, 'numMorphNormals': numMorphNormals };
-
-				}
-
-			}
-
-			if ( face instanceof THREE.Face3 ) {
-
-				geometry.geometryGroups[ groupHash ].faces3.push( f );
-
-			} else {
-
-				geometry.geometryGroups[ groupHash ].faces4.push( f );
-
-			}
-
-			geometry.geometryGroups[ groupHash ].vertices += vertices;
-
-		}
-
-		geometry.geometryGroupsList = [];
-
-		for ( var g in geometry.geometryGroups ) {
-
-			geometry.geometryGroups[ g ].id = _geometryGroupCounter ++;
-
-			geometry.geometryGroupsList.push( geometry.geometryGroups[ g ] );
-
-		}
-
-	};
-
 	// Objects refresh
 
 	this.initWebGLObjects = function ( scene ) {
@@ -4557,7 +4483,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( geometry.geometryGroups === undefined ) {
 
-					sortFacesByMaterial( geometry, material );
+					geometry.makeGroups( material instanceof THREE.MeshFaceMaterial );
 
 				}
 


### PR DESCRIPTION
I've been baking the static geometry in my scene together into larger BufferGeometry objects which are much more efficient.

This branch contains some utility methods I've added that has made it a lot easier
- THREE.SceneUtils.mergeMeshesRecursive - add a node tree in world-space into a Geometry
- THREE.SceneUtils.deduplicateMaterials - optimize for duplicate materials in a mesh
- THREE.GeometryUtils.makeBufferGeometries - split a Geometry into an array of BufferGeometry objects. In doing so, I moved WebGLRenderer's sortFacesByMaterial function into Geometry.makeGroups (so I could use it in makeBufferGeometries). I think it's a bit tidier there as it only affects Geometry and reduces WebGLRenderer by 70 lines.

So here's a pull request in case you want them in the main release.
:)
