### PR TITLE
Added removal of buffergeometry from properties

### DIFF
--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -66,6 +66,11 @@ THREE.WebGLGeometries = function ( gl, properties, info ) {
 
 		properties.delete( geometry );
 
+		var bufferproperty = properties.get( buffergeometry );
+		if ( bufferproperty.wireframe ) deleteAttribute( bufferproperty.wireframe );
+
+		properties.delete( buffergeometry );
+
 		info.memory.geometries --;
 
 	}


### PR DESCRIPTION
The BufferGeometry added to properties was never deleted and therefore wireframe objects leaked memory.

Fixes the memory leak reported in #7688
