### PR TITLE
bower.json should not be excluded from the package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
 	"ignore": [
 		"**/.*",
 		"*.md",
-		"bower.json",
 		"docs",
 		"editor",
 		"examples",


### PR DESCRIPTION
Several build systems (such as Sprockets), rely on either `bower.json`, or `package.json` being included with `bower install`. Removing `bower.json` from the `ignore` group allows those systems to resolve three correctly.
