### PR TITLE
Fixed Blender 2.66 exporter to export multiple actions. Credit to kontan.

### DIFF
--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -444,8 +444,9 @@ THREE.JSONLoader.prototype.parse = function ( json, texturePath ) {
 		}
 
 		geometry.bones = json.bones;
+		// could change this to json.animations[0] or remove completely
 		geometry.animation = json.animation;
-
+		geometry.animations = json.animations;
 	};
 
 	function parseMorphing( scale ) {

--- a/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/__init__.py
+++ b/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/__init__.py
@@ -222,7 +222,7 @@ def save_settings_export(properties):
     "option_scale"        : properties.option_scale,
 
     "align_model"         : properties.align_model,
-    "option_all_animation" : properties.option_all_animations
+    #"option_all_animation" : properties.option_all_animations
     }
 
     fname = get_settings_fullpath()
@@ -268,7 +268,7 @@ def restore_settings_export(properties):
 
     properties.option_frame_step = settings.get("option_frame_step", 1)
     properties.option_all_meshes = settings.get("option_all_meshes", True)
-    properties.option_all_animations = settings.get("option_all_animations", True)
+    #properties.option_all_animations = settings.get("option_all_animations", True)
 
 # ################################################################
 # Exporter
@@ -317,7 +317,7 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
 
     option_frame_step = IntProperty(name = "Frame step", description = "Animation frame step", min = 1, max = 1000, soft_min = 1, soft_max = 1000, default = 1)
     option_all_meshes = BoolProperty(name = "All meshes", description = "All meshes (merged)", default = True)
-    option_all_animations = BoolProperty(name = "All animations", description = "All animations", default = True)
+    #option_all_animations = BoolProperty(name = "All animations", description = "All animations", default = False)
 
     def invoke(self, context, event):
         restore_settings_export(self.properties)
@@ -414,8 +414,8 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
         row = layout.row()
         row.prop(self.properties, "option_animation_skeletal")
         row = layout.row()
-        row.prop(self.properties, "option_all_animations")
-        row = layout.row()
+        #row.prop(self.properties, "option_all_animations")
+        #row = layout.row()
         row.prop(self.properties, "option_frame_step")
         layout.separator()
 

--- a/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/__init__.py
+++ b/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/__init__.py
@@ -221,7 +221,8 @@ def save_settings_export(properties):
     "option_vertices_truncate" : properties.option_vertices_truncate,
     "option_scale"        : properties.option_scale,
 
-    "align_model"         : properties.align_model
+    "align_model"         : properties.align_model,
+    "option_all_animation" : properties.option_all_animations
     }
 
     fname = get_settings_fullpath()
@@ -267,6 +268,7 @@ def restore_settings_export(properties):
 
     properties.option_frame_step = settings.get("option_frame_step", 1)
     properties.option_all_meshes = settings.get("option_all_meshes", True)
+    properties.option_all_animations = settings.get("option_all_animations", True)
 
 # ################################################################
 # Exporter
@@ -315,6 +317,7 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
 
     option_frame_step = IntProperty(name = "Frame step", description = "Animation frame step", min = 1, max = 1000, soft_min = 1, soft_max = 1000, default = 1)
     option_all_meshes = BoolProperty(name = "All meshes", description = "All meshes (merged)", default = True)
+    option_all_animations = BoolProperty(name = "All animations", description = "All animations", default = True)
 
     def invoke(self, context, event):
         restore_settings_export(self.properties)
@@ -410,6 +413,8 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
         row.prop(self.properties, "option_animation_morph")
         row = layout.row()
         row.prop(self.properties, "option_animation_skeletal")
+        row = layout.row()
+        row.prop(self.properties, "option_all_animations")
         row = layout.row()
         row.prop(self.properties, "option_frame_step")
         layout.separator()

--- a/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/__init__.py
+++ b/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/__init__.py
@@ -222,7 +222,6 @@ def save_settings_export(properties):
     "option_scale"        : properties.option_scale,
 
     "align_model"         : properties.align_model,
-    #"option_all_animation" : properties.option_all_animations
     }
 
     fname = get_settings_fullpath()
@@ -268,7 +267,6 @@ def restore_settings_export(properties):
 
     properties.option_frame_step = settings.get("option_frame_step", 1)
     properties.option_all_meshes = settings.get("option_all_meshes", True)
-    #properties.option_all_animations = settings.get("option_all_animations", True)
 
 # ################################################################
 # Exporter
@@ -317,7 +315,6 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
 
     option_frame_step = IntProperty(name = "Frame step", description = "Animation frame step", min = 1, max = 1000, soft_min = 1, soft_max = 1000, default = 1)
     option_all_meshes = BoolProperty(name = "All meshes", description = "All meshes (merged)", default = True)
-    #option_all_animations = BoolProperty(name = "All animations", description = "All animations", default = False)
 
     def invoke(self, context, event):
         restore_settings_export(self.properties)
