### PR TITLE
Update matrix documentation to indicate row-major or column-major

### DIFF
--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -28,7 +28,7 @@
 		n33 -- todo
 		</div>
 		<div>
-		todo
+		Initialize the 3x3 matrix with a row-major sequence of values.
 		</div>
 
 
@@ -37,7 +37,7 @@
 
 		<h3>.[page:Float32Array elements]</h3>
 		<div>
-		Float32Array with matrix values.
+		Float32Array with column-major matrix values.
 		</div>
 
 
@@ -72,7 +72,7 @@
 		n33 -- todo
 		</div>
 		<div>
-		todo
+		Set the 3x3 matrix values to the given row-major sequence of values.
 		</div>
 
 		<h3>.multiplyScalar([page:todo s]) [page:todo]</h3>

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -40,18 +40,20 @@
 
 		<h3>[name]( [page:Float n11], [page:Float n12], [page:Float n13], [page:Float n14], [page:Float n21], [page:Float n22], [page:Float n23], [page:Float n24], [page:Float n31], [page:Float n32], [page:Float n33], [page:Float n34], [page:Float n41], [page:Float n42], [page:Float n43], [page:Float n44] )</h3>
 
-		<div>Initialises the matrix with the supplied n11..n44 values, or just creates an identity matrix if no values are passed.</div>
+		<div>
+		Initialises the matrix with the supplied row-major values n11..n44, or just creates an identity matrix if no values are passed.
+		</div>
 
 		<h2>Properties</h2>
 
 		<h3>.[page:Float32Array elements]</h3>
-
+		<div>A column-major list of matrix values.</div>
 
 		<h2>Methods</h2>
 
 		<h3>.set( [page:Float n11], [page:Float n12], [page:Float n13], [page:Float n14], [page:Float n21], [page:Float n22], [page:Float n23], [page:Float n24], [page:Float n31], [page:Float n32], [page:Float n33], [page:Float n34], [page:Float n41], [page:Float n42], [page:Float n43], [page:Float n44] ) [page:Matrix4]</h3>
 		<div>
-		Sets all fields of this matrix.
+		Sets all fields of this matrix to the supplied row-major values n11..n44.
 		</div>
 
 		<h3>.identity() [page:Matrix4]</h3>


### PR DESCRIPTION
Updated docs with language specifying whether matrix properties/methods use row-major or column-major ordering of values.
