### PR TITLE
Prevent duplicate FancySelect#setValue calls

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -187,9 +187,7 @@ Sidebar.Scene = function ( editor ) {
 
 	signals.objectSelected.add( function ( object ) {
 
-		// Prevent chaining calls to setValue when signals originate from the outliner control
-		if ( !outliner.signalingChange )
-			outliner.setValue( object !== null ? object.id : null );
+		outliner.setValue( object !== null ? object.id : null );
 
 	} );
 

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -187,7 +187,9 @@ Sidebar.Scene = function ( editor ) {
 
 	signals.objectSelected.add( function ( object ) {
 
-		outliner.setValue( object !== null ? object.id : null );
+		// Prevent chaining calls to setValue when signals originate from the outliner control
+		if ( !outliner.signalingChange )
+			outliner.setValue( object !== null ? object.id : null );
 
 	} );
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -361,14 +361,12 @@ UI.FancySelect = function () {
 
 				if ( scope.selectedIndex >= 0 && scope.selectedIndex < scope.options.length ) {
 
-					scope.signalingChange = true;
-
 					// Highlight selected dom elem and scroll parent if needed
 					scope.setValue( scope.options[ scope.selectedIndex ].value );
 
 					// Invoke object/helper/mesh selection logic
+					scope.signalingChange = true;
 					scope.dom.dispatchEvent( changeEvent );
-
 					scope.signalingChange = false;
 
 				}
@@ -417,11 +415,10 @@ UI.FancySelect.prototype.setOptions = function ( options ) {
 
 		option.addEventListener( 'click', function ( event ) {
 
-			scope.signalingChange = true;
-
 			scope.setValue( this.value );
-			scope.dom.dispatchEvent( changeEvent );
 
+			scope.signalingChange = true;
+			scope.dom.dispatchEvent( changeEvent );
 			scope.signalingChange = false;
 
 		}, false );
@@ -439,6 +436,9 @@ UI.FancySelect.prototype.getValue = function () {
 };
 
 UI.FancySelect.prototype.setValue = function ( value ) {
+
+	// Prevent chaining calls to setValue when signals originate from the outliner control
+	if ( outliner.signalingChange ) return;
 
 	if ( typeof value === 'number' ) value = value.toString();
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -361,11 +361,15 @@ UI.FancySelect = function () {
 
 				if ( scope.selectedIndex >= 0 && scope.selectedIndex < scope.options.length ) {
 
+					scope.signalingChange = true;
+
 					// Highlight selected dom elem and scroll parent if needed
 					scope.setValue( scope.options[ scope.selectedIndex ].value );
 
 					// Invoke object/helper/mesh selection logic
 					scope.dom.dispatchEvent( changeEvent );
+
+					scope.signalingChange = false;
 
 				}
 
@@ -413,8 +417,12 @@ UI.FancySelect.prototype.setOptions = function ( options ) {
 
 		option.addEventListener( 'click', function ( event ) {
 
+			scope.signalingChange = true;
+
 			scope.setValue( this.value );
 			scope.dom.dispatchEvent( changeEvent );
+
+			scope.signalingChange = false;
 
 		}, false );
 


### PR DESCRIPTION
Completes PR #3907

Original PR adds duplicate-prevention logic across FancySelect and SideBar.Scene classes.
This PR contains duplicate-prevention logic in the FancySelect class.
