### PR TITLE
Additional RingGeometry Fix

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -37,12 +37,7 @@ THREE.Object3D = function () {
 		scale: {
 			enumerable: true,
 			value: new THREE.Vector3( 1, 1, 1 )
-		},
-		visible: {
-			enumerable : true,
-			set : this.visibleSet,
-			get : this.visibleGet
-  		}
+		}
 	} );
 
 	this.renderDepth = null;
@@ -312,18 +307,6 @@ THREE.Object3D.prototype = {
 
 			this.children.push( object );
 
-			// set visibility
-			var realVisibility = (object._visibleWas !== undefined) ? object._visibleWas : object.visible;
-			if (this.visible)
-			{
-				object.visible = realVisibility;
-			}
-			else
-			{
-				object.visible = false;
-				object._visibleWas = realVisibility;
-			}
-						
 			// add to scene
 
 			var scene = this;
@@ -354,10 +337,6 @@ THREE.Object3D.prototype = {
 			object.dispatchEvent( { type: 'removed' } );
 
 			this.children.splice( index, 1 );
-			
-			// restore default visibility
-			var realVisibility = (object._visibleWas !== undefined) ? object._visibleWas : object.visible;
-			object.visible = realVisibility;
 
 			// remove from scene
 
@@ -558,62 +537,6 @@ THREE.Object3D.prototype = {
 		}
 
 		return object;
-
-	},
-	
-	visibleSet: function ( visible,drawableOnly ) {
-
-		visible = visible ? true : false;
-		this._visible = visible;
-		this._visibleWas = visible;
-
-		var parentVisible = true;
-		if (this.parent){
-			if (!this.parent.visible)
-				parentVisible = false;
-		}
-		
-		if( visible && parentVisible )
-		{
-
-			this.traverse( function( node ) {
-
-				if( drawableOnly )
-				{
-					if( node instanceof THREE.Camera ) return;
-					if( node instanceof THREE.Light ) return;
-				}
-
-				if( node._visibleWas !== undefined ) node._visible = node._visibleWas;
-				delete node._visibleWas;
-
-			});
-
-		}
-		else
-		{
-
-			this.traverse( function( node ) {
-
-				if( drawableOnly )
-				{
-					if( node instanceof THREE.Camera ) return;
-					if( node instanceof THREE.Light ) return;
-				}
-
-				if( node._visibleWas === undefined ) node._visibleWas = node._visible;
-				node._visible = false;
-
-			});
-
-		}
-	},
-
-	visibleGet: function () {
-
-		if ( this._visible === undefined ) return true;
-
-		return this._visible;
 
 	}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -37,7 +37,12 @@ THREE.Object3D = function () {
 		scale: {
 			enumerable: true,
 			value: new THREE.Vector3( 1, 1, 1 )
-		}
+		},
+		visible: {
+			enumerable : true,
+			set : this.visibleSet,
+			get : this.visibleGet
+  		}
 	} );
 
 	this.renderDepth = null;