@@ -414,8 +411,6 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
         row = layout.row()
         row.prop(self.properties, "option_animation_skeletal")
         row = layout.row()
-        #row.prop(self.properties, "option_all_animations")
-        #row = layout.row()
         row.prop(self.properties, "option_frame_step")
         layout.separator()
 

--- a/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -267,7 +267,8 @@ TEMPLATE_MODEL_ASCII = """\
 
 	"skinWeights" : [%(weights)s],
 
-	"animation" : {%(animation)s}
+	"animation"  : {%(animation)s},
+        "animations" : [%(animations)s]
 """
 
 TEMPLATE_VERTEX = "%g,%g,%g"
@@ -845,14 +846,14 @@ def generate_indices_and_weights(meshes, option_skinning):
 # (only the first action will exported)
 # ##############################################################################
 
-def generate_animation(option_animation_skeletal, option_frame_step, flipyz):
+def generate_animation(option_animation_skeletal, option_frame_step, flipyz, action_index):
 
-    if not option_animation_skeletal or len(bpy.data.actions) == 0:
+    if not option_animation_skeletal or len(bpy.data.actions) == 0 or len(bpy.data.actions) == 0:
         return ""
 
     # TODO: Add scaling influences
 
-    action = bpy.data.actions[0]
+    action = bpy.data.actions[action_index]
     armature, armatureObject = get_armature()
     if armature is None or armatureObject is None:
         return "", 0
@@ -931,6 +932,15 @@ def generate_animation(option_animation_skeletal, option_frame_step, flipyz):
     animation_string = '"name":"%s","fps":%d,"length":%g,"hierarchy":[%s]' % (action.name, fps, (frame_length / fps), hierarchy_string)
 
     return animation_string
+
+def generate_all_animations(option_animation_skeletal, option_frame_step, flipyz, option_all_animations):
+    all_animations_string = ""
+    if option_all_animations:
+        for index in range(0, len(bpy.data.actions)):
+            if index != 0 :
+                all_animations_string += ", \n"
+            all_animations_string += "{" + generate_animation(option_animation_skeletal, option_frame_step, flipyz, index) + "}"
+    return all_animations_string
 
 def handle_position_channel(channel, frame, position):
 
@@ -1290,6 +1300,7 @@ def generate_ascii_model(meshes, morphs,
                          filepath,
                          option_animation_morph,
                          option_animation_skeletal,
+                         option_all_animations,
                          option_frame_step):
 
     vertices = []
