### PR TITLE
Fix for geometry text pnltri and earcut examples

### DIFF
--- a/examples/webgl_geometry_text_earcut.html
+++ b/examples/webgl_geometry_text_earcut.html
@@ -54,7 +54,7 @@
 			    }
 			}
 
-			THREE.Shape.Utils.triangulateShape = function ( contour, holes ) {
+			THREE.ShapeUtils.triangulateShape = function ( contour, holes ) {
 			    var vertices = [];
 
 			    addContour( vertices, contour );

--- a/examples/webgl_geometry_text_pnltri.html
+++ b/examples/webgl_geometry_text_pnltri.html
@@ -47,7 +47,7 @@
 		<!-- replace built-in triangulation with PnlTri.js -->
 		<script src="js/libs/pnltri.min.js"></script>
 		<script>
-			THREE.Shape.Utils.triangulateShape = ( function () {
+			THREE.ShapeUtils.triangulateShape = ( function () {
 				var pnlTriangulator = new PNLTRI.Triangulator();
 				return function triangulateShape( contour, holes ) {
 					// console.log("new Triangulation: PnlTri.js " + PNLTRI.REVISION );


### PR DESCRIPTION
THREE.ShapeUtils.triangulateShape instead of THREE.Shape.Utils.triangulateShape
