### PR TITLE
Updates all light documentation to use color, not hex

### DIFF
--- a/docs/api/lights/AmbientLight.html
+++ b/docs/api/lights/AmbientLight.html
@@ -25,15 +25,15 @@
 		<div>[example:webgl_animation_cloth animation / cloth ]</div>
 		<div>[example:webgl_animation_skinning_blending animation / skinning / blending ]</div>
 		
-<code>var light = new THREE.AmbientLight( 0x404040 ); // soft white light
+<code>var light = new THREE.AmbientLight( new THREE.Color( 0.3, 0.3, 0.3 ) ); // soft white light
 scene.add( light );</code>
 
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Integer hex] )</h3>
+		<h3>[name]( [page:Color color] )</h3>
 		<div>
-		[page:Integer hex] — Numeric value of the RGB component of the color.
+		[page:Color color] -- The color of the light. Can be a THREE.Color or any value accepted by the [page:Color THREE.Color] constructor.<br />
 		</div>
 		<div>
 		This creates an Ambientlight with a color.

--- a/docs/api/lights/DirectionalLight.html
+++ b/docs/api/lights/DirectionalLight.html
@@ -30,7 +30,7 @@
 
 		<code>// White directional light at half intensity shining from the top.
 
-var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.5 );
+var directionalLight = new THREE.DirectionalLight( new THREE.Color( 1, 1, 1 ), 0.5 );
 directionalLight.position.set( 0, 1, 0 );
 scene.add( directionalLight );</code>
 
@@ -38,9 +38,9 @@ scene.add( directionalLight );</code>
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Integer hex], [page:Float intensity])</h3>
+		<h3>[name]([page:Color color], [page:Float intensity])</h3>
 		<div>
-		[page:Integer hex] -- Numeric value of the RGB component of the color. <br />
+		[page:Color color] -- The color of the light. Can be a THREE.Color or any value accepted by the [page:Color THREE.Color] constructor.<br />
 		[page:Float intensity] -- Numeric value of the light's strength/intensity.
 		</div>
 		<div>

--- a/docs/api/lights/HemisphereLight.html
+++ b/docs/api/lights/HemisphereLight.html
@@ -23,22 +23,23 @@
 		<div>[example:webgl_materials_lightmap materials / lightmap ]</div>
 		<div>[example:webgl_shaders_ocean shaders / ocean ]</div>
 		
-<code>var light = new THREE.HemisphereLight( 0xffffbb, 0x080820, 1 );
+<code>var light = new THREE.HemisphereLight( new THREE.Color( 1, 1, 0.8 ), new THREE.Color( 0.4, 0.4, 0.2 ), 1 );
 scene.add( light );</code>
 
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Integer skyColorHex], [page:Integer groundColorHex], [page:Float intensity])</h3>
+		<h3>[name]([page:Color skyColor], [page:Integer groundColor], [page:Float intensity])</h3>
         <div>
-		[page:Integer skyColorHex] — Numeric value of the RGB sky color.<br />
-		[page:Integer groundColorHex] — Numeric value of the RGB ground color.<br />
+		[page:Color skyColor] -- The color of the sky. Can be a THREE.Color or any value accepted by the [page:Color THREE.Color] constructor.<br />
+
+		[page:Color groundColor] -- The color of the sky. Can be a THREE.Color or any value accepted by the [page:Color THREE.Color] constructor.<br />
 		[page:Float intensity] — Numeric value of the light's strength/intensity.
 		</div>
 
 		<h2>Properties</h2>
 
-		<h3>[property:Float groundColor]</h3>
+		<h3>[property:Color groundColor]</h3>
 
 		<div>
 			Light's ground color.<br />

--- a/docs/api/lights/Light.html
+++ b/docs/api/lights/Light.html
@@ -18,9 +18,9 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Integer hex] )</h3>
+		<h3>[name]( [page:Color color] )</h3>
 		<div>
-		[page:Integer hex] — Numeric value of the RGB component of the color.
+		[page:Color color] -- The color of the light. Can be a THREE.Color or any value accepted by the [page:Color THREE.Color] constructor.<br />
 		</div>
 		<div>
 		This creates a light with color.<br />

--- a/docs/api/lights/PointLight.html
+++ b/docs/api/lights/PointLight.html
@@ -29,7 +29,7 @@
 		<div>[example:webgl_geometry_text geometry / text ]</div>
 		<div>[example:webgl_lensflares lensflares ]</div>
 		
-		<code>var light = new THREE.PointLight( 0xff0000, 1, 100 );
+		<code>var light = new THREE.PointLight( new THREE.Color( 1, 0 0 ), 1, 100 );
 light.position.set( 50, 50, 50 );
 scene.add( light );</code>
 
@@ -37,9 +37,9 @@ scene.add( light );</code>
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Integer hex], [page:Float intensity], [page:Number distance], [page:Float decay])</h3>
+		<h3>[name]([page:Color color], [page:Float intensity], [page:Number distance], [page:Float decay])</h3>
 		<div>
-		[page:Integer hex] — Numeric value of the RGB component of the color. <br />
+        [page:Color color] -- The color of the light. Can be a THREE.Color or any value accepted by the [page:Color THREE.Color] constructor.<br />
 		[page:Float intensity] — Numeric value of the light's strength/intensity. <br />
 		[page:Number distance] -- The distance of the light where the intensity is 0. When distance is 0, then the distance is endless. <br />
 		[page:Float decay] -- The amount the light dims along the distance of the light.

--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -28,7 +28,7 @@
 		<code>
 		// white spotlight shining from the side, casting shadow
 
-		var spotLight = new THREE.SpotLight( 0xffffff );
+		var spotLight = new THREE.SpotLight( new THREE.Color( 1, 1, 1 ) );
 		spotLight.position.set( 100, 1000, 100 );
 
 		spotLight.castShadow = true;
@@ -55,9 +55,9 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Integer hex], [page:Float intensity], [page:Float distance], [page:Radians angle], [page:Float exponent], [page:Float decay])</h3>
+		<h3>[name]([page:Integer color], [page:Float intensity], [page:Float distance], [page:Radians angle], [page:Float exponent], [page:Float decay])</h3>
 		<div>
-		[page:Integer hex] — Numeric value of the RGB component of the color. <br />
+		[page:Color color] -- The color of the light. Can be a THREE.Color or any value accepted by the [page:Color THREE.Color] constructor.<br />
 		[page:Float intensity] — Numeric value of the light's strength/intensity. <br />
 		[page:Float distance] -- Maximum distance from origin where light will shine whose intensity is attenuated linearly based on distance from origin. <br />
 		[page:Radians angle] -- Maximum angle of light dispersion from its direction whose upper bound is Math.PI/2.<br />


### PR DESCRIPTION
Addresses #7707. It's confusing to have a Color data type but then tell
users they can only use a primitive value that _represets_ a Color, even
though it's converted to a Color under the hood.

Note that the Material API still encourages the use of hex, which should
also be updated for consistency.
