### PR TITLE
Add start and end events triggered on mouse/wheel/touch down/up for trackball control

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -65,6 +65,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 	// events
 
 	var changeEvent = { type: 'change' };
+	var startEvent = { type: 'start'};
+	var endEvent = { type: 'end'};
 
 
 	// methods
@@ -389,6 +391,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		document.addEventListener( 'mousemove', mousemove, false );
 		document.addEventListener( 'mouseup', mouseup, false );
+		_this.dispatchEvent( startEvent );
+
 
 	}
 
@@ -426,6 +430,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		document.removeEventListener( 'mousemove', mousemove );
 		document.removeEventListener( 'mouseup', mouseup );
+		_this.dispatchEvent( endEvent );
 
 	}
 
@@ -449,6 +454,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 		}
 
 		_zoomStart.y += delta * 0.01;
+		_this.dispatchEvent( startEvent );
+		_this.dispatchEvent( endEvent );
 
 	}
 
@@ -479,6 +486,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 				_state = STATE.NONE;
 
 		}
+		_this.dispatchEvent( startEvent );
+
 
 	}
 
@@ -533,6 +542,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 		}
 
 		_state = STATE.NONE;
+		_this.dispatchEvent( endEvent );
 
 	}
 


### PR DESCRIPTION
The start and end events can be used to start or stop an animation loop, for example, so that the animation loop does not have to run continuously.  This can be done by starting the animate loop on a start event.  The animate loop checks a stop flag, schedules the next animate call, and calls the update function.  The update function triggers a change event if there has been a change in the controls, and the change event triggers a redraw.  The stop event sets the stop flag so that the animate function stops scheduling new runs.

A tricky thing is that the redraw function also needs to schedule an animate call, whether or not the stop flag is set, to handle cases where the object isn't quite done transitioning by the time the stop event is called.

Here is a snippet of my coffeescript code implementing the above logic, from https://github.com/sagemath/sagecell/blob/99d8f2e7e9365088f1a031f289f75fd60791752a/static/3d.coffee#L512:

``` coffee
    set_trackball_controls: () =>
        @controls = new THREE.TrackballControls(@camera, @renderer.domElement)
        @controls.dynamicDampingFactor = 0.3
        @controls.noRoll=true
        @controls.addEventListener('change', @controlChange)
        @controls.addEventListener('start', (() => @_animate=true; @_animation_frame=requestAnimationFrame(@animate)))
        @controls.addEventListener('end', (() => @_animate=false))

    animate: () =>
        if @_animate
            @_animation_frame = requestAnimationFrame(@animate)
        else
            @_animation_frame = false
        @controls?.update()

    controlChange: () =>
        # if there was any actual control updates, animate at least one more frame
        if !@_animation_frame
            @_animation_frame = requestAnimationFrame(@animate)
        @render_scene()

    render_scene: () =>
        @renderer.render(@scene, @camera)
```
