### PR TITLE
New TorusKnotBufferGeometry

### DIFF
--- a/docs/api/extras/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/extras/geometries/TorusKnotBufferGeometry.html
@@ -29,17 +29,15 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Integer p], [page:Integer q], [page:Float heightScale], [page:Float arc])</h3>
+		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer tubularSegments], [page:Integer radialSegments], [page:Integer p], [page:Integer q])</h3>
 		<div>
 			<ul>
 				<li>radius — Default is 100.</li>
 				<li>tube — Diameter of the tube. Default is 40.</li>
-				<li>radialSegments — Default is 64.</li>
-				<li>tubularSegments — Default is 8.</li>
+				<li>tubularSegments — Default is 64.</li>
+				<li>radialSegments — Default is 8.</li>
 				<li>p — This value determines, how many times the geometry winds around its axis of rotational symmetry. Default is 2.</li>
 				<li>q — This value determines, how many times the geometry winds around a circle in the interior of the torus. Default is 3.</li>
-				<li>heightScale — Default is 1.</li>
-				<li>arc — Central angle.  Default is Math.PI * 2.</li>
 			</ul>
 		</div>
 

--- a/docs/api/extras/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/extras/geometries/TorusKnotBufferGeometry.html
@@ -8,18 +8,18 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Geometry] &rarr;
+		[page:BufferGeometry] &rarr;
 
 		<h1>[name]</h1>
 
-		<div class="desc">Creates a torus knot, the particular shape of which is defined by a pair of coprime integers, p and q.  If p and q are not coprime, the result will be a torus link.</div>
+		<div class="desc">This is the [page:BufferGeometry] port of [page:TorusKnotGeometry].</div>
 
-		<iframe src='scenes/geometry-browser.html#TorusKnotGeometry'></iframe>
+		<iframe src='scenes/geometry-browser.html#TorusKnotBufferGeometry'></iframe>
 
 
 		<h2>Example</h2>
 
-		<code>var geometry = new THREE.TorusKnotGeometry( 10, 3, 100, 16 );
+		<code>var geometry = new THREE.TorusKnotBufferGeometry( 10, 3, 100, 16 );
 		var material = new THREE.MeshBasicMaterial( { color: 0xffff00 } );
 		var torusKnot = new THREE.Mesh( geometry, material );
 		scene.add( torusKnot );

--- a/docs/api/extras/geometries/TorusKnotGeometry.html
+++ b/docs/api/extras/geometries/TorusKnotGeometry.html
@@ -29,17 +29,15 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Integer p], [page:Integer q], [page:Float heightScale], [page:Float arc])</h3>
+		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer tubularSegments], [page:Integer radialSegments], [page:Integer p], [page:Integer q])</h3>
 		<div>
 			<ul>
 				<li>radius — Default is 100.</li>
 				<li>tube — Diameter of the tube. Default is 40.</li>
-				<li>radialSegments — Default is 64.</li>
-				<li>tubularSegments — Default is 8.</li>
+				<li>tubularSegments — Default is 64.</li>
+				<li>radialSegments — Default is 8.</li>
 				<li>p — This value determines, how many times the geometry winds around its axis of rotational symmetry. Default is 2.</li>
 				<li>q — This value determines, how many times the geometry winds around a circle in the interior of the torus. Default is 3.</li>
-				<li>heightScale — Default is 1.</li>
-				<li>arc — Central angle.  Default is Math.PI * 2.</li>
 			</ul>
 		</div>
 

--- a/docs/list.js
+++ b/docs/list.js
@@ -215,6 +215,7 @@ var list = {
 			[ "TextGeometry", "api/extras/geometries/TextGeometry" ],
 			[ "TorusBufferGeometry", "api/extras/geometries/TorusBufferGeometry" ],
 			[ "TorusGeometry", "api/extras/geometries/TorusGeometry" ],
+			[ "TorusKnotBufferGeometry", "api/extras/geometries/TorusKnotBufferGeometry" ],
 			[ "TorusKnotGeometry", "api/extras/geometries/TorusKnotGeometry" ],
 			[ "TubeGeometry", "api/extras/geometries/TubeGeometry" ]
 		],

