### PR TITLE
Fixed THREE.MorphAnimation so that multiple can run simultaneously

### DIFF
--- a/src/extras/animation/MorphAnimation.js
+++ b/src/extras/animation/MorphAnimation.js
@@ -1,5 +1,6 @@
 /**
  * @author mrdoob / http://mrdoob.com
+ * @author willy-vvu / http://willy-vvu.github.io
  */
 
 THREE.MorphAnimation = function ( mesh ) {
@@ -9,6 +10,8 @@ THREE.MorphAnimation = function ( mesh ) {
 	this.currentTime = 0;
 	this.duration = 1000;
 	this.loop = true;
+	this.lastFrame = 0;
+	this.currentFrame = 0;
 
 	this.isPlaying = false;
 
@@ -28,12 +31,7 @@ THREE.MorphAnimation.prototype = {
 
 	},
 
-	update: ( function () {
-
-		var lastFrame = 0;
-		var currentFrame = 0;
-
-		return function ( delta ) {
+	update: function ( delta ) {
 
 			if ( this.isPlaying === false ) return;
 
@@ -50,22 +48,20 @@ THREE.MorphAnimation.prototype = {
 			var interpolation = this.duration / this.frames;
 			var frame = Math.floor( this.currentTime / interpolation );
 
-			if ( frame != currentFrame ) {
+			if ( frame != this.currentFrame ) {
 
-				this.mesh.morphTargetInfluences[ lastFrame ] = 0;
-				this.mesh.morphTargetInfluences[ currentFrame ] = 1;
+				this.mesh.morphTargetInfluences[ this.lastFrame ] = 0;
+				this.mesh.morphTargetInfluences[ this.currentFrame ] = 1;
 				this.mesh.morphTargetInfluences[ frame ] = 0;
 
-				lastFrame = currentFrame;
-				currentFrame = frame;
+				this.lastFrame = this.currentFrame;
+				this.currentFrame = frame;
 
 			}
 
 			this.mesh.morphTargetInfluences[ frame ] = ( this.currentTime % interpolation ) / interpolation;
-			this.mesh.morphTargetInfluences[ lastFrame ] = 1 - this.mesh.morphTargetInfluences[ frame ];
+			this.mesh.morphTargetInfluences[ this.lastFrame ] = 1 - this.mesh.morphTargetInfluences[ frame ];
 
 		}
-
-	} )()
 
 };


### PR DESCRIPTION
That `var` was causing some interesting effects, breaking the ability for multiple animations to run at once.
