### PR TITLE
Don't treat render targets like textures.

### DIFF
--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -22,7 +22,7 @@
 		<ul>
 			<li>A *ShaderMaterial* will only be rendered properly by [page:WebGLRenderer], since the GLSL code in the *vertexShader* and *fragmentShader* properties must be compiled and run on the GPU using WebGL.</li>
 			<li>As of THREE r72, directly assigning attributes in a *ShaderMaterial* is no longer supported. A [page:BufferGeometry] instance (instead of a [page:Geometry] instance) must be used instead, using [page:BufferAttribute] instances to define custom attributes.</li>
-			<li>As of THREE r76, [page:WebGLRenderTarget] or [page:WebGLRenderTargetCube] instances are no longer supposed to be used as uniforms. Their [page:Texture texture] property must be used instead.</li>
+			<li>As of THREE r77, [page:WebGLRenderTarget] or [page:WebGLRenderTargetCube] instances are no longer supposed to be used as uniforms. Their [page:Texture texture] property must be used instead.</li>
 		</ul>
 		</div>
 

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -22,6 +22,7 @@
 		<ul>
 			<li>A *ShaderMaterial* will only be rendered properly by [page:WebGLRenderer], since the GLSL code in the *vertexShader* and *fragmentShader* properties must be compiled and run on the GPU using WebGL.</li>
 			<li>As of THREE r72, directly assigning attributes in a *ShaderMaterial* is no longer supported. A [page:BufferGeometry] instance (instead of a [page:Geometry] instance) must be used instead, using [page:BufferAttribute] instances to define custom attributes.</li>
+			<li>As of THREE r76, [page:WebGLRenderTarget] or [page:WebGLRenderTargetCube] instances are no longer supposed to be used as uniforms. Their [page:Texture texture] property must be used instead.</li>
 		</ul>
 		</div>
 
@@ -262,16 +263,8 @@
 					<td>[page:Texture THREE.Texture]</td>
 				</tr>
 				<tr>
-					<td>sampler2D</td>
-					<td>[page:WebGLRenderTarget THREE.WebGLRenderTarget]</td>
-				</tr>
-				<tr>
 					<td>samplerCube</td>
 					<td>[page:CubeTexture THREE.CubeTexture]</tr>
-				</tr>
-				<tr>
-					<td>samplerCube</td>
-					<td>[page:WebGLRenderTargetCube THREE.WebGLRenderTargetCube]</td>
 				</tr>
 
 			</tbody>

--- a/docs/api/renderers/WebGLRenderTarget.html
+++ b/docs/api/renderers/WebGLRenderTarget.html
@@ -23,7 +23,7 @@
 		height -- The height of the renderTarget.
 		</div>
 
-		<div>options is an optional object that holds texture parameters for an auto-generated target texture and depthBuffer/stencilBuffer booleans.</div>
+		<div>options is an optional object that holds texture parameters for an auto-generated target texture and depthBuffer/stencilBuffer booleans. For an explanation of the texture parameters see [page:Texture Texture].</div>
 
 		<div>
 		wrapS — [page:Number] default is *THREE.ClampToEdgeWrapping*. <br />
@@ -35,7 +35,7 @@
 		anisotropy — [page:Number], default is *1*. <br />
 		encoding — [page:Number], default is *THREE.LinearEncoding*. <br />
 		depthBuffer — [page:Boolean], default is *true*. Set this to false if you don't need it. <br />
-		stencilBuffer — [page:Boolean], default is *true*. Set this to false if you don't need it. <br />
+		stencilBuffer — [page:Boolean], default is *true*. Set this to false if you don't need it.
 		</div>
 
 		<div>

--- a/docs/api/renderers/WebGLRenderTarget.html
+++ b/docs/api/renderers/WebGLRenderTarget.html
@@ -17,90 +17,101 @@
 
 
 		<h3>[name]([page:Number width], [page:Number height], [page:Object options])</h3>
+
 		<div>
 		width -- The width of the renderTarget. <br />
-		height -- The height of the renderTarget. <br />
-		options -- The options sets the properties of the render target.
+		height -- The height of the renderTarget.
 		</div>
+
+		<div>options is an optional object that holds texture parameters for an auto-generated target texture and depthBuffer/stencilBuffer booleans.</div>
+
 		<div>
