### PR TITLE
Make visibility useful in hierarchy

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -500,7 +500,15 @@ THREE.Object3D.prototype = {
 	
 	updateVisibleWorld: function ( updateChildren ) {
 
-		this.visibleWorld =  this.parent.visibleWorld && this.visible ;
+		if ( this.parent === undefined ) {
+			
+			this.visibleWorld = this.visible;
+			
+		} else {
+
+			this.visibleWorld = this.parent.visibleWorld && this.visible;
+			
+		}
 
 		// update children
 		

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -51,6 +51,7 @@ THREE.Object3D = function () {
 	this.matrixWorldNeedsUpdate = false;
 
 	this.visible = true;
+	this.visibleWorld = true;
 
 	this.castShadow = false;
 	this.receiveShadow = false;
@@ -461,7 +462,7 @@ THREE.Object3D.prototype = {
 
 	},
 
-	updateMatrixWorld: function ( force ) {
+	updateMatrixWorld: function ( force, updateChildren ) {
 
 		if ( this.matrixAutoUpdate === true ) this.updateMatrix();
 
@@ -484,14 +485,49 @@ THREE.Object3D.prototype = {
 		}
 
 		// update children
+		
+		if (updateChildren === false) { 
 
-		for ( var i = 0, l = this.children.length; i < l; i ++ ) {
+			for ( var i = 0, l = this.children.length; i < l; i ++ ) {
 
-			this.children[ i ].updateMatrixWorld( force );
+				this.children[ i ].updateMatrixWorld( force, updateChildren );
 
+			}
+			
+		}
+		
+	},
+	
+	updateVisibleWorld: function ( updateChildren ) {
+
+		this.visibleWorld =  this.parent.visibleWorld && this.visible ;
+
+		// update children
+		
+		if (updateChildren === false) { 
+			
+			for ( var i = 0, l = this.children.length; i < l; i ++ ) {
+
+				this.children[ i ].updateVisibleWorld( updateChildren );
+
+			}
+			
 		}
 
 	},
+	
+	updateMatrixWorldAndVisibleWorld: function ( force ) {
+		
+		this.updateMatrixWorld( force , false );
+		this.updateVisibleWorld( false );
+		
+		for ( var i = 0, l = this.children.length; i < l; i ++ ) {
+
+			this.children[ i ].updateMatrixWorldAndVisibleWorld( force );
+
+		};
+		
+	};
 
 	clone: function ( object, recursive ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -535,7 +535,7 @@ THREE.Object3D.prototype = {
 
 		};
 		
-	};
+	},
 
 	clone: function ( object, recursive ) {
 

--- a/src/core/Projector.js
+++ b/src/core/Projector.js
@@ -82,7 +82,7 @@ THREE.Projector = function () {
 
 	var projectObject = function ( object ) {
 
-		if ( object.visible === false ) return;
+		if ( object.visibleWorld === false ) return;
 
 		if ( object instanceof THREE.Light ) {
 
@@ -312,7 +312,7 @@ THREE.Projector = function () {
 
 		_renderData.elements.length = 0;
 
-		if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+		if ( scene.autoUpdate === true ) scene.updateMatrixWorldAndVisibleWorld();
 		if ( camera.parent === undefined ) camera.updateMatrixWorld();
 
 		_viewMatrix.copy( camera.matrixWorldInverse.getInverse( camera.matrixWorld ) );

--- a/src/extras/core/Gyroscope.js
+++ b/src/extras/core/Gyroscope.js
@@ -10,7 +10,7 @@ THREE.Gyroscope = function () {
 
 THREE.Gyroscope.prototype = Object.create( THREE.Object3D.prototype );
 
-THREE.Gyroscope.prototype.updateMatrixWorld = function ( force ) {
+THREE.Gyroscope.prototype.updateMatrixWorld = function ( force, updateChildren ) {
 
 	this.matrixAutoUpdate && this.updateMatrix();
 
@@ -43,10 +43,14 @@ THREE.Gyroscope.prototype.updateMatrixWorld = function ( force ) {
 
 	// update children
 
-	for ( var i = 0, l = this.children.length; i < l; i ++ ) {
+	if (updateChildren === false) { 
+		
+		for ( var i = 0, l = this.children.length; i < l; i ++ ) {
 
-		this.children[ i ].updateMatrixWorld( force );
+			this.children[ i ].updateMatrixWorld( force, updateChildren );
 
+		}
+		
 	}
 
 };

--- a/src/extras/renderers/plugins/ShadowMapPlugin.js
+++ b/src/extras/renderers/plugins/ShadowMapPlugin.js
@@ -239,7 +239,7 @@ THREE.ShadowMapPlugin = function () {
 
 				webglObject.render = false;
 
-				if ( object.visible && object.castShadow ) {
+				if ( object.visibleWorld && object.castShadow ) {
 
 					if ( ! ( object instanceof THREE.Mesh || object instanceof THREE.ParticleSystem ) || ! ( object.frustumCulled ) || _frustum.intersectsObject( object ) ) {
 
@@ -323,7 +323,7 @@ THREE.ShadowMapPlugin = function () {
 				webglObject = renderList[ j ];
 				object = webglObject.object;
 
-				if ( object.visible && object.castShadow ) {
+				if ( object.visibleWorld && object.castShadow ) {
 
 					object._modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
 

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -111,6 +111,13 @@ THREE.SkinnedMesh.prototype.updateMatrixWorld = function () {
 
 }();
 
+THREE.SkinnedMesh.prototype.updateMatrixWorldAndVisibleWorld = function ( force ) {
+
+		this.updateMatrixWorld( force , false );
+		this.updateVisibleWorld( false );
+
+};
+
 THREE.SkinnedMesh.prototype.pose = function () {
 
 	this.updateMatrixWorld( true );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3249,7 +3249,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		// update scene graph
 
-		if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+		if ( scene.autoUpdate === true ) scene.updateMatrixWorldAndVisibleWorld();
 
 		// update camera matrices and frustum
 
@@ -3295,7 +3295,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			webglObject.id = i;
 			webglObject.render = false;
 
-			if ( object.visible ) {
+			if ( object.visibleWorld ) {
 
 				if ( ! ( object instanceof THREE.Mesh || object instanceof THREE.ParticleSystem ) || ! ( object.frustumCulled ) || _frustum.intersectsObject( object ) ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3343,7 +3343,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			webglObject = renderList[ i ];
 			object = webglObject.object;
 
-			if ( object.visible ) {
+			if ( object.visibleWorld ) {
 
 				setupMatrices( object, camera );
 
@@ -3518,7 +3518,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			webglObject = renderList[ i ];
 			object = webglObject.object;
 
-			if ( object.visible ) {
+			if ( object.visibleWorld ) {
 
 				if ( overrideMaterial ) {
 
@@ -5038,7 +5038,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( light instanceof THREE.AmbientLight ) {
 
-				if ( ! light.visible ) continue;
+				if ( ! light.visibleWorld ) continue;
 
 				if ( _this.gammaInput ) {
 
@@ -5058,7 +5058,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				dirCount += 1;
 
-				if ( ! light.visible ) continue;
+				if ( ! light.visibleWorld ) continue;
 
 				_direction.setFromMatrixPosition( light.matrixWorld );
 				_vector3.setFromMatrixPosition( light.target.matrixWorld );
@@ -5092,7 +5092,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				pointCount += 1;
 
-				if ( ! light.visible ) continue;
+				if ( ! light.visibleWorld ) continue;
 
 				pointOffset = pointLength * 3;
 
@@ -5120,7 +5120,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				spotCount += 1;
 
-				if ( ! light.visible ) continue;
+				if ( ! light.visibleWorld ) continue;
 
 				spotOffset = spotLength * 3;
 
@@ -5160,7 +5160,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				hemiCount += 1;
 
-				if ( ! light.visible ) continue;
+				if ( ! light.visibleWorld ) continue;
 
 				_direction.setFromMatrixPosition( light.matrixWorld );
 				_direction.normalize();
@@ -6045,7 +6045,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			var light = lights[ l ];
 
-			if ( light.onlyShadow || light.visible === false ) continue;
+			if ( light.onlyShadow || light.visibleWorld === false ) continue;
 
 			if ( light instanceof THREE.DirectionalLight ) dirLights ++;
 			if ( light instanceof THREE.PointLight ) pointLights ++;


### PR DESCRIPTION
This makes it possible to hide the parent and all children based on the parents.visiblitlity.
We could also add a property on the scene object to switch between the 2 systems if it would be nessecary.

It seems to be working now.

A few Notes:
- All Invisible nodes still get calculated for matrices and visibility:
  - The camera still needs the matrices.
  - The object its matrices could be used even when they are invisible. 
- The lights now also get removed based on its ancestors visibility.
- The used camera isn't affected by visibility altough children of the camera are also affected by it.
