### PR TITLE
ImageUtils.loadTexture: Enable 'onError' callback

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -20,6 +20,10 @@ THREE.ImageUtils = {
 
 			if ( onLoad ) onLoad( texture );
 
+		}, undefined, function ( event ) {
+
+			if ( onError ) onError( event );
+
 		} );
 
 		texture.image = image;


### PR DESCRIPTION
onError for `THREE.ImageUtils.loadTexture` currently does nothing, this PR fixes that
