### PR TITLE
Get world scale

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -472,19 +472,11 @@ THREE.Object3D.prototype = {
 
 	getWorldScale: function () {
 
-		var position = new THREE.Vector3();
-		var quaternion = new THREE.Quaternion();
-
 		return function ( optionalTarget ) {
-
-			var result = optionalTarget || new THREE.Vector3();
 
 			this.updateMatrixWorld( true );
 
-			this.matrixWorld.decompose( position, quaternion, result );
-
-			return result;
-
+			return result.setFromMatrixScale( this.matrixWorld );
 		};
 
 	}(),


### PR DESCRIPTION
Maybe I'm getting it wrong, but why is the hole matrix being decomposed if only the scale part is needed?
If it's not necessary, this PR just uses setFromMatrixScale to extract the scale from worldMatrix. Please check unit test if I missed any situation where decomposing and setFromMatrixScale may differ and please ignore first two commits (the second one reverts the first one) I just forgot to create a branch. Thx.
