### PR TITLE
Set to use HAVE_CURRENT_DATA for VideoTexture updates

### DIFF
--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -14,7 +14,7 @@ THREE.VideoTexture = function ( video, mapping, wrapS, wrapT, magFilter, minFilt
 
 		requestAnimationFrame( update );
 
-		if ( video.readyState === video.HAVE_ENOUGH_DATA ) {
+		if ( video.readyState === video.HAVE_CURRENT_DATA ) {
 
 			scope.needsUpdate = true;
 

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -14,7 +14,7 @@ THREE.VideoTexture = function ( video, mapping, wrapS, wrapT, magFilter, minFilt
 
 		requestAnimationFrame( update );
 
-		if ( video.readyState === video.HAVE_CURRENT_DATA ) {
+		if ( video.readyState >= video.HAVE_CURRENT_DATA ) {
 
 			scope.needsUpdate = true;
 


### PR DESCRIPTION
Video texture should check `readyState` of video to see if current frame is renderable, not if future frames are renderable. 

One thing I've noticed is that on Firefox, when streaming video, is that video textures will not render until a considerable amount of video is buffered in advance, regardless of the current frame being renderable.
