### PR TITLE
Include examples/fonts into bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
 		"editor",
 		"examples/*",
 		"!examples/js",
+		"!examples/fonts",
 		"src",
 		"test",
 		"utils",


### PR DESCRIPTION
Include examples/fonts into bower.json to permit to use TextGeometry when three.js downloaded from bower.
Error "Uncaught The font helvetiker with normal weight and normal style is missing." appear otherwise.
