### PR TITLE
Set MIME type properly in THREE.JSONLoader

### DIFF
--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -46,6 +46,7 @@ THREE.JSONLoader.prototype = {
 		var loader = new THREE.XHRLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setResponseType("application/json");
 		loader.load( url, function ( text ) {
 
 			var json = JSON.parse( text );

--- a/src/loaders/XHRLoader.js
+++ b/src/loaders/XHRLoader.js
@@ -68,7 +68,10 @@ THREE.XHRLoader.prototype = {
 		}, false );
 
 		if ( this.crossOrigin !== undefined ) request.crossOrigin = this.crossOrigin;
-		if ( this.responseType !== undefined ) request.responseType = this.responseType;
+		if ( this.responseType !== undefined ) {
+			request.responseType = this.responseType;
+			request.overrideMimeType( this.responseType );
+		}
 		if ( this.withCredentials !== undefined ) request.withCredentials = this.withCredentials;
 
 		request.send( null );


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#XMLHttpRequest%28%29) there just so happens to be a function named XMLHttpRequest.overrideMimeType( type )! If this is used, the browser will override the MIME type the server sends, and therefore not complain if the right request is sent but with no MIME type.

This also allows for better offline support! When trying to load a threejs .json model from a local file, there are no MIME types supplied by the server (since there is no server). THREE.JSONLoader will load the file successfully, but XMLHttpRequest will complain that the file is "not well-formed". This is because with no MIME types, the XMLHttpRequest defaults to thinking that it's XML instead of JSON, and so throws a warning that the file isn't well-formed XML. In a web application with lots of models being loaded, that ends up being a huge amount of warnings. To avoid that, this commit sets THREE.JSONLoader to force the type "application/json" by default. Invalid JSON will still throw an error when parsing as normal.

I assumed that if someone calls loader.setResponseType(), they want to interpret the response as a certain MIME type, but I'm not sure about that. 

Thanks!
