### PR TITLE
Added Box3.setFromObject(). Removed Object3D.computeBoundingBox().

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -41,8 +41,6 @@ THREE.Object3D = function () {
 
 	this.frustumCulled = true;
 
-	this.boundingBox = null;
-
 	this.userData = {};
 
 };
@@ -444,53 +442,6 @@ THREE.Object3D.prototype = {
 
 	},
 
-	computeBoundingBox: function() {
-
-		// computes the world-axis-aligned bounding box of object (including its children),
-		// accounting for both the object's and childrens' world transforms
-
-		var v1 = new THREE.Vector3();
-
-		return function() {
-
-			if ( this.boundingBox === null ) {
-
-				this.boundingBox = new THREE.Box3();
-
-			}
-
-			this.boundingBox.makeEmpty();
-
-			var scope = this.boundingBox;
-
-			this.updateMatrixWorld( true );
-
-			this.traverse( function ( node ) {
-
-				if ( node.geometry !== undefined && node.geometry.vertices !== undefined ) {
-
-					var vertices = node.geometry.vertices;
-
-					for ( var i = 0, il = vertices.length; i < il; i++ ) {
-
-						v1.copy( vertices[ i ] );
-
-						v1.applyMatrix4( node.matrixWorld );
-
-						scope.expandByPoint( v1 );
-
-					}
-
-				}
-
-			} );
-
-			return this.boundingBox;
-
-		};
-
-	}(),
-
 	clone: function ( object, recursive ) {
 
 		if ( object === undefined ) object = new THREE.Object3D();
@@ -524,12 +475,6 @@ THREE.Object3D.prototype = {
 		object.receiveShadow = this.receiveShadow;
 
 		object.frustumCulled = this.frustumCulled;
-
-		if ( this.boundingBox instanceof THREE.Box3 ) {
-
-			object.boundingBox = this.boundingBox.clone();
-
-		}
 
 		object.userData = JSON.parse( JSON.stringify( this.userData ) );
 

--- a/src/extras/helpers/BoundingBoxHelper.js
+++ b/src/extras/helpers/BoundingBoxHelper.js
@@ -20,10 +20,10 @@ THREE.BoundingBoxHelper.prototype = Object.create( THREE.Mesh.prototype );
 
 THREE.BoundingBoxHelper.prototype.update = function () {
 
-	this.object.computeBoundingBox();
+	this.box.setFromObject( this.object );
 
-	this.object.boundingBox.size( this.scale );
+	this.box.size( this.scale );
 
-	this.object.boundingBox.center( this.position );
+	this.box.center( this.position );
 
 };

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -1,5 +1,6 @@
 /**
  * @author bhouston / http://exocortex.com
+ * @author WestLangley / http://github.com/WestLangley
  */
 
 THREE.Box3 = function ( min, max ) {
@@ -87,6 +88,47 @@ THREE.Box3.prototype = {
 
 			this.min.copy( center ).sub( halfSize );
 			this.max.copy( center ).add( halfSize );
+
+			return this;
+
+		};
+
+	}(),
+
+	setFromObject: function() {
+
+		// Computes the world-axis-aligned bounding box of an object (including its children),
+		// accounting for both the object's, and childrens', world transforms
+
+		var v1 = new THREE.Vector3();
+
+		return function( object ) {
+
+			var scope = this;
+
+			object.updateMatrixWorld( true );
+
+			this.makeEmpty();
+
+			object.traverse( function ( node ) {
+
+				if ( node.geometry !== undefined && node.geometry.vertices !== undefined ) {
+
+					var vertices = node.geometry.vertices;
+
+					for ( var i = 0, il = vertices.length; i < il; i++ ) {
+
+						v1.copy( vertices[ i ] );
+
+						v1.applyMatrix4( node.matrixWorld );
+
+						scope.expandByPoint( v1 );
+
+					}
+
+				}
+
+			} );
 
 			return this;
 


### PR DESCRIPTION
Implements #3471

`Box3.setFromObject( object )` computes the world-axis-aligned bounding box of an object (including its children), accounting for both the object's, and children's, world transforms.

Backs out `Object3D.boundingBox` and `Object3D.computeBoundingBox()`.
