### PR TITLE
Fix formatting for code example.

### DIFF
--- a/docs/api/extras/geometries/ShapeGeometry.html
+++ b/docs/api/extras/geometries/ShapeGeometry.html
@@ -16,19 +16,20 @@
 		<h2>Example</h2>
 		
 		
-		<code>var rectLength = 120, rectWidth = 40;
+		<code>
+var rectLength = 120, rectWidth = 40;
 		
-		var rectShape = new THREE.Shape();
-		rectShape.moveTo( 0,0 );
-		rectShape.lineTo( 0, rectWidth );
-		rectShape.lineTo( rectLength, rectWidth );
-		rectShape.lineTo( rectLength, 0 );
-		rectShape.lineTo( 0, 0 );
-		
-		var rectGeom = new THREE.ShapeGeometry( rectShape );
-		var rectMesh = new THREE.Mesh( rectGeom, new THREE.MeshBasicMaterial( { color: 0xff0000 } ) ) ;		
-		
-		scene.add( rectMesh );
+var rectShape = new THREE.Shape();
+rectShape.moveTo( 0,0 );
+rectShape.lineTo( 0, rectWidth );
+rectShape.lineTo( rectLength, rectWidth );
+rectShape.lineTo( rectLength, 0 );
+rectShape.lineTo( 0, 0 );
+
+var rectGeom = new THREE.ShapeGeometry( rectShape );
+var rectMesh = new THREE.Mesh( rectGeom, new THREE.MeshBasicMaterial( { color: 0xff0000 } ) ) ;		
+	
+scene.add( rectMesh );
 		</code>
 	
 		<h2>Constructor</h2>


### PR DESCRIPTION
Please let me know if this is not targeting the right branch.

This fixes the problem of bad code formatting on the example in the page http://threejs.org/docs/#Reference/Extras.Geometries/ShapeGeometry
