### PR TITLE
Fix 404 to CompressedTextureLoader.js

### DIFF
--- a/examples/webgl_materials_texture_pvrtc.html
+++ b/examples/webgl_materials_texture_pvrtc.html
@@ -37,7 +37,6 @@
 		</div>
 
 		<script src="../build/three.min.js"></script>
-		<script src="js/loaders/CompressedTextureLoader.js"></script>
 		<script src="js/loaders/PVRLoader.js"></script>
 
 		<script src="js/Detector.js"></script>


### PR DESCRIPTION
CompressedTextureLoader is part of the main library since 6f06aa6 (r69).

Fixes PVRTC example #5807. This example is only supported on iOS.
