### PR TITLE
fixed THREE.Box3.containsPoint() bug

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -205,9 +205,9 @@ THREE.Box3.prototype = {
 
 	containsPoint: function ( point ) {
 
-		if ( point.x < this.min.x || point.x > this.max.x ||
-				 point.y < this.min.y || point.y > this.max.y ||
-				 point.z < this.min.z || point.z > this.max.z ) {
+		if ( point.x <= this.min.x || point.x >= this.max.x ||
+			 point.y <= this.min.y || point.y >= this.max.y ||
+			 point.z <= this.min.z || point.z >= this.max.z ) {
 
 			return false;
 


### PR DESCRIPTION
also fixed the ugly indentations

the docs say `THREE.Box3.containsPoint()` “expands the boundaries of this box to include point.”

example code that this pull requests fixes:

``` JavaScript
var box = new THREE.Box3(0, 0, 0);

var point = new THREE.Vector3(1, 1, 1);

box.expandByPoint(point);

console.log(box.containsPoint(point)); //false !?
```
