### PR TITLE
CTMLoader - BufferGeometry - Proper fix for loading large (>65k vertices) models 

### DIFF
--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -78,7 +78,7 @@ THREE.CTMLoader.prototype.loadParts = function( url, callback, parameters ) {
 };
 
 // Load CTMLoader compressed models
-//  - parameters
+//	- parameters
 //		- url (required)
 //		- callback (required)
 
@@ -116,8 +116,8 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 							var ctmFile = files[ i ];
 
-                            				var e1 = Date.now();
-                            				// console.log( "CTM data parse time [worker]: " + (e1-s) + " ms" );
+																		var e1 = Date.now();
+																		// console.log( "CTM data parse time [worker]: " + (e1-s) + " ms" );
 
 							if ( useBuffers ) {
 
@@ -129,8 +129,8 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 							}
 
-                            				var e = Date.now();
-                            				console.log( "model load time [worker]: " + (e-e1) + " ms, total: " + (e-s));
+																		var e = Date.now();
+																		console.log( "model load time [worker]: " + (e-e1) + " ms, total: " + (e-s));
 
 						}
 
@@ -207,15 +207,11 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 
 		var scope = this;
 
-		var reorderVertices = true;
-
 		scope.materials = [];
 
 		THREE.BufferGeometry.call( this );
 
-		var s = Date.now();
 		// init GL buffers
-
 		var vertexIndexArray = file.body.indices,
 		vertexPositionArray = file.body.vertices,
 		vertexNormalArray = file.body.normals;
@@ -230,226 +226,31 @@ THREE.CTMLoader.prototype.createModelBuffers = function ( file, callback ) {
 			vertexColorArray = file.body.attrMaps[ 0 ].attr;
 		}
 
