### PR TITLE
Example for using ESLint to help enforce your style rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+examples/js/libs/*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "0.11"
+script:
+  - grunt eslint
+
+before_install: npm install -g grunt-cli
+
+
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function( grunt ) {
   grunt.initConfig( {
     eslint: {
         target: [
-          'src/Three.js',
+          'src',
           //'examples',   // should turn this on but not yet. Too many errors
           //'test',       // should turn this on. Will need different options, can put in test/.eslistrc
         ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,31 @@
+"use strict";
+
+module.exports = function( grunt ) {
+
+  grunt.initConfig( {
+    eslint: {
+        target: [
+          'src/Three.js',
+          //'examples',   // should turn this on but not yet. Too many errors
+          //'test',       // should turn this on. Will need different options, can put in test/.eslistrc
+        ],
+        options: {
+            config: 'utils/build/eslint/eslint.json',
+            rulesdir: ['utils/build/eslint/rules'],
+
+            // eslint plugins installed through npm
+
+            plugin: [
+            //    'eslint-plugin-optional-comma-spacing',
+            //    'eslint-plugin-require-trailing-comma',
+            ],
+        },
+    },
+  });
+
+  grunt.loadNpmTasks( 'grunt-eslint' );
+
+  grunt.registerTask( 'default', ['eslint'] );
+
+};
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "three.js",
+  "description": "JavaScript 3D library",
+  "version": "0.0.70",
+  "scripts": {
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "eslint": "^0.11.0",
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^0.5.0",
+    "grunt-eslint": "^3.0.0"
+  }
+}

--- a/src/Three.js
+++ b/src/Three.js
@@ -2,9 +2,13 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
+/*eslint no-undef:0*/
+
 var THREE = { REVISION: '71dev' };
 
 // browserify support
