### PR TITLE
Remove reference to `diffuse` parameter in MTLLoader

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -319,7 +319,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					// Diffuse color (color under white light) using RGB values
 
-					params[ 'diffuse' ] = new THREE.Color().fromArray( value );
+					params[ 'color' ] = new THREE.Color().fromArray( value );
 
 					break;
 
@@ -387,12 +387,6 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 					break;
 
 			}
-
-		}
-
-		if ( params[ 'diffuse' ] ) {
-
-			params[ 'color' ] = params[ 'diffuse' ];
 
 		}
 


### PR DESCRIPTION
`kD` is set to the `color` parameter directly.
