### PR TITLE
Do not generate image texture if image is not loaded

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -5505,6 +5505,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var mipmap, mipmaps = texture.mipmaps;
 
+		var imageNotComplete = false;
+
 		if ( texture instanceof THREE.DataTexture ) {
 
 			// use manually created mipmaps if available
@@ -5573,11 +5575,21 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			} else {
 
-				_gl.texImage2D( _gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
+				if (texture.image.complete) {
+
+					_gl.texImage2D( _gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
+
+				} else {
+
+					imageNotComplete = true;
+
+				}
 
 			}
 
 		}
+
+		if (imageNotComplete) return;
 
 		if ( texture.generateMipmaps && isImagePowerOfTwo ) _gl.generateMipmap( _gl.TEXTURE_2D );
 


### PR DESCRIPTION
this gets rid of 'WebGL: INVALID_VALUE: texImage2D: invalid image' error messages
