### PR TITLE
Fix array overflow for Mesh.raycast on indexless BufferGeometry

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -175,15 +175,11 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 				var positions = attributes.position.array;
 
-				for ( var i = 0, j = 0, il = positions.length; i < il; i += 3, j += 9 ) {
+				for ( var i = 0, il = positions.length; i < il; i += 9 ) {
 
-					a = i;
-					b = i + 1;
-					c = i + 2;
-
-					vA.fromArray( positions, j );
-					vB.fromArray( positions, j + 3 );
-					vC.fromArray( positions, j + 6 );
+					vA.fromArray( positions, i );
+					vB.fromArray( positions, i + 3 );
+					vC.fromArray( positions, i + 6 );
 
 					if ( material.side === THREE.BackSide ) {
 
@@ -203,12 +199,16 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 					if ( distance < raycaster.near || distance > raycaster.far ) continue;
 
+					a = i / 3;
+					b = a + 1;
+					c = a + 2;
+
 					intersects.push( {
 
 						distance: distance,
 						point: intersectionPoint,
 						face: new THREE.Face3( a, b, c, THREE.Triangle.normal( vA, vB, vC ) ),
-						index: Math.floor(i/3), // triangle number in positions buffer semantics
+						index: a, // triangle number in positions buffer semantics
 						object: this
 
 					} );


### PR DESCRIPTION
Array overflow made raycasting on indexless BufferGeometry horribly slow (for one it was doing 3 times more work, but more importantly, array access outside of array bounds are horribly slow)

This got fixed in #4789, but apparently re-introduced somehow. Am I the only one silly enough to do a noticeable amount of raycasting on indexless buffergeometry? :)

I also pushed the definition of a, b and c down to after the intersect had been confirmed, as they are not needed before. Saves us incrementing and adding up a, b and c all the time.
