### PR TITLE
WebGLRenderer: Opaque overrideMaterial fix

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3370,13 +3370,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			var overrideMaterial = scene.overrideMaterial;
 
-			// Reset blending in case material.transparent = false. _setMaterial() doesn't set blending in such case.
+			// Reset blending in case material.transparent = false. setMaterial() doesn't set blending in such case.
 			this.setBlending( THREE.NoBlending );
-			this._setMaterial( overrideMaterial );
+			setMaterial( overrideMaterial );
 
-			_renderObjects( opaqueObjects, camera, lights, fog, overrideMaterial );
-			_renderObjects( transparentObjects, camera, lights, fog, overrideMaterial );
-			_renderObjectsImmediate( _webglObjectsImmediate, '', camera, lights, fog, overrideMaterial );
+			renderObjects( opaqueObjects, camera, lights, fog, overrideMaterial );
+			renderObjects( transparentObjects, camera, lights, fog, overrideMaterial );
+			renderObjectsImmediate( _webglObjectsImmediate, '', camera, lights, fog, overrideMaterial );
 
 		} else {
 
@@ -3384,13 +3384,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			this.setBlending( THREE.NoBlending );
 
-			_renderObjects( opaqueObjects, camera, lights, fog, null );
-			_renderObjectsImmediate( _webglObjectsImmediate, 'opaque', camera, lights, fog, null );
+			renderObjects( opaqueObjects, camera, lights, fog, null );
+			renderObjectsImmediate( _webglObjectsImmediate, 'opaque', camera, lights, fog, null );
 
 			// transparent pass (back-to-front order)
 
-			_renderObjects( transparentObjects, camera, lights, fog, null );
-			_renderObjectsImmediate( _webglObjectsImmediate, 'transparent', camera, lights, fog, null );
+			renderObjects( transparentObjects, camera, lights, fog, null );
+			renderObjectsImmediate( _webglObjectsImmediate, 'transparent', camera, lights, fog, null );
 
 		}
 
@@ -3479,21 +3479,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	this._setMaterial = function ( material ) {
-
-		if ( material.transparent === true ) {
-
-			_this.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha );
-
-		}
-
-		_this.setDepthTest( material.depthTest );
-		_this.setDepthWrite( material.depthWrite );
-		setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
-
-	}
-
-	function _renderObjects( renderList, camera, lights, fog, overrideMaterial ) {
+	function renderObjects( renderList, camera, lights, fog, overrideMaterial ) {
 
 		var material;
 
@@ -3516,7 +3502,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( ! material ) continue;
 
-				_this._setMaterial( material );
+				setMaterial( material );
 
 			}
 
@@ -3536,7 +3522,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function _renderObjectsImmediate ( renderList, materialType, camera, lights, fog, overrideMaterial ) {
+	function renderObjectsImmediate ( renderList, materialType, camera, lights, fog, overrideMaterial ) {
 
 		var material;
 
@@ -3557,7 +3543,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( ! material ) continue;
 
-					_this._setMaterial( material );
+					setMaterial( material );
 
 				}
 
@@ -4311,6 +4297,20 @@ THREE.WebGLRenderer = function ( parameters ) {
 			}
 
 		}
+
+	}
+
+	function setMaterial( material ) {
+
+		if ( material.transparent === true ) {
+
+			_this.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha );
+
+		}
+
+		_this.setDepthTest( material.depthTest );
+		_this.setDepthWrite( material.depthWrite );
+		setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3368,32 +3368,29 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( scene.overrideMaterial ) {
 
-			var material = scene.overrideMaterial;
+			var overrideMaterial = scene.overrideMaterial;
 
-			this.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha );
-			this.setDepthTest( material.depthTest );
-			this.setDepthWrite( material.depthWrite );
-			setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
+			// Reset blending in case material.transparent = false. setMaterial() doesn't set blending in such case.
+			this.setBlending( THREE.NoBlending );
+			this.setMaterial( overrideMaterial );
 
