### PR TITLE
Enhanced material documentation

### DIFF
--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -26,10 +26,14 @@
 		<div>
 		color — geometry color in hexadecimal. Default is 0xffffff.<br />
 		map — Set texture map. Default is null <br />
-		aoMap — Set ambient occlusion map. Default is null <br />
+		aoMap — Set ao map. Default is null.<br />
+		aoMapIntensity — Set ao map intensity. Default is 1.<br />
 		specularMap — Set specular map. Default is null.<br />
 		alphaMap — Set alpha map. Default is null.<br />
 		envMap — Set env map. Default is null.<br />
+		combine — Set combine operation. Default is THREE.MultiplyOperation.<br />
+		reflectivity — Set reflectivity. Default is 1.<br />
+		refractionRatio — Set refraction ratio. Default is 0.98.<br />
 		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
 		shading — Define shading type. Default is THREE.SmoothShading.<br />
 		wireframe — render geometry as wireframe. Default is false.<br />
@@ -54,6 +58,9 @@
 		<h3>[property:Texture aoMap]</h3>
 		<div>Set ambient occlusion map. Default is null.</div>
 
+		<h3>[property:Float aoMapIntensity]</h3>
+		<div>TODO</div>
+
 		<h3>[property:Texture specularMap]</h3>
 		<div>Set specular map. Default is null.</div>
 
@@ -63,6 +70,17 @@
 
 		<h3>[property:TextureCube envMap]</h3>
 		<div>Set env map. Default is null.</div>
+
+		<h3>[property:Integer combine]</h3>
+		<div>How to combine the result of the surface's color with the environment map, if any.</div>
+
+		<div>Options are [page:Textures THREE.Multiply] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
+
+		<h3>[property:Float reflectivity]</h3>
+		<div>How much the environment map affects the surface; also see "combine".</div>
+
+		<h3>[property:Float refractionRatio]</h3>
+		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
 
 		<h3>[property:Boolean fog]</h3>
 		<div>Define whether the material color is affected by global fog settings.</div>
@@ -95,21 +113,6 @@
 
 		<h3>[property:Boolean morphTargets]</h3>
 		<div>Define whether the material uses morphTargets. Default is false.</div>
-
-		<h3>[property:number combine]</h3>
-		<div>
-		How to combine the result of the surface's color with the environment map, if any.
-		</div>
-
-		<h3>[property:number reflectivity]</h3>
-		<div>
-		How much the environment map affects the surface; also see "combine".
-		</div>
-
-		<h3>[property:number refractionRatio]</h3>
-		<div>
-		The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.
-		</div>
 
 		<h2>Methods</h2>
 

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -27,11 +27,18 @@
 		color — Line color in hexadecimal. Default is 0xffffff.<br />
 		map — Sets the texture map. Default is null <br />
 		lightMap — Set light map. Default is null.<br />
+		lightMapIntensity — Set light map intensity. Default is 1.<br />
 		aoMap — Set ao map. Default is null.<br />
+		aoMapIntensity — Set ao map intensity. Default is 1.<br />
+		emissive - Set emissive color. Default is 0x000000.<br />
 		emissiveMap — Set emissive map. Default is null.<br />
+		emissiveIntensity — Set emissive map intensity. Default is 1.<br />
 		specularMap — Set specular map. Default is null.<br />
 		alphaMap — Set alpha map. Default is null.<br />
 		envMap — Set env map. Default is null.<br />
+		combine — Set combine operation. Default is THREE.MultiplyOperation.<br />
+		reflectivity — Set reflectivity. Default is 1.<br />
+		refractionRatio — Set refraction ratio. Default is 0.98.<br />
 		fog — Define whether the material color is affected by global fog settings. Default is false.<br />
 		wireframe — Render geometry as wireframe. Default is false (i.e. render as smooth shaded).<br/>
 		wireframeLinewidth — Controls wireframe thickness. Default is 1.<br/>
@@ -39,7 +46,8 @@
 		wireframeLinejoin — Define appearance of line joints. Default is 'round'.<br />
 		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
 		skinning — Define whether the material uses skinning. Default is false.<br />
-		morphTargets — Define whether the material uses morphTargets. Default is false.<br/>
+		morphTargets — Define whether the material uses morphTargets. Default is false.<br />
+		morphNormals — Define whether the material uses morphNormals. Default is false.
 		</div>
 
 
@@ -51,25 +59,31 @@
 		Diffuse color of the material. Default is white.<br />
 		</div>
 
