### PR TITLE
Preserve face ordering in OBJLoader and OBJMTLLoader.

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -45,68 +45,84 @@ THREE.OBJLoader.prototype = {
 			return new THREE.Face3( a, b, c, normals );
 
 		}
-    
+		
 		var object = new THREE.Object3D();
 		var geometry, material, mesh;
-    var face_offset = 0;
-    
-    function add_face( a, b, c, normals_inds ) {
-      if ( normals_inds === undefined ) {
-        geometry.faces.push( face3(
-  				parseInt( a ) - (face_offset + 1),
-  				parseInt( b ) - (face_offset + 1),
-  				parseInt( c ) - (face_offset + 1)
-  			) );
-      } else {
-        geometry.faces.push( face3(
-  				parseInt( a ) - (face_offset + 1),
-  				parseInt( b ) - (face_offset + 1),
-  				parseInt( c ) - (face_offset + 1),
-  				[
-  					normals[ parseInt( normals_inds[ 0 ] ) - 1 ].clone(),
-  					normals[ parseInt( normals_inds[ 1 ] ) - 1 ].clone(),
-  					normals[ parseInt( normals_inds[ 2 ] ) - 1 ].clone()
-  				]
-  			) );
-      }
-    }
-    
-    function add_uvs( a, b, c ) {
+		var face_offset = 0;
+		
+		function add_face( a, b, c, normals_inds ) {
+
+			if ( normals_inds === undefined ) {
+
+				geometry.faces.push( face3(
+					parseInt( a ) - (face_offset + 1),
+					parseInt( b ) - (face_offset + 1),
+					parseInt( c ) - (face_offset + 1)
+				) );
+
+			} else {
+
+				geometry.faces.push( face3(
+					parseInt( a ) - (face_offset + 1),
+					parseInt( b ) - (face_offset + 1),
+					parseInt( c ) - (face_offset + 1),
+					[
+						normals[ parseInt( normals_inds[ 0 ] ) - 1 ].clone(),
+						normals[ parseInt( normals_inds[ 1 ] ) - 1 ].clone(),
+						normals[ parseInt( normals_inds[ 2 ] ) - 1 ].clone()
+					]
+				) );
+
+			}
+
+		}
+		
+		function add_uvs( a, b, c ) {
+      
 			geometry.faceVertexUvs[ 0 ].push( [
 				uvs[ parseInt( a ) - 1 ].clone(),
 				uvs[ parseInt( b ) - 1 ].clone(),
 				uvs[ parseInt( c ) - 1 ].clone()
 			] );
-    }
-    
-    function handle_face_line(faces, uvs, normals_inds) {
 
-  		if ( faces[ 3 ] === undefined ) {
-        
-        add_face( faces[ 0 ], faces[ 1 ], faces[ 2 ], normals_inds );
-        
-        if (!(uvs === undefined) && uvs.length > 0) {
-          add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 2 ] );
-        }
+		}
+		
+		function handle_face_line(faces, uvs, normals_inds) {
 
-      } else {
-        
-        if (!(normals_inds === undefined) && normals_inds.length > 0) {
-          add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ], [ normals_inds[ 0 ], normals_inds[ 1 ], normals_inds[ 3 ] ]);
-          add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ], [ normals_inds[ 1 ], normals_inds[ 2 ], normals_inds[ 3 ] ]);
-        } else {
-          add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ]);
-          add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ]);
-        }
-        
-        if (!(uvs === undefined) && uvs.length > 0) {
-          add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 3 ] );
-          add_uvs( uvs[ 1 ], uvs[ 2 ], uvs[ 3 ] );
-        }
+			if ( faces[ 3 ] === undefined ) {
+				
+				add_face( faces[ 0 ], faces[ 1 ], faces[ 2 ], normals_inds );
+				
+				if (!(uvs === undefined) && uvs.length > 0) {
 
-  		}
-      
-    }
+					add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 2 ] );
+
+				}
+
+			} else {
+				
+				if (!(normals_inds === undefined) && normals_inds.length > 0) {
+
+					add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ], [ normals_inds[ 0 ], normals_inds[ 1 ], normals_inds[ 3 ] ]);
+					add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ], [ normals_inds[ 1 ], normals_inds[ 2 ], normals_inds[ 3 ] ]);
+
+				} else {
+
+					add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ]);
+					add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ]);
+
+				}
+				
+				if (!(uvs === undefined) && uvs.length > 0) {
+
+					add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 3 ] );
+					add_uvs( uvs[ 1 ], uvs[ 2 ], uvs[ 3 ] );
+
+				}
+
+			}
+			
+		}
 
 		// create mesh if no objects in text
 
