### PR TITLE
Add basePosition to VRControls, to allow VR cameras at positions other than the origin. 

### DIFF
--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -83,7 +83,7 @@ THREE.VRControls = function ( object, onError ) {
 
 			if ( state.position !== null ) {
 
-				object.position.copy( state.position ).multiplyScalar( scope.scale ).addVectors(basePosition, object.position); 
+				object.position.copy( state.position ).multiplyScalar( scope.scale ).addVector(basePosition); 
 
 			}
 

--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -119,11 +119,15 @@ THREE.VRControls = function ( object, onError ) {
 	};
 	
 	this.getBasePosition = function () {
+		
 		return basePosition; 
+		
 	}; 
 
 	this.setBasePosition = function ( position ) {
+		
 		basePosition.copy( position ); 
+		
 	}; 
 
 	this.dispose = function () {

--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -117,6 +117,14 @@ THREE.VRControls = function ( object, onError ) {
 		this.resetSensor();
 
 	};
+	
+	this.getBasePosition = function () {
+		return basePosition; 
+	}; 
+
+	this.setBasePosition = function ( position ) {
+		basePosition.copy( position ); 
+	}; 
 
 	this.dispose = function () {
 

--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -9,7 +9,7 @@ THREE.VRControls = function ( object, onError ) {
 
 	var vrInputs = [];
 
-	var basePosition = new THREE.Vector3().copy(object.position); 
+	var basePosition = new THREE.Vector3().copy( object.position ); 
 
 	function filterInvalidDevices( devices ) {
 
@@ -83,7 +83,7 @@ THREE.VRControls = function ( object, onError ) {
 
 			if ( state.position !== null ) {
 
-				object.position.copy( state.position ).multiplyScalar( scope.scale ).addVector(basePosition); 
+				object.position.copy( state.position ).multiplyScalar( scope.scale ).addVector( basePosition ); 
 
 			}
 

--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -9,6 +9,8 @@ THREE.VRControls = function ( object, onError ) {
 
 	var vrInputs = [];
 
+	var basePosition = new THREE.Vector3().copy(object.position); 
+
 	function filterInvalidDevices( devices ) {
 
 		// Exclude Cardboard position sensor if Oculus exists.
@@ -81,7 +83,7 @@ THREE.VRControls = function ( object, onError ) {
 
 			if ( state.position !== null ) {
 
-				object.position.copy( state.position ).multiplyScalar( scope.scale );
+				object.position.copy( state.position ).multiplyScalar( scope.scale ).addVectors(basePosition, object.position); 
 
 			}
 

--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -83,7 +83,7 @@ THREE.VRControls = function ( object, onError ) {
 
 			if ( state.position !== null ) {
 
-				object.position.copy( state.position ).multiplyScalar( scope.scale ).addVector( basePosition ); 
+				object.position.copy( state.position ).multiplyScalar( scope.scale ).add( basePosition ); 
 
 			}
 


### PR DESCRIPTION
Current implementation of VRControls.update() overwrites the passed object's position with the absolute position state of the sensor. 

**Old VRControls:**
- Create a PerspectiveCamera
- Set its position to ( 100, 200, 300 )
- Pass camera into VRControls constructor
- Call VRControls.update() 
- Camera position is reset to **( 0, 0, 0 ) + sensorPosition \* scale**

This pull requests adds a simple basePosition variable to VRControls. The basePosition is added to the sensor position in update() to avoid undesired snapping of the camera back to the world origin. 

**New VRControls:**
- Create a PerspectiveCamera
- Set its position to ( 100, 200, 300 )
- Pass camera into VRControls constructor, **which now stores basePosition = ( 100, 200, 300 )**
- Call VRControls.update() 
- Camera position is reset to **( 100, 200, 300 ) + sensorPosition \* scale**

Get and SetBasePosition helper functions are also added, allowing users to change the base position of the Camera after constructing VRControls. 
