### PR TITLE
Add "colorWrite" to material copy method

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -257,6 +257,8 @@ THREE.Material.prototype = {
 		this.depthTest = source.depthTest;
 		this.depthWrite = source.depthWrite;
 
+		this.colorWrite = source.colorWrite;
+
 		this.precision = source.precision;
 
 		this.polygonOffset = source.polygonOffset;


### PR DESCRIPTION
The `copy` method of the `Material` prototype does not take the `colorWrite` property into account. This PR changes this circumstance so the property is part of the copy.
