### PR TITLE
Removed deprecated code in other post-processing examples

### DIFF
--- a/examples/js/crossfade/scenes.js
+++ b/examples/js/crossfade/scenes.js
@@ -86,7 +86,7 @@ function Scene ( type, numObjects, cameraZ, fov, rotationSpeed, clearColor ) {
 	this.scene.add( light );
 
 	this.rotationSpeed = rotationSpeed;
-	defaultMaterial = new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors	} );
+	defaultMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors } );
 	this.mesh = new THREE.Mesh( generateGeometry( type, numObjects ), defaultMaterial );
 	this.scene.add( this.mesh );
 

--- a/examples/js/crossfade/transition.js
+++ b/examples/js/crossfade/transition.js
@@ -6,7 +6,7 @@ function Transition ( sceneA, sceneB ) {
 
 	this.textures = [];
 	for ( var i = 0; i < 6; i ++ )
-		this.textures[ i ] = new THREE.ImageUtils.loadTexture( 'textures/transition/transition' + ( i + 1 ) + '.png' );
+		this.textures[ i ] = new THREE.TextureLoader().load( 'textures/transition/transition' + ( i + 1 ) + '.png' );
 
 	this.quadmaterial = new THREE.ShaderMaterial( {
 

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -13,6 +13,7 @@
 				font-size:13px;
 				text-align:center;
 				font-weight: bold;
+				text-align:center;
 			}
 
 			a {
@@ -62,8 +63,7 @@
 			var camera, scene, renderer,
 				materials = [], objects = [],
 				singleMaterial, zmaterial = [],
-				parameters, i, j, k, h, color, x, y, z, s, n, nobjects,
-				material_depth, cubeMaterial;
+				parameters, i, j, k, h, color, x, y, z, s, n, nobjects, cubeMaterial;
 
 			var mouseX = 0, mouseY = 0;
 
@@ -95,8 +95,6 @@
 
 				renderer.sortObjects = false;
 
-				material_depth = new THREE.MeshDepthMaterial();
-
 				var path = "textures/cube/SwedishRoyalCastle/";
 				var format = '.jpg';
 				var urls = [
@@ -105,7 +103,7 @@
 						path + 'pz' + format, path + 'nz' + format
 					];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 
 				parameters = { color: 0xff1100, envMap: textureCube, shading: THREE.FlatShading };
 				cubeMaterial = new THREE.MeshBasicMaterial( parameters );

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -22,16 +22,12 @@
 
 			#info {
 				color:#fff;
-
+				position: relative;
 				top: 0px;
-
-				position: absolute;
+				width: 100em;
+				margin: 0 auto -2.1em;
 				padding: 5px;
-				width: 500px;
-				z-index: 5;
-
-				left: 50px;
-
+				z-index:100;
 			}
 		</style>
 	</head>
@@ -41,23 +37,17 @@ Use WEBGL Depth buffer support?
 -->
 	<body>
 		<script src="../build/three.min.js"></script>
-
+		<script src="js/shaders/BokehShader2.js"></script>
 
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
-
 		<script src='js/libs/dat.gui.min.js'></script>
 
 		<div id="info">
-
-
-	<a href="http://threejs.org" target="_blank">three.js</a> - webgl realistic depth-of-field bokeh example<br/>
-	shader ported from <a href="http://blenderartists.org/forum/showthread.php?237488-GLSL-depth-of-field-with-bokeh-v2-4-(update)">Martins Upitis</a>
-
+			<a href="http://threejs.org" target="_blank">three.js</a> - webgl realistic depth-of-field bokeh example -
+			shader ported from <a href="http://blenderartists.org/forum/showthread.php?237488-GLSL-depth-of-field-with-bokeh-v2-4-(update)">Martins Upitis</a>
 		</div>
 
-
-		<script src="js/shaders/BokehShader2.js"></script>
 		<script>
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
@@ -120,7 +110,7 @@ Use WEBGL Depth buffer support?
 							 r + "posy.jpg", r + "negy.jpg",
 							 r + "posz.jpg", r + "negz.jpg" ];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls  );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 				textureCube.format = THREE.RGBFormat;
 
 				// Skybox


### PR DESCRIPTION
I've cleaned up the other post-processing examples so all legacy code warnings should be gone.
- replaced `THREE.ImageUtils.load` with `new THREE.TextureLoader().load`
- replaced `THREE.ImageUtils.loadTextureCube` with `new THREE.CubeTextureLoader().load`
- change `THREE.MeshLambertMaterial` to `THREE.MeshPhongMaterial` (so the shading-property works again)
- little fixes in CSS and HTML
