### PR TITLE
Fixed a bug by inverting the conditional results around embed geometry tests

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/geometry.py
+++ b/utils/exporters/blender/addons/io_three/exporter/geometry.py
@@ -335,7 +335,7 @@ class Geometry(base_classes.BaseNode):
                 constants.METADATA: self.metadata
             })
         else:
-            if self.options.get(constants.EMBED_GEOMETRY):
+            if self.options.get(constants.EMBED_GEOMETRY, True):
                 data[constants.DATA] = {
                     constants.ATTRIBUTES: component_data
                 }


### PR DESCRIPTION
`{}.dict()` returns None when in fact we want to default to `True` for embedded geometry on scene exports.
