### PR TITLE
add Mesh.computePlanarShadow() method

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -314,6 +314,52 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 }() );
 
+THREE.Mesh.prototype.computePlanarShadow = function () {
+
+	// based on https://www.opengl.org/archives/resources/features/StencilTalk/tsld021.htm
+	var shadowMatrix = new THREE.Matrix4();
+
+	return function ( parentMesh, plane, lightPosition4D ) {
+		
+		var dot = plane.normal.x * lightPosition4D.x +
+			  plane.normal.y * lightPosition4D.y +
+			  plane.normal.z * lightPosition4D.z +
+			  -plane.constant * lightPosition4D.w;
+
+		var sme = shadowMatrix.elements;
+
+		sme[ 0 ]  = dot - lightPosition4D.x * plane.normal.x;
+		sme[ 4 ]  = - lightPosition4D.x * plane.normal.y;
+		sme[ 8 ]  = - lightPosition4D.x * plane.normal.z;
+		sme[ 12 ] = - lightPosition4D.x * -plane.constant;
+
+		sme[ 1 ]  = - lightPosition4D.y * plane.normal.x;
+		sme[ 5 ]  = dot - lightPosition4D.y * plane.normal.y;
+		sme[ 9 ]  = - lightPosition4D.y * plane.normal.z;
+		sme[ 13 ] = - lightPosition4D.y * -plane.constant;
+
+		sme[ 2 ]  = - lightPosition4D.z * plane.normal.x;
+		sme[ 6 ]  = - lightPosition4D.z * plane.normal.y;
+		sme[ 10 ] = dot - lightPosition4D.z * plane.normal.z;
+		sme[ 14 ] = - lightPosition4D.z * -plane.constant;
+
+		sme[ 3 ]  = - lightPosition4D.w * plane.normal.x;
+		sme[ 7 ]  = - lightPosition4D.w * plane.normal.y;
+		sme[ 11 ] = - lightPosition4D.w * plane.normal.z;
+		sme[ 15 ] = dot - lightPosition4D.w * -plane.constant;
+	
+		this.matrix.identity();
+		this.matrix.multiply( shadowMatrix );
+		this.matrix.multiply( parentMesh.matrix );
+		
+		this.matrixAutoUpdate = false;
+		
+		return this;
+
+	};
+
+}();
+
 THREE.Mesh.prototype.clone = function ( object, recursive ) {
 
 	if ( object === undefined ) object = new THREE.Mesh( this.geometry, this.material );


### PR DESCRIPTION
This PR adds a new computePlanarShadow method to the THREE.Mesh class.  Here's a simple demo of the new feature:
[computePlanarShadow-Demo](http://erichlof.github.io/computePlanarShadow-Demo/computePlanarShadow-Demo.html)

The function's signature is:

``` javascript
THREE.Mesh.computePlanarShadow( parentMesh, plane, lightPosition4D );
```

Where Mesh is a THREE.Mesh object with a dark semi-transparent BasicMaterial that has the same geometry as its shadow-casting parent mesh.  The function takes 3 arguments:

parentMesh: the original THREE.Mesh object created in the usual manner of any Three.js app

plane: - a THREE.Plane object specifying the plane in which the shadow will appear.  The Plane constructor takes 2 parameters which are its normal that points away from its surface, and a number constant.  This constant needs to match the y position of the shadow-receiving plane, for example ground.position.y

lightPosition4D: a THREE.Vector4 object describing the light source's 3D position.  The additional 4th component is a value ranging from > 0.0 to <= 1.0 which specifies the amount of light ray divergence.  A value of slightly greater than 0.0, such as 0.00001 will specify minimum light ray divergence, nearly parallel, like directional sunlight.  A value of 1.0 will specify maximum divergence as in a pointLight, like a lightbulb or candle.  The reason that this value cannot be == 0.0 is that there are errors when later trying to compute the inverseMatrix, so a value slightly greater than 0.0, such as 0.00001 avoids the numerical error.

There are about 20 lines of setup necessary before calling this function.  Most of these lines will already be in a Three.js app anyway, like adding a Mesh and Light to the scene.  The only special setup that might be new to some Three.js users is creating a THREE.Plane object and a THREE.Vector4 object for the shadow plane and 4D light source.  But once the initialization is done, the actual method usage is 1 line of code!  It is simply called once every animation loop.  A thorough step-by-step explanation can be found here:
https://github.com/erichlof/computePlanarShadow-Demo

The algorithm used for implementing this new method can be found here:
https://www.opengl.org/archives/resources/features/StencilTalk/tsld021.htm

I feel this new method would be advantageous to those developers who are wanting simple fast-performing  (but correct) planar shadows.  As with any shadow method, there are limitations which I will outline in a related issue:
https://github.com/mrdoob/three.js/issues/6060

Thanks!
-Erich
