### PR TITLE
Removed unused var verticesCount from OBJMTLLoader.js

### DIFF
--- a/examples/js/loaders/OBJMTLLoader.js
+++ b/examples/js/loaders/OBJMTLLoader.js
@@ -94,7 +94,6 @@ THREE.OBJMTLLoader.prototype = {
 
 				geometry = new THREE.Geometry();
 				mesh = new THREE.Mesh( geometry, material );
-				verticesCount = 0;
 
 			}
 
@@ -119,7 +118,6 @@ THREE.OBJMTLLoader.prototype = {
 		var mesh = new THREE.Mesh( geometry, material );
 
 		var vertices = [];
-		var verticesCount = 0;
 		var normals = [];
 		var uvs = [];
 


### PR DESCRIPTION
Removed `var verticesCount` as per #4968.
