### PR TITLE
Support OBJ files that wrap long lines using a backslash

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -219,7 +219,9 @@ THREE.OBJLoader.prototype = {
 
 		var smoothing_pattern = /^s\s+([01]|on|off)/;
 
-		//
+		// long lines can be split with a backslash...
+		text = text.replace(/\\(\r\n|\r|\n)/g,'');
+		var lines = text.split( '\n' );        
 
 		var lines = text.split( '\n' );
 


### PR DESCRIPTION
Rhino can wrap long lines with a backslash when exporting OBJ files.
