### PR TITLE
Make exporting data also work in Firefox

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -290,7 +290,13 @@ Menubar.File = function ( editor ) {
 		link.href = objectURL;
 		link.download = filename || 'data.json';
 		link.target = '_blank';
-		link.click();
+
+		var event = document.createEvent("MouseEvents");
+		event.initMouseEvent(
+			"click", true, false, window, 0, 0, 0, 0, 0
+			, false, false, false, false, 0, null
+		);
+		link.dispatchEvent(event);
 
 	};
 


### PR DESCRIPTION
This makes it possible to export string data in Firefox
