### PR TITLE
Enabled simple browserify support

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -5,6 +5,9 @@
  */
 
 var THREE = { REVISION: '67' };
+if (typeof module === 'object') {
+    module.exports = THREE;
+}
 
 self.console = self.console || {
 


### PR DESCRIPTION
This is a simple way to make THREE support browserify at a global level.  There is ongoing discussion on reworking the build system to directly take advantage of browersify for builds, but I don't think there is consensus on that yet.  See:
https://github.com/mrdoob/three.js/issues/4776
