### PR TITLE
Fixed an issue of key code

### DIFF
--- a/examples/webgl_geometry_colors_lookuptable.html
+++ b/examples/webgl_geometry_colors_lookuptable.html
@@ -276,7 +276,7 @@
 
 				var colorNumbers = ['16', '128', '256', '512' ];
 
-				if ( e.keyCode == 97 ) {
+				if ( e.keyCode == 65 ) {
 
 					cleanScene();
 
@@ -286,7 +286,7 @@
 
 					loadModel ( colorMap, numberOfColors, legendLayout );
 
-				} else if ( e.keyCode == 115 ) {
+				} else if ( e.keyCode == 83 ) {
 
 					cleanScene();
 
@@ -296,7 +296,7 @@
 
 					loadModel ( colorMap ,  numberOfColors, legendLayout );
 
-				} else if ( e.keyCode == 100 ) {
+				} else if ( e.keyCode == 68 ) {
 
 					if ( ! legendLayout ) {
 
@@ -316,7 +316,7 @@
 
 					}
 
-				} else if ( e.keyCode == 102 ) {
+				} else if ( e.keyCode == 70 ) {
 
 					cleanScene();
 


### PR DESCRIPTION
If the key event was changed from "keypress" to "keydown", there is a need to modify the key code at the same time.

// keypress
if ( e.keyCode == 97 ) {
} else if ( e.keyCode == 115 ) {
} else if ( e.keyCode == 100 ) {
} else if ( e.keyCode == 102 ) {

// keydown
if ( e.keyCode == 65 ) {
} else if ( e.keyCode == 83 ) {
} else if ( e.keyCode == 68 ) {
} else if ( e.keyCode == 70 ) {

See:
http://www.programming-magic.com/file/20080205232140/keycode_table.html
