### PR TITLE
fix positioning of VR buttons/labels in WebVR so not obscured by "View Source" when iframed from Examples (fixes #8331)

### DIFF
--- a/examples/webvr_cubes.html
+++ b/examples/webvr_cubes.html
@@ -15,7 +15,7 @@
 			.menu {
 				position: fixed;
 				bottom: 20px;
-				right: 20px;
+				left: 20px;
 			}
 
 			.button {
@@ -26,7 +26,7 @@
 			}
 
 			.button.enabled {
-				background-color: rgb(18, 36, 70);
+				background-color: rgb(18, 140, 36);
 			}
 
 			.button:hover {
@@ -130,7 +130,11 @@
 				if ( navigator.getVRDisplays === undefined && navigator.getVRDevices === undefined ) {
 
 					fullScreenButton.innerHTML = 'Your browser doesn\'t support WebVR';
-					fullScreenButton.classList.add('error');
+					fullScreenButton.classList.add( 'error' );
+
+				} else {
+
+					fullScreenButton.classList.add( 'enabled' );
 
 				}
 
@@ -138,7 +142,7 @@
 				vrEffect = new THREE.VREffect( renderer, function ( error ) {
 
 					fullScreenButton.innerHTML = error;
-					fullScreenButton.classList.add('error');
+					fullScreenButton.classList.add( 'error' );
 
 				} );
 
@@ -155,7 +159,7 @@
 
 				stats = new Stats();
 				stats.domElement.style.position = 'absolute';
-				stats.domElement.style.top = '0px';
+				stats.domElement.style.top = '0';
 				container.appendChild( stats.domElement );
 
 				//


### PR DESCRIPTION
### before

<img width="1440" alt="screenshot 2016-03-09 22 18 40" src="https://cloud.githubusercontent.com/assets/203725/13661397/33bdbc06-e647-11e5-89a8-c34a8329c616.png">
<img width="1440" alt="screenshot 2016-03-09 22 18 59" src="https://cloud.githubusercontent.com/assets/203725/13661398/33be1d22-e647-11e5-8d0c-6df1b656b66e.png">
### after

<img width="1440" alt="screenshot 2016-03-09 22 26 48" src="https://cloud.githubusercontent.com/assets/203725/13661399/33be666a-e647-11e5-8960-f192ca93c535.png">
<img width="1440" alt="screenshot 2016-03-09 22 29 33" src="https://cloud.githubusercontent.com/assets/203725/13661396/33bdb9fe-e647-11e5-8210-36a202fed1a4.png">
