### PR TITLE
Add a way of excluding items from intersectObjects via a callback

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -435,11 +435,17 @@
 
 	};
 
-	THREE.Raycaster.prototype.intersectObjects = function ( objects, recursive ) {
+	THREE.Raycaster.prototype.intersectObjects = function ( objects, recursive, test ) {
 
 		var intersects = [];
 
 		for ( var i = 0, l = objects.length; i < l; i ++ ) {
+
+			if ( test !== undefined && !test(objects[i]) ) {
+
+				continue;
+
+			}
 
 			intersectObject( objects[ i ], this, intersects );
 


### PR DESCRIPTION
For my project I need a way of selectively excluding items from intersectObjects based on userData attributes. Can be used like so:

```
raycaster.intersectObjects(objects, false, function(object) {
     return object.userData['shouldIntersect'];
}
```

I thought it was useful, so have submitted as a PR.
