### PR TITLE
clone _needsUpdate property in Texture.clone()

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -89,7 +89,7 @@ THREE.Texture.prototype = {
 		texture.premultiplyAlpha = this.premultiplyAlpha;
 		texture.flipY = this.flipY;
 		texture.unpackAlignment = this.unpackAlignment;
-
+		texture._needsUpdate = this._needsUpdate;
 		return texture;
 
 	},


### PR DESCRIPTION
The ShaderPass in EffectComposer clones the uniforms which recursively clones the bound textures, but this doesn't copy the needsUpdate property whose default value is false. Without the needUpdate property to true, the texture is not uploaded into webgl and the texture2D() function in the shader returns 0 everywhere without any error.

May I suggest a "MaterialPass"? To just throw the baby with the water, and if the developer wants a shader, well, it comes will the whole Material Object. Because soon ShaderPass will just be copying everything that's in a ShaderMaterial options anyways.
