### PR TITLE
transmit GLSL "defines" in ShaderPass

### DIFF
--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -10,6 +10,7 @@ THREE.ShaderPass = function ( shader, textureID ) {
 
 	this.material = new THREE.ShaderMaterial( {
 
+        	defines: shader.defines || {},
 		uniforms: this.uniforms,
 		vertexShader: shader.vertexShader,
 		fragmentShader: shader.fragmentShader


### PR DESCRIPTION
Otherwise we can't use defines in post processing shaders
