### PR TITLE
WebGLRenderer: Initialize 'z' when adding buffer to object list

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4684,7 +4684,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 				buffer: buffer,
 				object: object,
 				opaque: null,
-				transparent: null
+				transparent: null,
+				// z must be initialize, otherwise sorting is invalid.
+				z: 0
 			}
 		);
 


### PR DESCRIPTION
The "z" property is used when sorting object list but is was not initialized.

A bug occurs for objects that are first frustum culled and then visible. When they become visible "z" is undefined and sorting acts randomly.
