### PR TITLE
Adds indexing to 3DObject (recovered PR)

### DIFF
--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -288,7 +288,7 @@
 		The returnIndex flag defaults to false but when true it will return the index of the entity not the Object3D.
 		</div>
 		<div>
-		Returns the index of the object found or index (depending of returnIndex flag), and nothing if it is not found.<br />
+		Returns the index of the object found or the object (depending on the returnIndex flag), and nothing if it is not found.<br />
 		</div>
 
 		<h3>[method:null traverse]( [page:Function callback] )</h3>

--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -50,6 +50,13 @@
 		Array with object's children.
 		</div>
 
+		<h3>[property:Object3D searchOrder]</h3>
+		<div>
+		An Array with labels for extending searching of property names on the Objects. { see <a target=_parent href="#Reference/Core/Object3D.findChild">findChild</a> }<br />
+		Before resorting to this properties search list. It first searches for direct matches with Object3D and then for an array index. This final search list defaults to ['name', 'uuid'].<br />
+		<i>Warning: Don't use 'id' in this list as the indexing does not correlate and conflicts.</i><br />
+		</div>
+
 		<h3>[property:Vector3 position]</h3>
 		<div>
 		Object's local position.
@@ -215,12 +222,73 @@
 		Adds *object* as child of this object. An arbitrary number of objects may be added.
 		</div>
 
-		<h3>[method:null remove]( [page:Object3D object], ... )</h3>
+		<h3>[method:null addAt]( [page:Object entity], [page:Object3D object],  [page:Boolean move],  [page:Boolean shift] )</h3>
+		<div>
+		entity - Entity for matching. { see findChild } <br />
+		</div>
 		<div>
 		object - An object.<br />
 		</div>
 		<div>
-		Removes *object* as child of this object. An arbitrary number of objects may be removed.
+		move - A Boolean to allow moving an object if it is already found (default is true).
+		</div>
+		<div>
+		shift - A Boolean that helps when moving to shift the target index (default is true).
+		</div>
+		<div>
+		Adds *object* as child of this object at the given entity location if found. When object exists already, it moves it's indices and triggers a 'moved' Event.
+		</div>
+		<div>
+		Dependant on 'move', the 'shift' option compensates for moving the existing object if it needs to be moved from below the target location's index.<br />
+		</div>
+
+		<h3>[method:null remove]( [page:Object3D entity], ... )</h3>
+		<div>
+		entity - Entity for matching. {see findChild}
+		</div>
+		<div>
+		Removes *entity* as child of this object. the search entity can be either an index of an Object3D. An arbitrary number of entities may be removed.
+		</div>
+		<div>
+		Returns this object and not the removed items.
+		</div>
+
+		<h3>[method:null removeAll]( )</h3>
+		<div>
+		Removes All the objects from children systematically removing them, one by one.
+		</div>
+		<div>
+		Returns this object and not the removed items.
+		</div>
+
+		<h3>[method:null replace]( [page:Object3D entity], [page:Object3D newChild] )</h3>
+		<div>
+		entity - Entity for matching. {see findChild}
+		</div>
+		<div>
+		newChild - An object.
+		</div>
+		<div>
+		Replaces the entity with the new Child, but only if the old one is found. The search entity can be an index or Object.
+		</div>
+		<div>
+		Returns the old Object that has now been replaced, but nothing if not found.
+		</div>
+
+		<h3>[method:null findChild]( [page:Object3D entity], [page:Boolean returnIndex] )</h3>
+		<div>
+		entity - Entity for matching.
+		</div>
+		<div>
+		returnIndex - A Boolean.
+		</div>
+		<div>
+		"Entity" is used to find a matching child. First findChild searches for an Object3D match. Then an index key is checked, and finally the <a target=_parent href="#Reference/Core/Object3D.searchOrder">list</a> of properties is checked.<br />
+		The properties that are checked is controlled by <a target=_parent href="#Reference/Core/Object3D.searchOrder">searchOrder</a> a modifiable array that defaults to check the 'name' and 'uuid' in that adjustable order.
+		The returnIndex flag defaults to false but when true it will return the index of the entity not the Object3D.
+		</div>
+		<div>
+		Returns the index of the object found or index (depending of returnIndex flag), and nothing if it is not found.<br />
 		</div>
 
 		<h3>[method:null traverse]( [page:Function callback] )</h3>
