### PR TITLE
SimulationRenderer: Fix COLOR_ATTACHMENT format bug in Firefox

### DIFF
--- a/examples/js/SimulationRenderer.js
+++ b/examples/js/SimulationRenderer.js
@@ -211,9 +211,9 @@ function SimulationRenderer( WIDTH, renderer ) {
 
 	function generateVelocityTexture() {
 
-		var a = new Float32Array( PARTICLES * 3 );
+		var a = new Float32Array( PARTICLES * 4 );
 
-		for ( var k = 0, kl = a.length; k < kl; k += 3 ) {
+		for ( var k = 0, kl = a.length; k < kl; k += 4 ) {
 
 			var x = Math.random() - 0.5;
 			var y = Math.random() - 0.5;
@@ -222,10 +222,11 @@ function SimulationRenderer( WIDTH, renderer ) {
 			a[ k + 0 ] = x * 10;
 			a[ k + 1 ] = y * 10;
 			a[ k + 2 ] = z * 10;
+			a[ k + 3 ] = 1;
 
 		}
 
-		var texture = new THREE.DataTexture( a, WIDTH, WIDTH, THREE.RGBFormat, THREE.FloatType );
+		var texture = new THREE.DataTexture( a, WIDTH, WIDTH, THREE.RGBAFormat, THREE.FloatType );
 		texture.needsUpdate = true;
 
 		return texture;

--- a/examples/js/SimulationRenderer.js
+++ b/examples/js/SimulationRenderer.js
@@ -26,7 +26,7 @@ function SimulationRenderer( WIDTH, renderer ) {
 
 	}
 
-	if ( gl.getParameter( gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS ) == 0 ) {
+	if ( gl.getParameter( gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS ) === 0 ) {
 
 		alert( "No support for vertex shader textures!" );
 		return;
@@ -102,7 +102,7 @@ function SimulationRenderer( WIDTH, renderer ) {
 
 		rtPosition1 = getRenderTarget( THREE.RGBAFormat );
 		rtPosition2 = rtPosition1.clone();
-		rtVelocity1 = getRenderTarget( THREE.RGBFormat );
+		rtVelocity1 = getRenderTarget( THREE.RGBAFormat );
 		rtVelocity2 = rtVelocity1.clone();
 
 		simulator.renderTexture( dtPosition, rtPosition1 );


### PR DESCRIPTION
The example [webgl_gpgpu_birds](http://threejs.org/examples/#webgl_gpgpu_birds) is not working in Firefox. The following error message is logged in the browser console:

_Error: WebGL: drawElements: Incomplete framebuffer: Status 0x8cd6: COLOR_ATTACHMENT0 has an effective format of RGB32F, which is not renderable._

This PR changes the format of the velocity render target from `THREE.RGBFormat` to `THREE.RGBAFormat` to fix the bug. 

Tested with FF 45.0.1, Chrome 49.0.2623.87 and Safari 9.0.3 on OS X 10.10.5