-		<h3>[property:Color emissive]</h3>
-		<div>
-		Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
-		</div>
-
-		<h3>[property:Float emissiveIntensity]</h3>
-		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
-
 		<h3>[property:Texture map]</h3>
 		<div>Set color texture map. Default is null.</div>
 
 		<h3>[property:Texture lightMap]</h3>
 		<div>Set light map. Default is null. The lightMap requires a second set of UVs.</div>
 
+		<h3>[property:Float lightMapIntensity]</h3>
+		<div>TODO</div>
+
 		<h3>[property:Texture aoMap]</h3>
 		<div>Set ambient occlusion map. Default is null. The aoMap requires a second set of UVs.</div>
 
+		<h3>[property:Float aoMapIntensity]</h3>
+		<div>TODO</div>
+
+		<h3>[property:Color emissive]</h3>
+		<div>
+		Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
+		</div>
+
 		<h3>[property:Texture emissiveMap]</h3>
 		<div>Set emisssive (glow) map. Default is null. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.</div>
+
+		<h3>[property:Float emissiveIntensity]</h3>
+		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
 
 		<h3>[property:Texture specularMap]</h3>
 		<div>Since this material does not have a specular component, the specular value affects only how much of the environment map affects the surface. Default is null.</div>

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -37,8 +37,8 @@
 		emissiveIntensity — Set emissive map intensity. Default is 1.<br />
 		bumpMap — Set bump map. Default is null.<br />
 		bumpMapScale — Set bump map scale. Default is 1.<br />
-    normalMap — Set normal map. Default is null.<br />
-    normalMapScale — Set normal map scale. Default is (1, 1).<br />
+		normalMap — Set normal map. Default is null.<br />
+		normalMapScale — Set normal map scale. Default is (1, 1).<br />
 		displacementMap — Set displacement map. Default is null.<br />
 		displacementScale — Set displacement scale. Default is 1.<br />
 		displacementBias — Set displacement offset. Default is 0.<br />

--- a/docs/api/materials/MeshStandardMaterial.html
+++ b/docs/api/materials/MeshStandardMaterial.html
@@ -12,9 +12,9 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A material for shiny surfaces, evaluated per pixel.</div>
+		<div class="desc">TODO</div>
 
-		<iframe src='scenes/material-browser.html#MeshPhongMaterial'></iframe>
+		<iframe src='scenes/material-browser.html#MeshStandardMaterial'></iframe>
 
 		<h2>Constructor</h2>
 
@@ -25,28 +25,28 @@
 		</div>
 		<div>
 		color — geometry color in hexadecimal. Default is 0xffffff.<br />
-		specular — Set specular color. Default is 0x111111 .<br />
-		shininess — Set shininess Default is 30.<br />
+		roughness — Set roughness. Default is 0.5.<br />
+		metalness — Set metalness. Default is 0.5.<br />
 		map — Set texture map. Default is null.<br />
 		lightMap — Set light map. Default is null.<br />
 		lightMapIntensity — Set light map intensity. Default is 1.<br />
 		aoMap — Set ao map. Default is null.<br />
 		aoMapIntensity — Set ao map intensity. Default is 1.<br />
-		emissive - Set emissive color. Default is 0x000000.<br />
+    emissive - Set emissive color. Default is 0x000000.<br />
 		emissiveMap — Set emissive map. Default is null.<br />
 		emissiveIntensity — Set emissive map intensity. Default is 1.<br />
-		bumpMap — Set bump map. Default is null.<br />
+    bumpMap — Set bump map. Default is null.<br />
 		bumpMapScale — Set bump map scale. Default is 1.<br />
     normalMap — Set normal map. Default is null.<br />
     normalMapScale — Set normal map scale. Default is (1, 1).<br />
 		displacementMap — Set displacement map. Default is null.<br />
 		displacementScale — Set displacement scale. Default is 1.<br />
 		displacementBias — Set displacement offset. Default is 0.<br />
-		specularMap — Set specular map. Default is null.<br />
-		alphaMap — Set alpha map. Default is null.<br />
+    roughnessMap - Set roughness map. Default is null.<br />
+    metalnessMap - Set metalness map. Default is null.<br />
+    alphaMap — Set alpha map. Default is null.<br />
 		envMap — Set env map. Default is null.<br />
