### PR TITLE
all out disabling of logging messages

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/__init__.py
+++ b/utils/exporters/blender/addons/io_three/exporter/__init__.py
@@ -8,9 +8,10 @@ from . import scene, geometry, api, base_classes
 def _error_handler(func):
     
     def inner(filepath, options, *args, **kwargs):
-        level = options.get(constants.LOGGING, constants.DEBUG)
+        level = options.get(constants.LOGGING, constants.DISABLED)
         version = options.get('addon_version')
-        logger.init('io_three.export.log', level=level)
+        if level != constants.DISABLED:
+            logger.init('io_three.export.log', level=level)
         if version is not None:
             logger.debug("Addon Version %s", version)
         api.init()

--- a/utils/exporters/blender/addons/io_three/logger.py
+++ b/utils/exporters/blender/addons/io_three/logger.py
@@ -49,17 +49,35 @@ def init(filename, level=constants.DEBUG):
         LOGGER.addHandler(file_handler)
 
 
+def _logger(func):
+
+    def inner(*args):
+        if LOGGER is not None:
+            func(*args)
+
+    return inner
+
+
+@_logger
 def info(*args):
     LOGGER.info(*args)
 
+
+@_logger
 def debug(*args):
     LOGGER.debug(*args)
 
+
+@_logger
 def warning(*args):
     LOGGER.warning(*args)
 
+
+@_logger
 def error(*args):
     LOGGER.error(*args)
 
+
+@_logger
 def critical(*args):
     LOGGER.critical(*args)


### PR DESCRIPTION
Addresses the issue mentioned here
https://github.com/mrdoob/three.js/issues/6050#issuecomment-141724737

Message strings still resolve for every call no matter the verbosity. This commit addresses that by implementing an all out disabling of logging. This is also the default option since most users probably won't even be looking at a shell window when they export.
