### PR TITLE
node.js - Wrap shader precision directives in #ifdef GL_ES

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -158,8 +158,10 @@ THREE.WebGLProgram = ( function () {
 
 			prefix_vertex = [
 
+				'#ifdef GL_ES',
 				'precision ' + parameters.precision + ' float;',
 				'precision ' + parameters.precision + ' int;',
+				'#endif',
 
 				customDefines,
 
@@ -266,8 +268,10 @@ THREE.WebGLProgram = ( function () {
 
 			prefix_fragment = [
 
+				'#ifdef GL_ES',
 				'precision ' + parameters.precision + ' float;',
 				'precision ' + parameters.precision + ' int;',
+				'#endif',
 
 				( parameters.bumpMap || parameters.normalMap || parameters.flatShading ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 

--- a/src/renderers/webgl/plugins/LensFlarePlugin.js
+++ b/src/renderers/webgl/plugins/LensFlarePlugin.js
@@ -449,7 +449,7 @@ THREE.LensFlarePlugin = function ( renderer, flares ) {
 		var fragmentShader = gl.createShader( gl.FRAGMENT_SHADER );
 		var vertexShader = gl.createShader( gl.VERTEX_SHADER );
 
-		var prefix = "precision " + renderer.getPrecision() + " float;\n";
+		var prefix = "#ifdef GL_ES\nprecision " + renderer.getPrecision() + " float;\n#endif\n";
 
 		gl.shaderSource( fragmentShader, prefix + shader.fragmentShader );
 		gl.shaderSource( vertexShader, prefix + shader.vertexShader );

--- a/src/renderers/webgl/plugins/SpritePlugin.js
+++ b/src/renderers/webgl/plugins/SpritePlugin.js
@@ -249,7 +249,9 @@ THREE.SpritePlugin = function ( renderer, sprites ) {
 
 		gl.shaderSource( vertexShader, [
 
+			'#ifdef GL_ES',
 			'precision ' + renderer.getPrecision() + ' float;',
+			'#endif',
 
 			'uniform mat4 modelViewMatrix;',
 			'uniform mat4 projectionMatrix;',


### PR DESCRIPTION
This PR relates to #7085 / node.js server rendering with node-webgl and/or headless-gl

I've had success getting headless-gl to work with three.js; 

I just have to specify a fake canvas and pass an headless-gl context when I create my WebGLRenderer

```
    canvas = new Object() # mock object, not used in our 
    gl = require("gl")() # this is how you "import" headless-gl

    @renderer = new THREE.WebGLRenderer({
        antialias: true,
        width: 0,
        height: 0,
        canvas: canvas,
        context: gl
    })
```

Then I can just render into a new THREE.WebGLRenderTarget, it works like a charm.

My only problem left is that the Desktop OpenGL that headless-gl is gonna use under the hood for its context does not like/know about the precision GL_ES directive. Putting that directive inside an ifded just does the trick.

Thanks for taking a look and for having written that wonderful library.
