### PR TITLE
Box3.intersect should ensure that empty intersections result in fully empty boxes

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -385,6 +385,9 @@ THREE.Box3.prototype = {
 		this.min.max( box.min );
 		this.max.min( box.max );
 
+		// ensure that if there is no overlap, the result is fully empty, not slightly empty with non-inf/+inf values that will cause subsequence intersects to erroneously return valid values.
+		if( this.isEmpty() ) this.makeEmpty();
+
 		return this;
 
 	},


### PR DESCRIPTION
The issue is that Box3.intersect leaves the resulting state as not +Inf/-Inf if there was almost an intersection.  This causes problems if one is to use that non-intersection result, which is a partially empty box, in further operations.

For example:

Box A: [0,0,2] - [2,2,4]
Box B: [0,0,0] - [2,2,1]

Previously, before this PR, intersection A + B result, empty but only because of Z has a negative delta, not truly empty:
Box C: [0,0,2] - [2,2,1]

If we were to extend Box C with point (0,0,0), we'd create a box that is larger than just the single point, because it has some memory of its previous failed intersection:

Box C + extend with point (0,0,0): [0,0,0] - [2,2,1]

If you do a union with the partially empty box you also get a bad result:
Box C unioned with [-1,-1,-1]-[0,0,0]: [-1,-1,-1]-[2,2,1]

I believe that failed intersections should not leave memory of their failed intersections in the resulting empty box.  This PR achieves that result.
