### PR TITLE
Changed regex to support morph animations exported from blender

### DIFF
--- a/src/extras/objects/MorphBlendMesh.js
+++ b/src/extras/objects/MorphBlendMesh.js
@@ -11,6 +11,7 @@ THREE.MorphBlendMesh = function( geometry, material ) {
 
 	// prepare default animation
 	// (all frames played together in 1 second)
+
 	var numFrames = this.geometry.morphTargets.length;
 
 	var name = "__default";

--- a/src/extras/objects/MorphBlendMesh.js
+++ b/src/extras/objects/MorphBlendMesh.js
@@ -61,7 +61,7 @@ THREE.MorphBlendMesh.prototype.createAnimation = function ( name, start, end, fp
 
 THREE.MorphBlendMesh.prototype.autoCreateAnimations = function ( fps ) {
 
-	var pattern = /([a-z]+)(\d+)/;
+    var pattern = /([a-z]+)_?(\d+)/;
 
 	var firstAnimation, frameRanges = {};
 

--- a/src/extras/objects/MorphBlendMesh.js
+++ b/src/extras/objects/MorphBlendMesh.js
@@ -11,7 +11,7 @@ THREE.MorphBlendMesh = function( geometry, material ) {
 
 	// prepare default animation
 	// (all frames played together in 1 second)
-
+                                           p
 	var numFrames = this.geometry.morphTargets.length;
 
 	var name = "__default";
@@ -61,7 +61,7 @@ THREE.MorphBlendMesh.prototype.createAnimation = function ( name, start, end, fp
 
 THREE.MorphBlendMesh.prototype.autoCreateAnimations = function ( fps ) {
 
-    var pattern = /([a-z]+)_?(\d+)/;
+	var pattern = /([a-z]+)_?(\d+)/;
 
 	var firstAnimation, frameRanges = {};
 

--- a/src/extras/objects/MorphBlendMesh.js
+++ b/src/extras/objects/MorphBlendMesh.js
@@ -11,7 +11,6 @@ THREE.MorphBlendMesh = function( geometry, material ) {
 
 	// prepare default animation
 	// (all frames played together in 1 second)
-                                           p
 	var numFrames = this.geometry.morphTargets.length;
 
 	var name = "__default";

--- a/src/objects/MorphAnimMesh.js
+++ b/src/objects/MorphAnimMesh.js
@@ -57,7 +57,7 @@ THREE.MorphAnimMesh.prototype.parseAnimations = function () {
 
 	var firstAnimation, animations = geometry.animations;
 
-	var pattern = /([a-z]+)(\d+)/;
+	var pattern = /([a-z]+)_?(\d+)/;
 
 	for ( var i = 0, il = geometry.morphTargets.length; i < il; i ++ ) {
 


### PR DESCRIPTION
Very minor change in the regex pattern. Animations exported through the Three.js Blender plugin use an underscore between the frame and the name of the animation:

Animation_0000001
Animation_0000002
Animation_0000003

etc.

This is also present in the current release in the parseAnimation function of the MorphBlendMesh.js