-		Creates a new renderTarget with a certain width and height.
+		wrapS — [page:Number] default is *THREE.ClampToEdgeWrapping*. <br />
+		wrapT — [page:Number] default is *THREE.ClampToEdgeWrapping*. <br />
+		magFilter — [page:Number], default is *THREE.LinearFilter*. <br />
+		minFilter — [page:Number], default is *THREE.LinearFilter*. <br />
+		format — [page:Number], default is *THREE.RGBAFormat*. <br />
+		type — [page:Number], default is *THREE.UnsignedByteType*. <br />
+		anisotropy — [page:Number], default is *1*. <br />
+		encoding — [page:Number], default is *THREE.LinearEncoding*. <br />
+		depthBuffer — [page:Boolean], default is *true*. Set this to false if you don't need it. <br />
+		stencilBuffer — [page:Boolean], default is *true*. Set this to false if you don't need it. <br />
+		</div>
+
+		<div>
+		Creates a new render target with a certain width and height.
 		</div>
 
 		<h2>Properties</h2>
 
-		<h3>[property:number wrapS]</h3>
+		<h3>[property:number uuid]</h3>
 		<div>
-		The default is THREE.ClampToEdgeWrapping, where the edge is clamped to the outer edge texels. The other two choices are THREE.RepeatWrapping and THREE.MirroredRepeatWrapping.
+		A unique number for this render target instance.
 		</div>
 
-		<h3>[property:number wrapT]</h3>
+		<h3>[property:number width]</h3>
 		<div>
-		The default is THREE.ClampToEdgeWrapping, where the edge is clamped to the outer edge texels. The other two choices are THREE.RepeatWrapping and THREE.MirroredRepeatWrapping.
-		</div>
-		
-		<h3>[property:number magFilter]</h3>
-		<div>
-		How the texture is sampled when a texel covers more than one pixel. The default is THREE.LinearFilter, which takes the four closest texels and bilinearly interpolates among them. The other option is THREE.NearestFilter, which uses the value of the closest texel.
+		The width of the render target.
 		</div>
 
-		<h3>[property:number minFilter]</h3>
+		<h3>[property:number height]</h3>
 		<div>
-		How the texture is sampled when a texel covers less than one pixel. The default is THREE.LinearMipMapLinearFilter, which uses mipmapping and a trilinear filter. Other choices are THREE.NearestFilter, THREE.NearestMipMapNearestFilter, THREE.NearestMipMapLinearFilter, THREE.LinearFilter, and THREE.LinearMipMapNearestFilter. These vary whether the nearest texel or nearest four texels are retrieved on the nearest mipmap or nearest two mipmaps. Interpolation occurs among the samples retrieved.
+		The height of the render target.
 		</div>
 		
-		<h3>[property:number anisotropy]</h3>
+		<h3>[property:Vector4 scissor]</h3>
 		<div>
-		The number of samples taken along the axis through the pixel that has the highest density of texels. By default, this value is 1. A higher value gives a less blurry result than a basic mipmap, at the cost of more texture samples being used. Use renderer.getMaxAnisotropy() to find the maximum valid anisotropy value for the GPU; this value is usually a power of 2.
-		</div>
-		
-		<h3>[property:Vector2 repeat]</h3>
-		<div>
-		How many times the texture is repeated across the surface, in each direction U and V.
+		A rectangular area inside the render target's viewport. Fragments that are outside the area will be discarded.
 		</div>
 
-		<h3>[property:Vector2 offset]</h3>
+		<h3>[property:boolean scissorTest]</h3>
 		<div>
-		How much a single repetition of the texture is offset from the beginning, in each direction U and V. Typical range is 0.0 to 1.0.
-		</div>
-		
-		<h3>[property:number format]</h3>
-		<div>
-		The default is THREE.RGBAFormat for the texture. Other formats are: THREE.AlphaFormat, THREE.RGBFormat, THREE.LuminanceFormat, and THREE.LuminanceAlphaFormat. There are also compressed texture formats, if the S3TC extension is supported: THREE.RGB_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT3_Format, and THREE.RGBA_S3TC_DXT5_Format.
+		Indicates whether the scissor test is active or not.
 		</div>
 
-		<h3>[property:number type]</h3>
+		<h3>[property:Vector4 viewport]</h3>
 		<div>
