### PR TITLE
Remove material.ambient, no need for a secondary surface color just for ambient light

### DIFF
--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -408,12 +408,6 @@ Sidebar.Material = function ( editor ) {
 
 			}
 
-			if ( material.ambient !== undefined ) {
-
-				material.ambient.setHex( materialAmbient.getHexValue() );
-
-			}
-
 			if ( material.emissive !== undefined ) {
 
 				material.emissive.setHex( materialEmissive.getHexValue() );
@@ -639,7 +633,6 @@ Sidebar.Material = function ( editor ) {
 		var properties = {
 			'name': materialNameRow,
 			'color': materialColorRow,
-			'ambient': materialAmbientRow,
 			'emissive': materialEmissiveRow,
 			'specular': materialSpecularRow,
 			'shininess': materialShininessRow,
@@ -700,12 +693,6 @@ Sidebar.Material = function ( editor ) {
 			if ( material.color !== undefined ) {
 
 				materialColor.setHexValue( material.color.getHexString() );
-
-			}
-
-			if ( material.ambient !== undefined ) {
-
-				materialAmbient.setHexValue( material.ambient.getHexString() );
 
 			}
 

--- a/examples/js/ShaderSkin.js
+++ b/examples/js/ShaderSkin.js
@@ -38,7 +38,6 @@ THREE.ShaderSkin = {
 
 			"diffuse":  { type: "c", value: new THREE.Color( 0xeeeeee ) },
 			"specular": { type: "c", value: new THREE.Color( 0x111111 ) },
-			"ambient":  { type: "c", value: new THREE.Color( 0x050505 ) },
 			"opacity": 	  { type: "f", value: 1 },
 
 			"uRoughness": 	  		{ type: "f", value: 0.15 },
@@ -65,7 +64,6 @@ THREE.ShaderSkin = {
 			"uniform bool enableBump;",
 			"uniform bool enableSpecular;",
 
-			"uniform vec3 ambient;",
 			"uniform vec3 diffuse;",
 			"uniform vec3 specular;",
 			"uniform float opacity;",
@@ -295,7 +293,7 @@ THREE.ShaderSkin = {
 					"totalLight += hemiTotal;",
 				"#endif",
 
-				"gl_FragColor.xyz = gl_FragColor.xyz * ( totalLight + ambientLightColor * ambient ) + specularTotal;",
+				"gl_FragColor.xyz = gl_FragColor.xyz * ( totalLight + ambientLightColor ) + specularTotal;",
 
 				THREE.ShaderChunk[ "shadowmap_fragment" ],
 				THREE.ShaderChunk[ "linear_to_gamma_fragment" ],
@@ -377,7 +375,6 @@ THREE.ShaderSkin = {
 
 			"diffuse":  { type: "c", value: new THREE.Color( 0xeeeeee ) },
 			"specular": { type: "c", value: new THREE.Color( 0x111111 ) },
-			"ambient":  { type: "c", value: new THREE.Color( 0x050505 ) },
 			"opacity": 	  { type: "f", value: 1 },
 
 			"uRoughness": 	  		{ type: "f", value: 0.15 },
@@ -389,7 +386,6 @@ THREE.ShaderSkin = {
 
 		fragmentShader: [
 
-			"uniform vec3 ambient;",
 			"uniform vec3 diffuse;",
 			"uniform vec3 specular;",
 			"uniform float opacity;",
@@ -595,7 +591,7 @@ THREE.ShaderSkin = {
 
 					"gl_FragColor.xyz *= pow( colDiffuse.xyz, vec3( 0.5 ) );",
 
-					"gl_FragColor.xyz += ambientLightColor * ambient * colDiffuse.xyz + specularTotal;",
+					"gl_FragColor.xyz += ambientLightColor * colDiffuse.xyz + specularTotal;",
 
 					"#ifndef VERSION1",
 

--- a/examples/js/ShaderSkin.js
+++ b/examples/js/ShaderSkin.js
@@ -293,7 +293,7 @@ THREE.ShaderSkin = {
 					"totalLight += hemiTotal;",
 				"#endif",
 
-				"gl_FragColor.xyz = gl_FragColor.xyz * ( totalLight + ambientLightColor ) + specularTotal;",
+				"gl_FragColor.xyz = gl_FragColor.xyz * ( totalLight + ambientLightColor * diffuse ) + specularTotal;",
 
 				THREE.ShaderChunk[ "shadowmap_fragment" ],
 				THREE.ShaderChunk[ "linear_to_gamma_fragment" ],
@@ -591,7 +591,7 @@ THREE.ShaderSkin = {
 
 					"gl_FragColor.xyz *= pow( colDiffuse.xyz, vec3( 0.5 ) );",
 
-					"gl_FragColor.xyz += ambientLightColor * colDiffuse.xyz + specularTotal;",
+					"gl_FragColor.xyz += ambientLightColor * diffuse * colDiffuse.xyz + specularTotal;",
 
 					"#ifndef VERSION1",
 

--- a/examples/js/ShaderTerrain.js
+++ b/examples/js/ShaderTerrain.js
@@ -42,7 +42,6 @@ THREE.ShaderTerrain = {
 
 			"diffuse": { type: "c", value: new THREE.Color( 0xeeeeee ) },
 			"specular": { type: "c", value: new THREE.Color( 0x111111 ) },
-			"ambient": { type: "c", value: new THREE.Color( 0x050505 ) },
 			"shininess": { type: "f", value: 30 },
 			"opacity": { type: "f", value: 1 },
 
@@ -57,7 +56,6 @@ THREE.ShaderTerrain = {
 
 		fragmentShader: [
 
-			"uniform vec3 ambient;",
 			"uniform vec3 diffuse;",
 			"uniform vec3 specular;",
 			"uniform float shininess;",
@@ -288,8 +286,8 @@ THREE.ShaderTerrain = {
 
 				"#endif",
 
-				//"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * ambient) + totalSpecular;",
-				"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * ambient + totalSpecular );",
+				//"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor) + totalSpecular;",
+				"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor + totalSpecular );",
 
 				THREE.ShaderChunk[ "shadowmap_fragment" ],
 				THREE.ShaderChunk[ "linear_to_gamma_fragment" ],

--- a/examples/js/ShaderTerrain.js
+++ b/examples/js/ShaderTerrain.js
@@ -286,8 +286,8 @@ THREE.ShaderTerrain = {
 
 				"#endif",
 
-				//"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor) + totalSpecular;",
-				"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor + totalSpecular );",
+				//"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * diffuse ) + totalSpecular;",
+				"gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * diffuse + totalSpecular );",
 
 				THREE.ShaderChunk[ "shadowmap_fragment" ],
 				THREE.ShaderChunk[ "linear_to_gamma_fragment" ],

--- a/examples/js/exporters/SceneExporter.js
+++ b/examples/js/exporters/SceneExporter.js
@@ -472,7 +472,6 @@ THREE.SceneExporter.prototype = {
 				'	"type"    : "MeshLambertMaterial",',
 				'	"parameters"  : {',
 				'		"color"  : ' 	+ m.color.getHex() + ',',
-				'		"ambient"  : ' 	+ m.ambient.getHex() + ',',
 				'		"emissive"  : ' + m.emissive.getHex() + ',',
 
 				m.map ? 		'		"map" : ' + LabelString( getTextureName( m.map ) ) + ',' : '',
@@ -498,7 +497,6 @@ THREE.SceneExporter.prototype = {
 				'	"type"    : "MeshPhongMaterial",',
 				'	"parameters"  : {',
 				'		"color"  : ' 	+ m.color.getHex() + ',',
-				'		"ambient"  : ' 	+ m.ambient.getHex() + ',',
 				'		"emissive"  : ' + m.emissive.getHex() + ',',
 				'		"specular"  : ' + m.specular.getHex() + ',',
 				'		"shininess" : ' + m.shininess + ',',

--- a/examples/js/loaders/AssimpJSONLoader.js
+++ b/examples/js/loaders/AssimpJSONLoader.js
@@ -264,9 +264,6 @@ THREE.AssimpJSONLoader.prototype = {
 			else if(prop.key === '$clr.specular') {
 				init_props.specular = toColor(prop.value);
 			}
-			else if(prop.key === '$clr.ambient') {
-				init_props.ambient = toColor(prop.value);
-			}
 			else if(prop.key === '$clr.emissive') {
 				init_props.emissive = toColor(prop.value);
 			}
@@ -279,10 +276,6 @@ THREE.AssimpJSONLoader.prototype = {
 			else if (prop.key === '$mat.shininess') {
 				init_props.shininess = prop.value;
 			}
-		}
-
-		if(!init_props.ambient) {
-			init_props.ambient = init_props.color;
 		}
 
 		// note: three.js does not like it when a texture is added after the geometry

--- a/examples/js/loaders/BabylonLoader.js
+++ b/examples/js/loaders/BabylonLoader.js
@@ -51,7 +51,6 @@ THREE.BabylonLoader.prototype = {
 
 			var material = new THREE.MeshPhongMaterial();
 			material.name = data.name;
-			material.ambient.fromArray( data.ambient );
 			material.color.fromArray( data.diffuse );
 			material.emissive.fromArray( data.emissive );
 			material.specular.fromArray( data.specular );

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3576,7 +3576,6 @@ THREE.ColladaLoader = function () {
 
 			switch ( child.nodeName ) {
 
-				case 'ambient':
 				case 'emission':
 				case 'diffuse':
 				case 'specular':

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -296,8 +296,6 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					// Ambient color (color under shadow) using RGB values
 
-					params[ 'ambient' ] = new THREE.Color().fromArray( value );
-
 					break;
 
 				case 'ks':
@@ -350,7 +348,6 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 		if ( params[ 'diffuse' ] ) {
 
-			if ( !params[ 'ambient' ]) params[ 'ambient' ] = params[ 'diffuse' ];
 			params[ 'color' ] = params[ 'diffuse' ];
 
 		}

--- a/examples/js/loaders/gltf/glTFLoader.js
+++ b/examples/js/loaders/gltf/glTFLoader.js
@@ -785,11 +785,6 @@ THREE.glTFLoader.prototype.load = function( url, callback ) {
                 	params.shininess = shininess;
                 }
                 
-                if (!(values.ambient === undefined) && !(typeof(values.ambient) == 'string'))
-                {
-                	params.ambient = RgbArraytoHex(values.ambient);
-                }
-
                 if (!(values.emission === undefined))
                 {
                 	params.emissive = RgbArraytoHex(values.emission);

--- a/examples/js/renderers/SoftwareRenderer.js
+++ b/examples/js/renderers/SoftwareRenderer.js
@@ -298,9 +298,9 @@ THREE.SoftwareRenderer = function ( parameters ) {
 	}
 
 	function getPalette( material, bSimulateSpecular ) {
-		var diffuseR = material.ambient.r + material.color.r * 255;
-		var diffuseG = material.ambient.g + material.color.g * 255;
-		var diffuseB = material.ambient.b + material.color.b * 255;
+		var diffuseR = material.color.r * 255;
+		var diffuseG = material.color.g * 255;
+		var diffuseB = material.color.b * 255;
 		var palette = new Uint8Array(256*3);
 
 		if ( bSimulateSpecular ) {

--- a/examples/js/shaders/NormalDisplacementShader.js
+++ b/examples/js/shaders/NormalDisplacementShader.js
@@ -428,11 +428,11 @@ THREE.NormalDisplacementShader = {
 
 		"	#ifdef METAL",
 
-		"		gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor + totalSpecular );",
+		"		gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * diffuse + totalSpecular );",
 
 		"	#else",
 
-		"		gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor ) + totalSpecular;",
+		"		gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * diffuse ) + totalSpecular;",
 
 		"	#endif",
 

--- a/examples/js/shaders/NormalDisplacementShader.js
+++ b/examples/js/shaders/NormalDisplacementShader.js
@@ -54,7 +54,6 @@ THREE.NormalDisplacementShader = {
 
 	fragmentShader: [
 
-		"uniform vec3 ambient;",
 		"uniform vec3 diffuse;",
 		"uniform vec3 specular;",
 		"uniform float shininess;",

--- a/examples/js/shaders/NormalDisplacementShader.js
+++ b/examples/js/shaders/NormalDisplacementShader.js
@@ -37,7 +37,6 @@ THREE.NormalDisplacementShader = {
 
 		"diffuse": { type: "c", value: new THREE.Color( 0xffffff ) },
 		"specular": { type: "c", value: new THREE.Color( 0x111111 ) },
-		"ambient": { type: "c", value: new THREE.Color( 0xffffff ) },
 		"shininess": { type: "f", value: 30 },
 		"opacity": { type: "f", value: 1 },
 
@@ -429,11 +428,11 @@ THREE.NormalDisplacementShader = {
 
 		"	#ifdef METAL",
 
-		"		gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * ambient + totalSpecular );",
+		"		gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor + totalSpecular );",
 
 		"	#else",
 
-		"		gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor * ambient ) + totalSpecular;",
+		"		gl_FragColor.xyz = gl_FragColor.xyz * ( totalDiffuse + ambientLightColor ) + totalSpecular;",
 
 		"	#endif",
 

--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -109,7 +109,6 @@
 
 				var materialNormalMap = new THREE.MeshPhongMaterial( {
 				
-					ambient: 0x000000,
 					specular: 0x333333,
 					shininess: 15,
 					map: THREE.ImageUtils.loadTexture( "textures/planets/earth_atmos_2048.jpg" ),

--- a/examples/scenes/test_scene.js
+++ b/examples/scenes/test_scene.js
@@ -562,32 +562,32 @@
 
 		"phong_ben": {
 			"type": "MeshPhongMaterial",
-			"parameters": { "color": 1118481, "ambient": 1118481, "specular": 5601245, "shininess": 12, "bumpMap": "texture_bump_repeat", "bumpScale": 0.125 }
+			"parameters": { "color": 1118481, "specular": 5601245, "shininess": 12, "bumpMap": "texture_bump_repeat", "bumpScale": 0.125 }
 		},
 
 		"phong_man": {
 			"type": "MeshPhongMaterial",
-			"parameters": { "color": 16737894, "ambient": 16737894, "specular": 2236962, "shininess": 40, "wrapAround": true, "wrapRGB": [ 0.15, 0.02, 0.01 ] }
+			"parameters": { "color": 16737894, "specular": 2236962, "shininess": 40, "wrapAround": true, "wrapRGB": [ 0.15, 0.02, 0.01 ] }
 		},
 
 		"phong_hand": {
 			"type": "MeshPhongMaterial",
-			"parameters": { "color": 14531481, "ambient": 14531481, "specular": 2236962, "shininess": 40, "wrapAround": true, "wrapRGB": [ 0.15, 0.02, 0.01 ] }
+			"parameters": { "color": 14531481, "specular": 2236962, "shininess": 40, "wrapAround": true, "wrapRGB": [ 0.15, 0.02, 0.01 ] }
 		},
 
 		"phong_bunny": {
 			"type": "MeshPhongMaterial",
-			"parameters": { "color": 16777215, "ambient": 16777215, "specular": 1118481, "shininess": 10 }
+			"parameters": { "color": 16777215, "specular": 1118481, "shininess": 10 }
 		},
 
 		"phong_monster": {
 			"type": "MeshPhongMaterial",
-			"parameters": { "color": 16777215, "ambient": 16777215, "specular": 1118481, "shininess": 10 }
+			"parameters": { "color": 16777215, "specular": 1118481, "shininess": 10 }
 		},
 
 		"phong_disk": {
 			"type": "MeshPhongMaterial",
-			"parameters": { "color": 16733491, "ambient": 16733491, "specular": 1118481, "shininess": 30, "wireframe": false }
+			"parameters": { "color": 16733491, "specular": 1118481, "shininess": 30, "wireframe": false }
 		},
 
 		"phong_normal": {
@@ -597,12 +597,12 @@
 
 		"phong_morph": {
 			"type": "MeshPhongMaterial",
-			"parameters": { "color": 0, "ambient": 0, "specular": 16777215, "shininess": 50, "envMap": "cube_reflection", "reflectivity": 0.125, "combine": "MixOperation", "shading": "flat", "side": "double", "morphTargets": true, "morphNormals" : true }
+			"parameters": { "color": 0, "specular": 16777215, "shininess": 50, "envMap": "cube_reflection", "reflectivity": 0.125, "combine": "MixOperation", "shading": "flat", "side": "double", "morphTargets": true, "morphNormals" : true }
 		},
 
 		"phong_skin": {
 			"type": "MeshPhongMaterial",
-			"parameters": { "color": 0, "ambient": 0, "specular": 16777215, "shininess": 50, "envMap": "cube_reflection", "reflectivity": 0.5, "combine": "MixOperation", "skinning": true, "morphTargets": true }
+			"parameters": { "color": 0, "specular": 16777215, "shininess": 50, "envMap": "cube_reflection", "reflectivity": 0.5, "combine": "MixOperation", "skinning": true, "morphTargets": true }
 		},
 
 		"phong_compressed_cube": {

--- a/examples/webgl_animation_cloth.html
+++ b/examples/webgl_animation_cloth.html
@@ -187,7 +187,7 @@
 				clothTexture.wrapS = clothTexture.wrapT = THREE.RepeatWrapping;
 				clothTexture.anisotropy = 16;
 
-				var clothMaterial = new THREE.MeshPhongMaterial( { alphaTest: 0.5, ambient: 0xffffff, color: 0xffffff, specular: 0x030303, emissive: 0x111111, shiness: 10, map: clothTexture, side: THREE.DoubleSide } );
+				var clothMaterial = new THREE.MeshPhongMaterial( { alphaTest: 0.5, color: 0xffffff, specular: 0x030303, emissive: 0x111111, shiness: 10, map: clothTexture, side: THREE.DoubleSide } );
 
 				// cloth geometry
 				clothGeometry = new THREE.ParametricGeometry( clothFunction, cloth.w, cloth.h );

--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -233,7 +233,6 @@
 					m.specular.setHSL( 0, 0, 0.1 );
 
 					m.color.setHSL( 0.6, 0, 0.6 );
-					m.ambient.copy( m.color );
 
 					//m.map = map;
 					//m.envMap = envMap;

--- a/examples/webgl_buffergeometry.html
+++ b/examples/webgl_buffergeometry.html
@@ -217,7 +217,7 @@
 				geometry.computeBoundingSphere();
 
 				var material = new THREE.MeshPhongMaterial( {
-					color: 0xaaaaaa, ambient: 0xaaaaaa, specular: 0xffffff, shininess: 250,
+					color: 0xaaaaaa, specular: 0xffffff, shininess: 250,
 					side: THREE.DoubleSide, vertexColors: THREE.VertexColors
 				} );
 

--- a/examples/webgl_buffergeometry_uint.html
+++ b/examples/webgl_buffergeometry_uint.html
@@ -198,7 +198,7 @@
 				geometry.computeBoundingSphere();
 
 				var material = new THREE.MeshPhongMaterial( {
-					color: 0xaaaaaa, ambient: 0xaaaaaa, specular: 0xffffff, shininess: 250,
+					color: 0xaaaaaa, specular: 0xffffff, shininess: 250,
 					side: THREE.DoubleSide, vertexColors: THREE.VertexColors
 				} );
 

--- a/examples/webgl_effects_oculusrift.html
+++ b/examples/webgl_effects_oculusrift.html
@@ -183,7 +183,7 @@
 				texture.magFilter = THREE.NearestFilter;
 				texture.minFilter = THREE.LinearMipMapLinearFilter;
 
-				var mesh = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { map: texture, ambient: 0xbbbbbb } ) );
+				var mesh = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { map: texture } ) );
 				scene.add( mesh );
 
 				var ambientLight = new THREE.AmbientLight( 0xcccccc );

--- a/examples/webgl_geometries.html
+++ b/examples/webgl_geometries.html
@@ -53,7 +53,7 @@
 				map.wrapS = map.wrapT = THREE.RepeatWrapping;
 				map.anisotropy = 16;
 
-				var material = new THREE.MeshLambertMaterial( { ambient: 0xbbbbbb, map: map, side: THREE.DoubleSide } );
+				var material = new THREE.MeshLambertMaterial( { map: map, side: THREE.DoubleSide } );
 
 				//
 

--- a/examples/webgl_geometries2.html
+++ b/examples/webgl_geometries2.html
@@ -59,7 +59,7 @@
 				map.anisotropy = 16;
 
 				materials = [
-					new THREE.MeshLambertMaterial( { ambient: 0xbbbbbb, map: map, side: THREE.DoubleSide } ),
+					new THREE.MeshLambertMaterial( { map: map, side: THREE.DoubleSide } ),
 					new THREE.MeshBasicMaterial( { color: 0xffffff, wireframe: true, transparent: true, opacity: 0.1, side: THREE.DoubleSide } )
 				];
 

--- a/examples/webgl_geometry_colors_lookuptable.html
+++ b/examples/webgl_geometry_colors_lookuptable.html
@@ -172,7 +172,6 @@
 						side: THREE.DoubleSide,
 						specular: 0xF5F5F5,
 						color: 0xF5F5F5,
-						ambient : 0xFFFFFF,
 						shininess: 5,
 						vertexColors: THREE.VertexColors
 

--- a/examples/webgl_geometry_convex.html
+++ b/examples/webgl_geometry_convex.html
@@ -54,7 +54,7 @@
 				map.anisotropy = 16;
 
 				materials = [
-					new THREE.MeshLambertMaterial( { ambient: 0xbbbbbb, map: map } ),
+					new THREE.MeshLambertMaterial( { map: map } ),
 					new THREE.MeshBasicMaterial( { color: 0xffffff, wireframe: true, transparent: true, opacity: 0.1 } )
 				];
 

--- a/examples/webgl_geometry_extrude_shapes2.html
+++ b/examples/webgl_geometry_extrude_shapes2.html
@@ -292,7 +292,6 @@ var addGeoObject = function( group, svgObject ) {
 		color = new THREE.Color( theColors[i] ); 
 		material = new THREE.MeshLambertMaterial({
 			color: color,
-			ambient: color,
 			emissive: color,
 		});
 		amount = theAmounts[i];

--- a/examples/webgl_geometry_large_mesh.html
+++ b/examples/webgl_geometry_large_mesh.html
@@ -169,10 +169,10 @@
 
 				loader.load( 'obj/lucy/Lucy100k_bin.js', function ( geometry, materials ) {
 
-					addMesh( geometry, 0.75, 900, 0, 0,  0,0,0, new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0x030303, specular: 0x990000, shininess: 30 } ) );
+					addMesh( geometry, 0.75, 900, 0, 0,  0,0,0, new THREE.MeshPhongMaterial( { color: 0x030303, specular: 0x990000, shininess: 30 } ) );
 					addMesh( geometry, 0.75, 300, 0, 0,  0,0,0, new THREE.MeshFaceMaterial( materials ) );
-					addMesh( geometry, 0.75, -300, 0, 0, 0,0,0, new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0x111111, specular: 0xffaa00, shininess: 10 } ) );
-					addMesh( geometry, 0.75, -900, 0, 0, 0,0,0, new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0x555555, specular: 0x666666, shininess: 10 } ) );
+					addMesh( geometry, 0.75, -300, 0, 0, 0,0,0, new THREE.MeshPhongMaterial( { color: 0x111111, specular: 0xffaa00, shininess: 10 } ) );
+					addMesh( geometry, 0.75, -900, 0, 0, 0,0,0, new THREE.MeshPhongMaterial( { color: 0x555555, specular: 0x666666, shininess: 10 } ) );
 
 					loader.statusDomElement.style.display = "none";
 

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -182,7 +182,7 @@
 				texture.magFilter = THREE.NearestFilter;
 				texture.minFilter = THREE.LinearMipMapLinearFilter;
 
-				var mesh = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { map: texture, ambient: 0xbbbbbb } ) );
+				var mesh = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { map: texture } ) );
 				scene.add( mesh );
 
 				var ambientLight = new THREE.AmbientLight( 0xcccccc );

--- a/examples/webgl_geometry_minecraft_ao.html
+++ b/examples/webgl_geometry_minecraft_ao.html
@@ -278,7 +278,7 @@
 				texture.magFilter = THREE.NearestFilter;
 				texture.minFilter = THREE.LinearMipMapLinearFilter;
 
-				var mesh = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { map: texture, ambient: 0xbbbbbb, vertexColors: THREE.VertexColors } ) );
+				var mesh = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { map: texture, vertexColors: THREE.VertexColors } ) );
 				scene.add( mesh );
 
 				var ambientLight = new THREE.AmbientLight( 0xcccccc );

--- a/examples/webgl_geometry_shapes.html
+++ b/examples/webgl_geometry_shapes.html
@@ -73,7 +73,7 @@
 
 					var geometry = new THREE.ShapeGeometry( shape );
 
-					var mesh = new THREE.Mesh( geometry, new THREE.MeshPhongMaterial( { color: color, ambient: color, side: THREE.DoubleSide } ) );
+					var mesh = new THREE.Mesh( geometry, new THREE.MeshPhongMaterial( { color: color, side: THREE.DoubleSide } ) );
 					mesh.position.set( x, y, z - 125 );
 					mesh.rotation.set( rx, ry, rz );
 					mesh.scale.set( s, s, s );
@@ -83,7 +83,7 @@
 
 					var geometry = new THREE.ExtrudeGeometry( shape, extrudeSettings );
 
-					var mesh = new THREE.Mesh( geometry, new THREE.MeshPhongMaterial( { color: color, ambient: color } ) );
+					var mesh = new THREE.Mesh( geometry, new THREE.MeshPhongMaterial( { color: color } ) );
 					mesh.position.set( x, y, z - 75 );
 					mesh.rotation.set( rx, ry, rz );
 					mesh.scale.set( s, s, s );

--- a/examples/webgl_interactive_buffergeometry.html
+++ b/examples/webgl_interactive_buffergeometry.html
@@ -189,7 +189,7 @@
 				geometry.computeBoundingSphere();
 
 				var material = new THREE.MeshPhongMaterial( {
-						color: 0xaaaaaa, ambient: 0xaaaaaa, specular: 0xffffff, shininess: 250,
+						color: 0xaaaaaa, specular: 0xffffff, shininess: 250,
 						side: THREE.DoubleSide, vertexColors: THREE.VertexColors
 				} );
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -78,8 +78,6 @@
 
 					var object = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { color: Math.random() * 0xffffff } ) );
 
-					object.material.ambient = object.material.color;
-
 					object.position.x = Math.random() * 1000 - 500;
 					object.position.y = Math.random() * 600 - 300;
 					object.position.z = Math.random() * 800 - 400;

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -67,8 +67,7 @@
 				// cubes
 
 				cubeGeo = new THREE.BoxGeometry( 50, 50, 50 );
-				cubeMaterial = new THREE.MeshLambertMaterial( { color: 0xfeb74c, ambient: 0x00ff80, shading: THREE.FlatShading, map: THREE.ImageUtils.loadTexture( "textures/square-outline-textured.png" ) } );
-				cubeMaterial.ambient = cubeMaterial.color;
+				cubeMaterial = new THREE.MeshLambertMaterial( { color: 0xfeb74c, shading: THREE.FlatShading, map: THREE.ImageUtils.loadTexture( "textures/square-outline-textured.png" ) } );
 
 				// grid
 

--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -93,7 +93,7 @@
 				var s = 250;
 
 				var cube = new THREE.BoxGeometry( s, s, s );
-				var material = new THREE.MeshPhongMaterial( { ambient: 0x333333, color: 0xffffff, specular: 0xffffff, shininess: 50 } );
+				var material = new THREE.MeshPhongMaterial( { color: 0xffffff, specular: 0xffffff, shininess: 50 } );
 
 
 				for ( var i = 0; i < 3000; i ++ ) {

--- a/examples/webgl_lights_hemisphere.html
+++ b/examples/webgl_lights_hemisphere.html
@@ -165,7 +165,7 @@
 				// GROUND
 
 				var groundGeo = new THREE.PlaneBufferGeometry( 10000, 10000 );
-				var groundMat = new THREE.MeshPhongMaterial( { ambient: 0xffffff, color: 0xffffff, specular: 0x050505 } );
+				var groundMat = new THREE.MeshPhongMaterial( { color: 0xffffff, specular: 0x050505 } );
 				groundMat.color.setHSL( 0.095, 1, 0.75 );
 
 				var ground = new THREE.Mesh( groundGeo, groundMat );

--- a/examples/webgl_lights_pointlights.html
+++ b/examples/webgl_lights_pointlights.html
@@ -73,7 +73,7 @@
 
 				var callback = function( geometry ) {
 
-					object = new THREE.Mesh( geometry, new THREE.MeshPhongMaterial( { ambient: 0x555555, color: 0x555555, specular: 0xffffff, shininess: 50, shading: THREE.SmoothShading }  )  );
+					object = new THREE.Mesh( geometry, new THREE.MeshPhongMaterial( { color: 0x555555, specular: 0xffffff, shininess: 50, shading: THREE.SmoothShading }  )  );
 					object.scale.x = object.scale.y = object.scale.z = 0.80;
 					scene.add( object );
 

--- a/examples/webgl_lights_pointlights2.html
+++ b/examples/webgl_lights_pointlights2.html
@@ -128,8 +128,8 @@
 
 				// MATERIALS
 
-				var groundMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, ambient: 0x444444, map: texture } );
-				var objectMaterial = new THREE.MeshPhongMaterial( { color: 0x000000, ambient: 0x111111, specular: 0xffffff, metal: true, map: texture2 } );
+				var groundMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, map: texture } );
+				var objectMaterial = new THREE.MeshPhongMaterial( { color: 0x000000, specular: 0xffffff, metal: true, map: texture2 } );
 
 				// GROUND
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -199,7 +199,6 @@
 				if (sceneInfo.addGround) {
 	                var groundMaterial = new THREE.MeshPhongMaterial({
 	                        color: 0xFFFFFF,
-	                        ambient: 0x888888,
 	                        shading: THREE.SmoothShading,
 	                    });
 	                ground = new THREE.Mesh( new THREE.PlaneBufferGeometry(1024, 1024), groundMaterial);

--- a/examples/webgl_loader_json_blender.html
+++ b/examples/webgl_loader_json_blender.html
@@ -107,7 +107,6 @@
 					var material = materials[ 0 ];
 					material.morphTargets = true;
 					material.color.setHex( 0xffaaaa );
-					material.ambient.setHex( 0x222222 );
 
 					var faceMaterial = new THREE.MeshFaceMaterial( materials );
 

--- a/examples/webgl_loader_ply.html
+++ b/examples/webgl_loader_ply.html
@@ -78,7 +78,7 @@
 
 				var plane = new THREE.Mesh(
 					new THREE.PlaneBufferGeometry( 40, 40 ),
-					new THREE.MeshPhongMaterial( { ambient: 0x999999, color: 0x999999, specular: 0x101010 } )
+					new THREE.MeshPhongMaterial( { color: 0x999999, specular: 0x101010 } )
 				);
 				plane.rotation.x = -Math.PI/2;
 				plane.position.y = -0.5;
@@ -93,7 +93,7 @@
 				loader.addEventListener( 'load', function ( event ) {
 
 					var geometry = event.content;
-					var material = new THREE.MeshPhongMaterial( { ambient: 0x0055ff, color: 0x0055ff, specular: 0x111111, shininess: 200 } );
+					var material = new THREE.MeshPhongMaterial( { color: 0x0055ff, specular: 0x111111, shininess: 200 } );
 					var mesh = new THREE.Mesh( geometry, material );
 
 					mesh.position.set( 0, - 0.25, 0 );

--- a/examples/webgl_loader_stl.html
+++ b/examples/webgl_loader_stl.html
@@ -78,7 +78,7 @@
 
 				var plane = new THREE.Mesh(
 					new THREE.PlaneBufferGeometry( 40, 40 ),
-					new THREE.MeshPhongMaterial( { ambient: 0x999999, color: 0x999999, specular: 0x101010 } )
+					new THREE.MeshPhongMaterial( { color: 0x999999, specular: 0x101010 } )
 				);
 				plane.rotation.x = -Math.PI/2;
 				plane.position.y = -0.5;
@@ -92,7 +92,7 @@
 				var loader = new THREE.STLLoader();
 				loader.load( './models/stl/ascii/slotted_disk.stl', function ( geometry ) {
 
-					var material = new THREE.MeshPhongMaterial( { ambient: 0xff5533, color: 0xff5533, specular: 0x111111, shininess: 200 } );
+					var material = new THREE.MeshPhongMaterial( { color: 0xff5533, specular: 0x111111, shininess: 200 } );
 					var mesh = new THREE.Mesh( geometry, material );
 
 					mesh.position.set( 0, - 0.25, 0.6 );
@@ -109,7 +109,7 @@
 
 				// Binary files
 
-				var material = new THREE.MeshPhongMaterial( { ambient: 0x555555, color: 0xAAAAAA, specular: 0x111111, shininess: 200 } );
+				var material = new THREE.MeshPhongMaterial( { color: 0xAAAAAA, specular: 0x111111, shininess: 200 } );
 
 				loader.load( './models/stl/binary/pr2_head_pan.stl', function ( geometry ) {
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -334,7 +334,7 @@
 
 			"plastic" :
 			{
-				m: new THREE.MeshPhongMaterial( { color: 0x000000, specular: 0x888888, ambient: 0x000000, shininess: 250 } ),
+				m: new THREE.MeshPhongMaterial( { color: 0x000000, specular: 0x888888, shininess: 250 } ),
 				h: 0.6, s: 0.8, l: 0.1
 			},
 

--- a/examples/webgl_materials.html
+++ b/examples/webgl_materials.html
@@ -70,20 +70,20 @@
 
 				materials.push( new THREE.MeshLambertMaterial( { map: texture, transparent: true } ) );
 				materials.push( new THREE.MeshLambertMaterial( { color: 0xdddddd, shading: THREE.FlatShading } ) );
-				materials.push( new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.FlatShading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.FlatShading } ) );
 				materials.push( new THREE.MeshNormalMaterial( ) );
 				materials.push( new THREE.MeshBasicMaterial( { color: 0xffaa00, transparent: true, blending: THREE.AdditiveBlending } ) );
 				//materials.push( new THREE.MeshBasicMaterial( { color: 0xff0000, blending: THREE.SubtractiveBlending } ) );
 
 				materials.push( new THREE.MeshLambertMaterial( { color: 0xdddddd, shading: THREE.SmoothShading } ) );
-				materials.push( new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.SmoothShading, map: texture, transparent: true } ) );
+				materials.push( new THREE.MeshPhongMaterial( { color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.SmoothShading, map: texture, transparent: true } ) );
 				materials.push( new THREE.MeshNormalMaterial( { shading: THREE.SmoothShading } ) );
 				materials.push( new THREE.MeshBasicMaterial( { color: 0xffaa00, wireframe: true } ) );
 
 				materials.push( new THREE.MeshDepthMaterial() );
 
-				materials.push( new THREE.MeshLambertMaterial( { color: 0x666666, emissive: 0xff0000, ambient: 0x000000, shading: THREE.SmoothShading } ) );
-				materials.push( new THREE.MeshPhongMaterial( { color: 0x000000, specular: 0x666666, emissive: 0xff0000, ambient: 0x000000, shininess: 10, shading: THREE.SmoothShading, opacity: 0.9, transparent: true } ) );
+				materials.push( new THREE.MeshLambertMaterial( { color: 0x666666, emissive: 0xff0000, shading: THREE.SmoothShading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { color: 0x000000, specular: 0x666666, emissive: 0xff0000, shininess: 10, shading: THREE.SmoothShading, opacity: 0.9, transparent: true } ) );
 
 				materials.push( new THREE.MeshBasicMaterial( { map: texture, transparent: true } ) );
 

--- a/examples/webgl_materials2.html
+++ b/examples/webgl_materials2.html
@@ -57,22 +57,22 @@
 
 				var materials = [];
 
-				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture, bumpMap: imgTexture, bumpScale: bumpScale, color: 0xffffff, ambient: 0x777777, specular: specular, shininess: shininess, shading: shading } ) );
-				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture, bumpMap: imgTexture, bumpScale: bumpScale, color: 0x00ff00, ambient: 0x777777, specular: specular, shininess: shininess, shading: shading } ) );
-				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture, bumpMap: imgTexture, bumpScale: bumpScale, color: 0x00ff00, ambient: 0x007700, specular: specular, shininess: shininess, shading: shading } ) );
-				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture, bumpMap: imgTexture, bumpScale: bumpScale, color: 0x000000, ambient: 0x00ff00, specular: specular, shininess: shininess, shading: shading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture, bumpMap: imgTexture, bumpScale: bumpScale, color: 0xffffff, specular: specular, shininess: shininess, shading: shading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture, bumpMap: imgTexture, bumpScale: bumpScale, color: 0x00ff00, specular: specular, shininess: shininess, shading: shading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture, bumpMap: imgTexture, bumpScale: bumpScale, color: 0x00ff00, specular: specular, shininess: shininess, shading: shading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture, bumpMap: imgTexture, bumpScale: bumpScale, color: 0x000000, specular: specular, shininess: shininess, shading: shading } ) );
 
-				materials.push( new THREE.MeshLambertMaterial( { map: imgTexture, color: 0xffffff, ambient: 0x777777, shading: shading } ) );
-				materials.push( new THREE.MeshLambertMaterial( { map: imgTexture, color: 0xff0000, ambient: 0x777777, shading: shading } ) );
-				materials.push( new THREE.MeshLambertMaterial( { map: imgTexture, color: 0xff0000, ambient: 0x770000, shading: shading } ) );
-				materials.push( new THREE.MeshLambertMaterial( { map: imgTexture, color: 0x000000, ambient: 0xff0000, shading: shading } ) );
+				materials.push( new THREE.MeshLambertMaterial( { map: imgTexture, color: 0xffffff, shading: shading } ) );
+				materials.push( new THREE.MeshLambertMaterial( { map: imgTexture, color: 0xff0000, shading: shading } ) );
+				materials.push( new THREE.MeshLambertMaterial( { map: imgTexture, color: 0xff0000, shading: shading } ) );
+				materials.push( new THREE.MeshLambertMaterial( { map: imgTexture, color: 0x000000, shading: shading } ) );
 
 				shininess = 15;
 
-				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture2, bumpMap: imgTexture2, bumpScale: bumpScale, color: 0x000000, ambient: 0x000000, specular: 0xffaa00, shininess: shininess, metal: true, shading: shading } ) );
-				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture2, bumpMap: imgTexture2, bumpScale: bumpScale, color: 0x000000, ambient: 0x000000, specular: 0xaaff00, shininess: shininess, metal: true, shading: shading } ) );
-				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture2, bumpMap: imgTexture2, bumpScale: bumpScale, color: 0x000000, ambient: 0x000000, specular: 0x00ffaa, shininess: shininess, metal: true, shading: shading } ) );
-				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture2, bumpMap: imgTexture2, bumpScale: bumpScale, color: 0x000000, ambient: 0x000000, specular: 0x00aaff, shininess: shininess, metal: true, shading: shading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture2, bumpMap: imgTexture2, bumpScale: bumpScale, color: 0x000000, specular: 0xffaa00, shininess: shininess, metal: true, shading: shading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture2, bumpMap: imgTexture2, bumpScale: bumpScale, color: 0x000000, specular: 0xaaff00, shininess: shininess, metal: true, shading: shading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture2, bumpMap: imgTexture2, bumpScale: bumpScale, color: 0x000000, specular: 0x00ffaa, shininess: shininess, metal: true, shading: shading } ) );
+				materials.push( new THREE.MeshPhongMaterial( { map: imgTexture2, bumpMap: imgTexture2, bumpScale: bumpScale, color: 0x000000, specular: 0x00aaff, shininess: shininess, metal: true, shading: shading } ) );
 
 				// Spheres geometry
 

