### PR TITLE
Prevent chained/duplicate calls to FancySelect.setValue

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -187,7 +187,9 @@ Sidebar.Scene = function ( editor ) {
 
 	signals.objectSelected.add( function ( object ) {
 
-		outliner.setValue( object !== null ? object.id : null );
+		// Prevent chaining calls to setValue when signals originate from the outliner control
+		if ( !outliner.signalingChange )
+			outliner.setValue( object !== null ? object.id : null );
 
 	} );
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -361,11 +361,15 @@ UI.FancySelect = function () {
 
 				if ( scope.selectedIndex >= 0 && scope.selectedIndex < scope.options.length ) {
 
+					scope.signalingChange = true;
+
 					// Highlight selected dom elem and scroll parent if needed
 					scope.setValue( scope.options[ scope.selectedIndex ].value );
 
 					// Invoke object/helper/mesh selection logic
 					scope.dom.dispatchEvent( changeEvent );
+
+					scope.signalingChange = false;
 
 				}
 
@@ -413,8 +417,12 @@ UI.FancySelect.prototype.setOptions = function ( options ) {
 
 		option.addEventListener( 'click', function ( event ) {
 
+			scope.signalingChange = true;
+
 			scope.setValue( this.value );
 			scope.dom.dispatchEvent( changeEvent );
+
+			scope.signalingChange = false;
 
 		}, false );
 


### PR DESCRIPTION
While debugging the setValue event handler I noticed the function is called twice; once for the originating event and once for the cascaded event that comes after the signal is dispatched. An abbreviated path of the event chain that causes the duplicate call is as follows:

```
FancySelect:Dispatch(Change)  -> 
  editor:select -> editor:Dispatch(objectSelected) -> 
      SideBar.Scene:objectSelected -> 
        FancySelect.setValue()
```

This fix simply sets state tracking that a signal is being fired and then appropriately guards against calling setValue.
