### PR TITLE
Update FontUtils to fix #6709

### DIFF
--- a/src/extras/FontUtils.js
+++ b/src/extras/FontUtils.js
@@ -31,7 +31,7 @@ THREE.FontUtils = {
 
 		try {
 
-			return this.faces[ this.face ][ this.weight ][ this.style ];
+			return this.faces[ this.face.toLowerCase() ][ this.weight ][ this.style ];
 
 		} catch (e) {
 


### PR DESCRIPTION
This should be enough to make font family case independent.
