### PR TITLE
Recent examples cleanup

### DIFF
--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>threejs webgl - materials</title>
+		<title>threejs webgl - materials - hdr environment mapping</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<style>
 			body {
-				color: #fff;
+				color: #000;
 				font-family:Monospace;
 				font-size:13px;
 				text-align:center;
@@ -16,6 +16,7 @@
 				margin: 0px;
 				overflow: hidden;
 			}
+			a { color: #00f }
 
 			#info {
 				position: absolute;
@@ -87,6 +88,7 @@
 				scene = new THREE.Scene();
 
 				renderer = new THREE.WebGLRenderer( { antialias: false } );
+				renderer.setClearColor( new THREE.Color( 0xffffff ) );
 				renderer.toneMapping = THREE.LinearToneMapping;
 
 				standardMaterial = new THREE.MeshStandardMaterial( {

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -65,6 +65,7 @@
 				roughness: 1.0,
 				bumpScale: 0.3,
 				background: false,
+				exposure: 1.0,
 			};
 			var camera, scene, renderer, controls, objects = [];
 			var hdrCubeMap;
@@ -86,27 +87,11 @@
 				scene = new THREE.Scene();
 
 				renderer = new THREE.WebGLRenderer( { antialias: false } );
-
-				var roughnessTexture = THREE.ImageUtils.loadTexture( "../examples/textures/roughness_map.jpg" );
-				roughnessTexture.wrapS = THREE.RepeatWrapping;
-				roughnessTexture.wrapT = THREE.RepeatWrapping;
-				roughnessTexture.repeat.set( 9, 2 );
-
-				var hdrType = THREE.UnsignedByteType;
-
-				/*
-				if ( renderer.extensions.get( 'OES_texture_half_float' ) && renderer.extensions.get( 'OES_texture_half_float_linear' ) ) {
-					hdrType = THREE.HalfFloatType;
-				} else if ( renderer.extensions.get( 'OES_texture_float' ) && renderer.extensions.get( 'OES_texture_float_linear' ) ) {
-					hdrType = THREE.FloatType;
-				}
-				*/
+				renderer.toneMapping = THREE.LinearToneMapping;
 
 				standardMaterial = new THREE.MeshStandardMaterial( {
 					map: null,
-					roughnessMap: roughnessTexture,
 					bumpScale: - 0.05,
-					bumpMap: roughnessTexture,
 					color: 0xffffff,
 					metalness: 0.9,
 					roughness: 1.0,
@@ -137,6 +122,17 @@
 				planeMesh1.receiveShadow = true;
 				scene.add( planeMesh1 );
 
+				var textureLoader = new THREE.TextureLoader();
+				textureLoader.load( "../examples/textures/roughness_map.jpg", function( map ) {
+					map.wrapS = THREE.RepeatWrapping;
+					map.wrapT = THREE.RepeatWrapping;
+					map.anisotropy = 4;
+					map.repeat.set( 9, 2 );
+					standardMaterial.roughnessMap = map;
+					standardMaterial.bumpMap = map;
+					standardMaterial.needsUpdate = true;
+				} );
+
 				var genCubeUrls = function( prefix, postfix ) {
 					return [
 						prefix + 'px' + postfix, prefix + 'nx' + postfix,
@@ -146,7 +142,7 @@
 				};
 
 				var hdrUrls = genCubeUrls( "../examples/textures/cube/pisaHDR/", ".hdr" );
-				new THREE.HDRCubeTextureLoader().load( hdrType, hdrUrls, function ( hdrCubeMap ) {
+				new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, hdrUrls, function ( hdrCubeMap ) {
 
 					var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
 					pmremGenerator.update( renderer );
@@ -158,9 +154,6 @@
 
 					standardMaterial.envMap = hdrCubeRenderTarget;
 					standardMaterial.needsUpdate = true;
-
-					floorMaterial.envMap = hdrCubeRenderTarget;
-					floorMaterial.needsUpdate = true;
 				} );
 
 				var ldrUrls = genCubeUrls( "../examples/textures/cube/pisa/", ".png" );
@@ -238,6 +231,7 @@
 				gui.add( params, 'envMap', [ 'LDR', 'HDR', 'RGBM16' ] );
 				gui.add( params, 'roughness', 0, 1 );
 				gui.add( params, 'bumpScale', - 1, 1 );
+				gui.add( params, 'exposure', 0.1, 2 );
 				gui.open();
 
 			}
@@ -279,6 +273,8 @@
 					}
 
 				}
+
+				renderer.toneMappingExposure = params.exposure;
 
 				var timer = Date.now() * 0.00025;
 

--- a/examples/webgl_materials_transparency.html
+++ b/examples/webgl_materials_transparency.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>threejs webgl - materials</title>
+		<title>threejs webgl - materials - transparency</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<style>
@@ -16,6 +16,7 @@
 				margin: 0px;
 				overflow: hidden;
 			}
+			a { color: #eee }
 
 			#info {
 				position: absolute;
@@ -53,7 +54,7 @@
 
 			var container, stats;
 			var params = {
-				opacity: 0.5,
+				opacity: 0.2,
 				roughness: 1.0,
 				bumpScale: 0.3
 			};
@@ -79,9 +80,9 @@
 				standardMaterial = new THREE.MeshStandardMaterial( {
 					map: null,
 					bumpScale: - 0.05,
-					color: 0xffffff,
+					color: 0x0304ff,
 					metalness: 0.9,
-					roughness: 1.0,
+					roughness: 0.5,
 					shading: THREE.SmoothShading,
 					transparent: true
 				} );
@@ -95,9 +96,9 @@
 				standardMaterialPremultiplied = new THREE.MeshStandardMaterial( {
 					map: null,
 					bumpScale: - 0.05,
-					color: 0xffffff,
+					color: 0x0304ff,
 					metalness: 0.9,
-					roughness: 1.0,
+					roughness: 0.5,
 					shading: THREE.SmoothShading,
 					blending: THREE.PremultipliedAlphaBlending,
 					transparent: true
@@ -108,12 +109,14 @@
 					map.wrapS = THREE.RepeatWrapping;
 					map.wrapT = THREE.RepeatWrapping;
 					map.anisotropy = 4;
-					map.repeat.set( 9, 2 );
+					map.repeat.set( 2, 2 );
+					standardMaterial.map = map;
 					standardMaterial.roughnessMap = map;
-					standardMaterial.bumpMap = map;
+					//standardMaterial.bumpMap = map;
 					standardMaterial.needsUpdate = true;
+					standardMaterialPremultiplied.map = map;
 					standardMaterialPremultiplied.roughnessMap = map;
-					standardMaterialPremultiplied.bumpMap = map;
+					//standardMaterialPremultiplied.bumpMap = map;
 					standardMaterialPremultiplied.needsUpdate = true;
 			} );
 
@@ -139,7 +142,6 @@
 				planeMesh1.receiveShadow = true;
 				scene.add( planeMesh1 );
 
-
 				// Lights
 
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
@@ -148,6 +150,7 @@
 				spotLight.position.set( 50, 100, 50 );
 				spotLight.angle = Math.PI / 7;
 				spotLight.penumbra = 0.8
+				spotLight.intensity = 5;
 				spotLight.castShadow = true;
 				scene.add( spotLight );
 

--- a/examples/webgl_materials_transparency.html
+++ b/examples/webgl_materials_transparency.html
@@ -28,7 +28,7 @@
 	<body>
 
 		<div id="container"></div>
-		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Transparency with Non-Premultipled Alpha (left) versus Premultiplied Alpha (right) with RGBA8 Buffers by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
+		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Transparency with Premultiplied Alpha (right) and without (left)<br /> using RGBA8 Buffers by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
 
 		<script src="../build/three.min.js"></script>
 		<script src="../examples/js/controls/OrbitControls.js"></script>
@@ -88,7 +88,7 @@
 				} );
 				var geometry = new THREE.SphereGeometry( 18, 30, 30 );
 				var torusMesh1 = new THREE.Mesh( geometry, standardMaterial );
-				torusMesh1.position.x = -20.0;
+				torusMesh1.position.x = 20.0;
 				torusMesh1.castShadow = true;
 				scene.add( torusMesh1 );
 				objects.push( torusMesh1 );
@@ -121,7 +121,7 @@
 			} );
 
 				var torusMesh2 = new THREE.Mesh( geometry, standardMaterialPremultiplied );
