### PR TITLE
TrackballControls with new rotation mode

### DIFF
--- a/examples/misc_controls_trackball.html
+++ b/examples/misc_controls_trackball.html
@@ -35,8 +35,7 @@
 		<div id="container"></div>
 		<div id="info">
 			<a href="http://threejs.org" target="_blank">three.js</a> - trackball controls example</br>
-			MOVE mouse &amp; press LEFT/A: rotate, MIDDLE/S: zoom, RIGHT/D: pan</br>
-			R: switch from cylindrical (default) to spherical rotation
+			MOVE mouse &amp; press LEFT/A: rotate, MIDDLE/S: zoom, RIGHT/D: pan
 		</div>
 
 		<script src="../build/three.min.js"></script>
@@ -134,21 +133,9 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize, false );
-				window.addEventListener( 'keypress', onKeyPress, true);
-
 				//
 
 				render();
-
-			}
-
-			function onKeyPress ( e ) {
-
-				if ( e.keyCode === 114 ) {
-
-					controls.cylindricalRotation = !controls.cylindricalRotation;
-
-				}
 
 			}
 


### PR DESCRIPTION
Following indication on https://github.com/mrdoob/three.js/pull/6103 I submitted a new pull request by removing the old rotation on TrackballControls. The related example has been updated.
I also simplified the equation on getMouseOnCircle as suggested in the previous discussion.
