### PR TITLE
fix blender export by removing ref to constants.AREA_LIGHT removed in 43f1e3d

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/object.py
@@ -109,7 +109,7 @@ class Object(base_classes.BaseNode):
 
         lights = (constants.AMBIENT_LIGHT,
                   constants.DIRECTIONAL_LIGHT,
-                  constants.AREA_LIGHT, constants.POINT_LIGHT,
+                  constants.POINT_LIGHT,
                   constants.SPOT_LIGHT, constants.HEMISPHERE_LIGHT)
 
         if self[constants.TYPE] == constants.MESH:


### PR DESCRIPTION
the constant was removed when deferred renderer was removed in 43f1e3d.

got a py exception in blender, this fixed the export. am not sure about the logic how lights are handled in the exporter but this at least allows the code to execute. 
