### PR TITLE
Shader Clean Up

### DIFF
--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -31,16 +31,16 @@ struct GeometricContext {
 };
 
 
-vec3 transformDirection( in vec3 normal, in mat4 matrix ) {
+vec3 transformDirection( in vec3 dir, in mat4 matrix ) {
 
-	return normalize( ( matrix * vec4( normal, 0.0 ) ).xyz );
+	return normalize( ( matrix * vec4( dir, 0.0 ) ).xyz );
 
 }
 
 // http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
-vec3 inverseTransformDirection( in vec3 normal, in mat4 matrix ) {
+vec3 inverseTransformDirection( in vec3 dir, in mat4 matrix ) {
 
-	return normalize( ( vec4( normal, 0.0 ) * matrix ).xyz );
+	return normalize( ( vec4( dir, 0.0 ) * matrix ).xyz );
 
 }
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl
@@ -14,13 +14,15 @@ varying vec3 vViewPosition;
 
 
 struct BlinnPhongMaterial {
+
 	vec3	diffuseColor;
 	vec3	specularColor;
 	float	specularShininess;
 	float	specularStrength;
+
 };
 
-void BlinnPhongMaterial_RE_DirectLight( const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
 
 	float dotNL = saturate( dot( geometry.normal, directLight.direction ) );
 
@@ -31,13 +33,13 @@ void BlinnPhongMaterial_RE_DirectLight( const in IncidentLight directLight, cons
 
 }
 
-void BlinnPhongMaterial_RE_IndirectDiffuseLight( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
 
 	reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
 
 }
 
-#define Material_RE_DirectLight    BlinnPhongMaterial_RE_DirectLight
-#define Material_RE_IndirectDiffuseLight    BlinnPhongMaterial_RE_IndirectDiffuseLight
+#define RE_Direct				RE_Direct_BlinnPhong
+#define RE_IndirectDiffuse		RE_IndirectDiffuse_BlinnPhong
 
-#define Material_LightProbeLOD( material )   (0)
+#define Material_LightProbeLOD( material )	(0)

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_vertex.glsl
@@ -3,9 +3,3 @@
 	varying vec3 vWorldPosition;
 
 #endif
-
-#if NUM_POINT_LIGHTS > 0
-
-	uniform vec3 pointLightPosition[ NUM_POINT_LIGHTS ];
-
-#endif

--- a/src/renderers/shaders/ShaderChunk/lights_standard_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_standard_fragment.glsl
@@ -1,4 +1,4 @@
-PhysicalMaterial material;
+StandardMaterial material;
 material.diffuseColor = diffuseColor.rgb * ( 1.0 - metalnessFactor );
-material.specularRoughness = clamp( roughnessFactor, 0.04, 1.0 ); // disney's remapping of [ 0, 1 ] roughness to [ 0.04, 1 ]
+material.specularRoughness = clamp( roughnessFactor, 0.04, 1.0 );
 material.specularColor = mix( vec3( 0.04 ), diffuseColor.rgb, metalnessFactor );

--- a/src/renderers/shaders/ShaderChunk/lights_standard_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_standard_pars_fragment.glsl
@@ -1,36 +1,37 @@
-struct PhysicalMaterial {
+struct StandardMaterial {
+
 	vec3	diffuseColor;
 	float	specularRoughness;
 	vec3	specularColor;
-	float	clearCoatWeight;
-	float	clearCoatRoughness;
+
 };
 
-void PhysicalMaterial_RE_DirectLight( const in IncidentLight directLight, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_Direct_Standard( const in IncidentLight directLight, const in GeometricContext geometry, const in StandardMaterial material, inout ReflectedLight reflectedLight ) {
 
 	float dotNL = saturate( dot( geometry.normal, directLight.direction ) );
 
 	vec3 irradiance = dotNL * PI * directLight.color; // punctual light
 
 	reflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+
 	reflectedLight.directSpecular += irradiance * BRDF_Specular_GGX( directLight, geometry, material.specularColor, material.specularRoughness );
 
 }
 
-void PhysicalMaterial_RE_DiffuseIndirectLight( const in vec3 irradiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_IndirectDiffuse_Standard( const in vec3 irradiance, const in GeometricContext geometry, const in StandardMaterial material, inout ReflectedLight reflectedLight ) {
 
 	reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
 
 }
 
-void PhysicalMaterial_RE_SpecularIndirectLight( const in vec3 radiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_IndirectSpecular_Standard( const in vec3 radiance, const in GeometricContext geometry, const in StandardMaterial material, inout ReflectedLight reflectedLight ) {
 
 	reflectedLight.indirectSpecular += radiance * BRDF_Specular_GGX_Environment( geometry, material.specularColor, material.specularRoughness );
 
 }
 
-#define Material_RE_DirectLight    PhysicalMaterial_RE_DirectLight
-#define Material_RE_IndirectDiffuseLight    PhysicalMaterial_RE_DiffuseIndirectLight
-#define Material_RE_IndirectSpecularLight    PhysicalMaterial_RE_SpecularIndirectLight
+#define RE_Direct				RE_Direct_Standard
+#define RE_IndirectDiffuse		RE_IndirectDiffuse_Standard
+#define RE_IndirectSpecular		RE_IndirectSpecular_Standard
 
 #define Material_BlinnShininessExponent( material )   GGXRoughnessToBlinnExponent( material.specularRoughness )

--- a/src/renderers/shaders/ShaderChunk/lights_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_template.glsl
@@ -3,8 +3,8 @@
 //   for specific lighting scenarios.
 //
 // Instructions for use:
-//  - Ensure that both Material_RE_DirectLight, Material_RE_IndirectDiffuseLight and Material_RE_IndirectSpecularLight are defined
-//  - If you have defined a Material_RE_IndirectSpecularLight, you need to also provide a Material_LightProbeLOD.
+//  - Ensure that both RE_Direct, RE_IndirectDiffuse and RE_IndirectSpecular are defined
+//  - If you have defined an RE_IndirectSpecular, you need to also provide a Material_LightProbeLOD. <---- ???
 //  - Create a material parameter that is to be passed as the third parameter to your lighting functions.
 //
 // TODO:
@@ -14,11 +14,12 @@
 //
 
 GeometricContext geometry;
-geometry.position = -vViewPosition;
+
+geometry.position = - vViewPosition;
 geometry.normal = normal;
 geometry.viewDir = normalize( vViewPosition );
 
-#if ( NUM_POINT_LIGHTS > 0 ) && defined( Material_RE_DirectLight )
+#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )
 
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
@@ -36,13 +37,13 @@ geometry.viewDir = normalize( vViewPosition );
 		}
 		#endif
 
-		Material_RE_DirectLight( directLight, geometry, material, reflectedLight );
+		RE_Direct( directLight, geometry, material, reflectedLight );
 
 	}
 
 #endif
 
-#if ( NUM_SPOT_LIGHTS > 0 ) && defined( Material_RE_DirectLight )
+#if ( NUM_SPOT_LIGHTS > 0 ) && defined( RE_Direct )
 
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
@@ -60,13 +61,13 @@ geometry.viewDir = normalize( vViewPosition );
 		}
 		#endif
 
-		Material_RE_DirectLight( directLight, geometry, material, reflectedLight );
+		RE_Direct( directLight, geometry, material, reflectedLight );
 
 	}
 
 #endif
 
-#if ( NUM_DIR_LIGHTS > 0 ) && defined( Material_RE_DirectLight )
+#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )
 
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
@@ -84,21 +85,21 @@ geometry.viewDir = normalize( vViewPosition );
 		}
 		#endif
 
-		Material_RE_DirectLight( directLight, geometry, material, reflectedLight );
+		RE_Direct( directLight, geometry, material, reflectedLight );
 
 	}
 
 #endif
 
-#if defined( Material_RE_IndirectDiffuseLight )
+#if defined( RE_IndirectDiffuse )
 
 	{
 
-		vec3 indirectDiffuseIrradiance = getAmbientLightIrradiance( ambientLightColor );
+		vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );
 
 		#ifdef USE_LIGHTMAP
 
-			indirectDiffuseIrradiance += PI * texture2D( lightMap, vUv2 ).xyz * lightMapIntensity; // factor of PI should not be present; included here to prevent breakage
+			irradiance += PI * texture2D( lightMap, vUv2 ).xyz * lightMapIntensity; // factor of PI should not be present; included here to prevent breakage
 
 		#endif
 
@@ -106,7 +107,7 @@ geometry.viewDir = normalize( vViewPosition );
 
 			for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
-				indirectDiffuseIrradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
+				irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
 
 			}
 
