### PR TITLE
Don't unbind createMaterial in Loader

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -11248,7 +11248,7 @@ THREE.Loader.prototype = {
 
 		for ( var i = 0; i < materials.length; ++ i ) {
 
-			array[ i ] = THREE.Loader.prototype.createMaterial( materials[ i ], texturePath );
+			array[ i ] = this.createMaterial( materials[ i ], texturePath );
 
 		}
 

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -77,7 +77,7 @@ THREE.Loader.prototype = {
 
 		for ( var i = 0; i < materials.length; ++ i ) {
 
-			array[ i ] = THREE.Loader.prototype.createMaterial( materials[ i ], texturePath );
+			array[ i ] = this.createMaterial( materials[ i ], texturePath );
 
 		}
 


### PR DESCRIPTION
For some reason, `initMaterials` was calling `createMaterial` directly on `prototype`, instead of `this`, causing any changes to an individual loader to be ignored. Specifically, this was the problem:

``` javascript
var loader = new THREE.JSONLoader();
loader.crossOrigin = 'anonymous';
loader.load(/*...*/);
```

On [this line](https://github.com/sgrif/three.js/blob/sg-cross-origin/src/loaders/Loader.js#L173), `_this` would still be referencing the prototype, ignoring the `crossOrigin` property that had been set on the loader.
