### PR TITLE
[Proposal] Gamma Input/Output Override Per Material

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -46,6 +46,9 @@ THREE.Material = function () {
 
 	this._needsUpdate = true;
 
+	this.gammaInput = undefined; // default to renderer values
+	this.gammaOutput = undefined;
+
 };
 
 THREE.Material.prototype = {
@@ -270,6 +273,9 @@ THREE.Material.prototype = {
 		this.overdraw = source.overdraw;
 
 		this.visible = source.visible;
+
+		this.gammaInput = source.gammaInput;
+		this.gammaOutput = source.gammaOutput;
 
 		return this;
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -272,6 +272,16 @@ THREE.WebGLProgram = ( function () {
 
 		var prefixVertex, prefixFragment;
 
+		var gammaInput = renderer.gammaInput;
+		var gammaOutput = renderer.gammaOutput;
+
+		if ( typeof material.gammaInput === 'boolean' ) {
+			gammaInput = material.gammaInput;
+		}
+		if ( typeof material.gammaOutput === 'boolean' ) {
+			gammaOutput = material.gammaOutput;
+		}
+
 		if ( material instanceof THREE.RawShaderMaterial ) {
 
 			prefixVertex = '';
@@ -290,8 +300,8 @@ THREE.WebGLProgram = ( function () {
 
 				parameters.supportsVertexTextures ? '#define VERTEX_TEXTURES' : '',
 
-				renderer.gammaInput ? '#define GAMMA_INPUT' : '',
-				renderer.gammaOutput ? '#define GAMMA_OUTPUT' : '',
+				gammaInput ? '#define GAMMA_INPUT' : '',
+				gammaOutput ? '#define GAMMA_OUTPUT' : '',
 				'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 				'#define MAX_BONES ' + parameters.maxBones,
@@ -398,8 +408,8 @@ THREE.WebGLProgram = ( function () {
 
 				parameters.alphaTest ? '#define ALPHATEST ' + parameters.alphaTest : '',
 
-				renderer.gammaInput ? '#define GAMMA_INPUT' : '',
-				renderer.gammaOutput ? '#define GAMMA_OUTPUT' : '',
+				gammaInput ? '#define GAMMA_INPUT' : '',
+				gammaOutput ? '#define GAMMA_OUTPUT' : '',
 				'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 				( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',


### PR DESCRIPTION
I have an app that uses sRGB textures and post-processing, so `gammaInput` and `gammaOutput` are both set to false on the renderer.

However, one of my meshes uses a compressed DDS texture. WebGL doesn't seem to support compressed sRGB textures, so that particular mesh needs to use `gammaInput` instead of relying on the `sRGB` internal format.

This allows materials to individually override the global `gammaInput` / `gammaOutput` by specifying a boolean value (true / false). This way, a mesh with compressed textures can use `gammaInput`, while the rest of your scene can use sRGB.

Thoughts?
