### PR TITLE
preallocate dispatch-events

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -53,6 +53,8 @@ THREE.Geometry = function () {
 
 };
 
+THREE.Geometry.disposeEvent = { type: 'dispose' };
+
 THREE.Geometry.prototype = {
 
 	constructor: THREE.Geometry,
@@ -1030,7 +1032,7 @@ THREE.Geometry.prototype = {
 
 	dispose: function () {
 
-		this.dispatchEvent( { type: 'dispose' } );
+		this.dispatchEvent( THREE.Geometry.disposeEvent );
 
 	}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -78,6 +78,10 @@ THREE.Object3D = function () {
 
 THREE.Object3D.DefaultUp = new THREE.Vector3( 0, 1, 0 );
 
+THREE.Object3D.addedEvent = { type: 'added' };
+
+THREE.Object3D.removedEvent = { type: 'removed' };
+
 THREE.Object3D.prototype = {
 
 	constructor: THREE.Object3D,
@@ -329,7 +333,7 @@ THREE.Object3D.prototype = {
 			}
 
 			object.parent = this;
-			object.dispatchEvent( { type: 'added' } );
+			object.dispatchEvent( THREE.Object3D.addedEvent );
 
 			this.children.push( object );
 
@@ -361,7 +365,7 @@ THREE.Object3D.prototype = {
 
 			object.parent = undefined;
 
-			object.dispatchEvent( { type: 'removed' } );
+			object.dispatchEvent( THREE.Object3D.removedEvent );
 
 			this.children.splice( index, 1 );
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -45,6 +45,10 @@ THREE.Material = function () {
 
 };
 
+THREE.Material.updateEvent = { type: 'update' };
+
+THREE.Material.disposeEvent = { type: 'dispose' };
+
 THREE.Material.prototype = {
 
 	constructor: THREE.Material,
@@ -226,13 +230,13 @@ THREE.Material.prototype = {
 
 	update: function () {
 
-		this.dispatchEvent( { type: 'update' } );
+		this.dispatchEvent( THREE.Material.updateEvent );
 
 	},
 
 	dispose: function () {
 
-		this.dispatchEvent( { type: 'dispose' } );
+		this.dispatchEvent( THREE.Material.disposeEvent );
 
 	}
 


### PR DESCRIPTION
i just started to look for unnecessarily created event-objects and started to replace them with pre-allocated objects (only the most important ones). it may not make a big difference but i think its not a good style in general (perf/gc).

so if you like it i could go through other files as well (i would squash the commits). maybe `THREE.<part>.<eventName>Event` does not fit your style? if so do you have an idea where it should go namespace-wise?

```
$ git rev-parse HEAD
a6e79f38a0fb6e78b167ddbb407b5c5c22305b39
$ git grep "dispatchEvent( *{"
build/three.js:                 object.dispatchEvent( { type: 'added' } );
build/three.js:                 object.dispatchEvent( { type: 'removed' } );
build/three.js:         this.dispatchEvent( { type: 'dispose' } );
build/three.js:         this.dispatchEvent( { type: 'dispose' } );
build/three.js:         this.dispatchEvent( { type: 'update' } );
build/three.js:         this.dispatchEvent( { type: 'dispose' } );
build/three.js:         this.dispatchEvent( { type: 'update' } );
build/three.js:         this.dispatchEvent( { type: 'dispose' } );
build/three.js:         this.dispatchEvent( { type: 'dispose' } );
build/three.min.js:             this.dispatchEvent( { type: 'dispose' } );
build/three.min.js:             this.dispatchEvent( { type: 'update' } );
build/three.min.js:             this.dispatchEvent( { type: 'dispose' } );
build/three.min.js:             this.dispatchEvent( { type: 'dispose' } );
examples/js/loaders/PLYLoader.js:                       scope.dispatchEvent( { type: 'load', content: geometry } );
examples/js/loaders/PLYLoader.js:                       scope.dispatchEvent( { type: 'progress', loaded: event.loaded, total: event.total } );
examples/js/loaders/PLYLoader.js:                       scope.dispatchEvent( { type: 'error', message: 'Couldn\'t load URL [' + url + ']' } );
examples/js/loaders/VRMLLoader.js:                      scope.dispatchEvent( { type: 'load', content: object } );
examples/js/loaders/VRMLLoader.js:                      scope.dispatchEvent( { type: 'progress', loaded: event.loaded, total: event.total } );
examples/js/loaders/VRMLLoader.js:                      scope.dispatchEvent( { type: 'error', message: 'Couldn\'t load URL [' + url + ']' } );
examples/js/renderers/RaytracingRenderer.js:                                    scope.dispatchEvent( { type: "complete" } );
examples/js/wip/ProxyGeometry.js:       this.dispatchEvent( { type: 'allocate' } );
examples/js/wip/ProxyGeometry.js:       this.dispatchEvent( { type: 'allocate' } );
examples/js/wip/ProxyGeometry.js:       this.dispatchEvent( { type: 'allocate' } );
examples/js/wip/ProxyGeometry.js:       this.dispatchEvent( { type: 'allocate' } );
examples/js/wip/ProxyGeometry.js:       this.dispatchEvent( { type: 'allocate' } );
examples/js/wip/benchmark/TypedGeometry.js:             this.dispatchEvent( { type: 'dispose' } );
src/core/BufferGeometry.js:             this.dispatchEvent( { type: 'dispose' } );
src/core/Geometry.js:           this.dispatchEvent( { type: 'dispose' } );
src/core/Object3D.js:                   object.dispatchEvent( { type: 'added' } );
src/core/Object3D.js:                   object.dispatchEvent( { type: 'removed' } );
src/materials/Material.js:              this.dispatchEvent( { type: 'update' } );
src/materials/Material.js:              this.dispatchEvent( { type: 'dispose' } );
src/renderers/WebGLRenderTarget.js:             this.dispatchEvent( { type: 'dispose' } );
src/textures/Texture.js:                this.dispatchEvent( { type: 'update' } );
src/textures/Texture.js:                this.dispatchEvent( { type: 'dispose' } );
```
