### PR TITLE
Line-picking

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -353,20 +353,20 @@
 
 			for ( var i = 0; i < nbVertices - 1; i = i + step ) {
 
-				localRay.distanceSqToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );
-				interSegment.applyMatrix4( object.matrixWorld );
-				interRay.applyMatrix4( object.matrixWorld );
+				var distSq = localRay.distanceSqToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );
 
-				if ( interRay.distanceToSquared( interSegment ) <= precisionSq ) {
+				if ( distSq <= precisionSq ) {
 
-					var distance = raycaster.ray.origin.distanceTo( interRay );
+					var distance = localRay.origin.distanceTo( interRay );
 
 					if ( raycaster.near <= distance && distance <= raycaster.far ) {
 
 						intersects.push( {
 
 							distance: distance,
-							point: interSegment.clone(),
+							// What do we want? intersection point on the ray or on the segment??
+							// point: raycaster.ray.at( distance ),
+							point: interSegment.clone().applyMatrix4( object.matrixWorld ),
 							face: null,
 							faceIndex: null,
 							object: object

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -353,7 +353,7 @@
 
 			for ( var i = 0; i < nbVertices - 1; i = i + step ) {
 
-				localRay.distanceToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );
+				localRay.distanceSqToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );
 				interSegment.applyMatrix4( object.matrixWorld );
 				interRay.applyMatrix4( object.matrixWorld );
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -93,7 +93,7 @@ THREE.Ray.prototype = {
 
 	}(),
 
-	distanceToSegment: function( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
+	distanceSqToSegment: function( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
 
 		// from http://www.geometrictools.com/LibMathematics/Distance/Wm5DistRay3Segment3.cpp
 		// It returns the min distance between the ray and the segment

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -61,7 +61,7 @@ THREE.Ray.prototype = {
 
 		if ( directionDistance < 0 ) {
 
-			return this.origin.clone();
+			return result.copy( this.origin );
 
 		}
 

--- a/test/unit/math/Ray.js
+++ b/test/unit/math/Ray.js
@@ -182,7 +182,7 @@ test( "applyMatrix4", function() {
 });
 
 
-test( "distanceToSegment", function() {
+test( "distanceSqToSegment", function() {
 	var a = new THREE.Ray( one3.clone(), new THREE.Vector3( 0, 0, 1 ) );
 	var ptOnLine = new THREE.Vector3();
 	var ptOnSegment = new THREE.Vector3();
@@ -190,7 +190,7 @@ test( "distanceToSegment", function() {
 	//segment in front of the ray
 	var v0 = new THREE.Vector3( 3, 5, 50 );
 	var v1 = new THREE.Vector3( 50, 50, 50 ); // just a far away point
-	var distSqr = a.distanceToSegment( v0, v1, ptOnLine, ptOnSegment );
+	var distSqr = a.distanceSqToSegment( v0, v1, ptOnLine, ptOnSegment );
 
 	ok( ptOnSegment.distanceTo( v0 ) < 0.0001, "Passed!" );
 	ok( ptOnLine.distanceTo( new THREE.Vector3(1, 1, 50) ) < 0.0001, "Passed!" );
@@ -200,7 +200,7 @@ test( "distanceToSegment", function() {
 	//segment behind the ray
 	v0 = new THREE.Vector3( -50, -50, -50 ); // just a far away point
 	v1 = new THREE.Vector3( -3, -5, -4 );
-	distSqr = a.distanceToSegment( v0, v1, ptOnLine, ptOnSegment );
+	distSqr = a.distanceSqToSegment( v0, v1, ptOnLine, ptOnSegment );
 
 	ok( ptOnSegment.distanceTo( v1 ) < 0.0001, "Passed!" );
 	ok( ptOnLine.distanceTo( one3 ) < 0.0001, "Passed!" );
@@ -210,7 +210,7 @@ test( "distanceToSegment", function() {
 	//exact intersection between the ray and the segment
 	v0 = new THREE.Vector3( -50, -50, -50 );
 	v1 = new THREE.Vector3( 50, 50, 50 );
-	distSqr = a.distanceToSegment( v0, v1, ptOnLine, ptOnSegment );
+	distSqr = a.distanceSqToSegment( v0, v1, ptOnLine, ptOnSegment );
 
 	ok( ptOnSegment.distanceTo( one3 ) < 0.0001, "Passed!" );
 	ok( ptOnLine.distanceTo( one3 ) < 0.0001, "Passed!" );


### PR DESCRIPTION
Follows https://github.com/mrdoob/three.js/pull/3635:
1. Indeed this is stupid... Here's what I can do

``` javascript
for ( var i = 0; i < nbVertices - 1; i = i + step ) {

    var dist = localRay.distanceSqToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );

    if ( dist <= precisionSq ) {

        var distance = localRay.origin.distanceTo( interRay );

        if ( raycaster.near <= distance && distance <= raycaster.far ) {

            intersects.push( {

                distance: distance,
                // What do we want? intersection point on the ray or on the segment??
                //point: raycaster.ray.at( distance ),
                point: interSegment.clone().applyMatrix4( object.matrixWorld ),
                face: null,
                faceIndex: null,
                object: object

            } );
```

But in that case I think the scale matrix got an impact on 'dist'. The demo still works fine, though.
And btw what do we expect the raycaster to return as an intersection point? The point on the ray or on the line object (currently it's on the line)?
1. For the line intersection, I got some problems when dealing with scale matrix because the localRay wasn't normalized... that's why I normalized it. I think I kind of sux with scale matrix :(
2. If i'm not mistaken there're no signed distance in `Ray` anymore
3. Hmm currently it returns the ray's origin (btw in that case I forgot to put the value in the optional target arf). I don't think it's wrong saying that the closest point of a point behind the ray is the ray's origin...
4. I think only the scale matrix plays a role between local/world space when using `Raycaster.linePrecision`
