### PR TITLE
fix SpritePlugin to use with RenderTarget textures (#8532)

### DIFF
--- a/src/renderers/webgl/plugins/SpritePlugin.js
+++ b/src/renderers/webgl/plugins/SpritePlugin.js
@@ -221,7 +221,7 @@ THREE.SpritePlugin = function ( renderer, sprites ) {
 			state.setDepthTest( material.depthTest );
 			state.setDepthWrite( material.depthWrite );
 
-			if ( material.map && material.map.image && material.map.image.width ) {
+			if ( material.map ) {
 
 				renderer.setTexture( material.map, 0 );
 


### PR DESCRIPTION
The commit removes unnecessary check of texture.image 
