### PR TITLE
Support OBJ and MTL files that may contain tags split onto multiple line...

### DIFF
--- a/utils/converters/obj/convert_obj_three.py
+++ b/utils/converters/obj/convert_obj_three.py
@@ -362,7 +362,14 @@ def parse_mtl(fname):
 
     materials = {}
 
+    previous_line = ""
     for line in fileinput.input(fname):
+        line = previous_line + line
+        if line[-2:-1] == '\\':
+            previous_line = line[:-2]
+            continue
+        previous_line = ""
+
         chunks = line.split()
         if len(chunks) > 0:
 
@@ -505,7 +512,14 @@ def parse_obj(fname):
     object = 0
     smooth = 0
 
+    previous_line = ""
     for line in fileinput.input(fname):
+        line = previous_line + line
+        if line[-2:-1] == '\\':
+            previous_line = line[:-2]
+            continue
+        previous_line = ""
+
         chunks = line.split()
         if len(chunks) > 0:
 


### PR DESCRIPTION
...s, using a trailing backslash to signify the split, in the OBJ converter.

I had some additional issues with an OBJ that was somehow exported with some of its longer lines split into multiple lines, using a trailing backslash to signify the split. I'm not sure if that's really valid, but this change gets around the issue anyway.
