### PR TITLE
Texture JSON

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -59,9 +59,9 @@ THREE.ImageLoader.prototype = {
 
 		if ( this.crossOrigin !== undefined ) image.crossOrigin = this.crossOrigin;
 
-		image.src = url;
-
 		scope.manager.itemStart( url );
+
+		image.src = url;
 
 		return image;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -295,7 +295,7 @@ THREE.ObjectLoader.prototype = {
 
 	parseConstant: function ( json ) {
 
-		return typeof( json ) === 'number' ? json : THREE[json];
+		return typeof( json ) === 'number' ? json : THREE[ json ];
 
 	},
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -293,6 +293,12 @@ THREE.ObjectLoader.prototype = {
 
 	},
 
+	parseConstant: function ( json ) {
+
+		return typeof( json ) === 'number' ? json : THREE[json];
+
+	},
+
 	parseImages: function ( json, onLoad ) {
 
 		var scope = this;
@@ -358,15 +364,15 @@ THREE.ObjectLoader.prototype = {
 				texture.uuid = data.uuid;
 
 				if ( data.name !== undefined ) texture.name = data.name;
-				if ( data.mapping !== undefined ) texture.mapping = data.mapping;
+				if ( data.mapping !== undefined ) texture.mapping = this.parseConstant( data.mapping );
 				if ( data.repeat !== undefined ) texture.repeat = new THREE.Vector2( data.repeat[ 0 ], data.repeat[ 1 ] );
-				if ( data.minFilter !== undefined ) texture.minFilter = THREE[ data.minFilter ];
-				if ( data.magFilter !== undefined ) texture.magFilter = THREE[ data.magFilter ];
+				if ( data.minFilter !== undefined ) texture.minFilter = this.parseConstant( data.minFilter );
+				if ( data.magFilter !== undefined ) texture.magFilter = this.parseConstant( data.magFilter );
 				if ( data.anisotropy !== undefined ) texture.anisotropy = data.anisotropy;
 				if ( data.wrap instanceof Array ) {
 
-					texture.wrapS = THREE[ data.wrap[ 0 ] ];
-					texture.wrapT = THREE[ data.wrap[ 1 ] ];
+					texture.wrapS = this.parseConstant( data.wrap[ 0 ] );
+					texture.wrapT = this.parseConstant( data.wrap[ 1 ] );
 
 				}
 

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -112,9 +112,9 @@ THREE.ShaderMaterial.prototype.clone = function ( material ) {
 
 };
 
-THREE.ShaderMaterial.prototype.toJSON = function () {
+THREE.ShaderMaterial.prototype.toJSON = function ( meta ) {
 
-	var data = THREE.Material.prototype.toJSON.call( this );
+	var data = THREE.Material.prototype.toJSON.call( this, meta );
 
 	data.uniforms = this.uniforms;
 	data.vertexShader = this.vertexShader;

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -109,8 +109,19 @@ THREE.Texture.prototype = {
 				type: 'Texture',
 				generator: 'Texture.toJSON'
 			},
+
 			uuid: this.uuid,
-			mapping: this.mapping
+			name: this.name,
+
+			mapping: this.mapping,
+
+			repeat: [ this.repeat.x, this.repeat.y ],
+			offset: [ this.offset.x, this.offset.y ],
+			wrap: [ this.wrapS, this.wrapT ],
+
+			minFilter: this.minFilter,
+			magFilter: this.magFilter,
+			anisotropy: this.anisotropy
 		};
 
 		if ( this.image !== undefined ) {


### PR DESCRIPTION
Lets Texture.toJSON write texture info in numeric form.
Lets ObjectLoader read this format and also the symbolic one for some backward compatibility.
Also fixes a potential loader quirk.
