### PR TITLE
Fixing shadow map crash on Linux. [do not merge]

### DIFF
--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -105,7 +105,7 @@
 
 				scene.add( new THREE.HemisphereLight( 0x111111, 0x444444 ) );
 
-				var light = new THREE.DirectionalLight( 0xebf3ff, 1.5 );
+				var light = new THREE.DirectionalLight( 0x88ffff, 1.5 );
 				light.position.set( 0, 140, 500 ).multiplyScalar( 1.1 );
 				scene.add( light );
 
@@ -131,6 +131,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 				renderer.domElement.style.position = "relative";
+				renderer.s
 
 				container.appendChild( renderer.domElement );
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_fragment.glsl
@@ -97,6 +97,10 @@
 
 			bool frustumTest = all( frustumTestVec );
 
+			float shadowBiasLocal = shadowBias[ i ];
+			vec4 rgbaDepth = texture2D( shadowMap[ i ], shadowCoord.xy );
+			float shadowDarknessLocal = shadowDarkness[ i ];
+
 			if ( frustumTest ) {
 
 	#if defined( SHADOWMAP_TYPE_PCF )
@@ -215,13 +219,12 @@
 
 	#else // no percentage-closer filtering:
 
-				shadowCoord.z += shadowBias[ i ];
+				shadowCoord.z += shadowDarknessLocal;
 
-				vec4 rgbaDepth = texture2D( shadowMap[ i ], shadowCoord.xy );
 				float fDepth = unpackDepth( rgbaDepth );
 
 				if ( fDepth < shadowCoord.z )
-					shadow = shadowDarkness[ i ];
+					shadow = shadowDarknessLocal;
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_fragment.glsl
@@ -219,7 +219,7 @@
 
 	#else // no percentage-closer filtering:
 
-				shadowCoord.z += shadowDarknessLocal;
+				shadowCoord.z += shadowBiasLocal;
 
 				float fDepth = unpackDepth( rgbaDepth );
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -91,7 +91,7 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 	this.autoUpdate = true;
 	this.needsUpdate = false;
 
-	this.type = THREE.PCFShadowMap;
+	this.type = THREE.BasicShadowMap;
 	this.cullFace = THREE.CullFaceFront;
 
 	this.render = function ( scene, camera ) {


### PR DESCRIPTION
There is this error:

```
0:201(39): error: sampler arrays indexed with non-constant expressions is forbidden in GLSL 1.30 and later
```

It occurs on Linux machines.  Intel driver at least.
It occurs if shadow maps are enabled.

It should be solvable because the access patterns are similar between lights and shadow maps.
