### PR TITLE
Updating THREE.Clock so getElapsedTime doesn't invalidate

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -31,15 +31,21 @@ THREE.Clock.prototype = {
 
 	stop: function () {
 
-		this.getElapsedTime();
+		this.updateElapsedTime();
 		this.running = false;
 
 	},
 
 	getElapsedTime: function () {
 
-		this.getDelta();
+		this.updateElapsedTime();
 		return this.elapsedTime;
+
+	},
+
+	updateElapsedTime: function () {
+
+		this.elapsedTime += this.getDelta();
 
 	},
 
@@ -61,8 +67,6 @@ THREE.Clock.prototype = {
 
 			diff = 0.001 * ( newTime - this.oldTime );
 			this.oldTime = newTime;
-
-			this.elapsedTime += diff;
 
 		}
 


### PR DESCRIPTION
See https://github.com/mrdoob/three.js/issues/5696 - adds a function to
update elapsed time since the math is done in two places. As far as I
can tell, getDelta() shouldn't care about the elapsed time, so I removed
the calculation from there.
