### PR TITLE
added object.uniformValues for overwriting material.uniforms

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -241,6 +241,7 @@
 				"webgl_interactive_buffergeometry",
 				"webgl_interactive_cubes",
 				"webgl_interactive_cubes_gpu",
+				"webgl_interactive_instances_gpu",
 				"webgl_interactive_cubes_ortho",
 				"webgl_interactive_draggablecubes",
 				"webgl_interactive_lines",

--- a/examples/webgl_interactive_instances_gpu.html
+++ b/examples/webgl_interactive_instances_gpu.html
@@ -1,0 +1,443 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - interactive instances (gpu)</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #f0f0f0;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			.info {
+				position: absolute;
+				background-color: black;
+				opacity: 0.8;
+				color: white;
+				text-align: center;
+				top: 0px;
+				width: 100%;
+			}
+
+			.info a {
+				color: #00ffff;
+			}
+		</style>
+	</head>
+	<body>
+
+		<div class="info">
+
+			<a href="http://threejs.org" target="_blank">three.js</a> webgl - gpu picking of geometry instances using a single material
+
+			<br/><br/>
+
+			<div>
+
+				<span>number of instances </span>
+				<select id="instanceCount">
+					<option>500</option>
+					<option>1000</option>
+					<option selected>2000</option>
+					<option>3000</option>
+					<option>5000</option>
+					<option>10000</option>
+				</select>
+
+				&nbsp;&nbsp;&nbsp;
+
+				<span>use single material </span>
+				<input id="useSingleMaterial" type="checkbox" checked />
+
+			</div>
+
+		</div>
+
+		<div id="container"></div>
+
+		<script src="../build/three.min.js"></script>
+
+		<script src="../src/renderers/WebGLRenderer.js"></script>
+
+		<script src="js/controls/TrackballControls.js"></script>
+
+		<script src="js/libs/stats.min.js"></script>
+
+		<script id="pickingVert" type="x-shader/x-vertex">
+
+			// precision mediump float;
+			// precision mediump int;
+
+			// uniform mat4 modelViewMatrix;
+			// uniform mat4 projectionMatrix;
+
+			// attribute vec3 position;
+
+			void main()	{
+
+				gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+			}
+
+		</script>
+
+		<script id="pickingFrag" type="x-shader/x-fragment">
+
+			// precision mediump float;
+			// precision mediump int;
+
+			uniform vec3 pickingColor;
+
+			void main()	{
+
+				gl_FragColor.xyz = pickingColor;
+
+			}
+
+		</script>
+
+		<script>
+
+			var container, stats;
+			var camera, controls, scene, renderer;
+			var pickingData, pickingTexture, pickingScene;
+			var highlightBox;
+			var material, pickingMaterial
+			var materialList = [];
+			var geometry;
+
+			var mouse = new THREE.Vector2();
+			var scale = 1.03;
+
+			//create buffer for reading single pixel
+			var pixelBuffer = new Uint8Array( 4 );
+
+			//
+
+			var instanceCountElm = document.getElementById( 'instanceCount' );
+
+			var instanceCount = instanceCountElm.value;
+
+			instanceCountElm.addEventListener( "change", function(){
+
+				instanceCount = instanceCountElm.value;
+				console.log( "instanceCount", instanceCount );
+				initInstances();
+
+			} );
+
+			//
+
+			var useSingleMaterialElm = document.getElementById( 'useSingleMaterial' );
+
+			var useSingleMaterial = useSingleMaterialElm.checked;
+
+			useSingleMaterialElm.addEventListener( "change", function(){
+
+				useSingleMaterial = useSingleMaterialElm.checked;
+				console.log( "useSingleMaterial", useSingleMaterial );
+				initInstances();
+
+			} );
+
+			//
+
+			init();
+			initInstances();
+			animate();
+
+			function initInstances(){
+
+				// clean up
+
+				materialList.forEach( function( m ){
+					m.dispose();
+				} );
+
+				if( geometry ) geometry.dispose();
+
+				scene = new THREE.Scene();
+				pickingScene = new THREE.Scene();
+				pickingData = {};
+				materialList = [];
+
+				// make instances
+
+				var loader = new THREE.JSONLoader();
+				loader.load( 'obj/Suzanne.js', function ( geo ) {
+
+					geometry = geo;
+
+					geometry.computeVertexNormals();
+
+					geometry.computeBoundingBox();
+					var size = geometry.boundingBox.size();
+
+					highlightBox.children[0].geometry = new THREE.BoxGeometry(
+						size.x, size.y, size.z
+					);
+					highlightBox.children[1].geometry = new THREE.BoxGeometry(
+						size.x, size.y, size.z
+					);
+
+					console.time( "init mesh" );
+
+					for ( var i = 0; i < instanceCount; i ++ ) {
+
+						var object = new THREE.Mesh( geometry, material );
+						var color = Math.random() * 0xffffff;
+
+						object.position.x = Math.random() * 800 - 400;
+						object.position.y = Math.random() * 800 - 400;
+						object.position.z = Math.random() * 800 - 400;
+
+						object.rotation.x = Math.random() * 2 * Math.PI;
+						object.rotation.y = Math.random() * 2 * Math.PI;
+						object.rotation.z = Math.random() * 2 * Math.PI;
+
+						object.scale.x = object.scale.y = object.scale.z = Math.random() * 30;
+
+						scene.add( object );
+
+						//
+
+						pickingData[ i + 1 ] = object;
+
+						var pickingObject = object.clone();
+
+						pickingScene.add( pickingObject );
+
+						//
+
+						if( useSingleMaterial ){
+
+							object.uniformValues = [
+								[ "diffuse", new THREE.Color( color ) ]
+							]
+
+							pickingObject.material = pickingMaterial;
+							pickingObject.uniformValues = [
+								[ "pickingColor", new THREE.Color( i + 1 ) ]
+							]
+
+						}else{
+
+							object.material = material.clone();
+							object.material.color.setHex( color );
+							materialList.push( object.material );
+
+							pickingObject.material = pickingMaterial.clone();
+							pickingObject.material.uniforms.pickingColor.value.setHex( i + 1 );
+							materialList.push( pickingObject.material )
+
+						}
+
+					}
+
+					//
+
+					scene.add( camera );
+
+					scene.add( highlightBox );
+
+					render();
+
+					console.timeEnd( "init mesh" );
+
+					console.log( "material count", materialList.length );
+
+					console.log( renderer.info.memory )
+					console.log( renderer.info.render )
+
+					console.log( material )
+
+				} );
+
+			}
+
+			function init() {
+
+				container = document.getElementById( "container" );
+
+				camera = new THREE.PerspectiveCamera(
+					70, window.innerWidth / window.innerHeight, 1, 10000
+				);
+				camera.position.z = 500;
+				camera.add( new THREE.PointLight( 0xffffff, 1 ) );
+
+				//
+
+				pickingTexture = new THREE.WebGLRenderTarget(
+					window.innerWidth, window.innerHeight
+				);
+				pickingTexture.generateMipmaps = false;
+				pickingTexture.minFilter = THREE.NearestFilter;
+
+				//
+
+				material = new THREE.MeshPhongMaterial( {
+					shading: THREE.SmoothShading
+				} );
+
+				pickingMaterial = new THREE.ShaderMaterial( {
+
+					uniforms: {
+						pickingColor: {
+							type: "c", value: new THREE.Color()
+						}
+					},
+					vertexShader: document.getElementById( 'pickingVert' ).textContent,
+					fragmentShader: document.getElementById( 'pickingFrag' ).textContent
+
+				} );
+
+				//
+
+				var boxGeo = new THREE.BoxGeometry( 1, 1, 1 );
+
+				highlightBox = new THREE.Group();
+
+				highlightBox.add(
+					new THREE.Mesh(
+						boxGeo,
+						new THREE.MeshLambertMaterial( {
+							color: 0xffff00,
+							transparent: true,
+							opacity: 0.5,
+							side: THREE.BackSide
+						} )
+					)
+				);
+
+				highlightBox.add(
+					new THREE.Mesh(
+						boxGeo,
+						new THREE.MeshLambertMaterial( {
+							color: 0xffff00,
+							transparent: true,
+							opacity: 0.5,
+							side: THREE.FrontSide
+						} )
+					)
+				);
+
+				//
+
+				renderer = new THREE.WebGLRenderer( {
+					antialias: true,
+					alpha: true
+				} );
+				renderer.setClearColor( 0xffffff );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.sortObjects = false;
+				container.appendChild( renderer.domElement );
+
+				//
+
+				controls = new THREE.TrackballControls(
+					camera, renderer.domElement
+				);
+				controls.rotateSpeed = 1.0;
+				controls.zoomSpeed = 1.2;
+				controls.panSpeed = 0.8;
+				controls.noZoom = false;
+				controls.noPan = false;
+				controls.staticMoving = true;
+				controls.dynamicDampingFactor = 0.3;
+
+				//
+
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '0px';
+				container.appendChild( stats.domElement );
+
+				renderer.domElement.addEventListener( 'mousemove', onMouseMove );
+
+			}
+
+			//
+
+			function onMouseMove( e ) {
+
+				mouse.x = e.clientX;
+				mouse.y = e.clientY;
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+				controls.update();
+				stats.update();
+
+			}
+
+			function pick() {
+
+				// render the picking scene off-screen
+
+				renderer.render( pickingScene, camera, pickingTexture );
+
+				// read the pixel under the mouse from the texture
+
+				renderer.readRenderTargetPixels(
+					pickingTexture,
+					mouse.x,
+					pickingTexture.height - mouse.y,
+					1,
+					1,
+					pixelBuffer
+				);
+
+				// interpret the pixel as an ID
+
+				var id =
+					( pixelBuffer[0] << 16 ) |
+					( pixelBuffer[1] << 8 ) |
+					( pixelBuffer[2] );
+
+				var object = pickingData[ id ];
+
+				if ( object ) {
+
+					//move the highlightBox so that it surrounds the picked object
+
+					if ( object.position && object.rotation && object.scale ){
+
+						highlightBox.position.copy( object.position );
+						highlightBox.rotation.copy( object.rotation );
+
+						highlightBox.children[0].scale.copy( object.scale ).multiplyScalar( scale );
+						highlightBox.children[1].scale.copy( object.scale ).multiplyScalar( scale );
+
+						highlightBox.visible = true;
+
+					}
+
+				} else {
+
+					highlightBox.visible = false;
+
+				}
+
+			}
+
+			function render() {
+
+				pick();
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/examples/webgl_interactive_instances_gpu.html
+++ b/examples/webgl_interactive_instances_gpu.html
@@ -146,8 +146,6 @@
 				} );
 
 				if( geometry ) geometry.dispose();
