### PR TITLE
Update a typo in UCSCharacter.js.

### DIFF
--- a/examples/js/UCSCharacter.js
+++ b/examples/js/UCSCharacter.js
@@ -96,7 +96,7 @@ THREE.UCSCharacter = function() {
 
 		for ( var i = 0; i < textureUrls.length; i ++ ) {
 
-			textures[ i ] = textureLoader.load( baseUrl + textureUrls[ i ], scope.checkLoadingComplete );
+			textures[ i ] = textureLoader.load( baseUrl + textureUrls[ i ], scope.checkLoadComplete );
 			textures[ i ].mapping = THREE.UVMapping;
 			textures[ i ].name = textureUrls[ i ];
 


### PR DESCRIPTION
This typo will prevent the LoadComplete event to be triggered. And the example webgl_morphtargets_human failed to load it's control GUI.
