### PR TITLE
Issue #4336: WebGLRenderer: Consistent application of devicePixelRatio to parameters of setSize, setViewport and setScissor

### DIFF
--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -53,8 +53,6 @@
 
 			var windowWidth, windowHeight;
 
-			var dpr = window.devicePixelRatio || 1;
-
 			var views = [
 				{
 					left: 0,
@@ -285,11 +283,10 @@
 
 					view.updateCamera( camera, scene, mouseX, mouseY );
 
-					// multiply by the device pixel ratio in order to properly support high DPI displays
-					var left   = Math.floor( windowWidth  * view.left ) * dpr;
-					var bottom = Math.floor( windowHeight * view.bottom ) * dpr;
-					var width  = Math.floor( windowWidth  * view.width ) * dpr;
-					var height = Math.floor( windowHeight * view.height ) * dpr;
+					var left   = Math.floor( windowWidth  * view.left );
+					var bottom = Math.floor( windowHeight * view.bottom );
+					var width  = Math.floor( windowWidth  * view.width );
+					var height = Math.floor( windowHeight * view.height );
 					renderer.setViewport( left, bottom, width, height );
 					renderer.setScissor( left, bottom, width, height );
 					renderer.enableScissorTest ( true );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -303,17 +303,17 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		this.setViewport( 0, 0, _canvas.width, _canvas.height );
+		this.setViewport();
 
 	};
 
 	this.setViewport = function ( x, y, width, height ) {
 
-		_viewportX = x !== undefined ? x : 0;
-		_viewportY = y !== undefined ? y : 0;
+		_viewportX = x !== undefined ? x * this.devicePixelRatio : 0;
+		_viewportY = y !== undefined ? y * this.devicePixelRatio : 0;
 
-		_viewportWidth = width !== undefined ? width : _canvas.width;
-		_viewportHeight = height !== undefined ? height : _canvas.height;
+		_viewportWidth = width !== undefined ? width * this.devicePixelRatio : _canvas.width;
+		_viewportHeight = height !== undefined ? height * this.devicePixelRatio : _canvas.height;
 
 		_gl.viewport( _viewportX, _viewportY, _viewportWidth, _viewportHeight );
 
@@ -321,7 +321,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	this.setScissor = function ( x, y, width, height ) {
 
-		_gl.scissor( x, y, width, height );
+		var sX = x !== undefined ? x * this.devicePixelRatio : 0;
+		var sY = y !== undefined ? y * this.devicePixelRatio : 0;
+
+		var sW = width !== undefined ? width * this.devicePixelRatio : _canvas.width;
+		var sH = height !== undefined ? height * this.devicePixelRatio : _canvas.height;
+
+		_gl.scissor( sX, sY, sW, sH );
 
 	};
 


### PR DESCRIPTION
Details in Issue #4336

Changes to WebGLRenderer.setSize, setViewport and setScissor and a recent change to examples/webgl_multiple_views.html had to be reverted.

Not sure about the new default values in setScissor.

An additional change to WebGLRenderer.setRenderTarget might be necessary.
