### PR TITLE
Implement THREE.RingBufferGeometry

### DIFF
--- a/src/extras/geometries/RingBufferGeometry.js
+++ b/src/extras/geometries/RingBufferGeometry.js
@@ -1,0 +1,107 @@
+/**
+ * @author Kaleb Murphy
+ */
+
+THREE.RingBufferGeometry = function ( innerRadius, outerRadius, thetaSegments, phiSegments, thetaStart, thetaLength ) {
+
+	THREE.BufferGeometry.call( this );
+
+	this.type = 'RingBufferGeometry';
+
+	this.parameters = {
+		innerRadius: innerRadius,
+		outerRadius: outerRadius,
+		thetaSegments: thetaSegments,
+		phiSegments: phiSegments,
+		thetaStart: thetaStart,
+		thetaLength: thetaLength
+	};
+
+	innerRadius = innerRadius || 0;
+	outerRadius = outerRadius || 50;
+
+	thetaStart = thetaStart !== undefined ? thetaStart : 0;
+	thetaLength = thetaLength !== undefined ? thetaLength : Math.PI * 2;
+
+	thetaSegments = thetaSegments !== undefined ? Math.max( 3, thetaSegments ) : 8;
+	phiSegments = phiSegments !== undefined ? Math.max( 1, phiSegments ) : 8;
+
+	var vertices = (thetaSegments + 1) * (phiSegments + 1);
+
+	var positions = new Float32Array( vertices * 3 );
+	var normals = new Float32Array( vertices * 3 );
+	var uvs = new Float32Array( vertices * 2 );
+
+	var i, o, ii = 0, oo = 0, uvs = [], radius = innerRadius, radiusStep = ( ( outerRadius - innerRadius ) / phiSegments );
+
+	for ( i = 0; i < phiSegments + 1; i ++) {
+
+		// concentric circles inside ring
+
+		for ( o = 0; o < thetaSegments + 1; o ++, ii += 3, oo += 2) {
+
+			// number of segments per circle
+
+			var segment = thetaStart + o / thetaSegments * thetaLength;
+			positions[ ii + 0 ] = radius * Math.cos( segment );
+			positions[ ii + 1 ] = radius * Math.sin( segment );
+
+			uvs[ oo + 0 ] = ( positions[ ii + 0 ] / outerRadius + 1 ) / 2;
+			uvs[ oo + 1 ] = ( positions[ ii + 1 ] / outerRadius + 1 ) / 2;
+
+			normals[ ii + 2 ] = 1; // normal z
+
+		}
+
+		radius += radiusStep;
+
+	}
+
+	var indices = [];
+
+	for ( i = 0; i < phiSegments; i ++ ) {
+
+		// concentric circles inside ring
+
+		var thetaSegment = i * ( thetaSegments + 1 );
+
+		for ( o = 0; o < thetaSegments ; o ++ ) {
+
+			// number of segments per circle
+
+			var segment1 = o + thetaSegment,
+			    segment2 = segment1 + thetaSegments;
+
+			indices.push( segment1, segment2 + 1, segment2 + 2 );
+			indices.push( segment1, segment2 + 2, segment1 + 1 );
+
+		}
+
+	}
+
+	this.setIndex( new THREE.BufferAttribute( new Uint16Array( indices ), 1 ) );
+	this.addAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
+	this.addAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
+	this.addAttribute( 'uv', new THREE.BufferAttribute( uvs, 2 ) );
+
+	this.boundingSphere = new THREE.Sphere( new THREE.Vector3(), outerRadius );
+
+};
+
+THREE.RingBufferGeometry.prototype = Object.create( THREE.BufferGeometry.prototype );
+THREE.RingBufferGeometry.prototype.constructor = THREE.RingBufferGeometry;
+
+THREE.RingBufferGeometry.prototype.clone = function () {
+
+	var parameters = this.parameters;
+
+	return new THREE.RingBufferGeometry(
+		parameters.innerRadius,
+		parameters.outerRadius,
+		parameters.thetaSegments,
+		parameters.phiSegments,
+		parameters.thetaStart,
+		parameters.thetaLength
+	);
+
+};

--- a/src/extras/geometries/RingGeometry.js
+++ b/src/extras/geometries/RingGeometry.js
@@ -17,74 +17,7 @@ THREE.RingGeometry = function ( innerRadius, outerRadius, thetaSegments, phiSegm
 		thetaLength: thetaLength
 	};
 
