### PR TITLE
Negative f for pow() in shaders - debuShader parameter

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -25,6 +25,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 	_premultipliedAlpha = parameters.premultipliedAlpha !== undefined ? parameters.premultipliedAlpha : true,
 	_preserveDrawingBuffer = parameters.preserveDrawingBuffer !== undefined ? parameters.preserveDrawingBuffer : false,
 	_logarithmicDepthBuffer = parameters.logarithmicDepthBuffer !== undefined ? parameters.logarithmicDepthBuffer : false,
+	_debugShaders = parameters.debugShaders !== undefined ? parameters.debugShaders : true,
 
 	_clearColor = new THREE.Color( 0x000000 ),
 	_clearAlpha = 0;
@@ -4089,6 +4090,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			precision: _precision,
 			supportsVertexTextures: _supportsVertexTextures,
+			debugMode: _debugShaders,
 
 			map: !!material.map,
 			envMap: !!material.envMap,

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -1,6 +1,6 @@
 /**
  * Shader chunks for WebLG Shader library
- * 
+ *
  * @author alteredq / http://alteredqualia.com/
  * @author mrdoob / http://mrdoob.com/
  * @author mikael emtinger / http://gomo.se/
@@ -621,7 +621,7 @@ THREE.ShaderChunk = {
 		"		vec4 lPosition = viewMatrix * vec4( spotLightPosition[ i ], 1.0 );",
 		"		vec3 lVector = lPosition.xyz - mvPosition.xyz;",
 
-		"		float spotEffect = dot( spotLightDirection[ i ], normalize( spotLightPosition[ i ] - worldPosition.xyz ) );",
+		"		float spotEffect = max( dot( spotLightDirection[ i ], normalize( spotLightPosition[ i ] - worldPosition.xyz ) ), 0.0 );",
 
 		"		if ( spotEffect > spotLightAngleCos[ i ] ) {",
 
@@ -878,7 +878,7 @@ THREE.ShaderChunk = {
 
 		"		lVector = normalize( lVector );",
 
-		"		float spotEffect = dot( spotLightDirection[ i ], normalize( spotLightPosition[ i ] - vWorldPosition ) );",
+		"		float spotEffect = max( dot( spotLightDirection[ i ], normalize( spotLightPosition[ i ] - vWorldPosition ) ), 0.0 );",
 
 		"		if ( spotEffect > spotLightAngleCos[ i ] ) {",
 
@@ -973,7 +973,7 @@ THREE.ShaderChunk = {
 		"		const float mFresnelScale = 0.3;",
 		"		const float mFresnelPower = 5.0;",
 
-		"		float fresnel = mFresnelBias + mFresnelScale * pow( 1.0 + dot( normalize( -viewPosition ), normal ), mFresnelPower );",
+		"		float fresnel = mFresnelBias + mFresnelScale * pow( max( 1.0 + dot( normalize( -viewPosition ), normal ), 0.0 ), mFresnelPower );",
 				*/
 
 				// 2.0 => 2.0001 is hack to work around ANGLE bug
