### PR TITLE
On the fly sorting of object hierarchy in the UI

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -121,41 +121,45 @@ Sidebar.Scene = function ( editor ) {
 	signals.sceneGraphChanged.add( function () {
 
 		var scene = editor.scene;
-		var sceneType = editor.getObjectType( scene );
+		var aSorted = [];
 
-		var options = {};
-
-		options[ scene.id ] = '<span class="type ' + sceneType + '"></span> ' + scene.name;
-
-		( function addObjects( objects, pad ) {
-
-			for ( var i = 0, l = objects.length; i < l; i ++ ) {
-
-				var object = objects[ i ];
-				var objectType = editor.getObjectType( object );
-
-				var option = pad + '<span class="type ' + objectType + '"></span> ' + object.name;
-
-				if ( object instanceof THREE.Mesh ) {
-
-					var geometry = object.geometry;
-					var material = object.material;
-
-					var geometryType = editor.getGeometryType( geometry );
-					var materialType = editor.getMaterialType( material );
-
-					option += ' <span class="type ' + geometryType + '"></span> ' + geometry.name;
-					option += ' <span class="type ' + materialType + '"></span> ' + material.name;
-
-				}
-
-				options[ object.id ] = option;
-
-				addObjects( object.children, pad + '&nbsp;&nbsp;&nbsp;' );
-
-			}
-
-		} )( scene.children, '&nbsp;&nbsp;&nbsp;' );
+	        (function addObjects(object, pad)   {
+	
+	            var objectType = editor.getObjectType( object );
+	            var option = pad + '<span class="type ' + objectType + '"></span> ' + object.name;
+	
+	            if (object instanceof THREE.Mesh) {
+	
+	                var geometry = object.geometry;
+	                var material = object.material;
+	
+	                var geometryType = editor.getGeometryType( geometry );
+	                var materialType = editor.getMaterialType( material );
+	
+	                option += ' <span class="type ' + geometryType + '"></span> ' + geometry.name;
+	                option += ' <span class="type ' + materialType + '"></span> ' + material.name;
+	            }
+	
+	            aSorted[aSorted.length] = {object: object, html: option};
+	
+	            var length = object.children.length;
+	            for (var i = 0; i < length; ++i)    addObjects(object.children[i], pad + '&nbsp;&nbsp;&nbsp;');
+	
+	        })(scene, '');
+	
+	
+	        var i;
+	        var options = {};
+	        var sortedIds = [];
+	
+	        for (i = 0; i < aSorted.length; ++i)    sortedIds[sortedIds.length] = aSorted[i].object.id;
+	
+	        sortedIds.sort( function(a, b) { return a - b; } );
+	
+	        for (i = 0; i < aSorted.length; ++i)    {
+	            aSorted[i].object.id = sortedIds[i];
+	            options[sortedIds[i]] = aSorted[i].html;
+	        }
 
 		outliner.setOptions( options );
 


### PR DESCRIPTION
Hi,

Currently, the object hierarchy will not be updated in the UI unless you reload the editor. It shows when you try to change the parent of an object.

This fix just tweaks the sceneGraphChanged signal callback added by Sidebar.Scene.

Worth noting that due to the way UI.FancySelect.prototype.setOptions works, we have to swap around the IDs of ThreeJS objects that are meant to be listed. (ID, not UUID fortunately!)
There is no adverse effect to doing this in the editor app since it never relies on a given object having a given id.

The alternative is to tweak ui.js but I refrained since it looked as though you weren't the author (?)