-		combine — Set combine operation. Default is THREE.MultiplyOperation.<br />
-		reflectivity — Set reflectivity. Default is 1.<br />
+		envMapIntensity — Set env map intensity. Default is 1.0.<br />
 		refractionRatio — Set refraction ratio. Default is 0.98.<br />
 		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
 		shading — Define shading type. Default is THREE.SmoothShading.<br />
@@ -61,7 +61,7 @@
 		</div>
 		<div>
 		Example:<br>
-		materials.push( new THREE.MeshPhongMaterial( { color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.FlatShading } ) );
+		materials.push( new THREE.MeshStandardMaterial( { color: 0x550000, envMap: reflectionCube, roughness: 0.1, metalness: 1.0 } ) );
 
 		</div>
 
@@ -74,13 +74,15 @@
 		Diffuse color of the material. Default is white.<br />
 		</div>
 
-		<h3>[property:Color specular]</h3>
+    <h3>[property:Float roughness]</h3>
 		<div>
-		Specular color of the material, i.e., how shiny the material is and the color of its shine. Setting this the same color as the diffuse value (times some intensity) makes the material more metallic-looking; setting this to some gray makes the material look more plastic. Default is dark gray.<br />
+		TODO.<br />
 		</div>
 
-		<h3>[property:Float shininess]</h3>
-		<div>How shiny the specular highlight is; a higher value gives a sharper highlight. Default is *30*.</div>
+    <h3>[property:Float metalness]</h3>
+		<div>
+		TODO<br />
+		</div>
 
 		<h3>[property:Texture map]</h3>
 		<div>Set color texture map. Default is null. The texture map color is modulated by the diffuse color.</div>
@@ -94,19 +96,19 @@
 		<h3>[property:Texture aoMap]</h3>
 		<div>Set ambient occlusion map. Default is null. The aoMap requires a second set of UVs.</div>
 
-		<h3>[property:Float aoMapIntensity]</h3>
+    <h3>[property:Float aoMapIntensity]</h3>
 		<div>TODO</div>
 
-		<h3>[property:Color emissive]</h3>
-		<div>
-		Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
-		</div>
+    <h3>[property:Color emissive]</h3>
+    <div>
+    Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
+    </div>
 
 		<h3>[property:Texture emissiveMap]</h3>
 		<div>Set emisssive (glow) map. Default is null. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.</div>
 
-		<h3>[property:Float emissiveIntensity]</h3>
-		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
+    <h3>[property:Float emissiveIntensity]</h3>
+    <div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
 
 		<h3>[property:Texture bumpMap]</h3>
 		<div>
@@ -128,7 +130,7 @@
 
 		<h3>[property:Vector2 normalScale]</h3>
 		<div>
-			How much the normal map affects the material. Typical ranges are 0-1. Default is (1,1).
+			How much the normal map affects the material. Typical ranges are 0-1. Default is (1, 1).
 		</div>
 
 		<h3>[property:Texture displacementMap]</h3>
@@ -147,23 +149,25 @@
 			The offset of the displacement map's values on the mesh's vertices. Without a displacement map set, this value is not applied. Default is 0.
 		</div>
 
-		<h3>[property:Texture specularMap]</h3>
-		<div>The specular map value affects both how much the specular surface highlight contributes and how much of the environment map affects the surface. Default is null.</div>
+    <h3>[property:Texture roughnessMap]</h3>
+    <div>
+      TODO.
+    </div>
 
-		<h3>[property:Texture alphaMap]</h3>
-		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
-		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
+    <h3>[property:Texture metalnessMap]</h3>
+    <div>
+      TODO.
+    </div>
+
+    <h3>[property:Texture alphaMap]</h3>
+    <div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
+    <div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
 
 		<h3>[property:TextureCube envMap]</h3>
 		<div>Set env map. Default is null.</div>
 
-		<h3>[property:Integer combine]</h3>
-		<div>How to combine the result of the surface's color with the environment map, if any.</div>
-
-		<div>Options are [page:Textures THREE.MultiplyOperation] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
-
-		<h3>[property:Float reflectivity]</h3>
-		<div>How much the environment map affects the surface; also see "combine".</div>
+    <h3>[property:Float envMapIntensity]</h3>
+		<div>TODO</div>
 
 		<h3>[property:Float refractionRatio]</h3>
 		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>

--- a/docs/api/materials/MeshStandardMaterial.html
+++ b/docs/api/materials/MeshStandardMaterial.html
@@ -32,19 +32,19 @@
 		lightMapIntensity — Set light map intensity. Default is 1.<br />
 		aoMap — Set ao map. Default is null.<br />
 		aoMapIntensity — Set ao map intensity. Default is 1.<br />
