### PR TITLE
fix typo in PointCloud docs r68

### DIFF
--- a/docs/api/objects/PointCloud.html
+++ b/docs/api/objects/PointCloud.html
@@ -34,9 +34,9 @@
 
 		<div>An instance of [page:Material], defining the object's appearance. Default is a [page:PointCloudMaterial] with randomised colour.</div>
 
-		<h3>.[page:Boolean frustrumCulled]</h3>
+		<h3>.[page:Boolean frustumCulled]</h3>
 		
-		<div>Specifies whether the particle system will be culled if it's outside the camera's frustum. By default this is set to false.</div>
+		<div>Specifies whether the particle system will be culled if it's outside the camera's frustum. By default this is set to true.</div>
 
 		<h3>.[page:boolean sortParticles]</h3>
 		<div>


### PR DESCRIPTION
In r68, the variable name "frustrumCulled" has changed to  "frustumCulled" and default value is now true.
