### PR TITLE
Modifying color tests to use RGB between 0 and 1, not 0 and 255

### DIFF
--- a/test/unit/math/Color.js
+++ b/test/unit/math/Color.js
@@ -22,48 +22,48 @@ test( "copyColorString", function(){
 });
 
 test( "setRGB", function(){
-    var c = new THREE.Color()
-    c.setRGB(255, 2, 1);
-    ok( c.r == 255, "Red: " + c.r );
-    ok( c.g == 2, "Green: " + c.g );
-    ok( c.b == 1, "Blue: " + c.b );
+    var c = new THREE.Color();
+    c.setRGB(1, 0.2, 0.1);
+    ok( c.r == 1, "Red: " + c.r );
+    ok( c.g == 0.2, "Green: " + c.g );
+    ok( c.b == 0.1, "Blue: " + c.b );
 });
 
 test( "copyGammaToLinear", function(){
     var c = new THREE.Color();
     var c2 = new THREE.Color();
-    c2.setRGB(2, 4, 8)
-    c.copyGammaToLinear(c2)
-    ok( c.r == 4, "Red c: " + c.r + " Red c2: " + c2.r);
-    ok( c.g == 16, "Green c: " + c.g + " Green c2: " + c2.g);
-    ok( c.b == 64, "Blue c: " + c.b + " Blue c2: " + c2.b);
+    c2.setRGB(0.3, 0.5, 0.9);
+    c.copyGammaToLinear(c2);
+    ok( c.r == 0.09, "Red c: " + c.r + " Red c2: " + c2.r);
+    ok( c.g == 0.25, "Green c: " + c.g + " Green c2: " + c2.g);
+    ok( c.b == 0.81, "Blue c: " + c.b + " Blue c2: " + c2.b);
 });
 
 test( "copyLinearToGamma", function(){
     var c = new THREE.Color();
     var c2 = new THREE.Color();
-    c2.setRGB(4, 9, 16)
-    c.copyLinearToGamma(c2)
-    ok( c.r == 2, "Red c: " + c.r + " Red c2: " + c2.r);
-    ok( c.g == 3, "Green c: " + c.g + " Green c2: " + c2.g);
-    ok( c.b == 4, "Blue c: " + c.b + " Blue c2: " + c2.b);
+    c2.setRGB(0.09, 0.25, 0.81);
+    c.copyLinearToGamma(c2);
+    ok( c.r == 0.3, "Red c: " + c.r + " Red c2: " + c2.r);
+    ok( c.g == 0.5, "Green c: " + c.g + " Green c2: " + c2.g);
+    ok( c.b == 0.9, "Blue c: " + c.b + " Blue c2: " + c2.b);
 });
 
 
 test( "convertGammaToLinear", function(){
     var c = new THREE.Color();
-    c.setRGB(2, 4, 8)
-    c.convertGammaToLinear()
-    ok( c.r == 4, "Red: " + c.r );
-    ok( c.g == 16, "Green: " + c.g );
-    ok( c.b == 64, "Blue: " + c.b );
+    c.setRGB(0.3, 0.5, 0.9);
+    c.convertGammaToLinear();
+    ok( c.r == 0.09, "Red: " + c.r );
+    ok( c.g == 0.25, "Green: " + c.g );
+    ok( c.b == 0.81, "Blue: " + c.b );
 });
 
 
 test( "convertLinearToGamma", function(){
     var c = new THREE.Color();
-    c.setRGB(4, 9, 16)
-    c.convertLinearToGamma()
+    c.setRGB(4, 9, 16);
+    c.convertLinearToGamma();
     ok( c.r == 2, "Red: " + c.r );
     ok( c.g == 3, "Green: " + c.g );
     ok( c.b == 4, "Blue: " + c.b );
@@ -73,8 +73,8 @@ test("setWithNum", function(){
     var c = new THREE.Color();
     c.set(0xFF0000);
     ok( c.r == 1, "Red: " + c.r );
-    ok( c.g == 0, "Green: " + c.g );
-    ok( c.b == 0, "Blue: " + c.b );
+    ok( c.g === 0, "Green: " + c.g );
+    ok( c.b === 0, "Blue: " + c.b );
 });
 
 
@@ -95,10 +95,10 @@ test( "lerp", function(){
     var c = new THREE.Color();
     var c2 = new THREE.Color();
     c.setRGB(0, 0, 0);
-    c.lerp(c2, 2);
-    ok( c.r == 2, "Red: " + c.r );
-    ok( c.g == 2, "Green: " + c.g );
-    ok( c.b == 2, "Blue: " + c.b );
+    c.lerp(c2, 0.2);
+    ok( c.r == 0.2, "Red: " + c.r );
+    ok( c.g == 0.2, "Green: " + c.g );
+    ok( c.b == 0.2, "Blue: " + c.b );
     
 });
 
@@ -107,16 +107,16 @@ test( "setStyleRGBRed", function(){
     var c = new THREE.Color();
     c.setStyle('rgb(255,0,0)');
     ok( c.r == 1, "Red: " + c.r );
-    ok( c.g == 0, "Green: " + c.g );
-    ok( c.b == 0, "Blue: " + c.b );
+    ok( c.g === 0, "Green: " + c.g );
+    ok( c.b === 0, "Blue: " + c.b );
 });
 
 test( "setStyleRGBRedWithSpaces", function(){
     var c = new THREE.Color();
     c.setStyle('rgb(255, 0, 0)');
     ok( c.r == 1, "Red: " + c.r );
-    ok( c.g == 0, "Green: " + c.g );
-    ok( c.b == 0, "Blue: " + c.b );
+    ok( c.g === 0, "Green: " + c.g );
+    ok( c.b === 0, "Blue: " + c.b );
 });
 
 test( "setStyleRGBPercent", function(){


### PR DESCRIPTION
The docs for color indicate that setRGB et all take colors between 0 and
1, but the tests use 255 based values. Updating to reflect docs.

The unusual values were used to avoid floating point math errors.

Also added some minor things which fail in jshint
