### PR TITLE
WebGLRenderer: major ID collision issue fix

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2476,7 +2476,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var updateBuffers = false,
 			wireframeBit = material.wireframe ? 1 : 0,
-			geometryHash = ( geometry.id * 0xffffff ) + ( program.id * 2 ) + wireframeBit;
+			geometryHash = ( geometry.id * 0x1000000 ) + ( program.id * 4 ) + 2 + wireframeBit;
 
 		if ( geometryHash !== _currentGeometryGroupHash ) {
 
@@ -2821,7 +2821,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var updateBuffers = false,
 			wireframeBit = material.wireframe ? 1 : 0,
-			geometryGroupHash = ( geometryGroup.id * 0xffffff ) + ( program.id * 2 ) + wireframeBit;
+			geometryGroupHash = ( geometryGroup.id * 0x1000000 ) + ( program.id * 4 ) + wireframeBit;
 
 		if ( geometryGroupHash !== _currentGeometryGroupHash ) {
 


### PR DESCRIPTION
Hello Ricardo.
Fixed one slippy bug which caused headache.
In essence faulty code cause ID namespace collision, what make sometimes object invisible and if depth sort is on it cause flickering of some meshes.
It is actual in case when Scene have both types BufferGeometry and Geometry objects.
This is quite serious issue, surprised nobody found it.
Ricardo, please don't forget to mention my name in the next release this time.
