### PR TITLE
Check if PointsMaterial map is a WebGLRenderTarget.

### DIFF
--- a/examples/js/Mirror.js
+++ b/examples/js/Mirror.js
@@ -114,8 +114,8 @@ THREE.Mirror = function ( renderer, camera, options ) {
 
 	var parameters = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBFormat, stencilBuffer: false };
 
-	this.texture = new THREE.WebGLRenderTarget( width, height, parameters );
-	this.tempTexture = new THREE.WebGLRenderTarget( width, height, parameters );
+	this.renderTarget = new THREE.WebGLRenderTarget( width, height, parameters );
+	this.renderTarget2 = new THREE.WebGLRenderTarget( width, height, parameters );
 
 	var mirrorShader = THREE.ShaderLib[ "mirror" ];
 	var mirrorUniforms = THREE.UniformsUtils.clone( mirrorShader.uniforms );
@@ -128,14 +128,14 @@ THREE.Mirror = function ( renderer, camera, options ) {
 
 	} );
 
-	this.material.uniforms.mirrorSampler.value = this.texture;
+	this.material.uniforms.mirrorSampler.value = this.renderTarget.texture;
 	this.material.uniforms.mirrorColor.value = mirrorColor;
 	this.material.uniforms.textureMatrix.value = this.textureMatrix;
 
 	if ( ! THREE.Math.isPowerOfTwo( width ) || ! THREE.Math.isPowerOfTwo( height ) ) {
 
-		this.texture.generateMipmaps = false;
-		this.tempTexture.generateMipmaps = false;
+		this.renderTarget.texture.generateMipmaps = false;
+		this.renderTarget2.texture.generateMipmaps = false;
 
 	}
 
@@ -159,14 +159,14 @@ THREE.Mirror.prototype.renderWithMirror = function ( otherMirror ) {
 
 	// render the other mirror in temp texture
 	otherMirror.renderTemp();
-	otherMirror.material.uniforms.mirrorSampler.value = otherMirror.tempTexture;
+	otherMirror.material.uniforms.mirrorSampler.value = otherMirror.renderTarget2.texture;
 
 	// render the current mirror
 	this.render();
 	this.matrixNeedsUpdate = true;
 
 	// restore material and camera of other mirror
-	otherMirror.material.uniforms.mirrorSampler.value = otherMirror.texture;
+	otherMirror.material.uniforms.mirrorSampler.value = otherMirror.renderTarget.texture;
 	otherMirror.camera = tempCamera;
 
 	// restore texture matrix of other mirror
@@ -269,7 +269,7 @@ THREE.Mirror.prototype.render = function () {
 		var visible = this.material.visible;
 		this.material.visible = false;
 
-		this.renderer.render( scene, this.mirrorCamera, this.texture, true );
+		this.renderer.render( scene, this.mirrorCamera, this.renderTarget, true );
 
 		this.material.visible = visible;
 
@@ -294,7 +294,7 @@ THREE.Mirror.prototype.renderTemp = function () {
 
 	if ( scene !== undefined && scene instanceof THREE.Scene ) {
 
-		this.renderer.render( scene, this.mirrorCamera, this.tempTexture, true );
+		this.renderer.render( scene, this.mirrorCamera, this.renderTarget2, true );
 
 	}
 

--- a/examples/js/Ocean.js
+++ b/examples/js/Ocean.js
@@ -172,8 +172,8 @@
 	} );
 	// this.materialOcean.wireframe = true;
 	this.materialOcean.uniforms.u_geometrySize = { type: "f", value: this.resolution };
-	this.materialOcean.uniforms.u_displacementMap = { type: "t", value: this.displacementMapFramebuffer };
-	this.materialOcean.uniforms.u_normalMap = { type: "t", value: this.normalMapFramebuffer };
+	this.materialOcean.uniforms.u_displacementMap = { type: "t", value: this.displacementMapFramebuffer.texture };
+	this.materialOcean.uniforms.u_normalMap = { type: "t", value: this.normalMapFramebuffer.texture };
 	this.materialOcean.uniforms.u_oceanColor = { type: "v3", value: this.oceanColor };
 	this.materialOcean.uniforms.u_skyColor = { type: "v3", value: this.skyColor };
 	this.materialOcean.uniforms.u_sunDirection = { type: "v3", value: new THREE.Vector3( this.sunDirectionX, this.sunDirectionY, this.sunDirectionZ ) };
@@ -271,7 +271,7 @@ THREE.Ocean.prototype.renderWavePhase = function () {
 
 	}else {
 
-		this.materialPhase.uniforms.u_phases.value = this.pingPhase ? this.pingPhaseFramebuffer  : this.pongPhaseFramebuffer;
+		this.materialPhase.uniforms.u_phases.value = this.pingPhase ? this.pingPhaseFramebuffer.texture : this.pongPhaseFramebuffer.texture;
 
 	}
 	this.materialPhase.uniforms.u_deltaTime.value = this.deltaTime;
@@ -284,10 +284,10 @@ THREE.Ocean.prototype.renderWavePhase = function () {
 THREE.Ocean.prototype.renderSpectrum = function () {
 
 	this.scene.overrideMaterial = this.materialSpectrum;
-	this.materialSpectrum.uniforms.u_initialSpectrum.value = this.initialSpectrumFramebuffer;
-	this.materialSpectrum.uniforms.u_phases.value = this.pingPhase ? this.pingPhaseFramebuffer : this.pongPhaseFramebuffer;
-	this.materialSpectrum.uniforms.u_choppiness.value = this.choppiness ;
-	this.materialSpectrum.uniforms.u_size.value = this.size ;
+	this.materialSpectrum.uniforms.u_initialSpectrum.value = this.initialSpectrumFramebuffer.texture;
+	this.materialSpectrum.uniforms.u_phases.value = this.pingPhase ? this.pingPhaseFramebuffer.texture : this.pongPhaseFramebuffer.texture;
+	this.materialSpectrum.uniforms.u_choppiness.value = this.choppiness;
+	this.materialSpectrum.uniforms.u_size.value = this.size;
 	this.renderer.render( this.scene, this.oceanCamera, this.spectrumFramebuffer );
 
 };
@@ -303,19 +303,19 @@ THREE.Ocean.prototype.renderSpectrumFFT = function() {
 
 		if ( i === 0 ) {
 
-			this.materialOceanHorizontal.uniforms.u_input.value = this.spectrumFramebuffer;
+			this.materialOceanHorizontal.uniforms.u_input.value = this.spectrumFramebuffer.texture;
 			this.materialOceanHorizontal.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pingTransformFramebuffer );
 
 		} else if ( i % 2 === 1 ) {
 
-			this.materialOceanHorizontal.uniforms.u_input.value = this.pingTransformFramebuffer;
+			this.materialOceanHorizontal.uniforms.u_input.value = this.pingTransformFramebuffer.texture;
 			this.materialOceanHorizontal.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pongTransformFramebuffer );
 
 		} else {
 
-			this.materialOceanHorizontal.uniforms.u_input.value = this.pongTransformFramebuffer;
+			this.materialOceanHorizontal.uniforms.u_input.value = this.pongTransformFramebuffer.texture;
 			this.materialOceanHorizontal.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pingTransformFramebuffer );
 
@@ -327,19 +327,19 @@ THREE.Ocean.prototype.renderSpectrumFFT = function() {
 
 		if ( i === iterations * 2 - 1 ) {
 
-			this.materialOceanVertical.uniforms.u_input.value = ( iterations % 2 === 0 ) ? this.pingTransformFramebuffer : this.pongTransformFramebuffer;
+			this.materialOceanVertical.uniforms.u_input.value = ( iterations % 2 === 0 ) ? this.pingTransformFramebuffer.texture : this.pongTransformFramebuffer.texture;
 			this.materialOceanVertical.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.displacementMapFramebuffer );
 
 		} else if ( i % 2 === 1 ) {
 
-			this.materialOceanVertical.uniforms.u_input.value = this.pingTransformFramebuffer;
+			this.materialOceanVertical.uniforms.u_input.value = this.pingTransformFramebuffer.texture;
 			this.materialOceanVertical.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pongTransformFramebuffer );
 
 		} else {
 
-			this.materialOceanVertical.uniforms.u_input.value = this.pongTransformFramebuffer;
+			this.materialOceanVertical.uniforms.u_input.value = this.pongTransformFramebuffer.texture;
 			this.materialOceanVertical.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pingTransformFramebuffer );
 
