### PR TITLE
Editor: Integrate tern-threejs in script editor

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -47,6 +47,24 @@
 
 		<script src="js/libs/codemirror/mode/glsl.js"></script>
 
+		<link rel="stylesheet" href="js/libs/codemirror/addon/dialog.css">
+		<link rel="stylesheet" href="js/libs/codemirror/addon/show-hint.css">
+		<link rel="stylesheet" href="js/libs/codemirror/addon/tern.css">
+		<script src="js/libs/codemirror/addon/dialog.js"></script>
+		<script src="js/libs/codemirror/addon/show-hint.js"></script>
+		<script src="js/libs/codemirror/addon/tern.js"></script>
+		<script src="js/libs/acorn/acorn.js"></script>
+		<script src="js/libs/acorn/acorn_loose.js"></script>
+		<script src="js/libs/acorn/walk.js"></script>
+		<script src="js/libs/ternjs/polyfill.js"></script>
+		<script src="js/libs/ternjs/signal.js"></script>
+		<script src="js/libs/ternjs/tern.js"></script>
+		<script src="js/libs/ternjs/def.js"></script>
+		<script src="js/libs/ternjs/comment.js"></script>
+		<script src="js/libs/ternjs/infer.js"></script>
+		<script src="js/libs/ternjs/doc_comment.js"></script>
+		<script src="js/libs/tern-threejs/threejs.js"></script>
+
 		<script src="js/libs/jszip.min.js"></script>
 		<script src="js/libs/sortable.min.js"></script>
 		<script src="js/libs/signals.min.js"></script>

--- a/editor/js/Script.js
+++ b/editor/js/Script.js
@@ -53,7 +53,10 @@ var Script = function ( editor ) {
 		matchBrackets: true,
 		indentWithTabs: true,
 		tabSize: 4,
-		indentUnit: 4
+		indentUnit: 4,
+		hintOptions: {
+			completeSingle: false
+		}
 	} );
 	codemirror.setOption( 'theme', 'monokai' );
 	codemirror.on( 'change', function () {
@@ -107,7 +110,6 @@ var Script = function ( editor ) {
 		event.stopPropagation();
 
 	} );
-
 
 	// validate
 
@@ -222,6 +224,43 @@ var Script = function ( editor ) {
 		});
 
 	};
+
+	// tern js autocomplete
+
+	var server = new CodeMirror.TernServer( {
+		caseInsensitive: true,
+		plugins: { threejs: null }
+	} );
+
+	codemirror.setOption( 'extraKeys', {
+		'Ctrl-Space': function(cm) { server.complete(cm); },
+		'Ctrl-I': function(cm) { server.showType(cm); },
+		'Ctrl-O': function(cm) { server.showDocs(cm); },
+		'Alt-.': function(cm) { server.jumpToDef(cm); },
+		'Alt-,': function(cm) { server.jumpBack(cm); },
+		'Ctrl-Q': function(cm) { server.rename(cm); },
+		'Ctrl-.': function(cm) { server.selectName(cm); }
+	} );
+
+	codemirror.on( 'cursorActivity', function( cm ) {
+
+		if ( currentMode !== 'javascript' ) return;
+		server.updateArgHints( cm );
+
+	} );
+
+	codemirror.on( 'keypress', function( cm, kb ) {
+
+		if ( currentMode !== 'javascript' ) return;
+		var typed = String.fromCharCode( kb.which || kb.keyCode );
+		if ( /[\w\.]/.exec( typed ) ) {
+
+			server.complete( cm );
+
+		}
+
+	} );
+
 
 	//
 

--- a/editor/js/libs/acorn/acorn.js
+++ b/editor/js/libs/acorn/acorn.js
@@ -1,0 +1,3236 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.acorn = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+
+
+// The main exported interface (under `self.acorn` when in the
+// browser) is a `parse` function that takes a code string and
+// returns an abstract syntax tree as specified by [Mozilla parser
+// API][api].
+//
+// [api]: https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API
+
+"use strict";
+
+exports.parse = parse;
+
+// This function tries to parse a single expression at a given
+// offset in a string. Useful for parsing mixed-language formats
+// that embed JavaScript expressions.
+
+exports.parseExpressionAt = parseExpressionAt;
+
+// Acorn is organized as a tokenizer and a recursive-descent parser.
+// The `tokenize` export provides an interface to the tokenizer.
+
+exports.tokenizer = tokenizer;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+// Acorn is a tiny, fast JavaScript parser written in JavaScript.
+//
+// Acorn was written by Marijn Haverbeke, Ingvar Stepanyan, and
+// various contributors and released under an MIT license.
+//
+// Git repositories for Acorn are available at
+//
+//     http://marijnhaverbeke.nl/git/acorn
+//     https://github.com/marijnh/acorn.git
+//
+// Please use the [github bug tracker][ghbt] to report issues.
+//
+// [ghbt]: https://github.com/marijnh/acorn/issues
+//
+// This file defines the main parser interface. The library also comes
+// with a [error-tolerant parser][dammit] and an
+// [abstract syntax tree walker][walk], defined in other files.
+//
+// [dammit]: acorn_loose.js
+// [walk]: util/walk.js
+
+var _state = require("./state");
+
+var Parser = _state.Parser;
+
+var _options = require("./options");
+
+var getOptions = _options.getOptions;
+
+require("./parseutil");
+
+require("./statement");
+
+require("./lval");
+
+require("./expression");
+
+exports.Parser = _state.Parser;
+exports.plugins = _state.plugins;
+exports.defaultOptions = _options.defaultOptions;
+
+var _location = require("./location");
+
+exports.SourceLocation = _location.SourceLocation;
+exports.getLineInfo = _location.getLineInfo;
+exports.Node = require("./node").Node;
+
+var _tokentype = require("./tokentype");
+
+exports.TokenType = _tokentype.TokenType;
+exports.tokTypes = _tokentype.types;
+
+var _tokencontext = require("./tokencontext");
+
+exports.TokContext = _tokencontext.TokContext;
+exports.tokContexts = _tokencontext.types;
+
+var _identifier = require("./identifier");
+
+exports.isIdentifierChar = _identifier.isIdentifierChar;
+exports.isIdentifierStart = _identifier.isIdentifierStart;
+exports.Token = require("./tokenize").Token;
+
+var _whitespace = require("./whitespace");
+
+exports.isNewLine = _whitespace.isNewLine;
+exports.lineBreak = _whitespace.lineBreak;
+exports.lineBreakG = _whitespace.lineBreakG;
+var version = "1.0.1";exports.version = version;
+
+function parse(input, options) {
+  var p = parser(options, input);
+  var startPos = p.options.locations ? [p.pos, p.curPosition()] : p.pos;
+  p.nextToken();
+  return p.parseTopLevel(p.options.program || p.startNodeAt(startPos));
+}
+
+function parseExpressionAt(input, pos, options) {
+  var p = parser(options, input, pos);
+  p.nextToken();
+  return p.parseExpression();
+}
+
+function tokenizer(input, options) {
+  return parser(options, input);
+}
+
+function parser(options, input) {
+  return new Parser(getOptions(options), String(input));
+}
+
+},{"./expression":2,"./identifier":3,"./location":4,"./lval":5,"./node":6,"./options":7,"./parseutil":8,"./state":9,"./statement":10,"./tokencontext":11,"./tokenize":12,"./tokentype":13,"./whitespace":15}],2:[function(require,module,exports){
+// A recursive descent parser operates by defining functions for all
+// syntactic elements, and recursively calling those, each function
+// advancing the input stream and returning an AST node. Precedence
+// of constructs (for example, the fact that `!x[1]` means `!(x[1])`
+// instead of `(!x)[1]` is handled by the fact that the parser
+// function that parses unary prefix operators is called first, and
+// in turn calls the function that parses `[]` subscripts — that
+// way, it'll receive the node for `x[1]` already parsed, and wraps
+// *that* in the unary operator node.
+//
+// Acorn uses an [operator precedence parser][opp] to handle binary
+// operator precedence, because it is much more compact than using
+// the technique outlined above, which uses different, nesting
+// functions to specify precedence, for all of the ten binary
+// precedence levels that JavaScript defines.
+//
+// [opp]: http://en.wikipedia.org/wiki/Operator-precedence_parser
+
+"use strict";
+
+var tt = require("./tokentype").types;
+
+var Parser = require("./state").Parser;
+
+var reservedWords = require("./identifier").reservedWords;
+
+var has = require("./util").has;
+
+var pp = Parser.prototype;
+
+// Check if property name clashes with already added.
+// Object/class getters and setters are not allowed to clash —
+// either with each other or with an init property — and in
+// strict mode, init properties are also not allowed to be repeated.
+
+pp.checkPropClash = function (prop, propHash) {
+  if (this.options.ecmaVersion >= 6) return;
+  var key = prop.key,
+      name = undefined;
+  switch (key.type) {
+    case "Identifier":
+      name = key.name;break;
+    case "Literal":
+      name = String(key.value);break;
+    default:
+      return;
+  }
+  var kind = prop.kind || "init",
+      other = undefined;
+  if (has(propHash, name)) {
+    other = propHash[name];
+    var isGetSet = kind !== "init";
+    if ((this.strict || isGetSet) && other[kind] || !(isGetSet ^ other.init)) this.raise(key.start, "Redefinition of property");
+  } else {
+    other = propHash[name] = {
+      init: false,
+      get: false,
+      set: false
+    };
+  }
+  other[kind] = true;
+};
+
+// ### Expression parsing
+
+// These nest, from the most general expression type at the top to
+// 'atomic', nondivisible expression types at the bottom. Most of
+// the functions will simply let the function(s) below them parse,
+// and, *if* the syntactic construct they handle is present, wrap
+// the AST node that the inner parser gave them in another node.
+
+// Parse a full expression. The optional arguments are used to
+// forbid the `in` operator (in for loops initalization expressions)
+// and provide reference for storing '=' operator inside shorthand
+// property assignment in contexts where both object expression
+// and object pattern might appear (so it's possible to raise
+// delayed syntax error at correct position).
+
+pp.parseExpression = function (noIn, refShorthandDefaultPos) {
+  var start = this.markPosition();
+  var expr = this.parseMaybeAssign(noIn, refShorthandDefaultPos);
+  if (this.type === tt.comma) {
+    var node = this.startNodeAt(start);
+    node.expressions = [expr];
+    while (this.eat(tt.comma)) node.expressions.push(this.parseMaybeAssign(noIn, refShorthandDefaultPos));
+    return this.finishNode(node, "SequenceExpression");
+  }
+  return expr;
+};
+
+// Parse an assignment expression. This includes applications of
+// operators like `+=`.
+
+pp.parseMaybeAssign = function (noIn, refShorthandDefaultPos) {
+  if (this.type == tt._yield && this.inGenerator) return this.parseYield();
+
+  var failOnShorthandAssign = undefined;
+  if (!refShorthandDefaultPos) {
+    refShorthandDefaultPos = { start: 0 };
+    failOnShorthandAssign = true;
+  } else {
+    failOnShorthandAssign = false;
+  }
+  var start = this.markPosition();
+  var left = this.parseMaybeConditional(noIn, refShorthandDefaultPos);
+  if (this.type.isAssign) {
+    var node = this.startNodeAt(start);
+    node.operator = this.value;
+    node.left = this.type === tt.eq ? this.toAssignable(left) : left;
+    refShorthandDefaultPos.start = 0; // reset because shorthand default was used correctly
+    this.checkLVal(left);
+    this.next();
+    node.right = this.parseMaybeAssign(noIn);
+    return this.finishNode(node, "AssignmentExpression");
+  } else if (failOnShorthandAssign && refShorthandDefaultPos.start) {
+    this.unexpected(refShorthandDefaultPos.start);
+  }
+  return left;
+};
+
+// Parse a ternary conditional (`?:`) operator.
+
+pp.parseMaybeConditional = function (noIn, refShorthandDefaultPos) {
+  var start = this.markPosition();
+  var expr = this.parseExprOps(noIn, refShorthandDefaultPos);
+  if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
+  if (this.eat(tt.question)) {
+    var node = this.startNodeAt(start);
+    node.test = expr;
+    node.consequent = this.parseMaybeAssign();
+    this.expect(tt.colon);
+    node.alternate = this.parseMaybeAssign(noIn);
+    return this.finishNode(node, "ConditionalExpression");
+  }
+  return expr;
+};
+
+// Start the precedence parser.
+
+pp.parseExprOps = function (noIn, refShorthandDefaultPos) {
+  var start = this.markPosition();
+  var expr = this.parseMaybeUnary(refShorthandDefaultPos);
+  if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
+  return this.parseExprOp(expr, start, -1, noIn);
+};
+
+// Parse binary operators with the operator precedence parsing
+// algorithm. `left` is the left-hand side of the operator.
+// `minPrec` provides context that allows the function to stop and
+// defer further parser to one of its callers when it encounters an
+// operator that has a lower precedence than the set it is parsing.
+
+pp.parseExprOp = function (left, leftStart, minPrec, noIn) {
+  var prec = this.type.binop;
+  if (prec != null && (!noIn || this.type !== tt._in)) {
+    if (prec > minPrec) {
+      var node = this.startNodeAt(leftStart);
+      node.left = left;
+      node.operator = this.value;
+      var op = this.type;
+      this.next();
+      var start = this.markPosition();
+      node.right = this.parseExprOp(this.parseMaybeUnary(), start, prec, noIn);
+      this.finishNode(node, op === tt.logicalOR || op === tt.logicalAND ? "LogicalExpression" : "BinaryExpression");
+      return this.parseExprOp(node, leftStart, minPrec, noIn);
+    }
+  }
+  return left;
+};
+
+// Parse unary operators, both prefix and postfix.
+
+pp.parseMaybeUnary = function (refShorthandDefaultPos) {
+  if (this.type.prefix) {
+    var node = this.startNode(),
+        update = this.type === tt.incDec;
+    node.operator = this.value;
+    node.prefix = true;
+    this.next();
+    node.argument = this.parseMaybeUnary();
+    if (refShorthandDefaultPos && refShorthandDefaultPos.start) this.unexpected(refShorthandDefaultPos.start);
+    if (update) this.checkLVal(node.argument);else if (this.strict && node.operator === "delete" && node.argument.type === "Identifier") this.raise(node.start, "Deleting local variable in strict mode");
+    return this.finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
+  }
+  var start = this.markPosition();
+  var expr = this.parseExprSubscripts(refShorthandDefaultPos);
+  if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
+  while (this.type.postfix && !this.canInsertSemicolon()) {
+    var node = this.startNodeAt(start);
+    node.operator = this.value;
+    node.prefix = false;
+    node.argument = expr;
+    this.checkLVal(expr);
+    this.next();
+    expr = this.finishNode(node, "UpdateExpression");
+  }
+  return expr;
+};
+
+// Parse call, dot, and `[]`-subscript expressions.
+
+pp.parseExprSubscripts = function (refShorthandDefaultPos) {
+  var start = this.markPosition();
+  var expr = this.parseExprAtom(refShorthandDefaultPos);
+  if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
+  return this.parseSubscripts(expr, start);
+};
+
+pp.parseSubscripts = function (base, start, noCalls) {
+  if (this.eat(tt.dot)) {
+    var node = this.startNodeAt(start);
+    node.object = base;
+    node.property = this.parseIdent(true);
+    node.computed = false;
+    return this.parseSubscripts(this.finishNode(node, "MemberExpression"), start, noCalls);
+  } else if (this.eat(tt.bracketL)) {
+    var node = this.startNodeAt(start);
+    node.object = base;
+    node.property = this.parseExpression();
+    node.computed = true;
+    this.expect(tt.bracketR);
+    return this.parseSubscripts(this.finishNode(node, "MemberExpression"), start, noCalls);
+  } else if (!noCalls && this.eat(tt.parenL)) {
+    var node = this.startNodeAt(start);
+    node.callee = base;
+    node.arguments = this.parseExprList(tt.parenR, false);
+    return this.parseSubscripts(this.finishNode(node, "CallExpression"), start, noCalls);
+  } else if (this.type === tt.backQuote) {
+    var node = this.startNodeAt(start);
+    node.tag = base;
+    node.quasi = this.parseTemplate();
+    return this.parseSubscripts(this.finishNode(node, "TaggedTemplateExpression"), start, noCalls);
+  }return base;
+};
+
+// Parse an atomic expression — either a single token that is an
+// expression, an expression started by a keyword like `function` or
+// `new`, or an expression wrapped in punctuation like `()`, `[]`,
+// or `{}`.
+
+pp.parseExprAtom = function (refShorthandDefaultPos) {
+  var node = undefined;
+  switch (this.type) {
+    case tt._this:
+    case tt._super:
+      var type = this.type === tt._this ? "ThisExpression" : "Super";
+      node = this.startNode();
+      this.next();
+      return this.finishNode(node, type);
+
+    case tt._yield:
+      if (this.inGenerator) unexpected();
+
+    case tt.name:
+      var start = this.markPosition();
+      var id = this.parseIdent(this.type !== tt.name);
+      if (!this.canInsertSemicolon() && this.eat(tt.arrow)) {
+        return this.parseArrowExpression(this.startNodeAt(start), [id]);
+      }
+      return id;
+
+    case tt.regexp:
+      var value = this.value;
+      node = this.parseLiteral(value.value);
+      node.regex = { pattern: value.pattern, flags: value.flags };
+      return node;
+
+    case tt.num:case tt.string:
+      return this.parseLiteral(this.value);
+
+    case tt._null:case tt._true:case tt._false:
+      node = this.startNode();
+      node.value = this.type === tt._null ? null : this.type === tt._true;
+      node.raw = this.type.keyword;
+      this.next();
+      return this.finishNode(node, "Literal");
+
+    case tt.parenL:
+      return this.parseParenAndDistinguishExpression();
+
+    case tt.bracketL:
+      node = this.startNode();
+      this.next();
+      // check whether this is array comprehension or regular array
+      if (this.options.ecmaVersion >= 7 && this.type === tt._for) {
+        return this.parseComprehension(node, false);
+      }
+      node.elements = this.parseExprList(tt.bracketR, true, true, refShorthandDefaultPos);
+      return this.finishNode(node, "ArrayExpression");
+
+    case tt.braceL:
+      return this.parseObj(false, refShorthandDefaultPos);
+
+    case tt._function:
+      node = this.startNode();
+      this.next();
+      return this.parseFunction(node, false);
+
+    case tt._class:
+      return this.parseClass(this.startNode(), false);
+
+    case tt._new:
+      return this.parseNew();
+
+    case tt.backQuote:
+      return this.parseTemplate();
+
+    default:
+      this.unexpected();
+  }
+};
+
+pp.parseLiteral = function (value) {
+  var node = this.startNode();
+  node.value = value;
+  node.raw = this.input.slice(this.start, this.end);
+  this.next();
+  return this.finishNode(node, "Literal");
+};
+
+pp.parseParenExpression = function () {
+  this.expect(tt.parenL);
+  var val = this.parseExpression();
+  this.expect(tt.parenR);
+  return val;
+};
+
+pp.parseParenAndDistinguishExpression = function () {
+  var start = this.markPosition(),
+      val = undefined;
+  if (this.options.ecmaVersion >= 6) {
+    this.next();
+
+    if (this.options.ecmaVersion >= 7 && this.type === tt._for) {
+      return this.parseComprehension(this.startNodeAt(start), true);
+    }
+
+    var innerStart = this.markPosition(),
+        exprList = [],
+        first = true;
+    var refShorthandDefaultPos = { start: 0 },
+        spreadStart = undefined,
+        innerParenStart = undefined;
+    while (this.type !== tt.parenR) {
+      first ? first = false : this.expect(tt.comma);
+      if (this.type === tt.ellipsis) {
+        spreadStart = this.start;
+        exprList.push(this.parseRest());
+        break;
+      } else {
+        if (this.type === tt.parenL && !innerParenStart) {
+          innerParenStart = this.start;
+        }
+        exprList.push(this.parseMaybeAssign(false, refShorthandDefaultPos));
+      }
+    }
+    var innerEnd = this.markPosition();
+    this.expect(tt.parenR);
+
+    if (!this.canInsertSemicolon() && this.eat(tt.arrow)) {
+      if (innerParenStart) this.unexpected(innerParenStart);
+      return this.parseArrowExpression(this.startNodeAt(start), exprList);
+    }
+
+    if (!exprList.length) this.unexpected(this.lastTokStart);
+    if (spreadStart) this.unexpected(spreadStart);
+    if (refShorthandDefaultPos.start) this.unexpected(refShorthandDefaultPos.start);
+
+    if (exprList.length > 1) {
+      val = this.startNodeAt(innerStart);
+      val.expressions = exprList;
+      this.finishNodeAt(val, "SequenceExpression", innerEnd);
+    } else {
+      val = exprList[0];
+    }
+  } else {
+    val = this.parseParenExpression();
+  }
+
+  if (this.options.preserveParens) {
+    var par = this.startNodeAt(start);
+    par.expression = val;
+    return this.finishNode(par, "ParenthesizedExpression");
+  } else {
+    return val;
+  }
+};
+
+// New's precedence is slightly tricky. It must allow its argument
+// to be a `[]` or dot subscript expression, but not a call — at
+// least, not without wrapping it in parentheses. Thus, it uses the
+
+var empty = [];
+
+pp.parseNew = function () {
+  var node = this.startNode();
+  var meta = this.parseIdent(true);
+  if (this.options.ecmaVersion >= 6 && this.eat(tt.dot)) {
+    node.meta = meta;
+    node.property = this.parseIdent(true);
+    if (node.property.name !== "target") this.raise(node.property.start, "The only valid meta property for new is new.target");
+    return this.finishNode(node, "MetaProperty");
+  }
+  var start = this.markPosition();
+  node.callee = this.parseSubscripts(this.parseExprAtom(), start, true);
+  if (this.eat(tt.parenL)) node.arguments = this.parseExprList(tt.parenR, false);else node.arguments = empty;
+  return this.finishNode(node, "NewExpression");
+};
+
+// Parse template expression.
+
+pp.parseTemplateElement = function () {
+  var elem = this.startNode();
+  elem.value = {
+    raw: this.input.slice(this.start, this.end),
+    cooked: this.value
+  };
+  this.next();
+  elem.tail = this.type === tt.backQuote;
+  return this.finishNode(elem, "TemplateElement");
+};
+
+pp.parseTemplate = function () {
+  var node = this.startNode();
+  this.next();
+  node.expressions = [];
+  var curElt = this.parseTemplateElement();
+  node.quasis = [curElt];
+  while (!curElt.tail) {
+    this.expect(tt.dollarBraceL);
+    node.expressions.push(this.parseExpression());
+    this.expect(tt.braceR);
+    node.quasis.push(curElt = this.parseTemplateElement());
+  }
+  this.next();
+  return this.finishNode(node, "TemplateLiteral");
+};
+
+// Parse an object literal or binding pattern.
+
+pp.parseObj = function (isPattern, refShorthandDefaultPos) {
+  var node = this.startNode(),
+      first = true,
+      propHash = {};
+  node.properties = [];
+  this.next();
+  while (!this.eat(tt.braceR)) {
+    if (!first) {
+      this.expect(tt.comma);
+      if (this.afterTrailingComma(tt.braceR)) break;
+    } else first = false;
+
+    var prop = this.startNode(),
+        isGenerator = undefined,
+        start = undefined;
+    if (this.options.ecmaVersion >= 6) {
+      prop.method = false;
+      prop.shorthand = false;
+      if (isPattern || refShorthandDefaultPos) start = this.markPosition();
+      if (!isPattern) isGenerator = this.eat(tt.star);
+    }
+    this.parsePropertyName(prop);
+    if (this.eat(tt.colon)) {
+      prop.value = isPattern ? this.parseMaybeDefault() : this.parseMaybeAssign(false, refShorthandDefaultPos);
+      prop.kind = "init";
+    } else if (this.options.ecmaVersion >= 6 && this.type === tt.parenL) {
+      if (isPattern) this.unexpected();
+      prop.kind = "init";
+      prop.method = true;
+      prop.value = this.parseMethod(isGenerator);
+    } else if (this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" && (prop.key.name === "get" || prop.key.name === "set") && (this.type != tt.comma && this.type != tt.braceR)) {
+      if (isGenerator || isPattern) this.unexpected();
+      prop.kind = prop.key.name;
+      this.parsePropertyName(prop);
+      prop.value = this.parseMethod(false);
+    } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
+      prop.kind = "init";
+      if (isPattern) {
+        if (this.isKeyword(prop.key.name) || this.strict && (reservedWords.strictBind(prop.key.name) || reservedWords.strict(prop.key.name)) || !this.options.allowReserved && this.isReservedWord(prop.key.name)) this.raise(prop.key.start, "Binding " + prop.key.name);
+        prop.value = this.parseMaybeDefault(start, prop.key);
+      } else if (this.type === tt.eq && refShorthandDefaultPos) {
+        if (!refShorthandDefaultPos.start) refShorthandDefaultPos.start = this.start;
+        prop.value = this.parseMaybeDefault(start, prop.key);
+      } else {
+        prop.value = prop.key;
+      }
+      prop.shorthand = true;
+    } else this.unexpected();
+
+    this.checkPropClash(prop, propHash);
+    node.properties.push(this.finishNode(prop, "Property"));
+  }
+  return this.finishNode(node, isPattern ? "ObjectPattern" : "ObjectExpression");
+};
+
+pp.parsePropertyName = function (prop) {
+  if (this.options.ecmaVersion >= 6) {
+    if (this.eat(tt.bracketL)) {
+      prop.computed = true;
+      prop.key = this.parseMaybeAssign();
+      this.expect(tt.bracketR);
+      return;
+    } else {
+      prop.computed = false;
+    }
+  }
+  prop.key = this.type === tt.num || this.type === tt.string ? this.parseExprAtom() : this.parseIdent(true);
+};
+
+// Initialize empty function node.
+
+pp.initFunction = function (node) {
+  node.id = null;
+  if (this.options.ecmaVersion >= 6) {
+    node.generator = false;
+    node.expression = false;
+  }
+};
+
+// Parse object or class method.
+
+pp.parseMethod = function (isGenerator) {
+  var node = this.startNode();
+  this.initFunction(node);
+  this.expect(tt.parenL);
+  node.params = this.parseBindingList(tt.parenR, false, false);
+  var allowExpressionBody = undefined;
+  if (this.options.ecmaVersion >= 6) {
+    node.generator = isGenerator;
+    allowExpressionBody = true;
+  } else {
+    allowExpressionBody = false;
+  }
+  this.parseFunctionBody(node, allowExpressionBody);
+  return this.finishNode(node, "FunctionExpression");
+};
+
+// Parse arrow function expression with given parameters.
+
+pp.parseArrowExpression = function (node, params) {
+  this.initFunction(node);
+  node.params = this.toAssignableList(params, true);
+  this.parseFunctionBody(node, true);
+  return this.finishNode(node, "ArrowFunctionExpression");
+};
+
+// Parse function body and check parameters.
+
+pp.parseFunctionBody = function (node, allowExpression) {
+  var isExpression = allowExpression && this.type !== tt.braceL;
+
+  if (isExpression) {
+    node.body = this.parseMaybeAssign();
+    node.expression = true;
+  } else {
+    // Start a new scope with regard to labels and the `inFunction`
+    // flag (restore them to their old value afterwards).
+    var oldInFunc = this.inFunction,
+        oldInGen = this.inGenerator,
+        oldLabels = this.labels;
+    this.inFunction = true;this.inGenerator = node.generator;this.labels = [];
+    node.body = this.parseBlock(true);
+    node.expression = false;
+    this.inFunction = oldInFunc;this.inGenerator = oldInGen;this.labels = oldLabels;
+  }
+
+  // If this is a strict mode function, verify that argument names
+  // are not repeated, and it does not try to bind the words `eval`
+  // or `arguments`.
+  if (this.strict || !isExpression && node.body.body.length && this.isUseStrict(node.body.body[0])) {
+    var nameHash = {},
+        oldStrict = this.strict;
+    this.strict = true;
+    if (node.id) this.checkLVal(node.id, true);
+    for (var i = 0; i < node.params.length; i++) {
+      this.checkLVal(node.params[i], true, nameHash);
+    }this.strict = oldStrict;
+  }
+};
+
+// Parses a comma-separated list of expressions, and returns them as
+// an array. `close` is the token type that ends the list, and
+// `allowEmpty` can be turned on to allow subsequent commas with
+// nothing in between them to be parsed as `null` (which is needed
+// for array literals).
+
+pp.parseExprList = function (close, allowTrailingComma, allowEmpty, refShorthandDefaultPos) {
+  var elts = [],
+      first = true;
+  while (!this.eat(close)) {
+    if (!first) {
+      this.expect(tt.comma);
+      if (allowTrailingComma && this.afterTrailingComma(close)) break;
+    } else first = false;
+
+    if (allowEmpty && this.type === tt.comma) {
+      elts.push(null);
+    } else {
+      if (this.type === tt.ellipsis) elts.push(this.parseSpread(refShorthandDefaultPos));else elts.push(this.parseMaybeAssign(false, refShorthandDefaultPos));
+    }
+  }
+  return elts;
+};
+
+// Parse the next token as an identifier. If `liberal` is true (used
+// when parsing properties), it will also convert keywords into
+// identifiers.
+
+pp.parseIdent = function (liberal) {
+  var node = this.startNode();
+  if (liberal && this.options.allowReserved == "never") liberal = false;
+  if (this.type === tt.name) {
+    if (!liberal && (!this.options.allowReserved && this.isReservedWord(this.value) || this.strict && reservedWords.strict(this.value) && (this.options.ecmaVersion >= 6 || this.input.slice(this.start, this.end).indexOf("\\") == -1))) this.raise(this.start, "The keyword '" + this.value + "' is reserved");
+    node.name = this.value;
+  } else if (liberal && this.type.keyword) {
+    node.name = this.type.keyword;
+  } else {
+    this.unexpected();
+  }
+  this.next();
+  return this.finishNode(node, "Identifier");
+};
+
+// Parses yield expression inside generator.
+
+pp.parseYield = function () {
+  var node = this.startNode();
+  this.next();
+  if (this.type == tt.semi || this.canInsertSemicolon() || this.type != tt.star && !this.type.startsExpr) {
+    node.delegate = false;
+    node.argument = null;
+  } else {
+    node.delegate = this.eat(tt.star);
+    node.argument = this.parseMaybeAssign();
+  }
+  return this.finishNode(node, "YieldExpression");
+};
+
+// Parses array and generator comprehensions.
+
+pp.parseComprehension = function (node, isGenerator) {
+  node.blocks = [];
+  while (this.type === tt._for) {
+    var block = this.startNode();
+    this.next();
+    this.expect(tt.parenL);
+    block.left = this.parseBindingAtom();
+    this.checkLVal(block.left, true);
+    this.expectContextual("of");
+    block.right = this.parseExpression();
+    this.expect(tt.parenR);
+    node.blocks.push(this.finishNode(block, "ComprehensionBlock"));
+  }
+  node.filter = this.eat(tt._if) ? this.parseParenExpression() : null;
+  node.body = this.parseExpression();
+  this.expect(isGenerator ? tt.parenR : tt.bracketR);
+  node.generator = isGenerator;
+  return this.finishNode(node, "ComprehensionExpression");
+};
+
+},{"./identifier":3,"./state":9,"./tokentype":13,"./util":14}],3:[function(require,module,exports){
+
+
+// Test whether a given character code starts an identifier.
+
+"use strict";
+
+exports.isIdentifierStart = isIdentifierStart;
+
+// Test whether a given character is part of an identifier.
+
+exports.isIdentifierChar = isIdentifierChar;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+// This is a trick taken from Esprima. It turns out that, on
+// non-Chrome browsers, to check whether a string is in a set, a
+// predicate containing a big ugly `switch` statement is faster than
+// a regular expression, and on Chrome the two are about on par.
+// This function uses `eval` (non-lexical) to produce such a
+// predicate from a space-separated string of words.
+//
+// It starts by sorting the words by length.
+
+function makePredicate(words) {
+  words = words.split(" ");
+  var f = "",
+      cats = [];
+  out: for (var i = 0; i < words.length; ++i) {
+    for (var j = 0; j < cats.length; ++j) {
+      if (cats[j][0].length == words[i].length) {
+        cats[j].push(words[i]);
+        continue out;
+      }
+    }cats.push([words[i]]);
+  }
+  function compareTo(arr) {
+    if (arr.length == 1) {
+      return f += "return str === " + JSON.stringify(arr[0]) + ";";
+    }f += "switch(str){";
+    for (var i = 0; i < arr.length; ++i) {
+      f += "case " + JSON.stringify(arr[i]) + ":";
+    }f += "return true}return false;";
+  }
+
+  // When there are more than three length categories, an outer
+  // switch first dispatches on the lengths, to save on comparisons.
+
+  if (cats.length > 3) {
+    cats.sort(function (a, b) {
+      return b.length - a.length;
+    });
+    f += "switch(str.length){";
+    for (var i = 0; i < cats.length; ++i) {
+      var cat = cats[i];
+      f += "case " + cat[0].length + ":";
+      compareTo(cat);
+    }
+    f += "}"
+
+    // Otherwise, simply generate a flat `switch` statement.
+
+    ;
+  } else {
+    compareTo(words);
+  }
+  return new Function("str", f);
+}
+
+// Reserved word lists for various dialects of the language
+
+var reservedWords = {
+  3: makePredicate("abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile"),
+  5: makePredicate("class enum extends super const export import"),
+  6: makePredicate("enum await"),
+  strict: makePredicate("implements interface let package private protected public static yield"),
+  strictBind: makePredicate("eval arguments")
+};
+
+exports.reservedWords = reservedWords;
+// And the keywords
+
+var ecma5AndLessKeywords = "break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this";
+
+var keywords = {
+  5: makePredicate(ecma5AndLessKeywords),
+  6: makePredicate(ecma5AndLessKeywords + " let const class extends export import yield super")
+};
+
+exports.keywords = keywords;
+// ## Character categories
+
+// Big ugly regular expressions that match characters in the
+// whitespace, identifier, and identifier-start categories. These
+// are only applied when a character is found to actually have a
+// code point above 128.
+// Generated by `tools/generate-identifier-regex.js`.
+
+var nonASCIIidentifierStartChars = "ªµºÀ-ÖØ-öø-ˁˆ-ˑˠ-ˤˬˮͰ-ʹͶͷͺ-ͽͿΆΈ-ΊΌΎ-ΡΣ-ϵϷ-ҁҊ-ԯԱ-Ֆՙա-ևא-תװ-ײؠ-يٮٯٱ-ۓەۥۦۮۯۺ-ۼۿܐܒ-ܯݍ-ޥޱߊ-ߪߴߵߺࠀ-ࠕࠚࠤࠨࡀ-ࡘࢠ-ࢲऄ-हऽॐक़-ॡॱ-ঀঅ-ঌএঐও-নপ-রলশ-হঽৎড়ঢ়য়-ৡৰৱਅ-ਊਏਐਓ-ਨਪ-ਰਲਲ਼ਵਸ਼ਸਹਖ਼-ੜਫ਼ੲ-ੴઅ-ઍએ-ઑઓ-નપ-રલળવ-હઽૐૠૡଅ-ଌଏଐଓ-ନପ-ରଲଳଵ-ହଽଡ଼ଢ଼ୟ-ୡୱஃஅ-ஊஎ-ஐஒ-கஙசஜஞடணதந-பம-ஹௐఅ-ఌఎ-ఐఒ-నప-హఽౘౙౠౡಅ-ಌಎ-ಐಒ-ನಪ-ಳವ-ಹಽೞೠೡೱೲഅ-ഌഎ-ഐഒ-ഺഽൎൠൡൺ-ൿඅ-ඖක-නඳ-රලව-ෆก-ะาำเ-ๆກຂຄງຈຊຍດ-ທນ-ຟມ-ຣລວສຫອ-ະາຳຽເ-ໄໆໜ-ໟༀཀ-ཇཉ-ཬྈ-ྌက-ဪဿၐ-ၕၚ-ၝၡၥၦၮ-ၰၵ-ႁႎႠ-ჅჇჍა-ჺჼ-ቈቊ-ቍቐ-ቖቘቚ-ቝበ-ኈኊ-ኍነ-ኰኲ-ኵኸ-ኾዀዂ-ዅወ-ዖዘ-ጐጒ-ጕጘ-ፚᎀ-ᎏᎠ-Ᏼᐁ-ᙬᙯ-ᙿᚁ-ᚚᚠ-ᛪᛮ-ᛸᜀ-ᜌᜎ-ᜑᜠ-ᜱᝀ-ᝑᝠ-ᝬᝮ-ᝰក-ឳៗៜᠠ-ᡷᢀ-ᢨᢪᢰ-ᣵᤀ-ᤞᥐ-ᥭᥰ-ᥴᦀ-ᦫᧁ-ᧇᨀ-ᨖᨠ-ᩔᪧᬅ-ᬳᭅ-ᭋᮃ-ᮠᮮᮯᮺ-ᯥᰀ-ᰣᱍ-ᱏᱚ-ᱽᳩ-ᳬᳮ-ᳱᳵᳶᴀ-ᶿḀ-ἕἘ-Ἕἠ-ὅὈ-Ὅὐ-ὗὙὛὝὟ-ώᾀ-ᾴᾶ-ᾼιῂ-ῄῆ-ῌῐ-ΐῖ-Ίῠ-Ῥῲ-ῴῶ-ῼⁱⁿₐ-ₜℂℇℊ-ℓℕ℘-ℝℤΩℨK-ℹℼ-ℿⅅ-ⅉⅎⅠ-ↈⰀ-Ⱞⰰ-ⱞⱠ-ⳤⳫ-ⳮⳲⳳⴀ-ⴥⴧⴭⴰ-ⵧⵯⶀ-ⶖⶠ-ⶦⶨ-ⶮⶰ-ⶶⶸ-ⶾⷀ-ⷆⷈ-ⷎⷐ-ⷖⷘ-ⷞ々-〇〡-〩〱-〵〸-〼ぁ-ゖ゛-ゟァ-ヺー-ヿㄅ-ㄭㄱ-ㆎㆠ-ㆺㇰ-ㇿ㐀-䶵一-鿌ꀀ-ꒌꓐ-ꓽꔀ-ꘌꘐ-ꘟꘪꘫꙀ-ꙮꙿ-ꚝꚠ-ꛯꜗ-ꜟꜢ-ꞈꞋ-ꞎꞐ-ꞭꞰꞱꟷ-ꠁꠃ-ꠅꠇ-ꠊꠌ-ꠢꡀ-ꡳꢂ-ꢳꣲ-ꣷꣻꤊ-ꤥꤰ-ꥆꥠ-ꥼꦄ-ꦲꧏꧠ-ꧤꧦ-ꧯꧺ-ꧾꨀ-ꨨꩀ-ꩂꩄ-ꩋꩠ-ꩶꩺꩾ-ꪯꪱꪵꪶꪹ-ꪽꫀꫂꫛ-ꫝꫠ-ꫪꫲ-ꫴꬁ-ꬆꬉ-ꬎꬑ-ꬖꬠ-ꬦꬨ-ꬮꬰ-ꭚꭜ-ꭟꭤꭥꯀ-ꯢ가-힣ힰ-ퟆퟋ-ퟻ豈-舘並-龎ﬀ-ﬆﬓ-ﬗיִײַ-ﬨשׁ-זּטּ-לּמּנּסּףּפּצּ-ﮱﯓ-ﴽﵐ-ﶏﶒ-ﷇﷰ-ﷻﹰ-ﹴﹶ-ﻼＡ-Ｚａ-ｚｦ-ﾾￂ-ￇￊ-ￏￒ-ￗￚ-ￜ";
+var nonASCIIidentifierChars = "‌‍·̀-ͯ·҃-֑҇-ׇֽֿׁׂׅׄؐ-ًؚ-٩ٰۖ-ۜ۟-۪ۤۧۨ-ۭ۰-۹ܑܰ-݊ަ-ް߀-߉߫-߳ࠖ-࠙ࠛ-ࠣࠥ-ࠧࠩ-࡙࠭-࡛ࣤ-ःऺ-़ा-ॏ॑-ॗॢॣ०-९ঁ-ঃ়া-ৄেৈো-্ৗৢৣ০-৯ਁ-ਃ਼ਾ-ੂੇੈੋ-੍ੑ੦-ੱੵઁ-ઃ઼ા-ૅે-ૉો-્ૢૣ૦-૯ଁ-ଃ଼ା-ୄେୈୋ-୍ୖୗୢୣ୦-୯ஂா-ூெ-ைொ-்ௗ௦-௯ఀ-ఃా-ౄె-ైొ-్ౕౖౢౣ౦-౯ಁ-ಃ಼ಾ-ೄೆ-ೈೊ-್ೕೖೢೣ೦-೯ഁ-ഃാ-ൄെ-ൈൊ-്ൗൢൣ൦-൯ංඃ්ා-ුූෘ-ෟ෦-෯ෲෳัิ-ฺ็-๎๐-๙ັິ-ູົຼ່-ໍ໐-໙༘༙༠-༩༹༵༷༾༿ཱ-྄྆྇ྍ-ྗྙ-ྼ࿆ါ-ှ၀-၉ၖ-ၙၞ-ၠၢ-ၤၧ-ၭၱ-ၴႂ-ႍႏ-ႝ፝-፟፩-፱ᜒ-᜔ᜲ-᜴ᝒᝓᝲᝳ឴-៓៝០-៩᠋-᠍᠐-᠙ᢩᤠ-ᤫᤰ-᤻᥆-᥏ᦰ-ᧀᧈᧉ᧐-᧚ᨗ-ᨛᩕ-ᩞ᩠-᩿᩼-᪉᪐-᪙᪰-᪽ᬀ-ᬄ᬴-᭄᭐-᭙᭫-᭳ᮀ-ᮂᮡ-ᮭ᮰-᮹᯦-᯳ᰤ-᰷᱀-᱉᱐-᱙᳐-᳔᳒-᳨᳭ᳲ-᳴᳸᳹᷀-᷵᷼-᷿‿⁀⁔⃐-⃥⃜⃡-⃰⳯-⵿⳱ⷠ-〪ⷿ-゙゚〯꘠-꘩꙯ꙴ-꙽ꚟ꛰꛱ꠂ꠆ꠋꠣ-ꠧꢀꢁꢴ-꣄꣐-꣙꣠-꣱꤀-꤉ꤦ-꤭ꥇ-꥓ꦀ-ꦃ꦳-꧀꧐-꧙ꧥ꧰-꧹ꨩ-ꨶꩃꩌꩍ꩐-꩙ꩻ-ꩽꪰꪲ-ꪴꪷꪸꪾ꪿꫁ꫫ-ꫯꫵ꫶ꯣ-ꯪ꯬꯭꯰-꯹ﬞ︀-️︠-︭︳︴﹍-﹏０-９＿";
+
+var nonASCIIidentifierStart = new RegExp("[" + nonASCIIidentifierStartChars + "]");
+var nonASCIIidentifier = new RegExp("[" + nonASCIIidentifierStartChars + nonASCIIidentifierChars + "]");
+
+nonASCIIidentifierStartChars = nonASCIIidentifierChars = null;
+
+// These are a run-length and offset encoded representation of the
+// >0xffff code points that are a valid part of identifiers. The
+// offset starts at 0x10000, and each pair of numbers represents an
+// offset to the next range, and then a size of the range. They were
+// generated by tools/generate-identifier-regex.js
+var astralIdentifierStartCodes = [0, 11, 2, 25, 2, 18, 2, 1, 2, 14, 3, 13, 35, 122, 70, 52, 268, 28, 4, 48, 48, 31, 17, 26, 6, 37, 11, 29, 3, 35, 5, 7, 2, 4, 43, 157, 99, 39, 9, 51, 157, 310, 10, 21, 11, 7, 153, 5, 3, 0, 2, 43, 2, 1, 4, 0, 3, 22, 11, 22, 10, 30, 98, 21, 11, 25, 71, 55, 7, 1, 65, 0, 16, 3, 2, 2, 2, 26, 45, 28, 4, 28, 36, 7, 2, 27, 28, 53, 11, 21, 11, 18, 14, 17, 111, 72, 955, 52, 76, 44, 33, 24, 27, 35, 42, 34, 4, 0, 13, 47, 15, 3, 22, 0, 38, 17, 2, 24, 133, 46, 39, 7, 3, 1, 3, 21, 2, 6, 2, 1, 2, 4, 4, 0, 32, 4, 287, 47, 21, 1, 2, 0, 185, 46, 82, 47, 21, 0, 60, 42, 502, 63, 32, 0, 449, 56, 1288, 920, 104, 110, 2962, 1070, 13266, 568, 8, 30, 114, 29, 19, 47, 17, 3, 32, 20, 6, 18, 881, 68, 12, 0, 67, 12, 16481, 1, 3071, 106, 6, 12, 4, 8, 8, 9, 5991, 84, 2, 70, 2, 1, 3, 0, 3, 1, 3, 3, 2, 11, 2, 0, 2, 6, 2, 64, 2, 3, 3, 7, 2, 6, 2, 27, 2, 3, 2, 4, 2, 0, 4, 6, 2, 339, 3, 24, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 7, 4149, 196, 1340, 3, 2, 26, 2, 1, 2, 0, 3, 0, 2, 9, 2, 3, 2, 0, 2, 0, 7, 0, 5, 0, 2, 0, 2, 0, 2, 2, 2, 1, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 3, 3, 2, 6, 2, 3, 2, 3, 2, 0, 2, 9, 2, 16, 6, 2, 2, 4, 2, 16, 4421, 42710, 42, 4148, 12, 221, 16355, 541];
+var astralIdentifierCodes = [509, 0, 227, 0, 150, 4, 294, 9, 1368, 2, 2, 1, 6, 3, 41, 2, 5, 0, 166, 1, 1306, 2, 54, 14, 32, 9, 16, 3, 46, 10, 54, 9, 7, 2, 37, 13, 2, 9, 52, 0, 13, 2, 49, 13, 16, 9, 83, 11, 168, 11, 6, 9, 8, 2, 57, 0, 2, 6, 3, 1, 3, 2, 10, 0, 11, 1, 3, 6, 4, 4, 316, 19, 13, 9, 214, 6, 3, 8, 112, 16, 16, 9, 82, 12, 9, 9, 535, 9, 20855, 9, 135, 4, 60, 6, 26, 9, 1016, 45, 17, 3, 19723, 1, 5319, 4, 4, 5, 9, 7, 3, 6, 31, 3, 149, 2, 1418, 49, 4305, 6, 792618, 239];
+
+// This has a complexity linear to the value of the code. The
+// assumption is that looking up astral identifier characters is
+// rare.
+function isInAstralSet(code, set) {
+  var pos = 65536;
+  for (var i = 0; i < set.length; i += 2) {
+    pos += set[i];
+    if (pos > code) {
+      return false;
+    }pos += set[i + 1];
+    if (pos >= code) {
+      return true;
+    }
+  }
+}
+function isIdentifierStart(code, astral) {
+  if (code < 65) {
+    return code === 36;
+  }if (code < 91) {
+    return true;
+  }if (code < 97) {
+    return code === 95;
+  }if (code < 123) {
+    return true;
+  }if (code <= 65535) {
+    return code >= 170 && nonASCIIidentifierStart.test(String.fromCharCode(code));
+  }if (astral === false) {
+    return false;
+  }return isInAstralSet(code, astralIdentifierStartCodes);
+}
+
+function isIdentifierChar(code, astral) {
+  if (code < 48) {
+    return code === 36;
+  }if (code < 58) {
+    return true;
+  }if (code < 65) {
+    return false;
+  }if (code < 91) {
+    return true;
+  }if (code < 97) {
+    return code === 95;
+  }if (code < 123) {
+    return true;
+  }if (code <= 65535) {
+    return code >= 170 && nonASCIIidentifier.test(String.fromCharCode(code));
+  }if (astral === false) {
+    return false;
+  }return isInAstralSet(code, astralIdentifierStartCodes) || isInAstralSet(code, astralIdentifierCodes);
+}
+
+},{}],4:[function(require,module,exports){
+"use strict";
+
+var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+
+// The `getLineInfo` function is mostly useful when the
+// `locations` option is off (for performance reasons) and you
+// want to find the line/column position for a given character
+// offset. `input` should be the code string that the offset refers
+// into.
+
+exports.getLineInfo = getLineInfo;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var Parser = require("./state").Parser;
+
+var lineBreakG = require("./whitespace").lineBreakG;
+
+// These are used when `options.locations` is on, for the
+// `startLoc` and `endLoc` properties.
+
+var Position = exports.Position = (function () {
+  function Position(line, col) {
+    _classCallCheck(this, Position);
+
+    this.line = line;
+    this.column = col;
+  }
+
+  _createClass(Position, {
+    offset: {
+      value: function offset(n) {
+        return new Position(this.line, this.column + n);
+      }
+    }
+  });
+
+  return Position;
+})();
+
+var SourceLocation = exports.SourceLocation = function SourceLocation(p, start, end) {
+  _classCallCheck(this, SourceLocation);
+
+  this.start = start;
+  this.end = end;
+  if (p.sourceFile !== null) this.source = p.sourceFile;
+};
+
+function getLineInfo(input, offset) {
+  for (var line = 1, cur = 0;;) {
+    lineBreakG.lastIndex = cur;
+    var match = lineBreakG.exec(input);
+    if (match && match.index < offset) {
+      ++line;
+      cur = match.index + match[0].length;
+    } else {
+      return new Position(line, offset - cur);
+    }
+  }
+}
+
+var pp = Parser.prototype;
+
+// This function is used to raise exceptions on parse errors. It
+// takes an offset integer (into the current `input`) to indicate
+// the location of the error, attaches the position to the end
+// of the error message, and then raises a `SyntaxError` with that
+// message.
+
+pp.raise = function (pos, message) {
+  var loc = getLineInfo(this.input, pos);
+  message += " (" + loc.line + ":" + loc.column + ")";
+  var err = new SyntaxError(message);
+  err.pos = pos;err.loc = loc;err.raisedAt = this.pos;
+  throw err;
+};
+
+pp.curPosition = function () {
+  return new Position(this.curLine, this.pos - this.lineStart);
+};
+
+pp.markPosition = function () {
+  return this.options.locations ? [this.start, this.startLoc] : this.start;
+};
+
+},{"./state":9,"./whitespace":15}],5:[function(require,module,exports){
+"use strict";
+
+var tt = require("./tokentype").types;
+
+var Parser = require("./state").Parser;
+
+var reservedWords = require("./identifier").reservedWords;
+
+var has = require("./util").has;
+
+var pp = Parser.prototype;
+
+// Convert existing expression atom to assignable pattern
+// if possible.
+
+pp.toAssignable = function (node, isBinding) {
+  if (this.options.ecmaVersion >= 6 && node) {
+    switch (node.type) {
+      case "Identifier":
+      case "ObjectPattern":
+      case "ArrayPattern":
+      case "AssignmentPattern":
+        break;
+
+      case "ObjectExpression":
+        node.type = "ObjectPattern";
+        for (var i = 0; i < node.properties.length; i++) {
+          var prop = node.properties[i];
+          if (prop.kind !== "init") this.raise(prop.key.start, "Object pattern can't contain getter or setter");
+          this.toAssignable(prop.value, isBinding);
+        }
+        break;
+
+      case "ArrayExpression":
+        node.type = "ArrayPattern";
+        this.toAssignableList(node.elements, isBinding);
+        break;
+
+      case "AssignmentExpression":
+        if (node.operator === "=") {
+          node.type = "AssignmentPattern";
+        } else {
+          this.raise(node.left.end, "Only '=' operator can be used for specifying default value.");
+        }
+        break;
+
+      case "MemberExpression":
+        if (!isBinding) break;
+
+      default:
+        this.raise(node.start, "Assigning to rvalue");
+    }
+  }
+  return node;
+};
+
+// Convert list of expression atoms to binding list.
+
+pp.toAssignableList = function (exprList, isBinding) {
+  var end = exprList.length;
+  if (end) {
+    var last = exprList[end - 1];
+    if (last && last.type == "RestElement") {
+      --end;
+    } else if (last && last.type == "SpreadElement") {
+      last.type = "RestElement";
+      var arg = last.argument;
+      this.toAssignable(arg, isBinding);
+      if (arg.type !== "Identifier" && arg.type !== "MemberExpression" && arg.type !== "ArrayPattern") this.unexpected(arg.start);
+      --end;
+    }
+  }
+  for (var i = 0; i < end; i++) {
+    var elt = exprList[i];
+    if (elt) this.toAssignable(elt, isBinding);
+  }
+  return exprList;
+};
+
+// Parses spread element.
+
+pp.parseSpread = function (refShorthandDefaultPos) {
+  var node = this.startNode();
+  this.next();
+  node.argument = this.parseMaybeAssign(refShorthandDefaultPos);
+  return this.finishNode(node, "SpreadElement");
+};
+
+pp.parseRest = function () {
+  var node = this.startNode();
+  this.next();
+  node.argument = this.type === tt.name || this.type === tt.bracketL ? this.parseBindingAtom() : this.unexpected();
+  return this.finishNode(node, "RestElement");
+};
+
+// Parses lvalue (assignable) atom.
+
+pp.parseBindingAtom = function () {
+  if (this.options.ecmaVersion < 6) return this.parseIdent();
+  switch (this.type) {
+    case tt.name:
+      return this.parseIdent();
+
+    case tt.bracketL:
+      var node = this.startNode();
+      this.next();
+      node.elements = this.parseBindingList(tt.bracketR, true, true);
+      return this.finishNode(node, "ArrayPattern");
+
+    case tt.braceL:
+      return this.parseObj(true);
+
+    default:
+      this.unexpected();
+  }
+};
+
+pp.parseBindingList = function (close, allowEmpty, allowTrailingComma) {
+  var elts = [],
+      first = true;
+  while (!this.eat(close)) {
+    if (first) first = false;else this.expect(tt.comma);
+    if (allowEmpty && this.type === tt.comma) {
+      elts.push(null);
+    } else if (allowTrailingComma && this.afterTrailingComma(close)) {
+      break;
+    } else if (this.type === tt.ellipsis) {
+      elts.push(this.parseRest());
+      this.expect(close);
+      break;
+    } else {
+      elts.push(this.parseMaybeDefault());
+    }
+  }
+  return elts;
+};
+
+// Parses assignment pattern around given atom if possible.
+
+pp.parseMaybeDefault = function (startPos, left) {
+  startPos = startPos || this.markPosition();
+  left = left || this.parseBindingAtom();
+  if (!this.eat(tt.eq)) return left;
+  var node = this.startNodeAt(startPos);
+  node.operator = "=";
+  node.left = left;
+  node.right = this.parseMaybeAssign();
+  return this.finishNode(node, "AssignmentPattern");
+};
+
+// Verify that a node is an lval — something that can be assigned
+// to.
+
+pp.checkLVal = function (expr, isBinding, checkClashes) {
+  switch (expr.type) {
+    case "Identifier":
+      if (this.strict && (reservedWords.strictBind(expr.name) || reservedWords.strict(expr.name))) this.raise(expr.start, (isBinding ? "Binding " : "Assigning to ") + expr.name + " in strict mode");
+      if (checkClashes) {
+        if (has(checkClashes, expr.name)) this.raise(expr.start, "Argument name clash in strict mode");
+        checkClashes[expr.name] = true;
+      }
+      break;
+
+    case "MemberExpression":
+      if (isBinding) this.raise(expr.start, (isBinding ? "Binding" : "Assigning to") + " member expression");
+      break;
+
+    case "ObjectPattern":
+      for (var i = 0; i < expr.properties.length; i++) {
+        this.checkLVal(expr.properties[i].value, isBinding, checkClashes);
+      }break;
+
+    case "ArrayPattern":
+      for (var i = 0; i < expr.elements.length; i++) {
+        var elem = expr.elements[i];
+        if (elem) this.checkLVal(elem, isBinding, checkClashes);
+      }
+      break;
+
+    case "AssignmentPattern":
+      this.checkLVal(expr.left, isBinding, checkClashes);
+      break;
+
+    case "RestElement":
+      this.checkLVal(expr.argument, isBinding, checkClashes);
+      break;
+
+    default:
+      this.raise(expr.start, (isBinding ? "Binding" : "Assigning to") + " rvalue");
+  }
+};
+
+},{"./identifier":3,"./state":9,"./tokentype":13,"./util":14}],6:[function(require,module,exports){
+"use strict";
+
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var Parser = require("./state").Parser;
+
+var SourceLocation = require("./location").SourceLocation;
+
+// Start an AST node, attaching a start offset.
+
+var pp = Parser.prototype;
+
+var Node = exports.Node = function Node() {
+  _classCallCheck(this, Node);
+};
+
+pp.startNode = function () {
+  var node = new Node();
+  node.start = this.start;
+  if (this.options.locations) node.loc = new SourceLocation(this, this.startLoc);
+  if (this.options.directSourceFile) node.sourceFile = this.options.directSourceFile;
+  if (this.options.ranges) node.range = [this.start, 0];
+  return node;
+};
+
+pp.startNodeAt = function (pos) {
+  var node = new Node(),
+      start = pos;
+  if (this.options.locations) {
+    node.loc = new SourceLocation(this, start[1]);
+    start = pos[0];
+  }
+  node.start = start;
+  if (this.options.directSourceFile) node.sourceFile = this.options.directSourceFile;
+  if (this.options.ranges) node.range = [start, 0];
+  return node;
+};
+
+// Finish an AST node, adding `type` and `end` properties.
+
+pp.finishNode = function (node, type) {
+  node.type = type;
+  node.end = this.lastTokEnd;
+  if (this.options.locations) node.loc.end = this.lastTokEndLoc;
+  if (this.options.ranges) node.range[1] = this.lastTokEnd;
+  return node;
+};
+
+// Finish node at given position
+
+pp.finishNodeAt = function (node, type, pos) {
+  if (this.options.locations) {
+    node.loc.end = pos[1];pos = pos[0];
+  }
+  node.type = type;
+  node.end = pos;
+  if (this.options.ranges) node.range[1] = pos;
+  return node;
+};
+
+},{"./location":4,"./state":9}],7:[function(require,module,exports){
+
+
+// Interpret and default an options object
+
+"use strict";
+
+exports.getOptions = getOptions;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _util = require("./util");
+
+var has = _util.has;
+var isArray = _util.isArray;
+
+var SourceLocation = require("./location").SourceLocation;
+
+// A second optional argument can be given to further configure
+// the parser process. These options are recognized:
+
+var defaultOptions = {
+  // `ecmaVersion` indicates the ECMAScript version to parse. Must
+  // be either 3, or 5, or 6. This influences support for strict
+  // mode, the set of reserved words, support for getters and
+  // setters and other features.
+  ecmaVersion: 5,
+  // Source type ("script" or "module") for different semantics
+  sourceType: "script",
+  // `onInsertedSemicolon` can be a callback that will be called
+  // when a semicolon is automatically inserted. It will be passed
+  // th position of the comma as an offset, and if `locations` is
+  // enabled, it is given the location as a `{line, column}` object
+  // as second argument.
+  onInsertedSemicolon: null,
+  // `onTrailingComma` is similar to `onInsertedSemicolon`, but for
+  // trailing commas.
+  onTrailingComma: null,
+  // By default, reserved words are not enforced. Disable
+  // `allowReserved` to enforce them. When this option has the
+  // value "never", reserved words and keywords can also not be
+  // used as property names.
+  allowReserved: true,
+  // When enabled, a return at the top level is not considered an
+  // error.
+  allowReturnOutsideFunction: false,
+  // When enabled, import/export statements are not constrained to
+  // appearing at the top of the program.
+  allowImportExportEverywhere: false,
+  // When enabled, hashbang directive in the beginning of file
+  // is allowed and treated as a line comment.
+  allowHashBang: false,
+  // When `locations` is on, `loc` properties holding objects with
+  // `start` and `end` properties in `{line, column}` form (with
+  // line being 1-based and column 0-based) will be attached to the
+  // nodes.
+  locations: false,
+  // A function can be passed as `onToken` option, which will
+  // cause Acorn to call that function with object in the same
+  // format as tokenize() returns. Note that you are not
+  // allowed to call the parser from the callback—that will
+  // corrupt its internal state.
+  onToken: null,
+  // A function can be passed as `onComment` option, which will
+  // cause Acorn to call that function with `(block, text, start,
+  // end)` parameters whenever a comment is skipped. `block` is a
+  // boolean indicating whether this is a block (`/* */`) comment,
+  // `text` is the content of the comment, and `start` and `end` are
+  // character offsets that denote the start and end of the comment.
+  // When the `locations` option is on, two more parameters are
+  // passed, the full `{line, column}` locations of the start and
+  // end of the comments. Note that you are not allowed to call the
+  // parser from the callback—that will corrupt its internal state.
+  onComment: null,
+  // Nodes have their start and end characters offsets recorded in
+  // `start` and `end` properties (directly on the node, rather than
+  // the `loc` object, which holds line/column data. To also add a
+  // [semi-standardized][range] `range` property holding a `[start,
+  // end]` array with the same numbers, set the `ranges` option to
+  // `true`.
+  //
+  // [range]: https://bugzilla.mozilla.org/show_bug.cgi?id=745678
+  ranges: false,
+  // It is possible to parse multiple files into a single AST by
+  // passing the tree produced by parsing the first file as
+  // `program` option in subsequent parses. This will add the
+  // toplevel forms of the parsed file to the `Program` (top) node
+  // of an existing parse tree.
+  program: null,
+  // When `locations` is on, you can pass this to record the source
+  // file in every node's `loc` object.
+  sourceFile: null,
+  // This value, if given, is stored in every node, whether
+  // `locations` is on or off.
+  directSourceFile: null,
+  // When enabled, parenthesized expressions are represented by
+  // (non-standard) ParenthesizedExpression nodes
+  preserveParens: false,
+  plugins: {}
+};exports.defaultOptions = defaultOptions;
+
+function getOptions(opts) {
+  var options = {};
+  for (var opt in defaultOptions) {
+    options[opt] = opts && has(opts, opt) ? opts[opt] : defaultOptions[opt];
+  }if (isArray(options.onToken)) {
+    (function () {
+      var tokens = options.onToken;
+      options.onToken = function (token) {
+        return tokens.push(token);
+      };
+    })();
+  }
+  if (isArray(options.onComment)) options.onComment = pushComment(options, options.onComment);
+
+  return options;
+}
+
+function pushComment(options, array) {
+  return function (block, text, start, end, startLoc, endLoc) {
+    var comment = {
+      type: block ? "Block" : "Line",
+      value: text,
+      start: start,
+      end: end
+    };
+    if (options.locations) comment.loc = new SourceLocation(this, startLoc, endLoc);
+    if (options.ranges) comment.range = [start, end];
+    array.push(comment);
+  };
+}
+
+},{"./location":4,"./util":14}],8:[function(require,module,exports){
+"use strict";
+
+var tt = require("./tokentype").types;
+
+var Parser = require("./state").Parser;
+
+var lineBreak = require("./whitespace").lineBreak;
+
+var pp = Parser.prototype;
+
+// ## Parser utilities
+
+// Test whether a statement node is the string literal `"use strict"`.
+
+pp.isUseStrict = function (stmt) {
+  return this.options.ecmaVersion >= 5 && stmt.type === "ExpressionStatement" && stmt.expression.type === "Literal" && stmt.expression.value === "use strict";
+};
+
+// Predicate that tests whether the next token is of the given
+// type, and if yes, consumes it as a side effect.
+
+pp.eat = function (type) {
+  if (this.type === type) {
+    this.next();
+    return true;
+  } else {
+    return false;
+  }
+};
+
+// Tests whether parsed token is a contextual keyword.
+
+pp.isContextual = function (name) {
+  return this.type === tt.name && this.value === name;
+};
+
+// Consumes contextual keyword if possible.
+
+pp.eatContextual = function (name) {
+  return this.value === name && this.eat(tt.name);
+};
+
+// Asserts that following token is given contextual keyword.
+
+pp.expectContextual = function (name) {
+  if (!this.eatContextual(name)) this.unexpected();
+};
+
+// Test whether a semicolon can be inserted at the current position.
+
+pp.canInsertSemicolon = function () {
+  return this.type === tt.eof || this.type === tt.braceR || lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+};
+
+pp.insertSemicolon = function () {
+  if (this.canInsertSemicolon()) {
+    if (this.options.onInsertedSemicolon) this.options.onInsertedSemicolon(this.lastTokEnd, this.lastTokEndLoc);
+    return true;
+  }
+};
+
+// Consume a semicolon, or, failing that, see if we are allowed to
+// pretend that there is a semicolon at this position.
+
+pp.semicolon = function () {
+  if (!this.eat(tt.semi) && !this.insertSemicolon()) this.unexpected();
+};
+
+pp.afterTrailingComma = function (tokType) {
+  if (this.type == tokType) {
+    if (this.options.onTrailingComma) this.options.onTrailingComma(this.lastTokStart, this.lastTokStartLoc);
+    this.next();
+    return true;
+  }
+};
+
+// Expect a token of a given type. If found, consume it, otherwise,
+// raise an unexpected token error.
+
+pp.expect = function (type) {
+  this.eat(type) || this.unexpected();
+};
+
+// Raise an unexpected token error.
+
+pp.unexpected = function (pos) {
+  this.raise(pos != null ? pos : this.start, "Unexpected token");
+};
+
+},{"./state":9,"./tokentype":13,"./whitespace":15}],9:[function(require,module,exports){
+"use strict";
+
+exports.Parser = Parser;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _identifier = require("./identifier");
+
+var reservedWords = _identifier.reservedWords;
+var keywords = _identifier.keywords;
+
+var _tokentype = require("./tokentype");
+
+var tt = _tokentype.types;
+var lineBreak = _tokentype.lineBreak;
+
+function Parser(options, input, startPos) {
+  this.options = options;
+  this.loadPlugins(this.options.plugins);
+  this.sourceFile = this.options.sourceFile || null;
+  this.isKeyword = keywords[this.options.ecmaVersion >= 6 ? 6 : 5];
+  this.isReservedWord = reservedWords[this.options.ecmaVersion];
+  this.input = input;
+
+  // Set up token state
+
+  // The current position of the tokenizer in the input.
+  if (startPos) {
+    this.pos = startPos;
+    this.lineStart = Math.max(0, this.input.lastIndexOf("\n", startPos));
+    this.curLine = this.input.slice(0, this.lineStart).split(lineBreak).length;
+  } else {
+    this.pos = this.lineStart = 0;
+    this.curLine = 1;
+  }
+
+  // Properties of the current token:
+  // Its type
+  this.type = tt.eof;
+  // For tokens that include more information than their type, the value
+  this.value = null;
+  // Its start and end offset
+  this.start = this.end = this.pos;
+  // And, if locations are used, the {line, column} object
+  // corresponding to those offsets
+  this.startLoc = this.endLoc = null;
+
+  // Position information for the previous token
+  this.lastTokEndLoc = this.lastTokStartLoc = null;
+  this.lastTokStart = this.lastTokEnd = this.pos;
+
+  // The context stack is used to superficially track syntactic
+  // context to predict whether a regular expression is allowed in a
+  // given position.
+  this.context = this.initialContext();
+  this.exprAllowed = true;
+
+  // Figure out if it's a module code.
+  this.strict = this.inModule = this.options.sourceType === "module";
+
+  // Flags to track whether we are in a function, a generator.
+  this.inFunction = this.inGenerator = false;
+  // Labels in scope.
+  this.labels = [];
+
+  // If enabled, skip leading hashbang line.
+  if (this.pos === 0 && this.options.allowHashBang && this.input.slice(0, 2) === "#!") this.skipLineComment(2);
+}
+
+Parser.prototype.extend = function (name, f) {
+  this[name] = f(this[name]);
+};
+
+// Registered plugins
+
+var plugins = {};
+
+exports.plugins = plugins;
+Parser.prototype.loadPlugins = function (plugins) {
+  for (var _name in plugins) {
+    var plugin = exports.plugins[_name];
+    if (!plugin) throw new Error("Plugin '" + _name + "' not found");
+    plugin(this, plugins[_name]);
+  }
+};
+
+},{"./identifier":3,"./tokentype":13}],10:[function(require,module,exports){
+"use strict";
+
+var tt = require("./tokentype").types;
+
+var Parser = require("./state").Parser;
+
+var lineBreak = require("./whitespace").lineBreak;
+
+var pp = Parser.prototype;
+
+// ### Statement parsing
+
+// Parse a program. Initializes the parser, reads any number of
+// statements, and wraps them in a Program node.  Optionally takes a
+// `program` argument.  If present, the statements will be appended
+// to its body instead of creating a new node.
+
+pp.parseTopLevel = function (node) {
+  var first = true;
+  if (!node.body) node.body = [];
+  while (this.type !== tt.eof) {
+    var stmt = this.parseStatement(true, true);
+    node.body.push(stmt);
+    if (first && this.isUseStrict(stmt)) this.setStrict(true);
+    first = false;
+  }
+  this.next();
+  if (this.options.ecmaVersion >= 6) {
+    node.sourceType = this.options.sourceType;
+  }
+  return this.finishNode(node, "Program");
+};
+
+var loopLabel = { kind: "loop" },
+    switchLabel = { kind: "switch" };
+
+// Parse a single statement.
+//
+// If expecting a statement and finding a slash operator, parse a
+// regular expression literal. This is to handle cases like
+// `if (foo) /blah/.exec(foo)`, where looking at the previous token
+// does not help.
+
+pp.parseStatement = function (declaration, topLevel) {
+  var starttype = this.type,
+      node = this.startNode();
+
+  // Most types of statements are recognized by the keyword they
+  // start with. Many are trivial to parse, some require a bit of
+  // complexity.
+
+  switch (starttype) {
+    case tt._break:case tt._continue:
+      return this.parseBreakContinueStatement(node, starttype.keyword);
+    case tt._debugger:
+      return this.parseDebuggerStatement(node);
+    case tt._do:
+      return this.parseDoStatement(node);
+    case tt._for:
+      return this.parseForStatement(node);
+    case tt._function:
+      if (!declaration && this.options.ecmaVersion >= 6) this.unexpected();
+      return this.parseFunctionStatement(node);
+    case tt._class:
+      if (!declaration) this.unexpected();
+      return this.parseClass(node, true);
+    case tt._if:
+      return this.parseIfStatement(node);
+    case tt._return:
+      return this.parseReturnStatement(node);
+    case tt._switch:
+      return this.parseSwitchStatement(node);
+    case tt._throw:
+      return this.parseThrowStatement(node);
+    case tt._try:
+      return this.parseTryStatement(node);
+    case tt._let:case tt._const:
+      if (!declaration) this.unexpected(); // NOTE: falls through to _var
+    case tt._var:
+      return this.parseVarStatement(node, starttype);
+    case tt._while:
+      return this.parseWhileStatement(node);
+    case tt._with:
+      return this.parseWithStatement(node);
+    case tt.braceL:
+      return this.parseBlock();
+    case tt.semi:
+      return this.parseEmptyStatement(node);
+    case tt._export:
+    case tt._import:
+      if (!this.options.allowImportExportEverywhere) {
+        if (!topLevel) this.raise(this.start, "'import' and 'export' may only appear at the top level");
+        if (!this.inModule) this.raise(this.start, "'import' and 'export' may appear only with 'sourceType: module'");
+      }
+      return starttype === tt._import ? this.parseImport(node) : this.parseExport(node);
+
+    // If the statement does not start with a statement keyword or a
+    // brace, it's an ExpressionStatement or LabeledStatement. We
+    // simply start parsing an expression, and afterwards, if the
+    // next token is a colon and the expression was a simple
+    // Identifier node, we switch to interpreting it as a label.
+    default:
+      var maybeName = this.value,
+          expr = this.parseExpression();
+      if (starttype === tt.name && expr.type === "Identifier" && this.eat(tt.colon)) return this.parseLabeledStatement(node, maybeName, expr);else return this.parseExpressionStatement(node, expr);
+  }
+};
+
+pp.parseBreakContinueStatement = function (node, keyword) {
+  var isBreak = keyword == "break";
+  this.next();
+  if (this.eat(tt.semi) || this.insertSemicolon()) node.label = null;else if (this.type !== tt.name) this.unexpected();else {
+    node.label = this.parseIdent();
+    this.semicolon();
+  }
+
+  // Verify that there is an actual destination to break or
+  // continue to.
+  for (var i = 0; i < this.labels.length; ++i) {
+    var lab = this.labels[i];
+    if (node.label == null || lab.name === node.label.name) {
+      if (lab.kind != null && (isBreak || lab.kind === "loop")) break;
+      if (node.label && isBreak) break;
+    }
+  }
+  if (i === this.labels.length) this.raise(node.start, "Unsyntactic " + keyword);
+  return this.finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
+};
+
+pp.parseDebuggerStatement = function (node) {
+  this.next();
+  this.semicolon();
+  return this.finishNode(node, "DebuggerStatement");
+};
+
+pp.parseDoStatement = function (node) {
+  this.next();
+  this.labels.push(loopLabel);
+  node.body = this.parseStatement(false);
+  this.labels.pop();
+  this.expect(tt._while);
+  node.test = this.parseParenExpression();
+  if (this.options.ecmaVersion >= 6) this.eat(tt.semi);else this.semicolon();
+  return this.finishNode(node, "DoWhileStatement");
+};
+
+// Disambiguating between a `for` and a `for`/`in` or `for`/`of`
+// loop is non-trivial. Basically, we have to parse the init `var`
+// statement or expression, disallowing the `in` operator (see
+// the second parameter to `parseExpression`), and then check
+// whether the next token is `in` or `of`. When there is no init
+// part (semicolon immediately after the opening parenthesis), it
+// is a regular `for` loop.
+
+pp.parseForStatement = function (node) {
+  this.next();
+  this.labels.push(loopLabel);
+  this.expect(tt.parenL);
+  if (this.type === tt.semi) return this.parseFor(node, null);
+  if (this.type === tt._var || this.type === tt._let || this.type === tt._const) {
+    var _init = this.startNode(),
+        varKind = this.type;
+    this.next();
+    this.parseVar(_init, true, varKind);
+    this.finishNode(_init, "VariableDeclaration");
+    if ((this.type === tt._in || this.options.ecmaVersion >= 6 && this.isContextual("of")) && _init.declarations.length === 1 && !(varKind !== tt._var && _init.declarations[0].init)) return this.parseForIn(node, _init);
+    return this.parseFor(node, _init);
+  }
+  var refShorthandDefaultPos = { start: 0 };
+  var init = this.parseExpression(true, refShorthandDefaultPos);
+  if (this.type === tt._in || this.options.ecmaVersion >= 6 && this.isContextual("of")) {
+    this.toAssignable(init);
+    this.checkLVal(init);
+    return this.parseForIn(node, init);
+  } else if (refShorthandDefaultPos.start) {
+    this.unexpected(refShorthandDefaultPos.start);
+  }
+  return this.parseFor(node, init);
+};
+
+pp.parseFunctionStatement = function (node) {
+  this.next();
+  return this.parseFunction(node, true);
+};
+
+pp.parseIfStatement = function (node) {
+  this.next();
+  node.test = this.parseParenExpression();
+  node.consequent = this.parseStatement(false);
+  node.alternate = this.eat(tt._else) ? this.parseStatement(false) : null;
+  return this.finishNode(node, "IfStatement");
+};
+
+pp.parseReturnStatement = function (node) {
+  if (!this.inFunction && !this.options.allowReturnOutsideFunction) this.raise(this.start, "'return' outside of function");
+  this.next();
+
+  // In `return` (and `break`/`continue`), the keywords with
+  // optional arguments, we eagerly look for a semicolon or the
+  // possibility to insert one.
+
+  if (this.eat(tt.semi) || this.insertSemicolon()) node.argument = null;else {
+    node.argument = this.parseExpression();this.semicolon();
+  }
+  return this.finishNode(node, "ReturnStatement");
+};
+
+pp.parseSwitchStatement = function (node) {
+  this.next();
+  node.discriminant = this.parseParenExpression();
+  node.cases = [];
+  this.expect(tt.braceL);
+  this.labels.push(switchLabel);
+
+  // Statements under must be grouped (by label) in SwitchCase
+  // nodes. `cur` is used to keep the node that we are currently
+  // adding statements to.
+
+  for (var cur, sawDefault; this.type != tt.braceR;) {
+    if (this.type === tt._case || this.type === tt._default) {
+      var isCase = this.type === tt._case;
+      if (cur) this.finishNode(cur, "SwitchCase");
+      node.cases.push(cur = this.startNode());
+      cur.consequent = [];
+      this.next();
+      if (isCase) {
+        cur.test = this.parseExpression();
+      } else {
+        if (sawDefault) this.raise(this.lastTokStart, "Multiple default clauses");
+        sawDefault = true;
+        cur.test = null;
+      }
+      this.expect(tt.colon);
+    } else {
+      if (!cur) this.unexpected();
+      cur.consequent.push(this.parseStatement(true));
+    }
+  }
+  if (cur) this.finishNode(cur, "SwitchCase");
+  this.next(); // Closing brace
+  this.labels.pop();
+  return this.finishNode(node, "SwitchStatement");
+};
+
+pp.parseThrowStatement = function (node) {
+  this.next();
+  if (lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) this.raise(this.lastTokEnd, "Illegal newline after throw");
+  node.argument = this.parseExpression();
+  this.semicolon();
+  return this.finishNode(node, "ThrowStatement");
+};
+
+// Reused empty array added for node fields that are always empty.
+
+var empty = [];
+
+pp.parseTryStatement = function (node) {
+  this.next();
+  node.block = this.parseBlock();
+  node.handler = null;
+  if (this.type === tt._catch) {
+    var clause = this.startNode();
+    this.next();
+    this.expect(tt.parenL);
+    clause.param = this.parseBindingAtom();
+    this.checkLVal(clause.param, true);
+    this.expect(tt.parenR);
+    clause.guard = null;
+    clause.body = this.parseBlock();
+    node.handler = this.finishNode(clause, "CatchClause");
+  }
+  node.guardedHandlers = empty;
+  node.finalizer = this.eat(tt._finally) ? this.parseBlock() : null;
+  if (!node.handler && !node.finalizer) this.raise(node.start, "Missing catch or finally clause");
+  return this.finishNode(node, "TryStatement");
+};
+
+pp.parseVarStatement = function (node, kind) {
+  this.next();
+  this.parseVar(node, false, kind);
+  this.semicolon();
+  return this.finishNode(node, "VariableDeclaration");
+};
+
+pp.parseWhileStatement = function (node) {
+  this.next();
+  node.test = this.parseParenExpression();
+  this.labels.push(loopLabel);
+  node.body = this.parseStatement(false);
+  this.labels.pop();
+  return this.finishNode(node, "WhileStatement");
+};
+
+pp.parseWithStatement = function (node) {
+  if (this.strict) this.raise(this.start, "'with' in strict mode");
+  this.next();
+  node.object = this.parseParenExpression();
+  node.body = this.parseStatement(false);
+  return this.finishNode(node, "WithStatement");
+};
+
+pp.parseEmptyStatement = function (node) {
+  this.next();
+  return this.finishNode(node, "EmptyStatement");
+};
+
+pp.parseLabeledStatement = function (node, maybeName, expr) {
+  for (var i = 0; i < this.labels.length; ++i) {
+    if (this.labels[i].name === maybeName) this.raise(expr.start, "Label '" + maybeName + "' is already declared");
+  }var kind = this.type.isLoop ? "loop" : this.type === tt._switch ? "switch" : null;
+  this.labels.push({ name: maybeName, kind: kind });
+  node.body = this.parseStatement(true);
+  this.labels.pop();
+  node.label = expr;
+  return this.finishNode(node, "LabeledStatement");
+};
+
+pp.parseExpressionStatement = function (node, expr) {
+  node.expression = expr;
+  this.semicolon();
+  return this.finishNode(node, "ExpressionStatement");
+};
+
+// Parse a semicolon-enclosed block of statements, handling `"use
+// strict"` declarations when `allowStrict` is true (used for
+// function bodies).
+
+pp.parseBlock = function (allowStrict) {
+  var node = this.startNode(),
+      first = true,
+      oldStrict = undefined;
+  node.body = [];
+  this.expect(tt.braceL);
+  while (!this.eat(tt.braceR)) {
+    var stmt = this.parseStatement(true);
+    node.body.push(stmt);
+    if (first && allowStrict && this.isUseStrict(stmt)) {
+      oldStrict = this.strict;
+      this.setStrict(this.strict = true);
+    }
+    first = false;
+  }
+  if (oldStrict === false) this.setStrict(false);
+  return this.finishNode(node, "BlockStatement");
+};
+
+// Parse a regular `for` loop. The disambiguation code in
+// `parseStatement` will already have parsed the init statement or
+// expression.
+
+pp.parseFor = function (node, init) {
+  node.init = init;
+  this.expect(tt.semi);
+  node.test = this.type === tt.semi ? null : this.parseExpression();
+  this.expect(tt.semi);
+  node.update = this.type === tt.parenR ? null : this.parseExpression();
+  this.expect(tt.parenR);
+  node.body = this.parseStatement(false);
+  this.labels.pop();
+  return this.finishNode(node, "ForStatement");
+};
+
+// Parse a `for`/`in` and `for`/`of` loop, which are almost
+// same from parser's perspective.
+
+pp.parseForIn = function (node, init) {
+  var type = this.type === tt._in ? "ForInStatement" : "ForOfStatement";
+  this.next();
+  node.left = init;
+  node.right = this.parseExpression();
+  this.expect(tt.parenR);
+  node.body = this.parseStatement(false);
+  this.labels.pop();
+  return this.finishNode(node, type);
+};
+
+// Parse a list of variable declarations.
+
+pp.parseVar = function (node, isFor, kind) {
+  node.declarations = [];
+  node.kind = kind.keyword;
+  for (;;) {
+    var decl = this.startNode();
+    decl.id = this.parseBindingAtom();
+    this.checkLVal(decl.id, true);
+    if (this.eat(tt.eq)) {
+      decl.init = this.parseMaybeAssign(isFor);
+    } else if (kind === tt._const && !(this.type === tt._in || this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+      this.unexpected();
+    } else if (decl.id.type != "Identifier" && !(isFor && (this.type === tt._in || this.isContextual("of")))) {
+      this.raise(this.lastTokEnd, "Complex binding patterns require an initialization value");
+    } else {
+      decl.init = null;
+    }
+    node.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+    if (!this.eat(tt.comma)) break;
+  }
+  return node;
+};
+
+// Parse a function declaration or literal (depending on the
+// `isStatement` parameter).
+
+pp.parseFunction = function (node, isStatement, allowExpressionBody) {
+  this.initFunction(node);
+  if (this.options.ecmaVersion >= 6) node.generator = this.eat(tt.star);
+  if (isStatement || this.type === tt.name) node.id = this.parseIdent();
+  this.expect(tt.parenL);
+  node.params = this.parseBindingList(tt.parenR, false, false);
+  this.parseFunctionBody(node, allowExpressionBody);
+  return this.finishNode(node, isStatement ? "FunctionDeclaration" : "FunctionExpression");
+};
+
+// Parse a class declaration or literal (depending on the
+// `isStatement` parameter).
+
+pp.parseClass = function (node, isStatement) {
+  this.next();
+  node.id = this.type === tt.name ? this.parseIdent() : isStatement ? this.unexpected() : null;
+  node.superClass = this.eat(tt._extends) ? this.parseExprSubscripts() : null;
+  var classBody = this.startNode();
+  classBody.body = [];
+  this.expect(tt.braceL);
+  while (!this.eat(tt.braceR)) {
+    if (this.eat(tt.semi)) continue;
+    var method = this.startNode();
+    var isGenerator = this.eat(tt.star);
+    this.parsePropertyName(method);
+    if (this.type !== tt.parenL && !method.computed && method.key.type === "Identifier" && method.key.name === "static") {
+      if (isGenerator) this.unexpected();
+      method["static"] = true;
+      isGenerator = this.eat(tt.star);
+      this.parsePropertyName(method);
+    } else {
+      method["static"] = false;
+    }
+    method.kind = "method";
+    if (!method.computed && !isGenerator) {
+      if (method.key.type === "Identifier") {
+        if (this.type !== tt.parenL && (method.key.name === "get" || method.key.name === "set")) {
+          method.kind = method.key.name;
+          this.parsePropertyName(method);
+        } else if (!method["static"] && method.key.name === "constructor") {
+          method.kind = "constructor";
+        }
+      } else if (!method["static"] && method.key.type === "Literal" && method.key.value === "constructor") {
+        method.kind = "constructor";
+      }
+    }
+    method.value = this.parseMethod(isGenerator);
+    classBody.body.push(this.finishNode(method, "MethodDefinition"));
+  }
+  node.body = this.finishNode(classBody, "ClassBody");
+  return this.finishNode(node, isStatement ? "ClassDeclaration" : "ClassExpression");
+};
+
+// Parses module export declaration.
+
+pp.parseExport = function (node) {
+  this.next();
+  // export * from '...'
+  if (this.eat(tt.star)) {
+    this.expectContextual("from");
+    node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected();
+    this.semicolon();
+    return this.finishNode(node, "ExportAllDeclaration");
+  }
+  if (this.eat(tt._default)) {
+    // export default ...
+    var expr = this.parseMaybeAssign();
+    var needsSemi = true;
+    if (expr.type == "FunctionExpression" || expr.type == "ClassExpression") {
+      needsSemi = false;
+      if (expr.id) {
+        expr.type = expr.type == "FunctionExpression" ? "FunctionDeclaration" : "ClassDeclaration";
+      }
+    }
+    node.declaration = expr;
+    if (needsSemi) this.semicolon();
+    return this.finishNode(node, "ExportDefaultDeclaration");
+  }
+  // export var|const|let|function|class ...
+  if (this.type.keyword) {
+    node.declaration = this.parseStatement(true);
+    node.specifiers = [];
+    node.source = null;
+  } else {
+    // export { x, y as z } [from '...']
+    node.declaration = null;
+    node.specifiers = this.parseExportSpecifiers();
+    if (this.eatContextual("from")) {
+      node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected();
+    } else {
+      node.source = null;
+    }
+    this.semicolon();
+  }
+  return this.finishNode(node, "ExportNamedDeclaration");
+};
+
+// Parses a comma-separated list of module exports.
+
+pp.parseExportSpecifiers = function () {
+  var nodes = [],
+      first = true;
+  // export { x, y as z } [from '...']
+  this.expect(tt.braceL);
+  while (!this.eat(tt.braceR)) {
+    if (!first) {
+      this.expect(tt.comma);
+      if (this.afterTrailingComma(tt.braceR)) break;
+    } else first = false;
+
+    var node = this.startNode();
+    node.local = this.parseIdent(this.type === tt._default);
+    node.exported = this.eatContextual("as") ? this.parseIdent(true) : node.local;
+    nodes.push(this.finishNode(node, "ExportSpecifier"));
+  }
+  return nodes;
+};
+
+// Parses import declaration.
+
+pp.parseImport = function (node) {
+  this.next();
+  // import '...'
+  if (this.type === tt.string) {
+    node.specifiers = empty;
+    node.source = this.parseExprAtom();
+    node.kind = "";
+  } else {
+    node.specifiers = this.parseImportSpecifiers();
+    this.expectContextual("from");
+    node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected();
+  }
+  this.semicolon();
+  return this.finishNode(node, "ImportDeclaration");
+};
+
+// Parses a comma-separated list of module imports.
+
+pp.parseImportSpecifiers = function () {
+  var nodes = [],
+      first = true;
+  if (this.type === tt.name) {
+    // import defaultObj, { x, y as z } from '...'
+    var node = this.startNode();
+    node.local = this.parseIdent();
+    this.checkLVal(node.local, true);
+    nodes.push(this.finishNode(node, "ImportDefaultSpecifier"));
+    if (!this.eat(tt.comma)) return nodes;
+  }
+  if (this.type === tt.star) {
+    var node = this.startNode();
+    this.next();
+    this.expectContextual("as");
+    node.local = this.parseIdent();
+    this.checkLVal(node.local, true);
+    nodes.push(this.finishNode(node, "ImportNamespaceSpecifier"));
+    return nodes;
+  }
+  this.expect(tt.braceL);
+  while (!this.eat(tt.braceR)) {
+    if (!first) {
+      this.expect(tt.comma);
+      if (this.afterTrailingComma(tt.braceR)) break;
+    } else first = false;
+
+    var node = this.startNode();
+    node.imported = this.parseIdent(true);
+    node.local = this.eatContextual("as") ? this.parseIdent() : node.imported;
+    this.checkLVal(node.local, true);
+    nodes.push(this.finishNode(node, "ImportSpecifier"));
+  }
+  return nodes;
+};
+
+},{"./state":9,"./tokentype":13,"./whitespace":15}],11:[function(require,module,exports){
+"use strict";
+
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+// The algorithm used to determine whether a regexp can appear at a
+// given point in the program is loosely based on sweet.js' approach.
+// See https://github.com/mozilla/sweet.js/wiki/design
+
+var Parser = require("./state").Parser;
+
+var tt = require("./tokentype").types;
+
+var lineBreak = require("./whitespace").lineBreak;
+
+var TokContext = exports.TokContext = function TokContext(token, isExpr, preserveSpace, override) {
+  _classCallCheck(this, TokContext);
+
+  this.token = token;
+  this.isExpr = isExpr;
+  this.preserveSpace = preserveSpace;
+  this.override = override;
+};
+
+var types = {
+  b_stat: new TokContext("{", false),
+  b_expr: new TokContext("{", true),
+  b_tmpl: new TokContext("${", true),
+  p_stat: new TokContext("(", false),
+  p_expr: new TokContext("(", true),
+  q_tmpl: new TokContext("`", true, true, function (p) {
+    return p.readTmplToken();
+  }),
+  f_expr: new TokContext("function", true)
+};
+
+exports.types = types;
+var pp = Parser.prototype;
+
+pp.initialContext = function () {
+  return [types.b_stat];
+};
+
+pp.braceIsBlock = function (prevType) {
+  var parent = undefined;
+  if (prevType === tt.colon && (parent = this.curContext()).token == "{") return !parent.isExpr;
+  if (prevType === tt._return) return lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+  if (prevType === tt._else || prevType === tt.semi || prevType === tt.eof) return true;
+  if (prevType == tt.braceL) return this.curContext() === types.b_stat;
+  return !this.exprAllowed;
+};
+
+pp.updateContext = function (prevType) {
+  var update = undefined,
+      type = this.type;
+  if (type.keyword && prevType == tt.dot) this.exprAllowed = false;else if (update = type.updateContext) update.call(this, prevType);else this.exprAllowed = type.beforeExpr;
+};
+
+// Token-specific context update code
+
+tt.parenR.updateContext = tt.braceR.updateContext = function () {
+  if (this.context.length == 1) {
+    this.exprAllowed = true;
+    return;
+  }
+  var out = this.context.pop();
+  if (out === types.b_stat && this.curContext() === types.f_expr) {
+    this.context.pop();
+    this.exprAllowed = false;
+  } else if (out === types.b_tmpl) {
+    this.exprAllowed = true;
+  } else {
+    this.exprAllowed = !out.isExpr;
+  }
+};
+
+tt.braceL.updateContext = function (prevType) {
+  this.context.push(this.braceIsBlock(prevType) ? types.b_stat : types.b_expr);
+  this.exprAllowed = true;
+};
+
+tt.dollarBraceL.updateContext = function () {
+  this.context.push(types.b_tmpl);
+  this.exprAllowed = true;
+};
+
+tt.parenL.updateContext = function (prevType) {
+  var statementParens = prevType === tt._if || prevType === tt._for || prevType === tt._with || prevType === tt._while;
+  this.context.push(statementParens ? types.p_stat : types.p_expr);
+  this.exprAllowed = true;
+};
+
+tt.incDec.updateContext = function () {};
+
+tt._function.updateContext = function () {
+  if (this.curContext() !== types.b_stat) this.context.push(types.f_expr);
+  this.exprAllowed = false;
+};
+
+tt.backQuote.updateContext = function () {
+  if (this.curContext() === types.q_tmpl) this.context.pop();else this.context.push(types.q_tmpl);
+  this.exprAllowed = false;
+};
+
+// tokExprAllowed stays unchanged
+
+},{"./state":9,"./tokentype":13,"./whitespace":15}],12:[function(require,module,exports){
+"use strict";
+
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _identifier = require("./identifier");
+
+var isIdentifierStart = _identifier.isIdentifierStart;
+var isIdentifierChar = _identifier.isIdentifierChar;
+
+var _tokentype = require("./tokentype");
+
+var tt = _tokentype.types;
+var keywordTypes = _tokentype.keywords;
+
+var Parser = require("./state").Parser;
+
+var SourceLocation = require("./location").SourceLocation;
+
+var _whitespace = require("./whitespace");
+
+var lineBreak = _whitespace.lineBreak;
+var lineBreakG = _whitespace.lineBreakG;
+var isNewLine = _whitespace.isNewLine;
+var nonASCIIwhitespace = _whitespace.nonASCIIwhitespace;
+
+// Object type used to represent tokens. Note that normally, tokens
+// simply exist as properties on the parser object. This is only
+// used for the onToken callback and the external tokenizer.
+
+var Token = exports.Token = function Token(p) {
+  _classCallCheck(this, Token);
+
+  this.type = p.type;
+  this.value = p.value;
+  this.start = p.start;
+  this.end = p.end;
+  if (p.options.locations) this.loc = new SourceLocation(p, p.startLoc, p.endLoc);
+  if (p.options.ranges) this.range = [p.start, p.end];
+};
+
+// ## Tokenizer
+
+var pp = Parser.prototype;
+
+// Move to the next token
+
+pp.next = function () {
+  if (this.options.onToken) this.options.onToken(new Token(this));
+
+  this.lastTokEnd = this.end;
+  this.lastTokStart = this.start;
+  this.lastTokEndLoc = this.endLoc;
+  this.lastTokStartLoc = this.startLoc;
+  this.nextToken();
+};
+
+pp.getToken = function () {
+  this.next();
+  return new Token(this);
+};
+
+// If we're in an ES6 environment, make parsers iterable
+if (typeof Symbol !== "undefined") pp[Symbol.iterator] = function () {
+  var self = this;
+  return { next: function next() {
+      var token = self.getToken();
+      return {
+        done: token.type === tt.eof,
+        value: token
+      };
+    } };
+};
+
+// Toggle strict mode. Re-reads the next number or string to please
+// pedantic tests (`"use strict"; 010;` should fail).
+
+pp.setStrict = function (strict) {
+  this.strict = strict;
+  if (this.type !== tt.num && this.type !== tt.string) return;
+  this.pos = this.start;
+  if (this.options.locations) {
+    while (this.pos < this.lineStart) {
+      this.lineStart = this.input.lastIndexOf("\n", this.lineStart - 2) + 1;
+      --this.curLine;
+    }
+  }
+  this.nextToken();
+};
+
+pp.curContext = function () {
+  return this.context[this.context.length - 1];
+};
+
+// Read a single token, updating the parser object's token-related
+// properties.
+
+pp.nextToken = function () {
+  var curContext = this.curContext();
+  if (!curContext || !curContext.preserveSpace) this.skipSpace();
+
+  this.start = this.pos;
+  if (this.options.locations) this.startLoc = this.curPosition();
+  if (this.pos >= this.input.length) return this.finishToken(tt.eof);
+
+  if (curContext.override) return curContext.override(this);else this.readToken(this.fullCharCodeAtPos());
+};
+
+pp.readToken = function (code) {
+  // Identifier or keyword. '\uXXXX' sequences are allowed in
+  // identifiers, so '\' also dispatches to that.
+  if (isIdentifierStart(code, this.options.ecmaVersion >= 6) || code === 92 /* '\' */) return this.readWord();
+
+  return this.getTokenFromCode(code);
+};
+
+pp.fullCharCodeAtPos = function () {
+  var code = this.input.charCodeAt(this.pos);
+  if (code <= 55295 || code >= 57344) return code;
+  var next = this.input.charCodeAt(this.pos + 1);
+  return (code << 10) + next - 56613888;
+};
+
+pp.skipBlockComment = function () {
+  var startLoc = this.options.onComment && this.options.locations && this.curPosition();
+  var start = this.pos,
+      end = this.input.indexOf("*/", this.pos += 2);
+  if (end === -1) this.raise(this.pos - 2, "Unterminated comment");
+  this.pos = end + 2;
+  if (this.options.locations) {
+    lineBreakG.lastIndex = start;
+    var match = undefined;
+    while ((match = lineBreakG.exec(this.input)) && match.index < this.pos) {
+      ++this.curLine;
+      this.lineStart = match.index + match[0].length;
+    }
+  }
+  if (this.options.onComment) this.options.onComment(true, this.input.slice(start + 2, end), start, this.pos, startLoc, this.options.locations && this.curPosition());
+};
+
+pp.skipLineComment = function (startSkip) {
+  var start = this.pos;
+  var startLoc = this.options.onComment && this.options.locations && this.curPosition();
+  var ch = this.input.charCodeAt(this.pos += startSkip);
+  while (this.pos < this.input.length && ch !== 10 && ch !== 13 && ch !== 8232 && ch !== 8233) {
+    ++this.pos;
+    ch = this.input.charCodeAt(this.pos);
+  }
+  if (this.options.onComment) this.options.onComment(false, this.input.slice(start + startSkip, this.pos), start, this.pos, startLoc, this.options.locations && this.curPosition());
+};
+
+// Called at the start of the parse and after every token. Skips
+// whitespace and comments, and.
+
+pp.skipSpace = function () {
+  while (this.pos < this.input.length) {
+    var ch = this.input.charCodeAt(this.pos);
+    if (ch === 32) {
+      // ' '
+      ++this.pos;
+    } else if (ch === 13) {
+      ++this.pos;
+      var next = this.input.charCodeAt(this.pos);
+      if (next === 10) {
+        ++this.pos;
+      }
+      if (this.options.locations) {
+        ++this.curLine;
+        this.lineStart = this.pos;
+      }
+    } else if (ch === 10 || ch === 8232 || ch === 8233) {
+      ++this.pos;
+      if (this.options.locations) {
+        ++this.curLine;
+        this.lineStart = this.pos;
+      }
+    } else if (ch > 8 && ch < 14) {
+      ++this.pos;
+    } else if (ch === 47) {
+      // '/'
+      var next = this.input.charCodeAt(this.pos + 1);
+      if (next === 42) {
+        // '*'
+        this.skipBlockComment();
+      } else if (next === 47) {
+        // '/'
+        this.skipLineComment(2);
+      } else break;
+    } else if (ch === 160) {
+      // '\xa0'
+      ++this.pos;
+    } else if (ch >= 5760 && nonASCIIwhitespace.test(String.fromCharCode(ch))) {
+      ++this.pos;
+    } else {
+      break;
+    }
+  }
+};
+
+// Called at the end of every token. Sets `end`, `val`, and
+// maintains `context` and `exprAllowed`, and skips the space after
+// the token, so that the next one's `start` will point at the
+// right position.
+
+pp.finishToken = function (type, val) {
+  this.end = this.pos;
+  if (this.options.locations) this.endLoc = this.curPosition();
+  var prevType = this.type;
+  this.type = type;
+  this.value = val;
+
+  this.updateContext(prevType);
+};
+
+// ### Token reading
+
+// This is the function that is called to fetch the next token. It
+// is somewhat obscure, because it works in character codes rather
+// than characters, and because operator parsing has been inlined
+// into it.
+//
+// All in the name of speed.
+//
+pp.readToken_dot = function () {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next >= 48 && next <= 57) return this.readNumber(true);
+  var next2 = this.input.charCodeAt(this.pos + 2);
+  if (this.options.ecmaVersion >= 6 && next === 46 && next2 === 46) {
+    // 46 = dot '.'
+    this.pos += 3;
+    return this.finishToken(tt.ellipsis);
+  } else {
+    ++this.pos;
+    return this.finishToken(tt.dot);
+  }
+};
+
+pp.readToken_slash = function () {
+  // '/'
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (this.exprAllowed) {
+    ++this.pos;return this.readRegexp();
+  }
+  if (next === 61) return this.finishOp(tt.assign, 2);
+  return this.finishOp(tt.slash, 1);
+};
+
+pp.readToken_mult_modulo = function (code) {
+  // '%*'
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === 61) return this.finishOp(tt.assign, 2);
+  return this.finishOp(code === 42 ? tt.star : tt.modulo, 1);
+};
+
+pp.readToken_pipe_amp = function (code) {
+  // '|&'
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === code) return this.finishOp(code === 124 ? tt.logicalOR : tt.logicalAND, 2);
+  if (next === 61) return this.finishOp(tt.assign, 2);
+  return this.finishOp(code === 124 ? tt.bitwiseOR : tt.bitwiseAND, 1);
+};
+
+pp.readToken_caret = function () {
+  // '^'
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === 61) return this.finishOp(tt.assign, 2);
+  return this.finishOp(tt.bitwiseXOR, 1);
+};
+
+pp.readToken_plus_min = function (code) {
+  // '+-'
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === code) {
+    if (next == 45 && this.input.charCodeAt(this.pos + 2) == 62 && lineBreak.test(this.input.slice(this.lastTokEnd, this.pos))) {
+      // A `-->` line comment
+      this.skipLineComment(3);
+      this.skipSpace();
+      return this.nextToken();
+    }
+    return this.finishOp(tt.incDec, 2);
+  }
+  if (next === 61) return this.finishOp(tt.assign, 2);
+  return this.finishOp(tt.plusMin, 1);
+};
+
+pp.readToken_lt_gt = function (code) {
+  // '<>'
+  var next = this.input.charCodeAt(this.pos + 1);
+  var size = 1;
+  if (next === code) {
+    size = code === 62 && this.input.charCodeAt(this.pos + 2) === 62 ? 3 : 2;
+    if (this.input.charCodeAt(this.pos + size) === 61) return this.finishOp(tt.assign, size + 1);
+    return this.finishOp(tt.bitShift, size);
+  }
+  if (next == 33 && code == 60 && this.input.charCodeAt(this.pos + 2) == 45 && this.input.charCodeAt(this.pos + 3) == 45) {
+    if (this.inModule) unexpected();
+    // `<!--`, an XML-style comment that should be interpreted as a line comment
+    this.skipLineComment(4);
+    this.skipSpace();
+    return this.nextToken();
+  }
+  if (next === 61) size = this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2;
+  return this.finishOp(tt.relational, size);
+};
+
+pp.readToken_eq_excl = function (code) {
+  // '=!'
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === 61) return this.finishOp(tt.equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
+  if (code === 61 && next === 62 && this.options.ecmaVersion >= 6) {
+    // '=>'
+    this.pos += 2;
+    return this.finishToken(tt.arrow);
+  }
+  return this.finishOp(code === 61 ? tt.eq : tt.prefix, 1);
+};
+
+pp.getTokenFromCode = function (code) {
+  switch (code) {
+    // The interpretation of a dot depends on whether it is followed
+    // by a digit or another two dots.
+    case 46:
+      // '.'
+      return this.readToken_dot();
+
+    // Punctuation tokens.
+    case 40:
+      ++this.pos;return this.finishToken(tt.parenL);
+    case 41:
+      ++this.pos;return this.finishToken(tt.parenR);
+    case 59:
+      ++this.pos;return this.finishToken(tt.semi);
+    case 44:
+      ++this.pos;return this.finishToken(tt.comma);
+    case 91:
+      ++this.pos;return this.finishToken(tt.bracketL);
+    case 93:
+      ++this.pos;return this.finishToken(tt.bracketR);
+    case 123:
+      ++this.pos;return this.finishToken(tt.braceL);
+    case 125:
+      ++this.pos;return this.finishToken(tt.braceR);
+    case 58:
+      ++this.pos;return this.finishToken(tt.colon);
+    case 63:
+      ++this.pos;return this.finishToken(tt.question);
+
+    case 96:
+      // '`'
+      if (this.options.ecmaVersion < 6) break;
+      ++this.pos;
+      return this.finishToken(tt.backQuote);
+
+    case 48:
+      // '0'
+      var next = this.input.charCodeAt(this.pos + 1);
+      if (next === 120 || next === 88) return this.readRadixNumber(16); // '0x', '0X' - hex number
+      if (this.options.ecmaVersion >= 6) {
+        if (next === 111 || next === 79) return this.readRadixNumber(8); // '0o', '0O' - octal number
+        if (next === 98 || next === 66) return this.readRadixNumber(2); // '0b', '0B' - binary number
+      }
+    // Anything else beginning with a digit is an integer, octal
+    // number, or float.
+    case 49:case 50:case 51:case 52:case 53:case 54:case 55:case 56:case 57:
+      // 1-9
+      return this.readNumber(false);
+
+    // Quotes produce strings.
+    case 34:case 39:
+      // '"', "'"
+      return this.readString(code);
+
+    // Operators are parsed inline in tiny state machines. '=' (61) is
+    // often referred to. `finishOp` simply skips the amount of
+    // characters it is given as second argument, and returns a token
+    // of the type given by its first argument.
+
+    case 47:
+      // '/'
+      return this.readToken_slash();
+
+    case 37:case 42:
+      // '%*'
+      return this.readToken_mult_modulo(code);
+
+    case 124:case 38:
+      // '|&'
+      return this.readToken_pipe_amp(code);
+
+    case 94:
+      // '^'
+      return this.readToken_caret();
+
+    case 43:case 45:
+      // '+-'
+      return this.readToken_plus_min(code);
+
+    case 60:case 62:
+      // '<>'
+      return this.readToken_lt_gt(code);
+
+    case 61:case 33:
+      // '=!'
+      return this.readToken_eq_excl(code);
+
+    case 126:
+      // '~'
+      return this.finishOp(tt.prefix, 1);
+  }
+
+  this.raise(this.pos, "Unexpected character '" + codePointToString(code) + "'");
+};
+
+pp.finishOp = function (type, size) {
+  var str = this.input.slice(this.pos, this.pos + size);
+  this.pos += size;
+  return this.finishToken(type, str);
+};
+
+var regexpUnicodeSupport = false;
+try {
+  new RegExp("￿", "u");regexpUnicodeSupport = true;
+} catch (e) {}
+
+// Parse a regular expression. Some context-awareness is necessary,
+// since a '/' inside a '[]' set does not end the expression.
+
+pp.readRegexp = function () {
+  var escaped = undefined,
+      inClass = undefined,
+      start = this.pos;
+  for (;;) {
+    if (this.pos >= this.input.length) this.raise(start, "Unterminated regular expression");
+    var ch = this.input.charAt(this.pos);
+    if (lineBreak.test(ch)) this.raise(start, "Unterminated regular expression");
+    if (!escaped) {
+      if (ch === "[") inClass = true;else if (ch === "]" && inClass) inClass = false;else if (ch === "/" && !inClass) break;
+      escaped = ch === "\\";
+    } else escaped = false;
+    ++this.pos;
+  }
+  var content = this.input.slice(start, this.pos);
+  ++this.pos;
+  // Need to use `readWord1` because '\uXXXX' sequences are allowed
+  // here (don't ask).
+  var mods = this.readWord1();
+  var tmp = content;
+  if (mods) {
+    var validFlags = /^[gmsiy]*$/;
+    if (this.options.ecmaVersion >= 6) validFlags = /^[gmsiyu]*$/;
+    if (!validFlags.test(mods)) this.raise(start, "Invalid regular expression flag");
+    if (mods.indexOf("u") >= 0 && !regexpUnicodeSupport) {
+      // Replace each astral symbol and every Unicode escape sequence that
+      // possibly represents an astral symbol or a paired surrogate with a
+      // single ASCII symbol to avoid throwing on regular expressions that
+      // are only valid in combination with the `/u` flag.
+      // Note: replacing with the ASCII symbol `x` might cause false
+      // negatives in unlikely scenarios. For example, `[\u{61}-b]` is a
+      // perfectly valid pattern that is equivalent to `[a-b]`, but it would
+      // be replaced by `[x-b]` which throws an error.
+      tmp = tmp.replace(/\\u([a-fA-F0-9]{4})|\\u\{([0-9a-fA-F]+)\}|[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "x");
+    }
+  }
+  // Detect invalid regular expressions.
+  try {
+    new RegExp(tmp);
+  } catch (e) {
+    if (e instanceof SyntaxError) this.raise(start, "Error parsing regular expression: " + e.message);
+    this.raise(e);
+  }
+  // Get a regular expression object for this pattern-flag pair, or `null` in
+  // case the current environment doesn't support the flags it uses.
+  var value = undefined;
+  try {
+    value = new RegExp(content, mods);
+  } catch (err) {
+    value = null;
+  }
+  return this.finishToken(tt.regexp, { pattern: content, flags: mods, value: value });
+};
+
+// Read an integer in the given radix. Return null if zero digits
+// were read, the integer value otherwise. When `len` is given, this
+// will return `null` unless the integer has exactly `len` digits.
+
+pp.readInt = function (radix, len) {
+  var start = this.pos,
+      total = 0;
+  for (var i = 0, e = len == null ? Infinity : len; i < e; ++i) {
+    var code = this.input.charCodeAt(this.pos),
+        val = undefined;
+    if (code >= 97) val = code - 97 + 10; // a
+    else if (code >= 65) val = code - 65 + 10; // A
+    else if (code >= 48 && code <= 57) val = code - 48; // 0-9
+    else val = Infinity;
+    if (val >= radix) break;
+    ++this.pos;
+    total = total * radix + val;
+  }
+  if (this.pos === start || len != null && this.pos - start !== len) return null;
+
+  return total;
+};
+
+pp.readRadixNumber = function (radix) {
+  this.pos += 2; // 0x
+  var val = this.readInt(radix);
+  if (val == null) this.raise(this.start + 2, "Expected number in radix " + radix);
+  if (isIdentifierStart(this.fullCharCodeAtPos())) this.raise(this.pos, "Identifier directly after number");
+  return this.finishToken(tt.num, val);
+};
+
+// Read an integer, octal integer, or floating-point number.
+
+pp.readNumber = function (startsWithDot) {
+  var start = this.pos,
+      isFloat = false,
+      octal = this.input.charCodeAt(this.pos) === 48;
+  if (!startsWithDot && this.readInt(10) === null) this.raise(start, "Invalid number");
+  if (this.input.charCodeAt(this.pos) === 46) {
+    ++this.pos;
+    this.readInt(10);
+    isFloat = true;
+  }
+  var next = this.input.charCodeAt(this.pos);
+  if (next === 69 || next === 101) {
+    // 'eE'
+    next = this.input.charCodeAt(++this.pos);
+    if (next === 43 || next === 45) ++this.pos; // '+-'
+    if (this.readInt(10) === null) this.raise(start, "Invalid number");
+    isFloat = true;
+  }
+  if (isIdentifierStart(this.fullCharCodeAtPos())) this.raise(this.pos, "Identifier directly after number");
+
+  var str = this.input.slice(start, this.pos),
+      val = undefined;
+  if (isFloat) val = parseFloat(str);else if (!octal || str.length === 1) val = parseInt(str, 10);else if (/[89]/.test(str) || this.strict) this.raise(start, "Invalid number");else val = parseInt(str, 8);
+  return this.finishToken(tt.num, val);
+};
+
+// Read a string value, interpreting backslash-escapes.
+
+pp.readCodePoint = function () {
+  var ch = this.input.charCodeAt(this.pos),
+      code = undefined;
+
+  if (ch === 123) {
+    if (this.options.ecmaVersion < 6) this.unexpected();
+    ++this.pos;
+    code = this.readHexChar(this.input.indexOf("}", this.pos) - this.pos);
+    ++this.pos;
+    if (code > 1114111) this.unexpected();
+  } else {
+    code = this.readHexChar(4);
+  }
+  return code;
+};
+
+function codePointToString(code) {
+  // UTF-16 Decoding
+  if (code <= 65535) {
+    return String.fromCharCode(code);
+  }return String.fromCharCode((code - 65536 >> 10) + 55296, (code - 65536 & 1023) + 56320);
+}
+
+pp.readString = function (quote) {
+  var out = "",
+      chunkStart = ++this.pos;
+  for (;;) {
+    if (this.pos >= this.input.length) this.raise(this.start, "Unterminated string constant");
+    var ch = this.input.charCodeAt(this.pos);
+    if (ch === quote) break;
+    if (ch === 92) {
+      // '\'
+      out += this.input.slice(chunkStart, this.pos);
+      out += this.readEscapedChar();
+      chunkStart = this.pos;
+    } else {
+      if (isNewLine(ch)) this.raise(this.start, "Unterminated string constant");
+      ++this.pos;
+    }
+  }
+  out += this.input.slice(chunkStart, this.pos++);
+  return this.finishToken(tt.string, out);
+};
+
+// Reads template string tokens.
+
+pp.readTmplToken = function () {
+  var out = "",
+      chunkStart = this.pos;
+  for (;;) {
+    if (this.pos >= this.input.length) this.raise(this.start, "Unterminated template");
+    var ch = this.input.charCodeAt(this.pos);
+    if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) {
+      // '`', '${'
+      if (this.pos === this.start && this.type === tt.template) {
+        if (ch === 36) {
+          this.pos += 2;
+          return this.finishToken(tt.dollarBraceL);
+        } else {
+          ++this.pos;
+          return this.finishToken(tt.backQuote);
+        }
+      }
+      out += this.input.slice(chunkStart, this.pos);
+      return this.finishToken(tt.template, out);
+    }
+    if (ch === 92) {
+      // '\'
+      out += this.input.slice(chunkStart, this.pos);
+      out += this.readEscapedChar();
+      chunkStart = this.pos;
+    } else if (isNewLine(ch)) {
+      out += this.input.slice(chunkStart, this.pos);
+      ++this.pos;
+      if (ch === 13 && this.input.charCodeAt(this.pos) === 10) {
+        ++this.pos;
+        out += "\n";
+      } else {
+        out += String.fromCharCode(ch);
+      }
+      if (this.options.locations) {
+        ++this.curLine;
+        this.lineStart = this.pos;
+      }
+      chunkStart = this.pos;
+    } else {
+      ++this.pos;
+    }
+  }
+};
+
+// Used to read escaped characters
+
+pp.readEscapedChar = function () {
+  var ch = this.input.charCodeAt(++this.pos);
+  var octal = /^[0-7]+/.exec(this.input.slice(this.pos, this.pos + 3));
+  if (octal) octal = octal[0];
+  while (octal && parseInt(octal, 8) > 255) octal = octal.slice(0, -1);
+  if (octal === "0") octal = null;
+  ++this.pos;
+  if (octal) {
+    if (this.strict) this.raise(this.pos - 2, "Octal literal in strict mode");
+    this.pos += octal.length - 1;
+    return String.fromCharCode(parseInt(octal, 8));
+  } else {
+    switch (ch) {
+      case 110:
+        return "\n"; // 'n' -> '\n'
+      case 114:
+        return "\r"; // 'r' -> '\r'
+      case 120:
+        return String.fromCharCode(this.readHexChar(2)); // 'x'
+      case 117:
+        return codePointToString(this.readCodePoint()); // 'u'
+      case 116:
+        return "\t"; // 't' -> '\t'
+      case 98:
+        return "\b"; // 'b' -> '\b'
+      case 118:
+        return "\u000b"; // 'v' -> '\u000b'
+      case 102:
+        return "\f"; // 'f' -> '\f'
+      case 48:
+        return "\u0000"; // 0 -> '\0'
+      case 13:
+        if (this.input.charCodeAt(this.pos) === 10) ++this.pos; // '\r\n'
+      case 10:
+        // ' \n'
+        if (this.options.locations) {
+          this.lineStart = this.pos;++this.curLine;
+        }
+        return "";
+      default:
+        return String.fromCharCode(ch);
+    }
+  }
+};
+
+// Used to read character escape sequences ('\x', '\u', '\U').
+
+pp.readHexChar = function (len) {
+  var n = this.readInt(16, len);
+  if (n === null) this.raise(this.start, "Bad character escape sequence");
+  return n;
+};
+
+// Used to signal to callers of `readWord1` whether the word
+// contained any escape sequences. This is needed because words with
+// escape sequences must not be interpreted as keywords.
+
+var containsEsc;
+
+// Read an identifier, and return it as a string. Sets `containsEsc`
+// to whether the word contained a '\u' escape.
+//
+// Incrementally adds only escaped chars, adding other chunks as-is
+// as a micro-optimization.
+
+pp.readWord1 = function () {
+  containsEsc = false;
+  var word = "",
+      first = true,
+      chunkStart = this.pos;
+  var astral = this.options.ecmaVersion >= 6;
+  while (this.pos < this.input.length) {
+    var ch = this.fullCharCodeAtPos();
+    if (isIdentifierChar(ch, astral)) {
+      this.pos += ch <= 65535 ? 1 : 2;
+    } else if (ch === 92) {
+      // "\"
+      containsEsc = true;
+      word += this.input.slice(chunkStart, this.pos);
+      var escStart = this.pos;
+      if (this.input.charCodeAt(++this.pos) != 117) // "u"
+        this.raise(this.pos, "Expecting Unicode escape sequence \\uXXXX");
+      ++this.pos;
+      var esc = this.readCodePoint();
+      if (!(first ? isIdentifierStart : isIdentifierChar)(esc, astral)) this.raise(escStart, "Invalid Unicode escape");
+      word += codePointToString(esc);
+      chunkStart = this.pos;
+    } else {
+      break;
+    }
+    first = false;
+  }
+  return word + this.input.slice(chunkStart, this.pos);
+};
+
+// Read an identifier or keyword token. Will check for reserved
+// words when necessary.
+
+pp.readWord = function () {
+  var word = this.readWord1();
+  var type = tt.name;
+  if ((this.options.ecmaVersion >= 6 || !containsEsc) && this.isKeyword(word)) type = keywordTypes[word];
+  return this.finishToken(type, word);
+};
+
+},{"./identifier":3,"./location":4,"./state":9,"./tokentype":13,"./whitespace":15}],13:[function(require,module,exports){
+"use strict";
+
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+// ## Token types
+
+// The assignment of fine-grained, information-carrying type objects
+// allows the tokenizer to store the information it has about a
+// token in a way that is very cheap for the parser to look up.
+
+// All token type variables start with an underscore, to make them
+// easy to recognize.
+
+// The `beforeExpr` property is used to disambiguate between regular
+// expressions and divisions. It is set on all token types that can
+// be followed by an expression (thus, a slash after them would be a
+// regular expression).
+//
+// `isLoop` marks a keyword as starting a loop, which is important
+// to know when parsing a label, in order to allow or disallow
+// continue jumps to that label.
+
+var TokenType = exports.TokenType = function TokenType(label) {
+  var conf = arguments[1] === undefined ? {} : arguments[1];
+
+  _classCallCheck(this, TokenType);
+
+  this.label = label;
+  this.keyword = conf.keyword;
+  this.beforeExpr = !!conf.beforeExpr;
+  this.startsExpr = !!conf.startsExpr;
+  this.isLoop = !!conf.isLoop;
+  this.isAssign = !!conf.isAssign;
+  this.prefix = !!conf.prefix;
+  this.postfix = !!conf.postfix;
+  this.binop = conf.binop || null;
+  this.updateContext = null;
+};
+
+function binop(name, prec) {
+  return new TokenType(name, { beforeExpr: true, binop: prec });
+}
+var beforeExpr = { beforeExpr: true },
+    startsExpr = { startsExpr: true };
+
+var types = {
+  num: new TokenType("num", startsExpr),
+  regexp: new TokenType("regexp", startsExpr),
+  string: new TokenType("string", startsExpr),
+  name: new TokenType("name", startsExpr),
+  eof: new TokenType("eof"),
+
+  // Punctuation token types.
+  bracketL: new TokenType("[", { beforeExpr: true, startsExpr: true }),
+  bracketR: new TokenType("]"),
+  braceL: new TokenType("{", { beforeExpr: true, startsExpr: true }),
+  braceR: new TokenType("}"),
+  parenL: new TokenType("(", { beforeExpr: true, startsExpr: true }),
+  parenR: new TokenType(")"),
+  comma: new TokenType(",", beforeExpr),
+  semi: new TokenType(";", beforeExpr),
+  colon: new TokenType(":", beforeExpr),
+  dot: new TokenType("."),
+  question: new TokenType("?", beforeExpr),
+  arrow: new TokenType("=>", beforeExpr),
+  template: new TokenType("template"),
+  ellipsis: new TokenType("...", beforeExpr),
+  backQuote: new TokenType("`", startsExpr),
+  dollarBraceL: new TokenType("${", { beforeExpr: true, startsExpr: true }),
+
+  // Operators. These carry several kinds of properties to help the
+  // parser use them properly (the presence of these properties is
+  // what categorizes them as operators).
+  //
+  // `binop`, when present, specifies that this operator is a binary
+  // operator, and will refer to its precedence.
+  //
+  // `prefix` and `postfix` mark the operator as a prefix or postfix
+  // unary operator.
+  //
+  // `isAssign` marks all of `=`, `+=`, `-=` etcetera, which act as
+  // binary operators with a very low precedence, that should result
+  // in AssignmentExpression nodes.
+
+  eq: new TokenType("=", { beforeExpr: true, isAssign: true }),
+  assign: new TokenType("_=", { beforeExpr: true, isAssign: true }),
+  incDec: new TokenType("++/--", { prefix: true, postfix: true, startsExpr: true }),
+  prefix: new TokenType("prefix", { beforeExpr: true, prefix: true, startsExpr: true }),
+  logicalOR: binop("||", 1),
+  logicalAND: binop("&&", 2),
+  bitwiseOR: binop("|", 3),
+  bitwiseXOR: binop("^", 4),
+  bitwiseAND: binop("&", 5),
+  equality: binop("==/!=", 6),
+  relational: binop("</>", 7),
+  bitShift: binop("<</>>", 8),
+  plusMin: new TokenType("+/-", { beforeExpr: true, binop: 9, prefix: true, startsExpr: true }),
+  modulo: binop("%", 10),
+  star: binop("*", 10),
+  slash: binop("/", 10)
+};
+
+exports.types = types;
+// Map keyword names to token types.
+
+var keywords = {};
+
+exports.keywords = keywords;
+// Succinct definitions of keyword token types
+function kw(name) {
+  var options = arguments[1] === undefined ? {} : arguments[1];
+
+  options.keyword = name;
+  keywords[name] = types["_" + name] = new TokenType(name, options);
+}
+
+kw("break");
+kw("case", beforeExpr);
+kw("catch");
+kw("continue");
+kw("debugger");
+kw("default");
+kw("do", { isLoop: true });
+kw("else", beforeExpr);
+kw("finally");
+kw("for", { isLoop: true });
+kw("function");
+kw("if");
+kw("return", beforeExpr);
+kw("switch");
+kw("throw", beforeExpr);
+kw("try");
+kw("var");
+kw("let");
+kw("const");
+kw("while", { isLoop: true });
+kw("with");
+kw("new", { beforeExpr: true, startsExpr: true });
+kw("this", startsExpr);
+kw("super", startsExpr);
+kw("class");
+kw("extends", beforeExpr);
+kw("export");
+kw("import");
+kw("yield", { beforeExpr: true, startsExpr: true });
+kw("null", startsExpr);
+kw("true", startsExpr);
+kw("false", startsExpr);
+kw("in", { beforeExpr: true, binop: 7 });
+kw("instanceof", { beforeExpr: true, binop: 7 });
+kw("typeof", { beforeExpr: true, prefix: true, startsExpr: true });
+kw("void", { beforeExpr: true, prefix: true, startsExpr: true });
+kw("delete", { beforeExpr: true, prefix: true, startsExpr: true });
+
+},{}],14:[function(require,module,exports){
+"use strict";
+
+exports.isArray = isArray;
+
+// Checks if an object has a property.
+
+exports.has = has;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+function isArray(obj) {
+  return Object.prototype.toString.call(obj) === "[object Array]";
+}
+
+function has(obj, propName) {
+  return Object.prototype.hasOwnProperty.call(obj, propName);
+}
+
+},{}],15:[function(require,module,exports){
+"use strict";
+
+exports.isNewLine = isNewLine;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+// Matches a whole line break (where CRLF is considered a single
+// line break). Used to count lines.
+
+var lineBreak = /\r\n?|\n|\u2028|\u2029/;
+exports.lineBreak = lineBreak;
+var lineBreakG = new RegExp(lineBreak.source, "g");
+
+exports.lineBreakG = lineBreakG;
+
+function isNewLine(code) {
+  return code === 10 || code === 13 || code === 8232 || code == 8233;
+}
+
+var nonASCIIwhitespace = /[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
+exports.nonASCIIwhitespace = nonASCIIwhitespace;
+
+},{}]},{},[1])(1)
+});

--- a/editor/js/libs/acorn/acorn_loose.js
+++ b/editor/js/libs/acorn/acorn_loose.js
@@ -1,0 +1,1299 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}(g.acorn || (g.acorn = {})).loose = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+
+exports.parse_dammit = parse_dammit;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+// Acorn: Loose parser
+//
+// This module provides an alternative parser (`parse_dammit`) that
+// exposes that same interface as `parse`, but will try to parse
+// anything as JavaScript, repairing syntax error the best it can.
+// There are circumstances in which it will raise an error and give
+// up, but they are very rare. The resulting AST will be a mostly
+// valid JavaScript AST (as per the [Mozilla parser API][api], except
+// that:
+//
+// - Return outside functions is allowed
+//
+// - Label consistency (no conflicts, break only to existing labels)
+//   is not enforced.
+//
+// - Bogus Identifier nodes with a name of `"✖"` are inserted whenever
+//   the parser got too confused to return anything meaningful.
+//
+// [api]: https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API
+//
+// The expected use for this is to *first* try `acorn.parse`, and only
+// if that fails switch to `parse_dammit`. The loose parser might
+// parse badly indented code incorrectly, so **don't** use it as
+// your default parser.
+//
+// Quite a lot of acorn.js is duplicated here. The alternative was to
+// add a *lot* of extra cruft to that file, making it less readable
+// and slower. Copying and editing the code allowed me to make
+// invasive changes and simplifications without creating a complicated
+// tangle.
+
+var acorn = _interopRequireWildcard(require(".."));
+
+var _state = require("./state");
+
+var LooseParser = _state.LooseParser;
+
+require("./tokenize");
+
+require("./parseutil");
+
+require("./statement");
+
+require("./expression");
+
+exports.LooseParser = _state.LooseParser;
+
+acorn.defaultOptions.tabSize = 4;
+
+function parse_dammit(input, options) {
+  var p = new LooseParser(input, options);
+  p.next();
+  return p.parseTopLevel();
+}
+
+acorn.parse_dammit = parse_dammit;
+acorn.LooseParser = LooseParser;
+
+},{"..":2,"./expression":3,"./parseutil":4,"./state":5,"./statement":6,"./tokenize":7}],2:[function(require,module,exports){
+"use strict";
+
+module.exports = typeof window != "undefined" ? window.acorn : require(("suppress", "./acorn"));
+
+},{}],3:[function(require,module,exports){
+"use strict";
+
+var LooseParser = require("./state").LooseParser;
+
+var isDummy = require("./parseutil").isDummy;
+
+var tt = require("..").tokTypes;
+
+var lp = LooseParser.prototype;
+
+lp.checkLVal = function (expr) {
+  if (!expr) return expr;
+  switch (expr.type) {
+    case "Identifier":
+    case "MemberExpression":
+    case "ObjectPattern":
+    case "ArrayPattern":
+    case "RestElement":
+    case "AssignmentPattern":
+      return expr;
+
+    default:
+      return this.dummyIdent();
+  }
+};
+
+lp.parseExpression = function (noIn) {
+  var start = this.storeCurrentPos();
+  var expr = this.parseMaybeAssign(noIn);
+  if (this.tok.type === tt.comma) {
+    var node = this.startNodeAt(start);
+    node.expressions = [expr];
+    while (this.eat(tt.comma)) node.expressions.push(this.parseMaybeAssign(noIn));
+    return this.finishNode(node, "SequenceExpression");
+  }
+  return expr;
+};
+
+lp.parseParenExpression = function () {
+  this.pushCx();
+  this.expect(tt.parenL);
+  var val = this.parseExpression();
+  this.popCx();
+  this.expect(tt.parenR);
+  return val;
+};
+
+lp.parseMaybeAssign = function (noIn) {
+  var start = this.storeCurrentPos();
+  var left = this.parseMaybeConditional(noIn);
+  if (this.tok.type.isAssign) {
+    var node = this.startNodeAt(start);
+    node.operator = this.tok.value;
+    node.left = this.tok.type === tt.eq ? this.toAssignable(left) : this.checkLVal(left);
+    this.next();
+    node.right = this.parseMaybeAssign(noIn);
+    return this.finishNode(node, "AssignmentExpression");
+  }
+  return left;
+};
+
+lp.parseMaybeConditional = function (noIn) {
+  var start = this.storeCurrentPos();
+  var expr = this.parseExprOps(noIn);
+  if (this.eat(tt.question)) {
+    var node = this.startNodeAt(start);
+    node.test = expr;
+    node.consequent = this.parseMaybeAssign();
+    node.alternate = this.expect(tt.colon) ? this.parseMaybeAssign(noIn) : this.dummyIdent();
+    return this.finishNode(node, "ConditionalExpression");
+  }
+  return expr;
+};
+
+lp.parseExprOps = function (noIn) {
+  var start = this.storeCurrentPos();
+  var indent = this.curIndent,
+      line = this.curLineStart;
+  return this.parseExprOp(this.parseMaybeUnary(noIn), start, -1, noIn, indent, line);
+};
+
+lp.parseExprOp = function (left, start, minPrec, noIn, indent, line) {
+  if (this.curLineStart != line && this.curIndent < indent && this.tokenStartsLine()) return left;
+  var prec = this.tok.type.binop;
+  if (prec != null && (!noIn || this.tok.type !== tt._in)) {
+    if (prec > minPrec) {
+      var node = this.startNodeAt(start);
+      node.left = left;
+      node.operator = this.tok.value;
+      this.next();
+      if (this.curLineStart != line && this.curIndent < indent && this.tokenStartsLine()) {
+        node.right = this.dummyIdent();
+      } else {
+        var rightStart = this.storeCurrentPos();
+        node.right = this.parseExprOp(this.parseMaybeUnary(noIn), rightStart, prec, noIn, indent, line);
+      }
+      this.finishNode(node, /&&|\|\|/.test(node.operator) ? "LogicalExpression" : "BinaryExpression");
+      return this.parseExprOp(node, start, minPrec, noIn, indent, line);
+    }
+  }
+  return left;
+};
+
+lp.parseMaybeUnary = function (noIn) {
+  if (this.tok.type.prefix) {
+    var node = this.startNode(),
+        update = this.tok.type === tt.incDec;
+    node.operator = this.tok.value;
+    node.prefix = true;
+    this.next();
+    node.argument = this.parseMaybeUnary(noIn);
+    if (update) node.argument = this.checkLVal(node.argument);
+    return this.finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
+  } else if (this.tok.type === tt.ellipsis) {
+    var node = this.startNode();
+    this.next();
+    node.argument = this.parseMaybeUnary(noIn);
+    return this.finishNode(node, "SpreadElement");
+  }
+  var start = this.storeCurrentPos();
+  var expr = this.parseExprSubscripts();
+  while (this.tok.type.postfix && !this.canInsertSemicolon()) {
+    var node = this.startNodeAt(start);
+    node.operator = this.tok.value;
+    node.prefix = false;
+    node.argument = this.checkLVal(expr);
+    this.next();
+    expr = this.finishNode(node, "UpdateExpression");
+  }
+  return expr;
+};
+
+lp.parseExprSubscripts = function () {
+  var start = this.storeCurrentPos();
+  return this.parseSubscripts(this.parseExprAtom(), start, false, this.curIndent, this.curLineStart);
+};
+
+lp.parseSubscripts = function (base, start, noCalls, startIndent, line) {
+  for (;;) {
+    if (this.curLineStart != line && this.curIndent <= startIndent && this.tokenStartsLine()) {
+      if (this.tok.type == tt.dot && this.curIndent == startIndent) --startIndent;else return base;
+    }
+
+    if (this.eat(tt.dot)) {
+      var node = this.startNodeAt(start);
+      node.object = base;
+      if (this.curLineStart != line && this.curIndent <= startIndent && this.tokenStartsLine()) node.property = this.dummyIdent();else node.property = this.parsePropertyAccessor() || this.dummyIdent();
+      node.computed = false;
+      base = this.finishNode(node, "MemberExpression");
+    } else if (this.tok.type == tt.bracketL) {
+      this.pushCx();
+      this.next();
+      var node = this.startNodeAt(start);
+      node.object = base;
+      node.property = this.parseExpression();
+      node.computed = true;
+      this.popCx();
+      this.expect(tt.bracketR);
+      base = this.finishNode(node, "MemberExpression");
+    } else if (!noCalls && this.tok.type == tt.parenL) {
+      this.pushCx();
+      var node = this.startNodeAt(start);
+      node.callee = base;
+      node.arguments = this.parseExprList(tt.parenR);
+      base = this.finishNode(node, "CallExpression");
+    } else if (this.tok.type == tt.backQuote) {
+      var node = this.startNodeAt(start);
+      node.tag = base;
+      node.quasi = this.parseTemplate();
+      base = this.finishNode(node, "TaggedTemplateExpression");
+    } else {
+      return base;
+    }
+  }
+};
+
+lp.parseExprAtom = function () {
+  var node = undefined;
+  switch (this.tok.type) {
+    case tt._this:
+    case tt._super:
+      var type = this.tok.type === tt._this ? "ThisExpression" : "Super";
+      node = this.startNode();
+      this.next();
+      return this.finishNode(node, type);
+
+    case tt.name:
+      var start = this.storeCurrentPos();
+      var id = this.parseIdent();
+      return this.eat(tt.arrow) ? this.parseArrowExpression(this.startNodeAt(start), [id]) : id;
+
+    case tt.regexp:
+      node = this.startNode();
+      var val = this.tok.value;
+      node.regex = { pattern: val.pattern, flags: val.flags };
+      node.value = val.value;
+      node.raw = this.input.slice(this.tok.start, this.tok.end);
+      this.next();
+      return this.finishNode(node, "Literal");
+
+    case tt.num:case tt.string:
+      node = this.startNode();
+      node.value = this.tok.value;
+      node.raw = this.input.slice(this.tok.start, this.tok.end);
+      this.next();
+      return this.finishNode(node, "Literal");
+
+    case tt._null:case tt._true:case tt._false:
+      node = this.startNode();
+      node.value = this.tok.type === tt._null ? null : this.tok.type === tt._true;
+      node.raw = this.tok.type.keyword;
+      this.next();
+      return this.finishNode(node, "Literal");
+
+    case tt.parenL:
+      var parenStart = this.storeCurrentPos();
+      this.next();
+      var inner = this.parseExpression();
+      this.expect(tt.parenR);
+      if (this.eat(tt.arrow)) {
+        return this.parseArrowExpression(this.startNodeAt(parenStart), inner.expressions || (isDummy(inner) ? [] : [inner]));
+      }
+      if (this.options.preserveParens) {
+        var par = this.startNodeAt(parenStart);
+        par.expression = inner;
+        inner = this.finishNode(par, "ParenthesizedExpression");
+      }
+      return inner;
+
+    case tt.bracketL:
+      node = this.startNode();
+      this.pushCx();
+      node.elements = this.parseExprList(tt.bracketR, true);
+      return this.finishNode(node, "ArrayExpression");
+
+    case tt.braceL:
+      return this.parseObj();
+
+    case tt._class:
+      return this.parseClass();
+
+    case tt._function:
+      node = this.startNode();
+      this.next();
+      return this.parseFunction(node, false);
+
+    case tt._new:
+      return this.parseNew();
+
+    case tt._yield:
+      node = this.startNode();
+      this.next();
+      if (this.semicolon() || this.canInsertSemicolon() || this.tok.type != tt.star && !this.tok.type.startsExpr) {
+        node.delegate = false;
+        node.argument = null;
+      } else {
+        node.delegate = this.eat(tt.star);
+        node.argument = this.parseMaybeAssign();
+      }
+      return this.finishNode(node, "YieldExpression");
+
+    case tt.backQuote:
+      return this.parseTemplate();
+
+    default:
+      return this.dummyIdent();
+  }
+};
+
+lp.parseNew = function () {
+  var node = this.startNode(),
+      startIndent = this.curIndent,
+      line = this.curLineStart;
+  var meta = this.parseIdent(true);
+  if (this.options.ecmaVersion >= 6 && this.eat(tt.dot)) {
+    node.meta = meta;
+    node.property = this.parseIdent(true);
+    return this.finishNode(node, "MetaProperty");
+  }
+  var start = this.storeCurrentPos();
+  node.callee = this.parseSubscripts(this.parseExprAtom(), start, true, startIndent, line);
+  if (this.tok.type == tt.parenL) {
+    this.pushCx();
+    node.arguments = this.parseExprList(tt.parenR);
+  } else {
+    node.arguments = [];
+  }
+  return this.finishNode(node, "NewExpression");
+};
+
+lp.parseTemplateElement = function () {
+  var elem = this.startNode();
+  elem.value = {
+    raw: this.input.slice(this.tok.start, this.tok.end),
+    cooked: this.tok.value
+  };
+  this.next();
+  elem.tail = this.tok.type === tt.backQuote;
+  return this.finishNode(elem, "TemplateElement");
+};
+
+lp.parseTemplate = function () {
+  var node = this.startNode();
+  this.next();
+  node.expressions = [];
+  var curElt = this.parseTemplateElement();
+  node.quasis = [curElt];
+  while (!curElt.tail) {
+    this.next();
+    node.expressions.push(this.parseExpression());
+    if (this.expect(tt.braceR)) {
+      curElt = this.parseTemplateElement();
+    } else {
+      curElt = this.startNode();
+      curElt.value = { cooked: "", raw: "" };
+      curElt.tail = true;
+    }
+    node.quasis.push(curElt);
+  }
+  this.expect(tt.backQuote);
+  return this.finishNode(node, "TemplateLiteral");
+};
+
+lp.parseObj = function () {
+  var node = this.startNode();
+  node.properties = [];
+  this.pushCx();
+  var indent = this.curIndent + 1,
+      line = this.curLineStart;
+  this.eat(tt.braceL);
+  if (this.curIndent + 1 < indent) {
+    indent = this.curIndent;line = this.curLineStart;
+  }
+  while (!this.closes(tt.braceR, indent, line)) {
+    var prop = this.startNode(),
+        isGenerator = undefined,
+        start = undefined;
+    if (this.options.ecmaVersion >= 6) {
+      start = this.storeCurrentPos();
+      prop.method = false;
+      prop.shorthand = false;
+      isGenerator = this.eat(tt.star);
+    }
+    this.parsePropertyName(prop);
+    if (isDummy(prop.key)) {
+      if (isDummy(this.parseMaybeAssign())) this.next();this.eat(tt.comma);continue;
+    }
+    if (this.eat(tt.colon)) {
+      prop.kind = "init";
+      prop.value = this.parseMaybeAssign();
+    } else if (this.options.ecmaVersion >= 6 && (this.tok.type === tt.parenL || this.tok.type === tt.braceL)) {
+      prop.kind = "init";
+      prop.method = true;
+      prop.value = this.parseMethod(isGenerator);
+    } else if (this.options.ecmaVersion >= 5 && prop.key.type === "Identifier" && !prop.computed && (prop.key.name === "get" || prop.key.name === "set") && (this.tok.type != tt.comma && this.tok.type != tt.braceR)) {
+      prop.kind = prop.key.name;
+      this.parsePropertyName(prop);
+      prop.value = this.parseMethod(false);
+    } else {
+      prop.kind = "init";
+      if (this.options.ecmaVersion >= 6) {
+        if (this.eat(tt.eq)) {
+          var assign = this.startNodeAt(start);
+          assign.operator = "=";
+          assign.left = prop.key;
+          assign.right = this.parseMaybeAssign();
+          prop.value = this.finishNode(assign, "AssignmentExpression");
+        } else {
+          prop.value = prop.key;
+        }
+      } else {
+        prop.value = this.dummyIdent();
+      }
+      prop.shorthand = true;
+    }
+    node.properties.push(this.finishNode(prop, "Property"));
+    this.eat(tt.comma);
+  }
+  this.popCx();
+  if (!this.eat(tt.braceR)) {
+    // If there is no closing brace, make the node span to the start
+    // of the next token (this is useful for Tern)
+    this.last.end = this.tok.start;
+    if (this.options.locations) this.last.loc.end = this.tok.loc.start;
+  }
+  return this.finishNode(node, "ObjectExpression");
+};
+
+lp.parsePropertyName = function (prop) {
+  if (this.options.ecmaVersion >= 6) {
+    if (this.eat(tt.bracketL)) {
+      prop.computed = true;
+      prop.key = this.parseExpression();
+      this.expect(tt.bracketR);
+      return;
+    } else {
+      prop.computed = false;
+    }
+  }
+  var key = this.tok.type === tt.num || this.tok.type === tt.string ? this.parseExprAtom() : this.parseIdent();
+  prop.key = key || this.dummyIdent();
+};
+
+lp.parsePropertyAccessor = function () {
+  if (this.tok.type === tt.name || this.tok.type.keyword) return this.parseIdent();
+};
+
+lp.parseIdent = function () {
+  var name = this.tok.type === tt.name ? this.tok.value : this.tok.type.keyword;
+  if (!name) return this.dummyIdent();
+  var node = this.startNode();
+  this.next();
+  node.name = name;
+  return this.finishNode(node, "Identifier");
+};
+
+lp.initFunction = function (node) {
+  node.id = null;
+  node.params = [];
+  if (this.options.ecmaVersion >= 6) {
+    node.generator = false;
+    node.expression = false;
+  }
+};
+
+// Convert existing expression atom to assignable pattern
+// if possible.
+
+lp.toAssignable = function (node) {
+  if (this.options.ecmaVersion >= 6 && node) {
+    switch (node.type) {
+      case "ObjectExpression":
+        node.type = "ObjectPattern";
+        var props = node.properties;
+        for (var i = 0; i < props.length; i++) {
+          this.toAssignable(props[i].value);
+        }break;
+
+      case "ArrayExpression":
+        node.type = "ArrayPattern";
+        this.toAssignableList(node.elements);
+        break;
+
+      case "SpreadElement":
+        node.type = "RestElement";
+        node.argument = this.toAssignable(node.argument);
+        break;
+
+      case "AssignmentExpression":
+        node.type = "AssignmentPattern";
+        break;
+    }
+  }
+  return this.checkLVal(node);
+};
+
+lp.toAssignableList = function (exprList) {
+  for (var i = 0; i < exprList.length; i++) {
+    this.toAssignable(exprList[i]);
+  }return exprList;
+};
+
+lp.parseFunctionParams = function (params) {
+  this.pushCx();
+  params = this.parseExprList(tt.parenR);
+  return this.toAssignableList(params);
+};
+
+lp.parseMethod = function (isGenerator) {
+  var node = this.startNode();
+  this.initFunction(node);
+  node.params = this.parseFunctionParams();
+  node.generator = isGenerator || false;
+  node.expression = this.options.ecmaVersion >= 6 && this.tok.type !== tt.braceL;
+  node.body = node.expression ? this.parseMaybeAssign() : this.parseBlock();
+  return this.finishNode(node, "FunctionExpression");
+};
+
+lp.parseArrowExpression = function (node, params) {
+  this.initFunction(node);
+  node.params = this.toAssignableList(params);
+  node.expression = this.tok.type !== tt.braceL;
+  node.body = node.expression ? this.parseMaybeAssign() : this.parseBlock();
+  return this.finishNode(node, "ArrowFunctionExpression");
+};
+
+lp.parseExprList = function (close, allowEmpty) {
+  var indent = this.curIndent,
+      line = this.curLineStart,
+      elts = [];
+  this.next(); // Opening bracket
+  while (!this.closes(close, indent + 1, line)) {
+    if (this.eat(tt.comma)) {
+      elts.push(allowEmpty ? null : this.dummyIdent());
+      continue;
+    }
+    var elt = this.parseMaybeAssign();
+    if (isDummy(elt)) {
+      if (this.closes(close, indent, line)) break;
+      this.next();
+    } else {
+      elts.push(elt);
+    }
+    this.eat(tt.comma);
+  }
+  this.popCx();
+  if (!this.eat(close)) {
+    // If there is no closing brace, make the node span to the start
+    // of the next token (this is useful for Tern)
+    this.last.end = this.tok.start;
+    if (this.options.locations) this.last.loc.end = this.tok.loc.start;
+  }
+  return elts;
+};
+
+},{"..":2,"./parseutil":4,"./state":5}],4:[function(require,module,exports){
+"use strict";
+
+exports.isDummy = isDummy;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var LooseParser = require("./state").LooseParser;
+
+var _ = require("..");
+
+var Node = _.Node;
+var SourceLocation = _.SourceLocation;
+var lineBreak = _.lineBreak;
+var isNewLine = _.isNewLine;
+var tt = _.tokTypes;
+
+var lp = LooseParser.prototype;
+
+lp.startNode = function () {
+  var node = new Node();
+  node.start = this.tok.start;
+  if (this.options.locations) node.loc = new SourceLocation(this.toks, this.tok.loc.start);
+  if (this.options.directSourceFile) node.sourceFile = this.options.directSourceFile;
+  if (this.options.ranges) node.range = [this.tok.start, 0];
+  return node;
+};
+
+lp.storeCurrentPos = function () {
+  return this.options.locations ? [this.tok.start, this.tok.loc.start] : this.tok.start;
+};
+
+lp.startNodeAt = function (pos) {
+  var node = new Node();
+  if (this.options.locations) {
+    node.start = pos[0];
+    node.loc = new SourceLocation(this.toks, pos[1]);
+    pos = pos[0];
+  } else {
+    node.start = pos;
+  }
+  if (this.options.directSourceFile) node.sourceFile = this.options.directSourceFile;
+  if (this.options.ranges) node.range = [pos, 0];
+  return node;
+};
+
+lp.finishNode = function (node, type) {
+  node.type = type;
+  node.end = this.last.end;
+  if (this.options.locations) node.loc.end = this.last.loc.end;
+  if (this.options.ranges) node.range[1] = this.last.end;
+  return node;
+};
+
+lp.dummyIdent = function () {
+  var dummy = this.startNode();
+  dummy.name = "✖";
+  return this.finishNode(dummy, "Identifier");
+};
+
+function isDummy(node) {
+  return node.name == "✖";
+}
+
+lp.eat = function (type) {
+  if (this.tok.type === type) {
+    this.next();
+    return true;
+  } else {
+    return false;
+  }
+};
+
+lp.isContextual = function (name) {
+  return this.tok.type === tt.name && this.tok.value === name;
+};
+
+lp.eatContextual = function (name) {
+  return this.tok.value === name && this.eat(tt.name);
+};
+
+lp.canInsertSemicolon = function () {
+  return this.tok.type === tt.eof || this.tok.type === tt.braceR || lineBreak.test(this.input.slice(this.last.end, this.tok.start));
+};
+
+lp.semicolon = function () {
+  return this.eat(tt.semi);
+};
+
+lp.expect = function (type) {
+  if (this.eat(type)) return true;
+  for (var i = 1; i <= 2; i++) {
+    if (this.lookAhead(i).type == type) {
+      for (var j = 0; j < i; j++) {
+        this.next();
+      }return true;
+    }
+  }
+};
+
+lp.pushCx = function () {
+  this.context.push(this.curIndent);
+};
+lp.popCx = function () {
+  this.curIndent = this.context.pop();
+};
+
+lp.lineEnd = function (pos) {
+  while (pos < this.input.length && !isNewLine(this.input.charCodeAt(pos))) ++pos;
+  return pos;
+};
+
+lp.indentationAfter = function (pos) {
+  for (var count = 0;; ++pos) {
+    var ch = this.input.charCodeAt(pos);
+    if (ch === 32) ++count;else if (ch === 9) count += this.options.tabSize;else return count;
+  }
+};
+
+lp.closes = function (closeTok, indent, line, blockHeuristic) {
+  if (this.tok.type === closeTok || this.tok.type === tt.eof) return true;
+  return line != this.curLineStart && this.curIndent < indent && this.tokenStartsLine() && (!blockHeuristic || this.nextLineStart >= this.input.length || this.indentationAfter(this.nextLineStart) < indent);
+};
+
+lp.tokenStartsLine = function () {
+  for (var p = this.tok.start - 1; p >= this.curLineStart; --p) {
+    var ch = this.input.charCodeAt(p);
+    if (ch !== 9 && ch !== 32) return false;
+  }
+  return true;
+};
+
+},{"..":2,"./state":5}],5:[function(require,module,exports){
+"use strict";
+
+exports.LooseParser = LooseParser;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _ = require("..");
+
+var tokenizer = _.tokenizer;
+var SourceLocation = _.SourceLocation;
+var tt = _.tokTypes;
+
+function LooseParser(input, options) {
+  this.toks = tokenizer(input, options);
+  this.options = this.toks.options;
+  this.input = this.toks.input;
+  this.tok = this.last = { type: tt.eof, start: 0, end: 0 };
+  if (this.options.locations) {
+    var here = this.toks.curPosition();
+    this.tok.loc = new SourceLocation(this.toks, here, here);
+  }
+  this.ahead = []; // Tokens ahead
+  this.context = []; // Indentation contexted
+  this.curIndent = 0;
+  this.curLineStart = 0;
+  this.nextLineStart = this.lineEnd(this.curLineStart) + 1;
+}
+
+},{"..":2}],6:[function(require,module,exports){
+"use strict";
+
+var LooseParser = require("./state").LooseParser;
+
+var isDummy = require("./parseutil").isDummy;
+
+var _ = require("..");
+
+var getLineInfo = _.getLineInfo;
+var tt = _.tokTypes;
+
+var lp = LooseParser.prototype;
+
+lp.parseTopLevel = function () {
+  var node = this.startNodeAt(this.options.locations ? [0, getLineInfo(this.input, 0)] : 0);
+  node.body = [];
+  while (this.tok.type !== tt.eof) node.body.push(this.parseStatement());
+  this.last = this.tok;
+  if (this.options.ecmaVersion >= 6) {
+    node.sourceType = this.options.sourceType;
+  }
+  return this.finishNode(node, "Program");
+};
+
+lp.parseStatement = function () {
+  var starttype = this.tok.type,
+      node = this.startNode();
+
+  switch (starttype) {
+    case tt._break:case tt._continue:
+      this.next();
+      var isBreak = starttype === tt._break;
+      if (this.semicolon() || this.canInsertSemicolon()) {
+        node.label = null;
+      } else {
+        node.label = this.tok.type === tt.name ? this.parseIdent() : null;
+        this.semicolon();
+      }
+      return this.finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
+
+    case tt._debugger:
+      this.next();
+      this.semicolon();
+      return this.finishNode(node, "DebuggerStatement");
+
+    case tt._do:
+      this.next();
+      node.body = this.parseStatement();
+      node.test = this.eat(tt._while) ? this.parseParenExpression() : this.dummyIdent();
+      this.semicolon();
+      return this.finishNode(node, "DoWhileStatement");
+
+    case tt._for:
+      this.next();
+      this.pushCx();
+      this.expect(tt.parenL);
+      if (this.tok.type === tt.semi) return this.parseFor(node, null);
+      if (this.tok.type === tt._var || this.tok.type === tt._let || this.tok.type === tt._const) {
+        var _init = this.parseVar(true);
+        if (_init.declarations.length === 1 && (this.tok.type === tt._in || this.isContextual("of"))) {
+          return this.parseForIn(node, _init);
+        }
+        return this.parseFor(node, _init);
+      }
+      var init = this.parseExpression(true);
+      if (this.tok.type === tt._in || this.isContextual("of")) return this.parseForIn(node, this.toAssignable(init));
+      return this.parseFor(node, init);
+
+    case tt._function:
+      this.next();
+      return this.parseFunction(node, true);
+
+    case tt._if:
+      this.next();
+      node.test = this.parseParenExpression();
+      node.consequent = this.parseStatement();
+      node.alternate = this.eat(tt._else) ? this.parseStatement() : null;
+      return this.finishNode(node, "IfStatement");
+
+    case tt._return:
+      this.next();
+      if (this.eat(tt.semi) || this.canInsertSemicolon()) node.argument = null;else {
+        node.argument = this.parseExpression();this.semicolon();
+      }
+      return this.finishNode(node, "ReturnStatement");
+
+    case tt._switch:
+      var blockIndent = this.curIndent,
+          line = this.curLineStart;
+      this.next();
+      node.discriminant = this.parseParenExpression();
+      node.cases = [];
+      this.pushCx();
+      this.expect(tt.braceL);
+
+      var cur = undefined;
+      while (!this.closes(tt.braceR, blockIndent, line, true)) {
+        if (this.tok.type === tt._case || this.tok.type === tt._default) {
+          var isCase = this.tok.type === tt._case;
+          if (cur) this.finishNode(cur, "SwitchCase");
+          node.cases.push(cur = this.startNode());
+          cur.consequent = [];
+          this.next();
+          if (isCase) cur.test = this.parseExpression();else cur.test = null;
+          this.expect(tt.colon);
+        } else {
+          if (!cur) {
+            node.cases.push(cur = this.startNode());
+            cur.consequent = [];
+            cur.test = null;
+          }
+          cur.consequent.push(this.parseStatement());
+        }
+      }
+      if (cur) this.finishNode(cur, "SwitchCase");
+      this.popCx();
+      this.eat(tt.braceR);
+      return this.finishNode(node, "SwitchStatement");
+
+    case tt._throw:
+      this.next();
+      node.argument = this.parseExpression();
+      this.semicolon();
+      return this.finishNode(node, "ThrowStatement");
+
+    case tt._try:
+      this.next();
+      node.block = this.parseBlock();
+      node.handler = null;
+      if (this.tok.type === tt._catch) {
+        var clause = this.startNode();
+        this.next();
+        this.expect(tt.parenL);
+        clause.param = this.toAssignable(this.parseExprAtom());
+        this.expect(tt.parenR);
+        clause.guard = null;
+        clause.body = this.parseBlock();
+        node.handler = this.finishNode(clause, "CatchClause");
+      }
+      node.finalizer = this.eat(tt._finally) ? this.parseBlock() : null;
+      if (!node.handler && !node.finalizer) return node.block;
+      return this.finishNode(node, "TryStatement");
+
+    case tt._var:
+    case tt._let:
+    case tt._const:
+      return this.parseVar();
+
+    case tt._while:
+      this.next();
+      node.test = this.parseParenExpression();
+      node.body = this.parseStatement();
+      return this.finishNode(node, "WhileStatement");
+
+    case tt._with:
+      this.next();
+      node.object = this.parseParenExpression();
+      node.body = this.parseStatement();
+      return this.finishNode(node, "WithStatement");
+
+    case tt.braceL:
+      return this.parseBlock();
+
+    case tt.semi:
+      this.next();
+      return this.finishNode(node, "EmptyStatement");
+
+    case tt._class:
+      return this.parseClass(true);
+
+    case tt._import:
+      return this.parseImport();
+
+    case tt._export:
+      return this.parseExport();
+
+    default:
+      var expr = this.parseExpression();
+      if (isDummy(expr)) {
+        this.next();
+        if (this.tok.type === tt.eof) return this.finishNode(node, "EmptyStatement");
+        return this.parseStatement();
+      } else if (starttype === tt.name && expr.type === "Identifier" && this.eat(tt.colon)) {
+        node.body = this.parseStatement();
+        node.label = expr;
+        return this.finishNode(node, "LabeledStatement");
+      } else {
+        node.expression = expr;
+        this.semicolon();
+        return this.finishNode(node, "ExpressionStatement");
+      }
+  }
+};
+
+lp.parseBlock = function () {
+  var node = this.startNode();
+  this.pushCx();
+  this.expect(tt.braceL);
+  var blockIndent = this.curIndent,
+      line = this.curLineStart;
+  node.body = [];
+  while (!this.closes(tt.braceR, blockIndent, line, true)) node.body.push(this.parseStatement());
+  this.popCx();
+  this.eat(tt.braceR);
+  return this.finishNode(node, "BlockStatement");
+};
+
+lp.parseFor = function (node, init) {
+  node.init = init;
+  node.test = node.update = null;
+  if (this.eat(tt.semi) && this.tok.type !== tt.semi) node.test = this.parseExpression();
+  if (this.eat(tt.semi) && this.tok.type !== tt.parenR) node.update = this.parseExpression();
+  this.popCx();
+  this.expect(tt.parenR);
+  node.body = this.parseStatement();
+  return this.finishNode(node, "ForStatement");
+};
+
+lp.parseForIn = function (node, init) {
+  var type = this.tok.type === tt._in ? "ForInStatement" : "ForOfStatement";
+  this.next();
+  node.left = init;
+  node.right = this.parseExpression();
+  this.popCx();
+  this.expect(tt.parenR);
+  node.body = this.parseStatement();
+  return this.finishNode(node, type);
+};
+
+lp.parseVar = function (noIn) {
+  var node = this.startNode();
+  node.kind = this.tok.type.keyword;
+  this.next();
+  node.declarations = [];
+  do {
+    var decl = this.startNode();
+    decl.id = this.options.ecmaVersion >= 6 ? this.toAssignable(this.parseExprAtom()) : this.parseIdent();
+    decl.init = this.eat(tt.eq) ? this.parseMaybeAssign(noIn) : null;
+    node.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+  } while (this.eat(tt.comma));
+  if (!node.declarations.length) {
+    var decl = this.startNode();
+    decl.id = this.dummyIdent();
+    node.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+  }
+  if (!noIn) this.semicolon();
+  return this.finishNode(node, "VariableDeclaration");
+};
+
+lp.parseClass = function (isStatement) {
+  var node = this.startNode();
+  this.next();
+  if (this.tok.type === tt.name) node.id = this.parseIdent();else if (isStatement) node.id = this.dummyIdent();else node.id = null;
+  node.superClass = this.eat(tt._extends) ? this.parseExpression() : null;
+  node.body = this.startNode();
+  node.body.body = [];
+  this.pushCx();
+  var indent = this.curIndent + 1,
+      line = this.curLineStart;
+  this.eat(tt.braceL);
+  if (this.curIndent + 1 < indent) {
+    indent = this.curIndent;line = this.curLineStart;
+  }
+  while (!this.closes(tt.braceR, indent, line)) {
+    if (this.semicolon()) continue;
+    var method = this.startNode(),
+        isGenerator = undefined,
+        start = undefined;
+    if (this.options.ecmaVersion >= 6) {
+      method["static"] = false;
+      isGenerator = this.eat(tt.star);
+    }
+    this.parsePropertyName(method);
+    if (isDummy(method.key)) {
+      if (isDummy(this.parseMaybeAssign())) this.next();this.eat(tt.comma);continue;
+    }
+    if (method.key.type === "Identifier" && !method.computed && method.key.name === "static" && (this.tok.type != tt.parenL && this.tok.type != tt.braceL)) {
+      method["static"] = true;
+      isGenerator = this.eat(tt.star);
+      this.parsePropertyName(method);
+    } else {
+      method["static"] = false;
+    }
+    if (this.options.ecmaVersion >= 5 && method.key.type === "Identifier" && !method.computed && (method.key.name === "get" || method.key.name === "set") && this.tok.type !== tt.parenL && this.tok.type !== tt.braceL) {
+      method.kind = method.key.name;
+      this.parsePropertyName(method);
+      method.value = this.parseMethod(false);
+    } else {
+      if (!method.computed && !method["static"] && !isGenerator && (method.key.type === "Identifier" && method.key.name === "constructor" || method.key.type === "Literal" && method.key.value === "constructor")) {
+        method.kind = "constructor";
+      } else {
+        method.kind = "method";
+      }
+      method.value = this.parseMethod(isGenerator);
+    }
+    node.body.body.push(this.finishNode(method, "MethodDefinition"));
+  }
+  this.popCx();
+  if (!this.eat(tt.braceR)) {
+    // If there is no closing brace, make the node span to the start
+    // of the next token (this is useful for Tern)
+    this.last.end = this.tok.start;
+    if (this.options.locations) this.last.loc.end = this.tok.loc.start;
+  }
+  this.semicolon();
+  this.finishNode(node.body, "ClassBody");
+  return this.finishNode(node, isStatement ? "ClassDeclaration" : "ClassExpression");
+};
+
+lp.parseFunction = function (node, isStatement) {
+  this.initFunction(node);
+  if (this.options.ecmaVersion >= 6) {
+    node.generator = this.eat(tt.star);
+  }
+  if (this.tok.type === tt.name) node.id = this.parseIdent();else if (isStatement) node.id = this.dummyIdent();
+  node.params = this.parseFunctionParams();
+  node.body = this.parseBlock();
+  return this.finishNode(node, isStatement ? "FunctionDeclaration" : "FunctionExpression");
+};
+
+lp.parseExport = function () {
+  var node = this.startNode();
+  this.next();
+  if (this.eat(tt.star)) {
+    node.source = this.eatContextual("from") ? this.parseExprAtom() : null;
+    return this.finishNode(node, "ExportAllDeclaration");
+  }
+  if (this.eat(tt._default)) {
+    var expr = this.parseMaybeAssign();
+    if (expr.id) {
+      switch (expr.type) {
+        case "FunctionExpression":
+          expr.type = "FunctionDeclaration";break;
+        case "ClassExpression":
+          expr.type = "ClassDeclaration";break;
+      }
+    }
+    node.declaration = expr;
+    this.semicolon();
+    return this.finishNode(node, "ExportDefaultDeclaration");
+  }
+  if (this.tok.type.keyword) {
+    node.declaration = this.parseStatement();
+    node.specifiers = [];
+    node.source = null;
+  } else {
+    node.declaration = null;
+    node.specifiers = this.parseExportSpecifierList();
+    node.source = this.eatContextual("from") ? this.parseExprAtom() : null;
+    this.semicolon();
+  }
+  return this.finishNode(node, "ExportNamedDeclaration");
+};
+
+lp.parseImport = function () {
+  var node = this.startNode();
+  this.next();
+  if (this.tok.type === tt.string) {
+    node.specifiers = [];
+    node.source = this.parseExprAtom();
+    node.kind = "";
+  } else {
+    var elt = undefined;
+    if (this.tok.type === tt.name && this.tok.value !== "from") {
+      elt = this.startNode();
+      elt.local = this.parseIdent();
+      this.finishNode(elt, "ImportDefaultSpecifier");
+      this.eat(tt.comma);
+    }
+    node.specifiers = this.parseImportSpecifierList();
+    node.source = this.eatContextual("from") ? this.parseExprAtom() : null;
+    if (elt) node.specifiers.unshift(elt);
+  }
+  this.semicolon();
+  return this.finishNode(node, "ImportDeclaration");
+};
+
+lp.parseImportSpecifierList = function () {
+  var elts = [];
+  if (this.tok.type === tt.star) {
+    var elt = this.startNode();
+    this.next();
+    if (this.eatContextual("as")) elt.local = this.parseIdent();
+    elts.push(this.finishNode(elt, "ImportNamespaceSpecifier"));
+  } else {
+    var indent = this.curIndent,
+        line = this.curLineStart,
+        continuedLine = this.nextLineStart;
+    this.pushCx();
+    this.eat(tt.braceL);
+    if (this.curLineStart > continuedLine) continuedLine = this.curLineStart;
+    while (!this.closes(tt.braceR, indent + (this.curLineStart <= continuedLine ? 1 : 0), line)) {
+      var elt = this.startNode();
+      if (this.eat(tt.star)) {
+        if (this.eatContextual("as")) elt.local = this.parseIdent();
+        this.finishNode(elt, "ImportNamespaceSpecifier");
+      } else {
+        if (this.isContextual("from")) break;
+        elt.imported = this.parseIdent();
+        elt.local = this.eatContextual("as") ? this.parseIdent() : elt.imported;
+        this.finishNode(elt, "ImportSpecifier");
+      }
+      elts.push(elt);
+      this.eat(tt.comma);
+    }
+    this.eat(tt.braceR);
+    this.popCx();
+  }
+  return elts;
+};
+
+lp.parseExportSpecifierList = function () {
+  var elts = [];
+  var indent = this.curIndent,
+      line = this.curLineStart,
+      continuedLine = this.nextLineStart;
+  this.pushCx();
+  this.eat(tt.braceL);
+  if (this.curLineStart > continuedLine) continuedLine = this.curLineStart;
+  while (!this.closes(tt.braceR, indent + (this.curLineStart <= continuedLine ? 1 : 0), line)) {
+    if (this.isContextual("from")) break;
+    var elt = this.startNode();
+    elt.local = this.parseIdent();
+    elt.exported = this.eatContextual("as") ? this.parseIdent() : elt.local;
+    this.finishNode(elt, "ExportSpecifier");
+    elts.push(elt);
+    this.eat(tt.comma);
+  }
+  this.eat(tt.braceR);
+  this.popCx();
+  return elts;
+};
+
+},{"..":2,"./parseutil":4,"./state":5}],7:[function(require,module,exports){
+"use strict";
+
+var _ = require("..");
+
+var tt = _.tokTypes;
+var Token = _.Token;
+var isNewLine = _.isNewLine;
+var SourceLocation = _.SourceLocation;
+var getLineInfo = _.getLineInfo;
+var lineBreakG = _.lineBreakG;
+
+var LooseParser = require("./state").LooseParser;
+
+var lp = LooseParser.prototype;
+
+function isSpace(ch) {
+  return ch < 14 && ch > 8 || ch === 32 || ch === 160 || isNewLine(ch);
+}
+
+lp.next = function () {
+  this.last = this.tok;
+  if (this.ahead.length) this.tok = this.ahead.shift();else this.tok = this.readToken();
+
+  if (this.tok.start >= this.nextLineStart) {
+    while (this.tok.start >= this.nextLineStart) {
+      this.curLineStart = this.nextLineStart;
+      this.nextLineStart = this.lineEnd(this.curLineStart) + 1;
+    }
+    this.curIndent = this.indentationAfter(this.curLineStart);
+  }
+};
+
+lp.readToken = function () {
+  for (;;) {
+    try {
+      this.toks.next();
+      if (this.toks.type === tt.dot && this.input.substr(this.toks.end, 1) === "." && this.options.ecmaVersion >= 6) {
+        this.toks.end++;
+        this.toks.type = tt.ellipsis;
+      }
+      return new Token(this.toks);
+    } catch (e) {
+      if (!(e instanceof SyntaxError)) throw e;
+
+      // Try to skip some text, based on the error message, and then continue
+      var msg = e.message,
+          pos = e.raisedAt,
+          replace = true;
+      if (/unterminated/i.test(msg)) {
+        pos = this.lineEnd(e.pos + 1);
+        if (/string/.test(msg)) {
+          replace = { start: e.pos, end: pos, type: tt.string, value: this.input.slice(e.pos + 1, pos) };
+        } else if (/regular expr/i.test(msg)) {
+          var re = this.input.slice(e.pos, pos);
+          try {
+            re = new RegExp(re);
+          } catch (e) {}
+          replace = { start: e.pos, end: pos, type: tt.regexp, value: re };
+        } else if (/template/.test(msg)) {
+          replace = { start: e.pos, end: pos,
+            type: tt.template,
+            value: this.input.slice(e.pos, pos) };
+        } else {
+          replace = false;
+        }
+      } else if (/invalid (unicode|regexp|number)|expecting unicode|octal literal|is reserved|directly after number/i.test(msg)) {
+        while (pos < this.input.length && !isSpace(this.input.charCodeAt(pos))) ++pos;
+      } else if (/character escape|expected hexadecimal/i.test(msg)) {
+        while (pos < this.input.length) {
+          var ch = this.input.charCodeAt(pos++);
+          if (ch === 34 || ch === 39 || isNewLine(ch)) break;
+        }
+      } else if (/unexpected character/i.test(msg)) {
+        pos++;
+        replace = false;
+      } else if (/regular expression/i.test(msg)) {
+        replace = true;
+      } else {
+        throw e;
+      }
+      this.resetTo(pos);
+      if (replace === true) replace = { start: pos, end: pos, type: tt.name, value: "✖" };
+      if (replace) {
+        if (this.options.locations) replace.loc = new SourceLocation(this.toks, getLineInfo(this.input, replace.start), getLineInfo(this.input, replace.end));
+        return replace;
+      }
+    }
+  }
+};
+
+lp.resetTo = function (pos) {
+  this.toks.pos = pos;
+  var ch = this.input.charAt(pos - 1);
+  this.toks.exprAllowed = !ch || /[\[\{\(,;:?\/*=+\-~!|&%^<>]/.test(ch) || /[enwfd]/.test(ch) && /\b(keywords|case|else|return|throw|new|in|(instance|type)of|delete|void)$/.test(this.input.slice(pos - 10, pos));
+
+  if (this.options.locations) {
+    this.toks.curLine = 1;
+    this.toks.lineStart = lineBreakG.lastIndex = 0;
+    var match = undefined;
+    while ((match = lineBreakG.exec(this.input)) && match.index < pos) {
+      ++this.toks.curLine;
+      this.toks.lineStart = match.index + match[0].length;
+    }
+  }
+};
+
+lp.lookAhead = function (n) {
+  while (n > this.ahead.length) this.ahead.push(this.readToken());
+  return this.ahead[n - 1];
+};
+
+},{"..":2,"./state":5}]},{},[1])(1)
+});

--- a/editor/js/libs/acorn/walk.js
+++ b/editor/js/libs/acorn/walk.js
@@ -1,0 +1,344 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}(g.acorn || (g.acorn = {})).walk = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+
+// AST walker module for Mozilla Parser API compatible trees
+
+// A simple walk is one where you simply specify callbacks to be
+// called on specific nodes. The last two arguments are optional. A
+// simple use would be
+//
+//     walk.simple(myTree, {
+//         Expression: function(node) { ... }
+//     });
+//
+// to do something with all expressions. All Parser API node types
+// can be used to identify node types, as well as Expression,
+// Statement, and ScopeBody, which denote categories of nodes.
+//
+// The base argument can be used to pass a custom (recursive)
+// walker, and state can be used to give this walked an initial
+// state.
+
+exports.simple = simple;
+
+// An ancestor walk builds up an array of ancestor nodes (including
+// the current node) and passes them to the callback as the state parameter.
+exports.ancestor = ancestor;
+
+// A recursive walk is one where your functions override the default
+// walkers. They can modify and replace the state parameter that's
+// threaded through the walk, and can opt how and whether to walk
+// their child nodes (by calling their third argument on these
+// nodes).
+exports.recursive = recursive;
+
+// Find a node with a given start, end, and type (all are optional,
+// null can be used as wildcard). Returns a {node, state} object, or
+// undefined when it doesn't find a matching node.
+exports.findNodeAt = findNodeAt;
+
+// Find the innermost node of a given type that contains the given
+// position. Interface similar to findNodeAt.
+exports.findNodeAround = findNodeAround;
+
+// Find the outermost matching node after a given position.
+exports.findNodeAfter = findNodeAfter;
+
+// Find the outermost matching node before a given position.
+exports.findNodeBefore = findNodeBefore;
+
+// Used to create a custom walker. Will fill in all missing node
+// type properties with the defaults.
+exports.make = make;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+function simple(node, visitors, base, state) {
+  if (!base) base = exports.base;(function c(node, st, override) {
+    var type = override || node.type,
+        found = visitors[type];
+    base[type](node, st, c);
+    if (found) found(node, st);
+  })(node, state);
+}
+
+function ancestor(node, visitors, base, state) {
+  if (!base) base = exports.base;
+  if (!state) state = [];(function c(node, st, override) {
+    var type = override || node.type,
+        found = visitors[type];
+    if (node != st[st.length - 1]) {
+      st = st.slice();
+      st.push(node);
+    }
+    base[type](node, st, c);
+    if (found) found(node, st);
+  })(node, state);
+}
+
+function recursive(node, state, funcs, base) {
+  var visitor = funcs ? exports.make(funcs, base) : base;(function c(node, st, override) {
+    visitor[override || node.type](node, st, c);
+  })(node, state);
+}
+
+function makeTest(test) {
+  if (typeof test == "string") {
+    return function (type) {
+      return type == test;
+    };
+  } else if (!test) {
+    return function () {
+      return true;
+    };
+  } else {
+    return test;
+  }
+}
+
+var Found = function Found(node, state) {
+  _classCallCheck(this, Found);
+
+  this.node = node;this.state = state;
+};
+
+function findNodeAt(node, start, end, test, base, state) {
+  test = makeTest(test);
+  if (!base) base = exports.base;
+  try {
+    ;(function c(node, st, override) {
+      var type = override || node.type;
+      if ((start == null || node.start <= start) && (end == null || node.end >= end)) base[type](node, st, c);
+      if (test(type, node) && (start == null || node.start == start) && (end == null || node.end == end)) throw new Found(node, st);
+    })(node, state);
+  } catch (e) {
+    if (e instanceof Found) {
+      return e;
+    }throw e;
+  }
+}
+
+function findNodeAround(node, pos, test, base, state) {
+  test = makeTest(test);
+  if (!base) base = exports.base;
+  try {
+    ;(function c(node, st, override) {
+      var type = override || node.type;
+      if (node.start > pos || node.end < pos) {
+        return;
+      }base[type](node, st, c);
+      if (test(type, node)) throw new Found(node, st);
+    })(node, state);
+  } catch (e) {
+    if (e instanceof Found) {
+      return e;
+    }throw e;
+  }
+}
+
+function findNodeAfter(node, pos, test, base, state) {
+  test = makeTest(test);
+  if (!base) base = exports.base;
+  try {
+    ;(function c(node, st, override) {
+      if (node.end < pos) {
+        return;
+      }var type = override || node.type;
+      if (node.start >= pos && test(type, node)) throw new Found(node, st);
+      base[type](node, st, c);
+    })(node, state);
+  } catch (e) {
+    if (e instanceof Found) {
+      return e;
+    }throw e;
+  }
+}
+
+function findNodeBefore(node, pos, test, base, state) {
+  test = makeTest(test);
+  if (!base) base = exports.base;
+  var max = undefined;(function c(node, st, override) {
+    if (node.start > pos) {
+      return;
+    }var type = override || node.type;
+    if (node.end <= pos && (!max || max.node.end < node.end) && test(type, node)) max = new Found(node, st);
+    base[type](node, st, c);
+  })(node, state);
+  return max;
+}
+
+function make(funcs, base) {
+  if (!base) base = exports.base;
+  var visitor = {};
+  for (var type in base) visitor[type] = base[type];
+  for (var type in funcs) visitor[type] = funcs[type];
+  return visitor;
+}
+
+function skipThrough(node, st, c) {
+  c(node, st);
+}
+function ignore(_node, _st, _c) {}
+
+// Node walkers.
+
+var base = {};
+
+exports.base = base;
+base.Program = base.BlockStatement = function (node, st, c) {
+  for (var i = 0; i < node.body.length; ++i) {
+    c(node.body[i], st, "Statement");
+  }
+};
+base.Statement = skipThrough;
+base.EmptyStatement = ignore;
+base.ExpressionStatement = base.ParenthesizedExpression = function (node, st, c) {
+  return c(node.expression, st, "Expression");
+};
+base.IfStatement = function (node, st, c) {
+  c(node.test, st, "Expression");
+  c(node.consequent, st, "Statement");
+  if (node.alternate) c(node.alternate, st, "Statement");
+};
+base.LabeledStatement = function (node, st, c) {
+  return c(node.body, st, "Statement");
+};
+base.BreakStatement = base.ContinueStatement = ignore;
+base.WithStatement = function (node, st, c) {
+  c(node.object, st, "Expression");
+  c(node.body, st, "Statement");
+};
+base.SwitchStatement = function (node, st, c) {
+  c(node.discriminant, st, "Expression");
+  for (var i = 0; i < node.cases.length; ++i) {
+    var cs = node.cases[i];
+    if (cs.test) c(cs.test, st, "Expression");
+    for (var j = 0; j < cs.consequent.length; ++j) {
+      c(cs.consequent[j], st, "Statement");
+    }
+  }
+};
+base.ReturnStatement = base.YieldExpression = function (node, st, c) {
+  if (node.argument) c(node.argument, st, "Expression");
+};
+base.ThrowStatement = base.SpreadElement = base.RestElement = function (node, st, c) {
+  return c(node.argument, st, "Expression");
+};
+base.TryStatement = function (node, st, c) {
+  c(node.block, st, "Statement");
+  if (node.handler) c(node.handler.body, st, "ScopeBody");
+  if (node.finalizer) c(node.finalizer, st, "Statement");
+};
+base.WhileStatement = base.DoWhileStatement = function (node, st, c) {
+  c(node.test, st, "Expression");
+  c(node.body, st, "Statement");
+};
+base.ForStatement = function (node, st, c) {
+  if (node.init) c(node.init, st, "ForInit");
+  if (node.test) c(node.test, st, "Expression");
+  if (node.update) c(node.update, st, "Expression");
+  c(node.body, st, "Statement");
+};
+base.ForInStatement = base.ForOfStatement = function (node, st, c) {
+  c(node.left, st, "ForInit");
+  c(node.right, st, "Expression");
+  c(node.body, st, "Statement");
+};
+base.ForInit = function (node, st, c) {
+  if (node.type == "VariableDeclaration") c(node, st);else c(node, st, "Expression");
+};
+base.DebuggerStatement = ignore;
+
+base.FunctionDeclaration = function (node, st, c) {
+  return c(node, st, "Function");
+};
+base.VariableDeclaration = function (node, st, c) {
+  for (var i = 0; i < node.declarations.length; ++i) {
+    var decl = node.declarations[i];
+    if (decl.init) c(decl.init, st, "Expression");
+  }
+};
+
+base.Function = function (node, st, c) {
+  return c(node.body, st, "ScopeBody");
+};
+base.ScopeBody = function (node, st, c) {
+  return c(node, st, "Statement");
+};
+
+base.Expression = skipThrough;
+base.ThisExpression = base.Super = base.MetaProperty = ignore;
+base.ArrayExpression = base.ArrayPattern = function (node, st, c) {
+  for (var i = 0; i < node.elements.length; ++i) {
+    var elt = node.elements[i];
+    if (elt) c(elt, st, "Expression");
+  }
+};
+base.ObjectExpression = base.ObjectPattern = function (node, st, c) {
+  for (var i = 0; i < node.properties.length; ++i) {
+    c(node.properties[i], st);
+  }
+};
+base.FunctionExpression = base.ArrowFunctionExpression = base.FunctionDeclaration;
+base.SequenceExpression = base.TemplateLiteral = function (node, st, c) {
+  for (var i = 0; i < node.expressions.length; ++i) {
+    c(node.expressions[i], st, "Expression");
+  }
+};
+base.UnaryExpression = base.UpdateExpression = function (node, st, c) {
+  c(node.argument, st, "Expression");
+};
+base.BinaryExpression = base.AssignmentExpression = base.AssignmentPattern = base.LogicalExpression = function (node, st, c) {
+  c(node.left, st, "Expression");
+  c(node.right, st, "Expression");
+};
+base.ConditionalExpression = function (node, st, c) {
+  c(node.test, st, "Expression");
+  c(node.consequent, st, "Expression");
+  c(node.alternate, st, "Expression");
+};
+base.NewExpression = base.CallExpression = function (node, st, c) {
+  c(node.callee, st, "Expression");
+  if (node.arguments) for (var i = 0; i < node.arguments.length; ++i) {
+    c(node.arguments[i], st, "Expression");
+  }
+};
+base.MemberExpression = function (node, st, c) {
+  c(node.object, st, "Expression");
+  if (node.computed) c(node.property, st, "Expression");
+};
+base.ExportDeclaration = function (node, st, c) {
+  return c(node.declaration, st);
+};
+base.ImportDeclaration = function (node, st, c) {
+  for (var i = 0; i < node.specifiers.length; i++) {
+    c(node.specifiers[i], st);
+  }
+};
+base.ImportSpecifier = base.ImportBatchSpecifier = base.Identifier = base.Literal = ignore;
+
+base.TaggedTemplateExpression = function (node, st, c) {
+  c(node.tag, st, "Expression");
+  c(node.quasi, st);
+};
+base.ClassDeclaration = base.ClassExpression = function (node, st, c) {
+  if (node.superClass) c(node.superClass, st, "Expression");
+  for (var i = 0; i < node.body.body.length; i++) {
+    c(node.body.body[i], st);
+  }
+};
+base.MethodDefinition = base.Property = function (node, st, c) {
+  if (node.computed) c(node.key, st, "Expression");
+  c(node.value, st, "Expression");
+};
+base.ComprehensionExpression = function (node, st, c) {
+  for (var i = 0; i < node.blocks.length; i++) {
+    c(node.blocks[i].right, st, "Expression");
+  }c(node.body, st, "Expression");
+};
+
+},{}]},{},[1])(1)
+});

--- a/editor/js/libs/codemirror/addon/dialog.css
+++ b/editor/js/libs/codemirror/addon/dialog.css
@@ -1,0 +1,32 @@
+.CodeMirror-dialog {
+  position: absolute;
+  left: 0; right: 0;
+  background: inherit;
+  z-index: 15;
+  padding: .1em .8em;
+  overflow: hidden;
+  color: inherit;
+}
+
+.CodeMirror-dialog-top {
+  border-bottom: 1px solid #eee;
+  top: 0;
+}
+
+.CodeMirror-dialog-bottom {
+  border-top: 1px solid #eee;
+  bottom: 0;
+}
+
+.CodeMirror-dialog input {
+  border: none;
+  outline: none;
+  background: transparent;
+  width: 20em;
+  color: inherit;
+  font-family: monospace;
+}
+
+.CodeMirror-dialog button {
+  font-size: 70%;
+}

--- a/editor/js/libs/codemirror/addon/dialog.js
+++ b/editor/js/libs/codemirror/addon/dialog.js
@@ -1,0 +1,157 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+// Open simple dialogs on top of an editor. Relies on dialog.css.
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  function dialogDiv(cm, template, bottom) {
+    var wrap = cm.getWrapperElement();
+    var dialog;
+    dialog = wrap.appendChild(document.createElement("div"));
+    if (bottom)
+      dialog.className = "CodeMirror-dialog CodeMirror-dialog-bottom";
+    else
+      dialog.className = "CodeMirror-dialog CodeMirror-dialog-top";
+
+    if (typeof template == "string") {
+      dialog.innerHTML = template;
+    } else { // Assuming it's a detached DOM element.
+      dialog.appendChild(template);
+    }
+    return dialog;
+  }
+
+  function closeNotification(cm, newVal) {
+    if (cm.state.currentNotificationClose)
+      cm.state.currentNotificationClose();
+    cm.state.currentNotificationClose = newVal;
+  }
+
+  CodeMirror.defineExtension("openDialog", function(template, callback, options) {
+    if (!options) options = {};
+
+    closeNotification(this, null);
+
+    var dialog = dialogDiv(this, template, options.bottom);
+    var closed = false, me = this;
+    function close(newVal) {
+      if (typeof newVal == 'string') {
+        inp.value = newVal;
+      } else {
+        if (closed) return;
+        closed = true;
+        dialog.parentNode.removeChild(dialog);
+        me.focus();
+
+        if (options.onClose) options.onClose(dialog);
+      }
+    }
+
+    var inp = dialog.getElementsByTagName("input")[0], button;
+    if (inp) {
+      if (options.value) {
+        inp.value = options.value;
+        if (options.selectValueOnOpen !== false) {
+          inp.select();
+        }
+      }
+
+      if (options.onInput)
+        CodeMirror.on(inp, "input", function(e) { options.onInput(e, inp.value, close);});
+      if (options.onKeyUp)
+        CodeMirror.on(inp, "keyup", function(e) {options.onKeyUp(e, inp.value, close);});
+
+      CodeMirror.on(inp, "keydown", function(e) {
+        if (options && options.onKeyDown && options.onKeyDown(e, inp.value, close)) { return; }
+        if (e.keyCode == 27 || (options.closeOnEnter !== false && e.keyCode == 13)) {
+          inp.blur();
+          CodeMirror.e_stop(e);
+          close();
+        }
+        if (e.keyCode == 13) callback(inp.value, e);
+      });
+
+      if (options.closeOnBlur !== false) CodeMirror.on(inp, "blur", close);
+
+      inp.focus();
+    } else if (button = dialog.getElementsByTagName("button")[0]) {
+      CodeMirror.on(button, "click", function() {
+        close();
+        me.focus();
+      });
+
+      if (options.closeOnBlur !== false) CodeMirror.on(button, "blur", close);
+
+      button.focus();
+    }
+    return close;
+  });
+
+  CodeMirror.defineExtension("openConfirm", function(template, callbacks, options) {
+    closeNotification(this, null);
+    var dialog = dialogDiv(this, template, options && options.bottom);
+    var buttons = dialog.getElementsByTagName("button");
+    var closed = false, me = this, blurring = 1;
+    function close() {
+      if (closed) return;
+      closed = true;
+      dialog.parentNode.removeChild(dialog);
+      me.focus();
+    }
+    buttons[0].focus();
+    for (var i = 0; i < buttons.length; ++i) {
+      var b = buttons[i];
+      (function(callback) {
+        CodeMirror.on(b, "click", function(e) {
+          CodeMirror.e_preventDefault(e);
+          close();
+          if (callback) callback(me);
+        });
+      })(callbacks[i]);
+      CodeMirror.on(b, "blur", function() {
+        --blurring;
+        setTimeout(function() { if (blurring <= 0) close(); }, 200);
+      });
+      CodeMirror.on(b, "focus", function() { ++blurring; });
+    }
+  });
+
+  /*
+   * openNotification
+   * Opens a notification, that can be closed with an optional timer
+   * (default 5000ms timer) and always closes on click.
+   *
+   * If a notification is opened while another is opened, it will close the
+   * currently opened one and open the new one immediately.
+   */
+  CodeMirror.defineExtension("openNotification", function(template, options) {
+    closeNotification(this, close);
+    var dialog = dialogDiv(this, template, options && options.bottom);
+    var closed = false, doneTimer;
+    var duration = options && typeof options.duration !== "undefined" ? options.duration : 5000;
+
+    function close() {
+      if (closed) return;
+      closed = true;
+      clearTimeout(doneTimer);
+      dialog.parentNode.removeChild(dialog);
+    }
+
+    CodeMirror.on(dialog, 'click', function(e) {
+      CodeMirror.e_preventDefault(e);
+      close();
+    });
+
+    if (duration)
+      doneTimer = setTimeout(close, duration);
+
+    return close;
+  });
+});

--- a/editor/js/libs/codemirror/addon/show-hint.css
+++ b/editor/js/libs/codemirror/addon/show-hint.css
@@ -1,0 +1,38 @@
+.CodeMirror-hints {
+  position: absolute;
+  z-index: 10;
+  overflow: hidden;
+  list-style: none;
+
+  margin: 0;
+  padding: 2px;
+
+  -webkit-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  -moz-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  border-radius: 3px;
+  border: 1px solid silver;
+
+  background: white;
+  font-size: 90%;
+  font-family: monospace;
+
+  max-height: 20em;
+  overflow-y: auto;
+}
+
+.CodeMirror-hint {
+  margin: 0;
+  padding: 0 4px;
+  border-radius: 2px;
+  max-width: 19em;
+  overflow: hidden;
+  white-space: pre;
+  color: black;
+  cursor: pointer;
+}
+
+li.CodeMirror-hint-active {
+  background: #08f;
+  color: white;
+}

--- a/editor/js/libs/codemirror/addon/show-hint.js
+++ b/editor/js/libs/codemirror/addon/show-hint.js
@@ -1,0 +1,383 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  var HINT_ELEMENT_CLASS        = "CodeMirror-hint";
+  var ACTIVE_HINT_ELEMENT_CLASS = "CodeMirror-hint-active";
+
+  // This is the old interface, kept around for now to stay
+  // backwards-compatible.
+  CodeMirror.showHint = function(cm, getHints, options) {
+    if (!getHints) return cm.showHint(options);
+    if (options && options.async) getHints.async = true;
+    var newOpts = {hint: getHints};
+    if (options) for (var prop in options) newOpts[prop] = options[prop];
+    return cm.showHint(newOpts);
+  };
+
+  CodeMirror.defineExtension("showHint", function(options) {
+    // We want a single cursor position.
+    if (this.listSelections().length > 1 || this.somethingSelected()) return;
+
+    if (this.state.completionActive) this.state.completionActive.close();
+    var completion = this.state.completionActive = new Completion(this, options);
+    if (!completion.options.hint) return;
+
+    CodeMirror.signal(this, "startCompletion", this);
+    completion.update(true);
+  });
+
+  function Completion(cm, options) {
+    this.cm = cm;
+    this.options = this.buildOptions(options);
+    this.widget = null;
+    this.debounce = 0;
+    this.tick = 0;
+    this.startPos = this.cm.getCursor();
+    this.startLen = this.cm.getLine(this.startPos.line).length;
+
+    var self = this;
+    cm.on("cursorActivity", this.activityFunc = function() { self.cursorActivity(); });
+  }
+
+  var requestAnimationFrame = window.requestAnimationFrame || function(fn) {
+    return setTimeout(fn, 1000/60);
+  };
+  var cancelAnimationFrame = window.cancelAnimationFrame || clearTimeout;
+
+  Completion.prototype = {
+    close: function() {
+      if (!this.active()) return;
+      this.cm.state.completionActive = null;
+      this.tick = null;
+      this.cm.off("cursorActivity", this.activityFunc);
+
+      if (this.widget && this.data) CodeMirror.signal(this.data, "close");
+      if (this.widget) this.widget.close();
+      CodeMirror.signal(this.cm, "endCompletion", this.cm);
+    },
+
+    active: function() {
+      return this.cm.state.completionActive == this;
+    },
+
+    pick: function(data, i) {
+      var completion = data.list[i];
+      if (completion.hint) completion.hint(this.cm, data, completion);
+      else this.cm.replaceRange(getText(completion), completion.from || data.from,
+                                completion.to || data.to, "complete");
+      CodeMirror.signal(data, "pick", completion);
+      this.close();
+    },
+
+    cursorActivity: function() {
+      if (this.debounce) {
+        cancelAnimationFrame(this.debounce);
+        this.debounce = 0;
+      }
+
+      var pos = this.cm.getCursor(), line = this.cm.getLine(pos.line);
+      if (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
+          pos.ch < this.startPos.ch || this.cm.somethingSelected() ||
+          (pos.ch && this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
+        this.close();
+      } else {
+        var self = this;
+        this.debounce = requestAnimationFrame(function() {self.update();});
+        if (this.widget) this.widget.disable();
+      }
+    },
+
+    update: function(first) {
+      if (this.tick == null) return;
+      if (this.data) CodeMirror.signal(this.data, "update");
+      if (!this.options.hint.async) {
+        this.finishUpdate(this.options.hint(this.cm, this.options), first);
+      } else {
+        var myTick = ++this.tick, self = this;
+        this.options.hint(this.cm, function(data) {
+          if (self.tick == myTick) self.finishUpdate(data, first);
+        }, this.options);
+      }
+    },
+
+    finishUpdate: function(data, first) {
+      this.data = data;
+
+      var picked = (this.widget && this.widget.picked) || (first && this.options.completeSingle);
+      if (this.widget) this.widget.close();
+      if (data && data.list.length) {
+        if (picked && data.list.length == 1) {
+          this.pick(data, 0);
+        } else {
+          this.widget = new Widget(this, data);
+          CodeMirror.signal(data, "shown");
+        }
+      }
+    },
+
+    buildOptions: function(options) {
+      var editor = this.cm.options.hintOptions;
+      var out = {};
+      for (var prop in defaultOptions) out[prop] = defaultOptions[prop];
+      if (editor) for (var prop in editor)
+        if (editor[prop] !== undefined) out[prop] = editor[prop];
+      if (options) for (var prop in options)
+        if (options[prop] !== undefined) out[prop] = options[prop];
+      return out;
+    }
+  };
+
+  function getText(completion) {
+    if (typeof completion == "string") return completion;
+    else return completion.text;
+  }
+
+  function buildKeyMap(completion, handle) {
+    var baseMap = {
+      Up: function() {handle.moveFocus(-1);},
+      Down: function() {handle.moveFocus(1);},
+      PageUp: function() {handle.moveFocus(-handle.menuSize() + 1, true);},
+      PageDown: function() {handle.moveFocus(handle.menuSize() - 1, true);},
+      Home: function() {handle.setFocus(0);},
+      End: function() {handle.setFocus(handle.length - 1);},
+      Enter: handle.pick,
+      Tab: handle.pick,
+      Esc: handle.close
+    };
+    var custom = completion.options.customKeys;
+    var ourMap = custom ? {} : baseMap;
+    function addBinding(key, val) {
+      var bound;
+      if (typeof val != "string")
+        bound = function(cm) { return val(cm, handle); };
+      // This mechanism is deprecated
+      else if (baseMap.hasOwnProperty(val))
+        bound = baseMap[val];
+      else
+        bound = val;
+      ourMap[key] = bound;
+    }
+    if (custom)
+      for (var key in custom) if (custom.hasOwnProperty(key))
+        addBinding(key, custom[key]);
+    var extra = completion.options.extraKeys;
+    if (extra)
+      for (var key in extra) if (extra.hasOwnProperty(key))
+        addBinding(key, extra[key]);
+    return ourMap;
+  }
+
+  function getHintElement(hintsElement, el) {
+    while (el && el != hintsElement) {
+      if (el.nodeName.toUpperCase() === "LI" && el.parentNode == hintsElement) return el;
+      el = el.parentNode;
+    }
+  }
+
+  function Widget(completion, data) {
+    this.completion = completion;
+    this.data = data;
+    this.picked = false;
+    var widget = this, cm = completion.cm;
+
+    var hints = this.hints = document.createElement("ul");
+    hints.className = "CodeMirror-hints";
+    this.selectedHint = data.selectedHint || 0;
+
+    var completions = data.list;
+    for (var i = 0; i < completions.length; ++i) {
+      var elt = hints.appendChild(document.createElement("li")), cur = completions[i];
+      var className = HINT_ELEMENT_CLASS + (i != this.selectedHint ? "" : " " + ACTIVE_HINT_ELEMENT_CLASS);
+      if (cur.className != null) className = cur.className + " " + className;
+      elt.className = className;
+      if (cur.render) cur.render(elt, data, cur);
+      else elt.appendChild(document.createTextNode(cur.displayText || getText(cur)));
+      elt.hintId = i;
+    }
+
+    var pos = cm.cursorCoords(completion.options.alignWithWord ? data.from : null);
+    var left = pos.left, top = pos.bottom, below = true;
+    hints.style.left = left + "px";
+    hints.style.top = top + "px";
+    // If we're at the edge of the screen, then we want the menu to appear on the left of the cursor.
+    var winW = window.innerWidth || Math.max(document.body.offsetWidth, document.documentElement.offsetWidth);
+    var winH = window.innerHeight || Math.max(document.body.offsetHeight, document.documentElement.offsetHeight);
+    (completion.options.container || document.body).appendChild(hints);
+    var box = hints.getBoundingClientRect(), overlapY = box.bottom - winH;
+    if (overlapY > 0) {
+      var height = box.bottom - box.top, curTop = pos.top - (pos.bottom - box.top);
+      if (curTop - height > 0) { // Fits above cursor
+        hints.style.top = (top = pos.top - height) + "px";
+        below = false;
+      } else if (height > winH) {
+        hints.style.height = (winH - 5) + "px";
+        hints.style.top = (top = pos.bottom - box.top) + "px";
+        var cursor = cm.getCursor();
+        if (data.from.ch != cursor.ch) {
+          pos = cm.cursorCoords(cursor);
+          hints.style.left = (left = pos.left) + "px";
+          box = hints.getBoundingClientRect();
+        }
+      }
+    }
+    var overlapX = box.right - winW;
+    if (overlapX > 0) {
+      if (box.right - box.left > winW) {
+        hints.style.width = (winW - 5) + "px";
+        overlapX -= (box.right - box.left) - winW;
+      }
+      hints.style.left = (left = pos.left - overlapX) + "px";
+    }
+
+    cm.addKeyMap(this.keyMap = buildKeyMap(completion, {
+      moveFocus: function(n, avoidWrap) { widget.changeActive(widget.selectedHint + n, avoidWrap); },
+      setFocus: function(n) { widget.changeActive(n); },
+      menuSize: function() { return widget.screenAmount(); },
+      length: completions.length,
+      close: function() { completion.close(); },
+      pick: function() { widget.pick(); },
+      data: data
+    }));
+
+    if (completion.options.closeOnUnfocus) {
+      var closingOnBlur;
+      cm.on("blur", this.onBlur = function() { closingOnBlur = setTimeout(function() { completion.close(); }, 100); });
+      cm.on("focus", this.onFocus = function() { clearTimeout(closingOnBlur); });
+    }
+
+    var startScroll = cm.getScrollInfo();
+    cm.on("scroll", this.onScroll = function() {
+      var curScroll = cm.getScrollInfo(), editor = cm.getWrapperElement().getBoundingClientRect();
+      var newTop = top + startScroll.top - curScroll.top;
+      var point = newTop - (window.pageYOffset || (document.documentElement || document.body).scrollTop);
+      if (!below) point += hints.offsetHeight;
+      if (point <= editor.top || point >= editor.bottom) return completion.close();
+      hints.style.top = newTop + "px";
+      hints.style.left = (left + startScroll.left - curScroll.left) + "px";
+    });
+
+    CodeMirror.on(hints, "dblclick", function(e) {
+      var t = getHintElement(hints, e.target || e.srcElement);
+      if (t && t.hintId != null) {widget.changeActive(t.hintId); widget.pick();}
+    });
+
+    CodeMirror.on(hints, "click", function(e) {
+      var t = getHintElement(hints, e.target || e.srcElement);
+      if (t && t.hintId != null) {
+        widget.changeActive(t.hintId);
+        if (completion.options.completeOnSingleClick) widget.pick();
+      }
+    });
+
+    CodeMirror.on(hints, "mousedown", function() {
+      setTimeout(function(){cm.focus();}, 20);
+    });
+
+    CodeMirror.signal(data, "select", completions[0], hints.firstChild);
+    return true;
+  }
+
+  Widget.prototype = {
+    close: function() {
+      if (this.completion.widget != this) return;
+      this.completion.widget = null;
+      this.hints.parentNode.removeChild(this.hints);
+      this.completion.cm.removeKeyMap(this.keyMap);
+
+      var cm = this.completion.cm;
+      if (this.completion.options.closeOnUnfocus) {
+        cm.off("blur", this.onBlur);
+        cm.off("focus", this.onFocus);
+      }
+      cm.off("scroll", this.onScroll);
+    },
+
+    disable: function() {
+      this.completion.cm.removeKeyMap(this.keyMap);
+      var widget = this;
+      this.keyMap = {Enter: function() { widget.picked = true; }};
+      this.completion.cm.addKeyMap(this.keyMap);
+    },
+
+    pick: function() {
+      this.completion.pick(this.data, this.selectedHint);
+    },
+
+    changeActive: function(i, avoidWrap) {
+      if (i >= this.data.list.length)
+        i = avoidWrap ? this.data.list.length - 1 : 0;
+      else if (i < 0)
+        i = avoidWrap ? 0  : this.data.list.length - 1;
+      if (this.selectedHint == i) return;
+      var node = this.hints.childNodes[this.selectedHint];
+      node.className = node.className.replace(" " + ACTIVE_HINT_ELEMENT_CLASS, "");
+      node = this.hints.childNodes[this.selectedHint = i];
+      node.className += " " + ACTIVE_HINT_ELEMENT_CLASS;
+      if (node.offsetTop < this.hints.scrollTop)
+        this.hints.scrollTop = node.offsetTop - 3;
+      else if (node.offsetTop + node.offsetHeight > this.hints.scrollTop + this.hints.clientHeight)
+        this.hints.scrollTop = node.offsetTop + node.offsetHeight - this.hints.clientHeight + 3;
+      CodeMirror.signal(this.data, "select", this.data.list[this.selectedHint], node);
+    },
+
+    screenAmount: function() {
+      return Math.floor(this.hints.clientHeight / this.hints.firstChild.offsetHeight) || 1;
+    }
+  };
+
+  CodeMirror.registerHelper("hint", "auto", function(cm, options) {
+    var helpers = cm.getHelpers(cm.getCursor(), "hint"), words;
+    if (helpers.length) {
+      for (var i = 0; i < helpers.length; i++) {
+        var cur = helpers[i](cm, options);
+        if (cur && cur.list.length) return cur;
+      }
+    } else if (words = cm.getHelper(cm.getCursor(), "hintWords")) {
+      if (words) return CodeMirror.hint.fromList(cm, {words: words});
+    } else if (CodeMirror.hint.anyword) {
+      return CodeMirror.hint.anyword(cm, options);
+    }
+  });
+
+  CodeMirror.registerHelper("hint", "fromList", function(cm, options) {
+    var cur = cm.getCursor(), token = cm.getTokenAt(cur);
+    var found = [];
+    for (var i = 0; i < options.words.length; i++) {
+      var word = options.words[i];
+      if (word.slice(0, token.string.length) == token.string)
+        found.push(word);
+    }
+
+    if (found.length) return {
+      list: found,
+      from: CodeMirror.Pos(cur.line, token.start),
+            to: CodeMirror.Pos(cur.line, token.end)
+    };
+  });
+
+  CodeMirror.commands.autocomplete = CodeMirror.showHint;
+
+  var defaultOptions = {
+    hint: CodeMirror.hint.auto,
+    completeSingle: true,
+    alignWithWord: true,
+    closeCharacters: /[\s()\[\]{};:>,]/,
+    closeOnUnfocus: true,
+    completeOnSingleClick: false,
+    container: null,
+    customKeys: null,
+    extraKeys: null
+  };
+
+  CodeMirror.defineOption("hintOptions", null);
+});

--- a/editor/js/libs/codemirror/addon/tern.css
+++ b/editor/js/libs/codemirror/addon/tern.css
@@ -1,0 +1,86 @@
+.CodeMirror-Tern-completion {
+  padding-left: 22px;
+  position: relative;
+}
+.CodeMirror-Tern-completion:before {
+  position: absolute;
+  left: 2px;
+  bottom: 2px;
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: bold;
+  height: 15px;
+  width: 15px;
+  line-height: 16px;
+  text-align: center;
+  color: white;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.CodeMirror-Tern-completion-unknown:before {
+  content: "?";
+  background: #4bb;
+}
+.CodeMirror-Tern-completion-object:before {
+  content: "O";
+  background: #77c;
+}
+.CodeMirror-Tern-completion-fn:before {
+  content: "F";
+  background: #7c7;
+}
+.CodeMirror-Tern-completion-array:before {
+  content: "A";
+  background: #c66;
+}
+.CodeMirror-Tern-completion-number:before {
+  content: "1";
+  background: #999;
+}
+.CodeMirror-Tern-completion-string:before {
+  content: "S";
+  background: #999;
+}
+.CodeMirror-Tern-completion-bool:before {
+  content: "B";
+  background: #999;
+}
+
+.CodeMirror-Tern-completion-guess {
+  color: #999;
+}
+
+.CodeMirror-Tern-tooltip {
+  border: 1px solid silver;
+  border-radius: 3px;
+  color: #444;
+  padding: 2px 5px;
+  font-size: 90%;
+  font-family: monospace;
+  background-color: white;
+  white-space: pre-wrap;
+
+  max-width: 40em;
+  position: absolute;
+  z-index: 10;
+  -webkit-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  -moz-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+
+  transition: opacity 1s;
+  -moz-transition: opacity 1s;
+  -webkit-transition: opacity 1s;
+  -o-transition: opacity 1s;
+  -ms-transition: opacity 1s;
+}
+
+.CodeMirror-Tern-hint-doc {
+  max-width: 25em;
+  margin-top: -3px;
+}
+
+.CodeMirror-Tern-fname { color: black; }
+.CodeMirror-Tern-farg { color: #70a; }
+.CodeMirror-Tern-farg-current { text-decoration: underline; }
+.CodeMirror-Tern-type { color: #07c; }
+.CodeMirror-Tern-fhint-guess { opacity: .7; }

--- a/editor/js/libs/codemirror/addon/tern.js
+++ b/editor/js/libs/codemirror/addon/tern.js
@@ -1,0 +1,698 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+// Glue code between CodeMirror and Tern.
+//
+// Create a CodeMirror.TernServer to wrap an actual Tern server,
+// register open documents (CodeMirror.Doc instances) with it, and
+// call its methods to activate the assisting functions that Tern
+// provides.
+//
+// Options supported (all optional):
+// * defs: An array of JSON definition data structures.
+// * plugins: An object mapping plugin names to configuration
+//   options.
+// * getFile: A function(name, c) that can be used to access files in
+//   the project that haven't been loaded yet. Simply do c(null) to
+//   indicate that a file is not available.
+// * fileFilter: A function(value, docName, doc) that will be applied
+//   to documents before passing them on to Tern.
+// * switchToDoc: A function(name, doc) that should, when providing a
+//   multi-file view, switch the view or focus to the named file.
+// * showError: A function(editor, message) that can be used to
+//   override the way errors are displayed.
+// * completionTip: Customize the content in tooltips for completions.
+//   Is passed a single argument—the completion's data as returned by
+//   Tern—and may return a string, DOM node, or null to indicate that
+//   no tip should be shown. By default the docstring is shown.
+// * typeTip: Like completionTip, but for the tooltips shown for type
+//   queries.
+// * responseFilter: A function(doc, query, request, error, data) that
+//   will be applied to the Tern responses before treating them
+// * caseInsensitive: boolean to send case insensitive querys to tern
+//
+//
+// It is possible to run the Tern server in a web worker by specifying
+// these additional options:
+// * useWorker: Set to true to enable web worker mode. You'll probably
+//   want to feature detect the actual value you use here, for example
+//   !!window.Worker.
+// * workerScript: The main script of the worker. Point this to
+//   wherever you are hosting worker.js from this directory.
+// * workerDeps: An array of paths pointing (relative to workerScript)
+//   to the Acorn and Tern libraries and any Tern plugins you want to
+//   load. Or, if you minified those into a single script and included
+//   them in the workerScript, simply leave this undefined.
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+  // declare global: tern
+
+  CodeMirror.TernServer = function(options) {
+    var self = this;
+    this.options = options || {};
+    var plugins = this.options.plugins || (this.options.plugins = {});
+    if (!plugins.doc_comment) plugins.doc_comment = true;
+    if (this.options.useWorker) {
+      this.server = new WorkerServer(this);
+    } else {
+      this.server = new tern.Server({
+        getFile: function(name, c) { return getFile(self, name, c); },
+        async: true,
+        defs: this.options.defs || [],
+        plugins: plugins
+      });
+    }
+    this.docs = Object.create(null);
+    this.trackChange = function(doc, change) { trackChange(self, doc, change); };
+
+    this.cachedArgHints = null;
+    this.activeArgHints = null;
+    this.jumpStack = [];
+
+    this.getHint = function(cm, c) { return hint(self, cm, c); };
+    this.getHint.async = true;
+  };
+
+  CodeMirror.TernServer.prototype = {
+    addDoc: function(name, doc) {
+      var data = {doc: doc, name: name, changed: null};
+      this.server.addFile(name, docValue(this, data));
+      CodeMirror.on(doc, "change", this.trackChange);
+      return this.docs[name] = data;
+    },
+
+    delDoc: function(id) {
+      var found = resolveDoc(this, id);
+      if (!found) return;
+      CodeMirror.off(found.doc, "change", this.trackChange);
+      delete this.docs[found.name];
+      this.server.delFile(found.name);
+    },
+
+    hideDoc: function(id) {
+      closeArgHints(this);
+      var found = resolveDoc(this, id);
+      if (found && found.changed) sendDoc(this, found);
+    },
+
+    complete: function(cm) {
+      cm.showHint({hint: this.getHint});
+    },
+
+    showType: function(cm, pos, c) { showContextInfo(this, cm, pos, "type", c); },
+
+    showDocs: function(cm, pos, c) { showContextInfo(this, cm, pos, "documentation", c); },
+
+    updateArgHints: function(cm) { updateArgHints(this, cm); },
+
+    jumpToDef: function(cm) { jumpToDef(this, cm); },
+
+    jumpBack: function(cm) { jumpBack(this, cm); },
+
+    rename: function(cm) { rename(this, cm); },
+
+    selectName: function(cm) { selectName(this, cm); },
+
+    request: function (cm, query, c, pos) {
+      var self = this;
+      var doc = findDoc(this, cm.getDoc());
+      var request = buildRequest(this, doc, query, pos);
+
+      this.server.request(request, function (error, data) {
+        if (!error && self.options.responseFilter)
+          data = self.options.responseFilter(doc, query, request, error, data);
+        c(error, data);
+      });
+    },
+
+    destroy: function () {
+      if (this.worker) {
+        this.worker.terminate();
+        this.worker = null;
+      }
+    }
+  };
+
+  var Pos = CodeMirror.Pos;
+  var cls = "CodeMirror-Tern-";
+  var bigDoc = 250;
+
+  function getFile(ts, name, c) {
+    var buf = ts.docs[name];
+    if (buf)
+      c(docValue(ts, buf));
+    else if (ts.options.getFile)
+      ts.options.getFile(name, c);
+    else
+      c(null);
+  }
+
+  function findDoc(ts, doc, name) {
+    for (var n in ts.docs) {
+      var cur = ts.docs[n];
+      if (cur.doc == doc) return cur;
+    }
+    if (!name) for (var i = 0;; ++i) {
+      n = "[doc" + (i || "") + "]";
+      if (!ts.docs[n]) { name = n; break; }
+    }
+    return ts.addDoc(name, doc);
+  }
+
+  function resolveDoc(ts, id) {
+    if (typeof id == "string") return ts.docs[id];
+    if (id instanceof CodeMirror) id = id.getDoc();
+    if (id instanceof CodeMirror.Doc) return findDoc(ts, id);
+  }
+
+  function trackChange(ts, doc, change) {
+    var data = findDoc(ts, doc);
+
+    var argHints = ts.cachedArgHints;
+    if (argHints && argHints.doc == doc && cmpPos(argHints.start, change.to) <= 0)
+      ts.cachedArgHints = null;
+
+    var changed = data.changed;
+    if (changed == null)
+      data.changed = changed = {from: change.from.line, to: change.from.line};
+    var end = change.from.line + (change.text.length - 1);
+    if (change.from.line < changed.to) changed.to = changed.to - (change.to.line - end);
+    if (end >= changed.to) changed.to = end + 1;
+    if (changed.from > change.from.line) changed.from = change.from.line;
+
+    if (doc.lineCount() > bigDoc && change.to - changed.from > 100) setTimeout(function() {
+      if (data.changed && data.changed.to - data.changed.from > 100) sendDoc(ts, data);
+    }, 200);
+  }
+
+  function sendDoc(ts, doc) {
+    ts.server.request({files: [{type: "full", name: doc.name, text: docValue(ts, doc)}]}, function(error) {
+      if (error) window.console.error(error);
+      else doc.changed = null;
+    });
+  }
+
+  // Completion
+
+  function hint(ts, cm, c) {
+    ts.request(cm, {type: "completions", types: true, docs: true, urls: true, caseInsensitive: ts.options.caseInsensitive}, function(error, data) {
+      if (error) return showError(ts, cm, error);
+      var completions = [], after = "";
+      var from = data.start, to = data.end;
+      if (cm.getRange(Pos(from.line, from.ch - 2), from) == "[\"" &&
+          cm.getRange(to, Pos(to.line, to.ch + 2)) != "\"]")
+        after = "\"]";
+
+      for (var i = 0; i < data.completions.length; ++i) {
+        var completion = data.completions[i], className = typeToIcon(completion.type);
+        if (data.guess) className += " " + cls + "guess";
+        completions.push({text: completion.name + after,
+                          displayText: completion.name,
+                          className: className,
+                          data: completion});
+      }
+
+      var obj = {from: from, to: to, list: completions};
+      var tooltip = null;
+      CodeMirror.on(obj, "close", function() { remove(tooltip); });
+      CodeMirror.on(obj, "update", function() { remove(tooltip); });
+      CodeMirror.on(obj, "select", function(cur, node) {
+        remove(tooltip);
+        var content = ts.options.completionTip ? ts.options.completionTip(cur.data) : cur.data.doc;
+        if (content) {
+          tooltip = makeTooltip(node.parentNode.getBoundingClientRect().right + window.pageXOffset,
+                                node.getBoundingClientRect().top + window.pageYOffset, content);
+          tooltip.className += " " + cls + "hint-doc";
+        }
+      });
+      c(obj);
+    });
+  }
+
+  function typeToIcon(type) {
+    var suffix;
+    if (type == "?") suffix = "unknown";
+    else if (type == "number" || type == "string" || type == "bool") suffix = type;
+    else if (/^fn\(/.test(type)) suffix = "fn";
+    else if (/^\[/.test(type)) suffix = "array";
+    else suffix = "object";
+    return cls + "completion " + cls + "completion-" + suffix;
+  }
+
+  // Type queries
+
+  function showContextInfo(ts, cm, pos, queryName, c) {
+    ts.request(cm, queryName, function(error, data) {
+      if (error) return showError(ts, cm, error);
+      if (ts.options.typeTip) {
+        var tip = ts.options.typeTip(data);
+      } else {
+        var tip = elt("span", null, elt("strong", null, data.type || "not found"));
+        if (data.doc)
+          tip.appendChild(document.createTextNode(" — " + data.doc));
+        if (data.url) {
+          tip.appendChild(document.createTextNode(" "));
+          var child = tip.appendChild(elt("a", null, "[docs]"));
+          child.href = data.url;
+          child.target = "_blank";
+        }
+      }
+      tempTooltip(cm, tip);
+      if (c) c();
+    }, pos);
+  }
+
+  // Maintaining argument hints
+
+  function updateArgHints(ts, cm) {
+    closeArgHints(ts);
+
+    if (cm.somethingSelected()) return;
+    var state = cm.getTokenAt(cm.getCursor()).state;
+    var inner = CodeMirror.innerMode(cm.getMode(), state);
+    if (inner.mode.name != "javascript") return;
+    var lex = inner.state.lexical;
+    if (lex.info != "call") return;
+
+    var ch, argPos = lex.pos || 0, tabSize = cm.getOption("tabSize");
+    for (var line = cm.getCursor().line, e = Math.max(0, line - 9), found = false; line >= e; --line) {
+      var str = cm.getLine(line), extra = 0;
+      for (var pos = 0;;) {
+        var tab = str.indexOf("\t", pos);
+        if (tab == -1) break;
+        extra += tabSize - (tab + extra) % tabSize - 1;
+        pos = tab + 1;
+      }
+      ch = lex.column - extra;
+      if (str.charAt(ch) == "(") {found = true; break;}
+    }
+    if (!found) return;
+
+    var start = Pos(line, ch);
+    var cache = ts.cachedArgHints;
+    if (cache && cache.doc == cm.getDoc() && cmpPos(start, cache.start) == 0)
+      return showArgHints(ts, cm, argPos);
+
+    ts.request(cm, {type: "type", preferFunction: true, end: start}, function(error, data) {
+      if (error || !data.type || !(/^fn\(/).test(data.type)) return;
+      ts.cachedArgHints = {
+        start: pos,
+        type: parseFnType(data.type),
+        name: data.exprName || data.name || "fn",
+        guess: data.guess,
+        doc: cm.getDoc()
+      };
+      showArgHints(ts, cm, argPos);
+    });
+  }
+
+  function showArgHints(ts, cm, pos) {
+    closeArgHints(ts);
+
+    var cache = ts.cachedArgHints, tp = cache.type;
+    var tip = elt("span", cache.guess ? cls + "fhint-guess" : null,
+                  elt("span", cls + "fname", cache.name), "(");
+    for (var i = 0; i < tp.args.length; ++i) {
+      if (i) tip.appendChild(document.createTextNode(", "));
+      var arg = tp.args[i];
+      tip.appendChild(elt("span", cls + "farg" + (i == pos ? " " + cls + "farg-current" : ""), arg.name || "?"));
+      if (arg.type != "?") {
+        tip.appendChild(document.createTextNode(":\u00a0"));
+        tip.appendChild(elt("span", cls + "type", arg.type));
+      }
+    }
+    tip.appendChild(document.createTextNode(tp.rettype ? ") ->\u00a0" : ")"));
+    if (tp.rettype) tip.appendChild(elt("span", cls + "type", tp.rettype));
+    var place = cm.cursorCoords(null, "page");
+    ts.activeArgHints = makeTooltip(place.right + 1, place.bottom, tip);
+  }
+
+  function parseFnType(text) {
+    var args = [], pos = 3;
+
+    function skipMatching(upto) {
+      var depth = 0, start = pos;
+      for (;;) {
+        var next = text.charAt(pos);
+        if (upto.test(next) && !depth) return text.slice(start, pos);
+        if (/[{\[\(]/.test(next)) ++depth;
+        else if (/[}\]\)]/.test(next)) --depth;
+        ++pos;
+      }
+    }
+
+    // Parse arguments
+    if (text.charAt(pos) != ")") for (;;) {
+      var name = text.slice(pos).match(/^([^, \(\[\{]+): /);
+      if (name) {
+        pos += name[0].length;
+        name = name[1];
+      }
+      args.push({name: name, type: skipMatching(/[\),]/)});
+      if (text.charAt(pos) == ")") break;
+      pos += 2;
+    }
+
+    var rettype = text.slice(pos).match(/^\) -> (.*)$/);
+
+    return {args: args, rettype: rettype && rettype[1]};
+  }
+
+  // Moving to the definition of something
+
+  function jumpToDef(ts, cm) {
+    function inner(varName) {
+      var req = {type: "definition", variable: varName || null};
+      var doc = findDoc(ts, cm.getDoc());
+      ts.server.request(buildRequest(ts, doc, req), function(error, data) {
+        if (error) return showError(ts, cm, error);
+        if (!data.file && data.url) { window.open(data.url); return; }
+
+        if (data.file) {
+          var localDoc = ts.docs[data.file], found;
+          if (localDoc && (found = findContext(localDoc.doc, data))) {
+            ts.jumpStack.push({file: doc.name,
+                               start: cm.getCursor("from"),
+                               end: cm.getCursor("to")});
+            moveTo(ts, doc, localDoc, found.start, found.end);
+            return;
+          }
+        }
+        showError(ts, cm, "Could not find a definition.");
+      });
+    }
+
+    if (!atInterestingExpression(cm))
+      dialog(cm, "Jump to variable", function(name) { if (name) inner(name); });
+    else
+      inner();
+  }
+
+  function jumpBack(ts, cm) {
+    var pos = ts.jumpStack.pop(), doc = pos && ts.docs[pos.file];
+    if (!doc) return;
+    moveTo(ts, findDoc(ts, cm.getDoc()), doc, pos.start, pos.end);
+  }
+
+  function moveTo(ts, curDoc, doc, start, end) {
+    doc.doc.setSelection(start, end);
+    if (curDoc != doc && ts.options.switchToDoc) {
+      closeArgHints(ts);
+      ts.options.switchToDoc(doc.name, doc.doc);
+    }
+  }
+
+  // The {line,ch} representation of positions makes this rather awkward.
+  function findContext(doc, data) {
+    var before = data.context.slice(0, data.contextOffset).split("\n");
+    var startLine = data.start.line - (before.length - 1);
+    var start = Pos(startLine, (before.length == 1 ? data.start.ch : doc.getLine(startLine).length) - before[0].length);
+
+    var text = doc.getLine(startLine).slice(start.ch);
+    for (var cur = startLine + 1; cur < doc.lineCount() && text.length < data.context.length; ++cur)
+      text += "\n" + doc.getLine(cur);
+    if (text.slice(0, data.context.length) == data.context) return data;
+
+    var cursor = doc.getSearchCursor(data.context, 0, false);
+    var nearest, nearestDist = Infinity;
+    while (cursor.findNext()) {
+      var from = cursor.from(), dist = Math.abs(from.line - start.line) * 10000;
+      if (!dist) dist = Math.abs(from.ch - start.ch);
+      if (dist < nearestDist) { nearest = from; nearestDist = dist; }
+    }
+    if (!nearest) return null;
+
+    if (before.length == 1)
+      nearest.ch += before[0].length;
+    else
+      nearest = Pos(nearest.line + (before.length - 1), before[before.length - 1].length);
+    if (data.start.line == data.end.line)
+      var end = Pos(nearest.line, nearest.ch + (data.end.ch - data.start.ch));
+    else
+      var end = Pos(nearest.line + (data.end.line - data.start.line), data.end.ch);
+    return {start: nearest, end: end};
+  }
+
+  function atInterestingExpression(cm) {
+    var pos = cm.getCursor("end"), tok = cm.getTokenAt(pos);
+    if (tok.start < pos.ch && (tok.type == "comment" || tok.type == "string")) return false;
+    return /[\w)\]]/.test(cm.getLine(pos.line).slice(Math.max(pos.ch - 1, 0), pos.ch + 1));
+  }
+
+  // Variable renaming
+
+  function rename(ts, cm) {
+    var token = cm.getTokenAt(cm.getCursor());
+    if (!/\w/.test(token.string)) return showError(ts, cm, "Not at a variable");
+    dialog(cm, "New name for " + token.string, function(newName) {
+      ts.request(cm, {type: "rename", newName: newName, fullDocs: true}, function(error, data) {
+        if (error) return showError(ts, cm, error);
+        applyChanges(ts, data.changes);
+      });
+    });
+  }
+
+  function selectName(ts, cm) {
+    var name = findDoc(ts, cm.doc).name;
+    ts.request(cm, {type: "refs"}, function(error, data) {
+      if (error) return showError(ts, cm, error);
+      var ranges = [], cur = 0;
+      for (var i = 0; i < data.refs.length; i++) {
+        var ref = data.refs[i];
+        if (ref.file == name) {
+          ranges.push({anchor: ref.start, head: ref.end});
+          if (cmpPos(cur, ref.start) >= 0 && cmpPos(cur, ref.end) <= 0)
+            cur = ranges.length - 1;
+        }
+      }
+      cm.setSelections(ranges, cur);
+    });
+  }
+
+  var nextChangeOrig = 0;
+  function applyChanges(ts, changes) {
+    var perFile = Object.create(null);
+    for (var i = 0; i < changes.length; ++i) {
+      var ch = changes[i];
+      (perFile[ch.file] || (perFile[ch.file] = [])).push(ch);
+    }
+    for (var file in perFile) {
+      var known = ts.docs[file], chs = perFile[file];;
+      if (!known) continue;
+      chs.sort(function(a, b) { return cmpPos(b.start, a.start); });
+      var origin = "*rename" + (++nextChangeOrig);
+      for (var i = 0; i < chs.length; ++i) {
+        var ch = chs[i];
+        known.doc.replaceRange(ch.text, ch.start, ch.end, origin);
+      }
+    }
+  }
+
+  // Generic request-building helper
+
+  function buildRequest(ts, doc, query, pos) {
+    var files = [], offsetLines = 0, allowFragments = !query.fullDocs;
+    if (!allowFragments) delete query.fullDocs;
+    if (typeof query == "string") query = {type: query};
+    query.lineCharPositions = true;
+    if (query.end == null) {
+      query.end = pos || doc.doc.getCursor("end");
+      if (doc.doc.somethingSelected())
+        query.start = doc.doc.getCursor("start");
+    }
+    var startPos = query.start || query.end;
+
+    if (doc.changed) {
+      if (doc.doc.lineCount() > bigDoc && allowFragments !== false &&
+          doc.changed.to - doc.changed.from < 100 &&
+          doc.changed.from <= startPos.line && doc.changed.to > query.end.line) {
+        files.push(getFragmentAround(doc, startPos, query.end));
+        query.file = "#0";
+        var offsetLines = files[0].offsetLines;
+        if (query.start != null) query.start = Pos(query.start.line - -offsetLines, query.start.ch);
+        query.end = Pos(query.end.line - offsetLines, query.end.ch);
+      } else {
+        files.push({type: "full",
+                    name: doc.name,
+                    text: docValue(ts, doc)});
+        query.file = doc.name;
+        doc.changed = null;
+      }
+    } else {
+      query.file = doc.name;
+    }
+    for (var name in ts.docs) {
+      var cur = ts.docs[name];
+      if (cur.changed && cur != doc) {
+        files.push({type: "full", name: cur.name, text: docValue(ts, cur)});
+        cur.changed = null;
+      }
+    }
+
+    return {query: query, files: files};
+  }
+
+  function getFragmentAround(data, start, end) {
+    var doc = data.doc;
+    var minIndent = null, minLine = null, endLine, tabSize = 4;
+    for (var p = start.line - 1, min = Math.max(0, p - 50); p >= min; --p) {
+      var line = doc.getLine(p), fn = line.search(/\bfunction\b/);
+      if (fn < 0) continue;
+      var indent = CodeMirror.countColumn(line, null, tabSize);
+      if (minIndent != null && minIndent <= indent) continue;
+      minIndent = indent;
+      minLine = p;
+    }
+    if (minLine == null) minLine = min;
+    var max = Math.min(doc.lastLine(), end.line + 20);
+    if (minIndent == null || minIndent == CodeMirror.countColumn(doc.getLine(start.line), null, tabSize))
+      endLine = max;
+    else for (endLine = end.line + 1; endLine < max; ++endLine) {
+      var indent = CodeMirror.countColumn(doc.getLine(endLine), null, tabSize);
+      if (indent <= minIndent) break;
+    }
+    var from = Pos(minLine, 0);
+
+    return {type: "part",
+            name: data.name,
+            offsetLines: from.line,
+            text: doc.getRange(from, Pos(endLine, 0))};
+  }
+
+  // Generic utilities
+
+  var cmpPos = CodeMirror.cmpPos;
+
+  function elt(tagname, cls /*, ... elts*/) {
+    var e = document.createElement(tagname);
+    if (cls) e.className = cls;
+    for (var i = 2; i < arguments.length; ++i) {
+      var elt = arguments[i];
+      if (typeof elt == "string") elt = document.createTextNode(elt);
+      e.appendChild(elt);
+    }
+    return e;
+  }
+
+  function dialog(cm, text, f) {
+    if (cm.openDialog)
+      cm.openDialog(text + ": <input type=text>", f);
+    else
+      f(prompt(text, ""));
+  }
+
+  // Tooltips
+
+  function tempTooltip(cm, content) {
+    if (cm.state.ternTooltip) remove(cm.state.ternTooltip);
+    var where = cm.cursorCoords();
+    var tip = cm.state.ternTooltip = makeTooltip(where.right + 1, where.bottom, content);
+    function maybeClear() {
+      old = true;
+      if (!mouseOnTip) clear();
+    }
+    function clear() {
+      cm.state.ternTooltip = null;
+      if (!tip.parentNode) return;
+      cm.off("cursorActivity", clear);
+      cm.off('blur', clear);
+      cm.off('scroll', clear);
+      fadeOut(tip);
+    }
+    var mouseOnTip = false, old = false;
+    CodeMirror.on(tip, "mousemove", function() { mouseOnTip = true; });
+    CodeMirror.on(tip, "mouseout", function(e) {
+      if (!CodeMirror.contains(tip, e.relatedTarget || e.toElement)) {
+        if (old) clear();
+        else mouseOnTip = false;
+      }
+    });
+    setTimeout(maybeClear, 1700);
+    cm.on("cursorActivity", clear);
+    cm.on('blur', clear);
+    cm.on('scroll', clear);
+  }
+
+  function makeTooltip(x, y, content) {
+    var node = elt("div", cls + "tooltip", content);
+    node.style.left = x + "px";
+    node.style.top = y + "px";
+    document.body.appendChild(node);
+    return node;
+  }
+
+  function remove(node) {
+    var p = node && node.parentNode;
+    if (p) p.removeChild(node);
+  }
+
+  function fadeOut(tooltip) {
+    tooltip.style.opacity = "0";
+    setTimeout(function() { remove(tooltip); }, 1100);
+  }
+
+  function showError(ts, cm, msg) {
+    if (ts.options.showError)
+      ts.options.showError(cm, msg);
+    else
+      tempTooltip(cm, String(msg));
+  }
+
+  function closeArgHints(ts) {
+    if (ts.activeArgHints) { remove(ts.activeArgHints); ts.activeArgHints = null; }
+  }
+
+  function docValue(ts, doc) {
+    var val = doc.doc.getValue();
+    if (ts.options.fileFilter) val = ts.options.fileFilter(val, doc.name, doc.doc);
+    return val;
+  }
+
+  // Worker wrapper
+
+  function WorkerServer(ts) {
+    var worker = ts.worker = new Worker(ts.options.workerScript);
+    worker.postMessage({type: "init",
+                        defs: ts.options.defs,
+                        plugins: ts.options.plugins,
+                        scripts: ts.options.workerDeps});
+    var msgId = 0, pending = {};
+
+    function send(data, c) {
+      if (c) {
+        data.id = ++msgId;
+        pending[msgId] = c;
+      }
+      worker.postMessage(data);
+    }
+    worker.onmessage = function(e) {
+      var data = e.data;
+      if (data.type == "getFile") {
+        getFile(ts, data.name, function(err, text) {
+          send({type: "getFile", err: String(err), text: text, id: data.id});
+        });
+      } else if (data.type == "debug") {
+        window.console.log(data.message);
+      } else if (data.id && pending[data.id]) {
+        pending[data.id](data.err, data.body);
+        delete pending[data.id];
+      }
+    };
+    worker.onerror = function(e) {
+      for (var id in pending) pending[id](e);
+      pending = {};
+    };
+
+    this.addFile = function(name, text) { send({type: "add", name: name, text: text}); };
+    this.delFile = function(name) { send({type: "del", name: name}); };
+    this.request = function(body, c) { send({type: "req", body: body}, c); };
+  }
+});

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -1,0 +1,6028 @@
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    return mod(require("tern/lib/infer"), require("tern/lib/tern"));
+  if (typeof define == "function" && define.amd) // AMD
+    return define([ "tern/lib/infer", "tern/lib/tern" ], mod);
+  mod(tern, tern);
+})(function(infer, tern) {
+  "use strict";
+
+  tern.registerPlugin("threejs", function(server, options) {
+    return {
+      defs : {
+  "!name": "threejs",
+  "THREE": {
+    "Original": {
+      "!url": "http://threejs.org/docs/#Reference/Original",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "todo"
+    },
+    "Camera": {
+      "!url": "http://threejs.org/docs/#Reference/cameras/Camera",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "matrixWorldInverse": {
+          "!type": "+THREE.Matrix4",
+          "!doc": "This is the inverse of matrixWorld. MatrixWorld contains the Matrix which has the world transform of the Camera."
+        },
+        "projectionMatrix": {
+          "!type": "+THREE.Matrix4",
+          "!doc": "This is the matrix which contains the projection."
+        },
+        "lookAt": {
+          "!type": "fn(vector: +THREE.Vector3)",
+          "!doc": "vector — point to look at<br>\n\t\t<br>\n\t\tThis makes the camera look at the vector position in the global space as long as the parent of this camera is the scene or at position (0,0,0)."
+        }
+      },
+      "!doc": "Abstract base class for cameras. This class should always be inherited when you build a new camera.",
+      "!type": "fn()"
+    },
+    "CubeCamera": {
+      "!url": "http://threejs.org/docs/#Reference/cameras/CubeCamera",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "renderTarget": {
+          "!type": "+THREE.WebGLRenderTargetCube",
+          "!doc": "The cube texture that gets generated."
+        },
+        "updateCubeMap": {
+          "!type": "fn(renderer: todo, scene: todo) -> todo",
+          "!doc": "Call this to update the renderTarget."
+        }
+      },
+      "!doc": "Creates 6 cameras that render to a [page:WebGLRenderTargetCube].",
+      "!type": "fn(near: number, far: number, cubeResolution: number)"
+    },
+    "OrthographicCamera": {
+      "!url": "http://threejs.org/docs/#Reference/cameras/OrthographicCamera",
+      "prototype": {
+        "!proto": "THREE.Camera.prototype",
+        "left": {
+          "!type": "number",
+          "!doc": "Camera frustum left plane."
+        },
+        "right": {
+          "!type": "number",
+          "!doc": "Camera frustum right plane."
+        },
+        "top": {
+          "!type": "number",
+          "!doc": "Camera frustum top plane."
+        },
+        "bottom": {
+          "!type": "number",
+          "!doc": "Camera frustum bottom plane."
+        },
+        "near": {
+          "!type": "number",
+          "!doc": "Camera frustum near plane."
+        },
+        "far": {
+          "!type": "number",
+          "!doc": "Camera frustum far plane."
+        },
+        "updateProjectionMatrix": {
+          "!type": "fn()",
+          "!doc": "Updates the camera projection matrix. Must be called after change of parameters."
+        }
+      },
+      "!doc": "Camera with orthographic projection.",
+      "!type": "fn(left: number, right: number, top: number, bottom: number, near: number, far: number)"
+    },
+    "PerspectiveCamera": {
+      "!url": "http://threejs.org/docs/#Reference/cameras/PerspectiveCamera",
+      "prototype": {
+        "!proto": "THREE.Camera.prototype",
+        "fov": {
+          "!type": "number",
+          "!doc": "Camera frustum vertical field of view, from bottom to top of view, in degrees."
+        },
+        "aspect": {
+          "!type": "number",
+          "!doc": "Camera frustum aspect ratio, window width divided by window height."
+        },
+        "near": {
+          "!type": "number",
+          "!doc": "Camera frustum near plane."
+        },
+        "far": {
+          "!type": "number",
+          "!doc": "Camera frustum far plane."
+        },
+        "setLens": {
+          "!type": "fn(focalLength: number, frameSize: number)",
+          "!doc": "Uses focal length (in mm) to estimate and set FOV 35mm (fullframe) camera is used if frame size is not specified.<br>\n\t\tFormula based on [link:http://www.bobatkins.com/photography/technical/field_of_view.html]"
+        },
+        "setViewOffset": {
+          "!type": "fn(fullWidth: number, fullHeight: number, x: number, y: number, width: number, height: number)",
+          "!doc": "For example, if you have 3x2 monitors and each monitor is 1920x1080 and the monitors are in grid like this:<br>\n\n\t\t<pre>+---+---+---+\n| A | B | C |\n+---+---+---+\n| D | E | F |\n+---+---+---+</pre>\n\n\t\tthen for each monitor you would call it like this:<br>\n\n\t\t<code>var w = 1920;\nvar h = 1080;\nvar fullWidth = w * 3;\nvar fullHeight = h * 2;\n\n// A\ncamera.setViewOffset( fullWidth, fullHeight, w * 0, h * 0, w, h );\n// B\ncamera.setViewOffset( fullWidth, fullHeight, w * 1, h * 0, w, h );\n// C\ncamera.setViewOffset( fullWidth, fullHeight, w * 2, h * 0, w, h );\n// D\ncamera.setViewOffset( fullWidth, fullHeight, w * 0, h * 1, w, h );\n// E\ncamera.setViewOffset( fullWidth, fullHeight, w * 1, h * 1, w, h );\n// F\ncamera.setViewOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );\n</code>\n\n\t\tNote there is no reason monitors have to be the same size or in a grid."
+        },
+        "updateProjectionMatrix": {
+          "!type": "fn()",
+          "!doc": "Updates the camera projection matrix. Must be called after change of parameters."
+        }
+      },
+      "!doc": "Camera with perspective projection.",
+      "!type": "fn(fov: number, aspect: number, near: number, far: number)"
+    },
+    "CustomBlendingEquations": {
+      "!url": "http://threejs.org/docs/#Reference/constants/CustomBlendingEquations",
+      "prototype": {}
+    },
+    "GLState": {
+      "!url": "http://threejs.org/docs/#Reference/constants/GLState",
+      "prototype": {}
+    },
+    "Materials": {
+      "!url": "http://threejs.org/docs/#Reference/constants/Materials",
+      "prototype": {}
+    },
+    "ShadowingTypes": {
+      "!url": "http://threejs.org/docs/#Reference/constants/ShadowingTypes",
+      "prototype": {}
+    },
+    "Textures": {
+      "!url": "http://threejs.org/docs/#Reference/constants/Textures",
+      "prototype": {}
+    },
+    "BufferAttribute": {
+      "!url": "http://threejs.org/docs/#Reference/core/BufferAttribute",
+      "prototype": {
+        "array": {
+          "!type": "[]",
+          "!doc": "Stores the data associated with this attribute; can be an Array or a Typed Array. This element should have <code>itemSize * numVertices</code> elements, where numVertices is the number of vertices in the associated [page:BufferGeometry geometry]."
+        },
+        "itemSize": {
+          "!type": "number",
+          "!doc": "Records how many items of the array are associated with a particular vertex. For instance, if this\n\t\tattribute is storing a 3-component vector (such as a position, normal, or color), then itemSize should be 3."
+        },
+        "length": {
+          "!type": "number",
+          "!doc": "Gives the total number of elements in the array."
+        },
+        "needsUpdate": {
+          "!type": "bool",
+          "!doc": "Flag to indicate that this attribute has changed and should be re-send to the GPU. Set this to true when you modify the value of the array."
+        },
+        "setX": {
+          "!type": "fn(index, x)",
+          "!doc": "Sets the value of the array at <code>index * itemSize</code> to x"
+        },
+        "setY": {
+          "!type": "fn(index, y)",
+          "!doc": "Sets the value of the array at <code>index * itemSize + 1</code> to y"
+        },
+        "setZ": {
+          "!type": "fn(index, z)",
+          "!doc": "Sets the value of the array at <code>index * itemSize + 2</code> to z"
+        },
+        "setXY": {
+          "!type": "fn(index, x, y)",
+          "!doc": "Sets the value of the array at <code>index * itemSize</code> to x and \n\t\tsets the value of the array at <code>index * itemSize + 1</code> to y"
+        },
+        "setXYZ": {
+          "!type": "fn(index, x, y, z)",
+          "!doc": "Sets the value of the array at <code>index * itemSize</code> to x,\n\t\tthe value of the array at <code>index * itemSize + 1</code> to y, and\n\t\tthe value of the array at <code>index * itemSize + 2</code> to z."
+        },
+        "setXYZW": {
+          "!type": "fn(index, x, y, z, w)",
+          "!doc": "Sets the value of the array at <code>index * itemSize</code> to x,\n\t\tthe value of the array at <code>index * itemSize + 1</code> to y, \n\t\tthe value of the array at <code>index * itemSize + 2</code> to z, and\n\t\tthe value of the array at <code>index * itemSize + 3</code> to w."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.BufferAttribute",
+          "!doc": "Copies this attribute."
+        }
+      },
+      "!doc": "This class stores data for an attribute associated with a [page:BufferGeometry]. See that page for details and a usage example. This class is used to store builtin attributes such as vertex position, normals, color, etc., but can also be used in your code to store custom attributes in a [page:BufferGeometry].",
+      "!type": "fn(array: [], itemSize: number)"
+    },
+    "BufferGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/core/BufferGeometry",
+      "prototype": {
+        "id": {
+          "!type": "number",
+          "!doc": "Unique number for this buffergeometry instance."
+        },
+        "attributes": {
+          "!type": "Hashmap",
+          "!doc": "This hashmap has as id the name of the attribute to be set and as value the [page:BufferAttribute buffer] to set it to.\n\t\tRather than accessing this property directly, use addAttribute and getAttribute to access attributes of this geometry."
+        },
+        "drawCalls": {
+          "!type": "[]",
+          "!doc": "For geometries that use indexed triangles, this Array can be used to split the object into multiple WebGL draw calls. Each draw call will draw some subset of the vertices in this geometry using the configured [page:Material shader]. This may be necessary if, for instance, you have more than 65535 vertices in your object. \n\t\tEach element is an object of the form:\n\t\t<code>{ start: Integer, count: Integer, index: Integer }</code>\n\t\twhere start specifies the index of the first vertex in this draw call, count specifies how many vertices are included, and index specifies an optional offset.\n\n\t\tUse addDrawCall to add draw calls, rather than modifying this array directly."
+        },
+        "boundingBox": {
+          "!type": "+THREE.Box3",
+          "!doc": "Bounding box.\n\t\t<code>{ min: new THREE.Vector3(), max: new THREE.Vector3() }</code>"
+        },
+        "boundingSphere": {
+          "!type": "+THREE.Sphere",
+          "!doc": "Bounding sphere.\n\t\t<code>{ radius: float }</code>"
+        },
+        "morphTargets": {
+          "!type": "[]",
+          "!doc": "Array of morph targets. Each morph target is a Javascript object:\n\t\t<code>{ name: \"targetName\", vertices: [ new THREE.Vertex(), ... ] }</code>\n\t\tMorph vertices match number and order of primary vertices."
+        },
+        "hasTangents": {
+          "!type": "boolean",
+          "!doc": "True if BufferGeometry has tangents. Set in [page:.computeTangents]."
+        },
+        "addAttribute": {
+          "!type": "null",
+          "!doc": "Adds an attribute to this geometry. Use this rather than the attributes property, \n\t\tbecause an internal array of attributes is maintained to speed up iterating over\n\t\tattributes."
+        },
+        "addDrawCall": {
+          "!type": "fn(start: number, count: number, indexOffset: number)",
+          "!doc": "Adds a draw call to this geometry; see the drawcalls property for details."
+        },
+        "applyMatrix": {
+          "!type": "fn(matrix: +THREE.Matrix4)",
+          "!doc": "Bakes matrix transform directly into vertex coordinates."
+        },
+        "computeVertexNormals": {
+          "!type": "fn()",
+          "!doc": "Computes vertex normals by averaging face normals.<br>"
+        },
+        "computeTangents": {
+          "!type": "fn()",
+          "!doc": "Computes vertex tangents.<br>\n\t\tBased on [link:http://www.terathon.com/code/tangent.html]<br>\n\t\tGeometry must have vertex [page:UV UVs] (layer 0 will be used)."
+        },
+        "computeBoundingBox": {
+          "!type": "fn()",
+          "!doc": "Computes bounding box of the geometry, updating [page:Geometry Geometry.boundingBox] attribute.<br>\n\t\tBounding boxes aren't computed by default. They need to be explicitly computed, otherwise they are *null*."
+        },
+        "computeBoundingSphere": {
+          "!type": "fn()",
+          "!doc": "Computes bounding sphere of the geometry, updating [page:Geometry Geometry.boundingSphere] attribute.<br>\n\t\tBounding spheres aren't computed by default. They need to be explicitly computed, otherwise they are *null*."
+        },
+        "dispose": {
+          "!type": "fn()",
+          "!doc": "Disposes the object from memory. <br>\n\t\tYou need to call this when you want the bufferGeometry removed while the application is running."
+        },
+        "fromGeometry": {
+          "!type": "fn()",
+          "!doc": "Populates this BufferGeometry with data from a [page:Geometry] object."
+        },
+        "getAttribute": {
+          "!type": "fn(name: string) -> +THREE.BufferAttribute",
+          "!doc": "Returns the [page:BufferAttribute attribute] with the specified name."
+        },
+        "normalizeNormals": {
+          "!type": "fn()",
+          "!doc": "Every normal vector in a geometry will have a magnitude of 1.\n\t\tThis will correct lighting on the geometry surfaces."
+        }
+      },
+      "!doc": "<p>\n\t\tThis class is an efficient alternative to [page:Geometry], because it stores all data, including\n\t\tvertex positions, face indices, normals, colors, UVs, and custom attributes within buffers; this\n\t\treduces the cost of passing all this data to the GPU. \n\t\tThis also makes BufferGeometry harder to work with than [page:Geometry]; rather than accessing \n\t\tposition data as [page:Vector3] objects, color data as [page:Color] objects, and so on, you have to \n\t\taccess the raw data from the appropriate [page:BufferAttribute attribute] buffer. This makes \n\t\tBufferGeometry best-suited for static objects where you don't need to manipulate the geometry much\n\t\tafter instantiating it.\n\t\t</p>\n\n\t\t<h3>Example</h3>\n\t\t<code>\n\t\tvar geometry = new THREE.BufferGeometry();\n\t\t// create a simple square shape. We duplicate the top left and bottom right\n\t\t// vertices because each vertex needs to appear once per triangle. \n\t\tvar vertexPositions = [ \n\t\t\t[-1.0, -1.0,  1.0],\n\t\t\t[ 1.0, -1.0,  1.0],\n\t\t\t[ 1.0,  1.0,  1.0],\n\n\t\t\t[ 1.0,  1.0,  1.0],\n\t\t\t[-1.0,  1.0,  1.0],\n\t\t\t[-1.0, -1.0,  1.0]\n\t\t];\n\t\tvar vertices = new Float32Array( vertexPositions.length * 3 ); // three components per vertex\n\n\t\t// components of the position vector for each vertex are stored\n\t\t// contiguously in the buffer.\n\t\tfor ( var i = 0; i &lt; vertexPositions.length; i++ )\n\t\t{\n\t\t\tvertices[ i*3 + 0 ] = vertexPositions[i][0];\n\t\t\tvertices[ i*3 + 1 ] = vertexPositions[i][1];\n\t\t\tvertices[ i*3 + 2 ] = vertexPositions[i][2];\n\t\t}\n\n\t\t// itemSize = 3 because there are 3 values (components) per vertex\n\t\tgeometry.addAttribute( 'position', new THREE.BufferAttribute( vertices, 3 ) );\n\t\tvar material = new THREE.MeshBasicMaterial( { color: 0xff0000 } );\n\t\tvar mesh = new THREE.Mesh( geometry, material );\n\t\t</code>\n\t\t<p>More examples: [example:webgl_buffergeometry Complex mesh with non-indexed faces], [example:webgl_buffergeometry_uint Complex mesh with indexed faces], [example:webgl_buffergeometry_lines Lines], [example:webgl_buffergeometry_lines_indexed Indexed Lines], [example:webgl_buffergeometry_particles Particles], and [example:webgl_buffergeometry_rawshader Raw Shaders].</p>\n\n\t\t\n\t\t<h3>Accessing attributes</h3>\n\t\t<p>\n\t\tWebGL stores data associated with individual vertices of a geometry in <emph>attributes</emph>. \n\t\tExamples include the position of the vertex, the normal vector for the vertex, the vertex color,\n\t\tand so on. When using [page:Geometry], the [page:WebGLRenderer renderer] takes care of wrapping\n\t\tup this information into typed array buffers and sending this data to the shader. With \n\t\tBufferGeometry, all of this data is stored in buffers associated with an individual attributes.\n\t\tThis means that to get the position data associated with a vertex (for instance), you must call\n\t\t[page:.getAttribute] to access the 'position' [page:BufferAttribute attribute], then access the individual \n\t\tx, y, and z coordinates of the position.  \n\t\t</p>\n\t\t<p>\n\t\tThe following attributes are set by various members of this class:\n\t\t</p>\n\t\t<h4>[page:BufferAttribute position] (itemSize: 3)</h4>\n\t\t<div>\n\t\tStores the x, y, and z coordinates of each vertex in this geometry. Set by [page:.fromGeometry]().\n\t\t</div>\n\n\t\t<h4>[page:BufferAttribute normal] (itemSize: 3)</h4>\n\t\t<div>\n\t\tStores the x, y, and z components of the face or vertex normal vector of each vertex in this geometry.\n\t\tSet by [page:.fromGeometry]().\n\t\t</div>\n\n\t\t<h4>[page:BufferAttribute color] (itemSize: 3)</h4>\n\t\t<div>\n\t\tStores the red, green, and blue channels of vertex color of each vertex in this geometry.\n\t\tSet by [page:.fromGeometry]().\n\t\t</div>\n\n\t\t<h4>[page:BufferAttribute tangent] (itemSize: 3)</h4>\n\t\t<div>\n\t\tStores the x, y, and z components of the tangent vector of each vertex in this geometry. Set by [page:.computeTangents]().\n\t\t</div>\n\n\t\t<h4>[page:BufferAttribute index] (itemSize: 3)</h4>\n\t\tAllows for vertices to be re-used across multiple triangles; this is called using \"indexed triangles,\" and works much the same as it does in [page:Geometry]: each triangle is associated with the index of three vertices. This attribute therefore stores the index of each vertex for each triangular face.\n\n\t\tIf this attribute is not set, the [page:WebGLRenderer renderer] assumes that each three contiguous positions represent a single triangle.",
+      "!type": "fn()"
+    },
+    "Clock": {
+      "!url": "http://threejs.org/docs/#Reference/core/Clock",
+      "prototype": {
+        "autoStart": {
+          "!type": "bool",
+          "!doc": "If set, starts the clock automatically when the first update is called."
+        },
+        "startTime": {
+          "!type": "number",
+          "!doc": "When the clock is running, It holds the start time of the clock. <br>\n\t\tThis counted from the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC."
+        },
+        "oldTime": {
+          "!type": "number",
+          "!doc": "When the clock is running, It holds the previous time from a update.<br>\n\t\tThis counted from the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC."
+        },
+        "elapsedTime": {
+          "!type": "number",
+          "!doc": "When the clock is running, It holds the time elapsed between the start of the clock to the previous update.<br>\n\t\tThis counted from the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC."
+        },
+        "running": {
+          "!type": "bool",
+          "!doc": "This property keeps track whether the clock is running or not."
+        },
+        "start": {
+          "!type": "fn()",
+          "!doc": "Starts clock."
+        },
+        "stop": {
+          "!type": "fn()",
+          "!doc": "Stops clock."
+        },
+        "getElapsedTime": {
+          "!type": "fn() -> number",
+          "!doc": "Get the seconds passed since the clock started."
+        },
+        "getDelta": {
+          "!type": "fn() -> number",
+          "!doc": "Get the seconds passed since the last call to this method."
+        }
+      },
+      "!doc": "Object for keeping track of time.",
+      "!type": "fn(autoStart: bool)"
+    },
+    "EventDispatcher": {
+      "!url": "http://threejs.org/docs/#Reference/core/EventDispatcher",
+      "prototype": {
+        "addEventListener": {
+          "!type": "fn(type: string, listener: function)",
+          "!doc": "Adds a listener to an event type."
+        },
+        "hasEventListener": {
+          "!type": "fn(type: string, listener: function) -> bool",
+          "!doc": "Checks if listener is added to an event type."
+        },
+        "removeEventListener": {
+          "!type": "fn(type: string, listener: function)",
+          "!doc": "Removes a listener from an event type."
+        },
+        "dispatchEvent": {
+          "!type": "fn(type: string)",
+          "!doc": "Fire an event type."
+        }
+      },
+      "!doc": "JavaScript events for custom objects.<br>\n\t\t<a href=\"https://github.com/mrdoob/eventdispatcher.js\">https://github.com/mrdoob/eventdispatcher.js</a>",
+      "!type": "fn()"
+    },
+    "Face3": {
+      "!url": "http://threejs.org/docs/#Reference/core/Face3",
+      "prototype": {
+        "a": {
+          "!type": "number",
+          "!doc": "Vertex A index."
+        },
+        "b": {
+          "!type": "number",
+          "!doc": "Vertex B index."
+        },
+        "c": {
+          "!type": "number",
+          "!doc": "Vertex C index."
+        },
+        "normal": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Face normal."
+        },
+        "color": {
+          "!type": "+THREE.Color",
+          "!doc": "Face color."
+        },
+        "vertexNormals": {
+          "!type": "[]",
+          "!doc": "Array of 3 vertex normals."
+        },
+        "vertexColors": {
+          "!type": "[]",
+          "!doc": "Array of 3 vertex colors."
+        },
+        "vertexTangents": {
+          "!type": "[]",
+          "!doc": "Array of 3 vertex tangents."
+        },
+        "materialIndex": {
+          "!type": "number",
+          "!doc": "Material index (points to [page:MeshFaceMaterial MeshFaceMaterial.materials])."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Face3",
+          "!doc": "Creates a new clone of the Face3 object."
+        }
+      },
+      "!doc": "Triangle face.",
+      "!type": "fn(a: number, b: number, c: number, normal: +THREE.Vector3, color: +THREE.Color, materialIndex: number)"
+    },
+    "Geometry": {
+      "!url": "http://threejs.org/docs/#Reference/core/Geometry",
+      "prototype": {
+        "id": {
+          "!type": "number",
+          "!doc": "Unique number for this geometry instance."
+        },
+        "name": {
+          "!type": "string",
+          "!doc": "Name for this geometry. Default is an empty string."
+        },
+        "vertices": {
+          "!type": "[]",
+          "!doc": "Array of [page:Vector3 vertices].<br>\n\t\tThe array of vertices holds every position of points in the model.<br>\n\t\tTo signal an update in this array, [page:Geometry Geometry.verticesNeedUpdate] needs to be set to true."
+        },
+        "colors": {
+          "!type": "[]",
+          "!doc": "Array of vertex [page:Color colors], matching number and order of vertices.<br>\n\t\tUsed in [page:PointCloud] and [page:Line].<br>\n\t\t[page:Mesh Meshes] use per-face-use-of-vertex colors embedded directly in faces.<br>\n\t\tTo signal an update in this array, [page:Geometry Geometry.colorsNeedUpdate] needs to be set to true."
+        },
+        "faces": {
+          "!type": "[]",
+          "!doc": "Array of [page:Face3 triangles].<br>\n\t\tThe array of faces describe how each vertex in the model is connected with each other.<br>\n\t\tTo signal an update in this array, [page:Geometry Geometry.elementsNeedUpdate] needs to be set to true."
+        },
+        "faceVertexUvs": {
+          "!type": "[]",
+          "!doc": "Array of face [page:UV] layers.<br>\n\t\tEach UV layer is an array of [page:UV]s matching the order and number of vertices in faces.<br>\n\t\tTo signal an update in this array, [page:Geometry Geometry.uvsNeedUpdate] needs to be set to true."
+        },
+        "morphTargets": {
+          "!type": "[]",
+          "!doc": "Array of morph targets. Each morph target is a Javascript object:\n\t\t<code>{ name: \"targetName\", vertices: [ new THREE.Vector3(), ... ] }</code>\n\t\tMorph vertices match number and order of primary vertices."
+        },
+        "morphColors": {
+          "!type": "[]",
+          "!doc": "Array of morph colors. Morph colors have similar structure as morph targets, each color set is a Javascript object:\n\t\t<code>morphColor = { name: \"colorName\", colors: [ new THREE.Color(), ... ] }</code>\n\t\tMorph colors can match either the number and order of faces (face colors) or the number of vertices (vertex colors)."
+        },
+        "morphNormals": {
+          "!type": "[]",
+          "!doc": "Array of morph normals. Morph normals have similar structure as morph targets, each normal set is a Javascript object:\n\t\t<code>morphNormal = { name: \"NormalName\", normals: [ new THREE.Vector3(), ... ] }</code>"
+        },
+        "skinWeights": {
+          "!type": "[]",
+          "!doc": "Array of skinning weights, matching number and order of vertices."
+        },
+        "skinIndices": {
+          "!type": "[]",
+          "!doc": "Array of skinning indices, matching number and order of vertices."
+        },
+        "boundingBox": {
+          "!type": "object",
+          "!doc": "Bounding box.\n\t\t<code>{ min: new THREE.Vector3(), max: new THREE.Vector3() }</code>"
+        },
+        "boundingSphere": {
+          "!type": "object",
+          "!doc": "Bounding sphere.\n\t\t<code>{ radius: float }</code>"
+        },
+        "hasTangents": {
+          "!type": "bool",
+          "!doc": "True if geometry has tangents. Set in [page:Geometry Geometry.computeTangents]."
+        },
+        "dynamic": {
+          "!type": "bool",
+          "!doc": "Set to *true* if attribute buffers will need to change in runtime (using \"dirty\" flags).<br>\n\t\tUnless set to true internal typed arrays corresponding to buffers will be deleted once sent to GPU.<br>\n\t\tDefaults to true."
+        },
+        "verticesNeedUpdate": {
+          "!type": "bool",
+          "!doc": "Set to *true* if the vertices array has been updated."
+        },
+        "elementsNeedUpdate": {
+          "!type": "bool",
+          "!doc": "Set to *true* if the faces array has been updated."
+        },
+        "uvsNeedUpdate": {
+          "!type": "bool",
+          "!doc": "Set to *true* if the uvs array has been updated."
+        },
+        "normalsNeedUpdate": {
+          "!type": "bool",
+          "!doc": "Set to *true* if the normals array has been updated."
+        },
+        "tangentsNeedUpdate": {
+          "!type": "bool",
+          "!doc": "Set to *true* if the tangents in the faces has been updated."
+        },
+        "colorsNeedUpdate": {
+          "!type": "bool",
+          "!doc": "Set to *true* if the colors array has been updated."
+        },
+        "lineDistancesNeedUpdate": {
+          "!type": "bool",
+          "!doc": "Set to *true* if the linedistances array has been updated."
+        },
+        "lineDistances": {
+          "!type": "array",
+          "!doc": "An array containing distances between vertices for Line geometries.\n\t\tThis is required for LinePieces/LineDashedMaterial to render correctly.\n\t\tLine distances can also be generated with computeLineDistances."
+        },
+        "applyMatrix": {
+          "!type": "fn(matrix: +THREE.Matrix4)",
+          "!doc": "Bakes matrix transform directly into vertex coordinates."
+        },
+        "computeFaceNormals": {
+          "!type": "fn()",
+          "!doc": "Computes face normals."
+        },
+        "computeVertexNormals": {
+          "!type": "fn()",
+          "!doc": "Computes vertex normals by averaging face normals.<br>\n\t\tFace normals must be existing / computed beforehand."
+        },
+        "computeMorphNormals": {
+          "!type": "fn()",
+          "!doc": "Computes morph normals."
+        },
+        "computeTangents": {
+          "!type": "fn()",
+          "!doc": "Computes vertex tangents.<br>\n\t\tBased on [link:http://www.terathon.com/code/tangent.html]<br>\n\t\tGeometry must have vertex [page:UV UVs] (layer 0 will be used)."
+        },
+        "computeBoundingBox": {
+          "!type": "fn()",
+          "!doc": "Computes bounding box of the geometry, updating [page:Geometry Geometry.boundingBox] attribute."
+        },
+        "computeBoundingSphere": {
+          "!type": "fn()",
+          "!doc": "Neither bounding boxes or bounding spheres are computed by default. They need to be explicitly computed, otherwise they are *null*."
+        },
+        "merge": {
+          "!type": "fn(geometry: +THREE.Geometry, matrix: +THREE.Matrix4, materialIndexOffset: number)",
+          "!doc": "Merge two geometries or geometry and geometry from object (using object's transform)"
+        },
+        "mergeVertices": {
+          "!type": "fn()",
+          "!doc": "Checks for duplicate vertices using hashmap.<br>\n\t\tDuplicated vertices are removed and faces' vertices are updated."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Geometry",
+          "!doc": "Creates a new clone of the Geometry."
+        },
+        "dispose": {
+          "!type": "fn()",
+          "!doc": "Removes The object from memory. <br>\n\t\tDon't forget to call this method when you remove a geometry because it can cause memory leaks."
+        },
+        "computeLineDistances": {
+          "!type": "fn()",
+          "!doc": "Compute distances between vertices for Line geometries."
+        }
+      },
+      "!doc": "Base class for geometries.<br>\n\t\tA geometry holds all data necessary to describe a 3D model.",
+      "!type": "fn()"
+    },
+    "Object3D": {
+      "!url": "http://threejs.org/docs/#Reference/core/Object3D",
+      "prototype": {
+        "id": {
+          "!type": "number",
+          "!doc": "readonly – Unique number for this object instance."
+        },
+        "uuid": {
+          "!type": "string",
+          "!doc": "[link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID] of this object instance.\n\t\tThis gets automatically assigned, so this shouldn't be edited."
+        },
+        "name": {
+          "!type": "string",
+          "!doc": "Optional name of the object (doesn't need to be unique)."
+        },
+        "parent": {
+          "!type": "+THREE.Object3D",
+          "!doc": "Object's parent in the scene graph."
+        },
+        "children": {
+          "!type": "+THREE.Object3D",
+          "!doc": "Array with object's children."
+        },
+        "position": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Object's local position."
+        },
+        "rotation": {
+          "!type": "+THREE.Euler",
+          "!doc": "Object's local rotation (<a href=\"https://en.wikipedia.org/wiki/Euler_angles\" target=\"_blank\">Euler angles</a>), in radians."
+        },
+        "scale": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Object's local scale."
+        },
+        "up": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Up direction."
+        },
+        "matrix": {
+          "!type": "+THREE.Matrix4",
+          "!doc": "Local transform."
+        },
+        "quaternion": {
+          "!type": "+THREE.Quaternion",
+          "!doc": "Object's local rotation as [page:Quaternion Quaternion]."
+        },
+        "visible": {
+          "!type": "bool",
+          "!doc": "default – true"
+        },
+        "castShadow": {
+          "!type": "bool",
+          "!doc": "default – false"
+        },
+        "receiveShadow": {
+          "!type": "bool",
+          "!doc": "default – false"
+        },
+        "frustumCulled": {
+          "!type": "bool",
+          "!doc": "default – true"
+        },
+        "matrixAutoUpdate": {
+          "!type": "bool",
+          "!doc": "default – true"
+        },
+        "matrixWorldNeedsUpdate": {
+          "!type": "bool",
+          "!doc": "default – false"
+        },
+        "rotationAutoUpdate": {
+          "!type": "bool",
+          "!doc": "default – true"
+        },
+        "userData": {
+          "!type": "object",
+          "!doc": "An object that can be used to store custom data about the Object3d. It should not hold references to functions as these will not be cloned."
+        },
+        "matrixWorld": {
+          "!type": "+THREE.Matrix4",
+          "!doc": "The global transform of the object. If the Object3d has no parent, then it's identical to the local transform."
+        },
+        "applyMatrix": {
+          "!type": "fn(matrix: +THREE.Matrix4)",
+          "!doc": "This updates the position, rotation and scale with the matrix."
+        },
+        "translateX": {
+          "!type": "fn(distance: number)",
+          "!doc": "Translates object along x axis by distance."
+        },
+        "translateY": {
+          "!type": "fn(distance: number)",
+          "!doc": "Translates object along y axis by distance."
+        },
+        "translateZ": {
+          "!type": "fn(distance: number)",
+          "!doc": "Translates object along z axis by distance."
+        },
+        "localToWorld": {
+          "!type": "fn(vector: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Updates the vector from local space to world space."
+        },
+        "worldToLocal": {
+          "!type": "fn(vector: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Updates the vector from world space to local space."
+        },
+        "lookAt": {
+          "!type": "fn(vector: +THREE.Vector3)",
+          "!doc": "Rotates object to face point in space."
+        },
+        "traverse": {
+          "!type": "fn(callback: function)",
+          "!doc": "Executes the callback on this object and all descendants."
+        },
+        "traverseVisible": {
+          "!type": "fn(callback: function)",
+          "!doc": "Like traverse, but the callback will only be executed for visible objects.\n\t\tDescendants of invisible objects are not traversed."
+        },
+        "traverseAncestors": {
+          "!type": "fn(callback: function)",
+          "!doc": "Executes the callback on this object and all ancestors."
+        },
+        "updateMatrix": {
+          "!type": "fn()",
+          "!doc": "Updates local transform."
+        },
+        "updateMatrixWorld": {
+          "!type": "fn(force: bool)",
+          "!doc": "Updates global transform of the object and its children."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Object3D",
+          "!doc": "Creates a new clone of this object and all descendants."
+        },
+        "getObjectByName": {
+          "!type": "fn(name: string) -> +THREE.Object3D",
+          "!doc": "Searches through the object's children and returns the first with a matching name."
+        },
+        "getObjectById": {
+          "!type": "fn(id: number) -> +THREE.Object3D",
+          "!doc": "Searches through the object's children and returns the first with a matching id."
+        },
+        "translateOnAxis": {
+          "!type": "fn(axis: +THREE.Vector3, distance: number) -> +THREE.Object3D",
+          "!doc": "Translate an object by distance along an axis in object space. The axis is assumed to be normalized."
+        },
+        "rotateOnAxis": {
+          "!type": "fn(axis: +THREE.Vector3, angle: number) -> +THREE.Object3D",
+          "!doc": "Rotate an object along an axis in object space. The axis is assumed to be normalized."
+        },
+        "raycast": {
+          "!type": "fn(raycaster: +THREE.Raycaster, intersects: []) -> []",
+          "!doc": "Abstract method to get intersections between a casted ray and this object. Subclasses such as [page:Mesh], [page:Line], and [page:PointCloud] implement this method in order to participate in raycasting."
+        }
+      },
+      "!doc": "Base class for scene graph objects.",
+      "!type": "fn()"
+    },
+    "Raycaster": {
+      "!url": "http://threejs.org/docs/#Reference/core/Raycaster",
+      "prototype": {
+        "ray": {
+          "!type": "+THREE.Ray",
+          "!doc": "The Ray used for the raycasting."
+        },
+        "near": {
+          "!type": "float",
+          "!doc": "The near factor of the raycaster. This value indicates which objects can be discarded based on the distance.<br>\n\t\tThis value shouldn't be negative and should be smaller than the far property."
+        },
+        "far": {
+          "!type": "float",
+          "!doc": "The far factor of the raycaster. This value indicates which objects can be discarded based on the distance.<br>\n\t\tThis value shouldn't be negative and should be larger than the near property."
+        },
+        "precision": {
+          "!type": "float",
+          "!doc": "The precision factor of the raycaster when intersecting [page:Mesh] objects."
+        },
+        "set": {
+          "!type": "fn(origin: +THREE.Vector3, direction: +THREE.Vector3)",
+          "!doc": "Updates the ray with a new origin and direction."
+        },
+        "setFromCamera": {
+          "!type": "fn(coords: +THREE.Vector2, camera: +THREE.Camera)",
+          "!doc": "Updates the ray with a new origin and direction."
+        },
+        "intersectObject": {
+          "!type": "fn(object: +THREE.Object3D, recursive: bool) -> []",
+          "!doc": "Checks all intersection between the ray and the object with or without the descendants. Intersections are returned sorted by distance, closest first. An array of intersections is returned...\n        <code>\n            [ { distance, point, face, faceIndex, indices, object }, ... ]\n        </code>\n        <p>\n        [page:Float distance] – distance between the origin of the ray and the intersection<br>\n        [page:Vector3 point] – point of intersection, in world coordinates<br>\n        [page:Face3 face] – intersected face<br>\n        [page:Integer faceIndex] – index of the intersected face<br>\n        [page:Array indices] – indices of vertices comprising the intersected face<br>\n        [page:Object3D object] – the intersected object\n    \t</p>\n        <p>\n        When intersecting a [page:Mesh] with a [page:BufferGeometry], the *faceIndex* will be *undefined*, and *indices* will be set; when intersecting a [page:Mesh] with a [page:Geometry], *indices* will be *undefined*. \n        </p>\n\t\t<p>\n\t\t*Raycaster* delegates to the [page:Object3D.raycast raycast] method of the passed object, when evaluating whether the ray intersects the object or not. This allows [page:Mesh meshes] to respond differently to ray casting than [page:Line lines] and [page:PointCloud pointclouds].\n\t\t</p>\n\t\t<p>\n\t\t*Note* that for meshes, faces must be pointed towards the origin of the [page:.ray ray] in order to be detected; intersections of the ray passing through the back of a face will not be detected. To raycast against both faces of an object, you'll want to set the [page:Mesh.material material]'s [page:Material.side side] property to *THREE.DoubleSide*.  \n\t\t</p>"
+        },
+        "intersectObjects": {
+          "!type": "fn(objects: [], recursive: bool) -> []",
+          "!doc": "Checks all intersection between the ray and the objects with or without the descendants. Intersections are returned sorted by distance, closest first. Intersections are of the same form as those returned by [page:.intersectObject]."
+        }
+      },
+      "!doc": "This class makes raycasting easier. Raycasting is used for picking and more.",
+      "!type": "fn(origin: +THREE.Vector3, direction: +THREE.Vector3, near: number, far: number)"
+    },
+    "Lut": {
+      "!url": "http://threejs.org/docs/#Reference/examples/Lut",
+      "prototype": {
+        "minV": {
+          "!type": "number",
+          "!doc": "The minimum value to be represented with the lookup table. Default is 0."
+        },
+        "maxV": {
+          "!type": "number",
+          "!doc": "The maximum value to be represented with the lookup table. Default is 1."
+        },
+        "copy": {
+          "!type": "fn(lut: +THREE.Lut)",
+          "!doc": "Copies given lut."
+        },
+        "setminV": {
+          "!type": "fn(minV: number) -> +THREE.Lut",
+          "!doc": "Sets this Lut with the minimum value to be represented."
+        },
+        "setmaxV": {
+          "!type": "fn(maxV: number) -> +THREE.Lut",
+          "!doc": "Sets this Lut with the maximum value to be represented."
+        },
+        "changeNumberOfColors": {
+          "!type": "fn(numberOfColors: number) -> +THREE.Lut",
+          "!doc": "Sets this Lut with the number of colors to be used."
+        },
+        "changeColorMap": {
+          "!type": "fn(colorMap: number) -> +THREE.Lut",
+          "!doc": "Sets this Lut with the colormap to be used."
+        },
+        "addColorMap": {
+          "!type": "fn(colorMapName, arrayOfColors) -> +THREE.Lut",
+          "!doc": "Insert a new color map into the set of available color maps."
+        },
+        "getColor": {
+          "!type": "fn(value) -> +THREE.Lut",
+          "!doc": "Returns a Three.Color."
+        }
+      },
+      "!doc": "Represents a lookup table for colormaps. It is used to determine the color values from a range of data values.",
+      "!type": "fn(colormap, numberOfColors)"
+    },
+    "CombinedCamera": {
+      "!url": "http://threejs.org/docs/#Reference/examples/cameras/CombinedCamera",
+      "prototype": {
+        "!proto": "THREE.Camera.prototype",
+        "fov": {
+          "!type": "number",
+          "!doc": "Gets or sets the camera frustum vertical field of view in perspective view."
+        },
+        "left": {
+          "!type": "number",
+          "!doc": "Gets or sets the camera frustum left plane in orthographic view."
+        },
+        "right": {
+          "!type": "number",
+          "!doc": "Gets or sets the camera frustum right plane in orthographic view."
+        },
+        "top": {
+          "!type": "number",
+          "!doc": "Gets or sets the camera frustum top plane in orthographic view."
+        },
+        "bottom": {
+          "!type": "number",
+          "!doc": "Gets or sets the camera frustum bottom plane in orthographic view."
+        },
+        "zoom": {
+          "!type": "number",
+          "!doc": "Gets or sets the zoom factor of the camera."
+        },
+        "near": {
+          "!type": "number",
+          "!doc": "Gets camera frustum near plane."
+        },
+        "far": {
+          "!type": "number",
+          "!doc": "Gets camera frustum far plane."
+        },
+        "cameraO": {
+          "!type": "+THREE.OrthographicCamera",
+          "!doc": "Gets or sets the internal OrthographicCamera used as camera."
+        },
+        "cameraP": {
+          "!type": "+THREE.PerspectiveCamera",
+          "!doc": "Gets or sets the internal PerspectiveCamera used as camera."
+        },
+        "inOrthographicMode": {
+          "!type": "boolean",
+          "!doc": "Gets whether the combinedCamera is in Orthographic Mode."
+        },
+        "inPerspectiveMode": {
+          "!type": "boolean",
+          "!doc": "Gets whether the combinedCamera is in Perspective Mode."
+        },
+        "setFov": {
+          "!type": "fn(fov: number)",
+          "!doc": "sets the camera frustum vertical field of view in perspective view."
+        },
+        "setZoom": {
+          "!type": "fn(zoom: number)",
+          "!doc": "Sets the zoomfactor."
+        },
+        "setLens": {
+          "!type": "fn(focalLength: number, frameHeight: number)",
+          "!doc": "Sets the fov based on lens data."
+        },
+        "toFrontView": {
+          "!type": "fn()",
+          "!doc": "Sets the camera to view the front of the target."
+        },
+        "toBackView": {
+          "!type": "fn()",
+          "!doc": "Sets the camera to view the back of the target."
+        },
+        "toLeftView": {
+          "!type": "fn()",
+          "!doc": "Sets the camera to view the left of the target."
+        },
+        "toRightView": {
+          "!type": "fn()",
+          "!doc": "Sets the camera to view the right of the target."
+        },
+        "toTopView": {
+          "!type": "fn()",
+          "!doc": "Sets the camera to view the top."
+        },
+        "toBottomView": {
+          "!type": "fn()",
+          "!doc": "Sets the camera to view the bottom."
+        },
+        "setSize": {
+          "!type": "fn(width: number, height: number)",
+          "!doc": "Sets the size of the orthographic view."
+        },
+        "toOrthographic": {
+          "!type": "fn()",
+          "!doc": "Change the camera to orthographic view."
+        },
+        "toPerspective": {
+          "!type": "fn()",
+          "!doc": "Change the camera to Perspective view."
+        },
+        "updateProjectionMatrix": {
+          "!type": "fn()",
+          "!doc": "Updates the ProjectionMatrix."
+        }
+      },
+      "!doc": "A general purpose camera, for setting FOV, Lens Focal Length,\n \t\tand switching between perspective and orthographic views easily.\n \t\tUse this only if you do not wish to manage\n \t\tboth an Orthographic and Perspective Camera",
+      "!type": "fn(width: number, height: number, fov: number, near: number, far: number, orthoNear: number, orthoFar: number)"
+    },
+    "FontUtils": {
+      "!url": "http://threejs.org/docs/#Reference/extras/FontUtils",
+      "prototype": {
+        "divisions": {
+          "!type": "number",
+          "!doc": "The amount of segments in a curve. Default is 10."
+        },
+        "style": {
+          "!type": "string",
+          "!doc": "The style of the used font. Default is \"normal\"."
+        },
+        "weight": {
+          "!type": "string",
+          "!doc": "The weight of the used font. Default is \"normal\"."
+        },
+        "face": {
+          "!type": "string",
+          "!doc": "The name of the font. Default is \"helvetiker\"."
+        },
+        "faces": {
+          "!type": "object",
+          "!doc": "All Fonts which are already loaded in."
+        },
+        "size": {
+          "!type": "number",
+          "!doc": "The size of the used Font. Default is 150."
+        },
+        "drawText": {
+          "!type": "fn(text: string) -> object",
+          "!doc": "Calculates the path and offset of the text in the used font. It returns an  object like { paths : fontPaths, offset : width }."
+        },
+        "Triangulate": {
+          "!type": "fn(contour: [], indices: bool) -> []",
+          "!doc": "Triangulates a contour into an array of faces."
+        },
+        "extractGlyphPoints": {
+          "!type": "fn(c: string, face: string, scale: number, offset: number, path: +THREE.Path) -> object",
+          "!doc": "This ectracts the glyphPoints of the character of the face and returns an object containing the path and the new offset."
+        },
+        "generateShapes": {
+          "!type": "fn(text: string, parameters: object) -> []",
+          "!doc": "Generates shapes from the text and return them as an Array of [page:Shape]."
+        },
+        "loadFace": {
+          "!type": "fn(data: object) -> object",
+          "!doc": "This loads and saves the data of the face and return the data. When you add the font Data as javascriptfile, then this automatically get called. So there is no need to do this yourself."
+        },
+        "getFace": {
+          "!type": "fn() -> object",
+          "!doc": "Returns the used font its data based on its style and weight."
+        }
+      },
+      "!doc": "A class for text operations in three.js (See [page:TextGeometry])"
+    },
+    "GeometryUtils": {
+      "!url": "http://threejs.org/docs/#Reference/extras/GeometryUtils",
+      "prototype": {},
+      "!doc": "Contains handy functions geometry manipulations."
+    },
+    "ImageUtils": {
+      "!url": "http://threejs.org/docs/#Reference/extras/ImageUtils",
+      "prototype": {
+        "crossOrigin": {
+          "!type": "string",
+          "!doc": "The crossOrigin string to implement CORS for loading the image from a different domain that allows CORS."
+        },
+        "generateDataTexture": {
+          "!type": "fn(width: number, height: number, color: number) -> +THREE.DataTexture",
+          "!doc": "Generates a texture of a single color. It is a DataTexture with format, RGBFormat."
+        },
+        "parseDDS": {
+          "!type": "fn(buffer: string, loadMipmaps: boolean) -> +THREE.CompressedTexture",
+          "!doc": "Parses a DDS Image from the string into a CompressedTexture."
+        },
+        "loadCompressedTexture": {
+          "!type": "fn(url: todo, mapping: todo, onLoad: todo, onError: todo) -> todo",
+          "!doc": "todo"
+        },
+        "loadTexture": {
+          "!type": "fn(url: string, mapping: UVMapping, onLoad: function, onError: function) -> todo",
+          "!doc": "todo"
+        },
+        "getNormalMap": {
+          "!type": "fn(image: todo, depth: todo) -> todo",
+          "!doc": "todo"
+        },
+        "loadCompressedTextureCube": {
+          "!type": "fn(array: todo, mapping: todo, onLoad: todo, onError: todo) -> todo",
+          "!doc": "todo"
+        },
+        "loadTextureCube": {
+          "!type": "fn(array: todo, mapping: todo, onLoad: todo, onError: todo) -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "A Helper class to ease the loading of images of different types."
+    },
+    "SceneUtils": {
+      "!url": "http://threejs.org/docs/#Reference/extras/SceneUtils",
+      "prototype": {
+        "createMultiMaterialObject": {
+          "!type": "fn(geometry: +THREE.Geometry, materials: []) -> +THREE.Object3D",
+          "!doc": "Creates an new Object3D an new mesh for each material defined in materials. Beware that this is not the same as Meshfacematerial which defines multiple material for 1 mesh.<br>\n\t\tThis is mostly useful for object that need a material and a wireframe implementation."
+        },
+        "attach": {
+          "!type": "fn(child: +THREE.Object3D, scene: +THREE.Object3D, parent: +THREE.Object3D)",
+          "!doc": "Attaches the object to the parent without the moving the object in the worldspace."
+        },
+        "detach": {
+          "!type": "fn(child: +THREE.Object3D, parent: +THREE.Object3D, scene: +THREE.Object3D)",
+          "!doc": "Detaches the object from the parent and adds it back to the scene without moving in worldspace."
+        }
+      },
+      "!doc": "A class containing useful utility functions for scene manipulation."
+    },
+    "Animation": {
+      "!url": "http://threejs.org/docs/#Reference/extras/animation/Animation",
+      "prototype": {
+        "root": {
+          "!type": "Object3d",
+          "!doc": "The root object of the animation."
+        },
+        "data": {
+          "!type": "object",
+          "!doc": "The data containing the animation"
+        },
+        "hierarchy": {
+          "!type": "[]",
+          "!doc": "The objects that are influenced by the animation."
+        },
+        "currentTime": {
+          "!type": "number",
+          "!doc": "The time elapsed since the last start/restart of the animation."
+        },
+        "timeScale": {
+          "!type": "number",
+          "!doc": "The timez"
+        },
+        "isPlaying": {
+          "!type": "boolean",
+          "!doc": "Indicates whether the animation is playing. This shouldn't be adapted by user code."
+        },
+        "isPaused": {
+          "!type": "boolean",
+          "!doc": "Indicates whether the animation is paused. This shouldn't be adapted by user code."
+        },
+        "loop": {
+          "!type": "boolean",
+          "!doc": "Set to make the animation restart when the animation ends."
+        },
+        "interpolationType": {
+          "!type": "number",
+          "!doc": "The type to indicate how to interpolate between 2 data points."
+        },
+        "play": {
+          "!type": "fn(startTime: number)",
+          "!doc": "Starts the animation from a moment startTime in the animation."
+        },
+        "stop": {
+          "!type": "fn()",
+          "!doc": "Stops the animation."
+        },
+        "update": {
+          "!type": "fn(deltaTimeMS: number) -> bool",
+          "!doc": "Updates the animation in time. This shouldn't be called by user code. The animationHandler calls this method."
+        },
+        "interpolateCatmullRom": {
+          "!type": "fn(points: [], scale: number) -> array",
+          "!doc": "Interpolates the point based on the key. Is used in update."
+        },
+        "getNextKeyWith": {
+          "!type": "fn(type: string, h: object, key: number) -> object",
+          "!doc": "Gets the next key. Is used in Update."
+        },
+        "getPrevKeyWith": {
+          "!type": "fn(type: string, h: object, key: number) -> object",
+          "!doc": "Gets the previous key. Is used in Update."
+        }
+      },
+      "!doc": "This class animates an object based on an hierarchy. This hierarchy can be Object3ds or bones.",
+      "!type": "fn(root: Object3d, name: string)"
+    },
+    "AnimationHandler": {
+      "!url": "http://threejs.org/docs/#Reference/extras/animation/AnimationHandler",
+      "prototype": {
+        "CATMULLROM": {
+          "!type": "number",
+          "!doc": "Enum Value to indicate that the animation needs to be interpolated as CATMULLROM."
+        },
+        "CATMULLROM_FORWARD": {
+          "!type": "number",
+          "!doc": "Enum Value to indicate that the animation needs to be interpolated as CATMULLROM_FORWARD."
+        },
+        "LINEAR": {
+          "!type": "number",
+          "!doc": "Enum Value to indicate that the animation needs to be interpolated as LINEAR."
+        },
+        "removeFromUpdate": {
+          "!type": "fn(animation: +THREE.Animation)",
+          "!doc": "Removes the animation from the update cycle. This gets called when the animation stops. This shouldn't be called by usercode."
+        },
+        "get": {
+          "!type": "fn(name: string) -> object",
+          "!doc": "Gets the animationData from its library."
+        },
+        "update": {
+          "!type": "fn(deltaTimeMS: number)",
+          "!doc": "Updates all active animations with deltaTime."
+        },
+        "parse": {
+          "!type": "fn(root: object)",
+          "!doc": "Parses the object to get the hierachy."
+        },
+        "add": {
+          "!type": "fn(data: object)",
+          "!doc": "Adds the animationData from its library."
+        },
+        "addToUpdate": {
+          "!type": "fn(animation: +THREE.Animation)",
+          "!doc": "Adds the animation from the update cycle. This gets called when the animation starts. This shouldn't be called by user code."
+        }
+      },
+      "!doc": "The AnimationHandler handles the initialisation of the Animation data and \n\t\tthe animations itself. It keeps track of every animation and if it's active or not.\n\t\tIt also update all animations which are active if its method *update* is called.",
+      "!type": "fn()"
+    },
+    "AnimationMorphTarget": {
+      "!url": "http://threejs.org/docs/#Reference/extras/animation/AnimationMorphTarget",
+      "prototype": {
+        "root": {
+          "!type": "todo",
+          "!doc": "todo"
+        },
+        "data": {
+          "!type": "todo",
+          "!doc": "todo"
+        },
+        "hierarchy": {
+          "!type": "todo",
+          "!doc": "todo"
+        },
+        "currentTime": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "timeScale": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "isPlaying": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "isPaused": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "loop": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "influence": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "play": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "pause": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "stop": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "update": {
+          "!type": "fn(deltaTimeMS: todo) -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "todo",
+      "!type": "fn(root: todo, data: todo)"
+    },
+    "KeyFrameAnimation": {
+      "!url": "http://threejs.org/docs/#Reference/extras/animation/KeyFrameAnimation",
+      "prototype": {
+        "root": {
+          "!type": "todo",
+          "!doc": "todo"
+        },
+        "data": {
+          "!type": "todo",
+          "!doc": "todo"
+        },
+        "hierarchy": {
+          "!type": "todo",
+          "!doc": "todo"
+        },
+        "currentTime": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "timeScale": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "isPlaying": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "isPaused": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "loop": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "JITCompile": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "play": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "pause": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "stop": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "update": {
+          "!type": "fn(deltaTimeMS: todo) -> todo",
+          "!doc": "todo"
+        },
+        "interpolateCatmullRom": {
+          "!type": "fn(points: todo, scale: todo) -> todo",
+          "!doc": "todo"
+        },
+        "getNextKeyWith": {
+          "!type": "fn(sid: todo, h: todo, key: todo) -> todo",
+          "!doc": "todo"
+        },
+        "getPrevKeyWith": {
+          "!type": "fn(sid: todo, h: todo, key: todo) -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "todo",
+      "!type": "fn(root: todo, data: todo, JITCompile: todo)"
+    },
+    "Curve": {
+      "!url": "http://threejs.org/docs/#Reference/extras/core/Curve",
+      "prototype": {
+        "getPoint": {
+          "!type": "fn(t) -> Vector",
+          "!doc": "Returns a vector for point t of the curve where t is between 0 and 1"
+        },
+        "getPointAt": {
+          "!type": "fn(u) -> Vector",
+          "!doc": "Returns a vector for point at relative position in curve according to arc length"
+        },
+        "getPoints": {
+          "!type": "fn(divisions) -> []",
+          "!doc": "Get sequence of points using getPoint( t )"
+        },
+        "getSpacedPoints": {
+          "!type": "fn(divisions) -> []",
+          "!doc": "Get sequence of equi-spaced points using getPointAt( u )"
+        },
+        "getLength": {
+          "!type": "fn() -> number",
+          "!doc": "Get total curve arc length"
+        },
+        "getLengths": {
+          "!type": "fn(divisions) -> []",
+          "!doc": "Get list of cumulative segment lengths"
+        },
+        "updateArcLengths": {
+          "!type": "fn()",
+          "!doc": "Update the cumlative segment distance cache"
+        },
+        "getUtoTmapping": {
+          "!type": "fn(u, distance) -> number",
+          "!doc": "Given u ( 0 .. 1 ), get a t to find p. This gives you points which are equidistant"
+        },
+        "getTangent": {
+          "!type": "fn(t) -> Vector",
+          "!doc": "Returns a unit vector tangent at t. If the subclassed curve do not implement its tangent derivation, 2 points a small delta apart will be used to find its gradient which seems to give a reasonable approximation"
+        },
+        "getTangentAt": {
+          "!type": "fn(u) -> Vector",
+          "!doc": "Returns tangent at equidistant point u on the curve"
+        }
+      },
+      "!doc": "An extensible curve object which contains methods for interpolation.",
+      "!type": "fn()"
+    },
+    "CurvePath": {
+      "!url": "http://threejs.org/docs/#Reference/extras/core/CurvePath",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "curves": {
+          "!type": "array",
+          "!doc": "todo"
+        },
+        "bends": {
+          "!type": "array",
+          "!doc": "todo"
+        },
+        "autoClose": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "getWrapPoints": {
+          "!type": "fn(oldPts: todo, path: todo) -> todo",
+          "!doc": "todo"
+        },
+        "createPointsGeometry": {
+          "!type": "fn(divisions: todo) -> todo",
+          "!doc": "todo"
+        },
+        "addWrapPath": {
+          "!type": "fn(bendpath: todo) -> todo",
+          "!doc": "todo"
+        },
+        "createGeometry": {
+          "!type": "fn(points: todo) -> todo",
+          "!doc": "todo"
+        },
+        "add": {
+          "!type": "fn(curve: todo) -> todo",
+          "!doc": "todo"
+        },
+        "getTransformedSpacedPoints": {
+          "!type": "fn(segments: todo, bends: todo) -> todo",
+          "!doc": "todo"
+        },
+        "createSpacedPointsGeometry": {
+          "!type": "fn(divisions: todo) -> todo",
+          "!doc": "todo"
+        },
+        "closePath": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "getBoundingBox": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "getCurveLengths": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "getTransformedPoints": {
+          "!type": "fn(segments: todo, bends: todo) -> todo",
+          "!doc": "todo"
+        },
+        "checkConnection": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "todo",
+      "!type": "fn()"
+    },
+    "Gyroscope": {
+      "!url": "http://threejs.org/docs/#Reference/extras/core/Gyroscope",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype"
+      },
+      "!doc": "todo",
+      "!type": "fn()"
+    },
+    "Path": {
+      "!url": "http://threejs.org/docs/#Reference/extras/core/Path",
+      "prototype": {
+        "!proto": "THREE.CurvePath.prototype",
+        "actions": {
+          "!type": "array",
+          "!doc": "The possible actions that define the path."
+        },
+        "fromPoints": {
+          "!type": "fn(vectors) -> todo",
+          "!doc": "Adds to the Path from the points. The first vector defines the offset. After that the lines get defined."
+        },
+        "moveTo": {
+          "!type": "fn(x, y) -> todo",
+          "!doc": "This moves the offset to x and y"
+        },
+        "lineTo": {
+          "!type": "fn(x, y) -> todo",
+          "!doc": "This creates a line from the offset to X and Y and updates the offset to X and Y."
+        },
+        "quadraticCurveTo": {
+          "!type": "fn(aCPx, aCPy, aX, aY) -> todo",
+          "!doc": "This creates a quadratic curve from the offset to aX and aY with aCPx and aCPy as control point and updates the offset to aX and aY."
+        },
+        "bezierCurveTo": {
+          "!type": "fn(aCP1x, aCP1y, aCP2x, aCP2y, aX, aY) -> todo",
+          "!doc": "This creates a bezier curve from the offset to aX and aY with aCP1x, aCP1y and aCP1x, aCP1y  as control points and updates the offset to aX and aY."
+        },
+        "arc": {
+          "!type": "fn(aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise) -> todo",
+          "!doc": "todo"
+        },
+        "absarc": {
+          "!type": "fn(aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise) -> todo",
+          "!doc": "todo"
+        },
+        "ellipse": {
+          "!type": "fn(aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise) -> todo",
+          "!doc": "todo"
+        },
+        "absellipse": {
+          "!type": "fn(aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise) -> todo",
+          "!doc": "todo"
+        },
+        "toShapes": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "A 2d path representation, comprising of points, lines, and cubes,  similar to the html5 2d canvas api. It extends CurvePath.",
+      "!type": "fn(points: todo)"
+    },
+    "Shape": {
+      "!url": "http://threejs.org/docs/#Reference/extras/core/Shape",
+      "prototype": {
+        "!proto": "THREE.Path.prototype",
+        "holes": {
+          "!type": "array",
+          "!doc": "todo"
+        },
+        "makeGeometry": {
+          "!type": "fn(options: todo) -> todo",
+          "!doc": "Convenience method to return ShapeGeometry"
+        },
+        "extractAllPoints": {
+          "!type": "fn(divisions: todo) -> todo",
+          "!doc": "Get points of shape and holes (keypoints based on segments parameter)"
+        },
+        "extrude": {
+          "!type": "fn(options: todo) -> todo",
+          "!doc": "Convenience method to return ExtrudeGeometry"
+        },
+        "extractPoints": {
+          "!type": "fn(divisions: todo) -> todo",
+          "!doc": "todo"
+        },
+        "extractAllSpacedPoints": {
+          "!type": "fn(divisions: todo) -> todo",
+          "!doc": "todo"
+        },
+        "getPointsHoles": {
+          "!type": "fn(divisions: todo) -> todo",
+          "!doc": "Get points of holes"
+        },
+        "getSpacedPointsHoles": {
+          "!type": "fn(divisions: todo) -> todo",
+          "!doc": "Get points of holes (spaced by regular distance)"
+        }
+      },
+      "!doc": "Defines a 2d shape plane using paths.",
+      "!type": "fn()"
+    },
+    "ArcCurve": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/ArcCurve",
+      "prototype": {
+        "!proto": "THREE.EllipseCurve.prototype"
+      },
+      "!doc": "Alias for [page:EllipseCurve]"
+    },
+    "ClosedSplineCurve3": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/ClosedSplineCurve3",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "points": "[]"
+      },
+      "!doc": "Create a smooth 3d spline curve from a series of points that loops back onto itself",
+      "!type": "fn(points: [])"
+    },
+    "CubicBezierCurve": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/CubicBezierCurve",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "v0": "+THREE.Vector2",
+        "v1": "+THREE.Vector2",
+        "v2": "+THREE.Vector2",
+        "v3": "+THREE.Vector2"
+      },
+      "!doc": "Create a smooth 2d <a href=\"http://en.wikipedia.org/wiki/B%C3%A9zier_curve#mediaviewer/File:Bezier_curve.svg\" target=\"_blank\">cubic bezier curve</a>."
+    },
+    "CubicBezierCurve3": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/CubicBezierCurve3",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "v0": "+THREE.Vector3",
+        "v1": "+THREE.Vector3",
+        "v2": "+THREE.Vector3",
+        "v3": "+THREE.Vector3"
+      },
+      "!doc": "Create a smooth 3d <a href=\"http://en.wikipedia.org/wiki/B%C3%A9zier_curve#mediaviewer/File:Bezier_curve.svg\" target=\"_blank\">cubic bezier curve</a>.",
+      "!type": "fn(v0: +THREE.Vector3, v1: +THREE.Vector3, v2: +THREE.Vector3, v3: +THREE.Vector3)"
+    },
+    "EllipseCurve": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/EllipseCurve",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "aX": "number",
+        "aY": "number",
+        "xRadius": "Radians",
+        "yRadius": "Radians",
+        "aStartAngle": "number",
+        "aEndAngle": "number",
+        "aClockwise": "bool"
+      },
+      "!doc": "Creates a 2d curve in the shape of an ellipse.",
+      "!type": "fn(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: Radians, aEndAngle: Radians, aClockwise: bool)"
+    },
+    "LineCurve": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/LineCurve",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "v1": "+THREE.Vector2",
+        "v2": "+THREE.Vector2"
+      },
+      "!doc": "A curve representing a 2d line segment",
+      "!type": "fn(v1: +THREE.Vector2, v2: +THREE.Vector2)"
+    },
+    "LineCurve3": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/LineCurve3",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "v1": "+THREE.Vector3",
+        "v2": "+THREE.Vector3"
+      },
+      "!doc": "A curve representing a 3d line segment",
+      "!type": "fn(v1: +THREE.Vector3, v2: +THREE.Vector3)"
+    },
+    "QuadraticBezierCurve": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/QuadraticBezierCurve",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "v0": "+THREE.Vector2",
+        "v1": "+THREE.Vector2",
+        "v2": "+THREE.Vector2"
+      },
+      "!doc": "Create a smooth 2d <a href=\"http://en.wikipedia.org/wiki/B%C3%A9zier_curve#mediaviewer/File:B%C3%A9zier_2_big.gif\" target=\"_blank\">quadratic bezier curve</a>.",
+      "!type": "fn(v0: +THREE.Vector2, v1: +THREE.Vector2, v2: +THREE.Vector2)"
+    },
+    "QuadraticBezierCurve3": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/QuadraticBezierCurve3",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "v0": "+THREE.Vector3",
+        "v1": "+THREE.Vector3",
+        "v2": "+THREE.Vector3"
+      },
+      "!doc": "Create a smooth 3d <a href=\"http://en.wikipedia.org/wiki/B%C3%A9zier_curve#mediaviewer/File:B%C3%A9zier_2_big.gif\" target=\"_blank\">quadratic bezier curve</a>.",
+      "!type": "fn(v0: +THREE.Vector3, v1: +THREE.Vector3, v2: +THREE.Vector3)"
+    },
+    "SplineCurve": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/SplineCurve",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "points": "[]"
+      },
+      "!doc": "Create a smooth 2d spline curve from a series of points",
+      "!type": "fn(points: [])"
+    },
+    "SplineCurve3": {
+      "!url": "http://threejs.org/docs/#Reference/extras/curves/SplineCurve3",
+      "prototype": {
+        "!proto": "THREE.Curve.prototype",
+        "points": "[]"
+      },
+      "!doc": "Create a smooth 3d spline curve from a series of points",
+      "!type": "fn(points: [])"
+    },
+    "BoxGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/BoxGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "BoxGeometry is the quadrilateral primitive geometry class. It is typically used for creating a cube or irregular quadrilateral of the dimensions provided with the 'width', 'height', and 'depth' constructor arguments.",
+      "!type": "fn(width: number, height: number, depth: number, widthSegments: number, heightSegments: number, depthSegments: number)"
+    },
+    "CircleGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/CircleGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "CircleGeometry is a simple shape of Euclidean geometry.  It is contructed from a number of triangular segments that are oriented around a central point and extend as far out as a given radius.  It is built counter-clockwise from a start angle and a given central angle.  It can also be used to create regular polygons, where the number of segments determines the number of sides.",
+      "!type": "fn(radius: number, segments: number, thetaStart: number, thetaLength: number)"
+    },
+    "CubeGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/CubeGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "Renamed CubeGeometry to BoxGeometry. see [page:BoxGeometry]."
+    },
+    "CylinderGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/CylinderGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "A class for generating cylinder geometries",
+      "!type": "fn(radiusTop: number, radiusBottom: number, height: number, radiusSegments: number, heightSegments: number, openEnded: bool, thetaStart: number, thetaLength: number)"
+    },
+    "DodecahedronGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/DodecahedronGeometry",
+      "prototype": {
+        "!proto": "THREE.PolyhedronGeometry.prototype",
+        "parameters": {
+          "!type": "object",
+          "!doc": "An object with all of the parameters that were used to generate the geometry."
+        }
+      },
+      "!doc": "A class for generating a dodecahedron geometries.",
+      "!type": "fn(radius: number, detail: number)"
+    },
+    "ExtrudeGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/ExtrudeGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype",
+        "addShapeList": {
+          "!type": "fn(shapes: [], options: object)",
+          "!doc": "Adds the shapes to the list to extrude."
+        },
+        "addShape": {
+          "!type": "fn(shape: +THREE.Shape, options: object)",
+          "!doc": "Add the shape to the list to extrude."
+        }
+      },
+      "!doc": "Creates extruded geometry from a path shape",
+      "!type": "fn(shapes: [], options: object)"
+    },
+    "IcosahedronGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/IcosahedronGeometry",
+      "prototype": {
+        "!proto": "THREE.PolyhedronGeometry.prototype",
+        "parameters": {
+          "!type": "object",
+          "!doc": "An object with all of the parameters that were used to generate the geometry."
+        }
+      },
+      "!doc": "A class for generating an icosahedron geometry.",
+      "!type": "fn(radius: number, detail: number)"
+    },
+    "LatheGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/LatheGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "Class for generating meshes with axial symmetry. Possible uses include donuts, pipes, vases etc. The lathe rotate around the Z axis.",
+      "!type": "fn(points: [], segments: number, phiStart: number, phiLength: number)"
+    },
+    "OctahedronGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/OctahedronGeometry",
+      "prototype": {
+        "!proto": "THREE.PolyhedronGeometry.prototype",
+        "parameters": {
+          "!type": "object",
+          "!doc": "An object with all of the parameters that were used to generate the geometry."
+        }
+      },
+      "!doc": "A class for generating an octahedron geometry.",
+      "!type": "fn(radius: number, detail: number)"
+    },
+    "ParametricGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/ParametricGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "Generate geometry representing a parametric surface.",
+      "!type": "fn(func: function, slices: number, stacks: number)"
+    },
+    "PlaneGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/PlaneGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "A class for generating plane geometries",
+      "!type": "fn(width: number, height: number, widthSegments: number, heightSegments: number)"
+    },
+    "PolyhedronGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/PolyhedronGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype",
+        "parameters": {
+          "!type": "object",
+          "!doc": "An object with all of the parameters that were used to generate the geometry."
+        }
+      },
+      "!doc": "A polyhedron is a solid in three dimensions with flat faces. This class will take an array of vertices,\n\t\t\tproject them onto a sphere, and then divide them up to the desired level of detail. This class is used\n\t\t\tby [page:DodecahedronGeometry], [page:IcosahedronGeometry], [page:OctahedronGeometry],\n\t\t\tand [page:TetrahedronGeometry] to generate their respective geometries.",
+      "!type": "fn(vertices: [], faces: [], radius: number, detail: number)"
+    },
+    "RingGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/RingGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "A class for generating a two-dimensional ring geometry.",
+      "!type": "fn(innerRadius: number, outerRadius: number, thetaSegments: number, phiSegments: number, thetaStart: number, thetaLength: number)"
+    },
+    "ShapeGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/ShapeGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype",
+        "addShape": {
+          "!type": "fn(shape: +THREE.Shape, options: object)",
+          "!doc": "Adds a single shape to the geometry"
+        }
+      },
+      "!doc": "Creates a one-sided polygonal geometry from one or more path shapes. Similar to [page:ExtrudeGeometry]",
+      "!type": "fn(shapes: [], options: object)"
+    },
+    "SphereGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/SphereGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "A class for generating sphere geometries",
+      "!type": "fn(radius: number, widthSegments: number, heightSegments: number, phiStart: number, phiLength: number, thetaStart: number, thetaLength: number)"
+    },
+    "TetrahedronGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/TetrahedronGeometry",
+      "prototype": {
+        "!proto": "THREE.PolyhedronGeometry.prototype",
+        "parameters": {
+          "!type": "object",
+          "!doc": "An object with all of the parameters that were used to generate the geometry."
+        }
+      },
+      "!doc": "A class for generating a tetrahedron geometries.",
+      "!type": "fn(radius: number, detail: number)"
+    },
+    "TextGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/TextGeometry",
+      "prototype": {
+        "!proto": "THREE.ExtrudeGeometry.prototype"
+      },
+      "!doc": "This object creates an 3D object of text as a single object.",
+      "!type": "fn(text: string, parameters: object)"
+    },
+    "TorusGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/TorusGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "A class for generating torus geometries",
+      "!type": "fn(radius: number, tube: number, radialSegments: number, tubularSegments: number, arc: number)"
+    },
+    "TorusKnotGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/TorusKnotGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype"
+      },
+      "!doc": "Creates a torus knot, the particular shape of which is defined by a pair of coprime integers, p and q.  If p and q are not coprime, the result will be a torus link.",
+      "!type": "fn(radius: number, tube: number, radialSegments: number, tubularSegments: number, p: number, q: number, heightScale: number)"
+    },
+    "TubeGeometry": {
+      "!url": "http://threejs.org/docs/#Reference/extras/geometries/TubeGeometry",
+      "prototype": {
+        "!proto": "THREE.Geometry.prototype",
+        "parameters": {
+          "!type": "object",
+          "!doc": "An object with all of the parameters that were used to generate the geometry."
+        },
+        "tangents": {
+          "!type": "[]",
+          "!doc": "An array of [page:Vector3] tangents"
+        },
+        "normals": {
+          "!type": "[]",
+          "!doc": "An array of [page:Vector3] normals"
+        },
+        "binormals": {
+          "!type": "[]",
+          "!doc": "An array of [page:Vector3] binormals"
+        }
+      },
+      "!doc": "Creates a tube that extrudes along a 3d curve",
+      "!type": "fn(path: +THREE.Curve, segments: number, radius: number, radiusSegments: number, closed: bool)"
+    },
+    "ArrowHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/ArrowHelper",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "line": {
+          "!type": "+THREE.Line",
+          "!doc": "Contains the line part of the arrowHelper."
+        },
+        "cone": {
+          "!type": "+THREE.Mesh",
+          "!doc": "Contains the cone part of the arrowHelper."
+        },
+        "setColor": {
+          "!type": "fn(hex: number)",
+          "!doc": "Sets the color of the arrowHelper."
+        },
+        "setLength": {
+          "!type": "fn(length: number, headLength: number, headWidth: number)",
+          "!doc": "Sets the length of the arrowhelper."
+        },
+        "setDirection": {
+          "!type": "fn(dir: +THREE.Vector3)",
+          "!doc": "Sets the direction of the arrowhelper."
+        }
+      },
+      "!doc": "An 3D arrow Object.",
+      "!type": "fn(dir: +THREE.Vector3, origin: +THREE.Vector3, length: number, hex: number, headLength: number, headWidth: number)"
+    },
+    "AxisHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/AxisHelper",
+      "prototype": {
+        "!proto": "THREE.Line.prototype"
+      },
+      "!doc": "An axis object to visualize the the 3 axes in a simple way. <br>\n\t\t\tThe X axis is red. The Y axis is green. The Z axis is blue.",
+      "!type": "fn(size: number)"
+    },
+    "BoundingBoxHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/BoundingBoxHelper",
+      "prototype": {
+        "!proto": "THREE.Mesh.prototype",
+        "object": {
+          "!type": "+THREE.Object3D",
+          "!doc": "Contains the object3D to show the world-axis-aligned boundingbox."
+        },
+        "box": {
+          "!type": "+THREE.Box3",
+          "!doc": "Contains the bounding box of the object."
+        },
+        "update": {
+          "!type": "fn()",
+          "!doc": "Updates the BoundingBoxHelper based on the object property."
+        }
+      },
+      "!doc": "A helper object to show the world-axis-aligned bounding box for an object.",
+      "!type": "fn(object: +THREE.Object3D, hex: number)"
+    },
+    "BoxHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/BoxHelper",
+      "prototype": {
+        "!proto": "THREE.Line.prototype",
+        "update": {
+          "!type": "fn(object: +THREE.Object3D)",
+          "!doc": "Updates the helper's geometry to match the dimensions of the [page:Geometry.boundingBox bounding box] of the passed object's geometry.\n\n\t\t<h2>Source</h2>\n\n\t\t[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]"
+        }
+      },
+      "!doc": "Helper object to show a wireframe box (with no face diagonals) around an object",
+      "!type": "fn(object: +THREE.Object3D)"
+    },
+    "CameraHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/CameraHelper",
+      "prototype": {
+        "!proto": "THREE.Line.prototype",
+        "pointMap": {
+          "!type": "object",
+          "!doc": "This contains the points to viualize the cameraHelper"
+        },
+        "camera": {
+          "!type": "+THREE.Camera",
+          "!doc": "The camera to visualize."
+        },
+        "update": {
+          "!type": "fn()",
+          "!doc": "Updates the helper based on the projectionMatrix of the camera."
+        }
+      },
+      "!doc": "The camera Helper is an Object3D which helps visualizing what a camera contains in its frustum.<br>\n\t\tIt visualizes the frustum with an line Geometry.",
+      "!type": "fn(camera: +THREE.Camera)"
+    },
+    "DirectionalLightHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/DirectionalLightHelper",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "lightPlane": {
+          "!type": "+THREE.Line",
+          "!doc": "Contains the line mesh showing the location of the directional light."
+        },
+        "light": {
+          "!type": "+THREE.DirectionalLight",
+          "!doc": "Contains the directionalLight."
+        },
+        "targetLine": {
+          "!type": "+THREE.Line",
+          "!doc": "Contains the line mesh that shows the direction of the light."
+        },
+        "update": {
+          "!type": "fn()",
+          "!doc": "Updates the helper to match the position and direction of the [page:.light]."
+        }
+      },
+      "!doc": "Visualize a [page:DirectionalLight]'s effect on the scene",
+      "!type": "fn(light: +THREE.DirectionalLight, size: number)"
+    },
+    "EdgesHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/EdgesHelper",
+      "prototype": {
+        "!proto": "THREE.Line.prototype"
+      },
+      "!doc": "Creates a wireframe object that shows the \"hard\" edges of another object's geometry. To draw a full wireframe image of an object, see [page:WireframeHelper].",
+      "!type": "fn(object: +THREE.Object3D, color: +THREE.Color, thresholdAngle: number)"
+    },
+    "FaceNormalsHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/FaceNormalsHelper",
+      "prototype": {
+        "!proto": "THREE.Line.prototype",
+        "object": {
+          "!type": "+THREE.Object3D",
+          "!doc": "The attached object"
+        },
+        "update": {
+          "!type": "fn()",
+          "!doc": "Updates the face normal preview based on movement of the object."
+        }
+      },
+      "!doc": "Renders [page:ArrowHelper arrows] to visualize an object's [page:Face3 face] normals. Requires that the object's geometry be an instance of [page:Geometry] (does not work with [page:BufferGeometry]), and that face normals have been specified on all [page:Face3 faces] or calculated with [page:Geometry.computeFaceNormals computeFaceNormals].",
+      "!type": "fn(object: +THREE.Object3D, size: number, color: +THREE.Color, linewidth: number)"
+    },
+    "GridHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/GridHelper",
+      "prototype": {
+        "!proto": "THREE.Line.prototype",
+        "setColors": {
+          "!type": "fn(colorCenterLine: number, colorGrid: number)",
+          "!doc": "Updates the color of the grid lines."
+        }
+      },
+      "!doc": "The GridHelper is an object to define grids. Grids are two-dimensional arrays of lines.",
+      "!type": "fn(size: number, step: number)"
+    },
+    "HemisphereLightHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/HemisphereLightHelper",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "lightSphere": {
+          "!type": "+THREE.Mesh",
+          "!doc": "The sphere mesh that shows the location of the hemispherelight."
+        },
+        "light": {
+          "!type": "+THREE.HemisphereLight",
+          "!doc": "Contains the HemisphereLight."
+        },
+        "update": {
+          "!type": "fn()",
+          "!doc": "Updates the helper to match the position and direction of the [page:.light]."
+        }
+      },
+      "!doc": "Creates a visual aid for a [page:HemisphereLight HemisphereLight].",
+      "!type": "fn(light: +THREE.HemisphereLight, sphereSize: number)"
+    },
+    "PointLightHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/PointLightHelper",
+      "prototype": {
+        "!proto": "THREE.Mesh.prototype",
+        "lightSphere": {
+          "!type": "+THREE.Mesh",
+          "!doc": "todo"
+        },
+        "light": {
+          "!type": "+THREE.PointLight",
+          "!doc": "todo"
+        },
+        "update": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "This display a helper for a pointLight",
+      "!type": "fn(light: todo, sphereSize: todo)"
+    },
+    "SpotLightHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/SpotLightHelper",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "lightSphere": {
+          "!type": "+THREE.Mesh",
+          "!doc": "todo"
+        },
+        "light": {
+          "!type": "+THREE.SpotLight",
+          "!doc": "todo"
+        },
+        "lightCone": {
+          "!type": "+THREE.Mesh",
+          "!doc": "todo"
+        },
+        "update": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "todo",
+      "!type": "fn(light: todo, sphereSize: todo)"
+    },
+    "VertexNormalsHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/VertexNormalsHelper",
+      "prototype": {
+        "!proto": "THREE.Line.prototype",
+        "object": {
+          "!type": "+THREE.Object3D",
+          "!doc": "The attached object"
+        },
+        "update": {
+          "!type": "fn()",
+          "!doc": "Updates the vertex normal preview based on movement of the object."
+        }
+      },
+      "!doc": "Renders [page:ArrowHelper arrows] to visualize an object's vertex normal vectors. Requires that normals have been specified in a [page:BufferAttribute custom attribute] or have been calculated using [page:Geometry.computeVertexNormals computeVertexNormals].",
+      "!type": "fn(object: +THREE.Object3D, size: number, color: +THREE.Color, linewidth: number)"
+    },
+    "VertexTangentsHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/VertexTangentsHelper",
+      "prototype": {
+        "!proto": "THREE.Line.prototype",
+        "object": {
+          "!type": "+THREE.Object3D",
+          "!doc": "The attached object"
+        },
+        "update": {
+          "!type": "fn()",
+          "!doc": "Updates the vertex tangent preview arrows based on the new position and tangents of the object."
+        }
+      },
+      "!doc": "Renders [page:ArrowHelper arrows] to visualize an object's vertex tangent vectors. Requires that tangents have been specified in a [page:BufferAttribute custom attribute] or have been computed using [page:Geometry.computeTangents computeTangents].",
+      "!type": "fn(object: +THREE.Object3D, size: number, color: +THREE.Color, linewidth: number)"
+    },
+    "WireframeHelper": {
+      "!url": "http://threejs.org/docs/#Reference/extras/helpers/WireframeHelper",
+      "prototype": {
+        "!proto": "THREE.Line.prototype"
+      },
+      "!doc": "Creates a wireframe object that shows the edges of another object's geometry. To draw a  wireframe image showing only \"hard\" edges (edges between non-coplanar faces), see [page:EdgesHelper].",
+      "!type": "fn(object: +THREE.Object3D, color: +THREE.Color)"
+    },
+    "ImmediateRenderObject": {
+      "!url": "http://threejs.org/docs/#Reference/extras/objects/ImmediateRenderObject",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "render": {
+          "!type": "fn(renderCallback: function)",
+          "!doc": "This function needs to be overridden to start the creation of the object and should call renderCallback when finished."
+        }
+      },
+      "!doc": "base class for immediate rendering objects.",
+      "!type": "fn()"
+    },
+    "MorphBlendMesh": {
+      "!url": "http://threejs.org/docs/#Reference/extras/objects/MorphBlendMesh",
+      "prototype": {
+        "!proto": "THREE.Mesh.prototype",
+        "animationsMap": {
+          "!type": "object",
+          "!doc": "todo"
+        },
+        "animationsList": {
+          "!type": "array",
+          "!doc": "todo"
+        },
+        "setAnimationWeight": {
+          "!type": "fn(name: todo, weight: todo) -> todo",
+          "!doc": "todo"
+        },
+        "setAnimationFPS": {
+          "!type": "fn(name: todo, fps: todo) -> todo",
+          "!doc": "todo"
+        },
+        "createAnimation": {
+          "!type": "fn(name: todo, start: todo, end: todo, fps: todo) -> todo",
+          "!doc": "todo"
+        },
+        "playAnimation": {
+          "!type": "fn(name: todo) -> todo",
+          "!doc": "todo"
+        },
+        "update": {
+          "!type": "fn(delta: todo) -> todo",
+          "!doc": "todo"
+        },
+        "autoCreateAnimations": {
+          "!type": "fn(fps: todo) -> todo",
+          "!doc": "todo"
+        },
+        "setAnimationDuration": {
+          "!type": "fn(name: todo, duration: todo) -> todo",
+          "!doc": "todo"
+        },
+        "setAnimationDirectionForward": {
+          "!type": "fn(name: todo) -> todo",
+          "!doc": "todo"
+        },
+        "getAnimationDuration": {
+          "!type": "fn(name: todo) -> todo",
+          "!doc": "todo"
+        },
+        "getAnimationTime": {
+          "!type": "fn(name: todo) -> todo",
+          "!doc": "todo"
+        },
+        "setAnimationDirectionBackward": {
+          "!type": "fn(name: todo) -> todo",
+          "!doc": "todo"
+        },
+        "setAnimationTime": {
+          "!type": "fn(name: todo, time: todo) -> todo",
+          "!doc": "todo"
+        },
+        "stopAnimation": {
+          "!type": "fn(name: todo) -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "todo",
+      "!type": "fn(geometry: todo, material: todo)"
+    },
+    "AmbientLight": {
+      "!url": "http://threejs.org/docs/#Reference/lights/AmbientLight",
+      "prototype": {
+        "!proto": "THREE.Light.prototype"
+      },
+      "!doc": "This light's color gets applied to all the objects in the scene globally.",
+      "!type": "fn(hex: number)"
+    },
+    "AreaLight": {
+      "!url": "http://threejs.org/docs/#Reference/lights/AreaLight",
+      "prototype": {
+        "!proto": "THREE.Light.prototype",
+        "right": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Sets or gets an unit vector that indicates the right side of the light. This is calculated in local space."
+        },
+        "normal": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Sets or gets an unit vectorSets or gets an unit vector that indicates the right side of the light. This is calculated in local space."
+        },
+        "height": {
+          "!type": "number",
+          "!doc": "Sets or gets the height of the illuminating plane."
+        },
+        "width": {
+          "!type": "number",
+          "!doc": "Sets or gets the width of the illuminating plane."
+        },
+        "intensity": {
+          "!type": "number",
+          "!doc": "Light's intensity.<br>\n\t\tDefault — *1.0*."
+        },
+        "constantAttenuation": {
+          "!type": "number",
+          "!doc": "Sets or gets the attention of the light in constant space. This is independant of the distance of the light."
+        },
+        "linearAttenuation": {
+          "!type": "number",
+          "!doc": "Sets or gets the attention of the light in linear space. This increases the attenuation linearly with the distance from the light."
+        },
+        "quadraticAttenuation": {
+          "!type": "number",
+          "!doc": "Sets or gets the attention of the light in linear space. This increases the attenuation quadratic with the distance from the light."
+        }
+      },
+      "!doc": "This illuminates the scene from a complete surface. This light only works in the [page:WebGLDeferredRenderer deferredrenderer].",
+      "!type": "fn(hex: number, intensity: number)"
+    },
+    "DirectionalLight": {
+      "!url": "http://threejs.org/docs/#Reference/lights/DirectionalLight",
+      "prototype": {
+        "!proto": "THREE.Light.prototype",
+        "target": {
+          "!type": "+THREE.Object3D",
+          "!doc": "Target used for shadow camera orientation."
+        },
+        "intensity": {
+          "!type": "number",
+          "!doc": "Light's intensity.<br>\n\t\t\tDefault — *1.0*."
+        },
+        "onlyShadow": {
+          "!type": "bool",
+          "!doc": "If set to *true* light will only cast shadow but not contribute any lighting (as if *intensity* was 0 but cheaper to compute).<br>\n\t\t\tDefault — *false*."
+        },
+        "shadowCameraNear": {
+          "!type": "number",
+          "!doc": "Orthographic shadow camera frustum parameter.<br>\n\t\t\tDefault — *50*."
+        },
+        "shadowCameraFar": {
+          "!type": "number",
+          "!doc": "Orthographic shadow camera frustum parameter.<br>\n\t\t\tDefault — *5000*."
+        },
+        "shadowCameraLeft": {
+          "!type": "number",
+          "!doc": "Orthographic shadow camera frustum parameter.<br>\n\t\t\tDefault — *-500*."
+        },
+        "shadowCameraRight": {
+          "!type": "number",
+          "!doc": "Orthographic shadow camera frustum parameter.<br>\n\t\t\tDefault — *500*."
+        },
+        "shadowCameraTop": {
+          "!type": "number",
+          "!doc": "Orthographic shadow camera frustum parameter.<br>\n\t\t\tDefault — *500*."
+        },
+        "shadowCameraBottom": {
+          "!type": "number",
+          "!doc": "Orthographic shadow camera frustum parameter.<br>\n\t\t\tDefault — *-500*."
+        },
+        "shadowCameraVisible": {
+          "!type": "bool",
+          "!doc": "Show debug shadow camera frustum.<br>\n\t\t\tDefault — *false*."
+        },
+        "shadowBias": {
+          "!type": "number",
+          "!doc": "Shadow map bias, how much to add or subtract from the normalized depth when deciding whether a surface is in shadow.<br>\n\t\t\tDefault — *0*."
+        },
+        "shadowDarkness": {
+          "!type": "number",
+          "!doc": "Darkness of shadow casted by this light (from *0* to *1*).<br>\n\t\t\tDefault — *0.5*."
+        },
+        "shadowMapWidth": {
+          "!type": "number",
+          "!doc": "Shadow map texture width in pixels.<br>\n\t\t\tDefault — *512*."
+        },
+        "shadowMapHeight": {
+          "!type": "number",
+          "!doc": "Shadow map texture height in pixels.<br>\n\t\t\tDefault — *512*."
+        },
+        "shadowCascade": {
+          "!type": "bool",
+          "!doc": "**Experimental** If true, use a series of shadow maps in a cascade. This can give better z-depth resolution for a directional light. <br>\n\t\t\tDefault — *false*."
+        },
+        "shadowCascadeCount": {
+          "!type": "number",
+          "!doc": "Number of shadow maps to allocate in a cascade (one after another). <br>\n\t\t\tDefault — *2*."
+        },
+        "shadowCascadeOffset": {
+          "!type": "+THREE.Vector3",
+          "!doc": "A relative position to real camera where virtual shadow cameras are attached. A magic vector; scene and light orientation dependent. <br>\n\t\t\tDefault — *Three.Vector3( 0, 0, -1000 )*."
+        },
+        "shadowCascadeBias": {
+          "!type": "[]",
+          "!doc": "An array of shadowMapBias values for the corresponding shadow map in the cascade, near to far. <br>\n\t\t\tDefault — <strong>[ 0, 0, 0 ]</strong>."
+        },
+        "shadowCascadeWidth": {
+          "!type": "[]",
+          "!doc": "An array of shadowMapWidth values for the corresponding shadow map in the cascade, near to far. <br>\n\t\t\tDefault — <strong>[ 512, 512, 512 ]</strong>."
+        },
+        "shadowCascadeHeight": {
+          "!type": "[]",
+          "!doc": "An array of shadowMapHeight values for the corresponding shadow map in the cascade, near to far. <br>\n\t\t\tDefault — <strong>[ 512, 512, 512 ]</strong>."
+        },
+        "shadowCascadeNearZ": {
+          "!type": "[]",
+          "!doc": "An array of shadowMapNear values for the corresponding shadow map in the cascade, near to far. These typically start with -1.0 (near plane) and match with the previous shadowCascadeFarZ array value.<br>\n\t\t\tDefault — <strong>[ -1.000, 0.990, 0.998 ]</strong>."
+        },
+        "shadowCascadeFarZ": {
+          "!type": "[]",
+          "!doc": "An array of shadowMapFar values for the corresponding shadow map in the cascade, near to far. These typically match with the next shadowCascadeNearZ array value, ending in 1.0.<br>\n\t\t\tDefault — <strong>[ 0.990, 0.998, 1.000 ]</strong>."
+        },
+        "shadowCascadeArray": {
+          "!type": "[]",
+          "!doc": "Array of size shadowCascadeCount of [page:DirectionalLight THREE.DirectionalLight] objects. This holds the series of separate shadow maps in a cascade, near to far. Created internally."
+        },
+        "shadowMapSize": {
+          "!type": "+THREE.Vector2",
+          "!doc": "The shadowMapWidth and shadowMapHeight stored in a [page:Vector2 THREE.Vector2]. Set internally during rendering."
+        },
+        "shadowCamera": {
+          "!type": "+THREE.OrthographicCamera",
+          "!doc": "The shadow's view of the world. Computed internally during rendering from the shadowCamera* settings."
+        },
+        "shadowMatrix": {
+          "!type": "+THREE.Matrix4",
+          "!doc": "Model to shadow camera space, to compute location and depth in shadow map. Computed internally during rendering."
+        },
+        "shadowMap": {
+          "!type": "+THREE.WebGLRenderTarget",
+          "!doc": "The depth map generated using the shadowCamera; a location beyond a pixel's depth is in shadow. Computed internally during rendering."
+        }
+      },
+      "!doc": "Affects objects using [page:MeshLambertMaterial] or [page:MeshPhongMaterial].",
+      "!type": "fn(hex: number, intensity: number)"
+    },
+    "HemisphereLight": {
+      "!url": "http://threejs.org/docs/#Reference/lights/HemisphereLight",
+      "prototype": {
+        "!proto": "THREE.Light.prototype",
+        "groundColor": {
+          "!type": "number",
+          "!doc": "Light's ground color.<br>"
+        },
+        "intensity": {
+          "!type": "number",
+          "!doc": "Light's intensity.<br>\n\t\t\tDefault — *1.0*."
+        }
+      },
+      "!doc": "A light source positioned directly above the scene.",
+      "!type": "fn(skyColorHex: number, groundColorHex: number, intensity: number)"
+    },
+    "Light": {
+      "!url": "http://threejs.org/docs/#Reference/lights/Light",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "color": {
+          "!type": "+THREE.Color",
+          "!doc": "Color of the light.<br>"
+        }
+      },
+      "!doc": "Abstract base class for lights.",
+      "!type": "fn(hex: number)"
+    },
+    "PointLight": {
+      "!url": "http://threejs.org/docs/#Reference/lights/PointLight",
+      "prototype": {
+        "!proto": "THREE.Light.prototype",
+        "intensity": {
+          "!type": "number",
+          "!doc": "Light's intensity.<br>\n\t\t\tDefault - *1.0*."
+        },
+        "distance": {
+          "!type": "number",
+          "!doc": "If non-zero, light will attenuate linearly from maximum intensity at light *position* down to zero at *distance*.<br>\n\t\t\tDefault — *0.0*."
+        }
+      },
+      "!doc": "Affects objects using [page:MeshLambertMaterial] or [page:MeshPhongMaterial].",
+      "!type": "fn(hex: number, intensity: number, distance: number)"
+    },
+    "SpotLight": {
+      "!url": "http://threejs.org/docs/#Reference/lights/SpotLight",
+      "prototype": {
+        "!proto": "THREE.Light.prototype",
+        "target": {
+          "!type": "+THREE.Object3D",
+          "!doc": "Spotlight focus points at target.position.<br>\n\t\t\tDefault position — *(0,0,0)*."
+        },
+        "intensity": {
+          "!type": "number",
+          "!doc": "Light's intensity.<br>\n\t\t\tDefault — *1.0*."
+        },
+        "distance": {
+          "!type": "number",
+          "!doc": "If non-zero, light will attenuate linearly from maximum intensity at light *position* down to zero at *distance*.<br>\n\t\t\tDefault — *0.0*."
+        },
+        "angle": {
+          "!type": "number",
+          "!doc": "Maximum extent of the spotlight, in radians, from its direction. Should be no more than *Math.PI/2*.<br>\n\t\t\tDefault — *Math.PI/3*."
+        },
+        "exponent": {
+          "!type": "number",
+          "!doc": "Rapidity of the falloff of light from its target direction.<br>\n\t\t\tDefault — *10.0*."
+        },
+        "castShadow": {
+          "!type": "bool",
+          "!doc": "If set to *true* light will cast dynamic shadows. *Warning*: This is expensive and requires tweaking to get shadows looking right.<br>\n\t\t\tDefault — *false*."
+        },
+        "onlyShadow": {
+          "!type": "bool",
+          "!doc": "If set to *true* light will only cast shadow but not contribute any lighting (as if *intensity* was 0 but cheaper to compute).<br>\n\t\t\tDefault — *false*."
+        },
+        "shadowCameraNear": {
+          "!type": "number",
+          "!doc": "Perspective shadow camera frustum <em>near</em> parameter.<br>\n\t\t\tDefault — *50*."
+        },
+        "shadowCameraFar": {
+          "!type": "number",
+          "!doc": "Perspective shadow camera frustum <em>far</em> parameter.<br>\n\t\t\tDefault — *5000*."
+        },
+        "shadowCameraFov": {
+          "!type": "number",
+          "!doc": "Perspective shadow camera frustum <em>field of view</em> parameter.<br>\n\t\t\tDefault — *50*."
+        },
+        "shadowCameraVisible": {
+          "!type": "bool",
+          "!doc": "Show debug shadow camera frustum.<br>\n\t\t\tDefault — *false*."
+        },
+        "shadowBias": {
+          "!type": "number",
+          "!doc": "Shadow map bias, how much to add or subtract from the normalized depth when deciding whether a surface is in shadow.<br>\n\t\t\tDefault — *0*."
+        },
+        "shadowDarkness": {
+          "!type": "number",
+          "!doc": "Darkness of shadow casted by this light (from *0* to *1*).<br>\n\t\t\tDefault — *0.5*."
+        },
+        "shadowMapWidth": {
+          "!type": "number",
+          "!doc": "Shadow map texture width in pixels.<br>\n\t\t\tDefault — *512*."
+        },
+        "shadowMapHeight": {
+          "!type": "number",
+          "!doc": "Shadow map texture height in pixels.<br>\n\t\t\tDefault — *512*."
+        },
+        "shadowMapSize": {
+          "!type": "+THREE.Vector2",
+          "!doc": "The shadowMapWidth and shadowMapHeight stored in a [page:Vector2 THREE.Vector2]. Set internally during rendering."
+        },
+        "shadowCamera": {
+          "!type": "+THREE.PerspectiveCamera",
+          "!doc": "The shadow's view of the world. Computed internally during rendering from the shadowCamera* settings."
+        },
+        "shadowMatrix": {
+          "!type": "+THREE.Matrix4",
+          "!doc": "Model to shadow camera space, to compute location and depth in shadow map. Computed internally during rendering."
+        },
+        "shadowMap": {
+          "!type": "+THREE.WebGLRenderTarget",
+          "!doc": "The depth map generated using the shadowCamera; a location beyond a pixel's depth is in shadow. Computed internally during rendering."
+        }
+      },
+      "!doc": "A point light that can cast shadow in one direction.",
+      "!type": "fn(hex: number, intensity: number, distance: todo, angle: todo, exponent: todo)"
+    },
+    "BabylonLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/BabylonLoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and call onLoad with the parsed response content."
+        },
+        "parse": {
+          "!type": "fn(json: object) -> +THREE.Object3D",
+          "!doc": "Parse a <em>JSON</em> structure and return an [page:Object3D object] or a [page:Scene scene].<br>\n\t\tFound objects are converted to [page:Mesh] with a [page:BufferGeometry] and a default [page:MeshPhongMaterial].<br>\n\t\tLights are parsed accordingly."
+        }
+      },
+      "!doc": "A loader for loading a <em>.babylon</em> resource.",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "BufferGeometryLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/BufferGeometryLoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and call onLoad with the parsed response content."
+        },
+        "parse": {
+          "!type": "fn(json: object) -> +THREE.BufferGeometry",
+          "!doc": "Parse a <em>JSON</em> structure and return a [page:BufferGeometry]."
+        }
+      },
+      "!doc": "A loader for loading a [page:BufferGeometry].",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "Cache": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/Cache",
+      "prototype": {
+        "files": {
+          "!type": "object",
+          "!doc": "An [page:Object object] that hold cached values."
+        },
+        "add": {
+          "!type": "fn(key: string, value)",
+          "!doc": "Adds a cache entry with that key to hold the value. If this key already holds a value, it is overwritten."
+        },
+        "get": {
+          "!type": "fn(key: string)",
+          "!doc": "Get the value of key. If the key does not exist the null value is returned."
+        },
+        "remove": {
+          "!type": "fn(key: string)",
+          "!doc": "Remove the cached value associated with the key."
+        },
+        "clear": {
+          "!type": "fn()",
+          "!doc": "Remove all values from the cache."
+        }
+      },
+      "!doc": "A simple caching classe, used internaly by [page:XHRLoader].",
+      "!type": "fn()"
+    },
+    "ColladaLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/ColladaLoader",
+      "prototype": {
+        "options": {
+          "!type": "[]",
+          "!doc": "&nbsp;.[page:Boolean centerGeometry] — Force [page:Geometry] to always be centered at the local origin of the containing [page: Mesh].<br>\n\t\t&nbsp;.[page:Boolean convertUpAxis] — Axis conversion is done for geometries, animations, and controllers.<br>\n\t\t&nbsp;.[page:Boolean subdivideFaces] — Force subdivision into multiple [page: Face3].<br>\n\t\t&nbsp;.[page:String upAxis] — X, Y or Z<br>\n\t\t&nbsp;.[page:Boolean defaultEnvMap] — Cubemap to use for reflective or refractive materials.<br>"
+        },
+        "geometries": {
+          "!type": "object",
+          "!doc": "Parsed <em>.dae</em> geometries."
+        },
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function)",
+          "!doc": "Begin loading from url and call onLoad with the parsed response content."
+        },
+        "parse": {
+          "!type": "fn(doc: Document, callBack: function, url: string) -> object",
+          "!doc": "Parse an <em>XML Document</em> and return an [page:Object object] that contain loaded parts: .[page:Scene scene], .[page:Array morphs], .[page:Array skins], .[page:Array animations], .[page:Object dae]"
+        },
+        "setPreferredShading": {
+          "!type": "fn(shading: number)",
+          "!doc": "Set the .[page:Integer shading] property on the resource's materials.<br>\n\t\tOptions are [page:Materials THREE.SmoothShading], [page:Materials THREE.FlatShading], [page:Materials THREE.NoShading]."
+        },
+        "applySkin": {
+          "!type": "fn(geometry: +THREE.Geometry, instanceCtrl: object, frame: number)",
+          "!doc": "Apply a skin (vertices, animation, bones) from a <em>collada skin controller</em>, on the given [page:Geometry]."
+        }
+      },
+      "!doc": "A loader for <em>Collada</em> files.",
+      "!type": "fn()"
+    },
+    "ImageLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/ImageLoader",
+      "prototype": {
+        "crossOrigin": {
+          "!type": "string",
+          "!doc": "The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS."
+        },
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and return the [page:Image image] object that will contain the data."
+        },
+        "setCrossOrigin": {
+          "!type": "fn(value: string)",
+          "!doc": "The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS."
+        }
+      },
+      "!doc": "A loader for loading an [page:Image].",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "JSONLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/JSONLoader",
+      "prototype": {
+        "!proto": "THREE.Loader.prototype",
+        "withCredentials": {
+          "!type": "boolean",
+          "!doc": "If true, the ajax request will use cookies."
+        },
+        "showStatus": {
+          "!type": "bool",
+          "!doc": "If true, show loading status in the statusDomElement."
+        },
+        "statusDomElement": {
+          "!type": "DOMElement",
+          "!doc": "This is the recipient of status messages."
+        },
+        "onLoadStart": {
+          "!type": "function",
+          "!doc": "The default is a function with empty body."
+        },
+        "onLoadComplete": {
+          "!type": "function",
+          "!doc": "The default is a function with empty body."
+        },
+        "load": {
+          "!type": "fn(url: string, callback: function, texturePath: string)",
+          "!doc": "[page:String url] — required<br>\n\t\t[page:Function callback] — required. Will be called when load completes. The arguments will be the loaded [page:Object3D] and the loaded [page:Array materials].<br>\n\t\t[page:String texturePath] — optional. If not specified, textures will be assumed to be in the same folder as the Javascript model file."
+        },
+        "loadAjaxJSON": {
+          "!type": "fn(context: +THREE.JSONLoader, url: string, callback: function, texturePath: string, callbackProgress: function)",
+          "!doc": "Begin loading from url and call <em>callback</em> with the parsed response content."
+        },
+        "parse": {
+          "!type": "fn(json: object, texturePath: string) -> +THREE.Object3D",
+          "!doc": "Parse a <em>JSON</em> structure and return an [page:Object] containing the parsed .[page:Geometry] and .[page:Array materials]."
+        },
+        "needsTangents": {
+          "!type": "fn(materials: []) -> bool",
+          "!doc": "Checks if the loaded object needs tangents based on its materials."
+        },
+        "updateProgress": {
+          "!type": "fn(progress: object)",
+          "!doc": "Updates the DOM object with the progress made."
+        },
+        "createMaterial": {
+          "!type": "fn(m: object, texturePath: string) -> +THREE.Material",
+          "!doc": "Creates the Material based on the parameters m."
+        },
+        "initMaterials": {
+          "!type": "fn(materials: [], texturePath: string) -> []",
+          "!doc": "Creates an array of [page:Material] based on the array of parameters m. The index of the parameters decide the correct index of the materials."
+        },
+        "extractUrlBase": {
+          "!type": "fn(url: string) -> string",
+          "!doc": "Extract the base from the URL."
+        },
+        "addStatusElement": {
+          "!type": "fn() -> DOMElement",
+          "!doc": "Add a DOM element to indicate the progress and return the DOMElement"
+        }
+      },
+      "!doc": "A loader for loading objects in JSON format.",
+      "!type": "fn(showStatus: bool)"
+    },
+    "Loader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/Loader",
+      "prototype": {
+        "showStatus": {
+          "!type": "bool",
+          "!doc": "If true, show loading status in the statusDomElement."
+        },
+        "statusDomElement": {
+          "!type": "DOMElement",
+          "!doc": "This is the recipient of status messages."
+        },
+        "onLoadStart": {
+          "!type": "function",
+          "!doc": "The default is a function with empty body."
+        },
+        "onLoadProgress": {
+          "!type": "function",
+          "!doc": "The default is a function with empty body."
+        },
+        "onLoadComplete": {
+          "!type": "function",
+          "!doc": "The default is a function with empty body."
+        },
+        "crossOrigin": {
+          "!type": "string",
+          "!doc": "The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS."
+        },
+        "needsTangents": {
+          "!type": "fn(materials: []) -> bool",
+          "!doc": "Checks if the loaded object needs tangents based on its materials."
+        },
+        "updateProgress": {
+          "!type": "fn(progress: object)",
+          "!doc": "Updates the DOM object with the progress made."
+        },
+        "createMaterial": {
+          "!type": "fn(m: object, texturePath: string) -> +THREE.Material",
+          "!doc": "Creates the Material based on the parameters m."
+        },
+        "initMaterials": {
+          "!type": "fn(materials: [], texturePath: string) -> []",
+          "!doc": "Creates an array of [page:Material] based on the array of parameters m. The index of the parameters decide the correct index of the materials."
+        },
+        "extractUrlBase": {
+          "!type": "fn(url: string) -> string",
+          "!doc": "Extract the base from the URL."
+        },
+        "addStatusElement": {
+          "!type": "fn() -> DOMElement",
+          "!doc": "Add a DOM element to indicate the progress and return the DOMElement"
+        }
+      },
+      "!doc": "Base class for implementing loaders.",
+      "!type": "fn(showStatus: bool)"
+    },
+    "LoadingManager": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/LoadingManager",
+      "prototype": {
+        "onLoad": {
+          "!type": "function",
+          "!doc": "The function that needs to be called when all loaders are done."
+        },
+        "onProgress": {
+          "!type": "function",
+          "!doc": "The function that needs to be called when an item is complete. The arguments are url(The url of the item just loaded),<br>\n\t\tloaded(the amount of items already loaded), total( The total amount of items to be loaded.)"
+        },
+        "onError": {
+          "!type": "function",
+          "!doc": "The function that needs to be called when an item errors."
+        },
+        "itemStart": {
+          "!type": "fn(url: string)",
+          "!doc": "This should be called by any loader used by the manager when the loader starts loading an url. These shouldn't be called outside a loader."
+        },
+        "itemEnd": {
+          "!type": "fn(url: string)",
+          "!doc": "This should be called by any loader used by the manager when the loader ended loading an url.  These shouldn't be called outside a loader."
+        }
+      },
+      "!doc": "Handles and keeps track of loaded and pending data.",
+      "!type": "fn(onLoad: function, onProgress: function, onError: function)"
+    },
+    "MTLLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/MTLLoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and return the loaded material."
+        },
+        "parse": {
+          "!type": "fn(text: string) -> MTLLoaderMaterialCreator",
+          "!doc": "Parse a <em>mtl</em> text structure and return a [page:MTLLoaderMaterialCreator] instance.<br>"
+        }
+      },
+      "!doc": "A loader for loading an <em>.mtl</em> resource, used internaly by [page:OBJMTLLoader] and [page:UTF8Loader].",
+      "!type": "fn(baseUrl: string, options: object, crossOrigin: string)"
+    },
+    "MaterialLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/MaterialLoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and return the [page:Material] object that will contain the data."
+        },
+        "setCrossOrigin": {
+          "!type": "fn(value: string)",
+          "!doc": "The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS."
+        },
+        "parse": {
+          "!type": "fn(json: object) -> +THREE.Material",
+          "!doc": "Parse a <em>JSON</em> structure and create a new [page:Material] of the type [page:String json.type] with parameters defined in the json object."
+        }
+      },
+      "!doc": "A loader for loading a [page:Material] in JSON format.",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "OBJLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/OBJLoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and call onLoad with the parsed response content."
+        },
+        "parse": {
+          "!type": "fn(text: string) -> +THREE.Object3D",
+          "!doc": "Parse an <em>obj</em> text structure and return an [page:Object3D].<br>\n\t\tFound objects are converted to [page:Mesh] with a [page:BufferGeometry] and a default [page:MeshLambertMaterial]."
+        }
+      },
+      "!doc": "A loader for loading an <em>.obj</em> resource.",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "OBJMTLLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/OBJMTLLoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(objUrl: string, mtlUrl: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from urls and call onLoad with the parsed response content."
+        },
+        "parse": {
+          "!type": "fn(text: string, mtllibCallback: function) -> +THREE.Object3D",
+          "!doc": "Parse an <em>obj</em> text structure and return an [page:Object3D].<br>\n\t\tFound objects are converted to a [page:Mesh] and materials are converted to [page:MeshLambertMaterial]."
+        }
+      },
+      "!doc": "A loader for loading a <em>.obj</em> and its <em>.mtl</em> together.",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "ObjectLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/ObjectLoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and call onLoad with the parsed response content."
+        },
+        "parse": {
+          "!type": "fn(json: object) -> +THREE.Object3D",
+          "!doc": "Parse a <em>JSON</em> content and return a threejs object."
+        },
+        "setCrossOrigin": {
+          "!type": "fn(value: string)",
+          "!doc": "[page:String value] — The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS."
+        }
+      },
+      "!doc": "A loader for loading a JSON resource. Unlike the [page:JSONLoader], this one make use of the <em>.type</em> attributes of objects to map them to their original classes.",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "PDBLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/PDBLoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and call onLoad with the parsed response content."
+        },
+        "parsePDB": {
+          "!type": "fn(text: string) -> object",
+          "!doc": "Parse a <em>pdb</em> text and return a <em>JSON</em> structure.<br>"
+        },
+        "createModel": {
+          "!type": "fn(json: object, callback: function)",
+          "!doc": "Parse a <em>(JSON) pdb</em> structure and return two [page:Geometry]: one for atoms, one for bonds.<br>"
+        }
+      },
+      "!doc": "A loader for loading a <em>.pdb</em> resource.\n\t\t<br><br>\n\t\tThe <a href=\"http://en.wikipedia.org/wiki/Protein_Data_Bank_(file_format)\">Protein Data Bank file format</a> is a textual file format describing the three-dimensional structures of molecules.",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "SVGLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/SVGLoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and call onLoad with the response content."
+        }
+      },
+      "!doc": "A loader for loading an <em>.svg</em> resource.",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "TGALoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/TGALoader",
+      "prototype": {
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function) -> +THREE.DataTexture",
+          "!doc": "Begin loading from url and pass the loaded [page:DataTexture texture] to onLoad. The [page:DataTexture texture] is also directly returned for immediate use (but may not be fully loaded)."
+        }
+      },
+      "!doc": "Class for loading a <em>.tga</em> [page:DataTexture texture].",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "TextureLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/TextureLoader",
+      "prototype": {
+        "crossOrigin": {
+          "!type": "string",
+          "!doc": "default — *null*.<br>\n\t\tIf set, assigns the *crossOrigin* attribute of the image to the value of *crossOrigin*, prior to starting the load."
+        },
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and pass the loaded [page:Texture texture] to onLoad."
+        }
+      },
+      "!doc": "Class for loading a [page:Texture texture].",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "XHRLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/XHRLoader",
+      "prototype": {
+        "cache": {
+          "!type": "+THREE.Cache",
+          "!doc": "A [page:Cache cache] instance that hold the response from each request made through this loader, so each file is requested once."
+        },
+        "crossOrigin": {
+          "!type": "string",
+          "!doc": "The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS."
+        },
+        "responseType": {
+          "!type": "string",
+          "!doc": "Can be set to change the response type."
+        },
+        "load": {
+          "!type": "fn(url: string, onLoad: function, onProgress: function, onError: function)",
+          "!doc": "Begin loading from url and return the [page:String text] response that will contain the data."
+        },
+        "setCrossOrigin": {
+          "!type": "fn(value: string)",
+          "!doc": "[page:String value] — The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS."
+        },
+        "setResponseType": {
+          "!type": "fn(value: string)",
+          "!doc": "[page:String value] — the empty string (default), \"arraybuffer\", \"blob\", \"document\", \"json\", or \"text\"."
+        }
+      },
+      "!doc": "A low level class for loading resources with XmlHttpRequest, used internaly by most loaders.",
+      "!type": "fn(manager: +THREE.LoadingManager)"
+    },
+    "glTFLoader": {
+      "!url": "http://threejs.org/docs/#Reference/loaders/glTFLoader",
+      "prototype": {
+        "!proto": "THREE.Loader.prototype",
+        "load": {
+          "!type": "fn(url: string, callback: function) -> +THREE.Object3D",
+          "!doc": "Begin loading from url and call the callback function with the parsed response content."
+        }
+      },
+      "!doc": "A loader for loading a <em>.gltf</em> resource in <em>JSON</em> format.\n\t\t<br><br>\n\t\tThe <a href=\"https://www.khronos.org/gltf\">glTF file format</a> is a JSON file format to enable rapid delivery and loading of 3D content.",
+      "!type": "fn()"
+    },
+    "LineBasicMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/LineBasicMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "color": {
+          "!type": "number",
+          "!doc": "Sets the color of the line. Default is 0xffffff."
+        },
+        "linewidth": {
+          "!type": "number",
+          "!doc": "Due to limitations in the <a href=\"https://code.google.com/p/angleproject/\" target=\"_blank\">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value."
+        },
+        "linecap": {
+          "!type": "string",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer."
+        },
+        "linejoin": {
+          "!type": "string",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer."
+        },
+        "vertexColors": {
+          "!type": "number",
+          "!doc": "This setting might not have any effect when used with certain renderers."
+        },
+        "fog": {
+          "!type": "bool",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        }
+      },
+      "!doc": "A material for drawing wireframe-style geometries.",
+      "!type": "fn(parameters: object)"
+    },
+    "LineDashedMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/LineDashedMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "color": {
+          "!type": "+THREE.Color",
+          "!doc": "Sets the color of the line. Default is 0xffffff."
+        },
+        "linewidth": {
+          "!type": "number",
+          "!doc": "Due to limitations in the <a href=\"https://code.google.com/p/angleproject/\" target=\"_blank\">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value."
+        },
+        "scale": {
+          "!type": "number",
+          "!doc": "The scale of the dashed part of a line."
+        },
+        "dashSize": {
+          "!type": "number",
+          "!doc": "The size of the dash. This is both the gap with the stroke. Default is 3."
+        },
+        "gapSize": {
+          "!type": "number",
+          "!doc": "The size of the gap. Default is 1."
+        },
+        "vertexColors": {
+          "!type": "boolean",
+          "!doc": "This setting might not have any effect when used with certain renderers."
+        },
+        "fog": {
+          "!type": "boolean",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        }
+      },
+      "!doc": "A material for drawing wireframe-style geometries with dashed lines.",
+      "!type": "fn(parameters: object)"
+    },
+    "Material": {
+      "!url": "http://threejs.org/docs/#Reference/materials/Material",
+      "prototype": {
+        "id": {
+          "!type": "number",
+          "!doc": "Unique number for this material instance."
+        },
+        "name": {
+          "!type": "string",
+          "!doc": "Material name. Default is an empty string."
+        },
+        "opacity": {
+          "!type": "number",
+          "!doc": "Default is *1.0*."
+        },
+        "transparent": {
+          "!type": "bool",
+          "!doc": "Default is *false*."
+        },
+        "blendDst": {
+          "!type": "number",
+          "!doc": "Blending destination. It's one of the blending mode constants defined in [page:Three Three.js]. Default is [page:CustomBlendingEquation OneMinusSrcAlphaFactor]."
+        },
+        "blendEquation": {
+          "!type": "number",
+          "!doc": "Blending equation to use when applying blending. It's one of the constants defined in [page:Three Three.js]. Default is [page:CustomBlendingEquation AddEquation.]"
+        },
+        "depthTest": {
+          "!type": "bool",
+          "!doc": "Whether to have depth test enabled when rendering this material. Default is *true*."
+        },
+        "depthWrite": {
+          "!type": "bool",
+          "!doc": "When drawing 2D overlays it can be useful to disable the depth writing in order to layer several things together without creating z-index artifacts."
+        },
+        "polygonOffset": {
+          "!type": "bool",
+          "!doc": "Whether to use polygon offset. Default is *false*. This corresponds to the *POLYGON_OFFSET_FILL* WebGL feature."
+        },
+        "polygonOffsetFactor": {
+          "!type": "number",
+          "!doc": "Sets the polygon offset factor. Default is *0*."
+        },
+        "polygonOffsetUnits": {
+          "!type": "number",
+          "!doc": "Sets the polygon offset units. Default is *0*."
+        },
+        "alphaTest": {
+          "!type": "number",
+          "!doc": "Sets the alpha value to be used when running an alpha test. Default is *0*."
+        },
+        "overdraw": {
+          "!type": "number",
+          "!doc": "Amount of triangle expansion at draw time. This is a workaround for cases when gaps appear between triangles when using [page:CanvasRenderer]. *0.5* tends to give good results across browsers. Default is *0*."
+        },
+        "visible": {
+          "!type": "bool",
+          "!doc": "Defines whether this material is visible. Default is *true*."
+        },
+        "side": {
+          "!type": "Enum",
+          "!doc": "Default is [page:Materials THREE.FrontSide]. Other options are [page:Materials THREE.BackSide] and [page:Materials THREE.DoubleSide]."
+        },
+        "needsUpdate": {
+          "!type": "bool",
+          "!doc": "This property is automatically set to *true* when instancing a new material."
+        },
+        "clone": {
+          "!type": "fn(material: material) -> +THREE.Material",
+          "!doc": "This clones the material in the optional parameter and returns it."
+        },
+        "dispose": {
+          "!type": "fn()",
+          "!doc": "This disposes the material."
+        },
+        "setValues": {
+          "!type": "fn(values: object)",
+          "!doc": "Sets the properties based on the *values*."
+        }
+      },
+      "!doc": "Materials describe the appearance of [page:Object objects]. They are defined in a (mostly) renderer-independent way, so you don't have to rewrite materials if you decide to use a different renderer.",
+      "!type": "fn()"
+    },
+    "MeshBasicMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/MeshBasicMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "color": {
+          "!type": "number",
+          "!doc": "Sets the color of the geometry. Default is 0xffffff."
+        },
+        "lightMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "Set light map. Default is null."
+        },
+        "specularMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "Set specular map. Default is null."
+        },
+        "alphaMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected."
+        },
+        "envMap": {
+          "!type": "TextureCube",
+          "!doc": "Set env map. Default is null."
+        },
+        "fog": {
+          "!type": "bool",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        },
+        "shading": {
+          "!type": "string",
+          "!doc": "Define shading type. Default is THREE.SmoothShading."
+        },
+        "wireframe": {
+          "!type": "bool",
+          "!doc": "Render geometry as wireframe. Default is false (i.e. render as flat polygons)."
+        },
+        "wireframeLinewidth": {
+          "!type": "number",
+          "!doc": "Due to limitations in the <a href=\"https://code.google.com/p/angleproject/\" target=\"_blank\">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value."
+        },
+        "wireframeLinecap": {
+          "!type": "string",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer."
+        },
+        "wireframeLinejoin": {
+          "!type": "string",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer."
+        },
+        "vertexColors": {
+          "!type": "number",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        },
+        "skinning": {
+          "!type": "bool",
+          "!doc": "Define whether the material uses skinning. Default is false."
+        },
+        "morphTargets": {
+          "!type": "bool",
+          "!doc": "Define whether the material uses morphTargets. Default is false."
+        },
+        "map": {
+          "!type": "+THREE.Texture",
+          "!doc": "Sets the texture map. Default is  null."
+        },
+        "combine": {
+          "!type": "number",
+          "!doc": "How to combine the result of the surface's color with the environment map, if any."
+        },
+        "reflectivity": {
+          "!type": "number",
+          "!doc": "How much the environment map affects the surface; also see \"combine\"."
+        },
+        "refractionRatio": {
+          "!type": "number",
+          "!doc": "The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*."
+        }
+      },
+      "!doc": "A material for drawing geometries in a simple shaded (flat or wireframe) way.",
+      "!type": "fn(parameters: object)"
+    },
+    "MeshDepthMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/MeshDepthMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "morphTargets": {
+          "!type": "boolean",
+          "!doc": "Define whether the material uses morphTargets. Default is false."
+        },
+        "wireframe": {
+          "!type": "boolean",
+          "!doc": "Render geometry as wireframe. Default is false (i.e. render as smooth shaded)."
+        },
+        "wireframeLinewidth": {
+          "!type": "number",
+          "!doc": "Controls wireframe thickness. Default is 1.<br><br>\n\t\t\tDue to limitations in the ANGLE layer, on Windows platforms linewidth will always be 1 regardless of the set value."
+        }
+      },
+      "!doc": "A material for drawing geometry by depth. Depth is based off of the camera near and far plane. White is nearest, black is farthest.",
+      "!type": "fn(parameters: object)"
+    },
+    "MeshFaceMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/MeshFaceMaterial",
+      "prototype": {
+        "materials": {
+          "!type": "[]",
+          "!doc": "Get or set the materials for the geometry."
+        }
+      },
+      "!doc": "A Material to define multiple materials for the same geometry. \n\t\tThe geometry decides which material is used for which faces by the [page:Face3 faces materialindex].\n\t\tThe materialindex corresponds with the index of the material in the materials array.",
+      "!type": "fn(materials: [])"
+    },
+    "MeshLambertMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/MeshLambertMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "color": {
+          "!type": "+THREE.Color",
+          "!doc": "Diffuse color of the material. Default is white.<br>"
+        },
+        "emissive": {
+          "!type": "+THREE.Color",
+          "!doc": "Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br>"
+        },
+        "wrapAround": {
+          "!type": "boolean",
+          "!doc": "Define whether the diffuse lighting wraps around the model or not. This option adds a little more (tintable) light\n\t\t\tonto the side of the object in relation to a light."
+        },
+        "wrapRGB": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Decide how much of the wrap around values get used if the wrapAround option is set. The x, y, z values correspond\n\t\t\tto the r, g, b values respectively. The typical range is of each is from 0 to 1. For example setting all of the\n\t\t\tvector values to 0.5 will add a moderate amount of light to the side of the model. Changing *b* to 1 will\n\t\t\ttint the light on the side to be more blue. Defaults to *(1,1,1)*."
+        },
+        "map": {
+          "!type": "+THREE.Texture",
+          "!doc": "Set color texture map. Default is null."
+        },
+        "lightMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "Set light map. Default is null."
+        },
+        "specularMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "Since this material does not have a specular component, the specular value affects only how much of the environment map affects the surface. Default is null."
+        },
+        "alphaMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected."
+        },
+        "envMap": {
+          "!type": "TextureCube",
+          "!doc": "Set env map. Default is null."
+        },
+        "combine": {
+          "!type": "number",
+          "!doc": "Options are [page:Textures THREE.Multiply] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors."
+        },
+        "reflectivity": {
+          "!type": "number",
+          "!doc": "How much the environment map affects the surface; also see \"combine\"."
+        },
+        "refractionRatio": {
+          "!type": "number",
+          "!doc": "The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*."
+        },
+        "fog": {
+          "!type": "bool",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        },
+        "shading": {
+          "!type": "number",
+          "!doc": "Options are [page:Materials THREE.SmoothShading] (default), [page:Materials THREE.FlatShading], [page:Materials THREE.NoShading]."
+        },
+        "wireframe": {
+          "!type": "bool",
+          "!doc": "Whether the triangles' edges are displayed instead of surfaces. Default is *false*."
+        },
+        "wireframeLinewidth": {
+          "!type": "number",
+          "!doc": "Due to limitations in the <a href=\"https://code.google.com/p/angleproject/\" target=\"_blank\">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value."
+        },
+        "wireframeLinecap": {
+          "!type": "string",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer."
+        },
+        "wireframeLinejoin": {
+          "!type": "string",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer."
+        },
+        "vertexColors": {
+          "!type": "number",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        },
+        "skinning": {
+          "!type": "bool",
+          "!doc": "Define whether the material uses skinning. Default is *false*."
+        },
+        "morphTargets": {
+          "!type": "bool",
+          "!doc": "Define whether the material uses morphTargets. Default is *false*."
+        },
+        "morphNormals": {
+          "!type": "boolean",
+          "!doc": "Defines whether the material uses morphNormals. Set as true to pass morphNormal attributes from the [page:Geometry]\n\t\t\tto the shader. Default is *false*."
+        }
+      },
+      "!doc": "A material for non-shiny (Lambertian) surfaces, evaluated per vertex.",
+      "!type": "fn(parameters: object)"
+    },
+    "MeshNormalMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/MeshNormalMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "wireframe": {
+          "!type": "boolean",
+          "!doc": "Render geometry as wireframe. Default is false (i.e. render as smooth shaded)."
+        },
+        "wireframeLinewidth": {
+          "!type": "number",
+          "!doc": "Controls wireframe thickness. Default is 1.<br><br>\n\t\t\tDue to limitations in the ANGLE layer, on Windows platforms linewidth will always be 1 regardless of the set value."
+        },
+        "morphTargets": {
+          "!type": "boolean",
+          "!doc": "Define whether the material uses morphTargets. Default is false."
+        }
+      },
+      "!doc": "A material that maps the normal vectors to RGB colors.",
+      "!type": "fn(parameters: object)"
+    },
+    "MeshPhongMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/MeshPhongMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "color": {
+          "!type": "+THREE.Color",
+          "!doc": "Diffuse color of the material. Default is white.<br>"
+        },
+        "emissive": {
+          "!type": "+THREE.Color",
+          "!doc": "Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br>"
+        },
+        "specular": {
+          "!type": "+THREE.Color",
+          "!doc": "Specular color of the material, i.e., how shiny the material is and the color of its shine. Setting this the same color as the diffuse value (times some intensity) makes the material more metallic-looking; setting this to some gray makes the material look more plastic. Default is dark gray.<br>"
+        },
+        "shininess": {
+          "!type": "number",
+          "!doc": "How shiny the specular highlight is; a higher value gives a sharper highlight. Default is *30*. It should not be set to 0."
+        },
+        "metal": {
+          "!type": "boolean",
+          "!doc": "If set to true the shader multiplies the specular highlight by the underlying color of the object, making\n\t\t\tit appear to be more metal-like and darker. If set to false the specular highlight is added ontop of the\n\t\t\tunderlying colors."
+        },
+        "wrapAround": {
+          "!type": "boolean",
+          "!doc": "Define whether the diffuse lighting wraps around the model or not. This option adds a little more (tintable) light\n\t\t\tonto the side of the object in relation to a light."
+        },
+        "wrapRGB": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Decide how much of the wrap around values get used if the wrapAround option is set. The x, y, z values correspond\n\t\t\tto the r, g, b values respectively. The typical range is of each is from 0 to 1. For example setting all of the\n\t\t\tvector values to 0.5 will add a moderate amount of light to the side of the model. Changing *b* to 1 will\n\t\t\ttint the light on the side to be more blue. Defaults to (1,1,1)."
+        },
+        "map": {
+          "!type": "+THREE.Texture",
+          "!doc": "Set color texture map. Default is null."
+        },
+        "lightMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "Set light map. Default is null."
+        },
+        "bumpMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights.\n\t\t\tBump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will\n\t\t\tbe ignored."
+        },
+        "bumpScale": {
+          "!type": "number",
+          "!doc": "How much the bump map affects the material. Typical ranges are 0-1. Default is 1."
+        },
+        "normalMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change\n\t\t\tthe way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting."
+        },
+        "normalScale": {
+          "!type": "+THREE.Vector2",
+          "!doc": "How much the normal map affects the material. Typical ranges are 0-1. Default is (1,1)."
+        },
+        "specularMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "The specular map value affects both how much the specular surface highlight contributes and how much of the environment map affects the surface. Default is null."
+        },
+        "alphaMap": {
+          "!type": "+THREE.Texture",
+          "!doc": "Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected."
+        },
+        "envMap": {
+          "!type": "TextureCube",
+          "!doc": "Set env map. Default is null."
+        },
+        "combine": {
+          "!type": "number",
+          "!doc": "Options are [page:Textures THREE.MultiplyOperation] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors."
+        },
+        "reflectivity": {
+          "!type": "number",
+          "!doc": "How much the environment map affects the surface; also see \"combine\"."
+        },
+        "refractionRatio": {
+          "!type": "number",
+          "!doc": "The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*."
+        },
+        "fog": {
+          "!type": "bool",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        },
+        "shading": {
+          "!type": "number",
+          "!doc": "Options are [page:Materials THREE.SmoothShading] (default), [page:Materials THREE.FlatShading], [page:Materials THREE.NoShading]."
+        },
+        "wireframe": {
+          "!type": "bool",
+          "!doc": "Whether the triangles' edges are displayed instead of surfaces. Default is *false*."
+        },
+        "wireframeLinewidth": {
+          "!type": "number",
+          "!doc": "Due to limitations in the <a href=\"https://code.google.com/p/angleproject/\" target=\"_blank\">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value."
+        },
+        "wireframeLinecap": {
+          "!type": "string",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer."
+        },
+        "wireframeLinejoin": {
+          "!type": "string",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer."
+        },
+        "vertexColors": {
+          "!type": "number",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        },
+        "skinning": {
+          "!type": "bool",
+          "!doc": "Define whether the material uses skinning. Default is *false*."
+        },
+        "morphTargets": {
+          "!type": "bool",
+          "!doc": "Define whether the material uses morphTargets. Default is *false*."
+        },
+        "morphNormals": {
+          "!type": "boolean",
+          "!doc": "Defines whether the material uses morphNormals. Set as true to pass morphNormal attributes from the [page:Geometry]\n\t\t\tto the shader. Default is *false*."
+        }
+      },
+      "!doc": "A material for shiny surfaces, evaluated per pixel.",
+      "!type": "fn(parameters: object)"
+    },
+    "PointCloudMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/PointCloudMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "color": {
+          "!type": "number",
+          "!doc": "Sets the color of the particles. Default is 0xffffff."
+        },
+        "map": {
+          "!type": "+THREE.Texture",
+          "!doc": "Sets the color of the particles using data from a texture."
+        },
+        "size": {
+          "!type": "number",
+          "!doc": "Sets the size of the particles. Default is 1.0."
+        },
+        "sizeAttenuation": {
+          "!type": "bool",
+          "!doc": "Specify whether particles' size will get smaller with the distance. Default is true."
+        },
+        "vertexColors": {
+          "!type": "bool",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        },
+        "fog": {
+          "!type": "bool",
+          "!doc": "This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer."
+        }
+      },
+      "!doc": "The default material used by [page:PointCloud particle] systems.",
+      "!type": "fn(parameters: object)"
+    },
+    "RawShaderMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/RawShaderMaterial",
+      "prototype": {
+        "!proto": "THREE.ShaderMaterial.prototype"
+      },
+      "!doc": "This class works just like [page:ShaderMaterial], except that definitions of built-in uniforms and attributes are not automatically prepended to the GLSL shader code."
+    },
+    "ShaderMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/ShaderMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "uniforms": {
+          "!type": "object",
+          "!doc": "Object specifying the uniforms to be passed to the shader code; keys are uniform names, values are definitions of the form\n\t\t<code>\n\t\t{ type: 'f', value: 1.0 }\n\t\t</code>\n\t\twhere *type* is a <a href=\"#uniform-types\">uniform type string</a>, and *value* is the value of the uniform. Names must match the name of the uniform, as defined in the GLSL code. Note that uniforms are refreshed on every frame, so updating the value of the uniform will immediately update the value available to the GLSL code."
+        },
+        "attributes": {
+          "!type": "object",
+          "!doc": "<p>\n\t\tObject specifying the custom attributes to be passed to the shader code; keys are attribute names, values are definitions of the form\n\t\t<code>\n\t\t{ type: 'f', value: [1.0, 0.5, 2.0, ...] }\n\t\t</code>\n\t\twhere *type* is an <a href=\"#attribute-types\">attribute type string</a>, and *value* is an array containing an attribute value for each vertex in the geometry (or *undefined* if using [page:BufferGeometry]). Names must match the name of the attribute, as defined in the GLSL code.\n\t\t</p>\n\t\t<p>\n\t\tNote that attribute buffers are <emph>not</emph> refreshed automatically when their values change; if using [page:Geometry], set <code>needsUpdate = true</code> on the attribute definition. If using [page:BufferGeometry], set <code>needsUpdate = true</code> on the [page:BufferAttribute].\n\t\t</p>"
+        },
+        "defines": {
+          "!type": "object",
+          "!doc": "Defines custom constants using *#define* directives within the GLSL code for both the vertex shader and the fragment shader; each key/value pair yields another directive:\n\t\t<code>\n\t\tdefines: {\n\t\t\tFOO: 15,\n\t\t\tBAR: true\n\t\t}\n\t\t</code>\n\t\tyields the lines\n\t\t<code>\n\t\t#define FOO 15\n\t\t#define BAR true\n\t\t</code>\n\t\tin the GLSL code."
+        },
+        "vertexShader": {
+          "!type": "string",
+          "!doc": "Vertex shader GLSL code.  This is the actual code for the shader. In the example above, the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed as a string directly or loaded via AJAX instead."
+        },
+        "fragmentShader": {
+          "!type": "string",
+          "!doc": "Fragment shader GLSL code.  This is the actual code for the shader. In the example above, the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed as a string directly or loaded via AJAX instead."
+        },
+        "shading": {
+          "!type": "number",
+          "!doc": "Define shading type, which determines whether normals are smoothed between vertices; possible values are [page:Materials THREE.SmoothShading] or [page:Materials THREE.FlatShading]. Default is THREE.SmoothShading."
+        },
+        "linewidth": {
+          "!type": "number",
+          "!doc": "Due to limitations in the <a href=\"https://code.google.com/p/angleproject/\" target=\"_blank\">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value."
+        },
+        "wireframe": {
+          "!type": "bool",
+          "!doc": "Render geometry as wireframe (using GL_LINES instead of GL_TRIANGLES). Default is false (i.e. render as flat polygons)."
+        },
+        "wireframeLinewidth": {
+          "!type": "number",
+          "!doc": "Due to limitations in the <a href=\"https://code.google.com/p/angleproject/\" target=\"_blank\">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value."
+        },
+        "fog": {
+          "!type": "bool",
+          "!doc": "Define whether the material color is affected by global fog settings; true to pass fog uniforms to the shader. Default is false."
+        },
+        "lights": {
+          "!type": "bool",
+          "!doc": "Defines whether this material uses lighting; true to pass uniform data related to lighting to this shader"
+        },
+        "vertexColors": {
+          "!type": "number",
+          "!doc": "Define how the vertices are colored, by defining how the *colors* attribute gets populated. Possible values are [page:Materials THREE.NoColors], [page:Materials THREE.FaceColors] and [page:Materials THREE.VertexColors]. Default is THREE.NoColors."
+        },
+        "skinning": {
+          "!type": "bool",
+          "!doc": "Define whether the material uses skinning; true to pass skinning attributes to the shader. Default is false."
+        },
+        "morphTargets": {
+          "!type": "bool",
+          "!doc": "Defines whether the material uses morphTargets; true morphTarget attributes to this shader"
+        },
+        "morphNormals": {
+          "!type": "boolean",
+          "!doc": "Defines whether the material uses morphNormals. Set as true to pass morphNormal attributes from the [page:Geometry]\n\t\t\tto the shader. Default is *false*."
+        },
+        "program": {
+          "!type": "+THREE.WebGLProgram",
+          "!doc": "The compiled shader program associated with this material, generated by [page:WebGLRenderer]. You should not need to access this property."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.ShaderMaterial",
+          "!doc": "Generates a shallow copy of this material. Note that the vertexShader and fragmentShader are copied <emph>by reference</emph>, as are the definitions of the *attributes*; this means that clones of the material will share the same compiled [page:WebGLProgram]. However, the *uniforms* are copied <emph>by value</emph>, which allows you to have different sets of uniforms for different copies of the material."
+        }
+      },
+      "!doc": "Material rendered with custom shaders. A shader is a small program written in [link:https://www.opengl.org/documentation/glsl/ GLSL] to run on the GPU. You may want to use a custom shader if you need to:\n\t\t<ul>\n\t\t\t<li>implement an effect not included with any of the built-in [page:Material materials]</li>\n\t\t\t<li>combine many objects into a single [page:Geometry] or [page:BufferGeometry] in order to improve performance</li>\n\t\t\t<li>associate custom data with individual vertices (\"custom attributes\")</li>\n\t\t</ul>\n\t\tNote that a ShaderMaterial will only be rendered properly by [page:WebGLRenderer], since the GLSL code in the vertexShader and fragmentShader properties must be compiled and run on the GPU using WebGL.",
+      "!type": "fn(parameters: object)"
+    },
+    "SpriteCanvasMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/SpriteCanvasMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "color": {
+          "!type": "+THREE.Color",
+          "!doc": "The color of the sprite. The material will set up the color for the context before calling the material's program."
+        },
+        "program": {
+          "!type": "fn(context: CanvasRenderingContext2D, color: +THREE.Color)",
+          "!doc": "Define a program that will use the context to draw the sprite."
+        }
+      },
+      "!doc": "Create a material that can draw custom sprites using a 2d canvas.",
+      "!type": "fn(parameters: object)"
+    },
+    "SpriteMaterial": {
+      "!url": "http://threejs.org/docs/#Reference/materials/SpriteMaterial",
+      "prototype": {
+        "!proto": "THREE.Material.prototype",
+        "color": {
+          "!type": "+THREE.Color",
+          "!doc": "The texture is multiplied by this color. The default is 0xffffff"
+        },
+        "map": {
+          "!type": "+THREE.Texture",
+          "!doc": "The texture map. Default is null."
+        },
+        "rotation": {
+          "!type": "Radians",
+          "!doc": "The rotation of the sprite in radians. Default is 0."
+        },
+        "fog": {
+          "!type": "boolean",
+          "!doc": "Whether or not this material affected by the scene's fog. Default is false"
+        }
+      },
+      "!doc": "A material for a [page:Sprite].",
+      "!type": "fn(parameters: object)"
+    },
+    "Box2": {
+      "!url": "http://threejs.org/docs/#Reference/math/Box2",
+      "prototype": {
+        "min": {
+          "!type": "+THREE.Vector2",
+          "!doc": "Lower (x, y) boundary of this box."
+        },
+        "max": {
+          "!type": "+THREE.Vector2",
+          "!doc": "Upper (x, y) boundary of this box."
+        },
+        "set": {
+          "!type": "fn(min: +THREE.Vector2, max: +THREE.Vector2) -> +THREE.Box2",
+          "!doc": "Sets the lower and upper (x, y) boundaries of this box."
+        },
+        "expandByPoint": {
+          "!type": "fn(point: +THREE.Vector2) -> +THREE.Box2",
+          "!doc": "Expands the boundaries of this box to include *point*."
+        },
+        "clampPoint": {
+          "!type": "fn(point: +THREE.Vector2, optionalTarget: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "Clamps *point* within the bounds of this box."
+        },
+        "isIntersectionBox": {
+          "!type": "fn(box: +THREE.Box2) -> bool",
+          "!doc": "Determines whether or not this box intersects *box*."
+        },
+        "setFromPoints": {
+          "!type": "fn(points: []) -> +THREE.Box2",
+          "!doc": "Sets the upper and lower bounds of this box to include all of the points in *points*."
+        },
+        "size": {
+          "!type": "fn(optionalTarget: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "Returns the width and height of this box."
+        },
+        "union": {
+          "!type": "fn(box: +THREE.Box2) -> +THREE.Box2",
+          "!doc": "Unions this box with *box* setting the upper bound of this box to the greater of the \n\t\ttwo boxes' upper bounds and the lower bound of this box to the lesser of the two boxes'\n\t\tlower bounds."
+        },
+        "getParameter": {
+          "!type": "fn(point: +THREE.Vector2, optionalTarget: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "Returns a point as a proportion of this box's width and height."
+        },
+        "expandByScalar": {
+          "!type": "fn(scalar: float) -> +THREE.Box2",
+          "!doc": "Expands each dimension of the box by *scalar*. If negative, the dimensions of the box <br>\n\t\twill be contracted."
+        },
+        "intersect": {
+          "!type": "fn(box: +THREE.Box2) -> +THREE.Box2",
+          "!doc": "Returns the intersection of this and *box*, setting the upper bound of this box to the lesser <br>\n\t\tof the two boxes' upper bounds and the lower bound of this box to the greater of the two boxes' <br>\n\t\tlower bounds."
+        },
+        "containsBox": {
+          "!type": "fn(box: +THREE.Box2) -> bool",
+          "!doc": "Returns true if this box includes the entirety of *box*. If this and *box* overlap exactly,<br>\n\t\tthis function also returns true."
+        },
+        "translate": {
+          "!type": "fn(offset: +THREE.Vector2) -> +THREE.Box2",
+          "!doc": "Adds *offset* to both the upper and lower bounds of this box, effectively moving this box <br>\n\t\t*offset* units in 2D space."
+        },
+        "empty": {
+          "!type": "fn() -> bool",
+          "!doc": "Returns true if this box includes zero points within its bounds.<br>\n\t\tNote that a box with equal lower and upper bounds still includes one point, the\n\t\tone both bounds share."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Box2",
+          "!doc": "Returns a copy of this box."
+        },
+        "equals": {
+          "!type": "fn(box: +THREE.Box2) -> bool",
+          "!doc": "Returns true if this box and *box* share the same lower and upper bounds."
+        },
+        "expandByVector": {
+          "!type": "fn(vector: +THREE.Vector2) -> +THREE.Box2",
+          "!doc": "Expands this box equilaterally by *vector*. The width of this box will be\n\t\texpanded by the x component of *vector* in both directions. The height of \n\t\tthis box will be expanded by the y component of *vector* in both directions."
+        },
+        "copy": {
+          "!type": "fn(box: +THREE.Box2) -> +THREE.Box2",
+          "!doc": "Copies the values of *box* to this box."
+        },
+        "makeEmpty": {
+          "!type": "fn() -> +THREE.Box2",
+          "!doc": "Makes this box empty."
+        },
+        "center": {
+          "!type": "fn(optionalTarget: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "Returns the center point of this box."
+        },
+        "distanceToPoint": {
+          "!type": "fn(point: +THREE.Vector2) -> number",
+          "!doc": "Returns the distance from any edge of this box to the specified point. <br>\n\t\tIf the point lies inside of this box, the distance will be 0."
+        },
+        "containsPoint": {
+          "!type": "fn(point: +THREE.Vector2) -> bool",
+          "!doc": "Returns true if the specified point lies within the boundaries of this box."
+        },
+        "setFromCenterAndSize": {
+          "!type": "fn(center: +THREE.Vector2, size: +THREE.Vector2) -> +THREE.Box2",
+          "!doc": "Centers this box on *center* and sets this box's width and height to the values specified\n\t\tin *size*."
+        }
+      },
+      "!doc": "Represents a boundary box in 2D space.",
+      "!type": "fn(min: +THREE.Vector2, max: +THREE.Vector2)"
+    },
+    "Box3": {
+      "!url": "http://threejs.org/docs/#Reference/math/Box3",
+      "prototype": {
+        "min": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Lower (x, y, z) boundary of this box."
+        },
+        "max": {
+          "!type": "+THREE.Vector3",
+          "!doc": "Upper (x, y, z) boundary of this box."
+        },
+        "set": {
+          "!type": "fn(min: +THREE.Vector3, max: +THREE.Vector3) -> +THREE.Box3",
+          "!doc": "Sets the lower and upper (x, y, z) boundaries of this box."
+        },
+        "applyMatrix4": {
+          "!type": "fn(matrix: +THREE.Matrix4) -> +THREE.Box3",
+          "!doc": "Transforms this Box3 with the supplied matrix."
+        },
+        "clampPoint": {
+          "!type": "fn(point: +THREE.Vector3, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Clamps *point* within the bounds of this box."
+        },
+        "isIntersectionBox": {
+          "!type": "fn(box: +THREE.Box3) -> bool",
+          "!doc": "Determines whether or not this box intersects *box*."
+        },
+        "setFromPoints": {
+          "!type": "fn(points: []) -> +THREE.Box3",
+          "!doc": "Sets the upper and lower bounds of this box to include all of the points in *points*."
+        },
+        "setFromObject": {
+          "!type": "fn(object: +THREE.Object3D) -> +THREE.Box3",
+          "!doc": "Computes the world-axis-aligned bounding box of an object (including its children),\n\t\taccounting for both the object's, and childrens', world transforms"
+        },
+        "size": {
+          "!type": "fn(optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Returns the width, height, and depth of this box."
+        },
+        "union": {
+          "!type": "fn(box: +THREE.Box3) -> +THREE.Box3",
+          "!doc": "Unions this box with *box* setting the upper bound of this box to the greater of the \n\t\ttwo boxes' upper bounds and the lower bound of this box to the lesser of the two boxes'\n\t\tlower bounds."
+        },
+        "getParameter": {
+          "!type": "fn(point: +THREE.Vector3, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Returns point as a proportion of this box's width and height."
+        },
+        "intersect": {
+          "!type": "fn(box: +THREE.Box3) -> +THREE.Box3",
+          "!doc": "Returns the intersection of this and *box*, setting the upper bound of this box to the lesser <br>\n\t\tof the two boxes' upper bounds and the lower bound of this box to the greater of the two boxes' <br>\n\t\tlower bounds."
+        },
+        "containsBox": {
+          "!type": "fn(box: +THREE.Box3) -> bool",
+          "!doc": "Returns true if this box includes the entirety of *box*. If this and *box* overlap exactly,<br>\n\t\tthis function also returns true."
+        },
+        "containsPoint": {
+          "!type": "fn(point: +THREE.Vector3) -> bool",
+          "!doc": "Returns true if the specified point lies within the boundaries of this box."
+        },
+        "translate": {
+          "!type": "fn(offset: +THREE.Vector3) -> +THREE.Box3",
+          "!doc": "Adds *offset* to both the upper and lower bounds of this box, effectively moving this box <br>\n\t\t*offset* units in 3D space."
+        },
+        "empty": {
+          "!type": "fn() -> bool",
+          "!doc": "Returns true if this box includes zero points within its bounds.<br>\n\t\tNote that a box with equal lower and upper bounds still includes one point, the\n\t\tone both bounds share."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Box3",
+          "!doc": "Returns a copy of this box."
+        },
+        "equals": {
+          "!type": "fn(box: +THREE.Box3) -> bool",
+          "!doc": "Returns true if this box and *box* share the same lower and upper bounds."
+        },
+        "expandByPoint": {
+          "!type": "fn(point: +THREE.Vector3) -> +THREE.Box3",
+          "!doc": "Expands the boundaries of this box to include *point*."
+        },
+        "expandByScalar": {
+          "!type": "fn(scalar: float) -> +THREE.Box3",
+          "!doc": "Expands each dimension of the box by *scalar*. If negative, the dimensions of the box <br>\n\t\twill be contracted."
+        },
+        "expandByVector": {
+          "!type": "fn(vector: +THREE.Vector3) -> +THREE.Box3",
+          "!doc": "Expands this box equilaterally by *vector*. The width of this box will be\n\t\texpanded by the x component of *vector* in both directions. The height of \n\t\tthis box will be expanded by the y component of *vector* in both directions.\n\t\tThe depth of this box will be expanded by the z component of *vector* in\n\t\tboth directions."
+        },
+        "copy": {
+          "!type": "fn(box: +THREE.Box3) -> +THREE.Box3",
+          "!doc": "Copies the values of *box* to this box."
+        },
+        "makeEmpty": {
+          "!type": "fn() -> +THREE.Box3",
+          "!doc": "Makes this box empty."
+        },
+        "center": {
+          "!type": "fn(optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Returns the center point of this box."
+        },
+        "getBoundingSphere": {
+          "!type": "fn(optionalTarget: +THREE.Sphere) -> +THREE.Sphere",
+          "!doc": "Gets a sphere that bounds the box."
+        },
+        "distanceToPoint": {
+          "!type": "fn(point: +THREE.Vector3) -> number",
+          "!doc": "Returns the distance from any edge of this box to the specified point. <br>\n\t\tIf the point lies inside of this box, the distance will be 0."
+        },
+        "setFromCenterAndSize": {
+          "!type": "fn(center: +THREE.Vector3, size: +THREE.Vector3) -> +THREE.Box3",
+          "!doc": "Centers this box on *center* and sets this box's width and height to the values specified\n\t\tin *size*."
+        }
+      },
+      "!doc": "Represents a boundary box in 3d space.",
+      "!type": "fn(min: +THREE.Vector3, max: +THREE.Vector3)"
+    },
+    "Color": {
+      "!url": "http://threejs.org/docs/#Reference/math/Color",
+      "prototype": {
+        "r": {
+          "!type": "number",
+          "!doc": "Red channel value between 0 and 1. Default is 1."
+        },
+        "g": {
+          "!type": "number",
+          "!doc": "Green channel value between 0 and 1. Default is 1."
+        },
+        "b": {
+          "!type": "number",
+          "!doc": "Blue channel value between 0 and 1. Default is 1."
+        },
+        "copy": {
+          "!type": "fn(color: +THREE.Color) -> +THREE.Color",
+          "!doc": "Copies given color."
+        },
+        "copyGammaToLinear": {
+          "!type": "fn(color: +THREE.Color) -> +THREE.Color",
+          "!doc": "Copies given color making conversion from gamma to linear space."
+        },
+        "copyLinearToGamma": {
+          "!type": "fn(color: +THREE.Color) -> +THREE.Color",
+          "!doc": "Copies given color making conversion from linear to gamma space."
+        },
+        "convertGammaToLinear": {
+          "!type": "fn() -> +THREE.Color",
+          "!doc": "Converts this color from gamma to linear space."
+        },
+        "convertLinearToGamma": {
+          "!type": "fn() -> +THREE.Color",
+          "!doc": "Converts this color from linear to gamma space."
+        },
+        "setRGB": {
+          "!type": "fn(r: number, g: number, b: number) -> +THREE.Color",
+          "!doc": "Sets this color from RGB values."
+        },
+        "getHex": {
+          "!type": "fn() -> number",
+          "!doc": "Returns the hexadecimal value of this color."
+        },
+        "getHexString": {
+          "!type": "fn() -> string",
+          "!doc": "Returns the string formated hexadecimal value of this color."
+        },
+        "setHex": {
+          "!type": "fn(hex: number) -> +THREE.Color",
+          "!doc": "Sets this color from a hexadecimal value."
+        },
+        "setStyle": {
+          "!type": "fn(style: string) -> +THREE.Color",
+          "!doc": "Sets this color\tfrom a CSS-style string."
+        },
+        "getStyle": {
+          "!type": "fn() -> string",
+          "!doc": "Returns the value of this color as a CSS-style string. Example: rgb(255,0,0)"
+        },
+        "setHSL": {
+          "!type": "fn(h: number, s: number, l: number) -> +THREE.Color",
+          "!doc": "Sets color from hsl"
+        },
+        "offsetHSL": {
+          "!type": "fn(h: number, s: number, l: number) -> +THREE.Color",
+          "!doc": "Adds given h, s, and l to this color's existing h, s, and l values."
+        },
+        "add": {
+          "!type": "fn(color: +THREE.Color) -> +THREE.Color",
+          "!doc": "Adds rgb values of given color to rgb values of this color"
+        },
+        "addColors": {
+          "!type": "fn(color1: +THREE.Color, color2: +THREE.Color) -> +THREE.Color",
+          "!doc": "Sets this color to the sum of color1 and color2"
+        },
+        "addScalar": {
+          "!type": "fn(s: number) -> +THREE.Color",
+          "!doc": "Adds s to the rgb values of this color"
+        },
+        "multiply": {
+          "!type": "fn(color: +THREE.Color) -> +THREE.Color",
+          "!doc": "Multiplies this color's rgb values by given color's rgb values"
+        },
+        "multiplyScalar": {
+          "!type": "fn(s: number) -> +THREE.Color",
+          "!doc": "Multiplies this color's rgb values by s"
+        },
+        "lerp": {
+          "!type": "fn(color: +THREE.Color, alpha) -> +THREE.Color",
+          "!doc": "Linear interpolation of this colors rgb values and the rgb values of the first argument. The alpha argument can be thought of as the percent between the two colors, where 0 is this color and 1 is the first argument."
+        },
+        "toArray": {
+          "!type": "fn(array: []) -> []",
+          "!doc": "Returns an array [r,g,b]"
+        },
+        "equals": {
+          "!type": "fn(c: +THREE.Color) -> +THREE.Color",
+          "!doc": "Compares this color and c and returns true if they are the same, false otherwise."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Color",
+          "!doc": "Clones this color."
+        },
+        "set": {
+          "!type": "fn(value) -> +THREE.Color",
+          "!doc": "Delegates to .copy, .setStyle, or .setHex depending on input type."
+        }
+      },
+      "!doc": "Represents a color.",
+      "!type": "fn(value)"
+    },
+    "Euler": {
+      "!url": "http://threejs.org/docs/#Reference/math/Euler",
+      "prototype": {
+        "x": "number",
+        "y": "number",
+        "z": "number",
+        "order": "string",
+        "set": {
+          "!type": "fn(x: number, y: number, z: number, order: string) -> +THREE.Euler",
+          "!doc": "Sets the angles of this euler transform."
+        },
+        "copy": {
+          "!type": "fn(euler: +THREE.Euler) -> +THREE.Euler",
+          "!doc": "Copies value of *euler* to this euler."
+        },
+        "setFromRotationMatrix": {
+          "!type": "fn(m: +THREE.Matrix4, order: string) -> +THREE.Euler",
+          "!doc": "Sets the angles of this euler transform from a pure rotation matrix based on the orientation specified by order."
+        },
+        "setFromQuaternion": {
+          "!type": "fn(q: +THREE.Quaternion, order: string) -> +THREE.Euler",
+          "!doc": "Sets the angles of this euler transform from a normalized quaternion based on the orientation specified by order."
+        },
+        "reorder": {
+          "!type": "fn(newOrder: string) -> +THREE.Euler",
+          "!doc": "Resets the euler angle with a new order by creating a quaternion from this euler angle and then setting this euler angle with the quaternion and the new order. <br>\n\t\tWARNING: this discards revolution information."
+        },
+        "setFromVector3": {
+          "!type": "fn(vector: +THREE.Vector3, order: string) -> +THREE.Euler",
+          "!doc": "Optionally Vector3 to the XYZ parameters of Euler, and order to the Euler's order property."
+        },
+        "toVector3": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "Returns the Euler's XYZ properties as a Vector3."
+        },
+        "fromArray": {
+          "!type": "fn(array: []) -> +THREE.Euler",
+          "!doc": "Assigns this euler's x angle to array[0]. <br>\n\t\tAssigns this euler's y angle to array[1]. <br>\n\t\tAssigns this euler's z angle to array[2]. <br>\n\t\tOptionally assigns this euler's order to array[3]."
+        },
+        "toArray": {
+          "!type": "fn(array: []) -> []",
+          "!doc": "Returns an array [x, y, z, order]"
+        },
+        "equals": {
+          "!type": "fn(euler: +THREE.Euler) -> bool",
+          "!doc": "Checks for strict equality of this euler and *euler*."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Euler",
+          "!doc": "Returns a new euler created from this euler."
+        }
+      },
+      "!doc": "Euler Angles. <br><br>\n\n\t\tEuler angles describe a rotation transformation by rotating an object on its various axes in specified amounts per axis, and a specified axis order.\n\t\t(More information on <a href=\"http://en.wikipedia.org/wiki/Euler_angles\" target=\"blank\">Wikipedia</a>)",
+      "!type": "fn(x: number, y: number, z: number, order: string)"
+    },
+    "Frustum": {
+      "!url": "http://threejs.org/docs/#Reference/math/Frustum",
+      "prototype": {
+        "planes": {
+          "!type": "[]",
+          "!doc": "Array of 6 [page:Plane planes]."
+        },
+        "setFromMatrix": {
+          "!type": "fn(matrix: +THREE.Matrix4) -> +THREE.Frustum",
+          "!doc": "Array of 6 [page:Plane planes]."
+        },
+        "intersectsObject": {
+          "!type": "fn(object: +THREE.Object3D) -> bool",
+          "!doc": "Checks whether the object's bounding sphere is intersecting the Frustum."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Frustum",
+          "!doc": "Return a copy of this Frustum"
+        },
+        "set": {
+          "!type": "fn(p0: +THREE.Plane, p1: +THREE.Plane, p2: +THREE.Plane, p3: +THREE.Plane, p4: +THREE.Plane, p5: +THREE.Plane) -> bool",
+          "!doc": "Sets the current frustum from the passed planes. No plane order is implicitely implied."
+        },
+        "copy": {
+          "!type": "fn(frustum: +THREE.Frustum) -> +THREE.Frustum",
+          "!doc": "Copies the values of the passed frustum."
+        },
+        "containsPoint": {
+          "!type": "fn(point: +THREE.Vector3) -> bool",
+          "!doc": "Checks to see if the frustum contains the point."
+        },
+        "intersectsSphere": {
+          "!type": "fn(sphere: +THREE.Sphere) -> bool",
+          "!doc": "Check to see if the sphere intersects with the frustum."
+        }
+      },
+      "!doc": "<a href=\"http://en.wikipedia.org/wiki/Frustum\">Frustums</a> are used to determine what is inside the camera's field of view. They help speed up the rendering process.",
+      "!type": "fn(p0: +THREE.Plane, p1: +THREE.Plane, p2: +THREE.Plane, p3: +THREE.Plane, p4: +THREE.Plane, p5: +THREE.Plane)"
+    },
+    "Line3": {
+      "!url": "http://threejs.org/docs/#Reference/math/Line3",
+      "prototype": {
+        "start": "+THREE.Vector3",
+        "end": "+THREE.Vector3",
+        "set": {
+          "!type": "fn(start: +THREE.Vector3, end: +THREE.Vector3) -> +THREE.Line3",
+          "!doc": "Sets the start and end values by copying the provided vectors."
+        },
+        "copy": {
+          "!type": "fn(line: +THREE.Line3) -> +THREE.Line3",
+          "!doc": "Copies the passed line's start and end vectors to this line."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Line3",
+          "!doc": "Return a new copy of this [page:Line3]."
+        },
+        "equals": {
+          "!type": "fn(line: +THREE.Line3) -> bool",
+          "!doc": "<h3>[method:Float distance]()</h3>\n\t\t<div>\n\t\tReturns the length of the line segment.\n\t\t</div>\n\t\tReturns true if both line's start and end points are equal."
+        },
+        "distance": {
+          "!type": "fn() -> number",
+          "!doc": "Returns the length of the line segment."
+        },
+        "distanceSq": {
+          "!type": "fn() -> number",
+          "!doc": "Returns the line segment's length squared."
+        },
+        "applyMatrix4": {
+          "!type": "fn(matrix: +THREE.Matrix4) -> +THREE.Line3",
+          "!doc": "Apply a matrix transform to the line segment."
+        },
+        "at": {
+          "!type": "fn(t: number, optionalTarget: +THREE.Vector3) -> Vector",
+          "!doc": "Return a vector at a certain position along the line. When t = 0, it returns the start vector, and when t=1 it returns the end vector."
+        },
+        "center": {
+          "!type": "fn(optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Return the center of the line segment."
+        },
+        "delta": {
+          "!type": "fn(optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Returns the delta vector of the line segment, or the end vector minus the start vector."
+        },
+        "closestPointToPoint": {
+          "!type": "fn(point: +THREE.Vector3, clampToLine: bool, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Returns the closets point on the line. If clamp to line is true, then the returned value will be clamped to the line segment."
+        },
+        "closestPointToPointParameter": {
+          "!type": "fn(point: +THREE.Vector3, clampToLine: bool) -> number",
+          "!doc": "Returns a point parameter based on the closest point as projected on the line segement. If clamp to line is true, then the returned value will be between 0 and 1."
+        }
+      },
+      "!doc": "A geometric line segment represented by a start and end point.",
+      "!type": "fn(start: +THREE.Vector3, end: +THREE.Vector3)"
+    },
+    "Math": {
+      "!url": "http://threejs.org/docs/#Reference/math/Math",
+      "prototype": {
+        "clamp": {
+          "!type": "fn(x: number, a: number, b: number) -> number",
+          "!doc": "Clamps the *x* to be between *a* and *b*."
+        },
+        "clampBottom": {
+          "!type": "fn(x: number, a: number) -> number",
+          "!doc": "Clamps the *x* to be larger than *a*."
+        },
+        "mapLinear": {
+          "!type": "fn(x: number, a1: number, a2: number, b1: number, b2: number) -> number",
+          "!doc": "Linear mapping of *x* from range [*a1*, *a2*] to range [*b1*, *b2*]."
+        },
+        "random16": {
+          "!type": "fn() -> number",
+          "!doc": "Random float from 0 to 1 with 16 bits of randomness.<br>\n\t\tStandard Math.random() creates repetitive patterns when applied over larger space."
+        },
+        "randInt": {
+          "!type": "fn(low: number, high: number) -> number",
+          "!doc": "Random integer from *low* to *high* interval."
+        },
+        "randFloat": {
+          "!type": "fn(low: number, high: number) -> number",
+          "!doc": "Random float from *low* to *high* interval."
+        },
+        "randFloatSpread": {
+          "!type": "fn(range: number) -> number",
+          "!doc": "Random float from *- range / 2* to *range / 2* interval."
+        },
+        "sign": {
+          "!type": "fn(x: number) -> number",
+          "!doc": "Returns -1 if *x* is less than 0, 1 if *x* is greater than 0, and 0 if *x* is zero."
+        },
+        "degToRad": {
+          "!type": "fn(degrees: number) -> number",
+          "!doc": "Converts degrees to radians."
+        },
+        "radToDeg": {
+          "!type": "fn(radians: number) -> number",
+          "!doc": "Converts radians to degrees"
+        },
+        "smoothstep": {
+          "!type": "fn(x: number, min: number, max: number) -> number",
+          "!doc": "Returns a value between 0-1 that represents the percentage that x has moved between min and max, but smoothed or slowed down the closer X is to the min and max.<br><br>\n\t\t\n\t\t[link:http://en.wikipedia.org/wiki/Smoothstep Wikipedia]"
+        },
+        "smootherstep": {
+          "!type": "fn(x: number, min: number, max: number) -> number",
+          "!doc": "Returns a value between 0-1. It works the same as smoothstep, but more smooth."
+        }
+      },
+      "!doc": "Math utility functions"
+    },
+    "Matrix3": {
+      "!url": "http://threejs.org/docs/#Reference/math/Matrix3",
+      "prototype": {
+        "elements": {
+          "!type": "Float32Array",
+          "!doc": "Float32Array with column-major matrix values."
+        },
+        "transpose": {
+          "!type": "fn() -> +THREE.Matrix3",
+          "!doc": "Transposes this matrix in place."
+        },
+        "transposeIntoArray": {
+          "!type": "fn(array: []) -> +THREE.Matrix3",
+          "!doc": "Transposes this matrix into the supplied array, and returns itself."
+        },
+        "determinant": {
+          "!type": "fn() -> number",
+          "!doc": "Returns the matrix's determinant."
+        },
+        "set": {
+          "!type": "fn(n11: number, n12: number, n13: number, n21: number, n22: number, n23: number, n31: number, n32: number, n33: number) -> +THREE.Matrix3",
+          "!doc": "Set the 3x3 matrix values to the given row-major sequence of values."
+        },
+        "multiplyScalar": {
+          "!type": "fn(scalar: number) -> +THREE.Matrix3",
+          "!doc": "Multiply every component of the matrix by a scalar value."
+        },
+        "applyToVector3Array": {
+          "!type": "fn(array: []) -> []",
+          "!doc": "Multiply (apply) this matrix to every vector3 in the array."
+        },
+        "getNormalMatrix": {
+          "!type": "fn(matrix4: +THREE.Matrix4) -> +THREE.Matrix3",
+          "!doc": "Set this matrix as the normal matrix of the passed [page:Matrix4 matrix4]. The normal matrix is the inverse transpose of the matrix."
+        },
+        "getInverse": {
+          "!type": "fn(matrix4: +THREE.Matrix4, throwOnInvertible: bool) -> +THREE.Matrix3",
+          "!doc": "Set this matrix to the inverse of the passed matrix."
+        },
+        "copy": {
+          "!type": "fn(matrix: +THREE.Matrix3) -> +THREE.Matrix3",
+          "!doc": "Copy the values of the passed matrix."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Matrix3",
+          "!doc": "Create a copy of the matrix."
+        },
+        "identity": {
+          "!type": "fn() -> +THREE.Matrix3",
+          "!doc": "Set as an identity matrix.<br><br>\n\t\t\n\t\t1, 0, 0<br>\n\t\t0, 1, 0<br>\n\t\t0, 0, 1<br>"
+        }
+      },
+      "!doc": "A 3x3 matrix.",
+      "!type": "fn(n11: number, n12: number, n13: number, n21: number, n22: number, n23: number, n31: number, n32: number, n33: number)"
+    },
+    "Matrix4": {
+      "!url": "http://threejs.org/docs/#Reference/math/Matrix4",
+      "prototype": {
+        "elements": {
+          "!type": "Float32Array",
+          "!doc": "A column-major list of matrix values."
+        },
+        "set": {
+          "!type": "fn(n11: number, n12: number, n13: number, n14: number, n21: number, n22: number, n23: number, n24: number, n31: number, n32: number, n33: number, n34: number, n41: number, n42: number, n43: number, n44: number) -> +THREE.Matrix4",
+          "!doc": "Sets all fields of this matrix to the supplied row-major values n11..n44."
+        },
+        "identity": {
+          "!type": "fn() -> +THREE.Matrix4",
+          "!doc": "Resets this matrix to identity."
+        },
+        "copy": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Matrix4",
+          "!doc": "Copies a matrix *m* into this matrix."
+        },
+        "copyPosition": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Matrix4",
+          "!doc": "Copies the translation component of the supplied matrix *m* into this matrix translation component."
+        },
+        "makeBasis": {
+          "!type": "fn(xAxis: +THREE.Vector3, zAxis: +THREE.Vector3, zAxis: +THREE.Vector3) -> +THREE.Matrix4",
+          "!doc": "Creates the basis matrix consisting of the three provided axis vectors.  Returns the current matrix."
+        },
+        "extractBasis": {
+          "!type": "fn(xAxis: +THREE.Vector3, zAxis: +THREE.Vector3, zAxis: +THREE.Vector3) -> +THREE.Matrix4",
+          "!doc": "Extracts basis of into the three axis vectors provided.  Returns the current matrix."
+        },
+        "extractRotation": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Matrix4",
+          "!doc": "Extracts the rotation of the supplied matrix *m* into this matrix rotation component."
+        },
+        "lookAt": {
+          "!type": "fn(eye: +THREE.Vector3, center: +THREE.Vector3, up: +THREE.Vector3) -> +THREE.Matrix4",
+          "!doc": "Constructs a rotation matrix, looking from *eye* towards *center* with defined *up* vector."
+        },
+        "multiply": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Matrix4",
+          "!doc": "Multiplies this matrix by *m*."
+        },
+        "multiplyMatrices": {
+          "!type": "fn(a: +THREE.Matrix4, b: +THREE.Matrix4) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix to *a x b*."
+        },
+        "multiplyToArray": {
+          "!type": "fn(a: +THREE.Matrix4, b: +THREE.Matrix4, r: []) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix to *a x b* and stores the result into the flat array *r*.<br>\n\t\t*r* can be either a regular Array or a TypedArray."
+        },
+        "multiplyScalar": {
+          "!type": "fn(s: number) -> +THREE.Matrix4",
+          "!doc": "Multiplies this matrix by *s*."
+        },
+        "determinant": {
+          "!type": "fn() -> number",
+          "!doc": "Computes determinant of this matrix.<br>\n\t\tBased on [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm]"
+        },
+        "transpose": {
+          "!type": "fn() -> +THREE.Matrix4",
+          "!doc": "Transposes this matrix."
+        },
+        "flattenToArrayOffset": {
+          "!type": "fn(flat: [], offset: number) -> []",
+          "!doc": "Flattens this matrix into supplied *flat* array starting from *offset* position in the array."
+        },
+        "setPosition": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Matrix4",
+          "!doc": "Sets the position component for this matrix from vector *v*."
+        },
+        "getInverse": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix to the inverse of matrix *m*.<br>\n\t\tBased on [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm]."
+        },
+        "makeRotationFromEuler": {
+          "!type": "fn(euler: +THREE.Euler) -> +THREE.Matrix4",
+          "!doc": "Sets the rotation submatrix of this matrix to the rotation specified by Euler angles, the rest of the matrix is identity.<br>\n\t\tDefault order is *\"XYZ\"*."
+        },
+        "makeRotationFromQuaternion": {
+          "!type": "fn(q: +THREE.Quaternion) -> +THREE.Matrix4",
+          "!doc": "Sets the rotation submatrix of this matrix to the rotation specified by *q*. The rest of the matrix is identity."
+        },
+        "scale": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Matrix4",
+          "!doc": "Multiplies the columns of this matrix by vector *v*."
+        },
+        "compose": {
+          "!type": "fn(translation: +THREE.Vector3, quaternion: +THREE.Quaternion, scale: +THREE.Vector3) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix to the transformation composed of *translation*, *quaternion* and *scale*."
+        },
+        "decompose": {
+          "!type": "fn(translation: +THREE.Vector3, quaternion: +THREE.Quaternion, scale: +THREE.Vector3) -> []",
+          "!doc": "Decomposes this matrix into the *translation*, *quaternion* and *scale* components."
+        },
+        "makeTranslation": {
+          "!type": "fn(x: number, y: number, z: number) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix as translation transform."
+        },
+        "makeRotationX": {
+          "!type": "fn(theta: number) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix as rotation transform around x axis by *theta* radians."
+        },
+        "makeRotationY": {
+          "!type": "fn(theta: number) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix as rotation transform around y axis by *theta* radians."
+        },
+        "makeRotationZ": {
+          "!type": "fn(theta: number) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix as rotation transform around z axis by *theta* radians."
+        },
+        "makeRotationAxis": {
+          "!type": "fn(axis: +THREE.Vector3, theta: number) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix as rotation transform around *axis* by *angle* radians.<br>\n\t\tBased on [link:http://www.gamedev.net/reference/articles/article1199.asp]."
+        },
+        "makeScale": {
+          "!type": "fn(x: number, y: number, z: number) -> +THREE.Matrix4",
+          "!doc": "Sets this matrix as scale transform."
+        },
+        "makeFrustum": {
+          "!type": "fn(left: number, right: number, bottom: number, top: number, near: number, far: number) -> +THREE.Matrix4",
+          "!doc": "Creates a [page:Frustum frustum] matrix."
+        },
+        "makePerspective": {
+          "!type": "fn(fov: number, aspect: number, near: number, far: number) -> +THREE.Matrix4",
+          "!doc": "Creates a perspective projection matrix."
+        },
+        "makeOrthographic": {
+          "!type": "fn(left: number, right: number, bottom: number, top: number, near: number, far: number) -> +THREE.Matrix4",
+          "!doc": "Creates an orthographic projection matrix."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Matrix4",
+          "!doc": "Clones this matrix."
+        },
+        "applyToVector3Array": {
+          "!type": "fn(a: []) -> []",
+          "!doc": "Multiply (apply) this matrix to every vector3 in the array."
+        },
+        "getMaxScaleOnAxis": {
+          "!type": "fn() -> number",
+          "!doc": "Gets the max scale value of the 3 axes."
+        }
+      },
+      "!doc": "A 4x4 Matrix.",
+      "!type": "fn(n11: number, n12: number, n13: number, n14: number, n21: number, n22: number, n23: number, n24: number, n31: number, n32: number, n33: number, n34: number, n41: number, n42: number, n43: number, n44: number)"
+    },
+    "Plane": {
+      "!url": "http://threejs.org/docs/#Reference/math/Plane",
+      "prototype": {
+        "normal": "+THREE.Vector3",
+        "constant": "number",
+        "normalize": {
+          "!type": "fn() -> +THREE.Plane",
+          "!doc": "Normalizes the normal vector, and adjusts the constant value accordingly."
+        },
+        "set": {
+          "!type": "fn(normal: +THREE.Vector3, constant: number) -> +THREE.Plane",
+          "!doc": "Sets the plane's values."
+        },
+        "copy": {
+          "!type": "fn(plane: +THREE.Plane) -> +THREE.Plane",
+          "!doc": "Copies the values of the passed plane to this plane."
+        },
+        "applyMatrix4": {
+          "!type": "fn(matrix: +THREE.Matrix4, optionalNormalMatrix: +THREE.Matrix3) -> +THREE.Plane",
+          "!doc": "Apply a Matrix4 to the plane. The second parameter is optional.\n\t\t\n\t\t<code>\n\t\tvar optionalNormalMatrix = new THREE.Matrix3().getNormalMatrix( matrix ) \n\t\t</code>"
+        },
+        "orthoPoint": {
+          "!type": "fn(point: +THREE.Vector3, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Returns a vector in the same direction as the Plane's normal, but the magnitude is passed point's original distance to the plane."
+        },
+        "isIntersectionLine": {
+          "!type": "fn(line: +THREE.Line3) -> bool",
+          "!doc": "Tests whether a line segment intersects with the plane. (Do not mistake this for a collinear check.)"
+        },
+        "intersectLine": {
+          "!type": "fn(line: +THREE.Line3, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Returns the intersection point of the passed line and the plane. Returns undefined if the line does not intersect. Returns the line's starting point if the line is coplanar with the plane."
+        },
+        "setFromNormalAndCoplanarPoint": {
+          "!type": "fn(normal: +THREE.Vector3, point: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Sets the plane's values as defined by a normal and arbitrary coplanar point."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Plane",
+          "!doc": "Returns a new copy of this plane."
+        },
+        "distanceToPoint": {
+          "!type": "fn(point: +THREE.Vector3) -> number",
+          "!doc": "Returns the smallest distance from the point to the plane."
+        },
+        "equals": {
+          "!type": "fn(plane: +THREE.Plane) -> bool",
+          "!doc": "Checks to see if two planes are equal (their normals and constants match)"
+        },
+        "setComponents": {
+          "!type": "fn(x: number, y: number, z: number, w: number) -> +THREE.Plane",
+          "!doc": "Set the individual components that make up the plane."
+        },
+        "distanceToSphere": {
+          "!type": "fn(sphere: +THREE.Sphere) -> number",
+          "!doc": "Returns the smallest distance from an edge of the sphere to the plane."
+        },
+        "setFromCoplanarPoints": {
+          "!type": "fn(a: +THREE.Vector3, b: +THREE.Vector3, c: +THREE.Vector3) -> +THREE.Plane",
+          "!doc": "Defines the plane based on the 3 provided points. The winding order is counter clockwise, and determines which direction the normal will point."
+        },
+        "projectPoint": {
+          "!type": "fn(point: +THREE.Vector3, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Projects a point onto the plane. The projected point is the closest point on the plane to the passed point, so a line drawn from the projected point and the passed point would be orthogonal to the plane."
+        },
+        "negate": {
+          "!type": "fn() -> +THREE.Plane",
+          "!doc": "Negates both the normal vector and constant, effectively mirroring the plane across the origin."
+        },
+        "translate": {
+          "!type": "fn(offset: +THREE.Vector3) -> +THREE.Plane",
+          "!doc": "Translates the plane the distance defined by the vector. Note that this only affects the constant (distance from origin) and will not affect the normal vector."
+        },
+        "coplanarPoint": {
+          "!type": "fn(optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Returns a coplanar point. (The projection of the normal vector at the origin onto the plane.)"
+        }
+      },
+      "!doc": "A two dimensional surface that extends infinitely in 3d space.",
+      "!type": "fn(normal: +THREE.Vector3, constant: number)"
+    },
+    "Quaternion": {
+      "!url": "http://threejs.org/docs/#Reference/math/Quaternion",
+      "prototype": {
+        "x": "number",
+        "y": "number",
+        "z": "number",
+        "w": "number",
+        "set": {
+          "!type": "fn(x: number, y: number, z: number, w: number) -> +THREE.Quaternion",
+          "!doc": "Sets values of this quaternion."
+        },
+        "copy": {
+          "!type": "fn(q: +THREE.Quaternion) -> +THREE.Quaternion",
+          "!doc": "Copies values of *q* to this quaternion."
+        },
+        "setFromEuler": {
+          "!type": "fn(euler: +THREE.Euler) -> +THREE.Quaternion",
+          "!doc": "Sets this quaternion from rotation specified by Euler angle."
+        },
+        "setFromAxisAngle": {
+          "!type": "fn(axis: +THREE.Vector3, angle: number) -> +THREE.Quaternion",
+          "!doc": "Sets this quaternion from rotation specified by axis and angle.<br>\n\t\tAdapted from [link:http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm].<br>\n\t\t*Axis* is asumed to be normalized, *angle* is in radians."
+        },
+        "setFromRotationMatrix": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Quaternion",
+          "!doc": "Sets this quaternion from rotation component of *m*.<br>\n\t\tAdapted from [link:http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm]."
+        },
+        "setFromUnitVectors": {
+          "!type": "fn(vFrom: +THREE.Vector3, vTo: +THREE.Vector3) -> +THREE.Quaternion",
+          "!doc": "Sets this quaternion to the rotation required to rotate direction vector *vFrom* to direction vector *vTo*.<br>\n\t\tAdapted from [link:http://lolengine.net/blog/2013/09/18/beautiful-maths-quaternion-from-vectors].<br>\n\t\t*vFrom* and *vTo* are assumed to be normalized."
+        },
+        "inverse": {
+          "!type": "fn() -> +THREE.Quaternion",
+          "!doc": "Inverts this quaternion."
+        },
+        "length": {
+          "!type": "fn() -> number",
+          "!doc": "Computes length of this quaternion."
+        },
+        "normalize": {
+          "!type": "fn() -> +THREE.Quaternion",
+          "!doc": "Normalizes this quaternion."
+        },
+        "multiply": {
+          "!type": "fn(b: +THREE.Quaternion) -> +THREE.Quaternion",
+          "!doc": "Multiplies this quaternion by *b*."
+        },
+        "multiplyQuaternions": {
+          "!type": "fn(a: +THREE.Quaternion, b: +THREE.Quaternion) -> +THREE.Quaternion",
+          "!doc": "Sets this quaternion to *a x b*<br>\n\t\tAdapted from [link:http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm]."
+        },
+        "multiplyVector3": {
+          "!type": "fn(vector: +THREE.Vector3, dest: +THREE.Vector3) -> +THREE.Quaternion",
+          "!doc": "Rotates *vector* by this quaternion into *dest*.<br>\n\t\tIf *dest* is not specified, result goes to *vec*."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Quaternion",
+          "!doc": "Clones this quaternion."
+        },
+        "slerp": {
+          "!type": "fn(qb: +THREE.Quaternion, t: float) -> +THREE.Quaternion",
+          "!doc": "Handles the spherical linear interpolation between this quaternion's configuration\n\t\tand that of *qb*. *t* represents how close to the current (0) or target (1) rotation the\n\t\tresult should be."
+        },
+        "toArray": {
+          "!type": "fn(array: []) -> []",
+          "!doc": "Returns the numerical elements of this quaternion in an array of format (x, y, z, w)."
+        },
+        "equals": {
+          "!type": "fn(v: +THREE.Quaternion) -> bool",
+          "!doc": "Compares each component of *v* to each component of this quaternion to determine if they\n\t\trepresent the same rotation."
+        },
+        "lengthSq": {
+          "!type": "fn() -> number",
+          "!doc": "Calculates the squared length of the quaternion."
+        },
+        "fromArray": {
+          "!type": "fn(array: []) -> +THREE.Quaternion",
+          "!doc": "Sets this quaternion's component values from an array."
+        },
+        "conjugate": {
+          "!type": "fn() -> +THREE.Quaternion",
+          "!doc": "Returns the rotational conjugate of this quaternion. The conjugate of a quaternion\n\t\trepresents the same rotation in the opposite direction about the rotational axis."
+        }
+      },
+      "!doc": "Implementation of a <a href=\"http://en.wikipedia.org/wiki/Quaternion\">quaternion</a>. This is used for rotating things without encountering the dreaded <a href=\"http://en.wikipedia.org/wiki/Gimbal_lock\">gimbal lock</a> issue, amongst other advantages.",
+      "!type": "fn(x: number, y: number, z: number, w: number)"
+    },
+    "Ray": {
+      "!url": "http://threejs.org/docs/#Reference/math/Ray",
+      "prototype": {
+        "origin": {
+          "!type": "+THREE.Vector3",
+          "!doc": "The origin of the [page:Ray]."
+        },
+        "direction": {
+          "!type": "+THREE.Vector3",
+          "!doc": "The direction of the [page:Ray]. This must be normalized (with [page:Vector3].normalize) for the methods to operate properly."
+        },
+        "applyMatrix4": {
+          "!type": "fn(matrix4: +THREE.Matrix4) -> +THREE.Ray",
+          "!doc": "Transform this [page:Ray] by the [page:Matrix4]."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Ray",
+          "!doc": "Create a clone of this [page:Ray]."
+        },
+        "closestPointToPoint": {
+          "!type": "fn(point: +THREE.Vector3, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Get the point along this [page:Ray] that is closest to the [page:Vector3] provided."
+        },
+        "copy": {
+          "!type": "fn(ray: +THREE.Ray) -> +THREE.Ray",
+          "!doc": "Copy the properties of the provided [page:Ray], then return this [page:Ray]."
+        },
+        "distanceToPlane": {
+          "!type": "fn(plane: +THREE.Plane) -> number",
+          "!doc": "Get the distance from the origin to the [page:Plane], or *null* if the [page:Ray] doesn't intersect the [page:Plane]."
+        },
+        "distanceToPoint": {
+          "!type": "fn(point: +THREE.Vector3) -> number",
+          "!doc": "Get the distance of the closest approach between the [page:Ray] and the [page:Vector3]."
+        },
+        "equals": {
+          "!type": "fn(ray: +THREE.Ray) -> bool",
+          "!doc": "Return whether this and the other [page:Ray] have equal offsets and directions."
+        },
+        "isIntersectionBox": {
+          "!type": "fn(box: +THREE.Box3) -> bool",
+          "!doc": "Return whether or not this [page:Ray] intersects with the [page:Box3]."
+        },
+        "isIntersectionPlane": {
+          "!type": "fn(plane: +THREE.Plane) -> bool",
+          "!doc": "Return whether or not this [page:Ray] intersects with the [page:Plane]."
+        },
+        "isIntersectionSphere": {
+          "!type": "fn(sphere: +THREE.Sphere) -> bool",
+          "!doc": "Return whether or not this [page:Ray] intersects with the [page:Sphere]."
+        },
+        "recast": {
+          "!type": "fn(t: number) -> +THREE.Ray",
+          "!doc": "Shift the origin of this [page:Ray] along its direction by the distance given."
+        },
+        "set": {
+          "!type": "fn(origin: +THREE.Vector3, direction: +THREE.Vector3) -> +THREE.Ray",
+          "!doc": "Copy the parameters to the origin and direction properties."
+        }
+      },
+      "!doc": "A ray that emits from an origin in a certain direction.",
+      "!type": "fn(origin: +THREE.Vector3, direction: +THREE.Vector3)"
+    },
+    "Sphere": {
+      "!url": "http://threejs.org/docs/#Reference/math/Sphere",
+      "prototype": {
+        "center": "+THREE.Vector3",
+        "radius": "number",
+        "applyMatrix4": {
+          "!type": "fn(matrix: +THREE.Matrix4) -> +THREE.Sphere",
+          "!doc": "Transforms this sphere with the provided [page:Matrix4]."
+        },
+        "clampPoint": {
+          "!type": "fn(point: +THREE.Vector3, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Clamps a point within the sphere. If the point is is outside the sphere, it will clamp it to the closets point on the edge of the sphere."
+        },
+        "translate": {
+          "!type": "fn(offset: +THREE.Vector3) -> +THREE.Sphere",
+          "!doc": "Translate the sphere's center by the provided offset vector."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Sphere",
+          "!doc": "Provides a new copy of the sphere."
+        },
+        "equals": {
+          "!type": "fn(sphere: +THREE.Sphere) -> bool",
+          "!doc": "Checks to see if the two spheres' centers and radii are equal."
+        },
+        "setFromPoints": {
+          "!type": "fn(points: [], optionalCenter: +THREE.Vector3) -> +THREE.Sphere",
+          "!doc": "Computes the minimum bounding sphere for *points*. If *optionalCenter* is given, it is used as the sphere's center. Otherwise, the center of the axis-aligned bounding box encompassing *points* is calculated."
+        },
+        "distanceToPoint": {
+          "!type": "fn(point: +THREE.Vector3) -> number",
+          "!doc": "Returns the closest distance from the boundary of the sphere to the point. If the sphere contains the point, the distance will be negative."
+        },
+        "getBoundingBox": {
+          "!type": "fn(optionalTarget: Box) -> Box",
+          "!doc": "Returns a bounding box for the sphere, optionally setting a provided box target."
+        },
+        "containsPoint": {
+          "!type": "fn(point: +THREE.Vector3) -> bool",
+          "!doc": "Checks to see if the sphere contains the provided point inclusive of the edge of the sphere."
+        },
+        "copy": {
+          "!type": "fn(sphere: +THREE.Sphere) -> +THREE.Sphere",
+          "!doc": "Copies the values of the passed sphere to this sphere."
+        },
+        "intersectsSphere": {
+          "!type": "fn(sphere: +THREE.Sphere) -> bool",
+          "!doc": "Checks to see if two spheres intersect."
+        },
+        "empty": {
+          "!type": "fn() -> bool",
+          "!doc": "Checks to see if the sphere is empty (the radius set to 0)."
+        }
+      },
+      "!doc": "A geometric sphere defined by a center position and radius.",
+      "!type": "fn(center: +THREE.Vector3, radius: number)"
+    },
+    "Spline": {
+      "!url": "http://threejs.org/docs/#Reference/math/Spline",
+      "prototype": {
+        "points": "[]",
+        "initFromArray": {
+          "!type": "fn(a: [])",
+          "!doc": "Initialises using the data in the array as a series of points. Each value in *a* must be another array with three values, where a[n] is v, the value for the *nth* point, and v[0], v[1] and v[2] are the x, y and z coordinates of that point n, respectively."
+        },
+        "getPoint": {
+          "!type": "fn(k: number) -> +THREE.Vector3",
+          "!doc": "Return the interpolated point at *k*."
+        },
+        "getControlPointsArray": {
+          "!type": "fn() -> []",
+          "!doc": "Returns an array with triplets of x, y, z coordinates that correspond to the current control points."
+        },
+        "getLength": {
+          "!type": "fn(nSubDivisions: number) -> object",
+          "!doc": "Returns an object with the two properties. The property .[page:Number total] contains\n\t\t\tthe length of the spline when using nSubDivisions. The property .[page:Array chunkLength]\n\t\t\tcontains an array with the total length from the beginning of the spline to the end of that chunk."
+        },
+        "reparametrizeByArcLength": {
+          "!type": "fn(samplingCoef: number)",
+          "!doc": "This is done by resampling the original spline, with the density of sampling controlled by *samplingCoef*. Here it's interesting to note that denser sampling is not necessarily better: if sampling is too high, you may get weird kinks in curvature."
+        }
+      },
+      "!doc": "Represents a spline.",
+      "!type": "fn(points: [])"
+    },
+    "Triangle": {
+      "!url": "http://threejs.org/docs/#Reference/math/Triangle",
+      "prototype": {
+        "a": {
+          "!type": "+THREE.Vector3",
+          "!doc": "The first [page:Vector3] of the triangle."
+        },
+        "b": {
+          "!type": "+THREE.Vector3",
+          "!doc": "The second [page:Vector3] of the triangle."
+        },
+        "c": {
+          "!type": "+THREE.Vector3",
+          "!doc": "The third [page:Vector3] of the triangle."
+        },
+        "setFromPointsAndIndices": {
+          "!type": "fn(points: [], i0: number, i1: number, i2: number) -> +THREE.Triangle",
+          "!doc": "Sets the triangle's vectors to the vectors in the array."
+        },
+        "set": {
+          "!type": "fn(a: +THREE.Vector3, b: +THREE.Vector3, c: +THREE.Vector3) -> +THREE.Triangle",
+          "!doc": "Sets the triangle's vectors to the passed vectors."
+        },
+        "normal": {
+          "!type": "fn(optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Return the calculated normal of the triangle."
+        },
+        "barycoordFromPoint": {
+          "!type": "fn(point: +THREE.Vector3, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Return a barycentric coordinate from the given vector. <br><br>\n\t\t[link:http://commons.wikimedia.org/wiki/File:Barycentric_coordinates_1.png](Picture of barycentric coordinates)"
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Triangle",
+          "!doc": "Return a new copy of this triangle."
+        },
+        "area": {
+          "!type": "fn() -> number",
+          "!doc": "Return the area of the triangle."
+        },
+        "midpoint": {
+          "!type": "fn(optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Return the midpoint of the triangle. Optionally sets a target vector."
+        },
+        "equals": {
+          "!type": "fn(triangle: +THREE.Triangle) -> bool",
+          "!doc": "Checks to see if two triangles are equal (share the same vectors)."
+        },
+        "plane": {
+          "!type": "fn(optionalTarget: +THREE.Plane) -> +THREE.Plane",
+          "!doc": "Return a [page:Plane plane] based on the triangle. Optionally sets a target plane."
+        },
+        "containsPoint": {
+          "!type": "fn(point: +THREE.Vector3) -> bool",
+          "!doc": "Checks to see if the passed vector is within the triangle."
+        },
+        "copy": {
+          "!type": "fn(triangle: +THREE.Triangle) -> +THREE.Triangle",
+          "!doc": "Copies the values of the vertices of the passed triangle to this triangle."
+        }
+      },
+      "!doc": "A geometric triangle as defined by three vectors.",
+      "!type": "fn(a: +THREE.Vector3, b: +THREE.Vector3, c: +THREE.Vector3)"
+    },
+    "Vector2": {
+      "!url": "http://threejs.org/docs/#Reference/math/Vector2",
+      "prototype": {
+        "x": "number",
+        "y": "number",
+        "set": {
+          "!type": "fn(x: number, y: number) -> +THREE.Vector2",
+          "!doc": "Sets value of this vector."
+        },
+        "copy": {
+          "!type": "fn(v: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "Copies value of *v* to this vector."
+        },
+        "add": {
+          "!type": "fn(v: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "Adds *v* to this vector."
+        },
+        "addVectors": {
+          "!type": "fn(a: +THREE.Vector2, b: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "Sets this vector to *a + b*."
+        },
+        "sub": {
+          "!type": "fn(v: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "Subtracts *v* from this vector."
+        },
+        "subVectors": {
+          "!type": "fn(a: +THREE.Vector2, b: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "Sets this vector to *a - b*."
+        },
+        "multiplyScalar": {
+          "!type": "fn(s: number) -> +THREE.Vector2",
+          "!doc": "Multiplies this vector by scalar *s*."
+        },
+        "divideScalar": {
+          "!type": "fn(s: number) -> +THREE.Vector2",
+          "!doc": "Divides this vector by scalar *s*.<br>\n\t\tSet vector to *( 0, 0 )* if *s == 0*."
+        },
+        "negate": {
+          "!type": "fn() -> +THREE.Vector2",
+          "!doc": "Inverts this vector."
+        },
+        "dot": {
+          "!type": "fn(v: +THREE.Vector2) -> number",
+          "!doc": "Computes dot product of this vector and *v*."
+        },
+        "lengthSq": {
+          "!type": "fn() -> number",
+          "!doc": "Computes squared length of this vector."
+        },
+        "length": {
+          "!type": "fn() -> number",
+          "!doc": "Computes length of this vector."
+        },
+        "normalize": {
+          "!type": "fn() -> +THREE.Vector2",
+          "!doc": "Normalizes this vector."
+        },
+        "distanceTo": {
+          "!type": "fn(v: +THREE.Vector2) -> number",
+          "!doc": "Computes distance of this vector to *v*."
+        },
+        "distanceToSquared": {
+          "!type": "fn(v: +THREE.Vector2) -> number",
+          "!doc": "Computes squared distance of this vector to *v*."
+        },
+        "setLength": {
+          "!type": "fn(l: number) -> +THREE.Vector2",
+          "!doc": "Normalizes this vector and multiplies it by *l*."
+        },
+        "equals": {
+          "!type": "fn(v: +THREE.Vector2) -> bool",
+          "!doc": "Checks for strict equality of this vector and *v*."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Vector2",
+          "!doc": "Clones this vector."
+        },
+        "clamp": {
+          "!type": "fn(min: +THREE.Vector2, max: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "If this vector's x or y value is greater than the max vector's x or y value, it is replaced by the corresponding value. <br>\tIf this vector's x or y value is less than the min vector's x or y value, it is replace by the corresponding value."
+        },
+        "clampScalar": {
+          "!type": "fn(min: number, max: number) -> +THREE.Vector2",
+          "!doc": "If this vector's x or y values are greater than the max value, they are replaced by the max value. <br>  If this vector's x or y values are less than the min value, they are replace by the min value."
+        },
+        "floor": {
+          "!type": "fn() -> +THREE.Vector2",
+          "!doc": "The components of the vector are rounded downwards (towards negative infinity) to an integer value."
+        },
+        "ceil": {
+          "!type": "fn() -> +THREE.Vector2",
+          "!doc": "The components of the vector are rounded upwards (towards positive infinity) to an integer value."
+        },
+        "round": {
+          "!type": "fn() -> +THREE.Vector2",
+          "!doc": "The components of the vector are rounded towards the nearest integer value."
+        },
+        "roundToZero": {
+          "!type": "fn() -> +THREE.Vector2",
+          "!doc": "The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value."
+        },
+        "lerp": {
+          "!type": "fn(v: +THREE.Vector2, alpha: number) -> +THREE.Vector2",
+          "!doc": "Linear interpolation between this vector and v, where alpha is the percent along the line."
+        },
+        "lerpVectors": {
+          "!type": "fn(v1: +THREE.Vector2, v2: +THREE.Vector2, alpha: number) -> +THREE.Vector2",
+          "!doc": "Sets this vector to be the vector linearly interpolated between *v1* and *v2* with *alpha* factor."
+        },
+        "setComponent": {
+          "!type": "fn(index: number, value: number) -> undefined",
+          "!doc": "if index equals 0 method replaces this.x with value. <br>\n\t\tif index equals 1 method replaces this.y with value."
+        },
+        "addScalar": {
+          "!type": "fn(s: number) -> +THREE.Vector2",
+          "!doc": "Add the scalar value s to this vector's x and y values."
+        },
+        "getComponent": {
+          "!type": "fn(index: number) -> number",
+          "!doc": "if index equals 0 returns the x value. <br>\n\t\tif index equals 1 returns the y value."
+        },
+        "fromArray": {
+          "!type": "fn(array: []) -> +THREE.Vector2",
+          "!doc": "Sets this vector's x value to be array[0] and y value to be array[1]."
+        },
+        "toArray": {
+          "!type": "fn(array: []) -> []",
+          "!doc": "Returns an array [x, y]."
+        },
+        "min": {
+          "!type": "fn(v: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "If this vector's x or y value is less than v's x or y value, replace that value with the corresponding min value."
+        },
+        "max": {
+          "!type": "fn(v: +THREE.Vector2) -> +THREE.Vector2",
+          "!doc": "If this vector's x or y value is greater than v's x or y value, replace that value with the corresponding max value."
+        },
+        "setX": {
+          "!type": "fn(x: number) -> +THREE.Vector2",
+          "!doc": "replace this vector's x value with x."
+        },
+        "setY": {
+          "!type": "fn(y: number) -> +THREE.Vector2",
+          "!doc": "replace this vector's y value with y."
+        }
+      },
+      "!doc": "2D vector.",
+      "!type": "fn(x: number, y: number)"
+    },
+    "Vector3": {
+      "!url": "http://threejs.org/docs/#Reference/math/Vector3",
+      "prototype": {
+        "x": "number",
+        "y": "number",
+        "z": "number",
+        "set": {
+          "!type": "fn(x: number, y: number, z: number) -> +THREE.Vector3",
+          "!doc": "Sets value of this vector."
+        },
+        "setX": {
+          "!type": "fn(x: number) -> +THREE.Vector3",
+          "!doc": "Sets x value of this vector."
+        },
+        "setY": {
+          "!type": "fn(y: number) -> +THREE.Vector3",
+          "!doc": "Sets y value of this vector."
+        },
+        "setZ": {
+          "!type": "fn(z: number) -> +THREE.Vector3",
+          "!doc": "Sets z value of this vector."
+        },
+        "copy": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Copies value of *v* to this vector."
+        },
+        "add": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Adds *v* to this vector."
+        },
+        "addVectors": {
+          "!type": "fn(a: +THREE.Vector3, b: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Sets this vector to *a + b*."
+        },
+        "sub": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Subtracts *v* from this vector."
+        },
+        "subVectors": {
+          "!type": "fn(a: +THREE.Vector3, b: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Sets this vector to *a - b*."
+        },
+        "multiplyScalar": {
+          "!type": "fn(s: number) -> +THREE.Vector3",
+          "!doc": "Multiplies this vector by scalar *s*."
+        },
+        "divideScalar": {
+          "!type": "fn(s: number) -> +THREE.Vector3",
+          "!doc": "Divides this vector by scalar *s*.<br>\n\t\tSet vector to *( 0, 0, 0 )* if *s == 0*."
+        },
+        "negate": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "Inverts this vector."
+        },
+        "dot": {
+          "!type": "fn(v: +THREE.Vector3) -> number",
+          "!doc": "Computes dot product of this vector and *v*."
+        },
+        "lengthSq": {
+          "!type": "fn() -> number",
+          "!doc": "Computes squared length of this vector."
+        },
+        "length": {
+          "!type": "fn() -> number",
+          "!doc": "Computes length of this vector."
+        },
+        "lengthManhattan": {
+          "!type": "fn() -> number",
+          "!doc": "Computes Manhattan length of this vector.<br>\n\t\t[link:http://en.wikipedia.org/wiki/Taxicab_geometry]"
+        },
+        "normalize": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "Normalizes this vector. Transforms this Vector into a Unit vector by dividing the vector by it's length."
+        },
+        "distanceTo": {
+          "!type": "fn(v: +THREE.Vector3) -> number",
+          "!doc": "Computes distance of this vector to *v*."
+        },
+        "distanceToSquared": {
+          "!type": "fn(v: +THREE.Vector3) -> number",
+          "!doc": "Computes squared distance of this vector to *v*."
+        },
+        "setLength": {
+          "!type": "fn(l: number) -> +THREE.Vector3",
+          "!doc": "Normalizes this vector and multiplies it by *l*."
+        },
+        "cross": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Sets this vector to cross product of itself and *v*."
+        },
+        "crossVectors": {
+          "!type": "fn(a: +THREE.Vector3, b: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Sets this vector to cross product of *a* and *b*."
+        },
+        "setFromMatrixPosition": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Vector3",
+          "!doc": "Sets this vector extracting position from matrix transform."
+        },
+        "setFromMatrixScale": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Vector3",
+          "!doc": "Sets this vector extracting scale from matrix transform."
+        },
+        "equals": {
+          "!type": "fn(v: +THREE.Vector3) -> bool",
+          "!doc": "Checks for strict equality of this vector and *v*."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "Clones this vector."
+        },
+        "clamp": {
+          "!type": "fn(min: +THREE.Vector3, max: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "If this vector's x, y or z value is greater than the max vector's x, y or z value, it is replaced by the corresponding value. <br><br>\n\t\tIf this vector's x, y or z value is less than the min vector's x, y or z value, it is replace by the corresponding value."
+        },
+        "clampScalar": {
+          "!type": "fn(min: number, max: number) -> +THREE.Vector3",
+          "!doc": "If this vector's x, y or z values are greater than the max value, they are replaced by the max value. <br>  If this vector's x, y or z values are less than the min value, they are replace by the min value."
+        },
+        "floor": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "The components of the vector are rounded downwards (towards negative infinity) to an integer value."
+        },
+        "ceil": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "The components of the vector are rounded upwards (towards positive infinity) to an integer value."
+        },
+        "round": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "The components of the vector are rounded towards the nearest integer value."
+        },
+        "roundToZero": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value."
+        },
+        "applyMatrix3": {
+          "!type": "fn(m: +THREE.Matrix3) -> +THREE.Vector3",
+          "!doc": "Multiplies this vector times a 3 x 3 matrix."
+        },
+        "applyMatrix4": {
+          "!type": "fn(m: +THREE.Matrix3) -> +THREE.Vector3",
+          "!doc": "Multiplies this vector by 4 x 3 subset of a Matrix4."
+        },
+        "projectOnPlane": {
+          "!type": "fn(planeNormal: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Projects this vector onto a plane by subtracting this vector projected onto the plane's normal from this vector."
+        },
+        "projectOnVector": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "Projects this vector onto another vector."
+        },
+        "addScalar": {
+          "!type": "fn() -> +THREE.Vector3",
+          "!doc": "Adds a s to this vector."
+        },
+        "divide": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Divides this vector by vector v."
+        },
+        "min": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "If this vector's x, y, or z value is less than vector v's x, y, or z value, that value is replaced by the corresponding vector v value."
+        },
+        "max": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "If this vector's x, y, or z value is greater than vector v's x, y, or z value, that value is replaced by the corresponding vector v value."
+        },
+        "setComponent": {
+          "!type": "fn(index: number, value: number) -> +THREE.Vector3",
+          "!doc": "If index equals 0 the method sets this vector's x value to value <br>\n\t\tIf index equals 1 the method sets this vector's y value to value <br>\n\t\tIf index equals 2 the method sets this vector's z value to value"
+        },
+        "transformDirection": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Vector3",
+          "!doc": "Transforms the direction of this vector by a matrix (a 3 x 3 subset of a Matrix4) and then normalizes the result."
+        },
+        "multiplyVectors": {
+          "!type": "fn(a: +THREE.Vector3, b: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Sets this vector equal to the result of multiplying vector a by vector b."
+        },
+        "getComponent": {
+          "!type": "fn(index: number) -> number",
+          "!doc": "Returns the value of the vector component x, y, or z by an index. <br><br>\n\n\t\tIndex 0: x <br>\n\t\tIndex 1: y <br>\n\t\tIndex 2: z <br>"
+        },
+        "applyAxisAngle": {
+          "!type": "fn(axis: +THREE.Vector3, angle: number) -> +THREE.Vector3",
+          "!doc": "Applies a rotation specified by an axis and an angle to this vector."
+        },
+        "lerp": {
+          "!type": "fn(v: +THREE.Vector3, alpha: number) -> +THREE.Vector3",
+          "!doc": "Linear Interpolation between this vector and vector v, where alpha is the percent along the line."
+        },
+        "lerpVectors": {
+          "!type": "fn(v1: +THREE.Vector3, v2: +THREE.Vector3, alpha: number) -> +THREE.Vector3",
+          "!doc": "Sets this vector to be the vector linearly interpolated between *v1* and *v2* with *alpha* factor."
+        },
+        "angleTo": {
+          "!type": "fn(v: +THREE.Vector3) -> number",
+          "!doc": "Returns the angle between this vector and vector v in radians."
+        },
+        "setFromMatrixColumn": {
+          "!type": "fn(index: number, matrix: +THREE.Matrix4) -> +THREE.Vector3",
+          "!doc": "Sets this vector's x, y, and z equal to the column of the matrix specified by the index."
+        },
+        "reflect": {
+          "!type": "fn(normal: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Reflect incident vector off of plane orthogonal to normal. normal is assumed to have unit length."
+        },
+        "fromArray": {
+          "!type": "fn(array: []) -> +THREE.Vector3",
+          "!doc": "Sets the vector's components based on an array formatted like [x, y, z]"
+        },
+        "multiply": {
+          "!type": "fn(v: +THREE.Vector3) -> +THREE.Vector3",
+          "!doc": "Multipies this vector by vector v."
+        },
+        "applyProjection": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Vector3",
+          "!doc": "Multiplies this vector and m, and divides by perspective."
+        },
+        "toArray": {
+          "!type": "fn(array: []) -> []",
+          "!doc": "Assigns this vector's x value to array[0]. <br>\n\t\tAssigns this vector's y value to array[1]. <br>\n\t\tAssigns this vector's z value to array[2]. <br>\n\t\tReturns the created array."
+        },
+        "applyEuler": {
+          "!type": "fn(euler: +THREE.Euler) -> +THREE.Vector3",
+          "!doc": "Applies euler transform to this vector by converting the [page:Euler] obect to a [page:Quaternion] and applying."
+        },
+        "applyQuaternion": {
+          "!type": "fn(quaternion: +THREE.Quaternion) -> +THREE.Vector3",
+          "!doc": "Applies a [page:Quaternion] transform to this vector."
+        },
+        "project": {
+          "!type": "fn(camera: +THREE.Camera) -> +THREE.Vector3",
+          "!doc": "Projects the vector with the camera."
+        },
+        "unproject": {
+          "!type": "fn(camera: +THREE.Camera) -> +THREE.Vector3",
+          "!doc": "Unprojects the vector with the camera."
+        }
+      },
+      "!doc": "3D vector.",
+      "!type": "fn(x: number, y: number, z: number)"
+    },
+    "Vector4": {
+      "!url": "http://threejs.org/docs/#Reference/math/Vector4",
+      "prototype": {
+        "x": "number",
+        "y": "number",
+        "z": "number",
+        "w": "number",
+        "set": {
+          "!type": "fn(x: number, y: number, z: number, w: number) -> +THREE.Vector4",
+          "!doc": "Sets value of this vector."
+        },
+        "copy": {
+          "!type": "fn(v: +THREE.Vector4) -> +THREE.Vector4",
+          "!doc": "Copies value of *v* to this vector."
+        },
+        "add": {
+          "!type": "fn(v: +THREE.Vector4) -> +THREE.Vector4",
+          "!doc": "Adds *v* to this vector."
+        },
+        "addVectors": {
+          "!type": "fn(a: +THREE.Vector4, b: +THREE.Vector4) -> +THREE.Vector4",
+          "!doc": "Sets this vector to *a + b*."
+        },
+        "sub": {
+          "!type": "fn(v: +THREE.Vector4) -> +THREE.Vector4",
+          "!doc": "Subtracts *v* from this vector."
+        },
+        "subVectors": {
+          "!type": "fn(a: +THREE.Vector4, b: +THREE.Vector4) -> +THREE.Vector4",
+          "!doc": "Sets this vector to *a - b*."
+        },
+        "multiplyScalar": {
+          "!type": "fn(s: number) -> +THREE.Vector4",
+          "!doc": "Multiplies this vector by scalar *s*."
+        },
+        "divideScalar": {
+          "!type": "fn(s: number) -> +THREE.Vector4",
+          "!doc": "Divides this vector by scalar *s*.<br>\n\t\tSet vector to *( 0, 0, 0 )* if *s == 0*."
+        },
+        "negate": {
+          "!type": "fn() -> +THREE.Vector4",
+          "!doc": "Inverts this vector."
+        },
+        "dot": {
+          "!type": "fn(v: +THREE.Vector4) -> number",
+          "!doc": "Computes dot product of this vector and *v*."
+        },
+        "lengthSq": {
+          "!type": "fn() -> number",
+          "!doc": "Computes squared length of this vector."
+        },
+        "length": {
+          "!type": "fn() -> number",
+          "!doc": "Computes length of this vector."
+        },
+        "normalize": {
+          "!type": "fn() -> +THREE.Vector4",
+          "!doc": "Normalizes this vector."
+        },
+        "setLength": {
+          "!type": "fn(l: number) -> +THREE.Vector4",
+          "!doc": "Normalizes this vector and multiplies it by *l*."
+        },
+        "lerp": {
+          "!type": "fn(v: +THREE.Vector4, alpha: number) -> +THREE.Vector4",
+          "!doc": "Linearly interpolate between this vector and *v* with *alpha* factor."
+        },
+        "lerpVectors": {
+          "!type": "fn(v1: +THREE.Vector4, v2: +THREE.Vector4, alpha: number) -> +THREE.Vector4",
+          "!doc": "Sets this vector to be the vector linearly interpolated between *v1* and *v2* with *alpha* factor."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Vector4",
+          "!doc": "Clones this vector."
+        },
+        "clamp": {
+          "!type": "fn(min: +THREE.Vector4, max: +THREE.Vector4) -> +THREE.Vector4",
+          "!doc": "If this vector's x, y, z, or w value is greater than the max vector's x, y, z, or w value, it is replaced by the corresponding value.<br><br>\n\n\t\tIf this vector's x, y, z, or w value is less than the min vector's x, y, z, or w value, it is replace by the corresponding value."
+        },
+        "clampScalar": {
+          "!type": "fn(min: number, max: number) -> +THREE.Vector4",
+          "!doc": "If this vector's x, y, z or w values are greater than the max value, they are replaced by the max value. <br>\n\t\tIf this vector's x, y, z or w values are less than the min value, they are replace by the min value."
+        },
+        "floor": {
+          "!type": "fn() -> +THREE.Vector4",
+          "!doc": "The components of the vector are rounded downwards (towards negative infinity) to an integer value."
+        },
+        "ceil": {
+          "!type": "fn() -> +THREE.Vector4",
+          "!doc": "The components of the vector are rounded upwards (towards positive infinity) to an integer value."
+        },
+        "round": {
+          "!type": "fn() -> +THREE.Vector4",
+          "!doc": "The components of the vector are rounded towards the nearest integer value."
+        },
+        "roundToZero": {
+          "!type": "fn() -> +THREE.Vector4",
+          "!doc": "The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value."
+        },
+        "applyMatrix4": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Vector4",
+          "!doc": "Transforms the vector by the matrix."
+        },
+        "min": {
+          "!type": "fn(v: +THREE.Vector4) -> +THREE.Vector4",
+          "!doc": "If this vector's x, y, z, or w value is less than vector v's x, y, z, or w value, that value is replaced by the corresponding vector v value."
+        },
+        "max": {
+          "!type": "fn(v: +THREE.Vector4) -> +THREE.Vector4",
+          "!doc": "If this vector's x, y, z, or w value is greater than vector v's x, y, z, or w value, that value is replaced by the corresponding vector v value."
+        },
+        "addScalar": {
+          "!type": "fn(s: number) -> +THREE.Vector4",
+          "!doc": "Adds a scalar value to all of the vector's components."
+        },
+        "equals": {
+          "!type": "fn(v: +THREE.Vector4) -> bool",
+          "!doc": "Checks to see if this vector matches vector v."
+        },
+        "setAxisAngleFromRotationMatrix": {
+          "!type": "fn(m: +THREE.Matrix4) -> +THREE.Vector4",
+          "!doc": "Sets this Vector4 to the computed <a href=\"http://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation\" target=\"_blank\">axis-angle representation</a> of the rotation defined by Matrix4 m. Assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled).<br><br>\n\n\t\tThe axis is stored in components (x, y, z) of the vector, and the rotation in radians is stored in component w"
+        },
+        "setAxisAngleFromQuaternion": {
+          "!type": "fn(q: +THREE.Quaternion) -> +THREE.Vector4",
+          "!doc": "Sets this Vector4 to the computed <a href=\"http://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation\" target=\"_blank\">axis-angle representation</a> of the rotation defined by Quaternion q.<br><br>\n\n\t\tThe axis is stored in components (x, y, z) of the vector, and the rotation in radians is stored in component w"
+        },
+        "getComponent": {
+          "!type": "fn(index: number) -> number",
+          "!doc": "Returns the value of the vector component x, y, or z by an index.<br><br>\n\n\t\tIndex 0: x<br>\n\t\tIndex 1: y<br>\n\t\tIndex 2: z<br>\n\t\tIndex 3: w<br>"
+        },
+        "setComponent": {
+          "!type": "fn(index: number, value: number)",
+          "!doc": "Sets the value of the vector component\tx, y, or z by an index.<br><br>\n\n\t\tIndex 0: x<br>\n\t\tIndex 1: y<br>\n\t\tIndex 2: z<br>\n\t\tIndex 3: w<br>"
+        },
+        "fromArray": {
+          "!type": "fn(array: []) -> +THREE.Vector4",
+          "!doc": "Sets the vector's components based on an array formatted like [x, y, z, w]"
+        },
+        "toArray": {
+          "!type": "fn(array: []) -> []",
+          "!doc": "Returns an array in the format [x, y, z, w]"
+        },
+        "lengthManhattan": {
+          "!type": "fn() -> number",
+          "!doc": "Computes Manhattan length of this vector.<br>\n\t\t[link:http://en.wikipedia.org/wiki/Taxicab_geometry]"
+        },
+        "setX": {
+          "!type": "fn(x: number) -> +THREE.Vector4",
+          "!doc": "Sets the x component of the vector."
+        },
+        "setY": {
+          "!type": "fn(y: number) -> +THREE.Vector4",
+          "!doc": "Sets the y component of the vector."
+        },
+        "setZ": {
+          "!type": "fn(z: number) -> +THREE.Vector4",
+          "!doc": "Sets the z component of the vector."
+        },
+        "setW": {
+          "!type": "fn(w: number) -> +THREE.Vector4",
+          "!doc": "Sets the w component of the vector."
+        }
+      },
+      "!doc": "4D vector.",
+      "!type": "fn(x: number, y: number, z: number, w: number)"
+    },
+    "Bone": {
+      "!url": "http://threejs.org/docs/#Reference/objects/Bone",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "skinMatrix": {
+          "!type": "+THREE.Matrix4",
+          "!doc": "The matrix of the bone."
+        },
+        "skin": {
+          "!type": "+THREE.SkinnedMesh",
+          "!doc": "The skin that contains this bone."
+        },
+        "update": {
+          "!type": "fn(parentSkinMatrix: +THREE.Matrix4, forceUpdate: boolean) -> todo",
+          "!doc": "This updates the matrix of the bone and the matrices of its children."
+        }
+      },
+      "!doc": "A bone which is part of a SkinnedMesh.",
+      "!type": "fn(belongsToSkin: +THREE.SkinnedMesh)"
+    },
+    "LOD": {
+      "!url": "http://threejs.org/docs/#Reference/objects/LOD",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "objects": {
+          "!type": "array",
+          "!doc": "todo"
+        },
+        "addLevel": {
+          "!type": "fn(object: todo, distance: todo) -> todo",
+          "!doc": "todo"
+        },
+        "getObjectForDistance": {
+          "!type": "fn(distance: todo) -> todo",
+          "!doc": "todo"
+        },
+        "update": {
+          "!type": "fn(camera: todo) -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "todo",
+      "!type": "fn()"
+    },
+    "LensFlare": {
+      "!url": "http://threejs.org/docs/#Reference/objects/LensFlare",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "lensFlares": {
+          "!type": "array",
+          "!doc": "todo"
+        },
+        "positionScreen": {
+          "!type": "+THREE.Vector3",
+          "!doc": "todo"
+        },
+        "customUpdateCallback": {
+          "!type": "todo",
+          "!doc": "todo"
+        },
+        "updateLensFlares": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "todo",
+      "!type": "fn(texture: todo, size: todo, distance: todo, blending: todo, color: todo)"
+    },
+    "Line": {
+      "!url": "http://threejs.org/docs/#Reference/objects/Line",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "geometry": {
+          "!type": "+THREE.Geometry",
+          "!doc": "Vertices representing the line segment(s)."
+        },
+        "material": {
+          "!type": "+THREE.Material",
+          "!doc": "Material for the line."
+        },
+        "type": {
+          "!type": "number",
+          "!doc": "In OpenGL terms, LineStrip is the classic GL_LINE_STRIP and LinePieces is the equivalent to GL_LINES."
+        },
+        "raycast": {
+          "!type": "fn(raycaster: +THREE.Raycaster, intersects: []) -> []",
+          "!doc": "Get intersections between a casted ray and this Line. [page:Raycaster.intersectObject] will call this method."
+        }
+      },
+      "!doc": "A line or a series of lines.",
+      "!type": "fn(geometry: +THREE.Geometry, material: +THREE.Material, type: number)"
+    },
+    "Mesh": {
+      "!url": "http://threejs.org/docs/#Reference/objects/Mesh",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "geometry": {
+          "!type": "+THREE.Geometry",
+          "!doc": "An instance of [page:Geometry], defining the object's structure."
+        },
+        "material": {
+          "!type": "+THREE.Material",
+          "!doc": "An instance of [page:Material], defining the object's appearance. Default is a [page:MeshBasicMaterial] with wireframe mode enabled and randomised colour."
+        },
+        "getMorphTargetIndexByName": {
+          "!type": "fn(name: string) -> number",
+          "!doc": "Returns the index of a morph target defined by name."
+        },
+        "updateMorphTargets": {
+          "!type": "fn()",
+          "!doc": "Updates the morphtargets to have no influence on the object."
+        },
+        "raycast": {
+          "!type": "fn(raycaster: +THREE.Raycaster, intersects: []) -> []",
+          "!doc": "Get intersections between a casted ray and this mesh. [page:Raycaster.intersectObject] will call this method."
+        }
+      },
+      "!doc": "Base class for Mesh objects, such as [page:MorphAnimMesh] and [page:SkinnedMesh].",
+      "!type": "fn(geometry: +THREE.Geometry, material: +THREE.Material)"
+    },
+    "MorphAnimMesh": {
+      "!url": "http://threejs.org/docs/#Reference/objects/MorphAnimMesh",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "directionBackwards": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "direction": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "endKeyframe": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "mirroredLoop": {
+          "!type": "boolean",
+          "!doc": "todo"
+        },
+        "startKeyframe": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "lastKeyframe": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "length": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "time": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "duration": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "currentKeyframe": {
+          "!type": "number",
+          "!doc": "todo"
+        },
+        "setDirectionForward": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "playAnimation": {
+          "!type": "fn(label: todo, fps: todo) -> todo",
+          "!doc": "todo"
+        },
+        "setFrameRange": {
+          "!type": "fn(start: todo, end: todo) -> todo",
+          "!doc": "todo"
+        },
+        "setDirectionBackward": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "parseAnimations": {
+          "!type": "fn() -> todo",
+          "!doc": "todo"
+        },
+        "updateAnimation": {
+          "!type": "fn(delta: todo) -> todo",
+          "!doc": "todo"
+        },
+        "setAnimationLabel": {
+          "!type": "fn(label: todo, start: todo, end: todo) -> todo",
+          "!doc": "todo"
+        }
+      },
+      "!doc": "todo",
+      "!type": "fn(geometry: todo, material: todo)"
+    },
+    "PointCloud": {
+      "!url": "http://threejs.org/docs/#Reference/objects/PointCloud",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "geometry": {
+          "!type": "+THREE.Geometry",
+          "!doc": "An instance of [page:Geometry], where each vertex designates the position of a particle in the system."
+        },
+        "material": {
+          "!type": "+THREE.Material",
+          "!doc": "An instance of [page:Material], defining the object's appearance. Default is a [page:PointCloudMaterial] with randomised colour."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.PointCloud",
+          "!doc": "This creates a clone of the particle system."
+        },
+        "raycast": {
+          "!type": "fn(raycaster: +THREE.Raycaster, intersects: []) -> []",
+          "!doc": "Get intersections between a casted ray and this PointCloud. [page:Raycaster.intersectObject] will call this method."
+        }
+      },
+      "!doc": "A class for displaying particles in the form of variable size points. For example, if using the [page:WebGLRenderer], the particles are displayed using GL_POINTS.",
+      "!type": "fn(geometry: +THREE.Geometry, material: +THREE.Material)"
+    },
+    "SkinnedMesh": {
+      "!url": "http://threejs.org/docs/#Reference/objects/SkinnedMesh",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "bones": {
+          "!type": "array",
+          "!doc": "This contains the array of bones for this mesh. These should be set in the constructor."
+        },
+        "identityMatrix": {
+          "!type": "+THREE.Matrix4",
+          "!doc": "This is an identityMatrix to calculate the bones matrices from."
+        },
+        "useVertexTexture": {
+          "!type": "boolean",
+          "!doc": "The boolean defines whether a vertex texture is used to calculate the bones. This boolean shouldn't be changed after constructor."
+        },
+        "boneMatrices": {
+          "!type": "array",
+          "!doc": "This array of matrices contains the matrices of the bones. These get calculated in the constructor."
+        },
+        "pose": {
+          "!type": "fn()",
+          "!doc": "This method sets the skinnedmesh in the rest pose."
+        },
+        "addBone": {
+          "!type": "fn(bone: +THREE.Bone) -> +THREE.Bone",
+          "!doc": "This method adds the bone to the skinnedmesh when it is provided. It creates a new bone and adds that when no bone is given."
+        }
+      },
+      "!doc": "An 3d object that has bones data. These Bones can then be used to animate the vertices of the object.",
+      "!type": "fn(geometry: +THREE.Geometry, material: +THREE.Material, useVertexTexture: boolean)"
+    },
+    "Sprite": {
+      "!url": "http://threejs.org/docs/#Reference/objects/Sprite",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "material": {
+          "!type": "+THREE.SpriteMaterial",
+          "!doc": "An instance of [page:Material], defining the object's appearance. Default is a [page:SpriteMaterial] which is a white plane."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Sprite",
+          "!doc": "This creates a new clone of the sprite."
+        }
+      },
+      "!doc": "A sprite is a plane in an 3d scene which faces always towards the camera.",
+      "!type": "fn(material: +THREE.Material)"
+    },
+    "CanvasRenderer": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/CanvasRenderer",
+      "prototype": {
+        "info": {
+          "!type": "object",
+          "!doc": "An object with a series of statistical information about the graphics board memory and the rendering process. Useful for debugging or just for the sake of curiosity. The object contains the following fields:"
+        },
+        "domElement": {
+          "!type": "DOMElement",
+          "!doc": "A [page:Canvas] where the renderer draws its output.<br>\n\t\t\tThis is automatically created by the renderer in the constructor (if not provided already); you just need to add it to your page."
+        },
+        "autoClear": {
+          "!type": "bool",
+          "!doc": "Defines whether the renderer should automatically clear its output before rendering."
+        },
+        "sortObjects": {
+          "!type": "bool",
+          "!doc": "Defines whether the renderer should sort objects. Default is true.<br>\n      Note: Sorting is used to attempt to properly render objects that have some degree of transparency.  By definition, sorting objects may not work in all cases.  Depending on the needs of application, it may be neccessary to turn off sorting and use other methods to deal with transparency rendering e.g. manually determining the object rendering order."
+        },
+        "sortElements": {
+          "!type": "boolean",
+          "!doc": "Defines whether the renderer should sort the face of each object. Default is true."
+        },
+        "render": {
+          "!type": "fn(scene: +THREE.Scene, camera: +THREE.Camera)",
+          "!doc": "Render a scene using a camera."
+        },
+        "clear": {
+          "!type": "fn()",
+          "!doc": "Tells the renderer to clear its color drawing buffer with the clearcolor."
+        },
+        "setClearColor": {
+          "!type": "fn(color: +THREE.Color, alpha: number)",
+          "!doc": "This set the clearColor and the clearAlpha."
+        },
+        "setSize": {
+          "!type": "fn(width: number, height: number)",
+          "!doc": "This set the size of the drawing canvas and if updateStyle is set, then the css of the canvas is updated too."
+        },
+        "setClearColorHex": {
+          "!type": "fn(hex: number, alpha: number)",
+          "!doc": "This set the clearColor and the clearAlpha."
+        },
+        "getClearColorHex": {
+          "!type": "fn() -> number",
+          "!doc": "Returns the [page:number hex] color."
+        },
+        "getClearAlpha": {
+          "!type": "fn() -> number",
+          "!doc": "Returns the alpha value."
+        }
+      },
+      "!doc": "The Canvas renderer displays your beautifully crafted scenes <em>not</em> using WebGL, but draws it using the (slower) <a href=\"http://www.w3.org/html/wg/drafts/2dcontext/html5_canvas/\">Canvas 2D Context</a> API.<br><br>\n\t\t\tThis renderer can be a nice fallback from [page:WebGLRenderer] for simple scenes:\n\n\t\t\t<code>\n\t\t\tfunction webglAvailable() {\n\t\t\t\ttry {\n\t\t\t\t\tvar canvas = document.createElement( 'canvas' );\n\t\t\t\t\treturn !!( window.WebGLRenderingContext &amp;&amp; (\n\t\t\t\t\t\tcanvas.getContext( 'webgl' ) ||\n\t\t\t\t\t\tcanvas.getContext( 'experimental-webgl' ) )\n\t\t\t\t\t);\n\t\t\t\t} catch ( e ) {\n\t\t\t\t\treturn false;\n\t\t\t\t}\n\t\t\t}\n\n\t\t\tif ( webglAvailable() ) {\n\t\t\t\trenderer = new THREE.WebGLRenderer();\n\t\t\t} else {\n\t\t\t\trenderer = new THREE.CanvasRenderer();\n\t\t\t}\n\t\t\t</code>\n\n\t\t\tNote: both WebGLRenderer and CanvasRenderer are embedded in the web page using an HTML5 &lt;canvas&gt; tag.\n\t\t\tThe \"Canvas\" in CanvasRenderer means it uses Canvas 2D instead of WebGL.<br><br>\n\n\t\t\tDon't confuse either CanvasRenderer with the SoftwareRenderer example, which simulates a screen buffer in a Javascript array.",
+      "!type": "fn(parameters: object)"
+    },
+    "WebGLRenderTarget": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/WebGLRenderTarget",
+      "prototype": {
+        "wrapS": {
+          "!type": "number",
+          "!doc": "The default is THREE.ClampToEdgeWrapping, where the edge is clamped to the outer edge texels. The other two choices are THREE.RepeatWrapping and THREE.MirroredRepeatWrapping."
+        },
+        "wrapT": {
+          "!type": "number",
+          "!doc": "The default is THREE.ClampToEdgeWrapping, where the edge is clamped to the outer edge texels. The other two choices are THREE.RepeatWrapping and THREE.MirroredRepeatWrapping."
+        },
+        "magFilter": {
+          "!type": "number",
+          "!doc": "How the texture is sampled when a texel covers more than one pixel. The default is THREE.LinearFilter, which takes the four closest texels and bilinearly interpolates among them. The other option is THREE.NearestFilter, which uses the value of the closest texel."
+        },
+        "minFilter": {
+          "!type": "number",
+          "!doc": "How the texture is sampled when a texel covers less than one pixel. The default is THREE.LinearMipMapLinearFilter, which uses mipmapping and a trilinear filter. Other choices are THREE.NearestFilter, THREE.NearestMipMapNearestFilter, THREE.NearestMipMapLinearFilter, THREE.LinearFilter, and THREE.LinearMipMapNearestFilter. These vary whether the nearest texel or nearest four texels are retrieved on the nearest mipmap or nearest two mipmaps. Interpolation occurs among the samples retrieved."
+        },
+        "anisotropy": {
+          "!type": "number",
+          "!doc": "The number of samples taken along the axis through the pixel that has the highest density of texels. By default, this value is 1. A higher value gives a less blurry result than a basic mipmap, at the cost of more texture samples being used. Use renderer.getMaxAnisotropy() to find the maximum valid anisotropy value for the GPU; this value is usually a power of 2."
+        },
+        "repeat": {
+          "!type": "+THREE.Vector2",
+          "!doc": "How many times the texture is repeated across the surface, in each direction U and V."
+        },
+        "offset": {
+          "!type": "+THREE.Vector2",
+          "!doc": "How much a single repetition of the texture is offset from the beginning, in each direction U and V. Typical range is 0.0 to 1.0."
+        },
+        "format": {
+          "!type": "number",
+          "!doc": "The default is THREE.RGBAFormat for the texture. Other formats are: THREE.AlphaFormat, THREE.RGBFormat, THREE.LuminanceFormat, and THREE.LuminanceAlphaFormat. There are also compressed texture formats, if the S3TC extension is supported: THREE.RGB_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT3_Format, and THREE.RGBA_S3TC_DXT5_Format."
+        },
+        "type": {
+          "!type": "number",
+          "!doc": "The default is THREE.UnsignedByteType. Other valid types (as WebGL allows) are THREE.ByteType, THREE.ShortType, THREE.UnsignedShortType, THREE.IntType, THREE.UnsignedIntType, THREE.HalfFloatType, THREE.FloatType, THREE.UnsignedShort4444Type, THREE.UnsignedShort5551Type, and THREE.UnsignedShort565Type."
+        },
+        "depthBuffer": {
+          "!type": "boolean",
+          "!doc": "Renders to the depth buffer. Default is true."
+        },
+        "stencilBuffer": {
+          "!type": "boolean",
+          "!doc": "Renders to the stencil buffer. Default is true."
+        },
+        "generateMipmaps": {
+          "!type": "boolean",
+          "!doc": "Whether to generate mipmaps (if possible) for a texture. True by default."
+        },
+        "shareDepthFrom": {
+          "!type": "+THREE.WebGLRenderTarget",
+          "!doc": "Shares the depth from another WebGLRenderTarget. Default is null."
+        },
+        "setSize": {
+          "!type": "fn(width: number, height: number)",
+          "!doc": "Sets the size of the renderTarget."
+        },
+        "clone": {
+          "!type": "fn() -> RenderTarget",
+          "!doc": "Creates a copy of the render target."
+        },
+        "dispose": {
+          "!type": "fn()",
+          "!doc": "Dispatches a dispose event."
+        }
+      },
+      "!doc": "A render target is a buffer where the video card draws pixels for a scene that is being rendered in the background. It is used in different effects.",
+      "!type": "fn(width: number, height: number, options: object)"
+    },
+    "WebGLRenderTargetCube": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/WebGLRenderTargetCube",
+      "prototype": {
+        "!proto": "THREE.WebGLRenderTarget.prototype",
+        "activeCubeFace": {
+          "!type": "integer",
+          "!doc": "The activeCubeFace property corresponds to a cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) and is\n\t\tused and set internally by the [page:CubeCamera]."
+        }
+      },
+      "!doc": "[page:CubeCamera] uses this as its [page:WebGLRenderTarget]",
+      "!type": "fn(width: number, height: number, options: object)"
+    },
+    "WebGLRenderer": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/WebGLRenderer",
+      "prototype": {
+        "domElement": {
+          "!type": "DOMElement",
+          "!doc": "A [page:Canvas] where the renderer draws its output.<br>\n\t\tThis is automatically created by the renderer in the constructor (if not provided already); you just need to add it to your page."
+        },
+        "context": {
+          "!type": "WebGLRenderingContext",
+          "!doc": "The HTML5 Canvas's 'webgl' context obtained from the canvas where the renderer will draw."
+        },
+        "autoClear": {
+          "!type": "bool",
+          "!doc": "Defines whether the renderer should automatically clear its output before rendering."
+        },
+        "autoClearColor": {
+          "!type": "bool",
+          "!doc": "If autoClear is true, defines whether the renderer should clear the color buffer. Default is true."
+        },
+        "autoClearDepth": {
+          "!type": "bool",
+          "!doc": "If autoClear is true, defines whether the renderer should clear the depth buffer. Default is true."
+        },
+        "autoClearStencil": {
+          "!type": "bool",
+          "!doc": "If autoClear is true, defines whether the renderer should clear the stencil buffer. Default is true."
+        },
+        "sortObjects": {
+          "!type": "bool",
+          "!doc": "Note: Sorting is used to attempt to properly render objects that have some degree of transparency.  By definition, sorting objects may not work in all cases.  Depending on the needs of application, it may be neccessary to turn off sorting and use other methods to deal with transparency rendering e.g. manually determining the object rendering order."
+        },
+        "autoUpdateObjects": {
+          "!type": "bool",
+          "!doc": "Defines whether the renderer should auto update objects. Default is true."
+        },
+        "gammaInput": {
+          "!type": "bool",
+          "!doc": "Default is false. If set, then it expects that all textures and colors are premultiplied gamma."
+        },
+        "gammaOutput": {
+          "!type": "bool",
+          "!doc": "Default is false.  If set, then it expects that all textures and colors need to be outputted in premultiplied gamma."
+        },
+        "shadowMapEnabled": {
+          "!type": "bool",
+          "!doc": "Default is false. If set, use shadow maps in the scene."
+        },
+        "shadowMapType": {
+          "!type": "number",
+          "!doc": "Options are THREE.BasicShadowMap, THREE.PCFShadowMap, THREE.PCFSoftShadowMap. Default is THREE.PCFShadowMap."
+        },
+        "shadowMapCullFace": {
+          "!type": "number",
+          "!doc": "Default is THREE.CullFaceFront. The faces that needed to be culled. Possible values: THREE.CullFaceFront and THREE.CullFaceBack"
+        },
+        "shadowMapCascade": {
+          "!type": "bool",
+          "!doc": "Default is false. If Set, use cascaded shadowmaps. See [link:http://developer.download.nvidia.com/SDK/10.5/opengl/src/cascaded_shadow_maps/doc/cascaded_shadow_maps.pdf cascaded shadowmaps] for more information."
+        },
+        "maxMorphTargets": {
+          "!type": "number",
+          "!doc": "Default is 8. The maximum number of MorphTargets allowed in a shader. Keep in mind that the standard materials only allow 8 MorphTargets."
+        },
+        "maxMorphNormals": {
+          "!type": "number",
+          "!doc": "Default is 4. The maximum number of MorphNormals allowed in a shader. Keep in mind that the standard materials only allow 4 MorphNormals."
+        },
+        "autoScaleCubemaps": {
+          "!type": "bool",
+          "!doc": "Default is true. If set, then Cubemaps are scaled, when they are bigger than the maximum size, to make sure that they aren't bigger than the maximum size."
+        },
+        "info": {
+          "!type": "object",
+          "!doc": "<ul>\n\t\t\t<li>memory:\n\t\t\t\t<ul>\n\t\t\t\t\t<li>programs</li>\n\t\t\t\t\t<li>geometries</li>\n\t\t\t\t\t<li>textures</li>\n\t\t\t\t</ul>\n\t\t\t</li>\n\t\t\t<li>render:\n\t\t\t\t<ul>\n\t\t\t\t\t<li>calls</li>\n\t\t\t\t\t<li>vertices</li>\n\t\t\t\t\t<li>faces</li>\n\t\t\t\t\t<li>points</li>\n\t\t\t\t</ul>\n\t\t\t</li>\n\t\t</ul>"
+        },
+        "shadowMapPlugin": {
+          "!type": "+THREE.ShadowMapPlugin",
+          "!doc": "This contains the reference to the shadowMapPlugin."
+        },
+        "getContext": {
+          "!type": "fn() -> WebGLRenderingContext",
+          "!doc": "Return the WebGL context."
+        },
+        "supportsVertexTextures": {
+          "!type": "fn() -> bool",
+          "!doc": "Return a [page:Boolean] true if the context supports vertex textures."
+        },
+        "setSize": {
+          "!type": "fn(width: number, height: number)",
+          "!doc": "Resizes the output canvas to (width, height), and also sets the viewport to fit that size, starting in (0, 0)."
+        },
+        "setViewport": {
+          "!type": "fn(x: number, y: number, width: number, height: number)",
+          "!doc": "Sets the viewport to render from (x, y) to (x + width, y + height)."
+        },
+        "setScissor": {
+          "!type": "fn(x: number, y: number, width: number, height: number)",
+          "!doc": "Sets the scissor area from (x, y) to (x + width, y + height)."
+        },
+        "enableScissorTest": {
+          "!type": "fn(enable: bool)",
+          "!doc": "Enable the scissor test. When this is enabled, only the pixels within the defined scissor area will be affected by further renderer actions."
+        },
+        "setClearColor": {
+          "!type": "fn(color: +THREE.Color, alpha: number)",
+          "!doc": "Sets the clear color and opacity."
+        },
+        "getClearColor": {
+          "!type": "fn() -> +THREE.Color",
+          "!doc": "Returns a [page:Color THREE.Color] instance with the current clear color."
+        },
+        "getClearAlpha": {
+          "!type": "fn() -> number",
+          "!doc": "Returns a [page:Float float] with the current clear alpha. Ranges from 0 to 1."
+        },
+        "clear": {
+          "!type": "fn(color: bool, depth: bool, stencil: bool)",
+          "!doc": "Arguments default to true."
+        },
+        "renderBufferImmediate": {
+          "!type": "fn(object: +THREE.Object3D, program: shaderprogram, shading: +THREE.Material)",
+          "!doc": "Render an immediate buffer. Gets called by renderImmediateObject."
+        },
+        "renderBufferDirect": {
+          "!type": "fn(camera: +THREE.Camera, lights: [], fog: +THREE.Fog, material: +THREE.Material, geometryGroup: object, object: +THREE.Object3D)",
+          "!doc": "Render a buffer geometry group using the camera and with the correct material."
+        },
+        "renderBuffer": {
+          "!type": "fn(camera: +THREE.Camera, lights: [], fog: +THREE.Fog, material: +THREE.Material, geometryGroup: object, object: +THREE.Object3D)",
+          "!doc": "Render a geometry group using the camera and with the correct material."
+        },
+        "render": {
+          "!type": "fn(scene: +THREE.Scene, camera: +THREE.Camera, renderTarget: +THREE.WebGLRenderTarget, forceClear: bool)",
+          "!doc": "Even with forceClear set to true you can prevent certain buffers being cleared by setting either the .autoClearColor, .autoClearStencil or .autoClearDepth properties to false."
+        },
+        "renderImmediateObject": {
+          "!type": "fn(camera, lights, fog, material, object)",
+          "!doc": "Renders an immediate Object using a camera."
+        },
+        "setFaceCulling": {
+          "!type": "fn(cullFace, frontFace)",
+          "!doc": "If cullFace is false, culling will be disabled."
+        },
+        "setDepthTest": {
+          "!type": "fn(depthTest: boolean)",
+          "!doc": "This sets, based on depthTest, whether or not the depth data needs to be tested against the depth buffer."
+        },
+        "setDepthWrite": {
+          "!type": "fn(depthWrite: boolean)",
+          "!doc": "This sets, based on depthWrite, whether or not the depth data needs to be written in the depth buffer."
+        },
+        "setBlending": {
+          "!type": "fn(blending: number, blendEquation: number, blendSrc: number, blendDst: number)",
+          "!doc": "This method sets the correct blending."
+        },
+        "setTexture": {
+          "!type": "fn(texture: +THREE.Texture, slot: number)",
+          "!doc": "This method sets the correct texture to the correct slot for the wegl shader. The slot number can be found as a value of the uniform of the sampler."
+        },
+        "setRenderTarget": {
+          "!type": "fn(renderTarget: +THREE.WebGLRenderTarget)",
+          "!doc": "This method sets the active rendertarget."
+        },
+        "supportsCompressedTextureS3TC": {
+          "!type": "fn() -> boolean",
+          "!doc": "This method returns true if the webgl implementation supports compressed textures of the format S3TC."
+        },
+        "getMaxAnisotropy": {
+          "!type": "fn() -> number",
+          "!doc": "This returns the anisotropy level of the textures."
+        },
+        "getPrecision": {
+          "!type": "fn() -> string",
+          "!doc": "This gets the precision used by the shaders. It returns \"highp\",\"mediump\" or \"lowp\"."
+        },
+        "setMaterialFaces": {
+          "!type": "fn(material: +THREE.Material)",
+          "!doc": "This sets which side needs to be culled in the webgl renderer."
+        },
+        "supportsStandardDerivatives": {
+          "!type": "fn() -> boolean",
+          "!doc": "This method returns true if the webgl implementation supports standard derivatives."
+        },
+        "supportsFloatTextures": {
+          "!type": "fn() -> boolean",
+          "!doc": "This method returns true if the webgl implementation supports float textures."
+        },
+        "clearTarget": {
+          "!type": "fn(renderTarget: +THREE.WebGLRenderTarget, color: boolean, depth: boolean, stencil: boolean)",
+          "!doc": "This method clears a rendertarget. To do this, it activates the rendertarget."
+        }
+      },
+      "!doc": "The WebGL renderer displays your beautifully crafted scenes using WebGL, if your device supports it.",
+      "!type": "fn(parameters: object)"
+    },
+    "ShaderChunk": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/shaders/ShaderChunk",
+      "prototype": {},
+      "!doc": "Shader chunks for WebLG Shader library"
+    },
+    "ShaderLib": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/shaders/ShaderLib",
+      "prototype": {},
+      "!doc": "Webgl Shader Library for three.js"
+    },
+    "UniformsLib": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/shaders/UniformsLib",
+      "prototype": {},
+      "!doc": "Uniforms library for shared webgl shaders"
+    },
+    "UniformsUtils": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/shaders/UniformsUtils",
+      "prototype": {},
+      "!doc": "Uniform Utilities. Support merging and cloning of uniform variables"
+    },
+    "WebGLProgram": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/webgl/WebGLProgram",
+      "prototype": {
+        "uniforms": "object",
+        "attributes": "object",
+        "id": "string",
+        "code": "string",
+        "usedTimes": "number",
+        "program": "object",
+        "vertexShader": "+THREE.WebGLShader",
+        "fragmentShader": "+THREE.WebGLShader"
+      },
+      "!doc": "Constructor for the GLSL program sent to vertex and fragment shaders, including default uniforms and attributes.",
+      "!type": "fn(renderer: +THREE.WebGLRenderer, code: object, material: +THREE.Material, parameters: object)"
+    },
+    "WebGLShader": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/webgl/WebGLShader",
+      "prototype": {},
+      "!doc": "todo"
+    },
+    "LensFlarePlugin": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/webgl/plugins/LensFlarePlugin",
+      "prototype": {
+        "render": {
+          "!type": "fn(scene: +THREE.Scene, camera: +THREE.Camera, viewportWidth: number, viewportHeight: number)",
+          "!doc": "Renders the lensflares defined in the scene. This gets automatically called as post render function to draw the lensflares."
+        }
+      },
+      "!doc": "The Webglrenderer plugin class that allows lensflares to be rendered in the WebglRenderer. This plugin is automatically loaded in the Webglrenderer.",
+      "!type": "fn()"
+    },
+    "ShadowMapPlugin": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/webgl/plugins/ShadowMapPlugin",
+      "prototype": {
+        "render": {
+          "!type": "fn(scene: +THREE.Scene, camera: +THREE.Camera)",
+          "!doc": "Prepares the shadowmaps to be rendered defined in the scene. This gets automatically called as pre render function to draw the lensflares."
+        }
+      },
+      "!doc": "The Webglrenderer plugin class that allows shadowmaps to be rendered in the WebglRenderer. This plugin is automatically loaded in the Webglrenderer.",
+      "!type": "fn()"
+    },
+    "SpritePlugin": {
+      "!url": "http://threejs.org/docs/#Reference/renderers/webgl/plugins/SpritePlugin",
+      "prototype": {
+        "render": {
+          "!type": "fn(scene: +THREE.Scene, camera: +THREE.Camera)",
+          "!doc": "Renders the sprites defined in the scene. This gets automatically called as post-render function to draw the lensflares."
+        }
+      },
+      "!doc": "The Webglrenderer plugin class that allows Sprites to be rendered in the WebglRenderer. This plugin is automatically loaded in the Webglrenderer.",
+      "!type": "fn()"
+    },
+    "Fog": {
+      "!url": "http://threejs.org/docs/#Reference/scenes/Fog",
+      "prototype": {
+        "name": {
+          "!type": "string",
+          "!doc": "Default is the empty string."
+        },
+        "color": {
+          "!type": "+THREE.Color",
+          "!doc": "Fog color.  Example: If set to black, far away objects will be rendered black."
+        },
+        "near": {
+          "!type": "number",
+          "!doc": "Default is 1."
+        },
+        "far": {
+          "!type": "number",
+          "!doc": "Default is 1000."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.Fog",
+          "!doc": "Returns a copy of this."
+        }
+      },
+      "!doc": "This class contains the parameters that define linear fog, i.e., that grows linearly denser with the distance.",
+      "!type": "fn(hex: number, near: number, far: number)"
+    },
+    "FogExp2": {
+      "!url": "http://threejs.org/docs/#Reference/scenes/FogExp2",
+      "prototype": {
+        "name": {
+          "!type": "string",
+          "!doc": "Default is the empty string."
+        },
+        "color": {
+          "!type": "+THREE.Color",
+          "!doc": "Fog color. Example: If set to black, far away objects will be rendered black."
+        },
+        "density": {
+          "!type": "number",
+          "!doc": "Default is 0.00025."
+        },
+        "clone": {
+          "!type": "fn() -> +THREE.FogExp2",
+          "!doc": "Returns a copy of this."
+        }
+      },
+      "!doc": "This class contains the parameters that define exponential fog, i.e., that grows exponentially denser with the distance.",
+      "!type": "fn(hex: number, density: number)"
+    },
+    "Scene": {
+      "!url": "http://threejs.org/docs/#Reference/scenes/Scene",
+      "prototype": {
+        "!proto": "THREE.Object3D.prototype",
+        "fog": {
+          "!type": "+THREE.Fog",
+          "!doc": "A [page:Fog fog] instance defining the type of fog that affects everything rendered in the scene. Default is null."
+        },
+        "overrideMaterial": {
+          "!type": "+THREE.Material",
+          "!doc": "If not null, it will force everything in the scene to be rendered with that material. Default is null."
+        },
+        "autoUpdate": {
+          "!type": "boolean",
+          "!doc": "Default is true. If set, then the renderer checks every frame if the scene and its objects needs matrix updates. \n\t\tWhen it isn't, then you have to maintain all matrices in the scene yourself."
+        }
+      },
+      "!doc": "Scenes allow you to set up what and where is to be rendered by three.js. This is where you place objects, lights and cameras.",
+      "!type": "fn()"
+    },
+    "CompressedTexture": {
+      "!url": "http://threejs.org/docs/#Reference/textures/CompressedTexture",
+      "prototype": {
+        "!proto": "THREE.Texture.prototype",
+        "flipY": {
+          "!type": "boolean",
+          "!doc": "False by default. Flipping textures does not work for compressed textures."
+        },
+        "generateMipmaps": {
+          "!type": "boolean",
+          "!doc": "False by default. Mipmaps can't be generated for compressed textures"
+        }
+      },
+      "!doc": "Creates a texture based on data in compressed form.",
+      "!type": "fn(mipmaps: [], width: number, height: number, format: number, type: number, mapping: number, wrapS: number, wrapT: number, magFilter: number, minFilter: number, anisotropy: number)"
+    },
+    "DataTexture": {
+      "!url": "http://threejs.org/docs/#Reference/textures/DataTexture",
+      "prototype": {
+        "!proto": "THREE.Texture.prototype"
+      },
+      "!doc": "Creates a texture directly from bitmapdata, width and height.",
+      "!type": "fn(data: ArraybufferView, width: number, height: number, format: number, type: number, mapping: number, wrapS: number, wrapT: number, magFilter: number, minFilter: number, anisotropy: number)"
+    },
+    "Texture": {
+      "!url": "http://threejs.org/docs/#Reference/textures/Texture",
+      "prototype": {
+        "id": {
+          "!type": "number",
+          "!doc": "Unique number for this texture instance."
+        },
+        "image": {
+          "!type": "Image",
+          "!doc": "An Image object, typically created using the ImageUtils or [page:ImageLoader ImageLoader] classes. The Image object can include an image (e.g., PNG, JPG, GIF, DDS), video (e.g., MP4, OGG/OGV), or set of six images for a cube map. To use video as a texture you need to have a playing HTML5 video element as a source for your texture image and continuously update this texture as long as video is playing."
+        },
+        "mapping": {
+          "!type": "object",
+          "!doc": "How the image is applied to the object. An object type of THREE.UVMapping is the default, where the U,V coordinates are used to apply the map, and a single texture is expected. The other types are THREE.CubeReflectionMapping, for cube maps used as a reflection map; THREE.CubeRefractionMapping, refraction mapping; and THREE.SphericalReflectionMapping, a spherical reflection map projection."
+        },
+        "wrapS": {
+          "!type": "number",
+          "!doc": "The default is THREE.ClampToEdgeWrapping, where the edge is clamped to the outer edge texels. The other two choices are THREE.RepeatWrapping and THREE.MirroredRepeatWrapping."
+        },
+        "wrapT": {
+          "!type": "number",
+          "!doc": "NOTE: tiling of images in textures only functions if image dimensions are powers of two (2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...) in terms of pixels. Individual dimensions need not be equal, but each must be a power of two. This is a limitation of WebGL, not Three.js."
+        },
+        "magFilter": {
+          "!type": "number",
+          "!doc": "How the texture is sampled when a texel covers more than one pixel. The default is THREE.LinearFilter, which takes the four closest texels and bilinearly interpolates among them. The other option is THREE.NearestFilter, which uses the value of the closest texel."
+        },
+        "minFilter": {
+          "!type": "number",
+          "!doc": "How the texture is sampled when a texel covers less than one pixel. The default is THREE.LinearMipMapLinearFilter, which uses mipmapping and a trilinear filter. Other choices are THREE.NearestFilter, THREE.NearestMipMapNearestFilter, THREE.NearestMipMapLinearFilter, THREE.LinearFilter, and THREE.LinearMipMapNearestFilter. These vary whether the nearest texel or nearest four texels are retrieved on the nearest mipmap or nearest two mipmaps. Interpolation occurs among the samples retrieved."
+        },
+        "format": {
+          "!type": "number",
+          "!doc": "The default is THREE.RGBAFormat for the texture. Other formats are: THREE.AlphaFormat, THREE.RGBFormat, THREE.LuminanceFormat, and THREE.LuminanceAlphaFormat. There are also compressed texture formats, if the S3TC extension is supported: THREE.RGB_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT3_Format, and THREE.RGBA_S3TC_DXT5_Format."
+        },
+        "type": {
+          "!type": "number",
+          "!doc": "The default is THREE.UnsignedByteType. Other valid types (as WebGL allows) are THREE.ByteType, THREE.ShortType, THREE.UnsignedShortType, THREE.IntType, THREE.UnsignedIntType, THREE.FloatType, THREE.UnsignedShort4444Type, THREE.UnsignedShort5551Type, and THREE.UnsignedShort565Type."
+        },
+        "anisotropy": {
+          "!type": "number",
+          "!doc": "The number of samples taken along the axis through the pixel that has the highest density of texels. By default, this value is 1. A higher value gives a less blurry result than a basic mipmap, at the cost of more texture samples being used. Use renderer.getMaxAnisotropy() to find the maximum valid anisotropy value for the GPU; this value is usually a power of 2."
+        },
+        "needsUpdate": {
+          "!type": "boolean",
+          "!doc": "If a texture is changed after creation, set this flag to true so that the texture is properly set up. Particularly important for setting the wrap mode."
+        },
+        "repeat": {
+          "!type": "+THREE.Vector2",
+          "!doc": "How many times the texture is repeated across the surface, in each direction U and V."
+        },
+        "offset": {
+          "!type": "+THREE.Vector2",
+          "!doc": "How much a single repetition of the texture is offset from the beginning, in each direction U and V. Typical range is 0.0 to 1.0."
+        },
+        "name": {
+          "!type": "string",
+          "!doc": "Given name of the texture, empty string by default."
+        },
+        "generateMipmaps": {
+          "!type": "boolean",
+          "!doc": "Whether to generate mipmaps (if possible) for a texture. True by default."
+        },
+        "flipY": {
+          "!type": "boolean",
+          "!doc": "True by default. Flips the image's Y axis to match the WebGL texture coordinate space."
+        },
+        "mipmaps": {
+          "!type": "array",
+          "!doc": "Array of mipmaps generated."
+        },
+        "unpackAlignment": {
+          "!type": "number",
+          "!doc": "4 by default. Specifies the alignment requirements for the start of each pixel row in memory. The allowable values are 1 (byte-alignment), 2 (rows aligned to even-numbered bytes), 4 (word-alignment), and 8 (rows start on double-word boundaries). See <a href=\"http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml\">glPixelStorei</a> for more information."
+        },
+        "premultiplyAlpha": {
+          "!type": "boolean",
+          "!doc": "False by default, which is the norm for PNG images. Set to true if the RGB values have been stored premultiplied by alpha."
+        },
+        "onUpdate": {
+          "!type": "object",
+          "!doc": "A callback function, called when the texture is updated (e.g., when needsUpdate has been set to true and then the texture is used)."
+        }
+      },
+      "!doc": "Create a texture to apply to a surface or as a reflection or refraction map.",
+      "!type": "fn(image, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy)"
+    }
+  }
+}
+    };
+  });
+});

--- a/editor/js/libs/ternjs/comment.js
+++ b/editor/js/libs/ternjs/comment.js
@@ -1,0 +1,87 @@
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    return mod(exports);
+  if (typeof define == "function" && define.amd) // AMD
+    return define(["exports"], mod);
+  mod(tern.comment || (tern.comment = {}));
+})(function(exports) {
+  function isSpace(ch) {
+    return (ch < 14 && ch > 8) || ch === 32 || ch === 160;
+  }
+
+  function onOwnLine(text, pos) {
+    for (; pos > 0; --pos) {
+      var ch = text.charCodeAt(pos - 1);
+      if (ch == 10) break;
+      if (!isSpace(ch)) return false;
+    }
+    return true;
+  }
+
+  // Gather comments directly before a function
+  exports.commentsBefore = function(text, pos) {
+    var found = null, emptyLines = 0, topIsLineComment;
+    out: while (pos > 0) {
+      var prev = text.charCodeAt(pos - 1);
+      if (prev == 10) {
+        for (var scan = --pos, sawNonWS = false; scan > 0; --scan) {
+          prev = text.charCodeAt(scan - 1);
+          if (prev == 47 && text.charCodeAt(scan - 2) == 47) {
+            if (!onOwnLine(text, scan - 2)) break out;
+            var content = text.slice(scan, pos);
+            if (!emptyLines && topIsLineComment) found[0] = content + "\n" + found[0];
+            else (found || (found = [])).unshift(content);
+            topIsLineComment = true;
+            emptyLines = 0;
+            pos = scan - 2;
+            break;
+          } else if (prev == 10) {
+            if (!sawNonWS && ++emptyLines > 1) break out;
+            break;
+          } else if (!sawNonWS && !isSpace(prev)) {
+            sawNonWS = true;
+          }
+        }
+      } else if (prev == 47 && text.charCodeAt(pos - 2) == 42) {
+        for (var scan = pos - 2; scan > 1; --scan) {
+          if (text.charCodeAt(scan - 1) == 42 && text.charCodeAt(scan - 2) == 47) {
+            if (!onOwnLine(text, scan - 2)) break out;
+            (found || (found = [])).unshift(text.slice(scan, pos - 2));
+            topIsLineComment = false;
+            emptyLines = 0;
+            break;
+          }
+        }
+        pos = scan - 2;
+      } else if (isSpace(prev)) {
+        --pos;
+      } else {
+        break;
+      }
+    }
+    return found;
+  };
+
+  exports.commentAfter = function(text, pos) {
+    while (pos < text.length) {
+      var next = text.charCodeAt(pos);
+      if (next == 47) {
+        var after = text.charCodeAt(pos + 1), end;
+        if (after == 47) // line comment
+          end = text.indexOf("\n", pos + 2);
+        else if (after == 42) // block comment
+          end = text.indexOf("*/", pos + 2);
+        else
+          return;
+        return text.slice(pos + 2, end < 0 ? text.length : end);
+      } else if (isSpace(next)) {
+        ++pos;
+      }
+    }
+  };
+
+  exports.ensureCommentsBefore = function(text, node) {
+    if (node.hasOwnProperty("commentsBefore")) return node.commentsBefore;
+    return node.commentsBefore = exports.commentsBefore(text, node.start);
+  };
+});

--- a/editor/js/libs/ternjs/def.js
+++ b/editor/js/libs/ternjs/def.js
@@ -1,0 +1,589 @@
+// Type description parser
+//
+// Type description JSON files (such as ecma5.json and browser.json)
+// are used to
+//
+// A) describe types that come from native code
+//
+// B) to cheaply load the types for big libraries, or libraries that
+//    can't be inferred well
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    return exports.init = mod;
+  if (typeof define == "function" && define.amd) // AMD
+    return define({init: mod});
+  tern.def = {init: mod};
+})(function(exports, infer) {
+  "use strict";
+
+  function hop(obj, prop) {
+    return Object.prototype.hasOwnProperty.call(obj, prop);
+  }
+
+  var TypeParser = exports.TypeParser = function(spec, start, base, forceNew) {
+    this.pos = start || 0;
+    this.spec = spec;
+    this.base = base;
+    this.forceNew = forceNew;
+  };
+
+  function unwrapType(type, self, args) {
+    return type.call ? type(self, args) : type;
+  }
+
+  function extractProp(type, prop) {
+    if (prop == "!ret") {
+      if (type.retval) return type.retval;
+      var rv = new infer.AVal;
+      type.propagate(new infer.IsCallee(infer.ANull, [], null, rv));
+      return rv;
+    } else {
+      return type.getProp(prop);
+    }
+  }
+
+  function computedFunc(args, retType) {
+    return function(self, cArgs) {
+      var realArgs = [];
+      for (var i = 0; i < args.length; i++) realArgs.push(unwrapType(args[i], self, cArgs));
+      return new infer.Fn(name, infer.ANull, realArgs, unwrapType(retType, self, cArgs));
+    };
+  }
+  function computedUnion(types) {
+    return function(self, args) {
+      var union = new infer.AVal;
+      for (var i = 0; i < types.length; i++) unwrapType(types[i], self, args).propagate(union);
+      return union;
+    };
+  }
+  function computedArray(inner) {
+    return function(self, args) {
+      return new infer.Arr(inner(self, args));
+    };
+  }
+
+  TypeParser.prototype = {
+    eat: function(str) {
+      if (str.length == 1 ? this.spec.charAt(this.pos) == str : this.spec.indexOf(str, this.pos) == this.pos) {
+        this.pos += str.length;
+        return true;
+      }
+    },
+    word: function(re) {
+      var word = "", ch, re = re || /[\w$]/;
+      while ((ch = this.spec.charAt(this.pos)) && re.test(ch)) { word += ch; ++this.pos; }
+      return word;
+    },
+    error: function() {
+      throw new Error("Unrecognized type spec: " + this.spec + " (at " + this.pos + ")");
+    },
+    parseFnType: function(comp, name, top) {
+      var args = [], names = [], computed = false;
+      if (!this.eat(")")) for (var i = 0; ; ++i) {
+        var colon = this.spec.indexOf(": ", this.pos), argname;
+        if (colon != -1) {
+          argname = this.spec.slice(this.pos, colon);
+          if (/^[$\w?]+$/.test(argname))
+            this.pos = colon + 2;
+          else
+            argname = null;
+        }
+        names.push(argname);
+        var argType = this.parseType(comp);
+        if (argType.call) computed = true;
+        args.push(argType);
+        if (!this.eat(", ")) {
+          this.eat(")") || this.error();
+          break;
+        }
+      }
+      var retType, computeRet, computeRetStart, fn;
+      if (this.eat(" -> ")) {
+        var retStart = this.pos;
+        retType = this.parseType(true);
+        if (retType.call) {
+          if (top) {
+            computeRet = retType;
+            retType = infer.ANull;
+            computeRetStart = retStart;
+          } else {
+            computed = true;
+          }
+        }
+      } else {
+        retType = infer.ANull;
+      }
+      if (computed) return computedFunc(args, retType);
+
+      if (top && (fn = this.base))
+        infer.Fn.call(this.base, name, infer.ANull, args, names, retType);
+      else
+        fn = new infer.Fn(name, infer.ANull, args, names, retType);
+      if (computeRet) fn.computeRet = computeRet;
+      if (computeRetStart != null) fn.computeRetSource = this.spec.slice(computeRetStart, this.pos);
+      return fn;
+    },
+    parseType: function(comp, name, top) {
+      var main = this.parseTypeMaybeProp(comp, name, top);
+      if (!this.eat("|")) return main;
+      var types = [main], computed = main.call;
+      for (;;) {
+        var next = this.parseTypeMaybeProp(comp, name, top);
+        types.push(next);
+        if (next.call) computed = true;
+        if (!this.eat("|")) break;
+      }
+      if (computed) return computedUnion(types);
+      var union = new infer.AVal;
+      for (var i = 0; i < types.length; i++) types[i].propagate(union);
+      return union;
+    },
+    parseTypeMaybeProp: function(comp, name, top) {
+      var result = this.parseTypeInner(comp, name, top);
+      while (comp && this.eat(".")) result = this.extendWithProp(result);
+      return result;
+    },
+    extendWithProp: function(base) {
+      var propName = this.word(/[\w<>$!]/) || this.error();
+      if (base.apply) return function(self, args) {
+        return extractProp(base(self, args), propName);
+      };
+      return extractProp(base, propName);
+    },
+    parseTypeInner: function(comp, name, top) {
+      if (this.eat("fn(")) {
+        return this.parseFnType(comp, name, top);
+      } else if (this.eat("[")) {
+        var inner = this.parseType(comp);
+        this.eat("]") || this.error();
+        if (inner.call) return computedArray(inner);
+        if (top && this.base) {
+          infer.Arr.call(this.base, inner);
+          return this.base;
+        }
+        return new infer.Arr(inner);
+      } else if (this.eat("+")) {
+        var path = this.word(/[\w$<>\.!]/);
+        var base = parsePath(path + ".prototype");
+        var type;
+        if (!(base instanceof infer.Obj)) base = parsePath(path);
+        if (!(base instanceof infer.Obj)) return base;
+        if (comp && this.eat("[")) return this.parsePoly(base);
+        if (top && this.forceNew) return new infer.Obj(base);
+        return infer.getInstance(base);
+      } else if (comp && this.eat("!")) {
+        var arg = this.word(/\d/);
+        if (arg) {
+          arg = Number(arg);
+          return function(_self, args) {return args[arg] || infer.ANull;};
+        } else if (this.eat("this")) {
+          return function(self) {return self;};
+        } else if (this.eat("custom:")) {
+          var fname = this.word(/[\w$]/);
+          return customFunctions[fname] || function() { return infer.ANull; };
+        } else {
+          return this.fromWord("!" + this.word(/[\w$<>\.!]/));
+        }
+      } else if (this.eat("?")) {
+        return infer.ANull;
+      } else {
+        return this.fromWord(this.word(/[\w$<>\.!`]/));
+      }
+    },
+    fromWord: function(spec) {
+      var cx = infer.cx();
+      switch (spec) {
+      case "number": return cx.num;
+      case "string": return cx.str;
+      case "bool": return cx.bool;
+      case "<top>": return cx.topScope;
+      }
+      if (cx.localDefs && spec in cx.localDefs) return cx.localDefs[spec];
+      return parsePath(spec);
+    },
+    parsePoly: function(base) {
+      var propName = "<i>", match;
+      if (match = this.spec.slice(this.pos).match(/^\s*(\w+)\s*=\s*/)) {
+        propName = match[1];
+        this.pos += match[0].length;
+      }
+      var value = this.parseType(true);
+      if (!this.eat("]")) this.error();
+      if (value.call) return function(self, args) {
+        var instance = infer.getInstance(base);
+        value(self, args).propagate(instance.defProp(propName));
+        return instance;
+      };
+      var instance = infer.getInstance(base);
+      value.propagate(instance.defProp(propName));
+      return instance;
+    }
+  };
+
+  function parseType(spec, name, base, forceNew) {
+    var type = new TypeParser(spec, null, base, forceNew).parseType(false, name, true);
+    if (/^fn\(/.test(spec)) for (var i = 0; i < type.args.length; ++i) (function(i) {
+      var arg = type.args[i];
+      if (arg instanceof infer.Fn && arg.args && arg.args.length) addEffect(type, function(_self, fArgs) {
+        var fArg = fArgs[i];
+        if (fArg) fArg.propagate(new infer.IsCallee(infer.cx().topScope, arg.args, null, infer.ANull));
+      });
+    })(i);
+    return type;
+  }
+
+  function addEffect(fn, handler, replaceRet) {
+    var oldCmp = fn.computeRet, rv = fn.retval;
+    fn.computeRet = function(self, args, argNodes) {
+      var handled = handler(self, args, argNodes);
+      var old = oldCmp ? oldCmp(self, args, argNodes) : rv;
+      return replaceRet ? handled : old;
+    };
+  }
+
+  var parseEffect = exports.parseEffect = function(effect, fn) {
+    var m;
+    if (effect.indexOf("propagate ") == 0) {
+      var p = new TypeParser(effect, 10);
+      var origin = p.parseType(true);
+      if (!p.eat(" ")) p.error();
+      var target = p.parseType(true);
+      addEffect(fn, function(self, args) {
+        unwrapType(origin, self, args).propagate(unwrapType(target, self, args));
+      });
+    } else if (effect.indexOf("call ") == 0) {
+      var andRet = effect.indexOf("and return ", 5) == 5;
+      var p = new TypeParser(effect, andRet ? 16 : 5);
+      var getCallee = p.parseType(true), getSelf = null, getArgs = [];
+      if (p.eat(" this=")) getSelf = p.parseType(true);
+      while (p.eat(" ")) getArgs.push(p.parseType(true));
+      addEffect(fn, function(self, args) {
+        var callee = unwrapType(getCallee, self, args);
+        var slf = getSelf ? unwrapType(getSelf, self, args) : infer.ANull, as = [];
+        for (var i = 0; i < getArgs.length; ++i) as.push(unwrapType(getArgs[i], self, args));
+        var result = andRet ? new infer.AVal : infer.ANull;
+        callee.propagate(new infer.IsCallee(slf, as, null, result));
+        return result;
+      }, andRet);
+    } else if (m = effect.match(/^custom (\S+)\s*(.*)/)) {
+      var customFunc = customFunctions[m[1]];
+      if (customFunc) addEffect(fn, m[2] ? customFunc(m[2]) : customFunc);
+    } else if (effect.indexOf("copy ") == 0) {
+      var p = new TypeParser(effect, 5);
+      var getFrom = p.parseType(true);
+      p.eat(" ");
+      var getTo = p.parseType(true);
+      addEffect(fn, function(self, args) {
+        var from = unwrapType(getFrom, self, args), to = unwrapType(getTo, self, args);
+        from.forAllProps(function(prop, val, local) {
+          if (local && prop != "<i>")
+            to.propagate(new infer.PropHasSubset(prop, val));
+        });
+      });
+    } else {
+      throw new Error("Unknown effect type: " + effect);
+    }
+  };
+
+  var currentTopScope;
+
+  var parsePath = exports.parsePath = function(path, scope) {
+    var cx = infer.cx(), cached = cx.paths[path], origPath = path;
+    if (cached != null) return cached;
+    cx.paths[path] = infer.ANull;
+
+    var base = scope || currentTopScope || cx.topScope;
+
+    if (cx.localDefs) for (var name in cx.localDefs) {
+      if (path.indexOf(name) == 0) {
+        if (path == name) return cx.paths[path] = cx.localDefs[path];
+        if (path.charAt(name.length) == ".") {
+          base = cx.localDefs[name];
+          path = path.slice(name.length + 1);
+          break;
+        }
+      }
+    }
+
+    var parts = path.split(".");
+    for (var i = 0; i < parts.length && base != infer.ANull; ++i) {
+      var prop = parts[i];
+      if (prop.charAt(0) == "!") {
+        if (prop == "!proto") {
+          base = (base instanceof infer.Obj && base.proto) || infer.ANull;
+        } else {
+          var fn = base.getFunctionType();
+          if (!fn) {
+            base = infer.ANull;
+          } else if (prop == "!ret") {
+            base = fn.retval && fn.retval.getType(false) || infer.ANull;
+          } else {
+            var arg = fn.args && fn.args[Number(prop.slice(1))];
+            base = (arg && arg.getType(false)) || infer.ANull;
+          }
+        }
+      } else if (base instanceof infer.Obj) {
+        var propVal = (prop == "prototype" && base instanceof infer.Fn) ? base.getProp(prop) : base.props[prop];
+        if (!propVal || propVal.isEmpty())
+          base = infer.ANull;
+        else
+          base = propVal.types[0];
+      }
+    }
+    // Uncomment this to get feedback on your poorly written .json files
+    // if (base == infer.ANull) console.error("bad path: " + origPath + " (" + cx.curOrigin + ")");
+    cx.paths[origPath] = base == infer.ANull ? null : base;
+    return base;
+  };
+
+  function emptyObj(ctor) {
+    var empty = Object.create(ctor.prototype);
+    empty.props = Object.create(null);
+    empty.isShell = true;
+    return empty;
+  }
+
+  function isSimpleAnnotation(spec) {
+    if (!spec["!type"] || /^(fn\(|\[)/.test(spec["!type"])) return false;
+    for (var prop in spec)
+      if (prop != "!type" && prop != "!doc" && prop != "!url" && prop != "!span" && prop != "!data")
+        return false;
+    return true;
+  }
+
+  function passOne(base, spec, path) {
+    if (!base) {
+      var tp = spec["!type"];
+      if (tp) {
+        if (/^fn\(/.test(tp)) base = emptyObj(infer.Fn);
+        else if (tp.charAt(0) == "[") base = emptyObj(infer.Arr);
+        else throw new Error("Invalid !type spec: " + tp);
+      } else if (spec["!stdProto"]) {
+        base = infer.cx().protos[spec["!stdProto"]];
+      } else {
+        base = emptyObj(infer.Obj);
+      }
+      base.name = path;
+    }
+
+    for (var name in spec) if (hop(spec, name) && name.charCodeAt(0) != 33) {
+      var inner = spec[name];
+      if (typeof inner == "string" || isSimpleAnnotation(inner)) continue;
+      var prop = base.defProp(name);
+      passOne(prop.getObjType(), inner, path ? path + "." + name : name).propagate(prop);
+    }
+    return base;
+  }
+
+  function passTwo(base, spec, path) {
+    if (base.isShell) {
+      delete base.isShell;
+      var tp = spec["!type"];
+      if (tp) {
+        parseType(tp, path, base);
+      } else {
+        var proto = spec["!proto"] && parseType(spec["!proto"]);
+        infer.Obj.call(base, proto instanceof infer.Obj ? proto : true, path);
+      }
+    }
+
+    var effects = spec["!effects"];
+    if (effects && base instanceof infer.Fn) for (var i = 0; i < effects.length; ++i)
+      parseEffect(effects[i], base);
+    copyInfo(spec, base);
+
+    for (var name in spec) if (hop(spec, name) && name.charCodeAt(0) != 33) {
+      var inner = spec[name], known = base.defProp(name), innerPath = path ? path + "." + name : name;
+      if (typeof inner == "string") {
+        if (known.isEmpty()) parseType(inner, innerPath).propagate(known);
+      } else {
+        if (!isSimpleAnnotation(inner))
+          passTwo(known.getObjType(), inner, innerPath);
+        else if (known.isEmpty())
+          parseType(inner["!type"], innerPath, null, true).propagate(known);
+        else
+          continue;
+        if (inner["!doc"]) known.doc = inner["!doc"];
+        if (inner["!url"]) known.url = inner["!url"];
+        if (inner["!span"]) known.span = inner["!span"];
+      }
+    }
+    return base;
+  }
+
+  function copyInfo(spec, type) {
+    if (spec["!doc"]) type.doc = spec["!doc"];
+    if (spec["!url"]) type.url = spec["!url"];
+    if (spec["!span"]) type.span = spec["!span"];
+    if (spec["!data"]) type.metaData = spec["!data"];
+  }
+
+  function runPasses(type, arg) {
+    var parent = infer.cx().parent, pass = parent && parent.passes && parent.passes[type];
+    if (pass) for (var i = 0; i < pass.length; i++) pass[i](arg);
+  }
+
+  function doLoadEnvironment(data, scope) {
+    var cx = infer.cx();
+
+    infer.addOrigin(cx.curOrigin = data["!name"] || "env#" + cx.origins.length);
+    cx.localDefs = cx.definitions[cx.curOrigin] = Object.create(null);
+
+    runPasses("preLoadDef", data);
+
+    passOne(scope, data);
+
+    var def = data["!define"];
+    if (def) {
+      for (var name in def) {
+        var spec = def[name];
+        cx.localDefs[name] = typeof spec == "string" ? parsePath(spec) : passOne(null, spec, name);
+      }
+      for (var name in def) {
+        var spec = def[name];
+        if (typeof spec != "string") passTwo(cx.localDefs[name], def[name], name);
+      }
+    }
+
+    passTwo(scope, data);
+
+    runPasses("postLoadDef", data);
+
+    cx.curOrigin = cx.localDefs = null;
+  }
+
+  exports.load = function(data, scope) {
+    if (!scope) scope = infer.cx().topScope;
+    var oldScope = currentTopScope;
+    currentTopScope = scope;
+    try {
+      doLoadEnvironment(data, scope);
+    } finally {
+      currentTopScope = oldScope;
+    }
+  };
+
+  exports.parse = function(data, origin, path) {
+    var cx = infer.cx();
+    if (origin) {
+      cx.origin = origin;
+      cx.localDefs = cx.definitions[origin];
+    }
+
+    try {
+      if (typeof data == "string")
+        return parseType(data, path);
+      else
+        return passTwo(passOne(null, data, path), data, path);
+    } finally {
+      if (origin) cx.origin = cx.localDefs = null;
+    }
+  };
+
+  // Used to register custom logic for more involved effect or type
+  // computation.
+  var customFunctions = Object.create(null);
+  infer.registerFunction = function(name, f) { customFunctions[name] = f; };
+
+  var IsCreated = infer.constraint("created, target, spec", {
+    addType: function(tp) {
+      if (tp instanceof infer.Obj && this.created++ < 5) {
+        var derived = new infer.Obj(tp), spec = this.spec;
+        if (spec instanceof infer.AVal) spec = spec.getObjType(false);
+        if (spec instanceof infer.Obj) for (var prop in spec.props) {
+          var cur = spec.props[prop].types[0];
+          var p = derived.defProp(prop);
+          if (cur && cur instanceof infer.Obj && cur.props.value) {
+            var vtp = cur.props.value.getType(false);
+            if (vtp) p.addType(vtp);
+          }
+        }
+        this.target.addType(derived);
+      }
+    }
+  });
+
+  infer.registerFunction("Object_create", function(_self, args, argNodes) {
+    if (argNodes && argNodes.length && argNodes[0].type == "Literal" && argNodes[0].value == null)
+      return new infer.Obj();
+
+    var result = new infer.AVal;
+    if (args[0]) args[0].propagate(new IsCreated(0, result, args[1]));
+    return result;
+  });
+
+  var PropSpec = infer.constraint("target", {
+    addType: function(tp) {
+      if (!(tp instanceof infer.Obj)) return;
+      if (tp.hasProp("value"))
+        tp.getProp("value").propagate(this.target);
+      else if (tp.hasProp("get"))
+        tp.getProp("get").propagate(new infer.IsCallee(infer.ANull, [], null, this.target));
+    }
+  });
+
+  infer.registerFunction("Object_defineProperty", function(_self, args, argNodes) {
+    if (argNodes && argNodes.length >= 3 && argNodes[1].type == "Literal" &&
+        typeof argNodes[1].value == "string") {
+      var obj = args[0], connect = new infer.AVal;
+      obj.propagate(new infer.PropHasSubset(argNodes[1].value, connect, argNodes[1]));
+      args[2].propagate(new PropSpec(connect));
+    }
+    return infer.ANull;
+  });
+
+  infer.registerFunction("Object_defineProperties", function(_self, args, argNodes) {
+    if (args.length >= 2) {
+      var obj = args[0];
+      args[1].forAllProps(function(prop, val, local) {
+        if (!local) return;
+        var connect = new infer.AVal;
+        obj.propagate(new infer.PropHasSubset(prop, connect, argNodes && argNodes[1]));
+        val.propagate(new PropSpec(connect));
+      });
+    }
+    return infer.ANull;
+  });
+
+  var IsBound = infer.constraint("self, args, target", {
+    addType: function(tp) {
+      if (!(tp instanceof infer.Fn)) return;
+      this.target.addType(new infer.Fn(tp.name, infer.ANull, tp.args.slice(this.args.length),
+                                       tp.argNames.slice(this.args.length), tp.retval));
+      this.self.propagate(tp.self);
+      for (var i = 0; i < Math.min(tp.args.length, this.args.length); ++i)
+        this.args[i].propagate(tp.args[i]);
+    }
+  });
+
+  infer.registerFunction("Function_bind", function(self, args) {
+    if (!args.length) return infer.ANull;
+    var result = new infer.AVal;
+    self.propagate(new IsBound(args[0], args.slice(1), result));
+    return result;
+  });
+
+  infer.registerFunction("Array_ctor", function(_self, args) {
+    var arr = new infer.Arr;
+    if (args.length != 1 || !args[0].hasType(infer.cx().num)) {
+      var content = arr.getProp("<i>");
+      for (var i = 0; i < args.length; ++i) args[i].propagate(content);
+    }
+    return arr;
+  });
+
+  infer.registerFunction("Promise_ctor", function(_self, args, argNodes) {
+    if (args.length < 1) return infer.ANull;
+    var self = new infer.Obj(infer.cx().definitions.ecma6["Promise.prototype"]);
+    var valProp = self.defProp("value", argNodes && argNodes[0]);
+    var valArg = new infer.AVal;
+    valArg.propagate(valProp);
+    var exec = new infer.Fn("execute", infer.ANull, [valArg], ["value"], infer.ANull);
+    var reject = infer.cx().definitions.ecma6.promiseReject;
+    args[0].propagate(new infer.IsCallee(infer.ANull, [exec, reject], null, infer.ANull));
+    return self;
+  });
+
+  return exports;
+});

--- a/editor/js/libs/ternjs/doc_comment.js
+++ b/editor/js/libs/ternjs/doc_comment.js
@@ -1,0 +1,402 @@
+// Parses comments above variable declarations, function declarations,
+// and object properties as docstrings and JSDoc-style type
+// annotations.
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    return mod(require("../lib/infer"), require("../lib/tern"), require("../lib/comment"),
+               require("acorn"), require("acorn/dist/walk"));
+  if (typeof define == "function" && define.amd) // AMD
+    return define(["../lib/infer", "../lib/tern", "../lib/comment", "acorn/dist/acorn", "acorn/dist/walk"], mod);
+  mod(tern, tern, tern.comment, acorn, acorn.walk);
+})(function(infer, tern, comment, acorn, walk) {
+  "use strict";
+
+  var WG_MADEUP = 1, WG_STRONG = 101;
+
+  tern.registerPlugin("doc_comment", function(server, options) {
+    server.jsdocTypedefs = Object.create(null);
+    server.on("reset", function() {
+      server.jsdocTypedefs = Object.create(null);
+    });
+    server._docComment = {
+      weight: options && options.strong ? WG_STRONG : undefined,
+      fullDocs: options && options.fullDocs
+    };
+
+    return {
+      passes: {
+        postParse: postParse,
+        postInfer: postInfer,
+        postLoadDef: postLoadDef
+      }
+    };
+  });
+
+  function postParse(ast, text) {
+    function attachComments(node) { comment.ensureCommentsBefore(text, node); }
+
+    walk.simple(ast, {
+      VariableDeclaration: attachComments,
+      FunctionDeclaration: attachComments,
+      AssignmentExpression: function(node) {
+        if (node.operator == "=") attachComments(node);
+      },
+      ObjectExpression: function(node) {
+        for (var i = 0; i < node.properties.length; ++i)
+          attachComments(node.properties[i]);
+      },
+      CallExpression: function(node) {
+        if (isDefinePropertyCall(node)) attachComments(node);
+      }
+    });
+  }
+
+  function isDefinePropertyCall(node) {
+    return node.callee.type == "MemberExpression" &&
+      node.callee.object.name == "Object" &&
+      node.callee.property.name == "defineProperty" &&
+      node.arguments.length >= 3 &&
+      typeof node.arguments[1].value == "string";
+  }
+
+  function postInfer(ast, scope) {
+    jsdocParseTypedefs(ast.sourceFile.text, scope);
+
+    walk.simple(ast, {
+      VariableDeclaration: function(node, scope) {
+        if (node.commentsBefore)
+          interpretComments(node, node.commentsBefore, scope,
+                            scope.getProp(node.declarations[0].id.name));
+      },
+      FunctionDeclaration: function(node, scope) {
+        if (node.commentsBefore)
+          interpretComments(node, node.commentsBefore, scope,
+                            scope.getProp(node.id.name),
+                            node.body.scope.fnType);
+      },
+      AssignmentExpression: function(node, scope) {
+        if (node.commentsBefore)
+          interpretComments(node, node.commentsBefore, scope,
+                            infer.expressionType({node: node.left, state: scope}));
+      },
+      ObjectExpression: function(node, scope) {
+        for (var i = 0; i < node.properties.length; ++i) {
+          var prop = node.properties[i];
+          if (prop.commentsBefore)
+            interpretComments(prop, prop.commentsBefore, scope,
+                              node.objType.getProp(prop.key.name));
+        }
+      },
+      CallExpression: function(node, scope) {
+        if (node.commentsBefore && isDefinePropertyCall(node)) {
+          var type = infer.expressionType({node: node.arguments[0], state: scope}).getObjType();
+          if (type && type instanceof infer.Obj) {
+            var prop = type.props[node.arguments[1].value];
+            if (prop) interpretComments(node, node.commentsBefore, scope, prop);
+          }
+        }
+      }
+    }, infer.searchVisitor, scope);
+  }
+
+  function postLoadDef(data) {
+    var defs = data["!typedef"];
+    var cx = infer.cx(), orig = data["!name"];
+    if (defs) for (var name in defs)
+      cx.parent.jsdocTypedefs[name] =
+        maybeInstance(infer.def.parse(defs[name], orig, name), name);
+  }
+
+  // COMMENT INTERPRETATION
+
+  function interpretComments(node, comments, scope, aval, type) {
+    jsdocInterpretComments(node, scope, aval, comments);
+    var cx = infer.cx();
+
+    if (!type && aval instanceof infer.AVal && aval.types.length) {
+      type = aval.types[aval.types.length - 1];
+      if (!(type instanceof infer.Obj) || type.origin != cx.curOrigin || type.doc)
+        type = null;
+    }
+
+    var result = comments[comments.length - 1];
+    if (cx.parent._docComment.fullDocs) {
+      result = result.trim().replace(/\n[ \t]*\* ?/g, "\n");
+    } else {
+      var dot = result.search(/\.\s/);
+      if (dot > 5) result = result.slice(0, dot + 1);
+      result = result.trim().replace(/\s*\n\s*\*\s*|\s{1,}/g, " ");
+    }
+    result = result.replace(/^\s*\*+\s*/, "");
+
+    if (aval instanceof infer.AVal) aval.doc = result;
+    if (type) type.doc = result;
+  }
+
+  // Parses a subset of JSDoc-style comments in order to include the
+  // explicitly defined types in the analysis.
+
+  function skipSpace(str, pos) {
+    while (/\s/.test(str.charAt(pos))) ++pos;
+    return pos;
+  }
+
+  function isIdentifier(string) {
+    if (!acorn.isIdentifierStart(string.charCodeAt(0))) return false;
+    for (var i = 1; i < string.length; i++)
+      if (!acorn.isIdentifierChar(string.charCodeAt(i))) return false;
+    return true;
+  }
+
+  function parseLabelList(scope, str, pos, close) {
+    var labels = [], types = [], madeUp = false;
+    for (var first = true; ; first = false) {
+      pos = skipSpace(str, pos);
+      if (first && str.charAt(pos) == close) break;
+      var colon = str.indexOf(":", pos);
+      if (colon < 0) return null;
+      var label = str.slice(pos, colon);
+      if (!isIdentifier(label)) return null;
+      labels.push(label);
+      pos = colon + 1;
+      var type = parseType(scope, str, pos);
+      if (!type) return null;
+      pos = type.end;
+      madeUp = madeUp || type.madeUp;
+      types.push(type.type);
+      pos = skipSpace(str, pos);
+      var next = str.charAt(pos);
+      ++pos;
+      if (next == close) break;
+      if (next != ",") return null;
+    }
+    return {labels: labels, types: types, end: pos, madeUp: madeUp};
+  }
+
+  function parseType(scope, str, pos) {
+    var type, union = false, madeUp = false;
+    for (;;) {
+      var inner = parseTypeInner(scope, str, pos);
+      if (!inner) return null;
+      madeUp = madeUp || inner.madeUp;
+      if (union) inner.type.propagate(union);
+      else type = inner.type;
+      pos = skipSpace(str, inner.end);
+      if (str.charAt(pos) != "|") break;
+      pos++;
+      if (!union) {
+        union = new infer.AVal;
+        type.propagate(union);
+        type = union;
+      }
+    }
+    var isOptional = false;
+    if (str.charAt(pos) == "=") {
+      ++pos;
+      isOptional = true;
+    }
+    return {type: type, end: pos, isOptional: isOptional, madeUp: madeUp};
+  }
+
+  function parseTypeInner(scope, str, pos) {
+    pos = skipSpace(str, pos);
+    var type, madeUp = false;
+
+    if (str.indexOf("function(", pos) == pos) {
+      var args = parseLabelList(scope, str, pos + 9, ")"), ret = infer.ANull;
+      if (!args) return null;
+      pos = skipSpace(str, args.end);
+      if (str.charAt(pos) == ":") {
+        ++pos;
+        var retType = parseType(scope, str, pos + 1);
+        if (!retType) return null;
+        pos = retType.end;
+        ret = retType.type;
+        madeUp = retType.madeUp;
+      }
+      type = new infer.Fn(null, infer.ANull, args.types, args.labels, ret);
+    } else if (str.charAt(pos) == "[") {
+      var inner = parseType(scope, str, pos + 1);
+      if (!inner) return null;
+      pos = skipSpace(str, inner.end);
+      madeUp = inner.madeUp;
+      if (str.charAt(pos) != "]") return null;
+      ++pos;
+      type = new infer.Arr(inner.type);
+    } else if (str.charAt(pos) == "{") {
+      var fields = parseLabelList(scope, str, pos + 1, "}");
+      if (!fields) return null;
+      type = new infer.Obj(true);
+      for (var i = 0; i < fields.types.length; ++i) {
+        var field = type.defProp(fields.labels[i]);
+        field.initializer = true;
+        fields.types[i].propagate(field);
+      }
+      pos = fields.end;
+      madeUp = fields.madeUp;
+    } else if (str.charAt(pos) == "(") {
+      var inner = parseType(scope, str, pos + 1);
+      if (!inner) return null;
+      pos = skipSpace(str, inner.end);
+      if (str.charAt(pos) != ")") return null;
+      ++pos;
+      type = inner.type;
+    } else {
+      var start = pos;
+      if (!acorn.isIdentifierStart(str.charCodeAt(pos))) return null;
+      while (acorn.isIdentifierChar(str.charCodeAt(pos))) ++pos;
+      if (start == pos) return null;
+      var word = str.slice(start, pos);
+      if (/^(number|integer)$/i.test(word)) type = infer.cx().num;
+      else if (/^bool(ean)?$/i.test(word)) type = infer.cx().bool;
+      else if (/^string$/i.test(word)) type = infer.cx().str;
+      else if (/^(null|undefined)$/i.test(word)) type = infer.ANull;
+      else if (/^array$/i.test(word)) {
+        var inner = null;
+        if (str.charAt(pos) == "." && str.charAt(pos + 1) == "<") {
+          var inAngles = parseType(scope, str, pos + 2);
+          if (!inAngles) return null;
+          pos = skipSpace(str, inAngles.end);
+          madeUp = inAngles.madeUp;
+          if (str.charAt(pos++) != ">") return null;
+          inner = inAngles.type;
+        }
+        type = new infer.Arr(inner);
+      } else if (/^object$/i.test(word)) {
+        type = new infer.Obj(true);
+        if (str.charAt(pos) == "." && str.charAt(pos + 1) == "<") {
+          var key = parseType(scope, str, pos + 2);
+          if (!key) return null;
+          pos = skipSpace(str, key.end);
+          madeUp = madeUp || key.madeUp;
+          if (str.charAt(pos++) != ",") return null;
+          var val = parseType(scope, str, pos);
+          if (!val) return null;
+          pos = skipSpace(str, val.end);
+          madeUp = key.madeUp || val.madeUp;
+          if (str.charAt(pos++) != ">") return null;
+          val.type.propagate(type.defProp("<i>"));
+        }
+      } else {
+        while (str.charCodeAt(pos) == 46 ||
+               acorn.isIdentifierChar(str.charCodeAt(pos))) ++pos;
+        var path = str.slice(start, pos);
+        var cx = infer.cx(), defs = cx.parent && cx.parent.jsdocTypedefs, found;
+        if (defs && (path in defs)) {
+          type = defs[path];
+        } else if (found = infer.def.parsePath(path, scope).getObjType()) {
+          type = maybeInstance(found, path);
+        } else {
+          if (!cx.jsdocPlaceholders) cx.jsdocPlaceholders = Object.create(null);
+          if (!(path in cx.jsdocPlaceholders))
+            type = cx.jsdocPlaceholders[path] = new infer.Obj(null, path);
+          else
+            type = cx.jsdocPlaceholders[path];
+          madeUp = true;
+        }
+      }
+    }
+
+    return {type: type, end: pos, madeUp: madeUp};
+  }
+
+  function maybeInstance(type, path) {
+    if (type instanceof infer.Fn && /^[A-Z]/.test(path)) {
+      var proto = type.getProp("prototype").getObjType();
+      if (proto instanceof infer.Obj) return infer.getInstance(proto);
+    }
+    return type;
+  }
+
+  function parseTypeOuter(scope, str, pos) {
+    pos = skipSpace(str, pos || 0);
+    if (str.charAt(pos) != "{") return null;
+    var result = parseType(scope, str, pos + 1);
+    if (!result) return null;
+    var end = skipSpace(str, result.end);
+    if (str.charAt(end) != "}") return null;
+    result.end = end + 1;
+    return result;
+  }
+
+  function jsdocInterpretComments(node, scope, aval, comments) {
+    var type, args, ret, foundOne, self, parsed;
+
+    for (var i = 0; i < comments.length; ++i) {
+      var comment = comments[i];
+      var decl = /(?:\n|$|\*)\s*@(type|param|arg(?:ument)?|returns?|this)\s+(.*)/g, m;
+      while (m = decl.exec(comment)) {
+        if (m[1] == "this" && (parsed = parseType(scope, m[2], 0))) {
+          self = parsed;
+          foundOne = true;
+          continue;
+        }
+
+        if (!(parsed = parseTypeOuter(scope, m[2]))) continue;
+        foundOne = true;
+
+        switch(m[1]) {
+        case "returns": case "return":
+          ret = parsed; break;
+        case "type":
+          type = parsed; break;
+        case "param": case "arg": case "argument":
+            var name = m[2].slice(parsed.end).match(/^\s*(\[?)\s*([^\]\s=]+)\s*(?:=[^\]]+\s*)?(\]?).*/);
+            if (!name) continue;
+            var argname = name[2] + (parsed.isOptional || (name[1] === '[' && name[3] === ']') ? "?" : "");
+          (args || (args = Object.create(null)))[argname] = parsed;
+          break;
+        }
+      }
+    }
+
+    if (foundOne) applyType(type, self, args, ret, node, aval);
+  };
+
+  function jsdocParseTypedefs(text, scope) {
+    var cx = infer.cx();
+
+    var re = /\s@typedef\s+(.*)/g, m;
+    while (m = re.exec(text)) {
+      var parsed = parseTypeOuter(scope, m[1]);
+      var name = parsed && m[1].slice(parsed.end).match(/^\s*(\S+)/);
+      if (name)
+        cx.parent.jsdocTypedefs[name[1]] = parsed.type;
+    }
+  }
+
+  function propagateWithWeight(type, target) {
+    var weight = infer.cx().parent._docComment.weight;
+    type.type.propagate(target, weight || (type.madeUp ? WG_MADEUP : undefined));
+  }
+
+  function applyType(type, self, args, ret, node, aval) {
+    var fn;
+    if (node.type == "VariableDeclaration") {
+      var decl = node.declarations[0];
+      if (decl.init && decl.init.type == "FunctionExpression") fn = decl.init.body.scope.fnType;
+    } else if (node.type == "FunctionDeclaration") {
+      fn = node.body.scope.fnType;
+    } else if (node.type == "AssignmentExpression") {
+      if (node.right.type == "FunctionExpression")
+        fn = node.right.body.scope.fnType;
+    } else if (node.type == "CallExpression") {
+    } else { // An object property
+      if (node.value.type == "FunctionExpression") fn = node.value.body.scope.fnType;
+    }
+
+    if (fn && (args || ret || self)) {
+      if (args) for (var i = 0; i < fn.argNames.length; ++i) {
+        var name = fn.argNames[i], known = args[name];
+        if (!known && (known = args[name + "?"]))
+          fn.argNames[i] += "?";
+        if (known) propagateWithWeight(known, fn.args[i]);
+      }
+      if (ret) propagateWithWeight(ret, fn.retval);
+      if (self) propagateWithWeight(self, fn.self);
+    } else if (type) {
+      propagateWithWeight(type, aval);
+    }
+  };
+});

--- a/editor/js/libs/ternjs/infer.js
+++ b/editor/js/libs/ternjs/infer.js
@@ -1,0 +1,1635 @@
+// Main type inference engine
+
+// Walks an AST, building up a graph of abstract values and constraints
+// that cause types to flow from one node to another. Also defines a
+// number of utilities for accessing ASTs and scopes.
+
+// Analysis is done in a context, which is tracked by the dynamically
+// bound cx variable. Use withContext to set the current context.
+
+// For memory-saving reasons, individual types export an interface
+// similar to abstract values (which can hold multiple types), and can
+// thus be used in place abstract values that only ever contain a
+// single type.
+
+(function(root, mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    return mod(exports, require("acorn"), require("acorn/dist/acorn_loose"), require("acorn/dist/walk"),
+               require("./def"), require("./signal"));
+  if (typeof define == "function" && define.amd) // AMD
+    return define(["exports", "acorn/dist/acorn", "acorn/dist/acorn_loose", "acorn/dist/walk", "./def", "./signal"], mod);
+  mod(root.tern || (root.tern = {}), acorn, acorn, acorn.walk, tern.def, tern.signal); // Plain browser env
+})(this, function(exports, acorn, acorn_loose, walk, def, signal) {
+  "use strict";
+
+  var toString = exports.toString = function(type, maxDepth, parent) {
+    if (!type || type == parent || maxDepth && maxDepth < -3) return "?";
+    return type.toString(maxDepth, parent);
+  };
+
+  // A variant of AVal used for unknown, dead-end values. Also serves
+  // as prototype for AVals, Types, and Constraints because it
+  // implements 'empty' versions of all the methods that the code
+  // expects.
+  var ANull = exports.ANull = signal.mixin({
+    addType: function() {},
+    propagate: function() {},
+    getProp: function() { return ANull; },
+    forAllProps: function() {},
+    hasType: function() { return false; },
+    isEmpty: function() { return true; },
+    getFunctionType: function() {},
+    getObjType: function() {},
+    getType: function() {},
+    gatherProperties: function() {},
+    propagatesTo: function() {},
+    typeHint: function() {},
+    propHint: function() {},
+    toString: function() { return "?"; }
+  });
+
+  function extend(proto, props) {
+    var obj = Object.create(proto);
+    if (props) for (var prop in props) obj[prop] = props[prop];
+    return obj;
+  }
+
+  // ABSTRACT VALUES
+
+  var WG_DEFAULT = 100, WG_NEW_INSTANCE = 90, WG_MADEUP_PROTO = 10, WG_MULTI_MEMBER = 5,
+      WG_CATCH_ERROR = 5, WG_GLOBAL_THIS = 90, WG_SPECULATIVE_THIS = 2;
+
+  var AVal = exports.AVal = function() {
+    this.types = [];
+    this.forward = null;
+    this.maxWeight = 0;
+  };
+  AVal.prototype = extend(ANull, {
+    addType: function(type, weight) {
+      weight = weight || WG_DEFAULT;
+      if (this.maxWeight < weight) {
+        this.maxWeight = weight;
+        if (this.types.length == 1 && this.types[0] == type) return;
+        this.types.length = 0;
+      } else if (this.maxWeight > weight || this.types.indexOf(type) > -1) {
+        return;
+      }
+
+      this.signal("addType", type);
+      this.types.push(type);
+      var forward = this.forward;
+      if (forward) withWorklist(function(add) {
+        for (var i = 0; i < forward.length; ++i) add(type, forward[i], weight);
+      });
+    },
+
+    propagate: function(target, weight) {
+      if (target == ANull || (target instanceof Type && this.forward && this.forward.length > 2)) return;
+      if (weight && weight != WG_DEFAULT) target = new Muffle(target, weight);
+      (this.forward || (this.forward = [])).push(target);
+      var types = this.types;
+      if (types.length) withWorklist(function(add) {
+        for (var i = 0; i < types.length; ++i) add(types[i], target, weight);
+      });
+    },
+
+    getProp: function(prop) {
+      if (prop == "__proto__" || prop == "✖") return ANull;
+      var found = (this.props || (this.props = Object.create(null)))[prop];
+      if (!found) {
+        found = this.props[prop] = new AVal;
+        this.propagate(new PropIsSubset(prop, found));
+      }
+      return found;
+    },
+
+    forAllProps: function(c) {
+      this.propagate(new ForAllProps(c));
+    },
+
+    hasType: function(type) {
+      return this.types.indexOf(type) > -1;
+    },
+    isEmpty: function() { return this.types.length === 0; },
+    getFunctionType: function() {
+      for (var i = this.types.length - 1; i >= 0; --i)
+        if (this.types[i] instanceof Fn) return this.types[i];
+    },
+    getObjType: function() {
+      var seen = null;
+      for (var i = this.types.length - 1; i >= 0; --i) {
+        var type = this.types[i];
+        if (!(type instanceof Obj)) continue;
+        if (type.name) return type;
+        if (!seen) seen = type;
+      }
+      return seen;
+    },
+
+    getType: function(guess) {
+      if (this.types.length === 0 && guess !== false) return this.makeupType();
+      if (this.types.length === 1) return this.types[0];
+      return canonicalType(this.types);
+    },
+
+    toString: function(maxDepth, parent) {
+      if (this.types.length == 0) return toString(this.makeupType(), maxDepth, parent);
+      if (this.types.length == 1) return toString(this.types[0], maxDepth, parent);
+      var simplified = simplifyTypes(this.types);
+      if (simplified.length > 2) return "?";
+      return simplified.map(function(tp) { return toString(tp, maxDepth, parent); }).join("|");
+    },
+
+    computedPropType: function() {
+      if (!this.propertyOf) return null;
+      if (this.propertyOf.hasProp("<i>")) {
+        var computedProp = this.propertyOf.getProp("<i>");
+        if (computedProp == this) return null;
+        return computedProp.getType();
+      } else if (this.propertyOf.maybeProps && this.propertyOf.maybeProps["<i>"] == this) {
+        for (var prop in this.propertyOf.props) {
+          var val = this.propertyOf.props[prop];
+          if (!val.isEmpty()) return val;
+        }
+        return null;
+      }
+    },
+
+    makeupType: function() {
+      var computed = this.computedPropType();
+      if (computed) return computed;
+
+      if (!this.forward) return null;
+      for (var i = this.forward.length - 1; i >= 0; --i) {
+        var hint = this.forward[i].typeHint();
+        if (hint && !hint.isEmpty()) {guessing = true; return hint;}
+      }
+
+      var props = Object.create(null), foundProp = null;
+      for (var i = 0; i < this.forward.length; ++i) {
+        var prop = this.forward[i].propHint();
+        if (prop && prop != "length" && prop != "<i>" && prop != "✖" && prop != cx.completingProperty) {
+          props[prop] = true;
+          foundProp = prop;
+        }
+      }
+      if (!foundProp) return null;
+
+      var objs = objsWithProp(foundProp);
+      if (objs) {
+        var matches = [];
+        search: for (var i = 0; i < objs.length; ++i) {
+          var obj = objs[i];
+          for (var prop in props) if (!obj.hasProp(prop)) continue search;
+          if (obj.hasCtor) obj = getInstance(obj);
+          matches.push(obj);
+        }
+        var canon = canonicalType(matches);
+        if (canon) {guessing = true; return canon;}
+      }
+    },
+
+    typeHint: function() { return this.types.length ? this.getType() : null; },
+    propagatesTo: function() { return this; },
+
+    gatherProperties: function(f, depth) {
+      for (var i = 0; i < this.types.length; ++i)
+        this.types[i].gatherProperties(f, depth);
+    },
+
+    guessProperties: function(f) {
+      if (this.forward) for (var i = 0; i < this.forward.length; ++i) {
+        var prop = this.forward[i].propHint();
+        if (prop) f(prop, null, 0);
+      }
+      var guessed = this.makeupType();
+      if (guessed) guessed.gatherProperties(f);
+    }
+  });
+
+  function similarAVal(a, b, depth) {
+    var typeA = a.getType(false), typeB = b.getType(false);
+    if (!typeA || !typeB) return true;
+    return similarType(typeA, typeB, depth);
+  }
+
+  function similarType(a, b, depth) {
+    if (!a || depth >= 5) return b;
+    if (!a || a == b) return a;
+    if (!b) return a;
+    if (a.constructor != b.constructor) return false;
+    if (a.constructor == Arr) {
+      var innerA = a.getProp("<i>").getType(false);
+      if (!innerA) return b;
+      var innerB = b.getProp("<i>").getType(false);
+      if (!innerB || similarType(innerA, innerB, depth + 1)) return b;
+    } else if (a.constructor == Obj) {
+      var propsA = 0, propsB = 0, same = 0;
+      for (var prop in a.props) {
+        propsA++;
+        if (prop in b.props && similarAVal(a.props[prop], b.props[prop], depth + 1))
+          same++;
+      }
+      for (var prop in b.props) propsB++;
+      if (propsA && propsB && same < Math.max(propsA, propsB) / 2) return false;
+      return propsA > propsB ? a : b;
+    } else if (a.constructor == Fn) {
+      if (a.args.length != b.args.length ||
+          !a.args.every(function(tp, i) { return similarAVal(tp, b.args[i], depth + 1); }) ||
+          !similarAVal(a.retval, b.retval, depth + 1) || !similarAVal(a.self, b.self, depth + 1))
+        return false;
+      return a;
+    } else {
+      return false;
+    }
+  }
+
+  var simplifyTypes = exports.simplifyTypes = function(types) {
+    var found = [];
+    outer: for (var i = 0; i < types.length; ++i) {
+      var tp = types[i];
+      for (var j = 0; j < found.length; j++) {
+        var similar = similarType(tp, found[j], 0);
+        if (similar) {
+          found[j] = similar;
+          continue outer;
+        }
+      }
+      found.push(tp);
+    }
+    return found;
+  };
+
+  function canonicalType(types) {
+    var arrays = 0, fns = 0, objs = 0, prim = null;
+    for (var i = 0; i < types.length; ++i) {
+      var tp = types[i];
+      if (tp instanceof Arr) ++arrays;
+      else if (tp instanceof Fn) ++fns;
+      else if (tp instanceof Obj) ++objs;
+      else if (tp instanceof Prim) {
+        if (prim && tp.name != prim.name) return null;
+        prim = tp;
+      }
+    }
+    var kinds = (arrays && 1) + (fns && 1) + (objs && 1) + (prim && 1);
+    if (kinds > 1) return null;
+    if (prim) return prim;
+
+    var maxScore = 0, maxTp = null;
+    for (var i = 0; i < types.length; ++i) {
+      var tp = types[i], score = 0;
+      if (arrays) {
+        score = tp.getProp("<i>").isEmpty() ? 1 : 2;
+      } else if (fns) {
+        score = 1;
+        for (var j = 0; j < tp.args.length; ++j) if (!tp.args[j].isEmpty()) ++score;
+        if (!tp.retval.isEmpty()) ++score;
+      } else if (objs) {
+        score = tp.name ? 100 : 2;
+      }
+      if (score >= maxScore) { maxScore = score; maxTp = tp; }
+    }
+    return maxTp;
+  }
+
+  // PROPAGATION STRATEGIES
+
+  function Constraint() {}
+  Constraint.prototype = extend(ANull, {
+    init: function() { this.origin = cx.curOrigin; }
+  });
+
+  var constraint = exports.constraint = function(props, methods) {
+    var body = "this.init();";
+    props = props ? props.split(", ") : [];
+    for (var i = 0; i < props.length; ++i)
+      body += "this." + props[i] + " = " + props[i] + ";";
+    var ctor = Function.apply(null, props.concat([body]));
+    ctor.prototype = Object.create(Constraint.prototype);
+    for (var m in methods) if (methods.hasOwnProperty(m)) ctor.prototype[m] = methods[m];
+    return ctor;
+  };
+
+  var PropIsSubset = constraint("prop, target", {
+    addType: function(type, weight) {
+      if (type.getProp)
+        type.getProp(this.prop).propagate(this.target, weight);
+    },
+    propHint: function() { return this.prop; },
+    propagatesTo: function() {
+      if (this.prop == "<i>" || !/[^\w_]/.test(this.prop))
+        return {target: this.target, pathExt: "." + this.prop};
+    }
+  });
+
+  var PropHasSubset = exports.PropHasSubset = constraint("prop, type, originNode", {
+    addType: function(type, weight) {
+      if (!(type instanceof Obj)) return;
+      var prop = type.defProp(this.prop, this.originNode);
+      if (!prop.origin) prop.origin = this.origin;
+      this.type.propagate(prop, weight);
+    },
+    propHint: function() { return this.prop; }
+  });
+
+  var ForAllProps = constraint("c", {
+    addType: function(type) {
+      if (!(type instanceof Obj)) return;
+      type.forAllProps(this.c);
+    }
+  });
+
+  function withDisabledComputing(fn, body) {
+    cx.disabledComputing = {fn: fn, prev: cx.disabledComputing};
+    try {
+      return body();
+    } finally {
+      cx.disabledComputing = cx.disabledComputing.prev;
+    }
+  }
+  var IsCallee = exports.IsCallee = constraint("self, args, argNodes, retval", {
+    init: function() {
+      Constraint.prototype.init.call(this);
+      this.disabled = cx.disabledComputing;
+    },
+    addType: function(fn, weight) {
+      if (!(fn instanceof Fn)) return;
+      for (var i = 0; i < this.args.length; ++i) {
+        if (i < fn.args.length) this.args[i].propagate(fn.args[i], weight);
+        if (fn.arguments) this.args[i].propagate(fn.arguments, weight);
+      }
+      this.self.propagate(fn.self, this.self == cx.topScope ? WG_GLOBAL_THIS : weight);
+      var compute = fn.computeRet;
+      if (compute) for (var d = this.disabled; d; d = d.prev)
+        if (d.fn == fn || fn.originNode && d.fn.originNode == fn.originNode) compute = null;
+      if (compute)
+        compute(this.self, this.args, this.argNodes).propagate(this.retval, weight);
+      else
+        fn.retval.propagate(this.retval, weight);
+    },
+    typeHint: function() {
+      var names = [];
+      for (var i = 0; i < this.args.length; ++i) names.push("?");
+      return new Fn(null, this.self, this.args, names, ANull);
+    },
+    propagatesTo: function() {
+      return {target: this.retval, pathExt: ".!ret"};
+    }
+  });
+
+  var HasMethodCall = constraint("propName, args, argNodes, retval", {
+    init: function() {
+      Constraint.prototype.init.call(this);
+      this.disabled = cx.disabledComputing;
+    },
+    addType: function(obj, weight) {
+      var callee = new IsCallee(obj, this.args, this.argNodes, this.retval);
+      callee.disabled = this.disabled;
+      obj.getProp(this.propName).propagate(callee, weight);
+    },
+    propHint: function() { return this.propName; }
+  });
+
+  var IsCtor = exports.IsCtor = constraint("target, noReuse", {
+    addType: function(f, weight) {
+      if (!(f instanceof Fn)) return;
+      if (cx.parent && !cx.parent.options.reuseInstances) this.noReuse = true;
+      f.getProp("prototype").propagate(new IsProto(this.noReuse ? false : f, this.target), weight);
+    }
+  });
+
+  var getInstance = exports.getInstance = function(obj, ctor) {
+    if (ctor === false) return new Obj(obj);
+
+    if (!ctor) ctor = obj.hasCtor;
+    if (!obj.instances) obj.instances = [];
+    for (var i = 0; i < obj.instances.length; ++i) {
+      var cur = obj.instances[i];
+      if (cur.ctor == ctor) return cur.instance;
+    }
+    var instance = new Obj(obj, ctor && ctor.name);
+    instance.origin = obj.origin;
+    obj.instances.push({ctor: ctor, instance: instance});
+    return instance;
+  };
+
+  var IsProto = exports.IsProto = constraint("ctor, target", {
+    addType: function(o, _weight) {
+      if (!(o instanceof Obj)) return;
+      if ((this.count = (this.count || 0) + 1) > 8) return;
+      if (o == cx.protos.Array)
+        this.target.addType(new Arr);
+      else
+        this.target.addType(getInstance(o, this.ctor));
+    }
+  });
+
+  var FnPrototype = constraint("fn", {
+    addType: function(o, _weight) {
+      if (o instanceof Obj && !o.hasCtor) {
+        o.hasCtor = this.fn;
+        var adder = new SpeculativeThis(o, this.fn);
+        adder.addType(this.fn);
+        o.forAllProps(function(_prop, val, local) {
+          if (local) val.propagate(adder);
+        });
+      }
+    }
+  });
+
+  var IsAdded = constraint("other, target", {
+    addType: function(type, weight) {
+      if (type == cx.str)
+        this.target.addType(cx.str, weight);
+      else if (type == cx.num && this.other.hasType(cx.num))
+        this.target.addType(cx.num, weight);
+    },
+    typeHint: function() { return this.other; }
+  });
+
+  var IfObj = exports.IfObj = constraint("target", {
+    addType: function(t, weight) {
+      if (t instanceof Obj) this.target.addType(t, weight);
+    },
+    propagatesTo: function() { return this.target; }
+  });
+
+  var SpeculativeThis = constraint("obj, ctor", {
+    addType: function(tp) {
+      if (tp instanceof Fn && tp.self && tp.self.isEmpty())
+        tp.self.addType(getInstance(this.obj, this.ctor), WG_SPECULATIVE_THIS);
+    }
+  });
+
+  var Muffle = constraint("inner, weight", {
+    addType: function(tp, weight) {
+      this.inner.addType(tp, Math.min(weight, this.weight));
+    },
+    propagatesTo: function() { return this.inner.propagatesTo(); },
+    typeHint: function() { return this.inner.typeHint(); },
+    propHint: function() { return this.inner.propHint(); }
+  });
+
+  // TYPE OBJECTS
+
+  var Type = exports.Type = function() {};
+  Type.prototype = extend(ANull, {
+    constructor: Type,
+    propagate: function(c, w) { c.addType(this, w); },
+    hasType: function(other) { return other == this; },
+    isEmpty: function() { return false; },
+    typeHint: function() { return this; },
+    getType: function() { return this; }
+  });
+
+  var Prim = exports.Prim = function(proto, name) { this.name = name; this.proto = proto; };
+  Prim.prototype = extend(Type.prototype, {
+    constructor: Prim,
+    toString: function() { return this.name; },
+    getProp: function(prop) {return this.proto.hasProp(prop) || ANull;},
+    gatherProperties: function(f, depth) {
+      if (this.proto) this.proto.gatherProperties(f, depth);
+    }
+  });
+
+  var Obj = exports.Obj = function(proto, name) {
+    if (!this.props) this.props = Object.create(null);
+    this.proto = proto === true ? cx.protos.Object : proto;
+    if (proto && !name && proto.name && !(this instanceof Fn)) {
+      var match = /^(.*)\.prototype$/.exec(this.proto.name);
+      if (match) name = match[1];
+    }
+    this.name = name;
+    this.maybeProps = null;
+    this.origin = cx.curOrigin;
+  };
+  Obj.prototype = extend(Type.prototype, {
+    constructor: Obj,
+    toString: function(maxDepth) {
+      if (maxDepth == null) maxDepth = 0;
+      if (maxDepth <= 0 && this.name) return this.name;
+      var props = [], etc = false;
+      for (var prop in this.props) if (prop != "<i>") {
+        if (props.length > 5) { etc = true; break; }
+        if (maxDepth)
+          props.push(prop + ": " + toString(this.props[prop], maxDepth - 1, this));
+        else
+          props.push(prop);
+      }
+      props.sort();
+      if (etc) props.push("...");
+      return "{" + props.join(", ") + "}";
+    },
+    hasProp: function(prop, searchProto) {
+      var found = this.props[prop];
+      if (searchProto !== false)
+        for (var p = this.proto; p && !found; p = p.proto) found = p.props[prop];
+      return found;
+    },
+    defProp: function(prop, originNode) {
+      var found = this.hasProp(prop, false);
+      if (found) {
+        if (originNode && !found.originNode) found.originNode = originNode;
+        return found;
+      }
+      if (prop == "__proto__" || prop == "✖") return ANull;
+
+      var av = this.maybeProps && this.maybeProps[prop];
+      if (av) {
+        delete this.maybeProps[prop];
+        this.maybeUnregProtoPropHandler();
+      } else {
+        av = new AVal;
+        av.propertyOf = this;
+      }
+
+      this.props[prop] = av;
+      av.originNode = originNode;
+      av.origin = cx.curOrigin;
+      this.broadcastProp(prop, av, true);
+      return av;
+    },
+    getProp: function(prop) {
+      var found = this.hasProp(prop, true) || (this.maybeProps && this.maybeProps[prop]);
+      if (found) return found;
+      if (prop == "__proto__" || prop == "✖") return ANull;
+      var av = this.ensureMaybeProps()[prop] = new AVal;
+      av.propertyOf = this;
+      return av;
+    },
+    broadcastProp: function(prop, val, local) {
+      if (local) {
+        this.signal("addProp", prop, val);
+        // If this is a scope, it shouldn't be registered
+        if (!(this instanceof Scope)) registerProp(prop, this);
+      }
+
+      if (this.onNewProp) for (var i = 0; i < this.onNewProp.length; ++i) {
+        var h = this.onNewProp[i];
+        h.onProtoProp ? h.onProtoProp(prop, val, local) : h(prop, val, local);
+      }
+    },
+    onProtoProp: function(prop, val, _local) {
+      var maybe = this.maybeProps && this.maybeProps[prop];
+      if (maybe) {
+        delete this.maybeProps[prop];
+        this.maybeUnregProtoPropHandler();
+        this.proto.getProp(prop).propagate(maybe);
+      }
+      this.broadcastProp(prop, val, false);
+    },
+    ensureMaybeProps: function() {
+      if (!this.maybeProps) {
+        if (this.proto) this.proto.forAllProps(this);
+        this.maybeProps = Object.create(null);
+      }
+      return this.maybeProps;
+    },
+    removeProp: function(prop) {
+      var av = this.props[prop];
+      delete this.props[prop];
+      this.ensureMaybeProps()[prop] = av;
+      av.types.length = 0;
+    },
+    forAllProps: function(c) {
+      if (!this.onNewProp) {
+        this.onNewProp = [];
+        if (this.proto) this.proto.forAllProps(this);
+      }
+      this.onNewProp.push(c);
+      for (var o = this; o; o = o.proto) for (var prop in o.props) {
+        if (c.onProtoProp)
+          c.onProtoProp(prop, o.props[prop], o == this);
+        else
+          c(prop, o.props[prop], o == this);
+      }
+    },
+    maybeUnregProtoPropHandler: function() {
+      if (this.maybeProps) {
+        for (var _n in this.maybeProps) return;
+        this.maybeProps = null;
+      }
+      if (!this.proto || this.onNewProp && this.onNewProp.length) return;
+      this.proto.unregPropHandler(this);
+    },
+    unregPropHandler: function(handler) {
+      for (var i = 0; i < this.onNewProp.length; ++i)
+        if (this.onNewProp[i] == handler) { this.onNewProp.splice(i, 1); break; }
+      this.maybeUnregProtoPropHandler();
+    },
+    gatherProperties: function(f, depth) {
+      for (var prop in this.props) if (prop != "<i>")
+        f(prop, this, depth);
+      if (this.proto) this.proto.gatherProperties(f, depth + 1);
+    },
+    getObjType: function() { return this; }
+  });
+
+  var Fn = exports.Fn = function(name, self, args, argNames, retval) {
+    Obj.call(this, cx.protos.Function, name);
+    this.self = self;
+    this.args = args;
+    this.argNames = argNames;
+    this.retval = retval;
+  };
+  Fn.prototype = extend(Obj.prototype, {
+    constructor: Fn,
+    toString: function(maxDepth) {
+      if (maxDepth == null) maxDepth = 0;
+      var str = "fn(";
+      for (var i = 0; i < this.args.length; ++i) {
+        if (i) str += ", ";
+        var name = this.argNames[i];
+        if (name && name != "?") str += name + ": ";
+        str += maxDepth > -3 ? toString(this.args[i], maxDepth - 1, this) : "?";
+      }
+      str += ")";
+      if (!this.retval.isEmpty())
+        str += " -> " + (maxDepth > -3 ? toString(this.retval, maxDepth - 1, this) : "?");
+      return str;
+    },
+    getProp: function(prop) {
+      if (prop == "prototype") {
+        var known = this.hasProp(prop, false);
+        if (!known) {
+          known = this.defProp(prop);
+          var proto = new Obj(true, this.name && this.name + ".prototype");
+          proto.origin = this.origin;
+          known.addType(proto, WG_MADEUP_PROTO);
+        }
+        return known;
+      }
+      return Obj.prototype.getProp.call(this, prop);
+    },
+    defProp: function(prop, originNode) {
+      if (prop == "prototype") {
+        var found = this.hasProp(prop, false);
+        if (found) return found;
+        found = Obj.prototype.defProp.call(this, prop, originNode);
+        found.origin = this.origin;
+        found.propagate(new FnPrototype(this));
+        return found;
+      }
+      return Obj.prototype.defProp.call(this, prop, originNode);
+    },
+    getFunctionType: function() { return this; }
+  });
+
+  var Arr = exports.Arr = function(contentType) {
+    Obj.call(this, cx.protos.Array);
+    var content = this.defProp("<i>");
+    if (contentType) contentType.propagate(content);
+  };
+  Arr.prototype = extend(Obj.prototype, {
+    constructor: Arr,
+    toString: function(maxDepth) {
+      if (maxDepth == null) maxDepth = 0;
+      return "[" + (maxDepth > -3 ? toString(this.getProp("<i>"), maxDepth - 1, this) : "?") + "]";
+    }
+  });
+
+  // THE PROPERTY REGISTRY
+
+  function registerProp(prop, obj) {
+    var data = cx.props[prop] || (cx.props[prop] = []);
+    data.push(obj);
+  }
+
+  function objsWithProp(prop) {
+    return cx.props[prop];
+  }
+
+  // INFERENCE CONTEXT
+
+  exports.Context = function(defs, parent) {
+    this.parent = parent;
+    this.props = Object.create(null);
+    this.protos = Object.create(null);
+    this.origins = [];
+    this.curOrigin = "ecma5";
+    this.paths = Object.create(null);
+    this.definitions = Object.create(null);
+    this.purgeGen = 0;
+    this.workList = null;
+    this.disabledComputing = null;
+
+    exports.withContext(this, function() {
+      cx.protos.Object = new Obj(null, "Object.prototype");
+      cx.topScope = new Scope();
+      cx.topScope.name = "<top>";
+      cx.protos.Array = new Obj(true, "Array.prototype");
+      cx.protos.Function = new Obj(true, "Function.prototype");
+      cx.protos.RegExp = new Obj(true, "RegExp.prototype");
+      cx.protos.String = new Obj(true, "String.prototype");
+      cx.protos.Number = new Obj(true, "Number.prototype");
+      cx.protos.Boolean = new Obj(true, "Boolean.prototype");
+      cx.str = new Prim(cx.protos.String, "string");
+      cx.bool = new Prim(cx.protos.Boolean, "bool");
+      cx.num = new Prim(cx.protos.Number, "number");
+      cx.curOrigin = null;
+
+      if (defs) for (var i = 0; i < defs.length; ++i)
+        def.load(defs[i]);
+    });
+  };
+
+  var cx = null;
+  exports.cx = function() { return cx; };
+
+  exports.withContext = function(context, f) {
+    var old = cx;
+    cx = context;
+    try { return f(); }
+    finally { cx = old; }
+  };
+
+  exports.TimedOut = function() {
+    this.message = "Timed out";
+    this.stack = (new Error()).stack;
+  };
+  exports.TimedOut.prototype = Object.create(Error.prototype);
+  exports.TimedOut.prototype.name = "infer.TimedOut";
+
+  var timeout;
+  exports.withTimeout = function(ms, f) {
+    var end = +new Date + ms;
+    var oldEnd = timeout;
+    if (oldEnd && oldEnd < end) return f();
+    timeout = end;
+    try { return f(); }
+    finally { timeout = oldEnd; }
+  };
+
+  exports.addOrigin = function(origin) {
+    if (cx.origins.indexOf(origin) < 0) cx.origins.push(origin);
+  };
+
+  var baseMaxWorkDepth = 20, reduceMaxWorkDepth = 0.0001;
+  function withWorklist(f) {
+    if (cx.workList) return f(cx.workList);
+
+    var list = [], depth = 0;
+    var add = cx.workList = function(type, target, weight) {
+      if (depth < baseMaxWorkDepth - reduceMaxWorkDepth * list.length)
+        list.push(type, target, weight, depth);
+    };
+    try {
+      var ret = f(add);
+      for (var i = 0; i < list.length; i += 4) {
+        if (timeout && +new Date >= timeout)
+          throw new exports.TimedOut();
+        depth = list[i + 3] + 1;
+        list[i + 1].addType(list[i], list[i + 2]);
+      }
+      return ret;
+    } finally {
+      cx.workList = null;
+    }
+  }
+
+  // SCOPES
+
+  var Scope = exports.Scope = function(prev) {
+    Obj.call(this, prev || true);
+    this.prev = prev;
+  };
+  Scope.prototype = extend(Obj.prototype, {
+    constructor: Scope,
+    defVar: function(name, originNode) {
+      for (var s = this; ; s = s.proto) {
+        var found = s.props[name];
+        if (found) return found;
+        if (!s.prev) return s.defProp(name, originNode);
+      }
+    }
+  });
+
+  // RETVAL COMPUTATION HEURISTICS
+
+  function maybeInstantiate(scope, score) {
+    if (scope.fnType)
+      scope.fnType.instantiateScore = (scope.fnType.instantiateScore || 0) + score;
+  }
+
+  var NotSmaller = {};
+  function nodeSmallerThan(node, n) {
+    try {
+      walk.simple(node, {Expression: function() { if (--n <= 0) throw NotSmaller; }});
+      return true;
+    } catch(e) {
+      if (e == NotSmaller) return false;
+      throw e;
+    }
+  }
+
+  function maybeTagAsInstantiated(node, scope) {
+    var score = scope.fnType.instantiateScore;
+    if (!cx.disabledComputing && score && scope.fnType.args.length && nodeSmallerThan(node, score * 5)) {
+      maybeInstantiate(scope.prev, score / 2);
+      setFunctionInstantiated(node, scope);
+      return true;
+    } else {
+      scope.fnType.instantiateScore = null;
+    }
+  }
+
+  function setFunctionInstantiated(node, scope) {
+    var fn = scope.fnType;
+    // Disconnect the arg avals, so that we can add info to them without side effects
+    for (var i = 0; i < fn.args.length; ++i) fn.args[i] = new AVal;
+    fn.self = new AVal;
+    fn.computeRet = function(self, args) {
+      // Prevent recursion
+      return withDisabledComputing(fn, function() {
+        var oldOrigin = cx.curOrigin;
+        cx.curOrigin = fn.origin;
+        var scopeCopy = new Scope(scope.prev);
+        scopeCopy.originNode = scope.originNode;
+        for (var v in scope.props) {
+          var local = scopeCopy.defProp(v, scope.props[v].originNode);
+          for (var i = 0; i < args.length; ++i) if (fn.argNames[i] == v && i < args.length)
+            args[i].propagate(local);
+        }
+        var argNames = fn.argNames.length != args.length ? fn.argNames.slice(0, args.length) : fn.argNames;
+        while (argNames.length < args.length) argNames.push("?");
+        scopeCopy.fnType = new Fn(fn.name, self, args, argNames, ANull);
+        scopeCopy.fnType.originNode = fn.originNode;
+        if (fn.arguments) {
+          var argset = scopeCopy.fnType.arguments = new AVal;
+          scopeCopy.defProp("arguments").addType(new Arr(argset));
+          for (var i = 0; i < args.length; ++i) args[i].propagate(argset);
+        }
+        node.body.scope = scopeCopy;
+        walk.recursive(node.body, scopeCopy, null, scopeGatherer);
+        walk.recursive(node.body, scopeCopy, null, inferWrapper);
+        cx.curOrigin = oldOrigin;
+        return scopeCopy.fnType.retval;
+      });
+    };
+  }
+
+  function maybeTagAsGeneric(scope) {
+    var fn = scope.fnType, target = fn.retval;
+    if (target == ANull) return;
+    var targetInner, asArray;
+    if (!target.isEmpty() && (targetInner = target.getType()) instanceof Arr)
+      target = asArray = targetInner.getProp("<i>");
+
+    function explore(aval, path, depth) {
+      if (depth > 3 || !aval.forward) return;
+      for (var i = 0; i < aval.forward.length; ++i) {
+        var prop = aval.forward[i].propagatesTo();
+        if (!prop) continue;
+        var newPath = path, dest;
+        if (prop instanceof AVal) {
+          dest = prop;
+        } else if (prop.target instanceof AVal) {
+          newPath += prop.pathExt;
+          dest = prop.target;
+        } else continue;
+        if (dest == target) return newPath;
+        var found = explore(dest, newPath, depth + 1);
+        if (found) return found;
+      }
+    }
+
+    var foundPath = explore(fn.self, "!this", 0);
+    for (var i = 0; !foundPath && i < fn.args.length; ++i)
+      foundPath = explore(fn.args[i], "!" + i, 0);
+
+    if (foundPath) {
+      if (asArray) foundPath = "[" + foundPath + "]";
+      var p = new def.TypeParser(foundPath);
+      var parsed = p.parseType(true);
+      fn.computeRet = parsed.apply ? parsed : function() { return parsed; };
+      fn.computeRetSource = foundPath;
+      return true;
+    }
+  }
+
+  // SCOPE GATHERING PASS
+
+  function addVar(scope, nameNode) {
+    return scope.defProp(nameNode.name, nameNode);
+  }
+
+  var scopeGatherer = walk.make({
+    Function: function(node, scope, c) {
+      var inner = node.body.scope = new Scope(scope);
+      inner.originNode = node;
+      var argVals = [], argNames = [];
+      for (var i = 0; i < node.params.length; ++i) {
+        var param = node.params[i];
+        argNames.push(param.name);
+        argVals.push(addVar(inner, param));
+      }
+      inner.fnType = new Fn(node.id && node.id.name, new AVal, argVals, argNames, ANull);
+      inner.fnType.originNode = node;
+      if (node.id) {
+        var decl = node.type == "FunctionDeclaration";
+        addVar(decl ? scope : inner, node.id);
+      }
+      c(node.body, inner, "ScopeBody");
+    },
+    TryStatement: function(node, scope, c) {
+      c(node.block, scope, "Statement");
+      if (node.handler) {
+        var v = addVar(scope, node.handler.param);
+        c(node.handler.body, scope, "ScopeBody");
+        var e5 = cx.definitions.ecma5;
+        if (e5 && v.isEmpty()) getInstance(e5["Error.prototype"]).propagate(v, WG_CATCH_ERROR);
+      }
+      if (node.finalizer) c(node.finalizer, scope, "Statement");
+    },
+    VariableDeclaration: function(node, scope, c) {
+      for (var i = 0; i < node.declarations.length; ++i) {
+        var decl = node.declarations[i];
+        addVar(scope, decl.id);
+        if (decl.init) c(decl.init, scope, "Expression");
+      }
+    }
+  });
+
+  // CONSTRAINT GATHERING PASS
+
+  function propName(node, scope, c) {
+    var prop = node.property;
+    if (!node.computed) return prop.name;
+    if (prop.type == "Literal" && typeof prop.value == "string") return prop.value;
+    if (c) infer(prop, scope, c, ANull);
+    return "<i>";
+  }
+
+  function unopResultType(op) {
+    switch (op) {
+    case "+": case "-": case "~": return cx.num;
+    case "!": return cx.bool;
+    case "typeof": return cx.str;
+    case "void": case "delete": return ANull;
+    }
+  }
+  function binopIsBoolean(op) {
+    switch (op) {
+    case "==": case "!=": case "===": case "!==": case "<": case ">": case ">=": case "<=":
+    case "in": case "instanceof": return true;
+    }
+  }
+  function literalType(node) {
+    if (node.regex) return getInstance(cx.protos.RegExp);
+    switch (typeof node.value) {
+    case "boolean": return cx.bool;
+    case "number": return cx.num;
+    case "string": return cx.str;
+    case "object":
+    case "function":
+      if (!node.value) return ANull;
+      return getInstance(cx.protos.RegExp);
+    }
+  }
+
+  function ret(f) {
+    return function(node, scope, c, out, name) {
+      var r = f(node, scope, c, name);
+      if (out) r.propagate(out);
+      return r;
+    };
+  }
+  function fill(f) {
+    return function(node, scope, c, out, name) {
+      if (!out) out = new AVal;
+      f(node, scope, c, out, name);
+      return out;
+    };
+  }
+
+  var inferExprVisitor = {
+    ArrayExpression: ret(function(node, scope, c) {
+      var eltval = new AVal;
+      for (var i = 0; i < node.elements.length; ++i) {
+        var elt = node.elements[i];
+        if (elt) infer(elt, scope, c, eltval);
+      }
+      return new Arr(eltval);
+    }),
+    ObjectExpression: ret(function(node, scope, c, name) {
+      var obj = node.objType = new Obj(true, name);
+      obj.originNode = node;
+
+      for (var i = 0; i < node.properties.length; ++i) {
+        var prop = node.properties[i], key = prop.key, name;
+        if (prop.value.name == "✖") continue;
+
+        if (key.type == "Identifier") {
+          name = key.name;
+        } else if (typeof key.value == "string") {
+          name = key.value;
+        }
+        if (!name || prop.kind == "set") {
+          infer(prop.value, scope, c, ANull);
+          continue;
+        }
+
+        var val = obj.defProp(name, key), out = val;
+        val.initializer = true;
+        if (prop.kind == "get")
+          out = new IsCallee(obj, [], null, val);
+        infer(prop.value, scope, c, out, name);
+      }
+      return obj;
+    }),
+    FunctionExpression: ret(function(node, scope, c, name) {
+      var inner = node.body.scope, fn = inner.fnType;
+      if (name && !fn.name) fn.name = name;
+      c(node.body, scope, "ScopeBody");
+      maybeTagAsInstantiated(node, inner) || maybeTagAsGeneric(inner);
+      if (node.id) inner.getProp(node.id.name).addType(fn);
+      return fn;
+    }),
+    SequenceExpression: ret(function(node, scope, c) {
+      for (var i = 0, l = node.expressions.length - 1; i < l; ++i)
+        infer(node.expressions[i], scope, c, ANull);
+      return infer(node.expressions[l], scope, c);
+    }),
+    UnaryExpression: ret(function(node, scope, c) {
+      infer(node.argument, scope, c, ANull);
+      return unopResultType(node.operator);
+    }),
+    UpdateExpression: ret(function(node, scope, c) {
+      infer(node.argument, scope, c, ANull);
+      return cx.num;
+    }),
+    BinaryExpression: ret(function(node, scope, c) {
+      if (node.operator == "+") {
+        var lhs = infer(node.left, scope, c);
+        var rhs = infer(node.right, scope, c);
+        if (lhs.hasType(cx.str) || rhs.hasType(cx.str)) return cx.str;
+        if (lhs.hasType(cx.num) && rhs.hasType(cx.num)) return cx.num;
+        var result = new AVal;
+        lhs.propagate(new IsAdded(rhs, result));
+        rhs.propagate(new IsAdded(lhs, result));
+        return result;
+      } else {
+        infer(node.left, scope, c, ANull);
+        infer(node.right, scope, c, ANull);
+        return binopIsBoolean(node.operator) ? cx.bool : cx.num;
+      }
+    }),
+    AssignmentExpression: ret(function(node, scope, c) {
+      var rhs, name, pName;
+      if (node.left.type == "MemberExpression") {
+        pName = propName(node.left, scope, c);
+        if (node.left.object.type == "Identifier")
+          name = node.left.object.name + "." + pName;
+      } else {
+        name = node.left.name;
+      }
+
+      if (node.operator != "=" && node.operator != "+=") {
+        infer(node.right, scope, c, ANull);
+        rhs = cx.num;
+      } else {
+        rhs = infer(node.right, scope, c, null, name);
+      }
+
+      if (node.left.type == "MemberExpression") {
+        var obj = infer(node.left.object, scope, c);
+        if (pName == "prototype") maybeInstantiate(scope, 20);
+        if (pName == "<i>") {
+          // This is a hack to recognize for/in loops that copy
+          // properties, and do the copying ourselves, insofar as we
+          // manage, because such loops tend to be relevant for type
+          // information.
+          var v = node.left.property.name, local = scope.props[v], over = local && local.iteratesOver;
+          if (over) {
+            maybeInstantiate(scope, 20);
+            var fromRight = node.right.type == "MemberExpression" && node.right.computed && node.right.property.name == v;
+            over.forAllProps(function(prop, val, local) {
+              if (local && prop != "prototype" && prop != "<i>")
+                obj.propagate(new PropHasSubset(prop, fromRight ? val : ANull));
+            });
+            return rhs;
+          }
+        }
+        obj.propagate(new PropHasSubset(pName, rhs, node.left.property));
+      } else { // Identifier
+        rhs.propagate(scope.defVar(node.left.name, node.left));
+      }
+      return rhs;
+    }),
+    LogicalExpression: fill(function(node, scope, c, out) {
+      infer(node.left, scope, c, out);
+      infer(node.right, scope, c, out);
+    }),
+    ConditionalExpression: fill(function(node, scope, c, out) {
+      infer(node.test, scope, c, ANull);
+      infer(node.consequent, scope, c, out);
+      infer(node.alternate, scope, c, out);
+    }),
+    NewExpression: fill(function(node, scope, c, out, name) {
+      if (node.callee.type == "Identifier" && node.callee.name in scope.props)
+        maybeInstantiate(scope, 20);
+
+      for (var i = 0, args = []; i < node.arguments.length; ++i)
+        args.push(infer(node.arguments[i], scope, c));
+      var callee = infer(node.callee, scope, c);
+      var self = new AVal;
+      callee.propagate(new IsCtor(self, name && /\.prototype$/.test(name)));
+      self.propagate(out, WG_NEW_INSTANCE);
+      callee.propagate(new IsCallee(self, args, node.arguments, new IfObj(out)));
+    }),
+    CallExpression: fill(function(node, scope, c, out) {
+      for (var i = 0, args = []; i < node.arguments.length; ++i)
+        args.push(infer(node.arguments[i], scope, c));
+      if (node.callee.type == "MemberExpression") {
+        var self = infer(node.callee.object, scope, c);
+        var pName = propName(node.callee, scope, c);
+        if ((pName == "call" || pName == "apply") &&
+            scope.fnType && scope.fnType.args.indexOf(self) > -1)
+          maybeInstantiate(scope, 30);
+        self.propagate(new HasMethodCall(pName, args, node.arguments, out));
+      } else {
+        var callee = infer(node.callee, scope, c);
+        if (scope.fnType && scope.fnType.args.indexOf(callee) > -1)
+          maybeInstantiate(scope, 30);
+        var knownFn = callee.getFunctionType();
+        if (knownFn && knownFn.instantiateScore && scope.fnType)
+          maybeInstantiate(scope, knownFn.instantiateScore / 5);
+        callee.propagate(new IsCallee(cx.topScope, args, node.arguments, out));
+      }
+    }),
+    MemberExpression: fill(function(node, scope, c, out) {
+      var name = propName(node, scope);
+      var obj = infer(node.object, scope, c);
+      var prop = obj.getProp(name);
+      if (name == "<i>") {
+        var propType = infer(node.property, scope, c);
+        if (!propType.hasType(cx.num))
+          return prop.propagate(out, WG_MULTI_MEMBER);
+      }
+      prop.propagate(out);
+    }),
+    Identifier: ret(function(node, scope) {
+      if (node.name == "arguments" && scope.fnType && !(node.name in scope.props))
+        scope.defProp(node.name, scope.fnType.originNode)
+          .addType(new Arr(scope.fnType.arguments = new AVal));
+      return scope.getProp(node.name);
+    }),
+    ThisExpression: ret(function(_node, scope) {
+      return scope.fnType ? scope.fnType.self : cx.topScope;
+    }),
+    Literal: ret(function(node) {
+      return literalType(node);
+    })
+  };
+
+  function infer(node, scope, c, out, name) {
+    return inferExprVisitor[node.type](node, scope, c, out, name);
+  }
+
+  var inferWrapper = walk.make({
+    Expression: function(node, scope, c) {
+      infer(node, scope, c, ANull);
+    },
+
+    FunctionDeclaration: function(node, scope, c) {
+      var inner = node.body.scope, fn = inner.fnType;
+      c(node.body, scope, "ScopeBody");
+      maybeTagAsInstantiated(node, inner) || maybeTagAsGeneric(inner);
+      var prop = scope.getProp(node.id.name);
+      prop.addType(fn);
+    },
+
+    VariableDeclaration: function(node, scope, c) {
+      for (var i = 0; i < node.declarations.length; ++i) {
+        var decl = node.declarations[i], prop = scope.getProp(decl.id.name);
+        if (decl.init)
+          infer(decl.init, scope, c, prop, decl.id.name);
+      }
+    },
+
+    ReturnStatement: function(node, scope, c) {
+      if (!node.argument) return;
+      var output = ANull;
+      if (scope.fnType) {
+        if (scope.fnType.retval == ANull) scope.fnType.retval = new AVal;
+        output = scope.fnType.retval;
+      }
+      infer(node.argument, scope, c, output);
+    },
+
+    ForInStatement: function(node, scope, c) {
+      var source = infer(node.right, scope, c);
+      if ((node.right.type == "Identifier" && node.right.name in scope.props) ||
+          (node.right.type == "MemberExpression" && node.right.property.name == "prototype")) {
+        maybeInstantiate(scope, 5);
+        var varName;
+        if (node.left.type == "Identifier") {
+          varName = node.left.name;
+        } else if (node.left.type == "VariableDeclaration") {
+          varName = node.left.declarations[0].id.name;
+        }
+        if (varName && varName in scope.props)
+          scope.getProp(varName).iteratesOver = source;
+      }
+      c(node.body, scope, "Statement");
+    },
+
+    ScopeBody: function(node, scope, c) { c(node, node.scope || scope); }
+  });
+
+  // PARSING
+
+  function runPasses(passes, pass) {
+    var arr = passes && passes[pass];
+    var args = Array.prototype.slice.call(arguments, 2);
+    if (arr) for (var i = 0; i < arr.length; ++i) arr[i].apply(null, args);
+  }
+
+  var parse = exports.parse = function(text, passes, options) {
+    var ast;
+    try { ast = acorn.parse(text, options); }
+    catch(e) { ast = acorn_loose.parse_dammit(text, options); }
+    runPasses(passes, "postParse", ast, text);
+    return ast;
+  };
+
+  // ANALYSIS INTERFACE
+
+  exports.analyze = function(ast, name, scope, passes) {
+    if (typeof ast == "string") ast = parse(ast);
+
+    if (!name) name = "file#" + cx.origins.length;
+    exports.addOrigin(cx.curOrigin = name);
+
+    if (!scope) scope = cx.topScope;
+    walk.recursive(ast, scope, null, scopeGatherer);
+    runPasses(passes, "preInfer", ast, scope);
+    walk.recursive(ast, scope, null, inferWrapper);
+    runPasses(passes, "postInfer", ast, scope);
+
+    cx.curOrigin = null;
+  };
+
+  // PURGING
+
+  exports.purge = function(origins, start, end) {
+    var test = makePredicate(origins, start, end);
+    ++cx.purgeGen;
+    cx.topScope.purge(test);
+    for (var prop in cx.props) {
+      var list = cx.props[prop];
+      for (var i = 0; i < list.length; ++i) {
+        var obj = list[i], av = obj.props[prop];
+        if (!av || test(av, av.originNode)) list.splice(i--, 1);
+      }
+      if (!list.length) delete cx.props[prop];
+    }
+  };
+
+  function makePredicate(origins, start, end) {
+    var arr = Array.isArray(origins);
+    if (arr && origins.length == 1) { origins = origins[0]; arr = false; }
+    if (arr) {
+      if (end == null) return function(n) { return origins.indexOf(n.origin) > -1; };
+      return function(n, pos) { return pos && pos.start >= start && pos.end <= end && origins.indexOf(n.origin) > -1; };
+    } else {
+      if (end == null) return function(n) { return n.origin == origins; };
+      return function(n, pos) { return pos && pos.start >= start && pos.end <= end && n.origin == origins; };
+    }
+  }
+
+  AVal.prototype.purge = function(test) {
+    if (this.purgeGen == cx.purgeGen) return;
+    this.purgeGen = cx.purgeGen;
+    for (var i = 0; i < this.types.length; ++i) {
+      var type = this.types[i];
+      if (test(type, type.originNode))
+        this.types.splice(i--, 1);
+      else
+        type.purge(test);
+    }
+    if (this.forward) for (var i = 0; i < this.forward.length; ++i) {
+      var f = this.forward[i];
+      if (test(f)) {
+        this.forward.splice(i--, 1);
+        if (this.props) this.props = null;
+      } else if (f.purge) {
+        f.purge(test);
+      }
+    }
+  };
+  ANull.purge = function() {};
+  Obj.prototype.purge = function(test) {
+    if (this.purgeGen == cx.purgeGen) return true;
+    this.purgeGen = cx.purgeGen;
+    for (var p in this.props) {
+      var av = this.props[p];
+      if (test(av, av.originNode))
+        this.removeProp(p);
+      av.purge(test);
+    }
+  };
+  Fn.prototype.purge = function(test) {
+    if (Obj.prototype.purge.call(this, test)) return;
+    this.self.purge(test);
+    this.retval.purge(test);
+    for (var i = 0; i < this.args.length; ++i) this.args[i].purge(test);
+  };
+
+  // EXPRESSION TYPE DETERMINATION
+
+  function findByPropertyName(name) {
+    guessing = true;
+    var found = objsWithProp(name);
+    if (found) for (var i = 0; i < found.length; ++i) {
+      var val = found[i].getProp(name);
+      if (!val.isEmpty()) return val;
+    }
+    return ANull;
+  }
+
+  var typeFinder = {
+    ArrayExpression: function(node, scope) {
+      var eltval = new AVal;
+      for (var i = 0; i < node.elements.length; ++i) {
+        var elt = node.elements[i];
+        if (elt) findType(elt, scope).propagate(eltval);
+      }
+      return new Arr(eltval);
+    },
+    ObjectExpression: function(node) {
+      return node.objType;
+    },
+    FunctionExpression: function(node) {
+      return node.body.scope.fnType;
+    },
+    SequenceExpression: function(node, scope) {
+      return findType(node.expressions[node.expressions.length-1], scope);
+    },
+    UnaryExpression: function(node) {
+      return unopResultType(node.operator);
+    },
+    UpdateExpression: function() {
+      return cx.num;
+    },
+    BinaryExpression: function(node, scope) {
+      if (binopIsBoolean(node.operator)) return cx.bool;
+      if (node.operator == "+") {
+        var lhs = findType(node.left, scope);
+        var rhs = findType(node.right, scope);
+        if (lhs.hasType(cx.str) || rhs.hasType(cx.str)) return cx.str;
+      }
+      return cx.num;
+    },
+    AssignmentExpression: function(node, scope) {
+      return findType(node.right, scope);
+    },
+    LogicalExpression: function(node, scope) {
+      var lhs = findType(node.left, scope);
+      return lhs.isEmpty() ? findType(node.right, scope) : lhs;
+    },
+    ConditionalExpression: function(node, scope) {
+      var lhs = findType(node.consequent, scope);
+      return lhs.isEmpty() ? findType(node.alternate, scope) : lhs;
+    },
+    NewExpression: function(node, scope) {
+      var f = findType(node.callee, scope).getFunctionType();
+      var proto = f && f.getProp("prototype").getObjType();
+      if (!proto) return ANull;
+      return getInstance(proto, f);
+    },
+    CallExpression: function(node, scope) {
+      var f = findType(node.callee, scope).getFunctionType();
+      if (!f) return ANull;
+      if (f.computeRet) {
+        for (var i = 0, args = []; i < node.arguments.length; ++i)
+          args.push(findType(node.arguments[i], scope));
+        var self = ANull;
+        if (node.callee.type == "MemberExpression")
+          self = findType(node.callee.object, scope);
+        return f.computeRet(self, args, node.arguments);
+      } else {
+        return f.retval;
+      }
+    },
+    MemberExpression: function(node, scope) {
+      var propN = propName(node, scope), obj = findType(node.object, scope).getType();
+      if (obj) return obj.getProp(propN);
+      if (propN == "<i>") return ANull;
+      return findByPropertyName(propN);
+    },
+    Identifier: function(node, scope) {
+      return scope.hasProp(node.name) || ANull;
+    },
+    ThisExpression: function(_node, scope) {
+      return scope.fnType ? scope.fnType.self : cx.topScope;
+    },
+    Literal: function(node) {
+      return literalType(node);
+    }
+  };
+
+  function findType(node, scope) {
+    return typeFinder[node.type](node, scope);
+  }
+
+  var searchVisitor = exports.searchVisitor = walk.make({
+    Function: function(node, _st, c) {
+      var scope = node.body.scope;
+      if (node.id) c(node.id, scope);
+      for (var i = 0; i < node.params.length; ++i)
+        c(node.params[i], scope);
+      c(node.body, scope, "ScopeBody");
+    },
+    TryStatement: function(node, st, c) {
+      if (node.handler)
+        c(node.handler.param, st);
+      walk.base.TryStatement(node, st, c);
+    },
+    VariableDeclaration: function(node, st, c) {
+      for (var i = 0; i < node.declarations.length; ++i) {
+        var decl = node.declarations[i];
+        c(decl.id, st);
+        if (decl.init) c(decl.init, st, "Expression");
+      }
+    }
+  });
+  exports.fullVisitor = walk.make({
+    MemberExpression: function(node, st, c) {
+      c(node.object, st, "Expression");
+      c(node.property, st, node.computed ? "Expression" : null);
+    },
+    ObjectExpression: function(node, st, c) {
+      for (var i = 0; i < node.properties.length; ++i) {
+        c(node.properties[i].value, st, "Expression");
+        c(node.properties[i].key, st);
+      }
+    }
+  }, searchVisitor);
+
+  exports.findExpressionAt = function(ast, start, end, defaultScope, filter) {
+    var test = filter || function(_t, node) {
+      if (node.type == "Identifier" && node.name == "✖") return false;
+      return typeFinder.hasOwnProperty(node.type);
+    };
+    return walk.findNodeAt(ast, start, end, test, searchVisitor, defaultScope || cx.topScope);
+  };
+
+  exports.findExpressionAround = function(ast, start, end, defaultScope, filter) {
+    var test = filter || function(_t, node) {
+      if (start != null && node.start > start) return false;
+      if (node.type == "Identifier" && node.name == "✖") return false;
+      return typeFinder.hasOwnProperty(node.type);
+    };
+    return walk.findNodeAround(ast, end, test, searchVisitor, defaultScope || cx.topScope);
+  };
+
+  exports.expressionType = function(found) {
+    return findType(found.node, found.state);
+  };
+
+  // Finding the expected type of something, from context
+
+  exports.parentNode = function(child, ast) {
+    var stack = [];
+    function c(node, st, override) {
+      if (node.start <= child.start && node.end >= child.end) {
+        var top = stack[stack.length - 1];
+        if (node == child) throw {found: top};
+        if (top != node) stack.push(node);
+        walk.base[override || node.type](node, st, c);
+        if (top != node) stack.pop();
+      }
+    }
+    try {
+      c(ast, null);
+    } catch (e) {
+      if (e.found) return e.found;
+      throw e;
+    }
+  };
+
+  var findTypeFromContext = {
+    ArrayExpression: function(parent, _, get) { return get(parent, true).getProp("<i>"); },
+    ObjectExpression: function(parent, node, get) {
+      for (var i = 0; i < parent.properties.length; ++i) {
+        var prop = node.properties[i];
+        if (prop.value == node)
+          return get(parent, true).getProp(prop.key.name);
+      }
+    },
+    UnaryExpression: function(parent) { return unopResultType(parent.operator); },
+    UpdateExpression: function() { return cx.num; },
+    BinaryExpression: function(parent) { return binopIsBoolean(parent.operator) ? cx.bool : cx.num; },
+    AssignmentExpression: function(parent, _, get) { return get(parent.left); },
+    LogicalExpression: function(parent, _, get) { return get(parent, true); },
+    ConditionalExpression: function(parent, node, get) {
+      if (parent.consequent == node || parent.alternate == node) return get(parent, true);
+    },
+    NewExpression: function(parent, node, get) {
+      return this.CallExpression(parent, node, get);
+    },
+    CallExpression: function(parent, node, get) {
+      for (var i = 0; i < parent.arguments.length; i++) {
+        var arg = parent.arguments[i];
+        if (arg == node) {
+          var calleeType = get(parent.callee).getFunctionType();
+          if (calleeType instanceof Fn)
+            return calleeType.args[i];
+          break;
+        }
+      }
+    },
+    ReturnStatement: function(_parent, node, get) {
+      var fnNode = walk.findNodeAround(node.sourceFile.ast, node.start, "Function");
+      if (fnNode) {
+        var fnType = fnNode.node.type == "FunctionExpression"
+          ? get(fnNode.node, true).getFunctionType()
+          : fnNode.node.body.scope.fnType;
+        if (fnType) return fnType.retval.getType();
+      }
+    },
+    VariableDeclaration: function(parent, node, get) {
+      for (var i = 0; i < parent.declarations.length; i++) {
+        var decl = parent.declarations[i];
+        if (decl.init == node) return get(decl.id);
+      }
+    }
+  };
+
+  exports.typeFromContext = function(ast, found) {
+    var parent = exports.parentNode(found.node, ast);
+    var type = null;
+    if (findTypeFromContext.hasOwnProperty(parent.type)) {
+      type = findTypeFromContext[parent.type](parent, found.node, function(node, fromContext) {
+        var obj = {node: node, state: found.state};
+        var tp = fromContext ? exports.typeFromContext(ast, obj) : exports.expressionType(obj);
+        return tp || ANull;
+      });
+    }
+    return type || exports.expressionType(found);
+  };
+
+  // Flag used to indicate that some wild guessing was used to produce
+  // a type or set of completions.
+  var guessing = false;
+
+  exports.resetGuessing = function(val) { guessing = val; };
+  exports.didGuess = function() { return guessing; };
+
+  exports.forAllPropertiesOf = function(type, f) {
+    type.gatherProperties(f, 0);
+  };
+
+  var refFindWalker = walk.make({}, searchVisitor);
+
+  exports.findRefs = function(ast, baseScope, name, refScope, f) {
+    refFindWalker.Identifier = function(node, scope) {
+      if (node.name != name) return;
+      for (var s = scope; s; s = s.prev) {
+        if (s == refScope) f(node, scope);
+        if (name in s.props) return;
+      }
+    };
+    walk.recursive(ast, baseScope, null, refFindWalker);
+  };
+
+  var simpleWalker = walk.make({
+    Function: function(node, _st, c) { c(node.body, node.body.scope, "ScopeBody"); }
+  });
+
+  exports.findPropRefs = function(ast, scope, objType, propName, f) {
+    walk.simple(ast, {
+      MemberExpression: function(node, scope) {
+        if (node.computed || node.property.name != propName) return;
+        if (findType(node.object, scope).getType() == objType) f(node.property);
+      },
+      ObjectExpression: function(node, scope) {
+        if (findType(node, scope).getType() != objType) return;
+        for (var i = 0; i < node.properties.length; ++i)
+          if (node.properties[i].key.name == propName) f(node.properties[i].key);
+      }
+    }, simpleWalker, scope);
+  };
+
+  // LOCAL-VARIABLE QUERIES
+
+  var scopeAt = exports.scopeAt = function(ast, pos, defaultScope) {
+    var found = walk.findNodeAround(ast, pos, function(tp, node) {
+      return tp == "ScopeBody" && node.scope;
+    });
+    if (found) return found.node.scope;
+    else return defaultScope || cx.topScope;
+  };
+
+  exports.forAllLocalsAt = function(ast, pos, defaultScope, f) {
+    var scope = scopeAt(ast, pos, defaultScope);
+    scope.gatherProperties(f, 0);
+  };
+
+  // INIT DEF MODULE
+
+  // Delayed initialization because of cyclic dependencies.
+  def = exports.def = def.init({}, exports);
+});

--- a/editor/js/libs/ternjs/polyfill.js
+++ b/editor/js/libs/ternjs/polyfill.js
@@ -1,0 +1,80 @@
+// Shims to fill in enough of ECMAScript 5 to make Tern run. Does not
+// supply standard-compliant methods, in that some functionality is
+// left out (such as second argument to Object.create, self args in
+// array methods, etc). WILL clash with other ECMA5 polyfills in a
+// probably disruptive way.
+
+(function() {
+  Object.create = Object.create || (function() {
+    if (!({__proto__: null} instanceof Object))
+      return function(base) { return {__proto__: base}; };
+    function ctor() {}
+    var frame = document.body.appendChild(document.createElement("iframe"));
+    frame.src = "javascript:";
+    var empty = frame.contentWindow.Object.prototype;
+    delete empty.hasOwnProperty;
+    delete empty.isPrototypeOf;
+    delete empty.propertyIsEnumerable;
+    delete empty.valueOf;
+    delete empty.toString;
+    delete empty.toLocaleString;
+    delete empty.constructor;
+    return function(base) { ctor.prototype = base || empty; return new ctor(); };
+  })();
+
+  // Array methods
+
+  var AP = Array.prototype;
+
+  AP.some = AP.some || function(pred) {
+    for (var i = 0; i < this.length; ++i) if (pred(this[i], i)) return true;
+  };
+
+  AP.forEach = AP.forEach || function(f) {
+    for (var i = 0; i < this.length; ++i) f(this[i], i);
+  };
+
+  AP.indexOf = AP.indexOf || function(x, start) {
+    for (var i = start || 0; i < this.length; ++i) if (this[i] === x) return i;
+    return -1;
+  };
+
+  AP.lastIndexOf = AP.lastIndexOf || function(x, start) {
+    for (var i = start == null ? this.length - 1 : start; i >= 0; ++i) if (this[i] === x) return i;
+    return -1;
+  };
+
+  AP.map = AP.map || function(f) {
+    for (var r = [], i = 0; i < this.length; ++i) r.push(f(this[i], i));
+    return r;
+  };
+
+  Array.isArray = Array.isArray || function(v) {
+    return Object.prototype.toString.call(v) == "[object Array]";
+  };
+
+  String.prototype.trim = String.prototype.trim || function() {
+    var from = 0, to = this.length;
+    while (/\s/.test(this.charAt(from))) ++from;
+    while (/\s/.test(this.charAt(to - 1))) --to;
+    return this.slice(from, to);
+  };
+
+/*! JSON v3.2.4 | http://bestiejs.github.com/json3 | Copyright 2012, Kit Cambridge | http://kit.mit-license.org */
+if (!window.JSON) (function(){var e=void 0,i=!0,k=null,l={}.toString,m,n,p="function"===typeof define&&define.c,q=!p&&"object"==typeof exports&&exports;q||p?"object"==typeof JSON&&JSON?p?q=JSON:(q.stringify=JSON.stringify,q.parse=JSON.parse):p&&(q=this.JSON={}):q=this.JSON||(this.JSON={});var r,t,u,x,z,B,C,D,E,F,G,H,I,J=new Date(-3509827334573292),K,O,P;try{J=-109252==J.getUTCFullYear()&&0===J.getUTCMonth()&&1==J.getUTCDate()&&10==J.getUTCHours()&&37==J.getUTCMinutes()&&6==J.getUTCSeconds()&&708==J.getUTCMilliseconds()}catch(Q){}
+function R(b){var c,a,d,j=b=="json";if(j||b=="json-stringify"||b=="json-parse"){if(b=="json-stringify"||j){if(c=typeof q.stringify=="function"&&J){(d=function(){return 1}).toJSON=d;try{c=q.stringify(0)==="0"&&q.stringify(new Number)==="0"&&q.stringify(new String)=='""'&&q.stringify(l)===e&&q.stringify(e)===e&&q.stringify()===e&&q.stringify(d)==="1"&&q.stringify([d])=="[1]"&&q.stringify([e])=="[null]"&&q.stringify(k)=="null"&&q.stringify([e,l,k])=="[null,null,null]"&&q.stringify({A:[d,i,false,k,"\x00\u0008\n\u000c\r\t"]})==
+'{"A":[1,true,false,null,"\\u0000\\b\\n\\f\\r\\t"]}'&&q.stringify(k,d)==="1"&&q.stringify([1,2],k,1)=="[\n 1,\n 2\n]"&&q.stringify(new Date(-864E13))=='"-271821-04-20T00:00:00.000Z"'&&q.stringify(new Date(864E13))=='"+275760-09-13T00:00:00.000Z"'&&q.stringify(new Date(-621987552E5))=='"-000001-01-01T00:00:00.000Z"'&&q.stringify(new Date(-1))=='"1969-12-31T23:59:59.999Z"'}catch(f){c=false}}if(!j)return c}if(b=="json-parse"||j){if(typeof q.parse=="function")try{if(q.parse("0")===0&&!q.parse(false)){d=
+q.parse('{"A":[1,true,false,null,"\\u0000\\b\\n\\f\\r\\t"]}');if(a=d.a.length==5&&d.a[0]==1){try{a=!q.parse('"\t"')}catch(o){}if(a)try{a=q.parse("01")!=1}catch(g){}}}}catch(h){a=false}if(!j)return a}return c&&a}}
+if(!R("json")){J||(K=Math.floor,O=[0,31,59,90,120,151,181,212,243,273,304,334],P=function(b,c){return O[c]+365*(b-1970)+K((b-1969+(c=+(c>1)))/4)-K((b-1901+c)/100)+K((b-1601+c)/400)});if(!(m={}.hasOwnProperty))m=function(b){var c={},a;if((c.__proto__=k,c.__proto__={toString:1},c).toString!=l)m=function(a){var b=this.__proto__,a=a in(this.__proto__=k,this);this.__proto__=b;return a};else{a=c.constructor;m=function(b){var c=(this.constructor||a).prototype;return b in this&&!(b in c&&this[b]===c[b])}}c=
+k;return m.call(this,b)};n=function(b,c){var a=0,d,j,f;(d=function(){this.valueOf=0}).prototype.valueOf=0;j=new d;for(f in j)m.call(j,f)&&a++;d=j=k;if(a)a=a==2?function(a,b){var c={},d=l.call(a)=="[object Function]",f;for(f in a)!(d&&f=="prototype")&&!m.call(c,f)&&(c[f]=1)&&m.call(a,f)&&b(f)}:function(a,b){var c=l.call(a)=="[object Function]",d,f;for(d in a)!(c&&d=="prototype")&&m.call(a,d)&&!(f=d==="constructor")&&b(d);(f||m.call(a,d="constructor"))&&b(d)};else{j=["valueOf","toString","toLocaleString",
+"propertyIsEnumerable","isPrototypeOf","hasOwnProperty","constructor"];a=function(a,b){var c=l.call(a)=="[object Function]",d;for(d in a)!(c&&d=="prototype")&&m.call(a,d)&&b(d);for(c=j.length;d=j[--c];m.call(a,d)&&b(d));}}a(b,c)};R("json-stringify")||(r={"\\":"\\\\",'"':'\\"',"\u0008":"\\b","\u000c":"\\f","\n":"\\n","\r":"\\r","\t":"\\t"},t=function(b,c){return("000000"+(c||0)).slice(-b)},u=function(b){for(var c='"',a=0,d;d=b.charAt(a);a++)c=c+('\\"\u0008\u000c\n\r\t'.indexOf(d)>-1?r[d]:r[d]=d<" "?
+"\\u00"+t(2,d.charCodeAt(0).toString(16)):d);return c+'"'},x=function(b,c,a,d,j,f,o){var g=c[b],h,s,v,w,L,M,N,y,A;if(typeof g=="object"&&g){h=l.call(g);if(h=="[object Date]"&&!m.call(g,"toJSON"))if(g>-1/0&&g<1/0){if(P){v=K(g/864E5);for(h=K(v/365.2425)+1970-1;P(h+1,0)<=v;h++);for(s=K((v-P(h,0))/30.42);P(h,s+1)<=v;s++);v=1+v-P(h,s);w=(g%864E5+864E5)%864E5;L=K(w/36E5)%24;M=K(w/6E4)%60;N=K(w/1E3)%60;w=w%1E3}else{h=g.getUTCFullYear();s=g.getUTCMonth();v=g.getUTCDate();L=g.getUTCHours();M=g.getUTCMinutes();
+N=g.getUTCSeconds();w=g.getUTCMilliseconds()}g=(h<=0||h>=1E4?(h<0?"-":"+")+t(6,h<0?-h:h):t(4,h))+"-"+t(2,s+1)+"-"+t(2,v)+"T"+t(2,L)+":"+t(2,M)+":"+t(2,N)+"."+t(3,w)+"Z"}else g=k;else if(typeof g.toJSON=="function"&&(h!="[object Number]"&&h!="[object String]"&&h!="[object Array]"||m.call(g,"toJSON")))g=g.toJSON(b)}a&&(g=a.call(c,b,g));if(g===k)return"null";h=l.call(g);if(h=="[object Boolean]")return""+g;if(h=="[object Number]")return g>-1/0&&g<1/0?""+g:"null";if(h=="[object String]")return u(g);if(typeof g==
+"object"){for(b=o.length;b--;)if(o[b]===g)throw TypeError();o.push(g);y=[];c=f;f=f+j;if(h=="[object Array]"){s=0;for(b=g.length;s<b;A||(A=i),s++){h=x(s,g,a,d,j,f,o);y.push(h===e?"null":h)}b=A?j?"[\n"+f+y.join(",\n"+f)+"\n"+c+"]":"["+y.join(",")+"]":"[]"}else{n(d||g,function(b){var c=x(b,g,a,d,j,f,o);c!==e&&y.push(u(b)+":"+(j?" ":"")+c);A||(A=i)});b=A?j?"{\n"+f+y.join(",\n"+f)+"\n"+c+"}":"{"+y.join(",")+"}":"{}"}o.pop();return b}},q.stringify=function(b,c,a){var d,j,f,o,g,h;if(typeof c=="function"||
+typeof c=="object"&&c)if(l.call(c)=="[object Function]")j=c;else if(l.call(c)=="[object Array]"){f={};o=0;for(g=c.length;o<g;h=c[o++],(l.call(h)=="[object String]"||l.call(h)=="[object Number]")&&(f[h]=1));}if(a)if(l.call(a)=="[object Number]"){if((a=a-a%1)>0){d="";for(a>10&&(a=10);d.length<a;d=d+" ");}}else l.call(a)=="[object String]"&&(d=a.length<=10?a:a.slice(0,10));return x("",(h={},h[""]=b,h),j,f,d,"",[])});R("json-parse")||(z=String.fromCharCode,B={"\\":"\\",'"':'"',"/":"/",b:"\u0008",t:"\t",
+n:"\n",f:"\u000c",r:"\r"},C=function(){H=I=k;throw SyntaxError();},D=function(){for(var b=I,c=b.length,a,d,j,f,o;H<c;){a=b.charAt(H);if("\t\r\n ".indexOf(a)>-1)H++;else{if("{}[]:,".indexOf(a)>-1){H++;return a}if(a=='"'){d="@";for(H++;H<c;){a=b.charAt(H);if(a<" ")C();else if(a=="\\"){a=b.charAt(++H);if('\\"/btnfr'.indexOf(a)>-1){d=d+B[a];H++}else if(a=="u"){j=++H;for(f=H+4;H<f;H++){a=b.charAt(H);a>="0"&&a<="9"||a>="a"&&a<="f"||a>="A"&&a<="F"||C()}d=d+z("0x"+b.slice(j,H))}else C()}else{if(a=='"')break;
+d=d+a;H++}}if(b.charAt(H)=='"'){H++;return d}}else{j=H;if(a=="-"){o=i;a=b.charAt(++H)}if(a>="0"&&a<="9"){for(a=="0"&&(a=b.charAt(H+1),a>="0"&&a<="9")&&C();H<c&&(a=b.charAt(H),a>="0"&&a<="9");H++);if(b.charAt(H)=="."){for(f=++H;f<c&&(a=b.charAt(f),a>="0"&&a<="9");f++);f==H&&C();H=f}a=b.charAt(H);if(a=="e"||a=="E"){a=b.charAt(++H);(a=="+"||a=="-")&&H++;for(f=H;f<c&&(a=b.charAt(f),a>="0"&&a<="9");f++);f==H&&C();H=f}return+b.slice(j,H)}o&&C();if(b.slice(H,H+4)=="true"){H=H+4;return i}if(b.slice(H,H+5)==
+"false"){H=H+5;return false}if(b.slice(H,H+4)=="null"){H=H+4;return k}}C()}}return"$"},E=function(b){var c,a;b=="$"&&C();if(typeof b=="string"){if(b.charAt(0)=="@")return b.slice(1);if(b=="["){for(c=[];;a||(a=i)){b=D();if(b=="]")break;if(a)if(b==","){b=D();b=="]"&&C()}else C();b==","&&C();c.push(E(b))}return c}if(b=="{"){for(c={};;a||(a=i)){b=D();if(b=="}")break;if(a)if(b==","){b=D();b=="}"&&C()}else C();(b==","||typeof b!="string"||b.charAt(0)!="@"||D()!=":")&&C();c[b.slice(1)]=E(D())}return c}C()}return b},
+G=function(b,c,a){a=F(b,c,a);a===e?delete b[c]:b[c]=a},F=function(b,c,a){var d=b[c],j;if(typeof d=="object"&&d)if(l.call(d)=="[object Array]")for(j=d.length;j--;)G(d,j,a);else n(d,function(b){G(d,b,a)});return a.call(b,c,d)},q.parse=function(b,c){var a,d;H=0;I=b;a=E(D());D()!="$"&&C();H=I=k;return c&&l.call(c)=="[object Function]"?F((d={},d[""]=a,d),"",c):a})}p&&define(function(){return q});
+}());
+})();

--- a/editor/js/libs/ternjs/signal.js
+++ b/editor/js/libs/ternjs/signal.js
@@ -1,0 +1,26 @@
+(function(root, mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    return mod(exports);
+  if (typeof define == "function" && define.amd) // AMD
+    return define(["exports"], mod);
+  mod((root.tern || (root.tern = {})).signal = {}); // Plain browser env
+})(this, function(exports) {
+  function on(type, f) {
+    var handlers = this._handlers || (this._handlers = Object.create(null));
+    (handlers[type] || (handlers[type] = [])).push(f);
+  }
+  function off(type, f) {
+    var arr = this._handlers && this._handlers[type];
+    if (arr) for (var i = 0; i < arr.length; ++i)
+      if (arr[i] == f) { arr.splice(i, 1); break; }
+  }
+  function signal(type, a1, a2, a3, a4) {
+    var arr = this._handlers && this._handlers[type];
+    if (arr) for (var i = 0; i < arr.length; ++i) arr[i].call(this, a1, a2, a3, a4);
+  }
+
+  exports.mixin = function(obj) {
+    obj.on = on; obj.off = off; obj.signal = signal;
+    return obj;
+  };
+});

--- a/editor/js/libs/ternjs/tern.js
+++ b/editor/js/libs/ternjs/tern.js
@@ -1,0 +1,994 @@
+// The Tern server object
+
+// A server is a stateful object that manages the analysis for a
+// project, and defines an interface for querying the code in the
+// project.
+
+(function(root, mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    return mod(exports, require("./infer"), require("./signal"),
+               require("acorn"), require("acorn/dist/walk"));
+  if (typeof define == "function" && define.amd) // AMD
+    return define(["exports", "./infer", "./signal", "acorn/dist/acorn", "acorn/dist/walk"], mod);
+  mod(root.tern || (root.tern = {}), tern, tern.signal, acorn, acorn.walk); // Plain browser env
+})(this, function(exports, infer, signal, acorn, walk) {
+  "use strict";
+
+  var plugins = Object.create(null);
+  exports.registerPlugin = function(name, init) { plugins[name] = init; };
+
+  var defaultOptions = exports.defaultOptions = {
+    debug: false,
+    async: false,
+    getFile: function(_f, c) { if (this.async) c(null, null); },
+    defs: [],
+    plugins: {},
+    fetchTimeout: 1000,
+    dependencyBudget: 20000,
+    reuseInstances: true,
+    stripCRs: false
+  };
+
+  var queryTypes = {
+    completions: {
+      takesFile: true,
+      run: findCompletions
+    },
+    properties: {
+      run: findProperties
+    },
+    type: {
+      takesFile: true,
+      run: findTypeAt
+    },
+    documentation: {
+      takesFile: true,
+      run: findDocs
+    },
+    definition: {
+      takesFile: true,
+      run: findDef
+    },
+    refs: {
+      takesFile: true,
+      fullFile: true,
+      run: findRefs
+    },
+    rename: {
+      takesFile: true,
+      fullFile: true,
+      run: buildRename
+    },
+    files: {
+      run: listFiles
+    }
+  };
+
+  exports.defineQueryType = function(name, desc) { queryTypes[name] = desc; };
+
+  function File(name, parent) {
+    this.name = name;
+    this.parent = parent;
+    this.scope = this.text = this.ast = this.lineOffsets = null;
+  }
+  File.prototype.asLineChar = function(pos) { return asLineChar(this, pos); };
+
+  function updateText(file, text, srv) {
+    file.text = srv.options.stripCRs ? text.replace(/\r\n/g, "\n") : text;
+    infer.withContext(srv.cx, function() {
+      file.ast = infer.parse(file.text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
+    });
+    file.lineOffsets = null;
+  }
+
+  var Server = exports.Server = function(options) {
+    this.cx = null;
+    this.options = options || {};
+    for (var o in defaultOptions) if (!options.hasOwnProperty(o))
+      options[o] = defaultOptions[o];
+
+    this.handlers = Object.create(null);
+    this.files = [];
+    this.fileMap = Object.create(null);
+    this.needsPurge = [];
+    this.budgets = Object.create(null);
+    this.uses = 0;
+    this.pending = 0;
+    this.asyncError = null;
+    this.passes = Object.create(null);
+
+    this.defs = options.defs.slice(0);
+    for (var plugin in options.plugins) if (options.plugins.hasOwnProperty(plugin) && plugin in plugins) {
+      var init = plugins[plugin](this, options.plugins[plugin]);
+      if (init && init.defs) {
+        if (init.loadFirst) this.defs.unshift(init.defs);
+        else this.defs.push(init.defs);
+      }
+      if (init && init.passes) for (var type in init.passes) if (init.passes.hasOwnProperty(type))
+        (this.passes[type] || (this.passes[type] = [])).push(init.passes[type]);
+    }
+
+    this.reset();
+  };
+  Server.prototype = signal.mixin({
+    addFile: function(name, /*optional*/ text, parent) {
+      // Don't crash when sloppy plugins pass non-existent parent ids
+      if (parent && !(parent in this.fileMap)) parent = null;
+      ensureFile(this, name, parent, text);
+    },
+    delFile: function(name) {
+      var file = this.findFile(name);
+      if (file) {
+        this.needsPurge.push(file.name);
+        this.files.splice(this.files.indexOf(file), 1);
+        delete this.fileMap[name];
+      }
+    },
+    reset: function() {
+      this.signal("reset");
+      this.cx = new infer.Context(this.defs, this);
+      this.uses = 0;
+      this.budgets = Object.create(null);
+      for (var i = 0; i < this.files.length; ++i) {
+        var file = this.files[i];
+        file.scope = null;
+      }
+    },
+
+    request: function(doc, c) {
+      var inv = invalidDoc(doc);
+      if (inv) return c(inv);
+
+      var self = this;
+      doRequest(this, doc, function(err, data) {
+        c(err, data);
+        if (self.uses > 40) {
+          self.reset();
+          analyzeAll(self, null, function(){});
+        }
+      });
+    },
+
+    findFile: function(name) {
+      return this.fileMap[name];
+    },
+
+    flush: function(c) {
+      var cx = this.cx;
+      analyzeAll(this, null, function(err) {
+        if (err) return c(err);
+        infer.withContext(cx, c);
+      });
+    },
+
+    startAsyncAction: function() {
+      ++this.pending;
+    },
+    finishAsyncAction: function(err) {
+      if (err) this.asyncError = err;
+      if (--this.pending === 0) this.signal("everythingFetched");
+    }
+  });
+
+  function doRequest(srv, doc, c) {
+    if (doc.query && !queryTypes.hasOwnProperty(doc.query.type))
+      return c("No query type '" + doc.query.type + "' defined");
+
+    var query = doc.query;
+    // Respond as soon as possible when this just uploads files
+    if (!query) c(null, {});
+
+    var files = doc.files || [];
+    if (files.length) ++srv.uses;
+    for (var i = 0; i < files.length; ++i) {
+      var file = files[i];
+      if (file.type == "delete")
+        srv.delFile(file.name);
+      else
+        ensureFile(srv, file.name, null, file.type == "full" ? file.text : null);
+    }
+
+    var timeBudget = typeof doc.timeout == "number" ? [doc.timeout] : null;
+    if (!query) {
+      analyzeAll(srv, timeBudget, function(){});
+      return;
+    }
+
+    var queryType = queryTypes[query.type];
+    if (queryType.takesFile) {
+      if (typeof query.file != "string") return c(".query.file must be a string");
+      if (!/^#/.test(query.file)) ensureFile(srv, query.file, null);
+    }
+
+    analyzeAll(srv, timeBudget, function(err) {
+      if (err) return c(err);
+      var file = queryType.takesFile && resolveFile(srv, files, query.file);
+      if (queryType.fullFile && file.type == "part")
+        return c("Can't run a " + query.type + " query on a file fragment");
+
+      function run() {
+        var result;
+        try {
+          result = queryType.run(srv, query, file);
+        } catch (e) {
+          if (srv.options.debug && e.name != "TernError") console.error(e.stack);
+          return c(e);
+        }
+        c(null, result);
+      }
+      infer.withContext(srv.cx, timeBudget ? function() { infer.withTimeout(timeBudget[0], run); } : run);
+    });
+  }
+
+  function analyzeFile(srv, file) {
+    infer.withContext(srv.cx, function() {
+      file.scope = srv.cx.topScope;
+      srv.signal("beforeLoad", file);
+      infer.analyze(file.ast, file.name, file.scope, srv.passes);
+      srv.signal("afterLoad", file);
+    });
+    return file;
+  }
+
+  function ensureFile(srv, name, parent, text) {
+    var known = srv.findFile(name);
+    if (known) {
+      if (text != null) {
+        if (known.scope) {
+          srv.needsPurge.push(name);
+          known.scope = null;
+        }
+        updateText(known, text, srv);
+      }
+      if (parentDepth(srv, known.parent) > parentDepth(srv, parent)) {
+        known.parent = parent;
+        if (known.excluded) known.excluded = null;
+      }
+      return;
+    }
+
+    var file = new File(name, parent);
+    srv.files.push(file);
+    srv.fileMap[name] = file;
+    if (text != null) {
+      updateText(file, text, srv);
+    } else if (srv.options.async) {
+      srv.startAsyncAction();
+      srv.options.getFile(name, function(err, text) {
+        updateText(file, text || "", srv);
+        srv.finishAsyncAction(err);
+      });
+    } else {
+      updateText(file, srv.options.getFile(name) || "", srv);
+    }
+  }
+
+  function fetchAll(srv, c) {
+    var done = true, returned = false;
+    srv.files.forEach(function(file) {
+      if (file.text != null) return;
+      if (srv.options.async) {
+        done = false;
+        srv.options.getFile(file.name, function(err, text) {
+          if (err && !returned) { returned = true; return c(err); }
+          updateText(file, text || "", srv);
+          fetchAll(srv, c);
+        });
+      } else {
+        try {
+          updateText(file, srv.options.getFile(file.name) || "", srv);
+        } catch (e) { return c(e); }
+      }
+    });
+    if (done) c();
+  }
+
+  function waitOnFetch(srv, timeBudget, c) {
+    var done = function() {
+      srv.off("everythingFetched", done);
+      clearTimeout(timeout);
+      analyzeAll(srv, timeBudget, c);
+    };
+    srv.on("everythingFetched", done);
+    var timeout = setTimeout(done, srv.options.fetchTimeout);
+  }
+
+  function analyzeAll(srv, timeBudget, c) {
+    if (srv.pending) return waitOnFetch(srv, timeBudget, c);
+
+    var e = srv.fetchError;
+    if (e) { srv.fetchError = null; return c(e); }
+
+    if (srv.needsPurge.length > 0) infer.withContext(srv.cx, function() {
+      infer.purge(srv.needsPurge);
+      srv.needsPurge.length = 0;
+    });
+
+    var done = true;
+    // The second inner loop might add new files. The outer loop keeps
+    // repeating both inner loops until all files have been looked at.
+    for (var i = 0; i < srv.files.length;) {
+      var toAnalyze = [];
+      for (; i < srv.files.length; ++i) {
+        var file = srv.files[i];
+        if (file.text == null) done = false;
+        else if (file.scope == null && !file.excluded) toAnalyze.push(file);
+      }
+      toAnalyze.sort(function(a, b) {
+        return parentDepth(srv, a.parent) - parentDepth(srv, b.parent);
+      });
+      for (var j = 0; j < toAnalyze.length; j++) {
+        var file = toAnalyze[j];
+        if (file.parent && !chargeOnBudget(srv, file)) {
+          file.excluded = true;
+        } else if (timeBudget) {
+          var startTime = +new Date;
+          infer.withTimeout(timeBudget[0], function() { analyzeFile(srv, file); });
+          timeBudget[0] -= +new Date - startTime;
+        } else {
+          analyzeFile(srv, file);
+        }
+      }
+    }
+    if (done) c();
+    else waitOnFetch(srv, timeBudget, c);
+  }
+
+  function firstLine(str) {
+    var end = str.indexOf("\n");
+    if (end < 0) return str;
+    return str.slice(0, end);
+  }
+
+  function findMatchingPosition(line, file, near) {
+    var pos = Math.max(0, near - 500), closest = null;
+    if (!/^\s*$/.test(line)) for (;;) {
+      var found = file.indexOf(line, pos);
+      if (found < 0 || found > near + 500) break;
+      if (closest == null || Math.abs(closest - near) > Math.abs(found - near))
+        closest = found;
+      pos = found + line.length;
+    }
+    return closest;
+  }
+
+  function scopeDepth(s) {
+    for (var i = 0; s; ++i, s = s.prev) {}
+    return i;
+  }
+
+  function ternError(msg) {
+    var err = new Error(msg);
+    err.name = "TernError";
+    return err;
+  }
+
+  function resolveFile(srv, localFiles, name) {
+    var isRef = name.match(/^#(\d+)$/);
+    if (!isRef) return srv.findFile(name);
+
+    var file = localFiles[isRef[1]];
+    if (!file || file.type == "delete") throw ternError("Reference to unknown file " + name);
+    if (file.type == "full") return srv.findFile(file.name);
+
+    // This is a partial file
+
+    var realFile = file.backing = srv.findFile(file.name);
+    var offset = file.offset;
+    if (file.offsetLines) offset = {line: file.offsetLines, ch: 0};
+    file.offset = offset = resolvePos(realFile, file.offsetLines == null ? file.offset : {line: file.offsetLines, ch: 0}, true);
+    var line = firstLine(file.text);
+    var foundPos = findMatchingPosition(line, realFile.text, offset);
+    var pos = foundPos == null ? Math.max(0, realFile.text.lastIndexOf("\n", offset)) : foundPos;
+    var inObject, atFunction;
+
+    infer.withContext(srv.cx, function() {
+      infer.purge(file.name, pos, pos + file.text.length);
+
+      var text = file.text, m;
+      if (m = text.match(/(?:"([^"]*)"|([\w$]+))\s*:\s*function\b/)) {
+        var objNode = walk.findNodeAround(file.backing.ast, pos, "ObjectExpression");
+        if (objNode && objNode.node.objType)
+          inObject = {type: objNode.node.objType, prop: m[2] || m[1]};
+      }
+      if (foundPos && (m = line.match(/^(.*?)\bfunction\b/))) {
+        var cut = m[1].length, white = "";
+        for (var i = 0; i < cut; ++i) white += " ";
+        text = white + text.slice(cut);
+        atFunction = true;
+      }
+
+      var scopeStart = infer.scopeAt(realFile.ast, pos, realFile.scope);
+      var scopeEnd = infer.scopeAt(realFile.ast, pos + text.length, realFile.scope);
+      var scope = file.scope = scopeDepth(scopeStart) < scopeDepth(scopeEnd) ? scopeEnd : scopeStart;
+      file.ast = infer.parse(text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
+      infer.analyze(file.ast, file.name, scope, srv.passes);
+
+      // This is a kludge to tie together the function types (if any)
+      // outside and inside of the fragment, so that arguments and
+      // return values have some information known about them.
+      tieTogether: if (inObject || atFunction) {
+        var newInner = infer.scopeAt(file.ast, line.length, scopeStart);
+        if (!newInner.fnType) break tieTogether;
+        if (inObject) {
+          var prop = inObject.type.getProp(inObject.prop);
+          prop.addType(newInner.fnType);
+        } else if (atFunction) {
+          var inner = infer.scopeAt(realFile.ast, pos + line.length, realFile.scope);
+          if (inner == scopeStart || !inner.fnType) break tieTogether;
+          var fOld = inner.fnType, fNew = newInner.fnType;
+          if (!fNew || (fNew.name != fOld.name && fOld.name)) break tieTogether;
+          for (var i = 0, e = Math.min(fOld.args.length, fNew.args.length); i < e; ++i)
+            fOld.args[i].propagate(fNew.args[i]);
+          fOld.self.propagate(fNew.self);
+          fNew.retval.propagate(fOld.retval);
+        }
+      }
+    });
+    return file;
+  }
+
+  // Budget management
+
+  function astSize(node) {
+    var size = 0;
+    walk.simple(node, {Expression: function() { ++size; }});
+    return size;
+  }
+
+  function parentDepth(srv, parent) {
+    var depth = 0;
+    while (parent) {
+      parent = srv.findFile(parent).parent;
+      ++depth;
+    }
+    return depth;
+  }
+
+  function budgetName(srv, file) {
+    for (;;) {
+      var parent = srv.findFile(file.parent);
+      if (!parent.parent) break;
+      file = parent;
+    }
+    return file.name;
+  }
+
+  function chargeOnBudget(srv, file) {
+    var bName = budgetName(srv, file);
+    var size = astSize(file.ast);
+    var known = srv.budgets[bName];
+    if (known == null)
+      known = srv.budgets[bName] = srv.options.dependencyBudget;
+    if (known < size) return false;
+    srv.budgets[bName] = known - size;
+    return true;
+  }
+
+  // Query helpers
+
+  function isPosition(val) {
+    return typeof val == "number" || typeof val == "object" &&
+      typeof val.line == "number" && typeof val.ch == "number";
+  }
+
+  // Baseline query document validation
+  function invalidDoc(doc) {
+    if (doc.query) {
+      if (typeof doc.query.type != "string") return ".query.type must be a string";
+      if (doc.query.start && !isPosition(doc.query.start)) return ".query.start must be a position";
+      if (doc.query.end && !isPosition(doc.query.end)) return ".query.end must be a position";
+    }
+    if (doc.files) {
+      if (!Array.isArray(doc.files)) return "Files property must be an array";
+      for (var i = 0; i < doc.files.length; ++i) {
+        var file = doc.files[i];
+        if (typeof file != "object") return ".files[n] must be objects";
+        else if (typeof file.name != "string") return ".files[n].name must be a string";
+        else if (file.type == "delete") continue;
+        else if (typeof file.text != "string") return ".files[n].text must be a string";
+        else if (file.type == "part") {
+          if (!isPosition(file.offset) && typeof file.offsetLines != "number")
+            return ".files[n].offset must be a position";
+        } else if (file.type != "full") return ".files[n].type must be \"full\" or \"part\"";
+      }
+    }
+  }
+
+  var offsetSkipLines = 25;
+
+  function findLineStart(file, line) {
+    var text = file.text, offsets = file.lineOffsets || (file.lineOffsets = [0]);
+    var pos = 0, curLine = 0;
+    var storePos = Math.min(Math.floor(line / offsetSkipLines), offsets.length - 1);
+    var pos = offsets[storePos], curLine = storePos * offsetSkipLines;
+
+    while (curLine < line) {
+      ++curLine;
+      pos = text.indexOf("\n", pos) + 1;
+      if (pos === 0) return null;
+      if (curLine % offsetSkipLines === 0) offsets.push(pos);
+    }
+    return pos;
+  }
+
+  var resolvePos = exports.resolvePos = function(file, pos, tolerant) {
+    if (typeof pos != "number") {
+      var lineStart = findLineStart(file, pos.line);
+      if (lineStart == null) {
+        if (tolerant) pos = file.text.length;
+        else throw ternError("File doesn't contain a line " + pos.line);
+      } else {
+        pos = lineStart + pos.ch;
+      }
+    }
+    if (pos > file.text.length) {
+      if (tolerant) pos = file.text.length;
+      else throw ternError("Position " + pos + " is outside of file.");
+    }
+    return pos;
+  };
+
+  function asLineChar(file, pos) {
+    if (!file) return {line: 0, ch: 0};
+    var offsets = file.lineOffsets || (file.lineOffsets = [0]);
+    var text = file.text, line, lineStart;
+    for (var i = offsets.length - 1; i >= 0; --i) if (offsets[i] <= pos) {
+      line = i * offsetSkipLines;
+      lineStart = offsets[i];
+    }
+    for (;;) {
+      var eol = text.indexOf("\n", lineStart);
+      if (eol >= pos || eol < 0) break;
+      lineStart = eol + 1;
+      ++line;
+    }
+    return {line: line, ch: pos - lineStart};
+  }
+
+  var outputPos = exports.outputPos = function(query, file, pos) {
+    if (query.lineCharPositions) {
+      var out = asLineChar(file, pos);
+      if (file.type == "part")
+        out.line += file.offsetLines != null ? file.offsetLines : asLineChar(file.backing, file.offset).line;
+      return out;
+    } else {
+      return pos + (file.type == "part" ? file.offset : 0);
+    }
+  };
+
+  // Delete empty fields from result objects
+  function clean(obj) {
+    for (var prop in obj) if (obj[prop] == null) delete obj[prop];
+    return obj;
+  }
+  function maybeSet(obj, prop, val) {
+    if (val != null) obj[prop] = val;
+  }
+
+  // Built-in query types
+
+  function compareCompletions(a, b) {
+    if (typeof a != "string") { a = a.name; b = b.name; }
+    var aUp = /^[A-Z]/.test(a), bUp = /^[A-Z]/.test(b);
+    if (aUp == bUp) return a < b ? -1 : a == b ? 0 : 1;
+    else return aUp ? 1 : -1;
+  }
+
+  function isStringAround(node, start, end) {
+    return node.type == "Literal" && typeof node.value == "string" &&
+      node.start == start - 1 && node.end <= end + 1;
+  }
+
+  function pointInProp(objNode, point) {
+    for (var i = 0; i < objNode.properties.length; i++) {
+      var curProp = objNode.properties[i];
+      if (curProp.key.start <= point && curProp.key.end >= point)
+        return curProp;
+    }
+  }
+
+  var jsKeywords = ("break do instanceof typeof case else new var " +
+    "catch finally return void continue for switch while debugger " +
+    "function this with default if throw delete in try").split(" ");
+
+  function findCompletions(srv, query, file) {
+    if (query.end == null) throw ternError("missing .query.end field");
+    if (srv.passes.completion) for (var i = 0; i < srv.passes.completion.length; i++) {
+      var result = srv.passes.completion[i](file, query);
+      if (result) return result;
+    }
+
+    var wordStart = resolvePos(file, query.end), wordEnd = wordStart, text = file.text;
+    while (wordStart && acorn.isIdentifierChar(text.charCodeAt(wordStart - 1))) --wordStart;
+    if (query.expandWordForward !== false)
+      while (wordEnd < text.length && acorn.isIdentifierChar(text.charCodeAt(wordEnd))) ++wordEnd;
+    var word = text.slice(wordStart, wordEnd), completions = [], ignoreObj;
+    if (query.caseInsensitive) word = word.toLowerCase();
+    var wrapAsObjs = query.types || query.depths || query.docs || query.urls || query.origins;
+
+    function gather(prop, obj, depth, addInfo) {
+      // 'hasOwnProperty' and such are usually just noise, leave them
+      // out when no prefix is provided.
+      if ((objLit || query.omitObjectPrototype !== false) && obj == srv.cx.protos.Object && !word) return;
+      if (query.filter !== false && word &&
+          (query.caseInsensitive ? prop.toLowerCase() : prop).indexOf(word) !== 0) return;
+      if (ignoreObj && ignoreObj.props[prop]) return;
+      for (var i = 0; i < completions.length; ++i) {
+        var c = completions[i];
+        if ((wrapAsObjs ? c.name : c) == prop) return;
+      }
+      var rec = wrapAsObjs ? {name: prop} : prop;
+      completions.push(rec);
+
+      if (obj && (query.types || query.docs || query.urls || query.origins)) {
+        var val = obj.props[prop];
+        infer.resetGuessing();
+        var type = val.getType();
+        rec.guess = infer.didGuess();
+        if (query.types)
+          rec.type = infer.toString(val);
+        if (query.docs)
+          maybeSet(rec, "doc", val.doc || type && type.doc);
+        if (query.urls)
+          maybeSet(rec, "url", val.url || type && type.url);
+        if (query.origins)
+          maybeSet(rec, "origin", val.origin || type && type.origin);
+      }
+      if (query.depths) rec.depth = depth;
+      if (wrapAsObjs && addInfo) addInfo(rec);
+    }
+
+    var hookname, prop, objType, isKey;
+
+    var exprAt = infer.findExpressionAround(file.ast, null, wordStart, file.scope);
+    var memberExpr, objLit;
+    // Decide whether this is an object property, either in a member
+    // expression or an object literal.
+    if (exprAt) {
+      if (exprAt.node.type == "MemberExpression" && exprAt.node.object.end < wordStart) {
+        memberExpr = exprAt;
+      } else if (isStringAround(exprAt.node, wordStart, wordEnd)) {
+        var parent = infer.parentNode(exprAt.node, file.ast);
+        if (parent.type == "MemberExpression" && parent.property == exprAt.node)
+          memberExpr = {node: parent, state: exprAt.state};
+      } else if (exprAt.node.type == "ObjectExpression") {
+        var objProp = pointInProp(exprAt.node, wordEnd);
+        if (objProp) {
+          objLit = exprAt;
+          prop = isKey = objProp.key.name;
+        } else if (!word && !/:\s*$/.test(file.text.slice(0, wordStart))) {
+          objLit = exprAt;
+          prop = isKey = true;
+        }
+      }
+    }
+
+    if (objLit) {
+      // Since we can't use the type of the literal itself to complete
+      // its properties (it doesn't contain the information we need),
+      // we have to try asking the surrounding expression for type info.
+      objType = infer.typeFromContext(file.ast, objLit);
+      ignoreObj = objLit.node.objType;
+    } else if (memberExpr) {
+      prop = memberExpr.node.property;
+      prop = prop.type == "Literal" ? prop.value.slice(1) : prop.name;
+      memberExpr.node = memberExpr.node.object;
+      objType = infer.expressionType(memberExpr);
+    } else if (text.charAt(wordStart - 1) == ".") {
+      var pathStart = wordStart - 1;
+      while (pathStart && (text.charAt(pathStart - 1) == "." || acorn.isIdentifierChar(text.charCodeAt(pathStart - 1)))) pathStart--;
+      var path = text.slice(pathStart, wordStart - 1);
+      if (path) {
+        objType = infer.def.parsePath(path, file.scope).getObjType();
+        prop = word;
+      }
+    }
+
+    if (prop != null) {
+      srv.cx.completingProperty = prop;
+
+      if (objType) infer.forAllPropertiesOf(objType, gather);
+
+      if (!completions.length && query.guess !== false && objType && objType.guessProperties)
+        objType.guessProperties(function(p, o, d) {if (p != prop && p != "✖") gather(p, o, d);});
+      if (!completions.length && word.length >= 2 && query.guess !== false)
+        for (var prop in srv.cx.props) gather(prop, srv.cx.props[prop][0], 0);
+      hookname = "memberCompletion";
+    } else {
+      infer.forAllLocalsAt(file.ast, wordStart, file.scope, gather);
+      if (query.includeKeywords) jsKeywords.forEach(function(kw) {
+        gather(kw, null, 0, function(rec) { rec.isKeyword = true; });
+      });
+      hookname = "variableCompletion";
+    }
+    if (srv.passes[hookname])
+      srv.passes[hookname].forEach(function(hook) {hook(file, wordStart, wordEnd, gather);});
+
+    if (query.sort !== false) completions.sort(compareCompletions);
+    srv.cx.completingProperty = null;
+
+    return {start: outputPos(query, file, wordStart),
+            end: outputPos(query, file, wordEnd),
+            isProperty: !!prop,
+            isObjectKey: !!isKey,
+            completions: completions};
+  }
+
+  function findProperties(srv, query) {
+    var prefix = query.prefix, found = [];
+    for (var prop in srv.cx.props)
+      if (prop != "<i>" && (!prefix || prop.indexOf(prefix) === 0)) found.push(prop);
+    if (query.sort !== false) found.sort(compareCompletions);
+    return {completions: found};
+  }
+
+  var findExpr = exports.findQueryExpr = function(file, query, wide) {
+    if (query.end == null) throw ternError("missing .query.end field");
+
+    if (query.variable) {
+      var scope = infer.scopeAt(file.ast, resolvePos(file, query.end), file.scope);
+      return {node: {type: "Identifier", name: query.variable, start: query.end, end: query.end + 1},
+              state: scope};
+    } else {
+      var start = query.start && resolvePos(file, query.start), end = resolvePos(file, query.end);
+      var expr = infer.findExpressionAt(file.ast, start, end, file.scope);
+      if (expr) return expr;
+      expr = infer.findExpressionAround(file.ast, start, end, file.scope);
+      if (expr && (expr.node.type == "ObjectExpression" || wide ||
+                   (start == null ? end : start) - expr.node.start < 20 || expr.node.end - end < 20))
+        return expr;
+      return null;
+    }
+  };
+
+  function findExprOrThrow(file, query, wide) {
+    var expr = findExpr(file, query, wide);
+    if (expr) return expr;
+    throw ternError("No expression at the given position.");
+  }
+
+  function ensureObj(tp) {
+    if (!tp || !(tp = tp.getType()) || !(tp instanceof infer.Obj)) return null;
+    return tp;
+  }
+
+  function findExprType(srv, query, file, expr) {
+    var type;
+    if (expr) {
+      infer.resetGuessing();
+      type = infer.expressionType(expr);
+    }
+    if (srv.passes["typeAt"]) {
+      var pos = resolvePos(file, query.end);
+      srv.passes["typeAt"].forEach(function(hook) {
+        type = hook(file, pos, expr, type);
+      });
+    }
+    if (!type) throw ternError("No type found at the given position.");
+
+    var objProp;
+    if (expr.node.type == "ObjectExpression" && query.end != null &&
+        (objProp = pointInProp(expr.node, resolvePos(file, query.end)))) {
+      var name = objProp.key.name;
+      var fromCx = ensureObj(infer.typeFromContext(file.ast, expr));
+      if (fromCx && fromCx.hasProp(name)) {
+        type = fromCx.hasProp(name);
+      } else {
+        var fromLocal = ensureObj(type);
+        if (fromLocal && fromLocal.hasProp(name))
+          type = fromLocal.hasProp(name);
+      }
+    }
+    return type;
+  };
+
+  function findTypeAt(srv, query, file) {
+    var expr = findExpr(file, query), exprName;
+    var type = findExprType(srv, query, file, expr), exprType = type;
+    if (query.preferFunction)
+      type = type.getFunctionType() || type.getType();
+    else
+      type = type.getType();
+
+    if (expr) {
+      if (expr.node.type == "Identifier")
+        exprName = expr.node.name;
+      else if (expr.node.type == "MemberExpression" && !expr.node.computed)
+        exprName = expr.node.property.name;
+    }
+
+    if (query.depth != null && typeof query.depth != "number")
+      throw ternError(".query.depth must be a number");
+
+    var result = {guess: infer.didGuess(),
+                  type: infer.toString(exprType, query.depth),
+                  name: type && type.name,
+                  exprName: exprName};
+    if (type) storeTypeDocs(type, result);
+    if (!result.doc && exprType.doc) result.doc = exprType.doc;
+
+    return clean(result);
+  }
+
+  function findDocs(srv, query, file) {
+    var expr = findExpr(file, query);
+    var type = findExprType(srv, query, file, expr);
+    var result = {url: type.url, doc: type.doc, type: infer.toString(type)};
+    var inner = type.getType();
+    if (inner) storeTypeDocs(inner, result);
+    return clean(result);
+  }
+
+  function storeTypeDocs(type, out) {
+    if (!out.url) out.url = type.url;
+    if (!out.doc) out.doc = type.doc;
+    if (!out.origin) out.origin = type.origin;
+    var ctor, boring = infer.cx().protos;
+    if (!out.url && !out.doc && type.proto && (ctor = type.proto.hasCtor) &&
+        type.proto != boring.Object && type.proto != boring.Function && type.proto != boring.Array) {
+      out.url = ctor.url;
+      out.doc = ctor.doc;
+    }
+  }
+
+  var getSpan = exports.getSpan = function(obj) {
+    if (!obj.origin) return;
+    if (obj.originNode) {
+      var node = obj.originNode;
+      if (/^Function/.test(node.type) && node.id) node = node.id;
+      return {origin: obj.origin, node: node};
+    }
+    if (obj.span) return {origin: obj.origin, span: obj.span};
+  };
+
+  var storeSpan = exports.storeSpan = function(srv, query, span, target) {
+    target.origin = span.origin;
+    if (span.span) {
+      var m = /^(\d+)\[(\d+):(\d+)\]-(\d+)\[(\d+):(\d+)\]$/.exec(span.span);
+      target.start = query.lineCharPositions ? {line: Number(m[2]), ch: Number(m[3])} : Number(m[1]);
+      target.end = query.lineCharPositions ? {line: Number(m[5]), ch: Number(m[6])} : Number(m[4]);
+    } else {
+      var file = srv.findFile(span.origin);
+      target.start = outputPos(query, file, span.node.start);
+      target.end = outputPos(query, file, span.node.end);
+    }
+  };
+
+  function findDef(srv, query, file) {
+    var expr = findExpr(file, query);
+    var type = findExprType(srv, query, file, expr);
+    if (infer.didGuess()) return {};
+
+    var span = getSpan(type);
+    var result = {url: type.url, doc: type.doc, origin: type.origin};
+
+    if (type.types) for (var i = type.types.length - 1; i >= 0; --i) {
+      var tp = type.types[i];
+      storeTypeDocs(tp, result);
+      if (!span) span = getSpan(tp);
+    }
+
+    if (span && span.node) { // refers to a loaded file
+      var spanFile = span.node.sourceFile || srv.findFile(span.origin);
+      var start = outputPos(query, spanFile, span.node.start), end = outputPos(query, spanFile, span.node.end);
+      result.start = start; result.end = end;
+      result.file = span.origin;
+      var cxStart = Math.max(0, span.node.start - 50);
+      result.contextOffset = span.node.start - cxStart;
+      result.context = spanFile.text.slice(cxStart, cxStart + 50);
+    } else if (span) { // external
+      result.file = span.origin;
+      storeSpan(srv, query, span, result);
+    }
+    return clean(result);
+  }
+
+  function findRefsToVariable(srv, query, file, expr, checkShadowing) {
+    var name = expr.node.name;
+
+    for (var scope = expr.state; scope && !(name in scope.props); scope = scope.prev) {}
+    if (!scope) throw ternError("Could not find a definition for " + name + " " + !!srv.cx.topScope.props.x);
+
+    var type, refs = [];
+    function storeRef(file) {
+      return function(node, scopeHere) {
+        if (checkShadowing) for (var s = scopeHere; s != scope; s = s.prev) {
+          var exists = s.hasProp(checkShadowing);
+          if (exists)
+            throw ternError("Renaming `" + name + "` to `" + checkShadowing + "` would make a variable at line " +
+                            (asLineChar(file, node.start).line + 1) + " point to the definition at line " +
+                            (asLineChar(file, exists.name.start).line + 1));
+        }
+        refs.push({file: file.name,
+                   start: outputPos(query, file, node.start),
+                   end: outputPos(query, file, node.end)});
+      };
+    }
+
+    if (scope.originNode) {
+      type = "local";
+      if (checkShadowing) {
+        for (var prev = scope.prev; prev; prev = prev.prev)
+          if (checkShadowing in prev.props) break;
+        if (prev) infer.findRefs(scope.originNode, scope, checkShadowing, prev, function(node) {
+          throw ternError("Renaming `" + name + "` to `" + checkShadowing + "` would shadow the definition used at line " +
+                          (asLineChar(file, node.start).line + 1));
+        });
+      }
+      infer.findRefs(scope.originNode, scope, name, scope, storeRef(file));
+    } else {
+      type = "global";
+      for (var i = 0; i < srv.files.length; ++i) {
+        var cur = srv.files[i];
+        infer.findRefs(cur.ast, cur.scope, name, scope, storeRef(cur));
+      }
+    }
+
+    return {refs: refs, type: type, name: name};
+  }
+
+  function findRefsToProperty(srv, query, expr, prop) {
+    var objType = infer.expressionType(expr).getObjType();
+    if (!objType) throw ternError("Couldn't determine type of base object.");
+
+    var refs = [];
+    function storeRef(file) {
+      return function(node) {
+        refs.push({file: file.name,
+                   start: outputPos(query, file, node.start),
+                   end: outputPos(query, file, node.end)});
+      };
+    }
+    for (var i = 0; i < srv.files.length; ++i) {
+      var cur = srv.files[i];
+      infer.findPropRefs(cur.ast, cur.scope, objType, prop.name, storeRef(cur));
+    }
+
+    return {refs: refs, name: prop.name};
+  }
+
+  function findRefs(srv, query, file) {
+    var expr = findExprOrThrow(file, query, true);
+    if (expr && expr.node.type == "Identifier") {
+      return findRefsToVariable(srv, query, file, expr);
+    } else if (expr && expr.node.type == "MemberExpression" && !expr.node.computed) {
+      var p = expr.node.property;
+      expr.node = expr.node.object;
+      return findRefsToProperty(srv, query, expr, p);
+    } else if (expr && expr.node.type == "ObjectExpression") {
+      var pos = resolvePos(file, query.end);
+      for (var i = 0; i < expr.node.properties.length; ++i) {
+        var k = expr.node.properties[i].key;
+        if (k.start <= pos && k.end >= pos)
+          return findRefsToProperty(srv, query, expr, k);
+      }
+    }
+    throw ternError("Not at a variable or property name.");
+  }
+
+  function buildRename(srv, query, file) {
+    if (typeof query.newName != "string") throw ternError(".query.newName should be a string");
+    var expr = findExprOrThrow(file, query);
+    if (!expr || expr.node.type != "Identifier") throw ternError("Not at a variable.");
+
+    var data = findRefsToVariable(srv, query, file, expr, query.newName), refs = data.refs;
+    delete data.refs;
+    data.files = srv.files.map(function(f){return f.name;});
+
+    var changes = data.changes = [];
+    for (var i = 0; i < refs.length; ++i) {
+      var use = refs[i];
+      use.text = query.newName;
+      changes.push(use);
+    }
+
+    return data;
+  }
+
+  function listFiles(srv) {
+    return {files: srv.files.map(function(f){return f.name;})};
+  }
+
+  exports.version = "0.11.1";
+});


### PR DESCRIPTION
- relates to #6585

Some notes:
- uses [tern-threejs module js](https://github.com/tylerwbell/tern-threejs/blob/master/threejs.js)
- uses auto-complete as you type behaviour
- does not automatically autocomplete single matches
- uses insensitive autocomplete matching in tern ([Related PR](https://github.com/codemirror/CodeMirror/pull/3308))
- since acorn loose parser is being used, esprima parser could be removed to reduce number of libs..
- not including tern definitions for browser dom and ecma5 to reduce suggestions for now

![screenshot 2015-06-06 12 16 58](https://cloud.githubusercontent.com/assets/314997/8018301/7b86299a-0c47-11e5-97d3-7ee53a105d79.png)

![screenshot 2015-06-06 12 17 21](https://cloud.githubusercontent.com/assets/314997/8018302/7f35c938-0c47-11e5-9937-939f5f8a2b81.png)

ping @mrdoob @tylerwbell
