### PR TITLE
simple skeletal animation / skinning example without blending.

### DIFF
--- a/examples/webgl_animation_skinning.html
+++ b/examples/webgl_animation_skinning.html
@@ -87,45 +87,17 @@
 
 
 				var loader = new THREE.JSONLoader();
-				loader.load( "models/skinned/marine/marine_anims.js", function( geometry, materials ) {
+				var url = "models/skinned/marine/marine_anims.json";
+
+				loader.load( url, function( geometry, materials ) {
 					skinnedMesh = new THREE.SkinnedMesh(geometry, materials[0]);
 
 					var originalMaterial = materials[ 0 ];
 					originalMaterial.skinning = true;
-
-				/*
-					// Create the animations
-					for ( var i = 0; i < geometry.animations.length; ++ i ) {
-						var animName = geometry.animations[ i ].name;
-						scope.animations[ animName ] = new THREE.Animation( scope, geometry.animations[ i ] );
-					}
-				*/
+					originalMaterial.transparent = false;
 
 					start();
 				});
-			}
-
-			function onWindowResize() {
-
-				camera.aspect = window.innerWidth / window.innerHeight;
-				camera.updateProjectionMatrix();
-
-				renderer.setSize( window.innerWidth, window.innerHeight );
-
-			}
-
-			function onShowSkeleton( event ) {
-
-				var shouldShow = event.detail.shouldShow;
-				helper.visible = shouldShow;
-
-			}
-
-			function onShowModel( event ) {
-
-				var shouldShow = event.detail.shouldShow;
-				skinnedMesh.showModel( shouldShow );
-
 			}
 
 			function start() {
@@ -149,10 +121,9 @@
 				helper.material.linewidth = 3;
 				scene.add( helper );
 
-				helper.visible = false;
+				helper.visible = true;
 
-				//THREE.AnimationHandler.add( skinnedMesh.geometry.animations[0] );
-				var animation = new THREE.Animation( skinnedMesh, skinnedMesh.geometry.animations[1] );
+				var animation = new THREE.Animation( skinnedMesh, skinnedMesh.geometry.animations[0] );
 				animation.play(0, 1);
 
 				animate();
@@ -179,6 +150,28 @@
 				// ( will equal step size next time a single step is desired )
 
 				timeToStep = 0;
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			function onShowSkeleton( event ) {
+
+				var shouldShow = event.detail.shouldShow;
+				helper.visible = shouldShow;
+
+			}
+
+			function onShowModel( event ) {
+
+				var shouldShow = event.detail.shouldShow;
+				skinnedMesh.showModel( shouldShow );
 
 			}
 

--- a/examples/webgl_animation_skinning.html
+++ b/examples/webgl_animation_skinning.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - animation - skinning</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #fff;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+
+				background-color: #fff;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0px; width: 100%;
+				padding: 5px;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="container"></div>
+		<div id="info">
+			<a href="http://threejs.org" target="_blank">three.js</a> - Skeletal Animation
+		</div>
+
+		<script src="../build/three.min.js"></script>
+
+		<script src="js/Detector.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
+		<script src="js/libs/dat.gui.min.js"></script>
+
+		<script>
+
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var container, stats;
+
+			var skinnedMesh, helper, camera, scene, renderer, controls;
+
+			var clock = new THREE.Clock();
+			var gui = null;
+
+			var isFrameStepping = false;
+			var timeToStep = 0;
+
+			init();
+
+			function init() {
+
+				container = document.getElementById( 'container' );
+
+				scene = new THREE.Scene();
+				scene.add ( new THREE.AmbientLight( 0xaaaaaa ) );
+
+				var light = new THREE.DirectionalLight( 0xffffff, 1.5 );
+				light.position.set( 0, 0, 1000 );
+				scene.add( light );
+
+				renderer = new THREE.WebGLRenderer( { antialias: true, alpha: false } );
+				renderer.setClearColor( 0x777777 );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.autoClear = true;
+
+				container.appendChild( renderer.domElement );
+
+				//
+
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '0px';
+				container.appendChild( stats.domElement );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+				// listen for messages from the gui
+				window.addEventListener( 'toggle-show-skeleton', onShowSkeleton );
+
+
+				var loader = new THREE.JSONLoader();
+				loader.load( "models/skinned/marine/marine_anims.js", function( geometry, materials ) {
+					skinnedMesh = new THREE.SkinnedMesh(geometry, materials[0]);
+
+					var originalMaterial = materials[ 0 ];
+					originalMaterial.skinning = true;
+
+				/*
+					// Create the animations
+					for ( var i = 0; i < geometry.animations.length; ++ i ) {
+						var animName = geometry.animations[ i ].name;
+						scope.animations[ animName ] = new THREE.Animation( scope, geometry.animations[ i ] );
+					}
+				*/
+
+					start();
+				});
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			function onShowSkeleton( event ) {
+
+				var shouldShow = event.detail.shouldShow;
+				helper.visible = shouldShow;
+
+			}
+
+			function onShowModel( event ) {
+
+				var shouldShow = event.detail.shouldShow;
+				skinnedMesh.showModel( shouldShow );
+
+			}
+
+			function start() {
+
+				skinnedMesh.rotation.y = Math.PI * -135 / 180;
+				scene.add( skinnedMesh );
+
+				var aspect = window.innerWidth / window.innerHeight;
+				var radius = skinnedMesh.geometry.boundingSphere.radius;
+
+				camera = new THREE.PerspectiveCamera( 45, aspect, 1, 10000 );
+				camera.position.set( 0.0, radius, radius * 3.5 );
+
+				controls = new THREE.OrbitControls( camera );
+				controls.target.set( 0, radius, 0 );
+				controls.update();
+
+				// Create the debug visualization
+
+				helper = new THREE.SkeletonHelper( skinnedMesh );
+				helper.material.linewidth = 3;
+				scene.add( helper );
+
+				helper.visible = false;
+
+				//THREE.AnimationHandler.add( skinnedMesh.geometry.animations[0] );
+				var animation = new THREE.Animation( skinnedMesh, skinnedMesh.geometry.animations[1] );
+				animation.play(0, 1);
+
+				animate();
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate, renderer.domElement );
+
+				// step forward in time based on whether we're stepping and scale
+
+				var delta = clock.getDelta();
+				var scale = 1;
+				var stepSize = (!isFrameStepping) ? delta * scale: timeToStep;
+
+				helper.update();
+
+				THREE.AnimationHandler.update( stepSize );
+
+				renderer.render( scene, camera );
+				stats.update();
+
+				// if we are stepping, consume time
+				// ( will equal step size next time a single step is desired )
+
+				timeToStep = 0;
+
+			}
+
+		</script>
+
+	</body>
+</html>


### PR DESCRIPTION
This is the same as the skinning-blending example but just simplified: no blending, no BlendCharacter code etc.

I've often encountered the need to test a model with skeletal animation quickly and it has been annoying to not have a template / code for that ready.

Also in the editor it doesn't seem to work: so far when I've tried to enable skinning there, the model has just disappeared.

So I stripped the BlendCharacter code from the nice example to have this simple thing that just loads a skinned mesh and plays back an animation from it.

If this is wanted in I can clean it up / simplify it further a bit and add to the examples listing if it makes sense.

Oh and I've been running this now actually with the very useful skeleton helper on - should probably resurrect the GUI back in enough so that there'd be a toggle for that at least. Perhaps the anim play/stop too. 
