### PR TITLE
Fix for issue #2739

### DIFF
--- a/src/core/Projector.js
+++ b/src/core/Projector.js
@@ -391,7 +391,7 @@ THREE.Projector = function () {
 
 				_vector4.z *= invW;
 
-				if ( _vector4.z > 0 && _vector4.z < 1 ) {
+				if ( _vector4.z > -1 && _vector4.z < 1 ) {
 
 					_particle = getNextParticleInPool();
 					_particle.id = object.id;


### PR DESCRIPTION
As mentioned in http://stackoverflow.com/questions/11250053/three-js-canvas-particles-dont-render-with-orthographiccamera there is a clipping problem with particles that is apparent when using the Orthographic camera. The problem is in Projector.js that clips particles to the far part of the view frustrum.

I have made a JSFiddle illustrating the problem, http://jsfiddle.net/89Pgx/1/.
