### PR TITLE
Display correct element number.

### DIFF
--- a/examples/css3d_periodictable.html
+++ b/examples/css3d_periodictable.html
@@ -262,7 +262,7 @@
 
 					var number = document.createElement( 'div' );
 					number.className = 'number';
-					number.textContent = i + 1;
+					number.textContent = (i/5) + 1;
 					element.appendChild( number );
 
 					var symbol = document.createElement( 'div' );


### PR DESCRIPTION
Per a suggestion on the Google+ post about this example, this change fixes the incorrect element numbers displayed on the table.
