### PR TITLE
Add line segment index which was intersected with raycast

### DIFF
--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -100,6 +100,8 @@ THREE.Line.prototype.raycast = ( function () {
 							// What do we want? intersection point on the ray or on the segment??
 							// point: raycaster.ray.at( distance ),
 							point: interSegment.clone().applyMatrix4( this.matrixWorld ),
+							index: i,
+							offsetIndex: oi,
 							face: null,
 							faceIndex: null,
 							object: this
@@ -133,6 +135,7 @@ THREE.Line.prototype.raycast = ( function () {
 						// What do we want? intersection point on the ray or on the segment??
 						// point: raycaster.ray.at( distance ),
 						point: interSegment.clone().applyMatrix4( this.matrixWorld ),
+						index: i,
 						face: null,
 						faceIndex: null,
 						object: this
@@ -164,6 +167,7 @@ THREE.Line.prototype.raycast = ( function () {
 					// What do we want? intersection point on the ray or on the segment??
 					// point: raycaster.ray.at( distance ),
 					point: interSegment.clone().applyMatrix4( this.matrixWorld ),
+					index: i,
 					face: null,
 					faceIndex: null,
 					object: this


### PR DESCRIPTION
I would like to suggest including the index of the intersected line segment(similar as in PointCloud). As information of the exact line segment is quite useful. Related: #3708, #3692
