### PR TITLE
creation common.glsl utilities shader chunk and adopt it (fixes one bug)

### DIFF
--- a/examples/js/ShaderSkin.js
+++ b/examples/js/ShaderSkin.js
@@ -110,6 +110,7 @@ THREE.ShaderSkin = {
 
 			"varying vec3 vViewPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "shadowmap_pars_fragment" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
 			THREE.ShaderChunk[ "bumpmap_pars_fragment" ],
@@ -230,9 +231,7 @@ THREE.ShaderSkin = {
 
 					"for( int i = 0; i < MAX_DIR_LIGHTS; i++ ) {",
 
-						"vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );",
-
-						"vec3 dirVector = normalize( lDirection.xyz );",
+						"vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );",
 
 						"float dirDiffuseWeightFull = max( dot( normal, dirVector ), 0.0 );",
 						"float dirDiffuseWeightHalf = max( 0.5 * dot( normal, dirVector ) + 0.5, 0.0 );",
@@ -255,8 +254,7 @@ THREE.ShaderSkin = {
 
 					"for ( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {",
 
-						"vec4 lDirection = viewMatrix * vec4( hemisphereLightDirection[ i ], 0.0 );",
-						"vec3 lVector = normalize( lDirection.xyz );",
+						"vec3 lVector = transformDirection( hemisphereLightDirection[ i ], viewMatrix );",
 
 						"float dotProduct = dot( normal, lVector );",
 						"float hemiDiffuseWeight = 0.5 * dotProduct + 0.5;",
@@ -430,6 +428,7 @@ THREE.ShaderSkin = {
 
 			"varying vec3 vViewPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
 
 			"float fresnelReflectance( vec3 H, vec3 V, float F0 ) {",
@@ -526,9 +525,7 @@ THREE.ShaderSkin = {
 
 					"for( int i = 0; i < MAX_DIR_LIGHTS; i++ ) {",
 
-						"vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );",
-
-						"vec3 dirVector = normalize( lDirection.xyz );",
+						"vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );",
 
 						"float dirDiffuseWeight = max( dot( normal, dirVector ), 0.0 );",
 

--- a/examples/js/ShaderTerrain.js
+++ b/examples/js/ShaderTerrain.js
@@ -113,6 +113,7 @@ THREE.ShaderTerrain = {
 
 			"varying vec3 vViewPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "shadowmap_pars_fragment" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
 
@@ -204,9 +205,7 @@ THREE.ShaderTerrain = {
 
 					"for( int i = 0; i < MAX_DIR_LIGHTS; i++ ) {",
 
-						"vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );",
-
-						"vec3 dirVector = normalize( lDirection.xyz );",
+						"vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );",
 						"vec3 dirHalfVector = normalize( dirVector + viewPosition );",
 
 						"float dirDotNormalHalf = max( dot( normal, dirHalfVector ), 0.0 );",
@@ -230,8 +229,7 @@ THREE.ShaderTerrain = {
 
 					"for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {",
 
-						"vec4 lDirection = viewMatrix * vec4( hemisphereLightDirection[ i ], 0.0 );",
-						"vec3 lVector = normalize( lDirection.xyz );",
+						"vec3 lVector = transformDirection( hemisphereLightDirection[ i ], viewMatrix );",
 
 						// diffuse
 

--- a/src/renderers/shaders/ShaderChunk/color_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/color_vertex.glsl
@@ -2,7 +2,7 @@
 
 	#ifdef GAMMA_INPUT
 
-		vColor = color * color;
+		vColor = square( color );
 
 	#else
 

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -20,11 +20,11 @@ float whiteCompliment( in float a ) { return saturate( 1.0 - a ); }
 vec2  whiteCompliment( in vec2 a )  { return saturate( vec2(1.0) - a ); }
 vec3  whiteCompliment( in vec3 a )  { return saturate( vec3(1.0) - a ); }
 vec4  whiteCompliment( in vec4 a )  { return saturate( vec4(1.0) - a ); }
-vec3 transformNormal( in vec3 normal, in mat4 matrix ) {
+vec3 transformDirection( in vec3 normal, in mat4 matrix ) {
 	return normalize( ( matrix * vec4( normal, 0.0 ) ).xyz );
 }
 // http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
-vec3 inverseTransformNormal( in vec3 normal, in mat4 matrix ) {
+vec3 inverseTransformDirection( in vec3 normal, in mat4 matrix ) {
 	return normalize( ( vec4( normal, 0.0 ) * matrix ).xyz );
 }
 vec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal) {

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -1,0 +1,35 @@
+#define PI 3.14159
+#define PI2 6.28318
+#define RECIPROCAL_PI2 0.15915494
+#define LOG2 1.442695
+#define EPSILON 1e-6
+
+float square( in float a ) { return a*a; }
+vec2  square( in vec2 a )  { return vec2( a.x*a.x, a.y*a.y ); }
+vec3  square( in vec3 a )  { return vec3( a.x*a.x, a.y*a.y, a.z*a.z ); }
+vec4  square( in vec4 a )  { return vec4( a.x*a.x, a.y*a.y, a.z*a.z, a.w*a.w ); }
+float saturate( in float a ) { return clamp( a, 0.0, 1.0 ); }
+vec2  saturate( in vec2 a )  { return clamp( a, 0.0, 1.0 ); }
+vec3  saturate( in vec3 a )  { return clamp( a, 0.0, 1.0 ); }
+vec4  saturate( in vec4 a )  { return clamp( a, 0.0, 1.0 ); }
+float average( in float a ) { return a; }
+float average( in vec2 a )  { return ( a.x + a.y) * 0.5; }
+float average( in vec3 a )  { return ( a.x + a.y + a.z) * 0.3333333333; }
+float average( in vec4 a )  { return ( a.x + a.y + a.z + a.w) * 0.25; }
+float whiteCompliment( in float a ) { return saturate( 1.0 - a ); }
+vec2  whiteCompliment( in vec2 a )  { return saturate( vec2(1.0) - a ); }
+vec3  whiteCompliment( in vec3 a )  { return saturate( vec3(1.0) - a ); }
+vec4  whiteCompliment( in vec4 a )  { return saturate( vec4(1.0) - a ); }
+vec3 transformNormal( in vec3 normal, in mat4 matrix ) {
+	return normalize( ( viewMatrix * vec4( normal, 0.0 ) ).xyz );
+}
+vec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal) {
+	float distance = dot( planeNormal, point-pointOnPlane );
+	return point - distance * planeNormal;
+}
+float sideOfPlane( in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {
+	return sign( dot( point - pointOnPlane, planeNormal ) );
+}
+vec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 pointOnPlane, in vec3 planeNormal ) {
+	return pointOnLine + lineDirection * ( dot( planeNormal, pointOnPlane - pointOnLine ) / dot( planeNormal, lineDirection ) );
+}

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -14,7 +14,7 @@ vec3  saturate( in vec3 a )  { return clamp( a, 0.0, 1.0 ); }
 vec4  saturate( in vec4 a )  { return clamp( a, 0.0, 1.0 ); }
 float average( in float a ) { return a; }
 float average( in vec2 a )  { return ( a.x + a.y) * 0.5; }
-float average( in vec3 a )  { return ( a.x + a.y + a.z) * 0.3333333333; }
+float average( in vec3 a )  { return ( a.x + a.y + a.z) / 3.0; }
 float average( in vec4 a )  { return ( a.x + a.y + a.z + a.w) * 0.25; }
 float whiteCompliment( in float a ) { return saturate( 1.0 - a ); }
 vec2  whiteCompliment( in vec2 a )  { return saturate( vec2(1.0) - a ); }

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -21,7 +21,7 @@ vec2  whiteCompliment( in vec2 a )  { return saturate( vec2(1.0) - a ); }
 vec3  whiteCompliment( in vec3 a )  { return saturate( vec3(1.0) - a ); }
 vec4  whiteCompliment( in vec4 a )  { return saturate( vec4(1.0) - a ); }
 vec3 transformNormal( in vec3 normal, in mat4 matrix ) {
-	return normalize( ( viewMatrix * vec4( normal, 0.0 ) ).xyz );
+	return normalize( ( matrix * vec4( normal, 0.0 ) ).xyz );
 }
 // http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
 vec3 inverseTransformNormal( in vec3 normal, in mat4 matrix ) {

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -23,6 +23,10 @@ vec4  whiteCompliment( in vec4 a )  { return saturate( vec4(1.0) - a ); }
 vec3 transformNormal( in vec3 normal, in mat4 matrix ) {
 	return normalize( ( viewMatrix * vec4( normal, 0.0 ) ).xyz );
 }
+// http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
+vec3 inverseTransformNormal( in vec3 normal, in mat4 matrix ) {
+	return normalize( ( vec4( normal, 0.0 ) * matrix ).xyz );
+}
 vec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal) {
 	float distance = dot( planeNormal, point-pointOnPlane );
 	return point - distance * planeNormal;

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -5,7 +5,7 @@
 		vec3 cameraToVertex = normalize( vWorldPosition - cameraPosition );
 
 		// Transforming Normal Vectors with the Inverse Transformation
-		vec3 worldNormal = inverseTransformNormal( normal, viewMatrix );
+		vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );
 
 		#ifdef ENVMAP_MODE_REFLECTION
 
@@ -39,7 +39,7 @@
 		vec4 envColor = texture2D( envMap, sampleUV );
 		
 	#elif defined( ENVMAP_TYPE_SPHERE )
-		vec3 reflectView = flipNormal * ( transformNormal( reflectVec, viewMatrix ) + vec3(0.0,0.0,1.0) );
+		vec3 reflectView = flipNormal * ( transformDirection( reflectVec, viewMatrix ) + vec3(0.0,0.0,1.0) );
 		vec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -7,7 +7,7 @@
 		// http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
 		// Transforming Normal Vectors with the Inverse Transformation
 
-		vec3 worldNormal = normalize( vec3( vec4( normal, 0.0 ) * viewMatrix ) );
+		vec3 worldNormal = transformNormal( normal, viewMatrix );
 
 		#ifdef ENVMAP_MODE_REFLECTION
 
@@ -36,12 +36,12 @@
 
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 		vec2 sampleUV;
-		sampleUV.y = clamp( flipNormal * reflectVec.y * 0.5 + 0.5, 0.0, 1.0);
-		sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * 0.15915494309189533576888376337251 + 0.5; // reciprocal( 2 PI ) + 0.5
+		sampleUV.y = saturate( flipNormal * reflectVec.y * 0.5 + 0.5 );
+		sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * RECIPROCAL_2PI + 0.5;
 		vec4 envColor = texture2D( envMap, sampleUV );
 		
 	#elif defined( ENVMAP_TYPE_SPHERE )
-		vec3 reflectView = flipNormal * normalize((viewMatrix * vec4( reflectVec, 0.0 )).xyz + vec3(0.0,0.0,1.0));
+		vec3 reflectView = flipNormal * ( transformNormal( reflectVec, viewMatrix ) + vec3(0.0,0.0,1.0) );
 		vec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -4,10 +4,8 @@
 
 		vec3 cameraToVertex = normalize( vWorldPosition - cameraPosition );
 
-		// http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
 		// Transforming Normal Vectors with the Inverse Transformation
-
-		vec3 worldNormal = transformNormal( normal, viewMatrix );
+		vec3 worldNormal = inverseTransformNormal( normal, viewMatrix );
 
 		#ifdef ENVMAP_MODE_REFLECTION
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -35,7 +35,7 @@
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 		vec2 sampleUV;
 		sampleUV.y = saturate( flipNormal * reflectVec.y * 0.5 + 0.5 );
-		sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * RECIPROCAL_2PI + 0.5;
+		sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * RECIPROCAL_PI2 + 0.5;
 		vec4 envColor = texture2D( envMap, sampleUV );
 		
 	#elif defined( ENVMAP_TYPE_SPHERE )

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -39,7 +39,7 @@
 		vec4 envColor = texture2D( envMap, sampleUV );
 		
 	#elif defined( ENVMAP_TYPE_SPHERE )
-		vec3 reflectView = flipNormal * ( transformDirection( reflectVec, viewMatrix ) + vec3(0.0,0.0,1.0) );
+		vec3 reflectView = flipNormal * normalize((viewMatrix * vec4( reflectVec, 0.0 )).xyz + vec3(0.0,0.0,1.0));
 		vec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
@@ -1,7 +1,6 @@
 #if defined( USE_ENVMAP ) && ! defined( USE_BUMPMAP ) && ! defined( USE_NORMALMAP ) && ! defined( PHONG )
 
-	vec3 worldNormal = mat3( modelMatrix[ 0 ].xyz, modelMatrix[ 1 ].xyz, modelMatrix[ 2 ].xyz ) * objectNormal;
-	worldNormal = normalize( worldNormal );
+	vec3 worldNormal = transformNormal( objectNormal, modelMatrix );
 
 	vec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );
 

--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
@@ -1,6 +1,6 @@
 #if defined( USE_ENVMAP ) && ! defined( USE_BUMPMAP ) && ! defined( USE_NORMALMAP ) && ! defined( PHONG )
 
-	vec3 worldNormal = transformNormal( objectNormal, modelMatrix );
+	vec3 worldNormal = transformDirection( objectNormal, modelMatrix );
 
 	vec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );
 

--- a/src/renderers/shaders/ShaderChunk/fog_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/fog_fragment.glsl
@@ -12,9 +12,8 @@
 
 	#ifdef FOG_EXP2
 
-		const float LOG2 = 1.442695;
-		float fogFactor = exp2( - fogDensity * fogDensity * depth * depth * LOG2 );
-		fogFactor = 1.0 - clamp( fogFactor, 0.0, 1.0 );
+		float fogFactor = exp2( - square( fogDensity ) * square( depth ) * LOG2 );
+		fogFactor = whiteCompliment( fogFactor );
 
 	#else
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -12,8 +12,7 @@ transformedNormal = normalize( transformedNormal );
 
 for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
-	vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );
-	vec3 dirVector = normalize( lDirection.xyz );
+	vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );
 
 	float dotProduct = dot( transformedNormal, dirVector );
 	vec3 directionalLightWeighting = vec3( max( dotProduct, 0.0 ) );
@@ -173,8 +172,7 @@ for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
 	for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec4 lDirection = viewMatrix * vec4( hemisphereLightDirection[ i ], 0.0 );
-		vec3 lVector = normalize( lDirection.xyz );
+		vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );
 
 		float dotProduct = dot( transformedNormal, lVector );
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -12,7 +12,7 @@ transformedNormal = normalize( transformedNormal );
 
 for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
-	vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );
+	vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );
 
 	float dotProduct = dot( transformedNormal, dirVector );
 	vec3 directionalLightWeighting = vec3( max( dotProduct, 0.0 ) );
@@ -172,7 +172,7 @@ for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
 	for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );
+		vec3 lVector = transformDirection( hemisphereLightDirection[ i ], viewMatrix );
 
 		float dotProduct = dot( transformedNormal, lVector );
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -79,7 +79,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 		float lDistance = 1.0;
 		if ( spotLightDistance[ i ] > 0.0 )
-			lDistance = saturate( 1.0 - ( length( lVector ) / spotLightDistance[ i ] );
+			lDistance = saturate( 1.0 - ( length( lVector ) / spotLightDistance[ i ] ) );
 
 		lVector = normalize( lVector );
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -132,7 +132,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 	for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
-		vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );
+		vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );
 
 				// diffuse
 
