### PR TITLE
Safe EventDispatcher

### DIFF
--- a/examples/js/wip/benchmark/TypedGeometry.js
+++ b/examples/js/wip/benchmark/TypedGeometry.js
@@ -154,6 +154,8 @@ THREE.TypedGeometry = function ( size ) {
 
 	this.boundingBox = null;
 	this.boundingSphere = null;
+	this.eventDispatcher = new THREE.EventDispatcher();
+	this.eventDispatcher.exposePublicAPIOnObject( this );
 
 };
 
@@ -169,10 +171,10 @@ THREE.TypedGeometry.prototype = {
 
 	dispose: function () {
 
-		this.dispatchEvent( { type: 'dispose' } );
+		this.eventDispatcher.dispatchEvent( { type: 'dispose', target: this } );
 
 	}
 
 };
 
-THREE.EventDispatcher.prototype.apply( THREE.TypedGeometry.prototype );
+

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -2,46 +2,29 @@
  * https://github.com/mrdoob/eventdispatcher.js/
  */
 
-THREE.EventDispatcher = function () {}
+THREE.EventDispatcher = function () {
 
-THREE.EventDispatcher.prototype = {
+	var listeners = {};
 
-	constructor: THREE.EventDispatcher,
+	this.addEventListener = function ( type, listener ) {
 
-	apply: function ( object ) {
+		var listenersForType = listeners[ type ];
+		if ( listenersForType === undefined ) {
 
-		object.addEventListener = THREE.EventDispatcher.prototype.addEventListener;
-		object.hasEventListener = THREE.EventDispatcher.prototype.hasEventListener;
-		object.removeEventListener = THREE.EventDispatcher.prototype.removeEventListener;
-		object.dispatchEvent = THREE.EventDispatcher.prototype.dispatchEvent;
-
-	},
-
-	addEventListener: function ( type, listener ) {
-
-		if ( this._listeners === undefined ) this._listeners = {};
-
-		var listeners = this._listeners;
-
-		if ( listeners[ type ] === undefined ) {
-
-			listeners[ type ] = [];
+			listenersForType = [];
+			listeners[ type ] = listenersForType;
 
 		}
 
-		if ( listeners[ type ].indexOf( listener ) === - 1 ) {
+		if ( listenersForType.indexOf( listener ) === - 1 ) {
 
-			listeners[ type ].push( listener );
+			listenersForType.push( listener );
 
 		}
 
-	},
+	};
 
-	hasEventListener: function ( type, listener ) {
-
-		if ( this._listeners === undefined ) return false;
-
-		var listeners = this._listeners;
+	this.hasEventListener = function ( type, listener ) {
 
 		if ( listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1 ) {
 
@@ -51,46 +34,38 @@ THREE.EventDispatcher.prototype = {
 
 		return false;
 
-	},
+	};
 
-	removeEventListener: function ( type, listener ) {
+	this.removeEventListener = function ( type, listener ) {
 
-		if ( this._listeners === undefined ) return;
+		var listenersForType = listeners[ type ];
 
-		var listeners = this._listeners;
-		var listenerArray = listeners[ type ];
+		if ( listenersForType !== undefined ) {
 
-		if ( listenerArray !== undefined ) {
-
-			var index = listenerArray.indexOf( listener );
+			var index = listenersForType.indexOf( listener );
 
 			if ( index !== - 1 ) {
 
-				listenerArray.splice( index, 1 );
+				listenersForType.splice( index, 1 );
 
 			}
 
 		}
 
-	},
+	};
 
-	dispatchEvent: function ( event ) {
+	this.dispatchEvent = function ( event ) {
 
-		if ( this._listeners === undefined ) return;
+		var listenersForType = listeners[ event.type ];
 
-		var listeners = this._listeners;
-		var listenerArray = listeners[ event.type ];
-
-		if ( listenerArray !== undefined ) {
-
-			event.target = this;
+		if ( listenersForType !== undefined ) {
 
 			var array = [];
-			var length = listenerArray.length;
+			var length = listenersForType.length;
 
 			for ( var i = 0; i < length; i ++ ) {
 
-				array[ i ] = listenerArray[ i ];
+				array[ i ] = listenersForType[ i ];
 
 			}
 
@@ -102,6 +77,16 @@ THREE.EventDispatcher.prototype = {
 
 		}
 
-	}
+	};
+
+
+	this.exposePublicAPIOnObject = function ( object ) {
+
+		object.addEventListener = this.addEventListener;
+		object.hasEventListener = this.hasEventListener;
+		object.removeEventListener = this.removeEventListener;
+
+	};
+}
 
 };


### PR DESCRIPTION
This is just a suggestion. 

The current implementation of EventDispatcher is intrusive. It sticks `_listeners` on
object it's being added to. If that object already has a `_listeners` your out of luck.

Above is a non intrusive implementation for your consideration. The `listeners`
collection is not public whatsoever.

I [tested them on jsperf and it's the same speed on chrome and significantly faster
on Firefox](http://jsperf.com/event-dispatching)

I didn't expose `dispatchEvent` to the public API of `TypedGeometry` because it
seemed to me users of `TypedGeometry` shouldn't be able to dispatch events but
of course that could be exposed too.

Anyway, just passing it on as a suggestion. I'm learning JS as I go and finding that what I learned
at Google was wrong :P  They use their Closure Compiler and they basically
treat JavaScript like Java and expect the compiler to make things semi safe but
JavaScript can be safe all by itself so I'm slowly learing more JavaScripty
ways.