--- a/docs/scenes/js/geometry.js
+++ b/docs/scenes/js/geometry.js
@@ -752,20 +752,18 @@ var guis = {
 		var data = {
 			radius : 10,
 			tube : 3,
-			radialSegments : 64,
-			tubularSegments : 8,
+			tubularSegments : 64,
+			radialSegments : 8,
 			p : 2,
-			q : 3,
-			heightScale : 1,
-			arc : twoPi
+			q : 3
 		};
 
 		function generateGeometry() {
 
 			updateGroupGeometry( mesh,
 				new THREE.TorusKnotBufferGeometry(
-					data.radius, data.tube, data.radialSegments, data.tubularSegments,
-					data.p, data.q, data.heightScale, data.arc
+					data.radius, data.tube, data.tubularSegments, data.radialSegments,
+					data.p, data.q
 				)
 			);
 
@@ -775,12 +773,10 @@ var guis = {
 
 		folder.add( data, 'radius', 1, 20 ).onChange( generateGeometry );
 		folder.add( data, 'tube', 0.1, 10 ).onChange( generateGeometry );
-		folder.add( data, 'radialSegments', 3, 300 ).step( 1 ).onChange( generateGeometry );
-		folder.add( data, 'tubularSegments', 3, 20 ).step( 1 ).onChange( generateGeometry );
+		folder.add( data, 'tubularSegments', 3, 300 ).step( 1 ).onChange( generateGeometry );
+		folder.add( data, 'radialSegments', 3, 20 ).step( 1 ).onChange( generateGeometry );
 		folder.add( data, 'p', 1, 20 ).step( 1 ).onChange( generateGeometry );
 		folder.add( data, 'q', 1, 20 ).step( 1 ).onChange( generateGeometry );
-		folder.add( data, 'heightScale', 1, 20 ).onChange( generateGeometry );
-		folder.add( data, 'arc', 0.1, twoPi ).onChange( generateGeometry );
 
 		generateGeometry();
 
@@ -791,20 +787,18 @@ var guis = {
 		var data = {
 			radius : 10,
 			tube : 3,
-			radialSegments : 64,
-			tubularSegments : 8,
+			tubularSegments : 64,
+			radialSegments : 8,
 			p : 2,
-			q : 3,
-			heightScale : 1,
-			arc : twoPi
+			q : 3
 		};
 
 		function generateGeometry() {
 
 			updateGroupGeometry( mesh,
 				new THREE.TorusKnotGeometry(
-					data.radius, data.tube, data.radialSegments, data.tubularSegments,
-					data.p, data.q, data.heightScale, data.arc
+					data.radius, data.tube, data.tubularSegments, data.radialSegments,
+					data.p, data.q
 				)
 			);
 
@@ -814,12 +808,10 @@ var guis = {
 
 		folder.add( data, 'radius', 1, 20 ).onChange( generateGeometry );
 		folder.add( data, 'tube', 0.1, 10 ).onChange( generateGeometry );
-		folder.add( data, 'radialSegments', 3, 300 ).step( 1 ).onChange( generateGeometry );
-		folder.add( data, 'tubularSegments', 3, 20 ).step( 1 ).onChange( generateGeometry );
+		folder.add( data, 'tubularSegments', 3, 300 ).step( 1 ).onChange( generateGeometry );
+		folder.add( data, 'radialSegments', 3, 20 ).step( 1 ).onChange( generateGeometry );
 		folder.add( data, 'p', 1, 20 ).step( 1 ).onChange( generateGeometry );
 		folder.add( data, 'q', 1, 20 ).step( 1 ).onChange( generateGeometry );
-		folder.add( data, 'heightScale', 1, 20 ).onChange( generateGeometry );
-		folder.add( data, 'arc', 0.1, twoPi ).onChange( generateGeometry );
 
 		generateGeometry();
 

--- a/docs/scenes/js/geometry.js
+++ b/docs/scenes/js/geometry.js
@@ -747,6 +747,45 @@ var guis = {
 
 	},
 
+	TorusKnotBufferGeometry : function( mesh ) {
+
+		var data = {
+			radius : 10,
+			tube : 3,
+			radialSegments : 64,
+			tubularSegments : 8,
+			p : 2,
+			q : 3,
+			heightScale : 1,
+			arc : twoPi
+		};
+
+		function generateGeometry() {
+
+			updateGroupGeometry( mesh,
+				new THREE.TorusKnotBufferGeometry(
+					data.radius, data.tube, data.radialSegments, data.tubularSegments,
+					data.p, data.q, data.heightScale, data.arc
+				)
+			);
+
+		}
+
+		var folder = gui.addFolder( 'THREE.TorusKnotBufferGeometry' );
+
+		folder.add( data, 'radius', 1, 20 ).onChange( generateGeometry );
+		folder.add( data, 'tube', 0.1, 10 ).onChange( generateGeometry );
+		folder.add( data, 'radialSegments', 3, 300 ).step( 1 ).onChange( generateGeometry );
+		folder.add( data, 'tubularSegments', 3, 20 ).step( 1 ).onChange( generateGeometry );
+		folder.add( data, 'p', 1, 20 ).step( 1 ).onChange( generateGeometry );
+		folder.add( data, 'q', 1, 20 ).step( 1 ).onChange( generateGeometry );
+		folder.add( data, 'heightScale', 1, 20 ).onChange( generateGeometry );
+		folder.add( data, 'arc', 0.1, twoPi ).onChange( generateGeometry );
+
+		generateGeometry();
+
+	},
+
 	TorusKnotGeometry : function( mesh ) {
 
 		var data = {
@@ -756,7 +795,8 @@ var guis = {
 			tubularSegments : 8,
 			p : 2,
 			q : 3,
-			heightScale : 1
+			heightScale : 1,
+			arc : twoPi
 		};
 
 		function generateGeometry() {
@@ -764,13 +804,13 @@ var guis = {
 			updateGroupGeometry( mesh,
 				new THREE.TorusKnotGeometry(
 					data.radius, data.tube, data.radialSegments, data.tubularSegments,
-					data.p, data.q, data.heightScale
+					data.p, data.q, data.heightScale, data.arc
 				)
 			);
 
 		}
 
-		var folder = gui.addFolder( 'THREE.TorusGeometry' );
+		var folder = gui.addFolder( 'THREE.TorusKnotGeometry' );
 
 		folder.add( data, 'radius', 1, 20 ).onChange( generateGeometry );
 		folder.add( data, 'tube', 0.1, 10 ).onChange( generateGeometry );
@@ -779,6 +819,7 @@ var guis = {
 		folder.add( data, 'p', 1, 20 ).step( 1 ).onChange( generateGeometry );
 		folder.add( data, 'q', 1, 20 ).step( 1 ).onChange( generateGeometry );
 		folder.add( data, 'heightScale', 1, 20 ).onChange( generateGeometry );
+		folder.add( data, 'arc', 0.1, twoPi ).onChange( generateGeometry );
 
 		generateGeometry();
 

--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -198,13 +198,12 @@ Menubar.Add = function ( editor ) {
 
 		var radius = 2;
 		var tube = 0.8;
-		var radialSegments = 64;
-		var tubularSegments = 12;
+		var tubularSegments = 64;
+		var radialSegments = 12;
 		var p = 2;
 		var q = 3;
-		var heightScale = 1;
 
-		var geometry = new THREE.TorusKnotGeometry( radius, tube, radialSegments, tubularSegments, p, q, heightScale );
+		var geometry = new THREE.TorusKnotGeometry( radius, tube, tubularSegments, radialSegments, p, q );
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'TorusKnot ' + ( ++ meshCount );
 

--- a/editor/js/Sidebar.Geometry.TorusKnotGeometry.js
+++ b/editor/js/Sidebar.Geometry.TorusKnotGeometry.js
@@ -30,16 +30,6 @@ Sidebar.Geometry.TorusKnotGeometry = function ( editor, object ) {
 
 	container.add( tubeRow );
 
-	// radialSegments
-
-	var radialSegmentsRow = new UI.Row();
-	var radialSegments = new UI.Integer( parameters.radialSegments ).setRange( 1, Infinity ).onChange( update );
-
-	radialSegmentsRow.add( new UI.Text( 'Radial segments' ).setWidth( '90px' ) );
-	radialSegmentsRow.add( radialSegments );
-
-	container.add( radialSegmentsRow );
-
 	// tubularSegments
 
 	var tubularSegmentsRow = new UI.Row();
@@ -49,6 +39,16 @@ Sidebar.Geometry.TorusKnotGeometry = function ( editor, object ) {
 	tubularSegmentsRow.add( tubularSegments );
 
 	container.add( tubularSegmentsRow );
+
+	// radialSegments
+
+	var radialSegmentsRow = new UI.Row();
+	var radialSegments = new UI.Integer( parameters.radialSegments ).setRange( 1, Infinity ).onChange( update );
+
+	radialSegmentsRow.add( new UI.Text( 'Radial segments' ).setWidth( '90px' ) );
+	radialSegmentsRow.add( radialSegments );
+
+	container.add( radialSegmentsRow );
 
 	// p
 
@@ -70,16 +70,6 @@ Sidebar.Geometry.TorusKnotGeometry = function ( editor, object ) {
 
 	container.add( qRow );
 
-	// heightScale
-
-	var heightScaleRow = new UI.Row();
-	var heightScale = new UI.Number( parameters.heightScale ).onChange( update );
-
-	pRow.add( new UI.Text( 'Height scale' ).setWidth( '90px' ) );
-	pRow.add( heightScale );
-
-	container.add( heightScaleRow );
-
 
 	//
 
@@ -88,11 +78,10 @@ Sidebar.Geometry.TorusKnotGeometry = function ( editor, object ) {
 		editor.execute( new SetGeometryCommand( object, new THREE.TorusKnotGeometry(
 			radius.getValue(),
 			tube.getValue(),
-			radialSegments.getValue(),
 			tubularSegments.getValue(),
+			radialSegments.getValue(),
 			p.getValue(),
-			q.getValue(),
-			heightScale.getValue()
+			q.getValue()
 		) ) );
 
 	}

--- a/examples/js/ParametricGeometries.js
+++ b/examples/js/ParametricGeometries.js
@@ -170,18 +170,16 @@ THREE.ParametricGeometries.TubeGeometry.prototype.constructor = THREE.Parametric
   * Parametric Replacement for TorusKnotGeometry
   *
   *********************************************/
-THREE.ParametricGeometries.TorusKnotGeometry = function ( radius, tube, segmentsR, segmentsT, p, q, heightScale ) {
+THREE.ParametricGeometries.TorusKnotGeometry = function ( radius, tube, segmentsT, segmentsR, p, q ) {
 
 	var scope = this;
 
 	this.radius = radius || 200;
 	this.tube = tube || 40;
-	this.segmentsR = segmentsR || 64;
-	this.segmentsT = segmentsT || 8;
+	this.segmentsT = segmentsT || 64;
+	this.segmentsR = segmentsR || 8;
 	this.p = p || 2;
 	this.q = q || 3;
-	this.heightScale = heightScale || 1;
-
 
 	var TorusKnotCurve = THREE.Curve.create(
 
@@ -198,13 +196,13 @@ THREE.ParametricGeometries.TorusKnotGeometry = function ( radius, tube, segments
 				ty = ( 1 + r * Math.cos( q * t ) ) * Math.sin( p * t ),
 				tz = r * Math.sin( q * t );
 
-			return new THREE.Vector3( tx, ty * heightScale, tz ).multiplyScalar( radius );
+			return new THREE.Vector3( tx, ty, tz ).multiplyScalar( radius );
 
 		}
 
 	);
-	var segments = segmentsR;
-	var radiusSegments = segmentsT;
+	var segments = segmentsT;
+	var radiusSegments = segmentsR;
 	var extrudePath = new TorusKnotCurve();
 
 	THREE.ParametricGeometries.TubeGeometry.call( this, extrudePath, segments, tube, radiusSegments, true, false );

--- a/examples/webgl_geometries2.html
+++ b/examples/webgl_geometries2.html
@@ -63,19 +63,17 @@
 					new THREE.MeshBasicMaterial( { color: 0xffffff, wireframe: true, transparent: true, opacity: 0.1, side: THREE.DoubleSide } )
 				];
 
-
-				var heightScale = 1;
 				var p = 2;
 				var q = 3;
-				var radius = 150, tube = 10, segmentsR = 50, segmentsT = 20;
+				var radius = 150, tube = 10, segmentsT = 50, segmentsR = 20;
 
 				var GrannyKnot =  new THREE.Curves.GrannyKnot();
 
-				var torus2 = new THREE.ParametricGeometries.TorusKnotGeometry( radius, tube, segmentsR, segmentsT, p , q, heightScale );
+				var torus2 = new THREE.ParametricGeometries.TorusKnotGeometry( radius, tube, segmentsT, segmentsR, p , q );
 				var sphere2 = new THREE.ParametricGeometries.SphereGeometry( 75, 20, 10 );
 				var tube2 = new THREE.ParametricGeometries.TubeGeometry( GrannyKnot, 150, 2, 8, true, false );
 
-				// var torus = new THREE.TorusKnotGeometry( radius, tube, segmentsR, segmentsT, p , q, heightScale );
+				// var torus = new THREE.TorusKnotGeometry( radius, tube, segmentsR, segmentsT, p , q );
 				// var sphere = new THREE.SphereGeometry( 75, 20, 10 );
 				// var tube = new THREE.TubeGeometry( GrannyKnot, 150, 2, 8, true, false );
 

--- a/src/extras/geometries/TorusKnotBufferGeometry.js
+++ b/src/extras/geometries/TorusKnotBufferGeometry.js
@@ -3,7 +3,7 @@
  *
  * see: http://www.blackpawn.com/texts/pqtorus/
  */
-THREE.TorusKnotBufferGeometry = function ( radius, tube, radialSegments, tubularSegments, p, q, heightScale, arc ) {
+THREE.TorusKnotBufferGeometry = function ( radius, tube, tubularSegments, radialSegments, p, q, heightScale ) {
 
 	THREE.BufferGeometry.call( this );
 
@@ -12,22 +12,20 @@ THREE.TorusKnotBufferGeometry = function ( radius, tube, radialSegments, tubular
 	this.parameters = {
 		radius: radius,
 		tube: tube,
-		radialSegments: radialSegments,
 		tubularSegments: tubularSegments,
+		radialSegments: radialSegments,
 		p: p,
-		q: q,
-		heightScale: heightScale,
-		arc: arc
+		q: q
 	};
+
+	if( heightScale !== undefined ) console.warn( 'THREE.TorusKnotGeometry: heightScale has been deprecated. Use .scale( x, y, z ) instead.' );
 
 	radius = radius || 100;
 	tube = tube || 40;
-	radialSegments = Math.floor( radialSegments ) || 64;
-	tubularSegments = Math.floor( tubularSegments ) || 6;
+	tubularSegments = Math.floor( tubularSegments ) || 64;
+	radialSegments = Math.floor( radialSegments ) || 8;
 	p = p || 2;
 	q = q || 3;
-	heightScale = heightScale || 1;
-	arc = arc || Math.PI * 2;
 
 	// used to calculate buffer length
 	var vertexCount = ( ( radialSegments + 1 ) * ( tubularSegments + 1 ) );
@@ -55,17 +53,17 @@ THREE.TorusKnotBufferGeometry = function ( radius, tube, radialSegments, tubular
 
 	// generate vertices, normals and uvs
 
-	for ( i = 0; i <= radialSegments; ++ i ) {
+	for ( i = 0; i <= tubularSegments; ++ i ) {
 
-		// the radian "u" is used to calculate the position on the torus curve of the current radial segement
+		// the radian "u" is used to calculate the position on the torus curve of the current tubular segement
 
-		var u = i / radialSegments * p * arc;
+		var u = i / tubularSegments * p * Math.PI * 2;
 
 		// now we calculate two points. P1 is our current position on the curve, P2 is a little farther ahead.
 		// these points are used to create a special "coordinate space", which is necessary to calculate the correct vertex positions
 
-		calculatePositionOnCurve( u, p, q, radius, heightScale, P1 );
-		calculatePositionOnCurve( u + 0.01, p, q, radius, heightScale, P2 );
+		calculatePositionOnCurve( u, p, q, radius, P1 );
+		calculatePositionOnCurve( u + 0.01, p, q, radius, P2 );
 
 		// calculate orthonormal basis
 
@@ -79,12 +77,12 @@ THREE.TorusKnotBufferGeometry = function ( radius, tube, radialSegments, tubular
 		B.normalize();
 		N.normalize();
 
-		for ( j = 0; j <= tubularSegments; ++ j ) {
+		for ( j = 0; j <= radialSegments; ++ j ) {
 
 			// now calculate the vertices. they are nothing more than an extrusion of the torus curve.
 			// because we extrude a shape in the xy-plane, there is no need to calculate a z-value.
 
-			var v = j / tubularSegments * Math.PI * 2;
+			var v = j / radialSegments * Math.PI * 2;
 			var cx = - tube * Math.cos( v );
 			var cy = tube * Math.sin( v );
 
@@ -103,8 +101,8 @@ THREE.TorusKnotBufferGeometry = function ( radius, tube, radialSegments, tubular
 			normals.setXYZ( index, normal.x, normal.y, normal.z );
 
 			// uv
-			uv.x = i / radialSegments;
-			uv.y = j / tubularSegments;
+			uv.x = i / tubularSegments;
+			uv.y = j / radialSegments;
 			uvs.setXY( index, uv.x, uv.y );
 
 			// increase index
@@ -116,15 +114,15 @@ THREE.TorusKnotBufferGeometry = function ( radius, tube, radialSegments, tubular
 
 	// generate indices
 
-	for ( j = 1; j <= radialSegments; j ++ ) {
+	for ( j = 1; j <= tubularSegments; j ++ ) {
 
-		for ( i = 1; i <= tubularSegments; i ++ ) {
+		for ( i = 1; i <= radialSegments; i ++ ) {
 
 			// indices
-			var a = ( tubularSegments + 1 ) * ( j - 1 ) + ( i - 1 );
-			var b = ( tubularSegments + 1 ) * j + ( i - 1 );
-			var c = ( tubularSegments + 1 ) * j + i;
-			var d = ( tubularSegments + 1 ) * ( j - 1 ) + i;
+			var a = ( radialSegments + 1 ) * ( j - 1 ) + ( i - 1 );
+			var b = ( radialSegments + 1 ) * j + ( i - 1 );
+			var c = ( radialSegments + 1 ) * j + i;
+			var d = ( radialSegments + 1 ) * ( j - 1 ) + i;
 
 			// face one
 			indices.setX( indexOffset, a ); indexOffset++;
@@ -149,7 +147,7 @@ THREE.TorusKnotBufferGeometry = function ( radius, tube, radialSegments, tubular
 
 	// this function calculates the current position on the torus curve
 
-	function calculatePositionOnCurve( u, p, q, radius, heightScale, position ) {
+	function calculatePositionOnCurve( u, p, q, radius, position ) {
 
 		var cu = Math.cos( u );
 		var su = Math.sin( u );
@@ -158,7 +156,7 @@ THREE.TorusKnotBufferGeometry = function ( radius, tube, radialSegments, tubular
 
 		position.x = radius * ( 2 + cs ) * 0.5 * cu;
 		position.y = radius * ( 2 + cs ) * su * 0.5;
-		position.z = heightScale * radius * Math.sin( quOverP ) * 0.5;
+		position.z = radius * Math.sin( quOverP ) * 0.5;
 
 	}
 

--- a/src/extras/geometries/TorusKnotBufferGeometry.js
+++ b/src/extras/geometries/TorusKnotBufferGeometry.js
@@ -1,0 +1,168 @@
+/**
+ * @author Mugen87 / https://github.com/Mugen87
+ *
+ * see: http://www.blackpawn.com/texts/pqtorus/
+ */
+THREE.TorusKnotBufferGeometry = function ( radius, tube, radialSegments, tubularSegments, p, q, heightScale, arc ) {
+
+	THREE.BufferGeometry.call( this );
+
+	this.type = 'TorusKnotBufferGeometry';
+
+	this.parameters = {
+		radius: radius,
+		tube: tube,
+		radialSegments: radialSegments,
+		tubularSegments: tubularSegments,
+		p: p,
+		q: q,
+		heightScale: heightScale,
+		arc: arc
+	};
+
+	radius = radius || 100;
+	tube = tube || 40;
+	radialSegments = Math.floor( radialSegments ) || 64;
+	tubularSegments = Math.floor( tubularSegments ) || 6;
+	p = p || 2;
+	q = q || 3;
+	heightScale = heightScale || 1;
+	arc = arc || Math.PI * 2;
+
+	// used to calculate buffer length
+	var vertexCount = ( ( radialSegments + 1 ) * ( tubularSegments + 1 ) );
+	var indexCount = radialSegments * tubularSegments * 2 * 3;
+
+	// buffers
+	var indices = new THREE.BufferAttribute( new ( indexCount > 65535 ? Uint32Array : Uint16Array )( indexCount ) , 1 );
+	var vertices = new THREE.BufferAttribute( new Float32Array( vertexCount * 3 ), 3 );
+	var normals = new THREE.BufferAttribute( new Float32Array( vertexCount * 3 ), 3 );
+	var uvs = new THREE.BufferAttribute( new Float32Array( vertexCount * 2 ), 2 );
+
+	// helper variables
+	var i, j, index = 0, indexOffset = 0;
+
+	var vertex = new THREE.Vector3();
+	var normal = new THREE.Vector3();
+	var uv = new THREE.Vector2();
+
+	var P1 = new THREE.Vector3();
+	var P2 = new THREE.Vector3();
+
+	var B = new THREE.Vector3();
+	var T = new THREE.Vector3();
+	var N = new THREE.Vector3();
+
+	// generate vertices, normals and uvs
+
+	for ( i = 0; i <= radialSegments; ++ i ) {
+
+		// the radian "u" is used to calculate the position on the torus curve of the current radial segement
+
+		var u = i / radialSegments * p * arc;
+
+		// now we calculate two points. P1 is our current position on the curve, P2 is a little farther ahead.
+		// these points are used to create a special "coordinate space", which is necessary to calculate the correct vertex positions
+
+		calculatePositionOnCurve( u, p, q, radius, heightScale, P1 );
+		calculatePositionOnCurve( u + 0.01, p, q, radius, heightScale, P2 );
+
+		// calculate orthonormal basis
+
+		T.subVectors( P2, P1 );
+		N.addVectors( P2, P1 );
+		B.crossVectors( T, N );
+		N.crossVectors( B, T );
+
+		// normalize B, N. T can be ignored, we don't use it
+
+		B.normalize();
+		N.normalize();
+
+		for ( j = 0; j <= tubularSegments; ++ j ) {
+
+			// now calculate the vertices. they are nothing more than an extrusion of the torus curve.
+			// because we extrude a shape in the xy-plane, there is no need to calculate a z-value.
+
+			var v = j / tubularSegments * Math.PI * 2;
+			var cx = - tube * Math.cos( v );
+			var cy = tube * Math.sin( v );
+
+			// now calculate the final vertex position.
+			// first we orient the extrusion with our basis vectos, then we add it to the current position on the curve
+
+			vertex.x = P1.x + ( cx * N.x + cy * B.x );
+			vertex.y = P1.y + ( cx * N.y + cy * B.y );
+			vertex.z = P1.z + ( cx * N.z + cy * B.z );
+
+			// vertex
+			vertices.setXYZ( index, vertex.x, vertex.y, vertex.z );
+
+			// normal (P1 is always the center/origin of the extrusion, thus we can use it to calculate the normal)
+			normal.subVectors( vertex, P1 ).normalize();
+			normals.setXYZ( index, normal.x, normal.y, normal.z );
+
+			// uv
+			uv.x = i / radialSegments;
+			uv.y = j / tubularSegments;
+			uvs.setXY( index, uv.x, uv.y );
+
+			// increase index
+			index ++;
+
+		}
+
+	}
+
+	// generate indices
+
+	for ( j = 1; j <= radialSegments; j ++ ) {
+
+		for ( i = 1; i <= tubularSegments; i ++ ) {
+
+			// indices
+			var a = ( tubularSegments + 1 ) * ( j - 1 ) + ( i - 1 );
+			var b = ( tubularSegments + 1 ) * j + ( i - 1 );
+			var c = ( tubularSegments + 1 ) * j + i;
+			var d = ( tubularSegments + 1 ) * ( j - 1 ) + i;
+
+			// face one
+			indices.setX( indexOffset, a ); indexOffset++;
+			indices.setX( indexOffset, b ); indexOffset++;
+			indices.setX( indexOffset, d ); indexOffset++;
+
+			// face two
+			indices.setX( indexOffset, b ); indexOffset++;
+			indices.setX( indexOffset, c ); indexOffset++;
+			indices.setX( indexOffset, d ); indexOffset++;
+
+		}
+
+	}
+
+	// build geometry
+
+	this.setIndex( indices );
+	this.addAttribute( 'position', vertices );
+	this.addAttribute( 'normal', normals );
+	this.addAttribute( 'uv', uvs );
+
+	// this function calculates the current position on the torus curve
+
+	function calculatePositionOnCurve( u, p, q, radius, heightScale, position ) {
+
+		var cu = Math.cos( u );
+		var su = Math.sin( u );
+		var quOverP = q / p * u;
+		var cs = Math.cos( quOverP );
+
+		position.x = radius * ( 2 + cs ) * 0.5 * cu;
+		position.y = radius * ( 2 + cs ) * su * 0.5;
+		position.z = heightScale * radius * Math.sin( quOverP ) * 0.5;
+
+	}
+
+};
+
+THREE.TorusKnotBufferGeometry.prototype = Object.create( THREE.BufferGeometry.prototype );
+THREE.TorusKnotBufferGeometry.prototype.constructor = THREE.TorusKnotBufferGeometry;

--- a/src/extras/geometries/TorusKnotBufferGeometry.js
+++ b/src/extras/geometries/TorusKnotBufferGeometry.js
@@ -3,7 +3,7 @@
  *
  * see: http://www.blackpawn.com/texts/pqtorus/
  */
-THREE.TorusKnotBufferGeometry = function ( radius, tube, tubularSegments, radialSegments, p, q, heightScale ) {
+THREE.TorusKnotBufferGeometry = function ( radius, tube, tubularSegments, radialSegments, p, q ) {
 
 	THREE.BufferGeometry.call( this );
 
@@ -17,8 +17,6 @@ THREE.TorusKnotBufferGeometry = function ( radius, tube, tubularSegments, radial
 		p: p,
 		q: q
 	};
-
-	if( heightScale !== undefined ) console.warn( 'THREE.TorusKnotGeometry: heightScale has been deprecated. Use .scale( x, y, z ) instead.' );
 
 	radius = radius || 100;
 	tube = tube || 40;

--- a/src/extras/geometries/TorusKnotGeometry.js
+++ b/src/extras/geometries/TorusKnotGeometry.js
@@ -1,9 +1,8 @@
 /**
  * @author oosmoxiecode
- * based on http://code.google.com/p/away3d/source/browse/trunk/fp10/Away3D/src/away3d/primitives/TorusKnot.as?spec=svn2473&r=2473
  */
 
-THREE.TorusKnotGeometry = function ( radius, tube, radialSegments, tubularSegments, p, q, heightScale ) {
+THREE.TorusKnotGeometry = function ( radius, tube, radialSegments, tubularSegments, p, q, heightScale, arc ) {
 
 	THREE.Geometry.call( this );
 
@@ -16,97 +15,12 @@ THREE.TorusKnotGeometry = function ( radius, tube, radialSegments, tubularSegmen
 		tubularSegments: tubularSegments,
 		p: p,
 		q: q,
-		heightScale: heightScale
+		heightScale: heightScale,
+		arc: arc
 	};
 
-	radius = radius || 100;
-	tube = tube || 40;
-	radialSegments = radialSegments || 64;
-	tubularSegments = tubularSegments || 8;
-	p = p || 2;
-	q = q || 3;
-	heightScale = heightScale || 1;
-
-	var grid = new Array( radialSegments );
-	var tang = new THREE.Vector3();
-	var n = new THREE.Vector3();
-	var bitan = new THREE.Vector3();
-
-	for ( var i = 0; i < radialSegments; ++ i ) {
-
-		grid[ i ] = new Array( tubularSegments );
-		var u = i / radialSegments * 2 * p * Math.PI;
-		var p1 = getPos( u, q, p, radius, heightScale );
-		var p2 = getPos( u + 0.01, q, p, radius, heightScale );
-		tang.subVectors( p2, p1 );
-		n.addVectors( p2, p1 );
-
-		bitan.crossVectors( tang, n );
-		n.crossVectors( bitan, tang );
-		bitan.normalize();
-		n.normalize();
-
-		for ( var j = 0; j < tubularSegments; ++ j ) {
-
-			var v = j / tubularSegments * 2 * Math.PI;
-			var cx = - tube * Math.cos( v ); // TODO: Hack: Negating it so it faces outside.
-			var cy = tube * Math.sin( v );
-
-			var pos = new THREE.Vector3();
-			pos.x = p1.x + cx * n.x + cy * bitan.x;
-			pos.y = p1.y + cx * n.y + cy * bitan.y;
-			pos.z = p1.z + cx * n.z + cy * bitan.z;
-
-			grid[ i ][ j ] = this.vertices.push( pos ) - 1;
-
-		}
-
-	}
-
-	for ( var i = 0; i < radialSegments; ++ i ) {
-
-		for ( var j = 0; j < tubularSegments; ++ j ) {
-
-			var ip = ( i + 1 ) % radialSegments;
-			var jp = ( j + 1 ) % tubularSegments;
-
-			var a = grid[ i ][ j ];
-			var b = grid[ ip ][ j ];
-			var c = grid[ ip ][ jp ];
-			var d = grid[ i ][ jp ];
-
-			var uva = new THREE.Vector2( i / radialSegments, j / tubularSegments );
-			var uvb = new THREE.Vector2( ( i + 1 ) / radialSegments, j / tubularSegments );
-			var uvc = new THREE.Vector2( ( i + 1 ) / radialSegments, ( j + 1 ) / tubularSegments );
-			var uvd = new THREE.Vector2( i / radialSegments, ( j + 1 ) / tubularSegments );
-
-			this.faces.push( new THREE.Face3( a, b, d ) );
-			this.faceVertexUvs[ 0 ].push( [ uva, uvb, uvd ] );
-
-			this.faces.push( new THREE.Face3( b, c, d ) );
-			this.faceVertexUvs[ 0 ].push( [ uvb.clone(), uvc, uvd.clone() ] );
-
-		}
-
-	}
-
-	this.computeFaceNormals();
-	this.computeVertexNormals();
-
-	function getPos( u, in_q, in_p, radius, heightScale ) {
-
-		var cu = Math.cos( u );
-		var su = Math.sin( u );
-		var quOverP = in_q / in_p * u;
-		var cs = Math.cos( quOverP );
-
-		var tx = radius * ( 2 + cs ) * 0.5 * cu;
-		var ty = radius * ( 2 + cs ) * su * 0.5;
-		var tz = heightScale * radius * Math.sin( quOverP ) * 0.5;
-
-		return new THREE.Vector3( tx, ty, tz );
-
-	}
+	this.fromBufferGeometry( new THREE.TorusKnotBufferGeometry( radius, tube, radialSegments, tubularSegments, p, q, heightScale, arc ) );
+	this.mergeVertices();
 
 };
 

--- a/src/extras/geometries/TorusKnotGeometry.js
+++ b/src/extras/geometries/TorusKnotGeometry.js
@@ -2,7 +2,7 @@
  * @author oosmoxiecode
  */
 
-THREE.TorusKnotGeometry = function ( radius, tube, radialSegments, tubularSegments, p, q, heightScale, arc ) {
+THREE.TorusKnotGeometry = function ( radius, tube, tubularSegments, radialSegments, p, q, heightScale ) {
 
 	THREE.Geometry.call( this );
 
@@ -11,15 +11,15 @@ THREE.TorusKnotGeometry = function ( radius, tube, radialSegments, tubularSegmen
 	this.parameters = {
 		radius: radius,
 		tube: tube,
-		radialSegments: radialSegments,
 		tubularSegments: tubularSegments,
+		radialSegments: radialSegments,
 		p: p,
-		q: q,
-		heightScale: heightScale,
-		arc: arc
+		q: q
 	};
 
-	this.fromBufferGeometry( new THREE.TorusKnotBufferGeometry( radius, tube, radialSegments, tubularSegments, p, q, heightScale, arc ) );
+	if( heightScale !== undefined ) console.warn( 'THREE.TorusKnotGeometry: heightScale has been deprecated. Use .scale( x, y, z ) instead.' );
+
+	this.fromBufferGeometry( new THREE.TorusKnotBufferGeometry( radius, tube, tubularSegments, radialSegments, p, q ) );
 	this.mergeVertices();
 
 };

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -225,15 +225,15 @@ THREE.ObjectLoader.prototype = {
 						break;
 
 					case 'TorusKnotGeometry':
+					case 'TorusKnotBufferGeometry':
 
-						geometry = new THREE.TorusKnotGeometry(
+						geometry = new THREE[ data.type ](
 							data.radius,
 							data.tube,
 							data.radialSegments,
 							data.tubularSegments,
 							data.p,
-							data.q,
-							data.heightScale
+							data.q
 						);
 
 						break;

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -230,8 +230,8 @@ THREE.ObjectLoader.prototype = {
 						geometry = new THREE[ data.type ](
 							data.radius,
 							data.tube,
-							data.radialSegments,
 							data.tubularSegments,
+							data.radialSegments,
 							data.p,
 							data.q
 						);

--- a/test/unit/extras/geometries/TorusKnotGeometry.tests.js
+++ b/test/unit/extras/geometries/TorusKnotGeometry.tests.js
@@ -5,11 +5,10 @@
 	var parameters = {
 		radius: 10,
 		tube: 20,
-		radialSegments: 30,
-		tubularSegments: 10,
+		tubularSegments: 30,
+		radialSegments: 10,
 		p: 3,
-		q: 2,
-		heightScale: 2.0
+		q: 2
 	};
 
 	var geometries;
@@ -23,9 +22,9 @@
 				new THREE.TorusKnotGeometry(),
 				new THREE.TorusKnotGeometry( parameters.radius ),
 				new THREE.TorusKnotGeometry( parameters.radius, parameters.tube ),
-				new THREE.TorusKnotGeometry( parameters.radius, parameters.tube, parameters.radialSegments ),
-				new THREE.TorusKnotGeometry( parameters.radius, parameters.tube, parameters.radialSegments, parameters.tubularSegments ),
-				new THREE.TorusKnotGeometry( parameters.radius, parameters.tube, parameters.radialSegments, parameters.tubularSegments, parameters.p, parameters.q, parameters.heightScale ),
+				new THREE.TorusKnotGeometry( parameters.radius, parameters.tube, parameters.tubularSegments ),
+				new THREE.TorusKnotGeometry( parameters.radius, parameters.tube, parameters.tubularSegments, parameters.radialSegments ),
+				new THREE.TorusKnotGeometry( parameters.radius, parameters.tube, parameters.tubularSegments, parameters.radialSegments, parameters.p, parameters.q ),
 
 			];
 

--- a/utils/build/includes/extras.json
+++ b/utils/build/includes/extras.json
@@ -38,6 +38,7 @@
 	"src/extras/geometries/TextGeometry.js",
 	"src/extras/geometries/TorusBufferGeometry.js",
 	"src/extras/geometries/TorusGeometry.js",
+	"src/extras/geometries/TorusKnotBufferGeometry.js",
 	"src/extras/geometries/TorusKnotGeometry.js",
 	"src/extras/geometries/TubeGeometry.js",
 	"src/extras/geometries/PolyhedronGeometry.js",


### PR DESCRIPTION
This PR introduces `TorusKnotBufferGeometry`. Here is the corresponding [test fiddle](https://jsfiddle.net/fuwpLv10/7/).

There are some things i want to discuss:
- I'm afraid that the parameter `radialSegments` and `tubularSegments` have interchanged meanings in `TorusGeometry` and `TorusKnotGeometry`. I suggest that the implementation of `TorusGeometry` is correct, where `tubularSegments` determines the amount of vertical segments of the tube and `radialSegments` the amount of horizontal segments. Maybe it's good to align this in `TorusKnotBufferGeometry`.
- The `heightScale` parameter is confusing. It scales the z-component of a position on the torus curve which is quite extraordinary. Other geometries of three.js don't have such a parameter. And why is there no `widthScale` and `depthScale`? This implementation is somehow inconsistent. Is it basically possible to remove `heightScale` or mark it as deprecated?

Besides, i've added the `arc` parameter so `TorusKnotBufferGeometry` and  `TorusBufferGeometry` have more similar interfaces.
