### PR TITLE
Add EventDispatcher to RaytracingRenderer

### DIFF
--- a/examples/js/renderers/RaytracingRenderer.js
+++ b/examples/js/renderers/RaytracingRenderer.js
@@ -8,6 +8,8 @@ THREE.RaytracingRenderer = function ( parameters ) {
 	console.log( 'THREE.RaytracingRenderer', THREE.REVISION );
 
 	parameters = parameters || {};
+	
+	var scope = this;
 
 	var canvas = document.createElement( 'canvas' );
 	var context = canvas.getContext( '2d', {
@@ -38,8 +40,6 @@ THREE.RaytracingRenderer = function ( parameters ) {
 	var cache = {};
 
 	var animationFrameId = null;
-
-	var dispatch = this.dispatchEvent.bind(this);
 
 	this.domElement = canvas;
 
@@ -460,7 +460,7 @@ THREE.RaytracingRenderer = function ( parameters ) {
 
 				if ( blockY >= canvasHeight ) {
 
-					dispatch( { type: "complete" } );
+					scope.dispatchEvent( { type: "complete" } );
 
 					return;
 

--- a/examples/js/renderers/RaytracingRenderer.js
+++ b/examples/js/renderers/RaytracingRenderer.js
@@ -460,7 +460,7 @@ THREE.RaytracingRenderer = function ( parameters ) {
 
 				if ( blockY >= canvasHeight ) {
 
-					dispatch( { type: "renderfinish" } );
+					dispatch( { type: "complete" } );
 
 					return;
 

--- a/examples/js/renderers/RaytracingRenderer.js
+++ b/examples/js/renderers/RaytracingRenderer.js
@@ -39,6 +39,8 @@ THREE.RaytracingRenderer = function ( parameters ) {
 
 	var animationFrameId = null;
 
+	var dispatch = this.dispatchEvent.bind(this);
+
 	this.domElement = canvas;
 
 	this.autoClear = true;
@@ -456,7 +458,13 @@ THREE.RaytracingRenderer = function ( parameters ) {
 				blockX = 0;
 				blockY += blockSize;
 
-				if ( blockY >= canvasHeight ) return;
+				if ( blockY >= canvasHeight ) {
+
+					dispatch( { type: "renderfinish" } );
+
+					return;
+
+				}
 
 			}
 
@@ -533,3 +541,5 @@ THREE.RaytracingRenderer = function ( parameters ) {
 	};
 
 };
+
+THREE.EventDispatcher.prototype.apply(THREE.RaytracingRenderer.prototype);


### PR DESCRIPTION
I think it would be a good idea to have an event dispatched after the render is finished with the RaytracingRenderer. There is no real way of telling right now and since it acts a bit differently then the other renderers I think it would beneficial. 

I use it in my THREE.WebMExporter example here
http://chuckfairy.com/THREE.WebMExporter/examples/raytracing.html

Thanks for all the hard work guys!
