### PR TITLE
boundingSpheres with arbitrary centers

### DIFF
--- a/docs/api/math/Sphere.html
+++ b/docs/api/math/Sphere.html
@@ -90,13 +90,13 @@
 		todo
 		</div>
 
-		<h3>.setFromCenterAndPoints([page:todo center], [page:todo points]) [page:todo]</h3>
+		<h3>.setFromPoints([page:todo points], [page:Vector3 optionalCenter]) [page:todo]</h3>
 		<div>
-		center -- todo <br />
-		points -- todo
+		points -- list of [page:Vector3 vector] positions.<br />  
+		optionalCenter -- optional position for the sphere's center.<br />
 		</div>
 		<div>
-		todo
+		Computes the minimum bounding sphere for *points*. If *optionalCenter* is given, it is used as the sphere's center. Otherwise, the center of the axis-aligned bounding box encompassing *points* is calculated.
 		</div>
 
 		<h3>.distanceToPoint([page:todo point]) [page:todo]</h3>

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -68,11 +68,11 @@
 			var geometry = object.geometry;
 
 			// Checking boundingSphere distance to ray
-			matrixPosition.getPositionFromMatrix( object.matrixWorld );
 
 			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
-			sphere.set( matrixPosition, geometry.boundingSphere.radius * object.matrixWorld.getMaxScaleOnAxis() );
+			sphere.copy( geometry.boundingSphere );
+			sphere.applyMatrix4( object.matrixWorld );
 
 			if ( raycaster.ray.isIntersectionSphere( sphere ) === false ) {
 
@@ -253,8 +253,9 @@
 			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
 			// Checking boundingSphere distance to ray
-			matrixPosition.getPositionFromMatrix(object.matrixWorld);
-			sphere.set( matrixPosition, geometry.boundingSphere.radius * object.matrixWorld.getMaxScaleOnAxis() );
+
+			sphere.copy( geometry.boundingSphere );
+			sphere.applyMatrix4( object.matrixWorld );
 			
 			if ( raycaster.ray.isIntersectionSphere( sphere ) === false ) {
 

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -74,36 +74,18 @@ THREE.Frustum.prototype = {
 
 	intersectsObject: function () {
 
-		var center = new THREE.Vector3();
+		var sphere = new THREE.Sphere();
 
 		return function ( object ) {
 
-			// this method is expanded inlined for performance reasons.
-
 			var geometry = object.geometry;
-			var matrix = object.matrixWorld;
 
 			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
-			var negRadius = - geometry.boundingSphere.radius * matrix.getMaxScaleOnAxis();
+			sphere.copy( geometry.boundingSphere );
+			sphere.applyMatrix4( object.matrixWorld );
 
-			center.getPositionFromMatrix( matrix );
-
-			var planes = this.planes;
-
-			for ( var i = 0; i < 6; i ++ ) {
-
-				var distance = planes[ i ].distanceToPoint( center );
-
-				if ( distance < negRadius ) {
-
-					return false;
-
-				}
-
-			}
-
-			return true;
+			return this.intersectsSphere( sphere );
 
 		};
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -22,23 +22,35 @@ THREE.Sphere.prototype = {
 		return this;
 	},
 
-	setFromPoints: function ( points ) {
 
-		var radiusSq, maxRadiusSq = 0;
+	setFromPoints: function () {
 
-		for ( var i = 0, il = points.length; i < il; i ++ ) {
+		var _box = new THREE.Box3();
+		var _center = new THREE.Vector3();
 
-			radiusSq = points[ i ].lengthSq();
-			maxRadiusSq = Math.max( maxRadiusSq, radiusSq );
+		return function ( points, optionalCenter )  {
 
-		}
+			// use boundingBox center as sphere center
 
-		this.center.set( 0, 0, 0 );
-		this.radius = Math.sqrt( maxRadiusSq );
+			var center = optionalCenter || _box.setFromPoints( points ).center( _center );
 
-		return this;
+			var maxRadiusSq = 0;
 
-	},
+			for ( var i = 0, il = points.length; i < il; i ++ ) {
+
+				var radiusSq = center.distanceToSquared( points[ i ] );
+				maxRadiusSq = Math.max( maxRadiusSq, radiusSq );
+
+			}
+
+			this.center.copy( center );
+			this.radius = Math.sqrt( maxRadiusSq );
+
+			return this;			
+ 		
+ 		};
+
+	}(),
 
 	copy: function ( sphere ) {
 


### PR DESCRIPTION
Following #3689, #3446 and others, I've made modifications to `Raycaster` and `Frustum` to support spheres with arbitrary centers. The relevant bit of code is 

```
sphere.copy( geometry.boundingSphere );
sphere.applyMatrix4( object.matrixWorld );
```

Additionally, I've updated `Sphere.setFromPoints` so that it calculates a better bounding sphere. First it calculates a boundingBox around the points and uses its center as the sphere's center (unless `optionalCenter` is given, in which case that is used instead). Then, it calculates the minimum radius as in the old `setFromCenterAndPoints`.

There are other, better, but more complex algorithms to build an optimal boundingSphere. Do you think it's worth to go into that? 
