### PR TITLE
create texture path double slash fix

### DIFF
--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -147,7 +147,7 @@ THREE.Loader.prototype = {
 
 			var isCompressed = /\.dds$/i.test( sourceFile );
 			
-			var fullPath = texturePath + texturePath.slice(-1) === '/' : '' : '/' + sourceFile;
+			var fullPath = texturePath + (texturePath.slice(-1) === '/' ? '' : '/') + sourceFile;
 
 			if ( isCompressed ) {
 

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -146,7 +146,8 @@ THREE.Loader.prototype = {
 		function create_texture( where, name, sourceFile, repeat, offset, wrap, anisotropy ) {
 
 			var isCompressed = /\.dds$/i.test( sourceFile );
-			var fullPath = texturePath + "/" + sourceFile;
+			
+			var fullPath = texturePath + texturePath.slice(-1) === '/' : '' : '/' + sourceFile;
 
 			if ( isCompressed ) {
 


### PR DESCRIPTION
extractUrlBase already add a slash on texturePath hence an error occurs as for instance if texturePath is "/folder/folder2/" and sourceFile is "my.jpg" the result will be /folder/folder2//my.jpg.

It's a common issue in file path. For instance Java uses new File(String path, String fileName) constructor to avoid all those tricky things such as Windows/linux slashes and ending slash, unfortunatelly it does not exists in JS ;)
