### PR TITLE
Removed inexistent AdditiveAlphaBlending mode

### DIFF
--- a/examples/webgl_materials_blending.html
+++ b/examples/webgl_materials_blending.html
@@ -72,7 +72,7 @@
 
 				// OBJECTS
 
-				var blendings = [ "NoBlending", "NormalBlending", "AdditiveBlending", "SubtractiveBlending", "MultiplyBlending", "AdditiveAlphaBlending" ];
+				var blendings = [ "NoBlending", "NormalBlending", "AdditiveBlending", "SubtractiveBlending", "MultiplyBlending" ];
 
 				var map0 = THREE.ImageUtils.loadTexture( 'textures/UV_Grid_Sm.jpg' );
 				var map1 = THREE.ImageUtils.loadTexture( 'textures/sprite0.jpg' );

--- a/examples/webgl_materials_blending_custom.html
+++ b/examples/webgl_materials_blending_custom.html
@@ -202,7 +202,7 @@
 
 				// FOREGROUND OBJECTS
 
-				var blendings = [ "NoBlending", "NormalBlending", "AdditiveBlending", "SubtractiveBlending", "MultiplyBlending", "AdditiveAlphaBlending" ];
+				var blendings = [ "NoBlending", "NormalBlending", "AdditiveBlending", "SubtractiveBlending", "MultiplyBlending" ];
 
 				var src = [ "ZeroFactor", "OneFactor", "SrcAlphaFactor", "OneMinusSrcAlphaFactor", "DstAlphaFactor", "OneMinusDstAlphaFactor", "DstColorFactor", "OneMinusDstColorFactor", "SrcAlphaSaturateFactor" ];
 				var dst = [ "ZeroFactor", "OneFactor", "SrcColorFactor", "OneMinusSrcColorFactor", "SrcAlphaFactor", "OneMinusSrcAlphaFactor", "DstAlphaFactor", "OneMinusDstAlphaFactor" ];


### PR DESCRIPTION
Removed inexistent AdditiveAlphaBlending mode from the examples:
- examples/webgl_materials_blending.html
- examples/webgl_materials_blending_custom.html
