### PR TITLE
faster BufferGeometry.computeBoundingBox()

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -563,12 +563,32 @@ THREE.BufferGeometry.prototype = {
 				var bb = this.boundingBox;
 				bb.makeEmpty();
 
+				var minX = +Infinity;
+				var minY = +Infinity;
+				var minZ = +Infinity;
+
+				var maxX = -Infinity;
+				var maxY = -Infinity;
+				var maxZ = -Infinity;
+
 				for ( var i = 0, il = positions.length; i < il; i += 3 ) {
 
-					vector.fromArray( positions, i );
-					bb.expandByPoint( vector );
+					var x = positions[ i     ];
+					var y = positions[ i + 1 ];
+					var z = positions[ i + 2 ];
+
+					minX = Math.min( minX, x );
+					minY = Math.min( minY, y );
+					minZ = Math.min( minZ, z );
+
+					maxX = Math.max( maxX, x );
+					maxY = Math.max( maxY, y );
+					maxZ = Math.max( maxZ, z );
 
 				}
+
+				this.boundingBox.min.set( minX, minY, minZ );
+				this.boundingBox.max.set( maxX, maxY, maxZ );
 
 			}
 


### PR DESCRIPTION
This directly calculates the min and max of the bounding box instead of using the Box3 methods. It is much faster, especially for larger meshes. Not sure if such code expansion is desired for the library, just a suggestion. There are other places that could be optimized similarly.
