### PR TITLE
Unnecessary parameter

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -662,7 +662,7 @@
 
 		};
 
-		this.detach = function ( object ) {
+		this.detach = function () {
 
 			scope.object = undefined;
 			this.axis = null;


### PR DESCRIPTION
Detach was taking a parameter that wasn't used. Removing it.
