### PR TITLE
WebGLPrograms 'logarithmicDepthBuffer' capability fix

### DIFF
--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -160,7 +160,7 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 			flatShading: material.shading === THREE.FlatShading,
 
 			sizeAttenuation: material.sizeAttenuation,
-			logarithmicDepthBuffer: renderer.logarithmicDepthBuffer,
+			logarithmicDepthBuffer: capabilities.logarithmicDepthBuffer,
 
 			skinning: material.skinning,
 			maxBones: maxBones,


### PR DESCRIPTION
fix: corrected WebGLPrograms lookup of 'logarithmicDepthBuffer' capability (not present in renderer)
