### PR TITLE
Make ImageLoader use a default color

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -7,7 +7,7 @@ THREE.ImageUtils = {
 
 	crossOrigin: undefined,
 
-	loadTexture: function ( url, mapping, onLoad, onError ) {
+	loadTexture: function ( url, mapping, onLoad, onError, defaultColor ) {
 
 		var loader = new THREE.ImageLoader();
 		loader.crossOrigin = this.crossOrigin;
@@ -17,13 +17,16 @@ THREE.ImageUtils = {
 		var image = loader.load( url, function () {
 
 			texture.needsUpdate = true;
+			texture.defaultColor = undefined;
 
 			if ( onLoad ) onLoad( texture );
 
 		} );
 
+		texture.defaultColor = defaultColor || [ 128, 128, 128, 255 ];
 		texture.image = image;
 		texture.sourceFile = url;
+		texture.needsUpdate = true;
 
 		return texture;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5474,6 +5474,15 @@ THREE.WebGLRenderer = function ( parameters ) {
 			_gl.activeTexture( _gl.TEXTURE0 + slot );
 			_gl.bindTexture( _gl.TEXTURE_2D, texture.__webglTexture );
 
+			// If there is a default color the texture's image has not yet loaded.
+			if ( texture.defaultColor ) {
+
+				// set up a 1 pixel texture so rendering can happen immediately without WebGL errors.
+				_gl.texImage2D( _gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(texture.defaultColor));
+				return;
+
+			}
+
 			_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, texture.flipY );
 			_gl.pixelStorei( _gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, texture.premultiplyAlpha );
 			_gl.pixelStorei( _gl.UNPACK_ALIGNMENT, texture.unpackAlignment );


### PR DESCRIPTION
This will allow rendering without error while the image loads asynchronously.
