### PR TITLE
device orientation controls desktop compatibility

### DIFF
--- a/examples/js/controls/DeviceOrientationControls.js
+++ b/examples/js/controls/DeviceOrientationControls.js
@@ -15,7 +15,7 @@ THREE.DeviceOrientationControls = function ( object ) {
 
 	this.freeze = true;
 
-	this.deviceOrientation = {};
+	this.deviceOrientation = { beta: 90 };
 
 	this.screenOrientation = 0;
 


### PR DESCRIPTION
The history behind this is as follows: they have live project that they want to use DeviceOrientationControls with. So I replace:

``` javascript
scene.add (mainCamera);
```

with:

``` javascript
var mainCameraOrientation = new THREE.Object3D ();
mainCameraOrientation.add (mainCamera);
scene.add (mainCameraOrientation);
...
orientationControls = new THREE.DeviceOrientationControls (mainCameraOrientation);
...
// in the loop
orientationControls.update();
```

This works as expected on iOS v8, _but_ on desktop this rotates everything by 90° around X.

So this is what I had to do to make it work in both cases.
