### PR TITLE
Fix bower.json ignores

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,13 +14,13 @@
 	"ignore": [
 		"**/.*",
 		"*.md",
-		"docs",
-		"editor",
-		"examples/*",
-		"!examples/js",
-		"src",
-		"test",
-		"utils",
-		"LICENSE"
+		"/docs",
+		"/editor",
+		"/examples/*",
+		"!/examples/js",
+		"/src",
+		"/test",
+		"/utils",
+		"/LICENSE"
 	]
 }


### PR DESCRIPTION
Adds leading slashes to bower.json ignores. This ensures only top level directories are ignored and makes intentions clearer.

Specifically this prevents a current issue where [some useful stuff in examples/js/utils](https://github.com/mrdoob/three.js/tree/master/examples/js/utils) is mistakenly ignored by a bower install, as well as preventing potential future examples from being unintentionally ignored.
