### PR TITLE
adding check for uv[index] undefined in geometry merge. buffer geometry ...

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -202,7 +202,7 @@ THREE.OBJLoader.prototype = {
 
 		var face_pattern3 = /f( +(-?\d+)\/(-?\d+)\/(-?\d+))( +(-?\d+)\/(-?\d+)\/(-?\d+))( +(-?\d+)\/(-?\d+)\/(-?\d+))( +(-?\d+)\/(-?\d+)\/(-?\d+))?/;
 
-		// f vertex//normal vertex//normal vertex//normal ... 
+		// f vertex//normal vertex//normal vertex//normal ...
 
 		var face_pattern4 = /f( +(-?\d+)\/\/(-?\d+))( +(-?\d+)\/\/(-?\d+))( +(-?\d+)\/\/(-?\d+))( +(-?\d+)\/\/(-?\d+))?/
 
@@ -261,7 +261,7 @@ THREE.OBJLoader.prototype = {
 			} else if ( ( result = face_pattern2.exec( line ) ) !== null ) {
 
 				// ["f 1/1 2/2 3/3", " 1/1", "1", "1", " 2/2", "2", "2", " 3/3", "3", "3", undefined, undefined, undefined]
-				
+
 				addFace(
 					result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ],
 					result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ]
@@ -353,6 +353,9 @@ THREE.OBJLoader.prototype = {
 			}
 
 			var material = new THREE.MeshLambertMaterial();
+
+			buffergeometry.computeVertexNormals();
+
 			material.name = object.material.name;
 
 			var mesh = new THREE.Mesh( buffergeometry, material );

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -655,6 +655,12 @@ THREE.Geometry.prototype = {
 
 			for ( var j = 0, jl = uv.length; j < jl; j ++ ) {
 
+				if ( uv[ j ] === undefined ){
+
+					continue;
+
+				}
+
 				uvCopy.push( new THREE.Vector2( uv[ j ].x, uv[ j ].y ) );
 
 			}
@@ -801,7 +807,7 @@ THREE.Geometry.prototype = {
 						geometryGroup = { 'id': geometryGroupCounter++, 'faces3': [], 'materialIndex': materialIndex, 'vertices': 0, 'numMorphTargets': numMorphTargets, 'numMorphNormals': numMorphNormals };
 						this.geometryGroups[ groupHash ] = geometryGroup;
 						this.geometryGroupsList.push(geometryGroup);
-						
+
 					}
 
 				}


### PR DESCRIPTION
When using fromBufferGeometry, converting leaves objects liked [undefined, undefined, undefined] so this is a stopgap to allow merge until that is fixed.
There is also sometimes a problem with normals, that I haven't found an appropriate fix for. In another branch, I was fixing it by simply creating an empty attribute array for both UVs and Normals.
