### PR TITLE
PMREM bug fixes

### DIFF
--- a/examples/js/pmrem/PMREMCubeUVPacker.js
+++ b/examples/js/pmrem/PMREMCubeUVPacker.js
@@ -99,13 +99,18 @@ THREE.PMREMCubeUVPacker.prototype = {
 
 		var gammaInput = renderer.gammaInput;
     var gammaOutput = renderer.gammaOutput;
+		var toneMapping = renderer.toneMapping;
+		var toneMappingExposure = renderer.toneMappingExposure;
     renderer.gammaInput = false;
     renderer.gammaOutput = false;
+		renderer.toneMapping = THREE.LinearToneMapping;
+		renderer.toneMappingExposure = 1.0;
+		renderer.render( this.scene, this.camera, this.CubeUVRenderTarget, false );
 
-		renderer.render( this.scene, this.camera, this.CubeUVRenderTarget, true );
-
-    renderer.gammaInput = renderer.gammaInput;
-    renderer.gammaOutput = renderer.gammaOutput;
+		renderer.toneMapping = toneMapping;
+		renderer.toneMappingExposure = toneMappingExposure;
+		renderer.gammaInput = gammaInput;
+    renderer.gammaOutput = gammaOutput;
 	},
 
   getShader: function() {

--- a/examples/js/pmrem/PMREMCubeUVPacker.js
+++ b/examples/js/pmrem/PMREMCubeUVPacker.js
@@ -20,10 +20,18 @@ THREE.PMREMCubeUVPacker = function( cubeTextureLods, numLods ) {
 	this.numLods = numLods;
 	var size = cubeTextureLods[ 0 ].width * 4;
 
-	this.CubeUVRenderTarget = new THREE.WebGLRenderTarget( size, size,
-	{ format: THREE.RGBAFormat, magFilter: THREE.LinearFilter, minFilter: THREE.LinearFilter, type: cubeTextureLods[ 0 ].texture.type } );
-	this.CubeUVRenderTarget.texture.generateMipmaps = false;
-  this.CubeUVRenderTarget.mapping = THREE.CubeUVReflectionMapping;
+	var sourceTexture = cubeTextureLods[ 0 ].texture;
+	var params = {
+		format: sourceTexture.format,
+		magFilter: sourceTexture.magFilter,
+		minFilter: sourceTexture.minFilter,
+		type: sourceTexture.type,
+		generateMipmaps: sourceTexture.generateMipmaps,
+		anisotropy: sourceTexture.anisotropy,
+		encoding: sourceTexture.encoding
+	};
+	this.CubeUVRenderTarget = new THREE.WebGLRenderTarget( size, size, params );
+	this.CubeUVRenderTarget.mapping = THREE.CubeUVReflectionMapping;
 	this.camera = new THREE.OrthographicCamera( - size * 0.5, size * 0.5, - size * 0.5, size * 0.5, 0.0, 1000 );
 
 	this.scene = new THREE.Scene();
@@ -164,10 +172,11 @@ THREE.PMREMCubeUVPacker.prototype = {
               sampleDirection = normalize(vec3(-uv.x, uv.y, -1.0));\
           }\
           vec4 color = envMapTexelToLinear( textureCube( envMap, sampleDirection ) );\
-          gl_FragColor = linearToOutputTexel( color * vec4(testColor, 1.0) );\
+          gl_FragColor = linearToOutputTexel( color );\
         }",
 
 			blending: THREE.CustomBlending,
+			premultipliedAlpha: false,
 			blendSrc: THREE.OneFactor,
 			blendDst: THREE.ZeroFactor,
 			blendSrcAlpha: THREE.OneFactor,

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -26,18 +26,21 @@ THREE.PMREMGenerator = function( sourceTexture ) {
 	this.cubeLods = [];
 
 	var size = this.resolution;
-  var params = { format: this.sourceTexture.format, magFilter: this.sourceTexture.magFilter, minFilter: this.sourceTexture.minFilter, type: this.sourceTexture.type };
+  var params = {
+		format: this.sourceTexture.format,
+		magFilter: this.sourceTexture.magFilter,
+		minFilter: this.sourceTexture.minFilter,
+		type: this.sourceTexture.type,
+		generateMipmaps: this.sourceTexture.generateMipmaps,
+    anisotropy: this.sourceTexture.anisotropy,
+    encoding: this.sourceTexture.encoding
+	 };
 
   // how many LODs fit in the given CubeUV Texture.
 	this.numLods = Math.log2( size ) - 2;
   for ( var i = 0; i < this.numLods; i ++ ) {
 		var renderTarget = new THREE.WebGLRenderTargetCube( size, size, params );
-		renderTarget.texture.generateMipmaps = this.sourceTexture.generateMipmaps;
-    renderTarget.texture.anisotropy = this.sourceTexture.anisotropy;
-    renderTarget.texture.encoding = this.sourceTexture.encoding;
-    renderTarget.texture.minFilter = this.sourceTexture.minFilter;
-    renderTarget.texture.magFilter = this.sourceTexture.magFilter;
-		this.cubeLods.push( renderTarget );
+    this.cubeLods.push( renderTarget );
 		size = Math.max( 16, size / 2 );
 	}
 

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -78,6 +78,11 @@ THREE.PMREMGenerator.prototype = {
 
     var gammaInput = renderer.gammaInput;
     var gammaOutput = renderer.gammaOutput;
+		var toneMapping = renderer.toneMapping;
+		var toneMappingExposure = renderer.toneMappingExposure;
+
+    renderer.toneMapping = THREE.LinearToneMapping;
+		renderer.toneMappingExposure = 1.0;
     renderer.gammaInput = false;
     renderer.gammaOutput = false;
 		for ( var i = 0; i < this.numLods; i ++ ) {
@@ -92,8 +97,10 @@ THREE.PMREMGenerator.prototype = {
 
 		}
 
-    renderer.gammaInput = renderer.gammaInput;
-    renderer.gammaOutput = renderer.gammaOutput;
+		renderer.toneMapping = toneMapping;
+		renderer.toneMappingExposure = toneMappingExposure;
+    renderer.gammaInput = gammaInput;
+    renderer.gammaOutput = gammaOutput;
 
 	},
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -94,8 +94,8 @@
 					map: null,
 					bumpScale: - 0.05,
 					color: 0xffffff,
-					metalness: 0.1,
-					roughness: 0.3,
+					metalness: 1.0,
+					roughness: 1.0,
 					shading: THREE.SmoothShading
 				} );
 
@@ -199,7 +199,7 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				renderer.toneMapping = THREE.ReinhardToneMapping;
+				//renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -95,7 +95,7 @@
 					bumpScale: - 0.05,
 					color: 0xffffff,
 					metalness: 0.9,
-					roughness: 1.0,
+					roughness: 0.5,
 					shading: THREE.SmoothShading
 				} );
 
