### PR TITLE
Fixed JSON.stringify( object ).

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -546,7 +546,9 @@ THREE.Object3D.prototype = {
 
 	toJSON: function ( meta ) {
 
-		var isRootObject = ( meta === undefined );
+		var isRootObject = ( meta === undefined || meta === '' );
+		// when meta is an empty string, this method has been called from
+		// within JSON.stringify
 
 		var output = {};
 


### PR DESCRIPTION
`.toJSON` is a reserved name that is automatically called by `JSON.stringify`. Though we were unaware of it, it has been used out there. Recently people ran into problems, because no `meta` object is created in `Object3D.toJSON`, because the argument is not `undefined` but an empty string (see #8428).

This PR takes the edge off the issue: We can still rename `toJSON` to something like `serialize`, but this way the bug is fixed and there's no urgency to do so.
