### PR TITLE
Ray-line picking : the return

### DIFF
--- a/examples/canvas_interactive_lines.html
+++ b/examples/canvas_interactive_lines.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>three.js webgl - interactive lines</title>
+		<title>three.js canvas - interactive lines</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<style>
@@ -40,23 +40,15 @@
 				info.style.top = '10px';
 				info.style.width = '100%';
 				info.style.textAlign = 'center';
-				info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> webgl - interactive lines';
+				info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> canvas - interactive lines';
 				container.appendChild( info );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 10000 );
 
 				scene = new THREE.Scene();
 
-				var light = new THREE.DirectionalLight( 0xffffff, 2 );
-				light.position.set( 1, 1, 1 ).normalize();
-				scene.add( light );
-
-				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( -1, -1, -1 ).normalize();
-				scene.add( light );
-
 				var sphereGeometry = new THREE.SphereGeometry(3);
-				sphereInter = new THREE.Mesh( sphereGeometry, new THREE.MeshLambertMaterial( { color: 0xff0000 } ) );
+				sphereInter = new THREE.Mesh( sphereGeometry, new THREE.MeshBasicMaterial( { color: 0xff0000 } ) );
 				sphereInter.visible = false;
 				scene.add( sphereInter );
 
@@ -66,7 +58,7 @@
 				geometry.vertices.push( new THREE.Vector3( 0, 30, -40 ) );
 				geometry.vertices.push( new THREE.Vector3( -15, -15, -30 ) );
 
-				parentTransform = new THREE.Mesh();
+				parentTransform = new THREE.Object3D();
 				parentTransform.position.x = Math.random() * 40 - 20;
 				parentTransform.position.y = Math.random() * 40 - 20;
 				parentTransform.position.z = Math.random() * 40 - 20;
@@ -106,7 +98,7 @@
 				raycaster = new THREE.Raycaster();
 				raycaster.linePrecision = 3;
 
-				renderer = new THREE.WebGLRenderer();
+				renderer = new THREE.CanvasRenderer();
 				renderer.sortObjects = false;
 				renderer.setSize( window.innerWidth, window.innerHeight );
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -292,17 +292,17 @@
 			var vertices = object.geometry.vertices;
 			var nbVertices = vertices.length;
 			var interSegment = new THREE.Vector3();
