### PR TITLE
Fix crash in computeVertexNormals 

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -141,29 +141,11 @@ THREE.Geometry.prototype = {
 
 		var v, vl, f, fl, face, vertices;
 
-		// create internal buffers for reuse when calling this method repeatedly
-		// (otherwise memory allocation / deallocation every frame is big resource hog)
+		vertices = new Array( this.vertices.length );
 
-		if ( this.__tmpVertices === undefined || this.__tmpVertices.length != this.vertices.length) {
+		for ( v = 0, vl = this.vertices.length; v < vl; v ++ ) {
 
-			this.__tmpVertices = new Array( this.vertices.length );
-			vertices = this.__tmpVertices;
-
-			for ( v = 0, vl = this.vertices.length; v < vl; v ++ ) {
-
-				vertices[ v ] = new THREE.Vector3();
-
-			}
-
-		} else {
-
-			vertices = this.__tmpVertices;
-
-			for ( v = 0, vl = this.vertices.length; v < vl; v ++ ) {
-
-				vertices[ v ].set( 0, 0, 0 );
-
-			}
+			vertices[ v ] = new THREE.Vector3();
 
 		}
 
@@ -218,12 +200,9 @@ THREE.Geometry.prototype = {
 
 			face = this.faces[ f ];
 
-			if (face.vertexNormals === undefined || face.vertexNormals.length !== 3)
-				face.vertexNormals = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];
-
-			face.vertexNormals[ 0 ].copy( vertices[ face.a ] );
-			face.vertexNormals[ 1 ].copy( vertices[ face.b ] );
-			face.vertexNormals[ 2 ].copy( vertices[ face.c ] );
+			face.vertexNormals[ 0 ] = vertices[ face.a ].clone();
+			face.vertexNormals[ 1 ] = vertices[ face.b ].clone();
+			face.vertexNormals[ 2 ] = vertices[ face.c ].clone();
 
 		}
 
@@ -512,9 +491,6 @@ THREE.Geometry.prototype = {
 		var precision = Math.pow( 10, precisionPoints );
 		var i,il, face;
 		var indices, k, j, jl, u;
-
-		// reset cache of vertices as it now will be changing.
-		this.__tmpVertices = undefined;
 
 		for ( i = 0, il = this.vertices.length; i < il; i ++ ) {
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -144,7 +144,7 @@ THREE.Geometry.prototype = {
 		// create internal buffers for reuse when calling this method repeatedly
 		// (otherwise memory allocation / deallocation every frame is big resource hog)
 
-		if ( this.__tmpVertices === undefined ) {
+		if ( this.__tmpVertices === undefined || this.__tmpVertices.length != this.vertices.length) {
 
 			this.__tmpVertices = new Array( this.vertices.length );
 			vertices = this.__tmpVertices;
@@ -152,13 +152,6 @@ THREE.Geometry.prototype = {
 			for ( v = 0, vl = this.vertices.length; v < vl; v ++ ) {
 
 				vertices[ v ] = new THREE.Vector3();
-
-			}
-
-			for ( f = 0, fl = this.faces.length; f < fl; f ++ ) {
-
-				face = this.faces[ f ];
-				face.vertexNormals = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];
 
 			}
 
@@ -224,6 +217,9 @@ THREE.Geometry.prototype = {
 		for ( f = 0, fl = this.faces.length; f < fl; f ++ ) {
 
 			face = this.faces[ f ];
+
+			if (face.vertexNormals === undefined || face.vertexNormals.length !== 3)
+				face.vertexNormals = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];
 
 			face.vertexNormals[ 0 ].copy( vertices[ face.a ] );
 			face.vertexNormals[ 1 ].copy( vertices[ face.b ] );
@@ -573,7 +569,7 @@ THREE.Geometry.prototype = {
 
 		for ( i = faceIndicesToRemove.length - 1; i >= 0; i -- ) {
 			var idx = faceIndicesToRemove[ i ];
-			
+
 			this.faces.splice( idx, 1 );
 
 			for ( j = 0, jl = this.faceVertexUvs.length; j < jl; j ++ ) {


### PR DESCRIPTION
There is a crash in computeVertexNormals when it is called on a THREE.Geometry twice, when the .faces or .vertices fields were modified in between the two calls. 

The first time computeVertexNormals is called, .__tmpVertices is initialized, as well as f.vertexNormals in each face f. The next time computeVertexNormals is called, no initialization takes place if .__tmpVertices is not undefined, even if faces and/or vertices have changed since, rendering .__tmpVertices and f.vertexNormals invalid.

This commit makes sure that .__tmpVertices is updated whenever the .vertices array has changed in length, and that the f.vertexNormals are initialized whenever they are not present or of the right size (ie whenever faces have changed).
