### PR TITLE
Change TGALoader ouput from DataTexture with pixels to Texture with canvas

### DIFF
--- a/examples/js/loaders/TGALoader.js
+++ b/examples/js/loaders/TGALoader.js
@@ -390,36 +390,36 @@ THREE.TGALoader.prototype._parser = function ( buffer ) {
 				x_start = 0;
 				x_step = 1;
 				x_end = width;
-				y_start = height - 1;
-				y_step = -1;
-				y_end = -1;
+				y_start = 0;
+				y_step = 1;
+				y_end = height;
 				break;
 
 			case TGA_ORIGIN_BL:
 				x_start = 0;
 				x_step = 1;
 				x_end = width;
-				y_start = 0;
-				y_step = 1;
-				y_end = height;
+				y_start = height - 1;
+				y_step = - 1;
+				y_end = - 1;
 				break;
 
 			case TGA_ORIGIN_UR:
 				x_start = width - 1;
 				x_step = - 1;
 				x_end = - 1;
-				y_start = height - 1;
-				y_step = -1;
-				y_end = -1;
+				y_start = 0;
+				y_step = 1;
+				y_end = height;
 				break;
 
 			case TGA_ORIGIN_BR:
 				x_start = width - 1;
 				x_step = - 1;
 				x_end = - 1;
-				y_start = 0;
-				y_step = 1;
-				y_end = height;
+				y_start = height - 1;
+				y_step = - 1;
+				y_end = - 1;
 				break;
 
 		}


### PR DESCRIPTION
Refer to #8520

TGALoader outputs Texture with canvas now.
The texture is consistent to other images' texture,
like flipY = true and Y-direction is same as the others'.

BTW do you mind if I add me as author in the header?

If you accept this PR, these three PRs #8472 #8519 #8520 are no longer necessary
so I'm gonna close them without merging.
