### PR TITLE
Raycaster.prototype.setFromCamera() support for cameras with matrix-defined position

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -71,8 +71,8 @@
 
 			if ( camera instanceof THREE.PerspectiveCamera ) {
 
-				this.ray.origin.copy( camera.position );
-				this.ray.direction.set( coords.x, coords.y, 0.5 ).unproject( camera ).sub( camera.position ).normalize();
+				this.ray.origin.setFromMatrixPosition( camera.matrix );
+				this.ray.direction.set( coords.x, coords.y, 0.5 ).unproject( camera ).sub( this.ray.origin ).normalize();
 
 			} else if ( camera instanceof THREE.OrthographicCamera ) {
 


### PR DESCRIPTION
Raycaster.prototype.setFromCamera() was getting the camera's position from camera.position, which isn't updated on cameras that are moved around by direct matrix transform.

I believe grabbing it the position from camera.matrix still gives an accurate position for cameras that use the position property. At least, the canvas_interactive_cubes example still works.
