### PR TITLE
Apply ambient occlusion to ambient light sources only

### DIFF
--- a/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl
@@ -1,5 +1,5 @@
 #ifdef USE_AOMAP
 
-	outgoingLight *= ( texture2D( aoMap, vUv2 ).r - 1.0 ) * aoMapIntensity + 1.0;
+	totalAmbientLight *= ( texture2D( aoMap, vUv2 ).r - 1.0 ) * aoMapIntensity + 1.0;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl
@@ -1,5 +1,5 @@
 #ifdef USE_LIGHTMAP
 
-	outgoingLight += diffuseColor.xyz * texture2D( lightMap, vUv2 ).xyz * lightMapIntensity;
+	totalAmbientLight += texture2D( lightMap, vUv2 ).xyz * lightMapIntensity;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -156,10 +156,10 @@ vec3 totalSpecularLight = vec3( 0.0 );
 
 #ifdef METAL
 
-	outgoingLight += diffuseColor.rgb * ( totalDiffuseLight + ambientLightColor ) * specular + totalSpecularLight + emissive;
+	outgoingLight += diffuseColor.rgb * ( totalDiffuseLight + totalAmbientLight ) * specular + totalSpecularLight + emissive;
 
 #else
 
-	outgoingLight += diffuseColor.rgb * ( totalDiffuseLight + ambientLightColor ) + totalSpecularLight + emissive;
+	outgoingLight += diffuseColor.rgb * ( totalDiffuseLight + totalAmbientLight ) + totalSpecularLight + emissive;
 
 #endif

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -345,6 +345,7 @@ THREE.ShaderLib = {
 
 			"	vec3 outgoingLight = vec3( 0.0 );",	// outgoing light does not have an alpha, the surface does
 			"	vec4 diffuseColor = vec4( diffuse, opacity );",
+			"	vec3 totalAmbientLight = ambientLightColor;",
 
 				THREE.ShaderChunk[ "logdepthbuf_fragment" ],
 				THREE.ShaderChunk[ "map_fragment" ],
@@ -352,11 +353,11 @@ THREE.ShaderLib = {
 				THREE.ShaderChunk[ "alphamap_fragment" ],
 				THREE.ShaderChunk[ "alphatest_fragment" ],
 				THREE.ShaderChunk[ "specularmap_fragment" ],
+				THREE.ShaderChunk[ "lightmap_fragment" ],
+				THREE.ShaderChunk[ "aomap_fragment" ],
 
 				THREE.ShaderChunk[ "lights_phong_fragment" ],
 
-				THREE.ShaderChunk[ "aomap_fragment" ],
-				THREE.ShaderChunk[ "lightmap_fragment" ],
 				THREE.ShaderChunk[ "envmap_fragment" ],
 				THREE.ShaderChunk[ "shadowmap_fragment" ],
 


### PR DESCRIPTION
Modified the Phong shader so AO maps modulate only ambient light sources.

Currently, `MeshPhongMaterial` supports two sources of ambient diffuse light: `AmbientLight` and lightmaps. AO maps modulate both.

It remains to discuss the modeling of ambient specular lighting.
