### PR TITLE
work around Chrome on Andriod bug - can not use struct constructors.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -1,7 +1,14 @@
 vec3 diffuse = vec3( 1.0 );
 
-GeometricContext geometry = GeometricContext( mvPosition.xyz, normalize( transformedNormal ), normalize( -mvPosition.xyz ) );
-GeometricContext backGeometry = GeometricContext( geometry.position, -geometry.normal, geometry.viewDir );
+GeometricContext geometry;
+geometry.position = mvPosition.xyz;
+geometry.normal = normalize( transformedNormal );
+geometry.viewDir = normalize( -mvPosition.xyz );
+
+GeometricContext backGeometry;
+backGeometry.position = geometry.position;
+backGeometry.normal = -geometry.normal;
+backGeometry.viewDir = geometry.viewDir;
 
 vLightFront = vec3( 0.0 );
 

--- a/src/renderers/shaders/ShaderChunk/lights_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_template.glsl
@@ -13,7 +13,10 @@
 //  - Add diffuse light probe (irradiance cubemap) support.
 //
 
-GeometricContext geometry = GeometricContext( -vViewPosition, normal, normalize( vViewPosition ) );
+GeometricContext geometry;
+geometry.position = -vViewPosition;
+geometry.normal = normal;
+geometry.viewDir = normalize( vViewPosition );
 
 #if ( NUM_POINT_LIGHTS > 0 ) && defined( Material_RE_DirectLight )
 


### PR DESCRIPTION
Seems Chrome on Andriod has a bug, you can not use struct initializers.  (/ping @kenrussell)  They work on Firefox, Chrome in windows, Safari on iOS, and everywhere else it appears, but not on Chrome on Andriod.

This patch fixes the main issue that @mrdoob identified here:

https://github.com/mrdoob/three.js/pull/7324#issuecomment-154780930

Another issue is that the text in the example on my Andriod id black colored, when it is white on my desktop - but it appears to be a separate issue:

http://threejsworker.com/api/pullrequests/7556/examples/webgl_materials_variations_standard.html
