### PR TITLE
Ray casting returns uv coordinates

### DIFF
--- a/examples/webgl_texture_raycast.html
+++ b/examples/webgl_texture_raycast.html
@@ -47,14 +47,14 @@
 			<div class="control">
 				WrapS : <select onchange="setwrapS(this)">
 					<option value="ClampToEdgeWrapping">ClampToEdgeWrapping</option>
-					<option value="RepeatWrapping">RepeatWrapping</option>
+					<option value="RepeatWrapping" selected>RepeatWrapping</option>
 					<option value="MirroredRepeatWrapping">MirroredRepeatWrapping</option>
 				</select>
 			</div>
 			<div class="control">
 				WrapT : <select onchange="setwrapT(this)">
 					<option value="ClampToEdgeWrapping">ClampToEdgeWrapping</option>
-					<option value="RepeatWrapping">RepeatWrapping</option>
+					<option value="RepeatWrapping" selected>RepeatWrapping</option>
 					<option value="MirroredRepeatWrapping">MirroredRepeatWrapping</option>
 				</select>
 			</div>
@@ -70,33 +70,34 @@
 		<script src="../build/three.min.js"></script>
 		<script>
 
-			CanvasTexture = function (parentTexture) {
+			CanvasTexture = function ( parentTexture ) {
 
-				this._canvas = document.createElement("canvas");
-				this._context2D = this._canvas.getContext("2d");
+				this._canvas = document.createElement( "canvas" );
+				this._canvas.width = this._canvas.height = 1024;
+				this._context2D = this._canvas.getContext( "2d" );
 
-				if (parentTexture) {
+				if ( parentTexture ) {
 
-					this._parentTexture.push(parentTexture);
+					this._parentTexture.push( parentTexture );
 					parentTexture.image = this._canvas;
 
 				}
 
 				var that = this;
-				this._background = document.createElement("img");
-				this._background.addEventListener("load", function (event) {
+				this._background = document.createElement( "img" );
+				this._background.addEventListener( "load", function ( event ) {
 
 					that._canvas.width = that._background.naturalWidth;
 					that._canvas.height = that._background.naturalHeight;
 
-					that._rayonviseur = Math.ceil(Math.min(that._canvas.width, that._canvas.height / 30));
-					that._exterieurCroix = Math.ceil(0.70710678 * that._rayonviseur);
-					that._interieurCroix = Math.ceil(that._exterieurCroix / 10);
-					that._epaisseurViseur = Math.ceil(that._exterieurCroix / 10);
+					that._crossRadius = Math.ceil( Math.min( that._canvas.width, that._canvas.height / 30 ) );
+					that._crossMax = Math.ceil( 0.70710678 * that._crossRadius );
+					that._crossMin = Math.ceil( that._crossMax / 10 );
+					that._crossThickness = Math.ceil( that._crossMax / 10 );
 
 					that._draw();
 
-				}, false);
+				}, false );
 				this._background.crossOrigin = '';
 				this._background.src = "textures/UV_Grid_Sm.jpg";
 
@@ -114,25 +115,25 @@
 				_xCross: 0,
 				_yCross: 0,
 
-				_rayonviseur: 57,
-				_exterieurCroix: 40,
-				_interieurCroix: 4,
-				_epaisseurViseur: 4,
+				_crossRadius: 57,
+				_crossMax: 40,
+				_crossMin: 4,
+				_crossThickness: 4,
 
 				_parentTexture: [],
 
-				addParent: function (parentTexture) {
+				addParent: function ( parentTexture ) {
 
-					if (this._parentTexture.indexOf(parentTexture) === -1) {
+					if ( this._parentTexture.indexOf( parentTexture ) === - 1 ) {
 
-						this._parentTexture.push(parentTexture);
+						this._parentTexture.push( parentTexture );
 						parentTexture.image = this._canvas;
 
 					}
 
 				},
 
-				setCrossPosition: function (x, y) {
+				setCrossPosition: function ( x, y ) {
 
 					this._xCross = x * this._canvas.width;
 					this._yCross = y * this._canvas.height;
@@ -143,36 +144,35 @@
 
 				_draw: function () {
 
-					if (!this._context2D) return;
+					if ( ! this._context2D ) return;
 
-					this._context2D.clearRect(0, 0, this._canvas.width, this._canvas.height)
+					this._context2D.clearRect( 0, 0, this._canvas.width, this._canvas.height )
 
 					// Background.
-					this._context2D.drawImage(this._background, 0, 0);
+					this._context2D.drawImage( this._background, 0, 0 );
 
 					// Yellow cross.
-					this._context2D.lineWidth = this._epaisseurViseur * 3;
+					this._context2D.lineWidth = this._crossThickness * 3;
 					this._context2D.strokeStyle = "#FFFF00";
 
 					this._context2D.beginPath();
-					this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross - this._exterieurCroix - 2);
-					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross - this._interieurCroix);
+					this._context2D.moveTo( this._xCross - this._crossMax - 2, this._yCross - this._crossMax - 2 );
+					this._context2D.lineTo( this._xCross - this._crossMin, this._yCross - this._crossMin );
 
-					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross + this._interieurCroix);
-					this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross + this._exterieurCroix + 2);
+					this._context2D.moveTo( this._xCross + this._crossMin, this._yCross + this._crossMin );
+					this._context2D.lineTo( this._xCross + this._crossMax + 2, this._yCross + this._crossMax + 2 );
 
-					this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross + this._exterieurCroix + 2);
-					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross + this._interieurCroix);
+					this._context2D.moveTo( this._xCross - this._crossMax - 2, this._yCross + this._crossMax + 2 );
+					this._context2D.lineTo( this._xCross - this._crossMin, this._yCross + this._crossMin );
 
-					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross - this._interieurCroix);
-					this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross - this._exterieurCroix - 2);
+					this._context2D.moveTo( this._xCross + this._crossMin, this._yCross - this._crossMin );
+					this._context2D.lineTo( this._xCross + this._crossMax + 2, this._yCross - this._crossMax - 2 );
 
 					this._context2D.stroke();
 
