### PR TITLE
create "three.js" npm shim for "three" npm package.

### DIFF
--- a/utils/npm/node_modules/three.js/README.md
+++ b/utils/npm/node_modules/three.js/README.md
@@ -1,0 +1,10 @@
+three.js
+========
+
+**IMPORTANT NOTE**
+
+This ```three.js``` NPM package has been deprecated in favor of the three package available here:
+
+[Three NPM Package](http://npmjs.org/packages/three/)
+
+This NPM package currently acts as a shim for the three NPM package.

--- a/utils/npm/node_modules/three.js/package.json
+++ b/utils/npm/node_modules/three.js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "three.js",
+  "version": "0.73.2",
+  "description": "Note: 'three.js' npm package has been deprecated in favor of the 'three' npm package.",
+  "main": "shim.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mrdoob/three.js.git"
+  },
+  "author": {
+    "name": "mrdoob"
+  },
+  "dependencies": {
+    "three": "0.73.0"
+  }
+}

--- a/utils/npm/node_modules/three.js/shim.js
+++ b/utils/npm/node_modules/three.js/shim.js
@@ -1,0 +1,12 @@
+var THREE = require('three');
+
+console.warn( "WARNING: The 'three.js' npm package is deprecated in favor of the 'three' npm package, please upgrade.");
+
+if (typeof exports !== 'undefined') {
+  if (typeof module !== 'undefined' && module.exports) {
+    exports = module.exports = THREE;
+  }
+  exports.THREE = THREE;
+} else {
+  this['THREE'] = THREE;
+}


### PR DESCRIPTION
Create a three.js npm module that is a shim for the three npm module.  Submitting it back to the project if we ever need to do another shim to change the npm module name.

This ensures that both the `three.js` npm module works, at least the most recent version, it prints out a warning when used, and that there is no duplication of the code.  It is a simple matter for users to switch from the npm package `three.js` to `three` because they are essentially the same.

I have already pushed this version of the three.js shim to here:

https://www.npmjs.com/package/three.js

It isn't pretty but I think it gets the message across.

(Removed comment about needing @mrdoob to run the npm deprecate command, I was able to do it.)

I can update the wording on the NPM three.js package page to whatever you guys want.

/ping @DelvarWorld @toxicFork
