### PR TITLE
Updated Texture image description for using video as a texture.

### DIFF
--- a/docs/api/textures/Texture.html
+++ b/docs/api/textures/Texture.html
@@ -30,7 +30,7 @@
 
 		<h3>.[page:Image image]</h3>
 		<div>
-		An Image object, typically created using the ImageUtils or [page:ImageLoader ImageLoader] classes. The Image object can include an image (e.g., PNG, JPG, GIF, DDS), video (e.g., MP4, OGG/OGV), or set of six images for a cube map.
+		An Image object, typically created using the ImageUtils or [page:ImageLoader ImageLoader] classes. The Image object can include an image (e.g., PNG, JPG, GIF, DDS), video (e.g., MP4, OGG/OGV), or set of six images for a cube map. To use video as a texture you need to have a playing HTML5 video element as a source for your texture image and continuously update this texture as long as video is playing.
 		</div>
 
 		<h3>.[page:object mapping]</h3>


### PR DESCRIPTION
Line 33 says that you can directly use a video(.mp4, ogg/ogv) as a texture. However after much of trial and error, I believe only way to make video work is by placing a html5 video element and continuously updating texture based on video frames.

Made change in documentation to reflect this information.
