### PR TITLE
envmap_vertex: Corrected calculation of world normal

### DIFF
--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
@@ -1,8 +1,8 @@
 #if defined( USE_ENVMAP ) && ! defined( USE_BUMPMAP ) && ! defined( USE_NORMALMAP ) && ! defined( PHONG )
 
-	vec3 worldNormal = transformDirection( objectNormal, modelMatrix );
-
 	vec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );
+
+	vec3 worldNormal = inverseTransformDirection( transformedNormal, viewMatrix );
 
 	#ifdef ENVMAP_MODE_REFLECTION
 


### PR DESCRIPTION
We can't apply an arbitrary matrix to transform a normal -- we have to use the normal matrix.

The normal matrix for transforms into camera space is available, but the normal matrix for transforms into world space is not.

The solution is to transform the normal to camera space, and then back to world space using (the inverse of) the view matrix, which is available.

This error was only evident for non-uniformly-scaled meshes rendered with `MeshBasicMaterial` or `MeshLambertMaterial` that also have an environment map.

No wonder.
