### PR TITLE
Add Support for Reflectivity in Loader.js

### DIFF
--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -240,6 +240,9 @@ THREE.Loader.prototype = {
 						if ( value === true ) json.vertexColors = THREE.VertexColors;
 						if ( value === 'face' ) json.vertexColors = THREE.FaceColors;
 						break;
+					case 'reflectivity':
+                				json.reflectivity = value;
+                        			break;
 					default:
 						console.error( 'THREE.Loader.createMaterial: Unsupported', name, value );
 						break;


### PR DESCRIPTION
Loader will now read and pass reflectivity values present in materials. 

https://github.com/mrdoob/three.js/issues/7632
https://github.com/mrdoob/three.js/issues/7634
