### PR TITLE
Fix the new compatibility issue in #5407

### DIFF
--- a/utils/build/build.py
+++ b/utils/build/build.py
@@ -42,23 +42,23 @@ def main(argv=None):
 		sourcemap = sourcemapping = sourcemapargs = ''
 
 	fd, path = tempfile.mkstemp()
-	tmp = open(path, 'w', encoding='utf-8')
+	tmp = open_file(path, 'w')
 	sources = []
 		
 	if args.amd:
 		tmp.write('( function ( root, factory ) {\n\n\tif ( typeof define === \'function\' && define.amd ) {\n\n\t\tdefine( [ \'exports\' ], factory );\n\n\t} else if ( typeof exports === \'object\' ) {\n\n\t\tfactory( exports );\n\n\t} else {\n\n\t\tfactory( root );\n\n\t}\n\n}( this, function ( exports ) {\n\n')
 
 	for include in args.include:
-		with open('includes/' + include + '.json','r', encoding='utf-8') as f:
+		with open_file('includes/' + include + '.json','r') as f:
 			files = json.load(f)
 		for filename in files:
 			tmp.write('// File:' + filename)
 			tmp.write('\n\n')
 			filename = '../../' + filename
 			sources.append(filename)
-			with open(filename, 'r', encoding='utf-8') as f:
+			with open_file(filename, 'r') as f:
 				if filename.endswith(".glsl"):
-					tmp.write('THREE.ShaderChunk[ \'' + os.path.splitext(os.path.basename(filename))[0] + '\'] = "')
+					tmp.write('THREE.ShaderChunk[ \'' + os.path.splitext(os.path.basename(filename))[0] + '\'] = "') 
 					tmp.write(f.read().replace('\n','\\n'))
 					tmp.write('";\n\n')
 				else:
@@ -79,7 +79,7 @@ def main(argv=None):
 	else:
 		backup = ''
 		if os.path.exists(output):
-			with open(output, 'r', encoding='utf-8') as f: backup = f.read()
+			with open_file(output, 'r') as f: backup = f.read()
 			os.remove(output)
 
 		externs = ' --externs '.join(args.externs)
@@ -90,14 +90,22 @@ def main(argv=None):
 		# header
 
 		if os.path.exists(output):
-			with open(output, 'r', encoding='utf-8') as f: text = f.read()
-			with open(output, 'w', encoding='utf-8') as f: f.write('// threejs.org/license\n' + text + sourcemapping)
+			with open_file(output, 'r') as f: text = f.read()
+			with open_file(output, 'w') as f: f.write('// threejs.org/license\n' + text + sourcemapping)
 		else:
 			print("Minification with Closure compiler failed. Check your Java runtime version.")
-			with open(output, 'w', encoding='utf-8') as f: f.write(backup)
+			with open_file(output, 'w') as f: f.write(backup)
 
 	os.close(fd)
 	os.remove(path)
+
+
+def open_file(name, mode):
+
+	if sys.version_info < (3, 0):
+		return open(name, mode)
+	else:
+		return open(name, mode, encoding="utf-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I had fixed an encoding error in pull request #5407. But it has brought a new compatibility issue. The open BIF in python 2 won't accept the `encoding` parameter and it will occur a `TypeError`. So I create a function to encapsulate the incompatibility.
