### PR TITLE
Document three.js constants

### DIFF
--- a/docs/api/constants/CustomBlendingEquations.html
+++ b/docs/api/constants/CustomBlendingEquations.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<script src="../../list.js"></script>
+		<script src="../../page.js"></script>
+		<link type="text/css" rel="stylesheet" href="../../page.css" />
+	</head>
+	<body>
+		<h1>Custom Blending Equation Constants</h1>
+
+    <h2>Equations</h2>
+    <div>
+    THREE.AddEquation<br />
+    THREE.SubtractEquation<br />
+    THREE.ReverseSubtractEquation
+    </div>
+
+    <h2>Destination Factors</h2>
+    <div>
+    THREE.ZeroFactor<br />
+    THREE.OneFactor<br />
+    THREE.SrcColorFactor<br />
+    THREE.OneMinusSrcColorFactor<br />
+    THREE.SrcAlphaFactor<br />
+    THREE.OneMinusSrcAlphaFactor<br />
+    THREE.DstAlphaFactor<br />
+    THREE.OneMinusDstAlphaFactor
+    </div>
+
+    <h2>Source Factors</h2>
+    <div>
+    THREE.DstColorFactor<br />
+    THREE.OneMinusDstColorFactor<br />
+    THREE.SrcAlphaSaturateFactor
+    </div>
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/src/Three.js src/Three.js]
+	</body>
+</html>

--- a/docs/api/constants/GLState.html
+++ b/docs/api/constants/GLState.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<script src="../../list.js"></script>
+		<script src="../../page.js"></script>
+		<link type="text/css" rel="stylesheet" href="../../page.css" />
+	</head>
+	<body>
+		<h1>GL State Conflicts</h1>
+
+    <h2>Cull Face</h2>
+		<div>
+    THREE.CullFaceNone<br />
+    THREE.CullFaceBack<br />
+    THREE.CullFaceFront<br />
+    THREE.CullFaceFrontBack
+		</div>
+
+    <h2>Front Face Direction</h2>
+		<div>
+    THREE.FrontFaceDirectionCW<br />
+    THREE.FrontFaceDirectionCCW<br />
+		</div>
+    
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/src/Three.js src/Three.js]
+	</body>
+</html>

--- a/docs/api/constants/Materials.html
+++ b/docs/api/constants/Materials.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<script src="../../list.js"></script>
+		<script src="../../page.js"></script>
+		<link type="text/css" rel="stylesheet" href="../../page.css" />
+	</head>
+	<body>
+		<h1>Material Constants</h1>
+
+    <h2>Side</h2>
+		<div>
+    THREE.FrontSide<br />
+    THREE.BackSide<br />
+    THREE.DoubleSide
+		</div>
+
+    <h2>Shading</h2>
+		<div>
+    THREE.NoShading<br />
+    THREE.FlatShading<br />
+    THREE.SmoothShading
+		</div>
+
+    <h2>Colors</h2>
+		<div>
+    THREE.NoColors<br />
+    THREE.FaceColors<br />
+    THREE.VertexColors
+		</div>
+
+    <h2>Blending Mode</h2>
+		<div>
+    THREE.NoBlending<br />
+    THREE.NormalBlending<br />
+    THREE.AdditiveBlending<br />
+    THREE.SubtractiveBlending<br />
+    THREE.MultiplyBlending<br />
+    THREE.CustomBlending
+		</div>
+
+
+    
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/src/Three.js src/Three.js]
+	</body>
+</html>

--- a/docs/api/constants/ShadowingTypes.html
+++ b/docs/api/constants/ShadowingTypes.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<script src="../../list.js"></script>
+		<script src="../../page.js"></script>
+		<link type="text/css" rel="stylesheet" href="../../page.css" />
+	</head>
+	<body>
+		<h1>Shadowing Type Contants</h1>
+
+    <h2>Shadow Map</h2>
+		<div>
+    THREE.BasicShadowMap<br />
+    THREE.PCFShadowMap<br />
+    THREE.PCFSoftShadowMap
+		</div>
+
+    
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/src/Three.js src/Three.js]
+	</body>
+</html>

