### PR TITLE
Spherical coordinate class

### DIFF
--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -26,6 +26,7 @@ THREE.EditorControls = function ( object, domElement ) {
 	var normalMatrix = new THREE.Matrix3();
 	var pointer = new THREE.Vector2();
 	var pointerOld = new THREE.Vector2();
+	var spherical = new THREE.Spherical();
 
 	// events
 
@@ -86,15 +87,15 @@ THREE.EditorControls = function ( object, domElement ) {
 
 		vector.copy( object.position ).sub( center );
 
-		var spherical = new THREE.Spherical().fromVector3( vector );
+		spherical.fromVector3( vector );
 
 		spherical.theta += delta.x;
 		spherical.phi += delta.y;
 
 		spherical.makeSafe();
 
-		vector = spherical.toVector3();
-		
+		vector = spherical.toVector3( vector );
+
 		object.position.copy( center ).add( vector );
 
 		object.lookAt( center );

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -86,17 +86,15 @@ THREE.EditorControls = function ( object, domElement ) {
 
 		vector.copy( object.position ).sub( center );
 
-		var spherical = new THREE.Spherical().fromDirection( vector );
+		var spherical = new THREE.Spherical().fromVector3( vector );
 
 		spherical.theta += delta.x;
 		spherical.phi += delta.y;
 
 		spherical.makeSafe();
 
-		var radius = vector.length();
-
-		vector = spherical.direction().multiplyScalar( radius );
-
+		vector = spherical.toVector3();
+		
 		object.position.copy( center ).add( vector );
 
 		object.lookAt( center );

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -86,21 +86,16 @@ THREE.EditorControls = function ( object, domElement ) {
 
 		vector.copy( object.position ).sub( center );
 
-		var theta = Math.atan2( vector.x, vector.z );
-		var phi = Math.atan2( Math.sqrt( vector.x * vector.x + vector.z * vector.z ), vector.y );
+		var spherical = new THREE.Spherical().fromDirection( vector );
 
-		theta += delta.x;
-		phi += delta.y;
+		spherical.theta += delta.x;
+		spherical.phi += delta.y;
 
-		var EPS = 0.000001;
-
-		phi = Math.max( EPS, Math.min( Math.PI - EPS, phi ) );
+		spherical.makeSafe();
 
 		var radius = vector.length();
 
-		vector.x = radius * Math.sin( phi ) * Math.sin( theta );
-		vector.y = radius * Math.cos( phi );
-		vector.z = radius * Math.sin( phi ) * Math.cos( theta );
+		vector = spherical.direction().multiplyScalar( radius );
 
 		object.position.copy( center ).add( vector );
 

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -87,14 +87,14 @@ THREE.EditorControls = function ( object, domElement ) {
 
 		vector.copy( object.position ).sub( center );
 
-		spherical.fromVector3( vector );
+		spherical.setFromVector3( vector );
 
 		spherical.theta += delta.x;
 		spherical.phi += delta.y;
 
 		spherical.makeSafe();
 
-		vector = spherical.toVector3( vector );
+		vector.setFromSpherical( spherical );
 
 		object.position.copy( center ).add( vector );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -133,7 +133,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 			offset.applyQuaternion( quat );
 
 			// angle from z-axis around y-axis
-			spherical.fromDirection( offset );
+			spherical.fromVector3( offset );
 
 			if ( scope.autoRotate && state === STATE.NONE ) {
 
@@ -149,18 +149,18 @@ THREE.OrbitControls = function ( object, domElement ) {
 			// restrict phi to be between desired limits
 			spherical.phi = Math.max( scope.minPolarAngle, Math.min( scope.maxPolarAngle, spherical.phi ) );
 
-			// restrict phi to be betwee EPS and PI-EPS
-			spherical.phi = Math.max( EPS, Math.min( Math.PI - EPS, spherical.phi ) );
+			spherical.makeSafe();
 
-			var radius = offset.length() * scale;
+
+			spherical.radius *= scale;
 
 			// restrict radius to be between desired limits
-			radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, radius ) );
+			spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius ) );
 
 			// move target to panned location
 			scope.target.add( panOffset );
 
-			offset = spherical.direction( offset ).multiplyScalar( radius );
+			offset = spherical.toVector3( offset );
 
 			// rotate offset back to "camera-up-vector-is-up" space
 			offset.applyQuaternion( quatInverse );
@@ -175,7 +175,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			} else {
 
-				sphericalDelta.set( 0, 0 );
+				sphericalDelta.set( 0, 0, 0 );
 
 			}
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -133,7 +133,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 			offset.applyQuaternion( quat );
 
 			// angle from z-axis around y-axis
-			spherical.fromVector3( offset );
+			spherical.setFromVector3( offset );
 
 			if ( scope.autoRotate && state === STATE.NONE ) {
 
@@ -161,8 +161,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 			// move target to panned location
 			scope.target.add( panOffset );
 
-			offset = spherical.toVector3( offset );
-
+			offset.setFromSpherical( spherical );
+			
 			// rotate offset back to "camera-up-vector-is-up" space
 			offset.applyQuaternion( quatInverse );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -141,7 +141,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			}
 
-			spherical.add( sphericalDelta );
+			spherical.theta += sphericalDelta.theta;
+			spherical.phi += sphericalDelta.phi;
 
 			// restrict theta to be between desired limits
 			spherical.theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, spherical.theta ) );
