### PR TITLE
Fixed typo on font name

### DIFF
--- a/docs/api/extras/geometries/TextGeometry.html
+++ b/docs/api/extras/geometries/TextGeometry.html
@@ -93,13 +93,13 @@
 				<td>/examples/fonts/gentilis_bold.typeface.js</td>
 			</tr>
 			<tr>
-				<td>driod sans</td>
+				<td>droid sans</td>
 				<td>normal</td>
 				<td>normal</td>
 				<td>/examples/fonts/droid/droid_sans_regular.typeface.js</td>
 			</tr>
 			<tr>
-				<td>driod sans</td>
+				<td>droid sans</td>
 				<td>bold</td>
 				<td>normal</td>
 				<td>/examples/fonts/droid/droid_sans_bold.typeface.js</td>


### PR DESCRIPTION
Fixed typo ‘driod’ to ‘droid’ on list of font names.
