### PR TITLE
Proposal: new 'world' methods

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -33,6 +33,22 @@ THREE.Camera.prototype.lookAt = function () {
 
 }();
 
+THREE.Camera.prototype.worldDirection = function () {
+
+	var quaternion = new THREE.Quaternion();
+
+	return function ( optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Vector3();
+
+		this.worldQuaternion( quaternion );
+
+		return result.set( 0, 0, - 1 ).applyQuaternion( quaternion );
+
+	}
+
+}();
+
 THREE.Camera.prototype.clone = function ( camera ) {
 
 	if ( camera === undefined ) camera = new THREE.Camera();

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -486,6 +486,86 @@ THREE.Object3D.prototype = {
 
 	},
 
+	worldPosition: function ( optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Vector3();
+
+		this.updateMatrixWorld( true );
+
+		return result.setFromMatrixPosition( this.matrixWorld );
+
+	},
+
+	worldQuaternion: function () {
+
+		var position = new THREE.Vector3();
+		var scale = new THREE.Vector3();
+
+		return function ( optionalTarget ) {
+
+			var result = optionalTarget || new THREE.Quaternion();
+
+			this.updateMatrixWorld( true );
+
+			this.matrixWorld.decompose( position, result, scale );
+
+			return result;
+
+		}
+
+	}(),
+
+	worldRotation: function () {
+
+		var quaternion = new THREE.Quaternion();
+
+		return function ( optionalTarget ) {
+
+			var result = optionalTarget || new THREE.Euler();
+
+			this.worldQuaternion( quaternion );
+
+			return result.setFromQuaternion( quaternion, this.rotation.order, false );
+
+		}
+
+	}(),
+
+	worldScale: function () {
+
+		var position = new THREE.Vector3();
+		var quaternion = new THREE.Quaternion();
+
+		return function ( optionalTarget ) {
+
+			var result = optionalTarget || new THREE.Vector3();
+
+			this.updateMatrixWorld( true );
+
+			this.matrixWorld.decompose( position, quaternion, result );
+
+			return result;
+
+		}
+
+	}(),
+
+	worldDirection: function () {
+
+		var quaternion = new THREE.Quaternion();
+
+		return function ( optionalTarget ) {
+
+			var result = optionalTarget || new THREE.Vector3();
+
+			this.worldQuaternion( quaternion );
+
+			return result.set( 0, 0, 1 ).applyQuaternion( quaternion );
+
+		}
+
+	}(),
+
 	toJSON: function () {
 
 		var output = {


### PR DESCRIPTION
Requesting feedback on the usefulness of some additional `Object3D` and `Camera` methods:

```
Object3D.worldPosition( optionalTarget )
Object3D.worldQuaternion( optionalTarget )
Object3D.worldRotation( optionalTarget )
Object3D.worldScale( optionalTarget )
Object3D.worldDirection( optionalTarget )

Camera.worldDirection( optionalTarget ) // need a special one for camera...
```

Example usage:

```
var direction = camera.worldDirection();
```

or, using the optional target, and avoiding `new`,

```
var direction = new THREE.Vector3();
...
camera.worldDirection( direction );
```
