### PR TITLE
material.enhancedLightmaps

### DIFF
--- a/docs/api/constants/Textures.html
+++ b/docs/api/constants/Textures.html
@@ -13,7 +13,8 @@
 		<div>
 		THREE.MultiplyOperation<br />
 		THREE.MixOperation<br />
-		THREE.AddOperation
+		THREE.AddOperation<br />
+		THREE.Modulate2XOperation
 		</div>
 
 		<h2>Mapping Modes</h2>

--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -95,6 +95,11 @@
 		Sets the texture map. Default is  null.
 		</div> 
 
+		<h3>[property:Integer lightMapMode]</h3>
+		<div>
+		The operation used to apply the lightMap (if a lightMap is present) - can either be [page:Textures THREE.MultiplyOperation] (default) or [page:Textures THREE.Modulate2XOperation].
+		</div>
+
 		<h3>[property:number combine]</h3>
 		<div>
 		How to combine the result of the surface's color with the environment map, if any.

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -89,6 +89,12 @@
 		<h3>[property:TextureCube envMap]</h3>
 		<div>Set env map. Default is null.</div>
 
+		<h3>[property:Integer lightMapMode]</h3>
+		<div>
+		The operation used to apply the lightMap (if a lightMap is present) - can either be [page:Textures THREE.MultiplyOperation] (default) or [page:Textures THREE.Modulate2XOperation].
+		</div>
+
+    
 		<h3>[property:Integer combine]</h3>
 		<div>How to combine the result of the surface's color with the environment map, if any.</div> 
 		 

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -131,7 +131,12 @@
 
 		<h3>[property:TextureCube envMap]</h3>
 		<div>Set env map. Default is null.</div>
-		
+
+		<h3>[property:Integer lightMapMode]</h3>
+		<div>
+		The operation used to apply the lightMap (if a lightMap is present) - can either be [page:Textures THREE.MultiplyOperation] (default) or [page:Textures THREE.Modulate2XOperation].
+		</div>
+
 		<h3>[property:Integer combine]</h3>
 		<div>How to combine the result of the surface's color with the environment map, if any.</div> 
 		 

--- a/src/Three.js
+++ b/src/Three.js
@@ -112,6 +112,7 @@ THREE.SrcAlphaSaturateFactor = 210;
 THREE.MultiplyOperation = 0;
 THREE.MixOperation = 1;
 THREE.AddOperation = 2;
+THREE.Modulate2XOperation = 3;
 
 // Mapping modes
 

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -46,6 +46,7 @@ THREE.MeshBasicMaterial = function ( parameters ) {
 	this.map = null;
 
 	this.lightMap = null;
+	this.lightMapMode = THREE.MultiplyOperation;
 
 	this.specularMap = null;
 
@@ -88,6 +89,7 @@ THREE.MeshBasicMaterial.prototype.clone = function () {
 	material.map = this.map;
 
 	material.lightMap = this.lightMap;
+	material.lightMapMode = this.lightMapMode;
 
 	material.specularMap = this.specularMap;
 

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -55,6 +55,7 @@ THREE.MeshLambertMaterial = function ( parameters ) {
 	this.map = null;
 
 	this.lightMap = null;
+	this.lightMapMode = THREE.MultiplyOperation;
 
 	this.specularMap = null;
 
@@ -103,6 +104,7 @@ THREE.MeshLambertMaterial.prototype.clone = function () {
 	material.map = this.map;
 
 	material.lightMap = this.lightMap;
+	material.lightMapMode = this.lightMapMode;
 
 	material.specularMap = this.specularMap;
 

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -67,6 +67,7 @@ THREE.MeshPhongMaterial = function ( parameters ) {
 	this.map = null;
 
 	this.lightMap = null;
+	this.lightMapMode = THREE.MultiplyOperation;
 
 	this.bumpMap = null;
 	this.bumpScale = 1;
@@ -125,6 +126,7 @@ THREE.MeshPhongMaterial.prototype.clone = function () {
 	material.map = this.map;
 
 	material.lightMap = this.lightMap;
+	material.lightMapMode = this.lightMapMode;
 
 	material.bumpMap = this.bumpMap;
 	material.bumpScale = this.bumpScale;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4134,6 +4134,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			vertexColors: material.vertexColors,
 
+			lightMapMode: material.lightMapMode,
+
 			fog: fog,
 			useFog: material.fog,
 			fogExp: fog instanceof THREE.FogExp2,

--- a/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl
@@ -1,5 +1,15 @@
 #ifdef USE_LIGHTMAP
 
-	gl_FragColor = gl_FragColor * texture2D( lightMap, vUv2 );
+	#ifdef LIGHTMAP_MULTIPLY
+
+		gl_FragColor = gl_FragColor * texture2D( lightMap, vUv2 );
+
+	#endif
+
+	#ifdef LIGHTMAP_MODULATE2X
+
+		gl_FragColor = min( gl_FragColor * 2.0 * texture2D( lightMap, vUv2 ), 1.0 );
+
+	#endif
 
 #endif

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -108,6 +108,24 @@ THREE.WebGLProgram = ( function () {
 
 		}
 
+		var lightMapModeDefine = null;
+
+		if( parameters.lightMap ) {
+
+			switch ( material.lightMapMode ) {
+
+				case THREE.MultiplyOperation:
+					lightMapModeDefine = "LIGHTMAP_MULTIPLY";
+					break;
+
+				case THREE.Modulate2XOperation:
+					lightMapModeDefine = 'LIGHTMAP_MODULATE2X';
+					break;
+
+			}
+
+		}
+
 		// console.log( "building new program " );
 
 		//
@@ -259,6 +277,7 @@ THREE.WebGLProgram = ( function () {
 				parameters.envMap ? "#define USE_ENVMAP" : "",
 				envMapTypeDefine ? "#define " + envMapTypeDefine : "",
 				parameters.lightMap ? "#define USE_LIGHTMAP" : "",
+				parameters.lightMap ? "#define " + lightMapModeDefine : "",
 				parameters.bumpMap ? "#define USE_BUMPMAP" : "",
 				parameters.normalMap ? "#define USE_NORMALMAP" : "",
 				parameters.specularMap ? "#define USE_SPECULARMAP" : "",


### PR DESCRIPTION
This is a suggestion that I think could be useful.

`material.lightMap` currently can only darken a material, not lighten it up.
We're using a customised version of Three.js where lightMap is actually working like this:
- value < 0.5: Darken
- value = 0.5: Leave as is
- value > 0.5: Lighten

Together with a few config options (center, falloff and intensity) that is wrapped into the `material.enhancedLightMap` property. If this property is present, it triggers the shaders to work as described above.

Because of the hiding behind the new property it won't break backwards compatibility.

What do you think? For us it's pretty helpful, if we're modelling things like sunlight coming through windows (example http://beta.archilogic.com/JAHT4L)
