### PR TITLE
Transparency fix conform collada specs

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3615,7 +3615,7 @@ THREE.ColladaLoader = function () {
 					var f = child.querySelectorAll('float');
 
 					if ( f.length > 0 )
-						this[ child.nodeName ] = parseFloat( f[ 0 ].textContent );
+						this[ child.nodeName ] = 1.0 - parseFloat( f[ 0 ].textContent );
 
 					break;
 


### PR DESCRIPTION
If <transparency> does not exist then it has no effect on the equation’s result. This is equivalent
to a factor that is 1.0 (from collada specs)
