### PR TITLE
Allowing anisotropy for floating point textures if linear interpolati…

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2852,7 +2852,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		extension = extensions.get( 'EXT_texture_filter_anisotropic' );
 
-		if ( extension && texture.type !== THREE.FloatType && texture.type !== THREE.HalfFloatType ) {
+		if ( extension ) {
+			if ( texture.type === THREE.FloatType && !extensions.get( 'OES_texture_float_linear' ) ||
+					texture.type === THREE.HalfFloatType && !extensions.get( 'OES_texture_half_float_linear' ) ) {
+				return;
+			}
 
 			if ( texture.anisotropy > 1 || properties.get( texture ).__currentAnisotropy ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2853,10 +2853,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 		extension = extensions.get( 'EXT_texture_filter_anisotropic' );
 
 		if ( extension ) {
-			if ( texture.type === THREE.FloatType && !extensions.get( 'OES_texture_float_linear' ) ||
-					texture.type === THREE.HalfFloatType && !extensions.get( 'OES_texture_half_float_linear' ) ) {
-				return;
-			}
+			if ( texture.type === THREE.FloatType && extensions.get( 'OES_texture_float_linear' ) === null ) return;
+			if ( texture.type === THREE.HalfFloatType && extensions.get( 'OES_texture_half_float_linear' ) === null ) return;
 
 			if ( texture.anisotropy > 1 || properties.get( texture ).__currentAnisotropy ) {
 


### PR DESCRIPTION
…on is supported

Maybe this check should be done before using any linear filtering? Not sure why the check was only being done for anisotropy but I won't change it unless someone gives the go-ahead.
