### PR TITLE
Refactor deprecated materials in some examples

### DIFF
--- a/examples/canvas_ascii_effect.html
+++ b/examples/canvas_ascii_effect.html
@@ -71,7 +71,7 @@
 				light.position.set( - 500, - 500, - 500 );
 				scene.add( light );
 
-				sphere = new THREE.Mesh( new THREE.SphereGeometry( 200, 20, 10 ), new THREE.MeshLambertMaterial( { shading: THREE.FlatShading } ) );
+				sphere = new THREE.Mesh( new THREE.SphereGeometry( 200, 20, 10 ), new THREE.MeshLambertMaterial() );
 				scene.add( sphere );
 
 				// Plane

--- a/examples/canvas_camera_orthographic.html
+++ b/examples/canvas_camera_orthographic.html
@@ -74,7 +74,7 @@
 				// Cubes
 
 				var geometry = new THREE.BoxGeometry( 50, 50, 50 );
-				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, overdraw: 0.5 } );
+				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, overdraw: 0.5 } );
 
 				for ( var i = 0; i < 100; i ++ ) {
 

--- a/examples/canvas_camera_orthographic2.html
+++ b/examples/canvas_camera_orthographic2.html
@@ -143,7 +143,7 @@
 				// Cubes
 
 				var geometry = new THREE.BoxGeometry( 50, 50, 50 );
-				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, overdraw: 0.5 } );
+				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, overdraw: 0.5 } );
 
 				for ( var i = 0; i < 100; i ++ ) {
 

--- a/examples/canvas_lights_pointlights.html
+++ b/examples/canvas_lights_pointlights.html
@@ -94,7 +94,7 @@
 				loader = new THREE.JSONLoader();
 				loader.load( 'obj/WaltHeadLo.js', function ( geometry ) {
 
-					mesh = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, overdraw: 0.5 } ) );
+					mesh = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { color: 0xffffff, overdraw: 0.5 } ) );
 					scene.add( mesh );
 
 				} );

--- a/examples/canvas_performance.html
+++ b/examples/canvas_performance.html
@@ -69,7 +69,7 @@
 				// Spheres
 
 				geometry = new THREE.SphereGeometry( 100, 26, 18 );
-				material = new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, overdraw: 0.5 } );
+				material = new THREE.MeshLambertMaterial( { color: 0xffffff, overdraw: 0.5 } );
 
 				for ( var i = 0; i < 20; i ++ ) {
 

--- a/examples/misc_lights_test.html
+++ b/examples/misc_lights_test.html
@@ -42,7 +42,7 @@
 
 			var camera, scene, canvasRenderer, webglRenderer;
 
-			var mesh, zmesh, geometry;
+			var mesh, zmesh, geometry, material;
 
 			var directionalLight, pointLight;
 
@@ -70,8 +70,8 @@
 
 				// Spheres
 
-				var geometry = new THREE.SphereGeometry( 100, 16, 8 );
-				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, overdraw: 0.5 } );
+				geometry = new THREE.SphereGeometry( 100, 16, 8 );
+				material = new THREE.MeshPhongMaterial( { color: 0xffffff, shading: THREE.FlatShading, overdraw: 0.5, shininess: 0 } );
 
 				for ( var i = 0; i < 30; i ++ ) {
 
@@ -86,8 +86,7 @@
 
 				// Torus
 
-				var geometry = new THREE.TorusGeometry( 100, 25, 15, 30 );
-				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, overdraw: 0.5 } );
+				geometry = new THREE.TorusGeometry( 100, 25, 15, 30 );
 				mesh = new THREE.Mesh( geometry, material );
 				scene.add( mesh );
 
@@ -108,9 +107,9 @@
 				pointLight = new THREE.PointLight( 0xffaa00 );
 				scene.add( pointLight );
 
-				var geometry = new THREE.SphereGeometry( 100, 8, 4 );
-				var material = new THREE.MeshBasicMaterial( { color: 0xffaa00 } );
-				var mesh = new THREE.Mesh( geometry, material );
+				geometry = new THREE.SphereGeometry( 100, 8, 4 );
+				material = new THREE.MeshBasicMaterial( { color: 0xffaa00 } );
+				mesh = new THREE.Mesh( geometry, material );
 				mesh.scale.set( 0.05, 0.05, 0.05 );
 				pointLight.add( mesh );
 

--- a/examples/misc_sound.html
+++ b/examples/misc_sound.html
@@ -88,9 +88,9 @@
 
 				var sphere = new THREE.SphereGeometry( 20, 32, 16 );
 
-				material_sphere1 = new THREE.MeshLambertMaterial( { color: 0xffaa00, shading: THREE.FlatShading } );
-				material_sphere2 = new THREE.MeshLambertMaterial( { color: 0xff2200, shading: THREE.FlatShading } );
-				material_sphere3 = new THREE.MeshLambertMaterial( { color: 0x6622aa, shading: THREE.FlatShading } );
+				material_sphere1 = new THREE.MeshPhongMaterial( { color: 0xffaa00, shading: THREE.FlatShading, shininess: 0 } );
+				material_sphere2 = new THREE.MeshPhongMaterial( { color: 0xff2200, shading: THREE.FlatShading, shininess: 0 } );
+				material_sphere3 = new THREE.MeshPhongMaterial( { color: 0x6622aa, shading: THREE.FlatShading, shininess: 0 } );
 
 				// sound spheres
 

--- a/examples/webgl_geometry_colors.html
+++ b/examples/webgl_geometry_colors.html
@@ -151,7 +151,7 @@
 
 				var materials = [
 
-					new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors } ),
+					new THREE.MeshPhongMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors, shininess: 0 } ),
 					new THREE.MeshBasicMaterial( { color: 0x000000, shading: THREE.FlatShading, wireframe: true, transparent: true } )
 
 				];

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -86,7 +86,7 @@
 				var geometry = new THREE.Geometry(),
 				pickingGeometry = new THREE.Geometry(),
 				pickingMaterial = new THREE.MeshBasicMaterial( { vertexColors: THREE.VertexColors } ),
