### PR TITLE
WebVR: Respect full translation vector from HMD.

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -258,8 +258,10 @@ THREE.VREffect = function ( renderer, onError ) {
 			camera.matrixWorld.decompose( cameraL.position, cameraL.quaternion, cameraL.scale );
 			camera.matrixWorld.decompose( cameraR.position, cameraR.quaternion, cameraR.scale );
 
-			cameraL.translateX( eyeTranslationL.x * this.scale );
-			cameraR.translateX( eyeTranslationR.x * this.scale );
+			var scale = this.scale;
+			cameraL.translateOnAxis( eyeTranslationL, scale );
+			cameraR.translateOnAxis( eyeTranslationR, scale );
+
 
 			// render left eye
 			renderer.setViewport( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );


### PR DESCRIPTION
A quality device may very well report a translation along Z, because it's the only way to easily scale a stereoscopic system without distorting the combined FOV.

As illustrated below, the cameras have to be moved back for the combined FOV to stay the same (the angles of the individual cameras are fixed and the zero parallax plane scales automatically).

![stereo_scale](https://cloud.githubusercontent.com/assets/3916357/14229309/e5e3b934-f930-11e5-839c-1a6785ca05a2.gif)
