### PR TITLE
add bubbling and propagation of events throughout Object3D tree

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -262,6 +262,7 @@ var files = {
 		"misc_controls_pointerlock",
 		"misc_controls_trackball",
 		"misc_controls_transform",
+		"misc_events_bubbling",
 		"misc_fps",
 		"misc_lights_test",
 		"misc_lookat",

--- a/examples/misc_events_bubbling.html
+++ b/examples/misc_events_bubbling.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js misc - events / bubbling</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #f0f0f0;
+				margin: 0px;
+				overflow: hidden;
+			}
+			#info {
+				position: absolute;
+				top: 0px;
+				width: 100%;
+				padding: 5px;
+				text-align:center;
+			}
+			#prefs {
+				position: absolute;
+				top: 50px;
+				width: 100%;
+				padding: 5px;
+				text-align:center;
+			}
+			#clickinfo {
+				position: absolute;
+				bottom: 0px;
+				width: 100%;
+				padding: 5px;
+				text-align:center;
+			}
+		</style>
+	</head>
+	<body>
+		<canvas id="debug" style="position:absolute; left:100px"></canvas>
+
+		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - events / bubbling</div>
+
+		<div id="prefs"><label for="check_bubbling">bubbling enabled</label>: <input type="checkbox" name="check_bubbling" id="check_bubbling" value="1" checked /></div>
+		<div id="clickinfo">click inside any square to inspect target / currentTarget</div>
+
+		<script src="../build/three.js"></script>
+
+		<script src="js/renderers/Projector.js"></script>
+		<script src="js/renderers/CanvasRenderer.js"></script>
+
+		<script src="js/libs/stats.min.js"></script>
+
+		<script>
+
+			var container, stats;
+
+			var camera, scene, renderer;
+
+			var group, text, plane;
+
+			var mouseXOnMouseDown = 0;
+
+			var windowHalfX = window.innerWidth / 2;
+			var windowHalfY = window.innerHeight / 2;
+
+			var raycaster = new THREE.Raycaster();
+			var mouse = new THREE.Vector2();
+
+			var bubblingCheckbox = document.getElementById('check_bubbling');
+			var clickInfoElement = document.getElementById('clickinfo');
+			var clickInfoDefaultText = clickInfoElement.innerHTML;
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.set( 0, 0, 100 );
+
+				scene = new THREE.Scene();
+
+
+				function createPlane ( size, color, label ) {
+
+					var geometry = new THREE.PlaneGeometry( size, size );
+					var material = new THREE.MeshBasicMaterial( {color: color, side: THREE.DoubleSide} );
+					var plane = new THREE.Mesh( geometry, material );
+
+					plane.userData.label = label;
+
+					plane.addEventListener( 'click', function ( event ) {
+
+							// event.stopPropagation();
+
+							var clickInfo = "target: " + event.target.userData.label + " / " + "currentTarget: " + event.currentTarget.userData.label + "<br />";
+							clickInfoElement.innerHTML = clickInfoElement.innerHTML + clickInfo;
+
+					} );
+
+					plane.position.z = 10;
+
+					return plane
+
+				}
+
+				// build object tree
+				var root = createPlane(50, 0x000000, 'black');
+				scene.add( root );
+
+				var child1 = createPlane(35, 0x00ff00, 'green');
+				root.add(child1);
+
+				var child2 = createPlane(21, 0x0000ff, 'blue');
+				child1.add(child2);
+
+				var child3 = createPlane(10, 0xff0000, 'red');
+				child2.add(child3);
+
+				renderer = new THREE.CanvasRenderer();
+				renderer.setClearColor( 0xf0f0f0 );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.sortElements = false;
+				container.appendChild( renderer.domElement );
+
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '0px';
+				container.appendChild( stats.domElement );
+
+				document.addEventListener( 'click', onDocumentClick, false );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function onWindowResize() {
+
+				windowHalfX = window.innerWidth / 2;
+				windowHalfY = window.innerHeight / 2;
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			//
+
+			function onDocumentClick( event ) {
+
+				mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
+				mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+
+				raycaster.setFromCamera( mouse, camera );
+
+				var intersection = raycaster.intersectObject( scene, true );
+
+				if ( intersection.length > 0 ) {
+
+					clickInfoElement.innerHTML = "";
+					intersection[0].object.dispatchEvent({ type: "click", bubbles: bubblingCheckbox.checked });
+
+				} else {
+
+					clickInfoElement.innerHTML = clickInfoDefaultText;
+
+				}
+
+
+			}
+
+			//
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -76,6 +76,13 @@ THREE.EventDispatcher.prototype = {
 
 	dispatchEvent: function ( event ) {
 
+		if (event.target === undefined) {
+
+			// node which event is dispatched.
+			event.target = this;
+
+		}
+
 		if ( this._listeners === undefined ) return;
 
 		var listeners = this._listeners;
@@ -83,7 +90,8 @@ THREE.EventDispatcher.prototype = {
 
 		if ( listenerArray !== undefined ) {
 
-			event.target = this;
+			// node whose event listener’s callback is currently being invoked.
+			event.currentTarget = this;
 
 			var array = [];
 			var length = listenerArray.length;

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -718,4 +718,31 @@ THREE.Object3D.prototype = {
 
 THREE.EventDispatcher.prototype.apply( THREE.Object3D.prototype );
 
+//
+// Override EventDispatcher#dispatchEvent to allow event bubbling throughout
+// parent nodes
+//
+THREE.Object3D.prototype.dispatchEvent = function ( event ) {
+
+	if (event.stopPropagation === undefined) {
+
+		event.stopPropagation = function() {
+
+			event.propagationStopped = true;
+
+		}
+
+	}
+
+	THREE.EventDispatcher.prototype.dispatchEvent.call( this, event );
+
+		if ( !event.propagationStopped && event.bubbles && this.parent ) {
+
+			this.parent.dispatchEvent(event);
+
+		}
+
+};
+
+
 THREE.Object3DIdCount = 0;

--- a/test/unit/core/Object3D.js
+++ b/test/unit/core/Object3D.js
@@ -86,6 +86,35 @@ test( "getWorldRotation", function() {
 	ok( obj.getWorldRotation().y * RadToDeg === 90 , "y is equal" );
 });
 
+test( "dispatchEvent", function() {
+	var obj = new THREE.Object3D();
+	var child = new THREE.Object3D();
+	var deepChild = new THREE.Object3D();
+
+	obj.add(child);
+	child.add(deepChild);
+
+	var callCount = 0;
+	var listener = function() { callCount++; };
+
+	obj.addEventListener( 'anyType', listener );
+	ok( callCount === 0, "no event, no call" );
+
+	child.dispatchEvent( { type: 'anyType', bubbles: true } );
+	ok( callCount === 1, "one event, one call" );
+
+	child.dispatchEvent( { type: 'anyType' } );
+	ok( callCount === 1, "no bubbling, still one call" );
+
+	child.addEventListener( 'anyType', function(e) {
+		ok( e.target.uuid === deepChild.uuid, "'deepChild' is the target" );
+		ok( e.currentTarget.uuid === child.uuid, "'child' is the currentTarget" );
+		e.stopPropagation();
+	} );
+	deepChild.dispatchEvent( { type: 'anyType', bubbles: true } );
+	ok( callCount === 1, "propagation stopped, still one call" );
+});
+
 function checkIfPropsAreEqual(reference, obj) {
 	ok( obj.x === reference.x , "x is equal" );
 	ok( obj.y === reference.y , "y is equal!" );


### PR DESCRIPTION
As proposed on issue https://github.com/mrdoob/three.js/issues/8365, this pull-request enhances event handling on Object3D trees. 

It handles `bubbles` event attribute and adds `stopPropagation()` method, only for events triggered from `Object3D` instances - this feature doesn't make sense for other kind of objects such as `Material`, `Texture`, etc, AFAIK.

There's a simple test case for this on `test/unit/core/Object3D.js`.

It would be great to use the native `Event` / `CustomEvent` for this feature in the future - which might break existing applications though.

Feedback are welcome!
Thanks
