### PR TITLE
Remove "twice" in misc_controls_transform

### DIFF
--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -26,7 +26,7 @@
 
 		<div id="info">
 		"W" translate | "E" rotate | "R" scale | "+" increase size | "-" decrease size<br />
-		Press "Q" twice to toggle world/local space
+		Press "Q" to toggle world/local space
 		</div>
 
 		<script src="../build/three.min.js"></script>


### PR DESCRIPTION
This doesn't seem very important but it didn't make sense to me why the word "twice" was there, since you only have to press Q once to toggle between local or world space. So this PR removes it.
