### PR TITLE
Add support to collada loader for all 4 opaque modes

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3432,36 +3432,31 @@ THREE.ColladaLoader = function () {
 			// convert transparent color RBG to average value
 			var transparentColor = this['transparent'];
 			var transparencyLevel = 0;
-			
-			if ( this.transparency !== 0 ) {
 
-				// Determine transparency level based on opaque mode
-				if (transparentColor.opaque == "RGB_ONE") {
-					transparencyLevel = (3 - this.transparent.color.r -
-						this.transparent.color.g - 
-						this.transparent.color.b) / 
-						3;
-				} else if (transparentColor.opaque == "RGB_ZERO") {
-					transparencyLevel = (this.transparent.color.r +
-						this.transparent.color.g + 
-						this.transparent.color.b) / 
-						3;
-				} else if (transparentColor.opaque == "A_ONE") {
-					transparencyLevel = 1 - this.transparent.color.a;
-				} else { // A_ZERO (default in collada 1.5.0) - http://www.khronos.org/files/collada_1_5_release_notes.pdf (pg 16)
-					transparencyLevel = this.transparent.color.a;
-				}
-				
-				// Assumes all textures in the 'transparent' field will have an alpha channel
-				if ( transparentColor.isTexture() || transparencyLevel > 0 ) {
-					props[ 'transparent' ] = true;
-				} else {
-					props[ 'transparent' ] = false;
-				}
-				
+			// Determine transparency level based on opaque mode
+			if (transparentColor.opaque == "RGB_ONE") {
+				transparencyLevel = (3 - this.transparent.color.r -
+					this.transparent.color.g - 
+					this.transparent.color.b) / 
+					3 * this.transparency;
+			} else if (transparentColor.opaque == "RGB_ZERO") {
+				transparencyLevel = (this.transparent.color.r +
+					this.transparent.color.g + 
+					this.transparent.color.b) / 
+					3 * this.transparency;
+			} else if (transparentColor.opaque == "A_ONE") {
+				transparencyLevel = ( 1 - this.transparent.color.a ) * this.transparency;
+			} else { // A_ZERO (default in collada 1.5.0) - http://www.khronos.org/files/collada_1_5_release_notes.pdf (pg 16)
+				transparencyLevel = this.transparent.color.a * this.transparency;
+			}
+			
+			// Assumes all texures in the 'transparent' field will have an alpha channel
+			if ( transparentColor.isTexture() || transparencyLevel > 0 ) {
+				props[ 'transparent' ] = true;
 			} else {
 				props[ 'transparent' ] = false;
 			}
+
 			props[ 'opacity' ] = 1 - transparencyLevel;
 		}
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3452,7 +3452,7 @@ THREE.ColladaLoader = function () {
 					transparencyLevel = this.transparent.color.a;
 				}
 				
-				// Assumes all texures in the 'transparent' field will have an alpha channel
+				// Assumes all textures in the 'transparent' field will have an alpha channel
 				if ( transparentColor.isTexture() || transparencyLevel > 0 ) {
 					props[ 'transparent' ] = true;
 				} else {

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3451,8 +3451,13 @@ THREE.ColladaLoader = function () {
 				} else { // A_ZERO (default in collada 1.5.0) - http://www.khronos.org/files/collada_1_5_release_notes.pdf (pg 16)
 					transparencyLevel = this.transparent.color.a;
 				}
-			
-				props[ 'transparent' ] = true;
+				
+				// Assumes all texures in the 'transparent' field will have an alpha channel
+				if ( transparentColor.isTexture() || transparencyLevel > 0 ) {
+					props[ 'transparent' ] = true;
+				} else {
+					props[ 'transparent' ] = false;
+				}
 				
 			} else {
 				props[ 'transparent' ] = false;

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3428,37 +3428,36 @@ THREE.ColladaLoader = function () {
 
 		var props = {};
 
-		var transparent = false;
-
 		if (this['transparency'] !== undefined && this['transparent'] !== undefined) {
 			// convert transparent color RBG to average value
 			var transparentColor = this['transparent'];
 			var transparencyLevel = 0;
 			
-			// Determine transparency level based on opaque mode
-			if (transparentColor.opaque == "RGB_ONE") {
-				transparencyLevel = (3 - this.transparent.color.r -
-					this.transparent.color.g - 
-					this.transparent.color.b) / 
-					3 * this.transparency;
-			} else if (transparentColor.opaque == "RGB_ZERO") {
-				transparencyLevel = (this.transparent.color.r +
-					this.transparent.color.g + 
-					this.transparent.color.b) / 
-					3 * this.transparency;
-			} else if (transparentColor.opaque == "A_ONE") {
-				transparencyLevel = ( 1 - this.transparent.color.a ) * this.transparency;
-			} else { // A_ZERO (default in collada 1.5.0) - http://www.khronos.org/files/collada_1_5_release_notes.pdf (pg 16)
-				transparencyLevel = this.transparent.color.a * this.transparency;
-			}
+			if ( this.transparency !== 0 ) {
+
+				// Determine transparency level based on opaque mode
+				if (transparentColor.opaque == "RGB_ONE") {
+					transparencyLevel = (3 - this.transparent.color.r -
+						this.transparent.color.g - 
+						this.transparent.color.b) / 
+						3;
+				} else if (transparentColor.opaque == "RGB_ZERO") {
+					transparencyLevel = (this.transparent.color.r +
+						this.transparent.color.g + 
+						this.transparent.color.b) / 
+						3;
+				} else if (transparentColor.opaque == "A_ONE") {
+					transparencyLevel = 1 - this.transparent.color.a;
+				} else { // A_ZERO (default in collada 1.5.0) - http://www.khronos.org/files/collada_1_5_release_notes.pdf (pg 16)
+					transparencyLevel = this.transparent.color.a;
+				}
 			
-			if (transparencyLevel > 0) {
-				transparent = true;
 				props[ 'transparent' ] = true;
-				props[ 'opacity' ] = 1 - transparencyLevel;
-
+				
+			} else {
+				props[ 'transparent' ] = false;
 			}
-
+			props[ 'opacity' ] = 1 - transparencyLevel;
 		}
 
 		var keys = {
@@ -3534,7 +3533,7 @@ THREE.ColladaLoader = function () {
 
 							}
 
-						} else if ( prop === 'diffuse' || !transparent ) {
+						} else {
 
 							if ( prop === 'emission' ) {
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3436,17 +3436,17 @@ THREE.ColladaLoader = function () {
 			var transparencyLevel = 0;
 			
 			// Determine transparency level based on opaque mode
-			if(transparentColor.opaque == "RGB_ONE") {
+			if (transparentColor.opaque == "RGB_ONE") {
 				transparencyLevel = (3 - this.transparent.color.r -
 					this.transparent.color.g - 
 					this.transparent.color.b) / 
 					3 * this.transparency;
-			} else if(transparentColor.opaque == "RGB_ZERO") {
+			} else if (transparentColor.opaque == "RGB_ZERO") {
 				transparencyLevel = (this.transparent.color.r +
 					this.transparent.color.g + 
 					this.transparent.color.b) / 
 					3 * this.transparency;
-			} else if(transparentColor.opaque == "A_ONE") {
+			} else if (transparentColor.opaque == "A_ONE") {
 				transparencyLevel = ( 1 - this.transparent.color.a ) * this.transparency;
 			} else { // A_ZERO (default in collada 1.5.0) - http://www.khronos.org/files/collada_1_5_release_notes.pdf (pg 16)
 				transparencyLevel = this.transparent.color.a * this.transparency;

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -969,7 +969,7 @@ THREE.ColladaLoader = function () {
 
 						}
 
-						material3js.opacity = !material3js.opacity ? 1 : material3js.opacity;
+						material3js.opacity = ( material3js.opacity === undefined ) ? 1 : material3js.opacity;
 						used_materials[ instance_material.symbol ] = num_materials;
 						used_materials_array.push( material3js );
 						first_material = material3js;
@@ -3433,8 +3433,25 @@ THREE.ColladaLoader = function () {
 		if (this['transparency'] !== undefined && this['transparent'] !== undefined) {
 			// convert transparent color RBG to average value
 			var transparentColor = this['transparent'];
-			var transparencyLevel = (this.transparent.color.r + this.transparent.color.g + this.transparent.color.b) / 3 * this.transparency;
-
+			var transparencyLevel = 0;
+			
+			// Determine transparency level based on opaque mode
+			if(transparentColor.opaque == "RGB_ONE") {
+				transparencyLevel = (3 - this.transparent.color.r -
+					this.transparent.color.g - 
+					this.transparent.color.b) / 
+					3 * this.transparency;
+			} else if(transparentColor.opaque == "RGB_ZERO") {
+				transparencyLevel = (this.transparent.color.r +
+					this.transparent.color.g + 
+					this.transparent.color.b) / 
+					3 * this.transparency;
+			} else if(transparentColor.opaque == "A_ONE") {
+				transparencyLevel = ( 1 - this.transparent.color.a ) * this.transparency;
+			} else { // A_ZERO (default in collada 1.5.0) - http://www.khronos.org/files/collada_1_5_release_notes.pdf (pg 16)
+				transparencyLevel = this.transparent.color.a * this.transparency;
+			}
+			
 			if (transparencyLevel > 0) {
 				transparent = true;
 				props[ 'transparent' ] = true;


### PR DESCRIPTION
Note: this changes the default transparency behavior (be sure to call it out in release notes - some collada files may need to change)

This change should bring us in line with the [collada 1.5.0 spec](http://www.khronos.org/files/collada_1_5_release_notes.pdf) - see pg 16.

This change did make `loader / collada / skinning` show some specular hotspots on the character that weren't there before.  That baffles me.  @tparisi, do you have any idea why that might have happened?
