### PR TITLE
[Blender Exporter] support BasicMaterial

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/material.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/material.py
@@ -243,6 +243,9 @@ def shading(material):
         False: constants.LAMBERT
     }
 
+    if material.use_shadeless:
+        return constants.BASIC
+
     return dispatch[material.specular_intensity > 0.0]
 
 

--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -535,7 +535,6 @@ def materials(mesh, options):
 
         logger.info("Compiling attributes for %s", mat.name)
         attributes = {
-            constants.COLOR_EMISSIVE: material.emissive_color(mat),
             constants.SHADING: material.shading(mat),
             constants.OPACITY: material.opacity(mat),
             constants.TRANSPARENT: material.transparent(mat),
@@ -556,6 +555,12 @@ def materials(mesh, options):
         if (use_colors and mix) or (not use_colors):
             colors = material.diffuse_color(mat)
             attributes[constants.COLOR_DIFFUSE] = colors
+
+        if attributes[constants.SHADING] != constants.BASIC:
+            logger.info("Adding emissive attributes")
+            attributes.update({
+                constants.COLOR_EMISSIVE: material.emissive_color(mat),
+            })
 
         if attributes[constants.SHADING] == constants.PHONG:
             logger.info("Adding specular attributes")

--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -535,6 +535,7 @@ def materials(mesh, options):
 
         logger.info("Compiling attributes for %s", mat.name)
         attributes = {
+            constants.COLOR_EMISSIVE: material.emissive_color(mat),
             constants.SHADING: material.shading(mat),
             constants.OPACITY: material.opacity(mat),
             constants.TRANSPARENT: material.transparent(mat),
@@ -555,12 +556,6 @@ def materials(mesh, options):
         if (use_colors and mix) or (not use_colors):
             colors = material.diffuse_color(mat)
             attributes[constants.COLOR_DIFFUSE] = colors
-
-        if attributes[constants.SHADING] != constants.BASIC:
-            logger.info("Adding emissive attributes")
-            attributes.update({
-                constants.COLOR_EMISSIVE: material.emissive_color(mat),
-            })
 
         if attributes[constants.SHADING] == constants.PHONG:
             logger.info("Adding specular attributes")


### PR DESCRIPTION
for #7627

When you check `shadeless` in Material Pane, it will be published as `BasicMaterial`

![screen shot 2015-11-19 at 6 47 06 am](https://cloud.githubusercontent.com/assets/212837/11256874/63cd214a-8e89-11e5-8aeb-2f65d1cd9a22.png)

the JSON

```
// snip
   "materials": [{
        "DbgName": "Material",
        "visible": true,
        "wireframe": false,
        "transparent": false,
        "blending": "NormalBlending",
        "depthWrite": true,
        "colorDiffuse": [0.64,0,0],
        "shading": "basic",
        "DbgIndex": 0,
// snip
```
