### PR TITLE
Correct handling of OrthographicCamera for TrackballControls

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -210,7 +210,20 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 			factor = _touchZoomDistanceStart / _touchZoomDistanceEnd;
 			_touchZoomDistanceStart = _touchZoomDistanceEnd;
-			_eye.multiplyScalar( factor );
+
+			if ( this.object instanceof THREE.PerspectiveCamera ) {
+
+				_eye.multiplyScalar( factor );
+
+			} else {
+
+				this.object.left *= factor;
+				this.object.right *= factor;
+				this.object.top *= factor;
+				this.object.bottom *= factor;
+
+				this.object.updateProjectionMatrix();
+			}
 
 		} else {
 
@@ -218,7 +231,19 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 			if ( factor !== 1.0 && factor > 0.0 ) {
 
-				_eye.multiplyScalar( factor );
+				if ( this.object instanceof THREE.PerspectiveCamera ) {
+
+					_eye.multiplyScalar( factor );
+
+				} else {
+
+					this.object.left *= factor;
+					this.object.right *= factor;
+					this.object.top *= factor;
+					this.object.bottom *= factor;
+
+					this.object.updateProjectionMatrix();
+				}
 
 				if ( _this.staticMoving ) {
 


### PR DESCRIPTION
TrackballControls currently doesn't work if OrthographicCamera is used.
This commit fixes it without modifying the behavior for PerspectiveCamera
