### PR TITLE
Rename Matrix*.multiplyVector3Array() to Matrix*.applyToVector3Array()

### DIFF
--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -92,12 +92,12 @@
 		Multiply every component of the matrix by a scalar value.
 		</div>
 
-		<h3>.multiplyVector3Array([page:Array array]) [page:Array]</h3>
+		<h3>.applyToVector3Array([page:Array array]) [page:Array]</h3>
 		<div>
 		array -- An array in the form [vector1x, vector1y, vector1z, vector2x, vector2y, vector2z, ...]
 		</div>
 		<div>
-		Multiply (apply) this matrix against every vector3 in the array.
+		Multiply (apply) this matrix to every vector3 in the array.
 		</div>
 
 		<h3>.getNormalMatrix([page:Matrix4 matrix4]) [page:Matrix3 this]</h3>

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -229,12 +229,12 @@
 		Clones this matrix.
 		</div>
 
-		<h3>.multiplyVector3Array([page:Array a]) [page:Array]</h3>
+		<h3>.applyToVector3Array([page:Array a]) [page:Array]</h3>
 		<div>
 		array -- An array in the form [vector1x, vector1y, vector1z, vector2x, vector2y, vector2z, ...]
 		</div>
 		<div>
-		Multiply (apply) this matrix against every vector3 in the array.
+		Multiply (apply) this matrix to every vector3 in the array.
 		</div>
 
 		<h3>.getMaxScaleOnAxis() [page:Float]</h3>

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -66,7 +66,7 @@ THREE.BufferGeometry.prototype = {
 
 		if ( position !== undefined ) {
 
-			matrix.multiplyVector3Array( position.array );
+			matrix.applyToVector3Array( position.array );
 			position.needsUpdate = true;
 
 		}
@@ -77,7 +77,7 @@ THREE.BufferGeometry.prototype = {
 
 			var normalMatrix = new THREE.Matrix3().getNormalMatrix( matrix );
 
-			normalMatrix.multiplyVector3Array( normal.array );
+			normalMatrix.applyToVector3Array( normal.array );
 			normal.needsUpdate = true;
 
 		}

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -70,7 +70,14 @@ THREE.Matrix3.prototype = {
 
 	},
 
-	multiplyVector3Array: function() {
+	multiplyVector3Array: function ( a ) {
+
+		console.warn( 'DEPRECATED: Matrix3\'s .multiplyVector3Array() has been renamed. Use matrix.applyToVector3Array( array ) instead.' );
+		return this.applyToVector3Array( a );
+
+	},
+
+	applyToVector3Array: function() {
 
 		var v1 = new THREE.Vector3();
 
@@ -82,7 +89,7 @@ THREE.Matrix3.prototype = {
 				v1.y = a[ i + 1 ];
 				v1.z = a[ i + 2 ];
 
-				v1.applyMatrix3(this);
+				v1.applyMatrix3( this );
 
 				a[ i ]     = v1.x;
 				a[ i + 1 ] = v1.y;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -427,7 +427,14 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	multiplyVector3Array: function() {
+	multiplyVector3Array: function ( a ) {
+
+		console.warn( 'DEPRECATED: Matrix4\'s .multiplyVector3Array() has been renamed. Use matrix.applyToVector3Array( array ) instead.' );
+		return this.applyToVector3Array( a );
+
+	},
+
+	applyToVector3Array: function() {
 
 		var v1 = new THREE.Vector3();
 
@@ -439,7 +446,7 @@ THREE.Matrix4.prototype = {
 				v1.y = a[ i + 1 ];
 				v1.z = a[ i + 2 ];
 
-				v1.applyProjection( this );
+				v1.applyMatrix4( this );
 
 				a[ i ]     = v1.x;
 				a[ i + 1 ] = v1.y;


### PR DESCRIPTION
... so as to remain consistent with our naming conventions.

Also, `Matrix4.multiplyVector3Array()` was calling `Vector3.applyProjection()`, instead of `Vector3.applyMatrix4()`.

If we want to have the ability to apply a projection matrix to elements of an array, we should create an additional method: `Matrix4.applyProjectionToVector3Array()`. Currently, that capability is not needed.
