### PR TITLE
Bug fix: Viewport not restored correctly when rendering point light shadows for scenes that contain multiple light types.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
@@ -56,7 +56,7 @@
 			// Apply scale to avoid seams
 
 			// two texels less per square (one texel will do for NEAREST)
-			v *= scaleToCube * ( 1.0 - 4.0 * texelSizeY );
+			v *= scaleToCube * ( 1.0 - 2.0 * texelSizeY );
 
 			// Unwrap
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -128,6 +128,9 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 
 			var light = _lights[ i ];
 
+			// save the existing viewport so it can be restored later
+			_renderer.getViewport( _vector4 );
+
 			if ( light instanceof THREE.PointLight ) {
 
 				faceCount = 6;
@@ -226,9 +229,6 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 			_lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
 			shadowCamera.position.copy( _lightPositionWorld );
 
-			// save the existing viewport so it can be restored later
-			_renderer.getViewport( _vector4 );
-
 			_renderer.setRenderTarget( shadowMap );
 			_renderer.clear();
 
@@ -321,6 +321,7 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 
 			}
 
+			_renderer.setViewport( _vector4.x, _vector4.y, _vector4.z, _vector4.w );
 		}
 
 		// restore GL state
@@ -336,8 +337,6 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 			_gl.cullFace( _gl.BACK );
 
 		}
-
-		_renderer.setViewport( _vector4.x, _vector4.y, _vector4.z, _vector4.w );
 
 		_renderer.resetGLState();
 


### PR DESCRIPTION
I fixed the bug mentioned by @mrdoob regarding the view skewing when you have a scene with both a point light and directional light, and unrolled the loop in the PCF calculations for point lights.
