### PR TITLE
Lathe's custom UV mapping

### DIFF
--- a/editor/js/Sidebar.Geometry.LatheGeometry.js
+++ b/editor/js/Sidebar.Geometry.LatheGeometry.js
@@ -40,6 +40,17 @@ Sidebar.Geometry.LatheGeometry = function( editor, object ) {
 
 	container.add( phiLengthRow );
 
+	// mapping
+
+	var mappingRow = new UI.Row();
+	var mappingOptions = [ 'index', 'length' ];
+	var mapping = new UI.Select().setOptions( mappingOptions ).setValue( ( parameters.mapping || 'index' ).toLowerCase() === 'length' ? 1 : 0 ).onChange( update );
+
+	mappingRow.add( new UI.Text( 'Mapping' ).setWidth( '90px' ) );
+	mappingRow.add( mapping );
+
+	container.add( mappingRow );
+
 	// points
 
 	var lastPointIdx = 0;
@@ -129,7 +140,8 @@ Sidebar.Geometry.LatheGeometry = function( editor, object ) {
 			points,
 			segments.getValue(),
 			phiStart.getValue() / 180 * Math.PI,
-			phiLength.getValue() / 180 * Math.PI
+			phiLength.getValue() / 180 * Math.PI,
+			mappingOptions[ mapping.getValue() ]
 		);
 
 		editor.execute( new SetGeometryCommand( object, geometry ) );

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -263,7 +263,8 @@ THREE.ObjectLoader.prototype = {
 							data.points,
 							data.segments,
 							data.phiStart,
-							data.phiLength
+							data.phiLength,
+							data.mapping
 						);
 
 						break;


### PR DESCRIPTION
For my usage of LatheGeometry, I need a texture mapping that is proportional to the distance between the points.
As changing the UVs on an existing geometry is not something I master, it's easier for me to add an option to LatheGeometry.

So I added an extra parameters, mapping', that define the way the mapping is calculated. In this version mapping is not a constant but it should be.
You can see the difference in the editor as the parameter is managed.
