### PR TITLE
Fixed webgl_geometry_extrude_shapes.html example for IE11

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -86,6 +86,13 @@ Editor.prototype = {
 
 	},
 
+	setObjectName: function ( object, name ) {
+
+		object.name = name;
+		this.signals.sceneGraphChanged.dispatch();
+
+	},
+
 	removeObject: function ( object ) {
 
 		if ( object.parent === undefined ) return; // avoid deleting the camera or scene
@@ -113,9 +120,23 @@ Editor.prototype = {
 
 	},
 
+	setGeometryName: function ( geometry, name ) {
+
+		geometry.name = name;
+		this.signals.sceneGraphChanged.dispatch();
+
+	},
+
 	addMaterial: function ( material ) {
 
 		this.materials[ material.uuid ] = material;
+
+	},
+
+	setMaterialName: function ( material, name ) {
+
+		material.name = name;
+		this.signals.sceneGraphChanged.dispatch();
 
 	},
 

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -58,11 +58,18 @@ Editor.prototype = {
 		this.scene.name = scene.name;
 		this.scene.userData = JSON.parse( JSON.stringify( scene.userData ) );
 
+		// avoid render per object
+
+		this.signals.sceneGraphChanged.active = false;
+
 		while ( scene.children.length > 0 ) {
 
 			this.addObject( scene.children[ 0 ] );
 
 		}
+
+		this.signals.sceneGraphChanged.active = true;
+		this.signals.sceneGraphChanged.dispatch();
 
 	},
 

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -17,6 +17,8 @@ var Editor = function () {
 
 		sceneGraphChanged: new SIGNALS.Signal(),
 
+		cameraChanged: new SIGNALS.Signal(),
+
 		objectSelected: new SIGNALS.Signal(),
 		objectAdded: new SIGNALS.Signal(),
 		objectChanged: new SIGNALS.Signal(),

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -35,6 +35,7 @@ var Loader = function ( editor ) {
 	signals.objectAdded.add( this.saveLocalStorage );
 	signals.objectChanged.add( this.saveLocalStorage );
 	signals.objectRemoved.add( this.saveLocalStorage );
+	signals.sceneGraphChanged.add( this.saveLocalStorage );
 
 	this.loadFile = function ( file ) {
 

--- a/editor/js/Sidebar.Geometry.js
+++ b/editor/js/Sidebar.Geometry.js
@@ -17,7 +17,8 @@ Sidebar.Geometry = function ( editor ) {
 	var geometryUUIDRenew = new UI.Button( '⟳' ).setMarginLeft( '7px' ).onClick( function () {
 
 		geometryUUID.setValue( THREE.Math.generateUUID() );
-		update();
+
+		editor.selected.geometry.uuid = geometryUUID.getValue();
 
 	} );
 
@@ -30,7 +31,11 @@ Sidebar.Geometry = function ( editor ) {
 	// name
 
 	var geometryNameRow = new UI.Panel();
-	var geometryName = new UI.Input().setWidth( '150px' ).setColor( '#444' ).setFontSize( '12px' ).onChange( update );
+	var geometryName = new UI.Input().setWidth( '150px' ).setColor( '#444' ).setFontSize( '12px' ).onChange( function () {
+
+		editor.setGeometryName( editor.selected.geometry, geometryName.getValue() );
+
+	} );
 
 	geometryNameRow.add( new UI.Text( 'Name' ).setWidth( '90px' ).setColor( '#666' ) );
 	geometryNameRow.add( geometryName );
@@ -73,15 +78,6 @@ Sidebar.Geometry = function ( editor ) {
 
 
 	//
-
-	function update() {
-
-		var geometry = editor.selected.geometry;
-
-		geometry.uuid = geometryUUID.getValue();
-		geometry.name = geometryName.getValue();
-
-	}
 
 	function build() {
 

--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -47,7 +47,11 @@ Sidebar.Material = function ( editor ) {
 	// name
 
 	var materialNameRow = new UI.Panel();
-	var materialName = new UI.Input().setWidth( '150px' ).setColor( '#444' ).setFontSize( '12px' ).onChange( update );
+	var materialName = new UI.Input().setWidth( '150px' ).setColor( '#444' ).setFontSize( '12px' ).onChange( function () {
+
+		editor.setMaterialName( editor.selected.material, materialName.getValue() );
+
+	} );
 
 	materialNameRow.add( new UI.Text( 'Name' ).setWidth( '90px' ).setColor( '#666' ) );
 	materialNameRow.add( materialName );
@@ -314,12 +318,6 @@ Sidebar.Material = function ( editor ) {
 			if ( material.uuid !== undefined ) {
 
 				material.uuid = materialUUID.getValue();
-
-			}
-
-			if ( material.name !== undefined ) {
-
-				material.name = materialName.getValue();
 
 			}
 

--- a/editor/js/Sidebar.Object3D.js
+++ b/editor/js/Sidebar.Object3D.js
@@ -18,7 +18,8 @@ Sidebar.Object3D = function ( editor ) {
 	var objectUUIDRenew = new UI.Button( '⟳' ).setMarginLeft( '7px' ).onClick( function () {
 
 		objectUUID.setValue( THREE.Math.generateUUID() );
-		update();
+
+		editor.selected.uuid = objectUUID.getValue();
 
 	} );
 
@@ -31,7 +32,11 @@ Sidebar.Object3D = function ( editor ) {
 	// name
 
 	var objectNameRow = new UI.Panel();
-	var objectName = new UI.Input().setWidth( '150px' ).setColor( '#444' ).setFontSize( '12px' ).onChange( update );
+	var objectName = new UI.Input().setWidth( '150px' ).setColor( '#444' ).setFontSize( '12px' ).onChange( function () {
+
+			editor.setObjectName( editor.selected, objectName.getValue() );
+
+	} );
 
 	objectNameRow.add( new UI.Text( 'Name' ).setWidth( '90px' ).setColor( '#666' ) );
 	objectNameRow.add( objectName );
@@ -271,9 +276,6 @@ Sidebar.Object3D = function ( editor ) {
 		var object = editor.selected;
 
 		if ( object !== null ) {
-
-			object.uuid = objectUUID.getValue();
-			object.name = objectName.getValue();
 
 			if ( object.parent !== undefined ) {
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -44,9 +44,10 @@ var Viewport = function ( editor ) {
 	transformControls.addEventListener( 'change', function () {
 
         controls.enabled = true;
+
         if ( transformControls.axis ) controls.enabled = false;
         
-		if (editor.selected) signals.objectChanged.dispatch( editor.selected );
+		if ( editor.selected ) signals.objectChanged.dispatch( editor.selected );
 
 	} );
 	sceneHelpers.add( transformControls );
@@ -166,7 +167,7 @@ var Viewport = function ( editor ) {
 	controls.addEventListener( 'change', function () {
 
 		transformControls.update();
-		signals.objectChanged.dispatch( camera );
+		signals.cameraChanged.dispatch( camera );
 
 	} );
 
@@ -210,6 +211,12 @@ var Viewport = function ( editor ) {
 
 		render();
 		updateInfo();
+
+	} );
+
+	signals.cameraChanged.add( function () {
+
+		render();
 
 	} );
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -261,18 +261,35 @@ THREE.TransformGizmoTranslate = function () {
 	this.pickerGizmos = {
 
 		X: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.075, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "red", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "red", opacity: 0.25 } ) ),
 			new THREE.Vector3( 0.6, 0, 0 ),
 			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.075, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "green", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "green", opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0.6, 0 )
 		],
 		Z: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.075, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "blue", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "blue", opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0.6 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
+		],
+		XYZ: [
+			new THREE.Mesh( new THREE.OctahedronGeometry( 0.2, 0 ), new THREE.TransformGizmoMaterial( { color: "white", opacity: 0.25 } ) )
+		],
+		XY: [
+			new THREE.Mesh( new THREE.PlaneGeometry( 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: "yellow", opacity: 0.25 } ) ),
+			new THREE.Vector3( 0.2, 0.2, 0 )
+		],
+		YZ: [
+			new THREE.Mesh( new THREE.PlaneGeometry( 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: "cyan", opacity: 0.25 } ) ),
+			new THREE.Vector3( 0, 0.2, 0.2 ),
+			new THREE.Vector3( 0, Math.PI/2, 0 )
+		],
+		XZ: [
+			new THREE.Mesh( new THREE.PlaneGeometry( 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: "magenta", opacity: 0.25 } ) ),
+			new THREE.Vector3( 0.2, 0, 0.2 ),
+			new THREE.Vector3( -Math.PI/2, 0, 0 )
 		]
 
 	}
@@ -349,22 +366,22 @@ THREE.TransformGizmoRotate = function () {
 	this.pickerGizmos = {
 
 		X: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.05, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: "red", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: "red", opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0 ),
 			new THREE.Vector3( 0, -Math.PI/2, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.05, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: "green", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: "green", opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
 		],
 		Z: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.05, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: "blue", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: "blue", opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0 ),
 			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		E: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1.25, 0.05, 2, 24 ), new THREE.TransformGizmoMaterial( { color: "yellow", opacity: 0.25 } ) )
+			new THREE.Mesh( new THREE.TorusGeometry( 1.25, 0.12, 2, 24 ), new THREE.TransformGizmoMaterial( { color: "yellow", opacity: 0.25 } ) )
 		],
 		XYZE: [
 			new THREE.Mesh( new THREE.Geometry() ) // TODO
@@ -461,9 +478,6 @@ THREE.TransformGizmoScale = function () {
 
 	this.handleGizmos = {
 
-		XYZ: [
-			new THREE.Mesh( new THREE.CubeGeometry( 0.125, 0.125, 0.125 ), new THREE.TransformGizmoMaterial( { color: "white", opacity: 0.25 } ) )
-		],
 		X: [
 			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: "red" } ) ),
 			new THREE.Vector3( 0.5, 0, 0 ),
@@ -477,6 +491,9 @@ THREE.TransformGizmoScale = function () {
 			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: "blue" } ) ),
 			new THREE.Vector3( 0, 0, 0.5 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
+		],
+		XYZ: [
+			new THREE.Mesh( new THREE.CubeGeometry( 0.125, 0.125, 0.125 ), new THREE.TransformGizmoMaterial( { color: "white", opacity: 0.25 } ) )
 		]
 
 	}
@@ -484,21 +501,22 @@ THREE.TransformGizmoScale = function () {
 	this.pickerGizmos = {
 
 		X: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.125, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "red", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "red", opacity: 0.25 } ) ),
 			new THREE.Vector3( 0.6, 0, 0 ),
-			new THREE.Vector3( Math.PI/4, 0, -Math.PI/2 )
+			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.125, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "green", opacity: 0.25 } ) ),
-			new THREE.Vector3( 0, 0.6, 0 ),
-			new THREE.Vector3( 0, Math.PI/4, 0 )
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "green", opacity: 0.25 } ) ),
+			new THREE.Vector3( 0, 0.6, 0 )
 		],
 		Z: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.125, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "blue", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "blue", opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0.6 ),
