### PR TITLE
Texture.encoding improvements

### DIFF
--- a/src/renderers/shaders/ShaderChunk/encodings.glsl
+++ b/src/renderers/shaders/ShaderChunk/encodings.glsl
@@ -1,15 +1,5 @@
 // For a discussion of what this is, please read this: http://lousodrome.net/blog/light/2013/05/26/gamma-correct-and-hdr-rendering-in-a-32-bits-buffer/
 
-// These encodings should have the same integer values as THREE.LinearEncoding, THREE.sRGBEncoding, etc...
-#define ENCODING_Linear 3000
-#define ENCODING_sRGB   3001
-#define ENCODING_RGBE   3002
-#define ENCODING_LogLuv 3003
-#define ENCODING_RGBM7  3004
-#define ENCODING_RGBM16 3005
-#define ENCODING_RGBD   3006
-#define ENCODING_Gamma  3007
-
 vec4 LinearToLinear( in vec4 value ) {
   return value;
 }
@@ -55,17 +45,14 @@ vec4 RGBDToLinear( in vec4 value, in float maxRange ) {
 vec4 LinearToRGBD( in vec4 value, in float maxRange ) {
     float maxRGB = max( value.x, max( value.g, value.b ) );
     float D      = max( maxRange / maxRGB, 1.0 );
-    D            = saturate( floor( D ) / 255.0 );
+    D            = min( floor( D ) / 255.0, 1.0 );
     return vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );
 }
 
 // LogLuv reference: http://graphicrants.blogspot.ca/2009/04/rgbm-color-encoding.html
 
 // M matrix, for encoding
