### PR TITLE
Disable Shadow mapping for Outline drawing

### DIFF
--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -4293,8 +4293,13 @@ THREE.MMDHelper.prototype = {
 
 	renderOutline: function ( scene, camera ) {
 
+		var tmpEnabled = this.renderer.shadowMap.enabled;
+		this.renderer.shadowMap.enabled = false;
+
 		this.setupOutlineRendering();
 		this.renderer.render( scene, camera );
+
+		this.renderer.shadowMap.enabled = tmpEnabled;
 
 	},
 


### PR DESCRIPTION
I disabled Shadow mapping for Outline drawing to improve the performance when renderer.shadowMap.enabled is true.

MMDHelper.render() renders twice, firstly render main then secondly render outline.
Outline rendering doesn't need to render shadow because shadow is already rendered by main rendering.
