### PR TITLE
LoadingManager: add error callbacks, and per-item tracking

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -62,6 +62,8 @@ THREE.ImageLoader.prototype = {
 
 				onError( event );
 
+				scope.manager.itemFailed( url );
+
 			}, false );
 
 		}

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -6,7 +6,7 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 
 	var scope = this;
 
-	var isLoading = false, itemsLoaded = 0, itemsTotal = 0;
+	var isLoading = false, itemsLoaded = 0, itemsTotal = 0, itemsFailed = 0;
 
 	this.onLoad = onLoad;
 	this.onProgress = onProgress;
@@ -20,7 +20,7 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 
 			if ( scope.onStart !== undefined ) {
 
-				scope.onStart( url, itemsLoaded, itemsTotal );
+				scope.onStart( url, itemsLoaded, itemsTotal, itemsFailed );
 
 			}
 
@@ -36,7 +36,7 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 
 		if ( scope.onProgress !== undefined ) {
 
-			scope.onProgress( url, itemsLoaded, itemsTotal );
+			scope.onProgress( url, itemsLoaded, itemsTotal, itemsFailed );
 
 		}
 
@@ -49,6 +49,18 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 				scope.onLoad();
 
 			}
+
+		}
+
+	};
+
+	this.itemFailed = function ( url ) {
+
+		itemsFailed ++;
+	
+		if ( scope.onError !== undefined ) {
+
+			scope.onError( url, itemsLoaded, itemsTotal, itemsFailed );
 
 		}
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -12,9 +12,23 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 	this.onProgress = onProgress;
 	this.onError = onError;
 
+	this.items = {};
+
 	this.itemStart = function ( url ) {
 
 		itemsTotal ++;
+
+		if( this.items[url] === undefined ) {
+
+			this.items[url] = {
+				numStarts: 0,
+				numLoaded: 0,
+				numFails: 0
+			};
+
+		}
+
+		this.items[url].numStarts ++;
 
 		if ( isLoading === false ) {
 
@@ -33,6 +47,8 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 	this.itemEnd = function ( url ) {
 
 		itemsLoaded ++;
+
+		this.items[url].numLoaded ++;
 
 		if ( scope.onProgress !== undefined ) {
 
@@ -57,6 +73,8 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 	this.itemFailed = function ( url ) {
 
 		itemsFailed ++;
+
+		this.items[url].numFails ++;
 	
 		if ( scope.onError !== undefined ) {
 

--- a/src/loaders/XHRLoader.js
+++ b/src/loaders/XHRLoader.js
@@ -63,6 +63,8 @@ THREE.XHRLoader.prototype = {
 
 				onError( event );
 
+				scope.manager.itemFailed( url );
+
 			}, false );
 
 		}


### PR DESCRIPTION
Two simple commits:
- Add proper callbacks for when loading fails, it seemed like it was broken.
- Add per item tracking in the LoadingManager so that one can inspect all scene items to see how many times they have been requested, whether they loaded or failed.  This is useful for debugging and optimization and has very minimal cost in terms of memory allocations or update time.
