### PR TITLE
[VREffect] Add onWindowed and onFullscreen callbacks

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -21,10 +21,12 @@
  * https://drive.google.com/folderview?id=0BzudLt22BqGRbW9WTHMtOWMzNjQ&usp=sharing#list
  *
  */
-THREE.VREffect = function ( renderer, done ) {
+THREE.VREffect = function ( renderer, done, options ) {
 
 	var cameraLeft = new THREE.PerspectiveCamera();
 	var cameraRight = new THREE.PerspectiveCamera();
+
+	this.options = (options || {});
 
 	this._renderer = renderer;
 
@@ -149,20 +151,26 @@ THREE.VREffect = function ( renderer, done ) {
 		this.startFullscreen();
 	};
 
+	this.onFullScreenChanged = function(){
+	  var windowed = (!document.mozFullScreenElement && !document.webkitFullScreenElement);
+
+	  if ( windowed ) {
+	    this.setFullScreen( false );
+	    this.options.onWindowed && this.options.onWindowed();
+	  } else {
+	    this.options.onFullscreen && this.options.onFullscreen();
+	  }
+
+	};
+
 	this.startFullscreen = function() {
-		var self = this;
-		var renderer = this._renderer;
 		var vrHMD = this._vrHMD;
 		var canvas = renderer.domElement;
 		var fullScreenChange =
 			canvas.mozRequestFullScreen? 'mozfullscreenchange' : 'webkitfullscreenchange';
 
-		document.addEventListener( fullScreenChange, onFullScreenChanged, false );
-		function onFullScreenChanged() {
-			if ( !document.mozFullScreenElement && !document.webkitFullScreenElement ) {
-				self.setFullScreen( false );
-			}
-		}
+		document.addEventListener( fullScreenChange, this.onFullScreenChanged.bind(this), false );
+
 		if ( canvas.mozRequestFullScreen ) {
 			canvas.mozRequestFullScreen( { vrDisplay: vrHMD } );
 		} else {


### PR DESCRIPTION
This allows callbacks for `onFullScreen` and `onWindowed` for VREffect.  These allow users to manage VRstate changes without having to track `vrMode` themselves, which can be erroneously done (e.g. flipping state only when hotkey `f` is pressed, and ignoring the `escape` key).

Some questions present:
- It's a bit confusing to have both the done callback, and options with two more callbacks.  Perhaps there's a better way to report errors?
- It's probably fine to use `bind`, as this feature is targeting new browsers, and there's (exactly) one usage of `bind` already in the THREE.js code base.

Example usage:

``` javascript
     vrEffect = new THREE.VREffect(renderer, null, {
          onWindowed: function(){
            Leap.loopController.setOptimizeHMD(false);
          },
          onFullscreen: function(){
            Leap.loopController.setOptimizeHMD(true);
          }
        });
```