-		// reorder vertices
-		// (needed for buffer splitting, to keep together face vertices)
-		if ( reorderVertices ) {
-
-		    	function copyVertexInfo(v, vt) {
-
-				var sx = v * 3,
-			    	    sy = v * 3 + 1,
-			    	    sz = v * 3 + 2,
-
-			    	dx = vt * 3,
-			    	dy = vt * 3 + 1,
-			    	dz = vt * 3 + 2;
-
-				newVertices[ dx ] = vertexPositionArray[ sx ];
-				newVertices[ dy ] = vertexPositionArray[ sy ];
-				newVertices[ dz ] = vertexPositionArray[ sz ];
-
-				if ( vertexNormalArray ) {
-				    newNormals[ dx ] = vertexNormalArray[ sx ];
-				    newNormals[ dy ] = vertexNormalArray[ sy ];
-				    newNormals[ dz ] = vertexNormalArray[ sz ];
-				}
-
-				if ( vertexUvArray ) {
-				    newUvs[ vt * 2 ] 	 = vertexUvArray[ v * 2 ];
-				    newUvs[ vt * 2 + 1 ] = vertexUvArray[ v * 2 + 1 ];
-				}
-
-				if ( vertexColorArray ) {
-				    newColors[ vt * 4 ] 	= vertexColorArray[ v * 4 ];
-				    newColors[ vt * 4 + 1 ] = vertexColorArray[ v * 4 + 1 ];
-				    newColors[ vt * 4 + 2 ] = vertexColorArray[ v * 4 + 2 ];
-				    newColors[ vt * 4 + 3 ] = vertexColorArray[ v * 4 + 3 ];
-				}
-		    	}
-
-		    	function handleVertex( v, iMap ) {
-
-				if ( iMap[ v ] === undefined ) {
-
-					iMap[ v ] = vertexCounter;
-                    			reverseIndexMap[vertexCounter] = v;
-					vertexCounter += 1;
-				}
-                		return iMap[ v ];
-		    	}
-
-			var newFaces = new Uint32Array( vertexIndexArray.length );
-			var indexMap = {}, reverseIndexMap = {}, vertexCounter = 0;
-
-            		var spawledFaceCount = 0,
-                	    spawledFaceLimit = Math.ceil(vertexIndexArray.length/3000);
-            		var sprawledFaces = new Uint32Array( spawledFaceLimit );  // to store sprawled triangle indices
-
-			for ( var i = 0; i < vertexIndexArray.length; i += 3 ) {
-
-				var a = vertexIndexArray[ i ];
-				var b = vertexIndexArray[ i + 1 ];
-				var c = vertexIndexArray[ i + 2 ];
-
-				handleVertex( a, indexMap );
-				handleVertex( b, indexMap );
-				handleVertex( c, indexMap );
-
-				// check for sprawled triangles and put them aside to recreate later
-				if ( Math.abs( indexMap[a] - indexMap[b] ) > 65535 ||
-                     		     Math.abs( indexMap[b] - indexMap[c] ) > 65535 ||
-                     		     Math.abs( indexMap[c] - indexMap[a] ) > 65535 ){
-
-			    		// expand storage when neccessary
-			    		if (spawledFaceCount >= spawledFaceLimit) {
-						console.warn("reached sprawled faces limit: " + spawledFaceCount);
-						spawledFaceLimit *= 2;
-						var tArr = new Uint32Array( spawledFaceLimit );
-						tArr.set(sprawledFaces);
-						sprawledFaces = tArr;
-			    		}
-
-                    			sprawledFaces[ spawledFaceCount ] = i;  // starting index in newFaces
-                    			spawledFaceCount += 1;
-                		}
-                		else {
-
-				    newFaces[ i ] 	  = indexMap[ a ];
-				    newFaces[ i + 1 ] = indexMap[ b ];
-				    newFaces[ i + 2 ] = indexMap[ c ];
-                		}
-			}
-            		// console.log("Number of sprawled faces: " + spawledFaceCount + " current limit: " + spawledFaceLimit +
-                        //	" total: " + vertexIndexArray.length/3 + " vertices: " + vertexCounter);
-
-			// create dublicate vertices and update sprawled faces
-			var indexMap2 = {},
-			    noov = vertexCounter;   // # of original vertices
-
-			for (var isf = 0; isf < spawledFaceCount; isf++ ) {
-				var i = sprawledFaces[isf];
-
-				for (var j = 0; j < 3; j++) {
-				    var v = vertexIndexArray[ i + j ];
-				    newFaces[ i + j] = handleVertex(v, indexMap2);   // new vertex
-				}
-			}
-
-			// console.log("Created duplicated vertices: " + (vertexCounter - noov));
-
-			// copy xyz, uv, normals and colors into new arrays
-			var newVertices = new Float32Array( 3*vertexCounter );
-			var newNormals, newUvs, newColors;
-
-			if ( vertexNormalArray ) newNormals = new Float32Array( 3*vertexCounter );
-			if ( vertexUvArray ) newUvs = new Float32Array( 2*vertexCounter );
-			if ( vertexColorArray ) newColors = new Float32Array( 4*vertexCounter );
-
-			for (var iv = 0; iv < vertexCounter; iv++) {
-				copyVertexInfo(reverseIndexMap[iv], iv);
-			}
-
-			vertexIndexArray = newFaces;
-			vertexPositionArray = newVertices;
-
-			if ( vertexNormalArray ) vertexNormalArray = newNormals;
-			if ( vertexUvArray ) vertexUvArray = newUvs;
-			if ( vertexColorArray ) vertexColorArray = newColors;
-		}
-
-		// compute offsets
-
-		scope.offsets = [];
-
-		var indices = vertexIndexArray;
-
-		var start = 0,
-			min = vertexPositionArray.length,
-			max = 0,
-			minPrev = min;
-
-		for ( var i = 0; i < indices.length; ) {
-
-			for ( var j = 0; j < 3; ++ j ) {
-
-				var idx = indices[ i ++ ];
-
-				if ( idx < min ) min = idx;
-				if ( idx > max ) max = idx;
-
-			}
-
-			if ( max - min > 65535 ) {
-
-				i -= 3;
-
-                		if ( minPrev > 0 ) {
-
-				    for ( var k = start; k < i; ++ k )
-					    indices[ k ] -= minPrev;
-				}
-
-				scope.offsets.push( { start: start, count: i - start, index: minPrev } );
-
-				start = i;
-				min = vertexPositionArray.length;
-				max = 0;
-
-			}
-
-			minPrev = min;
-
-		}
-
-        	if ( minPrev > 0 ) {
-
-		    for ( var k = start; k < i; ++ k )
-			    indices[ k ] -= minPrev;
-		}
-		scope.offsets.push( { start: start, count: i - start, index: minPrev } );
-
-        	// var e = Date.now();
-		// console.log( "Vetex reordering time: " + (e-s) + " ms" );
-
-		// recast CTM 32-bit indices as 16-bit WebGL indices
-		var vertexIndexArray16 = new Uint16Array( vertexIndexArray );
-
 		// attributes
 		var attributes = scope.attributes;
 
