### PR TITLE
fix bad shadow parameters -- resolve part 2 of #8545

### DIFF
--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -122,7 +122,7 @@
 				light.castShadow = true;
 
 				light.shadow.mapSize.width = 1024;
-				light.shadow.mapSize.heigth = 1024;
+				light.shadow.mapSize.height = 1024;
 
 				var d = 390;
 


### PR DESCRIPTION
There were two recent regressions introduced into the examples.  This PR fixes the shadow artifacts visible on the animated morph character that were described in PR #8545.
