### PR TITLE
Fix up and unify support for AMD and node.js

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -6,13 +6,13 @@
 
 var THREE = THREE || { REVISION: '61' };
 
-self.console = self.console || {
+var console = {
 
-	info: function () {},
-	log: function () {},
-	debug: function () {},
-	warn: function () {},
-	error: function () {}
+	info: self.console.info || function () {},
+	log: self.console.log || function () {},
+	debug: self.console.debug || function () {},
+	warn: self.console.warn || function () {},
+	error: self.console.error || function () {}
 
 };
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -6,13 +6,13 @@
 
 var THREE = THREE || { REVISION: '61' };
 
-var console = {
+var console = self.console || {
 
-	info: self.console.info || function () {},
-	log: self.console.log || function () {},
-	debug: self.console.debug || function () {},
-	warn: self.console.warn || function () {},
-	error: self.console.error || function () {}
+	info: function () {},
+	log: function () {},
+	debug: function () {},
+	warn: function () {},
+	error: function () {}
 
 };
 

--- a/utils/build/build.py
+++ b/utils/build/build.py
@@ -44,6 +44,10 @@ def main(argv=None):
 	tmp = open(path, 'w')
 	sources = []
 
+	with open('header.js', 'r') as f:
+		tmp.write(f.read())
+		tmp.write('\n')
+
 	for include in args.include:
 		with open('includes/' + include + '.json','r') as f:
 			files = json.load(f)
@@ -53,6 +57,10 @@ def main(argv=None):
 			with open(filename, 'r') as f:
 				tmp.write(f.read())
 				tmp.write('\n')
+	
+	with open('footer.js', 'r') as f:
+		tmp.write(f.read())
+		tmp.write('\n')
 
 	tmp.close()
 
@@ -65,7 +73,7 @@ def main(argv=None):
 	else:
 
 		externs = ' --externs '.join(args.externs)
-		source = ' '.join(sources)
+		source = path
 		cmd = 'java -jar compiler/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --externs %s --jscomp_off=checkTypes --language_in=ECMASCRIPT5_STRICT --js %s --js_output_file %s %s' % (externs, source, output, sourcemapargs)
 		os.system(cmd)
 

--- a/utils/build/externs/common.js
+++ b/utils/build/externs/common.js
@@ -1,2 +1,4 @@
-var console;
 var JSON;
+var module;
+var define;
+var global;

--- a/utils/build/footer.js
+++ b/utils/build/footer.js
@@ -1,0 +1,14 @@
+if ( typeof module === "object" && module && typeof module.exports === "object" ) {
+	// Register as a node.js export
+	module.exports = THREE;
+}
+if ( typeof define === "function" && define.amd ) {
+	// Register as an AMD module.
+	define( [], function () { return THREE; } );
+}
+if ( typeof window === "object" && typeof window.document === "object" ) {
+	// Register as a window global
+	window.THREE = THREE;
+}
+
+})();

--- a/utils/build/header.js
+++ b/utils/build/header.js
@@ -1,0 +1,5 @@
+(function( undefined ) {
+
+var self = false;
+if(typeof window != 'undefined') self = window;
+else if(typeof global != 'undefined') self = global;


### PR DESCRIPTION
Don't touch console global
Export lib as node module, AMD module, and window global

I've tested this locally with node.js on both the standard and minified libraries.
The AMD loader test is here: https://demo.sites.team9000.net/tests/loader/require.html
The typical loader test is here: https://demo.sites.team9000.net/tests/loader/standard.html
