### PR TITLE
io_three min blender version

### DIFF
--- a/utils/exporters/blender/README.md
+++ b/utils/exporters/blender/README.md
@@ -8,6 +8,9 @@ The exporter (r69 and earlier) has been completely replaced. Please ensure you h
 
 ## Installation
 
+
+Recommended Blender version **>= 2.73.0**
+
 Copy the io_three folder to the scripts/addons folder. If it doesn't exist, create it. The full path is OS-dependent (see below).
 
 Once that is done, you need to activate the plugin. Open Blender preferences, look for
@@ -52,8 +55,10 @@ Activate the Import-Export addon under "User Preferences" > "Addons" and then us
 
 
 ## Enabling msgpack
+
 To enable msgpack compression copy the msgpack to scripts/modules.
 
 
 ## Importer
+
 Currently there is no import functionality available.

--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -40,7 +40,7 @@ bl_info = {
     'name': "Three.js Format",
     'author': "repsac, mrdoob, yomotsu, mpk, jpweeks, rkusa, tschw",
     'version': (1, 4, 0),
-    'blender': (2, 7, 3),
+    'blender': (2, 73, 0),
     'location': "File > Export",
     'description': "Export Three.js formatted JSON files.",
     'warning': "Importer not included.",


### PR DESCRIPTION
related to #6962 

Min version of blender was 2.7.3 instead of 2.73.0

http://wiki.blender.org/index.php/Dev:2.5/Py/Scripts/Guidelines/Addons

With this change we get a warning so a note in README.md might not be needed anymore. @antont what do you think?

NOTE: the screenshot was done with 2.70, but 2.73 is in the patch because I looked in git blame and the previous commit specifically incremented from 2.7.2 to 2.7.3
![min version warning](http://i.imgur.com/K5BP5mF.png)
