### PR TITLE
Make EffectComposer plugins use their own camera/scene/quad

### DIFF
--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -65,6 +65,13 @@ THREE.BloomPass = function ( strength, kernelSize, sigma, resolution ) {
 	this.needsSwap = false;
 	this.clear = false;
 
+
+	this.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
+	this.scene  = new THREE.Scene();
+
+	this.quad = new THREE.Mesh( new THREE.PlaneGeometry( 2, 2 ), null );
+	this.scene.add( this.quad );
+
 };
 
 THREE.BloomPass.prototype = {
@@ -75,12 +82,12 @@ THREE.BloomPass.prototype = {
 
 		// Render quad with blured scene into texture (convolution pass 1)
 
-		THREE.EffectComposer.quad.material = this.materialConvolution;
+		this.quad.material = this.materialConvolution;
 
 		this.convolutionUniforms[ "tDiffuse" ].value = readBuffer;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurX;
 
-		renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera, this.renderTargetX, true );
+		renderer.render( this.scene, this.camera, this.renderTargetX, true );
 
 
 		// Render quad with blured scene into texture (convolution pass 2)
@@ -88,17 +95,17 @@ THREE.BloomPass.prototype = {
 		this.convolutionUniforms[ "tDiffuse" ].value = this.renderTargetX;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurY;
 
-		renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera, this.renderTargetY, true );
+		renderer.render( this.scene, this.camera, this.renderTargetY, true );
 
 		// Render original scene with superimposed blur to texture
 
-		THREE.EffectComposer.quad.material = this.materialCopy;
+		this.quad.material = this.materialCopy;
 
 		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetY;
 
 		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
 
-		renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera, readBuffer, this.clear );
+		renderer.render( this.scene, this.camera, readBuffer, this.clear );
 
 	}
 

--- a/examples/js/postprocessing/DotScreenPass.js
+++ b/examples/js/postprocessing/DotScreenPass.js
@@ -27,6 +27,13 @@ THREE.DotScreenPass = function ( center, angle, scale ) {
 	this.renderToScreen = false;
 	this.needsSwap = true;
 
+
+	this.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
+	this.scene  = new THREE.Scene();
+
+	this.quad = new THREE.Mesh( new THREE.PlaneGeometry( 2, 2 ), null );
+	this.scene.add( this.quad );
+
 };
 
 THREE.DotScreenPass.prototype = {
@@ -36,15 +43,15 @@ THREE.DotScreenPass.prototype = {
 		this.uniforms[ "tDiffuse" ].value = readBuffer;
 		this.uniforms[ "tSize" ].value.set( readBuffer.width, readBuffer.height );
 
-		THREE.EffectComposer.quad.material = this.material;
+		this.quad.material = this.material;
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera );
+			renderer.render( this.scene, this.camera );
 
 		} else {
 
-			renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera, writeBuffer, false );
+			renderer.render( this.scene, this.camera, writeBuffer, false );
 
 		}
 

--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -133,12 +133,3 @@ THREE.EffectComposer.prototype = {
 	}
 
 };
-
-// shared ortho camera
-
-THREE.EffectComposer.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
-
-THREE.EffectComposer.quad = new THREE.Mesh( new THREE.PlaneGeometry( 2, 2 ), null );
-
-THREE.EffectComposer.scene = new THREE.Scene();
-THREE.EffectComposer.scene.add( THREE.EffectComposer.quad );

--- a/examples/js/postprocessing/FilmPass.js
+++ b/examples/js/postprocessing/FilmPass.js
@@ -28,6 +28,13 @@ THREE.FilmPass = function ( noiseIntensity, scanlinesIntensity, scanlinesCount, 
 	this.renderToScreen = false;
 	this.needsSwap = true;
 
+
+	this.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
+	this.scene  = new THREE.Scene();
+
+	this.quad = new THREE.Mesh( new THREE.PlaneGeometry( 2, 2 ), null );
+	this.scene.add( this.quad );
+
 };
 
 THREE.FilmPass.prototype = {
@@ -37,15 +44,15 @@ THREE.FilmPass.prototype = {
 		this.uniforms[ "tDiffuse" ].value = readBuffer;
 		this.uniforms[ "time" ].value += delta;
 
-		THREE.EffectComposer.quad.material = this.material;
+		this.quad.material = this.material;
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera );
+			renderer.render( this.scene, this.camera );
 
 		} else {
 
-			renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera, writeBuffer, false );
+			renderer.render( this.scene, this.camera, writeBuffer, false );
 
 		}
 

--- a/examples/js/postprocessing/SavePass.js
+++ b/examples/js/postprocessing/SavePass.js
@@ -34,6 +34,13 @@ THREE.SavePass = function ( renderTarget ) {
 	this.needsSwap = false;
 	this.clear = false;
 
+
+	this.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
+	this.scene  = new THREE.Scene();
+
+	this.quad = new THREE.Mesh( new THREE.PlaneGeometry( 2, 2 ), null );
+	this.scene.add( this.quad );
+
 };
 
 THREE.SavePass.prototype = {
@@ -46,9 +53,9 @@ THREE.SavePass.prototype = {
 
 		}
 
-		THREE.EffectComposer.quad.material = this.material;
+		this.quad.material = this.material;
 
-		renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera, this.renderTarget, this.clear );
+		renderer.render( this.scene, this.camera, this.renderTarget, this.clear );
 
 	}
 

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -22,6 +22,13 @@ THREE.ShaderPass = function ( shader, textureID ) {
 	this.needsSwap = true;
 	this.clear = false;
 
+
+	this.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
+	this.scene  = new THREE.Scene();
+
+	this.quad = new THREE.Mesh( new THREE.PlaneGeometry( 2, 2 ), null );
+	this.scene.add( this.quad );
+
 };
 
 THREE.ShaderPass.prototype = {
@@ -34,15 +41,15 @@ THREE.ShaderPass.prototype = {
 
 		}
 
-		THREE.EffectComposer.quad.material = this.material;
+		this.quad.material = this.material;
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera );
+			renderer.render( this.scene, this.camera );
 
 		} else {
 
-			renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera, writeBuffer, this.clear );
+			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
 
 		}
 

--- a/examples/js/postprocessing/TexturePass.js
+++ b/examples/js/postprocessing/TexturePass.js
@@ -25,15 +25,22 @@ THREE.TexturePass = function ( texture, opacity ) {
 	this.enabled = true;
 	this.needsSwap = false;
 
+
+	this.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
+	this.scene  = new THREE.Scene();
+
+	this.quad = new THREE.Mesh( new THREE.PlaneGeometry( 2, 2 ), null );
+	this.scene.add( this.quad );
+
 };
 
 THREE.TexturePass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta ) {
 
-		THREE.EffectComposer.quad.material = this.material;
+		this.quad.material = this.material;
 
-		renderer.render( THREE.EffectComposer.scene, THREE.EffectComposer.camera, readBuffer );
+		renderer.render( this.scene, this.camera, readBuffer );
 
 	}
 

--- a/examples/js/renderers/WebGLDeferredRenderer.js
+++ b/examples/js/renderers/WebGLDeferredRenderer.js
@@ -989,7 +989,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		passColor.camera = currentCamera;
 		passNormalDepth.camera = currentCamera;
 		passLightProxy.camera = currentCamera;
-		passLightFullscreen.camera = THREE.EffectComposer.camera;
+		passLightFullscreen.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
 
 		passColor.scene = scene;
 		passNormalDepth.scene = scene;


### PR DESCRIPTION
This fixes #2951 for now, until someone redesigns the postprocessing API.
