### PR TITLE
fix MorphBlendMesh start animation playing

### DIFF
--- a/src/extras/objects/MorphBlendMesh.js
+++ b/src/extras/objects/MorphBlendMesh.js
@@ -299,8 +299,12 @@ THREE.MorphBlendMesh.prototype.update = function ( delta ) {
 
 		if ( animation.directionBackwards ) mix = 1 - mix;
 
-		this.morphTargetInfluences[ animation.currentFrame ] = mix * weight;
-		this.morphTargetInfluences[ animation.lastFrame ] = ( 1 - mix ) * weight;
+		if (animation.currentFrame !== animation.lastFrame) {
+			this.morphTargetInfluences[animation.currentFrame] = mix * weight;
+			this.morphTargetInfluences[animation.lastFrame] = ( 1 - mix ) * weight;
+		} else {
+			this.morphTargetInfluences[animation.currentFrame] = weight;
+		}
 
 	}
 


### PR DESCRIPTION
bugfix: When currentFrame == animation.lastFrame then animation played incorrectly.
