### PR TITLE
fix sRGB encoding, missing constant.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl
@@ -15,7 +15,7 @@ vec4 sRGBToLinear( in vec4 value ) {
   return vec4( mix( pow( value.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), value.rgb * 0.0773993808, vec3( lessThanEqual( value.rgb, vec3( 0.04045 ) ) ) ), value.w );
 }
 vec4 LinearTosRGB( in vec4 value ) {
-  return vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.w );
+  return vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) * 1.055 - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.w );
 }
 
 vec4 RGBEToLinear( in vec4 value ) {


### PR DESCRIPTION
I was checking each of the encoding functions for correctness while chasing down a bug.  Found a bug unrelated to what I was trying to fix.

In the current source `sRGBToLinear( LinearTosRGB( color ) !== color`, which is a bug.  Adding this constant, which is present in the [sRGB Wikipedia article](https://en.wikipedia.org/wiki/SRGB#Specification_of_the_transformation) and also arises if you derive LinearTosRGB from sRGBToLinear.

The bug is actually present in the example code shared with me here:

https://github.com/mrdoob/three.js/pull/8117#issuecomment-186838313

The code linked to above should also be corrected to this, notice the addition of the `* 1.055` factor:

```
float srgbGammaCorrect( float c ) {

    return c <= 0.0031308 ? c * 12.92 : pow( c, 0.41666 ) * 1.055 - 0.055;

}
```

/ping @tschw 
