### PR TITLE
Export parameters

### DIFF
--- a/examples/js/exporters/SceneExporter.js
+++ b/examples/js/exporters/SceneExporter.js
@@ -402,10 +402,10 @@ THREE.SceneExporter.prototype = {
 
 				'\t' + LabelString( getGeometryName( g ) ) + ': {',
 				'	"type"    : "plane",',
-				'	"width"  : '  + g.width  + ',',
-				'	"height"  : ' + g.height + ',',
-				'	"widthSegments"  : ' + g.widthSegments + ',',
-				'	"heightSegments" : ' + g.heightSegments,
+				'	"width"  : '  + g.parameters.width  + ',',
+				'	"height"  : ' + g.parameters.height + ',',
+				'	"widthSegments"  : ' + g.parameters.widthSegments + ',',
+				'	"heightSegments" : ' + g.parameters.heightSegments,
 				'}'
 
 				];


### PR DESCRIPTION
I'm not sure what's the status of `SceneExporter` (supported, legacy, deprecated, RIP?), but this can't hurt. Fixes #4739,  #5067,  #5068 (the `BoxGeometry` parameters are already correctly exported).
