### PR TITLE
Fix for incorrect diffuse color being used.

### DIFF
--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -126,7 +126,7 @@ THREE.Loader.prototype = {
 
 				switch ( name ) {
 					case 'DbgColor':
-						json.color = value;
+						if (json.color === undefined) json.color = value;
 						break;
 					case 'DbgIndex':
 					case 'opticalDensity':


### PR DESCRIPTION
I found this issue testing the blender exporter. Basically randomly the
wrong diffuse color would be used. This was because the order of the
json properties would be different, and the DbgColor would overwrite the
colorDiffuse, this patch checks if the color has already been set and
doesn't set it to DbgColor.
