### PR TITLE
Removed deprecated THREE.ImageUtils.loadTextureCube in examples

### DIFF
--- a/docs/scenes/js/material.js
+++ b/docs/scenes/js/material.js
@@ -104,10 +104,10 @@ var envMaps = (function () {
 		path + 'pz' + format, path + 'nz' + format
 	];
 
-	var reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+	var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 	reflectionCube.format = THREE.RGBFormat;
 
-	var refractionCube = THREE.ImageUtils.loadTextureCube( urls );
+	var refractionCube = new THREE.CubeTextureLoader().load( urls );
 	refractionCube.mapping = THREE.CubeRefractionMapping;
 	refractionCube.format = THREE.RGBFormat;
 

--- a/examples/js/loaders/deprecated/SceneLoader.js
+++ b/examples/js/loaders/deprecated/SceneLoader.js
@@ -910,7 +910,8 @@ THREE.SceneLoader.prototype = {
 
 				} else {
 
-					texture = THREE.ImageUtils.loadTextureCube( url_array, textureJSON.mapping, generateTextureCallback( count ) );
+					texture = new THREE.CubeTextureLoader().load( urls, generateTextureCallback( count ) );
+					texture.mapping = textureJSON.mapping;
 
 				}
 

--- a/examples/misc_fps.html
+++ b/examples/misc_fps.html
@@ -214,7 +214,7 @@
 			// init 3D stuff
 
 			function makeSkybox( urls, size ) {
-				var skyboxCubemap = THREE.ImageUtils.loadTextureCube( urls );
+				var skyboxCubemap = new THREE.CubeTextureLoader().load( urls );
 				skyboxCubemap.format = THREE.RGBFormat;
 
 				var skyboxShader = THREE.ShaderLib['cube'];

--- a/examples/webgl_effects_anaglyph.html
+++ b/examples/webgl_effects_anaglyph.html
@@ -85,7 +85,7 @@
 					path + 'pz' + format, path + 'nz' + format
 				];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 				var material = new THREE.MeshBasicMaterial( { color: 0xffffff, envMap: textureCube } );
 
 				for ( var i = 0; i < 500; i ++ ) {

--- a/examples/webgl_effects_parallaxbarrier.html
+++ b/examples/webgl_effects_parallaxbarrier.html
@@ -225,11 +225,13 @@
 				document.addEventListener('mousemove', onDocumentMouseMove, false);
 
 				var r = "textures/cube/Bridge2/";
-				var urls = [ r + "posx.jpg", r + "negx.jpg",
-							 r + "posy.jpg", r + "negy.jpg",
-							 r + "posz.jpg", r + "negz.jpg" ];
+				var urls = [
+					r + "posx.jpg", r + "negx.jpg",
+					r + "posy.jpg", r + "negy.jpg",
+					r + "posz.jpg", r + "negz.jpg"
+				];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 
 				// common materials
 

--- a/examples/webgl_effects_stereo.html
+++ b/examples/webgl_effects_stereo.html
@@ -86,7 +86,9 @@
 					path + 'pz' + format, path + 'nz' + format
 				];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls, THREE.CubeRefractionMapping );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
+				textureCube.mapping = THREE.CubeRefractionMapping;
+				
 				var material = new THREE.MeshBasicMaterial( { color: 0xffffff, envMap: textureCube, refractionRatio: 0.95 } );
 
 				for ( var i = 0; i < 500; i ++ ) {

--- a/examples/webgl_geometry_teapot.html
+++ b/examples/webgl_geometry_teapot.html
@@ -121,11 +121,13 @@
 
 				// REFLECTION MAP
 				var path = "textures/cube/skybox/";
-				var urls = [ path + "px.jpg", path + "nx.jpg",
-							 path + "py.jpg", path + "ny.jpg",
-							 path + "pz.jpg", path + "nz.jpg" ];
+				var urls = [
+					path + "px.jpg", path + "nx.jpg",
+					path + "py.jpg", path + "ny.jpg",
+					path + "pz.jpg", path + "nz.jpg"
+				];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 
 				// MATERIALS
 				var materialColor = new THREE.Color();

--- a/examples/webgl_loader_ctm_materials.html
+++ b/examples/webgl_loader_ctm_materials.html
@@ -109,12 +109,13 @@
 				sceneCube.add( cameraCube );
 
 				var r = "textures/cube/pisa/";
-				var urls = [ r + "px.png", r + "nx.png",
-							 r + "py.png", r + "ny.png",
-							 r + "pz.png", r + "nz.png" ];
+				var urls = [
+					r + "px.png", r + "nx.png",
+					r + "py.png", r + "ny.png",
+					r + "pz.png", r + "nz.png"
+				];
 
-
-				textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				textureCube = new THREE.CubeTextureLoader().load( urls );
 
 				var shader = THREE.ShaderLib[ "cube" ];
 				shader.uniforms[ "tCube" ].value = textureCube;

--- a/examples/webgl_loader_utf8.html
+++ b/examples/webgl_loader_utf8.html
@@ -84,7 +84,7 @@
 					path + 'pz' + format, path + 'nz' + format
 				];
 
