### PR TITLE
#7952 New Stencil Buffer Management

### DIFF
--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -163,6 +163,7 @@ THREE.AdaptiveToneMappingPass.prototype = {
 		}
 
 		this.quad.material = this.materialToneMap;
+		this.quad.material.stencilTest = maskActive;
 		this.materialToneMap.uniforms.tDiffuse.value = readBuffer;
 		renderer.render( this.scene, this.camera, writeBuffer, this.clear );
 

--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -78,8 +78,6 @@ THREE.BloomPass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
-		if ( maskActive ) renderer.context.disable( renderer.context.STENCIL_TEST );
-
 		// Render quad with blured scene into texture (convolution pass 1)
 
 		this.quad.material = this.materialConvolution;
@@ -100,13 +98,11 @@ THREE.BloomPass.prototype = {
 		// Render original scene with superimposed blur to texture
 
 		this.quad.material = this.materialCopy;
+		this.quad.material.stencilTest = maskActive;
 
 		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetY;
 
-		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
-
 		renderer.render( this.scene, this.camera, readBuffer, this.clear );
-
 	}
 
 };

--- a/examples/js/postprocessing/BokehPass.js
+++ b/examples/js/postprocessing/BokehPass.js
@@ -37,7 +37,7 @@ THREE.BokehPass = function ( scene, camera, params ) {
 		console.error( "THREE.BokehPass relies on THREE.BokehShader" );
 
 	}
-	
+
 	var bokehShader = THREE.BokehShader;
 	var bokehUniforms = THREE.UniformsUtils.clone( bokehShader.uniforms );
 
@@ -63,8 +63,8 @@ THREE.BokehPass = function ( scene, camera, params ) {
 	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
 	this.scene2  = new THREE.Scene();
 
-	this.quad2 = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene2.add( this.quad2 );
+	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
+	this.scene2.add( this.quad );
 
 };
 
@@ -72,7 +72,8 @@ THREE.BokehPass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
-		this.quad2.material = this.materialBokeh;
+		this.quad.material = this.materialBokeh;
+		this.quad.material.stencilTest = maskActive;
 
 		// Render depth into texture
 
@@ -99,4 +100,3 @@ THREE.BokehPass.prototype = {
 	}
 
 };
-

