### PR TITLE
LoadingManager: add a mechanism to allow non-fatal loading errors

### DIFF
--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -6,8 +6,10 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 
 	var scope = this;
 
-	var isLoading = false, itemsLoaded = 0, itemsTotal = 0;
+	var isLoading = false, itemsLoaded = 0, itemsFailed = 0, itemsTotal = 0;
 
+	this.allowErrors = false;
+	
 	this.onStart = undefined;
 	this.onLoad = onLoad;
 	this.onProgress = onProgress;
@@ -31,6 +33,27 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 
 	};
 
+	function onItemDone () {
+
+		if ( itemsLoaded + itemsFailed === itemsTotal ) {
+
+			isLoading = false;
+
+			if ( itemsFailed === 0 || scope.allowErrors ) {
+
+				if ( scope.onLoad !== undefined ) {
+
+					scope.onLoad();
+
+				}
+
+			}
+
+
+		}
+
+	}
+
 	this.itemEnd = function ( url ) {
 
 		itemsLoaded ++;
@@ -41,27 +64,27 @@ THREE.LoadingManager = function ( onLoad, onProgress, onError ) {
 
 		}
 
-		if ( itemsLoaded === itemsTotal ) {
-
-			isLoading = false;
-
-			if ( scope.onLoad !== undefined ) {
-
-				scope.onLoad();
-
-			}
-
-		}
+		onItemDone();
 
 	};
 
 	this.itemError = function ( url ) {
+
+		itemsFailed ++;
 
 		if ( scope.onError !== undefined ) {
 
 			scope.onError( url );
 
 		}
+
+		onItemDone();
+
+	};
+
+	this.setAllowErrors = function ( allowErrors ) {
+
+		this.allowErrors = allowErrors;
 
 	};
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -342,13 +342,18 @@ THREE.ObjectLoader.prototype = {
 
 				scope.manager.itemEnd( url );
 
-			} );
+			}, undefined, function() {
+			
+				scope.manager.itemError( url );
+
+			});
 
 		}
 
 		if ( json !== undefined && json.length > 0 ) {
 
 			var manager = new THREE.LoadingManager( onLoad );
+			manager.setAllowErrors(true);
 
 			var loader = new THREE.ImageLoader( manager );
 			loader.setCrossOrigin( this.crossOrigin );


### PR DESCRIPTION
Currently, if THREE.ObjectLoader fails to load a single texture, neither success or failure is reported back to the caller. This change adds a mechanism to report errors and to allow onLoad() still be called when done with all items, even if there are errors, if the errors are non-fatal.
