### PR TITLE
Update WebGLRenderer.html

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -126,7 +126,7 @@
 
 		<h3>.[page:Boolean autoScaleCubemaps]</h3>
 
-		<div>Default is true. If set, then Cubemaps are scaled, when the are bigger the the maximum size, to make sure that they aren't bigger then the maximum size.</div>
+		<div>Default is true. If set, then Cubemaps are scaled, when they are bigger than the maximum size, to make sure that they aren't bigger than the maximum size.</div>
 
 
 		<h3>.[page:Boolean renderPluginsPre]</h3>


### PR DESCRIPTION
autoScaleCubemaps
Default is true. If set, then Cubemaps are scaled, when the(y) are bigger the(than) the maximum size, to make sure that they aren't bigger then(than) the maximum size.
