### PR TITLE
Added shared WebGL renderer and example.

### DIFF
--- a/examples/js/renderers/WebGLSharedRenderer.js
+++ b/examples/js/renderers/WebGLSharedRenderer.js
@@ -1,0 +1,195 @@
+/**
+* @author arodic / http://akirodic.com/
+*/
+
+/**
+THREE.WebGLRenderer wrapper that manages GL rendering context across multiple instances of
+THREE.WebGLSharedRenderer. All instances of this element will share a single WebGL canvas.
+An element instance becomes a host of the canvas any time WebGL API is used through one of
+its methods. Before this happens, the previous host needs to store the framebuffer data in a
+2D canvas before the WebGL canvas can be handed out.
+
+IMPORTANT: Keep in mind that WebGL canvas migration is expensive and should not be performed
+continuously. In other words, you cannot render with mutliple instances of
+THREE.WebGLSharedRenderer in realtime without severe performance penalties.
+*/
+
+
+( function() {
+
+  var currentHost;
+
+  var renderer, gl;
+  /**
+   * This function creates a single shared WebGLRenderer.
+   */
+  var _initWebGLRenderer = function( parameters ) {
+    if ( !renderer ) {
+      parameters.preserveDrawingBuffer = true;
+      renderer = new THREE.WebGLRenderer( parameters );
+      renderer.domElement.className = 'three-renderer';
+      gl = renderer.getContext();
+    }
+  };
+
+  var ctxPerfNow = 0;
+  var ctxPerfDelta = 1000;
+  var ctxPerfAverage = 1000;
+  var ctxPerfWarned;
+
+  /**
+   * This function runs every time renderer migrates to another three-renderer host
+   * It is designed to detect if migration feature is overrused by the user.
+   */
+  var _performanceCheck = function() {
+    if ( ctxPerfWarned ) return;
+    ctxPerfDelta = performance.now() - ctxPerfNow;
+    ctxPerfAverage = Math.min( ( ctxPerfAverage * 10 + ctxPerfDelta ) / 11, 1000 );
+    ctxPerfNow = performance.now();
+    if ( ctxPerfAverage < 16 ) {
+      console.warn( 'WebGLSharedRenderer performance warning: rendering multiple canvases!' );
+      ctxPerfWarned = true;
+    }
+  };
+
+  THREE.WebGLSharedRenderer = function ( parameters ) {
+
+    parameters = parameters || {};
+
+    _initWebGLRenderer( parameters );
+
+    this._canvas2d = document.createElement( 'canvas' );
+    this._context2d = this._canvas2d.getContext( '2d' );
+
+    this.domElement = document.createElement( 'div' );
+    this.domElement.appendChild( this._canvas2d );
+
+    this.width = this._canvas2d.width;
+    this.height = this._canvas2d.height;
+    this.domElement.style.width = this.width + 'px';
+    this.domElement.style.height = this.height + 'px';
+
+    this.context = gl;
+
+    this.autoClear = true;
+    this.autoClearColor = true;
+    this.autoClearDepth = true;
+    this.autoClearStencil = true;
+    this.sortObjects = true;
+    this.gammaFactor = 2.0;	// for backwards compatibility
+    this.gammaInput = false;
+    this.gammaOutput = false;
+    this.sortObjects = true;
+    this.maxMorphTargets = 8;
+    this.maxMorphNormals = 4;
+    this.autoScaleCubemaps = true;
+
+    var _clearColor = new THREE.Color( 0x000000 );
+    var _clearAlpha = 1;
+
+    /**
+    * Renderer method that will be available on this element as proxy.
+    * calling this method may triger renderer migration.
+    */
+    this.render = function () {
+      this._setHost();
+      renderer.render.apply( renderer, arguments );
+    };
+
+    this.setViewport = function() {
+      renderer.setViewport.apply( renderer, arguments );
+    };
+
+    this.setPixelRatio = function() {
+      renderer.setPixelRatio.apply( renderer, arguments );
+    };
+
+    this.clear = function() {
+      this._setHost();
+      renderer.clear.apply( renderer, arguments );
+    };
+
+    this.clearColor = function () {
+      this._setHost();
+      renderer.clearColor.apply( renderer, arguments );
+    };
+
+    this.clearDepth = function () {
+      this._setHost();
+      renderer.clearDepth.apply( renderer, arguments );
+    };
+
+    this.clearStencil = function () {
+      this._setHost();
+      renderer.clearStencil.apply( renderer, arguments );
+    };
+
+    this.clearTarget = function () {
+      this._setHost();
+      renderer.clearTarget.apply( renderer, arguments );
+    };
+
+    this._update = function() {
+      renderer.autoClear = this.autoClear;
+      renderer.autoClearColor = this.autoClearColor;
+      renderer.autoClearDepth = this.autoClearDepth;
+      renderer.autoClearStencil = this.autoClearStencil;
+      renderer.gammaFactor = this.gammaFactor;
+      renderer.gammaInput = this.gammaInput;
+      renderer.gammaOutput = this.gammaOutput;
+      renderer.sortObjects = this.sortObjects;
+      renderer.maxMorphTargets = this.maxMorphTargets;
+      renderer.maxMorphNormals = this.maxMorphNormals;
+      renderer.autoScaleCubemaps = this.autoScaleCubemaps;
+      renderer.setClearColor( _clearColor );
+      renderer.setClearAlpha( _clearAlpha );
+    };
+
+    this.setSize = function( width, height ) {
+      this._setHost();
+      this.width = width;
+      this.height = height;
+      this._canvas2d.width = width;
+      this._canvas2d.height = height;
+      this.domElement.style.width = width + 'px';
+      this.domElement.style.height = height + 'px';
+      renderer.setSize( width, height );
+    };
+
+    this.setClearColor = function ( clearColor ) {
+      _clearColor = clearColor;
+    };
+
+    this.setClearAplha = function ( clearAlpha ) {
+      _clearAlpha = clearAlpha;
+    };
+
+    this.getClearColor = function ( clearColor ) {
+      return _clearColor;
+    };
+
+    this.getClearAplha = function ( clearAlpha ) {
+      return _clearAlpha;
+    };
+
+    this._setHost = function() {
+      if ( this !== currentHost ) {
+        _performanceCheck();
+        if ( currentHost ) {
+          currentHost._canvas2d.style.display = 'inline-block';
+          currentHost._context2d.drawImage( renderer.domElement, 0, 0, currentHost._canvas2d.width, currentHost._canvas2d.height );
+          gl.flush();
+        }
+        currentHost = this;
+        this.domElement.appendChild( renderer.domElement );
+        this._canvas2d.style.display = 'none';
+        this.setSize( this.width, this.height );
+      }
+      this._update();
+    };
+
+  };
+
+  THREE.WebGLSharedRenderer.prototype.constructor = THREE.WebGLSharedRenderer;
+
+}());

