### PR TITLE
Avoid possible 'divide by 0' in G_GGX_Smith function

### DIFF
--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl
@@ -62,7 +62,9 @@ float G_GGX_Smith( const in float alpha, const in float dotNL, const in float do
 
 	float gv = dotNV + pow( a2 + ( 1.0 - a2 ) * pow2( dotNV ), 0.5 );
 
-	return 1.0 / ( gl * gv );
+	float denominator = ( gl * gv ) + 0.00001; // avoid possible divide by 0 on the next line
+	
+	return 1.0 / denominator;
 
 } // validated
 


### PR DESCRIPTION
As discussed in https://github.com/mrdoob/three.js/issues/8348 , this PR adds a small epsilon to the denominator at the end of the G_GGX_Smith function.  Previously, if either of the gl or gv terms were 0.0, on the following 'return' line, there would be a divide by 0 issue.   
