### PR TITLE
Fix x4121 warnings

### DIFF
--- a/examples/webgl_gpgpu_birds.html
+++ b/examples/webgl_gpgpu_birds.html
@@ -207,54 +207,53 @@
 				vec3 central = vec3( 0., 0., 0. );
 				dir = selfPosition - central;
 				dist = length( dir );
+
 				dir.y *= 2.5;
 				velocity -= normalize( dir ) * delta * 5.;
 
 				for (float y=0.0;y<height;y++) {
 					for (float x=0.0;x<width;x++) {
 
-						if (
-							x == gl_FragCoord.x && y == gl_FragCoord.y) continue;
-
 						birdPosition = texture2D( texturePosition,
 							vec2( x / resolution.x,  y / resolution.y ) ).xyz;
 
 						dir = birdPosition - selfPosition;
 						dist = length(dir);
+
+						if (dist < 0.0001) continue;
+
 						distSquared = dist * dist;
 
-						if ( dist > 0.0 && distSquared < zoneRadiusSquared ) {
+						if (distSquared > zoneRadiusSquared ) continue;
 
-							percent = distSquared / zoneRadiusSquared;
+						percent = distSquared / zoneRadiusSquared;
 
-							if ( percent < separationThresh ) { // low
+						if ( percent < separationThresh ) { // low
 
-								// Separation - Move apart for comfort
-								f = (separationThresh / percent - 1.0) * delta;
-								velocity -= normalize(dir) * f;
+							// Separation - Move apart for comfort
+							f = (separationThresh / percent - 1.0) * delta;
+							velocity -= normalize(dir) * f;
 
-							} else if ( percent < alignmentThresh ) { // high
+						} else if ( percent < alignmentThresh ) { // high
 
-								// Alignment - fly the same direction
-								float threshDelta = alignmentThresh - separationThresh;
-								float adjustedPercent = ( percent - separationThresh ) / threshDelta;
+							// Alignment - fly the same direction
+							float threshDelta = alignmentThresh - separationThresh;
+							float adjustedPercent = ( percent - separationThresh ) / threshDelta;
 
-								birdVelocity = texture2D( textureVelocity, vec2(x/resolution.x, y/resolution.y) ).xyz;
+							birdVelocity = texture2D( textureVelocity, vec2(x/resolution.x, y/resolution.y) ).xyz;
 
-								f = ( 0.5 - cos( adjustedPercent * PI_2 ) * 0.5 + 0.5 ) * delta;
-								velocity += normalize(birdVelocity) * f;
+							f = ( 0.5 - cos( adjustedPercent * PI_2 ) * 0.5 + 0.5 ) * delta;
+							velocity += normalize(birdVelocity) * f;
 
-							} else {
+						} else {
 
-								// Attraction / Cohesion - move closer
-								float threshDelta = 1.0 - alignmentThresh;
-								float adjustedPercent = ( percent - alignmentThresh ) / threshDelta;
+							// Attraction / Cohesion - move closer
+							float threshDelta = 1.0 - alignmentThresh;
+							float adjustedPercent = ( percent - alignmentThresh ) / threshDelta;
 
-								 f = ( 0.5 - ( cos( adjustedPercent * PI_2 ) * -0.5 + 0.5 ) ) * delta;
+							f = ( 0.5 - ( cos( adjustedPercent * PI_2 ) * -0.5 + 0.5 ) ) * delta;
 
-								 velocity += normalize(dir) * f;
-
-							}
+							velocity += normalize(dir) * f;
 
 						}
 

--- a/examples/webgl_gpgpu_birds.html
+++ b/examples/webgl_gpgpu_birds.html
@@ -214,8 +214,8 @@
 				for (float y=0.0;y<height;y++) {
 					for (float x=0.0;x<width;x++) {
 
-						birdPosition = texture2D( texturePosition,
-							vec2( x / resolution.x,  y / resolution.y ) ).xyz;
+						vec2 ref = vec2( x + 0.5, y + 0.5 ) / resolution.xy;
+						birdPosition = texture2D( texturePosition, ref ).xyz;
 
 						dir = birdPosition - selfPosition;
 						dist = length(dir);
@@ -240,7 +240,7 @@
 							float threshDelta = alignmentThresh - separationThresh;
 							float adjustedPercent = ( percent - separationThresh ) / threshDelta;
 
-							birdVelocity = texture2D( textureVelocity, vec2(x/resolution.x, y/resolution.y) ).xyz;
+							birdVelocity = texture2D( textureVelocity, ref ).xyz;
 
 							f = ( 0.5 - cos( adjustedPercent * PI_2 ) * 0.5 + 0.5 ) * delta;
 							velocity += normalize(birdVelocity) * f;


### PR DESCRIPTION
Fix warning `X4121: gradient-based operations must be moved out of flow
  control to prevent divergence. Performance may improve by using a non-gradient operation`
- This fix also give small amount of fps boost for Windows Chrome (about 2-5 fps faster with three.js/examples/webgl_gpgpu_birds.html#128)
