### PR TITLE
THREE.Line offsets fix

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2688,9 +2688,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					for ( var i = 0, il = offsets.length; i < il; i ++ ) {
 
-						var startIndex = offsets[ i ].index;
-
-						_gl.drawArrays( mode, startIndex, offsets[ i ].count );
+						_gl.drawArrays( mode, offsets[ i ].index, offsets[ i ].count );
 
 						_this.info.render.calls ++;
 						_this.info.render.points += offsets[ i ].count;
@@ -2797,9 +2795,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					for ( var i = 0, il = offsets.length; i < il; i ++ ) {
 
-						var startIndex = offsets[ i ].index;
-
-						_gl.drawArrays( mode, 0, offsets[ i ].count );
+						_gl.drawArrays( mode, offsets[ i ].index, offsets[ i ].count );
 
 						_this.info.render.calls ++;
 						_this.info.render.vertices += offsets[ i ].count;


### PR DESCRIPTION
Fixed non-indexed line arrays not using offset start index. Also removed needless variable assignment from THREE.Line case and THREE.PointCloud case.
