### PR TITLE
Smoother orbit controls

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -60,9 +60,10 @@ THREE.OrbitControls = function ( object, domElement ) {
 	this.autoRotateSpeed = 2.0; // 30 seconds per round when fps is 60
 
 	// How far you can orbit vertically, upper and lower limits.
-	// Range is 0 to Math.PI radians.
-	this.minPolarAngle = 0; // radians
-	this.maxPolarAngle = Math.PI; // radians
+	// Range is 0.01 to Math.PI-0.01 radians, which is sufficient to avoid
+	// noticable gimbal lock.
+	this.minPolarAngle = 0.01; // radians
+	this.maxPolarAngle = Math.PI - 0.01; // radians
 
 	// Set to true to disable use of the keys
 	this.noKeys = false;

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -55,12 +55,20 @@
 			init();
 			render();
 
+			function animate() {
+
+				requestAnimationFrame(animate);
+				controls.update();
+
+			}
+
 			function init() {
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 500;
 
 				controls = new THREE.OrbitControls( camera );
+				controls.damping = 0.2;
 				controls.addEventListener( 'change', render );
 
 				scene = new THREE.Scene();
@@ -116,6 +124,9 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize, false );
+
+				controls.addEventListener('change', render);
+				animate();
 
 			}
 


### PR DESCRIPTION
This is a set of three patches that makes OrbitControls feel more fluid and physical, at least on my three Mac OS browsers (Safari, Chrome, FireFox).

These three patches do the following:
- Avoids gimbal lock, or east-west sticking, when at the North or South poles by setting more reasonable default minimum and maximum polar angles
- Adds some damping to the rotation controls (inspired by `TrackballControls`)
- Fine-tunes the dollying behavior by moving linearly, rather than exponentially, in distance. Feels much better on Apple trackpad devices.