-    emissive - Set emissive color. Default is 0x000000.<br />
+		emissive - Set emissive color. Default is 0x000000.<br />
 		emissiveMap — Set emissive map. Default is null.<br />
 		emissiveIntensity — Set emissive map intensity. Default is 1.<br />
-    bumpMap — Set bump map. Default is null.<br />
+		bumpMap — Set bump map. Default is null.<br />
 		bumpMapScale — Set bump map scale. Default is 1.<br />
-    normalMap — Set normal map. Default is null.<br />
-    normalMapScale — Set normal map scale. Default is (1, 1).<br />
+		normalMap — Set normal map. Default is null.<br />
+		normalMapScale — Set normal map scale. Default is (1, 1).<br />
 		displacementMap — Set displacement map. Default is null.<br />
 		displacementScale — Set displacement scale. Default is 1.<br />
 		displacementBias — Set displacement offset. Default is 0.<br />
-    roughnessMap - Set roughness map. Default is null.<br />
-    metalnessMap - Set metalness map. Default is null.<br />
-    alphaMap — Set alpha map. Default is null.<br />
+		roughnessMap - Set roughness map. Default is null.<br />
+		metalnessMap - Set metalness map. Default is null.<br />
+		alphaMap — Set alpha map. Default is null.<br />
 		envMap — Set env map. Default is null.<br />
 		envMapIntensity — Set env map intensity. Default is 1.0.<br />
 		refractionRatio — Set refraction ratio. Default is 0.98.<br />
@@ -74,12 +74,12 @@
 		Diffuse color of the material. Default is white.<br />
 		</div>
 
-    <h3>[property:Float roughness]</h3>
+		<h3>[property:Float roughness]</h3>
 		<div>
 		TODO.<br />
 		</div>
 
-    <h3>[property:Float metalness]</h3>
+		<h3>[property:Float metalness]</h3>
 		<div>
 		TODO<br />
 		</div>
@@ -96,19 +96,19 @@
 		<h3>[property:Texture aoMap]</h3>
 		<div>Set ambient occlusion map. Default is null. The aoMap requires a second set of UVs.</div>
 
-    <h3>[property:Float aoMapIntensity]</h3>
+		<h3>[property:Float aoMapIntensity]</h3>
 		<div>TODO</div>
 
-    <h3>[property:Color emissive]</h3>
-    <div>
-    Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
-    </div>
+		<h3>[property:Color emissive]</h3>
+		<div>
+			Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
+		</div>
 
 		<h3>[property:Texture emissiveMap]</h3>
 		<div>Set emisssive (glow) map. Default is null. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.</div>
 
-    <h3>[property:Float emissiveIntensity]</h3>
-    <div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
+		<h3>[property:Float emissiveIntensity]</h3>
+		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
 
 		<h3>[property:Texture bumpMap]</h3>
 		<div>
@@ -149,24 +149,24 @@
 			The offset of the displacement map's values on the mesh's vertices. Without a displacement map set, this value is not applied. Default is 0.
 		</div>
 
-    <h3>[property:Texture roughnessMap]</h3>
-    <div>
-      TODO.
-    </div>
+		<h3>[property:Texture roughnessMap]</h3>
+		<div>
+			TODO.
+		</div>
 
-    <h3>[property:Texture metalnessMap]</h3>
-    <div>
-      TODO.
-    </div>
+		<h3>[property:Texture metalnessMap]</h3>
+		<div>
+			TODO.
+		</div>
 
-    <h3>[property:Texture alphaMap]</h3>
-    <div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
-    <div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
+		<h3>[property:Texture alphaMap]</h3>
+		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
+		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
 
 		<h3>[property:TextureCube envMap]</h3>
 		<div>Set env map. Default is null.</div>
 
-    <h3>[property:Float envMapIntensity]</h3>
+		<h3>[property:Float envMapIntensity]</h3>
 		<div>TODO</div>
 
 		<h3>[property:Float refractionRatio]</h3>

