### PR TITLE
Warning message for container size

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -96,7 +96,11 @@ THREE.TrackballControls = function ( object, domElement ) {
 			this.screen.top = box.top + window.pageYOffset - d.clientTop;
 			this.screen.width = box.width;
 			this.screen.height = box.height;
+			
 
+		}
+		if(!this.screen.width && !this.screen.height) {
+			console.warn('The width and height of container are both 0. Is the container properly sized?');
 		}
 
 	};


### PR DESCRIPTION
Very minor change to show a warning message when container width and height are both zero (a.k.a the container was hidden when TrackballControl is initialized). This could save hours of debugging time because the Trackball dragging silently breaks if that happens.
