### PR TITLE
allow silencing CTMLoader

### DIFF
--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -125,7 +125,7 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 							scope.createModel( ctmFile, callback );
 
 							var e = Date.now();
-							console.log( "model load time [worker]: " + (e-e1) + " ms, total: " + (e-s));
+							if (!parameters.silent) console.log( "model load time [worker]: " + (e-e1) + " ms, total: " + (e-s));
 
 						}
 


### PR DESCRIPTION
I do not now is this is intentional, but the others console.log() invocations are commented out. Maybe that one should also be commented out?
