### PR TITLE
fix MorphBlendMesh setAnimationFps()

### DIFF
--- a/src/extras/objects/MorphBlendMesh.js
+++ b/src/extras/objects/MorphBlendMesh.js
@@ -33,8 +33,8 @@ THREE.MorphBlendMesh.prototype.createAnimation = function ( name, start, end, fp
 
 	var animation = {
 
-		startFrame: start,
-		endFrame: end,
+		start: start,
+		end: end,
 
 		length: end - start + 1,
 
@@ -280,7 +280,7 @@ THREE.MorphBlendMesh.prototype.update = function ( delta ) {
 
 		}
 
-		var keyframe = animation.startFrame + THREE.Math.clamp( Math.floor( animation.time / frameTime ), 0, animation.length - 1 );
+		var keyframe = animation.start + THREE.Math.clamp( Math.floor( animation.time / frameTime ), 0, animation.length - 1 );
 		var weight = animation.weight;
 
 		if ( keyframe !== animation.currentFrame ) {


### PR DESCRIPTION
bugfix for: When setAnimationFPS then animation.duration is NaN.
