### PR TITLE
OBJExporter: handle children objects

### DIFF
--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -6,101 +6,101 @@ THREE.OBJExporter = function () {};
 
 THREE.OBJExporter.prototype = {
 
-    constructor: THREE.OBJExporter,
+	constructor: THREE.OBJExporter,
 
-    indexVertex: 0,
-    indexVertexUvs: 0,
-    indexNormals: 0,
+	indexVertex: 0,
+	indexVertexUvs: 0,
+	indexNormals: 0,
 
-    parse: function ( object, scaleFactor ) {
-        var output = '';
+	parse: function ( object, scaleFactor ) {
+		var output = '';
 
-        var nbVertex, nbVertexUvs, nbNormals;
-        nbVertex = nbVertexUvs = nbNormals = 0;
+		var nbVertex, nbVertexUvs, nbNormals;
+		nbVertex = nbVertexUvs = nbNormals = 0;
 
-        var geometry = object.geometry;
+		var geometry = object.geometry;
 
-        if (scaleFactor === undefined) {
-            scaleFactor = 1;
-        }
+		if (scaleFactor === undefined) {
+			scaleFactor = 1;
+		}
 
-        output += 'g ' + object.id + '\n';
+		output += 'g ' + object.id + '\n';
 
-        if (object.geometry) {
-            for ( var i = 0, l = geometry.vertices.length; i < l; i ++ ) {
+		if (object.geometry) {
+			for ( var i = 0, l = geometry.vertices.length; i < l; i ++ ) {
 
-                var vertex = geometry.vertices[ i ].clone();
-                vertex.applyMatrix4( object.matrixWorld );
+				var vertex = geometry.vertices[ i ].clone();
+				vertex.applyMatrix4( object.matrixWorld );
 
-                output += 'v ' + scaleFactor * vertex.x + ' ' + scaleFactor * vertex.y + ' ' + scaleFactor * vertex.z + '\n';
+				output += 'v ' + scaleFactor * vertex.x + ' ' + scaleFactor * vertex.y + ' ' + scaleFactor * vertex.z + '\n';
 
-                nbVertex++;
-            }
+				nbVertex++;
+			}
 
-            // uvs
+			// uvs
 
-            for ( var i = 0, l = geometry.faceVertexUvs[ 0 ].length; i < l; i ++ ) {
+			for ( var i = 0, l = geometry.faceVertexUvs[ 0 ].length; i < l; i ++ ) {
 
-                var vertexUvs = geometry.faceVertexUvs[ 0 ][ i ];
+				var vertexUvs = geometry.faceVertexUvs[ 0 ][ i ];
 
-                for ( var j = 0; j < vertexUvs.length; j ++ ) {
+				for ( var j = 0; j < vertexUvs.length; j ++ ) {
 
-                    var uv = vertexUvs[ j ];
-                    vertex.applyMatrix4( object.matrixWorld );
+					var uv = vertexUvs[ j ];
+					vertex.applyMatrix4( object.matrixWorld );
 
-                    output += 'vt ' + scaleFactor * uv.x + ' ' + scaleFactor * uv.y + '\n';
+					output += 'vt ' + scaleFactor * uv.x + ' ' + scaleFactor * uv.y + '\n';
 
-                    nbVertexUvs++;
-                }
+					nbVertexUvs++;
+				}
 
-            }
+			}
 
-            // normals
+			// normals
 
-            for ( var i = 0, l = geometry.faces.length; i < l; i ++ ) {
+			for ( var i = 0, l = geometry.faces.length; i < l; i ++ ) {
 
-                var normals = geometry.faces[ i ].vertexNormals;
+				var normals = geometry.faces[ i ].vertexNormals;
 
-                for ( var j = 0; j < normals.length; j ++ ) {
+				for ( var j = 0; j < normals.length; j ++ ) {
 
-                    var normal = normals[ j ];
-                    output += 'vn ' + scaleFactor * normal.x + ' ' + scaleFactor * normal.y + ' ' + scaleFactor * normal.z + '\n';
+					var normal = normals[ j ];
+					output += 'vn ' + scaleFactor * normal.x + ' ' + scaleFactor * normal.y + ' ' + scaleFactor * normal.z + '\n';
 
-                    nbNormals++;
-                }
+					nbNormals++;
+				}
 
-            }
+			}
 
-            // faces
+			// faces
 
-            for ( var i = 0, j = 1, l = geometry.faces.length; i < l; i ++, j += 3 ) {
+			for ( var i = 0, j = 1, l = geometry.faces.length; i < l; i ++, j += 3 ) {
 
-                var face = geometry.faces[ i ];
+				var face = geometry.faces[ i ];
 
-                output += 'f ';
-                output += ( this.indexVertex + face.a + 1 ) + '/' + ( this.indexVertexUvs + j ) + '/' + ( this.indexNormals + j ) + ' ';
-                output += ( this.indexVertex + face.b + 1 ) + '/' + ( this.indexVertexUvs + j + 1 ) + '/' + ( this.indexNormals + j + 1 ) + ' ';
-                output += ( this.indexVertex + face.c + 1 ) + '/' + ( this.indexVertexUvs + j + 2 ) + '/' + ( this.indexNormals + j + 2 ) + '\n';
+				output += 'f ';
+				output += ( this.indexVertex + face.a + 1 ) + '/' + ( this.indexVertexUvs + j ) + '/' + ( this.indexNormals + j ) + ' ';
+				output += ( this.indexVertex + face.b + 1 ) + '/' + ( this.indexVertexUvs + j + 1 ) + '/' + ( this.indexNormals + j + 1 ) + ' ';
+				output += ( this.indexVertex + face.c + 1 ) + '/' + ( this.indexVertexUvs + j + 2 ) + '/' + ( this.indexNormals + j + 2 ) + '\n';
 
-            }
-        }
+			}
+		}
 
-        // update index
-        this.indexVertex += nbVertex;
-        this.indexVertexUvs += nbVertexUvs
-        this.indexNormals += nbNormals
+		// update index
+		this.indexVertex += nbVertex;
+		this.indexVertexUvs += nbVertexUvs
+		this.indexNormals += nbNormals
 
-        // Create children objects
-        if (object.children && object.children.length > 0) {
+		// Create children objects
+		if (object.children && object.children.length > 0) {
 
-            for ( var i in object.children ) {
-                output += '# new children object: ' + object.children[i].id + '\n';
-                output += this.parse( object.children[i], scaleFactor );
-            }
-        }
+			for ( var i in object.children ) {
+				output += '# new children object: ' + object.children[i].id + '\n';
+				output += this.parse( object.children[i], scaleFactor );
+			}
+		}
 
-        return output;
+		return output;
 
-    }
+	}
 
 }

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -20,7 +20,7 @@ THREE.OBJExporter.prototype = {
 
 		var geometry = object.geometry;
 
-		output += 'g ' + object.id + '\n';
+		output += 'o ' + object.id + '\n';
 
 		if (object.geometry) {
 			for ( var i = 0, l = geometry.vertices.length; i < l; i ++ ) {

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -91,13 +91,10 @@ THREE.OBJExporter.prototype = {
 		this.indexNormals += nbNormals
 
 		// Create children objects
-		if (object.children && object.children.length > 0) {
-
-			for ( var i in object.children ) {
-				output += '# new children object: ' + object.children[i].id + '\n';
-				output += this.parse( object.children[i], scaleFactor );
-			}
-		}
+        for ( var i in object.children ) {
+            output += '# new children object: ' + object.children[i].id + '\n';
+            output += this.parse( object.children[i], scaleFactor );
+        }
 
 		return output;
 

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -12,17 +12,13 @@ THREE.OBJExporter.prototype = {
 	indexVertexUvs: 0,
 	indexNormals: 0,
 
-	parse: function ( object, scaleFactor ) {
+	parse: function ( object ) {
 		var output = '';
 
 		var nbVertex, nbVertexUvs, nbNormals;
 		nbVertex = nbVertexUvs = nbNormals = 0;
 
 		var geometry = object.geometry;
-
-		if (scaleFactor === undefined) {
-			scaleFactor = 1;
-		}
 
 		output += 'g ' + object.id + '\n';
 
@@ -32,7 +28,7 @@ THREE.OBJExporter.prototype = {
 				var vertex = geometry.vertices[ i ].clone();
 				vertex.applyMatrix4( object.matrixWorld );
 
-				output += 'v ' + scaleFactor * vertex.x + ' ' + scaleFactor * vertex.y + ' ' + scaleFactor * vertex.z + '\n';
+				output += 'v ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
 
 				nbVertex++;
 			}
@@ -48,7 +44,7 @@ THREE.OBJExporter.prototype = {
 					var uv = vertexUvs[ j ];
 					vertex.applyMatrix4( object.matrixWorld );
 
-					output += 'vt ' + scaleFactor * uv.x + ' ' + scaleFactor * uv.y + '\n';
+					output += 'vt ' + uv.x + ' ' + uv.y + '\n';
 
 					nbVertexUvs++;
 				}
@@ -64,7 +60,7 @@ THREE.OBJExporter.prototype = {
 				for ( var j = 0; j < normals.length; j ++ ) {
 
 					var normal = normals[ j ];
-					output += 'vn ' + scaleFactor * normal.x + ' ' + scaleFactor * normal.y + ' ' + scaleFactor * normal.z + '\n';
+					output += 'vn ' + normal.x + ' ' + normal.y + ' ' + normal.z + '\n';
 
 					nbNormals++;
 				}
@@ -91,10 +87,10 @@ THREE.OBJExporter.prototype = {
 		this.indexNormals += nbNormals
 
 		// Create children objects
-        for ( var i in object.children ) {
-            output += '# new children object: ' + object.children[i].id + '\n';
-            output += this.parse( object.children[i], scaleFactor );
-        }
+		for ( var i in object.children ) {
+			output += '# new children object: ' + object.children[i].id + '\n';
+			output += this.parse( object.children[i] );
+		}
 
 		return output;
 

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -8,89 +8,88 @@ THREE.OBJExporter.prototype = {
 
 	constructor: THREE.OBJExporter,
 
-	indexVertex: 0,
-	indexVertexUvs: 0,
-	indexNormals: 0,
-
 	parse: function ( object ) {
 		var output = '';
 
-		var nbVertex, nbVertexUvs, nbNormals;
-		nbVertex = nbVertexUvs = nbNormals = 0;
+		var indexVertex = 0;
+		var indexVertexUvs = 0
+		var indexNormals = 0;
 
-		var geometry = object.geometry;
+		var parseObject = function ( child ) {
 
-		output += 'o ' + object.id + '\n';
+			var nbVertex, nbVertexUvs, nbNormals;
+			nbVertex = nbVertexUvs = nbNormals = 0;
 
-		if (object.geometry) {
-			for ( var i = 0, l = geometry.vertices.length; i < l; i ++ ) {
+			var geometry = object.geometry;
 
-				var vertex = geometry.vertices[ i ].clone();
-				vertex.applyMatrix4( object.matrixWorld );
+			output += 'o ' + object.id + '\n';
 
-				output += 'v ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
+			if (object.geometry) {
+				for ( var i = 0, l = geometry.vertices.length; i < l; i ++ ) {
 
-				nbVertex++;
-			}
-
-			// uvs
-
-			for ( var i = 0, l = geometry.faceVertexUvs[ 0 ].length; i < l; i ++ ) {
-
-				var vertexUvs = geometry.faceVertexUvs[ 0 ][ i ];
-
-				for ( var j = 0; j < vertexUvs.length; j ++ ) {
-
-					var uv = vertexUvs[ j ];
+					var vertex = geometry.vertices[ i ].clone();
 					vertex.applyMatrix4( object.matrixWorld );
 
-					output += 'vt ' + uv.x + ' ' + uv.y + '\n';
+					output += 'v ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
 
-					nbVertexUvs++;
+					nbVertex++;
 				}
 
-			}
+				// uvs
 
-			// normals
+				for ( var i = 0, l = geometry.faceVertexUvs[ 0 ].length; i < l; i ++ ) {
 
-			for ( var i = 0, l = geometry.faces.length; i < l; i ++ ) {
+					var vertexUvs = geometry.faceVertexUvs[ 0 ][ i ];
 
-				var normals = geometry.faces[ i ].vertexNormals;
+					for ( var j = 0; j < vertexUvs.length; j ++ ) {
 
-				for ( var j = 0; j < normals.length; j ++ ) {
+						var uv = vertexUvs[ j ];
+						vertex.applyMatrix4( object.matrixWorld );
 
-					var normal = normals[ j ];
-					output += 'vn ' + normal.x + ' ' + normal.y + ' ' + normal.z + '\n';
+						output += 'vt ' + uv.x + ' ' + uv.y + '\n';
 
-					nbNormals++;
+						nbVertexUvs++;
+					}
+
 				}
 
+				// normals
+
+				for ( var i = 0, l = geometry.faces.length; i < l; i ++ ) {
+
+					var normals = geometry.faces[ i ].vertexNormals;
+
+					for ( var j = 0; j < normals.length; j ++ ) {
+
+						var normal = normals[ j ];
+						output += 'vn ' + normal.x + ' ' + normal.y + ' ' + normal.z + '\n';
+
+						nbNormals++;
+					}
+
+				}
+
+				// faces
+
+				for ( var i = 0, j = 1, l = geometry.faces.length; i < l; i ++, j += 3 ) {
+
+					var face = geometry.faces[ i ];
+
+					output += 'f ';
+					output += ( indexVertex + face.a + 1 ) + '/' + ( indexVertexUvs + j ) + '/' + ( indexNormals + j ) + ' ';
+					output += ( indexVertex + face.b + 1 ) + '/' + ( indexVertexUvs + j + 1 ) + '/' + ( indexNormals + j + 1 ) + ' ';
+					output += ( indexVertex + face.c + 1 ) + '/' + ( indexVertexUvs + j + 2 ) + '/' + ( indexNormals + j + 2 ) + '\n';
+
+				}
 			}
 
-			// faces
+			// update index
+			indexVertex += nbVertex;
+			indexVertexUvs += nbVertexUvs
+			indexNormals += nbNormals
+		};
 
-			for ( var i = 0, j = 1, l = geometry.faces.length; i < l; i ++, j += 3 ) {
-
-				var face = geometry.faces[ i ];
-
-				output += 'f ';
-				output += ( this.indexVertex + face.a + 1 ) + '/' + ( this.indexVertexUvs + j ) + '/' + ( this.indexNormals + j ) + ' ';
-				output += ( this.indexVertex + face.b + 1 ) + '/' + ( this.indexVertexUvs + j + 1 ) + '/' + ( this.indexNormals + j + 1 ) + ' ';
-				output += ( this.indexVertex + face.c + 1 ) + '/' + ( this.indexVertexUvs + j + 2 ) + '/' + ( this.indexNormals + j + 2 ) + '\n';
-
-			}
-		}
-
-		// update index
-		this.indexVertex += nbVertex;
-		this.indexVertexUvs += nbVertexUvs
-		this.indexNormals += nbNormals
-
-		// Create children objects
-		for ( var i in object.children ) {
-			output += '# new children object: ' + object.children[i].id + '\n';
-			output += this.parse( object.children[i] );
-		}
+		object.traverse( parseObject );
 
 		return output;
 


### PR DESCRIPTION
These improvements with the OBJExporter allow to export THREE.Object3D and their children.
- add a _scaleFactor_ param, to scale the final object.

BC break:
- OBJExporter need an Object3D (and not an object.geometry like the previous version).

It's my first PR, so feel free to give me your feedback.
