### PR TITLE
Custom UV on LatheGeometry without custom geometry

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -150,6 +150,8 @@
 
 		<!-- <script type="text/javascript" src="https://www.dropbox.com/static/api/2/dropins.js" id="dropboxjs" data-app-key="qyqgfqd9j8z890t"></script> -->
 
+		<script src="js/CustomUV.js"></script>
+
 		<script>
 
 			window.URL = window.URL || window.webkitURL;

--- a/editor/js/CustomUV.js
+++ b/editor/js/CustomUV.js
@@ -1,0 +1,135 @@
+﻿// Need a way to get real data when instancited by ObjectLoader
+THREE.LatheGeometry = ( function() {
+
+	var __threeGeometry = THREE.LatheGeometry;
+	var __prototype = THREE.LatheGeometry.prototype;
+
+	var ret = function customGeometry() {
+
+		this.__ctorArguments = arguments;
+
+		__threeGeometry.apply( this, arguments );
+
+	}
+
+	ret.__prototype = __prototype;
+
+	return ret;
+
+} )();
+
+THREE.LatheGeometry.prototype = THREE.LatheGeometry.__prototype;
+
+// As we want to customize UV => customize this.faceVertexUvs[0].push.
+THREE.Geometry = ( function() {
+
+	var __threeGeometry = THREE.Geometry;
+	var __prototype = THREE.Geometry.prototype;
+
+	var ret = function customGeometry() {
+
+		__threeGeometry.apply( this, arguments );
+
+		var __self = this;
+
+		this.faceVertexUvs[ 0 ].__push = this.faceVertexUvs[ 0 ].push;
+
+		this.faceVertexUvs[ 0 ].push = function() {
+
+			if ( __self.type === 'LatheGeometry' ) {
+
+				// Does anybody asked for custom UV mapping .
+				if ( __self.parameters.mapping === undefined ) {
+
+					__self.parameters.mapping = 'index';
+					if ( __self.__ctorArguments.length === 1 && __self.__ctorArguments[ 0 ].type === 'LatheGeometry' && __self.__ctorArguments[ 0 ].mapping ) {
+
+						__self.parameters.mapping = __self.__ctorArguments[ 0 ].mapping;
+
+					} else if ( __self.__ctorArguments.length === 5 ) {
+
+						__self.parameters.mapping = __self.__ctorArguments[ 4 ];
+
+					}
+
+				}
+
+				if ( __self.parameters.mapping === 'length' ) {
+
+					var np = __self.parameters.points.length;
+
+					if ( __self.ratioDistance === undefined ) {
+
+						// Compute new V based on length.
+						__self.ratioDistance = [ 0 ];
+						var distance = 0;
+
+						for ( var i = 1; i < np; i ++ ) {
+
+							var pt1 = __self.parameters.points[ i - 1 ];
+							var pt2 = __self.parameters.points[ i ];
+							var lgX = pt2.x - pt1.x;
+							var lgY = pt2.y - pt1.y;
+							distance += Math.sqrt( lgX * lgX + lgY * lgY );
+							__self.ratioDistance.push( distance );
+
+						}
+
+						for ( var i = 1; i < __self.parameters.points.length; i ++ ) {
+
+							__self.ratioDistance[ i ] /= distance;
+
+						}
+
+					}
+
+					// Compute control variables.
+					var inverseSegments = 1.0 / __self.parameters.segments;
+					var i = Math.floor( this.length / ( ( np - 1 ) * 2 ) );
+					var k = this.length % ( ( np - 1 ) * 2 );
+					var j = Math.floor( k / 2 );
+
+					// Compute UVs.
+					var u0 = i * inverseSegments;
+					var v0 = __self.ratioDistance[ j ];
+					var u1 = u0 + inverseSegments;
+					var v1 = __self.ratioDistance[ j + 1 ];
+
+					if ( k % 2 ) {
+
+						this.__push.apply( this, [[
+						new THREE.Vector2( u1, v0 ),
+						new THREE.Vector2( u1, v1 ),
+						new THREE.Vector2( u0, v1 )
+						]] );
+
+					} else {
+
+						this.__push.apply( this, [[
+						new THREE.Vector2( u0, v0 ),
+						new THREE.Vector2( u1, v0 ),
+						new THREE.Vector2( u0, v1 )
+						]] );
+
+					}
+
+				} else {
+
+					// Standard UVs.
+					this.__push.apply( this, arguments );
+
+				}
+
+			}
+
+		}
+
+	}
+
+	ret.__prototype = __prototype;
+
+	return ret;
+
+} )();
+
+THREE.Geometry.prototype = THREE.Geometry.__prototype;

--- a/editor/js/Sidebar.Geometry.LatheGeometry.js
+++ b/editor/js/Sidebar.Geometry.LatheGeometry.js
@@ -40,6 +40,17 @@ Sidebar.Geometry.LatheGeometry = function( editor, object ) {
 
 	container.add( phiLengthRow );
 
+	// mapping
+
+	var mappingRow = new UI.Row();
+	var mappingOptions = [ 'index', 'length' ];
+	var mapping = new UI.Select().setOptions( mappingOptions ).setValue( ( parameters.mapping || 'index' ).toLowerCase() === 'length' ? 1 : 0 ).onChange( update );
+
+	mappingRow.add( new UI.Text( 'Mapping' ).setWidth( '90px' ) );
+	mappingRow.add( mapping );
+
+	container.add( mappingRow );
+
 	// points
 
 	var lastPointIdx = 0;
@@ -129,7 +140,8 @@ Sidebar.Geometry.LatheGeometry = function( editor, object ) {
 			points,
 			segments.getValue(),
 			phiStart.getValue() / 180 * Math.PI,
-			phiLength.getValue() / 180 * Math.PI
+			phiLength.getValue() / 180 * Math.PI,
+			mappingOptions[ mapping.getValue() ]
 		);
 
 		editor.execute( new SetGeometryCommand( object, geometry ) );

--- a/src/extras/geometries/LatheGeometry.js
+++ b/src/extras/geometries/LatheGeometry.js
@@ -17,6 +17,18 @@ THREE.LatheGeometry = function ( points, segments, phiStart, phiLength ) {
 
 	this.type = 'LatheGeometry';
 
+	if ( arguments.length === 1 && arguments[ 0 ].type === 'LatheGeometry' ) {
+
+		// Called by ObjectLoader.
+		var data = arguments[ 0 ];
+
+		points = data.points;
+		segments = data.segments;
+		phiStart = data.phiStart;
+		phiLength = data.phiLength;
+
+	}
+
 	this.parameters = {
 		points: points,
 		segments: segments,

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -259,12 +259,7 @@ THREE.ObjectLoader.prototype = {
 
 					case 'LatheGeometry':
 
-						geometry = new THREE.LatheGeometry(
-							data.points,
-							data.segments,
-							data.phiStart,
-							data.phiLength
-						);
+						geometry = new THREE.LatheGeometry( data );
 
 						break;
 


### PR DESCRIPTION
In https://github.com/mrdoob/three.js/issues/8058 you suggested that custom geometries could be managed by `ObjectLoader`. I agree, but as I don't know how you want to manage the custom goemetries, I can't help you.

Here is a way to allow modification of standard geometries a worse way. I modified the editor to allow 2 UV mapping modes on LatheGeometry.

`LatheGeometry` and `ObjectLoader` are modified to give an "easy" access to the data serialised, nothing else.
The same kind of modification would be required for all geometries.
`ObjectLoader.parseGeometries` would be a big `geometry = new THREE[ data.type ]( data );` except for CubeGeometry, BufferGeometry and Geometry.
