### PR TITLE
Browser interoperability bug fixes for examples in IE 11 

### DIFF
--- a/examples/canvas_geometry_shapes.html
+++ b/examples/canvas_geometry_shapes.html
@@ -32,7 +32,7 @@
 
 			var container, stats;
 
-			var camera, scene, renderer;
+			var camera, scene, renderer, parent;
 
 			var text, plane;
 

--- a/examples/canvas_interactive_voxelpainter.html
+++ b/examples/canvas_interactive_voxelpainter.html
@@ -43,7 +43,7 @@
 				info.style.top = '10px';
 				info.style.width = '100%';
 				info.style.textAlign = 'center';
-				info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> - voxel painter<br><strong>click</strong>: add voxel, <strong>control + click</strong>: remove voxel, <strong>shift</strong>: rotate, <a href="javascript:save();return false;">save .png</a>';
+				info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> - voxel painter<br><strong>click</strong>: add voxel, <strong>control + click</strong>: remove voxel, <strong>shift</strong>: rotate, <a href="javascript:save()">save .png</a>';
 				container.appendChild( info );
 
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 10000 );
@@ -227,7 +227,7 @@
 			function save() {
 
 				window.open( renderer.domElement.toDataURL('image/png'), 'mywindow' );
-
+                return false;
 			}
 
 			//

--- a/examples/canvas_particles_shapes.html
+++ b/examples/canvas_particles_shapes.html
@@ -31,7 +31,7 @@
 
 			var container, stats;
 
-			var camera, scene, renderer;
+			var camera, scene, renderer, parent;
 
 			var text, plane;
 

--- a/examples/webgl_geometry_shapes.html
+++ b/examples/webgl_geometry_shapes.html
@@ -25,7 +25,7 @@
 
 			var container, stats;
 
-			var camera, scene, renderer;
+			var camera, scene, renderer, parent;
 
 			var text, plane;
 

--- a/examples/webgl_particles_shapes.html
+++ b/examples/webgl_particles_shapes.html
@@ -83,7 +83,7 @@
 
 			var container, stats;
 
-			var camera, scene, renderer;
+			var camera, scene, renderer, parent;
 
 			var text, plane;
 


### PR DESCRIPTION
Small fixes to a few of the three.js example files to make then work with WebGL in IE 11. The main problem was that the examples were overwriting the global window.parent. In IE 11 window.parent is read only so the examples were failing. On other platform browsers window.parent was being changed to a THREE.Object3D.

parent = new THREE.Object3D();

I added parent to the following declaration of vars

var camera, scene, renderer, parent;

This fixes the examples for IE 11.