@@ -115,24 +116,24 @@ geometry.viewDir = normalize( vViewPosition );
 		// #if defined( USE_ENVMAP ) && defined( STANDARD )
 
 			// TODO, replace 8 with the real maxMIPLevel
-			// indirectDiffuseIrradiance += getLightProbeIndirectIrradiance( /*lightProbe,*/ geometry, 8 ); // comment out until seams are fixed
+			// irradiance += getLightProbeIndirectIrradiance( /*lightProbe,*/ geometry, 8 ); // comment out until seams are fixed
 
 		// #endif
 
-		Material_RE_IndirectDiffuseLight( indirectDiffuseIrradiance, geometry, material, reflectedLight );
+		RE_IndirectDiffuse( irradiance, geometry, material, reflectedLight );
 
 	}
 
 #endif
 
-#if defined( USE_ENVMAP ) && defined( Material_RE_IndirectSpecularLight )
+#if defined( USE_ENVMAP ) && defined( RE_IndirectSpecular )
 
 	{
 
 		// TODO, replace 8 with the real maxMIPLevel
-		vec3 indirectSpecularRadiance = getLightProbeIndirectRadiance( /*specularLightProbe,*/ geometry, Material_BlinnShininessExponent( material ), 8 );
+		vec3 radiance = getLightProbeIndirectRadiance( /*specularLightProbe,*/ geometry, Material_BlinnShininessExponent( material ), 8 );
 
-		Material_RE_IndirectSpecularLight( indirectSpecularRadiance, geometry, material, reflectedLight );
+		RE_IndirectSpecular( radiance, geometry, material, reflectedLight );
 
     }
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -452,7 +452,6 @@ THREE.ShaderLib = {
 			THREE.ShaderChunk[ "uv2_pars_vertex" ],
 			THREE.ShaderChunk[ "displacementmap_pars_vertex" ],
 			THREE.ShaderChunk[ "envmap_pars_vertex" ],
-			THREE.ShaderChunk[ "lights_phong_pars_vertex" ], // use phong chunk for now
 			THREE.ShaderChunk[ "color_pars_vertex" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "skinning_pars_vertex" ],
@@ -489,7 +488,6 @@ THREE.ShaderLib = {
 
 				THREE.ShaderChunk[ "worldpos_vertex" ],
 				THREE.ShaderChunk[ "envmap_vertex" ],
-				THREE.ShaderChunk[ "lights_phong_vertex" ], // use phong chunk for now
 				THREE.ShaderChunk[ "shadowmap_vertex" ],
 
 			"}"


### PR DESCRIPTION
Refactor only.

Renamed struct `PhysicalMaterial` -> `StandardMaterial`, to make way for the future, more advanced, "Physical Material".

Also renamed some of the defines so they all follow the same pattern, and to make the code a bit easier to read.