@@ -1012,7 +1012,7 @@ THREE.ShaderChunk = {
 				// specular (sky light)
 
 		"		vec3 hemiHalfVectorSky = normalize( lVector + viewPosition );",
-		"		float hemiDotNormalHalfSky = 0.5 * dot( normal, hemiHalfVectorSky ) + 0.5;",
+		"		float hemiDotNormalHalfSky = 0.5 * max( dot( normal, hemiHalfVectorSky ), 0.0 ) + 0.5;",
 		"		float hemiSpecularWeightSky = specularStrength * max( pow( hemiDotNormalHalfSky, shininess ), 0.0 );",
 
 				// specular (ground light)
@@ -1020,7 +1020,7 @@ THREE.ShaderChunk = {
 		"		vec3 lVectorGround = -lVector;",
 
 		"		vec3 hemiHalfVectorGround = normalize( lVectorGround + viewPosition );",
-		"		float hemiDotNormalHalfGround = 0.5 * dot( normal, hemiHalfVectorGround ) + 0.5;",
+		"		float hemiDotNormalHalfGround = 0.5 * max( dot( normal, hemiHalfVectorGround ), 0.0 ) + 0.5;",
 		"		float hemiSpecularWeightGround = specularStrength * max( pow( hemiDotNormalHalfGround, shininess ), 0.0 );",
 
 		"		float dotProductGround = dot( normal, lVectorGround );",
@@ -1547,7 +1547,7 @@ THREE.ShaderChunk = {
 		"				vec3 shadowZ = vec3( shadowCoord.z );",
 		"				shadowKernel[0] = vec3(lessThan(depthKernel[0], shadowZ ));",
 		"				shadowKernel[0] *= vec3(0.25);",
-													
+
 		"				shadowKernel[1] = vec3(lessThan(depthKernel[1], shadowZ ));",
 		"				shadowKernel[1] *= vec3(0.25);",
 
@@ -1670,7 +1670,7 @@ THREE.ShaderChunk = {
 	// http://outerra.blogspot.com/2012/11/maximizing-depth-buffer-range-and.html
 
 	// WebGL doesn't support gl_FragDepth out of the box, unless the EXT_frag_depth extension is available.  On platforms
-	// without EXT_frag_depth, we have to fall back on linear z-buffer in the fragment shader, which means that some long 
+	// without EXT_frag_depth, we have to fall back on linear z-buffer in the fragment shader, which means that some long
 	// faces close to the camera may have issues.	This can be worked around by tesselating the model more finely when
 	// the camera is near the surface.
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -507,7 +507,7 @@ THREE.ShaderLib = {
 			"uniform float mNear;",
 			"uniform float mFar;",
 			"uniform float opacity;",
-			
+
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"void main() {",
@@ -818,7 +818,7 @@ THREE.ShaderLib = {
 
 			"			float specularNormalization = ( shininess + 2.0001 ) / 8.0;",
 
-			"			vec3 schlick = specular + vec3( 1.0 - specular ) * pow( 1.0 - dot( pointVector, pointHalfVector ), 5.0 );",
+			"			vec3 schlick = specular + vec3( 1.0 - specular ) * pow( max( 1.0 - dot( pointVector, pointHalfVector ), 0.0 ), 5.0 );",
 			"			pointSpecular += schlick * pointLightColor[ i ] * pointSpecularWeight * pointDiffuseWeight * pointDistance * specularNormalization;",
 
 			"		}",
@@ -843,7 +843,7 @@ THREE.ShaderLib = {
 
 			"			spotVector = normalize( spotVector );",
 
-			"			float spotEffect = dot( spotLightDirection[ i ], normalize( spotLightPosition[ i ] - vWorldPosition ) );",
+			"			float spotEffect = max( dot( spotLightDirection[ i ], normalize( spotLightPosition[ i ] - vWorldPosition ) ), 0.0 );",
 
 			"			if ( spotEffect > spotLightAngleCos[ i ] ) {",
 
@@ -876,7 +876,7 @@ THREE.ShaderLib = {
 
 			"				float specularNormalization = ( shininess + 2.0001 ) / 8.0;",
 
-			"				vec3 schlick = specular + vec3( 1.0 - specular ) * pow( 1.0 - dot( spotVector, spotHalfVector ), 5.0 );",
+			"				vec3 schlick = specular + vec3( 1.0 - specular ) * pow( max( 1.0 - dot( spotVector, spotHalfVector ), 0.0 ), 5.0 );",
 			"				spotSpecular += schlick * spotLightColor[ i ] * spotSpecularWeight * spotDiffuseWeight * spotDistance * specularNormalization * spotEffect;",
 
 			"			}",
@@ -924,7 +924,7 @@ THREE.ShaderLib = {
 
 			"			float specularNormalization = ( shininess + 2.0001 ) / 8.0;",
 
-			"			vec3 schlick = specular + vec3( 1.0 - specular ) * pow( 1.0 - dot( dirVector, dirHalfVector ), 5.0 );",
+			"			vec3 schlick = specular + vec3( 1.0 - specular ) * pow( max( 1.0 - dot( dirVector, dirHalfVector ), 0.0 ), 5.0 );",
 			"			dirSpecular += schlick * directionalLightColor[ i ] * dirSpecularWeight * dirDiffuseWeight * specularNormalization;",
 
 			"		}",
@@ -956,7 +956,7 @@ THREE.ShaderLib = {
 
 
 			"			vec3 hemiHalfVectorSky = normalize( lVector + viewPosition );",
-			"			float hemiDotNormalHalfSky = 0.5 * dot( normal, hemiHalfVectorSky ) + 0.5;",
+			"			float hemiDotNormalHalfSky = 0.5 *  max( dot( normal, hemiHalfVectorSky ), 0.0 ) + 0.5;",
 			"			float hemiSpecularWeightSky = specularTex.r * max( pow( hemiDotNormalHalfSky, shininess ), 0.0 );",
 
 						// specular (ground light)
@@ -964,7 +964,7 @@ THREE.ShaderLib = {
 			"			vec3 lVectorGround = -lVector;",
 
 			"			vec3 hemiHalfVectorGround = normalize( lVectorGround + viewPosition );",
-			"			float hemiDotNormalHalfGround = 0.5 * dot( normal, hemiHalfVectorGround ) + 0.5;",
+			"			float hemiDotNormalHalfGround = 0.5 * max( dot( normal, hemiHalfVectorGround ), 0.0 ) + 0.5);",
 			"			float hemiSpecularWeightGround = specularTex.r * max( pow( hemiDotNormalHalfGround, shininess ), 0.0 );",
 
 			"			float dotProductGround = dot( normal, lVectorGround );",
@@ -973,8 +973,8 @@ THREE.ShaderLib = {
 
 			"			float specularNormalization = ( shininess + 2.0001 ) / 8.0;",
 
-			"			vec3 schlickSky = specular + vec3( 1.0 - specular ) * pow( 1.0 - dot( lVector, hemiHalfVectorSky ), 5.0 );",
-			"			vec3 schlickGround = specular + vec3( 1.0 - specular ) * pow( 1.0 - dot( lVectorGround, hemiHalfVectorGround ), 5.0 );",
+			"			vec3 schlickSky = specular + vec3( 1.0 - specular ) * pow( max( 1.0 - dot( lVector, hemiHalfVectorSky ), 0.0 ), 5.0 );",
+			"			vec3 schlickGround = specular + vec3( 1.0 - specular ) * pow( max( 1.0 - dot( lVectorGround, hemiHalfVectorGround ), 0.0 ), 5.0 );",
 			"			hemiSpecular += hemiColor * specularNormalization * ( schlickSky * hemiSpecularWeightSky * max( dotProduct, 0.0 ) + schlickGround * hemiSpecularWeightGround * max( dotProductGround, 0.0 ) );",
 
 			"		}",

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -257,8 +257,8 @@ THREE.WebGLProgram = ( function () {
 
 		}
 
-		var glVertexShader = new THREE.WebGLShader( _gl, _gl.VERTEX_SHADER, prefix_vertex + vertexShader );
-		var glFragmentShader = new THREE.WebGLShader( _gl, _gl.FRAGMENT_SHADER, prefix_fragment + fragmentShader );
+		var glVertexShader = new THREE.WebGLShader( _gl, _gl.VERTEX_SHADER, prefix_vertex + vertexShader, parameters.debugMode );
+		var glFragmentShader = new THREE.WebGLShader( _gl, _gl.FRAGMENT_SHADER, prefix_fragment + fragmentShader, parameters.debugMode );
 
 		_gl.attachShader( program, glVertexShader );
 		_gl.attachShader( program, glFragmentShader );
@@ -283,7 +283,7 @@ THREE.WebGLProgram = ( function () {
 
 		}
 
-		if ( _gl.getProgramInfoLog( program ) !== '' ) {
+		if ( parameters.debugMode && _gl.getProgramInfoLog( program ) !== '' ) {
 
 			console.error( 'gl.getProgramInfoLog()', _gl.getProgramInfoLog( program ) );
 

--- a/src/renderers/webgl/WebGLShader.js
+++ b/src/renderers/webgl/WebGLShader.js
@@ -14,9 +14,9 @@ THREE.WebGLShader = ( function () {
 
 	};
 
-	return function ( gl, type, string ) {
+	return function ( gl, type, string, debugMode ) {
 
-		var shader = gl.createShader( type ); 
+		var shader = gl.createShader( type );
 
 		gl.shaderSource( shader, string );
 		gl.compileShader( shader );
@@ -27,7 +27,7 @@ THREE.WebGLShader = ( function () {
 
 		}
 
-		if ( gl.getShaderInfoLog( shader ) !== '' ) {
+		if ( debugMode && gl.getShaderInfoLog( shader ) !== '' ) {
 
 			console.error( 'THREE.WebGLShader:', 'gl.getShaderInfoLog()', gl.getShaderInfoLog( shader ) );
 			console.error( addLineNumbers( string ) );


### PR DESCRIPTION
- Fixes the following errors, because of negative values in pow() function of shaders:

```
(71,64-116): warning X3571: pow(f, e) will not work for negative f, use abs(f) 
or conditionally handle negative values if you expect them
```
-  Optional parameter (debugShaders) for displaying basic warning/errors of shaders.
  By default, it is 'true'.
- Example:

```
renderer = new THREE.WebGLRenderer( { antialias: true, debugShaders: false } );
```
