### PR TITLE
Change trackball mousewheel event to use a cross-browser version.

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -389,17 +389,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		if ( scope.enabled === false || scope.noZoom === true ) return;
 
-		var delta = 0;
-
-		if ( event.wheelDelta ) { // WebKit / Opera / Explorer 9
-
-			delta = event.wheelDelta;
-
-		} else if ( event.detail ) { // Firefox
-
-			delta = - event.detail;
-
-		}
+		var delta = event.deltaY;
 
 		if ( delta > 0 ) {
 
@@ -569,14 +559,86 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	this.domElement.addEventListener( 'contextmenu', function ( event ) { event.preventDefault(); }, false );
 	this.domElement.addEventListener( 'mousedown', onMouseDown, false );
-	this.domElement.addEventListener( 'mousewheel', onMouseWheel, false );
-	this.domElement.addEventListener( 'DOMMouseScroll', onMouseWheel, false ); // firefox
 
 	this.domElement.addEventListener( 'keydown', onKeyDown, false );
 
 	this.domElement.addEventListener( 'touchstart', touchstart, false );
 	this.domElement.addEventListener( 'touchend', touchend, false );
 	this.domElement.addEventListener( 'touchmove', touchmove, false );
+    
+    // Cross-browser mousewheel events, based on https://developer.mozilla.org/en-US/docs/Web/Reference/Events/wheel?redirectlocale=en-US&redirectslug=DOM%2FMozilla_event_reference%2Fwheel
+    // creates a "addWheelListener" method
+    // example: addWheelListener( elem, function( e ) { console.log( e.deltaY ); e.preventDefault(); } );
+    
+    // modern browsers support the 'wheel' event.  When legacy browser support (see link above for browser versions) is no longer a concern, the mousewheel
+    // event can be observed via
+    // this.domElement.addEventListener( 'wheel', onMouseWheel, false)
+    
+    var addWheelListener = (function(window,document) {
+
+        var prefix = "", _addEventListener, onwheel, support;
+
+        // detect event model
+        if ( window.addEventListener ) {
+            _addEventListener = "addEventListener";
+        } else {
+            _addEventListener = "attachEvent";
+            prefix = "on";
+        }
+
+        // detect available wheel event
+        support = "onwheel" in document.createElement("div") ? "wheel" : // Modern browsers support "wheel"
+                  document.onmousewheel !== undefined ? "mousewheel" : // Webkit and IE support at least "mousewheel"
+                  "DOMMouseScroll"; // let's assume that remaining browsers are older Firefox
+
+        var addWheelListener = function( elem, callback, useCapture ) {
+            _addWheelListener( elem, support, callback, useCapture );
+
+            // handle MozMousePixelScroll in older Firefox
+            if( support == "DOMMouseScroll" ) {
+                _addWheelListener( elem, "MozMousePixelScroll", callback, useCapture );
+            }
+        };
+
+        function _addWheelListener( elem, eventName, callback, useCapture ) {
+            elem[ _addEventListener ]( prefix + eventName, support == "wheel" ? callback : function( originalEvent ) {
+                !originalEvent && ( originalEvent = window.event );
+
+                // create a normalized event object
+                var event = {
+                    // keep a ref to the original event object
+                    originalEvent: originalEvent,
+                    target: originalEvent.target || originalEvent.srcElement,
+                    type: "wheel",
+                    deltaMode: originalEvent.type == "MozMousePixelScroll" ? 0 : 1,
+                    deltaX: 0,
+                    delatZ: 0,
+                    preventDefault: function() {
+                        originalEvent.preventDefault ?
+                            originalEvent.preventDefault() :
+                            originalEvent.returnValue = false;
+                    }
+                };
+                
+                // calculate deltaY (and deltaX) according to the event
+                if ( support == "mousewheel" ) {
+                    event.deltaY = - 1/40 * originalEvent.wheelDelta;
+                    // Webkit also support wheelDeltaX
+                    originalEvent.wheelDeltaX && ( event.deltaX = - 1/40 * originalEvent.wheelDeltaX );
+                } else {
+                    event.deltaY = originalEvent.detail;
+                }
+
+                // it's time to fire the callback
+                return callback( event );
+
+            }, useCapture || false );
+        }
+        return addWheelListener;
+
+    })(window,document);
+    
+    addWheelListener(this.domElement, onMouseWheel, false);
 
 };
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -389,6 +389,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		if ( scope.enabled === false || scope.noZoom === true ) return;
 
