### PR TITLE
ArrowHelper: fix undefined reference when using zero-length tails

### DIFF
--- a/src/extras/helpers/ArrowHelper.js
+++ b/src/extras/helpers/ArrowHelper.js
@@ -35,11 +35,9 @@ THREE.ArrowHelper = ( function () {
 
 		this.position.copy( origin );
 		
-		if ( headLength < length ) {
-			this.line = new THREE.Line( lineGeometry, new THREE.LineBasicMaterial( { color: color } ) );
-			this.line.matrixAutoUpdate = false;
-			this.add( this.line );
-		}
+		this.line = new THREE.Line( lineGeometry, new THREE.LineBasicMaterial( { color: color } ) );
+		this.line.matrixAutoUpdate = false;
+		this.add( this.line );
 
 		this.cone = new THREE.Mesh( coneGeometry, new THREE.MeshBasicMaterial( { color: color } ) );
 		this.cone.matrixAutoUpdate = false;
@@ -94,6 +92,9 @@ THREE.ArrowHelper.prototype.setLength = function ( length, headLength, headWidth
 	if ( headLength < length ){
 		this.line.scale.set( 1, length - headLength, 1 );
 		this.line.updateMatrix();
+		this.line.visible = true;
+	} else {
+		this.line.visible = false;
 	}
 
 	this.cone.scale.set( headWidth, headLength, headWidth );
@@ -104,7 +105,7 @@ THREE.ArrowHelper.prototype.setLength = function ( length, headLength, headWidth
 
 THREE.ArrowHelper.prototype.setColor = function ( color ) {
 
-	if ( this.line !== undefined ) this.line.material.color.set( color );
+	this.line.material.color.set( color );
 	this.cone.material.color.set( color );
 
 };


### PR DESCRIPTION
Commit 9e2103f9ce added support for zero-length tails by conditionally
creating the line object. However it kept using that object
unconditionally in some places (such as setLength), which results in
undefined references if an ArrowHelper is initially created with a
zero-size tail and then made longer by calling setLength().

This patch fixes this problem by always creating the tail object and
changing its "visible" property in setLength() to make it visible only
when it should be.
