### PR TITLE
Examples: Lensflare example contains an useless variable

### DIFF
--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -59,8 +59,6 @@
 
 			var clock = new THREE.Clock();
 
-			var composer;
-
 			init();
 			animate();
 


### PR DESCRIPTION
"composer" is never used