@@ -152,9 +152,6 @@
 					pmremCubeUVPacker.update( renderer );
 
 					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
-
-					standardMaterial.envMap = hdrCubeRenderTarget;
-					standardMaterial.needsUpdate = true;
 				} );
 
 				var ldrUrls = genCubeUrls( "./textures/cube/pisa/", ".png" );
@@ -206,16 +203,6 @@
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 
-				composer = new THREE.EffectComposer( renderer );
-				composer.setSize( window.innerWidth, window.innerHeight );
-
-				var renderScene = new THREE.RenderPass( scene, camera );
-				composer.addPass( renderScene );
-
-				var copyPass = new THREE.ShaderPass( THREE.CopyShader );
-				copyPass.renderToScreen = true;
-				composer.addPass( copyPass );
-
 				stats = new Stats();
 				stats.domElement.style.position = 'absolute';
 				stats.domElement.style.top = '0px';
@@ -230,7 +217,7 @@
 
 				var gui = new dat.GUI();
 
-				gui.add( params, 'envMap', [ 'LDR', 'HDR', 'RGBM16' ] );
+				gui.add( params, 'envMap', [ 'None', 'LDR', 'HDR', 'RGBM16' ] );
 				gui.add( params, 'roughness', 0, 1 );
 				gui.add( params, 'bumpScale', - 1, 1 );
 				gui.add( params, 'exposure', 0.1, 2 );
