### PR TITLE
Clean up of CubeTexture.images

### DIFF
--- a/examples/js/loaders/HDRCubeTextureLoader.js
+++ b/examples/js/loaders/HDRCubeTextureLoader.js
@@ -12,7 +12,7 @@ THREE.HDRCubeTextureLoader = function (manager) {
 }
 
 THREE.HDRCubeTextureLoader.prototype.load = function(type, urls, onLoad, onProgress, onError) {
-  var texture = new THREE.CubeTexture( [] );
+  var texture = new THREE.CubeTexture();
 
   texture.type = type;
   texture.encoding = (type === THREE.UnsignedByteType) ? THREE.RGBEEncoding : THREE.LinearEncoding;

--- a/src/loaders/CubeTextureLoader.js
+++ b/src/loaders/CubeTextureLoader.js
@@ -14,7 +14,7 @@ THREE.CubeTextureLoader.prototype = {
 
 	load: function ( urls, onLoad, onProgress, onError ) {
 
-		var texture = new THREE.CubeTexture( [] );
+		var texture = new THREE.CubeTexture();
 
 		var loader = new THREE.ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );

--- a/src/textures/CubeTexture.js
+++ b/src/textures/CubeTexture.js
@@ -4,6 +4,7 @@
 
 THREE.CubeTexture = function ( images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy ) {
 
+	images = images !== undefined ? images : [];
 	mapping = mapping !== undefined ? mapping : THREE.CubeReflectionMapping;
 
 	THREE.Texture.call( this, images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );

--- a/src/textures/CubeTexture.js
+++ b/src/textures/CubeTexture.js
@@ -8,7 +8,6 @@ THREE.CubeTexture = function ( images, mapping, wrapS, wrapT, magFilter, minFilt
 
 	THREE.Texture.call( this, images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
 
-	this.images = images;
 	this.flipY = false;
 
 };
@@ -16,12 +15,12 @@ THREE.CubeTexture = function ( images, mapping, wrapS, wrapT, magFilter, minFilt
 THREE.CubeTexture.prototype = Object.create( THREE.Texture.prototype );
 THREE.CubeTexture.prototype.constructor = THREE.CubeTexture;
 
-THREE.CubeTexture.prototype.copy = function ( source ) {
-
-	THREE.Texture.prototype.copy.call( this, source );
-
-	this.images = source.images;
-
-	return this;
-
-};
+Object.defineProperty(THREE.CubeTexture.prototype, "images", {
+		  get: function() {
+				return this.image;
+		  },
+			set: function( value ) {
+				this.image = value;
+			}
+		}
+);


### PR DESCRIPTION
I ran into a issue where I didn't initialize CubeTexture.images properly - so this PR intializes it to an empty array automatically.

A second issue came when I set CubeTexture.images to a new array.  It did nothing because CubeTexture relies upon images being the same variable as image (as the renderer only reads Texture.image, not CubeTexture.images), but it doesn't enforce this. I have changed code to make CubeTexture.images to be a property that just sets/get from Texture.image thus.  This ensures that I can set CubeTexture.images to a new array and it will work.