+
+/*global module*/
 
 if ( typeof module === 'object' ) {
 

--- a/utils/build/eslint/eslint.json
+++ b/utils/build/eslint/eslint.json
@@ -1,0 +1,58 @@
+{
+  "env": {
+    "browser": true,
+  },
+  "rules": {
+    // Rules that should be turned on but are off until the code is updated (change the 0 to a 2)
+
+    "camelcase": 0,                        // Disallow names_with_underscore
+    "comma-spacing": 0,                    // Require space after comma
+    "eqeqeq": 0,                           // Require === and !==
+    "key-spacing": 0,                      // Require a space after key as in "key: value"
+    "new-cap": 0,                          // Disallow captialized function to be used without new.
+    "new-parens": 0,                       // Require new to always have parens. "a = new b();" = ok, "a = new b;" = bad
+    "no-comma-dangle": 0,                  // Disallow dangling commas as in [ 1, 2, 3, ]
+    "no-extra-semi": 0,                    // Disallow extra semicolons. Example function foo() { };
+    "no-mixed-spaces-and-tabs": 0,         // Disallow both spaces and tabs in the same line for indenting
+    "no-spaced-func": 0,                   // Require no space at function call. "fn()" = ok, "fn ()" = bad
+    "no-space-before-semi": 0,             // Require no space before semicolon
+    "no-trailing-spaces": 0,               // Disallow trailing spaces
+    "no-unused-vars": 0,                   // Disallow unused variables.
+    "semi": 0,                             // Disallow missing semicolons
+    "space-after-keywords": [ 0, "always" ], // Require space after keywords
+    "space-in-brackets": [ 0, "always" ],    // Require space in parens
+    "space-in-parens": [ 0, "always" ],      // Require space in parens
+    "space-infix-ops": 0,                  // Require space around operators "a + b" = ok, "a+b" = bad
+    "strict": 0,                           // Require "use strict"
+    "three-space-unary-ops": [ 0, { "words": true, "nonwords": true } ],  // Require space before unary operators except "."
+
+    // Rules we intensionally want on
+
+    "comma-style": [ 2, "last" ],  // Require commas on the same line
+    "no-new-object": 2,            // Disallow "new Object()";
+    "three-no-new-array": 2,       // Disallow "new Array"
+    "brace-style": [ 2, "1tbs", { "allowSingleLine": false } ],  // Require k&r style braces
+
+    // Rules we intensionally want off
+
+    "yoda": 0,                   // Don't care if it's "if (1 == v)" or "if (v == 123)".
+    "no-empty": 0,               // Don't care if we have empty blocks
+    "eol-last": 0,               // Don't care if the file doesn't end with an EOL.
+    "no-shadow": 0,              // Don't care if the same variable name is used in an inner scope.
+    "no-multi-spaces": 0,        // Don't care if there's more than one space anywhere.
+    "no-unused-expressions": 0,  // Don't care if there are unused experssions. eg "flag && doThing();"
+    "consistent-return": 0,      // Don't care if some returns return no value
+    "dot-notation": 0,           // Don't care if it's obj["prop"] instead of obj.prop
+    "no-console": 0,             // allow the use of console
+    "curly": 0,                  // Don't require all if statements to have curly braces
+    "no-redeclare": 0,           // Don't care if var declared more than once in same scope. eg for (var x, ...) for (var x, ...);
+    "quotes": 0,                 // Don't care if quotes are double or single
+    "space-unary-ops": 0,        // Turn off default unary ops spacing
+    "no-use-before-define": 0,   // don't care if something is used before it's defined.
+    "no-underscore-dangle": 0,   // don't care if var starts with underscore
+  },
+  "globals": {
+    "THREE": false,        // Don't allow overriding THREE
+    "console": true,       // Define console and allow it to be overridden
+  }
+}

--- a/utils/build/eslint/eslint.json
+++ b/utils/build/eslint/eslint.json
@@ -3,35 +3,36 @@
     "browser": true,
   },
   "rules": {
-    // Rules that should be turned on but are off until the code is updated (change the 0 to a 2)
+    // Rules that should be turned on but are off until the code is updated
+    // (change the 0 to a 2 and move them down to the next section)
 
-    "camelcase": 0,                        // Disallow names_with_underscore
-    "comma-spacing": 0,                    // Require space after comma
-    "eqeqeq": 0,                           // Require === and !==
-    "key-spacing": 0,                      // Require a space after key as in "key: value"
-    "new-cap": 0,                          // Disallow captialized function to be used without new.
-    "new-parens": 0,                       // Require new to always have parens. "a = new b();" = ok, "a = new b;" = bad
-    "no-comma-dangle": 0,                  // Disallow dangling commas as in [ 1, 2, 3, ]
-    "no-extra-semi": 0,                    // Disallow extra semicolons. Example function foo() { };
-    "no-mixed-spaces-and-tabs": 0,         // Disallow both spaces and tabs in the same line for indenting
-    "no-spaced-func": 0,                   // Require no space at function call. "fn()" = ok, "fn ()" = bad
-    "no-space-before-semi": 0,             // Require no space before semicolon
-    "no-trailing-spaces": 0,               // Disallow trailing spaces
-    "no-unused-vars": 0,                   // Disallow unused variables.
-    "semi": 0,                             // Disallow missing semicolons
+    "brace-style": [ 0, "1tbs", { "allowSingleLine": true } ],  // Require k&r style braces
+    "camelcase": 0,                          // Disallow names_with_underscore
+    "comma-spacing": 0,                      // Require space after comma
+    "eqeqeq": 0,                             // Require === and !==
+    "key-spacing": 0,                        // Require a space after key as in "key: value"
+    "new-cap": 0,                            // Disallow captialized function to be used without new.
+    "new-parens": 0,                         // Require new to always have parens. "a = new b();" = ok, "a = new b;" = bad
+    "no-comma-dangle": 0,                    // Disallow dangling commas as in [ 1, 2, 3, ]
+    "no-extra-semi": 0,                      // Disallow extra semicolons. Example function foo() { };
+    "no-mixed-spaces-and-tabs": 0,           // Disallow both spaces and tabs in the same line for indenting
+    "no-spaced-func": 0,                     // Require no space at function call. "fn()" = ok, "fn ()" = bad
+    "no-space-before-semi": 0,               // Require no space before semicolon
+    "no-trailing-spaces": 0,                 // Disallow trailing spaces
+    "no-unused-vars": 0,                     // Disallow unused variables.
+    "semi": 0,                               // Disallow missing semicolons
     "space-after-keywords": [ 0, "always" ], // Require space after keywords
     "space-in-brackets": [ 0, "always" ],    // Require space in parens
     "space-in-parens": [ 0, "always" ],      // Require space in parens
-    "space-infix-ops": 0,                  // Require space around operators "a + b" = ok, "a+b" = bad
-    "strict": 0,                           // Require "use strict"
+    "space-infix-ops": 0,                    // Require space around operators "a + b" = ok, "a+b" = bad
+    "strict": 0,                             // Require "use strict"
+    "three-no-new-array": 0,                 // Disallow "new Array"
     "three-space-unary-ops": [ 0, { "words": true, "nonwords": true } ],  // Require space before unary operators except "."
 
     // Rules we intensionally want on
 
     "comma-style": [ 2, "last" ],  // Require commas on the same line
     "no-new-object": 2,            // Disallow "new Object()";
-    "three-no-new-array": 2,       // Disallow "new Array"
-    "brace-style": [ 2, "1tbs", { "allowSingleLine": false } ],  // Require k&r style braces
 
     // Rules we intensionally want off
 

--- a/utils/build/eslint/eslint.json
+++ b/utils/build/eslint/eslint.json
@@ -32,6 +32,7 @@
     // Rules we intensionally want on
 
     "comma-style": [ 2, "last" ],  // Require commas on the same line
+    "no-bang-boolean-cast": 2,     // Disallow !value. Effectively require checking value === null, undefined, false, 0, etc..
     "no-new-object": 2,            // Disallow "new Object()";
 
     // Rules we intensionally want off

--- a/utils/build/eslint/rules/no-bang-boolean-cast.js
+++ b/utils/build/eslint/rules/no-bang-boolean-cast.js
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Rule to flag unnecessary double negation in Boolean contexts
+ * @author Brandon Mills
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    function report(node, statement) {
+        context.report(node, "!variable not allowed in " + statement + ". Use variable !== null, undefined, false, 0 etc...");
+    }
+
+    return {
+        "UnaryExpression": function (node) {
+            var ancestors = context.getAncestors(),
+                parent = ancestors.pop();
+
+            // Exit early if it's guaranteed not to match
+            if (node.operator !== "!") {
+                return;
+            }
+
+            // if (<bool>) ...
+            if (parent.type === "IfStatement") {
+                report(node, "if statement condition");
+
+            // do ... while (<bool>)
+            } else if (parent.type === "DoWhileStatement") {
+                report(node, "do while loop condition");
+
+            // while (<bool>) ...
+            } else if (parent.type === "WhileStatement") {
+                report(node, "while loop condition");
+
+            // <bool> ? ... : ...
+            } else if (parent.type === "ConditionalExpression") {
+                report(node, "ternary condition");
+
+            // for (...; <bool>; ...) ...
+            } else if (parent.type === "ForStatement") {
+                report(node, "for loop condition");
+
+            }
+        }
+    };
+
+};

