### PR TITLE
BufferAttribute.length not compatible with r71

### DIFF
--- a/examples/js/loaders/gltf/glTFLoader.js
+++ b/examples/js/loaders/gltf/glTFLoader.js
@@ -84,7 +84,7 @@ THREE.glTFLoader.prototype.load = function( url, callback ) {
 
 	var ClassicGeometry = function() {
 
-		this.geometry = new THREE.BufferGeometry;
+		this.geometry = new THREE.BufferGeometry();
 
 		this.totalAttributes = 0;
 		this.loadedAttributes = 0;

--- a/examples/webgl_buffergeometry_instancing.html
+++ b/examples/webgl_buffergeometry_instancing.html
@@ -145,7 +145,7 @@
 
             var offsets = new THREE.InstancedBufferAttribute( new Float32Array( instances * 3 ), 3, 1, false );
 
-            for ( var i = 0, ul = offsets.length; i < ul; i++ ) {
+            for ( var i = 0, ul = offsets.count; i < ul; i++ ) {
 
                 offsets.setXYZ( i, Math.random() - 0.5, Math.random() - 0.5, Math.random() - 0.5 );
 
@@ -155,7 +155,7 @@
 
             var colors = new THREE.InstancedBufferAttribute( new Float32Array( instances * 4 ), 4, 1, false );
 
-            for ( var i = 0, ul = colors.length; i < ul; i++ ) {
+            for ( var i = 0, ul = colors.count; i < ul; i++ ) {
 
                 colors.setXYZW( i, Math.random(), Math.random(), Math.random(), Math.random() );
 
@@ -167,7 +167,7 @@
 
             var orientationsStart = new THREE.InstancedBufferAttribute( new Float32Array( instances * 4 ), 4, 1, false );
 
-            for ( var i = 0, ul = orientationsStart.length; i < ul; i++ ) {
+            for ( var i = 0, ul = orientationsStart.count; i < ul; i++ ) {
 
                 vector.set( Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1 );
                 vector.normalize();
@@ -180,7 +180,7 @@
 
             var orientationsEnd = new THREE.InstancedBufferAttribute( new Float32Array( instances * 4 ), 4, 1, false );
 
-            for ( var i = 0, ul = orientationsEnd.length; i < ul; i++ ) {
+            for ( var i = 0, ul = orientationsEnd.count; i < ul; i++ ) {
 
                 vector.set( Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1 );
                 vector.normalize();

--- a/examples/webgl_buffergeometry_instancing_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_dynamic.html
@@ -213,7 +213,7 @@
             var offsets = new THREE.InstancedBufferAttribute( new Float32Array( instances * 3 ), 3, 1, false );
 
             var vector = new THREE.Vector4();
-            for ( var i = 0, ul = offsets.length; i < ul; i++ ) {
+            for ( var i = 0, ul = offsets.count; i < ul; i++ ) {
                 var x = Math.random() * 100 - 50;
                 var y = Math.random() * 100 - 50;
                 var z = Math.random() * 100 - 50;
@@ -228,7 +228,7 @@
 
             orientations = new THREE.InstancedBufferAttribute( new Float32Array( instances * 4 ), 4, 1, true );
 
-            for ( var i = 0, ul = orientations.length; i < ul; i++ ) {
+            for ( var i = 0, ul = orientations.count; i < ul; i++ ) {
 
                 vector.set( Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1 );
                 vector.normalize();
@@ -318,7 +318,7 @@
             var delta = ( time - lastTime ) / 5000;
             tmpQ.set( moveQ.x * delta, moveQ.y * delta, moveQ.z * delta, 1 ).normalize();
 
-            for ( var i = 0, ul = orientations.length; i < ul; i++ ) {
+            for ( var i = 0, ul = orientations.count; i < ul; i++ ) {
                 var index = i * 4;
                 currentQ.set( orientations.array[index], orientations.array[index + 1], orientations.array[index + 2], orientations.array[index + 3] );
                 currentQ.multiply( tmpQ );

--- a/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
@@ -185,7 +185,7 @@
         var offsets = new THREE.InterleavedBufferAttribute( instanceBuffer, 3, 0 );
 
         var vector = new THREE.Vector4();
-        for ( var i = 0, ul = offsets.length; i < ul; i++ ) {
+        for ( var i = 0, ul = offsets.count; i < ul; i++ ) {
             var x = Math.random() * 100 - 50;
             var y = Math.random() * 100 - 50;
             var z = Math.random() * 100 - 50;
@@ -199,7 +199,7 @@
 
         orientations = new THREE.InterleavedBufferAttribute( instanceBuffer, 4, 4 );
 
-        for ( var i = 0, ul = orientations.length; i < ul; i++ ) {
+        for ( var i = 0, ul = orientations.count; i < ul; i++ ) {
 
             vector.set( Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1, Math.random() * 2 - 1 );
             vector.normalize();
@@ -290,7 +290,7 @@
         var delta = ( time - lastTime ) / 5000;
         tmpQ.set( moveQ.x * delta, moveQ.y * delta, moveQ.z * delta, 1 ).normalize();
 
-        for ( var i = 0, ul = orientations.length; i < ul; i++ ) {
+        for ( var i = 0, ul = orientations.count; i < ul; i++ ) {
             var index = i * instanceBuffer.stride + orientations.offset;
             currentQ.set( instanceBuffer.array[index], instanceBuffer.array[index + 1], instanceBuffer.array[index + 2], instanceBuffer.array[index + 3] );
             currentQ.multiply( tmpQ );

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -19,8 +19,8 @@ THREE.BufferAttribute.prototype = {
 
 	get length () {
 
-		console.warn( 'THREE.BufferAttribute: .length has been renamed to .count.' );
-		return this.count;
+		console.warn( 'THREE.BufferAttribute: .length has been deprecated. Please use .count.' );
+		return this.array.length;
 
 	},
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1067,7 +1067,7 @@ THREE.BufferGeometry.prototype = {
 				itemSize: attribute.itemSize,
 				type: attribute.array.constructor.name,
 				array: array
-			}
+			};
 
 		}
 
@@ -1082,7 +1082,7 @@ THREE.BufferGeometry.prototype = {
 			data.data.boundingSphere = {
 				center: boundingSphere.center.toArray(),
 				radius: boundingSphere.radius
-			}
+			};
 
 		}
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -26,6 +26,12 @@ THREE.InterleavedBuffer.prototype = {
 
 	},
 
+	get count () {
+
+		return this.array.length / this.stride;
+
+	},
+
 	copyAt: function ( index1, attribute, index2 ) {
 
 		index1 *= this.stride;

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -19,8 +19,8 @@ THREE.InterleavedBufferAttribute.prototype = {
 
 	get length() {
 
-		console.warn( 'THREE.InterleavedBufferAttribute: .length has been renamed to .count.' );
-		return this.count;
+		console.warn( 'THREE.BufferAttribute: .length has been deprecated. Please use .count.' );
+		return this.array.length;
 
 	},
 

--- a/src/extras/geometries/EdgesGeometry.js
+++ b/src/extras/geometries/EdgesGeometry.js
@@ -11,7 +11,7 @@ THREE.EdgesGeometry = function ( geometry, thresholdAngle ) {
 	var thresholdDot = Math.cos( THREE.Math.degToRad( thresholdAngle ) );
 
 	var edge = [ 0, 0 ], hash = {};
-	var sortFunction = function ( a, b ) { return a - b };
+	var sortFunction = function ( a, b ) { return a - b; };
 
 	var keys = [ 'a', 'b', 'c' ];
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -929,7 +929,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 							if ( geometry.maxInstancedCount === undefined ) {
 
-								geometry.maxInstancedCount = data.meshPerAttribute * ( data.array.length / data.stride );
+								geometry.maxInstancedCount = data.meshPerAttribute * data.count;
 
 							}
 
@@ -953,7 +953,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 							if ( geometry.maxInstancedCount === undefined ) {
 
-								geometry.maxInstancedCount = geometryAttribute.meshPerAttribute * ( geometryAttribute.array.length / geometryAttribute.itemSize );
+								geometry.maxInstancedCount = geometryAttribute.meshPerAttribute * geometryAttribute.count;
 
 							}
 
@@ -1184,11 +1184,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( position instanceof THREE.InterleavedBufferAttribute ) {
 
-						extension.drawArraysInstancedANGLE( mode, 0, position.data.array.length / position.data.stride, geometry.maxInstancedCount ); // Draw the instanced meshes
+						extension.drawArraysInstancedANGLE( mode, 0, position.data.count, geometry.maxInstancedCount ); // Draw the instanced meshes
 
 					} else {
 
-						extension.drawArraysInstancedANGLE( mode, 0, position.array.length / position.itemSize, geometry.maxInstancedCount ); // Draw the instanced meshes
+						extension.drawArraysInstancedANGLE( mode, 0, position.count, geometry.maxInstancedCount ); // Draw the instanced meshes
 
 					}
 
@@ -1196,19 +1196,19 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( position instanceof THREE.InterleavedBufferAttribute ) {
 
-						_gl.drawArrays( mode, 0, position.data.array.length / position.data.stride );
+						_gl.drawArrays( mode, 0, position.data.count );
 
 					} else {
 
-						_gl.drawArrays( mode, 0, position.array.length / position.itemSize );
+						_gl.drawArrays( mode, 0, position.count );
 
 					}
 
 				}
 
 				_this.info.render.calls++;
-				_this.info.render.vertices += position.array.length / position.itemSize;
-				_this.info.render.faces += position.array.length / ( 3 * position.itemSize );
+				_this.info.render.vertices += position.count;
+				_this.info.render.faces += position.count / 3;
 
 			} else {
 

--- a/test/unit/geometry/EdgesGeometry.js
+++ b/test/unit/geometry/EdgesGeometry.js
@@ -96,7 +96,7 @@ function testEdges ( vertList, idxList, numAfter ) {
 		var numBefore = idxList.length;
 		equal( countEdges (geom), numBefore, "Edges before!" );
 
-		var egeom = new THREE.EdgesGeometry ( geom );;
+		var egeom = new THREE.EdgesGeometry( geom );
 
 		equal( countEdges (egeom), numAfter, "Edges after!" );
 		output( geom, egeom );
@@ -163,7 +163,7 @@ function createIndexedBufferGeometry ( vertList, idxList ) {
 
 function addDrawCalls ( geometry ) {
 
-	var numTris = geometry.getAttribute( 'index' ).length / 3;
+	var numTris = geometry.getAttribute( 'index' ).count / 3;
 
 	var offset = 0;
 	for ( var i = 0 ; i < numTris; i ++ ) {
@@ -183,7 +183,7 @@ function countEdges ( geom ) {
 
 	if ( geom instanceof THREE.EdgesGeometry ) {
 
-		return geom.getAttribute( 'position' ).length / 2;
+		return geom.getAttribute( 'position' ).count / 2;
 
 	}
 
@@ -196,11 +196,11 @@ function countEdges ( geom ) {
 	var indices = geom.getAttribute( 'index' );
 	if ( indices !== undefined ) {
 
-		return indices.length;
+		return indices.count;
 
 	}
 
-	return geom.getAttribute( 'position' ).length;
+	return geom.getAttribute( 'position' ).count;
 
 }
 
@@ -228,7 +228,9 @@ function output ( geom, egeom ) {
 	scene.add(edges);
 
 	if (scene.children.length % 8 === 0) {
+
 		xoffset += 2;
+
 	}
 
 }


### PR DESCRIPTION
The definition of `BufferAttribute.length` has changed since r71 (see #6473).

r71: https://github.com/mrdoob/three.js/blob/master/src/core/BufferAttribute.js#L18-L22
r72dev: https://github.com/mrdoob/three.js/blob/dev/src/core/BufferAttribute.js#L18-L31

Backward compatibility with r71 should be retained, otherwise, the method should just be removed!

Implementation should be

```
get length () {

    console.warn( 'THREE.BufferAttribute: .length has been deprecated. Please use .count.' );
    return this.array.length;

}
```
