### PR TITLE
Cloning cleanup

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -52,8 +52,7 @@ THREE.Camera.prototype.lookAt = function () {
 
 THREE.Camera.prototype.clone = function () {
 
-	var camera = new this.constructor();
-	return camera.copy( this );
+	return new this.constructor().copy( this );
 
 };
 

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -52,7 +52,7 @@ THREE.Camera.prototype.lookAt = function () {
 
 THREE.Camera.prototype.clone = function () {
 
-	var camera = new THREE.Camera();
+	var camera = new this.constructor();
 	return camera.copy( this );
 
 };

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -38,22 +38,19 @@ THREE.OrthographicCamera.prototype.updateProjectionMatrix = function () {
 
 THREE.OrthographicCamera.prototype.clone = function () {
 
-	var camera = new THREE.OrthographicCamera();
+	var camera = new this.constructor( this.left, this.right, this.top, this.bottom, this.near, this.far );
+	return camera.copy( this );
 
-	camera.copy( this );
+};
 
-	camera.zoom = this.zoom;
-
-	camera.left = this.left;
-	camera.right = this.right;
-	camera.top = this.top;
-	camera.bottom = this.bottom;
-
-	camera.near = this.near;
-	camera.far = this.far;
-
-	return camera;
-
+THREE.OrthographicCamera.prototype.copy = function ( source ) {
+	
+	THREE.Camera.prototype.copy.call( this, source );
+	
+	this.zoom = source.zoom;
+	
+	return this;
+		
 };
 
 THREE.OrthographicCamera.prototype.toJSON = function ( meta ) {

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -36,16 +36,16 @@ THREE.OrthographicCamera.prototype.updateProjectionMatrix = function () {
 
 };
 
-THREE.OrthographicCamera.prototype.clone = function () {
-
-	var camera = new this.constructor( this.left, this.right, this.top, this.bottom, this.near, this.far );
-	return camera.copy( this );
-
-};
-
 THREE.OrthographicCamera.prototype.copy = function ( source ) {
 	
 	THREE.Camera.prototype.copy.call( this, source );
+	
+	this.left = source.left;
+	this.right = source.right;
+	this.top = source.top;
+	this.bottom = source.bottom;
+	this.near = source.near;
+	this.far = source.far;
 	
 	this.zoom = source.zoom;
 	

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -122,16 +122,14 @@ THREE.PerspectiveCamera.prototype.updateProjectionMatrix = function () {
 
 };
 
-THREE.PerspectiveCamera.prototype.clone = function () {
-
-	var camera = new this.constructor( this.fov, this.aspect, this.near, this.far );
-	return camera.copy( this );
-
-};
-
 THREE.PerspectiveCamera.prototype.copy = function ( source ) {
 	
 	THREE.Camera.prototype.copy.call( this, source );
+	
+	this.fov = source.fov;
+	this.aspect = source.aspect;
+	this.near = source.near;
+	this.far = source.far;
 	
 	this.zoom = source.zoom;
 	

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -124,19 +124,19 @@ THREE.PerspectiveCamera.prototype.updateProjectionMatrix = function () {
 
 THREE.PerspectiveCamera.prototype.clone = function () {
 
-	var camera = new THREE.PerspectiveCamera();
+	var camera = new this.constructor( this.fov, this.aspect, this.near, this.far );
+	return camera.copy( this );
 
-	camera.copy( this );
+};
 
-	camera.zoom = this.zoom;
-
-	camera.fov = this.fov;
-	camera.aspect = this.aspect;
-	camera.near = this.near;
-	camera.far = this.far;
-
-	return camera;
-
+THREE.PerspectiveCamera.prototype.copy = function ( source ) {
+	
+	THREE.Camera.prototype.copy.call( this, source );
+	
+	this.zoom = source.zoom;
+	
+	return this;
+		
 };
 
 THREE.PerspectiveCamera.prototype.toJSON = function ( meta ) {

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -281,7 +281,7 @@ THREE.BufferAttribute.prototype = {
 
 	clone: function () {
 
-		return new THREE.BufferAttribute( new this.array.constructor( this.array ), this.itemSize );
+		return new this.constructor( new this.array.constructor( this.array ), this.itemSize );
 
 	}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1241,8 +1241,7 @@ THREE.BufferGeometry.prototype = {
 
 	clone: function () {
 
-		var bufferGeometry = new this.constructor();
-		return bufferGeometry.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1241,7 +1241,8 @@ THREE.BufferGeometry.prototype = {
 
 	clone: function () {
 
-		return new THREE.BufferGeometry().copy( this );
+		var bufferGeometry = new this.constructor();
+		return bufferGeometry.copy( this );
 
 	},
 

--- a/src/core/DynamicBufferAttribute.js
+++ b/src/core/DynamicBufferAttribute.js
@@ -13,9 +13,3 @@ THREE.DynamicBufferAttribute = function ( array, itemSize ) {
 
 THREE.DynamicBufferAttribute.prototype = Object.create( THREE.BufferAttribute.prototype );
 THREE.DynamicBufferAttribute.prototype.constructor = THREE.DynamicBufferAttribute;
-
-THREE.DynamicBufferAttribute.prototype.clone = function () {
-
-	return new THREE.DynamicBufferAttribute( new this.array.constructor( this.array ), this.itemSize );
-
-};

--- a/src/core/Face3.js
+++ b/src/core/Face3.js
@@ -25,6 +25,13 @@ THREE.Face3.prototype = {
 
 	constructor: THREE.Face3,
 
+	clone: function () {
+
+		var face = new this.constructor();
+		return face.copy( this );
+
+	},
+
 	copy: function ( source ) {
 
 		this.a = source.a;
@@ -55,12 +62,6 @@ THREE.Face3.prototype = {
 		}
 
 		return this;
-
-	},
-
-	clone: function () {
-
-		return new THREE.Face3().copy( this );
 
 	}
 

--- a/src/core/Face3.js
+++ b/src/core/Face3.js
@@ -27,8 +27,7 @@ THREE.Face3.prototype = {
 
 	clone: function () {
 
-		var face = new this.constructor();
-		return face.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -1174,7 +1174,8 @@ THREE.Geometry.prototype = {
 
 	clone: function () {
 
-		return new THREE.Geometry().copy( this );
+		var geometry = new this.constructor();
+		return geometry.copy( this );
 
 	},
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -1174,8 +1174,7 @@ THREE.Geometry.prototype = {
 
 	clone: function () {
 
-		var geometry = new this.constructor();
-		return geometry.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/core/InstancedBufferGeometry.js
+++ b/src/core/InstancedBufferGeometry.js
@@ -32,14 +32,14 @@ THREE.InstancedBufferGeometry.prototype.copy = function ( source ) {
 	for ( var attr in source.attributes ) {
 
 		var sourceAttr = source.attributes[ attr ];
-		geometry.addAttribute( attr, sourceAttr.clone() );
+		this.addAttribute( attr, sourceAttr.clone() );
 
 	}
 
 	for ( var i = 0, il = source.drawcalls.length; i < il; i ++ ) {
 
 		var offset = source.drawcalls[ i ];
-		geometry.addDrawCall( offset.start, offset.count, offset.index, offset.instances );
+		this.addDrawCall( offset.start, offset.count, offset.index, offset.instances );
 
 	}
 	

--- a/src/core/InstancedBufferGeometry.js
+++ b/src/core/InstancedBufferGeometry.js
@@ -25,28 +25,26 @@ THREE.InstancedBufferGeometry.prototype.addDrawCall = function ( start, count, i
 
 	} );
 
-},
+};
 
-THREE.InstancedBufferGeometry.prototype.clone = function () {
+THREE.InstancedBufferGeometry.prototype.copy = function ( source ) {
+	
+	for ( var attr in source.attributes ) {
 
-	var geometry = new THREE.InstancedBufferGeometry();
-
-	for ( var attr in this.attributes ) {
-
-		var sourceAttr = this.attributes[ attr ];
+		var sourceAttr = source.attributes[ attr ];
 		geometry.addAttribute( attr, sourceAttr.clone() );
 
 	}
 
-	for ( var i = 0, il = this.drawcalls.length; i < il; i ++ ) {
+	for ( var i = 0, il = source.drawcalls.length; i < il; i ++ ) {
 
-		var offset = this.drawcalls[ i ];
+		var offset = source.drawcalls[ i ];
 		geometry.addDrawCall( offset.start, offset.count, offset.index, offset.instances );
 
 	}
-
-	return geometry;
-
+	
+	return this;
+	
 };
 
 THREE.EventDispatcher.prototype.apply( THREE.InstancedBufferGeometry.prototype );

--- a/src/core/InstancedInterleavedBuffer.js
+++ b/src/core/InstancedInterleavedBuffer.js
@@ -15,6 +15,6 @@ THREE.InstancedInterleavedBuffer.prototype.constructor = THREE.InstancedInterlea
 
 THREE.InstancedInterleavedBuffer.prototype.clone = function () {
 
-	return new THREE.InstancedInterleavedBuffer( new this.array.constructor( this.array ), this.stride, this.dynamic, this.meshPerAttribute );
+	return new this.constructor( new this.array.constructor( this.array ), this.stride, this.dynamic, this.meshPerAttribute );
 
 };

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -65,7 +65,7 @@ THREE.InterleavedBuffer.prototype = {
 
 	clone: function () {
 
-		return new THREE.InterleavedBuffer( new this.array.constructor( this.array ), this.stride, this.dynamic );
+		return new this.constructor( new this.array.constructor( this.array ), this.stride, this.dynamic );
 
 	}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -675,8 +675,7 @@ THREE.Object3D.prototype = {
 
 	clone: function ( recursive ) {
 
-		var object = new this.constructor();
-		return object.copy( this, recursive );
+		return new this.constructor().copy( this, recursive );
 
 	},
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -675,7 +675,8 @@ THREE.Object3D.prototype = {
 
 	clone: function ( recursive ) {
 
-		return new THREE.Object3D().copy( this, recursive );
+		var object = new this.constructor();
+		return object.copy( this, recursive );
 
 	},
 

--- a/src/lights/AmbientLight.js
+++ b/src/lights/AmbientLight.js
@@ -13,16 +13,6 @@ THREE.AmbientLight = function ( color ) {
 THREE.AmbientLight.prototype = Object.create( THREE.Light.prototype );
 THREE.AmbientLight.prototype.constructor = THREE.AmbientLight;
 
-THREE.AmbientLight.prototype.clone = function () {
-
-	var light = new THREE.AmbientLight();
-
-	light.copy( this );
-
-	return light;
-
-};
-
 THREE.AmbientLight.prototype.toJSON = function ( meta ) {
 
 	var data = THREE.Object3D.prototype.toJSON.call( this, meta );

--- a/src/lights/AreaLight.js
+++ b/src/lights/AreaLight.js
@@ -27,22 +27,26 @@ THREE.AreaLight = function ( color, intensity ) {
 THREE.AreaLight.prototype = Object.create( THREE.Light.prototype );
 THREE.AreaLight.prototype.constructor = THREE.AreaLight;
 
-THREE.AreaLight.prototype.clone = function () {
+THREE.PointLight.prototype.clone = function () {
 
-	var light = new THREE.AreaLight();
+	var light = new this.constructor( this.color, this.intensity );
+	return light.copy( this );
 
-	light.copy( this );
+};
 
-	light.normal.copy( this.normal );
-	light.right.copy( this.right );
-	light.intensity = this.intensity;
-	light.width = this.width;
-	light.height = this.height;
-	light.constantAttenuation = this.constantAttenuation;
-	light.linearAttenuation = this.linearAttenuation;
-	light.quadraticAttenuation = this.quadraticAttenuation;
+THREE.AreaLight.prototype.copy = function ( source ) {
 
-	return light;
+	THREE.Object3D.prototype.copy.call( this, source );
+
+	this.normal.copy( source.normal );
+	this.right.copy( source.right );
+	this.width = source.width;
+	this.height = source.height;
+	this.constantAttenuation = source.constantAttenuation;
+	this.linearAttenuation = source.linearAttenuation;
+	this.quadraticAttenuation = source.quadraticAttenuation;
+
+	return this;
 
 };
 

--- a/src/lights/AreaLight.js
+++ b/src/lights/AreaLight.js
@@ -27,17 +27,11 @@ THREE.AreaLight = function ( color, intensity ) {
 THREE.AreaLight.prototype = Object.create( THREE.Light.prototype );
 THREE.AreaLight.prototype.constructor = THREE.AreaLight;
 
-THREE.PointLight.prototype.clone = function () {
-
-	var light = new this.constructor( this.color, this.intensity );
-	return light.copy( this );
-
-};
-
 THREE.AreaLight.prototype.copy = function ( source ) {
 
-	THREE.Object3D.prototype.copy.call( this, source );
+	THREE.Light.prototype.copy.call( this, source );
 
+	this.intensity = source.intensity;
 	this.normal.copy( source.normal );
 	this.right.copy( source.right );
 	this.width = source.width;

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -19,8 +19,6 @@ THREE.DirectionalLight = function ( color, intensity ) {
 	this.castShadow = false;
 	this.onlyShadow = false;
 
-	//
-
 	this.shadowCameraNear = 50;
 	this.shadowCameraFar = 5000;
 
@@ -37,8 +35,6 @@ THREE.DirectionalLight = function ( color, intensity ) {
 	this.shadowMapWidth = 512;
 	this.shadowMapHeight = 512;
 
-	//
-
 	this.shadowMap = null;
 	this.shadowMapSize = null;
 	this.shadowCamera = null;
@@ -49,38 +45,38 @@ THREE.DirectionalLight = function ( color, intensity ) {
 THREE.DirectionalLight.prototype = Object.create( THREE.Light.prototype );
 THREE.DirectionalLight.prototype.constructor = THREE.DirectionalLight;
 
-THREE.DirectionalLight.prototype.clone = function () {
+THREE.DirectionalLight.prototype.clone = function() {
+	
+	var light = new this.constructor( this.color, this.intensity );
+	return light.copy( this );
+}
 
-	var light = new THREE.DirectionalLight();
+THREE.DirectionalLight.prototype.copy = function ( source ) {
 
-	light.copy( this );
+	THREE.Object3D.prototype.copy.call( this, source );
 
-	light.target = this.target.clone();
+	this.target = source.target.clone();
 
-	light.intensity = this.intensity;
+	this.castShadow = source.castShadow;
+	this.onlyShadow = source.onlyShadow;
 
-	light.castShadow = this.castShadow;
-	light.onlyShadow = this.onlyShadow;
+	this.shadowCameraNear = source.shadowCameraNear;
+	this.shadowCameraFar = source.shadowCameraFar;
 
-	//
+	this.shadowCameraLeft = source.shadowCameraLeft;
+	this.shadowCameraRight = source.shadowCameraRight;
+	this.shadowCameraTop = source.shadowCameraTop;
+	this.shadowCameraBottom = source.shadowCameraBottom;
 
-	light.shadowCameraNear = this.shadowCameraNear;
-	light.shadowCameraFar = this.shadowCameraFar;
+	this.shadowCameraVisible = source.shadowCameraVisible;
 
-	light.shadowCameraLeft = this.shadowCameraLeft;
-	light.shadowCameraRight = this.shadowCameraRight;
-	light.shadowCameraTop = this.shadowCameraTop;
-	light.shadowCameraBottom = this.shadowCameraBottom;
+	this.shadowBias = source.shadowBias;
+	this.shadowDarkness = source.shadowDarkness;
 
-	light.shadowCameraVisible = this.shadowCameraVisible;
+	this.shadowMapWidth = source.shadowMapWidth;
+	this.shadowMapHeight = source.shadowMapHeight;
 
-	light.shadowBias = this.shadowBias;
-	light.shadowDarkness = this.shadowDarkness;
-
-	light.shadowMapWidth = this.shadowMapWidth;
-	light.shadowMapHeight = this.shadowMapHeight;
-
-	return light;
+	return this;
 
 };
 

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -45,16 +45,11 @@ THREE.DirectionalLight = function ( color, intensity ) {
 THREE.DirectionalLight.prototype = Object.create( THREE.Light.prototype );
 THREE.DirectionalLight.prototype.constructor = THREE.DirectionalLight;
 
-THREE.DirectionalLight.prototype.clone = function() {
-	
-	var light = new this.constructor( this.color, this.intensity );
-	return light.copy( this );
-}
-
 THREE.DirectionalLight.prototype.copy = function ( source ) {
 
-	THREE.Object3D.prototype.copy.call( this, source );
+	THREE.Light.prototype.copy.call( this, source );
 
+	this.intensity = source.intensity;
 	this.target = source.target.clone();
 
 	this.castShadow = source.castShadow;

--- a/src/lights/HemisphereLight.js
+++ b/src/lights/HemisphereLight.js
@@ -21,14 +21,8 @@ THREE.HemisphereLight.prototype.constructor = THREE.HemisphereLight;
 
 THREE.HemisphereLight.prototype.clone = function () {
 
-	var light = new THREE.HemisphereLight();
-
-	light.copy( this );
-
-	light.groundColor.copy( this.groundColor );
-	light.intensity = this.intensity;
-
-	return light;
+	var light = new this.constructor( this.color, this.groundColor, this.intensity );
+	return light.copy(this);
 
 };
 

--- a/src/lights/HemisphereLight.js
+++ b/src/lights/HemisphereLight.js
@@ -19,10 +19,14 @@ THREE.HemisphereLight = function ( skyColor, groundColor, intensity ) {
 THREE.HemisphereLight.prototype = Object.create( THREE.Light.prototype );
 THREE.HemisphereLight.prototype.constructor = THREE.HemisphereLight;
 
-THREE.HemisphereLight.prototype.clone = function () {
+THREE.HemisphereLight.prototype.copy = function ( source ) {
 
-	var light = new this.constructor( this.color, this.groundColor, this.intensity );
-	return light.copy(this);
+	THREE.Light.prototype.copy.call( this, source );
+
+	this.groundColor.copy( source.groundColor );
+	this.intensity = source.intensity;
+
+	return this;
 
 };
 

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -16,9 +16,12 @@ THREE.Light = function ( color ) {
 THREE.Light.prototype = Object.create( THREE.Object3D.prototype );
 THREE.Light.prototype.constructor = THREE.Light;
 
-THREE.Light.prototype.clone = function () {
+THREE.Light.prototype.copy = function ( source ) {
 	
-	var light = new this.constructor( this.color );
-	return light.copy( this );
+	THREE.Object3D.prototype.copy.call( this, source );
+	
+	this.color.copy( source.color );
+	
+	return this;
 
 };

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -17,17 +17,8 @@ THREE.Light.prototype = Object.create( THREE.Object3D.prototype );
 THREE.Light.prototype.constructor = THREE.Light;
 
 THREE.Light.prototype.clone = function () {
-
-	var light = new THREE.Light();
+	
+	var light = new this.constructor( this.color );
 	return light.copy( this );
-
-};
-
-THREE.Light.prototype.copy = function ( source ) {
-
-	THREE.Object3D.prototype.copy.call( this, source );
-	this.color.copy( source.color );
-
-	return this;
 
 };

--- a/src/lights/PointLight.js
+++ b/src/lights/PointLight.js
@@ -17,10 +17,15 @@ THREE.PointLight = function ( color, intensity, distance, decay ) {
 THREE.PointLight.prototype = Object.create( THREE.Light.prototype );
 THREE.PointLight.prototype.constructor = THREE.PointLight;
 
-THREE.PointLight.prototype.clone = function () {
+THREE.PointLight.prototype.copy = function ( source ) {
 
-	var light = new this.constructor( this.color, this.intensity, this.distance, this.decay );
-	return light.copy( this );
+	THREE.Light.prototype.copy.call( this, source );
+
+	this.intensity = source.intensity;
+	this.distance = source.distance;
+	this.decay = source.decay;
+
+	return this;
 
 };
 

--- a/src/lights/PointLight.js
+++ b/src/lights/PointLight.js
@@ -19,15 +19,8 @@ THREE.PointLight.prototype.constructor = THREE.PointLight;
 
 THREE.PointLight.prototype.clone = function () {
 
-	var light = new THREE.PointLight();
-
-	light.copy( this );
-
-	light.intensity = this.intensity;
-	light.distance = this.distance;
-	light.decay = this.decay;
-
-	return light;
+	var light = new this.constructor( this.color, this.intensity, this.distance, this.decay );
+	return light.copy( this );
 
 };
 

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -45,14 +45,15 @@ THREE.SpotLight.prototype = Object.create( THREE.Light.prototype );
 THREE.SpotLight.prototype.constructor = THREE.SpotLight;
 
 THREE.SpotLight.prototype.copy = function ( source ) {
-	
+
 	THREE.Light.prototype.copy.call( this, source );
-	
+
 	this.intensity = source.intensity;
 	this.distance = source.distance;
 	this.angle = source.angle;
+	this.exponent = source.exponent;
 	this.decay = source.decay;
-	
+
 	this.target = source.target.clone();
 
 	this.castShadow = source.castShadow;

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -22,8 +22,6 @@ THREE.SpotLight = function ( color, intensity, distance, angle, exponent, decay 
 	this.castShadow = false;
 	this.onlyShadow = false;
 
-	//
-
 	this.shadowCameraNear = 50;
 	this.shadowCameraFar = 5000;
 	this.shadowCameraFov = 50;
@@ -35,8 +33,6 @@ THREE.SpotLight = function ( color, intensity, distance, angle, exponent, decay 
 
 	this.shadowMapWidth = 512;
 	this.shadowMapHeight = 512;
-
-	//
 
 	this.shadowMap = null;
 	this.shadowMapSize = null;
@@ -50,38 +46,34 @@ THREE.SpotLight.prototype.constructor = THREE.SpotLight;
 
 THREE.SpotLight.prototype.clone = function () {
 
-	var light = new THREE.SpotLight();
-
-	light.copy( this );
-
-	light.target = this.target.clone();
-
-	light.intensity = this.intensity;
-	light.distance = this.distance;
-	light.angle = this.angle;
-	light.exponent = this.exponent;
-	light.decay = this.decay;
-
-	light.castShadow = this.castShadow;
-	light.onlyShadow = this.onlyShadow;
-
-	//
-
-	light.shadowCameraNear = this.shadowCameraNear;
-	light.shadowCameraFar = this.shadowCameraFar;
-	light.shadowCameraFov = this.shadowCameraFov;
-
-	light.shadowCameraVisible = this.shadowCameraVisible;
-
-	light.shadowBias = this.shadowBias;
-	light.shadowDarkness = this.shadowDarkness;
-
-	light.shadowMapWidth = this.shadowMapWidth;
-	light.shadowMapHeight = this.shadowMapHeight;
-
-	return light;
+	var light = new this.constructor( this.color, this.intensity, this.distance, this.angle, this.exponent, this.decay );
+	return light.copy( this );
 
 };
+
+THREE.SpotLight.prototype.copy = function ( source ) {
+	
+	THREE.Object3D.prototype.copy.call( this, source );
+	
+	this.target = source.target.clone();
+
+	this.castShadow = source.castShadow;
+	this.onlyShadow = source.onlyShadow;
+
+	this.shadowCameraNear = source.shadowCameraNear;
+	this.shadowCameraFar = source.shadowCameraFar;
+	this.shadowCameraFov = source.shadowCameraFov;
+
+	this.shadowCameraVisible = source.shadowCameraVisible;
+
+	this.shadowBias = source.shadowBias;
+	this.shadowDarkness = source.shadowDarkness;
+
+	this.shadowMapWidth = source.shadowMapWidth;
+	this.shadowMapHeight = source.shadowMapHeight;
+
+	return this;
+}
 
 THREE.SpotLight.prototype.toJSON = function ( meta ) {
 

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -44,16 +44,14 @@ THREE.SpotLight = function ( color, intensity, distance, angle, exponent, decay 
 THREE.SpotLight.prototype = Object.create( THREE.Light.prototype );
 THREE.SpotLight.prototype.constructor = THREE.SpotLight;
 
-THREE.SpotLight.prototype.clone = function () {
-
-	var light = new this.constructor( this.color, this.intensity, this.distance, this.angle, this.exponent, this.decay );
-	return light.copy( this );
-
-};
-
 THREE.SpotLight.prototype.copy = function ( source ) {
 	
-	THREE.Object3D.prototype.copy.call( this, source );
+	THREE.Light.prototype.copy.call( this, source );
+	
+	this.intensity = source.intensity;
+	this.distance = source.distance;
+	this.angle = source.angle;
+	this.decay = source.decay;
 	
 	this.target = source.target.clone();
 

--- a/src/materials/LineBasicMaterial.js
+++ b/src/materials/LineBasicMaterial.js
@@ -43,22 +43,20 @@ THREE.LineBasicMaterial = function ( parameters ) {
 THREE.LineBasicMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.LineBasicMaterial.prototype.constructor = THREE.LineBasicMaterial;
 
-THREE.LineBasicMaterial.prototype.clone = function () {
+THREE.LineBasicMaterial.prototype.copy = function ( source ) {
 
-	var material = new THREE.LineBasicMaterial();
+	THREE.Material.prototype.copy.call( this, source );
 
-	material.copy( this );
+	this.color.copy( source.color );
 
-	material.color.copy( this.color );
+	this.linewidth = source.linewidth;
+	this.linecap = source.linecap;
+	this.linejoin = source.linejoin;
 
-	material.linewidth = this.linewidth;
-	material.linecap = this.linecap;
-	material.linejoin = this.linejoin;
+	this.vertexColors = source.vertexColors;
 
-	material.vertexColors = this.vertexColors;
+	this.fog = source.fog;
 
-	material.fog = this.fog;
-
-	return material;
+	return this;
 
 };

--- a/src/materials/LineDashedMaterial.js
+++ b/src/materials/LineDashedMaterial.js
@@ -51,6 +51,8 @@ THREE.LineBasicMaterial.prototype.copy = function ( source ) {
 	THREE.Material.prototype.copy.call( this, source );
 
 	this.color.copy( source.color );
+	
+	this.linewidth = source.linewidth;
 
 	this.scale = source.scale;
 	this.dashSize = source.dashSize;

--- a/src/materials/LineDashedMaterial.js
+++ b/src/materials/LineDashedMaterial.js
@@ -46,24 +46,20 @@ THREE.LineDashedMaterial = function ( parameters ) {
 THREE.LineDashedMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.LineDashedMaterial.prototype.constructor = THREE.LineDashedMaterial;
 
-THREE.LineDashedMaterial.prototype.clone = function () {
+THREE.LineBasicMaterial.prototype.copy = function ( source ) {
 
-	var material = new THREE.LineDashedMaterial();
+	THREE.Material.prototype.copy.call( this, source );
 
-	material.copy( this );
+	this.color.copy( source.color );
 
-	material.color.copy( this.color );
+	this.scale = source.scale;
+	this.dashSize = source.dashSize;
+	this.gapSize = source.gapSize;
 
-	material.linewidth = this.linewidth;
+	this.vertexColors = source.vertexColors;
 
-	material.scale = this.scale;
-	material.dashSize = this.dashSize;
-	material.gapSize = this.gapSize;
+	this.fog = source.fog;
 
-	material.vertexColors = this.vertexColors;
-
-	material.fog = this.fog;
-
-	return material;
+	return this;
 
 };

--- a/src/materials/LineDashedMaterial.js
+++ b/src/materials/LineDashedMaterial.js
@@ -46,7 +46,7 @@ THREE.LineDashedMaterial = function ( parameters ) {
 THREE.LineDashedMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.LineDashedMaterial.prototype.constructor = THREE.LineDashedMaterial;
 
-THREE.LineBasicMaterial.prototype.copy = function ( source ) {
+THREE.LineDashedMaterial.prototype.copy = function ( source ) {
 
 	THREE.Material.prototype.copy.call( this, source );
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -172,8 +172,7 @@ THREE.Material.prototype = {
 
 	clone: function () {
 
-		var material = new this.constructor();
-		return material.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -172,7 +172,8 @@ THREE.Material.prototype = {
 
 	clone: function () {
 
-		return new THREE.Material().copy( this );
+		var material = new this.constructor();
+		return material.copy( this );
 
 	},
 

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -79,42 +79,40 @@ THREE.MeshBasicMaterial = function ( parameters ) {
 THREE.MeshBasicMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.MeshBasicMaterial.prototype.constructor = THREE.MeshBasicMaterial;
 
-THREE.MeshBasicMaterial.prototype.clone = function () {
+THREE.MeshBasicMaterial.prototype.copy = function ( source ) {
+	
+	THREE.Material.prototype.copy.call( this, source );
 
-	var material = new THREE.MeshBasicMaterial();
+	this.color.copy( source.color );
 
-	material.copy( this );
+	this.map = source.map;
 
-	material.color.copy( this.color );
+	this.aoMap = source.aoMap;
+	this.aoMapIntensity = source.aoMapIntensity;
 
-	material.map = this.map;
+	this.specularMap = source.specularMap;
 
-	material.aoMap = this.aoMap;
-	material.aoMapIntensity = this.aoMapIntensity;
+	this.alphaMap = source.alphaMap;
 
-	material.specularMap = this.specularMap;
+	this.envMap = source.envMap;
+	this.combine = source.combine;
+	this.reflectivity = source.reflectivity;
+	this.refractionRatio = source.refractionRatio;
 
-	material.alphaMap = this.alphaMap;
+	this.fog = source.fog;
 
-	material.envMap = this.envMap;
-	material.combine = this.combine;
-	material.reflectivity = this.reflectivity;
-	material.refractionRatio = this.refractionRatio;
+	this.shading = source.shading;
 
-	material.fog = this.fog;
+	this.wireframe = source.wireframe;
+	this.wireframeLinewidth = source.wireframeLinewidth;
+	this.wireframeLinecap = source.wireframeLinecap;
+	this.wireframeLinejoin = source.wireframeLinejoin;
 
-	material.shading = this.shading;
+	this.vertexColors = source.vertexColors;
 
-	material.wireframe = this.wireframe;
-	material.wireframeLinewidth = this.wireframeLinewidth;
-	material.wireframeLinecap = this.wireframeLinecap;
-	material.wireframeLinejoin = this.wireframeLinejoin;
-
-	material.vertexColors = this.vertexColors;
-
-	material.skinning = this.skinning;
-	material.morphTargets = this.morphTargets;
-
-	return material;
+	this.skinning = source.skinning;
+	this.morphTargets = source.morphTargets;
+	
+	return this;
 
 };

--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -31,15 +31,13 @@ THREE.MeshDepthMaterial = function ( parameters ) {
 THREE.MeshDepthMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.MeshDepthMaterial.prototype.constructor = THREE.MeshDepthMaterial;
 
-THREE.MeshDepthMaterial.prototype.clone = function () {
+THREE.MeshDepthMaterial.prototype.copy = function ( source ) {
 
-	var material = new THREE.MeshDepthMaterial();
+	THREE.Material.prototype.copy.call( this, source );
 
-	material.copy( this );
+	this.wireframe = source.wireframe;
+	this.wireframeLinewidth = source.wireframeLinewidth;
 
-	material.wireframe = this.wireframe;
-	material.wireframeLinewidth = this.wireframeLinewidth;
-
-	return material;
+	return this;
 
 };

--- a/src/materials/MeshFaceMaterial.js
+++ b/src/materials/MeshFaceMaterial.js
@@ -45,7 +45,7 @@ THREE.MeshFaceMaterial.prototype = {
 
 	clone: function () {
 
-		var material = new THREE.MeshFaceMaterial();
+		var material = new this.constructor();
 
 		for ( var i = 0; i < this.materials.length; i ++ ) {
 

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -78,41 +78,39 @@ THREE.MeshLambertMaterial = function ( parameters ) {
 THREE.MeshLambertMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.MeshLambertMaterial.prototype.constructor = THREE.MeshLambertMaterial;
 
-THREE.MeshLambertMaterial.prototype.clone = function () {
+THREE.MeshLambertMaterial.prototype.copy = function ( source ) {
 
-	var material = new THREE.MeshLambertMaterial();
+	THREE.Material.prototype.copy.call( this, source );
 
-	material.copy( this );
+	this.color.copy( source.color );
+	this.emissive.copy( source.emissive );
 
-	material.color.copy( this.color );
-	material.emissive.copy( this.emissive );
+	this.map = source.map;
 
-	material.map = this.map;
+	this.specularMap = source.specularMap;
 
-	material.specularMap = this.specularMap;
+	this.alphaMap = source.alphaMap;
 
-	material.alphaMap = this.alphaMap;
+	this.envMap = source.envMap;
+	this.combine = source.combine;
+	this.reflectivity = source.reflectivity;
+	this.refractionRatio = source.refractionRatio;
 
-	material.envMap = this.envMap;
-	material.combine = this.combine;
-	material.reflectivity = this.reflectivity;
-	material.refractionRatio = this.refractionRatio;
+	this.fog = source.fog;
 
-	material.fog = this.fog;
+	this.shading = source.shading;
 
-	material.shading = this.shading;
+	this.wireframe = source.wireframe;
+	this.wireframeLinewidth = source.wireframeLinewidth;
+	this.wireframeLinecap = source.wireframeLinecap;
+	this.wireframeLinejoin = source.wireframeLinejoin;
 
-	material.wireframe = this.wireframe;
-	material.wireframeLinewidth = this.wireframeLinewidth;
-	material.wireframeLinecap = this.wireframeLinecap;
-	material.wireframeLinejoin = this.wireframeLinejoin;
+	this.vertexColors = source.vertexColors;
 
-	material.vertexColors = this.vertexColors;
+	this.skinning = source.skinning;
+	this.morphTargets = source.morphTargets;
+	this.morphNormals = source.morphNormals;
 
-	material.skinning = this.skinning;
-	material.morphTargets = this.morphTargets;
-	material.morphNormals = this.morphNormals;
-
-	return material;
+	return this;
 
 };

--- a/src/materials/MeshNormalMaterial.js
+++ b/src/materials/MeshNormalMaterial.js
@@ -32,15 +32,13 @@ THREE.MeshNormalMaterial = function ( parameters ) {
 THREE.MeshNormalMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.MeshNormalMaterial.prototype.constructor = THREE.MeshNormalMaterial;
 
-THREE.MeshNormalMaterial.prototype.clone = function () {
+THREE.MeshNormalMaterial.prototype.copy = function ( source ) {
 
-	var material = new THREE.MeshNormalMaterial();
+	THREE.Material.prototype.copy.call( this, source );
 
-	material.copy( this );
+	this.wireframe = source.wireframe;
+	this.wireframeLinewidth = source.wireframeLinewidth;
 
-	material.wireframe = this.wireframe;
-	material.wireframeLinewidth = this.wireframeLinewidth;
-
-	return material;
+	return this;
 
 };

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -166,9 +166,3 @@ THREE.MeshPhongMaterial.prototype.copy = function ( source ) {
 	return this;
 
 };
-
-THREE.MeshPhongMaterial.prototype.clone = function () {
-
-	return new THREE.MeshPhongMaterial().copy( this );
-
-};

--- a/src/materials/PointCloudMaterial.js
+++ b/src/materials/PointCloudMaterial.js
@@ -44,24 +44,22 @@ THREE.PointCloudMaterial = function ( parameters ) {
 THREE.PointCloudMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.PointCloudMaterial.prototype.constructor = THREE.PointCloudMaterial;
 
-THREE.PointCloudMaterial.prototype.clone = function () {
+THREE.PointCloudMaterial.prototype.copy = function ( source ) {
 
-	var material = new THREE.PointCloudMaterial();
+	THREE.Material.prototype.copy.call( this, source );
 
-	material.copy( this );
+	this.color.copy( source.color );
 
-	material.color.copy( this.color );
+	this.map = source.map;
 
-	material.map = this.map;
+	this.size = source.size;
+	this.sizeAttenuation = source.sizeAttenuation;
 
-	material.size = this.size;
-	material.sizeAttenuation = this.sizeAttenuation;
+	this.vertexColors = source.vertexColors;
 
-	material.vertexColors = this.vertexColors;
-
-	material.fog = this.fog;
-
-	return material;
+	this.fog = source.fog;
+	
+	return this;
 
 };
 

--- a/src/materials/RawShaderMaterial.js
+++ b/src/materials/RawShaderMaterial.js
@@ -12,13 +12,3 @@ THREE.RawShaderMaterial = function ( parameters ) {
 
 THREE.RawShaderMaterial.prototype = Object.create( THREE.ShaderMaterial.prototype );
 THREE.RawShaderMaterial.prototype.constructor = THREE.RawShaderMaterial;
-
-THREE.RawShaderMaterial.prototype.clone = function () {
-
-	var material = new THREE.RawShaderMaterial();
-
-	material.copy( this );
-
-	return material;
-
-};

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -89,13 +89,6 @@ THREE.ShaderMaterial = function ( parameters ) {
 THREE.ShaderMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.ShaderMaterial.prototype.constructor = THREE.ShaderMaterial;
 
-THREE.ShaderMaterial.prototype.clone = function () {
-
-	var material = new THREE.ShaderMaterial();
-	return material.copy( this );
-
-};
-
 THREE.ShaderMaterial.prototype.copy = function ( source ) {
 
 	THREE.Material.prototype.copy.call( this, source );

--- a/src/materials/SpriteMaterial.js
+++ b/src/materials/SpriteMaterial.js
@@ -39,19 +39,17 @@ THREE.SpriteMaterial = function ( parameters ) {
 THREE.SpriteMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.SpriteMaterial.prototype.constructor = THREE.SpriteMaterial;
 
-THREE.SpriteMaterial.prototype.clone = function () {
+THREE.SpriteMaterial.prototype.copy = function ( source ) {
 
-	var material = new THREE.SpriteMaterial();
+	THREE.Material.prototype.copy.call( this, source );
 
-	material.copy( this );
+	this.color.copy( source.color );
+	this.map = source.map;
 
-	material.color.copy( this.color );
-	material.map = this.map;
+	this.rotation = source.rotation;
 
-	material.rotation = this.rotation;
+	this.fog = source.fog;
 
-	material.fog = this.fog;
-
-	return material;
+	return this;
 
 };

--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -51,6 +51,13 @@ THREE.Box2.prototype = {
 		};
 
 	}(),
+	
+	clone: function () {
+
+		var box = new this.constructor();
+		return box.copy( this );
+
+	},
 
 	copy: function ( box ) {
 
@@ -224,12 +231,6 @@ THREE.Box2.prototype = {
 	equals: function ( box ) {
 
 		return box.min.equals( this.min ) && box.max.equals( this.max );
-
-	},
-
-	clone: function () {
-
-		return new THREE.Box2().copy( this );
 
 	}
 

--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -54,8 +54,7 @@ THREE.Box2.prototype = {
 	
 	clone: function () {
 
-		var box = new this.constructor();
-		return box.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -117,8 +117,7 @@ THREE.Box3.prototype = {
 
 	clone: function () {
 
-		var box = new this.constructor();
-		return box.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -115,6 +115,13 @@ THREE.Box3.prototype = {
 
 	}(),
 
+	clone: function () {
+
+		var box = new this.constructor();
+		return box.copy( this );
+
+	},
+
 	copy: function ( box ) {
 
 		this.min.copy( box.min );
@@ -342,12 +349,6 @@ THREE.Box3.prototype = {
 	equals: function ( box ) {
 
 		return box.min.equals( this.min ) && box.max.equals( this.max );
-
-	},
-
-	clone: function () {
-
-		return new THREE.Box3().copy( this );
 
 	}
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -271,6 +271,12 @@ THREE.Color.prototype = {
 
 	},
 
+	clone: function () {
+
+		return new this.constructor( this.color );
+
+	},
+
 	copy: function ( color ) {
 
 		this.r = color.r;
@@ -490,12 +496,6 @@ THREE.Color.prototype = {
 		array[ offset + 2 ] = this.b;
 
 		return array;
-
-	},
-
-	clone: function () {
-
-		return new THREE.Color().copy( this );
 
 	}
 

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -86,6 +86,12 @@ THREE.Euler.prototype = {
 
 	},
 
+	clone: function () {
+
+		return new this.constructor( this._x, this._y, this._z, this._order);
+
+	},
+
 	copy: function ( euler ) {
 
 		this._x = euler._x;
@@ -314,12 +320,6 @@ THREE.Euler.prototype = {
 
 	},
 
-	onChangeCallback: function () {},
-
-	clone: function () {
-
-		return new THREE.Euler( this._x, this._y, this._z, this._order );
-
-	}
+	onChangeCallback: function () {}
 
 };

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -38,6 +38,13 @@ THREE.Frustum.prototype = {
 
 	},
 
+	clone: function () {
+
+		var frustum = new this.constructor();
+		return frustum.copy( this );
+
+	},
+
 	copy: function ( frustum ) {
 
 		var planes = this.planes;
@@ -168,12 +175,6 @@ THREE.Frustum.prototype = {
 		}
 
 		return true;
-
-	},
-
-	clone: function () {
-
-		return new THREE.Frustum().copy( this );
 
 	}
 

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -40,8 +40,7 @@ THREE.Frustum.prototype = {
 
 	clone: function () {
 
-		var frustum = new this.constructor();
-		return frustum.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -22,6 +22,13 @@ THREE.Line3.prototype = {
 
 	},
 
+	clone: function () {
+
+		var line = new this.constructor();
+		return line.copy( this );
+
+	},
+
 	copy: function ( line ) {
 
 		this.start.copy( line.start );
@@ -114,12 +121,6 @@ THREE.Line3.prototype = {
 	equals: function ( line ) {
 
 		return line.start.equals( this.start ) && line.end.equals( this.end );
-
-	},
-
-	clone: function () {
-
-		return new THREE.Line3().copy( this );
 
 	}
 

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -24,8 +24,7 @@ THREE.Line3.prototype = {
 
 	clone: function () {
 
-		var line = new this.constructor();
-		return line.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -54,8 +54,7 @@ THREE.Matrix3.prototype = {
 
 	clone: function () {
 
-		var matrix = new this.constructor();
-		return matrix.fromArray( this.elements );
+		return new this.constructor().fromArray( this.elements );
 
 	},
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -52,6 +52,13 @@ THREE.Matrix3.prototype = {
 
 	},
 
+	clone: function () {
+
+		var matrix = new this.constructor();
+		return matrix.fromArray( this.elements );
+
+	},
+
 	copy: function ( m ) {
 
 		var me = m.elements;
@@ -283,12 +290,6 @@ THREE.Matrix3.prototype = {
 			te[ 3 ], te[ 4 ], te[ 5 ],
 			te[ 6 ], te[ 7 ], te[ 8 ]
 		];
-
-	},
-
-	clone: function () {
-
-		return new THREE.Matrix3().fromArray( this.elements );
 
 	}
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -62,6 +62,12 @@ THREE.Matrix4.prototype = {
 
 	},
 
+	clone: function () {
+
+		return new THREE.Matrix4().fromArray( this.elements );
+
+	},
+
 	copy: function ( m ) {
 
 		this.elements.set( m.elements );
@@ -1024,12 +1030,6 @@ THREE.Matrix4.prototype = {
 			te[ 8 ], te[ 9 ], te[ 10 ], te[ 11 ],
 			te[ 12 ], te[ 13 ], te[ 14 ], te[ 15 ]
 		];
-
-	},
-
-	clone: function () {
-
-		return new THREE.Matrix4().fromArray( this.elements );
 
 	}
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -61,8 +61,7 @@ THREE.Plane.prototype = {
 
 	clone: function () {
 
-		var plane = new this.constructor();
-		return plane.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -59,6 +59,12 @@ THREE.Plane.prototype = {
 
 	}(),
 
+	clone: function () {
+
+		var plane = new this.constructor();
+		return plane.copy( this );
+
+	},
 
 	copy: function ( plane ) {
 
@@ -211,12 +217,6 @@ THREE.Plane.prototype = {
 	equals: function ( plane ) {
 
 		return plane.normal.equals( this.normal ) && ( plane.constant === this.constant );
-
-	},
-
-	clone: function () {
-
-		return new THREE.Plane().copy( this );
 
 	}
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -83,6 +83,12 @@ THREE.Quaternion.prototype = {
 
 	},
 
+	clone: function () {
+
+		return new this.constructor( this._x, this._y, this._z, this._w );
+
+	},
+
 	copy: function ( quaternion ) {
 
 		this._x = quaternion.x;
@@ -504,13 +510,7 @@ THREE.Quaternion.prototype = {
 
 	},
 
-	onChangeCallback: function () {},
-
-	clone: function () {
-
-		return new THREE.Quaternion( this._x, this._y, this._z, this._w );
-
-	}
+	onChangeCallback: function () {}
 
 };
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -24,8 +24,7 @@ THREE.Ray.prototype = {
 
 	clone: function () {
 
-		var ray = new this.constructor();
-		return ray.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -22,6 +22,13 @@ THREE.Ray.prototype = {
 
 	},
 
+	clone: function () {
+
+		var ray = new this.constructor();
+		return ray.copy( this );
+
+	},
+
 	copy: function ( ray ) {
 
 		this.origin.copy( ray.origin );
@@ -520,12 +527,6 @@ THREE.Ray.prototype = {
 	equals: function ( ray ) {
 
 		return ray.origin.equals( this.origin ) && ray.direction.equals( this.direction );
-
-	},
-
-	clone: function () {
-
-		return new THREE.Ray().copy( this );
 
 	}
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -59,8 +59,7 @@ THREE.Sphere.prototype = {
 
 	clone: function () {
 
-		var sphere = new this.constructor();
-		return sphere.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -57,6 +57,13 @@ THREE.Sphere.prototype = {
 
 	}(),
 
+	clone: function () {
+
+		var sphere = new this.constructor();
+		return sphere.copy( this );
+
+	},
+
 	copy: function ( sphere ) {
 
 		this.center.copy( sphere.center );
@@ -141,12 +148,6 @@ THREE.Sphere.prototype = {
 	equals: function ( sphere ) {
 
 		return sphere.center.equals( this.center ) && ( sphere.radius === this.radius );
-
-	},
-
-	clone: function () {
-
-		return new THREE.Sphere().copy( this );
 
 	}
 

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -118,6 +118,13 @@ THREE.Triangle.prototype = {
 
 	},
 
+	clone: function () {
+
+		var triangle = new this.constructor();
+		return triangle.copy( this );
+
+	},
+
 	copy: function ( triangle ) {
 
 		this.a.copy( triangle.a );
@@ -180,12 +187,6 @@ THREE.Triangle.prototype = {
 	equals: function ( triangle ) {
 
 		return triangle.a.equals( this.a ) && triangle.b.equals( this.b ) && triangle.c.equals( this.c );
-
-	},
-
-	clone: function () {
-
-		return new THREE.Triangle().copy( this );
 
 	}
 

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -120,8 +120,7 @@ THREE.Triangle.prototype = {
 
 	clone: function () {
 
-		var triangle = new this.constructor();
-		return triangle.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -65,6 +65,12 @@ THREE.Vector2.prototype = {
 
 	},
 
+	clone: function () {
+
+		return new this.constructor( this.x, this.y );
+
+	},
+
 	copy: function ( v ) {
 
 		this.x = v.x;
@@ -442,12 +448,6 @@ THREE.Vector2.prototype = {
 		this.y = attribute.array[ index + 1 ];
 
 		return this;
-
-	},
-
-	clone: function () {
-
-		return new THREE.Vector2( this.x, this.y );
 
 	}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -79,6 +79,12 @@ THREE.Vector3.prototype = {
 
 	},
 
+	clone: function () {
+
+		return new this.constructor( this.x, this.y, this.z );
+
+	},
+
 	copy: function ( v ) {
 
 		this.x = v.x;
@@ -851,12 +857,6 @@ THREE.Vector3.prototype = {
 		this.z = attribute.array[ index + 2 ];
 
 		return this;
-
-	},
-
-	clone: function () {
-
-		return new THREE.Vector3( this.x, this.y, this.z );
 
 	}
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -90,6 +90,12 @@ THREE.Vector4.prototype = {
 
 	},
 
+	clone: function () {
+
+		return new this.constructor( this.x, this.y, this.z, this.w );
+
+	},
+
 	copy: function ( v ) {
 
 		this.x = v.x;
@@ -696,12 +702,6 @@ THREE.Vector4.prototype = {
 		this.w = attribute.array[ index + 3 ];
 
 		return this;
-
-	},
-
-	clone: function () {
-
-		return new THREE.Vector4( this.x, this.y, this.z, this.w );
 
 	}
 

--- a/src/objects/Bone.js
+++ b/src/objects/Bone.js
@@ -17,9 +17,12 @@ THREE.Bone = function ( skin ) {
 THREE.Bone.prototype = Object.create( THREE.Object3D.prototype );
 THREE.Bone.prototype.constructor = THREE.Bone;
 
-THREE.Bone.prototype.clone = function () {
+THREE.Bone.prototype.copy = function ( source ) {
 	
-	var bone = new this.constructor( this.skin );
-	return bone.copy( this );
+	THREE.Object3D.prototype.copy.call( this, source );
+	
+	this.skin = source.skin;
+	
+	return this;
 
 };

--- a/src/objects/Bone.js
+++ b/src/objects/Bone.js
@@ -18,17 +18,8 @@ THREE.Bone.prototype = Object.create( THREE.Object3D.prototype );
 THREE.Bone.prototype.constructor = THREE.Bone;
 
 THREE.Bone.prototype.clone = function () {
-
-	var bone = new THREE.Bone( this.skin );
+	
+	var bone = new this.constructor( this.skin );
 	return bone.copy( this );
-
-};
-
-THREE.Bone.prototype.copy = function ( source ) {
-
-	THREE.Object3D.prototype.copy.call( this, source );
-	this.skin = source.skin;
-
-	return this;
 
 };

--- a/src/objects/Group.js
+++ b/src/objects/Group.js
@@ -12,17 +12,3 @@ THREE.Group = function () {
 
 THREE.Group.prototype = Object.create( THREE.Object3D.prototype );
 THREE.Group.prototype.constructor = THREE.Group;
-
-THREE.Group.prototype.clone = function () {
-
-	var group = new THREE.Group();
-	return group.copy( this );
-
-};
-
-THREE.Group.prototype.copy = function ( source ) {
-
-	THREE.Object3D.prototype.copy.call( this, source );
-	return this;
-
-};

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -132,14 +132,6 @@ THREE.LOD.prototype.update = function () {
 
 }();
 
-THREE.LOD.prototype.clone = function () {
-
-	var lod = new THREE.LOD();
-	return lod.copy( this );
-
-};
-
-
 THREE.LOD.prototype.copy = function ( source ) {
 
 	THREE.Object3D.prototype.copy.call( this, source, false );

--- a/src/objects/LensFlare.js
+++ b/src/objects/LensFlare.js
@@ -78,13 +78,6 @@ THREE.LensFlare.prototype.updateLensFlares = function () {
 
 };
 
-THREE.LensFlare.prototype.clone = function () {
-
-	var flare = new THREE.LensFlare();
-	return flare.copy( this );
-
-};
-
 THREE.LensFlare.prototype.copy = function ( source ) {
 
 	THREE.Object3D.prototype.copy.call( this, source );

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -185,8 +185,7 @@ THREE.Line.prototype.raycast = ( function () {
 
 THREE.Line.prototype.clone = function () {
 
-	var line = new this.constructor( this.geometry, this.material );
-	return line.copy( this );
+	return new this.constructor( this.geometry, this.material ).copy( this );
 
 };
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -185,15 +185,8 @@ THREE.Line.prototype.raycast = ( function () {
 
 THREE.Line.prototype.clone = function () {
 
-	var line = new THREE.Line( this.geometry, this.material );
+	var line = new this.constructor( this.geometry, this.material );
 	return line.copy( this );
-
-};
-
-THREE.Line.prototype.copy = function ( source ) {
-
-	THREE.Object3D.prototype.copy.call( this, source );
-	return this;
 
 };
 

--- a/src/objects/LineSegments.js
+++ b/src/objects/LineSegments.js
@@ -12,13 +12,3 @@ THREE.LineSegments = function ( geometry, material ) {
 
 THREE.LineSegments.prototype = Object.create( THREE.Line.prototype );
 THREE.LineSegments.prototype.constructor = THREE.LineSegments;
-
-THREE.LineSegments.prototype.clone = function () {
-
-	var line = new THREE.LineSegments( this.geometry, this.material );
-
-	line.copy( this );
-
-	return line;
-
-};

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -307,15 +307,8 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 THREE.Mesh.prototype.clone = function () {
 
-	var mesh = new THREE.Mesh( this.geometry, this.material );
+	var mesh = new this.constructor( this.geometry, this.material );
 	return mesh.copy( this );
-
-};
-
-THREE.Mesh.prototype.copy = function ( source ) {
-
-	THREE.Object3D.prototype.copy.call( this, source );
-	return this;
 
 };
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -307,8 +307,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 THREE.Mesh.prototype.clone = function () {
 
-	var mesh = new this.constructor( this.geometry, this.material );
-	return mesh.copy( this );
+	return new this.constructor( this.geometry, this.material ).copy( this );
 
 };
 

--- a/src/objects/MorphAnimMesh.js
+++ b/src/objects/MorphAnimMesh.js
@@ -193,14 +193,9 @@ THREE.MorphAnimMesh.prototype.interpolateTargets = function ( a, b, t ) {
 
 };
 
-THREE.MorphAnimMesh.prototype.clone = function () {
-
-	var morph = new THREE.MorphAnimMesh( this.geometry, this.material );
-	return morph.copy( this );
-
-};
-
 THREE.MorphAnimMesh.prototype.copy = function ( source ) {
+
+	THREE.Object3D.prototype.copy.call( this, source );
 
 	this.duration = source.duration;
 	this.mirroredLoop = source.mirroredLoop;
@@ -211,8 +206,6 @@ THREE.MorphAnimMesh.prototype.copy = function ( source ) {
 
 	this.direction = source.direction;
 	this.directionBackwards = source.directionBackwards;
-
-	THREE.Mesh.prototype.copy.call( this, source );
 
 	return this;
 

--- a/src/objects/PointCloud.js
+++ b/src/objects/PointCloud.js
@@ -138,15 +138,8 @@ THREE.PointCloud.prototype.raycast = ( function () {
 
 THREE.PointCloud.prototype.clone = function () {
 
-	var pointCloud = new THREE.PointCloud( this.geometry, this.material );
+	var pointCloud = new this.constructor( this.geometry, this.material );
 	return pointCloud.copy( this );
-
-};
-
-THREE.PointCloud.prototype.copy = function ( source ) {
-
-	THREE.Object3D.prototype.copy.call( this, source );
-	return this;
 
 };
 

--- a/src/objects/PointCloud.js
+++ b/src/objects/PointCloud.js
@@ -138,8 +138,7 @@ THREE.PointCloud.prototype.raycast = ( function () {
 
 THREE.PointCloud.prototype.clone = function () {
 
-	var pointCloud = new this.constructor( this.geometry, this.material );
-	return pointCloud.copy( this );
+	return new this.constructor( this.geometry, this.material ).copy( this );
 
 };
 

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -145,14 +145,7 @@ THREE.SkinnedMesh.prototype.updateMatrixWorld = function( force ) {
 
 THREE.SkinnedMesh.prototype.clone = function() {
 
-	var skinMesh = new THREE.SkinnedMesh( this.geometry, this.material, this.useVertexTexture );
+	var skinMesh = new this.constructor( this.geometry, this.material, this.useVertexTexture );
 	return skinMesh.copy( this );
-
-};
-
-THREE.SkinnedMesh.prototype.copy = function( source ) {
-
-	THREE.Mesh.prototype.copy.call( this, source );
-	return this;
 
 };

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -145,7 +145,6 @@ THREE.SkinnedMesh.prototype.updateMatrixWorld = function( force ) {
 
 THREE.SkinnedMesh.prototype.clone = function() {
 
-	var skinMesh = new this.constructor( this.geometry, this.material, this.useVertexTexture );
-	return skinMesh.copy( this );
+	return new this.constructor( this.geometry, this.material, this.useVertexTexture ).copy( this );
 
 };

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -62,8 +62,7 @@ THREE.Sprite.prototype.raycast = ( function () {
 
 THREE.Sprite.prototype.clone = function () {
 
-	var sprite = new this.constructor( this.material );
-	return sprite.copy( this );
+	return new this.constructor( this.material ).copy( this );
 
 };
 

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -62,15 +62,8 @@ THREE.Sprite.prototype.raycast = ( function () {
 
 THREE.Sprite.prototype.clone = function () {
 
-	var sprite = new THREE.Sprite( this.material );
+	var sprite = new this.constructor( this.material );
 	return sprite.copy( this );
-
-};
-
-THREE.Sprite.prototype.copy = function ( source ) {
-
-	THREE.Object3D.prototype.copy.call( this, source );
-	return this;
 
 };
 

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -54,8 +54,7 @@ THREE.WebGLRenderTarget.prototype = {
 
 	clone: function () {
 
-		var renderTarget = new this.constructor();
-		return renderTarget.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -52,6 +52,13 @@ THREE.WebGLRenderTarget.prototype = {
 
 	},
 
+	clone: function () {
+
+		var renderTarget = new this.constructor();
+		return renderTarget.copy( this );
+
+	},
+
 	copy: function ( source ) {
 
 		this.width = source.width;
@@ -79,12 +86,6 @@ THREE.WebGLRenderTarget.prototype = {
 		this.shareDepthFrom = source.shareDepthFrom;
 
 		return this;
-
-	},
-
-	clone: function () {
-
-		return new THREE.WebGLRenderTarget().copy( this );
 
 	},
 

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -18,13 +18,6 @@ THREE.Scene = function () {
 THREE.Scene.prototype = Object.create( THREE.Object3D.prototype );
 THREE.Scene.prototype.constructor = THREE.Scene;
 
-THREE.Scene.prototype.clone = function () {
-
-	var scene = new THREE.Scene();
-	return scene.copy( this );
-
-};
-
 THREE.Scene.prototype.copy = function ( source ) {
 
 	THREE.Object3D.prototype.copy.call( this, source );

--- a/src/textures/CompressedTexture.js
+++ b/src/textures/CompressedTexture.js
@@ -23,13 +23,3 @@ THREE.CompressedTexture = function ( mipmaps, width, height, format, type, mappi
 
 THREE.CompressedTexture.prototype = Object.create( THREE.Texture.prototype );
 THREE.CompressedTexture.prototype.constructor = THREE.CompressedTexture;
-
-THREE.CompressedTexture.prototype.clone = function () {
-
-	var texture = new THREE.CompressedTexture();
-
-	texture.copy( this );
-
-	return texture;
-
-};

--- a/src/textures/CubeTexture.js
+++ b/src/textures/CubeTexture.js
@@ -16,14 +16,9 @@ THREE.CubeTexture = function ( images, mapping, wrapS, wrapT, magFilter, minFilt
 THREE.CubeTexture.prototype = Object.create( THREE.Texture.prototype );
 THREE.CubeTexture.prototype.constructor = THREE.CubeTexture;
 
-THREE.CubeTexture.clone = function () {
+THREE.CubeTexture.prototype.clone = function () {
 
-	var texture = new THREE.CubeTexture();
-
-	texture.copy( this );
-
-	texture.images = this.images;
-
-	return texture;
+	var texture = new this.constructor( this.images, this.mapping, this.wrapS, this.wrapT, this.magFilter, this.minFilter, this.format, this.type, this.anisotropy );
+	return texture.copy( this );
 
 };

--- a/src/textures/CubeTexture.js
+++ b/src/textures/CubeTexture.js
@@ -16,9 +16,12 @@ THREE.CubeTexture = function ( images, mapping, wrapS, wrapT, magFilter, minFilt
 THREE.CubeTexture.prototype = Object.create( THREE.Texture.prototype );
 THREE.CubeTexture.prototype.constructor = THREE.CubeTexture;
 
-THREE.CubeTexture.prototype.clone = function () {
+THREE.CubeTexture.prototype.copy = function ( source ) {
 
-	var texture = new this.constructor( this.images, this.mapping, this.wrapS, this.wrapT, this.magFilter, this.minFilter, this.format, this.type, this.anisotropy );
-	return texture.copy( this );
+	THREE.Texture.prototype.copy.call( this, source );
+	
+	this.images = source.images;
+	
+	return this;
 
 };

--- a/src/textures/DataTexture.js
+++ b/src/textures/DataTexture.js
@@ -12,13 +12,3 @@ THREE.DataTexture = function ( data, width, height, format, type, mapping, wrapS
 
 THREE.DataTexture.prototype = Object.create( THREE.Texture.prototype );
 THREE.DataTexture.prototype.constructor = THREE.DataTexture;
-
-THREE.DataTexture.prototype.clone = function () {
-
-	var texture = new THREE.DataTexture();
-
-	texture.copy( this );
-
-	return texture;
-
-};

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -57,8 +57,7 @@ THREE.Texture.prototype = {
 
 	clone: function () {
 
-		var texture = new this.constructor();
-		return texture.copy( this );
+		return new this.constructor().copy( this );
 
 	},
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -57,14 +57,28 @@ THREE.Texture.prototype = {
 
 	clone: function () {
 
-		var texture = new this.constructor( this.image, this.mapping, this.wrapS, this.wrapT, this.magFilter, this.minFilter, this.format, this.type, this.anisotropy );
+		var texture = new this.constructor();
 		return texture.copy( this );
 
 	},
 
 	copy: function ( source ) {
 
+		this.image = source.image;
 		this.mipmaps = source.mipmaps.slice( 0 );
+		
+		this.mapping = source.mapping;		
+		
+		this.wrapS = source.wrapS;		
+		this.wrapT = source.wrapT;		
+		
+		this.magFilter = source.magFilter;		
+		this.minFilter = source.minFilter;		
+		
+		this.anisotropy = source.anisotropy;		
+		
+		this.format = source.format;		
+		this.type = source.type;
 
 		this.offset.copy( source.offset );
 		this.repeat.copy( source.repeat );

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -57,27 +57,14 @@ THREE.Texture.prototype = {
 
 	clone: function () {
 
-		return new THREE.Texture().copy( this );
+		var texture = new this.constructor( this.image, this.mapping, this.wrapS, this.wrapT, this.magFilter, this.minFilter, this.format, this.type, this.anisotropy );
+		return texture.copy( this );
 
 	},
 
 	copy: function ( source ) {
 
-		this.image = source.image;
 		this.mipmaps = source.mipmaps.slice( 0 );
-
-		this.mapping = source.mapping;
-
-		this.wrapS = source.wrapS;
-		this.wrapT = source.wrapT;
-
-		this.magFilter = source.magFilter;
-		this.minFilter = source.minFilter;
-
-		this.anisotropy = source.anisotropy;
-
-		this.format = source.format;
-		this.type = source.type;
 
 		this.offset.copy( source.offset );
 		this.repeat.copy( source.repeat );


### PR DESCRIPTION
Updated clone + copy methods; rearranged methods; fix CubeTexture's clone method:
- Better inheriting of `clone` + `copy` methods where appropriate. This is done by calling `new this.constructor()` in parent classes. `this.constructor` refers to the current instance's constructor, so it should all compose nicely;
- ~~Pass in attributes directly as arguments to constructor when cloning, where appropriate (if arguments pattern is different from parent class). This mean `copy` isn't relied on to set those attributes.~~ Changed my mind. The way it was before –having `copy` take care of carrying over attributes– made sense.
- Change order of `clone` in some files (for better visibility into its relationship with `copy`, and to maintain consistency; can return to previous order if necessary);
- Fix CubeTexture's clone method: it was previously a non-prototypal method.

---

Lots of small changes, so it may need one or two pairs of scrutinous eyes.

---

Addresses #6981
