### PR TITLE
Loader progress status

### DIFF
--- a/examples/js/loaders/BinaryLoader.js
+++ b/examples/js/loaders/BinaryLoader.js
@@ -108,7 +108,7 @@ THREE.BinaryLoader.prototype.loadAjaxBuffers = function ( json, callback, binary
 
 			if ( event.lengthComputable ) {
 
-				callbackProgress( event );
+				callbackProgress( event, scope.statusDomElement );
 
 			}
 

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -42,7 +42,7 @@ THREE.Loader.prototype = {
 
 	},
 
-	updateProgress: function ( progress ) {
+	updateProgress: function ( progress, statusDomElement ) {
 
 		var message = "Loaded ";
 
@@ -57,7 +57,7 @@ THREE.Loader.prototype = {
 
 		}
 
-		this.statusDomElement.innerHTML = message;
+		statusDomElement.innerHTML = message;
 
 	},
 


### PR DESCRIPTION
Enabling showProgress on BinaryLoader will have 'undefined' statusDomElement while updateProgress. I am not sure whether this is the perfect solution on this scope issue or not.