@@ -230,7 +298,7 @@
 		<div>
 		Executes the callback on this object and all descendants.
 		</div>
-		
+
 		<h3>[method:null traverseVisible]( [page:Function callback] )</h3>
 		<div>
 		callback - A function with as first argument an object3D object.<br />
@@ -239,7 +307,7 @@
 		Like traverse, but the callback will only be executed for visible objects.
 		Descendants of invisible objects are not traversed.
 		</div>
-		
+
 		<h3>[method:null traverseAncestors]( [page:Function callback] )</h3>
 		<div>
 		callback - A function with as first argument an object3D object.<br />

--- a/test/unit/core/Object3D-Indecies.html
+++ b/test/unit/core/Object3D-Indecies.html
@@ -1,0 +1,500 @@
+/**
+ * @author MasterJames / https://github.com/MasterJames
+ */
+
+module( "Object3D-Indices" );
+let prevOrder = QUnit.config.reorder;
+QUnit.config.reorder = false;
+
+let pMat = new THREE.MeshPhongMaterial( { color: 0x666666, specular: 0x884488, shininess: 10, shading: THREE.FlatShading } );
+let aMat = new THREE.MeshPhongMaterial( { color: 0xdd0066, specular: 0x009966, shininess: 30, shading: THREE.FlatShading } );
+let bMat = new THREE.MeshPhongMaterial( { color: 0x0066dd, specular: 0x996600, shininess: 30, shading: THREE.FlatShading } );
+let cMat = new THREE.MeshPhongMaterial( { color: 0x66dd00, specular: 0x660099, shininess: 30, shading: THREE.FlatShading } );
+
+let testWorld = {
+	scn: new THREE.Scene(),
+	pBox: new THREE.Mesh(new THREE.BoxGeometry(1, 2, 3), pMat),
+	cBox0: new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), aMat),
+	cBox1: new THREE.Mesh(new THREE.BoxGeometry(2, 1, 1), aMat),
+	cBox2: new THREE.Mesh(new THREE.BoxGeometry(1, 2, 1), bMat),
+	cBox3: new THREE.Mesh(new THREE.BoxGeometry(2, 2, 1), cMat),
+	cBox4: new THREE.Mesh(new THREE.BoxGeometry(2, 1, 2), aMat),
+	cBox5: new THREE.Mesh(new THREE.BoxGeometry(1, 2, 2), bMat),
+	cBox6: new THREE.Mesh(new THREE.BoxGeometry(2, 2, 2), cMat),
+	cBox7: new THREE.Mesh(new THREE.BoxGeometry(0.25, 0.45, 0.35), aMat),
+	cBox8: new THREE.Mesh(new THREE.BoxGeometry(0.45, 0.25, 0.35), bMat),
+	cBox9: new THREE.Mesh(new THREE.BoxGeometry(0.45, 0.35, 0.25), cMat)
+};
+
+testWorld.pBox.name = "pBox";
+testWorld.cBox0.name = "cBox0";
+testWorld.cBox1.name = "cBox1";
+testWorld.cBox2.name = "cBox2";
+testWorld.cBox3.name = "cBox3";
+testWorld.cBox4.name = "cBox4";
+testWorld.cBox5.name = "cBox5";
+testWorld.cBox6.name = "cBox6";
+testWorld.cBox7.name = "cBox7";
+testWorld.cBox8.name = "cBox8";
+testWorld.cBox9.name = "cBox9";
+
+test( "add", function() {
+	let pBox = testWorld.pBox;
+	testWorld.scn.add(pBox);
+	pBox.add(testWorld.cBox0);
+	pBox.add(testWorld.cBox1);
+	pBox.add(testWorld.cBox2);
+	pBox.add(testWorld.cBox3);
+	pBox.add(testWorld.cBox4);
+
+	ok( pBox.findChild(0) === testWorld.cBox0, "cBox0 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox1, "cBox1 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox2, "cBox2 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox3, "cBox3 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+
+	ok( pBox.findChild(1) !== testWorld.cBox0, "cBox0 NOT at index 1" );
+	ok( pBox.findChild(2) !== testWorld.cBox0, "cBox0 NOT at index 2" );
+	ok( pBox.findChild(3) !== testWorld.cBox0, "cBox0 NOT at index 3" );
+	ok( pBox.findChild(4) !== testWorld.cBox0, "cBox0 NOT at index 4" );
+
+	ok( pBox.findChild(0) !== testWorld.cBox1, "cBox1 NOT at index 0" );
+	ok( pBox.findChild(2) !== testWorld.cBox1, "cBox1 NOT at index 2" );
+	ok( pBox.findChild(3) !== testWorld.cBox1, "cBox1 NOT at index 3" );
+	ok( pBox.findChild(4) !== testWorld.cBox1, "cBox1 NOT at index 4" );
+
+	ok( pBox.findChild(0) !== testWorld.cBox2, "cBox2 NOT at index 0" );
+	ok( pBox.findChild(1) !== testWorld.cBox2, "cBox2 NOT at index 1" );
+	ok( pBox.findChild(3) !== testWorld.cBox2, "cBox2 NOT at index 3" );
+	ok( pBox.findChild(4) !== testWorld.cBox2, "cBox2 NOT at index 4" );
+
+	ok( pBox.findChild(0) !== testWorld.cBox3, "cBox3 NOT at index 0" );
+	ok( pBox.findChild(1) !== testWorld.cBox3, "cBox3 NOT at index 1" );
+	ok( pBox.findChild(2) !== testWorld.cBox3, "cBox3 NOT at index 2" );
+	ok( pBox.findChild(4) !== testWorld.cBox3, "cBox3 NOT at index 4" );
+
+	ok( pBox.findChild(0) !== testWorld.cBox4, "cBox4 NOT at index 0" );
+	ok( pBox.findChild(1) !== testWorld.cBox4, "cBox4 NOT at index 1" );
+	ok( pBox.findChild(2) !== testWorld.cBox4, "cBox4 NOT at index 2" );
+	ok( pBox.findChild(3) !== testWorld.cBox4, "cBox4 NOT at index 3" );
+
+});
+
+test( "addAt with Index", function() {
+	let pBox = testWorld.pBox;
+	pBox.addAt(2, testWorld.cBox5);
+	pBox.addAt(4, testWorld.cBox6);
+
+	ok( pBox.findChild(0) === testWorld.cBox0, "cBox0 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox1, "cBox1 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox2, "cBox2 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox6, "cBox6 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox3, "cBox3 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox4, "cBox4 at index 6" );
+
+});
+
+test( "addAt with Object", function() {
+	let pBox = testWorld.pBox;
+	pBox.addAt(testWorld.cBox2, testWorld.cBox7);
+
+	ok( pBox.findChild(0) === testWorld.cBox0, "cBox0 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox1, "cBox1 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox7, "cBox7 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox2, "cBox2 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox6, "cBox6 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox3, "cBox3 at index 6" );
+	ok( pBox.findChild(7) === testWorld.cBox4, "cBox4 at index 7" );
+
+});
+
+test( "remove single Object", function() {
+	let pBox = testWorld.pBox;
+	pBox.remove(testWorld.cBox3);
+
+	ok( pBox.findChild(0) === testWorld.cBox0, "cBox0 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox1, "cBox1 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox7, "cBox7 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox2, "cBox2 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox6, "cBox6 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox4, "cBox4 at index 6" );
+
+});
+
+test( "remove multiple Objects exist", function() {
+	let pBox = testWorld.pBox;
+	pBox.remove(testWorld.cBox7, testWorld.cBox4, testWorld.cBox0);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox5, "cBox5 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox2, "cBox2 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox6, "cBox6 at index 3" );
+
+});
+
+test( "remove single Index exist", function() {
+	let pBox = testWorld.pBox;
+	pBox.remove(1);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox6, "cBox6 at index 2" );
+
+});
+
+test( "add 2 existing 1 does not", function() {
+	let pBox = testWorld.pBox;
+	pBox.add(testWorld.cBox1, testWorld.cBox2, testWorld.cBox7);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox6, "cBox6 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox7, "cBox7 at index 3" );
+
+});
+
+test( "addAt object exists, new doesn't (move = default:true, shift = default:true)", function() {
+	let pBox = testWorld.pBox;
+	pBox.addAt(testWorld.cBox7, testWorld.cBox3);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox6, "cBox6 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox3, "cBox3 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox7, "cBox7 at index 4" );
+
+});
+
+test( "addAt index exists, new doesn't (move = default:true, shift = default:true)", function() {
+	let pBox = testWorld.pBox;
+	pBox.addAt(2, testWorld.cBox4);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox4, "cBox4 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox6, "cBox6 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox3, "cBox3 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox7, "cBox7 at index 5" );
+
+});
+
+test( "addAt index exists, new exists (move = default:true, shift = default:true)", function() {
+	let pBox = testWorld.pBox;
+	pBox.addAt(4, testWorld.cBox4);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox6, "cBox6 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox4, "cBox4 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox3, "cBox3 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox7, "cBox7 at index 5" );
+
+});
+
+test( "addAt index exists, new doesn't (move = false)", function() {
+	let pBox = testWorld.pBox;
+	pBox.addAt(2, testWorld.cBox5, false);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox6, "cBox6 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox3, "cBox3 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox7, "cBox7 at index 6" );
+
+});
+
+test( "addAt object exists, exists (move = false)", function() {
+	let pBox = testWorld.pBox;
+	pBox.addAt(testWorld.cBox5, testWorld.cBox1, false);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox6, "cBox6 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox3, "cBox3 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox7, "cBox7 at index 6" );
+
+});
+
+test( "addAt object not found, exists (move = false)", function() {
+	let pBox = testWorld.pBox;
+	pBox.addAt(testWorld.cBox8, testWorld.cBox1, false);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox6, "cBox6 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox3, "cBox3 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox7, "cBox7 at index 6" );
+
+});
+
+test( "addAt index not found, exists (move = default:true) ", function() {
+	let pBox = testWorld.pBox;
+	pBox.addAt(683, testWorld.cBox8);
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox6, "cBox6 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox3, "cBox3 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox7, "cBox7 at index 6" );
+	ok( pBox.findChild(7) === testWorld.cBox8, "cBox8 at index 7" );
+
+});
+
+test( "replace at index with new object ", function() {
+	let pBox = testWorld.pBox;
+	let out = pBox.replace(3, testWorld.cBox9);
+
+	ok( out === testWorld.cBox6, "cBox6 returned" );
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox9, "cBox9 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox3, "cBox3 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox7, "cBox7 at index 6" );
+	ok( pBox.findChild(7) === testWorld.cBox8, "cBox8 at index 7" );
+
+});
+
+test( "replace index existing with existing [same spot] ", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.replace(3, testWorld.cBox9);
+	ok( out === undefined, "nothing returned [same spot]" );
+
+	out = pBox.replace(2, testWorld.cBox3);
+	ok( out === undefined, "nothing returned [same spot]" );
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox9, "cBox9 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox3, "cBox3 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox7, "cBox7 at index 6" );
+	ok( pBox.findChild(7) === testWorld.cBox8, "cBox8 at index 7" );
+
+});
+
+test( "replace index existing with new ", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.replace(4, testWorld.cBox6);
+	ok( out === testWorld.cBox4, "returned cBox4" );
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox9, "cBox9 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox6, "cBox6 at index 6" );
+	ok( pBox.findChild(5) === testWorld.cBox3, "cBox3 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox7, "cBox7 at index 6" );
+	ok( pBox.findChild(7) === testWorld.cBox8, "cBox8 at index 7" );
+
+});
+
+test( "replace object existing with new ", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.replace(testWorld.cBox9, testWorld.cBox4);
+	ok( out === testWorld.cBox9, "returned cBox9" );
+
+	ok( pBox.findChild(0) === testWorld.cBox1, "cBox1 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox2, "cBox2 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox5, "cBox5 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox4, "cBox4 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox6, "cBox6 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox3, "cBox3 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox7, "cBox7 at index 6" );
+	ok( pBox.findChild(7) === testWorld.cBox8, "cBox8 at index 7" );
+
+});
+
+test( "sorting with addAt ", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.addAt(testWorld.cBox5, testWorld.cBox3, true);
+	ok( out === testWorld.cBox3, "returned cBox3" );
+
+	out = pBox.addAt(0, testWorld.cBox0, false);
+	ok( out === testWorld.cBox0, "returned cBox0" );
+
+	out = pBox.addAt(testWorld.cBox4, testWorld.cBox5);
+	ok( out === testWorld.cBox5, "returned cBox5", true);
+
+	out = pBox.add(testWorld.cBox9);
+	ok( out === pBox, "returned this");
+
+	ok( pBox.findChild(0) === testWorld.cBox0, "cBox0 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox1, "cBox1 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox2, "cBox2 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox3, "cBox3 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox5, "cBox5 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox6, "cBox6 at index 6" );
+	ok( pBox.findChild(7) === testWorld.cBox7, "cBox7 at index 7" );
+	ok( pBox.findChild(8) === testWorld.cBox8, "cBox8 at index 8" );
+	ok( pBox.findChild(9) === testWorld.cBox9, "cBox8 at index 9" );
+
+});
+
+test( "remove All", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.remove(testWorld.cBox0, testWorld.cBox1, testWorld.cBox2,
+		testWorld.cBox3, testWorld.cBox4, testWorld.cBox5, testWorld.cBox6,
+		testWorld.cBox7, testWorld.cBox8, testWorld.cBox9);
+	ok( out === pBox, "returned this" );
+	ok( pBox.children.length === 0, "children empty" );
+
+});
+
+test( "remove many by objects", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.add(testWorld.cBox0, testWorld.cBox1, testWorld.cBox2,
+		testWorld.cBox3, testWorld.cBox4);
+	ok( out === pBox, "returned this" );
+	ok( pBox.children.length === 5, "5 re-added" );
+	ok( pBox.findChild(3) === testWorld.cBox3, "cBox3 at index 3" );
+
+
+	ok( pBox.findChild(0) === testWorld.cBox0, "cBox0 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox1, "cBox1 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox2, "cBox2 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox3, "cBox3 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+
+});
+
+test( "remove many by index", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.remove(0, 1, 3, 4, 5);
+	ok( out === pBox, "returned pBox" );
+	ok( pBox.children.length === 1, "1 left" );
+	ok( pBox.findChild(0) === testWorld.cBox2, "cBox2 at index 0" );
+
+});
+
+test( "removeAll", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.add(testWorld.cBox9, testWorld.cBox8, testWorld.cBox7,
+		testWorld.cBox6, testWorld.cBox5, testWorld.cBox4,
+		testWorld.cBox3, testWorld.cBox1, testWorld.cBox0); // no 2 it's still there
+
+	ok( pBox.children.length === 10, "full up" );
+
+	out = pBox.addAt(7, testWorld.cBox2, true, false);
+	ok( out === testWorld.cBox2, "returns moved object" );
+	ok( pBox.findChild(7) === testWorld.cBox2, "moved cBox2 to index 2" );
+
+	ok( pBox.findChild(0) === testWorld.cBox9, "cBox9 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox8, "cBox8 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox7, "cBox7 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox6, "cBox6 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox5, "cBox5 at index 4" );
+	ok( pBox.findChild(5) === testWorld.cBox4, "cBox4 at index 5" );
+	ok( pBox.findChild(6) === testWorld.cBox3, "cBox3 at index 6" );
+	ok( pBox.findChild(7) === testWorld.cBox2, "cBox2 at index 7" );
+	ok( pBox.findChild(8) === testWorld.cBox1, "cBox1 at index 8" );
+	ok( pBox.findChild(9) === testWorld.cBox0, "cBox0 at index 9" );
+
+	out = pBox.removeAll();
+	ok( pBox.children.length === 0, "removeAll emptied it" );
+
+
+});
+
+test( "remove single last remaining by object.name", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.remove('cBox5');
+	ok( out === pBox, "returned this" );
+	ok( pBox.children.length === 0, "cBox5 removed by name" );
+
+});
+
+test( "remove single exists by object.uuid", function() {
+	let pBox = testWorld.pBox;
+
+	let uuid = testWorld.cBox5.uuid;
+	let out = pBox.add(testWorld.cBox5);
+	ok( pBox.findChild(0) === testWorld.cBox5, "cBox5 at index 0" );
+	out = pBox.remove(uuid);
+	ok( out === pBox, "returned this" );
+	ok( pBox.children.length === 0, ( "cBox5 removed by uuid:" + uuid ) );
+
+});
+
+test( "findChild Object3D, index, and properties", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.add(testWorld.cBox3);
+	ok( out === pBox, "returned this" );
+
+	out = pBox.addAt(0, testWorld.cBox2);
+	ok( out === testWorld.cBox2, "added cBox2 index 0 and output matches" );
+
+	out = pBox.addAt(testWorld.cBox3, testWorld.cBox4);
+	ok( out === testWorld.cBox4, "added cBox4 at cBox3 and output matches" );
+
+	ok( pBox.findChild(0) === testWorld.cBox2, "cBox2 at index 0" );
+	ok( pBox.findChild(testWorld.cBox2) === testWorld.cBox2, "cBox2 via Object3D" );
+	ok( pBox.findChild('cBox2') === testWorld.cBox2, "cBox2 via name property" );
+	ok( pBox.findChild(out.uuid) === testWorld.cBox4, "cBox4 via uuid property" );
+
+	ok( pBox.children.length === 3, ( "length is correct" ) );
+
+});
+
+test( "addAt index, name property", function() {
+	let pBox = testWorld.pBox;
+
+	let out = pBox.addAt(0, testWorld.cBox1);
+	ok( out === testWorld.cBox1, "added cBox1 index 0 and output matches" );
+	out = pBox.addAt(0, testWorld.cBox0);
+	ok( out === testWorld.cBox0, "added cBox0 index 0 and output matches" );
+
+	out = pBox.addAt('cBox4', testWorld.cBox3);
+	ok( out === testWorld.cBox3, "added cBox3 at cBox4 and output matches" );
+
+	ok( pBox.children.length === 5, ( "length is correct" ) );
+
+	ok( pBox.findChild(0) === testWorld.cBox0, "cBox0 at index 0" );
+	ok( pBox.findChild(1) === testWorld.cBox1, "cBox1 at index 1" );
+	ok( pBox.findChild(2) === testWorld.cBox2, "cBox2 at index 2" );
+	ok( pBox.findChild(3) === testWorld.cBox3, "cBox3 at index 3" );
+	ok( pBox.findChild(4) === testWorld.cBox4, "cBox4 at index 4" );
+
+});
+
+
+test( "Clean Up", function() {
+	testWorld = undefined;
+	pMat = undefined;
+	aMat = undefined;
+	bMat = undefined;
+	cMat = undefined;
+	ok( testWorld === undefined, "testWorld Garbaged" );
+	ok( pMat === undefined, "pMat Garbaged" );
+	ok( aMat === undefined, "aMat Garbaged" );
+	ok( bMat === undefined, "bMat Garbaged" );
+	ok( cMat === undefined, "cMat Garbaged" );
+
+});
+
+QUnit.config.reorder = prevOrder;

