### PR TITLE
fix for PMREM warning: "INVALID_OPERATION: bindTexture: textures can not be used with multiple targets"

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -199,6 +199,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 	};
 
 	this.setBlending = function ( blending, blendEquation, blendSrc, blendDst, blendEquationAlpha, blendSrcAlpha, blendDstAlpha, premultipliedAlpha ) {
+
 		if ( blending === THREE.NoBlending ) {
 
 			this.disable( gl.BLEND );
@@ -571,6 +572,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 	};
 
 	this.bindTexture = function ( webglType, webglTexture ) {
+
 		if ( currentTextureSlot === undefined ) {
 
 			_this.activeTexture();

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -199,7 +199,6 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 	};
 
 	this.setBlending = function ( blending, blendEquation, blendSrc, blendDst, blendEquationAlpha, blendSrcAlpha, blendDstAlpha, premultipliedAlpha ) {
-
 		if ( blending === THREE.NoBlending ) {
 
 			this.disable( gl.BLEND );
@@ -572,7 +571,6 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 	};
 
 	this.bindTexture = function ( webglType, webglTexture ) {
-
 		if ( currentTextureSlot === undefined ) {
 
 			_this.activeTexture();
@@ -589,9 +587,12 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 		}
 
 		if ( boundTexture.type !== webglType || boundTexture.texture !== webglTexture ) {
-
-			gl.bindTexture( webglType, webglTexture || emptyTexture );
-
+			if( webglType === gl.TEXTURE_CUBE_MAP ) {
+				gl.bindTexture( webglType, webglTexture );
+			}
+			else {
+				gl.bindTexture( webglType, webglTexture || emptyTexture );
+			}
 			boundTexture.type = webglType;
 			boundTexture.texture = webglTexture;
 


### PR DESCRIPTION
This is a fix for warnings that currently show in Chrome when running the envmap_hdr example.  It warns that a texture can not be bound to two targets at once:

![image](https://cloud.githubusercontent.com/assets/588541/14212579/98c8e08c-f801-11e5-8edb-2d5fa8b23a75.png)

What is happening is that ThreeJS (for probably a good reason that I do not fully understand) is binding a default emptyTexture when one tries to bind a null texture (which means unbind.)   If I prevent this default behavior of binding the emptyTexture in the CubeTexture case, the bug/warning goes away.  I have seen no side effects of this change in my testing.
