### PR TITLE
Depthtextures

### DIFF
--- a/examples/webgl_rtt_depth.html
+++ b/examples/webgl_rtt_depth.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - render-to-texture</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #ffffff;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+				font-weight: bold;
+				background-color: #000000;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0px; width: 100%;
+				padding: 5px;
+			}
+
+			a {
+				color: #ffffff;
+			}
+
+		</style>
+	</head>
+	<body>
+
+		<div id="container"></div>
+		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> render-to-depth-texture webgl example</div>
+
+		<script src="../build/three.js"></script>
+
+		<script src="js/Detector.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script id="fragment_shader_screen" type="x-shader/x-fragment">
+
+			varying vec2 vUv;
+			uniform sampler2D tDepth;
+
+			void main() {
+				float depth = texture2D( tDepth, vUv).r;
+				depth = smoothstep(0.45, 0.55, depth);
+
+				gl_FragColor = vec4(depth, depth, depth, 1.0);
+			}
+
+		</script>
+
+		<script id="vertexShader" type="x-shader/x-vertex">
+
+			varying vec2 vUv;
+
+			void main() {
+
+				vUv = uv;
+				gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+			}
+
+		</script>
+
+		<script>
+
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var container, stats;
+
+			var cameraRTT, sceneRTT, sceneScreen, renderer, zmesh1, zmesh2;
+
+			var mouseX = 0, mouseY = 0;
+
+			var windowHalfX = window.innerWidth / 2;
+			var windowHalfY = window.innerHeight / 2;
+
+			var rtTexture, material, quad;
+
+			var delta = 0.01;
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.getElementById( 'container' );
+
+				cameraRTT = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, -10000, 10000 );
+				cameraRTT.position.z = 100;
+
+				//
+
+				sceneRTT = new THREE.Scene();
+				sceneScreen = new THREE.Scene();
+
+				depthTexture = new THREE.DepthTexture( window.innerWidth, window.innerHeight, true );
+				depthTexture.wrapS = THREE.ClampToEdgeWrapping;
+				depthTexture.wrapT = THREE.ClampToEdgeWrapping;
+				depthTexture.minFilter = THREE.LinearFilter;
+
+				rtTexture = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight,
+					{ minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBFormat, depth: depthTexture }
+				);
+
+				var materialScreen = new THREE.ShaderMaterial( {
+
+					uniforms: { tDepth: { type: "t", value: depthTexture } },
+					vertexShader: document.getElementById( 'vertexShader' ).textContent,
+					fragmentShader: document.getElementById( 'fragment_shader_screen' ).textContent,
+
+					depthWrite: false
+
+				} );
+
+				var plane = new THREE.PlaneBufferGeometry( window.innerWidth, window.innerHeight );
+
+				quad = new THREE.Mesh( plane, material );
+				quad.position.z = -100;
+				sceneRTT.add( quad );
+
+				var geometry = new THREE.TorusGeometry( 100, 25, 15, 30 );
+
+				var mat1 = new THREE.MeshPhongMaterial( { color: 0x555555, specular: 0xffaa00, shininess: 5 } );
+				var mat2 = new THREE.MeshPhongMaterial( { color: 0x550000, specular: 0xff2200, shininess: 5 } );
+
+				zmesh1 = new THREE.Mesh( geometry, mat1 );
+				zmesh1.position.set( 0, 0, 100 );
+				zmesh1.scale.set( 1.5, 1.5, 1.5 );
+				sceneRTT.add( zmesh1 );
+
+				zmesh2 = new THREE.Mesh( geometry, mat2 );
+				zmesh2.position.set( 0, 150, 100 );
+				zmesh2.scale.set( 0.75, 0.75, 0.75 );
+				sceneRTT.add( zmesh2 );
+
+				quad = new THREE.Mesh( plane, materialScreen );
+				quad.position.z = -100;
+				sceneScreen.add( quad );
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.autoClear = false;
+
+				container.appendChild( renderer.domElement );
+
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '0px';
+				container.appendChild( stats.domElement );
+			}
+
+			//
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
+				var time = Date.now() * 0.0015;
+
+				if ( zmesh1 && zmesh2 ) {
+
+					zmesh1.rotation.y = - time;
+					zmesh2.rotation.y = - time + Math.PI / 2;
+
+				}
+
+				renderer.clear();
+
+				// Render first scene into texture
+
+				renderer.render( sceneRTT, cameraRTT, rtTexture, true );
+
+				// Render full screen quad with generated texture
+
+				renderer.render( sceneScreen, cameraRTT );
+			}
+
+		</script>
+	</body>
+</html>

