### PR TITLE
CTMLoader improvements

### DIFF
--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -79,6 +79,12 @@ THREE.CTMLoader.prototype.loadParts = function( url, callback, parameters ) {
 
 };
 
+THREE.CTMLoader.workerURL = "js/loaders/ctm/CTMWorker.js";
+
+THREE.CTMLoader.prototype.createWorker = function () {
+	 return new Worker( THREE.CTMLoader.workerURL );
+};
+
 // Load CTMLoader compressed models
 //	- parameters
 //		- url (required)
@@ -97,6 +103,8 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 	var length = 0;
 
+	var self = this;
+
 	xhr.onreadystatechange = function() {
 
 		if ( xhr.readyState === 4 ) {
@@ -109,7 +117,7 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 				if ( parameters.useWorker ) {
 
-					var worker = new Worker( "js/loaders/ctm/CTMWorker.js" );
+					var worker = parameters.worker || self.createWorker();
 
 					worker.onmessage = function( event ) {
 


### PR DESCRIPTION
- allow to set worker url via THREE.CTMLoader.workerURL (usefull when file hierarchy does not match three.js hierarchy)
- allow to delegate worker creation (loader parameters and THREE.CTMLoader.prorotype.createWorker)
