### PR TITLE
Reset enabled attributes

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -287,6 +287,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		_lightsNeedUpdate = true;
 
+		for ( var i = 0; i < _enabledAttributes.length; i ++ ) {
+			_enabledAttributes[ i ] = 0;
+		}
 	};
 
 	setDefaultGLState();


### PR DESCRIPTION
This resets vertex attribute flags in `resetGLState`. This is needed to get [sprite text rendering](https://www.npmjs.org/package/gl-sprite-text) working, or anything else that might enable or disable vertex attributes separately from ThreeJS.
