### PR TITLE
Material handling

### DIFF
--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -41,6 +41,7 @@ THREE.MaterialLoader.prototype = {
 		if ( json.specular !== undefined ) material.specular.setHex( json.specular );
 		if ( json.shininess !== undefined ) material.shininess = json.shininess;
 		if ( json.uniforms !== undefined ) material.uniforms = json.uniforms;
+		if ( json.attributes !== undefined ) material.attributes = json.attributes;
 		if ( json.vertexShader !== undefined ) material.vertexShader = json.vertexShader;
 		if ( json.fragmentShader !== undefined ) material.fragmentShader = json.fragmentShader;
 		if ( json.vertexColors !== undefined ) material.vertexColors = json.vertexColors;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2092,7 +2092,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			// changed glsl or parameters
 			deallocateMaterial( material );
 
-		} else if ( shaderID === undefined ) {
+		} else if ( shaderID !== undefined ) {
 
 			// same glsl
 			return;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2092,11 +2092,14 @@ THREE.WebGLRenderer = function ( parameters ) {
 			// changed glsl or parameters
 			deallocateMaterial( material );
 
-		} else if ( shaderID ||
-				material.__webglShader.uniforms === material.uniforms ) {
+		} else if ( shaderID === undefined ) {
 
-			// stop unless the container object for the uniforms has
-			// changed - same glsl and parameters
+			// same glsl
+			return;
+
+		} else if ( material.__webglShader.uniforms === material.uniforms ) {
+
+			// same uniforms (container object)
 			return;
 
 		}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2092,9 +2092,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 			// changed glsl or parameters
 			deallocateMaterial( material );
 
-		} else {
+		} else if ( shaderID ||
+				material.__webglShader.uniforms === material.uniforms ) {
 
-			// same glsl and parameters
+			// stop unless the container object for the uniforms has
+			// changed - same glsl and parameters
 			return;
 
 		}


### PR DESCRIPTION
The change in the renderer fixes the following issue: In case of materials without a ShaderID (custom shaders), the renderer uses a flat copy of 'material.uniforms' in its data structure '__webglShader'. Now, when 'material.uniforms' gets replaced, the renderer keeps going with its outdated copy and fails to properly detect any further changes - even when 'needsUpdate' is set.
