### PR TITLE
Robustify texture update

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2758,7 +2758,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( texture.generateMipmaps && isImagePowerOfTwo ) _gl.generateMipmap( _gl.TEXTURE_2D );
 
-		textureProperties.__version = texture.version;
+		textureProperties.__version = texture.previousVersion = texture.version;
 
 		if ( texture.onUpdate ) texture.onUpdate( texture );
 
@@ -2923,7 +2923,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				textureProperties.__version = texture.version;
+				textureProperties.__version = texture.previousVersion = texture.version;
 
 				if ( texture.onUpdate ) texture.onUpdate( texture );
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -38,6 +38,7 @@ THREE.Texture = function ( image, mapping, wrapS, wrapT, magFilter, minFilter, f
 	this.unpackAlignment = 4; // valid values: 1, 2, 4, 8 (see http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml)
 
 	this.version = 0;
+	this.previousVersion = 0;
 	this.onUpdate = null;
 
 };
@@ -51,7 +52,7 @@ THREE.Texture.prototype = {
 
 	set needsUpdate ( value ) {
 
-		if ( value === true ) this.version ++;
+		this.version  = value ? this.version + 1 : this.previousVersion;
 
 	},
 


### PR DESCRIPTION
Switching texture.needsUpdate to true and immediately back to false will not trigger texture upload at next render pass.
