### PR TITLE
NormalDisplacementShader: fix calculation of reflection vector

### DIFF
--- a/examples/js/shaders/NormalDisplacementShader.js
+++ b/examples/js/shaders/NormalDisplacementShader.js
@@ -399,13 +399,15 @@ THREE.NormalDisplacementShader = {
 
 		"		vec3 cameraToVertex = normalize( vWorldPosition - cameraPosition );",
 
+		"		vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );",
+
 		"		#ifdef ENVMAP_MODE_REFLECTION",
 
-		"			vec3 vReflect = reflect( cameraToVertex, normal );",
+		"			vec3 vReflect = reflect( cameraToVertex, worldNormal );",
 
 		"		#else",
 
-		"			vec3 vReflect = refract( cameraToVertex, normal, refractionRatio );",
+		"			vec3 vReflect = refract( cameraToVertex, worldNormal, refractionRatio );",
 
 		"		#endif",
 

--- a/examples/webgl_materials_normaldisplacementmap.html
+++ b/examples/webgl_materials_normaldisplacementmap.html
@@ -185,6 +185,9 @@
 				var parameters = { fragmentShader: shader.fragmentShader, vertexShader: shader.vertexShader, uniforms: uniforms, lights: true, fog: false };
 				var material1 = new THREE.ShaderMaterial( parameters );
 
+				// Ensure that ENVMAP_MODE_REFLECTION is defined in shader
+				material1.envMap = reflectionCube;
+
 				var material2 = new THREE.MeshPhongMaterial( {
 					color: diffuse,
 					specular: specular,


### PR DESCRIPTION
This fixes a couple problems with the reflection map in examples/webgl_materials_normaldisplacementmap.html:
- In NormalDisplacementShader.js, fix calculation of the reflection vector like in commit dfe59fa5d037d199aff2516fe33561e7dcaddfad.
- In webgl_materials_normaldisplacementmap.html, set the material's envMap property to the cube texture to ensure that ENVMAP_MODE_REFLECTION is defined in the shader.
