### PR TITLE
Technique 'ambient' node case added

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3792,7 +3792,21 @@ THREE.ColladaLoader = function () {
 		switch ( this.type ) {
 
 			case 'constant':
-
+			
+		                if ( props.emissionMap !== undefined ) {
+		                	
+					props.aoMap = props.emissionMap;
+					delete props.emissionMap;
+		                    
+		                }
+		                
+		                if ( props.lightMap !== undefined ) {
+		                	
+					props.aoMap = props.lightMap;
+					delete props.lightMap;
+		                    
+		                }
+				
 				if (props.emissive != undefined) props.color = props.emissive;
 				this.material = new THREE.MeshBasicMaterial( props );
 				break;

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3584,6 +3584,7 @@ THREE.ColladaLoader = function () {
 
 			switch ( child.nodeName ) {
 
+				case 'ambient':
 				case 'emission':
 				case 'diffuse':
 				case 'specular':


### PR DESCRIPTION
The ambient node case is missing from technique/shader parsing
