### PR TITLE
Only put those uniforms to uniformsList which are in the program

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4256,7 +4256,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		for ( u in material.__webglShader.uniforms ) {
 
-			material.uniformsList.push( [ material.__webglShader.uniforms[ u ], u ] );
+			var location = material.program.uniforms[ u ];
+
+			if ( location ) {
+				material.uniformsList.push( [ material.__webglShader.uniforms[ u ], location ] );
+			}
 
 		}
 
@@ -4470,7 +4474,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			// load common uniforms
 
-			loadUniformsGeneric( program, material.uniformsList );
+			loadUniformsGeneric( material.uniformsList );
 
 		}
 
@@ -4758,15 +4762,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	};
 
-	function loadUniformsGeneric ( program, uniforms ) {
+	function loadUniformsGeneric ( uniforms ) {
 
 		var texture, textureUnit, offset;
 
 		for ( var j = 0, jl = uniforms.length; j < jl; j ++ ) {
 
-			var location = program.uniforms[ uniforms[ j ][ 1 ] ];
-
-			if ( ! location ) continue;
+			var location = uniforms[ j ][ 1 ];
 
 			var uniform = uniforms[ j ][ 0 ];
 


### PR DESCRIPTION
Also cache uniform locations in the uniformsList, so that querying them
from the program is not needed. This reduces CPU usage.
