### PR TITLE
Complete json roundtrip for lights

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -172,7 +172,7 @@ THREE.Object3D.prototype = {
 
 			return this;
 
-		}
+		};
 
 	}(),
 
@@ -227,7 +227,7 @@ THREE.Object3D.prototype = {
 
 			return this;
 
-		}
+		};
 
 	}(),
 
@@ -443,7 +443,7 @@ THREE.Object3D.prototype = {
 
 			return result;
 
-		}
+		};
 
 	}(),
 
@@ -459,7 +459,7 @@ THREE.Object3D.prototype = {
 
 			return result.setFromQuaternion( quaternion, this.rotation.order, false );
 
-		}
+		};
 
 	}(),
 
@@ -478,7 +478,7 @@ THREE.Object3D.prototype = {
 
 			return result;
 
-		}
+		};
 
 	}(),
 
@@ -494,7 +494,7 @@ THREE.Object3D.prototype = {
 
 			return result.set( 0, 0, 1 ).applyQuaternion( quaternion );
 
-		}
+		};
 
 	}(),
 

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -10,6 +10,8 @@ THREE.DirectionalLight = function ( color, intensity ) {
 	this.type = 'DirectionalLight';
 
 	this.position.set( 0, 1, 0 );
+	this.updateMatrix();
+
 	this.target = new THREE.Object3D();
 
 	this.intensity = ( intensity !== undefined ) ? intensity : 1;

--- a/src/lights/HemisphereLight.js
+++ b/src/lights/HemisphereLight.js
@@ -9,6 +9,7 @@ THREE.HemisphereLight = function ( skyColor, groundColor, intensity ) {
 	this.type = 'HemisphereLight';
 
 	this.position.set( 0, 100, 0 );
+	this.updateMatrix();
 
 	this.groundColor = new THREE.Color( groundColor );
 	this.intensity = ( intensity !== undefined ) ? intensity : 1;

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -9,6 +9,8 @@ THREE.SpotLight = function ( color, intensity, distance, angle, exponent, decay 
 	this.type = 'SpotLight';
 
 	this.position.set( 0, 1, 0 );
+	this.updateMatrix();
+
 	this.target = new THREE.Object3D();
 
 	this.intensity = ( intensity !== undefined ) ? intensity : 1;

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -519,6 +519,13 @@ THREE.ObjectLoader.prototype = {
 
 					break;
 
+
+				case 'AreaLight':
+
+					object = new THREE.AreaLight( data.color, data.intensity );
+
+					break;
+
 				case 'DirectionalLight':
 
 					object = new THREE.DirectionalLight( data.color, data.intensity );

--- a/test/unit/lights/AmbientLight.tests.js
+++ b/test/unit/lights/AmbientLight.tests.js
@@ -1,0 +1,27 @@
+(function () {
+
+	'use strict';
+
+	var lights;
+
+	QUnit.module( "Lights - AmbientLight", {
+
+		beforeEach: function() {
+
+			lights = [
+
+				new THREE.AmbientLight( 0xaaaaaa ),
+
+			];
+
+		}
+
+	});
+
+	QUnit.test( "standard light tests", function( assert ) {
+
+		runStdLightTests( assert, lights );
+
+	});
+
+})();

--- a/test/unit/lights/AreaLight.tests.js
+++ b/test/unit/lights/AreaLight.tests.js
@@ -1,0 +1,28 @@
+(function () {
+
+	'use strict';
+
+	var lights;
+
+	QUnit.module( "Lights - AreaLight", {
+
+		beforeEach: function() {
+
+			lights = [
+
+				new THREE.AreaLight( 0xaaaaaa ),
+				new THREE.AreaLight( 0xaaaaaa, 0.7 ),
+
+			];
+
+		}
+
+	});
+
+	QUnit.test( "standard light tests", function( assert ) {
+
+		runStdLightTests( assert, lights );
+
+	});
+
+})();

--- a/test/unit/lights/DirectionalLight.tests.js
+++ b/test/unit/lights/DirectionalLight.tests.js
@@ -1,0 +1,28 @@
+(function () {
+
+	'use strict';
+
+	var lights;
+
+	QUnit.module( "Lights - DirectionalLight", {
+
+		beforeEach: function() {
+
+			lights = [
+
+				new THREE.DirectionalLight( 0xaaaaaa ),
+				new THREE.DirectionalLight( 0xaaaaaa, 0.8 ),
+
+			];
+
+		}
+
+	});
+
+	QUnit.test( "standard light tests", function( assert ) {
+
+		runStdLightTests( assert, lights );
+
+	});
+
+})();

--- a/test/unit/lights/HemisphereLight.tests.js
+++ b/test/unit/lights/HemisphereLight.tests.js
@@ -1,0 +1,35 @@
+(function () {
+
+	'use strict';
+
+	var parameters = {
+		skyColor: 0x123456,
+		groundColor: 0xabc012,
+		intensity: 0.6
+	};
+
+	var lights;
+
+	QUnit.module( "Lights - HemisphereLight", {
+
+		beforeEach: function() {
+
+			lights = [
+
+				new THREE.HemisphereLight( parameters.skyColor ),
+				new THREE.HemisphereLight( parameters.skyColor, parameters.groundColor ),
+				new THREE.HemisphereLight( parameters.skyColor, parameters.groundColor, parameters.intensity ),
+
+			];
+
+		}
+
+	});
+
+	QUnit.test( "standard light tests", function( assert ) {
+
+		runStdLightTests( assert, lights );
+
+	});
+
+})();

--- a/test/unit/lights/PointLight.tests.js
+++ b/test/unit/lights/PointLight.tests.js
@@ -1,0 +1,27 @@
+(function () {
+
+	'use strict';
+
+	var lights;
+
+	QUnit.module( "Lights - PointLight", {
+
+		beforeEach: function() {
+
+			lights = [
+
+				new THREE.PointLight( 0xaaaaaa ),
+
+			];
+
+		}
+
+	});
+
+	QUnit.test( "standard light tests", function( assert ) {
+
+		runStdLightTests( assert, lights );
+
+	});
+
+})();

--- a/test/unit/lights/SpotLight.tests.js
+++ b/test/unit/lights/SpotLight.tests.js
@@ -1,0 +1,41 @@
+(function () {
+
+	'use strict';
+
+	var parameters = {
+		color: 0xaaaaaa,
+		intensity: 0.5,
+		distance: 100,
+		angle: 0.8,
+		exponent: 8,
+		decay: 2
+	};
+
+	var lights;
+
+	QUnit.module( "Lights - SpotLight", {
+
+		beforeEach: function() {
+
+			lights = [
+
+				new THREE.SpotLight( parameters.color ),
+				new THREE.SpotLight( parameters.color, parameters.intensity ),
+				new THREE.SpotLight( parameters.color, parameters.intensity, parameters.distance ),
+				new THREE.SpotLight( parameters.color, parameters.intensity, parameters.distance, parameters.angle ),
+				new THREE.SpotLight( parameters.color, parameters.intensity, parameters.distance, parameters.angle, parameters.exponent ),
+				new THREE.SpotLight( parameters.color, parameters.intensity, parameters.distance, parameters.angle, parameters.exponent, parameters.decay ),
+
+			];
+
+		}
+
+	});
+
+	QUnit.test( "standard light tests", function( assert ) {
+
+		runStdLightTests( assert, lights );
+
+	});
+
+})();

--- a/test/unit/qunit-utils.js
+++ b/test/unit/qunit-utils.js
@@ -143,3 +143,70 @@ function runStdGeometryTests( assert, geometries ) {
 	});
 
 }
+
+
+
+
+//
+//	LIGHT TEST HELPERS
+//
+
+// Run common light tests.
+function runStdLightTests( assert, lights ) {
+
+	_.each( lights, function( light ) {
+
+		// Clone
+		checkLightClone( light );
+
+		// json round trip
+		checkLightJsonRoundtrip( light );
+
+	});
+
+}
+
+
+function checkLightClone( light ) {
+
+	// Clone
+	var copy = light.clone();
+	QUnit.assert.notEqual( copy.uuid, light.uuid, "clone uuid should differ from original" );
+	QUnit.assert.notEqual( copy.id, light.id, "clone id should differ from original" );
+	QUnit.assert.smartEqual( copy, light, "clone is equal to original" );
+
+
+	// json round trip with clone
+	checkLightJsonRoundtrip( copy );
+
+}
+
+// Compare json file with its source Light.
+function checkLightJsonWriting( light, json ) {
+
+	QUnit.assert.equal( json.metadata.version, "4.4", "check metadata version" );
+	QUnit.assert.equalKey( light, json, 'type' );
+	QUnit.assert.equalKey( light, json, 'uuid' );
+	QUnit.assert.equal( json.id, undefined, "should not persist id" );
+
+}
+
+// Check parsing and reconstruction of json Light
+function checkLightJsonReading( json, light ) {
+
+	var loader = new THREE.ObjectLoader();
+	var outputLight = loader.parse( json );
+
+	QUnit.assert.smartEqual( outputLight, light, 'Reconstruct Light from ObjectLoader' );
+
+}
+
+// Verify light -> json -> light
+function checkLightJsonRoundtrip( light ) {
+
+	var json = light.toJSON();
+	checkLightJsonWriting( light, json.object );
+	checkLightJsonReading( json, light );
+
+}
+

--- a/test/unit/unittests_three.html
+++ b/test/unit/unittests_three.html
@@ -38,6 +38,12 @@
 
   <script src="geometry/EdgesGeometry.js"></script>
   <script src="extras/ImageUtils.test.js"></script>
+  <script src="lights/AmbientLight.tests.js"></script>
+  <script src="lights/AreaLight.tests.js"></script>
+  <script src="lights/DirectionalLight.tests.js"></script>
+  <script src="lights/HemisphereLight.tests.js"></script>
+  <script src="lights/PointLight.tests.js"></script>
+  <script src="lights/SpotLight.tests.js"></script>
 
   <script src="extras/geometries/BoxGeometry.tests.js"></script>
   <script src="extras/geometries/CircleBufferGeometry.tests.js"></script>


### PR DESCRIPTION
#6947 reminded me that I had this patch in my queue.
- `AreaLight`: Add to the `ObjectLoader`.
- `DirectionalLight`, `HemisphereLight`, `SpotLight`: Update `.matrix` in constructor. These lights are not create at origin. The default constructed Matrix4 is the identity matrix and is not correct for the actual position.
- Unit tests
