### PR TITLE
Fix bug in conversion of BufferedGeometry to Geometry.

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -312,7 +312,7 @@ THREE.Geometry.prototype = {
 
 		} else {
 
-			for ( var i = 0; i < vertices.length / 3; i += 3 ) {
+			for ( var i = 0; i < vertices.length; i += 3 ) {
 
 				addFace( i, i + 1, i + 2 );
 


### PR DESCRIPTION
Minor bug when converting from BufferedGeometry to Geometry.  Instead of creating all of the appropriate faces, one for every triplet of vertices, it was creating one face per vertex for the first third of all vertices and then skipping the rest.
