### PR TITLE
Support per-map per-Material UV channels, UV offset/repeat and texel scale/offset

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -127,6 +127,7 @@ var files = {
 		"webgl_materials_parallaxmap",
 		"webgl_materials_shaders_fresnel",
 		"webgl_materials_skin",
+		"webgl_materials_slots",
 		"webgl_materials_standard",
 		"webgl_materials_texture_anisotropy",
 		"webgl_materials_texture_compressed",

--- a/examples/webgl_materials_slots.html
+++ b/examples/webgl_materials_slots.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>threejs webgl - inline tone mapping</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #000;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+
+				background-color: #000;
+
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			a { color: #222 }
+
+			#info {
+				position: absolute;
+				top: 0px; width: 100%;
+				padding: 5px;
+			}
+		</style>
+	</head>
+	<body>
+
+		<div id="container"></div>
+		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Per-Map Per-Material UV Repeat/Offset, Texel Scale/Offset via<br/>THREE.TextureSlot by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
+
+		<script src="../build/three.min.js"></script>
+		<script src="../examples/js/controls/OrbitControls.js"></script>
+		<script src="../src/loaders/BinaryTextureLoader.js"></script>
+
+		<script src="../examples/js/Detector.js"></script>
+		<script src="../examples/js/libs/stats.min.js"></script>
+
+		<script src="../examples/js/libs/dat.gui.min.js"></script>
+		<script src="../src/loaders/BinaryTextureLoader.js"></script>
+		<script src="../examples/js/loaders/RGBELoader.js"></script>
+		<script src="../examples/js/loaders/HDRCubeTextureLoader.js"></script>
+		<script src="../examples/js/Half.js"></script>
+		<script src="../examples/js/Encodings.js"></script>
+		<script src="../examples/js/pmrem/PMREMGenerator.js"></script>
+		<script src="../examples/js/pmrem/PMREMCubeUVPacker.js"></script>
+
+		<script src="../examples/js/postprocessing/EffectComposer.js"></script>
+		<script src="../examples/js/postprocessing/RenderPass.js"></script>
+		<script src="../examples/js/postprocessing/MaskPass.js"></script>
+		<script src="../examples/js/postprocessing/ShaderPass.js"></script>
+		<script src="../examples/js/shaders/CopyShader.js"></script>
+		<script src="../examples/js/shaders/FXAAShader.js"></script>
+		<script src="../examples/js/postprocessing/BloomPass.js"></script>
+		<script src="../examples/js/shaders/ConvolutionShader.js"></script>
+
+		<script>
+
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var container, stats;
+			var params;
+			var camera, scene, renderer, controls, objects = [];
+			var composer;
+			var standardMaterial, standardMaterialPremultiplied, floorMaterial;
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 2000 );
+				camera.position.set( 0.0, 40, 40 * 3.5 );
+
+				scene = new THREE.Scene();
+
+				renderer = new THREE.WebGLRenderer( { antialias: false } );
+				renderer.setClearColor( new THREE.Color( 0xffffff ) );
+
+				standardMaterial = new THREE.MeshStandardMaterial( {
+					bumpScale: - 0.05,
+					color: 0xffffff,
+					metalness: 0.9,
+					roughness: 0.8,
+					shading: THREE.SmoothShading,
+					transparent: true,
+					blending: THREE.PremultipliedAlphaBlending
+				} );
+
+				var textureLoader = new THREE.TextureLoader();
+				textureLoader.load( "../examples/textures/brick_diffuse.jpg", function( map ) {
+					map.wrapS = THREE.RepeatWrapping;
+					map.wrapT = THREE.RepeatWrapping;
+					map.anisotropy = 4;
+					standardMaterial.mapSlot.uvRepeat.set( 9, 0.5 );
+					standardMaterial.map = map;
+					standardMaterial.needsUpdate = true;
+				} );
+				textureLoader.load( "../examples/textures/brick_bump.jpg", function( map ) {
+					map.wrapS = THREE.RepeatWrapping;
+					map.wrapT = THREE.RepeatWrapping;
+					map.anisotropy = 4;
+					standardMaterial.bumpMapSlot.uvRepeat.set( 9, 0.5 );
+					standardMaterial.bumpMap = map;
+					standardMaterial.needsUpdate = true;
+				} );
+				textureLoader.load( "../examples/textures/brick_roughness.jpg", function( map ) {
+					map.wrapS = THREE.RepeatWrapping;
+					map.wrapT = THREE.RepeatWrapping;
+					map.anisotropy = 4;
+					standardMaterial.roughnessMapSlot.uvRepeat.set( 9, 0.5 );
+					standardMaterial.roughnessMap = map;
+					standardMaterial.needsUpdate = true;
+				} );
+
+				var geometry = new THREE.TorusKnotGeometry( 18, 8, 150, 20 );;
+				var torusMesh1 = new THREE.Mesh( geometry, standardMaterial );
+				torusMesh1.position.x = 0.0;
+				torusMesh1.castShadow = true;
+				torusMesh1.receiveShadow = true;
+				scene.add( torusMesh1 );
+				objects.push( torusMesh1 );
+
+				floorMaterial = new THREE.MeshStandardMaterial( {
+					map: null,
+					roughnessMap: null,
+					color: 0xffffff,
+					metalness: 0.0,
+					roughness: 0.0,
+					shading: THREE.SmoothShading
+				} );
+
+				var planeGeometry = new THREE.PlaneBufferGeometry( 200, 200 );
+				var planeMesh1 = new THREE.Mesh( planeGeometry, floorMaterial );
+				planeMesh1.position.y = - 50;
+				planeMesh1.rotation.x = - Math.PI * 0.5;
+				planeMesh1.receiveShadow = true;
+				scene.add( planeMesh1 );
+
+				// Materials
+				var hdrpath = "../examples/textures/cube/hdrPisa/";
+				var hdrformat = '.hdr';
+				var hdrurls = [
+					hdrpath + 'px' + hdrformat, hdrpath + 'nx' + hdrformat,
+					hdrpath + 'py' + hdrformat, hdrpath + 'ny' + hdrformat,
+					hdrpath + 'pz' + hdrformat, hdrpath + 'nz' + hdrformat
+				];
+
+				var hdrCubeMap = new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, hdrurls, function ( hdrCubeMap ) {
+
+					var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
+					pmremGenerator.update( renderer );
+
+					var pmremCubeUVPacker = new THREE.PMREMCubeUVPacker( pmremGenerator.cubeLods );
+					pmremCubeUVPacker.update( renderer );
+
+					standardMaterial.envMap = pmremCubeUVPacker.CubeUVRenderTarget;
+					standardMaterial.needsUpdate = true;
+
+				} );
+
+				// Lights
+
+				scene.add( new THREE.AmbientLight( 0x222222 ) );
+
+				var spotLight = new THREE.SpotLight( 0xffffff );
+				spotLight.position.set( 50, 100, 50 );
+				spotLight.angle = Math.PI / 7;
+				spotLight.penumbra = 0.8
+				spotLight.castShadow = true;
+				scene.add( spotLight );
+
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.shadowMap.enabled = true;
+				container.appendChild( renderer.domElement );
+
+				renderer.gammaInput = true;
+				renderer.gammaOutput = true;
+
+				composer = new THREE.EffectComposer( renderer );
+				composer.setSize( window.innerWidth, window.innerHeight );
+
+				var renderScene = new THREE.RenderPass( scene, camera );
+				composer.addPass( renderScene );
+
+				var copyPass = new THREE.ShaderPass( THREE.CopyShader );
+				copyPass.renderToScreen = true;
+				composer.addPass( copyPass );
+
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '0px';
+
+				container.appendChild( stats.domElement );
+
+				controls = new THREE.OrbitControls( camera, renderer.domElement );
+				controls.target.set( 0, 0, 0 );
+				controls.update();
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+				var gui = new dat.GUI();
+
+				params = {};
+
+				var slotParams = function( slotName ) {
+					params[ slotName + 'TexelInvert'] = false;
+					gui.add( params, slotName + 'TexelInvert' );
+					if( slotName === "bumpMap" ) {
+						params[ slotName + 'TexelOffset'] = 0;
+						params[ slotName + 'TexelScale'] = 0.05;
+						gui.add( params, slotName + 'TexelScale', -0.1, 0.1 );
+					}
+					else {
+						params[ slotName + 'TexelOffset'] = 0;
+						gui.add( params, slotName + 'TexelOffset', -1, 1 );
+						params[ slotName + 'TexelScale'] = 1;
+						gui.add( params, slotName + 'TexelScale', -1, 1 );
+					}
+					params[ slotName + 'UVOffsetX'] = 0;
+					gui.add( params, slotName + 'UVOffsetX', 0, 1 );
+					params[ slotName + 'UVOffsetY'] = 0;
+					gui.add( params, slotName + 'UVOffsetY', 0, 1 );
+					params[ slotName + 'UVRepeatX'] = 4;
+					gui.add( params, slotName + 'UVRepeatX', -5, 5 );
+					params[ slotName + 'UVRepeatY'] = 1;
+					gui.add( params, slotName + 'UVRepeatY', -5, 5 );
+				};
+				slotParams( "map" );
+				slotParams( "bumpMap" );
+				slotParams( "roughnessMap" );
+				gui.open();
+
+			}
+
+			function onWindowResize() {
+
+				var width = window.innerWidth;
+				var height = window.innerHeight;
+
+				camera.aspect = width / height;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( width, height );
+				composer.setSize( width, height );
+
+			}
+
+			//
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
+				if ( standardMaterial !== undefined ) {
+
+					var setSlot = function( slot ) {
+						slot.texelTransform = true;
+						slot.texelScale = params[ slot.name + 'TexelScale'];
+						slot.texelOffset = params[ slot.name + 'TexelOffset'];
+						slot.texelInvert = params[ slot.name + 'TexelInvert'];
+						slot.uvTransform = true;
+						slot.uvRepeat.x = params[ slot.name + 'UVRepeatX'];
+						slot.uvRepeat.y = params[ slot.name + 'UVRepeatY'];
+						slot.uvOffset.x = params[ slot.name + 'UVOffsetX'];
+						slot.uvOffset.y = params[ slot.name + 'UVOffsetY'];
+					}
+					setSlot( standardMaterial.mapSlot );
+					setSlot( standardMaterial.bumpMapSlot );
+					setSlot( standardMaterial.roughnessMapSlot );
+				}
+
+				var timer = Date.now() * 0.00025;
+
+				camera.lookAt( scene.position );
+
+				for ( var i = 0, l = objects.length; i < l; i ++ ) {
+
+					var object = objects[ i ];
+					object.rotation.y += 0.005;
+
+				}
+
+				if( params.renderMode === "Composer" ) {
+					composer.render();
+				}
+				else {
+					renderer.render( scene, camera );
+				}
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/examples/webgl_materials_slots.html
+++ b/examples/webgl_materials_slots.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>threejs webgl - inline tone mapping</title>
+		<title>threejs webgl - per-mat per-material uv offset/repeat and texel scale/offset/invert</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<style>

--- a/examples/webgl_materials_slots.html
+++ b/examples/webgl_materials_slots.html
@@ -29,7 +29,7 @@
 	<body>
 
 		<div id="container"></div>
-		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Per-Map Per-Material UV Channel, UV Repeat/Offset, and Texel Scale/Offset/Invert<br/>via THREE.TextureSlot by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
+		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Per-Map Per-Material UV Channel, UV Repeat/Offset, and Texel Scale/Offset/Invert<br/>via THREE.Map by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
 
 		<script src="../build/three.min.js"></script>
 		<script src="../examples/js/controls/OrbitControls.js"></script>
@@ -203,37 +203,37 @@
 
 				params = {};
 
