### PR TITLE
MeshNormalMaterial: removed shading parameter from comments

### DIFF
--- a/src/materials/MeshNormalMaterial.js
+++ b/src/materials/MeshNormalMaterial.js
@@ -4,7 +4,6 @@
  * parameters = {
  *  opacity: <float>,
  *
- *  shading: THREE.FlatShading,
  *  blending: THREE.NormalBlending,
  *  depthTest: <bool>,
  *  depthWrite: <bool>,


### PR DESCRIPTION
Nothing special, just a little fix in the comment section of the `MeshNormalMaterial`...
