### PR TITLE
remove unused shareDepthFrom

### DIFF
--- a/docs/api/renderers/WebGLRenderTarget.html
+++ b/docs/api/renderers/WebGLRenderTarget.html
@@ -88,11 +88,6 @@
 		Whether to generate mipmaps (if possible) for a texture. True by default.
 		</div>
 
-		<h3>[property:WebGLRenderTarget shareDepthFrom]</h3>
-		<div>
-		Shares the depth from another WebGLRenderTarget. Default is null.
-		</div>
-
 		
 		<h2>Methods</h2>
 		

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -5292,10 +5292,6 @@
           "!type": "boolean",
           "!doc": "Whether to generate mipmaps (if possible) for a texture. True by default."
         },
-        "shareDepthFrom": {
-          "!type": "+THREE.WebGLRenderTarget",
-          "!doc": "Shares the depth from another WebGLRenderTarget. Default is null."
-        },
         "setSize": {
           "!type": "fn(width: number, height: number)",
           "!doc": "Sets the size of the renderTarget."

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -70,8 +70,6 @@ THREE.WebGLRenderTarget.prototype = {
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;
 
-		this.shareDepthFrom = source.shareDepthFrom;
-
 		return this;
 
 	},


### PR DESCRIPTION
`shareDepthFrom` has been deleted from `WebGLRenderTarget`, but still remains some