-				if( material ) material.dispose();
-				if( pickingMaterial ) pickingMaterial.dispose();
 
 				scene = new THREE.Scene();
 				scene.add( camera );
@@ -161,6 +159,7 @@
 					shading: THREE.SmoothShading,
 					color: new THREE.Color( 0xffff00 )
 				} );
+				materialList.push( material );
 
 				pickingMaterial = new THREE.ShaderMaterial( {
 
@@ -173,12 +172,14 @@
 					fragmentShader: document.getElementById( 'pickingFrag' ).textContent
 
 				} );
+				materialList.push( pickingMaterial );
 
 				// make instances
 				loader.load( 'obj/Suzanne.js', function ( geo ) {
 
-					geometry = geo;
-					geometry.computeVertexNormals();
+					// geometry = geo;
+					geometry = new THREE.BoxGeometry( 1, 1, 1 );
+					// geometry.computeVertexNormals();
 					geometry.computeBoundingBox();
 
 					geometrySize = geometry.boundingBox.size();
@@ -190,31 +191,52 @@
 					var objectRed = new THREE.Mesh( geometry, material );
 					objectRed.position.x = 800;
 					objectRed.scale.set( 50, 50, 50 );
-					objectRed.uniformValues = [
-						[ "diffuse", new THREE.Color( 0xff0000 ) ]
-					];
 					scene.add( objectRed );
 
 					var objectGreen = new THREE.Mesh( geometry, material );
 					objectGreen.position.x = 700;
 					objectGreen.scale.set( 40, 40, 40 );
-					objectGreen.uniformValues = [
-						[ "diffuse", new THREE.Color( 0x00ff00 ) ]
-					];
 					scene.add( objectGreen );
 
 					var objectBlue = new THREE.Mesh( geometry, material );
 					objectBlue.position.x = 620;
 					objectBlue.scale.set( 30, 30, 30 );
-					objectBlue.uniformValues = [
-						[ "diffuse", new THREE.Color( 0x0000ff ) ]
-					];
 					scene.add( objectBlue );
 
 					var objectDefault = new THREE.Mesh( geometry, material );
 					objectDefault.position.x = 560;
 					objectDefault.scale.set( 20, 20, 20 );
 					scene.add( objectDefault );
+
+					if( useSingleMaterial ){
+
+						objectRed.uniformValues = [
+							[ "diffuse", new THREE.Color( 0xff0000 ) ]
+						];
+
+						objectGreen.uniformValues = [
+							[ "diffuse", new THREE.Color( 0x00ff00 ) ]
+						];
+
+						objectBlue.uniformValues = [
+							[ "diffuse", new THREE.Color( 0x0000ff ) ]
+						];
+
+					}else{
+
+						objectRed.material = material.clone();
+						objectRed.material.color.setHex( 0xff0000 );
+						materialList.push( objectRed.material );
+
+						objectGreen.material = material.clone();
+						objectGreen.material.color.setHex( 0x00ff00 );
+						materialList.push( objectGreen.material );
+
+						objectBlue.material = material.clone();
+						objectBlue.material.color.setHex( 0x0000ff );
+						materialList.push( objectBlue.material );
+
+					}
 
 					// create a lot of geometry instances to compare the time
 					// needed to initialize a single vs. separate materials
@@ -277,7 +299,7 @@
 
 					console.timeEnd( "init mesh" );
 
-					console.log( "material count", materialList.length + 2 );
+					console.log( "material count", materialList.length );
 					console.log( renderer.info.memory )
 					console.log( renderer.info.render )
 
@@ -367,6 +389,8 @@
 
 				renderer.domElement.addEventListener( 'mousemove', onMouseMove );
 
+				// controls.addEventListener( 'change', render );
+
 			}
 
 			//
@@ -444,6 +468,8 @@
 			}
 
 			function render() {
+
+				// console.log( "render" )
 
 				pick();
 				renderer.render( scene, camera );

--- a/examples/webgl_interactive_instances_gpu.html
+++ b/examples/webgl_interactive_instances_gpu.html
@@ -59,22 +59,11 @@
 		<div id="container"></div>
 
 		<script src="../build/three.min.js"></script>
-
 		<script src="../src/renderers/WebGLRenderer.js"></script>
-
 		<script src="js/controls/TrackballControls.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="pickingVert" type="x-shader/x-vertex">
-
-			// precision mediump float;
-			// precision mediump int;
-
-			// uniform mat4 modelViewMatrix;
-			// uniform mat4 projectionMatrix;
-
-			// attribute vec3 position;
 
 			void main()	{
 
@@ -85,9 +74,6 @@
 		</script>
 
 		<script id="pickingFrag" type="x-shader/x-fragment">
-
-			// precision mediump float;
-			// precision mediump int;
 
 			uniform vec3 pickingColor;
 
@@ -107,12 +93,14 @@
 			var highlightBox;
 			var material, pickingMaterial
 			var materialList = [];
-			var geometry;
+			var geometry, geometrySize;
 
 			var mouse = new THREE.Vector2();
 			var scale = 1.03;
 
-			//create buffer for reading single pixel
+			var loader = new THREE.JSONLoader();
+
+			//create buffer for reading a single pixel
 			var pixelBuffer = new Uint8Array( 4 );
 
 			//
@@ -158,30 +146,78 @@
 				} );
 
 				if( geometry ) geometry.dispose();