--- a/examples/webgl_materials_bumpmap.html
+++ b/examples/webgl_materials_bumpmap.html
@@ -169,7 +169,7 @@
 				mapHeight.wrapS = mapHeight.wrapT = THREE.RepeatWrapping;
 				mapHeight.format = THREE.RGBFormat;
 
-				var material = new THREE.MeshPhongMaterial( { ambient: 0x552811, color: 0x552811, specular: 0x333333, shininess: 25, bumpMap: mapHeight, bumpScale: 19, metal: false } );
+				var material = new THREE.MeshPhongMaterial( { color: 0x552811, specular: 0x333333, shininess: 25, bumpMap: mapHeight, bumpScale: 19, metal: false } );
 
 				loader = new THREE.JSONLoader( true );
 				document.body.appendChild( loader.statusDomElement );

--- a/examples/webgl_materials_bumpmap_skin.html
+++ b/examples/webgl_materials_bumpmap_skin.html
@@ -276,7 +276,6 @@
 				uniforms[ "bumpMap" ].value = mapHeight;
 				uniforms[ "specularMap" ].value = mapSpecular;
 
-				uniforms[ "ambient" ].value.setHex( 0xa0a0a0 );
 				uniforms[ "diffuse" ].value.setHex( 0xa0a0a0 );
 				uniforms[ "specular" ].value.setHex( 0xa0a0a0 );
 

