### PR TITLE
Normalized ray + fix crossVectors

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -1,6 +1,7 @@
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author bhouston / http://exocortex.com/
+ * @author stephomi / http://stephaneginier.com/
  */
 
 ( function ( THREE ) {
@@ -8,13 +9,7 @@
 	THREE.Raycaster = function ( origin, direction, near, far ) {
 
 		this.ray = new THREE.Ray( origin, direction );
-
-		// normalized ray.direction required for accurate distance calculations
-		if ( this.ray.direction.lengthSq() > 0 ) {
-
-			this.ray.direction.normalize();
-
-		}
+		// direction is assumed to be normalized (for accurate distance calculations)
 
 		this.near = near || 0;
 		this.far = far || Infinity;
@@ -172,8 +167,6 @@
 
 						intersects.push( {
 
-							// this works because the original ray was normalized,
-							// and the transformed localRay wasn't
 							distance: distance,
 							point: interPoint,
 							face: null,
@@ -288,7 +281,6 @@
 			
 			inverseMatrix.getInverse( object.matrixWorld );
 			localRay.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
-			localRay.direction.normalize(); // for scale matrix
 
 			var vertices = geometry.vertices;
 			var nbVertices = vertices.length;
@@ -347,13 +339,7 @@
 	THREE.Raycaster.prototype.set = function ( origin, direction ) {
 
 		this.ray.set( origin, direction );
-
-		// normalized ray.direction required for accurate distance calculations
-		if ( this.ray.direction.length() > 0 ) {
-
-			this.ray.direction.normalize();
-
-		}
+		// direction is assumed to be normalized (for accurate distance calculations)
 
 	};
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -158,7 +158,7 @@
 							positions[ c * 3 + 2 ]
 						);
 
-						var interPoint = THREE.Triangle.intersectionRayTriangle( localRay, vA, vB, vC, material.side !== THREE.DoubleSide );
+						var interPoint = THREE.Triangle.intersectionRay( localRay, vA, vB, vC, material.side !== THREE.DoubleSide );
 
 						if ( !interPoint ) continue;
 
@@ -212,7 +212,7 @@
 						a = vertices[ face.a ];
 						b = vertices[ face.b ];
 						c = vertices[ face.c ];
-						interPoint = THREE.Triangle.intersectionRayTriangle( localRay, a, b, c, material.side !== THREE.DoubleSide );
+						interPoint = THREE.Triangle.intersectionRay( localRay, a, b, c, material.side !== THREE.DoubleSide );
 
 						if ( !interPoint ) {
 
@@ -226,11 +226,11 @@
 						b = vertices[ face.b ];
 						c = vertices[ face.c ];
 						d = vertices[ face.d ];
-						interPoint = THREE.Triangle.intersectionRayTriangle( localRay, a, b, d, material.side !== THREE.DoubleSide );
+						interPoint = THREE.Triangle.intersectionRay( localRay, a, b, d, material.side !== THREE.DoubleSide );
 
 						if( !interPoint ) {
 
-						 interPoint = THREE.Triangle.intersectionRayTriangle( localRay, b, c, d, material.side !== THREE.DoubleSide  );
+						 interPoint = THREE.Triangle.intersectionRay( localRay, b, c, d, material.side !== THREE.DoubleSide  );
 
 						 if( !interPoint ) continue;
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -287,6 +287,7 @@ THREE.Ray.prototype = {
 		this.direction.add( this.origin ).applyMatrix4( matrix4 );
 		this.origin.applyMatrix4( matrix4 );
 		this.direction.sub( this.origin );
+		this.direction.normalize();
 
 		return this;
 	},

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -92,7 +92,7 @@ THREE.Triangle.containsPoint = function() {
 
 }();
 
-THREE.Triangle.intersectionRayTriangle = function ()	{
+THREE.Triangle.intersectionRay = function ()	{
 
 	// Compute the offset origin, edges, and normal.
 	var diff = new THREE.Vector3();
@@ -235,6 +235,12 @@ THREE.Triangle.prototype = {
 	containsPoint: function ( point ) {
 
 		return THREE.Triangle.containsPoint( point, this.a, this.b, this.c );
+
+	},
+
+	intersectionRay: function ( ray, backfaceCulling ) {
+
+		return THREE.Triangle.intersectionRay( ray, this.a, this.b, this.c, backfaceCulling );
 
 	},
 

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -92,6 +92,69 @@ THREE.Triangle.containsPoint = function() {
 
 }();
 
+THREE.Triangle.intersectionRayTriangle = function ()	{
+
+	// Compute the offset origin, edges, and normal.
+	var diff = new THREE.Vector3();
+	var edge1 = new THREE.Vector3();
+	var edge2 = new THREE.Vector3();
+	var normal = new THREE.Vector3();
+
+	return function ( ray, a, b, c, backfaceCulling ) {
+
+		//from http://www.geometrictools.com/LibMathematics/Intersection/Wm5IntrRay3Triangle3.cpp
+
+		edge1.subVectors( b, a );
+		edge2.subVectors( c, a );
+		normal.crossVectors( edge1, edge2 );
+
+		// Solve Q + t*D = b1*E1 + b2*E2 (Q = kDiff, D = ray direction,
+		// E1 = kEdge1, E2 = kEdge2, N = Cross(E1,E2)) by
+		//   |Dot(D,N)|*b1 = sign(Dot(D,N))*Dot(D,Cross(Q,E2))
+		//   |Dot(D,N)|*b2 = sign(Dot(D,N))*Dot(D,Cross(E1,Q))
+		//   |Dot(D,N)|*t = -sign(Dot(D,N))*Dot(Q,N)
+		var DdN = ray.direction.dot(normal);
+		var sign;
+		if ( DdN > 0 ) {
+
+				if ( backfaceCulling ) return null;
+				sign = 1;
+
+		} else if ( DdN < 0 ) {
+
+				sign = - 1;
+				DdN = - DdN;
+
+		} else return null;
+
+		diff.subVectors( ray.origin, a );
+		var DdQxE2 = sign * ray.direction.dot( edge2.crossVectors( diff, edge2 ) );
+
+		// b1 < 0, no intersection
+		if ( DdQxE2 < 0 )
+			return null;
+
+		var DdE1xQ = sign * ray.direction.dot( edge1.cross( diff ) );
+		// b2 < 0, no intersection
+		if ( DdE1xQ < 0 )
+			return null;
+
+		// b1+b2 > 1, no intersection
+		if ( DdQxE2 + DdE1xQ > DdN )
+			return null
+
+		// Line intersects triangle, check if ray does.
+		var QdN = - sign * diff.dot( normal );
+		// t < 0, no intersection
+		if ( QdN < 0 )
+			return null
+
+		// Ray intersects triangle.
+		return ray.at( QdN / DdN );
+	}
+
+}();
+
 THREE.Triangle.prototype = {
 
 	constructor: THREE.Triangle,

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -484,9 +484,12 @@ THREE.Vector3.prototype = {
 
 	crossVectors: function ( a, b ) {
 
-		this.x = a.y * b.z - a.z * b.y;
-		this.y = a.z * b.x - a.x * b.z;
-		this.z = a.x * b.y - a.y * b.x;
+		var ax = a.x, ay = a.y, az = a.z;
+		var bx = b.x, by = b.y, bz = b.z;
+
+		this.x = ay * bz - az * by;
+		this.y = az * bx - ax * bz;
+		this.z = ax * by - ay * bx;
 
 		return this;
 


### PR DESCRIPTION
Looks like some guys really want a normalized ray in raycaster :D #3655
I also added a ray-triangle intersection function, it looks like the same performance as using ray-plane => triangleContainsPoint. Anyway, Webgl/Canvas_interactive_cubes work fine.
Hmm I'll let you be the judge on this PR.... (btw I didn't find any examples with interactive bufferGeometry...)

However, there is a small fix for the `crossVectors` function.
Here's the buggy case scenario, you've got two `Vector3` : `a` and `b`.
You want to put in `a` the value of 'b cross a' without creating a new object...so you do `a.crossVectors(b,a )` and pouf!
