### PR TITLE
Fix for undefined resetBlendWeights method Exception

### DIFF
--- a/examples/js/loaders/collada/KeyFrameAnimation.js
+++ b/examples/js/loaders/collada/KeyFrameAnimation.js
@@ -101,17 +101,12 @@ THREE.KeyFrameAnimation.prototype = {
 		}
 
 		this.isPaused = false;
-
-		THREE.AnimationHandler.play( this );
-
 	},
 
 	stop: function () {
 
 		this.isPlaying = false;
 		this.isPaused  = false;
-
-		THREE.AnimationHandler.stop( this );
 
 		// reset JIT matrix and remove cache
 


### PR DESCRIPTION
Removing both THREE.AnimationHandler.play and THREE.AnimationHandler.stop as they include "keyframe animation" in global THREE.AnimationHandler.update routine, which expects resetBlendWeights method that's missing for keyframe animations. I also don't see any use for it, as whole animation lifecycle is in this case handled inside KeyFrameAnimation.

In the end this causes undefined method exceptions in AnimationHandler.js#L208
if used in coonection with both KeyFrameAnimation and AnimationHandler for skinnned meshes.