-					for (var i = 0; i < this._parentTexture.length; i++) {
-					
-						//this._parentTexture[i].image = this._canvas;
-						this._parentTexture[i].needsUpdate = true;
+					for ( var i = 0; i < this._parentTexture.length; i ++ ) {
+
+						this._parentTexture[ i ].needsUpdate = true;
 
 					}
 
@@ -200,87 +200,89 @@
 
 			init();
 			render();
-			
+
 			function init() {
 
-				container = document.getElementById("container");
+				container = document.getElementById( "container" );
 
 				scene = new THREE.Scene();
 
-				camera = new THREE.PerspectiveCamera(45, width / height, 1, 1000);
-				camera.position.x = -30;
+				camera = new THREE.PerspectiveCamera( 45, width / height, 1, 1000 );
+				camera.position.x = - 30;
 				camera.position.y = 40;
 				camera.position.z = 50;
-				camera.lookAt(scene.position);
-			
+				camera.lookAt( scene.position );
+
 				renderer = new THREE.WebGLRenderer();
-				renderer.setClearColor(new THREE.Color(0xEEEEEE, 1.0));
-				renderer.setSize(width, height);
-				container.appendChild(renderer.domElement);
+				renderer.setClearColor( new THREE.Color( 0xEEEEEE, 1.0 ) );
+				renderer.setSize( width, height );
+				container.appendChild( renderer.domElement );
 
 				// A cube, in the middle.
-				cubeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping);
-				canvas = new CanvasTexture(cubeTexture);
-				var cubeMaterial = new THREE.MeshBasicMaterial({ map: cubeTexture });
-				var cubeGeometry = new THREE.BoxGeometry(20, 20, 20);
+				cubeTexture = new THREE.Texture( undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping );
+				canvas = new CanvasTexture( cubeTexture );
+				var cubeMaterial = new THREE.MeshBasicMaterial( { map: cubeTexture } );
+				var cubeGeometry = new THREE.BoxGeometry( 20, 20, 20 );
 				// Set a specific texture mapping.
 				var uvs;
-				for (var i = 0; i < cubeGeometry.faceVertexUvs[0].length; i++) {
+				for ( var i = 0; i < cubeGeometry.faceVertexUvs[ 0 ].length; i ++ ) {
 
-					uvs = cubeGeometry.faceVertexUvs[0][i];
-					for (var j = 0; j < 3; j++) {
+					uvs = cubeGeometry.faceVertexUvs[ 0 ][ i ];
+					for ( var j = 0; j < 3; j ++ ) {
 
-						if (uvs[j].x < 0.1) uvs[j].x = -1;
-						if (uvs[j].y < 0.1) uvs[j].y = -1;
+						if ( uvs[ j ].x < 0.1 ) uvs[ j ].x = - 1;
+						if ( uvs[ j ].y < 0.1 ) uvs[ j ].y = - 1;
 
 					}
 
 				}
-				var cube = new THREE.Mesh(cubeGeometry, cubeMaterial);
+				var cube = new THREE.Mesh( cubeGeometry, cubeMaterial );
 				cube.position.x = 4;
-				cube.position.y = -5;
+				cube.position.y = - 5;
 				cube.position.z = 0;
-				objects.push(cube);
-				scene.add(cube);
+				objects.push( cube );
+				scene.add( cube );
 
 				// A plane on the left.
-				planeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.MirroredRepeatWrapping, THREE.MirroredRepeatWrapping);
-				canvas.addParent(planeTexture);
-				var planeMaterial = new THREE.MeshBasicMaterial({ map: planeTexture });
-				var planeGeometry = new THREE.PlaneBufferGeometry(25, 25, 1, 1);
+				planeTexture = new THREE.Texture( undefined, THREE.UVMapping, THREE.MirroredRepeatWrapping, THREE.MirroredRepeatWrapping );
+				canvas.addParent( planeTexture );
+				var planeMaterial = new THREE.MeshBasicMaterial( { map: planeTexture } );
+				var planeGeometry = new THREE.PlaneBufferGeometry( 25, 25, 1, 1 );
 				var uvs = planeGeometry.attributes.uv.array;
-				for (var i = 0; i < uvs.length; i++) {
+				// Set a specific texture mapping.
+				for ( var i = 0; i < uvs.length; i ++ ) {
 
-					uvs[i] *= 2;
+					uvs[ i ] *= 2;
 
 				}
-				var plane = new THREE.Mesh(planeGeometry, planeMaterial);
-				plane.position.x = -16;
-				plane.position.y = -5;
+				var plane = new THREE.Mesh( planeGeometry, planeMaterial );
+				plane.position.x = - 16;
+				plane.position.y = - 5;
 				plane.position.z = 0;
-				objects.push(plane);
-				scene.add(plane);
+				objects.push( plane );
+				scene.add( plane );
 
 				// A circle on the right.
-				circleTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.ClampToEdgeWrapping, THREE.ClampToEdgeWrapping);
-				canvas.addParent(circleTexture);
-				var circleMaterial = new THREE.MeshBasicMaterial({ map: circleTexture });
-				var circleGeometry = new THREE.CircleBufferGeometry(25, 40, 0, Math.PI * 2);
+				circleTexture = new THREE.Texture( undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping );
+				canvas.addParent( circleTexture );
+				var circleMaterial = new THREE.MeshBasicMaterial( { map: circleTexture } );
+				var circleGeometry = new THREE.CircleBufferGeometry( 25, 40, 0, Math.PI * 2 );
 				var uvs = circleGeometry.attributes.uv.array;
-				for (var i = 0; i < uvs.length; i++) {
+				// Set a specific texture mapping.
+				for ( var i = 0; i < uvs.length; i ++ ) {
 
-					uvs[i] = (uvs[i] - 0.25) * 2;
+					uvs[ i ] = ( uvs[ i ] - 0.25 ) * 2;
 
 				}
-				var circle = new THREE.Mesh(circleGeometry, circleMaterial);
+				var circle = new THREE.Mesh( circleGeometry, circleMaterial );
 				circle.position.x = 24;
-				circle.position.y = -5;
+				circle.position.y = - 5;
 				circle.position.z = 0;
-				objects.push(circle);
-				scene.add(circle);
+				objects.push( circle );
+				scene.add( circle );
 
-				window.addEventListener('resize', onWindowResize, false);
-				container.addEventListener('click', onClick, false);
+				window.addEventListener( 'resize', onWindowResize, false );
+				container.addEventListener( 'click', onClick, false );
 
 			}
 
@@ -289,89 +291,90 @@
 				camera.aspect = window.innerWidth / window.innerHeight;
 				camera.updateProjectionMatrix();
 
-				renderer.setSize(window.innerWidth, window.innerHeight);
+				renderer.setSize( window.innerWidth, window.innerHeight );
 
 			};
 
-			function onClick(evt) {
+			function onClick( evt ) {
 
 				evt.preventDefault();
 
-				var array = getMousePosition(container, evt.clientX, evt.clientY);
-				onClickPosition.fromArray(array);
+				var array = getMousePosition( container, evt.clientX, evt.clientY );
+				onClickPosition.fromArray( array );
 
-				var intersects = getIntersects(onClickPosition, objects);
-				if (intersects.length > 0 && intersects[0].uv) {
+				var intersects = getIntersects( onClickPosition, objects );
+				if ( intersects.length > 0 && intersects[ 0 ].uv ) {
 
-					var uv = intersects[0].uv;
-					intersects[0].object.material.map.transformUv(uv);
-					canvas.setCrossPosition(uv.x, uv.y);
+					var uv = intersects[ 0 ].uv;
+					intersects[ 0 ].object.material.map.transformUv( uv );
+					canvas.setCrossPosition( uv.x, uv.y );
 
 				}
 
 			};
 
-			var getMousePosition = function (dom, x, y) {
+			var getMousePosition = function ( dom, x, y ) {
 
 				var rect = dom.getBoundingClientRect();
-				return [(x - rect.left) / rect.width, (y - rect.top) / rect.height];
+				return [ ( x - rect.left ) / rect.width, ( y - rect.top ) / rect.height ];
 
 			};
 
-			var getIntersects = function (point, objects) {
+			var getIntersects = function ( point, objects ) {
 
-				mouse.set((point.x * 2) - 1, -(point.y * 2) + 1);
+				mouse.set( ( point.x * 2 ) - 1, - ( point.y * 2 ) + 1 );
 
-				raycaster.setFromCamera(mouse, camera);
+				raycaster.setFromCamera( mouse, camera );
 
-				return raycaster.intersectObjects(objects);
+				return raycaster.intersectObjects( objects );
 
 			};
 
 			function render() {
 
-				requestAnimationFrame(render);
-				renderer.render(scene, camera);
+				requestAnimationFrame( render );
+				renderer.render( scene, camera );
 
 			};
 
-			function setwrapS(that) {
+			function setwrapS( that ) {
 
-				circleTexture.wrapS = THREE[that.value];
+				circleTexture.wrapS = THREE[ that.value ];
 				circleTexture.needsUpdate = true;
 
 			};
 
-			function setwrapT(that) {
+			function setwrapT( that ) {
 
-				circleTexture.wrapT = THREE[that.value];
+				circleTexture.wrapT = THREE[ that.value ];
 				circleTexture.needsUpdate = true;
 
 			};
 
-			function setOffsetU(that) {
+			function setOffsetU( that ) {
 
-				circleTexture.offset.x = parseFloat(that.value);
-
-			};
-
-			function setOffsetV(that) {
-
-				circleTexture.offset.y = parseFloat(that.value);
+				circleTexture.offset.x = parseFloat( that.value );
 
 			};
 
-			function setRepeatU(that) {
+			function setOffsetV( that ) {
 
-				circleTexture.repeat.x = parseFloat(that.value);
+				circleTexture.offset.y = parseFloat( that.value );
+
+			};
+
+			function setRepeatU( that ) {
+
+				circleTexture.repeat.x = parseFloat( that.value );
 
 			};
 
-			function setRepeatV(that) {
+			function setRepeatV( that ) {
 
-				circleTexture.repeat.y = parseFloat(that.value);
+				circleTexture.repeat.y = parseFloat( that.value );
 
 			};
+
 		</script>
 	</body>
 </html>

--- a/examples/webgl_texture_raycast.html
+++ b/examples/webgl_texture_raycast.html
@@ -21,249 +21,295 @@
 				top: 0px; width: 100%;
 				padding: 5px;
 			}
+
+			#controls {
+				position: absolute;
+				text-align:left;
+				top: 40px;
+				left: 5px;
+				padding: 5px;
+			}
+
+			.control {
+				margin-bottom: 3px;
+			}
+
+			input {
+				width: 50px;
+			}
 		</style>
 	</head>
 	<body>
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - texture intersection<br>Left to right: buffer geometry - geometry - indexed buffer geometry</div>
-		<!--<script src="../build/three.min.js"></script>-->
-		<script src="../build/three.js"></script>
+		<fieldset id="controls">
+			<legend>Circle</legend>
+			<div class="control">
+				WrapS : <select onchange="setwrapS(this)">
+					<option value="ClampToEdgeWrapping">ClampToEdgeWrapping</option>
+					<option value="RepeatWrapping">RepeatWrapping</option>
+					<option value="MirroredRepeatWrapping">MirroredRepeatWrapping</option>
+				</select>
+			</div>
+			<div class="control">
+				WrapT : <select onchange="setwrapT(this)">
+					<option value="ClampToEdgeWrapping">ClampToEdgeWrapping</option>
+					<option value="RepeatWrapping">RepeatWrapping</option>
+					<option value="MirroredRepeatWrapping">MirroredRepeatWrapping</option>
+				</select>
+			</div>
+			<div class="control">
+				Offset : X <input type="number" value="0" step="0.05" onchange="setOffsetU(this)" />
+				Y <input type="number" value="0" step="0.05" onchange="setOffsetV(this)" /><br />
+			</div>
+			<div class="control">
+				Repeat : X <input type="number" value="1" step="0.1" onchange="setRepeatU(this)" />
+				Y <input type="number" value="1" step="0.1" onchange="setRepeatV(this)" />
+			</div>
+		</fieldset>
+		<script src="../build/three.min.js"></script>
 		<script>
-			CanvasTexture = function(parentTexture) {
-				this._canvas = document.createElement("canvas");
-				this._context2D = this._canvas.getContext("2d");
+		CanvasTexture = function (parentTexture) {
+			this._canvas = document.createElement("canvas");
+			this._context2D = this._canvas.getContext("2d");
 
-				if (parentTexture) {
+			if (parentTexture) {
+				this._parentTexture.push(parentTexture);
+				parentTexture.image = this._canvas;
+			}
+
+			var that = this;
+			this._background = document.createElement("img");
+			this._background.addEventListener("load", function (event) {
+				that._canvas.width = that._background.naturalWidth;
+				that._canvas.height = that._background.naturalHeight;
+
+				that._rayonviseur = Math.ceil(Math.min(that._canvas.width, that._canvas.height / 30));
+				that._exterieurCroix = Math.ceil(0.70710678 * that._rayonviseur);
+				that._interieurCroix = Math.ceil(that._exterieurCroix / 10);
+				that._epaisseurViseur = Math.ceil(that._exterieurCroix / 10);
+
+				that._draw();
+			}, false);
+			this._background.crossOrigin = '';
+			this._background.src = "textures/UV_Grid_Sm.jpg";
+
+			this._draw();
+		}
+
+
+		CanvasTexture.prototype = {
+
+			constructor: CanvasTexture,
+
+			_canvas: null,
+			_context2D: null,
+			_xCross: 0,
+			_yCross: 0,
+
+			_rayonviseur: 57,
+			_exterieurCroix: 40,
+			_interieurCroix: 4,
+			_epaisseurViseur: 4,
+
+			_parentTexture: [],
+
+			addParent: function (parentTexture) {
+				if (this._parentTexture.indexOf(parentTexture) === -1) {
 					this._parentTexture.push(parentTexture);
 					parentTexture.image = this._canvas;
 				}
+			},
 
-				var that = this;
-				this._background = document.createElement("img");
-				this._background.addEventListener("load", function (event) {
-					that._canvas.width = that._background.naturalWidth;
-					that._canvas.height = that._background.naturalHeight;
-				
-					that._rayonviseur = Math.ceil(Math.min(that._canvas.width, that._canvas.height / 30));
-					that._exterieurCroix = Math.ceil(0.70710678 * that._rayonviseur);
-					that._interieurCroix = Math.ceil(that._exterieurCroix / 10);
-					that._epaisseurViseur = Math.ceil(that._exterieurCroix / 10);
-					
-					that._draw();
-				}, false);
-				this._background.crossOrigin = '';
-				this._background.src = "textures/UV_Grid_Sm.jpg";
+			setCrossPosition: function (x, y) {
+				this._xCross = x * this._canvas.width;
+				this._yCross = y * this._canvas.height;
 
 				this._draw();
-			}
+			},
 
+			_draw: function () {
+				if (!this._context2D) return;
 
-			CanvasTexture.prototype = {
+				this._context2D.clearRect(0, 0, this._canvas.width, this._canvas.height)
 
-				constructor: CanvasTexture,
+				// Background.
+				this._context2D.drawImage(this._background, 0, 0);
 
-				_canvas: null,
-				_context2D: null,
-				_xCross: 0,
-				_yCross: 0,
-				
-				_rayonviseur: 57,
-				_exterieurCroix: 40,
-				_interieurCroix: 4,
-				_epaisseurViseur: 4,
+				// Yellow cross.
+				this._context2D.lineWidth = this._epaisseurViseur * 3;
+				this._context2D.strokeStyle = "#FFFF00";
 
-				_parentTexture: [],
+				this._context2D.beginPath();
+				this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross - this._exterieurCroix - 2);
+				this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross - this._interieurCroix);
 
-				addParent: function (parentTexture) {
-					if (this._parentTexture.indexOf(parentTexture) === -1) {
-						this._parentTexture.push(parentTexture);
-						parentTexture.image = this._canvas;
-					}
-				 },
-				
-				setCrossPosition: function (x, y) {
-					this._xCross = x * this._canvas.width;
-					this._yCross = y * this._canvas.height;
-					
-					this._draw();
-				},
-				
-				_draw: function () {
-					if (!this._context2D) return;
+				this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross + this._interieurCroix);
+				this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross + this._exterieurCroix + 2);
 
-					this._context2D.clearRect(0, 0, this._canvas.width, this._canvas.height)
+				this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross + this._exterieurCroix + 2);
+				this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross + this._interieurCroix);
 
-					// Background.
-					this._context2D.drawImage(this._background, 0, 0);
+				this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross - this._interieurCroix);
+				this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross - this._exterieurCroix - 2);
 
-					// White cross.
-					this._context2D.lineWidth = this._epaisseurViseur * 3;
-					this._context2D.strokeStyle = "#FFFFFF";
+				this._context2D.stroke();
 
-					this._context2D.beginPath();
-					this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross - this._exterieurCroix -2);
-					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross - this._interieurCroix);
-
-					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross + this._interieurCroix);
-					this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross + this._exterieurCroix + 2);
-
-					this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross + this._exterieurCroix + 2);
-					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross + this._interieurCroix);
-
-					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross - this._interieurCroix);
-					this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross - this._exterieurCroix - 2);
-
-					this._context2D.stroke();
-					
-					// Black cross.
-					this._context2D.lineWidth = this._epaisseurViseur;
-					this._context2D.strokeStyle = "#000000";
-
-					this._context2D.beginPath();
-					this._context2D.moveTo(this._xCross - this._exterieurCroix, this._yCross - this._exterieurCroix);
-					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross - this._interieurCroix);
-
-					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross + this._interieurCroix);
-					this._context2D.lineTo(this._xCross + this._exterieurCroix, this._yCross + this._exterieurCroix);
-
-					this._context2D.moveTo(this._xCross - this._exterieurCroix, this._yCross + this._exterieurCroix);
-					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross + this._interieurCroix);
-
-					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross - this._interieurCroix);
-					this._context2D.lineTo(this._xCross + this._exterieurCroix, this._yCross - this._exterieurCroix);
-
-					this._context2D.stroke();
-					
-					for (var i = 0; i < this._parentTexture.length; i++) {
-						//this._parentTexture[i].image = this._canvas;
-						this._parentTexture[i].needsUpdate = true;
-					}
-
+				for (var i = 0; i < this._parentTexture.length; i++) {
+					//this._parentTexture[i].image = this._canvas;
+					this._parentTexture[i].needsUpdate = true;
 				}
 
 			}
