### PR TITLE
Autodesk/cube data texture3

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5753,7 +5753,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 						if (isDataTexture) {
 
-							_gl.texImage2D( _gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glFormat, cubeImage[i].width, cubeImage[i].height, 0, glFormat, glType, cubeImage[i].data );
+							_gl.texImage2D( _gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glFormat, cubeImage[ i ].width, cubeImage[ i ].height, 0, glFormat, glType, cubeImage[ i ].data );
 
 						} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5742,7 +5742,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 				var image = cubeImage[ 0 ],
 				isImagePowerOfTwo = THREE.Math.isPowerOfTwo( image.width ) && THREE.Math.isPowerOfTwo( image.height ),
 				glFormat = paramThreeToGL( texture.format ),
-				glType = paramThreeToGL( texture.type );
+				glType = paramThreeToGL( texture.type),
+				isDataTexture = !!image.data;
 
 				setTextureParameters( _gl.TEXTURE_CUBE_MAP, texture, isImagePowerOfTwo );
 
@@ -5750,7 +5751,15 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( ! isCompressed ) {
 
-						_gl.texImage2D( _gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glFormat, glFormat, glType, cubeImage[ i ] );
+						if (isDataTexture) {
+
+							_gl.texImage2D( _gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glFormat, cubeImage[i].width, cubeImage[i].height, 0, glFormat, glType, cubeImage[i].data );
+
+						} else {
+
+							_gl.texImage2D( _gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glFormat, glFormat, glType, cubeImage[ i ] );
+
+						}
 
 					} else {
 


### PR DESCRIPTION
Checks if the image.data property is there, as is the case for DataTexture.image. Otherwise uses the regular code path. 

This is an example how to construct a data cube map -- opted to assign the underlying image instead of the DataTexture itself as face since that seemed more consistent with what CubeMapTextureLoader does, but either way can be done. 

```
    var x_neg = new THREE.DataTexture( pixelsSide, 2, 2, THREE.RGBAFormat );
    var x_pos = new THREE.DataTexture( pixelsSide, 2, 2, THREE.RGBAFormat );
    var y_neg = new THREE.DataTexture( pixelsBot, 2, 2, THREE.RGBAFormat );
    var y_pos = new THREE.DataTexture( pixelsTop, 2, 2, THREE.RGBAFormat );
    var z_neg = new THREE.DataTexture( pixelsSide, 2, 2, THREE.RGBAFormat );
    var z_pos = new THREE.DataTexture( pixelsSide, 2, 2, THREE.RGBAFormat );

    var texture = new THREE.Texture(null, new THREE.CubeReflectionMapping(),
                                    THREE.RepeatWrapping, THREE.RepeatWrapping,
                                    THREE.LinearFilter, THREE.LinearFilter,
                                    THREE.RGBAFormat);
    texture.image = [x_pos.image, x_neg.image, y_pos.image, y_neg.image, z_pos.image, z_neg.image];
    texture.needsUpdate = true;
```
