### PR TITLE
PMREMGenerator basic version

### DIFF
--- a/examples/Scene_DynamicPMREM.html
+++ b/examples/Scene_DynamicPMREM.html
@@ -386,10 +386,12 @@
 				cubeCamera.updateCubeMap( renderer, scene );
 
 				sphere.visible = true; // *cough*
-                                                                if(pmremGenerator!==undefined) {
-                                                                    pmremGenerator.update(renderer);
-                                                                    pmremCubeUVPacker.update(renderer);
-                                                                }
+                                
+				if(pmremGenerator!==undefined) {
+
+                                   pmremGenerator.update(renderer);
+                                   pmremCubeUVPacker.update(renderer);
+                                }
 				renderer.render( scene, camera );
 
 			}

--- a/examples/Scene_DynamicPMREM.html
+++ b/examples/Scene_DynamicPMREM.html
@@ -1,0 +1,400 @@
+
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - materials - dynamic cube reflection</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				background-color: #000000;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0px; width: 100%;
+				color: #ffffff;
+				padding: 5px;
+				font-family:Monospace;
+				font-size:13px;
+				font-weight: bold;
+				text-align:center;
+			}
+
+			a {
+				color: #ffffff;
+			}
+		</style>
+	</head>
+	<body>
+
+                                <script src="../build/three.js"></script>
+                                <script src="js/libs/stats.min.js"></script>
+                                <script src="../src/extras/PMREMGenerator.js"></script>
+                                <script src="../src/extras/PMREM_CubeUVPacker.js"></script>
+                                
+                                
+                                <script id="vertexShader" type="x-shader/x-vertex">
+                                    varying vec3 worldNormal;
+                                    varying vec3 vecPos;
+                                    varying vec3 viewPos;
+                                    void main(){
+                                            worldNormal = (modelMatrix * vec4(normal,0.0)).xyz;
+                                            vecPos = (modelMatrix * vec4(position, 1.0 )).xyz;
+                                            viewPos = (modelViewMatrix * vec4(position, 1.0 )).xyz;
+                                            gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+                                    }
+                                </script>
+        
+                                <script id="fragmentShaderCubeUV" type="x-shader/x-fragment">
+                                        #extension GL_OES_standard_derivatives : enable
+                                        varying vec3 worldNormal;
+                                        varying vec3 vecPos;
+                                        varying vec3 viewPos;
+                                        uniform sampler2D textureCubeUV;
+                                        uniform float textureSize;
+                                        uniform float roughness;
+                                        uniform float mapSize;
+
+                                        float SchlickApproxFresenel(float a, float NdotV) {
+                                            float schlick = pow(1.0 - abs(NdotV), 5.0);
+                                            return a * ( 1.0 - schlick) + schlick;
+                                        }
+
+                                        int getFaceFromDirection(vec3 direction) {
+                                            vec3 absDirection = abs(direction);
+                                            int face = -1;
+                                            if( absDirection.x > absDirection.z ) {
+                                                if(absDirection.x > absDirection.y )
+                                                    face = direction.x > 0.0 ? 0 : 3;
+                                                else
+                                                    face = direction.y > 0.0 ? 1 : 4;                            
+                                            }
+                                            else {
+                                                if(absDirection.z > absDirection.y )
+                                                    face = direction.z > 0.0 ? 2 : 5;
+                                                else
+                                                    face = direction.y > 0.0 ? 1 : 4;
+                                            }
+                                            return face;
+                                        }
+
+                                        vec2 MipLevelInfo( vec3 vec, float roughnessLevel ) {
+                                            float s = log2(textureSize*0.25) - 1.0;
+                                            float scale = pow(2.0, s-roughnessLevel);
+                                            vec3 dx = dFdx( vec * scale );
+                                            vec3 dy = dFdy( vec * scale );
+                                            float d = max( dot( dx, dx ), dot( dy, dy ) );
+                                            // Clamp the value to the max mip level counts. hard coded to 6 mips
+                                            float rangeClamp = pow(2.0, (6.0 - 1.0) * 2.0);
+                                            d = clamp(d, 1.0, rangeClamp);
+                                            float mipLevel = 0.5 * log2(d);
+                                            return vec2(floor(mipLevel), fract(mipLevel));
+                                        }
+
+                                        vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
+                                            float maxLods =  log2(textureSize*0.25) - 2.0;
+                                            mipLevel = roughnessLevel > maxLods - 3.0 ? 0.0 : mipLevel;
+                                            float a = 16.0/textureSize;
+                                            float powScale = pow(2.0,roughnessLevel + mipLevel);
+                                            float scale = 1.0/pow(2.0,roughnessLevel + 2.0 + mipLevel);
+                                            float mipOffset = 0.75*(1.0 - 1.0/pow(2.0, mipLevel))/pow(2.0,roughnessLevel);
+                                            bool bRes = mipLevel == 0.0;
+                                            scale =  bRes && (scale < a) ? a : scale;
+
+                                            vec3 r;
+                                            vec2 offset;
+                                            int face = getFaceFromDirection(direction);
+
+                                            if( face == 0) {
+                                                r = vec3(direction.x, -direction.z, direction.y);
+                                                offset = vec2(0.0+mipOffset,0.75/powScale);
+                                                offset.y = bRes && (offset.y < 2.0*a) ?  a : offset.y;
+                                            }
+                                            else if( face == 1) {
+                                                r = vec3(direction.y, direction.x, direction.z);
+                                                offset = vec2(scale+mipOffset, 0.75/powScale);
+                                                offset.y = bRes && (offset.y < 2.0*a) ?  a : offset.y;
+                                            }
+                                            else if( face == 2) {
+                                                r = vec3(direction.z, direction.x, direction.y);
+                                                offset = vec2(2.0*scale+mipOffset, 0.75/powScale);
+                                                offset.y = bRes && (offset.y < 2.0*a) ?  a : offset.y;
+                                            }
+                                            else if( face == 3) {
+                                                r = vec3(direction.x, direction.z, direction.y);
+                                                offset = vec2(0.0+mipOffset,0.5/powScale);
+                                                offset.y = bRes && (offset.y < 2.0*a) ?  0.0 : offset.y;
+                                            }
+                                            else if( face == 4) {
+                                                r = vec3(direction.y, direction.x, -direction.z);
+                                                offset = vec2(scale+mipOffset, 0.5/powScale);
+                                                offset.y = bRes && (offset.y < 2.0*a) ?  0.0 : offset.y;
+                                            }
+                                            else {
+                                                r = vec3(direction.z, -direction.x, direction.y);
+                                                offset = vec2(2.0*scale+mipOffset, 0.5/powScale);
+                                                offset.y = bRes && (offset.y < 2.0*a) ?  0.0 : offset.y;
+                                            }
+                                            r = normalize(r);
+                                            float texelOffset = 0.5/textureSize;
+                                            float s1 = (r.y/abs(r.x) + 1.0)*0.5;
+                                            float s2 = (r.z/abs(r.x) + 1.0)*0.5;
+                                            vec2 uv = offset + vec2(s1*scale, s2*scale);
+                                            float min_x = offset.x + texelOffset; float max_x = offset.x + scale - texelOffset;
+                                            float min_y = offset.y + texelOffset; 
+                                            float max_y = offset.y + scale - texelOffset;
+                                            float delx = max_x - min_x;
+                                            float dely = max_y - min_y;
+                                            uv.x = min_x + s1*delx;
+                                            uv.y = min_y + s2*dely;
+                                            return uv;
+                                        }
+                                        
+                                        vec4 sampleCubeUV(vec3 reflectedDirection) {
+                                            float maxLods =  log2(textureSize*0.25) - 3.0;
+                                                float roughnessVal = roughness*maxLods;
+                                                float r1 = floor(roughnessVal);
+                                                float r2 = r1 + 1.0;
+                                                float t = fract(roughnessVal);
+                                                vec2 mipInfo = MipLevelInfo(reflectedDirection, r1);
+                                                float s = mipInfo.y;
+                                                float level0 = mipInfo.x;
+                                                float level1 = level0 + 1.0;
+                                                level1 = level1 > 5.0 ? 5.0 : level1;
+                                                // Tri linear interpolation.
+                                                vec2 uv_10 = getCubeUV(reflectedDirection, r1, level0);
+                                                vec2 uv_11 = getCubeUV(reflectedDirection, r1, level1);
+                                                vec2 uv_20 = getCubeUV(reflectedDirection, r2, level0);
+                                                vec2 uv_21 = getCubeUV(reflectedDirection, r2, level1);
+                                                vec4 color10 = texture2D(textureCubeUV, uv_10);
+                                                vec4 color11 = texture2D(textureCubeUV, uv_11);
+                                                vec4 color20 = texture2D(textureCubeUV, uv_20);
+                                                vec4 color21 = texture2D(textureCubeUV, uv_21);
+                                                vec4 c1 = mix(color10 , color11,  s);
+                                                vec4 c2 = mix(color20 , color21,  s);
+                                                vec4 c3 = mix(c1 , c2,  t);
+                                                return c3;
+                                        }
+                                        void main() {
+                                                vec3 viewVector = normalize(vecPos - cameraPosition);
+                                                vec3 Normal = normalize(worldNormal);
+                                                vec3 reflectedDirection = reflect(viewVector, Normal);
+                                                gl_FragColor = sampleCubeUV(reflectedDirection);
+                                        }
+                                </script>
+        
+        
+		<script>
+
+			var camera, cubeCamera, scene, renderer;
+			var cube, sphere, torus;
+                                                var pmremGenerator, pmremCubeUVPacker;
+                                                var testMaterialCubeUV;
+                                                
+			var fov = 70,
+			isUserInteracting = false,
+			onMouseDownMouseX = 0, onMouseDownMouseY = 0,
+			lon = 0, onMouseDownLon = 0,
+			lat = 0, onMouseDownLat = 0,
+			phi = 0, theta = 0;
+                                                
+                                                function changeRoughness(value) {
+                                                        testMaterialCubeUV.uniforms["roughness"].value = Number(value);
+                                                }   
+                                                
+			var texture = THREE.ImageUtils.loadTexture( 'textures/2294472375_24a3b8ef46_o.jpg', THREE.UVMapping, function () {
+                                                        init();
+                                                        initMaterial();
+                                                        pmremGenerator = new PMREMGenerator(cubeCamera.renderTarget);
+                                                        pmremCubeUVPacker = new PMREM_CubeUVPacker(pmremGenerator.cubeLods);
+                                                        testMaterialCubeUV.uniforms["textureCubeUV"].value = pmremCubeUVPacker.CubeUVRenderTarget;
+                                                        testMaterialCubeUV.uniforms["textureSize"].value = pmremCubeUVPacker.CubeUVRenderTarget.width;
+                                                        testMaterialCubeUV.uniforms["roughness"].value = 0.50;
+                                                        sphere.material = testMaterialCubeUV;
+                                                        animate();
+			} );
+                                                
+                                                var initMaterial = function() {
+
+                                                    testMaterialCubeUV = new THREE.ShaderMaterial({
+                                                        uniforms: {
+                                                            "roughness": {type: "f", value: 1.0},
+                                                            "textureSize": {type: "f", value: 0.0},
+                                                            "textureCubeUV": {type: "t", value: null}
+                                                        },
+                                                        vertexShader: document.getElementById( 'vertexShader' ).textContent,
+                                                        fragmentShader: document.getElementById( 'fragmentShaderCubeUV' ).textContent
+                                                    });
+                                                    testMaterialCubeUV.side = THREE.DoubleSide;
+                                                };
+			function init() {
+
+				camera = new THREE.PerspectiveCamera( fov, window.innerWidth / window.innerHeight, 1, 1000 );
+
+				scene = new THREE.Scene();
+
+				var mesh = new THREE.Mesh( new THREE.SphereGeometry( 500, 60, 40 ), new THREE.MeshBasicMaterial( { map: texture } ) );
+				mesh.scale.x = -1;
+				scene.add( mesh );
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				cubeCamera = new THREE.CubeCamera( 1, 1000, 256 );
+				cubeCamera.renderTarget.minFilter = THREE.LinearMipMapLinearFilter;
+				scene.add( cubeCamera );
+                                                                
+                                                                stats = new Stats();
+                                                                stats.domElement.style.position = 'absolute';
+                                                                stats.domElement.style.top = '0px';
+				document.body.appendChild( renderer.domElement );
+				document.body.appendChild( stats.domElement );
+
+				//
+
+				var material = new THREE.MeshBasicMaterial( { envMap: cubeCamera.renderTarget } );
+
+				sphere = new THREE.Mesh( new THREE.SphereGeometry( 20, 30, 15 ), testMaterialCubeUV );
+				scene.add( sphere );
+
+				cube = new THREE.Mesh( new THREE.BoxGeometry( 20, 20, 20 ), material );
+				scene.add( cube );
+
+				torus = new THREE.Mesh( new THREE.TorusKnotGeometry( 20, 5, 100, 25 ), material );
+				scene.add( torus );
+
+				//
+
+				document.addEventListener( 'mousedown', onDocumentMouseDown, false );
+				document.addEventListener( 'mousewheel', onDocumentMouseWheel, false );
+				document.addEventListener( 'MozMousePixelScroll', onDocumentMouseWheel, false);
+				window.addEventListener( 'resize', onWindowResized, false );
+
+				onWindowResized( null );
+
+			}
+
+			function onWindowResized( event ) {
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				camera.projectionMatrix.makePerspective( fov, window.innerWidth / window.innerHeight, 1, 1100 );
+			}
+
+			function onDocumentMouseDown( event ) {
+
+				event.preventDefault();
+
+				onPointerDownPointerX = event.clientX;
+				onPointerDownPointerY = event.clientY;
+
+				onPointerDownLon = lon;
+				onPointerDownLat = lat;
+
+				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
+				document.addEventListener( 'mouseup', onDocumentMouseUp, false );
+
+			}
+
+			function onDocumentMouseMove( event ) {
+
+				lon = ( event.clientX - onPointerDownPointerX ) * 0.1 + onPointerDownLon;
+				lat = ( event.clientY - onPointerDownPointerY ) * 0.1 + onPointerDownLat;
+
+			}
+
+			function onDocumentMouseUp( event ) {
+
+				document.removeEventListener( 'mousemove', onDocumentMouseMove, false );
+				document.removeEventListener( 'mouseup', onDocumentMouseUp, false );
+
+			}
+
+			function onDocumentMouseWheel( event ) {
+
+				// WebKit
+
+				if ( event.wheelDeltaY ) {
+
+					fov -= event.wheelDeltaY * 0.05;
+
+				// Opera / Explorer 9
+
+				} else if ( event.wheelDelta ) {
+
+					fov -= event.wheelDelta * 0.05;
+
+				// Firefox
+
+				} else if ( event.detail ) {
+
+					fov += event.detail * 1.0;
+
+				}
+
+				camera.projectionMatrix.makePerspective( fov, window.innerWidth / window.innerHeight, 1, 1100 );
+
+			}
+
+			function animate() {
+                                                                stats.update();
+				requestAnimationFrame( animate );
+				render();
+			}
+
+			function render() {
+				var time = Date.now();
+
+				lon += .15;
+
+				lat = Math.max( - 85, Math.min( 85, lat ) );
+				phi = THREE.Math.degToRad( 90 - lat );
+				theta = THREE.Math.degToRad( lon );
+
+				sphere.position.x = Math.sin( time * 0.001 ) * 30;
+				sphere.position.y = Math.sin( time * 0.0011 ) * 30;
+				sphere.position.z = Math.sin( time * 0.0012 ) * 30;
+
+				sphere.rotation.x += 0.02;
+				sphere.rotation.y += 0.03;
+
+				cube.position.x = Math.sin( time * 0.001 + 2 ) * 30;
+				cube.position.y = Math.sin( time * 0.0011 + 2 ) * 30;
+				cube.position.z = Math.sin( time * 0.0012 + 2 ) * 30;
+
+				cube.rotation.x += 0.02;
+				cube.rotation.y += 0.03;
+
+				torus.position.x = Math.sin( time * 0.001 + 4 ) * 30;
+				torus.position.y = Math.sin( time * 0.0011 + 4 ) * 30;
+				torus.position.z = Math.sin( time * 0.0012 + 4 ) * 30;
+
+				torus.rotation.x += 0.02;
+				torus.rotation.y += 0.03;
+
+				camera.position.x = 100 * Math.sin( phi ) * Math.cos( theta );
+				camera.position.y = 100 * Math.cos( phi );
+				camera.position.z = 100 * Math.sin( phi ) * Math.sin( theta );
+
+				camera.lookAt( scene.position );
+
+				sphere.visible = false; // *cough*
+
+				cubeCamera.updateCubeMap( renderer, scene );
+
+				sphere.visible = true; // *cough*
+                                                                if(pmremGenerator!==undefined) {
+                                                                    pmremGenerator.update(renderer);
+                                                                    pmremCubeUVPacker.update(renderer);
+                                                                }
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/examples/Scene_PMREM_CubeUV_PackingTest.html
+++ b/examples/Scene_PMREM_CubeUV_PackingTest.html
@@ -1,0 +1,133 @@
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>three.js webgl - loaders - OBJ loader</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+        <style>
+            body {
+                font-family: Monospace;
+                background-color: #000;
+                color: #fff;
+                margin: 0px;
+                overflow: hidden;
+            }
+            #info {
+                color: #fff;
+                position: absolute;
+                top: 10px;
+                width: 100%;
+                text-align: center;
+                z-index: 100;
+                display:block;
+            }
+            #info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }
+        </style>
+    </head>
+
+    <body>
+
+        <script src="../build/three.js"></script>
+        <script src="../src/extras/PMREMGenerator.js"></script>
+        <script src="../src/extras/PMREM_CubeUVPacker.js"></script>
+          
+        <script>
+
+var container;
+var camera, backgroundCamera, scene, renderer;
+
+var onTextureLoad = function() {
+    pmremGenerator = new PMREMGenerator(reflectionCube);
+    pmremCubeUVPacker = new PMREM_CubeUVPacker(pmremGenerator.cubeLods);
+    renderer.setClearColor(0xFFFFFF);
+    pmremGenerator.update(renderer);
+    pmremCubeUVPacker.update(renderer);
+    var material = new THREE.MeshBasicMaterial();
+    material.side = THREE.DoubleSide;
+    material.map = pmremCubeUVPacker.CubeUVRenderTarget;
+    var planeMesh = new THREE.Mesh(
+                        new THREE.PlaneGeometry(window.innerWidth, window.innerHeight, 0),
+                        material);
+    scene.add(planeMesh);
+    animate();
+};
+
+var path = "textures/cube/pisa/";
+                var format = '.png';
+                var urls = [
+                    path + 'px' + format, path + 'nx' + format,
+                    path + 'py' + format, path + 'ny' + format,
+                    path + 'pz' + format, path + 'nz' + format
+                ];
+var reflectionCube = THREE.ImageUtils.loadTextureCube(urls, undefined, onTextureLoad);
+reflectionCube.generateMipmaps = false;
+reflectionCube.magFilter = THREE.LinearFilter;
+reflectionCube.minFilter = THREE.LinearFilter;
+
+var pmremGenerator;
+var pmremCubeUVPacker;
+
+var windowHalfX = window.innerWidth / 2;
+var windowHalfY = window.innerHeight / 2;
+
+var cameraPosition = new THREE.Vector3();
+
+initScene();
+
+function initScene() {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    camera= new THREE.OrthographicCamera(-window.innerWidth*0.5, window.innerWidth*0.5, window.innerHeight*0.5, -window.innerHeight*0.5, 0.0, 1000);
+    // scene
+    scene = new THREE.Scene();
+    renderer = new THREE.WebGLRenderer({preserveDrawingBuffer: true, antialias: true});
+    renderer.context.getExtension('EXT_shader_texture_lod');
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    container.appendChild(renderer.domElement);
+        
+    document.addEventListener('mousemove', onDocumentMouseMove, false);
+    document.addEventListener('mousedown', onDocumentMouseDown, false);
+    document.addEventListener('mouseup', onDocumentMouseUp, false);
+    document.addEventListener('mousewheel', onDocumentMouseWheel, false);
+    window.addEventListener('resize', onWindowResize, false);
+}
+
+function onDocumentMouseMove(event)
+{
+}
+
+function onDocumentMouseWheel(event)
+{
+}
+
+function onDocumentMouseDown(e)
+{
+}
+
+function onDocumentMouseUp(e)
+{
+}
+
+function onWindowResize() {
+    windowHalfX = window.innerWidth / 2;
+    windowHalfY = window.innerHeight / 2;
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+    
+function animate() {
+    requestAnimationFrame(animate);
+    render();
+}
+
+function render() {
+    renderer.render(scene, camera);
+}
+
+        </script>
+
+    </body>
+</html>

--- a/examples/Scene_PMREM_CubeUV_Test.html
+++ b/examples/Scene_PMREM_CubeUV_Test.html
@@ -1,0 +1,342 @@
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>three.js webgl - loaders - OBJ loader</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+        <style>
+            body {
+                font-family: Monospace;
+                background-color: #000;
+                color: #fff;
+                margin: 0px;
+                overflow: hidden;
+            }
+            #info {
+                color: #fff;
+                position: absolute;
+                top: 10px;
+                width: 100%;
+                text-align: center;
+                z-index: 100;
+                display:block;
+            }
+            #info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }
+        </style>
+    </head>
+
+    <body>
+
+        <script src="../build/three.js"></script>
+        <script src="js/controls/OrbitControls.js"></script>
+        <script src="js/Detector.js"></script>
+        <script src="../src/extras/PMREMGenerator.js"></script>
+        <script src="../src/extras/PMREM_CubeUVPacker.js"></script>
+
+        <script id="vertexShader" type="x-shader/x-vertex">
+            varying vec3 worldNormal;
+            varying vec3 vecPos;
+            varying vec3 viewPos;
+            void main(){
+            worldNormal = (modelMatrix * vec4(normal,0.0)).xyz;
+            vecPos = (modelMatrix * vec4(position, 1.0 )).xyz;
+            viewPos = (modelViewMatrix * vec4(position, 1.0 )).xyz;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+            }
+        </script>
+
+<!--        This shader assumes that the each face(for a given roughness and mip level) is arranged in a fixed 
+        format as explained in PMREM_CubeUVPacker.js. Probably functionality of this shader should be 
+        moved to the main shader library of three.js.-->
+
+        <script id="fragmentShaderCubeUV" type="x-shader/x-fragment">
+                #extension GL_OES_standard_derivatives : enable
+                varying vec3 worldNormal;
+                varying vec3 vecPos;
+                varying vec3 viewPos;
+                uniform sampler2D textureCubeUV;
+                uniform float textureSize;
+                uniform float roughness;
+                
+                int getFaceFromDirection(vec3 direction) {
+                    vec3 absDirection = abs(direction);
+                    int face = -1;
+                    if( absDirection.x > absDirection.z ) {
+                        if(absDirection.x > absDirection.y )
+                            face = direction.x > 0.0 ? 0 : 3;
+                        else
+                            face = direction.y > 0.0 ? 1 : 4;                            
+                    }
+                    else {
+                        if(absDirection.z > absDirection.y )
+                            face = direction.z > 0.0 ? 2 : 5;
+                        else
+                            face = direction.y > 0.0 ? 1 : 4;
+                    }
+                    return face;
+                }
+                
+                vec2 MipLevelInfo( vec3 vec, float roughnessLevel ) {
+                    float s = log2(textureSize*0.25) - 1.0;
+                    float scale = pow(2.0, s-roughnessLevel);
+                    vec3 dx = dFdx( vec * scale );
+                    vec3 dy = dFdy( vec * scale );
+                    float d = max( dot( dx, dx ), dot( dy, dy ) );
+                    // Clamp the value to the max mip level counts. hard coded to 6 mips
+                    float rangeClamp = pow(2.0, (6.0 - 1.0) * 2.0);
+                    d = clamp(d, 1.0, rangeClamp);
+                    float mipLevel = 0.5 * log2(d);
+                    return vec2(floor(mipLevel), fract(mipLevel));
+                }
+                
+                vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
+                    float maxLods =  log2(textureSize*0.25) - 2.0;
+                    mipLevel = roughnessLevel > maxLods - 3.0 ? 0.0 : mipLevel;
+                    float a = 16.0/textureSize;
+                    float powScale = pow(2.0,roughnessLevel + mipLevel);
+                    float scale = 1.0/pow(2.0,roughnessLevel + 2.0 + mipLevel);
+                    float mipOffset = 0.75*(1.0 - 1.0/pow(2.0, mipLevel))/pow(2.0,roughnessLevel);
+                    bool bRes = mipLevel == 0.0;
+                    scale =  bRes && (scale < a) ? a : scale;
+                    
+                    vec3 r;
+                    vec2 offset;
+                    int face = getFaceFromDirection(direction);
+                    
+                    if( face == 0) {
+                        r = vec3(direction.x, -direction.z, direction.y);
+                        offset = vec2(0.0+mipOffset,0.75/powScale);
+                        offset.y = bRes && (offset.y < 2.0*a) ?  a : offset.y;
+                    }
+                    else if( face == 1) {
+                        r = vec3(direction.y, direction.x, direction.z);
+                        offset = vec2(scale+mipOffset, 0.75/powScale);
+                        offset.y = bRes && (offset.y < 2.0*a) ?  a : offset.y;
+                    }
+                    else if( face == 2) {
+                        r = vec3(direction.z, direction.x, direction.y);
+                        offset = vec2(2.0*scale+mipOffset, 0.75/powScale);
+                        offset.y = bRes && (offset.y < 2.0*a) ?  a : offset.y;
+                    }
+                    else if( face == 3) {
+                        r = vec3(direction.x, direction.z, direction.y);
+                        offset = vec2(0.0+mipOffset,0.5/powScale);
+                        offset.y = bRes && (offset.y < 2.0*a) ?  0.0 : offset.y;
+                    }
+                    else if( face == 4) {
+                        r = vec3(direction.y, direction.x, -direction.z);
+                        offset = vec2(scale+mipOffset, 0.5/powScale);
+                        offset.y = bRes && (offset.y < 2.0*a) ?  0.0 : offset.y;
+                    }
+                    else {
+                        r = vec3(direction.z, -direction.x, direction.y);
+                        offset = vec2(2.0*scale+mipOffset, 0.5/powScale);
+                        offset.y = bRes && (offset.y < 2.0*a) ?  0.0 : offset.y;
+                    }
+                    r = normalize(r);
+                    float texelOffset = 0.5/textureSize;
+                    float s1 = (r.y/abs(r.x) + 1.0)*0.5;
+                    float s2 = (r.z/abs(r.x) + 1.0)*0.5;
+                    vec2 uv = offset + vec2(s1*scale, s2*scale);
+                    float min_x = offset.x + texelOffset; float max_x = offset.x + scale - texelOffset;
+                    float min_y = offset.y + texelOffset; 
+                    float max_y = offset.y + scale - texelOffset;
+                    float delx = max_x - min_x;
+                    float dely = max_y - min_y;
+                    uv.x = min_x + s1*delx;
+                    uv.y = min_y + s2*dely;
+                    return uv;
+                }
+                
+                vec4 sampleCubeUV(vec3 reflectedDirection) {
+                    float maxLods =  log2(textureSize*0.25) - 3.0;
+                    float roughnessVal = roughness*maxLods;
+                    float r1 = floor(roughnessVal);
+                    float r2 = r1 + 1.0;
+                    float t = fract(roughnessVal);
+                    vec2 mipInfo = MipLevelInfo(reflectedDirection, r1);
+                    float s = mipInfo.y;
+                    float level0 = mipInfo.x;
+                    float level1 = level0 + 1.0;
+                    level1 = level1 > 5.0 ? 5.0 : level1;
+                    // Tri linear interpolation.
+                    vec2 uv_10 = getCubeUV(reflectedDirection, r1, level0);
+                    vec2 uv_11 = getCubeUV(reflectedDirection, r1, level1);
+                    vec2 uv_20 = getCubeUV(reflectedDirection, r2, level0);
+                    vec2 uv_21 = getCubeUV(reflectedDirection, r2, level1);
+                    vec4 color10 = texture2D(textureCubeUV, uv_10);
+                    vec4 color11 = texture2D(textureCubeUV, uv_11);
+                    vec4 color20 = texture2D(textureCubeUV, uv_20);
+                    vec4 color21 = texture2D(textureCubeUV, uv_21);
+                    vec4 c1 = mix(color10 , color11,  s);
+                    vec4 c2 = mix(color20 , color21,  s);
+                    vec4 c3 = mix(c1 , c2,  t);
+                    return c3;
+                }
+                
+                void main() {
+                        vec3 viewVector = normalize(vecPos - cameraPosition);
+                        vec3 Normal = normalize(worldNormal);
+                        vec3 reflectedDirection = reflect(viewVector, Normal);
+                        gl_FragColor = sampleCubeUV(reflectedDirection);
+                }
+        </script>
+
+        <script>
+
+var container, stats;
+var camera, backgroundCamera, scene, renderer, controls;
+var rootNode = new THREE.Object3D();
+
+var testMaterialCubeUV;
+
+var onTextureLoad = function () {
+    pmremGenerator = new PMREMGenerator(reflectionCube);
+    pmremCubeUVPacker = new PMREM_CubeUVPacker(pmremGenerator.cubeLods);
+    pmremGenerator.update(renderer);
+    pmremCubeUVPacker.update(renderer);
+    initMaterials();
+    initTestScene();
+    animate();
+};
+
+var initMaterials = function () {
+    testMaterialCubeUV = new THREE.ShaderMaterial({
+        uniforms: {
+            "roughness": {type: "f", value: 0.0},
+            "textureSize": {type: "f", value: 0.0},
+            "textureCubeUV": {type: "t", value: null}
+        },
+        vertexShader: document.getElementById('vertexShader').textContent,
+        fragmentShader: document.getElementById('fragmentShaderCubeUV').textContent
+    });
+    testMaterialCubeUV.side = THREE.DoubleSide;
+};
+
+var initTestScene = function () {
+    var sphereRadius = 0.5;
+    var sphereGeometry = new THREE.SphereGeometry(sphereRadius, 25, 16);
+    var sphereMesh = new THREE.Mesh(sphereGeometry, testMaterialCubeUV);
+    testMaterialCubeUV.uniforms["textureCubeUV"].value = pmremCubeUVPacker.CubeUVRenderTarget;
+    testMaterialCubeUV.uniforms["textureSize"].value = pmremCubeUVPacker.CubeUVRenderTarget.width;
+
+    var x = -3.5;
+    for (var i = 0; i < 8; i++) {
+        var cloneMesh = sphereMesh.clone();
+        cloneMesh.material = testMaterialCubeUV.clone();
+        cloneMesh.material.uniforms["roughness"].value = i / (pmremGenerator.numLods - 1);
+        cloneMesh.material.uniforms["textureCubeUV"].value = pmremCubeUVPacker.CubeUVRenderTarget;
+        cloneMesh.position.x = x;
+        rootNode.add(cloneMesh);
+        x += 2.1 * sphereRadius;
+    }
+    scene.add(rootNode);
+};
+
+var path = "textures/cube/pisa/";
+var format = '.png';
+var urls = [
+    path + 'px' + format, path + 'nx' + format,
+    path + 'py' + format, path + 'ny' + format,
+    path + 'pz' + format, path + 'nz' + format
+];
+var reflectionCube = THREE.ImageUtils.loadTextureCube(urls, undefined, onTextureLoad);
+reflectionCube.generateMipmaps = false;
+reflectionCube.magFilter = THREE.LinearFilter;
+reflectionCube.minFilter = THREE.LinearFilter;
+
+var pmremGenerator;
+var pmremCubeUVPacker;
+
+var windowHalfX = window.innerWidth / 2;
+var windowHalfY = window.innerHeight / 2;
+
+var cameraPosition = new THREE.Vector3();
+
+initScene();
+
+function initScene() {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.01, 1000);
+    camera.position.z = 5;
+    camera.position.x = 0;
+
+    controls = new THREE.OrbitControls(camera);
+    controls.addEventListener('change', render);
+    // scene
+    scene = new THREE.Scene();
+
+    renderer = new THREE.WebGLRenderer({preserveDrawingBuffer: true, antialias: true});
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    container.appendChild(renderer.domElement);
+
+    document.addEventListener('mousemove', onDocumentMouseMove, false);
+    document.addEventListener('mousedown', onDocumentMouseDown, false);
+    document.addEventListener('mouseup', onDocumentMouseUp, false);
+    document.addEventListener('mousewheel', onDocumentMouseWheel, false);
+    window.addEventListener('resize', onWindowResize, false);
+}
+
+function onDocumentMouseMove(event)
+{
+}
+
+function onDocumentMouseWheel(event)
+{
+    var pos = camera.position;
+    var d = pos.length();
+    cameraPosition.x = pos.x;
+    cameraPosition.y = pos.y;
+    cameraPosition.z = pos.z;
+    var min = 0.1;
+    var max = 100;
+    if (d < min)
+    {
+        cameraPosition.normalize();
+        pos.x = cameraPosition.x * min;
+        pos.y = cameraPosition.y * min;
+        pos.z = cameraPosition.z * min;
+    }
+    if (d > max)
+    {
+        cameraPosition.normalize();
+        pos.x = cameraPosition.x * max;
+        pos.y = cameraPosition.y * max;
+        pos.z = cameraPosition.z * max;
+    }
+}
+
+function onDocumentMouseDown(e)
+{
+}
+
+function onDocumentMouseUp(e)
+{
+}
+
+function onWindowResize() {
+    windowHalfX = window.innerWidth / 2;
+    windowHalfY = window.innerHeight / 2;
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+    render();
+}
+
+function render() {
+    renderer.setClearColor(0xFFFFFF);
+    renderer.render(scene, camera);
+}
+
+        </script>
+
+    </body>
+</html>

