### PR TITLE
Ensure that uniforms used by AdaptiveToneMapping are not shared between instances

### DIFF
--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -39,7 +39,7 @@ THREE.AdaptiveToneMappingPass = function ( adaptive, resolution ) {
 
 	this.materialLuminance = new THREE.ShaderMaterial( {
 
-		uniforms: THREE.LuminosityShader.uniforms,
+		uniforms: THREE.UniformsUtils.clone( THREE.LuminosityShader.uniforms ),
 		vertexShader: THREE.LuminosityShader.vertexShader,
 		fragmentShader: THREE.LuminosityShader.fragmentShader,
 		blending: THREE.NoBlending,
@@ -95,7 +95,7 @@ THREE.AdaptiveToneMappingPass = function ( adaptive, resolution ) {
 
 	this.materialAdaptiveLum = new THREE.ShaderMaterial( {
 
-		uniforms: this.adaptLuminanceShader.uniforms,
+		uniforms: THREE.UniformsUtils.clone( this.adaptLuminanceShader.uniforms ),
 		vertexShader: this.adaptLuminanceShader.vertexShader,
 		fragmentShader: this.adaptLuminanceShader.fragmentShader,
 		defines: this.adaptLuminanceShader.defines,
@@ -107,7 +107,7 @@ THREE.AdaptiveToneMappingPass = function ( adaptive, resolution ) {
 
 	this.materialToneMap = new THREE.ShaderMaterial( {
 
-		uniforms: THREE.ToneMapShader.uniforms,
+		uniforms: THREE.UniformsUtils.clone( THREE.ToneMapShader.uniforms ),
 		vertexShader: THREE.ToneMapShader.vertexShader,
 		fragmentShader: THREE.ToneMapShader.fragmentShader,
 		blending: THREE.NoBlending

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -85,12 +85,15 @@
 			function init() {
 
 				params = {
-					"Average Luminosity": 0.7,
+					bloomAmount: 1.0,
+					sunLight: 4.0,
+
+					enabled: true,
+					avgLuminance: 0.7,
 					middleGrey: 0.04,
 					maxLuminance: 16,
-					bloomAmount: 1.0,
+
 					adaptionRate: 2.0,
-					sunLight: 4.0,
 				};
 
 				container = document.createElement( 'div' );
@@ -395,22 +398,24 @@
 				// ldrEffectComposer.addPass( gammaPass );
 
 
-				var dynamicHdrGui = new dat.GUI();
+				var gui = new dat.GUI();
 
 				// dynamicHdrGui.add( params, 'projection', { 'From cam to mesh': 'camera', 'Normal to mesh': 'normal' } );
-				dynamicHdrGui.add( params, 'middleGrey', 0, 12 );
-				dynamicHdrGui.add( params, 'maxLuminance', 1, 30 );
-				dynamicHdrGui.add( params, 'adaptionRate', 0.0, 10.0 );
-				dynamicHdrGui.add( params, 'bloomAmount', 0.0, 10.0 );
-				dynamicHdrGui.add( params, 'sunLight', 0.1, 12.0 );
-				// dynamicHdrGui.add( params, 'clear' );
-				dynamicHdrGui.open();
+				var sceneGui = gui.addFolder( 'Scenes' );
+				var toneMappingGui = gui.addFolder( 'ToneMapping' );
+				var adaptiveToneMappingGui = gui.addFolder( 'AdaptiveOnly' );
 
-				var ldrGui = new dat.GUI();
-				ldrGui.domElement.style.position = 'absolute';
-				ldrGui.add( params, 'Average Luminosity', 0.001, 2.0 );
-				ldrGui.open();
+				sceneGui.add( params, 'bloomAmount', 0.0, 10.0 );
+				sceneGui.add( params, 'sunLight', 0.1, 12.0 );
 
+				toneMappingGui.add( params, 'enabled' );
+				toneMappingGui.add( params, 'middleGrey', 0, 12 );
+				toneMappingGui.add( params, 'avgLuminance', 0.001, 2.0 );
+				toneMappingGui.add( params, 'maxLuminance', 1, 30 );
+
+				adaptiveToneMappingGui.add( params, 'adaptionRate', 0.0, 10.0 );
+
+				gui.open();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
@@ -445,10 +450,19 @@
 					adaptiveLuminanceMat.uniforms.map.value = adaptToneMappingPass.luminanceRT;
 					currentLuminanceMat.uniforms.map.value = adaptToneMappingPass.currentLuminanceRT;
 					if ( adaptToneMappingPass.setAverageLuminance ) {
-						adaptToneMappingPass.setAverageLuminance( params["Average Luminosity"] );
+						adaptToneMappingPass.setAverageLuminance( params.avgLuminance );
 					}
+					adaptToneMappingPass.enabled = params.enabled;
 					adaptToneMappingPass.setMaxLuminance( params.maxLuminance );
 					adaptToneMappingPass.setMiddleGrey( params.middleGrey );
+
+					hdrToneMappingPass.enabled = params.enabled;
+					hdrToneMappingPass.setMaxLuminance( params.maxLuminance );
+					hdrToneMappingPass.setMiddleGrey( params.middleGrey );
+				
+					ldrToneMappingPass.enabled = params.enabled;
+					ldrToneMappingPass.setMaxLuminance( params.maxLuminance );
+					ldrToneMappingPass.setMiddleGrey( params.middleGrey );
 				}
 
 				directionalLight.intensity = params.sunLight;


### PR DESCRIPTION
As described in this issue https://github.com/mrdoob/three.js/issues/6244, the uniforms sets used in AdaptiveToneMapping are not cloned per instance, rather they are shared between all instances.  I believe this is not desirable, I also think it leads to incorrect results in the demo here (because which ever value is last set to the uniforms is what is used across all three AdaptiveToneMapping shaders):

http://threejs.org/examples/#webgl_shaders_tonemapping

While fixing this issue (whether it is a bug or not is debateable, see @MiiBond's comments), I refactored the above example to allow for enabling/disabling tone mapping as well as organizing the parameters.
