### PR TITLE
Finer grain timing in many examples

### DIFF
--- a/examples/canvas_ascii_effect.html
+++ b/examples/canvas_ascii_effect.html
@@ -116,8 +116,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/canvas_camera_orthographic.html
+++ b/examples/canvas_camera_orthographic.html
@@ -145,8 +145,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/canvas_camera_orthographic2.html
+++ b/examples/canvas_camera_orthographic2.html
@@ -208,8 +208,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/canvas_geometry_birds.html
+++ b/examples/canvas_geometry_birds.html
@@ -420,8 +420,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/canvas_geometry_cube.html
+++ b/examples/canvas_geometry_cube.html
@@ -193,8 +193,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_animation_skinning_blending.html
+++ b/examples/webgl_animation_skinning_blending.html
@@ -235,6 +235,8 @@
 
 				requestAnimationFrame( animate, renderer.domElement );
 
+				stats.begin();
+
 				// step forward in time based on whether we're stepping and scale
 
 				var scale = gui.getTimeScale();
@@ -248,7 +250,7 @@
 				gui.update( blendMesh.mixer.time );
 
 				renderer.render( scene, camera );
-				stats.update();
+				stats.end();
 
 				// if we are stepping, consume time
 				// ( will equal step size next time a single step is desired )

--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -635,8 +635,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 				if ( showMemInfo ) {
 

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -284,9 +284,9 @@
 
 				controls.update();
 
+				stats.begin();
 				render();
-
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -257,8 +257,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_materials_texture_manualmipmap.html
+++ b/examples/webgl_materials_texture_manualmipmap.html
@@ -240,8 +240,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_materials_transparency.html
+++ b/examples/webgl_materials_transparency.html
@@ -214,8 +214,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -215,8 +215,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -359,8 +359,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -278,8 +278,9 @@
 
 				requestAnimationFrame( animate, renderer.domElement );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -255,8 +255,9 @@
 
 				requestAnimationFrame( animate, renderer.domElement );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_postprocessing_msaa.html
+++ b/examples/webgl_postprocessing_msaa.html
@@ -164,6 +164,8 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
+
 				for ( var i = 0; i < scene.children.length; i ++ ) {
 
 					var child = scene.children[ i ];
@@ -174,8 +176,7 @@
 				}
 
 				composer.render();
-
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_postprocessing_smaa.html
+++ b/examples/webgl_postprocessing_smaa.html
@@ -108,6 +108,8 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
+
 				for ( var i = 0; i < scene.children.length; i ++ ) {
 
 					var child = scene.children[ i ];
@@ -119,7 +121,7 @@
 
 				composer.render();
 
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -191,8 +191,9 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 			function animate() {
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 			}
 
 			function render() {

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -429,8 +429,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -369,8 +369,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -252,8 +252,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 


### PR DESCRIPTION
I added proper stats.begin()/stats.end() to many examples.  I find it very useful as we have made ThreeJS so efficient that nearly all examples run at full screen refresh rate of 60 fps on my machine, making the timing (the second view of the stats window) information somewhat useless if we do not do stats.begin()/stats.end().  I should probably do it for all examples, but this is a start.
