### PR TITLE
arrow's line shouldn't interfere with the cone

### DIFF
--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -88,7 +88,7 @@ THREE.ArrowHelper.prototype.setLength = function ( length, headLength, headWidth
 	if ( headLength === undefined ) headLength = 0.2 * length;
 	if ( headWidth === undefined ) headWidth = 0.2 * headLength;
 
-	this.line.scale.set( 1, length, 1 );
+	this.line.scale.set( 1, length - headLength, 1 );
 	this.line.updateMatrix();
 
 	this.cone.scale.set( headWidth, headLength, headWidth );


### PR DESCRIPTION
the very tip of the arrow's cone is actually cylindrical, due to the line protruding from it

more noticeable if your headWidth is small
