### PR TITLE
Do not generate mipmaps if render target generateMipmaps is not set.

### DIFF
--- a/examples/js/WaterShader.js
+++ b/examples/js/WaterShader.js
@@ -177,7 +177,9 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 	if ( !THREE.Math.isPowerOfTwo(width) || !THREE.Math.isPowerOfTwo(height) )
 	{
 		this.texture.generateMipmaps = false;
+		this.texture.minFilter = THREE.LinearFilter;
 		this.tempTexture.generateMipmaps = false;
+		this.tempTexture.minFilter = THREE.LinearFilter;
 	}
 
 	this.updateTextureMatrix();

--- a/examples/webgl_terrain_dynamic.html
+++ b/examples/webgl_terrain_dynamic.html
@@ -314,7 +314,7 @@
 				var normalShader = THREE.NormalMapShader;
 
 				var rx = 256, ry = 256;
-				var pars = { minFilter: THREE.LinearMipmapLinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBFormat };
+				var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBFormat };
 
 				heightMap  = new THREE.WebGLRenderTarget( rx, ry, pars );
 				heightMap.generateMipmaps = false;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -4383,7 +4383,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				if ( isTargetPowerOfTwo ) _gl.generateMipmap( _gl.TEXTURE_CUBE_MAP );
+				if ( renderTarget.generateMipmaps && isTargetPowerOfTwo ) _gl.generateMipmap( _gl.TEXTURE_CUBE_MAP );
 
 			} else {
 
@@ -4424,7 +4424,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				if ( isTargetPowerOfTwo ) _gl.generateMipmap( _gl.TEXTURE_2D );
+				if ( renderTarget.generateMipmaps && isTargetPowerOfTwo ) _gl.generateMipmap( _gl.TEXTURE_2D );
 
 			}
 


### PR DESCRIPTION
This also fixes two examples that had generateMipmaps set to false but
requested LinearMipMapLinearFilter which after the changes results in
a WebGL error.

Fixes #6316
