### PR TITLE
Update OBJLoader.js

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -230,7 +230,7 @@ THREE.OBJLoader.prototype = {
 
 			var result;
 
-			if ( line.length === 0 || line.charAt( 0 ) === '#' ) {
+			if ( line.length === 0 || line.charAt( 0 ) === '#' line === "o") {
 
 				continue;
 


### PR DESCRIPTION
Here is the opening excerpt of the offending obj file:

```
o
v -325.6124572753907 -223.91587829589835 -164.99999999999997
v -325.4824523925782 -199.2478485107421 -164.99999999999997
v -353.73703002929693 -199.97297668457023 -164.99999999999997
v -353.73703002929693 -199.97297668457023 -164.99999999999997
v -353.9272766113282 -224.9038543701171 -164.99999999999997
v -325.6124572753907 -223.91587829589835 -164.99999999999997
v -353.73703002929693 -199.97297668457026 -329.9999976158142
v -325.4824523925782 -199.24784851074213 -329.9999976158142
v -325.6124572753907 -223.91587829589838 -329.9999976158142....
```

As far as I can tell, from reading the obj specification, the name line starting with "o" followed by nothing is legal.

This leads to the line being trimmed at line 229 with no pattern as expected at line 303 in the conditional which determines if the object should be named. Since this exception fails, there's no alternative for the flow but to bottom out at line 340 with a throw.

The proposed fix causes the blank name to be ignored. Incidentally it's the Three.js examples obj exporter (OBJExporter.js) which creates obj files without a name when a mesh indeed has no name. I was tempted to pull request the exporter instead, but as I mentioned, the obj specification does not disallow a blank name.
