### PR TITLE
adding Texture.addSubImage

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5563,7 +5563,20 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				} else {
 
-					_gl.texImage2D( _gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
+					if ( texture._subImages.length == 0 ) {
+					
+						_gl.texImage2D( _gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
+					
+					} else {				
+					
+						for ( var i = 0, il = texture._subImages.length; i < il; i ++ ) {
+							_gl.texSubImage2D( _gl.TEXTURE_2D, 0, texture._subImages[ i ]._subOffsetX, texture._subImages[ i ]._subOffsetY, glFormat, glType, texture._subImages[ i ].image );
+							
+						}
+						
+						texture._subImages = [];
+						
+					}
 
 				}
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -37,6 +37,8 @@ THREE.Texture = function ( image, mapping, wrapS, wrapT, magFilter, minFilter, f
 
 	this._needsUpdate = false;
 	this.onUpdate = null;
+	
+	this._subImages = [];
 
 };
 
@@ -88,6 +90,17 @@ THREE.Texture.prototype = {
 
 		return texture;
 
+	},
+	
+	addSubImage: function( offsetX, offsetY, image) {
+		
+		this._subImages.push( {
+			_subOffsetX: offsetX,
+			_subOffsetY: offsetY,
+			image: image
+		} );
+		
+		this.needsUpdate = true;
 	},
 
 	update: function () {


### PR DESCRIPTION
addSubImage allows to use "gl.texSubImage2D", a neat tool to replace
parts of a texture with another texture. Especially great for
TextureAtlases, MegaTexture / virtual texture usages, etc.
