### PR TITLE
fix: material.wireLinewidth was ignored when rendering a BufferGeometry

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2487,7 +2487,18 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( object instanceof THREE.Mesh ) {
 
-			var mode = material.wireframe === true ? _gl.LINES : _gl.TRIANGLES;
+			var mode;
+
+			if ( material.wireframe ) {
+
+				mode = _gl.LINES;
+				state.setLineWidth( material.wireframeLinewidth * pixelRatio );
+
+			} else {
+
+				mode = _gl.TRIANGLES;
+
+			}
 
 			var index = geometry.attributes.index;
 


### PR DESCRIPTION
The renderBufferDirect and renderBuffer functions handle wireframe Meshes differently. This fixes it.
