### PR TITLE
From #1454, small edit to TrackballControls.js to zoom properly with an Orthographic Camera

### DIFF
--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -29,9 +29,6 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 	this.staticMoving = false;
 	this.dynamicDampingFactor = 0.2;
 
-	this.minDistance = 0;
-	this.maxDistance = Infinity;
-
 	this.keys = [ 65 /*A*/, 83 /*S*/, 68 /*D*/ ];
 
 	// internals
@@ -240,26 +237,6 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 	};
 
-	this.checkDistances = function () {
-
-		if ( !_this.noZoom || !_this.noPan ) {
-
-			if ( _this.object.position.lengthSq() > _this.maxDistance * _this.maxDistance ) {
-
-				_this.object.position.setLength( _this.maxDistance );
-
-			}
-
-			if ( _eye.lengthSq() < _this.minDistance * _this.minDistance ) {
-
-				_this.object.position.addVectors( _this.target, _eye.setLength( _this.minDistance ) );
-
-			}
-
-		}
-
-	};
-
 	this.update = function () {
 
 		_eye.subVectors( _this.object.position, _this.target );
@@ -284,8 +261,6 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 		}
 
 		_this.object.position.addVectors( _this.target, _eye );
-
-		_this.checkDistances();
 
 		_this.object.lookAt( _this.target );
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -194,7 +194,19 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 			if ( factor !== 1.0 && factor > 0.0 ) {
 
-				_eye.multiplyScalar( factor );
+				if ( this.object instanceof THREE.PerspectiveCamera ) {
+
+					_eye.multiplyScalar( factor );
+
+				} else {
+
+					this.object.left *= factor;
+					this.object.right *= factor;
+					this.object.top *= factor;
+					this.object.bottom *= factor;
+
+					this.object.updateProjectionMatrix();
+				}
 
 				if ( _this.staticMoving ) {
 


### PR DESCRIPTION
Handles zoom for PerspectiveCamera and OrthographicCamera differently. Functional example of this in use [here](http://ec2-184-73-149-254.compute-1.amazonaws.com:9000/).
