### PR TITLE
Update ColladaLoader2 default wrapping to repeating

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -599,6 +599,11 @@ THREE.ColladaLoader.prototype = {
 						texture.offset.set( technique.offsetU, technique.offsetV );
 						texture.repeat.set( technique.repeatU, technique.repeatV );
 
+					} else {
+					
+						texture.wrapS = THREE.RepeatWrapping;
+						texture.wrapT = THREE.RepeatWrapping;
+					
 					}
 
 					texture.needsUpdate = true;


### PR DESCRIPTION
When Wrap Mode data is missing, fallback to Collada spec default repeated wrapping. Without this change the wrapping is clamped to edge which should not be the default behaviour.
