### PR TITLE
Add NPM support / add package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+examples/
+src/
+test/
+utils/
+docs/
+editor/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "three.js",
+  "version": "0.71.0",
+  "description": "JavaScript 3D library",
+  "main": "build/three.js",
+  "directories": {
+    "doc": "docs",
+    "example": "examples",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mrdoob/three.js"
+  },
+  "keywords": [
+    "three",
+    "three.js",
+    "3d",
+    "webgl"
+  ],
+  "author": "mrdoob",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mrdoob/three.js/issues"
+  },
+  "homepage": "http://threejs.org/"
+}


### PR DESCRIPTION
This is a response to https://github.com/mrdoob/three.js/pull/6055 in which @mrdoob's comments were not respected and thus the PR was not merged. This PR takes the comments into account.

> Moving this issue to dev branch re #5492
> 
> > This will allow browserify users to install three.js directly using npm.
> > 
> > The package can be installed straight from github by running npm install mrdoob/three.js (once this > pull request is merged. for now npm install mathisonian/three.js works).
> > 
> > It would also be cool to publish the package to npm. It looks like someone already published a browserify compatible three.js 2 years ago, maybe we can get they will give up ownership of that package name to make space for the official one.
