### PR TITLE
Add 'TextGeometry' to Object loader

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -189,6 +189,15 @@ THREE.ObjectLoader.prototype = {
 						geometry = geometryLoader.parse( data.data ).geometry;
 
 						break;
+						
+					case 'TextGeometry':
+					
+						geometry = new THREE.TextGeometry(
+							data.text,
+							data.data
+						); 
+						
+						break;
 
 				}
 


### PR DESCRIPTION
A very small change that allows text geometry to be loaded with the scene.  Here is an example: http://datable.net/WebGL/HW3/
