### PR TITLE
Adds ShaderMaterial properties to trigger inclusion of extensions

### DIFF
--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -59,6 +59,9 @@ THREE.ShaderMaterial = function ( parameters ) {
 	this.morphNormals = false; // set to use morph normals
 
 	this.derivatives = false; // set to use derivatives
+	this.fragDepth = false; // set to use fragment depth values
+	this.drawBuffers = false; // set to use draw buffers
+	this.shaderTextureLOD = false; // set to use shader texture LOD
 
 	// When rendered geometry doesn't include these attributes but the material does,
 	// use these default values in WebGL. This avoids errors when buffer data is missing.
@@ -116,6 +119,9 @@ THREE.ShaderMaterial.prototype.copy = function ( source ) {
 	this.morphNormals = source.morphNormals;
 
 	this.derivatives = source.derivatives;
+	this.fragDepth = source.fragDepth;
+	this.drawBuffers = source.drawBuffers;
+	this.shaderTextureLOD = source.shaderTextureLOD;
 
 	return this;
 

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -58,10 +58,12 @@ THREE.ShaderMaterial = function ( parameters ) {
 	this.morphTargets = false; // set to use morph targets
 	this.morphNormals = false; // set to use morph normals
 
-	this.derivatives = false; // set to use derivatives
-	this.fragDepth = false; // set to use fragment depth values
-	this.drawBuffers = false; // set to use draw buffers
-	this.shaderTextureLOD = false; // set to use shader texture LOD
+	this.extensions = {
+		derivatives: false, // set to use derivatives
+		fragDepth: false, // set to use fragment depth values
+		drawBuffers: false, // set to use draw buffers
+		shaderTextureLOD: false // set to use shader texture LOD
+	};
 
 	// When rendered geometry doesn't include these attributes but the material does,
 	// use these default values in WebGL. This avoids errors when buffer data is missing.
@@ -118,10 +120,7 @@ THREE.ShaderMaterial.prototype.copy = function ( source ) {
 	this.morphTargets = source.morphTargets;
 	this.morphNormals = source.morphNormals;
 
-	this.derivatives = source.derivatives;
-	this.fragDepth = source.fragDepth;
-	this.drawBuffers = source.drawBuffers;
-	this.shaderTextureLOD = source.shaderTextureLOD;
+	this.extensions = source.extensions;
 
 	return this;
 
@@ -139,3 +138,24 @@ THREE.ShaderMaterial.prototype.toJSON = function ( meta ) {
 	return data;
 
 };
+
+Object.defineProperties( THREE.ShaderMaterial.prototype, {
+
+	derivatives: {
+
+		get: function () {
+
+			return this.extensions.derivatives;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE. ShaderMaterial: .derivatives has been moved to .extensions.derivatives.' );
+			this.extensions.derivatives = value;
+
+		}
+
+	}
+
+} );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -2,6 +2,21 @@ THREE.WebGLProgram = ( function () {
 
 	var programIdCount = 0;
 
+	function generateExtensions( extensions, parameters, rendererExtensions ) {
+
+		extensions = extensions || {};
+
+		var chunks = [
+			( parameters.logarithmicDepthBuffer || extensions.derivatives ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
+			( extensions.fragDepth ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
+			( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : enable' : '',
+			( parameters.envMap || extensions.shaderTextureLOD ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : '',
+		];
+
+		return chunks.filter( filterEmptyLine ).join( '\n' );
+
+	}
+
 	function generateDefines( defines ) {
 
 		var chunks = [];
@@ -80,6 +95,7 @@ THREE.WebGLProgram = ( function () {
 
 		var gl = renderer.context;
 
+		var extensions = material.extensions;
 		var defines = material.defines;
 
 		var vertexShader = material.__webglShader.vertexShader;
@@ -153,6 +169,8 @@ THREE.WebGLProgram = ( function () {
 		// console.log( 'building new program ' );
 
 		//
+
+		var customExtensions = generateExtensions( extensions, parameters, renderer.extensions );
 
 		var customDefines = generateDefines( defines );
 
@@ -283,14 +301,10 @@ THREE.WebGLProgram = ( function () {
 
 			].filter( filterEmptyLine ).join( '\n' );
 
+
 			prefixFragment = [
 
-				parameters.bumpMap || parameters.normalMap || parameters.flatShading || material.derivatives ? '#extension GL_OES_standard_derivatives : enable' : '',
-				( parameters.logarithmicDepthBuffer || material.fragDepth ) && renderer.extensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
-
-				material.drawBuffers && renderer.extensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : enable' : '',
-
-				( parameters.envMap || material.shaderTextureLOD ) && renderer.extensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : '',
+				customExtensions,
 
 				'precision ' + parameters.precision + ' float;',
 				'precision ' + parameters.precision + ' int;',

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -9,7 +9,7 @@ THREE.WebGLProgram = ( function () {
 		var chunks = [
 			( parameters.logarithmicDepthBuffer || extensions.derivatives ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 			( extensions.fragDepth ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
-			( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : enable' : '',
+			( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : required' : '',
 			( parameters.envMap || extensions.shaderTextureLOD ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : '',
 		];
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -9,7 +9,7 @@ THREE.WebGLProgram = ( function () {
 		var chunks = [
 			( parameters.logarithmicDepthBuffer || extensions.derivatives ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 			( extensions.fragDepth ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
-			( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : required' : '',
+			( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : require' : '',
 			( parameters.envMap || extensions.shaderTextureLOD ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : '',
 		];
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -286,9 +286,11 @@ THREE.WebGLProgram = ( function () {
 			prefixFragment = [
 
 				parameters.bumpMap || parameters.normalMap || parameters.flatShading || material.derivatives ? '#extension GL_OES_standard_derivatives : enable' : '',
-				parameters.logarithmicDepthBuffer && renderer.extensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
+				( parameters.logarithmicDepthBuffer || material.fragDepth ) && renderer.extensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
 
-				parameters.envMap && renderer.extensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : '',
+				material.drawBuffers && renderer.extensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : enable' : '',
+
+				( parameters.envMap || material.shaderTextureLOD ) && renderer.extensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : '',
 
 				'precision ' + parameters.precision + ' float;',
 				'precision ' + parameters.precision + ' int;',


### PR DESCRIPTION
This change implements #7379 by adding three further properties to ShaderMaterial, to trigger inclusion of GL extensions (EXT_frag_depth, WEBGL_draw_buffers, EXT_shader_texture_lod). It follows the pattern of:

```
material.derivatives = true; 
```
