### PR TITLE
Use Raycaster.setFromCamera() method

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -1007,9 +1007,7 @@
 			var y = ( pointer.clientY - rect.top ) / rect.height;
 
 			pointerVector.set( ( x * 2 ) - 1, - ( y * 2 ) + 1, 0.5 );
-			pointerVector.unproject( camera );
-
-			ray.set( camPosition, pointerVector.sub( camPosition ).normalize() );
+			ray.setFromCamera( pointerVector, camera );
 
 			var intersections = ray.intersectObjects( objects, true );
 			return intersections[0] ? intersections[0] : false;

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -162,7 +162,13 @@
 				if ( SELECTED ) {
 
 					var intersects = raycaster.intersectObject( plane );
-					SELECTED.position.copy( intersects[ 0 ].point.sub( offset ) );
+
+					if ( intersects.length > 0 ) {
+
+						SELECTED.position.copy( intersects[ 0 ].point.sub( offset ) );
+
+					}
+
 					return;
 
 				}
@@ -201,9 +207,7 @@
 
 				event.preventDefault();
 
-				var vector = new THREE.Vector3( mouse.x, mouse.y, 0.5 ).unproject( camera );
-
-				var raycaster = new THREE.Raycaster( camera.position, vector.sub( camera.position ).normalize() );
+				raycaster.setFromCamera( mouse, camera );
 
 				var intersects = raycaster.intersectObjects( objects );
 
@@ -214,7 +218,12 @@
 					SELECTED = intersects[ 0 ].object;
 
 					var intersects = raycaster.intersectObject( plane );
-					offset.copy( intersects[ 0 ].point ).sub( plane.position );
+
+					if ( intersects.length > 0 ) {
+
+						offset.copy( intersects[ 0 ].point ).sub( plane.position );
+
+					}
 
 					container.style.cursor = 'move';
 


### PR DESCRIPTION
Convert two uses of raycaster to using setFromCamera(). One touches
TransformControls but should not affect #6795.

Also fix an error in webgl_interactive_draggablecubes.html when the
cursor is dragged outside of the backing "plane" (which is a large
planar mesh, not an infinite plane), returning no intersections. Now,
when the limit of the bounded plane is reached, the cubes just stop
following the cursor but no error is produced.

The PR was tested with webgl_interactive_draggablecubes.html and the editor.
