### PR TITLE
OrbitControls: pause autoRotate during user interaction

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -256,7 +256,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		phi = Math.atan2( Math.sqrt( offset.x * offset.x + offset.z * offset.z ), offset.y );
 
-		if ( this.autoRotate ) {
+		if ( this.autoRotate && state === STATE.NONE ) {
 
 			this.rotateLeft( getAutoRotationAngle() );
 


### PR DESCRIPTION
I recently tried out the autoRotate feature from OrbitControls and found an issues, which is (at least imho) not very user friendly: The models is continuing to auto rotate, even if the user is interacting with it (rotate/pan it... ) at the same time.

This pull request is changing the autoRotate behavior slightly to pause the autoRotate during user interaction.
