### PR TITLE
bump map export doesn't work correctly, can cause TypeError

### DIFF
--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -1965,8 +1965,8 @@ def extract_material_data(m, option_colors):
 
     if textures['bump']:
         material['mapBump'] = textures['bump']['texture'].image.name
-        if textures['normal']['slot'].use_map_normal:
-            material['mapBumpScale'] = textures['normal']['slot'].normal_factor
+        if textures['bump']['slot'].use_map_normal:
+            material['mapBumpScale'] = textures['bump']['slot'].normal_factor
 
     material['shading'] = m.THREE_materialType
     material['blending'] = m.THREE_blendingType


### PR DESCRIPTION
When there's a material with bump but without normal map TypeError is thrown:

Traceback (most recent call last):
  File "/home/railla/.config/blender/2.69/scripts/addons/io_mesh_threejs/**init**.py", line 337, in execute
    return io_mesh_threejs.export_threejs.save(self, context, **self.properties)
  File "/home/railla/.config/blender/2.69/scripts/addons/io_mesh_threejs/export_threejs.py", line 2521, in save
    option_copy_textures)
  File "/home/railla/.config/blender/2.69/scripts/addons/io_mesh_threejs/export_threejs.py", line 2390, in export_scene
    scene_text += generate_ascii_scene(data)
  File "/home/railla/.config/blender/2.69/scripts/addons/io_mesh_threejs/export_threejs.py", line 2289, in generate_ascii_scene
    materials, nmaterials = generate_materials_scene(data)
  File "/home/railla/.config/blender/2.69/scripts/addons/io_mesh_threejs/export_threejs.py", line 2112, in generate_materials_scene
    material = extract_material_data(m, data["use_colors"])
  File "/home/railla/.config/blender/2.69/scripts/addons/io_mesh_threejs/export_threejs.py", line 1968, in extract_material_data
    if textures['normal']['slot'].use_map_normal:
TypeError: 'NoneType' object is not subscriptable

It looks like a simple copy-paste error, so this has fixed error for me.
