### PR TITLE
Added parent traversal function to Object3d

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -533,7 +533,7 @@ THREE.Object3D.prototype = {
 		
 			callback( this.parent );
 		
-			this.parent.traverseParents( callback );
+			this.parent.traverseUp( callback );
 		
 		}
 	},

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -527,6 +527,17 @@ THREE.Object3D.prototype = {
 
 	},
 
+	traverseParents: function ( callback ) {
+
+		if( this.parent ){
+		
+			callback( this.parent );
+		
+			this.parent.traverseParents( callback );
+		
+		}
+	},
+
 	updateMatrix: function () {
 
 		this.matrix.compose( this.position, this.quaternion, this.scale );

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -527,15 +527,16 @@ THREE.Object3D.prototype = {
 
 	},
 
-	traverseUp: function ( callback ) {
+	traverseAncestors: function ( callback ) {
 
-		if( this.parent ){
-		
+		if ( this.parent ) {
+
 			callback( this.parent );
-		
-			this.parent.traverseUp( callback );
-		
+
+			this.parent.traverseAncestors( callback );
+
 		}
+
 	},
 
 	updateMatrix: function () {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -527,7 +527,7 @@ THREE.Object3D.prototype = {
 
 	},
 
-	traverseParents: function ( callback ) {
+	traverseUp: function ( callback ) {
 
 		if( this.parent ){
 		


### PR DESCRIPTION
Added a function to Object3D that steps up the parent chain of an object invoking a callback, using the parent as a parameter. Works similar to `traverse` 
