### PR TITLE
Fixing a minor warning that can occur with the google closure compiler. ...

### DIFF
--- a/src/extras/cameras/CombinedCamera.js
+++ b/src/extras/cameras/CombinedCamera.js
@@ -1,4 +1,4 @@
-/*
+/**
  *	@author zz85 / http://twitter.com/blurspline / http://www.lab4games.net/zz85/blog
  *
  *	A general perpose camera, for setting FOV, Lens Focal Length,
@@ -234,4 +234,3 @@ THREE.CombinedCamera.prototype.toBottomView = function() {
 	this.rotationAutoUpdate = false;
 
 };
-


### PR DESCRIPTION
Comment has jsdoc annotations but does not start with the jsdoc style comment header.  The warning looks like:
   WARNING - Parse error. Non-JSDoc comment has annotations. Did you mean to start it with '/**'?
