### PR TITLE
MTLLoader:  Support for loading bump maps

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -340,6 +340,17 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					break;
 
+				case 'map_bump':
+				case 'bump':
+
+					// Bump texture map
+
+					params[ 'bumpMap' ] = this.loadTexture( this.baseUrl + value );
+					params[ 'bumpMap' ].wrapS = this.wrap;
+					params[ 'bumpMap' ].wrapT = this.wrap;
+
+					break;
+
 				default:
 					break;
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -345,6 +345,8 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					// Bump texture map
 
+					if ( params[ 'bumpMap' ] ) break; // Avoid loading twice.
+
 					params[ 'bumpMap' ] = this.loadTexture( this.baseUrl + value );
 					params[ 'bumpMap' ].wrapS = this.wrap;
 					params[ 'bumpMap' ].wrapT = this.wrap;


### PR DESCRIPTION
Adds support for loading bump maps according to .mtl material property 'bump' and 'map_bump'. As an example, bump maps are used in a version of Dabrovic Sponza which is downloadable from: http://graphics.cs.williams.edu/data/meshes.xml

PS. Stackoverflow mentions similar solution to load bump maps in three.js: http://stackoverflow.com/questions/27643695/threejs-objmtlloader-and-bump-map

PPS. Here's the old .mtl spec: http://paulbourke.net/dataformats/mtl/
