### PR TITLE
Editor: Keyboard navigation of the sidebar scene graph

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -332,6 +332,34 @@ UI.FancySelect = function () {
 	dom.style.padding = '0';
 	dom.style.cursor = 'default';
 	dom.style.overflow = 'auto';
+	dom.tabIndex = 0;	// keyup event is ignored without setting tabIndex
+
+	// Broadcast for object selection after arrow navigation
+	var changeEvent = document.createEvent('HTMLEvents');
+	changeEvent.initEvent( 'change', true, true );
+
+	// Keybindings to support arrow navigation
+	dom.addEventListener( 'keyup', function (event) {
+
+		switch ( event.keyCode ) {
+			case 38: // up
+			case 40: // down
+				var index = scope.indexOf( scope.selectedValue );
+				index += ( event.keyCode == 38 ) ? -1 : 1;
+
+				if ( index >= 0 && index < scope.options.length ) {
+
+					// Select dom element
+					scope.setValue( scope.options[index].value );
+
+					// Invoke object selection logic
+					scope.dom.dispatchEvent( changeEvent );
+
+				}
+
+				break;
+		}
+	}, false);
 
 	this.dom = dom;
 
@@ -426,6 +454,27 @@ UI.FancySelect.prototype.setValue = function ( value ) {
 	return this;
 
 };
+
+UI.FancySelect.prototype.indexOf = function ( key ) {
+
+	if ( typeof key === 'number' ) key = key.toString();
+
+	// Iterate options and return the index of the first occurrence of the key
+	for ( var i = 0; i < this.options.length; i++ ) {
+
+		var element = this.options[i];
+
+		if ( element.value === key ) {
+
+			test = element;
+			return i;
+
+		}
+	}
+
+	return -1
+};
+
 
 // Checkbox
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -338,6 +338,19 @@ UI.FancySelect = function () {
 	var changeEvent = document.createEvent('HTMLEvents');
 	changeEvent.initEvent( 'change', true, true );
 
+	// Prevent native scroll behavior
+	dom.addEventListener( 'keydown', function (event) {
+
+		switch ( event.keyCode ) {
+			case 38: // up
+			case 40: // down
+				event.preventDefault();
+				event.stopPropagation();
+				break;
+		}
+
+	}, false);
+
 	// Keybindings to support arrow navigation
 	dom.addEventListener( 'keyup', function (event) {
 
@@ -349,10 +362,10 @@ UI.FancySelect = function () {
 
 				if ( index >= 0 && index < scope.options.length ) {
 
-					// Select dom element
+					// Highlight selected dom elem and scroll parent if needed
 					scope.setValue( scope.options[index].value );
 
-					// Invoke object selection logic
+					// Invoke object/helper/mesh selection logic
 					scope.dom.dispatchEvent( changeEvent );
 
 				}
@@ -431,13 +444,17 @@ UI.FancySelect.prototype.setValue = function ( value ) {
 
 			// scroll into view
 
-			var y = i * element.clientHeight;
-			var scrollTop = this.dom.scrollTop;
-			var domHeight = this.dom.clientHeight;
+			var y = element.offsetTop - this.dom.offsetTop,
+				bottomY = y + element.offsetHeight,
+				minScroll = bottomY - this.dom.offsetHeight;
 
-			if ( y < scrollTop || y > scrollTop + domHeight ) {
+			if ( this.dom.scrollTop > y ) {
 
-				this.dom.scrollTop = y;
+				this.dom.scrollTop = y
+
+			} else if ( this.dom.scrollTop < minScroll ) {
+
+				this.dom.scrollTop = minScroll;
 
 			}
 


### PR DESCRIPTION
Added keyboard navigation to the FancySelect control displayed in the sidebar, initially enabling the use of the up or down arrows keys to move through items. Also revised the scrolling logic as it didn't quite match normal control behavior or work correctly in all cases. This is probably best depicted with a screencast: http://screencast.com/t/NYnSeueyge. The key issues seemed to be:
- Some items fail to scroll into view - the first item requiring scroll doesn't fire correctly and selection occurs off-screen 
- An inconsistency between scroll up and scroll down behavior, where scroll down pages while scroll up single steps. More often scrollable controls tend to push one step in the required direction as needed.

Not sure if it's a feature you'd like to include but figured it was worth checking
