### PR TITLE
experimental alternative to THREE.PRemultipliedAlphaBlending.

### DIFF
--- a/examples/webgl_materials_transparency.html
+++ b/examples/webgl_materials_transparency.html
@@ -108,7 +108,7 @@
 					metalness: 0.9,
 					roughness: 1.0,
 					shading: THREE.SmoothShading,
-					blending: THREE.PremultipliedAlphaBlending,
+					premultipliedAlpha: true,
 					transparent: true
 				} );
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -156,7 +156,6 @@ THREE.AdditiveBlending = 2;
 THREE.SubtractiveBlending = 3;
 THREE.MultiplyBlending = 4;
 THREE.CustomBlending = 5;
-THREE.PremultipliedAlphaBlending = 6;
 
 // custom blending equations
 // (numbers start from 100 not to clash with other

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -39,6 +39,7 @@ THREE.Material = function () {
 	this.polygonOffsetUnits = 0;
 
 	this.alphaTest = 0;
+	this.premultipliedAlpha = false;
 
 	this.overdraw = 0; // Overdrawn pixels (typically between 0 and 1) for fixing antialiasing gaps in CanvasRenderer
 
@@ -194,6 +195,8 @@ THREE.Material.prototype = {
 		if ( this.opacity < 1 ) data.opacity = this.opacity;
 		if ( this.transparent === true ) data.transparent = this.transparent;
 		if ( this.alphaTest > 0 ) data.alphaTest = this.alphaTest;
+		if ( this.premultipliedAlpha === true ) data.premultipliedAlpha = this.premultipliedAlpha;
+
 		if ( this.wireframe === true ) data.wireframe = this.wireframe;
 		if ( this.wireframeLinewidth > 1 ) data.wireframeLinewidth = this.wireframeLinewidth;
 
@@ -266,7 +269,8 @@ THREE.Material.prototype = {
 		this.polygonOffsetUnits = source.polygonOffsetUnits;
 
 		this.alphaTest = source.alphaTest;
-
+		this.premultipliedAlpha = source.premultipliedAlpha;
+		
 		this.overdraw = source.overdraw;
 
 		this.visible = source.visible;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1570,7 +1570,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( material.transparent === true ) {
 
-			state.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha );
+			state.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha, material.premultipliedAlpha );
 
 		} else {
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -177,7 +177,7 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 
 			toneMapping: renderer.toneMapping,
 
-			premultipliedAlpha: ( material.blending === THREE.PremultipliedAlphaBlending ),
+			premultipliedAlpha: material.premultipliedAlpha,
 			alphaTest: material.alphaTest,
 			doubleSided: material.side === THREE.DoubleSide,
 			flipSided: material.side === THREE.BackSide

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -16,6 +16,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 	var compressedTextureFormats = null;
 
+	var currentPremultipledAlpha = false;
 	var currentBlending = null;
 	var currentBlendEquation = null;
 	var currentBlendSrc = null;
@@ -197,7 +198,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 	};
 
-	this.setBlending = function ( blending, blendEquation, blendSrc, blendDst, blendEquationAlpha, blendSrcAlpha, blendDstAlpha ) {
+	this.setBlending = function ( blending, blendEquation, blendSrc, blendDst, blendEquationAlpha, blendSrcAlpha, blendDstAlpha, premultipliedAlpha ) {
 
 		if ( blending === THREE.NoBlending ) {
 
@@ -209,9 +210,11 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 		}
 
-		if ( blending !== currentBlending ) {
+		if ( blending !== currentBlending || premultipliedAlpha !== currentPremultipledAlpha ) {
 
 			if ( blending === THREE.AdditiveBlending ) {
+
+				// TODO: Figure out how to handle premultipliedAlpha.
 
 				gl.blendEquation( gl.FUNC_ADD );
 				gl.blendFunc( gl.SRC_ALPHA, gl.ONE );
@@ -219,6 +222,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 			} else if ( blending === THREE.SubtractiveBlending ) {
 
 				// TODO: Find blendFuncSeparate() combination
+				// TODO: Figure out how to handle premultipliedAlpha.
 
 				gl.blendEquation( gl.FUNC_ADD );
 				gl.blendFunc( gl.ZERO, gl.ONE_MINUS_SRC_COLOR );
@@ -226,23 +230,30 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 			} else if ( blending === THREE.MultiplyBlending ) {
 
 				// TODO: Find blendFuncSeparate() combination
+				// TODO: Figure out how to handle premultipliedAlpha.
 
 				gl.blendEquation( gl.FUNC_ADD );
 				gl.blendFunc( gl.ZERO, gl.SRC_COLOR );
 
-			} else if( blending === THREE.PremultipliedAlphaBlending ) {
+			}	else {
 
-				gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
-				gl.blendFuncSeparate( gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA );
+				if( premultipliedAlpha ) {
 
-			} else {
+					gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+					gl.blendFuncSeparate( gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA );
 
-				gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
-				gl.blendFuncSeparate( gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA );
+				}
+				else {
+
+					gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+					gl.blendFuncSeparate( gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA );
+
+				}
 
 			}
 
 			currentBlending = blending;
+			currentPremultipledAlpha = premultipliedAlpha;
 
 		}
 


### PR DESCRIPTION
In response to @mrdoob's comment here: https://github.com/mrdoob/three.js/pull/8245#issuecomment-190675013

I've created an experimental PR that uses material.premultipliedAlpha to control alpha blending in a way that is compatible with the most common pre-existing Blend mode, NormalBlending.

This would allow for @mrdoob to change the default of material.premultipliedAlpha to be true for all materials and most things should not break in any way.

I am a bit worried that we may not be able to match all existing blend modes with premultipliedalpha as sometimes alpha means different things depending on how it is used and premultipliedAlpha may not make sense in some additive, subtractive or multiplicative cases.

Feedback welcome.  I do not mind if we go in this direction or not.