-		The default is THREE.UnsignedByteType. Other valid types (as WebGL allows) are THREE.ByteType, THREE.ShortType, THREE.UnsignedShortType, THREE.IntType, THREE.UnsignedIntType, THREE.HalfFloatType, THREE.FloatType, THREE.UnsignedShort4444Type, THREE.UnsignedShort5551Type, and THREE.UnsignedShort565Type.
+		The viewport of this render target.
 		</div>
-		
+
+		<h3>[property:Texture texture]</h3>
+		<div>
+		This texture instance holds the rendered pixels. Use it as input for further processing.
+		</div>
+
 		<h3>[property:boolean depthBuffer]</h3>
 		<div>
 		Renders to the depth buffer. Default is true.
 		</div>
-		
+
 		<h3>[property:boolean stencilBuffer]</h3>
 		<div>
 		Renders to the stencil buffer. Default is true.
 		</div>
 
-		<h3>[property:boolean generateMipmaps]</h3>
+		<h3>[property:DepthTexture depthTexture]</h3>
 		<div>
-		Whether to generate mipmaps (if possible) for a texture. True by default.
+		If set, the scene depth will be rendered to this texture. Default is null.
 		</div>
 
-		
+
 		<h2>Methods</h2>
-		
+
 		<h3>[method:null setSize]( [page:Number width], [page:Number height] )</h3>
 		<div>
-		Sets the size of the renderTarget.
+		Sets the size of the render target.
 		</div>
-		
-		<h3>[method:RenderTarget clone]()</h3>
+
+		<h3>[method:WebGLRenderTarget clone]()</h3>
 		<div>
-		Creates a copy of the render target.
+		Creates a copy of this render target.
 		</div>
-		
+
+		<h3>[method:WebGLRenderTarget copy]( [page:WebGLRenderTarget source] )</h3>
+		<div>
+		Adopts the settings of the given render target.
+		</div>
+
 		<h3>[method:null dispose]()</h3>
 		<div>
 		Dispatches a dispose event.

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3054,7 +3054,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			}
 
-			// in the future, texture will be expected to be a Texture instance
 			setTexture2D( texture, slot );
 
 		};
@@ -3080,7 +3079,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}() );
 
