### PR TITLE
Removed unused variables.

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -679,12 +679,12 @@ THREE.BufferGeometry.prototype = {
 		if ( indexBufferSize === undefined )
 			size = 65535; //WebGL limits type of index buffer values to 16-bit.
 
-		var s = Date.now();
+		//var s = Date.now();
 
 		var indices = this.attributes.index.array;
 		var vertices = this.attributes.position.array;
 
-		var verticesCount = ( vertices.length / 3 );
+		//var verticesCount = ( vertices.length / 3 );
 		var facesCount = ( indices.length / 3 );
 
 		/*

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -241,9 +241,8 @@ THREE.Geometry.prototype = {
 			// vertex normals weighted by triangle areas
 			// http://www.iquilezles.org/www/articles/normals/normals.htm
 
-			var vA, vB, vC, vD;
-			var cb = new THREE.Vector3(), ab = new THREE.Vector3(),
-				db = new THREE.Vector3(), dc = new THREE.Vector3(), bc = new THREE.Vector3();
+			var vA, vB, vC;
+			var cb = new THREE.Vector3(), ab = new THREE.Vector3();
 
 			for ( f = 0, fl = this.faces.length; f < fl; f ++ ) {
 
@@ -417,7 +416,7 @@ THREE.Geometry.prototype = {
 		// based on http://www.terathon.com/code/tangent.html
 		// tangents go to vertices
 
-		var f, fl, v, vl, i, il, vertexIndex,
+		var f, fl, v, vl, i, vertexIndex,
 			face, uv, vA, vB, vC, uvA, uvB, uvC,
 			x1, x2, y1, y2, z1, z2,
 			s1, s2, t1, t2, r, t, test,
@@ -699,8 +698,8 @@ THREE.Geometry.prototype = {
 		var v, key;
 		var precisionPoints = 4; // number of decimal points, eg. 4 for epsilon of 0.0001
 		var precision = Math.pow( 10, precisionPoints );
-		var i,il, face;
-		var indices, k, j, jl, u;
+		var i, il, face;
+		var indices, j, jl;
 
 		for ( i = 0, il = this.vertices.length; i < il; i ++ ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -19,8 +19,6 @@ THREE.Object3D = function () {
 
 	this.up = THREE.Object3D.DefaultUp.clone();
 
-	var scope = this;
-
 	var position = new THREE.Vector3();
 	var rotation = new THREE.Euler();
 	var quaternion = new THREE.Quaternion();

--- a/src/extras/FontUtils.js
+++ b/src/extras/FontUtils.js
@@ -56,7 +56,7 @@ THREE.FontUtils = {
 		ThreeFont.faces[ family ][ data.cssFontWeight ] = ThreeFont.faces[ family ][ data.cssFontWeight ] || {};
 		ThreeFont.faces[ family ][ data.cssFontWeight ][ data.cssFontStyle ] = data;
 
-		var face = ThreeFont.faces[ family ][ data.cssFontWeight ][ data.cssFontStyle ] = data;
+		ThreeFont.faces[ family ][ data.cssFontWeight ][ data.cssFontStyle ] = data;
 
 		return data;
 
@@ -64,11 +64,9 @@ THREE.FontUtils = {
 
 	drawText: function ( text ) {
 
-		var characterPts = [], allPts = [];
-
 		// RenderText
 
-		var i, p,
+		var i,
 			face = this.getFace(),
 			scale = this.size / face.resolution,
 			offset = 0,
@@ -180,8 +178,8 @@ THREE.FontUtils = {
 						for ( i2 = 1, divisions = this.divisions; i2 <= divisions; i2 ++ ) {
 
 							var t = i2 / divisions;
-							var tx = THREE.Shape.Utils.b2( t, cpx0, cpx1, cpx );
-							var ty = THREE.Shape.Utils.b2( t, cpy0, cpy1, cpy );
+							THREE.Shape.Utils.b2( t, cpx0, cpx1, cpx );
+							THREE.Shape.Utils.b2( t, cpy0, cpy1, cpy );
 						}
 
 					}
@@ -211,8 +209,8 @@ THREE.FontUtils = {
 						for ( i2 = 1, divisions = this.divisions; i2 <= divisions; i2 ++ ) {
 
 							var t = i2 / divisions;
-							var tx = THREE.Shape.Utils.b3( t, cpx0, cpx1, cpx2, cpx );
-							var ty = THREE.Shape.Utils.b3( t, cpy0, cpy1, cpy2, cpy );
+							THREE.Shape.Utils.b3( t, cpx0, cpx1, cpx2, cpx );
+							THREE.Shape.Utils.b3( t, cpy0, cpy1, cpy2, cpy );
 
 						}
 

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -633,7 +633,6 @@ THREE.Path.prototype.toShapes = function( isCCW, noHoles ) {
 			betterShapeHoles[sIdx] = [];
 		}
 		for (var sIdx = 0, sLen = newShapes.length; sIdx < sLen; sIdx ++ ) {
-			var sh = newShapes[sIdx];
 			var sho = newShapeHoles[sIdx];
 			for (var hIdx = 0; hIdx < sho.length; hIdx ++ ) {
 				var ho = sho[hIdx];

--- a/src/extras/geometries/ExtrudeGeometry.js
+++ b/src/extras/geometries/ExtrudeGeometry.js
@@ -123,7 +123,6 @@ THREE.ExtrudeGeometry.prototype.addShape = function ( shape, options ) {
 
 	var ahole, h, hl; // looping of holes
 	var scope = this;
-	var bevelPoints = [];
 
 	var shapesOffset = this.vertices.length;
 
@@ -182,13 +181,10 @@ THREE.ExtrudeGeometry.prototype.addShape = function ( shape, options ) {
 
 	var b, bs, t, z,
 		vert, vlen = vertices.length,
-		face, flen = faces.length,
-		cont, clen = contour.length;
+		face, flen = faces.length;
 
 
 	// Find directions for point movement
-
-	var RAD_TO_DEGREES = 180 / Math.PI;
 
 
 	function getBevelVec( inPt, inPrev, inNext ) {
@@ -291,10 +287,6 @@ THREE.ExtrudeGeometry.prototype.addShape = function ( shape, options ) {
 
 		//  (j)---(i)---(k)
 		// console.log('i,j,k', i, j , k)
-
-		var pt_i = contour[ i ];
-		var pt_j = contour[ j ];
-		var pt_k = contour[ k ];
 
 		contourMovements[ i ] = getBevelVec( contour[ i ], contour[ j ], contour[ k ] );
 

--- a/src/extras/geometries/ParametricGeometry.js
+++ b/src/extras/geometries/ParametricGeometry.js
@@ -26,7 +26,6 @@ THREE.ParametricGeometry = function ( func, slices, stacks ) {
 	var i, j, p;
 	var u, v;
 
-	var stackCount = stacks + 1;
 	var sliceCount = slices + 1;
 
 	for ( i = 0; i <= stacks; i ++ ) {

--- a/src/extras/geometries/PolyhedronGeometry.js
+++ b/src/extras/geometries/PolyhedronGeometry.js
@@ -28,7 +28,7 @@ THREE.PolyhedronGeometry = function ( vertices, indices, radius, detail ) {
 
 	}
 
-	var midpoints = [], p = this.vertices;
+	var p = this.vertices;
 
 	var faces = [];
 
@@ -136,7 +136,6 @@ THREE.PolyhedronGeometry = function ( vertices, indices, radius, detail ) {
 	function subdivide( face, detail ) {
 
 		var cols = Math.pow(2, detail);
-		var cells = Math.pow(4, detail);
 		var a = prepare( that.vertices[ face.a ] );
 		var b = prepare( that.vertices[ face.b ] );
 		var c = prepare( that.vertices[ face.c ] );

--- a/src/extras/geometries/ShapeGeometry.js
+++ b/src/extras/geometries/ShapeGeometry.js
@@ -59,7 +59,7 @@ THREE.ShapeGeometry.prototype.addShape = function ( shape, options ) {
 
 	//
 
-	var i, l, hole, s;
+	var i, l, hole;
 
 	var shapesOffset = this.vertices.length;
 	var shapePoints = shape.extractPoints( curveSegments );
@@ -108,7 +108,6 @@ THREE.ShapeGeometry.prototype.addShape = function ( shape, options ) {
 
 	var vert, vlen = vertices.length;
 	var face, flen = faces.length;
-	var cont, clen = contour.length;
 
 	for ( i = 0; i < vlen; i ++ ) {
 

--- a/src/extras/geometries/TubeGeometry.js
+++ b/src/extras/geometries/TubeGeometry.js
@@ -42,8 +42,6 @@ THREE.TubeGeometry = function ( path, segments, radius, radialSegments, closed, 
 
 		numpoints = segments + 1,
 
-		x, y, z,
-		tx, ty, tz,
 		u, v, r,
 
 		cx, cy,
@@ -154,9 +152,7 @@ THREE.TubeGeometry.SinusoidalTaper = function ( u ) {
 // For computing of Frenet frames, exposing the tangents, normals and binormals the spline
 THREE.TubeGeometry.FrenetFrames = function ( path, segments, closed ) {
 
-	var	tangent = new THREE.Vector3(),
-		normal = new THREE.Vector3(),
-		binormal = new THREE.Vector3(),
+	var	normal = new THREE.Vector3(),
 
 		tangents = [],
 		normals = [],
@@ -171,7 +167,7 @@ THREE.TubeGeometry.FrenetFrames = function ( path, segments, closed ) {
 		smallest,
 
 		tx, ty, tz,
-		i, u, v;
+		i, u;
 
 
 	// expose internals

--- a/src/extras/helpers/VertexNormalsHelper.js
+++ b/src/extras/helpers/VertexNormalsHelper.js
@@ -15,8 +15,6 @@ THREE.VertexNormalsHelper = function ( object, size, hex, linewidth ) {
 
 	var geometry = new THREE.Geometry();
 
-	var vertices = object.geometry.vertices;
-
 	var faces = object.geometry.faces;
 
 	for ( var i = 0, l = faces.length; i < l; i ++ ) {

--- a/src/extras/helpers/VertexTangentsHelper.js
+++ b/src/extras/helpers/VertexTangentsHelper.js
@@ -15,8 +15,6 @@ THREE.VertexTangentsHelper = function ( object, size, hex, linewidth ) {
 
 	var geometry = new THREE.Geometry();
 
-	var vertices = object.geometry.vertices;
-
 	var faces = object.geometry.faces;
 
 	for ( var i = 0, l = faces.length; i < l; i ++ ) {

--- a/src/extras/objects/MorphBlendMesh.js
+++ b/src/extras/objects/MorphBlendMesh.js
@@ -76,7 +76,6 @@ THREE.MorphBlendMesh.prototype.autoCreateAnimations = function ( fps ) {
 		if ( chunks && chunks.length > 1 ) {
 
 			var name = chunks[ 1 ];
-			var num = chunks[ 2 ];
 
 			if ( ! frameRanges[ name ] ) frameRanges[ name ] = { start: Infinity, end: - Infinity };
 

--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -16,8 +16,6 @@ THREE.JSONLoader.prototype.constructor = THREE.JSONLoader;
 
 THREE.JSONLoader.prototype.load = function ( url, callback, texturePath ) {
 
-	var scope = this;
-
 	// todo: unify load API to for easier SceneLoader use
 
 	texturePath = texturePath && ( typeof texturePath === 'string' ) ? texturePath : this.extractUrlBase( url );
@@ -112,8 +110,7 @@ THREE.JSONLoader.prototype.loadAjaxJSON = function ( context, url, callback, tex
 
 THREE.JSONLoader.prototype.parse = function ( json, texturePath ) {
 
-	var scope = this,
-	geometry = new THREE.Geometry(),
+	var geometry = new THREE.Geometry(),
 	scale = ( json.scale !== undefined ) ? 1.0 / json.scale : 1.0;
 
 	parseModel( scale );
@@ -145,7 +142,7 @@ THREE.JSONLoader.prototype.parse = function ( json, texturePath ) {
 		hasFaceNormal, hasFaceVertexNormal,
 		hasFaceColor, hasFaceVertexColor,
 
-		vertex, face, faceA, faceB, color, hex, normal,
+		vertex, face, faceA, faceB, hex, normal,
 
 		uvLayer, uv, u, v,
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -91,7 +91,7 @@ THREE.Matrix3.prototype = {
 			if ( offset === undefined ) offset = 0;
 			if ( length === undefined ) length = array.length;
 
-			for ( var i = 0, j = offset, il; i < length; i += 3, j += 3 ) {
+			for ( var i = 0, j = offset; i < length; i += 3, j += 3 ) {
 
 				v1.x = array[ j ];
 				v1.y = array[ j + 1 ];

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -470,7 +470,7 @@ THREE.Matrix4.prototype = {
 			if ( offset === undefined ) offset = 0;
 			if ( length === undefined ) length = array.length;
 
-			for ( var i = 0, j = offset, il; i < length; i += 3, j += 3 ) {
+			for ( var i = 0, j = offset; i < length; i += 3, j += 3 ) {
 
 				v1.x = array[ j ];
 				v1.y = array[ j + 1 ];

--- a/src/math/Spline.js
+++ b/src/math/Spline.js
@@ -125,7 +125,7 @@ THREE.Spline = function ( points ) {
 
 		var i, j,
 			index, indexCurrent, indexNext,
-			linearDistance, realDistance,
+			realDistance,
 			sampling, position,
 			newpoints = [],
 			tmpVec = new THREE.Vector3(),

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -220,7 +220,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 			var isFaceMaterial = this.material instanceof THREE.MeshFaceMaterial;
 			var objectMaterials = isFaceMaterial === true ? this.material.materials : null;
 
-			var a, b, c, d;
+			var a, b, c;
 			var precision = raycaster.precision;
 
 			var vertices = geometry.vertices;

--- a/src/objects/MorphAnimMesh.js
+++ b/src/objects/MorphAnimMesh.js
@@ -70,7 +70,6 @@ THREE.MorphAnimMesh.prototype.parseAnimations = function () {
 		if ( parts && parts.length > 1 ) {
 
 			var label = parts[ 1 ];
-			var num = parts[ 2 ];
 
 			if ( ! animations[ label ] ) animations[ label ] = { start: Infinity, end: - Infinity };
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1186,7 +1186,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	function setParticleBuffers ( geometry, hint, object ) {
 
-		var v, c, vertex, offset, index, color,
+		var v, c, vertex, offset, color,
 
 		vertices = geometry.vertices,
 		vl = vertices.length,
@@ -1202,7 +1202,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		customAttributes = geometry.__webglCustomAttributesList,
 		i, il,
-		a, ca, cal, value,
+		ca, cal, value,
 		customAttribute;
 
 		if ( dirtyVertices ) {
@@ -1361,7 +1361,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		customAttributes = geometry.__webglCustomAttributesList,
 
 		i, il,
-		a, ca, cal, value,
+		ca, cal, value,
 		customAttribute;
 
 		if ( dirtyVertices ) {
@@ -1521,20 +1521,17 @@ THREE.WebGLRenderer = function ( parameters ) {
 		var needsFaceNormals = materialNeedsFaceNormals( material );
 
 		var f, fl, fi, face,
-		vertexNormals, faceNormal, normal,
+		vertexNormals, faceNormal,
 		vertexColors, faceColor,
 		vertexTangents,
-		uv, uv2, v1, v2, v3, v4, t1, t2, t3, t4, n1, n2, n3, n4,
+		uv, uv2, v1, v2, v3, t1, t2, t3, n1, n2, n3,
 		c1, c2, c3,
-		sw1, sw2, sw3, sw4,
-		si1, si2, si3, si4,
-		sa1, sa2, sa3, sa4,
-		sb1, sb2, sb3, sb4,
-		m, ml, i, il,
+		sw1, sw2, sw3,
+		si1, si2, si3,
+		i, il,
 		vn, uvi, uv2i,
 		vk, vkl, vka,
 		nka, chf, faceVertexNormals,
-		a,
 
 		vertexIndex = 0,
 
@@ -5196,11 +5193,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	function setupLights ( lights ) {
 
-		var l, ll, light, n,
+		var l, ll, light,
 		r = 0, g = 0, b = 0,
 		color, skyColor, groundColor,
-		intensity,  intensitySq,
-		position,
+		intensity,
 		distance,
 
 		zlights = _lights,

--- a/src/renderers/webgl/plugins/ShadowMapPlugin.js
+++ b/src/renderers/webgl/plugins/ShadowMapPlugin.js
@@ -63,7 +63,7 @@ THREE.ShadowMapPlugin = function ( _renderer, _lights, _webglObjects, _webglObje
 		var i, il, j, jl, n,
 
 		shadowMap, shadowMatrix, shadowCamera,
-		program, buffer, material,
+		buffer, material,
 		webglObject, object, light,
 
 		lights = [],


### PR DESCRIPTION
This time I deleted based on uglifyjs warnings, and ignored unused function parameters.

```
WARN: Dropping unused variable il [three.js:4287,32]
WARN: Dropping unused variable il [three.js:4941,32]
WARN: Dropping unused variable linearDistance [three.js:6845,3]
WARN: Dropping unused variable scope [three.js:7426,5]
WARN: Side effects in initialization of unused variable s [three.js:9155,6]
WARN: Side effects in initialization of unused variable verticesCount [three.js:9160,6]
WARN: Dropping unused variable vD [three.js:9691,19]
WARN: Side effects in initialization of unused variable db [three.js:9693,4]
WARN: Side effects in initialization of unused variable dc [three.js:9693,30]
WARN: Side effects in initialization of unused variable bc [three.js:9693,56]
WARN: Dropping unused variable il [three.js:9867,23]
WARN: Dropping unused variable k [three.js:10150,15]
WARN: Dropping unused variable u [three.js:10150,25]
WARN: Dropping unused variable scope [three.js:11859,5]
WARN: Dropping unused variable color [three.js:11988,30]
WARN: Dropping unused variable scope [three.js:11955,5]
WARN: Dropping unused variable d [three.js:15490,16]
WARN: Side effects in initialization of unused variable num [three.js:16046,7]
WARN: Dropping unused variable index [three.js:18965,28]
WARN: Dropping unused variable a [three.js:18981,2]
WARN: Dropping unused variable a [three.js:19140,2]
WARN: Dropping unused variable normal [three.js:19300,29]
WARN: Dropping unused variable v4 [three.js:19303,23]
WARN: Dropping unused variable t4 [three.js:19303,39]
WARN: Dropping unused variable n4 [three.js:19303,55]
WARN: Dropping unused variable sw4 [three.js:19305,17]
WARN: Dropping unused variable si4 [three.js:19306,17]
WARN: Dropping unused variable sa1 [three.js:19307,2]
WARN: Dropping unused variable sa2 [three.js:19307,7]
WARN: Dropping unused variable sa3 [three.js:19307,12]
WARN: Dropping unused variable sa4 [three.js:19307,17]
WARN: Dropping unused variable sb1 [three.js:19308,2]
WARN: Dropping unused variable sb2 [three.js:19308,7]
WARN: Dropping unused variable sb3 [three.js:19308,12]
WARN: Dropping unused variable sb4 [three.js:19308,17]
WARN: Dropping unused variable m [three.js:19309,2]
WARN: Dropping unused variable ml [three.js:19309,5]
WARN: Dropping unused variable a [three.js:19313,2]
WARN: Dropping unused variable n [three.js:22975,20]
WARN: Dropping unused variable intensitySq [three.js:22978,14]
WARN: Dropping unused variable position [three.js:22979,2]
WARN: Dropping unused variable program [three.js:25507,2]
WARN: Side effects in initialization of unused variable face [three.js:26695,6]
WARN: Dropping unused variable characterPts [three.js:26703,6]
WARN: Dropping unused variable allPts [three.js:26703,25]
WARN: Dropping unused variable p [three.js:26707,9]
WARN: Side effects in initialization of unused variable tx [three.js:26819,11]
WARN: Side effects in initialization of unused variable ty [three.js:26820,11]
WARN: Side effects in initialization of unused variable tx [three.js:26850,11]
WARN: Side effects in initialization of unused variable ty [three.js:26851,11]
WARN: Side effects in initialization of unused variable sh [three.js:28614,7]
WARN: Dropping unused variable bevelPoints [three.js:31083,5]
WARN: Dropping unused variable cont [three.js:31143,2]
WARN: Side effects in initialization of unused variable clen [three.js:31143,8]
WARN: Side effects in initialization of unused variable RAD_TO_DEGREES [three.js:31148,5]
WARN: Side effects in initialization of unused variable pt_i [three.js:31252,6]
WARN: Side effects in initialization of unused variable pt_j [three.js:31253,6]
WARN: Side effects in initialization of unused variable pt_k [three.js:31254,6]
WARN: Dropping unused variable s [three.js:31696,17]
WARN: Dropping unused variable cont [three.js:31745,5]
WARN: Side effects in initialization of unused variable clen [three.js:31745,11]
WARN: Dropping unused variable x [three.js:32518,2]
WARN: Dropping unused variable y [three.js:32518,5]
WARN: Dropping unused variable z [three.js:32518,8]
WARN: Dropping unused variable tx [three.js:32519,2]
WARN: Dropping unused variable ty [three.js:32519,6]
WARN: Dropping unused variable tz [three.js:32519,10]
WARN: Side effects in initialization of unused variable tangent [three.js:32630,5]
WARN: Side effects in initialization of unused variable binormal [three.js:32632,2]
WARN: Dropping unused variable v [three.js:32647,8]
WARN: Side effects in initialization of unused variable cells [three.js:32913,6]
WARN: Dropping unused variable midpoints [three.js:32805,5]
WARN: Dropping unused variable stackCount [three.js:33201,5]
WARN: Side effects in initialization of unused variable vertices [three.js:34364,5]
WARN: Side effects in initialization of unused variable vertices [three.js:34467,5]
WARN: Side effects in initialization of unused variable num [three.js:34825,7]
```
#6225
