### PR TITLE
Protect against invalid pixel ratio

### DIFF
--- a/examples/js/renderers/CanvasRenderer.js
+++ b/examples/js/renderers/CanvasRenderer.js
@@ -155,7 +155,11 @@ THREE.CanvasRenderer = function ( parameters ) {
 
 	this.setPixelRatio = function ( value ) {
 
-		pixelRatio = value;
+		if ( value !== undefined ) {
+
+			pixelRatio = value;
+
+		}
 
 	};
 


### PR DESCRIPTION
We don't usually do this kind of checks, but the renderer's pixel ratio is usually taken directly from `window.devicePixelRatio`, which is undefined in older browsers.

Unbreaks examples in IE 10 (#6628).

I didn't patch `WebglRenderer`. All browsers that support `webgl` appear to define `window.devicePixelRatio`.
