### PR TITLE
Bringing back functionality from GeometryUtils.merge

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -557,10 +557,32 @@ THREE.Geometry.prototype = {
 	},
 
 	merge: function ( geometry, matrix, materialIndexOffset ) {
+	
+		console.warn( 'THREE.Geometry.merge() has been renamed to THREE.Geometry.mergeGeometry().' );
+		this.mergeGeometry( geometry, matrix, materialIndexOffset );
+	
+	},
+
+	mergeMesh: function ( mesh ) {
+	
+		if ( mesh instanceof THREE.Mesh === false ) {
+		
+			console.error( 'THREE.Geometry.mergeMesh(): mesh not an instance of THREE.Mesh.', mesh );
+			return;
+		
+		}
+
+		mesh.matrixAutoUpdate && mesh.updateMatrix();
+		
+		this.mergeGeometry( mesh.geometry, mesh.matrix );
+	
+	},
+
+	mergeGeometry: function ( geometry, matrix, materialIndexOffset ) {
 
 		if ( geometry instanceof THREE.Geometry === false ) {
 
-			console.error( 'THREE.Geometry.merge(): geometry not an instance of THREE.Geometry.', geometry );
+			console.error( 'THREE.Geometry.mergeGeometry(): geometry not an instance of THREE.Geometry.', geometry );
 			return;
 
 		}


### PR DESCRIPTION
This change splits Geometry.merge into two functions: mergeGeometry which takes THREE.Geometry as its first param and mergeMesh which emulates the old behavior of the THREE.GeomertryUtils.merge function which allowed a THREE.Mesh object to be passed. Geometry.merge remains for BC.
