### PR TITLE
Switch off draw for buffer update only

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -77,6 +77,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 	// flags
 
 	this.autoScaleCubemaps = true;
+	this.updateBuffersOnly = false;
 
 	// info
 
@@ -1267,7 +1268,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				customAttribute = customAttributes[ i ];
 
-				if ( customAttribute.needsUpdate && ( customAttribute.boundTo === undefined ||  customAttribute.boundTo === 'vertices' ) ) {
+				if ( customAttribute.needsUpdate === true && ( customAttribute.boundTo === undefined || customAttribute.boundTo === 'vertices' ) ) {
 
 					cal = customAttribute.value.length;
 
@@ -1439,7 +1440,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				customAttribute = customAttributes[ i ];
 
-				if ( customAttribute.needsUpdate && ( customAttribute.boundTo === undefined || customAttribute.boundTo === 'vertices' ) ) {
+				if ( customAttribute.needsUpdate === true && ( customAttribute.boundTo === undefined || customAttribute.boundTo === 'vertices' ) ) {
 
 					offset = 0;
 
@@ -2028,7 +2029,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				customAttribute = customAttributes[ i ];
 
-				if ( ! customAttribute.__original.needsUpdate ) continue;
+				if ( ! ( customAttribute.__original.needsUpdate === true ) ) continue;
 
 				offset_custom = 0;
 				offset_customSrc = 0;
@@ -2480,6 +2481,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		updateObject( object );
 
+		if ( this.updateBuffersOnly === true ) return;
+
 		var program = setProgram( camera, lights, fog, material, object );
 
 		var updateBuffers = false,
@@ -2818,6 +2821,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( material.visible === false ) return;
 
 		updateObject( object );
+
+		if ( this.updateBuffersOnly === true ) return;
 
 		var program = setProgram( camera, lights, fog, material, object );
 
@@ -4035,7 +4040,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		for ( var name in material.attributes ) {
 
-			if ( material.attributes[ name ].needsUpdate ) return true;
+		    if ( material.attributes[ name ].needsUpdate === true ) return true;
 
 		}
 
@@ -4315,7 +4320,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		_usedTextureUnits = 0;
 
-		if ( material.needsUpdate ) {
+		if ( material.needsUpdate === true ) {
 
 			if ( material.program ) deallocateMaterial( material );
 
@@ -5840,7 +5845,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		_gl.activeTexture( _gl.TEXTURE0 + slot );
 
-		if ( texture.needsUpdate ) {
+		if ( texture.needsUpdate === true ) {
 
 			_this.uploadTexture( texture );
 
@@ -5882,7 +5887,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( texture.image.length === 6 ) {
 
-			if ( texture.needsUpdate ) {
+		    if ( texture.needsUpdate === true ) {
 
 				if ( ! texture.image.__webglTextureCube ) {
 


### PR DESCRIPTION
This commit resolves #5948 with minimal changes; however the handling of the update flags must be done outside of the renderer. Refactoring might be better, but this change should have minimal side effects 

Example usage:

``` javascript
THREE.PostRenderUpdate = 3; // Non true or false state to avoid too much flow logic change in WebGLRenderer
var UpdatableTextures = []; // Array of dynamic textures
var UpdatableBuffers = []; // Array of dynamic buffers
```

Dynamic texture create and update

``` javascript
// Data texture create adding to UpdatableTextures array
var dynamicData = new Uint8Array(2048 * 2048 * 4);
var dynamicText = new THREE.DataTexture(dynamicData, 2048, 2048, THREE.RGBAFormat, THREE.UnsignedByteType);
UpdatableTextures.push(dynamicText);

// Change underlying data and then mark texture as post update
dynamicData[i] = n 
dynamicText.needsUpdate = THREE.PostRenderUpdate;
```

Dynamic buffer create and update

``` javascript
// Data buffer create adding to UpdatableBuffers array
var positions = new Float32Array(poolCount * 4 * 4);
var positionBuffer = new THREE.BufferAttribute(positions, 4);
geometry.addAttribute('position', positionBuffer);
UpdatableBuffers.push(positionBuffer);

// Change underlying data and then mark buffer as post update
positions[i] = n 
positionBuffer.needsUpdate = THREE.PostRenderUpdate;
```

Render loop, showing double pass, second time without draw

``` javascript
function render(time) {
    // update uniform related stuff...
    ...
    // Do draw phase
    renderer.render(sceneFront, camera, null, true);
    renderer.render(sceneTileDepth, camera);
    renderer.render(sceneTileColor, camera);
    renderer.render(sceneGround, camera);

    // Switch off draw
    renderer.updateBuffersOnly = true;

    // Update dynamic data textures
    for (var i = 0, ul = UpdatableTextures.length; i < ul; i++) {
        if (UpdatableTextures[i].needsUpdate === THREE.PostRenderUpdate) {
            // Set dynamic data textures marked as post update to need update
            UpdatableTextures[i].needsUpdate = true;
            // Upload dynamic data texture
            renderer.uploadTexture(UpdatableTextures[i]);
        }
    }

    // Set dynamic buffers marked as post update to need update
    for (var i = 0, ul = UpdatableBuffers.length; i < ul; i++) {
        if (UpdatableBuffers[i].needsUpdate === THREE.PostRenderUpdate) {
            UpdatableBuffers[i].needsUpdate = true;
        }
    }

    // Repeat draw steps only updating buffers due to updateBuffersOnly flag
    renderer.render(sceneFront, camera);
    renderer.render(sceneTileDepth, camera);
    renderer.render(sceneTileColor, camera);
    renderer.render(sceneGround, camera);

    // Switch on draw
    renderer.updateBuffersOnly = false;
}
```
