### PR TITLE
Using of pre-created properties for lightweight access

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -38,7 +38,7 @@ THREE.Camera.prototype.lookAt = function () {
 
 	// This routine does not support cameras with rotated and/or translated parent(s)
 
-	var m1 = new THREE.Matrix4();
+	var m1 = THREE.Object3D.cachedMatrix;
 
 	return function ( vector ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -185,7 +185,8 @@ THREE.Object3D.prototype = {
 
 	rotateX: function () {
 
-		var v1 = new THREE.Vector3( 1, 0, 0 );
+		var v1 = THREE.Object3D.chachedVector;
+		v1.set(1, 0, 0);
 
 		return function ( angle ) {
 
@@ -197,7 +198,8 @@ THREE.Object3D.prototype = {
 
 	rotateY: function () {
 
-		var v1 = new THREE.Vector3( 0, 1, 0 );
+		var v1 = THREE.Object3D.chachedVector;
+		v1.set(0, 1, 0);
 
 		return function ( angle ) {
 
@@ -209,7 +211,8 @@ THREE.Object3D.prototype = {
 
 	rotateZ: function () {
 
-		var v1 = new THREE.Vector3( 0, 0, 1 );
+		var v1 = THREE.Object3D.chachedVector;
+		v1.set(0, 0, 1);
 
 		return function ( angle ) {
 
@@ -224,7 +227,8 @@ THREE.Object3D.prototype = {
 		// translate object by distance along axis in object space
 		// axis is assumed to be normalized
 
-		var v1 = new THREE.Vector3();
+		var v1 = THREE.Object3D.chachedVector;
+		v1.set(0, 0, 0);
 
 		return function ( axis, distance ) {
 
@@ -247,7 +251,8 @@ THREE.Object3D.prototype = {
 
 	translateX: function () {
 
-		var v1 = new THREE.Vector3( 1, 0, 0 );
+		var v1 = THREE.Object3D.chachedVector;
+		v1.set(1, 0, 0);
 
 		return function ( distance ) {
 
@@ -259,7 +264,8 @@ THREE.Object3D.prototype = {
 
 	translateY: function () {
 
-		var v1 = new THREE.Vector3( 0, 1, 0 );
+		var v1 = THREE.Object3D.chachedVector;
+		v1.set(0, 1, 0);
 
 		return function ( distance ) {
 
@@ -271,7 +277,8 @@ THREE.Object3D.prototype = {
 
 	translateZ: function () {
 
-		var v1 = new THREE.Vector3( 0, 0, 1 );
+		var v1 = THREE.Object3D.chachedVector;
+		v1.set(0, 0, 1);
 
 		return function ( distance ) {
 
@@ -289,7 +296,13 @@ THREE.Object3D.prototype = {
 
 	worldToLocal: function () {
 
-		var m1 = new THREE.Matrix4();
+		var m1 = THREE.Object3D.chachedMatrix;
+		m1.set(
+			1, 0, 0, 0,
+			0, 1, 0, 0,
+			0, 0, 1, 0,
+			0, 0, 0, 1
+		);
 
 		return function ( vector ) {
 
@@ -303,7 +316,13 @@ THREE.Object3D.prototype = {
 
 		// This routine does not support objects with rotated and/or translated parent(s)
 
-		var m1 = new THREE.Matrix4();
+		var m1 = THREE.Object3D.chachedMatrix;
+		m1.set(
+			1, 0, 0, 0,
+			0, 1, 0, 0,
+			0, 0, 1, 0,
+			0, 0, 0, 1
+		);
 
 		return function ( vector ) {
 
@@ -437,8 +456,8 @@ THREE.Object3D.prototype = {
 
 	getWorldQuaternion: function () {
 
-		var position = new THREE.Vector3();
-		var scale = new THREE.Vector3();
+		// position and scale are only used for decompose and so they can have the same entity
+		var position = var scale = THREE.Object3D.chachedVector;
 
 		return function ( optionalTarget ) {
 
@@ -456,7 +475,7 @@ THREE.Object3D.prototype = {
 
 	getWorldRotation: function () {
 
-		var quaternion = new THREE.Quaternion();
+		var quaternion = THREE.Object3D.chachedQuaternion;
 
 		return function ( optionalTarget ) {
 
@@ -472,8 +491,8 @@ THREE.Object3D.prototype = {
 
 	getWorldScale: function () {
 
-		var position = new THREE.Vector3();
-		var quaternion = new THREE.Quaternion();
+		var position = THREE.Object3D.chachedVector;
+		var quaternion = THREE.Object3D.chachedQuaternion;
 
 		return function ( optionalTarget ) {
 
@@ -491,7 +510,7 @@ THREE.Object3D.prototype = {
 
 	getWorldDirection: function () {
 
-		var quaternion = new THREE.Quaternion();
+		var quaternion = THREE.Object3D.chachedQuaternion;
 
 		return function ( optionalTarget ) {
 
@@ -734,5 +753,8 @@ THREE.Object3D.prototype = {
 };
 
 THREE.EventDispatcher.prototype.apply( THREE.Object3D.prototype );
+THREE.Object3D.chachedVector = new THREE.Vector3(0, 0, 0);
+THREE.Object3D.chachedMatrix = new THREE.Matrix4();
+THREE.Object3D.chachedQuaternion = new THREE.Quaternion();
 
 THREE.Object3DIdCount = 0;

--- a/test/unit/cameras/Camera.js
+++ b/test/unit/cameras/Camera.js
@@ -1,0 +1,12 @@
+/**
+ * @author simonThiele / https://github.com/simonThiele
+ */
+
+module( "Camera" );
+
+test( "lookAt", function() {
+  var obj = new THREE.Camera();
+  obj.lookAt(new THREE.Vector3(0, 1, -1));
+
+	ok( obj.rotation.x * (180 / Math.PI) === 45 , "x is equal" );
+});

--- a/test/unit/core/Object3D.js
+++ b/test/unit/core/Object3D.js
@@ -1,0 +1,116 @@
+/**
+ * @author simonThiele / https://github.com/simonThiele
+ */
+
+module( "Object3D" );
+
+test( "rotateX", function() {
+  var obj = new THREE.Object3D();
+
+  // get a reference object for comparing
+	var reference = obj.rotateOnAxis(new THREE.Vector3(1, 0, 0), 45).rotation;
+  obj.rotateX(45);
+
+	checkIfPropsAreEqual(reference, obj.rotation);
+});
+
+test( "rotateY", function() {
+  var obj = new THREE.Object3D();
+
+  // get a reference object for comparing
+	var reference = obj.rotateOnAxis(new THREE.Vector3(0, 1, 0), -25).rotation;
+  obj.rotateY(45);
+
+  checkIfPropsAreEqual(reference, obj.rotation);
+});
+
+test( "rotateZ", function() {
+  var obj = new THREE.Object3D();
+
+  // get a reference object for comparing
+	var reference = obj.rotateOnAxis(new THREE.Vector3(0, 0, 1), 41.5324).rotation;
+  obj.rotateZ(45);
+
+	checkIfPropsAreEqual(reference, obj.rotation);
+});
+
+test( "rotateX -> y -> z -> x", function() {
+  var obj = new THREE.Object3D();
+
+  // get a reference object for comparing
+	var reference = obj.rotateOnAxis(new THREE.Vector3(1, 0, 0), 10).rotation;
+  obj.rotateX(10);
+
+	checkIfPropsAreEqual(reference, obj.rotation);
+
+  var reference = obj.rotateOnAxis(new THREE.Vector3(0, 1, 0), -32.324).rotation;
+  obj.rotateY(-32.324);
+
+  checkIfPropsAreEqual(reference, obj.rotation);
+
+  var reference = obj.rotateOnAxis(new THREE.Vector3(0, 0, 1), 12.4).rotation;
+  obj.rotateZ(12.4);
+
+  checkIfPropsAreEqual(reference, obj.rotation);
+
+  var reference = obj.rotateOnAxis(new THREE.Vector3(1, 0, 0), 23).rotation;
+  obj.rotateX(23);
+
+  checkIfPropsAreEqual(reference, obj.rotation);
+});
+
+test( "translateOnAxis", function() {
+  var obj = new THREE.Object3D();
+
+  // get a reference object for comparing
+	var reference = {x: 1, y: 1.23, z: -4.56};
+  obj.translateOnAxis(new THREE.Vector3(1, 0, 0), 1);
+  obj.translateOnAxis(new THREE.Vector3(0, 1, 0), 1.23);
+  obj.translateOnAxis(new THREE.Vector3(0, 0, 1), -4.56);
+
+  checkIfPropsAreEqual(reference, obj.position);
+});
+
+test( "translateX", function() {
+  var obj = new THREE.Object3D();
+  obj.translateX(1.234);
+
+  ok( obj.position.x === 1.234 , "x is equal" );
+});
+
+test( "translateY", function() {
+  var obj = new THREE.Object3D();
+  obj.translateY(1.234);
+
+  ok( obj.position.y === 1.234 , "y is equal" );
+});
+
+test( "translateZ", function() {
+  var obj = new THREE.Object3D();
+  obj.translateZ(1.234);
+
+  ok( obj.position.z === 1.234 , "z is equal" );
+});
+
+test( "lookAt", function() {
+  var obj = new THREE.Object3D();
+  obj.lookAt(new THREE.Vector3(0, -1, 1));
+
+  ok( obj.rotation.x * (180 / Math.PI) === 45 , "x is equal" );
+});
+
+test( "getWorldQuaternion", function() {
+  var obj = new THREE.Object3D();
+
+  obj.lookAt(new THREE.Vector3(0, -1, 1));
+  ok( obj.getWorldRotation().x * (180 / Math.PI) === 45 , "x is equal" );
+
+  obj.lookAt(new THREE.Vector3(1, 0, 0));
+  ok( obj.getWorldRotation().y * (180 / Math.PI) === 90 , "y is equal" );
+});
+
+function checkIfPropsAreEqual(reference, obj) {
+  ok( obj.x === reference.x , "x is equal" );
+  ok( obj.y === reference.y , "y is equal!" );
+  ok( obj.z === reference.z , "z is equal!" );
+}

--- a/test/unit/unittests_three.html
+++ b/test/unit/unittests_three.html
@@ -18,6 +18,10 @@
 
   <!-- add class-based unit tests below -->
 
+  <script src="core/Object3D.js"></script>
+
+  <script src="cameras/Camera.js"></script>
+
   <script src="math/Constants.js"></script>
   <script src="math/Box2.js"></script>
   <script src="math/Box3.js"></script>


### PR DESCRIPTION
Some support methods e.g. rotate or transform for Object3D, always create an empty Vector3, Quaternion or Matrix object to store some information which are not needed anymore after the method was called. To reduce work for GC there is one pre-initialised property for each (V, Q and M) inside Object3D which is used to store temporal data. If this objects needs to be in init state, it's properties (e.g. x, y or z) are set before using. Another big advantage reusing objects is that it gets a high performance boost (Local tests on creating 10k new Vectors agains reusing a single one and resetting it's properties is about 200% - 1000% faster). There are unittests inside this PR to make sure not to breaking existing code.
