### PR TITLE
Replaced use of XPath queries with querySelectorAll to fix IE11

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -131,16 +131,16 @@ THREE.ColladaLoader = function () {
 
 		parseAsset();
 		setUpConversion();
-		images = parseLib( "//dae:library_images/dae:image", _Image, "image" );
-		materials = parseLib( "//dae:library_materials/dae:material", Material, "material" );
-		effects = parseLib( "//dae:library_effects/dae:effect", Effect, "effect" );
-		geometries = parseLib( "//dae:library_geometries/dae:geometry", Geometry, "geometry" );
-		cameras = parseLib( ".//dae:library_cameras/dae:camera", Camera, "camera" );
-		lights = parseLib( ".//dae:library_lights/dae:light", Light, "light" );
-		controllers = parseLib( "//dae:library_controllers/dae:controller", Controller, "controller" );
-		animations = parseLib( "//dae:library_animations/dae:animation", Animation, "animation" );
-		visualScenes = parseLib( ".//dae:library_visual_scenes/dae:visual_scene", VisualScene, "visual_scene" );
-
+		images = parseLib( "library_images image", _Image, "image" );
+		materials = parseLib( "library_materials material", Material, "material" );
+		effects = parseLib( "library_effects effect", Effect, "effect" );
+		geometries = parseLib( "library_geometries geometry", Geometry, "geometry" );
+		cameras = parseLib( "library_cameras camera", Camera, "camera" );
+		lights = parseLib( "library_lights light", Light, "light" );
+		controllers = parseLib( "library_controllers controller", Controller, "controller" );
+		animations = parseLib( "library_animations animation", Animation, "animation" );
+		visualScenes = parseLib( "library_visual_scenes visual_scene", VisualScene, "visual_scene" );
+        
 		morphs = [];
 		skins = [];
 
@@ -197,15 +197,16 @@ THREE.ColladaLoader = function () {
 
 	function parseAsset () {
 
-		var elements = COLLADA.evaluate( '//dae:asset', COLLADA, _nsResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null );
+        var elements = COLLADA.querySelectorAll('asset');
+        
+        var elementsLength = elements.length; //cache loop length
+        for (var i = 0; i < elementsLength; i ++){
+            var element = elements[i];
+            
+            var elementChildNodesLength = element.childNodes.length;
+			for ( var j = 0; j < elementChildNodesLength; j ++ ) {
 
-		var element = elements.iterateNext();
-
-		if ( element && element.childNodes ) {
-
-			for ( var i = 0; i < element.childNodes.length; i ++ ) {
-
-				var child = element.childNodes[ i ];
+				var child = element.childNodes[ j ];
 
 				switch ( child.nodeName ) {
 
@@ -236,19 +237,19 @@ THREE.ColladaLoader = function () {
 
 	function parseLib ( q, classSpec, prefix ) {
 
-		var elements = COLLADA.evaluate(q, COLLADA, _nsResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null) ;
+        var elements = COLLADA.querySelectorAll(q);
 
-		var lib = {};
-		var element = elements.iterateNext();
+        var lib = {};
+
 		var i = 0;
 
-		while ( element ) {
+        var elementsLength = elements.length;
+		for (var j = 0; j < elementsLength; j++){
+            var element = elements[j];
 
-			var daeElement = ( new classSpec() ).parse( element );
+            var daeElement = ( new classSpec() ).parse( element );
 			if ( !daeElement.id || daeElement.id.length == 0 ) daeElement.id = prefix + ( i ++ );
 			lib[ daeElement.id ] = daeElement;
-
-			element = elements.iterateNext();
 
 		}
 
@@ -257,9 +258,9 @@ THREE.ColladaLoader = function () {
 	};
 
 	function parseScene() {
-
-		var sceneElement = COLLADA.evaluate( './/dae:scene/dae:instance_visual_scene', COLLADA, _nsResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null ).iterateNext();
-
+    
+        var sceneElement = COLLADA.querySelectorAll('scene instance_visual_scene')[0];
+        
 		if ( sceneElement ) {
 
 			var url = sceneElement.getAttribute( 'url' ).replace( /^#/, '' );
@@ -494,15 +495,15 @@ THREE.ColladaLoader = function () {
 	function setupSkinningMatrices ( bones, skin ) {
 
 		// FIXME: this is dumb...
-
-		for ( var i = 0; i < bones.length; i ++ ) {
-
+        
+		for ( var i = 0; i < bones.length ; i ++ ) {
+        
 			var bone = bones[ i ];
 			var found = -1;
 
 			if ( bone.type != 'JOINT' ) continue;
 
-			for ( var j = 0; j < skin.joints.length; j ++ ) {
+			for ( var j = 0; j < skin.joints.length ; j ++ ) {
 
 				if ( bone.sid == skin.joints[ j ] ) {
 
@@ -523,8 +524,8 @@ THREE.ColladaLoader = function () {
 
 				bone.weights = [];
 
-				for ( var j = 0; j < skin.weights.length; j ++ ) {
-
+                for ( var j = 0; j < skin.weights.length ; j ++ ) {
+                    
 					for (var k = 0; k < skin.weights[ j ].length; k ++) {
 
 						var w = skin.weights[ j ][ k ];
@@ -923,8 +924,8 @@ THREE.ColladaLoader = function () {
 	};
 
 	function getLibraryNode( id ) {
-
-		return COLLADA.evaluate( './/dae:library_nodes//dae:node[@id=\'' + id + '\']', COLLADA, _nsResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null ).iterateNext();
+    
+        return COLLADA.querySelectorAll('library_nodes node#'+id)[0];  //returns 'undefined' if nothing is matched
 
 	};
 
@@ -2200,21 +2201,17 @@ THREE.ColladaLoader = function () {
 					break;
 
 				case 'bind_material':
+            
+                    var instances = child.querySelectorAll('instance_material');
+                    
+					for (var j = 0; j < instances.length; j ++){
 
-					var instances = COLLADA.evaluate( './/dae:instance_material', child, _nsResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null );
+						var instance = instances[j];
 
-					if ( instances ) {
+                        this.instance_material.push( (new InstanceMaterial()).parse(instance) );
+						
+                    }
 
-						var instance = instances.iterateNext();
-
-						while ( instance ) {
-
-							this.instance_material.push( (new InstanceMaterial()).parse(instance) );
-							instance = instances.iterateNext();
-
-						}
-
-					}
 
 					break;
 
@@ -2265,19 +2262,11 @@ THREE.ColladaLoader = function () {
 
 			if ( child.nodeName == 'bind_material' ) {
 
-				var instances = COLLADA.evaluate( './/dae:instance_material', child, _nsResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null );
-
-				if ( instances ) {
-
-					var instance = instances.iterateNext();
-
-					while ( instance ) {
-
-						this.instance_material.push( (new InstanceMaterial()).parse(instance) );
-						instance = instances.iterateNext();
-
-					}
-
+                var instances = child.querySelectorAll('instance_material');
+                    
+            	for (var j = 0; j < instances.length; j++){
+                    var instance = instances[j];
+             		this.instance_material.push( (new InstanceMaterial()).parse(instance) );
 				}
 
 				break;
@@ -2422,8 +2411,8 @@ THREE.ColladaLoader = function () {
 		var source, numParams;
 		var vcIndex = 0, vcount = 3, maxOffset = 0;
 		var texture_sets = [];
-
-		for ( j = 0; j < inputs.length; j ++ ) {
+        
+		for ( j = 0; j < inputs.length ; j ++ ) {
 
 			input = inputs[ j ];
 			var offset = input.offset + 1;
@@ -3135,7 +3124,7 @@ THREE.ColladaLoader = function () {
 				case 'index_of_refraction':
 				case 'transparency':
 
-					var f = evaluateXPath( child, './/dae:float' );
+					var f = child.querySelectorAll('float');
 
 					if ( f.length > 0 )
 						this[ child.nodeName ] = parseFloat( f[ 0 ].textContent );
@@ -4399,33 +4388,13 @@ THREE.ColladaLoader = function () {
 
 	};
 
-	function evaluateXPath( node, query ) {
-
-		var instances = COLLADA.evaluate( query, node, _nsResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null );
-
-		var inst = instances.iterateNext();
-		var result = [];
-
-		while ( inst ) {
-
-			result.push( inst );
-			inst = instances.iterateNext();
-
-		}
-
-		return result;
-
-	};
-
 	function extractDoubleSided( obj, element ) {
 
 		obj.doubleSided = false;
 
-		var node = COLLADA.evaluate( './/dae:extra//dae:double_sided', element, _nsResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null );
-
+        var node = element.querySelectorAll('extra double_sided')[0];
+    
 		if ( node ) {
-
-			node = node.iterateNext();
 
 			if ( node && parseInt( node.textContent, 10 ) === 1 ) {
 


### PR DESCRIPTION
Replaced use of XPath queries with querySelectorAll to fix IE11. IE11 does not support XPath. However all modern browser support querySelectorAll() (http://caniuse.com/queryselector)

Collada examples now loads in IE11 without errors.  

webgl_loader_collada example now works.

webgl_loader_collada_keyframe example still has shader errors that need to be fixed in IE WebGL implementation.
