### PR TITLE
Vector3: Added array and offset to toArray()

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -489,14 +489,16 @@ THREE.Quaternion.prototype = {
 
 			if ( offset === undefined ) offset = 0;
 
-			array[ offset ] = this.x;
-			array[ offset + 1 ] = this.y;
-			array[ offset + 2 ] = this.z;
-			array[ offset + 3 ] = this.w;
+			array[ offset ] = this._x;
+			array[ offset + 1 ] = this._y;
+			array[ offset + 2 ] = this._z;
+			array[ offset + 3 ] = this._w;
+			
+			return array;
 
 		} else {
 
-			return [ this.x, this.y, this.z, this.w ];
+			return [ this._x, this._y, this._z, this._w ];
 
 		}
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -482,25 +482,18 @@ THREE.Quaternion.prototype = {
 		return this;
 
 	},
-	
+
 	toArray: function ( array, offset ) {
 
-		if ( array ) {
+		if ( array === undefined ) array = [];
+		if ( offset === undefined ) offset = 0;
 
-			if ( offset === undefined ) offset = 0;
+		array[ offset ] = this._x;
+		array[ offset + 1 ] = this._y;
+		array[ offset + 2 ] = this._z;
+		array[ offset + 3 ] = this._w;
 
-			array[ offset ] = this._x;
-			array[ offset + 1 ] = this._y;
-			array[ offset + 2 ] = this._z;
-			array[ offset + 3 ] = this._w;
-			
-			return array;
-
-		} else {
-
-			return [ this._x, this._y, this._z, this._w ];
-
-		}
+		return array;
 
 	},
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -482,10 +482,23 @@ THREE.Quaternion.prototype = {
 		return this;
 
 	},
+	
+	toArray: function ( array, offset ) {
 
-	toArray: function () {
+		if ( array ) {
 
-		return [ this._x, this._y, this._z, this._w ];
+			if ( offset === undefined ) offset = 0;
+
+			array[ offset ] = this.x;
+			array[ offset + 1 ] = this.y;
+			array[ offset + 2 ] = this.z;
+			array[ offset + 3 ] = this.w;
+
+		} else {
+
+			return [ this.x, this.y, this.z, this.w ];
+
+		}
 
 	},
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -388,20 +388,13 @@ THREE.Vector2.prototype = {
 
 	toArray: function ( array, offset ) {
 
-		if ( array ) {
+		if ( array === undefined ) array = [];
+		if ( offset === undefined ) offset = 0;
 
-			if ( offset === undefined ) offset = 0;
+		array[ offset ] = this.x;
+		array[ offset + 1 ] = this.y;
 
-			array[ offset ] = this.x;
-			array[ offset + 1 ] = this.y;
-			
-			return array;
-
-		} else {
-
-			return [ this.x, this.y ];
-
-		}
+		return array;
 
 	},
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -386,9 +386,20 @@ THREE.Vector2.prototype = {
 
 	},
 
-	toArray: function () {
+	toArray: function ( array, offset ) {
 
-		return [ this.x, this.y ];
+		if ( array ) {
+
+			if ( offset === undefined ) offset = 0;
+
+			array[ offset ] = this.x;
+			array[ offset + 1 ] = this.y;
+
+		} else {
+
+			return [ this.x, this.y ];
+
+		}
 
 	},
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -394,6 +394,8 @@ THREE.Vector2.prototype = {
 
 			array[ offset ] = this.x;
 			array[ offset + 1 ] = this.y;
+			
+			return array;
 
 		} else {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -805,6 +805,8 @@ THREE.Vector3.prototype = {
 			array[ offset ] = this.x;
 			array[ offset + 1 ] = this.y;
 			array[ offset + 2 ] = this.z;
+			
+			return array;
 
 		} else {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -798,21 +798,14 @@ THREE.Vector3.prototype = {
 
 	toArray: function ( array, offset ) {
 
-		if ( array ) {
+		if ( array === undefined ) array = [];
+		if ( offset === undefined ) offset = 0;
 
-			if ( offset === undefined ) offset = 0;
+		array[ offset ] = this.x;
+		array[ offset + 1 ] = this.y;
+		array[ offset + 2 ] = this.z;
 
-			array[ offset ] = this.x;
-			array[ offset + 1 ] = this.y;
-			array[ offset + 2 ] = this.z;
-			
-			return array;
-
-		} else {
-
-			return [ this.x, this.y, this.z ];
-
-		}
+		return array;
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -796,9 +796,21 @@ THREE.Vector3.prototype = {
 
 	},
 
-	toArray: function () {
+	toArray: function ( array, offset ) {
 
-		return [ this.x, this.y, this.z ];
+		if ( array ) {
+
+			if ( offset === undefined ) offset = 0;
+
+			array[ offset ] = this.x;
+			array[ offset + 1 ] = this.y;
+			array[ offset + 2 ] = this.z;
+
+		} else {
+
+			return [ this.x, this.y, this.z ];
+
+		}
 
 	},
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -633,10 +633,23 @@ THREE.Vector4.prototype = {
 		return this;
 
 	},
+	
+	toArray: function ( array, offset ) {
 
-	toArray: function () {
+		if ( array ) {
 
-		return [ this.x, this.y, this.z, this.w ];
+			if ( offset === undefined ) offset = 0;
+
+			array[ offset ] = this.x;
+			array[ offset + 1 ] = this.y;
+			array[ offset + 2 ] = this.z;
+			array[ offset + 3 ] = this.w;
+
+		} else {
+
+			return [ this.x, this.y, this.z, this.w ];
+
+		}
 
 	},
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -644,6 +644,8 @@ THREE.Vector4.prototype = {
 			array[ offset + 1 ] = this.y;
 			array[ offset + 2 ] = this.z;
 			array[ offset + 3 ] = this.w;
+			
+			return array;
 
 		} else {
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -633,25 +633,18 @@ THREE.Vector4.prototype = {
 		return this;
 
 	},
-	
+
 	toArray: function ( array, offset ) {
 
-		if ( array ) {
+		if ( array === undefined ) array = [];
+		if ( offset === undefined ) offset = 0;
 
-			if ( offset === undefined ) offset = 0;
+		array[ offset ] = this.x;
+		array[ offset + 1 ] = this.y;
+		array[ offset + 2 ] = this.z;
+		array[ offset + 3 ] = this.w;
 
-			array[ offset ] = this.x;
-			array[ offset + 1 ] = this.y;
-			array[ offset + 2 ] = this.z;
-			array[ offset + 3 ] = this.w;
-			
-			return array;
-
-		} else {
-
-			return [ this.x, this.y, this.z, this.w ];
-
-		}
+		return array;
 
 	},
 


### PR DESCRIPTION
Following the recent addition of `offset` to fromArray() I would like to propose similar additions to toArray() allowing for

```
v.toArray( array, offset );
```

instead of

```
array[ offset ] = v.x;
array[ offset + 1 ] = v.y;
array[ offset + 2 ] = v.z;
```
