### PR TITLE
Docs: some description for Geometry's lineDistances

### DIFF
--- a/docs/api/core/Geometry.html
+++ b/docs/api/core/Geometry.html
@@ -179,7 +179,9 @@
 
 		<h3>.[page:array lineDistances]</h3>
 		<div>
-		todo
+		An array containing distances between vertices for Line geometries.
+		This is required for LinePieces/LineDashedMaterial to render correctly.
+		Line distances can also be generated with computeLineDistances.
 		</div> 
 
 		<h2>Methods</h2>
@@ -275,7 +277,7 @@
 
 		<h3>.computeLineDistances() [page:todo]</h3>
 		<div>
-		todo
+		Compute distances between vertices for Line geometries.
 		</div>
 
 		<h3>.addEventListener([page:todo type], [page:todo listener]) [page:todo]</h3>


### PR DESCRIPTION
Added some documentation for `geometry.lineDistances` since it wasn't very obvious apart from its usage in `examples/webgl_lines_dashed.html`.
