### PR TITLE
WebGLState: Added clearDepth and clearStencil

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -52,14 +52,17 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 	var currentBoundTextures = {};
 
 	var currentClearColor = new THREE.Vector4();
+	var currentClearDepth = null;
+	var currentClearStencil = null;
+
 	var currentScissor = new THREE.Vector4();
 	var currentViewport = new THREE.Vector4();
 
 	this.init = function () {
 
 		this.clearColor( 0, 0, 0, 1 );
-		gl.clearDepth( 1 );
-		gl.clearStencil( 0 );
+		this.clearDepth( 1 );
+		this.clearStencil( 0 );
 
 		this.enable( gl.DEPTH_TEST );
 		gl.depthFunc( gl.LEQUAL );
@@ -585,7 +588,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 	};
 
-	//
+	// clear values
 
 	this.clearColor = function ( r, g, b, a ) {
 
@@ -599,6 +602,30 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 		}
 
 	};
+
+	this.clearDepth = function ( depth ) {
+
+		if ( currentClearDepth !== depth ) {
+
+			gl.clearDepth( depth );
+			currentClearDepth = depth;
+
+		}
+
+	};
+
+	this.clearStencil = function ( stencil ) {
+
+		if ( currentClearStencil !== stencil ) {
+
+			gl.clearStencil( stencil );
+			currentClearStencil = stencil;
+
+		}
+
+	};
+
+	//
 
 	this.scissor = function ( scissor ) {
 
@@ -643,8 +670,9 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 		currentBlending = null;
 
-		currentDepthWrite = null;
 		currentColorWrite = null;
+		currentDepthWrite = null;
+		currentStencilWrite = null;
 
 		currentFlipSided = null;
 


### PR DESCRIPTION
This PR adds two methods in `THREE.WebGLState`, `clearDepth`and `clearStencil`.  They specify the clear values for depth and stencil buffer.
