### PR TITLE
BoxGeometry: Merge redundant vertices

### DIFF
--- a/src/extras/geometries/BoxGeometry.js
+++ b/src/extras/geometries/BoxGeometry.js
@@ -20,6 +20,7 @@ THREE.BoxGeometry = function ( width, height, depth, widthSegments, heightSegmen
 
 	this.fromBufferGeometry( new THREE.BoxBufferGeometry( width, height, depth, widthSegments, heightSegments, depthSegments ) );
 
+	this.mergeVertices();
 };
 
 THREE.BoxGeometry.prototype = Object.create( THREE.Geometry.prototype );


### PR DESCRIPTION
PR #8195 introduces `BoxBufferGeometry`. This PR ensures, that redundant vertices in `BoxGeometry` are merged (like before PR #8195).
