### PR TITLE
Unused reference to .buffer

### DIFF
--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -43,21 +43,6 @@ THREE.WebGLGeometries = function ( gl, info ) {
 	function onGeometryDispose( event ) {
 
 		var geometry = event.target;
-		var buffergeometry = geometries[ geometry.id ];
-
-		for ( var name in buffergeometry.attributes ) {
-
-			var attribute = buffergeometry.attributes[ name ];
-
-			if ( attribute.buffer !== undefined ) {
-
-				gl.deleteBuffer( attribute.buffer );
-
-				delete attribute.buffer;
-
-			}
-
-		}
 
 		geometry.removeEventListener( 'dispose', onGeometryDispose );
 


### PR DESCRIPTION
`attribute.buffer` does seem to exist anymore. The only `.buffer` property I could find was in `Audio`.

This seems to be a leftover from 4c7239ebcb048d3d46b9ebd7a1a703449c437659, when `.buffer` was renamed `.__webglBuffer`.

After stepping through with a debugger in `onGeometryDispose`, I couldn't find any hidden state attached to the `BufferAttribute`. `.__webglBuffer`  is attached to the `WebGLProperties`, not the `BufferAttribute`.

With that, the last reference to `gl.deleteBuffer` is disappearing from the library. Is that expected?
