### PR TITLE
Normalize indentation in Blender exporter

### DIFF
--- a/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -267,7 +267,7 @@ TEMPLATE_MODEL_ASCII = """\
 
 	"skinWeights" : [%(weights)s],
 
-    "animations" : [%(animations)s]
+	"animations" : [%(animations)s]
 """
 
 TEMPLATE_VERTEX = "%g,%g,%g"


### PR DESCRIPTION
Making the exporter for Blender 2.66 producing consistent indentation (all tabs rather than mixed tabs and spaces).
