### PR TITLE
Post-Processing: Fixed include order in examples

### DIFF
--- a/examples/webgl_postprocessing_msaa.html
+++ b/examples/webgl_postprocessing_msaa.html
@@ -39,11 +39,11 @@
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script src="js/postprocessing/ManualMSAARenderPass.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/CompositeShader.js"></script>
 
 		<script src="js/postprocessing/EffectComposer.js"></script>
+		<script src="js/postprocessing/ManualMSAARenderPass.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_smaa.html
+++ b/examples/webgl_postprocessing_smaa.html
@@ -19,11 +19,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script src="js/postprocessing/SMAAPass.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/SMAAShader.js"></script>
 
 		<script src="js/postprocessing/EffectComposer.js"></script>
+		<script src="js/postprocessing/SMAAPass.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -40,12 +40,15 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 	</head>
 	<body>
 		<script src="../build/three.js"></script>
+
 		<script src="js/shaders/SSAOShader.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
+
+		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>
-		<script src="js/postprocessing/EffectComposer.js"></script>
+		
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -40,12 +40,12 @@
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script src="js/postprocessing/ManualMSAARenderPass.js"></script>
-		<script src="js/postprocessing/TAARenderPass.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/CompositeShader.js"></script>
 
 		<script src="js/postprocessing/EffectComposer.js"></script>
+		<script src="js/postprocessing/ManualMSAARenderPass.js"></script>
+		<script src="js/postprocessing/TAARenderPass.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>


### PR DESCRIPTION
Unfortunately, i had an old cached build file in my browser from this PR #8534 . To avoid a runtime error in some examples, it's necessary to re-order the JavaScript includes. The `EffectComposer` must always be at the top of the post processing files, otherwise we get `THREE.Pass` is `undefined`.
