### PR TITLE
Updated octree to r59 and reworked octree example

### DIFF
--- a/examples/js/Octree.js
+++ b/examples/js/Octree.js
@@ -1,6 +1,6 @@
-/**!
+/*!
  *
- * threeoctree.js (r56) / https://github.com/collinhover/threeoctree
+ * threeoctree.js (r59) / https://github.com/collinhover/threeoctree
  * (sparse) dynamic 3D spatial representation structure for fast searches.
  *
  * @author Collin Hover / http://collinhover.com/
@@ -105,16 +105,6 @@
 		this.utilVec31Search = new THREE.Vector3();
 		this.utilVec32Search = new THREE.Vector3();
 		
-		// hook into renderer as a post plugin
-		
-		this.renderer = parameters.renderer;
-		
-		if ( this.renderer instanceof THREE.WebGLRenderer || this.renderer instanceof THREE.CanvasRenderer ) {
-			
-			this.renderer.addPostPlugin( this );
-			
-		}
-		
 		// pass scene to see octree structure
 		
 		this.scene = parameters.scene;
@@ -136,6 +126,7 @@
 		this.depthMax = isNumber( parameters.depthMax ) ? parameters.depthMax : -1;
 		this.objectsThreshold = isNumber( parameters.objectsThreshold ) ? parameters.objectsThreshold : 8;
 		this.overlapPct = isNumber( parameters.overlapPct ) ? parameters.overlapPct : 0.15;
+		this.undeferred = parameters.undeferred || false;
 		
 		this.root = parameters.root instanceof THREE.OctreeNode ? parameters.root : new THREE.OctreeNode( parameters );
 		
@@ -143,25 +134,7 @@
 
 	THREE.Octree.prototype = {
 		
-		setRoot: function ( root ) { 
-			
-			if ( root instanceof THREE.OctreeNode ) {
-				
-				// store new root
-				
-				this.root = root;
-				
-				// update properties
-				
-				this.root.updateProperties();
-				
-			}
-			
-		},
-		
-		init: function () {},
-		
-		render: function () {
+		update: function () {
 			
 			// add any deferred objects that were waiting for render cycle
 			
@@ -183,7 +156,21 @@
 		
 		add: function ( object, options ) {
 			
-			this.objectsDeferred.push( { object: object, options: options } );
+			// add immediately
+			
+			if ( this.undeferred ) {
+				
+				this.updateObject( object );
+				
+				this.addDeferred( object, options );
+				
+			}
+			// defer add until update called
+			else {
+				
+				this.objectsDeferred.push( { object: object, options: options } );
+				
+			}
 			
 		},
 		
@@ -372,7 +359,7 @@
 			
 		},
 		
-		update: function () {
+		rebuild: function () {
 			
 			var i, l,
 				node,
@@ -581,6 +568,22 @@
 			}
 			
 			return results;
+			
+		},
+		
+		setRoot: function ( root ) { 
+			
+			if ( root instanceof THREE.OctreeNode ) {
+				
+				// store new root
+				
+				this.root = root;
+				
+				// update properties
+				
+				this.root.updateProperties();
+				
+			}
 			
 		},
 		

--- a/examples/js/Octree.js
+++ b/examples/js/Octree.js
@@ -686,7 +686,23 @@
 			}
 			else {
 				
-				this.radius = this.object.geometry ? this.object.geometry.boundingSphere.radius : this.object.boundRadius;
+				if ( this.object.geometry ) {
+					
+					if ( this.object.geometry.boundingSphere === null ) {
+						
+						this.object.geometry.computeBoundingSphere();
+						
+					}
+					
+					this.radius = this.object.geometry.boundingSphere.radius;
+					
+				}
+				else {
+					
+					this.radius = this.object.boundRadius;
+					
+				}
+				
 				this.position.getPositionFromMatrix( this.object.matrixWorld );
 				
 			}

--- a/examples/webgl_octree.html
+++ b/examples/webgl_octree.html
@@ -1,239 +1,461 @@
 <!DOCTYPE html>
-<html lang="en">
-	<head>
-		<title>three.js webgl - octree</title>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<style>
-			body {
-				background-color: #ffffff;
-				margin: 0px;
-				overflow: hidden;
-			}
-		</style>
-	</head>
-	<body>
-
-		<script type="text/javascript" src="../build/three.min.js"></script>
-		<script type="text/javascript" src="js/Octree.js"></script>
-		<script>
-
-			var camera, 
-				scene, 
-				renderer,
-				octree,
-				geometry, 
-				material, 
-				mesh,
-				meshes = [],
-				meshesSearch = [],
-				meshCountMax = 1000,
-				radius = 500,
-				radiusMax = radius * 10,
-				radiusMaxHalf = radiusMax * 0.5,
-				radiusSearch = 400,
-				searchMesh,
-				baseR = 255, baseG = 0, baseB = 255,
-				foundR = 0, foundG = 255, foundB = 0,
-				adding = true;
-
-			init();
-			animate();
-
-			function init() {
-			
-				// standard three scene, camera, renderer
-
-				scene = new THREE.Scene();
-
-				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, radius * 100 );
-				scene.add( camera );
-
-				renderer = new THREE.WebGLRenderer();
-				renderer.setSize( window.innerWidth, window.innerHeight );
-
-				document.body.appendChild( renderer.domElement );
-			
-				// create octree
-			
-				octree = new THREE.Octree( {
-					scene: scene
-				} );
-			
-				// create object to show search radius and add to scene
-			
-				searchMesh = new THREE.Mesh(
-					new THREE.SphereGeometry( radiusSearch ),
-					new THREE.MeshBasicMaterial( { color: 0x00FF00, transparent: true, opacity: 0.4 } )
-				);
-				scene.add( searchMesh );
-
-			}
-
-			function animate() {
-
-				// note: three.js includes requestAnimationFrame shim
-				requestAnimationFrame( animate );
-			
-				// modify octree structure by adding/removing objects
-			
-				modifyOctree();
-			
-				// search octree at random location
-			
-				searchOctree();
-			
-				// render results
-			
-				render();
-
-			}
-		
-			function modifyOctree() {
-			
-				// if is adding objects to octree
-			
-				if ( adding === true ) {
-				
-					// create new object
-				
-					geometry = new THREE.CubeGeometry( 50, 50, 50 );
-					material = new THREE.MeshBasicMaterial();
-					material.color.setRGB( baseR, baseG, baseB );
-				
-					mesh = new THREE.Mesh( geometry, material );
-				
-					// give new object a random position in radius
-				
-					mesh.position.set(
-						Math.random() * radiusMax - radiusMaxHalf,
-						Math.random() * radiusMax - radiusMaxHalf,
-						Math.random() * radiusMax - radiusMaxHalf
-					);
-				
-					// add new object to octree and scene
-				
-					octree.add( mesh );
-					scene.add( mesh );
-				
-					// store object for later
-				
-					meshes.push( mesh );
-				
-					// if at max, stop adding
-				
-					if ( meshes.length === meshCountMax ) {
-					
-						adding = false;
-					
-					}
-				
-				}
-				// else remove objects from octree
-				else {
-				
-					// get object
-				
-					mesh = meshes.shift();
-				
-					// remove from scene and octree
-				
-					scene.remove( mesh );
-					octree.remove( mesh );
-				
-					// if no more objects, start adding
-				
-					if ( meshes.length === 0 ) {
-					
-						adding = true;
-					
-					}
-				
-				}
-			
-				/*
-			
-				// octree details to console
-			
-				console.log( ' OCTREE: ', octree );
-				console.log( ' ... depth ', octree.depth, ' vs depth end?', octree.depth_end() );
-				console.log( ' ... num nodes: ', octree.node_count_end() );
-				console.log( ' ... total objects: ', octree.object_count_end(), ' vs tree objects length: ', octree.objects.length );
-			
-				// print full octree structure to console
-			
-				octree.to_console();
-			
-				*/
-			
-			}
-		
-			function searchOctree() {
-			
-				var i, il;
-			
-				// revert previous search objects to base color
-			
-				for ( i = 0, il = meshesSearch.length; i < il; i++ ) {
-				
-					meshesSearch[ i ].object.material.color.setRGB( baseR, baseG, baseB );
-				
-				}
-			
-				// new search position
-				searchMesh.position.set(
-					Math.random() * radiusMax - radiusMaxHalf,
-					Math.random() * radiusMax - radiusMaxHalf,
-					Math.random() * radiusMax - radiusMaxHalf
-				);
-			
-				// record start time
-			
-				var timeStart = Date.now();
-			
-				// search octree from search mesh position with search radius
-				// optional third parameter: boolean, if should sort results by object when using faces in octree
-				// optional fourth parameter: vector3, direction of search when using ray (assumes radius is distance/far of ray)
-			
-				var rayCaster = new THREE.Raycaster( new THREE.Vector3().copy( searchMesh.position ), new THREE.Vector3( Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1 ).normalize() );
-				meshesSearch = octree.search( rayCaster.ray.origin, radiusSearch, true, rayCaster.ray.direction );
-				var intersections = rayCaster.intersectOctreeObjects( meshesSearch );
-			
-				// record end time
-			
-				var timeEnd = Date.now();
-			
-				// set color of all meshes found in search
-			
-				for ( i = 0, il = meshesSearch.length; i < il; i++ ) {
-				
-					meshesSearch[ i ].object.material.color.setRGB( foundR, foundG, foundB );
-				
-				}
-			
-				/*
-			
-				// results to console
-			
-				console.log( 'OCTREE: ', octree );
-				console.log( '... searched ', meshes.length, ' and found ', meshesSearch.length, ' with intersections ', intersections.length, ' and took ', ( timeEnd - timeStart ), ' ms ' );
-			
-				*/
-			
-			}
-		
-			function render() {
+<html>
+<head>
 	
-				var timer = - Date.now() / 5000;
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="description" content="">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<style>
+		body {
+			font-family: Monospace;
+			background-color: #f0f0f0;
+			margin: 0px;
+			overflow: hidden;
+		}
+	</style>
+	
+    <title>THREE: Octree!</title>
 
-				camera.position.x = Math.cos( timer ) * 10000;
-				camera.position.z = Math.sin( timer ) * 10000;
-				camera.lookAt( scene.position );
+</head>
+
+<body>
+
+    <script type="text/javascript" src="../build/three.min.js"></script>
+    <script type="text/javascript" src="js/Octree.js"></script>
+	<script type="text/javascript" src="js/controls/TrackballControls.js"></script>
+	<script type="text/javascript" src="js/libs/stats.min.js"></script>
+	<script>
 		
-				renderer.render( scene, camera );
+		var camera, scene, renderer;
+
+		var controls, stats;
+		
+		var tracker;
+		
+		var octree;
+		
+		var objects = [];
+		var objectsSearch = [];
+		var searchMesh;
+		var totalFaces = 0;
+		
+		var simpleMeshCount = 2000;
+		var radius = 100;
+		var radiusMax = radius * 10;
+		var radiusMaxHalf = radiusMax * 0.5;
+		var radiusSearch = radius * 0.75;
+		
+		var baseColor = 0x333333;
+		var foundColor = 0x12C0E3;
+		var intersectColor = 0x00D66B;
+		
+		var clock = new THREE.Clock();
+		var searchDelay = 1;
+		var searchInterval = 0;
+		var useOctree = true;
+		
+		var projector;
+		
+		var mouse = new THREE.Vector2();
+		var intersected;
+
+		init();
+		animate();
+
+		function init() {
+			
+			// standard three scene, camera, renderer
+
+			scene = new THREE.Scene();
+
+			camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, radius * 100 );
+			camera.position.z = radius * 10;
+			scene.add( camera );
+
+			renderer = new THREE.WebGLRenderer();
+			renderer.setSize( window.innerWidth, window.innerHeight );
+
+			document.body.appendChild( renderer.domElement );
+			
+			// create octree
+			
+			octree = new THREE.Octree( {
+				// uncomment below to see the octree (may kill the fps)
+				//scene: scene,
+				renderer: renderer
+			} );
+			
+			// create object to show search radius and add to scene
+			
+			searchMesh = new THREE.Mesh( new THREE.SphereGeometry( radiusSearch ), new THREE.MeshBasicMaterial( { color: 0x12C0E3, transparent: true, opacity: 0.4 } ) );
+			scene.add( searchMesh );
+			
+			// lights
+			
+			var ambient = new THREE.AmbientLight( 0x101010 );
+			scene.add( ambient );
+
+			var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.5 );
+			directionalLight.position.set( 1, 1, 2 ).normalize();
+			scene.add( directionalLight );
+			
+			// create all objects
+			
+			var simpleGeometry = new THREE.CubeGeometry( 1, 1, 1 );
+			
+			for ( var i = 0; i < simpleMeshCount - 1; i++ ) {
+				
+				totalFaces += simpleGeometry.faces.length;
+				
+				var simpleMaterial = new THREE.MeshBasicMaterial();
+				simpleMaterial.color.setHex( baseColor );
+				
+				modifyOctree( simpleGeometry, simpleMaterial, false, true, true, true );
+				
+			}
+			
+			var loader = new THREE.JSONLoader();
+			
+			loader.load( 'obj/lucy/Lucy100k_slim.js', function ( geometry ) {
+
+				geometry.computeVertexNormals();
+				totalFaces += geometry.faces.length;
+				
+				var material = new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0x030303, specular: 0x030303, shininess: 30 } );
+				
+				modifyOctree( geometry, material, true );
+				
+			} );
+			
+			// projector for click intersection
+			
+			projector = new THREE.Projector();
+			
+			// camera controls
+			
+			controls = new THREE.TrackballControls( camera );
+			controls.rotateSpeed = 1.0;
+			controls.zoomSpeed = 1.2;
+			controls.panSpeed = 0.8;
+			controls.noZoom = false;
+			controls.noPan = false;
+			controls.staticMoving = true;
+			controls.dynamicDampingFactor = 0.3;
+			
+			// info
+			
+			var info = document.createElement( 'div' );
+			info.style.position = 'absolute';
+			info.style.top = '0';
+			info.style.width = '100%';
+			info.style.textAlign = 'center';
+			info.style.padding = '10px';
+			info.style.background = '#FFFFFF';
+			info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> webgl - octree (sparse & dynamic) - by <a href="http://github.com/collinhover/threeoctree" target="_blank">collinhover</a><br><small style="opacity:0.5">Lucy model from <a href="http://graphics.stanford.edu/data/3Dscanrep/">Stanford 3d scanning repository</a>(decimated with <a href="http://meshlab.sourceforge.net/">Meshlab</a>)</small>';
+			document.body.appendChild( info );
+			
+			// stats
+			
+			stats = new Stats();
+			stats.domElement.style.position = 'absolute';
+			stats.domElement.style.top = '0';
+			stats.domElement.style.left = '0';
+			stats.domElement.style.zIndex = 100;
+			
+			document.body.appendChild( stats.domElement );
+			
+			// bottom container
+			
+			var container = document.createElement( 'div' );
+			container.style.position = 'absolute';
+			container.style.bottom = '0';
+			container.style.width = '100%';
+			container.style.textAlign = 'center';
+			document.body.appendChild( container );
+			
+			// tracker
+			
+			tracker = document.createElement( 'div' );
+			tracker.style.width = '100%';
+			tracker.style.padding = '10px';
+			tracker.style.background = '#FFFFFF';
+			container.appendChild( tracker );
+			
+			// octree use toggle
+			
+			var toggle = document.createElement( 'div' );
+			toggle.style.position = 'absolute';
+			toggle.style.bottom = '100%';
+			toggle.style.width = '100%';
+			toggle.style.padding = '10px';
+			toggle.style.background = '#FFFFFF';
+			container.appendChild( toggle );
+			
+			var checkbox = document.createElement('input');
+			checkbox.type = "checkbox";
+			checkbox.name = "octreeToggle";
+			checkbox.value = "value";
+			checkbox.id = "octreeToggle";
+			checkbox.checked = true;
+
+			var label = document.createElement('label')
+			label.htmlFor = "octreeToggle";
+			label.appendChild(document.createTextNode('Use Octree') );
+
+			toggle.appendChild(checkbox);
+			toggle.appendChild(label);
+			
+			// events
+
+			checkbox.addEventListener( 'click', toggleOctree, false );
+			renderer.domElement.addEventListener( 'mousemove', onDocumentMouseMove, false );
+
+			window.addEventListener( 'resize', onWindowResize, false );
+
+		}
+		
+		function toggleOctree () {
+			
+			useOctree = !useOctree;
+			
+		}
+
+		function animate() {
+
+			// note: three.js includes requestAnimationFrame shim
+			
+			requestAnimationFrame( animate );
+			
+			// search octree at random location
+			
+			if ( searchInterval >= searchDelay ) {
+				
+				searchInterval = 0;
+				
+				searchOctree();
+				
+			}
+			
+			searchInterval += clock.getDelta();
+			
+			render();
+			
+			stats.update();
+
+		}
+		
+		function render() {
+
+			controls.update();
+
+			renderer.render( scene, camera );
+
+		}
+		
+		function modifyOctree( geometry, material, useFaces, randomPosition, randomRotation, randomScale ) {
+			
+			var mesh;
+			
+			if ( geometry ) {
+				
+				// create new object
+				
+				mesh = new THREE.Mesh( geometry, material );
+				
+				// give new object a random position, rotation, and scale
+				
+				if ( randomPosition ) {
+				
+					mesh.position.set( Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf );
+				
+				}
+				
+				if ( randomRotation ) {
+					
+					mesh.rotation.set( Math.random() * 2 * Math.PI, Math.random() * 2 * Math.PI, Math.random() * 2 * Math.PI );
+				
+				}
+				
+				if ( randomScale ) {
+					
+					mesh.scale.x = mesh.scale.y = mesh.scale.z = Math.random() * radius * 0.1 + radius * 0.05;
+					
+				}
+				
+				// add new object to octree and scene
+				// NOTE: octree object insertion is deferred until after the next render cycle
+				
+				octree.add( mesh, { useFaces: useFaces } );
+				scene.add( mesh );
+				
+				// store object
+				
+				objects.push( mesh );
+				
+				/*
+				
+				// octree details to console
+				
+				console.log( ' ============================================================================================================');
+				console.log( ' OCTREE: ', octree );
+				console.log( ' ... depth ', octree.depth, ' vs depth end?', octree.depthEnd() );
+				console.log( ' ... num nodes: ', octree.nodeCountEnd() );
+				console.log( ' ... total objects: ', octree.objectCountEnd(), ' vs tree objects length: ', octree.objects.length );
+				console.log( ' ============================================================================================================');
+				console.log( ' ');
+				
+				// print full octree structure to console
+				
+				octree.toConsole();
+				
+				*/
+				
+			}
+			
+		}
+		
+		function searchOctree() {
+			
+			var i, il;
+			
+			// revert previous search objects to base color
+			
+			for ( i = 0, il = objectsSearch.length; i < il; i++ ) {
+				
+				var mesh = objectsSearch[ i ].object;
+				
+				if ( mesh !== intersected ) {
+					
+					mesh.material.color.setHex( baseColor );
+					
+				}
+				
+			}
+			
+			// new search position
+			searchMesh.position.set( Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf );
+			
+			// record start time
+			
+			var timeStart = new Date().getTime();
+			
+			// search octree from search mesh position with search radius
+			// optional third parameter: boolean, if should sort results by object when using faces/vertices in octree
+			// optional fourth parameter: vector3, direction of search when using ray (assumes radius is distance/far of ray)
+			
+			var raycaster = new THREE.Raycaster( new THREE.Vector3().copy( searchMesh.position ), new THREE.Vector3( Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1 ).normalize() );
+			objectsSearch = octree.search( raycaster.ray.origin, radiusSearch, true, raycaster.ray.direction );
+			var intersections = raycaster.intersectOctreeObjects( objectsSearch );
+			
+			// record end time
+			
+			var timeEnd = new Date().getTime();
+			
+			// set color of all objects found in search
+			
+			for ( i = 0, il = objectsSearch.length; i < il; i++ ) {
+				
+				var mesh = objectsSearch[ i ].object;
+				
+				if ( mesh !== intersected ) {
+					
+					mesh.material.color.setHex( foundColor );
+					
+				}
+				
+			}
+			
+			/*
+			
+			// results to console
+			
+			console.log( 'OCTREE: ', octree );
+			console.log( '... searched ', objects.length, ' and found ', objectsSearch.length, ' with intersections ', intersections.length, ' and took ', ( timeEnd - timeStart ), ' ms ' );
+			
+			*/
+			
+		}
+		
+		function onWindowResize() {
+
+			camera.aspect = window.innerWidth / window.innerHeight;
+			camera.updateProjectionMatrix();
+
+			renderer.setSize( window.innerWidth, window.innerHeight );
+
+		}
+
+		function onDocumentMouseMove( event ) {
+
+			event.preventDefault();
+
+			mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
+			mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+			
+			var vector = new THREE.Vector3( mouse.x, mouse.y, 0.5 );
+			projector.unprojectVector( vector, camera );
+
+			var raycaster = new THREE.Raycaster( camera.position, vector.sub( camera.position ).normalize() );
+			var octreeObjects;
+			var numObjects;
+			var numFaces = 0;
+			var intersections;
+			
+			if ( useOctree ) {
+					
+				octreeObjects = octree.search( raycaster.ray.origin, raycaster.ray.far, true, raycaster.ray.direction );
+				
+				intersections = raycaster.intersectOctreeObjects( octreeObjects );
+				
+				numObjects = octreeObjects.length;
+				
+				for ( var i = 0, il = numObjects; i < il; i++ ) {
+					
+					numFaces += octreeObjects[ i ].faces.length;
+					
+				}
+				
+			}
+			else {
+				
+				intersections = raycaster.intersectObjects( objects );
+				numObjects = objects.length;
+				numFaces = totalFaces;
+				
+			}
+			
+			if ( intersections.length > 0 ) {
+
+				if ( intersected != intersections[ 0 ].object ) {
+
+					if ( intersected ) intersected.material.color.setHex( baseColor );
+
+					intersected = intersections[ 0 ].object;
+					intersected.material.color.setHex( intersectColor );
+
+				}
+
+				document.body.style.cursor = 'pointer';
 
 			}
+			else if ( intersected ) {
+				
+				intersected.material.color.setHex( baseColor );
+				intersected = null;
 
-		</script>
-	</body>
+				document.body.style.cursor = 'auto';
+
+			}
+			
+			// update tracker
+			
+			tracker.innerHTML = ( useOctree ? 'Octree search' : 'Search without octree' ) + ' using infinite ray from camera found [ ' + numObjects + ' / ' + objects.length + ' ] objects, [ ' + numFaces + ' / ' + totalFaces + ' ] faces, and [ ' + intersections.length + ' ] intersections.';
+			
+		}
+
+	</script>
+
+</body>
+
 </html>

