### PR TITLE
Tweak UMD/AMD wrapper.

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -36,7 +36,7 @@ function main() {
 	var sources = []; // used for source maps with minification
 
 	if ( args.amd ){
-		buffer.push('function ( root, factory ) {\n\n\tif ( typeof define === \'function\' && define.amd ) {\n\n\t\tdefine( [ \'exports\' ], factory );\n\n\t} else if ( typeof exports === \'object\' ) {\n\n\t\tfactory( exports );\n\n\t} else {\n\n\t\tfactory( root );\n\n\t}\n\n}( this, function ( exports ) {\n\n');
+		buffer.push('(function ( root, factory ) {\n\n\tif ( typeof define === \'function\' && define.amd ) {\n\n\t\tdefine( [ \'exports\' ], factory );\n\n\t} else if ( typeof exports === \'object\' ) {\n\n\t\tfactory( exports );\n\n\t} else {\n\n\t\tfactory( root );\n\n\t}\n\n}( this, function ( exports ) {\n\n');
 	};
 	
 	for ( var i = 0; i < args.include.length; i ++ ){
@@ -69,7 +69,7 @@ function main() {
 	}
 	
 	if ( args.amd ){
-		buffer.push('exports.THREE = THREE;\n\n} ) );');
+		buffer.push('return (exports.THREE = THREE);\n\n} ) );');
 	};
 	
 	var temp = buffer.join( '' );

--- a/utils/build/build.py
+++ b/utils/build/build.py
@@ -67,7 +67,7 @@ def main(argv=None):
 					tmp.write(u'\n')
 
 	if args.amd:
-		tmp.write('exports.THREE = THREE;\n\n} ) );')
+		tmp.write('return (exports.THREE = THREE);\n\n} ) );')
 
 	tmp.close()
 


### PR DESCRIPTION
The Node and Python builds generate slightly different wrappers with the `--amd` option is specified, and neither build includes a module return statement for the modularized THREE. This PR modifies the Node `--amd` build to match what the Python `--amd` build produces, and adds a module return statement to both while keeping the `module.exports = THREE` in place for CJS builds or legacy setups.
