### PR TITLE
add blender logging handlers only once

### DIFF
--- a/utils/exporters/blender/addons/io_three/logger.py
+++ b/utils/exporters/blender/addons/io_three/logger.py
@@ -32,20 +32,21 @@ def init(filename, level=constants.DEBUG):
     LOGGER = logging.getLogger('Three.Export')
     LOGGER.setLevel(LEVELS[level])
 
-    stream = logging.StreamHandler()
-    stream.setLevel(LEVELS[level])
+    if not LOGGER.handlers:
+        stream = logging.StreamHandler()
+        stream.setLevel(LEVELS[level])
 
-    format_ = '%(asctime)s - %(name)s - %(levelname)s: %(message)s'
-    formatter = logging.Formatter(format_)
+        format_ = '%(asctime)s - %(name)s - %(levelname)s: %(message)s'
+        formatter = logging.Formatter(format_)
 
-    stream.setFormatter(formatter)
+        stream.setFormatter(formatter)
 
-    file_handler = logging.FileHandler(LOG_FILE)
-    file_handler.setLevel(LEVELS[level])
-    file_handler.setFormatter(formatter)
+        file_handler = logging.FileHandler(LOG_FILE)
+        file_handler.setLevel(LEVELS[level])
+        file_handler.setFormatter(formatter)
 
-    LOGGER.addHandler(stream)
-    LOGGER.addHandler(file_handler)
+        LOGGER.addHandler(stream)
+        LOGGER.addHandler(file_handler)
 
 
 def info(*args):


### PR DESCRIPTION
This PR adds the blender logging handlers only once preventing duplicated logging output.

@repsac 
