### PR TITLE
Use setNeedsUpdate() instead of needsUpdate setter

### DIFF
--- a/docs/api/core/BufferAttribute.html
+++ b/docs/api/core/BufferAttribute.html
@@ -41,12 +41,13 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<div>
-		Flag to indicate that this attribute has changed and should be re-send to the GPU. Set this to true when you modify the value of the array.
+		Flag to indicate that this attribute has changed and should be re-sent to the GPU. Set this to true when you modify the value of the array.<br/>
+		This property is deprecated---instead, you should use the [page:BufferAttribute.setNeedsUpdate setNeedsUpdate] method.
 		</div>
 
 		<h3>[property:Integer version]</h3>
 		<div>
-		A version number, incremented every time the needsUpdate property is set to true.
+		A version number, incremented every time the [page:BufferAttribute.setNeedsUpdate setNeedsUpdate] method is called.
 		</div>
 
 
@@ -96,6 +97,11 @@
 		the value of the array at <code>index * itemSize + 1</code> to y,
 		the value of the array at <code>index * itemSize + 2</code> to z, and
 		the value of the array at <code>index * itemSize + 3</code> to w.
+		</div>
+
+		<h3>[method:null setNeedsUpdate]() </h3>
+		<div>
+		Increases the version number for the buffer, indicating that this attribute has changed and should be re-sent to the GPU. Call this method when you modify the value of the array.
 		</div>
 
 		<h3>[method:BufferAttribute clone]() </h3>

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -121,9 +121,9 @@
 			material.attributes.vertexOpacity.needsUpdate = true;
 			</code>
 			</li>
-			<li>When using [page:BufferGeometry], attribute data is stored within a [page:BufferAttribute] on the geometry itself, and the *value* within the material is ignored. To update an attribute, set the *needsUpdate* flag to true on the [page:BufferAttribute] of the geometry:
+			<li>When using [page:BufferGeometry], attribute data is stored within a [page:BufferAttribute] on the geometry itself, and the *value* within the material is ignored. To update an attribute, call the *setNeedsUpdate()* method on the [page:BufferAttribute] of the geometry:
 			<code>
-			geometry.attributes.vertexOpacity.needsUpdate = true;
+			geometry.attributes.vertexOpacity.setNeedsUpdate();
 			</code>
 			See [page:BufferGeometry] for details.</li>
 		</ul>
@@ -242,7 +242,7 @@
 		where *type* is an <a href="#attribute-types">attribute type string</a>, and *value* is an array containing an attribute value for each vertex in the geometry (or *undefined* if using [page:BufferGeometry]). Names must match the name of the attribute, as defined in the GLSL code.
 		</p>
 		<p>
-		Note that attribute buffers are <emph>not</emph> refreshed automatically when their values change; if using [page:Geometry], set <code>needsUpdate = true</code> on the attribute definition. If using [page:BufferGeometry], set <code>needsUpdate = true</code> on the [page:BufferAttribute].
+		Note that attribute buffers are <emph>not</emph> refreshed automatically when their values change; if using [page:Geometry], set <code>needsUpdate = true</code> on the attribute definition. If using [page:BufferGeometry], call <code>setNeedsUpdate()</code> on the [page:BufferAttribute].
 		</p>
 		</div>
 

--- a/docs/api/textures/Texture.html
+++ b/docs/api/textures/Texture.html
@@ -53,7 +53,7 @@
 		<div>
 		The default is THREE.ClampToEdgeWrapping, where the edge is clamped to the outer edge texels. The other two choices are THREE.RepeatWrapping and THREE.MirroredRepeatWrapping.
 		</div>
-		
+
 		<div>
 		NOTE: tiling of images in textures only functions if image dimensions are powers of two (2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...) in terms of pixels. Individual dimensions need not be equal, but each must be a power of two. This is a limitation of WebGL, not Three.js.
 		</div>
@@ -85,7 +85,13 @@
 
 		<h3>[property:boolean needsUpdate]</h3>
 		<div>
-		If a texture is changed after creation, set this flag to true so that the texture is properly set up. Particularly important for setting the wrap mode.
+		If a texture is changed after creation, set this flag to true so that the texture is properly set up. Particularly important for setting the wrap mode.<br/>
+		This property is deprecated---instead, you should use the [page:BufferAttribute.setNeedsUpdate setNeedsUpdate] method.
+		</div>
+
+		<h3>[property:Integer version]</h3>
+		<div>
+		A version number, incremented every time the [page:Texture.setNeedsUpdate setNeedsUpdate] method is called.
 		</div>
 
 		<h3>[property:Vector2 repeat]</h3>
@@ -137,6 +143,11 @@
 		<h2>Methods</h2>
 
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
+
+		<h3>[method:null setNeedsUpdate]() </h3>
+		<div>
+		Increases the version number for the texture, indicating that this texture has changed and should be re-sent to the GPU. Call this method when you modify the image or parameters of the texture. Particularly important for setting the wrap mode.
+		</div>
 
 		<h3>.clone([page:Texture texture])</h3>
 		<div>

