### PR TITLE
changed default transformControls mode to "world"

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -19,7 +19,7 @@ THREE.TransformControls = function ( camera, domElement, doc ) {
 	this.hovered = false;
 
 	this.mode = 'translate';
-	this.space = 'local';
+	this.space = 'world';
 	this.scale = 1;
 
 	this.snapDist = null;


### PR DESCRIPTION
Previously default transform mode was 'local' which doesn't support snapping to grid.
