### PR TITLE
Sorted materials docs parameters and properties to reflect order in materials source code

### DIFF
--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -24,17 +24,18 @@
 		<div>parameters is an object with one or more properties defining the material's appearance.</div>
 		<div>
 		color — geometry color in hexadecimal. Default is 0xffffff.<br />
-		wireframe — render geometry as wireframe. Default is false.<br />
-		wireframeLinewidth — Line thickness. Default is 1.<br />
-		wireframeLinecap — Define appearance of line ends. Default is 'round'.<br />
-		wireframeLinejoin — Define appearance of line joints. Default is 'round'.<br />
-		shading — Define shading type. Default is THREE.SmoothShading.<br />
-		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
+		map — Sets the texture map. Default is null <br />
 		lightMap — Set light map. Default is null.<br />
 		specularMap — Set specular map. Default is null.<br />
 		alphaMap — Set alpha map. Default is null.<br />
 		envMap — Set env map. Default is null.<br />
+		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
+		shading — Define shading type. Default is THREE.SmoothShading.<br />
+		wireframe — render geometry as wireframe. Default is false.<br />
+		wireframeLinewidth — Line thickness. Default is 1.<br />
+		wireframeLinecap — Define appearance of line ends. Default is 'round'.<br />
+		wireframeLinejoin — Define appearance of line joints. Default is 'round'.<br />
+		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
 		skinning — Define whether the material uses skinning. Default is false.<br />
 		morphTargets — Define whether the material uses morphTargets. Default is false.
 		</div>
@@ -44,6 +45,26 @@
 		<h3>[property:Integer color]</h3>
 		<div>Sets the color of the geometry. Default is 0xffffff.</div>
 		
+		<h3>[property:Texture lightMap]</h3>
+		<div>Set light map. Default is null.</div>
+
+		<h3>[property:Texture specularMap]</h3>
+		<div>Set specular map. Default is null.</div>
+
+		<h3>[property:Texture alphaMap]</h3>
+		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
+		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
+
+		<h3>[property:TextureCube envMap]</h3>
+		<div>Set env map. Default is null.</div>
+
+		<h3>[property:Boolean fog]</h3>
+		<div>Define whether the material color is affected by global fog settings.</div>
+		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
+
+		<h3>[property:String shading]</h3>
+		<div>Define shading type. Default is THREE.SmoothShading.</div>
+
 		<h3>[property:Boolean wireframe]</h3>
 		<div>Render geometry as wireframe. Default is false (i.e. render as flat polygons).</div>
 
@@ -59,29 +80,9 @@
 		<div>Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.</div>
 		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
 		
-		<h3>[property:String shading]</h3>
-		<div>Define shading type. Default is THREE.SmoothShading.</div>
-
 		<h3>[property:Integer vertexColors]</h3>
 		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
 		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
-
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
-
-		<h3>[property:Texture lightMap]</h3>
-		<div>Set light map. Default is null.</div>
-
-		<h3>[property:Texture specularMap]</h3>
-		<div>Set specular map. Default is null.</div>
-
-		<h3>[property:Texture alphaMap]</h3>
-		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
-		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
-
-		<h3>[property:TextureCube envMap]</h3>
-		<div>Set env map. Default is null.</div>
 
 		<h3>[property:Boolean skinning]</h3>
 		<div>Define whether the material uses skinning. Default is false.</div>

--- a/docs/api/materials/MeshDepthMaterial.html
+++ b/docs/api/materials/MeshDepthMaterial.html
@@ -23,6 +23,7 @@
 		parameters is an object with one or more properties defining the material's appearance. 
 		</div>
 		<div>
+		morphTargets -- Define whether the material uses morphTargets. Default is false.<br/>
 		wireframe -- Render geometry as wireframe. Default is false (i.e. render as smooth shaded).<br/>
 		wireframeLinewidth -- Controls wireframe thickness. Default is 1.<br/>
 		</div>
@@ -30,6 +31,9 @@
 
 		<h2>Properties</h2>
 
+
+		<h3>[property:boolean morphTargets]</h3>
+		<div>Define whether the material uses morphTargets. Default is false.</div> 
 
 		<h3>[property:boolean wireframe]</h3>
 		<div>Render geometry as wireframe. Default is false (i.e. render as smooth shaded).</div> 

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -22,6 +22,23 @@
 		<div>
 		parameters -- parameters is an object with one or more properties defining the material's appearance.
 		</div>