-		attributes[ "index" ]    = { itemSize: 1, array: vertexIndexArray16 };
+		attributes[ "index" ]		 = { itemSize: 1, array: vertexIndexArray };
 		attributes[ "position" ] = { itemSize: 3, array: vertexPositionArray };
 
-		if ( vertexNormalArray !== undefined ) {
-
+		if ( vertexNormalArray !== undefined ) 
 			attributes[ "normal" ] = { itemSize: 3, array: vertexNormalArray };
 
-		}
-
-		if ( vertexUvArray !== undefined ) {
-
+		if ( vertexUvArray !== undefined ) 
 			attributes[ "uv" ] = { itemSize: 2, array: vertexUvArray };
 
-		}
-
-		if ( vertexColorArray !== undefined ) {
-
+		if ( vertexColorArray !== undefined ) 
 			attributes[ "color" ]  = { itemSize: 4, array: vertexColorArray };
-
-		}
-
 	}
 
 	Model.prototype = Object.create( THREE.BufferGeometry.prototype );
 
 	var geometry = new Model();
 
+	geometry.computeOffsets();
+
 	// compute vertex normals if not present in the CTM model
-
 	if ( geometry.attributes[ "normal" ] === undefined ) {
-
 		geometry.computeVertexNormals();
-
 	}
 
 	callback( geometry );
