### PR TITLE
Corrected calculation of reflection vector

### DIFF
--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -91,13 +91,18 @@ THREE.ShaderChunk = {
 
 		"		vec3 cameraToVertex = normalize( vWorldPosition - cameraPosition );",
 
+				// http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
+				// "Transforming Normal Vectors with the Inverse Transformation"
+
+		"		vec3 worldNormal = normalize( vec3( vec4( normal, 0.0 ) * viewMatrix ) );",
+
 		"		if ( useRefract ) {",
 
-		"			reflectVec = refract( cameraToVertex, normal, refractionRatio );",
+		"			reflectVec = refract( cameraToVertex, worldNormal, refractionRatio );",
 
 		"		} else { ",
 
-		"			reflectVec = reflect( cameraToVertex, normal );",
+		"			reflectVec = reflect( cameraToVertex, worldNormal );",
 
 		"		}",
 


### PR DESCRIPTION
We need to reflect the world-space view vector around the _world-space_ (perturbed) normal when using a bump/normal map with an environment map. Previously, we were reflecting around the _camera-space_ (perturbed) normal.

Converting the camera-space perturbed normal back to world space requires the equivalent of the "normalMatrix" for `camera.matrixWorld`. The shader does not have access to that matrix.

Instead, a technique is used that assumes orthogonality of the rotation component of `viewMatrix`. This assumption is satisfied if `camera.scale = ( 1, 1, 1 )` -- which it should be.

It would actually be a good idea, I believe, to find a way to prevent scaling of the camera matrix.
