### PR TITLE
Fix Box3.addPoint to handle point with max coordinate added as first.

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -29,7 +29,8 @@ THREE.Box3.prototype = {
 
 			this.min.x = point.x;
 
-		} else if ( point.x > this.max.x ) {
+		}
+		if ( point.x > this.max.x ) {
 
 			this.max.x = point.x;
 
@@ -39,7 +40,8 @@ THREE.Box3.prototype = {
 
 			this.min.y = point.y;
 
-		} else if ( point.y > this.max.y ) {
+		}
+		if ( point.y > this.max.y ) {
 
 			this.max.y = point.y;
 
@@ -49,12 +51,13 @@ THREE.Box3.prototype = {
 
 			this.min.z = point.z;
 
-		} else if ( point.z > this.max.z ) {
+		}
+		if ( point.z > this.max.z ) {
 
 			this.max.z = point.z;
 
 		}
-		
+
 		return this;
 
 	},

--- a/test/unit/math/Box3.js
+++ b/test/unit/math/Box3.js
@@ -274,3 +274,13 @@ test( "translate", function() {
 	ok( d.clone().translate( one3 ).equals( b ), "Passed!" );
 	ok( b.clone().translate( one3.clone().negate() ).equals( d ), "Passed!" );
 });
+
+test( "addPoint", function() {
+	var a = new THREE.Box3();
+	a.addPoint( two3 );
+	a.addPoint( one3 );
+	a.addPoint( zero3 );
+
+	ok( a.min.equals( zero3 ), "Passed!" );
+	ok( a.max.equals( two3 ), "Passed!" );
+});


### PR DESCRIPTION
If a point with a coordinate that has maximal value is added to the Box3 as the first point, the coordinate is not assigned to the Box's max. If added points are reverse-sorted by some coordinate, the Box's max for this coordinate will stay -Infinity.
