### PR TITLE
Update Box3.js

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -184,15 +184,15 @@ THREE.Box3.prototype = {
 
 	containsPoint: function ( point ) {
 
-		if ( point.x < this.min.x || point.x > this.max.x ||
-		     point.y < this.min.y || point.y > this.max.y ||
-		     point.z < this.min.z || point.z > this.max.z ) {
+		if ( point.x > this.min.x || point.x < this.max.x ||
+		     point.y > this.min.y || point.y < this.max.y ||
+		     point.z > this.min.z || point.z < this.max.z ) {
 
-			return false;
+			return true;
 
 		}
 
-		return true;
+		return false;
 
 	},
 
@@ -229,15 +229,15 @@ THREE.Box3.prototype = {
 
 		// using 6 splitting planes to rule out intersections.
 
-		if ( box.max.x < this.min.x || box.min.x > this.max.x ||
-		     box.max.y < this.min.y || box.min.y > this.max.y ||
-		     box.max.z < this.min.z || box.min.z > this.max.z ) {
+		if ( box.max.x > this.min.x || box.min.x < this.max.x ||
+		     box.max.y > this.min.y || box.min.y < this.max.y ||
+		     box.max.z > this.min.z || box.min.z < this.max.z ) {
 
-			return false;
+			return true;
 
 		}
 
-		return true;
+		return false;
 
 	},
 


### PR DESCRIPTION
// edit - I was wrong - don't mind me - delete this request

the order in which  isIntersectionBox and containsPoint was checking for overlapping was to see if the object in question was NOT overlapping, then returning false if evaluating as true, and true if evaluating as false. That's really counter intuitive and confusing. I switched the less than or grater than signs and the false trues so that if the function evaluates as true, it returns true, if not it returns false. This should't change the way users interact with the function but it's much more intuitive source code.
