### PR TITLE
Allow mouse wheel events through iframe in Mac Safari

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -183,7 +183,7 @@
 			</a>
 			<div id="content"></div>
 		</div>
-		<iframe id="viewer" allowfullscreen></iframe>
+		<iframe id="viewer" allowfullscreen onmousewheel=""></iframe>
 
 		<script>
 


### PR DESCRIPTION
See issue #6074
See http://kb.tableau.com/articles/issue/scroll-bars-in-embedded-views-do-not-work-in-safari.
