### PR TITLE
Throw a decent error on missing font.

### DIFF
--- a/src/extras/FontUtils.js
+++ b/src/extras/FontUtils.js
@@ -33,7 +33,15 @@ THREE.FontUtils = {
 
 	getFace: function () {
 
-		return this.faces[ this.face ][ this.weight ][ this.style ];
+		try {
+
+			return this.faces[ this.face ][ this.weight ][ this.style ];
+
+		} catch (e) {
+
+			throw "The font " + this.face + " with " + this.weight + " weight and " + this.style + " style is missing."
+
+		};
 
 	},
 


### PR DESCRIPTION
It throws an error when the font is missing.
Ex: "The font helvetiker with normal weight and normal style is missing.

Fixes #4923.
