### PR TITLE
Updated WebGlRenderer render Method Documentation

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -259,8 +259,8 @@
 		<h3>.render( [page:Scene scene], [page:Camera camera], [page:WebGLRenderTarget renderTarget], [page:Boolean forceClear] )</h3>
 		<div>Render a scene using a camera.</div>
 		<div>The render is done to the renderTarget (if specified) or to the canvas as usual.</div>
-		<div>If forceClear is true, the canvas will be cleared before rendering, even if the renderer's autoClear property is false.</div>
-
+        <div>If forceClear is true the depth, stencil and color buffers will be cleared before rendering even if the renderer's autoClear property is false.</div>
+        <div>Even with forceClear set to true you can prevent certain buffers being cleared by setting either the .autoClearColor, .autoClearStencil or .autoClearDepth properties to false.</div>
 
 		<h3>.renderImmediateObject( camera, lights, fog, material, object )</h3>
 		<div>TODO.</div>


### PR DESCRIPTION
The WebGlRenderer.render's forceClear argument forces a
clear -only- for buffers with their .autoClear property is set to true.

Took me a while to find a bug in my code as I didn't understand
these flags overode the forceClear parameter for WebGlRenderer.render
