### PR TITLE
Length manhattan for the Vector2.

### DIFF
--- a/docs/api/math/Vector2.html
+++ b/docs/api/math/Vector2.html
@@ -103,7 +103,7 @@
 		Computes length of this vector.
 		</div>
 
-		<h3>[method:Float lengthManhatten]()</h3>
+		<h3>[method:Float lengthManhattan]()</h3>
 		<div>
 		Computes Manhattan length of this vector.<br />
 		[link:http://en.wikipedia.org/wiki/Taxicab_geometry]

--- a/docs/api/math/Vector2.html
+++ b/docs/api/math/Vector2.html
@@ -103,6 +103,12 @@
 		Computes length of this vector.
 		</div>
 
+		<h3>[method:Float lengthManhatten]()</h3>
+		<div>
+		Computes Manhattan length of this vector.<br />
+		[link:http://en.wikipedia.org/wiki/Taxicab_geometry]
+		</div>
+
 		<h3>[method:Vector2 normalize]() [page:Vector2 this]</h3>
 		<div>
 		Normalizes this vector.

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -337,7 +337,7 @@ THREE.Vector2.prototype = {
 
 	},
 
-	lengthManhatten: function() {
+	lengthManhattan: function() {
 
 		return Math.abs( this.x ) + Math.abs( this.y );
 	},

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -337,6 +337,11 @@ THREE.Vector2.prototype = {
 
 	},
 
+	lengthManhatten: function() {
+
+		return Math.abs( this.x ) + Math.abs( this.y );
+	},
+
 	normalize: function () {
 
 		return this.divideScalar( this.length() );


### PR DESCRIPTION
Hi!
It seems that `lengthManhattan` is missed for the Vector2.
Just added it.
