### PR TITLE
Fixed zoom bug in trackball control

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -278,12 +278,14 @@ THREE.TrackballControls = function ( object, domElement ) {
 			if ( _eye.lengthSq() > _this.maxDistance * _this.maxDistance ) {
 
 				_this.object.position.addVectors( _this.target, _eye.setLength( _this.maxDistance ) );
+				_zoomStart.copy( _zoomEnd );
 
 			}
 
 			if ( _eye.lengthSq() < _this.minDistance * _this.minDistance ) {
 
 				_this.object.position.addVectors( _this.target, _eye.setLength( _this.minDistance ) );
+				_zoomStart.copy( _zoomEnd );
 
 			}
 


### PR DESCRIPTION
Discovered a minor bug in the trackball control when using min/max distance. This patch fixes the bug.

When zooming past the min/max zoom distance, additional zoom events continue to increment the zoomStart. When trying to zoom back into the range, the zoom will feel 'stuck' as the zoomStart vector needs to be moved back into range first.

Essentially the eye position is clamped, but the zoomStart is not. This patch sets the zoomStart to the zoomEnd when clamping the eye, so that we can immediately zoom back into range without getting stuck first.
