### PR TITLE
Revert #8121 – "empty texture" handling

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -60,11 +60,6 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 	var currentScissor = new THREE.Vector4();
 	var currentViewport = new THREE.Vector4();
 
-	var emptyTexture = gl.createTexture();
-	gl.bindTexture( gl.TEXTURE_2D, emptyTexture );
-	gl.texParameteri( gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR );
-	gl.texImage2D( gl.TEXTURE_2D, 0, gl.RGB, 1, 1, 0, gl.RGB, gl.UNSIGNED_BYTE, new Uint8Array( 3 ) );
-
 	this.init = function () {
 
 		this.clearColor( 0, 0, 0, 1 );
@@ -591,7 +586,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 		if ( boundTexture.type !== webglType || boundTexture.texture !== webglTexture ) {
 
-			gl.bindTexture( webglType, webglTexture || emptyTexture );
+			gl.bindTexture( webglType, webglTexture );
 
 			boundTexture.type = webglType;
 			boundTexture.texture = webglTexture;


### PR DESCRIPTION
This reverts #8121 back to how it was before.
The original PR was only needed for WebGL2 in Chrome Canary. In FireFox, that error was not happening. The spec should allow `null` to be passed to bind texture from what I can tell, so Chrome should be fixing things rather than ThreeJS.

This PR is a cleaner fix to #8502.
