### PR TITLE
Modified TransformControls to work with Orthographic cameras and OrbitControls

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -150,6 +150,7 @@
 
 			this.traverse(function ( child ) {
 				if (child instanceof THREE.Mesh) {
+
 					child.updateMatrix();
 
 					var tempGeometry = new THREE.Geometry();
@@ -701,11 +702,17 @@
 			camRotation.setFromRotationMatrix( tempMatrix.extractRotation( camera.matrixWorld ) );
 
 			this.position.copy( worldPosition );
-			if (camera instanceof THREE.OrthographicCamera){
-				scale = scope.size * (camera.right-camera.left) / 2.0;
-			}else{
+
+			if ( camera instanceof THREE.OrthographicCamera ) {
+
+				scale = scope.size * ( camera.right - camera.left ) / 2.0;
+
+			} else {
+
 				scale = worldPosition.distanceTo( camPosition ) / 6 * scope.size;
+
 			}
+
 			this.scale.set( scale, scale, scale );
 
 			eye.copy( camPosition ).sub( worldPosition ).normalize();
@@ -761,6 +768,7 @@
 				var intersect = intersectObjects( pointer, scope.gizmo[_mode].pickers.children );
 
 				if ( intersect ) {
+
 					event.stopPropagation();
 
 					scope.dispatchEvent( mouseDownEvent );
@@ -980,15 +988,19 @@
 			var x = ( pointer.clientX - rect.left ) / rect.width;
 			var y = ( pointer.clientY - rect.top ) / rect.height;
 
-			if (camera instanceof THREE.OrthographicCamera){
+			if (camera instanceof THREE.OrthographicCamera ) {
+
 				pointerVector.set( ( x * 2 ) - 1, - ( y * 2 ) + 1, -1 );
 				pointerVector.unproject( camera );
 				camPosition.set( 0, 0, -1 ).transformDirection( camera.matrixWorld );
 				ray.set( pointerVector, camPosition );
-			}else{
+
+			} else {
+
 				pointerVector.set( ( x * 2 ) - 1, - ( y * 2 ) + 1, 0.5 );
 				pointerVector.unproject( camera );
 				ray.set( camPosition, pointerVector.sub( camPosition ).normalize() );
+
 			}
 
 			var intersections = ray.intersectObjects( objects, true );

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -701,7 +701,7 @@
 			camRotation.setFromRotationMatrix( tempMatrix.extractRotation( camera.matrixWorld ) );
 
 			this.position.copy( worldPosition );
-			if (camera.type == "OrthographicCamera"){
+			if (camera instanceof THREE.OrthographicCamera){
 				scale = scope.size * (camera.right-camera.left) / 2.0;
 			}else{
 				scale = worldPosition.distanceTo( camPosition ) / 6 * scope.size;
@@ -980,7 +980,7 @@
 			var x = ( pointer.clientX - rect.left ) / rect.width;
 			var y = ( pointer.clientY - rect.top ) / rect.height;
 
-			if (camera.type == "OrthographicCamera"){
+			if (camera instanceof THREE.OrthographicCamera){
 				pointerVector.set( ( x * 2 ) - 1, - ( y * 2 ) + 1, -1 );
 				pointerVector.unproject( camera );
 				camPosition.set( 0, 0, -1 ).transformDirection( camera.matrixWorld );

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -700,8 +700,12 @@
 			camPosition.setFromMatrixPosition( camera.matrixWorld );
 			camRotation.setFromRotationMatrix( tempMatrix.extractRotation( camera.matrixWorld ) );
 
-			scale = worldPosition.distanceTo( camPosition ) / 6 * scope.size;
 			this.position.copy( worldPosition );
+			if (camera.type == "OrthographicCamera"){
+				scale = scope.size * (camera.right-camera.left) / 2.0;
+			}else{
+				scale = worldPosition.distanceTo( camPosition ) / 6 * scope.size;
+			}
 			this.scale.set( scale, scale, scale );
 
 			eye.copy( camPosition ).sub( worldPosition ).normalize();
@@ -749,7 +753,6 @@
 			if ( scope.object === undefined || _dragging === true ) return;
 
 			event.preventDefault();
-			event.stopPropagation();
 
 			var pointer = event.changedTouches ? event.changedTouches[ 0 ] : event;
 
@@ -758,6 +761,7 @@
 				var intersect = intersectObjects( pointer, scope.gizmo[_mode].pickers.children );
 
 				if ( intersect ) {
+					event.stopPropagation();
 
 					scope.dispatchEvent( mouseDownEvent );
 
@@ -976,10 +980,16 @@
 			var x = ( pointer.clientX - rect.left ) / rect.width;
 			var y = ( pointer.clientY - rect.top ) / rect.height;
 
-			pointerVector.set( ( x * 2 ) - 1, - ( y * 2 ) + 1, 0.5 );
-			pointerVector.unproject( camera );
-
-			ray.set( camPosition, pointerVector.sub( camPosition ).normalize() );
+			if (camera.type == "OrthographicCamera"){
+				pointerVector.set( ( x * 2 ) - 1, - ( y * 2 ) + 1, -1 );
+				pointerVector.unproject( camera );
+				camPosition.set( 0, 0, -1 ).transformDirection( camera.matrixWorld );
+				ray.set( pointerVector, camPosition );
+			}else{
+				pointerVector.set( ( x * 2 ) - 1, - ( y * 2 ) + 1, 0.5 );
+				pointerVector.unproject( camera );
+				ray.set( camPosition, pointerVector.sub( camPosition ).normalize() );
+			}
 
 			var intersections = ray.intersectObjects( objects, true );
 			return intersections[0] ? intersections[0] : false;


### PR DESCRIPTION
- Fixed scaling of gizmo, and picking of gizmo parts.
- Moved stopPropagation on mousedown, so that propagation of the event is only stopped if the TransformControl is going to do something with it. This helps it play nicely when other controls are in use.
