### PR TITLE
Fix intersection uv for non-indexed BufferGeometry

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -218,21 +218,21 @@ THREE.Mesh.prototype.raycast = ( function () {
 
 					if ( distance < raycaster.near || distance > raycaster.far ) continue;
 
+					a = i / 3;
+					b = a + 1;
+					c = a + 2;
+
 					var uv;
 
 					if ( attributes.uv !== undefined ) {
 
 						var uvs = attributes.uv.array;
-						uvA.fromArray( uvs, i );
-						uvB.fromArray( uvs, i + 2 );
-						uvC.fromArray( uvs, i + 4 );
+						uvA.fromArray( uvs, a * 2 );
+						uvB.fromArray( uvs, b * 2 );
+						uvC.fromArray( uvs, c * 2 );
 						uv = uvIntersection( intersectionPoint, vA, vB, vC, uvA, uvB, uvC );
 
 					}
-
-					a = i / 3;
-					b = a + 1;
-					c = a + 2;
 
 					intersects.push( {
 


### PR DESCRIPTION
This is a simple fix for Mesh raycast, for the newly added uv point return: https://github.com/mrdoob/three.js/pull/7023. 

The uv point returned for non-indexed BufferGeometry was wrong because the indices used to read the uvs array were not right.

I think it will be good to refactor the code in the three branches in the raycast function ( BufferGeometry, non-indexed BufferGeometry and Geometry ) because most of the code is common to the three cases. I can generate a pull request for that later.

Thanks for all the work on this library!
