### PR TITLE
return XMLHttpRequest from load() methods that do not return anything else

### DIFF
--- a/examples/js/loaders/3MFLoader.js
+++ b/examples/js/loaders/3MFLoader.js
@@ -14,7 +14,7 @@ THREE.ThreeMFLoader.prototype = {
 		var scope = this;
 		var loader = new THREE.XHRLoader( scope.manager );
 		loader.setResponseType( 'arraybuffer' );
-		loader.load( url, function( text ) {
+		return loader.load( url, function( text ) {
 
 			onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/AMFLoader.js
+++ b/examples/js/loaders/AMFLoader.js
@@ -35,7 +35,7 @@ THREE.AMFLoader.prototype = {
 
 		var loader = new THREE.XHRLoader( scope.manager );
 		loader.setResponseType( 'arraybuffer' );
-		loader.load( url, function( text ) {
+		return loader.load( url, function( text ) {
 
 			onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/AWDLoader.js
+++ b/examples/js/loaders/AWDLoader.js
@@ -111,7 +111,7 @@
 
 			var loader = new THREE.XHRLoader( this.manager );
 			loader.setResponseType( 'arraybuffer' );
-			loader.load( url, function ( text ) {
+			return loader.load( url, function ( text ) {
 
 				onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/AssimpJSONLoader.js
+++ b/examples/js/loaders/AssimpJSONLoader.js
@@ -28,7 +28,7 @@ THREE.AssimpJSONLoader.prototype = {
 		this.texturePath = this.texturePath && ( typeof this.texturePath === "string" ) ? this.texturePath : this.extractUrlBase( url );
 
 		var loader = new THREE.XHRLoader( this.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			var json = JSON.parse( text ), scene, metadata;
 

--- a/examples/js/loaders/BabylonLoader.js
+++ b/examples/js/loaders/BabylonLoader.js
@@ -17,7 +17,7 @@ THREE.BabylonLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( JSON.parse( text ) ) );
 

--- a/examples/js/loaders/BinaryLoader.js
+++ b/examples/js/loaders/BinaryLoader.js
@@ -53,7 +53,7 @@ THREE.BinaryLoader.prototype = {
 		var scope = this;
 
 		var jsonloader = new THREE.XHRLoader( this.manager );
-		jsonloader.load( url, function ( data ) {
+		return jsonloader.load( url, function ( data ) {
 
 			var json = JSON.parse( data );
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -112,6 +112,8 @@ THREE.ColladaLoader = function () {
 			request.open( "GET", url, true );
 			request.send( null );
 
+			return request;
+
 		} else {
 
 			alert( "Don't know how to parse XML!" );

--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -25,7 +25,7 @@ THREE.ColladaLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( text, getBaseUrl( url ) ) );
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -35,7 +35,7 @@
 
 		var loader = new THREE.XHRLoader( scope.manager );
 		// loader.setCrossOrigin( this.crossOrigin );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			if ( ! scope.isFbxFormatASCII( text ) ) {
 

--- a/examples/js/loaders/KMZLoader.js
+++ b/examples/js/loaders/KMZLoader.js
@@ -18,7 +18,7 @@ THREE.KMZLoader.prototype = {
 
 		var loader = new THREE.XHRLoader( scope.manager );
 		loader.setResponseType( 'arraybuffer' );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/MD2Loader.js
+++ b/examples/js/loaders/MD2Loader.js
@@ -18,7 +18,7 @@ THREE.MD2Loader.prototype = {
 
 		var loader = new THREE.XHRLoader( scope.manager );
 		loader.setResponseType( 'arraybuffer' );
-		loader.load( url, function ( buffer ) {
+		return loader.load( url, function ( buffer ) {
 
 			onLoad( scope.parse( buffer ) );
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -20,7 +20,7 @@ THREE.MTLLoader.prototype = {
 
 		var loader = new THREE.XHRLoader( this.manager );
 		loader.setPath( this.path );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -20,7 +20,7 @@ THREE.OBJLoader.prototype = {
 
 		var loader = new THREE.XHRLoader( scope.manager );
 		loader.setPath( this.path );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -23,7 +23,7 @@ THREE.PCDLoader.prototype = {
 
 		var loader = new THREE.XHRLoader( scope.manager );
 		loader.setResponseType( 'arraybuffer' );
-		loader.load( url, function( data ) {
+		return loader.load( url, function( data ) {
 
 			onLoad( scope.parse( data, url ) );
 

--- a/examples/js/loaders/PDBLoader.js
+++ b/examples/js/loaders/PDBLoader.js
@@ -17,7 +17,7 @@ THREE.PDBLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			var json = scope.parsePDB( text );
 			scope.createModel( json, onLoad );

--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -45,7 +45,7 @@ THREE.PLYLoader.prototype = {
 
 		var loader = new THREE.XHRLoader( this.manager );
 		loader.setResponseType( 'arraybuffer' );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/PlayCanvasLoader.js
+++ b/examples/js/loaders/PlayCanvasLoader.js
@@ -17,7 +17,7 @@ THREE.PlayCanvasLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( JSON.parse( text ) ) );
 

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -43,7 +43,7 @@ THREE.STLLoader.prototype = {
 
 		var loader = new THREE.XHRLoader( scope.manager );
 		loader.setResponseType( 'arraybuffer' );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -20,7 +20,7 @@ THREE.SVGLoader.prototype = {
 		var parser = new DOMParser();
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( svgString ) {
+		return loader.load( url, function ( svgString ) {
 
 			var doc = parser.parseFromString( svgString, 'image/svg+xml' );  // application/xml
 

--- a/examples/js/loaders/VRMLLoader.js
+++ b/examples/js/loaders/VRMLLoader.js
@@ -31,7 +31,7 @@ THREE.VRMLLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( this.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -18,7 +18,7 @@ THREE.VTKLoader.prototype = {
 		// Will we bump into trouble reading the whole file into memory?
 		var scope = this;
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( text ) );
 

--- a/examples/js/loaders/deprecated/SceneLoader.js
+++ b/examples/js/loaders/deprecated/SceneLoader.js
@@ -29,7 +29,7 @@ THREE.SceneLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			scope.parse( JSON.parse( text ), onLoad, url );
 

--- a/src/loaders/AnimationLoader.js
+++ b/src/loaders/AnimationLoader.js
@@ -17,7 +17,7 @@ THREE.AnimationLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( JSON.parse( text ) ) );
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -17,7 +17,7 @@ THREE.BufferGeometryLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( JSON.parse( text ) ) );
 

--- a/src/loaders/FontLoader.js
+++ b/src/loaders/FontLoader.js
@@ -15,7 +15,7 @@ THREE.FontLoader.prototype = {
 	load: function ( url, onLoad, onProgress, onError ) {
 
 		var loader = new THREE.XHRLoader( this.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( new THREE.Font( JSON.parse( text.substring( 65, text.length - 2 ) ) ) );
 

--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -45,7 +45,7 @@ THREE.JSONLoader.prototype = {
 
 		var loader = new THREE.XHRLoader( this.manager );
 		loader.setWithCredentials( this.withCredentials );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			var json = JSON.parse( text );
 			var metadata = json.metadata;

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -18,7 +18,7 @@ THREE.MaterialLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( JSON.parse( text ) ) );
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -24,7 +24,7 @@ THREE.ObjectLoader.prototype = {
 		var scope = this;
 
 		var loader = new THREE.XHRLoader( scope.manager );
-		loader.load( url, function ( text ) {
+		return loader.load( url, function ( text ) {
 
 			scope.parse( JSON.parse( text ), onLoad );
 


### PR DESCRIPTION
Follow-up PR to #8091 I skipped some loaders where it was not obvious to me where to stick that return statement, and also things like XxxTextureLoader that already return textures from load() call.
