### PR TITLE
fixed Number.isNaN

### DIFF
--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -163,7 +163,7 @@ THREE.KeyframeTrack.prototype = {
 				return;
 			}
 
-			if ( ( typeof currKey.time ) !== 'number' || Number.isNaN( currKey.time ) ) {
+			if ( ( typeof currKey.time ) !== 'number' || isNaN( currKey.time ) ) {
 				console.error( "  key.time is not a valid number", this, i, currKey );
 				return;
 			}


### PR DESCRIPTION
On Safari, the function **isNaN** is NOT children of **Number**.
The code was breaking at this point.

I changed **Number.isNaN** to just **isNaN**.
Should work fine on all browsers.
Plus, this is how it is used on many other parts of the code.
