### PR TITLE
Remove redundant render call

### DIFF
--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -125,7 +125,6 @@
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
-				controls.addEventListener('change', render);
 				animate();
 
 			}


### PR DESCRIPTION
This removes a duplicate render call in the orbit controls example.
