### PR TITLE
Allow shape color to be set to black

### DIFF
--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -82,6 +82,7 @@ Sidebar.Material = function ( editor ) {
 
 	var materialColorRow = new UI.Panel();
 	var materialColor = new UI.Color().onChange( update );
+	materialColor.setValue('#ffffff');
 
 	materialColorRow.add( new UI.Text( 'Color' ).setWidth( '90px' ) );
 	materialColorRow.add( materialColor );


### PR DESCRIPTION
Previously, the shape color could not be set to black until another color change had occurred, because the change of materialColor from null to black wasn't registering as a change.
