### PR TITLE
Line: Return line-ray intersection distance in world space

### DIFF
--- a/docs/api/core/Raycaster.html
+++ b/docs/api/core/Raycaster.html
@@ -70,7 +70,7 @@
 		<h3>[name]( [page:Vector3 origin], [page:Vector3 direction], [page:Float near], [page:Float far] ) {</h3>
 		<div>
 		[page:Vector3 origin] — The origin vector where the ray casts from.<br />
-		[page:Vector3 direction] — The direction vector that  gives direction to the ray.<br />
+		[page:Vector3 direction] — The direction vector that gives direction to the ray. Should be normalized.<br />
 		[page:Float near] — All results returned are further away than near. Near can't be negative. Default value is 0.<br />
 		[page:Float far] — All results returned are closer then far. Far can't be lower then near . Default value is Infinity.
 		</div>
@@ -113,7 +113,7 @@
 		<h3>[method:null set]( [page:Vector3 origin], [page:Vector3 direction] )</h3>
 		<div>
 		[page:Vector3 origin] — The origin vector where the ray casts from.<br />
-		[page:Vector3 direction] — The direction vector that  gives direction to the ray.
+		[page:Vector3 direction] — The normalized direction vector that gives direction to the ray.
 		</div>
 		<div>
 		Updates the ray with a new origin and direction.

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -90,7 +90,9 @@ THREE.Line.prototype.raycast = ( function () {
 
 						if ( distSq > precisionSq ) continue;
 
-						var distance = ray.origin.distanceTo( interRay );
+						interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
+
+						var distance = raycaster.ray.origin.distanceTo( interRay );
 
 						if ( distance < raycaster.near || distance > raycaster.far ) continue;
 
@@ -125,7 +127,9 @@ THREE.Line.prototype.raycast = ( function () {
 
 					if ( distSq > precisionSq ) continue;
 
-					var distance = ray.origin.distanceTo( interRay );
+					interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
+
+					var distance = raycaster.ray.origin.distanceTo( interRay );
 
 					if ( distance < raycaster.near || distance > raycaster.far ) continue;
 
@@ -156,8 +160,10 @@ THREE.Line.prototype.raycast = ( function () {
 				var distSq = ray.distanceSqToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );
 
 				if ( distSq > precisionSq ) continue;
+				
+				interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
 
-				var distance = ray.origin.distanceTo( interRay );
+				var distance = raycaster.ray.origin.distanceTo( interRay );
 
 				if ( distance < raycaster.near || distance > raycaster.far ) continue;
 


### PR DESCRIPTION
Distance should be calculated in world space. Otherwise it fails, when Line has a scale transformation. Also added to the docs the requirement that the Raycaster direction vector needs to be normalized.
Issue #5827.
