### PR TITLE
Update function mergeVertices() in Geometry.js

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -573,12 +573,13 @@ THREE.Geometry.prototype = {
 		}
 
 		for ( i = faceIndicesToRemove.length - 1; i >= 0; i -- ) {
-
-			this.faces.splice( i, 1 );
+			var idx = faceIndicesToRemove[ i ];
+			
+			this.faces.splice( idx, 1 );
 
 			for ( j = 0, jl = this.faceVertexUvs.length; j < jl; j ++ ) {
 
-				this.faceVertexUvs[ j ].splice( i, 1 );
+				this.faceVertexUvs[ j ].splice( idx, 1 );
 
 			}
 


### PR DESCRIPTION
This function first merge close vertices and then remove faces which has more than 2 vertices that are the same after merging. It stores all faces that need be removed in an array but it removes the array index rather than the content in the array. This is a serious bug since it breaks the 3D model.
