### PR TITLE
new BufferGeometry wasnt add to the info.memory

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3630,7 +3630,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( geometry instanceof THREE.BufferGeometry ) {
 
-				//
+				_this.info.memory.geometries ++;
 
 			} else if ( object instanceof THREE.Mesh ) {
 


### PR DESCRIPTION
new BufferGeometry wasn't add to the info.memory but it was remove with dispose() witch create negative number of geometries in info.memory
