### PR TITLE
Added check of status & readystate

### DIFF
--- a/src/loaders/XHRLoader.js
+++ b/src/loaders/XHRLoader.js
@@ -40,8 +40,11 @@ THREE.XHRLoader.prototype = {
 		request.addEventListener( 'load', function ( event ) {
 
 			THREE.Cache.add( url, this.response );
-
-			if ( onLoad ) onLoad( this.response );
+			if ( this.status == 200 && this.readyState == 4 ) {
+				if ( onLoad ) onLoad( this.response );
+			} else {
+				if ( onError ) onError( event );
+			}
 
 			scope.manager.itemEnd( url );
 


### PR DESCRIPTION
The "load" event is fired if the request operation is successfully completed. To make sure that the request successfully loaded the content, status (and readyState) must be checked too.

See http://www.w3.org/TR/XMLHttpRequest/
