### PR TITLE
MeshStandardMaterial: Fix envMapIntensity

### DIFF
--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -39,6 +39,8 @@
  *  alphaMap: new THREE.Texture( <Image> ),
  *
  *  envMap: new THREE.CubeTexture( [posx, negx, posy, negy, posz, negz] ),
+ *  envMapIntensity: <float>
+ *
  *  refractionRatio: <float>,
  *
  *  shading: THREE.SmoothShading,

--- a/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl
@@ -1,5 +1,6 @@
 #if defined( USE_ENVMAP ) || defined( STANDARD )
 	uniform float reflectivity;
+	uniform float envMapIntenstiy;
 #endif
 
 #ifdef USE_ENVMAP

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -163,7 +163,7 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 		envMapColor.rgb = inputToLinear( envMapColor.rgb );
 
-		return PI * envMapColor.rgb;
+		return PI * envMapColor.rgb * envMapIntensity;
 
 	}
 
@@ -237,7 +237,7 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 		envMapColor.rgb = inputToLinear( envMapColor.rgb );
 
-		return envMapColor.rgb;
+		return envMapColor.rgb * envMapIntensity;
 
 	}
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/pull/7382#discussion_r44027245

This was partially implemented, already

/ping @bhouston Is this OK with you -- at least for now?
