### PR TITLE
OrbitControls minor fixes.

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -378,9 +378,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
-		document.addEventListener( 'mousemove', onMouseMove, false );
-		document.addEventListener( 'mouseup', onMouseUp, false );
-		scope.dispatchEvent( startEvent );
+		if ( state !== STATE.NONE ) {
+			document.addEventListener( 'mousemove', onMouseMove, false );
+			document.addEventListener( 'mouseup', onMouseUp, false );
+			scope.dispatchEvent( startEvent );
+		}
 
 	}
 
@@ -439,7 +441,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
-		scope.update();
+		if ( state !== STATE.NONE ) scope.update();
 
 	}
 
@@ -456,7 +458,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function onMouseWheel( event ) {
 
-		if ( scope.enabled === false || scope.noZoom === true ) return;
+		if ( scope.enabled === false || scope.noZoom === true || state !== STATE.NONE ) return;
 
 		event.preventDefault();
 		event.stopPropagation();
@@ -561,7 +563,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
-		scope.dispatchEvent( startEvent );
+		if ( state !== STATE.NONE ) scope.dispatchEvent( startEvent );
 
 	}
 


### PR DESCRIPTION
I recently tried to use the relatively new ability of OrbitControls to re-assign the mouse button inputs using `controls.mouseButtons`and noticed a small bug. 
The control still calls `update()` internally and also raises the start/change/end events even when the input  mouse/kb/touch event has not caused a state change.
This causes a few minor issues with changing cursors and also with the `autoRotate` speed

These fiddles demonstrate the problem and my fix;

issue: http://jsfiddle.net/satori99/1bmtu6k1/6/
fix: http://jsfiddle.net/satori99/ft8nvs2c/1/

This PR adds checks for `state !== STATE.NONE` before updating or raising events
I tried other examples that use OrbitControls and it does not affect existing code.