--- a/test/unit/unittests_three.html
+++ b/test/unit/unittests_three.html
@@ -36,6 +36,7 @@
   <script src="core/Clock.js"></script>
   <script src="core/EventDispatcher.js"></script>
   <script src="core/Object3D.js"></script>
+  <script src="core/Object3D-Indices.js"></script>
 
   <script src="math/Constants.js"></script>
   <script src="math/Box2.js"></script>


### PR DESCRIPTION
This "patch" was on my original dev-dev fork, which got rebased since, so this "patch" PR should restore this idea for the records.
It was not really needed but demonstrates not only how to include indexing to reference the children of an object, but provides even more power in searching with a findObject routing that checks in order of importance determined by an optionally customized list. This custom control enables an optimization of the list and should boost performance even if different search priorities are used together.

Also note it adds "replace", integrated with a powerful will find best match via a robust findObject function. As well as new Events for that ability. "Move" event too if I'm recalling correctly still.

**_You might like it?_ I thought it was no longer needed, but again worth reposting, lets just close this if your feel it's not necessary, but if another use-case should arise.**

Again the original poster requesting it Elias Hasle later realized it was probably better to use the name system (to replace "hat", etc.)
I also felt this needed more tests for the events and then I was going to check the double loop in the event handler under a heavy load. {which is mentioned in other threads referenced below.} [but I've been distracted by getting the spotlight examples working error free on multiple devices.]
