### PR TITLE
IE11 COLLADA xpath support fix

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -119,6 +119,14 @@ THREE.ColladaLoader = function () {
 	function parse( doc, callBack, url ) {
 
 		COLLADA = doc;
+		// If missing, add xpath support to XML document
+		if( !COLLADA.evaluate ) {
+			var temp = {document: COLLADA};
+			wgxpath.install(temp);
+			if( !this.XPathResult ) {
+				this.XPathResult = temp.XPathResult;
+			}
+		}
 		callBack = callBack || readyCallbackFunc;
 
 		if ( url !== undefined ) {

--- a/examples/webgl_loader_collada.html
+++ b/examples/webgl_loader_collada.html
@@ -35,6 +35,7 @@
 		<script src="../build/three.min.js"></script>
 
 		<script src="js/loaders/ColladaLoader.js"></script>
+		<script src="https://wicked-good-xpath.googlecode.com/files/wgxpath.install.js"></script>
 
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>

--- a/examples/webgl_loader_collada_keyframe.html
+++ b/examples/webgl_loader_collada_keyframe.html
@@ -37,6 +37,7 @@
 		<script src="../build/three.min.js"></script>
 
 		<script src="js/loaders/ColladaLoader.js"></script>
+		<script src="js/libs/wgxpath.install.js"></script>
 
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>

--- a/examples/webgl_loader_collada_keyframe.html
+++ b/examples/webgl_loader_collada_keyframe.html
@@ -37,7 +37,7 @@
 		<script src="../build/three.min.js"></script>
 
 		<script src="js/loaders/ColladaLoader.js"></script>
-		<script src="js/libs/wgxpath.install.js"></script>
+		<script src="https://wicked-good-xpath.googlecode.com/files/wgxpath.install.js"></script>
 
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>


### PR DESCRIPTION
This pull request adds xpath support to IE11 in order to enable the loading of COLLADA files. This fix uses the wgxpath.install.js lib from the wicked-good-xpath project (https://code.google.com/p/wicked-good-xpath/). 

Note: This fix only enables the loading of COLLADA files. There still exists shader compiler bugs that prevent some of the shaders in the COLLADA examples from compiling. However, enough of the scene is rendered to demonstrate that the loading of COLLADA files is working in IE11.
