### PR TITLE
Make OrbitControls compatible with CombinedCamera.

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -185,7 +185,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
-		if ( scope.object instanceof THREE.PerspectiveCamera ) {
+		if ( scope.object instanceof THREE.PerspectiveCamera || scope.object.inPerspectiveMode === true ) {
 
 			// perspective
 			var position = scope.object.position;
@@ -199,7 +199,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 			scope.panLeft( 2 * deltaX * targetDistance / element.clientHeight );
 			scope.panUp( 2 * deltaY * targetDistance / element.clientHeight );
 
-		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+		} else if ( scope.object instanceof THREE.OrthographicCamera || scope.object.inOrthographicMode === true ) {
 
 			// orthographic
 			scope.panLeft( deltaX * (scope.object.right - scope.object.left) / element.clientWidth );
@@ -222,11 +222,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
-		if ( scope.object instanceof THREE.PerspectiveCamera ) {
+		if ( scope.object instanceof THREE.PerspectiveCamera || scope.object.inPerspectiveMode === true ) {
 
 			scale /= dollyScale;
 
-		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+		} else if ( scope.object instanceof THREE.OrthographicCamera || scope.object.inOrthographicMode === true ) {
 
 			scope.object.zoom = Math.max( this.minZoom, Math.min( this.maxZoom, this.object.zoom * dollyScale ) );
 			scope.object.updateProjectionMatrix();
@@ -248,11 +248,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		}
 
-		if ( scope.object instanceof THREE.PerspectiveCamera ) {
+		if ( scope.object instanceof THREE.PerspectiveCamera || scope.object.inPerspectiveMode === true ) {
 
 			scale *= dollyScale;
 
-		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+		} else if ( scope.object instanceof THREE.OrthographicCamera || scope.object.inOrthographicMode === true ) {
 
 			scope.object.zoom = Math.max( this.minZoom, Math.min( this.maxZoom, this.object.zoom / dollyScale ) );
 			scope.object.updateProjectionMatrix();


### PR DESCRIPTION
I have been using r67 of three.js for a few months and chose to update to r71, which in turn caused some issues with regards to compatibility between CombinedCamera and OrbitControls. 
A simple fix, but thought it best to contribute it in case others need it and to make updates to future versions slightly easier.
