### PR TITLE
Docs: mark extras classes as such

### DIFF
--- a/docs/api/CONTRIBUTING.md
+++ b/docs/api/CONTRIBUTING.md
@@ -5,3 +5,4 @@ Contributing to the documentation
 - Use `[example:exampleName title]` (ot just `[example:exampleName]`) to link to the example `threejs.org/examples/#exampleName`.
 - Document a property by writing `<h3>[property:TypeName propertyName]</h3>`.
 - Document a method using `<h3>[method:ReturnType methodName]</h3>`.
+- Mark extras classes (not included in the build) as such

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@
 				border: 1px solid #2194CE;
 			}
 			#clearFilterButton {
-				position: absolute;
+				position: absolute; 
 				right: 6px;
 				top: 50%;
 				margin-top: -8px;
@@ -215,12 +215,8 @@
 			//filterInput.focus();
 
 			panel.addEventListener( 'click', function( e ) {
-				if ( e.target.parentElement.href && e.target.parentElement.href.indexOf('outbuild') ) {
-					// from a footnote link, default behaviour
-				} else {
-					//filterInput.focus();
-					e.preventDefault();
-				}
+				//filterInput.focus();
+				e.preventDefault();
 			} );
 
 			document.getElementById( 'expandButton' ).addEventListener( 'click', function( e ) {
@@ -264,17 +260,14 @@
 						var li = document.createElement( 'li' );
 						var a = document.createElement( 'a' );
 						a.setAttribute( 'href', '#' );
-						( function( s, c, p ) {
+						( function( s, c, p ) { 
 							a.addEventListener( 'click', function( e ) {
 								goTo( s, c, p );
 								e.preventDefault();
-							} )
+							} ) 
 						} )( section, category, page[ 0 ] )
 						a.textContent = page[ 0 ];
 						li.appendChild( a );
-						if ( page[ 2 ] ) {
-							li.appendChild( outBuildRef() );
-						}
 						ul.appendChild( li );
 
 						nameCategoryMap[page[0]] = {
@@ -293,8 +286,6 @@
 
 
 			}
-
-			ul.appendChild( outBuildNote() );
 
 			panel.appendChild( content )
 
@@ -370,7 +361,7 @@
 					// Resolve links of the form 'Class.member'
 					if(section.indexOf(MEMBER_DELIMITER) !== -1) {
 						parts = section.split(MEMBER_DELIMITER)
-						section = parts[0];
+						section = parts[0]; 
 						member = parts[1];
 					}
 
@@ -379,7 +370,7 @@
 					section = location.section;
 					category = location.category;
 					name = location.name;
-				}
+				} 
 
 				var title = 'three.js - documentation - ' + section + ' - ' + name;
 				var url = encodeUrl(section) + DELIMITER + encodeUrl( category ) + DELIMITER + encodeUrl(name) + (!!member ? MEMBER_DELIMITER + encodeUrl(member) : '');
@@ -396,49 +387,9 @@
 			function goToHash() {
 
 				var hash = window.location.hash.substring( 1 ).split(DELIMITER);
+				var member = hash[2].split(MEMBER_DELIMITER)
+				goTo( decodeUrl(hash[0]), decodeUrl(hash[1]), decodeUrl(member[0]), decodeUrl(member.length > 1 ? member[1] : '') );
 
-				if ( hash.length > 2 ) {
-
-					var member = hash[2].split(MEMBER_DELIMITER)
-					goTo( decodeUrl(hash[0]), decodeUrl(hash[1]), decodeUrl(member[0]), decodeUrl(member.length > 1 ? member[1] : '') );
-
-				}
-
-			}
-
-			function outBuildRef() {
-				var sup = document.createElement( 'sup' );
-				sup.textContent = '*';
-
-				var a = document.createElement( 'a' );
-				a.href = '#outbuild';
-				a.appendChild( document.createTextNode( ' ' ) );
-				a.appendChild( sup );
-
-				return a;
-			}
-
-			function outBuildNote() {
-				var a = document.createElement( 'a' );
-				a.name = 'outbuild';
-				a.textContent = '*';
-
-				var back = document.createElement( 'a' );
-				back.innerHTML = '&#8617;'
-				back.href = '#back';
-				back.addEventListener( 'click', function (event) {
-					event.preventDefault();
-					window.history.back();
-				} )
-
-				var note = document.createElement( 'li' );
-				note.appendChild( document.createElement( 'br' ) );
-				note.appendChild( document.createElement( 'br' ) );
-				note.appendChild( a );
-				note.appendChild( document.createTextNode( ' This class is not bundled in the Three.js build. ' ) );
-				note.appendChild( back );
-
-				return note;
 			}
 
 			window.addEventListener( 'hashchange', goToHash, false );

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@
 				border: 1px solid #2194CE;
 			}
 			#clearFilterButton {