-		</script>
-		<script>
 
-			var container = document.getElementById("container");
-			var width = window.innerWidth;
-			var height = window.innerHeight ;
-			var objects = [];
+		}
+	</script>
+	<script>
 
-			var scene = new THREE.Scene();
-			var camera = new THREE.PerspectiveCamera(45, width / height, 1, 1000);
-			camera.position.x = -30;
-			camera.position.y = 40;
-			camera.position.z = 50;
-			camera.lookAt(scene.position);
+		var container = document.getElementById("container");
+		var width = window.innerWidth;
+		var height = window.innerHeight;
+		var objects = [];
 
-			var raycaster = new THREE.Raycaster();
-			var mouse = new THREE.Vector2();
-			var onClickPosition = new THREE.Vector2();
+		var scene = new THREE.Scene();
+		var camera = new THREE.PerspectiveCamera(45, width / height, 1, 1000);
+		camera.position.x = -30;
+		camera.position.y = 40;
+		camera.position.z = 50;
+		camera.lookAt(scene.position);
 
-			var getMousePosition = function (dom, x, y) {
-				var rect = dom.getBoundingClientRect();
-				return [(x - rect.left) / rect.width, (y - rect.top) / rect.height];
-			};
+		var raycaster = new THREE.Raycaster();
+		var mouse = new THREE.Vector2();
+		var onClickPosition = new THREE.Vector2();
 
