### PR TITLE
Refine grid contrast

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -14,6 +14,7 @@ var Editor = function () {
 		snapChanged: new SIGNALS.Signal(),
 		spaceChanged: new SIGNALS.Signal(),
 		rendererChanged: new SIGNALS.Signal(),
+		themeChanged: new SIGNALS.Signal(),
 
 		sceneGraphChanged: new SIGNALS.Signal(),
 

--- a/editor/js/Sidebar.Renderer.js
+++ b/editor/js/Sidebar.Renderer.js
@@ -53,6 +53,8 @@ Sidebar.Renderer = function ( editor ) {
 
 		}
 
+		signals.themeChanged.dispatch( { selectedIndex: this.value } );
+
 	} );
 
 	themeRow.add( new UI.Text('Theme').setWidth('90px') );

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -407,6 +407,20 @@ var Viewport = function ( editor ) {
 
 	} );
 
+	signals.themeChanged.add( function ( theme ) {
+
+		switch ( theme.selectedIndex ) {
+
+			case '0': grid.setColors( new THREE.Color( 0x444444 ), new THREE.Color( 0x888888 ) ); break;
+			case '1': grid.setColors( new THREE.Color( 0xbbbbbb ), new THREE.Color( 0x888888 )); break;
+
+		}
+
+		// Force refresh
+		render();
+
+	});
+
 	//
 
 	var renderer;


### PR DESCRIPTION
While using the dark theme my eyes are now frequently drawn to axis lines where the structure of the grid seems to break down and it appears slightly hollow due to the axis line and background colors being so similar. The lack of contrast confuses the eye and at times I either see 1x2 rectangles (see attached) along the axis or a double wide path running the full length. It's somewhat distracting and this pull request attempts to put in place a system to address the problem, as well as providing a customizing point for hooking and extending the themeChanged event if one desires.

Finally, the contrast levels are a matter of preference and I went through a few iterations but finally decided to keep the existing grid color and simply resolve the axis line contrast issue. If interested, the following patch has a few workable contrast variations: https://gist.github.com/jlewin/6719065

**Existing Grid Contrast**
![axis-lines](https://f.cloud.github.com/assets/175113/1220590/69a906ee-26dd-11e3-8188-32d823178a0e.jpg)
