### PR TITLE
Revised PerspectiveCamera.

### DIFF
--- a/docs/api/cameras/PerspectiveCamera.html
+++ b/docs/api/cameras/PerspectiveCamera.html
@@ -42,14 +42,11 @@ scene.add( camera );</code>
 
 		<h2>Properties</h2>
 
-		<h3>[property:number zoom]</h3>
-		<div>Gets or sets the zoom factor of the camera. </div>
-
 		<h3>[property:Float fov]</h3>
 		<div>Camera frustum vertical field of view, from bottom to top of view, in degrees.</div>
 
-		<h3>[property:Float aspect]</h3>
-		<div>Camera frustum aspect ratio, window width divided by window height.</div>
+		<h3>[property:number zoom]</h3>
+		<div>Gets or sets the zoom factor of the camera. </div>
 
 		<h3>[property:Float near]</h3>
 		<div>Camera frustum near plane.</div>
@@ -57,18 +54,60 @@ scene.add( camera );</code>
 		<h3>[property:Float far]</h3>
 		<div>Camera frustum far plane.</div>
 
+		<h3>[property:Float focus]</h3>
+		<div>Object distance used for stereoscopy and depth-of-field effects. This parameter does not influence the projection matrix unless a StereoCamera is being used.</div>
+
+		<h3>[property:Float aspect]</h3>
+		<div>Camera frustum aspect ratio, window width divided by window height.</div>
+
+		<h3>[property:Object view]</h3>
+		<div>Frustum window specification or null.</div>
+
+		<h3>[property:Float filmGauge]</h3>
+		<div>Film size used for the larger axis. Default is 35 (millimeters). This parameter does not influence the projection matrix unless .filmOffset is set to a nonzero value.</div>
+
+		<h3>[property:Float filmOffset]</h3>
+		<div>Horizontal off-center offset in the same unit as .filmGauge.</div>
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setLens]( [page:Float focalLength], [page:Float frameSize] )</h3>
+		<h3>[method:Float getEffectiveFOV]()</h3>
+		<div>
+		Returns the current vertical field of view angle in degrees considering .zoom.
+		</div>
+
+		<h3>[method:Float getFocalLength]()</h3>
+		<div>
+		Returns the focal length of the current .fov in respect to .filmGauge.
+		</div>
+
+		<h3>[method:Float getFilmWidth]()</h3>
+		<div>
+		Returns the width of the image on the film. If .aspect is greater than or equal to one (landscape format), the result equals .filmGauge.
+		</div>
+
+		<h3>[method:Float getFilmHeight]()</h3>
+		<div>
+		Returns the height of the image on the film. If .aspect is less than or equal to one (portrait format), the result equals .fimlGauge.
+		</div>
+
+		<h3>[method:null setFocalLength]( [page:Float focalLength] )</h3>
+		<div>
+		Sets the FOV by focal length in respect to the current .filmGauge.
+		</div>
+		<div>
+		By default, the focal length is specified for a 35mm (full frame) camera.
+		</div>
+
+		<h3>[method:null setLens]( [page:Float focalLength], [page:Float filmGauge] )</h3>
 		<div>
 		focalLength — focal length<br />
-		frameSize — frame size
+		frameGauge — film gauge
 		</div>
 
 		<div>
