### PR TITLE
Vertex Editing

### DIFF
--- a/editor/css/dark.css
+++ b/editor/css/dark.css
@@ -128,8 +128,8 @@ input.Number {
 
 	#menubar .menu {
 		float: left;
-		width: 50px;
 		cursor: pointer;
+		position: relative;
 	}
 
 		#menubar .menu .title {
@@ -144,6 +144,8 @@ input.Number {
 			background-color: #111;
 			width: 140px;
 			border-top: solid 1px #1D1D1D;
+			position: absolute;
+			top: 33px;
 		}
 
 		#menubar .menu:hover .options {

--- a/editor/css/light.css
+++ b/editor/css/light.css
@@ -102,8 +102,8 @@ input.Number {
 
 	#menubar .menu {
 		float: left;
-		width: 50px;
 		cursor: pointer;
+		position: relative;
 	}
 
 		#menubar .menu .title {
@@ -117,6 +117,8 @@ input.Number {
 			padding: 5px 0px;
 			background: #eee;
 			width: 140px;
+			position: absolute;
+			top: 33px;
 		}
 
 		#menubar .menu:hover .options {

--- a/editor/index.html
+++ b/editor/index.html
@@ -54,6 +54,7 @@
 		<script src="js/Menubar.js"></script>
 		<script src="js/Menubar.File.js"></script>
 		<script src="js/Menubar.Edit.js"></script>
+		<script src="js/Menubar.Geometry.js"></script>
 		<script src="js/Menubar.Add.js"></script>
 		<script src="js/Menubar.View.js"></script>
 		<script src="js/Menubar.Help.js"></script>

