### PR TITLE
Added Box3/Sphere intersection tests

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -247,6 +247,16 @@ THREE.Box3.prototype = {
 
 	},
 
+	isIntersectionSphere: function ( sphere ) {
+
+		// Find the point on the AABB closest to the sphere center.
+		var closestPoint = this.clampPoint( sphere.center );
+
+		// If that point is inside the sphere, the AABB and sphere intersect.
+		return closestPoint.distanceToSquared( sphere.center ) <= ( sphere.radius * sphere.radius )
+
+	},
+
 	clampPoint: function ( point, optionalTarget ) {
 
 		var result = optionalTarget || new THREE.Vector3();

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -92,9 +92,22 @@ THREE.Sphere.prototype = {
 
 	intersectsSphere: function ( sphere ) {
 
+		console.warn( 'THREE.Sphere: .intersectsSphere() has been renamed to .isIntersectionSphere().' );
+
+		return this.isIntersectionSphere( sphere );
+	},
+
+	isIntersectionSphere: function ( sphere ) {
+
 		var radiusSum = this.radius + sphere.radius;
 
 		return sphere.center.distanceToSquared( this.center ) <= ( radiusSum * radiusSum );
+
+	},
+
+	isIntersectionBox: function ( box ) {
+
+		return box.isIntersectionSphere( this );
 
 	},
 


### PR DESCRIPTION
Ladies and Gentlemen! :wink:

I use the Sphere/AABB intersection test quite often in my 3D applications. Therefore, i have added to both prototypes (`THREE.Sphere` and `THREE.Box3`) new methods for this use case. 

Besides, i've renamed the method `intersectsSphere`to `isIntersectionSphere`, so the interfaces are more consistent. 
