### PR TITLE
Let the CubeTextureLoader use the loading manager.

### DIFF
--- a/src/loaders/CubeTextureLoader.js
+++ b/src/loaders/CubeTextureLoader.js
@@ -16,7 +16,7 @@ THREE.CubeTextureLoader.prototype = {
 
 		var texture = new THREE.CubeTexture( [] );
 
-		var loader = new THREE.ImageLoader();
+		var loader = new THREE.ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
 


### PR DESCRIPTION
Actually use the loading manager in the CubeTextureLoader by passing it
to the internal ImageLoader. Seems like this was overlooked.