-			var getIntersects = function (point, objects) {
-				mouse.set((point.x * 2) - 1, -(point.y * 2) + 1);
+		var getMousePosition = function (dom, x, y) {
+			var rect = dom.getBoundingClientRect();
+			return [(x - rect.left) / rect.width, (y - rect.top) / rect.height];
+		};
 
-				raycaster.setFromCamera(mouse, camera);
+		var getIntersects = function (point, objects) {
+			mouse.set((point.x * 2) - 1, -(point.y * 2) + 1);
 
-				return raycaster.intersectObjects(objects);
-			};
+			raycaster.setFromCamera(mouse, camera);
 
-			window.addEventListener('resize', function(evt) {
-				camera.aspect = window.innerWidth / window.innerHeight;
-				camera.updateProjectionMatrix();
+			return raycaster.intersectObjects(objects);
+		};
 
-				renderer.setSize( window.innerWidth, window.innerHeight );
-			}, false);
+		window.addEventListener('resize', function (evt) {
+			camera.aspect = window.innerWidth / window.innerHeight;
+			camera.updateProjectionMatrix();
 
-			container.addEventListener('click', function(evt) {
-				evt.preventDefault();
+			renderer.setSize(window.innerWidth, window.innerHeight);
+		}, false);
 
-				var array = getMousePosition(container, evt.clientX, evt.clientY);
-				onClickPosition.fromArray(array);
+		container.addEventListener('click', function (evt) {
+			evt.preventDefault();
 
-				var intersects = getIntersects(onClickPosition, objects);
-				if (intersects.length > 0) {
-					if (intersects[0].uv) {
-						var uv = intersects[0].uv;
-						intersects[0].object.material.map.transformUv(uv);
-						canvas.setCrossPosition(uv.x, uv.y);
-					}
-				}
-			}, false);
+			var array = getMousePosition(container, evt.clientX, evt.clientY);
+			onClickPosition.fromArray(array);
 
-
-			var renderer = new THREE.WebGLRenderer();
-			renderer.setClearColor(new THREE.Color(0xEEEEEE, 1.0));
-			renderer.setSize(width, height);
-			container.appendChild(renderer.domElement);
-
-			// A cube, in the middle.
-			var cubeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping);
-			var canvas = new CanvasTexture(cubeTexture);
-			var cubeMaterial = new THREE.MeshBasicMaterial( { map: cubeTexture } );
-			var cubeGeometry = new THREE.BoxGeometry(20, 20, 20);
-			// Set a specific texture mapping.
-			var uvs;
-			for (var i = 0; i < cubeGeometry.faceVertexUvs[0].length; i++) {
-				uvs = cubeGeometry.faceVertexUvs[0][i];
-				for (var j = 0; j < 3; j++) {
-					if (uvs[j].x < 0.1) uvs[j].x = -1;
-					if (uvs[j].y < 0.1) uvs[j].y = -1;
+			var intersects = getIntersects(onClickPosition, objects);
+			if (intersects.length > 0) {
+				if (intersects[0].uv) {
+					var uv = intersects[0].uv;
+					intersects[0].object.material.map.transformUv(uv);
+					canvas.setCrossPosition(uv.x, uv.y);
 				}
 			}
-			var cube = new THREE.Mesh(cubeGeometry, cubeMaterial);
-			cube.position.x = 4;
-			cube.position.y = -5;
-			cube.position.z = 0;
-			objects.push(cube);
-			scene.add(cube);
+		}, false);
 
-			// A plane on the left.
-			var planeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.MirroredRepeatWrapping, THREE.MirroredRepeatWrapping);
-			canvas.addParent(planeTexture);
-			var planeMaterial = new THREE.MeshBasicMaterial( { map: planeTexture } );
-			var planeGeometry = new THREE.PlaneBufferGeometry(25, 25, 1, 1);
-			var uvs = planeGeometry.attributes.uv.array;
-			for (var i = 0; i < uvs.length; i++) {
-				//if (uvs[i] < 0.1) uvs[i] = -1;
-				uvs[i] *= 2;
+
+		var renderer = new THREE.WebGLRenderer();
+		renderer.setClearColor(new THREE.Color(0xEEEEEE, 1.0));
+		renderer.setSize(width, height);
+		container.appendChild(renderer.domElement);
+
+		// A cube, in the middle.
+		var cubeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping);
+		var canvas = new CanvasTexture(cubeTexture);
+		var cubeMaterial = new THREE.MeshBasicMaterial({ map: cubeTexture });
+		var cubeGeometry = new THREE.BoxGeometry(20, 20, 20);
+		// Set a specific texture mapping.
+		var uvs;
+		for (var i = 0; i < cubeGeometry.faceVertexUvs[0].length; i++) {
+			uvs = cubeGeometry.faceVertexUvs[0][i];
+			for (var j = 0; j < 3; j++) {
+				if (uvs[j].x < 0.1) uvs[j].x = -1;
+				if (uvs[j].y < 0.1) uvs[j].y = -1;
 			}
-			var plane = new THREE.Mesh(planeGeometry, planeMaterial);
-			plane.position.x = -16;
-			plane.position.y = -5;
-			plane.position.z = 0;
-			objects.push(plane);
-			scene.add(plane);
+		}
+		var cube = new THREE.Mesh(cubeGeometry, cubeMaterial);
+		cube.position.x = 4;
+		cube.position.y = -5;
+		cube.position.z = 0;
+		objects.push(cube);
+		scene.add(cube);
 
-			// A circle on the left.
-			var circleTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.MirroredRepeatWrapping);
-			canvas.addParent(circleTexture);
-			var circleMaterial = new THREE.MeshBasicMaterial( { map: circleTexture } );
-			var circleGeometry = new THREE.CircleBufferGeometry(25, 40, 0, Math.PI * 2);
-			var uvs = circleGeometry.attributes.uv.array;
-			for (var i = 0; i < uvs.length; i++) {
-				uvs[i] *= 2;
-			}
-			var circle = new THREE.Mesh(circleGeometry, circleMaterial);
-			circle.position.x = 24;
-			circle.position.y = -5;
-			circle.position.z = 0;
-			objects.push(circle);
-			scene.add(circle);
-			
-			render();
+		// A plane on the left.
+		var planeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.MirroredRepeatWrapping, THREE.MirroredRepeatWrapping);
+		canvas.addParent(planeTexture);
+		var planeMaterial = new THREE.MeshBasicMaterial({ map: planeTexture });
+		var planeGeometry = new THREE.PlaneBufferGeometry(25, 25, 1, 1);
+		var uvs = planeGeometry.attributes.uv.array;
+		for (var i = 0; i < uvs.length; i++) {
+			//if (uvs[i] < 0.1) uvs[i] = -1;
+			uvs[i] *= 2;
+		}
+		var plane = new THREE.Mesh(planeGeometry, planeMaterial);
+		plane.position.x = -16;
+		plane.position.y = -5;
+		plane.position.z = 0;
+		objects.push(plane);
+		scene.add(plane);
 
-			function render() {
-				requestAnimationFrame(render);
-				renderer.render(scene, camera);
-			};
+		// A circle on the left.
+		var circleTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.ClampToEdgeWrapping, THREE.ClampToEdgeWrapping);
+		canvas.addParent(circleTexture);
+		var circleMaterial = new THREE.MeshBasicMaterial({ map: circleTexture });
+		var circleGeometry = new THREE.CircleBufferGeometry(25, 40, 0, Math.PI * 2);
+		var uvs = circleGeometry.attributes.uv.array;
+		for (var i = 0; i < uvs.length; i++) {
+			uvs[i] = (uvs[i] - 0.25) * 2;
+		}
+		var circle = new THREE.Mesh(circleGeometry, circleMaterial);
+		circle.position.x = 24;
+		circle.position.y = -5;
+		circle.position.z = 0;
+		objects.push(circle);
+		scene.add(circle);
 
+		render();
+
+		function render() {
+			requestAnimationFrame(render);
+			renderer.render(scene, camera);
+		};
+
+		function setwrapS(that) {
+			circleTexture.wrapS = THREE[that.value];
+			circleTexture.needsUpdate = true;
+		};
+
+		function setwrapT(that) {
+			circleTexture.wrapT = THREE[that.value];
+			circleTexture.needsUpdate = true;
+		};
+
+		function setOffsetU(that) {
+			circleTexture.offset.x = parseFloat(that.value);
+		};
+
+		function setOffsetV(that) {
+			circleTexture.offset.y = parseFloat(that.value);
+		};
+
+		function setRepeatU(that) {
+			circleTexture.repeat.x = parseFloat(that.value);
+		};
+
+		function setRepeatV(that) {
+			circleTexture.repeat.y = parseFloat(that.value);
+		};
 		</script>
 	</body>
 </html>

--- a/examples/webgl_texture_raycast.html
+++ b/examples/webgl_texture_raycast.html
@@ -69,247 +69,309 @@
 		</fieldset>
 		<script src="../build/three.min.js"></script>
 		<script>
