### PR TITLE
Memory tweak for Plane.applyMatrix4

### DIFF
--- a/docs/api/math/Plane.html
+++ b/docs/api/math/Plane.html
@@ -57,10 +57,10 @@
 		<h3>.applyMatrix4([page:Matrix4 matrix], [page:Matrix3 optionalNormalMatrix]) [page:Plane this]</h3>
 		<div>
 		matrix -- [Page:Matrix4] to apply <br />
-		optionalNormalMatrix -- (optional) normal [Page:Matrix3] of the Matrix4 to apply
+		optionalNormalMatrix -- (optional) pre-computed normal [Page:Matrix3] of the Matrix4 to apply
 		</div>
 		<div>
-		Apply a Matrix4 to the plane. The second parameter is optional, but if not provided a new Matrix3 will be created each time this method is called.
+		Apply a Matrix4 to the plane. The second parameter is optional.
 		
 		<code>
 		var optionalNormalMatrix = new THREE.Matrix3().getNormalMatrix( matrix ) 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -180,15 +180,15 @@ THREE.Plane.prototype = {
 
 		var v1 = new THREE.Vector3();
 		var v2 = new THREE.Vector3();
-		var m1 = new THREE.Matrix3()
+		var m1 = new THREE.Matrix3();
 
 		return function ( matrix, optionalNormalMatrix ) {
 
 			// compute new normal based on theory here:
 			// http://www.songho.ca/opengl/gl_normaltransform.html
-			optionalNormalMatrix = optionalNormalMatrix || m1.getNormalMatrix( matrix );
-			var newNormal = v1.copy( this.normal ).applyMatrix3( optionalNormalMatrix );
-
+			var normalMatrix = optionalNormalMatrix || m1.getNormalMatrix( matrix );
+			var newNormal = v1.copy( this.normal ).applyMatrix3( normalMatrix );
+			
 			var newCoplanarPoint = this.coplanarPoint( v2 );
 			newCoplanarPoint.applyMatrix4( matrix );
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -180,12 +180,13 @@ THREE.Plane.prototype = {
 
 		var v1 = new THREE.Vector3();
 		var v2 = new THREE.Vector3();
+		var m1 = new THREE.Matrix3()
 
 		return function ( matrix, optionalNormalMatrix ) {
 
 			// compute new normal based on theory here:
 			// http://www.songho.ca/opengl/gl_normaltransform.html
-			optionalNormalMatrix = optionalNormalMatrix || new THREE.Matrix3().getNormalMatrix( matrix );
+			optionalNormalMatrix = optionalNormalMatrix || m1.getNormalMatrix( matrix );
 			var newNormal = v1.copy( this.normal ).applyMatrix3( optionalNormalMatrix );
 
 			var newCoplanarPoint = this.coplanarPoint( v2 );


### PR DESCRIPTION
This moves a `new THREE.Matrix3()` call out of the loop, and into the object declaration. The unit tests pass.
