### PR TITLE
BufferGeometry: return the number of hit triangle in raycast

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -160,9 +160,9 @@ THREE.Mesh.prototype.raycast = ( function () {
 							distance: distance,
 							point: intersectionPoint,
 							face: new THREE.Face3( a, b, c, THREE.Triangle.normal( vA, vB, vC ) ),
-							faceIndex: null,
+							faceIndex: Math.floor(i/3), // triangle number in indices buffer semantics
 							object: this
-
+							
 						} );
 
 					}
@@ -206,7 +206,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 						distance: distance,
 						point: intersectionPoint,
 						face: new THREE.Face3( a, b, c, THREE.Triangle.normal( vA, vB, vC ) ),
-						faceIndex: null,
+						index: Math.floor(i/3), // triangle number in positions buffer semantics
 						object: this
 
 					} );


### PR DESCRIPTION
We need triangle number that was hit during raycast.
- if indexed, we need triangle number in the meaning of it's position in
  indices array. Originally ThreeJS does not return that information.
- if not indexed, we need that number in the meaning of it's position in
  positions array.

Even that raycast of unindexed BufferGeometry provide that information
in face attribute, we want to have it as 'index' attribute too for
uniformity.
