### PR TITLE
WebGLRenderer.renderPass - making post effects one liners

### DIFF
--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -65,12 +65,6 @@ THREE.BloomPass = function ( strength, kernelSize, sigma, resolution ) {
 
 	this.needsSwap = false;
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
-
-	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene.add( this.quad );
-
 };
 
 THREE.BloomPass.prototype = Object.create( THREE.Pass.prototype );
@@ -85,30 +79,25 @@ THREE.BloomPass.prototype = {
 
 		// Render quad with blured scene into texture (convolution pass 1)
 
-		this.quad.material = this.materialConvolution;
-
 		this.convolutionUniforms[ "tDiffuse" ].value = readBuffer;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurX;
 
-		renderer.render( this.scene, this.camera, this.renderTargetX, true );
-
+		renderer.renderPass( this.materialConvolution, this.renderTargetX, 0x000000, 0 );
 
 		// Render quad with blured scene into texture (convolution pass 2)
 
 		this.convolutionUniforms[ "tDiffuse" ].value = this.renderTargetX;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurY;
 
-		renderer.render( this.scene, this.camera, this.renderTargetY, true );
+		renderer.renderPass( this.materialConvolution, this.renderTargetY, 0x000000, 0 );
 
 		// Render original scene with superimposed blur to texture
-
-		this.quad.material = this.materialCopy;
 
 		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetY;
 
 		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
 
-		renderer.render( this.scene, this.camera, readBuffer, this.clear );
+		renderer.renderPass( this.materialCopy, readBuffer, this.clear ? renderer.getClearColor() : null, this.clear ? renderer.getClearAlpha() : null );
 
 	}
 

--- a/examples/js/postprocessing/BokehPass.js
+++ b/examples/js/postprocessing/BokehPass.js
@@ -39,7 +39,7 @@ THREE.BokehPass = function ( scene, camera, params ) {
 		console.error( "THREE.BokehPass relies on THREE.BokehShader" );
 
 	}
-	
+
 	var bokehShader = THREE.BokehShader;
 	var bokehUniforms = THREE.UniformsUtils.clone( bokehShader.uniforms );
 
@@ -59,12 +59,6 @@ THREE.BokehPass = function ( scene, camera, params ) {
 	this.uniforms = bokehUniforms;
 	this.needsSwap = false;
 
-	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene2  = new THREE.Scene();
-
-	this.quad2 = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene2.add( this.quad2 );
-
 };
 
 THREE.BokehPass.prototype = Object.create( THREE.Pass.prototype );
@@ -75,29 +69,19 @@ THREE.BokehPass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
-		this.quad2.material = this.materialBokeh;
-
 		// Render depth into texture
 
 		this.scene.overrideMaterial = this.materialDepth;
 
 		renderer.render( this.scene, this.camera, this.renderTargetDepth, true );
 
+		this.scene.overrideMaterial = null;
+
 		// Render bokeh composite
 
 		this.uniforms[ "tColor" ].value = readBuffer;
 
-		if ( this.renderToScreen ) {
-
-			renderer.render( this.scene2, this.camera2 );
-
-		} else {
-
-			renderer.render( this.scene2, this.camera2, writeBuffer, this.clear );
-
-		}
-
-		this.scene.overrideMaterial = null;
+		renderer.renderPass( this.materialBokeh, this.renderToScreen ? null : writeBuffer, this.clear ? 0x000000 : null, this.clear ? 0 : null );
 
 	}
 

--- a/examples/js/postprocessing/DotScreenPass.js
+++ b/examples/js/postprocessing/DotScreenPass.js
@@ -25,12 +25,6 @@ THREE.DotScreenPass = function ( center, angle, scale ) {
 
 	} );
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
-
-	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene.add( this.quad );
-
 };
 
 THREE.DotScreenPass.prototype = Object.create( THREE.Pass.prototype );
