### PR TITLE
Prevent crash when Line vertices length is 0

### DIFF
--- a/src/core/Projector.js
+++ b/src/core/Projector.js
@@ -561,6 +561,8 @@ THREE.Projector = function () {
 
 					vertices = object.geometry.vertices;
 
+					if ( vertices.length === 0 ) continue;
+
 					v1 = getNextVertexInPool();
 					v1.positionScreen.copy( vertices[ 0 ] ).applyMatrix4( _modelViewProjectionMatrix );
 


### PR DESCRIPTION
Added a check inside of the Projector.js to make sure that before accessing the 0th item of the
vertices array in the line geometry, that the length of the vertices array is more than 0.

```
This prevents crashing when a Line object is added to the scene before it has vertices
added to it.
```
