### PR TITLE
Getting rid of all the computed dependencies

### DIFF
--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -108,9 +108,18 @@ THREE.Loader.prototype = {
 		function nearest_pow2( n ) {
 
 			var l = Math.log( n ) / Math.LN2;
-			return Math.pow( 2, Math.round(  l ) );
+			return Math.pow( 2, Math.round( l ) );
 
 		}
+
+		var blendingLookup = {
+			NoBlending: THREE.NoBlending,
+			NormalBlending: THREE.NormalBlending,
+			AdditiveBlending: THREE.AdditiveBlending,
+			SubtractiveBlending: THREE.SubtractiveBlending,
+			MultiplyBlending: THREE.MultiplyBlending,
+			CustomBlending: THREE.CustomBlending
+		};
 
 		function create_texture( where, name, sourceFile, repeat, offset, wrap, anisotropy ) {
 
@@ -206,7 +215,7 @@ THREE.Loader.prototype = {
 
 		// defaults
 
-		var mtype = 'MeshLambertMaterial';
+		var Material = THREE.MeshLambertMaterial;
 		var mpars = { color: 0xeeeeee, opacity: 1.0, map: null, lightMap: null, normalMap: null, bumpMap: null, wireframe: false };
 
 		// parameters from model file
@@ -215,14 +224,14 @@ THREE.Loader.prototype = {
 
 			var shading = m.shading.toLowerCase();
 
-			if ( shading === 'phong' ) mtype = 'MeshPhongMaterial';
-			else if ( shading === 'basic' ) mtype = 'MeshBasicMaterial';
+			if ( shading === 'phong' ) Material = THREE.MeshPhongMaterial;
+			else if ( shading === 'basic' ) Material = THREE.MeshBasicMaterial;
 
 		}
 
-		if ( m.blending !== undefined && THREE[ m.blending ] !== undefined ) {
+		if ( m.blending !== undefined && blendingLookup[ m.blending ] !== undefined ) {
 
-			mpars.blending = THREE[ m.blending ];
+			mpars.blending = blendingLookup[ m.blending ];
 
 		}
 
@@ -391,7 +400,7 @@ THREE.Loader.prototype = {
 
 		}
 
-		var material = new THREE[ mtype ]( mpars );
+		var material = new Material( mpars );
 
 		if ( m.DbgName !== undefined ) material.name = m.DbgName;
 
@@ -416,7 +425,7 @@ THREE.Loader.Handlers = {
 		for ( var i = 0, l = this.handlers.length; i < l; i += 2 ) {
 
 			var regex = this.handlers[ i ];
-			var loader  = this.handlers[ i + 1 ];
+			var loader = this.handlers[ i + 1 ];
 
 			if ( regex.test( file ) ) {
 

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -34,7 +34,23 @@ THREE.MaterialLoader.prototype = {
 
 	parse: function ( json ) {
 
-		var material = new THREE[ json.type ];
+		var materialLookup = {
+			Material: THREE.Material,
+			LineBasicMaterial: THREE.LineBasicMaterial,
+			LineDashedMaterial: THREE.LineDashedMaterial,
+			MeshBasicMaterial: THREE.MeshBasicMaterial,
+			MeshDepthMaterial: THREE.MeshDepthMaterial,
+			MeshFaceMaterial: THREE.MeshFaceMaterial,
+			MeshLambertMaterial: THREE.MeshLambertMaterial,
+			MeshNormalMaterial: THREE.MeshNormalMaterial,
+			MeshPhongMaterial: THREE.MeshPhongMaterial,
+			PointCloudMaterial: THREE.PointCloudMaterial,
+			RawShaderMaterial: THREE.RawShaderMaterial,
+			ShaderMaterial: THREE.ShaderMaterial,
+			SpriteMaterial: THREE.SpriteMaterial
+		};
+
+		var material = new materialLookup[ json.type ];
 
 		if ( json.color !== undefined ) material.color.setHex( json.color );
 		if ( json.emissive !== undefined ) material.emissive.setHex( json.emissive );

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -86,9 +86,19 @@ THREE.ObjectLoader.prototype = {
 				switch ( data.type ) {
 
 					case 'PlaneGeometry':
+
+						geometry = new THREE.PlaneGeometry(
+							data.width,
+							data.height,
+							data.widthSegments,
+							data.heightSegments
+						);
+
+						break;
+
 					case 'PlaneBufferGeometry':
 
-						geometry = new THREE[ data.type ](
+						geometry = new THREE.PlaneBufferGeometry(
 							data.width,
 							data.height,
 							data.widthSegments,
@@ -332,13 +342,37 @@ THREE.ObjectLoader.prototype = {
 
 	parseTextures: function ( json, images ) {
 
-		function parseConstant( value ) {
+		var filterLookup = {
+			NearestFilter: THREE.NearestFilter,
+			NearestMipMapNearestFilter: THREE.NearestMipMapNearestFilter,
+			NearestMipMapLinearFilter: THREE.NearestMipMapLinearFilter,
+			LinearFilter: THREE.LinearFilter,
+			LinearMipMapNearestFilter: THREE.LinearMipMapNearestFilter,
+			LinearMipMapLinearFilter: THREE.LinearMipMapLinearFilter
+		};
+
+		var wrappingLookup = {
+			RepeatWrapping: THREE.RepeatWrapping,
+			ClampToEdgeWrapping: THREE.ClampToEdgeWrapping,
+			MirroredRepeatWrapping: THREE.MirroredRepeatWrapping
+		};
+
+		var mappingLookup = {
+			UVMapping: THREE.UVMapping,
+			CubeReflectionMapping: THREE.CubeReflectionMapping,
+			CubeRefractionMapping: THREE.CubeRefractionMapping,
+			EquirectangularReflectionMapping: THREE.EquirectangularReflectionMapping,
+			EquirectangularRefractionMapping: THREE.EquirectangularRefractionMapping,
+			SphericalReflectionMapping: THREE.SphericalReflectionMapping
+		};
+
+		function parseConstant( value, lookup ) {
 
 			if ( typeof( value ) === 'number' ) return value;
 
 			console.warn( 'THREE.ObjectLoader.parseTexture: Constant should be in numeric form.', value );
 
-			return THREE[ value ];
+			return lookup[ value ];
 
 		}
 
@@ -368,15 +402,15 @@ THREE.ObjectLoader.prototype = {
 				texture.uuid = data.uuid;
 
 				if ( data.name !== undefined ) texture.name = data.name;
-				if ( data.mapping !== undefined ) texture.mapping = parseConstant( data.mapping );
+				if ( data.mapping !== undefined ) texture.mapping = parseConstant( data.mapping, mappingLookup );
 				if ( data.repeat !== undefined ) texture.repeat = new THREE.Vector2( data.repeat[ 0 ], data.repeat[ 1 ] );
-				if ( data.minFilter !== undefined ) texture.minFilter = parseConstant( data.minFilter );
-				if ( data.magFilter !== undefined ) texture.magFilter = parseConstant( data.magFilter );
+				if ( data.minFilter !== undefined ) texture.minFilter = parseConstant( data.minFilter, filterLookup );
+				if ( data.magFilter !== undefined ) texture.magFilter = parseConstant( data.magFilter, filterLookup );
 				if ( data.anisotropy !== undefined ) texture.anisotropy = data.anisotropy;
 				if ( data.wrap instanceof Array ) {
 
-					texture.wrapS = parseConstant( data.wrap[ 0 ] );
-					texture.wrapT = parseConstant( data.wrap[ 1 ] );
+					texture.wrapS = parseConstant( data.wrap[ 0 ], wrappingLookup );
+					texture.wrapT = parseConstant( data.wrap[ 1 ], wrappingLookup );
 
 				}
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -73,7 +73,7 @@ THREE.Line.prototype.raycast = ( function () {
 
 				}
 
-				for ( var oi = 0; oi < offsets.length; oi ++) {
+				for ( var oi = 0; oi < offsets.length; oi ++ ) {
 
 					var start = offsets[ oi ].start;
 					var count = offsets[ oi ].count;
@@ -185,7 +185,7 @@ THREE.Line.prototype.raycast = ( function () {
 
 THREE.Line.prototype.clone = function ( object ) {
 
-	if ( object === undefined ) object = new THREE[ this.type ]( this.geometry, this.material );
+	if ( object === undefined ) object = new this.constructor( this.geometry, this.material );
 
 	THREE.Object3D.prototype.clone.call( this, object );
 


### PR DESCRIPTION
Basically, this commit gets rid of all the computed properties found on the THREE object, using lookup objects.
- this allows static dependency analysis to work
- this allows tools to perform source conversion to any module format (commonJS, AMD, es6, etc.)

In the loaders case, this also adds an extra layer of protection agains setting a wrong type on the json object.
Previously, setting, for instance, "Object3D" as the material type on a json file you load with MaterialLoader would have instantiated a new Object3D.

The ideal solution would be to have the lookup objects exported, so they can be modified by extensions, if needed.
