### PR TITLE
export vertexgroups from blender

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -29,6 +29,9 @@ THREE.Geometry = function () {
 	this.skinWeights = [];
 	this.skinIndices = [];
 
+        this.vertexGroupsWeights = [];
+        this.vertexGroupsIndices = [];
+
 	this.lineDistances = [];
 
 	this.boundingBox = null;

--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -466,6 +466,24 @@ THREE.JSONLoader.prototype.parse = function ( json, texturePath ) {
 
 	};
 
+	function parseVertexGroups() {
+
+		if ( json.vertexGroupsWeights ) {
+
+                        geometry.vertexGroupsWeights = json.vertexGroupsWeights;
+
+		}
+
+		if ( json.vertexGroupsIndices ) {
+
+                        geometry.vertexGroupsIndices = json.vertexGroupsIndices;
+
+		}
+
+		geometry.vertexGroups = json.vertexGroups;
+
+	};
+
 	function parseMorphing( scale ) {
 
 		if ( json.morphTargets !== undefined ) {

--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -111,6 +111,7 @@ THREE.JSONLoader.prototype.parse = function ( json, texturePath ) {
 	parseModel( scale );
 
 	parseSkin();
+        parseVertexGroups();
 	parseMorphing( scale );
 
 	geometry.computeFaceNormals();

--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/__init__.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/__init__.py
@@ -22,12 +22,12 @@
 
 
 bl_info = {
-    "name": "three.js format grgr",
+    "name": "three.js format",
     "author": "mrdoob, kikko, alteredq, remoe, pxf, n3tfr34k, crobi",
     "version": (1, 5, 0),
     "blender": (2, 7, 0),
     "location": "File > Import-Export",
-    "description": "Import-Export three.js meshes grgr",
+    "description": "Import-Export three.js meshes",
     "warning": "",
     "wiki_url": "https://github.com/mrdoob/three.js/tree/master/utils/exporters/blender",
     "tracker_url": "https://github.com/mrdoob/three.js/issues",

--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/__init__.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/__init__.py
@@ -22,12 +22,12 @@
 
 
 bl_info = {
-    "name": "three.js format",
+    "name": "three.js format grgr",
     "author": "mrdoob, kikko, alteredq, remoe, pxf, n3tfr34k, crobi",
     "version": (1, 5, 0),
     "blender": (2, 7, 0),
     "location": "File > Import-Export",
-    "description": "Import-Export three.js meshes",
+    "description": "Import-Export three.js meshes grgr",
     "warning": "",
     "wiki_url": "https://github.com/mrdoob/three.js/tree/master/utils/exporters/blender",
     "tracker_url": "https://github.com/mrdoob/three.js/issues",
@@ -218,6 +218,7 @@ def save_settings_export(properties):
     "option_uv_coords"       : properties.option_uv_coords,
     "option_faces"           : properties.option_faces,
     "option_vertices"        : properties.option_vertices,
+    "option_vertex_groups"   : properties.option_vertex_groups,
 
     "option_skinning"        : properties.option_skinning,
     "option_bones"           : properties.option_bones,
@@ -242,6 +243,7 @@ def restore_settings_export(properties):
         settings = json.load(f)
 
     properties.option_vertices = settings.get("option_vertices", True)
+    properties.option_vertex_groups = settings.get("option_vertex_groups", False)
     properties.option_vertices_truncate = settings.get("option_vertices_truncate", False)
     properties.option_faces = settings.get("option_faces", True)
     properties.option_normals = settings.get("option_normals", True)
@@ -286,6 +288,7 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
     filename_ext = ".js"
 
     option_vertices = BoolProperty(name = "Vertices", description = "Export vertices", default = True)
+    option_vertex_groups = BoolProperty(name = "Vertex groups", description = "Export vertex groups", default = True)
     option_vertices_deltas = BoolProperty(name = "Deltas", description = "Delta vertices", default = False)
     option_vertices_truncate = BoolProperty(name = "Truncate", description = "Truncate vertices", default = False)
 
@@ -355,6 +358,10 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
         # row.enabled = self.properties.option_vertices
         # row.prop(self.properties, "option_vertices_deltas")
         row.prop(self.properties, "option_vertices_truncate")
+        layout.separator()
+
+        row = layout.row()
+        row.prop(self.properties, "option_vertex_groups")
         layout.separator()
 
         row = layout.row()

--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -829,7 +829,7 @@ def generate_vertex_groups_with_indices_and_weights(meshes, option_vertex_group)
     if not option_vertex_group:
         return "", "", ""
 
-    vertex_groups = [] 
+    vertex_groups_names = []
     indices = []
     weights = []
 
@@ -850,37 +850,19 @@ def generate_vertex_groups_with_indices_and_weights(meshes, option_vertex_group)
             continue
 
         object = bpy.data.objects[mesh_index]
-
-        for vertex_group in object.vertex_groups:
-            vertex_groups.append('"%s"' % vertex_group.name)
+        vertex_groups_names += ['"%s"' % vertex_group.name for vertex_group in object.vertex_groups]
 
         for vertex in mesh.vertices:
-
-            # sort vertex_groups by influence
-
-            vertex_group_array = []
-
+            vertex_groups = []
+            vertex_groups_weights = []
             for group in vertex.groups:
-                index = group.group
-                weight = group.weight
+                vertex_groups.append('%d' % group.group)
+                vertex_groups_weights.append('%g' % group.weight)
 
-                vertex_group_array.append( (index, weight) )
-                
-            vertex_group_array.sort(key = operator.itemgetter(1), reverse=True)
-            
-            # select first N vertex_groups
+            indices.append('[%s]' % ",".join(vertex_groups))
+            weights.append('[%s]' % ",".join(vertex_groups_weights))
 
-            for i in range(MAX_INFLUENCES):
-
-                if i < len(vertex_group_array):
-                    indices.append('%d' % vertex_group_array[i][0])
-                    weights.append('%g' % vertex_group_array[i][1])
-                else:
-                    indices.append('0')
-                    weights.append('0')
-    
-    
-    vertex_groups_string = ",".join(vertex_groups)
+    vertex_groups_string = ",".join(vertex_groups_names)
     indices_string = ",".join(indices)
     weights_string = ",".join(weights)
 

--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -853,14 +853,12 @@ def generate_vertex_groups_with_indices_and_weights(meshes, option_vertex_group)
         vertex_groups_names += ['"%s"' % vertex_group.name for vertex_group in object.vertex_groups]
 
         for vertex in mesh.vertices:
-            vertex_groups = []
-            vertex_groups_weights = []
-            for group in vertex.groups:
-                vertex_groups.append('%d' % group.group)
-                vertex_groups_weights.append('%g' % group.weight)
+            vertex_groups = [(group.group, group.weight) for group in vertex.groups]
 
-            indices.append('[%s]' % ",".join(vertex_groups))
-            weights.append('[%s]' % ",".join(vertex_groups_weights))
+            vertex_groups.sort(key = operator.itemgetter(1), reverse=True)
+
+            indices.append("[%s]" % ",".join("%d" % g[0] for g in vertex_groups))
+            weights.append("[%s]" % ",".join("%g" % g[1] for g in vertex_groups))
 
     vertex_groups_string = ",".join(vertex_groups_names)
     indices_string = ",".join(indices)


### PR DESCRIPTION
I extended the blender-exporter to export vertexgroups when option vertexgroups is checked.

You can view the mesh I needed it for here: 3motic.com.