@@ -200,45 +216,47 @@ THREE.OBJLoader.prototype = {
 
 				// ["f 1 2 3", "1", "2", "3", undefined]
 
-        handle_face_line([ result[ 1 ], result[ 2 ], result[ 3 ], result[ 4 ] ]);
+				handle_face_line([ result[ 1 ], result[ 2 ], result[ 3 ], result[ 4 ] ]);
 
 			} else if ( ( result = face_pattern2.exec( line ) ) !== null ) {
 
 				// ["f 1/1 2/2 3/3", " 1/1", "1", "1", " 2/2", "2", "2", " 3/3", "3", "3", undefined, undefined, undefined]
-        
-        handle_face_line(
-          [ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
-          [ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //uv
-        );
+				
+				handle_face_line(
+					[ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
+					[ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //uv
+				);
 
 			} else if ( ( result = face_pattern3.exec( line ) ) !== null ) {
 
 				// ["f 1/1/1 2/2/2 3/3/3", " 1/1/1", "1", "1", "1", " 2/2/2", "2", "2", "2", " 3/3/3", "3", "3", "3", undefined, undefined, undefined, undefined]
 
-        handle_face_line(
-          [ result[ 2 ], result[ 6 ], result[ 10 ], result[ 14 ] ], //faces
-          [ result[ 3 ], result[ 7 ], result[ 11 ], result[ 15 ] ], //uv
-          [ result[ 4 ], result[ 8 ], result[ 12 ], result[ 16 ] ] //normal
-        );
+				handle_face_line(
+					[ result[ 2 ], result[ 6 ], result[ 10 ], result[ 14 ] ], //faces
+					[ result[ 3 ], result[ 7 ], result[ 11 ], result[ 15 ] ], //uv
+					[ result[ 4 ], result[ 8 ], result[ 12 ], result[ 16 ] ] //normal
+				);
 
 			} else if ( ( result = face_pattern4.exec( line ) ) !== null ) {
 
 				// ["f 1//1 2//2 3//3", " 1//1", "1", "1", " 2//2", "2", "2", " 3//3", "3", "3", undefined, undefined, undefined]
 
-        handle_face_line(
-          [ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
-          [ ], //uv
-          [ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //normal
-        );
+				handle_face_line(
+					[ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
+					[ ], //uv
+					[ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //normal
+				);
 
 			} else if ( /^o /.test( line ) ) {
 
 				// object
 
-        if (!(geometry === undefined)) {
-          face_offset = face_offset + geometry.vertices.length;
-        }
-        
+				if (!(geometry === undefined)) {
+
+					face_offset = face_offset + geometry.vertices.length;
+
+				}
+				
 				geometry = new THREE.Geometry();
 				material = new THREE.MeshLambertMaterial();
 
@@ -283,7 +301,7 @@ THREE.OBJLoader.prototype = {
 			geometry.computeBoundingSphere();
 
 		}
-    
+		
 		return object;
 
 	}

--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -63,9 +63,9 @@ THREE.OBJLoader.prototype = {
   				parseInt( b ) - (face_offset + 1),
   				parseInt( c ) - (face_offset + 1),
   				[
-  					normals[ parseInt( normals_inds[ 0 ] ) - 1 ],
-  					normals[ parseInt( normals_inds[ 1 ] ) - 1 ],
-  					normals[ parseInt( normals_inds[ 2 ] ) - 1 ]
+  					normals[ parseInt( normals_inds[ 0 ] ) - 1 ].clone(),
+  					normals[ parseInt( normals_inds[ 1 ] ) - 1 ].clone(),
+  					normals[ parseInt( normals_inds[ 2 ] ) - 1 ].clone()
   				]
   			) );
       }
@@ -73,9 +73,9 @@ THREE.OBJLoader.prototype = {
     
     function add_uvs( a, b, c ) {
 			geometry.faceVertexUvs[ 0 ].push( [
-				uvs[ parseInt( a ) - 1 ],
-				uvs[ parseInt( b ) - 1 ],
-				uvs[ parseInt( c ) - 1 ]
+				uvs[ parseInt( a ) - 1 ].clone(),
+				uvs[ parseInt( b ) - 1 ].clone(),
+				uvs[ parseInt( c ) - 1 ].clone()
 			] );
     }
     

--- a/examples/js/loaders/OBJMTLLoader.js
+++ b/examples/js/loaders/OBJMTLLoader.js
@@ -78,20 +78,20 @@ THREE.OBJMTLLoader.prototype = {
 
 		}
 
+    var face_offset = 0;
+
 		function meshN( meshName, materialName ) {
 
-			if ( geometry.vertices.length > 0 ) {
-
-				geometry.mergeVertices();
+			if ( vertices.length > 0 ) {
+        geometry.vertices = vertices;
+        geometry.mergeVertices();
 				geometry.computeCentroids();
 				geometry.computeFaceNormals();
 				geometry.computeBoundingSphere();
-
 				object.add( mesh );
 
 				geometry = new THREE.Geometry();
 				mesh = new THREE.Mesh( geometry, material );
-
 				verticesCount = 0;
 
 			}
@@ -119,6 +119,65 @@ THREE.OBJMTLLoader.prototype = {
 		var verticesCount = 0;
 		var normals = [];
 		var uvs = [];
+
+    function add_face( a, b, c, normals_inds ) {
+      if ( normals_inds === undefined ) {
+        geometry.faces.push( face3(
+  				parseInt( a ) - (face_offset + 1),
+  				parseInt( b ) - (face_offset + 1),
+  				parseInt( c ) - (face_offset + 1)
+  			) );
+      } else {
+        geometry.faces.push( face3(
+  				parseInt( a ) - (face_offset + 1),
+  				parseInt( b ) - (face_offset + 1),
+  				parseInt( c ) - (face_offset + 1),
+  				[
+  					normals[ parseInt( normals_inds[ 0 ] ) - 1 ],
+  					normals[ parseInt( normals_inds[ 1 ] ) - 1 ],
+  					normals[ parseInt( normals_inds[ 2 ] ) - 1 ]
+  				]
+  			) );
+      }
+    }
+    
+    function add_uvs( a, b, c ) {
+			geometry.faceVertexUvs[ 0 ].push( [
+				uvs[ parseInt( a ) - 1 ],
+				uvs[ parseInt( b ) - 1 ],
+				uvs[ parseInt( c ) - 1 ]
+			] );
+    }
+    
+    function handle_face_line(faces, uvs, normals_inds) {
+      
+  		if ( faces[ 3 ] === undefined ) {
+        
+        add_face( faces[ 0 ], faces[ 1 ], faces[ 2 ], normals_inds );
+        
+        if (!(uvs === undefined) && uvs.length > 0) {
+          add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 2 ] );
+        }
+
+      } else {
+        
+        if (!(normals_inds === undefined) && normals_inds.length > 0) {
+          add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ], [ normals_inds[ 0 ], normals_inds[ 1 ], normals_inds[ 3 ] ]);
+          add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ], [ normals_inds[ 1 ], normals_inds[ 2 ], normals_inds[ 3 ] ]);
+        } else {
+          add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ]);
+          add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ]);
+        }
+        
+        if (!(uvs === undefined) && uvs.length > 0) {
+          add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 3 ] );
+          add_uvs( uvs[ 1 ], uvs[ 2 ], uvs[ 3 ] );
+        }
+
+  		}
+      
+    }
+
 
 		// v float float float
 
