### PR TITLE
Added object reference to projected elements in Projector.js

### DIFF
--- a/examples/js/renderers/Projector.js
+++ b/examples/js/renderers/Projector.js
@@ -194,6 +194,7 @@ THREE.Projector = function () {
 
 			_vertex = getNextVertexInPool();
 			_vertex.position.set( x, y, z );
+			_vertex.object = object;
 
 			projectVertex( _vertex );
 
@@ -245,6 +246,7 @@ THREE.Projector = function () {
 			_line.z = ( v1.positionScreen.z + v2.positionScreen.z ) / 2;
 
 			_line.material = object.material;
+			_line.object = object;
 
 			_renderData.elements.push( _line );
 
@@ -286,6 +288,7 @@ THREE.Projector = function () {
 				_face.vertexNormalsLength = 3;
 
 				_face.material = object.material;
+				_face.object = object;
 
 				_renderData.elements.push( _face );
 


### PR DESCRIPTION
I am implementing marquee selection in viewport (rectangular select) using Projector.js and `camera.setViewOffset()` It turns out the projector returns sorted renderable objects whose bounding sphere intersects the frustum. However, that means that sometimes you would get objects that are not in the selection rectangle.

So I thought I could iterate through projected elements instead and pick out the related objects. This PR will allow that.

What do you think?
