### PR TITLE
Render buffer geometry lines/particles separately from buffer update

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2708,16 +2708,16 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				var position = geometryAttributes[ "position" ];
-
-				// render particles
-
-				_gl.drawArrays( _gl.POINTS, 0, position.numItems / 3 );
-
-				_this.info.render.calls ++;
-				_this.info.render.points += position.numItems / 3;
-
 			}
+
+			var position = geometryAttributes[ "position" ];
+
+			// render particles
+
+			_gl.drawArrays( _gl.POINTS, 0, position.numItems / 3 );
+
+			_this.info.render.calls ++;
+			_this.info.render.points += position.numItems / 3;
 
 		} else if ( object instanceof THREE.Line ) {
 
@@ -2755,22 +2755,22 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				// render lines
-
-				var primitives = ( object.type === THREE.LineStrip ) ? _gl.LINE_STRIP : _gl.LINES;
-
-				setLineWidth( material.linewidth );
-
-				var position = geometryAttributes[ "position" ];
-
-				_gl.drawArrays( primitives, 0, position.numItems / 3 );
-
-				_this.info.render.calls ++;
-				_this.info.render.points += position.numItems;
-
 			}
 
-    	}
+			// render lines
+
+			var primitives = ( object.type === THREE.LineStrip ) ? _gl.LINE_STRIP : _gl.LINES;
+
+			setLineWidth( material.linewidth );
+
+			var position = geometryAttributes[ "position" ];
+
+			_gl.drawArrays( primitives, 0, position.numItems / 3 );
+
+			_this.info.render.calls ++;
+			_this.info.render.points += position.numItems;
+
+		}
 
 	};
 


### PR DESCRIPTION
Line and particle buffer geometries are only being rendered if updateBuffers is true, while triangle buffer geometries are always rendered. This only works because updateBuffers is always set to true in renderPlugins (via _currentGeometryGroupHash), a fortuitous side effect of having 2 built-in plugins.

This change makes buffer geometry rendering consistent between triangles, lines and particles.