@@ -196,244 +255,44 @@ THREE.OBJMTLLoader.prototype = {
 
 				// ["f 1 2 3", "1", "2", "3", undefined]
 
-				 if ( result[ 4 ] === undefined ) {
-
-					geometry.vertices.push(
-						vertices[ parseInt( result[ 1 ] ) - 1 ],
-						vertices[ parseInt( result[ 2 ] ) - 1 ],
-						vertices[ parseInt( result[ 3 ] ) - 1 ]
-					);
-
-					geometry.faces.push( face3(
-						verticesCount ++,
-						verticesCount ++,
-						verticesCount ++
-					) );
-
-				} else {
-
-					geometry.vertices.push(
-						vertices[ parseInt( result[ 1 ] ) - 1 ],
-						vertices[ parseInt( result[ 2 ] ) - 1 ],
-						vertices[ parseInt( result[ 3 ] ) - 1 ],
-						vertices[ parseInt( result[ 4 ] ) - 1 ]
-					);
-
-					geometry.faces.push( face3(
-						verticesCount,
-						verticesCount + 1,
-						verticesCount + 3
-					) );
-
-					geometry.faces.push( face3(
-						verticesCount + 1,
-						verticesCount + 2,
-						verticesCount + 3
-					) );
-
-					verticesCount += 4;
-
-				}
+        handle_face_line([ result[ 1 ], result[ 2 ], result[ 3 ], result[ 4 ] ]);
 
 			} else if ( ( result = face_pattern2.exec( line ) ) !== null ) {
 
 				// ["f 1/1 2/2 3/3", " 1/1", "1", "1", " 2/2", "2", "2", " 3/3", "3", "3", undefined, undefined, undefined]
-
-				if ( result[ 10 ] === undefined ) {
-
-					geometry.vertices.push(
-						vertices[ parseInt( result[ 2 ] ) - 1 ],
-						vertices[ parseInt( result[ 5 ] ) - 1 ],
-						vertices[ parseInt( result[ 8 ] ) - 1 ]
-					);
-
-					geometry.faces.push( face3(
-						verticesCount ++,
-						verticesCount ++,
-						verticesCount ++
-					) );
-
-					geometry.faceVertexUvs[ 0 ].push( [
-						uvs[ parseInt( result[ 3 ] ) - 1 ],
-						uvs[ parseInt( result[ 6 ] ) - 1 ],
-						uvs[ parseInt( result[ 9 ] ) - 1 ]
-					] );
-
-				} else {
-
-					geometry.vertices.push(
-						vertices[ parseInt( result[ 2 ] ) - 1 ],
-						vertices[ parseInt( result[ 5 ] ) - 1 ],
-						vertices[ parseInt( result[ 8 ] ) - 1 ],
-						vertices[ parseInt( result[ 11 ] ) - 1 ]
-					);
-
-					geometry.faces.push( face3(
-						verticesCount,
-						verticesCount + 1,
-						verticesCount + 3
-					) );
-
-					geometry.faceVertexUvs[ 0 ].push( [
-						uvs[ parseInt( result[ 3 ] ) - 1 ],
-						uvs[ parseInt( result[ 6 ] ) - 1 ],
-						uvs[ parseInt( result[ 12 ] ) - 1 ]
-					] );
-
-					geometry.faces.push( face3(
-						verticesCount + 1,
-						verticesCount + 2,
-						verticesCount + 3
-					) );
-
-					geometry.faceVertexUvs[ 0 ].push( [
-						uvs[ parseInt( result[ 6 ] ) - 1 ],
-						uvs[ parseInt( result[ 9 ] ) - 1 ],
-						uvs[ parseInt( result[ 12 ] ) - 1 ]
-					] );
-
-					verticesCount += 4;
-
-				}
+        
+        handle_face_line(
+          [ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
+          [ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //uv
+        );
 
 			} else if ( ( result = face_pattern3.exec( line ) ) !== null ) {
 
 				// ["f 1/1/1 2/2/2 3/3/3", " 1/1/1", "1", "1", "1", " 2/2/2", "2", "2", "2", " 3/3/3", "3", "3", "3", undefined, undefined, undefined, undefined]
 
-				if ( result[ 13 ] === undefined ) {
-
-					geometry.vertices.push(
-						vertices[ parseInt( result[ 2 ] ) - 1 ],
-						vertices[ parseInt( result[ 6 ] ) - 1 ],
-						vertices[ parseInt( result[ 10 ] ) - 1 ]
-					);
-
-					geometry.faces.push( face3(
-						verticesCount ++,
-						verticesCount ++,
-						verticesCount ++,
-						[
-							normals[ parseInt( result[ 4 ] ) - 1 ],
-							normals[ parseInt( result[ 8 ] ) - 1 ],
-							normals[ parseInt( result[ 12 ] ) - 1 ]
-						]
-					) );
-
-					geometry.faceVertexUvs[ 0 ].push( [
-						uvs[ parseInt( result[ 3 ] ) - 1 ],
-						uvs[ parseInt( result[ 7 ] ) - 1 ],
-						uvs[ parseInt( result[ 11 ] ) - 1 ]
-					] );
-
-				} else {
-
-					geometry.vertices.push(
-						vertices[ parseInt( result[ 2 ] ) - 1 ],
-						vertices[ parseInt( result[ 6 ] ) - 1 ],
-						vertices[ parseInt( result[ 10 ] ) - 1 ],
-						vertices[ parseInt( result[ 14 ] ) - 1 ]
-					);
-
-					geometry.faces.push( face3(
-						verticesCount,
-						verticesCount + 1,
-						verticesCount + 3,
-						[
-							normals[ parseInt( result[ 4 ] ) - 1 ],
-							normals[ parseInt( result[ 8 ] ) - 1 ],
-							normals[ parseInt( result[ 16 ] ) - 1 ]
-						]
-					) );
-
-					geometry.faceVertexUvs[ 0 ].push( [
-						uvs[ parseInt( result[ 3 ] ) - 1 ],
-						uvs[ parseInt( result[ 7 ] ) - 1 ],
-						uvs[ parseInt( result[ 15 ] ) - 1 ]
-					] );
-
-					geometry.faces.push( face3(
-						verticesCount + 1,
-						verticesCount + 2,
-						verticesCount + 3,
-						[
-							normals[ parseInt( result[ 8 ] ) - 1 ],
-							normals[ parseInt( result[ 12 ] ) - 1 ],
-							normals[ parseInt( result[ 16 ] ) - 1 ]
-						]
-					) );
-
-					geometry.faceVertexUvs[ 0 ].push( [
-						uvs[ parseInt( result[ 7 ] ) - 1 ],
-						uvs[ parseInt( result[ 11 ] ) - 1 ],
-						uvs[ parseInt( result[ 15 ] ) - 1 ]
-					] );
-
-					verticesCount += 4;
-
-				}
+        handle_face_line(
+          [ result[ 2 ], result[ 6 ], result[ 10 ], result[ 14 ] ], //faces
+          [ result[ 3 ], result[ 7 ], result[ 11 ], result[ 15 ] ], //uv
+          [ result[ 4 ], result[ 8 ], result[ 12 ], result[ 16 ] ] //normal
+        );
 
 			} else if ( ( result = face_pattern4.exec( line ) ) !== null ) {
 
 				// ["f 1//1 2//2 3//3", " 1//1", "1", "1", " 2//2", "2", "2", " 3//3", "3", "3", undefined, undefined, undefined]
 
-				if ( result[ 10 ] === undefined ) {
-
-					geometry.vertices.push(
-						vertices[ parseInt( result[ 2 ] ) - 1 ],
-						vertices[ parseInt( result[ 5 ] ) - 1 ],
-						vertices[ parseInt( result[ 8 ] ) - 1 ]
-					);
-
-					geometry.faces.push( face3(
-						verticesCount ++,
-						verticesCount ++,
-						verticesCount ++,
-						[
-							normals[ parseInt( result[ 3 ] ) - 1 ],
-							normals[ parseInt( result[ 6 ] ) - 1 ],
-							normals[ parseInt( result[ 9 ] ) - 1 ]
-						]
-					) );
-
-				} else {
-
-					geometry.vertices.push(
-						vertices[ parseInt( result[ 2 ] ) - 1 ],
-						vertices[ parseInt( result[ 5 ] ) - 1 ],
-						vertices[ parseInt( result[ 8 ] ) - 1 ],
-						vertices[ parseInt( result[ 11 ] ) - 1 ]
-					);
-
-					geometry.faces.push( face3(
-						verticesCount,
-						verticesCount + 1,
-						verticesCount + 3,
-						[
-							normals[ parseInt( result[ 3 ] ) - 1 ],
-							normals[ parseInt( result[ 6 ] ) - 1 ],
-							normals[ parseInt( result[ 12 ] ) - 1 ]
-						]
-					) );
-
-					geometry.faces.push( face3(
-						verticesCount + 1,
-						verticesCount + 2,
-						verticesCount + 3,
-						[
-							normals[ parseInt( result[ 6 ] ) - 1 ],
-							normals[ parseInt( result[ 9 ] ) - 1 ],
-							normals[ parseInt( result[ 12 ] ) - 1 ]
-						]
-					) );
-
-					verticesCount += 4;
-
-				}
+        handle_face_line(
+          [ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
+          [ ], //uv
+          [ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //normal
+        );
 
 			} else if ( /^o /.test( line ) ) {
 
 				// object
-
+        
+        meshN();
+        face_offset = face_offset + vertices.length;
+        vertices = [];
 				object = new THREE.Object3D();
 				object.name = line.substring( 2 ).trim();
 				group.add( object );
@@ -476,7 +335,7 @@ THREE.OBJMTLLoader.prototype = {
 
 		//Add last object
 		meshN(undefined, undefined);
-
+    
 		return group;
 
 	}

--- a/examples/js/loaders/OBJMTLLoader.js
+++ b/examples/js/loaders/OBJMTLLoader.js
@@ -133,9 +133,9 @@ THREE.OBJMTLLoader.prototype = {
   				parseInt( b ) - (face_offset + 1),
   				parseInt( c ) - (face_offset + 1),
   				[
-  					normals[ parseInt( normals_inds[ 0 ] ) - 1 ],
-  					normals[ parseInt( normals_inds[ 1 ] ) - 1 ],
-  					normals[ parseInt( normals_inds[ 2 ] ) - 1 ]
+  					normals[ parseInt( normals_inds[ 0 ] ) - 1 ].clone(),
+  					normals[ parseInt( normals_inds[ 1 ] ) - 1 ].clone(),
+  					normals[ parseInt( normals_inds[ 2 ] ) - 1 ].clone()
   				]
   			) );
       }
@@ -143,9 +143,9 @@ THREE.OBJMTLLoader.prototype = {
     
     function add_uvs( a, b, c ) {
 			geometry.faceVertexUvs[ 0 ].push( [
-				uvs[ parseInt( a ) - 1 ],
-				uvs[ parseInt( b ) - 1 ],
-				uvs[ parseInt( c ) - 1 ]
+				uvs[ parseInt( a ) - 1 ].clone(),
+				uvs[ parseInt( b ) - 1 ].clone(),
+				uvs[ parseInt( c ) - 1 ].clone()
 			] );
     }
     

--- a/examples/js/loaders/OBJMTLLoader.js
+++ b/examples/js/loaders/OBJMTLLoader.js
@@ -78,16 +78,19 @@ THREE.OBJMTLLoader.prototype = {
 
 		}
 
-    var face_offset = 0;
+		var face_offset = 0;
 
 		function meshN( meshName, materialName ) {
 
 			if ( vertices.length > 0 ) {
-        geometry.vertices = vertices;
-        geometry.mergeVertices();
+
+				geometry.vertices = vertices;
+
+				geometry.mergeVertices();
 				geometry.computeCentroids();
 				geometry.computeFaceNormals();
 				geometry.computeBoundingSphere();
+
 				object.add( mesh );
 
 				geometry = new THREE.Geometry();
@@ -97,6 +100,7 @@ THREE.OBJMTLLoader.prototype = {
 			}
 
 			if ( meshName !== undefined ) mesh.name = meshName;
+
 			if ( materialName !== undefined ) {
 
 				material = new THREE.MeshLambertMaterial();
@@ -120,63 +124,77 @@ THREE.OBJMTLLoader.prototype = {
 		var normals = [];
 		var uvs = [];
 
-    function add_face( a, b, c, normals_inds ) {
-      if ( normals_inds === undefined ) {
-        geometry.faces.push( face3(
-  				parseInt( a ) - (face_offset + 1),
-  				parseInt( b ) - (face_offset + 1),
-  				parseInt( c ) - (face_offset + 1)
-  			) );
-      } else {
-        geometry.faces.push( face3(
-  				parseInt( a ) - (face_offset + 1),
-  				parseInt( b ) - (face_offset + 1),
-  				parseInt( c ) - (face_offset + 1),
-  				[
-  					normals[ parseInt( normals_inds[ 0 ] ) - 1 ].clone(),
-  					normals[ parseInt( normals_inds[ 1 ] ) - 1 ].clone(),
-  					normals[ parseInt( normals_inds[ 2 ] ) - 1 ].clone()
-  				]
-  			) );
-      }
-    }
-    
-    function add_uvs( a, b, c ) {
+		function add_face( a, b, c, normals_inds ) {
+
+			if ( normals_inds === undefined ) {
+
+				geometry.faces.push( face3(
+					parseInt( a ) - (face_offset + 1),
+					parseInt( b ) - (face_offset + 1),
+					parseInt( c ) - (face_offset + 1)
+				) );
+
+			} else {
+
+				geometry.faces.push( face3(
+					parseInt( a ) - (face_offset + 1),
+					parseInt( b ) - (face_offset + 1),
+					parseInt( c ) - (face_offset + 1),
+					[
+						normals[ parseInt( normals_inds[ 0 ] ) - 1 ].clone(),
+						normals[ parseInt( normals_inds[ 1 ] ) - 1 ].clone(),
+						normals[ parseInt( normals_inds[ 2 ] ) - 1 ].clone()
+					]
+				) );
+
+			}
+
+		}
+		
+		function add_uvs( a, b, c ) {
+
 			geometry.faceVertexUvs[ 0 ].push( [
 				uvs[ parseInt( a ) - 1 ].clone(),
 				uvs[ parseInt( b ) - 1 ].clone(),
 				uvs[ parseInt( c ) - 1 ].clone()
 			] );
-    }
-    
-    function handle_face_line(faces, uvs, normals_inds) {
-      
-  		if ( faces[ 3 ] === undefined ) {
-        
-        add_face( faces[ 0 ], faces[ 1 ], faces[ 2 ], normals_inds );
-        
-        if (!(uvs === undefined) && uvs.length > 0) {
-          add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 2 ] );
-        }
 
-      } else {
-        
-        if (!(normals_inds === undefined) && normals_inds.length > 0) {
-          add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ], [ normals_inds[ 0 ], normals_inds[ 1 ], normals_inds[ 3 ] ]);
-          add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ], [ normals_inds[ 1 ], normals_inds[ 2 ], normals_inds[ 3 ] ]);
-        } else {
-          add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ]);
-          add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ]);
-        }
-        
-        if (!(uvs === undefined) && uvs.length > 0) {
-          add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 3 ] );
-          add_uvs( uvs[ 1 ], uvs[ 2 ], uvs[ 3 ] );
-        }
+		}
+		
+		function handle_face_line(faces, uvs, normals_inds) {
+			
+			if ( faces[ 3 ] === undefined ) {
+				
+				add_face( faces[ 0 ], faces[ 1 ], faces[ 2 ], normals_inds );
+				
+				if (!(uvs === undefined) && uvs.length > 0) {
+					add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 2 ] );
+				}
 
