### PR TITLE
Set Face3 materialIndex when using MultiMaterial

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1170,6 +1170,13 @@ THREE.ColladaLoader = function () {
 				if ( num_materials > 1 ) {
 
 					material = new THREE.MultiMaterial( used_materials_array );
+					
+					for ( j = 0; j < geom.faces.length; j ++ ) {
+
+						var face = geom.faces[ j ];
+						face.materialIndex = used_materials[ face.daeMaterial ]
+
+					}
 
 				}
 


### PR DESCRIPTION
I noticed this was missing after updating from an older version of ColladaLoader.js. This fixes the face materialIndex not being set.
