### PR TITLE
Linking issue due to mismatched shader int precision (issue #3146)

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -6247,6 +6247,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		var prefix_vertex = [
 
 			"precision " + _precision + " float;",
+			"precision " + _precision + " int;",
 
 			customDefines,
 
@@ -6349,6 +6350,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		var prefix_fragment = [
 
 			"precision " + _precision + " float;",
+			"precision " + _precision + " int;",
 
 			( parameters.bumpMap || parameters.normalMap ) ? "#extension GL_OES_standard_derivatives : enable" : "",
 
@@ -6406,7 +6408,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( !_gl.getProgramParameter( program, _gl.LINK_STATUS ) ) {
 
 			console.error( "Could not initialise shader\n" + "VALIDATE_STATUS: " + _gl.getProgramParameter( program, _gl.VALIDATE_STATUS ) + ", gl error [" + _gl.getError() + "]" );
-
+			console.error( "Program Info Log: " + _gl.getProgramInfoLog( program ) );
 		}
 
 		// clean up


### PR DESCRIPTION
Forcing shader precision for ints to address Issue #3146. Also enabling program log to determine cause of linking errors.

The linking issue due to int precision has been seen in Chrome Canary for a while and just started happening in Chrome Beta this week, forcing me to look into the problem more. This issue crops up not only in my shaders but in many of the Three.js examples as well.

The solution was to just declare the precision of ints in both the vertex and fragment shaders. Perhaps a different precision value could be used so that the user could specify float and int precision separately?
