### PR TITLE
MeshStandardMaterial: Support indirect specular occlusion

### DIFF
--- a/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl
@@ -1,5 +1,15 @@
 #ifdef USE_AOMAP
 
-	reflectedLight.indirectDiffuse *= ( texture2D( aoMap, vUv2 ).r - 1.0 ) * aoMapIntensity + 1.0;
+	float ambientOcclusion = ( texture2D( aoMap, vUv2 ).r - 1.0 ) * aoMapIntensity + 1.0;
+
+	reflectedLight.indirectDiffuse *= ambientOcclusion;
+
+	#if defined( USE_ENVMAP ) && defined( STANDARD )
+
+		float dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );
+
+		reflectedLight.indirectSpecular *= computeSpecularOcclusion( dotNV, ambientOcclusion, material.specularRoughness );
+
+	#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/lights_standard_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_standard_pars_fragment.glsl
@@ -35,3 +35,10 @@ void RE_IndirectSpecular_Standard( const in vec3 radiance, const in GeometricCon
 #define RE_IndirectSpecular		RE_IndirectSpecular_Standard
 
 #define Material_BlinnShininessExponent( material )   GGXRoughnessToBlinnExponent( material.specularRoughness )
+
+// ref: http://www.frostbite.com/wp-content/uploads/2014/11/course_notes_moving_frostbite_to_pbr_v2.pdf
+float computeSpecularOcclusion( const in float dotNV, const in float ambientOcclusion, const in float roughness ) {
+
+	return saturate( pow( dotNV + ambientOcclusion, exp2( - 16.0 * roughness - 1.0 ) ) - 1.0 + ambientOcclusion );
+
+}


### PR DESCRIPTION
For `MeshStandardMaterial`, a specular occlusion term has been added which will occlude _indirect specular_ light from an environment map if an `aoMap` is present.

Fixes #8107
