### PR TITLE
Fixes a problem with fonts using cubic bezier curves (partial solution to #4590)

### DIFF
--- a/src/extras/FontUtils.js
+++ b/src/extras/FontUtils.js
@@ -187,11 +187,11 @@ THREE.FontUtils = {
 					cpx  = outline[ i ++ ] *  scaleX + offset;
 					cpy  = outline[ i ++ ] *  scaleY;
 					cpx1 = outline[ i ++ ] *  scaleX + offset;
-					cpy1 = outline[ i ++ ] * - scaleY;
+					cpy1 = outline[ i ++ ] *  scaleY;
 					cpx2 = outline[ i ++ ] *  scaleX + offset;
-					cpy2 = outline[ i ++ ] * - scaleY;
+					cpy2 = outline[ i ++ ] *  scaleY;
 
-					path.bezierCurveTo( cpx, cpy, cpx1, cpy1, cpx2, cpy2 );
+					path.bezierCurveTo( cpx1, cpy1, cpx2, cpy2, cpx, cpy );
 
 					laste = pts[ pts.length - 1 ];
 


### PR DESCRIPTION
### Problem

In `FontUtils.extractGlyphPoints` the case for "cubic bezier curve" may never have worked:
- negative scaling of control points
  - since its initial [commit](https://github.com/mrdoob/three.js/commit/1286e5171b6c1a2edff2b70c5df1eb823941a503)
- wrong parameter order when calling `path.bezierCurveTo`
  - introduced as wrong function `path.quadraticCurveTo` in [commit](https://github.com/mrdoob/three.js/commit/762f58a49015d9f2865d65abdbf3a76bfbf71bae)
  - changed to correct function `path.bezierCurveTo` in [commit](https://github.com/mrdoob/three.js/commit/cac14305d1304d69d2ecc36aaa17377efd89879d) without changing the parameter order.

The consequences as decribed in issue #4590, Version B can be seen here: http://jsfiddle.net/MnV2R/
This might also explain the problems with chinese fonts sometimes mentioned.
### Solution

The result of the patch can be seen here: http://jsfiddle.net/MnV2R/1/
This solves the basic problem of issue #4590, but not the consequences of the inconsistent winding order.
