### PR TITLE
Added method Ray.intersectBoundingSphere() / also 3 minor semicolon additions

### DIFF
--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -216,6 +216,45 @@ THREE.Ray.prototype = {
 		return this.distanceToPoint( sphere.center ) <= sphere.radius;
 
 	},
+	
+	intersectBoundingSphere: function ( mesh, optionalTarget ) {
+
+		// from http://www.scratchapixel.com/lessons/3d-basic-lessons/lesson-7-intersecting-simple-shapes/ray-sphere-intersection/
+		var L = new THREE.Vector3();
+		var radius = mesh.geometry.boundingSphere.radius;
+		var radius2 = radius * radius;
+
+		L.subVectors( mesh.position, this.origin );
+
+		var tca = L.dot( this.direction );
+
+		if ( tca < 0 ) {
+
+			return null;
+
+		}
+
+		var d2 = L.dot( L ) - tca * tca;
+
+		if ( d2 > radius2 ) {
+
+			return null;
+
+		}
+
+		var thc = Math.sqrt( radius2 - d2 );
+		// t0 = first collision point entrance on front of sphere
+		var t0 = tca - thc;
+
+		// t1 = exit point on back of sphere.  Rarely needed, so it is commented out
+		// var t1 = tca + thc; 
+
+		// Now return the THREE.Vector3() location (collision point) of this Ray,
+		//   scaled by amount t0 along Ray.direction  
+		// This collision point will always be located somewhere on the mesh's boundingSphere
+		return this.at( t0, optionalTarget );
+	
+	},
 
 	isIntersectionPlane: function ( plane ) {
 
@@ -233,7 +272,7 @@ THREE.Ray.prototype = {
 
 		if ( denominator * distToPoint < 0 ) {
 
-			return true
+			return true;
 
 		}
 
@@ -290,7 +329,7 @@ THREE.Ray.prototype = {
 
 			return this.intersectBox( box, v ) !== null;
 
-		}
+		};
 
 	}(),
 
@@ -441,7 +480,7 @@ THREE.Ray.prototype = {
 			// Ray intersects triangle.
 			return this.at( QdN / DdN, optionalTarget );
 	
-		}
+		};
 	
 	}(),
 


### PR DESCRIPTION
As requested in #4801, I have implemented a Ray.intersectBoundingSphere( mesh, optionalTarget ) method to Ray.js

This method takes a three.js meshObject and optionalTarget as parameters.  It will check 'this.Ray' against the bounding sphere of the mesh object that you supply it.  If there is no intersection, it will return 'null'.
If there is an intersection, it will return a THREE.Vector3() with the x,y, and z coordinates of the intersection location at the first point of entry on the front of the bounding sphere.  The hit location will always be located somewhere on the mesh's bounding sphere.
