### PR TITLE
Differentiate between heightfields and normalmaps and treat each appropriately

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3370,9 +3370,31 @@ THREE.ColladaLoader = function () {
 				case 'diffuse':
 				case 'specular':
 				case 'transparent':
-				case 'bump':
 
 					this[ child.nodeName ] = ( new ColorOrTexture() ).parse( child );
+					break;
+
+				case 'bump':
+
+					// If 'bumptype' is 'heightfield', create a 'bump' property
+					// Else if 'bumptype' is 'normalmap', create a 'normal' property
+					// (Default to 'bump')
+					var bumpType = child.getAttribute( 'bumptype' );
+					if ( bumpType ) {
+						if ( bumpType.toLowerCase() === "heightfield" ) {
+							this[ 'bump' ] = ( new ColorOrTexture() ).parse( child );
+						} else if ( bumpType.toLowerCase() === "normalmap" ) {
+							this[ 'normal' ] = ( new ColorOrTexture() ).parse( child );
+						} else {
+							console.error( "Shader.prototype.parse: Invalid value for attribute 'bumptype' (" + bumpType + 
+								           ") - valid bumptypes are 'HEIGHTFIELD' and 'NORMALMAP' - defaulting to 'HEIGHTFIELD'" );
+							this[ 'bump' ] = ( new ColorOrTexture() ).parse( child );
+						}
+					} else {
+						console.warn( "Shader.prototype.parse: Attribute 'bumptype' missing from bump node - defaulting to 'HEIGHTFIELD'" );
+						this[ 'bump' ] = ( new ColorOrTexture() ).parse( child );
+					}
+
 					break;
 
 				case 'shininess':
@@ -3424,10 +3446,11 @@ THREE.ColladaLoader = function () {
 		
 		var keys = {
 			'diffuse':'map', 
-			'ambient':"lightMap" ,
+			'ambient':'lightMap' ,
 			'specular':'specularMap',
 			'emission':'emissionMap',
-			'bump':'normalMap'
+			'bump':'bumpMap',
+			'normal':'normalMap'
 			};
 		
 		for ( var prop in this ) {
@@ -3439,6 +3462,7 @@ THREE.ColladaLoader = function () {
 				case 'diffuse':
 				case 'specular':
 				case 'bump':
+				case 'normal':
 
 					var cot = this[ prop ];
 


### PR DESCRIPTION
Right now the code assumes that any `bump` property is a normal map, which might not be a good assumption (it turns out not to be for some of our models).  This change reads the attribute from the collada model and reacts appropriately (treating it as a height field or normal map).

@BrettASwift, thank you for your help with this fix.
