### PR TITLE
additional ObjectLoader.js texture maps

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -437,6 +437,27 @@ THREE.ObjectLoader.prototype = {
 					object = new THREE.Line( geometry, material );
 
 					break;
+					
+				case 'PointCloud':
+
+					var geometry = geometries[ data.geometry ];
+					var material = materials[ data.material ];
+
+					if ( geometry === undefined ) {
+
+						console.warn( 'THREE.ObjectLoader: Undefined geometry', data.geometry );
+
+					}
+
+					if ( material === undefined ) {
+
+						console.warn( 'THREE.ObjectLoader: Undefined material', data.material );
+
+					}
+
+					object = new THREE.PointCloud( geometry, material );
+
+					break;
 
 				case 'Sprite':
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -229,10 +229,82 @@ THREE.ObjectLoader.prototype = {
 
 						console.warn( 'THREE.ObjectLoader: Undefined texture', data.map );
 
-				}
+					}
 
 					material.map = textures[ data.map ];
 
+				}
+				
+				if ( data.bumpMap ) {	
+			
+					if ( !textures[data.bumpMap] ) {
+						
+						console.warn( 'THREE.ObjectLoader: Undefined texture', data.bumpMap );
+					
+					}
+					
+					material.bumpMap = textures[data.bumpMap];
+					
+				}
+				
+				if ( data.alphaMap ) {
+					
+					if ( !textures[data.alphaMap] ) {
+						
+						console.warn( 'THREE.ObjectLoader: Undefined texture', data.alphaMap );
+						
+					}
+					
+					material.alphaMap = textures[data.alphaMap];
+					
+				}
+				
+				if ( data.envMap ) {
+				
+					if ( !textures[data.envMap] ) {
+						
+						console.warn( 'THREE.ObjectLoader: Undefined texture', data.envMap );
+						
+					}
+					
+					material.envMap = textures[data.envMap];
+					
+				}
+				
+				if ( data.normalMap ) {
+				
+					if ( !textures[data.normalMap] ) {
+						
+						console.warn( 'THREE.ObjectLoader: Undefined texture', data.normalMap );
+						
+					}
+					
+					material.normalMap = textures[data.normalMap];
+					
+				}
+				
+				if ( data.lightMap ) {
+				
+					if ( !textures[data.lightMap] ) {
+						
+						console.warn( 'THREE.ObjectLoader: Undefined texture', data.lightMap );
+						
+					}
+					
+					material.lightMap = textures[data.lightMap];
+					
+				}
+				
+				if ( data.specularMap ) {
+				
+					if ( !textures[data.specularMap] ) {
+						
+						console.warn( 'THREE.ObjectLoader: Undefined texture', data.specularMap );
+						
+					}
+					
+					material.specularMap = textures[data.specularMap];
+					
 				}
 
 				materials[ data.uuid ] = material;


### PR DESCRIPTION
Simple extension to the PR submitted by @denzp mrdoob#5502 to allow for other map types.  Tested here with map, bumpMap, and alphaMap: http://datable.net/WebGL/Test299/ 
