### PR TITLE
Use update range and bufferSubData

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -1,11 +1,15 @@
 /**
  * @author mrdoob / http://mrdoob.com/
+ * @author benaadams / https://twitter.com/ben_a_adams
  */
 
-THREE.BufferAttribute = function ( array, itemSize ) {
+THREE.BufferAttribute = function ( array, itemSize, dynamic ) {
 
 	this.array = array;
 	this.itemSize = itemSize;
+
+	this.dynamic = dynamic || false;
+	this.updateRange = { offset: 0, count: -1 };
 
 	this.needsUpdate = false;
 
@@ -32,11 +36,15 @@ THREE.BufferAttribute.prototype = {
 
 		}
 
+		this.markForUpdate( index1, this.itemSize );
+
 	},
 
 	set: function ( value ) {
 
 		this.array.set( value );
+
+		this.markForUpdate( 0, value.length );
 
 		return this;
 
@@ -44,7 +52,11 @@ THREE.BufferAttribute.prototype = {
 
 	setX: function ( index, x ) {
 
-		this.array[ index * this.itemSize ] = x;
+		index *= this.itemSize;
+
+		this.array[ index ] = x;
+
+		this.markForUpdate( index, 1 );
 
 		return this;
 
@@ -52,7 +64,11 @@ THREE.BufferAttribute.prototype = {
 
 	setY: function ( index, y ) {
 
+		index = index * this.itemSize + 1;
+
 		this.array[ index * this.itemSize + 1 ] = y;
+
+		this.markForUpdate( index, 1 );
 
 		return this;
 
@@ -60,7 +76,11 @@ THREE.BufferAttribute.prototype = {
 
 	setZ: function ( index, z ) {
 
+		index = index * this.itemSize + 2;
+
 		this.array[ index * this.itemSize + 2 ] = z;
+
+		this.markForUpdate( index, 1 );
 
 		return this;
 
@@ -73,6 +93,8 @@ THREE.BufferAttribute.prototype = {
 		this.array[ index     ] = x;
 		this.array[ index + 1 ] = y;
 
+		this.markForUpdate( index, 2 );
+
 		return this;
 
 	},
@@ -84,6 +106,8 @@ THREE.BufferAttribute.prototype = {
 		this.array[ index     ] = x;
 		this.array[ index + 1 ] = y;
 		this.array[ index + 2 ] = z;
+
+		this.markForUpdate( index, 3 );
 
 		return this;
 
@@ -98,8 +122,41 @@ THREE.BufferAttribute.prototype = {
 		this.array[ index + 2 ] = z;
 		this.array[ index + 3 ] = w;
 
+		this.markForUpdate( index, 4 );
+
 		return this;
 
+	},
+
+	setRange: function ( index, array ) {
+
+		index *= this.itemSize;
+
+		this.array.set( array, index );
+
+		this.markForUpdate( index, array.length );
+
+		return this;
+
+	},
+
+	markForUpdate: function ( offset, count ) {
+
+		if ( this.updateRange.count <= 0 ) {
+
+			this.updateRange.offset = offset;
+			this.updateRange.count = count;
+
+		} else {
+
+			var end0 = offset + count;
+			var end1 = this.updateRange.offset + this.updateRange.count;
+
+			this.updateRange.offset = ( offset <= this.updateRange.offset ) ? offset : this.updateRange.offset;
+			this.updateRange.count = ( ( end0 >= end1 ) ? end0 : end1 ) - this.updateRange.offset;
+		}
+
+		return this;
 	},
 
 	clone: function () {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3926,20 +3926,35 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				var key = attributesKeys[ i ];
 				var attribute = attributes[ key ];
+				var bufferType = ( key === 'index' ) ? _gl.ELEMENT_ARRAY_BUFFER : _gl.ARRAY_BUFFER;
 
 				if ( attribute.buffer === undefined ) {
 
 					attribute.buffer = _gl.createBuffer();
-					attribute.needsUpdate = true;
+					_gl.bindBuffer( bufferType, attribute.buffer );
+					_gl.bufferData( bufferType, attribute.array, ( attribute.dynamic === true ) ? _gl.DYNAMIC_DRAW : _gl.STATIC_DRAW );
 
-				}
+					attribute.needsUpdate = false;
 
-				if ( attribute.needsUpdate === true ) {
-
-					var bufferType = ( key === 'index' ) ? _gl.ELEMENT_ARRAY_BUFFER : _gl.ARRAY_BUFFER;
+				} else if ( attribute.needsUpdate === true ) {
 
 					_gl.bindBuffer( bufferType, attribute.buffer );
-					_gl.bufferData( bufferType, attribute.array, _gl.STATIC_DRAW );
+
+					if ( attribute.updateRange.count === -1 ) { // Not using update ranges
+
+						_gl.bufferSubData( bufferType, 0, attribute.array );
+
+					} else if ( attribute.updateRange.count === 0 ) {
+
+						console.error( 'THREE.WebGLRenderer.updateObject: using updateRange for THREE.BufferAttribute and marked as needsUpdate but count is 0.' );
+
+					} else {
+						
+						_gl.bufferSubData( bufferType, attribute.updateRange.offset * attribute.array.BYTES_PER_ELEMENT,
+										   attribute.array.subarray( attribute.updateRange.offset, attribute.updateRange.offset + attribute.updateRange.count ) );
+
+						attribute.updateRange.count = 0; // reset range
+					}
 
 					attribute.needsUpdate = false;
 


### PR DESCRIPTION
(Tab formatted source) For BufferGeometry added DYNAMIC_DRAW choice via
dynamic in BufferAttribute constructor, use bufferSubData for updates
after the initial create and a simple min/max update range to reduce
buffer upload/refresh

May also resolve #5042 supersedes #5952
