### PR TITLE
Fix middle-click zooming error in refactored OrbitControls

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -479,11 +479,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		if ( dollyDelta.y > 0 ) {
 
-			dollyIn( scope.getZoomScale() );
+			dollyIn( getZoomScale() );
 
 		} else if ( dollyDelta.y < 0 ) {
 
-			dollyOut( scope.getZoomScale() );
+			dollyOut( getZoomScale() );
 
 		}
 


### PR DESCRIPTION
This fixes middle-click zooming in the refactored `THREE.OrbitControls` code #7584.

`getZoomScale()` was made into an internal function but middle-click zooming still called it via a scope var.
