### PR TITLE
Add npm Build/Watch Scripts in `utils/build` for Node users

### DIFF
--- a/utils/build/package.json
+++ b/utils/build/package.json
@@ -1,24 +1,29 @@
 {
-    "name": "three.js",
-    "description": "JavaScript 3D library",
-    "version": "0.0.0",
-    "homepage" : "http://threejs.org/",
-    "author": "three.js contributors",
-    "help": {
-        "web": "http://stackoverflow.com/questions/tagged/three.js"
-    },
-
-    "devDependencies": {
-        "uglify-js": "^2.4.17",
-        "argparse" : "*"
-    },
-    
-    "repository" : {
-        "type" : "git",
-         "url" : "git://github.com/mrdoob/three.js.git"
-    },
-    "licenses": [{
-        "type": "The MIT License",
-        "url": "https://raw.github.com/mrdoob/three.js/master/LICENSE"
-    }]
+  "name": "three.js",
+  "description": "JavaScript 3D library",
+  "version": "0.0.0",
+  "homepage": "http://threejs.org/",
+  "author": "three.js contributors",
+  "help": {
+    "web": "http://stackoverflow.com/questions/tagged/three.js"
+  },
+  "scripts": {
+    "build": "node build.js --include common --include extras",
+    "watch": "onchange '../../src/**/*.js' -- npm run build"
+  },
+  "devDependencies": {
+    "argparse": "*",
+    "onchange": "^2.0.0",
+    "uglify-js": "^2.4.17"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mrdoob/three.js.git"
+  },
+  "licenses": [
+    {
+      "type": "The MIT License",
+      "url": "https://raw.github.com/mrdoob/three.js/master/LICENSE"
+    }
+  ]
 }


### PR DESCRIPTION
This improves the "Quickstart (Node.js)" process for those developing ThreeJS with tools like Node/npm/browserify/webpack/etc.

https://github.com/mrdoob/three.js/wiki/build.py,-or-how-to-generate-a-compressed-Three.js-file#quickstart-nodejs

Changes:
- Adds a `npm run build` command that handles the commons/defaults.
- Adds a `npm run watch` for development, so that changing files in `src/**` will re-run the above `build` script
- Reformatted the package.json to use two spaces, since this is the default with tooling like `npm install --save`

This makes it a bit easier to develop ThreeJS code within an application. You can symlink and/or `require()` the build file and changing ThreeJS source will trigger a re-build.

---

To recap, the build/dev commands are now:

```
# initial setup
npm install

# build JS bundle
npm run build

# or, you can still call the script directly
node build.js --include common --include extras

# for development, rebuild on 'src/**' file changes
npm run watch
```
