### PR TITLE
Add 'colors' object {} and '.setColor(s)' method to Helpers

### DIFF
--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -15,7 +15,7 @@
  */
 
 THREE.ArrowHelper = ( function () {
-
+	
 	var lineGeometry = new THREE.Geometry();
 	lineGeometry.vertices.push( new THREE.Vector3( 0, 0, 0 ), new THREE.Vector3( 0, 1, 0 ) );
 
@@ -33,20 +33,25 @@ THREE.ArrowHelper = ( function () {
 		if ( headLength === undefined ) headLength = 0.2 * length;
 		if ( headWidth === undefined ) headWidth = 0.2 * headLength;
 
+		this.colors = {
+			main: new THREE.Color()
+		};
+		this.colors.main.set( color );
+		
 		this.position.copy( origin );
 
-		this.line = new THREE.Line( lineGeometry, new THREE.LineBasicMaterial( { color: color } ) );
+		this.line = new THREE.Line( lineGeometry, new THREE.LineBasicMaterial( { color: this.colors.main } ) );
 		this.line.matrixAutoUpdate = false;
 		this.add( this.line );
 
-		this.cone = new THREE.Mesh( coneGeometry, new THREE.MeshBasicMaterial( { color: color } ) );
+		this.cone = new THREE.Mesh( coneGeometry, new THREE.MeshBasicMaterial( { color: this.colors.main } ) );
 		this.cone.matrixAutoUpdate = false;
 		this.add( this.cone );
 
 		this.setDirection( dir );
 		this.setLength( length, headLength, headWidth );
 
-	}
+	};
 
 }() );
 
