### PR TITLE
Faster checkEdge function

### DIFF
--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -191,13 +191,29 @@ THREE.WebGLObjects = function ( gl, properties, info ) {
 
 	function checkEdge( edges, a, b ) {
 
-		var hash = a < b ? a + '_' + b : b + '_' + a;
+		if ( a > b ){
 
-		if ( edges.hasOwnProperty( hash ) ) return false;
+			var tmp = a;
+			a = b;
+			b = tmp;
 
-		edges[ hash ] = 1;
+		}
 
-		return true;
+		var list = edges[ a ];
+
+		if( list === undefined ){
+
+			edges[ a ] = [ b ];
+			return true;
+
+		}else if( list.indexOf( b ) === -1 ){
+
+			list.push( b );
+			return true;
+
+		}
+
+		return false;
 
 	}
 


### PR DESCRIPTION
This one uses a two-level hash, though the second hash is just a list that is linearly scanned as it is expected to be very small (there are not many edges per vertex).
