### PR TITLE
OrbitControls should only emit change events when distance > epsilon

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -273,7 +273,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		scale = 1;
 		pan.set( 0, 0, 0 );
 
-		if ( lastPosition.distanceTo( this.object.position ) > 0 ) {
+		if ( lastPosition.distanceTo( this.object.position ) > EPS ) {
 
 			this.dispatchEvent( changeEvent );
 


### PR DESCRIPTION
Currently OrbitControls emits change events continuously due to float rounding error, comparing to epsilon instead of 0 fixes this
