### PR TITLE
Allow Raycaster intersection invisible objects

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -41,8 +41,6 @@
 
 	function intersectObject( object, raycaster, intersects, recursive ) {
 
-		if ( object.visible === false ) return;
-
 		object.raycast( raycaster, intersects );
 
 		if ( recursive === true ) {


### PR DESCRIPTION
This is useful for when using invisible meshes as a bounding mesh that is simpler or bigger than the original object, but you don't want the bounding mesh to be visible. I use this to make clicking detailed meshes easier for the user.
