### PR TITLE
Add normal and center options to THREE.PlaneBufferGeometry

### DIFF
--- a/src/extras/geometries/PlaneBufferGeometry.js
+++ b/src/extras/geometries/PlaneBufferGeometry.js
@@ -18,22 +18,33 @@ THREE.PlaneBufferGeometry = function ( width, height, widthSegments, heightSegme
 		cetner: center
 	};
 	
-	if( normal === undefined ) {
+	if ( normal === undefined ) {
+		
 		normal = new THREE.Vector3( 0, 0, 1 );
+		
 	} else {
+		
 		normal = normal.normalize( );
+		
 	}
 	
-	if( center === undefined ) {
+	if ( center === undefined ) {
+		
 		center = new THREE.Vector3( 0, 0, 0 );
+		
 	}
 	
 	// create an arbitrary (but nonparalell) vector to cross with the normal to get a vector in the desired plane.
 	var nonParallel;
-	if( normal.x === 0 && normal.z === 0 ) {
+	
+	if ( normal.x === 0 && normal.z === 0 ) {
+		
 		nonParallel = new THREE.Vector3( 0, 0, 1 );
+		
 	} else {
+		
 		nonParallel = new THREE.Vector3( 0, 1, 0 );
+		
 	}
 	
 	// note that the primaryVector will be ( 1, 0, 0 ) if the normal is not passed, resulting in the 

--- a/src/extras/geometries/PlaneBufferGeometry.js
+++ b/src/extras/geometries/PlaneBufferGeometry.js
@@ -3,7 +3,7 @@
  * based on http://papervision3d.googlecode.com/svn/trunk/as3/trunk/src/org/papervision3d/objects/primitives/Plane.as
  */
 
-THREE.PlaneBufferGeometry = function ( width, height, widthSegments, heightSegments ) {
+THREE.PlaneBufferGeometry = function ( width, height, widthSegments, heightSegments, normal, center ) {
 
 	THREE.BufferGeometry.call( this );
 
@@ -13,8 +13,40 @@ THREE.PlaneBufferGeometry = function ( width, height, widthSegments, heightSegme
 		width: width,
 		height: height,
 		widthSegments: widthSegments,
-		heightSegments: heightSegments
+		heightSegments: heightSegments,
+		normal: normal,
+		cetner: center
 	};
+	
+	if( normal === undefined ) {
+		normal = new THREE.Vector3( 0, 0, 1 );
+	} else {
+		normal = normal.normalize( );
+	}
+	
+	if( center === undefined ) {
+		center = new THREE.Vector3( 0, 0, 0 );
+	}
+	
+	// create an arbitrary (but nonparalell) vector to cross with the normal to get a vector in the desired plane.
+	var nonParallel;
+	if( normal.x === 0 && normal.z === 0 ) {
+		nonParallel = new THREE.Vector3( 0, 0, 1 );
+	} else {
+		nonParallel = new THREE.Vector3( 0, 1, 0 );
+	}
+	
+	// note that the primaryVector will be ( 1, 0, 0 ) if the normal is not passed, resulting in the 
+	// same behaviour as before the option to change the normal was added.
+	var primaryVector = nonParallel.cross( normal ).normalize( );
+	
+	// as above, this will be ( 0, -1, 0 ) if the normal is not passed, resulting in the previous behaviour.
+	// primary and normal are perpendicular unit vectors, so this is already normalized.
+	var secondaryVector = primaryVector.clone( ).cross( normal );
+	
+	// scratch vectors for calculating vertex position
+	var primaryScratch = new THREE.Vector3( );
+	var secondaryScratch = new THREE.Vector3( );
 
 	var width_half = width / 2;
 	var height_half = height / 2;
@@ -42,11 +74,18 @@ THREE.PlaneBufferGeometry = function ( width, height, widthSegments, heightSegme
 		for ( var ix = 0; ix < gridX1; ix ++ ) {
 
 			var x = ix * segment_width - width_half;
+			
+			primaryScratch.copy( primaryVector ).multiplyScalar( x );
+			secondaryScratch.copy( secondaryVector ).multiplyScalar( y );
+			primaryScratch.add( secondaryScratch ).add( center );
 
-			vertices[ offset ] = x;
-			vertices[ offset + 1 ] = - y;
+			vertices[ offset     ] = primaryScratch.x;
+			vertices[ offset + 1 ] = primaryScratch.y;
+			vertices[ offset + 2 ] = primaryScratch.z;
 
-			normals[ offset + 2 ] = 1;
+			normals[ offset     ] = normal.x;
+			normals[ offset + 1 ] = normal.y;
+			normals[ offset + 2 ] = normal.z;
 
 			uvs[ offset2 ] = ix / gridX;
 			uvs[ offset2 + 1 ] = 1 - ( iy / gridY );
@@ -101,7 +140,9 @@ THREE.PlaneBufferGeometry.prototype.clone = function () {
 		this.parameters.width,
 		this.parameters.height,
 		this.parameters.widthSegments,
-		this.parameters.heightSegments
+		this.parameters.heightSegments,
+		this.parameters.normal.clone(),
+		this.parameters.center.clone()
 	);
 
 	geometry.copy( this );

--- a/src/extras/geometries/PlaneGeometry.js
+++ b/src/extras/geometries/PlaneGeometry.js
@@ -3,7 +3,7 @@
  * based on http://papervision3d.googlecode.com/svn/trunk/as3/trunk/src/org/papervision3d/objects/primitives/Plane.as
  */
 
-THREE.PlaneGeometry = function ( width, height, widthSegments, heightSegments ) {
+THREE.PlaneGeometry = function ( width, height, widthSegments, heightSegments, normal, center ) {
 
 	THREE.Geometry.call( this );
 
@@ -14,9 +14,11 @@ THREE.PlaneGeometry = function ( width, height, widthSegments, heightSegments ) 
 		height: height,
 		widthSegments: widthSegments,
 		heightSegments: heightSegments
+		normal: normal,
+		center: center
 	};
 
-	this.fromBufferGeometry( new THREE.PlaneBufferGeometry( width, height, widthSegments, heightSegments ) );
+	this.fromBufferGeometry( new THREE.PlaneBufferGeometry( width, height, widthSegments, heightSegments, normal, center ) );
 
 };
 
@@ -29,7 +31,9 @@ THREE.PlaneGeometry.prototype.clone = function () {
 		this.parameters.width,
 		this.parameters.height,
 		this.parameters.widthSegments,
-		this.parameters.heightSegments
+		this.parameters.heightSegments,
+		this.parameters.normal.clone(),
+		this.parameters.center.clone()
 	);
 
 	return geometry;


### PR DESCRIPTION
With this change, THREE.PlaneBufferGeometry can be used to create any plane, rather than just one centered on the origin pointing towards the positive z axis.  This should not effect existing code that uses THREE.PlaneBufferGeometry, as the extra options are added to the end of the list of arguments to the constructor, and if they are not passed then default values will be used that give the same result as the old code.  