-			renderObjects( opaqueObjects, camera, lights, fog, true, material );
-			renderObjects( transparentObjects, camera, lights, fog, true, material );
-			renderObjectsImmediate( _webglObjectsImmediate, '', camera, lights, fog, false, material );
+			renderObjects( opaqueObjects, camera, lights, fog, overrideMaterial );
+			renderObjects( transparentObjects, camera, lights, fog, overrideMaterial );
+			renderObjectsImmediate( _webglObjectsImmediate, '', camera, lights, fog, overrideMaterial );
 
 		} else {
-
-			var material = null;
 
 			// opaque pass (front-to-back order)
 
 			this.setBlending( THREE.NoBlending );
 
-			renderObjects( opaqueObjects, camera, lights, fog, false, material );
-			renderObjectsImmediate( _webglObjectsImmediate, 'opaque', camera, lights, fog, false, material );
+			renderObjects( opaqueObjects, camera, lights, fog );
+			renderObjectsImmediate( _webglObjectsImmediate, 'opaque', camera, lights, fog );
 
 			// transparent pass (back-to-front order)
 
-			renderObjects( transparentObjects, camera, lights, fog, true, material );
-			renderObjectsImmediate( _webglObjectsImmediate, 'transparent', camera, lights, fog, true, material );
+			renderObjects( transparentObjects, camera, lights, fog );
+			renderObjectsImmediate( _webglObjectsImmediate, 'transparent', camera, lights, fog );
 
 		}
 
@@ -3482,7 +3479,23 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function renderObjects( renderList, camera, lights, fog, useBlending, overrideMaterial ) {
+	function setMaterial( material ) {
+
+		if ( material.transparent === true ) {
+
+			_this.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha );
+
+		}
+
+		_this.setDepthTest( material.depthTest );
+		_this.setDepthWrite( material.depthWrite );
+		setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
+
+	}
+
+	function renderObjects( renderList, camera, lights, fog, overrideMaterial ) {
+
+		overrideMaterial = overrideMaterial || null;
 
 		var material;
 
@@ -3505,11 +3518,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( ! material ) continue;
 
-				if ( useBlending ) _this.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha );
-
-				_this.setDepthTest( material.depthTest );
-				_this.setDepthWrite( material.depthWrite );
-				setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
+				_this.setMaterial( material );
 
 			}
 
@@ -3529,7 +3538,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function renderObjectsImmediate ( renderList, materialType, camera, lights, fog, useBlending, overrideMaterial ) {
+	function renderObjectsImmediate ( renderList, materialType, camera, lights, fog, overrideMaterial ) {
+
+		overrideMaterial = overrideMaterial || null;
 
 		var material;
 
@@ -3550,11 +3561,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( ! material ) continue;
 
-					if ( useBlending ) _this.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha );
-
-					_this.setDepthTest( material.depthTest );
-					_this.setDepthWrite( material.depthWrite );
-					setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
+					_this.setMaterial( material );
 
 				}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3384,13 +3384,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			this.setBlending( THREE.NoBlending );
 
-			renderObjects( opaqueObjects, camera, lights, fog );
-			renderObjectsImmediate( _webglObjectsImmediate, 'opaque', camera, lights, fog );
+			renderObjects( opaqueObjects, camera, lights, fog, null );
+			renderObjectsImmediate( _webglObjectsImmediate, 'opaque', camera, lights, fog, null );
 
 			// transparent pass (back-to-front order)
 
-			renderObjects( transparentObjects, camera, lights, fog );
-			renderObjectsImmediate( _webglObjectsImmediate, 'transparent', camera, lights, fog );
+			renderObjects( transparentObjects, camera, lights, fog, null );
+			renderObjectsImmediate( _webglObjectsImmediate, 'transparent', camera, lights, fog, null );
 
 		}
 
