### PR TITLE
Changed transparency to opacity

### DIFF
--- a/utils/converters/obj/convert_obj_three.py
+++ b/utils/converters/obj/convert_obj_three.py
@@ -443,9 +443,9 @@ def parse_mtl(fname):
             if (chunks[0] == "Tr" or chunks[0] == "d") and len(chunks) == 2:
                 materials[identifier]["transparent"] = True
                 if TRANSPARENCY == "invert":
-                    materials[identifier]["transparency"] = 1.0 - float(chunks[1])
+                    materials[identifier]["opacity"] = float(chunks[1])
                 else:
-                    materials[identifier]["transparency"] = float(chunks[1])
+                    materials[identifier]["opacity"] = 1.0 - float(chunks[1])
 
             # Optical density
             # Ni 1.0


### PR DESCRIPTION
The OBJ to JSON converter uses now opacity instead of transparency
attribute.

Fixes #6645