--- a/src/Three.js
+++ b/src/Three.js
@@ -262,6 +262,8 @@ THREE.LuminanceFormat = 1022;
 THREE.LuminanceAlphaFormat = 1023;
 // THREE.RGBEFormat handled as THREE.RGBAFormat in shaders
 THREE.RGBEFormat = THREE.RGBAFormat; //1024;
+THREE.DepthStencilFormat = 1026;
+THREE.DepthFormat = 1027;
 
 // DDS / ST3C Compressed texture formats
 

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -8,6 +8,7 @@
  In options, we can specify:
  * Texture parameters for an auto-generated target texture
  * depthBuffer/stencilBuffer: Booleans to indicate if we should generate these buffers
+ * depth: A target depth texture of type THREE.DepthTexture. This will override the depthBuffer/stencilBUffer settings
 */
 THREE.WebGLRenderTarget = function ( width, height, options ) {
 
@@ -27,8 +28,11 @@ THREE.WebGLRenderTarget = function ( width, height, options ) {
 
 	this.texture = new THREE.Texture( undefined, undefined, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy );
 
-	this.depthBuffer = options.depthBuffer !== undefined ? options.depthBuffer : true;
-	this.stencilBuffer = options.stencilBuffer !== undefined ? options.stencilBuffer : true;
+	this.depth = options.depth !== undefined ? options.depth : null;
+	if ( !this.depth ) {
+		this.depthBuffer = options.depthBuffer !== undefined ? options.depthBuffer : true;
+		this.stencilBuffer = options.stencilBuffer !== undefined ? options.stencilBuffer : true;
+	}
 
 };
 
@@ -66,6 +70,8 @@ THREE.WebGLRenderTarget.prototype = {
 		this.viewport.copy( source.viewport );
 
 		this.texture = source.texture.clone();
+		this.texture = this.texture.clone();
+		if (source.depth) this.depth = source.depth.clone();
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -206,6 +206,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 	extensions.get( 'OES_texture_float_linear' );
 	extensions.get( 'OES_texture_half_float' );
 	extensions.get( 'OES_texture_half_float_linear' );
+	extensions.get( 'WEBGL_depth_texture' );
 	extensions.get( 'OES_standard_derivatives' );
 	extensions.get( 'ANGLE_instanced_arrays' );
 
@@ -573,14 +574,14 @@ THREE.WebGLRenderer = function ( parameters ) {
 			for ( var i = 0; i < 6; i ++ ) {
 
 				_gl.deleteFramebuffer( renderTargetProperties.__webglFramebuffer[ i ] );
-				_gl.deleteRenderbuffer( renderTargetProperties.__webglDepthbuffer[ i ] );
+				if ( renderTargetProperties.__webglRenderbuffer[ i ] ) _gl.deleteRenderbuffer( renderTargetProperties.__webglRenderbuffer[ i ] );
 
 			}
 
 		} else {
 
 			_gl.deleteFramebuffer( renderTargetProperties.__webglFramebuffer );
-			_gl.deleteRenderbuffer( renderTargetProperties.__webglDepthbuffer );
+			if ( renderTargetProperties.__webglRenderbuffer ) _gl.deleteRenderbuffer( renderTargetProperties.__webglRenderbuffer );
 
 		}
 
@@ -3295,6 +3296,29 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
+	// Setup GL resources for the depth texture
+	function setupDepthTexture(depthTexture) {
+
+		var depthTextureProperties = properties.get( depthTexture );
+		var isPowerOfTwo = THREE.Math.isPowerOfTwo( depthTexture.width ) && THREE.Math.isPowerOfTwo( depthTexture.height );
+
+		depthTextureProperties.__webglTexture = _gl.createTexture();
+
+		_gl.bindTexture(_gl.TEXTURE_2D, depthTextureProperties.__webglTexture);
+		setTextureParameters(_gl.TEXTURE_2D, depthTexture, isPowerOfTwo);
+
+		if (depthTexture.hasStencil) {
+			_gl.texImage2D(_gl.TEXTURE_2D, 0, _gl.DEPTH_STENCIL, depthTexture.width, depthTexture.height, 0, _gl.DEPTH_STENCIL, extensions.get( 'WEBGL_depth_texture' ).UNSIGNED_INT_24_8_WEBGL, null);
+			_gl.framebufferTexture2D(_gl.FRAMEBUFFER, _gl.DEPTH_STENCIL_ATTACHMENT, _gl.TEXTURE_2D, depthTextureProperties.__webglTexture, 0);
+		}
+		else {
+			_gl.texImage2D(_gl.TEXTURE_2D, 0, _gl.DEPTH_COMPONENT, depthTexture.width, depthTexture.height, 0, _gl.DEPTH_COMPONENT, _gl.UNSIGNED_INT, null);
+			_gl.framebufferTexture2D(_gl.FRAMEBUFFER, _gl.DEPTH_ATTACHMENT, _gl.TEXTURE_2D, depthTextureProperties.__webglTexture, 0);
+		}
+
+		_gl.bindTexture(_gl.TEXTURE_2D, null);
+	}
+
 	// Set up GL resources for the render target
 	function setupRenderTarget( renderTarget ) {
 
@@ -3357,9 +3381,17 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		// Setup depth and stencil buffers
 
-		if ( renderTarget.depthBuffer ) {
+		if ( renderTarget.depth && extensions.get( 'WEBGL_depth_texture' ) ) {
 
-			setupDepthRenderbuffer( renderTarget );
+			// FIXME: Warning if WEBGL_depth_texture not available?
+			_gl.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer );
+			setupDepthTexture(renderTarget.depth);
+			_gl.bindFramebuffer(_gl.FRAMEBUFFER, null );
+
+		}
+		else if ( renderTarget.depthBuffer ) {
+
+			setupDepthRenderbuffer(renderTarget);
 
 		}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3297,26 +3297,31 @@ THREE.WebGLRenderer = function ( parameters ) {
 	}
 
 	// Setup GL resources for the depth texture
-	function setupDepthTexture(depthTexture) {
+	function setupDepthTexture( depthTexture ) {
 
 		var depthTextureProperties = properties.get( depthTexture );
 		var isPowerOfTwo = THREE.Math.isPowerOfTwo( depthTexture.width ) && THREE.Math.isPowerOfTwo( depthTexture.height );
 
 		depthTextureProperties.__webglTexture = _gl.createTexture();
 
-		_gl.bindTexture(_gl.TEXTURE_2D, depthTextureProperties.__webglTexture);
-		setTextureParameters(_gl.TEXTURE_2D, depthTexture, isPowerOfTwo);
+		_gl.bindTexture( _gl.TEXTURE_2D, depthTextureProperties.__webglTexture );
+		setTextureParameters( _gl.TEXTURE_2D, depthTexture, isPowerOfTwo );
 
-		if (depthTexture.hasStencil) {
-			_gl.texImage2D(_gl.TEXTURE_2D, 0, _gl.DEPTH_STENCIL, depthTexture.width, depthTexture.height, 0, _gl.DEPTH_STENCIL, extensions.get( 'WEBGL_depth_texture' ).UNSIGNED_INT_24_8_WEBGL, null);
-			_gl.framebufferTexture2D(_gl.FRAMEBUFFER, _gl.DEPTH_STENCIL_ATTACHMENT, _gl.TEXTURE_2D, depthTextureProperties.__webglTexture, 0);
+		if ( depthTexture.hasStencil ) {
+
+			_gl.texImage2D( _gl.TEXTURE_2D, 0, _gl.DEPTH_STENCIL, depthTexture.width, depthTexture.height, 0, _gl.DEPTH_STENCIL, extensions.get( 'WEBGL_depth_texture' ).UNSIGNED_INT_24_8_WEBGL, null );
+			_gl.framebufferTexture2D( _gl.FRAMEBUFFER, _gl.DEPTH_STENCIL_ATTACHMENT, _gl.TEXTURE_2D, depthTextureProperties.__webglTexture, 0 );
+
 		}
 		else {
-			_gl.texImage2D(_gl.TEXTURE_2D, 0, _gl.DEPTH_COMPONENT, depthTexture.width, depthTexture.height, 0, _gl.DEPTH_COMPONENT, _gl.UNSIGNED_INT, null);
-			_gl.framebufferTexture2D(_gl.FRAMEBUFFER, _gl.DEPTH_ATTACHMENT, _gl.TEXTURE_2D, depthTextureProperties.__webglTexture, 0);
+
+			_gl.texImage2D( _gl.TEXTURE_2D, 0, _gl.DEPTH_COMPONENT, depthTexture.width, depthTexture.height, 0, _gl.DEPTH_COMPONENT, _gl.UNSIGNED_INT, null );
+			_gl.framebufferTexture2D( _gl.FRAMEBUFFER, _gl.DEPTH_ATTACHMENT, _gl.TEXTURE_2D, depthTextureProperties.__webglTexture, 0 );
+
 		}
 
-		_gl.bindTexture(_gl.TEXTURE_2D, null);
+		_gl.bindTexture( _gl.TEXTURE_2D, null );
+
 	}
 
 	// Set up GL resources for the render target
@@ -3385,13 +3390,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			// FIXME: Warning if WEBGL_depth_texture not available?
 			_gl.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer );
-			setupDepthTexture(renderTarget.depth);
-			_gl.bindFramebuffer(_gl.FRAMEBUFFER, null );
+			setupDepthTexture( renderTarget.depth );
+			_gl.bindFramebuffer( _gl.FRAMEBUFFER, null );
 
 		}
 		else if ( renderTarget.depthBuffer ) {
 
-			setupDepthRenderbuffer(renderTarget);
+			setupDepthRenderbuffer( renderTarget );
 
 		}
 

--- a/src/textures/DepthTexture.js
+++ b/src/textures/DepthTexture.js
@@ -1,0 +1,31 @@
+/**
+ * @author Marius Kintel / https://github.com/kintel
+ */
+
+THREE.DepthTexture = function ( width, height, hasStencil ) {
+
+	var format = hasStencil ? THREE.DepthStencilFormat : THREE.DepthFormat;
+	var type = hasStencil ? THREE.UnsignedInt24_8Type : THREE.UnsignedIntType;
+
+	THREE.Texture.call( this, null, THREE.Texture.DEFAULT_MAPPING, THREE.ClampToEdgeWrapping, THREE.ClampToEdgeWrapping, THREE.NearestFilter, THREE.NearestFilter, format, type );
+
+	this.width = width;
+	this.height = height;
+	this.hasStencil = hasStencil;
+
+};
+
+THREE.DepthTexture.prototype = Object.create( THREE.Texture.prototype );
+
+THREE.DepthTexture.prototype.clone = function () {
+
+	var texture = new THREE.DepthTexture();
+
+	THREE.Texture.prototype.clone.call( this, texture );
+
+	texture.width = this.width;	
+	texture.height = this.height;
+
+	return texture;
+
+};

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -102,6 +102,7 @@
 	"src/textures/CompressedTexture.js",
 	"src/textures/DataTexture.js",
 	"src/textures/VideoTexture.js",
+	"src/textures/DepthTexture.js",
 	"src/objects/Group.js",
 	"src/objects/Points.js",
 	"src/objects/Line.js",


### PR DESCRIPTION
This adds support for depth textures to three.js, fixing issue #5308.
Depends on #7245

Usage:

```
var depthTexture = new THREE.DepthTexture(window.innerWidth, window.innerHeight, true); // True means attach a stencil buffer
var rtTexture = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, {
   <options>, depth: depthTexture } );
```

Note: This pull request was updated to not include sharing of resources as that's not yet properly supported in three.js.

TODO before merge:
- [ ] Consider not storing `DepthTexture.hasStencil`, add depth texture constants to `WebGLRenderer.paramThreeToGL` and look that up in `WebGLRenderer.setupDepthTexture`
- [ ] Documentation / usage
- [ ] More testing
  - [ ] Test using a rendered texture as a 'uvScaleMap'
  - [ ] Test mipmapping
  - [ ] Test rendering into cubemaps
- [x] An example: http://threejsworker.com/api/pullrequests/5402/examples/index.html#webgl_rtt_depth
