### PR TITLE
Conditional use of RGBA texture in effect composer

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -192,6 +192,9 @@
 		<h3>[method:Color getClearColor]()</h3>
 		<div>Returns a [page:Color THREE.Color] instance with the current clear color.</div>
 
+		<h3>[method:Boolean getAlpha]()</h3>
+		<div>Returns a [page:Boolean boolean] indicating if the canvas contains an alpha channel.</div>
+
 		<h3>[method:Float getClearAlpha]()</h3>
 		<div>Returns a [page:Float float] with the current clear alpha. Ranges from 0 to 1.</div>
 

--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -10,9 +10,11 @@ THREE.EffectComposer = function ( renderer, renderTarget ) {
 
 		var pixelRatio = renderer.getPixelRatio();
 
+		var format = renderer.getAlpha() ? THREE.RGBAFormat : THREE.RGBFormat;
+
 		var width  = Math.floor( renderer.context.canvas.width  / pixelRatio ) || 1;
 		var height = Math.floor( renderer.context.canvas.height / pixelRatio ) || 1;
-		var parameters = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBFormat, stencilBuffer: false };
+		var parameters = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: format, stencilBuffer: false };
 
 		renderTarget = new THREE.WebGLRenderTarget( width, height, parameters );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -554,6 +554,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	};
 
+	this.getAlpha = function () {
+
+		return _alpha;
+
+	};
+
 	this.getClearAlpha = function () {
 
 		return _clearAlpha;


### PR DESCRIPTION
Fixes #4376.

`LensFlare` doesn't mix well with `EffectComposer`. By default, `EffectComposer` uses `RGB` texture for the `renderTarget`, but `RGBA` format is needed - documented in #888 and #3085.

There is a workaround, which is to provide a `renderTarget` as input to the `EffectComposer` and not use the default.

With this patch, if the renderer enables the `alpha` channel for the canvas backbuffer, the `EffectComposer` will create a `renderTarget` that uses a `RGBA` texture instead of `RGB`.

I've confirmed the issue and I've confirmed the fix, but someone more familiar with the `EffectComposer` and `WebGLRenderTarget` will need to confirm that this is a reasonable solution.