@@ -1390,7 +1401,8 @@ def generate_ascii_model(meshes, morphs,
     "bones"     : bones_string,
     "indices"   : indices_string,
     "weights"   : weights_string,
-    "animation" : generate_animation(option_animation_skeletal, option_frame_step, flipyz)
+    "animation" : generate_animation(option_animation_skeletal, option_frame_step, flipyz, 0),
+    "animations" : generate_all_animations(option_animation_skeletal, option_frame_step, flipyz, option_all_animations)
     }
 
     text = TEMPLATE_FILE_ASCII % {
@@ -1473,6 +1485,7 @@ def generate_mesh_string(objects, scene,
                 filepath,
                 option_animation_morph,
                 option_animation_skeletal,
+                option_all_animations,
                 option_frame_step):
 
     meshes = extract_meshes(objects, scene, export_single_model, option_scale, flipyz)
@@ -1537,6 +1550,7 @@ def generate_mesh_string(objects, scene,
                                 filepath,
                                 option_animation_morph,
                                 option_animation_skeletal,
+                                option_all_animations,
                                 option_frame_step)
 
     # remove temp meshes
@@ -1564,6 +1578,7 @@ def export_mesh(objects,
                 option_copy_textures,
                 option_animation_morph,
                 option_animation_skeletal,
+                option_all_animations,
                 option_frame_step):
 
     """Export single mesh"""
@@ -1587,6 +1602,7 @@ def export_mesh(objects,
                 filepath,
                 option_animation_morph,
                 option_animation_skeletal,
+                option_all_animations,
                 option_frame_step)
 
     write_file(filepath, text)
@@ -2323,6 +2339,7 @@ def save(operator, context, filepath = "",
          option_copy_textures = False,
          option_animation_morph = False,
          option_animation_skeletal = False,
+         option_all_animations = False,
          option_frame_step = 1,
          option_all_meshes = True):
 
@@ -2446,6 +2463,7 @@ def save(operator, context, filepath = "",
                     option_copy_textures,
                     option_animation_morph,
                     option_animation_skeletal,
+                    option_all_animations,
                     option_frame_step)
 
     return {'FINISHED'}

--- a/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -267,7 +267,6 @@ TEMPLATE_MODEL_ASCII = """\
 
 	"skinWeights" : [%(weights)s],
 
-	"animation"  : {%(animation)s},
         "animations" : [%(animations)s]
 """
 
@@ -933,9 +932,9 @@ def generate_animation(option_animation_skeletal, option_frame_step, flipyz, act
 
     return animation_string
 
-def generate_all_animations(option_animation_skeletal, option_frame_step, flipyz, option_all_animations):
+def generate_all_animations(option_animation_skeletal, option_frame_step, flipyz):
     all_animations_string = ""
-    if option_all_animations:
+    if option_animation_skeletal:
         for index in range(0, len(bpy.data.actions)):
             if index != 0 :
                 all_animations_string += ", \n"
@@ -1300,7 +1299,7 @@ def generate_ascii_model(meshes, morphs,
                          filepath,
                          option_animation_morph,
                          option_animation_skeletal,
-                         option_all_animations,
+                         #option_all_animations,
                          option_frame_step):
 
     vertices = []
@@ -1401,8 +1400,7 @@ def generate_ascii_model(meshes, morphs,
     "bones"     : bones_string,
     "indices"   : indices_string,
     "weights"   : weights_string,
-    "animation" : generate_animation(option_animation_skeletal, option_frame_step, flipyz, 0),
-    "animations" : generate_all_animations(option_animation_skeletal, option_frame_step, flipyz, option_all_animations)
+    "animations" : generate_all_animations(option_animation_skeletal, option_frame_step, flipyz)
     }
 
     text = TEMPLATE_FILE_ASCII % {
@@ -1485,7 +1483,7 @@ def generate_mesh_string(objects, scene,
                 filepath,
                 option_animation_morph,
                 option_animation_skeletal,
-                option_all_animations,
+                #option_all_animations,
                 option_frame_step):
 
     meshes = extract_meshes(objects, scene, export_single_model, option_scale, flipyz)
@@ -1550,7 +1548,7 @@ def generate_mesh_string(objects, scene,
                                 filepath,
                                 option_animation_morph,
                                 option_animation_skeletal,
-                                option_all_animations,
+                                #option_all_animations,
                                 option_frame_step)
 
     # remove temp meshes
@@ -1578,7 +1576,7 @@ def export_mesh(objects,
                 option_copy_textures,
                 option_animation_morph,
                 option_animation_skeletal,
-                option_all_animations,
+                #option_all_animations,
                 option_frame_step):
 
     """Export single mesh"""
@@ -1602,7 +1600,7 @@ def export_mesh(objects,
                 filepath,
                 option_animation_morph,
                 option_animation_skeletal,
-                option_all_animations,
+                #option_all_animations,
                 option_frame_step)
 
     write_file(filepath, text)
@@ -2339,7 +2337,7 @@ def save(operator, context, filepath = "",
          option_copy_textures = False,
          option_animation_morph = False,
          option_animation_skeletal = False,
-         option_all_animations = False,
+         #option_all_animations = False,
          option_frame_step = 1,
          option_all_meshes = True):
 
@@ -2463,7 +2461,7 @@ def save(operator, context, filepath = "",
                     option_copy_textures,
                     option_animation_morph,
                     option_animation_skeletal,
-                    option_all_animations,
+                    #option_all_animations,
                     option_frame_step)
 
     return {'FINISHED'}

--- a/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -1299,7 +1299,6 @@ def generate_ascii_model(meshes, morphs,
                          filepath,
                          option_animation_morph,
                          option_animation_skeletal,
-                         #option_all_animations,
                          option_frame_step):
 
     vertices = []
@@ -1483,7 +1482,6 @@ def generate_mesh_string(objects, scene,
                 filepath,
                 option_animation_morph,
                 option_animation_skeletal,
-                #option_all_animations,
                 option_frame_step):
 
     meshes = extract_meshes(objects, scene, export_single_model, option_scale, flipyz)
@@ -1548,7 +1546,6 @@ def generate_mesh_string(objects, scene,
                                 filepath,
                                 option_animation_morph,
                                 option_animation_skeletal,
-                                #option_all_animations,
                                 option_frame_step)
 
     # remove temp meshes
@@ -1576,7 +1573,6 @@ def export_mesh(objects,
                 option_copy_textures,
                 option_animation_morph,
                 option_animation_skeletal,
-                #option_all_animations,
                 option_frame_step):
 
     """Export single mesh"""
@@ -1600,7 +1596,6 @@ def export_mesh(objects,
                 filepath,
                 option_animation_morph,
                 option_animation_skeletal,
-                #option_all_animations,
                 option_frame_step)
 
     write_file(filepath, text)
@@ -2337,7 +2332,6 @@ def save(operator, context, filepath = "",
          option_copy_textures = False,
          option_animation_morph = False,
          option_animation_skeletal = False,
-         #option_all_animations = False,
          option_frame_step = 1,
          option_all_meshes = True):
 
@@ -2461,7 +2455,6 @@ def save(operator, context, filepath = "",
                     option_copy_textures,
                     option_animation_morph,
                     option_animation_skeletal,
-                    #option_all_animations,
                     option_frame_step)
 
     return {'FINISHED'}


### PR DESCRIPTION
Added support for multiple animations exported from blender 2.66 exporter, incorporating kontan's changes from https://github.com/mrdoob/three.js/issues/2899 .
