### PR TITLE
Added documentation for getSize() method

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -163,6 +163,9 @@
 		<div>
 		Return a [page:Boolean] true if the context supports vertex textures.
 		</div>
+		
+		<h3>[method:Object getSize]()</h3>
+		<div>Returns an object containing the width and height of the renderer's output canvas, in pixels.</div>
 
 		<h3>[method:null setSize]( [page:Integer width], [page:Integer height], [page:Boolean updateStyle] )</h3>
 		<div>Resizes the output canvas to (width, height), and also sets the viewport to fit that size, starting in (0, 0). Setting updateStyle to true adds explicit pixel units to the output canvas style.</div>


### PR DESCRIPTION
The [getSize() method](https://github.com/mrdoob/three.js/blob/master/src/renderers/WebGLRenderer.js#L384) lacked an entry in the documentation.
