### PR TITLE
Screen size computation in TrackballControls.js

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -75,8 +75,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 			this.screen.left = 0;
 			this.screen.top = 0;
-			this.screen.width = _this.domElement.offsetWidth;
-			this.screen.height = _this.domElement.offsetHeight;
+			this.screen.width = this.domElement.offsetWidth;
+			this.screen.height = this.domElement.offsetHeight;
 
 		} else {
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -75,8 +75,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 			this.screen.left = 0;
 			this.screen.top = 0;
-			this.screen.width = window.innerWidth;
-			this.screen.height = window.innerHeight;
+			this.screen.width = _this.domElement.offsetWidth;
+			this.screen.height = _this.domElement.offsetHeight;
 
 		} else {
 


### PR DESCRIPTION
Screen size computation in TrackballControls.js is assuming that the container is the window, rather than this.domElement.  If you embed the renderer in something aside from the window, the projection code uses window dimensions rather than container dimensions.  This seems to work in latest Chrome and FF.
