### PR TITLE
Replace three.min.js in introduction docs

### DIFF
--- a/docs/manual/introduction/Creating-a-scene.html
+++ b/docs/manual/introduction/Creating-a-scene.html
@@ -19,7 +19,7 @@
 		<div>Three.js is a library that makes WebGL - 3D in the browser - easy to use. While a simple cube in raw WebGL would turn out hundreds of lines of Javascript and shader code, a Three.js equivalent is only a fraction of that.</div>
 
 		<h2>Before we start</h2>
-		<div>Before you can use Three.js, you need somewhere to display it. Save the following HTML to a file on your computer, along with a copy of <a href="http://threejs.org/build/three.min.js">three.min.js</a> in the js/ directory, and open it in your browser.</div>
+		<div>Before you can use Three.js, you need somewhere to display it. Save the following HTML to a file on your computer, along with a copy of <a href="http://threejs.org/build/three.js">three.js</a> in the js/ directory, and open it in your browser.</div>
 
 		<code>
 		&lt;!DOCTYPE html&gt;
@@ -33,7 +33,7 @@
 				&lt;/style&gt;
 			&lt;/head&gt;
 			&lt;body&gt;
-				&lt;script src="js/three.min.js"&gt;&lt;/script&gt;
+				&lt;script src="js/three.js"&gt;&lt;/script&gt;
 				&lt;script&gt;
 					// Our Javascript will go here.
 				&lt;/script&gt;
@@ -132,7 +132,7 @@
 				&lt;/style&gt;
 			&lt;/head&gt;
 			&lt;body&gt;
-				&lt;script src="js/three.min.js"&gt;&lt;/script&gt;
+				&lt;script src="js/three.js"&gt;&lt;/script&gt;
 				&lt;script&gt;
 					var scene = new THREE.Scene();
 					var camera = new THREE.PerspectiveCamera( 75, window.innerWidth/window.innerHeight, 0.1, 1000 );


### PR DESCRIPTION
Replace three.min.js with non-minified version in the "create your first scene" introduction. 
Continuing from there beginners will have a hard time debugging their code using the minified version.
