### PR TITLE
Fix EffectComposer memory problem

### DIFF
--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -117,7 +117,9 @@ THREE.EffectComposer.prototype = {
 
 		}
 
+		this.renderTarget1.dispose();
 		this.renderTarget1 = renderTarget;
+		this.renderTarget2.dispose();
 		this.renderTarget2 = renderTarget.clone();
 
 		this.writeBuffer = this.renderTarget1;
@@ -127,12 +129,8 @@ THREE.EffectComposer.prototype = {
 
 	setSize: function ( width, height ) {
 
-		var renderTarget = this.renderTarget1.clone();
-
-		renderTarget.width = width;
-		renderTarget.height = height;
-
-		this.reset( renderTarget );
+		this.renderTarget1.setSize( width, height );
+		this.renderTarget2.setSize( width, height );
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -697,7 +697,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		properties.delete( renderTargetProperties );
+		properties.delete( renderTarget );
 
 	}
 


### PR DESCRIPTION
As #6820 discussion, `EffectComposer` has memory problem while `reset()` or `setSize()`. It is because it will clone new RenderTarget but didn't dispose it. I have fixed this problem. I recommend we should be rather using renderTarget.setSize than `renderTarget.width = width; renderTarget.height = height; renderTarget.dispose()`. Because they do the same stuff.

One thing needs to be discussed. if we want users resize the `EffectComposr`, they should use the pixel ratio. As @benaadams original design, if we call `THREE.EffectComposer.setSize()`, it will go to `reset()`. However, It will NOT use renderer's pixel ratio because `this.reset( renderTarget )` will always send a valid renderTarget, and it will not be into the `if ( renderTarget === undefined ) { condition`. I have two options to enhance it.

First, we can add these lines in `EffectComposet.setSize()`

```
var pixelRatio = this.renderer.getPixelRatio();
var width  = Math.floor( this.renderer.context.canvas.width  / pixelRatio );
var height = Math.floor( this.renderer.context.canvas.height / pixelRatio );
this.renderTarget1.setSize( width, height );
this.renderTarget2.setSize( width, height );
```

Second, we can choose to disable `EffectComposet.setSize()` function for resize usage because `EffectComposet.reset()` would cover this task. The good example is `webgl_lines_colors.html` demo.

BTW, @WestLangley. The black effect while resizing window I have found the reason. That seems because mrdoob had a mistake while refactoring `WebRenderer`.
