### PR TITLE
Dispose attribute data if geometry is dynamic

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2393,7 +2393,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
-			if ( dispose && ! attributeItem.dynamic ) {
+			if ( dispose && ! geometry.dynamic ) {
 
 				attributeItem.array = null;
 


### PR DESCRIPTION
From the comments in BufferGeometry/Geometry, my understanding is the geometry dynamic property should control the disposal policy of attribute data.

Currently the code is checking the dynamic property of an attribute. Unless this is defined by the user it is always false. The geometry dynamic property seems to be unused.
