### PR TITLE
Examples: Fix Firefox Error in "webgl_interactive_cubes_gpu"

### DIFF
--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -205,7 +205,12 @@
 				var pixelBuffer = new Uint8Array( 4 );
 
 				//read the pixel under the mouse from the texture
-				renderer.readRenderTargetPixels(pickingTexture, mouse.x, pickingTexture.height - mouse.y, 1, 1, pixelBuffer);
+				//mouse coordinates must be greater than zero to prevent WebGL errors with gl.readPixels
+				if( mouse.x > 0 && mouse.y > 0 ) {
+
+					renderer.readRenderTargetPixels(pickingTexture, mouse.x, pickingTexture.height - mouse.y, 1, 1, pixelBuffer);
+
+				}
 
 				//interpret the pixel as an ID
 

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -205,12 +205,7 @@
 				var pixelBuffer = new Uint8Array( 4 );
 
 				//read the pixel under the mouse from the texture
-				//mouse coordinates must be greater than zero to prevent WebGL errors with gl.readPixels
-				if( mouse.x > 0 && mouse.y > 0 ) {
-
-					renderer.readRenderTargetPixels(pickingTexture, mouse.x, pickingTexture.height - mouse.y, 1, 1, pixelBuffer);
-
-				}
+				renderer.readRenderTargetPixels(pickingTexture, mouse.x, pickingTexture.height - mouse.y, 1, 1, pixelBuffer);
 
 				//interpret the pixel as an ID
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3762,7 +3762,13 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				if ( _gl.checkFramebufferStatus( _gl.FRAMEBUFFER ) === _gl.FRAMEBUFFER_COMPLETE ) {
 
-					_gl.readPixels( x, y, width, height, paramThreeToGL( texture.format ), paramThreeToGL( texture.type ), buffer );
+					// the following if statement ensures valid read requests (no out-of-bounds pixels, see #8604)
+
+					if ( ( x > 0 && x <= ( renderTarget.width - width ) ) && ( y > 0 && y <= ( renderTarget.height - height ) ) ) {
+
+						_gl.readPixels( x, y, width, height, paramThreeToGL( texture.format ), paramThreeToGL( texture.type ), buffer );
+
+					}
 
 				} else {
 


### PR DESCRIPTION
This PR fixes an error in `webgl_interactive_cubes_gpu` logged by Firefox 45.0.1.

> Error: WebGL: readPixels: Out-of-bounds reads with readPixels are deprecated, and may be slow.

The problem is that the example can generate read requests with `readRenderTargetPixels` that contain out-of-bounds pixels (see [FF source code](https://dxr.mozilla.org/mozilla-central/source/dom/canvas/WebGLContextGL.cpp#1645) for more information). To avoid this problem, an additional `if` statement prevents read request with mouse coordinates less or equal zero.

A more strict implementation could be done in `readRenderTargetPixels`. The method could only allow read request with `x` and `y` values within the range of [1, `renderTarget.width`] and [1, `renderTarget.height`]. 