+				if( material ) material.dispose();
+				if( pickingMaterial ) pickingMaterial.dispose();
 
 				scene = new THREE.Scene();
+				scene.add( camera );
+				scene.add( highlightBox );
+
 				pickingScene = new THREE.Scene();
 				pickingData = {};
 				materialList = [];
 
-				// make instances
+				material = new THREE.MeshPhongMaterial( {
+					shading: THREE.SmoothShading,
+					color: new THREE.Color( 0xffff00 )
+				} );
 
-				var loader = new THREE.JSONLoader();
+				pickingMaterial = new THREE.ShaderMaterial( {
+
+					uniforms: {
+						pickingColor: {
+							type: "c", value: new THREE.Color()
+						}
+					},
+					vertexShader: document.getElementById( 'pickingVert' ).textContent,
+					fragmentShader: document.getElementById( 'pickingFrag' ).textContent
+
+				} );
+
+				// make instances
 				loader.load( 'obj/Suzanne.js', function ( geo ) {
 
 					geometry = geo;
-
 					geometry.computeVertexNormals();
-
 					geometry.computeBoundingBox();
-					var size = geometry.boundingBox.size();
 
-					highlightBox.children[0].geometry = new THREE.BoxGeometry(
-						size.x, size.y, size.z
-					);
-					highlightBox.children[1].geometry = new THREE.BoxGeometry(
-						size.x, size.y, size.z
-					);
+					geometrySize = geometry.boundingBox.size();
+
+					// create some objects with .uniformValues and one
+					// without that use the same material to show that
+					// it is possible
+
+					var objectRed = new THREE.Mesh( geometry, material );
+					objectRed.position.x = 800;
+					objectRed.scale.set( 50, 50, 50 );
+					objectRed.uniformValues = [
+						[ "diffuse", new THREE.Color( 0xff0000 ) ]
+					];
+					scene.add( objectRed );
+
+					var objectGreen = new THREE.Mesh( geometry, material );
+					objectGreen.position.x = 700;
+					objectGreen.scale.set( 40, 40, 40 );
+					objectGreen.uniformValues = [
+						[ "diffuse", new THREE.Color( 0x00ff00 ) ]
+					];
+					scene.add( objectGreen );
+
+					var objectBlue = new THREE.Mesh( geometry, material );
+					objectBlue.position.x = 620;
+					objectBlue.scale.set( 30, 30, 30 );
+					objectBlue.uniformValues = [
+						[ "diffuse", new THREE.Color( 0x0000ff ) ]
+					];
+					scene.add( objectBlue );
+
+					var objectDefault = new THREE.Mesh( geometry, material );
+					objectDefault.position.x = 560;
+					objectDefault.scale.set( 20, 20, 20 );
+					scene.add( objectDefault );
+
+					// create a lot of geometry instances to compare the time
+					// needed to initialize a single vs. separate materials
 
 					console.time( "init mesh" );
 
@@ -208,20 +244,16 @@
 
 						var pickingObject = object.clone();
 
-						pickingScene.add( pickingObject );
-
-						//
-
 						if( useSingleMaterial ){
 
 							object.uniformValues = [
 								[ "diffuse", new THREE.Color( color ) ]
-							]
+							];
 
 							pickingObject.material = pickingMaterial;
 							pickingObject.uniformValues = [
 								[ "pickingColor", new THREE.Color( i + 1 ) ]
-							]
+							];
 
 						}else{
 
@@ -231,28 +263,23 @@
 
 							pickingObject.material = pickingMaterial.clone();
 							pickingObject.material.uniforms.pickingColor.value.setHex( i + 1 );
-							materialList.push( pickingObject.material )
+							materialList.push( pickingObject.material );
 
 						}