--- a/examples/webgl_materials_cars.html
+++ b/examples/webgl_materials_cars.html
@@ -241,19 +241,19 @@
 
 				var mlib = {
 
-				"Orange": 	new THREE.MeshLambertMaterial( { color: 0xff6600, ambient: 0xff2200, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.3 } ),
-				"Blue": 	new THREE.MeshLambertMaterial( { color: 0x001133, ambient: 0x001133, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.3 } ),
-				"Red": 		new THREE.MeshLambertMaterial( { color: 0x660000, ambient: 0x330000, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.25 } ),
-				"Black": 	new THREE.MeshLambertMaterial( { color: 0x000000, ambient: 0x000000, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.15 } ),
-				"White":	new THREE.MeshLambertMaterial( { color: 0xffffff, ambient: 0x666666, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.25 } ),
+				"Orange": 	new THREE.MeshLambertMaterial( { color: 0xff6600, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.3 } ),
+				"Blue": 	new THREE.MeshLambertMaterial( { color: 0x001133, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.3 } ),
+				"Red": 		new THREE.MeshLambertMaterial( { color: 0x660000, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.25 } ),
+				"Black": 	new THREE.MeshLambertMaterial( { color: 0x000000, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.15 } ),
+				"White":	new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.25 } ),
 
 				"Carmine": 	new THREE.MeshPhongMaterial( { color: 0x770000, specular:0xffaaaa, envMap: textureCube, combine: THREE.MultiplyOperation } ),
 				"Gold": 	new THREE.MeshPhongMaterial( { color: 0xaa9944, specular:0xbbaa99, shininess:50, envMap: textureCube, combine: THREE.MultiplyOperation } ),
 				"Bronze":	new THREE.MeshPhongMaterial( { color: 0x150505, specular:0xee6600, shininess:10, envMap: textureCube, combine: THREE.MixOperation, reflectivity: 0.25 } ),
 				"Chrome": 	new THREE.MeshPhongMaterial( { color: 0xffffff, specular:0xffffff, envMap: textureCube, combine: THREE.Multiply } ),
 
