### PR TITLE
Ignore empty entries in MTL files

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -311,6 +311,10 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 			var value = mat[ prop ];
 
+			if ( value === '' ) {
+				continue;
+			}
+
 			switch ( prop.toLowerCase() ) {
 
 				// Ns is material specular exponent


### PR DESCRIPTION
Every so often I stumble upon .mtl files that contain definitions that look like this:

```
newmtl Material__73
Ka 0.156863 0.156863 0.156863
Kd 0.156863 0.156863 0.156863
Ks 0 0 0
illum 2
Ns 128
map_Kd 
map_bump 
bump 
map_opacity 
map_d 
refl 
map_kS 
map_kA 
map_Ns 
```

Currently, a definition like this will lead to an unexpected material being created, as it will have all of the properties, but with empty values (including maps).

While this is technically an issue of the exporter that generated the file, just skipping those empty entries is a small fix, and will lead to less headaches for developers importing models.
