### PR TITLE
Add an example for App.Player

### DIFF
--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -22,7 +22,9 @@ var APP = {
 
 		this.load = function ( json ) {
 
-			vr = json.project.vr;
+			// vr = json.project.vr;
+			// jme- change
+			vr = false
 
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setClearColor( 0x000000 );

--- a/examples/app-player.html
+++ b/examples/app-player.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<head>
+	<title>three.js player - standalone - able to play example from three.js editor</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<style>
+		body {
+			background:#777;
+			padding:0;
+			margin:0;
+			font-weight: bold;
+			overflow:hidden;
+		}
+
+		#info {
+			position: absolute;
+			top: 0px; width: 100%;
+			color: #ffffff;
+			padding: 5px;
+			font-family:Monospace;
+			font-size:13px;
+			text-align:center;
+			z-index:1000;
+		}
+
+		a {
+			color: #ffffff;
+		}
+	</style>
+</head>
+
+<script src="../build/three.min.js"></script>
+<script src="../editor/js/libs/app.js"></script>
+<body>    
+	<div id="info">three.js standalone player 
+		- able to play examples app from <a href='http://threejs.org/editor'>three.js editor</a>
+		<br/>
+		examples : 
+		<a href='javascript:void(0)' onClick='load("../editor/examples/arkanoid.app.json")'>arkanoid</a> -
+		<a href='javascript:void(0)' onClick='load("../editor/examples/camera.app.json")'>camera</a> -
+		<a href='javascript:void(0)' onClick='load("../editor/examples/particles.app.json")'>particles</a> -
+		<a href='javascript:void(0)' onClick='load("../editor/examples/pong.app.json")'>pong</a>
+	</div>
+    <script>
+	    /**
+	     * - a select box to be able to pick between examples
+	     * - store the last url in the hash and reload it
+	     * - do a large play button in the middle, css animation to a stop button on top/right
+	     * - examples/app-player.html
+	     */
+
+		var appPlayer = new APP.Player();
+		var isRunning = false
+
+	    var appUrl = location.hash.substr(1) || '../editor/examples/arkanoid.app.json'
+		load(appUrl)
+
+		function load(appUrl){		
+			console.log('load', appUrl)
+	    	var loader = new THREE.XHRLoader();
+		    loader.load( appUrl, function( text ){
+				
+				if( isRunning ){
+		            appPlayer.stop();         
+		            document.body.removeChild(appPlayer.dom)            
+					isRunning = false
+				}
+				
+		        var json = JSON.parse( text );
+		        appPlayer.load(json)
+
+		        appPlayer.setSize(window.innerWidth, window.innerHeight)
+	            document.body.appendChild(appPlayer.dom)
+				appPlayer.play();
+
+				isRunning = true
+		    });
+			
+			location.hash = appUrl
+		}
+    </script>
+</body>

--- a/examples/app-player.html
+++ b/examples/app-player.html
@@ -27,11 +27,10 @@
 			color: #ffffff;
 		}
 	</style>
+	<script src="../build/three.min.js"></script>
+	<script src="../editor/js/libs/app.js"></script>
 </head>
-
-<script src="../build/three.min.js"></script>
-<script src="../editor/js/libs/app.js"></script>
-<body>    
+<body>	
 	<div id="info">three.js standalone player 
 		- able to play examples app from <a href='http://threejs.org/editor'>three.js editor</a>
 		<br/>
@@ -41,42 +40,35 @@
 		<a href='javascript:void(0)' onClick='load("../editor/examples/particles.app.json")'>particles</a> -
 		<a href='javascript:void(0)' onClick='load("../editor/examples/pong.app.json")'>pong</a>
 	</div>
-    <script>
-	    /**
-	     * - a select box to be able to pick between examples
-	     * - store the last url in the hash and reload it
-	     * - do a large play button in the middle, css animation to a stop button on top/right
-	     * - examples/app-player.html
-	     */
-
+	<script>
 		var appPlayer = new APP.Player();
 		var isRunning = false
 
-	    var appUrl = location.hash.substr(1) || '../editor/examples/arkanoid.app.json'
+		var appUrl = location.hash.substr(1) || '../editor/examples/arkanoid.app.json'
 		load(appUrl)
 
 		function load(appUrl){		
 			console.log('load', appUrl)
-	    	var loader = new THREE.XHRLoader();
-		    loader.load( appUrl, function( text ){
+			var loader = new THREE.XHRLoader();
+			loader.load( appUrl, function( text ){
 				
 				if( isRunning ){
-		            appPlayer.stop();         
-		            document.body.removeChild(appPlayer.dom)            
+					appPlayer.stop();	 
+					document.body.removeChild(appPlayer.dom)	
 					isRunning = false
 				}
 				
-		        var json = JSON.parse( text );
-		        appPlayer.load(json)
+				var json = JSON.parse( text );
+				appPlayer.load(json)
 
-		        appPlayer.setSize(window.innerWidth, window.innerHeight)
-	            document.body.appendChild(appPlayer.dom)
+				appPlayer.setSize(window.innerWidth, window.innerHeight)
+				document.body.appendChild(appPlayer.dom)
 				appPlayer.play();
 
 				isRunning = true
-		    });
+			});
 			
 			location.hash = appUrl
 		}
-    </script>
+	</script>
 </body>


### PR DESCRIPTION
It is a simple example for App.Player.
- it is live [here](https://jeromeetienne.github.io/three.js/examples/app-player.html)
- i put it in /examples but im not sure as it is part of the editor in a way.
- note that it support to load the file.app.json from the url, but people can share more easily
