### PR TITLE
blender exporter: file extension from ".js" to ".json"

### DIFF
--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/__init__.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/__init__.py
@@ -139,8 +139,8 @@ class ImportTHREEJS(bpy.types.Operator, ImportHelper):
     bl_idname = "import.threejs"
     bl_label = "Import Three.js"
 
-    filename_ext = ".js"
-    filter_glob = StringProperty(default="*.js", options={'HIDDEN'})
+    filename_ext = ".json"
+    filter_glob = StringProperty(default="*.json", options={'HIDDEN'})
 
     option_flip_yz = BoolProperty(name="Flip YZ", description="Flip YZ", default=True)
     recalculate_normals = BoolProperty(name="Recalculate normals", description="Recalculate vertex normals", default=True)
@@ -283,7 +283,7 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
     bl_idname = "export.threejs"
     bl_label = "Export Three.js"
 
-    filename_ext = ".js"
+    filename_ext = ".json"
 
     option_vertices = BoolProperty(name = "Vertices", description = "Export vertices", default = True)
     option_vertices_deltas = BoolProperty(name = "Deltas", description = "Delta vertices", default = False)
@@ -442,11 +442,11 @@ class ExportTHREEJS(bpy.types.Operator, ExportHelper):
 # ################################################################
 
 def menu_func_export(self, context):
-    default_path = bpy.data.filepath.replace(".blend", ".js")
-    self.layout.operator(ExportTHREEJS.bl_idname, text="Three.js (.js)").filepath = default_path
+    default_path = bpy.data.filepath.replace(".blend", ".json")
+    self.layout.operator(ExportTHREEJS.bl_idname, text="Three.js (.json)").filepath = default_path
 
 def menu_func_import(self, context):
-    self.layout.operator(ImportTHREEJS.bl_idname, text="Three.js (.js)")
+    self.layout.operator(ImportTHREEJS.bl_idname, text="Three.js (.json)")
 
 def register():
     bpy.utils.register_module(__name__)

--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -1802,7 +1802,7 @@ def generate_section(label, content):
 
 def get_mesh_filename(mesh):
     object_id = mesh["data"]["name"]
-    filename = "%s.js" % sanitize(object_id)
+    filename = "%s.json" % sanitize(object_id)
     return filename
 
 def generate_material_id_list(materials):
@@ -2563,7 +2563,7 @@ def save(operator, context, filepath = "",
 
     #print("URL TYPE", option_url_base_html)
 
-    filepath = ensure_extension(filepath, '.js')
+    filepath = ensure_extension(filepath, '.json')
 
     scene = context.scene
 


### PR DESCRIPTION
As (briefly) dicussed in #5426 here is the chance to the file extension for the blender exporter
".js" to ".json"
