### PR TITLE
tidier computeVertexNormals on BufferGeometry 

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -337,151 +337,151 @@ THREE.BufferGeometry.prototype = {
 
 	computeVertexNormals: function () {
 
-        var positionAttr = this.getAttribute( 'position' );
+		var positionAttr = this.getAttribute( 'position' );
 
-        if ( !positionAttr ) {
-            // If there are no positions, we cannot proceed.
-            return
-        }
+		if ( positionAttr === undefined ) {
+			// If there are no positions, we cannot proceed.
+			return
+		}
 
-        var nVertexElements = positionAttr.array.length;
+		var nVertexElements = positionAttr.array.length;
 
-        var normalAttr  = this.getAttribute( 'normal' );
+		var normalAttr  = this.getAttribute( 'normal' );
 
-        var i, il;
-        var j, jl;
+		var i, il;
+		var j, jl;
 
-        if ( !normalAttr ) {
+		if ( normalAttr === undefined ) {
 
-            // add a normal attribute
+			// add a normal attribute
 
-            this.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( nVertexElements ), 3 ) );
+			this.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( nVertexElements ), 3 ) );
 
-        } else {
+		} else {
 
-            // reset existing normals to zero
+			// reset existing normals to zero
 
-            for ( i = 0, il = normalAttr.array.length; i < il; i ++ ) {
+			for ( i = 0, il = normalAttr.array.length; i < il; i ++ ) {
 
-                normalAttr.array[ i ] = 0;
+				normalAttr.array[ i ] = 0;
 
-            }
+			}
 
-        }
+		}
 
-        // by here we definitely have position and normal attributes.
+		// by here we definitely have position and normal attributes.
 
-        var positions = this.getAttribute( 'position' ).array;
-        var normals = this.getAttribute( 'normal' ).array;
+		var positions = this.getAttribute( 'position' ).array;
+		var normals = this.getAttribute( 'normal' ).array;
 
-        var vA, vB, vC, x, y, z,
+		var vA, vB, vC, x, y, z,
 
-        pA = new THREE.Vector3(),
-        pB = new THREE.Vector3(),
-        pC = new THREE.Vector3(),
+		pA = new THREE.Vector3(),
+		pB = new THREE.Vector3(),
+		pC = new THREE.Vector3(),
 
-        cb = new THREE.Vector3(),
-        ab = new THREE.Vector3();
+		cb = new THREE.Vector3(),
+		ab = new THREE.Vector3();
 
-        // indexed elements
+		// indexed elements
 
