### PR TITLE
Absolute value on scale.x for success intersection

### DIFF
--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -40,7 +40,7 @@ THREE.Sprite.prototype.raycast = ( function () {
 
 		var distance = raycaster.ray.distanceToPoint( matrixPosition );
 
-		if ( distance > this.scale.x ) {
+		if ( distance > Math.abs(this.scale.x) ) {
 
 			return;
 


### PR DESCRIPTION
Sometimes we use negative value for scale.x in order to flip the sprite horizontally. So we need to check against the absolute value otherwise we do not get the object intersected.
