### PR TITLE
Fix parallaxmap shader crash

### DIFF
--- a/examples/js/shaders/ParallaxShader.js
+++ b/examples/js/shaders/ParallaxShader.js
@@ -82,7 +82,9 @@ THREE.ParallaxShader = {
 				"float heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
 
 				// while ( heightFromTexture > currentLayerHeight )
-				"for ( int i = 0; i == 0; i += 0 ) {",
+				// Infinite loops are not well supported. Do a "large" finite
+				// loop, but not too large, as it slows down some compilers.
+				"for ( int i = 0; i < 30; i += 1 ) {",
 					"if ( heightFromTexture <= currentLayerHeight ) {",
 						"break;",
 					"}",


### PR DESCRIPTION
Fixes #5813.

The infinite loop needs to be converted to a finite loop. I arbitrarily chose 30 as the max number of iterations for the loop to break on its own - it's not very large but experimentally, it seems to be enough.

I initially tried larger numbers, but they were causing trouble:
- The bigger the number, the slowest the shader. It takes approximately ~2 seconds for IE11 to compile the shader with `i < 250`.
- For any termination value above `277`, IE11 will simply not render...

For reference, Chrome and Firefox had no problem with very large termination condition.

The new loop header also fixes a warning in Chrome / ANGLE.