--- a/examples/webgl_octree.html
+++ b/examples/webgl_octree.html
@@ -1,478 +1,256 @@
 <!DOCTYPE html>
-<html>
-<head>
-	
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="description" content="">
-	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-	<style>
-		body {
-			font-family: Monospace;
-			background-color: #f0f0f0;
-			margin: 0px;
-			overflow: hidden;
-		}
-	</style>
-	
-    <title>THREE: Octree!</title>
-
-</head>
-
-<body>
-
-    <script type="text/javascript" src="../build/three.min.js"></script>
-    <script type="text/javascript" src="js/Octree.js"></script>
-	<script type="text/javascript" src="js/controls/TrackballControls.js"></script>
-	<script type="text/javascript" src="js/libs/stats.min.js"></script>
-	<script>
-		
-		var camera, scene, renderer;
-
-		var controls, stats;
-		
-		var tracker;
-		
-		var octree;
-		
-		var objects = [];
-		var objectsSearch = [];
-		var searchMesh;
-		var totalFaces = 0;
-		
-		var simpleMeshCount = 2000;
-		var radius = 100;
-		var radiusMax = radius * 10;
-		var radiusMaxHalf = radiusMax * 0.5;
-		var radiusSearch = radius * 0.75;
-		
-		var baseColor = 0x333333;
-		var foundColor = 0x12C0E3;
-		var intersectColor = 0x00D66B;
-		
-		var clock = new THREE.Clock();
-		var searchDelay = 1;
-		var searchInterval = 0;
-		var useOctree = true;
-		
-		var projector;
-		
-		var mouse = new THREE.Vector2();
-		var intersected;
-
-		init();
-		animate();
-
-		function init() {
-			
-			// standard three scene, camera, renderer
-
-			scene = new THREE.Scene();
-
-			camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, radius * 100 );
-			camera.position.z = radius * 10;
-			scene.add( camera );
-
-			renderer = new THREE.WebGLRenderer();
-			renderer.setSize( window.innerWidth, window.innerHeight );
-
-			document.body.appendChild( renderer.domElement );
-			
-			// create octree
-			
-			octree = new THREE.Octree( {
-				// uncomment below to see the octree (may kill the fps)
-				//scene: scene,
-				// when undeferred = true, objects are inserted immediately
-				// instead of being deferred until next octree.update() call
-				// this may decrease performance as it forces a matrix update
-				undeferred: false,
-				// set the max depth of tree
-				// where -1 is infinite
-				depthMax: -1,
-				// max number of objects before nodes split or merge
-				objectsThreshold: 8,
-				// percent between 0 and 1 that nodes will overlap each other
-				// helps insert objects that lie over more than one node
-				overlapPct: 0.15
-			} );
-			
-			// create object to show search radius and add to scene
-			
-			searchMesh = new THREE.Mesh( new THREE.SphereGeometry( radiusSearch ), new THREE.MeshBasicMaterial( { color: 0x12C0E3, transparent: true, opacity: 0.4 } ) );
-			scene.add( searchMesh );
-			
-			// lights
-			
-			var ambient = new THREE.AmbientLight( 0x101010 );
-			scene.add( ambient );
-
-			var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.5 );
-			directionalLight.position.set( 1, 1, 2 ).normalize();
-			scene.add( directionalLight );
-			
-			// create all objects
-			
-			var simpleGeometry = new THREE.CubeGeometry( 1, 1, 1 );
-			
-			for ( var i = 0; i < simpleMeshCount - 1; i++ ) {
-				
-				totalFaces += simpleGeometry.faces.length;
-				
-				var simpleMaterial = new THREE.MeshBasicMaterial();
-				simpleMaterial.color.setHex( baseColor );
-				
-				modifyOctree( simpleGeometry, simpleMaterial, false, true, true, true );
-				
+<html lang="en">
+	<head>
+		<title>three.js webgl - octree</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #f0f0f0;
+				margin: 0px;
+				overflow: hidden;
 			}
