### PR TITLE
Add property name translation for PLYLoader

### DIFF
--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -19,7 +19,11 @@
  */
 
 
-THREE.PLYLoader = function () {};
+THREE.PLYLoader = function ( propertyNameTranslation ) {
+
+	this.propertyNameTranslation = propertyNameTranslation === undefined? {} : propertyNameTranslation;
+	
+};
 
 THREE.PLYLoader.prototype = {
 
@@ -111,7 +115,7 @@ THREE.PLYLoader.prototype = {
 		var currentElement = undefined;
 		var lineType, lineValues;
 
-		function make_ply_element_property(propertValues) {
+		function make_ply_element_property(propertValues, propertyNameTranslation) {
 			
 			var property = Object();
 
@@ -127,6 +131,10 @@ THREE.PLYLoader.prototype = {
 
 				property.name = propertValues[1]
 
+			}
+			
+			if ( property.name in propertyNameTranslation ) {
+				property.name = propertyNameTranslation[property.name];
 			}
 
 			return property
@@ -174,7 +182,7 @@ THREE.PLYLoader.prototype = {
 				
 			case "property":
 
-				currentElement.properties.push( make_ply_element_property( lineValues ) );
+				currentElement.properties.push( make_ply_element_property( lineValues, this.propertyNameTranslation ) );
 
 				break;
 				

--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -3,19 +3,27 @@
  *
  * Description: A THREE loader for PLY ASCII files (known as the Polygon File Format or the Stanford Triangle Format).
  *
- * Currently only supports ASCII encoded files.
  *
  * Limitations: ASCII decoding assumes file is UTF-8.
  *
  * Usage:
  *	var loader = new THREE.PLYLoader();
- *	loader.addEventListener( 'load', function ( event ) {
+ *	loader.load('./models/ply/ascii/dolphins.ply', function (geometry) {
  *
- *		var geometry = event.content;
  *		scene.add( new THREE.Mesh( geometry ) );
  *
  *	} );
- *	loader.load( './models/ply/ascii/dolphins.ply' );
+ *
+ * If the PLY file uses non standard property names, they can be mapped while
+ * loading. For example, the following maps the properties
+ * “diffuse_(red|green|blue)” in the file to standard color names.
+ *
+ * loader.setPropertyNameMapping( {
+ *	diffuse_red: 'red',
+ *	diffuse_green: 'green',
+ *	diffuse_blue: 'blue'
+ * } );
+ * 
  */
 
 

--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -19,15 +19,21 @@
  */
 
 
-THREE.PLYLoader = function ( propertyNameTranslation ) {
+THREE.PLYLoader = function () {
 
-	this.propertyNameTranslation = propertyNameTranslation === undefined? {} : propertyNameTranslation;
+	this.propertyNameMapping = {};
 	
 };
 
 THREE.PLYLoader.prototype = {
 
 	constructor: THREE.PLYLoader,
+	
+	setPropertyNameMapping: function ( mapping ) {
+	
+		this.propertyNameMapping = mapping;
+	
+	},
 
 	load: function ( url, callback ) {
 
@@ -115,7 +121,7 @@ THREE.PLYLoader.prototype = {
 		var currentElement = undefined;
 		var lineType, lineValues;
 
-		function make_ply_element_property(propertValues, propertyNameTranslation) {
+		function make_ply_element_property(propertValues, propertyNameMapping) {
 			
 			var property = Object();
 
@@ -133,8 +139,8 @@ THREE.PLYLoader.prototype = {
 
 			}
 			
-			if ( property.name in propertyNameTranslation ) {
-				property.name = propertyNameTranslation[property.name];
+			if ( property.name in propertyNameMapping ) {
+				property.name = propertyNameMapping[property.name];
 			}
 
 			return property
@@ -182,7 +188,7 @@ THREE.PLYLoader.prototype = {
 				
 			case "property":
 
-				currentElement.properties.push( make_ply_element_property( lineValues, this.propertyNameTranslation ) );
+				currentElement.properties.push( make_ply_element_property( lineValues, this.propertyNameMapping ) );
 
 				break;
 				


### PR DESCRIPTION
The property names in PLY files are given as strings, some
implementations may use different names for common properties.
This commit adds a translation mechanism based on a map,
which is specified via the constructor.

Example with no translation:

``` javascript
  loader = new THREE.PLYLoader();
```

Example with translation:

``` javascript
  loader = new THREE.PLYLoader({
            diffuse_red: 'red',
            diffuse_green: 'green',
            diffuse_blue: 'blue'
        });
```
