### PR TITLE
update plane geometry doc

### DIFF
--- a/docs/api/extras/geometries/PlaneGeometry.html
+++ b/docs/api/extras/geometries/PlaneGeometry.html
@@ -41,7 +41,7 @@
 		<h2>Properties</h2>
 
 		<div>
-		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the contructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</div>
 
 		<h2>Source</h2>


### PR DESCRIPTION
The doc is outdated, the parameters are now located instead of the parameters property, (e.g. there is no myPlane.width)
