### PR TITLE
add stencil properties to material

### DIFF
--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -229,6 +229,8 @@ THREE.Loader.prototype = {
 						break;
 					case 'depthTest':
 					case 'depthWrite':
+					case 'stencilTest':
+					case 'stencilWrite':
 					case 'colorWrite':
 					case 'opacity':
 					case 'reflectivity':

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -70,6 +70,8 @@ THREE.MaterialLoader.prototype = {
 		if ( json.alphaTest !== undefined ) material.alphaTest = json.alphaTest;
 		if ( json.depthTest !== undefined ) material.depthTest = json.depthTest;
 		if ( json.depthWrite !== undefined ) material.depthWrite = json.depthWrite;
+		if ( json.stencilTest !== undefined ) material.stencilTest = json.stencilTest;
+		if ( json.stencilWrite !== undefined ) material.stencilWrite = json.stencilWrite;
 		if ( json.colorWrite !== undefined ) material.colorWrite = json.colorWrite;
 		if ( json.wireframe !== undefined ) material.wireframe = json.wireframe;
 		if ( json.wireframeLinewidth !== undefined ) material.wireframeLinewidth = json.wireframeLinewidth;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -30,6 +30,9 @@ THREE.Material = function () {
 	this.depthTest = true;
 	this.depthWrite = true;
 
+	this.stencilTest = false;
+	this.stencilWrite = false;
+
 	this.colorWrite = true;
 
 	this.precision = null; // override the renderer's default precision for this material
@@ -256,6 +259,9 @@ THREE.Material.prototype = {
 		this.depthFunc = source.depthFunc;
 		this.depthTest = source.depthTest;
 		this.depthWrite = source.depthWrite;
+
+		this.stencilTest = source.stencilTest;
+		this.stencilWrite = source.stencilWrite;
 
 		this.colorWrite = source.colorWrite;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1191,10 +1191,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		// Ensure depth buffer writing is enabled so it can be cleared on next render
+		// Ensure buffer writing is enabled so they can be cleared on next render
 
 		state.setDepthTest( true );
 		state.setDepthWrite( true );
+		state.setStencilTest( true );
+		state.setStencilWrite( true );
 		state.setColorWrite( true );
 
 		// _gl.finish();
@@ -1557,6 +1559,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 		state.setDepthFunc( material.depthFunc );
 		state.setDepthTest( material.depthTest );
 		state.setDepthWrite( material.depthWrite );
+		state.setStencilTest( material.stencilTest );
+		state.setStencilWrite( material.stencilWrite );
 		state.setColorWrite( material.colorWrite );
 		state.setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -627,6 +627,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 		currentBlending = null;
 
 		currentDepthWrite = null;
+		currentStencilWrite = null;
 		currentColorWrite = null;
 
 		currentFlipSided = null;


### PR DESCRIPTION
Hi everyone,

the PR #7816 provided a basic interface to work with the stencil buffer in three.js. This PR expands the `Material` prototype by two additional properties `stencilWrite` and `stencilTest`. These properties can be used to control which objects should be written to the stencil buffer and handled by the stencil test.

Please have a look at this testfile: [jsfiddle](http://jsfiddle.net/tmyhemfo/4/)

The default value of `stencilWrite` and `stencilTest` is `false`.

If you want to write a shape to the stencil buffer for testing (e.g. the surface of a mirror or window), you can code this:

``` javascript
new THREE.MeshBasicMaterial( { colorWrite: false, depthWrite: false, stencilWrite: true, stencilTest: true } );
```

If objects should take the stencil test, you just set:

``` javascript
new THREE.MeshBasicMaterial( { stencilTest: true } );
```

`stencilWrite` and `stencilTest` simplify the handling with the stencil buffer without doing big changes to the library (just 16 additions, 1 deletion). Users only need to ensure that the correct data are already in the stencil buffer for testing ( see method `updateStencilBuffer` in testfile). The rest can be configured via the new `Material`properties.
