### PR TITLE
added new function readRenderTargetPixels to WebGLRenderer

### DIFF
--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -203,12 +203,11 @@
 
 				renderer.render( pickingScene, camera, pickingTexture );
 
-				var gl = self.renderer.getContext();
+				//create buffer for reading single pixel
+				var pixelBuffer = new Uint8Array( 4 );
 
 				//read the pixel under the mouse from the texture
-
-				var pixelBuffer = new Uint8Array( 4 );
-				gl.readPixels( mouse.x, pickingTexture.height - mouse.y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixelBuffer );
+				renderer.readRenderTargetPixels(pickingTexture, mouse.x, pickingTexture.height - mouse.y, 1, 1, pixelBuffer);
 
 				//interpret the pixel as an ID
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -6176,31 +6176,52 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	};
 
-	//Read pixels from RGBA rendertarget.
-	this.readRenderTargetPixels = function(renderTarget, x, y, width, height, buffer) {
+	this.readRenderTargetPixels = function( renderTarget, x, y, width, height, buffer ) {
 
-		if(!(renderTarget && renderTarget instanceof THREE.WebGLRenderTarget))
-			throw new Error( 'renderTarget is not THREE.WebGLRenderTarget!' );
+	    if ( ! ( renderTarget instanceof THREE.WebGLRenderTarget ) ) {
 
-		if(renderTarget.__webglFramebuffer) {
+	        console.error( 'THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not THREE.WebGLRenderTarget.' );
+	        return;
 
-			if(renderTarget.format !== THREE.RGBAFormat)
-				throw new Error( 'Rendertarget is not in RGBA format. readPixels can read only RGBA format!' );
+	    }
 
-			var restore = false;
-			if ( renderTarget.__webglFramebuffer !== _currentFramebuffer ) {
-				_gl.bindFramebuffer(_gl.FRAMEBUFFER, renderTarget.__webglFramebuffer);
-				restore = true;
-			}
+	    if ( renderTarget.__webglFramebuffer ) {
 
-			if (_gl.checkFramebufferStatus(_gl.FRAMEBUFFER) === _gl.FRAMEBUFFER_COMPLETE)
-				_gl.readPixels(x, y, width, height, paramThreeToGL(renderTarget.format), _gl.UNSIGNED_BYTE, buffer);
-			else
-				throw new Error( 'readPixels from rendertarget failed. Framebuffer not complete!' );
+	        if ( renderTarget.format !== THREE.RGBAFormat ) {
 
-			if(restore)
-				_gl.bindFramebuffer(_gl.FRAMEBUFFER, _currentFramebuffer);
-		}
+	            console.error( 'THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA format. readPixels can read only RGBA format.' );
+	            return;
+
+	        }
+
+	        var restore = false;
+
+	        if ( renderTarget.__webglFramebuffer !== _currentFramebuffer ) {
+
+	            _gl.bindFramebuffer( _gl.FRAMEBUFFER, renderTarget.__webglFramebuffer );
+
+	            restore = true;
+
+	        }
+
+	        if ( _gl.checkFramebufferStatus( _gl.FRAMEBUFFER ) === _gl.FRAMEBUFFER_COMPLETE ) {
+
+	            _gl.readPixels( x, y, width, height, _gl.RGBA, _gl.UNSIGNED_BYTE, buffer );
+
+	        } else {
+
+	            console.error( 'THREE.WebGLRenderer.readRenderTargetPixels: readPixels from renderTarget failed. Framebuffer not complete.' );
+
+	        }
+
+	        if ( restore ) {
+
+	            _gl.bindFramebuffer( _gl.FRAMEBUFFER, _currentFramebuffer );
+
+	        }
+
+	    }
+
 	};
 
 	function updateRenderTargetMipmap ( renderTarget ) {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -6176,6 +6176,33 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	};
 
+	//Read pixels from RGBA rendertarget.
+	this.readRenderTargetPixels = function(renderTarget, x, y, width, height, buffer) {
+
+		if(!(renderTarget && renderTarget instanceof THREE.WebGLRenderTarget))
+			throw new Error( 'renderTarget is not THREE.WebGLRenderTarget!' );
+
+		if(renderTarget.__webglFramebuffer) {
+
+			if(renderTarget.format !== THREE.RGBAFormat)
+				throw new Error( 'Rendertarget is not in RGBA format. readPixels can read only RGBA format!' );
+
+			var restore = false;
+			if ( renderTarget.__webglFramebuffer !== _currentFramebuffer ) {
+				_gl.bindFramebuffer(_gl.FRAMEBUFFER, renderTarget.__webglFramebuffer);
+				restore = true;
+			}
+
+			if (_gl.checkFramebufferStatus(_gl.FRAMEBUFFER) === _gl.FRAMEBUFFER_COMPLETE)
+				_gl.readPixels(x, y, width, height, paramThreeToGL(renderTarget.format), _gl.UNSIGNED_BYTE, buffer);
+			else
+				throw new Error( 'readPixels from rendertarget failed. Framebuffer not complete!' );
+
+			if(restore)
+				_gl.bindFramebuffer(_gl.FRAMEBUFFER, _currentFramebuffer);
+		}
+	};
+
 	function updateRenderTargetMipmap ( renderTarget ) {
 
 		if ( renderTarget instanceof THREE.WebGLRenderTargetCube ) {


### PR DESCRIPTION
The function copies RGBA pixels from WebGLRenderTarget to unsigned byte array. Array must be of a size 4 \* width \* height.
This is useful when doing offscreen rendering and you need to access pixels directly.
Also it is useful when doing windowless rendering (i.e. using node.js) - then this is the only way to get rendered image.

included code refactoring from WestLangley 
