### PR TITLE
OrbitControls handles mouse moving outside of window

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -346,8 +346,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
-		scope.domElement.addEventListener( 'mousemove', onMouseMove, false );
-		scope.domElement.addEventListener( 'mouseup', onMouseUp, false );
+		document.addEventListener( 'mousemove', onMouseMove, false );
+		document.addEventListener( 'mouseup', onMouseUp, false );
 		scope.dispatchEvent( startEvent );
 
 	}
@@ -415,8 +415,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		if ( scope.enabled === false ) return;
 
-		scope.domElement.removeEventListener( 'mousemove', onMouseMove, false );
-		scope.domElement.removeEventListener( 'mouseup', onMouseUp, false );
+		document.removeEventListener( 'mousemove', onMouseMove, false );
+		document.removeEventListener( 'mouseup', onMouseUp, false );
 		scope.dispatchEvent( endEvent );
 		state = STATE.NONE;
 


### PR DESCRIPTION
OrbitControls will continue to follow the mouse position even after the
mouse button is up, if the user moves the cursor outside the window and
then releases it. The user must then click again inside the DOM element
to release the mouse tracking. See, for instance, the OrbitControls
example (http://threejs.org/examples/#misc_controls_orbit).

This can be fixed by attaching the `mousemove` and `mouseout` handlers
to `document` rather than `domElement`. This fix works on
Firefox 27.0.1, Safari 7.0.3, and Chrome 34.0.1847.131, on Mac OS
10.9.2.

Alternatively, the example could be changed to not pass a value for the
`domElement` argument, to get the default value of `document`.
