### PR TITLE
Flip faces (cw/ccw) and/or normals from material

### DIFF
--- a/examples/webgl_materials_flipSide.html
+++ b/examples/webgl_materials_flipSide.html
@@ -119,12 +119,6 @@
 					helpers[i].update();
 
 				}
-				/*
-				light1.position.x = Math.sin( time * 0.7 ) * 30;
-				light1.position.y = Math.cos( time * 0.5 ) * 40;
-				light1.position.z = Math.cos( time * 0.3 ) * 30;
-				*/
-
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_materials_flipSide.html
+++ b/examples/webgl_materials_flipSide.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>three.js webgl - geometry - cube</title>
+		<title>three.js webgl - materials - flipSide</title>
 		<meta charset="utf-8">
 		<style>
 			body {

--- a/examples/webgl_materials_flipSide.html
+++ b/examples/webgl_materials_flipSide.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - geometry - cube</title>
+		<meta charset="utf-8">
+		<style>
+			body {
+				margin: 0px;
+				background-color: #000000;
+				overflow: hidden;
+			}
+		</style>
+	</head>
+	<body>
+
+		<script src="../build/three.min.js"></script>
+
+		<script>
+
+			var camera, scene, renderer, material;
+			var light1, light2;
+			var meshes = [];
+			var helpers = [];
+
+			init();
+			animate();
+
+			function init() {
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				document.body.appendChild( renderer.domElement );
+
+				//
+
+				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 10000 );
+				camera.position.x = 500;
+				camera.position.z = 600;
+
+				scene = new THREE.Scene();
+
+				// Lights
+				var sphere = new THREE.SphereGeometry( 20, 16, 8 );
+
+				scene.add( new THREE.AmbientLight( 0x777777 ) );
+
+				light1 = new THREE.PointLight( 0xffffff, 1, 10000 );
+				light1.position.set( 500, 300, 0 );
+				scene.add( light1 );
+
+				var helperL1 = new THREE.Mesh( sphere, new THREE.MeshBasicMaterial( { color: 0xffffff } ) );
+				helperL1.position.copy(light1.position);
+				scene.add( helperL1 );
+
+				light2 = new THREE.PointLight( 0xff0040, 1, 10000 );
+				light2.position.set( 500, -300, 0 );
+				scene.add( light2 );
+
+				var helperL2 = new THREE.Mesh( sphere, new THREE.MeshBasicMaterial( { color: 0xff0040 } ) );
+				helperL2.position.copy(light2.position);
+				scene.add( helperL2 );
+
+				// Meshes
+				var geometry = new THREE.BoxGeometry( 200, 200, 200 );
+
+				var texture = THREE.ImageUtils.loadTexture( 'textures/crate.gif' );
+				texture.anisotropy = renderer.getMaxAnisotropy();
+
+				// Side
+				var side = THREE.FrontSide; // Try it with THREE.DoubleSide or THREE.BackSide
+
+				material = new THREE.MeshPhongMaterial( { map: texture, side: side} ); // default: THREE.NoFlip
+				meshes.push( new THREE.Mesh( geometry, material ) );
+
+				material = new THREE.MeshPhongMaterial( { map: texture, side: side, flipSide: THREE.FlipFaces} );
+				meshes.push( new THREE.Mesh( geometry, material ) );
+
+				material = new THREE.MeshPhongMaterial( { map: texture, side: side, flipSide: THREE.FlipNormals} );
+				meshes.push( new THREE.Mesh( geometry, material ) );
+
+				material = new THREE.MeshPhongMaterial( { map: texture, side: side, flipSide: THREE.FlipFacesNormals} );
+				meshes.push( new THREE.Mesh( geometry, material ) );
+
+				// Add Meshes and normal helpers
+      			for( var i = 0, il = meshes.length; i < il; i ++ ) {
+
+					helpers.push( new THREE.FaceNormalsHelper( meshes[i], 30 ) );
+
+      				meshes[i].position.x += i * 300.0;
+					scene.add( meshes[i] );
+					scene.add( helpers[i] );
+				}
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+				var time = Date.now() * 0.0005;
+
+  				for( var i = 0, il = meshes.length; i < il; i ++ ) {
+
+					meshes[i].rotation.x += 0.005;
+					meshes[i].rotation.y += 0.01;
+
+					helpers[i].update();
+
+				}
+				/*
+				light1.position.x = Math.sin( time * 0.7 ) * 30;
+				light1.position.y = Math.cos( time * 0.5 ) * 40;
+				light1.position.z = Math.cos( time * 0.3 ) * 30;
+				*/
+
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/src/Three.js
+++ b/src/Three.js
@@ -35,6 +35,13 @@ THREE.FrontSide = 0;
 THREE.BackSide = 1;
 THREE.DoubleSide = 2;
 
+// flip side
+
+THREE.NoFlip = 0;
+THREE.FlipFaces = 1;
+THREE.FlipNormals = 2;
+THREE.FlipFacesNormals = 3;
+
 // shading
 
 THREE.NoShading = 0;

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -256,6 +256,12 @@ THREE.Loader.prototype = {
 
 		}
 
+		if ( m.flipSide !== undefined ) {
+
+			mpars.flipSide = m.flipSide;
+
+		}
+
 		if ( m.doubleSided !== undefined ) {
 
 			mpars.side = THREE.DoubleSide;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -11,6 +11,7 @@ THREE.Material = function () {
 	this.name = '';
 
 	this.side = THREE.FrontSide;
+	this.flipSide = THREE.NoFlip;
 
 	this.opacity = 1;
 	this.transparent = false;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4034,7 +4034,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		material.addEventListener( 'dispose', onMaterialDispose );
 
-		var u, a, identifiers, i, parameters, maxLightCount, maxBones, maxShadows, shaderID;
+		var u, a, identifiers, i, parameters, maxLightCount, maxBones, maxShadows, shaderID, flipNormals;
 
 		if ( material instanceof THREE.MeshDepthMaterial ) {
 
@@ -4073,6 +4073,16 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( shaderID ) {
 
 			setMaterialShaders( material, THREE.ShaderLib[ shaderID ] );
+
+		}
+
+		if ( material.flipSide === THREE.NoFlip ) {
+
+			flipNormals = material.side === THREE.BackSide;
+
+		} else {
+
+			flipNormals = ( material.flipSide === THREE.FlipNormals || material.flipSide === THREE.FlipFacesNormals );
 
 		}
 
@@ -4130,7 +4140,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			metal: material.metal,
 			wrapAround: material.wrapAround,
 			doubleSided: material.side === THREE.DoubleSide,
-			flipSided: material.side === THREE.BackSide
+			flipSided: flipNormals
 
 		};
 
@@ -5262,8 +5272,18 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	this.setMaterialFaces = function ( material ) {
 
+		var flipFaces
 		var doubleSided = material.side === THREE.DoubleSide;
-		var flipSided = material.side === THREE.BackSide;
+
+		if ( material.flipSide === THREE.NoFlip ) {
+
+			flipFaces = material.side === THREE.BackSide;
+
+		} else {
+
+			flipFaces = ( material.flipSide === THREE.FlipFaces || material.flipSide === THREE.FlipFacesNormals );
+
+		}
 
 		if ( _oldDoubleSided !== doubleSided ) {
 
@@ -5281,9 +5301,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		if ( _oldFlipSided !== flipSided ) {
+		if ( _oldFlipSided !== flipFaces ) {
 
-			if ( flipSided ) {
+			if ( flipFaces ) {
 
 				_gl.frontFace( _gl.CW );
 
@@ -5293,7 +5313,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
-			_oldFlipSided = flipSided;
+			_oldFlipSided = flipFaces;
 
 		}
 


### PR DESCRIPTION
As discussed in #4904, the following flags determines our desired flip method (flipSide parameter in Material):

```
THREE.NoFlip = 0;
THREE.FlipFaces = 1;
THREE.FlipNormals = 2;
THREE.FlipFacesNormals = 3;
```

By default, THREE.NoFlip, considers  material.side === THREE.BackSide, which is the original behavior of three.js. So it won't change the core and only allows developers to flip faces and/or normals in real-time efficiently, regardless of the culling face mode (double/front/back)

one example scene is also included.
