### PR TITLE
RayCaster's intersectObjects now includes line vertex index

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -210,7 +210,7 @@
 							distance: planeDistance,
 							point: raycaster.ray.at( planeDistance ),
 							face: null,
-							faceIndex: null,
+							elementIndex: null,
 							object: object
 
 						} );
@@ -313,7 +313,7 @@
 						distance: planeDistance,
 						point: raycaster.ray.at( planeDistance ),
 						face: face,
-						faceIndex: f,
+						elementIndex: f,
 						object: object
 
 					} );
@@ -368,7 +368,7 @@
 							// point: raycaster.ray.at( distance ),
 							point: interSegment.clone().applyMatrix4( object.matrixWorld ),
 							face: null,
-							faceIndex: null,
+							elementIndex: i,
 							object: object
 
 						} );


### PR DESCRIPTION
This is useful to identify which line of the THREE.Line geometry was intersected.
