### PR TITLE
Determine BufferGeometry attribute numItems automatically.

### DIFF
--- a/examples/webgl_buffergeometry.html
+++ b/examples/webgl_buffergeometry.html
@@ -84,23 +84,19 @@
 				geometry.attributes = {
 					index: {
 						itemSize: 1,
-						array: new Uint16Array( triangles * 3 ),
-						numItems: triangles * 3
+						array: new Uint16Array( triangles * 3 )
 					},
 					position: {
 						itemSize: 3,
-						array: new Float32Array( triangles * 3 * 3 ),
-						numItems: triangles * 3 * 3
+						array: new Float32Array( triangles * 3 * 3 )
 					},
 					normal: {
 						itemSize: 3,
-						array: new Float32Array( triangles * 3 * 3 ),
-						numItems: triangles * 3 * 3
+						array: new Float32Array( triangles * 3 * 3 )
 					},
 					color: {
 						itemSize: 3,
-						array: new Float32Array( triangles * 3 * 3 ),
-						numItems: triangles * 3 * 3
+						array: new Float32Array( triangles * 3 * 3 )
 					}
 				}
 

--- a/examples/webgl_buffergeometry_custom_attributes_particles.html
+++ b/examples/webgl_buffergeometry_custom_attributes_particles.html
@@ -143,18 +143,15 @@
 
 				position: {
 					itemSize: 3,
-					array: new Float32Array( particles * 3 ),
-					numItems: particles * 3
+					array: new Float32Array( particles * 3 )
 				},
 				customColor: {
 					itemSize: 3,
-					array: new Float32Array( particles * 3 ),
-					numItems: particles * 3
+					array: new Float32Array( particles * 3 )
 				},
 				size: {
 					itemSize: 1,
 					array: new Float32Array( particles ),
-					numItems: particles * 1,
 					dynamic: true
 				},
 

--- a/examples/webgl_buffergeometry_lines.html
+++ b/examples/webgl_buffergeometry_lines.html
@@ -72,13 +72,11 @@
 				geometry.attributes = {
 					position: {
 						itemSize: 3,
-						array: new Float32Array(segments * 3),
-						numItems: segments * 3
+						array: new Float32Array(segments * 3)
 					},
 					color: {
 						itemSize: 3,
-						array: new Float32Array(segments * 3),
-						numItems: segments * 3
+						array: new Float32Array(segments * 3)
 					}
 				};
 

--- a/examples/webgl_buffergeometry_particles.html
+++ b/examples/webgl_buffergeometry_particles.html
@@ -73,13 +73,11 @@
 
 					position: {
 						itemSize: 3,
-						array: new Float32Array( particles * 3 ),
-						numItems: particles * 3
+						array: new Float32Array( particles * 3 )
 					},
 					color: {
 						itemSize: 3,
-						array: new Float32Array( particles * 3 ),
-						numItems: particles * 3
+						array: new Float32Array( particles * 3 )
 					}
 
 				}

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -187,8 +187,7 @@ THREE.BufferGeometry.prototype = {
 				this.attributes[ "normal" ] = {
 
 					itemSize: 3,
-					array: new Float32Array( nVertexElements ),
-					numItems: nVertexElements
+					array: new Float32Array( nVertexElements )
 
 				};
 
@@ -371,8 +370,7 @@ THREE.BufferGeometry.prototype = {
 			this.attributes[ "tangent" ] = {
 
 				itemSize: 4,
-				array: new Float32Array( nTangentElements ),
-				numItems: nTangentElements
+				array: new Float32Array( nTangentElements )
 
 			};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1150,6 +1150,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			attribute = geometry.attributes[ a ];
 
+			if ( attribute.numItems === undefined ) {
+
+				attribute.numItems = attribute.array.length;
+
+			}
+
 			attribute.buffer = _gl.createBuffer();
 
 			_gl.bindBuffer( type, attribute.buffer );

--- a/src/renderers/WebGLRenderer2.js
+++ b/src/renderers/WebGLRenderer2.js
@@ -462,6 +462,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			attribute = geometry.attributes[ a ];
 
+			if ( attribute.numItems === undefined ) {
+
+				attribute.numItems = attribute.array.length;
+
+			}
+
 			attribute.buffer = renderer.createBuffer();
 
 			if ( a === "index" ) {


### PR DESCRIPTION
Setting the `numItems` property of attributes has always felt redundant to me as the information is already in `array.length`. I understand that the array may be deleted, so `numItems` must be used, but I can't see any reason why that couldn't be automatically set during init. However, should there be some obscure reason to have different `numItems` and array size, this PR preserves the ability to set it manually.
