### PR TITLE
Reset GL state before rendering sprites and lens

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1726,6 +1726,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		// custom render plugins (post pass)
 
+		this.resetGLState();
 		spritePlugin.render( scene, camera );
 		lensFlarePlugin.render( scene, camera, _currentWidth, _currentHeight );
 

--- a/src/renderers/webgl/plugins/LensFlarePlugin.js
+++ b/src/renderers/webgl/plugins/LensFlarePlugin.js
@@ -295,8 +295,9 @@ THREE.LensFlarePlugin = function ( renderer, flares ) {
 
 		gl.useProgram( program );
 
-		gl.enableVertexAttribArray( attributes.vertex );
-		gl.enableVertexAttribArray( attributes.uv );
+		renderer.state.disableUnusedAttributes();
+		renderer.state.enableAttribute( attributes.vertex );
+		renderer.state.enableAttribute( attributes.uv );
 
 		// loop through all lens flares to update their occlusion and positions
 		// setup gl and common used attribs/unforms

--- a/src/renderers/webgl/plugins/SpritePlugin.js
+++ b/src/renderers/webgl/plugins/SpritePlugin.js
@@ -98,8 +98,9 @@ THREE.SpritePlugin = function ( renderer, sprites ) {
 
 		gl.useProgram( program );
 
-		gl.enableVertexAttribArray( attributes.position );
-		gl.enableVertexAttribArray( attributes.uv );
+		renderer.state.disableUnusedAttributes();
+		renderer.state.enableAttribute( attributes.position );
+		renderer.state.enableAttribute( attributes.uv );
 
 		gl.disable( gl.CULL_FACE );
 		gl.enable( gl.BLEND );


### PR DESCRIPTION
This is a tentative fix for #6361.

The problem with #6361 is that the GL state is not reset after the main rendering pass, before the sprites are rendered. 

The sprite plugin only uses 2 attributes, but the number of attributes enabled coming from the main rendering pass is pretty random. For this test case, a third attribute remains enabled. The 3rd attribute is probably pointing to the cleared buffer.

This patch fixes the error. However, I'm not sure that I'm calling the correct APIs to reinitialize the state, and that I am calling them at the right place!
