### PR TITLE
Fixed Triangulation false warning. Fixes #3564

### DIFF
--- a/src/extras/FontUtils.js
+++ b/src/extras/FontUtils.js
@@ -439,7 +439,7 @@ THREE.FontUtils.generateShapes = function( text, parameters ) {
 			cCROSSap = cX*apy - cY*apx;
 			bCROSScp = bX*cpy - bY*cpx;
 
-			if ( (aCROSSbp >= 0.0) && (bCROSScp >= 0.0) && (cCROSSap >= 0.0) ) return false;
+			if ( (aCROSSbp >= -EPSILON) && (bCROSScp >= -EPSILON) && (cCROSSap >= -EPSILON) ) return false;
 
 		}
 


### PR DESCRIPTION
The false warning occurred when a vertex was on an edge of a triangle being tested for removal from the polygon.  The snip function should then return false, as there is a vertex inside the triangle, but this was not detected because of rounding errors. The use of EPSILON instead of 0.0 fixes this.

With this patch, both jsFiddles work without showing the warning.
