### PR TITLE
Added intersectsBox method to Frustum

### DIFF
--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -131,7 +131,7 @@ THREE.Frustum.prototype = {
 
 	},
 
-	intersectsBox = function() {
+	intersectsBox : function() {
 
 		var p1 = new THREE.Vector3(),
 			p2 = new THREE.Vector3();
@@ -166,7 +166,7 @@ THREE.Frustum.prototype = {
 			return true;
 		};
 
-	}();
+	}(),
 
 
 	containsPoint: function ( point ) {

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -131,6 +131,44 @@ THREE.Frustum.prototype = {
 
 	},
 
+	intersectsBox = function() {
+
+		var p1 = new THREE.Vector3(),
+			p2 = new THREE.Vector3();
+
+		return function( box ) {
+
+			var planes = this.planes;
+			
+			for ( var i = 0; i < 6 ; i ++ ) {
+			
+				var plane = planes[i];
+				
+				p1.x = plane.normal.x > 0 ? box.min.x : box.max.x;
+				p2.x = plane.normal.x > 0 ? box.max.x : box.min.x;
+				p1.y = plane.normal.y > 0 ? box.min.y : box.max.y;
+				p2.y = plane.normal.y > 0 ? box.max.y : box.min.y;
+				p1.z = plane.normal.z > 0 ? box.min.z : box.max.z;
+				p2.z = plane.normal.z > 0 ? box.max.z : box.min.z;
+
+				var d1 = plane.distanceToPoint( p1 );
+				var d2 = plane.distanceToPoint( p2 );
+				
+				//if both outside plane, no intersection
+
+				if ( d1 < 0 && d2 < 0) {		
+					
+					return false;
+		
+				}
+			}
+
+			return true;
+		};
+
+	}();
+
+
 	containsPoint: function ( point ) {
 
 		var planes = this.planes;


### PR DESCRIPTION
I find it's sometimes better to test frustum culling against an axis aligned bouding box instead of a bouding sphere (for tall objects, for example), so I added a function for that. It's about half as efficient, but the gain in culling precision might be worth it, and the user might want to use that instead.

I also think intersectsObject should use boundingBox automatically if it is present. I didn't do anything in that method, but it might be something to consider.
