### PR TITLE
Make readRenderTargetPixels() work with implementation defined formats

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3148,13 +3148,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( properties.get( renderTarget ).__webglFramebuffer ) {
 
-			if ( renderTarget.format !== THREE.RGBAFormat ) {
-
-				console.error( 'THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA format. readPixels can read only RGBA format.' );
-				return;
-
-			}
-
 			var restore = false;
 
 			if ( properties.get( renderTarget ).__webglFramebuffer !== _currentFramebuffer ) {
@@ -3165,9 +3158,23 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
+			if ( renderTarget.format !== THREE.RGBAFormat && paramThreeToGL(renderTarget.format) !== _gl.getParameter(_gl.IMPLEMENTATION_COLOR_READ_FORMAT) ) {
+
+				console.error( 'THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA or implementation defined format.' );
+				return;
+
+			}
+
+			if ( renderTarget.type !== THREE.UnsignedByteType && paramThreeToGL(renderTarget.type) !== _gl.getParameter(_gl.IMPLEMENTATION_COLOR_READ_TYPE) ) {
+
+				console.error( 'THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.' );
+				return;
+
+			}
+
 			if ( _gl.checkFramebufferStatus( _gl.FRAMEBUFFER ) === _gl.FRAMEBUFFER_COMPLETE ) {
 
-				_gl.readPixels( x, y, width, height, _gl.RGBA, _gl.UNSIGNED_BYTE, buffer );
+				_gl.readPixels( x, y, width, height, paramThreeToGL(renderTarget.format), paramThreeToGL(renderTarget.type), buffer );
 
 			} else {
 


### PR DESCRIPTION
We have to bind the buffer before doing the test, because the answer is circumstantial ( https://www.khronos.org/registry/webgl/specs/1.0/#readpixels ).

Did you know that with the OES_texture_float extension Chrome allows rendering to a float texture then reading a float render target to a Float32ArrayBuffer in readPixels()  ?