--- a/utils/build/eslint/rules/three-no-new-array.js
+++ b/utils/build/eslint/rules/three-no-new-array.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview A rule to disallow calls to the Object constructor
+ * @author Matt DuVall <http://www.mattduvall.com/>
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "NewExpression": function(node) {
+            if (node.callee.name === "Array") {
+                context.report(node, "The array literal notation {} is preferrable.");
+            }
+        }
+    };
+
+};

--- a/utils/build/eslint/rules/three-space-unary-ops.js
+++ b/utils/build/eslint/rules/three-space-unary-ops.js
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview This rule shoud require or disallow spaces before or after unary operations.
+ * @author Marcin Kumorek
+ * @copyright 2014 Marcin Kumorek. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var options = context.options && Array.isArray(context.options) && context.options[0] || { words: true, nonwords: false };
+    var ignoredUnaryOperators = {
+        ".": true,
+    };
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+    * Check if it's an ignored unary expression
+    * @param {ASTNode} node AST node
+    * @returns {boolean} Wehther or not it should be ignored
+    */
+    function isIgnoredUnaryOperator(op) {
+        return op in ignoredUnaryOperators;
+    }
+
+    /**
+    * Check if the parent unary operator is "!" in order to know if it's "!!" convert to Boolean or just "!" negation
+    * @param {ASTnode} node AST node
+    * @returns {boolean} Whether or not the parent is unary "!" operator
+    */
+    function isParentUnaryBangExpression(node) {
+        return node && node.parent && node.parent.type === "UnaryExpression" && node.parent.operator === "!";
+    }
+
+    /**
+    * Checks if the type is a unary word expression
+    * @param {string} type value of AST token
+    * @returns {boolean} Whether the word is in the list of known words
+    */
+    function isWordExpression(type) {
+        return ["delete", "new", "typeof", "void"].indexOf(type) !== -1;
+    }
+
+    /**
+    * Check if the node's child argument is an "ObjectExpression"
+    * @param {ASTnode} node AST node
+    * @returns {boolean} Whether or not the argument's type is "ObjectExpression"
+    */
+    function isArgumentObjectExpression(node) {
+        return node.argument && node.argument.type && node.argument.type === "ObjectExpression";
+    }
+
+    /**
+    * Check Unary Word Operators for spaces after the word operator
+    * @param {ASTnode} node AST node
+    * @param {object} firstToken first token from the AST node
+    * @param {object} secondToken second token from the AST node
+    * @returns {void}
+    */
+    function checkUnaryWordOperatorForSpaces(node, firstToken, secondToken) {
+        if (options.words) {
+            if (secondToken.range[0] === firstToken.range[1]) {
+                context.report(node, "Unary word operator \"" + firstToken.value + "\" must be followed by whitespace.");
+            }
+        }
+
+        if (!options.words && isArgumentObjectExpression(node)) {
+            if (secondToken.range[0] > firstToken.range[1]) {
+                context.report(node, "Unexpected space after unary word operator \"" + firstToken.value + "\".");
+            }
+        }
+    }
+
+    /**
+    * Checks UnaryExpression, UpdateExpression and NewExpression for spaces before and after the operator
+    * @param {ASTnode} node AST node
+    * @returns {void}
+    */
+    function checkForSpaces(node) {
+        var tokens = context.getFirstTokens(node, 2),
+            firstToken = tokens[0],
+            secondToken = tokens[1];
+
+         if (isWordExpression(firstToken.value)) {
+             checkUnaryWordOperatorForSpaces(node, firstToken, secondToken);
+             return void 0;
+         }
+
+        if (options.nonwords) {
+            if (node.prefix) {
+                if (isIgnoredUnaryOperator(node.operator)) {
+                    return void 0;
+                }
+                if (isParentUnaryBangExpression(node)) {
+                    return void 0;
+                }
+                if (firstToken.range[1] === secondToken.range[0]) {
+                    context.report(node, "Unary operator \"" + firstToken.value + "\" must be followed by whitespace.");
+                }
+            } else {
+                if (isIgnoredUnaryOperator(secondToken.value)) {
+                    return void 0;
+                }
+                if (firstToken.range[1] === secondToken.range[0]) {
+                    context.report(node, "Space is required before unary expressions \"" + secondToken.value + "\".");
+                }
+            }
+        } else {
+            if (node.prefix) {
+                if (secondToken.range[0] > firstToken.range[1]) {
+                    context.report(node, "Unexpected space after unary operator \"" + firstToken.value + "\".");
+                }
+            } else {
+                if (secondToken.range[0] > firstToken.range[1]) {
+                    context.report(node, "Unexpected space before unary operator \"" + secondToken.value + "\".");
+                }
+            }
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+        "UnaryExpression": checkForSpaces,
+        "UpdateExpression": checkForSpaces,
+        "NewExpression": checkForSpaces
+    };
+
+};