-		CanvasTexture = function (parentTexture) {
-			this._canvas = document.createElement("canvas");
-			this._context2D = this._canvas.getContext("2d");
 
-			if (parentTexture) {
-				this._parentTexture.push(parentTexture);
-				parentTexture.image = this._canvas;
-			}
+			CanvasTexture = function (parentTexture) {
 
-			var that = this;
-			this._background = document.createElement("img");
-			this._background.addEventListener("load", function (event) {
-				that._canvas.width = that._background.naturalWidth;
-				that._canvas.height = that._background.naturalHeight;
+				this._canvas = document.createElement("canvas");
+				this._context2D = this._canvas.getContext("2d");
 
-				that._rayonviseur = Math.ceil(Math.min(that._canvas.width, that._canvas.height / 30));
-				that._exterieurCroix = Math.ceil(0.70710678 * that._rayonviseur);
-				that._interieurCroix = Math.ceil(that._exterieurCroix / 10);
-				that._epaisseurViseur = Math.ceil(that._exterieurCroix / 10);
+				if (parentTexture) {
 
-				that._draw();
-			}, false);
-			this._background.crossOrigin = '';
-			this._background.src = "textures/UV_Grid_Sm.jpg";
-
-			this._draw();
-		}
-
-
-		CanvasTexture.prototype = {
-
-			constructor: CanvasTexture,
-
-			_canvas: null,
-			_context2D: null,
-			_xCross: 0,
-			_yCross: 0,
-
-			_rayonviseur: 57,
-			_exterieurCroix: 40,
-			_interieurCroix: 4,
-			_epaisseurViseur: 4,
-
-			_parentTexture: [],
-
-			addParent: function (parentTexture) {
-				if (this._parentTexture.indexOf(parentTexture) === -1) {
 					this._parentTexture.push(parentTexture);
 					parentTexture.image = this._canvas;
-				}
-			},
 
-			setCrossPosition: function (x, y) {
-				this._xCross = x * this._canvas.width;
-				this._yCross = y * this._canvas.height;
+				}
+
+				var that = this;
+				this._background = document.createElement("img");
+				this._background.addEventListener("load", function (event) {
+
+					that._canvas.width = that._background.naturalWidth;
+					that._canvas.height = that._background.naturalHeight;
+
+					that._rayonviseur = Math.ceil(Math.min(that._canvas.width, that._canvas.height / 30));
+					that._exterieurCroix = Math.ceil(0.70710678 * that._rayonviseur);
+					that._interieurCroix = Math.ceil(that._exterieurCroix / 10);
+					that._epaisseurViseur = Math.ceil(that._exterieurCroix / 10);
+
+					that._draw();
+
+				}, false);
+				this._background.crossOrigin = '';
+				this._background.src = "textures/UV_Grid_Sm.jpg";
 
 				this._draw();
-			},
 
-			_draw: function () {
-				if (!this._context2D) return;
+			}
 
-				this._context2D.clearRect(0, 0, this._canvas.width, this._canvas.height)
 
-				// Background.
-				this._context2D.drawImage(this._background, 0, 0);
+			CanvasTexture.prototype = {
 
-				// Yellow cross.
-				this._context2D.lineWidth = this._epaisseurViseur * 3;
-				this._context2D.strokeStyle = "#FFFF00";
+				constructor: CanvasTexture,
 
-				this._context2D.beginPath();
-				this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross - this._exterieurCroix - 2);
-				this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross - this._interieurCroix);
+				_canvas: null,
+				_context2D: null,
+				_xCross: 0,
+				_yCross: 0,
 
-				this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross + this._interieurCroix);
-				this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross + this._exterieurCroix + 2);
+				_rayonviseur: 57,
+				_exterieurCroix: 40,
+				_interieurCroix: 4,
+				_epaisseurViseur: 4,
 
-				this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross + this._exterieurCroix + 2);
-				this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross + this._interieurCroix);
+				_parentTexture: [],
 
-				this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross - this._interieurCroix);
-				this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross - this._exterieurCroix - 2);
+				addParent: function (parentTexture) {
 
-				this._context2D.stroke();
+					if (this._parentTexture.indexOf(parentTexture) === -1) {
 
-				for (var i = 0; i < this._parentTexture.length; i++) {
-					//this._parentTexture[i].image = this._canvas;
-					this._parentTexture[i].needsUpdate = true;
+						this._parentTexture.push(parentTexture);
+						parentTexture.image = this._canvas;
+
+					}
+
+				},
+
+				setCrossPosition: function (x, y) {
+
+					this._xCross = x * this._canvas.width;
+					this._yCross = y * this._canvas.height;
+
+					this._draw();
+
+				},
+
+				_draw: function () {
+
+					if (!this._context2D) return;
+
+					this._context2D.clearRect(0, 0, this._canvas.width, this._canvas.height)
+
+					// Background.
+					this._context2D.drawImage(this._background, 0, 0);
+
+					// Yellow cross.
+					this._context2D.lineWidth = this._epaisseurViseur * 3;
+					this._context2D.strokeStyle = "#FFFF00";
+
+					this._context2D.beginPath();
+					this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross - this._exterieurCroix - 2);
+					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross - this._interieurCroix);
+
+					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross + this._interieurCroix);
+					this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross + this._exterieurCroix + 2);
+
+					this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross + this._exterieurCroix + 2);
+					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross + this._interieurCroix);
+
+					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross - this._interieurCroix);
+					this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross - this._exterieurCroix - 2);
+
+					this._context2D.stroke();
+
+					for (var i = 0; i < this._parentTexture.length; i++) {
+					
+						//this._parentTexture[i].image = this._canvas;
+						this._parentTexture[i].needsUpdate = true;
+
+					}
+
 				}
 
 			}
 
-		}
-	</script>
-	<script>
+		</script>
+		<script>
 
-		var container = document.getElementById("container");
-		var width = window.innerWidth;
-		var height = window.innerHeight;
-		var objects = [];
+			var width = window.innerWidth;
+			var height = window.innerHeight;
 
-		var scene = new THREE.Scene();
-		var camera = new THREE.PerspectiveCamera(45, width / height, 1, 1000);
-		camera.position.x = -30;
-		camera.position.y = 40;
-		camera.position.z = 50;
-		camera.lookAt(scene.position);
+			var canvas;
+			var objects = [];
+			var planeTexture, cubeTexture, circleTexture;
 
-		var raycaster = new THREE.Raycaster();
-		var mouse = new THREE.Vector2();
-		var onClickPosition = new THREE.Vector2();
+			var container;
 
-		var getMousePosition = function (dom, x, y) {
-			var rect = dom.getBoundingClientRect();
-			return [(x - rect.left) / rect.width, (y - rect.top) / rect.height];
-		};
+			var camera, scene, renderer;
 
-		var getIntersects = function (point, objects) {
-			mouse.set((point.x * 2) - 1, -(point.y * 2) + 1);
+			var raycaster = new THREE.Raycaster();
+			var mouse = new THREE.Vector2();
+			var onClickPosition = new THREE.Vector2();
 
-			raycaster.setFromCamera(mouse, camera);
+			init();
+			render();
+			
+			function init() {
 
-			return raycaster.intersectObjects(objects);
-		};
+				container = document.getElementById("container");
 
-		window.addEventListener('resize', function (evt) {
-			camera.aspect = window.innerWidth / window.innerHeight;
-			camera.updateProjectionMatrix();
+				scene = new THREE.Scene();
 
-			renderer.setSize(window.innerWidth, window.innerHeight);
-		}, false);
+				camera = new THREE.PerspectiveCamera(45, width / height, 1, 1000);
+				camera.position.x = -30;
+				camera.position.y = 40;
+				camera.position.z = 50;
+				camera.lookAt(scene.position);
+			
+				renderer = new THREE.WebGLRenderer();
+				renderer.setClearColor(new THREE.Color(0xEEEEEE, 1.0));
+				renderer.setSize(width, height);
+				container.appendChild(renderer.domElement);
 
-		container.addEventListener('click', function (evt) {
-			evt.preventDefault();
+				// A cube, in the middle.
+				cubeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping);
+				canvas = new CanvasTexture(cubeTexture);
+				var cubeMaterial = new THREE.MeshBasicMaterial({ map: cubeTexture });
+				var cubeGeometry = new THREE.BoxGeometry(20, 20, 20);
+				// Set a specific texture mapping.
+				var uvs;
+				for (var i = 0; i < cubeGeometry.faceVertexUvs[0].length; i++) {
 
-			var array = getMousePosition(container, evt.clientX, evt.clientY);
-			onClickPosition.fromArray(array);
+					uvs = cubeGeometry.faceVertexUvs[0][i];
+					for (var j = 0; j < 3; j++) {
 
-			var intersects = getIntersects(onClickPosition, objects);
-			if (intersects.length > 0) {
-				if (intersects[0].uv) {
+						if (uvs[j].x < 0.1) uvs[j].x = -1;
+						if (uvs[j].y < 0.1) uvs[j].y = -1;
+
+					}
+
+				}
+				var cube = new THREE.Mesh(cubeGeometry, cubeMaterial);
+				cube.position.x = 4;
+				cube.position.y = -5;
+				cube.position.z = 0;
+				objects.push(cube);
+				scene.add(cube);
+
+				// A plane on the left.
+				planeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.MirroredRepeatWrapping, THREE.MirroredRepeatWrapping);
+				canvas.addParent(planeTexture);
+				var planeMaterial = new THREE.MeshBasicMaterial({ map: planeTexture });
+				var planeGeometry = new THREE.PlaneBufferGeometry(25, 25, 1, 1);
+				var uvs = planeGeometry.attributes.uv.array;
+				for (var i = 0; i < uvs.length; i++) {
+
+					uvs[i] *= 2;
+
+				}
+				var plane = new THREE.Mesh(planeGeometry, planeMaterial);
+				plane.position.x = -16;
+				plane.position.y = -5;
+				plane.position.z = 0;
+				objects.push(plane);
+				scene.add(plane);
+
+				// A circle on the right.
+				circleTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.ClampToEdgeWrapping, THREE.ClampToEdgeWrapping);
+				canvas.addParent(circleTexture);
+				var circleMaterial = new THREE.MeshBasicMaterial({ map: circleTexture });
+				var circleGeometry = new THREE.CircleBufferGeometry(25, 40, 0, Math.PI * 2);
+				var uvs = circleGeometry.attributes.uv.array;
+				for (var i = 0; i < uvs.length; i++) {
+
+					uvs[i] = (uvs[i] - 0.25) * 2;
+
+				}
+				var circle = new THREE.Mesh(circleGeometry, circleMaterial);
+				circle.position.x = 24;
+				circle.position.y = -5;
+				circle.position.z = 0;
+				objects.push(circle);
+				scene.add(circle);
+
+				window.addEventListener('resize', onWindowResize, false);
+				container.addEventListener('click', onClick, false);
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize(window.innerWidth, window.innerHeight);
+
+			};
+
+			function onClick(evt) {
+
+				evt.preventDefault();
+
+				var array = getMousePosition(container, evt.clientX, evt.clientY);
+				onClickPosition.fromArray(array);
+
+				var intersects = getIntersects(onClickPosition, objects);
+				if (intersects.length > 0 && intersects[0].uv) {
+
 					var uv = intersects[0].uv;
 					intersects[0].object.material.map.transformUv(uv);
 					canvas.setCrossPosition(uv.x, uv.y);
+
 				}
-			}
-		}, false);
 
