### PR TITLE
Add missing update calls in OrbitControls

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -411,6 +411,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
+        scope.update();
 	}
 
 	function onKeyDown( event ) {
@@ -500,6 +501,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
+        var needUpdate = false;
+
 		switch ( event.touches.length ) {
 
 			case 1: // one-fingered touch: rotate
@@ -515,6 +518,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 				scope.rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed );
 
 				rotateStart.copy( rotateEnd );
+
+                needUpdate = true;
 				break;
 
 			case 2: // two-fingered touch: dolly
@@ -539,6 +544,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 				}
 
 				dollyStart.copy( dollyEnd );
+
+                needUpdate = true;
 				break;
 
 			case 3: // three-fingered touch: pan
@@ -551,10 +558,18 @@ THREE.OrbitControls = function ( object, domElement ) {
 				scope.pan( panDelta );
 
 				panStart.copy( panEnd );
+
+                needUpdate = true;
 				break;
 
 			default:
 				state = STATE.NONE;
+
+		}
+
+		if ( needUpdate ) {
+
+			scope.update();
 
 		}
 


### PR DESCRIPTION
Calls to scope.update() was missing in the mousewheel and touchmove event handlers

commit 352ed93babafa63355232c9213d7c9c63fe55da0 added calls to scope.update() from
https://github.com/greggman/three.js/commit/fde9f9917d6d8381f06bf22cdff766029d1761be
