### PR TITLE
do not rely on XMLHttpRequest load event to be scoped on the request

### DIFF
--- a/src/loaders/XHRLoader.js
+++ b/src/loaders/XHRLoader.js
@@ -39,9 +39,9 @@ THREE.XHRLoader.prototype = {
 
 		request.addEventListener( 'load', function ( event ) {
 
-			THREE.Cache.add( url, this.response );
+			THREE.Cache.add( url, request.response );
 
-			if ( onLoad ) onLoad( this.response );
+			if ( onLoad ) onLoad( request.response );
 
 			scope.manager.itemEnd( url );
 


### PR DESCRIPTION
Encountered an issue using xdomain, where the event's scope is not the request.
But, anyways, making less expectations helps in reading the code.

Modification of https://github.com/mrdoob/three.js/pull/7297
