### PR TITLE
Correctly labelling GL State 'Constants'

### DIFF
--- a/docs/api/constants/GLState.html
+++ b/docs/api/constants/GLState.html
@@ -7,7 +7,7 @@
 		<link type="text/css" rel="stylesheet" href="../../page.css" />
 	</head>
 	<body>
-		<h1>GL State Conflicts</h1>
+		<h1>GL State Constants</h1>
 
 		<h2>Cull Face</h2>
 		<div>


### PR DESCRIPTION
From previous label of 'Conflicts'
