### PR TITLE
Allow THREE to be used by Browserify more easily.

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -4,7 +4,7 @@
  * @author bhouston / http://exocortex.com
  */
 
-var THREE = { REVISION: '67' };
+var THREE = module.exports = { REVISION: '67' };
 
 self.console = self.console || {
 


### PR DESCRIPTION
For those of us using Browserify to do client builds, it would be nice to be compatible out of the box.  With this change it should work nicely.  Now, can I convince you to publish official builds to npm?
