### PR TITLE
Avoid defaulting crossOrigin attribute

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -5,7 +5,7 @@
 
 THREE.ImageUtils = {
 
-	crossOrigin: 'anonymous',
+	crossOrigin: undefined,
 
 	loadTexture: function ( url, mapping, onLoad, onError ) {
 

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -17,7 +17,7 @@ THREE.Loader.prototype = {
 
 	constructor: THREE.Loader,
 
-	crossOrigin: 'anonymous',
+	crossOrigin: undefined,
 
 	addStatusElement: function () {
 
@@ -138,7 +138,7 @@ THREE.Loader.prototype = {
 
 			};
 
-			image.crossOrigin = _this.crossOrigin;
+			if ( _this.crossOrigin !== undefined ) image.crossOrigin = _this.crossOrigin;
 			image.src = url;
 
 		}


### PR DESCRIPTION
Defaulting the crossOrigin attribute to 'anonymous' causes browsers to
not send credentials along with the request, even if the request is not
cross origin (at least with Chrome). A better default is to not set the
cross origin attribute, allowing browsers to behave normally. Users in a
cross origin environment can override this value.
