### PR TITLE
fix for vertices that are integer numbers

### DIFF
--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -31,43 +31,67 @@ THREE.VTKLoader.prototype = {
 		var indices = [];
 		var positions = [];
 
-		var pattern, result;
+		var result;
 
 		// float float float
 
-		pattern = /([\+|\-]?[\d]+[\.][\d|\-|e]+)[ ]+([\+|\-]?[\d]+[\.][\d|\-|e]+)[ ]+([\+|\-]?[\d]+[\.][\d|\-|e]+)/g;
+		var pat3Floats = /([\-]?[\d]+[\.]?[\d|\-|e]*)[ ]+([\-]?[\d]+[\.]?[\d|\-|e]*)[ ]+([\-]?[\d]+[\.]?[\d|\-|e]*)/g;
+		var patTriangle = /^3[ ]+([\d]+)[ ]+([\d]+)[ ]+([\d]+)/;
+		var patQuad = /^4[ ]+([\d]+)[ ]+([\d]+)[ ]+([\d]+)[ ]+([\d]+)/;
+		var patPOINTS = /^POINTS /;
+		var patPOLYGONS = /^POLYGONS /;
+		var inPointsSection = false;
+		var inPolygonsSection = false;
 
-		while ( ( result = pattern.exec( data ) ) !== null ) {
+		var lines = data.split('\n');
+		for ( var i = 0; i < lines.length; ++i ) {
 
-			// ["1.0 2.0 3.0", "1.0", "2.0", "3.0"]
+			line = lines[i];
 
-			positions.push( parseFloat( result[ 1 ] ), parseFloat( result[ 2 ] ), parseFloat( result[ 3 ] ) );
+			if ( inPointsSection ) {
 
-		}
+				// get the vertices
 
-		// 3 int int int
+				while ( ( result = pat3Floats.exec( line ) ) !== null ) {
+					positions.push( parseFloat( result[ 1 ] ), parseFloat( result[ 2 ] ), parseFloat( result[ 3 ] ) );
+				}
+			}
+			else if ( inPolygonsSection ) {
 
-		pattern = /3[ ]+([\d]+)[ ]+([\d]+)[ ]+([\d]+)/g;
+				result = patTriangle.exec(line);
 
-		while ( ( result = pattern.exec( data ) ) !== null ) {
+				if ( result !== null ) {
 
-			// ["3 1 2 3", "1", "2", "3"]
+					// 3 int int int
+					// triangle
 
-			indices.push( parseInt( result[ 1 ] ), parseInt( result[ 2 ] ), parseInt( result[ 3 ] ) );
+					indices.push( parseInt( result[ 1 ] ), parseInt( result[ 2 ] ), parseInt( result[ 3 ] ) );
+				}
+				else {
 
-		}
+					result = patQuad.exec(line);
 
-		// 4 int int int int
+					if ( result !== null ) {
 
-		pattern = /4[ ]+([\d]+)[ ]+([\d]+)[ ]+([\d]+)[ ]+([\d]+)/g;
+						// 4 int int int int
+						// break quad into two triangles
 
-		while ( ( result = pattern.exec( data ) ) !== null ) {
+						indices.push( parseInt( result[ 1 ] ), parseInt( result[ 2 ] ), parseInt( result[ 4 ] ) );
+						indices.push( parseInt( result[ 2 ] ), parseInt( result[ 3 ] ), parseInt( result[ 4 ] ) );
+					}
 
-			// ["4 1 2 3 4", "1", "2", "3", "4"]
+				}
 
-			indices.push( parseInt( result[ 1 ] ), parseInt( result[ 2 ] ), parseInt( result[ 4 ] ) );
-			indices.push( parseInt( result[ 2 ] ), parseInt( result[ 3 ] ), parseInt( result[ 4 ] ) );
+			}
 
+			if ( patPOLYGONS.exec(line) !== null ) {
+				inPointsSection = false;
+				inPolygonsSection = true;
+			}
+			if ( patPOINTS.exec(line) !== null ) {
+				inPolygonsSection = false;
+				inPointsSection = true;
+			}
 		}
 
 		var geometry = new THREE.BufferGeometry();


### PR DESCRIPTION
Hi,

VTKLoader.js was broken for cases where the vertices are integer numbers. An example of such file is shown below. The first set of x, y, z values is 0, 1, and 0. The file below was produced by the vtkPolyDataWriter class, part of the VTK library, so it is a valid VTK file. I checked that the bunny.vtk file could still be read with these changes. Thanks for updating. 

--Alex
# vtk DataFile Version 3.0

vtk output
ASCII
DATASET POLYDATA
POINTS 9 float
0 1 0 -0.707107 0.707107 8.65956e-17 0.707107 0.707107 0 
-1 6.12323e-17 1.22465e-16 1 6.12323e-17 0 -0.707107 -0.707107 8.65956e-17 
0.707107 -0.707107 0 1.22465e-16 -1 0 -1.22465e-16 -1 1.49976e-32 

POLYGONS 8 36
3 0 1 2 
4 2 1 3 4 
4 4 3 5 6 
3 6 5 7 
3 0 2 1 
4 1 2 4 3 
4 3 4 6 5 
3 5 6 8 