@@ -171,7 +172,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			if ( scope.enableDamping === true ) {
 
-				sphericalDelta.multiplyScalar( 1 - scope.dampingFactor );
+				spherical.theta *= ( 1 - scope.dampingFactor );
+				spherical.phi *= ( 1 - scope.dampingFactor );
 
 			} else {
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -133,12 +133,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 			offset.applyQuaternion( quat );
 
 			// angle from z-axis around y-axis
-
-			theta = Math.atan2( offset.x, offset.z );
-
-			// angle from y-axis
-
-			phi = Math.atan2( Math.sqrt( offset.x * offset.x + offset.z * offset.z ), offset.y );
+			spherical.fromDirection( offset );
 
 			if ( scope.autoRotate && state === STATE.NONE ) {
 
@@ -146,17 +141,16 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			}
 
-			theta += thetaDelta;
-			phi += phiDelta;
+			spherical.add( sphericalDelta );
 
 			// restrict theta to be between desired limits
-			theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, theta ) );
+			spherical.theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, spherical.theta ) );
 
 			// restrict phi to be between desired limits
-			phi = Math.max( scope.minPolarAngle, Math.min( scope.maxPolarAngle, phi ) );
+			spherical.phi = Math.max( scope.minPolarAngle, Math.min( scope.maxPolarAngle, spherical.phi ) );
 
 			// restrict phi to be betwee EPS and PI-EPS
-			phi = Math.max( EPS, Math.min( Math.PI - EPS, phi ) );
+			spherical.phi = Math.max( EPS, Math.min( Math.PI - EPS, spherical.phi ) );
 
 			var radius = offset.length() * scale;
 
@@ -166,9 +160,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 			// move target to panned location
 			scope.target.add( panOffset );
 
-			offset.x = radius * Math.sin( phi ) * Math.sin( theta );
-			offset.y = radius * Math.cos( phi );
-			offset.z = radius * Math.sin( phi ) * Math.cos( theta );
+			offset = spherical.direction( offset ).multiplyScalar( radius );
 
 			// rotate offset back to "camera-up-vector-is-up" space
 			offset.applyQuaternion( quatInverse );
@@ -179,13 +171,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			if ( scope.enableDamping === true ) {
 
-				thetaDelta *= ( 1 - scope.dampingFactor );
-				phiDelta *= ( 1 - scope.dampingFactor );
+				sphericalDelta.multiplyScalar( 1 - scope.dampingFactor );
 
 			} else {
 
-				thetaDelta = 0;
-				phiDelta = 0;
+				sphericalDelta.set( 0, 0 );
 
 			}
 
@@ -254,11 +244,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 	var EPS = 0.000001;
 
 	// current position in spherical coordinates
-	var theta;
-	var phi;
+	var spherical = new THREE.Spherical();
+	var sphericalDelta = new THREE.Spherical();
 
-	var phiDelta = 0;
-	var thetaDelta = 0;
 	var scale = 1;
 	var panOffset = new THREE.Vector3();
 	var zoomChanged = false;
@@ -289,13 +277,13 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function rotateLeft( angle ) {
 
-		thetaDelta -= angle;
+		sphericalDelta.theta -= angle;
 
 	}
 
 	function rotateUp( angle ) {
 
-		phiDelta -= angle;
+		sphericalDelta.phi -= angle;
 
 	}
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -162,7 +162,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 			scope.target.add( panOffset );
 
 			offset.setFromSpherical( spherical );
-			
+
 			// rotate offset back to "camera-up-vector-is-up" space
 			offset.applyQuaternion( quatInverse );
 
