### PR TITLE
fixing undefined check on quaternion's setFromEuler

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -112,7 +112,7 @@ THREE.Quaternion.prototype = {
 
 	setFromEuler: function ( euler, update ) {
 
-		if ( typeof euler['order'] === undefined ) {
+		if ( typeof euler['order'] === "undefined" ) {
 
 			console.error( 'ERROR: Quaternion\'s .setFromEuler() now expects a Euler rotation rather than a Vector3 and order.  Please update your code.' );
 		}


### PR DESCRIPTION
Hi,

While updating Cannon.js fps demo from r51 to r59, I found this error on setFromEuler. Quick js console explaining it:

``` javascript
euler = {}
> Object {}
typeof euler['order']
> "undefined"
typeof euler['order'] === undefined
> false
typeof euler['order'] === "undefined"
> true
```

Cheers.
