### PR TITLE
Multitouch fixes

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -561,22 +561,14 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 			case 0:
 				_state = STATE.NONE;
+				_touchZoomDistanceStart = _touchZoomDistanceEnd = 0;
 				break;
 
 			case 1:
 				_state = STATE.TOUCH_ROTATE;
-				_movePrev.copy( _moveCurr );
-				_moveCurr.copy( getMouseOnCircle( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY ) );
-				break;
-
-			default: // 2 or more
-				_state = STATE.TOUCH_ZOOM_PAN;
 				_touchZoomDistanceStart = _touchZoomDistanceEnd = 0;
-
-				var x = ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX ) / 2;
-				var y = ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY ) / 2;
-				_panEnd.copy( getMouseOnScreen( x, y ) );
-				_panStart.copy( _panEnd );
+				_moveCurr.copy( getMouseOnCircle( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY ) );
+				_movePrev.copy( _moveCurr );
 				break;
 
 		}


### PR DESCRIPTION
- Removed unnecessary `default` case for two or more touches on `touchend` to prevent issues with 3 or more touches.
- Reset zoom distances on `case 0` and `case 1`. I couldn't combine them easily without doing a separate `if` statement.
- Simplified `case 1` action to set `_moveCurr` and `_movePrev` to the current touch position preventing camera jumping next time `touchmove` is called.

Related to issue #7185 and pull request #7406
