### PR TITLE
Gamma correction fixes

### DIFF
--- a/src/renderers/shaders/ShaderChunk/color_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/color_vertex.glsl
@@ -1,5 +1,5 @@
 #ifdef USE_COLOR
 
-	vColor.xyz = inputToLinear( color.xyz );
+	vColor.xyz = color.xyz;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/shadowmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_fragment.glsl
@@ -209,9 +209,6 @@
 
 	}
 
-	// NOTE: I am unsure if this is correct in linear space.  -bhouston, Dec 29, 2014
-	shadowColor = inputToLinear( shadowColor );
-
 	outgoingLight = outgoingLight * shadowColor;
 
 #endif


### PR DESCRIPTION
Vertex colors are now assumed to be in linear space. See https://github.com/mrdoob/three.js/issues/5838#issuecomment-68454839.

I also removed the inverse gamma-correction in the shadowmap shader. I agree with @bhouston that it does not appear to have any justification.
