### PR TITLE
editor: sidebar tabs design

### DIFF
--- a/editor/css/dark.css
+++ b/editor/css/dark.css
@@ -147,8 +147,8 @@ input.Number {
 
 	#sidebar > .Panel {
 		color: #888;
-		padding: 10px;
-		border-top: 1px solid #333;
+        padding: 1px;
+		/* border-top: 1px solid #333; */
 	}
 
 	#sidebar #outliner {

--- a/editor/css/dark.css
+++ b/editor/css/dark.css
@@ -147,13 +147,12 @@ input.Number {
 
 	#sidebar > .Panel {
 		color: #888;
-        padding: 1px;
+		padding: 1px;
 		/* border-top: 1px solid #333; */
 	}
 
 	#sidebar #outliner {
 		width: 100%;
-		height: 140px;
 		color: #868686;
 		font-size: 12px;
 	}

--- a/editor/css/light.css
+++ b/editor/css/light.css
@@ -148,8 +148,8 @@ input.Number {
 
 	#sidebar > .Panel {
 		color: #888;
-		padding: 10px;
-		border-top: 1px solid #ccc;
+		padding: 1px;
+		/* border-top: 1px solid #ccc; */
 	}
 
 	#sidebar #outliner {

--- a/editor/css/light.css
+++ b/editor/css/light.css
@@ -154,7 +154,6 @@ input.Number {
 
 	#sidebar #outliner {
 		width: 100%;
-		height: 140px;
 		color: #444;
 		font-size: 12px;
 	}

--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -128,3 +128,56 @@ textarea, input { outline: none; } /* osx */
 .MeshPhongMaterial {
 	color: #ffaa88;
 }
+
+/* tab styling */
+
+.tabs input[type=radio] {
+    display:none;
+}
+
+.tabs {
+    float: none;
+    list-style: none;
+    position: relative;
+    padding: 0;
+}
+
+.tabs div.Panel.tab {
+    float: left;
+}
+
+.tabs label {
+    display: block;
+    padding: 5px 5px;
+    /*margin: 1px;*/
+    font-weight: normal;
+    background: #2c3e50;
+    cursor: pointer;
+    position: relative;
+}
+
+.tabs label:hover {
+    background: #3498db;
+}
+
+.tab-content {
+    z-index: 2;
+    display: none;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    padding: 15px;
+    position: absolute;
+    box-sizing: border-box;
+    border:1px solid #ccc;
+}
+
+[id^=tab]:checked + label {
+    background: #08C;
+    color: white;
+    top: 0;
+}
+
+[id^=tab]:checked ~ [id^=tab-content] {
+    display: block;
+}

--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -129,55 +129,53 @@ textarea, input { outline: none; } /* osx */
 	color: #ffaa88;
 }
 
-/* tab styling */
+/* tabs */
 
 .tabs input[type=radio] {
-    display:none;
+	display:none;
 }
 
 .tabs {
-    float: none;
-    list-style: none;
-    position: relative;
-    padding: 0;
+	float: none;
+	list-style: none;
+	position: relative;
+	padding: 0;
 }
 
 .tabs div.Panel.tab {
-    float: left;
+	float: left;
 }
 
 .tabs label {
-    display: block;
-    padding: 5px 5px;
-    /*margin: 1px;*/
-    font-weight: normal;
-    background: #2c3e50;
-    cursor: pointer;
-    position: relative;
+	display: block;
+	padding: 5px 5px;
+	font-weight: normal;
+	background: #2c3e50;
+	cursor: pointer;
+	position: relative;
 }
 
 .tabs label:hover {
-    background: #3498db;
+	background: #3498db;
 }
 
 .tab-content {
-    z-index: 2;
-    display: none;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    padding: 15px;
-    position: absolute;
-    box-sizing: border-box;
-    border:1px solid #ccc;
+	z-index: 2;
+	display: none;
+	left: 0;
+	height: 100%;
+	width: 100%;
+	padding: 5px;
+	position: absolute;
+	box-sizing: border-box;
 }
 
 [id^=tab]:checked + label {
-    background: #08C;
-    color: white;
-    top: 0;
+	background: #08C;
+	color: white;
+	top: 0;
 }
 
 [id^=tab]:checked ~ [id^=tab-content] {
-    display: block;
+	display: block;
 }

