### PR TITLE
Add missing line break after the fog property description of Lambert material

### DIFF
--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -29,7 +29,7 @@
 		specularMap — Set specular map. Default is null.<br />
 		alphaMap — Set alpha map. Default is null.<br />
 		envMap — Set env map. Default is null.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is false.
+		fog — Define whether the material color is affected by global fog settings. Default is false.<br />
 		shading — How the triangles of a curved surface are rendered. Default is [page:Materials THREE.SmoothShading].<br/>
 		wireframe — Render geometry as wireframe. Default is false (i.e. render as smooth shaded).<br/>
 		wireframeLinewidth — Controls wireframe thickness. Default is 1.<br/>


### PR DESCRIPTION
Seems like it was simply forgotten. Adding it makes it easier to scan through the properties.
