### PR TITLE
Renderer: Clarified lighting uniforms update.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2562,13 +2562,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		zlights = _lights,
 
-		viewMatrix = camera.matrixWorldInverse;
+		viewMatrix = camera.matrixWorldInverse,
 
-		// those are held by reference, so do not clobber
-		zlights.directional.length = 0;
-		zlights.point.length = 0;
-		zlights.spot.length = 0;
-		zlights.hemi.length = 0;
+		writeIndexDirectional = 0,
+		writeIndexPoint = 0,
+		writeIndexSpot = 0,
+		writeIndexHemi = 0;
 
 		for ( l = 0, ll = lights.length; l < ll; l ++ ) {
 
@@ -2596,7 +2595,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 
 				var lightUniforms = light.__webglUniforms;
-				zlights.directional.push( lightUniforms );
+				zlights.directional[ writeIndexDirectional ++ ] = lightUniforms;
 
 				if ( ! light.visible ) {
 					lightUniforms.color.setRGB( 0, 0, 0 );
@@ -2622,7 +2621,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 
 				var lightUniforms = light.__webglUniforms;
-				zlights.point.push( lightUniforms );
+				zlights.point[ writeIndexPoint ++ ] = lightUniforms; 
 
 				if ( ! light.visible ) {
 					lightUniforms.color.setRGB( 0, 0, 0 );
@@ -2650,7 +2649,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 
 				var lightUniforms = light.__webglUniforms;
-				zlights.spot.push( lightUniforms );
+				zlights.spot[ writeIndexSpot ++ ] = lightUniforms; 
 
 				if ( ! light.visible ) {
 					lightUniforms.color.setRGB( 0, 0, 0 );
@@ -2683,7 +2682,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 
 				var lightUniforms = light.__webglUniforms;
-				zlights.hemi.push( lightUniforms );
+				zlights.hemi[ writeIndexHemi ++ ] = lightUniforms; 
 
 				if ( ! light.visible ) {
 					lightUniforms.skyColor.setRGB( 0, 0, 0 );
@@ -2704,6 +2703,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 		zlights.ambient[ 0 ] = r;
 		zlights.ambient[ 1 ] = g;
 		zlights.ambient[ 2 ] = b;
+
+		zlights.directional.length = writeIndexDirectional;
+		zlights.point.length = writeIndexPoint;
+		zlights.spot.length = writeIndexSpot;
+		zlights.hemi.length = writeIndexHemi;
 
 	}
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -3,6 +3,11 @@ vec3 diffuse = vec3( 1.0 );
 GeometricContext geometry = GeometricContext( mvPosition.xyz, normalize( transformedNormal ), normalize( -mvPosition.xyz ) );
 GeometricContext backGeometry = GeometricContext( geometry.position, -geometry.normal, geometry.viewDir );
 
+	vLightFront = vec3( 0.0 );
+#ifdef DOUBLE_SIDED
+	vLightBack = vec3( 0.0 );
+#endif
+
 #if MAX_POINT_LIGHTS > 0
 
 	for ( int i = 0; i < MAX_POINT_LIGHTS; i ++ ) {


### PR DESCRIPTION
Lighting uniforms are not "refreshed" on the material - they are just wired up by reference.

The GL state is indeed refreshed - and the update is triggered via `.needsUpdate` flags on the uniform (wrapper objects) of the first material interested in lighting.

This implementation is in fact working, but very crude and the code is not sufficiently clear. This PR attempts to shed some light on the subtleties.

Also fixes: 
- Lighting update on camera change.
- Random materials' uniforms getting outdated on current `dev`. 
