### PR TITLE
WIP: first fix towards targetless lights

### DIFF
--- a/src/extras/helpers/DirectionalLightHelper.js
+++ b/src/extras/helpers/DirectionalLightHelper.js
@@ -79,4 +79,3 @@ THREE.DirectionalLightHelper.prototype.update = function () {
 	}
 
 }();
-

--- a/src/extras/renderers/plugins/ShadowMapPlugin.js
+++ b/src/extras/renderers/plugins/ShadowMapPlugin.js
@@ -104,7 +104,6 @@ THREE.ShadowMapPlugin = function () {
 						gyro.position.copy( light.shadowCascadeOffset );
 
 						gyro.add( virtualLight );
-						gyro.add( virtualLight.target );
 
 						camera.add( gyro );
 
@@ -199,10 +198,13 @@ THREE.ShadowMapPlugin = function () {
 			shadowMatrix = light.shadowMatrix;
 			shadowCamera = light.shadowCamera;
 
-			shadowCamera.position.setFromMatrixPosition( light.matrixWorld );
-			_matrixPosition.setFromMatrixPosition( light.target.matrixWorld );
-			shadowCamera.lookAt( _matrixPosition );
-			shadowCamera.updateMatrixWorld();
+			shadowCamera.matrixWorld.copy(light.matrixWorld);
+			shadowCamera.matrixWorld.elements[0] = -shadowCamera.matrixWorld.elements[0];
+			shadowCamera.matrixWorld.elements[1] = -shadowCamera.matrixWorld.elements[1];
+			shadowCamera.matrixWorld.elements[2] = -shadowCamera.matrixWorld.elements[2];
+			shadowCamera.matrixWorld.elements[8] = -shadowCamera.matrixWorld.elements[8];
+			shadowCamera.matrixWorld.elements[9] = -shadowCamera.matrixWorld.elements[9];
+			shadowCamera.matrixWorld.elements[10] = -shadowCamera.matrixWorld.elements[10];
 
 			shadowCamera.matrixWorldInverse.getInverse( shadowCamera.matrixWorld );
 
@@ -417,10 +419,9 @@ THREE.ShadowMapPlugin = function () {
 
 		var virtualLight = light.shadowCascadeArray[ cascade ];
 
-		virtualLight.position.copy( light.position );
-		virtualLight.target.position.copy( light.target.position );
-		virtualLight.lookAt( virtualLight.target );
-
+		virtualLight.matrixWorld.copy( light.matrixWorld )
+		virtualLight.matrixAutoUpdate = false;
+		
 		virtualLight.shadowCameraVisible = light.shadowCameraVisible;
 		virtualLight.shadowDarkness = light.shadowDarkness;
 

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -8,14 +8,11 @@ THREE.DirectionalLight = function ( color, intensity ) {
 	THREE.Light.call( this, color );
 
 	this.position.set( 0, 1, 0 );
-	this.target = new THREE.Object3D();
 
 	this.intensity = ( intensity !== undefined ) ? intensity : 1;
 
 	this.castShadow = false;
 	this.onlyShadow = false;
-
-	//
 
 	this.shadowCameraNear = 50;
 	this.shadowCameraFar = 5000;
@@ -32,9 +29,7 @@ THREE.DirectionalLight = function ( color, intensity ) {
 
 	this.shadowMapWidth = 512;
 	this.shadowMapHeight = 512;
-
-	//
-
+	
 	this.shadowCascade = false;
 
 	this.shadowCascadeOffset = new THREE.Vector3( 0, 0, - 1000 );
@@ -48,8 +43,6 @@ THREE.DirectionalLight = function ( color, intensity ) {
 	this.shadowCascadeFarZ  = [  0.990, 0.998, 1.000 ];
 
 	this.shadowCascadeArray = [];
-
-	//
 
 	this.shadowMap = null;
 	this.shadowMapSize = null;
@@ -66,14 +59,10 @@ THREE.DirectionalLight.prototype.clone = function () {
 
 	THREE.Light.prototype.clone.call( this, light );
 
-	light.target = this.target.clone();
-
 	light.intensity = this.intensity;
 
 	light.castShadow = this.castShadow;
 	light.onlyShadow = this.onlyShadow;
-
-	//
 
 	light.shadowCameraNear = this.shadowCameraNear;
 	light.shadowCameraFar = this.shadowCameraFar;
@@ -90,8 +79,6 @@ THREE.DirectionalLight.prototype.clone = function () {
 
 	light.shadowMapWidth = this.shadowMapWidth;
 	light.shadowMapHeight = this.shadowMapHeight;
-
-	//
 
 	light.shadowCascade = this.shadowCascade;
 

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -7,7 +7,6 @@ THREE.SpotLight = function ( color, intensity, distance, angle, exponent ) {
 	THREE.Light.call( this, color );
 
 	this.position.set( 0, 1, 0 );
-	this.target = new THREE.Object3D();
 
 	this.intensity = ( intensity !== undefined ) ? intensity : 1;
 	this.distance = ( distance !== undefined ) ? distance : 0;
@@ -48,8 +47,6 @@ THREE.SpotLight.prototype.clone = function () {
 
 	THREE.Light.prototype.clone.call( this, light );
 
-	light.target = this.target.clone();
-
 	light.intensity = this.intensity;
 	light.distance = this.distance;
 	light.angle = this.angle;
@@ -57,8 +54,6 @@ THREE.SpotLight.prototype.clone = function () {
 
 	light.castShadow = this.castShadow;
 	light.onlyShadow = this.onlyShadow;
-
-	//
 
 	light.shadowCameraNear = this.shadowCameraNear;
 	light.shadowCameraFar = this.shadowCameraFar;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5179,11 +5179,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 				dirCount += 1;
 
 				if ( ! light.visible ) continue;
-
-				_direction.setFromMatrixPosition( light.matrixWorld );
-				_vector3.setFromMatrixPosition( light.target.matrixWorld );
-				_direction.sub( _vector3 );
-				_direction.normalize();
+				
+				_direction.set( 0, 0, -1 );
+				_direction.transformDirection( light.matrixWorld );
 
 				dirOffset = dirLength * 3;
 
@@ -5249,17 +5247,16 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				_direction.setFromMatrixPosition( light.matrixWorld );
+				_vector3.setFromMatrixPosition( light.matrixWorld );
 
-				spotPositions[ spotOffset ]     = _direction.x;
-				spotPositions[ spotOffset + 1 ] = _direction.y;
-				spotPositions[ spotOffset + 2 ] = _direction.z;
+				spotPositions[ spotOffset ]     = _vector3.x;
+				spotPositions[ spotOffset + 1 ] = _vector3.y;
+				spotPositions[ spotOffset + 2 ] = _vector3.z;
 
 				spotDistances[ spotLength ] = distance;
-
-				_vector3.setFromMatrixPosition( light.target.matrixWorld );
-				_direction.sub( _vector3 );
-				_direction.normalize();
+				
+				_direction.set( 0, 0, -1 );
+				_direction.transformDirection( light.matrixWorld );
 
 				spotDirections[ spotOffset ]     = _direction.x;
 				spotDirections[ spotOffset + 1 ] = _direction.y;


### PR DESCRIPTION
This is a fix for #5079.

I still need to update the examples and helpers but otherwise it works.

The only thing I have a problem with, is that I need to negate the x and z component of the rotation for the camera of the shadowmap. I know they work, but I can't seem to find a logical explantion for it. [Link](https://github.com/gero3/three.js/blob/removeTarget/src/extras/renderers/plugins/ShadowMapPlugin.js#L201-L207)

@WestLangley Any ideas?? 
