### PR TITLE
Added Matrix3 uniforms loading

### DIFF
--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -187,6 +187,36 @@ THREE.Matrix3.prototype = {
 
 	},
 
+	flattenToArray: function ( flat ) {
+
+		var te = this.elements;
+		flat[ 0 ] = te[0]; flat[ 1 ] = te[1]; flat[ 2 ] = te[2];
+		flat[ 3 ] = te[3]; flat[ 4 ] = te[4]; flat[ 5 ] = te[5]; 
+		flat[ 6 ] = te[6]; flat[ 7 ] = te[7]; flat[ 8 ] = te[8];
+
+		return flat;
+
+	},
+
+	flattenToArrayOffset: function( flat, offset ) {
+
+		var te = this.elements;
+		flat[ offset ] = te[0];
+		flat[ offset + 1 ] = te[1];
+		flat[ offset + 2 ] = te[2];
+		
+		flat[ offset + 3 ] = te[3];
+		flat[ offset + 4 ] = te[4];
+		flat[ offset + 5 ] = te[5];
+		
+		flat[ offset + 6 ] = te[6];
+		flat[ offset + 7 ] = te[7];
+		flat[ offset + 8 ]  = te[8];
+
+		return flat;
+
+	},
+
 	getNormalMatrix: function ( m ) {
 
 		// input: THREE.Matrix4

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4855,6 +4855,33 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				_gl.uniform4fv( location, uniform._array );
 
+			} else if ( type === "m3") { // single THREE.Matrix3
+
+				if ( uniform._array === undefined ) {
+
+					uniform._array = new Float32Array( 9 );
+
+				}
+
+				value.flattenToArray( uniform._array );
+				_gl.uniformMatrix3fv( location, false, uniform._array );
+
+			} else if ( type === "m3v" ) { // array of THREE.Matrix3
+
+				if ( uniform._array === undefined ) {
+
+					uniform._array = new Float32Array( 9 * value.length );
+
+				}
+
+				for ( i = 0, il = value.length; i < il; i ++ ) {
+
+					value[ i ].flattenToArrayOffset( uniform._array, i * 9 );
+
+				}
+
+				_gl.uniformMatrix3fv( location, false, uniform._array );
+
 			} else if ( type === "m4") { // single THREE.Matrix4
 
 				if ( uniform._array === undefined ) {


### PR DESCRIPTION
Added handling of mat3 uniforms (both single and arrays) to loadUniformsGeneric() in WebGLRenderer.

The Matrix3 syntax follows the convention of the [current Matrix4 loading syntax](https://github.com/mrdoob/three.js/wiki/Uniforms-types). In the uniforms object:

| Type Property Value | Uniform |
| --- | --- |
| "m3" | single Matrix3 |
| "m3v" | Matrix3 array |
