### PR TITLE
Additional parameter to allow linear color shift

### DIFF
--- a/examples/js/shaders/ColorCorrectionShader.js
+++ b/examples/js/shaders/ColorCorrectionShader.js
@@ -1,6 +1,7 @@
 /**
  * @author alteredq / http://alteredqualia.com/
  *
+ *
  * Color correction
  */
 
@@ -10,7 +11,8 @@ THREE.ColorCorrectionShader = {
 
 		"tDiffuse": { type: "t", value: null },
 		"powRGB":   { type: "v3", value: new THREE.Vector3( 2, 2, 2 ) },
-		"mulRGB":   { type: "v3", value: new THREE.Vector3( 1, 1, 1 ) }
+		"mulRGB":   { type: "v3", value: new THREE.Vector3( 1, 1, 1 ) },
+        	"addRGB":   { type: "v3", value: new THREE.Vector3( 0, 0, 0 ) }
 
 	},
 
@@ -33,13 +35,14 @@ THREE.ColorCorrectionShader = {
 		"uniform sampler2D tDiffuse;",
 		"uniform vec3 powRGB;",
 		"uniform vec3 mulRGB;",
+        "uniform vec3 addRGB;",
 
 		"varying vec2 vUv;",
 
 		"void main() {",
 
 			"gl_FragColor = texture2D( tDiffuse, vUv );",
-			"gl_FragColor.rgb = mulRGB * pow( gl_FragColor.rgb, powRGB );",
+			"gl_FragColor.rgb = mulRGB * pow( (gl_FragColor.rgb + addRGB), powRGB );",
 
 		"}"
 

--- a/examples/js/shaders/ColorCorrectionShader.js
+++ b/examples/js/shaders/ColorCorrectionShader.js
@@ -35,7 +35,7 @@ THREE.ColorCorrectionShader = {
 		"uniform sampler2D tDiffuse;",
 		"uniform vec3 powRGB;",
 		"uniform vec3 mulRGB;",
-        "uniform vec3 addRGB;",
+        	"uniform vec3 addRGB;",
 
 		"varying vec2 vUv;",
 


### PR DESCRIPTION
addRGB will shift all colors linearly, before applying exponential and multiplicative color shifts. addRGB vector takes values in range [-1, 1]. This is a small tweak to enable a much wider application of this shader code.
