### PR TITLE
Fix variable typo. (I think.)

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -68,7 +68,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	this.setSize = function ( width, height ) {
 
-		renderSize = { width: width, height: height };
+		rendererSize = { width: width, height: height };
 
 		if ( isPresenting ) {
 


### PR DESCRIPTION
`renderSize` doesn't exist anywhere else. Assuming this is supposed to be `rendererSize`?
