### PR TITLE
JSONLoader progress callback

### DIFF
--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -13,7 +13,7 @@ THREE.JSONLoader = function ( showStatus ) {
 
 THREE.JSONLoader.prototype = Object.create( THREE.Loader.prototype );
 
-THREE.JSONLoader.prototype.load = function ( url, callback, texturePath ) {
+THREE.JSONLoader.prototype.load = function ( url, callback, texturePath, callbackProgress ) {
 
 	var scope = this;
 
@@ -22,7 +22,7 @@ THREE.JSONLoader.prototype.load = function ( url, callback, texturePath ) {
 	texturePath = texturePath && ( typeof texturePath === "string" ) ? texturePath : this.extractUrlBase( url );
 
 	this.onLoadStart();
-	this.loadAjaxJSON( this, url, callback, texturePath );
+	this.loadAjaxJSON( this, url, callback, texturePath, callbackProgress );
 
 };
 


### PR DESCRIPTION
Any reason why `JSONLoader.load()` shouldn't be able to take a progress callback? Seems like most other loaders' `.load()` do :)
