### PR TITLE
EffectComposer: Bugfix in reset method

### DIFF
--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -112,7 +112,7 @@ THREE.EffectComposer.prototype = {
 			var size = this.renderer.getSize();
 
 			renderTarget = this.renderTarget1.clone();
-			renderTarget.setSize( width, height );
+			renderTarget.setSize( size.width, size.height );
 
 		}
 


### PR DESCRIPTION
This PR prevents a runtime error in `EffectComposer .reset`. `width` and `height` are `undefined` (they should be properties of `size`).