@@ -247,7 +234,6 @@
 				camera.updateProjectionMatrix();
 
 				renderer.setSize( width, height );
-				composer.setSize( width, height );
 
 			}
 
@@ -299,7 +285,7 @@
 
 				}
 
-				composer.render();
+				renderer.render( scene, camera );
 
 			}
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -202,6 +202,7 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
+				renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 
@@ -269,14 +270,23 @@
 					standardMaterial.roughness = params.roughness;
 					standardMaterial.bumpScale = - 0.05 * params.bumpScale;
 					switch( params.envMap ) {
-						case 'LDR': standardMaterial.envMap = ldrCubeRenderTarget; break;
-						case 'HDR': standardMaterial.envMap = hdrCubeRenderTarget; break;
-						case 'RGBM16': standardMaterial.envMap = rgbmCubeRenderTarget; break;
+						case 'None': newEnvMap = null; break;
+						case 'LDR': newEnvMap = ldrCubeRenderTarget; break;
+						case 'HDR': newEnvMap = hdrCubeRenderTarget; break;
+						case 'RGBM16': newEnvMap = rgbmCubeRenderTarget; break;
+					}
+					if( newEnvMap !== standardMaterial.envMap ) {
+						standardMaterial.envMap = newEnvMap;
+						standardMaterial.needsUpdate = true;
+						floorMaterial.emissive = new THREE.Color( 1, 1, 1 );
+						floorMaterial.emissiveMap = newEnvMap;
+						floorMaterial.needsUpdate = true;
+						//console.log( 'standardMat', standardMaterial );
 					}
 
 				}
 
-				renderer.toneMappingExposure = params.exposure;
+				renderer.toneMappingExposure = Math.pow( params.exposure, 4.0 );
 
 				var timer = Date.now() * 0.00025;
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -94,8 +94,8 @@
 					map: null,
 					bumpScale: - 0.05,
 					color: 0xffffff,
-					metalness: 0.9,
-					roughness: 0.5,
+					metalness: 0.1,
+					roughness: 0.3,
 					shading: THREE.SmoothShading
 				} );
 
@@ -255,6 +255,7 @@
 
 					standardMaterial.roughness = params.roughness;
 					standardMaterial.bumpScale = - 0.05 * params.bumpScale;
+					var newEnvMap = standardMaterial.envMap;
 					switch( params.envMap ) {
 						case 'None': newEnvMap = null; break;
 						case 'LDR': newEnvMap = ldrCubeRenderTarget; break;
@@ -267,9 +268,7 @@
 						floorMaterial.emissive = new THREE.Color( 1, 1, 1 );
 						floorMaterial.emissiveMap = newEnvMap;
 						floorMaterial.needsUpdate = true;
-						//console.log( 'standardMat', standardMaterial );
 					}