-			new THREE.Vector3( Math.PI/2, Math.PI/4, 0 )
+			new THREE.Vector3( Math.PI/2, 0, 0 )
+		],
+		XYZ: [
+			new THREE.Mesh( new THREE.CubeGeometry( 0.4, 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: "white", opacity: 0.25 } ) )
 		]
-
 	}
 
 	this.setActivePlane = function ( axis, eye ) {
@@ -634,7 +652,6 @@ THREE.TransformControls = function ( camera, domElement ) {
 	 	this.gizmo["scale"].hide();
 	 	this.gizmo[_mode].show();
 
-	 	scope.dispatchEvent( changeEvent );
 	 	scope.update();
 
 	}
@@ -661,7 +678,6 @@ THREE.TransformControls = function ( camera, domElement ) {
 	 	this.gizmo["scale"].hide();	
 	 	this.gizmo[_mode].show();
 
-	 	scope.dispatchEvent( changeEvent );
 		this.update();
 
 	}
@@ -675,7 +691,6 @@ THREE.TransformControls = function ( camera, domElement ) {
 	this.setSize = function ( size ) {
 
 		scope.size = size;
-	 	scope.dispatchEvent( changeEvent );
 		this.update();
 	 	
 	}
@@ -684,7 +699,6 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		scope.space = space;
 
-	 	scope.dispatchEvent( changeEvent );
 		this.update();
 
 	}
@@ -715,6 +729,8 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		this.gizmo[_mode].highlight( scope.axis );
 
+		scope.dispatchEvent( changeEvent );
+
 	}
 
 	function onPointerHover( event ) {
@@ -731,13 +747,11 @@ THREE.TransformControls = function ( camera, domElement ) {
 		if ( intersect ) {
 
 			scope.axis = intersect.object.name;
-			scope.dispatchEvent( changeEvent );
 			scope.update();
 
 		} else {
 
 			scope.axis = false;
-			scope.dispatchEvent( changeEvent );
 			scope.update();
 
 		}
@@ -959,7 +973,6 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		}
 
-		scope.dispatchEvent( changeEvent );
 		scope.update();
 
 	}
@@ -968,7 +981,6 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		scope.axis = false;
 		_dragging = false;
-		scope.dispatchEvent( changeEvent );
 		scope.update();
 
 	}

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -23,16 +23,16 @@ THREE.TransformGizmo = function () {
 
 	this.handleGizmos = {
 		X: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.005, 0.005, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "red" } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.005, 0.005, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: 0xff0000 } ) ),
 			new THREE.Vector3( 0.5, 0, 0 ),
 			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.005, 0.005, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "green" } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.005, 0.005, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: 0x00ff00 } ) ),
 			new THREE.Vector3( 0, 0.5, 0 )
 		],
 		Z: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.005, 0.005, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "blue" } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.005, 0.005, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: 0x0000ff } ) ),
 			new THREE.Vector3( 0, 0, 0.5 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
 		]
@@ -226,33 +226,33 @@ THREE.TransformGizmoTranslate = function () {
 	this.handleGizmos = {
 
 		X: [
-			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: "red" } ) ),
+			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: 0xff0000 } ) ),
 			new THREE.Vector3( 0.5, 0, 0 ),
 			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: "green" } ) ),
+			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: 0x00ff00 } ) ),
 			new THREE.Vector3( 0, 0.5, 0 )
 		],
 		Z: [
-			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: "blue" } ) ),
+			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: 0x0000ff } ) ),
 			new THREE.Vector3( 0, 0, 0.5 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
 		],
 		XYZ: [
-			new THREE.Mesh( new THREE.OctahedronGeometry( 0.1, 0 ), new THREE.TransformGizmoMaterial( { color: "white", opacity: 0.25 } ) )
+			new THREE.Mesh( new THREE.OctahedronGeometry( 0.1, 0 ), new THREE.TransformGizmoMaterial( { color: 0xffffff, opacity: 0.25 } ) )
 		],
 		XY: [
-			new THREE.Mesh( new THREE.PlaneGeometry( 0.29, 0.29 ), new THREE.TransformGizmoMaterial( { color: "yellow", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.PlaneGeometry( 0.29, 0.29 ), new THREE.TransformGizmoMaterial( { color: 0xffff00, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0.15, 0.15, 0 )
 		],
 		YZ: [
-			new THREE.Mesh( new THREE.PlaneGeometry( 0.29, 0.29 ), new THREE.TransformGizmoMaterial( { color: "cyan", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.PlaneGeometry( 0.29, 0.29 ), new THREE.TransformGizmoMaterial( { color: 0x00ffff, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0.15, 0.15 ),
 			new THREE.Vector3( 0, Math.PI/2, 0 )
 		],
 		XZ: [
-			new THREE.Mesh( new THREE.PlaneGeometry( 0.29, 0.29 ), new THREE.TransformGizmoMaterial( { color: "magenta", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.PlaneGeometry( 0.29, 0.29 ), new THREE.TransformGizmoMaterial( { color: 0xff00ff, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0.15, 0, 0.15 ),
 			new THREE.Vector3( -Math.PI/2, 0, 0 )
 		]
@@ -262,33 +262,33 @@ THREE.TransformGizmoTranslate = function () {
 	this.pickerGizmos = {
 
 		X: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "red", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: 0xff0000, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0.6, 0, 0 ),
 			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "green", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: 0x00ff00, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0.6, 0 )
 		],
 		Z: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "blue", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: 0x0000ff, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0.6 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
 		],
 		XYZ: [
-			new THREE.Mesh( new THREE.OctahedronGeometry( 0.2, 0 ), new THREE.TransformGizmoMaterial( { color: "white", opacity: 0.25 } ) )
+			new THREE.Mesh( new THREE.OctahedronGeometry( 0.2, 0 ), new THREE.TransformGizmoMaterial( { color: 0xffffff, opacity: 0.25 } ) )
 		],
 		XY: [
-			new THREE.Mesh( new THREE.PlaneGeometry( 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: "yellow", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.PlaneGeometry( 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: 0xffff00, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0.2, 0.2, 0 )
 		],
 		YZ: [
-			new THREE.Mesh( new THREE.PlaneGeometry( 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: "cyan", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.PlaneGeometry( 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: 0x00ffff, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0.2, 0.2 ),
 			new THREE.Vector3( 0, Math.PI/2, 0 )
 		],
 		XZ: [
-			new THREE.Mesh( new THREE.PlaneGeometry( 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: "magenta", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.PlaneGeometry( 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: 0xff00ff, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0.2, 0, 0.2 ),
 			new THREE.Vector3( -Math.PI/2, 0, 0 )
 		]
@@ -341,25 +341,25 @@ THREE.TransformGizmoRotate = function () {
 	this.handleGizmos = {
 
 		X: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.005, 4, 32, Math.PI ), new THREE.TransformGizmoMaterial( { color: "red" } ) ),
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.005, 4, 32, Math.PI ), new THREE.TransformGizmoMaterial( { color: 0xff0000 } ) ),
 			new THREE.Vector3( 0, 0, 0 ),
 			new THREE.Vector3( 0, -Math.PI/2, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.005, 4, 32, Math.PI ), new THREE.TransformGizmoMaterial( { color: "green" } ) ),
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.005, 4, 32, Math.PI ), new THREE.TransformGizmoMaterial( { color: 0x00ff00 } ) ),
 			new THREE.Vector3( 0, 0, 0 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
 		],
 		Z: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.005, 4, 32, Math.PI ), new THREE.TransformGizmoMaterial( { color: "blue" } ) ),
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.005, 4, 32, Math.PI ), new THREE.TransformGizmoMaterial( { color: 0x0000ff } ) ),
 			new THREE.Vector3( 0, 0, 0 ),
 			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		E: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1.25, 0.005, 4, 64 ), new THREE.TransformGizmoMaterial( { color: "yellow", opacity: 0.25 } ) )
+			new THREE.Mesh( new THREE.TorusGeometry( 1.25, 0.005, 4, 64 ), new THREE.TransformGizmoMaterial( { color: 0xffff00, opacity: 0.25 } ) )
 		],
 		XYZE: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.005, 4, 64 ), new THREE.TransformGizmoMaterial( { color: "gray" } ) )
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.005, 4, 64 ), new THREE.TransformGizmoMaterial( { color: 0x787878 } ) )
 		]
 
 	}
