### PR TITLE
Fix for exception with 1 keyframe animations

### DIFF
--- a/examples/js/loaders/collada/KeyFrameAnimation.js
+++ b/examples/js/loaders/collada/KeyFrameAnimation.js
@@ -84,7 +84,7 @@ THREE.KeyFrameAnimation.prototype = {
 
 				var keys = this.data.hierarchy[ h ].keys;
 
-				if ( keys.length ) {
+				if ( keys.length > 1 ) {
 
 					node.animationCache.prevKey = keys[ 0 ];
 					node.animationCache.nextKey = keys[ 1 ];


### PR DESCRIPTION
Animations with only one key throw exception because next frame is not available.
