### PR TITLE
Morph animation name scheme

### DIFF
--- a/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
+++ b/utils/exporters/blender/2.65/scripts/addons/io_mesh_threejs/export_threejs.py
@@ -1517,14 +1517,27 @@ def generate_ascii_model(meshes, morphs,
             mesh_materials, nmaterial = generate_materials_string(mesh, scene, mesh_extract_colors, object.draw_type, option_copy_textures, filepath, nmaterial)
             materials.append(mesh_materials)
 
+    #Set morph animation names according to markers
+    frames_count = scene.frame_end - scene.frame_start + 1
+    frame_names = ['animation_']*(frames_count) 
+    
+    timeline_markers = sorted(scene.timeline_markers.items(), key=lambda k: k[1].frame)
 
+    #Rename all frame names to the name a previous marker holds
+    for k, v in timeline_markers:
+        frame = v.frame - scene.frame_start #If the frame doesnt start at 0
+        name = v.name
+        
+        for i in range(frame, frames_count):
+            frame_names[i] = name
+            
     morphTargets_string = ""
     nmorphTarget = 0
 
     if option_animation_morph:
         chunks = []
         for i, morphVertices in enumerate(morphs):
-            morphTarget = '{ "name": "%s_%06d", "vertices": [%s] }' % ("animation", i, morphVertices)
+            morphTarget = '{ "name": "%s%06d", "vertices": [%s] }' % (frame_names[i], i, morphVertices)
             chunks.append(morphTarget)
 
         morphTargets_string = ",\n\t".join(chunks)


### PR DESCRIPTION
Currently the exported morph targets have a hardcoded "animation_" prefix, this change names the animations according to timeline markers in Blender. The markers name all animation frames from the frame of the marker up to the next marker. If there are no markers, the animation frames are named as they were.
Making a character rig I missed this functionality, which gives me the ability to name animations (idle, walk, run, etc.)
