### PR TITLE
Temporal Anti-Aliasing at a cost of 1 render per frame

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -181,6 +181,7 @@ var files = {
 		"webgl_postprocessing_nodes",
 		"webgl_postprocessing_smaa",
 		"webgl_postprocessing_ssao",
+		"webgl_postprocessing_taa",
 		"webgl_raycast_texture",
 		"webgl_read_float_buffer",
 		"webgl_rtt",

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -18,16 +18,16 @@ THREE.ManualMSAARenderPass = function ( scene, camera, params ) {
 
 	if ( THREE.CompositeShader === undefined ) {
 
-		console.error( "THREE.MSAAPass relies on THREE.CompositeShader" );
+		console.error( "THREE.ManualMSAARenderPass relies on THREE.CompositeShader" );
 
 	}
 
 	var compositeShader = THREE.CompositeShader;
-	this.uniforms = THREE.UniformsUtils.clone( compositeShader.uniforms );
+	this.compositeUniforms = THREE.UniformsUtils.clone( compositeShader.uniforms );
 
 	this.materialComposite = new THREE.ShaderMaterial(	{
 
-		uniforms: this.uniforms,
+		uniforms: this.compositeUniforms,
 		vertexShader: compositeShader.vertexShader,
 		fragmentShader: compositeShader.fragmentShader,
 		transparent: true,
@@ -48,6 +48,8 @@ THREE.ManualMSAARenderPass = function ( scene, camera, params ) {
 };
 
 THREE.ManualMSAARenderPass.prototype = {
+
+	constructor: THREE.ManualMSAARenderPass,
 
 	dispose: function() {
 
@@ -88,8 +90,8 @@ THREE.ManualMSAARenderPass.prototype = {
 		var autoClear = renderer.autoClear;
 		renderer.autoClear = false;
 
-		this.uniforms[ "scale" ].value = 1.0 / ( jitterOffsets.length );
-		this.uniforms[ "tForeground" ].value = this.sampleRenderTarget;
+		this.compositeUniforms[ "scale" ].value = 1.0 / ( jitterOffsets.length );
+		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget;
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( var i = 0; i < jitterOffsets.length; i ++ ) {

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -1,6 +1,14 @@
 /**
- * @author bhouston / http://clara.io/ *
- */
+*
+* Manual Multi-Sample Anti-Aliasing Render Pass
+*
+* @author bhouston / http://clara.io/
+*
+* This manual approach to MSAA re-renders the scene ones for each sample with camera jitter and accumulates the results.
+*
+* References: https://en.wikipedia.org/wiki/Multisample_anti-aliasing
+*
+*/
 
 THREE.ManualMSAARenderPass = function ( scene, camera, params ) {
 

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -42,6 +42,8 @@ THREE.ManualMSAARenderPass = function ( scene, camera, params ) {
 		blending: THREE.CustomBlending,
 		blendSrc: THREE.OneFactor,
 		blendDst: THREE.OneFactor,
+		blendSrcAlpha: THREE.OneFactor,
+		blendDstAlpha: THREE.OneFactor,
 		blendEquation: THREE.AddEquation,
 		depthTest: false,
 		depthWrite: false

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -82,7 +82,7 @@ THREE.ManualMSAARenderPass.prototype = {
 	render: function ( renderer, writeBuffer, readBuffer, delta ) {
 
 		var camera = ( this.camera || this.scene.camera );
-		var jitterOffsets = THREE.ManualMSAARenderPass.JitterVectors[ Math.max( 0, Math.min( this.sampleLevel, 4 ) ) ];
+		var jitterOffsets = THREE.ManualMSAARenderPass.JitterVectors[ Math.max( 0, Math.min( this.sampleLevel, 5 ) ) ];
 
 		if( jitterOffsets.length === 1 ) {
 
@@ -152,5 +152,15 @@ THREE.ManualMSAARenderPass.JitterVectors = [
 		[ - 5, - 2 ], [ 2, 5 ], [ 5, 3 ], [ 3, - 5 ],
 		[ - 2, 6 ], [ 0, - 7 ], [ - 4, - 6 ], [ - 6, 4 ],
 		[ - 8, 0 ], [ 7, - 4 ], [ 6, 7 ], [ - 7, - 8 ]
+	],
+	[
+		[ - 4, - 7 ], [ - 7, - 5 ], [ - 3, - 5 ], [ - 5, - 4 ],
+		[ - 1, - 4 ], [ - 2, - 2 ], [ - 6, - 1 ], [ - 4, 0 ],
+		[ - 7, 1 ], [ - 1, 2 ], [ - 6, 3 ], [ - 3, 3 ],
+		[ - 7, 6 ], [ - 3, 6 ], [ - 5, 7 ], [ - 1, 7 ],
+		[ 5, - 7 ], [ 1, - 6 ], [ 6, - 5 ], [ 4, - 4 ],
+		[ 2, - 3 ], [ 7, - 2 ], [ 1, - 1 ], [ 4, - 1 ],
+		[ 2, 1 ], [ 6, 2 ], [ 0, 4 ], [ 4, 4 ],
+		[ 2, 5 ], [ 7, 5 ], [ 5, 6 ], [ 3, 7 ]
 	]
 ];

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -131,6 +131,9 @@ THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuf
 
 	}
 
+	// TODO: Add smooth transition from holdRenderTarget to sampleRenderTarget either while the sampleRenderTarget is being created or once it is done.
+	//   This should be possible with BlendShader I think.
+
 	this.accumulateUniforms[ "scale" ].value = 1.0;
 	this.accumulateUniforms[ "tForeground" ].value = ( this.accumulateIndex < jitterOffsets.length ) ? this.holdRenderTarget : this.sampleRenderTarget;
 	renderer.render( this.scene3, this.camera3, writeBuffer );

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -42,6 +42,8 @@ THREE.TAARenderPass = function ( scene, camera, params ) {
 		blending: THREE.CustomBlending,
 		blendSrc: THREE.OneFactor,
 		blendDst: THREE.OneFactor,
+		blendSrcAlpha: THREE.OneFactor,
+		blendDstAlpha: THREE.OneFactor,
 		blendEquation: THREE.AddEquation,
 		depthTest: false,
 		depthWrite: false

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -91,15 +91,16 @@ THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuf
 			THREE.ManualMSAARenderPass.prototype.render.call( this, renderer, this.holdRenderTarget, readBuffer, delta );
 
 			this.accumulateIndex = 0;
-			return;
 
 	}
+
+	var sampleWeight = 1.0 / ( jitterOffsets.length );
 
 	if( this.accumulateIndex >= 0 && this.accumulateIndex < jitterOffsets.length ) {
 		var autoClear = renderer.autoClear;
 		renderer.autoClear = false;
 
-		this.accumulateUniforms[ "scale" ].value = 1.0 / ( jitterOffsets.length );
+		this.accumulateUniforms[ "scale" ].value = sampleWeight;
 		this.accumulateUniforms[ "tForeground" ].value = writeBuffer;
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -1,0 +1,114 @@
+/**
+ * @author bhouston / http://clara.io/ *
+ */
+
+THREE.TAARenderPass = function ( scene, camera, params ) {
+
+	if ( THREE.ManualMSAARenderPass === undefined ) {
+
+		console.error( "THREE.TAARenderPass relies on THREE.ManualMSAARenderPass" );
+
+	}
+	THREE.ManualMSAARenderPass.call( this, scene, camera, params );
+
+	this.sampleLevel = 1;
+	this.accumulate = false;
+
+	if ( THREE.CompositeShader === undefined ) {
+
+		console.error( "THREE.TAARenderPass relies on THREE.CompositeShader" );
+
+	}
+
+	var accumulateShader = THREE.CompositeShader;
+	this.accumulateUniforms = THREE.UniformsUtils.clone( accumulateShader.uniforms );
+
+	this.materialAccumulate = new THREE.ShaderMaterial(	{
+
+		uniforms: this.accumulateUniforms,
+		vertexShader: accumulateShader.vertexShader,
+		fragmentShader: accumulateShader.fragmentShader,
+		transparent: true,
+		blending: THREE.CustomBlending,
+		blendSrc: THREE.OneFactor,
+		blendDst: THREE.OneMinusSrcAlphaFactor,
+		blendEquation: THREE.AddEquation,
+		depthTest: false,
+		depthWrite: false
+
+	} );
+
+	this.camera3 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene3	= new THREE.Scene();
+	this.quad3 = new THREE.Mesh( new THREE.PlaneGeometry( 2, 2 ), this.materialAccumulate );
+	this.scene3.add( this.quad3 );
+
+};
+
+THREE.TAARenderPass.prototype = Object.create( THREE.ManualMSAARenderPass.prototype );
+THREE.TAARenderPass.prototype.constructor = THREE.TAARenderPass;
+THREE.TAARenderPass.JitterVectors = THREE.ManualMSAARenderPass.JitterVectors;
+
+THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuffer, delta ) {
+
+	if( ! this.accumulate ) {
+
+			THREE.ManualMSAARenderPass.prototype.render.call( this, renderer, writeBuffer, readBuffer, delta );
+
+			this.accumulateIndex = 0;
+			return;
+
+	}
+
+	var jitterOffsets = THREE.TAARenderPass.JitterVectors[ 4 ];
+
+	var camera = ( this.camera || this.scene.camera );
+
+	if ( ! this.sampleRenderTarget ) {
+
+		this.sampleRenderTarget = new THREE.WebGLRenderTarget( readBuffer.width, readBuffer.height, this.params );
+
+	}
+
+
+	if( this.accumulateIndex < jitterOffsets.length ) {
+		var autoClear = renderer.autoClear;
+		renderer.autoClear = false;
+
+		this.accumulateUniforms[ "scale" ].value = 1.0 / ( jitterOffsets.length );
+		this.accumulateUniforms[ "tForeground" ].value = writeBuffer;
+
+		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
+		var numSamplesPerFrame = Math.pow( 2, this.sampleLevel );
+		for ( var i = 0; i < numSamplesPerFrame; i ++ ) {
+
+			var j = this.accumulateIndex;
+			// only jitters perspective cameras.	TODO: add support for jittering orthogonal cameras
+			var jitterOffset = jitterOffsets[j];
+			if ( camera.setViewOffset ) {
+				camera.setViewOffset( readBuffer.width, readBuffer.height,
+					jitterOffset[ 0 ] * 0.0625, jitterOffset[ 1 ] * 0.0625,   // 0.0625 = 1 / 16
+					readBuffer.width, readBuffer.height );
+			}
+
+			renderer.render( this.scene, this.camera, writeBuffer, true );
+
+			this.accumulateUniforms[ "scale" ].value = 1.0 / ( this.accumulateIndex + 1 );
+			renderer.render( this.scene3, this.camera3, this.sampleRenderTarget, ( this.accumulateIndex == 0 ) );
+
+			this.accumulateIndex ++;
+			if( this.accumulateIndex >= jitterOffsets.length ) break;
+		}
+
+		// reset jitter to nothing.	TODO: add support for orthogonal cameras
+		if ( camera.setViewOffset ) camera.setViewOffset( undefined, undefined, undefined, undefined, undefined, undefined );
+
+		renderer.autoClear = true;
+
+	}
+
+	this.accumulateUniforms[ "scale" ].value = 1.0;
+	this.accumulateUniforms[ "tForeground" ].value = this.sampleRenderTarget;
+	renderer.render( this.scene3, this.camera3, writeBuffer );
+
+}

--- a/examples/webgl_postprocessing_msaa.html
+++ b/examples/webgl_postprocessing_msaa.html
@@ -29,7 +29,7 @@
 	<body>
 		<div id="info">
 			<a href="http://threejs.org" target="_blank">three.js</a> - Manual Multi-Sample Anti-Aliasing (MSAA) pass by <a href="https://clara.io" target="_blank">Ben Houston</a><br/><br/>
-			This manual approach to MSAA re-renders the scene with camera jitter and accumulates the results.  It is a slow approach.<br/><br/>
+			This manual approach to MSAA re-renders the scene ones for each sample with camera jitter and accumulates the results.<br/><br/>
 			Texture interpolation, mipmapping and anistropic sampling is disabled to emphasize<br/> the effect MSAA levels have one the resulting render quality.
 		</div>
 

--- a/examples/webgl_postprocessing_msaa.html
+++ b/examples/webgl_postprocessing_msaa.html
@@ -72,7 +72,8 @@
 					'Level 1: 2 Samples': 1,
 					'Level 2: 4 Samples': 2,
 					'Level 3: 8 Samples': 3,
-					'Level 4: 16 Samples': 4
+					'Level 4: 16 Samples': 4,
+					'Level 5: 32 Samples': 5
 				} ).onFinishChange( function() {
 
 					if( msaaRenderPass ) {

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -29,8 +29,7 @@
 	<body>
 		<div id="info">
 			<a href="http://threejs.org" target="_blank">three.js</a> - Temporal Anti-Aliasing (TAA) pass by <a href="https://clara.io" target="_blank">Ben Houston</a><br/><br/>
-			When the rotation stops the scene automatically improves its static visual quality by accumulating jittered renders.<br/>
-			This allows for the static quality of a high quality, but slow MSAA shader at the cost of a single render per frame (if sampleLevel = 0).<br/><br/>
+			When there is no motion in the scene, the TAA render pass accumulates jittered camera samples across frames to create a high quality anti-aliased result.<br/><br/>
 			Texture interpolation, mipmapping and anistropic sampling is disabled to emphasize<br/> the effect MSAA levels have one the resulting render quality.
 		</div>
 

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -28,8 +28,9 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="http://threejs.org" target="_blank">three.js</a> - Manual Multi-Sample Anti-Aliasing (MSAA) pass by <a href="https://clara.io" target="_blank">Ben Houston</a><br/><br/>
-			This manual approach to MSAA re-renders the scene with camera jitter and accumulates the results.  It is a slow approach.<br/><br/>
+			<a href="http://threejs.org" target="_blank">three.js</a> - Temporal Anti-Aliasing (TAA) pass by <a href="https://clara.io" target="_blank">Ben Houston</a><br/><br/>
+			When the rotation stops the scene automatically improves its static visual quality by accumulating jittered renders.<br/>
+			This allows for the static quality of a high quality, but slow MSAA shader at the cost of a single render per frame (if sampleLevel = 0).<br/><br/>
 			Texture interpolation, mipmapping and anistropic sampling is disabled to emphasize<br/> the effect MSAA levels have one the resulting render quality.
 		</div>
 
@@ -40,6 +41,7 @@
 		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script src="js/postprocessing/ManualMSAARenderPass.js"></script>
+		<script src="js/postprocessing/TAARenderPass.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/CompositeShader.js"></script>
 
@@ -51,10 +53,10 @@
 
 		<script>
 
-			var camera, scene, renderer, composer, copyPass, msaaRenderPass;
+			var camera, scene, renderer, composer, copyPass, taaRenderPass, renderPass;
 			var gui, stats, texture;
 
-			var param = { MSAASampleLevel: 2 };
+			var param = { TAAEnabled: "1", TAASampleLevel: 0 };
 
 			init();
 			animate();
@@ -67,7 +69,21 @@
 
 				gui = new dat.GUI();
 
-				var example = gui.add( param, 'MSAASampleLevel', {
+				gui.add( param, 'TAAEnabled', {
+					'Disabled': '0',
+					'Enabled': '1'
+				} ).onFinishChange( function() {
+
+					if( taaRenderPass ) {
+
+						taaRenderPass.enabled = ( param.TAAEnabled === "1" );
+						renderPass.enabled = ( param.TAAEnabled !== "1" );
+
+					}
+
+				} );
+
+				gui.add( param, 'TAASampleLevel', {
 					'Level 0: 1 Sample': 0,
 					'Level 1: 2 Samples': 1,
 					'Level 2: 4 Samples': 2,
@@ -75,8 +91,8 @@
 					'Level 4: 16 Samples': 4
 				} ).onFinishChange( function() {
 
-					if( msaaRenderPass ) {
-						msaaRenderPass.sampleLevel = param.MSAASampleLevel;
+					if( taaRenderPass ) {
+						taaRenderPass.sampleLevel = param.TAASampleLevel;
 					}
 
 				} );
@@ -129,9 +145,12 @@
 
 				composer = new THREE.EffectComposer( renderer );
 
-				msaaRenderPass = new THREE.ManualMSAARenderPass( scene, camera );
-				msaaRenderPass.sampleLevel = param.MSAASampleLevel;
-				composer.addPass( msaaRenderPass );
+				taaRenderPass = new THREE.TAARenderPass( scene, camera );
+				composer.addPass( taaRenderPass );
+
+				renderPass = new THREE.RenderPass( scene, camera );
+				renderPass.enabled = false;
+				composer.addPass( renderPass );
 
 				copyPass = new THREE.ShaderPass( THREE.CopyShader );
 		    copyPass.renderToScreen = true;
@@ -155,21 +174,31 @@
 				var newWidth  = Math.floor( width / pixelRatio ) || 1;
 				var newHeight = Math.floor( height / pixelRatio ) || 1;
 				composer.setSize( newWidth, newHeight );
-				msaaRenderPass.setSize( newWidth, newHeight );
+				taaRenderPass.setSize( newWidth, newHeight );
 
 			}
 
 			function animate() {
 
+				this.index = this.index || 0;
+
 				requestAnimationFrame( animate );
 
-				for ( var i = 0; i < scene.children.length; i ++ ) {
+				this.index ++;
 
-					var child = scene.children[ i ];
+				if( Math.round( this.index / 200 ) % 2 === 0 ) {
+					for ( var i = 0; i < scene.children.length; i ++ ) {
 
-					child.rotation.x += 0.005;
-					child.rotation.y += 0.01;
+						var child = scene.children[ i ];
 
+						child.rotation.x += 0.005;
+						child.rotation.y += 0.01;
+
+					}
+					if( taaRenderPass ) taaRenderPass.accumulate = false;
+				}
+				else {
+					if( taaRenderPass ) taaRenderPass.accumulate = true;
 				}
 
 				composer.render();

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -88,7 +88,8 @@
 					'Level 1: 2 Samples': 1,
 					'Level 2: 4 Samples': 2,
 					'Level 3: 8 Samples': 3,
-					'Level 4: 16 Samples': 4
+					'Level 4: 16 Samples': 4,
+					'Level 5: 32 Samples': 5
 				} ).onFinishChange( function() {
 
 					if( taaRenderPass ) {

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -122,7 +122,7 @@
 
 				scene = new THREE.Scene();
 
-				var geometry = new THREE.BoxGeometry( 120, 120, 120, 20, 5, 3 );
+				var geometry = new THREE.BoxGeometry( 120, 120, 120 );
 				var material = new THREE.MeshBasicMaterial( { color: 0xffffff, wireframe: true } );
 
 				var mesh = new THREE.Mesh( geometry, material );

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -29,7 +29,8 @@
 	<body>
 		<div id="info">
 			<a href="http://threejs.org" target="_blank">three.js</a> - Temporal Anti-Aliasing (TAA) pass by <a href="https://clara.io" target="_blank">Ben Houston</a><br/><br/>
-			When there is no motion in the scene, the TAA render pass accumulates jittered camera samples across frames to create a high quality anti-aliased result.<br/><br/>
+			When there is no motion in the scene, the TAA render pass accumulates jittered camera samples<br/>
+			across frames to create a high quality anti-aliased result.<br/><br/>
 			Texture interpolation, mipmapping and anistropic sampling is disabled to emphasize<br/> the effect MSAA levels have one the resulting render quality.
 		</div>
 
@@ -121,7 +122,7 @@
 
 				scene = new THREE.Scene();
 
-				var geometry = new THREE.BoxGeometry( 120, 120, 120 );
+				var geometry = new THREE.BoxGeometry( 120, 120, 120, 20, 5, 3 );
 				var material = new THREE.MeshBasicMaterial( { color: 0xffffff, wireframe: true } );
 
 				var mesh = new THREE.Mesh( geometry, material );


### PR DESCRIPTION
This PR introduces the TAARenderPass, which is derived from the MSAARenderPass.  The TAA render passes operates like the MSAARenderPass unless you set the "accumulate" flag.  Once that flag is set, the TAA render pass will accumulate across frames the camera jittered renders.  If the scene is static it will, after 16 frames, produce a perfectly 16x MSAA anti-aliased result, but without any frame-rate sacrifice.

This TAARenderPass can be further improved once we implement a true deferred pipeline via the use of a motion vector pass, then it could do the accumulation even when the scene is dynamic by using the motion vectors to find out what the previous pixel values were.

I am sure there are more ways we can improve the TAA approach but this at least gives us a basic approach to start with.

Details on the general theory: http://iryoku.com/aacourse/