-			
-			var loader = new THREE.JSONLoader();
-			
-			loader.load( 'obj/lucy/Lucy100k_slim.js', function ( geometry ) {
+		</style>
+	</head>
+	<body>
 
-				geometry.computeVertexNormals();
-				totalFaces += geometry.faces.length;
+		<script type="text/javascript" src="../build/three.min.js"></script>
+		<script type="text/javascript" src="js/Octree.js"></script>
+		<script>
+
+			var camera, 
+				scene, 
+				renderer,
+				octree,
+				geometry, 
+				material, 
+				mesh,
+				meshes = [],
+				meshesSearch = [],
+				meshCountMax = 1000,
+				radius = 500,
+				radiusMax = radius * 10,
+				radiusMaxHalf = radiusMax * 0.5,
+				radiusSearch = 400,
+				searchMesh,
+				baseR = 255, baseG = 0, baseB = 255,
+				foundR = 0, foundG = 255, foundB = 0,
+				adding = true;
+
+			init();
+			animate();
+
+			function init() {
+			
+				// standard three scene, camera, renderer
+
+				scene = new THREE.Scene();
+
+				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, radius * 100 );
+				scene.add( camera );
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				document.body.appendChild( renderer.domElement );
+			
+				// create octree
+			
+				octree = new THREE.Octree( {
+					scene: scene
+				} );
+			
+				// create object to show search radius and add to scene
+			
+				searchMesh = new THREE.Mesh(
+					new THREE.SphereGeometry( radiusSearch ),
+					new THREE.MeshBasicMaterial( { color: 0x00FF00, transparent: true, opacity: 0.4 } )
+				);
+				scene.add( searchMesh );
 				
-				var material = new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0x030303, specular: 0x030303, shininess: 30 } );
+				// info
 				
