### PR TITLE
Add an optional inactive window for the mouse

### DIFF
--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -14,6 +14,8 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 	this.movementSpeed = 1.0;
 	this.lookSpeed = 0.005;
 
+	this.mouseInactiveWindow = 0;
+
 	this.lookVertical = true;
 	this.autoForward = false;
 	// this.invertVertical = false;
@@ -133,6 +135,9 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 			this.mouseY = event.pageY - this.domElement.offsetTop - this.viewHalfY;
 
 		}
+
+		this.mouseX = applyInactiveWindow( this.mouseX, this.viewHalfX, this.mouseInactiveWindow );
+		this.mouseY = applyInactiveWindow( this.mouseY, this.viewHalfY, this.mouseInactiveWindow );
 
 	};
 
@@ -277,6 +282,17 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 		};
 
 	};
+
+	function applyInactiveWindow( position, size, ratio ) {
+
+		var newPosition = ( Math.abs( position ) - size * ratio ) / ( 1 - ratio );
+
+		if ( newPosition < 0 ) return 0;
+
+		if ( position < 0 ) return -newPosition;
+
+		return newPosition;
+	}
 
 	this.handleResize();
 


### PR DESCRIPTION
The mouse will be active only if it's outside the window centered around the cursor, of `width = window.innerWidth * this.mouseInactiveWindow`, and respective height.

`mouseInactiveWindow` should be in the interval `[0, 1)`, and its default value is 0. That is, it's active everywhere by default, same as before.

This modification aims at enlarging the "non-moving area" of the mouse, and thus, helping the user to stand still, or move just with the keyboard.
