### PR TITLE
Add DefaultMatrixAutoUpdate to Object3D

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -64,7 +64,7 @@ THREE.Object3D = function () {
 	this.matrix = new THREE.Matrix4();
 	this.matrixWorld = new THREE.Matrix4();
 
-	this.matrixAutoUpdate = true;
+	this.matrixAutoUpdate = THREE.Object3D.DefaultMatrixAutoUpdate;
 	this.matrixWorldNeedsUpdate = false;
 
 	this.visible = true;
@@ -80,6 +80,7 @@ THREE.Object3D = function () {
 };
 
 THREE.Object3D.DefaultUp = new THREE.Vector3( 0, 1, 0 );
+THREE.Object3D.DefaultMatrixAutoUpdate = true;
 
 THREE.Object3D.prototype = {
 


### PR DESCRIPTION
For many projects, I end up setting matrixAutoUpdate to false for the majority of objects and manually trigger updateMatrix() as needed. It would be great if this could be set globally on a project basis.
