### PR TITLE
Update ColladaLoader to convert single-axis translation animation data according to upConversion

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -4718,7 +4718,7 @@ THREE.ColladaLoader = function () {
 
 	function setUpConversion() {
 
-		if ( !options.convertUpAxis || colladaUp === options.upAxis ) {
+		if ( options.convertUpAxis !== true || colladaUp === options.upAxis ) {
 
 			upConversion = null;
 
@@ -4749,7 +4749,7 @@ THREE.ColladaLoader = function () {
 
 	function fixCoords( data, sign ) {
 
-		if ( !options.convertUpAxis || colladaUp === options.upAxis ) {
+		if ( options.convertUpAxis !== true || colladaUp === options.upAxis ) {
 
 			return;
 
@@ -4807,7 +4807,7 @@ THREE.ColladaLoader = function () {
 
 	function getConvertedTranslation( axis, data ) {
 
-		if ( !options.convertUpAxis || colladaUp === options.upAxis ) {
+		if ( options.convertUpAxis !== true || colladaUp === options.upAxis ) {
 
 			return data;
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1342,7 +1342,7 @@ THREE.ColladaLoader = function () {
 					for ( var j = 0, jl = input.length; j < jl; j++ ) {
 
 						var time = input[j],
-							data = sampler.getData( transform.type, j ),
+							data = sampler.getData( transform.type, j, member ),
 							key = findKey( keys, time );
 
 						if ( !key ) {
@@ -4111,7 +4111,7 @@ THREE.ColladaLoader = function () {
 
 	};
 
-	Sampler.prototype.getData = function ( type, ndx ) {
+	Sampler.prototype.getData = function ( type, ndx, member ) {
 
 		var data;
 
@@ -4157,6 +4157,10 @@ THREE.ColladaLoader = function () {
 
 			data = this.output[ ndx ];
 
+			if ( member && type == 'translate' ) {
+				data = getConvertedTranslation( member, data );
+			}
+			
 		}
 
 		return data;
@@ -4799,6 +4803,31 @@ THREE.ColladaLoader = function () {
 
 		}
 
+	};
+
+	function getConvertedTranslation( axis, data ) {
+
+		if ( !options.convertUpAxis || colladaUp === options.upAxis ) {
+
+			return data;
+
+		}
+
+		switch ( axis ) {
+			case 'X':
+				data = upConversion == 'XtoY' ? data * -1 : data;
+				break;
+			case 'Y':
+				data = upConversion == 'YtoZ' || upConversion == 'YtoX' ? data * -1 : data;
+				break;
+			case 'Z':
+				data = upConversion == 'ZtoY' ? data * -1 : data ;
+				break;
+			default:
+				break;
+		}
+
+		return data;
 	};
 
 	function getConvertedVec3( data, offset ) {


### PR DESCRIPTION
In the latest version, the ColladaLoader properly converted the up direction for all animation keyframes except those that are a single-axis translation.  This fixes the up-direction conversion for those single-axis translations.

ColladaLoader examples still execute as before.

(Extra credit for those interested in seeing how the fix affects some models:
- Pull down the _development_ branch of the Virtual World Framework here:  https://github.com/virtual-world-framework/vwf.git - the model that shows the issue is `public/radio/radio.DAE`.  Load that into a three.js app, and you'll see that the battery on the back is oddly translated up from where it should be.
- You can see running properly with the fixes from this pull request [here](https://development.virtual.wf/radio) - I apologize for the cert error (we self-sign for our development server)