-				modifyOctree( geometry, material, true );
-				
-			} );
-			
-			// projector for click intersection
-			
-			projector = new THREE.Projector();
-			
-			// camera controls
-			
-			controls = new THREE.TrackballControls( camera );
-			controls.rotateSpeed = 1.0;
-			controls.zoomSpeed = 1.2;
-			controls.panSpeed = 0.8;
-			controls.noZoom = false;
-			controls.noPan = false;
-			controls.staticMoving = true;
-			controls.dynamicDampingFactor = 0.3;
-			
-			// info
-			
-			var info = document.createElement( 'div' );
-			info.style.position = 'absolute';
-			info.style.top = '0';
-			info.style.width = '100%';
-			info.style.textAlign = 'center';
-			info.style.padding = '10px';
-			info.style.background = '#FFFFFF';
-			info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> webgl - octree (sparse & dynamic) - by <a href="http://github.com/collinhover/threeoctree" target="_blank">collinhover</a><br><small style="opacity:0.5">Lucy model from <a href="http://graphics.stanford.edu/data/3Dscanrep/">Stanford 3d scanning repository</a>(decimated with <a href="http://meshlab.sourceforge.net/">Meshlab</a>)</small>';
-			document.body.appendChild( info );
-			
-			// stats
-			
-			stats = new Stats();
-			stats.domElement.style.position = 'absolute';
-			stats.domElement.style.top = '0';
-			stats.domElement.style.left = '0';
-			stats.domElement.style.zIndex = 100;
-			
-			document.body.appendChild( stats.domElement );
-			
-			// bottom container
-			
-			var container = document.createElement( 'div' );
-			container.style.position = 'absolute';
-			container.style.bottom = '0';
-			container.style.width = '100%';
-			container.style.textAlign = 'center';
-			document.body.appendChild( container );
-			
-			// tracker
-			
-			tracker = document.createElement( 'div' );
-			tracker.style.width = '100%';
-			tracker.style.padding = '10px';
-			tracker.style.background = '#FFFFFF';
-			container.appendChild( tracker );
-			
-			// octree use toggle
-			
-			var toggle = document.createElement( 'div' );
-			toggle.style.position = 'absolute';
-			toggle.style.bottom = '100%';
-			toggle.style.width = '100%';
-			toggle.style.padding = '10px';
-			toggle.style.background = '#FFFFFF';
-			container.appendChild( toggle );
-			
-			var checkbox = document.createElement('input');
-			checkbox.type = "checkbox";
-			checkbox.name = "octreeToggle";
-			checkbox.value = "value";
-			checkbox.id = "octreeToggle";
-			checkbox.checked = true;
+				var info = document.createElement( 'div' );
+				info.style.position = 'absolute';
+				info.style.top = '0';
+				info.style.width = '100%';
+				info.style.textAlign = 'center';
+				info.style.padding = '10px';
+				info.style.background = '#FFFFFF';
+				info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> webgl - octree (sparse & dynamic) - by <a href="http://github.com/collinhover/threeoctree" target="_blank">collinhover</a>';
+				document.body.appendChild( info );
 
