### PR TITLE
make logging optional for webgl renderer

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -7,9 +7,12 @@
 
 THREE.WebGLRenderer = function ( parameters ) {
 
-	console.log( 'THREE.WebGLRenderer', THREE.REVISION );
-
 	parameters = parameters || {};
+
+	var _logging = parameters.logging !== undefined ? parameters.logging : true;
+	if(_logging) {
+		console.log( 'THREE.WebGLRenderer', THREE.REVISION );
+	}
 
 	var _canvas = parameters.canvas !== undefined ? parameters.canvas : document.createElement( 'canvas' ),
 	_context = parameters.context !== undefined ? parameters.context : null,


### PR DESCRIPTION
Adds a `logging` parameter to the WebGL renderer.

Useful for situations where you don't want logging at all such as production or in a testing environment. Retains `true` as default but would think `false`would be a better option? 
