### PR TITLE
StereoEffect - Modified to be an off-axis stereo effect

### DIFF
--- a/examples/js/effects/StereoEffect.js
+++ b/examples/js/effects/StereoEffect.js
@@ -2,7 +2,7 @@
  * @author alteredq / http://alteredqualia.com/
  * @authod mrdoob / http://mrdoob.com/
  * @authod arodic / http://aleksandarrodic.com/
- * @authod fonserbc / http://twitter.com/fonserbc
+ * @authod fonserbc / http://fonserbc.github.io/
  *
  * Off-axis stereoscopic effect based on http://paulbourke.net/stereographics/stereorender/
  */
@@ -13,6 +13,9 @@ THREE.StereoEffect = function ( renderer ) {
 
 	this.eyeSeparation = 3;
 
+	/*
+	 * Distance to the non-parallax or projection plane
+	 */
 	this.focalLength = 15;
 
 	// internals
@@ -54,6 +57,7 @@ THREE.StereoEffect = function ( renderer ) {
 
 		// Stereo frustum calculation
 
+		// Effective fov of the camera
 		_fov = THREE.Math.radToDeg( 2 * Math.atan( Math.tan( THREE.Math.degToRad( camera.fov ) * 0.5 ) / camera.zoom ) );
 
 		_ndfl = camera.near / this.focalLength;
@@ -61,22 +65,17 @@ THREE.StereoEffect = function ( renderer ) {
 		_halfFocalWidth = _halfFocalHeight * 0.5 * camera.aspect;
 
 		_top = _halfFocalHeight * _ndfl;
-		_bottom = - _top;
+		_bottom = -_top;
 		_innerFactor = ( _halfFocalWidth + this.eyeSeparation / 2.0 ) / ( _halfFocalWidth * 2.0 );
 		_outerFactor = 1.0 - _innerFactor;
 
 		_outer = _halfFocalWidth * 2.0 * _ndfl * _outerFactor;
 		_inner = _halfFocalWidth * 2.0 * _ndfl * _innerFactor;
 
-
 		// left
 
-		_cameraL.fov = _fov;
-		_cameraL.aspect = 0.5 * camera.aspect;
-		_cameraL.near = camera.near;
-		_cameraL.far = camera.far;
 		_cameraL.projectionMatrix.makeFrustum(
-			- _outer,
+			-_outer,
 			_inner,
 			_bottom,
 			_top,
@@ -90,12 +89,8 @@ THREE.StereoEffect = function ( renderer ) {
 
 		// right
 
-		_cameraR.fov = _fov;
-		_cameraR.aspect = 0.5 * camera.aspect;
-		_cameraR.near = camera.near;
-		_cameraR.far = camera.far;
 		_cameraR.projectionMatrix.makeFrustum(
-			- _inner,
+			-_inner,
 			_outer,
 			_bottom,
 			_top,

--- a/examples/js/effects/StereoEffect.js
+++ b/examples/js/effects/StereoEffect.js
@@ -2,13 +2,18 @@
  * @author alteredq / http://alteredqualia.com/
  * @authod mrdoob / http://mrdoob.com/
  * @authod arodic / http://aleksandarrodic.com/
+ * @authod fonserbc / http://twitter.com/fonserbc
+ *
+ * Off-axis stereoscopic effect based on http://paulbourke.net/stereographics/stereorender/
  */
 
 THREE.StereoEffect = function ( renderer ) {
 
 	// API
 
-	this.separation = 3;
+	this.eyeSeparation = 3;
+
+	this.focalLength = 15;
 
 	// internals
 
@@ -20,6 +25,11 @@ THREE.StereoEffect = function ( renderer ) {
 
 	var _cameraL = new THREE.PerspectiveCamera();
 	var _cameraR = new THREE.PerspectiveCamera();
+
+	var _fov;
+	var _outer, _inner, _top, _bottom;
+	var _ndfl, _halfFocalWidth, _halfFocalHeight;
+	var _innerFactor, _outerFactor;
 
 	// initialization
 
@@ -42,27 +52,60 @@ THREE.StereoEffect = function ( renderer ) {
 	
 		camera.matrixWorld.decompose( _position, _quaternion, _scale );
 
+		// Stereo frustum calculation
+
+		_fov = THREE.Math.radToDeg( 2 * Math.atan( Math.tan( THREE.Math.degToRad( camera.fov ) * 0.5 ) / camera.zoom ) );
+
+		_ndfl = camera.near / this.focalLength;
+		_halfFocalHeight = Math.tan( THREE.Math.degToRad( _fov ) * 0.5 ) * this.focalLength;
+		_halfFocalWidth = _halfFocalHeight * 0.5 * camera.aspect;
+
+		_top = _halfFocalHeight * _ndfl;
+		_bottom = - _top;
+		_innerFactor = ( _halfFocalWidth + this.eyeSeparation / 2.0 ) / ( _halfFocalWidth * 2.0 );
+		_outerFactor = 1.0 - _innerFactor;
+
+		_outer = _halfFocalWidth * 2.0 * _ndfl * _outerFactor;
+		_inner = _halfFocalWidth * 2.0 * _ndfl * _innerFactor;
+
+
 		// left
 
-		_cameraL.fov = camera.fov;
+		_cameraL.fov = _fov;
 		_cameraL.aspect = 0.5 * camera.aspect;
 		_cameraL.near = camera.near;
 		_cameraL.far = camera.far;
-		_cameraL.updateProjectionMatrix();
+		_cameraL.projectionMatrix.makeFrustum(
+			- _outer,
+			_inner,
+			_bottom,
+			_top,
+			camera.near,
+			camera.far
+		);
 
 		_cameraL.position.copy( _position );
 		_cameraL.quaternion.copy( _quaternion );
-		_cameraL.translateX( - this.separation );
+		_cameraL.translateX( - this.eyeSeparation / 2.0 );
 
 		// right
 
+		_cameraR.fov = _fov;
+		_cameraR.aspect = 0.5 * camera.aspect;
 		_cameraR.near = camera.near;
 		_cameraR.far = camera.far;
-		_cameraR.projectionMatrix = _cameraL.projectionMatrix;
+		_cameraR.projectionMatrix.makeFrustum(
+			- _inner,
+			_outer,
+			_bottom,
+			_top,
+			camera.near,
+			camera.far
+		);
 
 		_cameraR.position.copy( _position );
 		_cameraR.quaternion.copy( _quaternion );
-		_cameraR.translateX( this.separation );
+		_cameraR.translateX( this.eyeSeparation / 2.0 );
 
 		//
 


### PR DESCRIPTION
I changed the StereoEffect to perform a more proper off-axis stereo as explained here http://paulbourke.net/stereographics/stereorender/

Stereo effect now supports both `eyeSeparation` and `focalLength`

I made a small demo where there are a lot of changes in eye separation and focal length, may be a bit dizzy. Demo here:
http://fonserbc.github.io/ballbox/

I was doing something for Cardboard and I found that the StereoEffect given was just a simple displacement of the cameras, I have worked with stereoscopy before and I thought it could be useful for other people.
