### PR TITLE
Uniform & attribute caching

### DIFF
--- a/docs/api/renderers/webgl/WebGLProgram.html
+++ b/docs/api/renderers/webgl/WebGLProgram.html
@@ -139,11 +139,6 @@
 		Returns a name-value mapping of all active vertex attribute locations.
 		</div>
 
-		<h3>[method:Array getAttributesKeys]()</h3>
-		<div>
-		Returns an array of all active vertex attribute names.
-		</div>
-
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/renderers/webgl/WebGLProgram.html
+++ b/docs/api/renderers/webgl/WebGLProgram.html
@@ -129,17 +129,17 @@
 
 		<h2>Methods</h2>
 		
-		<h3>[method:Object uniforms]()</h3>
+		<h3>[method:Object getUniforms]()</h3>
 		<div>
 		Returns a name-value mapping of all active uniform locations.
 		</div>
 
-		<h3>[method:Object attributes]()</h3>
+		<h3>[method:Object getAttributes]()</h3>
 		<div>
 		Returns a name-value mapping of all active vertex attribute locations.
 		</div>
 
-		<h3>[method:Array attributesKeys]()</h3>
+		<h3>[method:Array getAttributesKeys]()</h3>
 		<div>
 		Returns an array of all active vertex attribute names.
 		</div>

--- a/docs/api/renderers/webgl/WebGLProgram.html
+++ b/docs/api/renderers/webgl/WebGLProgram.html
@@ -109,12 +109,6 @@
 
 		<h2>Properties</h2>
 
-		<h3>[property:Object uniforms]</h3>
-		<div></div> 
-
-		<h3>[property:Object attributes]</h3>
-		<div></div> 
-
 		<h3>[property:String id]</h3>
 		<div></div> 
 
@@ -133,11 +127,22 @@
 		<h3>[property:WebGLShader fragmentShader]</h3>
 		<div></div> 
 
-
 		<h2>Methods</h2>
 		
-		<h3>none</h3>
-		<div></div>
+		<h3>[method:Object uniforms]()</h3>
+		<div>
+		Returns a name-value mapping of all active uniform locations.
+		</div>
+
+		<h3>[method:Object attributes]()</h3>
+		<div>
+		Returns a name-value mapping of all active vertex attribute locations.
+		</div>
+
+		<h3>[method:Array attributesKeys]()</h3>
+		<div>
+		Returns an array of all active vertex attribute names.
+		</div>
 
 		<h2>Source</h2>
 

--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -642,7 +642,7 @@ Sidebar.Material = function ( editor ) {
 			'emissive': materialEmissiveRow,
 			'specular': materialSpecularRow,
 			'shininess': materialShininessRow,
-			'program': materialProgramRow,
+			'vertexShader': materialProgramRow,
 			'vertexColors': materialVertexColorsRow,
 			'skinning': materialSkinningRow,
 			'map': materialMapRow,

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -968,7 +968,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				} else if ( materialDefaultAttributeValues !== undefined ) {
 
-					var value = materialDefaultAttributeValues[ key ];
+					var value = materialDefaultAttributeValues[ name ];
 					if ( value !== undefined ) {
 
 						switch ( value.length ) {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -779,14 +779,15 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( object.hasUvs && ! object.__webglUvBuffer ) object.__webglUvBuffer = _gl.createBuffer();
 		if ( object.hasColors && ! object.__webglColorBuffer ) object.__webglColorBuffer = _gl.createBuffer();
 
+		var attributes = program.attributes();
+
 		if ( object.hasPositions ) {
 
 			_gl.bindBuffer( _gl.ARRAY_BUFFER, object.__webglVertexBuffer );
 			_gl.bufferData( _gl.ARRAY_BUFFER, object.positionArray, _gl.DYNAMIC_DRAW );
 
-			state.enableAttribute( program.attributes.position );
-
-			_gl.vertexAttribPointer( program.attributes.position, 3, _gl.FLOAT, false, 0, 0 );
+			state.enableAttribute( attributes.position );
+			_gl.vertexAttribPointer( attributes.position, 3, _gl.FLOAT, false, 0, 0 );
 
 		}
 
@@ -839,9 +840,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			_gl.bufferData( _gl.ARRAY_BUFFER, object.normalArray, _gl.DYNAMIC_DRAW );
 
-			state.enableAttribute( program.attributes.normal );
+			state.enableAttribute( attributes.normal );
 
-			_gl.vertexAttribPointer( program.attributes.normal, 3, _gl.FLOAT, false, 0, 0 );
+			_gl.vertexAttribPointer( attributes.normal, 3, _gl.FLOAT, false, 0, 0 );
 
 		}
 
@@ -850,9 +851,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 			_gl.bindBuffer( _gl.ARRAY_BUFFER, object.__webglUvBuffer );
 			_gl.bufferData( _gl.ARRAY_BUFFER, object.uvArray, _gl.DYNAMIC_DRAW );
 
-			state.enableAttribute( program.attributes.uv );
+			state.enableAttribute( attributes.uv );
 
-			_gl.vertexAttribPointer( program.attributes.uv, 2, _gl.FLOAT, false, 0, 0 );
+			_gl.vertexAttribPointer( attributes.uv, 2, _gl.FLOAT, false, 0, 0 );
 
 		}
 
@@ -861,9 +862,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 			_gl.bindBuffer( _gl.ARRAY_BUFFER, object.__webglColorBuffer );
 			_gl.bufferData( _gl.ARRAY_BUFFER, object.colorArray, _gl.DYNAMIC_DRAW );
 
-			state.enableAttribute( program.attributes.color );
+			state.enableAttribute( attributes.color );
 
-			_gl.vertexAttribPointer( program.attributes.color, 3, _gl.FLOAT, false, 0, 0 );
+			_gl.vertexAttribPointer( attributes.color, 3, _gl.FLOAT, false, 0, 0 );
 
 		}
 
