### PR TITLE
Fix stl loader in IE

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -71,7 +71,7 @@ THREE.STLLoader.prototype.load = function (url, callback) {
 
 	}, false );
 
-	xhr.overrideMimeType('text/plain; charset=x-user-defined');
+	if (xhr.overrideMimeType) { xhr.overrideMimeType('text/plain; charset=x-user-defined'); }
 	xhr.open( 'GET', url, true );
 	xhr.responseType = "arraybuffer";
 	xhr.send( null );


### PR DESCRIPTION
In IE there is no 'xhr.overrideMimeType' option, so it fails to load model.
