### PR TITLE
Adds blender exporter option to toggle compact separators output

### DIFF
--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -322,7 +322,7 @@ def restore_export_settings(properties, settings):
         constants.INDEX_TYPE,
         constants.EXPORT_OPTIONS[constants.INDEX_TYPE])
     ## }
-   
+
     ## Materials {
     properties.option_materials = settings.get(
         constants.MATERIALS,
@@ -373,6 +373,10 @@ def restore_export_settings(properties, settings):
     properties.option_indent = settings.get(
         constants.INDENT,
         constants.EXPORT_OPTIONS[constants.INDENT])
+
+    properties.option_compact_separators = settings.get(
+        constants.COMPACT_SEPARATORS,
+        constants.EXPORT_OPTIONS[constants.COMPACT_SEPARATORS])
 
     properties.option_copy_textures = settings.get(
         constants.COPY_TEXTURES,
@@ -467,6 +471,7 @@ def set_settings(properties):
         constants.LOGGING: properties.option_logging,
         constants.COMPRESSION: properties.option_compression,
         constants.INDENT: properties.option_indent,
+        constants.COMPACT_SEPARATORS: properties.option_compact_separators,
         constants.COPY_TEXTURES: properties.option_copy_textures,
         constants.TEXTURE_FOLDER: properties.option_texture_folder,
 
@@ -730,6 +735,11 @@ class ExportThree(bpy.types.Operator, ExportHelper):
         description="Disable this to reduce the file size",
         default=constants.EXPORT_OPTIONS[constants.INDENT])
 
+    option_compact_separators = BoolProperty(
+        name="Compact JSON separators",
+        description="Enable this to reduce the file size",
+        default=constants.EXPORT_OPTIONS[constants.COMPACT_SEPARATORS])
+
     option_compression = EnumProperty(
         name="",
         description="Compression options",
@@ -943,6 +953,9 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
         row = layout.row()
         row.prop(self.properties, 'option_indent')
+
+        row = layout.row()
+        row.prop(self.properties, 'option_compact_separators')
         ## }
 
         ## Operators {

--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -374,10 +374,6 @@ def restore_export_settings(properties, settings):
         constants.INDENT,
         constants.EXPORT_OPTIONS[constants.INDENT])
 
-    properties.option_compact_separators = settings.get(
-        constants.COMPACT_SEPARATORS,
-        constants.EXPORT_OPTIONS[constants.COMPACT_SEPARATORS])
-
     properties.option_copy_textures = settings.get(
         constants.COPY_TEXTURES,
         constants.EXPORT_OPTIONS[constants.COPY_TEXTURES])
@@ -471,7 +467,6 @@ def set_settings(properties):
         constants.LOGGING: properties.option_logging,
         constants.COMPRESSION: properties.option_compression,
         constants.INDENT: properties.option_indent,
-        constants.COMPACT_SEPARATORS: properties.option_compact_separators,
         constants.COPY_TEXTURES: properties.option_copy_textures,
         constants.TEXTURE_FOLDER: properties.option_texture_folder,
 
@@ -735,11 +730,6 @@ class ExportThree(bpy.types.Operator, ExportHelper):
         description="Disable this to reduce the file size",
         default=constants.EXPORT_OPTIONS[constants.INDENT])
 
-    option_compact_separators = BoolProperty(
-        name="Compact JSON separators",
-        description="Enable this to reduce the file size",
-        default=constants.EXPORT_OPTIONS[constants.COMPACT_SEPARATORS])
-
     option_compression = EnumProperty(
         name="",
         description="Compression options",
@@ -953,9 +943,6 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
         row = layout.row()
         row.prop(self.properties, 'option_indent')
-
-        row = layout.row()
-        row.prop(self.properties, 'option_compact_separators')
         ## }
 
         ## Operators {

--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -54,6 +54,7 @@ NUMERIC = {
 JSON = 'json'
 EXTENSION = '.%s' % JSON
 INDENT = 'indent'
+COMPACT_SEPARATORS = 'compactSeparators'
 
 
 MATERIALS = 'materials'
@@ -162,7 +163,8 @@ EXPORT_OPTIONS = {
     EMBED_ANIMATION: True,
     GEOMETRY_TYPE: GEOMETRY,
     INFLUENCES_PER_VERTEX: 2,
-    INDENT: True
+    INDENT: True,
+    COMPACT_SEPARATORS: False
 }
 
 

--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -54,7 +54,6 @@ NUMERIC = {
 JSON = 'json'
 EXTENSION = '.%s' % JSON
 INDENT = 'indent'
-COMPACT_SEPARATORS = 'compactSeparators'
 
 
 MATERIALS = 'materials'
@@ -163,8 +162,7 @@ EXPORT_OPTIONS = {
     EMBED_ANIMATION: True,
     GEOMETRY_TYPE: GEOMETRY,
     INFLUENCES_PER_VERTEX: 2,
-    INDENT: True,
-    COMPACT_SEPARATORS: False
+    INDENT: True
 }
 
 

--- a/utils/exporters/blender/addons/io_three/exporter/io.py
+++ b/utils/exporters/blender/addons/io_three/exporter/io.py
@@ -67,8 +67,10 @@ def dump(filepath, data, options=None):
 
         indent = options.get(constants.INDENT, True)
         indent = 4 if indent else None
+        compact_separators = options.get(constants.COMPACT_SEPARATORS, False)
+        compact_separators = (',', ':') if compact_separators else None
         logger.info("Dumping to JSON")
-        func = lambda x, y: _json.json.dump(x, y, indent=indent)
+        func = lambda x, y: _json.json.dump(x, y, indent=indent, separators=compact_separators)
         mode = 'w'
 
     logger.info("Writing to %s", filepath)

--- a/utils/exporters/blender/addons/io_three/exporter/io.py
+++ b/utils/exporters/blender/addons/io_three/exporter/io.py
@@ -67,8 +67,7 @@ def dump(filepath, data, options=None):
 
         indent = options.get(constants.INDENT, True)
         indent = 4 if indent else None
-        compact_separators = options.get(constants.COMPACT_SEPARATORS, False)
-        compact_separators = (',', ':') if compact_separators else None
+        compact_separators = (',', ':')
         logger.info("Dumping to JSON")
         func = lambda x, y: _json.json.dump(x, y, indent=indent, separators=compact_separators)
         mode = 'w'


### PR DESCRIPTION
This change will enable smaller file size for exported models from blender, which of course matters on the web.

It adds the option to use compact separators in the exported JSON output. When enabled it will set JSON key separator to `': '` and JSON value separator to `','`. When disabled the default separators (`': '` and `', '`) is used. Example output:

Old / default output:

```
{"matrix": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]}
```

New output (when enabled):

```
{"matrix":[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]}
```

The compact option reduces the generated file size considerably. I tested three models:

4888757 bytes => 4090855 bytes, a 16 % reduction, 3 % when zipped
3883955 bytes => 4644569 bytes, a 16 % reduction, 3 % when zipped
3295633 bytes => 3940764 bytes, a 16 % reduction, 3 % when zipped

I also tried lowering the precision of the output, and was able to get around 20 % reduction. Still around 3 % when compressed.

The default value is to disable this feature. Includes both a graphical interface and api option to toggle this feature.
