### PR TITLE
Improved SpotLightHelper

### DIFF
--- a/src/extras/helpers/SpotLightHelper.js
+++ b/src/extras/helpers/SpotLightHelper.js
@@ -4,54 +4,52 @@
  * @author WestLangley / http://github.com/WestLangley
 */
 
-THREE.SpotLightHelper = function ( light, sphereSize ) {
+THREE.SpotLightHelper = function ( light ) {
 
-	THREE.Object3D.call( this );
-
-	this.matrixAutoUpdate = false;
+	// spotlight helper must be a child of the scene
 
 	this.light = light;
 
-	var geometry = new THREE.SphereGeometry( sphereSize, 4, 2 );
-	var material = new THREE.MeshBasicMaterial( { fog: false, wireframe: true } );
-	material.color.copy( this.light.color ).multiplyScalar( this.light.intensity );
+	var geometry = new THREE.CylinderGeometry( 0, 1, 1, 8, 1, true );
 
-	this.lightSphere = new THREE.Mesh( geometry, material );
-	this.lightSphere.matrixWorld = this.light.matrixWorld;
-	this.lightSphere.matrixAutoUpdate = false;
-	this.add( this.lightSphere );
-
-	geometry = new THREE.CylinderGeometry( 0.0001, 1, 1, 8, 1, true );
 	geometry.applyMatrix( new THREE.Matrix4().makeTranslation( 0, -0.5, 0 ) );
+
 	geometry.applyMatrix( new THREE.Matrix4().makeRotationX( - Math.PI / 2 ) );
 
-	material = new THREE.MeshBasicMaterial( { fog: false, wireframe: true, opacity: 0.3, transparent: true } );
-	material.color.copy( this.light.color ).multiplyScalar( this.light.intensity );
+	var material = new THREE.MeshBasicMaterial( { wireframe: true, opacity: 0.3, transparent: true } );
 
-	this.lightCone = new THREE.Mesh( geometry, material );
-	this.lightCone.position = this.light.position;
+	THREE.Mesh.call( this, geometry, material );
 
-	var coneLength = light.distance ? light.distance : 10000;
-	var coneWidth = coneLength * Math.tan( light.angle );
-
-	this.lightCone.scale.set( coneWidth, coneWidth, coneLength );
-	this.lightCone.lookAt( this.light.target.position );
-
-	this.add( this.lightCone );
+	this.update();
 
 };
 
-THREE.SpotLightHelper.prototype = Object.create( THREE.Object3D.prototype );
+THREE.SpotLightHelper.prototype = Object.create( THREE.Mesh.prototype );
 
-THREE.SpotLightHelper.prototype.update = function () {
+THREE.SpotLightHelper.prototype.update = ( function () {
 
-	var coneLength = this.light.distance ? this.light.distance : 10000;
-	var coneWidth = coneLength * Math.tan( this.light.angle );
+	var targetPosition = new THREE.Vector3();
 
-	this.lightCone.scale.set( coneWidth, coneWidth, coneLength );
-	this.lightCone.lookAt( this.light.target.position );
+	return function() {
 
-	this.lightSphere.material.color.copy( this.light.color ).multiplyScalar( this.light.intensity );
-	this.lightCone.material.color.copy( this.light.color ).multiplyScalar( this.light.intensity );
+		var coneLength = this.light.distance ? this.light.distance : 10000;
 
-};
+		var coneWidth = coneLength * Math.tan( this.light.angle );
+
+		this.scale.set( coneWidth, coneWidth, coneLength );
+
+		this.light.updateMatrixWorld( true );
+
+		this.position.getPositionFromMatrix( this.light.matrixWorld );
+
+		this.light.target.updateMatrixWorld( true );
+
+		targetPosition.getPositionFromMatrix( this.light.target.matrixWorld );
+
+		this.lookAt( targetPosition );
+
+		this.material.color.copy( this.light.color ).multiplyScalar( this.light.intensity );
+
+	}
+
+}());


### PR DESCRIPTION
`SpotLightHelper` geometry has been simplified. It is now just a cone. (I took the liberty of removing the sphere at the tip of the cone as it was not needed -- the light cone is sufficient.)

`SpotLightHelper` now works with spotlights that have parents.

As in the previous version, `SpotLightHelper.update()` must be called inside the render loop.

As in the previous version, an instance of `SpotLightHelper` must be a child of the scene. (This is because `SpotLightHelper.update()` relies on `Object3D.lookAt()`, which does not have hierarchical support.)
