### PR TITLE
fixed rendering indexed pointclouds

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2779,8 +2779,52 @@ THREE.WebGLRenderer = function ( parameters ) {
 			var position = geometry.attributes.position;
 
 			// render particles
+			
+			if ( geometry.attributes.index !== undefined ) {
+			
+				var indices = geometry.attributes.index;
+			
+				var type;
+				var size;
+				
+				if ( indices.array instanceof Uint16Array ) {
+				
+					type = _gl.UNSIGNED_SHORT;
+					size = 2;
+				
+				} else {
+				
+					console.error( "unsupported index data type" );
+					return;
+				
+				}
 
-			_gl.drawArrays( _gl.POINTS, 0, position.array.length / 3 );
+				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, indices.buffer );
+			
+				if ( geometry.offsets.length > 0 ) {
+				
+					for ( var i = 0; i < geometry.offsets.length; i++ ) {
+					
+						var offset = geometry.offsets[ i ];
+						
+						_gl.drawElements( _gl.POINTS, offset.count, type, offset.start * size );
+						
+					
+					}
+				
+				} else {
+					
+					_gl.drawElements( _gl.POINTS, indices.length, type, 0);
+					
+				}
+			
+			} else {
+			
+				_gl.drawArrays( _gl.POINTS, 0, position.array.length / 3 );
+			
+			}
+
+			
 
 			_this.info.render.calls ++;
 			_this.info.render.points += position.array.length / 3;


### PR DESCRIPTION
Fix for https://github.com/mrdoob/three.js/issues/4763

This code checks if indices are defined. If indices are defined but no offsets, all indices will be rendered

```
_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, indices.buffer );
_gl.drawElements( _gl.POINTS, indices.length, type, 0);
```

If offsets are also defined, then then all indices between offset.start and offset.start + offset.count are rendered. Not sure what offset.index does.

In this case, indices were stored in an Uint16Array array. Is this always the case? Is there another way of finding the gl type (_gl.UNSIGNED_SHORT) other than checking the type of the array with instanceof?

Took the raycasting example and modified the indexed point cloud.
The indexed pointcloud has indices from 0 to 5000
The point cloud with indices and offsets has 2 offets. One from 0 to 5000 and another from 10000 to 15000.

Without fix: http://potree.org/stuff/threejs/fix_indexed_pointclouds/examples/indexed_pointcloud.html
With fix: http://potree.org/stuff/threejs/fix_indexed_pointclouds/examples/indexed_pointcloud_fixed.html

Note that in the example without the fix, raycasting omits the points that are not indexed but they are rendered anyway. 
