### PR TITLE
Keep TrackballControls from consuming all events.

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -356,8 +356,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		if ( _this.enabled === false ) return;
 
-		window.removeEventListener( 'keydown', keydown );
-
 		_prevState = _state;
 
 		if ( _state !== STATE.NONE ) {
@@ -386,16 +384,11 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		_state = _prevState;
 
-		window.addEventListener( 'keydown', keydown, false );
-
 	}
 
 	function mousedown( event ) {
 
 		if ( _this.enabled === false ) return;
-
-		event.preventDefault();
-		event.stopPropagation();
 
 		if ( _state === STATE.NONE ) {
 
@@ -431,9 +424,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		if ( _this.enabled === false ) return;
 
-		event.preventDefault();
-		event.stopPropagation();
-
 		if ( _state === STATE.ROTATE && ! _this.noRotate ) {
 
 			_movePrev.copy( _moveCurr );
@@ -455,9 +445,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		if ( _this.enabled === false ) return;
 
-		event.preventDefault();
-		event.stopPropagation();
-
 		_state = STATE.NONE;
 
 		document.removeEventListener( 'mousemove', mousemove );
@@ -469,9 +456,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 	function mousewheel( event ) {
 
 		if ( _this.enabled === false ) return;
-
-		event.preventDefault();
-		event.stopPropagation();
 
 		var delta = 0;
 
@@ -528,9 +512,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 	function touchmove( event ) {
 
 		if ( _this.enabled === false ) return;
-
-		event.preventDefault();
-		event.stopPropagation();
 
 		switch ( event.touches.length ) {
 


### PR DESCRIPTION
`TrackballControls` play a lot nicer with `TransformControls` when they don't eat up all events. Still prevents the context menu, of course.
