### PR TITLE
use filepath() instead of filepath_from_user()

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/image.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/image.py
@@ -49,4 +49,4 @@ def file_path(image):
 
     """
     logger.debug("image.file_path(%s)", image)
-    return os.path.normpath(image.filepath_from_user())
+    return os.path.normpath(image.filepath())


### PR DESCRIPTION
When using the blender exporter, enabling the texture setting would cause the exporter to crash.

The crash was due to calling a method which doesn't exist: filepath_from_user(). A grep of the repo showed the method is not defined anywhere. Replacing it with the filepath() yields the desired result.

I tried to run the tests, but I wasn't sure how to interpret the results:

```
cd utils/exporters/blender/tests/scripts/
./test_geometry_phong_material.bash
```
