### PR TITLE
Added support for line width in shadows

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -369,6 +369,7 @@ THREE.WebGLShadowMap = function ( _renderer, _lights, _objects ) {
 		result.clipShadows = material.clipShadows;
 		result.clippingPlanes = material.clippingPlanes;
 		result.wireframeLinewidth = material.wireframeLinewidth;
+		result.linewidth = material.linewidth;
 
 		if ( isPointLight && result.uniforms.lightPos !== undefined ) {
 


### PR DESCRIPTION
This parallels the existing support for wireframe line width in shadows.

There remains the issue that the rendered width of the shadow is dependent on the size of the shadow map -- smaller shadow maps yield fatter line shadows.
