### PR TITLE
fix Sea3DLoader for new simplified lighting model.

### DIFF
--- a/examples/js/loaders/sea3d/SEA3DLoader.js
+++ b/examples/js/loaders/sea3d/SEA3DLoader.js
@@ -84,13 +84,14 @@ THREE.SEA3D.ShaderLib.replaceCode = function( src, target, replace ) {
 
 THREE.SEA3D.ShaderLib.fragStdMtl = THREE.SEA3D.ShaderLib.replaceCode( THREE.ShaderLib.phong.fragmentShader, [
 	//	Target
-	'outgoingLight += diffuseColor.rgb * ( totalDiffuseLight + totalAmbientLight ) * specular + totalSpecularLight + totalEmissiveLight;', // METAL
-	'outgoingLight += diffuseColor.rgb * ( totalDiffuseLight + totalAmbientLight ) + totalSpecularLight + totalEmissiveLight;'
+	'vec3 outgoingLight = ( reflectedLight.directDiffuse + reflectedLight.indirectDiffuse ) * specular + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveLight;', // METAL
+	'vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveLight;'
 ], [
 	//	Replace To
-	'outgoingLight += diffuseColor.rgb * ( totalDiffuseLight + totalAmbientLight + totalEmissiveLight ) * specular + totalSpecularLight;', // METAL
-	'outgoingLight += diffuseColor.rgb * ( totalDiffuseLight + totalAmbientLight + totalEmissiveLight ) + totalSpecularLight;'
+	'vec3 outgoingLight = ( reflectedLight.directDiffuse + reflectedLight.indirectDiffuse ) * specular + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveLight * specular;', // METAL
+	'vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveLight * diffuse;'
 ] );
+
 
 //
 //	Standard Material


### PR DESCRIPTION
Restore the exact look and feel of the Sea3D loader's materials after the switch to the simplified lighting model.

Compare:

http://threejs.org/examples/#webgl_loader_sea3d_hierarchy
http://ci.threejs.org/api/pullrequests/7487/examples/webgl_loader_sea3d_hierarchy.html