--- a/editor/js/Sidebar.Object3D.js
+++ b/editor/js/Sidebar.Object3D.js
@@ -6,18 +6,12 @@ Sidebar.Object3D = function ( editor ) {
 
 	var signals = editor.signals;
 
-	var container = new UI.CollapsiblePanel();
-	container.setCollapsed( editor.config.getKey( 'ui/sidebar/object3d/collapsed' ) );
-	container.onCollapsedChange( function ( boolean ) {
+    var container = new UI.Panel().setClass( 'Panel tab' );
 
-		editor.config.setKey( 'ui/sidebar/object3d/collapsed', boolean );
+    container.add( new UI.Radio('tabs', 'tab-object3d', false) );
+    container.add( new UI.Label('Obj3D', 'tab-object3d') );
 
-	} );
-	container.setDisplay( 'none' );
-
-	var objectType = new UI.Text().setTextTransform( 'uppercase' );
-	container.addStatic( objectType );
-	container.add( new UI.Break() );
+    var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-object3d' );
 
 	// uuid
 
@@ -35,7 +29,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectUUIDRow.add( objectUUID );
 	objectUUIDRow.add( objectUUIDRenew );
 
-	container.add( objectUUIDRow );
+	containercontent.add( objectUUIDRow );
 
 	// name
 
@@ -49,7 +43,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectNameRow.add( new UI.Text( 'Name' ).setWidth( '90px' ) );
 	objectNameRow.add( objectName );
 
-	container.add( objectNameRow );
+	containercontent.add( objectNameRow );
 
 	// parent
 
@@ -59,7 +53,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectParentRow.add( new UI.Text( 'Parent' ).setWidth( '90px' ) );
 	objectParentRow.add( objectParent );
 
-	container.add( objectParentRow );
+	containercontent.add( objectParentRow );
 
 	// position
 
@@ -71,7 +65,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectPositionRow.add( new UI.Text( 'Position' ).setWidth( '90px' ) );
 	objectPositionRow.add( objectPositionX, objectPositionY, objectPositionZ );
 
-	container.add( objectPositionRow );
+	containercontent.add( objectPositionRow );
 
 	// rotation
 
@@ -83,7 +77,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectRotationRow.add( new UI.Text( 'Rotation' ).setWidth( '90px' ) );
 	objectRotationRow.add( objectRotationX, objectRotationY, objectRotationZ );
 
-	container.add( objectRotationRow );
+	containercontent.add( objectRotationRow );
 
 	// scale
 
@@ -97,7 +91,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectScaleRow.add( objectScaleLock );
 	objectScaleRow.add( objectScaleX, objectScaleY, objectScaleZ );
 
-	container.add( objectScaleRow );
+	containercontent.add( objectScaleRow );
 
 	// fov
 
@@ -107,7 +101,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectFovRow.add( new UI.Text( 'Fov' ).setWidth( '90px' ) );
 	objectFovRow.add( objectFov );
 
-	container.add( objectFovRow );
+	containercontent.add( objectFovRow );
 
 	// near
 
@@ -117,7 +111,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectNearRow.add( new UI.Text( 'Near' ).setWidth( '90px' ) );
 	objectNearRow.add( objectNear );
 
-	container.add( objectNearRow );
+	containercontent.add( objectNearRow );
 
 	// far
 
@@ -127,7 +121,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectFarRow.add( new UI.Text( 'Far' ).setWidth( '90px' ) );
 	objectFarRow.add( objectFar );
 
-	container.add( objectFarRow );
+	containercontent.add( objectFarRow );
 
 	// intensity
 
@@ -137,7 +131,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectIntensityRow.add( new UI.Text( 'Intensity' ).setWidth( '90px' ) );
 	objectIntensityRow.add( objectIntensity );
 
-	container.add( objectIntensityRow );
+	containercontent.add( objectIntensityRow );
 
 	// color
 
@@ -147,7 +141,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectColorRow.add( new UI.Text( 'Color' ).setWidth( '90px' ) );
 	objectColorRow.add( objectColor );
 
-	container.add( objectColorRow );
+	containercontent.add( objectColorRow );
 
 	// ground color
 
@@ -157,7 +151,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectGroundColorRow.add( new UI.Text( 'Ground color' ).setWidth( '90px' ) );
 	objectGroundColorRow.add( objectGroundColor );
 
-	container.add( objectGroundColorRow );
+	containercontent.add( objectGroundColorRow );
 
 	// distance
 
@@ -167,7 +161,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectDistanceRow.add( new UI.Text( 'Distance' ).setWidth( '90px' ) );
 	objectDistanceRow.add( objectDistance );
 
-	container.add( objectDistanceRow );
+	containercontent.add( objectDistanceRow );
 
 	// angle
 
@@ -177,7 +171,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectAngleRow.add( new UI.Text( 'Angle' ).setWidth( '90px' ) );
 	objectAngleRow.add( objectAngle );
 
-	container.add( objectAngleRow );
+	containercontent.add( objectAngleRow );
 
 	// exponent
 
@@ -187,7 +181,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectExponentRow.add( new UI.Text( 'Exponent' ).setWidth( '90px' ) );
 	objectExponentRow.add( objectExponent );
 
-	container.add( objectExponentRow );
+	containercontent.add( objectExponentRow );
 
 	// visible
 
@@ -197,7 +191,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectVisibleRow.add( new UI.Text( 'Visible' ).setWidth( '90px' ) );
 	objectVisibleRow.add( objectVisible );
 
-	container.add( objectVisibleRow );
+	containercontent.add( objectVisibleRow );
 
 	// user data
 
@@ -226,7 +220,7 @@ Sidebar.Object3D = function ( editor ) {
 	objectUserDataRow.add( new UI.Text( 'User data' ).setWidth( '90px' ) );
 	objectUserDataRow.add( objectUserData );
 
-	container.add( objectUserDataRow );
+	containercontent.add( objectUserDataRow );
 
 
 	//
@@ -431,14 +425,14 @@ Sidebar.Object3D = function ( editor ) {
 
 		if ( object !== null ) {
 
-			container.setDisplay( 'block' );
+			//containercontent.setDisplay( 'block' );
 
 			updateRows( object );
 			updateUI( object );
 
 		} else {
 
-			container.setDisplay( 'none' );
+			containercontent.setDisplay( 'none' );
 
 		}
 
@@ -564,6 +558,8 @@ Sidebar.Object3D = function ( editor ) {
 		updateTransformRows( object );
 
 	}
+
+    container.add( containercontent );
 
 	return container;
 

--- a/editor/js/Sidebar.Object3D.js
+++ b/editor/js/Sidebar.Object3D.js
@@ -6,12 +6,12 @@ Sidebar.Object3D = function ( editor ) {
 
 	var signals = editor.signals;
 
-    var container = new UI.Panel().setClass( 'Panel tab' );
+	var container = new UI.Panel().setClass( 'Panel tab' );
 
-    container.add( new UI.Radio('tabs', 'tab-object3d', false) );
-    container.add( new UI.Label('Obj3D', 'tab-object3d') );
+	container.add( new UI.Radio( 'tabs' ).setId( 'tab-object3d' ) );
+	container.add( new UI.Label( 'Obj3D' ).setFor( 'tab-object3d' ) );
 
-    var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-object3d' );
+	var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-object3d' );
 
 	// uuid
 
@@ -559,7 +559,7 @@ Sidebar.Object3D = function ( editor ) {
 
 	}
 
-    container.add( containercontent );
+	container.add( containercontent );
 
 	return container;
 

--- a/editor/js/Sidebar.Renderer.js
+++ b/editor/js/Sidebar.Renderer.js
@@ -16,16 +16,12 @@ Sidebar.Renderer = function ( editor ) {
 
 	};
 
-	var container = new UI.CollapsiblePanel();
-	container.setCollapsed( editor.config.getKey( 'ui/sidebar/renderer/collapsed' ) );
-	container.onCollapsedChange( function ( boolean ) {
+	var container = new UI.Panel().setClass( 'Panel tab' );
 
-		editor.config.setKey( 'ui/sidebar/renderer/collapsed', boolean );
+	container.add( new UI.Radio('tabs', 'tab-renderer', true) );
+    container.add( new UI.Label('Renderer', 'tab-renderer') );
 
-	} );
-
-	container.addStatic( new UI.Text( 'RENDERER' ) );
-	container.add( new UI.Break() );
+	var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-renderer' );
 
 	// class
 
@@ -50,7 +46,7 @@ Sidebar.Renderer = function ( editor ) {
 	rendererTypeRow.add( new UI.Text( 'Type' ).setWidth( '90px' ) );
 	rendererTypeRow.add( rendererType );
 
-	container.add( rendererTypeRow );
+	containercontent.add( rendererTypeRow );
 
 	if ( editor.config.getKey( 'renderer' ) !== undefined ) {
 
@@ -71,7 +67,7 @@ Sidebar.Renderer = function ( editor ) {
 	rendererAntialiasRow.add( new UI.Text( 'Antialias' ).setWidth( '90px' ) );
 	rendererAntialiasRow.add( rendererAntialias );
 
-	container.add( rendererAntialiasRow );
+	containercontent.add( rendererAntialiasRow );
 
 	//
 
@@ -80,6 +76,8 @@ Sidebar.Renderer = function ( editor ) {
 		signals.rendererChanged.dispatch( rendererType.getValue(), rendererAntialias.getValue() );
 
 	}
+
+	container.add( containercontent );
 
 	return container;
 

--- a/editor/js/Sidebar.Renderer.js
+++ b/editor/js/Sidebar.Renderer.js
@@ -18,8 +18,8 @@ Sidebar.Renderer = function ( editor ) {
 
 	var container = new UI.Panel().setClass( 'Panel tab' );
 
-	container.add( new UI.Radio('tabs', 'tab-renderer', true) );
-    container.add( new UI.Label('Renderer', 'tab-renderer') );
+	container.add( new UI.Radio( 'tabs' ).setId( 'tab-renderer' ).setCheck() );
+	container.add( new UI.Label( 'Renderer' ).setFor( 'tab-renderer' ) );
 
 	var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-renderer' );
 

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -6,12 +6,12 @@ Sidebar.Scene = function ( editor ) {
 
 	var signals = editor.signals;
 
-    var container = new UI.Panel().setClass( 'Panel tab' );
+	var container = new UI.Panel().setClass( 'Panel tab' );
 
-    container.add( new UI.Radio('tabs', 'tab-scene', false) );
-    container.add( new UI.Label('Scene', 'tab-scene') );
+	container.add( new UI.Radio( 'tabs' ).setId( 'tab-scene' ) );
+	container.add( new UI.Label( 'Scene' ).setFor( 'tab-scene' ) );
 
-    var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-scene' );
+	var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-scene' );
 
 	var ignoreObjectSelectedSignal = false;
 
@@ -218,7 +218,7 @@ Sidebar.Scene = function ( editor ) {
 
 	} );
 
-    container.add( containercontent );
+	container.add( containercontent );
 
 	return container;
 

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -6,16 +6,12 @@ Sidebar.Scene = function ( editor ) {
 
 	var signals = editor.signals;
 
-	var container = new UI.CollapsiblePanel();
-	container.setCollapsed( editor.config.getKey( 'ui/sidebar/scene/collapsed' ) );
-	container.onCollapsedChange( function ( boolean ) {
+    var container = new UI.Panel().setClass( 'Panel tab' );
 
-		editor.config.setKey( 'ui/sidebar/scene/collapsed', boolean );
+    container.add( new UI.Radio('tabs', 'tab-scene', false) );
+    container.add( new UI.Label('Scene', 'tab-scene') );
 
-	} );
-
-	container.addStatic( new UI.Text( 'SCENE' ) );
-	container.add( new UI.Break() );
+    var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-scene' );
 
 	var ignoreObjectSelectedSignal = false;
 
@@ -34,8 +30,8 @@ Sidebar.Scene = function ( editor ) {
 		editor.focusById( parseInt( outliner.getValue() ) );
 
 	} );
-	container.add( outliner );
-	container.add( new UI.Break() );
+	containercontent.add( outliner );
+	containercontent.add( new UI.Break() );
 
 	// fog
 
@@ -69,7 +65,7 @@ Sidebar.Scene = function ( editor ) {
 	fogTypeRow.add( new UI.Text( 'Fog' ).setWidth( '90px' ) );
 	fogTypeRow.add( fogType );
 
-	container.add( fogTypeRow );
+	containercontent.add( fogTypeRow );
 
 	// fog color
 
@@ -86,7 +82,7 @@ Sidebar.Scene = function ( editor ) {
 	fogColorRow.add( new UI.Text( 'Fog color' ).setWidth( '90px' ) );
 	fogColorRow.add( fogColor );
 
-	container.add( fogColorRow );
+	containercontent.add( fogColorRow );
 
 	// fog near
 
@@ -98,7 +94,7 @@ Sidebar.Scene = function ( editor ) {
 	fogNearRow.add( new UI.Text( 'Fog near' ).setWidth( '90px' ) );
 	fogNearRow.add( fogNear );
 
-	container.add( fogNearRow );
+	containercontent.add( fogNearRow );
 
 	var fogFarRow = new UI.Panel();
 	fogFarRow.setDisplay( 'none' );
@@ -110,7 +106,7 @@ Sidebar.Scene = function ( editor ) {
 	fogFarRow.add( new UI.Text( 'Fog far' ).setWidth( '90px' ) );
 	fogFarRow.add( fogFar );
 
-	container.add( fogFarRow );
+	containercontent.add( fogFarRow );
 
 	// fog density
 
@@ -122,7 +118,7 @@ Sidebar.Scene = function ( editor ) {
 	fogDensityRow.add( new UI.Text( 'Fog density' ).setWidth( '90px' ) );
 	fogDensityRow.add( fogDensity );
 
-	container.add( fogDensityRow );
+	containercontent.add( fogDensityRow );
 
 	//
 
@@ -221,6 +217,8 @@ Sidebar.Scene = function ( editor ) {
 		outliner.setValue( object !== null ? object.id : null );
 
 	} );
+
+    container.add( containercontent );
 
 	return container;
 

--- a/editor/js/Sidebar.Script.js
+++ b/editor/js/Sidebar.Script.js
@@ -6,6 +6,14 @@ Sidebar.Script = function ( editor ) {
 
 	var signals = editor.signals;
 
+    var container = new UI.Panel().setClass( 'Panel tab' );
+
+    container.add( new UI.Radio('tabs', 'tab-script', false) );
+    container.add( new UI.Label('Script', 'tab-script') );
+
+    var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-script' );
+
+    /*
 	var container = new UI.CollapsiblePanel();
 	container.setCollapsed( editor.config.getKey( 'ui/sidebar/script/collapsed' ) );
 	container.onCollapsedChange( function ( boolean ) {
@@ -16,12 +24,13 @@ Sidebar.Script = function ( editor ) {
 	container.setDisplay( 'none' );
 
 	container.addStatic( new UI.Text( 'Script' ).setTextTransform( 'uppercase' ) );
-	container.add( new UI.Break() );
+	containercontent.add( new UI.Break() );
+    */
 
 	//
 
 	var scriptsContainer = new UI.Panel();
-	container.add( scriptsContainer );
+	containercontent.add( scriptsContainer );
 
 	var newScript = new UI.Button( 'New' );
 	newScript.onClick( function () {
@@ -30,7 +39,7 @@ Sidebar.Script = function ( editor ) {
 		editor.addScript( editor.selected, script );
 
 	} );
-	container.add( newScript );
+	containercontent.add( newScript );
 
 	/*
 	var loadScript = new UI.Button( 'Load' );
@@ -91,6 +100,7 @@ Sidebar.Script = function ( editor ) {
 
 			}
 
+            // containercontent.add( scriptsContainer );
 		}
 
 	}
@@ -101,13 +111,13 @@ Sidebar.Script = function ( editor ) {
 
 		if ( object !== null ) {
 
-			container.setDisplay( 'block' );
+			//containercontent.setDisplay( 'block' );
 
 			update();
 
 		} else {
 
-			container.setDisplay( 'none' );
+			containercontent.setDisplay( 'none' );
 
 		}
 
@@ -115,6 +125,8 @@ Sidebar.Script = function ( editor ) {
 
 	signals.scriptAdded.add( update );
 	signals.scriptRemoved.add( update );
+
+    container.add( containercontent );
 
 	return container;
 

--- a/editor/js/Sidebar.Script.js
+++ b/editor/js/Sidebar.Script.js
@@ -6,12 +6,12 @@ Sidebar.Script = function ( editor ) {
 
 	var signals = editor.signals;
 
-    var container = new UI.Panel().setClass( 'Panel tab' );
+	var container = new UI.Panel().setClass( 'Panel tab' );
 
-    container.add( new UI.Radio('tabs', 'tab-script', false) );
-    container.add( new UI.Label('Script', 'tab-script') );
+	container.add( new UI.Radio( 'tabs' ).setId( 'tab-script' ) );
+	container.add( new UI.Label( 'Script' ).setFor( 'tab-script' ) );
 
-    var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-script' );
+	var containercontent = new UI.Panel().setClass( 'Panel' ).setClass( 'Content tab-content' ).setId( 'tab-content-script' );
 
     /*
 	var container = new UI.CollapsiblePanel();
@@ -126,7 +126,7 @@ Sidebar.Script = function ( editor ) {
 	signals.scriptAdded.add( update );
 	signals.scriptRemoved.add( update );
 
-    container.add( containercontent );
+	container.add( containercontent );
 
 	return container;
 

--- a/editor/js/Sidebar.js
+++ b/editor/js/Sidebar.js
@@ -5,15 +5,20 @@
 var Sidebar = function ( editor ) {
 
 	var container = new UI.Panel();
-	container.setId( 'sidebar' );
+	container.setId( 'sidebar' ).setClass( 'Panel tabs' );
 
 	container.add( new Sidebar.Renderer( editor ) );
 	container.add( new Sidebar.Scene( editor ) );
+
+	container.add( new Sidebar.Script( editor ) );
+
 	container.add( new Sidebar.Object3D( editor ) );
+
+    /*
 	container.add( new Sidebar.Geometry( editor ) );
 	container.add( new Sidebar.Material( editor ) );
 	container.add( new Sidebar.Animation( editor ) );
-	container.add( new Sidebar.Script( editor ) );
+    */
 
 	return container;
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -670,7 +670,6 @@ UI.Label = function ( text ) {
 
 	this.dom = dom;
 	this.setValue( text );
-	//this.setFor( id );
 
 	return this;
 
@@ -709,8 +708,6 @@ UI.Label.prototype.setFor = function ( value ) {
 
 };
 
-
-
 // Radio
 
 UI.Radio = function ( name  ) {
@@ -722,11 +719,9 @@ UI.Radio = function ( name  ) {
 	var dom = document.createElement( 'input' );
 	dom.className = 'Radio';
 	dom.type = 'radio';
-	dom.name = name;
-	//dom.id = id;
 
 	this.dom = dom;
-	//this.setValue( boolean );
+	this.setValue( name );
 
 	return this;
 
@@ -745,7 +740,7 @@ UI.Radio.prototype.setValue = function ( value ) {
 
 	if ( value !== undefined ) {
 
-		this.dom.checked = value;
+		this.dom.name = value;
 
 	}
 
@@ -758,15 +753,11 @@ UI.Radio.prototype.setCheck = function ( value ) {
 	if ( value !== undefined ) {
 
 		this.dom.checked = '';
-		//dom.setAttribute('checked', '');
 	}
 
 	return this;
 
 };
-
-
-
 
 // Checkbox
 
@@ -807,7 +798,6 @@ UI.Checkbox.prototype.setValue = function ( value ) {
 	return this;
 
 };
-
 
 // Color
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -659,6 +659,104 @@ UI.FancySelect.prototype.setValue = function ( value ) {
 
 };
 
+// Label
+
+UI.Label = function ( text, forid ) {
+
+	UI.Element.call( this );
+
+	var dom = document.createElement( 'label' );
+	dom.className = 'Label';
+
+	this.dom = dom;
+	this.setValue( text );
+	this.setFor( forid );
+
+	return this;
+
+};
+
+UI.Label.prototype = Object.create( UI.Element.prototype );
+UI.Label.prototype.constructor = UI.Label;
+
+UI.Label.prototype.getValue = function () {
+
+	return this.dom.textContent;
+
+};
+
+UI.Label.prototype.setValue = function ( value ) {
+
+	if ( value !== undefined ) {
+
+		this.dom.textContent = value;
+
+	}
+
+	return this;
+
+};
+
+UI.Label.prototype.setFor = function ( value ) {
+
+	if ( value !== undefined ) {
+
+        this.dom.setAttribute('for', value);
+
+	}
+
+	return this;
+
+};
+
+
+
+// Radio
+
+UI.Radio = function ( name, id, boolean ) {
+
+	UI.Element.call( this );
+
+	var scope = this;
+
+	var dom = document.createElement( 'input' );
+	dom.className = 'Radio';
+	dom.type = 'radio';
+	dom.name = name;
+	dom.id = id;
+
+	this.dom = dom;
+	//this.setValue( boolean );
+
+    if ( boolean ) {
+        dom.setAttribute('checked', '');
+    }
+
+	return this;
+
+};
+
+UI.Radio.prototype = Object.create( UI.Element.prototype );
+UI.Radio.prototype.constructor = UI.Radio;
+
+UI.Radio.prototype.getValue = function () {
+
+	return this.dom.checked;
+
+};
+
+UI.Radio.prototype.setValue = function ( value ) {
+
+	if ( value !== undefined ) {
+
+		this.dom.checked = value;
+
+	}
+
+	return this;
+
+};
+
 
 // Checkbox
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -661,7 +661,7 @@ UI.FancySelect.prototype.setValue = function ( value ) {
 
 // Label
 
-UI.Label = function ( text, forid ) {
+UI.Label = function ( text ) {
 
 	UI.Element.call( this );
 
@@ -670,7 +670,7 @@ UI.Label = function ( text, forid ) {
 
 	this.dom = dom;
 	this.setValue( text );
-	this.setFor( forid );
+	//this.setFor( id );
 
 	return this;
 
@@ -713,7 +713,7 @@ UI.Label.prototype.setFor = function ( value ) {
 
 // Radio
 
-UI.Radio = function ( name, id, boolean ) {
+UI.Radio = function ( name  ) {
 
 	UI.Element.call( this );
 
@@ -723,14 +723,10 @@ UI.Radio = function ( name, id, boolean ) {
 	dom.className = 'Radio';
 	dom.type = 'radio';
 	dom.name = name;
-	dom.id = id;
+	//dom.id = id;
 
 	this.dom = dom;
 	//this.setValue( boolean );
-
-    if ( boolean ) {
-        dom.setAttribute('checked', '');
-    }
 
 	return this;
 
@@ -756,6 +752,20 @@ UI.Radio.prototype.setValue = function ( value ) {
 	return this;
 
 };
+
+UI.Radio.prototype.setCheck = function ( value ) {
+
+	if ( value !== undefined ) {
+
+		this.dom.checked = '';
+		//dom.setAttribute('checked', '');
+	}
+
+	return this;
+
+};
+
+
 
 
 // Checkbox


### PR DESCRIPTION
**This feature is not yet ready! It currently breaks some functionality.**

**[demo](http://wikischool.org/three.js/editor/)**

This implements a CSS based tab UI for the sidebar, based upon this [example](http://codepen.io/andornagy/full/CFekj/).

The tabs will allow for a quicker interaction (less collapsing / uncollapsing) and use the available space better.

It places the all tab contents into an overal tab container. This works fine mostly, but **it currently breaks with signalling / updating (due to the DOM structure being slighty different I suspect).** I could use some help with the following two issues related to this:

bug 1) When you eg. load the "pong" example and then select the "scene" object, the script tab shows the scene script. However after an update the scene script is never shown again. I think I need to do add the container content again in the update() function in "Sidebar.Script.js".

bug 2) When a scene object is selected the object not passed correctly by "updateUI( object )" in "Sidebar.Object3D.js". The error is: Uncaught ReferenceError: objectType is not defined

Both issues should be easy to fix once I know how to fix the correct DOM reference in these update cycles.

Once this works I will rewrite the other tab panels (geometry, material, animation) also. Then I may fixate the sidebar-tab-row (so it does not scroll with the content) and perhaps add some SVG icons instead of text (to save even more space). Other ideas welcome.
