### PR TITLE
Bug Squished: dispatchEvent is overwriting listeners array

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -76,7 +76,8 @@ THREE.EventDispatcher.prototype = {
 
 	dispatchEvent: function () {
 
-		var array = [];
+		var array = [],
+		    arrayIndex = 0;
 
 		return function ( event ) {
 
@@ -93,16 +94,19 @@ THREE.EventDispatcher.prototype = {
 
 			        for ( var i = 0; i < length; i ++ ) {
 			          
-					array.unshift(listenerArray[ i ]);
+					//a.k.a. .push(..), but faster
+					array[ arrayIndex ++ ] = listenerArray[ i ];
 			          
 			        }
+			        //arrayIndex became now equal to (arrayIndex + length)
 				
-				for ( var j = length - 1; j > -1; j -- ) {
+				for ( var j = arrayIndex - length; j < arrayIndex; j ++ ) {
 					
 					array[ j ].call( this, event );
-					array.splice( j, 1 );
-					
+
 				}
+				
+				arrayIndex -= length;
 
 			}
 

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -94,11 +94,6 @@ THREE.EventDispatcher.prototype = {
 				for ( var i = 0; i < length; i ++ ) {
 
 					array[ i ] = listenerArray[ i ];
-
-				}
-
-				for ( var i = 0; i < length; i ++ ) {
-
 					array[ i ].call( this, event );
 
 				}

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -91,11 +91,17 @@ THREE.EventDispatcher.prototype = {
 
 				var length = listenerArray.length;
 
-				for ( var i = 0; i < length; i ++ ) {
-
-					array[ i ] = listenerArray[ i ];
-					array[ i ].call( this, event );
-
+			        for ( var i = 0; i < length; i ++ ) {
+			          
+					array.unshift(listenerArray[ i ]);
+			          
+			        }
+				
+				for ( var j = length - 1; j > -1; j -- ) {
+					
+					array[ j ].call( this, event );
+					array.splice( j, 1 );
+					
 				}
 
 			}


### PR DESCRIPTION
Closing Issue #4804 See discussion on 4f42011a5d5f65fe8f17a050d7e6c65b17dc0c95
Considering the case were one of the functions in listenerArray actually dispatches an event of another object (objB)... immediately `array` would be overwritten since it is in a shared scope to any call to dispatchEvent. 