--- a/examples/webgl_shared_renderer.html
+++ b/examples/webgl_shared_renderer.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - shared renderer</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #808080;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+
+				background-color: #fff;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0px; width: 100%;
+				padding: 5px;
+			}
+
+			.renderer {
+				float: left;
+			}
+
+			a {
+				color: #0080ff;
+			}
+
+		</style>
+	</head>
+	<body>
+
+		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> webgl - shared renderer</div>
+
+		<script src="../build/three.min.js"></script>
+
+		<script src="js/Detector.js"></script>
+		<script src="js/renderers/WebGLSharedRenderer.js"></script>
+
+		<script>
+
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var camera, scene, renderers = [];
+			var group1, group2, group3;
+
+			init();
+			animate();
+
+			function init() {
+
+				camera = new THREE.PerspectiveCamera( 20, window.innerWidth / window.innerHeight, 1, 10000 );
+
+				scene = new THREE.Scene();
+
+				var light = new THREE.DirectionalLight( 0xffffff );
+				light.position.set( 0, 0, 1 );
+				scene.add( light );
+
+				var light = new THREE.DirectionalLight( 0xffff00, 0.75 );
+				light.position.set( 0, 0, - 1 );
+				scene.add( light );
+
+				// shadow
+
+				var canvas = document.createElement( 'canvas' );
+				canvas.width = 128;
+				canvas.height = 128;
+
+				var context = canvas.getContext( '2d' );
+				var gradient = context.createRadialGradient( canvas.width / 2, canvas.height / 2, 0, canvas.width / 2, canvas.height / 2, canvas.width / 2 );
+				gradient.addColorStop( 0.1, 'rgba(210,210,210,1)' );
+				gradient.addColorStop( 1, 'rgba(255,255,255,1)' );
+
+				context.fillStyle = gradient;
+				context.fillRect( 0, 0, canvas.width, canvas.height );
+
+				var shadowTexture = new THREE.CanvasTexture( canvas );
+
+				var shadowMaterial = new THREE.MeshBasicMaterial( { map: shadowTexture } );
+				var shadowGeo = new THREE.PlaneBufferGeometry( 300, 300, 1, 1 );
+
+				var mesh = new THREE.Mesh( shadowGeo, shadowMaterial );
+				mesh.position.y = - 250;
+				mesh.rotation.x = - Math.PI / 2;
+				scene.add( mesh );
+
+				var mesh = new THREE.Mesh( shadowGeo, shadowMaterial );
+				mesh.position.x = - 400;
+				mesh.position.y = - 250;
+				mesh.rotation.x = - Math.PI / 2;
+				scene.add( mesh );
+
+				var mesh = new THREE.Mesh( shadowGeo, shadowMaterial );
+				mesh.position.x = 400;
+				mesh.position.y = - 250;
+				mesh.rotation.x = - Math.PI / 2;
+				scene.add( mesh );
+
+				var faceIndices = [ 'a', 'b', 'c' ];
+
+				var color, f1, f2, f3, p, vertexIndex,
+
+					radius = 200,
+
+					geometry1 = new THREE.IcosahedronGeometry( radius, 1 ),
+					geometry2 = new THREE.IcosahedronGeometry( radius, 1 ),
+					geometry3 = new THREE.IcosahedronGeometry( radius, 1 );
+
+				for ( var i = 0; i < geometry1.faces.length; i ++ ) {
+
+					f1 = geometry1.faces[ i ];
+					f2 = geometry2.faces[ i ];
+					f3 = geometry3.faces[ i ];
+
+					for( var j = 0; j < 3; j ++ ) {
+
+						vertexIndex = f1[ faceIndices[ j ] ];
+
+						p = geometry1.vertices[ vertexIndex ];
+
+						color = new THREE.Color( 0xffffff );
+						color.setHSL( ( p.y / radius + 1 ) / 2, 1.0, 0.5 );
+
+						f1.vertexColors[ j ] = color;
+
+						color = new THREE.Color( 0xffffff );
+						color.setHSL( 0.0, ( p.y / radius + 1 ) / 2, 0.5 );
+
+						f2.vertexColors[ j ] = color;
+
+						color = new THREE.Color( 0xffffff );
+						color.setHSL( 0.125 * vertexIndex / geometry1.vertices.length, 1.0, 0.5 );
+
+						f3.vertexColors[ j ] = color;
+
+					}
+
+				}
+
+				var materials = [
+
+					new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors } ),
+					new THREE.MeshBasicMaterial( { color: 0x000000, shading: THREE.FlatShading, wireframe: true, transparent: true } )
+
+				];
+
+				group1 = THREE.SceneUtils.createMultiMaterialObject( geometry1, materials );
+				group1.position.x = -400;
+				scene.add( group1 );
+
+				group2 = THREE.SceneUtils.createMultiMaterialObject( geometry2, materials );
+				group2.position.x = 400;
+				scene.add( group2 );
+
+				group3 = THREE.SceneUtils.createMultiMaterialObject( geometry3, materials );
+				scene.add( group3 );
+
+				//
+
+				for ( var i = 0; i < 256; i ++ ) {
+					renderers[i] = new THREE.WebGLSharedRenderer( { antialias: true } );
+					renderers[i].setClearColor( 0xffffff );
+					renderers[i].setPixelRatio( window.devicePixelRatio );
+					renderers[i].setSize( Math.floor( window.innerWidth / 16 ), Math.floor( window.innerHeight / 16 ) );
+					document.body.appendChild( renderers[i].domElement );
+					renderers[i].domElement.classList.add('renderer');
+				}
+
+				setTimeout( function() {
+					for ( var i = 0; i < 256; i ++ ) {
+						renderers[i].render( scene, camera );
+					}
+				}, 100 );
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				// update scene
+
+				group1.rotation.z += Math.PI / 500;
+				group2.rotation.z += Math.PI / 500;
+				group3.rotation.z += Math.PI / 500;
+
+				var geometry = group3.children[ 0 ].geometry;
+
+				for ( var i = 0; i < geometry.faces.length; i ++ ) {
+
+						var f = geometry.faces[ i ];
+
+						for ( var j = 0; j < 3; j ++ ) {
+
+							var color = f.vertexColors[ j ];
+							color.setHex( ( color.getHex() + 0xfdfdfd ) % 0xffffff );
+
+						}
+
+					}
+
+				geometry.colorsNeedUpdate = true;
+
+				//
+
+				var time = performance.now() / 2000;
+
+				camera.position.x = Math.sin( time ) * 1800;
+				camera.position.z = Math.cos( time ) * 1800;
+
+				camera.lookAt( scene.position );
+
+				for ( var i = 0; i < 256; i ++ ) {
+					if ( renderers[i].domElement.parentNode.querySelector(":hover") ===
+							renderers[i].domElement ) {
+						renderers[i].render( scene, camera );
+					}
+				}
+
+			}
+
+		</script>
+
+	</body>
+</html>


### PR DESCRIPTION
This is a concept I developed a while ago to allow use of large number of canvases that share the same WebGL context. This is specially useful in applications with many viewports such as editors. All browsers limit the number of WebGL contexts you can create and the more contexts you have, there are greater chances for random context loss.

In a nutshell, `THREE.WebGLSharedRenderer` is a wrapper around `THREE.WebGLRenderer` that uses canvas 2D to store last rendered image and it manages WebGL canvas migration every time a user wants to update the canvas.

The obvious problem with this implementation is that during each canvas migration, data from the WebGL canvas needs to be copied to canvas 2D, and that is too expensive for real-time rendering of more than a few canvases. However, if renderers are used cautiously, the performance is quite good and memory footprint is considerably smaller than using multiple instances of `THREE.WebGLRenderer`

Note that [WEBGL_shared_resources](https://www.khronos.org/registry/webgl/extensions/WEBGL_shared_resources/) extension should allow resource sharing across contexts in the future.