-
 				}
 
 				renderer.toneMappingExposure = Math.pow( params.exposure, 4.0 );

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -25,7 +25,7 @@ THREE.WebGLRenderTarget = function ( width, height, options ) {
 
 	if ( options.minFilter === undefined ) options.minFilter = THREE.LinearFilter;
 
-	this.texture = new THREE.Texture( undefined, undefined, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy );
+	this.texture = new THREE.Texture( undefined, undefined, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
 
 	this.depthBuffer = options.depthBuffer !== undefined ? options.depthBuffer : true;
 	this.stencilBuffer = options.stencilBuffer !== undefined ? options.stencilBuffer : true;

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -205,6 +205,8 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 			#endif
 
+			envMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;
+
 		#elif defined( ENVMAP_TYPE_CUBE_UV )
 
 			vec3 queryVec = flipNormal * vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
@@ -215,8 +217,6 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 			vec4 envMapColor = vec4( 0.0 );
 
 		#endif
-
-		envMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;
 
 		return PI * envMapColor.rgb * envMapIntensity;
 
@@ -276,6 +276,8 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 			#endif
 
+			envMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;
+
 		#elif defined( ENVMAP_TYPE_CUBE_UV )
 
 			vec3 queryReflectVec = flipNormal * vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
@@ -297,6 +299,8 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 			#endif
 
+			envMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;
+
 		#elif defined( ENVMAP_TYPE_SPHERE )
 
 			vec3 reflectView = flipNormal * normalize((viewMatrix * vec4( reflectVec, 0.0 )).xyz + vec3(0.0,0.0,1.0));
@@ -311,9 +315,9 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 			#endif
 
-		#endif
+			envMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;
 
-		envMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;
+		#endif
 
 		return envMapColor.rgb * envMapIntensity;
 

--- a/src/textures/CompressedTexture.js
+++ b/src/textures/CompressedTexture.js
@@ -2,9 +2,9 @@
  * @author alteredq / http://alteredqualia.com/
  */
 
-THREE.CompressedTexture = function ( mipmaps, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy ) {
+THREE.CompressedTexture = function ( mipmaps, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy, encoding ) {
 
-	THREE.Texture.call( this, null, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
+	THREE.Texture.call( this, null, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding );
 
 	this.image = { width: width, height: height };
 	this.mipmaps = mipmaps;

--- a/src/textures/CubeTexture.js
+++ b/src/textures/CubeTexture.js
@@ -2,12 +2,12 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.CubeTexture = function ( images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy ) {
+THREE.CubeTexture = function ( images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding ) {
 
 	images = images !== undefined ? images : [];
 	mapping = mapping !== undefined ? mapping : THREE.CubeReflectionMapping;
 
-	THREE.Texture.call( this, images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
+	THREE.Texture.call( this, images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding );
 
 	this.flipY = false;
 

--- a/src/textures/DataTexture.js
+++ b/src/textures/DataTexture.js
@@ -2,9 +2,9 @@
  * @author alteredq / http://alteredqualia.com/
  */
 
-THREE.DataTexture = function ( data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy ) {
+THREE.DataTexture = function ( data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy, encoding ) {
 
-	THREE.Texture.call( this, null, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
+	THREE.Texture.call( this, null, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding );
 
 	this.image = { data: data, width: width, height: height };
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -4,7 +4,7 @@
  * @author szimek / https://github.com/szimek/
  */
 
-THREE.Texture = function ( image, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy ) {
+THREE.Texture = function ( image, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding ) {
 
 	Object.defineProperty( this, 'id', { value: THREE.TextureIdCount ++ } );
 
@@ -42,7 +42,7 @@ THREE.Texture = function ( image, mapping, wrapS, wrapT, magFilter, minFilter, f
 	//
 	// Also changing the encoding after already used by a Material will not automatically make the Material
 	// update.  You need to explicitly call Material.needsUpdate to trigger it to recompile.
-	this.encoding = THREE.LinearEncoding;
+	this.encoding = encoding !== undefined ? encoding :  THREE.LinearEncoding;
 
 	this.version = 0;
 	this.onUpdate = null;


### PR DESCRIPTION
As we launched the PMREM support in Clara.io we came across a bunch of bugs.  Here is a PR that brings these bug fixes back into Three.JS:
1. Most importantly in lights_pars.glsl we were double decoding texels in the case of CubeUV env maps.  We didn't notice this because of point (3).
2. In PMREMCubeUVPacker.js and PMREMGenerator.js we were not being careful about turning off tone mapping and gamma correction when rendering to texture, this was causing unwanted intensity changes in the resulting HDR maps.
3. We were not careful about maintaining the texel encodings in PMREMCubeUVPacker.js and it was mistakenly converting from the import HDR encoding to standard linear encoding during the texture packing operation.  This change brightens up the envmap_hdr example significantly.
4. I added encoding as a constructor parameter to Texture, DataTexture, CubeTexture, CompressedTexture.

This PR also shows the packed texture on the floor of envmap_hdr - which is nice to see.
