### PR TITLE
Modify ColladaLoader to call failCallback() if an error is detected in XMLHttpRequest.

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -79,13 +79,25 @@ THREE.ColladaLoader = function () {
 
 							if ( failCallback ) {
 
-								failCallback();
+								failCallback( { type: 'error', url: url } );
 
 							} else {
 
 								console.error( "ColladaLoader: Empty or non-existing file (" + url + ")" );
 
 							}
+
+						}
+
+					}else{
+
+						if( failCallback ){
+
+							failCallback( { type: 'error', url: url } );
+
+						}else{
+
+							console.error( 'ColladaLoader: Couldn\'t load "' + url + '" (' + request.status + ')' );
 
 						}
 


### PR DESCRIPTION
The load function has a failCallback argument, but it is called only when the error is 'Empty or non-existing file'. I added an 'else' instruction that will be executed only when a request.status !== 200(covering other errors beyond the 'empty file').
