### PR TITLE
Add feature to blender exporter to embed textures in .json file

### DIFF
--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -374,9 +374,9 @@ def restore_export_settings(properties, settings):
         constants.INDENT,
         constants.EXPORT_OPTIONS[constants.INDENT])
 
-    properties.option_copy_textures = settings.get(
-        constants.COPY_TEXTURES,
-        constants.EXPORT_OPTIONS[constants.COPY_TEXTURES])
+    properties.option_export_textures = settings.get(
+        constants.EXPORT_TEXTURES,
+        constants.EXPORT_OPTIONS[constants.EXPORT_TEXTURES])
 
     properties.option_embed_textures = settings.get(
         constants.EMBED_TEXTURES,
@@ -471,7 +471,7 @@ def set_settings(properties):
         constants.LOGGING: properties.option_logging,
         constants.COMPRESSION: properties.option_compression,
         constants.INDENT: properties.option_indent,
-        constants.COPY_TEXTURES: properties.option_copy_textures,
+        constants.EXPORT_TEXTURES: properties.option_export_textures,
         constants.EMBED_TEXTURES: properties.option_embed_textures,
         constants.TEXTURE_FOLDER: properties.option_texture_folder,
 
@@ -527,8 +527,8 @@ def animation_options():
     return anim
 
 def resolve_conflicts(self, context):
-    if(self.option_embed_textures):
-        self.option_copy_textures = False;
+    if(not self.option_export_textures):
+        self.option_embed_textures = False;
 
 class ExportThree(bpy.types.Operator, ExportHelper):
     """Class that handles the export properties"""
@@ -674,16 +674,16 @@ class ExportThree(bpy.types.Operator, ExportHelper):
         description="Embed animation data with the geometry data",
         default=constants.EXPORT_OPTIONS[constants.EMBED_ANIMATION])
 
-    option_copy_textures = BoolProperty(
-        name="Copy textures",
-        description="Copy textures",
-        default=constants.EXPORT_OPTIONS[constants.COPY_TEXTURES])
+    option_export_textures = BoolProperty(
+        name="Export textures",
+        description="Export textures",
+        default=constants.EXPORT_OPTIONS[constants.EXPORT_TEXTURES],
+        update=resolve_conflicts)
 
     option_embed_textures = BoolProperty(
         name="Embed textures",
         description="Embed base64 textures in .json",
-        default=constants.EXPORT_OPTIONS[constants.EMBED_TEXTURES],
-        update=resolve_conflicts)
+        default=constants.EXPORT_OPTIONS[constants.EMBED_TEXTURES])
 
     option_texture_folder = StringProperty(
         name="Texture folder",
@@ -929,11 +929,11 @@ class ExportThree(bpy.types.Operator, ExportHelper):
         row.prop(self.properties, 'option_maps')
 
         row = layout.row()
-        row.prop(self.properties, 'option_copy_textures')
-        row.enabled = not self.properties.option_embed_textures
+        row.prop(self.properties, 'option_export_textures')
 
         row = layout.row()
         row.prop(self.properties, 'option_embed_textures')
+        row.enabled = self.properties.option_export_textures
 
         row = layout.row()
         row.prop(self.properties, 'option_texture_folder')

--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -378,6 +378,10 @@ def restore_export_settings(properties, settings):
         constants.COPY_TEXTURES,
         constants.EXPORT_OPTIONS[constants.COPY_TEXTURES])
 
+    properties.option_embed_textures = settings.get(
+        constants.EMBED_TEXTURES,
+        constants.EXPORT_OPTIONS[constants.EMBED_TEXTURES])
+
     properties.option_texture_folder = settings.get(
         constants.TEXTURE_FOLDER,
         constants.EXPORT_OPTIONS[constants.TEXTURE_FOLDER])
@@ -468,6 +472,7 @@ def set_settings(properties):
         constants.COMPRESSION: properties.option_compression,
         constants.INDENT: properties.option_indent,
         constants.COPY_TEXTURES: properties.option_copy_textures,
+        constants.EMBED_TEXTURES: properties.option_embed_textures,
         constants.TEXTURE_FOLDER: properties.option_texture_folder,
 
         constants.SCENE: properties.option_export_scene,
@@ -520,6 +525,10 @@ def animation_options():
     ]
 
     return anim
+
+def resolve_conflicts(self, context):
+    if(self.option_embed_textures):
+        self.option_copy_textures = False;
 
 class ExportThree(bpy.types.Operator, ExportHelper):
     """Class that handles the export properties"""
@@ -669,6 +678,12 @@ class ExportThree(bpy.types.Operator, ExportHelper):
         name="Copy textures",
         description="Copy textures",
         default=constants.EXPORT_OPTIONS[constants.COPY_TEXTURES])
