### PR TITLE
Fix examples in Firefox

### DIFF
--- a/examples/webgl_geometry_colors_lookuptable.html
+++ b/examples/webgl_geometry_colors_lookuptable.html
@@ -112,7 +112,7 @@
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
-				window.addEventListener( "keypress", onKeyPress, true);
+				window.addEventListener( "keydown", onKeyDown, true);
 
 			}
 
@@ -272,7 +272,7 @@
 			}
 
 
-			function onKeyPress ( e ) {
+			function onKeyDown ( e ) {
 
 				var maps = [ 'rainbow', 'cooltowarm', 'blackbody', 'grayscale' ];
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -132,7 +132,7 @@
 			function onload() {
 
 				window.addEventListener( 'resize', onWindowResize, false );
-				document.addEventListener( 'keypress', function(e) { onKeyPress(e); }, false );
+				document.addEventListener( 'keydown', function(e) { onKeyDown(e); }, false );
 
 				buildSceneList();
 				switchScene(0);
@@ -343,7 +343,7 @@
 				renderer.render( scene, camera );
 			}
 
-			function onKeyPress(event) {
+			function onKeyDown(event) {
 
 				var chr = String.fromCharCode(event.keyCode);
 


### PR DESCRIPTION
Keyboard events handling for lookuptable and gltf examples does not work in Firefox.

In Firefox, `event.keyCode` is not defined for `keypress` events, only for `keyup` and `keydown`.

The fix is to use `keydown` instead of `keypress` for handling keyboard events, as the other examples do. `keypress` should be used for text input. `keydown` should be used for general keyboard events.
