### PR TITLE
Blender: add option to disable modifier application

### DIFF
--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -301,6 +301,10 @@ def restore_export_settings(properties, settings):
         constants.INFLUENCES_PER_VERTEX,
         constants.EXPORT_OPTIONS[constants.INFLUENCES_PER_VERTEX])
 
+    properties.option_apply_modifiers = settings.get(
+        constants.APPLY_MODIFIERS,
+        constants.EXPORT_OPTIONS[constants.APPLY_MODIFIERS])
+
     properties.option_geometry_type = settings.get(
         constants.GEOMETRY_TYPE,
         constants.EXPORT_OPTIONS[constants.GEOMETRY_TYPE])
@@ -424,6 +428,7 @@ def set_settings(properties):
         constants.NORMALS: properties.option_normals,
         constants.SKINNING: properties.option_skinning,
         constants.BONES: properties.option_bones,
+        constants.APPLY_MODIFIERS: properties.option_apply_modifiers,
         constants.GEOMETRY_TYPE: properties.option_geometry_type,
 
         constants.MATERIALS: properties.option_materials,
@@ -554,6 +559,12 @@ class ExportThree(bpy.types.Operator, ExportHelper):
         name="Bones",
         description="Export bones",
         default=constants.EXPORT_OPTIONS[constants.BONES])
+
+    option_apply_modifiers = BoolProperty(
+        name="Apply Modifiers",
+        description="Apply Modifiers to mesh objects",
+        default=constants.EXPORT_OPTIONS[constants.APPLY_MODIFIERS]
+    )
 
     option_scale = FloatProperty(
         name="Scale",
@@ -750,6 +761,9 @@ class ExportThree(bpy.types.Operator, ExportHelper):
         row = layout.row()
         row.prop(self.properties, 'option_bones')
         row.prop(self.properties, 'option_skinning')
+
+        row = layout.row()
+        row.prop(self.properties, 'option_apply_modifiers')
 
         row = layout.row()
         row.prop(self.properties, 'option_geometry_type')

--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -44,6 +44,7 @@ FACES = 'faces'
 NORMALS = 'normals'
 BONES = 'bones'
 UVS = 'uvs'
+APPLY_MODIFIERS = 'applyModifiers'
 COLORS = 'colors'
 MIX_COLORS = 'mixColors'
 SCALE = 'scale'
@@ -95,6 +96,7 @@ EXPORT_OPTIONS = {
     VERTICES: True,
     NORMALS: True,
     UVS: True,
+    APPLY_MODIFIERS: True,
     COLORS: False,
     MATERIALS: False,
     FACE_MATERIALS: False,

--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -329,7 +329,8 @@ def extract_mesh(obj, options, recalculate=False):
 
     """
     logger.debug('object.extract_mesh(%s, %s)', obj, options)
-    mesh_node = obj.to_mesh(context.scene, True, RENDER)
+    apply_modifiers = options.get(constants.APPLY_MODIFIERS, True)
+    mesh_node = obj.to_mesh(context.scene, apply_modifiers, RENDER)
 
     # transfer the geometry type to the extracted mesh
     mesh_node.THREE_geometry_type = obj.data.THREE_geometry_type


### PR DESCRIPTION
Add "Apply Modifiers" option to blender export:

![screen shot 2015-05-08 at 09 36 18](https://cloud.githubusercontent.com/assets/409021/7532313/bc5ea8d2-f565-11e4-8dcf-9da99d04f3ac.png)

Example use case: have a subdivision surface modifier for texture baking, but export without it

cc @repsac 
