### PR TITLE
Fix TransformControls intersection edge case

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -806,6 +806,7 @@
 			var pointer = event.changedTouches ? event.changedTouches[0] : event;
 
 			var planeIntersect = intersectObjects( pointer, [ scope.gizmo[_mode].activePlane ] );
+			if ( planeIntersect === false ) return;
 
 			point.copy( planeIntersect.point );
 


### PR DESCRIPTION
When dragging an object along a plane that is almost parallel to the camera, the planeIntersect sometimes returns false.

You can reproduce the bug by opening the [Three.js editor](http://threejs.org/editor/), creating a cube, almost aligning the camera with an axis and dragging the corresponding handle in the distance:

```
Uncaught TypeError: Cannot read property 'x' of undefined
```

This PR prevents the error from happening without changing the behavior (which I guess is correct).
