### PR TITLE
Fixing frustum unit test

### DIFF
--- a/test/unit/unittests_sources.html
+++ b/test/unit/unittests_sources.html
@@ -24,9 +24,9 @@
   <script src="../../src/math/Matrix3.js"></script>
   <script src="../../src/math/Matrix4.js"></script>
   <script src="../../src/math/Ray.js"></script>
+  <script src="../../src/math/Sphere.js"></script>
   <script src="../../src/math/Frustum.js"></script>
   <script src="../../src/math/Plane.js"></script>
-  <script src="../../src/math/Sphere.js"></script>
   <script src="../../src/math/Math.js"></script>
   <script src="../../src/math/Triangle.js"></script>
 


### PR DESCRIPTION
Hi,

I saw this unit test broken on dev branch:

![screen shot 2013-08-13 at 12 46 14 am](https://f.cloud.github.com/assets/148319/953122/ade9f184-03eb-11e3-87d0-a54f7d606f6c.png)

This is cause by the fact that  Frustum has a dependency on Sphere on dev branch: https://github.com/mrdoob/three.js/blob/dev/src/math/Frustum.js#L77

Note that it doesn't happen on master branch though: https://github.com/mrdoob/three.js/blob/master/src/math/Frustum.js#L77
