### PR TITLE
Changed the clock

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -1,28 +1,37 @@
 /**
  * @author alteredq / http://alteredqualia.com/
+ * @author timmutton / http://www.timmutton.com.au/
  */
 
 THREE.Clock = function ( autoStart ) {
 
 	this.autoStart = ( autoStart !== undefined ) ? autoStart : true;
 
+    if( this.autoStart ) {
+        this.start()
+    } 
+
 	this.startTime = 0;
 	this.oldTime = 0;
-	this.elapsedTime = 0;
+	//this.elapsedTime = 0;
 
 	this.running = false;
-
+	
 };
 
 THREE.Clock.prototype = {
 
 	constructor: THREE.Clock,
 
-	start: function () {
-
-		this.startTime = self.performance !== undefined && self.performance.now !== undefined
+    getCurrentTime: function () {
+        return self.performance !== undefined && self.performance.now !== undefined
 					? self.performance.now()
 					: Date.now();
+	},
+
+	start: function () {
+
+		this.startTime = this.getCurrentTime();
 
 		this.oldTime = this.startTime;
 		this.running = true;
@@ -30,19 +39,36 @@ THREE.Clock.prototype = {
 
 	stop: function () {
 
-		this.getElapsedTime();
 		this.running = false;
 
 	},
 
 	getElapsedTime: function () {
+	    var elapsed = 0;
+	    
+	    if ( this.autoStart && ! this.running ) {
 
-		this.getDelta();
-		return this.elapsedTime;
+			this.start();
 
+		}
+
+		if ( this.running ) {
+		 
+		    elapsed = 0.001 * (this.getCurrentTime() - this.startTime);
+		
+		}
+
+	    return elapsed;
+	
+	},
+	
+	getDelta: function () {
+	
+	    return this.getDeltaTime();
+	    
 	},
 
-	getDelta: function () {
+	getDeltaTime: function () {
 
 		var diff = 0;
 
@@ -54,14 +80,12 @@ THREE.Clock.prototype = {
 
 		if ( this.running ) {
 
-			var newTime = self.performance !== undefined && self.performance.now !== undefined
-					? self.performance.now()
-					: Date.now();
+			var newTime = this.getCurrentTime();
 
 			diff = 0.001 * ( newTime - this.oldTime );
 			this.oldTime = newTime;
 
-			this.elapsedTime += diff;
+			//this.elapsedTime += diff;
 
 		}
 

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -23,7 +23,8 @@ THREE.Clock.prototype = {
 
 	constructor: THREE.Clock,
 
-    getCurrentTime: function () {
+    //convenience function since this gets called a couple times
+    getTimeNow: function () {
         return self.performance !== undefined && self.performance.now !== undefined
 					? self.performance.now()
 					: Date.now();
@@ -31,10 +32,11 @@ THREE.Clock.prototype = {
 
 	start: function () {
 
-		this.startTime = this.getCurrentTime();
+		this.startTime = this.getTimeNow();
 
 		this.oldTime = this.startTime;
 		this.running = true;
+		
 	},
 
 	stop: function () {
@@ -54,7 +56,7 @@ THREE.Clock.prototype = {
 
 		if ( this.running ) {
 		 
-		    elapsed = 0.001 * (this.getCurrentTime() - this.startTime);
+		    elapsed = 0.001 * ( this.getTimeNow() - this.startTime );
 		
 		}
 
@@ -64,6 +66,8 @@ THREE.Clock.prototype = {
 	
 	getDelta: function () {
 	
+	    console.warn( 'DEPRECATED: Clock\'s .getDelta() has been moved to Clock\'s .getDeltaTime().' );
+
 	    return this.getDeltaTime();
 	    
 	},
@@ -72,7 +76,7 @@ THREE.Clock.prototype = {
 
 		var diff = 0;
 
-		if ( this.autoStart && ! this.running ) {
+		if ( this.autoStart && !this.running ) {
 
 			this.start();
 
@@ -80,7 +84,7 @@ THREE.Clock.prototype = {
 
 		if ( this.running ) {
 
-			var newTime = this.getCurrentTime();
+			var newTime = this.getTimeNow();
 
 			diff = 0.001 * ( newTime - this.oldTime );
 			this.oldTime = newTime;

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -7,9 +7,9 @@ THREE.Clock = function ( autoStart ) {
 
 	this.autoStart = ( autoStart !== undefined ) ? autoStart : true;
 
-    if( this.autoStart ) {
-        this.start()
-    } 
+	if( this.autoStart ) {
+		this.start()
+	} 
 
 	this.startTime = 0;
 	this.oldTime = 0;
@@ -23,9 +23,9 @@ THREE.Clock.prototype = {
 
 	constructor: THREE.Clock,
 
-    //convenience function since this gets called a couple times
-    getTimeNow: function () {
-        return self.performance !== undefined && self.performance.now !== undefined
+	//convenience function since this gets called a couple times
+	getTimeNow: function () {
+		return self.performance !== undefined && self.performance.now !== undefined
 					? self.performance.now()
 					: Date.now();
 	},
@@ -46,9 +46,9 @@ THREE.Clock.prototype = {
 	},
 
 	getElapsedTime: function () {
-	    var elapsed = 0;
-	    
-	    if ( this.autoStart && ! this.running ) {
+		var elapsed = 0;
+		
+		if ( this.autoStart && ! this.running ) {
 
 			this.start();
 
@@ -56,20 +56,20 @@ THREE.Clock.prototype = {
 
 		if ( this.running ) {
 		 
-		    elapsed = 0.001 * ( this.getTimeNow() - this.startTime );
+			elapsed = 0.001 * ( this.getTimeNow() - this.startTime );
 		
 		}
 
-	    return elapsed;
+		return elapsed;
 	
 	},
 	
 	getDelta: function () {
 	
-	    console.warn( 'DEPRECATED: Clock\'s .getDelta() has been moved to Clock\'s .getDeltaTime().' );
+		console.warn( 'DEPRECATED: Clock\'s .getDelta() has been moved to Clock\'s .getDeltaTime().' );
 
-	    return this.getDeltaTime();
-	    
+		return this.getDeltaTime();
+		
 	},
 
 	getDeltaTime: function () {


### PR DESCRIPTION
As it stands the clock can be a bit confusing to use. elapsedTime only returns a variable if you call getElapsedTime() or getDelta() on each frame, and if you need to use both you must call getDelta() before getElapsedTime() otherwise getDelta() will be incorrect (or unexpected depending on how you look at it). Also changed the constructor so that autoStart automatically starts the clock straight away (which would be the expected behaviour), changed getDelta() to getDeltaTime() for more consistent naming between the time getters and removed elapsedTime since it is now redundant
