### PR TITLE
Firing events on shader compile or link errors

### DIFF
--- a/examples/webgl_shader_error_handling.html
+++ b/examples/webgl_shader_error_handling.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - shader [Monjori]</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #ffffff;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+				font-weight: bold;
+
+				background-color: #000000;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0px; width: 100%;
+				padding: 5px;
+			}
+
+			a {
+
+				color: #ffffff;
+			}
+
+			#oldie a { color:#da0 }
+		</style>
+	</head>
+	<body>
+
+		<div id="container"></div>
+		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - shader demo. featuring <a href="http://www.pouet.net/prod.php?which=52761" target="_blank">Monjori by Mic</a></div>
+
+		<script src="../build/three.min.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
+		<script src="js/Detector.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script id="vertexShaderCompileError" type="x-shader/x-vertex">
+			varying vec3 temp;
+			void main()	{
+				gl_Position = vec4( position_typo, 1.0 );
+
+			}
+
+		</script>
+
+		<script id="vertexShaderLinkError" type="x-shader/x-vertex">
+		varying vec3 temp;
+			void main()	{
+				temp = vec3(position.xy, 0.0);
+				gl_Position = vec4( position, 1.0 );
+
+			}
+
+		</script>
+
+		<script id="fragmentShaderLinkError" type="x-shader/x-fragment">
+		varying vec2 temp;
+			void main()	{
+				gl_FragColor = vec4( temp, 0.0, 1.0 );
+
+			}
+
+		</script>
+
+		<script id="vertexShader" type="x-shader/x-vertex">
+			attribute float instanceData;
+	    varying vec3 vColour;
+	    uniform mat4 worldTransforms[ NUM_INSTANCES_PER_RENDER ];
+	    uniform vec3 instanceColours[ NUM_INSTANCES_PER_RENDER ];
+	    
+	    void main() {
+	    	
+	      vec4 worldPosition = worldTransforms[ int(instanceData) ] * vec4( position, 1.0 );
+	      gl_Position = projectionMatrix * viewMatrix * worldPosition;
+
+	      vColour = instanceColours[ int(instanceData) ];
+	    }
+    </script>
+
+		<script id="fragmentShader" type="x-shader/x-fragment">
+
+			varying vec3 vColour;
+			void main()	{
+
+				gl_FragColor = vec4( vColour, 1.0 );
+
+			}
+
+		</script>
+
+		<script>
+
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var container, stats;
+
+			var camera, scene, renderer;
+
+			var instanceUniforms = [];
+			var instanceMaterials = [];
+			var instanceMeshes = [];
+			var instanceObjects = [];
+			var instanceRotations = [];
+			var INSTANCE_SPREAD = 15;
+			var NUM_INSTANCES = 2000;
+			var NUM_INSTANCES_PER_RENDER = NUM_INSTANCES;
+
+			var vertexShaders = [];
+			var fragmentShaders = [];
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.getElementById( 'container' );
+
+				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 100 );
+				camera.position.z = 12;
+				controls = new THREE.OrbitControls( camera );
+				controls.target.set( 0, 0, 0 );
+				controls.update();
+
+				scene = new THREE.Scene();
+				window.scene = scene;
+
+				var geometry = new THREE.SphereBufferGeometry( 0.25, 16, 16 );
+
+				uniformsTemplate = {
+					worldTransforms: { type: "m4v", value: [] },
+					instanceColours: { type: "v3v", value: [] }
+				};
+
+				var material = new THREE.ShaderMaterial( {
+
+					vertexShader: document.getElementById( 'vertexShaderCompileError' ).textContent,
+					fragmentShader: document.getElementById( 'fragmentShader' ).textContent
+
+				} );
+
+				material.addEventListener('shaderCompileError', function(err) {
+					console.log('Shader failed to compile');
+					material.vertexShader = document.getElementById( 'vertexShaderLinkError' ).textContent;
+					material.fragmentShader = document.getElementById( 'fragmentShaderLinkError' ).textContent;
+					material.needsUpdate = true;
+				});
+
+				var linkFailed = true;
+				material.addEventListener('programLinkError', function(err) {
+					console.log('Program failed to link');
+					targetMesh.material = new THREE.MeshBasicMaterial( { color: 0x226666 } );
+				});
+
+				var targetMesh = new THREE.Mesh( geometry, material );
+				scene.add( targetMesh );
+
+				boxGeometry = new THREE.BoxGeometry(0.25, 0.25, 0.25);
+				boxBufferGeometry = new THREE.BufferGeometry().fromGeometry( boxGeometry );
+				
+				initializeInstanceObjects();
+				initializeInstanceData();
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.setPixelRatio( window.devicePixelRatio );
+				container.appendChild( renderer.domElement );
+
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '0px';
+				container.appendChild( stats.domElement );
+
+				onWindowResize();
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function cleanupInstanceData() {
+				for ( var i = 0; i < instanceMeshes.length; i++ ) {
+					scene.remove( instanceMeshes[i] );
+				}
+				instanceUniforms = [];
+				instanceMaterials = [];
+				instanceMeshes = [];
+			}
+
+			function initializeInstanceObjects() {
+				var object, rotation;
+				for ( var i = 0; i < NUM_INSTANCES; i++ ) {
+					object = new THREE.Object3D();
+					object.position.x = (Math.random() - 0.5 ) * INSTANCE_SPREAD;
+					object.position.y = (Math.random() - 0.5 ) * INSTANCE_SPREAD;
+					object.position.z = (Math.random() - 0.5 ) * INSTANCE_SPREAD;
+
+					object.color = new THREE.Vector3();
+					object.color.x = Math.random();
+					object.color.y = Math.random();
+					object.color.z = Math.random();
+					instanceObjects.push( object );
+					scene.add( object );
+
+					rotation = new THREE.Vector3( Math.random(), Math.random(), Math.random() );
+					instanceRotations.push( rotation );
+				}
+			}
+
+			function initializeInstanceData() {
+				cleanupInstanceData();
+
+				var numMeshes = Math.floor( NUM_INSTANCES / NUM_INSTANCES_PER_RENDER );
+				var remainder = NUM_INSTANCES - numMeshes * NUM_INSTANCES_PER_RENDER;
+				if ( remainder ) {
+					numMeshes++;
+				}
+
+				for ( var m = 0; m < numMeshes; m++ ) {
+					uniforms = THREE.UniformsUtils.clone( uniformsTemplate );
+					for ( var i = 0; i < NUM_INSTANCES_PER_RENDER; i++ ) {
+						uniforms.worldTransforms.value[ i ] = instanceObjects[ m * NUM_INSTANCES_PER_RENDER + i ].matrixWorld;
+						uniforms.instanceColours.value[ i ] = instanceObjects[ m * NUM_INSTANCES_PER_RENDER + i ].color;
+					}
+					instanceUniforms.push( uniforms );
+					instanceMaterials.push( initInstanceMaterial( m ) );
+					instanceMeshes.push( initInstanceMesh( m ) );
+					instanceMeshes[ m ].name = 'Instance Mesh #' + m;
+
+					scene.add( instanceMeshes[ m ] );
+				}
+
+				instanceMaterials[0].addEventListener( 'shaderCompileError', onInstanceCompileError );
+			}
+
+			function initInstanceMaterial( instanceId ) {
+				var params = {};
+				params.vertexShader = document.getElementById( 'vertexShader' ).textContent;
+				params.fragmentShader = document.getElementById( 'fragmentShader' ).textContent;
+				params.uniforms = instanceUniforms[ instanceId ];
+				params.attributes = {
+			    "instanceData" : { type: "f", value: null }
+			  };
+				params.defines = { 'NUM_INSTANCES_PER_RENDER' : NUM_INSTANCES_PER_RENDER };
+				return new THREE.ShaderMaterial( params );
+			}
+
+			function initInstanceMesh( instanceId ) {
+				
+				var instancesGeometry = new THREE.BufferGeometry();
+				var positions = boxBufferGeometry.getAttribute( 'position' );
+				var normals = boxBufferGeometry.getAttribute( 'normal' );
+				var numVertices = positions.array.length / positions.itemSize;
+				var instancePositions = new THREE.BufferAttribute( new Float32Array( NUM_INSTANCES_PER_RENDER * positions.array.length  ), 3 );
+				// var instanceNormals = new THREE.BufferAttribute( new Float32Array( NUM_INSTANCES_PER_RENDER * positions.array.length  ), 3 );
+				var instanceData = new THREE.BufferAttribute( new Float32Array( NUM_INSTANCES_PER_RENDER * numVertices ), 1 );
+				
+				for ( var inst = 0; inst < NUM_INSTANCES_PER_RENDER; inst++ ) {
+					for ( var vert = 0; vert < numVertices; vert++ ) {
+						var boxIndex = vert * 3;
+						var instIndex = inst * positions.array.length + vert * 3;
+						instancePositions.array[instIndex] = positions.array[boxIndex];
+						instancePositions.array[instIndex + 1] = positions.array[boxIndex + 1];
+						instancePositions.array[instIndex + 2] = positions.array[boxIndex + 2];
+
+						// instanceNormals.array[instIndex] = normals.array[boxIndex];
+						// instanceNormals.array[instIndex + 1] = normals.array[boxIndex + 1];
+						// instanceNormals.array[instIndex + 2] = normals.array[boxIndex + 2];
+
+						instanceData.array[inst * numVertices + vert] = inst;
+					}
+				}
+
+				instancesGeometry.addAttribute( 'position', instancePositions );
+				// instancesGeometry.addAttribute( 'normal', instanceNormals );
+				instancesGeometry.addAttribute( 'instanceData', instanceData );
+
+
+				return new THREE.Mesh( instancesGeometry, instanceMaterials[ instanceId ] );
+			}
+
+			function onInstanceCompileError( event ) {
+				NUM_INSTANCES_PER_RENDER = Math.round( NUM_INSTANCES_PER_RENDER / 2 );
+				initializeInstanceData();
+			}
+
+			function updateInstanceData( delta ) {
+				for ( var i = 0; i < instanceObjects.length; i++ ) {
+					instanceObjects[i].rotation.x += delta * instanceRotations[i].x;
+					instanceObjects[i].rotation.y += delta * instanceRotations[i].y;
+					instanceObjects[i].rotation.z += delta * instanceRotations[i].z;
+				}
+			}
+
+			function onWindowResize( event ) {
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+			}
+
+			//
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+				updateInstanceData( 0.017 );
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
+				
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/examples/webgl_shader_error_handling.html
+++ b/examples/webgl_shader_error_handling.html
@@ -109,7 +109,7 @@
 			var instanceObjects = [];
 			var instanceRotations = [];
 			var INSTANCE_SPREAD = 15;
