### PR TITLE
GLSL cleanup & portability fix

### DIFF
--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -3673,7 +3673,6 @@ THREE.ShaderLib[ 'mmd' ] = {
 		THREE.ShaderChunk[ "uv2_pars_vertex" ],
 		THREE.ShaderChunk[ "displacementmap_pars_vertex" ],
 		THREE.ShaderChunk[ "envmap_pars_vertex" ],
-		THREE.ShaderChunk[ "lights_phong_pars_vertex" ],
 		THREE.ShaderChunk[ "color_pars_vertex" ],
 		THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 		THREE.ShaderChunk[ "skinning_pars_vertex" ],
@@ -3714,7 +3713,6 @@ THREE.ShaderLib[ 'mmd' ] = {
 
 			THREE.ShaderChunk[ "worldpos_vertex" ],
 			THREE.ShaderChunk[ "envmap_vertex" ],
-			THREE.ShaderChunk[ "lights_phong_vertex" ],
 			THREE.ShaderChunk[ "shadowmap_vertex" ],
 
 		// ---- MMD specific for outline drawing

--- a/examples/js/nodes/materials/PhongNode.js
+++ b/examples/js/nodes/materials/PhongNode.js
@@ -46,7 +46,6 @@ THREE.PhongNode.prototype.build = function( builder ) {
 			"#endif",
 
 			THREE.ShaderChunk[ "common" ],
-			THREE.ShaderChunk[ "lights_phong_pars_vertex" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "skinning_pars_vertex" ],
 			THREE.ShaderChunk[ "shadowmap_pars_vertex" ],
@@ -88,7 +87,6 @@ THREE.PhongNode.prototype.build = function( builder ) {
 			"	vViewPosition = - mvPosition.xyz;",
 
 				THREE.ShaderChunk[ "worldpos_vertex" ],
-				THREE.ShaderChunk[ "lights_phong_vertex" ],
 				THREE.ShaderChunk[ "shadowmap_vertex" ]
 		);
 

--- a/examples/js/nodes/materials/StandardNode.js
+++ b/examples/js/nodes/materials/StandardNode.js
@@ -46,7 +46,6 @@ THREE.StandardNode.prototype.build = function( builder ) {
 			"#endif",
 
 			THREE.ShaderChunk[ "common" ],
-			THREE.ShaderChunk[ "lights_phong_pars_vertex" ],
 			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
 			THREE.ShaderChunk[ "skinning_pars_vertex" ],
 			THREE.ShaderChunk[ "shadowmap_pars_vertex" ],
@@ -88,7 +87,6 @@ THREE.StandardNode.prototype.build = function( builder ) {
 			"	vViewPosition = - mvPosition.xyz;",
 
 				THREE.ShaderChunk[ "worldpos_vertex" ],
-				THREE.ShaderChunk[ "lights_phong_vertex" ],
 				THREE.ShaderChunk[ "shadowmap_vertex" ]
 		);
 

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -144,7 +144,6 @@
 					vertexShader: [
 						"varying vec3 vViewPosition;",
 						"varying vec3 vNormal;",
-						THREE.ShaderChunk[ "lights_phong_pars_vertex" ],
 						"void main() {",
 							THREE.ShaderChunk[ "beginnormal_vertex" ],
 							THREE.ShaderChunk[ "defaultnormal_vertex" ],

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
@@ -19,8 +19,8 @@ int getFaceFromDirection(vec3 direction) {
     }
     return face;
 }
-const float cubeUV_maxLods1 = log2(cubeUV_textureSize*0.25) - 1.0;
-const float cubeUV_rangeClamp = exp2((6.0 - 1.0) * 2.0);
+float cubeUV_maxLods1 = log2(cubeUV_textureSize*0.25) - 1.0;
+float cubeUV_rangeClamp = exp2((6.0 - 1.0) * 2.0);
 
 vec2 MipLevelInfo( vec3 vec, float roughnessLevel, float roughness ) {
     float scale = exp2(cubeUV_maxLods1 - roughnessLevel);
@@ -35,7 +35,7 @@ vec2 MipLevelInfo( vec3 vec, float roughnessLevel, float roughness ) {
     return vec2(floor(mipLevel), fract(mipLevel));
 }
 
-const float cubeUV_maxLods2 = log2(cubeUV_textureSize*0.25) - 2.0;
+float cubeUV_maxLods2 = log2(cubeUV_textureSize*0.25) - 2.0;
 const float cubeUV_rcpTextureSize = 1.0 / cubeUV_textureSize;
 
 vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
@@ -97,7 +97,7 @@ vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
     return base + s * ( scale - 2.0 * texelOffset );
 }
 
-const float cubeUV_maxLods3 = log2(cubeUV_textureSize*0.25) - 3.0;
+float cubeUV_maxLods3 = log2(cubeUV_textureSize*0.25) - 3.0;
 
 vec4 textureCubeUV(vec3 reflectedDirection, float roughness ) {
     float roughnessVal = roughness* cubeUV_maxLods3;

--- a/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl
@@ -4,6 +4,11 @@
 #endif
 
 #ifdef USE_ENVMAP
+
+	#if ! defined( STANDARD ) && ( defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) )
+		varying vec3 vWorldPosition;
+	#endif
+
 	#ifdef ENVMAP_TYPE_CUBE
 		uniform samplerCube envMap;
 	#else
@@ -12,13 +17,9 @@
 	uniform float flipEnvMap;
 
 	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) || defined( STANDARD )
-
 		uniform float refractionRatio;
-
 	#else
-
 		varying vec3 vReflect;
-
 	#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/envmap_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_pars_vertex.glsl
@@ -1,7 +1,13 @@
-#if defined( USE_ENVMAP ) && ! defined( USE_BUMPMAP ) && ! defined( USE_NORMALMAP ) && ! defined( PHONG ) && ! defined( STANDARD )
+#ifdef USE_ENVMAP
 
-	varying vec3 vReflect;
+	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )
+		varying vec3 vWorldPosition;
 
-	uniform float refractionRatio;
+	#else
+
+		varying vec3 vReflect;
+		uniform float refractionRatio;
+
+	#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl
@@ -1,16 +1,24 @@
-#if defined( USE_ENVMAP ) && ! defined( USE_BUMPMAP ) && ! defined( USE_NORMALMAP ) && ! defined( PHONG ) && ! defined( STANDARD )
+#ifdef USE_ENVMAP
 
-	vec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );
+	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )
 
-	vec3 worldNormal = inverseTransformDirection( transformedNormal, viewMatrix );
-
-	#ifdef ENVMAP_MODE_REFLECTION
-
-		vReflect = reflect( cameraToVertex, worldNormal );
+		vWorldPosition = worldPosition.xyz;
 
 	#else
 
-		vReflect = refract( cameraToVertex, worldNormal, refractionRatio );
+		vec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );
+
+		vec3 worldNormal = inverseTransformDirection( transformedNormal, viewMatrix );
+
+		#ifdef ENVMAP_MODE_REFLECTION
+
+			vReflect = reflect( cameraToVertex, worldNormal );
+
+		#else
+
+			vReflect = refract( cameraToVertex, worldNormal, refractionRatio );
+
+		#endif
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl
@@ -1,9 +1,3 @@
-#ifdef USE_ENVMAP
-
-	varying vec3 vWorldPosition;
-
-#endif
-
 varying vec3 vViewPosition;
 
 #ifndef FLAT_SHADED

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_vertex.glsl
@@ -1,5 +1,0 @@
-#ifdef USE_ENVMAP
-
-	varying vec3 vWorldPosition;
-
-#endif

