### PR TITLE
fix blender export for meshs visible on multiple layers

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -502,12 +502,15 @@ def _on_visible_layer(obj, visible_layers):
     :param visible_layers:
 
     """
-    is_visible = True
+    is_visible = False
     for index, layer in enumerate(obj.layers):
-        if layer and index not in visible_layers:
-            logger.info('%s is on a hidden layer', obj.name)
-            is_visible = False
+        if layer and index in visible_layers:
+            is_visible = True
             break
+
+    if not is_visible:
+        logger.info('%s is on a hidden layer', obj.name)
+
     return is_visible
 
 


### PR DESCRIPTION
A mesh that is visible on multiple layers

![screen shot 2015-03-04 at 09 59 04](https://cloud.githubusercontent.com/assets/409021/6480542/242bf198-c255-11e4-9665-767cb821ca56.png)

is currently not exported.

This PR fixes this

@repsac 
