### PR TITLE
Light get world direction

### DIFF
--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -222,9 +222,10 @@ THREE.SVGRenderer = function () {
 
 			if ( light instanceof THREE.DirectionalLight ) {
 
-				var lightPosition = _vector3.setFromMatrixPosition( light.matrixWorld ).normalize();
-
-				var amount = normal.dot( lightPosition );
+				//var lightPosition = _vector3.setFromMatrixPosition( light.matrixWorld ).normalize();				
+				var lightDirection = light.getWorldDirection();
+				
+				var amount = normal.dot( lightDirection );
 
 				if ( amount <= 0 ) continue;
 

--- a/examples/js/renderers/WebGLDeferredRenderer.js
+++ b/examples/js/renderers/WebGLDeferredRenderer.js
@@ -428,10 +428,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		positionVS.setFromMatrixPosition( modelMatrix );
 		positionVS.applyMatrix4( viewMatrix );
 
-		directionVS.setFromMatrixPosition( modelMatrix );
-		tempVS.setFromMatrixPosition( light.target.matrixWorld );
-		directionVS.sub( tempVS );
-		directionVS.normalize();
+		directionVS = light.getWorldDirection( directionVS );	
 		directionVS.transformDirection( viewMatrix );
 
 		uniforms[ "lightPositionVS" ].value.copy( positionVS );
@@ -499,10 +496,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		var light = lightProxy.userData.originalLight;
 		var uniforms = lightProxy.material.uniforms;
 
-		directionVS.setFromMatrixPosition( light.matrixWorld );
-		tempVS.setFromMatrixPosition( light.target.matrixWorld );
-		directionVS.sub( tempVS );
-		directionVS.normalize();
+		directionVS = light.getWorldDirection( directionVS );
 		directionVS.transformDirection( currentCamera.matrixWorldInverse );
 
 		uniforms[ "lightDirectionVS" ].value.copy( directionVS );

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -60,6 +60,8 @@ THREE.DirectionalLight = function ( hex, intensity ) {
 
 THREE.DirectionalLight.prototype = Object.create( THREE.Light.prototype );
 
+THREE.DirectionalLight.prototype.getWorldDirection = THREE.Light._getWorldDirectionClosure();
+
 THREE.DirectionalLight.prototype.clone = function () {
 
 	var light = new THREE.DirectionalLight();

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -35,14 +35,9 @@ THREE.Light._getWorldDirectionClosure = function() {
 		var direction = optionalTarget || new THREE.Vector3();
 
 		direction.setFromMatrixPosition( this.matrixWorld );
-		
-		if( this.target ) {
-
-			targetPosition.setFromMatrixPosition( this.target.matrixWorld );
-			direction.sub( targetPosition );
-			direction.normalize();
-
-		}
+		targetPosition.setFromMatrixPosition( this.target.matrixWorld );
+		direction.sub( targetPosition );
+		direction.normalize();
 
 		return direction;
 

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -13,6 +13,30 @@ THREE.Light = function ( hex ) {
 
 THREE.Light.prototype = Object.create( THREE.Object3D.prototype );
 
+THREE.Light.prototype.getWorldDirection = function() {
+
+	var targetPosition = new THREE.Vector3();
+
+	return function ( optionalTarget ) {
+
+		var direction = optionalTarget || new THREE.Vector3();
+
+		direction.setFromMatrixPosition( this.matrixWorld );
+		
+		if( this.target ) {
+
+			targetPosition.setFromMatrixPosition( this.target.matrixWorld );
+			direction.sub( targetPosition );
+			direction.normalize();
+
+		}
+
+		return direction;
+
+	};
+
+}();
+
 THREE.Light.prototype.clone = function ( light ) {
 
 	if ( light === undefined ) light = new THREE.Light();

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -13,7 +13,20 @@ THREE.Light = function ( hex ) {
 
 THREE.Light.prototype = Object.create( THREE.Object3D.prototype );
 
-THREE.Light.prototype.getWorldDirection = function() {
+THREE.Light.prototype.clone = function ( light ) {
+
+	if ( light === undefined ) light = new THREE.Light();
+
+	THREE.Object3D.prototype.clone.call( this, light );
+
+	light.color.copy( this.color );
+
+	return light;
+
+};
+
+
+THREE.Light._getWorldDirectionClosure = function() {
 
 	var targetPosition = new THREE.Vector3();
 
@@ -34,17 +47,5 @@ THREE.Light.prototype.getWorldDirection = function() {
 		return direction;
 
 	};
-
-}();
-
-THREE.Light.prototype.clone = function ( light ) {
-
-	if ( light === undefined ) light = new THREE.Light();
-
-	THREE.Object3D.prototype.clone.call( this, light );
-
-	light.color.copy( this.color );
-
-	return light;
 
 };

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -42,6 +42,8 @@ THREE.SpotLight = function ( hex, intensity, distance, angle, exponent ) {
 
 THREE.SpotLight.prototype = Object.create( THREE.Light.prototype );
 
+THREE.SpotLight.prototype.getWorldDirection = THREE.Light._getWorldDirectionClosure();
+
 THREE.SpotLight.prototype.clone = function () {
 
 	var light = new THREE.SpotLight();

--- a/src/renderers/CanvasRenderer.js
+++ b/src/renderers/CanvasRenderer.js
@@ -418,9 +418,10 @@ THREE.CanvasRenderer = function ( parameters ) {
 
 			if ( light instanceof THREE.DirectionalLight ) {
 
-				var lightPosition = _vector3.setFromMatrixPosition( light.matrixWorld ).normalize();
+				//var lightDirection = _vector3.setFromMatrixPosition( light.matrixWorld ).normalize();
+				var lightDirection = light.getWorldDirection( _vector3 );
 
-				var amount = normal.dot( lightPosition );
+				var amount = normal.dot( lightDirection );
 
 				if ( amount <= 0 ) continue;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5017,10 +5017,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( ! light.visible ) continue;
 
-				_direction.setFromMatrixPosition( light.matrixWorld );
-				_vector3.setFromMatrixPosition( light.target.matrixWorld );
-				_direction.sub( _vector3 );
-				_direction.normalize();
+				_direction = light.getWorldDirection( _direction );
 
 				// skip lights with undefined direction
 				// these create troubles in OpenGL (making pixel black)
@@ -5099,10 +5096,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				spotDistances[ spotLength ] = distance;
 
-				_direction.copy( _vector3 );
-				_vector3.setFromMatrixPosition( light.target.matrixWorld );
-				_direction.sub( _vector3 );
-				_direction.normalize();
+				_direction = light.getWorldDirection( _direction );
 
 				spotDirections[ spotOffset ]     = _direction.x;
 				spotDirections[ spotOffset + 1 ] = _direction.y;


### PR DESCRIPTION
Addresses the duplicate code in the renderers for figuring out the direction of the SpotLight and DirectionalLight by moving it into a function in the Light classes.

In response to @WestLangley's comments I have made a shared but unusable static function on Light that is then attached in a usable way to the prototypes of SpotLight and DirectionalLight.  I did this to avoid writing the same code twice.

Fixes #4258.
