### PR TITLE
Blender camera export fix

### DIFF
--- a/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.66/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -2081,7 +2081,7 @@ def generate_cameras(data):
     if data["use_cameras"]:
 
         cams = bpy.data.objects
-        cams = [ob for ob in cams if (ob.type == 'CAMERA' and ob.select)]
+        cams = [ob for ob in cams if (ob.type == 'CAMERA')]
 
         if not cams:
             camera = DEFAULTS["camera"]


### PR DESCRIPTION
Export all cameras in `generate_cameras` (if 'export cameras' is checked), not just the selected one.