@@ -100,7 +105,8 @@ THREE.ArrowHelper.prototype.setLength = function ( length, headLength, headWidth
 
 THREE.ArrowHelper.prototype.setColor = function ( color ) {
 
-	this.line.material.color.set( color );
-	this.cone.material.color.set( color );
+	this.colors.main.set( color );
+	this.line.material.color.copy( this.colors.main );
+	this.cone.material.color.copy( this.colors.main );
 
 };

--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -106,6 +106,7 @@ THREE.ArrowHelper.prototype.setLength = function ( length, headLength, headWidth
 THREE.ArrowHelper.prototype.setColor = function ( color ) {
 
 	this.colors.main.set( color );
+	
 	this.line.material.color.copy( this.colors.main );
 	this.cone.material.color.copy( this.colors.main );
 

--- a/src/extras/helpers/AxisHelper.js
+++ b/src/extras/helpers/AxisHelper.js
@@ -6,6 +6,12 @@
 THREE.AxisHelper = function ( size ) {
 
 	size = size || 1;
+	
+	this.colors = {
+		xAxisStart: new THREE.Color( 1, 0, 0 ), xAxisEnd: new THREE.Color( 1, 0.6, 0 ),
+		yAxisStart: new THREE.Color( 0, 1, 0 ), yAxisEnd: new THREE.Color( 0.6, 1, 0 ),
+		zAxisStart: new THREE.Color( 0, 0, 1 ), zAxisEnd: new THREE.Color( 0, 0.6, 1 )
+	};
 
 	var vertices = new Float32Array( [
 		0, 0, 0,  size, 0, 0,
@@ -14,9 +20,9 @@ THREE.AxisHelper = function ( size ) {
 	] );
 
 	var colors = new Float32Array( [
-		1, 0, 0,  1, 0.6, 0,
-		0, 1, 0,  0.6, 1, 0,
-		0, 0, 1,  0, 0.6, 1
+		this.colors.xAxisStart.r, this.colors.xAxisStart.g, this.colors.xAxisStart.b,  this.colors.xAxisEnd.r, this.colors.xAxisEnd.g, this.colors.xAxisEnd.b,
+		this.colors.yAxisStart.r, this.colors.yAxisStart.g, this.colors.yAxisStart.b,  this.colors.yAxisEnd.r, this.colors.yAxisEnd.g, this.colors.yAxisEnd.b,
+		this.colors.zAxisStart.r, this.colors.zAxisStart.g, this.colors.zAxisStart.b,  this.colors.zAxisEnd.r, this.colors.zAxisEnd.g, this.colors.zAxisEnd.b
 	] );
 
 	var geometry = new THREE.BufferGeometry();
@@ -31,3 +37,22 @@ THREE.AxisHelper = function ( size ) {
 
 THREE.AxisHelper.prototype = Object.create( THREE.Line.prototype );
 THREE.AxisHelper.prototype.constructor = THREE.AxisHelper;
+
+THREE.AxisHelper.prototype.setColors = function ( xStart, xEnd, yStart, yEnd, zStart, zEnd ) {
+
+	this.colors.xAxisStart.set( xStart );  this.colors.xAxisEnd.set( xEnd );
+	this.colors.yAxisStart.set( yStart );  this.colors.yAxisEnd.set( yEnd );
+	this.colors.zAxisStart.set( zStart );  this.colors.zAxisEnd.set( zEnd );
+	
+	var colorArray = this.geometry.attributes.color.array;
+	
+	colorArray[ 0 ] = this.colors.xAxisStart.r;  colorArray[ 1 ] = this.colors.xAxisStart.g;  colorArray[ 2 ] = this.colors.xAxisStart.b;
+	colorArray[ 3 ] = this.colors.xAxisEnd.r;    colorArray[ 4 ] = this.colors.xAxisEnd.g;    colorArray[ 5 ] = this.colors.xAxisEnd.b;
+	colorArray[ 6 ] = this.colors.yAxisStart.r;  colorArray[ 7 ] = this.colors.yAxisStart.g;  colorArray[ 8 ] = this.colors.yAxisStart.b;
+	colorArray[ 9 ] = this.colors.yAxisEnd.r;    colorArray[ 10 ] = this.colors.yAxisEnd.g;   colorArray[ 11 ] = this.colors.yAxisEnd.b;
+	colorArray[ 12 ] = this.colors.zAxisStart.r; colorArray[ 13 ] = this.colors.zAxisStart.g; colorArray[ 14 ] = this.colors.zAxisStart.b;
+	colorArray[ 15 ] = this.colors.zAxisEnd.r;   colorArray[ 16 ] = this.colors.zAxisEnd.g;   colorArray[ 17 ] = this.colors.zAxisEnd.b;
+	
+	this.geometry.attributes.color.needsUpdate = true;
+
+};

--- a/src/extras/helpers/BoundingBoxHelper.js
+++ b/src/extras/helpers/BoundingBoxHelper.js
@@ -7,6 +7,7 @@
 THREE.BoundingBoxHelper = function ( object, color ) {
 
 	if ( color === undefined ) color = 0x888888;
+	
 	this.colors = {
     		main: new THREE.Color()
 	};

--- a/src/extras/helpers/BoundingBoxHelper.js
+++ b/src/extras/helpers/BoundingBoxHelper.js
@@ -4,15 +4,19 @@
 
 // a helper to show the world-axis-aligned bounding box for an object
 
-THREE.BoundingBoxHelper = function ( object, hex ) {
+THREE.BoundingBoxHelper = function ( object, color ) {
 
-	var color = ( hex !== undefined ) ? hex : 0x888888;
+	if ( color === undefined ) color = 0x888888;
+	this.colors = {
+    		main: new THREE.Color()
+	};
+	this.colors.main.set( color );
 
 	this.object = object;
 
 	this.box = new THREE.Box3();
 
-	THREE.Mesh.call( this, new THREE.BoxGeometry( 1, 1, 1 ), new THREE.MeshBasicMaterial( { color: color, wireframe: true } ) );
+	THREE.Mesh.call( this, new THREE.BoxGeometry( 1, 1, 1 ), new THREE.MeshBasicMaterial( { color: this.colors.main, wireframe: true } ) );
 
 };
 
@@ -27,4 +31,11 @@ THREE.BoundingBoxHelper.prototype.update = function () {
 
 	this.box.center( this.position );
 
+};
+
+THREE.BoundingBoxHelper.prototype.setColor = function ( color ) {
+	
+	this.colors.main.set( color );
+	this.material.color.copy( this.colors.main );
+	
 };

--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -2,12 +2,18 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.BoxHelper = function ( object ) {
+THREE.BoxHelper = function ( object, color ) {
+	
+	var tempColor = ( color !== undefined ) ? color : 0xffff00;
+	this.colors = {
+    		main: new THREE.Color()
+	};
+	this.colors.main.set( tempColor );
 
 	var geometry = new THREE.BufferGeometry();
 	geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( 72 ), 3 ) );
 
-	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: 0xffff00 } ), THREE.LinePieces );
+	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: this.colors.main } ), THREE.LinePieces );
 
 	if ( object !== undefined ) {
 
@@ -98,4 +104,11 @@ THREE.BoxHelper.prototype.update = function ( object ) {
 	this.matrix = object.matrixWorld;
 	this.matrixAutoUpdate = false;
 
+};
+
+THREE.BoxHelper.prototype.setColor = function ( color ) {
+	
+	this.colors.main.set( color );
+	this.material.color.copy( this.colors.main );
+	
 };

--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -5,6 +5,7 @@
 THREE.BoxHelper = function ( object, color ) {
 	
 	if ( color === undefined ) color = 0xffff00;
+	
 	this.colors = {
     		main: new THREE.Color()
 	};

--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -4,11 +4,11 @@
 
 THREE.BoxHelper = function ( object, color ) {
 	
-	var tempColor = ( color !== undefined ) ? color : 0xffff00;
+	if ( color === undefined ) color = 0xffff00;
 	this.colors = {
     		main: new THREE.Color()
 	};
-	this.colors.main.set( tempColor );
+	this.colors.main.set( color );
 
 	var geometry = new THREE.BufferGeometry();
 	geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( 72 ), 3 ) );

--- a/src/extras/helpers/CameraHelper.js
+++ b/src/extras/helpers/CameraHelper.js
@@ -16,58 +16,60 @@ THREE.CameraHelper = function ( camera ) {
 
 	// colors
 
-	var hexFrustum = 0xffaa00;
-	var hexCone = 0xff0000;
-	var hexUp = 0x00aaff;
-	var hexTarget = 0xffffff;
-	var hexCross = 0x333333;
+	this.colors = {
+		frustum: new THREE.Color( 0xffaa00 ),
+		cone: new THREE.Color( 0xff0000 ),
+		up: new THREE.Color( 0x00aaff ),
+		target: new THREE.Color( 0xffffff ),
+		cross: new THREE.Color( 0x333333 )	
+	};
 
 	// near
 
-	addLine( "n1", "n2", hexFrustum );
-	addLine( "n2", "n4", hexFrustum );
-	addLine( "n4", "n3", hexFrustum );
-	addLine( "n3", "n1", hexFrustum );
+	addLine( "n1", "n2", this.colors.frustum ); //0,1
+	addLine( "n2", "n4", this.colors.frustum ); //2,3
+	addLine( "n4", "n3", this.colors.frustum ); //4,5
+	addLine( "n3", "n1", this.colors.frustum ); //6,7
 
 	// far
 
-	addLine( "f1", "f2", hexFrustum );
-	addLine( "f2", "f4", hexFrustum );
-	addLine( "f4", "f3", hexFrustum );
-	addLine( "f3", "f1", hexFrustum );
+	addLine( "f1", "f2", this.colors.frustum ); //8,9
+	addLine( "f2", "f4", this.colors.frustum ); //10,11
+	addLine( "f4", "f3", this.colors.frustum ); //12,13
+	addLine( "f3", "f1", this.colors.frustum ); //14,15
 
 	// sides
 
-	addLine( "n1", "f1", hexFrustum );
-	addLine( "n2", "f2", hexFrustum );
-	addLine( "n3", "f3", hexFrustum );
-	addLine( "n4", "f4", hexFrustum );
+	addLine( "n1", "f1", this.colors.frustum ); //16,17
+	addLine( "n2", "f2", this.colors.frustum ); //18,19
+	addLine( "n3", "f3", this.colors.frustum ); //20,21
+	addLine( "n4", "f4", this.colors.frustum ); //22,23
 
 	// cone
 
-	addLine( "p", "n1", hexCone );
-	addLine( "p", "n2", hexCone );
-	addLine( "p", "n3", hexCone );
-	addLine( "p", "n4", hexCone );
+	addLine( "p", "n1", this.colors.cone ); //24,25
+	addLine( "p", "n2", this.colors.cone ); //26,27
+	addLine( "p", "n3", this.colors.cone ); //28,29
+	addLine( "p", "n4", this.colors.cone ); //30,31
 
 	// up
 
-	addLine( "u1", "u2", hexUp );
-	addLine( "u2", "u3", hexUp );
-	addLine( "u3", "u1", hexUp );
+	addLine( "u1", "u2", this.colors.up ); //32,33
+	addLine( "u2", "u3", this.colors.up ); //34,35
+	addLine( "u3", "u1", this.colors.up ); //36,37
 
 	// target
 
-	addLine( "c", "t", hexTarget );
-	addLine( "p", "c", hexCross );
+	addLine( "c", "t", this.colors.target ); //38,39
+	addLine( "p", "c", this.colors.cross ); //40,41
 
 	// cross
 
-	addLine( "cn1", "cn2", hexCross );
-	addLine( "cn3", "cn4", hexCross );
+	addLine( "cn1", "cn2", this.colors.cross ); //42,43
+	addLine( "cn3", "cn4", this.colors.cross ); //44,45
 
-	addLine( "cf1", "cf2", hexCross );
-	addLine( "cf3", "cf4", hexCross );
+	addLine( "cf1", "cf2", this.colors.cross ); //46,47
+	addLine( "cf3", "cf4", this.colors.cross ); //48,49
 
 	function addLine( a, b, hex ) {
 
@@ -185,3 +187,38 @@ THREE.CameraHelper.prototype.update = function () {
 	};
 
 }();
+
+THREE.CameraHelper.prototype.setColors = function ( frustum, cone, up, target, cross ) {
+
+	this.colors.frustum.set( frustum );
+	this.colors.cone.set( cone );
+	this.colors.up.set( up );
+	this.colors.target.set( target );
+	this.colors.cross.set( cross );
+	
+	var colorObjectArray = this.geometry.colors;
+	var i = 0;
+	
+	for ( i = 0; i < 24; i ++ ) {
+		colorObjectArray[ i ].set( frustum );	
+	}
+	
+	for ( i = 24; i < 32; i ++ ) {	
+		colorObjectArray[ i ].set( cone );	
+	}
+	
+	for ( i = 32; i < 38; i ++ ) {	
+		colorObjectArray[ i ].set( up );	
+	}
+	
+	for ( i = 38; i < 40; i ++ ) {	
+		colorObjectArray[ i ].set( target );	
+	}
+	
+	for ( i = 40; i < 50; i ++ ) {	
+		colorObjectArray[ i ].set( cross );	
+	}
+	
+	this.geometry.colorsNeedUpdate = true;
+	
+};

--- a/src/extras/helpers/CameraHelper.js
+++ b/src/extras/helpers/CameraHelper.js
@@ -200,23 +200,23 @@ THREE.CameraHelper.prototype.setColors = function ( frustum, cone, up, target, c
 	var i = 0;
 	
 	for ( i = 0; i < 24; i ++ ) {
-		colorObjectArray[ i ].set( frustum );	
+		colorObjectArray[ i ].copy( this.colors.frustum );	
 	}
 	
 	for ( i = 24; i < 32; i ++ ) {	
-		colorObjectArray[ i ].set( cone );	
+		colorObjectArray[ i ].copy( this.colors.cone );	
 	}
 	
 	for ( i = 32; i < 38; i ++ ) {	
-		colorObjectArray[ i ].set( up );	
+		colorObjectArray[ i ].copy( this.colors.up );	
 	}
 	
 	for ( i = 38; i < 40; i ++ ) {	
-		colorObjectArray[ i ].set( target );	
+		colorObjectArray[ i ].copy( this.colors.target );	
 	}
 	
 	for ( i = 40; i < 50; i ++ ) {	
-		colorObjectArray[ i ].set( cross );	
+		colorObjectArray[ i ].copy( this.colors.cross );	
 	}
 	
 	this.geometry.colorsNeedUpdate = true;

--- a/src/extras/helpers/EdgesHelper.js
+++ b/src/extras/helpers/EdgesHelper.js
@@ -5,6 +5,7 @@
 THREE.EdgesHelper = function ( object, color ) {
 
 	if ( color === undefined ) color = 0xffffff;
+	
 	this.colors = {
     		main: new THREE.Color()
 	};

--- a/src/extras/helpers/EdgesHelper.js
+++ b/src/extras/helpers/EdgesHelper.js
@@ -2,12 +2,16 @@
  * @author WestLangley / http://github.com/WestLangley
  */
 
-THREE.EdgesHelper = function ( object, hex ) {
+THREE.EdgesHelper = function ( object, color ) {
 
-	var color = ( hex !== undefined ) ? hex : 0xffffff;
+	if ( color === undefined ) color = 0xffffff;
+	this.colors = {
+    		main: new THREE.Color()
+	};
+	this.colors.main.set( color );
 
 	var edge = [ 0, 0 ], hash = {};
-	var sortFunction = function ( a, b ) { return a - b };
+	var sortFunction = function ( a, b ) { return a - b; };
 
 	var keys = [ 'a', 'b', 'c' ];
 	var geometry = new THREE.BufferGeometry();
@@ -74,7 +78,7 @@ THREE.EdgesHelper = function ( object, hex ) {
 
 	geometry.addAttribute( 'position', new THREE.BufferAttribute( coords, 3 ) );
 
-	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: color } ), THREE.LinePieces );
+	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: this.colors.main } ), THREE.LinePieces );
 
 	this.matrix = object.matrixWorld;
 	this.matrixAutoUpdate = false;
@@ -83,3 +87,10 @@ THREE.EdgesHelper = function ( object, hex ) {
 
 THREE.EdgesHelper.prototype = Object.create( THREE.Line.prototype );
 THREE.EdgesHelper.prototype.constructor = THREE.EdgesHelper;
+
+THREE.EdgesHelper.prototype.setColor = function ( color ) {
+	
+	this.colors.main.set( color );
+	this.material.color.copy( this.colors.main );
+	
+};

--- a/src/extras/helpers/FaceNormalsHelper.js
+++ b/src/extras/helpers/FaceNormalsHelper.js
@@ -9,7 +9,8 @@ THREE.FaceNormalsHelper = function ( object, size, color, linewidth ) {
 
 	this.size = ( size !== undefined ) ? size : 1;
 
-	if ( color === undefined ) color = 0xffffff;
+	if ( color === undefined ) color = 0xffff00;
+	
 	this.colors = {
     		main: new THREE.Color()
 	};

--- a/src/extras/helpers/FaceNormalsHelper.js
+++ b/src/extras/helpers/FaceNormalsHelper.js
@@ -3,13 +3,17 @@
  * @author WestLangley / http://github.com/WestLangley
 */
 
-THREE.FaceNormalsHelper = function ( object, size, hex, linewidth ) {
+THREE.FaceNormalsHelper = function ( object, size, color, linewidth ) {
 
 	this.object = object;
 
 	this.size = ( size !== undefined ) ? size : 1;
 
-	var color = ( hex !== undefined ) ? hex : 0xffff00;
+	if ( color === undefined ) color = 0xffffff;
+	this.colors = {
+    		main: new THREE.Color()
+	};
+	this.colors.main.set( color );
 
 	var width = ( linewidth !== undefined ) ? linewidth : 1;
 
@@ -23,7 +27,7 @@ THREE.FaceNormalsHelper = function ( object, size, hex, linewidth ) {
 
 	}
 
-	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: color, linewidth: width } ), THREE.LinePieces );
+	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: this.colors.main, linewidth: width } ), THREE.LinePieces );
 
 	this.matrixAutoUpdate = false;
 
@@ -73,3 +77,9 @@ THREE.FaceNormalsHelper.prototype.update = function () {
 
 };
 
+THREE.FaceNormalsHelper.prototype.setColor = function ( color ) {
+	
+	this.colors.main.set( color );
+	this.material.color.copy( this.colors.main );
+	
+};

--- a/src/extras/helpers/GridHelper.js
+++ b/src/extras/helpers/GridHelper.js
@@ -36,7 +36,7 @@ THREE.GridHelper = function ( size, step, colorCenterLine, colorGrid ) {
 THREE.GridHelper.prototype = Object.create( THREE.Line.prototype );
 THREE.GridHelper.prototype.constructor = THREE.GridHelper;
 
-THREE.GridHelper.prototype.setColors = function( colorCenterLine, colorGrid ) {
+THREE.GridHelper.prototype.setColors = function ( colorCenterLine, colorGrid ) {
 
 	this.colors.centerLine.set( colorCenterLine );
 	this.colors.grid.set( colorGrid );

--- a/src/extras/helpers/GridHelper.js
+++ b/src/extras/helpers/GridHelper.js
@@ -9,6 +9,7 @@ THREE.GridHelper = function ( size, step, colorCenterLine, colorGrid ) {
 	
 	if ( colorCenterLine === undefined ) colorCenterLine = 0x444444;
 	if ( colorGrid === undefined ) colorGrid = 0x888888;
+	
 	this.colors = {
 		centerLine: new THREE.Color(),
     		grid: new THREE.Color()

--- a/src/extras/helpers/GridHelper.js
+++ b/src/extras/helpers/GridHelper.js
@@ -2,13 +2,19 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.GridHelper = function ( size, step ) {
+THREE.GridHelper = function ( size, step, colorCenterLine, colorGrid ) {
 
 	var geometry = new THREE.Geometry();
 	var material = new THREE.LineBasicMaterial( { vertexColors: THREE.VertexColors } );
-
-	this.color1 = new THREE.Color( 0x444444 );
-	this.color2 = new THREE.Color( 0x888888 );
+	
+	if ( colorCenterLine === undefined ) colorCenterLine = 0x444444;
+	if ( colorGrid === undefined ) colorGrid = 0x888888;
+	this.colors = {
+		centerLine: new THREE.Color(),
+    		grid: new THREE.Color()
+	};
+	this.colors.centerLine.set( colorCenterLine );
+	this.colors.grid.set( colorGrid );
 
 	for ( var i = - size; i <= size; i += step ) {
 
@@ -17,7 +23,7 @@ THREE.GridHelper = function ( size, step ) {
 			new THREE.Vector3( i, 0, - size ), new THREE.Vector3( i, 0, size )
 		);
 
-		var color = i === 0 ? this.color1 : this.color2;
+		var color = i === 0 ? this.colors.centerLine : this.colors.grid;
 
 		geometry.colors.push( color, color, color, color );
 
@@ -32,9 +38,9 @@ THREE.GridHelper.prototype.constructor = THREE.GridHelper;
 
 THREE.GridHelper.prototype.setColors = function( colorCenterLine, colorGrid ) {
 
-	this.color1.set( colorCenterLine );
-	this.color2.set( colorGrid );
+	this.colors.centerLine.set( colorCenterLine );
+	this.colors.grid.set( colorGrid );
 
 	this.geometry.colorsNeedUpdate = true;
 
-}
+};

--- a/src/extras/helpers/SkeletonHelper.js
+++ b/src/extras/helpers/SkeletonHelper.js
@@ -14,7 +14,6 @@ THREE.SkeletonHelper = function ( object, color1, color2 ) {
 		color1: new THREE.Color(),
     		color2: new THREE.Color()
 	};
-	
 	this.colors.color1.set( color1 );
 	this.colors.color2.set( color2 );
 	

--- a/src/extras/helpers/SkeletonHelper.js
+++ b/src/extras/helpers/SkeletonHelper.js
@@ -5,8 +5,19 @@
  * @author ikerr / http://verold.com
  */
 
-THREE.SkeletonHelper = function ( object ) {
+THREE.SkeletonHelper = function ( object, color1, color2 ) {
 
+	if ( color1 === undefined ) color1 = 0x0000ff;
+	if ( color2 === undefined ) color2 = 0x00ff00;
+	
+	this.colors = {
+		color1: new THREE.Color(),
+    		color2: new THREE.Color()
+	};
+	
+	this.colors.color1.set( color1 );
+	this.colors.color2.set( color2 );
+	
 	this.bones = this.getBoneList( object );
 
 	var geometry = new THREE.Geometry();
@@ -19,8 +30,8 @@ THREE.SkeletonHelper = function ( object ) {
 
 			geometry.vertices.push( new THREE.Vector3() );
 			geometry.vertices.push( new THREE.Vector3() );
-			geometry.colors.push( new THREE.Color( 0, 0, 1 ) );
-			geometry.colors.push( new THREE.Color( 0, 1, 0 ) );
+			geometry.colors.push( this.colors.color1 );
+			geometry.colors.push( this.colors.color2 );
 
 		}
 
@@ -94,5 +105,14 @@ THREE.SkeletonHelper.prototype.update = function () {
 	geometry.verticesNeedUpdate = true;
 
 	geometry.computeBoundingSphere();
+
+};
+
+THREE.SkeletonHelper.prototype.setColors = function ( color1, color2 ) {
+
+	this.colors.color1.set( color1 );
+	this.colors.color2.set( color2 );
+	
+	this.geometry.colorsNeedUpdate = true;
 
 };

--- a/src/extras/helpers/VertexNormalsHelper.js
+++ b/src/extras/helpers/VertexNormalsHelper.js
@@ -3,13 +3,17 @@
  * @author WestLangley / http://github.com/WestLangley
 */
 
-THREE.VertexNormalsHelper = function ( object, size, hex, linewidth ) {
+THREE.VertexNormalsHelper = function ( object, size, color, linewidth ) {
 
 	this.object = object;
 
 	this.size = ( size !== undefined ) ? size : 1;
 
-	var color = ( hex !== undefined ) ? hex : 0xff0000;
+	if ( color === undefined ) color = 0xff0000;
+	this.colors = {
+    		main: new THREE.Color()
+	};
+	this.colors.main.set( color );
 
 	var width = ( linewidth !== undefined ) ? linewidth : 1;
 
@@ -31,7 +35,7 @@ THREE.VertexNormalsHelper = function ( object, size, hex, linewidth ) {
 
 	}
 
-	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: color, linewidth: width } ), THREE.LinePieces );
+	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: this.colors.main, linewidth: width } ), THREE.LinePieces );
 
 	this.matrixAutoUpdate = false;
 
@@ -95,6 +99,13 @@ THREE.VertexNormalsHelper.prototype.update = ( function ( object ) {
 
 		return this;
 
-	}
+	};
 
 }());
+
+THREE.VertexNormalsHelper.prototype.setColor = function ( color ) {
+	
+	this.colors.main.set( color );
+	this.material.color.copy( this.colors.main );
+	
+};

--- a/src/extras/helpers/VertexNormalsHelper.js
+++ b/src/extras/helpers/VertexNormalsHelper.js
@@ -10,6 +10,7 @@ THREE.VertexNormalsHelper = function ( object, size, color, linewidth ) {
 	this.size = ( size !== undefined ) ? size : 1;
 
 	if ( color === undefined ) color = 0xff0000;
+	
 	this.colors = {
     		main: new THREE.Color()
 	};

--- a/src/extras/helpers/VertexTangentsHelper.js
+++ b/src/extras/helpers/VertexTangentsHelper.js
@@ -10,6 +10,7 @@ THREE.VertexTangentsHelper = function ( object, size, color, linewidth ) {
 	this.size = ( size !== undefined ) ? size : 1;
 
 	if ( color === undefined ) color = 0x0000ff;
+	
 	this.colors = {
     		main: new THREE.Color()
 	};

--- a/src/extras/helpers/VertexTangentsHelper.js
+++ b/src/extras/helpers/VertexTangentsHelper.js
@@ -3,13 +3,17 @@
  * @author WestLangley / http://github.com/WestLangley
 */
 
-THREE.VertexTangentsHelper = function ( object, size, hex, linewidth ) {
+THREE.VertexTangentsHelper = function ( object, size, color, linewidth ) {
 
 	this.object = object;
 
 	this.size = ( size !== undefined ) ? size : 1;
 
-	var color = ( hex !== undefined ) ? hex : 0x0000ff;
+	if ( color === undefined ) color = 0x0000ff;
+	this.colors = {
+    		main: new THREE.Color()
+	};
+	this.colors.main.set( color );
 
 	var width = ( linewidth !== undefined ) ? linewidth : 1;
 
@@ -32,7 +36,7 @@ THREE.VertexTangentsHelper = function ( object, size, hex, linewidth ) {
 
 	}
 
-	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: color, linewidth: width } ), THREE.LinePieces );
+	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: this.colors.main, linewidth: width } ), THREE.LinePieces );
 
 	this.matrixAutoUpdate = false;
 
@@ -92,6 +96,13 @@ THREE.VertexTangentsHelper.prototype.update = ( function ( object ) {
 
 		return this;
 
-	}
+	};
 
 }());
