### PR TITLE
Allow Helper colors to be specified in the constructor

### DIFF
--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -2,6 +2,7 @@
  * @author WestLangley / http://github.com/WestLangley
  * @author zz85 / http://github.com/zz85
  * @author bhouston / http://exocortex.com
+ * @author deignacio
  *
  * Creates an arrow for visualizing directions
  *
@@ -9,7 +10,7 @@
  *  dir - Vector3
  *  origin - Vector3
  *  length - Number
- *  color - color in hex value
+ *  hex - color in hex value
  *  headLength - Number
  *  headWidth - Number
  */
@@ -22,13 +23,13 @@ THREE.ArrowHelper = ( function () {
 	var coneGeometry = new THREE.CylinderGeometry( 0, 0.5, 1, 5, 1 );
 	coneGeometry.applyMatrix( new THREE.Matrix4().makeTranslation( 0, - 0.5, 0 ) );
 
-	return function ( dir, origin, length, color, headLength, headWidth ) {
+	return function ( dir, origin, length, hex, headLength, headWidth ) {
 
 		// dir is assumed to be normalized
 
 		THREE.Object3D.call( this );
 
-		if ( color === undefined ) color = 0xffff00;
+		var color = ( hex !== undefined ) ? hex : 0xffff00;
 		if ( length === undefined ) length = 1;
 		if ( headLength === undefined ) headLength = 0.2 * length;
 		if ( headWidth === undefined ) headWidth = 0.2 * headLength;

--- a/src/extras/helpers/AxisHelper.js
+++ b/src/extras/helpers/AxisHelper.js
@@ -1,9 +1,10 @@
 /**
  * @author sroucheray / http://sroucheray.org/
  * @author mrdoob / http://mrdoob.com/
+ * @author deignacio
  */
 
-THREE.AxisHelper = function ( size ) {
+THREE.AxisHelper = function ( size, hexes ) {
 
 	size = size || 1;
 
@@ -13,7 +14,7 @@ THREE.AxisHelper = function ( size ) {
 		0, 0, 0,  0, 0, size
 	] );
 
-	var colors = new Float32Array( [
+	var colors = new Float32Array( ( hexes !== undefined ) ? hexes : [
 		1, 0, 0,  1, 0.6, 0,
 		0, 1, 0,  0.6, 1, 0,
 		0, 0, 1,  0, 0.6, 1

--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -1,13 +1,16 @@
 /**
  * @author mrdoob / http://mrdoob.com/
+ * @author deignacio
  */
 
-THREE.BoxHelper = function ( object ) {
+THREE.BoxHelper = function ( object, hex ) {
+
+	var color = ( hex !== undefined ) ? hex : 0xffff00;
 
 	var geometry = new THREE.BufferGeometry();
 	geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( 72 ), 3 ) );
 
-	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: 0xffff00 } ), THREE.LinePieces );
+	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: color } ), THREE.LinePieces );
 
 	if ( object !== undefined ) {
 

--- a/src/extras/helpers/CameraHelper.js
+++ b/src/extras/helpers/CameraHelper.js
@@ -1,26 +1,36 @@
 /**
  * @author alteredq / http://alteredqualia.com/
+ * @author deignacio
  *
  *	- shows frustum, line of sight and up of the camera
  *	- suitable for fast updates
+ *	- colors can be overridden in the constructor
  * 	- based on frustum visualization in lightgl.js shadowmap example
  *		http://evanw.github.com/lightgl.js/tests/shadowmap.html
  */
 
-THREE.CameraHelper = function ( camera ) {
+THREE.CameraHelper = function ( camera, hexes ) {
+
+	var colors = {};
+	colors["material"] = ( hexes !== undefined && hexes["material"] === undefined ) hexes["material"] = 0xffffff;
+	colors["frustum"] = ( hexes !== undefined && hexes["frustum"] === undefined ) hexes["frustum"] = 0xffaa00;
+	colors["cone"] = ( hexes !== undefined && hexes["cone"] === undefined ) hexes["cone"] = 0xff0000;
+	colors["up"] = ( hexes !== undefined && hexes["up"] === undefined ) hexes["up"] = 0x00aaff;
+	colors["target"] = ( hexes !== undefined && hexes["target"] === undefined ) hexes["target"] = 0xffffff;
+	colors["cross"] = ( hexes !== undefined && hexes["cross"] === undefined ) hexes["cross"] = 0x333333;
 
 	var geometry = new THREE.Geometry();
-	var material = new THREE.LineBasicMaterial( { color: 0xffffff, vertexColors: THREE.FaceColors } );
+	var material = new THREE.LineBasicMaterial( { color: colors["material"], vertexColors: THREE.FaceColors } );
 
 	var pointMap = {};
 
 	// colors
 
-	var hexFrustum = 0xffaa00;
-	var hexCone = 0xff0000;
-	var hexUp = 0x00aaff;
-	var hexTarget = 0xffffff;
-	var hexCross = 0x333333;
+	var hexFrustum = colors["frustum"];
+	var hexCone = colors["cone"];
+	var hexUp = colors["up"];
+	var hexTarget = colors["target"];
+	var hexCross = colors["cross"];
 
 	// near
 

--- a/src/extras/helpers/GridHelper.js
+++ b/src/extras/helpers/GridHelper.js
@@ -2,13 +2,13 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.GridHelper = function ( size, step ) {
+THREE.GridHelper = function ( size, step, hex1, hex2 ) {
 
 	var geometry = new THREE.Geometry();
 	var material = new THREE.LineBasicMaterial( { vertexColors: THREE.VertexColors } );
 
-	this.color1 = new THREE.Color( 0x444444 );
-	this.color2 = new THREE.Color( 0x888888 );
+	this.color1 = new THREE.Color( ( hex1 !== undefined ) ? hex1 : 0x444444 );
+	this.color2 = new THREE.Color( ( hex2 !== undefined ) ? hex2 : 0x888888 );
 
 	for ( var i = - size; i <= size; i += step ) {
 


### PR DESCRIPTION
The Helper classes inconsistently allow the user to specify a color in their constructor.  These patches are made to allow colors to be provided in the Axis, Box, Camera, and Grid Helpers, and then change ArrowHelper to use the same code pattern.
