### PR TITLE
OBJLoader now reports unknown lines

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -20,7 +20,7 @@ THREE.OBJLoader.prototype = {
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.load( url, function ( text ) {
 
-			onLoad( scope.parse( text ) );
+			onLoad( scope.parse( text, onError ) );
 
 		}, onProgress, onError );
 
@@ -32,7 +32,7 @@ THREE.OBJLoader.prototype = {
 
 	},
 
-	parse: function ( text ) {
+	parse: function ( text, onError ) {
 
 		console.time( 'OBJLoader' );
 
@@ -334,7 +334,7 @@ THREE.OBJLoader.prototype = {
 
 			} else {
 
-				// console.log( "THREE.OBJLoader: Unhandled line " + line );
+				onError( "THREE.OBJLoader: Unhandled line: " + line );
 
 			}
 


### PR DESCRIPTION
Now the OBJLoader reports unknown lines via the `onError` function. This
allows apps to either display the error for building robust apps, or
just ignore it if you don't care for some reason.
