### PR TITLE
Remove console log from PlaneGeometry

### DIFF
--- a/src/extras/geometries/PlaneGeometry.js
+++ b/src/extras/geometries/PlaneGeometry.js
@@ -5,8 +5,6 @@
 
 THREE.PlaneGeometry = function ( width, height, widthSegments, heightSegments ) {
 
-	console.log( 'THREE.PlaneGeometry: Consider using THREE.PlaneBufferGeometry for lower memory footprint.' );
-
 	THREE.Geometry.call( this );
 
 	this.type = 'PlaneGeometry';


### PR DESCRIPTION
Doesn't seem like we need a console log every time PlaneGeometry is used. Is PlaneGeometry really that bad?