+
+						pickingScene.add( pickingObject );
 
 					}
 
 					//
 
-					scene.add( camera );
-
-					scene.add( highlightBox );
-
 					render();
 
 					console.timeEnd( "init mesh" );
 
-					console.log( "material count", materialList.length );
-
+					console.log( "material count", materialList.length + 2 );
 					console.log( renderer.info.memory )
 					console.log( renderer.info.render )
-
-					console.log( material )
 
 				} );
 
@@ -265,7 +292,7 @@
 				camera = new THREE.PerspectiveCamera(
 					70, window.innerWidth / window.innerHeight, 1, 10000
 				);
-				camera.position.z = 500;
+				camera.position.z = 1500;
 				camera.add( new THREE.PointLight( 0xffffff, 1 ) );
 
 				//
@@ -275,24 +302,6 @@
 				);
 				pickingTexture.generateMipmaps = false;
 				pickingTexture.minFilter = THREE.NearestFilter;
-
-				//
-
-				material = new THREE.MeshPhongMaterial( {
-					shading: THREE.SmoothShading
-				} );
-
-				pickingMaterial = new THREE.ShaderMaterial( {
-
-					uniforms: {
-						pickingColor: {
-							type: "c", value: new THREE.Color()
-						}
-					},
-					vertexShader: document.getElementById( 'pickingVert' ).textContent,
-					fragmentShader: document.getElementById( 'pickingFrag' ).textContent
-
-				} );
 
 				//
 
