### PR TITLE
Replace

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -321,7 +321,7 @@ THREE.Quaternion.prototype = {
 
 	length: function () {
 
-		return Math.sqrt( this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w );
+		return Math.sqrt( this.lengthSq() );
 
 	},
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -321,7 +321,7 @@ THREE.Vector2.prototype = {
 
 	length: function () {
 
-		return Math.sqrt( this.lengthSq()) );
+		return Math.sqrt( this.lengthSq() );
 
 	},
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -321,7 +321,7 @@ THREE.Vector2.prototype = {
 
 	length: function () {
 
-		return Math.sqrt( this.x * this.x + this.y * this.y );
+		return Math.sqrt( this.lengthSq()) );
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -524,7 +524,7 @@ THREE.Vector3.prototype = {
 
 	length: function () {
 
-		return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
+		return Math.sqrt( this.lengthSq() );
 
 	},
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -569,7 +569,7 @@ THREE.Vector4.prototype = {
 
 	length: function () {
 
-		return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w );
+		return Math.sqrt( this.lengthSq() );
 
 	},
 


### PR DESCRIPTION
Replacing

``` javascript
length: function() {
    return Math.sqrt( /*blah blah blah*/ );
}
```

to be

``` javascript
length: function() {
    return Math.sqrt( this.lengthSq() );
}
```
