### PR TITLE
Blender exporter normal bug fix

### DIFF
--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -42,7 +42,7 @@ DEFAULTS = {
 "bgalpha" : 1.0,
 
 "position" : [0, 0, 0],
-"rotation" : [-math.pi/2, 0, 0],
+"rotation" : [0, 0, 0],
 "scale"    : [1, 1, 1],
 
 "camera"  :


### PR DESCRIPTION
Global rotation is not taken into account for normals by the json loader.
This leads to all objects/cameras/lights in the scene being rotated correctly,
but with all normals pointing into the wrong direction (90deg off...)

Not applying rotation at all fixes this problem.

As I'm not sure if this behaviour of the loader is intentional, it might be that this fix is just fighting a symptom. The full fix may be to apply global rotations to all normals by the loader. 

Can somebody say if this intentional behaviour, or if the json loader needs fixing?
