### PR TITLE
Fixed horizontal VR-effect for some mobile browsers

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -127,13 +127,33 @@ THREE.VREffect = function ( renderer, onError ) {
 			cameraR.translateX( eyeTranslationR.x * this.scale );
 
 			// render left eye
-			renderer.setViewport( 0, 0, size.width / 2, size.height );
-			renderer.setScissor( 0, 0, size.width / 2, size.height );
+			if (size.width > size.height) {
+
+				renderer.setViewport( 0, 0, size.width / 2, size.height );
+				renderer.setScissor( 0, 0, size.width / 2, size.height );
+
+			} else {
+
+				renderer.setViewport( 0, 0, size.width, size.height / 2 );
+				renderer.setScissor( 0, 0, size.width, size.height / 2 );
+
+			}
+
 			renderer.render( scene, cameraL );
 
 			// render right eye
-			renderer.setViewport( size.width / 2, 0, size.width / 2, size.height );
-			renderer.setScissor( size.width / 2, 0, size.width / 2, size.height );
+			if (size.width > size.height) {
+
+				renderer.setViewport( size.width / 2, 0, size.width / 2, size.height );
+				renderer.setScissor( size.width / 2, 0, size.width / 2, size.height );
+
+			} else {
+
+				renderer.setViewport( 0, size.height / 2, size.width, size.height / 2 );
+				renderer.setScissor( 0, size.height / 2, size.width, size.height / 2 );
+
+			}
+
 			renderer.render( scene, cameraR );
 
 			renderer.setScissorTest( false );


### PR DESCRIPTION
Some mobile browsers (Chrome 46, Firefox 43 Release) does not change orientation in fullscreen mode (with disabled auto rotation). This causes horizontal splitting for VR mode.

I have tested on Samsung Note 4:
Chrome 34.0.1847 Mobile (Android 4.4.4 stock) - now works fine
Chrome 46.0.2490 Mobile - now works fine
Firefox Mobile 43 (Release) - now works fine
~~Firefox Mobile 46 (Nightly) - with this change splitting works as before, but dev branch broken rotation of cameras in VR-mode.~~

https://mozvr.github.io/panorama-viewer/ - example with incorrect splitting
