### PR TITLE
Faster cube uv envmaps

### DIFF
--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
@@ -43,9 +43,16 @@ const float cubeUV_rcpTextureSize = 1.0 / float(CUBE_UV_TEXTURE_SIZE);
 vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
     mipLevel = roughnessLevel > cubeUV_maxLods2 - 3.0 ? 0.0 : mipLevel;
     float a = 16.0 * cubeUV_rcpTextureSize;
-    float powScale = exp2(roughnessLevel + mipLevel);
-    float scale = 1.0/exp2(roughnessLevel + 2.0 + mipLevel);
-    float mipOffset = 0.75*(1.0 - 1.0/exp2(mipLevel))/exp2(roughnessLevel);
+
+    vec2 exp2_packed = exp2( vec2( roughnessLevel, mipLevel ) );
+    vec2 rcp_exp2_packed = vec2( 1.0 ) / exp2_packed;
+    // float powScale = exp2(roughnessLevel + mipLevel);
+    float powScale = exp2_packed.x * exp2_packed.y;
+    // float scale =  1.0 / exp2(roughnessLevel + 2.0 + mipLevel);
+    float scale = rcp_exp2_packed.x * rcp_exp2_packed.y * 0.25;
+    // float mipOffset = 0.75*(1.0 - 1.0/exp2(mipLevel))/exp2(roughnessLevel);
+    float mipOffset = 0.75*(1.0 - rcp_exp2_packed.y) * rcp_exp2_packed.x;
+
     bool bRes = mipLevel == 0.0;
     scale =  bRes && (scale < a) ? a : scale;
 

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
@@ -108,6 +108,7 @@ vec4 textureCubeUV(vec3 reflectedDirection, float roughness, float textureSize) 
     level1 = level1 > 5.0 ? 5.0 : level1;
 
 #if defined( DISABLE_CUBE_UV_MIPMAP_INTERPOLATION )
+    // round to nearest mipmap if we are not interpolating.
     level0 += min( floor( s + 0.5 ), 5.0 );
 #endif
 
@@ -118,7 +119,7 @@ vec4 textureCubeUV(vec3 reflectedDirection, float roughness, float textureSize) 
     vec2 uv_20 = getCubeUV(reflectedDirection, r2, level0, textureSize);
     vec4 color20 = envMapTexelToLinear(texture2D(envMap, uv_20));
 
-    vec4 result = mix(color10 , color20,  t);
+    vec4 result = mix(color10, color20, t);
 
 #if ! defined( DISABLE_CUBE_UV_MIPMAP_INTERPOLATION )
 
@@ -128,16 +129,12 @@ vec4 textureCubeUV(vec3 reflectedDirection, float roughness, float textureSize) 
     vec2 uv_21 = getCubeUV(reflectedDirection, r2, level1, textureSize);
     vec4 color21 = envMapTexelToLinear(texture2D(envMap, uv_21));
 
-    vec4 c2 = mix(color11 , color21,  t);
-    result = mix(result , c2,  s);
+    vec4 c2 = mix(color11, color21, t);
+    result = mix(result, c2, s);
 
 #endif
-/*
-    vec4 c1 = mix(color10 , color11,  s);
-    vec4 c2 = mix(color20 , color21,  s);
-    vec4 c3 = mix(c1 , c2,  t);*/
 
-    return vec4( result.rgb, 1.0);
+    return vec4(result.rgb, 1.0);
 }
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
@@ -108,7 +108,7 @@ vec4 textureCubeUV(vec3 reflectedDirection, float roughness, float textureSize) 
     level1 = level1 > 5.0 ? 5.0 : level1;
 
 #if defined( DISABLE_CUBE_UV_MIPMAP_INTERPOLATION )
-    level0 += min( floor( s + 1.0 ), 5.0 );
+    level0 += min( floor( s + 0.5 ), 5.0 );
 #endif
 
     // Tri linear interpolation.
@@ -130,14 +130,14 @@ vec4 textureCubeUV(vec3 reflectedDirection, float roughness, float textureSize) 
 
     vec4 c2 = mix(color11 , color21,  t);
     result = mix(result , c2,  s);
-    
+
 #endif
 /*
     vec4 c1 = mix(color10 , color11,  s);
     vec4 c2 = mix(color20 , color21,  s);
     vec4 c3 = mix(c1 , c2,  t);*/
 
-    return vec4(result.rgb, 1.0);
+    return vec4( result.rgb, 1.0);
 }
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
@@ -21,26 +21,28 @@ int getFaceFromDirection(vec3 direction) {
     }
     return face;
 }
