### PR TITLE
Fix Deferred Rendering Examples on Retina Displays

### DIFF
--- a/examples/js/renderers/WebGLDeferredRenderer.js
+++ b/examples/js/renderers/WebGLDeferredRenderer.js
@@ -31,7 +31,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	if ( this.renderer === undefined ) {
 
-		this.renderer = new THREE.WebGLRenderer( { antialias: false } );
+		this.renderer = new THREE.WebGLRenderer( { antialias: false, devicePixelRatio : devicePixelRatio } );
 		this.renderer.setSize( fullWidth, fullHeight );
 		this.renderer.setClearColor( 0x000000, 0 );
 

--- a/examples/js/renderers/WebGLDeferredRenderer.js
+++ b/examples/js/renderers/WebGLDeferredRenderer.js
@@ -7,13 +7,22 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	var _this = this;
 
-	var fullWidth = parameters.width !== undefined ? parameters.width : 800;
-	var fullHeight = parameters.height !== undefined ? parameters.height : 600;
+	var pixelWidth = parameters.width !== undefined ? parameters.width : 800;
+	var pixelHeight = parameters.height !== undefined ? parameters.height : 600;
 	var currentScale = parameters.scale !== undefined ? parameters.scale : 1;
+    
+	var devicePixelRatio = parameters.devicePixelRatio !== undefined
+		? parameters.devicePixelRatio
+			: self.devicePixelRatio !== undefined
+				? self.devicePixelRatio
+				: 1;
 
+	var fullWidth = pixelWidth * devicePixelRatio;
+	var fullHeight = pixelHeight * devicePixelRatio;
+	
 	var scaledWidth = Math.floor( currentScale * fullWidth );
 	var scaledHeight = Math.floor( currentScale * fullHeight );
-
+	
 	var brightness = parameters.brightness !== undefined ? parameters.brightness : 1;
 	var tonemapping = parameters.tonemapping !== undefined ? parameters.tonemapping : THREE.SimpleOperator;
 	var antialias = parameters.antialias !== undefined ? parameters.antialias : false;


### PR DESCRIPTION
At the moment all the deferred lighting examples are broken for Retina users - the rendered output is shrunk to the bottom left corner of the screen.

This seems to be because the WebGLRenderer now uses devicePixelRatio, whereas the WebGLDeferredRenderer is still working in virtual pixels. 

I have updated WebGLDeferredRenderer so that it passes the 'virtual' pixels to the instance of WebGLRenderer it's using, and then uses the number of real pixels internally. 

I dread to think the effect this will have on performance for people using retina displays but it looks pretty nice. It's configurable in the same way it's configurable for the standard WebGLRenderer, and passes any user configured devicePixelRatio parameter on.
