### PR TITLE
Attempt to work around compiler errors regarding IncidentLight return variable

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -24,7 +24,7 @@ vec3 directLightColor_Diffuse;
 
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
-		directLight = getPointDirectLightIrradiance( pointLights[ i ], geometry );
+		getPointDirectLightIrradiance( pointLights[ i ], geometry, directLight );
 
 		dotNL = dot( geometry.normal, directLight.direction );
 		directLightColor_Diffuse = PI * directLight.color;
@@ -45,7 +45,7 @@ vec3 directLightColor_Diffuse;
 
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
-		directLight = getSpotDirectLightIrradiance( spotLights[ i ], geometry );
+		getSpotDirectLightIrradiance( spotLights[ i ], geometry, directLight );
 
 		dotNL = dot( geometry.normal, directLight.direction );
 		directLightColor_Diffuse = PI * directLight.color;
@@ -65,7 +65,7 @@ vec3 directLightColor_Diffuse;
 
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
-		directLight = getDirectionalDirectLightIrradiance( directionalLights[ i ], geometry );
+		getDirectionalDirectLightIrradiance( directionalLights[ i ], geometry, directLight );
 
 		dotNL = dot( geometry.normal, directLight.direction );
 		directLightColor_Diffuse = PI * directLight.color;

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -28,15 +28,11 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 	uniform DirectionalLight directionalLights[ NUM_DIR_LIGHTS ];
 
-	IncidentLight getDirectionalDirectLightIrradiance( const in DirectionalLight directionalLight, const in GeometricContext geometry ) {
-
-		IncidentLight directLight;
+	void getDirectionalDirectLightIrradiance( const in DirectionalLight directionalLight, const in GeometricContext geometry, out IncidentLight directLight ) {
 
 		directLight.color = directionalLight.color;
 		directLight.direction = directionalLight.direction;
 		directLight.visible = true;
-
-		return directLight;
 
 	}
 
@@ -59,9 +55,8 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 	uniform PointLight pointLights[ NUM_POINT_LIGHTS ];
 
-	IncidentLight getPointDirectLightIrradiance( const in PointLight pointLight, const in GeometricContext geometry ) {
-
-		IncidentLight directLight;
+	// directLight is an out parameter as having it as a return value caused compiler errors on some devices
+	void getPointDirectLightIrradiance( const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight directLight ) {
 
 		vec3 lVector = pointLight.position - geometry.position;
 		directLight.direction = normalize( lVector );
@@ -81,8 +76,6 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 			directLight.visible = false;
 
 		}
-
-		return directLight;
 
 	}
 
@@ -108,9 +101,8 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 	uniform SpotLight spotLights[ NUM_SPOT_LIGHTS ];
 
-	IncidentLight getSpotDirectLightIrradiance( const in SpotLight spotLight, const in GeometricContext geometry ) {
-
-		IncidentLight directLight;
+	// directLight is an out parameter as having it as a return value caused compiler errors on some devices
+	void getSpotDirectLightIrradiance( const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight directLight  ) {
 
 		vec3 lVector = spotLight.position - geometry.position;
 		directLight.direction = normalize( lVector );
@@ -133,8 +125,6 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 			directLight.visible = false;
 
 		}
-
-		return directLight;
 
 	}
 

--- a/src/renderers/shaders/ShaderChunk/lights_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_template.glsl
@@ -29,7 +29,7 @@ IncidentLight directLight;
 
 		pointLight = pointLights[ i ];
 
-		directLight = getPointDirectLightIrradiance( pointLight, geometry );
+		getPointDirectLightIrradiance( pointLight, geometry, directLight );
 
 		#ifdef USE_SHADOWMAP
 		directLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ] ) : 1.0;
@@ -49,7 +49,7 @@ IncidentLight directLight;
 
 		spotLight = spotLights[ i ];
 
-		directLight = getSpotDirectLightIrradiance( spotLight, geometry );
+		getSpotDirectLightIrradiance( spotLight, geometry, directLight );
 
 		#ifdef USE_SHADOWMAP
 		directLight.color *= all( bvec2( spotLight.shadow, directLight.visible ) ) ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
@@ -69,7 +69,7 @@ IncidentLight directLight;
 
 		directionalLight = directionalLights[ i ];
 
-		directLight = getDirectionalDirectLightIrradiance( directionalLight, geometry );
+		getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
 
 		#ifdef USE_SHADOWMAP
 		directLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;


### PR DESCRIPTION
Tryinng to adddress this bug: https://github.com/mrdoob/three.js/issues/8161

But I can not reproduce the bug so this workaround is guided by @kozec first suggestion here: https://github.com/mrdoob/three.js/issues/8161#issuecomment-200730919 and my similar suspicions mentioned here: https://github.com/mrdoob/three.js/issues/8161#issuecomment-200347933

Please test this fix @doexclusive, @Frankling, and anyone else who has seen it.