--- a/examples/Scene_PMREM_CubeUV_Test.html
+++ b/examples/Scene_PMREM_CubeUV_Test.html
@@ -159,7 +159,6 @@
                     float s = mipInfo.y;
                     float level0 = mipInfo.x;
                     float level1 = level0 + 1.0;
-                    level1 = level1 > 5.0 ? 5.0 : level1;
                     // Tri linear interpolation.
                     vec2 uv_10 = getCubeUV(reflectedDirection, r1, level0);
                     vec2 uv_11 = getCubeUV(reflectedDirection, r1, level1);

--- a/examples/Scene_PMREM_Test.html
+++ b/examples/Scene_PMREM_Test.html
@@ -1,0 +1,227 @@
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>three.js webgl - loaders - OBJ loader</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+        <style>
+            body {
+                font-family: Monospace;
+                background-color: #000;
+                color: #fff;
+                margin: 0px;
+                overflow: hidden;
+            }
+            #info {
+                color: #fff;
+                position: absolute;
+                top: 10px;
+                width: 100%;
+                text-align: center;
+                z-index: 100;
+                display:block;
+            }
+            #info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }
+        </style>
+    </head>
+
+    <body>
+
+        <script src="../build/three.js"></script>
+        <script src="js/controls/OrbitControls.js"></script>
+        <script src="js/Detector.js"></script>
+        <script src="../src/extras/PMREMGenerator.js"></script>
+        <script src="../src/extras/PMREM_CubeUVPacker.js"></script>
+        
+        <script id="vertexShader" type="x-shader/x-vertex">
+                varying vec3 worldNormal;
+                varying vec3 vecPos;
+                varying vec3 viewPos;
+                void main(){
+                        worldNormal = (modelMatrix * vec4(normal,0.0)).xyz;
+                        vecPos = (modelMatrix * vec4(position, 1.0 )).xyz;
+                        viewPos = (modelViewMatrix * vec4(position, 1.0 )).xyz;
+                        gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+                }
+        </script>
+        
+        <script id="fragmentShader" type="x-shader/x-fragment">
+                #extension GL_EXT_shader_texture_lod : enable
+                varying vec3 worldNormal;
+                varying vec3 vecPos;
+                varying vec3 viewPos;
+                uniform samplerCube cubeTexture;
+                uniform float mapSize;
+                
+                vec3 fixSeams(vec3 vec) {
+                    float scale = 1.0 - 1.0 / mapSize;
+                    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
+                    if (abs(vec.x) != M) vec.x *= scale;
+                    if (abs(vec.y) != M) vec.y *= scale;
+                    if (abs(vec.z) != M) vec.z *= scale;
+                    return vec;
+                }
+
+                void main() {
+                        vec3 viewVector = normalize(vecPos - cameraPosition);
+                        vec3 Normal = normalize(worldNormal);
+                        vec3 reflectedDirection = fixSeams(reflect(viewVector, Normal));
+                        vec4 colorRefl = textureCube( cubeTexture, reflectedDirection);
+                        gl_FragColor = colorRefl;
+                }
+        </script>
+        
+        <script>
+
+var container;
+var camera, backgroundCamera, scene, renderer, controls;
+var rootNode = new THREE.Object3D();
+
+var testMaterial;
+
+var onTextureLoad = function() {
+    pmremGenerator = new PMREMGenerator(reflectionCube);
+    pmremGenerator.update(renderer);
+    initMaterials();
+    initTestScene();
+    animate();
+};
+
+var initMaterials = function() {
+    testMaterial = new THREE.ShaderMaterial({
+        uniforms: {
+            "mapSize" : {type: "f", value: 0},
+            "cubeTexture": {type: "t", value: null},
+        },
+        vertexShader: document.getElementById( 'vertexShader' ).textContent,
+        fragmentShader: document.getElementById( 'fragmentShader' ).textContent
+    });
+};
+
+var initTestScene = function() {
+    var sphereRadius = 0.5;
+    var sphereGeometry = new THREE.SphereGeometry(sphereRadius,25,16);
+    var sphereMesh = new THREE.Mesh(sphereGeometry, testMaterial);
+    
+    var x = -2.5;
+    for( var i=0; i<pmremGenerator.numLods; i++) {
+        var cloneMesh = sphereMesh.clone();
+        cloneMesh.material = testMaterial.clone();
+        cloneMesh.material.uniforms["cubeTexture"].value = pmremGenerator.cubeLods[i];    
+        cloneMesh.material.uniforms["mapSize"].value = pmremGenerator.cubeLods[i].width;    
+        cloneMesh.position.x = x;
+        rootNode.add(cloneMesh);
+        x += 2.1 * sphereRadius;
+    }
+    scene.add(rootNode);
+};
+
+var path = "textures/cube/pisa/";
+                var format = '.png';
+                var urls = [
+                    path + 'px' + format, path + 'nx' + format,
+                    path + 'py' + format, path + 'ny' + format,
+                    path + 'pz' + format, path + 'nz' + format
+                ];
+var reflectionCube = THREE.ImageUtils.loadTextureCube(urls, undefined, onTextureLoad);
+reflectionCube.generateMipmaps = false;
+reflectionCube.magFilter = THREE.LinearFilter;
+reflectionCube.minFilter = THREE.LinearFilter;
+
+var pmremGenerator;
+
+var windowHalfX = window.innerWidth / 2;
+var windowHalfY = window.innerHeight / 2;
+
+var cameraPosition = new THREE.Vector3();
+
+initScene();
+animate();
+
+function initScene() {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.01, 1000);
+    camera.position.z = 4;
+    camera.position.x = 0;
+     
+    controls = new THREE.OrbitControls(camera);
+    controls.addEventListener('change', render);
+    // scene
+    scene = new THREE.Scene();
+    
+    renderer = new THREE.WebGLRenderer({preserveDrawingBuffer: true, antialias: true});
+    renderer.context.getExtension('EXT_shader_texture_lod');
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    container.appendChild(renderer.domElement);
+        
+    document.addEventListener('mousemove', onDocumentMouseMove, false);
+    document.addEventListener('mousedown', onDocumentMouseDown, false);
+    document.addEventListener('mouseup', onDocumentMouseUp, false);
+    document.addEventListener('mousewheel', onDocumentMouseWheel, false);
+    window.addEventListener('resize', onWindowResize, false);
+}
+
+function onDocumentMouseMove(event)
+{
+}
+
+function onDocumentMouseWheel(event)
+{
+    var pos = camera.position;
+    var d = pos.length();
+    cameraPosition.x = pos.x;
+    cameraPosition.y = pos.y;
+    cameraPosition.z = pos.z;
+    var min = 0.1;
+    var max = 100;
+    if (d < min)
+    {
+        cameraPosition.normalize();
+        pos.x = cameraPosition.x * min;
+        pos.y = cameraPosition.y * min;
+        pos.z = cameraPosition.z * min;
+    }
+    if (d > max)
+    {
+        cameraPosition.normalize();
+        pos.x = cameraPosition.x * max;
+        pos.y = cameraPosition.y * max;
+        pos.z = cameraPosition.z * max;
+    }
+
+}
+
+function onDocumentMouseDown(e)
+{
+}
+
+function onDocumentMouseUp(e)
+{
+}
+
+function onWindowResize() {
+    windowHalfX = window.innerWidth / 2;
+    windowHalfY = window.innerHeight / 2;
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+    
+function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+    render();
+}
+
+function render() {
+    renderer.setClearColor(0xFFFFFF);
+    renderer.render(scene, camera);
+}
+
+        </script>
+
+    </body>
+</html>

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -1,0 +1,180 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+var vertexShaderPMREM = "varying vec2 vUv;\
+                   void main() {\
+                        vUv = uv;\
+                        gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\
+                   }";
+
+var fragmentShaderPMREM = "varying vec2 vUv;\
+                    uniform int faceIndex;\
+                    uniform float roughness;\
+                    uniform samplerCube sourceTexture;\
+                    \
+                    float rnd(vec2 uv) {\
+                        return fract(sin(dot(uv, vec2(12.9898, 78.233) * 2.0)) * 43758.5453);\
+                    }\
+                    float GGXRoughnessToBlinnExponent( const in float ggxRoughness ) {\
+                        float a = ggxRoughness + 0.0001;\
+                        a *= a;\
+                        return ( 2.0 / a - 2.0 );\
+                    }\
+                    const float PI = 3.14159265358979;\
+                    vec3 ImportanceSamplePhong(vec2 uv, mat3 vecSpace, float specPow) {\
+                        float phi = uv.y * 2.0 * PI;\
+                        float cosTheta = pow(1.0 - uv.x, 1.0 / (specPow + 1.0));\
+                        float sinTheta = sqrt(1.0 - cosTheta * cosTheta);\
+                        vec3 sampleDir = vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);\
+                        return vecSpace * sampleDir;\
+                    }\
+                    vec3 ImportanceSampleGGX( vec2 uv, mat3 vecSpace, float Roughness )\
+                    {\
+                            float a = Roughness * Roughness;\
+                            float Phi = 2.0 * PI * uv.x;\
+                            float CosTheta = sqrt( (1.0 - uv.y) / ( 1.0 + (a*a - 1.0) * uv.y ) );\
+                            float SinTheta = sqrt( 1.0 - CosTheta * CosTheta );\
+                            return vecSpace * vec3(SinTheta * cos( Phi ), SinTheta * sin( Phi ), CosTheta);\
+                    }\
+                    mat3 matrixFromVector(vec3 n) {\
+                        float a = 1.0 / (1.0 + n.z);\
+                        float b = -n.x * n.y * a;\
+                        vec3 b1 = vec3(1.0 - n.x * n.x * a, b, -n.x);\
+                        vec3 b2 = vec3(b, 1.0 - n.y * n.y * a, -n.y);\
+                        return mat3(b1, b2, n);\
+                    }\
+                    \
+                    vec4 testColorMap() {\
+                        vec4 color;\
+                        if(faceIndex == 0)\
+                            color = vec4(1.0,0.0,0.0,1.0);\
+                        else if(faceIndex == 1)\
+                            color = vec4(0.0,1.0,0.0,1.0);\
+                        else if(faceIndex == 2)\
+                            color = vec4(0.0,0.0,1.0,1.0);\
+                        else if(faceIndex == 3)\
+                            color = vec4(1.0,1.0,0.0,1.0);\
+                        else if(faceIndex == 4)\
+                            color = vec4(0.0,1.0,1.0,1.0);\
+                        else\
+                            color = vec4(1.0,0.0,1.0,1.0);\n\
+                        return color;\
+                    }\
+                    \
+                    void main() {\
+                        vec3 sampleDirection;\
+                        vec2 uv = vUv*2.0 - 1.0;\
+                        uv.y *= -1.0;\
+                        if (faceIndex==0) {\
+                            sampleDirection = vec3(1.0, -uv.y, -uv.x);\
+                        }\
+                        else if (faceIndex==1) {\
+                            sampleDirection = vec3(-1.0, -uv.y, uv.x);\
+                        } else if (faceIndex==2) {\
+                            sampleDirection = vec3(uv.x, 1.0, uv.y);\
+                        } else if (faceIndex==3) {\
+                            sampleDirection = vec3(uv.x, -1.0, -uv.y);\
+                        } else if (faceIndex==4) {\
+                            sampleDirection = vec3(uv.x, -uv.y, 1.0);\
+                        } else {\
+                            sampleDirection = vec3(-uv.x, -uv.y, -1.0);\
+                        }\
+                        mat3 vecSpace = matrixFromVector(normalize(sampleDirection));\
+                        vec3 color = vec3(0.0);\
+                        const int NumSamples = 256;\
+                        vec3 vect;\
+                        float weight = 0.0;\
+                        for(int i=0; i<NumSamples; i++) {\
+                            float sini = sin(float(i));\
+                            float cosi = cos(float(i));\
+                            float rand = rnd(vec2(sini, cosi));\
+                            float blinnExp = GGXRoughnessToBlinnExponent(roughness);\
+                            vect = ImportanceSampleGGX(vec2(float(i) / float(NumSamples), rand), vecSpace, roughness);\
+                            float dotProd = dot(vect, normalize(sampleDirection));\
+                            weight += dotProd;\
+                            color += textureCube(sourceTexture, vect).rgb * dotProd;\
+                        }\
+                        color /= float(weight);\
+                        gl_FragColor = vec4( color, 1.0);\
+                   }";
+
+var materialPMREM = new THREE.ShaderMaterial(
+        {
+	uniforms: {
+		"faceIndex": { type: 'i', value: 0 },
+		"roughness": { type: 'f', value: 0.5 },
+		"sourceTexture": { type: 't', value: null }
+	},
+	vertexShader: vertexShaderPMREM,
+	fragmentShader: fragmentShaderPMREM
+        }
+);
+
+var PMREMGenerator = function( cubeTexture, resolution, numLods ) {
+
+	this.sourceTexture = cubeTexture;
+	this.cubeLods = [];
+	this.numSamplesPerLod = [];
+	this.numLods = numLods;
+	var size = resolution;
+	for ( var i = 0; i < this.numLods; i ++ ) {
+
+		var renderTarget = new THREE.WebGLRenderTargetCube( size, size,
+		{ format: THREE.RGBFormat, magFilter: THREE.LinearFilter, minFilter: THREE.LinearFilter } );
+		renderTarget.texture.generateMipmaps = false;
+		//renderTarget.texture.wrapS = THREE.ClampToEdgeWrapping;
+		//renderTarget.texture.wrapT = THREE.ClampToEdgeWrapping;
+		this.cubeLods.push( renderTarget );
+		if ( size > 16 )
+		size /= 2;
+
+	}
+
+	this.camera = new THREE.OrthographicCamera( - 1, 1, - 1, 1, - 0.01, 1000 );
+
+	this.planeMesh = new THREE.Mesh(
+	new THREE.PlaneGeometry( 2, 2, 0 ),
+	materialPMREM );
+	this.planeMesh.material.side = THREE.DoubleSide;
+	this.scene = new THREE.Scene();
+	this.scene.add( this.planeMesh );
+	this.scene.add( this.camera );
+
+	materialPMREM.uniforms[ "sourceTexture" ].value = this.sourceTexture;
+
+};
+
+PMREMGenerator.prototype = {
+	constructor : PMREMGenerator,
+
+	update: function( renderer ) {
+
+		materialPMREM.uniforms[ "sourceTexture" ].value = this.sourceTexture;
+		for ( var i = 0; i < this.numLods; i ++ ) {
+
+			materialPMREM.uniforms[ "roughness" ].value = i / ( this.numLods - 1 );
+			this.renderToCubeMapTarget( renderer, this.cubeLods[ i ] );
+			if ( i < 5 )
+			materialPMREM.uniforms[ "sourceTexture" ].value = this.cubeLods[ i ];
+
+		}
+
+	},
+
+	renderToCubeMapTarget: function( renderer, renderTarget ) {
+
+		for ( var i = 0; i < 6; i ++ )
+		this.renderToCubeMapTargetFace( renderer, renderTarget, i )
+
+	},
+
+	renderToCubeMapTargetFace: function( renderer, renderTarget, faceIndex ) {
+
+		renderTarget.activeCubeFace = faceIndex;
+		materialPMREM.uniforms[ "faceIndex" ].value = faceIndex;
+		renderer.render( this.scene, this.camera, renderTarget, true );
+
+	}
+};

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -3,6 +3,15 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+/*
+ * To avoid cube map seams, I create an extra pixel around each face. This way when the cube map is
+ * sampled by an application later(with a little care by sampling the centre of the texel), the extra 1 border
+ *  of pixels makes sure that there is no seams artifacts present. This works perfectly for cubeUV format as
+ *  well where the 6 faces can be arranged in any manner whatsoever.
+ * Code in the beginning of fragment shader's main function does this job for a given resolution.
+ *  Run Scene_PMREM_Test.html in the examples directory to see the sampling from the cube lods generated
+ *  by this class.
+ */
 var vertexShaderPMREM = "varying vec2 vUv;\
                    void main() {\
                         vUv = uv;\
@@ -13,6 +22,8 @@ var fragmentShaderPMREM = "varying vec2 vUv;\
                     uniform int faceIndex;\
                     uniform float roughness;\
                     uniform samplerCube sourceTexture;\
