### PR TITLE
Added event for start gizmo drag

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -568,6 +568,7 @@
 		var _plane = "XY";
 
 		var changeEvent = { type: "change" };
+		var clickEvent = { type: "click" };
 		var objectChangeEvent = { type: "objectChange" };
 
 		var ray = new THREE.Raycaster();
@@ -757,6 +758,8 @@
 				var intersect = intersectObjects( pointer, scope.gizmo[_mode].pickers.children );
 
 				if ( intersect ) {
+
+					scope.dispatchEvent( clickEvent );
 
 					scope.axis = intersect.object.name;
 


### PR DESCRIPTION
Provides an event in TransformControls for when a gizmo is selected. This is necessary to cleanly prioritize selection of a gizmo over other models in the scene--for example when the gizmo is behind another model that would be selected by raycasting. The other solution would require including gizmo faces in the raycast objects array.
