### PR TITLE
bug fix: clear angle divisor for all geometries if instancing is used.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -25,6 +25,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 	_antialias = parameters.antialias !== undefined ? parameters.antialias : false,
 	_premultipliedAlpha = parameters.premultipliedAlpha !== undefined ? parameters.premultipliedAlpha : true,
 	_preserveDrawingBuffer = parameters.preserveDrawingBuffer !== undefined ? parameters.preserveDrawingBuffer : false,
+	_usedInstancedBuffer = false,
 
 	_clearColor = new THREE.Color( 0x000000 ),
 	_clearAlpha = 0;
@@ -935,6 +936,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 							extension.vertexAttribDivisorANGLE( programAttribute, data.meshPerAttribute );
 
+							_usedInstancedBuffer = true;
+
 							if ( geometry.maxInstancedCount === undefined ) {
 
 								geometry.maxInstancedCount = data.meshPerAttribute * data.count;
@@ -959,9 +962,25 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 							extension.vertexAttribDivisorANGLE( programAttribute, geometryAttribute.meshPerAttribute );
 
+							_usedInstancedBuffer = true;
+
 							if ( geometry.maxInstancedCount === undefined ) {
 
 								geometry.maxInstancedCount = geometryAttribute.meshPerAttribute * geometryAttribute.count;
+
+							}
+
+						} else {
+
+						 if ( _usedInstancedBuffer ) {
+
+								extension = extensions.get( 'ANGLE_instanced_arrays' );
+
+								if ( extension != null ) {
+
+									extension.vertexAttribDivisorANGLE( programAttribute, 0 );
+
+								}
 
 							}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -25,7 +25,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 	_antialias = parameters.antialias !== undefined ? parameters.antialias : false,
 	_premultipliedAlpha = parameters.premultipliedAlpha !== undefined ? parameters.premultipliedAlpha : true,
 	_preserveDrawingBuffer = parameters.preserveDrawingBuffer !== undefined ? parameters.preserveDrawingBuffer : false,
-	_usedInstancedBuffer = false,
 
 	_clearColor = new THREE.Color( 0x000000 ),
 	_clearAlpha = 0;
@@ -936,7 +935,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 							extension.vertexAttribDivisorANGLE( programAttribute, data.meshPerAttribute );
 
-							_usedInstancedBuffer = true;
+							state.usedInstancedBufferCount = data.meshPerAttribute;
 
 							if ( geometry.maxInstancedCount === undefined ) {
 
@@ -962,25 +961,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 							extension.vertexAttribDivisorANGLE( programAttribute, geometryAttribute.meshPerAttribute );
 
-							_usedInstancedBuffer = true;
+							state.usedInstancedBufferCount = geometryAttribute.meshPerAttribute;
 
 							if ( geometry.maxInstancedCount === undefined ) {
 
 								geometry.maxInstancedCount = geometryAttribute.meshPerAttribute * geometryAttribute.count;
-
-							}
-
-						} else {
-
-						 if ( _usedInstancedBuffer ) {
-
-								extension = extensions.get( 'ANGLE_instanced_arrays' );
-
-								if ( extension != null ) {
-
-									extension.vertexAttribDivisorANGLE( programAttribute, 0 );
-
-								}
 
 							}
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -82,11 +82,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 			var extension = extensions.get( 'ANGLE_instanced_arrays' );
 
-			if ( extension != null ) {
-
-				extension.vertexAttribDivisorANGLE( attribute, 0 );
-
-			}
+			extension.vertexAttribDivisorANGLE( attribute, 0 );
 
 		}
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -78,6 +78,18 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 		}
 
+		if ( this.usedInstancedBufferCount > 0 ) {
+
+			var extension = extensions.get( 'ANGLE_instanced_arrays' );
+
+			if ( extension != null ) {
+
+				extension.vertexAttribDivisorANGLE( attribute, 0 );
+
+			}
+
+		}
+
 	};
 
 	this.disableUnusedAttributes = function () {


### PR DESCRIPTION
This fixes the issue I mentioned in #5171 : when angle instancing is used together with regular geometries, there are strange problems, for example objects that do not render or textures are uniformly coloured by one of its pixel values.

I am not sure if this is the best way to fix it, but at least it works for now.