+		<div>
+		color — Line color in hexadecimal. Default is 0xffffff.<br />
+		map — Sets the texture map. Default is null <br />
+		lightMap — Set light map. Default is null.<br />
+		specularMap — Set specular map. Default is null.<br />
+		alphaMap — Set alpha map. Default is null.<br />
+		envMap — Set env map. Default is null.<br />
+		fog — Define whether the material color is affected by global fog settings. Default is false.
+		shading — How the triangles of a curved surface are rendered. Default is [page:Materials THREE.SmoothShading].<br/>
+		wireframe — Render geometry as wireframe. Default is false (i.e. render as smooth shaded).<br/>
+		wireframeLinewidth — Controls wireframe thickness. Default is 1.<br/>
+		wireframeLinecap — Define appearance of line ends. Default is 'round'.<br />
+		wireframeLinejoin — Define appearance of line joints. Default is 'round'.<br />
+		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
+		skinning — Define whether the material uses skinning. Default is false.<br />
+		morphTargets — Define whether the material uses morphTargets. Default is false.<br/>
+		</div>
 
 
 		<h2>Properties</h2>
@@ -41,6 +58,51 @@
 		<div>
 		Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
 		</div>
+		
+		<h3>[property:boolean wrapAround]</h3>
+		<div>
+			Define whether the diffuse lighting wraps around the model or not. This option adds a little more (tintable) light
+			onto the side of the object in relation to a light.
+		</div>
+
+		<h3>[property:Vector3 wrapRGB]</h3>
+		<div>
+			Decide how much of the wrap around values get used if the wrapAround option is set. The x, y, z values correspond
+			to the r, g, b values respectively. The typical range is of each is from 0 to 1. For example setting all of the
+			vector values to 0.5 will add a moderate amount of light to the side of the model. Changing *b* to 1 will
+			tint the light on the side to be more blue. Defaults to *(1,1,1)*.
+		</div> 
+
+		<h3>[property:Texture map]</h3>
+		<div>Set color texture map. Default is null.</div>
+
+		<h3>[property:Texture lightMap]</h3>
+		<div>Set light map. Default is null.</div>
+
+		<h3>[property:Texture specularMap]</h3>
+		<div>Since this material does not have a specular component, the specular value affects only how much of the environment map affects the surface. Default is null.</div>
+
+		<h3>[property:Texture alphaMap]</h3>
+		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
+		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
+
+		<h3>[property:TextureCube envMap]</h3>
+		<div>Set env map. Default is null.</div>
+
+		<h3>[property:Integer combine]</h3>
+		<div>How to combine the result of the surface's color with the environment map, if any.</div> 
+		 
+		<div>Options are [page:Textures THREE.Multiply] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
+		 
+		<h3>[property:Float reflectivity]</h3>
+		<div>How much the environment map affects the surface; also see "combine".</div> 
+
+		<h3>[property:Float refractionRatio]</h3>
+		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
+
+		<h3>[property:Boolean fog]</h3>
+		<div>Define whether the material color is affected by global fog settings. Default is *true*.</div>
+		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
 
 		<h3>[property:Integer shading]</h3>
 		<div>How the triangles of a curved surface are rendered: as a smooth surface, as flat separate facets, or no shading at all.</div>
@@ -66,56 +128,11 @@
 		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
 		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings. Default is *true*.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
-
-		<h3>[property:Texture map]</h3>
-		<div>Set color texture map. Default is null.</div>
-
-		<h3>[property:Texture lightMap]</h3>
-		<div>Set light map. Default is null.</div>
-
-		<h3>[property:Texture specularMap]</h3>
-		<div>Since this material does not have a specular component, the specular value affects only how much of the environment map affects the surface. Default is null.</div>
-
-		<h3>[property:Texture alphaMap]</h3>
-		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
-		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
-
-		<h3>[property:TextureCube envMap]</h3>
-		<div>Set env map. Default is null.</div>
-
-		<h3>[property:Float reflectivity]</h3>
-		<div>How much the environment map affects the surface; also see "combine".</div> 
-
-		<h3>[property:Float refractionRatio]</h3>
-		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
-
-		<h3>[property:Integer combine]</h3>
-		<div>How to combine the result of the surface's color with the environment map, if any.</div> 
-		 
-		<div>Options are [page:Textures THREE.Multiply] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
-		 
 		<h3>[property:Boolean skinning]</h3>
 		<div>Define whether the material uses skinning. Default is *false*.</div>
 	
 		<h3>[property:Boolean morphTargets]</h3>
 		<div>Define whether the material uses morphTargets. Default is *false*.</div>	
