### PR TITLE
Update loader-assimp2json example

### DIFF
--- a/examples/js/loaders/AssimpJSONLoader.js
+++ b/examples/js/loaders/AssimpJSONLoader.js
@@ -31,7 +31,27 @@ THREE.AssimpJSONLoader.prototype = {
 		var loader = new THREE.XHRLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.load( url, function ( text ) {
-			var scene = scope.parse( JSON.parse( text ) );
+			var json = JSON.parse( text ), scene, metadata;
+
+			// Check __metadata__ meta header if present
+			// This header is used to disambiguate between
+			// different JSON-based file formats.
+			metadata = json.__metadata__;
+			if ( typeof metadata !== 'undefined' )
+			{
+				// Check if assimp2json at all
+				if ( metadata.format !== 'assimp2json' ) {
+					onError('Not an assimp2json scene');
+					return;
+				}
+				// Check major format version
+				else if ( metadata.version < 100 && metadata.version >= 200 ) {
+					onError('Unsupported assimp2json file format version');
+					return;
+				}
+			}
+
+			scene = scope.parse( json );
 			onLoad( scene );
 		} );
 	},

--- a/examples/models/assimp/interior/interior.assimp.json
+++ b/examples/models/assimp/interior/interior.assimp.json
@@ -1,5 +1,9 @@
 {
-	 "rootnode": {
+	 "__metadata__": {
+	 	 "format" : "assimp2json"
+	 	,"version": 100
+	}
+	,"rootnode": {
 		 "name": "<3DSRoot>"
 		,"transformation": [
 			 1

--- a/examples/models/assimp/jeep/jeep.assimp.json
+++ b/examples/models/assimp/jeep/jeep.assimp.json
@@ -1,5 +1,9 @@
 {
-	 "rootnode": {
+	 "__metadata__": {
+	 	 "format" : "assimp2json"
+	 	,"version": 100
+	}
+	,"rootnode": {
 		 "name": "<MS3DRoot>"
 		,"transformation": [
 			 1

--- a/examples/webgl_loader_assimp2json.html
+++ b/examples/webgl_loader_assimp2json.html
@@ -82,7 +82,7 @@
 
 			// Load jeep model using the AssimpJSONLoader
 			var loader1 = new THREE.AssimpJSONLoader();
-			loader1.load( 'models/assimp/jeep/jeep1.ms3d.json', function ( assimpjson ) {
+			loader1.load( 'models/assimp/jeep/jeep.assimp.json', function ( assimpjson ) {
 
 				assimpjson.scale.x = assimpjson.scale.y = assimpjson.scale.z = 0.2;
 				assimpjson.updateMatrix();
@@ -93,7 +93,7 @@
 
 			// load interior model
 			var loader2 = new THREE.AssimpJSONLoader();
-			loader2.load( 'models/assimp/interior/interior.3ds.json', function ( assimpjson ) {
+			loader2.load( 'models/assimp/interior/interior.assimp.json', function ( assimpjson ) {
 
 				assimpjson.scale.x = assimpjson.scale.y = assimpjson.scale.z = 1;
 				assimpjson.updateMatrix();


### PR DESCRIPTION
As mentioned in #3565, this updates the examples to reflect changes to assimp2json: i) the `assimp.json` file extension and ii) format metadata to disambiguate between different JSON formats.

The change to the loader is backwards compatible.