-        if ( this.getAttribute( 'index' ) ) {
+		if ( this.getAttribute( 'index' ) ) {
 
-            var indices = this.getAttribute( 'index' ).array;
+			var indices = this.getAttribute( 'index' ).array;
 
-            var offsets = ( this.offsets.length > 0 ? this.offsets : [ { start: 0, count: indices.length, index: 0 } ] );
+			var offsets = ( this.offsets.length > 0 ? this.offsets : [ { start: 0, count: indices.length, index: 0 } ] );
 
-            for ( j = 0, jl = offsets.length; j < jl; ++ j ) {
+			for ( j = 0, jl = offsets.length; j < jl; ++ j ) {
 
-                var start = offsets[ j ].start;
-                var count = offsets[ j ].count;
-                var index = offsets[ j ].index;
+				var start = offsets[ j ].start;
+				var count = offsets[ j ].count;
+				var index = offsets[ j ].index;
 
-                for ( i = start, il = start + count; i < il; i += 3 ) {
+				for ( i = start, il = start + count; i < il; i += 3 ) {
 
-                    vA = index + indices[ i ];
-                    vB = index + indices[ i + 1 ];
-                    vC = index + indices[ i + 2 ];
+					vA = index + indices[ i ];
+					vB = index + indices[ i + 1 ];
+					vC = index + indices[ i + 2 ];
 
-                    x = positions[ vA * 3 ];
-                    y = positions[ vA * 3 + 1 ];
-                    z = positions[ vA * 3 + 2 ];
-                    pA.set( x, y, z );
+					x = positions[ vA * 3 ];
+					y = positions[ vA * 3 + 1 ];
+					z = positions[ vA * 3 + 2 ];
+					pA.set( x, y, z );
 
-                    x = positions[ vB * 3 ];
-                    y = positions[ vB * 3 + 1 ];
-                    z = positions[ vB * 3 + 2 ];
-                    pB.set( x, y, z );
+					x = positions[ vB * 3 ];
+					y = positions[ vB * 3 + 1 ];
+					z = positions[ vB * 3 + 2 ];
+					pB.set( x, y, z );
 
-                    x = positions[ vC * 3 ];
-                    y = positions[ vC * 3 + 1 ];
-                    z = positions[ vC * 3 + 2 ];
-                    pC.set( x, y, z );
+					x = positions[ vC * 3 ];
+					y = positions[ vC * 3 + 1 ];
+					z = positions[ vC * 3 + 2 ];
+					pC.set( x, y, z );
 
-                    cb.subVectors( pC, pB );
-                    ab.subVectors( pA, pB );
-                    cb.cross( ab );
+					cb.subVectors( pC, pB );
+					ab.subVectors( pA, pB );
+					cb.cross( ab );
 
-                    normals[ vA * 3     ] += cb.x;
-                    normals[ vA * 3 + 1 ] += cb.y;
-                    normals[ vA * 3 + 2 ] += cb.z;
+					normals[ vA * 3     ] += cb.x;
+					normals[ vA * 3 + 1 ] += cb.y;
+					normals[ vA * 3 + 2 ] += cb.z;
 
-                    normals[ vB * 3     ] += cb.x;
-                    normals[ vB * 3 + 1 ] += cb.y;
-                    normals[ vB * 3 + 2 ] += cb.z;
+					normals[ vB * 3     ] += cb.x;
+					normals[ vB * 3 + 1 ] += cb.y;
+					normals[ vB * 3 + 2 ] += cb.z;
 
-                    normals[ vC * 3     ] += cb.x;
-                    normals[ vC * 3 + 1 ] += cb.y;
-                    normals[ vC * 3 + 2 ] += cb.z;
+					normals[ vC * 3     ] += cb.x;
+					normals[ vC * 3 + 1 ] += cb.y;
+					normals[ vC * 3 + 2 ] += cb.z;
 
-                }
+				}
 
-            }
+			}
 
-        // non-indexed elements (unconnected triangle soup)
+		// non-indexed elements (unconnected triangle soup)
 
-        } else {
+		} else {
 
-            for ( i = 0, il = positions.length; i < il; i += 9 ) {
+			for ( i = 0, il = positions.length; i < il; i += 9 ) {
 
-                x = positions[ i ];
-                y = positions[ i + 1 ];
-                z = positions[ i + 2 ];
-                pA.set( x, y, z );
+				x = positions[ i ];
+				y = positions[ i + 1 ];
+				z = positions[ i + 2 ];
+				pA.set( x, y, z );
 
-                x = positions[ i + 3 ];
-                y = positions[ i + 4 ];
-                z = positions[ i + 5 ];
-                pB.set( x, y, z );
+				x = positions[ i + 3 ];
+				y = positions[ i + 4 ];
+				z = positions[ i + 5 ];
+				pB.set( x, y, z );
 
-                x = positions[ i + 6 ];
-                y = positions[ i + 7 ];
-                z = positions[ i + 8 ];
-                pC.set( x, y, z );
+				x = positions[ i + 6 ];
+				y = positions[ i + 7 ];
+				z = positions[ i + 8 ];
+				pC.set( x, y, z );
 
-                cb.subVectors( pC, pB );
-                ab.subVectors( pA, pB );
-                cb.cross( ab );
+				cb.subVectors( pC, pB );
+				ab.subVectors( pA, pB );
+				cb.cross( ab );
 
-                normals[ i     ] = cb.x;
-                normals[ i + 1 ] = cb.y;
-                normals[ i + 2 ] = cb.z;
+				normals[ i     ] = cb.x;
+				normals[ i + 1 ] = cb.y;
+				normals[ i + 2 ] = cb.z;
 
-                normals[ i + 3 ] = cb.x;
-                normals[ i + 4 ] = cb.y;
-                normals[ i + 5 ] = cb.z;
+				normals[ i + 3 ] = cb.x;
+				normals[ i + 4 ] = cb.y;
+				normals[ i + 5 ] = cb.z;
 
-                normals[ i + 6 ] = cb.x;
-                normals[ i + 7 ] = cb.y;
-                normals[ i + 8 ] = cb.z;
+				normals[ i + 6 ] = cb.x;
+				normals[ i + 7 ] = cb.y;
+				normals[ i + 8 ] = cb.z;
 
-            }
+			}
 
-        }
+		}
 
-        this.normalizeNormals();
+		this.normalizeNormals();
 
-        this.normalsNeedUpdate = true;
+		this.normalsNeedUpdate = true;
 
 	},
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -222,7 +222,7 @@ THREE.BufferGeometry.prototype = {
 
 		}
 
-		this.computeBoundingSphere()
+		this.computeBoundingSphere();
 
 		return this;
 
