### PR TITLE
Fix Scene Loader

### DIFF
--- a/examples/js/loaders/deprecated/SceneLoader.js
+++ b/examples/js/loaders/deprecated/SceneLoader.js
@@ -910,7 +910,7 @@ THREE.SceneLoader.prototype = {
 
 				} else {
 
-					texture = new THREE.CubeTextureLoader().load( urls, generateTextureCallback( count ) );
+					texture = new THREE.CubeTextureLoader().load( url_array, generateTextureCallback( count ) );
 					texture.mapping = textureJSON.mapping;
 
 				}


### PR DESCRIPTION
[This commit](https://github.com/mrdoob/three.js/commit/0f5e69cec8a13d9b9819565f04b5db466548538d#diff-96b1bdbd7110f611907545802eaa5805R913)  changed a `url_array` to `urls` which broke the loader + example page. This corrects it.
