### PR TITLE
Scene: pass through all arguments given to Scene.copy() to Object3D.copy()

### DIFF
--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -20,7 +20,7 @@ THREE.Scene.prototype.constructor = THREE.Scene;
 
 THREE.Scene.prototype.copy = function ( source ) {
 
-	THREE.Object3D.prototype.copy.call( this, source );
+	THREE.Object3D.prototype.copy.apply( this, arguments );
 
 	if ( source.fog !== null ) this.fog = source.fog.clone();
 	if ( source.overrideMaterial !== null ) this.overrideMaterial = source.overrideMaterial.clone();


### PR DESCRIPTION
Previously this would have omitted the recursive flag.