+			};
 
-		var renderer = new THREE.WebGLRenderer();
-		renderer.setClearColor(new THREE.Color(0xEEEEEE, 1.0));
-		renderer.setSize(width, height);
-		container.appendChild(renderer.domElement);
+			var getMousePosition = function (dom, x, y) {
 
-		// A cube, in the middle.
-		var cubeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping);
-		var canvas = new CanvasTexture(cubeTexture);
-		var cubeMaterial = new THREE.MeshBasicMaterial({ map: cubeTexture });
-		var cubeGeometry = new THREE.BoxGeometry(20, 20, 20);
-		// Set a specific texture mapping.
-		var uvs;
-		for (var i = 0; i < cubeGeometry.faceVertexUvs[0].length; i++) {
-			uvs = cubeGeometry.faceVertexUvs[0][i];
-			for (var j = 0; j < 3; j++) {
-				if (uvs[j].x < 0.1) uvs[j].x = -1;
-				if (uvs[j].y < 0.1) uvs[j].y = -1;
-			}
-		}
-		var cube = new THREE.Mesh(cubeGeometry, cubeMaterial);
-		cube.position.x = 4;
-		cube.position.y = -5;
-		cube.position.z = 0;
-		objects.push(cube);
-		scene.add(cube);
+				var rect = dom.getBoundingClientRect();
+				return [(x - rect.left) / rect.width, (y - rect.top) / rect.height];
 
-		// A plane on the left.
-		var planeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.MirroredRepeatWrapping, THREE.MirroredRepeatWrapping);
-		canvas.addParent(planeTexture);
-		var planeMaterial = new THREE.MeshBasicMaterial({ map: planeTexture });
-		var planeGeometry = new THREE.PlaneBufferGeometry(25, 25, 1, 1);
-		var uvs = planeGeometry.attributes.uv.array;
-		for (var i = 0; i < uvs.length; i++) {
-			//if (uvs[i] < 0.1) uvs[i] = -1;
-			uvs[i] *= 2;
-		}
-		var plane = new THREE.Mesh(planeGeometry, planeMaterial);
-		plane.position.x = -16;
-		plane.position.y = -5;
-		plane.position.z = 0;
-		objects.push(plane);
-		scene.add(plane);
+			};
 
-		// A circle on the left.
-		var circleTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.ClampToEdgeWrapping, THREE.ClampToEdgeWrapping);
-		canvas.addParent(circleTexture);
-		var circleMaterial = new THREE.MeshBasicMaterial({ map: circleTexture });
-		var circleGeometry = new THREE.CircleBufferGeometry(25, 40, 0, Math.PI * 2);
-		var uvs = circleGeometry.attributes.uv.array;
-		for (var i = 0; i < uvs.length; i++) {
-			uvs[i] = (uvs[i] - 0.25) * 2;
-		}
-		var circle = new THREE.Mesh(circleGeometry, circleMaterial);
-		circle.position.x = 24;
-		circle.position.y = -5;
-		circle.position.z = 0;
-		objects.push(circle);
-		scene.add(circle);
+			var getIntersects = function (point, objects) {
 
-		render();
+				mouse.set((point.x * 2) - 1, -(point.y * 2) + 1);
 
-		function render() {
-			requestAnimationFrame(render);
-			renderer.render(scene, camera);
-		};
+				raycaster.setFromCamera(mouse, camera);
 
-		function setwrapS(that) {
-			circleTexture.wrapS = THREE[that.value];
-			circleTexture.needsUpdate = true;
-		};
+				return raycaster.intersectObjects(objects);
 
-		function setwrapT(that) {
-			circleTexture.wrapT = THREE[that.value];
-			circleTexture.needsUpdate = true;
-		};
+			};
 
-		function setOffsetU(that) {
-			circleTexture.offset.x = parseFloat(that.value);
-		};
+			function render() {
 
-		function setOffsetV(that) {
-			circleTexture.offset.y = parseFloat(that.value);
-		};
+				requestAnimationFrame(render);
+				renderer.render(scene, camera);
 
-		function setRepeatU(that) {
-			circleTexture.repeat.x = parseFloat(that.value);
-		};
+			};
 
-		function setRepeatV(that) {
-			circleTexture.repeat.y = parseFloat(that.value);
-		};
+			function setwrapS(that) {
+
+				circleTexture.wrapS = THREE[that.value];
+				circleTexture.needsUpdate = true;
+
+			};
+
+			function setwrapT(that) {
+
+				circleTexture.wrapT = THREE[that.value];
+				circleTexture.needsUpdate = true;
+
+			};
+
+			function setOffsetU(that) {
+
+				circleTexture.offset.x = parseFloat(that.value);
+
+			};
+
+			function setOffsetV(that) {
+
+				circleTexture.offset.y = parseFloat(that.value);
+
+			};
+
+			function setRepeatU(that) {
+
+				circleTexture.repeat.x = parseFloat(that.value);
+
+			};
+
+			function setRepeatV(that) {
+
+				circleTexture.repeat.y = parseFloat(that.value);
+
+			};
 		</script>
 	</body>
 </html>