--- a/docs/list.js
+++ b/docs/list.js
@@ -76,6 +76,7 @@ var list = {
 			[ "MeshLambertMaterial", "api/materials/MeshLambertMaterial" ],
 			[ "MeshNormalMaterial", "api/materials/MeshNormalMaterial" ],
 			[ "MeshPhongMaterial", "api/materials/MeshPhongMaterial" ],
+			[ "MeshStandardMaterial", "api/materials/MeshStandardMaterial" ],
 			[ "PointsMaterial", "api/materials/PointsMaterial" ],
 			[ "RawShaderMaterial", "api/materials/RawShaderMaterial" ],
 			[ "ShaderMaterial", "api/materials/ShaderMaterial" ],

--- a/docs/scenes/js/material.js
+++ b/docs/scenes/js/material.js
@@ -525,13 +525,13 @@ function chooseFromHash ( gui, mesh, geometry ) {
 
 	case "MeshStandardMaterial" :
 
-			material = new THREE.MeshStandardMaterial({color: 0x2194CE});
-			guiMaterial( gui, mesh, material, geometry );
-			guiMeshStandardMaterial( gui, mesh, material, geometry );
+		material = new THREE.MeshStandardMaterial({color: 0x2194CE});
+		guiMaterial( gui, mesh, material, geometry );
+		guiMeshStandardMaterial( gui, mesh, material, geometry );
 
-			return material;
+		return material;
 
-			break;
+		break;
 
 	case "MeshDepthMaterial" :
 

--- a/docs/scenes/js/material.js
+++ b/docs/scenes/js/material.js
@@ -453,6 +453,39 @@ function guiMeshPhongMaterial ( gui, mesh, material, geometry ) {
 
 }
 
+function guiMeshStandardMaterial ( gui, mesh, material, geometry ) {
+
+	var data = {
+		color : material.color.getHex(),
+		emissive : material.emissive.getHex(),
+		envMaps : envMapKeys,
+		map : textureMapKeys,
+		lightMap : textureMapKeys,
+		specularMap : textureMapKeys,
+		alphaMap : textureMapKeys
+	};
+
+	var folder = gui.addFolder('THREE.MeshStandardMaterial');
+
+	folder.addColor( data, 'color' ).onChange( handleColorChange( material.color ) );
+	folder.addColor( data, 'emissive' ).onChange( handleColorChange( material.emissive ) );
+
+	folder.add( material, 'roughness', 0, 1 );
+	folder.add( material, 'metalness', 0, 1 );
+	folder.add( material, 'shading', constants.shading).onChange( needsUpdate( material, geometry ) );
+	folder.add( material, 'wireframe' );
+	folder.add( material, 'wireframeLinewidth', 0, 10 );
+	folder.add( material, 'vertexColors', constants.colors);
+	folder.add( material, 'fog' );
+	folder.add( data, 'envMaps', envMapKeys ).onChange( updateTexture( material, 'envMap', envMaps ) );
+	folder.add( data, 'map', textureMapKeys ).onChange( updateTexture( material, 'map', textureMaps ) );
+	folder.add( data, 'lightMap', textureMapKeys ).onChange( updateTexture( material, 'lightMap', textureMaps ) );
+	folder.add( data, 'alphaMap', textureMapKeys ).onChange( updateTexture( material, 'alphaMap', textureMaps ) );
+
+	// TODO roughnessMap and metalnessMap
+
+}
+
 function chooseFromHash ( gui, mesh, geometry ) {
 
 	var selectedMaterial = window.location.hash.substring(1) || "MeshBasicMaterial";
@@ -489,6 +522,16 @@ function chooseFromHash ( gui, mesh, geometry ) {
 		return material;
 
 		break;
+
+	case "MeshStandardMaterial" :
+
+			material = new THREE.MeshStandardMaterial({color: 0x2194CE});
+			guiMaterial( gui, mesh, material, geometry );
+			guiMeshStandardMaterial( gui, mesh, material, geometry );
+
+			return material;
+
+			break;
 
 	case "MeshDepthMaterial" :
 


### PR DESCRIPTION
This PR adds the documentation file for `MeshStandardMaterial` and some missing entries for `MeshBasicMaterial`, `MeshLambertMaterial` and `MeshPhongMaterial`. I've also expanded the material browser, so we have an example for `MeshStandardMaterial`.

However, there are still some TODOs. It would be great if one of the core developers can provide the following texts.
- general description of `MeshStandardMaterial`
- description of `aoMapIntensity`, `lightMapIntensity`, `roughness`, `metalness`, `roughnessMap`, `metalnessMap`

![standard](https://cloud.githubusercontent.com/assets/12612165/13033274/dca7234c-d310-11e5-9dcf-7435bd176ce7.jpg)