--- a/editor/js/Menubar.Geometry.js
+++ b/editor/js/Menubar.Geometry.js
@@ -1,0 +1,358 @@
+Menubar.Geometry = function ( editor ) {
+
+	var container = new UI.Panel();
+	container.setClass( 'menu' );
+
+	var title = new UI.Panel();
+	title.setClass( 'title' );
+	title.setTextContent( 'Geometry' );
+	container.add( title );
+
+	var options = new UI.Panel();
+	options.setClass( 'options' );
+	container.add( options );
+
+	// Convert to Geometry
+
+	var option = new UI.Panel();
+	option.setClass( 'option' );
+	option.setTextContent( 'Convert to Geometry' );
+	option.onClick( function () {
+
+		// convert to Geometry
+		
+		var object = editor.selected;
+
+		if ( object.geometry instanceof THREE.Geometry ) {
+
+			if ( object.parent === undefined ) return; // avoid flattening the camera or scene
+
+			if ( confirm( 'Convert ' + object.name + ' to Geometry?' ) === false ) return;
+
+			var original = object.geometry;
+			
+			var geometry = new THREE.Geometry();
+
+			geometry.name = original.name;
+
+			geometry.vertices = original.vertices;
+			geometry.colors = original.colors;
+
+			geometry.faces =  original.faces;
+
+			geometry.faceVertexUvs =  original.faceVertexUvs;
+
+			geometry.morphTargets =  original.morphTargets;
+			geometry.morphColors =  original.morphColors;
+			geometry.morphNormals =  original.morphNormals;
+
+			geometry.skinWeights = original.skinWeights;
+			geometry.skinIndices = original.skinIndices;
+
+			geometry.lineDistances = original.lineDistances;
+
+			geometry.boundingBox = original.boundingBox;
+			geometry.boundingSphere = original.boundingSphere;
+
+			geometry.hasTangents = original.hasTangents;
+
+			geometry.dynamic = original.dynamic;
+			
+			editor.scene.traverse( function(obj) {
+				if ( obj.geometry === original ) {
+					obj.geometry = geometry;
+					editor.signals.objectChanged.dispatch( obj );
+				}
+			} );
+
+		}
+
+	} );
+	options.add( option );
+
+	// Convert to BufferGeometry
+
+	var option = new UI.Panel();
+	option.setClass( 'option' );
+	option.setTextContent( 'Convert to BufferGeometry' );
+	option.onClick( function () {
+
+		// convert to BufferGeometry
+		
+		var object = editor.selected;
+
+		if ( object.geometry instanceof THREE.Geometry ) {
+
+			if ( object.parent === undefined ) return; // avoid flattening the camera or scene
+
+			if ( confirm( 'Convert ' + object.name + ' to BufferGeometry?' ) === false ) return;
+
+			object.geometry = new THREE.BufferGeometry().fromGeometry( object.geometry );
+
+			editor.signals.objectChanged.dispatch( object );
+
+		}
+
+	} );
+	options.add( option );
+
+	// Flatten
+
+	var option = new UI.Panel();
+	option.setClass( 'option' );
+	option.setTextContent( 'Flatten' );
+	option.onClick( function () {
+
+		var object = editor.selected;
+
+		if ( object.parent === undefined ) return; // avoid flattening the camera or scene
+
+		if ( confirm( 'Flatten ' + object.name + '?' ) === false ) return;
+
+		var geometry = object.geometry.clone();
+		geometry.applyMatrix( object.matrix );
+
+		object.geometry = geometry;
+
+		object.position.set( 0, 0, 0 );
+		object.rotation.set( 0, 0, 0 );
+		object.scale.set( 1, 1, 1 );
+		
+		object.geometry.buffersNeedUpdate = true;
+		editor.signals.objectChanged.dispatch( object );
+
+	} );
+	options.add( option );
+
+	// Compute face normals
+
+	var option = new UI.Panel();
+	option.setClass( 'option' );
+	option.setTextContent( 'Compute Face Normals' );
+	option.onClick( function () {
+
+		var object = editor.selected;
+
+		if( object && object.geometry ) {
+			
+			var geometry = object.geometry;
+			var faces = geometry.faces;
+			
+			// remove vertex normals
+			
+			for ( var i = 0, l = faces.length; i < l; ++i ) {
+				faces[i].vertexNormals = [];
+			}
+			
+			geometry.computeFaceNormals();
+			geometry.normalsNeedUpdate = true;
+			
+			editor.signals.objectChanged.dispatch( object );
+		}
+	} );
+	options.add( option );
+
+	// Compute vertex normals
+
+	var option = new UI.Panel();
+	option.setClass( 'option' );
+	option.setTextContent( 'Compute Vertex Normals' );
+	option.onClick( function () {
+
+		var object = editor.selected;
+
+		if( object && object.geometry ) {
+			
+			var geometry = object.geometry;
+			
+			geometry.computeFaceNormals();
+			geometry.computeVertexNormals();
+			geometry.normalsNeedUpdate = true;
+			
+			editor.signals.objectChanged.dispatch( object );
+		}
+	} );
+	options.add( option );
+
+	//
+
+	options.add( new UI.HorizontalRule() );
+
+	// vertex edit
+
+	var option = new UI.Panel();
+	option.setClass( 'option' );
+	option.setTextContent( 'Toggle Vertex Edit' );
+	option.onClick( function () {
+
+		vertexEdit( editor.selected );
+
+	} );
+	options.add( option );
+
+	// events
+
+	// change geometry whenever a picker is changed
+
+	editor.signals.objectChanged.add( function( picker ) {
+
+		if ( !picker.editorData ) return;
+
+		if ( picker.editorData.vertex ) {
+
+			var vertex = picker.editorData.vertex;
+			var object = picker.editorData.object;
+
+			var inverse = (new THREE.Matrix4).getInverse( object.matrixWorld );
+
+			vertex.copy( picker.position );
+			vertex.applyMatrix4( inverse );
+
+			object.geometry.verticesNeedUpdate = true;
+			object.geometry.computeBoundingBox();
+			
+		}
+
+	} );
+
+	// update pickers whenever the object is changed
+
+	editor.signals.objectChanged.add( function( object ) {
+		
+		updatePickers( object );
+		
+	} );
+
+	// remove pickers on remove
+
+	editor.signals.objectRemoved.add( function( object ) {
+		
+		removePickers( object );
+		
+	} );
+
+	// scale pickers depending on camera distance
+	
+	editor.signals.cameraChanged.add( function( camera ) {
+
+		if( !camera ) return;
+
+		editor.sceneHelpers.traverse( function( object ) {
+
+			if ( object.editorData && object.editorData.scales ) {
+				
+				var factor = 0.01 * object.position.distanceTo( camera.position );
+				object.scale.set( factor, factor, factor );
+				
+			}
+		} );
+		
+	} );
+	
+	// functions
+	
+	// toggle vertex edit
+	
+	function vertexEdit( object ) {
+		
+		if ( !object ) return;
+		
+		var editorData = object.editorData = object.editorData || {};
+		
+		removePickers( object );
+
+		if ( editorData.vertexEdit ) {
+			
+			editorData.vertexEdit = false;
+			
+			return;
+		}
+		
+		if ( object.geometry instanceof THREE.Geometry ) {
+			
+			editorData.pickers = [];
+			
+			var geometry = object.geometry;
+			var vertices = geometry.vertices;
+			
+			for ( var i = 0, l = vertices.length; i < l; ++i ) {
+				
+				var vertex = vertices[i];
+				
+				var picker = new THREE.Mesh( new THREE.BoxGeometry(1, 1, 1), material );
+				
+				picker.editorData = {
+					helper: true,
+					selectFirst: true,
+					scales: true,
+					vertex: vertex,
+					object: object
+				};
+				
+				picker.material.depthTest = false;
+				picker.material.transparent = true;
+				picker.visible = true;
+				
+				editor.signals.objectAdded.dispatch( picker );
+				
+				editor.sceneHelpers.add( picker );
+				
+				editorData.pickers.push( picker );
+			}
+			
+			updatePickers( object );
+			
+			editorData.vertexEdit = true;
+			
+			editor.signals.cameraChanged.dispatch( editor.camera );
+		}
+	}
+	
+	// update pickers on object
+	
+	function updatePickers( object ) {
+		
+		if ( object.editorData && object.editorData.pickers ) {
+			
+			var pickers = object.editorData.pickers;
+			
+			for ( var i = 0, l = pickers.length; i < l; ++i ) {
+				
+				var picker = pickers[i];
+				
+				if ( picker.editorData.vertex ) {
+					
+					picker.position.copy( picker.editorData.vertex );
+					picker.position.applyMatrix4( picker.editorData.object.matrixWorld );
+				}
+			}
+			
+		}
+	}
+	
+	// remove pickers from object
+	
+	function removePickers( object ) {
+		
+		if ( object.editorData && object.editorData.pickers ) {
+				
+			var pickers = object.editorData.pickers;
+			
+			for ( var i = 0, l = pickers.length; i < l; ++i ) {
+				
+				editor.sceneHelpers.remove( pickers[i] );
+				editor.signals.objectRemoved.dispatch( pickers[i] );
+				
+			}
+			
+			object.editorData.pickers = [];
+		}
+	}
+	
+	// material
+	
+	var material = new THREE.MeshBasicMaterial( { color: 0xff9900 } );
+
+	return container;
+
+};

