### PR TITLE
Fixed minor typos on AreaLight documentation

### DIFF
--- a/docs/api/lights/AreaLight.html
+++ b/docs/api/lights/AreaLight.html
@@ -16,9 +16,9 @@
 
 		<h2>Example</h2>
 		<h2>Example</h2>
-		
+
 		<div>[example:webgldeferred_arealights arealights ]</div>
-		
+
 		<code>areaLight1 = new THREE.AreaLight( 0xffffff, 1 );
 areaLight1.position.set( 0.0001, 10.0001, -18.5001 );
 areaLight1.rotation.set( -0.74719, 0.0001, 0.0001 );
@@ -46,23 +46,23 @@ scene.add( areaLight1 );</code>
 
 		<h3>[property:Vector3 right]</h3>
 		<div>
-		Sets or gets an unit vector that indicates the right side of the light. This is calculated in local space. 
-		</div> 
+		Sets or gets an unit vector that indicates the right side of the light. This is calculated in local space.
+		</div>
 
 		<h3>[property:Vector3 normal]</h3>
 		<div>
 		Sets or gets an unit vectorSets or gets an unit vector that indicates the right side of the light. This is calculated in local space.
-		</div> 
+		</div>
 
 		<h3>[property:number height]</h3>
 		<div>
-		Sets or gets the height of the illuminating plane. 
-		</div> 
+		Sets or gets the height of the illuminating plane.
+		</div>
 
 		<h3>[property:number width]</h3>
 		<div>
-		Sets or gets the width of the illuminating plane. 
-		</div> 
+		Sets or gets the width of the illuminating plane.
+		</div>
 
 		<h3>[property:Float intensity]</h3>
 		<div>
@@ -72,19 +72,19 @@ scene.add( areaLight1 );</code>
 
 		<h3>[property:number constantAttenuation]</h3>
 		<div>
-		Sets or gets the attention of the light in constant space. This is independant of the distance of the light. 
-		</div> 
+		Sets or gets the attenuation of the light in constant space. This is independant of the distance of the light.
+		</div>
 
 		<h3>[property:number linearAttenuation]</h3>
 		<div>
-		Sets or gets the attention of the light in linear space. This increases the attenuation linearly with the distance from the light.
-		</div> 
+		Sets or gets the attenuation of the light in linear space. This increases the attenuation linearly with the distance from the light.
+		</div>
 
 		<h3>[property:number quadraticAttenuation]</h3>
 		<div>
-		Sets or gets the attention of the light in linear space. This increases the attenuation quadratic with the distance from the light.
-		</div> 
-		
+		Sets or gets the attenuation of the light in quadratic space. This increases the attenuation quadraticly with the distance from the light.
+		</div>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]


### PR DESCRIPTION
I found a few typos in the AreaLight documentation while going through the attenuation descriptions, and decided to patch them up.  

(Apologies for the slightly awkward commit history before the final -- actual -- change :) )
