### PR TITLE
preserving the name of temporary mesh changes name of the initial mesh

### DIFF
--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -1479,10 +1479,6 @@ def extract_meshes(objects, scene, export_single_model, option_scale, flipyz):
             if not mesh:
                 raise Exception("Error, could not get mesh data from object [%s]" % object.name)
 
-            # preserve original name
-
-            mesh.name = object.name
-
             if export_single_model:
 
                 if flipyz:


### PR DESCRIPTION
A while ago I noticed that after exporting to JSON some of the meshes in the blend-file change their names to 'mesh_name.00N', couldn't understand why, but then found this.

If the name is changed to be the same as the name of the existing mesh Blender will resolve this 'conflict' by appending a number to the name of that existing mesh.
Which is not cool because it will stay changed after export is complete.
Also, it looks like the name of the temporary mesh is not used anywhere later on so there's no point in giving it any kind of name
