### PR TITLE
Make the fragment shader in this sample spec compliant

### DIFF
--- a/examples/webgl_shader.html
+++ b/examples/webgl_shader.html
@@ -65,7 +65,7 @@
 				f=400.0*(p.y*0.5+0.5);
 				i=200.0+sin(e*g+a/150.0)*20.0;
 				d=200.0+cos(f*g/2.0)*18.0+cos(e*g)*7.0;
-				r=sqrt(pow(i-e,2.0)+pow(d-f,2.0));
+				r=sqrt(pow(abs(i-e),2.0)+pow(abs(d-f),2.0));
 				q=f/r;
 				e=(r*cos(q))-a/2.0;f=(r*sin(q))-a/2.0;
 				d=sin(e*g)*176.0+sin(e*g)*164.0+r;


### PR DESCRIPTION
The fragment shader in this sample was calling pow(x, y) where x < 0
but according to the spec pow(x, y) where x < 0 is undefined.

This sample therefore didn't run on iOS where that GPU looks like it
it returns 0 or NaN when x < 0