@@ -172,8 +172,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			if ( scope.enableDamping === true ) {
 
-				spherical.theta *= ( 1 - scope.dampingFactor );
-				spherical.phi *= ( 1 - scope.dampingFactor );
+				sphericalDelta.theta *= ( 1 - scope.dampingFactor );
+				sphericalDelta.phi *= ( 1 - scope.dampingFactor );
 
 			} else {
 

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -9,7 +9,7 @@ THREE.Spherical = function ( phi, theta ) {
 	this.theta = ( theta !== undefined ) ? theta : 0; // around the equator of the sphere
 
 	return this;
-	
+
 };
 
 THREE.Spherical.prototype = {
@@ -54,6 +54,14 @@ THREE.Spherical.prototype = {
 
     return this;
   },
+
+	// restrict phi to be betwee EPS and PI-EPS
+	makeSafe: function() {
+
+		var EPS = 0.000001;
+		this.phi = Math.max( EPS, Math.min( Math.PI - EPS, this.phi ) );
+
+	},
 
   fromDirection: function( direction ) {
 

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -4,6 +4,9 @@
  *
  * Ref: https://en.wikipedia.org/wiki/Spherical_coordinate_system
  *
+ * The poles (phi) are at the positive and negative y axis.
+ * The equator starts at positive z.
+ *
  */
 
 THREE.Spherical = function ( radius, phi, theta ) {

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -55,7 +55,7 @@ THREE.Spherical.prototype = {
 
 	},
 
-  fromVector3: function( vec3 ) {
+  setFromVector3: function( vec3 ) {
 
 		this.radius = vec3.length();
 		if( this.radius === 0 ) {
@@ -64,25 +64,11 @@ THREE.Spherical.prototype = {
 		}
 		else {
     	this.theta = Math.atan2( vec3.x, vec3.z ); // equator angle around y-up axis
-    	this.phi = Math.acos( vec3.y / this.radius ); // polar angle
+    	this.phi = Math.acos( THREE.Math.clamp( vec3.y / this.radius, -1, 1 ) ); // polar angle
 		}
 
     return this;
 
   },
-
-  toVector3: function( optionalTarget ) {
-
-    var result = optionalTarget || new THREE.Vector3();
-		var sinPhiRadius = Math.sin( this.phi ) * this.radius;
-    result.set(
-      sinPhiRadius * Math.sin( this.theta ),
-      Math.cos( this.phi ) * this.radius,
-      sinPhiRadius * Math.cos( this.theta )
-    );
-
-    return result;
-
-  }
 
 };

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -1,0 +1,81 @@
+/**
+ * @author bhouston / http://clara.io
+ * @author WestLangley / http://github.com/WestLangley
+ */
+
+THREE.Spherical = function ( phi, theta ) {
+
+	this.phi = ( phi !== undefined ) ? phi : 0; // up / down towards top and bottom pole
+	this.theta = ( theta !== undefined ) ? theta : 0; // around the equator of the sphere
+
+	return this;
+	
+};
+
+THREE.Spherical.prototype = {
+
+	constructor: THREE.Spherical,
+
+	set: function ( phi, theta ) {
+
+    this.phi = phi;
+    this.theta = theta;
+
+  },
+
+	clone: function () {
+
+		return new this.constructor().copy( this );
+
+	},
+
+	copy: function ( other ) {
+
+		this.phi.copy( other.phi );
+		this.theta.copy( other.theta );
+
+		return this;
+
+	},
+
+  add: function ( other ) {
+
+    this.phi += other.phi;
+    this.theta += other.theta;
+
+    return this;
+
+  },
+
+  multiplyScalar: function( scalar ) {
+
+    this.phi *= scalar;
+    this.theta *= scalar;
+
+    return this;
+  },
+
+  fromDirection: function( direction ) {
+
+    this.theta = Math.atan2( direction.x, direction.z ); // equator angle around y-up axis
+    this.phi = Math.atan2( Math.sqrt( direction.x * direction.x + direction.z * direction.z ), direction.y ); // polar angle
+
+    return this;
+
+  },
+
+  direction: function( optionalTarget ) {
+
+    var result = optionalTarget || new THREE.Vector3();
+		var sinPhi = Math.sin( this.phi );
+    result.set(
+      sinPhi * Math.sin( this.theta ),
+      Math.cos( this.phi ),
+      sinPhi * Math.cos( this.theta )
+    );
+
+    return result;
+
+  }
+
+};

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -1,10 +1,14 @@
 /**
  * @author bhouston / http://clara.io
  * @author WestLangley / http://github.com/WestLangley
+ *
+ * Ref: https://en.wikipedia.org/wiki/Spherical_coordinate_system
+ *
  */
 
-THREE.Spherical = function ( phi, theta ) {
+THREE.Spherical = function ( radius, phi, theta ) {
 
+	this.radius = ( radius !== undefined ) ? radius : 1.0;
 	this.phi = ( phi !== undefined ) ? phi : 0; // up / down towards top and bottom pole
 	this.theta = ( theta !== undefined ) ? theta : 0; // around the equator of the sphere
 
@@ -16,8 +20,9 @@ THREE.Spherical.prototype = {
 
 	constructor: THREE.Spherical,
 
-	set: function ( phi, theta ) {
+	set: function ( radius, phi, theta ) {
 
+		this.radius = radius;
     this.phi = phi;
     this.theta = theta;
 
@@ -31,6 +36,7 @@ THREE.Spherical.prototype = {
 
 	copy: function ( other ) {
 
+		this.radius.copy( other.radius );
 		this.phi.copy( other.phi );
 		this.theta.copy( other.theta );
 
@@ -40,6 +46,7 @@ THREE.Spherical.prototype = {
 
   add: function ( other ) {
 
+		this.radius += other.radius;
     this.phi += other.phi;
     this.theta += other.theta;
 
@@ -49,6 +56,7 @@ THREE.Spherical.prototype = {
 
   multiplyScalar: function( scalar ) {
 
+		this.radius *= scalar;
     this.phi *= scalar;
     this.theta *= scalar;
 
@@ -63,23 +71,30 @@ THREE.Spherical.prototype = {
 
 	},
 
-  fromDirection: function( direction ) {
+  fromVector3: function( vec3 ) {
 
-    this.theta = Math.atan2( direction.x, direction.z ); // equator angle around y-up axis
-    this.phi = Math.atan2( Math.sqrt( direction.x * direction.x + direction.z * direction.z ), direction.y ); // polar angle
+		this.radius = vec3.length();
+		if( this.radius === 0 ) {
+			this.theta = 0;
+			this.phi = 0;
+		}
+		else {
+    	this.theta = Math.atan2( vec3.x, vec3.z ); // equator angle around y-up axis
+    	this.phi = Math.acos( vec3.y / this.radius ); // polar angle
+		}
 
     return this;
 
   },
 
-  direction: function( optionalTarget ) {
+  toVector3: function( optionalTarget ) {
 
     var result = optionalTarget || new THREE.Vector3();
-		var sinPhi = Math.sin( this.phi );
+		var sinPhiRadius = Math.sin( this.phi ) * this.radius;
     result.set(
-      sinPhi * Math.sin( this.theta ),
-      Math.cos( this.phi ),
-      sinPhi * Math.cos( this.theta )
+      sinPhiRadius * Math.sin( this.theta ),
+      Math.cos( this.phi ) * this.radius,
+      sinPhiRadius * Math.cos( this.theta )
     );
 
     return result;

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -47,25 +47,6 @@ THREE.Spherical.prototype = {
 
 	},
 
-  add: function ( other ) {
-
-		this.radius += other.radius;
-    this.phi += other.phi;
-    this.theta += other.theta;
-
-    return this;
-
-  },
-
-  multiplyScalar: function( scalar ) {
-
-		this.radius *= scalar;
-    this.phi *= scalar;
-    this.theta *= scalar;
-
-    return this;
-  },
-
 	// restrict phi to be betwee EPS and PI-EPS
 	makeSafe: function() {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -693,6 +693,17 @@ THREE.Vector3.prototype = {
 
 	},
 
+	setFromSpherical: function( s ) {
+
+		var sinPhiRadius = Math.sin( s.phi ) * s.radius;
+		this.x = sinPhiRadius * Math.sin( s.theta );
+		this.y = Math.cos( s.phi ) * s.radius;
+		this.z = sinPhiRadius * Math.cos( s.theta );
+
+		return this;
+
+	},
+
 	setFromMatrixPosition: function ( m ) {
 
 		this.x = m.elements[ 12 ];

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -15,6 +15,7 @@
 	"src/math/Sphere.js",
 	"src/math/Frustum.js",
 	"src/math/Plane.js",
+	"src/math/Spherical.js",
 	"src/math/Math.js",
 	"src/math/Spline.js",
 	"src/math/Triangle.js",


### PR DESCRIPTION
Just a quick little class that represents formally Spherical Coordinates in the standard form of radius, phi, theta per the Wikipedia definition:

https://en.wikipedia.org/wiki/Spherical_coordinate_system

It centralized some duplicate code used in both the OrbitControl and in the Editor.

I think it is useful, especially in the context of our needs at Clara.io, but I do understand that because it is related mostly to manipulators/controllers (that is our interest as well and the only places it is used in ThreeJS), that it may be best to put it into /examples/js/math or something rather than in the core library.
