### PR TITLE
Blender Exporter: Fixed orphaned data left over from multiple exports

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/base_classes.py
+++ b/utils/exporters/blender/addons/io_three/exporter/base_classes.py
@@ -14,6 +14,7 @@ class BaseClass(constants.BASE_DICT):
         self._parent = parent
 
         constants.BASE_DICT.update(self, self._defaults.copy())
+        BaseClass._defaults = {}
 
     def __setitem__(self, key, value):
         if not isinstance(value, constants.VALID_DATA_TYPES):

--- a/utils/exporters/blender/addons/io_three/exporter/scene.py
+++ b/utils/exporters/blender/addons/io_three/exporter/scene.py
@@ -14,16 +14,16 @@ from . import (
 
 class Scene(base_classes.BaseScene):
     """Class that handles the contruction of a Three scene"""
-    _defaults = {
-        constants.METADATA: constants.DEFAULT_METADATA.copy(),
-        constants.GEOMETRIES: [],
-        constants.MATERIALS: [],
-        constants.IMAGES: [],
-        constants.TEXTURES: []
-    }
 
     def __init__(self, filepath, options=None):
         logger.debug("Scene().__init__(%s, %s)", filepath, options)
+        self._defaults = {
+            constants.METADATA: constants.DEFAULT_METADATA.copy(),
+            constants.GEOMETRIES: [],
+            constants.MATERIALS: [],
+            constants.IMAGES: [],
+            constants.TEXTURES: []
+        }
         base_classes.BaseScene.__init__(self, filepath, options or {})
 
         source_file = api.scene_name()


### PR DESCRIPTION
Fixed a bug that was causing orphaned indices when performing more than 1 export of multiple scenes from the same Blender session

Addresses: https://github.com/mrdoob/three.js/issues/6913
