### PR TITLE
Add color option and setColor method to BoxHelper

### DIFF
--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -19,6 +19,7 @@ THREE.BoxHelper = function ( object, color ) {
 };
 
 THREE.BoxHelper.prototype = Object.create( THREE.Line.prototype );
+THREE.BoxHelper.prototype.constructor = THREE.BoxHelper;
 
 THREE.BoxHelper.prototype.update = function ( object ) {
 

--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -2,12 +2,13 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.BoxHelper = function ( object ) {
+THREE.BoxHelper = function ( object, color ) {
 
+	var boxColor = ( color !== undefined ) ? color : 0xffff00; 
 	var geometry = new THREE.BufferGeometry();
 	geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( 72 ), 3 ) );
 
-	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: 0xffff00 } ), THREE.LinePieces );
+	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: boxColor } ), THREE.LinePieces );
 
 	if ( object !== undefined ) {
 
@@ -18,7 +19,6 @@ THREE.BoxHelper = function ( object ) {
 };
 
 THREE.BoxHelper.prototype = Object.create( THREE.Line.prototype );
-THREE.BoxHelper.prototype.constructor = THREE.BoxHelper;
 
 THREE.BoxHelper.prototype.update = function ( object ) {
 

--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -3,12 +3,15 @@
  */
 
 THREE.BoxHelper = function ( object, color ) {
+	
+	var tempColor = ( color !== undefined ) ? color : 0xffff00;
+	this.color = new THREE.Color();
+	this.color.set( tempColor );
 
-	var boxColor = ( color !== undefined ) ? color : 0xffff00; 
 	var geometry = new THREE.BufferGeometry();
 	geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( 72 ), 3 ) );
 
-	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: boxColor } ), THREE.LinePieces );
+	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: this.color } ), THREE.LinePieces );
 
 	if ( object !== undefined ) {
 
@@ -99,4 +102,11 @@ THREE.BoxHelper.prototype.update = function ( object ) {
 	this.matrix = object.matrixWorld;
 	this.matrixAutoUpdate = false;
 
+};
+
+THREE.BoxHelper.prototype.setColor = function ( color ) {
+	
+	this.color.set( color );
+	this.material.color.copy( this.color );
+	
 };


### PR DESCRIPTION
EDIT: added THREE.Color object to helper and setColor method.
This simple PR adds a color option to BoxHelper's constructor.  Valid arguments could be, for example:

var helper = new THREE.BoxHelper(box, 0xffffff);
var helper = new THREE.BoxHelper(box, 'rgb(0,255,0)');
var helper = new THREE.BoxHelper(box, 'red');

If no color is specified, it defaults to a Yellow color, which is the current three.js color default for BoxHelper.

Also a setColor method is added which functions like:

helper.setColor( 'blue' );
helper.setColor( 'rgb(255,0,255)' );
helper.setColor( 0xffff00 );
