### PR TITLE
Remove console.log of which renderer was chosen.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -7,8 +7,6 @@
 
 THREE.WebGLRenderer = function ( parameters ) {
 
-	console.log( 'THREE.WebGLRenderer', THREE.REVISION );
-
 	parameters = parameters || {};
 
 	var _canvas = parameters.canvas !== undefined ? parameters.canvas : document.createElement( 'canvas' ),


### PR DESCRIPTION
This console.log should be stripped out IMHO. Many devs, myself obviously included like to have a clean console output. Every library that is chatty adds up to a messy console:

This PR removes it.
