### PR TITLE
Fix for Firefox WebVR

### DIFF
--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -12,14 +12,14 @@ THREE.VRControls = function ( object, onError ) {
 	function filterInvalidDevices( devices ) {
 
 		var
-			OculusDeviceId = 'HMDInfo-dev-0x421e7eb800',
-			CardboardDeviceId = 'HMDInfo-dev-0x421e7ecc00';
+			OculusDeviceName = 'VR Position Device (oculus)',
+			CardboardDeviceName = 'VR Position Device (cardboard)';
 
 
 		// Exclude Cardboard position sensor if Oculus exists.
 		var oculusDevices = devices.filter( function ( device ) {
 
-			return device.deviceId === OculusDeviceId;
+			return device.deviceName === OculusDeviceName;
 
 		} );
 
@@ -27,7 +27,7 @@ THREE.VRControls = function ( object, onError ) {
 
 			return devices.filter( function ( device ) {
 
-				return device.deviceId !== CardboardDeviceId;
+				return device.deviceName !== CardboardDeviceName;
 
 			} );
 

--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -9,17 +9,45 @@ THREE.VRControls = function ( object, onError ) {
 
 	var vrInputs = [];
 
+	function filterInvalidDevices( devices ) {
+
+		var
+			OculusDeviceId = 'HMDInfo-dev-0x421e7eb800',
+			CardboardDeviceId = 'HMDInfo-dev-0x421e7ecc00';
+
+
+		// Exclude Cardboard position sensor if Oculus exists.
+		var oculusDevices = devices.filter( function ( device ) {
+
+			return device.deviceId === OculusDeviceId;
+
+		} );
+
+		if ( oculusDevices.length >= 1 ) {
+
+			return devices.filter( function ( device ) {
+
+				return device.deviceId !== CardboardDeviceId;
+
+			} );
+
+		} else {
+
+			return devices;
+
+		}
+
+	}
+
 	function gotVRDevices( devices ) {
+
+		devices = filterInvalidDevices( devices );
 
 		for ( var i = 0; i < devices.length; i ++ ) {
 
-			var device = devices[ i ];
-
-			if ( device instanceof PositionSensorVRDevice ) {
+			if ( devices[ i ] instanceof PositionSensorVRDevice ) {
 
 				vrInputs.push( devices[ i ] );
-
-				break; // We keep the first we encounter
 
 			}
 

--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -19,13 +19,15 @@ THREE.VRControls = function ( object, onError ) {
 
 				vrInputs.push( devices[ i ] );
 
+				break; // We keep the first we encounter
+
 			}
 
 		}
 
 		if ( onError ) onError( 'HMD not available' );
 
-	};
+	}
 
 	if ( navigator.getVRDevices ) {
 
@@ -41,7 +43,7 @@ THREE.VRControls = function ( object, onError ) {
 
 	this.update = function () {
 
-		for ( var i = 0; i < vrInputs.length; i++ ) {
+		for ( var i = 0; i < vrInputs.length; i ++ ) {
 
 			var vrInput = vrInputs[ i ];
 
@@ -65,7 +67,7 @@ THREE.VRControls = function ( object, onError ) {
 
 	this.resetSensor = function () {
 
-		for ( var i = 0; i < vrInputs.length; i++ ) {
+		for ( var i = 0; i < vrInputs.length; i ++ ) {
 
 			var vrInput = vrInputs[ i ];
 

--- a/examples/vr_cubes.html
+++ b/examples/vr_cubes.html
@@ -84,7 +84,7 @@
 
 				crosshair = new THREE.Mesh(
 					new THREE.RingGeometry( 0.5, 1, 32 ),
-					new THREE.LineBasicMaterial( {
+					new THREE.MeshBasicMaterial( {
 						color: 0x00bb00,
 						transparent: true,
 						opacity: 0.5

--- a/examples/vr_cubes.html
+++ b/examples/vr_cubes.html
@@ -58,8 +58,9 @@
 			var vrEffect;
 			var vrControls;
 
-			var mouse = new THREE.Vector2(), INTERSECTED;
+			var INTERSECTED;
 			var radius = 100, theta = 0;
+			var crosshair;
 
 			init();
 			animate();
@@ -80,6 +81,16 @@
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 10000 );
 
 				scene = new THREE.Scene();
+
+				crosshair = new THREE.Mesh(
+					new THREE.RingGeometry( 0.5, 1, 32 ),
+					new THREE.LineBasicMaterial( {
+						color: 0x00bb00,
+						transparent: true,
+						opacity: 0.5
+					} )
+				);
+				scene.add( crosshair );
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( 1, 1, 1 ).normalize();
@@ -130,7 +141,9 @@
 				} );
 
 				fullScreenButton.onclick = function() {
+
 					vrEffect.setFullScreen( true );
+
 				};
 
 				renderer.setClearColor( 0xf0f0f0 );
@@ -142,8 +155,6 @@
 				stats.domElement.style.position = 'absolute';
 				stats.domElement.style.top = '0px';
 				container.appendChild( stats.domElement );
-
-				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 
 				//
 
@@ -160,15 +171,6 @@
 
 			}
 
-			function onDocumentMouseMove( event ) {
-
-				event.preventDefault();
-
-				mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
-				mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
-
-			}
-
 			//
 
 			function animate() {
@@ -182,18 +184,9 @@
 
 			function render() {
 
-				theta += 0.1;
-
-				camera.position.x = radius * Math.sin( THREE.Math.degToRad( theta ) );
-				camera.position.y = radius * Math.sin( THREE.Math.degToRad( theta ) );
-				camera.position.z = radius * Math.cos( THREE.Math.degToRad( theta ) );
-				camera.lookAt( scene.position );
-
-				camera.updateMatrixWorld();
-
 				// find intersections
 
-				raycaster.setFromCamera( mouse, camera );
+				raycaster.setFromCamera( { x: 0, y: 0 }, camera );
 
 				var intersects = raycaster.intersectObjects( scene.children );
 
@@ -218,6 +211,21 @@
 				}
 
 				vrControls.update();
+				crosshair.quaternion.copy( camera.quaternion );
+				crosshair.position.set( 0, 0, 0 );
+				if ( INTERSECTED ) {
+
+					crosshair.translateZ(
+						-scene.position.distanceTo( INTERSECTED.position ) +
+						INTERSECTED.geometry.boundingSphere.radius + 5
+					);
+
+				}
+				else {
+
+					crosshair.translateZ(-40);
+
+				}
 				vrEffect.render( scene, camera );
 
 			}

--- a/examples/vr_cubes.html
+++ b/examples/vr_cubes.html
@@ -211,8 +211,10 @@
 				}
 
 				vrControls.update();
+
 				crosshair.quaternion.copy( camera.quaternion );
 				crosshair.position.set( 0, 0, 0 );
+
 				if ( INTERSECTED ) {
 
 					crosshair.translateZ(
@@ -226,6 +228,7 @@
 					crosshair.translateZ(-40);
 
 				}
+
 				vrEffect.render( scene, camera );
 
 			}


### PR DESCRIPTION
This fixes VRControls to workaround the behaviour in the new Firefox Nightly builds where it [returns multiple position sensor devices](https://mail.mozilla.org/pipermail/web-vr-discuss/2015-April/000611.html) (one for Oculus and one for Cardboard) regardless of whether you're on a desktop PC or not. 

I've also tweaked the VR Cubes example so that it makes a bit more sense for VR.
