### PR TITLE
Update points parser for VTK Loader

### DIFF
--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -60,7 +60,7 @@ THREE.VTKLoader.prototype = {
 
 		// float float float
 
-		pattern = /([\+|\-]?[\d]+[\.][\d|\-|e]+)[ ]+([\+|\-]?[\d]+[\.][\d|\-|e]+)[ ]+([\+|\-]?[\d]+[\.][\d|\-|e]+)/g;
+		pattern = /([\+|\-]?[\d]+[\.]*[\d|\-|e]*)[ ]+([\+|\-]?[\d]+[\.]*[\d|\-|e]*)[ ]+([\+|\-]?[\d]+[\.]*[\d|\-|e]*)/g;
 
 		while ( ( result = pattern.exec( data ) ) !== null ) {
 


### PR DESCRIPTION
Some vtk files don't have float numbers in POINTS section.
They are int numbers. For example, parse wants:
0.0 1.5 2.0
But came:
0 1.5 2
This fix remove part after "." in number, and parse will work.
In previos implementation pattern search nothing.
I would like to have more for VTK in Three.js
