### PR TITLE
Diffuse indirect environment light

### DIFF
--- a/examples/webgl_materials_variations_physical2.html
+++ b/examples/webgl_materials_variations_physical2.html
@@ -161,11 +161,11 @@
 
 				// Lights
 
-				scene.add( new THREE.AmbientLight( 0x222222 ) );
+				//scene.add( new THREE.AmbientLight( 0x222222 ) );
 
-				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
-				directionalLight.position.set( 1, 1, 1 ).normalize();
-				scene.add( directionalLight );
+				//var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
+				//directionalLight.position.set( 1, 1, 1 ).normalize();
+				//scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );
 				particleLight.add( pointLight );

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -124,7 +124,7 @@ uniform vec3 ambientLightColor;
 
 		#ifdef ENVMAP_TYPE_CUBE
 
-			vec3 queryVec = flipNormal * vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
+			vec3 queryVec = flipNormal * vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
 
 			#if defined( TEXTURE_CUBE_LOD_EXT )				
 

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -107,6 +107,46 @@ uniform vec3 ambientLightColor;
 
 #if defined( USE_ENVMAP ) && defined( PHYSICAL )
 
+
+	vec3 getDiffuseLightProbeIndirectLightColor( /*const in SpecularLightProbe specularLightProbe,*/ const in GeometricContext geometry, const in int maxMIPLevel ) { 
+
+		#ifdef DOUBLE_SIDED
+
+			float flipNormal = ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+
+		#else
+
+			float flipNormal = 1.0;
+
+		#endif
+
+		vec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );
+
+		#ifdef ENVMAP_TYPE_CUBE
+
+			vec3 queryVec = flipNormal * vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
+
+			#if defined( TEXTURE_CUBE_LOD_EXT )				
+
+				vec4 envMapColor = textureCubeLodEXT( envMap, queryVec, float( maxMIPLevel ) );
+
+			#else
+
+				vec4 envMapColor = textureCube( envMap, queryVec, float( maxMIPLevel ) );
+
+			#endif
+		#else
+
+			vec4 envMapColor = vec3( 0.0 );
+
+		#endif
+
+		envMapColor.rgb = inputToLinear( envMapColor.rgb );
+
+		return envMapColor.rgb;
+
+	}
+
 	// taken from here: http://casual-effects.blogspot.ca/2011/08/plausible-environment-lighting-in-two.html
 	float getSpecularMIPLevel( const in float blinnShininessExponent, const in int maxMIPLevel ) {
 

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -126,12 +126,16 @@ uniform vec3 ambientLightColor;
 
 			vec3 queryVec = flipNormal * vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
 
+			// TODO: replace with properly filtered cubemaps and access the irradiance LOD level, be it the last LOD level
+			// of a specular cubemap, or just the default level of a specially created irradiance cubemap.
+
 			#if defined( TEXTURE_CUBE_LOD_EXT )				
 
 				vec4 envMapColor = textureCubeLodEXT( envMap, queryVec, float( maxMIPLevel ) );
 
 			#else
 
+				// force the bias high to get the last LOD level as it is the most blurred.				
 				vec4 envMapColor = textureCube( envMap, queryVec, float( maxMIPLevel ) );
 
 			#endif

--- a/src/renderers/shaders/ShaderChunk/lights_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_template.glsl
@@ -73,6 +73,13 @@ GeometricContext geometry = GeometricContext( -vViewPosition, normalize( normal 
 
 #endif
 
+#if defined( USE_ENVMAP ) && defined( PHYSICAL )
+
+		// TODO, replace 8 with the real maxMIPLevel
+		indirectDiffuseColor += getDiffuseLightProbeIndirectLightColor( /*lightProbe,*/ geometry, 8 );
+
+#endif
+
 		Material_RE_IndirectDiffuseLight( indirectDiffuseColor, geometry, material, reflectedLight );
 
 	}


### PR DESCRIPTION
This builds upon the cosine specular LOD filtering PR: #7414 

In this PR I add the calculation of indirect diffuse from the environment map.  This is done by querying the lowest level of the environment map in the normal direction (as opposed to the specular reflection direction) and accumulating it in the indirect diffuse section in the lights_template.glsl.
