### PR TITLE
Parse materialIndex when adding groups 

### DIFF
--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -64,7 +64,7 @@ THREE.BufferGeometryLoader.prototype = {
 
 				var group = groups[ i ];
 
-				geometry.addGroup( group.start, group.count );
+				geometry.addGroup( group.start, group.count, group.materialIndex );
 
 			}
 


### PR DESCRIPTION
Simple addition to make the `THREE.ObjectLoader` parse the `group.materialIndex` property in Object Format 4 JSON files.

[before (current dev)](http://jsfiddle.net/satori99/co6f33su/2/) and [after (PR)](http://jsfiddle.net/satori99/ckrLuvbq/1/). 

Both fiddles load the [same JSON](https://gist.github.com/satori99/37e7e2c3318123efa0b9) file.