-				var slotParams = function( slotName ) {
-					params[ slotName + 'TexelInvert'] = ( slotName === 'rough' );
-					gui.add( params, slotName + 'TexelInvert' );
-					if( slotName === "bump" ) {
-						params[ slotName + 'TexelOffset'] = 0;
-						params[ slotName + 'TexelScale'] = 0.05;
-						gui.add( params, slotName + 'TexelScale', -0.1, 0.1 );
+				var mapParams = function( mapName ) {
+					params[ mapName + 'TexelInvert'] = ( mapName === 'rough' );
+					gui.add( params, mapName + 'TexelInvert' );
+					if( mapName === "bump" ) {
+						params[ mapName + 'TexelOffset'] = 0;
+						params[ mapName + 'TexelScale'] = 0.05;
+						gui.add( params, mapName + 'TexelScale', -0.1, 0.1 );
 					}
 					else {
-						params[ slotName + 'TexelOffset'] = ( slotName === 'rough' ) ? 0.4 : 0;
-						if( slotName === 'rough' ) params[ slotName + 'TexelScale'] = 0.6;
-						else if( slotName === 'emissive' ) params[ slotName + 'TexelScale'] = 0.3;
-						else params[ slotName + 'TexelScale'] = 1.0;
-						if( slotName !== "normal" ) {
-							gui.add( params, slotName + 'TexelOffset', -1, 1 );
-							gui.add( params, slotName + 'TexelScale', -1, 1 );
+						params[ mapName + 'TexelOffset'] = ( mapName === 'rough' ) ? 0.4 : 0;
+						if( mapName === 'rough' ) params[ mapName + 'TexelScale'] = 0.6;
+						else if( mapName === 'emissive' ) params[ mapName + 'TexelScale'] = 0.3;
+						else params[ mapName + 'TexelScale'] = 1.0;
+						if( mapName !== "normal" ) {
+							gui.add( params, mapName + 'TexelOffset', -1, 1 );
+							gui.add( params, mapName + 'TexelScale', -1, 1 );
 						}
 					}
-					params[ slotName + 'UVOffsetX'] = 0;
-					gui.add( params, slotName + 'UVOffsetX', 0, 1 );
-					params[ slotName + 'UVOffsetY'] = 0;
-					gui.add( params, slotName + 'UVOffsetY', 0, 1 );
-					params[ slotName + 'UVRepeatX'] = 1;
-					gui.add( params, slotName + 'UVRepeatX', 0.01, 5 );
-					params[ slotName + 'UVRepeatY'] = 1;
-					gui.add( params, slotName + 'UVRepeatY', 0.01, 5 );
+					params[ mapName + 'UVOffsetX'] = 0;
+					gui.add( params, mapName + 'UVOffsetX', 0, 1 );
+					params[ mapName + 'UVOffsetY'] = 0;
+					gui.add( params, mapName + 'UVOffsetY', 0, 1 );
+					params[ mapName + 'UVRepeatX'] = 1;
+					gui.add( params, mapName + 'UVRepeatX', 0.01, 5 );
+					params[ mapName + 'UVRepeatY'] = 1;
+					gui.add( params, mapName + 'UVRepeatY', 0.01, 5 );
 				};
-				slotParams( "map" );
-				slotParams( "normal" );
-				slotParams( "rough" );
-				slotParams( "emissive" );
+				mapParams( "map" );
+				mapParams( "normal" );
+				mapParams( "rough" );
+				mapParams( "emissive" );
 				gui.open();
 
 			}
@@ -266,16 +266,16 @@
 
 				if ( standardMaterial !== undefined ) {
 
-					var setSlot = function( slot, name ) {
-						slot.texelTransform = true;
-						slot.texelScale = params[ name + 'TexelScale'];
-						slot.texelOffset = params[ name + 'TexelOffset'];
-						slot.texelInvert = params[ name + 'TexelInvert'];
-						slot.uvTransform = true;
-						slot.uvRepeat.x = params[ name + 'UVRepeatX'];
-						slot.uvRepeat.y = params[ name + 'UVRepeatY'];
-						slot.uvOffset.x = params[ name + 'UVOffsetX'];
-						slot.uvOffset.y = params[ name + 'UVOffsetY'];
+					var setSlot = function( map, name ) {
+						map.texelTransform = true;
+						map.texelScale = params[ name + 'TexelScale'];
+						map.texelOffset = params[ name + 'TexelOffset'];
+						map.texelInvert = params[ name + 'TexelInvert'];
+						map.uvTransform = true;
+						map.uvRepeat.x = params[ name + 'UVRepeatX'];
+						map.uvRepeat.y = params[ name + 'UVRepeatY'];
+						map.uvOffset.x = params[ name + 'UVOffsetX'];
+						map.uvOffset.y = params[ name + 'UVOffsetY'];
 					}
 					setSlot( standardMaterial.mapSlot, "map" );
 					setSlot( standardMaterial.normalMapSlot, "normal" );

--- a/examples/webgl_materials_slots.html
+++ b/examples/webgl_materials_slots.html
@@ -29,7 +29,7 @@
 	<body>
 
 		<div id="container"></div>
-		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Per-Map Per-Material UV Repeat/Offset, Texel Scale/Offset/Invert<br/>via THREE.TextureSlot by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
+		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Per-Map Per-Material UV Channel, UV Repeat/Offset, and Texel Scale/Offset/Invert<br/>via THREE.TextureSlot by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
 
 		<script src="../build/three.min.js"></script>
 		<script src="../examples/js/controls/OrbitControls.js"></script>
@@ -125,7 +125,7 @@
 				} );
 
 
-				var geometry = new THREE.SphereGeometry( 35, 36, 36 );
+				var geometry = new THREE.SphereGeometry( 35, 48, 48 );
 				var torusMesh1 = new THREE.Mesh( geometry, standardMaterial );
 				torusMesh1.position.x = 0.0;
 				torusMesh1.castShadow = true;
@@ -158,7 +158,7 @@
 
 				// Lights
 
-				scene.add( new THREE.AmbientLight( 0x222222 ) );
+				//scene.add( new THREE.AmbientLight( 0x222222 ) );
 
 				var spotLight = new THREE.SpotLight( 0xffffff );
 				spotLight.position.set( 50, 100, 50 );
@@ -173,7 +173,7 @@
 				container.appendChild( renderer.domElement );
 
 				renderer.toneMapping = THREE.ReinhardToneMapping;
-				renderer.toneMappingExposure = 4;
+				renderer.toneMappingExposure = 6;
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 

--- a/examples/webgl_materials_slots.html
+++ b/examples/webgl_materials_slots.html
@@ -29,7 +29,7 @@
 	<body>
 
 		<div id="container"></div>
-		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Per-Map Per-Material UV Repeat/Offset, Texel Scale/Offset via<br/>THREE.TextureSlot by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
+		<div id="info"><a href="http://threejs.org" target="_blank">threejs</a> - Per-Map Per-Material UV Repeat/Offset, Texel Scale/Offset/Invert<br/>via THREE.TextureSlot by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
 
 		<script src="../build/three.min.js"></script>
 		<script src="../examples/js/controls/OrbitControls.js"></script>
@@ -212,7 +212,7 @@
 				var slotParams = function( slotName ) {
 					params[ slotName + 'TexelInvert'] = false;
 					gui.add( params, slotName + 'TexelInvert' );
-					if( slotName === "bumpMap" ) {
+					if( slotName === "bump" ) {
 						params[ slotName + 'TexelOffset'] = 0;
 						params[ slotName + 'TexelScale'] = 0.05;
 						gui.add( params, slotName + 'TexelScale', -0.1, 0.1 );
@@ -233,8 +233,8 @@
 					gui.add( params, slotName + 'UVRepeatY', -5, 5 );
 				};
 				slotParams( "map" );
-				slotParams( "bumpMap" );
-				slotParams( "roughnessMap" );
+				slotParams( "bump" );
+				slotParams( "rough" );
 				gui.open();
 
 			}
@@ -267,20 +267,20 @@
 
 				if ( standardMaterial !== undefined ) {
 
-					var setSlot = function( slot ) {
+					var setSlot = function( slot, name ) {
 						slot.texelTransform = true;
-						slot.texelScale = params[ slot.name + 'TexelScale'];
-						slot.texelOffset = params[ slot.name + 'TexelOffset'];
-						slot.texelInvert = params[ slot.name + 'TexelInvert'];
+						slot.texelScale = params[ name + 'TexelScale'];
+						slot.texelOffset = params[ name + 'TexelOffset'];
+						slot.texelInvert = params[ name + 'TexelInvert'];
 						slot.uvTransform = true;
-						slot.uvRepeat.x = params[ slot.name + 'UVRepeatX'];
-						slot.uvRepeat.y = params[ slot.name + 'UVRepeatY'];
-						slot.uvOffset.x = params[ slot.name + 'UVOffsetX'];
-						slot.uvOffset.y = params[ slot.name + 'UVOffsetY'];
+						slot.uvRepeat.x = params[ name + 'UVRepeatX'];
+						slot.uvRepeat.y = params[ name + 'UVRepeatY'];
+						slot.uvOffset.x = params[ name + 'UVOffsetX'];
+						slot.uvOffset.y = params[ name + 'UVOffsetY'];
 					}
-					setSlot( standardMaterial.mapSlot );
-					setSlot( standardMaterial.bumpMapSlot );
-					setSlot( standardMaterial.roughnessMapSlot );
+					setSlot( standardMaterial.mapSlot, "map" );
+					setSlot( standardMaterial.bumpMapSlot, "bump" );
+					setSlot( standardMaterial.roughnessMapSlot, "rough" );
 				}
 
 				var timer = Date.now() * 0.00025;

--- a/examples/webgl_materials_slots.html
+++ b/examples/webgl_materials_slots.html
@@ -75,7 +75,7 @@
 				document.body.appendChild( container );
 
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 2000 );
-				camera.position.set( 0.0, 40, 40 * 3.5 );
+				camera.position.set( 0.0, 80, 40 * 3.5 );
 
 				scene = new THREE.Scene();
 
@@ -85,62 +85,53 @@
 				standardMaterial = new THREE.MeshStandardMaterial( {
 					bumpScale: - 0.05,
 					color: 0xffffff,
+					emissive: 0xffffff,
 					metalness: 0.9,
 					roughness: 0.8,
+					normalScale: new THREE.Vector2( 1, -1 ),
 					shading: THREE.SmoothShading,
 					transparent: true,
 					blending: THREE.PremultipliedAlphaBlending
 				} );
 
 				var textureLoader = new THREE.TextureLoader();
-				textureLoader.load( "../examples/textures/brick_diffuse.jpg", function( map ) {
+				textureLoader.load( "../examples/textures/planets/earth_atmos_2048.jpg", function( map ) {
 					map.wrapS = THREE.RepeatWrapping;
 					map.wrapT = THREE.RepeatWrapping;
 					map.anisotropy = 4;
-					standardMaterial.mapSlot.uvRepeat.set( 9, 0.5 );
 					standardMaterial.map = map;
 					standardMaterial.needsUpdate = true;
 				} );
-				textureLoader.load( "../examples/textures/brick_bump.jpg", function( map ) {
+				textureLoader.load( "../examples/textures/planets/earth_normal_2048.jpg", function( map ) {
 					map.wrapS = THREE.RepeatWrapping;
 					map.wrapT = THREE.RepeatWrapping;
 					map.anisotropy = 4;
-					standardMaterial.bumpMapSlot.uvRepeat.set( 9, 0.5 );
-					standardMaterial.bumpMap = map;
+					standardMaterial.normalMap = map;
 					standardMaterial.needsUpdate = true;
 				} );
-				textureLoader.load( "../examples/textures/brick_roughness.jpg", function( map ) {
+				textureLoader.load( "../examples/textures/planets/earth_specular_2048.jpg", function( map ) {
 					map.wrapS = THREE.RepeatWrapping;
 					map.wrapT = THREE.RepeatWrapping;
 					map.anisotropy = 4;
-					standardMaterial.roughnessMapSlot.uvRepeat.set( 9, 0.5 );
 					standardMaterial.roughnessMap = map;
 					standardMaterial.needsUpdate = true;
 				} );
+				textureLoader.load( "../examples/textures/planets/earth_lights_2048.png", function( map ) {
+					map.wrapS = THREE.RepeatWrapping;
+					map.wrapT = THREE.RepeatWrapping;
+					map.anisotropy = 4;
+					standardMaterial.emissiveMap = map;
+					standardMaterial.needsUpdate = true;
+				} );
 
-				var geometry = new THREE.TorusKnotGeometry( 18, 8, 150, 20 );;
+
+				var geometry = new THREE.SphereGeometry( 35, 36, 36 );
 				var torusMesh1 = new THREE.Mesh( geometry, standardMaterial );
 				torusMesh1.position.x = 0.0;
 				torusMesh1.castShadow = true;
 				torusMesh1.receiveShadow = true;
 				scene.add( torusMesh1 );
 				objects.push( torusMesh1 );
-
-				floorMaterial = new THREE.MeshStandardMaterial( {
-					map: null,
-					roughnessMap: null,
-					color: 0xffffff,
-					metalness: 0.0,
-					roughness: 0.0,
-					shading: THREE.SmoothShading
-				} );
-
-				var planeGeometry = new THREE.PlaneBufferGeometry( 200, 200 );
-				var planeMesh1 = new THREE.Mesh( planeGeometry, floorMaterial );
-				planeMesh1.position.y = - 50;
-				planeMesh1.rotation.x = - Math.PI * 0.5;
-				planeMesh1.receiveShadow = true;
-				scene.add( planeMesh1 );
 
 				// Materials
 				var hdrpath = "../examples/textures/cube/hdrPisa/";
@@ -160,6 +151,7 @@
 					pmremCubeUVPacker.update( renderer );
 
 					standardMaterial.envMap = pmremCubeUVPacker.CubeUVRenderTarget;
+					standardMaterial.envMapIntensity = 3;
 					standardMaterial.needsUpdate = true;
 
 				} );
@@ -180,6 +172,8 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
+				renderer.toneMapping = THREE.ReinhardToneMapping;
+				renderer.toneMappingExposure = 4;
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 
@@ -210,7 +204,7 @@
 				params = {};
 
 				var slotParams = function( slotName ) {
-					params[ slotName + 'TexelInvert'] = false;
+					params[ slotName + 'TexelInvert'] = ( slotName === 'rough' );
 					gui.add( params, slotName + 'TexelInvert' );
 					if( slotName === "bump" ) {
 						params[ slotName + 'TexelOffset'] = 0;
@@ -218,23 +212,28 @@
 						gui.add( params, slotName + 'TexelScale', -0.1, 0.1 );
 					}
 					else {
-						params[ slotName + 'TexelOffset'] = 0;
-						gui.add( params, slotName + 'TexelOffset', -1, 1 );
-						params[ slotName + 'TexelScale'] = 1;
-						gui.add( params, slotName + 'TexelScale', -1, 1 );
+						params[ slotName + 'TexelOffset'] = ( slotName === 'rough' ) ? 0.4 : 0;
+						if( slotName === 'rough' ) params[ slotName + 'TexelScale'] = 0.6;
+						else if( slotName === 'emissive' ) params[ slotName + 'TexelScale'] = 0.3;
+						else params[ slotName + 'TexelScale'] = 1.0;
+						if( slotName !== "normal" ) {
+							gui.add( params, slotName + 'TexelOffset', -1, 1 );
+							gui.add( params, slotName + 'TexelScale', -1, 1 );
+						}
 					}
 					params[ slotName + 'UVOffsetX'] = 0;
 					gui.add( params, slotName + 'UVOffsetX', 0, 1 );
 					params[ slotName + 'UVOffsetY'] = 0;
 					gui.add( params, slotName + 'UVOffsetY', 0, 1 );
-					params[ slotName + 'UVRepeatX'] = 4;
-					gui.add( params, slotName + 'UVRepeatX', -5, 5 );
+					params[ slotName + 'UVRepeatX'] = 1;
+					gui.add( params, slotName + 'UVRepeatX', 0.01, 5 );
 					params[ slotName + 'UVRepeatY'] = 1;
-					gui.add( params, slotName + 'UVRepeatY', -5, 5 );
+					gui.add( params, slotName + 'UVRepeatY', 0.01, 5 );
 				};
 				slotParams( "map" );
-				slotParams( "bump" );
+				slotParams( "normal" );
 				slotParams( "rough" );
+				slotParams( "emissive" );
 				gui.open();
 
 			}
@@ -279,8 +278,9 @@
 						slot.uvOffset.y = params[ name + 'UVOffsetY'];
 					}
 					setSlot( standardMaterial.mapSlot, "map" );
-					setSlot( standardMaterial.bumpMapSlot, "bump" );
+					setSlot( standardMaterial.normalMapSlot, "normal" );
 					setSlot( standardMaterial.roughnessMapSlot, "rough" );
+					setSlot( standardMaterial.emissiveMapSlot, "emissive" );
 				}
 
 				var timer = Date.now() * 0.00025;

--- a/src/materials/Map.js
+++ b/src/materials/Map.js
@@ -3,7 +3,7 @@
  *
  */
 
-THREE.TextureSlot = function ( name, uvChannel, uvTransform, texelTransform ) {
+THREE.Map = function ( name, uvChannel, uvTransform, texelTransform ) {
 
   this.name = name || "unnamed";
 
@@ -14,7 +14,7 @@ THREE.TextureSlot = function ( name, uvChannel, uvTransform, texelTransform ) {
   this.uvTransform = uvTransform || false;
   this.uvOffset = new THREE.Vector2( 0, 0 );
   this.uvRepeat = new THREE.Vector2( 1.0, 1.0 );
-  //this.uvRotation = 0;
+  //this.uvRotation = 0;  - not implemented because offset/repeat fix in a vec4 uniform, rotation doesn't.
 
   this.texelTransform = uvTransform || false;
   this.texelScale = 1.0;
@@ -23,9 +23,9 @@ THREE.TextureSlot = function ( name, uvChannel, uvTransform, texelTransform ) {
 
 };
 
-THREE.TextureSlot.prototype = {
+THREE.Map.prototype = {
 
-  constructor: THREE.TextureSlot,
+  constructor: THREE.Map,
 
   copy: function ( source ) {
 
@@ -66,6 +66,6 @@ THREE.TextureSlot.prototype = {
 
 };
 
-THREE.TextureSlot.SupportedSlotNames = [
+THREE.Map.SupportedMapNames = [
 	'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap', 'displacementMap'
 ];

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -77,7 +77,7 @@ THREE.MeshStandardMaterial = function ( parameters ) {
 	this.lightMapSlot = new THREE.TextureSlot( "lightMap", 1, false, true );
 
 	//this.aoMap = null;
-	//this.aoMapIntensity = 1.0;
+	this.aoMapIntensity = 1.0;
 	this.aoMapSlot = new THREE.TextureSlot( "aoMap", 1, false, true );
 
 	this.emissive = new THREE.Color( 0x000000 );
@@ -107,8 +107,8 @@ THREE.MeshStandardMaterial = function ( parameters ) {
 	//this.alphaMap = null;
 	this.alphaMapSlot = new THREE.TextureSlot( "alphaMap", 0, false, false );
 
-	this.slots = [ this.mapSlot, this.lightMapSlot, this.aoMapSlot, this.emissiveMapSlot, this.bumpMapSlot,
-		this.normalMapSlot, this.roughnessMapSlot, this.metalnessMapSlot, this.alphaMapSlot ];
+	//this.slots = [ this.mapSlot, this.lightMapSlot, this.aoMapSlot, this.emissiveMapSlot, this.bumpMapSlot,
+	//	this.normalMapSlot, this.roughnessMapSlot, this.metalnessMapSlot, this.alphaMapSlot ];
 
 	this.envMap = null;
 	this.envMapIntensity = 1.0;
@@ -161,6 +161,7 @@ var closure = function () {
 				return this.lightMapSlot.texelScale;
 		  },
 			set: function( value ) {
+				this.lightMapSlot.texelTransform = true;
 				this.lightMapSlot.texelScale = value;
 			}
 		},
@@ -170,14 +171,6 @@ var closure = function () {
 		  },
 			set: function( value ) {
 				this.aoMapSlot.texture = value;
-			}
-		},
-		"aoMapIntensity": {
-		  get: function() {
-				return this.aoMapSlot.texelScale;
-		  },
-			set: function( value ) {
-				this.aoMapSlot.texelScale = value;
 			}
 		},
 		"emissiveMap": {
@@ -201,6 +194,7 @@ var closure = function () {
 				return this.emissiveMapSlot.texelScale;
 		  },
 			set: function( value ) {
+				this.emissiveMapSlot.texelTransform = true;
 				this.emissiveMapSlot.texelScale = value;
 			}
 		},
@@ -225,6 +219,7 @@ var closure = function () {
 				return this.displacementMapSlot.texelScale;
 		  },
 			set: function( value ) {
+				this.displacementMapSlot.texelTransform = true;
 				this.displacementMapSlot.texelScale = value;
 			}
 		},
@@ -233,6 +228,7 @@ var closure = function () {
 				return this.displacementMapSlot.texelOffset;
 		  },
 			set: function( value ) {
+				this.displacementMapSlot.texelTransform = true;
 				this.displacementMapSlot.texelOffset = value;
 			}
 		},
@@ -289,12 +285,6 @@ THREE.MeshStandardMaterial.prototype.copy = function ( source ) {
 	this.emissiveIntensity = source.emissiveIntensity;
 
 	this.normalScale.copy( source.normalScale );
-
-	this.roughnessMap = source.roughnessMap;
-
-	this.metalnessMap = source.metalnessMap;
-
-	this.alphaMap = source.alphaMap;
 
 	this.envMap = source.envMap;
 	this.envMapIntensity = source.envMapIntensity;

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -118,7 +118,7 @@ THREE.MeshStandardMaterial = function ( parameters ) {
 	this.fog = true;
 
 	this.shading = THREE.SmoothShading;
-	this.blending = THREE.PremultipliedAlphaNormalBlending;
+	this.blending = THREE.PremultipliedAlphaBlending;
 
 	this.wireframe = false;
 	this.wireframeLinewidth = 1;

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -66,19 +66,16 @@ THREE.MeshStandardMaterial = function ( parameters ) {
 	this.type = 'MeshStandardMaterial';
 
 	this.color = new THREE.Color( 0xffffff ); // diffuse
-	this.roughness = 0.5;
-	this.metalness = 0.5;
-
 	//this.map = null;
 	this.mapSlot = new THREE.TextureSlot( "map", 0, false, false );
 
-	//this.lightMap = null;
-	//this.lightMapIntensity = 1.0;
-	this.lightMapSlot = new THREE.TextureSlot( "lightMap", 1, false, true );
+	this.roughness = 0.5;
+	//this.roughnessMap = null;
+	this.roughnessMapSlot = new THREE.TextureSlot( "roughnessMap", 0, false, false );
 
-	//this.aoMap = null;
-	this.aoMapIntensity = 1.0;
-	this.aoMapSlot = new THREE.TextureSlot( "aoMap", 1, false, true );
+	this.metalness = 0.5;
+	//this.metalnessMap = null;
+	this.metalnessMapSlot = new THREE.TextureSlot( "metalnessMap", 0, false, false );
 
 	this.emissive = new THREE.Color( 0x000000 );
 	this.emissiveIntensity = 1.0;
@@ -98,17 +95,16 @@ THREE.MeshStandardMaterial = function ( parameters ) {
 	//this.displacementBias = 0;
 	this.displacementMapSlot = new THREE.TextureSlot( "displacementMap", 0, false, true );
 
-	//this.roughnessMap = null;
-	this.roughnessMapSlot = new THREE.TextureSlot( "roughnessMap", 0, false, false );
+	//this.lightMap = null;
+	//this.lightMapIntensity = 1.0;
+	this.lightMapSlot = new THREE.TextureSlot( "lightMap", 1, false, true );
 
-	//this.metalnessMap = null;
-	this.metalnessMapSlot = new THREE.TextureSlot( "metalnessMap", 0, false, false );
+	//this.aoMap = null;
+	this.aoMapIntensity = 1.0;
+	this.aoMapSlot = new THREE.TextureSlot( "aoMap", 1, false, true );
 
 	//this.alphaMap = null;
 	this.alphaMapSlot = new THREE.TextureSlot( "alphaMap", 0, false, false );
-
-	//this.slots = [ this.mapSlot, this.lightMapSlot, this.aoMapSlot, this.emissiveMapSlot, this.bumpMapSlot,
-	//	this.normalMapSlot, this.roughnessMapSlot, this.metalnessMapSlot, this.alphaMapSlot ];
 
 	this.envMap = null;
 	this.envMapIntensity = 1.0;
@@ -267,24 +263,31 @@ THREE.MeshStandardMaterial.prototype.copy = function ( source ) {
 	THREE.Material.prototype.copy.call( this, source );
 
 	this.color.copy( source.color );
-	this.roughness = source.roughness;
-	this.metalness = source.metalness;
-
 	this.mapSlot.copy( source.mapSlot );
-	this.lightMapSlot.copy( source.lightMapSlot );
-	this.aoMapSlot.copy( source.aoMapSlot );
-	this.emissiveMapSlot.copy( source.emissiveMapSlot );
-	this.bumpMapSlot.copy( source.bumpMapSlot );
-	this.normalMapSlot.copy( source.normalMapSlot );
-	this.displacementMapSlot.copy( source.displacementMapSlot );
+
+	this.roughness = source.roughness;
 	this.roughnessMapSlot.copy( source.roughnessMapSlot );
+
+	this.metalness = source.metalness;
 	this.metalnessMapSlot.copy( source.metalnessMapSlot );
-	this.alphaMapSlot.copy( source.alphaMapSlot );
+
+	this.lightMapSlot.copy( source.lightMapSlot );
+
+	this.aoMapIntensity = source.aoMapIntensity;
+	this.aoMapSlot.copy( source.aoMapSlot );
 
 	this.emissive.copy( source.emissive );
 	this.emissiveIntensity = source.emissiveIntensity;
+	this.emissiveMapSlot.copy( source.emissiveMapSlot );
+
+	this.bumpMapSlot.copy( source.bumpMapSlot );
 
 	this.normalScale.copy( source.normalScale );
+	this.normalMapSlot.copy( source.normalMapSlot );
+
+	this.displacementMapSlot.copy( source.displacementMapSlot );
+
+	this.alphaMapSlot.copy( source.alphaMapSlot );
 
 	this.envMap = source.envMap;
 	this.envMapIntensity = source.envMapIntensity;

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -67,44 +67,44 @@ THREE.MeshStandardMaterial = function ( parameters ) {
 
 	this.color = new THREE.Color( 0xffffff ); // diffuse
 	//this.map = null;
-	this.mapSlot = new THREE.TextureSlot( "map", 0, false, false );
+	this.mapSlot = new THREE.Map( "map", 0, false, false );
 
 	this.roughness = 0.5;
 	//this.roughnessMap = null;
-	this.roughnessMapSlot = new THREE.TextureSlot( "roughnessMap", 0, false, false );
+	this.roughnessMapSlot = new THREE.Map( "roughnessMap", 0, false, false );
 
 	this.metalness = 0.5;
 	//this.metalnessMap = null;
-	this.metalnessMapSlot = new THREE.TextureSlot( "metalnessMap", 0, false, false );
+	this.metalnessMapSlot = new THREE.Map( "metalnessMap", 0, false, false );
 
 	this.emissive = new THREE.Color( 0x000000 );
 	this.emissiveIntensity = 1.0;
 	//this.emissiveMap = null;
-	this.emissiveMapSlot = new THREE.TextureSlot( "emissiveMap", 0, false, false );
+	this.emissiveMapSlot = new THREE.Map( "emissiveMap", 0, false, false );
 
 	//this.bumpMap = null;
 	//this.bumpScale = 1;
-	this.bumpMapSlot = new THREE.TextureSlot( "bumpMap", 0, false, true );
+	this.bumpMapSlot = new THREE.Map( "bumpMap", 0, false, true );
 
 	//this.normalMap = null;
 	this.normalScale = new THREE.Vector2( 1, 1 );
-	this.normalMapSlot = new THREE.TextureSlot( "normalMap", 0, false, false );
+	this.normalMapSlot = new THREE.Map( "normalMap", 0, false, false );
 
 	//this.displacementMap = null;
 	//this.displacementScale = 1;
 	//this.displacementBias = 0;
-	this.displacementMapSlot = new THREE.TextureSlot( "displacementMap", 0, false, true );
+	this.displacementMapSlot = new THREE.Map( "displacementMap", 0, false, true );
 
 	//this.lightMap = null;
 	//this.lightMapIntensity = 1.0;
-	this.lightMapSlot = new THREE.TextureSlot( "lightMap", 1, false, true );
+	this.lightMapSlot = new THREE.Map( "lightMap", 1, false, true );
 
 	//this.aoMap = null;
 	this.aoMapIntensity = 1.0;
-	this.aoMapSlot = new THREE.TextureSlot( "aoMap", 1, false, true );
+	this.aoMapSlot = new THREE.Map( "aoMap", 1, false, true );
 
 	//this.alphaMap = null;
-	this.alphaMapSlot = new THREE.TextureSlot( "alphaMap", 0, false, false );
+	this.alphaMapSlot = new THREE.Map( "alphaMap", 0, false, false );
 
 	this.envMap = null;
 	this.envMapIntensity = 1.0;

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -1,5 +1,6 @@
 /**
  * @author WestLangley / http://github.com/WestLangley
+ * @author Ben Houston / bhouston / http://clara.io
  *
  * parameters = {
  *  color: <hex>,
@@ -41,7 +42,7 @@
  *  refractionRatio: <float>,
  *
  *  shading: THREE.SmoothShading,
- *  blending: THREE.PremultipliedAlphaBlending,
+ *  blending: THREE.PremultipliedAlphaNormalBlending,
  *  depthTest: <bool>,
  *  depthWrite: <bool>,
  *
@@ -68,33 +69,46 @@ THREE.MeshStandardMaterial = function ( parameters ) {
 	this.roughness = 0.5;
 	this.metalness = 0.5;
 
-	this.map = null;
+	//this.map = null;
+	this.mapSlot = new THREE.TextureSlot( "map", 0, false, false );
 
-	this.lightMap = null;
-	this.lightMapIntensity = 1.0;
+	//this.lightMap = null;
+	//this.lightMapIntensity = 1.0;
+	this.lightMapSlot = new THREE.TextureSlot( "lightMap", 1, false, true );
 
-	this.aoMap = null;
-	this.aoMapIntensity = 1.0;
+	//this.aoMap = null;
+	//this.aoMapIntensity = 1.0;
+	this.aoMapSlot = new THREE.TextureSlot( "aoMap", 1, false, true );
 
 	this.emissive = new THREE.Color( 0x000000 );
 	this.emissiveIntensity = 1.0;
-	this.emissiveMap = null;
+	//this.emissiveMap = null;
+	this.emissiveMapSlot = new THREE.TextureSlot( "emissiveMap", 0, false, false );
 
-	this.bumpMap = null;
-	this.bumpScale = 1;
+	//this.bumpMap = null;
+	//this.bumpScale = 1;
+	this.bumpMapSlot = new THREE.TextureSlot( "bumpMap", 0, false, true );
 
-	this.normalMap = null;
+	//this.normalMap = null;
 	this.normalScale = new THREE.Vector2( 1, 1 );
+	this.normalMapSlot = new THREE.TextureSlot( "normalMap", 0, false, false );
 
-	this.displacementMap = null;
-	this.displacementScale = 1;
-	this.displacementBias = 0;
+	//this.displacementMap = null;
+	//this.displacementScale = 1;
+	//this.displacementBias = 0;
+	this.displacementMapSlot = new THREE.TextureSlot( "displacementMap", 0, false, true );
 
-	this.roughnessMap = null;
+	//this.roughnessMap = null;
+	this.roughnessMapSlot = new THREE.TextureSlot( "roughnessMap", 0, false, false );
 
-	this.metalnessMap = null;
+	//this.metalnessMap = null;
+	this.metalnessMapSlot = new THREE.TextureSlot( "metalnessMap", 0, false, false );
 
-	this.alphaMap = null;
+	//this.alphaMap = null;
+	this.alphaMapSlot = new THREE.TextureSlot( "alphaMap", 0, false, false );
+
+	this.slots = [ this.mapSlot, this.lightMapSlot, this.aoMapSlot, this.emissiveMapSlot, this.bumpMapSlot,
+		this.normalMapSlot, this.roughnessMapSlot, this.metalnessMapSlot, this.alphaMapSlot ];
 
 	this.envMap = null;
 	this.envMapIntensity = 1.0;
@@ -104,7 +118,7 @@ THREE.MeshStandardMaterial = function ( parameters ) {
 	this.fog = true;
 
 	this.shading = THREE.SmoothShading;
-	this.blending = THREE.PremultipliedAlphaBlending;
+	this.blending = THREE.PremultipliedAlphaNormalBlending;
 
 	this.wireframe = false;
 	this.wireframeLinewidth = 1;
@@ -124,6 +138,134 @@ THREE.MeshStandardMaterial = function ( parameters ) {
 THREE.MeshStandardMaterial.prototype = Object.create( THREE.Material.prototype );
 THREE.MeshStandardMaterial.prototype.constructor = THREE.MeshStandardMaterial;
 
+var closure = function () {
+	var propertyMappings = {
+		"map": {
+		  get: function() {
+				return this.mapSlot.texture;
+		  },
+			set: function( value ) {
+				this.mapSlot.texture = value;
+			}
+		},
+		"lightMap": {
+		  get: function() {
+				return this.lightMapSlot.texture;
+		  },
+			set: function( value ) {
+				this.lightMapSlot.texture = value;
+			}
+		},
+		"lightMapIntensity": {
+		  get: function() {
+				return this.lightMapSlot.texelScale;
+		  },
+			set: function( value ) {
+				this.lightMapSlot.texelScale = value;
+			}
+		},
+		"aoMap": {
+		  get: function() {
+				return this.aoMapSlot.texture;
+		  },
+			set: function( value ) {
+				this.aoMapSlot.texture = value;
+			}
+		},
+		"aoMapIntensity": {
+		  get: function() {
+				return this.aoMapSlot.texelScale;
+		  },
+			set: function( value ) {
+				this.aoMapSlot.texelScale = value;
+			}
+		},
+		"emissiveMap": {
+		  get: function() {
+				return this.emissiveMapSlot.texture;
+		  },
+			set: function( value ) {
+				this.emissiveMapSlot.texture = value;
+			}
+		},
+		"bumpMap": {
+		  get: function() {
+				return this.bumpMapSlot.texture;
+		  },
+			set: function( value ) {
+				this.bumpMapSlot.texture = value;
+			}
+		},
+		"bumpScale": {
+		  get: function() {
+				return this.emissiveMapSlot.texelScale;
+		  },
+			set: function( value ) {
+				this.emissiveMapSlot.texelScale = value;
+			}
+		},
+		"normalMap": {
+		  get: function() {
+				return this.normalMapSlot.texture;
+		  },
+			set: function( value ) {
+				this.normalMapSlot.texture = value;
+			}
+		},
+		"displacementMap": {
+		  get: function() {
+				return this.displacementMapSlot.texture;
+		  },
+			set: function( value ) {
+				this.displacementMapSlot.texture = value;
+			}
+		},
+		"displacementScale": {
+		  get: function() {
+				return this.displacementMapSlot.texelScale;
+		  },
+			set: function( value ) {
+				this.displacementMapSlot.texelScale = value;
+			}
+		},
+		"displacementBias": {
+		  get: function() {
+				return this.displacementMapSlot.texelOffset;
+		  },
+			set: function( value ) {
+				this.displacementMapSlot.texelOffset = value;
+			}
+		},
+		"roughnessMap": {
+		  get: function() {
+				return this.roughnessMapSlot.texture;
+		  },
+			set: function( value ) {
+				this.roughnessMapSlot.texture = value;
+			}
+		},
+		"metalnessMap": {
+		  get: function() {
+				return this.metalnessMapSlot.texture;
+		  },
+			set: function( value ) {
+				this.metalnessMapSlot.texture = value;
+			}
+		},
+		"alphaMap": {
+		  get: function() {
+				return this.alphaMapSlot.texture;
+		  },
+			set: function( value ) {
+				this.alphaMapSlot.texture = value;
+			}
+		}
+	};
+	for( var propertyName in propertyMappings ) {
+		Object.defineProperty(THREE.MeshStandardMaterial.prototype, propertyName, propertyMappings[ propertyName ] );
+	}
+}();
+
 THREE.MeshStandardMaterial.prototype.copy = function ( source ) {
 
 	THREE.Material.prototype.copy.call( this, source );
@@ -132,27 +274,21 @@ THREE.MeshStandardMaterial.prototype.copy = function ( source ) {
 	this.roughness = source.roughness;
 	this.metalness = source.metalness;
 
-	this.map = source.map;
-
-	this.lightMap = source.lightMap;
-	this.lightMapIntensity = source.lightMapIntensity;
-
-	this.aoMap = source.aoMap;
-	this.aoMapIntensity = source.aoMapIntensity;
+	this.mapSlot.copy( source.mapSlot );
+	this.lightMapSlot.copy( source.lightMapSlot );
+	this.aoMapSlot.copy( source.aoMapSlot );
+	this.emissiveMapSlot.copy( source.emissiveMapSlot );
+	this.bumpMapSlot.copy( source.bumpMapSlot );
+	this.normalMapSlot.copy( source.normalMapSlot );
+	this.displacementMapSlot.copy( source.displacementMapSlot );
+	this.roughnessMapSlot.copy( source.roughnessMapSlot );
+	this.metalnessMapSlot.copy( source.metalnessMapSlot );
+	this.alphaMapSlot.copy( source.alphaMapSlot );
 
 	this.emissive.copy( source.emissive );
-	this.emissiveMap = source.emissiveMap;
 	this.emissiveIntensity = source.emissiveIntensity;
 
-	this.bumpMap = source.bumpMap;
-	this.bumpScale = source.bumpScale;
-
-	this.normalMap = source.normalMap;
 	this.normalScale.copy( source.normalScale );
-
-	this.displacementMap = source.displacementMap;
-	this.displacementScale = source.displacementScale;
-	this.displacementBias = source.displacementBias;
 
 	this.roughnessMap = source.roughnessMap;
 

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -191,11 +191,11 @@ var closure = function () {
 		},
 		"bumpScale": {
 		  get: function() {
-				return this.emissiveMapSlot.texelScale;
+				return this.bumpMapSlot.texelScale;
 		  },
 			set: function( value ) {
-				this.emissiveMapSlot.texelTransform = true;
-				this.emissiveMapSlot.texelScale = value;
+				this.bumpMapSlot.texelTransform = true;
+				this.bumpMapSlot.texelScale = value;
 			}
 		},
 		"normalMap": {

--- a/src/materials/TextureSlot.js
+++ b/src/materials/TextureSlot.js
@@ -1,0 +1,67 @@
+/**
+ * @author Ben Houston / bhouston / http://clara.io
+ *
+ */
+
+THREE.TextureSlot = function ( name, uvChannel, uvTransform, texelTransform ) {
+
+  this.name = name || "unnamed";
+
+  this.texture = null;
+
+  this.uvChannel = uvChannel || 0;
+
+  this.uvTransform = uvTransform || false;
+  this.uvOffset = new THREE.Vector2( 0, 0 );
+  this.uvRepeat = new THREE.Vector2( 1.0, 1.0 );
+  this.uvRotation = 0;
+
+  this.texelTransform = uvTransform || false;
+  this.texelScale = 1.0;
+  this.texelOffset = 0.0;
+  this.texelInvert = false;
+
+};
+
+THREE.TextureSlot.prototype = {
+
+  constructor: THREE.TextureSlot,
+
+  copy: function ( source ) {
+
+    this.name = source.name;
+
+  	this.texture = source.texture;
+
+    this.uvChannel = source.uvChannel;
+
+    this.uvTransform = source.uvTransform;
+    this.uvOffset = source.uvOffset;
+    this.uvRepeat = source.uvRepeat;
+    this.uvRotation = source.uvRotation;
+
+    this.texelTransform = source.texelTransform;
+    this.texelScale = source.texelScale;
+    this.texelOffset = source.texelOffset;
+    this.texelInvert = source.texelInvert;
+
+  	return this;
+
+  },
+
+  // bakes all the input texel parameters into just two.
+  getFlattenedTexelTransform: function() {
+
+      if( this.texelInvert ) {
+        return {
+          texelScale: -this.texelScale,
+          texelOffset: this.texelScale + this.texelOffset
+        };
+      }
+      return {
+        texelScale: this.texelScale,
+        texelOffset: this.texelOffset
+      };
+  }
+
+};

--- a/src/materials/TextureSlot.js
+++ b/src/materials/TextureSlot.js
@@ -14,7 +14,7 @@ THREE.TextureSlot = function ( name, uvChannel, uvTransform, texelTransform ) {
   this.uvTransform = uvTransform || false;
   this.uvOffset = new THREE.Vector2( 0, 0 );
   this.uvRepeat = new THREE.Vector2( 1.0, 1.0 );
-  this.uvRotation = 0;
+  //this.uvRotation = 0;
 
   this.texelTransform = uvTransform || false;
   this.texelScale = 1.0;
@@ -38,7 +38,7 @@ THREE.TextureSlot.prototype = {
     this.uvTransform = source.uvTransform;
     this.uvOffset = source.uvOffset;
     this.uvRepeat = source.uvRepeat;
-    this.uvRotation = source.uvRotation;
+    //this.uvRotation = source.uvRotation;
 
     this.texelTransform = source.texelTransform;
     this.texelScale = source.texelScale;

--- a/src/materials/TextureSlot.js
+++ b/src/materials/TextureSlot.js
@@ -67,5 +67,5 @@ THREE.TextureSlot.prototype = {
 };
 
 THREE.TextureSlot.SupportedSlotNames = [
-	'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap'
+	'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap', 'displacementMap'
 ];

--- a/src/materials/TextureSlot.js
+++ b/src/materials/TextureSlot.js
@@ -65,3 +65,7 @@ THREE.TextureSlot.prototype = {
   }
 
 };
+
+THREE.TextureSlot.SupportedSlotNames = [
+	'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap'
+];

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1894,6 +1894,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	// Uniforms (refresh uniforms objects)
 
+	var supportedSlots = [
+		'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap'
+	];
+
 	function refreshUniformsCommon ( uniforms, material ) {
 
 		uniforms.opacity.value = material.opacity;
@@ -1906,13 +1910,36 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		uniforms.map.value = material.map;
-		uniforms.specularMap.value = material.specularMap;
-		uniforms.alphaMap.value = material.alphaMap;
+		for( var i = 0; i < supportedSlots.length; i ++ ) {
+			var slotName = supportedSlots[i];
+			var slot = material[ slotName + 'Slot' ];
+			if( slot ) {
+				uniforms[slotName].value = slot.texture;
+				if( slot.uvTransform ) {
+					uniforms[slotName +"UVTransformParams"].value.set(
+						slot.uvOffset.x,
+						slot.uvOffset.y,
+						slot.uvRepeat.x,
+						slot.uvRepeat.y );
+				}
+				if( slot.texelTransform ) {
+					var texelTransform = slot.getFlattenedTexelTransform();
+					uniforms[slotName +"TexelTransformParams"].value.set(
+						texelTransform.texelScale,
+						texelTransform.texelOffset );
+				}
+			}
+			else if( material[ slotName ] ) {
+				uniforms[slotName].value = material[slotName];
+			}
+		}
+		//uniforms.map.value = material.map;
+		//uniforms.specularMap.value = material.specularMap;
+		//uniforms.alphaMap.value = material.alphaMap;
 
 		if ( material.aoMap ) {
 
-			uniforms.aoMap.value = material.aoMap;
+			//uniforms.aoMap.value = material.aoMap;
 			uniforms.aoMapIntensity.value = material.aoMapIntensity;
 
 		}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1914,10 +1914,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 				uniforms[slotName].value = slot.texture;
 				if( slot.uvTransform ) {
 					uniforms[slotName +"UVTransformParams"].value.set(
-						slot.uvOffset.x,
-						slot.uvOffset.y,
 						slot.uvRepeat.x,
-						slot.uvRepeat.y );
+						slot.uvRepeat.y,
+						slot.uvOffset.x,
+						slot.uvOffset.y );
 				}
 				if( slot.texelTransform ) {
 					var texelTransform = slot.getFlattenedTexelTransform();

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1906,28 +1906,28 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		var supportedSlots = THREE.TextureSlot.SupportedSlotNames;
-		for( var i = 0; i < supportedSlots.length; i ++ ) {
-			var slotName = supportedSlots[i];
-			var slot = material[ slotName + 'Slot' ];
-			if( slot ) {
-				uniforms[slotName].value = slot.texture;
-				if( slot.uvTransform ) {
-					uniforms[slotName +"UVTransformParams"].value.set(
-						slot.uvRepeat.x,
-						slot.uvRepeat.y,
-						slot.uvOffset.x,
-						slot.uvOffset.y );
+		var supportedMapNames = THREE.Map.SupportedMapNames;
+		for( var i = 0; i < supportedMapNames.length; i ++ ) {
+			var mapName = supportedMapNames[i];
+			var map = material[ mapName + 'Slot' ];
+			if( map ) {
+				uniforms[mapName].value = map.texture;
+				if( map.uvTransform ) {
+					uniforms[mapName +"UVTransformParams"].value.set(
+						map.uvRepeat.x,
+						map.uvRepeat.y,
+						map.uvOffset.x,
+						map.uvOffset.y );
 				}
-				if( slot.texelTransform ) {
-					var texelTransform = slot.getFlattenedTexelTransform();
-					uniforms[slotName +"TexelTransformParams"].value.set(
+				if( map.texelTransform ) {
+					var texelTransform = map.getFlattenedTexelTransform();
+					uniforms[mapName +"TexelTransformParams"].value.set(
 						texelTransform.texelScale,
 						texelTransform.texelOffset );
 				}
 			}
-			else if( material[ slotName ] ) {
-				uniforms[slotName].value = material[slotName];
+			else if( material[ mapName ] ) {
+				uniforms[mapName].value = material[mapName];
 			}
 		}
 		//uniforms.map.value = material.map;
@@ -2901,7 +2901,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function uploadTexture( textureProperties, texture, slot ) {
+	function uploadTexture( textureProperties, texture, map ) {
 
 		if ( textureProperties.__webglInit === undefined ) {
 
@@ -2915,7 +2915,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
+		state.activeTexture( _gl.TEXTURE0 + map );
 		state.bindTexture( _gl.TEXTURE_2D, textureProperties.__webglTexture );
 
 		_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, texture.flipY );
@@ -3022,7 +3022,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	this.setTexture = function ( texture, slot ) {
+	this.setTexture = function ( texture, map ) {
 
 		var textureProperties = properties.get( texture );
 
@@ -3044,13 +3044,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
-			uploadTexture( textureProperties, texture, slot );
+			uploadTexture( textureProperties, texture, map );
 
 			return;
 
 		}
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
+		state.activeTexture( _gl.TEXTURE0 + map );
 		state.bindTexture( _gl.TEXTURE_2D, textureProperties.__webglTexture );
 
 	};
@@ -3117,7 +3117,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function setCubeTexture ( texture, slot ) {
+	function setCubeTexture ( texture, map ) {
 
 		var textureProperties = properties.get( texture );
 
@@ -3135,7 +3135,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				state.activeTexture( _gl.TEXTURE0 + slot );
+				state.activeTexture( _gl.TEXTURE0 + map );
 				state.bindTexture( _gl.TEXTURE_CUBE_MAP, textureProperties.__image__webglTextureCube );
 
 				_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, texture.flipY );
@@ -3224,7 +3224,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			} else {
 
-				state.activeTexture( _gl.TEXTURE0 + slot );
+				state.activeTexture( _gl.TEXTURE0 + map );
 				state.bindTexture( _gl.TEXTURE_CUBE_MAP, textureProperties.__image__webglTextureCube );
 
 			}
@@ -3233,9 +3233,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function setCubeTextureDynamic ( texture, slot ) {
+	function setCubeTextureDynamic ( texture, map ) {
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
+		state.activeTexture( _gl.TEXTURE0 + map );
 		state.bindTexture( _gl.TEXTURE_CUBE_MAP, properties.get( texture ).__webglTexture );
 
 	}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1894,10 +1894,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	// Uniforms (refresh uniforms objects)
 
-	var supportedSlots = [
-		'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap'
-	];
-
 	function refreshUniformsCommon ( uniforms, material ) {
 
 		uniforms.opacity.value = material.opacity;
@@ -1910,6 +1906,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
+		var supportedSlots = THREE.TextureSlot.SupportedSlotNames;
 		for( var i = 0; i < supportedSlots.length; i ++ ) {
 			var slotName = supportedSlots[i];
 			var slot = material[ slotName + 'Slot' ];

--- a/src/renderers/shaders/ShaderChunk/alphamap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/alphamap_fragment.glsl
@@ -1,5 +1,11 @@
 #ifdef USE_ALPHAMAP
 
-	diffuseColor.a *= texture2D( alphaMap, vUv ).g;
+#if defined( TEXTURE_SLOTS )
+	vec2 alphaUv = alphaMapUV();
+#else
+	vec2 alphaUv = vUv;
+#endif
+
+	diffuseColor.a *= alphaMapTexelTransform( texture2D( alphaMap, alphaUv ) ).g;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/alphamap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/alphamap_pars_fragment.glsl
@@ -1,5 +1,7 @@
-#ifdef USE_ALPHAMAP
+#if ! defined( TEXTURE_SLOTS )
+	#ifdef USE_ALPHAMAP
 
-	uniform sampler2D alphaMap;
+		uniform sampler2D alphaMap;
 
+	#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl
@@ -1,6 +1,12 @@
 #ifdef USE_AOMAP
 
-	float ambientOcclusion = ( texture2D( aoMap, vUv2 ).r - 1.0 ) * aoMapIntensity + 1.0;
+#if defined( TEXTURE_SLOTS )
+	vec2 aoUv = aoMapUV();
+#else
+	vec2 aoUv = vUv2;
+#endif
+
+	float ambientOcclusion = ( aoMapTexelTransform( texture2D( aoMap, aoUv ) ).r - 1.0 ) * aoMapIntensity + 1.0;
 
 	reflectedLight.indirectDiffuse *= ambientOcclusion;
 

--- a/src/renderers/shaders/ShaderChunk/aomap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/aomap_pars_fragment.glsl
@@ -1,6 +1,9 @@
 #ifdef USE_AOMAP
 
+#if ! defined( TEXTURE_SLOTS )
 	uniform sampler2D aoMap;
+#endif
+
 	uniform float aoMapIntensity;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl
@@ -1,7 +1,11 @@
 #ifdef USE_BUMPMAP
 
+#if ! defined( TEXTURE_SLOTS )
+
 	uniform sampler2D bumpMap;
 	uniform float bumpScale;
+
+#endif
 
 	// Derivative maps - bump mapping unparametrized surfaces by Morten Mikkelsen
 	// http://mmikkelsen3d.blogspot.sk/2011/07/derivative-maps.html
@@ -10,12 +14,18 @@
 
 	vec2 dHdxy_fwd() {
 
-		vec2 dSTdx = dFdx( vUv );
-		vec2 dSTdy = dFdy( vUv );
+#if defined( TEXTURE_SLOTS )
+		vec2 bumpUv = bumpMapUV();
+#else
+		vec2 bumpUv = vUv;
+#endif
 
-		float Hll = bumpScale * texture2D( bumpMap, vUv ).x;
-		float dBx = bumpScale * texture2D( bumpMap, vUv + dSTdx ).x - Hll;
-		float dBy = bumpScale * texture2D( bumpMap, vUv + dSTdy ).x - Hll;
+		vec2 dSTdx = dFdx( bumpUv );
+		vec2 dSTdy = dFdy( bumpUv );
+
+		float Hll = bumpMapTexelTransform( texture2D( bumpMap, bumpUv ) ).x;
+		float dBx = bumpMapTexelTransform( texture2D( bumpMap, bumpUv + dSTdx ) ).x - Hll;
+		float dBy = bumpMapTexelTransform( texture2D( bumpMap, bumpUv + dSTdy ) ).x - Hll;
 
 		return vec2( dBx, dBy );
 

--- a/src/renderers/shaders/ShaderChunk/emissivemap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/emissivemap_fragment.glsl
@@ -1,8 +1,14 @@
 #ifdef USE_EMISSIVEMAP
 
-	vec4 emissiveColor = texture2D( emissiveMap, vUv );
+#if defined( TEXTURE_SLOTS )
+	vec2 emissiveUv = emissiveMapUV();
+#else
+	vec2 emissiveUv = vUv;
+#endif
 
-	emissiveColor.rgb = emissiveMapTexelToLinear( emissiveColor ).rgb;
+	vec4 emissiveColor = texture2D( emissiveMap, emissiveUv );
+
+	emissiveColor.rgb = emissiveMapTexelTransform( emissiveMapTexelToLinear( emissiveColor ) ).rgb;
 
 	totalEmissiveLight *= emissiveColor.rgb;
 

--- a/src/renderers/shaders/ShaderChunk/emissivemap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/emissivemap_pars_fragment.glsl
@@ -1,5 +1,7 @@
-#ifdef USE_EMISSIVEMAP
+#if ! defined( TEXTURE_SLOTS )
+	#ifdef USE_EMISSIVEMAP
 
-	uniform sampler2D emissiveMap;
+		uniform sampler2D emissiveMap;
 
+	#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl
@@ -1,5 +1,11 @@
 #ifdef USE_LIGHTMAP
 
-	reflectedLight.indirectDiffuse += PI * texture2D( lightMap, vUv2 ).xyz * lightMapIntensity; // factor of PI should not be present; included here to prevent breakage
+#if defined( TEXTURE_SLOTS )
+	vec2 lightUv = lightMapUV();
+#else
+	vec2 lightUv = vUv2;
+#endif
+
+	reflectedLight.indirectDiffuse += PI * emissiveMapTexelTransform( texture2D( lightMap, lightUv ) ).xyz; // factor of PI should not be present; included here to prevent breakage
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/lightmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lightmap_pars_fragment.glsl
@@ -1,6 +1,8 @@
-#ifdef USE_LIGHTMAP
+#if ! defined( TEXTURE_SLOTS )
+	#ifdef USE_LIGHTMAP
 
-	uniform sampler2D lightMap;
-	uniform float lightMapIntensity;
+		uniform sampler2D lightMap;
+		uniform float lightMapIntensity;
 
+	#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/map_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/map_fragment.glsl
@@ -1,8 +1,14 @@
 #ifdef USE_MAP
 
-	vec4 texelColor = texture2D( map, vUv );
+#if defined( TEXTURE_SLOTS )
+	vec2 mapUv = mapUV();
+#else
+	vec2 mapUv = vUv;
+#endif
 
-	texelColor = mapTexelToLinear( texelColor );
+	vec4 texelColor = texture2D( map, mapUv );
+
+	texelColor = mapTexelTransform( mapTexelToLinear( texelColor ) );
 	diffuseColor *= texelColor;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/map_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/map_pars_fragment.glsl
@@ -1,5 +1,7 @@
-#ifdef USE_MAP
+#if ! defined( TEXTURE_SLOTS )
+	#ifdef USE_MAP
 
-	uniform sampler2D map;
+		uniform sampler2D map;
 
+	#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/metalnessmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/metalnessmap_fragment.glsl
@@ -8,7 +8,7 @@ float metalnessFactor = metalness;
 		vec2 metalnessUv = vUv;
 	#endif
 
-	vec4 texelMetalness = metalnessTexelTransform( texture2D( metalnessMap, metalnessUv ) );
+	vec4 texelMetalness = metalnessMapTexelTransform( texture2D( metalnessMap, metalnessUv ) );
 	metalnessFactor *= texelMetalness.r;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/metalnessmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/metalnessmap_fragment.glsl
@@ -2,7 +2,13 @@ float metalnessFactor = metalness;
 
 #ifdef USE_METALNESSMAP
 
-	vec4 texelMetalness = texture2D( metalnessMap, vUv );
+	#if defined( TEXTURE_SLOTS )
+		vec2 metalnessUv = metalnessMapUV();
+	#else
+		vec2 metalnessUv = vUv;
+	#endif
+
+	vec4 texelMetalness = metalnessTexelTransform( texture2D( metalnessMap, metalnessUv ) );
 	metalnessFactor *= texelMetalness.r;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/metalnessmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/metalnessmap_pars_fragment.glsl
@@ -1,5 +1,7 @@
-#ifdef USE_METALNESSMAP
+#if ! defined( TEXTURE_SLOTS )
+	#ifdef USE_METALNESSMAP
 
-	uniform sampler2D metalnessMap;
+		uniform sampler2D metalnessMap;
 
+	#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl
@@ -1,23 +1,31 @@
 #ifdef USE_NORMALMAP
 
-	uniform sampler2D normalMap;
-	uniform vec2 normalScale;
+	#if ! defined( TEXTURE_SLOTS )
+		uniform sampler2D normalMap;
+	#endif
+		uniform vec2 normalScale;
 
 	// Per-Pixel Tangent Space Normal Mapping
 	// http://hacksoflife.blogspot.ch/2009/11/per-pixel-tangent-space-normal-mapping.html
 
 	vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm ) {
 
+		#if defined( TEXTURE_SLOTS )
+			vec2 normalUv = normalMapUV();
+		#else
+			vec2 normalUv = vUv;
+		#endif
+
 		vec3 q0 = dFdx( eye_pos.xyz );
 		vec3 q1 = dFdy( eye_pos.xyz );
-		vec2 st0 = dFdx( vUv.st );
-		vec2 st1 = dFdy( vUv.st );
+		vec2 st0 = dFdx( normalUv.st );
+		vec2 st1 = dFdy( normalUv.st );
 
 		vec3 S = normalize( q0 * st1.t - q1 * st0.t );
 		vec3 T = normalize( -q0 * st1.s + q1 * st0.s );
 		vec3 N = normalize( surf_norm );
 
-		vec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
+		vec3 mapN = texture2D( normalMap, normalUv ).xyz * 2.0 - 1.0;
 		mapN.xy = normalScale * mapN.xy;
 		mat3 tsn = mat3( S, T, N );
 		return normalize( tsn * mapN );

--- a/src/renderers/shaders/ShaderChunk/roughnessmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/roughnessmap_fragment.glsl
@@ -2,7 +2,13 @@ float roughnessFactor = roughness;
 
 #ifdef USE_ROUGHNESSMAP
 
-	vec4 texelRoughness = texture2D( roughnessMap, vUv );
+	#if defined( TEXTURE_SLOTS )
+		vec2 roughnessUv = roughnessMapUV();
+	#else
+		vec2 roughnessUv = vUv;
+	#endif
+
+	vec4 texelRoughness = roughnessMapTexelTransform( texture2D( roughnessMap, roughnessUv ) );
 	roughnessFactor *= texelRoughness.r;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/roughnessmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/roughnessmap_pars_fragment.glsl
@@ -1,5 +1,7 @@
-#ifdef USE_ROUGHNESSMAP
+#if ! defined( TEXTURE_SLOTS )
+	#ifdef USE_ROUGHNESSMAP
 
-	uniform sampler2D roughnessMap;
+		uniform sampler2D roughnessMap;
 
+	#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/slot_texel_transform_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/slot_texel_transform_template.glsl
@@ -1,7 +1,7 @@
-uniform vec2 <SLOT_NAME>TexelTransformParams;
+uniform vec2 $SLOT_NAME$TexelTransformParams;
 
-vec4 <SLOT_NAME>TexelTransform( vec4 value ) {
-    value.rgb *= <SLOT_NAME>TexelTransformParams.x;
-    value.rgb += vec3( <SLOT_NAME>TexelTransformParams.y );
+vec4 $SLOT_NAME$TexelTransform( vec4 value ) {
+    value.rgb *= $SLOT_NAME$TexelTransformParams.x;
+    value.rgb += vec3( $SLOT_NAME$TexelTransformParams.y );
     return value;
 }

--- a/src/renderers/shaders/ShaderChunk/slot_texel_transform_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/slot_texel_transform_template.glsl
@@ -1,0 +1,7 @@
+uniform vec2 <SLOT_NAME>TexelTransformParams;
+
+vec4 <SLOT_NAME>TexelTransform( vec4 value ) {
+    value.rgb *= <SLOT_NAME>TexelTransformParams.x;
+    value.rgb += vec3( <SLOT_NAME>TexelTransformParams.y );
+    return value;
+}

--- a/src/renderers/shaders/ShaderChunk/slot_uv_transform_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/slot_uv_transform_template.glsl
@@ -1,8 +1,8 @@
-uniform vec4 <SLOT_NAME>UVTransformParams;
+uniform vec4 $SLOT_NAME$UVTransformParams;
 
-vec2 <SLOT_NAME>UV() {
-  vec2 value = <UV_VAR_NAME>;
-  value.xy *= <SLOT_NAME>UVTransformParams.xy;
-  value.xy += <SLOT_NAME>UVTransformParams.zw;
+vec2 $SLOT_NAME$UV() {
+  vec2 value = $UV_VAR_NAME$;
+  value.xy *= $SLOT_NAME$UVTransformParams.xy;
+  value.xy += $SLOT_NAME$UVTransformParams.zw;
   return value;
 }

--- a/src/renderers/shaders/ShaderChunk/slot_uv_transform_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/slot_uv_transform_template.glsl
@@ -1,0 +1,8 @@
+uniform vec4 <SLOT_NAME>UVTransformParams;
+
+vec2 <SLOT_NAME>UV() {
+  vec2 value = <UV_VAR_NAME>;
+  value.xy *= <SLOT_NAME>UVTransformParams.xy;
+  value.xy += <SLOT_NAME>UVTransformParams.zw;
+  return value;
+}

--- a/src/renderers/shaders/ShaderChunk/specularmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/specularmap_fragment.glsl
@@ -2,7 +2,13 @@ float specularStrength;
 
 #ifdef USE_SPECULARMAP
 
-	vec4 texelSpecular = texture2D( specularMap, vUv );
+	#if defined( TEXTURE_SLOTS )
+		vec2 specularUv = specularMapUV();
+	#else
+		vec2 specularUv = vUv;
+	#endif
+
+	vec4 texelSpecular = specularMapTexelTransform( texture2D( specularMap, specularUv ) );
 	specularStrength = texelSpecular.r;
 
 #else

--- a/src/renderers/shaders/ShaderChunk/specularmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/specularmap_pars_fragment.glsl
@@ -1,5 +1,7 @@
-#ifdef USE_SPECULARMAP
+#if ! defined( TEXTURE_SLOTS )
+	#ifdef USE_SPECULARMAP
 
-	uniform sampler2D specularMap;
+		uniform sampler2D specularMap;
 
+	#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/uv2_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/uv2_pars_fragment.glsl
@@ -1,5 +1,7 @@
-#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )
+#if ! defined( TEXTURE_SLOTS )
+	#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )
 
-	varying vec2 vUv2;
+		varying vec2 vUv2;
 
+	#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/uv_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/uv_pars_fragment.glsl
@@ -1,5 +1,9 @@
-#if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )
+#if ! defined( TEXTURE_SLOTS )
 
-	varying vec2 vUv;
+	#if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )
 
+		varying vec2 vUv;
+
+	#endif
+	
 #endif

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -68,7 +68,6 @@ THREE.UniformsLib = {
 
 		"normalMap": { type: "t", value: null },
 		"normalScale": { type: "v2", value: new THREE.Vector2( 1, 1 ) }, // for backwards compatibility
-		"normalScale": { type: "v2", value: new THREE.Vector2( 1, 1 ) },
 		"normalMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
 		"normalMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) }
 

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -10,10 +10,17 @@ THREE.UniformsLib = {
 		"opacity": { type: "f", value: 1.0 },
 
 		"map": { type: "t", value: null },
+		"mapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"mapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) },
 		"offsetRepeat": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
 
 		"specularMap": { type: "t", value: null },
+		"specularMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"specularMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) },
+
 		"alphaMap": { type: "t", value: null },
+		"alphaMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"alphaMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) },
 
 		"envMap": { type: "t", value: null },
 		"flipEnvMap": { type: "f", value: - 1 },
@@ -25,6 +32,8 @@ THREE.UniformsLib = {
 	aomap: {
 
 		"aoMap": { type: "t", value: null },
+		"aoMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"aoMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) },
 		"aoMapIntensity": { type: "f", value: 1 }
 
 	},
@@ -32,47 +41,62 @@ THREE.UniformsLib = {
 	lightmap: {
 
 		"lightMap": { type: "t", value: null },
+		"lightMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"lightMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) },
 		"lightMapIntensity": { type: "f", value: 1 }
 
 	},
 
 	emissivemap: {
 
-		"emissiveMap": { type: "t", value: null }
+		"emissiveMap": { type: "t", value: null },
+		"emissiveMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"emissiveMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) }
 
 	},
 
 	bumpmap: {
 
 		"bumpMap": { type: "t", value: null },
-		"bumpScale": { type: "f", value: 1 }
+		"bumpScale": { type: "f", value: 1 }, // for backwards compatibility
+		"bumpMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"bumpMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) }
 
 	},
 
 	normalmap: {
 
 		"normalMap": { type: "t", value: null },
-		"normalScale": { type: "v2", value: new THREE.Vector2( 1, 1 ) }
+		"normalScale": { type: "v2", value: new THREE.Vector2( 1, 1 ) }, // for backwards compatibility
+		"normalScale": { type: "v2", value: new THREE.Vector2( 1, 1 ) },
+		"normalMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"normalMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) }
 
 	},
 
 	displacementmap: {
 
 		"displacementMap": { type: "t", value: null },
-		"displacementScale": { type: "f", value: 1 },
-		"displacementBias": { type: "f", value: 0 }
+		"displacementScale": { type: "f", value: 1 }, // for backwards compatibility
+		"displacementBias": { type: "f", value: 0 }, // for backwards compatibility
+		"displacementMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"displacementMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) }
 
 	},
 
 	roughnessmap: {
 
-		"roughnessMap": { type: "t", value: null }
+		"roughnessMap": { type: "t", value: null },
+		"roughnessMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"roughnessMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) }
 
 	},
 
 	metalnessmap: {
 
-		"metalnessMap": { type: "t", value: null }
+		"metalnessMap": { type: "t", value: null },
+		"metalnessMapUVTransformParams": { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+		"metalnessMapTexelTransformParams": { type: "v2", value: new THREE.Vector2( 1, 0 ) }
 
 	},
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -575,33 +575,34 @@ THREE.WebGLProgram = ( function () {
 				'\n'
 
 			].filter( filterEmptyLine ).join( '\n' );
-
-			var slotUVChannelsCode = "";
-			var slotTexelTransformCode = "";
-			var slotUvChannels = [];
-			for( var i = 0; i < supportedSlots.length; i ++ ) {
-				var slotName = supportedSlots[i];
-				var slot = material[ slotName + 'Slot' ];
-				if( slot || material[ slotName ] ) {
-					if( slot && ! slotUvChannels[ slot.uvChannel ]) slotUvChannels[ slot.uvChannel ] = true;
-					slotTexelTransformCode += getTexelTransformFunction( slotName, slot );
-					slotUVChannelsCode += "uniform sampler2D " + slotName + ";\n";
-					slotUVChannelsCode += getUVFunction( slotName, slot, false );
-				}
-			}
-			if( Object.keys( slotUvChannels ).length > 0 ) {
-				var slotUVPrefix = "";
-				slotUVPrefix += "#define TEXTURE_SLOTS\n";
-				for( var uvChannel in slotUvChannels ) {
-					uvChannel = parseInt( uvChannel );
-					var uvChannelName = "vUv";
-					if( uvChannel > 0 ) uvChannelName += '' + ( uvChannel + 1 );
-					slotUVPrefix += "varying vec2 " + uvChannelName + ";\n";
-				}
-				prefixFragment += slotUVPrefix + slotUVChannelsCode;
-			}
-			prefixFragment += slotTexelTransformCode;
 		}
+
+
+		var slotUVChannelsCode = "";
+		var slotTexelTransformCode = "";
+		var slotUvChannels = [];
+		for( var i = 0; i < supportedSlots.length; i ++ ) {
+			var slotName = supportedSlots[i];
+			var slot = material[ slotName + 'Slot' ];
+			if( material[ slotName ] || ( slot && slot.texture ) ) {
+				if( slot && ! slotUvChannels[ slot.uvChannel ]) slotUvChannels[ slot.uvChannel ] = true;
+				slotTexelTransformCode += getTexelTransformFunction( slotName, slot );
+				slotUVChannelsCode += "uniform sampler2D " + slotName + ";\n";
+				slotUVChannelsCode += getUVFunction( slotName, slot, false );
+			}
+		}
+		if( Object.keys( slotUvChannels ).length > 0 ) {
+			var slotUVPrefix = "";
+			slotUVPrefix += "#define TEXTURE_SLOTS\n";
+			for( var uvChannel in slotUvChannels ) {
+				uvChannel = parseInt( uvChannel );
+				var uvChannelName = "vUv";
+				if( uvChannel > 0 ) uvChannelName += '' + ( uvChannel + 1 );
+				slotUVPrefix += "varying vec2 " + uvChannelName + ";\n";
+			}
+			prefixFragment += slotUVPrefix + slotUVChannelsCode;
+		}
+		prefixFragment += slotTexelTransformCode;
 
 		vertexShader = parseIncludes( vertexShader, parameters );
 		vertexShader = replaceLightNums( vertexShader, parameters );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -46,33 +46,33 @@ THREE.WebGLProgram = ( function () {
 
 	}
 
-	function getTexelTransformFunction( slotName, slot ) {
+	function getTexelTransformFunction( mapName, map ) {
 
-		if( ! slot || ! slot.texelTransform ) {
-			return "vec4 " + slotName + "TexelTransform( vec4 value ) { return value; }\n";
+		if( ! map || ! map.texelTransform ) {
+			return "vec4 " + mapName + "TexelTransform( vec4 value ) { return value; }\n";
 		}
 
-		var transform = slot.getFlattenedTexelTransform();
+		var transform = map.getFlattenedTexelTransform();
 		var template = THREE.ShaderChunk[ 'slot_texel_transform_template' ];
-		var result = template.replace( /\$SLOT_NAME\$/g, slotName );
+		var result = template.replace( /\$SLOT_NAME\$/g, mapName );
 		return result;
 
 	}
 
-	function getUVFunction( slotName, slot, isVertexShader ) {
+	function getUVFunction( mapName, map, isVertexShader ) {
 
 		var uvVariableName = ( isVertexShader ) ? "uv" : "vUv";
-		if( slot && slot.uvChannel > 0 ) {
-			uvVariableName += ( slot.uvChannel + 1 );
+		if( map && map.uvChannel > 0 ) {
+			uvVariableName += ( map.uvChannel + 1 );
 		}
 
-		if( ! slot || ! slot.uvTransform ) {
-			return "vec2 " + slotName + "UV() { return " + uvVariableName + "; }\n";
+		if( ! map || ! map.uvTransform ) {
+			return "vec2 " + mapName + "UV() { return " + uvVariableName + "; }\n";
 		}
 
-		var transform = slot.getFlattenedTexelTransform();
+		var transform = map.getFlattenedTexelTransform();
 		var template = THREE.ShaderChunk[ 'slot_uv_transform_template' ];
-		var result = template.replace( /\$SLOT_NAME\$/g, slotName );
+		var result = template.replace( /\$SLOT_NAME\$/g, mapName );
 		result = result.replace( /\$UV_VAR_NAME\$/g, uvVariableName );
 		return result;
 
@@ -574,33 +574,33 @@ THREE.WebGLProgram = ( function () {
 		}
 
 
-		var supportedSlots = THREE.TextureSlot.SupportedSlotNames;
+		var supportedMapNames = THREE.Map.SupportedMapNames;
 
-		var slotUVChannelsCode = "";
-		var slotTexelTransformCode = "";
-		var slotUvChannels = [];
-		for( var i = 0; i < supportedSlots.length; i ++ ) {
-			var slotName = supportedSlots[i];
-			var slot = material[ slotName + 'Slot' ];
-			if( material[ slotName ] || ( slot && slot.texture ) ) {
-				if( slot && ! slotUvChannels[ slot.uvChannel ]) slotUvChannels[ slot.uvChannel ] = true;
-				slotTexelTransformCode += getTexelTransformFunction( slotName, slot );
-				slotUVChannelsCode += "uniform sampler2D " + slotName + ";\n";
-				slotUVChannelsCode += getUVFunction( slotName, slot, false );
+		var mapUVChannelsCode = "";
+		var mapTexelTransformCode = "";
+		var mapUvChannels = [];
+		for( var i = 0; i < supportedMapNames.length; i ++ ) {
+			var mapName = supportedMapNames[i];
+			var map = material[ mapName + 'Slot' ];
+			if( material[ mapName ] || ( map && map.texture ) ) {
+				if( map && ! mapUvChannels[ map.uvChannel ]) mapUvChannels[ map.uvChannel ] = true;
+				mapTexelTransformCode += getTexelTransformFunction( mapName, map );
+				mapUVChannelsCode += "uniform sampler2D " + mapName + ";\n";
+				mapUVChannelsCode += getUVFunction( mapName, map, false );
 			}
 		}
-		if( Object.keys( slotUvChannels ).length > 0 ) {
-			var slotUVPrefix = "";
-			slotUVPrefix += "#define TEXTURE_SLOTS\n";
-			for( var uvChannel in slotUvChannels ) {
+		if( Object.keys( mapUvChannels ).length > 0 ) {
+			var mapUVPrefix = "";
+			mapUVPrefix += "#define TEXTURE_SLOTS\n";
+			for( var uvChannel in mapUvChannels ) {
 				uvChannel = parseInt( uvChannel );
 				var uvChannelName = "vUv";
 				if( uvChannel > 0 ) uvChannelName += '' + ( uvChannel + 1 );
-				slotUVPrefix += "varying vec2 " + uvChannelName + ";\n";
+				mapUVPrefix += "varying vec2 " + uvChannelName + ";\n";
 			}
-			prefixFragment += slotUVPrefix + slotUVChannelsCode;
+			prefixFragment += mapUVPrefix + mapUVChannelsCode;
 		}
-		prefixFragment += slotTexelTransformCode;
+		prefixFragment += mapTexelTransformCode;
 
 		vertexShader = parseIncludes( vertexShader, parameters );
 		vertexShader = replaceLightNums( vertexShader, parameters );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -7,10 +7,6 @@ THREE.WebGLProgram = ( function () {
 	var arrayStructRe = /^([\w\d_]+)\[(\d+)\]\.([\w\d_]+)$/;
 	var arrayRe = /^([\w\d_]+)\[0\]$/;
 
-	var supportedSlots = [
-		'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap'
-	];
-
 	function getEncodingComponents( encoding ) {
 
 		switch ( encoding ) {
@@ -577,6 +573,8 @@ THREE.WebGLProgram = ( function () {
 			].filter( filterEmptyLine ).join( '\n' );
 		}
 
+
+		var supportedSlots = THREE.TextureSlot.SupportedSlotNames;
 
 		var slotUVChannelsCode = "";
 		var slotTexelTransformCode = "";

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -46,6 +46,38 @@ THREE.WebGLProgram = ( function () {
 
 	}
 
+	function getTexelTransformFunction( slot ) {
+
+		if( ! slot.texelTransform ) {
+			return "vec4 " + slot.name + "TexelTransform( vec4 value ) { return value; }";
+		}
+
+		var transform = slot.getFlattenedTexelTransform();
+		var template = THREE.ShaderChunk[ 'slot_texel_transform_template' ];
+		var result = template.replace( "<SLOT_NAME>", slot.name );
+		return result;
+
+	}
+
+	function getUVFunction( slot, isVertexShader ) {
+
+		var uvVariableName = ( isVertexShader ) ? "vUv" : "uv";
+		if( slot.uvChannel > 0 ) {
+			uvVariableName += slot.uvChannel;
+		}
+
+		if( ! slot.uvTransform ) {
+			return "vec2 " + slot.name + "UV() { return " + uvName + "; }";
+		}
+
+		var transform = slot.getFlattenedTexelTransform();
+		var template = THREE.ShaderChunk[ 'slot_texel_transform_template' ];
+		var result = template.replace( "<SLOT_NAME>", slot.name );
+		result = result.replace( "<UV_VAR_NAME>", uvVariableName );
+		return result;
+
+	}
+
 	function getToneMappingFunction( functionName, toneMapping ) {
 		var toneMappingName;
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -27,9 +27,9 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 		"alphaTest", "doubleSided", "flipSided"
 	];
 
-	var supportedSlots = THREE.TextureSlot.SupportedSlotNames;
-	for( var i = 0; i < supportedSlots.length; i ++ ) {
-		var name = supportedSlots[i];
+	var supportedMaps = THREE.Map.SupportedMapNames;
+	for( var i = 0; i < supportedMaps.length; i ++ ) {
+		var name = supportedMaps[i];
 		parameterNames.push( name );
 		parameterNames.push( name + 'UVChannel' );
 		parameterNames.push( name + 'UVTransform' );
@@ -180,18 +180,18 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 
 		};
 
-		var supportedSlots = THREE.TextureSlot.SupportedSlotNames;
+		var supportedMapNames = THREE.Map.SupportedMapNames;
 
-		for( var i = 0; i < supportedSlots.length; i ++ ) {
-			var name = supportedSlots[i];
+		for( var i = 0; i < supportedMapNames.length; i ++ ) {
+			var mapName = supportedMapNames[i];
 			// backwards compatibility
-			parameters[name] = !! material[ name ];
+			parameters[mapName] = !! material[ mapName ];
 
 			// new functional for slot-based maps
-			var slot = material[ name + 'Slot' ];
-			parameters[name + "UVChannel" ] = ( slot !== undefined ) ? slot.uvChannel : 0;
-			parameters[name + "UVTransform" ] = ( slot !== undefined ) ? slot.uvTransform : false;
-			parameters[name + "TexelTransform" ] = ( slot !== undefined ) ? slot.texelTransform : false;
+			var map = material[ mapName + 'Slot' ];
+			parameters[mapName + "UVChannel" ] = ( map !== undefined ) ? map.uvChannel : 0;
+			parameters[mapName + "UVTransform" ] = ( map !== undefined ) ? map.uvTransform : false;
+			parameters[mapName + "TexelTransform" ] = ( map !== undefined ) ? map.texelTransform : false;
 		}
 
 		return parameters;

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -14,7 +14,7 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 		PointsMaterial: 'points'
 	};
 
-	var slots = [
+	var supportedSlots = [
 		'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap'
 	];
 
@@ -31,8 +31,8 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 		"alphaTest", "doubleSided", "flipSided"
 	];
 
-	for( var i = 0; i < slots.length; i ++ ) {
-		var name = slots[i];
+	for( var i = 0; i < supportedSlots.length; i ++ ) {
+		var name = supportedSlots[i];
 		parameterNames.push( name );
 		parameterNames.push( name + 'UVChannel' );
 		parameterNames.push( name + 'UVTransform' );
@@ -183,8 +183,8 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 
 		};
 
-		for( var i = 0; i < slots.length; i ++ ) {
-			var name = slots[i];
+		for( var i = 0; i < supportedSlots.length; i ++ ) {
+			var name = supportedSlots[i];
 			// backwards compatibility
 			parameters[name] = !! material[ name ];
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -14,10 +14,6 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 		PointsMaterial: 'points'
 	};
 
-	var supportedSlots = [
-		'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap'
-	];
-
 	var parameterNames = [
 		"precision", "supportsVertexTextures", "mapEncoding", "envMap", "envMapMode", "envMapEncoding",
 		"emissiveMapEncoding",
@@ -31,6 +27,7 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 		"alphaTest", "doubleSided", "flipSided"
 	];
 
+	var supportedSlots = THREE.TextureSlot.SupportedSlotNames;
 	for( var i = 0; i < supportedSlots.length; i ++ ) {
 		var name = supportedSlots[i];
 		parameterNames.push( name );
@@ -182,6 +179,8 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 			flipSided: material.side === THREE.BackSide
 
 		};
+
+		var supportedSlots = THREE.TextureSlot.SupportedSlotNames;
 
 		for( var i = 0; i < supportedSlots.length; i ++ ) {
 			var name = supportedSlots[i];

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -14,11 +14,14 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 		PointsMaterial: 'points'
 	};
 
+	var slots = [
+		'map', 'lightMap', 'aoMap', 'emissiveMap', 'specularMap', 'bumpMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'alphaMap'
+	];
+
 	var parameterNames = [
-		"precision", "supportsVertexTextures", "map", "mapEncoding", "envMap", "envMapMode", "envMapEncoding",
-		"lightMap", "aoMap", "emissiveMap", "emissiveMapEncoding", "bumpMap", "normalMap", "displacementMap", "specularMap",
-		"roughnessMap", "metalnessMap",
-		"alphaMap", "combine", "vertexColors", "fog", "useFog", "fogExp",
+		"precision", "supportsVertexTextures", "mapEncoding", "envMap", "envMapMode", "envMapEncoding",
+		"emissiveMapEncoding",
+		"combine", "vertexColors", "fog", "useFog", "fogExp",
 		"flatShading", "sizeAttenuation", "logarithmicDepthBuffer", "skinning",
 		"maxBones", "useVertexTexture", "morphTargets", "morphNormals",
 		"maxMorphTargets", "maxMorphNormals", "premultipliedAlpha",
@@ -28,6 +31,13 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 		"alphaTest", "doubleSided", "flipSided"
 	];
 
+	for( var i = 0; i < slots.length; i ++ ) {
+		var name = slots[i];
+		parameterNames.push( name );
+		parameterNames.push( name + 'UVChannel' );
+		parameterNames.push( name + 'UVTransform' );
+		parameterNames.push( name + 'TexelTransform' );
+	}
 
 	function allocateBones ( object ) {
 
@@ -125,23 +135,12 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 			precision: precision,
 			supportsVertexTextures: capabilities.vertexTextures,
 			outputEncoding: getTextureEncodingFromMap( renderer.getCurrentRenderTarget(), renderer.gammaOutput ),
-			map: !! material.map,
 			mapEncoding: getTextureEncodingFromMap( material.map, renderer.gammaInput ),
-			envMap: !! material.envMap,
+			envMap: !!material.envMap,
 			envMapMode: material.envMap && material.envMap.mapping,
 			envMapEncoding: getTextureEncodingFromMap( material.envMap, renderer.gammaInput ),
 			envMapCubeUV: ( !! material.envMap ) && ( ( material.envMap.mapping === THREE.CubeUVReflectionMapping ) || ( material.envMap.mapping === THREE.CubeUVRefractionMapping ) ),
-			lightMap: !! material.lightMap,
-			aoMap: !! material.aoMap,
-			emissiveMap: !! material.emissiveMap,
 			emissiveMapEncoding: getTextureEncodingFromMap( material.emissiveMap, renderer.gammaInput ),
-			bumpMap: !! material.bumpMap,
-			normalMap: !! material.normalMap,
-			displacementMap: !! material.displacementMap,
-			roughnessMap: !! material.roughnessMap,
-			metalnessMap: !! material.metalnessMap,
-			specularMap: !! material.specularMap,
-			alphaMap: !! material.alphaMap,
 
 			combine: material.combine,
 
@@ -183,6 +182,18 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 			flipSided: material.side === THREE.BackSide
 
 		};
+
+		for( var i = 0; i < slots.length; i ++ ) {
+			var name = slots[i];
+			// backwards compatibility
+			parameters[name] = !! material[ name ];
+
+			// new functional for slot-based maps
+			var slot = material[ name + 'Slot' ];
+			parameters[name + "UVChannel" ] = ( slot !== undefined ) ? slot.uvChannel : 0;
+			parameters[name + "UVTransform" ] = ( slot !== undefined ) ? slot.uvTransform : false;
+			parameters[name + "TexelTransform" ] = ( slot !== undefined ) ? slot.texelTransform : false;
+		}
 
 		return parameters;
 

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -187,6 +187,8 @@
 	"src/renderers/shaders/ShaderChunk/skinnormal_vertex.glsl",
 	"src/renderers/shaders/ShaderChunk/specularmap_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/specularmap_pars_fragment.glsl",
+	"src/renderers/shaders/ShaderChunk/slot_texel_transform_template.glsl",
+	"src/renderers/shaders/ShaderChunk/slot_uv_transform_template.glsl",
 	"src/renderers/shaders/ShaderChunk/tonemapping_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/uv2_pars_fragment.glsl",

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -82,7 +82,7 @@
 	"src/loaders/CubeTextureLoader.js",
 	"src/loaders/BinaryTextureLoader.js",
 	"src/loaders/CompressedTextureLoader.js",
-	"src/materials/TextureSlot.js",
+	"src/materials/Map.js",
 	"src/materials/Material.js",
 	"src/materials/LineBasicMaterial.js",
 	"src/materials/LineDashedMaterial.js",

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -82,6 +82,7 @@
 	"src/loaders/CubeTextureLoader.js",
 	"src/loaders/BinaryTextureLoader.js",
 	"src/loaders/CompressedTextureLoader.js",
+	"src/materials/TextureSlot.js",
 	"src/materials/Material.js",
 	"src/materials/LineBasicMaterial.js",
 	"src/materials/LineDashedMaterial.js",


### PR DESCRIPTION
This introduces the idea of TextureSlots to Materials in a fully backwards compatible fashion (excluding likely a bug here or there.)  TextureSlots allow per-mat per-Material UV channels, UV offset/repeat, and texel scale/offset/invert.

This addresses the very common issue, see #5876, #7826, #7956 and #3549, besides just being broadlly useful.  I have implemented something like this in the Clara.io private ThreeJS branch, this is my attempt to polish that code and bring it back into ThreeJS proper.

What this PR does is replace the direct maps on MeshStandardMaterial with TextureSlots.  TextureSlot is a new class that can contain a texture as well as its UV Channel, an optional UV transform (offset, repeat) and an optional scalar Texel transform (scale, offset.)

This allows one to set the UV channel you want a map to follow.  It defaults to the previously ThreeJS defaults.

This also allows one to set the UV offset/repeat on a per map basis, if TextureSlot.uvTransform is set to true.  It no longer needs to be based on the textures repeat/offset.  Although I have written it so that the per map UV offset/repeat is applied along with the per-texture offset/repeat so that the previous workflows still work.

It also allows one to offset, scale and invert the resulting texel value if TextureSlot.texelTransform is set to true.  This is replaces the need for bumpScale, lightMapIntensity, displacementScale, displacementBias, and generally is very useful.

The idea of texture slots was relatively easy to support because it's uniform organization allows one to create for loops in various places in order to process them.

This PR is a rough one, and so far only applied to MeshStandardMaterial, but the design is there and if we can support getting this into dev this I can expand support of TextureSlots to the other materials.

This PR is smart about only including sampler2D, varyings, and uniforms into the resulting shaders if they are needed.  Thus it is very efficient in that sense, and if TextureSlots capabilities are not used, they do not add any additional uniforms.

/ping @QuaziKb @huttarl @Monokai @jcarpenter @titansoftime @Zob1 @benaadams @endel @karimbeyrouti @rhys-vdw (You guys requested this feature previously)
