### PR TITLE
npm - include examples

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-examples/
 src/
 test/
 utils/


### PR DESCRIPTION
The `examples` directory includes some important classes like `OBJMTLLoader`.
They are not accessible from the npm package.
To resolve this, I suggest that the examples directory be included in the npm package.
They do **not** need to be added to the bundle.
