### PR TITLE
fix bug in invClipZ unpacking glsl code.

### DIFF
--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -35,7 +35,7 @@
         padding: 5px;
         display: inline-block;
       }
-      
+
       #error {
         margin: auto;
         margin-top: 40px;
@@ -45,7 +45,7 @@
         background: #CE0808;
       }
     </style>
-    
+
     <script id="post-vert" type="x-shader/x-vertex">
       varying vec2 vUv;
 
@@ -56,23 +56,19 @@
     </script>
     <script id="post-frag" type="x-shader/x-fragment">
       #include <packing>
-    
+
       varying vec2 vUv;
       uniform sampler2D tDiffuse;
       uniform sampler2D tDepth;
       uniform float cameraNear;
       uniform float cameraFar;
 
-      float readDepth (sampler2D depthSampler, vec2 coord) {
-        float cameraFarPlusNear = cameraFar + cameraNear;
-        float cameraFarMinusNear = cameraFar - cameraNear;
-        float cameraCoef = 2.0 * cameraNear;
-        return cameraCoef / (cameraFarPlusNear - texture2D(depthSampler, coord).x * cameraFarMinusNear);
-      }
 
-      // float depthTexel = texture2D(tDepth, vUv).x;
-      // float depth = invClipZToViewZ(depthTexel, cameraNear, cameraFar);
-      // float linearClipZ = viewZToLinearClipZ(depth, cameraNear, cameraFar);
+      float readDepth (sampler2D depthSampler, vec2 coord) {
+        float fragCoordZ = texture2D(depthSampler, coord).x;
+        float viewZ = invClipZToViewZ( fragCoordZ, cameraNear, cameraFar );
+        return viewZToLinearClipZ( viewZ, cameraNear, cameraFar );
+      }
 
       void main() {
         vec3 diffuse = texture2D(tDiffuse, vUv).rgb;

--- a/src/renderers/shaders/ShaderChunk/packing.glsl
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl
@@ -32,5 +32,5 @@ float viewZToInvClipZ( const in float viewZ, const in float near, const in float
   return (( near + viewZ ) * far ) / (( far - near ) * viewZ );
 }
 float invClipZToViewZ( const in float invClipZ, const in float near, const in float far ) {
-  return ( near * far ) / ( ( near - far ) * invClipZ - far );
+  return ( near * far ) / ( ( far - near ) * invClipZ - far );
 }


### PR DESCRIPTION
I had a sign bug in glsl unpacking code for perspective depth buffer values.  @mattdesl ran into this with his new depth texture example with the commented out code here:

https://github.com/mrdoob/three.js/pull/8577/commits/9350eb557d3ad3c11775c854425a4873b0bc0c7e

This PR fixes the decoding.