-				defaultMaterial = new THREE.MeshLambertMaterial({ color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors	} );
+				defaultMaterial = new THREE.MeshPhongMaterial({ color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors, shininess: 0	} );
 
 				function applyVertexColors( g, c ) {
 

--- a/examples/webgl_lights_pointlights2.html
+++ b/examples/webgl_lights_pointlights2.html
@@ -130,7 +130,7 @@
 				// MATERIALS
 
 				var groundMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, map: texture } );
-				var objectMaterial = new THREE.MeshPhongMaterial( { color: 0x000000, specular: 0xffffff, map: texture2 } );
+				var objectMaterial = new THREE.MeshStandardMaterial( { color: 0x000000, map: texture2, roughness: 0.2, metalness: 1.0 } );
 
 				// GROUND
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -307,7 +307,7 @@
 
 			"shiny"  :
 			{
-				m: new THREE.MeshPhongMaterial( { color: 0x550000, specular: 0x440000, envMap: reflectionCube, combine: THREE.MixOperation, reflectivity: 0.3, metal: true } ),
+				m: new THREE.MeshStandardMaterial( { color: 0x550000, envMap: reflectionCube, roughness: 0.1, metalness: 1.0 } ),
 				h: 0, s: 0.8, l: 0.2
 			},
 

--- a/examples/webgl_modifier_subdivision.html
+++ b/examples/webgl_modifier_subdivision.html
@@ -249,7 +249,7 @@
 				group.add( mesh );
 
 				var meshmaterials = [
-					new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors } ),
+					new THREE.MeshPhongMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors, shininess: 0 } ),
 					new THREE.MeshBasicMaterial( { color: 0x405040, wireframe: true, opacity: 0.8, transparent: true } )
 				];
 

--- a/examples/webgl_multiple_canvases_circle.html
+++ b/examples/webgl_multiple_canvases_circle.html
@@ -283,7 +283,7 @@
 
 					var materials = [
 
-						new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors } ),
+						new THREE.MeshPhongMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors, shininess: 0 } ),
 						new THREE.MeshBasicMaterial( { color: 0x000000, shading: THREE.FlatShading, wireframe: true } )
 
 					];

--- a/examples/webgl_multiple_canvases_complex.html
+++ b/examples/webgl_multiple_canvases_complex.html
@@ -210,7 +210,7 @@
 
 					var materials = [
 
-						new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors } ),
+						new THREE.MeshPhongMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors, shininess: 0 } ),
 						new THREE.MeshBasicMaterial( { color: 0x000000, shading: THREE.FlatShading, wireframe: true, transparent: true } )
 
 					];

--- a/examples/webgl_multiple_canvases_grid.html
+++ b/examples/webgl_multiple_canvases_grid.html
@@ -226,7 +226,7 @@
 
 					var materials = [
 
-						new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors } ),
+						new THREE.MeshPhongMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors, shininess: 0 } ),
 						new THREE.MeshBasicMaterial( { color: 0x000000, shading: THREE.FlatShading, wireframe: true, transparent: true } )
 
 					];

--- a/examples/webgl_multiple_renderers.html
+++ b/examples/webgl_multiple_renderers.html
@@ -140,7 +140,7 @@
 
 				var materials = [
 
-					new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors } ),
+					new THREE.MeshPhongMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors, shininess: 0 } ),
 					new THREE.MeshBasicMaterial( { color: 0x000000, shading: THREE.FlatShading, wireframe: true, transparent: true } )
 
 				];

--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -207,7 +207,7 @@
 
 				var materials = [
 
-					new THREE.MeshLambertMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors } ),
+					new THREE.MeshPhongMaterial( { color: 0xffffff, shading: THREE.FlatShading, vertexColors: THREE.VertexColors, shininess: 0 } ),
 					new THREE.MeshBasicMaterial( { color: 0x000000, shading: THREE.FlatShading, wireframe: true, transparent: true } )
 
 				];

--- a/examples/webgl_shadowmesh.html
+++ b/examples/webgl_shadowmesh.html
@@ -163,7 +163,7 @@
 
 				// YELLOW PYRAMID and PYRAMID'S SHADOW
 				var pyramidGeometry = new THREE.CylinderGeometry( 0, 0.5, 2, 4 );
-				var pyramidMaterial = new THREE.MeshLambertMaterial( { color: 'rgb(255,255,0)', emissive: 0x440000, shading: THREE.FlatShading } );
+				var pyramidMaterial = new THREE.MeshPhongMaterial( { color: 'rgb(255,255,0)', emissive: 0x440000, shading: THREE.FlatShading, shininess: 0 } );
 				pyramid = new THREE.Mesh( pyramidGeometry, pyramidMaterial );
 				pyramid.position.set( - 4, 1, 2 );
 				scene.add( pyramid );


### PR DESCRIPTION
This PR changes some material settings in the examples...
- It replaces the combination of  `THREE.MeshPhongMaterial` and the deprecated `metal` property with a `THREE.MeshStandardMaterial`.
- The combination `THREE.MeshLambertMaterial` and `THREE.FlatShading` is replaced with a `THREE.MeshPhongMaterial`, `THREE.FlatShading` and a `shininess` value of zero.
- In all canvas examples, i just removed `THREE.FlatShading` from `THREE.MeshLambertMaterial`. I think the usage of a `THREE.MeshPhongMaterial` makes no sense in these cases...
