### PR TITLE
Scene updates with multiple renderers

### DIFF
--- a/docs/api/core/BufferAttribute.html
+++ b/docs/api/core/BufferAttribute.html
@@ -43,10 +43,14 @@
 		Flag to indicate that this attribute has changed and should be re-send to the GPU. Set this to true when you modify the value of the array.
 		</div>
 
+		<h3>[property:Integer version]</h3>
+		<div>
+		A version number, incremented every time the needsUpdate property is set to true.
+		</div>
 
 
 		<h2>Methods</h2>
-		
+
 		<h3>[method:null copyAt] ( [page:Integer index1], attribute, [page:Integer index2] ) </h3>
 		<div>
 		Copies itemSize values in the array from the vertex at index2 to the vertex at index1.

--- a/examples/webgl_multiple_renderers.html
+++ b/examples/webgl_multiple_renderers.html
@@ -99,6 +99,8 @@
 
 			function animate() {
 
+				updateScene();
+
 				for ( var i = 0; i < apps.length; ++i ) {
 
 					apps[ i ].animate();
@@ -223,12 +225,33 @@
 				group2.rotation.x = 0;
 				scene.add( group2 );
 
-				group3 = THREE.SceneUtils.createMultiMaterialObject( geometry3, materials );
+				group3 = new THREE.Group();
+				group3.add( new THREE.Mesh( new THREE.BufferGeometry().fromGeometry( geometry3 ), materials[0] ) );
+				group3.add( new THREE.Mesh( geometry3, materials[1] ) );
+				group3.name = 'rotating ball';
 				group3.position.x = 0;
 				group3.rotation.x = 0;
 				scene.add( group3 );
 
 				return scene;
+			}
+
+			function updateScene () {
+
+				var group = scene.getObjectByName( 'rotating ball' )
+				group.rotation.x += Math.PI / 600;
+
+				var geometry = group.children[0].geometry;
+				var array = geometry.attributes.color.array;
+
+				for (var i = 0; i < array.length; i ++) {
+
+					array[i] = ( array[i] + 0.99 ) % 1.0;
+
+				}
+
+				geometry.attributes.color.needsUpdate = true;
+
 			}
 
 			function App( container, fullWidth, fullHeight ) {

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -9,7 +9,8 @@ THREE.BufferAttribute = function ( array, itemSize ) {
 	this.array = array;
 	this.itemSize = itemSize;
 
-	this.needsUpdate = false;
+	this._needsUpdate = false;
+	this.updateCounter = 0;
 
 };
 
@@ -27,6 +28,20 @@ THREE.BufferAttribute.prototype = {
 	get count() {
 
 		return this.array.length / this.itemSize;
+
+	},
+
+	get needsUpdate() {
+
+		return this._needsUpdate;
+
+	},
+
+	set needsUpdate( value ) {
+
+		if ( value === true ) this.updateCounter ++;
+
+		this._needsUpdate = value;
 
 	},
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -9,7 +9,7 @@ THREE.BufferAttribute = function ( array, itemSize ) {
 	this.array = array;
 	this.itemSize = itemSize;
 
-	this.updateCounter = 0;
+	this.version = 0;
 
 };
 
@@ -32,7 +32,7 @@ THREE.BufferAttribute.prototype = {
 
 	set needsUpdate( value ) {
 
-		if ( value === true ) this.updateCounter ++;
+		if ( value === true ) this.version ++;
 
 	},
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -9,7 +9,6 @@ THREE.BufferAttribute = function ( array, itemSize ) {
 	this.array = array;
 	this.itemSize = itemSize;
 
-	this._needsUpdate = false;
 	this.updateCounter = 0;
 
 };
@@ -31,17 +30,9 @@ THREE.BufferAttribute.prototype = {
 
 	},
 
-	get needsUpdate() {
-
-		return this._needsUpdate;
-
-	},
-
 	set needsUpdate( value ) {
 
 		if ( value === true ) this.updateCounter ++;
-
-		this._needsUpdate = value;
 
 	},
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -9,7 +9,6 @@ THREE.InterleavedBuffer = function ( array, stride, dynamic ) {
 	this.array = array;
 	this.stride = stride;
 
-	this._needsUpdate = false;
 	this.updateCounter = 0;
 
 	this.dynamic = dynamic || false;
@@ -33,17 +32,9 @@ THREE.InterleavedBuffer.prototype = {
 
 	},
 
-	get needsUpdate() {
-
-		return this._needsUpdate;
-
-	},
-
 	set needsUpdate( value ) {
 
 		if ( value === true ) this.updateCounter ++;
-
-		this._needsUpdate = value;
 
 	},
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -9,7 +9,7 @@ THREE.InterleavedBuffer = function ( array, stride, dynamic ) {
 	this.array = array;
 	this.stride = stride;
 
-	this.updateCounter = 0;
+	this.version = 0;
 
 	this.dynamic = dynamic || false;
 	this.updateRange = { offset: 0, count: -1 };
@@ -34,7 +34,7 @@ THREE.InterleavedBuffer.prototype = {
 
 	set needsUpdate( value ) {
 
-		if ( value === true ) this.updateCounter ++;
+		if ( value === true ) this.version ++;
 
 	},
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -9,7 +9,8 @@ THREE.InterleavedBuffer = function ( array, stride, dynamic ) {
 	this.array = array;
 	this.stride = stride;
 
-	this.needsUpdate = false;
+	this._needsUpdate = false;
+	this.updateCounter = 0;
 
 	this.dynamic = dynamic || false;
 	this.updateRange = { offset: 0, count: -1 };
@@ -29,6 +30,20 @@ THREE.InterleavedBuffer.prototype = {
 	get count () {
 
 		return this.array.length / this.stride;
+
+	},
+
+	get needsUpdate() {
+
+		return this._needsUpdate;
+
+	},
+
+	set needsUpdate( value ) {
+
+		if ( value === true ) this.updateCounter ++;
+
+		this._needsUpdate = value;
 
 	},
 

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -185,7 +185,7 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 			createBuffer( attributeProperties, data, bufferType );
 
-		} else if ( attributeProperties.updateCounter !== data.updateCounter ) {
+		} else if ( attributeProperties.version !== data.version ) {
 
 			updateBuffer( attributeProperties, data, bufferType );
 
@@ -210,8 +210,7 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 		gl.bufferData( bufferType, data.array, usage );
 
-		attributeProperties.updateCounter = data.updateCounter;
-		data.needsUpdate = false;
+		attributeProperties.version = data.version;
 
 	}
 
@@ -236,8 +235,7 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 		}
 
-		attributeProperties.updateCounter = data.updateCounter;
-		data.needsUpdate = false;
+		attributeProperties.version = data.version;
 
 	}
 

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -168,60 +168,67 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 		for ( var name in attributes ) {
 
 			var attribute = attributes[ name ];
-
-			var bufferType = ( name === 'index' ) ? gl.ELEMENT_ARRAY_BUFFER : gl.ARRAY_BUFFER;
-
-			var data = ( attribute instanceof THREE.InterleavedBufferAttribute ) ? attribute.data : attribute;
-
-			var attributeProperties = properties.get( data );
-
-			if ( attributeProperties.__webglBuffer === undefined ) {
-
-				attributeProperties.__webglBuffer = gl.createBuffer();
-				gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
-
-				var usage = gl.STATIC_DRAW;
-
-				if ( data instanceof THREE.DynamicBufferAttribute
-						 || ( data instanceof THREE.InstancedBufferAttribute && data.dynamic === true )
-						 || ( data instanceof THREE.InterleavedBuffer && data.dynamic === true ) ) {
-
-					usage = gl.DYNAMIC_DRAW;
-
-				}
-
-				gl.bufferData( bufferType, data.array, usage );
-
-				data.needsUpdate = false;
-
-			} else if ( data.needsUpdate === true ) {
-
-				gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
-
-				if ( data.updateRange === undefined || data.updateRange.count === -1 ) { // Not using update ranges
-
-					gl.bufferSubData( bufferType, 0, data.array );
-
-				} else if ( data.updateRange.count === 0 ) {
-
-					console.error( 'THREE.WebGLRenderer.updateObject: using updateRange for THREE.DynamicBufferAttribute and marked as needsUpdate but count is 0, ensure you are using set methods or updating manually.' );
-
-				} else {
-
-					gl.bufferSubData( bufferType, data.updateRange.offset * data.array.BYTES_PER_ELEMENT,
-									 data.array.subarray( data.updateRange.offset, data.updateRange.offset + data.updateRange.count ) );
-
-					data.updateRange.count = 0; // reset range
-
-				}
-
-				data.needsUpdate = false;
-
-			}
+			updateAttribute( attribute, name );
 
 		}
 
-	};
+	}
+
+	function updateAttribute ( attribute, name ) {
+
+		var bufferType = ( name === 'index' ) ? gl.ELEMENT_ARRAY_BUFFER : gl.ARRAY_BUFFER;
+
+		var data = ( attribute instanceof THREE.InterleavedBufferAttribute ) ? attribute.data : attribute;
+
+		var attributeProperties = properties.get( data );
+
+		if ( attributeProperties.__webglBuffer === undefined ) {
+
+			attributeProperties.__webglBuffer = gl.createBuffer();
+			gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
+
+			var usage = gl.STATIC_DRAW;
+
+			if ( data instanceof THREE.DynamicBufferAttribute
+				 || ( data instanceof THREE.InstancedBufferAttribute && data.dynamic === true )
+				 || ( data instanceof THREE.InterleavedBuffer && data.dynamic === true ) ) {
+
+				usage = gl.DYNAMIC_DRAW;
+
+			}
+
+			gl.bufferData( bufferType, data.array, usage );
+
+			data.needsUpdate = false;
+
+		} else if ( data.needsUpdate === true ) {
+
+			gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
+
+			if ( data.updateRange === undefined || data.updateRange.count === -1 ) { // Not using update ranges
+
+				gl.bufferSubData( bufferType, 0, data.array );
+
+			} else if ( data.updateRange.count === 0 ) {
+
+				console.error( 'THREE.WebGLRenderer.updateObject: using updateRange for THREE.DynamicBufferAttribute and marked as needsUpdate but count is 0, ensure you are using set methods or updating manually.' );
+
+			} else {
+
+				gl.bufferSubData( bufferType, data.updateRange.offset * data.array.BYTES_PER_ELEMENT,
+								  data.array.subarray( data.updateRange.offset, data.updateRange.offset + data.updateRange.count ) );
+
+				data.updateRange.count = 0; // reset range
+
+			}
+
+			data.needsUpdate = false;
+
+		}
+
+	}
+
+
 
 	// returns the webgl buffer for a specified attribute
 	this.getAttributeBuffer = function ( attribute ) {

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -185,7 +185,7 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 			createBuffer( attributeProperties, data, bufferType );
 
-		} else if ( data.needsUpdate === true ) {
+		} else if ( attributeProperties.updateCounter !== data.updateCounter ) {
 
 			updateBuffer( attributeProperties, data, bufferType );
 
@@ -210,11 +210,12 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 		gl.bufferData( bufferType, data.array, usage );
 
+		attributeProperties.updateCounter = data.updateCounter;
 		data.needsUpdate = false;
 
 	}
 
-	function updateBuffer( attributeProperties, data, bufferType ) {
+	function updateBuffer ( attributeProperties, data, bufferType ) {
 
 		gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
 
@@ -235,6 +236,7 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 		}
 
+		attributeProperties.updateCounter = data.updateCounter;
 		data.needsUpdate = false;
 
 	}

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -167,8 +167,7 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 		for ( var name in attributes ) {
 
-			var attribute = attributes[ name ];
-			updateAttribute( attribute, name );
+			updateAttribute( attributes[ name ], name );
 
 		}
 
@@ -184,64 +183,74 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 		if ( attributeProperties.__webglBuffer === undefined ) {
 
-			attributeProperties.__webglBuffer = gl.createBuffer();
-			gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
-
-			var usage = gl.STATIC_DRAW;
-
-			if ( data instanceof THREE.DynamicBufferAttribute
-				 || ( data instanceof THREE.InstancedBufferAttribute && data.dynamic === true )
-				 || ( data instanceof THREE.InterleavedBuffer && data.dynamic === true ) ) {
-
-				usage = gl.DYNAMIC_DRAW;
-
-			}
-
-			gl.bufferData( bufferType, data.array, usage );
-
-			data.needsUpdate = false;
+			createBuffer( attributeProperties, data, bufferType );
 
 		} else if ( data.needsUpdate === true ) {
 
-			gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
-
-			if ( data.updateRange === undefined || data.updateRange.count === -1 ) { // Not using update ranges
-
-				gl.bufferSubData( bufferType, 0, data.array );
-
-			} else if ( data.updateRange.count === 0 ) {
-
-				console.error( 'THREE.WebGLRenderer.updateObject: using updateRange for THREE.DynamicBufferAttribute and marked as needsUpdate but count is 0, ensure you are using set methods or updating manually.' );
-
-			} else {
-
-				gl.bufferSubData( bufferType, data.updateRange.offset * data.array.BYTES_PER_ELEMENT,
-								  data.array.subarray( data.updateRange.offset, data.updateRange.offset + data.updateRange.count ) );
-
-				data.updateRange.count = 0; // reset range
-
-			}
-
-			data.needsUpdate = false;
+			updateBuffer( attributeProperties, data, bufferType );
 
 		}
 
 	}
 
+	function createBuffer ( attributeProperties, data, bufferType ) {
 
+		attributeProperties.__webglBuffer = gl.createBuffer();
+		gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
+
+		var usage = gl.STATIC_DRAW;
+
+		if ( data instanceof THREE.DynamicBufferAttribute
+			 || ( data instanceof THREE.InstancedBufferAttribute && data.dynamic === true )
+			 || ( data instanceof THREE.InterleavedBuffer && data.dynamic === true ) ) {
+
+			usage = gl.DYNAMIC_DRAW;
+
+		}
+
+		gl.bufferData( bufferType, data.array, usage );
+
+		data.needsUpdate = false;
+
+	}
+
+	function updateBuffer( attributeProperties, data, bufferType ) {
+
+		gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
+
+		if ( data.updateRange === undefined || data.updateRange.count === -1 ) { // Not using update ranges
+
+			gl.bufferSubData( bufferType, 0, data.array );
+
+		} else if ( data.updateRange.count === 0 ) {
+
+			console.error( 'THREE.WebGLRenderer.updateObject: using updateRange for THREE.DynamicBufferAttribute and marked as needsUpdate but count is 0, ensure you are using set methods or updating manually.' );
+
+		} else {
+
+			gl.bufferSubData( bufferType, data.updateRange.offset * data.array.BYTES_PER_ELEMENT,
+							  data.array.subarray( data.updateRange.offset, data.updateRange.offset + data.updateRange.count ) );
+
+			data.updateRange.count = 0; // reset range
+
+		}
+
+		data.needsUpdate = false;
+
+	}
 
 	// returns the webgl buffer for a specified attribute
 	this.getAttributeBuffer = function ( attribute ) {
 
 		if ( attribute instanceof THREE.InterleavedBufferAttribute ) {
 
-			return properties.get( attribute.data ).__webglBuffer
+			return properties.get( attribute.data ).__webglBuffer;
 
 		}
 
 		return properties.get( attribute ).__webglBuffer;
 
-	}
+	};
 
 	this.update = function ( renderList ) {
 


### PR DESCRIPTION
This implements solution 2 described in #6800.

When a `BufferAttribute` is updated, instead of turning a flag to true, a counter is incremented. Each renderer can independently keep track of the latest changes by keeping track of the counters.

The interface is the same as before, though a property: `buffer.needsUpdate = true;`. I can implement a method if you want: `buffer.setNeedsUpdate()`. The property is never read from so I did not provide a getter.

I did a bit of refactoring in `WebGLObjects` to extract 3 new functions from `updateObject`, but the actual changes to this class boils down to changing `if ( data.needsUpdate === true ) { ... }` to:

```
if ( attributeProperties.updateCounter !== data.updateCounter ) {

    ...
    attributeProperties.updateCounter = data.updateCounter;

}
```

I initially planned to preview solution 2 and 3 (using 'update' events callback). However, I have some questions regarding solution 3 (e.g. should the gl buffers be updated immediately following an update to the `BufferAttribute`?). In any case, the changes needed to start work on solution 3 are common with this patch (getting rid of the boolean flag and isolate function to update an individual buffer in `WebGLObjects`).
