### PR TITLE
Get the OES_texture_float_linear extension.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -191,6 +191,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 	var _gl;
 
 	var _glExtensionTextureFloat;
+	var _glExtensionTextureFloatLinear;
 	var _glExtensionStandardDerivatives;
 	var _glExtensionTextureFilterAnisotropic;
 	var _glExtensionCompressedTextureS3TC;
@@ -7277,6 +7278,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		}
 
 		_glExtensionTextureFloat = _gl.getExtension( 'OES_texture_float' );
+		_glExtensionTextureFloatLinear = _gl.getExtension( 'OES_texture_float_linear' );
 		_glExtensionStandardDerivatives = _gl.getExtension( 'OES_standard_derivatives' );
 
 		_glExtensionTextureFilterAnisotropic = _gl.getExtension( 'EXT_texture_filter_anisotropic' ) ||


### PR DESCRIPTION
There's a bug in most WebGL implementations that the OES_texture_float
extension is not supposed to allow the various LINEAR filtering modes.
To filter a floating point texture with linear filtering requires
enabling OES_texture_float_linear.

This CL does that. The code has not been updated to actually
check the extension exists and doing or disallowing the appropriate
features.

Enabling it will mean on desktop things just work as they did before.

On mobile/tablets it's far more likley OES_texture_float_linear
does not exist.

Note: the WebGL bug has been fixed in Chrome Canary so apps using floating point textures with linear filtering will fail unless they enable OES_texture_float_linear