@@ -3495,8 +3495,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	function renderObjects( renderList, camera, lights, fog, overrideMaterial ) {
 
-		overrideMaterial = overrideMaterial || null;
-
 		var material;
 
 		for ( var i = 0, l = renderList.length; i < l; i ++ ) {
@@ -3539,8 +3537,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 	}
 
 	function renderObjectsImmediate ( renderList, materialType, camera, lights, fog, overrideMaterial ) {
-
-		overrideMaterial = overrideMaterial || null;
 
 		var material;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3479,7 +3479,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function _setMaterial( material ) {
+	this._setMaterial = function ( material ) {
 
 		if ( material.transparent === true ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3370,13 +3370,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			var overrideMaterial = scene.overrideMaterial;
 
-			// Reset blending in case material.transparent = false. setMaterial() doesn't set blending in such case.
+			// Reset blending in case material.transparent = false. _setMaterial() doesn't set blending in such case.
 			this.setBlending( THREE.NoBlending );
-			this.setMaterial( overrideMaterial );
+			this._setMaterial( overrideMaterial );
 
-			renderObjects( opaqueObjects, camera, lights, fog, overrideMaterial );
-			renderObjects( transparentObjects, camera, lights, fog, overrideMaterial );
-			renderObjectsImmediate( _webglObjectsImmediate, '', camera, lights, fog, overrideMaterial );
+			_renderObjects( opaqueObjects, camera, lights, fog, overrideMaterial );
+			_renderObjects( transparentObjects, camera, lights, fog, overrideMaterial );
+			_renderObjectsImmediate( _webglObjectsImmediate, '', camera, lights, fog, overrideMaterial );
 
 		} else {
 
@@ -3384,13 +3384,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			this.setBlending( THREE.NoBlending );
 
-			renderObjects( opaqueObjects, camera, lights, fog, null );
-			renderObjectsImmediate( _webglObjectsImmediate, 'opaque', camera, lights, fog, null );
+			_renderObjects( opaqueObjects, camera, lights, fog, null );
+			_renderObjectsImmediate( _webglObjectsImmediate, 'opaque', camera, lights, fog, null );
 
 			// transparent pass (back-to-front order)
 
-			renderObjects( transparentObjects, camera, lights, fog, null );
-			renderObjectsImmediate( _webglObjectsImmediate, 'transparent', camera, lights, fog, null );
+			_renderObjects( transparentObjects, camera, lights, fog, null );
+			_renderObjectsImmediate( _webglObjectsImmediate, 'transparent', camera, lights, fog, null );
 
 		}
 
@@ -3479,7 +3479,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function setMaterial( material ) {
+	function _setMaterial( material ) {
 
 		if ( material.transparent === true ) {
 
@@ -3493,7 +3493,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function renderObjects( renderList, camera, lights, fog, overrideMaterial ) {
+	function _renderObjects( renderList, camera, lights, fog, overrideMaterial ) {
 
 		var material;
 
@@ -3516,7 +3516,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( ! material ) continue;
 
-				_this.setMaterial( material );
+				_this._setMaterial( material );
 
 			}
 
@@ -3536,7 +3536,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function renderObjectsImmediate ( renderList, materialType, camera, lights, fog, overrideMaterial ) {
+	function _renderObjectsImmediate ( renderList, materialType, camera, lights, fog, overrideMaterial ) {
 
 		var material;
 
@@ -3557,7 +3557,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( ! material ) continue;
 
-					_this.setMaterial( material );
+					_this._setMaterial( material );
 
 				}
 


### PR DESCRIPTION
Fixes a bug with `overrideMaterial` where blending is used even when `overrideMaterial.transparent = false`. This conflicts with `render()` behavior that disables blending for such materials.

Also removes unnecessary `useBlending` parameter from `renderObjects()` and `renderObjectsImmediate()`, and makes them private by '_' prefix. Common material setting code was also pulled out as separate `_setMaterial()`.
