### PR TITLE
export material's transparency attribute in blender

### DIFF
--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -116,6 +116,7 @@ bpy.types.Material.THREE_blending_type = EnumProperty(
 
 bpy.types.Material.THREE_depth_write = BoolProperty(default=True)
 bpy.types.Material.THREE_depth_test = BoolProperty(default=True)
+bpy.types.Material.THREE_double_sided = BoolProperty(default=False)
 
 class ThreeMaterial(bpy.types.Panel):
     """Adds custom properties to the Materials of an object"""
@@ -149,6 +150,10 @@ class ThreeMaterial(bpy.types.Panel):
             row = layout.row()
             row.prop(mat, 'THREE_depth_test',
                      text="Enable depth testing")
+
+            row = layout.row()
+            row.prop(mat, 'THREE_double_sided',
+                     text="Double-sided")
 
 def _mag_filters(index):
     """Three.js mag filters

--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -289,6 +289,8 @@ NORMAL_BLENDING = 0
 VERTEX_COLORS_ON = 2
 VERTEX_COLORS_OFF = 0
 
+SIDE_DOUBLE = 2
+
 THREE_BASIC = 'MeshBasicMaterial'
 THREE_LAMBERT = 'MeshLambertMaterial'
 THREE_PHONG = 'MeshPhongMaterial'

--- a/utils/exporters/blender/addons/io_three/exporter/api/material.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/material.py
@@ -125,6 +125,24 @@ def depth_write(material):
 
 
 @_material
+def double_sided(material):
+    """
+
+    :param material:
+    :return: THREE_double_sided value
+    :rtype: bool
+
+    """
+    logger.debug("material.double_sided(%s)", material)
+    try:
+        write = material.THREE_double_sided
+    except AttributeError:
+        logger.debug("No THREE_double_sided attribute found")
+        write = False
+    return write
+
+
+@_material
 def diffuse_color(material):
     """
 

--- a/utils/exporters/blender/addons/io_three/exporter/material.py
+++ b/utils/exporters/blender/addons/io_three/exporter/material.py
@@ -46,6 +46,9 @@ class Material(base_classes.BaseNode):
         if api.material.transparent(self.node):
             self[constants.TRANSPARENT] = True
 
+        if api.material.double_sided(self.node):
+            self[constants.SIDE] = constants.SIDE_DOUBLE
+
         self[constants.DEPTH_TEST] = api.material.depth_test(self.node)
 
         self[constants.DEPTH_WRITE] = api.material.depth_write(self.node)

--- a/utils/exporters/blender/addons/io_three/exporter/material.py
+++ b/utils/exporters/blender/addons/io_three/exporter/material.py
@@ -43,6 +43,9 @@ class Material(base_classes.BaseNode):
 
         self[constants.BLENDING] = api.material.blending(self.node)
 
+        if api.material.transparent(self.node):
+            self[constants.TRANSPARENT] = True
+
         self[constants.DEPTH_TEST] = api.material.depth_test(self.node)
 
         self[constants.DEPTH_WRITE] = api.material.depth_write(self.node)


### PR DESCRIPTION
This fix checks if material has transparency enabled and adds an attribute to JSON. It adds nothing if transparency is disabled to save some space.

It also adds a "double-sided" checkbox to the material panel and exports it as "sides:2" if checked.
