### PR TITLE
Hide warning X3557

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -76,6 +76,25 @@ THREE.WebGLProgram = ( function () {
 
 	}
 
+	function getProgramInfoLog ( gl, program ) {
+
+		var programLogInfo = gl.getProgramInfoLog( program );
+
+		// Filter empty line.
+		// Filter warning X3557: loop only executes for 1 iteration
+		programLogInfo = programLogInfo
+			.split( /\r\n|\r|\n/ )
+			.filter( function ( line ) {
+
+				return line !== '' && ! line.match( /X3557/ );
+
+			} )
+			.join( '\n' );
+
+		return programLogInfo;
+
+	}
+
 	return function ( renderer, code, material, parameters ) {
 
 		var gl = renderer.context;
@@ -378,7 +397,7 @@ THREE.WebGLProgram = ( function () {
 
 		gl.linkProgram( program );
 
-		var programLog = gl.getProgramInfoLog( program );
+		var programLog = getProgramInfoLog( gl, program );
 		var vertexLog = gl.getShaderInfoLog( glVertexShader );
 		var fragmentLog = gl.getShaderInfoLog( glFragmentShader );
 


### PR DESCRIPTION
When reporting warnings from glProgramInfoLog, do not report warning
X3557 - a suggestion to remove a trivial loop that is emitted on some
platforms. There is nothing a end user can do about this optimization
tip. The loops are generated by shader macro when a material is
illuminated by exactly one light source (of a given type).

The program info is a multiline string. Removing a warning can leave
blanks lines. Remove blank lines from the log too. Other messages are
kept.

Fixes #4834.