@@ -44,17 +38,7 @@ THREE.DotScreenPass.prototype = {
 		this.uniforms[ "tDiffuse" ].value = readBuffer;
 		this.uniforms[ "tSize" ].value.set( readBuffer.width, readBuffer.height );
 
-		this.quad.material = this.material;
-
-		if ( this.renderToScreen ) {
-
-			renderer.render( this.scene, this.camera );
-
-		} else {
-
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
-
-		}
+		renderer.renderPass( this.material, this.renderToScreen ? null : writeBuffer, this.clear ? 0x000000 : null, this.clear ? 0 : null );
 
 	}
 

--- a/examples/js/postprocessing/FilmPass.js
+++ b/examples/js/postprocessing/FilmPass.js
@@ -26,12 +26,6 @@ THREE.FilmPass = function ( noiseIntensity, scanlinesIntensity, scanlinesCount, 
 	if ( scanlinesIntensity !== undefined ) this.uniforms.sIntensity.value = scanlinesIntensity;
 	if ( scanlinesCount !== undefined ) this.uniforms.sCount.value = scanlinesCount;
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
-
-	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene.add( this.quad );
-
 };
 
 THREE.FilmPass.prototype = Object.create( THREE.Pass.prototype );
@@ -45,17 +39,7 @@ THREE.FilmPass.prototype = {
 		this.uniforms[ "tDiffuse" ].value = readBuffer;
 		this.uniforms[ "time" ].value += delta;
 
-		this.quad.material = this.material;
-
-		if ( this.renderToScreen ) {
-
-			renderer.render( this.scene, this.camera );
-
-		} else {
-
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
-
-		}
+		renderer.renderPass( this.material, this.renderToScreen ? null : writeBuffer, this.clear ? 0x000000 : null, this.clear ? 0 : null );
 
 	}
 

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -13,7 +13,6 @@ THREE.GlitchPass = function ( dt_size ) {
 
 	if ( dt_size == undefined ) dt_size = 64;
 
-
 	this.uniforms[ "tDisp" ].value = this.generateHeightmap( dt_size );
 
 
@@ -22,12 +21,6 @@ THREE.GlitchPass = function ( dt_size ) {
 		vertexShader: shader.vertexShader,
 		fragmentShader: shader.fragmentShader
 	} );
-
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
-
-	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene.add( this.quad );
 
 	this.goWild = false;
 	this.curF = 0;
@@ -74,17 +67,8 @@ THREE.GlitchPass.prototype = {
 		}
 
 		this.curF ++;
-		this.quad.material = this.material;
 
-		if ( this.renderToScreen ) {
-
-			renderer.render( this.scene, this.camera );
-
-		} else {
-
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
-
-		}
+		renderer.renderPass( this.material, this.renderToScreen ? null : writeBuffer, this.clear ? this.renderer.getClearColor() : null, this.clear ? this.renderer.getClearAlpha() : null );
 
 	},
 

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -49,11 +49,6 @@ THREE.ManualMSAARenderPass = function ( scene, camera, params ) {
 
 	} );
 
-	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene2	= new THREE.Scene();
-	this.quad2 = new THREE.Mesh( new THREE.PlaneGeometry( 2, 2 ), this.materialComposite );
-	this.scene2.add( this.quad2 );
-
 };
 
 THREE.ManualMSAARenderPass.prototype = Object.create( THREE.Pass.prototype );
@@ -116,7 +111,8 @@ THREE.ManualMSAARenderPass.prototype = {
 			}
 
 			renderer.render( this.scene, this.camera, this.sampleRenderTarget, true );
-			renderer.render( this.scene2, this.camera2, writeBuffer, ( i === 0 ) );
+
+			renderer.renderPass( this.materialComposite, writeBuffer, ( i === 0 ) ? renderer.getClearColor() : null, ( i === 0 ) ? renderer.getClearAlpha() : null );
 
 		}
 

--- a/examples/js/postprocessing/SMAAPass.js
+++ b/examples/js/postprocessing/SMAAPass.js
@@ -96,12 +96,6 @@ THREE.SMAAPass = function ( width, height ) {
 
 	this.needsSwap = false;
 
-	this.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
-	this.scene  = new THREE.Scene();
-
-	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene.add( this.quad );
-
 };
 
 THREE.SMAAPass.prototype = Object.create( THREE.Pass.prototype );
