### PR TITLE
Fix StereoEffect so it actually clips correctly

### DIFF
--- a/examples/js/effects/StereoEffect.js
+++ b/examples/js/effects/StereoEffect.js
@@ -122,14 +122,18 @@ THREE.StereoEffect = function ( renderer ) {
 
 		//
 
-		renderer.setViewport( 0, 0, _width * 2, _height );
 		renderer.clear();
+		renderer.enableScissorTest( true );
 
+		renderer.setScissor( 0, 0, _width, _height );
 		renderer.setViewport( 0, 0, _width, _height );
 		renderer.render( scene, _cameraL );
 
+		renderer.setScissor( _width, 0, _width, _height );
 		renderer.setViewport( _width, 0, _width, _height );
 		renderer.render( scene, _cameraR );
+
+		renderer.enableScissorTest( false );
 
 	};
 


### PR DESCRIPTION
Line and point rasterization is not clipped by gl.viewport,
gl.viewport only clips vertex calculations. If a vertex is
on the edge of the viewport (so it's not clipped) but it's
being turned into a `POINT`, and say `gl_PointSize = 16` then
 that point will get rendered partially outside the viewport.

Also gl.clear is not affected by viewport settings, only scissor
settings so there's no reason to change the viewport to clear.
