### PR TITLE
Math float32array offset prototype

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -390,14 +390,7 @@ THREE.Geometry.prototype = {
 			THREE.Vector3.sub( cb.array, vC.array, vB.array );
 			THREE.Vector3.sub( ab.array, vA.array, vB.array );
 			THREE.Vector3.cross( cb.array, cb.array, ab.array );
-			THREE.Vector3.normalize( cb.array, cb.array );
-			/*cb.subVectors( vC, vB );
-			ab.subVectors( vA, vB );
-			cb.cross( ab );
-
-			cb.normalize();*/
-
-			THREE.Vector3.copy( face.normal.array, cb.array );
+			THREE.Vector3.normalize( face.normal.array, cb.array );
 
 		}
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -387,10 +387,10 @@ THREE.Geometry.prototype = {
 			var vA = this.vertices[ face.a ];
 			var vC = this.vertices[ face.c ];
 
-			THREE.Vector3.sub( cb.array, vC.array, vB.array );
-			THREE.Vector3.sub( ab.array, vA.array, vB.array );
-			THREE.Vector3.cross( cb.array, cb.array, ab.array );
-			THREE.Vector3.normalize( face.normal.array, cb.array );
+			THREE.Vector3.sub( cb.array, cb.offset, vC.array, vC.offset, vB.array, vB.offset );
+			THREE.Vector3.sub( ab.array, ab.offset, vA.array, vA.offset, vB.array, vB.offset );
+			THREE.Vector3.cross( cb.array, cb.offset, cb.array, cb.offset, ab.array, ab.offset );
+			THREE.Vector3.normalize( face.normal.array, face.normal.offset, cb.array, cb.offset );
 
 		}
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -383,17 +383,21 @@ THREE.Geometry.prototype = {
 
 			var face = this.faces[ f ];
 
-			var vA = this.vertices[ face.a ];
 			var vB = this.vertices[ face.b ];
+			var vA = this.vertices[ face.a ];
 			var vC = this.vertices[ face.c ];
 
-			cb.subVectors( vC, vB );
+			THREE.Vector3.sub( cb.array, vC.array, vB.array );
+			THREE.Vector3.sub( ab.array, vA.array, vB.array );
+			THREE.Vector3.cross( cb.array, cb.array, ab.array );
+			THREE.Vector3.normalize( cb.array, cb.array );
+			/*cb.subVectors( vC, vB );
 			ab.subVectors( vA, vB );
 			cb.cross( ab );
 
-			cb.normalize();
+			cb.normalize();*/
 
-			face.normal.copy( cb );
+			THREE.Vector3.copy( face.normal.array, cb.array );
 
 		}
 

--- a/src/math/Allocators.js
+++ b/src/math/Allocators.js
@@ -40,4 +40,4 @@ THREE.SimpleAllocator = {
 };
 
 
-THREE.DefaultAllocator = THREE.SimpleAllocator;
+THREE.DefaultAllocator = THREE.BlockAllocator;

--- a/src/math/Allocators.js
+++ b/src/math/Allocators.js
@@ -1,0 +1,43 @@
+THREE.MemoryBlockSize = 32768; // 32K as a wild guess
+THREE.BlockAllocator = {
+
+    currentBuffer: new ArrayBuffer( THREE.MemoryBlockSize ),
+    currentOffset: 0,
+
+    getFloat32: function ( length ) {
+
+        var buffer = this.currentBuffer,
+            start = this.currentOffset,
+            bytes = length * Float32Array.BYTES_PER_ELEMENT,
+            newOffset = start + bytes;
+
+        if ( newOffset > buffer.byteLength ) {
+            // insufficient free memory in buffer
+
+            buffer = new ArrayBuffer( THREE.MemoryBlockSize );
+            start = 0;
+            newOffset = bytes;
+
+            this.currentBuffer = buffer;
+
+        }
+
+        this.currentOffset = newOffset;
+        return new Float32Array( buffer, start, length );
+
+    }
+
+};
+
+THREE.SimpleAllocator = {
+
+  getFloat32: function( length ) {
+
+    return new Float32Array( length );
+
+  }
+
+};
+
+
+THREE.DefaultAllocator = THREE.BlockAllocator;

