### PR TITLE
Editor: Bugfix Sidebar LatheGeometry .addPointButton

### DIFF
--- a/editor/js/Sidebar.Geometry.LatheGeometry.js
+++ b/editor/js/Sidebar.Geometry.LatheGeometry.js
@@ -63,9 +63,17 @@ Sidebar.Geometry.LatheGeometry = function( editor, object ) {
 
 	var addPointButton = new UI.Button( '+' ).onClick( function() {
 
-		var point = pointsUI[ pointsUI.length - 1 ];
+		if( pointsUI.length === 0 ){
 
-		pointsList.add( createPointRow( point.x.getValue(), point.y.getValue() ) );
+			pointsList.add( createPointRow( 0, 0 ) );
+
+		} else {
+
+			var point = pointsUI[ pointsUI.length - 1 ];
+
+			pointsList.add( createPointRow( point.x.getValue(), point.y.getValue() ) );
+
+		}
 
 		update();
 


### PR DESCRIPTION
If you create a `LatheGeometry` with the `Editor` and remove all points of the geometry, you get a runtime error while adding a new point.

![editor](https://cloud.githubusercontent.com/assets/12612165/13637752/56b602ce-e609-11e5-8b2f-b11c3aeff273.jpg)

This PR fixes the issue. The `click` event listener of `addPointButton` now adds a point with (0,0) if the point list is empty. 
