### PR TITLE
fix capitalization of "UVGenerator"

### DIFF
--- a/docs/api/extras/geometries/ExtrudeGeometry.html
+++ b/docs/api/extras/geometries/ExtrudeGeometry.html
@@ -35,7 +35,7 @@
 <li>frames —  THREE.TubeGeometry.FrenetFrames.  containing arrays of tangents, normals, binormals</li>
 <li>material —  int. material index for front and back faces</li>
 <li>extrudeMaterial —  int. material index for extrusion and beveled faces</li>
-<li>uvGenerator —  Object. object that provides UV generator functions</li>
+<li>UVGenerator —  Object. object that provides UV generator functions</li>
 	</ul>
 
 		</div>
@@ -65,7 +65,7 @@
 <li>frames —  THREE.TubeGeometry.FrenetFrames.  containing arrays of tangents, normals, binormals</li>
 <li>material —  int. material index for front and back faces</li>
 <li>extrudeMaterial —  int. material index for extrusion and beveled faces</li>
-<li>uvGenerator —  Object. object that provides UV generator functions</li>
+<li>UVGenerator —  Object. object that provides UV generator functions</li>
 	</ul>
 	</div>
 		<div>Adds the shapes to the list to extrude.</div>
@@ -86,7 +86,7 @@
 <li>frames —  THREE.TubeGeometry.FrenetFrames.  containing arrays of tangents, normals, binormals</li>
 <li>material —  int. material index for front and back faces</li>
 <li>extrudeMaterial —  int. material index for extrusion and beveled faces</li>
-<li>uvGenerator —  Object. object that provides UV generator functions</li>
+<li>UVGenerator —  Object. object that provides UV generator functions</li>
 	</ul>
 	</div>
 		<div>Add the shape to the list to extrude.</div>


### PR DESCRIPTION
The docs list it as "uvGenerator" instead of "UVGenerator", took me a while to spot why it wasn't working...

(I'm not sure why GitHub is describing this as adding/deleting 98 lines? If there's something I should be doing differently let me know...)
