### PR TITLE
Make the default lid properly-sized

### DIFF
--- a/examples/js/geometries/TeapotBufferGeometry.js
+++ b/examples/js/geometries/TeapotBufferGeometry.js
@@ -415,8 +415,8 @@ THREE.TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLi
 	lid = lid === undefined ? true : lid;
 	body = body === undefined ? true : body;
 
-	// Should the lid be snug? It's not traditional, so off by default
-	fitLid = fitLid === undefined ? false : fitLid;
+	// Should the lid be snug? It's not traditional, but we make it snug by default
+	fitLid = fitLid === undefined ? true : fitLid;
 
 	// Jim Blinn scaled the teapot down in size by about 1.3 for
 	// some rendering tests. He liked the new proportions that he kept


### PR DESCRIPTION
Make the default args all `true` by default. The properly-sized lid looks better, no?
