### PR TITLE
Blender: Avoid obscure error on certain non-image textures.

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/texture.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/texture.py
@@ -174,5 +174,6 @@ def textures():
         if mat.users == 0:
             continue
         for slot in mat.texture_slots:
-            if slot and slot.use and slot.texture.type == IMAGE:
+            if (slot and slot.use and
+                    slot.texture and slot.texture.type == IMAGE):
                 yield slot.texture.name


### PR DESCRIPTION
Sorry, one line slipped through separating my changeset for submission.
