### PR TITLE
added .clone() method to cameras

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -32,3 +32,16 @@ THREE.Camera.prototype.lookAt = function () {
 	};
 
 }();
+
+THREE.Camera.prototype.clone = function (camera) {
+
+	if ( camera === undefined ) camera = new THREE.Camera();
+
+	THREE.Object3D.prototype.clone.call( this, camera );
+
+	camera.matrixWorldInverse.copy(this.matrixWorldInverse);
+	camera.projectionMatrix.copy(this.projectionMatrix);
+	camera.projectionMatrixInverse.copy(this.projectionMatrixInverse);
+
+	return camera;
+};

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -25,3 +25,22 @@ THREE.OrthographicCamera.prototype.updateProjectionMatrix = function () {
 	this.projectionMatrix.makeOrthographic( this.left, this.right, this.top, this.bottom, this.near, this.far );
 
 };
+
+THREE.OrthographicCamera.prototype.clone = function () {
+
+	var camera = new THREE.OrthographicCamera();
+
+	THREE.Camera.prototype.clone.call( this, camera );
+
+	camera.left = this.left;
+	camera.right = this.right;
+	camera.top = this.top;
+	camera.bottom = this.bottom;
+	
+	camera.near = this.near;
+	camera.far = this.far;
+	
+	camera.updateProjectionMatrix();
+
+	return camera;
+};

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -114,3 +114,19 @@ THREE.PerspectiveCamera.prototype.updateProjectionMatrix = function () {
 	}
 
 };
+
+THREE.PerspectiveCamera.prototype.clone = function () {
+
+	var camera = new THREE.PerspectiveCamera();
+
+	THREE.Camera.prototype.clone.call( this, camera );
+
+	camera.fov = this.fov;
+	camera.aspect = this.aspect;
+	camera.near = this.near;
+	camera.far = this.far;
+	
+	camera.updateProjectionMatrix();
+
+	return camera;
+};


### PR DESCRIPTION
Since it was not implemented, I decided to add the .clone() method to Camera, OrthographicCamera and PerspectiveCamera. Can be useful to create a 'snapshot' of an existing moving camera for example.
This is my first pull request for this project, I hope I did it correctly ;)
