### PR TITLE
improve recycling of programs

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -903,13 +903,15 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	};
 
-	var deallocateMaterial = function ( material ) {
+	var deallocateMaterial = function ( material, optionalDisconnectedProgram ) {
 
-		var program = material.program.program;
+		var program = optionalDisconnectedProgram || material.program;
 
 		if ( program === undefined ) return;
 
-		material.program = undefined;
+		if( ! optionalDisconnectedProgram ) {
+			material.program = undefined;
+		}
 
 		// only deallocate GL program if this was the last use of shared program
 		// assumed there is only single copy of any program in the _programs list
@@ -4276,10 +4278,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( material.needsUpdate ) {
 
-			if ( material.program ) deallocateMaterial( material );
+			var oldProgram = material.program;
 
 			initMaterial( material, lights, fog, object );
 			material.needsUpdate = false;
+
+			if ( oldProgram ) deallocateMaterial( material, oldProgram );
 
 		}
 


### PR DESCRIPTION
When a material changes, Three.JS current deallocates the associated material program, and then creates a new program.  Often the new program is the same as the previous program.  The deallocator is smart in that it uses reference counting, but if only a single material of the specific type is in use, the reference count will go to zero every time in this scenario, and the program will be deallocated and then it is requested again where it is re-created: thus the reference count codes 1 to 0 to 1.

What I have done is change the order slightly, so now when a material changes, it first requests the new program before it deallocates the old program.  This ensures that if the program can be reused it's reference count goes from 1 to 2 to 1, thus avoiding an unnecessary deallocation.

This change greatly speeds up https://Clara.io in the face of dynamic materials and lights.
