### PR TITLE
Added check of status & readystate

### DIFF
--- a/src/loaders/XHRLoader.js
+++ b/src/loaders/XHRLoader.js
@@ -45,7 +45,11 @@ THREE.XHRLoader.prototype = {
 
 			THREE.Cache.add( url, response );
 
-			if ( onLoad ) onLoad( response );
+			if ( this.status == 200 && this.readyState == 4 ) {
+				if ( onLoad ) onLoad( response );	
+			} else {
+				if ( onError ) onError( event );
+			};
 
 			scope.manager.itemEnd( url );
 


### PR DESCRIPTION
The "load" event is fired if the request operation is successfully completed. To make sure that the request successfully loaded the content, status must be checked too.

See http://www.w3.org/TR/XMLHttpRequest/
