### PR TITLE
Removed matrixAutoUpdate From Animation 

### DIFF
--- a/src/extras/animation/Animation.js
+++ b/src/extras/animation/Animation.js
@@ -53,8 +53,6 @@ THREE.Animation.prototype.reset = function () {
 
 		var object = this.hierarchy[ h ];
 
-		object.matrixAutoUpdate = true;
-
 		if ( object.animationCache === undefined ) {
 
 			object.animationCache = {
@@ -236,9 +234,6 @@ THREE.Animation.prototype.update = (function(){
 					animationCache.nextKey[ type ] = nextKey;
 
 				}
-
-				object.matrixAutoUpdate = true;
-				object.matrixWorldNeedsUpdate = true;
 
 				var scale = ( this.currentTime - prevKey.time ) / ( nextKey.time - prevKey.time );
 


### PR DESCRIPTION
Removed the lines forcing matrixAutoApdate and matrixWorldNeedsUpdate to true from Animations update and reset. Per Issue #5704
