### PR TITLE
Adding ability to override shader precision, per material

### DIFF
--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -59,6 +59,8 @@ THREE.ShaderMaterial = function ( parameters ) {
 	this.morphTargets = false; // set to use morph targets
 	this.morphNormals = false; // set to use morph normals
 
+	this.precision = null; // override the renderer's default precision for this material
+
 	// When rendered geometry doesn't include these attributes but the material does,
 	// use these default values in WebGL. This avoids errors when buffer data is missing.
 	this.defaultAttributeValues = {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1966,14 +1966,14 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( material.precision ) {
 			if ( material.precision === 'highp' && ! highpAvailable ) {
 				if ( mediumpAvailable ) {
-					console.warn('THREE.WebGLRenderer: Material requires highp but only mediump is available.');
+					THREE.warn('THREE.WebGLRenderer: Material requires highp but only mediump is available.');
 				} else {
-					console.warn('THREE.WebGLRenderer: Material requires highp but only lowp is available.');
+					THREE.warn('THREE.WebGLRenderer: Material requires highp but only lowp is available.');
 				}
 			}
 
 			if ( material.precision === 'mediump' && ! mediumpAvailable ) {
-				console.warn('THREE.WebGLRenderer: Material requires mediump but only lowp is available.');
+				THREE.warn('THREE.WebGLRenderer: Material requires mediump but only lowp is available.');
 			}
 		}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1963,9 +1963,23 @@ THREE.WebGLRenderer = function ( parameters ) {
 		var maxShadows = allocateShadows( lights );
 		var maxBones = allocateBones( object );
 
+		if ( material.precision ) {
+			if ( material.precision === 'highp' && ! highpAvailable ) {
+				if ( mediumpAvailable ) {
+					material.precision = 'mediump';
+				} else {
+					material.precision = 'lowp';
+				}
+			}
+
+			if ( material.precision === 'mediump' && ! mediumpAvailable ) {
+				material.precision = 'lowp';
+			}
+		}
+
 		var parameters = {
 
-			precision: _precision,
+			precision: material.precision ? material.precision : _precision,
 			supportsVertexTextures: _supportsVertexTextures,
 
 			map: !! material.map,

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1966,14 +1966,14 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( material.precision ) {
 			if ( material.precision === 'highp' && ! highpAvailable ) {
 				if ( mediumpAvailable ) {
-					material.precision = 'mediump';
+					console.warn("Material requires highp but only mediump is available.");
 				} else {
-					material.precision = 'lowp';
+					console.warn("Material requires highp but only lowp is available.");
 				}
 			}
 
 			if ( material.precision === 'mediump' && ! mediumpAvailable ) {
-				material.precision = 'lowp';
+				console.warn("Material requires mediump but only lowp is available.");
 			}
 		}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1966,14 +1966,14 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( material.precision ) {
 			if ( material.precision === 'highp' && ! highpAvailable ) {
 				if ( mediumpAvailable ) {
-					console.warn("Material requires highp but only mediump is available.");
+					console.warn('THREE.WebGLRenderer: Material requires highp but only mediump is available.');
 				} else {
-					console.warn("Material requires highp but only lowp is available.");
+					console.warn('THREE.WebGLRenderer: Material requires highp but only lowp is available.');
 				}
 			}
 
 			if ( material.precision === 'mediump' && ! mediumpAvailable ) {
-				console.warn("Material requires mediump but only lowp is available.");
+				console.warn('THREE.WebGLRenderer: Material requires mediump but only lowp is available.');
 			}
 		}
 


### PR DESCRIPTION
This allows the default precision to be set, per material, by defining `THREE.ShaderMaterial.precision`.

I've found it useful on mobile platforms to be able to set a particular shader to use highp while the rest of the app defaults to mediump or lowp. Despite being able to specify precision, per variable, in GLSL, the default uniforms assigned by three.js always have the precision defined in `THREE.WebGLRenderer` so this override is necessary.

It could potentially be defined for `THREE.Material` instead of just `THREE.ShaderMaterial`. What do you think?
