### PR TITLE
Make it possible to remove animationData.

### DIFF
--- a/src/extras/animation/AnimationHandler.js
+++ b/src/extras/animation/AnimationHandler.js
@@ -52,6 +52,17 @@ THREE.AnimationHandler = (function() {
 		initData( data );
 
 	};
+	
+	//--- remove ---
+
+	that.remove = function( name ) {
+
+		if ( library[ name ] === undefined )
+			console.log( "THREE.AnimationHandler.add: Warning! " + name + " doesn't exists in library. Doing nothing." );
+			
+		library[ name ] = undefined;
+
+	};
 
 
 	//--- get ---


### PR DESCRIPTION
For the moment, It is use at own risk. It doesn't check if data gets used by animations.

fixes #3494.