@@ -337,147 +337,151 @@ THREE.BufferGeometry.prototype = {
 
 	computeVertexNormals: function () {
 
-		if ( this.attributes[ 'position' ] ) {
+        var positionAttr = this.getAttribute( 'position' );
 
-			var i, il;
-			var j, jl;
+        if ( !positionAttr ) {
+            // If there are no positions, we cannot proceed.
+            return
+        }
 
-			var nVertexElements = this.attributes[ 'position' ].array.length;
+        var nVertexElements = positionAttr.array.length;
 
-			if ( this.attributes[ 'normal' ] === undefined ) {
+        var normalAttr  = this.getAttribute( 'normal' );
 
-				this.attributes[ 'normal' ] = {
+        var i, il;
+        var j, jl;
 
-					itemSize: 3,
-					array: new Float32Array( nVertexElements )
+        if ( !normalAttr ) {
 
-				};
+            // add a normal attribute
 
-			} else {
+            this.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( nVertexElements ), 3 ) );
 
-				// reset existing normals to zero
+        } else {
 
-				for ( i = 0, il = this.attributes[ 'normal' ].array.length; i < il; i ++ ) {
+            // reset existing normals to zero
 
-					this.attributes[ 'normal' ].array[ i ] = 0;
+            for ( i = 0, il = normalAttr.array.length; i < il; i ++ ) {
 
-				}
+                normalAttr.array[ i ] = 0;
 
-			}
+            }
 
-			var positions = this.attributes[ 'position' ].array;
-			var normals = this.attributes[ 'normal' ].array;
+        }
 
-			var vA, vB, vC, x, y, z,
+        // by here we definitely have position and normal attributes.
 
-			pA = new THREE.Vector3(),
-			pB = new THREE.Vector3(),
-			pC = new THREE.Vector3(),
+        var positions = this.getAttribute( 'position' ).array;
+        var normals = this.getAttribute( 'normal' ).array;
 
-			cb = new THREE.Vector3(),
-			ab = new THREE.Vector3();
+        var vA, vB, vC, x, y, z,
 
-			// indexed elements
+        pA = new THREE.Vector3(),
+        pB = new THREE.Vector3(),
+        pC = new THREE.Vector3(),
 
-			if ( this.attributes[ 'index' ] ) {
+        cb = new THREE.Vector3(),
+        ab = new THREE.Vector3();
 
-				var indices = this.attributes[ 'index' ].array;
+        // indexed elements
 
-				var offsets = ( this.offsets.length > 0 ? this.offsets : [ { start: 0, count: indices.length, index: 0 } ] );
+        if ( this.getAttribute( 'index' ) ) {
 
-				for ( j = 0, jl = offsets.length; j < jl; ++ j ) {
+            var indices = this.getAttribute( 'index' ).array;
 
-					var start = offsets[ j ].start;
-					var count = offsets[ j ].count;
-					var index = offsets[ j ].index;
+            var offsets = ( this.offsets.length > 0 ? this.offsets : [ { start: 0, count: indices.length, index: 0 } ] );
 
-					for ( i = start, il = start + count; i < il; i += 3 ) {
+            for ( j = 0, jl = offsets.length; j < jl; ++ j ) {
 
-						vA = index + indices[ i ];
-						vB = index + indices[ i + 1 ];
-						vC = index + indices[ i + 2 ];
+                var start = offsets[ j ].start;
+                var count = offsets[ j ].count;
+                var index = offsets[ j ].index;
 
-						x = positions[ vA * 3 ];
-						y = positions[ vA * 3 + 1 ];
-						z = positions[ vA * 3 + 2 ];
-						pA.set( x, y, z );
+                for ( i = start, il = start + count; i < il; i += 3 ) {
 
-						x = positions[ vB * 3 ];
-						y = positions[ vB * 3 + 1 ];
-						z = positions[ vB * 3 + 2 ];
-						pB.set( x, y, z );
+                    vA = index + indices[ i ];
+                    vB = index + indices[ i + 1 ];
+                    vC = index + indices[ i + 2 ];
 
-						x = positions[ vC * 3 ];
-						y = positions[ vC * 3 + 1 ];
-						z = positions[ vC * 3 + 2 ];
-						pC.set( x, y, z );
+                    x = positions[ vA * 3 ];
+                    y = positions[ vA * 3 + 1 ];
+                    z = positions[ vA * 3 + 2 ];
+                    pA.set( x, y, z );
 
-						cb.subVectors( pC, pB );
-						ab.subVectors( pA, pB );
-						cb.cross( ab );
+                    x = positions[ vB * 3 ];
+                    y = positions[ vB * 3 + 1 ];
+                    z = positions[ vB * 3 + 2 ];
+                    pB.set( x, y, z );
 
-						normals[ vA * 3     ] += cb.x;
-						normals[ vA * 3 + 1 ] += cb.y;
-						normals[ vA * 3 + 2 ] += cb.z;
+                    x = positions[ vC * 3 ];
+                    y = positions[ vC * 3 + 1 ];
+                    z = positions[ vC * 3 + 2 ];
+                    pC.set( x, y, z );
 
-						normals[ vB * 3     ] += cb.x;
-						normals[ vB * 3 + 1 ] += cb.y;
-						normals[ vB * 3 + 2 ] += cb.z;
+                    cb.subVectors( pC, pB );
+                    ab.subVectors( pA, pB );
+                    cb.cross( ab );
 
-						normals[ vC * 3     ] += cb.x;
-						normals[ vC * 3 + 1 ] += cb.y;
-						normals[ vC * 3 + 2 ] += cb.z;
+                    normals[ vA * 3     ] += cb.x;
+                    normals[ vA * 3 + 1 ] += cb.y;
+                    normals[ vA * 3 + 2 ] += cb.z;
 
-					}
+                    normals[ vB * 3     ] += cb.x;
+                    normals[ vB * 3 + 1 ] += cb.y;
+                    normals[ vB * 3 + 2 ] += cb.z;
 
-				}
+                    normals[ vC * 3     ] += cb.x;
+                    normals[ vC * 3 + 1 ] += cb.y;
+                    normals[ vC * 3 + 2 ] += cb.z;
 
-			// non-indexed elements (unconnected triangle soup)
+                }
 
-			} else {
+            }
 
-				for ( i = 0, il = positions.length; i < il; i += 9 ) {
+        // non-indexed elements (unconnected triangle soup)
 
-					x = positions[ i ];
-					y = positions[ i + 1 ];
-					z = positions[ i + 2 ];
-					pA.set( x, y, z );
+        } else {
 
-					x = positions[ i + 3 ];
-					y = positions[ i + 4 ];
-					z = positions[ i + 5 ];
-					pB.set( x, y, z );
+            for ( i = 0, il = positions.length; i < il; i += 9 ) {
 
-					x = positions[ i + 6 ];
-					y = positions[ i + 7 ];
-					z = positions[ i + 8 ];
-					pC.set( x, y, z );
+                x = positions[ i ];
+                y = positions[ i + 1 ];
+                z = positions[ i + 2 ];
+                pA.set( x, y, z );
 
-					cb.subVectors( pC, pB );
-					ab.subVectors( pA, pB );
-					cb.cross( ab );
+                x = positions[ i + 3 ];
+                y = positions[ i + 4 ];
+                z = positions[ i + 5 ];
+                pB.set( x, y, z );
 
-					normals[ i     ] = cb.x;
-					normals[ i + 1 ] = cb.y;
-					normals[ i + 2 ] = cb.z;
+                x = positions[ i + 6 ];
+                y = positions[ i + 7 ];
+                z = positions[ i + 8 ];
+                pC.set( x, y, z );
 
-					normals[ i + 3 ] = cb.x;
-					normals[ i + 4 ] = cb.y;
-					normals[ i + 5 ] = cb.z;
+                cb.subVectors( pC, pB );
+                ab.subVectors( pA, pB );
+                cb.cross( ab );
 
-					normals[ i + 6 ] = cb.x;
-					normals[ i + 7 ] = cb.y;
-					normals[ i + 8 ] = cb.z;
+                normals[ i     ] = cb.x;
+                normals[ i + 1 ] = cb.y;
+                normals[ i + 2 ] = cb.z;
 
-				}
+                normals[ i + 3 ] = cb.x;
+                normals[ i + 4 ] = cb.y;
+                normals[ i + 5 ] = cb.z;
 
-			}
+                normals[ i + 6 ] = cb.x;
+                normals[ i + 7 ] = cb.y;
+                normals[ i + 8 ] = cb.z;
 
-			this.normalizeNormals();
+            }
 
-			this.normalsNeedUpdate = true;
+        }
 
-		}
+        this.normalizeNormals();
+
+        this.normalsNeedUpdate = true;
 
 	},
 


### PR DESCRIPTION
This is a suggestion for a slightly tidier version of `BufferGeometry.computeVertexNormals()`. Main points:
1. Remove 140 line `if` statement with a short check for `position` attribute at the start of the method
2. Adds missing `normal` attribute using `addAttribute()` with a true `THREE.BufferAttribute` in lieu of a manual attribute addition.
3. Checks for attributes using `getAttribute()` rather than manually checking the attributes property.

I haven't altered the actual computation at all, purely a cosmetic change - unfortunately the diff looks awful due to the if statement shift :(
