### PR TITLE
blender exporter breaks when parent contains keyframe animation and child does not

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -174,8 +174,12 @@ EXPORTED_TRACKABLE_FIELDS = [ "location", "scale", "rotation_quaternion" ]
 
 @_object
 def animated_xform(obj, options):
+    if obj.animation_data is None:
+        return []
     fcurves = obj.animation_data
     if not fcurves:
+        return []
+    if fcurves.action is None:
         return []
     fcurves = fcurves.action.fcurves
 


### PR DESCRIPTION
Objects with parents containing keyframe animations, but which don't themselves contain keyframe animations, break the exporter. This small patch adds a check that the animation object and action are not NoneType, returning an empty animation when they are. It is common to animate a parent object with children which remain stationary relative to the parent.
