### PR TITLE
Add error for invalid skinIndices or skinWeights import data lengths. Fixes #4421

### DIFF
--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -452,6 +452,14 @@ THREE.JSONLoader.prototype.parse = function ( json, texturePath ) {
 		}
 
 		geometry.bones = json.bones;
+
+    if ( (geometry.bones.length > 0) && (
+      (geometry.skinWeights.length != geometry.skinIndices.length) ||
+      (geometry.skinWeights.length != geometry.vertices.length) ) ) {
+        console.warn('When skinning, number of vertices (' + geometry.vertices.length + '), skinIndices (' +
+          geometry.skinIndices.length + '), and skinWeights (' + geometry.skinWeights.length + ') should match.');
+    }
+
 		// could change this to json.animations[0] or remove completely
 		geometry.animation = json.animation;
 		geometry.animations = json.animations;

--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -453,12 +453,13 @@ THREE.JSONLoader.prototype.parse = function ( json, texturePath ) {
 
 		geometry.bones = json.bones;
 
-    if ( (geometry.bones.length > 0) && (
-      (geometry.skinWeights.length != geometry.skinIndices.length) ||
-      (geometry.skinWeights.length != geometry.vertices.length) ) ) {
-        console.warn('When skinning, number of vertices (' + geometry.vertices.length + '), skinIndices (' +
-          geometry.skinIndices.length + '), and skinWeights (' + geometry.skinWeights.length + ') should match.');
-    }
+		if ( (geometry.bones.length > 0) && (
+			(geometry.skinWeights.length != geometry.skinIndices.length) ||
+			(geometry.skinIndices.length != geometry.vertices.length) ) ) {
+				console.warn('When skinning, number of vertices (' + geometry.vertices.length + '), skinIndices (' +
+					geometry.skinIndices.length + '), and skinWeights (' + geometry.skinWeights.length + ') should match.');
+		}
+
 
 		// could change this to json.animations[0] or remove completely
 		geometry.animation = json.animation;


### PR DESCRIPTION
I use `geometry.bones.length > 0` to determine whether the mesh is intended to be skinned or not.  Perhaps there should instead be a field in the json itself, allowing this line in the javascript to be scrapped: `material.skinning = true`.

But that is outside the scope of this PR.
