### PR TITLE
Declaring self variable instead of implicit global

### DIFF
--- a/src/extras/FontUtils.js
+++ b/src/extras/FontUtils.js
@@ -464,5 +464,6 @@ THREE.FontUtils.generateShapes = function ( text, parameters ) {
 } )( THREE.FontUtils );
 
 // To use the typeface.js face files, hook up the API
+var self = self || {};
 self._typeface_js = { faces: THREE.FontUtils.faces, loadFace: THREE.FontUtils.loadFace };
 THREE.typeface_js = self._typeface_js;


### PR DESCRIPTION
I'm not sure what the purpose of this self statement is, but self is undefined which causes problems when using the unminified version of three.
