### PR TITLE
WebGLShadowMap: Fixed clearColor bug

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -74,7 +74,7 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 
 		// set GL state for depth map
 
-		_gl.clearColor( 1, 1, 1, 1 );
+		_renderer.clearColor( 1, 1, 1, 1 );
 		_state.disable( _gl.BLEND );
 
 		_state.enable( _gl.CULL_FACE );
@@ -237,7 +237,7 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 		var clearColor = _renderer.getClearColor(),
 		clearAlpha = _renderer.getClearAlpha();
 
-		_gl.clearColor( clearColor.r, clearColor.g, clearColor.b, clearAlpha );
+		_renderer.clearColor( clearColor.r, clearColor.g, clearColor.b, clearAlpha );
 		_state.enable( _gl.BLEND );
 
 		if ( scope.cullFace === THREE.CullFaceFront ) {


### PR DESCRIPTION
We can't call `gl.clearColor()` directly. We need to call `renderer.clearColor()`, instead. The latter method takes into consideration the renderer's `premultipliedAlpha` setting.

Fixes bug [reported on stackoverflow](http://stackoverflow.com/questions/32429942/three-js-if-enabling-shadow-maps-for-the-renderer-setting-alpha-for-the-clear).
