### PR TITLE
Blender Exporter Normals Fix

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -308,6 +308,7 @@ def faces(mesh, options, material_list=None):
     if vertex_normals:
         logger.debug("Indexing normals")
         for index, normal in enumerate(vertex_normals):
+            normal = (normal[0], normal[2], -normal[1])
             normal_indices[str(normal)] = index
 
     logger.info("Parsing %d faces", len(mesh.tessfaces))
@@ -356,7 +357,7 @@ def faces(mesh, options, material_list=None):
         if vertex_normals:
             for vertex in face.vertices:
                 normal = mesh.vertices[vertex].normal
-                normal = (normal.x, normal.y, normal.z) if face.use_smooth else (face.normal.x, face.normal.y, face.normal.z)
+                normal = (normal.x, normal.z, -normal.y) if face.use_smooth else (face.normal.x, face.normal.z, -face.normal.y)
                 face_data.append(normal_indices[str(normal)])
                 mask[constants.NORMALS] = True
 
@@ -611,6 +612,7 @@ def normals(mesh):
     normal_vectors = []
 
     for vector in _normals(mesh):
+        vector = (vector[0], vector[2], -vector[1])
         normal_vectors.extend(vector)
 
     return normal_vectors


### PR DESCRIPTION
Normals weren't properly transformed with last exporter change so they were flipped on their side 90 degrees. This fixes that so lighting works as expected now.
