### PR TITLE
use strict (in)equalities

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -316,7 +316,7 @@ THREE.BufferGeometry.prototype = {
 		var hasFaceVertexUv = faceVertexUvs[ 0 ] && faceVertexUvs[ 0 ].length > 0;
 		var hasFaceVertexUv2 = faceVertexUvs[ 1 ] && faceVertexUvs[ 1 ].length > 0;
 
-		var hasFaceVertexNormals = faces[ 0 ] && faces[ 0 ].vertexNormals.length == 3;
+		var hasFaceVertexNormals = faces[ 0 ] && faces[ 0 ].vertexNormals.length === 3;
 
 		var positions = new Float32Array( faces.length * 3 * 3 );
 		this.addAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
@@ -977,7 +977,7 @@ THREE.BufferGeometry.prototype = {
 
 			for ( var vo = 0; vo < 3; vo ++ ) {
 				var vid = indices[ findex * 3 + vo ];
-				if ( vertexMap[ vid ] == - 1 ) {
+				if ( vertexMap[ vid ] === - 1 ) {
 					//Unmapped vertice
 					faceVertices[ vo * 2 ] = vid;
 					faceVertices[ vo * 2 + 1 ] = - 1;
@@ -1111,7 +1111,7 @@ THREE.BufferGeometry.prototype = {
 		/* Create a copy of all attributes for reordering. */
 		var sortedAttributes = {};
 		for ( var attr in this.attributes ) {
-			if ( attr == 'index' )
+			if ( attr === 'index' )
 				continue;
 			var sourceArray = this.attributes[ attr ].array;
 			sortedAttributes[ attr ] = new sourceArray.constructor( this.attributes[ attr ].itemSize * vertexCount );
@@ -1121,7 +1121,7 @@ THREE.BufferGeometry.prototype = {
 		for ( var new_vid = 0; new_vid < vertexCount; new_vid ++ ) {
 			var vid = indexMap[ new_vid ];
 			for ( var attr in this.attributes ) {
-				if ( attr == 'index' )
+				if ( attr === 'index' )
 					continue;
 				var attrArray = this.attributes[ attr ].array;
 				var attrSize = this.attributes[ attr ].itemSize;
@@ -1134,7 +1134,7 @@ THREE.BufferGeometry.prototype = {
 		/* Carry the new sorted buffers locally */
 		this.attributes[ 'index' ].array = indexBuffer;
 		for ( var attr in this.attributes ) {
-			if ( attr == 'index' )
+			if ( attr === 'index' )
 				continue;
 			this.attributes[ attr ].array = sortedAttributes[ attr ];
 			this.attributes[ attr ].numItems = this.attributes[ attr ].itemSize * vertexCount;

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -757,7 +757,7 @@ THREE.Geometry.prototype = {
 			// if any duplicate vertices are found in a Face3
 			// we have to remove the face as nothing can be saved
 			for ( var n = 0; n < 3; n ++ ) {
-				if ( indices[ n ] == indices[ ( n + 1 ) % 3 ] ) {
+				if ( indices[ n ] === indices[ ( n + 1 ) % 3 ] ) {
 
 					dupIndex = n;
 					faceIndicesToRemove.push( i );

--- a/src/extras/animation/MorphAnimation.js
+++ b/src/extras/animation/MorphAnimation.js
@@ -52,7 +52,7 @@ THREE.MorphAnimation.prototype = {
 
 		var influences = this.mesh.morphTargetInfluences;
 
-		if ( frame != this.currentFrame ) {
+		if ( frame !== this.currentFrame ) {
 
 			influences[ this.lastFrame ] = 0;
 			influences[ this.currentFrame ] = 1;

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -110,7 +110,7 @@ THREE.Curve.prototype.getLengths = function ( divisions ) {
 	if ( ! divisions ) divisions = (this.__arcLengthDivisions) ? (this.__arcLengthDivisions) : 200;
 
 	if ( this.cacheArcLengths
-		&& ( this.cacheArcLengths.length == divisions + 1 )
+		&& ( this.cacheArcLengths.length === divisions + 1 )
 		&& ! this.needsUpdate) {
 
 		//THREE.log( "cached", this.cacheArcLengths );
@@ -202,7 +202,7 @@ THREE.Curve.prototype.getUtoTmapping = function ( u, distance ) {
 
 	//THREE.log('b' , i, low, high, Date.now()- time);
 
-	if ( arcLengths[ i ] == targetArcLength ) {
+	if ( arcLengths[ i ] === targetArcLength ) {
 
 		var t = i / ( il - 1 );
 		return t;

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -12,7 +12,7 @@ THREE.CurvePath = function () {
 
 	this.curves = [];
 	this.bends = [];
-	
+
 	this.autoClose = false; // Automatically closes the path
 };
 
@@ -37,11 +37,11 @@ THREE.CurvePath.prototype.closePath = function() {
 	// Add a line curve if start and end of lines are not connected
 	var startPoint = this.curves[0].getPoint(0);
 	var endPoint = this.curves[this.curves.length - 1].getPoint(1);
-	
+
 	if (! startPoint.equals(endPoint)) {
 		this.curves.push( new THREE.LineCurve(endPoint, startPoint) );
 	}
-	
+
 };
 
 // To get accurate point with reference to
@@ -107,7 +107,7 @@ THREE.CurvePath.prototype.getCurveLengths = function() {
 
 	// We use cache values if curves and cache array are same length
 
-	if ( this.cacheLengths && this.cacheLengths.length == this.curves.length ) {
+	if ( this.cacheLengths && this.cacheLengths.length === this.curves.length ) {
 
 		return this.cacheLengths;
 
@@ -322,4 +322,3 @@ THREE.CurvePath.prototype.getWrapPoints = function ( oldPts, path ) {
 	return oldPts;
 
 };
-

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -376,7 +376,7 @@ THREE.Path.prototype.getPoints = function( divisions, closedPath ) {
 			//THREE.log(points);
 
 			break;
-		  
+
 		case THREE.PathActions.ELLIPSE:
 
 			var aX = args[ 0 ], aY = args[ 1 ],
@@ -464,9 +464,9 @@ THREE.Path.prototype.toShapes = function( isCCW, noHoles ) {
 			args = item.args;
 			action = item.action;
 
-			if ( action == THREE.PathActions.MOVE_TO ) {
+			if ( action === THREE.PathActions.MOVE_TO ) {
 
-				if ( lastPath.actions.length != 0 ) {
+				if ( lastPath.actions.length !== 0 ) {
 
 					subPaths.push( lastPath );
 					lastPath = new THREE.Path();
@@ -479,7 +479,7 @@ THREE.Path.prototype.toShapes = function( isCCW, noHoles ) {
 
 		}
 
-		if ( lastPath.actions.length != 0 ) {
+		if ( lastPath.actions.length !== 0 ) {
 
 			subPaths.push( lastPath );
 
@@ -534,17 +534,17 @@ THREE.Path.prototype.toShapes = function( isCCW, noHoles ) {
 				}
 				if ( ( inPt.y < edgeLowPt.y ) || ( inPt.y > edgeHighPt.y ) ) 		continue;
 
-				if ( inPt.y == edgeLowPt.y ) {
-					if ( inPt.x == edgeLowPt.x )		return	true;		// inPt is on contour ?
+				if ( inPt.y === edgeLowPt.y ) {
+					if ( inPt.x === edgeLowPt.x )		return	true;		// inPt is on contour ?
 					// continue;				// no intersection or edgeLowPt => doesn't count !!!
 				} else {
 					var perpEdge = edgeDy * (inPt.x - edgeLowPt.x) - edgeDx * (inPt.y - edgeLowPt.y);
-					if ( perpEdge == 0 )				return	true;		// inPt is on contour ?
+					if ( perpEdge === 0 )				return	true;		// inPt is on contour ?
 					if ( perpEdge < 0 ) 				continue;
 					inside = ! inside;		// true intersection left of inPt
 				}
 			} else {		// parallel or colinear
-				if ( inPt.y != edgeLowPt.y ) 		continue;			// parallel
+				if ( inPt.y !== edgeLowPt.y ) 		continue;			// parallel
 				// egde lies on the same horizontal line as inPt
 				if ( ( ( edgeHighPt.x <= inPt.x ) && ( inPt.x <= edgeLowPt.x ) ) ||
 					 ( ( edgeLowPt.x <= inPt.x ) && ( inPt.x <= edgeHighPt.x ) ) )		return	true;	// inPt: Point on contour !
@@ -557,14 +557,14 @@ THREE.Path.prototype.toShapes = function( isCCW, noHoles ) {
 
 
 	var subPaths = extractSubpaths( this.actions );
-	if ( subPaths.length == 0 ) return [];
+	if ( subPaths.length === 0 ) return [];
 
 	if ( noHoles === true )	return	toShapesNoHoles( subPaths );
 
 
 	var solid, tmpPath, tmpShape, shapes = [];
 
-	if ( subPaths.length == 1) {
+	if ( subPaths.length === 1) {
 
 		tmpPath = subPaths[0];
 		tmpShape = new THREE.Shape();
@@ -579,7 +579,7 @@ THREE.Path.prototype.toShapes = function( isCCW, noHoles ) {
 	holesFirst = isCCW ? ! holesFirst : holesFirst;
 
 	// THREE.log("Holes first", holesFirst);
-	
+
 	var betterShapeHoles = [];
 	var newShapes = [];
 	var newShapeHoles = [];
@@ -605,7 +605,7 @@ THREE.Path.prototype.toShapes = function( isCCW, noHoles ) {
 			newShapes[mainIdx] = { s: new THREE.Shape(), p: tmpPoints };
 			newShapes[mainIdx].s.actions = tmpPath.actions;
 			newShapes[mainIdx].s.curves = tmpPath.curves;
-			
+
 			if ( holesFirst )	mainIdx ++;
 			newShapeHoles[mainIdx] = [];
 
@@ -639,7 +639,7 @@ THREE.Path.prototype.toShapes = function( isCCW, noHoles ) {
 				var hole_unassigned = true;
 				for (var s2Idx = 0; s2Idx < newShapes.length; s2Idx ++ ) {
 					if ( isPointInsidePolygon( ho.p, newShapes[s2Idx].p ) ) {
-						if ( sIdx != s2Idx )		toChange.push( { froms: sIdx, tos: s2Idx, hole: hIdx } );
+						if ( sIdx !== s2Idx )	toChange.push( { froms: sIdx, tos: s2Idx, hole: hIdx } );
 						if ( hole_unassigned ) {
 							hole_unassigned = false;
 							betterShapeHoles[s2Idx].push( ho );

--- a/src/extras/core/Shape.js
+++ b/src/extras/core/Shape.js
@@ -128,7 +128,7 @@ THREE.Shape.Utils = {
 
 		function point_in_segment_2D_colin( inSegPt1, inSegPt2, inOtherPt ) {
 			// inOtherPt needs to be colinear to the inSegment
-			if ( inSegPt1.x != inSegPt2.x ) {
+			if ( inSegPt1.x !== inSegPt2.x ) {
 				if ( inSegPt1.x < inSegPt2.x ) {
 					return	( ( inSegPt1.x <= inOtherPt.x ) && ( inOtherPt.x <= inSegPt2.x ) );
 				} else {
@@ -170,19 +170,19 @@ THREE.Shape.Utils = {
 
 				// i.e. to reduce rounding errors
 				// intersection at endpoint of segment#1?
-				if ( perpSeg2 == 0 ) {
+				if ( perpSeg2 === 0 ) {
 					if ( ( inExcludeAdjacentSegs ) &&
-						 ( ( perpSeg1 == 0 ) || ( perpSeg1 == limit ) ) )		return [];
+						 ( ( perpSeg1 === 0 ) || ( perpSeg1 === limit ) ) )		return [];
 					return [ inSeg1Pt1 ];
 				}
-				if ( perpSeg2 == limit ) {
+				if ( perpSeg2 === limit ) {
 					if ( ( inExcludeAdjacentSegs ) &&
-						 ( ( perpSeg1 == 0 ) || ( perpSeg1 == limit ) ) )		return [];
+						 ( ( perpSeg1 === 0 ) || ( perpSeg1 === limit ) ) )		return [];
 					return [ inSeg1Pt2 ];
 				}
 				// intersection at endpoint of segment#2?
-				if ( perpSeg1 == 0 )		return [ inSeg2Pt1 ];
-				if ( perpSeg1 == limit )	return [ inSeg2Pt2 ];
+				if ( perpSeg1 === 0 )		return [ inSeg2Pt1 ];
+				if ( perpSeg1 === limit )	return [ inSeg2Pt2 ];
 
 				// return real intersection point
 				var factorSeg1 = perpSeg2 / limit;
@@ -190,17 +190,17 @@ THREE.Shape.Utils = {
 							y: inSeg1Pt1.y + factorSeg1 * seg1dy } ];
 
 			} else {		// parallel or colinear
-				if ( ( perpSeg1 != 0 ) ||
-					 ( seg2dy * seg1seg2dx != seg2dx * seg1seg2dy ) ) 			return [];
+				if ( ( perpSeg1 !== 0 ) ||
+					 ( seg2dy * seg1seg2dx !== seg2dx * seg1seg2dy ) ) 			return [];
 
 				// they are collinear or degenerate
-				var seg1Pt = ( (seg1dx == 0) && (seg1dy == 0) );	// segment1 ist just a point?
-				var seg2Pt = ( (seg2dx == 0) && (seg2dy == 0) );	// segment2 ist just a point?
+				var seg1Pt = ( (seg1dx === 0) && (seg1dy === 0) );	// segment1 ist just a point?
+				var seg2Pt = ( (seg2dx === 0) && (seg2dy === 0) );	// segment2 ist just a point?
 				// both segments are points
 				if ( seg1Pt && seg2Pt ) {
-					if ( (inSeg1Pt1.x != inSeg2Pt1.x) ||
-						 (inSeg1Pt1.y != inSeg2Pt1.y) )		return [];   	// they are distinct  points
-					return [ inSeg1Pt1 ];                 					// they are the same point
+					if ( (inSeg1Pt1.x !== inSeg2Pt1.x) ||
+						 (inSeg1Pt1.y !== inSeg2Pt1.y) )		return [];	// they are distinct  points
+					return [ inSeg1Pt1 ];                 						// they are the same point
 				}
 				// segment#1  is a single point
 				if ( seg1Pt ) {
@@ -216,7 +216,7 @@ THREE.Shape.Utils = {
 				// they are collinear segments, which might overlap
 				var seg1min, seg1max, seg1minVal, seg1maxVal;
 				var seg2min, seg2max, seg2minVal, seg2maxVal;
-				if (seg1dx != 0) {		// the segments are NOT on a vertical line
+				if (seg1dx !== 0) {		// the segments are NOT on a vertical line
 					if ( inSeg1Pt1.x < inSeg1Pt2.x ) {
 						seg1min = inSeg1Pt1; seg1minVal = inSeg1Pt1.x;
 						seg1max = inSeg1Pt2; seg1maxVal = inSeg1Pt2.x;
@@ -249,7 +249,7 @@ THREE.Shape.Utils = {
 				}
 				if ( seg1minVal <= seg2minVal ) {
 					if ( seg1maxVal <  seg2minVal )	return [];
-					if ( seg1maxVal == seg2minVal )	{
+					if ( seg1maxVal === seg2minVal )	{
 						if ( inExcludeAdjacentSegs )		return [];
 						return [ seg2min ];
 					}
@@ -257,7 +257,7 @@ THREE.Shape.Utils = {
 					return	[ seg2min, seg2max ];
 				} else {
 					if ( seg1minVal >  seg2maxVal )	return [];
-					if ( seg1minVal == seg2maxVal )	{
+					if ( seg1minVal === seg2maxVal )	{
 						if ( inExcludeAdjacentSegs )		return [];
 						return [ seg1min ];
 					}
@@ -574,4 +574,3 @@ THREE.Shape.Utils = {
 	}
 
 };
-

--- a/src/extras/curves/CatmullRomCurve3.js
+++ b/src/extras/curves/CatmullRomCurve3.js
@@ -100,7 +100,7 @@ THREE.CatmullRomCurve3 = ( function() {
 			intPoint = Math.floor( point );
 			weight = point - intPoint;
 
-			if ( weight == 0 && intPoint == l - 1 ) {
+			if ( weight === 0 && intPoint === l - 1 ) {
 
 				intPoint = l - 2;
 				weight = 1;
@@ -109,7 +109,7 @@ THREE.CatmullRomCurve3 = ( function() {
 
 			var p0, p1, p2, p3;
 
-			if ( intPoint == 0 ) {
+			if ( intPoint === 0 ) {
 
 				// extrapolate first point
 				tmp.subVectors( points[ 0 ], points[ 1 ] ).add( points[ 0 ] );

--- a/src/extras/curves/SplineCurve.js
+++ b/src/extras/curves/SplineCurve.js
@@ -19,7 +19,7 @@ THREE.SplineCurve.prototype.getPoint = function ( t ) {
 	var intPoint = Math.floor( point );
 	var weight = point - intPoint;
 
-	var point0 = points[ intPoint == 0 ? intPoint : intPoint - 1 ];
+	var point0 = points[ intPoint === 0 ? intPoint : intPoint - 1 ];
 	var point1 = points[ intPoint ];
 	var point2 = points[ intPoint > points.length - 2 ? points.length - 1 : intPoint + 1 ];
 	var point3 = points[ intPoint > points.length - 3 ? points.length - 1 : intPoint + 2 ];

--- a/src/extras/geometries/ExtrudeGeometry.js
+++ b/src/extras/geometries/ExtrudeGeometry.js
@@ -250,7 +250,7 @@ THREE.ExtrudeGeometry.prototype.addShape = function ( shape, options ) {
 				if ( v_prev_x < - EPSILON ) {
 					if ( v_next_x < - EPSILON ) { direction_eq = true; }
 				} else {
-					if ( Math.sign(v_prev_y) == Math.sign(v_next_y) ) { direction_eq = true; }
+					if ( Math.sign(v_prev_y) === Math.sign(v_next_y) ) { direction_eq = true; }
 				}
 			}
 

--- a/src/extras/geometries/PolyhedronGeometry.js
+++ b/src/extras/geometries/PolyhedronGeometry.js
@@ -153,7 +153,7 @@ THREE.PolyhedronGeometry = function ( vertices, indices, radius, detail ) {
 
 			for ( var j = 0; j <= rows; j ++) {
 
-				if ( j == 0 && i == cols ) {
+				if ( j === 0 && i === cols ) {
 
 					v[ i ][ j ] = aj;
 
@@ -175,7 +175,7 @@ THREE.PolyhedronGeometry = function ( vertices, indices, radius, detail ) {
 
 				var k = Math.floor( j / 2 );
 
-				if ( j % 2 == 0 ) {
+				if ( j % 2 === 0 ) {
 
 					make(
 						v[ i ][ k + 1],

--- a/src/loaders/CompressedTextureLoader.js
+++ b/src/loaders/CompressedTextureLoader.js
@@ -49,7 +49,7 @@ THREE.CompressedTextureLoader.prototype = {
 
 					if ( loaded === 6 ) {
 
-						if (texDatas.mipmapCount == 1)
+						if (texDatas.mipmapCount === 1)
  							texture.minFilter = THREE.LinearFilter;
 
 						texture.format = texDatas.format;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -91,7 +91,7 @@ THREE.Material.prototype = {
 
 					currentValue.copy( newValue );
 
-				} else if ( key == 'overdraw' ) {
+				} else if ( key === 'overdraw' ) {
 
 					// ensure overdraw is backwards-compatable with legacy boolean type
 					this[ key ] = Number( newValue );

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -17,11 +17,11 @@ THREE.Math = {
 
 			for ( var i = 0; i < 36; i ++ ) {
 
-				if ( i == 8 || i == 13 || i == 18 || i == 23 ) {
+				if ( i === 8 || i === 13 || i === 18 || i === 23 ) {
 
 					uuid[ i ] = '-';
 
-				} else if ( i == 14 ) {
+				} else if ( i === 14 ) {
 
 					uuid[ i ] = '4';
 
@@ -30,7 +30,7 @@ THREE.Math = {
 					if ( rnd <= 0x02 ) rnd = 0x2000000 + ( Math.random() * 0x1000000 ) | 0;
 					r = rnd & 0xf;
 					rnd = rnd >> 4;
-					uuid[ i ] = chars[ ( i == 19 ) ? ( r & 0x3 ) | 0x8 : r ];
+					uuid[ i ] = chars[ ( i === 19 ) ? ( r & 0x3 ) | 0x8 : r ];
 
 				}
 			}

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -685,7 +685,7 @@ THREE.Matrix4.prototype = {
 
 		var det = n11 * te[ 0 ] + n21 * te[ 4 ] + n31 * te[ 8 ] + n41 * te[ 12 ];
 
-		if ( det == 0 ) {
+		if ( det === 0 ) {
 
 			var msg = "THREE.Matrix4.getInverse(): can't invert matrix, determinant is 0";
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -140,10 +140,10 @@ THREE.Plane.prototype = {
 
 			var denominator = this.normal.dot( direction );
 
-			if ( denominator == 0 ) {
+			if ( denominator === 0 ) {
 
 				// line is coplanar, return origin
-				if ( this.distanceToPoint( line.start ) == 0 ) {
+				if ( this.distanceToPoint( line.start ) === 0 ) {
 
 					return result.copy( line.start );
 
@@ -210,7 +210,7 @@ THREE.Plane.prototype = {
 
 	equals: function ( plane ) {
 
-		return plane.normal.equals( this.normal ) && ( plane.constant == this.constant );
+		return plane.normal.equals( this.normal ) && ( plane.constant === this.constant );
 
 	},
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -261,7 +261,7 @@ THREE.Ray.prototype = {
 			// in order to always return an intersect point that is in front of the ray.
 			if ( t0 < 0 ) return this.at( t1, optionalTarget );
 
-			// else t0 is in front of the ray, so return the first collision point scaled by t0 
+			// else t0 is in front of the ray, so return the first collision point scaled by t0
 			return this.at( t0, optionalTarget );
 
 		}
@@ -297,10 +297,10 @@ THREE.Ray.prototype = {
 	distanceToPlane: function ( plane ) {
 
 		var denominator = plane.normal.dot( this.direction );
-		if ( denominator == 0 ) {
+		if ( denominator === 0 ) {
 
 			// line is coplanar, return origin
-			if ( plane.distanceToPoint( this.origin ) == 0 ) {
+			if ( plane.distanceToPoint( this.origin ) === 0 ) {
 
 				return 0;
 

--- a/src/math/Spline.js
+++ b/src/math/Spline.js
@@ -104,7 +104,7 @@ THREE.Spline = function ( points ) {
 			point = ( this.points.length - 1 ) * index;
 			intPoint = Math.floor( point );
 
-			if ( intPoint != oldIntPoint ) {
+			if ( intPoint !== oldIntPoint ) {
 
 				chunkLengths[ intPoint ] = totalLength;
 				oldIntPoint = intPoint;

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -61,7 +61,7 @@ THREE.Triangle.barycoordFromPoint = function () {
 		var result = optionalTarget || new THREE.Vector3();
 
 		// colinear or singular triangle
-		if ( denom == 0 ) {
+		if ( denom === 0 ) {
 			// arbitrary location outside of triangle?
 			// not sure if this is the best idea, maybe should be returning undefined
 			return result.set( - 2, - 1, - 1 );


### PR DESCRIPTION
I started to look into a few performance numbers of three.js when working through my profilings I saw a few places where non strict equalities are used. I checked with your codebase and you generally seem to prefer the strict ones. I went through all the ones in this pr, and they all work with strict as will.
