### PR TITLE
Fixed bug in MTLLoader.js

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -405,7 +405,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 };
 
-THREE.MTLLoader.prototype.loadTexture = function ( url, mapping, onLoad, onError ) {
+THREE.MTLLoader.MaterialCreator.prototype.loadTexture = function ( url, mapping, onLoad, onError ) {
 
 	var isCompressed = /\.dds$/i.test( url );
 


### PR DESCRIPTION
Before this fix, there was this error in the console:

> Object [object Object] has no method 'loadTexture'

for these examples files:
- examples/webgl_loader_scene.html
- examples/webgl_loader_scene.html
- examples/webgl_loader_utf8.html

`loadTexture()` was attached to the wrong prototype.

After this fix, all the above example files load without errors. The visual results look correct in the viewport too.