-	innerRadius = innerRadius || 0;
-	outerRadius = outerRadius || 50;
-
-	thetaStart = thetaStart !== undefined ? thetaStart : 0;
-	thetaLength = thetaLength !== undefined ? thetaLength : Math.PI * 2;
-
-	thetaSegments = thetaSegments !== undefined ? Math.max( 3, thetaSegments ) : 8;
-	phiSegments = phiSegments !== undefined ? Math.max( 1, phiSegments ) : 8;
-
-	var i, o, uvs = [], radius = innerRadius, radiusStep = ( ( outerRadius - innerRadius ) / phiSegments );
-
-	for ( i = 0; i < phiSegments + 1; i ++ ) {
-
-		// concentric circles inside ring
-
-		for ( o = 0; o < thetaSegments + 1; o ++ ) {
-
-			// number of segments per circle
-
-			var vertex = new THREE.Vector3();
-			var segment = thetaStart + o / thetaSegments * thetaLength;
-			vertex.x = radius * Math.cos( segment );
-			vertex.y = radius * Math.sin( segment );
-
-			this.vertices.push( vertex );
-			uvs.push( new THREE.Vector2( ( vertex.x / outerRadius + 1 ) / 2, ( vertex.y / outerRadius + 1 ) / 2 ) );
-
-		}
-
-		radius += radiusStep;
-
-	}
-
-	var n = new THREE.Vector3( 0, 0, 1 );
-
-	for ( i = 0; i < phiSegments; i ++ ) {
-
-		// concentric circles inside ring
-
-		var thetaSegment = i * ( thetaSegments + 1 );
-
-		for ( o = 0; o < thetaSegments ; o ++ ) {
-
-			// number of segments per circle
-
-			var segment = o + thetaSegment;
-
-			var v1 = segment;
-			var v2 = segment + thetaSegments + 1;
-			var v3 = segment + thetaSegments + 2;
-
-			this.faces.push( new THREE.Face3( v1, v2, v3, [ n.clone(), n.clone(), n.clone() ] ) );
-			this.faceVertexUvs[ 0 ].push( [ uvs[ v1 ].clone(), uvs[ v2 ].clone(), uvs[ v3 ].clone() ] );
-
-			v1 = segment;
-			v2 = segment + thetaSegments + 2;
-			v3 = segment + 1;
-
-			this.faces.push( new THREE.Face3( v1, v2, v3, [ n.clone(), n.clone(), n.clone() ] ) );
-			this.faceVertexUvs[ 0 ].push( [ uvs[ v1 ].clone(), uvs[ v2 ].clone(), uvs[ v3 ].clone() ] );
-
-		}
-
-	}
-
-	this.computeFaceNormals();
-
-	this.boundingSphere = new THREE.Sphere( new THREE.Vector3(), radius );
+	this.fromBufferGeometry( new THREE.RingBufferGeometry( innerRadius, outerRadius, thetaSegments, phiSegments, thetaStart, thetaLength ) );
 
 };
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -218,6 +218,19 @@ THREE.ObjectLoader.prototype = {
 
 						break;
 
+					case 'RingBufferGeometry':
+
+						geometry = new THREE.RingBufferGeometry(
+							data.innerRadius,
+							data.outerRadius,
+							data.thetaSegments,
+							data.phiSegments,
+							data.thetaStart,
+							data.thetaLength
+						);
+
+						break;
+
 					case 'RingGeometry':
 
 						geometry = new THREE.RingGeometry(

--- a/test/unit/extras/geometries/RingBufferGeometry.tests.js
+++ b/test/unit/extras/geometries/RingBufferGeometry.tests.js
@@ -1,0 +1,42 @@
+(function () {
+
+	'use strict';
+
+	var parameters = {
+		innerRadius: 10,
+		outerRadius: 60,
+		thetaSegments: 12,
+		phiSegments: 14,
+		thetaStart: 0.1,
+		thetaLength: 2.0
+	};
+
+	var geometries;
+
+	QUnit.module( "Extras - Geometries - RingBufferGeometry", {
+
+		beforeEach: function() {
+
+			geometries = [
+
+				new THREE.RingBufferGeometry(),
+				new THREE.RingBufferGeometry( parameters.innerRadius ),
+				new THREE.RingBufferGeometry( parameters.innerRadius, parameters.outerRadius ),
+				new THREE.RingBufferGeometry( parameters.innerRadius, parameters.outerRadius, parameters.thetaSegments ),
+				new THREE.RingBufferGeometry( parameters.innerRadius, parameters.outerRadius, parameters.thetaSegments, parameters.phiSegments ),
+				new THREE.RingBufferGeometry( parameters.innerRadius, parameters.outerRadius, parameters.thetaSegments, parameters.phiSegments, parameters.thetaStart ),
+				new THREE.RingBufferGeometry( parameters.innerRadius, parameters.outerRadius, parameters.thetaSegments, parameters.phiSegments, parameters.thetaStart, parameters.thetaLength ),
+
+			];
+
+		}
+
+	});
+
+	QUnit.test( "standard geometry tests", function( assert ) {
+
+		runStdGeometryTests( assert, geometries );
+
+	});
+
+})();

--- a/test/unit/unittests_three.html
+++ b/test/unit/unittests_three.html
@@ -80,6 +80,7 @@
   <script src="extras/geometries/PlaneBufferGeometry.tests.js"></script>
   <script src="extras/geometries/PlaneGeometry.tests.js"></script>
   <script src="extras/geometries/PolyhedronGeometry.tests.js"></script>
+  <script src="extras/geometries/RingBufferGeometry.tests.js"></script>
   <script src="extras/geometries/RingGeometry.tests.js"></script>
   <script src="extras/geometries/ShapeGeometry.tests.js"></script>
   <script src="extras/geometries/SphereBufferGeometry.tests.js"></script>

--- a/utils/build/includes/extras.json
+++ b/utils/build/includes/extras.json
@@ -30,6 +30,7 @@
 	"src/extras/geometries/PlaneGeometry.js",
 	"src/extras/geometries/PlaneBufferGeometry.js",
 	"src/extras/geometries/RingGeometry.js",
+	"src/extras/geometries/RingBufferGeometry.js",
 	"src/extras/geometries/SphereGeometry.js",
 	"src/extras/geometries/SphereBufferGeometry.js",
 	"src/extras/geometries/TextGeometry.js",


### PR DESCRIPTION
As "somewhat propsed" by me in https://github.com/mrdoob/three.js/issues/8060 :see_no_evil: 
Created `THREE.RingBufferGeometry` from `RingGeometry`.
Following the logic of `THREE.CircleBufferGeometry`.

Hope I got everything right and ready to merge.
Tested via geometry-browser by "injecting" the new js files.
Glad to contribute to such an amazing framework.

Keep up the good work!
