### PR TITLE
Fixed: NormalMaterial on the Docs does not work

### DIFF
--- a/docs/scenes/js/material.js
+++ b/docs/scenes/js/material.js
@@ -365,7 +365,6 @@ function guiMeshNormalMaterial ( gui, mesh, material, geometry ) {
 
 	var folder = gui.addFolder('THREE.MeshNormalMaterial');
 
-	folder.add( material, 'shading', constants.shading).onChange( needsUpdate( material, geometry ) );
 	folder.add( material, 'wireframe' );
 	folder.add( material, 'wireframeLinewidth', 0, 10 );
 	folder.add( material, 'morphTargets' ).onChange( updateMorphs( mesh, material ) );


### PR DESCRIPTION
NormalMaterial on the Docs is not working.
see http://threejs.org/docs/#Reference/Materials/MeshNormalMaterial

![](https://cloud.githubusercontent.com/assets/212837/6768527/0deb1e96-d0b4-11e4-9fe1-356e5c414bf1.png)

It should not refer shading property.

shading property for normalMaterial has been removed at https://github.com/mrdoob/three.js/commit/9d72d80f3fb00d8e3532ace349c39eba2a8ff22a
