### PR TITLE
add Geometry.clearVertexNormals ()

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -338,6 +338,11 @@ THREE.Geometry.prototype = {
 
 	},
 
+	clearVertexNormals: function () {
+		for(var i = 0; i < this.faces.length; ++i)    
+			this.faces[ i ].vertexNormals = [ ];
+	},
+
 	computeMorphNormals: function () {
 
 		var i, il, f, fl, face;


### PR DESCRIPTION
Once `Geometry.computeVertexNormals ()` is called, there is no way to switch back to use face normals for rendering which is fine for some applications especially for static models. Toggling between face normals and vertex normals helps comparing the rendering differences and we can see each triangle clearly only using face normals which is important for some applications (e.g. mesh optimization).
Clearing vertex normals is just a quick work around, but still costs a lot if we only toggling between two normals when the geometry is static. Will there be better to add a flag say whether vertex normals should be used for rendering. Any suggestions?
