### PR TITLE
Allow optional use of bufferSubData in setDirectBuffers

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2393,18 +2393,24 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( attributeItem.needsUpdate ) {
 
-				if ( attributeName === 'index' ) {
+				var target = attributeName === 'index' ? _gl.ELEMENT_ARRAY_BUFFER : _gl.ARRAY_BUFFER;
 
-					_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attributeItem.buffer );
-					_gl.bufferData( _gl.ELEMENT_ARRAY_BUFFER, attributeItem.array, hint );
+				var updateElements = attributeItem.updateElements;
 
-				} else {
-
-					_gl.bindBuffer( _gl.ARRAY_BUFFER, attributeItem.buffer );
-					_gl.bufferData( _gl.ARRAY_BUFFER, attributeItem.array, hint );
-
+				if ( updateElements instanceof Array && updateElements.length > 0 ) {
+					for ( var i = 0; i < updateElements.length; i++ ) {
+						var offset = updateElements[i];
+						var view = attributeItem.array.subarray( offset[0], offset[1] );
+						_gl.bindBuffer( target, attributeItem.buffer );
+						_gl.bufferSubData( target, offset[0] * attributeItem.array.BYTES_PER_ELEMENT, view );
+					}
+				}
+				else {
+					_gl.bindBuffer( target, attributeItem.buffer );
+					_gl.bufferData( target, attributeItem.array, hint );
 				}
 
+				attributeItem.updateElements = [];
 				attributeItem.needsUpdate = false;
 
 			}


### PR DESCRIPTION
Demo: http://tyrovr.com/lab/three.js/bufferSubData/ (see the "animate" function for how it's used: http://tyrovr.com/lab/three.js/bufferSubData/main.js) 

Edit: It's not clear from the text on the demo page, but bufferSubData is being called 1000x per frame when it is being used; bufferData once when it is being used.

User can add an array of ranges of an attribute array to update, instead of sending the entire buffer to the GPU if they are only updating a fraction of it e.g.,

``` javascript
geometry.attributes.position.array.set( [ 0,0,0, 1,0,0, 0,1,0 ] );
// ... render
geometry.attributes.position.array[0] = -1;
geometry.attributes.position.updateElements = [ [ 0, 1 ] ]; // [ start of range, end of range + 1 ]
geometry.attributes.position.needsUpdate = true;
// ... render, position.array[ 0 ] is sent to GPU
```

If `updateElements` is an empty array or not an Array, the whole array is copied, per usual.

In the demo above, I get a reduction from 96% to 12% of time spent in setDirectBuffers when using bufferSubData.

Thanks for looking!
