### PR TITLE
Fixed zooming with scroll: it doesn't scroll the page now

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -386,6 +386,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	}
 
 	function onMouseWheel( event ) {
+		event.preventDefault();
 
 		if ( scope.enabled === false || scope.noZoom === true ) return;
 


### PR DESCRIPTION
Now, when you use scroll for zooming in and out, the parental container (e.g. browser window) doesn't get scrolled.