+                    uniform float mapSize;\
+                    uniform vec3 testColor;\
                     \
                     float rnd(vec2 uv) {\
                         return fract(sin(dot(uv, vec2(12.9898, 78.233) * 2.0)) * 43758.5453);\
@@ -66,7 +77,14 @@ var fragmentShaderPMREM = "varying vec2 vUv;\
                     void main() {\
                         vec3 sampleDirection;\
                         vec2 uv = vUv*2.0 - 1.0;\
-                        uv.y *= -1.0;\
+                        float offset = -1.0/mapSize;\
+                        const float a = -1.0;\
+                        const float b = 1.0;\
+                        float c = -1.0 + offset;\
+                        float d = 1.0 - offset;\
+                        float bminusa = b - a;\
+                        uv.x = (uv.x - a)/bminusa * d - (uv.x - b)/bminusa * c;\
+                        uv.y = (uv.y - a)/bminusa * d - (uv.y - b)/bminusa * c;\
                         if (faceIndex==0) {\
                             sampleDirection = vec3(1.0, -uv.y, -uv.x);\
                         }\
@@ -83,14 +101,13 @@ var fragmentShaderPMREM = "varying vec2 vUv;\
                         }\
                         mat3 vecSpace = matrixFromVector(normalize(sampleDirection));\
                         vec3 color = vec3(0.0);\
