### PR TITLE
gitignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 *.swp
 .project
-utils/npm/node_modules/*
+node_modules


### PR DESCRIPTION
Hello.
When do npm install (fixed by #4614) for build, untracked files was came like this:

```
$ cd utils/build
$ npm install
...
argparse@0.1.15 node_modules/argparse
├── underscore@1.4.4
└── underscore.string@2.3.3

uglify-js2@2.1.11 node_modules/uglify-js2
├── source-map@0.1.33 (amdefine@0.1.0)
└── optimist@0.3.7 (wordwrap@0.0.2)

$ git status
On branch dev
Your branch is ahead of 'origin/dev' by 2 commits.
  (use "git push" to publish your local commits)

Untracked files:
  (use "git add <file>..." to include in what will be committed)

    utils/build/node_modules/
```

Many of project gitignore node_modules so I fixed like that.
