### PR TITLE
CubeCamera.updateCubeMap(): restore the default framebuffer

### DIFF
--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -72,6 +72,8 @@ THREE.CubeCamera = function ( near, far, cubeResolution ) {
 		renderTarget.activeCubeFace = 5;
 		renderer.render( scene, cameraNZ, renderTarget );
 
+		renderer.setRenderTarget( null );
+
 	};
 
 };


### PR DESCRIPTION
Calls to `renderer.clear()` operate on the current framebuffer. However, following `updateCubeMap()`, the current framebuffer is the last face of the cube map. This change fixes that by restoring the default framebuffer.

Perhaps it would be better to restore the prior framebuffer, but this change is better than what we have currently.
