### PR TITLE
Expanding documentation for api/object/LineSegments

### DIFF
--- a/docs/api/objects/LineSegments.html
+++ b/docs/api/objects/LineSegments.html
@@ -12,7 +12,7 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A series of lines.</div>
+		<div class="desc">A series of lines drawn between pairs of vertices.</div>
 
 
 		<h2>Constructor</h2>
@@ -20,7 +20,7 @@
 		<h3>[name]( [page:Geometry geometry], [page:Material material] )</h3>
 
 		<div>
-		geometry — Vertices representing the line segment(s).<br />
+		geometry — Pair(s) of vertices representing each line segment(s).<br />
 		material — Material for the line. Default is [page:LineBasicMaterial LineBasicMaterial].
 		</div>
 
@@ -31,7 +31,7 @@
 
 		<h3>[property:Geometry geometry]</h3>
 		<div>
-		Vertices representing the line segment(s).
+		Pair(s) of vertices representing the line segment(s).
 		</div>
 
 		<h3>[property:Material material]</h3>


### PR DESCRIPTION
I had been wrestling with a problem for a few days regarding how to draw only certain lines when creating a line, and the documentation was not entirely clear about how `THREE.LineSegments` really differed from `THREE.Line`, nor were there decent examples of this after extensive googling.

Finally found an answer after asking SO: http://stackoverflow.com/questions/35759623/removing-linesegments-from-line

And now we're good! 

As such, I've updated the docs for `THREE.LineSegments` to be at least a little more clear with how line segments are assembled in Three.js. Very small and simple change, but I think it was necessary for clarity.
