### PR TITLE
Fix package.json to make 'npm install' work.

### DIFF
--- a/utils/build/package.json
+++ b/utils/build/package.json
@@ -1,7 +1,7 @@
 {
     "name": "three.js",
     "description": "JavaScript 3D library",
-    "version": "50dev",
+    "version": "0.0.0",
     "homepage" : "http://threejs.org/",
     "author": "three.js contributors",
     "help": {


### PR DESCRIPTION
As I try to install depdencies for build using node.js, following error occurs (the command that i used is 'npm install' under utils/build)

```
  npm ERR! Error: Invalid version: "50dev"
```

It's true that the version is invalid. Semantic versioning has to be used instead.
http://stackoverflow.com/questions/16887993/npm-why-is-a-version-0-1-invalid
http://semver.org/

The reason why I changed it to _0.0.0_ instead current version like _0.66.2_ or some else is that _version_ has no meaning in this file. And also this value doesn't need to be maintained (The real, meaningful _version_ is the one passed through utils/npm/build.js as a argument maybe). So I think specifying a certain version here makes no problem now but may confuse those who read this file later whether he have to update the value or not.
