### PR TITLE
Fixed flickering lighting with MeshLambertMaterial.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -3,6 +3,11 @@ vec3 diffuse = vec3( 1.0 );
 GeometricContext geometry = GeometricContext( mvPosition.xyz, normalize( transformedNormal ), normalize( -mvPosition.xyz ) );
 GeometricContext backGeometry = GeometricContext( geometry.position, -geometry.normal, geometry.viewDir );
 
+	vLightFront = vec3( 0.0 );
+#ifdef DOUBLE_SIDED
+	vLightBack = vec3( 0.0 );
+#endif
+
 #if MAX_POINT_LIGHTS > 0
 
 	for ( int i = 0; i < MAX_POINT_LIGHTS; i ++ ) {


### PR DESCRIPTION
A trivial fix.

I wonder whether the initialization got sliced off just recently, or wasn't even there in the first place - a ticking bomb waiting to run on recycled memory...

See #7447.
