### PR TITLE
Make object3d hierarchy children inherit parents' layers

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1336,13 +1336,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
-		}
+			var children = object.children;
 
-		var children = object.children;
+			for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-		for ( var i = 0, l = children.length; i < l; i ++ ) {
+				projectObject( children[ i ], camera );
 
-			projectObject( children[ i ], camera );
+			}
 
 		}
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -360,28 +360,32 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 
 		if ( object.visible === false ) return;
 
-		if ( object.layers.test( camera.layers ) && ( object instanceof THREE.Mesh || object instanceof THREE.Line || object instanceof THREE.Points ) ) {
+		if ( object.layers.test( camera.layers ) ) {
 
-			if ( object.castShadow && ( object.frustumCulled === false || _frustum.intersectsObject( object ) === true ) ) {
+			if ( object instanceof THREE.Mesh || object instanceof THREE.Line || object instanceof THREE.Points ) {
 
-				var material = object.material;
+				if ( object.castShadow && ( object.frustumCulled === false || _frustum.intersectsObject( object ) === true ) ) {
 
-				if ( material.visible === true ) {
+					var material = object.material;
 
-					object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
-					_renderList.push( object );
+					if ( material.visible === true ) {
+
+						object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
+						_renderList.push( object );
+
+					}
 
 				}
-
+			
 			}
 
-		}
+			var children = object.children;
 
-		var children = object.children;
+			for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-		for ( var i = 0, l = children.length; i < l; i ++ ) {
+				projectObject( children[ i ], camera, shadowCamera );
 
-			projectObject( children[ i ], camera, shadowCamera );
+			}
 
 		}
 


### PR DESCRIPTION
If a parent is in one layer, the parent's children should inherit that.

This way, we can have two subtrees, e.g. in a stereo setting, one for left eye and one for right.

This avoids having to traverse the entire object3d hierarchy before rendering to set the right mask for each object3d 
Also, projectObject() doesn't have to unnecessarily traverse subtrees that can be culled at the root
