### PR TITLE
decouple PerspectiveCamera parameters in ObjectLoader

### DIFF
--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -215,7 +215,8 @@ THREE.PerspectiveCamera.prototype.toJSON = function( meta ) {
 	data.object.focus = this.focus;
 
 	data.object.aspect = this.aspect;
-	data.object.view = this.view === null ? null : Object.assign( {}, this.view );
+	
+	if( this.view ) data.object.view = Object.assign( {}, this.view );
 
 	data.object.filmGauge = this.filmGauge;
 	data.object.filmOffset = this.filmOffset;

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -473,7 +473,7 @@ THREE.ObjectLoader.prototype = {
 					if ( data.zoom !== undefined ) object.zoom = data.zoom;
 					if ( data.filmGauge !== undefined ) object.filmGauge = data.filmGauge;
 					if ( data.filmOffset !== undefined ) object.filmOffset = data.filmOffset;
-					if ( data.view !== null ) object.view = Object.assign( {}, data.view );
+					if ( data.view !== undefined ) object.view = Object.assign( {}, data.view );
 
 					break;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -471,16 +471,9 @@ THREE.ObjectLoader.prototype = {
 
 					if ( data.focus !== undefined ) object.focus = data.focus;
 					if ( data.zoom !== undefined ) object.zoom = data.zoom;
-
-					if ( data.filmGauge !== undefined ) {
-
-						if ( data.view !== null )
-							object.view = Object.assign( {}, data.view );
-
-						object.filmGauge = data.filmGauge;
-						object.filmOffset = data.filmOffset;
-
-					}
+					if ( data.filmGauge !== undefined ) object.filmGauge = data.filmGauge;
+					if ( data.filmOffset !== undefined ) object.filmOffset = data.filmOffset;
+					if ( data.view !== null ) object.view = Object.assign( {}, data.view );
 
 					break;
 


### PR DESCRIPTION
Just improving long-term robustness in the read by removing unnecessary coupling between PerspectiveCamera parameters.

For more discussion see here: https://github.com/mrdoob/three.js/pull/8561/files/7eea5d47d86a6376175761cddab2742f17de177f#r59205742
