### PR TITLE
fix blender camera and light export (if obj.name != camera/light.name)

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/camera.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/camera.py
@@ -21,7 +21,8 @@ def _camera(func):
         if isinstance(name, types.Camera):
             camera = name
         else:
-            camera = data.cameras[name]
+            obj = data.objects[name]
+            camera = data.cameras[obj.data.name]
 
         return func(camera, *args, **kwargs)
 

--- a/utils/exporters/blender/addons/io_three/exporter/api/light.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/light.py
@@ -21,7 +21,8 @@ def _lamp(func):
         if isinstance(name, types.Lamp):
             lamp = name
         else:
-            lamp = data.lamps[name]
+            obj = data.objects[name]
+            lamp = data.lamps[obj.data.name]
 
         return func(lamp, *args, **kwargs)
 


### PR DESCRIPTION
Fix the blender exporter to support light/camera objects with different names than their actual light/camera data, e.g.:

![screen shot 2015-03-04 at 11 06 34](https://cloud.githubusercontent.com/assets/409021/6481610/4f91e3d8-c25f-11e4-9eba-b4df6715bed3.png)

@repsac 
