### PR TITLE
Intercepting Texture Loading during imports + some code cleanup

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -2,7 +2,7 @@
  * @author Tim Knip / http://www.floorplanner.com/ / tim at floorplanner.com
  */
 
-THREE.ColladaLoader = function () {
+THREE.ColladaLoader = function ( ) {
 
 	var COLLADA = null;
 	var scene = null;
@@ -25,7 +25,7 @@ THREE.ColladaLoader = function () {
 	var baseUrl;
 	var morphs;
 	var skins;
-
+	
 	var flip_uv = true;
 	var preferredShading = THREE.SmoothShading;
 
@@ -44,7 +44,11 @@ THREE.ColladaLoader = function () {
 		upAxis: 'Y',
 
 		// For reflective or refractive materials we'll use this cubemap
-		defaultEnvMap: null
+		defaultEnvMap: null,
+
+		// for overriding default image loading behavior
+		imageLoader: new THREE.DefaultImageLoader()
+
 
 	};
 
@@ -3151,7 +3155,7 @@ THREE.ColladaLoader = function () {
 
 								if (image) {
 
-									var texture = THREE.ImageUtils.loadTexture(baseUrl + image.init_from);
+									var texture = options.imageLoader.loadTexture(baseUrl + image.init_from);
 									texture.wrapS = cot.texOpts.wrapU ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
 									texture.wrapT = cot.texOpts.wrapV ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
 									texture.offset.x = cot.texOpts.offsetU;

--- a/examples/js/loaders/OBJMTLLoader.js
+++ b/examples/js/loaders/OBJMTLLoader.js
@@ -5,7 +5,11 @@
  * @author angelxuanchang
  */
 
-THREE.OBJMTLLoader = function () {};
+THREE.OBJMTLLoader = function () {
+
+	this.imageLoader = new THREE.DefaultImageLoader();
+
+};
 
 THREE.OBJMTLLoader.prototype = {
 
@@ -41,7 +45,7 @@ THREE.OBJMTLLoader.prototype = {
 
 		// Loader for MTL
 
-		var mtlLoader = new THREE.MTLLoader( url.substr( 0, url.lastIndexOf( "/" ) + 1 ), options );
+		var mtlLoader = new THREE.MTLLoader( url.substr( 0, url.lastIndexOf( "/" ) + 1 ), options, this.imageLoader );
 		mtlLoader.addEventListener( 'load', waitReady );
 		mtlLoader.addEventListener( 'error', waitReady );
 

--- a/src/extras/DefaultImageLoader.js
+++ b/src/extras/DefaultImageLoader.js
@@ -1,0 +1,42 @@
+/**
+ * @author bhouston / http://exocortex.com/
+ */
+
+THREE.DefaultImageLoader = function () {
+
+	//this.ensurePowerOf2 = false;
+
+};
+
+THREE.DefaultImageLoader.prototype = {
+
+ 	loadTexture: function ( url, mapping, onLoad, onError ) {
+
+		return THREE.ImageUtils.loadTexture( url, mapping, onLoad, onError );
+
+	},
+
+	loadCompressedTexture: function ( url, mapping, onLoad, onError ) {
+
+		return THREE.ImageUtils.loadCompressedTexture( url, mapping, onLoad, onError );
+
+	},
+
+	loadTextureCube: function ( array, mapping, onLoad, onError ) {
+
+		return THREE.ImageUtils.loadTextureCube( array, mapping, onLoad, onError );
+
+	},
+
+	loadCompressedTextureCube: function ( array, mapping, onLoad, onError ) {
+
+		return THREE.ImageUtils.loadCompressedTextureCube( array, mapping, onLoad, onError );
+
+	},
+
+	generateDataTexture: function ( width, height, color ) {
+
+		return THREE.ImageUtils.generateDataTexture( width, height, color );
+	}
+
+};

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -548,6 +548,24 @@ THREE.ImageUtils = {
 
 		return texture;
 
+	},
+
+	ensurePowerOfTwoImage: function ( image ) {
+
+		if ( ! THREE.Math.isPowerOfTwo( image.width ) || ! THREE.Math.isPowerOfTwo( image.height ) ) {
+
+			var canvas = document.createElement( "canvas" );
+			canvas.width = THREE.Math.nextHighestPowerOfTwo( image.width );
+			canvas.height = THREE.Math.nextHighestPowerOfTwo( image.height );
+
+			var ctx = canvas.getContext("2d");
+			ctx.drawImage( image, 0, 0, image.width, image.height, 0, 0, canvas.width, canvas.height );
+			return canvas;
+
+		}
+
+		return image;
+
 	}
 
 };

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -11,6 +11,7 @@ THREE.Loader = function ( showStatus ) {
 	this.onLoadProgress = function () {};
 	this.onLoadComplete = function () {};
 
+	this.imageLoader = new THREE.DefaultImageLoader();
 };
 
 THREE.Loader.prototype = {

--- a/src/loaders/SceneLoader.js
+++ b/src/loaders/SceneLoader.js
@@ -14,6 +14,8 @@ THREE.SceneLoader = function () {
 	this.geometryHandlerMap = {};
 	this.hierarchyHandlerMap = {};
 
+	this.imageLoader = new THREE.DefaultImageLoader();
+	
 	this.addGeometryHandler( "ascii", THREE.JSONLoader );
 
 };
@@ -959,11 +961,11 @@ THREE.SceneLoader.prototype.parse = function ( json, callbackFinished, url ) {
 
 			if ( isCompressed ) {
 
-				texture = THREE.ImageUtils.loadCompressedTextureCube( url_array, textureJSON.mapping, generateTextureCallback( count ) );
+				texture = this.imageLoader.loadCompressedTextureCube( url_array, textureJSON.mapping, generateTextureCallback( count ) );
 
 			} else {
 
-				texture = THREE.ImageUtils.loadTextureCube( url_array, textureJSON.mapping, generateTextureCallback( count ) );
+				texture = this.imageLoader.loadTextureCube( url_array, textureJSON.mapping, generateTextureCallback( count ) );
 
 			}
 
@@ -975,11 +977,11 @@ THREE.SceneLoader.prototype.parse = function ( json, callbackFinished, url ) {
 
 			if ( isCompressed ) {
 
-				texture = THREE.ImageUtils.loadCompressedTexture( fullUrl, textureJSON.mapping, textureCallback );
+				texture = this.imageLoader.loadCompressedTexture( fullUrl, textureJSON.mapping, textureCallback );
 
 			} else {
 
-				texture = THREE.ImageUtils.loadTexture( fullUrl, textureJSON.mapping, textureCallback );
+				texture = this.imageLoader.loadTexture( fullUrl, textureJSON.mapping, textureCallback );
 
 			}
 

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -113,6 +113,26 @@ THREE.Math = {
 
 		};
 
-	}()
+	}(),
+
+	isPowerOfTwo: function ( x ) {
+
+		return ( x & ( x - 1 ) ) === 0;
+
+	},
+
+	nextHighestPowerOfTwo: function( x ) {
+
+		--x;
+
+		for ( var i = 1; i < 32; i <<= 1 ) {
+
+			x = x | x >> i;
+
+		}
+
+		return x + 1;
+
+	}
 
 };

--- a/utils/build/includes/extras.json
+++ b/utils/build/includes/extras.json
@@ -1,6 +1,7 @@
 [
 	"src/extras/GeometryUtils.js",
 	"src/extras/ImageUtils.js",
+	"src/extras/DefaultImageLoader.js",
 	"src/extras/SceneUtils.js",
 	"src/extras/FontUtils.js",
 	"src/extras/core/Curve.js",


### PR DESCRIPTION
This PR enables both #3412 and #3430 to be addressed as extensions to ThreeJS because this PR allows for image loading to be replaced within the standard JS loaders via replacing the imageLoader class.

The key idea is that loaders that will load textures use the member variable of the loader class called `this.imageLoader` instead of calling `THREE.ImageUtils` directly.

By default `this.imageLoader` is set to `new THREE.DefaultImageLoader()` which is a proxy for `THREE.ImageUtils` but users can change the class that is set to `this.imageLoader` to override the default behavior provided by ThreeJS.

I believe this is a minimal change.

I have also removed the need for MTL to resize textures on load to powers of 2.  This should either be in all loaders or none of them.  It isn't a unique requirement for MTLs.  I've also moved the utility functions that were used for this to THREE.Math so they can be reused by others.