-				position: absolute; 
+				position: absolute;
 				right: 6px;
 				top: 50%;
 				margin-top: -8px;
@@ -215,8 +215,12 @@
 			//filterInput.focus();
 
 			panel.addEventListener( 'click', function( e ) {
-				//filterInput.focus();
-				e.preventDefault();
+				if ( e.target.parentElement.href && e.target.parentElement.href.indexOf('outbuild') ) {
+					// from a footnote link, default behaviour
+				} else {
+					//filterInput.focus();
+					e.preventDefault();
+				}
 			} );
 
 			document.getElementById( 'expandButton' ).addEventListener( 'click', function( e ) {
@@ -260,14 +264,17 @@
 						var li = document.createElement( 'li' );
 						var a = document.createElement( 'a' );
 						a.setAttribute( 'href', '#' );
-						( function( s, c, p ) { 
+						( function( s, c, p ) {
 							a.addEventListener( 'click', function( e ) {
 								goTo( s, c, p );
 								e.preventDefault();
-							} ) 
+							} )
 						} )( section, category, page[ 0 ] )
 						a.textContent = page[ 0 ];
 						li.appendChild( a );
+						if ( page[ 2 ] ) {
+							li.appendChild( outBuildRef() );
+						}
 						ul.appendChild( li );
 
 						nameCategoryMap[page[0]] = {
@@ -286,6 +293,8 @@
 
 
 			}
+
+			ul.appendChild( outBuildNote() );
 
 			panel.appendChild( content )
 
@@ -361,7 +370,7 @@
 					// Resolve links of the form 'Class.member'
 					if(section.indexOf(MEMBER_DELIMITER) !== -1) {
 						parts = section.split(MEMBER_DELIMITER)
-						section = parts[0]; 
+						section = parts[0];
 						member = parts[1];
 					}
 
@@ -370,7 +379,7 @@
 					section = location.section;
 					category = location.category;
 					name = location.name;
-				} 
+				}
 
 				var title = 'three.js - documentation - ' + section + ' - ' + name;
 				var url = encodeUrl(section) + DELIMITER + encodeUrl( category ) + DELIMITER + encodeUrl(name) + (!!member ? MEMBER_DELIMITER + encodeUrl(member) : '');
@@ -387,9 +396,49 @@
 			function goToHash() {
 
 				var hash = window.location.hash.substring( 1 ).split(DELIMITER);
-				var member = hash[2].split(MEMBER_DELIMITER)
-				goTo( decodeUrl(hash[0]), decodeUrl(hash[1]), decodeUrl(member[0]), decodeUrl(member.length > 1 ? member[1] : '') );
 
+				if ( hash.length > 2 ) {
+
+					var member = hash[2].split(MEMBER_DELIMITER)
+					goTo( decodeUrl(hash[0]), decodeUrl(hash[1]), decodeUrl(member[0]), decodeUrl(member.length > 1 ? member[1] : '') );
+
+				}
+
+			}
+
+			function outBuildRef() {
+				var sup = document.createElement( 'sup' );
+				sup.textContent = '*';
+
+				var a = document.createElement( 'a' );
+				a.href = '#outbuild';
+				a.appendChild( document.createTextNode( ' ' ) );
+				a.appendChild( sup );
+
+				return a;
+			}
+
+			function outBuildNote() {
+				var a = document.createElement( 'a' );
+				a.name = 'outbuild';
+				a.textContent = '*';
+
+				var back = document.createElement( 'a' );
+				back.innerHTML = '&#8617;'
+				back.href = '#back';
+				back.addEventListener( 'click', function (event) {
+					event.preventDefault();
+					window.history.back();
+				} )
+
+				var note = document.createElement( 'li' );
+				note.appendChild( document.createElement( 'br' ) );
+				note.appendChild( document.createElement( 'br' ) );
+				note.appendChild( a );
+				note.appendChild( document.createTextNode( ' This class is not bundled in the Three.js build. ' ) );
+				note.appendChild( back );
+
+				return note;
 			}
 
 			window.addEventListener( 'hashchange', goToHash, false );

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@
 				border: 1px solid #2194CE;
 			}
 			#clearFilterButton {
-				position: absolute; 
+				position: absolute;
 				right: 6px;
 				top: 50%;
 				margin-top: -8px;
@@ -260,20 +260,20 @@
 						var li = document.createElement( 'li' );
 						var a = document.createElement( 'a' );
 						a.setAttribute( 'href', '#' );
