### PR TITLE
Patch to a way to a scripts with an Syntax highlighting

### DIFF
--- a/docs/page.js
+++ b/docs/page.js
@@ -62,18 +62,18 @@ var onDocumentLoad = function ( event ) {
 	// Syntax highlighting
 
 	var styleBase = document.createElement( 'link' );
-	styleBase.href = '../../prettify/prettify.css';
+	styleBase.href = pathname.substring( 0, pathname.indexOf( 'docs' ) + 4 ) + '/prettify/prettify.css';
 	styleBase.rel = 'stylesheet';
 
 	var styleCustom = document.createElement( 'link' );
-	styleCustom.href = '../../prettify/threejs.css';
+	styleCustom.href = pathname.substring( 0, pathname.indexOf( 'docs' ) + 4 ) + '/prettify/threejs.css';
 	styleCustom.rel = 'stylesheet';
 
 	document.head.appendChild( styleBase );
 	document.head.appendChild( styleCustom );
 
 	var prettify = document.createElement( 'script' );
-	prettify.src = '../../prettify/prettify.js';
+	prettify.src = pathname.substring( 0, pathname.indexOf( 'docs' ) + 4 ) + '/prettify/prettify.js';
 
 	prettify.onload = function () {
 


### PR DESCRIPTION
For some deeply sitting files the highlighting doesn't work as the way is incorrect. It is corrected. **Before** 

![image](https://cloud.githubusercontent.com/assets/3669935/4444962/513e39c8-47f5-11e4-82c3-35ba80a7e52e.png)

and **after**:

![image](https://cloud.githubusercontent.com/assets/3669935/4444966/583371f8-47f5-11e4-9b66-dbb5a763163c.png)
