### PR TITLE
Adds support for raycasting with morphs

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -247,6 +247,8 @@
 				var precision = raycaster.precision;
 
 				var vertices = geometry.vertices;
+				var morphTargets = geometry.morphTargets;
+				var morphInfluences = object.morphTargetInfluences;
 
 				for ( var f = 0, fl = geometry.faces.length; f < fl; f ++ ) {
 
@@ -259,7 +261,49 @@
 					a = vertices[ face.a ];
 					b = vertices[ face.b ];
 					c = vertices[ face.c ];
-					
+
+					if ( material.morphTargets === true) {
+						vA.set(0, 0, 0);
+						vB.set(0, 0, 0);
+						vC.set(0, 0, 0);
+
+						for(var t = 0, tl = morphTargets.length; t < tl; t ++ ) {
+
+							var targets = morphTargets[t].vertices;
+							var influence = morphInfluences[t];
+
+							vA.x += (targets[ face.a ].x - a.x) * influence;
+							vA.y += (targets[ face.a ].y - a.y) * influence;
+							vA.z += (targets[ face.a ].z - a.z) * influence;
+
+							vB.x += (targets[ face.b ].x - b.x) * influence;
+							vB.y += (targets[ face.b ].y - b.y) * influence;
+							vB.z += (targets[ face.b ].z - b.z) * influence;
+
+							vC.x += (targets[ face.c ].x - c.x) * influence;
+							vC.y += (targets[ face.c ].y - c.y) * influence;
+							vC.z += (targets[ face.c ].z - c.z) * influence;
+
+						}
+
+						vA.x += a.x;
+						vA.y += a.y;
+						vA.z += a.z;
+
+						vB.x += b.x;
+						vB.y += b.y;
+						vB.z += b.z;
+
+						vC.x += c.x;
+						vC.y += c.y;
+						vC.z += c.z;
+
+						a = vA;
+						b = vB;
+						c = vC;
+
+					}
+
 					if ( material.side === THREE.BackSide ) {
 							
 						var intersectionPoint = localRay.intersectTriangle( c, b, a, true ); 


### PR DESCRIPTION
This isn't insanely fast, but it stops the bug described [here](https://stackoverflow.com/q/13723473/102441), where the RayCaster assumes all meshes are in their unmorphed form.

Tested on a mesh with 10000 vertices, runs at a reasonable speed. The code path should only be taken if morphs are enabled anyway.

I've chosen time over memory here - it may be faster to precalculate all the morphed points, but then you end up allocating a lot of vector objects. Also, the calculations are written out elementwise to try and optimize for speed.
