### PR TITLE
Adds check complete on shader resource available delegate (#6442)

### DIFF
--- a/examples/js/loaders/gltf/glTFLoader.js
+++ b/examples/js/loaders/gltf/glTFLoader.js
@@ -443,6 +443,7 @@ THREE.glTFLoader.prototype.load = function( url, callback ) {
 	ShaderDelegate.prototype.resourceAvailable = function(data, ctx) {
 		theLoader.shadersLoaded ++;
 		theLoader.shaders[ctx.id] = data;
+		theLoader.checkComplete();
 		return true;
 	};
 


### PR DESCRIPTION
Resolves issue #6442. When geometry bin is returned before shader resources, check complete is also performed as per shader loaded. This allows the loader (user) callback to be run.
