### PR TITLE
Fixes size attenuation calculation for GL points

### DIFF
--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -601,7 +601,7 @@ THREE.ShaderLib = {
 			"	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
 
 			"	#ifdef USE_SIZEATTENUATION",
-			"		gl_PointSize = size * ( scale / length( mvPosition.xyz ) );",
+			"		gl_PointSize = size * ( scale / -mvPosition.z );",
 			"	#else",
 			"		gl_PointSize = size;",
 			"	#endif",


### PR DESCRIPTION
The calculation for perspective-based size attenuation of GL points was wrong; the scale should be entirely based on distance in the z-axis relative to the camera. This change makes points fit perfectly with identical quads in the same scene (where previously the size would nonsensically shrink towards the sides of the image).

For comparison:

This is what is currently found in three.js:
![length_xyz](https://cloud.githubusercontent.com/assets/8540042/10713258/7632a09a-7a83-11e5-9bab-290f212e1b14.PNG)

This is the fixed version:
![z_only](https://cloud.githubusercontent.com/assets/8540042/10713312/9f6c696c-7a85-11e5-94cb-5fb102378ad3.PNG)

This is a scene consisting of polygonal planes positioned at the same places that the point cloud vertices were; you can see that other than a minor rounding error rasterizing one of the quads, it's identical to the corrected size calculation.
![poly_reference](https://cloud.githubusercontent.com/assets/8540042/10713314/af8d6b20-7a85-11e5-86be-3f3b98a2ca2a.PNG)
