### PR TITLE
Added Mesh as acceptable parameter to Geometry.merge()

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -9781,14 +9781,14 @@ THREE.Geometry.prototype = {
 
 		this.boundingSphere.setFromPoints( this.vertices );
 
-	},	
+	},
 
 	merge: function ( geometry, matrix, materialIndexOffset ) {
 	
 		console.warn( 'THREE.Geometry.merge() has been renamed to THREE.Geometry.mergeGeometry().' );
 		this.mergeGeometry( geometry, matrix, materialIndexOffset );
 	
-	},	
+	},
 
 	mergeMesh: function ( mesh ) {
 	

--- a/build/three.js
+++ b/build/three.js
@@ -9782,25 +9782,34 @@ THREE.Geometry.prototype = {
 		this.boundingSphere.setFromPoints( this.vertices );
 
 	},
-
+	
 	merge: function ( geometry, matrix, materialIndexOffset ) {
 	
-		if ( geometry instanceof THREE.Mesh ) {
-
-			geometry.matrixAutoUpdate && geometry.updateMatrix();
-
-			matrix = geometry.matrix;
-			geometry = geometry.geometry;
-			
-			this.merge( geometry, matrix, materialIndexOffset );
-			
+		console.warn( 'THREE.Geometry.merge() has been renamed to THREE.Geometry.mergeGeometry().' );
+		this.mergeGeometry( geometry, matrix, materialIndexOffset );
+	
+	},
+	
+	mergeMesh: function ( mesh ) {
+	
+		if ( mesh instanceof THREE.Mesh === false ) {
+		
+			console.error( 'THREE.Geometry.mergeMesh(): mesh not an instance of THREE.Mesh.', mesh );
 			return;
+		
+		}
 
-		}	
+		mesh.matrixAutoUpdate && mesh.updateMatrix();
+		
+		this.mergeGeometry( mesh.geometry, mesh.matrix );
+	
+	},
+
+	mergeGeometry: function ( geometry, matrix, materialIndexOffset ) {
 
 		if ( geometry instanceof THREE.Geometry === false ) {
 
-			console.error( 'THREE.Geometry.merge(): geometry not an instance of THREE.Geometry.', geometry );
+			console.error( 'THREE.Geometry.mergeGeometry(): geometry not an instance of THREE.Geometry.', geometry );
 			return;
 
 		}

--- a/build/three.js
+++ b/build/three.js
@@ -9789,7 +9789,7 @@ THREE.Geometry.prototype = {
 
 			geometry.matrixAutoUpdate && geometry.updateMatrix();
 
-			var matrix = geometry.matrix;
+			matrix = geometry.matrix;
 			geometry = geometry.geometry;
 			
 			this.merge( geometry, matrix, materialIndexOffset );

--- a/build/three.js
+++ b/build/three.js
@@ -9781,15 +9781,15 @@ THREE.Geometry.prototype = {
 
 		this.boundingSphere.setFromPoints( this.vertices );
 
-	},
-	
+	},	
+
 	merge: function ( geometry, matrix, materialIndexOffset ) {
 	
 		console.warn( 'THREE.Geometry.merge() has been renamed to THREE.Geometry.mergeGeometry().' );
 		this.mergeGeometry( geometry, matrix, materialIndexOffset );
 	
-	},
-	
+	},	
+
 	mergeMesh: function ( mesh ) {
 	
 		if ( mesh instanceof THREE.Mesh === false ) {

--- a/build/three.js
+++ b/build/three.js
@@ -9784,6 +9784,19 @@ THREE.Geometry.prototype = {
 	},
 
 	merge: function ( geometry, matrix, materialIndexOffset ) {
+	
+		if ( geometry instanceof THREE.Mesh ) {
+
+			geometry.matrixAutoUpdate && geometry.updateMatrix();
+
+			var matrix = geometry.matrix;
+			geometry = geometry.geometry;
+			
+			this.merge( geometry, matrix, materialIndexOffset );
+			
+			return;
+
+		}	
 
 		if ( geometry instanceof THREE.Geometry === false ) {
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -557,10 +557,32 @@ THREE.Geometry.prototype = {
 	},
 
 	merge: function ( geometry, matrix, materialIndexOffset ) {
+	
+		console.warn( 'THREE.Geometry.merge() has been renamed to THREE.Geometry.mergeGeometry().' );
+		this.mergeGeometry( geometry, matrix, materialIndexOffset );
+	
+	},
+
+	mergeMesh: function ( mesh ) {
+	
+		if ( mesh instanceof THREE.Mesh === false ) {
+		
+			console.error( 'THREE.Geometry.mergeMesh(): mesh not an instance of THREE.Mesh.', mesh );
+			return;
+		
+		}
+
+		mesh.matrixAutoUpdate && mesh.updateMatrix();
+		
+		this.mergeGeometry( mesh.geometry, mesh.matrix );
+	
+	},
+
+	mergeGeometry: function ( geometry, matrix, materialIndexOffset ) {
 
 		if ( geometry instanceof THREE.Geometry === false ) {
 
-			console.error( 'THREE.Geometry.merge(): geometry not an instance of THREE.Geometry.', geometry );
+			console.error( 'THREE.Geometry.mergeGeometry(): geometry not an instance of THREE.Geometry.', geometry );
 			return;
 
 		}


### PR DESCRIPTION
This adds the functionality that existed in GeometryUtils.merge() which allows a Mesh to be passed to merge. I'm not sure if this was left out on purpose, but I found it fairly convenient.
