### PR TITLE
Removed deprecated code in webgl_postprocessing_advanced.html

### DIFF
--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -117,7 +117,7 @@
 				//
 
 				var materialColor = new THREE.MeshBasicMaterial( {
-					map: THREE.ImageUtils.loadTexture( "textures/cube/SwedishRoyalCastle/pz.jpg" ),
+					map:  new THREE.TextureLoader().load( "textures/cube/SwedishRoyalCastle/pz.jpg" ),
 					depthTest: false
 				} );
 
@@ -334,13 +334,13 @@
 
 			function createMesh( geometry, scene, scale ) {
 
-				var mat2 = new THREE.MeshLambertMaterial( {
+				var mat2 = new THREE.MeshPhongMaterial( {
 
 					color: 0x999999,
 					specular: 0x080808,
 					shininess: 20,
-					map: THREE.ImageUtils.loadTexture( "obj/leeperrysmith/Map-COL.jpg" ),
-					normalMap: THREE.ImageUtils.loadTexture( "obj/leeperrysmith/Infinite-Level_02_Tangent_SmoothUV.jpg" ),
+					map: new THREE.TextureLoader().load( "obj/leeperrysmith/Map-COL.jpg" ),
+					normalMap: new THREE.TextureLoader().load("obj/leeperrysmith/Infinite-Level_02_Tangent_SmoothUV.jpg" ),
 					normalScale: new THREE.Vector2( 0.75, 0.75 )
 
 				} );


### PR DESCRIPTION
When i've tried to develop the alternative masking approach, i've noticed some deprecated code in `webgl_postprocessing_advanced.html`. This PR should remove all respective warnings.
