### PR TITLE
NodeMaterial improvements

### DIFF
--- a/examples/js/nodes/BuilderNode.js
+++ b/examples/js/nodes/BuilderNode.js
@@ -68,7 +68,7 @@ THREE.BuilderNode.prototype = {
 
 	},
 
-	getFormat : function( format ) {
+	getFormatName : function( format ) {
 
 		return format.replace( 'c', 'v3' ).replace( /fv1|iv1/, 'v1' );
 
@@ -76,7 +76,7 @@ THREE.BuilderNode.prototype = {
 
 	getFormatLength : function( format ) {
 
-		return parseInt( this.getFormat( format ).substr( 1 ) );
+		return parseInt( this.getFormatName( format ).substr( 1 ) );
 
 	},
 
@@ -90,7 +90,7 @@ THREE.BuilderNode.prototype = {
 
 	format : function( code, from, to ) {
 
-		var format = this.getFormat( from + '=' + to );
+		var format = this.getFormatName( from + '=' + to );
 
 		switch ( format ) {
 			case 'v1=v2': return 'vec2(' + code + ')';

--- a/examples/js/nodes/BuilderNode.js
+++ b/examples/js/nodes/BuilderNode.js
@@ -136,7 +136,7 @@ THREE.BuilderNode.prototype = {
 
 	},
 
-	getElementIndex : function( elm ) {
+	getIndexByElement : function( elm ) {
 
 		return THREE.BuilderNode.elements.indexOf( elm );
 

--- a/examples/js/nodes/NodeLib.js
+++ b/examples/js/nodes/NodeLib.js
@@ -56,7 +56,7 @@ THREE.NodeLib.add( new THREE.FunctionNode( [
 THREE.NodeLib.add( new THREE.FunctionNode( [
 // Per-Pixel Tangent Space Normal Mapping
 // http://hacksoflife.blogspot.ch/2009/11/per-pixel-tangent-space-normal-mapping.html
-"vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 map, vec2 mUv, float scale ) {",
+"vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 map, vec2 mUv, vec2 scale ) {",
 	"vec3 q0 = dFdx( eye_pos );",
 	"vec3 q1 = dFdy( eye_pos );",
 	"vec2 st0 = dFdx( mUv.st );",

--- a/examples/js/nodes/materials/PhongNode.js
+++ b/examples/js/nodes/materials/PhongNode.js
@@ -114,7 +114,7 @@ THREE.PhongNode.prototype.build = function( builder ) {
 		if ( this.normalScale && this.normal ) this.normalScale.verify( builder );
 
 		if ( this.environment ) this.environment.verify( builder );
-		if ( this.environmentAlpha && this.environment ) this.environmentAlpha.verify( builder );
+		if ( this.environmentIntensity && this.environment ) this.environmentIntensity.verify( builder );
 
 		// build code
 
@@ -133,7 +133,7 @@ THREE.PhongNode.prototype.build = function( builder ) {
 		var normalScale = this.normalScale && this.normal ? this.normalScale.buildCode( builder, 'v2' ) : undefined;
 
 		var environment = this.environment ? this.environment.buildCode( builder, 'c' ) : undefined;
-		var environmentAlpha = this.environmentAlpha && this.environment ? this.environmentAlpha.buildCode( builder, 'fv1' ) : undefined;
+		var environmentIntensity = this.environmentIntensity && this.environment ? this.environmentIntensity.buildCode( builder, 'fv1' ) : undefined;
 
 		material.requestAttrib.transparent = alpha != undefined;
 
@@ -236,11 +236,11 @@ THREE.PhongNode.prototype.build = function( builder ) {
 
 			output.push( environment.code );
 
-			if ( environmentAlpha ) {
+			if ( environmentIntensity ) {
 
-				output.push( environmentAlpha.code );
+				output.push( environmentIntensity.code );
 
-				output.push( "outgoingLight = mix(" + 'outgoingLight' + "," + environment.result + "," + environmentAlpha.result + ");" );
+				output.push( "outgoingLight = mix(" + 'outgoingLight' + "," + environment.result + "," + environmentIntensity.result + ");" );
 
 			}
 			else {

--- a/examples/js/nodes/materials/PhongNode.js
+++ b/examples/js/nodes/materials/PhongNode.js
@@ -32,6 +32,7 @@ THREE.PhongNode.prototype.build = function( builder ) {
 		material.mergeUniform( THREE.UniformsUtils.merge( [
 
 			THREE.UniformsLib[ "fog" ],
+			THREE.UniformsLib[ "ambient" ],
 			THREE.UniformsLib[ "lights" ],
 			THREE.UniformsLib[ "shadowmap" ]
 
@@ -113,7 +114,7 @@ THREE.PhongNode.prototype.build = function( builder ) {
 		if ( this.normalScale && this.normal ) this.normalScale.verify( builder );
 
 		if ( this.environment ) this.environment.verify( builder );
-		if ( this.reflectivity && this.environment ) this.reflectivity.verify( builder );
+		if ( this.environmentAlpha && this.environment ) this.environmentAlpha.verify( builder );
 
 		// build code
 
@@ -129,10 +130,10 @@ THREE.PhongNode.prototype.build = function( builder ) {
 		var emissive = this.emissive ? this.emissive.buildCode( builder, 'c' ) : undefined;
 
 		var normal = this.normal ? this.normal.buildCode( builder, 'v3' ) : undefined;
-		var normalScale = this.normalScale && this.normal ? this.normalScale.buildCode( builder, 'fv1' ) : undefined;
+		var normalScale = this.normalScale && this.normal ? this.normalScale.buildCode( builder, 'v2' ) : undefined;
 
 		var environment = this.environment ? this.environment.buildCode( builder, 'c' ) : undefined;
-		var reflectivity = this.reflectivity && this.environment ? this.reflectivity.buildCode( builder, 'fv1' ) : undefined;
+		var environmentAlpha = this.environmentAlpha && this.environment ? this.environmentAlpha.buildCode( builder, 'fv1' ) : undefined;
 
 		material.requestAttrib.transparent = alpha != undefined;
 
@@ -140,6 +141,7 @@ THREE.PhongNode.prototype.build = function( builder ) {
 			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
 			THREE.ShaderChunk[ "bsdfs" ],
+			THREE.ShaderChunk[ "ambient_pars" ],
 			THREE.ShaderChunk[ "lights_pars" ],
 			THREE.ShaderChunk[ "lights_phong_pars_fragment" ],
 			THREE.ShaderChunk[ "shadowmap_pars_fragment" ],
@@ -186,7 +188,7 @@ THREE.PhongNode.prototype.build = function( builder ) {
 				'normal = perturbNormal2Arb(-vViewPosition,normal,' +
 				normal.result + ',' +
 				new THREE.UVNode().build( builder, 'v2' ) + ',' +
-				( normalScale ? normalScale.result : '1.0' ) + ');'
+				( normalScale ? normalScale.result : 'vec2( 1.0 )' ) + ');'
 			);
 
 		}
@@ -234,11 +236,11 @@ THREE.PhongNode.prototype.build = function( builder ) {
 
 			output.push( environment.code );
 
-			if ( reflectivity ) {
+			if ( environmentAlpha ) {
 
-				output.push( reflectivity.code );
+				output.push( environmentAlpha.code );
 
-				output.push( "outgoingLight = mix(" + 'outgoingLight' + "," + environment.result + "," + reflectivity.result + ");" );
+				output.push( "outgoingLight = mix(" + 'outgoingLight' + "," + environment.result + "," + environmentAlpha.result + ");" );
 
 			}
 			else {

--- a/examples/js/nodes/materials/PhongNodeMaterial.js
+++ b/examples/js/nodes/materials/PhongNodeMaterial.js
@@ -14,4 +14,4 @@ THREE.PhongNodeMaterial.prototype = Object.create( THREE.NodeMaterial.prototype 
 THREE.PhongNodeMaterial.prototype.constructor = THREE.PhongNodeMaterial;
 
 THREE.NodeMaterial.Shortcuts( THREE.PhongNodeMaterial.prototype, 'node',
-[ 'color', 'alpha', 'specular', 'shininess', 'normal', 'normalScale', 'emissive', 'ambient', 'shadow', 'ao', 'environment', 'reflectivity', 'transform' ] );
+[ 'color', 'alpha', 'specular', 'shininess', 'normal', 'normalScale', 'emissive', 'ambient', 'shadow', 'ao', 'environment', 'environmentAlpha', 'transform' ] );

--- a/examples/js/nodes/materials/PhongNodeMaterial.js
+++ b/examples/js/nodes/materials/PhongNodeMaterial.js
@@ -14,4 +14,4 @@ THREE.PhongNodeMaterial.prototype = Object.create( THREE.NodeMaterial.prototype 
 THREE.PhongNodeMaterial.prototype.constructor = THREE.PhongNodeMaterial;
 
 THREE.NodeMaterial.Shortcuts( THREE.PhongNodeMaterial.prototype, 'node',
-[ 'color', 'alpha', 'specular', 'shininess', 'normal', 'normalScale', 'emissive', 'ambient', 'shadow', 'ao', 'environment', 'environmentAlpha', 'transform' ] );
+[ 'color', 'alpha', 'specular', 'shininess', 'normal', 'normalScale', 'emissive', 'ambient', 'shadow', 'ao', 'environment', 'environmentIntensity', 'transform' ] );

--- a/examples/js/nodes/materials/StandardNode.js
+++ b/examples/js/nodes/materials/StandardNode.js
@@ -120,7 +120,7 @@ THREE.StandardNode.prototype.build = function( builder ) {
 		if ( this.normalScale && this.normal ) this.normalScale.verify( builder );
 
 		if ( this.environment ) this.environment.verify( builder, 'env', requires ); // isolate environment from others inputs ( see TextureNode, CubeTextureNode )
-		if ( this.environmentAlpha && this.environment ) this.environmentAlpha.verify( builder );
+		if ( this.environmentIntensity && this.environment ) this.environmentIntensity.verify( builder );
 
 		// build code
 
@@ -139,7 +139,7 @@ THREE.StandardNode.prototype.build = function( builder ) {
 		var normalScale = this.normalScale && this.normal ? this.normalScale.buildCode( builder, 'v2' ) : undefined;
 
 		var environment = this.environment ? this.environment.buildCode( builder, 'c', 'env', requires ) : undefined;
-		var environmentAlpha = this.environmentAlpha && this.environment ? this.environmentAlpha.buildCode( builder, 'fv1' ) : undefined;
+		var environmentIntensity = this.environmentIntensity && this.environment ? this.environmentIntensity.buildCode( builder, 'fv1' ) : undefined;
 
 		material.requestAttrib.transparent = alpha != undefined;
 
@@ -254,10 +254,10 @@ THREE.StandardNode.prototype.build = function( builder ) {
 			output.push( environment.code );
 			output.push( "RE_IndirectSpecular(" + environment.result + ", geometry, material, reflectedLight );" );
 
-			if ( environmentAlpha ) {
+			if ( environmentIntensity ) {
 
-				output.push( environmentAlpha.code );
-				output.push( "reflectedLight.indirectSpecular *= " + environmentAlpha.result + ";" );
+				output.push( environmentIntensity.code );
+				output.push( "reflectedLight.indirectSpecular *= " + environmentIntensity.result + ";" );
 
 			}
 

--- a/examples/js/nodes/materials/StandardNodeMaterial.js
+++ b/examples/js/nodes/materials/StandardNodeMaterial.js
@@ -14,4 +14,4 @@ THREE.StandardNodeMaterial.prototype = Object.create( THREE.NodeMaterial.prototy
 THREE.StandardNodeMaterial.prototype.constructor = THREE.StandardNodeMaterial;
 
 THREE.NodeMaterial.Shortcuts( THREE.StandardNodeMaterial.prototype, 'node',
-[ 'color', 'alpha', 'roughness', 'metalness', 'normal', 'normalScale', 'emissive', 'ambient', 'shadow', 'ao', 'environment', 'environmentAlpha', 'transform' ] );
+[ 'color', 'alpha', 'roughness', 'metalness', 'normal', 'normalScale', 'emissive', 'ambient', 'shadow', 'ao', 'environment', 'environmentIntensity', 'transform' ] );

--- a/examples/js/nodes/materials/StandardNodeMaterial.js
+++ b/examples/js/nodes/materials/StandardNodeMaterial.js
@@ -14,4 +14,4 @@ THREE.StandardNodeMaterial.prototype = Object.create( THREE.NodeMaterial.prototy
 THREE.StandardNodeMaterial.prototype.constructor = THREE.StandardNodeMaterial;
 
 THREE.NodeMaterial.Shortcuts( THREE.StandardNodeMaterial.prototype, 'node',
-[ 'color', 'alpha', 'roughness', 'metalness', 'normal', 'normalScale', 'emissive', 'ambient', 'shadow', 'ao', 'environment', 'reflectivity', 'transform' ] );
+[ 'color', 'alpha', 'roughness', 'metalness', 'normal', 'normalScale', 'emissive', 'ambient', 'shadow', 'ao', 'environment', 'environmentAlpha', 'transform' ] );

--- a/examples/js/nodes/utils/SwitchNode.js
+++ b/examples/js/nodes/utils/SwitchNode.js
@@ -36,7 +36,7 @@ THREE.SwitchNode.prototype.generate = function( builder, output ) {
 
 	for ( i = 0; i < len; i ++ ) {
 
-		outputLength = Math.max( outputLength, builder.getElementIndex( this.component.charAt( i ) ) );
+		outputLength = Math.max( outputLength, builder.getIndexByElement( this.component.charAt( i ) ) );
 
 	}
 
@@ -49,7 +49,7 @@ THREE.SwitchNode.prototype.generate = function( builder, output ) {
 	for ( i = 0; i < len; i ++ ) {
 
 		var elm = this.component.charAt( i );
-		var idx = builder.getElementIndex( this.component.charAt( i ) );
+		var idx = builder.getIndexByElement( this.component.charAt( i ) );
 
 		if ( idx > outputLength ) idx = outputLength;
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -273,7 +273,7 @@
 					//mtl.shadow = // shadowmap
 					//mtl.ao = // ambient occlusion
 					//mtl.environment = // reflection map (CubeMap recommended)
-					//mtl.reflectivity = // environment intensity
+					//mtl.environmentAlpha = // environment alpha
 					//mtl.transform = // vertex transformation
 
 					var mask = new THREE.SwitchNode( new THREE.TextureNode( decalDiffuse ), 'w' );
@@ -282,7 +282,7 @@
 					mtl.specular = new THREE.FloatNode( .5 );
 					mtl.shininess = new THREE.FloatNode( 15 );
 					mtl.environment = new THREE.CubeTextureNode( cubemap );
-					mtl.reflectivity = mask;
+					mtl.environmentAlpha = mask;
 					mtl.normal = new THREE.TextureNode( grassNormal );
 					mtl.normalScale = new THREE.Math1Node( mask, THREE.Math1Node.INVERT );
 
@@ -305,7 +305,7 @@
 					//mtl.shadow = // shadowmap
 					//mtl.ao = // ambient occlusion
 					//mtl.environment = // reflection map (CubeMap recommended)
-					//mtl.reflectivity = // environment intensity
+					//mtl.environmentAlpha = // environment alpha
 					//mtl.transform = // vertex transformation
 
 					var mask = new THREE.SwitchNode( new THREE.TextureNode( decalDiffuse ), 'w' );
@@ -619,7 +619,7 @@
 
 					mtl.color = new THREE.ColorNode( 0x3399FF );
 					mtl.environment = color;
-					mtl.reflectivity = new THREE.Math1Node( fresnel, THREE.Math1Node.SAT );
+					mtl.environmentAlpha = new THREE.Math1Node( fresnel, THREE.Math1Node.SAT );
 
 					// GUI
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -619,7 +619,7 @@
 
 					mtl.color = new THREE.ColorNode( 0x3399FF );
 					mtl.environment = color;
-					mtl.environmentAlpha = new THREE.Math1Node( fresnel, THREE.Math1Node.SAT );
+					mtl.environmentIntensity = new THREE.Math1Node( fresnel, THREE.Math1Node.SAT );
 
 					// GUI
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -273,7 +273,7 @@
 					//mtl.shadow = // shadowmap
 					//mtl.ao = // ambient occlusion
 					//mtl.environment = // reflection map (CubeMap recommended)
-					//mtl.environmentAlpha = // environment alpha
+					//mtl.environmentIntensity = // environment intensity
 					//mtl.transform = // vertex transformation
 
 					var mask = new THREE.SwitchNode( new THREE.TextureNode( decalDiffuse ), 'w' );
@@ -282,7 +282,7 @@
 					mtl.specular = new THREE.FloatNode( .5 );
 					mtl.shininess = new THREE.FloatNode( 15 );
 					mtl.environment = new THREE.CubeTextureNode( cubemap );
-					mtl.environmentAlpha = mask;
+					mtl.environmentIntensity = mask;
 					mtl.normal = new THREE.TextureNode( grassNormal );
 					mtl.normalScale = new THREE.Math1Node( mask, THREE.Math1Node.INVERT );
 
@@ -305,7 +305,7 @@
 					//mtl.shadow = // shadowmap
 					//mtl.ao = // ambient occlusion
 					//mtl.environment = // reflection map (CubeMap recommended)
-					//mtl.environmentAlpha = // environment alpha
+					//mtl.environmentIntensity = // environment intensity
 					//mtl.transform = // vertex transformation
 
 					var mask = new THREE.SwitchNode( new THREE.TextureNode( decalDiffuse ), 'w' );

--- a/examples/webgl_postprocessing_nodes.html
+++ b/examples/webgl_postprocessing_nodes.html
@@ -334,18 +334,29 @@
 
 						var normal = new THREE.TextureNode( decalNormal );
 						var normalXY = new THREE.SwitchNode( normal, 'xy' );
+						var scale = new THREE.FloatNode( .5 );
+						var flip = new THREE.Vector2Node( -1, 1 );
+
+						var normalXYFlip = new THREE.Math1Node(
+							normalXY,
+							THREE.Math1Node.INVERT
+						);
 
 						var offsetNormal = new THREE.OperatorNode(
-							normalXY,
+							normalXYFlip,
 							new THREE.FloatNode( .5 ),
 							THREE.OperatorNode.ADD
 						);
 
-						var scale = new THREE.FloatNode( .5 );
+						var scaleTexture = new THREE.OperatorNode(
+							new THREE.SwitchNode( normal, 'z' ),
+							offsetNormal,
+							THREE.OperatorNode.MUL
+						);
 
 						var scaleNormal = new THREE.Math3Node(
 							new THREE.FloatNode( 1 ),
-							offsetNormal,
+							scaleTexture,
 							scale,
 							THREE.Math3Node.MIX
 						);
@@ -367,6 +378,14 @@
 							scale.number = val;
 
 						}, false, 0, 1 );
+
+						addGui( 'invert', false, function( val ) {
+
+							offsetNormal.a = val ? normalXYFlip : normalXY;
+
+							nodepass.build();
+
+						} );
 
 					break;
 
@@ -435,7 +454,7 @@
 
 							nodepass.build();
 
-						}, false, 0, 1 );
+						} );
 
 					break;
 


### PR DESCRIPTION
- `reflectivity` to `environmentAlpha` in Phong/Standard `Node`

I think we can use `environment` input to `refraction` and `reflection` with `alpha` input.
- vec2 to normalmap scale https://github.com/mrdoob/three.js/pull/7830
- flip refraction options `webgl_postprocessing_nodes.html
  `
