### PR TITLE
Blender exporter change

### DIFF
--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -2175,7 +2175,12 @@ def generate_cameras(data):
                     "aspect"    : 1.333,
                     "near"      : camera.clip_start,
                     "far"       : camera.clip_end,
-                    "position"  : generate_vec3([cameraobj.location[0], -cameraobj.location[1], cameraobj.location[2]], data["flipyz"]),
+                # Before this commit (Sun Feb  9 IST 2014) the Y position of
+                # camera was explicitly negated as below:
+                #   "position"  : generate_vec3([cameraobj.location[0], -cameraobj.location[1], cameraobj.location[2]], data["flipyz"]),
+                # It caused incorrect camera setup. The reason for negation was
+                # unknown - maybe it was needed in some situation.
+                    "position"  : generate_vec3([cameraobj.location[0], cameraobj.location[1], cameraobj.location[2]], data["flipyz"]),
                     "target"    : generate_vec3([0, 0, 0])
                     }
 

--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -2175,9 +2175,9 @@ def generate_cameras(data):
                     "aspect"    : 1.333,
                     "near"      : camera.clip_start,
                     "far"       : camera.clip_end,
-                    # Before this commit (Sun Feb  9 IST 2014) the Y position of camera was explicitly negated as below:
+                    # Before this fix the Y position of camera was explicitly negated, causing incorrect camera pos. The reason 
+                    # for negation was unknown, maybe it was needed in some situation.  The old line was:
                     # "position"  : generate_vec3([cameraobj.location[0], -cameraobj.location[1], cameraobj.location[2]], data["flipyz"]),
-                    # It caused incorrect camera setup. The reason for negation was unknown, maybe it was needed in some situation.
                     "position"  : generate_vec3([cameraobj.location[0], cameraobj.location[1], cameraobj.location[2]], data["flipyz"]),
                     "target"    : generate_vec3([0, 0, 0])
                     }

--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -2175,11 +2175,9 @@ def generate_cameras(data):
                     "aspect"    : 1.333,
                     "near"      : camera.clip_start,
                     "far"       : camera.clip_end,
-                # Before this commit (Sun Feb  9 IST 2014) the Y position of
-                # camera was explicitly negated as below:
-                #   "position"  : generate_vec3([cameraobj.location[0], -cameraobj.location[1], cameraobj.location[2]], data["flipyz"]),
-                # It caused incorrect camera setup. The reason for negation was
-                # unknown - maybe it was needed in some situation.
+                    # Before this commit (Sun Feb  9 IST 2014) the Y position of camera was explicitly negated as below:
+                    # "position"  : generate_vec3([cameraobj.location[0], -cameraobj.location[1], cameraobj.location[2]], data["flipyz"]),
+                    # It caused incorrect camera setup. The reason for negation was unknown, maybe it was needed in some situation.
                     "position"  : generate_vec3([cameraobj.location[0], cameraobj.location[1], cameraobj.location[2]], data["flipyz"]),
                     "target"    : generate_vec3([0, 0, 0])
                     }


### PR DESCRIPTION
Blender Exporter: Y position of camera was being explicitly negated, causing incorrect camera pos. The reason for negation was unknown, maybe it was needed in some situation.

See Issue: https://github.com/mrdoob/three.js/issues/4207#issuecomment-34570131
