### PR TITLE
Add invert method to invert the face Vertex order

### DIFF
--- a/src/core/Face3.js
+++ b/src/core/Face3.js
@@ -25,6 +25,16 @@ THREE.Face3.prototype = {
 
 	constructor: THREE.Face3,
 
+	invert: function() {
+	
+	    var a = face.a;
+
+            face.a = face.c;
+
+            face.c = a;
+		
+	},
+
 	clone: function () {
 
 		var face = new THREE.Face3( this.a, this.b, this.c );


### PR DESCRIPTION
Sometimes the face vertex order is not counterclockwise resulting in the material to render on the backside of the face. To quickly solve this issue it would be useful to have an invert method in THREE.Face3. Hope you also see the use of such a method.
