### PR TITLE
fix CatmullRomCurve3 end-point extrapolation

### DIFF
--- a/src/extras/curves/CatmullRomCurve3.js
+++ b/src/extras/curves/CatmullRomCurve3.js
@@ -131,7 +131,7 @@ THREE.CatmullRomCurve3 = ( function() {
 			} else {
 
 				// extrapolate last point
-				tmp.subVectors( points[ l - 1 ], points[ l - 2 ] ).add( points[ l - 2 ] );
+				tmp.subVectors( points[ l - 1 ], points[ l - 2 ] ).add( points[ l - 1 ] );
 				p3 = tmp;
 
 			}


### PR DESCRIPTION
The last point extrapolation used to pick exactly the last point as extrapolant due to an indexing error, which is of course not intended.
It now correctly extrapolates from the last point with the predicted tangent.