@@ -408,15 +417,19 @@
 
 				if ( object ) {
 
-					//move the highlightBox so that it surrounds the picked object
+					// move the highlightBox so that it surrounds the picked object
 
 					if ( object.position && object.rotation && object.scale ){
 
 						highlightBox.position.copy( object.position );
 						highlightBox.rotation.copy( object.rotation );
 
-						highlightBox.children[0].scale.copy( object.scale ).multiplyScalar( scale );
-						highlightBox.children[1].scale.copy( object.scale ).multiplyScalar( scale );
+						highlightBox.children[0].scale.copy( object.scale )
+							.multiply( geometrySize )
+							.multiplyScalar( scale );
+						highlightBox.children[1].scale.copy(
+							highlightBox.children[0].scale
+						);
 
 						highlightBox.visible = true;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4571,14 +4571,21 @@ THREE.WebGLRenderer = function ( parameters ) {
 			// temporarily overwrite uniforms with values from object
 
 			overwriteUniformsObject( material, object );
-			material.needsRefresh = true;
 
 		}else if( refreshMaterial || material.needsRefresh ){
 
 			// load common uniforms
 
 			loadUniformsGeneric( material.uniformsList );
-			material.needsRefresh = false;
+
+			if( material.needsRefresh ){
+
+				// unset flags
+
+				markUniformsNeedsUpdate( material.uniformsList, undefined );
+				material.needsRefresh = undefined;
+
+			}
 
 		}
 
@@ -4834,6 +4841,16 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
+	function markUniformsNeedsUpdate ( uniforms, flag ){
+
+		for ( var j = 0, jl = uniforms.length; j < jl; j ++ ) {
+
+			uniforms[ j ][ 0 ].needsUpdate = flag;
+
+		}
+
+	}
+
 	function overwriteUniformsObject ( material, object ) {
 
 		// overwrite uniforms with values from object
@@ -4856,14 +4873,19 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		loadUniformsGeneric( material.uniformsList );
 
+		markUniformsNeedsUpdate( material.uniformsList, false );
+
 		for ( var u, j = 0, jl = m_values.length; j < jl; j ++ ) {
 
 			u = m_values[ j ];
 
 			// recover saved material value
 			m_uniforms[ u[ 0 ] ].value = u[ 1 ];
+			m_uniforms[ u[ 0 ] ].needsUpdate = true;
 
 		}
+
+		material.needsRefresh = true;
 
 	}
 
@@ -4901,12 +4923,16 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var texture, textureUnit, offset;
 
+		var k = 0;
+
 		for ( var j = 0, jl = uniforms.length; j < jl; j ++ ) {
 
 			var uniform = uniforms[ j ][ 0 ];
 
 			// needsUpdate property is not added to all uniforms.
 			if ( uniform.needsUpdate === false ) continue;
+
+			k += 1;
 
 			var type = uniform.type;
 			var value = uniform.value;
@@ -5230,6 +5256,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 			}
 
 		}
+
+		// console.log( k, uniforms.length )
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4310,7 +4310,15 @@ THREE.WebGLRenderer = function ( parameters ) {
 			var location = material.program.uniforms[ u ];
 
 			if ( location ) {
-				material.uniformsList.push( [ material.__webglShader.uniforms[ u ], location ] );
+
+				material.uniformsList.push( [
+
+					material.__webglShader.uniforms[ u ],
+					location,
+					u
+
+				] );
+
 			}
 
 		}
@@ -4563,6 +4571,25 @@ THREE.WebGLRenderer = function ( parameters ) {
 				refreshUniformsShadow( m_uniforms, lights );
 
 			}
+
+		}
+
+		// overwrite uniforms with values from object
+
+		var o_values = object.uniformValues;
+
+		if ( o_values ) {
+
+			for ( var j = 0, jl = o_values.length; j < jl; j ++ ) {
+
+				u = o_values[ j ];
+				m_uniforms[ u[ 0 ] ].value = u[ 1 ];
+
+			}
+
+		}
+
+		if ( refreshMaterial || o_values ) {
 
 			// load common uniforms
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4311,13 +4311,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( location ) {
 
-				material.uniformsList.push( [
-
-					material.__webglShader.uniforms[ u ],
-					location,
-					u
-
-				] );
+				material.uniformsList.push( [ material.__webglShader.uniforms[ u ], location ] );
 
 			}
 
@@ -4574,26 +4568,17 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		// overwrite uniforms with values from object
+		if( object.uniformValues ){
 
-		var o_values = object.uniformValues;
+			// temporarily overwrite uniforms with values from object
 
-		if ( o_values ) {
+			overwriteUniformsObject( material, object );
 
-			for ( var j = 0, jl = o_values.length; j < jl; j ++ ) {
-
-				u = o_values[ j ];
-				m_uniforms[ u[ 0 ] ].value = u[ 1 ];
-
-			}
-
-		}
-
-		if ( refreshMaterial || o_values ) {
-
-			// load common uniforms
+		}else if( refreshMaterial || material.needsRefresh ){
 
 			loadUniformsGeneric( material.uniformsList );
+
+			material.needsRefresh = false;
 
 		}
 
@@ -4844,6 +4829,49 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 
 			}
+
+		}
+
+	}
+
+	function overwriteUniformsObject ( material, object ) {
+
+		// overwrite uniforms with values from object
+
+		var m_uniforms = material.__webglShader.uniforms;
+		var m_values = [];
+		var o_values = object.uniformValues;
+
+		if ( o_values ) {
+
+			for ( var u, j = 0, jl = o_values.length; j < jl; j ++ ) {
+
+				u = o_values[ j ];
+
+				// save material value
+				m_values[ j ] = [ u[ 0 ], m_uniforms[ u[ 0 ] ].value ];
+
+				// overwrite with object value
+				m_uniforms[ u[ 0 ] ].value = u[ 1 ];
+
+			}
+
+		}
+
+		loadUniformsGeneric( material.uniformsList );
+
+		if ( m_values.length > 0 ) {
+
+			for ( var u, j = 0, jl = m_values.length; j < jl; j ++ ) {
+
+				u = m_values[ j ];
+
+				// recover saved material value
+				m_uniforms[ u[ 0 ] ].value = u[ 1 ];
+
+			}
+
+			material.needsRefresh = true;
 
 		}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4310,9 +4310,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			var location = material.program.uniforms[ u ];
 
 			if ( location ) {
-
 				material.uniformsList.push( [ material.__webglShader.uniforms[ u ], location ] );
-
 			}
 
 		}