-                        const int NumSamples = 256;\
+                        const int NumSamples = 32;\
                         vec3 vect;\
                         float weight = 0.0;\
                         for(int i=0; i<NumSamples; i++) {\
                             float sini = sin(float(i));\
                             float cosi = cos(float(i));\
                             float rand = rnd(vec2(sini, cosi));\
-                            float blinnExp = GGXRoughnessToBlinnExponent(roughness);\
                             vect = ImportanceSampleGGX(vec2(float(i) / float(NumSamples), rand), vecSpace, roughness);\
                             float dotProd = dot(vect, normalize(sampleDirection));\
                             weight += dotProd;\
@@ -105,34 +122,52 @@ var materialPMREM = new THREE.ShaderMaterial(
 	uniforms: {
 		"faceIndex": { type: 'i', value: 0 },
 		"roughness": { type: 'f', value: 0.5 },
-		"sourceTexture": { type: 't', value: null }
+		"mapSize": { type: 'f', value: 0.5 },
+		"sourceTexture": { type: 't', value: null },
+		"testColor": { type: 'v3', value: new THREE.Vector3( 1, 1, 1 ) }
 	},
 	vertexShader: vertexShaderPMREM,
 	fragmentShader: fragmentShaderPMREM
         }
 );
 
-var PMREMGenerator = function( cubeTexture, resolution, numLods ) {
+var PMREMGenerator = function( cubeTexture ) {
 
+	if ( cubeTexture instanceof THREE.CubeTexture ) {
+
+		if ( cubeTexture.images[ 0 ] === undefined )
+		console.error( "CubeTexture Not Initialized" );
+		this.resolution = cubeTexture.images[ 0 ].width;
+
+	}
+	else if ( cubeTexture instanceof THREE.WebGLRenderTargetCube ) {
+
+		if ( cubeTexture === undefined )
+		console.error( "Render Target Not Initialized" );
+		this.resolution = cubeTexture.width;
+
+	}
+	else {
+
+		console.error( "Wrong Input to PMREMGenerator" );
+
+	}
 	this.sourceTexture = cubeTexture;
 	this.cubeLods = [];
-	this.numSamplesPerLod = [];
-	this.numLods = numLods;
-	var size = resolution;
+	var size = this.resolution;
+	this.numLods = Math.log2( size ) - 2;
 	for ( var i = 0; i < this.numLods; i ++ ) {
 
 		var renderTarget = new THREE.WebGLRenderTargetCube( size, size,
 		{ format: THREE.RGBFormat, magFilter: THREE.LinearFilter, minFilter: THREE.LinearFilter } );
 		renderTarget.texture.generateMipmaps = false;
-		//renderTarget.texture.wrapS = THREE.ClampToEdgeWrapping;
-		//renderTarget.texture.wrapT = THREE.ClampToEdgeWrapping;
 		this.cubeLods.push( renderTarget );
 		if ( size > 16 )
 		size /= 2;
 
 	}
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, - 1, 1, - 0.01, 1000 );
+	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0.0, 1000 );
 
 	this.planeMesh = new THREE.Mesh(
 	new THREE.PlaneGeometry( 2, 2, 0 ),
@@ -149,12 +184,28 @@ var PMREMGenerator = function( cubeTexture, resolution, numLods ) {
 PMREMGenerator.prototype = {
 	constructor : PMREMGenerator,
 
+	/*
+	     * More thought and work is needed here.
+	     * Right now it's a kind of a hack to use the previously convolved map to convolve the current one.
+	     * I tried to use the original map to convolve all the lods, but for many textures(specially the high frequency)
+	     * even a high number of samples(1024) dosen't lead to satisfactory results.
+	     * By using the previous convolved maps, a lower number of samples are generally sufficient(right now 32, which
+	     * gives okay results unless we see the reflection very carefully, or zoom in too much), however the math
+	     * goes wrong as the distribution function tries to sample a larger area than what it should be. So I simply scaled
+	     * the roughness by 0.9(totally empirical) to try to visually match the original result.
+	     * The condition "if(i <5)" is also an attemt to make the result match the original result.
+	     * This method requires the most amount of thinking I guess. Here is a paper which we could try to implement in future::
+	     * http://http.developer.nvidia.com/GPUGems3/gpugems3_ch20.html
+	     */
 	update: function( renderer ) {
 
 		materialPMREM.uniforms[ "sourceTexture" ].value = this.sourceTexture;
 		for ( var i = 0; i < this.numLods; i ++ ) {
 
-			materialPMREM.uniforms[ "roughness" ].value = i / ( this.numLods - 1 );
+			var r = i / ( this.numLods - 1 );
+			materialPMREM.uniforms[ "roughness" ].value = r * 0.9;
+			var size = this.cubeLods[ i ].width;
+			materialPMREM.uniforms[ "mapSize" ].value = size;
 			this.renderToCubeMapTarget( renderer, this.cubeLods[ i ] );
 			if ( i < 5 )
 			materialPMREM.uniforms[ "sourceTexture" ].value = this.cubeLods[ i ];
@@ -172,6 +223,7 @@ PMREMGenerator.prototype = {
 
 	renderToCubeMapTargetFace: function( renderer, renderTarget, faceIndex ) {
 
+		renderTarget.texture.generateMipmaps = false;
 		renderTarget.activeCubeFace = faceIndex;
 		materialPMREM.uniforms[ "faceIndex" ].value = faceIndex;
 		renderer.render( this.scene, this.camera, renderTarget, true );

--- a/src/extras/PMREM_CubeUVPacker.js
+++ b/src/extras/PMREM_CubeUVPacker.js
@@ -1,0 +1,172 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+/*
+ * This class takes the cube lods(corresponding to different roughness values), and creates a single cubeUV
+ * Texture. The format for a given roughness set of faces is simply::
+ * +X+Y+Z
+ * -X-Y-Z
+ * For every roughness a mip map chain is also saved, which is essential to remove the texture artifacts due to
+ * minification.
+ * Right now for every face a PlaneMesh is drawn, which leads to a lot of geometry draw calls, but can be replaced
+ * later by drawing a single buffer and by sending the appropriate faceIndex via vertex attributes.
+ * The arrangement of the faces is fixed, as assuming this arrangement, the sampling function has been written.
+ * Run Scene_PMREM_CubeUV_PackingTest.html in the examples directory to visualize the packing.
+ * Run Scene_PMREM_CubeUV_Test.html and  Scene_DynamicPMREM.html in the examples directory to see the
+ * working code using this packing.
+ */
+var vertexShaderPMREMCubeUV = "precision highp float;\
+                   varying vec2 vUv;\
+                   void main() {\
+                        vUv = uv;\
+                        gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\
+                   }";
+
+var fragmentShaderPMREMCubeUV = "precision highp float;\
+    varying vec2 vUv;\
+    uniform samplerCube cubeTexture;\
+    uniform float mapSize;\
+    uniform vec3 testColor;\
+    uniform int faceIndex;\
+    \
+    const float PI = 3.14159265358979;\
+    vec4 sampleCubeMap(float phi, float theta) {\
+        float sinTheta = sin(theta);\
+        float cosTheta = cos(theta);\
+        vec3 sampleDir = vec3(cos(phi) * sinTheta, cosTheta, sin(phi) * sinTheta);\
+        vec4 color = textureCube(cubeTexture, sampleDir);\
+        return color * vec4(testColor, 1.0);\
+    }\
+    void main() {\
+        vec3 sampleDirection;\
+        vec2 uv = vUv;\
+        uv = uv * 2.0 - 1.0;\
+        uv.y *= -1.0;\
+        if(faceIndex == 0) {\
+            sampleDirection = normalize(vec3(1.0, uv.y, -uv.x));\
+        }\
+        else if(faceIndex == 1) {\
+            sampleDirection = normalize(vec3(uv.x, 1.0, uv.y));\
+        }\
+        else if(faceIndex == 2) {\
+            sampleDirection = normalize(vec3(uv.x, uv.y, 1.0));\
+        }\
+        else if(faceIndex == 3) {\
+            sampleDirection = normalize(vec3(-1.0, uv.y, uv.x));\
+        }\
+        else if(faceIndex == 4) {\
+            sampleDirection = normalize(vec3(uv.x, -1.0, -uv.y));\
+        }\
+        else {\
+            sampleDirection = normalize(vec3(-uv.x, uv.y, -1.0));\
+        }\
+        vec4 color = textureCube(cubeTexture, (sampleDirection));\
+        gl_FragColor = color * vec4(testColor, 1.0);\
+    }\
+";
+var uniformsPMREMCubeUV = {
+	"faceIndex": { type: 'i', value: 0 },
+	"mapSize": { type: 'f', value: 0 },
+	"cubeTexture": { type: 't', value: null },
+	"testColor": { type: 'v3', value: new THREE.Vector3( 1, 1, 1 ) }
+};
+
+var testColor = [];
+testColor.push( new THREE.Vector3( 1, 0, 0 ) );
+testColor.push( new THREE.Vector3( 0, 1, 0 ) );
+testColor.push( new THREE.Vector3( 0, 0, 1 ) );
+testColor.push( new THREE.Vector3( 1, 1, 0 ) );
+testColor.push( new THREE.Vector3( 0, 1, 1 ) );
+testColor.push( new THREE.Vector3( 1, 0, 1 ) );
+testColor.push( new THREE.Vector3( 1, 1, 1 ) );
+testColor.push( new THREE.Vector3( 0.5, 1, 0.5 ) );
+
+var PMREM_CubeUVPacker = function( cubeTextureLods, numLods ) {
+
+	this.cubeLods = cubeTextureLods;
+	this.numLods = numLods;
+	var size = cubeTextureLods[ 0 ].width * 4;
+
+	this.CubeUVRenderTarget = new THREE.WebGLRenderTarget( size, size,
+	{ format: THREE.RGBFormat, magFilter: THREE.LinearFilter, minFilter: THREE.LinearFilter } );
+	this.CubeUVRenderTarget.texture.generateMipmaps = false;
+
+	this.camera = new THREE.OrthographicCamera( - size * 0.5, size * 0.5, - size * 0.5, size * 0.5, 0.0, 1000 );
+
+	this.scene = new THREE.Scene();
+	this.scene.add( this.camera );
+
+	this.objects = [];
+	var xOffset = 0;
+	var faceOffsets = [];
+	faceOffsets.push( new THREE.Vector2( 0, 0 ) );
+	faceOffsets.push( new THREE.Vector2( 1, 0 ) );
+	faceOffsets.push( new THREE.Vector2( 2, 0 ) );
+	faceOffsets.push( new THREE.Vector2( 0, 1 ) );
+	faceOffsets.push( new THREE.Vector2( 1, 1 ) );
+	faceOffsets.push( new THREE.Vector2( 2, 1 ) );
+	var yOffset = 0;
+	var textureResolution = size;
+	size = cubeTextureLods[ 0 ].width;
+
+	var offset2 = 0;
+	var c = 4.0;
+	this.numLods = Math.log2( cubeTextureLods[ 0 ].width ) - 2;
+	for ( var i = 0; i < this.numLods; i ++ ) {
+
+		var offset1 = ( textureResolution - textureResolution / c ) * 0.5;
+		if ( size > 16 )
+		c *= 2;
+		var nMips = size > 16 ? 6 : 1;
+		var mipOffsetX = 0;
+		var mipOffsetY = 0;
+		var mipSize = size;
+		for ( var j = 0; j < nMips; j ++ ) {
+
+			// Mip Maps
+			for ( var k = 0; k < 6; k ++ ) {
+
+				// 6 Cube Faces
+				var material = new THREE.ShaderMaterial();
+				material.vertexShader = vertexShaderPMREMCubeUV;
+				material.fragmentShader = fragmentShaderPMREMCubeUV;
+				material.uniforms = THREE.UniformsUtils.clone( uniformsPMREMCubeUV );
+				material.uniforms[ "cubeTexture" ].value = this.cubeLods[ i ];
+				material.uniforms[ "faceIndex" ].value = k;
+				material.uniforms[ "mapSize" ].value = mipSize;
+				var color = material.uniforms[ "testColor" ].value;
+				//color.copy(testColor[j]);
+				var planeMesh = new THREE.Mesh(
+				new THREE.PlaneGeometry( mipSize, mipSize, 0 ),
+				material );
+				planeMesh.position.x = faceOffsets[ k ].x * mipSize - offset1 + mipOffsetX;
+				planeMesh.position.y = faceOffsets[ k ].y * mipSize - offset1 + offset2 + mipOffsetY;
+				planeMesh.material.side = THREE.DoubleSide;
+				this.scene.add( planeMesh );
+				this.objects.push( planeMesh );
+
+			}
+			mipOffsetY += 1.75 * mipSize;
+			mipOffsetX += 1.25 * mipSize;
+			mipSize /= 2;
+
+		}
+		offset2 += 2 * size;
+		if ( size > 16 )
+		size /= 2;
+
+	}
+
+};
+
+PMREM_CubeUVPacker.prototype = {
+	constructor : PMREM_CubeUVPacker,
+
+	update: function( renderer ) {
+
+		renderer.render( this.scene, this.camera, this.CubeUVRenderTarget, true );
+
+	}
+};


### PR DESCRIPTION
Hi Guys,
I have written a simple class PMREMGenerator for Convolving the Environment maps corresponding to various roughness values. This is just a start and I was doing some experiments to see if we can do it at run time, generating LatLon/cubeUV maps from the convolved cube maps etc. I think it requires some refactoring as well, but I think, that can be done later when this class is completely ready for use.
Some of the code is still experimental, as I was trying to make it run at every frame. I think, that if we go for Physically believable approach, rather than Physically accurate, it's quite possible, as it can be possible to make the sample count as low as 32, in which case I get 60 fps on my Mac Book Pro(Intel HD Graphics 4000 1024 MB). That way, it could be possible to generate dynamic filtered cube maps.
Here is a very basic result, which I created using my custom shader where for each sphere, one of the convolved cube map texture is applied::
![screen shot 2015-12-22 at 7 49 43 am](https://cloud.githubusercontent.com/assets/7601170/12078526/c66f3e84-b23b-11e5-9f29-03291cb26a54.png)
Now I need some help from ThreeJS experts regarding how to use the convolved cube maps which this class generates as an array of WebGLRenderTargetCube.
I think the best way would be, to be able to directly write these convolved cube maps into the mip map level of a cube texture. Once that is done, I think the code is already there in ThreeJS which can handle the selection of appropriate lod from a given roughness value.
Other option would be to read back the data from each of the WebGLRenderTargetCube, and then manually upload the mip maps for the cube texture. 
I am not sure, of how to do the above two options in ThreeJS currently so, if someone could shed some light on the way to achieve that, it would be great.

Apart from this, I also have written a simple LaLon Map converter(Also runs on the GPU, and not Included here right now), which creates a packed map of LaLon maps of varying roughness, and mip levels, from the array of WebGLRenderTargetCube generated by this class. Here is a preview of that::
![latlon packed](https://cloud.githubusercontent.com/assets/7601170/12078587/e94f8fb0-b23d-11e5-86c0-ca4d2550ac4c.png)
Basically for each LatLon map, which corresponds to a given roughness, I also store the mip maps. These mip maps helps a lot in alleviating the moire patterns while minification. I have written a custom shader to sample from this latlon map for various roughness values and also removing the moire patterns by selecting the appropriate mip levels, and then doing a trilinear interpolation to blend the results.
I think that LatLon maps have this advantage over the cube maps, as we can't have the mip map levels for each of the roughness.
Probably a cubeUV format can also solve this problem, and I am experimenting with that currently.

But I think first of all, if we can use these array of WebGLRenderTargetCube textures for lod(roughness) selection, it would be a good first step forward. Thanks for your support.
