### PR TITLE
fix MeshDepthMaterial, addresses issue #8550

### DIFF
--- a/src/renderers/shaders/ShaderLib/depth_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_frag.glsl
@@ -2,6 +2,8 @@ uniform float mNear;
 uniform float mFar;
 uniform float opacity;
 
+varying vec3 vViewPosition;
+
 #include <common>
 #include <packing>
 #include <logdepthbuf_pars_fragment>
@@ -12,17 +14,7 @@ void main() {
 	#include <clipping_planes_fragment>
 	#include <logdepthbuf_fragment>
 
-	#ifdef USE_LOGDEPTHBUF_EXT
-
-		float depth = gl_FragDepthEXT / gl_FragCoord.w;
-
-	#else
-
-		float depth = gl_FragCoord.z / gl_FragCoord.w;
-
-	#endif
-
-	float color = 1.0 - smoothstep( mNear, mFar, depth );
+	float color = 1.0 - smoothstep( mNear, mFar, vViewPosition.z );
 	gl_FragColor = vec4( vec3( color ), opacity );
 
 }

--- a/src/renderers/shaders/ShaderLib/depth_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_frag.glsl
@@ -2,7 +2,7 @@ uniform float mNear;
 uniform float mFar;
 uniform float opacity;
 
-varying vec3 vViewPosition;
+varying float viewZDepth;
 
 #include <common>
 #include <packing>
@@ -14,7 +14,7 @@ void main() {
 	#include <clipping_planes_fragment>
 	#include <logdepthbuf_fragment>
 
-	float color = 1.0 - smoothstep( mNear, mFar, vViewPosition.z );
+	float color = 1.0 - smoothstep( mNear, mFar, viewZDepth );
 	gl_FragColor = vec4( vec3( color ), opacity );
 
 }

--- a/src/renderers/shaders/ShaderLib/depth_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_frag.glsl
@@ -2,7 +2,7 @@ uniform float mNear;
 uniform float mFar;
 uniform float opacity;
 
-varying float viewZDepth;
+varying float vViewZDepth;
 
 #include <common>
 #include <packing>
@@ -14,7 +14,7 @@ void main() {
 	#include <clipping_planes_fragment>
 	#include <logdepthbuf_fragment>
 
-	float color = 1.0 - smoothstep( mNear, mFar, viewZDepth );
+	float color = 1.0 - smoothstep( mNear, mFar, vViewZDepth );
 	gl_FragColor = vec4( vec3( color ), opacity );
 
 }

--- a/src/renderers/shaders/ShaderLib/depth_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_vert.glsl
@@ -3,7 +3,7 @@
 #include <logdepthbuf_pars_vertex>
 #include <clipping_planes_pars_vertex>
 
-varying vec3 vViewPosition;
+varying float viewZDepth;
 
 void main() {
 
@@ -13,6 +13,6 @@ void main() {
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>
 
-	vViewPosition = - mvPosition.xyz;
+	viewZDepth = - mvPosition.z;
 
 }

--- a/src/renderers/shaders/ShaderLib/depth_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_vert.glsl
@@ -3,7 +3,7 @@
 #include <logdepthbuf_pars_vertex>
 #include <clipping_planes_pars_vertex>
 
-varying float viewZDepth;
+varying float vViewZDepth;
 
 void main() {
 
@@ -13,6 +13,6 @@ void main() {
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>
 
-	viewZDepth = - mvPosition.z;
+	vViewZDepth = - mvPosition.z;
 
 }

--- a/src/renderers/shaders/ShaderLib/depth_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_vert.glsl
@@ -3,6 +3,8 @@
 #include <logdepthbuf_pars_vertex>
 #include <clipping_planes_pars_vertex>
 
+varying vec3 vViewPosition;
+
 void main() {
 
 	#include <begin_vertex>
@@ -10,5 +12,7 @@ void main() {
 	#include <project_vertex>
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>
+
+	vViewPosition = - mvPosition.xyz;
 
 }


### PR DESCRIPTION
This PR fixes the inaccuracy of MeshDepthMaterial.  Basically it wasn't really working as discussed here #8550.  I have followed @tschw's suggestion and used a varying to pass along the depth from the vertex to the fragment -- I have done this in this PR.
