### PR TITLE
Fix bug where applyProjection should be used instead of applyMatrix4

### DIFF
--- a/examples/js/renderers/Projector.js
+++ b/examples/js/renderers/Projector.js
@@ -175,7 +175,7 @@ THREE.Projector = function () {
 			var positionWorld = vertex.positionWorld;
 			var positionScreen = vertex.positionScreen;
 
-			positionWorld.copy( position ).applyMatrix4( _modelMatrix );
+			positionWorld.copy( position ).applyProjection( _modelMatrix );
 			positionScreen.copy( positionWorld ).applyMatrix4( _viewProjectionMatrix );
 
 			var invW = 1 / positionScreen.w;

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -64,7 +64,7 @@ THREE.Geometry.prototype = {
 		for ( var i = 0, il = this.vertices.length; i < il; i ++ ) {
 
 			var vertex = this.vertices[ i ];
-			vertex.applyMatrix4( matrix );
+			vertex.applyProjection( matrix );
 
 		}
 


### PR DESCRIPTION
Vector3.applyMatrix4 is only used for affine matrices but arbitrary Matrix4 should be allowed in the two places I have changed.
Demo of bugs http://jsfiddle.net/fta2012/4ctg5yuz/2/
Fixed in http://jsfiddle.net/fta2012/ojozsrcx/1/

I feel like applyMatrix4 is probably used incorrectly in a few more places. Will open an issue to discuss proper fix.
