### PR TITLE
ObjectLoader: support data urls

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -311,8 +311,9 @@ THREE.ObjectLoader.prototype = {
 			for ( var i = 0, l = json.length; i < l; i ++ ) {
 
 				var image = json[ i ];
+				var path = /^(\/\/)|([a-z]+:(\/\/)?)/i.test( image.url ) ? image.url : scope.texturePath + image.url;
 
-				images[ image.uuid ] = loadImage( scope.texturePath + image.url );
+				images[ image.uuid ] = loadImage( path );
 
 			}
 


### PR DESCRIPTION
I've many small textures and playing around with possible solutions to improve load time. One possible way is to embed images as Data-URLs.

This PR prevents the ObjectLoader from prepending the texture base path to Data URLs.
