### PR TITLE
Add doctype and meta charset to example HTML

### DIFF
--- a/docs/manual/introduction/Creating-a-scene.html
+++ b/docs/manual/introduction/Creating-a-scene.html
@@ -21,8 +21,10 @@
 		<div>Before you can use Three.js, you need somewhere to display it. Save the following HTML to a file on your computer, along with a copy of <a href="http://threejs.org/build/three.min.js">three.min.js</a> in the js/ directory, and open it in your browser.</div>
 
 		<code>
+		&lt;!DOCTYPE html&gt;
 		&lt;html&gt;
 			&lt;head&gt;
+				&lt;meta charset=utf-8&gt;
 				&lt;title&gt;My first Three.js app&lt;/title&gt;
 				&lt;style&gt;
 					body { margin: 0; }


### PR DESCRIPTION
This means that people using this code:
- Are writing _valid_ HTML
- Won't have encoding issues (browsers always assume Windows-1252 unless told otherwise)
- Won't have their page rendered in quirks mode
- Aren't learning bad habits
