### PR TITLE
ObjectLoader continues to be broken with cached images

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -20,13 +20,21 @@ THREE.ImageLoader.prototype = {
 
 		if ( cached !== undefined ) {
 
+			scope.manager.itemStart( url );
+
 			if ( onLoad ) {
 
 				setTimeout( function () {
 
 					onLoad( cached );
 
+					scope.manager.itemEnd( url );
+
 				}, 0 );
+
+			} else {
+
+				scope.manager.itemEnd( url );
 
 			}
 


### PR DESCRIPTION
see [here](https://github.com/mrdoob/three.js/blob/master/src/loaders/ObjectLoader.js#L338) new manager is created for image loader, but [here](https://github.com/mrdoob/three.js/blob/master/src/loaders/ImageLoader.js#L21-L35) it is never notified and so its onLoad is never called.

for those who will come from google, r71 / r72 patch code:

``` javascript
        var originalLoad = THREE.ImageLoader.prototype.load;
        THREE.ImageLoader.prototype.load = function ( url, onLoad, onProgress, onError ) {
            var scope = this;
            var cached = THREE.Cache.get( url );
            if ( cached !== undefined ) {
                scope.manager.itemStart( url );
                if ( onLoad ) {
                    setTimeout( function () {
                        onLoad( cached );
                        scope.manager.itemEnd( url );
                    }, 0 );
                } else {
                    scope.manager.itemEnd( url );
                }
                return cached;
            }
            return originalLoad.call( this, url, onLoad, onProgress, onError );
        }
```
