### PR TITLE
Return geometry after calling applyMatrix()

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -87,6 +87,8 @@ THREE.Geometry.prototype = {
 		this.verticesNeedUpdate = true;
 		this.normalsNeedUpdate = true;
 
+		return this;
+
 	},
 
 	rotateX: function () {


### PR DESCRIPTION
Return geometry (`this`) after calling `applyMatrix():`
