### PR TITLE
Speed up for the raycaster. (With 20.000 faces: Firefox 27x, Chrome 6x)

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -393,40 +393,40 @@ THREE.BufferGeometry.prototype = {
 
 					for ( var i = start, il = start + count; i < il; i += 3 ) {
 
-						vA = index + indices[ i ];
-						vB = index + indices[ i + 1 ];
-						vC = index + indices[ i + 2 ];
+						vA = ( index + indices[ i ] ) * 3;
+						vB = ( index + indices[ i + 1 ] ) * 3;
+						vC = ( index + indices[ i + 2 ] ) * 3;
 
-						x = positions[ vA * 3 ];
-						y = positions[ vA * 3 + 1 ];
-						z = positions[ vA * 3 + 2 ];
+						x = positions[ vA ];
+						y = positions[ vA + 1 ];
+						z = positions[ vA + 2 ];
 						pA.set( x, y, z );
 
-						x = positions[ vB * 3 ];
-						y = positions[ vB * 3 + 1 ];
-						z = positions[ vB * 3 + 2 ];
+						x = positions[ vB ];
+						y = positions[ vB + 1 ];
+						z = positions[ vB + 2 ];
 						pB.set( x, y, z );
 
-						x = positions[ vC * 3 ];
-						y = positions[ vC * 3 + 1 ];
-						z = positions[ vC * 3 + 2 ];
+						x = positions[ vC ];
+						y = positions[ vC + 1 ];
+						z = positions[ vC + 2 ];
 						pC.set( x, y, z );
 
 						cb.subVectors( pC, pB );
 						ab.subVectors( pA, pB );
 						cb.cross( ab );
 
-						normals[ vA * 3     ] += cb.x;
-						normals[ vA * 3 + 1 ] += cb.y;
-						normals[ vA * 3 + 2 ] += cb.z;
+						normals[ vA     ] += cb.x;
+						normals[ vA + 1 ] += cb.y;
+						normals[ vA + 2 ] += cb.z;
 
-						normals[ vB * 3     ] += cb.x;
-						normals[ vB * 3 + 1 ] += cb.y;
-						normals[ vB * 3 + 2 ] += cb.z;
+						normals[ vB     ] += cb.x;
+						normals[ vB + 1 ] += cb.y;
+						normals[ vB + 2 ] += cb.z;
 
-						normals[ vC * 3     ] += cb.x;
-						normals[ vC * 3 + 1 ] += cb.y;
-						normals[ vC * 3 + 2 ] += cb.z;
+						normals[ vC     ] += cb.x;
+						normals[ vC + 1 ] += cb.y;
+						normals[ vC + 2 ] += cb.z;
 
 					}
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -329,13 +329,13 @@ THREE.Ray.prototype = {
 
 		return function ( box ) {
 
-			return this.intersectBox( box, v ) !== null;
+			return this.intersectBox( box, v, v, v ) !== null;
 
 		};
 
 	}(),
 
-	intersectBox: function ( box , optionalTarget ) {
+	intersectBox: function ( box , optionalTargetVisibleNearest, optionalTargetNear, optionalTargetFar ) {
 
 		// http://www.scratchapixel.com/lessons/3d-basic-lessons/lesson-7-intersecting-simple-shapes/ray-box-intersection/
 
@@ -399,7 +399,11 @@ THREE.Ray.prototype = {
 
 		if ( tmax < 0 ) return null;
 
-		return this.at( tmin >= 0 ? tmin : tmax, optionalTarget );
+		this.at( tmin, optionalTargetNear );
+		this.at( tmax, optionalTargetFar );
+
+        optionalTargetVisibleNearest = (tmin >= 0 ? optionalTargetNear : optionalTargetFar);
+		return optionalTargetVisibleNearest;
 
 	},
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -140,13 +140,13 @@ THREE.Mesh.prototype.raycast = ( function () {
 						b = ( index + indices[ i + 1 ] ) * 3;
 						c = ( index + indices[ i + 2 ] ) * 3;
 
-						// Test if the triangl eis near the ray.
-                        if (positions[ a     ] < minX && positions[ b     ] < minX && positions[ c     ] < minX) continue;
-                        if (positions[ a + 1 ] < minY && positions[ b + 1 ] < minY && positions[ c + 1 ] < minY) continue;
-                        if (positions[ a + 2 ] < minZ && positions[ b + 2 ] < minZ && positions[ c + 2 ] < minZ) continue;
-                        if (positions[ a     ] > maxX && positions[ b     ] > maxX && positions[ c     ] > maxX) continue;
-                        if (positions[ a + 1 ] > maxY && positions[ b + 1 ] > maxY && positions[ c + 1 ] > maxY) continue;
-                        if (positions[ a + 2 ] > maxZ && positions[ b + 2 ] > maxZ && positions[ c + 2 ] > maxZ) continue;
+						// Test if the triangle is near the ray.
+						if (positions[ a     ] < minX && positions[ b     ] < minX && positions[ c     ] < minX) continue;
+						if (positions[ a + 1 ] < minY && positions[ b + 1 ] < minY && positions[ c + 1 ] < minY) continue;
+						if (positions[ a + 2 ] < minZ && positions[ b + 2 ] < minZ && positions[ c + 2 ] < minZ) continue;
+						if (positions[ a     ] > maxX && positions[ b     ] > maxX && positions[ c     ] > maxX) continue;
+						if (positions[ a + 1 ] > maxY && positions[ b + 1 ] > maxY && positions[ c + 1 ] > maxY) continue;
+						if (positions[ a + 2 ] > maxZ && positions[ b + 2 ] > maxZ && positions[ c + 2 ] > maxZ) continue;
 
 						vA.set(
 							positions[ a ],
@@ -206,6 +206,14 @@ THREE.Mesh.prototype.raycast = ( function () {
 					a = i;
 					b = i + 1;
 					c = i + 2;
+
+					// Test if the triangle is near the ray.
+					if (positions[ j     ] < minX && positions[ j + 3 ] < minX && positions[ j + 6 ] < minX) continue;
+					if (positions[ j + 1 ] < minY && positions[ j + 4 ] < minY && positions[ j + 7 ] < minY) continue;
+					if (positions[ j + 2 ] < minZ && positions[ j + 5 ] < minZ && positions[ j + 8 ] < minZ) continue;
+					if (positions[ j     ] > maxX && positions[ j + 3 ] > maxX && positions[ j + 6 ] > maxX) continue;
+					if (positions[ j + 1 ] > maxY && positions[ j + 4 ] > maxY && positions[ j + 7 ] > maxY) continue;
+					if (positions[ j + 2 ] > maxZ && positions[ j + 5 ] > maxZ && positions[ j + 8 ] > maxZ) continue;
 
 					vA.set(
 						positions[ j ],


### PR DESCRIPTION
Speed up for the raycaster. 

I don't know if this is hte right place to start the discussion. But i tried to be backward compatible in the file Ray.js. So there are 3 OptionalTargets now.  I don't know if this is the right way to go.

In firefox i am 27 times faster with this new work flow.
Chrome handles the trinagle intersection better and is only 6 times faster.  This is with a mesh with 20.000 faces.  With smaler objects it is possible that there is no performance gain or even a performance loss by very small objects. 