-			var NUM_INSTANCES = 2000;
+			var NUM_INSTANCES = 2048;
 			var NUM_INSTANCES_PER_RENDER = NUM_INSTANCES;
 
 			var vertexShaders = [];

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -891,7 +891,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		var geometry = objects.geometries.get( object );
 		var program = setProgram( camera, lights, fog, material, object );
-
+		
+		if ( !( program instanceof THREE.WebGLProgram ) ) {
+			return;
+		}
+		
 		var updateBuffers = false,
 			wireframeBit = material.wireframe ? 1 : 0,
 			geometryProgram = geometry.id + '_' + program.id + '_' + wireframeBit;
@@ -2035,7 +2039,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			var programInfo = _programs[ p ];
 
-			if ( programInfo.code === code ) {
+			if ( programInfo && programInfo.code === code ) {
 
 				program = programInfo;
 
@@ -2054,11 +2058,20 @@ THREE.WebGLRenderer = function ( parameters ) {
 		if ( program === undefined ) {
 
 			material.__webglShader = materialProperties.__webglShader;
-			program = new THREE.WebGLProgram( _this, code, material, parameters );
+			try {
+				program = new THREE.WebGLProgram( _this, code, material, parameters );
+			}
+			catch ( err ) {
+				material.dispatchEvent( { type: err.message }, err );
+				program = {'error' : err, 'code': code };
+			}
 			_programs.push( program );
 
 			_infoMemory.programs = _programs.length;
-
+		}
+		
+		if ( !( program instanceof THREE.WebGLProgram ) ) {
+			return;
 		}
 
 		materialProperties.program = program;
@@ -2153,7 +2166,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			initMaterial( material, lights, fog, object );
 			material.needsUpdate = false;
+			
+		}
 
+		if ( !( materialProperties.program instanceof THREE.WebGLProgram ) ) {
+			return;
 		}
 
 		var refreshProgram = false;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -378,6 +378,8 @@ THREE.WebGLProgram = ( function () {
 
 			console.error( 'THREE.WebGLProgram: shader error: ', gl.getError(), 'gl.VALIDATE_STATUS', gl.getProgramParameter( program, gl.VALIDATE_STATUS ), 'gl.getProgramInfoLog', programLog, vertexLog, fragmentLog );
 
+			throw new Error( 'programLinkError' );
+
 		} else if ( programLog !== '' ) {
 
 			console.warn( 'THREE.WebGLProgram: gl.getProgramInfoLog()', programLog );

--- a/src/renderers/webgl/WebGLShader.js
+++ b/src/renderers/webgl/WebGLShader.js
@@ -17,6 +17,7 @@ THREE.WebGLShader = ( function () {
 	return function WebGLShader( gl, type, string ) {
 
 		var shader = gl.createShader( type );
+		var throwCompileError = false;
 
 		gl.shaderSource( shader, string );
 		gl.compileShader( shader );
@@ -24,13 +25,17 @@ THREE.WebGLShader = ( function () {
 		if ( gl.getShaderParameter( shader, gl.COMPILE_STATUS ) === false ) {
 
 			console.error( 'THREE.WebGLShader: Shader couldn\'t compile.' );
-
+			throwCompileError = true;
 		}
 
 		if ( gl.getShaderInfoLog( shader ) !== '' ) {
 
 			console.warn( 'THREE.WebGLShader: gl.getShaderInfoLog()', type === gl.VERTEX_SHADER ? 'vertex' : 'fragment', gl.getShaderInfoLog( shader ), addLineNumbers( string ) );
 
+		}
+
+		if ( throwCompileError ) {
+			throw new Error( 'shaderCompileError' );
 		}
 
 		// --enable-privileged-webgl-extension


### PR DESCRIPTION
Here's a quick change where a `THREE.Material` will dispatch a 'shaderCompileError' or a 'programLinkError' event when it fails to compile or link respectively.

This is useful if, for example, a shader fails to compile on the target hardware due to limited capabilities (e.g. varying or uniforms counts) and you want to automatically scale back the shader at run time.

This is also potentially useful if the user is editing shaders in your application and you want to handle errors cleanly. Though, I'm not currently passing any detailed information through the event.

Any suggestions or feedback on this?

I included a very contrived example where a compile error is captured, the shaders are substituted, a link error is then captured and a MeshBasicMaterial is substituted. Also, a material with many uniforms repeatedly fails to compile and the code keeps scaling the number down until it runs on your machine.
