### PR TITLE
Fix to export of PlaneGeometry type.

### DIFF
--- a/examples/js/exporters/SceneExporter.js
+++ b/examples/js/exporters/SceneExporter.js
@@ -402,10 +402,10 @@ THREE.SceneExporter.prototype = {
 
 				'\t' + LabelString( getGeometryName( g ) ) + ': {',
 				'	"type"    : "plane",',
-				'	"width"  : '  + g.width  + ',',
-				'	"height"  : ' + g.height + ',',
-				'	"widthSegments"  : ' + g.widthSegments + ',',
-				'	"heightSegments" : ' + g.heightSegments,
+				'	"width"  : '  + g.parameters.width  + ',',
+				'	"height"  : ' + g.parameters.height + ',',
+				'	"widthSegments"  : ' + g.parameters.widthSegments + ',',
+				'	"heightSegments" : ' + g.parameters.heightSegments,
 				'}'
 
 				];


### PR DESCRIPTION
Similar to the changes made in the commit:
https://github.com/mrdoob/three.js/commit/91071670f88cfa6a7e3d949fe371e118ac9ff3d4

PlaneGeometry was missed in that fix.
