### PR TITLE
Added bindPosition, bindQuaternion, bindRotation, and bindScale to Object3D

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -860,29 +860,6 @@ THREE.Object3D.prototype = {
       value: object.quaternion
     });
 
-    var quaternion = object.quaternion;
-        rotation = object.rotation;
-
-    // Remember the last callback, since Object3D needs this to keep this.quaternion in sync
-    var lastrotcallback = object.rotation.onChangeCallback;
-        lastquatcallback = object.quaternion.onChangeCallback;
-
-    var onRotationChange = function () {
-
-      this.quaternion.setFromEuler( rotation, false );
-      object.quaternion.setFromEuler( rotation, false );
-      lastrotcallback();
-
-    }.bind(this);
-
-    var onQuaternionChange = function () {
-
-      this.rotation.setFromQuaternion( quaternion, undefined, false );
-      object.rotation.setFromQuaternion( quaternion, undefined, false );
-      lastquatcallback();
-
-    }.bind(this);
-
   },
 
   bindScale: function( scale ) {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -844,6 +844,47 @@ THREE.Object3D.prototype = {
 
   },
 
+  bindObjectRotation: function( object ) {
+
+    delete this.rotation;
+    delete this.quaternion;
+
+    Object.defineProperty( this, "rotation", {
+      enumerable: true,
+      configurable: true,
+      value: object.rotation
+    });
+    Object.defineProperty( this, "quaternion", {
+      enumerable: true,
+      configurable: true,
+      value: object.quaternion
+    });
+
+    var quaternion = object.quaternion;
+        rotation = object.rotation;
+
+    // Remember the last callback, since Object3D needs this to keep this.quaternion in sync
+    var lastrotcallback = object.rotation.onChangeCallback;
+        lastquatcallback = object.quaternion.onChangeCallback;
+
+    var onRotationChange = function () {
+
+      this.quaternion.setFromEuler( rotation, false );
+      object.quaternion.setFromEuler( rotation, false );
+      lastrotcallback();
+
+    }.bind(this);
+
+    var onQuaternionChange = function () {
+
+      this.rotation.setFromQuaternion( quaternion, undefined, false );
+      object.rotation.setFromQuaternion( quaternion, undefined, false );
+      lastquatcallback();
+
+    }.bind(this);
+
+  },
+
   bindScale: function( scale ) {
 
     delete this.scale;

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -806,6 +806,13 @@ THREE.Object3D.prototype = {
 
     } );
 
+    rotation.onChange( function () {
+
+      quaternion.setFromEuler( rotation, false );
+
+    } );
+
+
   },
 
   bindRotation: function( rotation ) {
@@ -822,6 +829,12 @@ THREE.Object3D.prototype = {
     rotation.onChange( function () {
 
       quaternion.setFromEuler( rotation, false );
+
+    } );
+
+    quaternion.onChange( function () {
+
+      rotation.setFromQuaternion( quaternion, undefined, false );
 
     } );
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -826,9 +826,13 @@ THREE.Object3D.prototype = {
 
     var quaternion = this.quaternion;
 
+    // Remember the last callback, since Object3D needs this to keep this.quaternion in sync
+    var lastcallback = rotation.onChangeCallback;
+
     rotation.onChange( function () {
 
       quaternion.setFromEuler( rotation, false );
+      lastcallback();
 
     } );
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -40,20 +40,24 @@ THREE.Object3D = function () {
 	Object.defineProperties( this, {
 		position: {
 			enumerable: true,
+			configurable: true,
 			value: position
 		},
 		rotation: {
 			enumerable: true,
+			configurable: true,
 			value: rotation
 		},
 		quaternion: {
 			enumerable: true,
+			configurable: true,
 			value: quaternion
 		},
 		scale: {
 			enumerable: true,
+			configurable: true,
 			value: scale
-		},
+		}
 	} );
 
 	this.rotationAutoUpdate = true;
@@ -772,7 +776,63 @@ THREE.Object3D.prototype = {
 
 		return object;
 
-	}
+	},
+
+  bindPosition: function( position ) {
+
+    delete this.position;
+    Object.defineProperty( this, "position", {
+      enumerable: true,
+      value: position
+    });
+
+  },
+
+  bindQuaternion: function( quaternion ) {
+
+    delete this.quaternion;
+    Object.defineProperty( this, "quaternion", {
+      enumerable: true,
+      value: quaternion
+    });
+
+    var rotation = this.rotation;
+
+    quaternion.onChange( function () {
+
+      rotation.setFromQuaternion( quaternion, undefined, false );
+
+    } );
+
+  },
+
+  bindRotation: function( rotation ) {
+
+    delete this.rotation;
+    Object.defineProperty( this, "rotation", {
+      enumerable: true,
+      value: rotation
+    });
+
+    var quaternion = this.quaternion;
+
+    rotation.onChange( function () {
+
+      quaternion.setFromEuler( rotation, false );
+
+    } );
+
+  },
+
+  bindScale: function( scale ) {
+
+    delete this.scale;
+    Object.defineProperty( this, "scale", {
+      enumerable: true,
+      value: scale
+    });
+
+  }
 
 };
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -783,6 +783,7 @@ THREE.Object3D.prototype = {
     delete this.position;
     Object.defineProperty( this, "position", {
       enumerable: true,
+      configurable: true,
       value: position
     });
 
@@ -793,6 +794,7 @@ THREE.Object3D.prototype = {
     delete this.quaternion;
     Object.defineProperty( this, "quaternion", {
       enumerable: true,
+      configurable: true,
       value: quaternion
     });
 
@@ -811,6 +813,7 @@ THREE.Object3D.prototype = {
     delete this.rotation;
     Object.defineProperty( this, "rotation", {
       enumerable: true,
+      configurable: true,
       value: rotation
     });
 
@@ -829,6 +832,7 @@ THREE.Object3D.prototype = {
     delete this.scale;
     Object.defineProperty( this, "scale", {
       enumerable: true,
+      configurable: true,
       value: scale
     });
 


### PR DESCRIPTION
This patch allows the user to rebind an `Object3D`'s `position`, `quaternion`, `rotation`, and `scale` properties at runtime.  This is very useful if, for instance, your positions and rotations are handled by an external physics or particle library (like sparks.js - #5071)

As of r68, three.js requires users to keep these objects in sync every frame, but being able to share references is much better for performance.  I agree that prior to making these properties immutable, it was too easy for inexperienced users to reassign these properties and cause unintended side effects.  This change would still prevent people from inadvertently reassigning obj.position/rotation/etc. but allows them to set up references when it makes sense and they know it's what they want to do.
