### PR TITLE
better objectScaleLock in the editor

### DIFF
--- a/editor/js/Sidebar.Object3D.js
+++ b/editor/js/Sidebar.Object3D.js
@@ -224,10 +224,18 @@ Sidebar.Object3D = function ( editor ) {
 
 		if ( objectScaleLock.getValue() === true ) {
 
-			var scale = objectScaleX.getValue() / object.scale.x;
+			if ( Math.abs( object.scale.x ) < 1e-300 ) {
 
-			objectScaleY.setValue( objectScaleY.getValue() * scale );
-			objectScaleZ.setValue( objectScaleZ.getValue() * scale );
+				objectScaleX.setValue( 0 );
+
+			} else {
+
+				var scale = objectScaleX.getValue() / object.scale.x;
+
+				objectScaleY.setValue( objectScaleY.getValue() * scale );
+				objectScaleZ.setValue( objectScaleZ.getValue() * scale );
+
+			}
 
 		}
 
@@ -241,10 +249,18 @@ Sidebar.Object3D = function ( editor ) {
 
 		if ( objectScaleLock.getValue() === true ) {
 
-			var scale = objectScaleY.getValue() / object.scale.y;
+			if ( Math.abs( object.scale.y ) < 1e-300 ) {
 
-			objectScaleX.setValue( objectScaleX.getValue() * scale );
-			objectScaleZ.setValue( objectScaleZ.getValue() * scale );
+				objectScaleY.setValue( 0 );
+
+			} else {
+
+				var scale = objectScaleY.getValue() / object.scale.y;
+
+				objectScaleX.setValue( objectScaleX.getValue() * scale );
+				objectScaleZ.setValue( objectScaleZ.getValue() * scale );
+
+			}
 
 		}
 
@@ -258,10 +274,18 @@ Sidebar.Object3D = function ( editor ) {
 
 		if ( objectScaleLock.getValue() === true ) {
 
-			var scale = objectScaleZ.getValue() / object.scale.z;
+			if ( Math.abs( object.scale.z ) < 1e-300 ) {
 
-			objectScaleX.setValue( objectScaleX.getValue() * scale );
-			objectScaleY.setValue( objectScaleY.getValue() * scale );
+				objectScaleZ.setValue( 0 );
+
+			} else {
+
+				var scale = objectScaleZ.getValue() / object.scale.z;
+
+				objectScaleX.setValue( objectScaleX.getValue() * scale );
+				objectScaleY.setValue( objectScaleY.getValue() * scale );
+
+			}
 
 		}
 

--- a/editor/js/Sidebar.Object3D.js
+++ b/editor/js/Sidebar.Object3D.js
@@ -232,8 +232,16 @@ Sidebar.Object3D = function ( editor ) {
 
 				var scale = objectScaleX.getValue() / object.scale.x;
 
-				objectScaleY.setValue( objectScaleY.getValue() * scale );
-				objectScaleZ.setValue( objectScaleZ.getValue() * scale );
+				if ( Math.abs( scale ) < 1e-300 ) {
+
+					objectScaleX.setValue( object.scale.x );
+
+				} else {
+
+					objectScaleY.setValue( objectScaleY.getValue() * scale );
+					objectScaleZ.setValue( objectScaleZ.getValue() * scale );
+
+				}
 
 			}
 
@@ -257,8 +265,16 @@ Sidebar.Object3D = function ( editor ) {
 
 				var scale = objectScaleY.getValue() / object.scale.y;
 
-				objectScaleX.setValue( objectScaleX.getValue() * scale );
-				objectScaleZ.setValue( objectScaleZ.getValue() * scale );
+				if ( Math.abs( scale ) < 1e-300 ) {
+
+					objectScaleY.setValue( object.scale.y );
+
+				} else {
+
+					objectScaleX.setValue( objectScaleX.getValue() * scale );
+					objectScaleZ.setValue( objectScaleZ.getValue() * scale );
+
+				}
 
 			}
 
@@ -282,8 +298,16 @@ Sidebar.Object3D = function ( editor ) {
 
 				var scale = objectScaleZ.getValue() / object.scale.z;
 
-				objectScaleX.setValue( objectScaleX.getValue() * scale );
-				objectScaleY.setValue( objectScaleY.getValue() * scale );
+				if ( Math.abs( scale ) < 1e-300 ) {
+
+					objectScaleZ.setValue( object.scale.z );
+
+				} else {
+
+					objectScaleX.setValue( objectScaleX.getValue() * scale );
+					objectScaleY.setValue( objectScaleY.getValue() * scale );
+
+				}
 
 			}
 


### PR DESCRIPTION
Previously, if you crossed over zero scale into negative scales, you could sometimes slip into NaNs, and then had to uncheck scale lock and reset scales manually. With this change this is kinda fixed (there are still rounding errors thanks to UI.Number.prototype.setValue that make scales go out of sync after some time, but no NaNs now).
