### PR TITLE
Make the info panel invisible to mouse

### DIFF
--- a/editor/css/dark.css
+++ b/editor/css/dark.css
@@ -46,6 +46,7 @@ input.Number {
 
 	#viewport #info {
 		text-shadow: 1px 1px 0px rgba(0,0,0,0.25);
+		pointer-events: none;
 	}
 
 #script {

--- a/editor/css/light.css
+++ b/editor/css/light.css
@@ -39,6 +39,7 @@ input.Number {
 
 	#viewport #info {
 		text-shadow: 1px 1px 0px rgba(0,0,0,0.25);
+		pointer-events: none;
 	}
 
 #script {


### PR DESCRIPTION
There is an `#info` panel in the view port of the editor.

When I rotate (left mouse button drag) or translate (right mouse button drag) the scene, my mouse pointer may cross the `#info` panel.

If that occurs, my drag action will be interrupted unexpectedly.

By add a CSS property `pointer-events: none;` to this panel, this problem will be solved.