@@ -116,31 +110,17 @@ THREE.SMAAPass.prototype = {
 
 		this.uniformsEdges[ "tDiffuse" ].value = readBuffer;
 
-		this.quad.material = this.materialEdges;
-
-		renderer.render( this.scene, this.camera, this.edgesRT, this.clear );
+		renderer.renderPass( this.materialEdges, this.edgesRT, this.clear ? renderer.getClearColor() : null, this.clear ? renderer.getClearAlpha() : null );
 
 		// pass 2
 
-		this.quad.material = this.materialWeights;
-
-		renderer.render( this.scene, this.camera, this.weightsRT, this.clear );
+		renderer.renderPass( this.materialWeights, this.weightsRT, this.clear ? renderer.getClearColor() : null, this.clear ? renderer.getClearAlpha() : null );
 
 		// pass 3
 
 		this.uniformsBlend[ "tColor" ].value = readBuffer;
 
-		this.quad.material = this.materialBlend;
-
-		if ( this.renderToScreen ) {
-
-			renderer.render( this.scene, this.camera );
-
-		} else {
-
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
-
-		}
+		renderer.renderPass( this.materialBlend, this.renderToScreen ? null : writeBuffer, this.clear ? renderer.getClearColor() : null, this.clear ? renderer.getClearAlpha() : null );
 
 	},
 

--- a/examples/js/postprocessing/SavePass.js
+++ b/examples/js/postprocessing/SavePass.js
@@ -34,12 +34,6 @@ THREE.SavePass = function ( renderTarget ) {
 
 	this.needsSwap = false;
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
-
-	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene.add( this.quad );
-
 };
 
 THREE.SavePass.prototype = Object.create( THREE.Pass.prototype );
@@ -56,9 +50,7 @@ THREE.SavePass.prototype = {
 
 		}
 
-		this.quad.material = this.material;
-
-		renderer.render( this.scene, this.camera, this.renderTarget, this.clear );
+		renderer.renderPass( this.material, this.renderTarget, this.clear ? renderer.getClearColor() : null, this.clear ? renderer.getClearAlpha() : null );
 
 	}
 

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -46,7 +46,7 @@ THREE.ShaderPass.prototype = {
 
 		}
 
-		renderer.renderPass( this.material, this.renderTarget, this.clear ? renderer.getClearColor() : null, this.clear ? renderer.getClearAlpha() : null );
+		renderer.renderPass( this.material, this.renderToScreen ? null : writeBuffer, this.clear ? renderer.getClearColor() : null, this.clear ? renderer.getClearAlpha() : null );
 
 	}
 

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -30,12 +30,6 @@ THREE.ShaderPass = function( shader, textureID ) {
 
 	}
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene = new THREE.Scene();
-
-	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene.add( this.quad );
-
 };
 
 THREE.ShaderPass.prototype = Object.create( THREE.Pass.prototype );
@@ -52,17 +46,7 @@ THREE.ShaderPass.prototype = {
 
 		}
 
-		this.quad.material = this.material;
-
-		if ( this.renderToScreen ) {
-
-			renderer.render( this.scene, this.camera );
-
-		} else {
-
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
-
-		}
+		renderer.renderPass( this.material, this.renderTarget, this.clear ? renderer.getClearColor() : null, this.clear ? renderer.getClearAlpha() : null );
 
 	}
 

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -90,7 +90,7 @@ THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuf
 
 			renderer.render( this.scene, this.camera, writeBuffer, true );
 
-			renderer.render( this.scene2, this.camera2, this.sampleRenderTarget, ( this.accumulateIndex === 0 ) );
+			renderer.renderPass( this.materialComposite, this.sampleRenderTarget, ( this.accumulateIndex === 0 ) ? renderer.getClearColor() : null, ( this.accumulateIndex === 0 ) ? renderer.getClearAlpha() : null );
 
 			this.accumulateIndex ++;
 			if( this.accumulateIndex >= jitterOffsets.length ) break;