@@ -307,6 +312,18 @@ THREE.Object3D.prototype = {
 
 			this.children.push( object );
 
+			// set visibility
+			var realVisibility = (object._visibleWas !== undefined) ? object._visibleWas : object.visible;
+			if (this.visible)
+			{
+				object.visible = realVisibility;
+			}
+			else
+			{
+				object.visible = false;
+				object._visibleWas = realVisibility;
+			}
+						
 			// add to scene
 
 			var scene = this;
@@ -337,6 +354,10 @@ THREE.Object3D.prototype = {
 			object.dispatchEvent( { type: 'removed' } );
 
 			this.children.splice( index, 1 );
+			
+			// restore default visibility
+			var realVisibility = (object._visibleWas !== undefined) ? object._visibleWas : object.visible;
+			object.visible = realVisibility;
 
 			// remove from scene
 
@@ -537,6 +558,62 @@ THREE.Object3D.prototype = {
 		}
 
 		return object;
+
+	},
+	
+	visibleSet: function ( visible,drawableOnly ) {
+
+		visible = visible ? true : false;
+		this._visible = visible;
+		this._visibleWas = visible;
+
+		var parentVisible = true;
+		if (this.parent){
+			if (!this.parent.visible)
+				parentVisible = false;
+		}
+		
+		if( visible && parentVisible )
+		{
+
+			this.traverse( function( node ) {
+
+				if( drawableOnly )
+				{
+					if( node instanceof THREE.Camera ) return;
+					if( node instanceof THREE.Light ) return;
+				}
+
+				if( node._visibleWas !== undefined ) node._visible = node._visibleWas;
+				delete node._visibleWas;
+
+			});
+
+		}
+		else
+		{
+
+			this.traverse( function( node ) {
+
+				if( drawableOnly )
+				{
+					if( node instanceof THREE.Camera ) return;
+					if( node instanceof THREE.Light ) return;
+				}
+
+				if( node._visibleWas === undefined ) node._visibleWas = node._visible;
+				node._visible = false;
+
+			});
+
+		}
+	},
+
+	visibleGet: function () {
+
+		if ( this._visible === undefined ) return true;
+
+		return this._visible;
 
 	}
 

--- a/src/extras/geometries/RingGeometry.js
+++ b/src/extras/geometries/RingGeometry.js
@@ -1,5 +1,6 @@
 /**
  * @author Kaleb Murphy
+ * @author Dashiel Nemeth
  */
 
 THREE.RingGeometry = function ( innerRadius, outerRadius, thetaSegments, phiSegments, thetaStart, thetaLength ) {
@@ -10,10 +11,12 @@ THREE.RingGeometry = function ( innerRadius, outerRadius, thetaSegments, phiSegm
 	outerRadius = outerRadius || 50;
 
 	thetaStart = thetaStart !== undefined ? thetaStart : 0;
-	thetaLength = thetaLength !== undefined ? thetaLength : Math.PI * 2;
+	thetaLength = thetaLength !== undefined ? Math.min( Math.PI * 2, thetaLength ) : Math.PI * 2;
 
 	thetaSegments = thetaSegments !== undefined ? Math.max( 3, thetaSegments ) : 8;
-	phiSegments = phiSegments !== undefined ? Math.max( 3, phiSegments ) : 8;
+	phiSegments = phiSegments !== undefined ? Math.max( 1, phiSegments ) : 8;
+
+	var completeRing = ( thetaLength >= Math.PI * 2 ) ? true : false;
 
 	var i, o, uvs = [], radius = innerRadius, radiusStep = ( ( outerRadius - innerRadius ) / phiSegments );
 
@@ -21,6 +24,9 @@ THREE.RingGeometry = function ( innerRadius, outerRadius, thetaSegments, phiSegm
 
 		for ( o = 0; o <= thetaSegments; o ++ ) { // number of segments per circle
 
+			if ( o == thetaSegments && completeRing )
+				break;
+		
 			var vertex = new THREE.Vector3();
 			var segment = thetaStart + o / thetaSegments * thetaLength;
 
@@ -36,27 +42,26 @@ THREE.RingGeometry = function ( innerRadius, outerRadius, thetaSegments, phiSegm
 	}
 
 	var n = new THREE.Vector3( 0, 0, 1 );
+	var ringVerts = ( completeRing ) ? thetaSegments : thetaSegments + 1;
+	var lastSegment = ( completeRing ) ? thetaSegments - 1 : -1;
 
 	for ( i = 0; i < phiSegments; i ++ ) { // concentric circles inside ring
 
-		var thetaSegment = i * thetaSegments;
+		var firstInner = ringVerts * i;
+		var firstOuter = firstInner + ringVerts;
+	
+		for ( o = 0; o < thetaSegments; o ++ ) { // number of segments per circle
 
-		for ( o = 0; o <= thetaSegments; o ++ ) { // number of segments per circle
-
-			var segment = o + thetaSegment;
-
-			var v1 = segment + i;
-			var v2 = segment + thetaSegments + i;
-			var v3 = segment + thetaSegments + 1 + i;
+			// Clockwise around the quad from inner left
+			var v1 = firstInner + o;
+			var v2 = firstOuter + o;
+			var v3 = ( o == lastSegment ) ? firstOuter : v2 + 1;
+			var v4 = ( o == lastSegment ) ? firstInner : v1 + 1;
 
 			this.faces.push( new THREE.Face3( v1, v2, v3, [ n.clone(), n.clone(), n.clone() ] ) );
 			this.faceVertexUvs[ 0 ].push( [ uvs[ v1 ].clone(), uvs[ v2 ].clone(), uvs[ v3 ].clone() ]);
-
-			v1 = segment + i;
-			v2 = segment + thetaSegments + 1 + i;
-			v3 = segment + 1 + i;
-
-			this.faces.push( new THREE.Face3( v1, v2, v3, [ n.clone(), n.clone(), n.clone() ] ) );
+			
+			this.faces.push( new THREE.Face3( v1, v3, v4, [ n.clone(), n.clone(), n.clone() ] ) );
 			this.faceVertexUvs[ 0 ].push( [ uvs[ v1 ].clone(), uvs[ v2 ].clone(), uvs[ v3 ].clone() ]);
 
 		}

--- a/src/extras/geometries/RingGeometry.js
+++ b/src/extras/geometries/RingGeometry.js
@@ -62,7 +62,7 @@ THREE.RingGeometry = function ( innerRadius, outerRadius, thetaSegments, phiSegm
 			this.faceVertexUvs[ 0 ].push( [ uvs[ v1 ].clone(), uvs[ v2 ].clone(), uvs[ v3 ].clone() ]);
 			
 			this.faces.push( new THREE.Face3( v1, v3, v4, [ n.clone(), n.clone(), n.clone() ] ) );
-			this.faceVertexUvs[ 0 ].push( [ uvs[ v1 ].clone(), uvs[ v2 ].clone(), uvs[ v3 ].clone() ]);
+			this.faceVertexUvs[ 0 ].push( [ uvs[ v1 ].clone(), uvs[ v3 ].clone(), uvs[ v4 ].clone() ]);
 
 		}
 	}


### PR DESCRIPTION
This change removes the extra triangles connecting the ends of a partial RingGeometry, and sets the minimum number of concentric bands to one, like merpnderp's #4878 does. However, it also:
- Eliminates the redundant vertices created when the ring is complete, and welds the seem
- Prevents values of thetaLength greater than 2 \* PI which would create overlapping geo
- Removes some redundant calculation form the process of RingGeometry face generation

Targeting Dev as requested in https://github.com/mrdoob/three.js/pull/4899#event-437000579
