### PR TITLE
Fix error in BoxHelper with non-geometric objects

### DIFF
--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -28,6 +28,8 @@ THREE.BoxHelper.prototype.update = ( function () {
 
 		box.setFromObject( object );
 
+		if ( box.empty() ) return;
+
 		var min = box.min;
 		var max = box.max;
 


### PR DESCRIPTION
1- Open the Editor on the dev branch
2- Create and drag a Light
3- There are errors in the console related to NaN in bounding box/bounding sphere.

I'm not sure what's the source of the regression but this fixes it.
