### PR TITLE
pixelRatio editable by create parameters

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -14,7 +14,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 	var _canvas = parameters.canvas !== undefined ? parameters.canvas : document.createElement( 'canvas' ),
 	_context = parameters.context !== undefined ? parameters.context : null,
 
-	pixelRatio = 1,
+	pixelRatio = parameters.pixelRatio !== undefined ? parameters.pixelRatio : 1,
 
 	_precision = parameters.precision !== undefined ? parameters.precision : 'highp',
 


### PR DESCRIPTION
pixelRatio could be set by the create parameters.

I didn't find the commit where devicePixelRatio was renamed to pixelRatio. 
But i still wanna set the pixelRatio when i create a renderer. 
I don't know if there was a reason to disable it. 
