### PR TITLE
Cleanups of trackball->orbit control changes

### DIFF
--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -63,13 +63,10 @@
 
 				controls.rotateSpeed = 5.0;
 				controls.zoomSpeed = 5;
-				controls.panSpeed = 2;
+				controls.keyPanSpeed = 10;
 
 				controls.noZoom = false;
 				controls.noPan = false;
-
-				controls.staticMoving = true;
-				controls.dynamicDampingFactor = 0.3;
 
 				scene = new THREE.Scene();
 
@@ -117,16 +114,12 @@
 				camera.updateProjectionMatrix();
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
-
-				controls.handleResize();
-
 			}
 
 			function animate() {
 
 				requestAnimationFrame( animate );
 
-				controls.update();
 				renderer.render( scene, camera );
 
 				stats.update();

--- a/examples/webgl_morphtargets_md2.html
+++ b/examples/webgl_morphtargets_md2.html
@@ -161,6 +161,7 @@
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
 				controls.target.set( 0, 50, 0 );
+				controls.update();
 
 				// GUI
 
@@ -340,7 +341,6 @@
 
 				var delta = clock.getDelta();
 
-				controls.update();
 				character.update( delta );
 
 				renderer.render( scene, camera );

--- a/examples/webgl_morphtargets_md2_control.html
+++ b/examples/webgl_morphtargets_md2_control.html
@@ -168,6 +168,7 @@
 
 				cameraControls = new THREE.OrbitControls( camera, renderer.domElement );
 				cameraControls.target.set( 0, 50, 0 );
+				cameraControls.noKeys = true;
 
 				// CHARACTER
 

--- a/examples/webgl_terrain_dynamic.html
+++ b/examples/webgl_terrain_dynamic.html
@@ -284,13 +284,10 @@
 
 				controls.rotateSpeed = 1.0;
 				controls.zoomSpeed = 1.2;
-				controls.panSpeed = 0.8;
+				controls.keyPanSpeed = 7.0;
 
 				controls.noZoom = false;
 				controls.noPan = false;
-
-				controls.staticMoving = false;
-				controls.dynamicDampingFactor = 0.15;
 
 				controls.keys = [ 65, 83, 68 ];
 


### PR DESCRIPTION
From comments on pull request 5156,
https://github.com/mrdoob/three.js/pull/5156, a few changes are worth
doing.

> TrackballControls has properties that OrbitControls does not, so those
> need to be changed in this PR, too.

Good point, I forgot to check. webgl_terrain_dynamic.html and
webgl_loader_vrml.html indeed have these, the others do not. I've fixed
and will make a separate PR.

> Also, for static scenes, OrbitControls does not require an animation
> loop. (You just have to make sure render() is called after a texture is
> loaded.)

I'm not entirely following (events are a weak spot for me), but noticed
controls.update() and controls.handleResize(); calls that appears to not
be necessary in webgl_loader_vrml.html and webgl_morphtargets_md2.html
render() loops but could simply be moved to after creation of the
controls.

The webgl_morphtargets_md2_control.html example needs to have an
additional line of code, otherwise arrow keys affect movement and the
camera position:

cameraControls.noKeys = true;
