### PR TITLE
BufferGeometry: Clone attributes

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -100,6 +100,31 @@ THREE.BufferAttribute.prototype = {
 
 		return this;
 
+	},
+
+	clone: function () {
+
+		var attribute = new THREE.BufferAttribute( null, this.itemSize );
+
+		var types = [ Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array ];
+
+		var sourceArray = this.array;
+
+		for ( var i = 0, il = types.length; i < il; i ++ ) {
+
+			var type = types[ i ];
+
+			if ( sourceArray instanceof type ) {
+
+				attribute.array = new type( sourceArray );
+				break;
+
+			}
+
+		}
+
+		return attribute;
+
 	}
 
 };

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -929,34 +929,10 @@ THREE.BufferGeometry.prototype = {
 
 		var geometry = new THREE.BufferGeometry();
 
-		var types = [ Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array ];
-
 		for ( var attr in this.attributes ) {
 
 			var sourceAttr = this.attributes[ attr ];
-			var sourceArray = sourceAttr.array;
-
-			var attribute = {
-
-				itemSize: sourceAttr.itemSize,
-				array: null
-
-			};
-
-			for ( var i = 0, il = types.length; i < il; i ++ ) {
-
-				var type = types[ i ];
-
-				if ( sourceArray instanceof type ) {
-
-					attribute.array = new type( sourceArray );
-					break;
-
-				}
-
-			}
-
-			geometry.attributes[ attr ] = attribute;
+			geometry.addAttribute( attr, sourceAttr.clone() );
 
 		}
 


### PR DESCRIPTION
Introduce BufferAttribute.clone().

Cloned attribute generated in BufferGeometry.clone() now remain instances of BufferAttribute. Previously, they were recreated as simple Object.

Make sure to go through BufferGeometry addAttribute() machinery when cloning the attributes.