-			var label = document.createElement('label')
-			label.htmlFor = "octreeToggle";
-			label.appendChild(document.createTextNode('Use Octree') );
+			}
 
-			toggle.appendChild(checkbox);
-			toggle.appendChild(label);
-			
-			// events
+			function animate() {
 
-			checkbox.addEventListener( 'click', toggleOctree, false );
-			renderer.domElement.addEventListener( 'mousemove', onDocumentMouseMove, false );
-
-			window.addEventListener( 'resize', onWindowResize, false );
-
-		}
-		
-		function toggleOctree () {
+				// note: three.js includes requestAnimationFrame shim
+				requestAnimationFrame( animate );
 			
-			useOctree = !useOctree;
+				// modify octree structure by adding/removing objects
 			
-		}
-
-		function animate() {
-
-			// note: three.js includes requestAnimationFrame shim
+				modifyOctree();
 			
-			requestAnimationFrame( animate );
+				// search octree at random location
 			
-			// search octree at random location
-			
-			if ( searchInterval >= searchDelay ) {
-				
-				searchInterval = 0;
-				
 				searchOctree();
+			
+				// render results
+			
+				render();
 				
+				// update octree to add deferred objects
+				
+				octree.update();
+
 			}
-			
-			searchInterval += clock.getDelta();
-			
-			render();
-			
-			stats.update();
-
-		}
 		
