### PR TITLE
Texture JSON suggestion

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -320,7 +320,7 @@ THREE.ObjectLoader.prototype = {
 			for ( var i = 0, l = json.length; i < l; i ++ ) {
 
 				var image = json[ i ];
-				images[ image.uuid ] = loadImage( image.src );
+				images[ image.uuid ] = loadImage( image.url );
 
 			}
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -146,7 +146,7 @@ THREE.Texture.prototype = {
 
 				}
 
-				meta.images[ this.image.uuid ] = { uuid: this.image.uuid, src: src };
+				meta.images[ this.image.uuid ] = { uuid: this.image.uuid, url: src };
 
 			}
 


### PR DESCRIPTION
Rename image.src back to image.url - backward compatible and clearly distinct from the DOM <img> element property. Reading back this property is a bad idea because the URL may become absolute and easily bake a "localhost" (or otherwise wrong path) into production data.

Also, I see Canvas.toDataURL returning an assumed-original, wrong location with Firefox - and all textures vanish from the editor on reload. Chrome returns a Blob, probably matching the intentions behind the code. Blobs conveniently avoid all path troubles, but are not entirely painless (volatility, re-encode, extra memory consumption).
As an image encapsulation seems to be work in progress, here's my vote for storing the locations of the source files as-is. Not exactly a new idea, as there is a rarly used 'sourceFile' attribute in Texture. Blobs only when no original files are accessible.
