### PR TITLE
Update OBJLoader.js to parse blank named objects and groups

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -306,7 +306,7 @@ THREE.OBJLoader.prototype = {
 				// or
 				// g group_name
 
-				var name = result[ 0 ].substr(1).trim();
+				var name = result[ 0 ].substr( 1 ).trim();
 
 				if ( foundObjects === false ) {
 

--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -215,7 +215,7 @@ THREE.OBJLoader.prototype = {
 		// f vertex//normal vertex//normal vertex//normal ...
 		var face_pattern4 = /^f\s+((-?\d+)\/\/(-?\d+))\s+((-?\d+)\/\/(-?\d+))\s+((-?\d+)\/\/(-?\d+))(?:\s+((-?\d+)\/\/(-?\d+)))?/;
 
-		var object_pattern = /^[og]\s+(.+)/;
+		var object_pattern = /^[og]\s*(.+)?/;
 
 		var smoothing_pattern = /^s\s+(\d+|on|off)/;
 
@@ -306,7 +306,7 @@ THREE.OBJLoader.prototype = {
 				// or
 				// g group_name
 
-				var name = result[ 1 ].trim();
+				var name = result[ 0 ].substr(1).trim();
 
 				if ( foundObjects === false ) {
 


### PR DESCRIPTION
.obj files allow named objects and polygon groups, but these names can sometimes be blank.

See https://github.com/mrdoob/three.js/pull/8296

Hopefully I'm doing this pull request thing correctly...
