### PR TITLE
TransformControls: undefined intersection

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -795,16 +795,20 @@
 
 					var planeIntersect = intersectObjects( pointer, [ scope.gizmo[_mode].activePlane ] );
 
-					oldPosition.copy( scope.object.position );
-					oldScale.copy( scope.object.scale );
+					if ( planeIntersect ) {
 
-					oldRotationMatrix.extractRotation( scope.object.matrix );
-					worldRotationMatrix.extractRotation( scope.object.matrixWorld );
+						oldPosition.copy( scope.object.position );
+						oldScale.copy( scope.object.scale );
 
-					parentRotationMatrix.extractRotation( scope.object.parent.matrixWorld );
-					parentScale.setFromMatrixScale( tempMatrix.getInverse( scope.object.parent.matrixWorld ) );
+						oldRotationMatrix.extractRotation( scope.object.matrix );
+						worldRotationMatrix.extractRotation( scope.object.matrixWorld );
 
-					offset.copy( planeIntersect.point );
+						parentRotationMatrix.extractRotation( scope.object.parent.matrixWorld );
+						parentScale.setFromMatrixScale( tempMatrix.getInverse( scope.object.parent.matrixWorld ) );
+
+						offset.copy( planeIntersect.point );
+
+					}
 
 				}
 
@@ -818,12 +822,14 @@
 
 			if ( scope.object === undefined || scope.axis === null || _dragging === false ) return;
 
-			event.preventDefault();
-			event.stopPropagation();
-
 			var pointer = event.changedTouches ? event.changedTouches[0] : event;
 
 			var planeIntersect = intersectObjects( pointer, [ scope.gizmo[_mode].activePlane ] );
+
+			if ( planeIntersect === false ) return;
+
+			event.preventDefault();
+			event.stopPropagation();
 
 			point.copy( planeIntersect.point );
 


### PR DESCRIPTION
Avoid processing move events when the move target location is undefined.

This happens when the pointer (touch or mouse) location doesn't
intersect the active moving plane of the controls.

To reproduce in the editor:
1- select an object
2- select a moving plane
3- drag the object to the side until the moving plane is no longer
facing the camera.

The backside of the moving plane (now facing the camera) is not
intersected by the ray, therefore, the intersection point is undefined.
