### PR TITLE
Minor ArrowHelper Change

### DIFF
--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -56,11 +56,11 @@ THREE.ArrowHelper.prototype.setDirection = function () {
 
 		// dir is assumed to be normalized
 
-		if ( dir.y > 0.999 ) {
+		if ( dir.y > 0.99999 ) {
 
 			this.quaternion.set( 0, 0, 0, 1 );
 
-		} else if ( dir.y < - 0.999 ) {
+		} else if ( dir.y < - 0.99999 ) {
 
 			this.quaternion.set( 1, 0, 0, 0 );
 


### PR DESCRIPTION
As discussed in [this](http://stackoverflow.com/questions/16801888/why-does-arrowhelper-not-hit-the-target) stackoverflow question, the `ArrowHelper` direction is slightly off when the desired direction is approximately "straight up" -- or "straight down".

A simple constant change fixes the problem adequately, without causing numerical problems. The max error is now about 1/4 degrees.