-  		}
-      
-    }
+			} else {
+				
+				if (!(normals_inds === undefined) && normals_inds.length > 0) {
+
+					add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ], [ normals_inds[ 0 ], normals_inds[ 1 ], normals_inds[ 3 ] ]);
+					add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ], [ normals_inds[ 1 ], normals_inds[ 2 ], normals_inds[ 3 ] ]);
+
+				} else {
+
+					add_face( faces[ 0 ], faces[ 1 ], faces[ 3 ]);
+					add_face( faces[ 1 ], faces[ 2 ], faces[ 3 ]);
+
+				}
+				
+				if (!(uvs === undefined) && uvs.length > 0) {
+
+					add_uvs( uvs[ 0 ], uvs[ 1 ], uvs[ 3 ] );
+					add_uvs( uvs[ 1 ], uvs[ 2 ], uvs[ 3 ] );
+
+				}
+
+			}
+			
+		}
 
 
 		// v float float float
@@ -255,44 +273,44 @@ THREE.OBJMTLLoader.prototype = {
 
 				// ["f 1 2 3", "1", "2", "3", undefined]
 
-        handle_face_line([ result[ 1 ], result[ 2 ], result[ 3 ], result[ 4 ] ]);
+				handle_face_line([ result[ 1 ], result[ 2 ], result[ 3 ], result[ 4 ] ]);
 
 			} else if ( ( result = face_pattern2.exec( line ) ) !== null ) {
 
 				// ["f 1/1 2/2 3/3", " 1/1", "1", "1", " 2/2", "2", "2", " 3/3", "3", "3", undefined, undefined, undefined]
-        
-        handle_face_line(
-          [ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
-          [ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //uv
-        );
+				
+				handle_face_line(
+					[ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
+					[ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //uv
+				);
 
 			} else if ( ( result = face_pattern3.exec( line ) ) !== null ) {
 
 				// ["f 1/1/1 2/2/2 3/3/3", " 1/1/1", "1", "1", "1", " 2/2/2", "2", "2", "2", " 3/3/3", "3", "3", "3", undefined, undefined, undefined, undefined]
 
-        handle_face_line(
-          [ result[ 2 ], result[ 6 ], result[ 10 ], result[ 14 ] ], //faces
-          [ result[ 3 ], result[ 7 ], result[ 11 ], result[ 15 ] ], //uv
-          [ result[ 4 ], result[ 8 ], result[ 12 ], result[ 16 ] ] //normal
-        );
+				handle_face_line(
+					[ result[ 2 ], result[ 6 ], result[ 10 ], result[ 14 ] ], //faces
+					[ result[ 3 ], result[ 7 ], result[ 11 ], result[ 15 ] ], //uv
+					[ result[ 4 ], result[ 8 ], result[ 12 ], result[ 16 ] ] //normal
+				);
 
 			} else if ( ( result = face_pattern4.exec( line ) ) !== null ) {
 
 				// ["f 1//1 2//2 3//3", " 1//1", "1", "1", " 2//2", "2", "2", " 3//3", "3", "3", undefined, undefined, undefined]
 
-        handle_face_line(
-          [ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
-          [ ], //uv
-          [ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //normal
-        );
+				handle_face_line(
+					[ result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ] ], //faces
+					[ ], //uv
+					[ result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ] ] //normal
+				);
 
 			} else if ( /^o /.test( line ) ) {
 
 				// object
-        
-        meshN();
-        face_offset = face_offset + vertices.length;
-        vertices = [];
+				
+				meshN();
+				face_offset = face_offset + vertices.length;
+				vertices = [];
 				object = new THREE.Object3D();
 				object.name = line.substring( 2 ).trim();
 				group.add( object );
@@ -335,7 +353,7 @@ THREE.OBJMTLLoader.prototype = {
 
 		//Add last object
 		meshN(undefined, undefined);
-    
+		
 		return group;
 
 	}


### PR DESCRIPTION
OBJ loaders did not correctly preserve vertex and face list ordering and were creating duplicate vertex entries, rather than letting faces share vertices. Reordering the faces was breaking our morph creation system, which relies on the mesh topology being fixed.

This should be as efficient as the code it replaces for large models (possibly very slightly more so, as it doesn't duplicate vertices, so should use a bit less memory). But it would be worth testing it against the large models referenced in #3937 and #3965, just to make sure.