--- a/examples/webgl_texture_raycast.html
+++ b/examples/webgl_texture_raycast.html
@@ -1,0 +1,269 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js ray cast - texture - canvas</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #808080;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+
+				background-color: #ffffff;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0px; width: 100%;
+				padding: 5px;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="container"></div>
+		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - texture intersection<br>Left to right: buffer geometry - geometry - indexed buffer geometry</div>
+		<!--<script src="../build/three.min.js"></script>-->
+		<script src="../build/three.js"></script>
+		<script>
+			CanvasTexture = function(parentTexture) {
+				this._canvas = document.createElement("canvas");
+				this._context2D = this._canvas.getContext("2d");
+
+				if (parentTexture) {
+					this._parentTexture.push(parentTexture);
+					parentTexture.image = this._canvas;
+				}
+
+				var that = this;
+				this._background = document.createElement("img");
+				this._background.addEventListener("load", function (event) {
+					that._canvas.width = that._background.naturalWidth;
+					that._canvas.height = that._background.naturalHeight;
+				
+					that._rayonviseur = Math.ceil(Math.min(that._canvas.width, that._canvas.height / 30));
+					that._exterieurCroix = Math.ceil(0.70710678 * that._rayonviseur);
+					that._interieurCroix = Math.ceil(that._exterieurCroix / 10);
+					that._epaisseurViseur = Math.ceil(that._exterieurCroix / 10);
+					
+					that._draw();
+				}, false);
+				this._background.crossOrigin = '';
+				this._background.src = "textures/UV_Grid_Sm.jpg";
+
+				this._draw();
+			}
+
+
+			CanvasTexture.prototype = {
+
+				constructor: CanvasTexture,
+
+				_canvas: null,
+				_context2D: null,
+				_xCross: 0,
+				_yCross: 0,
+				
+				_rayonviseur: 57,
+				_exterieurCroix: 40,
+				_interieurCroix: 4,
+				_epaisseurViseur: 4,
+
+				_parentTexture: [],
+
+				addParent: function (parentTexture) {
+					if (this._parentTexture.indexOf(parentTexture) === -1) {
+						this._parentTexture.push(parentTexture);
+						parentTexture.image = this._canvas;
+					}
+				 },
+				
+				setCrossPosition: function (x, y) {
+					this._xCross = x * this._canvas.width;
+					this._yCross = y * this._canvas.height;
+					
+					this._draw();
+				},
+				
+				_draw: function () {
+					if (!this._context2D) return;
+
+					this._context2D.clearRect(0, 0, this._canvas.width, this._canvas.height)
+
+					// Background.
+					this._context2D.drawImage(this._background, 0, 0);
+
+					// White cross.
+					this._context2D.lineWidth = this._epaisseurViseur * 3;
+					this._context2D.strokeStyle = "#FFFFFF";
+
+					this._context2D.beginPath();
+					this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross - this._exterieurCroix -2);
+					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross - this._interieurCroix);
+
+					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross + this._interieurCroix);
+					this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross + this._exterieurCroix + 2);
+
+					this._context2D.moveTo(this._xCross - this._exterieurCroix - 2, this._yCross + this._exterieurCroix + 2);
+					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross + this._interieurCroix);
+
+					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross - this._interieurCroix);
+					this._context2D.lineTo(this._xCross + this._exterieurCroix + 2, this._yCross - this._exterieurCroix - 2);
+
+					this._context2D.stroke();
+					
+					// Black cross.
+					this._context2D.lineWidth = this._epaisseurViseur;
+					this._context2D.strokeStyle = "#000000";
+
+					this._context2D.beginPath();
+					this._context2D.moveTo(this._xCross - this._exterieurCroix, this._yCross - this._exterieurCroix);
+					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross - this._interieurCroix);
+
+					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross + this._interieurCroix);
+					this._context2D.lineTo(this._xCross + this._exterieurCroix, this._yCross + this._exterieurCroix);
+
+					this._context2D.moveTo(this._xCross - this._exterieurCroix, this._yCross + this._exterieurCroix);
+					this._context2D.lineTo(this._xCross - this._interieurCroix, this._yCross + this._interieurCroix);
+
+					this._context2D.moveTo(this._xCross + this._interieurCroix, this._yCross - this._interieurCroix);
+					this._context2D.lineTo(this._xCross + this._exterieurCroix, this._yCross - this._exterieurCroix);
+
+					this._context2D.stroke();
+					
+					for (var i = 0; i < this._parentTexture.length; i++) {
+						//this._parentTexture[i].image = this._canvas;
+						this._parentTexture[i].needsUpdate = true;
+					}
+
+				}
+
+			}
+		</script>
+		<script>
+
+			var container = document.getElementById("container");
+			var width = window.innerWidth;
+			var height = window.innerHeight ;
+			var objects = [];
+
+			var scene = new THREE.Scene();
+			var camera = new THREE.PerspectiveCamera(45, width / height, 1, 1000);
+			camera.position.x = -30;
+			camera.position.y = 40;
+			camera.position.z = 50;
+			camera.lookAt(scene.position);
+
+			var raycaster = new THREE.Raycaster();
+			var mouse = new THREE.Vector2();
+			var onClickPosition = new THREE.Vector2();
+
+			var getMousePosition = function (dom, x, y) {
+				var rect = dom.getBoundingClientRect();
+				return [(x - rect.left) / rect.width, (y - rect.top) / rect.height];
+			};
+
+			var getIntersects = function (point, objects) {
+				mouse.set((point.x * 2) - 1, -(point.y * 2) + 1);
+
+				raycaster.setFromCamera(mouse, camera);
+
+				return raycaster.intersectObjects(objects);
+			};
+
+			window.addEventListener('resize', function(evt) {
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+			}, false);
+
+			container.addEventListener('click', function(evt) {
+				evt.preventDefault();
+
+				var array = getMousePosition(container, evt.clientX, evt.clientY);
+				onClickPosition.fromArray(array);
+
+				var intersects = getIntersects(onClickPosition, objects);
+				if (intersects.length > 0) {
+					if (intersects[0].uv) {
+						var uv = intersects[0].uv;
+						intersects[0].object.material.map.transformUv(uv);
+						canvas.setCrossPosition(uv.x, uv.y);
+					}
+				}
+			}, false);
+
+
+			var renderer = new THREE.WebGLRenderer();
+			renderer.setClearColor(new THREE.Color(0xEEEEEE, 1.0));
+			renderer.setSize(width, height);
+			container.appendChild(renderer.domElement);
+
+			// A cube, in the middle.
+			var cubeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.RepeatWrapping);
+			var canvas = new CanvasTexture(cubeTexture);
+			var cubeMaterial = new THREE.MeshBasicMaterial( { map: cubeTexture } );
+			var cubeGeometry = new THREE.BoxGeometry(20, 20, 20);
+			// Set a specific texture mapping.
+			var uvs;
+			for (var i = 0; i < cubeGeometry.faceVertexUvs[0].length; i++) {
+				uvs = cubeGeometry.faceVertexUvs[0][i];
+				for (var j = 0; j < 3; j++) {
+					if (uvs[j].x < 0.1) uvs[j].x = -1;
+					if (uvs[j].y < 0.1) uvs[j].y = -1;
+				}
+			}
+			var cube = new THREE.Mesh(cubeGeometry, cubeMaterial);
+			cube.position.x = 4;
+			cube.position.y = -5;
+			cube.position.z = 0;
+			objects.push(cube);
+			scene.add(cube);
+
+			// A plane on the left.
+			var planeTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.MirroredRepeatWrapping, THREE.MirroredRepeatWrapping);
+			canvas.addParent(planeTexture);
+			var planeMaterial = new THREE.MeshBasicMaterial( { map: planeTexture } );
+			var planeGeometry = new THREE.PlaneBufferGeometry(25, 25, 1, 1);
+			var uvs = planeGeometry.attributes.uv.array;
+			for (var i = 0; i < uvs.length; i++) {
+				//if (uvs[i] < 0.1) uvs[i] = -1;
+				uvs[i] *= 2;
+			}
+			var plane = new THREE.Mesh(planeGeometry, planeMaterial);
+			plane.position.x = -16;
+			plane.position.y = -5;
+			plane.position.z = 0;
+			objects.push(plane);
+			scene.add(plane);
+
+			// A circle on the left.
+			var circleTexture = new THREE.Texture(undefined, THREE.UVMapping, THREE.RepeatWrapping, THREE.MirroredRepeatWrapping);
+			canvas.addParent(circleTexture);
+			var circleMaterial = new THREE.MeshBasicMaterial( { map: circleTexture } );
+			var circleGeometry = new THREE.CircleBufferGeometry(25, 40, 0, Math.PI * 2);
+			var uvs = circleGeometry.attributes.uv.array;
+			for (var i = 0; i < uvs.length; i++) {
+				uvs[i] *= 2;
+			}
+			var circle = new THREE.Mesh(circleGeometry, circleMaterial);
+			circle.position.x = 24;
+			circle.position.y = -5;
+			circle.position.z = 0;
+			objects.push(circle);
+			scene.add(circle);
+			
+			render();
+
+			function render() {
+				requestAnimationFrame(render);
+				renderer.render(scene, camera);
+			};
+
+		</script>
+	</body>
+</html>

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -173,7 +173,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 						if ( intersectionPoint === null ) continue;
 
-						pInter.copy(intersectionPoint);
+						pInter.copy( intersectionPoint );
 						intersectionPoint.applyMatrix4( this.matrixWorld );
 
 						var distance = raycaster.ray.origin.distanceTo( intersectionPoint );
@@ -229,7 +229,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 					if ( intersectionPoint === null ) continue;
 
-					pInter.copy(intersectionPoint);
+					pInter.copy( intersectionPoint );
 					intersectionPoint.applyMatrix4( this.matrixWorld );
 
 					var distance = raycaster.ray.origin.distanceTo( intersectionPoint );
@@ -331,7 +331,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 				if ( intersectionPoint === null ) continue;
 
