### PR TITLE
Blender importer: tessface generated before accessing it

### DIFF
--- a/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/import_threejs.py
+++ b/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/import_threejs.py
@@ -130,6 +130,7 @@ def create_mesh_object(name, vertices, materials, face_data, flipYZ, recalculate
     if face_data["hasVertexNormals"]:
 
         print("setting vertex normals")
+        me.update(calc_tessface = True)
 
         for fi in range(len(faces)):
 
@@ -268,6 +269,7 @@ def create_mesh_object(name, vertices, materials, face_data, flipYZ, recalculate
             me.materials.append(m)
 
         print("setting materials (faces)")
+        me.update(calc_tessface = True)
 
         for fi in range(len(faces)):
 


### PR DESCRIPTION
When importing an object in Blender, it crashes with an index 0 out of range accessing me.tessfaces. I generated the tessfaces(me.update(tessface = True)), now looks that imports correctly.
