### PR TITLE
IE11 CTM Loader XHR2 fix for overrideMimeType

### DIFF
--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -72,7 +72,6 @@ THREE.CTMLoader.prototype.loadParts = function( url, callback, parameters ) {
 	}
 
 	xhr.open( "GET", url, true );
-	if ( xhr.overrideMimeType && !( 'FormData' in window ) ) xhr.overrideMimeType( "text/plain; charset=x-user-defined" );
 	xhr.setRequestHeader( "Content-Type", "text/plain" );
 	xhr.send( null );
 
@@ -101,13 +100,7 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 			if ( xhr.status === 200 || xhr.status === 0 ) {
 
-				var binaryData;
-
-				if( xhr.responseType === 'arraybuffer' )  {
-					binaryData = new Uint8Array(xhr.response);
-				} else {
-					binaryData  = xhr.responseText;
-				}
+				var binaryData = new Uint8Array(xhr.response);
 
 				var s = Date.now();
 
@@ -201,17 +194,7 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 	}
 
 	xhr.open( "GET", url, true );
-
-	// check if xhr2 is available
-	if ( 'FormData' in window ) {
-
-		xhr.responseType = "arraybuffer";
-
-	} else if ( xhr.overrideMimeType )  {
-
-		xhr.overrideMimeType( "text/plain; charset=x-user-defined" );
-
-	}
+	xhr.responseType = "arraybuffer";
 
 	xhr.send( null );
 

--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -72,7 +72,7 @@ THREE.CTMLoader.prototype.loadParts = function( url, callback, parameters ) {
 	}
 
 	xhr.open( "GET", url, true );
-	if ( xhr.overrideMimeType ) xhr.overrideMimeType( "text/plain; charset=x-user-defined" );
+	if ( xhr.overrideMimeType && !( 'FormData' in window ) ) xhr.overrideMimeType( "text/plain; charset=x-user-defined" );
 	xhr.setRequestHeader( "Content-Type", "text/plain" );
 	xhr.send( null );
 
@@ -101,7 +101,13 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 			if ( xhr.status === 200 || xhr.status === 0 ) {
 
-				var binaryData = xhr.responseText;
+				var binaryData;
+
+				if( xhr.responseType === 'arraybuffer' )  {
+					binaryData = new Uint8Array(xhr.response);
+				} else {
+					binaryData  = xhr.responseText;
+				}
 
 				var s = Date.now();
 
@@ -194,8 +200,19 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 	}
 
-	xhr.overrideMimeType( "text/plain; charset=x-user-defined" );
 	xhr.open( "GET", url, true );
+
+	// check if xhr2 is available
+	if ( 'FormData' in window ) {
+
+		xhr.responseType = "arraybuffer";
+
+	} else if ( xhr.overrideMimeType )  {
+
+		xhr.overrideMimeType( "text/plain; charset=x-user-defined" );
+
+	}
+
 	xhr.send( null );
 
 };

--- a/examples/js/loaders/ctm/ctm.js
+++ b/examples/js/loaders/ctm/ctm.js
@@ -585,25 +585,14 @@ CTM.InterleavedStream.prototype.writeByte = function(value){
 CTM.Stream = function(data){
   this.data = data;
   this.offset = 0;
-  if (typeof data === 'string'){
-	this.readByte = this.readByteFromString;
-	this.readString = this.readStringFromString;
-  } else {
-	this.readByte = this.readByteFromArray;
-	this.readString = this.readStringFromArray;
-  }
 };
 
 CTM.Stream.prototype.TWO_POW_MINUS23 = Math.pow(2, -23);
 
 CTM.Stream.prototype.TWO_POW_MINUS126 = Math.pow(2, -126);
 
-CTM.Stream.prototype.readByteFromArray = function(){
+CTM.Stream.prototype.readByte = function(){
   return this.data[this.offset ++] & 0xff;
-};
-
-CTM.Stream.prototype.readByteFromString = function(){
-  return this.data.charCodeAt(this.offset ++) & 0xff;
 };
 
 CTM.Stream.prototype.readInt32 = function(){
@@ -636,21 +625,12 @@ CTM.Stream.prototype.readFloat32 = function(){
   return s * 0;
 };
 
-CTM.Stream.prototype.readStringFromArray = function(){
+CTM.Stream.prototype.readString = function(){
   var len = this.readInt32();
 
   this.offset += len;
 
   return this.data.subarray(this.offset - len, len);
-};
-
-
-CTM.Stream.prototype.readStringFromString = function(){
-  var len = this.readInt32();
-
-  this.offset += len;
-
-  return this.data.substr(this.offset - len, len);
 };
 
 CTM.Stream.prototype.readArrayInt32 = function(array){

--- a/examples/js/loaders/ctm/ctm.js
+++ b/examples/js/loaders/ctm/ctm.js
@@ -585,13 +585,24 @@ CTM.InterleavedStream.prototype.writeByte = function(value){
 CTM.Stream = function(data){
   this.data = data;
   this.offset = 0;
+  if (typeof data === 'string'){
+	this.readByte = this.readByteFromString;
+	this.readString = this.readStringFromString;
+  } else {
+	this.readByte = this.readByteFromArray;
+	this.readString = this.readStringFromArray;
+  }
 };
 
 CTM.Stream.prototype.TWO_POW_MINUS23 = Math.pow(2, -23);
 
 CTM.Stream.prototype.TWO_POW_MINUS126 = Math.pow(2, -126);
 
-CTM.Stream.prototype.readByte = function(){
+CTM.Stream.prototype.readByteFromArray = function(){
+  return this.data[this.offset ++] & 0xff;
+};
+
+CTM.Stream.prototype.readByteFromString = function(){
   return this.data.charCodeAt(this.offset ++) & 0xff;
 };
 
@@ -625,7 +636,16 @@ CTM.Stream.prototype.readFloat32 = function(){
   return s * 0;
 };
 
-CTM.Stream.prototype.readString = function(){
+CTM.Stream.prototype.readStringFromArray = function(){
+  var len = this.readInt32();
+
+  this.offset += len;
+
+  return this.data.subarray(this.offset - len, len);
+};
+
+
+CTM.Stream.prototype.readStringFromString = function(){
   var len = this.readInt32();
 
   this.offset += len;


### PR DESCRIPTION
IE11 does not correctly support overrideMimeType. This pull request adds XHR2 support to the CTM Loader when available. The following changes were made:

CTMLoader.js
1. Uses if ( 'FormData' in window ) to test for XHR2 support. This is the same test used by Modernizer.
2. If no XHR2 support, older overrideMimeType method is used.

ctm.js
1. Added support to handle ArrayBuffer returned by XHR2 response.
2. String support is still used if response is text from overrideMimeType XHR request.

If the use of XHR2 is acceptable, similar changes to the other loaders will be made to add XHR2 support and fix the IE11 problem with overrideMimeType.

Note: This pull request only fixes the problem in IE11 with the use of overrideMimeType. The scene will partially load but some of the shaders will not compile due to IE11 shader compiler bugs.
