### PR TITLE
Fix non-looped animations ending before last key is applied

### DIFF
--- a/src/extras/animation/Animation.js
+++ b/src/extras/animation/Animation.js
@@ -195,7 +195,6 @@ THREE.Animation.prototype.update = (function(){
 			} else {
 
 				this.stop();
-				return;
 
 			}
 


### PR DESCRIPTION
Before this fix, the animation stops when the time is past the end but doesn't render anything, leaving the object interpolated almost-but-not-quite all the way to the last key.

With this fix, the animation goes through the code once after the time is past the end of the animation which makes sure the last key is applied correctly.

-David
