### PR TITLE
Add support for loading SkinnedMeshes from SceneLoader + bug fix.

### DIFF
--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -177,7 +177,7 @@ THREE.AnimationClip.parse = function( json ) {
 
 
 // parse the animation.hierarchy format
-THREE.AnimationClip.parseAnimation = function( animation, bones, nodeName ) {
+THREE.AnimationClip.parseAnimation = function( animation, bones ) {
 
 	if ( ! animation ) {
 		console.error( "  no animation in JSONLoader data" );
@@ -211,7 +211,7 @@ THREE.AnimationClip.parseAnimation = function( animation, bones, nodeName ) {
 	};
 
 	var tracks = [];
-
+	
 	var clipName = animation.name || 'default';
 	var duration = animation.length || -1; // automatic length determination in AnimationClip.
 	var fps = animation.fps || 30;
@@ -259,7 +259,7 @@ THREE.AnimationClip.parseAnimation = function( animation, bones, nodeName ) {
 
 				}
 
-				tracks.push( new THREE.NumberKeyframeTrack( nodeName + '.morphTargetInfluence[' + morphTargetName + ']', keys ) );
+				tracks.push( new THREE.NumberKeyframeTrack( '.morphTargetInfluence[' + morphTargetName + ']', keys ) );
 
 			}
 
@@ -267,7 +267,7 @@ THREE.AnimationClip.parseAnimation = function( animation, bones, nodeName ) {
 
 		} else {
 
-			var boneName = nodeName + '.bones[' + bones[ h ].name + ']';
+			var boneName = '.bones[' + bones[ h ].name + ']';
 
 			// track contains positions...
 			var positionTrack = convertTrack( boneName + '.position', animationKeys, 'pos', THREE.VectorKeyframeTrack, function( animationKey ) {

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -514,9 +514,22 @@ THREE.ObjectLoader.prototype = {
 
 					break;
 
-				case 'Mesh':
+				case 'Mesh': {
 
-					object = new THREE.Mesh( getGeometry( data.geometry ), getMaterial( data.material ) );
+						var geometry = getGeometry( data.geometry );
+						
+						if( geometry.bones && geometry.bones.length > 0 ) {
+
+							object = new THREE.SkinnedMesh( geometry, getMaterial( data.material ) );
+
+						}
+						else {
+
+							object = new THREE.Mesh( geometry, getMaterial( data.material ) );	
+
+						}
+
+					}
 
 					break;
 


### PR DESCRIPTION
ObjectLoader would only load Meshes, not SkinnedMeshes.  We found it nicer if ObjectLoader would load meshes that have bones as SkinnedMeshes.  This change does that.

Additionally, there was a bug with nodeName not being set in the AnimationClip.parseAnimation() function.  This removes nodeName as it wasn't necessary anyhow.
