### PR TITLE
Auto-name items on load in Editor in case their name is blank

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -559,7 +559,7 @@ THREE.ObjectLoader.prototype = {
 
 			object.uuid = data.uuid;
 
-			if ( data.name !== undefined ) object.name = data.name;
+			if ( data.name !== undefined ) object.name = data.name; else object.name = object.type; // + " @" + object.id;
 			if ( data.matrix !== undefined ) {
 
 				matrix.fromArray( data.matrix );


### PR DESCRIPTION
When importing json scene, we have a lot of colored rectangles on the
right pane of the editor, all without names. That's not so easy to navigate by
mouse there. With names, navigation is much cleaner.
