### PR TITLE
Blender: add button to save settings to .blend file

### DIFF
--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -329,3 +329,4 @@ DBG_COLORS = (0xeeeeee, 0xee0000, 0x00ee00, 0x0000ee,
 
 DOUBLE_SIDED = 'doubleSided'
 
+EXPORT_SETTINGS_KEY = 'threeExportSettings'


### PR DESCRIPTION
Adds a button to persist export settings into the .blend file

![screen shot 2015-03-11 at 17 41 05](https://cloud.githubusercontent.com/assets/409021/6601435/f865449e-c815-11e4-909f-73205c1f397d.png)

![screen shot 2015-03-11 at 17 41 30](https://cloud.githubusercontent.com/assets/409021/6601436/fa1974ea-c815-11e4-8ae2-e14c53a08fed.png)

Refs #6177

cc @repsac 
