### PR TITLE
Allow morphTargets to be undefined in DepthPassPlugin

### DIFF
--- a/src/extras/renderers/plugins/DepthPassPlugin.js
+++ b/src/extras/renderers/plugins/DepthPassPlugin.js
@@ -121,7 +121,7 @@ THREE.DepthPassPlugin = function () {
 
 				if ( objectMaterial ) _renderer.setMaterialFaces( object.material );
 
-				useMorphing = object.geometry.morphTargets.length > 0 && objectMaterial.morphTargets;
+				useMorphing = typeof(object.geometry.morphTargets) !== 'undefined' && object.geometry.morphTargets.length > 0 && objectMaterial.morphTargets;
 				useSkinning = object instanceof THREE.SkinnedMesh && objectMaterial.skinning;
 
 				if ( object.customDepthMaterial ) {


### PR DESCRIPTION
This fixes what looked to be old logic that assumes `geometry.morphTargets` will always exist.
