### PR TITLE
changed VREffect to only update world matrices once and address a problem when the camera's parent is dynamic

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -51,8 +51,8 @@ THREE.VREffect = function ( renderer, onError, camera ) {
 				cameraL.projectionMatrix.copy( fovToProjection( eyeFOVL, true, zNear, zFar ) );
 				cameraR.projectionMatrix.copy( fovToProjection( eyeFOVR, true, zNear, zFar ) );
 
-				stereoTransformL.makeTranslation( eyeTranslationL.x, eyeTranslationL.y, eyeTranslationL.z );
-				stereoTransformR.makeTranslation( eyeTranslationR.x, eyeTranslationR.y, eyeTranslationR.z );
+				stereoTransformL.makeTranslation( this.scale * eyeTranslationL.x, this.scale * eyeTranslationL.y, this.scale * eyeTranslationL.z );
+				stereoTransformR.makeTranslation( this.scale * eyeTranslationR.x, this.scale * eyeTranslationR.y, this.scale * eyeTranslationR.z );
 
 				break; // We keep the first we encounter
 
@@ -70,7 +70,7 @@ THREE.VREffect = function ( renderer, onError, camera ) {
 
 	if ( navigator.getVRDevices ) {
 
-		navigator.getVRDevices().then( gotVRDevices );
+		navigator.getVRDevices().then( gotVRDevices.bind(this) );
 
 	}
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -127,7 +127,7 @@ THREE.VREffect = function ( renderer, onError, camera ) {
 		if ( vrHMD ) {
 
 			var sceneL, sceneR;
-
+			var autoUpdate;
 			if ( Array.isArray( scene ) ) {
 
 				sceneL = scene[ 0 ];
@@ -137,7 +137,14 @@ THREE.VREffect = function ( renderer, onError, camera ) {
 
 				sceneL = scene;
 				sceneR = scene;
-				if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+				autoUpdate = scene.autoUpdate;
+
+				if ( autoUpdate === true ) {
+
+					scene.updateMatrixWorld();
+					scene.autoUpdate = false;
+
+				}
 
 			}
 
@@ -162,6 +169,12 @@ THREE.VREffect = function ( renderer, onError, camera ) {
 			renderer.render( sceneR, cameraR );
 
 			renderer.enableScissorTest( false );
+
+			if ( autoUpdate === true ) {
+
+				scene.autoUpdate = autoUpdate;
+
+			}
 
 			return;
 

--- a/examples/vr_cubes.html
+++ b/examples/vr_cubes.html
@@ -49,6 +49,7 @@
 		<script src="../build/three.min.js"></script>
 		<script src="js/effects/VREffect.js"></script>
 		<script src="js/controls/VRControls.js"></script>
+		<script src="js/controls/FlyControls.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script>
@@ -63,6 +64,15 @@
 			var radius = 100, theta = 0;
 			var crosshair;
 
+			var SCENARIO; // in both cases the camera is a child of an object that is moving (magicCarpet in this example)
+			// the camera's local matrix is dynamic, e.g. controlled by vrControls:
+			SCENARIO = "A";
+			// the camera's local matrix is fixed (less common case, it seems to me, but I still like to handle it):
+			//SCENARIO = "B";
+			var magicCarpet;
+			var flyControls;
+			var clock = new THREE.Clock();
+			
 			init();
 			animate();
 
@@ -79,7 +89,7 @@
 				info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> webgl - interactive cubes';
 				container.appendChild( info );
 
-				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 10000 );
+				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.2, 10000 );
 
 				scene = new THREE.Scene();
 
@@ -141,6 +151,19 @@
 					fullScreenButton.classList.add('error');
 
 				} );
+
+				if (SCENARIO == "A") {
+					magicCarpet = new THREE.Mesh( new THREE.PlaneGeometry( 1.5, 2 ).rotateX( -Math.PI / 2 ).translate( 0, -1, 0 ) );
+				}
+				else if (SCENARIO == "B") {
+					magicCarpet = new THREE.Mesh( new THREE.PlaneGeometry( 1.5, 2 ).rotateX( -Math.PI / 2 ) );
+					camera.position.y += 1;
+				}
+				magicCarpet.add( camera );
+				scene.add( magicCarpet );
+				flyControls = new THREE.FlyControls( magicCarpet );
+				flyControls.movementSpeed *= 20;
+				flyControls.rollSpeed *= 10;
 
 				fullScreenButton.onclick = function() {
 
@@ -212,7 +235,11 @@
 
 				}
 
-				vrControls.update();
+				var delta = clock.getDelta();
+				flyControls.update( delta );
+				if (SCENARIO == "A") {
+					vrControls.update();
+				}
 
 				crosshair.quaternion.copy( camera.quaternion );
 				crosshair.position.set( 0, 0, 0 );


### PR DESCRIPTION
When VREffect is applied to a camera that is added to a moving object (e.g. a vehicle that the viewer is riding in), I observe unwanted relative motion between the moving object and the viewpoint.  The modified vr_cubes example illustrates this effect.  This all applies to the case where there is one scene, not distinct left and right eye scenes.

Breakdown of the problem as I understand it:

(base line 136) Since the camera has a parent, camera.updateMatrixWorld is not performed.  

(base lines 141, 142) The decomposition performed here is then based on a potentially stale camera.matrixWorld.

(base line 150) Calling renderer.render here would update the entire scene graph (unless scene.autoUpdate was false), which would update camera.matrixWorld, but cameraL.matrixWorld is only updated (WebGLRenderer.js line 1092) for the rendered frame based on the previous stale decomposition.

(base line 155) Similar deal in this call to renderer.render for cameraR.  It also seems like the whole scene graph would be updated again, which is unnecessary as far as I can tell.

The changes I made to VREffect,js are along the lines of those made in another fork (where WebGLRenderer itself is patched): https://github.com/capnmidnight/three.js/commit/3cc06752fcf05688e94d6b5efd916ff000e3be97

(head line 144) The scene graph is updated once up front, which updates camera.matrixWorld.

(head lines 162, 168) cameraL.matrixWorld and cameraR.matrixWorld are formed directly by matrix multiplication with translation matrices that are initialized once when the VR parameters are determined (head lines 54, 55).

(head lines 122, 123) cameraL and cameraR matrixAutoUpdate are set to false, so when renderer.render is called for each (head lines 163, 169), the internal call to camera.updateMatrixWorld (WebGLRenderer.js line 1092) won't overwrite the matrices that were just formed in head lines 162, 168.

The shuffling around of the projection matrices is not relevant, only further optimization as far as I can see... sorry for mucking up the pull request with that, I'm happy to clean things up if any of these changes are of interest!

To test things you can run the modified vr_cubes example, swapping between the previous and proposed versions of VREffect.js.