--- a/editor/js/Menubar.Geometry.js
+++ b/editor/js/Menubar.Geometry.js
@@ -42,7 +42,6 @@ Menubar.Geometry = function ( editor ) {
 
 			// TODO not supported
 			geometry.computeVertexNormals();
-			geometry.attributes.normal.needsUpdate = true;
 
 		}
 
@@ -73,7 +72,6 @@ Menubar.Geometry = function ( editor ) {
 		} else if ( geometry instanceof THREE.BufferGeometry ) {
 
 			geometry.computeVertexNormals();
-			geometry.attributes.normal.needsUpdate = true;
 
 		}
 

--- a/editor/js/Menubar.Geometry.js
+++ b/editor/js/Menubar.Geometry.js
@@ -19,18 +19,18 @@ Menubar.Geometry = function ( editor ) {
 	option.setTextContent( 'Convert to Geometry' );
 	option.onClick( function () {
 
-		// convert to Geometry
-		
+
+
 		var object = editor.selected;
 
 		if ( object.geometry instanceof THREE.Geometry ) {
 
-			if ( object.parent === undefined ) return; // avoid flattening the camera or scene
+			// convert BoxGeometry and similar to basic Geometry
 
 			if ( confirm( 'Convert ' + object.name + ' to Geometry?' ) === false ) return;
 
 			var original = object.geometry;
-			
+
 			var geometry = new THREE.Geometry();
 
 			geometry.name = original.name;
@@ -38,13 +38,13 @@ Menubar.Geometry = function ( editor ) {
 			geometry.vertices = original.vertices;
 			geometry.colors = original.colors;
 
-			geometry.faces =  original.faces;
+			geometry.faces = original.faces;
 
-			geometry.faceVertexUvs =  original.faceVertexUvs;
+			geometry.faceVertexUvs = original.faceVertexUvs;
 
-			geometry.morphTargets =  original.morphTargets;
-			geometry.morphColors =  original.morphColors;
-			geometry.morphNormals =  original.morphNormals;
+			geometry.morphTargets = original.morphTargets;
+			geometry.morphColors = original.morphColors;
+			geometry.morphNormals = original.morphNormals;
 
 			geometry.skinWeights = original.skinWeights;
 			geometry.skinIndices = original.skinIndices;
@@ -57,13 +57,22 @@ Menubar.Geometry = function ( editor ) {
 			geometry.hasTangents = original.hasTangents;
 
 			geometry.dynamic = original.dynamic;
-			
+
+			// replace in scene
 			editor.scene.traverse( function(obj) {
+
 				if ( obj.geometry === original ) {
+
 					obj.geometry = geometry;
 					editor.signals.objectChanged.dispatch( obj );
+
 				}
+
 			} );
+
+		} else if ( object.geometry instanceof THREE.BufferGeometry ) {
+
+			// TODO convert BufferGeometry to Geometry
 
 		}
 
@@ -78,7 +87,7 @@ Menubar.Geometry = function ( editor ) {
 	option.onClick( function () {
 
 		// convert to BufferGeometry
-		
+
 		var object = editor.selected;
 
 		if ( object.geometry instanceof THREE.Geometry ) {
@@ -87,39 +96,23 @@ Menubar.Geometry = function ( editor ) {
 
 			if ( confirm( 'Convert ' + object.name + ' to BufferGeometry?' ) === false ) return;
 
-			object.geometry = new THREE.BufferGeometry().fromGeometry( object.geometry );
+			var original = object.geometry;
 
-			editor.signals.objectChanged.dispatch( object );
+			var geometry = new THREE.BufferGeometry().fromGeometry( original );
+
+			// replace in scene
+			editor.scene.traverse( function(obj) {
+
+				if ( obj.geometry === original ) {
+
+					obj.geometry = geometry;
+					editor.signals.objectChanged.dispatch( obj );
+
+				}
+
+			} );
 
 		}
-
-	} );
-	options.add( option );
-
-	// Flatten
-
-	var option = new UI.Panel();
-	option.setClass( 'option' );
-	option.setTextContent( 'Flatten' );
-	option.onClick( function () {
-
-		var object = editor.selected;
-
-		if ( object.parent === undefined ) return; // avoid flattening the camera or scene
-
-		if ( confirm( 'Flatten ' + object.name + '?' ) === false ) return;
-
-		var geometry = object.geometry.clone();
-		geometry.applyMatrix( object.matrix );
-
-		object.geometry = geometry;
-
-		object.position.set( 0, 0, 0 );
-		object.rotation.set( 0, 0, 0 );
-		object.scale.set( 1, 1, 1 );
-		
-		object.geometry.buffersNeedUpdate = true;
-		editor.signals.objectChanged.dispatch( object );
 
 	} );
 	options.add( option );
@@ -133,22 +126,31 @@ Menubar.Geometry = function ( editor ) {
 
 		var object = editor.selected;
 
-		if( object && object.geometry ) {
-			
-			var geometry = object.geometry;
+		if ( !object ) return;
+
+		var geometry = object.geometry;
+
+		if ( geometry instanceof THREE.Geometry ) {
+
 			var faces = geometry.faces;
-			
+
 			// remove vertex normals
-			
+
 			for ( var i = 0, l = faces.length; i < l; ++i ) {
 				faces[i].vertexNormals = [];
 			}
-			
+
 			geometry.computeFaceNormals();
 			geometry.normalsNeedUpdate = true;
-			
-			editor.signals.objectChanged.dispatch( object );
+
+		} else if ( geometry instanceof THREE.BufferGeometry ) {
+
+			// TODO not supported
+
 		}
+
+		editor.signals.objectChanged.dispatch( object );
+
 	} );
 	options.add( option );
 
@@ -161,16 +163,25 @@ Menubar.Geometry = function ( editor ) {
 
 		var object = editor.selected;
 
-		if( object && object.geometry ) {
-			
-			var geometry = object.geometry;
-			
+		if ( !object ) return;
+
+		var geometry = object.geometry;
+
+		if ( geometry instanceof THREE.Geometry ) {
+
 			geometry.computeFaceNormals();
 			geometry.computeVertexNormals();
 			geometry.normalsNeedUpdate = true;
-			
-			editor.signals.objectChanged.dispatch( object );
+
+		} else if ( geometry instanceof THREE.BufferGeometry ) {
+
+			geometry.computeVertexNormals();
+			geometry.getAttribute( 'normal' ).needsUpdate = true;
+
 		}
+
+		editor.signals.objectChanged.dispatch( object );
+
 	} );
 	options.add( option );
 
@@ -192,166 +203,311 @@ Menubar.Geometry = function ( editor ) {
 
 	// events
 
-	// change geometry whenever a picker is changed
+	// update pickers whenever an object is changed
 
-	editor.signals.objectChanged.add( function( picker ) {
-
-		if ( !picker.editorData ) return;
-
-		if ( picker.editorData.vertex ) {
-
-			var vertex = picker.editorData.vertex;
-			var object = picker.editorData.object;
-
-			var inverse = (new THREE.Matrix4).getInverse( object.matrixWorld );
-
-			vertex.copy( picker.position );
-			vertex.applyMatrix4( inverse );
-
-			object.geometry.verticesNeedUpdate = true;
-			object.geometry.computeBoundingBox();
-			
-		}
-
-	} );
-
-	// update pickers whenever the object is changed
-
-	editor.signals.objectChanged.add( function( object ) {
-		
-		updatePickers( object );
-		
-	} );
+	editor.signals.objectChanged.add( updatePickers );
 
 	// remove pickers on remove
 
-	editor.signals.objectRemoved.add( function( object ) {
-		
+	editor.signals.objectRemoved.add( removePickers );
+
+	// change geometry whenever a picker is changed
+
+	editor.signals.objectChanged.add( applyPicker );
+
+	// scale helpers depending on camera distance
+
+	editor.signals.cameraChanged.add( scaleHelpers );
+
+	// functions
+
+	// toggle vertex edit
+
+	function vertexEdit( object ) {
+
+		if ( !object || !object.geometry ) return;
+
+		object.editorData = object.editorData || {};
+
 		removePickers( object );
-		
-	} );
 
-	// scale pickers depending on camera distance
-	
-	editor.signals.cameraChanged.add( function( camera ) {
+		if ( object.editorData.vertexEdit ) {
 
-		if( !camera ) return;
+			object.editorData.vertexEdit = false;
+			return;
+
+		}
+
+		if ( object.geometry instanceof THREE.Geometry ) {
+
+			vertexEditGeometry( object );
+
+		} else if ( object.geometry instanceof THREE.BufferGeometry ) {
+
+			vertexEditBufferGeometry( object );
+
+		}
+
+	}
+
+	function vertexEditGeometry( object ) {
+
+		var pickers = [];
+		var pickerMap = {};
+
+		var geometry = object.geometry;
+		var vertices = geometry.vertices;
+
+		for ( var i = 0, l = vertices.length; i < l; ++i ) {
+
+			var vertex = vertices[i];
+
+			var x = vertex.x;
+			var y = vertex.y;
+			var z = vertex.z;
+
+			var key = x + ',' + y + ',' + z;
+
+			if ( pickerMap[key] ) {
+
+				pickerMap[key].editorData.vertices.push( vertex );
+				continue;
+
+			}
+
+			var picker = addPicker( { vertices: [vertex], object: object } );
+
+			pickers.push( picker );
+			pickerMap[key] = picker;
+
+		}
+
+		object.editorData.pickers = pickers;
+		object.editorData.geometry = geometry;
+		object.editorData.vertexEdit = true;
+
+		updatePickers( object );
+
+		editor.signals.cameraChanged.dispatch( editor.camera );
+
+	}
+
+	function vertexEditBufferGeometry( object ) {
+
+		var pickerMap = {};
+		var pickers = [];
+
+		var geometry = object.geometry;
+		var positionBuffer = geometry.getAttribute( 'position' );
+
+		if ( !positionBuffer ) return;
+
+		var positionArray = positionBuffer.array;
+
+		for ( var i = 0, l = positionArray.length / 3; i < l; ++i ) {
+
+			var x = positionArray[ 3 * i ];
+			var y = positionArray[ 3 * i + 1 ];
+			var z = positionArray[ 3 * i + 2 ];
+
+			var key = x + ',' + y + ',' + z;
+
+			if ( pickerMap[key] ) {
+
+				pickerMap[key].editorData.indices.push( i );
+				continue;
+
+			}
+
+			var picker = addPicker( { indices: [i], object: object } );
+
+			pickers.push( picker );
+			pickerMap[key] = picker;
+
+		}
+
+		object.editorData.pickers = pickers;
+		object.editorData.geometry = geometry;
+		object.editorData.vertexEdit = true;
+
+		updatePickers( object );
+
+		editor.signals.cameraChanged.dispatch( editor.camera );
+
+	}
+
+	// apply picker to its geometry
+
+	function applyPicker( picker ) {
+
+		if ( !picker.editorData || !picker.editorData.vertexPicker ) return;
+
+		var object = picker.editorData.object;
+		var geometry = object.geometry;
+
+		var inverse = (new THREE.Matrix4).getInverse( object.matrixWorld );
+		var vertex = picker.position.clone().applyMatrix4( inverse );
+
+		if ( geometry instanceof THREE.Geometry ) {
+
+			var vertices = picker.editorData.vertices;
+
+			for ( var i = 0, l = vertices.length; i < l; ++i ) {
+
+				vertices[i].copy( vertex );
+
+			}
+
+			geometry.verticesNeedUpdate = true;
+
+		} else if ( geometry instanceof THREE.BufferGeometry ) {
+
+			var positionBuffer = object.geometry.getAttribute( 'position' );
+
+			if ( !positionBuffer ) return;
+
+			var positionArray = positionBuffer.array;
+
+			var indices = picker.editorData.indices;
+
+			for ( var i = 0, l = indices.length; i < l; ++i ) {
+
+				positionArray[ 3 * indices[i] ] = vertex.x;
+				positionArray[ 3 * indices[i] + 1 ] = vertex.y;
+				positionArray[ 3 * indices[i] + 2 ] = vertex.z;
+
+			}
+
+			positionBuffer.needsUpdate = true;
+
+		}
+
+		object.geometry.computeBoundingBox();
+
+	}
+
+	// update pickers on object
+
+	function updatePickers( object ) {
+
+		if ( object.editorData && object.editorData.pickers ) {
+
+			var pickers = object.editorData.pickers;
+
+			if( object.editorData.geometry !== object.geometry ) {
+
+				// object geometry has changed in the mean time, stop vertex editing
+				removePickers( object );
+				object.editorData.vertexEdit = false;
+
+				return;
+
+			}
+
+			if ( object.geometry instanceof THREE.Geometry ) {
+
+				for ( var i = 0, l = pickers.length; i < l; ++i ) {
+
+					var picker = pickers[i];
+
+					picker.position.copy( picker.editorData.vertices[0] );
+					picker.position.applyMatrix4( picker.editorData.object.matrixWorld );
+
+				}
+
+			} else if ( object.geometry instanceof THREE.BufferGeometry ) {
+
+				var positionBuffer = object.geometry.getAttribute( 'position' );
+
+				if ( !positionBuffer ) return;
+
+				var positionArray = positionBuffer.array;
+
+				for ( var i = 0, l = pickers.length; i < l; ++i ) {
+
+					var picker = pickers[i];
+					var index = picker.editorData.indices[0];
+
+					var x = positionArray[ 3 * index ];
+					var y = positionArray[ 3 * index + 1 ];
+					var z = positionArray[ 3 * index + 2 ];
+
+					picker.position.set( x, y, z );
+					picker.position.applyMatrix4( picker.editorData.object.matrixWorld );
+
+				}
+
+			}
+
+		}
+
+	}
+
+	// remove pickers from object
+
+	function removePickers( object ) {
+
+		if ( object.editorData && object.editorData.pickers ) {
+
+			var pickers = object.editorData.pickers;
+
+			for ( var i = 0, l = pickers.length; i < l; ++i ) {
+
+				editor.sceneHelpers.remove( pickers[i] );
+				editor.signals.objectRemoved.dispatch( pickers[i] );
+
+			}
+
+			object.editorData.pickers = null;
+		}
+	}
+
+	// add a picker to scene helpers
+
+	var addPicker = (function() {
+
+		var cube = new THREE.BoxGeometry(1, 1, 1);
+		var material = new THREE.MeshBasicMaterial( { color: 0xff9900 } );
+		material.depthTest = false;
+		material.transparent = true;
+
+		return function( editorData ) {
+
+			var picker = new THREE.Mesh( cube, material );
+
+			editorData.helper = true,
+			editorData.selectFirst = true,
+			editorData.scales = true;
+			editorData.vertexPicker = true;
+
+			picker.editorData = editorData;
+
+			editor.sceneHelpers.add( picker );
+			editor.signals.objectAdded.dispatch( picker );
+
+			return picker
+
+		}
+
+	})();
+
+	// scale helpers
+
+	function scaleHelpers( camera ) {
+
+		if ( !camera ) return;
 
 		editor.sceneHelpers.traverse( function( object ) {
 
 			if ( object.editorData && object.editorData.scales ) {
-				
-				var factor = 0.01 * object.position.distanceTo( camera.position );
+
+				var factor = 0.009 * object.position.distanceTo( camera.position );
 				object.scale.set( factor, factor, factor );
-				
+
 			}
 		} );
-		
-	} );
-	
-	// functions
-	
-	// toggle vertex edit
-	
-	function vertexEdit( object ) {
-		
-		if ( !object ) return;
-		
-		var editorData = object.editorData = object.editorData || {};
-		
-		removePickers( object );
 
-		if ( editorData.vertexEdit ) {
-			
-			editorData.vertexEdit = false;
-			
-			return;
-		}
-		
-		if ( object.geometry instanceof THREE.Geometry ) {
-			
-			editorData.pickers = [];
-			
-			var geometry = object.geometry;
-			var vertices = geometry.vertices;
-			
-			for ( var i = 0, l = vertices.length; i < l; ++i ) {
-				
-				var vertex = vertices[i];
-				
-				var picker = new THREE.Mesh( new THREE.BoxGeometry(1, 1, 1), material );
-				
-				picker.editorData = {
-					helper: true,
-					selectFirst: true,
-					scales: true,
-					vertex: vertex,
-					object: object
-				};
-				
-				picker.material.depthTest = false;
-				picker.material.transparent = true;
-				picker.visible = true;
-				
-				editor.signals.objectAdded.dispatch( picker );
-				
-				editor.sceneHelpers.add( picker );
-				
-				editorData.pickers.push( picker );
-			}
-			
-			updatePickers( object );
-			
-			editorData.vertexEdit = true;
-			
-			editor.signals.cameraChanged.dispatch( editor.camera );
-		}
 	}
-	
-	// update pickers on object
-	
-	function updatePickers( object ) {
-		
-		if ( object.editorData && object.editorData.pickers ) {
-			
-			var pickers = object.editorData.pickers;
-			
-			for ( var i = 0, l = pickers.length; i < l; ++i ) {
-				
-				var picker = pickers[i];
-				
-				if ( picker.editorData.vertex ) {
-					
-					picker.position.copy( picker.editorData.vertex );
-					picker.position.applyMatrix4( picker.editorData.object.matrixWorld );
-				}
-			}
-			
-		}
-	}
-	
-	// remove pickers from object
-	
-	function removePickers( object ) {
-		
-		if ( object.editorData && object.editorData.pickers ) {
-				
-			var pickers = object.editorData.pickers;
-			
-			for ( var i = 0, l = pickers.length; i < l; ++i ) {
-				
-				editor.sceneHelpers.remove( pickers[i] );
-				editor.signals.objectRemoved.dispatch( pickers[i] );
-				
-			}
-			
-			object.editorData.pickers = [];
-		}
-	}
-	
-	// material
-	
-	var material = new THREE.MeshBasicMaterial( { color: 0xff9900 } );
 
 	return container;
 

--- a/editor/js/Menubar.Geometry.js
+++ b/editor/js/Menubar.Geometry.js
@@ -253,7 +253,6 @@ Menubar.Geometry = function ( editor ) {
 	function vertexEditGeometry( object ) {
 
 		var pickers = [];
-		var pickerMap = {};
 
 		var geometry = object.geometry;
 		var vertices = geometry.vertices;
@@ -261,24 +260,26 @@ Menubar.Geometry = function ( editor ) {
 		for ( var i = 0, l = vertices.length; i < l; ++i ) {
 
 			var vertex = vertices[i];
+			var exists = false;
 
-			var x = vertex.x;
-			var y = vertex.y;
-			var z = vertex.z;
+			for ( var j = 0, l2 = pickers.length; j < l2; ++j ) {
 
-			var key = x + ',' + y + ',' + z;
+				if ( pickers[j].editorData.vertices[0].distanceTo( vertex ) < 0.0001 ) {
 
-			if ( pickerMap[key] ) {
+					pickers[j].editorData.vertices.push( vertex );
+					exists = true;
+					break;
 
-				pickerMap[key].editorData.vertices.push( vertex );
-				continue;
+				}
 
 			}
 
-			var picker = addPicker( { vertices: [vertex], object: object } );
+			if ( !exists ) {
 
-			pickers.push( picker );
-			pickerMap[key] = picker;
+				var picker = addPicker( { vertices: [vertex], object: object } );
+				pickers.push( picker );
+
+			}
 
 		}
 
@@ -294,7 +295,6 @@ Menubar.Geometry = function ( editor ) {
 
 	function vertexEditBufferGeometry( object ) {
 
-		var pickerMap = {};
 		var pickers = [];
 
 		var geometry = object.geometry;
@@ -309,20 +309,28 @@ Menubar.Geometry = function ( editor ) {
 			var x = positionArray[ 3 * i ];
 			var y = positionArray[ 3 * i + 1 ];
 			var z = positionArray[ 3 * i + 2 ];
+			var vertex = new THREE.Vector3( x, y, z );
 
-			var key = x + ',' + y + ',' + z;
+			var exists = false;
 
-			if ( pickerMap[key] ) {
+			for ( var j = 0, l2 = pickers.length; j < l2; ++j ) {
 
-				pickerMap[key].editorData.indices.push( i );
-				continue;
+				if ( pickers[j].editorData.vertex.distanceTo( vertex ) < 0.0001 ) {
+
+					pickers[j].editorData.indices.push( i );
+					exists = true;
+					break;
+
+				}
 
 			}
 
-			var picker = addPicker( { indices: [i], object: object } );
+			if ( !exists ) {
 
-			pickers.push( picker );
-			pickerMap[key] = picker;
+				var picker = addPicker( { indices: [i], vertex: vertex, object: object } );
+				pickers.push( picker );
+
+			}
 
 		}
 

--- a/editor/js/Menubar.js
+++ b/editor/js/Menubar.js
@@ -4,6 +4,7 @@ var Menubar = function ( editor ) {
 
 	container.add( new Menubar.File( editor ) );
 	container.add( new Menubar.Edit( editor ) );
+	container.add( new Menubar.Geometry( editor ) );
 	container.add( new Menubar.Add( editor ) );
 	container.add( new Menubar.View( editor ) );
 	container.add( new Menubar.Help( editor ) );

--- a/editor/js/Sidebar.Object3D.js
+++ b/editor/js/Sidebar.Object3D.js
@@ -275,7 +275,11 @@ Sidebar.Object3D = function ( editor ) {
 
 		if ( object !== null ) {
 
-			if ( object.parent !== undefined ) {
+			// never change parent for helpers
+
+			helper = object.editorData && object.editorData.helper;
+
+			if ( object.parent !== undefined && !helper ) {
 
 				var newParentId = parseInt( objectParent.getValue() );
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -133,12 +133,13 @@ var Viewport = function ( editor ) {
 
 					var other = intersects[i].object;
 
-					if(other.editorData && other.editorData.selectFirst ) {
+					if ( other.editorData && other.editorData.selectFirst ) {
 
 						object = other;
 						break;
 
 					}
+
 				}
 
 				if ( object.userData.object !== undefined ) {
@@ -210,7 +211,7 @@ var Viewport = function ( editor ) {
 				break;
 
 		}
-		
+
 		renderer.setClearColor( clearColor );
 
 		render();

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -30,6 +30,8 @@ var Viewport = function ( editor ) {
 	camera.position.fromArray( editor.config.getKey( 'camera' ).position );
 	camera.lookAt( new THREE.Vector3().fromArray( editor.config.getKey( 'camera' ).target ) );
 
+	editor.camera = camera;
+
 	//
 
 	var selectionBox = new THREE.BoxHelper();
@@ -124,6 +126,20 @@ var Viewport = function ( editor ) {
 			if ( intersects.length > 0 ) {
 
 				var object = intersects[ 0 ].object;
+
+				// priority selection, e.g. for geometry helpers
+
+				for( var i = 0, l = intersects.length; i < l; ++i ) {
+
+					var other = intersects[i].object;
+
+					if(other.editorData && other.editorData.selectFirst ) {
+
+						object = other;
+						break;
+
+					}
+				}
 
 				if ( object.userData.object !== undefined ) {
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -475,7 +475,7 @@ THREE.BufferGeometry.prototype = {
 
 			this.normalizeNormals();
 
-			this.normalsNeedUpdate = true;
+			this.attributes[ 'normal' ].needsUpdate = true;
 
 		}
 


### PR DESCRIPTION
Hi,
I just added simple vertex editing to the three.js editor, and I thought I might share it with you. This could be a starting point for more geometry functionality.

Demo: https://rawgit.com/morris/three.js/geometryEditor/editor/index.html

![preview](https://cloud.githubusercontent.com/assets/32837/3791650/45d5716e-1b4a-11e4-961b-2d7a6f8c416a.jpg)

Features a new Geometry menu with a few new options:
- toggle vertex edit on the selected object
- calculate face normals or vertex normals
- convert any geometry to a raw Geometry instance

Problems/Todo:
- currently only works with raw Geometry, not with BufferGeometry or BoxGeometry etc.
- if you modify a BoxGeometry or similar, you have to convert to Geometry manually, or otherwise the editor won't save the new vertex data
- the sidebar for the vertices is the same as for any Object3D; would probably be nicer to have a decicated sidebar for that

There's only a few tweaks I had to insert apart from the new Menubar.Geometry.js:
- made the menu have variable width so "Geometry" fits
- prevent adding the new picker objects into the scene graph when working with the sidebar
- exposed camera from the viewport as an editor property
- priority selection of pickers

This is my first attempt at a pull request, so any tips how i can do better would be great :)