@@ -631,15 +432,15 @@ THREE.CTMLoader.prototype.createModelClassic = function ( file, callback ) {
 
 	function f3n ( scope, normals, a, b, c, mi, nai, nbi, nci ) {
 
-		var nax = normals[ nai * 3     ],
+		var nax = normals[ nai * 3		 ],
 			nay = normals[ nai * 3 + 1 ],
 			naz = normals[ nai * 3 + 2 ],
 
-			nbx = normals[ nbi * 3     ],
+			nbx = normals[ nbi * 3		 ],
 			nby = normals[ nbi * 3 + 1 ],
 			nbz = normals[ nbi * 3 + 2 ],
 
-			ncx = normals[ nci * 3     ],
+			ncx = normals[ nci * 3		 ],
 			ncy = normals[ nci * 3 + 1 ],
 			ncz = normals[ nci * 3 + 2 ];
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -273,15 +273,15 @@ THREE.BufferGeometry.prototype = {
 						ab.subVectors( pA, pB );
 						cb.cross( ab );
 
-						normals[ vA * 3 ]     += cb.x;
+						normals[ vA * 3 ]			+= cb.x;
 						normals[ vA * 3 + 1 ] += cb.y;
 						normals[ vA * 3 + 2 ] += cb.z;
 
-						normals[ vB * 3 ]     += cb.x;
+						normals[ vB * 3 ]			+= cb.x;
 						normals[ vB * 3 + 1 ] += cb.y;
 						normals[ vB * 3 + 2 ] += cb.z;
 
-						normals[ vC * 3 ]     += cb.x;
+						normals[ vC * 3 ]			+= cb.x;
 						normals[ vC * 3 + 1 ] += cb.y;
 						normals[ vC * 3 + 2 ] += cb.z;
 
@@ -314,7 +314,7 @@ THREE.BufferGeometry.prototype = {
 					ab.subVectors( pA, pB );
 					cb.cross( ab );
 
-					normals[ i ] 	 = cb.x;
+					normals[ i ]	 = cb.x;
 					normals[ i + 1 ] = cb.y;
 					normals[ i + 2 ] = cb.z;
 
@@ -352,7 +352,7 @@ THREE.BufferGeometry.prototype = {
 
 			n = 1.0 / Math.sqrt( x * x + y * y + z * z );
 
-			normals[ i ] 	 *= n;
+			normals[ i ]	 *= n;
 			normals[ i + 1 ] *= n;
 			normals[ i + 2 ] *= n;
 
@@ -530,7 +530,7 @@ THREE.BufferGeometry.prototype = {
 			test = tmp2.dot( tan2[ v ] );
 			w = ( test < 0.0 ) ? -1.0 : 1.0;
 
-			tangents[ v * 4 ]     = tmp.x;
+			tangents[ v * 4 ]			= tmp.x;
 			tangents[ v * 4 + 1 ] = tmp.y;
 			tangents[ v * 4 + 2 ] = tmp.z;
 			tangents[ v * 4 + 3 ] = w;
@@ -560,6 +560,166 @@ THREE.BufferGeometry.prototype = {
 		this.hasTangents = true;
 		this.tangentsNeedUpdate = true;
 
+	},
+
+	/*
+		computeOffsets
+		Compute the draw offset for large models by chunking the index buffer into chunks of 65k addressable vertices.
+		This method will effectively rewrite the index buffer and remap all attributes to match the new indices.
+		WARNING: This method will also expand the vertex count to prevent sprawled triangles across draw offsets.
+		indexBufferSize - Defaults to 65535, but allows for larger or smaller chunks.
+	*/
+	computeOffsets: function(indexBufferSize) {
+
+		var size = indexBufferSize;
+		if(indexBufferSize === undefined)
+			size = 65535; //WebGL limits type of index buffer values to 16-bit.
+
+		var s = Date.now();
+
+		var indices = this.attributes['index'].array;
+		var vertices = this.attributes['position'].array;
+
+		var verticesCount = (vertices.length/3);
+		var facesCount = (indices.length/3);
+
+		/*
+		console.log("Computing buffers in offsets of "+size+" -> indices:"+indices.length+" vertices:"+vertices.length);
+		console.log("Faces to process: "+(indices.length/3));
+		console.log("Reordering "+verticesCount+" vertices.");
+		*/
+
+		var sortedIndices = new Uint16Array( indices.length ); //16-bit buffers
+		var indexPtr = 0;
+		var vertexPtr = 0;
+
+		var offsets = [ { start:0, count:0, index:0 } ];
+		var offset = offsets[0];
+
+		var duplicatedVertices = 0;
+		var newVerticeMaps = 0;
+		var faceVertices = new Int32Array(6);
+		var vertexMap = new Int32Array( vertices.length );
+		var revVertexMap = new Int32Array( vertices.length );
+		for(var j = 0; j < vertices.length; j++) { vertexMap[j] = -1; revVertexMap[j] = -1; }
+
+		/*
+			Traverse every face and reorder vertices in the proper offsets of 65k.
+			We can have more than 65k entries in the index buffer per offset, but only reference 65k values.
+		*/
+		for(var findex = 0; findex < facesCount; findex++) {
+			newVerticeMaps = 0;
+
+			for(var vo = 0; vo < 3; vo++) {
+				var vid = indices[ findex*3 + vo ];
+				if(vertexMap[vid] == -1) {
+					//Unmapped vertice
+					faceVertices[vo*2] = vid;
+					faceVertices[vo*2+1] = -1;
+					newVerticeMaps++;
+				} else if(vertexMap[vid] < offset.index) {
+					//Reused vertices from previous block (duplicate)
+					faceVertices[vo*2] = vid;
+					faceVertices[vo*2+1] = -1;
+					duplicatedVertices++;
+				} else {
+					//Reused vertice in the current block
+					faceVertices[vo*2] = vid;
+					faceVertices[vo*2+1] = vertexMap[vid];
+				}
+			}
+
+			var faceMax = vertexPtr + newVerticeMaps;
+			if(faceMax > (offset.index + size)) {
+				var new_offset = { start:indexPtr, count:0, index:vertexPtr };
+				offsets.push(new_offset);
+				offset = new_offset;
+
+				//Re-evaluate reused vertices in light of new offset.
+				for(var v = 0; v < 6; v+=2) {
+					var new_vid = faceVertices[v+1];
+					if(new_vid > -1 && new_vid < offset.index)
+						faceVertices[v+1] = -1;
+				}
+			}
+
+			//Reindex the face.
+			for(var v = 0; v < 6; v+=2) {
+				var vid = faceVertices[v];
+				var new_vid = faceVertices[v+1];
+
+				if(new_vid === -1)
+					new_vid = vertexPtr++;
+
+				vertexMap[vid] = new_vid;
+				revVertexMap[new_vid] = vid;
+				sortedIndices[indexPtr++] = new_vid - offset.index; //XXX overflows at 16bit
+				offset.count++;
+			}
+		}
+
+		/* Move all attribute values to map to the new computed indices , also expand the vertice stack to match our new vertexPtr. */
+		this.reorderBuffers(sortedIndices, revVertexMap, vertexPtr);
+		this.offsets = offsets;
+
+		/*
+		var orderTime = Date.now();
+		console.log("Reorder time: "+(orderTime-s)+"ms");
+		console.log("Duplicated "+duplicatedVertices+" vertices.");
+		console.log("Compute Buffers time: "+(Date.now()-s)+"ms");
+		console.log("Draw offsets: "+offsets.length);
+		*/
+
+		return offsets;
+	},
+
+	/*
+		reoderBuffers:
+		Reorder attributes based on a new indexBuffer and indexMap.
+		indexBuffer - Uint16Array of the new ordered indices.
+		indexMap - Int32Array where the position is the new vertex ID and the value the old vertex ID for each vertex.
+		vertexCount - Amount of total vertices considered in this reordering (in case you want to grow the vertice stack).
+	*/
+	reorderBuffers: function(indexBuffer, indexMap, vertexCount) {
+
+		/* Create a copy of all attributes for reordering. */
+		var sortedAttributes = {};
+		var types = [ Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array ];
+		for( var attr in this.attributes ) {
+			if(attr == 'index')
+				continue;
+			var sourceArray = this.attributes[attr].array;
+			for ( var i = 0, il = types.length; i < il; i++ ) {
+				var type = types[i];
+				if (sourceArray instanceof type) {
+					sortedAttributes[attr] = new type( this.attributes[attr].itemSize * vertexCount );
+					break;
+				}
+			}
+		}
+
+		/* Move attribute positions based on the new index map */
+		for(var new_vid = 0; new_vid < vertexCount; new_vid++) {
+			var vid = indexMap[new_vid];
+			for ( var attr in this.attributes ) {
+				if(attr == 'index')
+					continue;
+				var attrArray = this.attributes[attr].array;
+				var attrSize = this.attributes[attr].itemSize;
+				var sortedAttr = sortedAttributes[attr];
+				for(var k = 0; k < attrSize; k++)
+					sortedAttr[ new_vid * attrSize + k ] = attrArray[ vid * attrSize + k ];
+			}
+		}
+
+		/* Carry the new sorted buffers locally */
+		this.attributes['index'].array = indexBuffer;
+		for ( var attr in this.attributes ) {
+			if(attr == 'index')
+				continue;
+			this.attributes[attr].array = sortedAttributes[attr];
+			this.attributes[attr].numItems = this.attributes[attr].itemSize * vertexCount;
+		}
 	},
 
 	clone: function () {


### PR DESCRIPTION
The following changeset introduce 2 new methods to BufferGeometry:
- computeOffsets( CHUNK_SIZE ) - Reorder the geometry index buffer and attributes so that all indices are drawn by offsets of a CHUNK_SIZE items max. (Defaults to 16-bits to respect WebGL max). This is done by properly reordering the index buffer and duplicating vertices that would be in different offsets.
- reorderBuffers() - Reorder and/or grow all vertex attributes in the geometry to adhere to a new index map. (Used by computeOffsets).

This patch set also includes a change to the CTMLoader to remove the previous chunking/reordering algorithm that was flawed for complex and large meshes that heavily reuse vertices where it would generate an insane amount of offsets.  (Over 8,000 on our test mesh with 1.5M faces)

This patch with the same mesh generated a perfect output with only 12 draw offsets.

This was tested with production models with over 6 million triangles.

Hope this helps!