@@ -106,13 +106,13 @@ THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuf
 	if( accumulationWeight > 0 ) {
 		this.compositeUniforms[ "scale" ].value = 1.0;
 		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget;
-		renderer.render( this.scene2, this.camera2, writeBuffer, true );
+		renderer.renderPass( this.materialComposite, writeBuffer, renderer.getClearColor(), renderer.getClearAlpha() );
 	}
 
 	if( accumulationWeight < 1.0 ) {
 		this.compositeUniforms[ "scale" ].value = 1.0 - accumulationWeight;
 		this.compositeUniforms[ "tForeground" ].value = this.holdRenderTarget;
-		renderer.render( this.scene2, this.camera2, writeBuffer, ( accumulationWeight === 0 ) );
+		renderer.renderPass( this.materialComposite, writeBuffer, ( this.accumulateIndex === 0 ) ? renderer.getClearColor() : null, ( this.accumulateIndex === 0 ) ? renderer.getClearAlpha() : null );
 	}
 
 	renderer.autoClear = autoClear;

--- a/examples/js/postprocessing/TexturePass.js
+++ b/examples/js/postprocessing/TexturePass.js
@@ -26,12 +26,6 @@ THREE.TexturePass = function ( texture, opacity ) {
 
 	this.needsSwap = false;
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
-
-	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
-	this.scene.add( this.quad );
-
 };
 
 THREE.TexturePass.prototype = Object.create( THREE.Pass.prototype );
@@ -41,10 +35,8 @@ THREE.TexturePass.prototype = {
 	constructor: THREE.TexturePass,
 
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
-
-		this.quad.material = this.material;
-
-		renderer.render( this.scene, this.camera, readBuffer, this.clear );
+		
+		renderer.renderPass( this.material, readBuffer, this.clear ? renderer.getClearColor() : null, this.clear ? renderer.getClearAlpha() : null );
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1166,9 +1166,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 		}
 
 		// save original state
-		var originalClearColor = this.getClearColor(), originalClearAlpha = this.getClearAlpha();
+		var originalClearColor = this.getClearColor(), originalClearAlpha = this.getClearAlpha(), originalAutoClear = this.autoClear;
 
 		// setup pass state
