### PR TITLE
Removed unnecessary touchZoomDistance resets

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -561,12 +561,10 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 			case 0:
 				_state = STATE.NONE;
-				_touchZoomDistanceStart = _touchZoomDistanceEnd = 0;
 				break;
 
 			case 1:
 				_state = STATE.TOUCH_ROTATE;
-				_touchZoomDistanceStart = _touchZoomDistanceEnd = 0;
 				_moveCurr.copy( getMouseOnCircle( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY ) );
 				_movePrev.copy( _moveCurr );
 				break;


### PR DESCRIPTION
The `_touchZoomDistanceStart` and `_touchZoomDistanceEnd` resets are not needed since the values will be set in the `touchstart` function when two or more touches are present.
