### PR TITLE
Fix blending state management

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -66,6 +66,16 @@ THREE.WebGLState = function ( gl, paramThreeToGL ) {
 		}
 
 	};
+	
+	this.enableBlending = function(){
+		gl.enable( gl.BLEND );
+		currentBlending = null;
+	};
+	
+	this.disableBlending = function(){
+		gl.disable( gl.BLEND );
+		currentBlending = null;
+	};
 
 	this.setBlending = function ( blending, blendEquation, blendSrc, blendDst, blendEquationAlpha, blendSrcAlpha, blendDstAlpha ) {
 

--- a/src/renderers/webgl/plugins/LensFlarePlugin.js
+++ b/src/renderers/webgl/plugins/LensFlarePlugin.js
@@ -355,7 +355,7 @@ THREE.LensFlarePlugin = function ( renderer, flares ) {
 				gl.uniform2f( uniforms.scale, scale.x, scale.y );
 				gl.uniform3f( uniforms.screenPosition, screenPosition.x, screenPosition.y, screenPosition.z );
 
-				gl.disable( gl.BLEND );
+				renderer.state.disableBlending();
 				gl.enable( gl.DEPTH_TEST );
 
 				gl.drawElements( gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0 );
@@ -395,7 +395,7 @@ THREE.LensFlarePlugin = function ( renderer, flares ) {
 				// render flares
 
 				gl.uniform1i( uniforms.renderType, 2 );
-				gl.enable( gl.BLEND );
+				renderer.state.enableBlending();
 
 				for ( var j = 0, jl = flare.lensFlares.length; j < jl; j ++ ) {
 

--- a/src/renderers/webgl/plugins/ShadowMapPlugin.js
+++ b/src/renderers/webgl/plugins/ShadowMapPlugin.js
@@ -74,7 +74,7 @@ THREE.ShadowMapPlugin = function ( _renderer, _lights, _webglObjects, _webglObje
 		// set GL state for depth map
 
 		_gl.clearColor( 1, 1, 1, 1 );
-		_gl.disable( _gl.BLEND );
+		_renderer.state.disableBlending();
 
 		_gl.enable( _gl.CULL_FACE );
 		_gl.frontFace( _gl.CCW );
@@ -336,7 +336,7 @@ THREE.ShadowMapPlugin = function ( _renderer, _lights, _webglObjects, _webglObje
 		clearAlpha = _renderer.getClearAlpha();
 
 		_gl.clearColor( clearColor.r, clearColor.g, clearColor.b, clearAlpha );
-		_gl.enable( _gl.BLEND );
+		_renderer.state.enableBlending();
 
 		if ( _renderer.shadowMapCullFace === THREE.CullFaceFront ) {
 

--- a/src/renderers/webgl/plugins/SpritePlugin.js
+++ b/src/renderers/webgl/plugins/SpritePlugin.js
@@ -102,7 +102,7 @@ THREE.SpritePlugin = function ( renderer, sprites ) {
 		gl.enableVertexAttribArray( attributes.uv );
 
 		gl.disable( gl.CULL_FACE );
-		gl.enable( gl.BLEND );
+		renderer.state.enableBlending();
 
 		gl.bindBuffer( gl.ARRAY_BUFFER, vertexBuffer );
 		gl.vertexAttribPointer( attributes.position, 2, gl.FLOAT, false, 2 * 8, 0 );


### PR DESCRIPTION
I set the currentBlending to 'null' so that any later call to setBlending will be applied no matter what.
This might trigger some unnecessary gl calls if the glState === currentState.
But that would occur only (at worst) 3 times per render.

Tested changes on Sprites only.
This change fixes the issue and do not seems to introduce any problem.
https://github.com/mrdoob/three.js/issues/6666

Might require some more testing though
