### PR TITLE
Update AssimpJSONLoader.js

### DIFF
--- a/examples/js/loaders/AssimpJSONLoader.js
+++ b/examples/js/loaders/AssimpJSONLoader.js
@@ -219,7 +219,9 @@ THREE.AssimpJSONLoader.prototype = {
 						has_textures.push(keyname);
 
 						loader.setCrossOrigin(this.crossOrigin);
-						loader.load(scope.texturePath + '/' + prop.value, function(tex) {
+						var material_url = scope.texturePath + '/' + prop.value
+						material_url = material_url.replace(/\\/g, '/');
+						loader.load(material_url, function(tex) {
 							if(tex) {
 								// TODO: read texture settings from assimp.
 								// Wrapping is the default, though.


### PR DESCRIPTION
Assimp2Json keeps windows backslashes in paths, while in servers slashes should be used.
