### PR TITLE
Fix 'Math.sign' polyfill to match ES6 specs

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -16,9 +16,11 @@ if ( typeof module === 'object' ) {
 
 if ( Math.sign === undefined ) {
 
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign 
+
 	Math.sign = function ( x ) {
 
-		return ( x < 0 ) ? - 1 : ( x > 0 ) ? 1 : 0;
+		return ( x < 0 ) ? - 1 : ( x > 0 ) ? 1 : +x;
 
 	};
 

--- a/test/unit/math/Math.js
+++ b/test/unit/math/Math.js
@@ -1,0 +1,35 @@
+/**
+ * @author humbletim / https://github.com/humbletim
+ */
+
+module( "Math" );
+
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign
+//http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.sign
+/* 
+20.2.2.29 Math.sign(x)
+
+Returns the sign of the x, indicating whether x is positive, negative or zero.
+
+If x is NaN, the result is NaN.
+If x is -0, the result is -0.
+If x is +0, the result is +0.
+If x is negative and not -0, the result is -1.
+If x is positive and not +0, the result is +1.
+*/
+
+test( "Math.sign/polyfill", function() {
+
+	ok( isNaN( Math.sign(NaN) ) , "If x is NaN<NaN>, the result is NaN.");
+	ok( isNaN( Math.sign(new THREE.Vector3()) ) , "If x is NaN<object>, the result is NaN.");
+	ok( isNaN( Math.sign() ) , "If x is NaN<undefined>, the result is NaN.");
+	ok( isNaN( Math.sign('--3') ) , "If x is NaN<'--3'>, the result is NaN.");
+	ok( Math.sign(-0) === -0 , "If x is -0, the result is -0.");
+	ok( Math.sign(+0) === +0 , "If x is +0, the result is +0.");
+	ok( Math.sign(-Infinity) === -1 , "If x is negative<-Infinity> and not -0, the result is -1.");
+	ok( Math.sign('-3') === -1 , "If x is negative<'-3'> and not -0, the result is -1.");
+	ok( Math.sign('-1e-10') === -1 , "If x is negative<'-1e-10'> and not -0, the result is -1.");
+	ok( Math.sign(+Infinity) === +1 , "If x is positive<+Infinity> and not +0, the result is +1.");
+	ok( Math.sign('+3') === +1 , "If x is positive<'+3'> and not +0, the result is +1.");
+
+});

--- a/test/unit/unittests_sources.html
+++ b/test/unit/unittests_sources.html
@@ -45,6 +45,7 @@
   <script src="math/Euler.js"></script>
   <script src="math/Line3.js"></script>
   <script src="math/Quaternion.js"></script>
+  <script src="math/Math.js"></script>
   <script src="math/Matrix3.js"></script>
   <script src="math/Matrix4.js"></script>
   <script src="math/Frustum.js"></script>

--- a/test/unit/unittests_three-math.html
+++ b/test/unit/unittests_three-math.html
@@ -28,6 +28,7 @@
   <script src="math/Euler.js"></script>
   <script src="math/Line3.js"></script>
   <script src="math/Quaternion.js"></script>
+  <script src="math/Math.js"></script>
   <script src="math/Matrix3.js"></script>
   <script src="math/Matrix4.js"></script>
   <script src="math/Frustum.js"></script>

--- a/test/unit/unittests_three.html
+++ b/test/unit/unittests_three.html
@@ -28,6 +28,7 @@
   <script src="math/Euler.js"></script>
   <script src="math/Line3.js"></script>
   <script src="math/Quaternion.js"></script>
+  <script src="math/Math.js"></script>
   <script src="math/Matrix3.js"></script>
   <script src="math/Matrix4.js"></script>
   <script src="math/Frustum.js"></script>

--- a/test/unit/unittests_three.min.html
+++ b/test/unit/unittests_three.min.html
@@ -28,6 +28,7 @@
   <script src="math/Euler.js"></script>
   <script src="math/Line3.js"></script>
   <script src="math/Quaternion.js"></script>
+  <script src="math/Math.js"></script>
   <script src="math/Matrix3.js"></script>
   <script src="math/Matrix4.js"></script>
   <script src="math/Frustum.js"></script>


### PR DESCRIPTION
This fix corrects for subtle differences in behavior between Three.js's `Math.sign` polyfill compared to ES6 specs and native implementations.

In particular it now handles the cases of `Math.sign(-0)` and `Math.sign(NaN)` correctly.