-
-		<h3>[property:boolean wrapAround]</h3>
-		<div>
-			Define whether the diffuse lighting wraps around the model or not. This option adds a little more (tintable) light
-			onto the side of the object in relation to a light.
-		</div>
-
-		<h3>[property:Vector3 wrapRGB]</h3>
-		<div>
-			Decide how much of the wrap around values get used if the wrapAround option is set. The x, y, z values correspond
-			to the r, g, b values respectively. The typical range is of each is from 0 to 1. For example setting all of the
-			vector values to 0.5 will add a moderate amount of light to the side of the model. Changing *b* to 1 will
-			tint the light on the side to be more blue. Defaults to *(1,1,1)*.
-		</div> 
 
 		<h3>[property:boolean morphNormals]</h3>
 		<div>

--- a/docs/api/materials/MeshNormalMaterial.html
+++ b/docs/api/materials/MeshNormalMaterial.html
@@ -24,26 +24,21 @@
 		parameters is an object with one or more properties defining the material's appearance. 
 		</div>
 		<div>
-		morphTargets -- Define whether the material uses morphTargets. Default is false.<br/>
-		shading --  How the triangles of a curved surface are rendered. Default is [page:Materials THREE.SmoothShading].<br/>
+		shading --  How the triangles of a curved surface are rendered. Default is [page:Materials THREE.FlatShading].<br/>
 		wireframe -- Render geometry as wireframe. Default is false (i.e. render as smooth shaded).<br/>
 		wireframeLinewidth -- Controls wireframe thickness. Default is 1.<br/>
+		morphTargets -- Define whether the material uses morphTargets. Default is false.<br/>
 		</div>
 
 
 		<h2>Properties</h2>
 
 
-
-		<h3>[property:boolean morphTargets]</h3>
-		<div>Define whether the material uses morphTargets. Default is false.</div> 
-
 		<h3>[property:number shading]</h3>
 		<div>
 			How the triangles of a curved surface are rendered: as a smooth surface, as flat separate facets, or no shading at all.<br/><br/>
-			Options are [page:Materials THREE.SmoothShading] (default), [page:Materials THREE.FlatShading]
+			Options are [page:Materials THREE.SmoothShading], [page:Materials THREE.FlatShading](default)
 		</div>
-		
 
 		<h3>[property:boolean wireframe]</h3>
 		<div>
@@ -55,6 +50,9 @@
 			Controls wireframe thickness. Default is 1.<br/><br/>
 			Due to limitations in the ANGLE layer, on Windows platforms linewidth will always be 1 regardless of the set value.
 		</div> 
+
+		<h3>[property:boolean morphTargets]</h3>
+		<div>Define whether the material uses morphTargets. Default is false.</div> 
 
 		<h2>Methods</h2>
 

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -23,6 +23,23 @@
 		parameters -- an object with one or more of the material's properties defining the its appearance.
 		</div>
 		<div>
+		color — geometry color in hexadecimal. Default is 0xffffff.<br />
+		map — Sets the texture map. Default is null <br />
+		lightMap — Set light map. Default is null.<br />
+		specularMap — Set specular map. Default is null.<br />
+		alphaMap — Set alpha map. Default is null.<br />
+		envMap — Set env map. Default is null.<br />
+		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
+		shading — Define shading type. Default is THREE.SmoothShading.<br />
+		wireframe — render geometry as wireframe. Default is false.<br />
+		wireframeLinewidth — Line thickness. Default is 1.<br />
+		wireframeLinecap — Define appearance of line ends. Default is 'round'.<br />
+		wireframeLinejoin — Define appearance of line joints. Default is 'round'.<br />
+		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
+		skinning — Define whether the material uses skinning. Default is false.<br />
+		morphTargets — Define whether the material uses morphTargets. Default is false.
+		</div>
+		<div>
 		Example:<br>
 		materials.push( new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.FlatShading } ) );
 	
@@ -55,6 +72,81 @@
 		<h3>[property:Float shininess]</h3>
 		<div>How shiny the specular highlight is; a higher value gives a sharper highlight. Default is *30*.</div>
 
