### PR TITLE
Update webgl_camera.html, removing container div

### DIFF
--- a/examples/webgl_camera.html
+++ b/examples/webgl_camera.html
@@ -37,8 +37,6 @@
 		</style>
 	</head>
 	<body>
-
-		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - cameras<br/>
 		<b>O</b> orthographic <b>P</b> perspective
 		</div>


### PR DESCRIPTION
Container div is unnecessary since it's created in init() function as an appendChild() to body.
