### PR TITLE
Multitouch Fix for TrackBallControls

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -539,7 +539,11 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 			case 1:
 				_movePrev.copy( _moveCurr );
-				_moveCurr.copy( getMouseOnCircle(  event.touches[ 0 ].pageX, event.touches[ 0 ].pageY ) );
+				_moveCurr.copy( getMouseOnCircle( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY ) );
+				if ( _state !== STATE.TOUCH_ROTATE ) {
+					_state = STATE.TOUCH_ROTATE;
+					_movePrev.copy( _moveCurr );
+				}
 				break;
 
 			case 2:
@@ -565,9 +569,15 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		switch ( event.touches.length ) {
 
+			case 0:
+				_state = STATE.NONE;
+				break;
+
 			case 1:
-				_movePrev.copy( _moveCurr );
-				_moveCurr.copy( getMouseOnCircle(  event.touches[ 0 ].pageX, event.touches[ 0 ].pageY ) );
+				if ( _state === STATE.TOUCH_ROTATE ) {
+					_movePrev.copy( _moveCurr );
+					_moveCurr.copy( getMouseOnCircle( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY ) );
+				}
 				break;
 
 			case 2:
@@ -581,7 +591,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		}
 
-		_state = STATE.NONE;
 		_this.dispatchEvent( endEvent );
 
 	}


### PR DESCRIPTION
Fix for #7185. After using two fingers, the camera would rapidly rotate if both fingers were not removed simultaneously. Adding in some state checks in `touchmove` and `touchend` prevents the jump from the null `_movePrev`, allowing users to quickly go from zooming and panning to rotating.
