### PR TITLE
Ie9 console bug

### DIFF
--- a/examples/js/renderers/CanvasRenderer.js
+++ b/examples/js/renderers/CanvasRenderer.js
@@ -35,7 +35,7 @@ THREE.SpriteCanvasMaterial.prototype.clone = function () {
 
 THREE.CanvasRenderer = function ( parameters ) {
 
-	console.log( 'THREE.CanvasRenderer', THREE.REVISION );
+	if(window.console && console.log) { console.log( 'THREE.CanvasRenderer', THREE.REVISION ); }
 
 	var smoothstep = THREE.Math.smoothstep;
 

--- a/examples/js/renderers/Projector.js
+++ b/examples/js/renderers/Projector.js
@@ -131,21 +131,21 @@ THREE.Projector = function () {
 
 	this.projectVector = function ( vector, camera ) {
 
-		console.warn( 'THREE.Projector: .projectVector() is now vector.project().' );
+		if(window.console && console.warn) { console.warn( 'THREE.Projector: .projectVector() is now vector.project().' ); }
 		vector.project( camera );
 
 	};
 
 	this.unprojectVector = function ( vector, camera ) {
 
-		console.warn( 'THREE.Projector: .unprojectVector() is now vector.unproject().' );
+		if(window.console && console.warn) { console.warn( 'THREE.Projector: .unprojectVector() is now vector.unproject().' ); }
 		vector.unproject( camera );
 
 	};
 
 	this.pickingRay = function ( vector, camera ) {
 
-		console.error( 'THREE.Projector: .pickingRay() is now raycaster.setFromCamera().' );
+		if(window.console && console.error) { console.error( 'THREE.Projector: .pickingRay() is now raycaster.setFromCamera().' ); }
 
 	};
 


### PR DESCRIPTION
IE9 does not define window.console until the developer tools are open. The console.log() throws an error. Adding a check to confirm that the console and log()--or warn() or error()--function is defined so that we can use in IE9.
