### PR TITLE
Dev

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -44,12 +44,13 @@ THREE.STLLoader.prototype = {
 		var loader = new THREE.XHRLoader( scope.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setResponseType('arraybuffer');
-		loader.load( url, function ( text ) {
+		var request = loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( text ) );
 
 		}, onProgress, onError );
 
+		return request;
 	},
 
 	parse: function ( data ) {

--- a/src/loaders/XHRLoader.js
+++ b/src/loaders/XHRLoader.js
@@ -65,6 +65,8 @@ THREE.XHRLoader.prototype = {
 
 		scope.manager.itemStart( url );
 
+		return request;
+
 	},
 
 	setResponseType: function ( value ) {


### PR DESCRIPTION
So I the main thing I added was returning the XMLHttpRequest object from the XHRLoader. This gives other loaders that use the XHRLoader object (such as STLLoader) access to the XMLHttpRequest object. Therefore allowing manipulation of the XMLHttpRequest object and access to the built in functions of the object. Mainly XMLHttpRequest.abort() so when using STLLoader one can cancel the load by calling abort on the request object. Issues #6641 and #6634 are relevant here.

Here's an example of code for how the changes can be useful.

```
var loader = new THREE.STLLoader();
var request = {};

function loadMyObj(url){
    request = loader.load(url, function(object){
        scene.add(object);
    }
}

function cancelLoad(){
    request.abort();
}
```

I only added to the STLLoader in examples > js but this can be easily added to the any other loaders that use XHRLoader. 
