### PR TITLE
Removing uuid assumption from MaterialLoader.parse() but on the dev b…

### DIFF
--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -49,7 +49,11 @@ THREE.MaterialLoader.prototype = {
 	parse: function ( json ) {
 
 		var material = new THREE[ json.type ];
-		material.uuid = json.uuid;
+		if ( json.uuid !== undefined) {
+			material.uuid = json.uuid;
+		} else {
+			material.uuid = THREE.Math.generateUUID();
+		}
 
 		if ( json.name !== undefined ) material.name = json.name;
 		if ( json.color !== undefined ) material.color.setHex( json.color );


### PR DESCRIPTION
…ranch this time.

Currently, the MaterialLoader.parse() method assumes that the incoming JSON object will have a UUID set. If, however, the JSON object does not contain this value, materials will be generated with a UUID of 'undefined'.

In some situations, because of the way shader uniforms are handled for material shaders, an undefined UUID can cause unexpected behavior (multiple objects with the same appearance) or errors (such as where the WebGLProperties.get function uses object.uuid to pass through the list of uniforms to the shader program).

This fix drops this assumption and generates a true UUID using the same generator as the standard Materials constructor, THREE.Math.generateUUID()

Test scene for this is here:
http://codepen.io/JamesHagerman/pen/xZGMmo