--- a/examples/js/postprocessing/ClearPass.js
+++ b/examples/js/postprocessing/ClearPass.js
@@ -10,9 +10,12 @@ THREE.ClearPass = function () {
 
 THREE.ClearPass.prototype = {
 
-	render: function ( renderer, writeBuffer, readBuffer ) {
+	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		renderer.setRenderTarget( readBuffer );
+		renderer.clear();
+
+		renderer.setRenderTarget( writeBuffer );
 		renderer.clear();
 
 	}

--- a/examples/js/postprocessing/DotScreenPass.js
+++ b/examples/js/postprocessing/DotScreenPass.js
@@ -38,12 +38,13 @@ THREE.DotScreenPass = function ( center, angle, scale ) {
 
 THREE.DotScreenPass.prototype = {
 
-	render: function ( renderer, writeBuffer, readBuffer, delta ) {
+	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.uniforms[ "tDiffuse" ].value = readBuffer;
 		this.uniforms[ "tSize" ].value.set( readBuffer.width, readBuffer.height );
 
 		this.quad.material = this.material;
+		this.quad.material.stencilTest = maskActive;
 
 		if ( this.renderToScreen ) {
 

--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -24,13 +24,10 @@ THREE.EffectComposer = function ( renderer, renderTarget ) {
 	this.writeBuffer = this.renderTarget1;
 	this.readBuffer = this.renderTarget2;
 
+	if ( THREE.MaskPass === undefined )
+		console.error( "THREE.EffectComposer relies on THREE.MaskPass" );
+
 	this.passes = [];
-
-	if ( THREE.CopyShader === undefined )
-		console.error( "THREE.EffectComposer relies on THREE.CopyShader" );
-
-	this.copyPass = new THREE.ShaderPass( THREE.CopyShader );
-
 };
 
 THREE.EffectComposer.prototype = {
@@ -57,10 +54,10 @@ THREE.EffectComposer.prototype = {
 
 	render: function ( delta ) {
 
+		var maskActive = false;
+
 		this.writeBuffer = this.renderTarget1;
 		this.readBuffer = this.renderTarget2;
-
-		var maskActive = false;
 
 		var pass, i, il = this.passes.length;
 
@@ -73,18 +70,6 @@ THREE.EffectComposer.prototype = {
 			pass.render( this.renderer, this.writeBuffer, this.readBuffer, delta, maskActive );
 
 			if ( pass.needsSwap ) {
-
-				if ( maskActive ) {
-
-					var context = this.renderer.context;
-
-					context.stencilFunc( context.NOTEQUAL, 1, 0xffffffff );
-
-					this.copyPass.render( this.renderer, this.writeBuffer, this.readBuffer, delta );
-
-					context.stencilFunc( context.EQUAL, 1, 0xffffffff );
-
-				}
 
 				this.swapBuffers();
 

--- a/examples/js/postprocessing/FilmPass.js
+++ b/examples/js/postprocessing/FilmPass.js
@@ -39,12 +39,13 @@ THREE.FilmPass = function ( noiseIntensity, scanlinesIntensity, scanlinesCount, 
 
 THREE.FilmPass.prototype = {
 
-	render: function ( renderer, writeBuffer, readBuffer, delta ) {
+	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.uniforms[ "tDiffuse" ].value = readBuffer;
 		this.uniforms[ "time" ].value += delta;
 
 		this.quad.material = this.material;
+		this.quad.material.stencilTest = maskActive;
 
 		if ( this.renderToScreen ) {
 

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -1,19 +1,19 @@
 /**
- 
+
  */
 
 THREE.GlitchPass = function ( dt_size ) {
 
 	if ( THREE.DigitalGlitch === undefined ) console.error( "THREE.GlitchPass relies on THREE.DigitalGlitch" );
-	
+
 	var shader = THREE.DigitalGlitch;
 	this.uniforms = THREE.UniformsUtils.clone( shader.uniforms );
 
 	if ( dt_size == undefined ) dt_size = 64;
-	
-	
+
+
 	this.uniforms[ "tDisp" ].value = this.generateHeightmap( dt_size );
-	
+
 
 	this.material = new THREE.ShaderMaterial( {
 		uniforms: this.uniforms,
@@ -31,21 +31,21 @@ THREE.GlitchPass = function ( dt_size ) {
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.scene.add( this.quad );
-	
+
 	this.goWild = false;
 	this.curF = 0;
 	this.generateTrigger();
-	
+
 };
 
 THREE.GlitchPass.prototype = {
 
-	render: function ( renderer, writeBuffer, readBuffer, delta ) {
+	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.uniforms[ "tDiffuse" ].value = readBuffer;
 		this.uniforms[ 'seed' ].value = Math.random();//default seeding
 		this.uniforms[ 'byp' ].value = 0;
-		
+
 		if ( this.curF % this.randX == 0 || this.goWild == true ) {
 
 			this.uniforms[ 'amount' ].value = Math.random() / 30;
@@ -72,8 +72,10 @@ THREE.GlitchPass.prototype = {
 
 		}
 		this.curF ++;
-		
+
 		this.quad.material = this.material;
+    this.quad.material.stencilTest = maskActive;
+    
 		if ( this.renderToScreen ) {
 
 			renderer.render( this.scene, this.camera );
@@ -94,7 +96,7 @@ THREE.GlitchPass.prototype = {
 
 		var data_arr = new Float32Array( dt_size * dt_size * 3 );
 		var length = dt_size * dt_size;
-		
+
 		for ( var i = 0; i < length; i ++ ) {
 
 			var val = THREE.Math.randFloat( 0, 1 );
@@ -103,7 +105,7 @@ THREE.GlitchPass.prototype = {
 			data_arr[ i * 3 + 2 ] = val;
 
 		}
-		
+
 		var texture = new THREE.DataTexture( data_arr, dt_size, dt_size, THREE.RGBFormat, THREE.FloatType );
 		texture.needsUpdate = true;
 		return texture;

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -74,7 +74,7 @@ THREE.GlitchPass.prototype = {
 		this.curF ++;
 
 		this.quad.material = this.material;
-    this.quad.material.stencilTest = maskActive;
+		this.quad.material.stencilTest = maskActive;
     
 		if ( this.renderToScreen ) {
 

--- a/examples/js/postprocessing/RenderPass.js
+++ b/examples/js/postprocessing/RenderPass.js
@@ -23,7 +23,7 @@ THREE.RenderPass = function ( scene, camera, overrideMaterial, clearColor, clear
 
 THREE.RenderPass.prototype = {
 
-	render: function ( renderer, writeBuffer, readBuffer, delta ) {
+	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.scene.overrideMaterial = this.overrideMaterial;
 

--- a/examples/js/postprocessing/SavePass.js
+++ b/examples/js/postprocessing/SavePass.js
@@ -45,7 +45,7 @@ THREE.SavePass = function ( renderTarget ) {
 
 THREE.SavePass.prototype = {
 
-	render: function ( renderer, writeBuffer, readBuffer, delta ) {
+	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		if ( this.uniforms[ this.textureID ] ) {
 
@@ -54,6 +54,7 @@ THREE.SavePass.prototype = {
 		}
 
 		this.quad.material = this.material;
+		this.quad.material.stencilTest = maskActive;
 
 		renderer.render( this.scene, this.camera, this.renderTarget, this.clear );
 

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -45,7 +45,7 @@ THREE.ShaderPass = function( shader, textureID ) {
 
 THREE.ShaderPass.prototype = {
 
-	render: function( renderer, writeBuffer, readBuffer, delta ) {
+	render: function( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		if ( this.uniforms[ this.textureID ] ) {
 
@@ -54,6 +54,7 @@ THREE.ShaderPass.prototype = {
 		}
 
 		this.quad.material = this.material;
+		this.quad.material.stencilTest = maskActive;
 
 		if ( this.renderToScreen ) {
 

--- a/examples/js/postprocessing/TexturePass.js
+++ b/examples/js/postprocessing/TexturePass.js
@@ -25,7 +25,6 @@ THREE.TexturePass = function ( texture, opacity ) {
 	this.enabled = true;
 	this.needsSwap = false;
 
-
 	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
 	this.scene  = new THREE.Scene();
 
@@ -36,9 +35,10 @@ THREE.TexturePass = function ( texture, opacity ) {
 
 THREE.TexturePass.prototype = {
 
-	render: function ( renderer, writeBuffer, readBuffer, delta ) {
+	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.quad.material = this.material;
+		this.quad.material.stencilTest = maskActive;
 
 		renderer.render( this.scene, this.camera, readBuffer );
 

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -61,6 +61,7 @@
 		<script src="js/postprocessing/TexturePass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>
+		<script src="js/postprocessing/ClearPass.js"></script>
 
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
@@ -157,7 +158,7 @@
 				stats = new Stats();
 				stats.domElement.style.position = 'absolute';
 				stats.domElement.style.top = '0px';
-				//container.appendChild( stats.domElement );
+				container.appendChild( stats.domElement );
 
 				//
 
@@ -193,18 +194,16 @@
 				effectColorify1.uniforms[ 'color' ].value.setRGB( 1, 0.8, 0.8 );
 				effectColorify2.uniforms[ 'color' ].value.setRGB( 1, 0.75, 0.5 );
 
+				effectColorify1.needsSwap = false;
+
+				var clear = new THREE.ClearPass();
 				var clearMask = new THREE.ClearMaskPass();
 				var renderMask = new THREE.MaskPass( sceneModel, cameraPerspective );
 				var renderMaskInverse = new THREE.MaskPass( sceneModel, cameraPerspective );
 
 				renderMaskInverse.inverse = true;
 
-				//effectFilm.renderToScreen = true;
-				//effectFilmBW.renderToScreen = true;
-				//effectDotScreen.renderToScreen = true;
-				//effectBleach.renderToScreen = true;
 				effectVignette.renderToScreen = true;
-				//effectCopy.renderToScreen = true;
 
 				//
 
@@ -227,6 +226,7 @@
 
 				composerScene = new THREE.EffectComposer( renderer, new THREE.WebGLRenderTarget( rtWidth * 2, rtHeight * 2, rtParameters ) );
 
+				composerScene.addPass( clear );
 				composerScene.addPass( renderBackground );
 				composerScene.addPass( renderModel );
 				composerScene.addPass( renderMaskInverse );
@@ -238,20 +238,22 @@
 
 				renderScene = new THREE.TexturePass( composerScene.renderTarget2 );
 
-				//
+				// bottom left
 
 				composer1 = new THREE.EffectComposer( renderer, new THREE.WebGLRenderTarget( rtWidth, rtHeight, rtParameters ) );
 
+				composer1.addPass( clear );
 				composer1.addPass( renderScene );
 				//composer1.addPass( renderMask );
 				composer1.addPass( effectFilmBW );
 				//composer1.addPass( clearMask );
 				composer1.addPass( effectVignette );
 
-				//
+				// bottom right
 
 				composer2 = new THREE.EffectComposer( renderer, new THREE.WebGLRenderTarget( rtWidth, rtHeight, rtParameters ) );
 
+				composer2.addPass( clear );
 				composer2.addPass( renderScene );
 				composer2.addPass( effectDotScreen );
 				composer2.addPass( renderMask );
@@ -262,10 +264,11 @@
 				composer2.addPass( clearMask );
 				composer2.addPass( effectVignette );
 
-				//
+				// top left
 
 				composer3 = new THREE.EffectComposer( renderer, new THREE.WebGLRenderTarget( rtWidth, rtHeight, rtParameters ) );
 
+				composer3.addPass( clear );
 				composer3.addPass( renderScene );
 				//composer3.addPass( renderMask );
 				composer3.addPass( effectSepia );
@@ -273,10 +276,11 @@
 				//composer3.addPass( clearMask );
 				composer3.addPass( effectVignette );
 
-				//
+				// top right
 
 				composer4 = new THREE.EffectComposer( renderer, new THREE.WebGLRenderTarget( rtWidth, rtHeight, rtParameters ) );
 
+				composer4.addPass( clear );
 				composer4.addPass( renderScene );
 				//composer4.addPass( renderMask );
 				composer4.addPass( effectBloom );
@@ -286,8 +290,6 @@
 				composer4.addPass( effectVignette );
 
 				//
-
-				//onWindowResize();
 
 				renderScene.uniforms[ "tDiffuse" ].value = composerScene.renderTarget2;
 
@@ -341,7 +343,9 @@
 					shininess: 20,
 					map: new THREE.TextureLoader().load( "obj/leeperrysmith/Map-COL.jpg" ),
 					normalMap: new THREE.TextureLoader().load("obj/leeperrysmith/Infinite-Level_02_Tangent_SmoothUV.jpg" ),
-					normalScale: new THREE.Vector2( 0.75, 0.75 )
+					normalScale: new THREE.Vector2( 0.75, 0.75 ),
+					stencilTest: true,
+					stencilWrite: true
 
 				} );
 

--- a/examples/webgl_postprocessing_masking.html
+++ b/examples/webgl_postprocessing_masking.html
@@ -47,10 +47,12 @@
 				var scene1 = new THREE.Scene();
 				var scene2 = new THREE.Scene();
 
-				box = new THREE.Mesh( new THREE.BoxGeometry( 4, 4, 4 ) );
+				var maskMaterial = new THREE.MeshBasicMaterial( { stencilTest: true, stencilWrite: true, colorWrite: false, depthWrite: false } );
+
+				box = new THREE.Mesh( new THREE.BoxGeometry( 4, 4, 4 ), maskMaterial );
 				scene1.add( box );
 
-				torus = new THREE.Mesh( new THREE.TorusGeometry( 3, 1, 16, 32 ) );
+				torus = new THREE.Mesh( new THREE.TorusGeometry( 3, 1, 16, 32 ), maskMaterial );
 				scene2.add( torus );
 
 				renderer = new THREE.WebGLRenderer( { antialias: false } );

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -229,6 +229,8 @@ THREE.Loader.prototype = {
 						break;
 					case 'depthTest':
 					case 'depthWrite':
+					case 'stencilTest':
+					case 'stencilWrite':
 					case 'colorWrite':
 					case 'opacity':
 					case 'reflectivity':

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -70,6 +70,8 @@ THREE.MaterialLoader.prototype = {
 		if ( json.alphaTest !== undefined ) material.alphaTest = json.alphaTest;
 		if ( json.depthTest !== undefined ) material.depthTest = json.depthTest;
 		if ( json.depthWrite !== undefined ) material.depthWrite = json.depthWrite;
+		if ( json.stencilTest !== undefined ) material.stencilTest = json.stencilTest;
+		if ( json.stencilWrite !== undefined ) material.stencilWrite = json.stencilWrite;
 		if ( json.colorWrite !== undefined ) material.colorWrite = json.colorWrite;
 		if ( json.wireframe !== undefined ) material.wireframe = json.wireframe;
 		if ( json.wireframeLinewidth !== undefined ) material.wireframeLinewidth = json.wireframeLinewidth;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -30,6 +30,9 @@ THREE.Material = function () {
 	this.depthTest = true;
 	this.depthWrite = true;
 
+	this.stencilTest = false;
+	this.stencilWrite = false;
+
 	this.colorWrite = true;
 
 	this.precision = null; // override the renderer's default precision for this material
@@ -256,6 +259,9 @@ THREE.Material.prototype = {
 		this.depthFunc = source.depthFunc;
 		this.depthTest = source.depthTest;
 		this.depthWrite = source.depthWrite;
+
+		this.stencilTest = source.stencilTest;
+		this.stencilWrite = source.stencilWrite;
 
 		this.colorWrite = source.colorWrite;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1196,10 +1196,12 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		// Ensure depth buffer writing is enabled so it can be cleared on next render
+		// Ensure buffer writing is enabled so they can be cleared on next render
 
 		state.setDepthTest( true );
 		state.setDepthWrite( true );
+		state.setStencilTest( true );
+		state.setStencilWrite( true );
 		state.setColorWrite( true );
 
 		// _gl.finish();
@@ -1562,6 +1564,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 		state.setDepthFunc( material.depthFunc );
 		state.setDepthTest( material.depthTest );
 		state.setDepthWrite( material.depthWrite );
+		state.setStencilTest( material.stencilTest );
+		state.setStencilWrite( material.stencilWrite );
 		state.setColorWrite( material.colorWrite );
 		state.setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 


### PR DESCRIPTION
This PR enables three.js to manage the stencil buffer via material properties. 

As mentioned in #7952, i had some problems to implement the masking in context of post-processing with the new material properties. But now i found a way to achieve this in a meaningful way.
1. If a scene wants to use post-processing with masking, users only have to do one additional step with the new approach. They must provide a masking material like in `webgl_postprocessing_masking.html`. That means a material with `stencilWrite` and `stencilTest` set to `true`.
2. The actual post-processing pass chain does not change. If you want to start masking, you need an instance of `THREE.MaskPass`. If you want to stop it, you must use `THREE.ClearMaskPass`.
3. If `THREE.EffectComposer` detects a `THREE.MaskPass`, it activates masking and informs each upcoming pass about the new state (see parameter `maskActive`of render method).
4. A pass evaluates this parameter and sets its internal `quad.material.stencilTest` to the respective value (this will enable/disable the stencil test ONLY for this pass).

With this new approach, direct manipulation of the WebGL State is no longer required. `THREE.WebGLRenderer` handles everything over material properties.
