### PR TITLE
Update BufferGeometry.js

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -826,7 +826,7 @@ THREE.BufferGeometry.prototype = {
 
 	computeOffsets: function ( size ) {
 
-		console.warn( 'THREE.BufferGeometry: .computeOffsets() has been removed.')
+		console.warn( 'THREE.BufferGeometry: .computeOffsets() has been removed.');
 
 	},
 


### PR DESCRIPTION
Added semicolon at line 829. Unclosed console call due to missing semicolon caused grunt.removeLogging to create a fractured file which lead to an unexpected token error during build and uglify.
