### PR TITLE
Fix SkinnedMesh so that it can be used with BufferGeometry

### DIFF
--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -216,23 +216,35 @@ THREE.SkinnedMesh.prototype.pose = function () {
 
 	this.updateMatrixWorld( true );
 
-	for ( var i = 0; i < this.geometry.skinIndices.length; i ++ ) {
+	this.normalizeSkinWeights();
 
-		// normalize weights
+};
 
-		var sw = this.geometry.skinWeights[ i ];
+THREE.SkinnedMesh.prototype.normalizeSkinWeights = function () {
 
-		var scale = 1.0 / sw.lengthManhattan();
+	if (this.geometry instanceof THREE.Geometry) {
 
-		if ( scale !== Infinity ) {
+		for ( var i = 0; i < this.geometry.skinIndices.length; i ++ ) {
 
-			sw.multiplyScalar( scale );
+			var sw = this.geometry.skinWeights[ i ];
 
-		} else {
+			var scale = 1.0 / sw.lengthManhattan();
 
-			sw.set( 1 ); // this will be normalized by the shader anyway
+			if ( scale !== Infinity ) {
+
+				sw.multiplyScalar( scale );
+
+			} else {
+
+				sw.set( 1 ); // this will be normalized by the shader anyway
+
+			}
 
 		}
+
+	} else {
+
+		// skinning weights assumed to be normalized for THREE.BufferGeometry
 
 	}
 


### PR DESCRIPTION
THREE.SkinnedMesh previously assumed its geometry was an instance of THREE.Geometry while normalizing skinning weights

See also https://github.com/mrdoob/three.js/issues/3510
