### PR TITLE
Fix proposal for issue #8244

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -543,7 +543,7 @@ THREE.PropertyBinding.parseTrackName = function( trackName ) {
 	//	  .bone[Armature.DEF_cog].position
 	// created and tested via https://regex101.com/#javascript
 
-	var re = /^(([\w]+\/)*)([\w-\d]+)?(\.([\w]+)(\[([\w\d\[\]\_. ]+)\])?)?(\.([\w.]+)(\[([\w\d\[\]\_. ]+)\])?)$/;
+	var re = /^(([\w]+\/)*)([\w-\d]+)?(\.([\w]+)(\[([\w\d\[\]\_.:\- ]+)\])?)?(\.([\w.]+)(\[([\w\d\[\]\_. ]+)\])?)$/;
 	var matches = re.exec(trackName);
 
 	if( ! matches ) {


### PR DESCRIPTION
Make the parseTrackName() regular expression more lenient to accommodate bone names that contain '-' and ':' characters. 

Original PR:
https://github.com/mrdoob/three.js/pull/8247

Fix for issue:
https://github.com/mrdoob/three.js/issues/8244
