### PR TITLE
Examples: Clean up center/target OrbitControls

### DIFF
--- a/examples/webgl_geometry_terrain_raycast.html
+++ b/examples/webgl_geometry_terrain_raycast.html
@@ -79,13 +79,13 @@
 				scene = new THREE.Scene();
 
 				controls = new THREE.OrbitControls(camera);
-				controls.center.set( 0.0, 100.0, 0.0 );
+				controls.target.set( 0.0, 100.0, 0.0 );
 				controls.userPanSpeed = 100;
 
 				data = generateHeight( worldWidth, worldDepth );
 
-				controls.center.y = data[ worldHalfWidth + worldHalfDepth * worldWidth ] + 500;
-				camera.position.y =  controls.center.y + 2000;
+				controls.target.y = data[ worldHalfWidth + worldHalfDepth * worldWidth ] + 500;
+				camera.position.y =  controls.target.y + 2000;
 				camera.position.x = 2000;
 
 				var geometry = new THREE.PlaneBufferGeometry( 7500, 7500, worldWidth - 1, worldDepth - 1 );

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -263,7 +263,7 @@
 						defaultCamera.position.copy(sceneInfo.cameraPos);
 
 					if (sceneInfo.center) {
-						orbitControls.center.copy(sceneInfo.center);
+						orbitControls.target.copy(sceneInfo.center);
 					}
 
 					if (sceneInfo.objectPosition) {

--- a/examples/webgl_morphtargets_human.html
+++ b/examples/webgl_morphtargets_human.html
@@ -130,7 +130,7 @@
 				window.addEventListener( 'resize', onWindowResize, false );
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
-				controls.center.set( 0, 3000, 0 );
+				controls.target.set( 0, 3000, 0 );
 
 				controls.addEventListener( 'change', render );
 

--- a/examples/webgl_shaders_vector.html
+++ b/examples/webgl_shaders_vector.html
@@ -109,7 +109,7 @@
 				camera.position.set( 0, 100, 500 );
 
 				controls = new THREE.OrbitControls( camera );
-				controls.center.set( 0, 100, 0 );
+				controls.target.set( 0, 100, 0 );
 
 				scene = new THREE.Scene();
 


### PR DESCRIPTION
This PR replaces the deprecated `center` property with `target` for all `THREE.OrbitControls` objects.
