### PR TITLE
Add missing self variable if not defined and when running under node environment

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -14,6 +14,14 @@ if ( typeof define === 'function' && define.amd ) {
 
 	module.exports = THREE;
 
+	// detects wheather self is not defined and uses global in node environment
+	if ( typeof self === 'undefined' ) {
+
+		// self gets hoisted!
+		var self = global;
+
+	}
+
 }
 
 


### PR DESCRIPTION
Hi,

I'm writing an application with node which runs on console (so not in the browser) and therefore self is not defined when importing three as a module. We currently using npm from @bhouston which contains a self fix but shouldn't work for BufferGeometryLoader. To make sure three runs under a node environment, I set self to global and hoist it so it's globally available. This fix works for me in the browser and in the node environment. Any concerns ?
