### PR TITLE
Added NoShading

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -139,6 +139,7 @@ THREE.DoubleSide = 2;
 
 // shading
 
+THREE.NoShading = 0;
 THREE.FlatShading = 1;
 THREE.SmoothShading = 2;
 


### PR DESCRIPTION
In the declaration file for Three.js over at DefinitelyTyped, it states that there are three options for Shading: NoShading, FlatShading and SmoothShading. 

So I think that either, NoShading has to be removed from the declaration file, or added to the JavaScript file. 
And I'm supposing adding it to the JavaScript file. 
