### PR TITLE
Vector2/3/4 + Quaternion Optimizations

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -10,7 +10,7 @@ THREE.Quaternion = function ( x, y, z, w ) {
 	this._x = x || 0;
 	this._y = y || 0;
 	this._z = z || 0;
-	this._w = ( w !== undefined ) ? w : 1;
+	this._w = ( w !== void(0) ) ? w : 1;
 
 };
 
@@ -109,12 +109,12 @@ THREE.Quaternion.prototype = {
 		// 	20696-function-to-convert-between-dcm-euler-angles-quaternions-and-euler-vectors/
 		//	content/SpinCalc.m
 
-		var c1 = Math.cos( euler._x / 2 );
-		var c2 = Math.cos( euler._y / 2 );
-		var c3 = Math.cos( euler._z / 2 );
-		var s1 = Math.sin( euler._x / 2 );
-		var s2 = Math.sin( euler._y / 2 );
-		var s3 = Math.sin( euler._z / 2 );
+		var c1 = Math.cos( euler._x * 0.5 );
+		var c2 = Math.cos( euler._y * 0.5 );
+		var c3 = Math.cos( euler._z * 0.5 );
+		var s1 = Math.sin( euler._x * 0.5 );
+		var s2 = Math.sin( euler._y * 0.5 );
+		var s3 = Math.sin( euler._z * 0.5 );
 
 		if ( euler.order === 'XYZ' ) {
 
@@ -172,7 +172,7 @@ THREE.Quaternion.prototype = {
 
 		// assumes axis is normalized
 
-		var halfAngle = angle / 2, s = Math.sin( halfAngle );
+		var halfAngle = angle * 0.5, s = Math.sin( halfAngle );
 
 		this._x = axis.x * s;
 		this._y = axis.y * s;
@@ -256,7 +256,7 @@ THREE.Quaternion.prototype = {
 
 		return function ( vFrom, vTo ) {
 
-			if ( v1 === undefined ) v1 = new THREE.Vector3();
+			if ( v1 === void(0) ) v1 = new THREE.Vector3();
 
 			r = vFrom.dot( vTo ) + 1;
 
@@ -346,10 +346,10 @@ THREE.Quaternion.prototype = {
 
 			l = 1 / l;
 
-			this._x = this._x * l;
-			this._y = this._y * l;
-			this._z = this._z * l;
-			this._w = this._w * l;
+			this._x *= l;
+			this._y *= l;
+			this._z *= l;
+			this._w *= l;
 
 		}
 
@@ -361,7 +361,7 @@ THREE.Quaternion.prototype = {
 
 	multiply: function ( q, p ) {
 
-		if ( p !== undefined ) {
+		if ( p !== void(0) ) {
 
 			console.warn( 'THREE.Quaternion: .multiply() now only accepts one argument. Use .multiplyQuaternions( a, b ) instead.' );
 			return this.multiplyQuaternions( q, p );
@@ -470,7 +470,7 @@ THREE.Quaternion.prototype = {
 
 	fromArray: function ( array, offset ) {
 
-		if ( offset === undefined ) offset = 0;
+		if ( offset === void(0) ) offset = 0;
 
 		this._x = array[ offset ];
 		this._y = array[ offset + 1 ];
@@ -485,8 +485,8 @@ THREE.Quaternion.prototype = {
 
 	toArray: function ( array, offset ) {
 
-		if ( array === undefined ) array = [];
-		if ( offset === undefined ) offset = 0;
+		if ( array === void(0) ) array = [];
+		if ( offset === void(0) ) offset = 0;
 
 		array[ offset ] = this._x;
 		array[ offset + 1 ] = this._y;

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -294,8 +294,8 @@ THREE.Vector2.prototype = {
 
 	roundToZero: function () {
 
-		this.x = this.x | 0; // n < 0 : ceil(n) : floor(n)
-		this.y = this.y | 0; // n < 0 : ceil(n) : floor(n)
+		this.x |= 0; // n < 0 : ceil(n) : floor(n)
+		this.y |= 0; // n < 0 : ceil(n) : floor(n)
 
 		return this;
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -76,7 +76,7 @@ THREE.Vector2.prototype = {
 
 	add: function ( v, w ) {
 
-		if ( w !== undefined ) {
+		if ( w !== void(0) ) {
 
 			console.warn( 'THREE.Vector2: .add() now only accepts one argument. Use .addVectors( a, b ) instead.' );
 			return this.addVectors( v, w );
@@ -110,7 +110,7 @@ THREE.Vector2.prototype = {
 
 	sub: function ( v, w ) {
 
-		if ( w !== undefined ) {
+		if ( w !== void(0) ) {
 
 			console.warn( 'THREE.Vector2: .sub() now only accepts one argument. Use .subVectors( a, b ) instead.' );
 			return this.subVectors( v, w );
@@ -164,10 +164,8 @@ THREE.Vector2.prototype = {
 
 		if ( scalar !== 0 ) {
 
-			var invScalar = 1 / scalar;
-
-			this.x *= invScalar;
-			this.y *= invScalar;
+			this.x /= scalar;
+			this.y /= scalar;
 
 		} else {
 
@@ -249,7 +247,7 @@ THREE.Vector2.prototype = {
 
 		return function ( minVal, maxVal ) {
 
-			if ( min === undefined ) {
+			if ( min === void(0) ) {
 
 				min = new THREE.Vector2();
 				max = new THREE.Vector2();
@@ -294,8 +292,8 @@ THREE.Vector2.prototype = {
 
 	roundToZero: function () {
 
-		this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
-		this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
+		this.x = this.x | 0; // n < 0 : ceil(n) : floor(n)
+		this.y = this.y | 0; // n < 0 : ceil(n) : floor(n)
 
 		return this;
 
@@ -377,7 +375,7 @@ THREE.Vector2.prototype = {
 
 	fromArray: function ( array, offset ) {
 
-		if ( offset === undefined ) offset = 0;
+		if ( offset === void(0) ) offset = 0;
 
 		this.x = array[ offset ];
 		this.y = array[ offset + 1 ];
@@ -388,8 +386,8 @@ THREE.Vector2.prototype = {
 
 	toArray: function ( array, offset ) {
 
-		if ( array === undefined ) array = [];
-		if ( offset === undefined ) offset = 0;
+		if ( array === void(0)) array = [];
+		if ( offset === void(0)) offset = 0;
 
 		array[ offset ] = this.x;
 		array[ offset + 1 ] = this.y;
@@ -400,15 +398,12 @@ THREE.Vector2.prototype = {
 
 	fromAttribute: function ( attribute, index, offset ) {
 
-	    if ( offset === undefined ) offset = 0;
-
-	    index = index * attribute.itemSize + offset;
+	    index = index * attribute.itemSize + (offset || 0);
 
 	    this.x = attribute.array[ index ];
 	    this.y = attribute.array[ index + 1 ];
 
 	    return this;
-
 	},
 
 	clone: function () {

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -164,8 +164,10 @@ THREE.Vector2.prototype = {
 
 		if ( scalar !== 0 ) {
 
-			this.x /= scalar;
-			this.y /= scalar;
+			scalar = 1 / scalar;
+
+			this.x *= scalar;
+			this.y *= scalar;
 
 		} else {
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -8,7 +8,7 @@
 THREE.Vector2 = function ( x, y ) {
 
 	this.x = x || 0;
-	this.y = y || 0;
+	this.y = y || 0; 
 
 };
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -368,10 +368,12 @@ THREE.Vector3.prototype = {
 	divideScalar: function ( scalar ) {
 
 		if ( scalar !== 0 ) {
+			
+			scalar = 1 / scalar;
 
-			this.x /= scalar;
-			this.y /= scalar;
-			this.z /= scalar;
+			this.x *= scalar;
+			this.y *= scalar;
+			this.z *= scalar;
 
 		} else {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -527,9 +527,9 @@ THREE.Vector3.prototype = {
 
 	roundToZero: function () {
 
-		this.x = this.x | 0;
-		this.y = this.y | 0;
-		this.z = this.z | 0;
+		this.x |= 0;
+		this.y |= 0;
+		this.z |= 0;
 
 		return this;
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -91,7 +91,7 @@ THREE.Vector3.prototype = {
 
 	add: function ( v, w ) {
 
-		if ( w !== undefined ) {
+		if ( w !== void(0) ) {
 
 			console.warn( 'THREE.Vector3: .add() now only accepts one argument. Use .addVectors( a, b ) instead.' );
 			return this.addVectors( v, w );
@@ -128,7 +128,7 @@ THREE.Vector3.prototype = {
 
 	sub: function ( v, w ) {
 
-		if ( w !== undefined ) {
+		if ( w !== void(0) ) {
 
 			console.warn( 'THREE.Vector3: .sub() now only accepts one argument. Use .subVectors( a, b ) instead.' );
 			return this.subVectors( v, w );
@@ -155,7 +155,7 @@ THREE.Vector3.prototype = {
 
 	multiply: function ( v, w ) {
 
-		if ( w !== undefined ) {
+		if ( w !== void(0) ) {
 
 			console.warn( 'THREE.Vector3: .multiply() now only accepts one argument. Use .multiplyVectors( a, b ) instead.' );
 			return this.multiplyVectors( v, w );
@@ -202,7 +202,7 @@ THREE.Vector3.prototype = {
 
 			}
 
-			if ( quaternion === undefined ) quaternion = new THREE.Quaternion();
+			if ( quaternion === void(0) ) quaternion = new THREE.Quaternion();
 
 			this.applyQuaternion( quaternion.setFromEuler( euler ) );
 
@@ -218,7 +218,7 @@ THREE.Vector3.prototype = {
 
 		return function ( axis, angle ) {
 
-			if ( quaternion === undefined ) quaternion = new THREE.Quaternion();
+			if ( quaternion === void(0) ) quaternion = new THREE.Quaternion();
 
 			this.applyQuaternion( quaternion.setFromAxisAngle( axis, angle ) );
 
@@ -230,15 +230,15 @@ THREE.Vector3.prototype = {
 
 	applyMatrix3: function ( m ) {
 
+		m = m.elements; // caching
+
 		var x = this.x;
 		var y = this.y;
 		var z = this.z;
 
-		var e = m.elements;
-
-		this.x = e[ 0 ] * x + e[ 3 ] * y + e[ 6 ] * z;
-		this.y = e[ 1 ] * x + e[ 4 ] * y + e[ 7 ] * z;
-		this.z = e[ 2 ] * x + e[ 5 ] * y + e[ 8 ] * z;
+		this.x = m[ 0 ] * x + m[ 3 ] * y + m[ 6 ] * z;
+		this.y = m[ 1 ] * x + m[ 4 ] * y + m[ 7 ] * z;
+		this.z = m[ 2 ] * x + m[ 5 ] * y + m[ 8 ] * z;
 
 		return this;
 
@@ -246,15 +246,15 @@ THREE.Vector3.prototype = {
 
 	applyMatrix4: function ( m ) {
 
+		m = m.elements; // caching
+
 		// input: THREE.Matrix4 affine matrix
 
 		var x = this.x, y = this.y, z = this.z;
 
-		var e = m.elements;
-
-		this.x = e[ 0 ] * x + e[ 4 ] * y + e[ 8 ]  * z + e[ 12 ];
-		this.y = e[ 1 ] * x + e[ 5 ] * y + e[ 9 ]  * z + e[ 13 ];
-		this.z = e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z + e[ 14 ];
+		this.x = m[ 0 ] * x + m[ 4 ] * y + m[ 8 ]  * z + m[ 12 ];
+		this.y = m[ 1 ] * x + m[ 5 ] * y + m[ 9 ]  * z + m[ 13 ];
+		this.z = m[ 2 ] * x + m[ 6 ] * y + m[ 10 ] * z + m[ 14 ];
 
 		return this;
 
@@ -262,16 +262,17 @@ THREE.Vector3.prototype = {
 
 	applyProjection: function ( m ) {
 
+		m = m.elements;
+
 		// input: THREE.Matrix4 projection matrix
 
 		var x = this.x, y = this.y, z = this.z;
 
-		var e = m.elements;
-		var d = 1 / ( e[ 3 ] * x + e[ 7 ] * y + e[ 11 ] * z + e[ 15 ] ); // perspective divide
+		var d = 1 / ( m[ 3 ] * x + m[ 7 ] * y + m[ 11 ] * z + m[ 15 ] ); // perspective divide
 
-		this.x = ( e[ 0 ] * x + e[ 4 ] * y + e[ 8 ]  * z + e[ 12 ] ) * d;
-		this.y = ( e[ 1 ] * x + e[ 5 ] * y + e[ 9 ]  * z + e[ 13 ] ) * d;
-		this.z = ( e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z + e[ 14 ] ) * d;
+		this.x = ( m[ 0 ] * x + m[ 4 ] * y + m[ 8 ]  * z + m[ 12 ] ) * d;
+		this.y = ( m[ 1 ] * x + m[ 5 ] * y + m[ 9 ]  * z + m[ 13 ] ) * d;
+		this.z = ( m[ 2 ] * x + m[ 6 ] * y + m[ 10 ] * z + m[ 14 ] ) * d;
 
 		return this;
 
@@ -311,7 +312,7 @@ THREE.Vector3.prototype = {
 
 		return function ( camera ) {
 
-			if ( matrix === undefined ) matrix = new THREE.Matrix4();
+			if ( matrix === void(0) ) matrix = new THREE.Matrix4();
 
 			matrix.multiplyMatrices( camera.projectionMatrix, matrix.getInverse( camera.matrixWorld ) );
 			return this.applyProjection( matrix );
@@ -326,7 +327,7 @@ THREE.Vector3.prototype = {
 
 		return function ( camera ) {
 
-			if ( matrix === undefined ) matrix = new THREE.Matrix4();
+			if ( matrix === void(0) ) matrix = new THREE.Matrix4();
 
 			matrix.multiplyMatrices( camera.matrixWorld, matrix.getInverse( camera.projectionMatrix ) );
 			return this.applyProjection( matrix );
@@ -337,16 +338,16 @@ THREE.Vector3.prototype = {
 
 	transformDirection: function ( m ) {
 
+		m = m.elements; // caching
+
 		// input: THREE.Matrix4 affine matrix
 		// vector interpreted as a direction
 
 		var x = this.x, y = this.y, z = this.z;
 
-		var e = m.elements;
-
-		this.x = e[ 0 ] * x + e[ 4 ] * y + e[ 8 ]  * z;
-		this.y = e[ 1 ] * x + e[ 5 ] * y + e[ 9 ]  * z;
-		this.z = e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z;
+		this.x = m[ 0 ] * x + m[ 4 ] * y + m[ 8 ]  * z;
+		this.y = m[ 1 ] * x + m[ 5 ] * y + m[ 9 ]  * z;
+		this.z = m[ 2 ] * x + m[ 6 ] * y + m[ 10 ] * z;
 
 		this.normalize();
 
@@ -368,11 +369,9 @@ THREE.Vector3.prototype = {
 
 		if ( scalar !== 0 ) {
 
-			var invScalar = 1 / scalar;
-
-			this.x *= invScalar;
-			this.y *= invScalar;
-			this.z *= invScalar;
+			this.x /= scalar;
+			this.y /= scalar;
+			this.z /= scalar;
 
 		} else {
 
@@ -478,7 +477,7 @@ THREE.Vector3.prototype = {
 
 		return function ( minVal, maxVal ) {
 
-			if ( min === undefined ) {
+			if ( min === void(0) ) {
 
 				min = new THREE.Vector3();
 				max = new THREE.Vector3();
@@ -526,9 +525,9 @@ THREE.Vector3.prototype = {
 
 	roundToZero: function () {
 
-		this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
-		this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
-		this.z = ( this.z < 0 ) ? Math.ceil( this.z ) : Math.floor( this.z );
+		this.x = this.x | 0;
+		this.y = this.y | 0;
+		this.z = this.z | 0;
 
 		return this;
 
@@ -536,9 +535,9 @@ THREE.Vector3.prototype = {
 
 	negate: function () {
 
-		this.x = - this.x;
-		this.y = - this.y;
-		this.z = - this.z;
+		this.x *= -1;
+		this.y *= -1;
+		this.z *= -1;
 
 		return this;
 
@@ -599,7 +598,7 @@ THREE.Vector3.prototype = {
 
 	cross: function ( v, w ) {
 
-		if ( w !== undefined ) {
+		if ( w !== void(0) ) {
 
 			console.warn( 'THREE.Vector3: .cross() now only accepts one argument. Use .crossVectors( a, b ) instead.' );
 			return this.crossVectors( v, w );
@@ -618,12 +617,9 @@ THREE.Vector3.prototype = {
 
 	crossVectors: function ( a, b ) {
 
-		var ax = a.x, ay = a.y, az = a.z;
-		var bx = b.x, by = b.y, bz = b.z;
-
-		this.x = ay * bz - az * by;
-		this.y = az * bx - ax * bz;
-		this.z = ax * by - ay * bx;
+		this.x = a.y * b.z - a.z * b.y;
+		this.y = a.z * b.x - a.x * b.z;
+		this.z = a.x * b.y - a.y * b.x;
 
 		return this;
 
@@ -635,7 +631,7 @@ THREE.Vector3.prototype = {
 
 		return function ( vector ) {
 
-			if ( v1 === undefined ) v1 = new THREE.Vector3();
+			if ( v1 === void(0) ) v1 = new THREE.Vector3();
 
 			v1.copy( vector ).normalize();
 
@@ -653,7 +649,7 @@ THREE.Vector3.prototype = {
 
 		return function ( planeNormal ) {
 
-			if ( v1 === undefined ) v1 = new THREE.Vector3();
+			if ( v1 === void(0) ) v1 = new THREE.Vector3();
 
 			v1.copy( this ).projectOnVector( planeNormal );
 
@@ -672,7 +668,7 @@ THREE.Vector3.prototype = {
 
 		return function ( normal ) {
 
-			if ( v1 === undefined ) v1 = new THREE.Vector3();
+			if ( v1 === void(0) ) v1 = new THREE.Vector3();
 
 			return this.sub( v1.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
 
@@ -682,11 +678,9 @@ THREE.Vector3.prototype = {
 
 	angleTo: function ( v ) {
 
-		var theta = this.dot( v ) / ( this.length() * v.length() );
-
 		// clamp, to handle numerical problems
 
-		return Math.acos( THREE.Math.clamp( theta, - 1, 1 ) );
+		return Math.acos( THREE.Math.clamp( this.dot( v ) / ( this.length() * v.length() ), - 1, 1 ) );
 
 	},
 
@@ -743,9 +737,11 @@ THREE.Vector3.prototype = {
 
 	setFromMatrixPosition: function ( m ) {
 
-		this.x = m.elements[ 12 ];
-		this.y = m.elements[ 13 ];
-		this.z = m.elements[ 14 ];
+		m = m.elements; // caching
+
+		this.x = m[ 12 ];
+		this.y = m[ 13 ];
+		this.z = m[ 14 ];
 
 		return this;
 
@@ -753,9 +749,11 @@ THREE.Vector3.prototype = {
 
 	setFromMatrixScale: function ( m ) {
 
-		var sx = this.set( m.elements[ 0 ], m.elements[ 1 ], m.elements[  2 ] ).length();
-		var sy = this.set( m.elements[ 4 ], m.elements[ 5 ], m.elements[  6 ] ).length();
-		var sz = this.set( m.elements[ 8 ], m.elements[ 9 ], m.elements[ 10 ] ).length();
+		m = m.elements; // caching
+
+		var sx = this.set( m[ 0 ], m[ 1 ], m[  2 ] ).length();
+		var sy = this.set( m[ 4 ], m[ 5 ], m[  6 ] ).length();
+		var sz = this.set( m[ 8 ], m[ 9 ], m[ 10 ] ).length();
 
 		this.x = sx;
 		this.y = sy;
@@ -766,13 +764,13 @@ THREE.Vector3.prototype = {
 
 	setFromMatrixColumn: function ( index, matrix ) {
 
-		var offset = index * 4;
+		index *= 4; // offset
 
-		var me = matrix.elements;
+		matrix = matrix.elements; // caching
 
-		this.x = me[ offset ];
-		this.y = me[ offset + 1 ];
-		this.z = me[ offset + 2 ];
+		this.x = matrix[ index ];
+		this.y = matrix[ index + 1 ];
+		this.z = matrix[ index + 2 ];
 
 		return this;
 
@@ -786,7 +784,7 @@ THREE.Vector3.prototype = {
 
 	fromArray: function ( array, offset ) {
 
-		if ( offset === undefined ) offset = 0;
+		if ( offset === void(0) ) offset = 0;
 
 		this.x = array[ offset ];
 		this.y = array[ offset + 1 ];
@@ -798,8 +796,8 @@ THREE.Vector3.prototype = {
 
 	toArray: function ( array, offset ) {
 
-		if ( array === undefined ) array = [];
-		if ( offset === undefined ) offset = 0;
+		if ( array === void(0) ) array = [];
+		if ( offset === void(0) ) offset = 0;
 
 		array[ offset ] = this.x;
 		array[ offset + 1 ] = this.y;
@@ -811,9 +809,7 @@ THREE.Vector3.prototype = {
 
 	fromAttribute: function ( attribute, index, offset ) {
 
-	    if ( offset === undefined ) offset = 0;
-
-	    index = index * attribute.itemSize + offset;
+	    index = index * attribute.itemSize + (offset || 0);
 
 	    this.x = attribute.array[ index ];
 	    this.y = attribute.array[ index + 1 ];

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -346,7 +346,7 @@ THREE.Vector4.prototype = {
 			}
 
 			// this singularity is angle = 180
-			return this.set( x, y, z, /*angle*/Math.PI );; // return 180 deg rotation
+			return this.set( x, y, z, /*angle*/Math.PI ); // return 180 deg rotation
 
 		}
 
@@ -364,7 +364,7 @@ THREE.Vector4.prototype = {
 		this.x = ( m32 - m23 ) / s;
 		this.y = ( m13 - m31 ) / s;
 		this.z = ( m21 - m12 ) / s;
-		this.w = Math.acos( ( m11 + m22 + m33 - 1 ) * 0.5 );
+		this.w = Math.acos( ( m11 + m22 + m33 - 1 ) * 0.5 ); // divide by 2
 
 		return this;
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -11,7 +11,7 @@ THREE.Vector4 = function ( x, y, z, w ) {
 	this.x = x || 0;
 	this.y = y || 0;
 	this.z = z || 0;
-	this.w = ( w !== undefined ) ? w : 1;
+	this.w = ( w !== void(0) ) ? w : 1;
 
 };
 
@@ -95,7 +95,7 @@ THREE.Vector4.prototype = {
 		this.x = v.x;
 		this.y = v.y;
 		this.z = v.z;
-		this.w = ( v.w !== undefined ) ? v.w : 1;
+		this.w = ( v.w !== void(0) ) ? v.w : 1;
 
 		return this;
 
@@ -103,7 +103,7 @@ THREE.Vector4.prototype = {
 
 	add: function ( v, w ) {
 
-		if ( w !== undefined ) {
+		if ( w !== void(0) ) {
 
 			console.warn( 'THREE.Vector4: .add() now only accepts one argument. Use .addVectors( a, b ) instead.' );
 			return this.addVectors( v, w );
@@ -143,7 +143,7 @@ THREE.Vector4.prototype = {
 
 	sub: function ( v, w ) {
 
-		if ( w !== undefined ) {
+		if ( w !== void(0) ) {
 
 			console.warn( 'THREE.Vector4: .sub() now only accepts one argument. Use .subVectors( a, b ) instead.' );
 			return this.subVectors( v, w );
@@ -183,17 +183,17 @@ THREE.Vector4.prototype = {
 
 	applyMatrix4: function ( m ) {
 
+		m = m.elements;
+
 		var x = this.x;
 		var y = this.y;
 		var z = this.z;
 		var w = this.w;
 
-		var e = m.elements;
-
-		this.x = e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z + e[ 12 ] * w;
-		this.y = e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z + e[ 13 ] * w;
-		this.z = e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z + e[ 14 ] * w;
-		this.w = e[ 3 ] * x + e[ 7 ] * y + e[ 11 ] * z + e[ 15 ] * w;
+		this.x = m[ 0 ] * x + m[ 4 ] * y + m[ 8 ] * z + m[ 12 ] * w;
+		this.y = m[ 1 ] * x + m[ 5 ] * y + m[ 9 ] * z + m[ 13 ] * w;
+		this.z = m[ 2 ] * x + m[ 6 ] * y + m[ 10 ] * z + m[ 14 ] * w;
+		this.w = m[ 3 ] * x + m[ 7 ] * y + m[ 11 ] * z + m[ 15 ] * w;
 
 		return this;
 
@@ -203,12 +203,12 @@ THREE.Vector4.prototype = {
 
 		if ( scalar !== 0 ) {
 
-			var invScalar = 1 / scalar;
+			scalar = 1 / scalar;
 
-			this.x *= invScalar;
-			this.y *= invScalar;
-			this.z *= invScalar;
-			this.w *= invScalar;
+			this.x *= scalar;
+			this.y *= scalar;
+			this.z *= scalar;
+			this.w *= scalar;
 
 		} else {
 
@@ -257,7 +257,7 @@ THREE.Vector4.prototype = {
 
 		// assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
 
-		var angle, x, y, z,		// variables for result
+		var x, y, z,		// variables for result
 			epsilon = 0.01,		// margin to allow for rounding errors
 			epsilon2 = 0.1,		// margin to distinguish between 0 and 180 degrees
 
@@ -282,22 +282,18 @@ THREE.Vector4.prototype = {
 
 				// this singularity is identity matrix so angle = 0
 
-				this.set( 1, 0, 0, 0 );
-
-				return this; // zero angle, arbitrary axis
+				return this.set( 1, 0, 0, 0 ); // zero angle, arbitrary axis
 
 			}
 
 			// otherwise this singularity is angle = 180
 
-			angle = Math.PI;
-
-			var xx = ( m11 + 1 ) / 2;
-			var yy = ( m22 + 1 ) / 2;
-			var zz = ( m33 + 1 ) / 2;
-			var xy = ( m12 + m21 ) / 4;
-			var xz = ( m13 + m31 ) / 4;
-			var yz = ( m23 + m32 ) / 4;
+			var xx = ( m11 + 1 ) * 0.5; // divided by 2
+			var yy = ( m22 + 1 ) * 0.5; // divided by 2
+			var zz = ( m33 + 1 ) * 0.5; // divided by 2
+			var xy = ( m12 + m21 ) * 0.25; // divided by 4
+			var xz = ( m13 + m31 ) * 0.25; // divided by 4
+			var yz = ( m23 + m32 ) * 0.25; // divided by 4
 
 			if ( ( xx > yy ) && ( xx > zz ) ) { // m11 is the largest diagonal term
 
@@ -349,9 +345,8 @@ THREE.Vector4.prototype = {
 
 			}
 
-			this.set( x, y, z, angle );
-
-			return this; // return 180 deg rotation
+			// this singularity is angle = 180
+			return this.set( x, y, z, /*angle*/Math.PI );; // return 180 deg rotation
 
 		}
 
@@ -369,7 +364,7 @@ THREE.Vector4.prototype = {
 		this.x = ( m32 - m23 ) / s;
 		this.y = ( m13 - m31 ) / s;
 		this.z = ( m21 - m12 ) / s;
-		this.w = Math.acos( ( m11 + m22 + m33 - 1 ) / 2 );
+		this.w = Math.acos( ( m11 + m22 + m33 - 1 ) * 0.5 );
 
 		return this;
 
@@ -489,7 +484,7 @@ THREE.Vector4.prototype = {
 
 		return function ( minVal, maxVal ) {
 
-			if ( min === undefined ) {
+			if ( min === void(0) ) {
 
 				min = new THREE.Vector4();
 				max = new THREE.Vector4();
@@ -540,10 +535,10 @@ THREE.Vector4.prototype = {
 
     roundToZero: function () {
 
-        this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
-        this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
-        this.z = ( this.z < 0 ) ? Math.ceil( this.z ) : Math.floor( this.z );
-        this.w = ( this.w < 0 ) ? Math.ceil( this.w ) : Math.floor( this.w );
+        this.x |= 0; // n < 0 ? ceil(n) : floor(n)
+        this.y |= 0; // n < 0 ? ceil(n) : floor(n)
+        this.z |= 0; // n < 0 ? ceil(n) : floor(n)
+        this.w |= 0; // n < 0 ? ceil(n) : floor(n)
 
         return this;
 
@@ -551,10 +546,10 @@ THREE.Vector4.prototype = {
 
 	negate: function () {
 
-		this.x = - this.x;
-		this.y = - this.y;
-		this.z = - this.z;
-		this.w = - this.w;
+		this.x *= - 1;
+		this.y *= - 1;
+		this.z *= - 1;
+		this.w *= - 1;
 
 		return this;
 
@@ -623,7 +618,7 @@ THREE.Vector4.prototype = {
 
 	fromArray: function ( array, offset ) {
 
-		if ( offset === undefined ) offset = 0;
+		if ( offset === void(0) ) offset = 0;
 
 		this.x = array[ offset ];
 		this.y = array[ offset + 1 ];
@@ -636,8 +631,8 @@ THREE.Vector4.prototype = {
 
 	toArray: function ( array, offset ) {
 
-		if ( array === undefined ) array = [];
-		if ( offset === undefined ) offset = 0;
+		if ( array === void(0) ) array = [];
+		if ( offset === void(0) ) offset = 0;
 
 		array[ offset ] = this.x;
 		array[ offset + 1 ] = this.y;
@@ -650,9 +645,7 @@ THREE.Vector4.prototype = {
 
 	fromAttribute: function ( attribute, index, offset ) {
 
-	    if ( offset === undefined ) offset = 0;
-
-	    index = index * attribute.itemSize + offset;
+	    index = index * attribute.itemSize + (offset || 0);
 
 	    this.x = attribute.array[ index ];
 	    this.y = attribute.array[ index + 1 ];


### PR DESCRIPTION
- variable reuse (less mem, faster attribution - http://jsperf.com/pro-var-reuse);
- `undefined` replaced by `void(0)`, since is slight faster, value safe and uses less chars (http://jsperf.com/typeof-vs-undefined-check/22);
- `<Vector2/3/4>.roundToZero()` ceils negatives and floors positives using a simple `n |= 0`;
- using `*= -1` to negate properties (better minification, http://jsperf.com/fast-negate-numeric-property);
- multiply is faster than divide (http://jsperf.com/multiply-vs-divide/3) ex: `n / 2` to `n * 0.5` and `n / 4` to `n * 0.25`;
- minor optimizations.
