### PR TITLE
Set renderer to correct resolution when entering VR mode

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -61,8 +61,6 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	this.scale = 1;
 
-	this.bufferScale = 1.0;
-
 	var isPresenting = false;
 	var cachedWidth, cachedHeight;
 
@@ -84,7 +82,6 @@ THREE.VREffect = function ( renderer, onError ) {
 	var canvas = renderer.domElement;
 	var fullscreenchange = canvas.mozRequestFullScreen ? 'mozfullscreenchange' : 'webkitfullscreenchange';
 
-	var self = this;
 	document.addEventListener( fullscreenchange, function () {
 
 		if ( vrHMD && deprecatedAPI ) {
@@ -98,7 +95,7 @@ THREE.VREffect = function ( renderer, onError ) {
 				cachedHeight = size.height;
 
 				var eyeParamsL = vrHMD.getEyeParameters( 'left' );
-				renderer.setSize( eyeParamsL.renderRect.width * 2 * self.bufferScale, eyeParamsL.renderRect.height * self.bufferScale );
+				renderer.setSize( eyeParamsL.renderRect.width * 2, eyeParamsL.renderRect.height, false );
 
 			} else {
 
@@ -121,7 +118,7 @@ THREE.VREffect = function ( renderer, onError ) {
 			cachedHeight = size.height;
 
 			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
-			renderer.setSize( eyeParamsL.renderWidth * 2 * self.bufferScale, eyeParamsL.renderHeight * self.bufferScale );
+			renderer.setSize( eyeParamsL.renderWidth * 2, eyeParamsL.renderHeight, false );
 
 		} else {
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -61,24 +61,50 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	this.scale = 1;
 
+	this.bufferScale = 1.0;
+
+	var isPresenting = false;
+	var cachedWidth, cachedHeight;
+
 	this.setSize = function ( width, height ) {
 
-		renderer.setSize( width, height );
+		cachedWidth = width;
+		cachedHeight = height;
+
+		if ( !isPresenting ) {
+
+			renderer.setSize( width, height );
+
+		}
 
 	};
 
 	// fullscreen
 
-	var isPresenting = false;
-
 	var canvas = renderer.domElement;
 	var fullscreenchange = canvas.mozRequestFullScreen ? 'mozfullscreenchange' : 'webkitfullscreenchange';
 
+	var self = this;
 	document.addEventListener( fullscreenchange, function () {
 
 		if ( vrHMD && deprecatedAPI ) {
 
 			isPresenting = document.mozFullScreenElement || document.webkitFullscreenElement;
+
+			if ( isPresenting ) {
+
+				var size = renderer.getSize();
+				cachedWidth = size.width;
+				cachedHeight = size.height;
+
+				var eyeParamsL = vrHMD.getEyeParameters( 'left' );
+				renderer.setSize( eyeParamsL.renderRect.width * 2 * self.bufferScale, eyeParamsL.renderRect.height * self.bufferScale );
+
+			} else {
+
+				renderer.setSize( cachedWidth, cachedHeight );
+
+			}
 
 		}
 
@@ -87,6 +113,21 @@ THREE.VREffect = function ( renderer, onError ) {
 	window.addEventListener( 'vrdisplaypresentchange', function () {
 
 		isPresenting = vrHMD && vrHMD.isPresenting;
+
+		if ( isPresenting ) {
+
+			var size = renderer.getSize();
+			cachedWidth = size.width;
+			cachedHeight = size.height;
+
+			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
+			renderer.setSize( eyeParamsL.renderWidth * 2 * self.bufferScale, eyeParamsL.renderHeight * self.bufferScale );
+
+		} else {
+
+			renderer.setSize( cachedWidth, cachedHeight );
+
+		}
 
 	}, false );
 


### PR DESCRIPTION
This ensures that the scene always renders with the best resolution for
the HMD in use. (Will get a 1:1 pixel ratio) For performance reasons
developers may want to render at a lower than recommended resolution. To
do so set VREffect.bufferScale to a lower values (like 0.75).

Will restore the renderer to the previously set resolution when the user
exits VR mode.
