### PR TITLE
Adding an option to THREE.BoundingBoxHelper to disregard invisible ob…

### DIFF
--- a/src/extras/helpers/BoundingBoxHelper.js
+++ b/src/extras/helpers/BoundingBoxHelper.js
@@ -19,9 +19,9 @@ THREE.BoundingBoxHelper = function ( object, hex ) {
 THREE.BoundingBoxHelper.prototype = Object.create( THREE.Mesh.prototype );
 THREE.BoundingBoxHelper.prototype.constructor = THREE.BoundingBoxHelper;
 
-THREE.BoundingBoxHelper.prototype.update = function () {
+THREE.BoundingBoxHelper.prototype.update = function ( disregardInvisibleObjects ) {
 
-	this.box.setFromObject( this.object );
+	this.box.setFromObject( this.object, disregardInvisibleObjects );
 
 	this.box.size( this.scale );
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -61,7 +61,7 @@ THREE.Box3.prototype = {
 
 		var v1 = new THREE.Vector3();
 
-		return function ( object ) {
+		return function ( object, disregardInvisibleObjects ) {
 
 			var scope = this;
 
@@ -70,6 +70,12 @@ THREE.Box3.prototype = {
 			this.makeEmpty();
 
 			object.traverse( function ( node ) {
+
+				if (disregardInvisibleObjects && !node.visible) {
+
+					return;
+
+				}
 
 				var geometry = node.geometry;
 


### PR DESCRIPTION
Adding an option to THREE.BoundingBoxHelper to disregard invisible objects while building the bounding box.

I was using a THREE.BoundingBoxHelper to update a camera viewport, but one of the objects in the scene (a THREE.GridHelper) was causing the scene to become tiny, even though it was invisible.

Example use:

```
// mainObj has a child with visible = false, we don't want to include it in the bounding box:
var bb = new THREE.BoundingBoxHelper( mainObj );
bb.update( true ); // disregardInvisibleObjects = true
```
