### PR TITLE
EventListener for Opera + IE so mousewheel actually zooms as expected.

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -559,6 +559,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	window.addEventListener( 'keydown', keydown, false );
 	window.addEventListener( 'keyup', keyup, false );
+	window.addEventListener( 'mousewheel', mousewheel, false); //Opera / IE
 
 	this.handleResize();
 


### PR DESCRIPTION
TrackballControls didn't work properly for me in Opera, due to a different mousewheel listener. I added 1 line of code that fixes this.
