### PR TITLE
Fix for typo in ColladaLoader

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -25,7 +25,7 @@ THREE.ColladaLoader = function () {
 	var animData;
 	var kinematics;
 	var visualScenes;
-	var kinematicsModel;
+	var kinematicsModels;
 	var baseUrl;
 	var morphs;
 	var skins;


### PR DESCRIPTION
Fix for typo in ColladaLoader: kinematicsModel is already defined in line 11, but in line 28 it should be called kinematicsModels (plural) like the visualScene/visualScenes the line before it.
