### PR TITLE
Fix for "self is not defined" in node.js

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -6,6 +6,8 @@
 
 var THREE = { REVISION: '67' };
 
+var self = self || {};
+
 self.console = self.console || {
 
 	info: function () {},


### PR DESCRIPTION
Node.js (v0.10.26) seems to have no "self" global var. Therefore, calling a check on "self.console" throws an exception. This is solved by simply defining the "self" var. I don't understand in wich contexts that var is supposed to be pre-defined, but i guess my patch would not break that use case anyway.