+		<h3>[property:boolean metal]</h3>
+		<div>
+			If set to true the shader multiplies the specular highlight by the underlying color of the object, making
+			it appear to be more metal-like and darker. If set to false the specular highlight is added ontop of the
+			underlying colors.
+		</div> 
+
+		<h3>[property:boolean wrapAround]</h3>
+		<div>
+			Define whether the diffuse lighting wraps around the model or not. This option adds a little more (tintable) light
+			onto the side of the object in relation to a light.
+		</div>
+
+		<h3>[property:Vector3 wrapRGB]</h3>
+		<div>
+			Decide how much of the wrap around values get used if the wrapAround option is set. The x, y, z values correspond
+			to the r, g, b values respectively. The typical range is of each is from 0 to 1. For example setting all of the
+			vector values to 0.5 will add a moderate amount of light to the side of the model. Changing *b* to 1 will
+			tint the light on the side to be more blue. Defaults to (1,1,1).
+		</div>
+
+		<h3>[property:Texture map]</h3>
+		<div>Set color texture map. Default is null.</div>
+
+		<h3>[property:Texture lightMap]</h3>
+		<div>Set light map. Default is null.</div>
+
+		<h3>[property:Texture bumpMap]</h3>
+		<div>
+			The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights.
+			Bump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will
+			be ignored.
+		</div>
+		
+		<h3>[property:Float bumpScale]</h3>
+		<div>
+			How much the bump map affects the material. Typical ranges are 0-1. Default is 1.
+		</div>
+
+		<h3>[property:Texture normalMap]</h3>
+		<div>
+			The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change
+			the way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting.
+		</div>
+		
+		<h3>[property:Vector2 normalScale]</h3>
+		<div>
+			How much the normal map affects the material. Typical ranges are 0-1. Default is (1,1).
+		</div> 
+
+		<h3>[property:Texture specularMap]</h3>
+		<div>The specular map value affects both how much the specular surface highlight contributes and how much of the environment map affects the surface. Default is null.</div>
+
+		<h3>[property:Texture alphaMap]</h3>
+		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
+		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
+
+		<h3>[property:TextureCube envMap]</h3>
+		<div>Set env map. Default is null.</div>
+		
+		<h3>[property:Integer combine]</h3>
+		<div>How to combine the result of the surface's color with the environment map, if any.</div> 
+		 
+		<div>Options are [page:Textures THREE.MultiplyOperation] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
+		 
+		<h3>[property:Float reflectivity]</h3>
+		<div>How much the environment map affects the surface; also see "combine".</div> 
+
+		<h3>[property:Float refractionRatio]</h3>
+		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
+
+		<h3>[property:Boolean fog]</h3>
+		<div>Define whether the material color is affected by global fog settings. Default is *true*.</div>
+		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
+
 		<h3>[property:Integer shading]</h3>
 		<div>How the triangles of a curved surface are rendered: as a smooth surface, as flat separate facets, or no shading at all.</div>
 
@@ -79,92 +171,16 @@
 		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
 		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings. Default is *true*.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
-
-		<h3>[property:Texture map]</h3>
-		<div>Set color texture map. Default is null.</div>
-
-		<h3>[property:Texture lightMap]</h3>
-		<div>Set light map. Default is null.</div>
-
-		<h3>[property:Texture specularMap]</h3>
-		<div>The specular map value affects both how much the specular surface highlight contributes and how much of the environment map affects the surface. Default is null.</div>
-
-		<h3>[property:Texture alphaMap]</h3>
-		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
-		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
-
-		<h3>[property:TextureCube envMap]</h3>
-		<div>Set env map. Default is null.</div>
-
-		<h3>[property:Float reflectivity]</h3>
-		<div>How much the environment map affects the surface; also see "combine".</div> 
-
-		<h3>[property:Float refractionRatio]</h3>
-		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
-
-		<h3>[property:Integer combine]</h3>
-		<div>How to combine the result of the surface's color with the environment map, if any.</div> 
-		 
-		<div>Options are [page:Textures THREE.MultiplyOperation] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
-		 
 		<h3>[property:Boolean skinning]</h3>
 		<div>Define whether the material uses skinning. Default is *false*.</div>
 	
 		<h3>[property:Boolean morphTargets]</h3>
 		<div>Define whether the material uses morphTargets. Default is *false*.</div>	
 
