### PR TITLE
Added references to base material class in docu

### DIFF
--- a/docs/api/materials/LineBasicMaterial.html
+++ b/docs/api/materials/LineBasicMaterial.html
@@ -31,6 +31,7 @@
 		</div>
 
 		<h2>Properties</h2>
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Integer color]</h3>
 		<div>Sets the color of the line. Default is 0xffffff.</div>
@@ -55,7 +56,7 @@
 		<div>Define whether the material color is affected by global fog settings.</div>
 		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
 
-		
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/materials/LineDashedMaterial.html
+++ b/docs/api/materials/LineDashedMaterial.html
@@ -32,13 +32,12 @@
 
 
 		<h2>Properties</h2>
-
-
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Color color]</h3>
 		<div>
 		Sets the color of the line. Default is 0xffffff.
-		</div> 
+		</div>
 
 		<h3>[property:number linewidth]</h3>
 		<div>Controls line thickness. Default is 1.</div>
@@ -47,17 +46,17 @@
 		<h3>[property:number scale]</h3>
 		<div>
 		The scale of the dashed part of a line.
-		</div> 
+		</div>
 
 		<h3>[property:number dashSize]</h3>
 		<div>
 		The size of the dash. This is both the gap with the stroke. Default is 3.
-		</div> 
+		</div>
 
 		<h3>[property:number gapSize]</h3>
 		<div>
 		The size of the gap. Default is 1.
-		</div> 
+		</div>
 
 		<h3>[property:boolean vertexColors]</h3>
 		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>

--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -46,6 +46,7 @@
 		</div>
 
 		<h2>Properties</h2>
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Integer color]</h3>
 		<div>Sets the color of the geometry. Default is 0xffffff.</div>

--- a/docs/api/materials/MeshDepthMaterial.html
+++ b/docs/api/materials/MeshDepthMaterial.html
@@ -13,7 +13,7 @@
 		<h1>[name]</h1>
 
 		<div class="desc">A material for drawing geometry by depth. Depth is based off of the camera near and far plane. White is nearest, black is farthest.</div>
-		
+
 		<iframe src='scenes/material-browser.html#MeshDepthMaterial'></iframe>
 
 		<h2>Constructor</h2>
@@ -21,7 +21,7 @@
 
 		<h3>[name]([page:Object parameters])</h3>
 		<div>
-		parameters is an object with one or more properties defining the material's appearance. 
+		parameters is an object with one or more properties defining the material's appearance.
 		</div>
 		<div>
 		morphTargets -- Define whether the material uses morphTargets. Default is false.<br/>
@@ -31,20 +31,20 @@
 
 
 		<h2>Properties</h2>
-
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:boolean morphTargets]</h3>
-		<div>Define whether the material uses morphTargets. Default is false.</div> 
+		<div>Define whether the material uses morphTargets. Default is false.</div>
 
 		<h3>[property:boolean wireframe]</h3>
-		<div>Render geometry as wireframe. Default is false (i.e. render as smooth shaded).</div> 
-		
+		<div>Render geometry as wireframe. Default is false (i.e. render as smooth shaded).</div>
+
 		<h3>[property:number wireframeLinewidth]</h3>
 		<div>
 			Controls wireframe thickness. Default is 1.<br/><br/>
 			Due to limitations in the ANGLE layer, on Windows platforms linewidth will always be 1 regardless of the set value.
-		</div> 
-		
+		</div>
+
 		<h2>Methods</h2>
 
 

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -52,7 +52,7 @@
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Material] class for common parameters.</div>
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Color color]</h3>
 		<div>

--- a/docs/api/materials/MeshNormalMaterial.html
+++ b/docs/api/materials/MeshNormalMaterial.html
@@ -32,7 +32,7 @@
 
 
 		<h2>Properties</h2>
-
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:boolean wireframe]</h3>
 		<div>

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -67,7 +67,7 @@
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Material] class for common parameters.</div>
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Color color]</h3>
 		<div>

--- a/docs/api/materials/MeshStandardMaterial.html
+++ b/docs/api/materials/MeshStandardMaterial.html
@@ -67,7 +67,7 @@
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Material] class for common parameters.</div>
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Color color]</h3>
 		<div>

--- a/docs/api/materials/PointsMaterial.html
+++ b/docs/api/materials/PointsMaterial.html
@@ -20,7 +20,7 @@
 		<h3>[name]( [page:Object parameters] )</h3>
 
 		<div>parameters is an object with one or more properties defining the material's appearance.</div>
-		
+
 		<div>
 		color — Particle color in hexadecimal. Default is 0xffffff.<br />
 		map — a [page:Texture texture].If defined, then a point has the data from texture as colors. Default is null.<br />
@@ -31,27 +31,28 @@
 		</div>
 
 		<h2>Properties</h2>
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Number color]</h3>
-		
+
 		<div>Sets the color of the particles. Default is 0xffffff.</div>
-		
+
 		<h3>[property:Texture map]</h3>
-		
+
 		<div>Sets the color of the particles using data from a texture.</div>
-		
+
 		<h3>[property:Number size]</h3>
-		
+
 		<div>Sets the size of the particles. Default is 1.0.</div>
 
 		<h3>[property:Boolean sizeAttenuation]</h3>
-		
+
 		<div>Specify whether particles' size will get smaller with the distance. Default is true.</div>
 
 		<h3>[property:Boolean vertexColors]</h3>
 		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
 		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
-		
+
 		<h3>[property:Boolean fog]</h3>
 		<div>Define whether the material color is affected by global fog settings.</div>
 		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -211,6 +211,7 @@
 		</div>
 
 		<h2>Properties</h2>
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Object uniforms]</h3>
 		<div>

--- a/docs/api/materials/SpriteMaterial.html
+++ b/docs/api/materials/SpriteMaterial.html
@@ -31,13 +31,13 @@
 
 
 		<h2>Properties</h2>
-
+		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Color color]</h3>
-		<div>The texture is multiplied by this color. The default is 0xffffff</div> 
+		<div>The texture is multiplied by this color. The default is 0xffffff</div>
 
 		<h3>[property:Texture map]</h3>
-		<div>The texture map. Default is null.</div> 
+		<div>The texture map. Default is null.</div>
 
 		<h3>[property:Radians rotation]</h3>
 		<div>The rotation of the sprite in radians. Default is 0.</div>


### PR DESCRIPTION
This PR completes the references from certain material documentation files to the base material class. That makes it easier for users to see the relationship between `Material` and e.g. `MeshBasicMaterial`...
