### PR TITLE
Support removeEventListener inside event handler

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -77,6 +77,7 @@ THREE.EventDispatcher.prototype = {
 
 		if ( listenerArray !== undefined ) {
 
+			listenerArray = listenerArray.slice();
 			event.target = this;
 
 			for ( var i = 0, l = listenerArray.length; i < l; i ++ ) {


### PR DESCRIPTION
Support the following (and similar) use-case:

``` javascript
var object = new THREE.Object3D()
var doOnce = function() { 
    // do something
    object.removeEventListener("foo",doOnce);
}
object.addEventListener("foo", doOnce);
```
