### PR TITLE
Overwritten THREE.Geometry.clone for THREE.TubeGeometry to fix #7301

### DIFF
--- a/src/extras/geometries/TubeGeometry.js
+++ b/src/extras/geometries/TubeGeometry.js
@@ -138,6 +138,14 @@ THREE.TubeGeometry = function ( path, segments, radius, radialSegments, closed, 
 
 THREE.TubeGeometry.prototype = Object.create( THREE.Geometry.prototype );
 THREE.TubeGeometry.prototype.constructor = THREE.TubeGeometry;
+THREE.TubeGeometry.prototype.clone = function() {
+
+	return new this.constructor( this.parameters.path,
+		this.parameters.segments, this.parameters.radius, this.parameters.radialSegments,
+		this.parameters.closed, this.parameters.taper
+	);
+
+};
 
 THREE.TubeGeometry.NoTaper = function ( u ) {
 


### PR DESCRIPTION
I'm not sure if I'm exactly following code style guidelines for Three.js. Please tell me if I need to make adjustements so we get this landed :)