+		event.preventDefault();
+		event.stopPropagation();
+
 		var delta = event.deltaY;
 
 		if ( delta > 0 ) {

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -462,19 +462,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 		event.preventDefault();
 		event.stopPropagation();
 
-		var delta = 0;
-
-		if ( event.wheelDelta ) { // WebKit / Opera / Explorer 9
-
-			delta = event.wheelDelta / 40;
-
-		} else if ( event.detail ) { // Firefox
-
-			delta = - event.detail / 3;
-
-		}
-
-		_zoomStart.y += delta * 0.01;
+		_zoomStart.y -= event.deltaY * 0.01;
 		_this.dispatchEvent( startEvent );
 		_this.dispatchEvent( endEvent );
 
@@ -571,15 +559,87 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	this.domElement.addEventListener( 'mousedown', mousedown, false );
 
-	this.domElement.addEventListener( 'mousewheel', mousewheel, false );
-	this.domElement.addEventListener( 'DOMMouseScroll', mousewheel, false ); // firefox
-
 	this.domElement.addEventListener( 'touchstart', touchstart, false );
 	this.domElement.addEventListener( 'touchend', touchend, false );
 	this.domElement.addEventListener( 'touchmove', touchmove, false );
 
 	window.addEventListener( 'keydown', keydown, false );
 	window.addEventListener( 'keyup', keyup, false );
+
+    // Cross-browser mousewheel events, based on https://developer.mozilla.org/en-US/docs/Web/Reference/Events/wheel?redirectlocale=en-US&redirectslug=DOM%2FMozilla_event_reference%2Fwheel
+    // creates a "addWheelListener" method
+    // example: addWheelListener( elem, function( e ) { console.log( e.deltaY ); e.preventDefault(); } );
+    
+    // modern browsers support the 'wheel' event.  When legacy browser support (see link above for browser versions) is no longer a concern, the mousewheel
+    // event can be observed via
+    // this.domElement.addEventListener( 'wheel', onMouseWheel, false)
+    
+    var addWheelListener = (function(window,document) {
+
+        var prefix = "", _addEventListener, onwheel, support;
+
+        // detect event model
+        if ( window.addEventListener ) {
+            _addEventListener = "addEventListener";
+        } else {
+            _addEventListener = "attachEvent";
+            prefix = "on";
+        }
+
+        // detect available wheel event
+        support = "onwheel" in document.createElement("div") ? "wheel" : // Modern browsers support "wheel"
+                  document.onmousewheel !== undefined ? "mousewheel" : // Webkit and IE support at least "mousewheel"
+                  "DOMMouseScroll"; // let's assume that remaining browsers are older Firefox
+
+        var addWheelListener = function( elem, callback, useCapture ) {
+            _addWheelListener( elem, support, callback, useCapture );
+
+            // handle MozMousePixelScroll in older Firefox
+            if( support == "DOMMouseScroll" ) {
+                _addWheelListener( elem, "MozMousePixelScroll", callback, useCapture );
+            }
+        };
+
+        function _addWheelListener( elem, eventName, callback, useCapture ) {
+            elem[ _addEventListener ]( prefix + eventName, support == "wheel" ? callback : function( originalEvent ) {
+                !originalEvent && ( originalEvent = window.event );
+
+                // create a normalized event object
+                var event = {
+                    // keep a ref to the original event object
+                    originalEvent: originalEvent,
+                    target: originalEvent.target || originalEvent.srcElement,
+                    type: "wheel",
+                    deltaMode: originalEvent.type == "MozMousePixelScroll" ? 0 : 1,
+                    deltaX: 0,
+                    delatZ: 0,
+                    preventDefault: function() {
+                        originalEvent.preventDefault ?
+                            originalEvent.preventDefault() :
+                            originalEvent.returnValue = false;
+                    }
+                };
+                
+                // calculate deltaY (and deltaX) according to the event
+                if ( support == "mousewheel" ) {
+                    event.deltaY = - 1/40 * originalEvent.wheelDelta;
+                    // Webkit also support wheelDeltaX
+                    originalEvent.wheelDeltaX && ( event.deltaX = - 1/40 * originalEvent.wheelDeltaX );
+                } else {
+                    event.deltaY = originalEvent.detail;
+                }
+
+                // it's time to fire the callback
+                return callback( event );
+
+            }, useCapture || false );
+        }
+        return addWheelListener;
+
+    })(window,document);
+
+    
+    addWheelListener(this.domElement, mousewheel, false);
 
 	this.handleResize();
 


### PR DESCRIPTION
This uses Mozilla's cross-browser code at https://developer.mozilla.org/en-US/docs/Web/Reference/Events/wheel?redirectlocale=en-US&redirectslug=DOM%2FMozilla_event_reference%2Fwheel

Before this change, firefox would scroll the page while zooming, for example.
