### PR TITLE
Ability to set custom Gamma factors and clean up glsl code

### DIFF
--- a/examples/js/ShaderDeferred.js
+++ b/examples/js/ShaderDeferred.js
@@ -225,11 +225,7 @@ THREE.ShaderDeferred = {
 
 					"#endif",
 
-					"#ifdef GAMMA_INPUT",
-
-						"cubeColor.xyz *= cubeColor.xyz;",
-
-					"#endif",
+					"cubeColor.xyz = inputToLinear( cubeColor.xyz );",
 
 					"if ( combine == 1 ) {",
 

--- a/examples/js/ShaderTerrain.js
+++ b/examples/js/ShaderTerrain.js
@@ -134,12 +134,8 @@ THREE.ShaderTerrain = {
 					"vec4 colDiffuse1 = texture2D( tDiffuse1, uvOverlay );",
 					"vec4 colDiffuse2 = texture2D( tDiffuse2, uvOverlay );",
 
-					"#ifdef GAMMA_INPUT",
-
-						"colDiffuse1.xyz *= colDiffuse1.xyz;",
-						"colDiffuse2.xyz *= colDiffuse2.xyz;",
-
-					"#endif",
+					"colDiffuse1.xyz = inputToLinear( colDiffuse1.xyz );",
+					"colDiffuse2.xyz = inputToLinear( colDiffuse2.xyz );",
 
 					"gl_FragColor = gl_FragColor * mix ( colDiffuse1, colDiffuse2, 1.0 - texture2D( tDisplacement, uvBase ) );",
 

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -88,6 +88,10 @@
 				shadowBias: -0.0002,
 				shadowDarkness: 0.3
 
+			}, gamma = {
+				gammaFactor: 2.0,
+				gammaInput: true,
+				gammaOutput: true
 			};
 
 			init();
@@ -385,44 +389,70 @@
 
 				gui = new dat.GUI();
 
-				gui.add( shadowConfig, 'shadowCameraVisible' ).onChange( function() {
+				shadowGUI = gui.addFolder( "Shadow" );
+    	
+    			shadowGUI.add( shadowConfig, 'shadowCameraVisible' ).onChange( function() {
 
 					sunLight.shadowCameraVisible = shadowConfig.shadowCameraVisible;
 
 				});
 
-				gui.add( shadowConfig, 'shadowCameraNear', 1, 1500 ).onChange( function() {
+				shadowGUI.add( shadowConfig, 'shadowCameraNear', 1, 1500 ).onChange( function() {
 
 					sunLight.shadowCamera.near = shadowConfig.shadowCameraNear;
 					sunLight.shadowCamera.updateProjectionMatrix();
 
 				});
 
-				gui.add( shadowConfig, 'shadowCameraFar', 1501, 5000 ).onChange( function() {
+				shadowGUI.add( shadowConfig, 'shadowCameraFar', 1501, 5000 ).onChange( function() {
 
 					sunLight.shadowCamera.far = shadowConfig.shadowCameraFar;
 					sunLight.shadowCamera.updateProjectionMatrix();
 
 				});
 
-				gui.add( shadowConfig, 'shadowCameraFov', 1, 120 ).onChange( function() {
+				shadowGUI.add( shadowConfig, 'shadowCameraFov', 1, 120 ).onChange( function() {
 
 					sunLight.shadowCamera.fov = shadowConfig.shadowCameraFov;
 					sunLight.shadowCamera.updateProjectionMatrix();
 
 				});
 
-				gui.add( shadowConfig, 'shadowBias', -0.01, 0.01 ).onChange( function() {
+				shadowGUI.add( shadowConfig, 'shadowBias', -0.01, 0.01 ).onChange( function() {
 
 					sunLight.shadowBias = shadowConfig.shadowBias;
 
 				});
 
-				gui.add( shadowConfig, 'shadowDarkness', 0, 1 ).onChange( function() {
+				shadowGUI.add( shadowConfig, 'shadowDarkness', 0, 1 ).onChange( function() {
+
+				});
+				shadowGUI.open();
+
+				gammaGUI = gui.addFolder( "Gamma" );
+    
+				gammaGUI.add( gamma, 'gammaFactor', 0.1, 4.0 ).onChange( function() {
+
+					renderer.gammaFactor = gamma.gammaFactor;
+
+				});
+				gammaGUI.open();
+
+				/*
+
+				Not exposed because they are not easily dynamically updated - as all shaders need to be recompiled.  -bhouston
+
+				gammaGUI.add( gamma, 'gammaInput', true ).onChange( function() {
+
+					renderer.gammaInput = gamma.gammaInput;
 
 				});
 
-				gui.close();
+				gammaGUI.add( gamma, 'gammaOutput', true ).onChange( function() {
+
+					renderer.gammaOutput = gamma.gammaOutput;
+
+				});*/
 
 			}
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -173,21 +173,26 @@ THREE.Color.prototype = {
 
 	},
 
-	copyGammaToLinear: function ( color ) {
+	copyGammaToLinear: function ( color, gammaFactor ) {
 
-		this.r = color.r * color.r;
-		this.g = color.g * color.g;
-		this.b = color.b * color.b;
+		gammaFactor = gammaFactor || 2.0;
+
+		this.r = Math.pow( color.r, gammaFactor );
+		this.g = Math.pow( color.g, gammaFactor );
+		this.b = Math.pow( color.b, gammaFactor );
 
 		return this;
 
 	},
 
-	copyLinearToGamma: function ( color ) {
+	copyLinearToGamma: function ( color, gammaFactor ) {
 
-		this.r = Math.sqrt( color.r );
-		this.g = Math.sqrt( color.g );
-		this.b = Math.sqrt( color.b );
+		gammaFactor = gammaFactor || 2.0;
+
+		var safeInverse = ( gammaFactor > 0 ) ? ( 1.0 / gammaFactor ) : 1.0;
+		this.r = Math.pow( color.r, safeInverse );
+		this.g = Math.pow( color.g, safeInverse );
+		this.b = Math.pow( color.b, safeInverse );
 
 		return this;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4525,7 +4525,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( _this.gammaInput ) {
 
-			uniforms.diffuse.value.copyGammaToLinear( material.color, this.gammaFactor );
+			uniforms.diffuse.value.copyGammaToLinear( material.color, _this.gammaFactor );
 
 		} else {
 
@@ -4659,9 +4659,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( _this.gammaInput ) {
 
-			uniforms.ambient.value.copyGammaToLinear( material.ambient, this.gammaFactor );
-			uniforms.emissive.value.copyGammaToLinear( material.emissive, this.gammaFactor );
-			uniforms.specular.value.copyGammaToLinear( material.specular, this.gammaFactor );
+			uniforms.ambient.value.copyGammaToLinear( material.ambient, _this.gammaFactor );
+			uniforms.emissive.value.copyGammaToLinear( material.emissive, _this.gammaFactor );
+			uniforms.specular.value.copyGammaToLinear( material.specular, _this.gammaFactor );
+
 
 		} else {
 
@@ -4683,8 +4684,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( _this.gammaInput ) {
 
-			uniforms.ambient.value.copyGammaToLinear( material.ambient, this.gammaFactor );
-			uniforms.emissive.value.copyGammaToLinear( material.emissive, this.gammaFactor );
+			uniforms.ambient.value.copyGammaToLinear( material.ambient, _this.gammaFactor );
+			uniforms.emissive.value.copyGammaToLinear( material.emissive, _this.gammaFactor );
 
 		} else {
 
@@ -5158,11 +5159,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	//
 
-	function setColorGamma( array, offset, color, intensity ) {
+	function setColorGamma( array, offset, color, intensity, gammaFactor ) {
 
-		array[ offset ]     = Math.pow( color.r * intensity, this.gammaFactor );
-		array[ offset + 1 ] = Math.pow( color.g * intensity, this.gammaFactor );
-		array[ offset + 2 ] = Math.pow( color.b * intensity, this.gammaFactor );
+		array[ offset ]     = Math.pow( color.r * intensity, gammaFactor );
+		array[ offset + 1 ] = Math.pow( color.g * intensity, gammaFactor );
+		array[ offset + 2 ] = Math.pow( color.b * intensity, gammaFactor );
 
 	}
 
@@ -5234,9 +5235,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					r += Math.pow( color.r, this.gammaFactor );
-					g += Math.pow( color.g, this.gammaFactor );
-					b += Math.pow( color.b, this.gammaFactor );
+					r += Math.pow( color.r, _this.gammaFactor );
+					g += Math.pow( color.g, _this.gammaFactor );
+					b += Math.pow( color.b, _this.gammaFactor );
 
 				} else {
 
@@ -5265,7 +5266,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					setColorGamma( dirColors, dirOffset, color, intensity );
+					setColorGamma( dirColors, dirOffset, color, intensity, _this.gammaFactor );
 
 				} else {
 
@@ -5285,7 +5286,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					setColorGamma( pointColors, pointOffset, color, intensity );
+					setColorGamma( pointColors, pointOffset, color, intensity, _this.gammaFactor );
 
 				} else {
 
@@ -5313,7 +5314,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					setColorGamma( spotColors, spotOffset, color, intensity );
+					setColorGamma( spotColors, spotOffset, color, intensity, _this.gammaFactor );
 
 				} else {
 
@@ -5362,8 +5363,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					setColorGamma( hemiSkyColors, hemiOffset, skyColor, intensity );
-					setColorGamma( hemiGroundColors, hemiOffset, groundColor, intensity );
+					setColorGamma( hemiSkyColors, hemiOffset, skyColor, intensity, _this.gammaFactor );
+					setColorGamma( hemiGroundColors, hemiOffset, groundColor, intensity, _this.gammaFactor );
 
 				} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -58,6 +58,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	// physically based shading
 
+	this.gammaFactor = 2.0;	// for backwards compatibility
 	this.gammaInput = false;
 	this.gammaOutput = false;
 
@@ -4524,7 +4525,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( _this.gammaInput ) {
 
-			uniforms.diffuse.value.copyGammaToLinear( material.color );
+			uniforms.diffuse.value.copyGammaToLinear( material.color, this.gammaFactor );
 
 		} else {
 
@@ -4658,9 +4659,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( _this.gammaInput ) {
 
-			uniforms.ambient.value.copyGammaToLinear( material.ambient );
-			uniforms.emissive.value.copyGammaToLinear( material.emissive );
-			uniforms.specular.value.copyGammaToLinear( material.specular );
+			uniforms.ambient.value.copyGammaToLinear( material.ambient, this.gammaFactor );
+			uniforms.emissive.value.copyGammaToLinear( material.emissive, this.gammaFactor );
+			uniforms.specular.value.copyGammaToLinear( material.specular, this.gammaFactor );
 
 		} else {
 
@@ -4682,8 +4683,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( _this.gammaInput ) {
 
-			uniforms.ambient.value.copyGammaToLinear( material.ambient );
-			uniforms.emissive.value.copyGammaToLinear( material.emissive );
+			uniforms.ambient.value.copyGammaToLinear( material.ambient, this.gammaFactor );
+			uniforms.emissive.value.copyGammaToLinear( material.emissive, this.gammaFactor );
 
 		} else {
 
@@ -5157,11 +5158,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	//
 
-	function setColorGamma( array, offset, color, intensitySq ) {
+	function setColorGamma( array, offset, color, intensity ) {
 
-		array[ offset ]     = color.r * color.r * intensitySq;
-		array[ offset + 1 ] = color.g * color.g * intensitySq;
-		array[ offset + 2 ] = color.b * color.b * intensitySq;
+		array[ offset ]     = Math.pow( color.r * intensity, this.gammaFactor );
+		array[ offset + 1 ] = Math.pow( color.g * intensity, this.gammaFactor );
+		array[ offset + 2 ] = Math.pow( color.b * intensity, this.gammaFactor );
 
 	}
 
@@ -5233,9 +5234,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					r += color.r * color.r;
-					g += color.g * color.g;
-					b += color.b * color.b;
+					r += Math.pow( color.r, this.gammaFactor );
+					g += Math.pow( color.g, this.gammaFactor );
+					b += Math.pow( color.b, this.gammaFactor );
 
 				} else {
 
@@ -5264,7 +5265,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					setColorGamma( dirColors, dirOffset, color, intensity * intensity );
+					setColorGamma( dirColors, dirOffset, color, intensity );
 
 				} else {
 
@@ -5284,7 +5285,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					setColorGamma( pointColors, pointOffset, color, intensity * intensity );
+					setColorGamma( pointColors, pointOffset, color, intensity );
 
 				} else {
 
@@ -5312,7 +5313,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					setColorGamma( spotColors, spotOffset, color, intensity * intensity );
+					setColorGamma( spotColors, spotOffset, color, intensity );
 
 				} else {
 
@@ -5361,10 +5362,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _this.gammaInput ) {
 
-					intensitySq = intensity * intensity;
-
-					setColorGamma( hemiSkyColors, hemiOffset, skyColor, intensitySq );
-					setColorGamma( hemiGroundColors, hemiOffset, groundColor, intensitySq );
+					setColorGamma( hemiSkyColors, hemiOffset, skyColor, intensity );
+					setColorGamma( hemiGroundColors, hemiOffset, groundColor, intensity );
 
 				} else {
 

--- a/src/renderers/shaders/ShaderChunk/color_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/color_vertex.glsl
@@ -1,13 +1,5 @@
 #ifdef USE_COLOR
 
-	#ifdef GAMMA_INPUT
-
-		vColor = square( color );
-
-	#else
-
-		vColor = color;
-
-	#endif
+	vColor.xyz = inputToLinear( color.xyz );
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/color_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/color_vertex.glsl
@@ -2,7 +2,7 @@
 
 	#ifdef GAMMA_INPUT
 
-		vColor = color * color;
+		vColor = square( color );
 
 	#else
 

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -37,3 +37,19 @@ float sideOfPlane( in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {
 vec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 pointOnPlane, in vec3 planeNormal ) {
 	return pointOnLine + lineDirection * ( dot( planeNormal, pointOnPlane - pointOnLine ) / dot( planeNormal, lineDirection ) );
 }
+
+vec3 inputToLinear( in vec3 a ) {
+#ifdef GAMMA_INPUT
+	return pow( a.rgb, vec3( float( GAMMA_FACTOR ) ) );
+#else
+	return a;
+#endif
+}
+
+vec3 linearToOutput( in vec3 a ) {
+#ifdef GAMMA_OUTPUT
+	return pow( a.rgb, vec3( 1.0 / float( GAMMA_FACTOR ) ) );
+#else
+	return a;
+#endif
+}

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -20,11 +20,11 @@ float whiteCompliment( in float a ) { return saturate( 1.0 - a ); }
 vec2  whiteCompliment( in vec2 a )  { return saturate( vec2(1.0) - a ); }
 vec3  whiteCompliment( in vec3 a )  { return saturate( vec3(1.0) - a ); }
 vec4  whiteCompliment( in vec4 a )  { return saturate( vec4(1.0) - a ); }
-vec3 transformNormal( in vec3 normal, in mat4 matrix ) {
+vec3 transformDirection( in vec3 normal, in mat4 matrix ) {
 	return normalize( ( matrix * vec4( normal, 0.0 ) ).xyz );
 }
 // http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
-vec3 inverseTransformNormal( in vec3 normal, in mat4 matrix ) {
+vec3 inverseTransformDirection( in vec3 normal, in mat4 matrix ) {
 	return normalize( ( vec4( normal, 0.0 ) * matrix ).xyz );
 }
 vec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal) {

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -1,0 +1,35 @@
+#define PI 3.14159
+#define PI2 6.28318
+#define RECIPROCAL_PI2 0.15915494
+#define LOG2 1.442695
+#define EPSILON 1e-6
+
+float square( in float a ) { return a*a; }
+vec2  square( in vec2 a )  { return vec2( a.x*a.x, a.y*a.y ); }
+vec3  square( in vec3 a )  { return vec3( a.x*a.x, a.y*a.y, a.z*a.z ); }
+vec4  square( in vec4 a )  { return vec4( a.x*a.x, a.y*a.y, a.z*a.z, a.w*a.w ); }
+float saturate( in float a ) { return clamp( a, 0.0, 1.0 ); }
+vec2  saturate( in vec2 a )  { return clamp( a, 0.0, 1.0 ); }
+vec3  saturate( in vec3 a )  { return clamp( a, 0.0, 1.0 ); }
+vec4  saturate( in vec4 a )  { return clamp( a, 0.0, 1.0 ); }
+float average( in float a ) { return a; }
+float average( in vec2 a )  { return ( a.x + a.y) * 0.5; }
+float average( in vec3 a )  { return ( a.x + a.y + a.z) * 0.3333333333; }
+float average( in vec4 a )  { return ( a.x + a.y + a.z + a.w) * 0.25; }
+float whiteCompliment( in float a ) { return saturate( 1.0 - a ); }
+vec2  whiteCompliment( in vec2 a )  { return saturate( vec2(1.0) - a ); }
+vec3  whiteCompliment( in vec3 a )  { return saturate( vec3(1.0) - a ); }
+vec4  whiteCompliment( in vec4 a )  { return saturate( vec4(1.0) - a ); }
+vec3 transformNormal( in vec3 normal, in mat4 matrix ) {
+	return normalize( ( viewMatrix * vec4( normal, 0.0 ) ).xyz );
+}
+vec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal) {
+	float distance = dot( planeNormal, point-pointOnPlane );
+	return point - distance * planeNormal;
+}
+float sideOfPlane( in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {
+	return sign( dot( point - pointOnPlane, planeNormal ) );
+}
+vec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 pointOnPlane, in vec3 planeNormal ) {
+	return pointOnLine + lineDirection * ( dot( planeNormal, pointOnPlane - pointOnLine ) / dot( planeNormal, lineDirection ) );
+}

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -14,7 +14,7 @@ vec3  saturate( in vec3 a )  { return clamp( a, 0.0, 1.0 ); }
 vec4  saturate( in vec4 a )  { return clamp( a, 0.0, 1.0 ); }
 float average( in float a ) { return a; }
 float average( in vec2 a )  { return ( a.x + a.y) * 0.5; }
-float average( in vec3 a )  { return ( a.x + a.y + a.z) * 0.3333333333; }
+float average( in vec3 a )  { return ( a.x + a.y + a.z) / 3.0; }
 float average( in vec4 a )  { return ( a.x + a.y + a.z + a.w) * 0.25; }
 float whiteCompliment( in float a ) { return saturate( 1.0 - a ); }
 vec2  whiteCompliment( in vec2 a )  { return saturate( vec2(1.0) - a ); }

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -21,7 +21,7 @@ vec2  whiteCompliment( in vec2 a )  { return saturate( vec2(1.0) - a ); }
 vec3  whiteCompliment( in vec3 a )  { return saturate( vec3(1.0) - a ); }
 vec4  whiteCompliment( in vec4 a )  { return saturate( vec4(1.0) - a ); }
 vec3 transformNormal( in vec3 normal, in mat4 matrix ) {
-	return normalize( ( viewMatrix * vec4( normal, 0.0 ) ).xyz );
+	return normalize( ( matrix * vec4( normal, 0.0 ) ).xyz );
 }
 // http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
 vec3 inverseTransformNormal( in vec3 normal, in mat4 matrix ) {

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -40,7 +40,7 @@ vec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 poi
 
 vec3 inputToLinear( in vec3 a ) {
 #ifdef GAMMA_INPUT
-	return pow( a.rgb, vec3( float( GAMMA_FACTOR ) ) );
+	return pow( a, vec3( float( GAMMA_FACTOR ) ) );
 #else
 	return a;
 #endif
@@ -48,7 +48,7 @@ vec3 inputToLinear( in vec3 a ) {
 
 vec3 linearToOutput( in vec3 a ) {
 #ifdef GAMMA_OUTPUT
-	return pow( a.rgb, vec3( 1.0 / float( GAMMA_FACTOR ) ) );
+	return pow( a, vec3( 1.0 / float( GAMMA_FACTOR ) ) );
 #else
 	return a;
 #endif

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -23,6 +23,10 @@ vec4  whiteCompliment( in vec4 a )  { return saturate( vec4(1.0) - a ); }
 vec3 transformNormal( in vec3 normal, in mat4 matrix ) {
 	return normalize( ( viewMatrix * vec4( normal, 0.0 ) ).xyz );
 }
+// http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
+vec3 inverseTransformNormal( in vec3 normal, in mat4 matrix ) {
+	return normalize( ( vec4( normal, 0.0 ) * matrix ).xyz );
+}
 vec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal) {
 	float distance = dot( planeNormal, point-pointOnPlane );
 	return point - distance * planeNormal;

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -5,7 +5,7 @@
 		vec3 cameraToVertex = normalize( vWorldPosition - cameraPosition );
 
 		// Transforming Normal Vectors with the Inverse Transformation
-		vec3 worldNormal = inverseTransformNormal( normal, viewMatrix );
+		vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );
 
 		#ifdef ENVMAP_MODE_REFLECTION
 
@@ -39,7 +39,7 @@
 		vec4 envColor = texture2D( envMap, sampleUV );
 		
 	#elif defined( ENVMAP_TYPE_SPHERE )
-		vec3 reflectView = flipNormal * ( transformNormal( reflectVec, viewMatrix ) + vec3(0.0,0.0,1.0) );
+		vec3 reflectView = flipNormal * ( transformDirection( reflectVec, viewMatrix ) + vec3(0.0,0.0,1.0) );
 		vec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -43,11 +43,7 @@
 		vec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );
 	#endif
 
-	#ifdef GAMMA_INPUT
-
-		envColor.xyz *= envColor.xyz;
-
-	#endif
+	envColor.xyz = inputToLinear( envColor.xyz );
 
 	#ifdef ENVMAP_BLENDING_MULTIPLY
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -7,7 +7,7 @@
 		// http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
 		// Transforming Normal Vectors with the Inverse Transformation
 
-		vec3 worldNormal = normalize( vec3( vec4( normal, 0.0 ) * viewMatrix ) );
+		vec3 worldNormal = transformNormal( normal, viewMatrix );
 
 		#ifdef ENVMAP_MODE_REFLECTION
 
@@ -36,12 +36,12 @@
 
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 		vec2 sampleUV;
-		sampleUV.y = clamp( flipNormal * reflectVec.y * 0.5 + 0.5, 0.0, 1.0);
-		sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * 0.15915494309189533576888376337251 + 0.5; // reciprocal( 2 PI ) + 0.5
+		sampleUV.y = saturate( flipNormal * reflectVec.y * 0.5 + 0.5 );
+		sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * RECIPROCAL_2PI + 0.5;
 		vec4 envColor = texture2D( envMap, sampleUV );
 		
 	#elif defined( ENVMAP_TYPE_SPHERE )
-		vec3 reflectView = flipNormal * normalize((viewMatrix * vec4( reflectVec, 0.0 )).xyz + vec3(0.0,0.0,1.0));
+		vec3 reflectView = flipNormal * ( transformNormal( reflectVec, viewMatrix ) + vec3(0.0,0.0,1.0) );
 		vec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -4,10 +4,8 @@
 
 		vec3 cameraToVertex = normalize( vWorldPosition - cameraPosition );
 
-		// http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
 		// Transforming Normal Vectors with the Inverse Transformation
-
-		vec3 worldNormal = transformNormal( normal, viewMatrix );
+		vec3 worldNormal = inverseTransformNormal( normal, viewMatrix );
 
 		#ifdef ENVMAP_MODE_REFLECTION
 

--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
@@ -1,7 +1,6 @@
 #if defined( USE_ENVMAP ) && ! defined( USE_BUMPMAP ) && ! defined( USE_NORMALMAP ) && ! defined( PHONG )
 
-	vec3 worldNormal = mat3( modelMatrix[ 0 ].xyz, modelMatrix[ 1 ].xyz, modelMatrix[ 2 ].xyz ) * objectNormal;
-	worldNormal = normalize( worldNormal );
+	vec3 worldNormal = transformNormal( objectNormal, modelMatrix );
 
 	vec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );
 

--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
@@ -1,6 +1,6 @@
 #if defined( USE_ENVMAP ) && ! defined( USE_BUMPMAP ) && ! defined( USE_NORMALMAP ) && ! defined( PHONG )
 
-	vec3 worldNormal = transformNormal( objectNormal, modelMatrix );
+	vec3 worldNormal = transformDirection( objectNormal, modelMatrix );
 
 	vec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );
 

--- a/src/renderers/shaders/ShaderChunk/fog_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/fog_fragment.glsl
@@ -12,9 +12,8 @@
 
 	#ifdef FOG_EXP2
 
-		const float LOG2 = 1.442695;
-		float fogFactor = exp2( - fogDensity * fogDensity * depth * depth * LOG2 );
-		fogFactor = 1.0 - clamp( fogFactor, 0.0, 1.0 );
+		float fogFactor = exp2( - square( fogDensity ) * square( depth ) * LOG2 );
+		fogFactor = whiteCompliment( fogFactor );
 
 	#else
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -12,8 +12,7 @@ transformedNormal = normalize( transformedNormal );
 
 for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
-	vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );
-	vec3 dirVector = normalize( lDirection.xyz );
+	vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );
 
 	float dotProduct = dot( transformedNormal, dirVector );
 	vec3 directionalLightWeighting = vec3( max( dotProduct, 0.0 ) );
@@ -173,8 +172,7 @@ for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
 	for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec4 lDirection = viewMatrix * vec4( hemisphereLightDirection[ i ], 0.0 );
-		vec3 lVector = normalize( lDirection.xyz );
+		vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );
 
 		float dotProduct = dot( transformedNormal, lVector );
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -12,7 +12,7 @@ transformedNormal = normalize( transformedNormal );
 
 for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
-	vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );
+	vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );
 
 	float dotProduct = dot( transformedNormal, dirVector );
 	vec3 directionalLightWeighting = vec3( max( dotProduct, 0.0 ) );
@@ -172,7 +172,7 @@ for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
 	for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );
+		vec3 lVector = transformDirection( hemisphereLightDirection[ i ], viewMatrix );
 
 		float dotProduct = dot( transformedNormal, lVector );
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -79,7 +79,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 		float lDistance = 1.0;
 		if ( spotLightDistance[ i ] > 0.0 )
-			lDistance = saturate( 1.0 - ( length( lVector ) / spotLightDistance[ i ] );
+			lDistance = saturate( 1.0 - ( length( lVector ) / spotLightDistance[ i ] ) );
 
 		lVector = normalize( lVector );
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -132,7 +132,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 	for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
-		vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );
+		vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );
 
 				// diffuse
 
@@ -197,7 +197,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 	for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );
+		vec3 lVector = transformDirection( hemisphereLightDirection[ i ], viewMatrix );
 
 		// diffuse
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -29,7 +29,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 		float lDistance = 1.0;
 		if ( pointLightDistance[ i ] > 0.0 )
-			lDistance = 1.0 - min( ( length( lVector ) / pointLightDistance[ i ] ), 1.0 );
+			lDistance = saturate( 1.0 - ( length( lVector ) / pointLightDistance[ i ] ) );
 
 		lVector = normalize( lVector );
 
@@ -79,7 +79,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 		float lDistance = 1.0;
 		if ( spotLightDistance[ i ] > 0.0 )
-			lDistance = 1.0 - min( ( length( lVector ) / spotLightDistance[ i ] ), 1.0 );
+			lDistance = saturate( 1.0 - ( length( lVector ) / spotLightDistance[ i ] );
 
 		lVector = normalize( lVector );
 
@@ -132,8 +132,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 	for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
 
-		vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );
-		vec3 dirVector = normalize( lDirection.xyz );
+		vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );
 
 				// diffuse
 
@@ -198,8 +197,7 @@ vec3 viewPosition = normalize( vViewPosition );
 
 	for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec4 lDirection = viewMatrix * vec4( hemisphereLightDirection[ i ], 0.0 );
-		vec3 lVector = normalize( lDirection.xyz );
+		vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );
 
 		// diffuse
 

--- a/src/renderers/shaders/ShaderChunk/linear_to_gamma_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/linear_to_gamma_fragment.glsl
@@ -1,5 +1,2 @@
-#ifdef GAMMA_OUTPUT
 
-	gl_FragColor.xyz = sqrt( gl_FragColor.xyz );
-
-#endif
+	gl_FragColor.xyz = linearToOutput( gl_FragColor.xyz );

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl
@@ -1,6 +1,6 @@
 #ifdef USE_LOGDEPTHBUF
 
-	gl_Position.z = log2(max(1e-6, gl_Position.w + 1.0)) * logDepthBufFC;
+	gl_Position.z = log2(max( EPSILON, gl_Position.w + 1.0 )) * logDepthBufFC;
 
 	#ifdef USE_LOGDEPTHBUF_EXT
 

--- a/src/renderers/shaders/ShaderChunk/map_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/map_fragment.glsl
@@ -2,11 +2,7 @@
 
 	vec4 texelColor = texture2D( map, vUv );
 
-	#ifdef GAMMA_INPUT
-
-		texelColor.xyz *= texelColor.xyz;
-
-	#endif
+	texelColor.xyz = inputToLinear( texelColor.xyz );
 
 	gl_FragColor = gl_FragColor * texelColor;
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_fragment.glsl
@@ -209,11 +209,8 @@
 
 	}
 
-	#ifdef GAMMA_OUTPUT
-
-		shadowColor *= shadowColor;
-
-	#endif
+	// NOTE: I am unsure if this is correct in linear space.  -bhouston, Dec 29, 2014
+	shadowColor = inputToLinear( shadowColor );
 
 	gl_FragColor.xyz = gl_FragColor.xyz * shadowColor;
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -749,35 +749,15 @@ THREE.ShaderLib = {
 
 			"	if( enableDiffuse ) {",
 
-			"		#ifdef GAMMA_INPUT",
-
-			"			vec4 texelColor = texture2D( tDiffuse, vUv );",
-			"			texelColor.xyz *= texelColor.xyz;",
-
-			"			gl_FragColor = gl_FragColor * texelColor;",
-
-			"		#else",
-
-			"			gl_FragColor = gl_FragColor * texture2D( tDiffuse, vUv );",
-
-			"		#endif",
+			"		vec4 texelColor = texture2D( tDiffuse, vUv );",
+			"		texelColor.xyz = inputToLinear( texelColor.xyz );",
+			"		gl_FragColor = gl_FragColor * texelColor;",
 
 			"	}",
 
 			"	if( enableAO ) {",
 
-			"		#ifdef GAMMA_INPUT",
-
-			"			vec4 aoColor = texture2D( tAO, vUv );",
-			"			aoColor.xyz *= aoColor.xyz;",
-
-			"			gl_FragColor.xyz = gl_FragColor.xyz * aoColor.xyz;",
-
-			"		#else",
-
-			"			gl_FragColor.xyz = gl_FragColor.xyz * texture2D( tAO, vUv ).xyz;",
-
-			"		#endif",
+			"		gl_FragColor.xyz = gl_FragColor.xyz * inputToLinear( texture2D( tAO, vUv ).xyz );",
 
 			"	}",
 			
@@ -1054,12 +1034,7 @@ THREE.ShaderLib = {
 			"		#endif",
 
 			"		vec4 cubeColor = textureCube( tCube, vec3( -vReflect.x, vReflect.yz ) );",
-
-			"		#ifdef GAMMA_INPUT",
-
-			"			cubeColor.xyz *= cubeColor.xyz;",
-
-			"		#endif",
+			"		cubeColor.xyz = inputToLinear( cubeColor.xyz );",
 
 			"		gl_FragColor.xyz = mix( gl_FragColor.xyz, cubeColor.xyz, specularTex.r * reflectivity );",
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -21,6 +21,7 @@ THREE.ShaderLib = {
 
 		vertexShader: [
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "map_pars_vertex" ],
 			THREE.ShaderChunk[ "lightmap_pars_vertex" ],
 			THREE.ShaderChunk[ "envmap_pars_vertex" ],
@@ -63,6 +64,7 @@ THREE.ShaderLib = {
 			"uniform vec3 diffuse;",
 			"uniform float opacity;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "map_pars_fragment" ],
 			THREE.ShaderChunk[ "alphamap_pars_fragment" ],
@@ -126,6 +128,7 @@ THREE.ShaderLib = {
 
 			"#endif",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "map_pars_vertex" ],
 			THREE.ShaderChunk[ "lightmap_pars_vertex" ],
 			THREE.ShaderChunk[ "envmap_pars_vertex" ],
@@ -173,6 +176,7 @@ THREE.ShaderLib = {
 
 			"#endif",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "map_pars_fragment" ],
 			THREE.ShaderChunk[ "alphamap_pars_fragment" ],
@@ -252,6 +256,7 @@ THREE.ShaderLib = {
 			"varying vec3 vViewPosition;",
 			"varying vec3 vNormal;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "map_pars_vertex" ],
 			THREE.ShaderChunk[ "lightmap_pars_vertex" ],
 			THREE.ShaderChunk[ "envmap_pars_vertex" ],
@@ -303,6 +308,7 @@ THREE.ShaderLib = {
 			"uniform vec3 specular;",
 			"uniform float shininess;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "map_pars_fragment" ],
 			THREE.ShaderChunk[ "alphamap_pars_fragment" ],
@@ -357,6 +363,7 @@ THREE.ShaderLib = {
 			"uniform float size;",
 			"uniform float scale;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_vertex" ],
 			THREE.ShaderChunk[ "shadowmap_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
@@ -388,6 +395,7 @@ THREE.ShaderLib = {
 			"uniform vec3 psColor;",
 			"uniform float opacity;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "map_particle_pars_fragment" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
@@ -433,6 +441,7 @@ THREE.ShaderLib = {
 
 			"varying float vLineDistance;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
@@ -461,6 +470,7 @@ THREE.ShaderLib = {
 
 			"varying float vLineDistance;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
@@ -497,6 +507,7 @@ THREE.ShaderLib = {
 
 		vertexShader: [
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
@@ -516,6 +527,7 @@ THREE.ShaderLib = {
 			"uniform float mFar;",
 			"uniform float opacity;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"void main() {",
@@ -553,6 +565,7 @@ THREE.ShaderLib = {
 
 			"varying vec3 vNormal;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
@@ -573,6 +586,7 @@ THREE.ShaderLib = {
 			"uniform float opacity;",
 			"varying vec3 vNormal;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"void main() {",
@@ -642,6 +656,7 @@ THREE.ShaderLib = {
 
 		fragmentShader: [
 
+
 			"uniform vec3 ambient;",
 			"uniform vec3 diffuse;",
 			"uniform vec3 specular;",
@@ -671,6 +686,8 @@ THREE.ShaderLib = {
 			"varying vec2 vUv;",
 
 			"uniform vec3 ambientLightColor;",
+
+			THREE.ShaderChunk[ "common" ],
 
 			"#if MAX_DIR_LIGHTS > 0",
 
@@ -898,8 +915,7 @@ THREE.ShaderLib = {
 
 			"		for( int i = 0; i < MAX_DIR_LIGHTS; i++ ) {",
 
-			"			vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );",
-			"			vec3 dirVector = normalize( lDirection.xyz );",
+			"			vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );",
 
 						// diffuse
 
@@ -942,8 +958,7 @@ THREE.ShaderLib = {
 
 			"		for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {",
 
-			"			vec4 lDirection = viewMatrix * vec4( hemisphereLightDirection[ i ], 0.0 );",
-			"			vec3 lVector = normalize( lDirection.xyz );",
+			"			vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );",
 
 						// diffuse
 
@@ -1083,6 +1098,7 @@ THREE.ShaderLib = {
 			"varying vec3 vWorldPosition;",
 			"varying vec3 vViewPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "skinning_pars_vertex" ],
 			THREE.ShaderChunk[ "shadowmap_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
@@ -1215,12 +1231,12 @@ THREE.ShaderLib = {
 
 			"varying vec3 vWorldPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
 			"void main() {",
 
-			"	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
-			"	vWorldPosition = worldPosition.xyz;",
+			"	vec4 worldPosition = transformNormal( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
@@ -1237,6 +1253,7 @@ THREE.ShaderLib = {
 
 			"varying vec3 vWorldPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"void main() {",
@@ -1264,12 +1281,12 @@ THREE.ShaderLib = {
 
 			"varying vec3 vWorldPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
 
 			"void main() {",
 
-			"	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
-			"	vWorldPosition = worldPosition.xyz;",
+			"	vec4 worldPosition = transformNormal( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
@@ -1286,6 +1303,7 @@ THREE.ShaderLib = {
 
 			"varying vec3 vWorldPosition;",
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"void main() {",
@@ -1293,8 +1311,8 @@ THREE.ShaderLib = {
 				// "	gl_FragColor = textureCube( tCube, vec3( tFlip * vWorldPosition.x, vWorldPosition.yz ) );",
 				"vec3 direction = normalize( vWorldPosition );",
 				"vec2 sampleUV;",
-				"sampleUV.y = clamp( tFlip * direction.y * -0.5 + 0.5, 0.0, 1.0);",
-				"sampleUV.x = atan( direction.z, direction.x ) * 0.15915494309189533576888376337251 + 0.5;", // reciprocal( 2 PI ) + 0.5
+				"sampleUV.y = saturate( tFlip * direction.y * -0.5 + 0.5 );",
+				"sampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_2PI + 0.5;", 
 				"gl_FragColor = texture2D( tEquirect, sampleUV );",
 
 				THREE.ShaderChunk[ "logdepthbuf_fragment" ],
@@ -1323,6 +1341,7 @@ THREE.ShaderLib = {
 
 		vertexShader: [
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "skinning_pars_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
@@ -1341,6 +1360,7 @@ THREE.ShaderLib = {
 
 		fragmentShader: [
 
+			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
 
 			"vec4 pack_depth( const in float depth ) {",

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -915,7 +915,7 @@ THREE.ShaderLib = {
 
 			"		for( int i = 0; i < MAX_DIR_LIGHTS; i++ ) {",
 
-			"			vec3 dirVector = transformNormal( directionalLightDirection[ i ], viewMatrix );",
+			"			vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );",
 
 						// diffuse
 
@@ -958,7 +958,7 @@ THREE.ShaderLib = {
 
 			"		for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {",
 
-			"			vec3 lVector = transformNormal( hemisphereLightDirection[ i ], viewMatrix );",
+			"			vec3 lVector = transformDirection( hemisphereLightDirection[ i ], viewMatrix );",
 
 						// diffuse
 
@@ -1236,7 +1236,7 @@ THREE.ShaderLib = {
 
 			"void main() {",
 
-			"	vWorldPosition = transformNormal( position, modelMatrix );",
+			"	vWorldPosition = transformDirection( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
@@ -1286,7 +1286,7 @@ THREE.ShaderLib = {
 
 			"void main() {",
 
-			"	vWorldPosition = transformNormal( position, modelMatrix );",
+			"	vWorldPosition = transformDirection( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -1236,7 +1236,7 @@ THREE.ShaderLib = {
 
 			"void main() {",
 
-			"	vec4 worldPosition = transformNormal( position, modelMatrix );",
+			"	vWorldPosition = transformNormal( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
@@ -1286,7 +1286,7 @@ THREE.ShaderLib = {
 
 			"void main() {",
 
-			"	vec4 worldPosition = transformNormal( position, modelMatrix );",
+			"	vWorldPosition = transformNormal( position, modelMatrix );",
 
 			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -135,6 +135,8 @@ THREE.WebGLProgram = ( function () {
 
 		}
 
+		var gammaFactorDefine = ( renderer.gammaFactor > 0 ) ? renderer.gammaFactor : 1.0;
+
 		// console.log( "building new program " );
 
 		//
@@ -165,7 +167,7 @@ THREE.WebGLProgram = ( function () {
 
 				_this.gammaInput ? "#define GAMMA_INPUT" : "",
 				_this.gammaOutput ? "#define GAMMA_OUTPUT" : "",
-				"#define GAMMA_FACTOR " + this.renderer.gammaFactor,
+				"#define GAMMA_FACTOR " + gammaFactorDefine,
 
 				"#define MAX_DIR_LIGHTS " + parameters.maxDirLights,
 				"#define MAX_POINT_LIGHTS " + parameters.maxPointLights,
@@ -280,7 +282,7 @@ THREE.WebGLProgram = ( function () {
 
 				_this.gammaInput ? "#define GAMMA_INPUT" : "",
 				_this.gammaOutput ? "#define GAMMA_OUTPUT" : "",
-				"#define GAMMA_FACTOR " + this.renderer.gammaFactor,
+				"#define GAMMA_FACTOR " + gammaFactorDefine,
 
 				( parameters.useFog && parameters.fog ) ? "#define USE_FOG" : "",
 				( parameters.useFog && parameters.fogExp ) ? "#define FOG_EXP2" : "",

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -165,6 +165,7 @@ THREE.WebGLProgram = ( function () {
 
 				_this.gammaInput ? "#define GAMMA_INPUT" : "",
 				_this.gammaOutput ? "#define GAMMA_OUTPUT" : "",
+				"#define GAMMA_FACTOR " + this.renderer.gammaFactor,
 
 				"#define MAX_DIR_LIGHTS " + parameters.maxDirLights,
 				"#define MAX_POINT_LIGHTS " + parameters.maxPointLights,
@@ -279,6 +280,7 @@ THREE.WebGLProgram = ( function () {
 
 				_this.gammaInput ? "#define GAMMA_INPUT" : "",
 				_this.gammaOutput ? "#define GAMMA_OUTPUT" : "",
+				"#define GAMMA_FACTOR " + this.renderer.gammaFactor,
 
 				( parameters.useFog && parameters.fog ) ? "#define USE_FOG" : "",
 				( parameters.useFog && parameters.fogExp ) ? "#define FOG_EXP2" : "",

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -83,6 +83,7 @@
 	"src/scenes/Fog.js",
 	"src/scenes/FogExp2.js",
 	"src/renderers/shaders/ShaderChunk.js",
+	"src/renderers/shaders/ShaderChunk/common.glsl",
 	"src/renderers/shaders/ShaderChunk/alphatest_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl",
 	"src/renderers/shaders/ShaderChunk/map_particle_pars_fragment.glsl",


### PR DESCRIPTION
This builds upon the [common.glsl PR here](https://github.com/mrdoob/three.js/pull/5785).  This implements the idea expressed [here](https://github.com/mrdoob/three.js/pull/5785#issuecomment-68302484) and subsequently endorsed by @WestLangley.

This add the variable `WebGLRenderer.gammaFactor` which is correctly propagated to shaders as the define `GAMMA_FACTOR`.  I have moved the conditional application of gamma correction to two helper functions within common.glsl `inputToLinear` and `linearToOutput`, instead of having it spread across a lot of shader files.

I have also changed both `THREE.Color.copyLinearToGamma()` and `THREE.Color.copyGammaToLinear()` to take the gamma exponential as an optional parameter.

I have made the code backwards compatible by defaulting the gamma correction factor to 2.0, which matches the approximation used by the square()/sqrt() methods.  (Although a better default would be 2.2, which matches the sRGB standard: https://en.wikipedia.org/wiki/SRGB -- pointed out by @WestLangley.)

Lastly, I have added a "gammaFactor" control to the webgl_shader_physical.html example, but I need to somehow force the shaders to recompile -- if someone could give me a hint on the easy way to do that, it would be greatly appreciated.
