### PR TITLE
Improved SphereGeometry UV Map at Poles

### DIFF
--- a/src/extras/geometries/SphereGeometry.js
+++ b/src/extras/geometries/SphereGeometry.js
@@ -67,11 +67,13 @@ THREE.SphereGeometry = function ( radius, widthSegments, heightSegments, phiStar
 
 			if ( Math.abs( this.vertices[ v1 ].y ) === this.radius ) {
 
+				uv1.x = ( uv1.x + uv2.x ) / 2;
 				this.faces.push( new THREE.Face3( v1, v3, v4, [ n1, n3, n4 ] ) );
 				this.faceVertexUvs[ 0 ].push( [ uv1, uv3, uv4 ] );
 
 			} else if ( Math.abs( this.vertices[ v3 ].y ) === this.radius ) {
 
+				uv3.x = ( uv3.x + uv4.x ) / 2;
 				this.faces.push( new THREE.Face3( v1, v2, v3, [ n1, n2, n3 ] ) );
 				this.faceVertexUvs[ 0 ].push( [ uv1, uv2, uv3 ] );
 


### PR DESCRIPTION
Modified `SphereGeometry` UVs at the poles so there is less distortion.

Before

![old sphere uv map](https://f.cloud.github.com/assets/1000017/1535244/f134c402-4ca0-11e3-8490-85e4936ee1f0.png)

After

![new sphere uv map](https://f.cloud.github.com/assets/1000017/1535245/fb0ec54a-4ca0-11e3-9456-cbddc744ab17.png)
