### PR TITLE
Fix install instructions of Blender export on Mac. fixes #6994

### DIFF
--- a/utils/exporters/blender/README.md
+++ b/utils/exporters/blender/README.md
@@ -30,13 +30,9 @@ OR (for 2.6)
 
 ### OSX
 
-Depends on where blender.app is. Assuming you copied it to your Applications folder:
+In your user's library for user installed Blender addons:
 
-    /Applications/blender.app/Contents/Resources/2.7X/scripts/addons
-    
-OR (for 2.6)
-
-    /Applications/blender.app/Contents/MacOS/2.6X/scripts/addons
+    /Users/(myuser)/Library/Application Support/Blender/2.7X/scripts/addons
 
 ### Linux
 


### PR DESCRIPTION
Fix to #6994

Further improvements to the process are possible too (provide zip or make blender support installing py packages from dirs and not only zips, see issue for details)
