### PR TITLE
Fix PMREM cubemap size at 256 for performance reasons

### DIFF
--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -11,10 +11,10 @@
  *  by this class.
  */
 
-THREE.PMREMGenerator = function( sourceTexture, resolution ) {
+THREE.PMREMGenerator = function( sourceTexture ) {
 
 	this.sourceTexture = sourceTexture;
-  this.resolution = ( resolution !== undefined ) ? resolution : 256;
+  this.resolution = 256; // NODE: 256 is currently hard coded in the glsl code for performance reasons
 
   var monotonicEncoding = ( sourceTexture.encoding === THREE.LinearEncoding ) ||
     ( sourceTexture.encoding === THREE.GammaEncoding ) || ( sourceTexture.encoding === THREE.sRGBEncoding );

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -11,27 +11,10 @@
  *  by this class.
  */
 
- THREE.PMREMGenerator = function( sourceTexture ) {
-	if ( sourceTexture instanceof THREE.CubeTexture ) {
+THREE.PMREMGenerator = function( sourceTexture, resolution ) {
 
-		if ( sourceTexture.images[ 0 ] === undefined )
-		  console.error( "sourceTexture Not Initialized" );
-      if(sourceTexture.images[ 0 ] instanceof THREE.DataTexture) {
-          this.resolution = sourceTexture.images[ 0 ].image.width;
-      }
-      else {
-          this.resolution = sourceTexture.images[ 0 ].width;
-      }
-
-	}
-	else if ( sourceTexture instanceof THREE.WebGLRenderTargetCube ) {
-		if ( sourceTexture === undefined ) console.error( "Render Target Not Initialized" );
-		this.resolution = sourceTexture.width;
-	}
-	else {
-		console.error( "Wrong Input to PMREMGenerator" );
-	}
 	this.sourceTexture = sourceTexture;
+  this.resolution = ( resolution !== undefined ) ? resolution : 256;
 
   var monotonicEncoding = ( sourceTexture.encoding === THREE.LinearEncoding ) ||
     ( sourceTexture.encoding === THREE.GammaEncoding ) || ( sourceTexture.encoding === THREE.sRGBEncoding );


### PR DESCRIPTION
We were allowing the PMREM cubemap size to vary based on the input images, but we had hard coded 256 as the size within the glsl.  This PR makes it clear that we have fixed the size and we also no longer varying the cubemap size based on the input.
