### PR TITLE
Fixed rotateOnAxis in Object3D.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -142,7 +142,7 @@ THREE.Object3D.prototype = {
 
 			q1.setFromAxisAngle( axis, angle );
 
-			this.quaternion.multiply( q1 );
+			this.quaternion.multiplyQuaternions( q1, this.quaternion );
 
 			return this;
 


### PR DESCRIPTION
The order in which the quaternions are multiplied was reversed.  For the justification, see the part that starts with "Two rotation quaternions can be combined ..." on this wiki page:
http://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