-
-		<h3>[property:boolean wrapAround]</h3>
-		<div>
-			Define whether the diffuse lighting wraps around the model or not. This option adds a little more (tintable) light
-			onto the side of the object in relation to a light.
-		</div>
-
-		<h3>[property:Vector3 wrapRGB]</h3>
-		<div>
-			Decide how much of the wrap around values get used if the wrapAround option is set. The x, y, z values correspond
-			to the r, g, b values respectively. The typical range is of each is from 0 to 1. For example setting all of the
-			vector values to 0.5 will add a moderate amount of light to the side of the model. Changing *b* to 1 will
-			tint the light on the side to be more blue. Defaults to (1,1,1).
-		</div>
-
 		<h3>[property:boolean morphNormals]</h3>
 		<div>
 			Defines whether the material uses morphNormals. Set as true to pass morphNormal attributes from the [page:Geometry]
 			to the shader. Default is *false*.
-		</div>
-
-		<h3>[property:boolean metal]</h3>
-		<div>
-			If set to true the shader multiplies the specular highlight by the underlying color of the object, making
-			it appear to be more metal-like and darker. If set to false the specular highlight is added ontop of the
-			underlying colors.
-		</div> 
-
-		<h3>[property:Texture normalMap]</h3>
-		<div>
-			The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change
-			the way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting.
-		</div>
-		
-		<h3>[property:Vector2 normalScale]</h3>
-		<div>
-			How much the normal map affects the material. Typical ranges are 0-1. Default is (1,1).
-		</div> 
-
-		<h3>[property:Texture bumpMap]</h3>
-		<div>
-			The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights.
-			Bump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will
-			be ignored.
-		</div>
-		
-		<h3>[property:Float bumpScale]</h3>
-		<div>
-			How much the bump map affects the material. Typical ranges are 0-1. Default is 1.
 		</div>
 
 		<h2>Methods</h2>

--- a/docs/api/materials/PointCloudMaterial.html
+++ b/docs/api/materials/PointCloudMaterial.html
@@ -48,7 +48,9 @@
 		<div>Specify whether particles' size will get smaller with the distance. Default is true.</div>
 
 		<h3>[property:Boolean vertexColors]</h3>
-
+		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
+		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
+		
 		<h3>[property:Boolean fog]</h3>
 		<div>Define whether the material color is affected by global fog settings.</div>
 		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -210,7 +210,15 @@
 		<div>
 		parameters -- An object containing various parameters setting up shaders and their uniforms.
 		</div>
-
+		<div>
+		shading — Define shading type. Default is THREE.SmoothShading.<br />
+		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
+		wireframe — render geometry as wireframe. Default is false.<br />
+		wireframeLinewidth — Line thickness. Default is 1.<br />
+		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
+		skinning — Define whether the material uses skinning. Default is false.<br />
+		morphTargets — Define whether the material uses morphTargets. Default is false.
+		</div>
 
 		<h2>Properties</h2>
 
@@ -254,36 +262,40 @@
 		in the GLSL code.
 		</div>
 
-		<h3>[property:String fragmentShader]</h3>
-		<div>
-		Fragment shader GLSL code.  This is the actual code for the shader. In the example above, the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed as a string directly or loaded via AJAX instead.
-		</div>
-
 		<h3>[property:String vertexShader]</h3>
 		<div>
 		Vertex shader GLSL code.  This is the actual code for the shader. In the example above, the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed as a string directly or loaded via AJAX instead.
 		</div>
 
-
-		<h3>[property:Boolean lights]</h3>
+		<h3>[property:String fragmentShader]</h3>
 		<div>
-		Defines whether this material uses lighting; true to pass uniform data related to lighting to this shader
+		Fragment shader GLSL code.  This is the actual code for the shader. In the example above, the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed as a string directly or loaded via AJAX instead.
 		</div>
 
-		<h3>[property:Boolean morphTargets]</h3>
+		<h3>[property:Number shading]</h3>
 		<div>
-		Defines whether the material uses morphTargets; true morphTarget attributes to this shader
+		Define shading type, which determines whether normals are smoothed between vertices; possible values are [page:Materials THREE.SmoothShading] or [page:Materials THREE.FlatShading]. Default is THREE.SmoothShading.
 		</div>
 
-		<h3>[property:boolean morphNormals]</h3>
-		<div>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal attributes from the [page:Geometry]
-			to the shader. Default is *false*.
-		</div>
+		<h3>[property:Number linewidth]</h3>
+		<div>Controls line thickness; only effective if the material is attached to a [page:Line]. Default is 1.</div>
+		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
 
 		<h3>[property:Boolean wireframe]</h3>
 		<div>
 		Render geometry as wireframe (using GL_LINES instead of GL_TRIANGLES). Default is false (i.e. render as flat polygons).
