### PR TITLE
Less resource-hungry per-pixel lighting

### DIFF
--- a/examples/js/ShaderSkin.js
+++ b/examples/js/ShaderSkin.js
@@ -197,9 +197,7 @@ THREE.ShaderSkin = {
 
 					"for ( int i = 0; i < MAX_POINT_LIGHTS; i ++ ) {",
 
-						"vec4 lPosition = viewMatrix * vec4( pointLightPosition[ i ], 1.0 );",
-
-						"vec3 lVector = lPosition.xyz + vViewPosition.xyz;",
+						"vec3 lVector = pointLightPosition[ i ] + vViewPosition.xyz;",
 
 						"float attenuation = calcLightAttenuation( length( lVector ), pointLightDistance[ i ], pointLightDecay[i] );",
 
@@ -628,9 +626,7 @@ THREE.ShaderSkin = {
 
 					"for( int i = 0; i < MAX_POINT_LIGHTS; i++ ) {",
 
-						"vec4 lPosition = viewMatrix * vec4( pointLightPosition[ i ], 1.0 );",
-
-						"vec3 lVector = lPosition.xyz - mvPosition.xyz;",
+						"vec3 lVector = pointLightPosition[ i ] - mvPosition.xyz;",
 
 						"float attenuation = calcLightAttenuation( length( lVector ), pointLightDistance[ i ], pointLightDecay[i] );",
 
@@ -717,9 +713,7 @@ THREE.ShaderSkin = {
 
 					"for( int i = 0; i < MAX_POINT_LIGHTS; i++ ) {",
 
-						"vec4 lPosition = viewMatrix * vec4( pointLightPosition[ i ], 1.0 );",
-
-						"vec3 lVector = lPosition.xyz - mvPosition.xyz;",
+						"vec3 lVector = pointLightPosition[ i ] - mvPosition.xyz;",
 
 						"float attenuation = calcLightAttenuation( length( lVector ), pointLightDistance[ i ], pointLightDecay[i] );",
 

--- a/examples/js/ShaderTerrain.js
+++ b/examples/js/ShaderTerrain.js
@@ -168,8 +168,7 @@ THREE.ShaderTerrain = {
 
 					"for ( int i = 0; i < MAX_POINT_LIGHTS; i ++ ) {",
 
-						"vec4 lPosition = viewMatrix * vec4( pointLightPosition[ i ], 1.0 );",
-						"vec3 lVector = lPosition.xyz + vViewPosition.xyz;",
+						"vec3 lVector = pointLightPosition[ i ] + vViewPosition.xyz;",
 
 						"float attenuation = calcLightAttenuation( length( lVector ), pointLightDistance[ i ], pointLightDecay[i] );",
 
@@ -198,7 +197,7 @@ THREE.ShaderTerrain = {
 
 					"for( int i = 0; i < MAX_DIR_LIGHTS; i++ ) {",
 
-						"vec3 dirVector = transformDirection( directionalLightDirection[ i ], viewMatrix );",
+						"vec3 dirVector = directionalLightDirection[ i ];",
 						"vec3 dirHalfVector = normalize( dirVector + viewPosition );",
 
 						"float dirDotNormalHalf = max( dot( normal, dirHalfVector ), 0.0 );",
@@ -222,7 +221,7 @@ THREE.ShaderTerrain = {
 
 					"for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {",
 
-						"vec3 lVector = transformDirection( hemisphereLightDirection[ i ], viewMatrix );",
+						"vec3 lVector = hemisphereLightDirection[ i ];",
 
 						// diffuse
 

--- a/examples/js/shaders/NormalDisplacementShader.js
+++ b/examples/js/shaders/NormalDisplacementShader.js
@@ -186,8 +186,7 @@ THREE.NormalDisplacementShader = {
 
 		"		for ( int i = 0; i < MAX_POINT_LIGHTS; i ++ ) {",
 
-		"			vec4 lPosition = viewMatrix * vec4( pointLightPosition[ i ], 1.0 );",
-		"			vec3 pointVector = lPosition.xyz + vViewPosition.xyz;",
+		"			vec3 pointVector = pointLightPosition[ i ] + vViewPosition.xyz;",
 
 		"			float pointDistance = 1.0;",
 		"			if ( pointLightDistance[ i ] > 0.0 )",
@@ -222,8 +221,7 @@ THREE.NormalDisplacementShader = {
 
 		"		for ( int i = 0; i < MAX_SPOT_LIGHTS; i ++ ) {",
 
-		"			vec4 lPosition = viewMatrix * vec4( spotLightPosition[ i ], 1.0 );",
-		"			vec3 spotVector = lPosition.xyz + vViewPosition.xyz;",
+		"			vec3 spotVector = spotLightPosition[ i ] + vViewPosition.xyz;",
 
 		"			float spotDistance = 1.0;",
 		"			if ( spotLightDistance[ i ] > 0.0 )",
@@ -231,7 +229,7 @@ THREE.NormalDisplacementShader = {
 
 		"			spotVector = normalize( spotVector );",
 
-		"			float spotEffect = dot( spotLightDirection[ i ], normalize( spotLightPosition[ i ] - vWorldPosition ) );",
+		"			float spotEffect = dot( spotLightDirection[ i ], spotVector );",
 
 		"			if ( spotEffect > spotLightAngleCos[ i ] ) {",
 
@@ -267,8 +265,7 @@ THREE.NormalDisplacementShader = {
 
 		"		for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {",
 
-		"			vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );",
-		"			vec3 dirVector = normalize( lDirection.xyz );",
+		"			vec3 dirVector = directionalLightDirection[ i ];",
 
 					// diffuse
 
@@ -297,8 +294,7 @@ THREE.NormalDisplacementShader = {
 
 		"		for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {",
 
-		"			vec4 lDirection = viewMatrix * vec4( hemisphereLightDirection[ i ], 0.0 );",
-		"			vec3 lVector = normalize( lDirection.xyz );",
+		"			vec3 lVector = hemisphereLightDirection[ i ];",
 
 					// diffuse
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1873,7 +1873,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				if ( _lightsNeedUpdate ) {
 
 					refreshLights = true;
-					setupLights( lights );
+					setupLights( lights, camera );
 					_lightsNeedUpdate = false;
 
 				}
@@ -2585,7 +2585,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function setupLights ( lights ) {
+	function setupLights ( lights, camera ) {
 
 		var l, ll, light,
 		r = 0, g = 0, b = 0,
@@ -2594,6 +2594,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 		distance,
 
 		zlights = _lights,
+
+		viewMatrix = camera.matrixWorldInverse,
 
 		dirColors = zlights.directional.colors,
 		dirPositions = zlights.directional.positions,
@@ -2657,7 +2659,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				_direction.setFromMatrixPosition( light.matrixWorld );
 				_vector3.setFromMatrixPosition( light.target.matrixWorld );
 				_direction.sub( _vector3 );
-				_direction.normalize();
+				_direction.transformDirection( viewMatrix );
 
 				dirOffset = dirLength * 3;
 
@@ -2680,6 +2682,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				setColorLinear( pointColors, pointOffset, color, intensity );
 
 				_vector3.setFromMatrixPosition( light.matrixWorld );
+				_vector3.applyMatrix4( viewMatrix );
 
 				pointPositions[ pointOffset + 0 ] = _vector3.x;
 				pointPositions[ pointOffset + 1 ] = _vector3.y;
@@ -2702,16 +2705,17 @@ THREE.WebGLRenderer = function ( parameters ) {
 				setColorLinear( spotColors, spotOffset, color, intensity );
 
 				_direction.setFromMatrixPosition( light.matrixWorld );
+				_vector3.copy( _direction ).applyMatrix4( viewMatrix );
 
-				spotPositions[ spotOffset + 0 ] = _direction.x;
-				spotPositions[ spotOffset + 1 ] = _direction.y;
-				spotPositions[ spotOffset + 2 ] = _direction.z;
+				spotPositions[ spotOffset + 0 ] = _vector3.x;
+				spotPositions[ spotOffset + 1 ] = _vector3.y;
+				spotPositions[ spotOffset + 2 ] = _vector3.z;
 
 				spotDistances[ spotLength ] = distance;
 
 				_vector3.setFromMatrixPosition( light.target.matrixWorld );
 				_direction.sub( _vector3 );
-				_direction.normalize();
+				_direction.transformDirection( viewMatrix );
 
 				spotDirections[ spotOffset + 0 ] = _direction.x;
 				spotDirections[ spotOffset + 1 ] = _direction.y;
@@ -2730,7 +2734,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				if ( ! light.visible ) continue;
 
 				_direction.setFromMatrixPosition( light.matrixWorld );
-				_direction.normalize();
+				_direction.transformDirection( viewMatrix );
 
 				hemiOffset = hemiLength * 3;
 

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -54,7 +54,13 @@ float calcLightAttenuation( float lightDistance, float cutoffDistance, float dec
 
 vec3 F_Schlick( in vec3 specularColor, in float dotLH ) {
 
-	return ( 1.0 - specularColor ) * pow( 1.0 - dotLH, 5.0 ) + specularColor;
+	// Original approximation by Christophe Schlick '94
+	//;float fresnel = pow( 1.0 - dotLH, 5.0 );
+
+	// Optimized variant (presented by Epic at SIGGRAPH '13)
+	float fresnel = exp2( ( -5.55437 * dotLH - 6.98316 ) * dotLH );
+
+	return ( 1.0 - specularColor ) * fresnel + specularColor;
 
 }
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -14,8 +14,7 @@ vec3 normal = normalize( transformedNormal );
 
 		vec3 lightColor = pointLightColor[ i ];
 
-		vec4 lPosition = viewMatrix * vec4( pointLightPosition[ i ], 1.0 );
-		vec3 lVector = lPosition.xyz - mvPosition.xyz;
+		vec3 lVector = pointLightPosition[ i ] - mvPosition.xyz;
 		vec3 lightDir = normalize( lVector );
 
 		// attenuation
@@ -45,11 +44,10 @@ vec3 normal = normalize( transformedNormal );
 		vec3 lightColor = spotLightColor[ i ];
 
 		vec3 lightPosition = spotLightPosition[ i ];
-		vec4 lPosition = viewMatrix * vec4( lightPosition, 1.0 );
-		vec3 lVector = lPosition.xyz - mvPosition.xyz;
+		vec3 lVector = lightPosition - mvPosition.xyz;
 		vec3 lightDir = normalize( lVector );
 
-		float spotEffect = dot( spotLightDirection[ i ], normalize( lightPosition - worldPosition.xyz ) );
+		float spotEffect = dot( spotLightDirection[ i ], lightDir );
 
 		if ( spotEffect > spotLightAngleCos[ i ] ) {
 
@@ -85,7 +83,7 @@ vec3 normal = normalize( transformedNormal );
 
 		vec3 lightColor = directionalLightColor[ i ];
 
-		vec3 lightDir = transformDirection( directionalLightDirection[ i ], viewMatrix );
+		vec3 lightDir = directionalLightDirection[ i ];
 
 		// diffuse
 
@@ -107,7 +105,7 @@ vec3 normal = normalize( transformedNormal );
 
 	for ( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec3 lightDir = transformDirection( hemisphereLightDirection[ i ], viewMatrix );
+		vec3 lightDir = hemisphereLightDirection[ i ];
 
 		// diffuse
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl
@@ -38,8 +38,7 @@ vec3 totalSpecularLight = vec3( 0.0 );
 		vec3 lightColor = pointLightColor[ i ];
 
 		vec3 lightPosition = pointLightPosition[ i ];
-		vec4 lPosition = viewMatrix * vec4( lightPosition, 1.0 );
-		vec3 lVector = lPosition.xyz + vViewPosition.xyz;
+		vec3 lVector = lightPosition + vViewPosition.xyz;
 		vec3 lightDir = normalize( lVector );
 
 		// attenuation
@@ -70,11 +69,10 @@ vec3 totalSpecularLight = vec3( 0.0 );
 		vec3 lightColor = spotLightColor[ i ];
 
 		vec3 lightPosition = spotLightPosition[ i ];
-		vec4 lPosition = viewMatrix * vec4( lightPosition, 1.0 );
-		vec3 lVector = lPosition.xyz + vViewPosition.xyz;
+		vec3 lVector = lightPosition + vViewPosition.xyz;
 		vec3 lightDir = normalize( lVector );
 
-		float spotEffect = dot( spotLightDirection[ i ], normalize( lightPosition - vWorldPosition ) );
+		float spotEffect = dot( spotLightDirection[ i ], lightDir );
 
 		if ( spotEffect > spotLightAngleCos[ i ] ) {
 
@@ -110,7 +108,7 @@ vec3 totalSpecularLight = vec3( 0.0 );
 
 		vec3 lightColor = directionalLightColor[ i ];
 
-		vec3 lightDir = transformDirection( directionalLightDirection[ i ], viewMatrix );
+		vec3 lightDir = directionalLightDirection[ i ];
 
 		// diffuse
 
@@ -132,7 +130,7 @@ vec3 totalSpecularLight = vec3( 0.0 );
 
 	for( int i = 0; i < MAX_HEMI_LIGHTS; i ++ ) {
 
-		vec3 lightDir = transformDirection( hemisphereLightDirection[ i ], viewMatrix );
+		vec3 lightDir = hemisphereLightDirection[ i ];
 
 		// diffuse
 


### PR DESCRIPTION
`MeshPhongMaterial` is currently too slow to portably run on weaker GPUs: On these targets, the frame rate drops dramatically when larger regions are shaded or the context goes bananas when compiling the shader (probably because of its complexity exceeding device / driver limits).

Luckily, this situation can be improved quite easily:

The light positions and directions can be transformed to view space _once_ when setting up the lighting information in the renderer instead of _once per pixel or vertex_. Further, the expensive `pow` special function in the Fresnel term can be avoided using another (visually equivalent) approximation presented by Epic at SG2013. Although looking harmless in GLSL, transforms and `pow` compile to a multitude of instructions at hardware level and add significant complexity per light source.
