### PR TITLE
Fix docs for Matrix3#getInverse()

### DIFF
--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -166,7 +166,7 @@ THREE.Matrix3.prototype = {
 
 	getInverse: function ( matrix, throwOnInvertible ) {
 
-		// input: THREE.Matrix4
+		// input: THREE.Matrix3
 		// ( based on http://code.google.com/p/webgl-mjs/ )
 
 		var me = matrix.elements;


### PR DESCRIPTION
It looked awkward to me that `Matrix3#getInverse()` would take a `Matrix4` as input. After looking at the code, I think that this is just a typo.