+const float cubeUV_maxLods1 = log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 1.0;
+const float cubeUV_rangeClamp = exp2((6.0 - 1.0) * 2.0);
 
 vec2 MipLevelInfo( vec3 vec, float roughnessLevel, float roughness ) {
-    float s = log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 1.0;
-    float scale = exp2(s - roughnessLevel);
+    float scale = exp2(cubeUV_maxLods1 - roughnessLevel);
     float dxRoughness = dFdx(roughness);
     float dyRoughness = dFdy(roughness);
     vec3 dx = dFdx( vec * scale * dxRoughness );
     vec3 dy = dFdy( vec * scale * dyRoughness );
     float d = max( dot( dx, dx ), dot( dy, dy ) );
     // Clamp the value to the max mip level counts. hard coded to 6 mips
-    float rangeClamp = exp2((6.0 - 1.0) * 2.0);
-    d = clamp(d, 1.0, rangeClamp);
+    d = clamp(d, 1.0, cubeUV_rangeClamp);
     float mipLevel = 0.5 * log2(d);
     return vec2(floor(mipLevel), fract(mipLevel));
 }
 
+const float cubeUV_maxLods2 = log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 2.0;
+const float cubeUV_rcpTextureSize = 1.0 / float(CUBE_UV_TEXTURE_SIZE);
+
 vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
-    float maxLods = log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 2.0;
-    mipLevel = roughnessLevel > maxLods - 3.0 ? 0.0 : mipLevel;
-    float a = 16.0/float(CUBE_UV_TEXTURE_SIZE);
+    mipLevel = roughnessLevel > cubeUV_maxLods2 - 3.0 ? 0.0 : mipLevel;
+    float a = 16.0 * cubeUV_rcpTextureSize;
     float powScale = exp2(roughnessLevel + mipLevel);
     float scale = 1.0/exp2(roughnessLevel + 2.0 + mipLevel);
     float mipOffset = 0.75*(1.0 - 1.0/exp2(mipLevel))/exp2(roughnessLevel);
@@ -84,7 +86,7 @@ vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
         offset.y = bRes && (offset.y < 2.0*a) ?  0.0 : offset.y;
     }
     r = normalize(r);
-    float texelOffset = 0.5/float(CUBE_UV_TEXTURE_SIZE);
+    float texelOffset = 0.5 * cubeUV_rcpTextureSize;
     float s1 = (r.y/abs(r.x) + 1.0)*0.5;
     float s2 = (r.z/abs(r.x) + 1.0)*0.5;
     vec2 uv = offset + vec2(s1, s2) * scale;
@@ -99,9 +101,10 @@ vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
     return uv;
 }
 
+const float cubeUV_maxLods3 = log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 3.0;
+
 vec4 textureCubeUV(vec3 reflectedDirection, float roughness ) {
-    float maxLods =  log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 3.0;
-    float roughnessVal = roughness*maxLods;
+    float roughnessVal = roughness* cubeUV_maxLods3;
     float r1 = floor(roughnessVal);
     float r2 = r1 + 1.0;
     float t = fract(roughnessVal);

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
@@ -94,18 +94,9 @@ vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
     }
     r = normalize(r);
     float texelOffset = 0.5 * cubeUV_rcpTextureSize;
-    float s1 = (r.y/abs(r.x) + 1.0)*0.5;
-    float s2 = (r.z/abs(r.x) + 1.0)*0.5;
-    vec2 uv = offset + vec2(s1, s2) * scale;
-    float min_x = offset.x + texelOffset;
-    float max_x = offset.x + scale - texelOffset;
-    float min_y = offset.y + texelOffset;
-    float max_y = offset.y + scale - texelOffset;
-    float delx = max_x - min_x;
-    float dely = max_y - min_y;
-    uv.x = min_x + s1*delx;
-    uv.y = min_y + s2*dely;
-    return uv;
+    vec2 s = ( r.yz / abs( r.x ) + vec2( 1.0 ) ) * 0.5;
+    vec2 base = offset + vec2( texelOffset );
+    return base + s * ( scale - 2.0 * texelOffset );
 }
 
 const float cubeUV_maxLods3 = log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 3.0;

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
@@ -2,7 +2,7 @@
 
 #ifdef ENVMAP_TYPE_CUBE_UV
 
-#define CUBE_UV_TEXTURE_SIZE 1024
+const float cubeUV_textureSize = 1024.0;
 
 int getFaceFromDirection(vec3 direction) {
     vec3 absDirection = abs(direction);
@@ -21,7 +21,7 @@ int getFaceFromDirection(vec3 direction) {
     }
     return face;
 }
