### PR TITLE
OrbitControls: Support OrthographicCamera Zooming

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -37,9 +37,13 @@ THREE.OrbitControls = function ( object, domElement ) {
 	this.noZoom = false;
 	this.zoomSpeed = 1.0;
 
-	// Limits to how far you can dolly in and out
+	// Limits to how far you can dolly in and out ( PerspectiveCamera only )
 	this.minDistance = 0;
 	this.maxDistance = Infinity;
+
+	// Limits to how far you can zoom in and out ( OrthographicCamera only )
+	this.minZoom = 0;
+	this.maxZoom = Infinity;
 
 	// Set to true to disable this control
 	this.noRotate = false;
@@ -112,6 +116,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	this.target0 = this.target.clone();
 	this.position0 = this.object.position.clone();
+	this.zoom0 = this.object.zoom;
 
 	// so camera.up is the orbit axis
 
@@ -180,7 +185,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
-		if ( scope.object.fov !== undefined ) {
+		if ( scope.object instanceof THREE.PerspectiveCamera ) {
 
 			// perspective
 			var position = scope.object.position;
@@ -194,7 +199,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 			scope.panLeft( 2 * deltaX * targetDistance / element.clientHeight );
 			scope.panUp( 2 * deltaY * targetDistance / element.clientHeight );
 
-		} else if ( scope.object.top !== undefined ) {
+		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
 
 			// orthographic
 			scope.panLeft( deltaX * (scope.object.right - scope.object.left) / element.clientWidth );
@@ -217,7 +222,21 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
-		scale /= dollyScale;
+		if ( scope.object instanceof THREE.PerspectiveCamera ) {
+
+			scale /= dollyScale;
+
+		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+
+			scope.object.zoom = Math.max( this.minZoom, Math.min( this.maxZoom, this.object.zoom * dollyScale ) );
+			scope.object.updateProjectionMatrix();
+			scope.dispatchEvent( changeEvent );
+
+		} else {
+
+			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+
+		}
 
 	};
 
@@ -229,7 +248,21 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
-		scale *= dollyScale;
+		if ( scope.object instanceof THREE.PerspectiveCamera ) {
+
+			scale *= dollyScale;
+
+		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+
+			scope.object.zoom = Math.max( this.minZoom, Math.min( this.maxZoom, this.object.zoom / dollyScale ) );
+			scope.object.updateProjectionMatrix();
+			scope.dispatchEvent( changeEvent );
+
+		} else {
+
+			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+
+		}
 
 	};
 
@@ -315,6 +348,10 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		this.target.copy( this.target0 );
 		this.object.position.copy( this.position0 );
+		this.object.zoom = this.zoom0;
+
+		this.object.updateProjectionMatrix();
+		this.dispatchEvent( changeEvent );
 
 		this.update();
 


### PR DESCRIPTION
`OrbitControls` previously supported `OrthographicCamera`s, but zooming with an `OrthographicCamera` was not supported.

A perspective camera can "zoom" by changing the zoom factor or by dollying -- i.e., moving closer to the object. An orthographic camera can only zoom by changing the zoom factor -- and consequently, the camera projection matrix.

`OrbitControls` "zooms" a perspective camera by dollying, and an orthographic camera by changing the zoom factor.
