### PR TITLE
OBJExporter: Fix uv and normal indexes in face values 

### DIFF
--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -120,15 +120,15 @@ THREE.OBJExporter.prototype = {
 				for ( var i = 0, j = 1, l = faces.length; i < l; i ++, j += 3 ) {
 
 					var face = faces[ i ];
+					var indices = [];
 
-					output += 'f ';
-	
 					for ( var m = 0; m < 3; m ++ ) {
-
-						output += ( indexVertex + face[ faceVertexKeys[ m ] ] + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + m + 1 ) : '' ) + '/' + ( indexNormals + j + m + 1 );
-						output += m === 2 ? "\n" : " ";
-
+					
+					    indices[ m ] = ( indexVertex + face[ faceVertexKeys[ m ] ] + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + m + 1 ) : '' ) + '/' + ( indexNormals + j + m + 1 );
+					
 					}
+					
+					output += 'f ' + indices.join( ' ' ) + "\n";
 
 				}
 

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -15,8 +15,8 @@ THREE.OBJExporter.prototype = {
 		var indexVertex = 0;
 		var indexVertexUvs = 0;
 		var indexNormals = 0;
-		
-		var faceVertexKeys = ["a", "b", "c"];
+
+		var faceVertexKeys = [ "a", "b", "c" ];
 
 		var parseMesh = function ( mesh ) {
 
@@ -28,7 +28,7 @@ THREE.OBJExporter.prototype = {
 
 			if ( geometry instanceof THREE.BufferGeometry ) {
 
-				geometry = new THREE.Geometry().fromBufferGeometry(geometry);
+				geometry = new THREE.Geometry().fromBufferGeometry( geometry );
 
 			}
 
@@ -114,18 +114,20 @@ THREE.OBJExporter.prototype = {
 					}
 
 				}
-				
+	
 				// faces
-				
+	
 				for ( var i = 0, j = 1, l = faces.length; i < l; i ++, j += 3 ) {
 
 					var face = faces[ i ];
 
 					output += 'f ';
-					
+	
 					for ( var m = 0; m < 3; m ++ ) {
+
 						output += ( indexVertex + face[ faceVertexKeys[ m ] ] + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + m + 1 ) : '' ) + '/' + ( indexNormals + j + m + 1 );
 						output += m === 2 ? "\n" : " ";
+
 					}
 
 				}

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -117,7 +117,7 @@ THREE.OBJExporter.prototype = {
 
 				// faces
 				var indices = [];
-	
+
 				for ( var i = 0, j = 1, l = faces.length; i < l; i ++, j += 3 ) {
 
 					var face = faces[ i ];

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -121,9 +121,9 @@ THREE.OBJExporter.prototype = {
 					var face = faces[ i ];
 
 					output += 'f ';
-					output += ( indexVertex + face.a + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j     ) : '' ) + '/' + ( indexNormals + j     ) + ' ';
-					output += ( indexVertex + face.b + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + 1 ) : '' ) + '/' + ( indexNormals + j + 1 ) + ' ';
-					output += ( indexVertex + face.c + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + 2 ) : '' ) + '/' + ( indexNormals + j + 2 ) + '\n';
+					output += ( indexVertex + face.a + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + 0 + 1 ) : '' ) + '/' + ( indexNormals + j + 0 + 1 ) + ' ';
+					output += ( indexVertex + face.b + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + 1 + 1 ) : '' ) + '/' + ( indexNormals + j + 1 + 1 ) + ' ';
+					output += ( indexVertex + face.c + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + 2 + 1 ) : '' ) + '/' + ( indexNormals + j + 2 + 1 ) + '\n';
 
 				}
 

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -114,13 +114,13 @@ THREE.OBJExporter.prototype = {
 					}
 
 				}
-	
+
 				// faces
+				var indices = [];
 	
 				for ( var i = 0, j = 1, l = faces.length; i < l; i ++, j += 3 ) {
 
 					var face = faces[ i ];
-					var indices = [];
 
 					for ( var m = 0; m < 3; m ++ ) {
 					

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -15,6 +15,8 @@ THREE.OBJExporter.prototype = {
 		var indexVertex = 0;
 		var indexVertexUvs = 0;
 		var indexNormals = 0;
+		
+		var faceVertexKeys = ["a", "b", "c"];
 
 		var parseMesh = function ( mesh ) {
 
@@ -112,18 +114,19 @@ THREE.OBJExporter.prototype = {
 					}
 
 				}
-
+				
 				// faces
-
-
+				
 				for ( var i = 0, j = 1, l = faces.length; i < l; i ++, j += 3 ) {
 
 					var face = faces[ i ];
 
 					output += 'f ';
-					output += ( indexVertex + face.a + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + 0 + 1 ) : '' ) + '/' + ( indexNormals + j + 0 + 1 ) + ' ';
-					output += ( indexVertex + face.b + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + 1 + 1 ) : '' ) + '/' + ( indexNormals + j + 1 + 1 ) + ' ';
-					output += ( indexVertex + face.c + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + 2 + 1 ) : '' ) + '/' + ( indexNormals + j + 2 + 1 ) + '\n';
+					
+					for ( var m = 0; m < 3; m ++ ) {
+						output += ( indexVertex + face[ faceVertexKeys[ m ] ] + 1 ) + '/' + ( hasVertexUvs ? ( indexVertexUvs + j + m + 1 ) : '' ) + '/' + ( indexNormals + j + m + 1 );
+						output += m === 2 ? "\n" : " ";
+					}
 
 				}
 


### PR DESCRIPTION
Before, only the vertex value was altered to reflect the 1-indexed nature of OBJs. This fixes uvs and normal values as well.

I believe most readers corrected for this (I know Meshlab, Meshmixer, and XCode did), but THREE's OBJLoader itself did not: it complained about trying to access an out-of-index element (`vertexes[0 - 1]`)

This PR also simplifies the creation of the `f v/vt/vn v/vt/vn v/vt/vn\n` line by using a for loop
