### PR TITLE
OrbitControls: adding a mouseout listener which does exactly the same…

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -412,6 +412,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		if ( state !== STATE.NONE ) {
 			document.addEventListener( 'mousemove', onMouseMove, false );
 			document.addEventListener( 'mouseup', onMouseUp, false );
+			document.addEventListener( 'mouseout', onMouseOut, false );
 			scope.dispatchEvent( startEvent );
 		}
 
@@ -482,6 +483,19 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
+		document.removeEventListener( 'mouseout', onMouseOut, false );
+		scope.dispatchEvent( endEvent );
+		state = STATE.NONE;
+
+	}
+
+	function onMouseOut( /* event */ ) {
+
+		if ( scope.enabled === false ) return;
+
+		document.removeEventListener( 'mousemove', onMouseMove, false );
+		document.removeEventListener( 'mouseup', onMouseUp, false );
+		document.removeEventListener( 'mouseout', onMouseOut, false );
 		scope.dispatchEvent( endEvent );
 		state = STATE.NONE;
 
@@ -705,6 +719,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
+		document.removeEventListener( 'mouseout', onMouseOut, false );
 
 		window.removeEventListener( 'keydown', onKeyDown, false );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -412,7 +412,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		if ( state !== STATE.NONE ) {
 			document.addEventListener( 'mousemove', onMouseMove, false );
 			document.addEventListener( 'mouseup', onMouseUp, false );
-			document.addEventListener( 'mouseout', onMouseOut, false );
+			document.addEventListener( 'mouseout', onMouseUp, false );
 			scope.dispatchEvent( startEvent );
 		}
 
@@ -483,19 +483,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
-		document.removeEventListener( 'mouseout', onMouseOut, false );
-		scope.dispatchEvent( endEvent );
-		state = STATE.NONE;
-
-	}
-
-	function onMouseOut( /* event */ ) {
-
-		if ( scope.enabled === false ) return;
-
-		document.removeEventListener( 'mousemove', onMouseMove, false );
-		document.removeEventListener( 'mouseup', onMouseUp, false );
-		document.removeEventListener( 'mouseout', onMouseOut, false );
+		document.removeEventListener( 'mouseout', onMouseUp, false );
 		scope.dispatchEvent( endEvent );
 		state = STATE.NONE;
 
@@ -719,7 +707,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
-		document.removeEventListener( 'mouseout', onMouseOut, false );
+		document.removeEventListener( 'mouseout', onMouseUp, false );
 
 		window.removeEventListener( 'keydown', onKeyDown, false );
 


### PR DESCRIPTION
OrbitControls: adding a `mouseout` listener which does exactly the same as `mouseup`.

I noticed that when I use a page that uses OrbitControls, they can get stuck when doing the following:
- move the mouse over the element attached to the OrbitControls.
- click and hold left button.
- move mouse outside the element (say through the left edge).
- release left button.
- move mouse, and enter the element (say from the top edge).

Expected result: scene moves until the mouse exits, scene stays still when the mouse reenters.
Actual result: scene moves until the mouse exits, but it jumps to a very different point of view when the mouse reenters. The camera tracks the mouse movement until the next `mouseup` event.

This can be repro'd easily at http://threejs.org/examples/#misc_controls_orbit (and locally in the dev branch).

I'm not exactly in love with the solution, because it duplicates some code. What do you all think about having `onMouseUp` and `onMouseOut` both call a new `_onMouseUpOrOut`?