-			var interLine = new THREE.Vector3();
+			var interRay = new THREE.Vector3();
 			var step = object.type === THREE.LineStrip ? 1 : 2;
 
 			for(var i = 0; i < nbVertices - 1; i=i+step) {
 
-				localRay.distanceSqAndPointToSegment(vertices[i], vertices[i + 1], interLine, interSegment);
+				localRay.distanceToSegment(vertices[i], vertices[i + 1], interRay, interSegment);
 				interSegment.applyMatrix4(object.matrixWorld);
-				interLine.applyMatrix4(object.matrixWorld);
-				if(interLine.distanceToSquared(interSegment) <= precisionSq) {
+				interRay.applyMatrix4(object.matrixWorld);
+				if(interRay.distanceToSquared(interSegment) <= precisionSq) {
 
-					var distance = raycaster.ray.origin.distanceTo(interLine);
+					var distance = raycaster.ray.origin.distanceTo(interRay);
 
 					if(raycaster.near <= distance && distance <= raycaster.far) {
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -148,11 +148,11 @@
 
 						var planeDistance = localRay.distanceToPlane( facePlane );
 
-						// bail if raycaster and plane are parallel
-						if ( Math.abs( planeDistance ) < precision ) continue;
+						// bail if raycaster is too close to the plane
+						if ( planeDistance < precision ) continue;
 
-						// if negative distance, then plane is behind raycaster
-						if ( planeDistance < 0 ) continue;
+						// bail if raycaster is behind raycaster
+						if ( planeDistance === null ) continue;
 
 						// check if we hit the wrong side of a single sided face
 						side = material.side;
@@ -210,11 +210,11 @@
 
 					var planeDistance = localRay.distanceToPlane( facePlane );
 
-					// bail if raycaster and plane are parallel
-					if ( Math.abs( planeDistance ) < precision ) continue;
+					// bail if raycaster is too close to the plane
+					if ( planeDistance < precision ) continue;
 
-					// if negative distance, then plane is behind raycaster
-					if ( planeDistance < 0 ) continue;
+					// bail if raycaster is behind raycaster
+					if ( planeDistance === null ) continue;
 
 					// check if we hit the wrong side of a single sided face
 					side = material.side;

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -78,62 +78,76 @@ THREE.Ray.prototype = {
 
 	}(),
 
-	distanceSqAndPointToSegment: function( v0, v1, optionalPointOnLine, optionalPointOnSegment ) {
-		// from http://www.geometrictools.com/LibMathematics/Distance/Wm5DistLine3Segment3.cpp
-		// It returns the min distance between the ray (actually... the line) and the segment
+	distanceToSegment: function( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
+		// from http://www.geometrictools.com/LibMathematics/Distance/Wm5DistRay3Segment3.cpp
+		// It returns the min distance between the ray and the segment
 		// defined by v0 and v1
 		// It can also set two optional targets :
-		// - The closest point on the ray (...line)
+		// - The closest point on the ray
 		// - The closest point on the segment
 		var segCenter = v0.clone().add( v1 ).multiplyScalar( 0.5 );
 		var segDir = v1.clone().sub( v0 ).normalize();
-		var segExtent = v0.distanceTo( v1 ) *0.5;
+		var segExtent = v0.distanceTo( v1 ) * 0.5;
 		var diff = this.origin.clone().sub( segCenter );
-		var a01 = -this.direction.dot( segDir );
+		var a01 = - this.direction.dot( segDir );
 		var b0 = diff.dot( this.direction );
+		var b1 = - diff.dot( segDir );
 		var c = diff.lengthSq();
 		var det = Math.abs( 1 - a01 * a01 );
-		var b1, s0, s1, sqrDist, extDet;
-		if( det >= 0 ) {
-			// The line and segment are not parallel.
-			b1 = -diff.dot( segDir );
+		var s0, s1, sqrDist, extDet;
+		if (det >= 0) {
+			// The ray and segment are not parallel.
+			s0 = a01 * b1 - b0;
 			s1 = a01 * b0 - b1;
 			extDet = segExtent * det;
-			if( s1 >= -extDet ) {
-				if( s1 <= extDet ) {
-					// Two interior points are closest, one on the line and one
-					// on the segment.
-					var invDet = 1 / det;
-					s0 = ( a01 * b1 - b0 ) * invDet;
-					s1 *= invDet;
-					sqrDist = s0 * ( s0 + a01 * s1 + 2 * b0 ) + s1 * ( a01 * s0 + s1 + 2 * b1 ) + c;
+			if (s0 >= 0) {
+				if (s1 >= -extDet) {
+					if (s1 <= extDet) { // region 0
+						// Minimum at interior points of ray and segment.
+						var invDet = 1 / det;
+						s0 *= invDet;
+						s1 *= invDet;
+						sqrDist = s0 * ( s0 + a01 * s1 + 2 * b0 ) + s1 * ( a01 * s0 + s1 + 2 * b1 ) + c;
+					}
+					else { // region 1
+						s1 = segExtent;
+						s0 = Math.max( 0, - ( a01 * s1 + b0) );
+						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+					}
 				}
-				else {
-					// The endpoint e1 of the segment and an interior point of
-					// the line are closest.
-					s1 = segExtent;
-					s0 = - ( a01 * s1 + b0 );
+				else { // region 5
+					s1 = - segExtent;
+					s0 = Math.max( 0, - ( a01 * s1 + b0) );
 					sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 				}
 			}
 			else {
-				// The end point e0 of the segment and an interior point of the
-				// line are closest.
-				s1 = - segExtent;
-				s0 = - ( a01 * s1 + b0 );
-				sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+				if ( s1 <= - extDet) { // region 4
+					s0 = Math.max( 0, - ( - a01 * segExtent + b0 ) );
+					s1 = ( s0 > 0 ) ? - segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
+					sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+				}
+				else if (s1 <= extDet) { // region 3
+					s0 = 0;
+					s1 = Math.min( Math.max( - segExtent, - b1 ), segExtent );
+					sqrDist = s1 * ( s1 + 2 * b1 ) + c;
+				}
+				else { // region 2
+					s0 = Math.max( 0, - ( a01 * segExtent + b0 ) );
+					s1 = ( s0 > 0 ) ? segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
+					sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+				}
 			}
 		}
 		else {
-			// The line and segment are parallel.  Choose the closest pair so that
-			// one point is at segment center.
-			s1 = 0;
-			s0 = - b0;
-			sqrDist = b0 * s0 + c;
+			// Ray and segment are parallel.
+			s1 = ( a01 > 0 ) ? - segExtent : segExtent;
+			s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
+			sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 		}
-		if(optionalPointOnLine)
-			optionalPointOnLine.copy( this.direction.clone().multiplyScalar( s0 ).add( this.origin ) );
-		if(optionalPointOnSegment)
+		if( optionalPointOnRay )
+			optionalPointOnRay.copy( this.direction.clone().multiplyScalar( s0 ).add( this.origin ) );
+		if( optionalPointOnSegment )
 			optionalPointOnSegment.copy( segDir.clone().multiplyScalar( s1 ).add( segCenter ) );
 		return sqrDist;
 	},

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -59,6 +59,12 @@ THREE.Ray.prototype = {
 		result.subVectors( point, this.origin );
 		var directionDistance = result.dot( this.direction );
 
+		if ( directionDistance < 0 ) {
+
+			return this.origin.clone();
+
+		}
+
 		return result.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
 
 	},
@@ -70,6 +76,14 @@ THREE.Ray.prototype = {
 		return function ( point ) {
 
 			var directionDistance = v1.subVectors( point, this.origin ).dot( this.direction );
+
+			// point behind the ray
+			if ( directionDistance < 0 ) {
+
+				return this.origin.distanceTo( point);
+
+			}
+
 			v1.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
 
 			return v1.distanceTo( point );
@@ -160,22 +174,22 @@ THREE.Ray.prototype = {
 
 	isIntersectionPlane: function ( plane ) {
 
-		// check if the line and plane are non-perpendicular, if they
-		// eventually they will intersect.
+		// check if the ray lies on the plane first
+		var distToPoint = plane.distanceToPoint( this.origin );
+		if ( distToPoint === 0 ) {
+
+			return true;
+
+		}
+
 		var denominator = plane.normal.dot( this.direction );
-		if ( denominator != 0 ) {
+		if ( denominator * distToPoint < 0 ) {
 
-			return true;
-
-		}
-
-		// line is coplanar, return origin
-		if( plane.distanceToPoint( this.origin ) == 0 ) {
-
-			return true;
+			return true
 
 		}
 
+		// ray origin is behind the plane (and is pointing behind it)
 		return false;
 
 	},
@@ -192,14 +206,15 @@ THREE.Ray.prototype = {
 
 			}
 
-			// Unsure if this is the correct method to handle this case.
-			return undefined;
+			// null is preferable to undefined since undefined means.... it is undefined
+			return null;
 
 		}
 
 		var t = - ( this.origin.dot( plane.normal ) + plane.constant ) / denominator;
 
-		return t;
+		// Undefined if the ray never intersects the plane
+		return t >= 0 ? t : null;
 
 	},
 
@@ -207,9 +222,9 @@ THREE.Ray.prototype = {
 
 		var t = this.distanceToPlane( plane );
 
-		if ( t === undefined ) {
+		if ( t === null ) {
 
-			return undefined;
+			return null;
 		}
 
 		return this.at( t, optionalTarget );

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -59,6 +59,12 @@ THREE.Ray.prototype = {
 		result.subVectors( point, this.origin );
 		var directionDistance = result.dot( this.direction );
 
+		if ( directionDistance < 0 ) {
+
+			return this.origin.clone();
+
+		}
+
 		return result.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
 
 	},
@@ -70,6 +76,14 @@ THREE.Ray.prototype = {
 		return function ( point ) {
 
 			var directionDistance = v1.subVectors( point, this.origin ).dot( this.direction );
+
+			// point behind the ray
+			if ( directionDistance < 0 ) {
+
+				return this.origin.distanceTo( point);
+
+			}
+
 			v1.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
 
 			return v1.distanceTo( point );
@@ -160,22 +174,22 @@ THREE.Ray.prototype = {
 
 	isIntersectionPlane: function ( plane ) {
 
-		// check if the line and plane are non-perpendicular, if they
-		// eventually they will intersect.
+		// check if the ray lies on the plane first
+		var distToPoint = plane.distanceToPoint( this.origin );
+		if ( distToPoint === 0 ) {
+
+			return true;
+
+		}
+
 		var denominator = plane.normal.dot( this.direction );
-		if ( denominator != 0 ) {
+		if ( denominator * distToPoint < 0 ) {
 
-			return true;
-
-		}
-
-		// line is coplanar, return origin
-		if( plane.distanceToPoint( this.origin ) == 0 ) {
-
-			return true;
+			return true
 
 		}
 
+		// ray origin is behind the plane (and is pointing behind it)
 		return false;
 
 	},

--- a/test/unit/math/Ray.js
+++ b/test/unit/math/Ray.js
@@ -64,25 +64,33 @@ test( "recast/clone", function() {
 test( "closestPointToPoint", function() {
 	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
-	// nearby the ray
+	// behind the ray
 	var b = a.closestPointToPoint( zero3 );
-	ok( b.equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
+	ok( b.equals( one3 ), "Passed!" );
+
+	// front of the ray
+	var c = a.closestPointToPoint( new THREE.Vector3( 0, 0, 50 ) );
+	ok( c.equals( new THREE.Vector3( 1, 1, 50 ) ), "Passed!" );
 
 	// exactly on the ray
-	var c = a.closestPointToPoint( one3 );
-	ok( c.equals( one3 ), "Passed!" );
+	var d = a.closestPointToPoint( one3 );
+	ok( d.equals( one3 ), "Passed!" );
 });
 
 test( "distanceToPoint", function() {
 	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
-	// nearby the ray
+	// behind the ray
 	var b = a.distanceToPoint( zero3 );
-	ok( b == Math.sqrt( 2 ), "Passed!" );
+	ok( b === Math.sqrt( 3 ), "Passed!" );
+
+	// front of the ray
+	var c = a.distanceToPoint( new THREE.Vector3( 0, 0, 50 ) );
+	ok( c === Math.sqrt( 2 ), "Passed!" );
 
 	// exactly on the ray
-	var c = a.distanceToPoint( one3 );
-	ok( c == 0, "Passed!" );
+	var d = a.distanceToPoint( one3 );
+	ok( d === 0, "Passed!" );
 });
 
 test( "isIntersectionSphere", function() {
@@ -94,7 +102,7 @@ test( "isIntersectionSphere", function() {
 	var f = new THREE.Sphere( two3, 1 );
 
 	ok( ! a.isIntersectionSphere( b ), "Passed!" );
-	ok( a.isIntersectionSphere( c ), "Passed!" );
+	ok( ! a.isIntersectionSphere( c ), "Passed!" );
 	ok( a.isIntersectionSphere( d ), "Passed!" );
 	ok( ! a.isIntersectionSphere( e ), "Passed!" );
 	ok( ! a.isIntersectionSphere( f ), "Passed!" );
@@ -103,7 +111,7 @@ test( "isIntersectionSphere", function() {
 test( "isIntersectionPlane", function() {
 	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
-	// parallel plane behind
+	// parallel plane in front of the ray
 	var b = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), one3.clone().sub( new THREE.Vector3( 0, 0, -1 ) ) );
 	ok( a.isIntersectionPlane( b ), "Passed!" );
 
@@ -111,9 +119,9 @@ test( "isIntersectionPlane", function() {
 	var c = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), one3.clone().sub( new THREE.Vector3( 0, 0, 0 ) ) );
 	ok( a.isIntersectionPlane( c ), "Passed!" );
 
-	// parallel plane infront
+	// parallel plane behind the ray
 	var d = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), one3.clone().sub( new THREE.Vector3( 0, 0, 1 ) ) );
-	ok( a.isIntersectionPlane( d ), "Passed!" );
+	ok( ! a.isIntersectionPlane( d ), "Passed!" );
 
 	// perpendical ray that overlaps exactly
 	var e = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 1, 0, 0 ), one3 );
@@ -129,15 +137,15 @@ test( "intersectPlane", function() {
 
 	// parallel plane behind
 	var b = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), new THREE.Vector3( 1, 1, -1 ) );
-	ok( a.intersectPlane( b ).equals( new THREE.Vector3( 1, 1, -1 ) ), "Passed!" );
+	ok( a.intersectPlane( b ) === null, "Passed!" );
 
 	// parallel plane coincident with origin
 	var c = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), new THREE.Vector3( 1, 1, 0 ) );
-	ok( a.intersectPlane( c ).equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
+	ok( a.intersectPlane( c ) === null, "Passed!" );
 
 	// parallel plane infront
 	var d = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), new THREE.Vector3( 1, 1, 1 ) );
-	ok( a.intersectPlane( d ).equals( new THREE.Vector3( 1, 1, 1 ) ), "Passed!" );
+	ok( a.intersectPlane( d ).equals( a.origin ), "Passed!" );
 
 	// perpendical ray that overlaps exactly
 	var e = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 1, 0, 0 ), one3 );
@@ -145,7 +153,7 @@ test( "intersectPlane", function() {
 
 	// perpendical ray that doesn't overlap
 	var f = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 1, 0, 0 ), zero3 );
-	ok( a.intersectPlane( f ) === undefined, "Passed!" );
+	ok( a.intersectPlane( f ) === null, "Passed!" );
 });
 
 

--- a/test/unit/math/Ray.js
+++ b/test/unit/math/Ray.js
@@ -174,19 +174,39 @@ test( "applyMatrix4", function() {
 });
 
 
-test( "distanceSqAndPointToSegment4", function() {
+test( "distanceToSegment", function() {
 	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
-	var v0 = new THREE.Vector3( 3, 5, 50 );
-	var v1 = new THREE.Vector3( 50, 50, 50 ); // just a far away point
 	var ptOnLine = new THREE.Vector3();
 	var ptOnSegment = new THREE.Vector3();
-	var distSqr = a.distanceSqAndPointToSegment( v0, v1, ptOnLine, ptOnSegment );
-	var m = new THREE.Matrix4();
+
+	//segment in front of the ray
+	var v0 = new THREE.Vector3( 3, 5, 50 );
+	var v1 = new THREE.Vector3( 50, 50, 50 ); // just a far away point
+	var distSqr = a.distanceToSegment( v0, v1, ptOnLine, ptOnSegment );
 
 	ok( ptOnSegment.distanceTo( v0 ) < 0.0001, "Passed!" );
 	ok( ptOnLine.distanceTo( new THREE.Vector3(1, 1, 50) ) < 0.0001, "Passed!" );
 	// ((3-1) * (3-1) + (5-1) * (5-1) = 4 + 16 = 20
-	ok( distSqr === 20, "Passed!" );
+	ok( Math.abs( distSqr - 20 ) < 0.0001, "Passed!" );
+
+	//segment behind the ray
+	v0 = new THREE.Vector3( -50, -50, -50 ); // just a far away point
+	v1 = new THREE.Vector3( -3, -5, -4 );
+	distSqr = a.distanceToSegment( v0, v1, ptOnLine, ptOnSegment );
+
+	ok( ptOnSegment.distanceTo( v1 ) < 0.0001, "Passed!" );
+	ok( ptOnLine.distanceTo( one3 ) < 0.0001, "Passed!" );
+	// ((-3-1) * (-3-1) + (-5-1) * (-5-1) + (-4-1) + (-4-1) = 16 + 36 + 25 = 77
+	ok( Math.abs( distSqr - 77 ) < 0.0001, "Passed!" );
+
+	//exact intersection between the ray and the segment
+	v0 = new THREE.Vector3( -50, -50, -50 );
+	v1 = new THREE.Vector3( 50, 50, 50 );
+	distSqr = a.distanceToSegment( v0, v1, ptOnLine, ptOnSegment );
+
+	ok( ptOnSegment.distanceTo( one3 ) < 0.0001, "Passed!" );
+	ok( ptOnLine.distanceTo( one3 ) < 0.0001, "Passed!" );
+	ok( distSqr < 0.0001, "Passed!" );
 });
 
 

--- a/test/unit/math/Ray.js
+++ b/test/unit/math/Ray.js
@@ -64,25 +64,33 @@ test( "recast/clone", function() {
 test( "closestPointToPoint", function() {
 	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
-	// nearby the ray
+	// behind the ray
 	var b = a.closestPointToPoint( zero3 );
-	ok( b.equals( new THREE.Vector3( 1, 1, 0 ) ), "Passed!" );
+	ok( b.equals( one3 ), "Passed!" );
+
+	// front of the ray
+	var c = a.closestPointToPoint( new THREE.Vector3( 0, 0, 50 ) );
+	ok( c.equals( new THREE.Vector3( 1, 1, 50 ) ), "Passed!" );
 
 	// exactly on the ray
-	var c = a.closestPointToPoint( one3 );
-	ok( c.equals( one3 ), "Passed!" );
+	var d = a.closestPointToPoint( one3 );
+	ok( d.equals( one3 ), "Passed!" );
 });
 
 test( "distanceToPoint", function() {
 	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
-	// nearby the ray
+	// behind the ray
 	var b = a.distanceToPoint( zero3 );
-	ok( b == Math.sqrt( 2 ), "Passed!" );
+	ok( b === Math.sqrt( 3 ), "Passed!" );
+
+	// front of the ray
+	var c = a.distanceToPoint( new THREE.Vector3( 0, 0, 50 ) );
+	ok( c === Math.sqrt( 2 ), "Passed!" );
 
 	// exactly on the ray
-	var c = a.distanceToPoint( one3 );
-	ok( c == 0, "Passed!" );
+	var d = a.distanceToPoint( one3 );
+	ok( d === 0, "Passed!" );
 });
 
 test( "isIntersectionSphere", function() {
@@ -94,7 +102,7 @@ test( "isIntersectionSphere", function() {
 	var f = new THREE.Sphere( two3, 1 );
 
 	ok( ! a.isIntersectionSphere( b ), "Passed!" );
-	ok( a.isIntersectionSphere( c ), "Passed!" );
+	ok( ! a.isIntersectionSphere( c ), "Passed!" );
 	ok( a.isIntersectionSphere( d ), "Passed!" );
 	ok( ! a.isIntersectionSphere( e ), "Passed!" );
 	ok( ! a.isIntersectionSphere( f ), "Passed!" );
@@ -103,7 +111,7 @@ test( "isIntersectionSphere", function() {
 test( "isIntersectionPlane", function() {
 	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 
-	// parallel plane behind
+	// parallel plane in front of the ray
 	var b = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), one3.clone().sub( new THREE.Vector3( 0, 0, -1 ) ) );
 	ok( a.isIntersectionPlane( b ), "Passed!" );
 
@@ -111,9 +119,9 @@ test( "isIntersectionPlane", function() {
 	var c = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), one3.clone().sub( new THREE.Vector3( 0, 0, 0 ) ) );
 	ok( a.isIntersectionPlane( c ), "Passed!" );
 
-	// parallel plane infront
+	// parallel plane behind the ray
 	var d = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 0, 0, 1 ), one3.clone().sub( new THREE.Vector3( 0, 0, 1 ) ) );
-	ok( a.isIntersectionPlane( d ), "Passed!" );
+	ok( ! a.isIntersectionPlane( d ), "Passed!" );
 
 	// perpendical ray that overlaps exactly
 	var e = new THREE.Plane().setFromNormalAndCoplanarPoint( new THREE.Vector3( 1, 0, 0 ), one3 );


### PR DESCRIPTION
Following the issues discussed here https://github.com/mrdoob/three.js/pull/3629 :

1,2,3. I changed the Ray class so that it is now used as a ray and not a line.
    I don't really know how much of an impact it could have... so it's up to you
    But I agree that there's a kind of confusion between ray/line/segment (on top of that Line in three.js is an Object3D and not a math thing...)
4. Added a few unit test for the ray
5. webgl_interactives_lines changed to canvas_interactives_lines
6. I don't think that setting the initial threshold to 1 is good.
    Depending on the scene scale, you are likely to pick every lines or none of them...

As I said previously, to get an 'absolute' threshold.. you'll have to unproject the vertices on display and compare with the mouse position or use color-picking :D
