### PR TITLE
ObjectLoader: Added LatheBufferGeometry

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -239,8 +239,9 @@ THREE.ObjectLoader.prototype = {
 						break;
 
 					case 'LatheGeometry':
+					case 'LatheBufferGeometry':
 
-						geometry = new THREE.LatheGeometry(
+						geometry = new THREE[ data.type ](
 							data.points,
 							data.segments,
 							data.phiStart,


### PR DESCRIPTION
This little PR adds `LatheBufferGeometry` to `ObjectLoader .parseGeometries`. I've missed this in my first PR...
