### PR TITLE
Fix OrbitControls in firefox

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -778,7 +778,7 @@
 			this.domElement.removeEventListener( 'contextmenu', contextmenu, false );
 			this.domElement.removeEventListener( 'mousedown', onMouseDown, false );
 			this.domElement.removeEventListener( 'mousewheel', onMouseWheel, false );
-			this.domElement.removeEventListener( 'DOMMouseScroll', onMouseWheel, false ); // firefox
+			this.domElement.removeEventListener( 'MozMousePixelScroll', onMouseWheel, false ); // firefox
 
 			this.domElement.removeEventListener( 'touchstart', touchstart, false );
 			this.domElement.removeEventListener( 'touchend', touchend, false );
@@ -795,7 +795,7 @@
 
 		this.domElement.addEventListener( 'mousedown', onMouseDown, false );
 		this.domElement.addEventListener( 'mousewheel', onMouseWheel, false );
-		this.domElement.addEventListener( 'DOMMouseScroll', onMouseWheel, false ); // firefox
+		this.domElement.addEventListener( 'MozMousePixelScroll', onMouseWheel, false ); // firefox
 
 		this.domElement.addEventListener( 'touchstart', touchstart, false );
 		this.domElement.addEventListener( 'touchend', touchend, false );


### PR DESCRIPTION
Zooming in & out of objects in firefox does also scroll the hole page. There are multiple StackOverflow discussions about this issue. See [here](http://stackoverflow.com/questions/25293927/threejs-rendering-scene-in-div-prevent-scrolling-of-browser-window-do-zoom-i) and [here](http://stackoverflow.com/questions/31685502/prevent-page-scrolling-while-mouse-is-over-scene-in-firefox).

The answer in the first linked question also provides a link where you can experience the bug: http://www.matheretter.de/formeln/geometrie/zylinder/

I fixed that behavior by changing the event listener from `DOMMouseScroll` to `MozMousePixelScroll`.

Used Firefox Version: 41.0.1 on OS X El Capitan (10.11)
