### PR TITLE
Fixed 'WebGLRenderer.clear' method's description

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -218,7 +218,7 @@
 
 		<h3>.clear( [page:Boolean color], [page:Boolean depth], [page:Boolean stencil] )</h3>
 		<div>Tells the renderer to clear its color, depth or stencil drawing buffer(s).</div>
-		<div>If no parameters are passed, no buffer will be cleared.</div>
+		<div>Arguments default to true.</div>
 
 		<h3>.addPostPlugin( plugin )</h3>
 		<div>Initialises the postprocessing plugin, and adds it to the renderPluginsPost array.</div>


### PR DESCRIPTION
WebGLRenderer's documentation incorrectly stated that if no parameters were passed to it, the 'clear' method will not clear any buffers. The default behaviour is in fact the opposite: if an argument is undefined, the corresponding buffer will be cleared. The document now correctly describes the default behaviour.
Source code of the method: https://github.com/mrdoob/three.js/blob/master/src/renderers/WebGLRenderer.js#L368
