### PR TITLE
Three.js editor UI.Number NaN patch

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -648,6 +648,10 @@ UI.Number = function ( number ) {
 
 			dom.value = number;
 
+		} else {
+
+			dom.value = '0.00';
+
 		}
 
 	};


### PR DESCRIPTION
Fix for when user selects UI.Number element then deletes the value and submits an empty value which causes a NaN value and thus hiding the object from the scene until fixed. This fix replaces the empty/null value from user with 0.

![image](https://f.cloud.github.com/assets/843453/1347189/6225dda0-36ac-11e3-87fc-a196d8e184e4.png)
