### PR TITLE
Packing.glsl - unify all packing/unpacking functions into a single glsl snippet

### DIFF
--- a/examples/js/ShaderSkin.js
+++ b/examples/js/ShaderSkin.js
@@ -83,6 +83,7 @@ THREE.ShaderSkin = {
 
 			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "bsdfs" ],
+			THREE.ShaderChunk[ "packing" ],
 			THREE.ShaderChunk[ "lights_pars" ],
 			THREE.ShaderChunk[ "shadowmap_pars_fragment" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],

--- a/examples/js/shaders/SSAOShader.js
+++ b/examples/js/shaders/SSAOShader.js
@@ -75,13 +75,7 @@ THREE.SSAOShader = {
 
 		// RGBA depth
 
-		"float unpackDepth( const in vec4 rgba_depth ) {",
-
-			"const vec4 bit_shift = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );",
-			"float depth = dot( rgba_depth, bit_shift );",
-			"return depth;",
-
-		"}",
+		"#include <packing>",
 
 		// generating noise / pattern texture for dithering
 
@@ -116,7 +110,7 @@ THREE.SSAOShader = {
 			"float cameraCoef = 2.0 * cameraNear;",
 
 			// "return ( 2.0 * cameraNear ) / ( cameraFar + cameraNear - unpackDepth( texture2D( tDepth, coord ) ) * ( cameraFar - cameraNear ) );",
-			"return cameraCoef / ( cameraFarPlusNear - unpackDepth( texture2D( tDepth, coord ) ) * cameraFarMinusNear );",
+			"return cameraCoef / ( cameraFarPlusNear - unpackRGBAToLinearUnit( texture2D( tDepth, coord ) ) * cameraFarMinusNear );",
 
 
 		"}",

--- a/examples/js/shaders/UnpackDepthRGBAShader.js
+++ b/examples/js/shaders/UnpackDepthRGBAShader.js
@@ -35,19 +35,11 @@ THREE.UnpackDepthRGBAShader = {
 
 		"varying vec2 vUv;",
 
-		// RGBA depth
-
-		"float unpackDepth( const in vec4 rgba_depth ) {",
-
-			"const vec4 bit_shift = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );",
-			"float depth = dot( rgba_depth, bit_shift );",
-			"return depth;",
-
-		"}",
+		"#include <packing>",
 
 		"void main() {",
 
-			"float depth = 1.0 - unpackDepth( texture2D( tDiffuse, vUv ) );",
+			"float depth = 1.0 - unpackRGBAToLinearUnit( texture2D( tDiffuse, vUv ) );",
 			"gl_FragColor = opacity * vec4( vec3( depth ), 1.0 );",
 
 		"}"

--- a/examples/webgl_animation_cloth.html
+++ b/examples/webgl_animation_cloth.html
@@ -46,18 +46,10 @@
 
 		<script type="x-shader/x-fragment" id="fragmentShaderDepth">
 
+			#include <packing>
+
 			uniform sampler2D texture;
 			varying vec2 vUV;
-
-			vec4 pack_depth( const in float depth ) {
-
-				const vec4 bit_shift = vec4( 256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0 );
-				const vec4 bit_mask  = vec4( 0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0 );
-				vec4 res = fract( depth * bit_shift );
-				res -= res.xxyz * bit_mask;
-				return res;
-
-			}
 
 			void main() {
 
@@ -65,7 +57,7 @@
 
 				if ( pixel.a < 0.5 ) discard;
 
-				gl_FragData[ 0 ] = pack_depth( gl_FragCoord.z );
+				gl_FragData[ 0 ] = packLinearUnitToRGBA( gl_FragCoord.z );
 
 			}
 		</script>

--- a/src/renderers/shaders/ShaderChunk/packing.glsl
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl
@@ -1,0 +1,25 @@
+vec3 packNormalToRGB( const in vec3 normal ) {
+  return normalize( normal ) * 0.5 + 0.5;
+}
+
+vec3 unpackRGBToNormal( const in vec3 rgb ) {
+  return 1.0 - 2.0 * rgb.xyz;
+}
+
+
+vec4 packLinearUnitToRGBA( const in float value ) {
+
+	const vec4 bit_shift = vec4( 256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0 );
+	const vec4 bit_mask = vec4( 0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0 );
+	vec4 res = mod( value * bit_shift * vec4( 255 ), vec4( 256 ) ) / vec4( 255 );
+	res -= res.xxyz * bit_mask;
+	return res;
+
+}
+
+float unpackRGBAToLinearUnit( const in vec4 rgba ) {
+
+	const vec4 bitSh = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );
+	return dot( rgba, bitSh );
+
+}

--- a/src/renderers/shaders/ShaderChunk/packing.glsl
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl
@@ -11,7 +11,7 @@ vec4 packLinearUnitToRGBA( const in float value ) {
 
 	const vec4 bit_shift = vec4( 256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0 );
 	const vec4 bit_mask = vec4( 0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0 );
-	vec4 res = mod( value * bit_shift * vec4( 255 ), vec4( 256 ) ) / vec4( 255 );
+	vec4 res = fract( value * bit_shift );
 	res -= res.xxyz * bit_mask;
 	return res;
 

--- a/src/renderers/shaders/ShaderChunk/packing.glsl
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl
@@ -10,7 +10,7 @@ vec3 unpackRGBToNormal( const in vec3 rgb ) {
 vec4 packLinearUnitToRGBA( const in float value ) {
 	const vec4 bit_shift = vec4( 256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0 );
 	const vec4 bit_mask = vec4( 0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0 );
-	vec4 res = fract( value * bit_shift );
+	vec4 res = mod( value * bit_shift * vec4( 255 ), vec4( 256 ) ) / vec4( 255 );
 	res -= res.xxyz * bit_mask;
 	return res;
 }

--- a/src/renderers/shaders/ShaderChunk/packing.glsl
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl
@@ -8,18 +8,14 @@ vec3 unpackRGBToNormal( const in vec3 rgb ) {
 
 
 vec4 packLinearUnitToRGBA( const in float value ) {
-
 	const vec4 bit_shift = vec4( 256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0 );
 	const vec4 bit_mask = vec4( 0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0 );
 	vec4 res = fract( value * bit_shift );
 	res -= res.xxyz * bit_mask;
 	return res;
-
 }
 
 float unpackRGBAToLinearUnit( const in vec4 rgba ) {
-
 	const vec4 bitSh = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );
 	return dot( rgba, bitSh );
-
 }

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
@@ -21,16 +21,9 @@
 
 	#endif
 
-	float unpackDepth( const in vec4 rgba_depth ) {
-
-		const vec4 bit_shift = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );
-		return dot( rgba_depth, bit_shift );
-
-	}
-
 	float texture2DCompare( sampler2D depths, vec2 uv, float compare ) {
 
-		return step( compare, unpackDepth( texture2D( depths, uv ) ) );
+		return step( compare, unpackRGBAToLinearUnit( texture2D( depths, uv ) ) );
 
 	}
 

--- a/src/renderers/shaders/ShaderLib/depthRGBA_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/depthRGBA_frag.glsl
@@ -1,15 +1,6 @@
 #include <common>
 #include <logdepthbuf_pars_fragment>
-
-vec4 pack_depth( const in float depth ) {
-
-	const vec4 bit_shift = vec4( 256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0 );
-	const vec4 bit_mask = vec4( 0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0 );
-	vec4 res = mod( depth * bit_shift * vec4( 255 ), vec4( 256 ) ) / vec4( 255 );
-	res -= res.xxyz * bit_mask;
-	return res;
-
-}
+#include <packing>
 
 void main() {
 
@@ -17,17 +8,14 @@ void main() {
 
 	#ifdef USE_LOGDEPTHBUF_EXT
 
-		gl_FragData[ 0 ] = pack_depth( gl_FragDepthEXT );
+		float depth = gl_FragDepthEXT;
 
 	#else
 
-		gl_FragData[ 0 ] = pack_depth( gl_FragCoord.z );
+		float depth = gl_FragCoord.z;
 
 	#endif
 
-	//gl_FragData[ 0 ] = pack_depth( gl_FragCoord.z / gl_FragCoord.w );
-	//float z = ( ( gl_FragCoord.z / gl_FragCoord.w ) - 3.0 ) / ( 4000.0 - 3.0 );
-	//gl_FragData[ 0 ] = pack_depth( z );
-	//gl_FragData[ 0 ] = vec4( z, z, z, 1.0 );
+	gl_FragData[ 0 ] = packLinearUnitToRGBA( depth );
 
 }

--- a/src/renderers/shaders/ShaderLib/depth_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_frag.glsl
@@ -3,6 +3,7 @@ uniform float mFar;
 uniform float opacity;
 
 #include <common>
+#include <packing>
 #include <logdepthbuf_pars_fragment>
 
 void main() {

--- a/src/renderers/shaders/ShaderLib/distanceRGBA_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/distanceRGBA_frag.glsl
@@ -2,27 +2,11 @@ uniform vec3 lightPos;
 varying vec4 vWorldPosition;
 
 #include <common>
+#include <packing>
 
-vec4 pack1K ( float depth ) {
-
-	depth /= 1000.0;
-	const vec4 bitSh = vec4( 256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0 );
-	const vec4 bitMsk = vec4( 0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0 );
-	vec4 res = mod( depth * bitSh * vec4( 255 ), vec4( 256 ) ) / vec4( 255 );
-	res -= res.xxyz * bitMsk;
-	return res;
-
-}
-
-float unpack1K ( vec4 color ) {
-
-	const vec4 bitSh = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );
-	return dot( color, bitSh ) * 1000.0;
-
-}
 
 void main () {
 
-	gl_FragColor = pack1K( length( vWorldPosition.xyz - lightPos.xyz ) );
+	gl_FragColor = packLinearUnitToRGBA( length( vWorldPosition.xyz - lightPos.xyz ) / 1000.0 );
 
 }

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl
@@ -11,6 +11,7 @@ varying vec3 vLightFront;
 #endif
 
 #include <common>
+#include <packing>
 #include <color_pars_fragment>
 #include <uv_pars_fragment>
 #include <uv2_pars_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
@@ -7,6 +7,7 @@ uniform float shininess;
 uniform float opacity;
 
 #include <common>
+#include <packing>
 #include <color_pars_fragment>
 #include <uv_pars_fragment>
 #include <uv2_pars_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
@@ -18,6 +18,7 @@ varying vec3 vViewPosition;
 #endif
 
 #include <common>
+#include <packing>
 #include <color_pars_fragment>
 #include <uv_pars_fragment>
 #include <uv2_pars_fragment>

--- a/src/renderers/shaders/ShaderLib/meshstandard_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshstandard_frag.glsl
@@ -17,6 +17,7 @@ varying vec3 vViewPosition;
 #endif
 
 #include <common>
+#include <packing>
 #include <color_pars_fragment>
 #include <uv_pars_fragment>
 #include <uv2_pars_fragment>

--- a/src/renderers/shaders/ShaderLib/normal_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/normal_frag.glsl
@@ -2,11 +2,12 @@ uniform float opacity;
 varying vec3 vNormal;
 
 #include <common>
+#include <packing>
 #include <logdepthbuf_pars_fragment>
 
 void main() {
 
-	gl_FragColor = vec4( 0.5 * normalize( vNormal ) + 0.5, opacity );
+	gl_FragColor = vec4( packNormalToRGB( vNormal ), opacity );
 
 	#include <logdepthbuf_fragment>
 

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -177,6 +177,7 @@
 	"src/renderers/shaders/ShaderChunk/morphtarget_vertex.glsl",
 	"src/renderers/shaders/ShaderChunk/normal_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl",
+	"src/renderers/shaders/ShaderChunk/packing.glsl",
 	"src/renderers/shaders/ShaderChunk/premultiplied_alpha_fragment.glsl",
 	"src/renderers/shaders/ShaderChunk/project_vertex.glsl",
 	"src/renderers/shaders/ShaderChunk/roughnessmap_fragment.glsl",


### PR DESCRIPTION
We currently have packing and unpacking functions all over the place.  This PR removes these spread out functions and unifies them into the packing.glsl snippet.

One of those rare PRs that reduces the amount of code in ThreeJS.
