### PR TITLE
OBJMTLLoader - When parsing OBJ files, only generate a new mesh in `mesh...

### DIFF
--- a/examples/js/loaders/OBJMTLLoader.js
+++ b/examples/js/loaders/OBJMTLLoader.js
@@ -82,7 +82,7 @@ THREE.OBJMTLLoader.prototype = {
 
 		function meshN( meshName, materialName ) {
 
-			if ( vertices.length > 0 ) {
+			if ( geometry.faces.length > 0 ) {
 
 				geometry.vertices = vertices;
 


### PR DESCRIPTION
...N()` if the face count is positive. The old behavior gated on vertex count being positive, but this produced "empty" meshes with no faces for some OBJ files. The specific OBJ file that prompted this fix was written by the Assimp C++ library, and contained, in this order: vertex definitions, texcoord definitions, a "usemtl" statement, and then face definitions.