+
+    option_embed_textures = BoolProperty(
+        name="Embed textures",
+        description="Embed base64 textures in .json",
+        default=constants.EXPORT_OPTIONS[constants.EMBED_TEXTURES],
+        update=resolve_conflicts)
 
     option_texture_folder = StringProperty(
         name="Texture folder",
@@ -915,6 +930,10 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
         row = layout.row()
         row.prop(self.properties, 'option_copy_textures')
+        row.enabled = not self.properties.option_embed_textures
+
+        row = layout.row()
+        row.prop(self.properties, 'option_embed_textures')
 
         row = layout.row()
         row.prop(self.properties, 'option_texture_folder')

--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -93,7 +93,7 @@ LIGHTS = 'lights'
 HIERARCHY = 'hierarchy'
 FACE_MATERIALS = 'faceMaterials'
 SKINNING = 'skinning'
-COPY_TEXTURES = 'copyTextures'
+EXPORT_TEXTURES = 'exportTextures'
 EMBED_TEXTURES = 'embedTextures'
 TEXTURE_FOLDER = 'textureFolder'
 ENABLE_PRECISION = 'enablePrecision'
@@ -154,7 +154,7 @@ EXPORT_OPTIONS = {
     CAMERAS: False,
     LIGHTS: False,
     HIERARCHY: False,
-    COPY_TEXTURES: True,
+    EXPORT_TEXTURES: True,
     EMBED_TEXTURES: False,
     TEXTURE_FOLDER: '',
     LOGGING: DEBUG,

--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -94,6 +94,7 @@ HIERARCHY = 'hierarchy'
 FACE_MATERIALS = 'faceMaterials'
 SKINNING = 'skinning'
 COPY_TEXTURES = 'copyTextures'
+EMBED_TEXTURES = 'embedTextures'
 TEXTURE_FOLDER = 'textureFolder'
 ENABLE_PRECISION = 'enablePrecision'
 PRECISION = 'precision'
@@ -154,6 +155,7 @@ EXPORT_OPTIONS = {
     LIGHTS: False,
     HIERARCHY: False,
     COPY_TEXTURES: True,
+    EMBED_TEXTURES: False,
     TEXTURE_FOLDER: '',
     LOGGING: DEBUG,
     ENABLE_PRECISION: True,

--- a/utils/exporters/blender/addons/io_three/exporter/geometry.py
+++ b/utils/exporters/blender/addons/io_three/exporter/geometry.py
@@ -148,7 +148,7 @@ class Geometry(base_classes.BaseNode):
     def copy_textures(self, texture_folder=''):
         """Copy the textures to the destination directory."""
         logger.debug("Geometry().copy_textures()")
-        if self.options.get(constants.COPY_TEXTURES):
+        if self.options.get(constants.EXPORT_TEXTURES) and not self.options.get(constants.EMBED_TEXTURES):
             texture_registration = self.register_textures()
             if texture_registration:
                 logger.info("%s has registered textures", self.node)

--- a/utils/exporters/blender/addons/io_three/exporter/image.py
+++ b/utils/exporters/blender/addons/io_three/exporter/image.py
@@ -1,4 +1,5 @@
 import os
+import base64
 from .. import constants, logger
 from . import base_classes, io, api
 
@@ -11,8 +12,17 @@ class Image(base_classes.BaseNode):
         logger.debug("Image().__init__(%s)", node)
         base_classes.BaseNode.__init__(self, node, parent, constants.IMAGE)
 
-        texture_folder = self.scene.options.get(constants.TEXTURE_FOLDER, "")
-        self[constants.URL] = os.path.join(texture_folder, api.image.file_name(self.node))
+        if(self.scene.options.get(constants.EMBED_TEXTURES, False)):
+            texturefile = open(api.image.file_path(self.node),"rb")
+            extension = os.path.splitext(api.image.file_path(self.node))[1][1:].strip().lower()
+            if(extension == 'jpg') :
+                extension = 'jpeg'
+            self[constants.URL] = "data:image/" + extension + ";base64," + base64.b64encode(texturefile.read()).decode("utf-8")
+            texturefile.close();
+        else:
+            texture_folder = self.scene.options.get(constants.TEXTURE_FOLDER, "")
+            self[constants.URL] = os.path.join(texture_folder, api.image.file_name(self.node))
+
 
     @property
     def destination(self):

--- a/utils/exporters/blender/addons/io_three/exporter/scene.py
+++ b/utils/exporters/blender/addons/io_three/exporter/scene.py
@@ -171,7 +171,7 @@ class Scene(base_classes.BaseScene):
 
         io.dump(self.filepath, data, options=self.options)
 
-        if self.options.get(constants.COPY_TEXTURES):
+        if self.options.get(constants.EXPORT_TEXTURES) and not self.options.get(constants.EMBED_TEXTURES):
             texture_folder = self.options.get(constants.TEXTURE_FOLDER)
             for geo in self[constants.GEOMETRIES]:
                 logger.info("Copying textures from %s", geo.node)


### PR DESCRIPTION
This PR adds a feature to the blender exporter to embed textures in the .json file as base64 strings, much like three.js editor. I find this pretty useful when using the three.js editor from disk or from the web, since the texture paths from the .json file will usually not be correct relative to the three.js editor root.

The patch uses the native base64 library in python to do the encoding, and disables the copy_textures option when selected, to avoid the confusing situation of copying texture image files without using them.
