### PR TITLE
Examples: Removed deprecated THREE.ClosedSplineCurve3

### DIFF
--- a/examples/webgl_geometry_extrude_shapes.html
+++ b/examples/webgl_geometry_extrude_shapes.html
@@ -66,13 +66,16 @@
 
 				//
 
-				var closedSpline = new THREE.ClosedSplineCurve3( [
+				var closedSpline = new THREE.CatmullRomCurve3( [
 					new THREE.Vector3( -60, -100,  60 ),
 					new THREE.Vector3( -60,   20,  60 ),
 					new THREE.Vector3( -60,  120,  60 ),
 					new THREE.Vector3(  60,   20, -60 ),
 					new THREE.Vector3(  60, -100, -60 )
 				] );
+
+				closedSpline.type = 'catmullrom';
+				closedSpline.closed = true;
 
 				var extrudeSettings = {
 					steps			: 100,

--- a/examples/webgl_geometry_extrude_splines.html
+++ b/examples/webgl_geometry_extrude_splines.html
@@ -46,13 +46,16 @@
 		var pipeSpline = new THREE.CatmullRomCurve3([
 				new THREE.Vector3(0, 10, -10), new THREE.Vector3(10, 0, -10), new THREE.Vector3(20, 0, 0), new THREE.Vector3(30, 0, 10), new THREE.Vector3(30, 0, 20), new THREE.Vector3(20, 0, 30), new THREE.Vector3(10, 0, 30), new THREE.Vector3(0, 0, 30), new THREE.Vector3(-10, 10, 30), new THREE.Vector3(-10, 20, 30), new THREE.Vector3(0, 30, 30), new THREE.Vector3(10, 30, 30), new THREE.Vector3(20, 30, 15), new THREE.Vector3(10, 30, 10), new THREE.Vector3(0, 30, 10), new THREE.Vector3(-10, 20, 10), new THREE.Vector3(-10, 10, 10), new THREE.Vector3(0, 0, 10), new THREE.Vector3(10, -10, 10), new THREE.Vector3(20, -15, 10), new THREE.Vector3(30, -15, 10), new THREE.Vector3(40, -15, 10), new THREE.Vector3(50, -15, 10), new THREE.Vector3(60, 0, 10), new THREE.Vector3(70, 0, 0), new THREE.Vector3(80, 0, 0), new THREE.Vector3(90, 0, 0), new THREE.Vector3(100, 0, 0)]);
 
-		var sampleClosedSpline = new THREE.ClosedSplineCurve3([
+		var sampleClosedSpline = new THREE.CatmullRomCurve3([
 			new THREE.Vector3(0, -40, -40),
 			new THREE.Vector3(0, 40, -40),
 			new THREE.Vector3(0, 140, -40),
 			new THREE.Vector3(0, 40, 40),
 			new THREE.Vector3(0, -40, 40),
 		]);
+
+		sampleClosedSpline.type = 'catmullrom';
+		sampleClosedSpline.closed = true;
 
 		// Keep a dictionary of Curve instances
 		var splines = {

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -24,7 +24,6 @@
  * THREE.QuadraticBezierCurve3
  * THREE.CubicBezierCurve3
  * THREE.SplineCurve3
- * THREE.ClosedSplineCurve3
  *
  * A series of curves can be represented as a THREE.CurvePath
  *


### PR DESCRIPTION
Nothing special. This PR just replaces `THREE.ClosedSplineCurve3` with
`THREE.CatmullRomCurve3` to avoid undesirable warnings.