@@ -893,7 +894,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 		}
 
 		var geometryAttributes = geometry.attributes;
-		var programAttributes = program.attributes;
+
+		var programAttributes = program.attributes();
 
 		var materialDefaultAttributeValues = material.defaultAttributeValues;
 
@@ -1995,7 +1997,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		material.program = program;
 
-		var attributes = program.attributes;
+		var attributes = program.attributes();
 
 		if ( material.morphTargets ) {
 
@@ -2031,9 +2033,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		material.uniformsList = [];
 
+		var uniformLocations = material.program.uniforms();
 		for ( var u in material.__webglShader.uniforms ) {
 
-			var location = material.program.uniforms[ u ];
+			var location = uniformLocations[ u ];
 
 			if ( location ) {
 				material.uniformsList.push( [ material.__webglShader.uniforms[ u ], location ] );
@@ -2079,7 +2082,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		var refreshLights = false;
 
 		var program = material.program,
-			p_uniforms = program.uniforms,
+			p_uniforms = program.uniforms(),
 			m_uniforms = material.__webglShader.uniforms;
 
 		if ( program.id !== _currentProgram ) {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -779,7 +779,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( object.hasUvs && ! object.__webglUvBuffer ) object.__webglUvBuffer = _gl.createBuffer();
 		if ( object.hasColors && ! object.__webglColorBuffer ) object.__webglColorBuffer = _gl.createBuffer();
 
-		var attributes = program.attributes();
+		var attributes = program.getAttributes();
 
 		if ( object.hasPositions ) {
 
@@ -895,7 +895,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var geometryAttributes = geometry.attributes;
 
-		var programAttributes = program.attributes();
+		var programAttributes = program.getAttributes();
 
 		var materialDefaultAttributeValues = material.defaultAttributeValues;
 
@@ -1997,7 +1997,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		material.program = program;
 
-		var attributes = program.attributes();
+		var attributes = program.getAttributes();
 
 		if ( material.morphTargets ) {
 
@@ -2033,7 +2033,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		material.uniformsList = [];
 
-		var uniformLocations = material.program.uniforms();
+		var uniformLocations = material.program.getUniforms();
 		for ( var u in material.__webglShader.uniforms ) {
 
 			var location = uniformLocations[ u ];
@@ -2082,7 +2082,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		var refreshLights = false;
 
 		var program = material.program,
-			p_uniforms = program.uniforms(),
+			p_uniforms = program.getUniforms(),
 			m_uniforms = material.__webglShader.uniforms;
 
 		if ( program.id !== _currentProgram ) {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -895,6 +895,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 		var geometryAttributes = geometry.attributes;
 		var programAttributes = program.attributes;
 
+		var materialDefaultAttributeValues = material.defaultAttributeValues;
+
 		for ( var name in programAttributes ) {
 
 			var programAttribute = programAttributes[ name ];
@@ -962,17 +964,27 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					}
 
-				} else if ( material.defaultAttributeValues !== undefined ) {
+				} else if ( materialDefaultAttributeValues !== undefined ) {
 
-					if ( material.defaultAttributeValues[ name ] !== undefined ) {
+					var value = materialDefaultAttributeValues[ key ];
+					if ( value !== undefined ) {
 
-						if ( material.defaultAttributeValues[ name ].length === 2 ) {
+						switch ( value.length ) {
 
-							_gl.vertexAttrib2fv( programAttribute, material.defaultAttributeValues[ name ] );
+							case 2:
+								_gl.vertexAttrib2fv( programAttribute, value );
+								break;
 
-						} else if ( material.defaultAttributeValues[ name ].length === 3 ) {
+							case 3:
+								_gl.vertexAttrib3fv( programAttribute, value );
+								break;
 
-							_gl.vertexAttrib3fv( programAttribute, material.defaultAttributeValues[ name ] );
+							case 4:
+								_gl.vertexAttrib4fv( programAttribute, value );
+								break;
+
+							default:
+								_gl.vertexAttrib1fv( programAttribute, value );
 
 						}
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -409,23 +409,13 @@ THREE.WebGLProgram = ( function () {
 		// set up caching for attribute keys and locations
 
 		var getAttributes = function() { return this._cachedAttributes; };
-		var getAttribKeys = function() { return this._cachedAttribKeys; };
 
 		this.getAttributes = function() {
 
 			var attributes = fetchAttributeLocations( gl, program );
 			this._cachedAttributes = attributes;
-			this._cachedAttribKeys = Object.keys( attributes );
 			this.getAttributes = getAttributes;
-			this.getAttributesKeys = getAttribKeys;
 			return attributes;
-
-		};
-
-		this.getAttributesKeys = function() {
-
-			this.attributes();
-			return this._cachedAttribKeys;
 
 		};
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -396,12 +396,12 @@ THREE.WebGLProgram = ( function () {
 
 		var getUniforms = function() { return this._cachedUniforms; };
 
-		this.uniforms = function() {
+		this.getUniforms = function() {
 
 			// fetch, cache, and next time just use a dumb accessor
 			var uniforms = fetchUniformLocations( gl, program );
 			this._cachedUniforms = uniforms;
-			this.uniforms = getUniforms;
+			this.getUniforms = getUniforms;
 			return uniforms;
 
 		};
@@ -411,18 +411,18 @@ THREE.WebGLProgram = ( function () {
 		var getAttributes = function() { return this._cachedAttributes; };
 		var getAttribKeys = function() { return this._cachedAttribKeys; };
 
-		this.attributes = function() {
+		this.getAttributes = function() {
 
 			var attributes = fetchAttributeLocations( gl, program );
 			this._cachedAttributes = attributes;
 			this._cachedAttribKeys = Object.keys( attributes );
-			this.attributes = getAttributes;
-			this.attributesKeys = getAttribKeys;
+			this.getAttributes = getAttributes;
+			this.getAttributesKeys = getAttribKeys;
 			return attributes;
 
 		};
 
-		this.attributesKeys = function() {
+		this.getAttributesKeys = function() {
 
 			this.attributes();
 			return this._cachedAttribKeys;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -154,16 +154,16 @@ THREE.WebGLProgram = ( function () {
 
 		var program = gl.createProgram();
 
-		var prefix_vertex, prefix_fragment;
+		var prefixVertex, prefixFragment;
 
 		if ( material instanceof THREE.RawShaderMaterial ) {
 
-			prefix_vertex = '';
-			prefix_fragment = '';
+			prefixVertex = '';
+			prefixFragment = '';
 
 		} else {
 
-			prefix_vertex = [
+			prefixVertex = [
 
 				'precision ' + parameters.precision + ' float;',
 				'precision ' + parameters.precision + ' int;',
@@ -270,7 +270,7 @@ THREE.WebGLProgram = ( function () {
 
 			].filter( filterEmptyLine ).join( '\n' );
 
-			prefix_fragment = [
+			prefixFragment = [
 
 				( parameters.bumpMap || parameters.normalMap || parameters.flatShading || material.derivatives ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 
@@ -331,8 +331,11 @@ THREE.WebGLProgram = ( function () {
 
 		}
 
-		var glVertexShader = new THREE.WebGLShader( gl, gl.VERTEX_SHADER, prefix_vertex + vertexShader );
-		var glFragmentShader = new THREE.WebGLShader( gl, gl.FRAGMENT_SHADER, prefix_fragment + fragmentShader );
+		var vertexGlsl = prefixVertex + vertexShader;
+		var fragmentGlsl = prefixFragment + fragmentShader;
+
+		var glVertexShader = new THREE.WebGLShader( gl, gl.VERTEX_SHADER, vertexGlsl );
+		var glFragmentShader = new THREE.WebGLShader( gl, gl.FRAGMENT_SHADER, fragmentGlsl );
 
 		gl.attachShader( program, glVertexShader );
 		gl.attachShader( program, glFragmentShader );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -406,7 +406,7 @@ THREE.WebGLProgram = ( function () {
 
 		};
 
-		// set up caching for attribute keys and locations
+		// set up caching for attribute locations
 
 		var getAttributes = function() { return this._cachedAttributes; };
 
@@ -418,6 +418,39 @@ THREE.WebGLProgram = ( function () {
 			return attributes;
 
 		};
+
+		// DEPRECATED
+
+		Object.defineProperties( this, {
+
+			uniforms: {
+				get: function() {
+
+					console.warn( 'THREE.WebGLProgram: .uniforms is now .getUniforms().' );
+					return this.getUniforms();
+
+				}
+			},
+
+			attributes: {
+				get: function() {
+
+					console.warn( 'THREE.WebGLProgram: .attributes is now .getAttributes().' );
+					return this.getAttributes();
+
+				}
+			},
+
+			attributesKeys: {
+				get: function() {
+
+					console.warn( 'THREE.WebGLProgram: .attributesKeys has been removed.' );
+					return Object.keys( this.getAttributes() );
+
+				}
+			}
+		});
+
 
 		//
 


### PR DESCRIPTION
Fixes the issue explained in #6557, also for vertex attributes, and does so properly, that is without hackily parsing the GLSL but querying the GL for caching when the renderer needs the information. 

So `WebGLProgram.prototype.uniforms` `.attributes` and `.attributesKeys` (is the latter still needed?) are functions now. API docs update included.

Plus a fix to the editor - my test case. The first commit will be rather empty, as its essence went into dev already and this branch was rebased.
