### PR TITLE
Added examples-js folders to npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
-examples/
-src/
+examples/*
+!examples/js/
+src/*
+!src/extras/
 test/
 utils/
 docs/

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 examples/*
 !examples/js/
-src/*
-!src/extras/
+src/
 test/
 utils/
 docs/


### PR DESCRIPTION
Including the examples-js and extras folder in the npm package so that they can be obtained from the main repo rather than trying to find them from forks maintained by different parties.

This is a dev-targeted PR for the same one done on master previously:
https://github.com/mrdoob/three.js/pull/7590
"Bower package already contains examples-js folder, and extras also has
some very good helpers, so it will be good to have them in npm package
as well"