--- a/src/math/Allocators.js
+++ b/src/math/Allocators.js
@@ -14,7 +14,7 @@ THREE.BlockAllocator = {
         if ( newOffset > buffer.byteLength ) {
             // insufficient free memory in buffer
 
-            buffer = new ArrayBuffer( THREE.MemoryBlockSize );
+            buffer = new Float32Array( THREE.MemoryBlockSize );
             start = 0;
             newOffset = bytes;
 

--- a/src/math/Allocators.js
+++ b/src/math/Allocators.js
@@ -1,17 +1,17 @@
-THREE.MemoryBlockSize = 32768; // 32K as a wild guess
+THREE.MemoryBlockSize = 1024*16; // 32K as a wild guess
 THREE.BlockAllocator = {
 
-    currentBuffer: new ArrayBuffer( THREE.MemoryBlockSize ),
+    currentBuffer: new Float32Array( THREE.MemoryBlockSize ),
     currentOffset: 0,
 
     getFloat32: function ( length ) {
 
         var buffer = this.currentBuffer,
             start = this.currentOffset,
-            bytes = length * Float32Array.BYTES_PER_ELEMENT,
+            bytes = length,// * Float32Array.BYTES_PER_ELEMENT,
             newOffset = start + bytes;
 
-        if ( newOffset > buffer.byteLength ) {
+        if ( newOffset >= THREE.MemoryBlockSize ) {
             // insufficient free memory in buffer
 
             buffer = new Float32Array( THREE.MemoryBlockSize );

--- a/src/math/Allocators.js
+++ b/src/math/Allocators.js
@@ -40,4 +40,4 @@ THREE.SimpleAllocator = {
 };
 
 
-THREE.DefaultAllocator = THREE.BlockAllocator;
+THREE.DefaultAllocator = THREE.SimpleAllocator;

--- a/src/math/Allocators.js
+++ b/src/math/Allocators.js
@@ -1,31 +1,25 @@
 THREE.MemoryBlockSize = 1024*16; // 32K as a wild guess
 THREE.BlockAllocator = {
 
-    currentBuffer: new Float32Array( THREE.MemoryBlockSize ),
-    currentOffset: 0,
+  activeBuffer: new Float32Array( THREE.MemoryBlockSize ),
+  nextOffset: 0,
+  //currentIndex: 0,
 
-    getFloat32: function ( length ) {
+  getFloat32: function ( length ) {
 
-        var buffer = this.currentBuffer,
-            start = this.currentOffset,
-            bytes = length,// * Float32Array.BYTES_PER_ELEMENT,
-            newOffset = start + bytes;
+    var offset = this.nextOffset;
+    this.nextOffset += length;
 
-        if ( newOffset >= THREE.MemoryBlockSize ) {
-            // insufficient free memory in buffer
+    if( this.nextOffset >= THREE.MemoryBlockSize ) {
 
-            buffer = new Float32Array( THREE.MemoryBlockSize );
-            start = 0;
-            newOffset = bytes;
-
-            this.currentBuffer = buffer;
-
-        }
-
-        this.currentOffset = newOffset;
-        return start;//new Float32Array( buffer, start, length );
+      this.activeBuffer = new Float32Array( THREE.MemoryBlockSize );
+      this.nextOffset = length;
+      offset = 0;
 
     }
+
+    return offset;
+  }
 
 };
 

--- a/src/math/Allocators.js
+++ b/src/math/Allocators.js
@@ -23,7 +23,7 @@ THREE.BlockAllocator = {
         }
 
         this.currentOffset = newOffset;
-        return new Float32Array( buffer, start, length );
+        return start;//new Float32Array( buffer, start, length );
 
     }
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -120,7 +120,11 @@ Object.assign( THREE.Vector3, {
 
 	divideScalar: function( r, ro, a, ao, s ) {
 
-		THREE.Vector3.multiplyScalar( r, ro, a, ao, 1.0 / s );
+		s = 1.0 / s;
+
+		if( ! isFinite( s ) ) s = 0;
+
+		THREE.Vector3.multiplyScalar( r, ro, a, ao, s );
 
 	},
 
@@ -157,7 +161,7 @@ Object.assign( THREE.Vector3, {
 
 	},
 
-	ceiling: function( r, ro, v, vo ) {
+	ceil: function( r, ro, v, vo ) {
 
 		r[ro+0] = Math.ceil( v[vo+0] );
 		r[ro+1] = Math.ceil( v[vo+1] );
@@ -187,7 +191,7 @@ Object.assign( THREE.Vector3, {
 
 	},
 
-	lengthSq: function( v,vo ) {
+	lengthSq: function( v, vo ) {
 
 		var x = v[vo+0], y = v[vo+1], z = v[vo+2];
 		return Math.fround( x*x + y*y + z*z );
@@ -226,21 +230,12 @@ Object.assign( THREE.Vector3, {
 	normalize: function( r, ro, v, vo ) {
 
 		var x = v[vo+0], y = v[vo+1], z = v[vo+2];
-		var scalar = x*x + y*y + z*z;
-		if( Math.abs( scalar ) < 0.000001 ) {
+		var scalar = 1.0 / Math.sqrt( x*x + y*y + z*z );
+		if( ! isFinite( scalar ) ) scalar = 0.0;
 
-			r[ro+0] = r[ro+1] = r[ro+2] = 0.0;
-
-		}
-		else {
-
-			scalar = 1.0 / Math.sqrt( scalar );
-
-			r[ro+0] = v[vo+0] * scalar;
-			r[ro+1] = v[vo+1] * scalar;
-			r[ro+2] = v[vo+2] * scalar;
-
-		}
+		r[ro+0] = v[vo+0] * scalar;
+		r[ro+1] = v[vo+1] * scalar;
+		r[ro+2] = v[vo+2] * scalar;
 
 		return this;
 
@@ -248,14 +243,14 @@ Object.assign( THREE.Vector3, {
 
 	distance: function( a, ao, b, bo ) {
 
-		var x = b[bo+0] - a[ao+0], y = b[bo+1] - a[ao+1], z = b[bo+1] - a[ao+0];
+		var x = b[bo+0] - a[ao+0], y = b[bo+1] - a[ao+1], z = b[bo+2] - a[ao+2];
 		return Math.sqrt( x*x + y*y + z*z );
 
 	},
 
 	distanceSq: function( a, ao, b, bo ) {
 
-		var x = b[bo+0] - a[ao+0], y = b[bo+1] - a[ao+1], z = b[bo+1] - a[ao+0];
+		var x = b[bo+0] - a[ao+0], y = b[bo+1] - a[ao+1], z = b[bo+2] - a[ao+2];
 		return x*x + y*y + z*z;
 
 	},
@@ -621,7 +616,7 @@ THREE.Vector3.prototype = {
 
 		// This function assumes min < max, if this assumption isn't true it will not operate correctly
 
-		THREE.Vector3.clamp( this.array, this.offset, this.array, this.offset, min.array, min.offset, max.array, min.offset );
+		THREE.Vector3.clamp( this.array, this.offset, this.array, this.offset, min.array, min.offset, max.array, max.offset );
 
 		return this;
 
@@ -727,21 +722,7 @@ THREE.Vector3.prototype = {
 
 	normalize: function () {
 
-		var a = this.array;
-
-		var scalar = 1.0 / Math.sqrt( a[0] * a[0] + a[1] * a[1] + a[2] * a[2] );
-		if( ! isFinite( scalar ) ) {
-
-			a[0] = a[1] = a[2] = 0.0;
-
-		}
-		else {
-
-			a[0] *= scalar;
-			a[1] *= scalar;
-			a[2] *= scalar;
-
-		}
+		THREE.Vector3.normalize( this.array, this.offset, this.array, this.offset );
 
 		return this;
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -10,17 +10,17 @@
 
  THREE.Vector3 = function ( array, x, y, z ) {
 
- 	if( !( ( array instanceof Float32Array ) || ( array === undefined ) ) ) {
+	 if( !( ( array instanceof Float32Array ) || ( array === undefined ) ) ) {
 
- 		z = y; y = x; x = array; array = null;
+		 z = y; y = x; x = array; array = null;
 
- 	}
+	 }
 
 	this.array = array || new Float32Array( 3 );
 
- 	if( x !== undefined ) this.set( x, y, z );
+	 if( x !== undefined ) this.set( x, y, z );
 
- 	return this;
+	 return this;
 
  };
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -5,9 +5,18 @@
  * @author mikael emtinger / http://gomo.se/
  * @author egraether / http://egraether.com/
  * @author WestLangley / http://github.com/WestLangley
+ * @author Ben Houston / https://clara.io
  */
 
-THREE.Vector3 = function ( x, y, z ) {
+THREE.Vector3 = function ( array, x, y, z ) {
+
+	if( typeof buffer === 'Number' ) {
+		this.array = new Float32Array( 3 );
+		z = y; y = x; x = array;
+	}
+	else {
+		this.array = array;
+	}
 
 	this.x = x || 0;
 	this.y = y || 0;
@@ -15,15 +24,198 @@ THREE.Vector3 = function ( x, y, z ) {
 
 };
 
+THREE.Vector3.set = function( r, x, y, z ) {
+
+	r[0] = x;
+	r[1] = y;
+	r[2] = z;
+
+};
+
+THREE.Vector3.setComponent = function( r, index, v ) {
+
+	r[index] = v;
+
+};
+
+THREE.Vector3.getComponent = function( v, index ) {
+
+	return v[index];
+
+};
+
+THREE.Vector3.copy = function( r, v ) {
+
+	r[0] = v[0];
+	r[1] = v[1];
+	r[2] = v[2];
+
+}
+
+THREE.Vector3.add = function( r, a, b ) {
+
+	r[0] = a[0] + b[0];
+	r[1] = a[1] + b[1];
+	r[2] = a[2] + b[2];
+
+}
+
+THREE.Vector3.addScalar = function( r, a, b ) {
+
+	r[0] = a[0] + b;
+	r[1] = a[1] + b;
+	r[2] = a[2] + b;
+
+}
+
+THREE.Vector3.sub = function( r, a, b ) {
+
+	r[0] = a[0] - b[0];
+	r[1] = a[1] - b[1];
+	r[2] = a[2] - b[2];
+
+}
+
+THREE.Vector3.subScalar = function( r, a, b ) {
+
+	THREE.Vector3.addScalar( r, a, -b );
+
+}
+
+THREE.Vector3.multiply = function( r, a, b ) {
+
+	r[0] = a[0] * b[0];
+	r[1] = a[1] * b[1];
+	r[2] = a[2] * b[2];
+
+}
+
+THREE.Vector3.multiplyScalar = function( r, a, scalar ) {
+
+	if( ! isFinite( scalar ) ) scalar = 0.0;
+
+	r[0] = a[0] * scalar;
+	r[1] = a[1] * scalar;
+	r[2] = a[2] * scalar;
+
+}
+
+THREE.Vector3.divide = function( r, a, b ) {
+
+	r[0] = a[0] / b[0];
+	r[1] = a[1] / b[1];
+	r[2] = a[2] / b[2];
+
+}
+
+THREE.Vector3.divideScalar = function( r, a, scalar ) {
+
+	THREE.Vector3.multiplyScalar( r, a, 1.0 / scalar );
+
+}
+
+// TODO: auto-generate min, max, floor, ceiing, round functions?
+THREE.Vector3.min = function( r, a, b ) {
+
+	r[0] = Math.min( a[0], b[0] );
+	r[1] = Math.min( a[1], b[1] );
+	r[2] = Math.min( a[2], b[2] );
+
+}
+
+THREE.Vector3.max = function( r, a, b ) {
+
+	r[0] = Math.max( a[0], b[0] );
+	r[1] = Math.max( a[1], b[1] );
+	r[2] = Math.max( a[2], b[2] );
+
+}
+
+THREE.Vector3.clamp = function( r, v, min, max ) {
+
+	r[0] = Math.min( max[0], Math.max( v[0], min[0] ) );
+	r[1] = Math.min( max[1], Math.max( v[1], min[1] ) );
+	r[2] = Math.min( max[2], Math.max( v[2], min[2] ) );
+
+}
+
+THREE.Vector3.floor = function( r, v ) {
+
+	r[0] = Math.floor( v[0] );
+	r[1] = Math.floor( v[1] );
+	r[2] = Math.floor( v[2] );
+
+}
+
+THREE.Vector3.ceiling = function( r, v ) {
+
+	r[0] = Math.ceiling( v[0] );
+	r[1] = Math.ceiling( v[1] );
+	r[2] = Math.ceiling( v[2] );
+
+}
+
+THREE.Vector3.round = function( r, v ) {
+
+	r[0] = Math.round( v[0] );
+	r[1] = Math.round( v[1] );
+	r[2] = Math.round( v[2] );
+
+}
+
+THREE.Vector3.negate = function( r, v ) {
+
+	r[0] = -v[0];
+	r[1] = -v[1];
+	r[2] = -v[2];
+
+}
+
+THREE.Vector3.dot = function( a, b ) {
+
+	return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+
+}
+
+THREE.Vector3.lengthSq = function( v ) {
+
+	return THREE.Vector3.dot( v, v );
+
+}
+
+THREE.Vector3.length = function( v ) {
+
+	return Math.sqrt( THREE.Vector3.lengthSq( v ) );
+
+}
+
+THREE.Vector3.cross = function( r, a, b ) {
+
+	var ax = a[0], ay = a[1], az = a[2];
+	var bx = b[1], by = b[1], bz = b[2];
+
+	r[0] = ay * bz - az * by;
+	r[1] = az * bx - ax * bz;
+	r[2] = ax * by - ay * bx;
+
+}
+
+THREE.Vector3.copyArray = function( r, rOffset, v, vOffest ) {
+
+	r[ rOffset + 0 ] = v[ vOffest + 0 ];
+	r[ rOffset + 1 ] = v[ vOffest + 1 ];
+	r[ rOffset + 2 ] = v[ vOffest + 2 ];
+
+}
+
+
 THREE.Vector3.prototype = {
 
 	constructor: THREE.Vector3,
 
 	set: function ( x, y, z ) {
 
-		this.x = x;
-		this.y = y;
-		this.z = z;
+		THREE.Vector3.set( this.array, x, y, z );
 
 		return this;
 
@@ -31,61 +223,30 @@ THREE.Vector3.prototype = {
 
 	setScalar: function ( scalar ) {
 
-		this.x = scalar;
-		this.y = scalar;
-		this.z = scalar;
+		THREE.Vector3.set( this.array, scalar, scalar, scalar );
 
 		return this;
 
 	},
 
-	setX: function ( x ) {
+	set x( v ) { this.array[0] = v; },
+	get x() { return this.array[0]; },
 
-		this.x = x;
+	set x( v ) { this.array[0] = v; },
+	get y() { return this.array[1]; },
 
-		return this;
-
-	},
-
-	setY: function ( y ) {
-
-		this.y = y;
-
-		return this;
-
-	},
-
-	setZ: function ( z ) {
-
-		this.z = z;
-
-		return this;
-
-	},
+	set x( v ) { this.array[0] = v; },
+	get z() { return this.array[2]; },
 
 	setComponent: function ( index, value ) {
 
-		switch ( index ) {
-
-			case 0: this.x = value; break;
-			case 1: this.y = value; break;
-			case 2: this.z = value; break;
-			default: throw new Error( 'index is out of range: ' + index );
-
-		}
+		THREE.Vector3.setComponent( this.array, index, value );
 
 	},
 
 	getComponent: function ( index ) {
 
-		switch ( index ) {
-
-			case 0: return this.x;
-			case 1: return this.y;
-			case 2: return this.z;
-			default: throw new Error( 'index is out of range: ' + index );
-
-		}
+		return THREE.Vector3.getComponent( this.array, index );
 
 	},
 
@@ -97,9 +258,7 @@ THREE.Vector3.prototype = {
 
 	copy: function ( v ) {
 
-		this.x = v.x;
-		this.y = v.y;
-		this.z = v.z;
+		THREE.Vector3.copy( this.array, v.array );
 
 		return this;
 
@@ -114,9 +273,7 @@ THREE.Vector3.prototype = {
 
 		}
 
-		this.x += v.x;
-		this.y += v.y;
-		this.z += v.z;
+		THREE.Vector3.add( this.array, this.array, v.array );
 
 		return this;
 
@@ -124,9 +281,7 @@ THREE.Vector3.prototype = {
 
 	addScalar: function ( s ) {
 
-		this.x += s;
-		this.y += s;
-		this.z += s;
+		THREE.Vector3.add( this.array, this.array, s );
 
 		return this;
 
@@ -134,9 +289,7 @@ THREE.Vector3.prototype = {
 
 	addVectors: function ( a, b ) {
 
-		this.x = a.x + b.x;
-		this.y = a.y + b.y;
-		this.z = a.z + b.z;
+		THREE.Vector3.add( this.array, a.array, b.array );
 
 		return this;
 
@@ -144,9 +297,7 @@ THREE.Vector3.prototype = {
 
 	addScaledVector: function ( v, s ) {
 
-		this.x += v.x * s;
-		this.y += v.y * s;
-		this.z += v.z * s;
+		THREE.Vector3.addScaledVector( this.array, v.array, s );
 
 		return this;
 
@@ -161,9 +312,7 @@ THREE.Vector3.prototype = {
 
 		}
 
-		this.x -= v.x;
-		this.y -= v.y;
-		this.z -= v.z;
+		THREE.Vector3.sub( this.array, this.array, v.array );
 
 		return this;
 
@@ -171,9 +320,7 @@ THREE.Vector3.prototype = {
 
 	subScalar: function ( s ) {
 
-		this.x -= s;
-		this.y -= s;
-		this.z -= s;
+		THREE.Vector3.subScalar( this.array, this.array, v.array );
 
 		return this;
 
@@ -181,9 +328,7 @@ THREE.Vector3.prototype = {
 
 	subVectors: function ( a, b ) {
 
-		this.x = a.x - b.x;
-		this.y = a.y - b.y;
-		this.z = a.z - b.z;
+		THREE.Vector3.sub( this.array, a.array, b.array );
 
 		return this;
 
@@ -198,9 +343,7 @@ THREE.Vector3.prototype = {
 
 		}
 
-		this.x *= v.x;
-		this.y *= v.y;
-		this.z *= v.z;
+		THREE.Vector3.multiply( this.array, this.array, v.array );
 
 		return this;
 
@@ -208,19 +351,7 @@ THREE.Vector3.prototype = {
 
 	multiplyScalar: function ( scalar ) {
 
-		if ( isFinite( scalar ) ) {
-
-			this.x *= scalar;
-			this.y *= scalar;
-			this.z *= scalar;
-
-		} else {
-
-			this.x = 0;
-			this.y = 0;
-			this.z = 0;
-
-		}
+		THREE.Vector3.multiplyScalar( this.array, this.array, scalar );
 
 		return this;
 
@@ -228,9 +359,7 @@ THREE.Vector3.prototype = {
 
 	multiplyVectors: function ( a, b ) {
 
-		this.x = a.x * b.x;
-		this.y = a.y * b.y;
-		this.z = a.z * b.z;
+		THREE.Vector3.multiplyScalar( this.array, a.array, b.array );
 
 		return this;
 
@@ -402,9 +531,7 @@ THREE.Vector3.prototype = {
 
 	divide: function ( v ) {
 
-		this.x /= v.x;
-		this.y /= v.y;
-		this.z /= v.z;
+		THREE.Vector3.divide( this.array, this.array, v.array );
 
 		return this;
 
@@ -412,15 +539,13 @@ THREE.Vector3.prototype = {
 
 	divideScalar: function ( scalar ) {
 
-		return this.multiplyScalar( 1 / scalar );
+		THREE.Vector3.divideScalar( this.array, this.array, scalar );
 
 	},
 
 	min: function ( v ) {
 
-		this.x = Math.min( this.x, v.x );
-		this.y = Math.min( this.y, v.y );
-		this.z = Math.min( this.z, v.z );
+		THREE.Vector3.min( this.array, this.array, v.array );
 
 		return this;
 
@@ -428,9 +553,7 @@ THREE.Vector3.prototype = {
 
 	max: function ( v ) {
 
-		this.x = Math.max( this.x, v.x );
-		this.y = Math.max( this.y, v.y );
-		this.z = Math.max( this.z, v.z );
+		THREE.Vector3.max( this.array, this.array, v.array );
 
 		return this;
 
@@ -440,9 +563,7 @@ THREE.Vector3.prototype = {
 
 		// This function assumes min < max, if this assumption isn't true it will not operate correctly
 
-		this.x = Math.max( min.x, Math.min( max.x, this.x ) );
-		this.y = Math.max( min.y, Math.min( max.y, this.y ) );
-		this.z = Math.max( min.z, Math.min( max.z, this.z ) );
+		THREE.Vector3.clamp( this.array, this.array, min.array, max.array );
 
 		return this;
 
@@ -482,9 +603,7 @@ THREE.Vector3.prototype = {
 
 	floor: function () {
 
-		this.x = Math.floor( this.x );
-		this.y = Math.floor( this.y );
-		this.z = Math.floor( this.z );
+		THREE.Vector3.floor( this.array, this.array );
 
 		return this;
 
@@ -492,9 +611,7 @@ THREE.Vector3.prototype = {
 
 	ceil: function () {
 
-		this.x = Math.ceil( this.x );
-		this.y = Math.ceil( this.y );
-		this.z = Math.ceil( this.z );
+		THREE.Vector3.ceil( this.array, this.array );
 
 		return this;
 
@@ -502,9 +619,7 @@ THREE.Vector3.prototype = {
 
 	round: function () {
 
-		this.x = Math.round( this.x );
-		this.y = Math.round( this.y );
-		this.z = Math.round( this.z );
+		THREE.Vector3.round( this.array, this.array );
 
 		return this;
 
@@ -522,9 +637,7 @@ THREE.Vector3.prototype = {
 
 	negate: function () {
 
-		this.x = - this.x;
-		this.y = - this.y;
-		this.z = - this.z;
+		THREE.Vector3.negate( this.array, this.array );
 
 		return this;
 
@@ -532,19 +645,19 @@ THREE.Vector3.prototype = {
 
 	dot: function ( v ) {
 
-		return this.x * v.x + this.y * v.y + this.z * v.z;
+		return THREE.Vector3.dot( this.array, v.array );
 
 	},
 
 	lengthSq: function () {
 
-		return this.x * this.x + this.y * this.y + this.z * this.z;
+		return THREE.Vector3.lengthSq( this.array );
 
 	},
 
 	length: function () {
 
-		return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
+		return THREE.Vector3.length( this.array );
 
 	},
 
@@ -593,11 +706,7 @@ THREE.Vector3.prototype = {
 
 		}
 
-		var x = this.x, y = this.y, z = this.z;
-
-		this.x = y * v.z - z * v.y;
-		this.y = z * v.x - x * v.z;
-		this.z = x * v.y - y * v.x;
+		THREE.Vector3.cross( this.array, this.array, v.array );
 
 		return this;
 
@@ -605,12 +714,7 @@ THREE.Vector3.prototype = {
 
 	crossVectors: function ( a, b ) {
 
-		var ax = a.x, ay = a.y, az = a.z;
-		var bx = b.x, by = b.y, bz = b.z;
-
-		this.x = ay * bz - az * by;
-		this.y = az * bx - ax * bz;
-		this.z = ax * by - ay * bx;
+		THREE.Vector3.cross( this.array, a.array, b.array );
 
 		return this;
 
@@ -679,17 +783,13 @@ THREE.Vector3.prototype = {
 
 	distanceTo: function ( v ) {
 
-		return Math.sqrt( this.distanceToSquared( v ) );
+		return THREE.Vector3.length( this.array, v.array );
 
 	},
 
 	distanceToSquared: function ( v ) {
 
-		var dx = this.x - v.x;
-		var dy = this.y - v.y;
-		var dz = this.z - v.z;
-
-		return dx * dx + dy * dy + dz * dz;
+		return THREE.Vector3.lengthSq( this.array, v.array );
 
 	},
 
@@ -748,11 +848,7 @@ THREE.Vector3.prototype = {
 
 	fromArray: function ( array, offset ) {
 
-		if ( offset === undefined ) offset = 0;
-
-		this.x = array[ offset ];
-		this.y = array[ offset + 1 ];
-		this.z = array[ offset + 2 ];
+		THREE.Vector3.copyArray( this.array, 0, array, ( offset === undefined ) ? 0 : offset );
 
 		return this;
 
@@ -760,12 +856,7 @@ THREE.Vector3.prototype = {
 
 	toArray: function ( array, offset ) {
 
-		if ( array === undefined ) array = [];
-		if ( offset === undefined ) offset = 0;
-
-		array[ offset ] = this.x;
-		array[ offset + 1 ] = this.y;
-		array[ offset + 2 ] = this.z;
+		THREE.Vector3.copyArray( array || [], offset, this.array, 0 );
 
 		return array;
 
@@ -773,13 +864,7 @@ THREE.Vector3.prototype = {
 
 	fromAttribute: function ( attribute, index, offset ) {
 
-		if ( offset === undefined ) offset = 0;
-
-		index = index * attribute.itemSize + offset;
-
-		this.x = attribute.array[ index ];
-		this.y = attribute.array[ index + 1 ];
-		this.z = attribute.array[ index + 2 ];
+		THREE.Vector3.copyArray( this.array, 0, attribute.array, index * attribute.itemSize + offset );
 
 		return this;
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -16,11 +16,9 @@
 
 	 }*/
 
-	this.array = THREE.DefaultAllocator.getFloat32( 3 );
+	this.array = new Float32Array( 3 );//THREE.DefaultAllocator.getFloat32( 3 );
 
-	 if( x !== undefined ) this.set( x, y, z );
-
-	 return this;
+	 if( x !== undefined ) THREE.Vector3.set( this.array, x, y, z );
 
  };
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -8,30 +8,22 @@
  * @author Ben Houston / https://clara.io
  */
 
- THREE.Vector3 = function ( x, y, z ) {
+ THREE.Vector3 = function ( array, x, y, z ) {
 
-	 /*if( !( ( array instanceof Float32Array ) || ( array === undefined ) ) ) {
+	 if( typeof array === 'number' ) {
 
 		 z = y; y = x; x = array; array = null;
 
-	 }*/
+	 }
 
-	this.array = new Float32Array( 3 );//THREE.DefaultAllocator.getFloat32( 3 );
+	this.array = array || THREE.DefaultAllocator.getFloat32( 3 );
 
 	 if( x !== undefined ) THREE.Vector3.set( this.array, x, y, z );
 
  };
 
 
-
-var h = function( target, methods ) {
-
-	for( var name in methods ) {
-
-		target[name] = methods[name];
-	}
-
-}( THREE.Vector3, {
+Object.assign( THREE.Vector3, {
 
 	set: function( r, x, y, z ) {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -69,6 +69,14 @@ Object.assign( THREE.Vector3, {
 
 	},
 
+	addScaledVector: function( r, a, b, scale ) {
+
+		r[0] = a[0] + b[0] * scale;
+		r[1] = a[1] + b[1] * scale;
+		r[2] = a[2] + b[2] * scale;
+
+	},
+
 	sub: function( r, a, b ) {
 
 		r[0] = a[0] - b[0];
@@ -180,14 +188,16 @@ Object.assign( THREE.Vector3, {
 
 	lengthSq: function( v ) {
 
-		return v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+		var x = v[0], y = v[1], z = v[2];
+		return x*x + y*y + z*z;
 
 	},
 
 	// NOTE: using magnitude because THREE.VEctor3.length is defined as the number of function arguments to the constructor THREE.Vector3(), argh.
 	magnitude: function( v ) {
 
-		return Math.sqrt( v[0] * v[0] + v[1] * v[1] + v[2] * v[2] );
+		var x = v[0], y = v[1], z = v[2];
+		return Math.sqrt( x*x + y*y + z*z );
 
 	},
 
@@ -223,6 +233,20 @@ Object.assign( THREE.Vector3, {
 	normalize: function( r, v ) {
 
 		THREE.Vector3.divideScalar( r, r, THREE.Vector3.magnitude( v ) );
+
+	},
+
+	distance: function( a, b ) {
+
+		var x = b[0] - a[0], y = b[1] - a[1], z = b[1] - a[0];
+		return Math.sqrt( x*x + y*y + z*z );
+
+	},
+
+	distanceSq: function( a, b ) {
+
+		var x = b[0] - a[0], y = b[1] - a[1], z = b[1] - a[0];
+		return x*x + y*y + z*z;
 
 	},
 
@@ -319,7 +343,7 @@ THREE.Vector3.prototype = {
 
 	addScaledVector: function ( v, s ) {
 
-		THREE.Vector3.addScaledVector( this.array, v.array, s );
+		THREE.Vector3.addScaledVector( this.array, this.array, v.array, s );
 
 		return this;
 
@@ -729,7 +753,7 @@ THREE.Vector3.prototype = {
 
 	lerpVectors: function ( v1, v2, alpha ) {
 
-		this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
+		THREE.Vector3.lerp( this.array, v1.array, v2.array, alpha );
 
 		return this;
 
@@ -821,13 +845,13 @@ THREE.Vector3.prototype = {
 
 	distanceTo: function ( v ) {
 
-		return THREE.Vector3.magnitude( this.array, v.array );
+		return THREE.Vector3.distance( this.array, v.array );
 
 	},
 
 	distanceToSquared: function ( v ) {
 
-		return THREE.Vector3.lengthSq( this.array, v.array );
+		return THREE.Vector3.distanceSq( this.array, v.array );
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -232,7 +232,7 @@ var h = function( target, methods ) {
 
 	normalize: function( r, v ) {
 
-		THREE.Vector3.divideScalar( r, THREE.Vector3.magnitude( v ) );
+		THREE.Vector3.divideScalar( r, r, THREE.Vector3.magnitude( v ) );
 
 	},
 
@@ -703,8 +703,22 @@ THREE.Vector3.prototype = {
 
 	normalize: function () {
 
-		THREE.Vector3.normalize( this.array, this.array );
-		
+		var a = this.array;
+
+		var scalar = 1.0 / Math.sqrt( a[0] * a[0] + a[1] * a[1] + a[2] * a[2] );
+		if( ! isFinite( scalar ) ) {
+
+			a[0] = a[1] = a[2] = 0.0;
+
+		}
+		else {
+
+			a[0] *= scalar;
+			a[1] *= scalar;
+			a[2] *= scalar;
+
+		}
+
 		return this;
 
 	},

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -16,7 +16,7 @@
 
 	 }
 
-	this.array = array || new Float32Array( 3 );
+	this.array = array || THREE.DefaultAllocator.getFloat32( 3 );
 
 	 if( x !== undefined ) this.set( x, y, z );
 
@@ -220,8 +220,6 @@ THREE.Vector3.copyArray = function( r, rOffset, v, vOffest ) {
 	r[ rOffset + 2 ] = v[ vOffest + 2 ];
 
 }
-
-
 
 
 THREE.Vector3.prototype = {

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -8,251 +8,237 @@
  * @author Ben Houston / https://clara.io
  */
 
- THREE.Vector3 = function ( array, x, y, z ) {
+THREE.Vector3 = function ( x, y, z ) {
 
-	 if( typeof array === 'number' ) {
+	this.offset = THREE.BlockAllocator.getFloat32( 3 );
+	this.array = THREE.BlockAllocator.currentBuffer;
 
-		 z = y; y = x; x = array; array = null;
-
-	 }
-
-	this.array = array || THREE.DefaultAllocator.getFloat32( 3 );
-
-	 if( x !== undefined ) THREE.Vector3.set( this.array, x, y, z );
-
- };
+	if( x !== undefined ) THREE.Vector3.set( this.array, this.offset, x, y, z );
+};
 
 
 Object.assign( THREE.Vector3, {
 
-	set: function( r, x, y, z ) {
+	set: function( r, ro, x, y, z ) {
 
-		r[0] = x;
-		r[1] = y;
-		r[2] = z;
-
-	},
-
-	setComponent: function( r, index, v ) {
-
-		r[index] = v;
+		r[ro+0] = x;
+		r[ro+1] = y;
+		r[ro+2] = z;
 
 	},
 
-	getComponent: function( v, index ) {
+	setComponent: function( r, ro, index, v ) {
 
-		return v[index];
-
-	},
-
-	copy: function( r, v ) {
-
-		r[0] = v[0];
-		r[1] = v[1];
-		r[2] = v[2];
+		r[ro+index] = v;
 
 	},
 
-	add: function( r, a, b ) {
+	getComponent: function( v, vo, index ) {
 
-		r[0] = a[0] + b[0];
-		r[1] = a[1] + b[1];
-		r[2] = a[2] + b[2];
+		return v[vo+index];
 
 	},
 
-	addScalar: function( r, a, b ) {
+	copy: function( r, ro, v, vo ) {
 
-		r[0] = a[0] + b;
-		r[1] = a[1] + b;
-		r[2] = a[2] + b;
-
-	},
-
-	addScaledVector: function( r, a, b, scale ) {
-
-		r[0] = a[0] + b[0] * scale;
-		r[1] = a[1] + b[1] * scale;
-		r[2] = a[2] + b[2] * scale;
+		r[ro+0] = v[vo+0];
+		r[ro+1] = v[vo+1];
+		r[ro+2] = v[vo+2];
 
 	},
 
-	sub: function( r, a, b ) {
+	add: function( r, ro, a, ao, b, bo ) {
 
-		r[0] = a[0] - b[0];
-		r[1] = a[1] - b[1];
-		r[2] = a[2] - b[2];
-
-	},
-
-	subSelf: function( r, v ) {
-
-		r[0] -= v[0];
-		r[1] -= v[1];
-		r[2] -= v[2];
+		r[ro+0] = a[ao+0] + b[bo+0];
+		r[ro+1] = a[ao+1] + b[bo+1];
+		r[ro+2] = a[ao+2] + b[bo+2];
 
 	},
 
-	subScalar: function( r, a, b ) {
+	addScalar: function( r, ro, a, ao, s ) {
 
-		THREE.Vector3.addScalar( r, a, -b );
-
-	},
-
-	multiply: function( r, a, b ) {
-
-		r[0] = a[0] * b[0];
-		r[1] = a[1] * b[1];
-		r[2] = a[2] * b[2];
+		r[ro+0] = a[ao+0] + s;
+		r[ro+1] = a[ao+1] + s;
+		r[ro+2] = a[ao+2] + s;
 
 	},
 
-	multiplyScalar: function( r, a, scalar ) {
+	addScaledVector: function( r, ro, a, ao, b, bo, scale ) {
 
-		if( ! isFinite( scalar ) ) scalar = 0.0;
-
-		r[0] = a[0] * scalar;
-		r[1] = a[1] * scalar;
-		r[2] = a[2] * scalar;
+		r[ro+0] = a[ao+0] + Math.fround( b[bo+0] * scale );
+		r[ro+1] = a[ao+1] + Math.fround( b[bo+1] * scale );
+		r[ro+2] = a[ao+2] + Math.fround( b[bo+2] * scale );
 
 	},
 
-	divide: function( r, a, b ) {
+	sub: function( r, ro, a, ao, b, bo ) {
 
-		r[0] = a[0] / b[0];
-		r[1] = a[1] / b[1];
-		r[2] = a[2] / b[2];
+		r[ro+0] = a[ao+0] - b[bo+0];
+		r[ro+1] = a[ao+1] - b[bo+1];
+		r[ro+2] = a[ao+2] - b[bo+2];
 
 	},
 
-	divideScalar: function( r, a, scalar ) {
+	subSelf: function( r, ro, v, vo ) {
 
-		THREE.Vector3.multiplyScalar( r, a, 1.0 / scalar );
+		r[ro+0] -= v[vo+0];
+		r[ro+1] -= v[vo+1];
+		r[ro+2] -= v[vo+2];
+
+	},
+
+	subScalar: function( r, ro, v, vo, s ) {
+
+		THREE.Vector3.addScalar( r, ro, v, vo, -s );
+
+	},
+
+	multiply: function( r, ro, a, ao, b, bo ) {
+
+		r[ro+0] = a[ao+0] * b[bo+0];
+		r[ro+1] = a[ao+1] * b[bo+1];
+		r[ro+2] = a[ao+2] * b[bo+2];
+
+	},
+
+
+	multiplyScalar: function( r, ro, a, ao, s ) {
+
+		r[ro+0] = a[ao+0] * s;
+		r[ro+1] = a[ao+1] * s;
+		r[ro+2] = a[ao+2] * s;
+
+	},
+
+	divide: function( r, ro, a, ao, b, bo ) {
+
+		r[ro+0] = a[ao+0] / b[bo+0];
+		r[ro+1] = a[ao+1] / b[bo+1];
+		r[ro+2] = a[ao+2] / b[bo+2];
+
+	},
+
+	divideScalar: function( r, ro, a, ao, s ) {
+
+		THREE.Vector3.multiplyScalar( r, ro, a, ao, 1.0 / s );
 
 	},
 
 	// TODO: auto-generate min, max, floor, ceiing, round functions?
-	min: function( r, a, b ) {
+	min: function( r, ro, a, ao, b, bo ) {
 
-		r[0] = Math.min( a[0], b[0] );
-		r[1] = Math.min( a[1], b[1] );
-		r[2] = Math.min( a[2], b[2] );
-
-	},
-
-	max: function( r, a, b ) {
-
-		r[0] = Math.max( a[0], b[0] );
-		r[1] = Math.max( a[1], b[1] );
-		r[2] = Math.max( a[2], b[2] );
+		r[ro+0] = Math.min( a[ao+0], b[bo+0] );
+		r[ro+1] = Math.min( a[ao+1], b[bo+1] );
+		r[ro+2] = Math.min( a[ao+2], b[bo+2] );
 
 	},
 
-	clamp: function( r, v, min, max ) {
+	max: function( r, ro, a, ao, b, bo ) {
 
-		r[0] = Math.min( max[0], Math.max( v[0], min[0] ) );
-		r[1] = Math.min( max[1], Math.max( v[1], min[1] ) );
-		r[2] = Math.min( max[2], Math.max( v[2], min[2] ) );
-
-	},
-
-	floor: function( r, v ) {
-
-		r[0] = Math.floor( v[0] );
-		r[1] = Math.floor( v[1] );
-		r[2] = Math.floor( v[2] );
+		r[ro+0] = Math.max( a[ao+0], b[bo+0] );
+		r[ro+1] = Math.max( a[ao+1], b[bo+1] );
+		r[ro+2] = Math.max( a[ao+2], b[bo+2] );
 
 	},
 
-	ceiling: function( r, v ) {
+	clamp: function( r, ro, v, vo, min, no, max, xo ) {
 
-		r[0] = Math.ceiling( v[0] );
-		r[1] = Math.ceiling( v[1] );
-		r[2] = Math.ceiling( v[2] );
-
-	},
-
-	round: function( r, v ) {
-
-		r[0] = Math.round( v[0] );
-		r[1] = Math.round( v[1] );
-		r[2] = Math.round( v[2] );
+		r[ro+0] = Math.min( max[xo+0], Math.max( v[vo+0], min[no+0] ) );
+		r[ro+1] = Math.min( max[xo+1], Math.max( v[vo+1], min[no+1] ) );
+		r[ro+2] = Math.min( max[xo+2], Math.max( v[vo+2], min[no+2] ) );
 
 	},
 
-	negate: function( r, v ) {
+	floor: function( r, ro, v, vo ) {
 
-		r[0] = -v[0];
-		r[1] = -v[1];
-		r[2] = -v[2];
-
-	},
-
-	dot: function( a, b ) {
-
-		return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+		r[ro+0] = Math.floor( v[vo+0] );
+		r[ro+1] = Math.floor( v[vo+1] );
+		r[ro+2] = Math.floor( v[vo+2] );
 
 	},
 
-	lengthSq: function( v ) {
+	ceiling: function( r, ro, v, vo ) {
 
-		var x = v[0], y = v[1], z = v[2];
-		return x*x + y*y + z*z;
+		r[ro+0] = Math.ceil( v[vo+0] );
+		r[ro+1] = Math.ceil( v[vo+1] );
+		r[ro+2] = Math.ceil( v[vo+2] );
+
+	},
+
+	round: function( r, ro, v, vo ) {
+
+		r[ro+0] = Math.round( v[vo+0] );
+		r[ro+1] = Math.round( v[vo+1] );
+		r[ro+2] = Math.round( v[vo+2] );
+
+	},
+
+	negate: function( r, ro, v, vo ) {
+
+		r[ro+0] = -v[vo+0];
+		r[ro+1] = -v[vo+1];
+		r[ro+2] = -v[vo+2];
+
+	},
+
+	dot: function( a, ao, b, bo ) {
+
+		return Math.fround( a[ao+0] * b[bo+0] + a[ao+1] * b[bo+1] + a[ao+2] * b[bo+2] );
+
+	},
+
+	lengthSq: function( v,vo ) {
+
+		var x = v[vo+0], y = v[vo+1], z = v[vo+2];
+		return Math.fround( x*x + y*y + z*z );
 
 	},
 
 	// NOTE: using magnitude because THREE.VEctor3.length is defined as the number of function arguments to the constructor THREE.Vector3(), argh.
-	magnitude: function( v ) {
+	magnitude: function( v, vo ) {
 
-		var x = v[0], y = v[1], z = v[2];
-		return Math.sqrt( x*x + y*y + z*z );
+		var x = v[vo+0], y = v[vo+1], z = v[vo+2];
+		return Math.sqrt( Math.fround( x*x + y*y + z*z ) );
 
 	},
 
-	lerp: function( r, a, b, alpha ) {
+	lerp: function( r, ro, a, ao, b, bo, alpha ) {
 
 		var oneMinusAlpha = 1.0 - alpha;
 
-		r[0] = a[0] * oneMinusAlpha + b[0] * alpha;
-		r[1] = a[1] * oneMinusAlpha + b[1] * alpha;
-		r[2] = a[2] * oneMinusAlpha + b[2] * alpha;
+		r[ro+0] = Math.fround( a[ao+0] * oneMinusAlpha ) + Math.fround( b[bo+0] * alpha );
+		r[ro+1] = Math.fround( a[ao+1] * oneMinusAlpha ) + Math.fround( b[bo+1] * alpha );
+		r[ro+2] = Math.fround( a[ao+2] * oneMinusAlpha ) + Math.fround( b[bo+2] * alpha );
 
 	},
 
-	cross: function( r, a, b ) {
+	cross: function( r, ro, a, ao, b, bo ) {
 
-		var ax = a[0], ay = a[1], az = a[2];
-		var bx = b[0], by = b[1], bz = b[2];
+		var ax = a[ao+0], ay = a[ao+1], az = a[ao+2];
+		var bx = b[bo+0], by = b[bo+1], bz = b[bo+2];
 
-		r[0] = ay * bz - az * by;
-		r[1] = az * bx - ax * bz;
-		r[2] = ax * by - ay * bx;
-
-	},
-
-	copyArray: function( r, rOffset, v, vOffest ) {
-
-		r[ rOffset + 0 ] = v[ vOffest + 0 ];
-		r[ rOffset + 1 ] = v[ vOffest + 1 ];
-		r[ rOffset + 2 ] = v[ vOffest + 2 ];
+		r[ro+0] = ay * bz - az * by;
+		r[ro+1] = az * bx - ax * bz;
+		r[ro+2] = ax * by - ay * bx;
 
 	},
 
-	normalize: function( r, a ) {
+	normalize: function( r, ro, v, vo ) {
 
-		var scalar = a[0] * a[0] + a[1] * a[1] + a[2] * a[2];
+		var x = v[vo+0], y = v[vo+1], z = v[vo+2];
+		var scalar = x*x + y*y + z*z;
 		if( Math.abs( scalar ) < 0.000001 ) {
 
-			r[0] = r[1] = r[2] = 0.0;
+			r[ro+0] = r[ro+1] = r[ro+2] = 0.0;
 
 		}
 		else {
 
 			scalar = 1.0 / Math.sqrt( scalar );
 
-			r[0] = a[0] * scalar;
-			r[1] = a[1] * scalar;
-			r[2] = a[2] * scalar;
+			r[ro+0] = v[vo+0] * scalar;
+			r[ro+1] = v[vo+1] * scalar;
+			r[ro+2] = v[vo+2] * scalar;
 
 		}
 
@@ -260,16 +246,16 @@ Object.assign( THREE.Vector3, {
 
 	},
 
-	distance: function( a, b ) {
+	distance: function( a, ao, b, bo ) {
 
-		var x = b[0] - a[0], y = b[1] - a[1], z = b[1] - a[0];
+		var x = b[bo+0] - a[ao+0], y = b[bo+1] - a[ao+1], z = b[bo+1] - a[ao+0];
 		return Math.sqrt( x*x + y*y + z*z );
 
 	},
 
-	distanceSq: function( a, b ) {
+	distanceSq: function( a, ao, b, bo ) {
 
-		var x = b[0] - a[0], y = b[1] - a[1], z = b[1] - a[0];
+		var x = b[bo+0] - a[ao+0], y = b[bo+1] - a[ao+1], z = b[bo+1] - a[ao+0];
 		return x*x + y*y + z*z;
 
 	},
@@ -282,7 +268,7 @@ THREE.Vector3.prototype = {
 
 	set: function ( x, y, z ) {
 
-		THREE.Vector3.set( this.array, x, y, z );
+		THREE.Vector3.set( this.array, this.offset, x, y, z );
 
 		return this;
 
@@ -290,33 +276,33 @@ THREE.Vector3.prototype = {
 
 	setScalar: function ( scalar ) {
 
-		THREE.Vector3.set( this.array, scalar, scalar, scalar );
+		THREE.Vector3.set( this.array, this.offset, scalar, scalar, scalar );
 
 		return this;
 
 	},
 
-	set x( v ) { this.array[0] = v; },
-	set y( v ) { this.array[1] = v; },
-	set z( v ) { this.array[2] = v; },
+	set x( v ) { this.array[this.offset+0] = v; },
+	set y( v ) { this.array[this.offset+1] = v; },
+	set z( v ) { this.array[this.offset+2] = v; },
 
-	get x() { return this.array[0]; },
-	get y() { return this.array[1]; },
-	get z() { return this.array[2]; },
+	get x() { return this.array[this.offset+0]; },
+	get y() { return this.array[this.offset+1]; },
+	get z() { return this.array[this.offset+2]; },
 
-	setX: function ( v ) { this.array[0] = v; return this; },
-	setY: function ( v ) { this.array[1] = v; return this; },
-	setZ: function ( v ) { this.array[2] = v; return this; },
+	setX: function ( v ) { this.array[this.offset+0] = v; return this; },
+	setY: function ( v ) { this.array[this.offset+1] = v; return this; },
+	setZ: function ( v ) { this.array[this.offset+2] = v; return this; },
 
 	setComponent: function ( index, value ) {
 
-		THREE.Vector3.setComponent( this.array, index, value );
+		THREE.Vector3.setComponent( this.array, this.offset, index, value );
 
 	},
 
 	getComponent: function ( index ) {
 
-		return THREE.Vector3.getComponent( this.array, index );
+		return THREE.Vector3.getComponent( this.array, this.offset, index );
 
 	},
 
@@ -328,7 +314,7 @@ THREE.Vector3.prototype = {
 
 	copy: function ( v ) {
 
-		THREE.Vector3.copy( this.array, v.array );
+		THREE.Vector3.copy( this.array, this.offset, v.array, v.offset );
 
 		return this;
 
@@ -343,7 +329,7 @@ THREE.Vector3.prototype = {
 
 		}
 
-		THREE.Vector3.add( this.array, this.array, v.array );
+		THREE.Vector3.add( this.array, this.offset, this.array, this.offset, v.array, v.offset );
 
 		return this;
 
@@ -351,7 +337,7 @@ THREE.Vector3.prototype = {
 
 	addScalar: function ( s ) {
 
-		THREE.Vector3.add( this.array, this.array, s );
+		THREE.Vector3.add( this.array, this.offset, this.array, this.offset, s );
 
 		return this;
 
@@ -359,7 +345,7 @@ THREE.Vector3.prototype = {
 
 	addVectors: function ( a, b ) {
 
-		THREE.Vector3.add( this.array, a.array, b.array );
+		THREE.Vector3.add( this.array, this.offset, a.array, a.offset, b.array, b.offset );
 
 		return this;
 
@@ -367,7 +353,7 @@ THREE.Vector3.prototype = {
 
 	addScaledVector: function ( v, s ) {
 
-		THREE.Vector3.addScaledVector( this.array, this.array, v.array, s );
+		THREE.Vector3.addScaledVector( this.array, this.offset, this.array, this.offset, v.array, v.offset, s );
 
 		return this;
 
@@ -382,7 +368,7 @@ THREE.Vector3.prototype = {
 
 		}
 
-		THREE.Vector3.sub( this.array, this.array, v.array );
+		THREE.Vector3.sub( this.array, this.offset, this.array, this.offset, v.array, v.offset );
 
 		return this;
 
@@ -390,7 +376,7 @@ THREE.Vector3.prototype = {
 
 	subScalar: function ( s ) {
 
-		THREE.Vector3.subScalar( this.array, this.array, s );
+		THREE.Vector3.subScalar( this.array, this.offset, this.array, this.offset, s );
 
 		return this;
 
@@ -398,7 +384,7 @@ THREE.Vector3.prototype = {
 
 	subVectors: function ( a, b ) {
 
-		THREE.Vector3.sub( this.array, a.array, b.array );
+		THREE.Vector3.sub( this.array, this.offset, a.array, a.offset, b.array, b.offset );
 
 		return this;
 
@@ -413,7 +399,7 @@ THREE.Vector3.prototype = {
 
 		}
 
-		THREE.Vector3.multiply( this.array, this.array, v.array );
+		THREE.Vector3.multiply( this.array, this.offset, this.array, this.offset, v.array, v.offset );
 
 		return this;
 
@@ -421,7 +407,7 @@ THREE.Vector3.prototype = {
 
 	multiplyScalar: function ( scalar ) {
 
-		THREE.Vector3.multiplyScalar( this.array, this.array, scalar );
+		THREE.Vector3.multiplyScalar( this.array, this.offset, this.array, this.offset, scalar );
 
 		return this;
 
@@ -429,7 +415,7 @@ THREE.Vector3.prototype = {
 
 	multiplyVectors: function ( a, b ) {
 
-		THREE.Vector3.multiplyScalar( this.array, a.array, b.array );
+		THREE.Vector3.multiplyScalar( this.array, this.offset, a.array, a.offset, b.array, b.offset );
 
 		return this;
 
@@ -601,7 +587,7 @@ THREE.Vector3.prototype = {
 
 	divide: function ( v ) {
 
-		THREE.Vector3.divide( this.array, this.array, v.array );
+		THREE.Vector3.divide( this.array, this.offset, this.array, this.offset, v.array, v.offset );
 
 		return this;
 
@@ -609,7 +595,7 @@ THREE.Vector3.prototype = {
 
 	divideScalar: function ( scalar ) {
 
-		THREE.Vector3.divideScalar( this.array, this.array, scalar );
+		THREE.Vector3.divideScalar( this.array, this.offset, this.array, this.offset, scalar );
 
 		return this;
 
@@ -617,7 +603,7 @@ THREE.Vector3.prototype = {
 
 	min: function ( v ) {
 
-		THREE.Vector3.min( this.array, this.array, v.array );
+		THREE.Vector3.min( this.array, this.offset, this.array, this.offset, v.array, v.offset );
 
 		return this;
 
@@ -625,7 +611,7 @@ THREE.Vector3.prototype = {
 
 	max: function ( v ) {
 
-		THREE.Vector3.max( this.array, this.array, v.array );
+		THREE.Vector3.max( this.array, this.offset, this.array, this.offset, v.array, v.offset );
 
 		return this;
 
@@ -635,7 +621,7 @@ THREE.Vector3.prototype = {
 
 		// This function assumes min < max, if this assumption isn't true it will not operate correctly
 
-		THREE.Vector3.clamp( this.array, this.array, min.array, max.array );
+		THREE.Vector3.clamp( this.array, this.offset, this.array, this.offset, min.array, min.offset, max.array, min.offset );
 
 		return this;
 
@@ -675,7 +661,7 @@ THREE.Vector3.prototype = {
 
 	floor: function () {
 
-		THREE.Vector3.floor( this.array, this.array );
+		THREE.Vector3.floor( this.array, this.offset, this.array, this.offset );
 
 		return this;
 
@@ -683,7 +669,7 @@ THREE.Vector3.prototype = {
 
 	ceil: function () {
 
-		THREE.Vector3.ceil( this.array, this.array );
+		THREE.Vector3.ceil( this.array, this.offset, this.array, this.offset );
 
 		return this;
 
@@ -691,7 +677,7 @@ THREE.Vector3.prototype = {
 
 	round: function () {
 
-		THREE.Vector3.round( this.array, this.array );
+		THREE.Vector3.round( this.array, this.offset, this.array, this.offset );
 
 		return this;
 
@@ -709,7 +695,7 @@ THREE.Vector3.prototype = {
 
 	negate: function () {
 
-		THREE.Vector3.negate( this.array, this.array );
+		THREE.Vector3.negate( this.array, this.offset, this.array, this.offset );
 
 		return this;
 
@@ -717,19 +703,19 @@ THREE.Vector3.prototype = {
 
 	dot: function ( v ) {
 
-		return THREE.Vector3.dot( this.array, v.array );
+		return THREE.Vector3.dot( this.array, this.offset, v.array, v.offset );
 
 	},
 
 	lengthSq: function () {
 
-		return THREE.Vector3.lengthSq( this.array );
+		return THREE.Vector3.lengthSq( this.array, this.offset );
 
 	},
 
 	length: function () {
 
-		return THREE.Vector3.magnitude( this.array );
+		return THREE.Vector3.magnitude( this.array, this.offset );
 
 	},
 
@@ -769,7 +755,7 @@ THREE.Vector3.prototype = {
 
 	lerp: function ( v, alpha ) {
 
-	 THREE.Vector3.lerp( this.array, this.array, v.array, alpha );
+	 THREE.Vector3.lerp( this.array, this.offset, this.array, this.offset, v.array, v.offset, alpha );
 
 		return this;
 
@@ -777,7 +763,7 @@ THREE.Vector3.prototype = {
 
 	lerpVectors: function ( v1, v2, alpha ) {
 
-		THREE.Vector3.lerp( this.array, v1.array, v2.array, alpha );
+		THREE.Vector3.lerp( this.array, this.offset, v1.array, v1.offset, v2.array, v2.offset, alpha );
 
 		return this;
 
@@ -792,7 +778,7 @@ THREE.Vector3.prototype = {
 
 		}
 
-		THREE.Vector3.cross( this.array, this.array, v.array );
+		THREE.Vector3.cross( this.array, this.offset, this.array, this.offset, v.array, v.offset );
 
 		return this;
 
@@ -800,7 +786,7 @@ THREE.Vector3.prototype = {
 
 	crossVectors: function ( a, b ) {
 
-		THREE.Vector3.cross( this.array, a.array, b.array );
+		THREE.Vector3.cross( this.array, this.offset, a.array, a.offset, b.array, b.offset );
 
 		return this;
 
@@ -869,13 +855,13 @@ THREE.Vector3.prototype = {
 
 	distanceTo: function ( v ) {
 
-		return THREE.Vector3.distance( this.array, v.array );
+		return THREE.Vector3.distance( this.array, this.offset, v.array, v.offset );
 
 	},
 
 	distanceToSquared: function ( v ) {
 
-		return THREE.Vector3.distanceSq( this.array, v.array );
+		return THREE.Vector3.distanceSq( this.array, this.offset, v.array, v.offset );
 
 	},
 
@@ -934,7 +920,7 @@ THREE.Vector3.prototype = {
 
 	fromArray: function ( array, offset ) {
 
-		THREE.Vector3.copyArray( this.array, 0, array, ( offset === undefined ) ? 0 : offset );
+		THREE.Vector3.copy( this.array, this.offset, array, ( offset === undefined ) ? 0 : offset );
 
 		return this;
 
@@ -942,7 +928,7 @@ THREE.Vector3.prototype = {
 
 	toArray: function ( array, offset ) {
 
-		THREE.Vector3.copyArray( array || [], offset, this.array, 0 );
+		THREE.Vector3.copy( array || [], offset, this.array, this.offset );
 
 		return array;
 
@@ -950,7 +936,7 @@ THREE.Vector3.prototype = {
 
 	fromAttribute: function ( attribute, index, offset ) {
 
-		THREE.Vector3.copyArray( this.array, 0, attribute.array, index * attribute.itemSize + offset );
+		THREE.Vector3.copy( this.array, this.offset, attribute.array, index * attribute.itemSize + offset );
 
 		return this;
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -85,6 +85,14 @@ Object.assign( THREE.Vector3, {
 
 	},
 
+	subSelf: function( r, v ) {
+
+		r[0] -= v[0];
+		r[1] -= v[1];
+		r[2] -= v[2];
+
+	},
+
 	subScalar: function( r, a, b ) {
 
 		THREE.Vector3.addScalar( r, a, -b );
@@ -230,9 +238,25 @@ Object.assign( THREE.Vector3, {
 
 	},
 
-	normalize: function( r, v ) {
+	normalize: function( r, a ) {
 
-		THREE.Vector3.divideScalar( r, r, THREE.Vector3.magnitude( v ) );
+		var scalar = a[0] * a[0] + a[1] * a[1] + a[2] * a[2];
+		if( Math.abs( scalar ) < 0.000001 ) {
+
+			r[0] = r[1] = r[2] = 0.0;
+
+		}
+		else {
+
+			scalar = 1.0 / Math.sqrt( scalar );
+
+			r[0] = a[0] * scalar;
+			r[1] = a[1] * scalar;
+			r[2] = a[2] * scalar;
+
+		}
+
+		return this;
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -8,15 +8,15 @@
  * @author Ben Houston / https://clara.io
  */
 
- THREE.Vector3 = function ( array, x, y, z ) {
+ THREE.Vector3 = function ( x, y, z ) {
 
-	 if( !( ( array instanceof Float32Array ) || ( array === undefined ) ) ) {
+	 /*if( !( ( array instanceof Float32Array ) || ( array === undefined ) ) ) {
 
 		 z = y; y = x; x = array; array = null;
 
-	 }
+	 }*/
 
-	this.array = array || THREE.DefaultAllocator.getFloat32( 3 );
+	this.array = THREE.DefaultAllocator.getFloat32( 3 );
 
 	 if( x !== undefined ) this.set( x, y, z );
 
@@ -26,201 +26,217 @@
 
 
 
-THREE.Vector3.set = function( r, x, y, z ) {
+var h = function( target, methods ) {
 
-	r[0] = x;
-	r[1] = y;
-	r[2] = z;
+	for( var name in methods ) {
 
-};
+		target[name] = methods[name];
+	}
 
-THREE.Vector3.setComponent = function( r, index, v ) {
+}( THREE.Vector3, {
 
-	r[index] = v;
+	set: function( r, x, y, z ) {
 
-};
+		r[0] = x;
+		r[1] = y;
+		r[2] = z;
 
-THREE.Vector3.getComponent = function( v, index ) {
+	},
 
-	return v[index];
+	setComponent: function( r, index, v ) {
 
-};
+		r[index] = v;
 
-THREE.Vector3.copy = function( r, v ) {
+	},
 
-	r[0] = v[0];
-	r[1] = v[1];
-	r[2] = v[2];
+	getComponent: function( v, index ) {
 
-}
+		return v[index];
 
-THREE.Vector3.add = function( r, a, b ) {
+	},
 
-	r[0] = a[0] + b[0];
-	r[1] = a[1] + b[1];
-	r[2] = a[2] + b[2];
+	copy: function( r, v ) {
 
-}
+		r[0] = v[0];
+		r[1] = v[1];
+		r[2] = v[2];
 
-THREE.Vector3.addScalar = function( r, a, b ) {
+	},
 
-	r[0] = a[0] + b;
-	r[1] = a[1] + b;
-	r[2] = a[2] + b;
+	add: function( r, a, b ) {
 
-}
+		r[0] = a[0] + b[0];
+		r[1] = a[1] + b[1];
+		r[2] = a[2] + b[2];
 
-THREE.Vector3.sub = function( r, a, b ) {
+	},
 
-	r[0] = a[0] - b[0];
-	r[1] = a[1] - b[1];
-	r[2] = a[2] - b[2];
+	addScalar: function( r, a, b ) {
 
-}
+		r[0] = a[0] + b;
+		r[1] = a[1] + b;
+		r[2] = a[2] + b;
 
-THREE.Vector3.subScalar = function( r, a, b ) {
+	},
 
-	THREE.Vector3.addScalar( r, a, -b );
+	sub: function( r, a, b ) {
 
-}
+		r[0] = a[0] - b[0];
+		r[1] = a[1] - b[1];
+		r[2] = a[2] - b[2];
 
-THREE.Vector3.multiply = function( r, a, b ) {
+	},
 
-	r[0] = a[0] * b[0];
-	r[1] = a[1] * b[1];
-	r[2] = a[2] * b[2];
+	subScalar: function( r, a, b ) {
 
-}
+		THREE.Vector3.addScalar( r, a, -b );
 
-THREE.Vector3.multiplyScalar = function( r, a, scalar ) {
+	},
 
-	if( ! isFinite( scalar ) ) scalar = 0.0;
+	multiply: function( r, a, b ) {
 
-	r[0] = a[0] * scalar;
-	r[1] = a[1] * scalar;
-	r[2] = a[2] * scalar;
+		r[0] = a[0] * b[0];
+		r[1] = a[1] * b[1];
+		r[2] = a[2] * b[2];
 
-}
+	},
 
-THREE.Vector3.divide = function( r, a, b ) {
+	multiplyScalar: function( r, a, scalar ) {
 
-	r[0] = a[0] / b[0];
-	r[1] = a[1] / b[1];
-	r[2] = a[2] / b[2];
+		if( ! isFinite( scalar ) ) scalar = 0.0;
 
-}
+		r[0] = a[0] * scalar;
+		r[1] = a[1] * scalar;
+		r[2] = a[2] * scalar;
 
-THREE.Vector3.divideScalar = function( r, a, scalar ) {
+	},
 
-	THREE.Vector3.multiplyScalar( r, a, 1.0 / scalar );
+	divide: function( r, a, b ) {
 
-}
+		r[0] = a[0] / b[0];
+		r[1] = a[1] / b[1];
+		r[2] = a[2] / b[2];
 
-// TODO: auto-generate min, max, floor, ceiing, round functions?
-THREE.Vector3.min = function( r, a, b ) {
+	},
 
-	r[0] = Math.min( a[0], b[0] );
-	r[1] = Math.min( a[1], b[1] );
-	r[2] = Math.min( a[2], b[2] );
+	divideScalar: function( r, a, scalar ) {
 
-}
+		THREE.Vector3.multiplyScalar( r, a, 1.0 / scalar );
 
-THREE.Vector3.max = function( r, a, b ) {
+	},
 
-	r[0] = Math.max( a[0], b[0] );
-	r[1] = Math.max( a[1], b[1] );
-	r[2] = Math.max( a[2], b[2] );
+	// TODO: auto-generate min, max, floor, ceiing, round functions?
+	min: function( r, a, b ) {
 
-}
+		r[0] = Math.min( a[0], b[0] );
+		r[1] = Math.min( a[1], b[1] );
+		r[2] = Math.min( a[2], b[2] );
 
-THREE.Vector3.clamp = function( r, v, min, max ) {
+	},
 
-	r[0] = Math.min( max[0], Math.max( v[0], min[0] ) );
-	r[1] = Math.min( max[1], Math.max( v[1], min[1] ) );
-	r[2] = Math.min( max[2], Math.max( v[2], min[2] ) );
+	max: function( r, a, b ) {
 
-}
+		r[0] = Math.max( a[0], b[0] );
+		r[1] = Math.max( a[1], b[1] );
+		r[2] = Math.max( a[2], b[2] );
 
-THREE.Vector3.floor = function( r, v ) {
+	},
 
-	r[0] = Math.floor( v[0] );
-	r[1] = Math.floor( v[1] );
-	r[2] = Math.floor( v[2] );
+	clamp: function( r, v, min, max ) {
 
-}
+		r[0] = Math.min( max[0], Math.max( v[0], min[0] ) );
+		r[1] = Math.min( max[1], Math.max( v[1], min[1] ) );
+		r[2] = Math.min( max[2], Math.max( v[2], min[2] ) );
 
-THREE.Vector3.ceiling = function( r, v ) {
+	},
 
-	r[0] = Math.ceiling( v[0] );
-	r[1] = Math.ceiling( v[1] );
-	r[2] = Math.ceiling( v[2] );
+	floor: function( r, v ) {
 
-}
+		r[0] = Math.floor( v[0] );
+		r[1] = Math.floor( v[1] );
+		r[2] = Math.floor( v[2] );
 
-THREE.Vector3.round = function( r, v ) {
+	},
 
-	r[0] = Math.round( v[0] );
-	r[1] = Math.round( v[1] );
-	r[2] = Math.round( v[2] );
+	ceiling: function( r, v ) {
 
-}
+		r[0] = Math.ceiling( v[0] );
+		r[1] = Math.ceiling( v[1] );
+		r[2] = Math.ceiling( v[2] );
 
-THREE.Vector3.negate = function( r, v ) {
+	},
 
-	r[0] = -v[0];
-	r[1] = -v[1];
-	r[2] = -v[2];
+	round: function( r, v ) {
 
-}
+		r[0] = Math.round( v[0] );
+		r[1] = Math.round( v[1] );
+		r[2] = Math.round( v[2] );
 
-THREE.Vector3.dot = function( a, b ) {
+	},
 
-	return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+	negate: function( r, v ) {
 
-}
+		r[0] = -v[0];
+		r[1] = -v[1];
+		r[2] = -v[2];
 
-THREE.Vector3.lengthSq = function( v ) {
+	},
 
-	return THREE.Vector3.dot( v, v );
+	dot: function( a, b ) {
 
-}
+		return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 
-// NOTE: using magnitude because THREE.VEctor3.length is defined as the number of function arguments to the constructor THREE.Vector3(), argh.
-THREE.Vector3.magnitude = function( v ) {
+	},
 
-	return Math.sqrt( THREE.Vector3.lengthSq( v ) );
+	lengthSq: function( v ) {
 
-}
+		return v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
 
-THREE.Vector3.lerp = function( r, a, b, alpha ) {
+	},
 
-	var oneMinusAlpha = 1.0 - alpha;
+	// NOTE: using magnitude because THREE.VEctor3.length is defined as the number of function arguments to the constructor THREE.Vector3(), argh.
+	magnitude: function( v ) {
 
-	r[0] = a[0] * oneMinusAlpha + b[0] * alpha;
-	r[1] = a[1] * oneMinusAlpha + b[1] * alpha;
-	r[2] = a[2] * oneMinusAlpha + b[2] * alpha;
+		return Math.sqrt( v[0] * v[0] + v[1] * v[1] + v[2] * v[2] );
 
-}
+	},
 
-THREE.Vector3.cross = function( r, a, b ) {
+	lerp: function( r, a, b, alpha ) {
 
-	var ax = a[0], ay = a[1], az = a[2];
-	var bx = b[1], by = b[1], bz = b[2];
+		var oneMinusAlpha = 1.0 - alpha;
 
-	r[0] = ay * bz - az * by;
-	r[1] = az * bx - ax * bz;
-	r[2] = ax * by - ay * bx;
+		r[0] = a[0] * oneMinusAlpha + b[0] * alpha;
+		r[1] = a[1] * oneMinusAlpha + b[1] * alpha;
+		r[2] = a[2] * oneMinusAlpha + b[2] * alpha;
 
-}
+	},
 
-THREE.Vector3.copyArray = function( r, rOffset, v, vOffest ) {
+	cross: function( r, a, b ) {
 
-	r[ rOffset + 0 ] = v[ vOffest + 0 ];
-	r[ rOffset + 1 ] = v[ vOffest + 1 ];
-	r[ rOffset + 2 ] = v[ vOffest + 2 ];
+		var ax = a[0], ay = a[1], az = a[2];
+		var bx = b[0], by = b[1], bz = b[2];
 
-}
+		r[0] = ay * bz - az * by;
+		r[1] = az * bx - ax * bz;
+		r[2] = ax * by - ay * bx;
 
+	},
+
+	copyArray: function( r, rOffset, v, vOffest ) {
+
+		r[ rOffset + 0 ] = v[ vOffest + 0 ];
+		r[ rOffset + 1 ] = v[ vOffest + 1 ];
+		r[ rOffset + 2 ] = v[ vOffest + 2 ];
+
+	},
+
+	normalize: function( r, v ) {
+
+		THREE.Vector3.divideScalar( r, THREE.Vector3.magnitude( v ) );
+
+	},
+
+});
 
 THREE.Vector3.prototype = {
 
@@ -687,7 +703,9 @@ THREE.Vector3.prototype = {
 
 	normalize: function () {
 
-		return this.divideScalar( this.length() );
+		THREE.Vector3.normalize( this.array, this.array );
+		
+		return this;
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -8,21 +8,23 @@
  * @author Ben Houston / https://clara.io
  */
 
-THREE.Vector3 = function ( array, x, y, z ) {
+ THREE.Vector3 = function ( array, x, y, z ) {
 
-	if( typeof buffer === 'Number' ) {
-		this.array = new Float32Array( 3 );
-		z = y; y = x; x = array;
-	}
-	else {
-		this.array = array;
-	}
+ 	if( !( ( array instanceof Float32Array ) || ( array === undefined ) ) ) {
 
-	this.x = x || 0;
-	this.y = y || 0;
-	this.z = z || 0;
+ 		z = y; y = x; x = array; array = null;
 
-};
+ 	}
+
+	this.array = array || new Float32Array( 3 );
+
+ 	if( x !== undefined ) this.set( x, y, z );
+
+ 	return this;
+
+ };
+
+
 
 THREE.Vector3.set = function( r, x, y, z ) {
 
@@ -183,9 +185,20 @@ THREE.Vector3.lengthSq = function( v ) {
 
 }
 
-THREE.Vector3.length = function( v ) {
+// NOTE: using magnitude because THREE.VEctor3.length is defined as the number of function arguments to the constructor THREE.Vector3(), argh.
+THREE.Vector3.magnitude = function( v ) {
 
 	return Math.sqrt( THREE.Vector3.lengthSq( v ) );
+
+}
+
+THREE.Vector3.lerp = function( r, a, b, alpha ) {
+
+	var oneMinusAlpha = 1.0 - alpha;
+
+	r[0] = a[0] * oneMinusAlpha + b[0] * alpha;
+	r[1] = a[1] * oneMinusAlpha + b[1] * alpha;
+	r[2] = a[2] * oneMinusAlpha + b[2] * alpha;
 
 }
 
@@ -209,6 +222,8 @@ THREE.Vector3.copyArray = function( r, rOffset, v, vOffest ) {
 }
 
 
+
+
 THREE.Vector3.prototype = {
 
 	constructor: THREE.Vector3,
@@ -230,13 +245,16 @@ THREE.Vector3.prototype = {
 	},
 
 	set x( v ) { this.array[0] = v; },
+	set y( v ) { this.array[1] = v; },
+	set z( v ) { this.array[2] = v; },
+
 	get x() { return this.array[0]; },
-
-	set x( v ) { this.array[0] = v; },
 	get y() { return this.array[1]; },
-
-	set x( v ) { this.array[0] = v; },
 	get z() { return this.array[2]; },
+
+	setX: function ( v ) { this.array[0] = v; return this; },
+	setY: function ( v ) { this.array[1] = v; return this; },
+	setZ: function ( v ) { this.array[2] = v; return this; },
 
 	setComponent: function ( index, value ) {
 
@@ -320,7 +338,7 @@ THREE.Vector3.prototype = {
 
 	subScalar: function ( s ) {
 
-		THREE.Vector3.subScalar( this.array, this.array, v.array );
+		THREE.Vector3.subScalar( this.array, this.array, s );
 
 		return this;
 
@@ -541,6 +559,8 @@ THREE.Vector3.prototype = {
 
 		THREE.Vector3.divideScalar( this.array, this.array, scalar );
 
+		return this;
+
 	},
 
 	min: function ( v ) {
@@ -657,7 +677,7 @@ THREE.Vector3.prototype = {
 
 	length: function () {
 
-		return THREE.Vector3.length( this.array );
+		return THREE.Vector3.magnitude( this.array );
 
 	},
 
@@ -681,9 +701,7 @@ THREE.Vector3.prototype = {
 
 	lerp: function ( v, alpha ) {
 
-		this.x += ( v.x - this.x ) * alpha;
-		this.y += ( v.y - this.y ) * alpha;
-		this.z += ( v.z - this.z ) * alpha;
+	 THREE.Vector3.lerp( this.array, this.array, v.array, alpha );
 
 		return this;
 
@@ -783,7 +801,7 @@ THREE.Vector3.prototype = {
 
 	distanceTo: function ( v ) {
 
-		return THREE.Vector3.length( this.array, v.array );
+		return THREE.Vector3.magnitude( this.array, v.array );
 
 	},
 

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -1,5 +1,6 @@
 [
 	"src/Three.js",
+	"src/math/Allocators.js",
 	"src/math/Color.js",
 	"src/math/Quaternion.js",
 	"src/math/Vector2.js",


### PR DESCRIPTION
This is a second quick prototype on how to redo the math library design to maximize speed.  This one uses large pre-allocated Float32Arrays and shares them between multiple Vector3s.  Vector3 now has an array and a offset.

I have found this to be as performant as the current ThreeJS design although this should be tremendously flexible, especially since the functional library can be used direct on large attribute arrays without the creation of Views.

I believe this outperforms gl-matrix, with the caveat that it can leak memory under various circumstances.

(This is in contract to this quick prototype that created an Float32Array view for each Vector3, which was a significant slowdown (~20% slower on creation): #8667)

/ping @tschw @toji @mrdoob
