### PR TITLE
#8170 Example Viewer: Replaced "view-source" protocol with github link

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -276,10 +276,7 @@
 		button.textContent = 'View source';
 		button.addEventListener( 'click', function ( event ) {
 
-			var array = location.href.split( '/' );
-			array.pop();
-
-			window.open( 'view-source:' + array.join( '/' ) + '/' + selected + '.html' );
+			window.open( 'https://github.com/mrdoob/three.js/blob/master/examples/' + selected + '.html' );
 
 		}, false );
 		button.style.display = 'none';


### PR DESCRIPTION
This PR replaces the "view-source" protocol in the example viewer with a https-link to github.

see #8170 for more information
