### PR TITLE
Implemented panSpeed for OrbitControls

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -65,6 +65,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	// Set to false to disable panning
 	this.enablePan = true;
+	this.panSpeed = 1.0;
 	this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
 
 	// Set to true to automatically rotate around the target
@@ -193,6 +194,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 	this.pan = function ( deltaX, deltaY /*, screenWidth, screenHeight */ ) {
 
 		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+		deltaX = scope.panSpeed * deltaX;
+		deltaY = scope.panSpeed * deltaY;
 
 		if ( scope.object instanceof THREE.PerspectiveCamera ) {
 


### PR DESCRIPTION
I noticed that OrbitControls has `rotateSpeed` and `zoomSpeed` but no `panSpeed`. This is super problematic when using an OrthographicCamera because the panning is just way too fast to be usable. 

By implementing `panSpeed`, developers can finetune the panning behaviour to their desired speed.

Luckily the code for OrbitControls is pretty great so implementing this was easy.

I checked the examples and it seems to work really well.
