### PR TITLE
Adding logic to assign material.program for MeshFaceMaterials

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1305,6 +1305,16 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					if ( material !== null && material.visible === true ) {
 
+						if ( material instanceof THREE.MeshFaceMaterial ) {
+							for ( var i = 0, l = material.materials.length; i < l; i ++ ) {
+								if ( properties.get( material.materials[ i ] ) ) {
+
+									material.materials[ i ].program = properties.get( material.materials[ i ] ).program;
+
+								}
+							}
+						}
+
 						if ( properties.get( material ) ) {
 
 							material.program = properties.get( material ).program;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1314,11 +1314,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 								}
 							}
 						}
+						else {
+							if ( properties.get( material ) ) {
 
-						if ( properties.get( material ) ) {
+								material.program = properties.get( material ).program;
 
-							material.program = properties.get( material ).program;
-
+							}
 						}
 
 						if ( material.transparent ) {


### PR DESCRIPTION
Just noticed that material.program doesn't get set for materials inside of a MeshFaceMaterial. I added some code to projectObject to assign it.

On a related note, I also noticed that material.program doesn't get assigned until the next render call after the shader is compiled and linked. So you can't check the program.diagnostics until after you've rendered the material twice...