-		Uses focal length (in mm) to estimate and set FOV 35mm (fullframe) camera is used if frame size is not specified.<br />
-		Formula based on [link:http://www.bobatkins.com/photography/technical/field_of_view.html]
+		Sets .fov by focal length. Optionally also sets .filmGauge.
+		This method is deprecated, please use .setFocalLength instead.
 		</div>
 
 		<h3>[method:null setViewOffset]( [page:Float fullWidth], [page:Float fullHeight], [page:Float x], [page:Float y], [page:Float width], [page:Float height] )</h3>

--- a/docs/api/examples/cameras/CombinedCamera.html
+++ b/docs/api/examples/cameras/CombinedCamera.html
@@ -130,10 +130,10 @@
 		Sets the zoomfactor.
 		</div>
 
-		<h3>[method:null setLens]([page:number focalLength], [page:Number frameHeight])</h3>
+		<h3>[method:null setLens]([page:number focalLength], [page:Number filmGauge])</h3>
 		<div>
 		focalLength -- The focal length of a lens is defined as the distance from the optical center of a lens (or, the secondary principal point for a complex lens like a camera lens) to the focal point (sensor) when the lens is focused on an object at infinity. <br />
-		frameHeight -- the size of the frame in mm. (default is *35*)
+		filmGauge -- the size of the frame in mm. (default is *35*)
 		</div>
 		<div>
 		Sets the fov based on lens data.

--- a/examples/js/cameras/CinematicCamera.js
+++ b/examples/js/cameras/CinematicCamera.js
@@ -31,26 +31,26 @@ THREE.CinematicCamera.prototype.constructor = THREE.CinematicCamera;
 
 
 // providing fnumber and coc(Circle of Confusion) as extra arguments
-THREE.CinematicCamera.prototype.setLens = function ( focalLength, frameHeight, fNumber, coc ) {
+THREE.CinematicCamera.prototype.setLens = function ( focalLength, filmGauge, fNumber, coc ) {
 
 	// In case of cinematicCamera, having a default lens set is important
 	if ( focalLength === undefined ) focalLength = 35;
+	if ( filmGauge !== undefined ) this.filmGauge = filmGauge;
 
-	THREE.PerspectiveCamera.prototype.setLens.call( this, focalLength, frameHeight );
+	this.setFocalLength( focalLength );
 
 	// if fnumber and coc are not provided, cinematicCamera tries to act as a basic PerspectiveCamera
 	if ( fNumber === undefined ) fNumber = 8;
 	if ( coc === undefined ) coc = 0.019;
 
-	this.focalLength = focalLength;
 	this.fNumber = fNumber;
 	this.coc = coc;
 
 	// fNumber is focalLength by aperture
-	this.aperture = this.focalLength / this.fNumber;
+	this.aperture = focalLength / this.fNumber;
 
 	// hyperFocal is required to calculate depthOfField when a lens tries to focus at a distance with given fNumber and focalLength
-	this.hyperFocal = ( this.focalLength * this.focalLength ) / ( this.aperture * this.coc );
+	this.hyperFocal = ( focalLength * focalLength ) / ( this.aperture * this.coc );
 
 };
 
@@ -80,14 +80,16 @@ THREE.CinematicCamera.prototype.focusAt = function ( focusDistance ) {
 
 	if ( focusDistance === undefined ) focusDistance = 20;
 
-	// distance from the camera (normal to frustrum) to focus on (unused)
-	this.focusDistance = focusDistance;
+	var focalLength = this.getFocalLength();
+
+	// distance from the camera (normal to frustrum) to focus on
+	this.focus = focusDistance;
 
 	// the nearest point from the camera which is in focus (unused)
-	this.nearPoint = ( this.hyperFocal * this.focusDistance ) / ( this.hyperFocal + ( this.focusDistance - this.focalLength ) );
+	this.nearPoint = ( this.hyperFocal * this.focus ) / ( this.hyperFocal + ( this.focus - focalLength ) );
 
 	// the farthest point from the camera which is in focus (unused)
-	this.farPoint = ( this.hyperFocal * this.focusDistance ) / ( this.hyperFocal - ( this.focusDistance - this.focalLength ) );
+	this.farPoint = ( this.hyperFocal * this.focus ) / ( this.hyperFocal - ( this.focus - focalLength ) );
 
 	// the gap or width of the space in which is everything is in focus (unused)
 	this.depthOfField = this.farPoint - this.nearPoint;
@@ -95,7 +97,7 @@ THREE.CinematicCamera.prototype.focusAt = function ( focusDistance ) {
 	// Considering minimum distance of focus for a standard lens (unused)
 	if ( this.depthOfField < 0 ) this.depthOfField = 0;
 
-	this.sdistance = this.smoothstep( this.near, this.far, this.focusDistance );
+	this.sdistance = this.smoothstep( this.near, this.far, this.focus );
 
 	this.ldistance = this.linearize( 1 -	this.sdistance );
 

--- a/examples/js/cameras/CombinedCamera.js
+++ b/examples/js/cameras/CombinedCamera.js
@@ -146,14 +146,17 @@ THREE.CombinedCamera.prototype.updateProjectionMatrix = function() {
 
 /*
 * Uses Focal Length (in mm) to estimate and set FOV
-* 35mm (fullframe) camera is used if frame size is not specified;
+* 35mm (full frame) camera is used if frame size is not specified;
 * Formula based on http://www.bobatkins.com/photography/technical/field_of_view.html
 */
-THREE.CombinedCamera.prototype.setLens = function ( focalLength, frameHeight ) {
+THREE.CombinedCamera.prototype.setLens = function ( focalLength, filmGauge ) {
 
-	if ( frameHeight === undefined ) frameHeight = 24;
+	if ( filmGauge === undefined ) filmGauge = 35;
 
-	var fov = 2 * THREE.Math.radToDeg( Math.atan( frameHeight / ( focalLength * 2 ) ) );
+	var vExtentSlope = 0.5 * filmGauge /
+			( focalLength * Math.max( this.cameraP.aspect, 1 ) );
+
+	var fov = THREE.Math.RAD2DEG * 2 * Math.atan( vExtentSlope );
 
 	this.setFov( fov );
 

--- a/src/cameras/StereoCamera.js
+++ b/src/cameras/StereoCamera.js
@@ -24,20 +24,20 @@ THREE.StereoCamera.prototype = {
 
 	update: ( function () {
 
-		var focalLength, fov, aspect, near, far;
+		var focus, fov, aspect, near, far;
 
 		var eyeRight = new THREE.Matrix4();
 		var eyeLeft = new THREE.Matrix4();
 
 		return function update ( camera ) {
 
-			var needsUpdate = focalLength !== camera.focalLength || fov !== camera.fov ||
+			var needsUpdate = focus !== camera.focus || fov !== camera.fov ||
 												aspect !== camera.aspect * this.aspect || near !== camera.near ||
 												far !== camera.far;
 
 			if ( needsUpdate ) {
 
-				focalLength = camera.focalLength;
+				focus = camera.focus;
 				fov = camera.fov;
 				aspect = camera.aspect * this.aspect;
 				near = camera.near;
@@ -48,7 +48,7 @@ THREE.StereoCamera.prototype = {
 
 				var projectionMatrix = camera.projectionMatrix.clone();
 				var eyeSep = 0.064 / 2;
-				var eyeSepOnProjection = eyeSep * near / focalLength;
+				var eyeSepOnProjection = eyeSep * near / focus;
 				var ymax = near * Math.tan( THREE.Math.DEG2RAD * fov * 0.5 );
 				var xmin, xmax;
 


### PR DESCRIPTION
- Allows extra skew for stereo rendering.
- Allows to query effective FOV angle (considering .zoom).
- Proper copy / serialization of all properties.
- Tidier, single code path frustum calculation.
- No longer uses ProjectionMatrix.makePerspective.

See discussion in #7036 with @bhouston, about smooth interaction with tools, realistic DOF, lens settings and a higher level API for stereo rendering.

To verify the refactor in the first commit is non-breaking:
http://ci.threejs.org/api/pullrequests/8495/examples/webgl_multiple_canvases_grid.html
http://ci.threejs.org/api/pullrequests/8495/examples/webgl_multiple_canvases_complex.html
