### PR TITLE
Euler: Add missing semicolon

### DIFF
--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -216,7 +216,7 @@ THREE.Euler.prototype = {
 
 		} else {
 
-			console.warn( 'THREE.Euler: .setFromRotationMatrix() given unsupported order: ' + order )
+			console.warn( 'THREE.Euler: .setFromRotationMatrix() given unsupported order: ' + order );
 
 		}
 


### PR DESCRIPTION
An other small improvement. This time in `Euler`.
