### PR TITLE
Fix KeyframeTrack.trim() wrong stride calculation bug

### DIFF
--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -207,10 +207,11 @@ THREE.KeyframeTrack.prototype = {
 			var from = firstKeysToRemove;
 			var to = nKeys - lastKeysToRemove - firstKeysToRemove;
 
+			var stride = this.getValueSize();
+
 			this.times = THREE.AnimationUtils.arraySlice( times, from, to );
 
 			var values = this.values;
-			var stride = this.getValueSize();
 			this.values = THREE.AnimationUtils.arraySlice( values, from * stride, to * stride );
 
 		}


### PR DESCRIPTION
@mrdoob 
@tschw 

If I'm right, this.getValueSize() should be called before this.times is updated in KeyframeTrack.trim() because this.getValueSize() returns this.values.length / this.times.length, correct?

For example, imagine the case that this.times and this.values has four elements and one element is trimmed.
this.getValueSize() always should return 1 but it returns 4/3 after "this.times = THREE.AnimationUtils.arraySlice( times, from, to );" in the current code.
#7900
