### PR TITLE
Polyfill for es6 Function.Name

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -26,6 +26,23 @@ if ( Math.sign === undefined ) {
 
 }
 
+if ( Function.prototype.name === undefined && Object.defineProperty !== undefined ) {
+
+	// Missing in IE9-11.
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
+
+	Object.defineProperty( Function.prototype, 'name', {
+
+		get: function() {
+
+			var name = this.toString().match(/^\s*function\s*(\S*)\s*\(/)[1];
+			return name;
+
+		}
+
+	});
+}
+
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent.button
 
 THREE.MOUSE = { LEFT: 0, MIDDLE: 1, RIGHT: 2 };


### PR DESCRIPTION
Gets the name of a function (missing in IE9-11).

This is useful during serialization, to extract the name the constructor
function.

```
type = attribute.array.constructor.name; // e.g. "Float32Array"
```

Fixes #6349.
