### PR TITLE
export textures from blender with correct clip/repeat mode

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/texture.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/texture.py
@@ -155,12 +155,20 @@ def wrap(texture):
 
     """
     logger.debug("texture.wrap(%s)", texture)
-    wrapping = {
-        True: constants.WRAPPING.MIRROR,
-        False: constants.WRAPPING.REPEAT
-    }
-    return (wrapping[texture.use_mirror_x],
-            wrapping[texture.use_mirror_y])
+
+    if(texture.extension == "REPEAT"):
+        wrapping = {
+            True: constants.WRAPPING.MIRROR,
+            False: constants.WRAPPING.REPEAT
+        }
+        return (wrapping[texture.use_mirror_x],
+                wrapping[texture.use_mirror_y])
+
+    # provide closest available three.js behavior.
+    # other possible values: "CLIP", "EXTEND", "CLIP_CUBE", "CHECKER",
+    # best match CLAMP behavior
+    else:
+        return (constants.WRAPPING.CLAMP, constants.WRAPPING.CLAMP);
 
 
 def textures():


### PR DESCRIPTION
Currently, regardless of the Image Mapping : Extension setting for a texture in blender, the exporter will export a texture that uses the REPEAT or MIRROR texture wrapping modes. This patch checks the extension type and sets the wrapping mode accordingly.
