### PR TITLE
Fix "no texture bound" warnings in WebGL2 context

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -58,6 +58,13 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 	var currentScissor = new THREE.Vector4();
 	var currentViewport = new THREE.Vector4();
 
+	var emptyTexture = gl.createTexture();
+	gl.bindTexture(gl.TEXTURE_2D, emptyTexture);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, 1, 1, 0, gl.RGB, gl.UNSIGNED_BYTE, new Uint8Array([
+		0, 0, 0
+	]));
+
 	this.init = function () {
 
 		this.clearColor( 0, 0, 0, 1 );
@@ -551,7 +558,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 		if ( boundTexture.type !== webglType || boundTexture.texture !== webglTexture ) {
 
-			gl.bindTexture( webglType, webglTexture );
+			gl.bindTexture( webglType, webglTexture || emptyTexture );
 
 			boundTexture.type = webglType;
 			boundTexture.texture = webglTexture;


### PR DESCRIPTION
When you switch contexts to WebGL2 in Chrome Canary, you get an error that no texture is bound to unit X.

![screen shot 2016-02-12 at 2 56 14 pm](https://cloud.githubusercontent.com/assets/1383811/13018773/ac815b1a-d199-11e5-8191-a3fca8799870.png)

This happens with code like this:

``` js
const material = new THREE.MeshBasicMaterial({
  map: new THREE.Texture() // Gets manually updated later
});
```

To fix, this PR creates a dummy 1x1 black RGB texture, and uses that as the default.

However, maybe this is something that the Chrome team should fix, since it isn't happening in FireFox Nightly on WebGL2.
