### PR TITLE
mdcs code style change for negative numbers

### DIFF
--- a/utils/codestyle/config.json
+++ b/utils/codestyle/config.json
@@ -1,13 +1,14 @@
 {
     "preset": "mdcs",
+    "disallowSpaceAfterPrefixUnaryOperators": ["+", "-"],
     "disallowNewlineBeforeBlockStatements": true,
     "requireSpaceAfterBinaryOperators": [","],
     "disallowKeywordsOnNewLine": ["else"],
-    "excludeFiles": [ 
-        "../../.c9/", 
-        "../../.c9version/", 
-        "../../.git/", 
-        "../../build/", 
+    "excludeFiles": [
+        "../../.c9/",
+        "../../.c9version/",
+        "../../.git/",
+        "../../build/",
         "../../docs/",
         "../../editor/",
         "../../node_modules/",
@@ -28,5 +29,4 @@
         "../../examples/js/SimplexNoise.js",
         "../../examples/js/loaders/UTF8Loader.js"
         ]
-    
 }


### PR DESCRIPTION
Changes spacing rule for signed numbers

From
`cameraFront.set( 0, 0, - 1 );`

to
`cameraFront.set( 0, 0, -1 );`

The rule for subtraction expression doesn't change: `2 - 1`.