-				pInter.copy(intersectionPoint);
+				pInter.copy( intersectionPoint );
 				intersectionPoint.applyMatrix4( this.matrixWorld );
 
 				var distance = raycaster.ray.origin.distanceTo( intersectionPoint );

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -73,6 +73,8 @@ THREE.Mesh.prototype.raycast = ( function () {
 	var uvA = new THREE.Vector2();
 	var uvB = new THREE.Vector2();
 	var uvC = new THREE.Vector2();
+	var bary = new THREE.Vector3();
+	var pInter = new THREE.Vector3();
 
 	return function raycast( raycaster, intersects ) {
 
@@ -113,7 +115,7 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 		var textureIntersection = function ( pIntersection, p1, p2, p3, uv1, uv2, uv3 ) {
 
-			var bary = THREE.Triangle.barycoordFromPoint( pIntersection, p1, p2, p3 );
+			THREE.Triangle.barycoordFromPoint( pIntersection, p1, p2, p3, bary );
 
 			uv1.multiplyScalar( bary.x );
 			uv2.multiplyScalar( bary.y );
@@ -171,21 +173,24 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 						if ( intersectionPoint === null ) continue;
 
-						// intersectionPoint in UV coordinates.
-						var uv = undefined;
-						if ( material.map && attributes.uv !== undefined ) {
-							var uvs = attributes.uv.array;
-							uvA.fromArray( uvs, a * 2 );
-							uvB.fromArray( uvs, b * 2 );
-							uvC.fromArray( uvs, c * 2 );
-							uv = textureIntersection( intersectionPoint, vA, vB, vC, uvA, uvB, uvC )
-						}
-
+						pInter.copy(intersectionPoint);
 						intersectionPoint.applyMatrix4( this.matrixWorld );
 
 						var distance = raycaster.ray.origin.distanceTo( intersectionPoint );
 
 						if ( distance < raycaster.near || distance > raycaster.far ) continue;
+
+						// intersectionPoint in UV coordinates.
+						var uv = undefined;
+						if ( material.map && attributes.uv !== undefined ) {
+
+							var uvs = attributes.uv.array;
+							uvA.fromArray( uvs, a * 2 );
+							uvB.fromArray( uvs, b * 2 );
+							uvC.fromArray( uvs, c * 2 );
+							uv = textureIntersection( pInter, vA, vB, vC, uvA, uvB, uvC );
+
+						}
 
 						intersects.push( {
 
@@ -224,21 +229,24 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 					if ( intersectionPoint === null ) continue;
 
-					// intersectionPoint in UV coordinates.
-					var uv = undefined;
-					if ( material.map && attributes.uv !== undefined ) {
-						var uvs = attributes.uv.array;
-						uvA.fromArray( uvs, i );
-						uvB.fromArray( uvs, i + 2 );
-						uvC.fromArray( uvs, i + 4 );
-						uv = textureIntersection( intersectionPoint, vA, vB, vC, uvA, uvB, uvC )
-					}
-
+					pInter.copy(intersectionPoint);
 					intersectionPoint.applyMatrix4( this.matrixWorld );
 
 					var distance = raycaster.ray.origin.distanceTo( intersectionPoint );
 
 					if ( distance < raycaster.near || distance > raycaster.far ) continue;
+
+					// intersectionPoint in UV coordinates.
+					var uv = undefined;
+					if ( material.map && attributes.uv !== undefined ) {
+
+						var uvs = attributes.uv.array;
+						uvA.fromArray( uvs, i );
+						uvB.fromArray( uvs, i + 2 );
+						uvC.fromArray( uvs, i + 4 );
+						uv = textureIntersection( pInter, vA, vB, vC, uvA, uvB, uvC );
+
+					}
 
 					a = i / 3;
 					b = a + 1;
@@ -323,21 +331,24 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 				if ( intersectionPoint === null ) continue;
 
-				// intersectionPoint in UV coordinates.
-				var uv = undefined;
-				if ( material.map && geometry.faceVertexUvs[ 0 ] !== undefined ) {
-					var uvs = geometry.faceVertexUvs[ 0 ][ f ];
-					uvA.copy( uvs[ 0 ] );
-					uvB.copy( uvs[ 1 ] );
-					uvC.copy( uvs[ 2 ] );
-					uv = textureIntersection( intersectionPoint, a, b, c, uvA, uvB, uvC )
-				}
-
+				pInter.copy(intersectionPoint);
 				intersectionPoint.applyMatrix4( this.matrixWorld );
 
 				var distance = raycaster.ray.origin.distanceTo( intersectionPoint );
 
 				if ( distance < raycaster.near || distance > raycaster.far ) continue;
+
+				// intersectionPoint in UV coordinates.
+				var uv = undefined;
+				if ( material.map && geometry.faceVertexUvs[ 0 ] !== undefined ) {
+
+					var uvs = geometry.faceVertexUvs[ 0 ][ f ];
+					uvA.copy( uvs[ 0 ] );
+					uvB.copy( uvs[ 1 ] );
+					uvC.copy( uvs[ 2 ] );
+					uv = textureIntersection( pInter, a, b, c, uvA, uvB, uvC );
+
+				}
 
 				intersects.push( {
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -185,6 +185,56 @@ THREE.Texture.prototype = {
 
 		this.dispatchEvent( { type: 'dispose' } );
 
+	},
+
+	transformUv: function ( uv ) {
+
+		if ( this.mapping !== THREE.UVMapping ) {
+			return;
+		}
+
+		uv.multiply( this.repeat );
+		uv.add( this.offset );
+
+		if ( uv.x < 0 || uv.x > 1 ) {
+			switch ( this.wrapS ) {
+				case THREE.RepeatWrapping:
+					uv.x = uv.x - Math.floor( uv.x );
+					break;
+				case THREE.ClampToEdgeWrapping:
+					uv.x = uv.x < 0 ? 0 : 1;
+					break;
+				case THREE.MirroredRepeatWrapping:
+					if ( Math.abs(Math.floor( uv.x ) % 2) === 1 ) {
+						uv.x = Math.ceil( uv.x ) - uv.x;
+					} else {
+						uv.x = uv.x - Math.floor( uv.x );
+					}
+				break;
+			}
+		}
+
+		if ( uv.y < 0 || uv.y > 1 ) {
+			switch ( this.wrapT ) {
+				case THREE.RepeatWrapping:
+					uv.y = uv.y - Math.floor( uv.y );
+					break;
+				case THREE.ClampToEdgeWrapping:
+					uv.y = uv.y < 0 ? 0 : 1;
+					break;
+				case THREE.MirroredRepeatWrapping:
+					if ( Math.abs( Math.floor( uv.y ) % 2 ) === 1 ) {
+						uv.y = Math.ceil( uv.y ) - uv.y;
+					} else {
+						uv.y = uv.y - Math.floor( uv.y );
+					}
+					break;
+			}
+		}
+
+		if ( this.flipY ) {
+			uv.y = 1 - uv.y;
+		}
 	}
 
 };

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -189,52 +189,79 @@ THREE.Texture.prototype = {
 
 	transformUv: function ( uv ) {
 
-		if ( this.mapping !== THREE.UVMapping ) {
-			return;
-		}
+		if ( this.mapping !== THREE.UVMapping )  return;
 
 		uv.multiply( this.repeat );
 		uv.add( this.offset );
 
 		if ( uv.x < 0 || uv.x > 1 ) {
+
 			switch ( this.wrapS ) {
+
 				case THREE.RepeatWrapping:
+
 					uv.x = uv.x - Math.floor( uv.x );
 					break;
+
 				case THREE.ClampToEdgeWrapping:
+
 					uv.x = uv.x < 0 ? 0 : 1;
 					break;
+
 				case THREE.MirroredRepeatWrapping:
-					if ( Math.abs(Math.floor( uv.x ) % 2) === 1 ) {
+
+					if ( Math.abs( Math.floor( uv.x ) % 2 ) === 1 ) {
+
 						uv.x = Math.ceil( uv.x ) - uv.x;
+
 					} else {
+
 						uv.x = uv.x - Math.floor( uv.x );
+
 					}
-				break;
+					break;
+
 			}
+
 		}
 
 		if ( uv.y < 0 || uv.y > 1 ) {
+
 			switch ( this.wrapT ) {
+
 				case THREE.RepeatWrapping:
+
 					uv.y = uv.y - Math.floor( uv.y );
 					break;
+
 				case THREE.ClampToEdgeWrapping:
+
 					uv.y = uv.y < 0 ? 0 : 1;
 					break;
+
 				case THREE.MirroredRepeatWrapping:
+
 					if ( Math.abs( Math.floor( uv.y ) % 2 ) === 1 ) {
+
 						uv.y = Math.ceil( uv.y ) - uv.y;
+
 					} else {
+
 						uv.y = uv.y - Math.floor( uv.y );
+
 					}
 					break;
+
 			}
+
 		}
 
 		if ( this.flipY ) {
+
 			uv.y = 1 - uv.y;
+
 		}
+
 	}
 
 };


### PR DESCRIPTION
Mesh.js raycast method is updated to calculate intersection point in uv
coordinates. The calculus is done in the new inner method
textureIntersection and added to the object returned as the uv property.

Texture.js has a new public method, transformUv, that convert the
coordinates from uv (range 0 to 1) to the real texture coordinates. The
input parameter is modified on output. Useful to have the intersection
point in texture coordinates.

There is no example in this commit because I only have example with
canvas, no with plain image.

Fixes #6762
