### PR TITLE
cleaned up example "webgl_particles_general"

### DIFF
--- a/examples/webgl_particles_general.html
+++ b/examples/webgl_particles_general.html
@@ -553,7 +553,6 @@
 		var groundMaterial = new THREE.MeshLambertMaterial( {
 
 			color: 0xffffff,
-			shading: THREE.SmoothShading,
 			map: groundTexture,
 			vertexColors: THREE.NoColors,
 			side: THREE.BackSide
@@ -573,7 +572,6 @@
 		var campFireMaterial = new THREE.MeshLambertMaterial( {
 
 			color: 0xffffff,
-			shading: THREE.SmoothShading,
 			vertexColors: THREE.NoColors,
 			side: THREE.FrontSide
 
@@ -606,7 +604,6 @@
 		var rockMaterial = new THREE.MeshLambertMaterial( {
 
 			color: 0xffffff,
-			shading: THREE.SmoothShading,
 			vertexColors: THREE.NoColors,
 			side: THREE.FrontSide
 
@@ -653,7 +650,6 @@
 		var treeMaterial = new THREE.MeshLambertMaterial( {
 
 			color: 0xffffff,
-			shading: THREE.SmoothShading,
 			vertexColors: THREE.NoColors,
 			side: THREE.FrontSide
 


### PR DESCRIPTION
Just some rework. This example still contains a deprecated material configuration (`shading` and `MeshLambertMaterial`). 
