### PR TITLE
Abstract away the shader selection configuration

### DIFF
--- a/src/materials/LineBasicMaterial.js
+++ b/src/materials/LineBasicMaterial.js
@@ -25,6 +25,7 @@ THREE.LineBasicMaterial = function ( parameters ) {
 	THREE.Material.call( this );
 
 	this.type = 'LineBasicMaterial';
+	this.shaderID = 'basic';
 
 	this.color = new THREE.Color( 0xffffff );
 

--- a/src/materials/LineDashedMaterial.js
+++ b/src/materials/LineDashedMaterial.js
@@ -26,6 +26,7 @@ THREE.LineDashedMaterial = function ( parameters ) {
 	THREE.Material.call( this );
 
 	this.type = 'LineDashedMaterial';
+	this.shaderID = 'dashed';
 
 	this.color = new THREE.Color( 0xffffff );
 

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -40,6 +40,7 @@ THREE.MeshBasicMaterial = function ( parameters ) {
 	THREE.Material.call( this );
 
 	this.type = 'MeshBasicMaterial';
+	this.shaderID = 'basic';
 
 	this.color = new THREE.Color( 0xffffff ); // emissive
 

--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -19,6 +19,7 @@ THREE.MeshDepthMaterial = function ( parameters ) {
 	THREE.Material.call( this );
 
 	this.type = 'MeshDepthMaterial';
+	this.shaderID = 'depth';
 
 	this.morphTargets = false;
 	this.wireframe = false;

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -44,6 +44,7 @@ THREE.MeshLambertMaterial = function ( parameters ) {
 	THREE.Material.call( this );
 
 	this.type = 'MeshLambertMaterial';
+	this.shaderID = 'lambert';
 
 	this.color = new THREE.Color( 0xffffff ); // diffuse
 	this.ambient = new THREE.Color( 0xffffff );

--- a/src/materials/MeshNormalMaterial.js
+++ b/src/materials/MeshNormalMaterial.js
@@ -19,6 +19,7 @@ THREE.MeshNormalMaterial = function ( parameters ) {
 	THREE.Material.call( this, parameters );
 
 	this.type = 'MeshNormalMaterial';
+	this.shaderID = 'normal';
 
 	this.shading = THREE.FlatShading;
 

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -52,6 +52,7 @@ THREE.MeshPhongMaterial = function ( parameters ) {
 	THREE.Material.call( this );
 
 	this.type = 'MeshPhongMaterial';
+	this.shaderID = 'phong';
 
 	this.color = new THREE.Color( 0xffffff ); // diffuse
 	this.ambient = new THREE.Color( 0xffffff );

--- a/src/materials/PointCloudMaterial.js
+++ b/src/materials/PointCloudMaterial.js
@@ -25,6 +25,7 @@ THREE.PointCloudMaterial = function ( parameters ) {
 	THREE.Material.call( this );
 
 	this.type = 'PointCloudMaterial';
+	this.shaderID = 'particle_basic';
 
 	this.color = new THREE.Color( 0xffffff );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4056,41 +4056,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		material.addEventListener( 'dispose', onMaterialDispose );
 
-		var shaderID;
-
-		if ( material instanceof THREE.MeshDepthMaterial ) {
-
-			shaderID = 'depth';
-
-		} else if ( material instanceof THREE.MeshNormalMaterial ) {
-
-			shaderID = 'normal';
-
-		} else if ( material instanceof THREE.MeshBasicMaterial ) {
-
-			shaderID = 'basic';
-
-		} else if ( material instanceof THREE.MeshLambertMaterial ) {
-
-			shaderID = 'lambert';
-
-		} else if ( material instanceof THREE.MeshPhongMaterial ) {
-
-			shaderID = 'phong';
-
-		} else if ( material instanceof THREE.LineBasicMaterial ) {
-
-			shaderID = 'basic';
-
-		} else if ( material instanceof THREE.LineDashedMaterial ) {
-
-			shaderID = 'dashed';
-
-		} else if ( material instanceof THREE.PointCloudMaterial ) {
-
-			shaderID = 'particle_basic';
-
-		}
+		var shaderID = material.shaderID;
 
 		if ( shaderID ) {
 


### PR DESCRIPTION
Beyond the obvious design benefit of allowing the materials to define how they should be rendered in a duck-typed way, there should be a performance benefit as well: instanceof tests are about [3x more expansive](http://jsfiddle.net/nkLdw986/) than testing a direct reference on the object, and with this change we've removed 8 such tests (in the worst case).

This change is part of the proposed change to incrementally clean-up the WebGLRenderer from hard-coded material-dependent configurations (#2957).