-const float cubeUV_maxLods1 = log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 1.0;
+const float cubeUV_maxLods1 = log2(cubeUV_textureSize*0.25) - 1.0;
 const float cubeUV_rangeClamp = exp2((6.0 - 1.0) * 2.0);
 
 vec2 MipLevelInfo( vec3 vec, float roughnessLevel, float roughness ) {
@@ -37,8 +37,8 @@ vec2 MipLevelInfo( vec3 vec, float roughnessLevel, float roughness ) {
     return vec2(floor(mipLevel), fract(mipLevel));
 }
 
-const float cubeUV_maxLods2 = log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 2.0;
-const float cubeUV_rcpTextureSize = 1.0 / float(CUBE_UV_TEXTURE_SIZE);
+const float cubeUV_maxLods2 = log2(cubeUV_textureSize*0.25) - 2.0;
+const float cubeUV_rcpTextureSize = 1.0 / cubeUV_textureSize;
 
 vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
     mipLevel = roughnessLevel > cubeUV_maxLods2 - 3.0 ? 0.0 : mipLevel;
@@ -99,7 +99,7 @@ vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
     return base + s * ( scale - 2.0 * texelOffset );
 }
 
-const float cubeUV_maxLods3 = log2(float(CUBE_UV_TEXTURE_SIZE)*0.25) - 3.0;
+const float cubeUV_maxLods3 = log2(cubeUV_textureSize*0.25) - 3.0;
 
 vec4 textureCubeUV(vec3 reflectedDirection, float roughness ) {
     float roughnessVal = roughness* cubeUV_maxLods3;

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
@@ -1,5 +1,3 @@
-#define DISABLE_CUBE_UV_MIPMAP_INTERPOLATION
-
 #ifdef ENVMAP_TYPE_CUBE_UV
 
 const float cubeUV_textureSize = 1024.0;
@@ -112,10 +110,8 @@ vec4 textureCubeUV(vec3 reflectedDirection, float roughness ) {
     float level1 = level0 + 1.0;
     level1 = level1 > 5.0 ? 5.0 : level1;
 
-#if defined( DISABLE_CUBE_UV_MIPMAP_INTERPOLATION )
     // round to nearest mipmap if we are not interpolating.
     level0 += min( floor( s + 0.5 ), 5.0 );
-#endif
 
     // Tri linear interpolation.
     vec2 uv_10 = getCubeUV(reflectedDirection, r1, level0);
@@ -125,19 +121,6 @@ vec4 textureCubeUV(vec3 reflectedDirection, float roughness ) {
     vec4 color20 = envMapTexelToLinear(texture2D(envMap, uv_20));
 
     vec4 result = mix(color10, color20, t);
-
-#if ! defined( DISABLE_CUBE_UV_MIPMAP_INTERPOLATION )
-
-    vec2 uv_11 = getCubeUV(reflectedDirection, r1, level1);
-    vec4 color11 = envMapTexelToLinear(texture2D(envMap, uv_11));
-
-    vec2 uv_21 = getCubeUV(reflectedDirection, r2, level1);
-    vec4 color21 = envMapTexelToLinear(texture2D(envMap, uv_21));
-
-    vec4 c2 = mix(color11, color21, t);
-    result = mix(result, c2, s);
-
-#endif
 
     return vec4(result.rgb, 1.0);
 }

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -182,7 +182,7 @@
 		#elif defined( ENVMAP_TYPE_CUBE_UV )
 
 				vec3 queryVec = flipNormal * vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
-				vec4 envMapColor = textureCubeUV(queryVec, 1.0, 1024.0);
+				vec4 envMapColor = textureCubeUV(queryVec, 1.0);
 
 		#else
 
@@ -253,7 +253,7 @@
 		#elif defined( ENVMAP_TYPE_CUBE_UV )
 
 			vec3 queryReflectVec = flipNormal * vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
-			vec4 envMapColor = textureCubeUV(queryReflectVec, BlinnExponentToGGXRoughness(blinnShininessExponent), 1024.0);
+			vec4 envMapColor = textureCubeUV(queryReflectVec, BlinnExponentToGGXRoughness(blinnShininessExponent));
 
 		#elif defined( ENVMAP_TYPE_EQUIREC )
 


### PR DESCRIPTION
This PR adds a flag, DISABLE_CUBE_UV_MIPMAP_INTERPOLATION, into the cube_uv_reflection_fragment.glsl that disables mipmap interpolation.  This halves the complexity of this part shader in terms of code as well as number of texel fetches while keeping quality roughly the same -- I can not tell the difference in the current examples.

We have had reports over the last few days that the cube_uv_reflection_fragment shader was too intense for some older MBPs who relied on Intel GPUs to drive retina displays - thx @mattdesl, and @wvl.  This should help with that and other lower end devices driving high resolution displays.

This easy fix was suggested by @spidersharma03.
