### PR TITLE
Remove Geometry.__tmpVertices from examples

### DIFF
--- a/examples/js/modifiers/ExplodeModifier.js
+++ b/examples/js/modifiers/ExplodeModifier.js
@@ -38,6 +38,5 @@ THREE.ExplodeModifier.prototype.modify = function ( geometry ) {
 	}
 
 	geometry.vertices = vertices;
-	delete geometry.__tmpVertices;
 
 };

--- a/examples/js/modifiers/SubdivisionModifier.js
+++ b/examples/js/modifiers/SubdivisionModifier.js
@@ -31,8 +31,6 @@ THREE.SubdivisionModifier.prototype.modify = function ( geometry ) {
 
 	}
 
-	delete geometry.__tmpVertices;
-
 	geometry.computeFaceNormals();
 	geometry.computeVertexNormals();
 


### PR DESCRIPTION
`Geometry.__tmpVertices` was removed from `Geometry.js` in https://github.com/mrdoob/three.js/pull/4216.
