### PR TITLE
Fixed Double-Counting of Opacity when Vertex Colors Used

### DIFF
--- a/src/renderers/WebGLShaders.js
+++ b/src/renderers/WebGLShaders.js
@@ -1207,7 +1207,7 @@ THREE.ShaderChunk = {
 
 		"#ifdef USE_COLOR",
 
-			"gl_FragColor = gl_FragColor * vec4( vColor, opacity );",
+			"gl_FragColor = gl_FragColor * vec4( vColor, 1.0 );",
 
 		"#endif"
 


### PR DESCRIPTION
In `WebGLShaders.js`, the following pattern was double-counting opacity when `USE_COLOR` is defined:

```
"gl_FragColor = vec4( vec3 ( 1.0 ), opacity );"
    ...
"gl_FragColor = gl_FragColor * vec4( vColor, opacity );",
```

This is now fixed.
