### PR TITLE
Fix bug in ObjectLoader.  material.bumpScale is a float not a Vector2.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -248,7 +248,7 @@ THREE.ObjectLoader.prototype = {
 
 					material.bumpMap = getTexture( data.bumpMap );
 					if ( data.bumpScale ) {
-						material.bumpScale = new THREE.Vector2( data.bumpScale, data.bumpScale );
+						material.bumpScale = data.bumpScale;
 					}
 
 				}


### PR DESCRIPTION
Simple bug fix.

material.bumpScale is a scalar value, not a Vector2.  I think this is a copy/paste error from normalScale which is a Vector2.
