### PR TITLE
Update ctm.js

### DIFF
--- a/examples/js/loaders/ctm/ctm.js
+++ b/examples/js/loaders/ctm/ctm.js
@@ -630,7 +630,7 @@ CTM.Stream.prototype.readString = function(){
 
   this.offset += len;
 
-  return this.data.subarray(this.offset - len, len);
+  return String.fromCharCode.apply(null,this.data.subarray(this.offset - len, this.offset));
 };
 
 CTM.Stream.prototype.readArrayInt32 = function(array){


### PR DESCRIPTION
CTM.Stream.prototype.readString() should return a String.
Otherwise comparison in the CTMLoader (file.body.attrMaps[ 0 ].name === "Color") won't work and vertexColors won't be initialized.
Also subarray has different arguments than the former substr method.
