### PR TITLE
Check for status 0 as well as status 200

### DIFF
--- a/src/loaders/XHRLoader.js
+++ b/src/loaders/XHRLoader.js
@@ -45,7 +45,7 @@ THREE.XHRLoader.prototype = {
 
 			THREE.Cache.add( url, response );
 
-			if ( this.status == 200 && this.readyState == 4 ) {
+			if ( ( this.status === 0 || this.status === 200 )  && this.readyState === 4 ) {
 
 				if ( onLoad ) onLoad( response );
 


### PR DESCRIPTION
While testing with the XHRLoader on the dev branch, I noticed that my local examples weren't loading when accessing via `file://`

When opening a file locally (via `file://`) the status code seems to report as `0`. Checking if the status code is `0` fixes the issue. This bug was introduced in 302ac826216449dbb38879dcfdec75b3c4934525

Also, substitute `==` with `===`
