### PR TITLE
Internet Explorer fix for UI.Number and UI.Integer slider.

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -596,6 +596,9 @@ UI.Number = function ( number ) {
 	var distance = 0;
 	var onMouseDownValue = 0;
 
+	var pointer = new THREE.Vector2();
+	var pointerOld = new THREE.Vector2();
+
 	var onMouseDown = function ( event ) {
 
 		event.preventDefault();
@@ -603,6 +606,8 @@ UI.Number = function ( number ) {
 		distance = 0;
 
 		onMouseDownValue = parseFloat( dom.value );
+
+		pointerOld.set( event.clientX, event.clientY );
 
 		document.addEventListener( 'mousemove', onMouseMove, false );
 		document.addEventListener( 'mouseup', onMouseUp, false );
@@ -613,8 +618,10 @@ UI.Number = function ( number ) {
 
 		var currentValue = dom.value;
 
-		var movementX = event.movementX || event.webkitMovementX || event.mozMovementX || 0;
-		var movementY = event.movementY || event.webkitMovementY || event.mozMovementY || 0;
+		pointer.set( event.clientX, event.clientY );
+
+		var movementX = pointer.x - pointerOld.x;
+		var movementY = pointer.y - pointerOld.y;
 
 		distance += movementX - movementY;
 
@@ -623,6 +630,8 @@ UI.Number = function ( number ) {
 		dom.value = Math.min( scope.max, Math.max( scope.min, number ) ).toFixed( scope.precision );
 
 		if ( currentValue !== dom.value ) dom.dispatchEvent( changeEvent );
+
+		pointerOld.set( event.clientX, event.clientY );
 
 	};
 
@@ -747,6 +756,9 @@ UI.Integer = function ( number ) {
 	var distance = 0;
 	var onMouseDownValue = 0;
 
+	var pointer = new THREE.Vector2();
+	var pointerOld = new THREE.Vector2();
+
 	var onMouseDown = function ( event ) {
 
 		event.preventDefault();
@@ -754,6 +766,8 @@ UI.Integer = function ( number ) {
 		distance = 0;
 
 		onMouseDownValue = parseFloat( dom.value );
+
+		pointerOld.set( event.clientX, event.clientY );
 
 		document.addEventListener( 'mousemove', onMouseMove, false );
 		document.addEventListener( 'mouseup', onMouseUp, false );
@@ -764,8 +778,10 @@ UI.Integer = function ( number ) {
 
 		var currentValue = dom.value;
 
-		var movementX = event.movementX || event.webkitMovementX || event.mozMovementX || 0;
-		var movementY = event.movementY || event.webkitMovementY || event.mozMovementY || 0;
+		pointer.set( event.clientX, event.clientY );
+
+		var movementX = pointer.x - pointerOld.x;
+		var movementY = pointer.y - pointerOld.y;
 
 		distance += movementX - movementY;
 
@@ -774,6 +790,8 @@ UI.Integer = function ( number ) {
 		dom.value = Math.min( scope.max, Math.max( scope.min, number ) ) | 0;
 
 		if ( currentValue !== dom.value ) dom.dispatchEvent( changeEvent );
+
+		pointerOld.set( event.clientX, event.clientY );
 
 	};
 


### PR DESCRIPTION
**Issue:**
In Internet Explorer the "slider" function of both Number and Integer class doesn't work as properly due to event objects in IE not having the proper movement data compared to Firefox & Chrome.

**Solution:**
Implemented similar fix to TransformControls using a previous and current pointer positions. Maybe there is a better way to do this but I was unable to find the correct movement property on event objects in IE. I assume they don't exist after my research.

**Tested on the following:**
Both Win 7 and Win 8.1
Chrome 30
Firefox 24
IE 11

**Note:** I didn't test below IE 11 since previous versions don't support webgl.
