### PR TITLE
Arealight for MeshPhongMaterial & WebGLRenderer

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -253,6 +253,7 @@
 				"webgl_lights_hemisphere",
 				"webgl_lights_pointlights",
 				"webgl_lights_pointlights2",
+				"webgl_lights_arealights",
 				"webgl_lines_colors",
 				"webgl_lines_cubes",
 				"webgl_lines_dashed",

--- a/examples/webgl_lights_arealights.html
+++ b/examples/webgl_lights_arealights.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - lights - point lights</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				background-color: #000;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0px; width: 100%;
+				color: #ffffff;
+				padding: 5px;
+				font-family: Monospace;
+				font-size: 13px;
+				text-align: center;
+			}
+
+			a {
+				color: #ff0080;
+				text-decoration: none;
+			}
+
+			a:hover {
+				color: #0080ff;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="container"></div>
+		<div id="info">
+			<a href="http://threejs.org" target="_blank">three.js</a> - area lights WebGL demo.<br />			
+		</div>
+
+		<script src="../build/three.min.js"></script>
+
+		<script src="js/loaders/BinaryLoader.js"></script>
+
+		<script src="js/Detector.js"></script>
+
+		<script src="js/libs/stats.min.js"></script>
+
+		<script>
+	
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var SCALE = 1;
+
+			var WIDTH = window.innerWidth;
+			var HEIGHT = window.innerHeight;
+
+			var NEAR = 1.0, FAR = 350.0;
+			var VIEW_ANGLE = 40;
+
+			// controls
+
+			var mouseX = 0;
+			var mouseY = 0;
+
+			var targetX = 0, targetY = 0;
+			var angle = 0;
+			var target = new THREE.Vector3( 0, 0, 0 );
+
+			var windowHalfX = window.innerWidth / 2;
+			var windowHalfY = window.innerHeight / 2;
+
+			var sceneMaterial = null;
+
+			// core
+
+			var renderer, camera, scene, stats, clock;
+
+			// lights
+
+			var areaLight1, areaLight2, areaLight3;
+
+			//
+
+			init();
+			animate();
+
+			// -----------------------------
+
+			function init() {
+
+				// renderer
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				var container = document.getElementById( 'container' );
+				container.appendChild( renderer.domElement );
+
+				// camera
+
+				camera = new THREE.PerspectiveCamera( VIEW_ANGLE, WIDTH / HEIGHT, NEAR, FAR );
+				camera.position.y = 40;
+
+				// scene
+
+				scene = new THREE.Scene();
+				scene.add( camera );
+
+				// stats
+
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '8px';
+				stats.domElement.style.zIndex = 100;
+				container.appendChild( stats.domElement );
+
+				// clock
+
+				clock = new THREE.Clock();
+
+				// add lights
+
+				initLights();
+
+				// add objects
+
+				initObjects();
+
+				// events
+
+				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			// -----------------------------
+
+			function createAreaEmitter( light ) {
+
+				var geometry = new THREE.PlaneGeometry( 1, 1 );
+				var material = new THREE.MeshBasicMaterial( { color: light.color.getHex(), vertexColors: THREE.FaceColors } );
+
+				var emitter = new THREE.Mesh( geometry, material );
+				emitter.scale.set( light.width * 2, 1.0, light.height * 2 );
+
+				return emitter;
+
+			}
+
+			function setupAreaLight( light ) {
+
+				var matrix = light.matrixWorld;
+
+				light.right.applyMatrix4( matrix );
+				light.normal.applyMatrix4( matrix );
+
+			}
+
+			function initLights() {
+
+				areaLight1 = new THREE.AreaLight( 0xffffff, 1 );
+				areaLight1.position.set( 0.0001, 10.0001, -18.5001 );
+				areaLight1.rotation.set( -0.74719, 0.0001, 0.0001 );
+				areaLight1.width = 10;
+				areaLight1.height = 1;
+
+				areaLight1.add(areaLight1.target);
+				areaLight1.target.position.set(0, 0, -1);
+
+				scene.add( areaLight1 );
+
+				var meshEmitter = createAreaEmitter( areaLight1 );
+				areaLight1.add( meshEmitter );
+
+				//
+
+				areaLight2 = new THREE.AreaLight( 0x33ff66, 1.5 );
+				areaLight2.position.set( -19.0001, 3.0001, 0.0001 );
+				areaLight2.rotation.set( -1.5707, 0.0001, 1.5707 );
+				areaLight2.width = 8;
+				areaLight2.height = 1;
+
+				areaLight2.add(areaLight2.target);
+				areaLight1.target.position.set(0, 0, -1);
+
+				scene.add( areaLight2 );
+
+				var meshEmitter = createAreaEmitter( areaLight2 );
+				areaLight2.add( meshEmitter );
+
+				//
+
+				areaLight3 = new THREE.AreaLight( 0x3366ff, 1.5 );
+				areaLight3.position.set( 19.0001, 3.0001, 0.0001 );
+				areaLight3.rotation.set( -1.5707, -1.5707, -1.5707 );
+				areaLight3.width = 8;
+				areaLight3.height = 1;
+
+				areaLight2.add(areaLight3.target);
+				areaLight1.target.position.set(0, 0, -1);
+
+				scene.add( areaLight3 );
+
+				var meshEmitter = createAreaEmitter( areaLight3 );
+				areaLight3.add( meshEmitter );
+
+			}
+
+			// -----------------------------
+
+			function initObjects() {
+
+				var loader = new THREE.BinaryLoader();
+				loader.load( "obj/box/box.js", function ( geometry, materials ) {
+
+					sceneMaterial = new THREE.MeshPhongMaterial( { color: 0xffaa55, specular: 0x888888, shininess: 200 } );
+
+					var object = new THREE.Mesh( geometry, sceneMaterial );
+					object.scale.multiplyScalar( 2 );
+					scene.add( object );
+
+				} );
+
+			}
+
+
+			// -----------------------------
+
+			function onWindowResize( event ) {
+
+				windowHalfX = window.innerWidth / 2;
+				windowHalfY = window.innerHeight / 2;
+
+				WIDTH = window.innerWidth;
+				HEIGHT = window.innerHeight - 2 * MARGIN;
+
+				renderer.setSize( WIDTH, HEIGHT );
+
+				camera.aspect = WIDTH / HEIGHT;
+				camera.updateProjectionMatrix();
+
+			}
+
+			function onDocumentMouseMove( event ) {
+
+				mouseX = ( event.clientX - windowHalfX ) * 1;
+				mouseY = ( event.clientY - windowHalfY ) * 1;
+
+			}
+
+			// -----------------------------
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
+				// update camera
+
+				var delta = clock.getDelta();
+
+				targetX = mouseX * .001;
+				targetY = mouseY * .001;
+
+				angle += 0.05 * ( targetX - angle );
+
+				camera.position.x = -Math.sin( angle ) * 40;
+				camera.position.z =  Math.cos( angle ) * 40;
+
+				camera.lookAt( target );
+
+				var time = Date.now();
+
+				areaLight1.position.x = Math.sin( Date.now() * 0.001 ) * 9;
+				areaLight1.position.y = Math.sin( Date.now() * 0.0013 ) * 5 + 5;
+
+				areaLight2.position.y = Math.sin( Date.now() * 0.0011 ) * 3 + 5;
+				areaLight2.position.z = Math.sin( Date.now() * 0.00113 ) * 10;
+
+				areaLight3.position.y = Math.sin( Date.now() * 0.00111 ) * 3 + 5;
+				areaLight3.position.z = Math.sin( Date.now() * 0.001113 ) * 10;
+
+				if( sceneMaterial ) {
+					sceneMaterial.shininess = Math.sin( Date.now() * 0.002 ) * 100 + 100;
+				}
+
+				// render
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+	</body>
+
+</html>

--- a/src/lights/AreaLight.js
+++ b/src/lights/AreaLight.js
@@ -1,28 +1,43 @@
 /**
+ * @author bhouston / http://clara.io/
  * @author MPanknin / http://www.redplant.de/
  * @author alteredq / http://alteredqualia.com/
  */
 
-THREE.AreaLight = function ( color, intensity ) {
+THREE.AreaLight = function ( color, intensity, distance, decayExponent ) {
 
 	THREE.Light.call( this, color );
 
-	this.type = 'AreaLight';
-
-	this.normal = new THREE.Vector3( 0, - 1, 0 );
-	this.right = new THREE.Vector3( 1, 0, 0 );
+	this.position.set( 0, 1, 0 );
+	this.target = new THREE.Object3D();
 
 	this.intensity = ( intensity !== undefined ) ? intensity : 1;
+	this.distance = ( distance !== undefined ) ? distance : 0;
+	this.decayExponent = ( decayExponent !== undefined ) ? decayExponent : 0;	// for physically correct lights, should be 2.
 
 	this.width = 1.0;
 	this.height = 1.0;
 
-	this.constantAttenuation = 1.5;
-	this.linearAttenuation = 0.5;
-	this.quadraticAttenuation = 0.1;
-
+	// TODO: implement shadow maps.  -bhouston, Oct 15, 2014
 };
 
 THREE.AreaLight.prototype = Object.create( THREE.Light.prototype );
-THREE.AreaLight.prototype.constructor = THREE.AreaLight;
 
+THREE.AreaLight.prototype.clone = function () {
+
+	var light = new THREE.AreaLight();
+
+	THREE.Light.prototype.clone.call( this, light );
+
+	light.target = this.target.clone();
+	
+	light.intensity = this.intensity;
+	light.distance = this.distance;
+	light.decayExponent = this.decayExponent;
+
+	light.width = this.width;
+	light.height = this.height;
+
+	return light;
+
+};

--- a/src/lights/AreaLight.js
+++ b/src/lights/AreaLight.js
@@ -9,7 +9,7 @@ THREE.AreaLight = function ( color, intensity, distance, decayExponent ) {
 	THREE.Light.call( this, color );
 
 	this.position.set( 0, 1, 0 );
-	this.target = new THREE.Object3D();
+	this.target = new THREE.Object3D(); 
 
 	this.intensity = ( intensity !== undefined ) ? intensity : 1;
 	this.distance = ( distance !== undefined ) ? distance : 0;
@@ -22,6 +22,7 @@ THREE.AreaLight = function ( color, intensity, distance, decayExponent ) {
 };
 
 THREE.AreaLight.prototype = Object.create( THREE.Light.prototype );
+THREE.AreaLight.prototype.constructor = THREE.AreaLight;
 
 THREE.AreaLight.prototype.clone = function () {
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -90,6 +90,31 @@ THREE.Matrix4.prototype = {
 
 	},
 
+	extractBasis: function ( xAxis, yAxis, zAxis ) {
+ 
+ 		var te = this.elements;
+ 
+		xAxis.set( te[0], te[1], te[2] );
+		yAxis.set( te[4], te[5], te[6] );
+		zAxis.set( te[8], te[9], te[10] );
+ 
+ 		return this;
+ 		
+ 	},
+ 
+	makeBasis: function ( xAxis, yAxis, zAxis ) {
+
+		this.identity();
+
+		var te = this.elements;
+	    te.elements[0] = xAxis.x; te.elements[1] = xAxis.y; te.elements[2] = xAxis.z;
+	    te.elements[4] = yAxis.x; te.elements[5] = yAxis.y; te.elements[6] = yAxis.z;
+	    te.elements[8] = zAxis.x; te.elements[9] = zAxis.y; te.elements[10] = zAxis.z;
+
+	    return this;
+
+	},
+
 	extractRotation: function () {
 
 		var v1 = new THREE.Vector3();

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -157,6 +157,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 	_projScreenMatrixPS = new THREE.Matrix4(),
 
 	_vector3 = new THREE.Vector3(),
+	_width = new THREE.Vector3(),	// for area light
+	_height = new THREE.Vector3(),	// for area light
 
 	// light arrays cache
 
@@ -5442,8 +5444,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 				areaLength += 1;
 
 			}
-
-		}
 
 		}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -173,7 +173,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		point: { length: 0, colors: [], positions: [], distances: [] },
 		spot: { length: 0, colors: [], positions: [], distances: [], directions: [], anglesCos: [], exponents: [] },
 		hemi: { length: 0, skyColors: [], groundColors: [], positions: [] },
-		area: { length: 0, colors: new Array(), positions: new Array(), distances: new Array(), decayExponents: new Array(), widths: new Array(), heights: new Array() }
+		area: { length: 0, colors: [], positions: [], distances: [], decayExponents: [], widths: [], heights: [] }
 
 	};
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_pars_vertex.glsl
@@ -38,6 +38,17 @@ uniform vec3 ambientLightColor;
 
 #endif
 
+#if MAX_AREA_LIGHTS > 0
+
+	uniform vec3 areaLightColor[ MAX_AREA_LIGHTS ];
+	uniform vec3 areaLightPosition[ MAX_AREA_LIGHTS ];
+	uniform vec3 areaLightWidth[ MAX_AREA_LIGHTS ];
+	uniform vec3 areaLightHeight[ MAX_AREA_LIGHTS ];
+	uniform float areaLightDistance[ MAX_AREA_LIGHTS ];
+	uniform float areaLightDecayExponent[ MAX_AREA_LIGHTS ];
+
+#endif
+
 #ifdef WRAP_AROUND
 
 	uniform vec3 wrapRGB;

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -262,7 +262,11 @@ vec3 viewPosition = normalize( vViewPosition );
 		vec3 nearestPointInside = lPosition + ( right *nearest2D.x + up * nearest2D.y );
 
 		vec3 lVector = ( nearestPointInside + vViewPosition.xyz );
-		float distanceAttenuation = calcLightAttenuation( length( lVector ), areaLightDistance[ i ], areaLightDecayExponent[i] );
+
+		float distanceAttenuation = 1.0;
+		if ( areaLightDistance[ i ] > 0.0 )
+			distanceAttenuation = saturate( 1.0 - ( length( lVector ) / areaLightDistance[ i ] ) );
+		//float distanceAttenuation = calcLightAttenuation( length( lVector ), areaLightDistance[ i ], areaLightDecayExponent[i] );
 		lVector = normalize( lVector );
 			
 		float nDotLDiffuse = saturate( dot( normal, lVector ) );

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl
@@ -36,6 +36,17 @@ uniform vec3 ambientLightColor;
 
 #endif
 
+#if MAX_AREA_LIGHTS > 0
+
+	uniform vec3 areaLightColor[ MAX_AREA_LIGHTS ];
+	uniform vec3 areaLightPosition[ MAX_AREA_LIGHTS ];
+	uniform vec3 areaLightWidth[ MAX_AREA_LIGHTS ];
+	uniform vec3 areaLightHeight[ MAX_AREA_LIGHTS ];
+	uniform float areaLightDistance[ MAX_AREA_LIGHTS ];
+	uniform float areaLightDecayExponent[ MAX_AREA_LIGHTS ];
+
+#endif
+
 #if MAX_SPOT_LIGHTS > 0 || defined( USE_BUMPMAP ) || defined( USE_ENVMAP )
 
 	varying vec3 vWorldPosition;

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -69,6 +69,12 @@ THREE.UniformsLib = {
 		"spotLightAngleCos" : { type: "fv1", value: [] },
 		"spotLightExponent" : { type: "fv1", value: [] }
 
+		"areaLightColor" : { type: "fv", value: [] },
+		"areaLightPosition" : { type: "fv", value: [] },
+		"areaLightDistance" : { type: "fv1", value: [] },
+		"areaLightDecayExponent" : { type: "fv1", value: [] },
+		"areaLightWidth" : { type: "fv", value: [] },
+		"areaLightHeight" : { type: "fv", value: [] }
 	},
 
 	particle: {

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -67,7 +67,7 @@ THREE.UniformsLib = {
 		"spotLightDirection" : { type: "fv", value: [] },
 		"spotLightDistance" : { type: "fv1", value: [] },
 		"spotLightAngleCos" : { type: "fv1", value: [] },
-		"spotLightExponent" : { type: "fv1", value: [] }
+		"spotLightExponent" : { type: "fv1", value: [] },
 
 		"areaLightColor" : { type: "fv", value: [] },
 		"areaLightPosition" : { type: "fv", value: [] },

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -170,6 +170,7 @@ THREE.WebGLProgram = ( function () {
 				"#define MAX_POINT_LIGHTS " + parameters.maxPointLights,
 				"#define MAX_SPOT_LIGHTS " + parameters.maxSpotLights,
 				"#define MAX_HEMI_LIGHTS " + parameters.maxHemiLights,
+				"#define MAX_AREA_LIGHTS " + parameters.maxAreaLights,
 
 				"#define MAX_SHADOWS " + parameters.maxShadows,
 
@@ -272,6 +273,7 @@ THREE.WebGLProgram = ( function () {
 				"#define MAX_POINT_LIGHTS " + parameters.maxPointLights,
 				"#define MAX_SPOT_LIGHTS " + parameters.maxSpotLights,
 				"#define MAX_HEMI_LIGHTS " + parameters.maxHemiLights,
+				"#define MAX_AREA_LIGHTS " + parameters.maxAreaLights,
 
 				"#define MAX_SHADOWS " + parameters.maxShadows,
 


### PR DESCRIPTION
There was always an AreaLight class but it was only used in the deferred renderer examples.  This is an implementation that works with MeshPhongMaterial and WebGLRenderer.

It isn't perfect and it is based on http://stackoverflow.com/questions/17021264/improved-area-lighting-in-webgl-threejs

AreaLight should be properly added to the Three.JS Editor, although I do not know how to do that.

Includes my merge parts of these two other PRs: https://github.com/mrdoob/three.js/pull/5785 https://github.com/mrdoob/three.js/pull/5788
