### PR TITLE
Remove unnecessary usage of Math.log2, it is not supported in IE.

### DIFF
--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -47,7 +47,7 @@ THREE.AdaptiveToneMappingPass = function ( adaptive, resolution ) {
 
 	this.adaptLuminanceShader = {
 		defines: {
-			"MIP_LEVEL_1X1" : Math.log2( this.resolution ).toFixed(1),
+			"MIP_LEVEL_1X1" : ( Math.log( this.resolution ) / Math.log( 2.0 ) ).toFixed(1),
 		},
 		uniforms: {
 			"lastLum": { type: "t", value: null },


### PR DESCRIPTION
Math.log2 used in AdaptiveToneMapping.js is an experimental function, details:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2

Most importantly, Math.log2 is not supported in IE, thus the Master-branch tone mapping example crashes in IE:

http://threejs.org/examples/#webgl_shaders_tonemapping

But the fix is simple, just use any log function and divide by the log of 2, and then you've effectively taken the log2 of the number.  I've made this equivalent change and now the example works in IE.

/ping @MiiBond
