### PR TITLE
Moved predefined uniforms to separated array, so that the same set of uniforms is used in fragment and vertex prefixes.

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -181,6 +181,17 @@ THREE.WebGLProgram = ( function () {
 
 		} else {
 
+			var commonUniforms = [
+
+				'uniform mat4 modelMatrix;',
+				'uniform mat4 modelViewMatrix;',
+				'uniform mat4 projectionMatrix;',
+				'uniform mat4 viewMatrix;',
+				'uniform mat3 normalMatrix;',
+				'uniform vec3 cameraPosition;'
+
+			];
+
 			prefixVertex = [
 
 				'precision ' + parameters.precision + ' float;',
@@ -237,14 +248,6 @@ THREE.WebGLProgram = ( function () {
 				parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
 				parameters.logarithmicDepthBuffer && renderer.extensions.get('EXT_frag_depth') ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-
-				'uniform mat4 modelMatrix;',
-				'uniform mat4 modelViewMatrix;',
-				'uniform mat4 projectionMatrix;',
-				'uniform mat4 viewMatrix;',
-				'uniform mat3 normalMatrix;',
-				'uniform vec3 cameraPosition;',
-
 				'attribute vec3 position;',
 				'attribute vec3 normal;',
 				'attribute vec2 uv;',
@@ -289,7 +292,7 @@ THREE.WebGLProgram = ( function () {
 
 				'\n'
 
-			].filter( filterEmptyLine ).join( '\n' );
+			].concat( commonUniforms ).filter( filterEmptyLine ).join( '\n' );
 
 			prefixFragment = [
 
@@ -346,12 +349,9 @@ THREE.WebGLProgram = ( function () {
 				parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
 				parameters.logarithmicDepthBuffer && renderer.extensions.get('EXT_frag_depth') ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-				'uniform mat4 viewMatrix;',
-				'uniform vec3 cameraPosition;',
-
 				'\n'
 
-			].filter( filterEmptyLine ).join( '\n' );
+			].concat( commonUniforms ).filter( filterEmptyLine ).join( '\n' );
 
 		}
 


### PR DESCRIPTION
There is a set of predefined uniforms, that are available in vertex shader:
- modelMatrix
- modelViewMatrix
- projectionMatrix
- viewMatrix
- normalMatrix
- cameraPosition

However, only the following set was predefined for fragment shader:
- viewMatrix
- cameraPosition

For the most cases it is enough for fragment shader, however there are some cases in which other uniforms may be needed. 
There is no reason to keep to different sets of uniforms for fragment and vertex shader, as they are shared by the common program (gl.getUniformLocation is called on the program, not shader). 
Hence, my suggestion is to combine predefined uniforms into a separated array, that is used in both, vertex and fragment prefixes.