@@ -367,22 +367,22 @@ THREE.TransformGizmoRotate = function () {
 	this.pickerGizmos = {
 
 		X: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: "red", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: 0xff0000, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0 ),
 			new THREE.Vector3( 0, -Math.PI/2, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: "green", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: 0x00ff00, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
 		],
 		Z: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: "blue", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), new THREE.TransformGizmoMaterial( { color: 0x0000ff, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0 ),
 			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		E: [
-			new THREE.Mesh( new THREE.TorusGeometry( 1.25, 0.12, 2, 24 ), new THREE.TransformGizmoMaterial( { color: "yellow", opacity: 0.25 } ) )
+			new THREE.Mesh( new THREE.TorusGeometry( 1.25, 0.12, 2, 24 ), new THREE.TransformGizmoMaterial( { color: 0xffff00, opacity: 0.25 } ) )
 		],
 		XYZE: [
 			new THREE.Mesh( new THREE.Geometry() ) // TODO
@@ -480,21 +480,21 @@ THREE.TransformGizmoScale = function () {
 	this.handleGizmos = {
 
 		X: [
-			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: "red" } ) ),
+			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: 0xff0000 } ) ),
 			new THREE.Vector3( 0.5, 0, 0 ),
 			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: "green" } ) ),
+			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: 0x00ff00 } ) ),
 			new THREE.Vector3( 0, 0.5, 0 )
 		],
 		Z: [
-			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: "blue" } ) ),
+			new THREE.Mesh( arrowGeometry, new THREE.TransformGizmoMaterial( { color: 0x0000ff } ) ),
 			new THREE.Vector3( 0, 0, 0.5 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
 		],
 		XYZ: [
-			new THREE.Mesh( new THREE.CubeGeometry( 0.125, 0.125, 0.125 ), new THREE.TransformGizmoMaterial( { color: "white", opacity: 0.25 } ) )
+			new THREE.Mesh( new THREE.CubeGeometry( 0.125, 0.125, 0.125 ), new THREE.TransformGizmoMaterial( { color: 0xffffff, opacity: 0.25 } ) )
 		]
 
 	}
@@ -502,21 +502,21 @@ THREE.TransformGizmoScale = function () {
 	this.pickerGizmos = {
 
 		X: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "red", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: 0xff0000, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0.6, 0, 0 ),
 			new THREE.Vector3( 0, 0, -Math.PI/2 )
 		],
 		Y: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "green", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: 0x00ff00, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0.6, 0 )
 		],
 		Z: [
-			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: "blue", opacity: 0.25 } ) ),
+			new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), new THREE.TransformGizmoMaterial( { color: 0x0000ff, opacity: 0.25 } ) ),
 			new THREE.Vector3( 0, 0, 0.6 ),
 			new THREE.Vector3( Math.PI/2, 0, 0 )
 		],
 		XYZ: [
-			new THREE.Mesh( new THREE.CubeGeometry( 0.4, 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: "white", opacity: 0.25 } ) )
+			new THREE.Mesh( new THREE.CubeGeometry( 0.4, 0.4, 0.4 ), new THREE.TransformGizmoMaterial( { color: 0xffffff, opacity: 0.25 } ) )
 		]
 	}
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -680,6 +680,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 	 	this.gizmo[_mode].show();
 
 		this.update();
+		scope.dispatchEvent( changeEvent );
 
 	}
 
@@ -693,14 +694,15 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		scope.size = size;
 		this.update();
+		scope.dispatchEvent( changeEvent );
 	 	
 	}
 
 	this.setSpace = function ( space ) {
 
 		scope.space = space;
-
 		this.update();
+		scope.dispatchEvent( changeEvent );
 
 	}
 