-				"Orange metal": new THREE.MeshLambertMaterial( { color: 0xff6600, ambient: 0xff2200, envMap: textureCube, combine: THREE.MultiplyOperation } ),
-				"Blue metal": 	new THREE.MeshLambertMaterial( { color: 0x001133, ambient: 0x002266, envMap: textureCube, combine: THREE.MultiplyOperation } ),
+				"Orange metal": new THREE.MeshLambertMaterial( { color: 0xff6600, envMap: textureCube, combine: THREE.MultiplyOperation } ),
+				"Blue metal": 	new THREE.MeshLambertMaterial( { color: 0x001133, envMap: textureCube, combine: THREE.MultiplyOperation } ),
 				"Red metal": 	new THREE.MeshLambertMaterial( { color: 0x770000, envMap: textureCube, combine: THREE.MultiplyOperation } ),
 				"Green metal": 	new THREE.MeshLambertMaterial( { color: 0x007711, envMap: textureCube, combine: THREE.MultiplyOperation } ),
 				"Black metal":	new THREE.MeshLambertMaterial( { color: 0x222222, envMap: textureCube, combine: THREE.MultiplyOperation } ),

--- a/examples/webgl_materials_cubemap.html
+++ b/examples/webgl_materials_cubemap.html
@@ -112,9 +112,9 @@
 				refractionCube.format = THREE.RGBFormat;
 
 				//var cubeMaterial3 = new THREE.MeshPhongMaterial( { color: 0x000000, specular:0xaa0000, envMap: reflectionCube, combine: THREE.MixOperation, reflectivity: 0.25 } );
