### PR TITLE
tolerate geom without UVs in AssimpJSONLoader

### DIFF
--- a/examples/js/loaders/AssimpJSONLoader.js
+++ b/examples/js/loaders/AssimpJSONLoader.js
@@ -87,7 +87,7 @@ THREE.AssimpJSONLoader.prototype = {
 		// read texture coordinates - three.js attaches them to its faces
 		json.texturecoords = json.texturecoords || [];
 		for(i = 0, e = json.texturecoords.length; i < e; ++i) {
-
+			//note: does it really make sense to have this function def inside the for here? is it a closure?
 			function convertTextureCoords(in_uv, out_faces, out_vertex_uvs) {
 				var i, e, face, a, b, c;
 
@@ -104,7 +104,12 @@ THREE.AssimpJSONLoader.prototype = {
 				}
 			}
 
-			convertTextureCoords(json.texturecoords[i], geometry.faces, geometry.faceVertexUvs[i]);
+                        var uvs = geometry.faceVertexUvs[i];
+                        if (!uvs) {
+                            console.log("no uvs in: " + geometry + " at " + i);
+                        } else {
+			    convertTextureCoords(json.texturecoords[i], geometry.faces, geometry.faceVertexUvs[i]);
+                        }
 		}
 
 		// read normals - three.js also attaches them to its faces

--- a/examples/js/loaders/AssimpJSONLoader.js
+++ b/examples/js/loaders/AssimpJSONLoader.js
@@ -108,7 +108,7 @@ THREE.AssimpJSONLoader.prototype = {
                         if (!uvs) {
                             console.log("no uvs in: " + geometry + " at " + i);
                         } else {
-			    convertTextureCoords(json.texturecoords[i], geometry.faces, geometry.faceVertexUvs[i]);
+			    convertTextureCoords(json.texturecoords[i], geometry.faces, uvs);
                         }
 		}
 

--- a/examples/js/loaders/AssimpJSONLoader.js
+++ b/examples/js/loaders/AssimpJSONLoader.js
@@ -105,9 +105,7 @@ THREE.AssimpJSONLoader.prototype = {
 			}
 
 			var uvs = geometry.faceVertexUvs[i];
-			if (!uvs) {
-			    console.log("no uvs in: " + geometry + " at " + i);
-			} else {
+			if (uvs) {
 			    convertTextureCoords(json.texturecoords[i], geometry.faces, uvs);
 			}
 		}

--- a/examples/js/loaders/AssimpJSONLoader.js
+++ b/examples/js/loaders/AssimpJSONLoader.js
@@ -104,12 +104,12 @@ THREE.AssimpJSONLoader.prototype = {
 				}
 			}
 
-                        var uvs = geometry.faceVertexUvs[i];
-                        if (!uvs) {
-                            console.log("no uvs in: " + geometry + " at " + i);
-                        } else {
+			var uvs = geometry.faceVertexUvs[i];
+			if (!uvs) {
+			    console.log("no uvs in: " + geometry + " at " + i);
+			} else {
 			    convertTextureCoords(json.texturecoords[i], geometry.faces, uvs);
-                        }
+			}
 		}
 
 		// read normals - three.js also attaches them to its faces


### PR DESCRIPTION
just a quick hack now to get my test working - if something like this makes sense i can improve this as necessary.

@acgessler is the original author but apparently @anasAsh touched this part recently so here go pings..

my test is live at http://playsign.tklapp.com:8000/oulu3dlive/ - there's two blocks and with the latter b1_2 one i got this problem. with this fix/hack it shows ~ok. is converted from max-exported FBX. probably there is some bad junk geom or export prob so UVs are missing in some part. the json file in the source repo is https://github.com/antont/oulu3dlive/blob/master/models/b1_2/b1_2.assimp2json