-				torusMesh2.position.x = 20.0;
+				torusMesh2.position.x = -20.0;
 				torusMesh2.castShadow = true;
 				scene.add( torusMesh2 );
 				objects.push( torusMesh2 );

--- a/examples/webgl_materials_transparency.html
+++ b/examples/webgl_materials_transparency.html
@@ -76,16 +76,9 @@
 
 				renderer = new THREE.WebGLRenderer( { antialias: false } );
 
-				var roughnessTexture = THREE.ImageUtils.loadTexture( "../examples/textures/roughness_map.jpg" );
-				roughnessTexture.wrapS = THREE.RepeatWrapping;
-				roughnessTexture.wrapT = THREE.RepeatWrapping;
-				roughnessTexture.repeat.set( 9, 2 );
-
 				standardMaterial = new THREE.MeshStandardMaterial( {
 					map: null,
-					roughnessMap: roughnessTexture,
 					bumpScale: - 0.05,
-					bumpMap: roughnessTexture,
 					color: 0xffffff,
 					metalness: 0.9,
 					roughness: 1.0,
@@ -101,9 +94,7 @@
 
 				standardMaterialPremultiplied = new THREE.MeshStandardMaterial( {
 					map: null,
-					roughnessMap: roughnessTexture,
 					bumpScale: - 0.05,
-					bumpMap: roughnessTexture,
 					color: 0xffffff,
 					metalness: 0.9,
 					roughness: 1.0,
@@ -111,6 +102,20 @@
 					blending: THREE.PremultipliedAlphaBlending,
 					transparent: true
 				} );
+
+				var textureLoader = new THREE.TextureLoader();
+				textureLoader.load( "../examples/textures/roughness_map.jpg", function( map ) {
+					map.wrapS = THREE.RepeatWrapping;
+					map.wrapT = THREE.RepeatWrapping;
+					map.anisotropy = 4;
+					map.repeat.set( 9, 2 );
+					standardMaterial.roughnessMap = map;
+					standardMaterial.bumpMap = map;
+					standardMaterial.needsUpdate = true;
+					standardMaterialPremultiplied.roughnessMap = map;
+					standardMaterialPremultiplied.bumpMap = map;
+					standardMaterialPremultiplied.needsUpdate = true;
+			} );
 
 				var torusMesh2 = new THREE.Mesh( geometry, standardMaterialPremultiplied );
 				torusMesh2.position.x = 20.0;

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -39,7 +39,7 @@
 		<script src="../examples/js/libs/dat.gui.min.js"></script>
 		<script src="../src/loaders/BinaryTextureLoader.js"></script>
 		<script src="../examples/js/loaders/RGBELoader.js"></script>
-		<script src="../examples/js/loaders/HDRCubeMapLoader.js"></script>
+		<script src="../examples/js/loaders/HDRCubeTextureLoader.js"></script>
 		<script src="../examples/js/Half.js"></script>
 		<script src="../examples/js/Encodings.js"></script>
 		<script src="../examples/js/pmrem/PMREMGenerator.js"></script>
@@ -165,7 +165,7 @@
 					hdrpath + 'pz' + hdrformat, hdrpath + 'nz' + hdrformat
 				];
 
-				var hdrCubeMap = new THREE.HDRCubeMapLoader().load( THREE.UnsignedByteType, hdrurls, function ( hdrCubeMap ) {
+				var hdrCubeMap = new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, hdrurls, function ( hdrCubeMap ) {
 
 					var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
 					pmremGenerator.update( renderer );

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>threejs webgl - materials</title>
+		<title>threejs webgl - inline tone mapping</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<style>
 			body {
-				color: #fff;
+				color: #000;
 				font-family:Monospace;
 				font-size:13px;
 				text-align:center;
@@ -16,6 +16,8 @@
 				margin: 0px;
 				overflow: hidden;
 			}
+
+			a { color: #222 }
 
 			#info {
 				position: absolute;
@@ -95,6 +97,7 @@
 				scene = new THREE.Scene();
 
 				renderer = new THREE.WebGLRenderer( { antialias: false } );
+				renderer.setClearColor( new THREE.Color( 0xffffff ) );
 
 				standardMaterial = new THREE.MeshStandardMaterial( {
 					bumpScale: - 0.05,

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -29,7 +29,7 @@
 	<body>
 
 		<div id="container"></div>
-		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Inline Tone Mapping (within a Material's fragment shader) without using a pre-processing step or float/half buffers by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
+		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Inline Tone Mapping (within a Material's fragment shader) without<br/>using a pre-processing step or float/half buffers by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
 
 		<script src="../build/three.min.js"></script>
 		<script src="../examples/js/controls/OrbitControls.js"></script>
@@ -66,8 +66,8 @@
 				roughness: 1.0,
 				bumpScale: 1.0,
 				exposure: 3.0,
-				whitePoint: 1.0,
-				toneMapping: "Cineon",
+				whitePoint: 5.0,
+				toneMapping: "Uncharted2",
 				renderMode: "Renderer"
 			};
 


### PR DESCRIPTION
I cleaned up the recent tonemapping, transparency and envmap_hdr examples to look better and have better defaults, and more meaningful options.  I also fixed one bug introduced by some of my recent PRs being slightly incompatible with each other.

The examples now look like this now:

![image](https://cloud.githubusercontent.com/assets/588541/13429790/d994d7e0-df8f-11e5-82e6-5173a3ab44ec.png)

![image](https://cloud.githubusercontent.com/assets/588541/13429840/26897286-df90-11e5-9bb4-9c450b085d69.png)

![image](https://cloud.githubusercontent.com/assets/588541/13429879/5f323e38-df90-11e5-8eb6-7e2ee46615f8.png)
