### PR TITLE
Modify ColladaLoader so baseUrl supports directory separators

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -124,9 +124,10 @@ THREE.ColladaLoader = function () {
 
 		if ( url !== undefined ) {
 
-			var parts = url.split( '/' );
+            		var separator = url.indexOf( '\\' ) >= 0 ? '\\' : '/';
+			var parts = url.split( separator );
 			parts.pop();
-			baseUrl = ( parts.length < 1 ? '.' : parts.join( '/' ) ) + '/';
+			baseUrl = ( parts.length < 1 ? '.' : parts.join( separator ) ) + separator;
 
 		}
 


### PR DESCRIPTION
I recently started using node-webkit for a threejs project and I have been having problems loading relative assets inside my Collada (DAE) models. Turned out to be an issue with the baseUrl variable inside the ColladaLoader.

Not sure if this fix is appropriate since there may be many other places, and maybe there should be a utility function for this, but this seems like a good start.
