### PR TITLE
Directional lights have no distance property

### DIFF
--- a/docs/api/lights/DirectionalLight.html
+++ b/docs/api/lights/DirectionalLight.html
@@ -27,7 +27,7 @@ scene.add( directionalLight );</code>
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Float hex], [page:Float intensity], [page:Float distance] )</h3>
+		<h3>[name]( [page:Float hex], [page:Float intensity])</h3>
 
 
 		<h2>Properties</h2>
@@ -41,12 +41,6 @@ scene.add( directionalLight );</code>
 		<div>
 			Light's intensity.<br />
 			Default — *1.0*.
-		</div>
-
-		<h3>.[page:Float distance]</h3>
-		<div>
-			If non-zero, light will attenuate linearly from maximum intensity at light *position* down to zero at *distance*.<br />
-			Default — *0.0*.
 		</div>
 
 		<h3>.[page:Boolean onlyShadow]</h3>


### PR DESCRIPTION
I deleted the third argument and the corresponding argument description in the page.
