### PR TITLE
remove the usage of arguments in setFromMatrixColumn

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -188,7 +188,7 @@ Object.defineProperties( THREE.Vector3.prototype, {
 	getColumnFromMatrix: {
 		value: function ( index, matrix ) {
 			console.warn( 'THREE.Vector3: .getColumnFromMatrix() has been renamed to .setFromMatrixColumn().' );
-			return this.setFromMatrixColumn( index, matrix );
+			return this.setFromMatrixColumn( matrix, index );
 		}
 	}
 } );

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -706,9 +706,9 @@ THREE.Vector3.prototype = {
 		if ( typeof m === 'number' ) {
 
 			console.warn( 'THREE.Vector3: setFromMatrixColumn now expects ( matrix, index ).' );
-
-			m = arguments[ 1 ];
-			index = arguments[ 0 ];
+			var temp = m
+			m = index;
+			index = temp;
 
 		}
 


### PR DESCRIPTION
This removes a small unoptimised function from Three.js.

![image](https://cloud.githubusercontent.com/assets/155535/14760184/e8f94cda-093c-11e6-9bb8-601c57a7ffb5.png)
