### PR TITLE
fixing the wrong couting on WebGL buffers stored into memory

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -517,8 +517,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		deallocateGeometry( geometry );
 
-		_this.info.memory.geometries --;
-
 	};
 
 	var onTextureDispose = function ( event ) {
@@ -586,6 +584,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
+		_this.info.memory.geometries --;
+
 	};
 
 	var deallocateGeometry = function ( geometry ) {
@@ -605,6 +605,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 
 			}
+
+			_this.info.memory.geometries --;
 
 		} else {
 
@@ -638,9 +640,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-			}
+			} else {
 
-			deleteBuffers( geometry );
+				deleteBuffers( geometry );
+
+			}
 
 		}
 


### PR DESCRIPTION
renderer.info.memory.geometries was giving false information on the storage of WebGLBuffers on the graphic unit.