-				var cubeMaterial3 = new THREE.MeshLambertMaterial( { color: 0xff6600, ambient: 0x993300, envMap: reflectionCube, combine: THREE.MixOperation, reflectivity: 0.3 } );
-				var cubeMaterial2 = new THREE.MeshLambertMaterial( { color: 0xffee00, ambient: 0x996600, envMap: refractionCube, refractionRatio: 0.95 } );
-				var cubeMaterial1 = new THREE.MeshLambertMaterial( { color: 0xffffff, ambient: 0xaaaaaa, envMap: reflectionCube } )
+				var cubeMaterial3 = new THREE.MeshLambertMaterial( { color: 0xff6600, envMap: reflectionCube, combine: THREE.MixOperation, reflectivity: 0.3 } );
+				var cubeMaterial2 = new THREE.MeshLambertMaterial( { color: 0xffee00, envMap: refractionCube, refractionRatio: 0.95 } );
+				var cubeMaterial1 = new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: reflectionCube } )
 
 				// Skybox
 

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -215,22 +215,22 @@
 
 					body: [],
 
-					"Chrome": new THREE.MeshLambertMaterial( { color: 0xffffff, ambient: 0xffffff, envMap: cubeTarget  } ),
+					"Chrome": new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: cubeTarget  } ),
 
