### PR TITLE
FBX Converter now exports in a ObjectLoader compatible format

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -390,6 +390,8 @@ THREE.ObjectLoader.prototype = {
 				if ( data.aoMap !== undefined ) material.aoMap = getTexture( data.aoMap );
 				if ( data.aoMapIntensity !== undefined ) material.aoMapIntensity = data.aoMapIntensity;
 
+				if ( data.emissiveMap !== undefined ) material.emissiveMap = getTexture( data.emissiveMap );
+
 				if ( data.referencedMaterials !== undefined ) material.referencedMaterials = data.referencedMaterials;
 
 				materials[ data.uuid ] = material;

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -497,7 +497,7 @@ THREE.ObjectLoader.prototype = {
 
 				case 'Scene':
 
-					object = new THREE.Scene();
+					object = new THREE.Scene( data.fog );
 
 					break;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -649,7 +649,17 @@ THREE.ObjectLoader.prototype = {
 			} else {
 
 				if ( data.position !== undefined ) object.position.fromArray( data.position );
-				if ( data.rotation !== undefined ) object.rotation.fromArray( data.rotation );
+
+				if ( data.rotation !== undefined ) {
+
+					object.rotation.fromArray( data.rotation );
+
+				} else if ( data.quaternion !== undefined ) {
+
+					object.quaternion.fromArray( data.quaternion );
+
+				}
+
 				if ( data.scale !== undefined ) object.scale.fromArray( data.scale );
 
 			}

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -2,13 +2,13 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.Scene = function () {
+THREE.Scene = function ( fog ) {
 
 	THREE.Object3D.call( this );
 
 	this.type = 'Scene';
 
-	this.fog = null;
+	this.fog =  ( fog !== undefined ) ? fog : null;
 	this.overrideMaterial = null;
 
 	this.autoUpdate = true; // checked by the renderer

--- a/utils/build/includes/canvas.json
+++ b/utils/build/includes/canvas.json
@@ -45,7 +45,7 @@
 	"src/materials/MeshPhongMaterial.js",
 	"src/materials/MeshDepthMaterial.js",
 	"src/materials/MeshNormalMaterial.js",
-	"src/materials/MeshFaceMaterial.js",
+	"src/materials/MultiMaterial.js",
 	"src/materials/SpriteMaterial.js",
 	"src/textures/Texture.js",
 	"src/textures/CompressedTexture.js",

--- a/utils/converters/fbx/README.md
+++ b/utils/converters/fbx/README.md
@@ -12,16 +12,31 @@ Utility for converting model files to the Three.js JSON format
 ## Usage 
 
 ```
-convert_to_threejs.py [source_file] [output_file] [options]
+convert_to_threejs.py [source_file.fbx] [output_file.js] [options]
 
 Options:
-  -t, --triangulate       force non-triangle geometry into triangles
-  -x, --ignore-textures   don't include texture references in output file
-  -u, --force-prefix      prefix all object names in output file to ensure uniqueness
-  -f, --flatten-scene     merge all geometries and apply node transforms
-  -c, --add-camera        include default camera in output scene
-  -l, --add-light         include default light in output scene
-  -p, --pretty-print      prefix all object names in output file
+  -h, --help            show this help message and exit
+  -t, --triangulate     force quad geometry into triangles
+  -x, --ignore-textures
+                        don't include texture references in output file
+  -n, --no-texture-copy
+                        don't copy texture files
+  -i, --ignore-texture-collisions
+                        Allow copied textures with the same filename to
+                        overwrite each other
+  -o DIR, --texture-output-dir=DIR
+                        write copied textures to specified directory (relative
+                        to the output .js file)
+  -a, --no-transparency-detection
+                        don't automatically enable transparency for materials
+                        with diffuse maps containing alpha
+  -u, --force-prefix    prefix all object names in output file to ensure
+                        uniqueness
+  -f, --flatten-scene   merge all geometries and apply node transforms
+  -y, --force-y-up      ensure that the y axis shows up
+  -c, --add-camera      include default camera in output scene
+  -l, --add-light       include default light in output scene
+  -p, --pretty-print    nicely format the output JSON
 ```
 
 ## Current Limitations
@@ -31,7 +46,6 @@ Options:
 * Some camera properties are not converted correctly
 * Some light properties are not converted correctly
 * Some material properties are not converted correctly
-* Textures must be put in asset's folder, and use relative path in the material
 
 ## Dependencies
 

--- a/utils/converters/fbx/convert_to_threejs.py
+++ b/utils/converters/fbx/convert_to_threejs.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python
 # @author zfedoran / http://github.com/zfedoran
 
 import os

--- a/utils/converters/fbx/convert_to_threejs.py
+++ b/utils/converters/fbx/convert_to_threejs.py
@@ -290,8 +290,7 @@ def triangulate_scene(scene):
 def detect_texture_transparency(texture_path):
     args = ('identify', '-verbose', texture_path)
     popen = subprocess.Popen(args, stdout=subprocess.PIPE)
-    popen.wait()
-    output = popen.stdout.read()
+    output = popen.communicate()[0]
     match = re.search('Alpha:\s*\n\s*min: [0-9]+ \([0-9.]+\)\s*\n\s*max: [0-9]+ \([0-9.]+\)\s*\n\s*mean: ([0-9.]+)', output)
 
     try:
@@ -510,8 +509,7 @@ def copy_texture(source_path):
         if texture_conversion_enabled:
             args = ('identify', '-format', '%m', source_path)
             popen = subprocess.Popen(args, stdout=subprocess.PIPE)
-            popen.wait()
-            image_format = popen.stdout.read().strip()
+            image_format = popen.communicate()[0].strip()
             convert = image_format not in WEB_FORMATS
             if convert:
                 extension = '.png' if detect_texture_transparency(source_path) else '.jpg'
@@ -539,7 +537,7 @@ def copy_texture(source_path):
                 try:
                     args = ('convert', source_path, destination_path)
                     popen = subprocess.Popen(args)
-                    popen.wait()
+                    popen.communicate()
                 except (OSError) as e:
                     sys.exit(-1)
             else:
@@ -1975,7 +1973,7 @@ if __name__ == "__main__":
     identify_present = False
     try:
         popen = subprocess.Popen(('identify', '-help'), stdout=subprocess.PIPE)
-        popen.wait()
+        popen.communicate()
         identify_present = True
     except OSError as e:
         pass
@@ -1991,7 +1989,7 @@ if __name__ == "__main__":
         convert_present = False
         try:
             popen = subprocess.Popen(('convert', '-help'), stdout=subprocess.PIPE)
-            popen.wait()
+            popen.communicate()
             convert_present = True
         except OSError as e:
             pass

--- a/utils/converters/fbx/convert_to_threejs.py
+++ b/utils/converters/fbx/convert_to_threejs.py
@@ -6,8 +6,9 @@ import math
 import operator
 import re
 import json
-import types
 import shutil
+import subprocess
+import uuid
 
 # #####################################################
 # Globals
@@ -15,6 +16,9 @@ import shutil
 option_triangulate = True
 option_textures = True
 option_copy_textures = True
+option_ignore_texture_collision = False
+option_texture_output_dir = 'maps'
+option_transparency_detection = True
 option_prefix = True
 option_geometry = False
 option_forced_y_up = False
@@ -22,9 +26,32 @@ option_default_camera = False
 option_default_light = False
 option_pretty_print = False
 
+texture_conversion_enabled = True
+
+metadata_key = 'metadata'
+children_key = 'children'
+data_key = 'data'
+type_key = 'type'
+uuid_key = 'uuid'
+name_key = 'name'
+
 converter = None
-inputFolder = ""
-outputFolder = ""
+output_directory = ''
+
+copied_texture_dict = {}
+
+WEB_FORMATS = ['PNG', 'JPEG', 'GIF']
+
+FBX_TEXTURE_BINDINGS = {
+  'DiffuseColor': 'map',
+  'EmissiveColor': 'emissiveMap',
+  'SpecularColor': 'specularMap',
+  'NormalMap': 'normalMap',
+  'Bump': 'bumpMap',
+  'TransparencyFactor': 'alphaMap',
+  'ReflectionColor': 'envMap',
+  'AmbientFactor': 'aoMap'
+}
 
 # #####################################################
 # Pretty Printing Hacks
@@ -48,8 +75,8 @@ class ChunkedIndent(object):
         self.force_rounding = force_rounding
     def encode(self):
         # Turn the flat array into an array of arrays where each subarray is of
-        # length chunk_size. Then string concat the values in the chunked 
-        # arrays, delimited with a ', ' and round the values finally append 
+        # length chunk_size. Then string concat the values in the chunked
+        # arrays, delimited with a ', ' and round the values finally append
         # '{CHUNK}' so that we can find the strings with regex later
         if not self.value:
             return None
@@ -58,8 +85,7 @@ class ChunkedIndent(object):
         else:
             return ['{CHUNK}%s' % ', '.join(str(f) for f in self.value[i:i+self.size]) for i in range(0, len(self.value), self.size)]
 
-# This custom encoder looks for instances of NoIndent or ChunkedIndent. 
-# When it finds 
+# This custom encoder looks for instances of NoIndent or ChunkedIndent.
 class CustomEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, NoIndent) or isinstance(obj, ChunkedIndent):
@@ -67,16 +93,19 @@ class CustomEncoder(json.JSONEncoder):
         else:
             return json.JSONEncoder.default(self, obj)
 
-def executeRegexHacks(output_string):
+def execute_regex_hacks(output_string):
     # turn strings of arrays into arrays (remove the double quotes)
     output_string = re.sub(':\s*\"(\[.*\])\"', r': \1', output_string)
     output_string = re.sub('(\n\s*)\"(\[.*\])\"', r'\1\2', output_string)
     output_string = re.sub('(\n\s*)\"{CHUNK}(.*)\"', r'\1\2', output_string)
 
-    # replace '0metadata' with metadata
-    output_string = re.sub('0metadata', r'metadata', output_string)
-    # replace 'zchildren' with children
-    output_string = re.sub('zchildren', r'children', output_string)
+    # replace alphabetically sorted keys with regular keys
+    output_string = re.sub(metadata_key, r'metadata', output_string)
+    output_string = re.sub(children_key, r'children', output_string)
+    output_string = re.sub(data_key, r'data', output_string)
+    output_string = re.sub(type_key, r'type', output_string)
+    output_string = re.sub(uuid_key, r'uuid', output_string)
+    output_string = re.sub(name_key, r'name', output_string)
 
     # add an extra newline after '"children": {'
     output_string = re.sub('(children.*{\s*\n)', r'\1\n', output_string)
@@ -92,7 +121,7 @@ def executeRegexHacks(output_string):
 # #####################################################
 
 # FbxVector2 is not JSON serializable
-def serializeVector2(v, round_vector = False):
+def serialize_vector2(v, round_vector = False):
     # JSON does not support NaN or Inf
     if math.isnan(v[0]) or math.isinf(v[0]):
         v[0] = 0
@@ -106,7 +135,7 @@ def serializeVector2(v, round_vector = False):
         return [v[0], v[1]]
 
 # FbxVector3 is not JSON serializable
-def serializeVector3(v, round_vector = False):
+def serialize_vector3(v, round_vector = False):
     # JSON does not support NaN or Inf
     if math.isnan(v[0]) or math.isinf(v[0]):
         v[0] = 0
@@ -122,7 +151,7 @@ def serializeVector3(v, round_vector = False):
         return [v[0], v[1], v[2]]
 
 # FbxVector4 is not JSON serializable
-def serializeVector4(v, round_vector = False):
+def serialize_vector4(v, round_vector = False):
     # JSON does not support NaN or Inf
     if math.isnan(v[0]) or math.isinf(v[0]):
         v[0] = 0
@@ -142,21 +171,18 @@ def serializeVector4(v, round_vector = False):
 # #####################################################
 # Helpers
 # #####################################################
-def getRadians(v):
-    return ((v[0]*math.pi)/180, (v[1]*math.pi)/180, (v[2]*math.pi)/180)
-
-def getHex(c):
+def pack_color(c):
     color = (int(c[0]*255) << 16) + (int(c[1]*255) << 8) + int(c[2]*255)
     return int(color)
 
-def setBit(value, position, on):
+def set_bit(value, position, on):
     if on:
         mask = 1 << position
         return (value | mask)
     else:
         mask = ~(1 << position)
         return (value & mask)
-    
+
 def generate_uvs(uv_layers):
     layers = []
     for uvs in uv_layers:
@@ -174,9 +200,9 @@ def generate_uvs(uv_layers):
 # #####################################################
 # Object Name Helpers
 # #####################################################
-def hasUniqueName(o, class_id):
+def has_unique_name(o, class_id):
     scene = o.GetScene()
-    object_name = o.GetName() 
+    object_name = o.GetName()
     object_id = o.GetUniqueID()
 
     object_count = scene.GetSrcObjectCount(class_id)
@@ -184,7 +210,7 @@ def hasUniqueName(o, class_id):
     for i in range(object_count):
         other = scene.GetSrcObject(class_id, i)
         other_id = other.GetUniqueID()
-        other_name = other.GetName() 
+        other_name = other.GetName()
 
         if other_id == object_id:
             continue
@@ -193,73 +219,54 @@ def hasUniqueName(o, class_id):
 
     return True
 
-def getObjectName(o, force_prefix = False): 
+def get_object_name(o, force_prefix = False):
     if not o:
-        return ""  
+        return ""
 
-    object_name = o.GetName() 
-    object_id = o.GetUniqueID()
+    if option_prefix or force_prefix or not has_unique_name(o, FbxNode.ClassId):
+        return "Object_%s_" % o.GetUniqueID() + o.GetName()
+    else:
+        return o.GetName()
 
-    if not force_prefix:
-        force_prefix = not hasUniqueName(o, FbxNode.ClassId)
+def get_multi_material_name(o):
+    if option_prefix or not has_unique_name(o, FbxSurfaceMaterial.ClassId):
+        return "Material_%s_" % o.GetUniqueID() + o.GetName()
+    else:
+        return o.GetName()
 
-    prefix = ""
-    if option_prefix or force_prefix:
-        prefix = "Object_%s_" % object_id
+def get_material_name(o):
+    return "Material_%s_" % o.GetUniqueID() + o.GetName()
 
-    return prefix + object_name
-
-def getMaterialName(o, force_prefix = False):
-    object_name = o.GetName() 
-    object_id = o.GetUniqueID()
-
-    if not force_prefix:
-        force_prefix = not hasUniqueName(o, FbxSurfaceMaterial.ClassId)
-
-    prefix = ""
-    if option_prefix or force_prefix:
-        prefix = "Material_%s_" % object_id
-
-    return prefix + object_name
-
-def getTextureName(t, force_prefix = False):
+def get_texture_name(t):
     if type(t) is FbxFileTexture:
         texture_file = t.GetFileName()
-        texture_id = os.path.splitext(os.path.basename(texture_file))[0]
+        texture_name = os.path.splitext(os.path.basename(texture_file))[0]
     else:
-        texture_id = t.GetName()
-        if texture_id == "_empty_":
-            texture_id = ""
-    prefix = ""
-    if option_prefix or force_prefix:
-        prefix = "Texture_%s_" % t.GetUniqueID()
-        if len(texture_id) == 0:
-            prefix = prefix[0:len(prefix)-1]
-    return prefix + texture_id
+        texture_name = t.GetName()
+        if texture_name == "_empty_":
+            texture_name = ""
 
-def getMtlTextureName(texture_name, texture_id, force_prefix = False):
-    texture_name = os.path.splitext(texture_name)[0]
-    prefix = ""
-    if option_prefix or force_prefix:
-        prefix = "Texture_%s_" % texture_id
-    return prefix + texture_name
+    if len(texture_name) == 0:
+        return "Texture_" + t.GetUniqueID()
+    else:
+        return "Texture_%s_" % t.GetUniqueID() + texture_name
 
-def getPrefixedName(o, prefix):
-    return (prefix + '_%s_') % o.GetUniqueID() + o.GetName()
+def get_geometry_name(o):
+    return 'Geometry_%s_' % o.GetUniqueID() + o.GetName()
 
 # #####################################################
-# Triangulation 
+# Triangulation
 # #####################################################
 def triangulate_node_hierarchy(node):
-    node_attribute = node.GetNodeAttribute();
+    node_attribute = node.GetNodeAttribute()
 
     if node_attribute:
         if node_attribute.GetAttributeType() == FbxNodeAttribute.eMesh or \
-           node_attribute.GetAttributeType() == FbxNodeAttribute.eNurbs or \
-           node_attribute.GetAttributeType() == FbxNodeAttribute.eNurbsSurface or \
-           node_attribute.GetAttributeType() == FbxNodeAttribute.ePatch:
-            converter.TriangulateInPlace(node);
-        
+                        node_attribute.GetAttributeType() == FbxNodeAttribute.eNurbs or \
+                        node_attribute.GetAttributeType() == FbxNodeAttribute.eNurbsSurface or \
+                        node_attribute.GetAttributeType() == FbxNodeAttribute.ePatch:
+            converter.TriangulateInPlace(node)
+
         child_count = node.GetChildCount()
         for i in range(child_count):
             triangulate_node_hierarchy(node.GetChild(i))
@@ -273,28 +280,31 @@ def triangulate_scene(scene):
 # #####################################################
 # Generate Material Object
 # #####################################################
-def generate_texture_bindings(material_property, material_params):
-    # FBX to Three.js texture types 
-    binding_types = {
-        "DiffuseColor": "map", 
-        "DiffuseFactor": "diffuseFactor", 
-        "EmissiveColor": "emissiveMap", 
-        "EmissiveFactor": "emissiveFactor", 
-        "AmbientColor": "lightMap", # "ambientMap", 
-        "AmbientFactor": "ambientFactor", 
-        "SpecularColor": "specularMap", 
-        "SpecularFactor": "specularFactor", 
-        "ShininessExponent": "shininessExponent",
-        "NormalMap": "normalMap", 
-        "Bump": "bumpMap", 
-        "TransparentColor": "transparentMap", 
-        "TransparencyFactor": "transparentFactor", 
-        "ReflectionColor": "reflectionMap", 
-        "ReflectionFactor": "reflectionFactor", 
-        "DisplacementColor": "displacementMap", 
-        "VectorDisplacementColor": "vectorDisplacementMap"
-    }
+def detect_texture_transparency(texture_path):
+    args = ('identify', '-verbose', texture_path)
+    popen = subprocess.Popen(args, stdout=subprocess.PIPE)
+    popen.wait()
+    output = popen.stdout.read()
+    match = re.search('Alpha:\s*\n\s*min: [0-9]+ \([0-9.]+\)\s*\n\s*max: [0-9]+ \([0-9.]+\)\s*\n\s*mean: ([0-9.]+)', output)
 
+    try:
+        variable_alpha = float(match.group(1)) > 0.0
+    except:
+        variable_alpha = False
+
+    return variable_alpha or ('Alpha:' in output and 'Alpha: none' not in output)
+
+def bind_texture(material_object, texture_dict, fbx_texture_type, texture):
+    if fbx_texture_type in FBX_TEXTURE_BINDINGS:
+        binding_type = FBX_TEXTURE_BINDINGS[fbx_texture_type]
+        texture_uuid = texture_dict[get_texture_name(texture)]
+        material_object[binding_type] = texture_uuid
+        if option_transparency_detection and binding_type == 'map':
+            material_object['transparent'] = detect_texture_transparency(texture.GetFileName())
+    else:
+        sys.stderr.write("Warning: %s is not a supported texture type - %s was not bound.\n" % (fbx_texture_type, texture.GetFileName()))
+
+def generate_texture_bindings(material_property, material_object, texture_dict):
     if material_property.IsValid():
         #Here we have to check if it's layeredtextures, or just textures:
         layered_texture_count = material_property.GetSrcObjectCount(FbxLayeredTexture.ClassId)
@@ -304,154 +314,136 @@ def generate_texture_bindings(material_property, material_params):
                 texture_count = layered_texture.GetSrcObjectCount(FbxTexture.ClassId)
                 for k in range(texture_count):
                     texture = layered_texture.GetSrcObject(FbxTexture.ClassId,k)
-                    if texture:
-                        texture_id = getTextureName(texture, True)
-                        material_params[binding_types[str(material_property.GetName())]] = texture_id
+                    if texture and type(texture) is FbxFileTexture:
+                        bind_texture(material_object, texture_dict, str(material_property.GetName()), texture)
         else:
             # no layered texture simply get on the property
             texture_count = material_property.GetSrcObjectCount(FbxTexture.ClassId)
             for j in range(texture_count):
                 texture = material_property.GetSrcObject(FbxTexture.ClassId,j)
-                if texture:
-                    texture_id = getTextureName(texture, True)
-                    material_params[binding_types[str(material_property.GetName())]] = texture_id
+                if texture and type(texture) is FbxFileTexture:
+                    bind_texture(material_object, texture_dict, str(material_property.GetName()), texture)
 
-def generate_material_object(material):
-    #Get the implementation to see if it's a hardware shader.
-    implementation = GetImplementation(material, "ImplementationHLSL")
-    implementation_type = "HLSL"
-    if not implementation:
-        implementation = GetImplementation(material, "ImplementationCGFX")
-        implementation_type = "CGFX"
+def generate_material_object(material, texture_dict, material_list, material_dict):
 
-    output = None
-    material_params = None
     material_type = None
+    material_object = None
 
-    if implementation:
-        print("Shader materials are not supported")
-        
+    if GetImplementation(material, "ImplementationHLSL") or GetImplementation(material, "ImplementationCGFX"):
+
+        sys.stderr.write("Shader materials are not supported\n")
+
     elif material.GetClassId().Is(FbxSurfaceLambert.ClassId):
 
-        ambient   = getHex(material.Ambient.Get())
-        diffuse   = getHex(material.Diffuse.Get())
-        emissive  = getHex(material.Emissive.Get())
-        opacity   = 1.0 - material.TransparencyFactor.Get()
-        opacity   = 1.0 if opacity == 0 else opacity
-        opacity   = opacity
-        transparent = False
+        diffuse = pack_color(material.Diffuse.Get())
+        emissive = pack_color(material.Emissive.Get())
+        opacity = 1.0 if material.TransparencyFactor.Get() == 1.0 else 1.0 - material.TransparencyFactor.Get()
+        transparent = opacity < 0.9995
         reflectivity = 1
 
-        material_type = 'MeshBasicMaterial'
-#        material_type = 'MeshLambertMaterial'
-        material_params = {
-
-          'color' : diffuse,
-          'ambient' : ambient,
-          'emissive' : emissive,
-          'reflectivity' : reflectivity,
-          'transparent' : transparent,
-          'opacity' : opacity
-
+        material_type = 'MeshLambertMaterial'
+        material_object = {
+          'color': diffuse,
+          'emissive': emissive,
+          'reflectivity': reflectivity,
+          'transparent': transparent,
+          'opacity': opacity
         }
 
     elif material.GetClassId().Is(FbxSurfacePhong.ClassId):
 
-        ambient   = getHex(material.Ambient.Get())
-        diffuse   = getHex(material.Diffuse.Get())
-        emissive  = getHex(material.Emissive.Get())
-        specular  = getHex(material.Specular.Get())
-        opacity   = 1.0 - material.TransparencyFactor.Get()
-        opacity   = 1.0 if opacity == 0 else opacity
-        opacity   = opacity
+        diffuse = pack_color(material.Diffuse.Get())
+        emissive = pack_color(material.Emissive.Get())
+        specular = pack_color(material.Specular.Get())
+        opacity = 1.0 if material.TransparencyFactor.Get() == 1.0 else 1.0 - material.TransparencyFactor.Get()
+        transparent = opacity < 0.9995
         shininess = material.Shininess.Get()
-        transparent = False
         reflectivity = 1
-        bumpScale = 1
+        bump_scale = 1
 
         material_type = 'MeshPhongMaterial'
-        material_params = {
-
-          'color' : diffuse,
-          'ambient' : ambient,
-          'emissive' : emissive,
-          'specular' : specular,
-          'shininess' : shininess,
-          'bumpScale' : bumpScale,
-          'reflectivity' : reflectivity,
-          'transparent' : transparent,
-          'opacity' : opacity
-
+        material_object = {
+          'color': diffuse,
+          'emissive': emissive,
+          'specular': specular,
+          'shininess': shininess,
+          'bumpScale': bump_scale,
+          'reflectivity': reflectivity,
+          'transparent': transparent,
+          'opacity': opacity
         }
 
     else:
-        print "Unknown type of Material", getMaterialName(material)
+        sys.stderr.write("Unknown type of material: {0}\n".format(get_material_name(material)))
 
-    # default to Lambert Material if the current Material type cannot be handeled
-    if not material_type:
-        ambient   = getHex((0,0,0))
-        diffuse   = getHex((0.5,0.5,0.5))
-        emissive  = getHex((0,0,0))
-        opacity   = 1
+    # default to MeshBasicMaterial if the current material type cannot be handeled
+    if material_type == None or material_object == None:
+        diffuse = pack_color((0.5,0.5,0.5))
+        emissive = pack_color((0,0,0))
+        opacity = 1
         transparent = False
         reflectivity = 1
 
-        material_type = 'MeshLambertMaterial'
-        material_params = {
-
-          'color' : diffuse,
-          'ambient' : ambient,
-          'emissive' : emissive,
-          'reflectivity' : reflectivity,
-          'transparent' : transparent,
-          'opacity' : opacity
-
+        material_type = 'MeshBasicMaterial'
+        material_object = {
+          'color': diffuse,
+          'emissive': emissive,
+          'reflectivity': reflectivity,
+          'transparent': transparent,
+          'opacity': opacity
         }
 
     if option_textures:
         texture_count = FbxLayerElement.sTypeTextureCount()
         for texture_index in range(texture_count):
             material_property = material.FindProperty(FbxLayerElement.sTextureChannelNames(texture_index))
-            generate_texture_bindings(material_property, material_params)
+            generate_texture_bindings(material_property, material_object, texture_dict)
 
-    material_params['wireframe'] = False
-    material_params['wireframeLinewidth'] = 1
+    material_object['wireframe'] = False
+    material_object['wireframeLinewidth'] = 1
 
-    output = {
-      'type' : material_type,
-      'parameters' : material_params
-    }
+    if 'map' in material_object: # If we have a diffuse map, we don't want diffuse color
+        del material_object['color']
 
-    return output
+    material_uuid = str(uuid.uuid4())
+    material_name = get_material_name(material)
 
-def generate_proxy_material_object(node, material_names):
-    
-    material_type = 'MeshFaceMaterial'
-    material_params = { 
-      'materials' : material_names 
-    }
+    material_object[type_key] = material_type
+    material_object[uuid_key] = material_uuid
+    material_object[name_key] = material_name
 
-    output = {
-      'type' : material_type,
-      'parameters' : material_params
-    }
+    material_list.append(material_object)
+    material_dict[material_name] = material_uuid
 
-    return output
+def generate_multi_material_object(node, submaterial_uuids, material_list, material_dict):
+
+    material_type = 'MultiMaterial'
+    material_uuid = str(uuid.uuid4())
+    material_name = get_multi_material_name(node)
+
+    material_list.append({
+      type_key: material_type,
+      uuid_key: material_uuid,
+      name_key: material_name,
+      'referencedMaterials': submaterial_uuids
+    })
+    material_dict[material_name] = material_uuid
 
 # #####################################################
 # Find Scene Materials
 # #####################################################
-def extract_materials_from_node(node, material_dict):
-    name = node.GetName()
-    mesh = node.GetNodeAttribute()
+def extract_multi_materials_from_node(node, material_list, material_dict):
+    material_count = 0
 
+    mesh = node.GetNodeAttribute()
     node = None
+
     if mesh:
         node = mesh.GetNode()
         if node:
             material_count = node.GetMaterialCount()
-    
-    material_names = []
+
+    material_uuids = []
     for l in range(mesh.GetLayerCount()):
         materials = mesh.GetLayer(l).GetMaterials()
         if materials:
@@ -460,109 +452,137 @@ def extract_materials_from_node(node, material_dict):
                 continue
             for i in range(material_count):
                 material = node.GetMaterial(i)
-                material_names.append(getMaterialName(material))
+                material_uuids.append(material_dict[get_material_name(material)])
 
     if material_count > 1:
-        proxy_material = generate_proxy_material_object(node, material_names)
-        proxy_name = getMaterialName(node, True)
-        material_dict[proxy_name] = proxy_material
+        generate_multi_material_object(node, material_uuids, material_list, material_dict)
 
-def generate_materials_from_hierarchy(node, material_dict):
+def generate_multi_materials_from_hierarchy(node, material_list, material_dict):
     if node.GetNodeAttribute() == None:
         pass
     else:
         attribute_type = (node.GetNodeAttribute().GetAttributeType())
         if attribute_type == FbxNodeAttribute.eMesh:
-            extract_materials_from_node(node, material_dict)
+            extract_multi_materials_from_node(node, material_list, material_dict)
     for i in range(node.GetChildCount()):
-        generate_materials_from_hierarchy(node.GetChild(i), material_dict)
+        generate_multi_materials_from_hierarchy(node.GetChild(i), material_list, material_dict)
 
-def generate_material_dict(scene):
+def generate_material_list(scene, texture_dict):
+    material_list = []
     material_dict = {}
 
     # generate all materials for this scene
     material_count = scene.GetSrcObjectCount(FbxSurfaceMaterial.ClassId)
     for i in range(material_count):
         material = scene.GetSrcObject(FbxSurfaceMaterial.ClassId, i)
-        material_object = generate_material_object(material)
-        material_name = getMaterialName(material)
-        material_dict[material_name] = material_object
+        generate_material_object(material, texture_dict, material_list, material_dict)
 
-    # generate material porxies
     # Three.js does not support meshs with multiple materials, however it does
     # support materials with multiple submaterials
     node = scene.GetRootNode()
     if node:
         for i in range(node.GetChildCount()):
-            generate_materials_from_hierarchy(node.GetChild(i), material_dict)
+            generate_multi_materials_from_hierarchy(node.GetChild(i), material_list, material_dict)
 
-    return material_dict
+    return material_list, material_dict
 
 # #####################################################
-# Generate Texture Object 
+# Generate Texture Object
 # #####################################################
-def generate_texture_object(texture):
+def copy_texture(source_path):
+    if os.path.exists(source_path):
+        filename = os.path.basename(source_path)
 
-    #TODO: extract more texture properties
-    wrap_u = texture.GetWrapModeU()
-    wrap_v = texture.GetWrapModeV()
-    offset = texture.GetUVTranslation()
+        if option_copy_textures:
+            relative_path = os.path.join(option_texture_output_dir, filename)
+        else:
+            relative_path = filename
 
-    if type(texture) is FbxFileTexture:
-        url = texture.GetFileName()
+        convert = False
+
+        if texture_conversion_enabled:
+            args = ('identify', '-format', '%m', source_path)
+            popen = subprocess.Popen(args, stdout=subprocess.PIPE)
+            popen.wait()
+            image_format = popen.stdout.read()
+            convert = image_format not in WEB_FORMATS
+            if convert:
+                extension = '.png' if detect_texture_transparency(source_path) else '.jpg'
+                relative_path = os.path.splitext(relative_path)[0] + extension
+
+        if relative_path in copied_texture_dict:
+            previous_source = copied_texture_dict[relative_path]
+
+            if previous_source != source_path:
+                if option_ignore_texture_collision:
+                    sys.stderr.write("Warning: Ignored texture collision at {0}. {1} will be used instead of {2}\n".format(relative_path, previous_source, source_path))
+                else:
+                    sys.exit("Error: Texture names not unique. Both {0} and {1} end up as {2}".format(previous_source, source_path, relative_path))
+        else:
+            destination_path = os.path.join(output_directory, relative_path)
+            destination_directory = os.path.dirname(destination_path)
+
+            if not os.path.exists(destination_directory):
+                try:
+                    os.makedirs(destination_directory)
+                except IOError as e:
+                    sys.exit("I/O error({0}) {1}: creating directory {2}".format(e.errno, e.strerror, destination_directory))
+
+            if convert:
+                try:
+                    args = ('convert', source_path, destination_path)
+                    popen = subprocess.Popen(args)
+                    popen.wait()
+                except (OSError) as e:
+                    sys.exit(-1)
+            else:
+                try:
+                    shutil.copyfile(source_path, destination_path)
+                except IOError as e:
+                    sys.exit("I/O error({0}) {1}: copying {2} to {3}".format(e.errno, e.strerror, source_path, destination_path))
+
+            copied_texture_dict[relative_path] = source_path
+
+        return relative_path
     else:
-        url = getTextureName( texture )
-        
-    #url = replace_inFolder2OutFolder( url )
-    #print( url )
+        sys.exit("ERROR: Couldn't locate referenced texture " + source_path)
 
-    index = url.rfind( '/' )
-    if index == -1:
-        index = url.rfind( '\\' )
-    filename = url[ index+1 : len(url) ]
+def generate_texture_data(texture, image_dict, texture_list, texture_dict):
+    if type(texture) is FbxFileTexture:
+        texture_path = texture.GetFileName()
+    else:
+        texture_path = texture.getName()
 
-    output = {
+    if option_copy_textures:
+        relative_path = copy_texture(texture_path)
+    else:
+        relative_path = os.path.basename(texture_path)
 
-      'url': filename,
-      'fullpath': url,
-      'repeat': serializeVector2( (1,1) ),
-      'offset': serializeVector2( texture.GetUVTranslation() ),
-      'magFilter': 'LinearFilter',
-      'minFilter': 'LinearMipMapLinearFilter',
+    if relative_path in image_dict:
+        image_uuid = image_dict[relative_path]
+    else:
+        image_uuid = str(uuid.uuid4())
+        image_dict[relative_path] = image_uuid
+
+    texture_uuid = str(uuid.uuid4())
+    texture_name = get_texture_name(texture)
+
+    texture_list.append({
+      uuid_key: texture_uuid,
+      name_key: texture_name,
+      'image': image_uuid,
+      'repeat': serialize_vector2((1,1)),
+      'offset': serialize_vector2(texture.GetUVTranslation()),
+      'magFilter': 1006, # THREE.LinearFilter
+      'minFilter': 1008, # THREE.LinearMipMapLinearFilter
       'anisotropy': True
-
-    }
-    
-    return output
-
-# #####################################################
-# Replace Texture input path to output
-# #####################################################
-def replace_inFolder2OutFolder(url):
-    folderIndex =  url.find(inputFolder)
-        
-    if  folderIndex != -1:
-        url = url[ folderIndex+len(inputFolder): ]
-        url = outputFolder + url
-            
-    return url
-
-# #####################################################
-# Replace Texture output path to input
-# #####################################################
-def replace_OutFolder2inFolder(url):
-    folderIndex =  url.find(outputFolder)
-        
-    if  folderIndex != -1:
-        url = url[ folderIndex+len(outputFolder): ]
-        url = inputFolder + url
-            
-    return url
+    })
+    texture_dict[texture_name] = texture_uuid
 
 # #####################################################
 # Find Scene Textures
 # #####################################################
-def extract_material_textures(material_property, texture_dict):
+def extract_material_textures(material_property, texture_list, texture_dict, image_dict):
     if material_property.IsValid():
         #Here we have to check if it's layeredtextures, or just textures:
         layered_texture_count = material_property.GetSrcObjectCount(FbxLayeredTexture.ClassId)
@@ -573,55 +593,57 @@ def extract_material_textures(material_property, texture_dict):
                 for k in range(texture_count):
                     texture = layered_texture.GetSrcObject(FbxTexture.ClassId,k)
                     if texture:
-                        texture_object = generate_texture_object(texture)
-                        texture_name = getTextureName( texture, True )
-                        texture_dict[texture_name] = texture_object
+                        generate_texture_data(texture, image_dict, texture_list, texture_dict)
         else:
             # no layered texture simply get on the property
             texture_count = material_property.GetSrcObjectCount(FbxTexture.ClassId)
             for j in range(texture_count):
                 texture = material_property.GetSrcObject(FbxTexture.ClassId,j)
                 if texture:
-                    texture_object = generate_texture_object(texture)
-                    texture_name = getTextureName( texture, True )
-                    texture_dict[texture_name] = texture_object
+                    generate_texture_data(texture, image_dict, texture_list, texture_dict)
 
-def extract_textures_from_node(node, texture_dict):
-    name = node.GetName()
+def extract_textures_from_node(node, texture_list, texture_dict, image_dict):
     mesh = node.GetNodeAttribute()
-    
+
     #for all materials attached to this mesh
     material_count = mesh.GetNode().GetSrcObjectCount(FbxSurfaceMaterial.ClassId)
     for material_index in range(material_count):
         material = mesh.GetNode().GetSrcObject(FbxSurfaceMaterial.ClassId, material_index)
 
         #go through all the possible textures types
-        if material:            
+        if material:
             texture_count = FbxLayerElement.sTypeTextureCount()
             for texture_index in range(texture_count):
                 material_property = material.FindProperty(FbxLayerElement.sTextureChannelNames(texture_index))
-                extract_material_textures(material_property, texture_dict)
+                extract_material_textures(material_property, texture_list, texture_dict, image_dict)
 
-def generate_textures_from_hierarchy(node, texture_dict):
+def generate_textures_from_hierarchy(node, texture_list, texture_dict, image_dict):
     if node.GetNodeAttribute() == None:
         pass
     else:
         attribute_type = (node.GetNodeAttribute().GetAttributeType())
         if attribute_type == FbxNodeAttribute.eMesh:
-            extract_textures_from_node(node, texture_dict)
+            extract_textures_from_node(node, texture_list, texture_dict, image_dict)
     for i in range(node.GetChildCount()):
-        generate_textures_from_hierarchy(node.GetChild(i), texture_dict)
+        generate_textures_from_hierarchy(node.GetChild(i), texture_list, texture_dict, image_dict)
 
-def generate_texture_dict(scene):
+def generate_texture_and_image_lists(scene):
     if not option_textures:
         return {}
 
+    texture_list = []
     texture_dict = {}
+    image_dict = {}
     node = scene.GetRootNode()
     if node:
         for i in range(node.GetChildCount()):
-            generate_textures_from_hierarchy(node.GetChild(i), texture_dict)
-    return texture_dict
+            generate_textures_from_hierarchy(node.GetChild(i), texture_list, texture_dict, image_dict)
+
+    image_list = []
+    for url, image_uuid in image_dict.iteritems():
+        image_list.append({uuid_key: image_uuid, 'url': url})
+
+    return texture_list, image_list, texture_dict
 
 # #####################################################
 # Extract Fbx SDK Mesh Data
@@ -644,14 +666,14 @@ def extract_fbx_vertex_positions(mesh):
         r = FbxVector4(r[0], r[1], r[2], 1)
         s = node.GeometricScaling.Get()
         s = FbxVector4(s[0], s[1], s[2], 1)
-        
-        hasGeometricTransform = False
+
+        has_geometric_transform = False
         if t[0] != 0 or t[1] != 0 or t[2] != 0 or \
-           r[0] != 0 or r[1] != 0 or r[2] != 0 or \
-           s[0] != 1 or s[1] != 1 or s[2] != 1:
-            hasGeometricTransform = True
-        
-        if hasGeometricTransform:
+                        r[0] != 0 or r[1] != 0 or r[2] != 0 or \
+                        s[0] != 1 or s[1] != 1 or s[2] != 1:
+            has_geometric_transform = True
+
+        if has_geometric_transform:
             geo_transform = FbxMatrix(t,r,s)
         else:
             geo_transform = FbxMatrix()
@@ -664,9 +686,9 @@ def extract_fbx_vertex_positions(mesh):
             transform = node.EvaluateGlobalTransform()
             transform = FbxMatrix(transform) * geo_transform
 
-        elif hasGeometricTransform:
+        elif has_geometric_transform:
             transform = geo_transform
-            
+
         if transform:
             for i in range(len(positions)):
                 v = positions[i]
@@ -677,27 +699,26 @@ def extract_fbx_vertex_positions(mesh):
     return positions
 
 def extract_fbx_vertex_normals(mesh):
-#   eNone             The mapping is undetermined.
-#   eByControlPoint   There will be one mapping coordinate for each surface control point/vertex.
-#   eByPolygonVertex  There will be one mapping coordinate for each vertex, for every polygon of which it is a part. This means that a vertex will have as many mapping coordinates as polygons of which it is a part.
-#   eByPolygon        There can be only one mapping coordinate for the whole polygon.
-#   eByEdge           There will be one mapping coordinate for each unique edge in the mesh. This is meant to be used with smoothing layer elements.
-#   eAllSame          There can be only one mapping coordinate for the whole surface.
+    #   eNone             The mapping is undetermined.
+    #   eByControlPoint   There will be one mapping coordinate for each surface control point/vertex.
+    #   eByPolygonVertex  There will be one mapping coordinate for each vertex, for every polygon of which it is a part. This means that a vertex will have as many mapping coordinates as polygons of which it is a part.
+    #   eByPolygon        There can be only one mapping coordinate for the whole polygon.
+    #   eByEdge           There will be one mapping coordinate for each unique edge in the mesh. This is meant to be used with smoothing layer elements.
+    #   eAllSame          There can be only one mapping coordinate for the whole surface.
 
     layered_normal_indices = []
     layered_normal_values = []
 
     poly_count = mesh.GetPolygonCount()
-    control_points = mesh.GetControlPoints() 
 
     for l in range(mesh.GetLayerCount()):
         mesh_normals = mesh.GetLayer(l).GetNormals()
         if not mesh_normals:
             continue
-          
+
         normals_array = mesh_normals.GetDirectArray()
         normals_count = normals_array.GetCount()
-  
+
         if normals_count == 0:
             continue
 
@@ -718,14 +739,14 @@ def extract_fbx_vertex_normals(mesh):
             r = FbxVector4(r[0], r[1], r[2], 1)
             s = node.GeometricScaling.Get()
             s = FbxVector4(s[0], s[1], s[2], 1)
-            
-            hasGeometricTransform = False
+
+            has_geometric_transform = False
             if t[0] != 0 or t[1] != 0 or t[2] != 0 or \
-               r[0] != 0 or r[1] != 0 or r[2] != 0 or \
-               s[0] != 1 or s[1] != 1 or s[2] != 1:
-                hasGeometricTransform = True
-            
-            if hasGeometricTransform:
+                            r[0] != 0 or r[1] != 0 or r[2] != 0 or \
+                            s[0] != 1 or s[1] != 1 or s[2] != 1:
+                has_geometric_transform = True
+
+            if has_geometric_transform:
                 geo_transform = FbxMatrix(t,r,s)
             else:
                 geo_transform = FbxMatrix()
@@ -738,9 +759,9 @@ def extract_fbx_vertex_normals(mesh):
                 transform = node.EvaluateGlobalTransform()
                 transform = FbxMatrix(transform) * geo_transform
 
-            elif hasGeometricTransform:
+            elif has_geometric_transform:
                 transform = geo_transform
-                
+
             if transform:
                 t = FbxVector4(0,0,0,1)
                 transform.SetRow(3, t)
@@ -754,14 +775,14 @@ def extract_fbx_vertex_normals(mesh):
                     normal_values[i] = normal
 
         # indices
-        vertexId = 0
+        vertex_id = 0
         for p in range(poly_count):
             poly_size = mesh.GetPolygonSize(p)
             poly_normals = []
 
             for v in range(poly_size):
                 control_point_index = mesh.GetPolygonVertex(p, v)
-                
+
                 # mapping mode is by control points. The mesh should be smooth and soft.
                 # we can get normals by retrieving each control point
                 if mesh_normals.GetMappingMode() == FbxLayerElement.eByControlPoint:
@@ -780,18 +801,18 @@ def extract_fbx_vertex_normals(mesh):
                 elif mesh_normals.GetMappingMode() == FbxLayerElement.eByPolygonVertex:
 
                     if mesh_normals.GetReferenceMode() == FbxLayerElement.eDirect:
-                        poly_normals.append(vertexId)
+                        poly_normals.append(vertex_id)
 
                     elif mesh_normals.GetReferenceMode() == FbxLayerElement.eIndexToDirect:
-                        index = mesh_normals.GetIndexArray().GetAt(vertexId)
+                        index = mesh_normals.GetIndexArray().GetAt(vertex_id)
                         poly_normals.append(index)
 
                 elif mesh_normals.GetMappingMode() == FbxLayerElement.eByPolygon or \
-                     mesh_normals.GetMappingMode() ==  FbxLayerElement.eAllSame or \
-                     mesh_normals.GetMappingMode() ==  FbxLayerElement.eNone:       
-                    print("unsupported normal mapping mode for polygon vertex")
+                                mesh_normals.GetMappingMode() ==  FbxLayerElement.eAllSame or \
+                                mesh_normals.GetMappingMode() ==  FbxLayerElement.eNone:
+                    sys.stderr.write("unsupported normal mapping mode for polygon vertex\n")
 
-                vertexId += 1
+                vertex_id += 1
             normal_indices.append(poly_normals)
 
         layered_normal_values.append(normal_values)
@@ -808,27 +829,26 @@ def extract_fbx_vertex_normals(mesh):
     return normal_values, normal_indices
 
 def extract_fbx_vertex_colors(mesh):
-#   eNone             The mapping is undetermined.
-#   eByControlPoint   There will be one mapping coordinate for each surface control point/vertex.
-#   eByPolygonVertex  There will be one mapping coordinate for each vertex, for every polygon of which it is a part. This means that a vertex will have as many mapping coordinates as polygons of which it is a part.
-#   eByPolygon        There can be only one mapping coordinate for the whole polygon.
-#   eByEdge           There will be one mapping coordinate for each unique edge in the mesh. This is meant to be used with smoothing layer elements.
-#   eAllSame          There can be only one mapping coordinate for the whole surface.
+    #   eNone             The mapping is undetermined.
+    #   eByControlPoint   There will be one mapping coordinate for each surface control point/vertex.
+    #   eByPolygonVertex  There will be one mapping coordinate for each vertex, for every polygon of which it is a part. This means that a vertex will have as many mapping coordinates as polygons of which it is a part.
+    #   eByPolygon        There can be only one mapping coordinate for the whole polygon.
+    #   eByEdge           There will be one mapping coordinate for each unique edge in the mesh. This is meant to be used with smoothing layer elements.
+    #   eAllSame          There can be only one mapping coordinate for the whole surface.
 
     layered_color_indices = []
     layered_color_values = []
 
     poly_count = mesh.GetPolygonCount()
-    control_points = mesh.GetControlPoints() 
 
     for l in range(mesh.GetLayerCount()):
         mesh_colors = mesh.GetLayer(l).GetVertexColors()
         if not mesh_colors:
             continue
-          
+
         colors_array = mesh_colors.GetDirectArray()
         colors_count = colors_array.GetCount()
-  
+
         if colors_count == 0:
             continue
 
@@ -842,7 +862,7 @@ def extract_fbx_vertex_colors(mesh):
             color_values.append(color)
 
         # indices
-        vertexId = 0
+        vertex_id = 0
         for p in range(poly_count):
             poly_size = mesh.GetPolygonSize(p)
             poly_colors = []
@@ -858,20 +878,20 @@ def extract_fbx_vertex_colors(mesh):
                         poly_colors.append(index)
                 elif mesh_colors.GetMappingMode() == FbxLayerElement.eByPolygonVertex:
                     if mesh_colors.GetReferenceMode() == FbxLayerElement.eDirect:
-                        poly_colors.append(vertexId)
+                        poly_colors.append(vertex_id)
                     elif mesh_colors.GetReferenceMode() == FbxLayerElement.eIndexToDirect:
-                        index = mesh_colors.GetIndexArray().GetAt(vertexId)
+                        index = mesh_colors.GetIndexArray().GetAt(vertex_id)
                         poly_colors.append(index)
                 elif mesh_colors.GetMappingMode() == FbxLayerElement.eByPolygon or \
-                     mesh_colors.GetMappingMode() ==  FbxLayerElement.eAllSame or \
-                     mesh_colors.GetMappingMode() ==  FbxLayerElement.eNone:       
-                    print("unsupported color mapping mode for polygon vertex")
+                                mesh_colors.GetMappingMode() ==  FbxLayerElement.eAllSame or \
+                                mesh_colors.GetMappingMode() ==  FbxLayerElement.eNone:
+                    sys.stderr.write("unsupported color mapping mode for polygon vertex\n")
 
-                vertexId += 1
+                vertex_id += 1
             color_indices.append(poly_colors)
 
-        layered_color_indices.append( color_indices )
-        layered_color_values.append( color_values )
+        layered_color_indices.append(color_indices)
+        layered_color_values.append(color_values)
 
     color_values = []
     color_indices = []
@@ -881,42 +901,29 @@ def extract_fbx_vertex_colors(mesh):
         color_values = layered_color_values[0]
         color_indices = layered_color_indices[0]
 
-    '''
-    # The Fbx SDK defaults mesh.Color to (0.8, 0.8, 0.8)
-    # This causes most models to receive incorrect vertex colors
-    if len(color_values) == 0:
-        color = mesh.Color.Get()
-        color_values = [[color[0], color[1], color[2]]]
-        color_indices = []
-        for p in range(poly_count):
-            poly_size = mesh.GetPolygonSize(p)
-            color_indices.append([0] * poly_size)
-    '''
-
     return color_values, color_indices
 
 def extract_fbx_vertex_uvs(mesh):
-#   eNone             The mapping is undetermined.
-#   eByControlPoint   There will be one mapping coordinate for each surface control point/vertex.
-#   eByPolygonVertex  There will be one mapping coordinate for each vertex, for every polygon of which it is a part. This means that a vertex will have as many mapping coordinates as polygons of which it is a part.
-#   eByPolygon        There can be only one mapping coordinate for the whole polygon.
-#   eByEdge           There will be one mapping coordinate for each unique edge in the mesh. This is meant to be used with smoothing layer elements.
-#   eAllSame          There can be only one mapping coordinate for the whole surface.
+    #   eNone             The mapping is undetermined.
+    #   eByControlPoint   There will be one mapping coordinate for each surface control point/vertex.
+    #   eByPolygonVertex  There will be one mapping coordinate for each vertex, for every polygon of which it is a part. This means that a vertex will have as many mapping coordinates as polygons of which it is a part.
+    #   eByPolygon        There can be only one mapping coordinate for the whole polygon.
+    #   eByEdge           There will be one mapping coordinate for each unique edge in the mesh. This is meant to be used with smoothing layer elements.
+    #   eAllSame          There can be only one mapping coordinate for the whole surface.
 
     layered_uv_indices = []
     layered_uv_values = []
 
     poly_count = mesh.GetPolygonCount()
-    control_points = mesh.GetControlPoints() 
 
     for l in range(mesh.GetLayerCount()):
         mesh_uvs = mesh.GetLayer(l).GetUVs()
         if not mesh_uvs:
             continue
-          
+
         uvs_array = mesh_uvs.GetDirectArray()
         uvs_count = uvs_array.GetCount()
-  
+
         if uvs_count == 0:
             continue
 
@@ -930,7 +937,7 @@ def extract_fbx_vertex_uvs(mesh):
             uv_values.append(uv)
 
         # indices
-        vertexId = 0
+        vertex_id = 0
         for p in range(poly_count):
             poly_size = mesh.GetPolygonSize(p)
             poly_uvs = []
@@ -945,17 +952,17 @@ def extract_fbx_vertex_uvs(mesh):
                         index = mesh_uvs.GetIndexArray().GetAt(control_point_index)
                         poly_uvs.append(index)
                 elif mesh_uvs.GetMappingMode() == FbxLayerElement.eByPolygonVertex:
-                    uv_texture_index = mesh_uvs.GetIndexArray().GetAt(vertexId)
-                    
+                    uv_texture_index = mesh_uvs.GetIndexArray().GetAt(vertex_id)
+
                     if mesh_uvs.GetReferenceMode() == FbxLayerElement.eDirect or \
-                       mesh_uvs.GetReferenceMode() == FbxLayerElement.eIndexToDirect:
+                                    mesh_uvs.GetReferenceMode() == FbxLayerElement.eIndexToDirect:
                         poly_uvs.append(uv_texture_index)
                 elif mesh_uvs.GetMappingMode() == FbxLayerElement.eByPolygon or \
-                     mesh_uvs.GetMappingMode() ==  FbxLayerElement.eAllSame or \
-                     mesh_uvs.GetMappingMode() ==  FbxLayerElement.eNone:       
-                    print("unsupported uv mapping mode for polygon vertex")
+                                mesh_uvs.GetMappingMode() ==  FbxLayerElement.eAllSame or \
+                                mesh_uvs.GetMappingMode() ==  FbxLayerElement.eNone:
+                    sys.stderr.write("unsupported uv mapping mode for polygon vertex\n")
 
-                vertexId += 1
+                vertex_id += 1
             uv_indices.append(poly_uvs)
 
         layered_uv_values.append(uv_values)
@@ -970,11 +977,11 @@ def generate_normal_key(normal):
     return (round(normal[0], 6), round(normal[1], 6), round(normal[2], 6))
 
 def generate_color_key(color):
-    return getHex(color)
+    return pack_color(color)
 
 def generate_uv_key(uv):
     return (round(uv[0], 6), round(uv[1], 6))
-                
+
 def append_non_duplicate_uvs(source_uvs, dest_uvs, counts):
     source_layer_count = len(source_uvs)
     for layer_index in range(source_layer_count):
@@ -993,7 +1000,7 @@ def append_non_duplicate_uvs(source_uvs, dest_uvs, counts):
         source_uv_layer = source_uvs[layer_index]
 
         for uv in source_uv_layer:
-            key = generate_uv_key(uv) 
+            key = generate_uv_key(uv)
             if key not in dest_uv_layer:
                 dest_uv_layer[key] = count
                 count += 1
@@ -1005,15 +1012,14 @@ def append_non_duplicate_uvs(source_uvs, dest_uvs, counts):
 def generate_unique_normals_dictionary(mesh_list):
     normals_dictionary = {}
     nnormals = 0
-      
+
     # Merge meshes, remove duplicate data
     for mesh in mesh_list:
-        node = mesh.GetNode()
         normal_values, normal_indices = extract_fbx_vertex_normals(mesh)
 
         if len(normal_values) > 0:
             for normal in normal_values:
-                key = generate_normal_key(normal) 
+                key = generate_normal_key(normal)
                 if key not in normals_dictionary:
                     normals_dictionary[key] = nnormals
                     nnormals += 1
@@ -1023,14 +1029,14 @@ def generate_unique_normals_dictionary(mesh_list):
 def generate_unique_colors_dictionary(mesh_list):
     colors_dictionary = {}
     ncolors = 0
-      
+
     # Merge meshes, remove duplicate data
     for mesh in mesh_list:
         color_values, color_indices = extract_fbx_vertex_colors(mesh)
 
         if len(color_values) > 0:
             for color in color_values:
-                key = generate_color_key(color) 
+                key = generate_color_key(color)
                 if key not in colors_dictionary:
                     colors_dictionary[key] = ncolors
                     ncolors += 1
@@ -1067,7 +1073,7 @@ def generate_colors_from_dictionary(colors_dictionary):
 def generate_uvs_from_dictionary_layers(uvs_dictionary_layers):
     uv_values = []
     for uvs_dictionary in uvs_dictionary_layers:
-        uv_values_layer = []    
+        uv_values_layer = []
         for key, index in sorted(uvs_dictionary.items(), key = operator.itemgetter(1)):
             uv_values_layer.append(key)
         uv_values.append(uv_values_layer)
@@ -1136,9 +1142,8 @@ def process_mesh_vertices(mesh_list):
     vertex_offset_list = [0]
     vertices = []
     for mesh in mesh_list:
-        node = mesh.GetNode()
         mesh_vertices = extract_fbx_vertex_positions(mesh)
-                
+
         vertices.extend(mesh_vertices[:])
         vertex_offset += len(mesh_vertices)
         vertex_offset_list.append(vertex_offset)
@@ -1154,7 +1159,7 @@ def process_mesh_materials(mesh_list):
     #TODO: remove duplicate mesh references
     for mesh in mesh_list:
         node = mesh.GetNode()
-                
+
         material_count = node.GetMaterialCount()
         if material_count > 0:
             for l in range(mesh.GetLayerCount()):
@@ -1166,7 +1171,7 @@ def process_mesh_materials(mesh_list):
 
                     for i in range(material_count):
                         material = node.GetMaterial(i)
-                        materials_list.append( material )
+                        materials_list.append(material)
 
                     material_offset += material_count
                     material_offset_list.append(material_offset)
@@ -1178,15 +1183,14 @@ def process_mesh_polygons(mesh_list, normals_to_indices, colors_to_indices, uvs_
     for mesh_index in range(len(mesh_list)):
         mesh = mesh_list[mesh_index]
 
-        flipWindingOrder = False
+        flip_winding_order = False
         node = mesh.GetNode()
         if node:
             local_scale = node.EvaluateLocalScaling()
             if local_scale[0] < 0 or local_scale[1] < 0 or local_scale[2] < 0:
-                flipWindingOrder = True
+                flip_winding_order = True
 
         poly_count = mesh.GetPolygonCount()
-        control_points = mesh.GetControlPoints() 
 
         normal_values, normal_indices = extract_fbx_vertex_normals(mesh)
         color_values, color_indices = extract_fbx_vertex_colors(mesh)
@@ -1204,7 +1208,7 @@ def process_mesh_polygons(mesh_list, normals_to_indices, colors_to_indices, uvs_
                 uv_indices = uv_indices_layers[l]
                 face_uv_indices = generate_uv_indices_for_poly(poly_index, uv_values, uv_indices, uvs_to_indices_list[l])
                 face_uv_layers.append(face_uv_indices)
-                
+
             face_vertices = []
             for vertex_index in range(poly_size):
                 control_point_index = mesh.GetPolygonVertex(poly_index, vertex_index)
@@ -1217,7 +1221,7 @@ def process_mesh_polygons(mesh_list, normals_to_indices, colors_to_indices, uvs_
                 material_offset = material_offset_list[mesh_index]
 
             vertex_offset = vertex_offset_list[mesh_index]
-            
+
             if poly_size > 4:
                 new_face_normals = []
                 new_face_colors = []
@@ -1235,59 +1239,59 @@ def process_mesh_polygons(mesh_list, normals_to_indices, colors_to_indices, uvs_
                         for layer in face_uv_layers:
                             new_face_uv_layers.append([layer[0], layer[i+1], layer[i+2]])
 
-                    face = generate_mesh_face(mesh, 
-                        poly_index,
-                        new_face_vertices,
-                        new_face_normals,
-                        new_face_colors,
-                        new_face_uv_layers,
-                        vertex_offset,
-                        material_offset,
-                        flipWindingOrder)
+                    face = generate_mesh_face(mesh,
+                                              poly_index,
+                                              new_face_vertices,
+                                              new_face_normals,
+                                              new_face_colors,
+                                              new_face_uv_layers,
+                                              vertex_offset,
+                                              material_offset,
+                                              flip_winding_order)
                     faces.append(face)
             else:
-                face = generate_mesh_face(mesh, 
-                          poly_index,
-                          face_vertices,
-                          face_normals,
-                          face_colors,
-                          face_uv_layers,
-                          vertex_offset,
-                          material_offset,
-                          flipWindingOrder)
+                face = generate_mesh_face(mesh,
+                                          poly_index,
+                                          face_vertices,
+                                          face_normals,
+                                          face_colors,
+                                          face_uv_layers,
+                                          vertex_offset,
+                                          material_offset,
+                                          flip_winding_order)
                 faces.append(face)
 
     return faces
 
-def generate_mesh_face(mesh, polygon_index, vertex_indices, normals, colors, uv_layers, vertex_offset, material_offset, flipOrder):
-    isTriangle = ( len(vertex_indices) == 3 )
-    nVertices = 3 if isTriangle else 4
+def generate_mesh_face(mesh, polygon_index, vertex_indices, normals, colors, uv_layers, vertex_offset, material_offset, flip_order):
+    is_triangle = len(vertex_indices) == 3
+    nvertices = 3 if is_triangle else 4
 
-    hasMaterial = False
+    has_material = False
     for l in range(mesh.GetLayerCount()):
         materials = mesh.GetLayer(l).GetMaterials()
         if materials:
-            hasMaterial = True
+            has_material = True
             break
-                
-    hasFaceUvs = False
-    hasFaceVertexUvs = len(uv_layers) > 0
-    hasFaceNormals = False 
-    hasFaceVertexNormals = len(normals) > 0
-    hasFaceColors = False 
-    hasFaceVertexColors = len(colors) > 0
 
-    faceType = 0
-    faceType = setBit(faceType, 0, not isTriangle)
-    faceType = setBit(faceType, 1, hasMaterial)
-    faceType = setBit(faceType, 2, hasFaceUvs)
-    faceType = setBit(faceType, 3, hasFaceVertexUvs)
-    faceType = setBit(faceType, 4, hasFaceNormals)
-    faceType = setBit(faceType, 5, hasFaceVertexNormals)
-    faceType = setBit(faceType, 6, hasFaceColors)
-    faceType = setBit(faceType, 7, hasFaceVertexColors)
+    has_face_uvs = False
+    has_face_vertex_uvs = len(uv_layers) > 0
+    has_face_normals = False
+    has_face_vertex_normals = len(normals) > 0
+    has_face_colors = False
+    has_face_vertex_colors = len(colors) > 0
 
-    faceData = []
+    face_type = 0
+    face_type = set_bit(face_type, 0, not is_triangle)
+    face_type = set_bit(face_type, 1, has_material)
+    face_type = set_bit(face_type, 2, has_face_uvs)
+    face_type = set_bit(face_type, 3, has_face_vertex_uvs)
+    face_type = set_bit(face_type, 4, has_face_normals)
+    face_type = set_bit(face_type, 5, has_face_vertex_normals)
+    face_type = set_bit(face_type, 6, has_face_colors)
+    face_type = set_bit(face_type, 7, has_face_vertex_colors)
+
+    face_data = []
 
     # order is important, must match order in JSONLoader
 
@@ -1299,37 +1303,37 @@ def generate_mesh_face(mesh, polygon_index, vertex_indices, normals, colors, uv_
     # face color index
     # face vertex colors indices
 
-    faceData.append(faceType)
+    face_data.append(face_type)
 
-    if flipOrder:
-        if nVertices == 3:
+    if flip_order:
+        if nvertices == 3:
             vertex_indices = [vertex_indices[0], vertex_indices[2], vertex_indices[1]]
-            if hasFaceVertexNormals:
+            if has_face_vertex_normals:
                 normals = [normals[0], normals[2], normals[1]]
-            if hasFaceVertexColors:
+            if has_face_vertex_colors:
                 colors = [colors[0], colors[2], colors[1]]
-            if hasFaceVertexUvs:
+            if has_face_vertex_uvs:
                 tmp = []
                 for polygon_uvs in uv_layers:
                     tmp.append([polygon_uvs[0], polygon_uvs[2], polygon_uvs[1]])
                 uv_layers = tmp
         else:
             vertex_indices = [vertex_indices[0], vertex_indices[3], vertex_indices[2], vertex_indices[1]]
-            if hasFaceVertexNormals:
+            if has_face_vertex_normals:
                 normals = [normals[0], normals[3], normals[2], normals[1]]
-            if hasFaceVertexColors:
+            if has_face_vertex_colors:
                 colors = [colors[0], colors[3], colors[2], colors[1]]
-            if hasFaceVertexUvs:
+            if has_face_vertex_uvs:
                 tmp = []
                 for polygon_uvs in uv_layers:
                     tmp.append([polygon_uvs[0], polygon_uvs[3], polygon_uvs[2], polygon_uvs[3]])
                 uv_layers = tmp
-        
-    for i in range(nVertices):
-        index = vertex_indices[i] + vertex_offset
-        faceData.append(index)
 
-    if hasMaterial:
+    for i in range(nvertices):
+        index = vertex_indices[i] + vertex_offset
+        face_data.append(index)
+
+    if has_material:
         material_id = 0
         for l in range(mesh.GetLayerCount()):
             materials = mesh.GetLayer(l).GetMaterials()
@@ -1337,30 +1341,30 @@ def generate_mesh_face(mesh, polygon_index, vertex_indices, normals, colors, uv_
                 material_id = materials.GetIndexArray().GetAt(polygon_index)
                 break
         material_id += material_offset
-        faceData.append( material_id )
+        face_data.append(material_id)
 
-    if hasFaceVertexUvs:
+    if has_face_vertex_uvs:
         for polygon_uvs in uv_layers:
-            for i in range(nVertices):
+            for i in range(nvertices):
                 index = polygon_uvs[i]
-                faceData.append(index)
+                face_data.append(index)
 
-    if hasFaceVertexNormals:
-        for i in range(nVertices):
+    if has_face_vertex_normals:
+        for i in range(nvertices):
             index = normals[i]
-            faceData.append(index)
+            face_data.append(index)
 
-    if hasFaceVertexColors:
-        for i in range(nVertices):
+    if has_face_vertex_colors:
+        for i in range(nvertices):
             index = colors[i]
-            faceData.append(index)
+            face_data.append(index)
 
-    return faceData 
+    return face_data
 
 # #####################################################
-# Generate Mesh Object (for scene output format) 
+# Generate JSONLoader compatible Geometry
 # #####################################################
-def generate_scene_output(node):
+def generate_geometry_data(node, geometry_dict):
     mesh = node.GetNodeAttribute()
 
     # This is done in order to keep the scene output and non-scene output code DRY
@@ -1373,18 +1377,18 @@ def generate_scene_output(node):
     normals_to_indices = generate_unique_normals_dictionary(mesh_list)
     colors_to_indices = generate_unique_colors_dictionary(mesh_list)
     uvs_to_indices_list = generate_unique_uvs_dictionary_layers(mesh_list)
-    
+
     normal_values = generate_normals_from_dictionary(normals_to_indices)
     color_values = generate_colors_from_dictionary(colors_to_indices)
     uv_values = generate_uvs_from_dictionary_layers(uvs_to_indices_list)
 
     # Generate mesh faces for the Three.js file format
-    faces = process_mesh_polygons(mesh_list, 
-                normals_to_indices,
-                colors_to_indices, 
-                uvs_to_indices_list,
-                vertex_offsets, 
-                material_offsets)
+    faces = process_mesh_polygons(mesh_list,
+                                  normals_to_indices,
+                                  colors_to_indices,
+                                  uvs_to_indices_list,
+                                  vertex_offsets,
+                                  material_offsets)
 
     # Generate counts for uvs, vertices, normals, colors, and faces
     nuvs = []
@@ -1410,34 +1414,30 @@ def generate_scene_output(node):
         normal_values = ChunkedIndent(normal_values, 15, True)
         color_values = ChunkedIndent(color_values, 15)
         faces = ChunkedIndent(faces, 30)
-  
+
     metadata = {
-      'vertices' : nvertices,
-      'normals' : nnormals,
-      'colors' : ncolors,
-      'faces' : nfaces,
-      'uvs' : nuvs
+      'vertices': nvertices,
+      'normals': nnormals,
+      'colors': ncolors,
+      'faces': nfaces,
+      'uvs': nuvs
     }
 
-    output = {
-      'scale' : 1,
-      'materials' : [],
-      'vertices' : vertices,
-      'normals' : [] if nnormals <= 0 else normal_values,
-      'colors' : [] if ncolors <= 0 else color_values,
-      'uvs' : uv_values,
-      'faces' : faces
+    geometry_name = get_geometry_name(node)
+
+    return {
+      name_key: geometry_name,
+      'scale': 1,
+      'vertices': vertices,
+      'normals': [] if nnormals <= 0 else normal_values,
+      'colors': [] if ncolors <= 0 else color_values,
+      'uvs': uv_values,
+      'faces': faces,
+      metadata_key: metadata
     }
-
-    if option_pretty_print:
-        output['0metadata'] = metadata
-    else:
-        output['metadata'] = metadata
-
-    return output
 
 # #####################################################
-# Generate Mesh Object (for non-scene output) 
+# Generate Mesh Object (for non-scene output)
 # #####################################################
 def generate_non_scene_output(scene):
     mesh_list = generate_mesh_list(scene)
@@ -1449,18 +1449,18 @@ def generate_non_scene_output(scene):
     normals_to_indices = generate_unique_normals_dictionary(mesh_list)
     colors_to_indices = generate_unique_colors_dictionary(mesh_list)
     uvs_to_indices_list = generate_unique_uvs_dictionary_layers(mesh_list)
-    
+
     normal_values = generate_normals_from_dictionary(normals_to_indices)
     color_values = generate_colors_from_dictionary(colors_to_indices)
     uv_values = generate_uvs_from_dictionary_layers(uvs_to_indices_list)
 
     # Generate mesh faces for the Three.js file format
-    faces = process_mesh_polygons(mesh_list, 
-                normals_to_indices,
-                colors_to_indices, 
-                uvs_to_indices_list,
-                vertex_offsets, 
-                material_offsets)
+    faces = process_mesh_polygons(mesh_list,
+                                  normals_to_indices,
+                                  colors_to_indices,
+                                  uvs_to_indices_list,
+                                  vertex_offsets,
+                                  material_offsets)
 
     # Generate counts for uvs, vertices, normals, colors, and faces
     nuvs = []
@@ -1488,32 +1488,26 @@ def generate_non_scene_output(scene):
         faces = NoIndent(faces)
 
     metadata = {
-      'formatVersion' : 3,
-      'type' : 'geometry',
-      'generatedBy' : 'convert-to-threejs.py',
-      'vertices' : nvertices,
-      'normals' : nnormals,
-      'colors' : ncolors,
-      'faces' : nfaces,
-      'uvs' : nuvs
+      'formatVersion': 3,
+      type_key: 'geometry',
+      'generatedBy': 'convert-to-threejs.py',
+      'vertices': nvertices,
+      'normals': nnormals,
+      'colors': ncolors,
+      'faces': nfaces,
+      'uvs': nuvs
     }
 
-    output = {
-      'scale' : 1,
-      'materials' : [],
-      'vertices' : vertices,
-      'normals' : [] if nnormals <= 0 else normal_values,
-      'colors' : [] if ncolors <= 0 else color_values,
-      'uvs' : uv_values,
-      'faces' : faces
+    return {
+      'scale': 1,
+      'materials': [],
+      'vertices': vertices,
+      'normals': [] if nnormals <= 0 else normal_values,
+      'colors': [] if ncolors <= 0 else color_values,
+      'uvs': uv_values,
+      'faces': faces,
+      metadata_key: metadata
     }
-
-    if option_pretty_print:
-        output['0metadata'] = metadata
-    else:
-        output['metadata'] = metadata
-
-    return output
 
 def generate_mesh_list_from_hierarchy(node, mesh_list):
     if node.GetNodeAttribute() == None:
@@ -1521,12 +1515,12 @@ def generate_mesh_list_from_hierarchy(node, mesh_list):
     else:
         attribute_type = (node.GetNodeAttribute().GetAttributeType())
         if attribute_type == FbxNodeAttribute.eMesh or \
-           attribute_type == FbxNodeAttribute.eNurbs or \
-           attribute_type == FbxNodeAttribute.eNurbsSurface or \
-           attribute_type == FbxNodeAttribute.ePatch:
+                        attribute_type == FbxNodeAttribute.eNurbs or \
+                        attribute_type == FbxNodeAttribute.eNurbsSurface or \
+                        attribute_type == FbxNodeAttribute.ePatch:
 
             if attribute_type != FbxNodeAttribute.eMesh:
-                converter.TriangulateInPlace(node);
+                converter.TriangulateInPlace(node)
 
             mesh_list.append(node.GetNodeAttribute())
 
@@ -1541,68 +1535,42 @@ def generate_mesh_list(scene):
             generate_mesh_list_from_hierarchy(node.GetChild(i), mesh_list)
     return mesh_list
 
-# #####################################################
-# Generate Embed Objects 
-# #####################################################
-def generate_embed_dict_from_hierarchy(node, embed_dict):
+def generate_geometry_list_from_hierarchy(node, geometry_list, geometry_dict):
     if node.GetNodeAttribute() == None:
         pass
     else:
         attribute_type = (node.GetNodeAttribute().GetAttributeType())
         if attribute_type == FbxNodeAttribute.eMesh or \
-           attribute_type == FbxNodeAttribute.eNurbs or \
-           attribute_type == FbxNodeAttribute.eNurbsSurface or \
-           attribute_type == FbxNodeAttribute.ePatch:
+                        attribute_type == FbxNodeAttribute.eNurbs or \
+                        attribute_type == FbxNodeAttribute.eNurbsSurface or \
+                        attribute_type == FbxNodeAttribute.ePatch:
 
             if attribute_type != FbxNodeAttribute.eMesh:
-                converter.TriangulateInPlace(node);
+                converter.TriangulateInPlace(node)
 
-            embed_object = generate_scene_output(node)
-            embed_name = getPrefixedName(node, 'Embed')
-            embed_dict[embed_name] = embed_object
+            geometry_data = generate_geometry_data(node, geometry_dict)
+            geometry_uuid = str(uuid.uuid4())
+
+            geometry_list.append({
+              type_key: 'Geometry',
+              uuid_key: geometry_uuid,
+              data_key: geometry_data
+            })
+            geometry_dict[geometry_data[name_key]] = geometry_uuid
 
     for i in range(node.GetChildCount()):
-        generate_embed_dict_from_hierarchy(node.GetChild(i), embed_dict)
+        generate_geometry_list_from_hierarchy(node.GetChild(i), geometry_list, geometry_dict)
 
-def generate_embed_dict(scene):
-    embed_dict = {}
-    node = scene.GetRootNode()
-    if node:
-        for i in range(node.GetChildCount()):
-            generate_embed_dict_from_hierarchy(node.GetChild(i), embed_dict)
-    return embed_dict
-
-# #####################################################
-# Generate Geometry Objects 
-# #####################################################
-def generate_geometry_object(node):
-
-    output = {
-      'type' : 'embedded',
-      'id' : getPrefixedName( node, 'Embed' )
-    }
-
-    return output
-
-def generate_geometry_dict_from_hierarchy(node, geometry_dict):
-    if node.GetNodeAttribute() == None:
-        pass
-    else:
-        attribute_type = (node.GetNodeAttribute().GetAttributeType())
-        if attribute_type == FbxNodeAttribute.eMesh:
-            geometry_object = generate_geometry_object(node)
-            geometry_name = getPrefixedName( node, 'Geometry' )
-            geometry_dict[geometry_name] = geometry_object
-    for i in range(node.GetChildCount()):
-        generate_geometry_dict_from_hierarchy(node.GetChild(i), geometry_dict)
-
-def generate_geometry_dict(scene):
+def generate_geometry_list(scene):
+    geometry_list = []
     geometry_dict = {}
+
     node = scene.GetRootNode()
     if node:
         for i in range(node.GetChildCount()):
-            generate_geometry_dict_from_hierarchy(node.GetChild(i), geometry_dict)
-    return geometry_dict
+            generate_geometry_list_from_hierarchy(node.GetChild(i), geometry_list, geometry_dict)
+
+    return geometry_list, geometry_dict
 
 
 # #####################################################
@@ -1613,15 +1581,14 @@ def generate_default_light():
     color = (1,1,1)
     intensity = 80.0
 
-    output = {
-      'type': 'DirectionalLight',
-      'color': getHex(color),
+    return {
+      type_key: 'DirectionalLight',
+      uuid_key: str(uuid.uuid4()),
+      name_key: 'DirectionalLight',
+      'color': pack_color(color),
       'intensity': intensity/100.00,
-      'direction': serializeVector3( direction ),
-      'target': getObjectName( None )
+      'direction': serialize_vector3(direction)
     }
-
-    return output
 
 def generate_light_object(node):
     light = node.GetNodeAttribute()
@@ -1636,9 +1603,9 @@ def generate_light_object(node):
     if light_type == "directional":
 
         # Three.js directional lights emit light from a point in 3d space to a target node or the origin.
-        # When there is no target, we need to take a point, one unit away from the origin, and move it 
+        # When there is no target, we need to take a point, one unit away from the origin, and move it
         # into the right location so that the origin acts like the target
-        
+
         if node.GetTarget():
             direction = position
         else:
@@ -1646,43 +1613,39 @@ def generate_light_object(node):
             scale = FbxVector4(1,1,1,1)
             rotation = transform.GetR()
             matrix = FbxMatrix(translation, rotation, scale)
-            direction = matrix.MultNormalize(FbxVector4(0,1,0,1)) 
+            direction = matrix.MultNormalize(FbxVector4(0,1,0,1))
 
         output = {
-
-          'type': 'DirectionalLight',
-          'color': getHex(light.Color.Get()),
+          type_key: 'DirectionalLight',
+          'color': pack_color(light.Color.Get()),
           'intensity': light.Intensity.Get()/100.0,
-          'direction': serializeVector3( direction ),
-          'target': getObjectName( node.GetTarget() ) 
-
+          'direction': serialize_vector3(direction),
+          # TODO: ObjectLoader doesn't support targets
+          #'target': getObjectName(node.GetTarget())
         }
 
     elif light_type == "point":
 
         output = {
-
-          'type': 'PointLight',
-          'color': getHex(light.Color.Get()),
+          type_key: 'PointLight',
+          'color': pack_color(light.Color.Get()),
           'intensity': light.Intensity.Get()/100.0,
-          'position': serializeVector3( position ),
+          'position': serialize_vector3(position),
           'distance': light.FarAttenuationEnd.Get()
-
         }
 
     elif light_type == "spot":
 
         output = {
-
-          'type': 'SpotLight',
-          'color': getHex(light.Color.Get()),
+          type_key: 'SpotLight',
+          'color': pack_color(light.Color.Get()),
           'intensity': light.Intensity.Get()/100.0,
-          'position': serializeVector3( position ),
+          'position': serialize_vector3(position),
           'distance': light.FarAttenuationEnd.Get(),
           'angle': light.OuterAngle.Get()*math.pi/180,
           'exponent': light.DecayType.Get(),
-          'target': getObjectName( node.GetTarget() ) 
-
+          # TODO: ObjectLoader doesn't support targets
+          #'target': getObjectName(node.GetTarget())
         }
 
     return output
@@ -1696,15 +1659,13 @@ def generate_ambient_light(scene):
     if ambient_color[0] == 0 and ambient_color[1] == 0 and ambient_color[2] == 0:
         return None
 
-    output = {
-
-      'type': 'AmbientLight',
-      'color': getHex(ambient_color)
-
+    return {
+      type_key: 'AmbientLight',
+      uuid_key: str(uuid.uuid4()),
+      name_key: 'AmbientLight',
+      'color': pack_color(ambient_color),
     }
 
-    return output
-    
 # #####################################################
 # Generate Camera Node Objects
 # #####################################################
@@ -1714,27 +1675,26 @@ def generate_default_camera():
     far = 1000
     fov = 75
 
-    output = {
-      'type': 'PerspectiveCamera',
+    return {
+      type_key: 'PerspectiveCamera',
+      uuid_key: str(uuid.uuid4()),
+      name_key: 'DefaultCamera',
       'fov': fov,
       'near': near,
       'far': far,
-      'position': serializeVector3( position ) 
+      'position': serialize_vector3(position)
     }
-
-    return output
 
 def generate_camera_object(node):
     camera = node.GetNodeAttribute()
     position = camera.Position.Get()
-  
+
     projection_types = [ "perspective", "orthogonal" ]
     projection = projection_types[camera.ProjectionType.Get()]
 
     near = camera.NearPlane.Get()
     far = camera.FarPlane.Get()
 
-    name = getObjectName( node )
     output = {}
 
     if projection == "perspective":
@@ -1743,14 +1703,12 @@ def generate_camera_object(node):
         fov = camera.FieldOfView.Get()
 
         output = {
-
-          'type': 'PerspectiveCamera',
+          type_key: 'PerspectiveCamera',
           'fov': fov,
           'aspect': aspect,
           'near': near,
           'far': far,
-          'position': serializeVector3( position )
-
+          'position': serialize_vector3(position)
         }
 
     elif projection == "orthogonal":
@@ -1761,51 +1719,26 @@ def generate_camera_object(node):
         bottom = ""
 
         output = {
-
-          'type': 'PerspectiveCamera',
+          type_key: 'PerspectiveCamera',
           'left': left,
           'right': right,
           'top': top,
           'bottom': bottom,
           'near': near,
           'far': far,
-          'position': serializeVector3( position )
-
+          'position': serialize_vector3(position)
         }
 
     return output
 
 # #####################################################
-# Generate Camera Names
+# Generate Mesh Node Object
 # #####################################################
-def generate_camera_name_list_from_hierarchy(node, camera_list):
-    if node.GetNodeAttribute() == None:
-        pass
-    else:
-        attribute_type = (node.GetNodeAttribute().GetAttributeType())
-        if attribute_type == FbxNodeAttribute.eCamera:
-            camera_string = getObjectName(node) 
-            camera_list.append(camera_string)
-    for i in range(node.GetChildCount()):
-        generate_camera_name_list_from_hierarchy(node.GetChild(i), camera_list)
-
-def generate_camera_name_list(scene):
-    camera_list = []
-    node = scene.GetRootNode()
-    if node:
-        for i in range(node.GetChildCount()):
-            generate_camera_name_list_from_hierarchy(node.GetChild(i), camera_list)
-    return camera_list
-
-# #####################################################
-# Generate Mesh Node Object 
-# #####################################################
-def generate_mesh_object(node):
+def generate_mesh_object(node, geometry_dict, material_dict):
     mesh = node.GetNodeAttribute()
     transform = node.EvaluateLocalTransform()
     position = transform.GetT()
     scale = transform.GetS()
-    rotation = getRadians(transform.GetR())
     quaternion = transform.GetQ()
 
     material_count = node.GetMaterialCount()
@@ -1821,262 +1754,145 @@ def generate_mesh_object(node):
                     continue
                 for i in range(material_count):
                     material = node.GetMaterial(i)
-                    material_names.append( getMaterialName(material) )
+                    material_names.append(get_material_name(material))
 
         if not material_count > 1 and not len(material_names) > 0:
             material_names.append('')
 
-        #If this mesh has more than one material, use a proxy material
-        material_name = getMaterialName( node, True) if material_count > 1 else material_names[0] 
+        material_name = get_multi_material_name(node) if material_count > 1 else material_names[0]
 
-    output = {
-      'geometry': getPrefixedName( node, 'Geometry' ),
-      'material': material_name,
-      'position': serializeVector3( position ),
-      'quaternion': serializeVector4( quaternion ),
-      'scale': serializeVector3( scale ),
-      'visible': True,
+    return {
+       type_key: 'Mesh',
+      'geometry': geometry_dict[get_geometry_name(node)],
+      'material': material_dict[material_name],
+      'position': serialize_vector3(position),
+      'quaternion': serialize_vector4(quaternion),
+      'scale': serialize_vector3(scale),
+      'visible': True
     }
 
-    return output
-
 # #####################################################
-# Generate Node Object 
+# Generate Node Object
 # #####################################################
-def generate_object(node):
-    node_types = ["Unknown", "Null", "Marker", "Skeleton", "Mesh", "Nurbs", "Patch", "Camera", 
-    "CameraStereo", "CameraSwitcher", "Light", "OpticalReference", "OpticalMarker", "NurbsCurve", 
-    "TrimNurbsSurface", "Boundary", "NurbsSurface", "Shape", "LODGroup", "SubDiv", "CachedEffect", "Line"]
+def generate_generic_object(node):
+    node_types = ["Unknown", "Null", "Marker", "Skeleton", "Mesh", "Nurbs", "Patch", "Camera",
+                  "CameraStereo", "CameraSwitcher", "Light", "OpticalReference", "OpticalMarker", "NurbsCurve",
+                  "TrimNurbsSurface", "Boundary", "NurbsSurface", "Shape", "LODGroup", "SubDiv", "CachedEffect", "Line"]
 
     transform = node.EvaluateLocalTransform()
     position = transform.GetT()
     scale = transform.GetS()
-    rotation = getRadians(transform.GetR())
     quaternion = transform.GetQ()
 
-    node_type = ""
     if node.GetNodeAttribute() == None:
         node_type = "Null"
     else:
         node_type = node_types[node.GetNodeAttribute().GetAttributeType()]
 
-    name = getObjectName( node )
-    output = {
-      'fbx_type': node_type,
-      'position': serializeVector3( position ),
-      'quaternion': serializeVector4( quaternion ),
-      'scale': serializeVector3( scale ),
+    return {
+      type_key: node_type,
+      'position': serialize_vector3(position),
+      'quaternion': serialize_vector4(quaternion),
+      'scale': serialize_vector3(scale),
       'visible': True
     }
 
-    return output
-
 # #####################################################
-# Parse Scene Node Objects 
+# Parse Scene Node Objects
 # #####################################################
-def generate_object_hierarchy(node, object_dict):
-    object_count = 0
+def generate_object(node, geometry_dict, material_dict):
     if node.GetNodeAttribute() == None:
-        object_data = generate_object(node)
+        object_data = generate_generic_object(node)
     else:
         attribute_type = (node.GetNodeAttribute().GetAttributeType())
         if attribute_type == FbxNodeAttribute.eMesh:
-            object_data = generate_mesh_object(node)
+            object_data = generate_mesh_object(node, geometry_dict, material_dict)
         elif attribute_type == FbxNodeAttribute.eLight:
             object_data = generate_light_object(node)
         elif attribute_type == FbxNodeAttribute.eCamera:
             object_data = generate_camera_object(node)
         else:
-            object_data = generate_object(node)
+            object_data = generate_generic_object(node)
 
-    object_count += 1
-    object_name = getObjectName(node)
+    object_data[uuid_key] = str(uuid.uuid4())
+    object_data[name_key] = get_object_name(node)
 
-    object_children = {}
+    children = []
+
     for i in range(node.GetChildCount()):
-        object_count += generate_object_hierarchy(node.GetChild(i), object_children)
+        children.append(generate_object(node.GetChild(i), geometry_dict, material_dict))
 
-    if node.GetChildCount() > 0:
-        # Having 'children' above other attributes is hard to read.
-        # We can send it to the bottom using the last letter of the alphabet 'z'. 
-        # This letter is removed from the final output.
-        if option_pretty_print:
-            object_data['zchildren'] = object_children
-        else:
-            object_data['children'] = object_children
+    if len(children) > 0:
+        object_data[children_key] = children
 
-    object_dict[object_name] = object_data
+    return object_data
 
-    return object_count
-
-def generate_scene_objects(scene):
-    object_count = 0
-    object_dict = {}
+def generate_scene_object(scene, geometry_dict, material_dict):
+    children = []
 
     ambient_light = generate_ambient_light(scene)
     if ambient_light:
-        object_dict['AmbientLight'] = ambient_light
-        object_count += 1
+        children.append(ambient_light)
 
     if option_default_light:
-        default_light = generate_default_light()
-        object_dict['DefaultLight'] = default_light
-        object_count += 1
+        children.append(generate_default_light())
 
     if option_default_camera:
-        default_camera = generate_default_camera()
-        object_dict['DefaultCamera'] = default_camera
-        object_count += 1
+        children.append(generate_default_camera())
 
     node = scene.GetRootNode()
     if node:
         for i in range(node.GetChildCount()):
-            object_count += generate_object_hierarchy(node.GetChild(i), object_dict)
+            children.append(generate_object(node.GetChild(i), geometry_dict, material_dict))
 
-    return object_dict, object_count
+    return {
+      type_key: 'Scene',
+      uuid_key: str(uuid.uuid4()),
+      name_key: 'Scene',
+      'position': serialize_vector3((0,0,0)),
+      'rotation': serialize_vector3((0,0,0)),
+      'scale': serialize_vector3((1,1,1)),
+      children_key: children
+    }
 
 # #####################################################
 # Generate Scene Output
 # #####################################################
-def extract_scene(scene, filename):
-    global_settings = scene.GetGlobalSettings()
-    objects, nobjects = generate_scene_objects(scene)
+def extract_scene(scene):
+    geometries, geometry_dict = generate_geometry_list(scene)
+    textures, images, texture_dict = generate_texture_and_image_lists(scene)
+    materials, material_dict = generate_material_list(scene, texture_dict)
 
-    textures = generate_texture_dict(scene)
-    materials = generate_material_dict(scene)
-    geometries = generate_geometry_dict(scene)
-    embeds = generate_embed_dict(scene)
-
-    ntextures = len(textures)
-    nmaterials = len(materials)
-    ngeometries = len(geometries)
-
-    position = serializeVector3( (0,0,0) )
-    rotation = serializeVector3( (0,0,0) )
-    scale    = serializeVector3( (1,1,1) )
-
-    camera_names = generate_camera_name_list(scene)
-    scene_settings = scene.GetGlobalSettings()
-
-    # This does not seem to be any help here
-    # global_settings.GetDefaultCamera() 
-
-    defcamera = camera_names[0] if len(camera_names) > 0 else ""
-    if option_default_camera:
-      defcamera = 'default_camera'
+    object = generate_scene_object(scene, geometry_dict, material_dict)
 
     metadata = {
-      'formatVersion': 3.2,
-      'type': 'scene',
-      'generatedBy': 'convert-to-threejs.py',
-      'objects': nobjects,
-      'geometries': ngeometries,
-      'materials': nmaterials,
-      'textures': ntextures
+      'formatVersion': 4.3,
+      type_key: 'Object',
+      'generatedBy': 'convert-to-threejs.py'
     }
 
-    transform = {
-      'position' : position,
-      'rotation' : rotation,
-      'scale' : scale
-    }
-
-    defaults = {
-      'bgcolor' : 0,
-      'camera' : defcamera,
-      'fog' : ''
-    }
-
-    output = {
-      'objects': objects,
+    return {
       'geometries': geometries,
-      'materials': materials,
+      'images': images,
       'textures': textures,
-      'embeds': embeds,
-      'transform': transform,
-      'defaults': defaults,
+      'materials': materials,
+      'object': object,
+      metadata_key: metadata
     }
 
-    if option_pretty_print:
-        output['0metadata'] = metadata
-    else:
-        output['metadata'] = metadata
-
-    return output
-
 # #####################################################
-# Generate Non-Scene Output 
+# Generate Non-Scene Output
 # #####################################################
-def extract_geometry(scene, filename):
-    output = generate_non_scene_output(scene)
-    return output
+def extract_geometry(scene):
+    return generate_non_scene_output(scene)
 
 # #####################################################
 # File Helpers
 # #####################################################
 def write_file(filepath, content):
-    index = filepath.rfind('/')
-    dir = filepath[0:index]
-    
-    #if not os.path.exists(dir):
-        #os.makedirs(dir)
-    
     out = open(filepath, "w")
     out.write(content.encode('utf8', 'replace'))
     out.close()
-
-def read_file(filepath):
-    f = open(filepath)
-    content = f.readlines()
-    f.close()
-    return content
-
-def copy_textures(textures):
-    texture_dict = {}
-    
-    for key in textures:
-        url = textures[key]['fullpath']        
-        #src = replace_OutFolder2inFolder(url)
-
-        #print( src )
-        #print( url )
-
-        if url in texture_dict:  # texture has been copied
-            continue
-        
-        if not os.path.exists(url):
-            print("copy_texture error: we can't find this texture at " + url)
-            continue
-        
-        try:
-            index = url.rfind('/')
-            if index == -1:
-                index = url.rfind( '\\' )
-            filename = url[index+1:len(url)]
-            saveFolder = "maps"
-            saveFilename = saveFolder + "/" + filename
-            #print( src )
-            #print( url )
-            #print( saveFilename )
-            if not os.path.exists(saveFolder):
-                os.makedirs(saveFolder)
-            shutil.copyfile(url, saveFilename)
-            texture_dict[url] = True
-        except IOError as e:
-            print "I/O error({0}): {1} {2}".format(e.errno, e.strerror, url)
-
-def findFilesWithExt(directory, ext, include_path = True):
-    ext = ext.lower()
-    found = []
-    for root, dirs, files in os.walk(directory):
-        for filename in files:
-            current_ext = os.path.splitext(filename)[1].lower()
-            if current_ext == ext:
-                if include_path:
-                    found.append(os.path.join(root, filename))    
-                else:
-                    found.append(filename)
-    return found
 
 # #####################################################
 # main
@@ -2095,90 +1911,127 @@ if __name__ == "__main__":
         elif platform.system() == 'Linux':
             msg += '"/usr/local/lib/python2.6/site-packages"'
         elif platform.system() == 'Darwin':
-            msg += '"/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages"'        
+            msg += '"/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages"'
         msg += ' folder.'
-        print(msg)
-        sys.exit(1)
-    
+        sys.exit(msg)
+
     usage = "Usage: %prog [source_file.fbx] [output_file.js] [options]"
     parser = OptionParser(usage=usage)
 
     parser.add_option('-t', '--triangulate', action='store_true', dest='triangulate', help="force quad geometry into triangles", default=False)
     parser.add_option('-x', '--ignore-textures', action='store_true', dest='notextures', help="don't include texture references in output file", default=False)
     parser.add_option('-n', '--no-texture-copy', action='store_true', dest='notexturecopy', help="don't copy texture files", default=False)
+    parser.add_option('-i', '--ignore-texture-collisions', action='store_true', dest='ignoretexturecollisions', help="Allow copied textures with the same filename to overwrite each other")
+    parser.add_option("-o", "--texture-output-dir", dest="textureoutputdir", help="write copied textures to specified directory (relative to the output .js file)", metavar='DIR', default='maps')
+    parser.add_option('-a', '--no-transparency-detection', action='store_true', dest='notransparencydetection', help="don't automatically enable transparency for materials with diffuse maps containing alpha", default=False)
     parser.add_option('-u', '--force-prefix', action='store_true', dest='prefix', help="prefix all object names in output file to ensure uniqueness", default=False)
     parser.add_option('-f', '--flatten-scene', action='store_true', dest='geometry', help="merge all geometries and apply node transforms", default=False)
     parser.add_option('-y', '--force-y-up', action='store_true', dest='forceyup', help="ensure that the y axis shows up", default=False)
     parser.add_option('-c', '--add-camera', action='store_true', dest='defcamera', help="include default camera in output scene", default=False)
     parser.add_option('-l', '--add-light', action='store_true', dest='deflight', help="include default light in output scene", default=False)
-    parser.add_option('-p', '--pretty-print', action='store_true', dest='pretty', help="prefix all object names in output file", default=False)
+    parser.add_option('-p', '--pretty-print', action='store_true', dest='pretty', help="nicely format the output JSON", default=False)
 
     (options, args) = parser.parse_args()
 
-    option_triangulate = options.triangulate 
-    option_textures = True if not options.notextures else False
-    option_copy_textures = True if not options.notexturecopy else False
+    option_triangulate = options.triangulate
+    option_textures = not options.notextures
+    option_copy_textures = not options.notexturecopy
+    option_ignore_texture_collision = options.ignoretexturecollisions
+    option_texture_output_dir = options.textureoutputdir
+    option_transparency_detection = not options.notransparencydetection
     option_prefix = options.prefix
-    option_geometry = options.geometry 
+    option_geometry = options.geometry
     option_forced_y_up = options.forceyup
-    option_default_camera = options.defcamera 
-    option_default_light = options.deflight 
-    option_pretty_print = options.pretty 
+    option_default_camera = options.defcamera
+    option_default_light = options.deflight
+    option_pretty_print = options.pretty
 
     # Prepare the FBX SDK.
     sdk_manager, scene = InitializeSdkObjects()
     converter = FbxGeometryConverter(sdk_manager)
 
-    # The converter takes an FBX file as an argument.
+    identify_present = False
+    try:
+        popen = subprocess.Popen(('identify', '-help'), stdout=subprocess.PIPE)
+        popen.wait()
+        identify_present = True
+    except OSError as e:
+        pass
+
+    if not identify_present:
+        if option_transparency_detection:
+            sys.exit('\nTransparency detection requires ImageMagick (identify) to be installed\nEnsure identify is in your PATH or specify the --no-transparency-detection flag')
+        if option_copy_textures:
+            sys.stderr.write('\nWARNING: ImageMagick (identify) not found installed in PATH.\nTextures will not automatically be converted to web compatible file formats\n')
+            texture_conversion_enabled = False
+
+    if option_copy_textures:
+        convert_present = False
+        try:
+            popen = subprocess.Popen(('convert', '-help'), stdout=subprocess.PIPE)
+            popen.wait()
+            convert_present = True
+        except OSError as e:
+            pass
+
+        if not convert_present:
+            sys.stderr.write('\nWARNING: ImageMagick (convert) not found installed in PATH.\nTextures will not automatically be converted to web compatible file formats\n')
+            texture_conversion_enabled = False
+
+# The converter takes an FBX file as an argument.
     if len(args) > 1:
         print("\nLoading file: %s" % args[0])
         result = LoadScene(sdk_manager, scene, args[0])
     else:
         result = False
-        print("\nUsage: convert_fbx_to_threejs [source_file.fbx] [output_file.js]\n")
+        sys.exit("\nUsage: convert_fbx_to_threejs [source_file.fbx] [output_file.js]\n")
 
     if not result:
-        print("\nAn error occurred while loading the file...")
+        sys.stderr.write("\nAn error occurred while loading the file...\n")
     else:
         if option_triangulate:
             print("\nForcing geometry to triangles")
             triangulate_scene(scene)
-            
-        axis_system = FbxAxisSystem.MayaYUp
-        
-        if not option_forced_y_up:
-            # According to asset's coordinate to convert scene 
-            upVector = scene.GetGlobalSettings().GetAxisSystem().GetUpVector();
-            if upVector[0] == 3:
-                axis_system = FbxAxisSystem.MayaZUp
-        
-        axis_system.ConvertScene(scene)
-        
-        inputFolder = args[0].replace( "\\", "/" );
-        index = args[0].rfind( "/" );
-        inputFolder = inputFolder[:index]
 
-        outputFolder = args[1].replace( "\\", "/" );
-        index = args[1].rfind( "/" );
-        outputFolder = outputFolder[:index]
-         
+        axis_system = FbxAxisSystem.MayaYUp
+
+        if not option_forced_y_up:
+            # According to asset's coordinate to convert scene
+            up_vector = scene.GetGlobalSettings().GetAxisSystem().GetUpVector()
+            if up_vector[0] == 3:
+                axis_system = FbxAxisSystem.MayaZUp
+
+        axis_system.ConvertScene(scene)
+
+        output_path = os.path.join(os.getcwd(), args[1])
+        output_directory = os.path.dirname(output_path)
+
+        if not os.path.exists(output_directory):
+            try:
+                os.makedirs(output_directory)
+            except IOError as e:
+                sys.exit("I/O error({0}): {1} {2}".format(e.errno, e.strerror, output_directory))
+
+        if option_pretty_print:
+            metadata_key = '00_metadata'
+            type_key = '01_type'
+            uuid_key = '02_uuid'
+            name_key = '03_name'
+            data_key = 'zy_data'
+            children_key = 'zz_children'
+
         if option_geometry:
-            output_content = extract_geometry(scene, os.path.basename(args[0]))
+            output_content = extract_geometry(scene)
         else:
-            output_content = extract_scene(scene, os.path.basename(args[0]))
+            output_content = extract_scene(scene)
 
         if option_pretty_print:
             output_string = json.dumps(output_content, indent=4, cls=CustomEncoder, separators=(',', ': '), sort_keys=True)
-            output_string = executeRegexHacks(output_string)
+            output_string = execute_regex_hacks(output_string)
         else:
             output_string = json.dumps(output_content, separators=(',', ': '), sort_keys=True)
 
-
-        output_path = os.path.join(os.getcwd(), args[1])
         write_file(output_path, output_string)
-        
-        if option_copy_textures:
-            copy_textures( output_content['textures'] )       
 
         print("\nExported Three.js file to:\n%s\n" % output_path)
 

--- a/utils/converters/fbx/convert_to_threejs.py
+++ b/utils/converters/fbx/convert_to_threejs.py
@@ -54,6 +54,12 @@ FBX_TEXTURE_BINDINGS = {
   'AmbientFactor': 'aoMap'
 }
 
+THREE_REPEAT_WRAPPING = 1000
+THREE_CLAMP_TO_EDGE_WRAPPING = 1001
+
+THREE_LINEAR_FILTER = 1006
+THREE_LINEAR_MIP_MAP_LINEAR_FILTER = 1008
+
 # #####################################################
 # Pretty Printing Hacks
 # #####################################################
@@ -565,6 +571,11 @@ def generate_texture_data(texture, image_dict, texture_list, texture_dict):
         image_uuid = str(uuid.uuid4())
         image_dict[relative_path] = image_uuid
 
+    wrap_mode_s = THREE_REPEAT_WRAPPING if texture.GetWrapModeU() == FbxTexture.eRepeat else THREE_CLAMP_TO_EDGE_WRAPPING
+    wrap_mode_t = THREE_REPEAT_WRAPPING if texture.GetWrapModeV() == FbxTexture.eRepeat else THREE_CLAMP_TO_EDGE_WRAPPING
+    repeat_s = 1.0 if wrap_mode_s == THREE_CLAMP_TO_EDGE_WRAPPING else texture.GetScaleU()
+    repeat_t = 1.0 if wrap_mode_t == THREE_CLAMP_TO_EDGE_WRAPPING else texture.GetScaleV()
+
     texture_uuid = str(uuid.uuid4())
     texture_name = get_texture_name(texture)
 
@@ -572,10 +583,11 @@ def generate_texture_data(texture, image_dict, texture_list, texture_dict):
       uuid_key: texture_uuid,
       name_key: texture_name,
       'image': image_uuid,
-      'repeat': serialize_vector2((1,1)),
+      'wrap': [wrap_mode_s, wrap_mode_t],
+      'repeat': serialize_vector2((repeat_s, repeat_t)),
       'offset': serialize_vector2(texture.GetUVTranslation()),
-      'magFilter': 1006, # THREE.LinearFilter
-      'minFilter': 1008, # THREE.LinearMipMapLinearFilter
+      'magFilter': THREE_LINEAR_FILTER,
+      'minFilter': THREE_LINEAR_MIP_MAP_LINEAR_FILTER,
       'anisotropy': True
     })
     texture_dict[texture_name] = texture_uuid

--- a/utils/converters/fbx/convert_to_threejs.py
+++ b/utils/converters/fbx/convert_to_threejs.py
@@ -254,7 +254,7 @@ def get_texture_name(t):
             texture_name = ""
 
     if len(texture_name) == 0:
-        return "Texture_" + t.GetUniqueID()
+        return "Texture_%s" % t.GetUniqueID()
     else:
         return "Texture_%s_" % t.GetUniqueID() + texture_name
 

--- a/utils/converters/fbx/convert_to_threejs.py
+++ b/utils/converters/fbx/convert_to_threejs.py
@@ -1775,16 +1775,23 @@ def generate_mesh_object(node, geometry_dict, material_dict):
             material_names.append('')
 
         material_name = get_multi_material_name(node) if material_count > 1 else material_names[0]
+    else:
+        mesh_name = 'Mesh_%s_%s' % (mesh.GetUniqueID(), mesh.GetName()) if len(mesh.GetName()) > 0 else 'Mesh_%s' % mesh.GetUniqueID()
+        sys.stderr.write("WARNING: Mesh '%s' has no materials\n" % mesh_name)
 
-    return {
-       type_key: 'Mesh',
-      'geometry': geometry_dict[get_geometry_name(node)],
-      'material': material_dict[material_name],
-      'position': serialize_vector3(position),
-      'quaternion': serialize_vector4(quaternion),
-      'scale': serialize_vector3(scale),
-      'visible': True
+    output = {
+        type_key: 'Mesh',
+        'geometry': geometry_dict[get_geometry_name(node)],
+        'position': serialize_vector3(position),
+        'quaternion': serialize_vector4(quaternion),
+        'scale': serialize_vector3(scale),
+        'visible': True
     }
+
+    if len(material_name) > 0:
+        output['material'] = material_dict[material_name]
+
+    return output
 
 # #####################################################
 # Generate Node Object

--- a/utils/converters/fbx/convert_to_threejs.py
+++ b/utils/converters/fbx/convert_to_threejs.py
@@ -21,7 +21,6 @@ option_ignore_texture_collision = False
 option_texture_output_dir = 'maps'
 option_transparency_detection = True
 option_prefix = True
-option_geometry = False
 option_forced_y_up = False
 option_default_camera = False
 option_default_light = False
@@ -45,14 +44,14 @@ copied_texture_dict = {}
 WEB_FORMATS = ['PNG', 'JPEG', 'GIF']
 
 FBX_TEXTURE_BINDINGS = {
-  'DiffuseColor': 'map',
-  'EmissiveColor': 'emissiveMap',
-  'SpecularColor': 'specularMap',
-  'NormalMap': 'normalMap',
-  'Bump': 'bumpMap',
-  'TransparencyFactor': 'alphaMap',
-  'ReflectionColor': 'envMap',
-  'AmbientFactor': 'aoMap'
+    'DiffuseColor': 'map',
+    'EmissiveColor': 'emissiveMap',
+    'SpecularColor': 'specularMap',
+    'NormalMap': 'normalMap',
+    'Bump': 'bumpMap',
+    'TransparencyFactor': 'alphaMap',
+    'ReflectionColor': 'envMap',
+    'AmbientFactor': 'aoMap'
 }
 
 THREE_REPEAT_WRAPPING = 1000
@@ -358,11 +357,11 @@ def generate_material_object(material, texture_dict, material_list, material_dic
 
         material_type = 'MeshLambertMaterial'
         material_object = {
-          'color': diffuse,
-          'emissive': emissive,
-          'reflectivity': reflectivity,
-          'transparent': transparent,
-          'opacity': opacity
+            'color': diffuse,
+            'emissive': emissive,
+            'reflectivity': reflectivity,
+            'transparent': transparent,
+            'opacity': opacity
         }
 
     elif material.GetClassId().Is(FbxSurfacePhong.ClassId):
@@ -378,14 +377,14 @@ def generate_material_object(material, texture_dict, material_list, material_dic
 
         material_type = 'MeshPhongMaterial'
         material_object = {
-          'color': diffuse,
-          'emissive': emissive,
-          'specular': specular,
-          'shininess': shininess,
-          'bumpScale': bump_scale,
-          'reflectivity': reflectivity,
-          'transparent': transparent,
-          'opacity': opacity
+            'color': diffuse,
+            'emissive': emissive,
+            'specular': specular,
+            'shininess': shininess,
+            'bumpScale': bump_scale,
+            'reflectivity': reflectivity,
+            'transparent': transparent,
+            'opacity': opacity
         }
 
     else:
@@ -401,11 +400,11 @@ def generate_material_object(material, texture_dict, material_list, material_dic
 
         material_type = 'MeshBasicMaterial'
         material_object = {
-          'color': diffuse,
-          'emissive': emissive,
-          'reflectivity': reflectivity,
-          'transparent': transparent,
-          'opacity': opacity
+            'color': diffuse,
+            'emissive': emissive,
+            'reflectivity': reflectivity,
+            'transparent': transparent,
+            'opacity': opacity
         }
 
     if option_textures:
@@ -437,10 +436,10 @@ def generate_multi_material_object(node, submaterial_uuids, material_list, mater
     material_name = get_multi_material_name(node)
 
     material_list.append({
-      type_key: material_type,
-      uuid_key: material_uuid,
-      name_key: material_name,
-      'referencedMaterials': submaterial_uuids
+        type_key: material_type,
+        uuid_key: material_uuid,
+        name_key: material_name,
+        'referencedMaterials': submaterial_uuids
     })
     material_dict[material_name] = material_uuid
 
@@ -583,15 +582,15 @@ def generate_texture_data(texture, image_dict, texture_list, texture_dict):
         texture_uuid = str(uuid.uuid4())
 
         texture_list.append({
-          uuid_key: texture_uuid,
-          name_key: texture_name,
-          'image': image_uuid,
-          'wrap': [wrap_mode_s, wrap_mode_t],
-          'repeat': serialize_vector2((repeat_s, repeat_t)),
-          'offset': serialize_vector2(texture.GetUVTranslation()),
-          'magFilter': THREE_LINEAR_FILTER,
-          'minFilter': THREE_LINEAR_MIP_MAP_LINEAR_FILTER,
-          'anisotropy': True
+            uuid_key: texture_uuid,
+            name_key: texture_name,
+            'image': image_uuid,
+            'wrap': [wrap_mode_s, wrap_mode_t],
+            'repeat': serialize_vector2((repeat_s, repeat_t)),
+            'offset': serialize_vector2(texture.GetUVTranslation()),
+            'magFilter': THREE_LINEAR_FILTER,
+            'minFilter': THREE_LINEAR_MIP_MAP_LINEAR_FILTER,
+            'anisotropy': True
         })
         texture_dict[texture_name] = texture_uuid
 
@@ -696,13 +695,7 @@ def extract_fbx_vertex_positions(mesh):
 
         transform = None
 
-        if option_geometry:
-            # FbxMeshes are local to their node, we need the vertices in global space
-            # when scene nodes are not exported
-            transform = node.EvaluateGlobalTransform()
-            transform = FbxMatrix(transform) * geo_transform
-
-        elif has_geometric_transform:
+        if has_geometric_transform:
             transform = geo_transform
 
         if transform:
@@ -769,13 +762,7 @@ def extract_fbx_vertex_normals(mesh):
 
             transform = None
 
-            if option_geometry:
-                # FbxMeshes are local to their node, we need the vertices in global space
-                # when scene nodes are not exported
-                transform = node.EvaluateGlobalTransform()
-                transform = FbxMatrix(transform) * geo_transform
-
-            elif has_geometric_transform:
+            if has_geometric_transform:
                 transform = geo_transform
 
             if transform:
@@ -1153,7 +1140,7 @@ def generate_uv_indices_for_poly(poly_index, mesh_uv_values, mesh_uv_indices, uv
 
     return output_poly_uv_indices
 
-def process_mesh_vertices(mesh_list):
+def process_geometry_vertices(mesh_list):
     vertex_offset = 0
     vertex_offset_list = [0]
     vertices = []
@@ -1165,7 +1152,6 @@ def process_mesh_vertices(mesh_list):
         vertex_offset_list.append(vertex_offset)
 
     return vertices, vertex_offset_list
-
 
 def process_mesh_materials(mesh_list):
     material_offset = 0
@@ -1380,197 +1366,106 @@ def generate_mesh_face(mesh, polygon_index, vertex_indices, normals, colors, uv_
 # #####################################################
 # Generate JSONLoader compatible Geometry
 # #####################################################
-def generate_geometry_data(node, geometry_dict):
-    mesh = node.GetNodeAttribute()
+def generate_geometry_data(node):
+    geometry = node.GetNodeAttribute()
 
     # This is done in order to keep the scene output and non-scene output code DRY
-    mesh_list = [ mesh ]
+    geometry_list = [ geometry ]
 
     # Extract the mesh data into arrays
-    vertices, vertex_offsets = process_mesh_vertices(mesh_list)
-    materials, material_offsets = process_mesh_materials(mesh_list)
+    vertices, vertex_offsets = process_geometry_vertices(geometry_list)
+    materials, material_offsets = process_mesh_materials(geometry_list)
 
-    normals_to_indices = generate_unique_normals_dictionary(mesh_list)
-    colors_to_indices = generate_unique_colors_dictionary(mesh_list)
-    uvs_to_indices_list = generate_unique_uvs_dictionary_layers(mesh_list)
-
-    normal_values = generate_normals_from_dictionary(normals_to_indices)
-    color_values = generate_colors_from_dictionary(colors_to_indices)
-    uv_values = generate_uvs_from_dictionary_layers(uvs_to_indices_list)
-
-    # Generate mesh faces for the Three.js file format
-    faces = process_mesh_polygons(mesh_list,
-                                  normals_to_indices,
-                                  colors_to_indices,
-                                  uvs_to_indices_list,
-                                  vertex_offsets,
-                                  material_offsets)
-
-    # Generate counts for uvs, vertices, normals, colors, and faces
-    nuvs = []
-    for layer_index, uvs in enumerate(uv_values):
-        nuvs.append(str(len(uvs)))
-
+    # Count then flatten vertices
     nvertices = len(vertices)
-    nnormals = len(normal_values)
-    ncolors = len(color_values)
-    nfaces = len(faces)
-
-    # Flatten the arrays, currently they are in the form of [[0, 1, 2], [3, 4, 5], ...]
     vertices = [val for v in vertices for val in v]
-    normal_values = [val for n in normal_values for val in n]
-    color_values = [c for c in color_values]
-    faces = [val for f in faces for val in f]
-    uv_values = generate_uvs(uv_values)
 
     # Disable automatic json indenting when pretty printing for the arrays
     if option_pretty_print:
-        nuvs = NoIndent(nuvs)
         vertices = ChunkedIndent(vertices, 15, True)
-        normal_values = ChunkedIndent(normal_values, 15, True)
-        color_values = ChunkedIndent(color_values, 15)
-        faces = ChunkedIndent(faces, 30)
 
     metadata = {
-      'vertices': nvertices,
-      'normals': nnormals,
-      'colors': ncolors,
-      'faces': nfaces,
-      'uvs': nuvs
+        'vertices': nvertices
     }
+
+    if geometry.GetAttributeType() == FbxNodeAttribute.eMesh:
+        normals_to_indices = generate_unique_normals_dictionary(geometry_list)
+        colors_to_indices = generate_unique_colors_dictionary(geometry_list)
+        uvs_to_indices_list = generate_unique_uvs_dictionary_layers(geometry_list)
+
+        normal_values = generate_normals_from_dictionary(normals_to_indices)
+        color_values = generate_colors_from_dictionary(colors_to_indices)
+        uv_values = generate_uvs_from_dictionary_layers(uvs_to_indices_list)
+
+        # Generate mesh faces for the Three.js file format
+        faces = process_mesh_polygons(geometry_list,
+                                      normals_to_indices,
+                                      colors_to_indices,
+                                      uvs_to_indices_list,
+                                      vertex_offsets,
+                                      material_offsets)
+
+        # Generate counts for uvs, normals, colors, and faces
+        nuvs = []
+        for layer_index, uvs in enumerate(uv_values):
+            nuvs.append(str(len(uvs)))
+
+        nnormals = len(normal_values)
+        ncolors = len(color_values)
+        nfaces = len(faces)
+
+        # Flatten the arrays, currently they are in the form of [[0, 1, 2], [3, 4, 5], ...]
+        normal_values = [val for n in normal_values for val in n]
+        color_values = [c for c in color_values]
+        faces = [val for f in faces for val in f]
+        uv_values = generate_uvs(uv_values)
+
+        # Disable automatic json indenting when pretty printing for the arrays
+        if option_pretty_print:
+            nuvs = NoIndent(nuvs)
+            normal_values = ChunkedIndent(normal_values, 15, True)
+            color_values = ChunkedIndent(color_values, 15)
+            faces = ChunkedIndent(faces, 30)
+
+        metadata['normals'] = nnormals
+        metadata['colors'] = ncolors
+        metadata['faces'] = nfaces
+        metadata['uvs'] = nuvs
+    else:
+        normal_values = None
+        color_values = None
+        uv_values = None
+        faces = None
 
     geometry_name = get_geometry_name(node)
 
     return {
-      name_key: geometry_name,
-      'scale': 1,
-      'vertices': vertices,
-      'normals': [] if nnormals <= 0 else normal_values,
-      'colors': [] if ncolors <= 0 else color_values,
-      'uvs': uv_values,
-      'faces': faces,
-      metadata_key: metadata
+        name_key: geometry_name,
+        'scale': 1,
+        'vertices': vertices,
+        'normals': [] if not normal_values else normal_values,
+        'colors': [] if not color_values else color_values,
+        'uvs': [] if not uv_values else uv_values,
+        'faces': [] if not faces else faces,
+        metadata_key: metadata
     }
-
-# #####################################################
-# Generate Mesh Object (for non-scene output)
-# #####################################################
-def generate_non_scene_output(scene):
-    mesh_list = generate_mesh_list(scene)
-
-    # Extract the mesh data into arrays
-    vertices, vertex_offsets = process_mesh_vertices(mesh_list)
-    materials, material_offsets = process_mesh_materials(mesh_list)
-
-    normals_to_indices = generate_unique_normals_dictionary(mesh_list)
-    colors_to_indices = generate_unique_colors_dictionary(mesh_list)
-    uvs_to_indices_list = generate_unique_uvs_dictionary_layers(mesh_list)
-
-    normal_values = generate_normals_from_dictionary(normals_to_indices)
-    color_values = generate_colors_from_dictionary(colors_to_indices)
-    uv_values = generate_uvs_from_dictionary_layers(uvs_to_indices_list)
-
-    # Generate mesh faces for the Three.js file format
-    faces = process_mesh_polygons(mesh_list,
-                                  normals_to_indices,
-                                  colors_to_indices,
-                                  uvs_to_indices_list,
-                                  vertex_offsets,
-                                  material_offsets)
-
-    # Generate counts for uvs, vertices, normals, colors, and faces
-    nuvs = []
-    for layer_index, uvs in enumerate(uv_values):
-        nuvs.append(str(len(uvs)))
-
-    nvertices = len(vertices)
-    nnormals = len(normal_values)
-    ncolors = len(color_values)
-    nfaces = len(faces)
-
-    # Flatten the arrays, currently they are in the form of [[0, 1, 2], [3, 4, 5], ...]
-    vertices = [val for v in vertices for val in v]
-    normal_values = [val for n in normal_values for val in n]
-    color_values = [c for c in color_values]
-    faces = [val for f in faces for val in f]
-    uv_values = generate_uvs(uv_values)
-
-    # Disable json indenting when pretty printing for the arrays
-    if option_pretty_print:
-        nuvs = NoIndent(nuvs)
-        vertices = NoIndent(vertices)
-        normal_values = NoIndent(normal_values)
-        color_values = NoIndent(color_values)
-        faces = NoIndent(faces)
-
-    metadata = {
-      'formatVersion': 3,
-      type_key: 'geometry',
-      'generatedBy': 'convert-to-threejs.py',
-      'vertices': nvertices,
-      'normals': nnormals,
-      'colors': ncolors,
-      'faces': nfaces,
-      'uvs': nuvs
-    }
-
-    return {
-      'scale': 1,
-      'materials': [],
-      'vertices': vertices,
-      'normals': [] if nnormals <= 0 else normal_values,
-      'colors': [] if ncolors <= 0 else color_values,
-      'uvs': uv_values,
-      'faces': faces,
-      metadata_key: metadata
-    }
-
-def generate_mesh_list_from_hierarchy(node, mesh_list):
-    if node.GetNodeAttribute() == None:
-        pass
-    else:
-        attribute_type = (node.GetNodeAttribute().GetAttributeType())
-        if attribute_type == FbxNodeAttribute.eMesh or \
-                        attribute_type == FbxNodeAttribute.eNurbs or \
-                        attribute_type == FbxNodeAttribute.eNurbsSurface or \
-                        attribute_type == FbxNodeAttribute.ePatch:
-
-            if attribute_type != FbxNodeAttribute.eMesh:
-                converter.TriangulateInPlace(node)
-
-            mesh_list.append(node.GetNodeAttribute())
-
-    for i in range(node.GetChildCount()):
-        generate_mesh_list_from_hierarchy(node.GetChild(i), mesh_list)
-
-def generate_mesh_list(scene):
-    mesh_list = []
-    node = scene.GetRootNode()
-    if node:
-        for i in range(node.GetChildCount()):
-            generate_mesh_list_from_hierarchy(node.GetChild(i), mesh_list)
-    return mesh_list
 
 def generate_geometry_list_from_hierarchy(node, geometry_list, geometry_dict):
     if node.GetNodeAttribute() == None:
         pass
     else:
         attribute_type = (node.GetNodeAttribute().GetAttributeType())
-        if attribute_type == FbxNodeAttribute.eMesh or \
-                        attribute_type == FbxNodeAttribute.eNurbs or \
-                        attribute_type == FbxNodeAttribute.eNurbsSurface or \
-                        attribute_type == FbxNodeAttribute.ePatch:
-
-            if attribute_type != FbxNodeAttribute.eMesh:
+        if attribute_type in FBX_GEOMETRY_TYPES:
+            if attribute_type in FBX_ABSTRACT_GEOMETRY_TYPES:
                 converter.TriangulateInPlace(node)
 
-            geometry_data = generate_geometry_data(node, geometry_dict)
+            geometry_data = generate_geometry_data(node)
             geometry_uuid = str(uuid.uuid4())
 
             geometry_list.append({
-              type_key: 'Geometry',
-              uuid_key: geometry_uuid,
-              data_key: geometry_data
+                type_key: 'Geometry',
+                uuid_key: geometry_uuid,
+                data_key: geometry_data
             })
             geometry_dict[geometry_data[name_key]] = geometry_uuid
 
@@ -1636,12 +1531,12 @@ def generate_default_light():
     intensity = 80.0
 
     return {
-      type_key: 'DirectionalLight',
-      uuid_key: str(uuid.uuid4()),
-      name_key: 'DirectionalLight',
-      'color': pack_color(color),
-      'intensity': intensity/100.00,
-      'direction': serialize_vector3(direction)
+        type_key: 'DirectionalLight',
+        uuid_key: str(uuid.uuid4()),
+        name_key: 'DirectionalLight',
+        'color': pack_color(color),
+        'intensity': intensity/100.00,
+        'direction': serialize_vector3(direction)
     }
 
 def generate_light_object(node):
@@ -1670,36 +1565,36 @@ def generate_light_object(node):
             direction = matrix.MultNormalize(FbxVector4(0,1,0,1))
 
         output = {
-          type_key: 'DirectionalLight',
-          'color': pack_color(light.Color.Get()),
-          'intensity': light.Intensity.Get()/100.0,
-          'direction': serialize_vector3(direction),
-          # TODO: ObjectLoader doesn't support targets
-          #'target': getObjectName(node.GetTarget())
+            type_key: 'DirectionalLight',
+            'color': pack_color(light.Color.Get()),
+            'intensity': light.Intensity.Get()/100.0,
+            'direction': serialize_vector3(direction),
+            # TODO: ObjectLoader doesn't support targets
+            #'target': getObjectName(node.GetTarget())
         }
 
     elif light_type == "point":
 
         output = {
-          type_key: 'PointLight',
-          'color': pack_color(light.Color.Get()),
-          'intensity': light.Intensity.Get()/100.0,
-          'position': serialize_vector3(position),
-          'distance': light.FarAttenuationEnd.Get()
+            type_key: 'PointLight',
+            'color': pack_color(light.Color.Get()),
+            'intensity': light.Intensity.Get()/100.0,
+            'position': serialize_vector3(position),
+            'distance': light.FarAttenuationEnd.Get()
         }
 
     elif light_type == "spot":
 
         output = {
-          type_key: 'SpotLight',
-          'color': pack_color(light.Color.Get()),
-          'intensity': light.Intensity.Get()/100.0,
-          'position': serialize_vector3(position),
-          'distance': light.FarAttenuationEnd.Get(),
-          'angle': light.OuterAngle.Get()*math.pi/180,
-          'exponent': light.DecayType.Get(),
-          # TODO: ObjectLoader doesn't support targets
-          #'target': getObjectName(node.GetTarget())
+            type_key: 'SpotLight',
+            'color': pack_color(light.Color.Get()),
+            'intensity': light.Intensity.Get()/100.0,
+            'position': serialize_vector3(position),
+            'distance': light.FarAttenuationEnd.Get(),
+            'angle': light.OuterAngle.Get()*math.pi/180,
+            'exponent': light.DecayType.Get(),
+            # TODO: ObjectLoader doesn't support targets
+            #'target': getObjectName(node.GetTarget())
         }
 
     return output
@@ -1714,10 +1609,10 @@ def generate_ambient_light(scene):
         return None
 
     return {
-      type_key: 'AmbientLight',
-      uuid_key: str(uuid.uuid4()),
-      name_key: 'AmbientLight',
-      'color': pack_color(ambient_color),
+        type_key: 'AmbientLight',
+        uuid_key: str(uuid.uuid4()),
+        name_key: 'AmbientLight',
+        'color': pack_color(ambient_color),
     }
 
 # #####################################################
@@ -1730,13 +1625,13 @@ def generate_default_camera():
     fov = 75
 
     return {
-      type_key: 'PerspectiveCamera',
-      uuid_key: str(uuid.uuid4()),
-      name_key: 'DefaultCamera',
-      'fov': fov,
-      'near': near,
-      'far': far,
-      'position': serialize_vector3(position)
+        type_key: 'PerspectiveCamera',
+        uuid_key: str(uuid.uuid4()),
+        name_key: 'DefaultCamera',
+        'fov': fov,
+        'near': near,
+        'far': far,
+        'position': serialize_vector3(position)
     }
 
 def generate_camera_object(node):
@@ -1757,12 +1652,12 @@ def generate_camera_object(node):
         fov = camera.FieldOfView.Get()
 
         output = {
-          type_key: 'PerspectiveCamera',
-          'fov': fov,
-          'aspect': aspect,
-          'near': near,
-          'far': far,
-          'position': serialize_vector3(position)
+            type_key: 'PerspectiveCamera',
+            'fov': fov,
+            'aspect': aspect,
+            'near': near,
+            'far': far,
+            'position': serialize_vector3(position)
         }
 
     elif projection == "orthogonal":
@@ -1773,47 +1668,46 @@ def generate_camera_object(node):
         bottom = ""
 
         output = {
-          type_key: 'PerspectiveCamera',
-          'left': left,
-          'right': right,
-          'top': top,
-          'bottom': bottom,
-          'near': near,
-          'far': far,
-          'position': serialize_vector3(position)
+            type_key: 'PerspectiveCamera',
+            'left': left,
+            'right': right,
+            'top': top,
+            'bottom': bottom,
+            'near': near,
+            'far': far,
+            'position': serialize_vector3(position)
         }
 
     return output
 
 # #####################################################
-# Generate Mesh Node Object
+# Generate Geometry Node Object
 # #####################################################
-def generate_mesh_object(node, geometry_dict, material_dict):
-    mesh = node.GetNodeAttribute()
+def generate_geometry_object(geometry_type, node, geometry_dict, material_dict):
+    geometry = node.GetNodeAttribute()
     transform = node.EvaluateLocalTransform()
     position = transform.GetT()
     scale = transform.GetS()
     quaternion = transform.GetQ()
 
-    mesh_node = mesh.GetNode() # Same as node unless the mesh is instanced
-    material_count = mesh_node.GetMaterialCount()
+    geometry_node = geometry.GetNode() # Same as node unless the mesh is instanced
+    material_count = geometry_node.GetMaterialCount()
     material_name = ""
 
     if material_count > 0:
         material_names = []
 
         for i in range(material_count):
-            material = mesh_node.GetMaterial(i)
+            material = geometry_node.GetMaterial(i)
             material_names.append(get_material_name(material))
 
-        material_name = get_multi_material_name(mesh_node) if material_count > 1 else material_names[0]
+        material_name = get_multi_material_name(geometry_node) if material_count > 1 else material_names[0]
     else:
-        mesh_name = 'Mesh_%s_%s' % (mesh.GetUniqueID(), mesh.GetName()) if len(mesh.GetName()) > 0 else 'Mesh_%s' % mesh.GetUniqueID()
-        sys.stderr.write("WARNING: Mesh '%s' has no materials\n" % mesh_name)
+        sys.stderr.write("WARNING: %s '%s' has no materials\n" % (geometry_type, get_object_name(node)))
 
     output = {
-        type_key: 'Mesh',
-        'geometry': geometry_dict[get_geometry_name(mesh_node)],
+        type_key: geometry_type,
+        'geometry': geometry_dict[get_geometry_name(geometry_node)],
         'position': serialize_vector3(position),
         'quaternion': serialize_vector4(quaternion),
         'scale': serialize_vector3(scale),
@@ -1844,11 +1738,11 @@ def generate_generic_object(node):
         node_type = node_types[node.GetNodeAttribute().GetAttributeType()]
 
     return {
-      type_key: node_type,
-      'position': serialize_vector3(position),
-      'quaternion': serialize_vector4(quaternion),
-      'scale': serialize_vector3(scale),
-      'visible': True
+        type_key: node_type,
+        'position': serialize_vector3(position),
+        'quaternion': serialize_vector4(quaternion),
+        'scale': serialize_vector3(scale),
+        'visible': True
     }
 
 # #####################################################
@@ -1860,11 +1754,13 @@ def generate_object(node, geometry_dict, material_dict):
     else:
         attribute_type = (node.GetNodeAttribute().GetAttributeType())
         if attribute_type == FbxNodeAttribute.eMesh:
-            object_data = generate_mesh_object(node, geometry_dict, material_dict)
+            object_data = generate_geometry_object('Mesh', node, geometry_dict, material_dict)
         elif attribute_type == FbxNodeAttribute.eLight:
             object_data = generate_light_object(node)
         elif attribute_type == FbxNodeAttribute.eCamera:
             object_data = generate_camera_object(node)
+        elif attribute_type == FbxNodeAttribute.eLine:
+            object_data = generate_geometry_object('LineSegments', node, geometry_dict, material_dict)
         else:
             object_data = generate_generic_object(node)
 
@@ -1900,13 +1796,13 @@ def generate_scene_object(scene, geometry_dict, material_dict):
             children.append(generate_object(node.GetChild(i), geometry_dict, material_dict))
 
     return {
-      type_key: 'Scene',
-      uuid_key: str(uuid.uuid4()),
-      name_key: 'Scene',
-      'position': serialize_vector3((0,0,0)),
-      'rotation': serialize_vector3((0,0,0)),
-      'scale': serialize_vector3((1,1,1)),
-      children_key: children
+        type_key: 'Scene',
+        uuid_key: str(uuid.uuid4()),
+        name_key: 'Scene',
+        'position': serialize_vector3((0,0,0)),
+        'rotation': serialize_vector3((0,0,0)),
+        'scale': serialize_vector3((1,1,1)),
+        children_key: children
     }
 
 # #####################################################
@@ -1920,25 +1816,19 @@ def extract_scene(scene):
     object = generate_scene_object(scene, geometry_dict, material_dict)
 
     metadata = {
-      'formatVersion': 4.3,
-      type_key: 'Object',
-      'generatedBy': 'convert-to-threejs.py'
+        'formatVersion': 4.3,
+        type_key: 'Object',
+        'generatedBy': 'convert-to-threejs.py'
     }
 
     return {
-      'geometries': geometries,
-      'images': images,
-      'textures': textures,
-      'materials': materials,
-      'object': object,
-      metadata_key: metadata
+        'geometries': geometries,
+        'images': images,
+        'textures': textures,
+        'materials': materials,
+        'object': object,
+        metadata_key: metadata
     }
-
-# #####################################################
-# Generate Non-Scene Output
-# #####################################################
-def extract_geometry(scene):
-    return generate_non_scene_output(scene)
 
 # #####################################################
 # File Helpers
@@ -1979,7 +1869,6 @@ if __name__ == "__main__":
     parser.add_option("-o", "--texture-output-dir", dest="textureoutputdir", help="write copied textures to specified directory (relative to the output .js file)", metavar='DIR', default='maps')
     parser.add_option('-a', '--no-transparency-detection', action='store_true', dest='notransparencydetection', help="don't automatically enable transparency for materials with diffuse maps containing alpha", default=False)
     parser.add_option('-u', '--force-prefix', action='store_true', dest='prefix', help="prefix all object names in output file to ensure uniqueness", default=False)
-    parser.add_option('-f', '--flatten-scene', action='store_true', dest='geometry', help="merge all geometries and apply node transforms", default=False)
     parser.add_option('-y', '--force-y-up', action='store_true', dest='forceyup', help="ensure that the y axis shows up", default=False)
     parser.add_option('-c', '--add-camera', action='store_true', dest='defcamera', help="include default camera in output scene", default=False)
     parser.add_option('-l', '--add-light', action='store_true', dest='deflight', help="include default light in output scene", default=False)
@@ -1995,7 +1884,6 @@ if __name__ == "__main__":
     option_texture_output_dir = options.textureoutputdir
     option_transparency_detection = not options.notransparencydetection
     option_prefix = options.prefix
-    option_geometry = options.geometry
     option_forced_y_up = options.forceyup
     option_default_camera = options.defcamera
     option_default_light = options.deflight
@@ -2006,7 +1894,20 @@ if __name__ == "__main__":
     sdk_manager, scene = InitializeSdkObjects()
     converter = FbxGeometryConverter(sdk_manager)
 
+    FBX_GEOMETRY_TYPES = [FbxNodeAttribute.eMesh,
+                          FbxNodeAttribute.eNurbs,
+                          FbxNodeAttribute.eNurbsSurface,
+                          FbxNodeAttribute.ePatch,
+                          FbxNodeAttribute.eLine]
+
+    FBX_ABSTRACT_GEOMETRY_TYPES = [
+        FbxNodeAttribute.eNurbs,
+        FbxNodeAttribute.eNurbsSurface,
+        FbxNodeAttribute.ePatch
+    ]
+
     identify_present = False
+
     try:
         popen = subprocess.Popen(('identify', '-help'), stdout=subprocess.PIPE)
         popen.communicate()
@@ -2034,7 +1935,7 @@ if __name__ == "__main__":
             sys.stderr.write('\nWARNING: ImageMagick (convert) not found installed in PATH.\nTextures will not automatically be converted to web compatible file formats\n')
             texture_conversion_enabled = False
 
-# The converter takes an FBX file as an argument.
+    # The converter takes an FBX file as an argument.
     if len(args) > 1:
         print("\nLoading file: %s" % args[0])
         result = LoadScene(sdk_manager, scene, args[0])
@@ -2076,10 +1977,7 @@ if __name__ == "__main__":
             data_key = 'zy_data'
             children_key = 'zz_children'
 
-        if option_geometry:
-            output_content = extract_geometry(scene)
-        else:
-            output_content = extract_scene(scene)
+        output_content = extract_scene(scene)
 
         if option_pretty_print:
             output_string = json.dumps(output_content, indent=4, cls=CustomEncoder, separators=(',', ': '), sort_keys=True)


### PR DESCRIPTION
Had to make a few changes to three.js itself to get things working (namely adding a Reference object). 

@mrdoob The very recent renaming of MeshFaceMaterial to MultiMaterial made my rebase a tad difficult, but I'll forgive you because you fixed the UV coordinate bug I was having with MeshFaceMaterial :wink: 

~~I've also made MultiMaterial a real Material. This was required because initMaterial needed to be called to setup things like material.precision (@mrdoob unless you already addressed this?) If this is unnecessary or undesirable I'll happily drop this commit.~~ (_DROPPED_)
