### PR TITLE
Color/Euler: 'toArray' broken expectations fix

### DIFF
--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -377,7 +377,7 @@ THREE.Color.prototype = {
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
 
-		array[ offset + 0 ] = this.r;
+		array[ offset ] = this.r;
 		array[ offset + 1 ] = this.g;
 		array[ offset + 2 ] = this.b;
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -372,7 +372,7 @@ THREE.Color.prototype = {
 
 	},
 
-	toArray: function( array, offset ) {
+	toArray: function ( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -372,10 +372,16 @@ THREE.Color.prototype = {
 
 	},
 
-	toArray: function () {
+	toArray: function( array, offset ) {
 
-		return [ this.r, this.g, this.b ];
+		if ( array === undefined ) array = [];
+		if ( offset === undefined ) offset = 0;
 
+		array[ offset + 0 ] = this.r;
+		array[ offset + 1 ] = this.g;
+		array[ offset + 2 ] = this.b;
+
+		return array;
 	},
 
 	clone: function () {

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -280,7 +280,7 @@ THREE.Euler.prototype = {
 
 	},
 
-	toArray: function ( array, offset, withoutOrder ) {
+	toArray: function ( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -288,6 +288,7 @@ THREE.Euler.prototype = {
 		array[ offset ] = this._x;
 		array[ offset + 1 ] = this._y;
 		array[ offset + 2 ] = this._z;
+		array[ offset + 3 ] = this._order;
 
 		return array;
 	},

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -280,10 +280,20 @@ THREE.Euler.prototype = {
 
 	},
 
-	toArray: function () {
+	toArray: function( array, offset, withoutOrder ) {
 
-		return [ this._x, this._y, this._z, this._order ];
+		if ( array === undefined ) array = [];
+		if ( offset === undefined ) offset = 0;
 
+		array[ offset + 0 ] = this._x;
+		array[ offset + 1 ] = this._y;
+		array[ offset + 2 ] = this._z;
+
+		if( !withoutOrder ) {
+			array[ offset + 3 ] = this._order;
+		}
+
+		return array;
 	},
 
 	toVector3: function ( optionalResult ) {

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -289,10 +289,6 @@ THREE.Euler.prototype = {
 		array[ offset + 1 ] = this._y;
 		array[ offset + 2 ] = this._z;
 
-		if( !withoutOrder ) {
-			array[ offset + 3 ] = this._order;
-		}
-
 		return array;
 	},
 

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -289,7 +289,7 @@ THREE.Euler.prototype = {
 		array[ offset + 1 ] = this._y;
 		array[ offset + 2 ] = this._z;
 
-		if( withoutOrder === true ) {
+		if( !withoutOrder ) {
 			array[ offset + 3 ] = this._order;
 		}
 

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -280,16 +280,16 @@ THREE.Euler.prototype = {
 
 	},
 
-	toArray: function( array, offset, withoutOrder ) {
+	toArray: function ( array, offset, withoutOrder ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
 
-		array[ offset + 0 ] = this._x;
+		array[ offset ] = this._x;
 		array[ offset + 1 ] = this._y;
 		array[ offset + 2 ] = this._z;
 
-		if( !withoutOrder ) {
+		if( withoutOrder === true ) {
 			array[ offset + 3 ] = this._order;
 		}
 


### PR DESCRIPTION
Hello guys. Currently Vector's/Quaternion's behavior of "toArray" drastically differ from Color's/Euler's. Last 2 don't have input parameters array/offset, but Vector's/Quaternion's do. It breaks expectations. I didn't even think the problem could be in this, so I spent much time with this. This commit will save hundreds of devs from wasting time with this drawback.

That's how Quaternion's "toArray" looks like:

```
    toArray: function ( array, offset ) {

        if ( array === undefined ) array = [];
        if ( offset === undefined ) offset = 0;

        array[ offset ] = this._x;
        array[ offset + 1 ] = this._y;
        array[ offset + 2 ] = this._z;
        array[ offset + 3 ] = this._w;

        return array;

    },
```

Difference is obvious.