@@ -353,7 +353,7 @@ THREE.Ocean.prototype.renderNormalMap = function () {
 
 	this.scene.overrideMaterial = this.materialNormal;
 	if ( this.changed ) this.materialNormal.uniforms.u_size.value = this.size;
-	this.materialNormal.uniforms.u_displacementMap.value = this.displacementMapFramebuffer;
+	this.materialNormal.uniforms.u_displacementMap.value = this.displacementMapFramebuffer.texture;
 	this.renderer.render( this.scene, this.oceanCamera, this.normalMapFramebuffer, true );
 
 };

--- a/examples/js/SimulationRenderer.js
+++ b/examples/js/SimulationRenderer.js
@@ -106,10 +106,10 @@ function SimulationRenderer( WIDTH, renderer ) {
 		rtVelocity2 = rtVelocity1.clone();
 
 		simulator.renderTexture( dtPosition, rtPosition1 );
-		simulator.renderTexture( rtPosition1, rtPosition2 );
+		simulator.renderTexture( rtPosition1.texture, rtPosition2 );
 
 		simulator.renderTexture( dtVelocity, rtVelocity1 );
-		simulator.renderTexture( rtVelocity1, rtVelocity2 );
+		simulator.renderTexture( rtVelocity1.texture, rtVelocity2 );
 
 		simulator.velocityUniforms.testing.value = 10;
 
@@ -146,8 +146,8 @@ function SimulationRenderer( WIDTH, renderer ) {
 	this.renderPosition = function( position, velocity, output, delta ) {
 
 		mesh.material = positionShader;
-		positionShader.uniforms.texturePosition.value = position;
-		positionShader.uniforms.textureVelocity.value = velocity;
+		positionShader.uniforms.texturePosition.value = position.texture;
+		positionShader.uniforms.textureVelocity.value = velocity.texture;
 		positionShader.uniforms.time.value = performance.now();
 		positionShader.uniforms.delta.value = delta;
 		renderer.render( scene, camera, output );
@@ -158,8 +158,8 @@ function SimulationRenderer( WIDTH, renderer ) {
 	this.renderVelocity = function( position, velocity, output, delta ) {
 
 		mesh.material = velocityShader;
-		velocityShader.uniforms.texturePosition.value = position;
-		velocityShader.uniforms.textureVelocity.value = velocity;
+		velocityShader.uniforms.texturePosition.value = position.texture;
+		velocityShader.uniforms.textureVelocity.value = velocity.texture;
 		velocityShader.uniforms.time.value = performance.now();
 		velocityShader.uniforms.delta.value = delta;
 		renderer.render( scene, camera, output );

--- a/examples/js/WaterShader.js
+++ b/examples/js/WaterShader.js
@@ -150,9 +150,11 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 	this.lookAtPosition = new THREE.Vector3( 0, 0, - 1 );
 	this.clipPlane = new THREE.Vector4();
 
-	if ( camera instanceof THREE.PerspectiveCamera )
+	if ( camera instanceof THREE.PerspectiveCamera ) {
+
 		this.camera = camera;
-	else {
+
+	} else {
 
 		this.camera = new THREE.PerspectiveCamera();
 		console.log( this.name + ': camera is not a Perspective Camera!' );
@@ -163,8 +165,8 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 
 	this.mirrorCamera = this.camera.clone();
 
-	this.texture = new THREE.WebGLRenderTarget( width, height );
-	this.tempTexture = new THREE.WebGLRenderTarget( width, height );
+	this.renderTarget = new THREE.WebGLRenderTarget( width, height );
+	this.renderTarget2 = new THREE.WebGLRenderTarget( width, height );
 
 	var mirrorShader = THREE.ShaderLib[ "water" ];
 	var mirrorUniforms = THREE.UniformsUtils.clone( mirrorShader.uniforms );
@@ -178,7 +180,7 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 		fog: this.fog
 	} );
 
-	this.material.uniforms.mirrorSampler.value = this.texture;
+	this.material.uniforms.mirrorSampler.value = this.renderTarget.texture;
 	this.material.uniforms.textureMatrix.value = this.textureMatrix;
 	this.material.uniforms.alpha.value = this.alpha;
 	this.material.uniforms.time.value = this.time;
@@ -192,10 +194,10 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 
 	if ( ! THREE.Math.isPowerOfTwo( width ) || ! THREE.Math.isPowerOfTwo( height ) ) {
 
-		this.texture.generateMipmaps = false;
-		this.texture.minFilter = THREE.LinearFilter;
-		this.tempTexture.generateMipmaps = false;
-		this.tempTexture.minFilter = THREE.LinearFilter;
+		this.renderTarget.texture.generateMipmaps = false;
+		this.renderTarget.texture.minFilter = THREE.LinearFilter;
+		this.renderTarget2.texture.generateMipmaps = false;
+		this.renderTarget2.texture.minFilter = THREE.LinearFilter;
 
 	}
 

--- a/examples/js/crossfade/scenes.js
+++ b/examples/js/crossfade/scenes.js
@@ -101,10 +101,15 @@ function Scene ( type, numObjects, cameraZ, fov, rotationSpeed, clearColor ) {
 
 		renderer.setClearColor( this.clearColor );
 
-		if ( rtt )
+		if ( rtt ) {
+
 			renderer.render( this.scene, this.camera, this.fbo, true );
-		else
+
+		} else {
+
 			renderer.render( this.scene, this.camera );
+
+		}
 
 	};
 

--- a/examples/js/crossfade/transition.js
+++ b/examples/js/crossfade/transition.js
@@ -94,8 +94,8 @@ function Transition ( sceneA, sceneB ) {
 	this.sceneA = sceneA;
 	this.sceneB = sceneB;
 
-	this.quadmaterial.uniforms.tDiffuse1.value = sceneA.fbo;
-	this.quadmaterial.uniforms.tDiffuse2.value = sceneB.fbo;
+	this.quadmaterial.uniforms.tDiffuse1.value = sceneA.fbo.texture;
+	this.quadmaterial.uniforms.tDiffuse2.value = sceneB.fbo.texture;
 
 	this.needChange = false;
 

--- a/examples/js/effects/AnaglyphEffect.js
+++ b/examples/js/effects/AnaglyphEffect.js
@@ -24,8 +24,8 @@ THREE.AnaglyphEffect = function ( renderer, width, height ) {
 
 		uniforms: {
 
-			"mapLeft": { type: "t", value: _renderTargetL },
-			"mapRight": { type: "t", value: _renderTargetR }
+			"mapLeft": { type: "t", value: _renderTargetL.texture },
+			"mapRight": { type: "t", value: _renderTargetR.texture }
 
 		},
 

--- a/examples/js/effects/ParallaxBarrierEffect.js
+++ b/examples/js/effects/ParallaxBarrierEffect.js
@@ -21,8 +21,8 @@ THREE.ParallaxBarrierEffect = function ( renderer ) {
 
 		uniforms: {
 
-			"mapLeft": { type: "t", value: _renderTargetL },
-			"mapRight": { type: "t", value: _renderTargetR }
+			"mapLeft": { type: "t", value: _renderTargetL.texture },
+			"mapRight": { type: "t", value: _renderTargetR.texture }
 
 		},
 

--- a/examples/js/pmrem/PMREMCubeUVPacker.js
+++ b/examples/js/pmrem/PMREMCubeUVPacker.js
@@ -45,11 +45,13 @@ THREE.PMREMCubeUVPacker = function( cubeTextureLods, numLods ) {
 	var offset2 = 0;
 	var c = 4.0;
 	this.numLods = Math.log2( cubeTextureLods[ 0 ].width ) - 2;
+
 	for ( var i = 0; i < this.numLods; i ++ ) {
 
 		var offset1 = ( textureResolution - textureResolution / c ) * 0.5;
-		if ( size > 16 )
-		c *= 2;
+
+		if ( size > 16 ) c *= 2;
+
 		var nMips = size > 16 ? 6 : 1;
 		var mipOffsetX = 0;
 		var mipOffsetY = 0;
@@ -62,15 +64,13 @@ THREE.PMREMCubeUVPacker = function( cubeTextureLods, numLods ) {
 
 				// 6 Cube Faces
 				var material = this.getShader();
-				material.uniforms[ "envMap" ].value = this.cubeLods[ i ];
-				material.envMap = this.cubeLods[ i ]
+				material.uniforms[ "envMap" ].value = this.cubeLods[ i ].texture;
+				material.envMap = this.cubeLods[ i ].texture;
 				material.uniforms[ "faceIndex" ].value = k;
 				material.uniforms[ "mapSize" ].value = mipSize;
 				var color = material.uniforms[ "testColor" ].value;
 				//color.copy(testColor[j]);
-				var planeMesh = new THREE.Mesh(
-				new THREE.PlaneGeometry( mipSize, mipSize, 0 ),
-				material );
+				var planeMesh = new THREE.Mesh( new THREE.PlaneGeometry( mipSize, mipSize, 0 ), material );
 				planeMesh.position.x = faceOffsets[ k ].x * mipSize - offset1 + mipOffsetX;
 				planeMesh.position.y = faceOffsets[ k ].y * mipSize - offset1 + offset2 + mipOffsetY;
 				planeMesh.material.side = THREE.DoubleSide;
@@ -78,6 +78,7 @@ THREE.PMREMCubeUVPacker = function( cubeTextureLods, numLods ) {
 				this.objects.push( planeMesh );
 
 			}
+
 			mipOffsetY += 1.75 * mipSize;
 			mipOffsetX += 1.25 * mipSize;
 			mipSize /= 2;

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -30,7 +30,9 @@ THREE.PMREMGenerator = function( sourceTexture ) {
 
   // how many LODs fit in the given CubeUV Texture.
 	this.numLods = Math.log2( size ) - 2;
+
   for ( var i = 0; i < this.numLods; i ++ ) {
+
 		var renderTarget = new THREE.WebGLRenderTargetCube( size, size, params );
 		renderTarget.texture.generateMipmaps = this.sourceTexture.generateMipmaps;
     renderTarget.texture.anisotropy = this.sourceTexture.anisotropy;
@@ -39,6 +41,7 @@ THREE.PMREMGenerator = function( sourceTexture ) {
     renderTarget.texture.magFilter = this.sourceTexture.magFilter;
 		this.cubeLods.push( renderTarget );
 		size = Math.max( 16, size / 2 );
+
 	}
 
 	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0.0, 1000 );
@@ -80,6 +83,7 @@ THREE.PMREMGenerator.prototype = {
     var gammaOutput = renderer.gammaOutput;
     renderer.gammaInput = false;
     renderer.gammaOutput = false;
+
 		for ( var i = 0; i < this.numLods; i ++ ) {
 
 			var r = i / ( this.numLods - 1 );
@@ -87,8 +91,8 @@ THREE.PMREMGenerator.prototype = {
 			var size = this.cubeLods[ i ].width;
 			this.shader.uniforms[ "mapSize" ].value = size;
 			this.renderToCubeMapTarget( renderer, this.cubeLods[ i ] );
-			if ( i < 5 )
-			this.shader.uniforms[ "envMap" ].value = this.cubeLods[ i ];
+
+			if ( i < 5 ) this.shader.uniforms[ "envMap" ].value = this.cubeLods[ i ].texture;
 
 		}
 
@@ -100,12 +104,15 @@ THREE.PMREMGenerator.prototype = {
 	renderToCubeMapTarget: function( renderer, renderTarget ) {
 
 		for ( var i = 0; i < 6; i ++ ) {
-		  this.renderToCubeMapTargetFace( renderer, renderTarget, i )
+
+		  this.renderToCubeMapTargetFace( renderer, renderTarget, i );
+
     }
 
 	},
 
 	renderToCubeMapTargetFace: function( renderer, renderTarget, faceIndex ) {
+
 		renderTarget.activeCubeFace = faceIndex;
 		this.shader.uniforms[ "faceIndex" ].value = faceIndex;
 		renderer.render( this.scene, this.camera, renderTarget, true );

--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -144,26 +144,26 @@ THREE.AdaptiveToneMappingPass.prototype = {
 
 			//Render the luminance of the current scene into a render target with mipmapping enabled
 			this.quad.material = this.materialLuminance;
-			this.materialLuminance.uniforms.tDiffuse.value = readBuffer;
+			this.materialLuminance.uniforms.tDiffuse.value = readBuffer.texture;
 			renderer.render( this.scene, this.camera, this.currentLuminanceRT );
 
 			//Use the new luminance values, the previous luminance and the frame delta to
 			//adapt the luminance over time.
 			this.quad.material = this.materialAdaptiveLum;
 			this.materialAdaptiveLum.uniforms.delta.value = delta;
-			this.materialAdaptiveLum.uniforms.lastLum.value = this.previousLuminanceRT;
-			this.materialAdaptiveLum.uniforms.currentLum.value = this.currentLuminanceRT;
+			this.materialAdaptiveLum.uniforms.lastLum.value = this.previousLuminanceRT.texture;
+			this.materialAdaptiveLum.uniforms.currentLum.value = this.currentLuminanceRT.texture;
 			renderer.render( this.scene, this.camera, this.luminanceRT );
 
 			//Copy the new adapted luminance value so that it can be used by the next frame.
 			this.quad.material = this.materialCopy;
-			this.copyUniforms.tDiffuse.value = this.luminanceRT;
+			this.copyUniforms.tDiffuse.value = this.luminanceRT.texture;
 			renderer.render( this.scene, this.camera, this.previousLuminanceRT );
 
 		}
 
 		this.quad.material = this.materialToneMap;
-		this.materialToneMap.uniforms.tDiffuse.value = readBuffer;
+		this.materialToneMap.uniforms.tDiffuse.value = readBuffer.texture;
 		renderer.render( this.scene, this.camera, writeBuffer, this.clear );
 
 	},
@@ -201,7 +201,7 @@ THREE.AdaptiveToneMappingPass.prototype = {
 		if ( this.adaptive ) {
 
 			this.materialToneMap.defines[ "ADAPTED_LUMINANCE" ] = "";
-			this.materialToneMap.uniforms.luminanceMap.value = this.luminanceRT;
+			this.materialToneMap.uniforms.luminanceMap.value = this.luminanceRT.texture;
 
 		}
 		//Put something in the adaptive luminance texture so that the scene can render initially
@@ -221,13 +221,13 @@ THREE.AdaptiveToneMappingPass.prototype = {
 
 			this.adaptive = true;
 			this.materialToneMap.defines[ "ADAPTED_LUMINANCE" ] = "";
-			this.materialToneMap.uniforms.luminanceMap.value = this.luminanceRT;
+			this.materialToneMap.uniforms.luminanceMap.value = this.luminanceRT.texture;
 
 		} else {
 
 			this.adaptive = false;
 			delete this.materialToneMap.defines[ "ADAPTED_LUMINANCE" ];
-			this.materialToneMap.uniforms.luminanceMap.value = undefined;
+			this.materialToneMap.uniforms.luminanceMap.value = null;
 
 		}
 		this.materialToneMap.needsUpdate = true;

--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -84,7 +84,7 @@ THREE.BloomPass.prototype = {
 
 		this.quad.material = this.materialConvolution;
 
-		this.convolutionUniforms[ "tDiffuse" ].value = readBuffer;
+		this.convolutionUniforms[ "tDiffuse" ].value = readBuffer.texture;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurX;
 
 		renderer.render( this.scene, this.camera, this.renderTargetX, true );
@@ -92,7 +92,7 @@ THREE.BloomPass.prototype = {
 
 		// Render quad with blured scene into texture (convolution pass 2)
 
-		this.convolutionUniforms[ "tDiffuse" ].value = this.renderTargetX;
+		this.convolutionUniforms[ "tDiffuse" ].value = this.renderTargetX.texture;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurY;
 
 		renderer.render( this.scene, this.camera, this.renderTargetY, true );
@@ -101,7 +101,7 @@ THREE.BloomPass.prototype = {
 
 		this.quad.material = this.materialCopy;
 
-		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetY;
+		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetY.texture;
 
 		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
 

--- a/examples/js/postprocessing/BokehPass.js
+++ b/examples/js/postprocessing/BokehPass.js
@@ -41,7 +41,7 @@ THREE.BokehPass = function ( scene, camera, params ) {
 	var bokehShader = THREE.BokehShader;
 	var bokehUniforms = THREE.UniformsUtils.clone( bokehShader.uniforms );
 
-	bokehUniforms[ "tDepth" ].value = this.renderTargetDepth;
+	bokehUniforms[ "tDepth" ].value = this.renderTargetDepth.texture;
 
 	bokehUniforms[ "focus" ].value = focus;
 	bokehUniforms[ "aspect" ].value = aspect;
@@ -82,7 +82,7 @@ THREE.BokehPass.prototype = {
 
 		// Render bokeh composite
 
-		this.uniforms[ "tColor" ].value = readBuffer;
+		this.uniforms[ "tColor" ].value = readBuffer.texture;
 
 		if ( this.renderToScreen ) {
 

--- a/examples/js/postprocessing/DotScreenPass.js
+++ b/examples/js/postprocessing/DotScreenPass.js
@@ -40,7 +40,7 @@ THREE.DotScreenPass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta ) {
 
-		this.uniforms[ "tDiffuse" ].value = readBuffer;
+		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;
 		this.uniforms[ "tSize" ].value.set( readBuffer.width, readBuffer.height );
 
 		this.quad.material = this.material;

--- a/examples/js/postprocessing/FilmPass.js
+++ b/examples/js/postprocessing/FilmPass.js
@@ -41,7 +41,7 @@ THREE.FilmPass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta ) {
 
-		this.uniforms[ "tDiffuse" ].value = readBuffer;
+		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;
 		this.uniforms[ "time" ].value += delta;
 
 		this.quad.material = this.material;

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -42,8 +42,8 @@ THREE.GlitchPass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta ) {
 
-		this.uniforms[ "tDiffuse" ].value = readBuffer;
-		this.uniforms[ 'seed' ].value = Math.random();//default seeding
+		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;
+		this.uniforms[ 'seed' ].value = Math.random(); // default seeding
 		this.uniforms[ 'byp' ].value = 0;
 		
 		if ( this.curF % this.randX == 0 || this.goWild == true ) {

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -101,7 +101,7 @@ THREE.ManualMSAARenderPass.prototype = {
 		renderer.autoClear = false;
 
 		this.compositeUniforms[ "scale" ].value = 1.0 / ( jitterOffsets.length );
-		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget;
+		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget.texture;
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( var i = 0; i < jitterOffsets.length; i ++ ) {

--- a/examples/js/postprocessing/SMAAPass.js
+++ b/examples/js/postprocessing/SMAAPass.js
@@ -68,7 +68,7 @@ THREE.SMAAPass = function ( width, height ) {
 	this.uniformsWeights = THREE.UniformsUtils.clone( THREE.SMAAShader[1].uniforms );
 
 	this.uniformsWeights[ "resolution" ].value.set( 1 / width, 1 / height );
-	this.uniformsWeights[ "tDiffuse" ].value = this.edgesRT;
+	this.uniformsWeights[ "tDiffuse" ].value = this.edgesRT.texture;
 	this.uniformsWeights[ "tArea" ].value = this.areaTexture;
 	this.uniformsWeights[ "tSearch" ].value = this.searchTexture;
 
@@ -84,7 +84,7 @@ THREE.SMAAPass = function ( width, height ) {
 	this.uniformsBlend = THREE.UniformsUtils.clone( THREE.SMAAShader[2].uniforms );
 
 	this.uniformsBlend[ "resolution" ].value.set( 1 / width, 1 / height );
-	this.uniformsBlend[ "tDiffuse" ].value = this.weightsRT;
+	this.uniformsBlend[ "tDiffuse" ].value = this.weightsRT.texture;
 
 	this.materialBlend = new THREE.ShaderMaterial( {
 		uniforms: this.uniformsBlend,
@@ -114,7 +114,7 @@ THREE.SMAAPass.prototype = {
 
 		// pass 1
 
-		this.uniformsEdges[ "tDiffuse" ].value = readBuffer;
+		this.uniformsEdges[ "tDiffuse" ].value = readBuffer.texture;
 
 		this.quad.material = this.materialEdges;
 
@@ -128,7 +128,7 @@ THREE.SMAAPass.prototype = {
 
 		// pass 3
 
-		this.uniformsBlend[ "tColor" ].value = readBuffer;
+		this.uniformsBlend[ "tColor" ].value = readBuffer.texture;
 
 		this.quad.material = this.materialBlend;
 

--- a/examples/js/postprocessing/SavePass.js
+++ b/examples/js/postprocessing/SavePass.js
@@ -49,7 +49,7 @@ THREE.SavePass.prototype = {
 
 		if ( this.uniforms[ this.textureID ] ) {
 
-			this.uniforms[ this.textureID ].value = readBuffer;
+			this.uniforms[ this.textureID ].value = readBuffer.texture;
 
 		}
 

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -49,7 +49,7 @@ THREE.ShaderPass.prototype = {
 
 		if ( this.uniforms[ this.textureID ] ) {
 
-			this.uniforms[ this.textureID ].value = readBuffer;
+			this.uniforms[ this.textureID ].value = readBuffer.texture;
 
 		}
 

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -73,7 +73,7 @@ THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuf
 	if( this.accumulateIndex >= 0 && this.accumulateIndex < jitterOffsets.length ) {
 
 		this.compositeUniforms[ "scale" ].value = sampleWeight;
-		this.compositeUniforms[ "tForeground" ].value = writeBuffer;
+		this.compositeUniforms[ "tForeground" ].value = writeBuffer.texture;
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		var numSamplesPerFrame = Math.pow( 2, this.sampleLevel );
@@ -105,13 +105,13 @@ THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuf
 
 	if( accumulationWeight > 0 ) {
 		this.compositeUniforms[ "scale" ].value = 1.0;
-		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget;
+		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget.texture;
 		renderer.render( this.scene2, this.camera2, writeBuffer, true );
 	}
 
 	if( accumulationWeight < 1.0 ) {
 		this.compositeUniforms[ "scale" ].value = 1.0 - accumulationWeight;
-		this.compositeUniforms[ "tForeground" ].value = this.holdRenderTarget;
+		this.compositeUniforms[ "tForeground" ].value = this.holdRenderTarget.texture;
 		renderer.render( this.scene2, this.camera2, writeBuffer, ( accumulationWeight === 0 ) );
 	}
 

--- a/examples/js/utils/ShadowMapViewer.js
+++ b/examples/js/utils/ShadowMapViewer.js
@@ -150,7 +150,7 @@ THREE.ShadowMapViewer = function ( light ) {
 			//always end up with the scene's first added shadow casting light's shadowMap
 			//in the shader
 			//See: https://github.com/mrdoob/three.js/issues/5932
-			uniforms.tDiffuse.value = light.shadow.map;
+			uniforms.tDiffuse.value = light.shadow.map ? light.shadow.map.texture : null;
 
 			userAutoClearSetting = renderer.autoClear;
 			renderer.autoClear = false; // To allow render overlay

--- a/examples/webgl_interactive_instances_gpu.html
+++ b/examples/webgl_interactive_instances_gpu.html
@@ -986,10 +986,13 @@
 
 			}
 
+			stats.begin();
+
 			controls.update();
-			stats.update();
 
 			render();
+
+			stats.end();
 
 		}
 

--- a/examples/webgl_materials_bumpmap_skin.html
+++ b/examples/webgl_materials_bumpmap_skin.html
@@ -221,7 +221,7 @@
 				uniforms[ "enableBump" ].value = true;
 				uniforms[ "enableSpecular" ].value = true;
 
-				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1;
+				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1.texture;
 				uniforms[ "tDiffuse" ].value = mapColor;
 
 				uniforms[ "bumpMap" ].value = mapHeight;

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -210,31 +210,31 @@
 
 					body: [],
 
-					"Chrome": new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: cubeTarget  } ),
+					"Chrome": new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: cubeTarget.texture  } ),
 
-					"Dark chrome": new THREE.MeshLambertMaterial( { color: 0x444444, envMap: cubeTarget } ),
+					"Dark chrome": new THREE.MeshLambertMaterial( { color: 0x444444, envMap: cubeTarget.texture } ),
 
-					"Black rough": new THREE.MeshLambertMaterial( { color: 0x050505, } ),
+					"Black rough": new THREE.MeshLambertMaterial( { color: 0x050505 } ),
 
-					"Dark glass": new THREE.MeshLambertMaterial( { color: 0x101020, envMap: cubeTarget, opacity: 0.5, transparent: true } ),
+					"Dark glass": new THREE.MeshLambertMaterial( { color: 0x101020, envMap: cubeTarget.texture, opacity: 0.5, transparent: true } ),
 					"Orange glass": new THREE.MeshLambertMaterial( { color: 0xffbb00, opacity: 0.5, transparent: true } ),
 					"Red glass": new THREE.MeshLambertMaterial( { color: 0xff0000, opacity: 0.5, transparent: true } ),
 
-					"Black metal": new THREE.MeshLambertMaterial( { color: 0x222222, envMap: cubeTarget, combine: THREE.MultiplyOperation } ),
-					"Orange metal": new THREE.MeshLambertMaterial( { color: 0xff6600, envMap: cubeTarget, combine: THREE.MultiplyOperation } )
+					"Black metal": new THREE.MeshLambertMaterial( { color: 0x222222, envMap: cubeTarget.texture, combine: THREE.MultiplyOperation } ),
+					"Orange metal": new THREE.MeshLambertMaterial( { color: 0xff6600, envMap: cubeTarget.texture, combine: THREE.MultiplyOperation } )
 
 				};
 
-				mlib.body.push( [ "Orange", new THREE.MeshLambertMaterial( { color: 0x883300, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
-				mlib.body.push( [ "Blue", new THREE.MeshLambertMaterial( { color: 0x113355, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
-				mlib.body.push( [ "Red", new THREE.MeshLambertMaterial( { color: 0x660000, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
-				mlib.body.push( [ "Black", new THREE.MeshLambertMaterial( { color: 0x000000, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
-				mlib.body.push( [ "White", new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
+				mlib.body.push( [ "Orange", new THREE.MeshLambertMaterial( { color: 0x883300, envMap: cubeTarget.texture, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
+				mlib.body.push( [ "Blue", new THREE.MeshLambertMaterial( { color: 0x113355, envMap: cubeTarget.texture, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
+				mlib.body.push( [ "Red", new THREE.MeshLambertMaterial( { color: 0x660000, envMap: cubeTarget.texture, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
+				mlib.body.push( [ "Black", new THREE.MeshLambertMaterial( { color: 0x000000, envMap: cubeTarget.texture, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
+				mlib.body.push( [ "White", new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: cubeTarget.texture, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
 
-				mlib.body.push( [ "Carmine", new THREE.MeshPhongMaterial( { color: 0x770000, specular: 0xffaaaa, envMap: cubeTarget, combine: THREE.MultiplyOperation } ) ] );
-				mlib.body.push( [ "Gold", new THREE.MeshPhongMaterial( { color: 0xaa9944, specular: 0xbbaa99, shininess: 50, envMap: cubeTarget, combine: THREE.MultiplyOperation } ) ] );
-				mlib.body.push( [ "Bronze", new THREE.MeshPhongMaterial( { color: 0x150505, specular: 0xee6600, shininess: 10, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
-				mlib.body.push( [ "Chrome", new THREE.MeshPhongMaterial( { color: 0xffffff, specular: 0xffffff, envMap: cubeTarget, combine: THREE.MultiplyOperation } ) ] );
+				mlib.body.push( [ "Carmine", new THREE.MeshPhongMaterial( { color: 0x770000, specular: 0xffaaaa, envMap: cubeTarget.texture, combine: THREE.MultiplyOperation } ) ] );
+				mlib.body.push( [ "Gold", new THREE.MeshPhongMaterial( { color: 0xaa9944, specular: 0xbbaa99, shininess: 50, envMap: cubeTarget.texture, combine: THREE.MultiplyOperation } ) ] );
+				mlib.body.push( [ "Bronze", new THREE.MeshPhongMaterial( { color: 0x150505, specular: 0xee6600, shininess: 10, envMap: cubeTarget.texture, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
+				mlib.body.push( [ "Chrome", new THREE.MeshPhongMaterial( { color: 0xffffff, specular: 0xffffff, envMap: cubeTarget.texture, combine: THREE.MultiplyOperation } ) ] );
 
 				// FLARES
 				var textureLoader = new THREE.TextureLoader();
@@ -324,11 +324,11 @@
 
 					var params  = {
 
-						"a" : { map: flareA, useScreenCoordinates: false, color: 0xffffff, blending: THREE.AdditiveBlending },
-						"b" : { map: flareB, useScreenCoordinates: false, color: 0xffffff, blending: THREE.AdditiveBlending },
+						"a" : { map: flareA, color: 0xffffff, blending: THREE.AdditiveBlending },
+						"b" : { map: flareB, color: 0xffffff, blending: THREE.AdditiveBlending },
 
-						"ar" : { map: flareA, useScreenCoordinates: false, color: 0xff0000, blending: THREE.AdditiveBlending },
-						"br" : { map: flareB, useScreenCoordinates: false, color: 0xff0000, blending: THREE.AdditiveBlending }
+						"ar" : { map: flareA, color: 0xff0000, blending: THREE.AdditiveBlending },
+						"br" : { map: flareB, color: 0xff0000, blending: THREE.AdditiveBlending }
 
 					};
 
@@ -445,7 +445,7 @@
 
 				// motion blur
 
-				effectBlend.uniforms[ 'tDiffuse2' ].value = effectSave.renderTarget;
+				effectBlend.uniforms[ 'tDiffuse2' ].value = effectSave.renderTarget.texture;
 				effectBlend.uniforms[ 'mixRatio' ].value = 0.65;
 
 				var renderModel = new THREE.RenderPass( scene, camera );
@@ -676,7 +676,7 @@
 
 				var shadowPlane = new THREE.PlaneBufferGeometry( shadowWidth, shadowHeight );
 				var shadowMaterial = new THREE.MeshBasicMaterial( {
-					color: 0xffffff, opacity: 0.5, transparent: true, map: shadowTexture,
+					color: 0xffffff, opacity: 0.5, transparent: true, map: shadowTexture.texture,
 					polygonOffset: false, polygonOffsetFactor: -0.5, polygonOffsetUnits: 1
 				} );
 
@@ -868,8 +868,11 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
+
 				render();
-				stats.update();
+
+				stats.end();
 
 			}
 

--- a/examples/webgl_materials_cubemap_dynamic2.html
+++ b/examples/webgl_materials_cubemap_dynamic2.html
@@ -78,7 +78,7 @@
 
 				//
 
-				var material = new THREE.MeshBasicMaterial( { envMap: cubeCamera.renderTarget } );
+				var material = new THREE.MeshBasicMaterial( { envMap: cubeCamera.renderTarget.texture } );
 
 				sphere = new THREE.Mesh( new THREE.SphereGeometry( 20, 30, 15 ), material );
 				scene.add( sphere );

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -153,8 +153,9 @@
 
 					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
 
-					standardMaterial.envMap = hdrCubeRenderTarget;
+					standardMaterial.envMap = hdrCubeRenderTarget.texture;
 					standardMaterial.needsUpdate = true;
+
 				} );
 
 				var ldrUrls = genCubeUrls( "./textures/cube/pisa/", ".png" );
@@ -169,6 +170,7 @@
 					pmremCubeUVPacker.update( renderer );
 
 					ldrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+
 				} );
 
 
@@ -184,6 +186,7 @@
 					pmremCubeUVPacker.update( renderer );
 
 					rgbmCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+
 				} );
 
 				// Lights
@@ -269,9 +272,9 @@
 					standardMaterial.roughness = params.roughness;
 					standardMaterial.bumpScale = - 0.05 * params.bumpScale;
 					switch( params.envMap ) {
-						case 'LDR': standardMaterial.envMap = ldrCubeRenderTarget; break;
-						case 'HDR': standardMaterial.envMap = hdrCubeRenderTarget; break;
-						case 'RGBM16': standardMaterial.envMap = rgbmCubeRenderTarget; break;
+						case 'LDR': standardMaterial.envMap = ldrCubeRenderTarget ? ldrCubeRenderTarget.texture : null; break;
+						case 'HDR': standardMaterial.envMap = hdrCubeRenderTarget ? hdrCubeRenderTarget.texture : null; break;
+						case 'RGBM16': standardMaterial.envMap = rgbmCubeRenderTarget ? rgbmCubeRenderTarget.texture : null; break;
 					}
 
 				}

--- a/examples/webgl_materials_skin.html
+++ b/examples/webgl_materials_skin.html
@@ -214,7 +214,7 @@
 				composerScene = new THREE.EffectComposer( renderer, new THREE.WebGLRenderTarget( rtwidth, rtheight, pars ) );
 				composerScene.addPass( renderModelUV );
 
-				renderScene = new THREE.TexturePass( composerScene.renderTarget2 );
+				renderScene = new THREE.TexturePass( composerScene.renderTarget2.texture );
 
 				//
 
@@ -241,12 +241,12 @@
 
 				//
 
-				uniforms[ "tBlur1" ].value = composerScene.renderTarget2;
-				uniforms[ "tBlur2" ].value = composerUV1.renderTarget2;
-				uniforms[ "tBlur3" ].value = composerUV2.renderTarget2;
-				uniforms[ "tBlur4" ].value = composerUV3.renderTarget2;
+				uniforms[ "tBlur1" ].value = composerScene.renderTarget2.texture;
+				uniforms[ "tBlur2" ].value = composerUV1.renderTarget2.texture;
+				uniforms[ "tBlur3" ].value = composerUV2.renderTarget2.texture;
+				uniforms[ "tBlur4" ].value = composerUV3.renderTarget2.texture;
 
-				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1;
+				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1.texture;
 
 				//
 

--- a/examples/webgl_materials_standard.html
+++ b/examples/webgl_materials_standard.html
@@ -205,8 +205,9 @@
 
 					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
 
-					material.envMap = hdrCubeRenderTarget;
+					material.envMap = hdrCubeRenderTarget.texture;
 					material.needsUpdate = true;
+
 				} );
 
 				//

--- a/examples/webgl_points_billboards_colors.html
+++ b/examples/webgl_points_billboards_colors.html
@@ -168,8 +168,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -236,7 +236,7 @@
 
 				//
 
-				renderScene = new THREE.TexturePass( composerScene.renderTarget2 );
+				renderScene = new THREE.TexturePass( composerScene.renderTarget2.texture );
 
 				//
 
@@ -289,7 +289,7 @@
 
 				//onWindowResize();
 
-				renderScene.uniforms[ "tDiffuse" ].value = composerScene.renderTarget2;
+				renderScene.uniforms[ "tDiffuse" ].value = composerScene.renderTarget2.texture;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
@@ -319,7 +319,7 @@
 				composer3.setSize( halfWidth, halfHeight );
 				composer4.setSize( halfWidth, halfHeight );
 
-				renderScene.uniforms[ "tDiffuse" ].value = composerScene.renderTarget2;
+				renderScene.uniforms[ "tDiffuse" ].value = composerScene.renderTarget2.texture;
 
 				quadBG.scale.set( window.innerWidth, window.innerHeight, 1 );
 				quadMask.scale.set( window.innerWidth / 2, window.innerHeight / 2, 1 );

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -411,8 +411,8 @@ Use WEBGL Depth buffer support?
 
 				postprocessing.bokeh_uniforms = THREE.UniformsUtils.clone( bokeh_shader.uniforms );
 
-				postprocessing.bokeh_uniforms[ "tColor" ].value = postprocessing.rtTextureColor;
-				postprocessing.bokeh_uniforms[ "tDepth" ].value = postprocessing.rtTextureDepth;
+				postprocessing.bokeh_uniforms[ "tColor" ].value = postprocessing.rtTextureColor.texture;
+				postprocessing.bokeh_uniforms[ "tDepth" ].value = postprocessing.rtTextureDepth.texture;
 
 				postprocessing.bokeh_uniforms[ "textureWidth" ].value = window.innerWidth;
 

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -350,7 +350,7 @@
 					var stepLen = filterLen * Math.pow( TAPS_PER_PASS, -pass );
 
 					postprocessing.godrayGenUniforms[ "fStepSize" ].value = stepLen;
-					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureDepth;
+					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureDepth.texture;
 
 					postprocessing.scene.overrideMaterial = postprocessing.materialGodraysGenerate;
 
@@ -362,7 +362,7 @@
 					stepLen = filterLen * Math.pow( TAPS_PER_PASS, -pass );
 
 					postprocessing.godrayGenUniforms[ "fStepSize" ].value = stepLen;
-					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureGodRays2;
+					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureGodRays2.texture;
 
 					renderer.render( postprocessing.scene, postprocessing.camera, postprocessing.rtTextureGodRays1  );
 
@@ -372,14 +372,14 @@
 					stepLen = filterLen * Math.pow( TAPS_PER_PASS, -pass );
 
 					postprocessing.godrayGenUniforms[ "fStepSize" ].value = stepLen;
-					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureGodRays1;
+					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureGodRays1.texture;
 
 					renderer.render( postprocessing.scene, postprocessing.camera , postprocessing.rtTextureGodRays2  );
 
 					// final pass - composite god-rays onto colors
 
-					postprocessing.godrayCombineUniforms["tColors"].value = postprocessing.rtTextureColors;
-					postprocessing.godrayCombineUniforms["tGodRays"].value = postprocessing.rtTextureGodRays2;
+					postprocessing.godrayCombineUniforms["tColors"].value = postprocessing.rtTextureColors.texture;
+					postprocessing.godrayCombineUniforms["tGodRays"].value = postprocessing.rtTextureGodRays2.texture;
 
 					postprocessing.scene.overrideMaterial = postprocessing.materialGodraysCombine;
 

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -174,7 +174,7 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 				ssaoPass = new THREE.ShaderPass( THREE.SSAOShader );
 				ssaoPass.renderToScreen = true;
 				//ssaoPass.uniforms[ "tDiffuse" ].value will be set by ShaderPass
-				ssaoPass.uniforms[ "tDepth" ].value = depthRenderTarget;
+				ssaoPass.uniforms[ "tDepth" ].value = depthRenderTarget.texture;
 				ssaoPass.uniforms[ 'size' ].value.set( window.innerWidth, window.innerHeight );
 				ssaoPass.uniforms[ 'cameraNear' ].value = camera.near;
 				ssaoPass.uniforms[ 'cameraFar' ].value = camera.far;

--- a/examples/webgl_read_float_buffer.html
+++ b/examples/webgl_read_float_buffer.html
@@ -136,7 +136,7 @@
 
 				var materialScreen = new THREE.ShaderMaterial( {
 
-					uniforms: { tDiffuse: { type: "t", value: rtTexture } },
+					uniforms: { tDiffuse: { type: "t", value: rtTexture.texture } },
 					vertexShader: document.getElementById( 'vertexShader' ).textContent,
 					fragmentShader: document.getElementById( 'fragment_shader_screen' ).textContent,
 
@@ -210,8 +210,9 @@
 
 				requestAnimationFrame( animate );
 
+				stats.begin();
 				render();
-				stats.update();
+				stats.end();
 
 			}
 

--- a/examples/webgl_rtt.html
+++ b/examples/webgl_rtt.html
@@ -139,7 +139,7 @@
 
 				var materialScreen = new THREE.ShaderMaterial( {
 
-					uniforms: { tDiffuse: { type: "t", value: rtTexture } },
+					uniforms: { tDiffuse: { type: "t", value: rtTexture.texture } },
 					vertexShader: document.getElementById( 'vertexShader' ).textContent,
 					fragmentShader: document.getElementById( 'fragment_shader_screen' ).textContent,
 
@@ -174,7 +174,7 @@
 
 				var n = 5,
 					geometry = new THREE.SphereGeometry( 10, 64, 32 ),
-					material2 = new THREE.MeshBasicMaterial( { color: 0xffffff, map: rtTexture } );
+					material2 = new THREE.MeshBasicMaterial( { color: 0xffffff, map: rtTexture.texture } );
 
 				for( var j = 0; j < n; j ++ ) {
 

--- a/examples/webgl_shaders_ocean2.html
+++ b/examples/webgl_shaders_ocean2.html
@@ -177,10 +177,10 @@
 						this.ms_Ocean.materialOcean.uniforms.u_exposure.value = this.ms_Ocean.exposure;
 						this.ms_Ocean.changed = false;
 					}
-					this.ms_Ocean.materialOcean.uniforms.u_normalMap.value = this.ms_Ocean.normalMapFramebuffer ;
-					this.ms_Ocean.materialOcean.uniforms.u_displacementMap.value = this.ms_Ocean.displacementMapFramebuffer ;
-					this.ms_Ocean.materialOcean.uniforms.u_projectionMatrix.value = this.ms_Camera.projectionMatrix ;
-					this.ms_Ocean.materialOcean.uniforms.u_viewMatrix.value = this.ms_Camera.matrixWorldInverse ;
+					this.ms_Ocean.materialOcean.uniforms.u_normalMap.value = this.ms_Ocean.normalMapFramebuffer.texture;
+					this.ms_Ocean.materialOcean.uniforms.u_displacementMap.value = this.ms_Ocean.displacementMapFramebuffer.texture;
+					this.ms_Ocean.materialOcean.uniforms.u_projectionMatrix.value = this.ms_Camera.projectionMatrix;
+					this.ms_Ocean.materialOcean.uniforms.u_viewMatrix.value = this.ms_Camera.matrixWorldInverse;
 					this.ms_Ocean.materialOcean.uniforms.u_cameraPosition.value = this.ms_Camera.position;
 					this.ms_Ocean.materialOcean.depthTest = true;
 					//this.ms_Scene.__lights[1].position.x = this.ms_Scene.__lights[1].position.x + 0.01;

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -157,7 +157,7 @@
 
 				var materialLambert = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, map: textureNoiseColor } );
 				var materialPhong = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, specular: 0x999999, map: textureLava } );
-				var materialPhongCube = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, specular: 0x999999, envMap: cubeCamera.renderTarget } );
+				var materialPhongCube = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, specular: 0x999999, envMap: cubeCamera.renderTarget.texture } );
 
 				// OBJECTS
 

--- a/examples/webgl_terrain_dynamic.html
+++ b/examples/webgl_terrain_dynamic.html
@@ -315,7 +315,7 @@
 				var rx = 256, ry = 256;
 				var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBFormat };
 
-				heightMap  = new THREE.WebGLRenderTarget( rx, ry, pars );
+				heightMap = new THREE.WebGLRenderTarget( rx, ry, pars );
 				heightMap.texture.generateMipmaps = false;
 
 				normalMap = new THREE.WebGLRenderTarget( rx, ry, pars );
@@ -333,7 +333,7 @@
 
 				uniformsNormal.height.value = 0.05;
 				uniformsNormal.resolution.value.set( rx, ry );
-				uniformsNormal.heightMap.value = heightMap;
+				uniformsNormal.heightMap.value = heightMap.texture;
 
 				var vertexShader = document.getElementById( 'vertexShader' ).textContent;
 
@@ -365,14 +365,14 @@
 
 				uniformsTerrain = THREE.UniformsUtils.clone( terrainShader.uniforms );
 
-				uniformsTerrain[ "tNormal" ].value = normalMap;
+				uniformsTerrain[ "tNormal" ].value = normalMap.texture;
 				uniformsTerrain[ "uNormalScale" ].value = 3.5;
 
-				uniformsTerrain[ "tDisplacement" ].value = heightMap;
+				uniformsTerrain[ "tDisplacement" ].value = heightMap.texture;
 
-				uniformsTerrain[ "tDiffuse1" ].value = diffuseTexture1;
-				uniformsTerrain[ "tDiffuse2" ].value = diffuseTexture2;
-				uniformsTerrain[ "tSpecular" ].value = specularMap;
+				uniformsTerrain[ "tDiffuse1" ].value = diffuseTexture1.texture;
+				uniformsTerrain[ "tDiffuse2" ].value = diffuseTexture2.texture;
+				uniformsTerrain[ "tSpecular" ].value = specularMap.texture;
 				uniformsTerrain[ "tDetail" ].value = detailTexture;
 
 				uniformsTerrain[ "enableDiffuse1" ].value = true;
@@ -389,9 +389,9 @@
 				uniformsTerrain[ "uRepeatOverlay" ].value.set( 6, 6 );
 
 				var params = [
-					[ 'heightmap', 	document.getElementById( 'fragmentShaderNoise' ).textContent, 	vertexShader, uniformsNoise, false ],
-					[ 'normal', 	normalShader.fragmentShader,  normalShader.vertexShader, uniformsNormal, false ],
-					[ 'terrain', 	terrainShader.fragmentShader, terrainShader.vertexShader, uniformsTerrain, true ]
+					[ 'heightmap', document.getElementById( 'fragmentShaderNoise' ).textContent, vertexShader, uniformsNoise, false ],
+					[ 'normal', normalShader.fragmentShader, normalShader.vertexShader, uniformsNormal, false ],
+					[ 'terrain', terrainShader.fragmentShader, terrainShader.vertexShader, uniformsTerrain, true ]
 				 ];
 
 				for( var i = 0; i < params.length; i ++ ) {

--- a/src/renderers/WebGLRenderTargetCube.js
+++ b/src/renderers/WebGLRenderTargetCube.js
@@ -9,6 +9,8 @@ THREE.WebGLRenderTargetCube = function ( width, height, options ) {
 	this.activeCubeFace = 0; // PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5
 	this.activeMipMapLevel = 0;
 
+	this.texture.renderTargetCube = true;
+
 };
 
 THREE.WebGLRenderTargetCube.prototype = Object.create( THREE.WebGLRenderTarget.prototype );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2046,8 +2046,16 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( material.map !== null ) {
 
-			var offset = material.map.offset;
-			var repeat = material.map.repeat;
+			var map = material.map;
+
+			if ( map instanceof THREE.WebGLRenderTarget ) {
+
+				map = map.texture;
+
+			}
+
+			var offset = map.offset;
+			var repeat = map.repeat;
 
 			uniforms.offsetRepeat.value.set( offset.x, offset.y, repeat.x, repeat.y );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -103,6 +103,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	_width = _canvas.width,
 	_height = _canvas.height,
+	_halfClientHeight = _canvas.clientHeight / 2.0,
 
 	_pixelRatio = 1,
 
@@ -396,6 +397,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		_canvas.width = width * _pixelRatio;
 		_canvas.height = height * _pixelRatio;
+
+		_halfClientHeight = _canvas.clientHeight / 2.0;
 
 		if ( updateStyle !== false ) {
 
@@ -2040,7 +2043,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		uniforms.diffuse.value = material.color;
 		uniforms.opacity.value = material.opacity;
 		uniforms.size.value = material.size * _pixelRatio;
-		uniforms.scale.value = _canvas.clientHeight / 2.0; // TODO: Cache this.
+		uniforms.scale.value = _halfClientHeight;
 
 		uniforms.map.value = material.map;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2049,16 +2049,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( material.map !== null ) {
 
-			var map = material.map;
-
-			if ( map instanceof THREE.WebGLRenderTarget ) {
-
-				map = map.texture;
-
-			}
-
-			var offset = map.offset;
-			var repeat = map.repeat;
+			var offset = material.map.offset;
+			var repeat = material.map.repeat;
 
 			uniforms.offsetRepeat.value.set( offset.x, offset.y, repeat.x, repeat.y );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2004,6 +2004,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( uvScaleMap instanceof THREE.WebGLRenderTarget ) {
 
+				console.warn( 'THREE.WebGLRenderTarget: don\'t use render targets as textures. Use their .texture property instead.' );
 				uvScaleMap = uvScaleMap.texture;
 
 			}
@@ -2015,8 +2016,15 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
+		if ( material.envMap instanceof THREE.WebGLRenderTargetCube ) {
+
+			console.warn( 'THREE.WebGLRenderTargetCube: don\'t use render targets as textures. Use their .texture property instead.' );
+			material.envMap = material.envMap.texture;
+
+		}
+
 		uniforms.envMap.value = material.envMap;
-		uniforms.flipEnvMap.value = ( material.envMap instanceof THREE.WebGLRenderTargetCube ) ? 1 : - 1;
+		uniforms.flipEnvMap.value = ( material.envMap && material.envMap.renderTargetCube ) ? 1 : - 1;
 
 		uniforms.reflectivity.value = material.reflectivity;
 		uniforms.refractionRatio.value = material.refractionRatio;
@@ -2508,6 +2516,18 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			if ( ! texture ) return;
 
+			if ( texture instanceof THREE.WebGLRenderTarget ) {
+
+				console.warn( 'THREE.WebGLRenderTarget: don\'t use render targets as textures. Use their .texture property instead.' );
+				texture = texture.texture;
+
+			} else if ( texture instanceof THREE.WebGLRenderTargetCube ) {
+
+				console.warn( 'THREE.WebGLRenderTargetCube: don\'t use render targets as textures. Use their .texture property instead.' );
+				texture = texture.texture;
+
+			}
+
 			if ( texture instanceof THREE.CubeTexture ||
 				 ( Array.isArray( texture.image ) && texture.image.length === 6 ) ) {
 
@@ -2515,13 +2535,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				setCubeTexture( texture, textureUnit );
 
-			} else if ( texture instanceof THREE.WebGLRenderTargetCube ) {
+			} else if ( texture.renderTargetCube ) {
 
-				setCubeTextureDynamic( texture.texture, textureUnit );
-
-			} else if ( texture instanceof THREE.WebGLRenderTarget ) {
-
-				_this.setTexture( texture.texture, textureUnit );
+				setCubeTextureDynamic( texture, textureUnit );
 
 			} else {
 
@@ -2554,6 +2570,18 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( ! texture ) continue;
 
+				if ( texture instanceof THREE.WebGLRenderTarget ) {
+
+					console.warn( 'THREE.WebGLRenderTarget: don\'t use render targets as textures. Use their .texture property instead.' );
+					texture = texture.texture;
+
+				} else if ( texture instanceof THREE.WebGLRenderTargetCube ) {
+
+					console.warn( 'THREE.WebGLRenderTargetCube: don\'t use render targets as textures. Use their .texture property instead.' );
+					texture = texture.texture;
+
+				}
+
 				if ( texture instanceof THREE.CubeTexture ||
 					 ( texture.image instanceof Array && texture.image.length === 6 ) ) {
 
@@ -2561,13 +2589,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 					setCubeTexture( texture, textureUnit );
 
-				} else if ( texture instanceof THREE.WebGLRenderTarget ) {
+				} else if ( texture.renderTargetCube ) {
 
-					_this.setTexture( texture.texture, textureUnit );
-
-				} else if ( texture instanceof THREE.WebGLRenderTargetCube ) {
-
-					setCubeTextureDynamic( texture.texture, textureUnit );
+					setCubeTextureDynamic( texture, textureUnit );
 
 				} else {
 
@@ -2631,6 +2655,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		color,
 		intensity,
 		distance,
+		shadowMap,
 
 		viewMatrix = camera.matrixWorldInverse,
 
@@ -2646,6 +2671,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 			color = light.color;
 			intensity = light.intensity;
 			distance = light.distance;
+
+			shadowMap = ( light.shadow && light.shadow.map ) ? light.shadow.map.texture : null;
 
 			if ( light instanceof THREE.AmbientLight ) {
 
@@ -2673,7 +2700,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				_lights.directionalShadowMap[ directionalLength ] = light.shadow.map;
+				_lights.directionalShadowMap[ directionalLength ] = shadowMap;
 				_lights.directionalShadowMatrix[ directionalLength ] = light.shadow.matrix;
 				_lights.directional[ directionalLength ++ ] = uniforms;
 
@@ -2706,7 +2733,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				_lights.spotShadowMap[ spotLength ] = light.shadow.map;
+				_lights.spotShadowMap[ spotLength ] = shadowMap;
 				_lights.spotShadowMatrix[ spotLength ] = light.shadow.matrix;
 				_lights.spot[ spotLength ++ ] = uniforms;
 
@@ -2731,7 +2758,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				_lights.pointShadowMap[ pointLength ] = light.shadow.map;
+				_lights.pointShadowMap[ pointLength ] = shadowMap;
 
 				if ( _lights.pointShadowMatrix[ pointLength ] === undefined ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -103,7 +103,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	_width = _canvas.width,
 	_height = _canvas.height,
-	_halfClientHeight = _canvas.clientHeight / 2.0,
 
 	_pixelRatio = 1,
 
@@ -397,8 +396,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		_canvas.width = width * _pixelRatio;
 		_canvas.height = height * _pixelRatio;
-
-		_halfClientHeight = _canvas.clientHeight / 2.0;
 
 		if ( updateStyle !== false ) {
 
@@ -2051,7 +2048,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		uniforms.diffuse.value = material.color;
 		uniforms.opacity.value = material.opacity;
 		uniforms.size.value = material.size * _pixelRatio;
-		uniforms.scale.value = _halfClientHeight;
+		uniforms.scale.value = _canvas.clientHeight / 2.0; // TODO: Cache this.
 
 		uniforms.map.value = material.map;
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -80,9 +80,11 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 
 		} else if ( map instanceof THREE.WebGLRenderTarget ) {
 
+			console.warn( 'THREE.WebGLRenderTarget: don\'t use render targets as textures. Use their .texture property instead.' );
 			encoding = map.texture.encoding;
 
 		}
+
 
 		// add backwards compatibility for WebGLRenderer.gammaInput/gammaOutput parameter, should probably be removed at some point.
 		if ( encoding === THREE.LinearEncoding && gammaOverrideLinear ) {
@@ -117,13 +119,15 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 
 		}
 
+		var currentRenderTarget = renderer.getCurrentRenderTarget();
+
 		var parameters = {
 
 			shaderID: shaderID,
 
 			precision: precision,
 			supportsVertexTextures: capabilities.vertexTextures,
-			outputEncoding: getTextureEncodingFromMap( renderer.getCurrentRenderTarget(), renderer.gammaOutput ),
+			outputEncoding: getTextureEncodingFromMap( ( ! currentRenderTarget ) ? null : currentRenderTarget.texture, renderer.gammaOutput ),
 			map: !! material.map,
 			mapEncoding: getTextureEncodingFromMap( material.map, renderer.gammaInput ),
 			envMap: !! material.envMap,


### PR DESCRIPTION
When using a WebGLRenderTarget as a map for the PointsMaterial, the following warning will be logged to the console every frame: _THREE.WebGLRenderTarget: .repeat is now .texture.repeat._

981e0a2 fixes this by checking if the given map is a WebGLRenderTarget.

2d4b856 takes care of a small TODO note. The canvas' clientHeight property doesn't need to be divided by 2 every frame. Now its stored as a local variable and will only be updated when the setSize method is called.
