### PR TITLE
Added Alpha Test to Normal Map Shader

### DIFF
--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -763,6 +763,8 @@ THREE.ShaderLib = {
 			"		#endif",
 
 			"	}",
+			
+			THREE.ShaderChunk[ "alphatest_fragment" ],
 
 			"	if( enableSpecular )",
 			"		specularTex = texture2D( tSpecular, vUv ).xyz;",


### PR DESCRIPTION
Added the `alphatest_fragment` from `THREE.ShaderChunk` to the `normal map` shader.
