### PR TITLE
Hide LensFlare if not visible

### DIFF
--- a/src/extras/renderers/plugins/LensFlarePlugin.js
+++ b/src/extras/renderers/plugins/LensFlarePlugin.js
@@ -158,6 +158,9 @@ THREE.LensFlarePlugin = function () {
 
 			flare = flares[ i ];
 
+			if (!flare.visible)
+				continue;
+			
 			tempPosition.set( flare.matrixWorld.elements[12], flare.matrixWorld.elements[13], flare.matrixWorld.elements[14] );
 
 			tempPosition.applyMatrix4( camera.matrixWorldInverse );


### PR DESCRIPTION
This fix ensures that lens flares aren't rendered if their `visible` property is set to false. 