+		this.autoClear = false;
 		var clearNeeded = ( clearColor !== undefined )&&( clearColor !== null );
 		if( clearNeeded  ) {
 			this.setClearColor( clearColor );
@@ -1179,6 +1180,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		this.render( this.postScene, this.postCamera, renderTarget, clearNeeded  );
 
 		// restore original state
+		this.autoClear = originalAutoClear;
 		this.setClearColor( originalClearColor );
 		this.setClearAlpha( originalClearAlpha );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1172,14 +1172,15 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		// setup pass state
 		this.autoClear = false;
-		if( clearColor !== undefined ) {
+		var isExplicitClearColor = ( clearColor !== undefined )&&( clearColor !== null );
+		if( isExplicitClearColor ) {
 			this.setClearColor( clearColor );
 			this.setClearAlpha( clearAlpha || 0.0 );
 		}
 		this.postQuad.material = passMaterial;
-		
+
 		// render pass
-		this.render( this.postScene, this.postCamera, renderTarget, clearColor !== undefined );
+		this.render( this.postScene, this.postCamera, renderTarget, isExplicitClearColor );
 
 		// restore original state
 		this.autoClear = originalAutoClear;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1158,7 +1158,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	this.renderPass = function ( passMaterial, renderTarget, clearColor, clearAlpha ) {
 
-		if( ! this.passScene ) {
+		if( ! this.postScene ) {
 			this.postCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 			this.postQuad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), null);
 			this.postScene = new THREE.Scene();

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1168,7 +1168,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		// save original state
 		var originalAutoClear = this.autoClear;
 		var originalClearColor = this.getClearColor();
-		var originalClearAlpha = this.getClearColor();
+		var originalClearAlpha = this.getClearAlpha();
 
 		// setup pass state
 		this.autoClear = false;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -71,6 +71,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 	this.toneMappingExposure = 1.0;
 	this.toneMappingWhitePoint = 1.0;
 
+	this.passCamera = null;
+	this.passQuad = null;
+	this.passScene = null;
+
 	// morphs
 
 	this.maxMorphTargets = 8;
@@ -1149,6 +1153,38 @@ THREE.WebGLRenderer = function ( parameters ) {
 			return a.id - b.id;
 
 		}
+
+	}
+
+	this.renderPass = function ( passMaterial, renderTarget, clearColor, clearAlpha ) {
+
+		if( ! this.passScene ) {
+			this.postCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+			this.postQuad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), null);
+			this.postScene = new THREE.Scene();
+			this.postScene.add( this.postQuad );
+		}
+
+		// save original state
+		var originalAutoClear = this.autoClear;
+		var originalClearColor = this.getClearColor();
+		var originalClearAlpha = this.getClearColor();
+
+		// setup pass state
+		this.autoClear = false;
+		if( clearColor !== undefined ) {
+			this.setClearColor( clearColor );
+			this.setClearAlpha( clearAlpha || 0.0 );
+		}
+		this.postQuad.material = passMaterial;
+		
+		// render pass
+		this.render( this.postScene, this.postCamera, renderTarget, clearColor !== undefined );
+
+		// restore original state
+		this.autoClear = originalAutoClear;
+		this.setClearColor( originalClearColor );
+		this.setClearAlpha( originalClearAlpha );
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1166,24 +1166,19 @@ THREE.WebGLRenderer = function ( parameters ) {
 		}
 
 		// save original state
-		var originalAutoClear = this.autoClear;
-		var originalClearColor = this.getClearColor();
-		var originalClearAlpha = this.getClearAlpha();
+		var originalClearColor = this.getClearColor(), originalClearAlpha = this.getClearAlpha();
 
 		// setup pass state
-		this.autoClear = false;
-		var isExplicitClearColor = ( clearColor !== undefined )&&( clearColor !== null );
-		if( isExplicitClearColor ) {
+		var clearNeeded = ( clearColor !== undefined )&&( clearColor !== null );
+		if( clearNeeded  ) {
 			this.setClearColor( clearColor );
 			this.setClearAlpha( clearAlpha || 0.0 );
 		}
-		this.postQuad.material = passMaterial;
 
-		// render pass
-		this.render( this.postScene, this.postCamera, renderTarget, isExplicitClearColor );
+		this.postQuad.material = passMaterial;
+		this.render( this.postScene, this.postCamera, renderTarget, clearNeeded  );
 
 		// restore original state
-		this.autoClear = originalAutoClear;
 		this.setClearColor( originalClearColor );
 		this.setClearAlpha( originalClearAlpha );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1158,11 +1158,11 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	this.renderPass = function ( passMaterial, renderTarget, clearColor, clearAlpha ) {
 
-		if( ! this.postScene ) {
-			this.postCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
-			this.postQuad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), null);
-			this.postScene = new THREE.Scene();
-			this.postScene.add( this.postQuad );
+		if( ! this.passScene ) {
+			this.passCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+			this.passQuad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), null);
+			this.passScene = new THREE.Scene();
+			this.passScene.add( this.passQuad );
 		}
 
 		// save original state
@@ -1176,8 +1176,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 			this.setClearAlpha( clearAlpha || 0.0 );
 		}
 
-		this.postQuad.material = passMaterial;
-		this.render( this.postScene, this.postCamera, renderTarget, clearNeeded  );
+		this.passQuad.material = passMaterial;
+		this.render( this.passScene, this.passCamera, renderTarget, clearNeeded  );
 
 		// restore original state
 		this.autoClear = originalAutoClear;


### PR DESCRIPTION
Prior to this PR it was actually a lot of work to render a post effect.  One needed to create a scene, add a plane to it and an orthographic camera.  One then needed to set a material on that plane and then render it.  It looked like this:

```
// setup
this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );     
this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );      
this.scene  = new THREE.Scene();        
this.scene.add( this.quad );

// usage:
this.quad.material = this.materialConvolution;
renderer.render( this.scene, this.camera, this.renderTarget, true );
```

This PR makes a function for that common workflow.  This means that rendering post effects is now one line:

```
renderer.renderPass( this.materialConvolution, this.renderTarget, 0x000000, 0 );
```

I find this very useful and I think it will encourage people to use render passes because it makes them easy to use.
