### PR TITLE
can cause problems if object and datablock names are different

### DIFF
--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -2453,7 +2453,7 @@ def save(operator, context, filepath = "",
                 # otherwise can share geometry
 
                 #else:
-                name = object.name
+                name = object.data.name
 
                 if name not in geo_set:
 
@@ -2479,7 +2479,7 @@ def save(operator, context, filepath = "",
                                                         option_animation_skeletal,
                                                         option_frame_step)
 
-                        embeds[object.data.name] = model_string
+                        embeds[name] = model_string
 
                     else:
 


### PR DESCRIPTION
Just run into this exporting scene of objects with non-matching mesh names.

The problem was that separate object .js files were named based on the object names (object,name), while scene file used names of the meshes (object.data.name)
