### PR TITLE
Fix collada keyframe example

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -7,6 +7,7 @@ THREE.ColladaLoader = function () {
 
 	var COLLADA = null;
 	var scene = null;
+	var rootObject = null;
 	var daeScene;
 
 	var readyCallbackFunc = null;
@@ -147,12 +148,15 @@ THREE.ColladaLoader = function () {
 
 		daeScene = parseScene();
 		scene = new THREE.Scene();
+		rootObject = new THREE.Object3D();
 
 		for ( var i = 0; i < daeScene.nodes.length; i ++ ) {
 
-			scene.add( createSceneGraph( daeScene.nodes[ i ] ) );
+			rootObject.add( createSceneGraph( daeScene.nodes[ i ] ) );
 
 		}
+
+		scene.add(rootObject);
 
 		// unit conversion
 		scene.scale.multiplyScalar( colladaUnit );
@@ -162,6 +166,7 @@ THREE.ColladaLoader = function () {
 		var result = {
 
 			scene: scene,
+			rootObject: rootObject,
 			morphs: morphs,
 			skins: skins,
 			animations: animData,

--- a/examples/webgl_loader_collada_keyframe.html
+++ b/examples/webgl_loader_collada_keyframe.html
@@ -60,7 +60,7 @@
 
 			loader.load( './models/collada/pump/pump.dae', function ( collada ) {
 
-				model = collada.scene;
+				model = collada.rootObject;
 				animations = collada.animations;
 				kfAnimationsLength = animations.length;
 				model.scale.x = model.scale.y = model.scale.z = 0.125; // 1/8 scale, modeled in cm


### PR DESCRIPTION
The collada keyframe example was broken, so I fixed it by adding a reference to the root Object3D in the collada loader