+
+THREE.VertexTangentsHelper.prototype.setColor = function ( color ) {
+	
+	this.colors.main.set( color );
+	this.material.color.copy( this.colors.main );
+	
+};

--- a/src/extras/helpers/WireframeHelper.js
+++ b/src/extras/helpers/WireframeHelper.js
@@ -5,6 +5,7 @@
 THREE.WireframeHelper = function ( object, color ) {
 
 	if ( color === undefined ) color = 0xffffff;
+	
 	this.colors = {
     		main: new THREE.Color()
 	};

--- a/src/extras/helpers/WireframeHelper.js
+++ b/src/extras/helpers/WireframeHelper.js
@@ -2,12 +2,16 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.WireframeHelper = function ( object, hex ) {
+THREE.WireframeHelper = function ( object, color ) {
 
-	var color = ( hex !== undefined ) ? hex : 0xffffff;
+	if ( color === undefined ) color = 0xffffff;
+	this.colors = {
+    		main: new THREE.Color()
+	};
+	this.colors.main.set( color );
 
 	var edge = [ 0, 0 ], hash = {};
-	var sortFunction = function ( a, b ) { return a - b };
+	var sortFunction = function ( a, b ) { return a - b; };
 
 	var keys = [ 'a', 'b', 'c' ];
 	var geometry = new THREE.BufferGeometry();
@@ -166,7 +170,7 @@ THREE.WireframeHelper = function ( object, hex ) {
 
 	}
 
-	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: color } ), THREE.LinePieces );
+	THREE.Line.call( this, geometry, new THREE.LineBasicMaterial( { color: this.colors.main } ), THREE.LinePieces );
 
 	this.matrix = object.matrixWorld;
 	this.matrixAutoUpdate = false;
@@ -175,3 +179,10 @@ THREE.WireframeHelper = function ( object, hex ) {
 
 THREE.WireframeHelper.prototype = Object.create( THREE.Line.prototype );
 THREE.WireframeHelper.prototype.constructor = THREE.WireframeHelper;
+
+THREE.WireframeHelper.prototype.setColor = function ( color ) {
+	
+	this.colors.main.set( color );
+	this.material.color.copy( this.colors.main );
+	
+};


### PR DESCRIPTION
Hi @mrdoob 
    This PR adds the requested 'colors' object to all relevant helpers.  Also I added optional color arguments to the initial helper constructors (where needed and intuitive).  Finally, to allow the user to directly change the colors, I added a .setColor or .setColors method to all the relevant helpers.  Changed colors are affected immediately on the next Render frame.
    As previously mentioned, I did not touch the Light helpers, because they derive their colors directly from their parent light source, and changing these helpers' colors is not really useful IMO.
The most difficult one to change in this PR was AxisHelper, because it is buffergeometry.  Learned a lot from that one! :)
    I personally will get a lot of use out of the ability to change the helpers' colors on the fly.  Hopefully others will too.  Let me know if I need to update or correct anything.  Thanks!
-Erich