--- a/src/renderers/shaders/ShaderChunk/lights_phong_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_vertex.glsl
@@ -1,5 +1,0 @@
-#ifdef USE_ENVMAP
-
-	vWorldPosition = worldPosition.xyz;
-
-#endif

--- a/src/renderers/shaders/ShaderLib/meshphong_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphong_vert.glsl
@@ -13,7 +13,6 @@ varying vec3 vViewPosition;
 #include <uv2_pars_vertex>
 #include <displacementmap_pars_vertex>
 #include <envmap_pars_vertex>
-#include <lights_phong_pars_vertex>
 #include <color_pars_vertex>
 #include <morphtarget_pars_vertex>
 #include <skinning_pars_vertex>
@@ -49,7 +48,6 @@ void main() {
 
 	#include <worldpos_vertex>
 	#include <envmap_vertex>
-	#include <lights_phong_vertex>
 	#include <shadowmap_vertex>
 
 }

--- a/src/renderers/shaders/ShaderLib/meshstandard_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshstandard_vert.glsl
@@ -12,7 +12,6 @@ varying vec3 vViewPosition;
 #include <uv_pars_vertex>
 #include <uv2_pars_vertex>
 #include <displacementmap_pars_vertex>
-#include <envmap_pars_vertex>
 #include <color_pars_vertex>
 #include <morphtarget_pars_vertex>
 #include <skinning_pars_vertex>
@@ -48,7 +47,6 @@ void main() { // STANDARD
 	vViewPosition = - mvPosition.xyz;
 
 	#include <worldpos_vertex>
-	#include <envmap_vertex>
 	#include <shadowmap_vertex>
 
 }

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -154,8 +154,6 @@
 	"src/renderers/shaders/ShaderChunk/lights_pars.glsl",
 	"src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl",
-	"src/renderers/shaders/ShaderChunk/lights_phong_pars_vertex.glsl",
-	"src/renderers/shaders/ShaderChunk/lights_phong_vertex.glsl",
 	"src/renderers/shaders/ShaderChunk/lights_standard_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/lights_standard_pars_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/lights_template.glsl",


### PR DESCRIPTION
Cleanup work & fixes.

It seems `vWorldPosition` is only used for envmapping and the only thing left in `phong_*vertex`, so let's refactor it over to where it actually belongs - certainly isn't phong-specific enough to keep these definitions in extra files.

Also some drivers don't like initializing constants from function calls. IIRC it's legal (at least for built-in functions) by now, but it hasn't been in all revisions of the spec and I got a compile error on Intel/Mesa. I found that one testing the former commit.
