### PR TITLE
Add Support for Reflectivity in Maya Exporter

### DIFF
--- a/utils/exporters/maya/plug-ins/threeJsFileTranslator.py
+++ b/utils/exporters/maya/plug-ins/threeJsFileTranslator.py
@@ -241,6 +241,7 @@ class ThreeJsWriter(object):
             "vertexColors": False
         }
         if isinstance(mat, nodetypes.Phong):
+            result["reflectivity"] = mat.getReflectivity()
             result["colorSpecular"] = mat.getSpecularColor().rgb
             result["specularCoef"] = mat.getCosPower()
             if self.options["specularMaps"]:


### PR DESCRIPTION
Specifically passes the reflectivity value from phong materials. Lambert materials do not have this parameter. 

https://github.com/mrdoob/three.js/issues/7634
https://github.com/mrdoob/three.js/issues/7632
