### PR TITLE
ObjLoader improvements

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -18,11 +18,11 @@ THREE.OBJLoader = function ( manager ) {
 		// f vertex vertex vertex
 		face_vertex              : /^f\s+(-?\d+)\s+(-?\d+)\s+(-?\d+)(?:\s+(-?\d+))?/,
 		// f vertex/uv vertex/uv vertex/uv
-		face_vertex_uv           : /^f\s+((-?\d+)\/(-?\d+))\s+((-?\d+)\/(-?\d+))\s+((-?\d+)\/(-?\d+))(?:\s+((-?\d+)\/(-?\d+)))?/,
+		face_vertex_uv           : /^f\s+(-?\d+)\/(-?\d+)\s+(-?\d+)\/(-?\d+)\s+(-?\d+)\/(-?\d+)(?:\s+(-?\d+)\/(-?\d+))?/,
 		// f vertex/uv/normal vertex/uv/normal vertex/uv/normal
-		face_vertex_uv_normal    : /^f\s+((-?\d+)\/(-?\d+)\/(-?\d+))\s+((-?\d+)\/(-?\d+)\/(-?\d+))\s+((-?\d+)\/(-?\d+)\/(-?\d+))(?:\s+((-?\d+)\/(-?\d+)\/(-?\d+)))?/,
+		face_vertex_uv_normal    : /^f\s+(-?\d+)\/(-?\d+)\/(-?\d+)\s+(-?\d+)\/(-?\d+)\/(-?\d+)\s+(-?\d+)\/(-?\d+)\/(-?\d+)(?:\s+(-?\d+)\/(-?\d+)\/(-?\d+))?/,
 		// f vertex//normal vertex//normal vertex//normal
-		face_vertex_normal       : /^f\s+((-?\d+)\/\/(-?\d+))\s+((-?\d+)\/\/(-?\d+))\s+((-?\d+)\/\/(-?\d+))(?:\s+((-?\d+)\/\/(-?\d+)))?/,
+		face_vertex_normal       : /^f\s+(-?\d+)\/\/(-?\d+)\s+(-?\d+)\/\/(-?\d+)\s+(-?\d+)\/\/(-?\d+)(?:\s+(-?\d+)\/\/(-?\d+))?/,
 		// o object_name | g group_name
 		object_pattern           : /^[og]\s*(.+)?/,
 		// s boolean
@@ -259,7 +259,8 @@ THREE.OBJLoader.prototype = {
 			else
 				line = line.trim();
 
-			if ( line.length === 0 ) {
+			var lineLength = line.length;
+			if ( lineLength === 0 ) {
 				continue;
 			}
 
@@ -276,6 +277,7 @@ THREE.OBJLoader.prototype = {
 
 				if ( lineSecondChar === " " && ( result = this.regexp.vertex_pattern.exec( line ) ) !== null ) {
 
+					// 0                  1      2      3
 					// ["v 1.0 2.0 3.0", "1.0", "2.0", "3.0"]
 
 					state.vertices.push(
@@ -286,6 +288,7 @@ THREE.OBJLoader.prototype = {
 
 				} else if ( lineSecondChar === "n" && ( result = this.regexp.normal_pattern.exec( line ) ) !== null ) {
 
+					// 0                   1      2      3
 					// ["vn 1.0 2.0 3.0", "1.0", "2.0", "3.0"]
 
 					state.normals.push(
@@ -296,6 +299,7 @@ THREE.OBJLoader.prototype = {
 
 				} else if ( lineSecondChar === "t" && ( result = this.regexp.uv_pattern.exec( line ) ) !== null ) {
 
+					// 0               1      2
 					// ["vt 0.1 0.2", "0.1", "0.2"]
 
 					state.uvs.push(
@@ -303,49 +307,62 @@ THREE.OBJLoader.prototype = {
 						parseFloat( result[ 2 ] )
 					);
 
+				} else {
+
+					throw new Error( "Unexpected vertex/normal/uv line: '" + line  + "'");
+
 				}
+
 			} else if ( lineFirstChar === "f" ) {
 
 				if ( ( result = this.regexp.face_vertex_uv_normal.exec( line ) ) !== null ) {
 
 					// f vertex/uv/normal vertex/uv/normal vertex/uv/normal
-					// ["f 1/1/1 2/2/2 3/3/3", " 1/1/1", "1", "1", "1", " 2/2/2", "2", "2", "2", " 3/3/3", "3", "3", "3", undefined, undefined, undefined, undefined]
+					// 0                        1    2    3    4    5    6    7    8    9   10         11         12
+					// ["f 1/1/1 2/2/2 3/3/3", "1", "1", "1", "2", "2", "2", "3", "3", "3", undefined, undefined, undefined]
 
 					state.addFace(
-						result[ 2 ], result[ 6 ], result[ 10 ], result[ 14 ],
-						result[ 3 ], result[ 7 ], result[ 11 ], result[ 15 ],
-						result[ 4 ], result[ 8 ], result[ 12 ], result[ 16 ]
+						result[ 1 ], result[ 4 ], result[ 7 ], result[ 10 ],
+						result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ],
+						result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ]
 					);
 
 				} else if ( ( result = this.regexp.face_vertex_uv.exec( line ) ) !== null ) {
 
 					// f vertex/uv vertex/uv vertex/uv
-					// ["f 1/1 2/2 3/3", " 1/1", "1", "1", " 2/2", "2", "2", " 3/3", "3", "3", undefined, undefined, undefined]
+					// 0                  1    2    3    4    5    6   7          8
+					// ["f 1/1 2/2 3/3", "1", "1", "2", "2", "3", "3", undefined, undefined]
 
 					state.addFace(
-						result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ],
-						result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ]
+						result[ 1 ], result[ 3 ], result[ 5 ], result[ 7 ],
+						result[ 2 ], result[ 4 ], result[ 6 ], result[ 8 ]
 					);
 
 				} else if ( ( result = this.regexp.face_vertex_normal.exec( line ) ) !== null ) {
 
 					// f vertex//normal vertex//normal vertex//normal
-					// ["f 1//1 2//2 3//3", " 1//1", "1", "1", " 2//2", "2", "2", " 3//3", "3", "3", undefined, undefined, undefined]
+					// 0                     1    2    3    4    5    6   7          8
+					// ["f 1//1 2//2 3//3", "1", "1", "2", "2", "3", "3", undefined, undefined]
 
 					state.addFace(
-						result[ 2 ], result[ 5 ], result[ 8 ], result[ 11 ],
+						result[ 1 ], result[ 3 ], result[ 5 ], result[ 7 ],
 						undefined, undefined, undefined, undefined,
-						result[ 3 ], result[ 6 ], result[ 9 ], result[ 12 ]
+						result[ 2 ], result[ 4 ], result[ 6 ], result[ 8 ]
 					);
 
 				} else if ( ( result = this.regexp.face_vertex.exec( line ) ) !== null ) {
 
 					// f vertex vertex vertex
+					// 0            1    2    3   4
 					// ["f 1 2 3", "1", "2", "3", undefined]
 
 					state.addFace(
 						result[ 1 ], result[ 2 ], result[ 3 ], result[ 4 ]
 					);
+
+				} else {
+
+					throw new Error( "Unexpected face line: '" + line  + "'");
 
 				}
 
@@ -379,7 +396,11 @@ THREE.OBJLoader.prototype = {
 
 			} else {
 
-				throw new Error( "Unexpected line: " + line );
+				// Handle null terminated files without exception
+				if (line === "\0")
+					continue;
+
+				throw new Error( "Unexpected line: '" + line  + "'");
 
 			}
 

--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -88,14 +88,14 @@ THREE.OBJLoader.prototype = {
 				}
 
 				this.object = {
-					name : name || "",
+					name : name || '',
 					geometry : {
 						vertices : [],
 						normals  : [],
 						uvs      : []
 					},
 					material : {
-						name   : "",
+						name   : '',
 						smooth : true
 					},
 					fromDeclaration : (fromDeclaration !== false)
@@ -231,7 +231,7 @@ THREE.OBJLoader.prototype = {
 			}
 		};
 
-		state.startObject("", false);
+		state.startObject('', false);
 		return state;
 	},
 
@@ -249,7 +249,7 @@ THREE.OBJLoader.prototype = {
 		var lines = text.split( '\n' );
 
 		// Faster to just trim left side of the line. Use if available.
-		var trimLeft = (typeof "".trimLeft === "function");
+		var trimLeft = (typeof ''.trimLeft === 'function');
 
 		for ( var i = 0; i < lines.length; i ++ ) {
 
@@ -271,11 +271,11 @@ THREE.OBJLoader.prototype = {
 			}
 
 			var result = [];
-			if ( lineFirstChar === "v" ) {
+			if ( lineFirstChar === 'v' ) {
 
 				var lineSecondChar = line.charAt( 1 );
 
-				if ( lineSecondChar === " " && ( result = this.regexp.vertex_pattern.exec( line ) ) !== null ) {
+				if ( lineSecondChar === ' ' && ( result = this.regexp.vertex_pattern.exec( line ) ) !== null ) {
 
 					// 0                  1      2      3
 					// ["v 1.0 2.0 3.0", "1.0", "2.0", "3.0"]
@@ -286,7 +286,7 @@ THREE.OBJLoader.prototype = {
 						parseFloat( result[ 3 ] )
 					);
 
-				} else if ( lineSecondChar === "n" && ( result = this.regexp.normal_pattern.exec( line ) ) !== null ) {
+				} else if ( lineSecondChar === 'n' && ( result = this.regexp.normal_pattern.exec( line ) ) !== null ) {
 
 					// 0                   1      2      3
 					// ["vn 1.0 2.0 3.0", "1.0", "2.0", "3.0"]
@@ -297,7 +297,7 @@ THREE.OBJLoader.prototype = {
 						parseFloat( result[ 3 ] )
 					);
 
-				} else if ( lineSecondChar === "t" && ( result = this.regexp.uv_pattern.exec( line ) ) !== null ) {
+				} else if ( lineSecondChar === 't' && ( result = this.regexp.uv_pattern.exec( line ) ) !== null ) {
 
 					// 0               1      2
 					// ["vt 0.1 0.2", "0.1", "0.2"]
@@ -392,7 +392,7 @@ THREE.OBJLoader.prototype = {
 				// smooth shading
 
 				var value = result[ 1 ].trim().toLowerCase();
-				state.object.material.smooth = ( value === "1" || value === "on" );
+				state.object.material.smooth = ( value === '1' || value === 'on' );
 
 			} else {
 

--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -487,6 +487,10 @@ THREE.OBJLoader.prototype = {
 			var geometry = object.geometry;
 			var isLine = (geometry.type === 'Line');
 
+			// Skip o/g line declarations that did not follow with any faces
+			if ( geometry.vertices.length === 0 )
+				continue;
+
 			var buffergeometry = new THREE.BufferGeometry();
 
 			buffergeometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( geometry.vertices ), 3 ) );

--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -469,7 +469,7 @@ THREE.OBJLoader.prototype = {
 			} else {
 
 				// Handle null terminated files without exception
-				if (line === "\0")
+				if (line === '\0')
 					continue;
 
 				throw new Error( "Unexpected line: '" + line  + "'");


### PR DESCRIPTION
I was discussing these improvements in #8404. I ended up implementing other tweaks that I discovered while trying to improve the loading speed.

The numbers are quite positive, but mileage may wary per user. My setup is quite fast i7 machine, but I would guess the wins might be even bigger for slower machines (eg. phones/tablets). Depends how CPU costly the regex execs that are now skipped are there.

I created a test file that loads `models/obj/cerberus/Cerberus.obj` once as text and calls `ObjLoader.parse` with the same string 50 times. I ran this test 10 times (F5) and calculated averages. This file was selected as its the biggest in the repo I could find (2.5mb ~70k lines) and uses all vertex/normal/uv declarations which is the most complex it gets and probably most common kind of model out there in the wild.

I did multiple commit batches and monitored the perf along the way, each time eking out a few more msec wins. Here is the current standing.

```
BRANCH          AVG             DIFF                PER parse()
---------------------------------------------------------------
dev             5044.90 msec                        100.90 msec
objloader       4136.44 msec    -908.46 msec         82.73 msec (-18.17 msec)
```
- Create all regexes once per ObjLoader instance.
- Execute group of regexes only if their common prefix is detected (v/f).
- Eliminate unnecessary regex.exec calls inside a group (v/f) if can be easily detected with prefix (v/vn/vt).
- Replace `\r\n` > `\n` to handle windows line endings better, which is faster than String.split(regex) that detects both. Earlier implementations .trim() handled removing the postfix `\r`, which was slower than doing it once.
- Move funcs and state declared on each parse call to a state object. Functions no longer use/manipulate variables from parent scope.
- Check common cases of f regex first. This speeds up loading models that have normals and/or uv:s defined.
- Replace array.push(1,2,3, ...) with individual .push() calls where performance is gained (addVertex and friends). Measured on latest Chrome and FF.
- As the regex and rest of the logic can handle postfix whitespace, use String.trimLeft if available to reduce per line costs.
- Speed up regex execution by removing unused group captures from ^f lines.

Few notable improvements and bug fixes
- Add `container.materialLibraries` array that holds all `mtllib ref` referenced found in parsing. Allows app developers to fetch referenced files and post load materials into the children with `child.material.name`.
- Handle null (\0) terminated files. At least one (LeePerrySmith.obj) in the three.js repo was throwing exception because of this when it should not. Afaik this was not introduced by me, probably this file is not used in any example atm.
- Add support for obj spec lines to create geometries and THREE.Line `l  v1/vt1   v2/vt2   v3/vt3 . . .`

---

@mrdoob I'm putting this here for review if anyone catches something from reading the code. I have plans to update this PR with the following, so maybe don't merge this yet.
- Create ObjLoader test html page that loads all .obj files in the repo. This can be later used to verify stuff when doing changes to the loader. I also would like a visual confirmation all files in the repo still render after my fixes. I have already tested all variances of `f` that the loader executes and they work as expected.
  - Where would be a good place for this kind of file? Should the http://threejs.org/examples/#webgl_loader_obj be used or should i make one under `/test/` that is not visible to the public? I suppose the example page should be something nice looking, all of the models are not textured etc.
- Implement test that runs various files on the same page (pretty much what the above page would do). Loading just one model with the same `f` format on each line does not surface the V8 opt/deopt "bug" that slows down loading. But it will hit many people in production as they load multiple objs with potentially many kinds of `f` formatting. This probably involves creating specialized `addFace` for each type of `f` line the loader supports. I'll investigate it a bit more.
