### PR TITLE
OrbitControls.js: moving the mouse wheel now causes a re-render on its own.

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -411,6 +411,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
+		if(delta != 0) scope.update();
+
 	}
 
 	function onKeyDown( event ) {


### PR DESCRIPTION
I found a problem in OrbitControls.js where moving the mouse wheel was not causing a re-render, so the resulting change in zoom level was not visible until another event occurred. I fixed this by adding a call to update() within the mousewheel event callback. This bug is not present in the misc_orbit_controls.html example because something besides the OrbitControls event listener is causing updates constantly, but it is present in the OrbitControls object when used on its own. This bug may also be present in the touch counterparts, but I have not tested them.

Edit: The name of this commit is misleading. A mousewheel event does not cause a re-render, but rather a call to update(), which in turn dispatches a "change" event.
