### PR TITLE
fix deferred renderer with new separate uv/uv2 vertex/fragment params.

### DIFF
--- a/examples/js/ShaderDeferred.js
+++ b/examples/js/ShaderDeferred.js
@@ -149,8 +149,9 @@ THREE.ShaderDeferred = {
 
 			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "color_pars_fragment" ],
+			THREE.ShaderChunk[ "uv_pars_fragment" ],
+			THREE.ShaderChunk[ "uv2_pars_fragment" ],
 			THREE.ShaderChunk[ "map_pars_fragment" ],
-			THREE.ShaderChunk[ "lightmap_pars_fragment" ],
 
 			"#ifdef USE_ENVMAP",
 
@@ -309,8 +310,8 @@ THREE.ShaderDeferred = {
 		vertexShader : [
 
 			THREE.ShaderChunk[ "common" ],
-			THREE.ShaderChunk[ "map_pars_vertex" ],
-			THREE.ShaderChunk[ "lightmap_pars_vertex" ],
+			THREE.ShaderChunk[ "uv_pars_vertex" ],
+			THREE.ShaderChunk[ "uv2_pars_vertex" ],
 			THREE.ShaderChunk[ "color_pars_vertex" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "skinning_pars_vertex" ],
@@ -324,8 +325,8 @@ THREE.ShaderDeferred = {
 
 			"void main() {",
 
-				THREE.ShaderChunk[ "map_vertex" ],
-				THREE.ShaderChunk[ "lightmap_vertex" ],
+				THREE.ShaderChunk[ "uv_vertex" ],
+				THREE.ShaderChunk[ "uv2_vertex" ],
 				THREE.ShaderChunk[ "color_vertex" ],
 
 				THREE.ShaderChunk[ "skinbase_vertex" ],


### PR DESCRIPTION
Fixed bug noticed by @mrdoob here: https://github.com/mrdoob/three.js/pull/5805#issuecomment-87132441