@@ -4568,16 +4566,18 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		if( object.uniformValues ){
+		if( object.uniformValues && object.uniformValues.length > 0 ){
 
 			// temporarily overwrite uniforms with values from object
 
 			overwriteUniformsObject( material, object );
+			material.needsRefresh = true;
 
 		}else if( refreshMaterial || material.needsRefresh ){
 
-			loadUniformsGeneric( material.uniformsList );
+			// load common uniforms
 
+			loadUniformsGeneric( material.uniformsList );
 			material.needsRefresh = false;
 
 		}
@@ -4842,36 +4842,26 @@ THREE.WebGLRenderer = function ( parameters ) {
 		var m_values = [];
 		var o_values = object.uniformValues;
 
-		if ( o_values ) {
+		for ( var u, j = 0, jl = o_values.length; j < jl; j ++ ) {
 
-			for ( var u, j = 0, jl = o_values.length; j < jl; j ++ ) {
+			u = o_values[ j ];
 
-				u = o_values[ j ];
+			// save material value
+			m_values[ j ] = [ u[ 0 ], m_uniforms[ u[ 0 ] ].value ];
 
-				// save material value
-				m_values[ j ] = [ u[ 0 ], m_uniforms[ u[ 0 ] ].value ];
-
-				// overwrite with object value
-				m_uniforms[ u[ 0 ] ].value = u[ 1 ];
-
-			}
+			// overwrite with object value
+			m_uniforms[ u[ 0 ] ].value = u[ 1 ];
 
 		}
 
 		loadUniformsGeneric( material.uniformsList );
 
-		if ( m_values.length > 0 ) {
+		for ( var u, j = 0, jl = m_values.length; j < jl; j ++ ) {
 
-			for ( var u, j = 0, jl = m_values.length; j < jl; j ++ ) {
+			u = m_values[ j ];
 
-				u = m_values[ j ];
-
-				// recover saved material value
-				m_uniforms[ u[ 0 ] ].value = u[ 1 ];
-
-			}
-
-			material.needsRefresh = true;
+			// recover saved material value
+			m_uniforms[ u[ 0 ] ].value = u[ 1 ];
 
 		}
 


### PR DESCRIPTION
Continuing from #6021. Allow a new property `.uniformValues` in renderable objects that overwrites values in `material.uniforms`.
