### PR TITLE
Added Object3D.computeBoundingBox() and THREE.BoundingBoxHelper

### DIFF
--- a/src/extras/helpers/BoundingBoxHelper.js
+++ b/src/extras/helpers/BoundingBoxHelper.js
@@ -1,0 +1,29 @@
+/**
+ * @author WestLangley / http://github.com/WestLangley
+ */
+
+// a helper to show the world-axis-aligned bounding box for an object
+
+THREE.BoundingBoxHelper = function ( object, hex ) {
+
+	var color = hex || 0x888888;
+
+	this.object = object;
+
+	this.box = new THREE.Box3();
+
+	THREE.Mesh.call( this, new THREE.CubeGeometry( 1, 1, 1 ), new THREE.MeshBasicMaterial( { color: color, wireframe: true } ) );
+
+};
+
+THREE.BoundingBoxHelper.prototype = Object.create( THREE.Mesh.prototype );
+
+THREE.BoundingBoxHelper.prototype.update = function () {
+
+	this.object.computeBoundingBox();
+
+	this.object.boundingBox.size( this.scale );
+
+	this.object.boundingBox.center( this.position );
+
+};

--- a/utils/build/includes/extras.json
+++ b/utils/build/includes/extras.json
@@ -46,6 +46,7 @@
 	"src/extras/helpers/AxisHelper.js",
 	"src/extras/helpers/ArrowHelper.js",
 	"src/extras/helpers/BoxHelper.js",
+	"src/extras/helpers/BoundingBoxHelper.js",
 	"src/extras/helpers/CameraHelper.js",
 	"src/extras/helpers/DirectionalLightHelper.js",
 	"src/extras/helpers/FaceNormalsHelper.js",


### PR DESCRIPTION
Implements #3471

Object3D.computeBoundingBox() computes the world-axis-aligned bounding box of an object (including its children), accounting for both the object's, and children's, world transforms.
