### PR TITLE
Removed preventDefault() from mouse event handlers in editorControls

### DIFF
--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -116,8 +116,6 @@ THREE.EditorControls = function ( object, domElement ) {
 
 		if ( scope.enabled === false ) return;
 
-		event.preventDefault();
-
 		if ( event.button === 0 ) {
 
 			state = STATE.ROTATE;
@@ -144,8 +142,6 @@ THREE.EditorControls = function ( object, domElement ) {
 	function onMouseMove( event ) {
 
 		if ( scope.enabled === false ) return;
-
-		event.preventDefault();
 
 		pointer.set( event.clientX, event.clientY );
 


### PR DESCRIPTION
@mrdoob is calling preventDefault() here necessary? It doesn't seem to do anything and it prevents the canvas/viewport from being focused when clicked. What I'm trying to achieve is to make a viewport element that can be focused and this prevents that.

Perhaps that was the original intention? Maybe you wanted the fields in the side panel to stay focused while user interacts with the viewport?
