### PR TITLE
Added GL call to disable attributes when reset is called. This fixes …

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -423,6 +423,7 @@ THREE.WebGLState = function ( gl, paramThreeToGL ) {
 
 		for ( var i = 0; i < enabledAttributes.length; i ++ ) {
 
+			gl.disableVertexAttribArray( i );
 			enabledAttributes[ i ] = 0;
 
 		}

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -423,7 +423,9 @@ THREE.WebGLState = function ( gl, paramThreeToGL ) {
 
 		for ( var i = 0; i < enabledAttributes.length; i ++ ) {
 
-			gl.disableVertexAttribArray( i );
+			if ( enabledAttributes[ i ] ) {
+				gl.disableVertexAttribArray( i );
+			}
 			enabledAttributes[ i ] = 0;
 
 		}


### PR DESCRIPTION
…an issue where attributes are still enabled from previous frame but `state.enabledAttributes` structure has them marked as disabled. This lead to the infamous 'attempt to access out of range vertices in attribute X' messages in the console.
