### PR TITLE
Sprite: Fix raycast bug

### DIFF
--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -39,7 +39,7 @@ THREE.Sprite.prototype.raycast = ( function () {
 		matrixPosition.setFromMatrixPosition( this.matrixWorld );
 
 		var distanceSq = raycaster.ray.distanceSqToPoint( matrixPosition );
-		var guessSizeSq = this.scale.x * this.scale.y;
+		var guessSizeSq = this.scale.x * this.scale.y / 4;
 
 		if ( distanceSq > guessSizeSq ) {
 


### PR DESCRIPTION
Raycasting with sprites is an approximation in that the sprite is treated as a disk. In addition, sprites can be non-square, and can be rotated.

With this change, if the sprite is square, the "clickable" region is inside the inscribed circle. If the sprite is non-square, the approximation is not very good, but it is better than before.

ref: http://stackoverflow.com/questions/36123458/three-raycaster-not-working-properly-with-scaled-three-sprite