-						( function( s, c, p ) { 
+						( function( s, c, p ) {
 							a.addEventListener( 'click', function( e ) {
 								goTo( s, c, p );
 								e.preventDefault();
-							} ) 
-						} )( section, category, page[ 0 ] )
+							} )
+						} )( section, category, cleanPageName( page[0] ) )
 						a.textContent = page[ 0 ];
 						li.appendChild( a );
 						ul.appendChild( li );
 
-						nameCategoryMap[page[0]] = {
+						nameCategoryMap[ cleanPageName( page[0] ) ] = {
 							section: section,
 							category: category,
-							name: page[0],
+							name: cleanPageName( page[0] ),
 							element: a
 						};
 
@@ -286,6 +286,8 @@
 
 
 			}
+
+			ul.appendChild( outBuildNote() );
 
 			panel.appendChild( content )
 
@@ -361,7 +363,7 @@
 					// Resolve links of the form 'Class.member'
 					if(section.indexOf(MEMBER_DELIMITER) !== -1) {
 						parts = section.split(MEMBER_DELIMITER)
-						section = parts[0]; 
+						section = parts[0];
 						member = parts[1];
 					}
 
@@ -370,7 +372,7 @@
 					section = location.section;
 					category = location.category;
 					name = location.name;
-				} 
+				}
 
 				var title = 'three.js - documentation - ' + section + ' - ' + name;
 				var url = encodeUrl(section) + DELIMITER + encodeUrl( category ) + DELIMITER + encodeUrl(name) + (!!member ? MEMBER_DELIMITER + encodeUrl(member) : '');
@@ -390,6 +392,12 @@
 				var member = hash[2].split(MEMBER_DELIMITER)
 				goTo( decodeUrl(hash[0]), decodeUrl(hash[1]), decodeUrl(member[0]), decodeUrl(member.length > 1 ? member[1] : '') );
 
+			}
+
+			function outBuildNote() {
+				var note = document.createElement( 'li' );
+				note.innerHTML = '<br><br> * This class is not bundled in the Three.js build. ';
+				return note;
 			}
 
 			window.addEventListener( 'hashchange', goToHash, false );

--- a/docs/list.js
+++ b/docs/list.js
@@ -46,7 +46,7 @@ var list = {
 
 
 		"Loaders": [
-			[ "BabylonLoader", "api/loaders/BabylonLoader" ],
+			[ "BabylonLoader", "api/loaders/BabylonLoader", true ],
 			[ "BufferGeometryLoader", "api/loaders/BufferGeometryLoader" ],
 			[ "Cache", "api/loaders/Cache" ],
 			[ "ColladaLoader", "api/loaders/ColladaLoader" ],

--- a/docs/list.js
+++ b/docs/list.js
@@ -46,7 +46,7 @@ var list = {
 
 
 		"Loaders": [
-			[ "BabylonLoader", "api/loaders/BabylonLoader" ],
+			[ "BabylonLoader *", "api/loaders/BabylonLoader" ],
 			[ "BufferGeometryLoader", "api/loaders/BufferGeometryLoader" ],
 			[ "Cache", "api/loaders/Cache" ],
 			[ "ColladaLoader", "api/loaders/ColladaLoader" ],
@@ -264,10 +264,16 @@ for ( var section in list ) {
 		for ( var i = 0; i < list[ section ][ category ].length; i ++ ) {
 
 			var page = list[ section ][ category ][ i ];
-			pages[ section ][ category ][ page[ 0 ] ] = page[ 1 ];
+			pages[ section ][ category ][ cleanPageName( page[ 0 ] ) ] = page[ 1 ];
 
 		}
 
 	}
+
+}
+
+function cleanPageName( name ) {
+
+	return name.replace(/\ \*/g, '');
 
 }

--- a/docs/list.js
+++ b/docs/list.js
@@ -46,7 +46,7 @@ var list = {
 
 
 		"Loaders": [
-			[ "BabylonLoader", "api/loaders/BabylonLoader", true ],
+			[ "BabylonLoader", "api/loaders/BabylonLoader" ],
 			[ "BufferGeometryLoader", "api/loaders/BufferGeometryLoader" ],
 			[ "Cache", "api/loaders/Cache" ],
 			[ "ColladaLoader", "api/loaders/ColladaLoader" ],


### PR DESCRIPTION
> @mrdoob : I was thinking. In the list of pages, how about adding a ¹ to the items that are not included in the build. (Like BabylonLoader ¹)

I wonder about how to do this.
- Should `examples/js` classes be differentiated from `extras/` stuff ?
- Should we use kind-of-footnotes like this http://daringfireball.net/2005/07/footnotes ?
- Should these footnotes be generated in javascript ? If so, how about a new `[note:]` macro ?
