### PR TITLE
MTLLoader improvements

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -14,6 +14,19 @@ THREE.MTLLoader.prototype = {
 
 	constructor: THREE.MTLLoader,
 
+	/**
+	 * Loads and parses a MTL asset from a URL.
+	 *
+	 * @param {String} url - URL to the MTL file.
+	 * @param {Function} [onLoad] - Callback invoked with the loaded object.
+	 * @param {Function} [onProgress] - Callback for download progress.
+	 * @param {Function} [onError] - Callback for download errors.
+	 *
+	 * @see setPath setTexturePath
+	 *
+	 * @note In order for relative texture references to resolve correctly
+	 * you must call setPath and/or setTexturePath explicity prior to load.
+	 */
 	load: function ( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
@@ -22,7 +35,7 @@ THREE.MTLLoader.prototype = {
 		loader.setPath( this.path );
 		loader.load( url, function ( text ) {
 
-			onLoad( scope.parse( text, url ) );
+			onLoad( scope.parse( text ) );
 
 		}, onProgress, onError );
 
@@ -85,14 +98,17 @@ THREE.MTLLoader.prototype = {
 	},
 
 	/**
-	 * Parses loaded MTL file
+	 * Parses a MTL file.
+	 *
 	 * @param {String} text - Content of MTL file
-	 * @param {String} [url] - URL where object was loaded.
-	 * Used to detect base path for textures if not explicitly
-	 * set with setPath or setTexturePath.
 	 * @return {THREE.MTLLoader.MaterialCreator}
+	 *
+	 * @see setPath setTexturePath
+	 *
+	 * @note In order for relative texture references to resolve correctly
+	 * you must call setPath and/or setTexturePath explicity prior to parse.
 	 */
-	parse: function ( text, url ) {
+	parse: function ( text ) {
 
 		var lines = text.split( '\n' );
 		var info = {};
@@ -143,16 +159,7 @@ THREE.MTLLoader.prototype = {
 
 		}
 
-		// Resolve texture base path from URL if not explicitly set
-		var texturePath = this.texturePath || this.path;
-		if ( url && typeof texturePath !== 'string' ) {
-			var indexDir = url.lastIndexOf( '/' );
-			if ( indexDir !== -1 && url.length > indexDir ) {
-				texturePath = url.substring( 0, indexDir + 1 );
-			}
-		}
-
-		var materialCreator = new THREE.MTLLoader.MaterialCreator( texturePath, this.materialOptions );
+		var materialCreator = new THREE.MTLLoader.MaterialCreator( this.texturePath || this.path, this.materialOptions );
 		materialCreator.setCrossOrigin( this.crossOrigin );
 		materialCreator.setManager( this.manager );
 		materialCreator.setMaterials( materialsInfo );

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -348,6 +348,19 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 		};
 
+		var resolveURL = function ( baseUrl, url ) {
+
+			if ( typeof url !== 'string' || url === '' )
+				return '';
+
+			// Absolute URL
+			if ( url.toLowerCase().indexOf('http://') === 0 || url.toLowerCase().indexOf('https://') === 0 ) {
+				return url;
+			}
+
+			return baseUrl + url;
+		};
+
 		for ( var prop in mat ) {
 
 			var value = mat[ prop ];
@@ -379,7 +392,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( params.map ) break; // Keep the first encountered texture
 
-					params.map = this.loadTexture( this._resolveURL( value ) );
+					params.map = this.loadTexture( resolveURL( this.baseUrl, value ) );
 					params.map.wrapS = this.wrap;
 					params.map.wrapT = this.wrap;
 
@@ -423,7 +436,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( params.bumpMap ) break; // Keep the first encountered texture
 
-					params.bumpMap = this.loadTexture( this._resolveURL( value ) );
+					params.bumpMap = this.loadTexture( resolveURL( this.baseUrl, value ) );
 					params.bumpMap.wrapS = this.wrap;
 					params.bumpMap.wrapT = this.wrap;
 
@@ -439,19 +452,6 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 		this.materials[ materialName ] = new THREE.MeshPhongMaterial( params );
 		return this.materials[ materialName ];
 
-	},
-
-	_resolveURL: function ( url ) {
-
-		if ( typeof url !== 'string' || url === '' )
-			return '';
-
-		// Absolute URL
-		if ( url.toLowerCase().indexOf('http://') === 0 || url.toLowerCase().indexOf('https://') === 0 ) {
-			return url;
-		}
-
-		return this.baseUrl + url;
 	},
 
 	loadTexture: function ( url, mapping, onLoad, onProgress, onError ) {

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -379,7 +379,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( params.map ) break; // Keep the first encountered texture
 
-					params.map = this.loadTexture( this.baseUrl + value );
+					params.map = this.loadTexture( this._resolveURL( value ) );
 					params.map.wrapS = this.wrap;
 					params.map.wrapT = this.wrap;
 
@@ -423,7 +423,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( params.bumpMap ) break; // Keep the first encountered texture
 
-					params.bumpMap = this.loadTexture( this.baseUrl + value );
+					params.bumpMap = this.loadTexture( this._resolveURL( value ) );
 					params.bumpMap.wrapS = this.wrap;
 					params.bumpMap.wrapT = this.wrap;
 
@@ -441,6 +441,18 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 	},
 
+	_resolveURL: function ( url ) {
+
+		if ( typeof url !== 'string' || url === '' )
+			return '';
+
+		// Absolute URL
+		if ( url.toLowerCase().indexOf('http://') === 0 || url.toLowerCase().indexOf('https://') === 0 ) {
+			return url;
+		}
+
+		return this.baseUrl + url;
+	},
 
 	loadTexture: function ( url, mapping, onLoad, onProgress, onError ) {
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -36,8 +36,8 @@ THREE.MTLLoader.prototype = {
 	 * @param {String} path
 	 *
 	 * @example
-	 *     mtlLoader.setPath("assets/obj/");
-	 *     mtlLoader.load("my.mtl", ...);
+	 *     mtlLoader.setPath( 'assets/obj/' );
+	 *     mtlLoader.load( 'my.mtl', ... );
 	 */
 	setPath: function ( path ) {
 
@@ -54,9 +54,9 @@ THREE.MTLLoader.prototype = {
 	 * @param {String} path
 	 *
 	 * @example
-	 *     mtlLoader.setPath("assets/obj/");
-	 *     mtlLoader.setTexturePath("assets/textures/");
-	 *     mtlLoader.load("my.mtl", ...);
+	 *     mtlLoader.setPath( 'assets/obj/' );
+	 *     mtlLoader.setTexturePath( 'assets/textures/' );
+	 *     mtlLoader.load( 'my.mtl', ... );
 	 */
 	setTexturePath: function( path ) {
 
@@ -179,7 +179,7 @@ THREE.MTLLoader.prototype = {
 
 THREE.MTLLoader.MaterialCreator = function( baseUrl, options ) {
 
-	this.baseUrl = baseUrl || "";
+	this.baseUrl = baseUrl || '';
 	this.options = options;
 	this.materialsInfo = {};
 	this.materials = {};

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -94,7 +94,7 @@ THREE.MTLLoader.prototype = {
 	 */
 	parse: function ( text, url ) {
 
-		var lines = text.split( "\n" );
+		var lines = text.split( '\n' );
 		var info = {};
 		var delimiter_pattern = /\s+/;
 		var materialsInfo = {};
@@ -116,10 +116,10 @@ THREE.MTLLoader.prototype = {
 			var key = ( pos >= 0 ) ? line.substring( 0, pos ) : line;
 			key = key.toLowerCase();
 
-			var value = ( pos >= 0 ) ? line.substring( pos + 1 ) : "";
+			var value = ( pos >= 0 ) ? line.substring( pos + 1 ) : '';
 			value = value.trim();
 
-			if ( key === "newmtl" ) {
+			if ( key === 'newmtl' ) {
 
 				// New material
 
@@ -128,7 +128,7 @@ THREE.MTLLoader.prototype = {
 
 			} else if ( info ) {
 
-				if ( key === "ka" || key === "kd" || key === "ks" ) {
+				if ( key === 'ka' || key === 'kd' || key === 'ks' ) {
 
 					var ss = value.split( delimiter_pattern, 3 );
 					info[ key ] = [ parseFloat( ss[ 0 ] ), parseFloat( ss[ 1 ] ), parseFloat( ss[ 2 ] ) ];
@@ -355,14 +355,14 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					// Diffuse color (color under white light) using RGB values
 
-					params[ 'color' ] = new THREE.Color().fromArray( value );
+					params.color = new THREE.Color().fromArray( value );
 
 					break;
 
 				case 'ks':
 
 					// Specular color (color when light is reflected from shiny surface) using RGB values
-					params[ 'specular' ] = new THREE.Color().fromArray( value );
+					params.specular = new THREE.Color().fromArray( value );
 
 					break;
 
@@ -370,9 +370,9 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					// Diffuse texture map
 
-					params[ 'map' ] = this.loadTexture( this.baseUrl + value );
-					params[ 'map' ].wrapS = this.wrap;
-					params[ 'map' ].wrapT = this.wrap;
+					params.map = this.loadTexture( this.baseUrl + value );
+					params.map.wrapS = this.wrap;
+					params.map.wrapT = this.wrap;
 
 					break;
 
@@ -381,7 +381,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 					// The specular exponent (defines the focus of the specular highlight)
 					// A high exponent results in a tight, concentrated highlight. Ns values normally range from 0 to 1000.
 
-					params[ 'shininess' ] = parseFloat( value );
+					params.shininess = parseFloat( value );
 
 					break;
 
@@ -389,8 +389,8 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( value < 1 ) {
 
-						params[ 'opacity' ] = value;
-						params[ 'transparent' ] = true;
+						params.opacity = value;
+						params.transparent = true;
 
 					}
 
@@ -400,8 +400,8 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( value > 0 ) {
 
-						params[ 'opacity' ] = 1 - value;
-						params[ 'transparent' ] = true;
+						params.opacity = 1 - value;
+						params.transparent = true;
 
 					}
 
@@ -412,11 +412,11 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					// Bump texture map
 
-					if ( params[ 'bumpMap' ] ) break; // Avoid loading twice.
+					if ( params.bumpMap ) break; // Avoid loading twice.
 
-					params[ 'bumpMap' ] = this.loadTexture( this.baseUrl + value );
-					params[ 'bumpMap' ].wrapS = this.wrap;
-					params[ 'bumpMap' ].wrapT = this.wrap;
+					params.bumpMap = this.loadTexture( this.baseUrl + value );
+					params.bumpMap.wrapS = this.wrap;
+					params.bumpMap.wrapT = this.wrap;
 
 					break;
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -25,7 +25,7 @@ THREE.MTLLoader.prototype = {
 	 * @see setPath setTexturePath
 	 *
 	 * @note In order for relative texture references to resolve correctly
-	 * you must call setPath and/or setTexturePath explicity prior to load.
+	 * you must call setPath and/or setTexturePath explicitly prior to load.
 	 */
 	load: function ( url, onLoad, onProgress, onError ) {
 
@@ -106,7 +106,7 @@ THREE.MTLLoader.prototype = {
 	 * @see setPath setTexturePath
 	 *
 	 * @note In order for relative texture references to resolve correctly
-	 * you must call setPath and/or setTexturePath explicity prior to parse.
+	 * you must call setPath and/or setTexturePath explicitly prior to parse.
 	 */
 	parse: function ( text ) {
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -370,6 +370,8 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					// Diffuse texture map
 
+					if ( params.map ) break; // Keep the first encountered texture
+
 					params.map = this.loadTexture( this.baseUrl + value );
 					params.map.wrapS = this.wrap;
 					params.map.wrapT = this.wrap;
@@ -412,7 +414,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					// Bump texture map
 
-					if ( params.bumpMap ) break; // Avoid loading twice.
+					if ( params.bumpMap ) break; // Keep the first encountered texture
 
 					params.bumpMap = this.loadTexture( this.baseUrl + value );
 					params.bumpMap.wrapS = this.wrap;

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -354,7 +354,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 				return '';
 
 			// Absolute URL
-			if ( url.toLowerCase().indexOf('http://') === 0 || url.toLowerCase().indexOf('https://') === 0 ) {
+			if ( /^https?:\/\//i.test( url ) ) {
 				return url;
 			}
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -22,7 +22,7 @@ THREE.MTLLoader.prototype = {
 		loader.setPath( this.path );
 		loader.load( url, function ( text ) {
 
-			onLoad( scope.parse( text ) );
+			onLoad( scope.parse( text, url ) );
 
 		}, onProgress, onError );
 
@@ -86,10 +86,13 @@ THREE.MTLLoader.prototype = {
 
 	/**
 	 * Parses loaded MTL file
-	 * @param text - Content of MTL file
+	 * @param {String} text - Content of MTL file
+	 * @param {String} [url] - URL where object was loaded.
+	 * Used to detect base path for textures if not explicitly
+	 * set with setPath or setTexturePath.
 	 * @return {THREE.MTLLoader.MaterialCreator}
 	 */
-	parse: function ( text ) {
+	parse: function ( text, url ) {
 
 		var lines = text.split( "\n" );
 		var info = {};
@@ -140,7 +143,16 @@ THREE.MTLLoader.prototype = {
 
 		}
 
-		var materialCreator = new THREE.MTLLoader.MaterialCreator( this.texturePath || this.path, this.materialOptions );
+		// Resolve texture base path from URL if not explicitly set
+		var texturePath = this.texturePath || this.path;
+		if ( url && typeof texturePath !== 'string' ) {
+			var indexDir = url.lastIndexOf( '/' );
+			if ( indexDir !== -1 && url.length > indexDir ) {
+				texturePath = url.substring( 0, indexDir + 1 );
+			}
+		}
+
+		var materialCreator = new THREE.MTLLoader.MaterialCreator( texturePath, this.materialOptions );
 		materialCreator.setCrossOrigin( this.crossOrigin );
 		materialCreator.setManager( this.manager );
 		materialCreator.setMaterials( materialsInfo );

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -28,17 +28,47 @@ THREE.MTLLoader.prototype = {
 
 	},
 
-	setPath: function ( value ) {
+	/**
+	 * Set base path for resolving references.
+	 * If set this path will be prepended to each loaded and found reference.
+	 *
+	 * @see setTexturePath
+	 * @param {String} path
+	 *
+	 * @example
+	 *     mtlLoader.setPath("assets/obj/");
+	 *     mtlLoader.load("my.mtl", ...);
+	 */
+	setPath: function ( path ) {
 
-		this.path = value;
+		this.path = path;
 
 	},
 
-	setBaseUrl: function( value ) {
+	/**
+	 * Set base path for resolving texture references.
+	 * If set this path will be prepended found texture reference.
+	 * If not set and setPath is, it will be used as texture base path.
+	 *
+	 * @see setPath
+	 * @param {String} path
+	 *
+	 * @example
+	 *     mtlLoader.setPath("assets/obj/");
+	 *     mtlLoader.setTexturePath("assets/textures/");
+	 *     mtlLoader.load("my.mtl", ...);
+	 */
+	setTexturePath: function( path ) {
 
-		// TODO: Merge with setPath()? Or rename to setTexturePath?
+		this.texturePath = path;
 
-		this.baseUrl = value;
+	},
+
+	setBaseUrl: function( path ) {
+
+		console.warn( 'THREE.MTLLoader: .setBaseUrl() is deprecated. Use .setTexturePath( path ) for texture path or .setPath( path ) for general base path instead.' );
+
+		this.setTexturePath( path );
 
 	},
 
@@ -110,7 +140,7 @@ THREE.MTLLoader.prototype = {
 
 		}
 
-		var materialCreator = new THREE.MTLLoader.MaterialCreator( this.baseUrl, this.materialOptions );
+		var materialCreator = new THREE.MTLLoader.MaterialCreator( this.texturePath || this.path, this.materialOptions );
 		materialCreator.setCrossOrigin( this.crossOrigin );
 		materialCreator.setManager( this.manager );
 		materialCreator.setMaterials( materialsInfo );
@@ -137,7 +167,7 @@ THREE.MTLLoader.prototype = {
 
 THREE.MTLLoader.MaterialCreator = function( baseUrl, options ) {
 
-	this.baseUrl = baseUrl;
+	this.baseUrl = baseUrl || "";
 	this.options = options;
 	this.materialsInfo = {};
 	this.materials = {};

--- a/examples/webgl_loader_obj_mtl.html
+++ b/examples/webgl_loader_obj_mtl.html
@@ -88,7 +88,6 @@
 				THREE.Loader.Handlers.add( /\.dds$/i, new THREE.DDSLoader() );
 
 				var mtlLoader = new THREE.MTLLoader();
-				mtlLoader.setBaseUrl( 'obj/male02/' );
 				mtlLoader.setPath( 'obj/male02/' );
 				mtlLoader.load( 'male02_dds.mtl', function( materials ) {
 


### PR DESCRIPTION
- Deprecate badly named `setBaseUrl` in favor of `setTexturePath`
- If `.path` is set but `.texturePath` is not, select `.path` to be passed into MaterialCreator.
- ~~If neither is set, try to auto detect base path from .mtl source URL. the `.load()` function now passes the source URL into `.parse()`.~~ (reverted)
- Don't override already found diffuse texture, makes behavior the same as bump map logic.
- Make single quotes consistent and other style cleanup.
- Add documentation to what setPath/setTexturePath actually do, also more to load/parse.
- These changes do not change previous behavior of the loader. Updating users will see a deprecation warning if their code calls `setBaseUrl` but the value is still set.
- Don't break parsed absolute URL texture references.

I think auto detecting the texture base path is pretty neat. You can go from this

``` js
mtlLoader.setPath("my/relative/path/");
// mandatory duplicate call for textures to load correctly
mtlLoader.setBaseUrl("my/relative/path/");
mtlLoader.load("my.mtl");
.... or
// mtl loads but textures break
mtlLoader.load("my/relative/path/my.mtl");
```

to

``` js
mtlLoader.setPath("my/relative/path/");
// explicit texture path not set, will use setPath as base
mtlLoader.load("my.mtl");
... or
// just works, texture path "my/relative/path/" resolved automatically
mtlLoader.load("my/relative/path/my.mtl");
```
