### PR TITLE
Drag gizmo handles with left mouse button only

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -752,7 +752,7 @@
 
 		function onPointerDown( event ) {
 
-			if ( scope.object === undefined || _dragging === true ) return;
+			if ( scope.object === undefined || _dragging === true || event.button !== 0 ) return;
 
 			event.preventDefault();
 			event.stopPropagation();
@@ -798,7 +798,7 @@
 
 		function onPointerMove( event ) {
 
-			if ( scope.object === undefined || scope.axis === null || _dragging === false ) return;
+			if ( scope.object === undefined || scope.axis === null || _dragging === false || event.button !== 0 ) return;
 
 			event.preventDefault();
 			event.stopPropagation();
@@ -966,6 +966,8 @@
 		}
 
 		function onPointerUp( event ) {
+
+			if ( event.button !== 0 ) return;
 
 			if ( _dragging && ( scope.axis !== null ) ) {
 				mouseUpEvent.mode = _mode;


### PR DESCRIPTION
In the Three.js editor, the right mouse button is used to pan the view and the middle mouse button is used to zoom in / out so it doesn't make sense that they'd also grab the transform handles.

You can reproduce this bug by holding middle click on an arrow of the translation gizmo and moving up/down. The view will zoom in/out while the dragged object moves too, which is surprising and not useful.

This PR limits dragging to the left mouse button, fixing the issue.