-				reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+				reflectionCube = new THREE.CubeTextureLoader().load( urls );
 
 				// LIGHTS
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -261,10 +261,10 @@
 				path + 'pz' + format, path + 'nz' + format
 			];
 
-			var reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+			var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 			reflectionCube.format = THREE.RGBFormat;
 
-			var refractionCube = THREE.ImageUtils.loadTextureCube( urls );
+			var refractionCube = new THREE.CubeTextureLoader().load( urls );
 			reflectionCube.format = THREE.RGBFormat;
 			refractionCube.mapping = THREE.CubeRefractionMapping;
 

--- a/examples/webgl_materials_cars.html
+++ b/examples/webgl_materials_cars.html
@@ -229,11 +229,13 @@
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 
 				var r = "textures/cube/Bridge2/";
-				var urls = [ r + "posx.jpg", r + "negx.jpg",
-							 r + "posy.jpg", r + "negy.jpg",
-							 r + "posz.jpg", r + "negz.jpg" ];
+				var urls = [
+					r + "posx.jpg", r + "negx.jpg",
+					r + "posy.jpg", r + "negy.jpg",
+					r + "posz.jpg", r + "negz.jpg"
+				];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 				textureCube.format = THREE.RGBFormat;
 
 				// common materials

--- a/examples/webgl_materials_cubemap.html
+++ b/examples/webgl_materials_cubemap.html
@@ -105,10 +105,10 @@
 						path + 'pz' + format, path + 'nz' + format
 					];
 
-				var reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 				reflectionCube.format = THREE.RGBFormat;
 
-				var refractionCube = THREE.ImageUtils.loadTextureCube( urls );
+				var refractionCube = new THREE.CubeTextureLoader().load( urls );
 				refractionCube.mapping = THREE.CubeRefractionMapping;
 				refractionCube.format = THREE.RGBFormat;
 

--- a/examples/webgl_materials_cubemap_balls_reflection.html
+++ b/examples/webgl_materials_cubemap_balls_reflection.html
@@ -87,7 +87,7 @@
 					path + 'pz' + format, path + 'nz' + format
 				];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 				var material = new THREE.MeshBasicMaterial( { color: 0xffffff, envMap: textureCube } );
 
 				for ( var i = 0; i < 500; i ++ ) {

--- a/examples/webgl_materials_cubemap_balls_refraction.html
+++ b/examples/webgl_materials_cubemap_balls_refraction.html
@@ -86,7 +86,9 @@
 					path + 'pz' + format, path + 'nz' + format
 				];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls, THREE.CubeRefractionMapping );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
+				textureCube.mapping = THREE.CubeRefractionMapping;
+
 				var material = new THREE.MeshBasicMaterial( { color: 0xffffff, envMap: textureCube, refractionRatio: 0.95 } );
 
 				for ( var i = 0; i < 500; i ++ ) {

--- a/examples/webgl_materials_cubemap_escher.html
+++ b/examples/webgl_materials_cubemap_escher.html
@@ -78,17 +78,19 @@
 							 r + "py.jpg", r + "ny.jpg",
 							 r + "pz.jpg", r + "nz.jpg" ];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 				*/
 
 				var r = "textures/cube/Escher/dds/";
 
-				var urls = [ r + "px.dds", r + "nx.dds",
-							 r + "py.dds", r + "ny.dds",
-							 r + "pz.dds", r + "nz.dds" ];
+				var urls = [
+					r + "px.dds", r + "nx.dds",
+					r + "py.dds", r + "ny.dds",
+					r + "pz.dds", r + "nz.dds"
+				];
 
 				var loader = new THREE.DDSLoader();
-				
+
 				var textureCube = loader.load( urls );
 				var material = new THREE.MeshBasicMaterial( { color: 0xffffff, envMap: textureCube } );
 				var geometry = new THREE.SphereGeometry( 100, 96, 64 );

--- a/examples/webgl_materials_cubemap_refraction.html
+++ b/examples/webgl_materials_cubemap_refraction.html
@@ -99,11 +99,14 @@
 
 				var r = "textures/cube/Park3Med/";
 
