### PR TITLE
THREE.PointCloud offsets fix

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2690,7 +2690,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 						var startIndex = offsets[ i ].index;
 
-						_gl.drawArrays( mode, 0, offsets[ i ].count );
+						_gl.drawArrays( mode, startIndex, offsets[ i ].count );
 
 						_this.info.render.calls ++;
 						_this.info.render.points += offsets[ i ].count;


### PR DESCRIPTION
Hi Ricardo,
I fixed particle drawing with offsets always starting at 0 index. Looks like it was copy'n'paste typo.
