### PR TITLE
Adds method to calculate the quaternion rotation angle

### DIFF
--- a/docs/api/math/Quaternion.html
+++ b/docs/api/math/Quaternion.html
@@ -92,6 +92,11 @@
 		Computes length of this quaternion.
 		</div>
 
+		<h3>[method:Float angle]()</h3>
+		<div>
+		Computes the rotation angle of this quaternion.
+		</div>
+
 		<h3>[method:Quaternion normalize]()</h3>
 		<div>
 		Normalizes this quaternion.
@@ -131,12 +136,12 @@
 		<h3>[method:Quaternion slerp]([page:Quaternion qb], [page:float t])</h3>
 		<div>
 		qb -- Target quaternion rotation.<br />
-		t -- Normalized [0..1] interpolation factor. 
+		t -- Normalized [0..1] interpolation factor.
 		</div>
 		<div>
 		Handles the spherical linear interpolation between this quaternion's configuration
-		and that of *qb*. *t* represents how close to the current (0) or target (1) rotation the 
-		result should be. 
+		and that of *qb*. *t* represents how close to the current (0) or target (1) rotation the
+		result should be.
 		</div>
 
 		<h3>.toArray() [page: Array]</h3>
@@ -155,7 +160,7 @@
 
 		<h3>[method:Float lengthSq]()</h3>
 		<div>
-		Calculates the squared length of the quaternion. 
+		Calculates the squared length of the quaternion.
 		</div>
 
 		<h3>[method:Quaternion fromArray]([page:Array array])</h3>

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -3,6 +3,7 @@
  * @author alteredq / http://alteredqualia.com/
  * @author WestLangley / http://github.com/WestLangley
  * @author bhouston / http://exocortex.com
+ * @author dmarcos / http://github.com/dmarcos
  */
 
 THREE.Quaternion = function ( x, y, z, w ) {
@@ -328,6 +329,17 @@ THREE.Quaternion.prototype = {
 	length: function () {
 
 		return Math.sqrt( this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w );
+
+	},
+
+	angle: function () {
+
+		// On not normalized quaternions the w component
+		// might not be in the acos domain interval [-1, 1]
+		// If quaternion is not normalized it uses a normalized copy
+		var q = this.length() === 1? this : this.clone().normalize();
+
+		return 2 * Math.acos(q._w);
 
 	},
 

--- a/test/unit/math/Quaternion.js
+++ b/test/unit/math/Quaternion.js
@@ -137,6 +137,75 @@ test( "normalize/length/lengthSq", function() {
 	ok( a.length() == 1, "Passed!");
 });
 
+test( "angle/setFromAxisAngle", function() {
+	var axis = new THREE.Vector3( 1, 0, 0 );
+	var angle = Math.PI;
+	var q = new THREE.Quaternion().setFromAxisAngle( axis, angle );
+	var q2;
+	function equalAngles( a1, a2 ) {
+		// Tolerance for floating point loss of precission
+		var epsilon = 0.0000000001;
+		return Math.abs( a1 - a2 ) <= epsilon;
+	}
+
+	var angleOutput = q.angle();
+
+	ok( angle === angleOutput, "Passed!");
+
+	angle = 0;
+	q = new THREE.Quaternion().setFromAxisAngle( axis, angle );
+	angleOutput = q.angle();
+
+	ok( equalAngles( angle, angleOutput ), "Passed!");
+
+	angle = 2 * Math.PI;
+	q = new THREE.Quaternion().setFromAxisAngle( axis, angle );
+	angleOutput = q.angle();
+
+	ok( equalAngles( angle, angleOutput ), "Passed!");
+
+	angle = Math.PI / 2;
+	q = new THREE.Quaternion().setFromAxisAngle( axis, angle );
+	angleOutput = q.angle();
+
+	ok( equalAngles( angle, angleOutput ), "Passed!");
+
+	angle = - Math.PI / 2;
+	q = new THREE.Quaternion().setFromAxisAngle( axis, angle );
+	angleOutput = - q.angle();
+
+	ok( equalAngles( angle, angleOutput ), "Passed!");
+
+	angle = Math.PI / 4;
+	q = new THREE.Quaternion().setFromAxisAngle( axis, angle );
+	angleOutput = q.angle();
+
+	ok( equalAngles( angle, angleOutput ), "Passed!");
+
+	angle = - Math.PI / 4;
+	q = new THREE.Quaternion().setFromAxisAngle( axis, angle );
+	angleOutput = - q.angle();
+
+	ok( equalAngles( angle, angleOutput ), "Passed!");
+
+	angle = Math.PI / 4;
+	q = new THREE.Quaternion().setFromAxisAngle( axis, angle );
+	q2 = new THREE.Quaternion().setFromAxisAngle( axis, 2 * angle );
+	q.multiply( q2 )
+	angleOutput = q.angle();
+
+	ok( equalAngles( 3 * angle, angleOutput ), "Passed!");
+
+	angle = Math.PI / 4;
+	q = new THREE.Quaternion().setFromAxisAngle( axis, angle );
+	q2 = new THREE.Quaternion().setFromAxisAngle( axis, 2 * angle );
+	q.slerp( q2, 1.0 )
+	angleOutput = q.angle();
+
+	ok( equalAngles( 2 * angle, angleOutput ), "Passed!");
+
+});
+
 test( "inverse/conjugate", function() {
 	var a = new THREE.Quaternion( x, y, z, w );
 
@@ -173,7 +242,7 @@ test( "multiplyQuaternions/multiply", function() {
 });
 
 test( "multiplyVector3", function() {
-	
+
 	var angles = [ new THREE.Euler( 1, 0, 0 ), new THREE.Euler( 0, 1, 0 ), new THREE.Euler( 0, 0, 1 ) ];
 
 	// ensure euler conversion for Quaternion matches that of Matrix4
@@ -185,7 +254,7 @@ test( "multiplyVector3", function() {
 			var v0 = new THREE.Vector3(1, 0, 0);
 			var qv = v0.clone().applyQuaternion( q );
 			var mv = v0.clone().applyMatrix4( m );
-		
+
 			ok( qv.distanceTo( mv ) < 0.001, "Passed!" );
 		}
 	}
@@ -195,7 +264,7 @@ test( "multiplyVector3", function() {
 test( "equals", function() {
 	var a = new THREE.Quaternion( x, y, z, w );
 	var b = new THREE.Quaternion( -x, -y, -z, -w );
-	
+
 	ok( a.x != b.x, "Passed!" );
 	ok( a.y != b.y, "Passed!" );
 


### PR DESCRIPTION
The two last unit tests don't pass because of floating point numbers precision. The formula works as expected.

The input angle is:
0.7853981633974483
The function output:
0.7853981633974484

Is there any specific way to handle these issues in threejs? Is it fare to truncate the results and discard some of the least significant decimal positions?