@@ -737,7 +739,6 @@ THREE.TransformControls = function ( camera, domElement ) {
 		if ( scope.object === undefined || _dragging == true ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		var pointer = event.touches? event.touches[0] : event;
 

--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -117,8 +117,8 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 							var ctmFile = files[ i ];
 
-                            var e1 = Date.now();
-                            // console.log( "CTM data parse time [worker]: " + (e1-s) + " ms" );
+                            				var e1 = Date.now();
+                            				// console.log( "CTM data parse time [worker]: " + (e1-s) + " ms" );
 
 							if ( useBuffers ) {
 
@@ -130,8 +130,8 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 							}
 
-                            var e = Date.now();
-                            console.log( "model load time [worker]: " + (e-e1) + " ms, total: " + (e-s));
+                            				var e = Date.now();
+                            				console.log( "model load time [worker]: " + (e-e1) + " ms, total: " + (e-s));
 
 						}
 
@@ -234,57 +234,57 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 		// (needed for buffer splitting, to keep together face vertices)
 		if ( reorderVertices ) {
 
-            function copyVertexInfo(v, vt) {
+		    	function copyVertexInfo(v, vt) {
 
-                var sx = v * 3,
-                    sy = v * 3 + 1,
-                    sz = v * 3 + 2,
+				var sx = v * 3,
+			    	    sy = v * 3 + 1,
+			    	    sz = v * 3 + 2,
 
-                    dx = vt * 3,
-                    dy = vt * 3 + 1,
-                    dz = vt * 3 + 2;
+			    	dx = vt * 3,
+			    	dy = vt * 3 + 1,
+			    	dz = vt * 3 + 2;
 
-                newVertices[ dx ] = vertexPositionArray[ sx ];
-                newVertices[ dy ] = vertexPositionArray[ sy ];
-                newVertices[ dz ] = vertexPositionArray[ sz ];
+				newVertices[ dx ] = vertexPositionArray[ sx ];
+				newVertices[ dy ] = vertexPositionArray[ sy ];
+				newVertices[ dz ] = vertexPositionArray[ sz ];
 
-                if ( vertexNormalArray ) {
-                    newNormals[ dx ] = vertexNormalArray[ sx ];
-                    newNormals[ dy ] = vertexNormalArray[ sy ];
-                    newNormals[ dz ] = vertexNormalArray[ sz ];
-                }
+				if ( vertexNormalArray ) {
+				    newNormals[ dx ] = vertexNormalArray[ sx ];
+				    newNormals[ dy ] = vertexNormalArray[ sy ];
+				    newNormals[ dz ] = vertexNormalArray[ sz ];
+				}
 
-                if ( vertexUvArray ) {
-                    newUvs[ vt * 2 ] 	 = vertexUvArray[ v * 2 ];
-                    newUvs[ vt * 2 + 1 ] = vertexUvArray[ v * 2 + 1 ];
-                }
+				if ( vertexUvArray ) {
+				    newUvs[ vt * 2 ] 	 = vertexUvArray[ v * 2 ];
+				    newUvs[ vt * 2 + 1 ] = vertexUvArray[ v * 2 + 1 ];
+				}
 
-                if ( vertexColorArray ) {
-                    newColors[ vt * 4 ] 	= vertexColorArray[ v * 4 ];
-                    newColors[ vt * 4 + 1 ] = vertexColorArray[ v * 4 + 1 ];
-                    newColors[ vt * 4 + 2 ] = vertexColorArray[ v * 4 + 2 ];
-                    newColors[ vt * 4 + 3 ] = vertexColorArray[ v * 4 + 3 ];
-                }
-            }
+				if ( vertexColorArray ) {
+				    newColors[ vt * 4 ] 	= vertexColorArray[ v * 4 ];
+				    newColors[ vt * 4 + 1 ] = vertexColorArray[ v * 4 + 1 ];
+				    newColors[ vt * 4 + 2 ] = vertexColorArray[ v * 4 + 2 ];
+				    newColors[ vt * 4 + 3 ] = vertexColorArray[ v * 4 + 3 ];
+				}
+		    	}
 
-			function handleVertex( v, iMap ) {
+		    	function handleVertex( v, iMap ) {
 
 				if ( iMap[ v ] === undefined ) {
 
 					iMap[ v ] = vertexCounter;
-                    reverseIndexMap[vertexCounter] = v;
+                    			reverseIndexMap[vertexCounter] = v;
 					vertexCounter += 1;
 				}
-                return iMap[ v ];
-			}
+                		return iMap[ v ];
+		    	}
 
 			var newFaces = new Uint32Array( vertexIndexArray.length );
 			var indexMap = {}, reverseIndexMap = {}, vertexCounter = 0;
 
-            // in most Reality Capture models < 1% of faces**2 are sprawled, for complex CAD/CAM > 2%
-            var spawledFaceCount = 0,
-                spawledFaceLimit = Math.ceil(vertexIndexArray.length/3000);
-            var sprawledFaces = new Uint32Array( spawledFaceLimit );  // to store sprawled triangle indices
+            		// in most Reality Capture models < 1% of faces**2 are sprawled, for complex CAD/CAM > 2%
+            		var spawledFaceCount = 0,
+                	    spawledFaceLimit = Math.ceil(vertexIndexArray.length/3000);
+            		var sprawledFaces = new Uint32Array( spawledFaceLimit );  // to store sprawled triangle indices
 
 			for ( var i = 0; i < vertexIndexArray.length; i += 3 ) {
 
@@ -298,56 +298,57 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 
 				// check for sprawled triangles and put them aside to recreate later
 				if ( Math.abs( indexMap[a] - indexMap[b] ) > 65535 ||
-                     Math.abs( indexMap[b] - indexMap[c] ) > 65535 ||
-                     Math.abs( indexMap[c] - indexMap[a] ) > 65535 ){
+                     		     Math.abs( indexMap[b] - indexMap[c] ) > 65535 ||
+                     		     Math.abs( indexMap[c] - indexMap[a] ) > 65535 ){
 
-                    // expand storage when neccessary
-                    if (spawledFaceCount >= spawledFaceLimit) {
-                        console.warn("reached sprawled faces limit: " + spawledFaceCount);
-                        spawledFaceLimit *= 2;
-                        var tArr = new Uint32Array( spawledFaceLimit );
-                        tArr.set(sprawledFaces);
-                        sprawledFaces = tArr;
-                    }
+			    		// expand storage when neccessary
+			    		if (spawledFaceCount >= spawledFaceLimit) {
+						console.warn("reached sprawled faces limit: " + spawledFaceCount);
+						spawledFaceLimit *= 2;
+						var tArr = new Uint32Array( spawledFaceLimit );
+						tArr.set(sprawledFaces);
+						sprawledFaces = tArr;
+			    		}
 
-                    sprawledFaces[ spawledFaceCount ] = i;  // starting index in newFaces
-                    spawledFaceCount += 1;
-                }
-                else {
+                    			sprawledFaces[ spawledFaceCount ] = i;  // starting index in newFaces
+                    			spawledFaceCount += 1;
+                		}
+                		else {
 
 				    newFaces[ i ] 	  = indexMap[ a ];
 				    newFaces[ i + 1 ] = indexMap[ b ];
 				    newFaces[ i + 2 ] = indexMap[ c ];
-                }
+                		}
 			}
-            console.log("Number of sprawled faces: " + spawledFaceCount + " current limit: " + spawledFaceLimit +
-                        " total: " + vertexIndexArray.length/3 + " vertices: " + vertexCounter);
+            		// console.log("Number of sprawled faces: " + spawledFaceCount + " current limit: " + spawledFaceLimit +
+                        //	" total: " + vertexIndexArray.length/3 + " vertices: " + vertexCounter);
 
-            // create dublicate vertices and update sprawled faces
-            var indexMap2 = {},
-                noov = vertexCounter;   // # of original vertices
+			// create dublicate vertices and update sprawled faces
+			var indexMap2 = {},
+			    noov = vertexCounter;   // # of original vertices
 
-            for (var isf = 0; isf < spawledFaceCount; isf++ ) {
-                var i = sprawledFaces[isf];
+			for (var isf = 0; isf < spawledFaceCount; isf++ ) {
+				var i = sprawledFaces[isf];
 
-                for (var j = 0; j < 3; j++) {
-                    var v = vertexIndexArray[ i + j ];
-                    newFaces[ i + j] = handleVertex(v, indexMap2);   // new vertex
-                }
-            }
-            // console.log("Created duplicated vertices: " + (vertexCounter - noov));
+				for (var j = 0; j < 3; j++) {
+				    var v = vertexIndexArray[ i + j ];
+				    newFaces[ i + j] = handleVertex(v, indexMap2);   // new vertex
+				}
+			}
 
-            // copy xyz, uv, normals and colors into new arrays
-            var newVertices = new Float32Array( 3*vertexCounter );
+			// console.log("Created duplicated vertices: " + (vertexCounter - noov));
+
+			// copy xyz, uv, normals and colors into new arrays
+			var newVertices = new Float32Array( 3*vertexCounter );
 			var newNormals, newUvs, newColors;
 
 			if ( vertexNormalArray ) newNormals = new Float32Array( 3*vertexCounter );
 			if ( vertexUvArray ) newUvs = new Float32Array( 2*vertexCounter );
 			if ( vertexColorArray ) newColors = new Float32Array( 4*vertexCounter );
 
-            for (var iv = 0; iv < vertexCounter; iv++) {
-                copyVertexInfo(reverseIndexMap[iv], iv);
-            }
+			for (var iv = 0; iv < vertexCounter; iv++) {
+				copyVertexInfo(reverseIndexMap[iv], iv);
+			}
 
 			vertexIndexArray = newFaces;
 			vertexPositionArray = newVertices;
@@ -383,7 +384,7 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 
 				i -= 3;
 
-                if ( minPrev > 0 ) {
+                		if ( minPrev > 0 ) {
 
 				    for ( var k = start; k < i; ++ k )
 					    indices[ k ] -= minPrev;
@@ -401,15 +402,15 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 
 		}
 
-        if ( minPrev > 0 ) {
+        	if ( minPrev > 0 ) {
 
 		    for ( var k = start; k < i; ++ k )
 			    indices[ k ] -= minPrev;
 		}
 		scope.offsets.push( { start: start, count: i - start, index: minPrev } );
 
-        var e = Date.now();
-		console.log( "Vetex reordering time: " + (e-s) + " ms" );
+        	// var e = Date.now();
+		// console.log( "Vetex reordering time: " + (e-s) + " ms" );
 
 		// recast CTM 32-bit indices as 16-bit WebGL indices
 		var vertexIndexArray16 = new Uint16Array( vertexIndexArray );

--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -281,7 +281,6 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 			var newFaces = new Uint32Array( vertexIndexArray.length );
 			var indexMap = {}, reverseIndexMap = {}, vertexCounter = 0;
 
-            		// in most Reality Capture models < 1% of faces**2 are sprawled, for complex CAD/CAM > 2%
             		var spawledFaceCount = 0,
                 	    spawledFaceLimit = Math.ceil(vertexIndexArray.length/3000);
             		var sprawledFaces = new Uint32Array( spawledFaceLimit );  // to store sprawled triangle indices

--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -103,7 +103,7 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 				var binaryData = xhr.responseText;
 
-				//var s = Date.now();
+				var s = Date.now();
 
 				if ( parameters.useWorker ) {
 
@@ -117,6 +117,9 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 							var ctmFile = files[ i ];
 
+                            var e1 = Date.now();
+                            // console.log( "CTM data parse time [worker]: " + (e1-s) + " ms" );
+
 							if ( useBuffers ) {
 
 								scope.createModelBuffers( ctmFile, callback );
@@ -127,10 +130,11 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 							}
 
+                            var e = Date.now();
+                            console.log( "model load time [worker]: " + (e-e1) + " ms, total: " + (e-s));
+
 						}
 
-						//var e = Date.now();
-						//console.log( "CTM data parse time [worker]: " + (e-s) + " ms" );
 
 					};
 
@@ -209,6 +213,7 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 
 		THREE.BufferGeometry.call( this );
 
+		var s = Date.now();
 		// init GL buffers
 
 		var vertexIndexArray = file.body.indices,
@@ -218,98 +223,131 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 		var vertexUvArray, vertexColorArray;
 
 		if ( file.body.uvMaps !== undefined && file.body.uvMaps.length > 0 ) {
-
 			vertexUvArray = file.body.uvMaps[ 0 ].uv;
-
 		}
 
 		if ( file.body.attrMaps !== undefined && file.body.attrMaps.length > 0 && file.body.attrMaps[ 0 ].name === "Color" ) {
-
 			vertexColorArray = file.body.attrMaps[ 0 ].attr;
-
 		}
 
 		// reorder vertices
 		// (needed for buffer splitting, to keep together face vertices)
-
 		if ( reorderVertices ) {
 
-			var newFaces = new Uint32Array( vertexIndexArray.length ),
-				newVertices = new Float32Array( vertexPositionArray.length );
+            function copyVertexInfo(v, vt) {
 
-			var newNormals, newUvs, newColors;
+                var sx = v * 3,
+                    sy = v * 3 + 1,
+                    sz = v * 3 + 2,
 
-			if ( vertexNormalArray ) newNormals = new Float32Array( vertexNormalArray.length );
-			if ( vertexUvArray ) newUvs = new Float32Array( vertexUvArray.length );
-			if ( vertexColorArray ) newColors = new Float32Array( vertexColorArray.length );
+                    dx = vt * 3,
+                    dy = vt * 3 + 1,
+                    dz = vt * 3 + 2;
 
-			var indexMap = {}, vertexCounter = 0;
+                newVertices[ dx ] = vertexPositionArray[ sx ];
+                newVertices[ dy ] = vertexPositionArray[ sy ];
+                newVertices[ dz ] = vertexPositionArray[ sz ];
 
-			function handleVertex( v ) {
+                if ( vertexNormalArray ) {
+                    newNormals[ dx ] = vertexNormalArray[ sx ];
+                    newNormals[ dy ] = vertexNormalArray[ sy ];
+                    newNormals[ dz ] = vertexNormalArray[ sz ];
+                }
 
-				if ( indexMap[ v ] === undefined ) {
+                if ( vertexUvArray ) {
+                    newUvs[ vt * 2 ] 	 = vertexUvArray[ v * 2 ];
+                    newUvs[ vt * 2 + 1 ] = vertexUvArray[ v * 2 + 1 ];
+                }
 
-					indexMap[ v ] = vertexCounter;
+                if ( vertexColorArray ) {
+                    newColors[ vt * 4 ] 	= vertexColorArray[ v * 4 ];
+                    newColors[ vt * 4 + 1 ] = vertexColorArray[ v * 4 + 1 ];
+                    newColors[ vt * 4 + 2 ] = vertexColorArray[ v * 4 + 2 ];
+                    newColors[ vt * 4 + 3 ] = vertexColorArray[ v * 4 + 3 ];
+                }
+            }
 
-					var sx = v * 3,
-						sy = v * 3 + 1,
-						sz = v * 3 + 2,
+			function handleVertex( v, iMap ) {
 
-						dx = vertexCounter * 3,
-						dy = vertexCounter * 3 + 1,
-						dz = vertexCounter * 3 + 2;
+				if ( iMap[ v ] === undefined ) {
 
-					newVertices[ dx ] = vertexPositionArray[ sx ];
-					newVertices[ dy ] = vertexPositionArray[ sy ];
-					newVertices[ dz ] = vertexPositionArray[ sz ];
-
-					if ( vertexNormalArray ) {
-
-						newNormals[ dx ] = vertexNormalArray[ sx ];
-						newNormals[ dy ] = vertexNormalArray[ sy ];
-						newNormals[ dz ] = vertexNormalArray[ sz ];
-
-					}
-
-					if ( vertexUvArray ) {
-
-						newUvs[ vertexCounter * 2 ] 	= vertexUvArray[ v * 2 ];
-						newUvs[ vertexCounter * 2 + 1 ] = vertexUvArray[ v * 2 + 1 ];
-
-					}
-
-					if ( vertexColorArray ) {
-
-						newColors[ vertexCounter * 4 ] 	   = vertexColorArray[ v * 4 ];
-						newColors[ vertexCounter * 4 + 1 ] = vertexColorArray[ v * 4 + 1 ];
-						newColors[ vertexCounter * 4 + 2 ] = vertexColorArray[ v * 4 + 2 ];
-						newColors[ vertexCounter * 4 + 3 ] = vertexColorArray[ v * 4 + 3 ];
-
-					}
-
+					iMap[ v ] = vertexCounter;
+                    reverseIndexMap[vertexCounter] = v;
 					vertexCounter += 1;
-
 				}
-
+                return iMap[ v ];
 			}
 
-			var a, b, c;
+			var newFaces = new Uint32Array( vertexIndexArray.length );
+			var indexMap = {}, reverseIndexMap = {}, vertexCounter = 0;
+
+            // in most Reality Capture models < 1% of faces**2 are sprawled, for complex CAD/CAM > 2%
+            var spawledFaceCount = 0,
+                spawledFaceLimit = Math.ceil(vertexIndexArray.length/3000);
+            var sprawledFaces = new Uint32Array( spawledFaceLimit );  // to store sprawled triangle indices
 
 			for ( var i = 0; i < vertexIndexArray.length; i += 3 ) {
 
-				a = vertexIndexArray[ i ];
-				b = vertexIndexArray[ i + 1 ];
-				c = vertexIndexArray[ i + 2 ];
+				var a = vertexIndexArray[ i ];
+				var b = vertexIndexArray[ i + 1 ];
+				var c = vertexIndexArray[ i + 2 ];
 
-				handleVertex( a );
-				handleVertex( b );
-				handleVertex( c );
+				handleVertex( a, indexMap );
+				handleVertex( b, indexMap );
+				handleVertex( c, indexMap );
 
-				newFaces[ i ] 	  = indexMap[ a ];
-				newFaces[ i + 1 ] = indexMap[ b ];
-				newFaces[ i + 2 ] = indexMap[ c ];
+				// check for sprawled triangles and put them aside to recreate later
+				if ( Math.abs( indexMap[a] - indexMap[b] ) > 65535 ||
+                     Math.abs( indexMap[b] - indexMap[c] ) > 65535 ||
+                     Math.abs( indexMap[c] - indexMap[a] ) > 65535 ){
 
+                    // expand storage when neccessary
+                    if (spawledFaceCount >= spawledFaceLimit) {
+                        console.warn("reached sprawled faces limit: " + spawledFaceCount);
+                        spawledFaceLimit *= 2;
+                        var tArr = new Uint32Array( spawledFaceLimit );
+                        tArr.set(sprawledFaces);
+                        sprawledFaces = tArr;
+                    }
+
+                    sprawledFaces[ spawledFaceCount ] = i;  // starting index in newFaces
+                    spawledFaceCount += 1;
+                }
+                else {
+
+				    newFaces[ i ] 	  = indexMap[ a ];
+				    newFaces[ i + 1 ] = indexMap[ b ];
+				    newFaces[ i + 2 ] = indexMap[ c ];
+                }
 			}
+            console.log("Number of sprawled faces: " + spawledFaceCount + " current limit: " + spawledFaceLimit +
+                        " total: " + vertexIndexArray.length/3 + " vertices: " + vertexCounter);
+
+            // create dublicate vertices and update sprawled faces
+            var indexMap2 = {},
+                noov = vertexCounter;   // # of original vertices
+
+            for (var isf = 0; isf < spawledFaceCount; isf++ ) {
+                var i = sprawledFaces[isf];
+
+                for (var j = 0; j < 3; j++) {
+                    var v = vertexIndexArray[ i + j ];
+                    newFaces[ i + j] = handleVertex(v, indexMap2);   // new vertex
+                }
+            }
+            // console.log("Created duplicated vertices: " + (vertexCounter - noov));
+
+            // copy xyz, uv, normals and colors into new arrays
+            var newVertices = new Float32Array( 3*vertexCounter );
+			var newNormals, newUvs, newColors;
+
+			if ( vertexNormalArray ) newNormals = new Float32Array( 3*vertexCounter );
+			if ( vertexUvArray ) newUvs = new Float32Array( 2*vertexCounter );
+			if ( vertexColorArray ) newColors = new Float32Array( 4*vertexCounter );
+
+            for (var iv = 0; iv < vertexCounter; iv++) {
+                copyVertexInfo(reverseIndexMap[iv], iv);
+            }
 
 			vertexIndexArray = newFaces;
 			vertexPositionArray = newVertices;
@@ -317,7 +355,6 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 			if ( vertexNormalArray ) vertexNormalArray = newNormals;
 			if ( vertexUvArray ) vertexUvArray = newUvs;
 			if ( vertexColorArray ) vertexColorArray = newColors;
-
 		}
 
 		// compute offsets
@@ -346,10 +383,10 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 
 				i -= 3;
 
-				for ( var k = start; k < i; ++ k ) {
+                if ( minPrev > 0 ) {
 
-					indices[ k ] -= minPrev;
-
+				    for ( var k = start; k < i; ++ k )
+					    indices[ k ] -= minPrev;
 				}
 
 				scope.offsets.push( { start: start, count: i - start, index: minPrev } );
@@ -364,20 +401,20 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 
 		}
 
-		for ( var k = start; k < i; ++ k ) {
+        if ( minPrev > 0 ) {
 
-			indices[ k ] -= minPrev;
-
+		    for ( var k = start; k < i; ++ k )
+			    indices[ k ] -= minPrev;
 		}
-
 		scope.offsets.push( { start: start, count: i - start, index: minPrev } );
 
-		// recast CTM 32-bit indices as 16-bit WebGL indices
+        var e = Date.now();
+		console.log( "Vetex reordering time: " + (e-s) + " ms" );
 
+		// recast CTM 32-bit indices as 16-bit WebGL indices
 		var vertexIndexArray16 = new Uint16Array( vertexIndexArray );
 
 		// attributes
-
 		var attributes = scope.attributes;
 
 		attributes[ "index" ]    = { itemSize: 1, array: vertexIndexArray16, numItems: vertexIndexArray16.length };

--- a/examples/js/loaders/ctm/ctm.js
+++ b/examples/js/loaders/ctm/ctm.js
@@ -1,3 +1,30 @@
+/*
+Copyright (c) 2011 Juan Mellado
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/*
+References:
+- "OpenCTM: The Open Compressed Triangle Mesh file format" by Marcus Geelnard
+  http://openctm.sourceforge.net/
+*/
 
 var CTM = CTM || {};
 
@@ -348,6 +375,7 @@ CTM.restoreIndices = function(indices, len){
   var i = 3;
   if (len > 0){
     indices[2] += indices[0];
+    indices[1] += indices[0];
   }
   for (; i < len; i += 3){
     indices[i] += indices[i - 3];

--- a/examples/webgl_geometry_extrude_shapes.html
+++ b/examples/webgl_geometry_extrude_shapes.html
@@ -1,333 +1,333 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>three.js webgl - geometry - extrude splines</title>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+<head>
+    <title>three.js webgl - geometry - extrude splines</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 
-		<style>
-		body {
-			font-family: Monospace;
-			background-color: #f0f0f0;
-			margin: 0px;
-			overflow: hidden;
-		}
-		</style>
-	</head>
+    <style>
+        body {
+            font-family: Monospace;
+            background-color: #f0f0f0;
+            margin: 0px;
+            overflow: hidden;
+        }
+    </style>
+</head>
 
-	<body>
-		<canvas id="debug" style="position:absolute; left:100px"></canvas>
+<body>
+<canvas id="debug" style="position:absolute; left:100px"></canvas>
 
-		<script src="../build/three.min.js"></script>
-		<script src="js/libs/stats.min.js"></script>
+<script src="../build/three.min.js"></script>
+<script src="js/libs/stats.min.js"></script>
 
 
-		<script>
+<script>
 
-			var container, stats;
+var container, stats;
 
-			var camera, scene, renderer;
+var camera, scene, renderer;
 
-			var text, plane;
+var group, text, plane;
 
-			var targetRotation = 0;
-			var targetRotationOnMouseDown = 0;
+var targetRotation = 0;
+var targetRotationOnMouseDown = 0;
 
-			var mouseX = 0;
-			var mouseXOnMouseDown = 0;
+var mouseX = 0;
+var mouseXOnMouseDown = 0;
 
-			var windowHalfX = window.innerWidth / 2;
-			var windowHalfY = window.innerHeight / 2;
+var windowHalfX = window.innerWidth / 2;
+var windowHalfY = window.innerHeight / 2;
 
-			init();
-			animate();
+init();
+animate();
 
-			function init() {
+function init() {
 
-				container = document.createElement( 'div' );
-				document.body.appendChild( container );
+    container = document.createElement( 'div' );
+    document.body.appendChild( container );
 
-				var info = document.createElement( 'div' );
-				info.style.position = 'absolute';
-				info.style.top = '10px';
-				info.style.width = '100%';
-				info.style.textAlign = 'center';
-				info.innerHTML = 'Shapes Extrusion via Spline path<br/>Drag to spin';
-				container.appendChild( info );
+    var info = document.createElement( 'div' );
+    info.style.position = 'absolute';
+    info.style.top = '10px';
+    info.style.width = '100%';
+    info.style.textAlign = 'center';
+    info.innerHTML = 'Shapes Extrusion via Spline path<br/>Drag to spin';
+    container.appendChild( info );
 
-				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.set( 0, 150, 500 );
+    camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 1000 );
+    camera.position.set( 0, 150, 500 );
 
-				scene = new THREE.Scene();
+    scene = new THREE.Scene();
 
-				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0, 0, 1 );
-				scene.add( light );
+    var light = new THREE.DirectionalLight( 0xffffff );
+    light.position.set( 0, 0, 1 );
+    scene.add( light );
 
-				parent = new THREE.Object3D();
-				parent.position.y = 50;
-				scene.add( parent );
+    group = new THREE.Object3D();
+    group.position.y = 50;
+    scene.add( group );
 
-				function addGeometry( geometry, color, x, y, z, rx, ry, rz, s ) {
+    function addGeometry( geometry, color, x, y, z, rx, ry, rz, s ) {
 
-					// 3d shape
+        // 3d shape
 
-					var mesh = THREE.SceneUtils.createMultiMaterialObject( geometry, [ new THREE.MeshLambertMaterial( { color: color, opacity: 0.2, transparent: true } ), new THREE.MeshBasicMaterial( { color: 0x000000, wireframe: true,  opacity: 0.3 } ) ] );
+        var mesh = THREE.SceneUtils.createMultiMaterialObject( geometry, [ new THREE.MeshLambertMaterial( { color: color, opacity: 0.2, transparent: true } ), new THREE.MeshBasicMaterial( { color: 0x000000, wireframe: true,  opacity: 0.3 } ) ] );
 
-					mesh.position.set( x, y, z - 75 );
-					// mesh.rotation.set( rx, ry, rz );
-					mesh.scale.set( s, s, s );
+        mesh.position.set( x, y, z - 75 );
+        // mesh.rotation.set( rx, ry, rz );
+        mesh.scale.set( s, s, s );
 
-					if ( geometry.debug ) mesh.add( geometry.debug );
+        if ( geometry.debug ) mesh.add( geometry.debug );
 
-					parent.add( mesh );
+        group.add( mesh );
 
-				}
+    }
 
-				var extrudeSettings = { amount: 200,  bevelEnabled: true, bevelSegments: 2, steps: 150 }; // bevelSegments: 2, steps: 2 , bevelSegments: 5, bevelSize: 8, bevelThickness:5,
+    var extrudeSettings = { amount: 200,  bevelEnabled: true, bevelSegments: 2, steps: 150 }; // bevelSegments: 2, steps: 2 , bevelSegments: 5, bevelSize: 8, bevelThickness:5,
 
-				// var extrudePath = new THREE.Path();
+    // var extrudePath = new THREE.Path();
 
-				// extrudePath.moveTo( 0, 0 );
-				// extrudePath.lineTo( 10, 10 );
-				// extrudePath.quadraticCurveTo( 80, 60, 160, 10 );
-				// extrudePath.quadraticCurveTo( 240, -40, 320, 10 );
+    // extrudePath.moveTo( 0, 0 );
+    // extrudePath.lineTo( 10, 10 );
+    // extrudePath.quadraticCurveTo( 80, 60, 160, 10 );
+    // extrudePath.quadraticCurveTo( 240, -40, 320, 10 );
 
 
-				extrudeSettings.bevelEnabled = false;
+    extrudeSettings.bevelEnabled = false;
 
-				var extrudeBend = new THREE.SplineCurve3( //Closed
-				[
+    var extrudeBend = new THREE.SplineCurve3( //Closed
+            [
 
-				  new THREE.Vector3( 30, 12, 83),
-				  new THREE.Vector3( 40, 20, 67),
-				  new THREE.Vector3( 60, 40, 99),
-				  new THREE.Vector3( 10, 60, 49),
-				  new THREE.Vector3( 25, 80, 40)
+                new THREE.Vector3( 30, 12, 83),
+                new THREE.Vector3( 40, 20, 67),
+                new THREE.Vector3( 60, 40, 99),
+                new THREE.Vector3( 10, 60, 49),
+                new THREE.Vector3( 25, 80, 40)
 
-				]);
+            ]);
 
-			var pipeSpline = new THREE.SplineCurve3([
-				new THREE.Vector3(0, 10, -10), new THREE.Vector3(10, 0, -10), new THREE.Vector3(20, 0, 0), new THREE.Vector3(30, 0, 10), new THREE.Vector3(30, 0, 20), new THREE.Vector3(20, 0, 30), new THREE.Vector3(10, 0, 30), new THREE.Vector3(0, 0, 30), new THREE.Vector3(-10, 10, 30), new THREE.Vector3(-10, 20, 30), new THREE.Vector3(0, 30, 30), new THREE.Vector3(10, 30, 30), new THREE.Vector3(20, 30, 15), new THREE.Vector3(10, 30, 10), new THREE.Vector3(0, 30, 10), new THREE.Vector3(-10, 20, 10), new THREE.Vector3(-10, 10, 10), new THREE.Vector3(0, 0, 10), new THREE.Vector3(10, -10, 10), new THREE.Vector3(20, -15, 10), new THREE.Vector3(30, -15, 10), new THREE.Vector3(40, -15, 10), new THREE.Vector3(50, -15, 10), new THREE.Vector3(60, 0, 10), new THREE.Vector3(70, 0, 0), new THREE.Vector3(80, 0, 0), new THREE.Vector3(90, 0, 0), new THREE.Vector3(100, 0, 0)]
-			);
+    var pipeSpline = new THREE.SplineCurve3([
+        new THREE.Vector3(0, 10, -10), new THREE.Vector3(10, 0, -10), new THREE.Vector3(20, 0, 0), new THREE.Vector3(30, 0, 10), new THREE.Vector3(30, 0, 20), new THREE.Vector3(20, 0, 30), new THREE.Vector3(10, 0, 30), new THREE.Vector3(0, 0, 30), new THREE.Vector3(-10, 10, 30), new THREE.Vector3(-10, 20, 30), new THREE.Vector3(0, 30, 30), new THREE.Vector3(10, 30, 30), new THREE.Vector3(20, 30, 15), new THREE.Vector3(10, 30, 10), new THREE.Vector3(0, 30, 10), new THREE.Vector3(-10, 20, 10), new THREE.Vector3(-10, 10, 10), new THREE.Vector3(0, 0, 10), new THREE.Vector3(10, -10, 10), new THREE.Vector3(20, -15, 10), new THREE.Vector3(30, -15, 10), new THREE.Vector3(40, -15, 10), new THREE.Vector3(50, -15, 10), new THREE.Vector3(60, 0, 10), new THREE.Vector3(70, 0, 0), new THREE.Vector3(80, 0, 0), new THREE.Vector3(90, 0, 0), new THREE.Vector3(100, 0, 0)]
+    );
 
-			var sampleClosedSpline = new THREE.ClosedSplineCurve3([
-				new THREE.Vector3(0, -40, -40),
-				new THREE.Vector3(0, 40, -40),
-				new THREE.Vector3(0, 140, -40),
-				new THREE.Vector3(0, 40, 40),
-				new THREE.Vector3(0, -40, 40),
-			]);
+    var sampleClosedSpline = new THREE.ClosedSplineCurve3([
+        new THREE.Vector3(0, -40, -40),
+        new THREE.Vector3(0, 40, -40),
+        new THREE.Vector3(0, 140, -40),
+        new THREE.Vector3(0, 40, 40),
+        new THREE.Vector3(0, -40, 40),
+    ]);
 
-			var randomPoints = [];
+    var randomPoints = [];
 
-			for ( var i = 0; i < 10; i ++ ) {
+    for ( var i = 0; i < 10; i ++ ) {
 
-				randomPoints.push( new THREE.Vector3(Math.random() * 200,Math.random() * 200,Math.random() * 200 ) );
+        randomPoints.push( new THREE.Vector3(Math.random() * 200,Math.random() * 200,Math.random() * 200 ) );
 
-			}
+    }
 
-			var randomSpline =  new THREE.SplineCurve3( randomPoints );
+    var randomSpline =  new THREE.SplineCurve3( randomPoints );
 
-			extrudeSettings.extrudePath = randomSpline; // extrudeBend sampleClosedSpline pipeSpline randomSpline
+    extrudeSettings.extrudePath = randomSpline; // extrudeBend sampleClosedSpline pipeSpline randomSpline
 
-			// Circle
+    // Circle
 
-			var circleRadius = 4;
-			var circleShape = new THREE.Shape();
-			circleShape.moveTo( 0, circleRadius );
-			circleShape.quadraticCurveTo( circleRadius, circleRadius, circleRadius, 0 );
-			circleShape.quadraticCurveTo( circleRadius, -circleRadius, 0, -circleRadius );
-			circleShape.quadraticCurveTo( -circleRadius, -circleRadius, -circleRadius, 0 );
-			circleShape.quadraticCurveTo( -circleRadius, circleRadius, 0, circleRadius);
+    var circleRadius = 4;
+    var circleShape = new THREE.Shape();
+    circleShape.moveTo( 0, circleRadius );
+    circleShape.quadraticCurveTo( circleRadius, circleRadius, circleRadius, 0 );
+    circleShape.quadraticCurveTo( circleRadius, -circleRadius, 0, -circleRadius );
+    circleShape.quadraticCurveTo( -circleRadius, -circleRadius, -circleRadius, 0 );
+    circleShape.quadraticCurveTo( -circleRadius, circleRadius, 0, circleRadius);
 
-			var rectLength = 12, rectWidth = 4;
+    var rectLength = 12, rectWidth = 4;
 
-			var rectShape = new THREE.Shape();
+    var rectShape = new THREE.Shape();
 
-			rectShape.moveTo( -rectLength/2, -rectWidth/2 );
-			rectShape.lineTo( -rectLength/2, rectWidth/2 );
-			rectShape.lineTo( rectLength/2, rectWidth/2 );
-			rectShape.lineTo( rectLength/2, -rectLength/2 );
-			rectShape.lineTo( -rectLength/2, -rectLength/2 );
+    rectShape.moveTo( -rectLength/2, -rectWidth/2 );
+    rectShape.lineTo( -rectLength/2, rectWidth/2 );
+    rectShape.lineTo( rectLength/2, rectWidth/2 );
+    rectShape.lineTo( rectLength/2, -rectLength/2 );
+    rectShape.lineTo( -rectLength/2, -rectLength/2 );
 
 
-			var pts = [], starPoints = 5, l;
+    var pts = [], starPoints = 5, l;
 
-			for ( i = 0; i < starPoints * 2; i ++ ) {
+    for ( i = 0; i < starPoints * 2; i ++ ) {
 
-				if ( i % 2 == 1 ) {
+        if ( i % 2 == 1 ) {
 
-					l = 5;
+            l = 5;
 
-				} else {
+        } else {
 
-					l = 10;
+            l = 10;
 
-				}
+        }
 
-				var a = i / starPoints * Math.PI;
-				pts.push( new THREE.Vector2 ( Math.cos( a ) * l, Math.sin( a ) * l ) );
+        var a = i / starPoints * Math.PI;
+        pts.push( new THREE.Vector2 ( Math.cos( a ) * l, Math.sin( a ) * l ) );
 
-			}
+    }
 
-			var starShape = new THREE.Shape( pts );
+    var starShape = new THREE.Shape( pts );
 
-			// Smiley
+    // Smiley
 
-			var smileyShape = new THREE.Shape();
-			smileyShape.moveTo( 80, 40 );
-			smileyShape.arc( 40, 40, 40, 0, Math.PI*2, false );
+    var smileyShape = new THREE.Shape();
+    smileyShape.moveTo( 80, 40 );
+    smileyShape.arc( 40, 40, 40, 0, Math.PI*2, false );
 
-			var smileyEye1Path = new THREE.Path();
-			smileyEye1Path.moveTo( 35, 20 );
-			smileyEye1Path.arc( 25, 20, 10, 0, Math.PI*2, true );
-			smileyShape.holes.push( smileyEye1Path );
+    var smileyEye1Path = new THREE.Path();
+    smileyEye1Path.moveTo( 35, 20 );
+    smileyEye1Path.arc( 25, 20, 10, 0, Math.PI*2, true );
+    smileyShape.holes.push( smileyEye1Path );
 
-			var smileyEye2Path = new THREE.Path();
-			smileyEye2Path.moveTo( 65, 20 );
-			smileyEye2Path.arc( 55, 20, 10, 0, Math.PI*2, true );
-			smileyShape.holes.push( smileyEye2Path );
+    var smileyEye2Path = new THREE.Path();
+    smileyEye2Path.moveTo( 65, 20 );
+    smileyEye2Path.arc( 55, 20, 10, 0, Math.PI*2, true );
+    smileyShape.holes.push( smileyEye2Path );
 
-			var smileyMouthPath = new THREE.Path();
+    var smileyMouthPath = new THREE.Path();
 
-			smileyMouthPath.moveTo( 20, 40 );
-			smileyMouthPath.quadraticCurveTo( 40, 60, 60, 40 );
-			smileyMouthPath.bezierCurveTo( 70, 45, 70, 50, 60, 60 );
-			smileyMouthPath.quadraticCurveTo( 40, 80, 20, 60 );
-			smileyMouthPath.quadraticCurveTo( 5, 50, 20, 40 );
+    smileyMouthPath.moveTo( 20, 40 );
+    smileyMouthPath.quadraticCurveTo( 40, 60, 60, 40 );
+    smileyMouthPath.bezierCurveTo( 70, 45, 70, 50, 60, 60 );
+    smileyMouthPath.quadraticCurveTo( 40, 80, 20, 60 );
+    smileyMouthPath.quadraticCurveTo( 5, 50, 20, 40 );
 
-			smileyShape.holes.push( smileyMouthPath );
+    smileyShape.holes.push( smileyMouthPath );
 
-			var circle3d = starShape.extrude( extrudeSettings ); //circleShape rectShape smileyShape starShape
-			// var circle3d = new THREE.ExtrudeGeometry(circleShape, extrudeBend, extrudeSettings );
+    var circle3d = starShape.extrude( extrudeSettings ); //circleShape rectShape smileyShape starShape
+    // var circle3d = new THREE.ExtrudeGeometry(circleShape, extrudeBend, extrudeSettings );
 
-			var tube = new THREE.TubeGeometry(extrudeSettings.extrudePath, 150, 4, 5, false, true);
-			// new THREE.TubeGeometry(extrudePath, segments, 2, radiusSegments, closed2, debug);
+    var tube = new THREE.TubeGeometry(extrudeSettings.extrudePath, 150, 4, 5, false, true);
+    // new THREE.TubeGeometry(extrudePath, segments, 2, radiusSegments, closed2, debug);
 
 
-			addGeometry( circle3d, 0xff1111,  -100,  0, 0,     0, 0, 0, 1 );
-			addGeometry( tube, 0x00ff11,  0,  0, 0,     0, 0, 0, 1 );
-			console.log(tube);
+    addGeometry( circle3d, 0xff1111,  -100,  0, 0,     0, 0, 0, 1 );
+    addGeometry( tube, 0x00ff11,  0,  0, 0,     0, 0, 0, 1 );
+    console.log(tube);
 
-			//
+    //
 
-			renderer = new THREE.WebGLRenderer( { antialias: true } );
-			renderer.setSize( window.innerWidth, window.innerHeight );
+    renderer = new THREE.WebGLRenderer( { antialias: true } );
+    renderer.setSize( window.innerWidth, window.innerHeight );
 
-			container.appendChild( renderer.domElement );
+    container.appendChild( renderer.domElement );
 
-			stats = new Stats();
-			stats.domElement.style.position = 'absolute';
-			stats.domElement.style.top = '0px';
-			container.appendChild( stats.domElement );
+    stats = new Stats();
+    stats.domElement.style.position = 'absolute';
+    stats.domElement.style.top = '0px';
+    container.appendChild( stats.domElement );
 
-			document.addEventListener( 'mousedown', onDocumentMouseDown, false );
-			document.addEventListener( 'touchstart', onDocumentTouchStart, false );
-			document.addEventListener( 'touchmove', onDocumentTouchMove, false );
+    document.addEventListener( 'mousedown', onDocumentMouseDown, false );
+    document.addEventListener( 'touchstart', onDocumentTouchStart, false );
+    document.addEventListener( 'touchmove', onDocumentTouchMove, false );
 
-			//
+    //
 
-			window.addEventListener( 'resize', onWindowResize, false );
+    window.addEventListener( 'resize', onWindowResize, false );
 
-		}
+}
 
-		function onWindowResize() {
+function onWindowResize() {
 
-			windowHalfX = window.innerWidth / 2;
-			windowHalfY = window.innerHeight / 2;
+    windowHalfX = window.innerWidth / 2;
+    windowHalfY = window.innerHeight / 2;
 
-			camera.aspect = window.innerWidth / window.innerHeight;
-			camera.updateProjectionMatrix();
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
 
-			renderer.setSize( window.innerWidth, window.innerHeight );
+    renderer.setSize( window.innerWidth, window.innerHeight );
 
-		}
+}
 
-		//
+//
 
-		function onDocumentMouseDown( event ) {
+function onDocumentMouseDown( event ) {
 
-			event.preventDefault();
+    event.preventDefault();
 
-			document.addEventListener( 'mousemove', onDocumentMouseMove, false );
-			document.addEventListener( 'mouseup', onDocumentMouseUp, false );
-			document.addEventListener( 'mouseout', onDocumentMouseOut, false );
+    document.addEventListener( 'mousemove', onDocumentMouseMove, false );
+    document.addEventListener( 'mouseup', onDocumentMouseUp, false );
+    document.addEventListener( 'mouseout', onDocumentMouseOut, false );
 
-			mouseXOnMouseDown = event.clientX - windowHalfX;
-			targetRotationOnMouseDown = targetRotation;
+    mouseXOnMouseDown = event.clientX - windowHalfX;
+    targetRotationOnMouseDown = targetRotation;
 
-		}
+}
 
-		function onDocumentMouseMove( event ) {
+function onDocumentMouseMove( event ) {
 
-			mouseX = event.clientX - windowHalfX;
+    mouseX = event.clientX - windowHalfX;
 
-			targetRotation = targetRotationOnMouseDown + ( mouseX - mouseXOnMouseDown ) * 0.02;
+    targetRotation = targetRotationOnMouseDown + ( mouseX - mouseXOnMouseDown ) * 0.02;
 
-		}
+}
 
-		function onDocumentMouseUp( event ) {
+function onDocumentMouseUp( event ) {
 
-			document.removeEventListener( 'mousemove', onDocumentMouseMove, false );
-			document.removeEventListener( 'mouseup', onDocumentMouseUp, false );
-			document.removeEventListener( 'mouseout', onDocumentMouseOut, false );
+    document.removeEventListener( 'mousemove', onDocumentMouseMove, false );
+    document.removeEventListener( 'mouseup', onDocumentMouseUp, false );
+    document.removeEventListener( 'mouseout', onDocumentMouseOut, false );
 
-		}
+}
 
-		function onDocumentMouseOut( event ) {
+function onDocumentMouseOut( event ) {
 
-			document.removeEventListener( 'mousemove', onDocumentMouseMove, false );
-			document.removeEventListener( 'mouseup', onDocumentMouseUp, false );
-			document.removeEventListener( 'mouseout', onDocumentMouseOut, false );
+    document.removeEventListener( 'mousemove', onDocumentMouseMove, false );
+    document.removeEventListener( 'mouseup', onDocumentMouseUp, false );
+    document.removeEventListener( 'mouseout', onDocumentMouseOut, false );
 
-		}
+}
 
-		function onDocumentTouchStart( event ) {
+function onDocumentTouchStart( event ) {
 
-			if ( event.touches.length == 1 ) {
+    if ( event.touches.length == 1 ) {
 
-				event.preventDefault();
+        event.preventDefault();
 
-				mouseXOnMouseDown = event.touches[ 0 ].pageX - windowHalfX;
-				targetRotationOnMouseDown = targetRotation;
+        mouseXOnMouseDown = event.touches[ 0 ].pageX - windowHalfX;
+        targetRotationOnMouseDown = targetRotation;
 
-			}
+    }
 
-		}
+}
 
-		function onDocumentTouchMove( event ) {
+function onDocumentTouchMove( event ) {
 
-			if ( event.touches.length == 1 ) {
+    if ( event.touches.length == 1 ) {
 
-				event.preventDefault();
+        event.preventDefault();
 
-				mouseX = event.touches[ 0 ].pageX - windowHalfX;
-				targetRotation = targetRotationOnMouseDown + ( mouseX - mouseXOnMouseDown ) * 0.05;
+        mouseX = event.touches[ 0 ].pageX - windowHalfX;
+        targetRotation = targetRotationOnMouseDown + ( mouseX - mouseXOnMouseDown ) * 0.05;
 
-			}
+    }
 
-		}
+}
 
-		//
+//
 
-		function animate() {
+function animate() {
 
-			requestAnimationFrame( animate );
+    requestAnimationFrame( animate );
 
-			render();
-			stats.update();
+    render();
+    stats.update();
 
-		}
+}
 
-		function render() {
+function render() {
 
-			parent.rotation.y += ( targetRotation - parent.rotation.y ) * 0.05;
-			renderer.render( scene, camera );
+    group.rotation.y += ( targetRotation - group.rotation.y ) * 0.05;
+    renderer.render( scene, camera );
 
-		}
+}
 
-	</script>
+</script>
 
 </body>
 </html>

--- a/src/extras/geometries/ExtrudeGeometry.js
+++ b/src/extras/geometries/ExtrudeGeometry.js
@@ -5,15 +5,13 @@
  *
  * parameters = {
  *
- *  size: <float>, // size of the text
- *  height: <float>, // thickness to extrude text
  *  curveSegments: <int>, // number of points on the curves
  *  steps: <int>, // number of points for z-side extrusions / used for subdividing segements of extrude spline too
- *  amount: <int>, // Amount
+ *  amount: <int>, // Depth to extrude the shape
  *
  *  bevelEnabled: <bool>, // turn on bevel
- *  bevelThickness: <float>, // how deep into text bevel goes
- *  bevelSize: <float>, // how far from text outline is bevel
+ *  bevelThickness: <float>, // how deep into the original shape bevel goes
+ *  bevelSize: <float>, // how far from shape outline is bevel
  *  bevelSegments: <int>, // number of bevel layers
  *
  *  extrudePath: <THREE.CurvePath> // 3d spline path to extrude shape along. (creates Frames if .frames aren't defined)


### PR DESCRIPTION
Fixed webgl_geometry_extrude_shapes.html example for IE11. The example was assigning  a new THREE.Object3D to parent which is a reserved global for the parent window. I updated the example to use var group to be consistent with the other examples.
