### PR TITLE
Octree support for boundingSphere with arbitrary center

### DIFF
--- a/examples/js/Octree.js
+++ b/examples/js/Octree.js
@@ -1,6 +1,6 @@
 /*!
  *
- * threeoctree.js (r59) / https://github.com/collinhover/threeoctree
+ * threeoctree.js (r60) / https://github.com/collinhover/threeoctree
  * (sparse) dynamic 3D spatial representation structure for fast searches.
  *
  * @author Collin Hover / http://collinhover.com/
@@ -681,14 +681,14 @@
 					}
 					
 					this.radius = this.object.geometry.boundingSphere.radius;
+					this.position.copy( this.object.geometry.boundingSphere.center ).applyMatrix4( this.object.matrixWorld );
 					
 				} else {
 					
 					this.radius = this.object.boundRadius;
+					this.position.getPositionFromMatrix( this.object.matrixWorld );
 					
 				}
-				
-				this.position.getPositionFromMatrix( this.object.matrixWorld );
 				
 			}
 			


### PR DESCRIPTION
As noted in #3748, octree assumed boundingSphere had a zero center. This should account for arbitrary center points in boundingSphere, and appears stable with latest r60dev build.
