### PR TITLE
remove ability to set depth formula on MeshDepthMaterial.

### DIFF
--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -20,7 +20,7 @@
         font-weight: bold;
         pointer-events: auto;
       }
-      
+
       canvas {
         position: absolute;
         top: 0;
@@ -66,8 +66,8 @@
 
       float readDepth (sampler2D depthSampler, vec2 coord) {
         float fragCoordZ = texture2D(depthSampler, coord).x;
-        float viewZ = invClipZToViewZ( fragCoordZ, cameraNear, cameraFar );
-        return viewZToLinearClipZ( viewZ, cameraNear, cameraFar );
+        float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );
+        return viewZToOrthoDepth( viewZ, cameraNear, cameraFar );
       }
 
       void main() {
@@ -86,11 +86,11 @@
       <a href="http://threejs.org" target="_blank">threejs</a> - WebGL - Depth Texture<br/>
       Stores render target depth in a texture attachment.<br/>
       Created by <a href="http://twitter.com/mattdesl" target="_blank">@mattdesl</a>.
-      
+
       <div id="error" style="display: none;">
       Your browser does not support <strong>WEBGL_depth_texture</strong>.<br/><br/>
       This demo will not work.
-      </div>  
+      </div>
     </div>
 
     <script src="../build/three.js"></script>
@@ -110,7 +110,7 @@
       function init() {
 
         var canvas = document.querySelector('canvas');
-        var gl; 
+        var gl;
         try {
 
           gl = canvas.getContext('webgl2');
@@ -121,7 +121,7 @@
 
         }
         var isWebGL2 = Boolean(gl);
-        
+
         renderer = new THREE.WebGLRenderer( {
           canvas: canvas,
           context: gl
@@ -217,7 +217,7 @@
           scene.add(mesh);
 
         }
-        
+
       }
 
       function onWindowResize() {

--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -66,7 +66,7 @@
 			var cameraOrtho, cameraPerspective;
 			var controlsOrtho, controlsPerspective;
 
-			var mesh, materialStandard, materialDepthAuto, materialDepthAutoRGBA, materialDepthLinearClipZ, materialDepthLinearClipZRGBA, materialDepthInvClipZ, materialDepthInvClipZRGBA, materialNormal;
+			var mesh, materialStandard, materialDepthLinear, materialDepthRGBA, materialNormal;
 
 			var pointLight, ambientLight;
 
@@ -83,7 +83,7 @@
 			function initGui() {
 
 				var gui = new dat.GUI();
-				gui.add( params, 'material', [ 'standard', 'normal', 'depthAuto', 'depthAutoRGBA', 'depthLinearClipZ', 'depthLinearClipZRGBA', 'depthInvClipZ', 'depthInvClipZRGBA' ] );
+				gui.add( params, 'material', [ 'standard', 'normal', 'depthLinear', 'depthRGBA' ] );
 				gui.add( params, 'camera', [ 'perspective', 'ortho' ] );
 
 			}
@@ -172,8 +172,7 @@
 					side: THREE.DoubleSide
 				} );
 
-				materialDepthAuto = new THREE.MeshDepthMaterial( {
-					depthFormat: THREE.AutoDepthFormat,
+				materialDepthLinear = new THREE.MeshDepthMaterial( {
 					depthPacking: THREE.LinearDepthPacking,
 
 					displacementMap: displacementMap,
@@ -183,52 +182,7 @@
 					side: THREE.DoubleSide
 				} );
 
-				materialDepthAutoRGBA = new THREE.MeshDepthMaterial( {
-					depthFormat: THREE.AutoDepthFormat,
-					depthPacking: THREE.RGBADepthPacking,
-
-					displacementMap: displacementMap,
-					displacementScale: SCALE,
-					displacementBias: BIAS,
-
-					side: THREE.DoubleSide
-				} );
-
-				materialDepthLinearClipZ = new THREE.MeshDepthMaterial( {
-					depthFormat: THREE.LinearClipZDepthFormat,
-					depthPacking: THREE.LinearDepthPacking,
-
-					displacementMap: displacementMap,
-					displacementScale: SCALE,
-					displacementBias: BIAS,
-
-					side: THREE.DoubleSide
-				} );
-
-				materialDepthLinearClipZRGBA = new THREE.MeshDepthMaterial( {
-					depthFormat: THREE.LinearClipZDepthFormat,
-					depthPacking: THREE.RGBADepthPacking,
-
-					displacementMap: displacementMap,
-					displacementScale: SCALE,
-					displacementBias: BIAS,
-
-					side: THREE.DoubleSide
-				} );
-
-				materialDepthInvClipZ = new THREE.MeshDepthMaterial( {
-					depthFormat: THREE.InvClipZDepthFormat,
-					depthPacking: THREE.LinearDepthPacking,
-
-					displacementMap: displacementMap,
-					displacementScale: SCALE,
-					displacementBias: BIAS,
-
-					side: THREE.DoubleSide
-				} );
-
-				materialDepthInvClipZRGBA = new THREE.MeshDepthMaterial( {
-					depthFormat: THREE.InvClipZDepthFormat,
+				materialDepthRGBA = new THREE.MeshDepthMaterial( {
 					depthPacking: THREE.RGBADepthPacking,
 
 					displacementMap: displacementMap,
@@ -307,14 +261,12 @@
 					var material = mesh.material;
 
 					switch ( params.material ) {
+						
 						case 'standard': material = materialStandard; break;
-						case 'depthAuto': material = materialDepthAuto; break;
-						case 'depthAutoRGBA': material = materialDepthAutoRGBA; break;
-						case 'depthLinearClipZ': material = materialDepthLinearClipZ; break;
-						case 'depthLinearClipZRGBA': material = materialDepthLinearClipZRGBA; break;
-						case 'depthInvClipZ': material = materialDepthInvClipZ; break;
-						case 'depthInvClipZRGBA': material = materialDepthInvClipZRGBA; break;
+						case 'depthLinear': material = materialDepthLinear; break;
+						case 'depthRGBA': material = materialDepthRGBA; break;
 						case 'normal': material = materialNormal; break;
+
 					}
 
 					mesh.material = material;
@@ -324,7 +276,6 @@
 				switch ( params.camera ) {
 
 					case 'perspective': camera = cameraPerspective; break;
-
 					case 'ortho': camera = cameraOrtho; break;
 
 				}

--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -21,7 +21,6 @@ THREE.MeshDepthMaterial = function ( parameters ) {
 
 	this.type = 'MeshDepthMaterial';
 
-	this.depthFormat = THREE.AutoDepthFormat;
 	this.depthPacking = THREE.LinearDepthPacking;
 
 	this.skinning = false;
@@ -45,7 +44,6 @@ THREE.MeshDepthMaterial.prototype.copy = function ( source ) {
 
 	THREE.Material.prototype.copy.call( this, source );
 
-	this.depthFormat = source.depthFormat;
 	this.depthPacking = source.depthPacking;
 
 	this.skinning = source.skinning;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1994,8 +1994,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			} else if ( material instanceof THREE.MeshDepthMaterial ) {
 
-				m_uniforms.mNear.value = camera.near;
-				m_uniforms.mFar.value = camera.far;
 				m_uniforms.opacity.value = material.opacity;
 
 				if ( material.displacementMap ) {

--- a/src/renderers/shaders/ShaderChunk/packing.glsl
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl
@@ -21,16 +21,16 @@ float unpackRGBAToLinearUnit( const in vec4 rgba ) {
 
 // NOTE: viewZ/eyeZ is < 0 when in front of the camera per OpenGL conventions
 
-float viewZToLinearClipZ( const in float viewZ, const in float near, const in float far ) {
+float viewZToOrthoDepth( const in float viewZ, const in float near, const in float far ) {
   return ( viewZ + near ) / ( near - far );
 }
-float linearClipZToViewZ( const in float linearClipZ, const in float near, const in float far ) {
+float OrthoDepthToViewZ( const in float linearClipZ, const in float near, const in float far ) {
   return linearClipZ * ( near - far ) - near;
 }
 
-float viewZToInvClipZ( const in float viewZ, const in float near, const in float far ) {
+float viewZToPerspectiveDepth( const in float viewZ, const in float near, const in float far ) {
   return (( near + viewZ ) * far ) / (( far - near ) * viewZ );
 }
-float invClipZToViewZ( const in float invClipZ, const in float near, const in float far ) {
+float perspectiveDepthToViewZ( const in float invClipZ, const in float near, const in float far ) {
   return ( near * far ) / ( ( far - near ) * invClipZ - far );
 }

--- a/src/renderers/shaders/ShaderLib/depth_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_frag.glsl
@@ -1,19 +1,6 @@
-#if DEPTH_FORMAT != 3100
-
-	uniform float mNear;
-	uniform float mFar;
-
-#endif
-
 #if DEPTH_PACKING == 3200
 
 	uniform float opacity;
-
-#endif
-
-#if DEPTH_FORMAT != 3100
-
-	varying float vViewZDepth;
 
 #endif
 
@@ -27,29 +14,13 @@ void main() {
 	#include <clipping_planes_fragment>
 	#include <logdepthbuf_fragment>
 
-	float transformedDepth = 0.0;
-
-	#if DEPTH_FORMAT == 3100 // AutoDepthFormat
-
-		transformedDepth = gl_FragCoord.z;
-
-	#elif DEPTH_FORMAT == 3101
-
-		transformedDepth = viewZToLinearClipZ( vViewZDepth, mNear, mFar );
-
-	#elif DEPTH_FORMAT == 3102
-
-		transformedDepth = viewZToInvClipZ( vViewZDepth, mNear, mFar );
-
-	#endif
-
 	#if DEPTH_PACKING == 3200
 
-		gl_FragColor = vec4( vec3( transformedDepth ), opacity );
+		gl_FragColor = vec4( vec3( gl_FragCoord.z ), opacity );
 
 	#elif DEPTH_PACKING == 3201
 
-		gl_FragColor = packLinearUnitToRGBA( transformedDepth );
+		gl_FragColor = packLinearUnitToRGBA( gl_FragCoord.z );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderLib/depth_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_vert.glsl
@@ -6,12 +6,6 @@
 #include <logdepthbuf_pars_vertex>
 #include <clipping_planes_pars_vertex>
 
-#if DEPTH_FORMAT != 3100
-
-	varying float vViewZDepth;
-
-#endif
-
 void main() {
 
 	#include <uv_vertex>
@@ -25,11 +19,5 @@ void main() {
 	#include <project_vertex>
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>
-
-	#if DEPTH_FORMAT != 3100
-
-		vViewZDepth = mvPosition.z;
-
-	#endif
 
 }

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -443,8 +443,6 @@ THREE.WebGLProgram = ( function () {
 				parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
 				parameters.logarithmicDepthBuffer && renderer.extensions.get( 'EXT_frag_depth' ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-				parameters.depthFormat ? "#define DEPTH_FORMAT " + material.depthFormat : '',
-
 				'uniform mat4 modelMatrix;',
 				'uniform mat4 modelViewMatrix;',
 				'uniform mat4 projectionMatrix;',
@@ -565,7 +563,6 @@ THREE.WebGLProgram = ( function () {
 				parameters.outputEncoding ? getTexelEncodingFunction( "linearToOutputTexel", parameters.outputEncoding ) : '',
 
 				parameters.depthPacking ? "#define DEPTH_PACKING " + material.depthPacking : '',
-				parameters.depthFormat ? "#define DEPTH_FORMAT " + material.depthFormat : '',
 
 				'\n'
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -25,7 +25,7 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 		"maxMorphTargets", "maxMorphNormals", "premultipliedAlpha",
 		"numDirLights", "numPointLights", "numSpotLights", "numHemiLights",
 		"shadowMapEnabled", "shadowMapType", "toneMapping", 'physicallyCorrectLights',
-		"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "depthPacking", "depthFormat"
+		"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "depthPacking"
 	];
 
 
@@ -184,8 +184,7 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 			doubleSided: material.side === THREE.DoubleSide,
 			flipSided: material.side === THREE.BackSide,
 
-			depthPacking: ( material.depthPacking !== undefined ) ? material.depthPacking : false,
-			depthFormat: ( material.depthFormat !== undefined ) ? material.depthFormat : false
+			depthPacking: ( material.depthPacking !== undefined ) ? material.depthPacking : false
 
 		};
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -47,7 +47,6 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 	// init
 
 	var depthMaterialTemplate = new THREE.MeshDepthMaterial();
-	depthMaterialTemplate.depthFormat = THREE.AutoDepthFormat;
 	depthMaterialTemplate.depthPacking = THREE.RGBADepthPacking;
 	depthMaterialTemplate.clipping = true;
 


### PR DESCRIPTION
This PR implements the conclusions derived from a discussion between @WestLangley  @mrdoob and myself here: https://github.com/mrdoob/three.js/pull/8586

We decided to remove the ability to set the depth formula in MeshDepthMAterial and thus are always relying upon gl_FragCoord.z.

This ends up removing a lot of code and is probably the right thing to do anyhow as the flexilibity offered before was unnecessary and all the code in ThreeJS has already been updated to be able to decode gl_FragCoord.z as necessary in the previous PR.

I've also renamed the depth formulas based on @WestLangley's feedback.
