### PR TITLE
Add stop condition when parse faceVextexUvs in merge

### DIFF
--- a/src/extras/GeometryUtils.js
+++ b/src/extras/GeometryUtils.js
@@ -105,6 +105,12 @@ THREE.GeometryUtils = {
 		for ( i = 0, il = uvs2.length; i < il; i ++ ) {
 
 			var uv = uvs2[ i ], uvCopy = [];
+			
+			if ( uv === undefined ) {
+				
+				break;
+				
+			}
 
 			for ( var j = 0, jl = uv.length; j < jl; j ++ ) {
 

--- a/src/extras/GeometryUtils.js
+++ b/src/extras/GeometryUtils.js
@@ -108,7 +108,7 @@ THREE.GeometryUtils = {
 			
 			if ( uv === undefined ) {
 				
-				break;
+				continue;
 				
 			}
 


### PR DESCRIPTION
When I tried to merge geometries, create by JSON Loader, sometimes last uv is undefined.
