### PR TITLE
BufferAttribute: Simplify cloning

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -104,26 +104,7 @@ THREE.BufferAttribute.prototype = {
 
 	clone: function () {
 
-		var attribute = new THREE.BufferAttribute( null, this.itemSize );
-
-		var types = [ Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array ];
-
-		var sourceArray = this.array;
-
-		for ( var i = 0, il = types.length; i < il; i ++ ) {
-
-			var type = types[ i ];
-
-			if ( sourceArray instanceof type ) {
-
-				attribute.array = new type( sourceArray );
-				break;
-
-			}
-
-		}
-
-		return attribute;
+		return new THREE.BufferAttribute( new this.array.constructor( this.array ), this.itemSize );
 
 	}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -829,7 +829,6 @@ THREE.BufferGeometry.prototype = {
 
 		/* Create a copy of all attributes for reordering. */
 		var sortedAttributes = {};
-		var types = [ Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array ];
 		for ( var attr in this.attributes ) {
 			if ( attr == 'index' )
 				continue;

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -834,13 +834,7 @@ THREE.BufferGeometry.prototype = {
 			if ( attr == 'index' )
 				continue;
 			var sourceArray = this.attributes[ attr ].array;
-			for ( var i = 0, il = types.length; i < il; i ++ ) {
-				var type = types[ i ];
-				if ( sourceArray instanceof type ) {
-					sortedAttributes[ attr ] = new type( this.attributes[ attr ].itemSize * vertexCount );
-					break;
-				}
-			}
+			sortedAttributes[ attr ] = new sourceArray.constructor( this.attributes[ attr ].itemSize * vertexCount );
 		}
 
 		/* Move attribute positions based on the new index map */


### PR DESCRIPTION
Per comment on mrdoob/three.js#5262

Do the same trick when allocating the array in BufferGeometry.reorderBuffers.
