### PR TITLE
allow for projection plane offset.

### DIFF
--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -927,15 +927,20 @@ THREE.Matrix4.prototype = {
 
 	},
 
-	makePerspective: function ( fov, aspect, near, far ) {
+	makePerspective: function ( fov, aspect, near, far, projectionPlaneSize, projectionPlaneOffset ) {
 
 		var ymax = near * Math.tan( THREE.Math.degToRad( fov * 0.5 ) );
 		var ymin = - ymax;
 		var xmin = ymin * aspect;
 		var xmax = ymax * aspect;
 
-		return this.makeFrustum( xmin, xmax, ymin, ymax, near, far );
+		var projectionMatrix = this.makeFrustum( xmin, xmax, ymin, ymax, near, far );
 
+		// shift principle point, details: http://ksimek.github.io/2013/08/13/intrinsic/
+		projectionMatrix.elements[8] = 2 * projectionPlaneOffset.x / projectionPlaneSize.x;
+		projectionMatrix.elements[9] = 2 * projectionPlaneOffset.y / projectionPlaneSize.y;
+
+		return projectionMatrix;
 	},
 
 	makeOrthographic: function ( left, right, top, bottom, near, far ) {

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -938,8 +938,12 @@ THREE.Matrix4.prototype = {
 
 		if( projectionPlaneOffset && projectionPlaneSize ) {
 			// shift principle point, details: http://ksimek.github.io/2013/08/13/intrinsic/
-			projectionMatrix.elements[8] = 2 * projectionPlaneOffset.x / projectionPlaneSize.x;
-			projectionMatrix.elements[9] = 2 * projectionPlaneOffset.y / projectionPlaneSize.y;
+			if( projectionPlaneSize.x !== 0 ) {
+				projectionMatrix.elements[8] = 2 * projectionPlaneOffset.x / projectionPlaneSize.x;
+			}
+			if( projectionPlaneSize.y !== 0 ) {
+				projectionMatrix.elements[9] = 2 * projectionPlaneOffset.y / projectionPlaneSize.y;
+			}
 		}
 
 		return projectionMatrix;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -936,9 +936,11 @@ THREE.Matrix4.prototype = {
 
 		var projectionMatrix = this.makeFrustum( xmin, xmax, ymin, ymax, near, far );
 
-		// shift principle point, details: http://ksimek.github.io/2013/08/13/intrinsic/
-		projectionMatrix.elements[8] = 2 * projectionPlaneOffset.x / projectionPlaneSize.x;
-		projectionMatrix.elements[9] = 2 * projectionPlaneOffset.y / projectionPlaneSize.y;
+		if( projectionPlaneOffset && projectionPlaneSize ) {
+			// shift principle point, details: http://ksimek.github.io/2013/08/13/intrinsic/
+			projectionMatrix.elements[8] = 2 * projectionPlaneOffset.x / projectionPlaneSize.x;
+			projectionMatrix.elements[9] = 2 * projectionPlaneOffset.y / projectionPlaneSize.y;
+		}
 
 		return projectionMatrix;
 	},


### PR DESCRIPTION
For stereo cameras that are perfectly compatible with Maya, Softimage, Mental Ray, VRay, one needs to support shifting the principle point around.  This patch allows that.

Specifically look at the "principle point" discussion on this page: http://ksimek.github.io/2013/08/13/intrinsic/
