### PR TITLE
rendertarget resizable

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -39,9 +39,14 @@ THREE.WebGLRenderTarget.prototype = {
 
 	setSize: function ( width, height ) {
 
-		this.width = width;
-		this.height = height;
+		if ( this.width !== width || this.height !== height ) {
 
+			this.width = width;
+			this.height = height;
+
+			this.dispose();
+
+		}
 	},
 
 	clone: function () {


### PR DESCRIPTION
drop current rendertarget when resized; will be recreated in next render

Also fixes: https://github.com/potree/potree/issues/131
