### PR TITLE
Added shadow support for imported JSON files

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -530,7 +530,8 @@ THREE.ObjectLoader.prototype = {
 				}
 
 			}
-
+			if (data.castShadow !== undefined) object.castShadow = data.castShadow;
+			if (data.receiveShadow !== undefined) object.receiveShadow = data.receiveShadow;
 			return object;
 
 		}


### PR DESCRIPTION
Previously, Three.JS would IGNORE imported castShadow and receiveShadow settings on objects. This setting is now corrected.