### PR DESCRIPTION
I just got done setting this up for one of my projects and I thought I'd show you how to set it up for yours if you're interested. I'm not expecting you to pull this request (you can if you want) but rather if you don't like it as is you can reference it.

So, if you get this branch, cd to the root folder and type

```
npm install
sudo npm install grunt-cli -g   // assuming you don't have grunt installed already
```

then you can now do

```
grunt eslint
```

and it checks many or most of your style rules. See `utils/build/eslint/eslint.json` that most of the rules are off right now because the code is breaking them all over the place :P Ideally if you add this to the official three.js repo we could turn on one rule, fix all the warnings, then make a pull request and repeat until its all one style. 

It's currently only checking the `src` folder. Ideally we'd turn it on for the `examples` and `test` folders as well. One thing I need to look into is how easy it would be it lint inline html scripts for the examples folder but hey, one step at a time.

So ... first that makes it easy to manually check if the code mostly matches your style guide but...
## travis-ci

if you setup a free account on travis-ci.org and turn it on
for the three.js repo it will lint any pull request automatically 
and have the results directly in the pull request on github.

I turned it on on my copy of three.js repo. 
[You can see it ran here](https://travis-ci.org/greggman/three.js)
## git integration

You can also setup a git pre-commit script to run "grunt eslint" before
committing. That's a local only thing meaning it won't propagate to other
users but it might be useful for yourself if you want to make sure you don't
commit something that breaks your own rules
## custom rules

[ESLint](http://eslint.org) allows custom rules. The easiest way to make a custom rule is to copy one of the built in rules. So for example

```
cp node_modules/eslint/lib/rules/brace-style.js utils/build/eslint/rules/three-brace-style.js
```

Now there's a rule called `three-brace-style`. You could modify it so it enforced a blank line after `{` and before `}`
## overriding rules

Sometimes you need to override a rule for special code. You can do that with a comment in the code. For example if you wanted to allow an unused var you could do this

```
/*eslint no-unused-vars: 0*/
```
## where to put these files

I thought I should put all of these files in `utils/eslint` or `utils/build/eslint`. The advantage to the latter is that you already have a `package.json` file there that I'm guessing you use. The reason I put a few files in the root though is because that way they work with travis-ci without much work. If you move them somewhere else I suspect there's a bunch of work to do to get travis-ci to handle that case. Of course it's up to you.
