### PR TITLE
Add getShaderPrecisionFormat polyfill

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -221,6 +221,20 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
+	if ( _gl.getShaderPrecisionFormat === undefined ) {
+
+		_gl.getShaderPrecisionFormat = function () {
+
+			return {
+				'rangeMin': 1,
+				'rangeMax': 1,
+				'precision': 1
+			};
+
+		}
+
+	}
+
 	var capabilities = new THREE.WebGLCapabilities( _gl, extensions, parameters );
 
 	var state = new THREE.WebGLState( _gl, extensions, paramThreeToGL );


### PR DESCRIPTION
#8264

"has no method 'getShaderPrecisionFormat'" issue was solved
on his Android 4 with this change.

His Android 4.4 works now.
His Android 4.1.2 is facing a new problem "shader compile error"
but it should be another issue.

Note:
With this change, renderer.precision will be 'highp' on
non-getShaderPrecisionFormat-support environment
unless explicitly pass the precision parameter on
WebGLRenderer instance creation like this
"new THREE.WebGLRenderer({precision: 'mediump'});"