--- a/editor/js/Sidebar.Geometry.Modifiers.js
+++ b/editor/js/Sidebar.Geometry.Modifiers.js
@@ -17,7 +17,7 @@ Sidebar.Geometry.Modifiers = function ( signals, object ) {
 
 		if ( geometry instanceof THREE.BufferGeometry ) {
 
-			geometry.attributes.normal.needsUpdate = true;
+			geometry.attributes.normal.setNeedsUpdate();
 
 		} else {
 

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -56,7 +56,7 @@ UI.Texture = function ( mapping ) {
 
 					var texture = new THREE.Texture( this, mapping );
 					texture.sourceFile = file.name;
-					texture.needsUpdate = true;
+					texture.setNeedsUpdate();
 
 					scope.setValue( texture );
 

--- a/examples/canvas_geometry_earth.html
+++ b/examples/canvas_geometry_earth.html
@@ -101,7 +101,7 @@
 				context.fillRect( 0, 0, canvas.width, canvas.height );
 
 				var texture = new THREE.Texture( canvas );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				var geometry = new THREE.PlaneBufferGeometry( 300, 300, 3, 3 );
 				var material = new THREE.MeshBasicMaterial( { map: texture, overdraw: 0.5 } );

--- a/examples/canvas_geometry_panorama.html
+++ b/examples/canvas_geometry_panorama.html
@@ -122,7 +122,7 @@
 				image.onload = function () {
 
 					texture.image = this;
-					texture.needsUpdate = true;
+					texture.setNeedsUpdate();
 
 				};
 				image.src = path;

--- a/examples/canvas_geometry_panorama_fisheye.html
+++ b/examples/canvas_geometry_panorama_fisheye.html
@@ -132,7 +132,7 @@
 				image.onload = function () {
 
 					texture.image = this;
-					texture.needsUpdate = true;
+					texture.setNeedsUpdate();
 
 				};
 				image.src = path;

--- a/examples/canvas_geometry_terrain.html
+++ b/examples/canvas_geometry_terrain.html
@@ -70,7 +70,7 @@
 
 				var data = generateHeight( 1024, 1024 );
 				var texture = new THREE.Texture( generateTexture( data, 1024, 1024 ) );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				var material = new THREE.MeshBasicMaterial( { map: texture, overdraw: 0.5 } );
 

--- a/examples/canvas_materials.html
+++ b/examples/canvas_materials.html
@@ -169,7 +169,7 @@
 				var image = document.createElement( 'img' );
 				var texture = new THREE.Texture( image, THREE.UVMapping );
 
-				image.onload = function () { texture.needsUpdate = true; };
+				image.onload = function () { texture.setNeedsUpdate(); };
 				image.src = path;
 
 				return texture;

--- a/examples/canvas_materials_video.html
+++ b/examples/canvas_materials_video.html
@@ -208,8 +208,8 @@
 
 					imageContext.drawImage( video, 0, 0 );
 
-					if ( texture ) texture.needsUpdate = true;
-					if ( textureReflection ) textureReflection.needsUpdate = true;
+					if ( texture ) texture.setNeedsUpdate();
+					if ( textureReflection ) textureReflection.setNeedsUpdate();
 
 				}
 

--- a/examples/js/Ocean.js
+++ b/examples/js/Ocean.js
@@ -255,7 +255,7 @@ THREE.Ocean.prototype.generateSeedPhaseTexture = function() {
 	this.pingPhaseTexture.wrapS = THREE.ClampToEdgeWrapping;
 	this.pingPhaseTexture.wrapT = THREE.ClampToEdgeWrapping;
 	this.pingPhaseTexture.type = THREE.FloatType;
-	this.pingPhaseTexture.needsUpdate = true;
+	this.pingPhaseTexture.setNeedsUpdate();
 
 };
 

--- a/examples/js/SimulationRenderer.js
+++ b/examples/js/SimulationRenderer.js
@@ -205,7 +205,7 @@ function SimulationRenderer( WIDTH, renderer ) {
 		var texture = new THREE.DataTexture( a, WIDTH, WIDTH, THREE.RGBAFormat, THREE.FloatType );
 		texture.minFilter = THREE.NearestFilter;
 		texture.magFilter = THREE.NearestFilter;
-		texture.needsUpdate = true;
+		texture.setNeedsUpdate();
 		texture.flipY = false;
 
 		return texture;
@@ -231,7 +231,7 @@ function SimulationRenderer( WIDTH, renderer ) {
 		var texture = new THREE.DataTexture( a, WIDTH, WIDTH, THREE.RGBFormat, THREE.FloatType );
 		texture.minFilter = THREE.NearestFilter;
 		texture.magFilter = THREE.NearestFilter;
-		texture.needsUpdate = true;
+		texture.setNeedsUpdate();
 		texture.flipY = false;
 
 		return texture;

--- a/examples/js/loaders/AWDLoader.js
+++ b/examples/js/loaders/AWDLoader.js
@@ -469,7 +469,7 @@
 			loader.load( this._baseDir + url, function( image ) {
 
 				tex.image = image;
-				tex.needsUpdate = true;
+				tex.setNeedsUpdate();
 
 			} );
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -4314,7 +4314,7 @@
 		loader.load( url, function ( image ) {
 
 			texture.image = image;
-			texture.needsUpdate = true;
+			texture.setNeedsUpdate();
 
 		} );
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -421,7 +421,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 			loader.load( url, function ( image ) {
 
 				texture.image = THREE.MTLLoader.ensurePowerOfTwo_( image );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				if ( onLoad ) onLoad( texture );
 

--- a/examples/js/loaders/deprecated/SceneLoader.js
+++ b/examples/js/loaders/deprecated/SceneLoader.js
@@ -968,7 +968,7 @@ THREE.SceneLoader.prototype = {
 						loader.load( fullUrl, function ( image ) {
 
 							texture.image = image;
-							texture.needsUpdate = true;
+							texture.setNeedsUpdate();
 
 							textureCallback();
 

--- a/examples/js/loaders/sea3d/SEA3DLoader.js
+++ b/examples/js/loaders/sea3d/SEA3DLoader.js
@@ -1640,7 +1640,7 @@ THREE.SEA3D.prototype.readImage = function(sea) {
 		}
 		
 		texture.image = image;
-		texture.needsUpdate = true; 	
+		texture.setNeedsUpdate(); 	
 	}
 	
 	image.src = this.bufferToTexture( sea.data.buffer );	
@@ -1678,7 +1678,7 @@ THREE.SEA3D.prototype.readCubeMap = function(sea) {
 		
 		cubeImage.onload = function () {			
 			if (++images.loadedCount == 6)
-				texture.needsUpdate = true;			
+				texture.setNeedsUpdate();			
 		}
 
 		cubeImage.src = this.bufferToTexture( faces[i].buffer );

--- a/examples/js/math/Lut.js
+++ b/examples/js/math/Lut.js
@@ -196,7 +196,7 @@ THREE.Lut.prototype = {
 		}
 
 		this.legend.ctx.putImageData( imageData, 0, 0 );
-		this.legend.texture.needsUpdate = true;
+		this.legend.texture.setNeedsUpdate();
 
 		this.legend.legendGeometry = new THREE.PlaneBufferGeometry( this.legend.dimensions.width, this.legend.dimensions.height );
 		this.legend.legendMaterial = new THREE.MeshBasicMaterial( { map : this.legend.texture, side : THREE.DoubleSide } );
@@ -329,7 +329,7 @@ THREE.Lut.prototype = {
 
 		var txtTitle = new THREE.Texture( canvasTitle );
 		txtTitle.minFilter = THREE.LinearFilter;
-		txtTitle.needsUpdate = true;
+		txtTitle.setNeedsUpdate();
 
 		var spriteMaterialTitle = new THREE.SpriteMaterial( { map: txtTitle, useScreenCoordinates: false } );
 
@@ -410,7 +410,7 @@ THREE.Lut.prototype = {
 
 				var txtTick = new THREE.Texture( canvasTick );
 				txtTick.minFilter = THREE.LinearFilter;
-				txtTick.needsUpdate = true;
+				txtTick.setNeedsUpdate();
 
 				var spriteMaterialTick = new THREE.SpriteMaterial( { map: txtTick, useScreenCoordinates: false } );
 

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -112,7 +112,7 @@ THREE.GlitchPass.prototype = {
 		console.log( dt_size );
 		texture.minFilter = THREE.NearestFilter;
 		texture.magFilter = THREE.NearestFilter;
-		texture.needsUpdate = true;
+		texture.setNeedsUpdate();
 		texture.flipY = false;
 		return texture;
 

--- a/examples/js/utils/ShadowMapViewer.js
+++ b/examples/js/utils/ShadowMapViewer.js
@@ -82,7 +82,7 @@ THREE.ShadowMapViewer = function ( light ) {
 		var labelTexture = new THREE.Texture( labelCanvas );
 		labelTexture.magFilter = THREE.LinearFilter;
 		labelTexture.minFilter = THREE.LinearFilter;
-		labelTexture.needsUpdate = true;
+		labelTexture.setNeedsUpdate();
 
 		var labelMaterial = new THREE.MeshBasicMaterial( { map: labelTexture, side: THREE.DoubleSide } );
 		labelMaterial.transparent = true;

--- a/examples/misc_ubiquity_test2.html
+++ b/examples/misc_ubiquity_test2.html
@@ -72,7 +72,7 @@
 
 						var tex = texture1.clone();
 
-						tex.needsUpdate = true; // cloning does not set this
+						tex.setNeedsUpdate(); // cloning does not set this
 
 						tex.offset.x = 0.1 * THREE.Math.randInt( 0, 7 );
 						tex.offset.y = 0.1 * THREE.Math.randInt( 0, 7 );

--- a/examples/software_geometry_earth.html
+++ b/examples/software_geometry_earth.html
@@ -101,7 +101,7 @@
 				context.fillRect( 0, 0, canvas.width, canvas.height );
 
 				var texture = new THREE.Texture( canvas );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				var geometry = new THREE.PlaneBufferGeometry( 300, 300, 3, 3 );
 				var material = new THREE.MeshBasicMaterial( { map: texture, overdraw: 0.5 } );

--- a/examples/webgl_buffergeometry_custom_attributes_particles.html
+++ b/examples/webgl_buffergeometry_custom_attributes_particles.html
@@ -210,7 +210,7 @@
 
 			}
 
-			geometry.attributes.size.needsUpdate = true;
+			geometry.attributes.size.setNeedsUpdate();
 
 			renderer.render( scene, camera );
 

--- a/examples/webgl_buffergeometry_drawcalls.html
+++ b/examples/webgl_buffergeometry_drawcalls.html
@@ -275,10 +275,10 @@
 
 
 				linesMesh.geometry.drawcalls[ 0 ].count = numConnected * 2;
-				linesMesh.geometry.attributes.position.needsUpdate = true;
-				linesMesh.geometry.attributes.color.needsUpdate = true;
+				linesMesh.geometry.attributes.position.setNeedsUpdate();
+				linesMesh.geometry.attributes.color.setNeedsUpdate();
 
-				pointCloud.geometry.attributes.position.needsUpdate = true;
+				pointCloud.geometry.attributes.position.setNeedsUpdate();
 
 				requestAnimationFrame( animate );
 

--- a/examples/webgl_buffergeometry_instancing_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_dynamic.html
@@ -326,7 +326,7 @@
                 orientations.setXYZW( i, currentQ.x, currentQ.y, currentQ.z, currentQ.w );
 
             }
-            orientations.needsUpdate = true;
+            orientations.setNeedsUpdate();
             lastTime = time;
         }
 

--- a/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
@@ -298,7 +298,7 @@
             orientations.setXYZW( i, currentQ.x, currentQ.y, currentQ.z, currentQ.w );
 
         }
-        instanceBuffer.needsUpdate = true;
+        instanceBuffer.setNeedsUpdate();
         lastTime = time;
     }
 

--- a/examples/webgl_custom_attributes.html
+++ b/examples/webgl_custom_attributes.html
@@ -197,7 +197,7 @@
 
 			}
 
-			sphere.geometry.attributes.displacement.needsUpdate = true;
+			sphere.geometry.attributes.displacement.setNeedsUpdate();
 
 			renderer.render( scene, camera );
 

--- a/examples/webgl_custom_attributes_lines.html
+++ b/examples/webgl_custom_attributes_lines.html
@@ -217,7 +217,7 @@
 
 			}
 
-			attributes.displacement.needsUpdate = true;
+			attributes.displacement.setNeedsUpdate();
 
 			renderer.render( scene, camera );
 

--- a/examples/webgl_geometry_colors.html
+++ b/examples/webgl_geometry_colors.html
@@ -85,7 +85,7 @@
 				context.fillRect( 0, 0, canvas.width, canvas.height );
 
 				var shadowTexture = new THREE.Texture( canvas );
-				shadowTexture.needsUpdate = true;
+				shadowTexture.setNeedsUpdate();
 
 				var shadowMaterial = new THREE.MeshBasicMaterial( { map: shadowTexture } );
 				var shadowGeo = new THREE.PlaneBufferGeometry( 300, 300, 1, 1 );

--- a/examples/webgl_geometry_terrain.html
+++ b/examples/webgl_geometry_terrain.html
@@ -93,7 +93,7 @@
 				}
 
 				texture = new THREE.Texture( generateTexture( data, worldWidth, worldDepth ), THREE.UVMapping, THREE.ClampToEdgeWrapping, THREE.ClampToEdgeWrapping );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( { map: texture } ) );
 				scene.add( mesh );

--- a/examples/webgl_geometry_terrain_fog.html
+++ b/examples/webgl_geometry_terrain_fog.html
@@ -95,7 +95,7 @@
 				}
 
 				texture = new THREE.Texture( generateTexture( data, worldWidth, worldDepth ), THREE.UVMapping, THREE.ClampToEdgeWrapping, THREE.ClampToEdgeWrapping );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( { map: texture } ) );
 				scene.add( mesh );

--- a/examples/webgl_geometry_terrain_raycast.html
+++ b/examples/webgl_geometry_terrain_raycast.html
@@ -102,7 +102,7 @@
 				geometry.computeFaceNormals();
 
 				texture = new THREE.Texture( generateTexture( data, worldWidth, worldDepth ), THREE.UVMapping, THREE.ClampToEdgeWrapping, THREE.ClampToEdgeWrapping );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( { map: texture } ) );
 				scene.add( mesh );

--- a/examples/webgl_loader_json_objconverter.html
+++ b/examples/webgl_loader_json_objconverter.html
@@ -102,7 +102,7 @@
 				xc.fillRect(96, 96, 32, 32);
 
 				var xm = new THREE.MeshBasicMaterial( { map: new THREE.Texture( x, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping ) } );
-				xm.map.needsUpdate = true;
+				xm.map.setNeedsUpdate();
 				xm.map.repeat.set( 10, 10 );
 
 				geometry = new THREE.PlaneBufferGeometry( 100, 100, 15, 10 );
@@ -250,7 +250,7 @@
 					xc.fillText( i, 10, 64 );
 
 					var xm = new THREE.MeshBasicMaterial( { map: new THREE.Texture( x ), transparent: true } );
-					xm.map.needsUpdate = true;
+					xm.map.setNeedsUpdate();
 
 					mesh = new THREE.Mesh( new THREE.PlaneBufferGeometry( size, size ), xm );
 					mesh.position.x = i * ( size + 5 ) - ( ( materials.length - 1 )* ( size + 5 )/2);

--- a/examples/webgl_loader_obj.html
+++ b/examples/webgl_loader_obj.html
@@ -94,7 +94,7 @@
 				loader.load( 'textures/UV_Grid_Sm.jpg', function ( image ) {
 
 					texture.image = image;
-					texture.needsUpdate = true;
+					texture.setNeedsUpdate();
 
 				} );
 

--- a/examples/webgl_materials.html
+++ b/examples/webgl_materials.html
@@ -66,7 +66,7 @@
 				// Materials
 
 				var texture = new THREE.Texture( generateTexture() );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				materials.push( new THREE.MeshLambertMaterial( { map: texture, transparent: true } ) );
 				materials.push( new THREE.MeshLambertMaterial( { color: 0xdddddd, shading: THREE.FlatShading } ) );

--- a/examples/webgl_materials_blending.html
+++ b/examples/webgl_materials_blending.html
@@ -56,7 +56,7 @@
 				mapBg = new THREE.Texture( x );
 				mapBg.wrapS = mapBg.wrapT = THREE.RepeatWrapping;
 				mapBg.repeat.set( 128, 64 );
-				mapBg.needsUpdate = true;
+				mapBg.setNeedsUpdate();
 
 				/*
 				var mapBg = THREE.ImageUtils.loadTexture( "textures/disturb.jpg" );
@@ -158,7 +158,7 @@
 				xc.fillText( text, 10, 22 );
 
 				var map = new THREE.Texture( x );
-				map.needsUpdate = true;
+				map.setNeedsUpdate();
 
 				var material = new THREE.MeshBasicMaterial( { map: map, transparent: true } );
 				return material;
@@ -168,7 +168,7 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				
+
 				var time = Date.now() * 0.00025;
 				var ox = ( time * -0.01 * mapBg.repeat.x ) % 1;
 				var oy = ( time * -0.01 * mapBg.repeat.y ) % 1;

--- a/examples/webgl_materials_blending_custom.html
+++ b/examples/webgl_materials_blending_custom.html
@@ -141,12 +141,12 @@
 				var mapBg0 = new THREE.Texture( x );
 				mapBg0.wrapS = mapBg0.wrapT = THREE.RepeatWrapping;
 				mapBg0.repeat.set( 128, 64 );
-				mapBg0.needsUpdate = true;
+				mapBg0.setNeedsUpdate();
 
 				var mapBg1 = new THREE.Texture( x2 );
 				mapBg1.wrapS = mapBg1.wrapT = THREE.RepeatWrapping;
 				mapBg1.repeat.set( 128, 64 );
-				mapBg1.needsUpdate = true;
+				mapBg1.setNeedsUpdate();
 
 				var mapBg2 = THREE.ImageUtils.loadTexture( "textures/disturb.jpg" );
 				mapBg2.wrapS = mapBg2.wrapT = THREE.RepeatWrapping;
@@ -193,7 +193,7 @@
 					var mapPre = map.clone();
 
 					mapPre.premultiplyAlpha = true;
-					mapPre.needsUpdate = true;
+					mapPre.setNeedsUpdate();
 
 					mapsNoPre.push( map );
 					mapsPre.push( mapPre );
@@ -417,7 +417,7 @@
 				xc.fillText( text, 8, 22 );
 
 				var map = new THREE.Texture( x );
-				map.needsUpdate = true;
+				map.setNeedsUpdate();
 
 				var material = new THREE.MeshBasicMaterial( { map: map, transparent: true } );
 				return material;

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -546,7 +546,7 @@
 			//
 
 			var shadowTexture = new THREE.Texture( canvas );
-			shadowTexture.needsUpdate = true;
+			shadowTexture.setNeedsUpdate();
 
 			var shadowPlane = new THREE.PlaneBufferGeometry( 400, 400 );
 			var shadowMaterial = new THREE.MeshBasicMaterial( {

--- a/examples/webgl_materials_grass.html
+++ b/examples/webgl_materials_grass.html
@@ -41,7 +41,7 @@
 				var geometry = new THREE.PlaneBufferGeometry( 100, 100 );
 
 				var texture = new THREE.Texture( generateTexture() );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				for ( var i = 0; i < 15; i ++ ) {
 

--- a/examples/webgl_materials_texture_filters.html
+++ b/examples/webgl_materials_texture_filters.html
@@ -117,13 +117,13 @@
 				var textureCanvas = new THREE.Texture( imageCanvas, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping );
 					materialCanvas = new THREE.MeshBasicMaterial( { map: textureCanvas } );
 
-				textureCanvas.needsUpdate = true;
+				textureCanvas.setNeedsUpdate();
 				textureCanvas.repeat.set( 1000, 1000 );
 
 				var textureCanvas2 = new THREE.Texture( imageCanvas, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping, THREE.NearestFilter, THREE.NearestFilter );
 					materialCanvas2 = new THREE.MeshBasicMaterial( { color: 0xffccaa, map: textureCanvas2 } );
 
-				textureCanvas2.needsUpdate = true;
+				textureCanvas2.setNeedsUpdate();
 				textureCanvas2.repeat.set( 1000, 1000 );
 
 				var geometry = new THREE.PlaneBufferGeometry( 100, 100 );
@@ -144,7 +144,7 @@
 					var image = texturePainting.image;
 
 					texturePainting2.image = image;
-					texturePainting2.needsUpdate = true;
+					texturePainting2.setNeedsUpdate();
 
 					scene.add( meshCanvas );
 					scene2.add( meshCanvas2 );

--- a/examples/webgl_materials_texture_manualmipmap.html
+++ b/examples/webgl_materials_texture_manualmipmap.html
@@ -130,14 +130,14 @@
 				textureCanvas1.mipmaps[ 5 ] = mipmap( 4,  '#004' );
 				textureCanvas1.mipmaps[ 6 ] = mipmap( 2,  '#044' );
 				textureCanvas1.mipmaps[ 7 ] = mipmap( 1,  '#404' );
-				textureCanvas1.needsUpdate = true;
+				textureCanvas1.setNeedsUpdate();
 
 				materialCanvas1 = new THREE.MeshBasicMaterial( { map: textureCanvas1 } );
 
 				var textureCanvas2 = textureCanvas1.clone();
 				textureCanvas2.magFilter = THREE.NearestFilter;
 				textureCanvas2.minFilter = THREE.NearestMipMapNearestFilter;
-				textureCanvas2.needsUpdate = true;
+				textureCanvas2.setNeedsUpdate();
 				materialCanvas2 = new THREE.MeshBasicMaterial( { color: 0xffccaa, map: textureCanvas2 } );
 
 				var geometry = new THREE.PlaneBufferGeometry( 100, 100 );
@@ -158,7 +158,7 @@
 					var image = texturePainting1.image;
 
 					texturePainting2.image = image;
-					texturePainting2.needsUpdate = true;
+					texturePainting2.setNeedsUpdate();
 
 					scene1.add( meshCanvas1 );
 					scene2.add( meshCanvas2 );

--- a/examples/webgl_multiple_canvases_circle.html
+++ b/examples/webgl_multiple_canvases_circle.html
@@ -237,7 +237,7 @@
 					context.fillRect( 0, 0, canvas.width, canvas.height );
 
 					var shadowTexture = new THREE.Texture( canvas );
-					shadowTexture.needsUpdate = true;
+					shadowTexture.setNeedsUpdate();
 
 					var shadowMaterial = new THREE.MeshBasicMaterial( { map: shadowTexture } );
 					var shadowGeo = new THREE.PlaneBufferGeometry( 300, 300, 1, 1 );

--- a/examples/webgl_multiple_canvases_complex.html
+++ b/examples/webgl_multiple_canvases_complex.html
@@ -145,7 +145,7 @@
 					context.fillRect( 0, 0, canvas.width, canvas.height );
 
 					var shadowTexture = new THREE.Texture( canvas );
-					shadowTexture.needsUpdate = true;
+					shadowTexture.setNeedsUpdate();
 
 					var shadowMaterial = new THREE.MeshBasicMaterial( { map: shadowTexture } );
 					var shadowGeo = new THREE.PlaneBufferGeometry( 300, 300, 1, 1 );

--- a/examples/webgl_multiple_canvases_grid.html
+++ b/examples/webgl_multiple_canvases_grid.html
@@ -161,7 +161,7 @@
 					context.fillRect( 0, 0, canvas.width, canvas.height );
 
 					var shadowTexture = new THREE.Texture( canvas );
-					shadowTexture.needsUpdate = true;
+					shadowTexture.setNeedsUpdate();
 
 					var shadowMaterial = new THREE.MeshBasicMaterial( { map: shadowTexture } );
 					var shadowGeo = new THREE.PlaneBufferGeometry( 300, 300, 1, 1 );

--- a/examples/webgl_multiple_renderers.html
+++ b/examples/webgl_multiple_renderers.html
@@ -145,7 +145,7 @@
 				context.fillRect( 0, 0, canvas.width, canvas.height );
 
 				var shadowTexture = new THREE.Texture( canvas );
-				shadowTexture.needsUpdate = true;
+				shadowTexture.setNeedsUpdate();
 
 				var shadowMaterial = new THREE.MeshBasicMaterial( { map: shadowTexture } );
 				var shadowGeo = new THREE.PlaneBufferGeometry( 300, 300, 1, 1 );

--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -142,7 +142,7 @@
 				context.fillRect( 0, 0, canvas.width, canvas.height );
 
 				var shadowTexture = new THREE.Texture( canvas );
-				shadowTexture.needsUpdate = true;
+				shadowTexture.setNeedsUpdate();
 
 				var shadowMaterial = new THREE.MeshBasicMaterial( { map: shadowTexture, transparent: true } );
 				var shadowGeo = new THREE.PlaneBufferGeometry( 300, 300, 1, 1 );

--- a/examples/webgl_nearestneighbour.html
+++ b/examples/webgl_nearestneighbour.html
@@ -218,7 +218,7 @@
 						// set the alpha according to distance
 						alphas[ objectIndex ] = 1.0 / maxDistance * object[1];
 						// update the attribute
-						_particleGeom.attributes.alpha.needsUpdate = true;
+						_particleGeom.attributes.alpha.setNeedsUpdate();
 					}
 				}
 			}

--- a/examples/webgl_panorama_equirectangular.html
+++ b/examples/webgl_panorama_equirectangular.html
@@ -112,7 +112,7 @@
 					reader.addEventListener( 'load', function ( event ) {
 
 						material.map.image.src = event.target.result;
-						material.map.needsUpdate = true;
+						material.map.setNeedsUpdate();
 
 					}, false );
 					reader.readAsDataURL( event.dataTransfer.files[ 0 ] );

--- a/examples/webgl_particles_shapes.html
+++ b/examples/webgl_particles_shapes.html
@@ -258,7 +258,7 @@
 				var sprite = generateSprite() ;
 
 				texture = new THREE.Texture( sprite );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				uniforms = {
 

--- a/examples/webgl_sandbox.html
+++ b/examples/webgl_sandbox.html
@@ -81,8 +81,8 @@
 				var texture2 = new THREE.Texture( generateTexture( 0, 1, 0 ), THREE.SphericalReflectionMapping );
 				var texture3 = THREE.ImageUtils.loadTexture( 'textures/land_ocean_ice_cloud_2048.jpg' );
 
-				texture1.needsUpdate = true;
-				texture2.needsUpdate = true;
+				texture1.setNeedsUpdate();
+				texture2.setNeedsUpdate();
 
 				var materials = [
 

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -149,7 +149,7 @@
 					cubeMap.images[ 3 ] = getSide( 1, 2 ); // ny
 					cubeMap.images[ 4 ] = getSide( 1, 1 ); // pz
 					cubeMap.images[ 5 ] = getSide( 3, 1 ); // nz
-					cubeMap.needsUpdate = true;
+					cubeMap.setNeedsUpdate();
 
 				} );
 

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -134,7 +134,7 @@
 				xc.fillRect(96, 96, 32, 32);
 
 				var texturePattern = new THREE.Texture( x, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping );
-				texturePattern.needsUpdate = true;
+				texturePattern.setNeedsUpdate();
 				texturePattern.repeat.set( 1000, 1000 );
 				texturePattern.format = THREE.RGBFormat;
 

--- a/examples/webgl_test_memory.html
+++ b/examples/webgl_test_memory.html
@@ -75,7 +75,7 @@
 			    var geometry = new THREE.SphereBufferGeometry( 50, Math.random() * 64, Math.random() * 32 );
 
 				var texture = new THREE.Texture( createImage() );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				var material = new THREE.MeshBasicMaterial( { map: texture, wireframe: true } );
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -32,7 +32,9 @@ THREE.BufferAttribute.prototype = {
 
 	set needsUpdate( value ) {
 
-		if ( value === true ) this.version ++;
+		console.warn( 'THREE.BufferAttribute: .needsUpdate is deprecated. Use .setNeedsUpdate() instead.' );
+
+		if ( value === true ) this.setNeedsUpdate();
 
 	},
 
@@ -276,6 +278,12 @@ THREE.BufferAttribute.prototype = {
 		this.array[ index + 3 ] = w;
 
 		return this;
+
+	},
+
+	setNeedsUpdate: function () {
+
+		this.version ++;
 
 	},
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -87,7 +87,7 @@ THREE.BufferGeometry.prototype = {
 		if ( position !== undefined ) {
 
 			matrix.applyToVector3Array( position.array );
-			position.needsUpdate = true;
+			position.setNeedsUpdate();
 
 		}
 
@@ -98,7 +98,7 @@ THREE.BufferGeometry.prototype = {
 			var normalMatrix = new THREE.Matrix3().getNormalMatrix( matrix );
 
 			normalMatrix.applyToVector3Array( normal.array );
-			normal.needsUpdate = true;
+			normal.setNeedsUpdate();
 
 		}
 
@@ -213,7 +213,7 @@ THREE.BufferGeometry.prototype = {
 			if ( attribute !== undefined ) {
 
 				attribute.copyVector3sArray( geometry.vertices );
-				attribute.needsUpdate = true;
+				attribute.setNeedsUpdate();
 
 			}
 
@@ -228,7 +228,7 @@ THREE.BufferGeometry.prototype = {
 			if ( attribute !== undefined ) {
 
 				attribute.copyVector3sArray( geometry.normals );
-				attribute.needsUpdate = true;
+				attribute.setNeedsUpdate();
 
 			}
 
@@ -243,7 +243,7 @@ THREE.BufferGeometry.prototype = {
 			if ( attribute !== undefined ) {
 
 				attribute.copyColorsArray( geometry.colors );
-				attribute.needsUpdate = true;
+				attribute.setNeedsUpdate();
 
 			}
 
@@ -258,7 +258,7 @@ THREE.BufferGeometry.prototype = {
 			if ( attribute !== undefined ) {
 
 				attribute.copyVector4sArray( geometry.tangents );
-				attribute.needsUpdate = true;
+				attribute.setNeedsUpdate();
 
 			}
 
@@ -273,7 +273,7 @@ THREE.BufferGeometry.prototype = {
 			if ( attribute !== undefined ) {
 
 				attribute.copyArray( geometry.lineDistances );
-				attribute.needsUpdate = true;
+				attribute.setNeedsUpdate();
 
 			}
 
@@ -618,7 +618,7 @@ THREE.BufferGeometry.prototype = {
 
 			this.normalizeNormals();
 
-			attributes.normal.needsUpdate = true;
+			attributes.normal.setNeedsUpdate();
 
 		}
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -34,7 +34,9 @@ THREE.InterleavedBuffer.prototype = {
 
 	set needsUpdate( value ) {
 
-		if ( value === true ) this.version ++;
+		console.warn( 'THREE.InterleavedBuffer: .needsUpdate is deprecated. Use .setNeedsUpdate() instead.' );
+
+		if ( value === true ) this.setNeedsUpdate();
 
 	},
 
@@ -60,6 +62,12 @@ THREE.InterleavedBuffer.prototype = {
 		this.array.set( value, offset );
 
 		return this;
+
+	},
+
+	setNeedsUpdate: function () {
+
+		this.version ++;
 
 	},
 

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -18,7 +18,7 @@ THREE.ImageUtils = {
 		loader.load( url, function ( image ) {
 
 			texture.image = image;
-			texture.needsUpdate = true;
+			texture.setNeedsUpdate();
 
 			if ( onLoad ) onLoad( texture );
 
@@ -55,7 +55,7 @@ THREE.ImageUtils = {
 
 				if ( loaded === 6 ) {
 
-					texture.needsUpdate = true;
+					texture.setNeedsUpdate();
 
 					if ( onLoad ) onLoad( texture );
 
@@ -208,7 +208,7 @@ THREE.ImageUtils = {
 		}
 
 		var texture = new THREE.DataTexture( data, width, height, THREE.RGBFormat );
-		texture.needsUpdate = true;
+		texture.setNeedsUpdate();
 
 		return texture;
 

--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -91,7 +91,7 @@ THREE.BoxHelper.prototype.update = ( function () {
 		vertices[ 66 ] = max.x; vertices[ 67 ] = min.y; vertices[ 68 ] = max.z;
 		vertices[ 69 ] = max.x; vertices[ 70 ] = min.y; vertices[ 71 ] = min.z;
 
-		this.geometry.attributes.position.needsUpdate = true;
+		this.geometry.attributes.position.setNeedsUpdate();
 
 		this.geometry.computeBoundingSphere();
 

--- a/src/extras/helpers/FaceNormalsHelper.js
+++ b/src/extras/helpers/FaceNormalsHelper.js
@@ -103,7 +103,7 @@ THREE.FaceNormalsHelper.prototype.update = ( function () {
 
 		}
 
-		position.needsUpdate = true;
+		position.setNeedsUpdate();
 
 		return this;
 

--- a/src/extras/helpers/VertexNormalsHelper.js
+++ b/src/extras/helpers/VertexNormalsHelper.js
@@ -137,7 +137,7 @@ THREE.VertexNormalsHelper.prototype.update = ( function () {
 
 		}
 
-		position.needsUpdate = true;
+		position.setNeedsUpdate();
 
 		return this;
 

--- a/src/extras/helpers/VertexTangentsHelper.js
+++ b/src/extras/helpers/VertexTangentsHelper.js
@@ -135,7 +135,7 @@ THREE.VertexTangentsHelper.prototype.update = ( function ( object ) {
 
 		}
 
-		position.needsUpdate = true;
+		position.setNeedsUpdate();
 
 		return this;
 

--- a/src/loaders/BinaryTextureLoader.js
+++ b/src/loaders/BinaryTextureLoader.js
@@ -76,7 +76,7 @@ THREE.BinaryTextureLoader.prototype = {
 
 			}
 
-			texture.needsUpdate = true;
+			texture.setNeedsUpdate();
 
 			if ( onLoad ) onLoad( texture, texData );
 

--- a/src/loaders/CompressedTextureLoader.js
+++ b/src/loaders/CompressedTextureLoader.js
@@ -56,7 +56,7 @@ THREE.CompressedTextureLoader.prototype = {
  							texture.minFilter = THREE.LinearFilter;
 
 						texture.format = texDatas.format;
-						texture.needsUpdate = true;
+						texture.setNeedsUpdate();
 
 						if ( onLoad ) onLoad( texture );
 
@@ -114,7 +114,7 @@ THREE.CompressedTextureLoader.prototype = {
 				}
 
 				texture.format = texDatas.format;
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				if ( onLoad ) onLoad( texture );
 

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -116,7 +116,7 @@ THREE.Loader.prototype = {
 
 						}
 
-						texture.needsUpdate = true;
+						texture.setNeedsUpdate();
 
 					} );
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -434,7 +434,7 @@ THREE.ObjectLoader.prototype = {
 				}
 
 				var texture = new THREE.Texture( images[ data.image ] );
-				texture.needsUpdate = true;
+				texture.setNeedsUpdate();
 
 				texture.uuid = data.uuid;
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -21,7 +21,7 @@ THREE.TextureLoader.prototype = {
 		loader.load( url, function ( image ) {
 
 			var texture = new THREE.Texture( image );
-			texture.needsUpdate = true;
+			texture.setNeedsUpdate();
 
 			if ( onLoad !== undefined ) {
 

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -164,7 +164,7 @@ THREE.Skeleton.prototype.update = ( function () {
 
 		if ( this.useVertexTexture ) {
 
-			this.boneTexture.needsUpdate = true;
+			this.boneTexture.setNeedsUpdate();
 
 		}
 

--- a/src/renderers/webgl/plugins/SpritePlugin.js
+++ b/src/renderers/webgl/plugins/SpritePlugin.js
@@ -81,7 +81,7 @@ THREE.SpritePlugin = function ( renderer, sprites ) {
 		context.fillRect( 0, 0, 8, 8 );
 
 		texture = new THREE.Texture( canvas );
-		texture.needsUpdate = true;
+		texture.setNeedsUpdate();
 
 	};
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -51,7 +51,15 @@ THREE.Texture.prototype = {
 
 	set needsUpdate ( value ) {
 
-		if ( value === true ) this.version ++;
+		console.warn( 'THREE.Texture: .needsUpdate is deprecated. Use .setNeedsUpdate() instead.' );
+
+		if ( value === true ) this.setNeedsUpdate();
+
+	},
+
+	setNeedsUpdate: function () {
+
+		this.version ++;
 
 	},
 

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -16,7 +16,7 @@ THREE.VideoTexture = function ( video, mapping, wrapS, wrapT, magFilter, minFilt
 
 		if ( video.readyState === video.HAVE_ENOUGH_DATA ) {
 
-			scope.needsUpdate = true;
+			scope.setNeedsUpdate();
 
 		}
 


### PR DESCRIPTION
For `Texture`, `BufferAttribute`, and `InterleavedBuffer`, introduce new method `setNeedsUpdate()` instead of the faked property `needsUpdate`. Replace uses of `needsUpdate = true` and document the new APi.

Naming: `setNeedsUpdate()` could be named something like `incrementVersion()` if you prefer. I don't think `update()` is appropriate as it doesn't directly perform an update.

`Material` and uniforms don't have a version counter, They still use the boolean flag `needsUpdate` (no change).
