### PR TITLE
Eliminated hardcoded dimension, added support for pixel ratio.

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -156,11 +156,9 @@ THREE.VREffect = function ( renderer, done ) {
 		}
 		// VR Mode enabled
 		this._canvasOriginalSize = {
-			width: renderer.domElement.width,
-			height: renderer.domElement.height
+			width: renderer.domElement.width / renderer.getPixelRatio(),
+			height: renderer.domElement.height / renderer.getPixelRatio()
 		};
-		// Hardcoded Rift display size
-		renderer.setSize( 1280, 800, false );
 		this.startFullscreen();
 	};
 


### PR DESCRIPTION
Aside to @mrdoob : should the WebGLRenderer provide getSize() => {width:
..., height: ...} element that takes into account pixel ratio?

Also, @dmarcos I want to make sure this doesn't break your Oculus demos.
