### PR TITLE
Added deletion of geometry properties.

### DIFF
--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -64,6 +64,8 @@ THREE.WebGLGeometries = function ( gl, properties, info ) {
 		var property = properties.get( geometry );
 		if ( property.wireframe ) deleteAttribute( property.wireframe );
 
+		properties.delete( geometry );
+
 		info.memory.geometries --;
 
 	}


### PR DESCRIPTION
Geometry were not deleted from properties on dispose, causing memory leak.