-const mat3 cLogLuvM = mat3(
-  0.2209, 0.3390, 0.4184,
-  0.1138, 0.6780, 0.7319,
-  0.0102, 0.1130, 0.2969);
+const mat3 cLogLuvM = mat3( 0.2209, 0.3390, 0.4184, 0.1138, 0.6780, 0.7319, 0.0102, 0.1130, 0.2969 );
 vec4 LinearToLogLuv( in vec4 value )  {
   vec3 Xp_Y_XYZp = value.rgb * cLogLuvM;
   Xp_Y_XYZp = max(Xp_Y_XYZp, vec3(1e-6, 1e-6, 1e-6));
@@ -78,10 +65,7 @@ vec4 LinearToLogLuv( in vec4 value )  {
 }
 
 // Inverse M matrix, for decoding
-const mat3 cLogLuvInverseM = mat3(
-  6.0014, -2.7008, -1.7996,
-  -1.3320,  3.1029, -5.7721,
-  0.3008, -1.0882,  5.6268);
+const mat3 cLogLuvInverseM = mat3( 6.0014, -2.7008, -1.7996, -1.3320, 3.1029, -5.7721, 0.3008, -1.0882, 5.6268 );
 vec4 LogLuvToLinear( in vec4 value ) {
   float Le = value.z * 255.0 + value.w;
   vec3 Xp_Y_XYZp;

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -71,7 +71,6 @@ THREE.ShaderLib = {
 			"#endif",
 
 			'#include <common>',
-			'#include <encodings>',
 			'#include <color_pars_fragment>',
 			'#include <uv_pars_fragment>',
 			'#include <uv2_pars_fragment>',
@@ -200,7 +199,6 @@ THREE.ShaderLib = {
 			"#endif",
 
 			'#include <common>',
-			'#include <encodings>',
 			'#include <color_pars_fragment>',
 			'#include <uv_pars_fragment>',
 			'#include <uv2_pars_fragment>',
@@ -365,7 +363,6 @@ THREE.ShaderLib = {
 			"uniform float opacity;",
 
 			'#include <common>',
-			'#include <encodings>',
 			'#include <color_pars_fragment>',
 			'#include <uv_pars_fragment>',
 			'#include <uv2_pars_fragment>',
@@ -529,7 +526,6 @@ THREE.ShaderLib = {
 			"#endif",
 
 			'#include <common>',
-			'#include <encodings>',
 			'#include <color_pars_fragment>',
 			'#include <uv_pars_fragment>',
 			'#include <uv2_pars_fragment>',
@@ -634,7 +630,6 @@ THREE.ShaderLib = {
 			"uniform float opacity;",
 
 			'#include <common>',
-			'#include <encodings>',
 			'#include <color_pars_fragment>',
 			'#include <map_particle_pars_fragment>',
 			'#include <fog_pars_fragment>',

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -429,7 +429,6 @@ THREE.WebGLProgram = ( function () {
 
 			].filter( filterEmptyLine ).join( '\n' );
 
-
 			prefixFragment = [
 
 				customExtensions,
@@ -451,16 +450,13 @@ THREE.WebGLProgram = ( function () {
 				( parameters.useFog && parameters.fogExp ) ? '#define FOG_EXP2' : '',
 
 				parameters.map ? '#define USE_MAP' : '',
-				parameters.mapEncoding ? getTexelDecodingFunction( "mapTexelToLinear", material.map.encoding ) : '',
 				parameters.envMap ? '#define USE_ENVMAP' : '',
 				parameters.envMap ? '#define ' + envMapTypeDefine : '',
 				parameters.envMap ? '#define ' + envMapModeDefine : '',
 				parameters.envMap ? '#define ' + envMapBlendingDefine : '',
 				parameters.lightMap ? '#define USE_LIGHTMAP' : '',
-				parameters.envMapEncoding ? getTexelDecodingFunction( "envMapTexelToLinear", material.envMap.encoding ) : '',
 				parameters.aoMap ? '#define USE_AOMAP' : '',
 				parameters.emissiveMap ? '#define USE_EMISSIVEMAP' : '',
-				parameters.emissiveMapEncoding ? getTexelDecodingFunction( "emissiveMapTexelToLinear", material.emissiveMap.encoding ) : '',
 				parameters.bumpMap ? '#define USE_BUMPMAP' : '',
 				parameters.normalMap ? '#define USE_NORMALMAP' : '',
 				parameters.specularMap ? '#define USE_SPECULARMAP' : '',
@@ -485,6 +481,12 @@ THREE.WebGLProgram = ( function () {
 
 				'uniform mat4 viewMatrix;',
 				'uniform vec3 cameraPosition;',
+
+				( parameters.mapEncoding || parameters.envMapEncoding || parameters.emissiveMapEncoding ) ? THREE.ShaderChunk['encodings'] : "",
+
+				parameters.mapEncoding ? getTexelDecodingFunction( "mapTexelToLinear", parameters.mapEncoding ) : '',
+				parameters.envMapEncoding ? getTexelDecodingFunction( "envMapTexelToLinear", parameters.envMapEncoding ) : '',
+				parameters.emissiveMapEncoding ? getTexelDecodingFunction( "emissiveMapTexelToLinear", parameters.emissiveMapEncoding ) : '',
 
 				'\n'
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -88,6 +88,27 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 
 		}
 
+		var getTextureEncodingFromMap = function( map ) {
+			if( ! map ) { // no texture
+				return false;
+			}
+			var encoding;
+			if( map.encoding !== undefined ) { // standard texture
+				encoding = map.encoding;
+			}
+			else if( map.texture !== undefined ) {  // render target pretending to be a texture, get the texture inside it.
+				encoding = map.texture.encoding;
+			}
+			else {
+				throw new Error( "can not determine texture encoding from map: " + map );
+			}
+			// add backwards compatibility for WebGLRenderer.gammaInput parameter, should probably be removed at some point. 
+			if( encoding === THREE.LinearEncoding && renderer.gammaInput ) {
+				encoding = THREE.GammaEncoding;
+			}
+			return encoding;
+		}
+
 		var parameters = {
 
 			shaderID: shaderID,
@@ -96,14 +117,14 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 			supportsVertexTextures: capabilities.vertexTextures,
 
 			map: !! material.map,
-			mapEncoding: ( !! material.map ) ? material.map.encoding : false,
+			mapEncoding: getTextureEncodingFromMap( material.map ),
 			envMap: !! material.envMap,
 			envMapMode: material.envMap && material.envMap.mapping,
-			envMapEncoding: ( !! material.envMap ) ? material.envMap.encoding : false,
+			envMapEncoding: getTextureEncodingFromMap( material.envMap ),
 			lightMap: !! material.lightMap,
 			aoMap: !! material.aoMap,
 			emissiveMap: !! material.emissiveMap,
-			emissiveMapEncoding: ( !! material.emissiveMap ) ? material.emissiveMap.encoding : false,
+			emissiveMapEncoding: getTextureEncodingFromMap( material.emissiveMap ),
 			bumpMap: !! material.bumpMap,
 			normalMap: !! material.normalMap,
 			displacementMap: !! material.displacementMap,


### PR DESCRIPTION
This PR fixes two issues identified by @mrdoob.

The first is that the cardboard example didn't work.  The reason for this failure was because cardboard was using a WebGLRenderTarget as the Material.map value rather than Texture.  I have addressed this by using a function to access the encoding parameter that will optionally traverse down a WebGLRenderTarget to get the encoding its its encapsulated texture:

https://github.com/mrdoob/three.js/pull/8217/files#diff-5e43a0b5002eb2c419def3baf67d4e67R91

The second issue is that the cloth example looked different.  This was caused by breaking backwards compatilibity with the WebGLRenderer.gammaInput parameter.  I have fixed this by optionally switching to THREE.GammaEncoding for input textures that are in the THREE.LinearEncoding state if WebGLRenderer.gammaInput is true.  Now all examples should look the same:

https://github.com/mrdoob/three.js/pull/8217/files#diff-5e43a0b5002eb2c419def3baf67d4e67R106