-					"Dark chrome": new THREE.MeshLambertMaterial( { color: 0x444444, ambient: 0x444444, envMap: cubeTarget } ),
+					"Dark chrome": new THREE.MeshLambertMaterial( { color: 0x444444, envMap: cubeTarget } ),
 
-					"Black rough": new THREE.MeshLambertMaterial( { color: 0x050505, ambient: 0x050505 } ),
+					"Black rough": new THREE.MeshLambertMaterial( { color: 0x050505, } ),
 
-					"Dark glass": new THREE.MeshLambertMaterial( { color: 0x101020, ambient: 0x101020, envMap: cubeTarget, opacity: 0.5, transparent: true } ),
-					"Orange glass": new THREE.MeshLambertMaterial( { color: 0xffbb00, ambient: 0xffbb00, opacity: 0.5, transparent: true } ),
-					"Red glass": new THREE.MeshLambertMaterial( { color: 0xff0000, ambient: 0xff0000, opacity: 0.5, transparent: true } ),
+					"Dark glass": new THREE.MeshLambertMaterial( { color: 0x101020, envMap: cubeTarget, opacity: 0.5, transparent: true } ),
+					"Orange glass": new THREE.MeshLambertMaterial( { color: 0xffbb00, opacity: 0.5, transparent: true } ),
+					"Red glass": new THREE.MeshLambertMaterial( { color: 0xff0000, opacity: 0.5, transparent: true } ),
 
-					"Black metal": new THREE.MeshLambertMaterial( { color: 0x222222, ambient: 0x222222, envMap: cubeTarget, combine: THREE.MultiplyOperation } ),
-					"Orange metal": new THREE.MeshLambertMaterial( { color: 0xff6600, ambient: 0xff6600, envMap: cubeTarget, combine: THREE.MultiplyOperation } )
+					"Black metal": new THREE.MeshLambertMaterial( { color: 0x222222, envMap: cubeTarget, combine: THREE.MultiplyOperation } ),
+					"Orange metal": new THREE.MeshLambertMaterial( { color: 0xff6600, envMap: cubeTarget, combine: THREE.MultiplyOperation } )
 
 				}
 
