### PR TITLE
Avoid unnecessary Math.sqrt operations

### DIFF
--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -341,7 +341,7 @@ THREE.Matrix4.prototype = {
 
 			z.subVectors( eye, target ).normalize();
 
-			if ( z.length() === 0 ) {
+			if ( z.lengthSq() === 0 ) {
 
 				z.z = 1;
 
@@ -349,7 +349,7 @@ THREE.Matrix4.prototype = {
 
 			x.crossVectors( up, z ).normalize();
 
-			if ( x.length() === 0 ) {
+			if ( x.lengthSq() === 0 ) {
 
 				z.x += 0.0001;
 				x.crossVectors( up, z ).normalize();

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -701,7 +701,7 @@ THREE.Vector3.prototype = {
 
 	angleTo: function ( v ) {
 
-		var theta = this.dot( v ) / ( this.length() * v.length() );
+		var theta = this.dot( v ) / ( Math.sqrt( this.lengthSq() * v.lengthSq() ) );
 
 		// clamp, to handle numerical problems
 


### PR DESCRIPTION
In the methods `Vector3.angleTo()` and `Matrix4.lookAt()` we can save some `Math.sqrt()` operations by replacing `length()` with `lengthSq()`. I think the code easily explain the changes.
