### PR TITLE
RequireJs native support

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -9,6 +9,7 @@ if (typeof define === 'function' && define.amd) {
     define("three", THREE);
 } else if ('undefined' !== typeof exports && 'undefined' !== typeof module) {
     module.exports = THREE;
+}
  
 
 // polyfills

--- a/src/Three.js
+++ b/src/Three.js
@@ -5,12 +5,11 @@
 var THREE = { REVISION: '72dev' };
 
 // browserify support
-
-if ( typeof module === 'object' ) {
-
-	module.exports = THREE;
-
-}
+if (typeof define === 'function' && define.amd) {
+    define("three", THREE);
+} else if ('undefined' !== typeof exports && 'undefined' !== typeof module) {
+    module.exports = THREE;
+ 
 
 // polyfills
 


### PR DESCRIPTION
Closes #6930.
Allows users to include library as AMD module without using shim.
