### PR TITLE
Remove redundant loop from dispatchEvent

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -84,7 +84,7 @@ THREE.EventDispatcher.prototype = {
 
 			event.target = this;
 
-			for ( var i = 0; i < listenerArray.length; i ++ ) {
+			for ( var i = listenerArray.length - 1; 0 <= i; i -= 1 ) {
 
         listenerArray[ i ].call( this, event );
 

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -78,25 +78,15 @@ THREE.EventDispatcher.prototype = {
 
 		if ( this._listeners === undefined ) return;
 
-		var listeners = this._listeners;
-		var listenerArray = listeners[ event.type ];
+		var listenerArray = this._listeners[ event.type ];
 
 		if ( listenerArray !== undefined ) {
 
 			event.target = this;
 
-			var array = [];
-			var length = listenerArray.length;
+			for ( var i = 0; i < listenerArray.length; i ++ ) {
 
-			for ( var i = 0; i < length; i ++ ) {
-
-				array[ i ] = listenerArray[ i ];
-
-			}
-
-			for ( var i = 0; i < length; i ++ ) {
-
-				array[ i ].call( this, event );
+        listenerArray[ i ].call( this, event );
 
 			}
 


### PR DESCRIPTION
The 'dispatchEvent' method of 'THREE.EventDispatcher' ran two loops
to execute callbacks. The first copied references to callback
functions from the listener array to another array, and then the
second loop would call the callbacks from this second array. This
is completely unnecessary, therefore the second loop was removed
and the callbacks are now accessed from the listener array when
executed.

A random sample of 12 examples seem functional after the patch.