@@ -197,7 +197,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 	for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );
+		vec3 lVector = transformDirection( hemisphereLightDirection[ i ], viewMatrix );
 
 		// diffuse
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -29,7 +29,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 		float lDistance = 1.0;
 		if ( pointLightDistance[ i ] > 0.0 )
-			lDistance = 1.0 - min( ( length( lVector ) / pointLightDistance[ i ] ), 1.0 );
+			lDistance = saturate( 1.0 - ( length( lVector ) / pointLightDistance[ i ] ) );
 
 		lVector = normalize( lVector );
 
@@ -79,7 +79,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 		float lDistance = 1.0;
 		if ( spotLightDistance[ i ] > 0.0 )
-			lDistance = 1.0 - min( ( length( lVector ) / spotLightDistance[ i ] ), 1.0 );
+			lDistance = saturate( 1.0 - ( length( lVector ) / spotLightDistance[ i ] );
 
 		lVector = normalize( lVector );
 
@@ -132,8 +132,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 	for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
-		vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );
-		vec3 dirVector = normalize( lDirection.xyz );
+		vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );
 
 				// diffuse
 
@@ -198,8 +197,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 	for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec4 lDirection = viewMatrix * vec4( hemisphereLightDirection[ i ], 0.0 );
-		vec3 lVector = normalize( lDirection.xyz );
+		vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );
 
 		// diffuse
 

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl
@@ -1,6 +1,6 @@
 #ifdef USE_LOGDEPTHBUF
 
