### PR TITLE
Remove arguments to allow optimalisations

### DIFF
--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -34,12 +34,12 @@
 		b - THe blue component of the color if it is defined. 
 		</div>
 		<div>
-		All arguments are optional. The default color is White.
-		When all arguments are defined then r is the red component, g is the green component and b is the blue component of the color.
-		When only r is defined:
+		All arguments are optional. The default color is White.<br />
+		When all arguments are defined then r is the red component, g is the green component and b is the blue component of the color.<br />
+		When only r is defined:<br />
 		<ul>
-			<li>It can be a hexadecimal of the color</li>
-			<li>It can be an another color instance</li>
+			<li>It can be a hexadecimal of the color.</li>
+			<li>It can be an another color instance.</li>
 			<li>It can be a CSS style. For Instance:
 				<ul>
 					<li>rgb(250, 0,0)</li>

--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -31,7 +31,7 @@
 		<div>
 		r - the red component of the color if arguments g and b are defined. If they are not defined, it can be a hexadecimal or a CSS-style string or a Color instance.<br />
 		g - The green component of the color if it is defined.<br />
-		b - THe blue component of the color if it is defined. 
+		b - The blue component of the color if it is defined. 
 		</div>
 		<div>
 		All arguments are optional. The default color is White.<br />

--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -27,9 +27,31 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( value )</h3>
+		<h3>[name]( r, g, b )</h3>
 		<div>
-		value — optional argument that sets initial color.  Can be a hexadecimal or a CSS-style string, for example, "rgb(250, 0,0)", "rgb(100%,0%,0%)", "hsl(0, 100%, 50%)", "#ff0000", "#f00", or "red", or three arguments that represent color channels.
+		r - the red component of the color if arguments g and b are defined. If they are not defined, it can be a hexadecimal or a CSS-style string or a Color instance.
+		g - The green component of the color if it is defined.
+		b - THe blue component of the color if it is defined. 
+		</div>
+		<div>
+		All arguments are optional. The default color is White.
+		When all arguments are defined then r is the red component, g is the green component and b is the blue component of the color.
+		When only r is defined:
+		<ul>
+			<li>It can be a hexadecimal of the color</li>
+			<li>It can be an another color instance</li>
+			<li>It can be a CSS style. For Instance:
+				<ul>
+					<li>rgb(250, 0,0)</li>
+					<li>rgb(100%,0%,0%)</li>
+					<li>hsl(0, 100%, 50%)</li>
+					<li>#ff0000</li>
+					<li>#f00</li>
+					<li>red</li>
+				</ul>
+			
+			</li>
+		</ul>
 		</div>
 
 		<h2>Properties</h2>

--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -29,8 +29,8 @@
 
 		<h3>[name]( r, g, b )</h3>
 		<div>
-		r - the red component of the color if arguments g and b are defined. If they are not defined, it can be a hexadecimal or a CSS-style string or a Color instance.
-		g - The green component of the color if it is defined.
+		r - the red component of the color if arguments g and b are defined. If they are not defined, it can be a hexadecimal or a CSS-style string or a Color instance.<br />
+		g - The green component of the color if it is defined.<br />
 		b - THe blue component of the color if it is defined. 
 		</div>
 		<div>

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -2,7 +2,7 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.Color = function ( rOrColor, g, b ) {
+THREE.Color = function ( r, g, b ) {
 
     if ( g === undefined && b === undefined ) {
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -2,15 +2,15 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.Color = function ( color ) {
+THREE.Color = function ( rOrColor, g, b ) {
 
-	if ( arguments.length === 3 ) {
+	if ( g !== undefined ) {
 
-		return this.fromArray( arguments );
+		return this.setRGB( rOrColor, g, b );
 
 	}
 
-	return this.set( color );
+	return this.set( rOrColor );
 
 };
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -4,13 +4,14 @@
 
 THREE.Color = function ( rOrColor, g, b ) {
 
-	if ( g !== undefined ) {
+    if ( g === undefined && b === undefined ) {
 
-		return this.setRGB( rOrColor, g, b );
+        // r is THREE.Color, hex or string
+        return this.set( r );
 
-	}
+    }
 
-	return this.set( rOrColor );
+    return this.setRGB( r, g, b );
 
 };
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -4,14 +4,14 @@
 
 THREE.Color = function ( r, g, b ) {
 
-    if ( g === undefined && b === undefined ) {
+	if ( g === undefined && b === undefined ) {
 
-        // r is THREE.Color, hex or string
-        return this.set( r );
+		// r is THREE.Color, hex or string
+		return this.set( r );
 
-    }
+	}
 
-    return this.setRGB( r, g, b );
+	return this.setRGB( r, g, b );
 
 };
 


### PR DESCRIPTION
This cleans up the color construstor to allow optimalisations. 

![image](https://cloud.githubusercontent.com/assets/155535/14760902/82bb73a8-0950-11e6-806e-0f91665509e6.png)
