### PR TITLE
r71 fix 32bit index buffer extension not enable automatically for Line

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1244,7 +1244,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			var type, size;
 
-			if ( index.array instanceof Uint32Array ) {
+			if ( index.array instanceof Uint32Array && extensions.get( 'OES_element_index_uint' ) ) {
 
 				type = _gl.UNSIGNED_INT;
 				size = 4;


### PR DESCRIPTION
I get error WebGL Invalid Type when I render Line BufferGeometry with 32bit index buffer.
This is enable automatically for other type of mesh.
