### PR TITLE
trackball -> orbit fixes

### DIFF
--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -34,7 +34,7 @@
 
 		<script src="../build/three.min.js"></script>
 
-		<script src="js/controls/TrackballControls.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/loaders/VRMLLoader.js"></script>
 
@@ -59,17 +59,14 @@
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.01, 1e10 );
 				camera.position.z = 6;
 
-				controls = new THREE.TrackballControls( camera );
+				controls = new THREE.OrbitControls( camera );
 
 				controls.rotateSpeed = 5.0;
 				controls.zoomSpeed = 5;
-				controls.panSpeed = 2;
+				controls.keyPanSpeed = 10;
 
 				controls.noZoom = false;
 				controls.noPan = false;
-
-				controls.staticMoving = true;
-				controls.dynamicDampingFactor = 0.3;
 
 				scene = new THREE.Scene();
 
@@ -117,16 +114,12 @@
 				camera.updateProjectionMatrix();
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
-
-				controls.handleResize();
-
 			}
 
 			function animate() {
 
 				requestAnimationFrame( animate );
 
-				controls.update();
 				renderer.render( scene, camera );
 
 				stats.update();

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -60,7 +60,7 @@
 
 	<script src="../build/three.min.js"></script>
 
-	<script src="js/controls/TrackballControls.js"></script>
+	<script src="js/controls/OrbitControls.js"></script>
 
 	<script src="js/shaders/CopyShader.js"></script>
 	<script src="js/shaders/FXAAShader.js"></script>
@@ -174,7 +174,7 @@
 
 			// CONTROLS
 
-			controls = new THREE.TrackballControls( camera, renderer.domElement );
+			controls = new THREE.OrbitControls( camera, renderer.domElement );
 
 			// STATS
 

--- a/examples/webgl_materials_lightmap.html
+++ b/examples/webgl_materials_lightmap.html
@@ -26,7 +26,7 @@
 	<body>
 		<script src="../build/three.min.js"></script>
 
-		<script src="js/controls/TrackballControls.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
@@ -96,7 +96,7 @@
 
 				// CONTROLS
 
-				controls = new THREE.TrackballControls( camera );
+				controls = new THREE.OrbitControls( camera );
 				controls.target.z = 150;
 
 				// LIGHTS

--- a/examples/webgl_morphtargets_md2.html
+++ b/examples/webgl_morphtargets_md2.html
@@ -46,7 +46,7 @@
 
 		<script src="../build/three.min.js"></script>
 
-		<script src="js/controls/TrackballControls.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src='js/MD2Character.js'></script>
 
@@ -159,8 +159,9 @@
 
 				// CONTROLS
 
-				controls = new THREE.TrackballControls( camera, renderer.domElement );
+				controls = new THREE.OrbitControls( camera, renderer.domElement );
 				controls.target.set( 0, 50, 0 );
+				controls.update();
 
 				// GUI
 
@@ -340,7 +341,6 @@
 
 				var delta = clock.getDelta();
 
-				controls.update();
 				character.update( delta );
 
 				renderer.render( scene, camera );

--- a/examples/webgl_morphtargets_md2_control.html
+++ b/examples/webgl_morphtargets_md2_control.html
@@ -46,7 +46,7 @@
 
 		<script src="../build/three.min.js"></script>
 
-		<script src="js/controls/TrackballControls.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src='js/MD2CharacterComplex.js'></script>
 
@@ -166,8 +166,9 @@
 
 				// CONTROLS
 
-				cameraControls = new THREE.TrackballControls( camera, renderer.domElement );
+				cameraControls = new THREE.OrbitControls( camera, renderer.domElement );
 				cameraControls.target.set( 0, 50, 0 );
+				cameraControls.noKeys = true;
 
 				// CHARACTER
 

--- a/examples/webgl_terrain_dynamic.html
+++ b/examples/webgl_terrain_dynamic.html
@@ -56,7 +56,7 @@
 
 		<script src="../build/three.min.js"></script>
 
-		<script src="js/controls/TrackballControls.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/shaders/BleachBypassShader.js"></script>
 		<script src="js/shaders/ConvolutionShader.js"></script>
@@ -279,18 +279,15 @@
 				camera = new THREE.PerspectiveCamera( 40, SCREEN_WIDTH / SCREEN_HEIGHT, 2, 4000 );
 				camera.position.set( -1200, 800, 1200 );
 
-				controls = new THREE.TrackballControls( camera );
+				controls = new THREE.OrbitControls( camera );
 				controls.target.set( 0, 0, 0 );
 
 				controls.rotateSpeed = 1.0;
 				controls.zoomSpeed = 1.2;
-				controls.panSpeed = 0.8;
+				controls.keyPanSpeed = 7.0;
 
 				controls.noZoom = false;
 				controls.noPan = false;
-
-				controls.staticMoving = false;
-				controls.dynamicDampingFactor = 0.15;
 
 				controls.keys = [ 65, 83, 68 ];
 


### PR DESCRIPTION
(I hope I'm doing this correctly - it's a bit of a nightmare dealing with Github and knowing what it really wants, if you don't do this every week.)

From comments on pull request 5156,
https://github.com/mrdoob/three.js/pull/5156, a few changes are worth
doing.

> TrackballControls has properties that OrbitControls does not, so those
> need to be changed in this PR, too.

Good point, I forgot to check. webgl_terrain_dynamic.html and
webgl_loader_vrml.html indeed have these, the others do not. I've fixed
and will make a separate PR.

> Also, for static scenes, OrbitControls does not require an animation
> loop. (You just have to make sure render() is called after a texture is
> loaded.)

I'm not entirely following (events are a weak spot for me), but noticed
controls.update() and controls.handleResize(); calls that appears to not
be necessary in webgl_loader_vrml.html and webgl_morphtargets_md2.html
render() loops but could simply be moved to after creation of the
controls.

The webgl_morphtargets_md2_control.html example needs to have an
additional line of code, otherwise arrow keys affect movement and the
camera position:

cameraControls.noKeys = true;
