### PR TITLE
Update shaders of MMD

### DIFF
--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -3713,6 +3713,7 @@ THREE.ShaderLib[ 'mmd' ] = {
 		THREE.ShaderChunk[ "skinning_pars_vertex" ],
 		THREE.ShaderChunk[ "shadowmap_pars_vertex" ],
 		THREE.ShaderChunk[ "logdepthbuf_pars_vertex" ],
+		THREE.ShaderChunk[ "clipping_planes_pars_vertex" ],
 
 		// ---- MMD specific for outline drawing
 		"	uniform bool outlineDrawing;",
@@ -3743,6 +3744,7 @@ THREE.ShaderLib[ 'mmd' ] = {
 			THREE.ShaderChunk[ "skinning_vertex" ],
 			THREE.ShaderChunk[ "project_vertex" ],
 			THREE.ShaderChunk[ "logdepthbuf_vertex" ],
+			THREE.ShaderChunk[ "clipping_planes_vertex" ],
 
 		"	vViewPosition = - mvPosition.xyz;",
 
@@ -3776,6 +3778,7 @@ THREE.ShaderLib[ 'mmd' ] = {
 		"uniform float opacity;",
 
 		THREE.ShaderChunk[ "common" ],
+		THREE.ShaderChunk[ "packing" ],
 		THREE.ShaderChunk[ "color_pars_fragment" ],
 		THREE.ShaderChunk[ "uv_pars_fragment" ],
 		THREE.ShaderChunk[ "uv2_pars_fragment" ],
@@ -3794,6 +3797,7 @@ THREE.ShaderLib[ 'mmd' ] = {
 		THREE.ShaderChunk[ "normalmap_pars_fragment" ],
 		THREE.ShaderChunk[ "specularmap_pars_fragment" ],
 		THREE.ShaderChunk[ "logdepthbuf_pars_fragment" ],
+		THREE.ShaderChunk[ "clipping_planes_pars_fragment" ],
 
 		// ---- MMD specific for cel shading
 		"	uniform bool outlineDrawing;",
@@ -3815,7 +3819,13 @@ THREE.ShaderLib[ 'mmd' ] = {
 		"#undef RE_Direct",
 		"void RE_Direct_BlinnMMD( const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {",
 		"	float dotNL = saturate( dot( geometry.normal, directLight.direction ) );",
-		"	vec3 irradiance = dotNL * PI * directLight.color; // punctual light",
+		"	vec3 irradiance = dotNL * directLight.color;",
+
+		"	#ifndef PHYSICALLY_CORRECT_LIGHTS",
+
+		"		irradiance *= PI; // punctual light",
+
+		"	#endif",
 
 		// ---- MMD specific for toon mapping
 		"	if ( celShading ) {",
@@ -3827,6 +3837,7 @@ THREE.ShaderLib[ 'mmd' ] = {
 
 		"	reflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;",
 		"}",
+		// ---- MMD specific for toon mapping
 		"#define RE_Direct	RE_Direct_BlinnMMD",
 		// ---- MMD specific for toon mapping
 
@@ -3839,9 +3850,11 @@ THREE.ShaderLib[ 'mmd' ] = {
 		"	}",
 		// ---- MMD specific for outline drawing
 
+			THREE.ShaderChunk[ "clipping_planes_fragment" ],
+
 		"	vec4 diffuseColor = vec4( diffuse, opacity );",
 		"	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );",
-		"	vec3 totalEmissiveLight = emissive;",
+		"	vec3 totalEmissiveRadiance = emissive;",
 
 			THREE.ShaderChunk[ "logdepthbuf_fragment" ],
 			THREE.ShaderChunk[ "map_fragment" ],
@@ -3859,14 +3872,16 @@ THREE.ShaderLib[ 'mmd' ] = {
 			// modulation
 			THREE.ShaderChunk[ "aomap_fragment" ],
 
-			"vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveLight;",
+			"vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;",
 
 			THREE.ShaderChunk[ "envmap_fragment" ],
-			THREE.ShaderChunk[ "linear_to_gamma_fragment" ],
-
-			THREE.ShaderChunk[ "fog_fragment" ],
 
 		"	gl_FragColor = vec4( outgoingLight, diffuseColor.a );",
+
+			THREE.ShaderChunk[ "premultiplied_alpha_fragment" ],
+			THREE.ShaderChunk[ "tonemapping_fragment" ],
+			THREE.ShaderChunk[ "encodings_fragment" ],
+			THREE.ShaderChunk[ "fog_fragment" ],
 
 		"}"
 


### PR DESCRIPTION
I've updated MMDMaterial shaders to follow MeshPhongMaterial's.
With this update the shader compile error which occurs if trying to render shadow will be fixed.

I think I seriously need a way to automatically follow MeshPhongMaterials shaders...
