### PR TITLE
Improve ability to detect the format of a STL file

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -68,8 +68,9 @@ THREE.STLLoader.prototype = {
 				
 			}
 
+			// some binary files will have different size from expected,
+			// checking characters higher than ASCII to confirm is binary
 			var fileLength = reader.byteLength;
-
 			for ( var index = 0; index < fileLength; index ++ ) {
 
 				if ( reader.getUint8(index, false) > 127 ) {

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -61,7 +61,26 @@ THREE.STLLoader.prototype = {
 			face_size = (32 / 8 * 3) + ((32 / 8 * 3) * 3) + (16 / 8);
 			n_faces = reader.getUint32(80,true);
 			expect = 80 + (32 / 8) + (n_faces * face_size);
-			return expect === reader.byteLength;
+			
+			if ( expect === reader.byteLength ) {
+				
+				return true;
+				
+			}
+
+			var fileLength = reader.byteLength;
+
+			for ( var index = 0; index < fileLength; index ++ ) {
+
+				if ( reader.getUint8(index, false) > 127 ) {
+					
+					return true;
+					
+				}
+
+			}
+
+			return false;
 
 		};
 


### PR DESCRIPTION
Try to resolve #5734.

For some reason, few binary STL files will have larger size than the value calculated based on metadata, causing them to be recognized as ASCII ones. To detect those files, a byte-by-byte check loop is added, it tries to find a non-ASCII character byte, if any is found, this file will be recognized as binary format.

The additional checking process slightly affected the loading time of ASCII files, for example a 78MB ASCII file will need 3 more seconds to go through the loop using a computer manufactured in 2012. However most mesh in this size will be encoded in binary format, so large ASCII file is uncommon.