--- a/docs/api/constants/Textures.html
+++ b/docs/api/constants/Textures.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<script src="../../list.js"></script>
+		<script src="../../page.js"></script>
+		<link type="text/css" rel="stylesheet" href="../../page.css" />
+	</head>
+	<body>
+		<h1>Texture Constants</h1>
+
+    <h2>Texture Constants</h2>
+    <h2>Operations</h2>
+    <div>
+    THREE.MultiplyOperation<br />
+    THREE.MixOperation<br />
+    THREE.AddOperation
+    </div>
+
+    <h2>Mapping Modes</h2>
+    <div>
+    THREE.UVMapping<br />
+    THREE.CubeReflectionMapping<br />
+    THREE.CubeRefractionMapping<br />
+    THREE.SphericalReflectionMapping<br />
+    THREE.SphericalRefractionMapping
+    </div>
+
+    <h2>Wrapping Modes</h2>
+    <div>
+    THREE.RepeatWrapping<br />
+    THREE.ClampToEdgeWrapping<br />
+    THREE.MirroredRepeatWrapping
+    </div>
+
+    <h2>Filters</h2>
+    <div>
+    THREE.NearestFilter<br />
+    THREE.NearestMipMapNearestFilter<br />
+    THREE.NearestMipMapLinearFilter<br />
+    THREE.LinearFilter<br />
+    THREE.LinearMipMapNearestFilter<br />
+    THREE.LinearMipMapLinearFilter
+    </div>
+
+    <h2>Data Types</h2>
+    <div>
+    THREE.UnsignedByteType<br />
+    THREE.ByteType<br />
+    THREE.ShortType<br />
+    THREE.UnsignedShortType<br />
+    THREE.IntType<br />
+    THREE.UnsignedIntType<br />
+    THREE.FloatType
+    </div>
+
+    <h2>Pixel Types</h2>
+    <div>
+    THREE.UnsignedShort4444Type<br />
+    THREE.UnsignedShort5551Type<br />
+    THREE.UnsignedShort565Type
+    </div>
+
+    <h2>Pixel Formats</h2>
+    <div>
+    THREE.AlphaFormat<br />
+    THREE.RGBFormat<br />
+    THREE.RGBAFormat<br />
+    THREE.LuminanceFormat<br />
+    THREE.LuminanceAlphaFormat
+    </div>
+
+    <h2>Compressed Texture Formats</h2>
+    <div>
+    THREE.RGB_S3TC_DXT1_Format<br />
+    THREE.RGBA_S3TC_DXT1_Format<br />
+    THREE.RGBA_S3TC_DXT3_Format<br />
+    THREE.RGBA_S3TC_DXT5_Format
+    </div>
+
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/src/Three.js src/Three.js]
+	</body>
+</html>

--- a/docs/list.js
+++ b/docs/list.js
@@ -7,6 +7,14 @@ var list = {
 	},
 
 	"Reference": {
+    "Constants": [
+      [ "CustomBlendingEquation", "api/constants/CustomBlendingEquations"],
+      [ "GLState", "api/constants/GLState"],
+      [ "Materials", "api/constants/Materials"],
+      [ "ShadowingTypes", "api/constants/ShadowingTypes"],
+      [ "Textures", "api/constants/Textures"]
+    ],
+
 		"Cameras": [
 			[ "Camera", "api/cameras/Camera" ],
 			[ "OrthographicCamera", "api/cameras/OrthographicCamera" ],


### PR DESCRIPTION
I thought it would be valuable to have three.js constants documented somewhere other than in code.

Ultimately, I'd also like to make it so that when we have a property that says something along the lines of "default is NormalBlending", you can click NormalBlending and be taken to the page of constants showing other options.  This patch opens up that ability, as you could now do [page:Materials NormalBlending].

I'm open to feedback on whether the Constants category belongs at the front of reference or elsewhere.

It might also be nice to get short descriptions of various constants ultimately, though I don't have that expertise and they may all be self-explanatory anyways.
