### PR TITLE
Clock

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -55,7 +55,7 @@ THREE.Clock.prototype = {
 
 			var newTime = ( performance || Date ).now();
 
-			diff = 0.001 * ( newTime - this.oldTime );
+			diff = ( newTime - this.oldTime ) / 1000;
 			this.oldTime = newTime;
 
 			this.elapsedTime += diff;

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -20,7 +20,7 @@ THREE.Clock.prototype = {
 
 	start: function () {
 
-		this.startTime = performance.now();
+		this.startTime = ( performance || Date ).now();
 
 		this.oldTime = this.startTime;
 		this.running = true;
@@ -53,7 +53,7 @@ THREE.Clock.prototype = {
 
 		if ( this.running ) {
 
-			var newTime = performance.now();
+			var newTime = ( performance || Date ).now();
 
 			diff = 0.001 * ( newTime - this.oldTime );
 			this.oldTime = newTime;


### PR DESCRIPTION
Fixes #8112 and keeps using `performance`, even though the precision decreases over a longer period of time.
