### PR TITLE
fix minor bug (exp2->pow2) in physical lights attention calculation

### DIFF
--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl
@@ -11,11 +11,12 @@ float punctualLightIntensityToIrradianceFactor( const in float lightDistance, co
 #if defined ( PHYSICALLY_CORRECT_LIGHTS )
 
 			// based upon Frostbite 3 Moving to Physically-based Rendering
-			// http://www.frostbite.com/wp-content/uploads/2014/11/course_notes_moving_frostbite_to_pbr.pdf
+			// page 32, equation 26: E[window1]
+			// http://www.frostbite.com/wp-content/uploads/2014/11/course_notes_moving_frostbite_to_pbr_v2.pdf
 			// this is intended to be used on spot and point lights who are represented as luminous intensity
 			// but who must be converted to luminous irradiance for surface lighting calculation
 			float distanceFalloff = 1.0 / max( pow( lightDistance, decayExponent ), 0.01 );
-			float maxDistanceCutoffFactor = exp2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) ) ;
+			float maxDistanceCutoffFactor = pow2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) );
 			return distanceFalloff * maxDistanceCutoffFactor;
 
 #else


### PR DESCRIPTION
Seems I didn't translate the equation from Frostbite 3 PBR paper correctly.  I used a exp2 rather than pow2, thus instead of x^2, I implemented 2^x, which are very different mathematical functions.

This PR fixes that and also expands the comments for this function so it is easier to find it in the paper.
