### PR TITLE
fix VRControls onError

### DIFF
--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -21,7 +21,11 @@ THREE.VRControls = function ( object, onError ) {
 
 		}
 
-		if ( onError ) onError( 'HMD not available' );
+		if ( vrInputs.length === 0 ) {
+
+			if ( onError ) onError( 'PositionSensorVRDevice not available' );
+
+		}
 
 	}
 


### PR DESCRIPTION
The VRControls onError callback was always being called (if it was provided), now it should only be called when no input devices are available.  Error msg also slightly modified.
