### PR TITLE
Fix utils/build/build.js Compilation

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -50,15 +50,21 @@ function main() {
 			
 			buffer.push('// File:' + files[ j ]);
 			buffer.push('\n\n');
+
+			contents = fs.readFileSync( file, 'utf8' );
+
 			if( file.indexOf( '.glsl') >= 0 ) {
-				buffer.push('THREE.ShaderChunk[\'' + path.basename(file, '.glsl') + '\'] = "');
-				buffer.push(fs.readFileSync( file, 'utf8' ));
-				buffer.push('";\n\n');
-			}
-			else {
+
+				buffer.push( 'THREE.ShaderChunk[ \'' + path.basename( file, '.glsl' ) + '\' ] =')
+				buffer.push( JSON.stringify( contents ) );
+				buffer.push( ';\n\n' );
+
+			} else {
+
 				sources.push( file );
-				buffer.push( fs.readFileSync( file, 'utf8' ) );
-				buffer.push('\n');
+				buffer.push( contents );
+				buffer.push( '\n' );
+
 			}
 
 		}


### PR DESCRIPTION
Shaders weren't packaged correctly. Now

``` sh
node build.js --include common --include extras --output ../../build/three.js
node build.js --include common --include extras --minify --output ../../build/three.min.js
```

builds js files that really run.
