### PR TITLE
correct typo in Shape documentation page

### DIFF
--- a/docs/api/extras/core/Shape.html
+++ b/docs/api/extras/core/Shape.html
@@ -30,7 +30,7 @@
 
 		var extrudeSettings = { amount: 8, bevelEnabled: true, bevelSegments: 2, steps: 2, bevelSize: 1, bevelThickness: 1 };
 
-		var geometry = new THREE.ExtrudeGeometry( shape, extrudeSettings );
+		var geometry = new THREE.ExtrudeGeometry( heartShape, extrudeSettings );
 
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshPhongMaterial() );
 		</code>


### PR DESCRIPTION
Fix for issue #8571 .
I'm new to GitHub. I don't know why the diff is showing 125 additions and 125 deletions, where I only changed one word without formatting the entire source. I'm editing it directly in GitHub website. Is it a problem? I don't want to mess it up.
