### PR TITLE
Object3D remove() can take arbitrary arguments.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -353,6 +353,16 @@ THREE.Object3D.prototype = {
 
 	remove: function ( object ) {
 
+		if ( arguments.length > 1 ) {
+
+			for ( var i = 0; i < arguments.length; i++ ) {
+
+				this.remove( arguments[ i ] );
+
+			}
+
+		};
+
 		var index = this.children.indexOf( object );
 
 		if ( index !== - 1 ) {


### PR DESCRIPTION
Now is possible to do:

```
obj.remove( obj2, obj3 );
```

From discussion in #4958, see also #4977.
