### PR TITLE
AutoReverse flag for THREE.ShapeGeometry options

### DIFF
--- a/src/extras/geometries/ShapeGeometry.js
+++ b/src/extras/geometries/ShapeGeometry.js
@@ -50,7 +50,8 @@ THREE.ShapeGeometry.prototype.addShape = function ( shape, options ) {
 
 	if ( options === undefined ) options = {};
 	var curveSegments = options.curveSegments !== undefined ? options.curveSegments : 12;
-
+	var autoReverse = options.autoReverse !== undefined ? options.autoReverse : true;
+	
 	var material = options.material;
 	var uvgen = options.UVGenerator === undefined ? THREE.ExtrudeGeometry.WorldUVGenerator : options.UVGenerator;
 
@@ -66,7 +67,7 @@ THREE.ShapeGeometry.prototype.addShape = function ( shape, options ) {
 
 	var reverse = ! THREE.Shape.Utils.isClockWise( vertices );
 
-	if ( reverse ) {
+	if ( reverse && autoReverse ) {
 
 		vertices = vertices.reverse();
 


### PR DESCRIPTION
When I create a `THREE.ShapeGeometry` from a list of points in clockwise order because I want the result to have the frontside of my resulting faces in the opposite direction the method automatically reverses the order of my points. It would be useful to have an autoReverse flag in the ShapeGeometry configuration/options to be able to control this behavior.