-				var urls = [ r + "px.jpg", r + "nx.jpg",
-							 r + "py.jpg", r + "ny.jpg",
-							 r + "pz.jpg", r + "nz.jpg" ];
+				var urls = [
+					r + "px.jpg", r + "nx.jpg",
+					r + "py.jpg", r + "ny.jpg",
+					r + "pz.jpg", r + "nz.jpg"
+				];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls, THREE.CubeRefractionMapping );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
+				textureCube.mapping = THREE.CubeRefractionMapping;
 
 				var cubeMaterial3 = new THREE.MeshBasicMaterial( { color: 0xccddff, envMap: textureCube, refractionRatio: 0.98, reflectivity:0.9 } );
 				var cubeMaterial2 = new THREE.MeshBasicMaterial( { color: 0xccfffd, envMap: textureCube, refractionRatio: 0.985 } );

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -134,7 +134,7 @@
 						path + 'pz' + format, path + 'nz' + format
 					];
 
-				var reflectionCube = THREE.ImageUtils.loadTextureCube( urls, THREE.CubeReflectionMapping );
+				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 
 				// material
 

--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -24,7 +24,7 @@
 	</head>
 
 	<body>
-		
+
 		<script src="../build/three.min.js"></script>
 
 		<script src="js/controls/OrbitControls.js"></script>
@@ -78,7 +78,7 @@
 							 r + "posy.jpg", r + "negy.jpg",
 							 r + "posz.jpg", r + "negz.jpg" ];
 
-				textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				textureCube = new THREE.CubeTextureLoader().load( urls );
 				textureCube.format = THREE.RGBFormat;
 				textureCube.mapping = THREE.CubeReflectionMapping;
 

--- a/examples/webgl_materials_shaders_fresnel.html
+++ b/examples/webgl_materials_shaders_fresnel.html
@@ -89,7 +89,7 @@
 					];
 
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 				textureCube.format = THREE.RGBFormat;
 
 				var shader = THREE.FresnelShader;

--- a/examples/webgl_materials_variations_basic.html
+++ b/examples/webgl_materials_variations_basic.html
@@ -80,7 +80,7 @@
 						path + 'pz' + format, path + 'nz' + format
 					];
 
-				var reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 				reflectionCube.format = THREE.RGBFormat;
 
 				var cubeWidth = 400;

--- a/examples/webgl_materials_variations_lambert.html
+++ b/examples/webgl_materials_variations_lambert.html
@@ -80,7 +80,7 @@
 						path + 'pz' + format, path + 'nz' + format
 					];
 
-				var reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 				reflectionCube.format = THREE.RGBFormat;
 
 				var cubeWidth = 400;

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -81,7 +81,7 @@
 						path + 'pz' + format, path + 'nz' + format
 					];
 
-				var reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 				reflectionCube.format = THREE.RGBFormat;
 
 				var cubeWidth = 400;

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -80,7 +80,7 @@
 						path + 'pz' + format, path + 'nz' + format
 					];
 
-				var reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 				reflectionCube.format = THREE.RGBFormat;
 
 				var cubeWidth = 400;

--- a/examples/webgl_materials_variations_standard2.html
+++ b/examples/webgl_materials_variations_standard2.html
@@ -80,7 +80,7 @@
 						path + 'pz' + format, path + 'nz' + format
 					];
 
-				var reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 				reflectionCube.format = THREE.RGBFormat;
 
 				var cubeWidth = 400;

--- a/examples/webgl_performance_doublesided.html
+++ b/examples/webgl_performance_doublesided.html
@@ -80,7 +80,7 @@
 						path + 'pz' + format, path + 'nz' + format
 					];
 
-				var reflectionCube = THREE.ImageUtils.loadTextureCube( urls );
+				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
 				reflectionCube.format = THREE.RGBFormat;
 
 				var material = new THREE.MeshPhongMaterial( { specular: 0x101010, shininess: 100, envMap: reflectionCube, combine: THREE.MixOperation, reflectivity: 0.1, side: THREE.DoubleSide } );

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -320,7 +320,7 @@
 							 r + "dark-s_py.jpg", r + "dark-s_ny.jpg",
 							 r + "dark-s_pz.jpg", r + "dark-s_nz.jpg" ];
 
-				var textureCube = THREE.ImageUtils.loadTextureCube( urls );
+				var textureCube = new THREE.CubeTextureLoader().load( urls );
 				textureCube.format = THREE.RGBFormat;
 				var skyboxShader = THREE.ShaderLib[ "cube" ];
 				skyboxShader.uniforms[ "tCube" ].value = textureCube;


### PR DESCRIPTION
This PR changes the following in the entire project, except Three.Legacy.js.

`THREE.ImageUtils.loadTextureCube`-> `THREE.CubeTextureLoader`

I've tested all examples with the new code.
