### PR TITLE
Fix Blender UV export for BufferGeometry

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -140,6 +140,7 @@ def buffer_uv(mesh, options):
         uv = (uv.uv[0], uv.uv[1])
         if round_off:
             uv = utilities.round_off(uv, round_val)
+        uvs_.extend(uv)
     
     return uvs_
 


### PR DESCRIPTION
This is a fix for the new Blender exporter in the `dev` branch.

It was not possible to export UVs for BufferGeometry, because the exporter was always returning an empty array for them due to missing `extend()` call.
