### PR TITLE
Generalizing search/get methods in Object3D

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -379,33 +379,24 @@ THREE.Object3D.prototype = {
 
 	getObjectById: function ( id, recursive ) {
 
-		if ( this.id === id ) return this;
-
-		for ( var i = 0, l = this.children.length; i < l; i ++ ) {
-
-			var child = this.children[ i ];
-			var object = child.getObjectById( id, recursive );
-
-			if ( object !== undefined ) {
-
-				return object;
-
-			}
-
-		}
-
-		return undefined;
+		return this.getObjectByProperty('id', id, recursive);
 
 	},
 
 	getObjectByName: function ( name, recursive ) {
 
-		if ( this.name === name ) return this;
+		return this.getObjectByProperty('name', name, recursive);
+
+	},
+	
+	getObjectByProperty: function ( name, value, recursive ) {
+
+		if ( this[name] === value ) return this;
 
 		for ( var i = 0, l = this.children.length; i < l; i ++ ) {
 
 			var child = this.children[ i ];
-			var object = child.getObjectByName( name, recursive );
+			var object = child.getObjectByProperty( name, value, recursive );
 
 			if ( object !== undefined ) {
 


### PR DESCRIPTION
I often end up adding custom properties to my `THREE.Object3D` objects but it is hard to use my custom parameters to find objects. Right now there are two specific methods to find objects by a property. `getObjectById` and `getObjectByName`. My suggestion is to add a less specific getObjectByProperty method with as first param the `propertyName` or `name` and second param `propertyValue` or `value`. We are able to reuse this new method in `getObjectById` and `getObjectByName`. This ends up in less code with more flexibility.

An additional suggestion would be to add a get method to find by `uuid` like this:

```
getObjectByUuid: function ( uuid, recursive ) {

    return this.getObjectByProperty( 'uuid', uuid, recursive );

},

```

I hope you guys also see advantages in this change.
