### PR TITLE
Fixed `fov` parsing

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1248,8 +1248,11 @@ THREE.ColladaLoader = function () {
 			var instance_camera = node.cameras[i];
 			var cparams = cameras[instance_camera.url];
 
-			var cam = new THREE.PerspectiveCamera(cparams.yfov, parseFloat(cparams.aspect_ratio),
-					parseFloat(cparams.znear), parseFloat(cparams.zfar));
+			var cam = new THREE.PerspectiveCamera(
+				parseFloat(cparams.xfov || cparams.yfov),
+				parseFloat(cparams.aspect_ratio),
+				parseFloat(cparams.znear),
+				parseFloat(cparams.zfar));
 
 			obj.add(cam);
 		}


### PR DESCRIPTION
Changed `cparams.yfov` to `parseFloat(cparams.xfov || cparams.yfov)`.

Collada files exported from Cinema 4D use an `<xfov>` tag to specify the FOV of cameras within a scene. Both `xfov` and `yfov`are parsed in the `parseOptics` function, but they are not correctly passed onto the `PerspectiveCamera` constructor, so new instances default to an FOV of `50`.

This update resolves this issue.
