### PR TITLE
Blender exporter skinned mesh fix

### DIFF
--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -525,8 +525,7 @@ def animation_options():
     """
     anim = [
         (constants.OFF, constants.OFF.title(), constants.OFF),
-        (constants.POSE, constants.POSE.title(), constants.POSE),
-        (constants.REST, constants.REST.title(), constants.REST)
+        (constants.POSE, constants.POSE.title(), constants.POSE)
     ]
 
     return anim
@@ -727,7 +726,7 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
     option_animation_skeletal = EnumProperty(
         name="",
-        description="Export animation (skeletal)",
+        description="Export animation (skeletal) NOTE: Mesh must be in bind pose",
         items=animation_options(),
         default=constants.OFF)
 

--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -756,8 +756,8 @@ def vertices(mesh):
     vertices_ = []
 
     for vertex in mesh.vertices:
-        vertices_.extend((vertex.co.x, vertex.co.y, vertex.co.z))
-
+        vertices_.extend((vertex.co.x, vertex.co.z, -vertex.co.y))
+        
     return vertices_
 
 

--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -218,6 +218,10 @@ def animated_xform(obj, options):
     track_loc = track_loc[0]
     use_inverted = options.get(constants.HIERARCHY, False) and obj.parent
 
+    if times == None:
+    logger.info("In animated xform: Unable to extract trackable fields from %s", objName)
+    return tracks
+
     # for each frame
     inverted_fallback = mathutils.Matrix() if use_inverted else None
     convert_matrix = AXIS_CONVERSION    # matrix to convert the exported matrix
@@ -374,7 +378,7 @@ def matrix(obj, options):
         parent_inverted = obj.parent.matrix_world.inverted(mathutils.Matrix())
         return parent_inverted * obj.matrix_world
     else:
-        return AXIS_CONVERSION * obj.matrix_world
+        return obj.matrix_world
 
 
 @_object

--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -219,8 +219,8 @@ def animated_xform(obj, options):
     use_inverted = options.get(constants.HIERARCHY, False) and obj.parent
 
     if times == None:
-    logger.info("In animated xform: Unable to extract trackable fields from %s", objName)
-    return tracks
+        logger.info("In animated xform: Unable to extract trackable fields from %s", objName)
+        return tracks
 
     # for each frame
     inverted_fallback = mathutils.Matrix() if use_inverted else None


### PR DESCRIPTION
Fixes issue with skinned meshes being flipped 90 degrees on their sides. 
- Skinned meshes now work with hierarchies turned on and off

The transformations between the mesh and the bones were inconsistent. While static mesh verts were properly transformed, it didn't take into account the bone transformations, resulting in skinned meshes with undesirable deformations.
### Notes
- Skinned meshes must be exported when skinned mesh is currently in bind pose.
- **Must** select 'Pose' from Skeletal Animations drop down in Exporter options. Currently 'Rest' doesn't work.

@repsac Please test future modifications with one of the marine Blender files included in #8410. Use examples/webgl_animation_skinning_blending.html. Thanks.

Related to issues #8317 and #8337 
