### PR TITLE
Fix Scene Loader

### DIFF
--- a/examples/js/loaders/deprecated/SceneLoader.js
+++ b/examples/js/loaders/deprecated/SceneLoader.js
@@ -891,19 +891,19 @@ THREE.SceneLoader.prototype = {
 			if ( Array.isArray( textureJSON.url ) ) {
 
 				var count = textureJSON.url.length;
-				var url_array = [];
+				var urls = [];
 
 				for ( var i = 0; i < count; i ++ ) {
 
-					url_array[ i ] = get_url( textureJSON.url[ i ], data.urlBaseType );
+					urls[ i ] = get_url( textureJSON.url[ i ], data.urlBaseType );
 
 				}
 
-				var loader = THREE.Loader.Handlers.get( url_array[ 0 ] );
+				var loader = THREE.Loader.Handlers.get( urls[ 0 ] );
 
 				if ( loader !== null ) {
 
-					texture = loader.load( url_array, generateTextureCallback( count ) );
+					texture = loader.load( urls, generateTextureCallback( count ) );
 
 					if ( textureJSON.mapping !== undefined )
 						texture.mapping = textureJSON.mapping;


### PR DESCRIPTION
[This commit](https://github.com/mrdoob/three.js/commit/0f5e69cec8a13d9b9819565f04b5db466548538d#diff-96b1bdbd7110f611907545802eaa5805R913)  changed a `url_array` to `urls` which broke the loader + example page. This patches SceneLoader to use the same naming convention as other files.
