### PR TITLE
Support for FaceColors with BufferGeometry

### DIFF
--- a/examples/webgl_geometry_cube.html
+++ b/examples/webgl_geometry_cube.html
@@ -30,11 +30,27 @@
 
 				scene = new THREE.Scene();
 
-				var texture = THREE.ImageUtils.loadTexture( 'textures/crate.gif' );
+				var geometry = new THREE.BufferGeometry().fromGeometry( new THREE.BoxGeometry( 200, 200, 200 ) );
 
-				var geometry = new THREE.BoxGeometry( 200, 200, 200 );
-				var material = new THREE.MeshBasicMaterial( { map: texture } );
+				var vertsPerFace = 3;
+				var faceColor = new Float32Array( 36 );
 
+				for ( var i = 0; i < 6; i ++ ) {
+
+					var color = new THREE.Color( 0xffffff * Math.random() );
+
+					faceColor[i * 6 + 0] = color.r;
+					faceColor[i * 6 + 1] = color.g;
+					faceColor[i * 6 + 2] = color.b;
+					faceColor[i * 6 + 3] = color.r;
+					faceColor[i * 6 + 4] = color.g;
+					faceColor[i * 6 + 5] = color.b;
+
+				}
+
+				geometry.addAttribute( 'color', new THREE.ElementBufferAttribute( faceColor, 3, vertsPerFace ) );
+
+				var material = new THREE.MeshBasicMaterial( { vertexColors: THREE.FaceColors } );
 				mesh = new THREE.Mesh( geometry, material );
 				scene.add( mesh );
 

--- a/src/core/ElementBufferAttribute.js
+++ b/src/core/ElementBufferAttribute.js
@@ -1,0 +1,16 @@
+THREE.ElementBufferAttribute = function ( array, itemSize, grouping ) {
+
+	THREE.BufferAttribute.call( this, array, itemSize );
+
+	this.grouping = grouping;
+
+};
+
+THREE.ElementBufferAttribute.prototype = Object.create( THREE.BufferAttribute.prototype );
+THREE.ElementBufferAttribute.prototype.constructor = THREE.ElementBufferAttribute;
+
+THREE.ElementBufferAttribute.prototype.clone = function () {
+
+	return new THREE.ElementBufferAttribute( new this.array.constructor( this.array ), this.itemSize, this.grouping );
+
+};

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -193,7 +193,35 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 		}
 
-		gl.bufferData( bufferType, data.array, usage );
+		if ( data.grouping !== undefined && data.grouping > 1 ) {
+
+			var array = data.array;
+			var vertexArray = new array.constructor( data.count * data.itemSize * data.grouping );
+
+			// TODO Optimize.
+			var idx = 0;
+			for ( var i = 0, il = data.count; i < il; i ++ ) {
+
+				for ( var k = 0, kl = data.grouping; k < kl; k ++ ) {
+
+					for ( var j = 0, jl = data.itemSize; j < jl; j ++ ) {
+
+						var value = array[ i * data.itemSize + j ];
+						vertexArray[ idx ++ ] = value;
+
+					}
+
+				}
+
+			}
+
+			gl.bufferData( bufferType, vertexArray, usage );
+
+		} else {
+
+			gl.bufferData( bufferType, data.array, usage );
+
+		}
 
 		attributeProperties.version = data.version;
 
@@ -202,6 +230,8 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 	function updateBuffer ( attributeProperties, data, bufferType ) {
 
 		gl.bindBuffer( bufferType, attributeProperties.__webglBuffer );
+
+		// TODO Update ElementBufferAttribute
 
 		if ( data.updateRange === undefined || data.updateRange.count === -1 ) { // Not using update ranges
 

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -26,6 +26,7 @@
 	"src/core/Face4.js",
 	"src/core/BufferAttribute.js",
 	"src/core/DynamicBufferAttribute.js",
+	"src/core/ElementBufferAttribute.js",
 	"src/core/InstancedBufferAttribute.js",
 	"src/core/InterleavedBuffer.js",
 	"src/core/InstancedInterleavedBuffer.js",


### PR DESCRIPTION
**Not for merging** This is just a quick prototype to show one way face-varying (or element-varying) properties could be implemented with `BufferGeometry`. 

Example using `THREE.MeshBasicMaterial( { vertexColors: THREE.FaceColors } )`

![face](https://cloud.githubusercontent.com/assets/8649151/8770122/51506a6a-2e79-11e5-886d-b46e793bce42.PNG)
