### PR TITLE
Update ColladaLoader.js

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -541,7 +541,9 @@ THREE.ColladaLoader = function () {
 
 			} else {
 
-				throw 'ColladaLoader: Could not find joint \'' + bone.sid + '\'.';
+				console.log('ColladaLoader: Could not find joint \'' + bone.sid + '\'.');
+				bone.skinningMatrix = new THREE.Matrix4();
+			    	bone.weights = [];
 
 			}
 


### PR DESCRIPTION
Make missing joints a console warning rather than a showstopper. Often models will still be loadable / usable.
