### PR TITLE
VREffect: taking pixelRatio into account when calculating renderer width and height

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -97,8 +97,8 @@ THREE.VREffect = function ( renderer, done ) {
 		var leftEyeTranslation = this.leftEyeTranslation;
 		var rightEyeTranslation = this.rightEyeTranslation;
 		var renderer = this._renderer;
-		var rendererWidth = renderer.context.drawingBufferWidth;
-		var rendererHeight = renderer.context.drawingBufferHeight;
+		var rendererWidth = renderer.context.drawingBufferWidth / renderer.getPixelRatio();
+		var rendererHeight = renderer.context.drawingBufferHeight / renderer.getPixelRatio();
 		var eyeDivisionLine = rendererWidth / 2;
 
 		renderer.enableScissorTest( true );


### PR DESCRIPTION
According to the [release notes of r70](https://plus.google.com/+ricardocabello/posts/VGg2KQQ5zXy), developers should add this line of code:

``` javascript
renderer.setPixelRatio( window.devicePixelRatio );
```

When setting a pixel ratio not equal to 1 (for instance on a Macbook Retina or a random smartphone) and using the VREffect, the renderar only renders a part of the screen, see screenshot below:
![without-pixelratio](https://cloud.githubusercontent.com/assets/1140124/6709346/f40f93dc-cd78-11e4-9f58-f9bf297eaff4.png)

Applying the PR to the VREffect.js makes the screen to be renderer correctly:
![with-pixelratio](https://cloud.githubusercontent.com/assets/1140124/6709347/f4114920-cd78-11e4-9670-906ecbeec3dc.png)
