### PR TITLE
Removed Raycaster.precision

### DIFF
--- a/docs/api/core/Raycaster.html
+++ b/docs/api/core/Raycaster.html
@@ -98,11 +98,6 @@
 		This value shouldn't be negative and should be larger than the near property. 
 		</div>
 
-		<h3>[property:float precision]</h3>
-		<div>
-		The precision factor of the raycaster when intersecting [page:Mesh] objects. 
-		</div>
-
 		<h3>.[page:float linePrecision]</h3>
 		<div>
 		The precision factor of the raycaster when intersecting [page:Line] objects. 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -54,7 +54,6 @@
 
 		constructor: THREE.Raycaster,
 
-		precision: 0.0001,
 		linePrecision: 1,
 
 		set: function ( origin, direction ) {

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -107,7 +107,6 @@ THREE.Mesh.prototype.raycast = ( function () {
 			var attributes = geometry.attributes;
 
 			var a, b, c;
-			var precision = raycaster.precision;
 
 			if ( attributes.index !== undefined ) {
 
@@ -153,7 +152,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 						var distance = raycaster.ray.origin.distanceTo( intersectionPoint );
 
-						if ( distance < precision || distance < raycaster.near || distance > raycaster.far ) continue;
+						if ( distance < raycaster.near || distance > raycaster.far ) continue;
 
 						intersects.push( {
 
@@ -199,7 +198,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 					var distance = raycaster.ray.origin.distanceTo( intersectionPoint );
 
-					if ( distance < precision || distance < raycaster.near || distance > raycaster.far ) continue;
+					if ( distance < raycaster.near || distance > raycaster.far ) continue;
 
 					intersects.push( {
 
@@ -221,7 +220,6 @@ THREE.Mesh.prototype.raycast = ( function () {
 			var objectMaterials = isFaceMaterial === true ? this.material.materials : null;
 
 			var a, b, c;
-			var precision = raycaster.precision;
 
 			var vertices = geometry.vertices;
 
@@ -294,7 +292,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 				var distance = raycaster.ray.origin.distanceTo( intersectionPoint );
 
-				if ( distance < precision || distance < raycaster.near || distance > raycaster.far ) continue;
+				if ( distance < raycaster.near || distance > raycaster.far ) continue;
 
 				intersects.push( {
 

--- a/src/objects/PointCloud.js
+++ b/src/objects/PointCloud.js
@@ -54,6 +54,8 @@ THREE.PointCloud.prototype.raycast = ( function () {
 
 				var distance = raycaster.ray.origin.distanceTo( intersectPoint );
 
+				if ( distance < raycaster.near || distance > raycaster.far ) return;
+
 				intersects.push( {
 
 					distance: distance,


### PR DESCRIPTION
`Raycaster.precision` was being misused. See discussion in https://github.com/mrdoob/three.js/issues/6615.

Also added `Raycaster.near / Raycaster.far` testing when raycasting againt `PointCloud`. Fixes https://github.com/mrdoob/three.js/issues/6615.