-	gl_Position.z = log2(max(1e-6, gl_Position.w + 1.0)) * logDepthBufFC;
+	gl_Position.z = log2(max( EPSILON, gl_Position.w + 1.0 )) * logDepthBufFC;
 
 	#ifdef USE_LOGDEPTHBUF_EXT
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -21,6 +21,7 @@ THREE.ShaderLib = {
 
 		vertexShader: [
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "map_pars_vertex" ],
 			THREE.ShaderChunk[ "lightmap_pars_vertex" ],
 			THREE.ShaderChunk[ "envmap_pars_vertex" ],
@@ -63,6 +64,7 @@ THREE.ShaderLib = {
 			"uniform vec3 diffuse;",
 			"uniform float opacity;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "map_pars_fragment" ],
 			THREE.ShaderChunk[ "alphamap_pars_fragment" ],
@@ -126,6 +128,7 @@ THREE.ShaderLib = {
 
 			"#endif",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "map_pars_vertex" ],
 			THREE.ShaderChunk[ "lightmap_pars_vertex" ],
 			THREE.ShaderChunk[ "envmap_pars_vertex" ],
@@ -173,6 +176,7 @@ THREE.ShaderLib = {
 
 			"#endif",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "map_pars_fragment" ],
 			THREE.ShaderChunk[ "alphamap_pars_fragment" ],
@@ -252,6 +256,7 @@ THREE.ShaderLib = {
 			"varying vec3 vViewPosition;",
 			"varying vec3 vNormal;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "map_pars_vertex" ],
 			THREE.ShaderChunk[ "lightmap_pars_vertex" ],
 			THREE.ShaderChunk[ "envmap_pars_vertex" ],
@@ -303,6 +308,7 @@ THREE.ShaderLib = {
 			"uniform vec3 specular;",
 			"uniform float shininess;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "map_pars_fragment" ],
 			THREE.ShaderChunk[ "alphamap_pars_fragment" ],
@@ -357,6 +363,7 @@ THREE.ShaderLib = {
 			"uniform float size;",
 			"uniform float scale;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_vertex" ],
 			THREE.ShaderChunk[ "shadowmap_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
@@ -388,6 +395,7 @@ THREE.ShaderLib = {
 			"uniform vec3 psColor;",
 			"uniform float opacity;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "map_particle_pars_fragment" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
@@ -433,6 +441,7 @@ THREE.ShaderLib = {
 
 			"varying float vLineDistance;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
@@ -461,6 +470,7 @@ THREE.ShaderLib = {
 
 			"varying float vLineDistance;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
@@ -497,6 +507,7 @@ THREE.ShaderLib = {
 
 		vertexShader: [
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
@@ -516,6 +527,7 @@ THREE.ShaderLib = {
 			"uniform float mFar;",
 			"uniform float opacity;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"void main() {",
@@ -553,6 +565,7 @@ THREE.ShaderLib = {
 
 			"varying vec3 vNormal;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
@@ -573,6 +586,7 @@ THREE.ShaderLib = {
 			"uniform float opacity;",
 			"varying vec3 vNormal;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"void main() {",
@@ -642,6 +656,7 @@ THREE.ShaderLib = {
 
 		fragmentShader: [
 
+
 			"uniform vec3 ambient;",
 			"uniform vec3 diffuse;",
 			"uniform vec3 specular;",
@@ -671,6 +686,8 @@ THREE.ShaderLib = {
 			"varying vec2 vUv;",
 
 			"uniform vec3 ambientLightColor;",
+
+			THREE.ShaderChunk[ "common" ],
 
 			"#if MAX_DIR_LIGHTS > 0",
 
@@ -898,8 +915,7 @@ THREE.ShaderLib = {
 
 			"		for( int i = 0; i < MAX_DIR_LIGHTS; i++ ) {",
 
-			"			vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );",
-			"			vec3 dirVector = normalize( lDirection.xyz );",
+			"			vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );",
 
 						// diffuse
 
@@ -942,8 +958,7 @@ THREE.ShaderLib = {
 
 			"		for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {",
 
-			"			vec4 lDirection = viewMatrix * vec4( hemisphereLightDirection[ i ], 0.0 );",
-			"			vec3 lVector = normalize( lDirection.xyz );",
+			"			vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );",
 
 						// diffuse
 
@@ -1083,6 +1098,7 @@ THREE.ShaderLib = {
 			"varying vec3 vWorldPosition;",
 			"varying vec3 vViewPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "skinning_pars_vertex" ],
 			THREE.ShaderChunk[ "shadowmap_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
@@ -1215,12 +1231,12 @@ THREE.ShaderLib = {
 
 			"varying vec3 vWorldPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
 			"void main() {",
 
-			"	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
-			"	vWorldPosition = worldPosition.xyz;",
+			"	vec4 worldPosition = transformNormal( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
@@ -1237,6 +1253,7 @@ THREE.ShaderLib = {
 
 			"varying vec3 vWorldPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"void main() {",
@@ -1264,12 +1281,12 @@ THREE.ShaderLib = {
 
 			"varying vec3 vWorldPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
 			"void main() {",
 
-			"	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
-			"	vWorldPosition = worldPosition.xyz;",
+			"	vec4 worldPosition = transformNormal( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
@@ -1286,6 +1303,7 @@ THREE.ShaderLib = {
 
 			"varying vec3 vWorldPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"void main() {",
@@ -1293,8 +1311,8 @@ THREE.ShaderLib = {
 				// "	gl_FragColor = textureCube( tCube, vec3( tFlip * vWorldPosition.x, vWorldPosition.yz ) );",
 				"vec3 direction = normalize( vWorldPosition );",
 				"vec2 sampleUV;",
-				"sampleUV.y = clamp( tFlip * direction.y * -0.5 + 0.5, 0.0, 1.0);",
-				"sampleUV.x = atan( direction.z, direction.x ) * 0.15915494309189533576888376337251 + 0.5;", // reciprocal( 2 PI ) + 0.5
+				"sampleUV.y = saturate( tFlip * direction.y * -0.5 + 0.5 );",
+				"sampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_2PI + 0.5;", 
 				"gl_FragColor = texture2D( tEquirect, sampleUV );",
 
 				THREE.ShaderChunk[ "logdepthbuf_fragment" ],
@@ -1323,6 +1341,7 @@ THREE.ShaderLib = {
 
 		vertexShader: [
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "skinning_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
@@ -1341,6 +1360,7 @@ THREE.ShaderLib = {
 
 		fragmentShader: [
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"vec4 pack_depth( const in float depth ) {",

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -1312,7 +1312,7 @@ THREE.ShaderLib = {
 				"vec3 direction = normalize( vWorldPosition );",
 				"vec2 sampleUV;",
 				"sampleUV.y = saturate( tFlip * direction.y * -0.5 + 0.5 );",
-				"sampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_2PI + 0.5;", 
+				"sampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_PI2 + 0.5;", 
 				"gl_FragColor = texture2D( tEquirect, sampleUV );",
 
 				THREE.ShaderChunk[ "logdepthbuf_fragment" ],

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -915,7 +915,7 @@ THREE.ShaderLib = {
 
 			"		for( int i = 0; i < MAX_DIR_LIGHTS; i++ ) {",
 
-			"			vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );",
+			"			vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );",
 
 						// diffuse
 
@@ -958,7 +958,7 @@ THREE.ShaderLib = {
 
 			"		for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {",
 
-			"			vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );",
+			"			vec3 lVector = transformDirection( hemisphereLightDirection[ i ], viewMatrix );",
 
 						// diffuse
 
@@ -1236,7 +1236,7 @@ THREE.ShaderLib = {
 
 			"void main() {",
 
-			"	vWorldPosition = transformNormal( position, modelMatrix );",
+			"	vWorldPosition = transformDirection( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
@@ -1286,7 +1286,7 @@ THREE.ShaderLib = {
 
 			"void main() {",
 
-			"	vWorldPosition = transformNormal( position, modelMatrix );",
+			"	vWorldPosition = transformDirection( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -1236,7 +1236,7 @@ THREE.ShaderLib = {
 
 			"void main() {",
 
-			"	vec4 worldPosition = transformNormal( position, modelMatrix );",
+			"	vWorldPosition = transformNormal( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
@@ -1286,7 +1286,7 @@ THREE.ShaderLib = {
 
 			"void main() {",
 
-			"	vec4 worldPosition = transformNormal( position, modelMatrix );",
+			"	vWorldPosition = transformNormal( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -83,6 +83,7 @@
 	"src/scenes/Fog.js",
 	"src/scenes/FogExp2.js",
 	"src/renderers/shaders/ShaderChunk.js",
+	"src/renderers/shaders/ShaderChunk/common.glsl",
 	"src/renderers/shaders/ShaderChunk/alphatest_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl",
 	"src/renderers/shaders/ShaderChunk/map_particle_pars_fragment.glsl",


### PR DESCRIPTION
This adds common.glsl, a common file of GLSL shader utilities.

The idea is to add useful commonly used functions to this so that we do not have to replicate code unnecessary across all shaders.  The hope is that more centralization of utility functions will simplify the shader code.

I actually found a bug while doing this.  In apply the transformNormal() function to envmap_fragment.glsl, I noticed that the order of the vector and matrix were inverted:

https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl#L10

All other matrix-vector multiplications are in the opposite order.

The original idea for a common.glsl was proposed here back in January 2014:  https://github.com/mrdoob/three.js/issues/4271#issuecomment-31689451
https://github.com/mrdoob/three.js/issues/4271#issuecomment-31710837
https://github.com/mrdoob/three.js/issues/4271#issuecomment-31752034

PS. This is part one of a couple PRs related to adding Physically-Based Rendering materials to Three.JS.
