### PR TITLE
WebGLRenderer modularization experiment

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -214,6 +214,18 @@ THREE.RGBA_PVRTC_4BPPV1_Format = 2102;
 THREE.RGBA_PVRTC_2BPPV1_Format = 2103;
 
 
+// UTILITIES
+
+THREE.extend = function( type, fnName, fn ) {
+	
+	if ( type !== undefined && type.prototype.hasOwnProperty( fnName ) === false ) {
+
+		type.prototype[fnName] = fn;
+
+	}
+
+};
+
 // DEPRECATED
 
 THREE.Projector = function () {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -232,6 +232,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 	// Extend renderable objects by injecting functions into their prototypes.
 	THREE.WebGLRenderFog().init();
 	THREE.WebGLRenderLights().init();
+	THREE.WebGLRenderMaterials().init();
 
 
 	//
@@ -2213,9 +2214,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
-			if ( material instanceof THREE.MeshPhongMaterial ||
-				 material instanceof THREE.MeshLambertMaterial ||
-				 material.lights ) {
+			if ( material.__supportsLights() ) {
 
 				if ( _lightsNeedUpdate ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -231,6 +231,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	// Extend renderable objects by injecting functions into their prototypes.
 	THREE.WebGLRenderFog().init();
+	THREE.WebGLRenderLights().init();
 
 
 	//
@@ -2224,10 +2225,14 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 
 				if ( refreshLights ) {
+
 					refreshUniformsLights( m_uniforms, _lights );
 					markUniformsLightsNeedsUpdate( m_uniforms, true );
+
 				} else {
+
 					markUniformsLightsNeedsUpdate( m_uniforms, false );
+
 				}
 
 			}
@@ -2511,17 +2516,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				var light = lights[ i ];
 
-				if ( ! light.castShadow ) continue;
-
-				if ( light instanceof THREE.SpotLight || ( light instanceof THREE.DirectionalLight && ! light.shadowCascade ) ) {
-
-					uniforms.shadowMap.value[ j ] = light.shadowMap;
-					uniforms.shadowMapSize.value[ j ] = light.shadowMapSize;
-
-					uniforms.shadowMatrix.value[ j ] = light.shadowMatrix;
-
-					uniforms.shadowDarkness.value[ j ] = light.shadowDarkness;
-					uniforms.shadowBias.value[ j ] = light.shadowBias;
+				if ( light.__refreshUniformsShadow( undefined, uniforms, j ) === true ) {
 
 					j ++;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2236,56 +2236,17 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
-			if ( material instanceof THREE.MeshBasicMaterial ||
-				 material instanceof THREE.MeshLambertMaterial ||
-				 material instanceof THREE.MeshPhongMaterial ) {
-
-				refreshUniformsCommon( m_uniforms, material );
-
-			}
-
 			// refresh single material specific uniforms
 
-			if ( material instanceof THREE.LineBasicMaterial ) {
+			if ( material.__refreshUniforms !== undefined ) {
 
-				refreshUniformsLine( m_uniforms, material );
-
-			} else if ( material instanceof THREE.LineDashedMaterial ) {
-
-				refreshUniformsLine( m_uniforms, material );
-				refreshUniformsDash( m_uniforms, material );
-
-			} else if ( material instanceof THREE.PointCloudMaterial ) {
-
-				refreshUniformsParticle( m_uniforms, material );
-
-			} else if ( material instanceof THREE.MeshPhongMaterial ) {
-
-				refreshUniformsPhong( m_uniforms, material );
-
-			} else if ( material instanceof THREE.MeshLambertMaterial ) {
-
-				refreshUniformsLambert( m_uniforms, material );
-
-			} else if ( material instanceof THREE.MeshBasicMaterial ) {
-
-				refreshUniformsBasic( m_uniforms, material );
-
-			} else if ( material instanceof THREE.MeshDepthMaterial ) {
-
-				m_uniforms.mNear.value = camera.near;
-				m_uniforms.mFar.value = camera.far;
-				m_uniforms.opacity.value = material.opacity;
-
-			} else if ( material instanceof THREE.MeshNormalMaterial ) {
-
-				m_uniforms.opacity.value = material.opacity;
+				material.__refreshUniforms( this, m_uniforms );
 
 			}
 
 			if ( object.receiveShadow && ! material._shadowPass ) {
 
-				refreshUniformsShadow( m_uniforms, lights );
+				refreshUniformsShadow( this, m_uniforms, lights );
 
 			}
 
@@ -2304,150 +2265,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 		}
 
 		return program;
-
-	}
-
-	// Uniforms (refresh uniforms objects)
-
-	function refreshUniformsCommon ( uniforms, material ) {
-
-		uniforms.opacity.value = material.opacity;
-
-		uniforms.diffuse.value = material.color;
-
-		uniforms.map.value = material.map;
-		uniforms.specularMap.value = material.specularMap;
-		uniforms.alphaMap.value = material.alphaMap;
-
-		if ( material.bumpMap ) {
-
-			uniforms.bumpMap.value = material.bumpMap;
-			uniforms.bumpScale.value = material.bumpScale;
-
-		}
-
-		if ( material.normalMap ) {
-
-			uniforms.normalMap.value = material.normalMap;
-			uniforms.normalScale.value.copy( material.normalScale );
-
-		}
-
-		// uv repeat and offset setting priorities
-		// 1. color map
-		// 2. specular map
-		// 3. normal map
-		// 4. bump map
-		// 5. alpha map
-		// 6. emissive map
-
-		var uvScaleMap;
-
-		if ( material.map ) {
-
-			uvScaleMap = material.map;
-
-		} else if ( material.specularMap ) {
-
-			uvScaleMap = material.specularMap;
-
-		} else if ( material.normalMap ) {
-
-			uvScaleMap = material.normalMap;
-
-		} else if ( material.bumpMap ) {
-
-			uvScaleMap = material.bumpMap;
-
-		} else if ( material.alphaMap ) {
-
-			uvScaleMap = material.alphaMap;
-
-		} else if ( material.emissiveMap ) {
-
-			uvScaleMap = material.emissiveMap;
-
-		}
-
-		if ( uvScaleMap !== undefined ) {
-
-			var offset = uvScaleMap.offset;
-			var repeat = uvScaleMap.repeat;
-
-			uniforms.offsetRepeat.value.set( offset.x, offset.y, repeat.x, repeat.y );
-
-		}
-
-		uniforms.envMap.value = material.envMap;
-		uniforms.flipEnvMap.value = ( material.envMap instanceof THREE.WebGLRenderTargetCube ) ? 1 : - 1;
-
-		uniforms.reflectivity.value = material.reflectivity;
-		uniforms.refractionRatio.value = material.refractionRatio;
-
-	}
-
-	function refreshUniformsLine ( uniforms, material ) {
-
-		uniforms.diffuse.value = material.color;
-		uniforms.opacity.value = material.opacity;
-
-	}
-
-	function refreshUniformsDash ( uniforms, material ) {
-
-		uniforms.dashSize.value = material.dashSize;
-		uniforms.totalSize.value = material.dashSize + material.gapSize;
-		uniforms.scale.value = material.scale;
-
-	}
-
-	function refreshUniformsParticle ( uniforms, material ) {
-
-		uniforms.psColor.value = material.color;
-		uniforms.opacity.value = material.opacity;
-		uniforms.size.value = material.size;
-		uniforms.scale.value = _canvas.height / 2.0; // TODO: Cache this.
-
-		uniforms.map.value = material.map;
-
-		if ( material.map !== null ) {
-
-			var offset = material.map.offset;
-			var repeat = material.map.repeat;
-
-			uniforms.offsetRepeat.value.set( offset.x, offset.y, repeat.x, repeat.y );
-
-		}
-
-	}
-
-	function refreshUniformsPhong ( uniforms, material ) {
-
-		uniforms.shininess.value = material.shininess;
-
-		uniforms.emissive.value = material.emissive;
-		uniforms.specular.value = material.specular;
-
-		uniforms.lightMap.value = material.lightMap;
-		uniforms.lightMapIntensity.value = material.lightMapIntensity;
-
-		uniforms.aoMap.value = material.aoMap;
-		uniforms.aoMapIntensity.value = material.aoMapIntensity;
-
-		uniforms.emissiveMap.value = material.emissiveMap;
-
-	}
-
-	function refreshUniformsLambert ( uniforms, material ) {
-
-		uniforms.emissive.value = material.emissive;
-
-	}
-
-	function refreshUniformsBasic ( uniforms, material ) {
-
-		uniforms.aoMap.value = material.aoMap;
-		uniforms.aoMapIntensity.value = material.aoMapIntensity;
 
 	}
 
@@ -2505,7 +2322,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function refreshUniformsShadow ( uniforms, lights ) {
+	function refreshUniformsShadow ( renderer, uniforms, lights ) {
 
 		if ( uniforms.shadowMatrix ) {
 
@@ -2515,7 +2332,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				var light = lights[ i ];
 
-				if ( light.__refreshUniformsShadow( undefined, uniforms, j ) === true ) {
+				if ( light.__refreshUniformsShadow( renderer, uniforms, j ) === true ) {
 
 					j ++;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -229,6 +229,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
+	// Extend renderable objects by injecting functions into their prototypes.
+	THREE.WebGLRenderFog().init();
+
+
 	//
 
 	var glClearColor = function ( r, g, b, a ) {
@@ -2204,7 +2208,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( fog && material.fog ) {
 
-				refreshUniformsFog( m_uniforms, fog );
+				fog.__refreshUniformsFog( renderer, m_uniforms );
 
 			}
 
@@ -2408,23 +2412,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 			var repeat = material.map.repeat;
 
 			uniforms.offsetRepeat.value.set( offset.x, offset.y, repeat.x, repeat.y );
-
-		}
-
-	}
-
-	function refreshUniformsFog ( uniforms, fog ) {
-
-		uniforms.fogColor.value = fog.color;
-
-		if ( fog instanceof THREE.Fog ) {
-
-			uniforms.fogNear.value = fog.near;
-			uniforms.fogFar.value = fog.far;
-
-		} else if ( fog instanceof THREE.FogExp2 ) {
-
-			uniforms.fogDensity.value = fog.density;
 
 		}
 

--- a/src/renderers/webgl/WebGLRenderFog.js
+++ b/src/renderers/webgl/WebGLRenderFog.js
@@ -1,0 +1,50 @@
+THREE.WebGLRenderFog = function () {
+
+	//
+	//	INITIALIZATION
+	//
+
+	function init() {
+
+		registerFog();
+
+	}
+
+	function registerFog() {
+
+		THREE.extend( THREE.Fog, '__refreshUniformsFog', refreshUniformsFog );
+		THREE.extend( THREE.FogExp2, '__refreshUniformsFog', refreshUniformsFogExp2 );
+
+	}
+	
+
+	//
+	//	FOG
+	//
+
+	function refreshUniformsFog ( renderer, uniforms ) {
+
+		var fog = this;
+
+		uniforms.fogColor.value = fog.color;
+		uniforms.fogNear.value = fog.near;
+		uniforms.fogFar.value = fog.far;
+
+	}
+
+	function refreshUniformsFogExp2 ( renderer, uniforms ) {
+
+		var fog = this;
+
+		uniforms.fogColor.value = fog.color;
+		uniforms.fogDensity.value = fog.density;
+
+	}
+
+	return {
+
+		init: init,
+
+	};
+
+};

--- a/src/renderers/webgl/WebGLRenderLights.js
+++ b/src/renderers/webgl/WebGLRenderLights.js
@@ -1,0 +1,71 @@
+THREE.WebGLRenderLights = function () {
+
+	function init() {
+
+		registerRefreshShadow();
+
+	}
+
+	function registerRefreshShadow() {
+
+		THREE.extend( THREE.Light, '__refreshUniformsShadow', refreshShadowNoop );
+		THREE.extend( THREE.SpotLight, '__refreshUniformsShadow', refreshShadowSpot );
+		THREE.extend( THREE.DirectionalLight, '__refreshUniformsShadow', refreshShadowDirectional );
+
+	}
+
+
+	//
+	//	SHADOWS
+	//
+
+
+	function refreshShadowNoop ( renderer, uniforms, lightIndex ) {
+
+		return false;
+
+	}
+
+	function refreshShadowSpot ( renderer, uniforms, lightIndex ) {
+
+		var light = this;
+
+		if ( ! light.castShadow ) return false;
+
+		uniforms.shadowMap.value[ lightIndex ] = light.shadowMap;
+		uniforms.shadowMapSize.value[ lightIndex ] = light.shadowMapSize;
+
+		uniforms.shadowMatrix.value[ lightIndex ] = light.shadowMatrix;
+
+		uniforms.shadowDarkness.value[ lightIndex ] = light.shadowDarkness;
+		uniforms.shadowBias.value[ lightIndex ] = light.shadowBias;
+
+		return true;
+
+	}
+
+	function refreshShadowDirectional ( renderer, uniforms, lightIndex ) {
+
+		var light = this;
+
+		if ( ! light.castShadow || light.shadowCascade ) return false;
+
+		uniforms.shadowMap.value[ lightIndex ] = light.shadowMap;
+		uniforms.shadowMapSize.value[ lightIndex ] = light.shadowMapSize;
+
+		uniforms.shadowMatrix.value[ lightIndex ] = light.shadowMatrix;
+
+		uniforms.shadowDarkness.value[ lightIndex ] = light.shadowDarkness;
+		uniforms.shadowBias.value[ lightIndex ] = light.shadowBias;
+
+		return true;
+
+	}
+
+	return {
+
+		init: init,
+
+	};
+
+};

--- a/src/renderers/webgl/WebGLRenderMaterials.js
+++ b/src/renderers/webgl/WebGLRenderMaterials.js
@@ -1,0 +1,44 @@
+THREE.WebGLRenderMaterials = function () {
+
+	//
+	//	INITIALIZATION
+	//
+
+	function init() {
+
+		registerRefreshLights();
+
+	}
+
+
+	//
+	//	LIGHTS
+	//
+
+	function registerRefreshLights() {
+
+		function hasLightsCommon() {
+
+			return this.lights;
+
+		}
+
+		function isLambertOrPhong() {
+
+			return true;
+
+		}
+
+		THREE.extend( THREE.Material, '__supportsLights', hasLightsCommon );
+		THREE.extend( THREE.MeshLambertMaterial, '__supportsLights', isLambertOrPhong );
+		THREE.extend( THREE.MeshPhongMaterial, '__supportsLights', isLambertOrPhong );
+
+	}
+
+	return {
+
+		init: init,
+
+	};
+
+};

--- a/src/renderers/webgl/WebGLRenderMaterials.js
+++ b/src/renderers/webgl/WebGLRenderMaterials.js
@@ -7,6 +7,7 @@ THREE.WebGLRenderMaterials = function () {
 	function init() {
 
 		registerRefreshLights();
+		registerRefreshUniforms();
 
 	}
 
@@ -32,6 +33,205 @@ THREE.WebGLRenderMaterials = function () {
 		THREE.extend( THREE.Material, '__supportsLights', hasLightsCommon );
 		THREE.extend( THREE.MeshLambertMaterial, '__supportsLights', isLambertOrPhong );
 		THREE.extend( THREE.MeshPhongMaterial, '__supportsLights', isLambertOrPhong );
+
+	}
+
+
+	//
+	//	UNIFORMS
+	//
+
+	function registerRefreshUniforms() {
+
+		THREE.extend( THREE.Material, '__refreshUniforms', refreshUniformsNoop );
+		THREE.extend( THREE.LineBasicMaterial, '__refreshUniforms', refreshUniformsLine );
+		THREE.extend( THREE.LineDashedMaterial, '__refreshUniforms', refreshUniformsDash );
+		THREE.extend( THREE.PointCloudMaterial, '__refreshUniforms', refreshUniformsParticle );
+		THREE.extend( THREE.MeshBasicMaterial, '__refreshUniforms', refreshUniformsBasic );
+		THREE.extend( THREE.MeshLambertMaterial, '__refreshUniforms', refreshUniformsLambert );
+		THREE.extend( THREE.MeshPhongMaterial, '__refreshUniforms', refreshUniformsPhong );
+		THREE.extend( THREE.MeshDepthMaterial, '__refreshUniforms', refreshUniformsDepth );
+		THREE.extend( THREE.MeshNormalMaterial, '__refreshUniforms', refreshUniformsNormal );
+
+	}
+
+	// Uniforms (refresh uniforms objects)
+
+	function refreshUniformsCommon ( material, uniforms ) {
+
+		uniforms.opacity.value = material.opacity;
+
+		uniforms.diffuse.value = material.color;
+
+		uniforms.map.value = material.map;
+		uniforms.specularMap.value = material.specularMap;
+		uniforms.alphaMap.value = material.alphaMap;
+
+		if ( material.bumpMap ) {
+
+			uniforms.bumpMap.value = material.bumpMap;
+			uniforms.bumpScale.value = material.bumpScale;
+
+		}
+
+		if ( material.normalMap ) {
+
+			uniforms.normalMap.value = material.normalMap;
+			uniforms.normalScale.value.copy( material.normalScale );
+
+		}
+
+		// uv repeat and offset setting priorities
+		// 1. color map
+		// 2. specular map
+		// 3. normal map
+		// 4. bump map
+		// 5. alpha map
+		// 6. emissive map
+
+		var uvScaleMap;
+
+		if ( material.map ) {
+
+			uvScaleMap = material.map;
+
+		} else if ( material.specularMap ) {
+
+			uvScaleMap = material.specularMap;
+
+		} else if ( material.normalMap ) {
+
+			uvScaleMap = material.normalMap;
+
+		} else if ( material.bumpMap ) {
+
+			uvScaleMap = material.bumpMap;
+
+		} else if ( material.alphaMap ) {
+
+			uvScaleMap = material.alphaMap;
+
+		} else if ( material.emissiveMap ) {
+
+			uvScaleMap = material.emissiveMap;
+
+		}
+
+		if ( uvScaleMap !== undefined ) {
+
+			var offset = uvScaleMap.offset;
+			var repeat = uvScaleMap.repeat;
+
+			uniforms.offsetRepeat.value.set( offset.x, offset.y, repeat.x, repeat.y );
+
+		}
+
+		uniforms.envMap.value = material.envMap;
+		uniforms.flipEnvMap.value = ( material.envMap instanceof THREE.WebGLRenderTargetCube ) ? 1 : - 1;
+
+		uniforms.reflectivity.value = material.reflectivity;
+		uniforms.refractionRatio.value = material.refractionRatio;
+
+	}
+
+	function refreshUniformsNoop ( renderer, uniforms ) {
+
+	}
+
+	function refreshUniformsLine ( renderer, uniforms ) {
+
+		var material = this;
+
+		uniforms.diffuse.value = material.color;
+		uniforms.opacity.value = material.opacity;
+
+	}
+
+	function refreshUniformsDash ( renderer, uniforms ) {
+
+		var material = this;
+		refreshUniformsLine( renderer, uniforms );
+
+		uniforms.dashSize.value = material.dashSize;
+		uniforms.totalSize.value = material.dashSize + material.gapSize;
+		uniforms.scale.value = material.scale;
+
+	}
+
+	function refreshUniformsParticle ( renderer, uniforms ) {
+
+		var material = this;
+
+		uniforms.psColor.value = material.color;
+		uniforms.opacity.value = material.opacity;
+		uniforms.size.value = material.size;
+		uniforms.scale.value = _canvas.height / 2.0; // TODO: Cache this.
+
+		uniforms.map.value = material.map;
+
+		if ( material.map !== null ) {
+
+			var offset = material.map.offset;
+			var repeat = material.map.repeat;
+
+			uniforms.offsetRepeat.value.set( offset.x, offset.y, repeat.x, repeat.y );
+
+		}
+
+	}
+
+	function refreshUniformsBasic ( renderer, uniforms ) {
+
+		var material = this;
+		refreshUniformsCommon( material, uniforms );
+
+		uniforms.aoMap.value = material.aoMap;
+		uniforms.aoMapIntensity.value = material.aoMapIntensity;
+
+	}
+
+	function refreshUniformsLambert ( renderer, uniforms ) {
+
+		var material = this;
+		refreshUniformsCommon( material, uniforms );
+
+		uniforms.emissive.value = material.emissive;
+
+	}
+
+	function refreshUniformsPhong ( renderer, uniforms ) {
+
+		var material = this;
+		refreshUniformsCommon( material, uniforms );
+
+		uniforms.shininess.value = material.shininess;
+
+		uniforms.emissive.value = material.emissive;
+		uniforms.specular.value = material.specular;
+
+		uniforms.lightMap.value = material.lightMap;
+		uniforms.lightMapIntensity.value = material.lightMapIntensity;
+
+		uniforms.aoMap.value = material.aoMap;
+		uniforms.aoMapIntensity.value = material.aoMapIntensity;
+
+		uniforms.emissiveMap.value = material.emissiveMap;
+
+	}
+
+	function refreshUniformsDepth ( renderer, uniforms ) {
+
+		var material = this;
+		uniforms.mNear.value = camera.near;
+		uniforms.mFar.value = camera.far;
+		uniforms.opacity.value = material.opacity;
+
+	}
+
+	function refreshUniformsNormal ( renderer, uniforms ) {
+
+		var material = this;
+		uniforms.opacity.value = material.opacity;
 
 	}
 

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -161,6 +161,7 @@
 	"src/renderers/webgl/WebGLObjects.js",
 	"src/renderers/webgl/WebGLProgram.js",
 	"src/renderers/webgl/WebGLRenderFog.js",
+	"src/renderers/webgl/WebGLRenderLights.js",
 	"src/renderers/webgl/WebGLShader.js",
 	"src/renderers/webgl/WebGLShadowMap.js",
 	"src/renderers/webgl/WebGLState.js",

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -160,6 +160,7 @@
 	"src/renderers/webgl/WebGLGeometries.js",
 	"src/renderers/webgl/WebGLObjects.js",
 	"src/renderers/webgl/WebGLProgram.js",
+	"src/renderers/webgl/WebGLRenderFog.js",
 	"src/renderers/webgl/WebGLShader.js",
 	"src/renderers/webgl/WebGLShadowMap.js",
 	"src/renderers/webgl/WebGLState.js",

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -162,6 +162,7 @@
 	"src/renderers/webgl/WebGLProgram.js",
 	"src/renderers/webgl/WebGLRenderFog.js",
 	"src/renderers/webgl/WebGLRenderLights.js",
+	"src/renderers/webgl/WebGLRenderMaterials.js",
 	"src/renderers/webgl/WebGLShader.js",
 	"src/renderers/webgl/WebGLShadowMap.js",
 	"src/renderers/webgl/WebGLState.js",


### PR DESCRIPTION
There has been a lot of talk on breaking up the renderer into smaller components, but I have not seen a lot of details on how to accomplish this refactoring.

Would this PR be a pattern you would consider?

I've only limited myself to transforming four small parts of the renderer. In case you find the diff too unruly, I suggest that you take a look at the more digestible individual commits.

In any case, here is an overview of the approach.

Instead of a monolithic renderer, the logic is broken down into smaller functions. The prototypes of the renderable objects (material, lights, etc) are extended with these functions. Implementation details are pushed into the objects, which become responsible to update the gl state. The renderer is just the orchestrator.

This is similar to how the `Raycaster` was split up with the introduction of `object.prototype.raycast()` (7ff6237), with the difference that the functions are "plugged in" the prototypes at runtime (when the first `WebGLRenderer` is constructed). This method ensures that the core classes are not coupled to any specific renderer implementation (`THREE.MeshBasicMaterial` initially knows nothing about `WebGLRenderer`, yet is still able to encapsulate type-dependent logic on behalf of the renderer).

One large switch block like this:

```
if ( material instanceof THREE.MeshBasicMaterial ) {

    refreshUniformsBasic( m_uniforms, material );

} else if ( material instanceof THREE.MeshPhongMaterial ) {

    refreshUniformsPhong( m_uniforms, material );

} else if ( material instanceof THREE.MeshLambertMaterial ) {
    // ...
```

is replaced by this single line dispatch:

```
material.refreshUniforms( m_uniforms );

// well, the actual line looks more like...
// material.__refreshUniforms( this /* renderer */, m_uniforms );
```