-	//this.setTextureCube = setTextureCube;
 	this.setTextureCube = ( function() {
 
 		var warned = false;
@@ -3107,7 +3105,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				// CompressedTexture can have Array in image :/
 
-				// this function alone should take care of cube textures in the future
+				// this function alone should take care of cube textures
 				setTextureCube( texture, slot );
 
 			} else {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3100,6 +3100,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			}
 
 			// currently relying on the fact that WebGLRenderTargetCube.texture is a Texture and NOT a CubeTexture
+			// TODO: unify these code paths
 			if ( texture instanceof THREE.CubeTexture ||
 				 ( Array.isArray( texture.image ) && texture.image.length === 6 ) ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2049,6 +2049,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( uvScaleMap !== undefined ) {
 
+			// backwards compatibility
 			if ( uvScaleMap instanceof THREE.WebGLRenderTarget ) {
 
 				uvScaleMap = uvScaleMap.texture;
@@ -2063,7 +2064,9 @@ THREE.WebGLRenderer = function ( parameters ) {
 		}
 
 		uniforms.envMap.value = material.envMap;
-		uniforms.flipEnvMap.value = ( material.envMap instanceof THREE.WebGLRenderTargetCube ) ? 1 : - 1;
+
+		// don't flip CubeTexture envMaps, flip everything else (WebGLRenderTargetCube)
+		uniforms.flipEnvMap.value = ( ! ( material.envMap instanceof THREE.CubeTexture ) ) ? 1 : - 1;
 
 		uniforms.reflectivity.value = material.reflectivity;
 		uniforms.refractionRatio.value = material.refractionRatio;
@@ -2290,6 +2293,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		color,
 		intensity,
 		distance,
+		shadowMap,
 
 		viewMatrix = camera.matrixWorldInverse,
 
@@ -2305,6 +2309,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 			color = light.color;
 			intensity = light.intensity;
 			distance = light.distance;
+
+			shadowMap = ( light.shadow && light.shadow.map ) ? light.shadow.map.texture : null;
 
 			if ( light instanceof THREE.AmbientLight ) {
 
@@ -2332,7 +2338,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				_lights.directionalShadowMap[ directionalLength ] = light.shadow.map;
+				_lights.directionalShadowMap[ directionalLength ] = shadowMap;
 				_lights.directionalShadowMatrix[ directionalLength ] = light.shadow.matrix;
 				_lights.directional[ directionalLength ++ ] = uniforms;
 
@@ -2365,7 +2371,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				_lights.spotShadowMap[ spotLength ] = light.shadow.map;
+				_lights.spotShadowMap[ spotLength ] = shadowMap;
 				_lights.spotShadowMatrix[ spotLength ] = light.shadow.matrix;
 				_lights.spot[ spotLength ++ ] = uniforms;
 
@@ -2390,7 +2396,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 				}
 
-				_lights.pointShadowMap[ pointLength ] = light.shadow.map;
+				_lights.pointShadowMap[ pointLength ] = shadowMap;
 
 				if ( _lights.pointShadowMatrix[ pointLength ] === undefined ) {
 
@@ -2806,8 +2812,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	function setTexture2D( texture, slot ) {
 
-		if ( texture instanceof THREE.WebGLRenderTarget ) texture = texture.texture;
-
 		var textureProperties = properties.get( texture );
 
 		if ( texture.version > 0 && textureProperties.__version !== texture.version ) {
@@ -2837,7 +2841,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 		state.activeTexture( _gl.TEXTURE0 + slot );
 		state.bindTexture( _gl.TEXTURE_2D, textureProperties.__webglTexture );
 
-	};
+	}
 
 	function clampToMaxSize ( image, maxSize ) {
 
@@ -2901,7 +2905,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function setCubeTexture ( texture, slot ) {
+	function setTextureCube ( texture, slot ) {
 
 		var textureProperties = properties.get( texture );
 
@@ -2980,7 +2984,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 								} else {
 
-									console.warn( "THREE.WebGLRenderer: Attempt to load unsupported compressed texture format in .setCubeTexture()" );
+									console.warn( "THREE.WebGLRenderer: Attempt to load unsupported compressed texture format in .setTextureCube()" );
 
 								}
 
@@ -3017,47 +3021,96 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	}
 
-	function setCubeTextureDynamic ( texture, slot ) {
+	function setTextureCubeDynamic ( texture, slot ) {
 
 		state.activeTexture( _gl.TEXTURE0 + slot );
 		state.bindTexture( _gl.TEXTURE_CUBE_MAP, properties.get( texture ).__webglTexture );
 
 	}
 
-	var setTextureWarned = false;
-	this.setTexture = function( texture, slot ) {
-
-		if ( ! setTextureWarned ) {
-
-			console.warn( "THREE.WebGLRenderer: .setTexture is deprecated, " +
-				"use setTexture2D instead." );
-			setTextureWarned = true;
-
-		}
-
-		setTexture2D( texture, slot );
-
-	};
-
 	this.allocTextureUnit = allocTextureUnit;
-	this.setTexture2D = setTexture2D;
-	this.setTextureCube = function( texture, slot ) {
 
-		if ( texture instanceof THREE.CubeTexture ||
-			 ( Array.isArray( texture.image ) && texture.image.length === 6 ) ) {
+	this.setTexture2D = ( function() {
 
-			// CompressedTexture can have Array in image :/
+		var warned = false;
 
-			setCubeTexture( texture, slot );
+		return function( texture, slot ) {
 
-		} else {
-			// assumed: texture instanceof THREE.WebGLRenderTargetCube
+			if ( texture instanceof THREE.WebGLRenderTarget ) {
 
-			setCubeTextureDynamic( texture.texture, slot );
+				if ( ! warned ) {
 
-		}
+					console.warn( "THREE.WebGLRenderer.setTexture2D: don't use render targets as textures. Use their .texture property instead." );
+					warned = true;
 
-	};
+				}
+
+				texture = texture.texture;
+
+			}
+
+			setTexture2D( texture, slot );
+
+		};
+
+	}() );
+
+	this.setTexture = ( function() {
+
+		var warned = false;
+
+		return function( texture, slot ) {
+
+			if ( ! warned ) {
+
+				console.warn( "THREE.WebGLRenderer: .setTexture is deprecated, use setTexture2D instead." );
+				warned = true;
+
+			}
+
+			_this.setTexture2D( texture, slot );
+
+		};
+
+	}() );
+
+	this.setTextureCube = ( function() {
+
+		var warned = false;
+
+		return function( texture, slot ) {
+
+			if ( texture instanceof THREE.WebGLRenderTargetCube ) {
+
+				if ( ! warned ) {
+
+					console.warn( "THREE.WebGLRenderer.setTextureCube: don't use cube render targets as textures. Use their .texture property instead." );
+					warned = true;
+
+				}
+
+				texture = texture.texture;
+
+			}
+
+			if ( texture instanceof THREE.CubeTexture ||
+				 ( Array.isArray( texture.image ) && texture.image.length === 6 ) ) {
+
+				// CompressedTexture can have Array in image :/
+
+				setTextureCube( texture, slot );
+
+			} else {
+
+				// assumed: texture property of THREE.WebGLRenderTargetCube
+
+				setTextureCubeDynamic( texture, slot );
+
+			}
+
+		};
+
+	}() );
 
 	// Render targets
 
@@ -3122,7 +3175,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 			renderTarget.depthTexture.needsUpdate = true;
 		}
 
-		_this.setTexture( renderTarget.depthTexture, 0 );
+		_this.setTexture2D( renderTarget.depthTexture, 0 );
 
 		var webglDepthTexture = properties.get( renderTarget.depthTexture ).__webglTexture;
 		_gl.framebufferTexture2D( _gl.FRAMEBUFFER, _gl.DEPTH_ATTACHMENT, _gl.TEXTURE_2D, webglDepthTexture, 0 );

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -81,6 +81,7 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 
 		} else if ( map instanceof THREE.WebGLRenderTarget ) {
 
+			console.warn( "THREE.WebGLPrograms.getTextureEncodingFromMap: don't use render targets as textures. Use their .texture property instead." );
 			encoding = map.texture.encoding;
 
 		}
@@ -118,13 +119,15 @@ THREE.WebGLPrograms = function ( renderer, capabilities ) {
 
 		}
 
+		var currentRenderTarget = renderer.getCurrentRenderTarget();
+
 		var parameters = {
 
 			shaderID: shaderID,
 
 			precision: precision,
 			supportsVertexTextures: capabilities.vertexTextures,
-			outputEncoding: getTextureEncodingFromMap( renderer.getCurrentRenderTarget(), renderer.gammaOutput ),
+			outputEncoding: getTextureEncodingFromMap( ( ! currentRenderTarget ) ? null : currentRenderTarget.texture, renderer.gammaOutput ),
 			map: !! material.map,
 			mapEncoding: getTextureEncodingFromMap( material.map, renderer.gammaInput ),
 			envMap: !! material.envMap,


### PR DESCRIPTION
Hi,

in #8615 I outlined some difficulties that arised during an attempt to move away from treating render targets like textures. @tschw informed me about relevant changes that paved the way for a straight-forward solution to all this.

In #8417 I stated that I'd start with refactoring the examples, but it turned out that this doesn't work anymore because of [this line](https://github.com/mrdoob/three.js/pull/8606/commits/3c354341e14d6ba8e04b6ee2698a6b613453bd70#diff-c0e88b98497597a015ecf238e91ac3a0R3042). If you use the `texture` property of a `CubeCamera`'s `renderTarget` as a map right now, it will break things. So I chose to do it the other way around and started with refactoring the library.

Warnings regarding the use of render targets as textures won't be spammed. I used IIFEs for better encapsulation for the backwards compatibility code and marked the code that might not be easily identified as back-compat code.

In an earlier [diff comment](https://github.com/mrdoob/three.js/pull/8417/files#r57252265) @mrdoob suggested to use `material.envMap instanceof THREE.CubeTexture` instead of a dynamic flag and I replied that the CubeTexture wasn't involved in the respective logic. However, after thinking about alternatives for a while I eventually realised that I was wrong. It's possible to just use the fact that the CubeTexture is not involved directly, because it's involved indirectly. I'm not too familiar with the codebase and that got in my way of thinking.

``` js
uniforms.flipEnvMap.value = ( material.envMap instanceof THREE.WebGLRenderTargetCube ) ? 1 : - 1;
```

can be replicated as

``` js
uniforms.flipEnvMap.value = ( ! ( material.envMap instanceof THREE.CubeTexture ) ) ? 1 : - 1;
```

With this, `WebGLRenderTargetCube` and `Texture` can be left untouched.

I made sure that all the examples work with these changes. I also refactored and checked them again for a seperate PR in case this one gets merged.
