### PR TITLE
OBJLoader now optionally reports unknown lines

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -14,7 +14,7 @@ THREE.OBJLoader.prototype = {
 
 	constructor: THREE.OBJLoader,
 
-	load: function ( url, onLoad, onProgress, onError, onParseFail ) {
+	load: function ( url, onLoad, onProgress, onError, onWarning ) {
 
 		var scope = this;
 
@@ -22,7 +22,7 @@ THREE.OBJLoader.prototype = {
 		loader.setPath( this.path );
 		loader.load( url, function ( text ) {
 
-			onLoad( scope.parse( text, onParseFail || onError ) );
+			onLoad( scope.parse( text, onWarning ) );
 
 		}, onProgress, onError );
 
@@ -40,7 +40,7 @@ THREE.OBJLoader.prototype = {
 
 	},
 
-	parse: function ( text, onParseFail ) {
+	parse: function ( text, onWarning ) {
 
 		console.time( 'OBJLoader' );
 
@@ -337,7 +337,11 @@ THREE.OBJLoader.prototype = {
 
 			} else {
 				
-				onParseFail("THREE.OBJLoader: Unknown line", line)
+				if (onWarning) {
+
+					onWarning("THREE.OBJLoader: Unknown line", line)
+
+				}
 
 			}
 

--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -14,7 +14,7 @@ THREE.OBJLoader.prototype = {
 
 	constructor: THREE.OBJLoader,
 
-	load: function ( url, onLoad, onProgress, onError ) {
+	load: function ( url, onLoad, onProgress, onError, onParseFail ) {
 
 		var scope = this;
 
@@ -22,7 +22,7 @@ THREE.OBJLoader.prototype = {
 		loader.setPath( this.path );
 		loader.load( url, function ( text ) {
 
-			onLoad( scope.parse( text ) );
+			onLoad( scope.parse( text, onParseFail || onError ) );
 
 		}, onProgress, onError );
 
@@ -40,7 +40,7 @@ THREE.OBJLoader.prototype = {
 
 	},
 
-	parse: function ( text ) {
+	parse: function ( text, onParseFail ) {
 
 		console.time( 'OBJLoader' );
 
@@ -336,8 +336,8 @@ THREE.OBJLoader.prototype = {
 				object.material.smooth = result[ 1 ] === "1" || result[ 1 ] === "on";
 
 			} else {
-
-				// console.log( "THREE.OBJLoader: Unhandled line " + line );
+				
+				onParseFail("THREE.OBJLoader: Unknown line", line)
 
 			}
 


### PR DESCRIPTION
Now the OBJLoader reports unknown lines via the `onParseFail` function. This
allows apps to either display the error for building robust apps, or
just ignore it if you don't care for some reason. Default is to use the `onError` function to report parsing error as well to keep things simple.
