### PR TITLE
allow THREE.Box3 as an input of Boxhelper

### DIFF
--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -30,7 +30,15 @@ THREE.BoxHelper.prototype.update = ( function () {
 
 	return function ( object ) {
 
-		box.setFromObject( object );
+		if ( object instanceof THREE.Box3 ) {
+
+			box.copy( object );
+
+		} else {
+
+			box.setFromObject( object );
+
+		}
 
 		if ( box.isEmpty() ) return;
 


### PR DESCRIPTION
This helps when when the bounding box is not computed from an object, but comes from elsewhere
