### PR TITLE
Add support of camera zoom to CSS3DRenderer

### DIFF
--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -212,7 +212,7 @@ THREE.CSS3DRenderer = function () {
 
 	this.render = function ( scene, camera ) {
 
-		var fov = 0.5 / Math.tan( THREE.Math.degToRad( camera.fov * 0.5 ) ) * _height;
+		var fov = 0.5 / Math.tan( THREE.Math.degToRad( camera.getEffectiveFOV() * 0.5 ) ) * _height;
 
 		if ( cache.camera.fov !== fov ) {
 


### PR DESCRIPTION
If we use zoom, `camera.fov` is not change. By replacing `camera.fov` by `camera.getEffectiveFOV`, the correct FOV is get.