-				mlib.body.push( [ "Orange", new THREE.MeshLambertMaterial( { color: 0x883300, ambient: 0x883300, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
+				mlib.body.push( [ "Orange", new THREE.MeshLambertMaterial( { color: 0x883300, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
 				mlib.body.push( [ "Blue", new THREE.MeshLambertMaterial( { color: 0x113355, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
 				mlib.body.push( [ "Red", new THREE.MeshLambertMaterial( { color: 0x660000, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
 				mlib.body.push( [ "Black", new THREE.MeshLambertMaterial( { color: 0x000000, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
@@ -558,7 +558,7 @@
 
 			function addObject( geometry, color, x, y, z, sy ) {
 
-				var object = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { color: color, ambient: color } ) );
+				var object = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { color: color } ) );
 				object.position.set( x, y, z );
 				object.castShadow = true;
 				object.receiveShadow = true;

--- a/examples/webgl_materials_normaldisplacementmap.html
+++ b/examples/webgl_materials_normaldisplacementmap.html
@@ -188,7 +188,6 @@
 				var material2 = new THREE.MeshPhongMaterial( {
 					color: diffuse,
 					specular: specular,
-					ambient: ambient,
 					shininess: shininess,
 					normalMap: uniforms[ "tNormal" ].value,
 					normalScale: uniforms[ "uNormalScale" ].value,

--- a/examples/webgl_materials_normaldisplacementmap.html
+++ b/examples/webgl_materials_normaldisplacementmap.html
@@ -148,7 +148,7 @@
 
 				// common material parameters
 
-				var ambient = 0x050505, diffuse = 0x331100, specular = 0xffffff, shininess = 10, scale = 23;
+				var diffuse = 0x331100, specular = 0xffffff, shininess = 10, scale = 23;
 
 				// normal map shader
 
@@ -172,7 +172,6 @@
 
 				uniforms[ "diffuse" ].value.setHex( diffuse );
 				uniforms[ "specular" ].value.setHex( specular );
-				uniforms[ "ambient" ].value.setHex( ambient );
 
 				uniforms[ "shininess" ].value = shininess;
 
@@ -181,7 +180,6 @@
 
 				uniforms[ "diffuse" ].value.convertGammaToLinear();
 				uniforms[ "specular" ].value.convertGammaToLinear();
-				uniforms[ "ambient" ].value.convertGammaToLinear();
 
 
 				var parameters = { fragmentShader: shader.fragmentShader, vertexShader: shader.vertexShader, uniforms: uniforms, lights: true, fog: false };

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -120,7 +120,6 @@
 
 				var material = new THREE.MeshPhongMaterial( {
 					color: 0xdddddd,
-					ambient: 0x111111,
 					specular: 0x222222,
 					shininess: 35,
 					map: THREE.ImageUtils.loadTexture( "obj/leeperrysmith/Map-COL.jpg" ),

--- a/examples/webgl_materials_skin.html
+++ b/examples/webgl_materials_skin.html
@@ -113,7 +113,7 @@
 
 				// MATERIALS
 
-				var ambient = 0x111111, diffuse = 0xbbbbbb, specular = 0x070707, shininess = 50;
+				var diffuse = 0xbbbbbb, specular = 0x070707, shininess = 50;
 
 				specular = 0x555555;
 
@@ -130,7 +130,6 @@
 
 				uniformsUV[ "diffuse" ].value.setHex( diffuse );
 				uniformsUV[ "specular" ].value.setHex( specular );
-				uniformsUV[ "ambient" ].value.setHex( ambient );
 
 				uniformsUV[ "uRoughness" ].value = 0.185;
 				uniformsUV[ "uSpecularBrightness" ].value = 0.8;

--- a/examples/webgl_objects_update.html
+++ b/examples/webgl_objects_update.html
@@ -57,7 +57,7 @@
 				map.wrapS = map.wrapT = THREE.RepeatWrapping;
 				map.anisotropy = 16;
 
-				//var material = new THREE.MeshLambertMaterial( { ambient: 0xbbbbbb, map: map, side: THREE.DoubleSide } );
+				//var material = new THREE.MeshLambertMaterial( { map: map, side: THREE.DoubleSide } );
 
 				//
 

--- a/examples/webgl_octree_raycasting.html
+++ b/examples/webgl_octree_raycasting.html
@@ -123,7 +123,7 @@
 				geometry.computeVertexNormals();
 				totalFaces += geometry.faces.length;
 				
-				var material = new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0x030303, specular: 0x030303, shininess: 30 } );
+				var material = new THREE.MeshPhongMaterial( { color: 0x030303, specular: 0x030303, shininess: 30 } );
 				
 				modifyOctree( geometry, material, true );
 				

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -335,7 +335,6 @@
 				var mat2 = new THREE.MeshLambertMaterial( {
 				
 					color: 0x999999,
-					ambient: 0x444444,
 					specular: 0x080808,
 					shininess: 20,
 					map: THREE.ImageUtils.loadTexture( "obj/leeperrysmith/Map-COL.jpg" ),

--- a/examples/webgl_sandbox.html
+++ b/examples/webgl_sandbox.html
@@ -96,8 +96,8 @@
 					new THREE.MeshLambertMaterial( { map: texture3 } ),
 					new THREE.MeshLambertMaterial( { color: 0xdddddd, shading: THREE.FlatShading } ),
 					new THREE.MeshLambertMaterial( { color: 0xdddddd, shading: THREE.SmoothShading } ),
-					new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.FlatShading } ),
-					new THREE.MeshPhongMaterial( { ambient: 0x030303, color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.SmoothShading } )
+					new THREE.MeshPhongMaterial( { color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.FlatShading } ),
+					new THREE.MeshPhongMaterial( { color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.SmoothShading } )
 
 				];
 

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -166,7 +166,6 @@
 
 				var groundMaterial = new THREE.MeshPhongMaterial( {
 					shininess: 80,
-					ambient: 0x444444,
 					color: 0xffffff,
 					specular: 0xffffff,
 					map: textureSquares
@@ -265,7 +264,7 @@
 
 				loader.load( "models/animated/sittingBox.js", function( geometry ) {
 
-					var morphMaterial = new THREE.MeshPhongMaterial( { ambient: 0x000000, color: 0x000000, specular: 0xff9900, shininess: 50, morphTargets: true, morphNormals: true, side: THREE.DoubleSide } );
+					var morphMaterial = new THREE.MeshPhongMaterial( { color: 0x000000, specular: 0xff9900, shininess: 50, morphTargets: true, morphNormals: true, side: THREE.DoubleSide } );
 					morphMaterial.shading = THREE.FlatShading;
 
 					geometry.computeMorphNormals();

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -197,9 +197,9 @@
 
 				} );
 
-				var materialLambert = new THREE.MeshPhongMaterial( { shininess: 50, ambient: 0x444444, color: 0xffffff, map: textureNoiseColor } );
-				var materialPhong = new THREE.MeshPhongMaterial( { shininess: 50, ambient: 0x444444, color: 0xffffff, specular: 0x999999, map: textureLava } );
-				var materialPhongCube = new THREE.MeshPhongMaterial( { shininess: 50, ambient: 0x444444, color: 0xffffff, specular: 0x999999, envMap: cubeCamera.renderTarget } );
+				var materialLambert = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, map: textureNoiseColor } );
+				var materialPhong = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, specular: 0x999999, map: textureLava } );
+				var materialPhongCube = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, specular: 0x999999, envMap: cubeCamera.renderTarget } );
 
 				// OBJECTS
 
@@ -213,7 +213,7 @@
 
 				function addObjectColor( geometry, color, x, y, z, ry ) {
 
-					var material = new THREE.MeshPhongMaterial( { color: 0xffffff, ambient: 0x444444 } );
+					var material = new THREE.MeshPhongMaterial( { color: 0xffffff } );
 
 					return addObject( geometry, material, x, y, z, ry );
 

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -270,7 +270,7 @@
 				textGeo.computeBoundingBox();
 				var centerOffset = -0.5 * ( textGeo.boundingBox.max.x - textGeo.boundingBox.min.x );
 
-				var textMaterial = new THREE.MeshPhongMaterial( { color: 0xff0000, specular: 0xffffff, ambient: 0xaa0000 } );
+				var textMaterial = new THREE.MeshPhongMaterial( { color: 0xff0000, specular: 0xffffff } );
 
 				var mesh = new THREE.Mesh( textGeo, textMaterial );
 				mesh.position.x = centerOffset;

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -237,7 +237,6 @@
 
 				var geometry = new THREE.PlaneBufferGeometry( 100, 100 );
 				var planeMaterial = new THREE.MeshPhongMaterial( { color: 0xffdd99 } );
-				planeMaterial.ambient = planeMaterial.color;
 
 				var ground = new THREE.Mesh( geometry, planeMaterial );
 
@@ -313,7 +312,6 @@
 					if ( fudgeColor ) {
 
 						material.color.offsetHSL( 0, Math.random() * 0.5 - 0.25, Math.random() * 0.5 - 0.25 );
-						material.ambient = material.color;
 
 					}
 

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -171,7 +171,6 @@
 
 				var geometry = new THREE.PlaneBufferGeometry( 100, 100 );
 				var planeMaterial = new THREE.MeshPhongMaterial( { color: 0xffdd99 } );
-				planeMaterial.ambient = planeMaterial.color;
 
 				var ground = new THREE.Mesh( geometry, planeMaterial );
 
@@ -205,7 +204,7 @@
 				textGeo.computeBoundingBox();
 				var centerOffset = -0.5 * ( textGeo.boundingBox.max.x - textGeo.boundingBox.min.x );
 
-				var textMaterial = new THREE.MeshPhongMaterial( { color: 0xff0000, specular: 0xffffff, ambient: 0xaa0000 } );
+				var textMaterial = new THREE.MeshPhongMaterial( { color: 0xff0000, specular: 0xffffff } );
 
 				var mesh = new THREE.Mesh( textGeo, textMaterial );
 				mesh.position.x = centerOffset;
@@ -247,7 +246,6 @@
 					if ( fudgeColor ) {
 
 						material.color.offsetHSL( 0, Math.random() * 0.5 - 0.25, Math.random() * 0.5 - 0.25 );
-						material.ambient = material.color;
 
 					}
 

--- a/examples/webgl_terrain_dynamic.html
+++ b/examples/webgl_terrain_dynamic.html
@@ -380,7 +380,6 @@
 
 				uniformsTerrain[ "diffuse" ].value.setHex( 0xffffff );
 				uniformsTerrain[ "specular" ].value.setHex( 0xffffff );
-				uniformsTerrain[ "ambient" ].value.setHex( 0x111111 );
 
 				uniformsTerrain[ "shininess" ].value = 30;
 

--- a/examples/webgldeferred_animation.html
+++ b/examples/webgldeferred_animation.html
@@ -257,7 +257,6 @@
 						originalMaterial.map = undefined;
 						originalMaterial.shading = THREE.SmoothShading;
 						originalMaterial.color.setHSL( 0.01, 0.3, 0.3 );
-						originalMaterial.ambient.copy( originalMaterial.color );
 						originalMaterial.specular.setHSL( 0, 0, 0.1 );
 						originalMaterial.shininess = 75;
 

--- a/examples/webgldeferred_arealights.html
+++ b/examples/webgldeferred_arealights.html
@@ -267,7 +267,6 @@
 						// back / top / front torso
 						new THREE.MeshLambertMaterial( {
 							color: 0x000000,
-							ambient: 0x000000,
 							envMap: textureCube,
 							combine: THREE.MixOperation,
 							reflectivity: 0.15

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -300,12 +300,6 @@ THREE.Loader.prototype = {
 
 		}
 
-		if ( m.colorAmbient ) {
-
-			mpars.ambient = rgb2hex( m.colorAmbient );
-
-		}
-
 		if ( m.colorEmissive ) {
 
 			mpars.emissive = rgb2hex( m.colorEmissive );

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -37,7 +37,6 @@ THREE.MaterialLoader.prototype = {
 		var material = new THREE[ json.type ];
 
 		if ( json.color !== undefined ) material.color.setHex( json.color );
-		if ( json.ambient !== undefined ) material.ambient.setHex( json.ambient );
 		if ( json.emissive !== undefined ) material.emissive.setHex( json.emissive );
 		if ( json.specular !== undefined ) material.specular.setHex( json.specular );
 		if ( json.shininess !== undefined ) material.shininess = json.shininess;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -112,7 +112,6 @@ THREE.Material.prototype = {
 		} else if ( this instanceof THREE.MeshLambertMaterial ) {
 
 			output.color = this.color.getHex();
-			output.ambient = this.ambient.getHex();
 			output.emissive = this.emissive.getHex();
 			if ( this.vertexColors !== THREE.NoColors ) output.vertexColors = this.vertexColors;
 			if ( this.blending !== THREE.NormalBlending ) output.blending = this.blending;
@@ -121,7 +120,6 @@ THREE.Material.prototype = {
 		} else if ( this instanceof THREE.MeshPhongMaterial ) {
 
 			output.color = this.color.getHex();
-			output.ambient = this.ambient.getHex();
 			output.emissive = this.emissive.getHex();
 			output.specular = this.specular.getHex();
 			output.shininess = this.shininess;

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -4,7 +4,6 @@
  *
  * parameters = {
  *  color: <hex>,
- *  ambient: <hex>,
  *  emissive: <hex>,
  *  opacity: <float>,
  *
@@ -46,7 +45,6 @@ THREE.MeshLambertMaterial = function ( parameters ) {
 	this.type = 'MeshLambertMaterial';
 
 	this.color = new THREE.Color( 0xffffff ); // diffuse
-	this.ambient = new THREE.Color( 0xffffff );
 	this.emissive = new THREE.Color( 0x000000 );
 
 	this.wrapAround = false;
@@ -94,7 +92,6 @@ THREE.MeshLambertMaterial.prototype.clone = function () {
 	THREE.Material.prototype.clone.call( this, material );
 
 	material.color.copy( this.color );
-	material.ambient.copy( this.ambient );
 	material.emissive.copy( this.emissive );
 
 	material.wrapAround = this.wrapAround;

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -4,7 +4,6 @@
  *
  * parameters = {
  *  color: <hex>,
- *  ambient: <hex>,
  *  emissive: <hex>,
  *  specular: <hex>,
  *  shininess: <float>,
@@ -54,7 +53,6 @@ THREE.MeshPhongMaterial = function ( parameters ) {
 	this.type = 'MeshPhongMaterial';
 
 	this.color = new THREE.Color( 0xffffff ); // diffuse
-	this.ambient = new THREE.Color( 0xffffff );
 	this.emissive = new THREE.Color( 0x000000 );
 	this.specular = new THREE.Color( 0x111111 );
 	this.shininess = 30;
@@ -112,7 +110,6 @@ THREE.MeshPhongMaterial.prototype.clone = function () {
 	THREE.Material.prototype.clone.call( this, material );
 
 	material.color.copy( this.color );
-	material.ambient.copy( this.ambient );
 	material.emissive.copy( this.emissive );
 	material.specular.copy( this.specular );
 	material.shininess = this.shininess;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4694,13 +4694,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( _this.gammaInput ) {
 
-			uniforms.ambient.value.copyGammaToLinear( material.ambient );
 			uniforms.emissive.value.copyGammaToLinear( material.emissive );
 			uniforms.specular.value.copyGammaToLinear( material.specular );
 
 		} else {
 
-			uniforms.ambient.value = material.ambient;
 			uniforms.emissive.value = material.emissive;
 			uniforms.specular.value = material.specular;
 
@@ -4718,12 +4716,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( _this.gammaInput ) {
 
-			uniforms.ambient.value.copyGammaToLinear( material.ambient );
 			uniforms.emissive.value.copyGammaToLinear( material.emissive );
 
 		} else {
 
-			uniforms.ambient.value = material.ambient;
 			uniforms.emissive.value = material.emissive;
 
 		}

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_pars_vertex.glsl
@@ -1,4 +1,3 @@
-uniform vec3 ambient;
 uniform vec3 diffuse;
 uniform vec3 emissive;
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -193,10 +193,10 @@ for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
 #endif
 
-vLightFront = ( vLightFront + ambientLightColor ) * diffuse + emissive;
+vLightFront = vLightFront * diffuse + diffuse * ambientLightColor + emissive;
 
 #ifdef DOUBLE_SIDED
 
-	vLightBack = ( ambientLightColor + vLightBack ) * diffuse + emissive;
-
+	vLightBack = vLightBack * diffuse + diffuse * ambientLightColor + emissive;
+	
 #endif

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -193,10 +193,10 @@ for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
 #endif
 
-vLightFront = vLightFront * diffuse + ambient * ambientLightColor + emissive;
+vLightFront = ( vLightFront + ambientLightColor ) * diffuse + emissive;
 
 #ifdef DOUBLE_SIDED
 
-	vLightBack = vLightBack * diffuse + ambient * ambientLightColor + emissive;
+	vLightBack = ( ambientLightColor + vLightBack ) * diffuse + emissive;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -269,10 +269,10 @@ vec3 totalSpecular = vec3( 0.0 );
 
 #ifdef METAL
 
-	gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor * ambient + totalSpecular );
+	gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor + totalSpecular );
 
 #else
 
-	gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor * ambient ) + totalSpecular;
+	gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor ) + totalSpecular;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -269,10 +269,10 @@ vec3 totalSpecular = vec3( 0.0 );
 
 #ifdef METAL
 
-	gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor + totalSpecular );
+	gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor * diffuse + totalSpecular );
 
 #else
 
-	gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor ) + totalSpecular;
+	gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor * diffuse ) + totalSpecular;
 
 #endif

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -107,7 +107,6 @@ THREE.ShaderLib = {
 			THREE.UniformsLib[ "shadowmap" ],
 
 			{
-				"ambient"  : { type: "c", value: new THREE.Color( 0xffffff ) },
 				"emissive" : { type: "c", value: new THREE.Color( 0x000000 ) },
 				"wrapRGB"  : { type: "v3", value: new THREE.Vector3( 1, 1, 1 ) }
 			}
@@ -236,7 +235,6 @@ THREE.ShaderLib = {
 			THREE.UniformsLib[ "shadowmap" ],
 
 			{
-				"ambient"  : { type: "c", value: new THREE.Color( 0xffffff ) },
 				"emissive" : { type: "c", value: new THREE.Color( 0x000000 ) },
 				"specular" : { type: "c", value: new THREE.Color( 0x111111 ) },
 				"shininess": { type: "f", value: 30 },
@@ -298,7 +296,6 @@ THREE.ShaderLib = {
 			"uniform vec3 diffuse;",
 			"uniform float opacity;",
 
-			"uniform vec3 ambient;",
 			"uniform vec3 emissive;",
 			"uniform vec3 specular;",
 			"uniform float shininess;",


### PR DESCRIPTION
Per discussion here: https://github.com/mrdoob/three.js/pull/5741#issuecomment-67893202

Now it should be mentioned that sometimes `material.ambient` is considered to be a per-material incoming non-directional light intensity (sometimes called `material.selfIllumination`, but not to be confused with `material.emissive`) rather than as a surface color specifically for ambient light as it is treated now  If we wanted to go that route, we would modify the shading equation and leave `material.ambient` around, and it would be additive with ambientLightColor, both of which would then be modulated by the `material.color`.

I am okay with either route.
