### PR TITLE
Raycaster first checks for intersection with bounding box

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -81,6 +81,18 @@
 
 			}
 
+			//Check boundingBox before continuing
+			
+			inverseMatrix.getInverse( object.matrixWorld );	
+			localRay.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
+
+			if ( geometry.boundingBox !== null) {
+				if ( localRay.isIntersectionBox(geometry.boundingBox) === false )  {
+					return intersects;
+				}
+			}
+
+
 			var vertices = geometry.vertices;
 
 			if ( geometry instanceof THREE.BufferGeometry ) {
@@ -97,10 +109,6 @@
 
 				var a, b, c;
 				var precision = raycaster.precision;
-
-				inverseMatrix.getInverse( object.matrixWorld );
-
-				localRay.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
 
 				var fl;
 				var indexed = false;
@@ -227,10 +235,6 @@
 
 				var a, b, c, d;
 				var precision = raycaster.precision;
-
-				inverseMatrix.getInverse( object.matrixWorld );
-
-				localRay.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
 
 				for ( var f = 0, fl = geometry.faces.length; f < fl; f ++ ) {
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -243,6 +243,77 @@ THREE.Ray.prototype = {
 
 	},
 
+	isIntersectionBox: function () {
+		
+		var v = new THREE.Vector3();
+
+		return function ( box ) {
+
+			return this.intersectBox( box, v ) !== null;
+
+		}
+
+	}(),
+
+	intersectBox: function ( box , optionalTarget ) {
+
+		// http://www.scratchapixel.com/lessons/3d-basic-lessons/lesson-7-intersecting-simple-shapes/ray-box-intersection/
+
+		var tmin,tmax,tymin,tymax,tzmin,tzmax;
+
+		var invdirx = 1/this.direction.x,
+			invdiry = 1/this.direction.y,
+			invdirz = 1/this.direction.z;
+
+		var origin = this.origin;
+
+		if (invdirx >= 0) {
+				
+			tmin = (box.min.x - origin.x) * invdirx;
+			tmax = (box.max.x - origin.x) * invdirx;
+
+		} else { 
+
+			tmin = (box.max.x - origin.x) * invdirx;
+			tmax = (box.min.x - origin.x) * invdirx;
+		}			
+
+		if (invdiry >= 0) {
+		
+			tymin = (box.min.y - origin.y) * invdiry;
+			tymax = (box.max.y - origin.y) * invdiry;
+
+		} else {
+
+			tymin = (box.max.y - origin.y) * invdiry;
+			tymax = (box.min.y - origin.y) * invdiry;
+		}
+
+		if ((tmin > tymax) || (tymin > tmax)) return null;
+
+		if (tymin > tmin) tmin = tymin;
+
+		if (tymax < tmax) tmax = tymax;
+
+		if (invdirz >= 0) {
+		
+			tzmin = (box.min.z - origin.z) * invdirz;
+			tzmax = (box.max.z - origin.z) * invdirz;
+
+		} else {
+
+			tzmin = (box.max.z - origin.z) * invdirz;
+			tzmax = (box.min.z - origin.z) * invdirz;
+		}
+
+		if ((tmin > tzmax) || (tzmin > tmax)) return null;
+
+		if (tzmin > tmin) tmin = tzmin; 
+
+		return this.at( tmin, optionalTarget );;
+
+	},
+
 	distanceToPlane: function ( plane ) {
 
 		var denominator = plane.normal.dot( this.direction );

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -308,9 +308,15 @@ THREE.Ray.prototype = {
 
 		if ((tmin > tzmax) || (tzmin > tmax)) return null;
 
-		if (tzmin > tmin) tmin = tzmin; 
+		if (tzmin > tmin) tmin = tzmin;
 
-		return this.at( tmin, optionalTarget );;
+		if (tzmax < tmax) tmax = tzmax;
+
+		//return point closest to the ray (positive side)
+
+		if ( tmax < 0 ) return null;
+
+		return this.at( tmin >= 0 ? tmin : tmax, optionalTarget );
 
 	},
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -291,9 +291,9 @@ THREE.Ray.prototype = {
 
 		if ((tmin > tymax) || (tymin > tmax)) return null;
 
-		if (tymin > tmin) tmin = tymin;
+		if (tymin > tmin || isNaN(tmin) ) tmin = tymin;
 
-		if (tymax < tmax) tmax = tymax;
+		if (tymax < tmax || isNaN(tmax) ) tmax = tymax;
 
 		if (invdirz >= 0) {
 		
@@ -308,9 +308,9 @@ THREE.Ray.prototype = {
 
 		if ((tmin > tzmax) || (tzmin > tmax)) return null;
 
-		if (tzmin > tmin) tmin = tzmin;
+		if (tzmin > tmin || isNaN(tmin) ) tmin = tzmin;
 
-		if (tzmax < tmax) tmax = tzmax;
+		if (tzmax < tmax || isNaN(tmax) ) tmax = tzmax;
 
 		//return point closest to the ray (positive side)
 

--- a/test/unit/math/Ray.js
+++ b/test/unit/math/Ray.js
@@ -217,3 +217,33 @@ test( "distanceSqToSegment", function() {
 	ok( distSqr < 0.0001, "Passed!" );
 });
 
+test( "intersectBox", function() {
+
+	var TOL = 0.0001;
+	
+	var box = new THREE.Box3( new THREE.Vector3(  -1, -1, -1 ), new THREE.Vector3( 1, 1, 1 ) );
+
+	var a = new THREE.Ray( new THREE.Vector3( -2, 0, 0 ), new THREE.Vector3( 1, 0, 0) );
+	//ray should intersect box at -1,0,0
+	ok( a.isIntersectionBox(box) === true, "Passed!" );
+	ok( a.intersectBox(box).distanceTo( new THREE.Vector3( -1, 0, 0 ) ) < TOL, "Passed!" );
+
+	var b = new THREE.Ray( new THREE.Vector3( -2, 0, 0 ), new THREE.Vector3( -1, 0, 0) );
+	//ray is point away from box, it should not intersect
+	ok( b.isIntersectionBox(box) === false, "Passed!" );
+	ok( b.intersectBox(box) === null, "Passed!" );
+
+	var c = new THREE.Ray( new THREE.Vector3( 0, 0, 0 ), new THREE.Vector3( 1, 0, 0) );
+	// ray is inside box, should return exit point
+	ok( c.isIntersectionBox(box) === true, "Passed!" );
+	ok( c.intersectBox(box).distanceTo( new THREE.Vector3( 1, 0, 0 ) ) < TOL, "Passed!" );
+
+	//even if we attempt to use unnormalized direction vector, it should work
+	var a = new THREE.Ray( new THREE.Vector3( 0, -2, -1 ), new THREE.Vector3( 0, 100, 100) );
+	//ray should intersect box at -1,0,0
+	ok( a.isIntersectionBox(box) === true, "Passed!" );
+	ok( a.intersectBox(box).distanceTo( new THREE.Vector3( 0, -1, 0 ) ) < TOL, "Passed!" );	
+	
+});
+
+

--- a/test/unit/math/Ray.js
+++ b/test/unit/math/Ray.js
@@ -242,6 +242,16 @@ test( "intersectBox", function() {
 	//tilted ray should intersect box at 0,1,0
 	ok( d.isIntersectionBox(box) === true, "Passed!" );
 	ok( d.intersectBox(box).distanceTo( new THREE.Vector3( 0, 1, 0 ) ) < TOL, "Passed!" );	
+
+	var e = new THREE.Ray( new THREE.Vector3( 1, -2, 1 ), new THREE.Vector3( 0, 1, 0).normalize() );
+	//handle case where ray is coplar with one of the boxes side - box in front of ray
+	ok( e.isIntersectionBox(box) === true, "Passed!" );
+	ok( e.intersectBox(box).distanceTo( new THREE.Vector3( 1, -1, 1 ) ) < TOL, "Passed!" );	
+	
+	var f = new THREE.Ray( new THREE.Vector3( 1, -2, 0 ), new THREE.Vector3( 0, -1, 0).normalize() );
+	//handle case where ray is coplar with one of the boxes side - box behind ray
+	ok( f.isIntersectionBox(box) === false, "Passed!" );
+	ok( f.intersectBox(box) == null, "Passed!" );		
 	
 });
 

--- a/test/unit/math/Ray.js
+++ b/test/unit/math/Ray.js
@@ -238,11 +238,10 @@ test( "intersectBox", function() {
 	ok( c.isIntersectionBox(box) === true, "Passed!" );
 	ok( c.intersectBox(box).distanceTo( new THREE.Vector3( 1, 0, 0 ) ) < TOL, "Passed!" );
 
-	//even if we attempt to use unnormalized direction vector, it should work
-	var a = new THREE.Ray( new THREE.Vector3( 0, -2, -1 ), new THREE.Vector3( 0, 100, 100) );
-	//ray should intersect box at -1,0,0
-	ok( a.isIntersectionBox(box) === true, "Passed!" );
-	ok( a.intersectBox(box).distanceTo( new THREE.Vector3( 0, -1, 0 ) ) < TOL, "Passed!" );	
+	var d = new THREE.Ray( new THREE.Vector3( 0, 2, 1 ), new THREE.Vector3( 0, -1, -1).normalize() );
+	//tilted ray should intersect box at 0,1,0
+	ok( d.isIntersectionBox(box) === true, "Passed!" );
+	ok( d.intersectBox(box).distanceTo( new THREE.Vector3( 0, 1, 0 ) ) < TOL, "Passed!" );	
 	
 });
 


### PR DESCRIPTION
I've added an intersection test between a `Ray` and a `Box3`.

Additionally, in `Raycaster`, the method `intersectObject` first checks for an intersection with the object's bounding box (if it exists ) before continuing with tests against the faces of the mesh. The ray is transformed to the local coordinates of the object for this.

This might be useful for complex meshes with a lot of faces that are not very well approximated by a bounding sphere. I leave it open for discussion whether that is enough to justify this change or not.
