### PR TITLE
Allow arrow keys to move orbit controls diagonally

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -362,6 +362,8 @@
 
 		// The four arrow keys
 		this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
+		// Track whether keys are up or down (down = true)
+		this.keyState = { LEFT: false, UP: false, RIGHT: false, BOTTOM: false };
 
 		// Mouse buttons
 		this.mouseButtons = { ORBIT: THREE.MOUSE.LEFT, ZOOM: THREE.MOUSE.MIDDLE, PAN: THREE.MOUSE.RIGHT };
@@ -610,27 +612,65 @@
 			switch ( event.keyCode ) {
 
 				case scope.keys.UP:
-					pan( 0, scope.keyPanSpeed );
-					scope.update();
+					scope.keyState.UP = true;
 					break;
 
 				case scope.keys.BOTTOM:
-					pan( 0, - scope.keyPanSpeed );
-					scope.update();
+					scope.keyState.BOTTOM = true;
 					break;
 
 				case scope.keys.LEFT:
-					pan( scope.keyPanSpeed, 0 );
-					scope.update();
+					scope.keyState.LEFT = true;
 					break;
 
 				case scope.keys.RIGHT:
-					pan( - scope.keyPanSpeed, 0 );
-					scope.update();
+					scope.keyState.RIGHT = true;
 					break;
 
 			}
 
+			var deltaX = 0;
+			if ( scope.keyState.LEFT ) deltaX += scope.keyPanSpeed;
+			if ( scope.keyState.RIGHT ) deltaX -= scope.keyPanSpeed;
+
+			var deltaY = 0;
+			if ( scope.keyState.UP ) deltaY += scope.keyPanSpeed;
+			if ( scope.keyState.BOTTOM ) deltaY -= scope.keyPanSpeed;
+
+			if (deltaX === 0 && deltaY === 0) return;
+			if (deltaX !== 0 && deltaY !== 0) {
+				// Travel diagonally at the same speed as axis-aligned
+				deltaX /= Math.SQRT2;
+				deltaY /= Math.SQRT2;
+			}
+			pan( deltaX, deltaY );
+			scope.update();
+
+		}
+
+		function onKeyUp( event ) {
+
+			if ( scope.enabled === false || scope.enableKeys === false || scope.enablePan === false ) return;
+
+			switch ( event.keyCode ) {
+
+				case scope.keys.UP:
+					scope.keyState.UP = false;
+					break;
+
+				case scope.keys.BOTTOM:
+					scope.keyState.BOTTOM = false;
+					break;
+
+				case scope.keys.LEFT:
+					scope.keyState.LEFT = false;
+					break;
+
+				case scope.keys.RIGHT:
+					scope.keyState.RIGHT = false;
+					break;
+
+			}
 		}
 
 		function touchstart( event ) {
@@ -788,6 +828,7 @@
 			document.removeEventListener( 'mouseup', onMouseUp, false );
 
 			window.removeEventListener( 'keydown', onKeyDown, false );
+			window.removeEventListener( 'keyup', onKeyUp, false );
 
 		}
 
@@ -802,6 +843,7 @@
 		this.domElement.addEventListener( 'touchmove', touchmove, false );
 
 		window.addEventListener( 'keydown', onKeyDown, false );
+		window.addEventListener( 'keyup', onKeyUp, false );
 
 		// force an update at start
 		this.update();


### PR DESCRIPTION
By tracking the up/down state of the arrow keys, we allow diagonal movement of
the orbiting camera. (This movement is really a dolly, but the code calls it a
pan?) Before, if you held the right arrow and then held the up arrow, you'd go up, not up and to the right.

I hate adding dozens of lines of code, but it's fairly straightforward and matches the existing style. I've only changed the orbit controls; I can do others if you'd like.

If you hold down an arrow key, and then tap another key, the movement stops (Chrome, Yosemite). This bug also exists in the current version, and is because the browser only sends `keydown` events for the most recently pressed key. It sends these events repeatedly, and this drives the motion, rather than an external clock.
