### PR TITLE
Added vector truncate methods

### DIFF
--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -292,17 +292,17 @@ THREE.Vector2.prototype = {
 
 	clampLength: function ( min, max ) {
 
-			var oldLength = this.length();
+		var oldLength = this.length();
 
-			var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
+		var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
 
-			if ( newLength !== oldLength ) {
+		if ( newLength !== oldLength ) {
 
-				this.divideScalar( oldLength ).multiplyScalar( newLength );
+			this.divideScalar( oldLength ).multiplyScalar( newLength );
 
-			}
+		}
 
-			return this;
+		return this;
 
 	},
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -296,9 +296,9 @@ THREE.Vector2.prototype = {
 
 		var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
 
-		if ( newLength !== oldLength ) {
+		if ( oldLength !== 0 && newLength !== oldLength ) {
 
-			this.divideScalar( oldLength ).multiplyScalar( newLength );
+			this.multiplyScalar( newLength / oldLength );
 
 		}
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -290,15 +290,11 @@ THREE.Vector2.prototype = {
 
 	}(),
 
-	clampLength: function () {
+	clampLength: function ( min, max ) {
 
-		var oldLength, newLength;
+			var oldLength = this.length();
 
-		return function clampLength( min, max ) {
-
-			oldLength = this.length();
-
-			newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
+			var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
 
 			if ( newLength !== oldLength ) {
 
@@ -308,9 +304,7 @@ THREE.Vector2.prototype = {
 
 			return this;
 
-		};
-
-	}(),
+	},
 
 	floor: function () {
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -302,7 +302,7 @@ THREE.Vector2.prototype = {
 
 			if ( newLength !== oldLength ) {
 
-				this.multiplyScalar( newLength / oldLength );
+				this.divideScalar( oldLength ).multiplyScalar( newLength );
 
 			}
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -292,15 +292,9 @@ THREE.Vector2.prototype = {
 
 	clampLength: function ( min, max ) {
 
-		var oldLength = this.length();
+		var length = this.length();
 
-		var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
-
-		if ( oldLength !== 0 && newLength !== oldLength ) {
-
-			this.multiplyScalar( newLength / oldLength );
-
-		}
+		this.multiplyScalar( Math.max( min, Math.min( max, length ) ) / length );
 
 		return this;
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -290,6 +290,28 @@ THREE.Vector2.prototype = {
 
 	}(),
 
+	clampLength: function () {
+
+		var oldLength, newLength;
+
+		return function clampLength( min, max ) {
+
+			oldLength = this.length();
+
+			newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
+
+			if ( newLength !== oldLength ) {
+
+				this.multiplyScalar( newLength / oldLength );
+
+			}
+
+			return this;
+
+		};
+
+	}(),
+
 	floor: function () {
 
 		this.x = Math.floor( this.x );

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -532,7 +532,7 @@ THREE.Vector3.prototype = {
 
 			if ( newLength !== oldLength ) {
 
-				this.multiplyScalar( newLength / oldLength );
+				this.divideScalar( oldLength ).multiplyScalar( newLength );
 
 			}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -526,9 +526,9 @@ THREE.Vector3.prototype = {
 
 		var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
 
-		if ( newLength !== oldLength ) {
+		if ( oldLength !== 0 && newLength !== oldLength ) {
 
-			this.divideScalar( oldLength ).multiplyScalar( newLength );
+			this.multiplyScalar( newLength / oldLength );
 
 		}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -522,15 +522,9 @@ THREE.Vector3.prototype = {
 
 	clampLength: function ( min, max ) {
 
-		var oldLength = this.length();
+		var length = this.length();
 
-		var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
-
-		if ( oldLength !== 0 && newLength !== oldLength ) {
-
-			this.multiplyScalar( newLength / oldLength );
-
-		}
+		this.multiplyScalar( Math.max( min, Math.min( max, length ) ) / length );
 
 		return this;
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -520,15 +520,11 @@ THREE.Vector3.prototype = {
 
 	}(),
 
-	clampLength: function () {
+	clampLength: function ( min, max ) {
 
-		var oldLength, newLength;
+			var oldLength = this.length();
 
-		return function clampLength( min, max ) {
-
-			oldLength = this.length();
-
-			newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
+			var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
 
 			if ( newLength !== oldLength ) {
 
@@ -538,9 +534,7 @@ THREE.Vector3.prototype = {
 
 			return this;
 
-		};
-
-	}(),
+	},
 
 	floor: function () {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -522,17 +522,17 @@ THREE.Vector3.prototype = {
 
 	clampLength: function ( min, max ) {
 
-			var oldLength = this.length();
+		var oldLength = this.length();
 
-			var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
+		var newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
 
-			if ( newLength !== oldLength ) {
+		if ( newLength !== oldLength ) {
 
-				this.divideScalar( oldLength ).multiplyScalar( newLength );
+			this.divideScalar( oldLength ).multiplyScalar( newLength );
 
-			}
+		}
 
-			return this;
+		return this;
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -520,6 +520,28 @@ THREE.Vector3.prototype = {
 
 	}(),
 
+	clampLength: function () {
+
+		var oldLength, newLength;
+
+		return function clampLength( min, max ) {
+
+			oldLength = this.length();
+
+			newLength = ( oldLength < min ) ? min : ( ( oldLength > max ) ? max : oldLength );
+
+			if ( newLength !== oldLength ) {
+
+				this.multiplyScalar( newLength / oldLength );
+
+			}
+
+			return this;
+
+		};
+
+	}(),
+
 	floor: function () {
 
 		this.x = Math.floor( this.x );


### PR DESCRIPTION
First of all, many thanks for this great library! :wink: 

I want to contribute a method for each THREE.Vector prototype. I use frequently this functionality when i develop AI logic for games.

Let's say you calculate a "force" vector for a game entity (e.g. a vehicle). To ensure, that the calculated force does not exceed a maximum amount, you can use the "truncate" method to bound the length of a vector to a specific value.
