### PR TITLE
Remove stopPropagation from TransformControls

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -755,7 +755,6 @@
 			if ( scope.object === undefined || _dragging === true ) return;
 
 			event.preventDefault();
-			event.stopPropagation();
 
 			var pointer = event.changedTouches ? event.changedTouches[ 0 ] : event;
 
@@ -801,7 +800,6 @@
 			if ( scope.object === undefined || scope.axis === null || _dragging === false ) return;
 
 			event.preventDefault();
-			event.stopPropagation();
 
 			var pointer = event.changedTouches? event.changedTouches[0] : event;
 


### PR DESCRIPTION
- better interoperability with controls eg. OrbitControls since events are stolen by TransformControls.

this might cause a change in behaviour where a transformed action will propagate to another controls, hence one could do

``` js
controls = new THREE.OrbitControls( camera );
transformControl = new THREE.TransformControls( camera, renderer.domElement );

transformControl.addEventListener( 'mouseDown', function() {

    controls.enabled = false;

});

transformControl.addEventListener( 'mouseUp', function() {

    controls.enabled = true;

});
```

if this behaviour is not preferred, then removing stopPropagation from `.onPointerDown` should suffice.
