### PR TITLE
adding configurable: true to Object.defineProperty for ES6 immutable classes

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -8,7 +8,7 @@
 
 THREE.Object3D = function () {
 
-	Object.defineProperty( this, 'id', { value: THREE.Object3DIdCount ++ } );
+	Object.defineProperty( this, 'id', { value: THREE.Object3DIdCount ++, configurable: true } );
 
 	this.uuid = THREE.Math.generateUUID();
 
@@ -44,25 +44,31 @@ THREE.Object3D = function () {
 	Object.defineProperties( this, {
 		position: {
 			enumerable: true,
-			value: position
+			value: position,
+			configurable: true
 		},
 		rotation: {
 			enumerable: true,
-			value: rotation
+			value: rotation,
+			configurable: true
 		},
 		quaternion: {
 			enumerable: true,
-			value: quaternion
+			value: quaternion,
+			configurable: true
 		},
 		scale: {
 			enumerable: true,
-			value: scale
+			value: scale,
+			configurable: true
 		},
 		modelViewMatrix: {
-			value: new THREE.Matrix4()
+			value: new THREE.Matrix4(),
+			configurable: true
 		},
 		normalMatrix: {
-			value: new THREE.Matrix3()
+			value: new THREE.Matrix3(),
+			configurable: true
 		}
 	} );
 

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -13,7 +13,8 @@ THREE.LOD = function () {
 	Object.defineProperties( this, {
 		levels: {
 			enumerable: true,
-			value: []
+			value: [],
+			configurable: true
 		},
 		objects: {
 			get: function () {


### PR DESCRIPTION
Apologies for any inconvenience, but I'm not sure of any easier way to point this out without submitting a pull request.  

Precursor: I'm using Browserify with Bebelify (preset ES2015).
I've been building an ES6 scene using Three.js and I ran into problems with `Object.defineProperty`. 

`Main.js`

``` js
// setup scene
// add SpinningCube to scene
```

`SpinningCube.js`

``` js
'use strict';
import THREE from 'three';
export default class SpinningCube extends THREE.Mesh {
  constructor () {
    super();
    var mat = new THREE.MeshPhongMaterial({
      color: "#FFFFF",
      shininess: 1
    });
    var geo = new THREE.BoxGeometry( 1, 1, 1 );
    THREE.Mesh.call( this, geo, mat );
    this.position.x = (Math.random() - .5 ) * 30;
    this.position.y = (Math.random() - .5 ) * 30;
    this.position.z = (Math.random() - .5 ) * 30;
    this.rot = Math.random();
  }
  update ( time ) {
    this.rotation.x += this.rot * Math.PI / 180;
    this.rotation.y += this.rot * Math.PI / 180;
  }
};
```

But then I got error..

```
Uncaught TypeError: Cannot redefine property: id
THREE.Object3D @ three.js:7644
THREE.Mesh @ three.js:18735
SpinningCube @ SpinningCube.js:84
6../SpinningCube @ index.js:21
s @ _prelude.js:1
e @ _prelude.js:1
(anonymous function) @ _prelude.js:1
```

So I looked closer under the hood at `THREE.Object3D` and `THREE.Mesh` to figure out what was wrong.  Turns out the error was due to `Object.defineProperty` attempting to "redefine" the a property which, I guess, is immutable.  To fix this I added `configurable: true` to where `Object.defineProperty` could be "redefined".  After doing this I was able to run my ES6 script.

I then reverted to ES5 version of the same code, leaving my defineProperty updates, and I was able to run the code as expected.  Thus leading me to creating this pull request/discussion.
