### PR TITLE
MeshDepthMaterial: Added alphaTest support

### DIFF
--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -2,9 +2,15 @@
  * @author mrdoob / http://mrdoob.com/
  * @author alteredq / http://alteredqualia.com/
  * @author bhouston / https://clara.io
+ * @author WestLangley / http://github.com/WestLangley
  *
  * parameters = {
+ *
  *  opacity: <float>,
+ *
+ *  map: new THREE.Texture( <Image> ),
+ *
+ *  alphaMap: new THREE.Texture( <Image> ),
  *
  *  displacementMap: new THREE.Texture( <Image> ),
  *  displacementScale: <float>,
@@ -25,6 +31,10 @@ THREE.MeshDepthMaterial = function ( parameters ) {
 
 	this.skinning = false;
 	this.morphTargets = false;
+
+	this.map = null;
+
+	this.alphaMap = null;
 
 	this.displacementMap = null;
 	this.displacementScale = 1;
@@ -48,6 +58,10 @@ THREE.MeshDepthMaterial.prototype.copy = function ( source ) {
 
 	this.skinning = source.skinning;
 	this.morphTargets = source.morphTargets;
+
+	this.map = source.map;
+
+	this.alphaMap = source.alphaMap;
 
 	this.displacementMap = source.displacementMap;
 	this.displacementScale = source.displacementScale;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1890,7 +1890,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 			if ( material instanceof THREE.MeshBasicMaterial ||
 				 material instanceof THREE.MeshLambertMaterial ||
 				 material instanceof THREE.MeshPhongMaterial ||
-				 material instanceof THREE.MeshStandardMaterial ) {
+				 material instanceof THREE.MeshStandardMaterial ||
+				 material instanceof THREE.MeshDepthMaterial ) {
 
 				refreshUniformsCommon( m_uniforms, material );
 
@@ -1928,8 +1929,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 				refreshUniformsStandard( m_uniforms, material );
 
 			} else if ( material instanceof THREE.MeshDepthMaterial ) {
-
-				m_uniforms.opacity.value = material.opacity;
 
 				if ( material.displacementMap ) {
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -171,11 +171,8 @@ THREE.ShaderLib = {
 
 		uniforms: THREE.UniformsUtils.merge( [
 
-			THREE.UniformsLib[ 'displacementmap' ],
-
-			{
-				"opacity" : { type: "1f", value: 1.0 }
-			}
+			THREE.UniformsLib[ 'common' ],
+			THREE.UniformsLib[ 'displacementmap' ]
 
 		] ),
 

--- a/src/renderers/shaders/ShaderLib/depth_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_frag.glsl
@@ -6,12 +6,28 @@
 
 #include <common>
 #include <packing>
+#include <uv_pars_fragment>
+#include <map_pars_fragment>
+#include <alphamap_pars_fragment>
 #include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
 
 	#include <clipping_planes_fragment>
+
+	vec4 diffuseColor = vec4( 1.0 );
+
+	#if DEPTH_PACKING == 3200
+
+		diffuseColor.a = opacity;
+
+	#endif
+
+	#include <map_fragment>
+	#include <alphamap_fragment>
+	#include <alphatest_fragment>
+
 	#include <logdepthbuf_fragment>
 
 	#if DEPTH_PACKING == 3200


### PR DESCRIPTION
So, for example, in http://threejs.org/examples/webgl_animation_cloth.html, you can specify a custom depth material like so:

``` javascript
object.customDepthMaterial = new THREE.MeshDepthMaterial( {
    depthPacking: THREE.RGBADepthPacking,
    map: texture,
    alphaTest: 0.5,
    side: THREE.DoubleSide
} );
```

And shadows work perfectly. In addition, texture `offset` and `repeat` are automatically honored.

You can alternately specify an `alphaMap`.
