### PR TITLE
Fixing: Sprites aren't affected by FogExp2 (#6444)

### DIFF
--- a/src/renderers/webgl/plugins/SpritePlugin.js
+++ b/src/renderers/webgl/plugins/SpritePlugin.js
@@ -324,7 +324,7 @@ THREE.SpritePlugin = function ( renderer, sprites ) {
 					'} else {',
 
 						'const float LOG2 = 1.442695;',
-						'float fogFactor = exp2( - fogDensity * fogDensity * depth * depth * LOG2 );',
+						'fogFactor = exp2( - fogDensity * fogDensity * depth * depth * LOG2 );',
 						'fogFactor = 1.0 - clamp( fogFactor, 0.0, 1.0 );',
 
 					'}',


### PR DESCRIPTION
See issue #6444. Solved by WestLangley.
