### PR TITLE
Miscelaneous Fixes

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -87,6 +87,18 @@ THREE.Geometry.prototype = {
 
 		}
 
+		if ( this.boundingBox instanceof THREE.Box3 ) {
+
+			this.computeBoundingBox();
+
+		}
+
+		if ( this.boundingSphere instanceof THREE.Sphere ) {
+
+			this.computeBoundingSphere();
+
+		}
+
 	},
 
 	computeCentroids: function () {
@@ -593,7 +605,7 @@ THREE.Geometry.prototype = {
 
 		}
 
-		this.boundingSphere.setFromCenterAndPoints( this.boundingSphere.center, this.vertices );
+		this.boundingSphere.setFromPoints( this.vertices );
 
 	},
 

--- a/src/extras/geometries/TubeGeometry.js
+++ b/src/extras/geometries/TubeGeometry.js
@@ -11,7 +11,7 @@
  * http://www.cs.indiana.edu/pub/techreports/TR425.pdf
  */
 
-THREE.TubeGeometry = function( path, segments, radius, radialSegments, closed, debug ) {
+THREE.TubeGeometry = function( path, segments, radius, radialSegments, closed ) {
 
 	THREE.Geometry.call( this );
 
@@ -20,8 +20,6 @@ THREE.TubeGeometry = function( path, segments, radius, radialSegments, closed, d
 	this.radius = radius || 1;
 	this.radialSegments = radialSegments || 8;
 	this.closed = closed || false;
-
-	if ( debug ) this.debug = new THREE.Object3D();
 
 	this.grid = [];
 
@@ -74,14 +72,6 @@ THREE.TubeGeometry = function( path, segments, radius, radialSegments, closed, d
 		tangent = tangents[ i ];
 		normal = normals[ i ];
 		binormal = binormals[ i ];
-
-		if ( this.debug ) {
-
-			this.debug.add( new THREE.ArrowHelper(tangent, pos, radius, 0x0000ff ) );
-			this.debug.add( new THREE.ArrowHelper(normal, pos, radius, 0xff0000 ) );
-			this.debug.add( new THREE.ArrowHelper(binormal, pos, radius, 0x00ff00 ) );
-
-		}
 
 		for ( j = 0; j < this.radialSegments; j++ ) {
 
@@ -244,7 +234,7 @@ THREE.TubeGeometry.FrenetFrames = function(path, segments, closed) {
 
 			vec.normalize();
 
-			theta = Math.acos( tangents[ i-1 ].dot( tangents[ i ] ) );
+			theta = Math.acos( THREE.Math.clamp( tangents[ i-1 ].dot( tangents[ i ] ), -1, 1 ) ); // clamp for floating pt errors
 
 			normals[ i ].applyMatrix4( mat.makeRotationAxis( vec, theta ) );
 
@@ -259,7 +249,7 @@ THREE.TubeGeometry.FrenetFrames = function(path, segments, closed) {
 
 	if ( closed ) {
 
-		theta = Math.acos( normals[ 0 ].dot( normals[ numpoints-1 ] ) );
+		theta = Math.acos( THREE.Math.clamp( normals[ 0 ].dot( normals[ numpoints-1 ] ), -1, 1 ) );
 		theta /= ( numpoints - 1 );
 
 		if ( tangents[ 0 ].dot( vec.crossVectors( normals[ 0 ], normals[ numpoints-1 ] ) ) > 0 ) {

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -22,18 +22,18 @@ THREE.Sphere.prototype = {
 		return this;
 	},
 
-	setFromCenterAndPoints: function ( center, points ) {
+	setFromPoints: function ( points ) {
 
-		var maxRadiusSq = 0;
+		var radiusSq, maxRadiusSq = 0;
 
 		for ( var i = 0, il = points.length; i < il; i ++ ) {
 
-			var radiusSq = center.distanceToSquared( points[ i ] );
+			radiusSq = points[ i ].lengthSq();
 			maxRadiusSq = Math.max( maxRadiusSq, radiusSq );
 
 		}
 
-		this.center = center;
+		this.center.set( 0, 0, 0 );
 		this.radius = Math.sqrt( maxRadiusSq );
 
 		return this;


### PR DESCRIPTION
Both `Frustum` and `Raycaster` assume the `boundingSphere` is zero-based. I made some corrections consistent with that assumption. We can implement non-zero-based bounding spheres later.

`TubeGeometry` had some numerical issues.

Added calls to recompute the bounding box/sphere in `Geometry.applyMatrix()`. ( I do not feel such a change is appropriate for `Object3D.applyMatrix()`, as these bounds can become invalid after every transformation. )