+		</div>
+
+		<h3>[property:Number wireframeLinewidth]</h3>
+		<div>Controls wireframe thickness; only effective if the material is attached to a [page:Mesh] and *wireframe* is true. Default is 1.</div>
+		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
+
+		<h3>[property:Boolean fog]</h3>
+		<div>Define whether the material color is affected by global fog settings; true to pass fog uniforms to the shader. Default is false.</div>
+
+		<h3>[property:Boolean lights]</h3>
+		<div>
+		Defines whether this material uses lighting; true to pass uniform data related to lighting to this shader
 		</div>
 
 		<h3>[property:Number vertexColors]</h3>
@@ -296,22 +308,16 @@
 		Define whether the material uses skinning; true to pass skinning attributes to the shader. Default is false.
 		</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings; true to pass fog uniforms to the shader. Default is false.</div>
-
-
-		<h3>[property:Number shading]</h3>
+		<h3>[property:Boolean morphTargets]</h3>
 		<div>
-		Define shading type, which determines whether normals are smoothed between vertices; possible values are [page:Materials THREE.SmoothShading] or [page:Materials THREE.FlatShading]. Default is THREE.SmoothShading.
+		Defines whether the material uses morphTargets; true morphTarget attributes to this shader
 		</div>
 
-		<h3>[property:Number linewidth]</h3>
-		<div>Controls line thickness; only effective if the material is attached to a [page:Line]. Default is 1.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
-
-		<h3>[property:Number wireframeLinewidth]</h3>
-		<div>Controls wireframe thickness; only effective if the material is attached to a [page:Mesh] and *wireframe* is true. Default is 1.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
+		<h3>[property:boolean morphNormals]</h3>
+		<div>
+			Defines whether the material uses morphNormals. Set as true to pass morphNormal attributes from the [page:Geometry]
+			to the shader. Default is *false*.
+		</div>
 
 		<h3>[property:WebGLProgram program]</h3>
 		<div>

--- a/docs/api/materials/SpriteMaterial.html
+++ b/docs/api/materials/SpriteMaterial.html
@@ -22,27 +22,27 @@
 		parameters -- an object defining the the default properties
 		</div>
 		<div>
-		map - the texture map<br/>
 		color - color of the sprite<br/>
-		fog - whether or not to use the scene fog<br/>
+		map - the texture map<br/>
 		rotation - the rotation of the sprite
+		fog - whether or not to use the scene fog<br/>
 		</div>
 
 
 		<h2>Properties</h2>
 
 
-		<h3>[property:Texture map]</h3>
-		<div>The texture map. Default is null.</div> 
-
 		<h3>[property:Color color]</h3>
 		<div>The texture is multiplied by this color. The default is 0xffffff</div> 
 
-		<h3>[property:boolean fog]</h3>
-		<div>Whether or not this material affected by the scene's fog. Default is false</div>
+		<h3>[property:Texture map]</h3>
+		<div>The texture map. Default is null.</div> 
 
 		<h3>[property:Radians rotation]</h3>
 		<div>The rotation of the sprite in radians. Default is 0.</div>
+
+		<h3>[property:boolean fog]</h3>
+		<div>Whether or not this material affected by the scene's fog. Default is false</div>
 
 		<h2>Source</h2>
 

--- a/src/materials/PointCloudMaterial.js
+++ b/src/materials/PointCloudMaterial.js
@@ -8,6 +8,7 @@
  *  map: new THREE.Texture( <Image> ),
  *
  *  size: <float>,
+ *	sizeAttenuation: <bool>,
  *
  *  blending: THREE.NormalBlending,
  *  depthTest: <bool>,

--- a/src/materials/PointCloudMaterial.js
+++ b/src/materials/PointCloudMaterial.js
@@ -8,7 +8,7 @@
  *  map: new THREE.Texture( <Image> ),
  *
  *  size: <float>,
- *	sizeAttenuation: <bool>,
+ *  sizeAttenuation: <bool>,
  *
  *  blending: THREE.NormalBlending,
  *  depthTest: <bool>,


### PR DESCRIPTION
Parameters were out of order in most material docs and did not agree with the order offered by the source code.

I also added any missing parameters/properties that were clearly displayed in other material docs. 

Finally, fixed a mistake in MeshNormalMaterial.html where parameter shading default claimed to be THREE.SmoothShading and not THREE.FlatShading according to source code.
