### PR TITLE
Shorten assignments of default values

### DIFF
--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -15,8 +15,8 @@ THREE.OrthographicCamera = function ( left, right, top, bottom, near, far ) {
 	this.top = top;
 	this.bottom = bottom;
 
-	this.near = ( near !== undefined ) ? near : 0.1;
-	this.far = ( far !== undefined ) ? far : 2000;
+	this.near = near || 0.1;
+	this.far = far || 2000;
 
 	this.updateProjectionMatrix();
 

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -4,7 +4,7 @@
 
 THREE.Clock = function ( autoStart ) {
 
-	this.autoStart = ( autoStart !== undefined ) ? autoStart : true;
+	this.autoStart = autoStart || true;
 
 	this.startTime = 0;
 	this.oldTime = 0;

--- a/src/extras/curves/ClosedSplineCurve3.js
+++ b/src/extras/curves/ClosedSplineCurve3.js
@@ -7,7 +7,7 @@ THREE.ClosedSplineCurve3 = THREE.Curve.create(
 
 	function ( points /* array of Vector3 */) {
 
-		this.points = ( points == undefined ) ? [] : points;
+		this.points = points || [];
 
 	},
 

--- a/src/extras/curves/SplineCurve.js
+++ b/src/extras/curves/SplineCurve.js
@@ -4,7 +4,7 @@
 
 THREE.SplineCurve = function ( points /* array of Vector2 */ ) {
 
-	this.points = ( points == undefined ) ? [] : points;
+	this.points = points || [];
 
 };
 

--- a/src/extras/curves/SplineCurve3.js
+++ b/src/extras/curves/SplineCurve3.js
@@ -7,7 +7,7 @@ THREE.SplineCurve3 = THREE.Curve.create(
 
 	function ( points /* array of Vector3 */) {
 
-		this.points = ( points == undefined ) ? [] : points;
+		this.points = points || [];
 
 	},
 

--- a/src/extras/helpers/BoundingBoxHelper.js
+++ b/src/extras/helpers/BoundingBoxHelper.js
@@ -6,7 +6,7 @@
 
 THREE.BoundingBoxHelper = function ( object, hex ) {
 
-	var color = ( hex !== undefined ) ? hex : 0x888888;
+	var color = hex || 0x888888;
 
 	this.object = object;
 

--- a/src/extras/helpers/EdgesHelper.js
+++ b/src/extras/helpers/EdgesHelper.js
@@ -4,7 +4,7 @@
 
 THREE.EdgesHelper = function ( object, hex ) {
 
-	var color = ( hex !== undefined ) ? hex : 0xffffff;
+	var color = hex || 0xffffff;
 
 	var edge = [ 0, 0 ], hash = {};
 	var sortFunction = function ( a, b ) { return a - b };

--- a/src/extras/helpers/FaceNormalsHelper.js
+++ b/src/extras/helpers/FaceNormalsHelper.js
@@ -7,11 +7,11 @@ THREE.FaceNormalsHelper = function ( object, size, hex, linewidth ) {
 
 	this.object = object;
 
-	this.size = ( size !== undefined ) ? size : 1;
+	this.size = size || 1;
 
-	var color = ( hex !== undefined ) ? hex : 0xffff00;
+	var color = hex || 0xffff00;
 
-	var width = ( linewidth !== undefined ) ? linewidth : 1;
+	var width = linewidth || 1;
 
 	var geometry = new THREE.Geometry();
 

--- a/src/extras/helpers/VertexNormalsHelper.js
+++ b/src/extras/helpers/VertexNormalsHelper.js
@@ -7,11 +7,11 @@ THREE.VertexNormalsHelper = function ( object, size, hex, linewidth ) {
 
 	this.object = object;
 
-	this.size = ( size !== undefined ) ? size : 1;
+	this.size = size || 1;
 
-	var color = ( hex !== undefined ) ? hex : 0xff0000;
+	var color = hex || 0xff0000;
 
-	var width = ( linewidth !== undefined ) ? linewidth : 1;
+	var width = linewidth || 1;
 
 	var geometry = new THREE.Geometry();
 

--- a/src/extras/helpers/VertexTangentsHelper.js
+++ b/src/extras/helpers/VertexTangentsHelper.js
@@ -7,11 +7,11 @@ THREE.VertexTangentsHelper = function ( object, size, hex, linewidth ) {
 
 	this.object = object;
 
-	this.size = ( size !== undefined ) ? size : 1;
+	this.size = size || 1;
 
-	var color = ( hex !== undefined ) ? hex : 0x0000ff;
+	var color = hex || 0x0000ff;
 
-	var width = ( linewidth !== undefined ) ? linewidth : 1;
+	var width = linewidth || 1;
 
 	var geometry = new THREE.Geometry();
 

--- a/src/extras/helpers/WireframeHelper.js
+++ b/src/extras/helpers/WireframeHelper.js
@@ -4,7 +4,7 @@
 
 THREE.WireframeHelper = function ( object, hex ) {
 
-	var color = ( hex !== undefined ) ? hex : 0xffffff;
+	var color = hex || 0xffffff;
 
 	var edge = [ 0, 0 ], hash = {};
 	var sortFunction = function ( a, b ) { return a - b };

--- a/src/lights/AreaLight.js
+++ b/src/lights/AreaLight.js
@@ -12,7 +12,7 @@ THREE.AreaLight = function ( color, intensity ) {
 	this.normal = new THREE.Vector3( 0, - 1, 0 );
 	this.right = new THREE.Vector3( 1, 0, 0 );
 
-	this.intensity = ( intensity !== undefined ) ? intensity : 1;
+	this.intensity = intensity || 1;
 
 	this.width = 1.0;
 	this.height = 1.0;

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -12,7 +12,7 @@ THREE.DirectionalLight = function ( color, intensity ) {
 	this.position.set( 0, 1, 0 );
 	this.target = new THREE.Object3D();
 
-	this.intensity = ( intensity !== undefined ) ? intensity : 1;
+	this.intensity = intensity || 1;
 
 	this.castShadow = false;
 	this.onlyShadow = false;

--- a/src/lights/HemisphereLight.js
+++ b/src/lights/HemisphereLight.js
@@ -11,7 +11,7 @@ THREE.HemisphereLight = function ( skyColor, groundColor, intensity ) {
 	this.position.set( 0, 100, 0 );
 
 	this.groundColor = new THREE.Color( groundColor );
-	this.intensity = ( intensity !== undefined ) ? intensity : 1;
+	this.intensity = intensity || 1;
 
 };
 

--- a/src/lights/PointLight.js
+++ b/src/lights/PointLight.js
@@ -8,8 +8,8 @@ THREE.PointLight = function ( color, intensity, distance ) {
 
 	this.type = 'PointLight';
 
-	this.intensity = ( intensity !== undefined ) ? intensity : 1;
-	this.distance = ( distance !== undefined ) ? distance : 0;
+	this.intensity = intensity || 1;
+	this.distance = distance || 0;
 
 };
 

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -11,10 +11,10 @@ THREE.SpotLight = function ( color, intensity, distance, angle, exponent ) {
 	this.position.set( 0, 1, 0 );
 	this.target = new THREE.Object3D();
 
-	this.intensity = ( intensity !== undefined ) ? intensity : 1;
-	this.distance = ( distance !== undefined ) ? distance : 0;
-	this.angle = ( angle !== undefined ) ? angle : Math.PI / 3;
-	this.exponent = ( exponent !== undefined ) ? exponent : 10;
+	this.intensity = intensity || 1;
+	this.distance = distance || 0;
+	this.angle = angle || Math.PI / 3;
+	this.exponent = exponent || 10;
 
 	this.castShadow = false;
 	this.onlyShadow = false;

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -4,7 +4,7 @@
 
 THREE.BufferGeometryLoader = function ( manager ) {
 
-	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+	this.manager = manager || THREE.DefaultLoadingManager;
 
 };
 

--- a/src/loaders/GeometryLoader.js
+++ b/src/loaders/GeometryLoader.js
@@ -4,7 +4,7 @@
 
 THREE.GeometryLoader = function ( manager ) {
 
-	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+	this.manager = manager || THREE.DefaultLoadingManager;
 
 };
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -5,7 +5,7 @@
 THREE.ImageLoader = function ( manager ) {
 
 	this.cache = new THREE.Cache();
-	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+	this.manager = manager || THREE.DefaultLoadingManager;
 
 };
 

--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -107,7 +107,7 @@ THREE.JSONLoader.prototype.parse = function ( json, texturePath ) {
 
 	var scope = this,
 	geometry = new THREE.Geometry(),
-	scale = ( json.scale !== undefined ) ? 1.0 / json.scale : 1.0;
+        scale = 1.0 / json.scale || 1.0
 
 	parseModel( scale );
 
@@ -418,7 +418,7 @@ THREE.JSONLoader.prototype.parse = function ( json, texturePath ) {
 	};
 
 	function parseSkin() {
-		var influencesPerVertex = ( json.influencesPerVertex !== undefined ) ? json.influencesPerVertex : 2;
+		var influencesPerVertex = json.influencesPerVertex || 2;
 
 		if ( json.skinWeights ) {
 

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -4,7 +4,7 @@
 
 THREE.MaterialLoader = function ( manager ) {
 
-	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+	this.manager = manager || THREE.DefaultLoadingManager;
 
 };
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -4,7 +4,7 @@
 
 THREE.ObjectLoader = function ( manager ) {
 
-	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+	this.manager = manager || THREE.DefaultLoadingManager;
 
 };
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -4,7 +4,7 @@
 
 THREE.TextureLoader = function ( manager ) {
 
-	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+	this.manager = manager || THREE.DefaultLoadingManager;
 
 };
 

--- a/src/loaders/XHRLoader.js
+++ b/src/loaders/XHRLoader.js
@@ -5,7 +5,7 @@
 THREE.XHRLoader = function ( manager ) {
 
 	this.cache = new THREE.Cache();
-	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+	this.manager = manager || THREE.DefaultLoadingManager;
 
 };
 

--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -4,8 +4,8 @@
 
 THREE.Box2 = function ( min, max ) {
 
-	this.min = ( min !== undefined ) ? min : new THREE.Vector2( Infinity, Infinity );
-	this.max = ( max !== undefined ) ? max : new THREE.Vector2( - Infinity, - Infinity );
+	this.min = min || new THREE.Vector2( Infinity, Infinity );
+	this.max = max || new THREE.Vector2( - Infinity, - Infinity );
 
 };
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -5,8 +5,8 @@
 
 THREE.Box3 = function ( min, max ) {
 
-	this.min = ( min !== undefined ) ? min : new THREE.Vector3( Infinity, Infinity, Infinity );
-	this.max = ( max !== undefined ) ? max : new THREE.Vector3( - Infinity, - Infinity, - Infinity );
+	this.min = min || new THREE.Vector3( Infinity, Infinity, Infinity );
+	this.max = max || new THREE.Vector3( - Infinity, - Infinity, - Infinity );
 
 };
 

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -8,12 +8,12 @@ THREE.Frustum = function ( p0, p1, p2, p3, p4, p5 ) {
 
 	this.planes = [
 
-		( p0 !== undefined ) ? p0 : new THREE.Plane(),
-		( p1 !== undefined ) ? p1 : new THREE.Plane(),
-		( p2 !== undefined ) ? p2 : new THREE.Plane(),
-		( p3 !== undefined ) ? p3 : new THREE.Plane(),
-		( p4 !== undefined ) ? p4 : new THREE.Plane(),
-		( p5 !== undefined ) ? p5 : new THREE.Plane()
+		p0 || new THREE.Plane(),
+		p1 || new THREE.Plane(),
+		p2 || new THREE.Plane(),
+		p3 || new THREE.Plane(),
+		p4 || new THREE.Plane(),
+		p5 || new THREE.Plane()
 
 	];
 

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -4,8 +4,8 @@
 
 THREE.Line3 = function ( start, end ) {
 
-	this.start = ( start !== undefined ) ? start : new THREE.Vector3();
-	this.end = ( end !== undefined ) ? end : new THREE.Vector3();
+	this.start = start || new THREE.Vector3();
+	this.end = end || new THREE.Vector3();
 
 };
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -4,8 +4,8 @@
 
 THREE.Plane = function ( normal, constant ) {
 
-	this.normal = ( normal !== undefined ) ? normal : new THREE.Vector3( 1, 0, 0 );
-	this.constant = ( constant !== undefined ) ? constant : 0;
+	this.normal = normal || new THREE.Vector3( 1, 0, 0 );
+	this.constant = constant || 0;
 
 };
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -10,7 +10,7 @@ THREE.Quaternion = function ( x, y, z, w ) {
 	this._x = x || 0;
 	this._y = y || 0;
 	this._z = z || 0;
-	this._w = ( w !== undefined ) ? w : 1;
+	this._w = w || 1;
 
 };
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -4,8 +4,8 @@
 
 THREE.Ray = function ( origin, direction ) {
 
-	this.origin = ( origin !== undefined ) ? origin : new THREE.Vector3();
-	this.direction = ( direction !== undefined ) ? direction : new THREE.Vector3();
+	this.origin = origin || new THREE.Vector3();
+	this.direction = direction || new THREE.Vector3();
 
 };
 
@@ -251,7 +251,7 @@ THREE.Ray.prototype = {
 			// in order to always return an intersect point that is in front of the ray.
 			if ( t0 < 0 ) return this.at( t1, optionalTarget );
 
-			// else t0 is in front of the ray, so return the first collision point scaled by t0 
+			// else t0 is in front of the ray, so return the first collision point scaled by t0
 			return this.at( t0, optionalTarget );
 
 		}

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -5,8 +5,8 @@
 
 THREE.Sphere = function ( center, radius ) {
 
-	this.center = ( center !== undefined ) ? center : new THREE.Vector3();
-	this.radius = ( radius !== undefined ) ? radius : 0;
+	this.center = center || new THREE.Vector3();
+	this.radius = radius || 0;
 
 };
 

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -5,9 +5,9 @@
 
 THREE.Triangle = function ( a, b, c ) {
 
-	this.a = ( a !== undefined ) ? a : new THREE.Vector3();
-	this.b = ( b !== undefined ) ? b : new THREE.Vector3();
-	this.c = ( c !== undefined ) ? c : new THREE.Vector3();
+	this.a = a || new THREE.Vector3();
+	this.b = b || new THREE.Vector3();
+	this.c = c || new THREE.Vector3();
 
 };
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -11,7 +11,7 @@ THREE.Vector4 = function ( x, y, z, w ) {
 	this.x = x || 0;
 	this.y = y || 0;
 	this.z = z || 0;
-	this.w = ( w !== undefined ) ? w : 1;
+	this.w = w || 1;
 
 };
 
@@ -95,7 +95,7 @@ THREE.Vector4.prototype = {
 		this.x = v.x;
 		this.y = v.y;
 		this.z = v.z;
-		this.w = ( v.w !== undefined ) ? v.w : 1;
+		this.w = v.w || 1;
 
 		return this;
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -8,10 +8,10 @@ THREE.Line = function ( geometry, material, mode ) {
 
 	this.type = 'Line';
 
-	this.geometry = geometry !== undefined ? geometry : new THREE.Geometry();
-	this.material = material !== undefined ? material : new THREE.LineBasicMaterial( { color: Math.random() * 0xffffff } );
+	this.geometry = geometry || new THREE.Geometry();
+	this.material = material || new THREE.LineBasicMaterial( { color: Math.random() * 0xffffff } );
 
-	this.mode = ( mode !== undefined ) ? mode : THREE.LineStrip;
+	this.mode = mode || THREE.LineStrip;
 
 };
 

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -21,7 +21,7 @@ THREE.Sprite = ( function () {
 		this.type = 'Sprite';
 
 		this.geometry = geometry;
-		this.material = ( material !== undefined ) ? material : new THREE.SpriteMaterial();
+		this.material = material || new THREE.SpriteMaterial();
 
 	};
 

--- a/src/scenes/Fog.js
+++ b/src/scenes/Fog.js
@@ -9,8 +9,8 @@ THREE.Fog = function ( color, near, far ) {
 
 	this.color = new THREE.Color( color );
 
-	this.near = ( near !== undefined ) ? near : 1;
-	this.far = ( far !== undefined ) ? far : 1000;
+	this.near = near || 1;
+	this.far = far || 1000;
 
 };
 

--- a/src/scenes/FogExp2.js
+++ b/src/scenes/FogExp2.js
@@ -8,7 +8,7 @@ THREE.FogExp2 = function ( color, density ) {
 	this.name = '';
 
 	this.color = new THREE.Color( color );
-	this.density = ( density !== undefined ) ? density : 0.00025;
+	this.density = density || 0.00025;
 
 };
 


### PR DESCRIPTION
this is a question as well as a pull request.
  in this project, when a parameter isn't supplied and needs to fall back to the default value, this code is used:

``` js
parameter = ( paramater !== undefined ) ? parameter : defaultValue;
```

  but this could also be done as such:

``` js
parameter = paramater || defaultValue;
```

  (obviously the logical OR will be activated if the paramater is falsy)
  why does this project use the first method?

I suspect there's something stupid I'm missing out on. In the small chance that I'm not missing out on anything, then I changed the code to use the second method - hence this is a pull request.
