### PR TITLE
Line and Points (not just Mesh) can use instanced rendering

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -864,16 +864,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 				}
 
 			}
-
-			if ( geometry instanceof THREE.InstancedBufferGeometry && geometry.maxInstancedCount > 0 ) {
-
-				renderer.renderInstances( geometry, drawStart, drawCount );
-
-			} else {
-
-				renderer.render( drawStart, drawCount );
-
-			}
+			
 
 		} else if ( object instanceof THREE.Line ) {
 
@@ -893,11 +884,18 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
-			renderer.render( drawStart, drawCount );
-
 		} else if ( object instanceof THREE.Points ) {
 
 			renderer.setMode( _gl.POINTS );
+
+		}
+		
+		if ( geometry instanceof THREE.InstancedBufferGeometry && geometry.maxInstancedCount > 0 ) {
+
+			renderer.renderInstances( geometry, drawStart, drawCount );
+
+		} else {
+
 			renderer.render( drawStart, drawCount );
 
 		}


### PR DESCRIPTION
Previously only Meshes would have the opportunity to be rendered with instancing. If a Line or Points was created with an InstancedBufferGeometry, they would be given this option. This edit to renderBufferDirect checks the geometry of all these types for use of instancing, and allows each to now use the feature
