### PR TITLE
intersects Add Item

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -110,9 +110,12 @@
 
 			}
 
+			var len = intersects.length;
+
 			for ( var i = 0, l = objects.length; i < l; i ++ ) {
 
 				intersectObject( objects[ i ], this, intersects, recursive );
+				if ( intersects.length > len ) { intersects[ len ].item = i; len++; }
 
 			}
 


### PR DESCRIPTION
a quick way to determine the number of the object to the intersection for `intersectObjects`.
for example:

```
var intersects = raycaster.intersectObjects( objects );
if (intersects.length > 0) {

    item = intersects[0].item;
    // item = objects.indexOf(intersects[ 0 ].object);
    DHTMLSound('snd/' + String( item ) + '.mp3', 'sound' + String( item ), ' ');

}
```

[example](http://alexan0308.github.io/threejs/examples/#piano)