-		function render() {
-
-			controls.update();
-
-			renderer.render( scene, camera );
+			function modifyOctree() {
 			
-			// update octree post render
-			// this ensures any objects being added
-			// have already had their matrices updated
+				// if is adding objects to octree
 			
-			octree.update();
-
-		}
-		
-		function modifyOctree( geometry, material, useFaces, randomPosition, randomRotation, randomScale ) {
-			
-			var mesh;
-			
-			if ( geometry ) {
+				if ( adding === true ) {
 				
-				// create new object
+					// create new object
 				
-				mesh = new THREE.Mesh( geometry, material );
+					geometry = new THREE.CubeGeometry( 50, 50, 50 );
+					material = new THREE.MeshBasicMaterial();
+					material.color.setRGB( baseR, baseG, baseB );
 				
-				// give new object a random position, rotation, and scale
+					mesh = new THREE.Mesh( geometry, material );
 				
-				if ( randomPosition ) {
+					// give new object a random position in radius
 				
-					mesh.position.set( Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf );
+					mesh.position.set(
+						Math.random() * radiusMax - radiusMaxHalf,
+						Math.random() * radiusMax - radiusMaxHalf,
+						Math.random() * radiusMax - radiusMaxHalf
+					);
+				
+					// add new object to octree and scene
+				
+					octree.add( mesh );
+					scene.add( mesh );
+				
+					// store object for later
+				
+					meshes.push( mesh );
+				
+					// if at max, stop adding
+				
+					if ( meshes.length === meshCountMax ) {
+					
+						adding = false;
+					
+					}
 				
 				}
+				// else remove objects from octree
+				else {
 				
-				if ( randomRotation ) {
+					// get object
+				
+					mesh = meshes.shift();
+				
+					// remove from scene and octree
+				
+					scene.remove( mesh );
+					octree.remove( mesh );
+				
+					// if no more objects, start adding
+				
+					if ( meshes.length === 0 ) {
 					
-					mesh.rotation.set( Math.random() * 2 * Math.PI, Math.random() * 2 * Math.PI, Math.random() * 2 * Math.PI );
+						adding = true;
+					
+					}
 				
 				}
-				
-				if ( randomScale ) {
-					
-					mesh.scale.x = mesh.scale.y = mesh.scale.z = Math.random() * radius * 0.1 + radius * 0.05;
-					
-				}
-				
-				// add new object to octree and scene
-				// NOTE: octree object insertion is deferred until after the next render cycle
-				
-				octree.add( mesh, { useFaces: useFaces } );
-				scene.add( mesh );
-				
-				// store object
-				
-				objects.push( mesh );
-				
+			
 				/*
-				
+			
 				// octree details to console
-				
-				console.log( ' ============================================================================================================');
+			
 				console.log( ' OCTREE: ', octree );
-				console.log( ' ... depth ', octree.depth, ' vs depth end?', octree.depthEnd() );
-				console.log( ' ... num nodes: ', octree.nodeCountEnd() );
-				console.log( ' ... total objects: ', octree.objectCountEnd(), ' vs tree objects length: ', octree.objects.length );
-				console.log( ' ============================================================================================================');
-				console.log( ' ');
-				
+				console.log( ' ... depth ', octree.depth, ' vs depth end?', octree.depth_end() );
+				console.log( ' ... num nodes: ', octree.node_count_end() );
+				console.log( ' ... total objects: ', octree.object_count_end(), ' vs tree objects length: ', octree.objects.length );
+			
 				// print full octree structure to console
-				
-				octree.toConsole();
-				
+			
+				octree.to_console();
+			
 				*/
-				
-			}
 			
-		}
+			}
 		
-		function searchOctree() {
+			function searchOctree() {
 			
-			var i, il;
+				var i, il;
 			
-			// revert previous search objects to base color
+				// revert previous search objects to base color
 			
-			for ( i = 0, il = objectsSearch.length; i < il; i++ ) {
+				for ( i = 0, il = meshesSearch.length; i < il; i++ ) {
 				
-				var mesh = objectsSearch[ i ].object;
+					meshesSearch[ i ].object.material.color.setRGB( baseR, baseG, baseB );
 				
-				if ( mesh !== intersected ) {
-					
-					mesh.material.color.setHex( baseColor );
-					
 				}
+			
+				// new search position
+				searchMesh.position.set(
+					Math.random() * radiusMax - radiusMaxHalf,
+					Math.random() * radiusMax - radiusMaxHalf,
+					Math.random() * radiusMax - radiusMaxHalf
+				);
+			
+				// record start time
+			
+				var timeStart = Date.now();
+			
+				// search octree from search mesh position with search radius
+				// optional third parameter: boolean, if should sort results by object when using faces in octree
+				// optional fourth parameter: vector3, direction of search when using ray (assumes radius is distance/far of ray)
+			
+				var rayCaster = new THREE.Raycaster( new THREE.Vector3().copy( searchMesh.position ), new THREE.Vector3( Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1 ).normalize() );
+				meshesSearch = octree.search( rayCaster.ray.origin, radiusSearch, true, rayCaster.ray.direction );
+				var intersections = rayCaster.intersectOctreeObjects( meshesSearch );
+			
+				// record end time
+			
+				var timeEnd = Date.now();
+			
+				// set color of all meshes found in search
+			
+				for ( i = 0, il = meshesSearch.length; i < il; i++ ) {
 				
-			}
-			
-			// new search position
-			searchMesh.position.set( Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf );
-			
-			// record start time
-			
-			var timeStart = new Date().getTime();
-			
-			// search octree from search mesh position with search radius
-			// optional third parameter: boolean, if should sort results by object when using faces/vertices in octree
-			// optional fourth parameter: vector3, direction of search when using ray (assumes radius is distance/far of ray)
-			
-			var raycaster = new THREE.Raycaster( new THREE.Vector3().copy( searchMesh.position ), new THREE.Vector3( Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1 ).normalize() );
-			objectsSearch = octree.search( raycaster.ray.origin, radiusSearch, true, raycaster.ray.direction );
-			var intersections = raycaster.intersectOctreeObjects( objectsSearch );
-			
-			// record end time
-			
-			var timeEnd = new Date().getTime();
-			
-			// set color of all objects found in search
-			
-			for ( i = 0, il = objectsSearch.length; i < il; i++ ) {
+					meshesSearch[ i ].object.material.color.setRGB( foundR, foundG, foundB );
 				
-				var mesh = objectsSearch[ i ].object;
-				
-				if ( mesh !== intersected ) {
-					
-					mesh.material.color.setHex( foundColor );
-					
 				}
-				
+			
+				/*
+			
+				// results to console
+			
+				console.log( 'OCTREE: ', octree );
+				console.log( '... searched ', meshes.length, ' and found ', meshesSearch.length, ' with intersections ', intersections.length, ' and took ', ( timeEnd - timeStart ), ' ms ' );
+			
+				*/
+			
 			}
-			
-			/*
-			
-			// results to console
-			
-			console.log( 'OCTREE: ', octree );
-			console.log( '... searched ', objects.length, ' and found ', objectsSearch.length, ' with intersections ', intersections.length, ' and took ', ( timeEnd - timeStart ), ' ms ' );
-			
-			*/
-			
-		}
 		
-		function onWindowResize() {
+			function render() {
+	
+				var timer = - Date.now() / 5000;
 
-			camera.aspect = window.innerWidth / window.innerHeight;
-			camera.updateProjectionMatrix();
-
-			renderer.setSize( window.innerWidth, window.innerHeight );
-
-		}
-
-		function onDocumentMouseMove( event ) {
-
-			event.preventDefault();
-
-			mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
-			mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
-			
-			var vector = new THREE.Vector3( mouse.x, mouse.y, 0.5 );
-			projector.unprojectVector( vector, camera );
-
-			var raycaster = new THREE.Raycaster( camera.position, vector.sub( camera.position ).normalize() );
-			var octreeObjects;
-			var numObjects;
-			var numFaces = 0;
-			var intersections;
-			
-			if ( useOctree ) {
-					
-				octreeObjects = octree.search( raycaster.ray.origin, raycaster.ray.far, true, raycaster.ray.direction );
-				
-				intersections = raycaster.intersectOctreeObjects( octreeObjects );
-				
-				numObjects = octreeObjects.length;
-				
-				for ( var i = 0, il = numObjects; i < il; i++ ) {
-					
-					numFaces += octreeObjects[ i ].faces.length;
-					
-				}
-				
-			}
-			else {
-				
-				intersections = raycaster.intersectObjects( objects );
-				numObjects = objects.length;
-				numFaces = totalFaces;
-				
-			}
-			
-			if ( intersections.length > 0 ) {
-
-				if ( intersected != intersections[ 0 ].object ) {
-
-					if ( intersected ) intersected.material.color.setHex( baseColor );
-
-					intersected = intersections[ 0 ].object;
-					intersected.material.color.setHex( intersectColor );
-
-				}
-
-				document.body.style.cursor = 'pointer';
+				camera.position.x = Math.cos( timer ) * 10000;
+				camera.position.z = Math.sin( timer ) * 10000;
+				camera.lookAt( scene.position );
+		
+				renderer.render( scene, camera );
 
 			}
-			else if ( intersected ) {
-				
-				intersected.material.color.setHex( baseColor );
-				intersected = null;
 
-				document.body.style.cursor = 'auto';
-
-			}
-			
-			// update tracker
-			
-			tracker.innerHTML = ( useOctree ? 'Octree search' : 'Search without octree' ) + ' using infinite ray from camera found [ ' + numObjects + ' / ' + objects.length + ' ] objects, [ ' + numFaces + ' / ' + totalFaces + ' ] faces, and [ ' + intersections.length + ' ] intersections.';
-			
-		}
-
-	</script>
-
-</body>
-
+		</script>
+	</body>
 </html>

--- a/examples/webgl_octree.html
+++ b/examples/webgl_octree.html
@@ -83,7 +83,18 @@
 			octree = new THREE.Octree( {
 				// uncomment below to see the octree (may kill the fps)
 				//scene: scene,
-				renderer: renderer
+				// when undeferred = true, objects are inserted immediately
+				// instead of being deferred until next octree.update() call
+				// this may decrease performance as it forces a matrix update
+				undeferred: false,
+				// set the max depth of tree
+				// where -1 is infinite
+				depthMax: -1,
+				// max number of objects before nodes split or merge
+				objectsThreshold: 8,
+				// percent between 0 and 1 that nodes will overlap each other
+				// helps insert objects that lie over more than one node
+				overlapPct: 0.15
 			} );
 			
 			// create object to show search radius and add to scene
@@ -250,6 +261,12 @@
 			controls.update();
 
 			renderer.render( scene, camera );
+			
+			// update octree post render
+			// this ensures any objects being added
+			// have already had their matrices updated
+			
+			octree.update();
 
 		}
 		

--- a/examples/webgl_octree_raycasting.html
+++ b/examples/webgl_octree_raycasting.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<html>
+<head>
+	
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="description" content="">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<style>
+		body {
+			font-family: Monospace;
+			background-color: #f0f0f0;
+			margin: 0px;
+			overflow: hidden;
+		}
+	</style>
+	
+    <title>THREE: Octree!</title>
+
+</head>
+
+<body>
+
+    <script type="text/javascript" src="../build/three.min.js"></script>
+    <script type="text/javascript" src="js/Octree.js"></script>
+	<script type="text/javascript" src="js/controls/TrackballControls.js"></script>
+	<script type="text/javascript" src="js/libs/stats.min.js"></script>
+	<script>
+		
+		var camera, scene, renderer;
+
+		var controls, stats;
+		
+		var tracker;
+		
+		var octree;
+		
+		var objects = [];
+		var objectsSearch = [];
+		var totalFaces = 0;
+		
+		var simpleMeshCount = 2000;
+		var radius = 100;
+		var radiusMax = radius * 10;
+		var radiusMaxHalf = radiusMax * 0.5;
+		var radiusSearch = radius * 0.75;
+		
+		var baseColor = 0x333333;
+		var foundColor = 0x12C0E3;
+		var intersectColor = 0x00D66B;
+		
+		var clock = new THREE.Clock();
+		var searchDelay = 1;
+		var searchInterval = 0;
+		var useOctree = true;
+		
+		var projector;
+		
+		var mouse = new THREE.Vector2();
+		var intersected;
+
+		init();
+		animate();
+
+		function init() {
+			
+			// standard three scene, camera, renderer
+
+			scene = new THREE.Scene();
+
+			camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, radius * 100 );
+			camera.position.z = radius * 10;
+			scene.add( camera );
+
+			renderer = new THREE.WebGLRenderer();
+			renderer.setSize( window.innerWidth, window.innerHeight );
+
+			document.body.appendChild( renderer.domElement );
+			
+			// create octree
+			
+			octree = new THREE.Octree( {
+				// uncomment below to see the octree (may kill the fps)
+				//scene: scene,
+				// when undeferred = true, objects are inserted immediately
+				// instead of being deferred until next octree.update() call
+				// this may decrease performance as it forces a matrix update
+				undeferred: false,
+				// set the max depth of tree
+				// where -1 is infinite
+				depthMax: -1,
+				// max number of objects before nodes split or merge
+				objectsThreshold: 8,
+				// percent between 0 and 1 that nodes will overlap each other
+				// helps insert objects that lie over more than one node
+				overlapPct: 0.15
+			} );
+			
+			// lights
+			
+			var ambient = new THREE.AmbientLight( 0x101010 );
+			scene.add( ambient );
+
+			var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.5 );
+			directionalLight.position.set( 1, 1, 2 ).normalize();
+			scene.add( directionalLight );
+			
+			// create all objects
+			
+			var simpleGeometry = new THREE.CubeGeometry( 1, 1, 1 );
+			
+			for ( var i = 0; i < simpleMeshCount - 1; i++ ) {
+				
+				totalFaces += simpleGeometry.faces.length;
+				
+				var simpleMaterial = new THREE.MeshBasicMaterial();
+				simpleMaterial.color.setHex( baseColor );
+				
+				modifyOctree( simpleGeometry, simpleMaterial, false, true, true, true );
+				
+			}
+			
+			var loader = new THREE.JSONLoader();
+			
+			loader.load( 'obj/lucy/Lucy100k_slim.js', function ( geometry ) {
+
+				geometry.computeVertexNormals();
+				totalFaces += geometry.faces.length;
+				
+				var material = new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0x030303, specular: 0x030303, shininess: 30 } );
+				
+				modifyOctree( geometry, material, true );
+				
+			} );
+			
+			// projector for click intersection
+			
+			projector = new THREE.Projector();
+			
+			// camera controls
+			
+			controls = new THREE.TrackballControls( camera );
+			controls.rotateSpeed = 1.0;
+			controls.zoomSpeed = 1.2;
+			controls.panSpeed = 0.8;
+			controls.noZoom = false;
+			controls.noPan = false;
+			controls.staticMoving = true;
+			controls.dynamicDampingFactor = 0.3;
+			
+			// info
+			
+			var info = document.createElement( 'div' );
+			info.style.position = 'absolute';
+			info.style.top = '0';
+			info.style.width = '100%';
+			info.style.textAlign = 'center';
+			info.style.padding = '10px';
+			info.style.background = '#FFFFFF';
+			info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> webgl - octree (raycasting performance) - by <a href="http://github.com/collinhover/threeoctree" target="_blank">collinhover</a><br><small style="opacity:0.5">Lucy model from <a href="http://graphics.stanford.edu/data/3Dscanrep/">Stanford 3d scanning repository</a>(decimated with <a href="http://meshlab.sourceforge.net/">Meshlab</a>)</small>';
+			document.body.appendChild( info );
+			
+			// stats
+			
+			stats = new Stats();
+			stats.domElement.style.position = 'absolute';
+			stats.domElement.style.top = '0';
+			stats.domElement.style.left = '0';
+			stats.domElement.style.zIndex = 100;
+			
+			document.body.appendChild( stats.domElement );
+			
+			// bottom container
+			
+			var container = document.createElement( 'div' );
+			container.style.position = 'absolute';
+			container.style.bottom = '0';
+			container.style.width = '100%';
+			container.style.textAlign = 'center';
+			document.body.appendChild( container );
+			
+			// tracker
+			
+			tracker = document.createElement( 'div' );
+			tracker.style.width = '100%';
+			tracker.style.padding = '10px';
+			tracker.style.background = '#FFFFFF';
+			container.appendChild( tracker );
+			
+			// octree use toggle
+			
+			var toggle = document.createElement( 'div' );
+			toggle.style.position = 'absolute';
+			toggle.style.bottom = '100%';
+			toggle.style.width = '100%';
+			toggle.style.padding = '10px';
+			toggle.style.background = '#FFFFFF';
+			container.appendChild( toggle );
+			
+			var checkbox = document.createElement('input');
+			checkbox.type = "checkbox";
+			checkbox.name = "octreeToggle";
+			checkbox.value = "value";
+			checkbox.id = "octreeToggle";
+			checkbox.checked = true;
+
+			var label = document.createElement('label')
+			label.htmlFor = "octreeToggle";
+			label.appendChild(document.createTextNode('Use Octree') );
+
+			toggle.appendChild(checkbox);
+			toggle.appendChild(label);
+			
+			// events
+
+			checkbox.addEventListener( 'click', toggleOctree, false );
+			renderer.domElement.addEventListener( 'mousemove', onDocumentMouseMove, false );
+
+			window.addEventListener( 'resize', onWindowResize, false );
+
+		}
+		
+		function toggleOctree () {
+			
+			useOctree = !useOctree;
+			
+		}
+
+		function animate() {
+
+			// note: three.js includes requestAnimationFrame shim
+			
+			requestAnimationFrame( animate );
+			
+			render();
+			
+			stats.update();
+
+		}
+		
+		function render() {
+
+			controls.update();
+
+			renderer.render( scene, camera );
+			
+			// update octree post render
+			// this ensures any objects being added
+			// have already had their matrices updated
+			
+			octree.update();
+
+		}
+		
+		function modifyOctree( geometry, material, useFaces, randomPosition, randomRotation, randomScale ) {
+			
+			var mesh;
+			
+			if ( geometry ) {
+				
+				// create new object
+				
+				mesh = new THREE.Mesh( geometry, material );
+				
+				// give new object a random position, rotation, and scale
+				
+				if ( randomPosition ) {
+				
+					mesh.position.set( Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf, Math.random() * radiusMax - radiusMaxHalf );
+				
+				}
+				
+				if ( randomRotation ) {
+					
+					mesh.rotation.set( Math.random() * 2 * Math.PI, Math.random() * 2 * Math.PI, Math.random() * 2 * Math.PI );
+				
+				}
+				
+				if ( randomScale ) {
+					
+					mesh.scale.x = mesh.scale.y = mesh.scale.z = Math.random() * radius * 0.1 + radius * 0.05;
+					
+				}
+				
+				// add new object to octree and scene
+				// NOTE: octree object insertion is deferred until after the next render cycle
+				
+				octree.add( mesh, { useFaces: useFaces } );
+				scene.add( mesh );
+				
+				// store object
+				
+				objects.push( mesh );
+				
+				/*
+				
+				// octree details to console
+				
+				console.log( ' ============================================================================================================');
+				console.log( ' OCTREE: ', octree );
+				console.log( ' ... depth ', octree.depth, ' vs depth end?', octree.depthEnd() );
+				console.log( ' ... num nodes: ', octree.nodeCountEnd() );
+				console.log( ' ... total objects: ', octree.objectCountEnd(), ' vs tree objects length: ', octree.objects.length );
+				console.log( ' ============================================================================================================');
+				console.log( ' ');
+				
+				// print full octree structure to console
+				
+				octree.toConsole();
+				
+				*/
+				
+			}
+			
+		}
+		
+		function onWindowResize() {
+
+			camera.aspect = window.innerWidth / window.innerHeight;
+			camera.updateProjectionMatrix();
+
+			renderer.setSize( window.innerWidth, window.innerHeight );
+
+		}
+
+		function onDocumentMouseMove( event ) {
+
+			event.preventDefault();
+
+			mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
+			mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+			
+			var vector = new THREE.Vector3( mouse.x, mouse.y, 0.5 );
+			projector.unprojectVector( vector, camera );
+
+			var raycaster = new THREE.Raycaster( camera.position, vector.sub( camera.position ).normalize() );
+			var octreeObjects;
+			var numObjects;
+			var numFaces = 0;
+			var intersections;
+			
+			if ( useOctree ) {
+					
+				octreeObjects = octree.search( raycaster.ray.origin, raycaster.ray.far, true, raycaster.ray.direction );
+				
+				intersections = raycaster.intersectOctreeObjects( octreeObjects );
+				
+				numObjects = octreeObjects.length;
+				
+				for ( var i = 0, il = numObjects; i < il; i++ ) {
+					
+					numFaces += octreeObjects[ i ].faces.length;
+					
+				}
+				
+			}
+			else {
+				
+				intersections = raycaster.intersectObjects( objects );
+				numObjects = objects.length;
+				numFaces = totalFaces;
+				
+			}
+			
+			if ( intersections.length > 0 ) {
+
+				if ( intersected != intersections[ 0 ].object ) {
+
+					if ( intersected ) intersected.material.color.setHex( baseColor );
+
+					intersected = intersections[ 0 ].object;
+					intersected.material.color.setHex( intersectColor );
+
+				}
+
+				document.body.style.cursor = 'pointer';
+
+			}
+			else if ( intersected ) {
+				
+				intersected.material.color.setHex( baseColor );
+				intersected = null;
+
+				document.body.style.cursor = 'auto';
+
+			}
+			
+			// update tracker
+			
+			tracker.innerHTML = ( useOctree ? 'Octree search' : 'Search without octree' ) + ' using infinite ray from camera found [ ' + numObjects + ' / ' + objects.length + ' ] objects, [ ' + numFaces + ' / ' + totalFaces + ' ] faces, and [ ' + intersections.length + ' ] intersections.';
+			
+		}
+
+	</script>
+
+</body>
+
+</html>


### PR DESCRIPTION
This only changes files in the examples folder. Octree changed to handle vertices (and particle systems), removed some slow checks such as isNaN, and added deferred object insertion. Initially when I ported the Octree to r59, I hooked the renderer as a post plugin to insert deferred objects, but after some thought I removed that in place of a manually called update to give user more control. Also added option to skip deferral and return to previous method (which is slightly worse on performance). See also #2148.
