### PR TITLE
compute reference plane on the fly for draggable cube example

### DIFF
--- a/docs/api/math/Plane.html
+++ b/docs/api/math/Plane.html
@@ -78,6 +78,15 @@
 		Returns a vector in the same direction as the Plane's normal, but the magnitude is passed point's original distance to the plane.
 		</div>
 
+		<h3>[method:Vector3 intersectRay]([page:Ray ray], [page:Vector3 optionalTarget]) or [page:undefined]</h3>
+		<div>
+		ray -- [page:Ray] <br />
+		optionalTarget -- [page:Vector3]
+		</div>
+		<div>
+		Returns the intersection point of the passed ray and the plane. Returns undefined if the line does not intersect. Returns the ray's starting point if the line is coplanar with the plane.
+		</div>
+
 		<h3>[method:Boolean intersectsLine]([page:Line3 line])</h3>
 		<div>
 		line -- [page:Line3]

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -219,6 +219,11 @@
 						INTERSECTED = intersects[ 0 ].object;
 						INTERSECTED.currentHex = INTERSECTED.material.color.getHex();
 
+            plane = {
+              origin: new THREE.Vector3().copy(INTERSECTED.position),
+              direction: new THREE.Vector3().copy(camera.position).sub(INTERSECTED.position)
+            }
+
 					}
 
 					container.style.cursor = 'pointer';
@@ -248,12 +253,6 @@
 					controls.enabled = false;
 
 					SELECTED = intersects[ 0 ].object;
-
-          // generate plane!
-          plane = {
-          	origin: intersects[ 0 ].point,
-          	direction: raycaster.ray.direction.clone().negate()
-          }
 
           var intersection = rayPlaneIntersection(raycaster.ray, plane);
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -29,6 +29,7 @@
 			var plane = new THREE.Plane();
 			var raycaster = new THREE.Raycaster();
 			var mouse = new THREE.Vector2(),
+			offset = new THREE.Vector3(),
 			INTERSECTED, SELECTED;
 
 			init();
@@ -150,7 +151,7 @@
 
 					if ( intersection ) {
 
-						SELECTED.position.copy( intersection );
+						SELECTED.position.copy( intersection ).sub( offset );
 
 					}
 
@@ -202,6 +203,14 @@
 					controls.enabled = false;
 
 					SELECTED = intersects[ 0 ].object;
+
+					var intersection = plane.intersectRay(raycaster.ray);
+
+					if ( intersection ) {
+
+						offset.copy( intersection ).sub( SELECTED.position );
+
+					}
 
 					container.style.cursor = 'move';
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -26,13 +26,10 @@
 			var container, stats;
 			var camera, controls, scene, renderer;
 			var objects = [];
-			var plane = {
-				origin: new THREE.Vector3(),
-				direction: new THREE.Vector3()
-			}
+			var line = new THREE.Line3();
+			var plane = new THREE.Plane();
 			var raycaster = new THREE.Raycaster();
 			var mouse = new THREE.Vector2(),
-			offset = new THREE.Vector3(),
 			INTERSECTED, SELECTED;
 
 			init();
@@ -139,55 +136,6 @@
 
 			}
 
-			function rayPlaneIntersection(ray, plane) {
-				// ray: {origin, direction}
-				// plane: {origin, direction}
-				//
-				// LOGIC:
-				//
-				// Ray equation: P = P0 + tV
-				// P = <Px, Py, Pz>
-				// P0 = <ray.position.x, ray.position.y, ray.position.z>
-				// V = <ray.direction.x, ray.direction.y, ray.direction.z>
-				//
-				// Therefore:
-				// Px = ray.position.x + t*ray.direction.x
-				// Py = ray.position.y + t*ray.direction.y
-				// Pz = ray.position.z + t*ray.direction.z
-				//
-				//
-				//
-				// Plane equation: ax + by + cz + d = 0
-				// a = plane.direction.x
-				// b = plane.direction.y
-				// c = plane.direction.z
-				// d = -( plane.direction.x*plane.position.x +
-				//				plane.direction.y*plane.position.y +
-				//				plane.direction.z*plane.position.z )
-				//
-				//
-				// 1- in the plane equation, we replace x, y and z by Px, Py and Pz
-				// 2- find t
-				// 3- replace t in Px, Py and Pz to get the coordinate of the intersection
-				//
-
-				if (ray.direction.dot(plane.direction) !== 0) {
-
-					let t = (plane.direction.x * (plane.origin.x - ray.origin.x) + plane.direction.y * (plane.origin.y - ray.origin.y) + plane.direction.z * (plane.origin.z - ray.origin.z)) /
-						(plane.direction.x * ray.direction.x + plane.direction.y * ray.direction.y + plane.direction.z * ray.direction.z);
-
-					let intersection = new THREE.Vector3(
-						ray.origin.x + t * ray.direction.x,
-						ray.origin.y + t * ray.direction.y,
-						ray.origin.z + t * ray.direction.z);
-
-					return intersection;
-
-				}
-
-				return null;
-			}
-
 			function onDocumentMouseMove( event ) {
 
 				event.preventDefault();
@@ -199,10 +147,11 @@
 
 				if ( SELECTED ) {
 
-					var intersection = rayPlaneIntersection(raycaster.ray, plane);
+					var intersection = plane.intersectRay(raycaster.ray);
+
 					if ( intersection != null ) {
 
-						SELECTED.position.copy( intersection.sub( offset ) );
+						SELECTED.position.copy( intersection );
 
 					}
 
@@ -221,8 +170,9 @@
 						INTERSECTED = intersects[ 0 ].object;
 						INTERSECTED.currentHex = INTERSECTED.material.color.getHex();
 
-						plane.origin.copy(INTERSECTED.position);
-						plane.direction.copy( camera.getWorldDirection() );
+						plane.setFromNormalAndCoplanarPoint(
+							camera.getWorldDirection(),
+							INTERSECTED.position);
 
 					}
 
@@ -254,14 +204,6 @@
 
 					SELECTED = intersects[ 0 ].object;
 
-					var intersection = rayPlaneIntersection(raycaster.ray, plane);
-
-					if ( intersection != null ) {
-
-						offset.copy( intersection ).sub( plane.origin );
-
-					}
-
 					container.style.cursor = 'move';
 
 				}
@@ -275,8 +217,6 @@
 				controls.enabled = true;
 
 				if ( INTERSECTED ) {
-
-					plane.origin.copy(INTERSECTED.position);
 
 					SELECTED = null;
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -137,52 +137,53 @@
 			}
 
 			function rayPlaneIntersection(ray, plane) {
-      // ray: {origin, direction}
-      // plane: {origin, direction}
-      //
-      // LOGIC:
-      //
-      // Ray equation: P = P0 + tV
-      // P = <Px, Py, Pz>
-      // P0 = <ray.position.x, ray.position.y, ray.position.z>
-      // V = <ray.direction.x, ray.direction.y, ray.direction.z>
-      //
-      // Therefore:
-      // Px = ray.position.x + t*ray.direction.x
-      // Py = ray.position.y + t*ray.direction.y
-      // Pz = ray.position.z + t*ray.direction.z
-      //
-      //
-      //
-      // Plane equation: ax + by + cz + d = 0
-      // a = plane.direction.x
-      // b = plane.direction.y
-      // c = plane.direction.z
-      // d = -( plane.direction.x*plane.position.x +
-      //        plane.direction.y*plane.position.y +
-      //        plane.direction.z*plane.position.z )
-      //
-      //
-      // 1- in the plane equation, we replace x, y and z by Px, Py and Pz
-      // 2- find t
-      // 3- replace t in Px, Py and Pz to get the coordinate of the intersection
-      //
+        // ray: {origin, direction}
+        // plane: {origin, direction}
+        //
+        // LOGIC:
+        //
+        // Ray equation: P = P0 + tV
+        // P = <Px, Py, Pz>
+        // P0 = <ray.position.x, ray.position.y, ray.position.z>
+        // V = <ray.direction.x, ray.direction.y, ray.direction.z>
+        //
+        // Therefore:
+        // Px = ray.position.x + t*ray.direction.x
+        // Py = ray.position.y + t*ray.direction.y
+        // Pz = ray.position.z + t*ray.direction.z
+        //
+        //
+        //
+        // Plane equation: ax + by + cz + d = 0
+        // a = plane.direction.x
+        // b = plane.direction.y
+        // c = plane.direction.z
+        // d = -( plane.direction.x*plane.position.x +
+        //        plane.direction.y*plane.position.y +
+        //        plane.direction.z*plane.position.z )
+        //
+        //
+        // 1- in the plane equation, we replace x, y and z by Px, Py and Pz
+        // 2- find t
+        // 3- replace t in Px, Py and Pz to get the coordinate of the intersection
+        //
 
-      if (ray.direction.dot(plane.direction) !== 0) {
+        if (ray.direction.dot(plane.direction) !== 0) {
 
-        let t = (plane.direction.x * (plane.origin.x - ray.origin.x) + plane.direction.y * (plane.origin.y - ray.origin.y) + plane.direction.z * (plane.origin.z - ray.origin.z)) /
-        (plane.direction.x * ray.direction.x + plane.direction.y * ray.direction.y + plane.direction.z * ray.direction.z);
+          let t = (plane.direction.x * (plane.origin.x - ray.origin.x) + plane.direction.y * (plane.origin.y - ray.origin.y) + plane.direction.z * (plane.origin.z - ray.origin.z)) /
+          (plane.direction.x * ray.direction.x + plane.direction.y * ray.direction.y + plane.direction.z * ray.direction.z);
 
-        let intersection = new THREE.Vector3(
-          ray.origin.x + t * ray.direction.x,
-          ray.origin.y + t * ray.direction.y,
-          ray.origin.z + t * ray.direction.z);
+          let intersection = new THREE.Vector3(
+            ray.origin.x + t * ray.direction.x,
+            ray.origin.y + t * ray.direction.y,
+            ray.origin.z + t * ray.direction.z);
 
-        return intersection;
+          return intersection;
 
-      }
+        }
 
-      return null;
+        return null;
+        
       }
 
 			function onDocumentMouseMove( event ) {

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -150,7 +150,7 @@
 
 					if ( plane.intersectRay( raycaster.ray, intersection ) ) {
 
-						SELECTED.position.copy( intersection ).sub( offset );
+						SELECTED.position.copy( intersection.sub( offset ) );
 
 					}
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -137,54 +137,54 @@
 			}
 
 			function rayPlaneIntersection(ray, plane) {
-        // ray: {origin, direction}
-        // plane: {origin, direction}
-        //
-        // LOGIC:
-        //
-        // Ray equation: P = P0 + tV
-        // P = <Px, Py, Pz>
-        // P0 = <ray.position.x, ray.position.y, ray.position.z>
-        // V = <ray.direction.x, ray.direction.y, ray.direction.z>
-        //
-        // Therefore:
-        // Px = ray.position.x + t*ray.direction.x
-        // Py = ray.position.y + t*ray.direction.y
-        // Pz = ray.position.z + t*ray.direction.z
-        //
-        //
-        //
-        // Plane equation: ax + by + cz + d = 0
-        // a = plane.direction.x
-        // b = plane.direction.y
-        // c = plane.direction.z
-        // d = -( plane.direction.x*plane.position.x +
-        //        plane.direction.y*plane.position.y +
-        //        plane.direction.z*plane.position.z )
-        //
-        //
-        // 1- in the plane equation, we replace x, y and z by Px, Py and Pz
-        // 2- find t
-        // 3- replace t in Px, Py and Pz to get the coordinate of the intersection
-        //
+        			// ray: {origin, direction}
+        			// plane: {origin, direction}
+        			//
+        			// LOGIC:
+        			//
+				// Ray equation: P = P0 + tV
+        			// P = <Px, Py, Pz>
+        			// P0 = <ray.position.x, ray.position.y, ray.position.z>
+        			// V = <ray.direction.x, ray.direction.y, ray.direction.z>
+        			//
+        			// Therefore:
+        			// Px = ray.position.x + t*ray.direction.x
+        			// Py = ray.position.y + t*ray.direction.y
+        			// Pz = ray.position.z + t*ray.direction.z
+        			//
+        			//
+        			//
+        			// Plane equation: ax + by + cz + d = 0
+				// a = plane.direction.x
+        			// b = plane.direction.y
+        			// c = plane.direction.z
+        			// d = -( plane.direction.x*plane.position.x +
+        			//        plane.direction.y*plane.position.y +
+        			//        plane.direction.z*plane.position.z )
+        			//
+        			//
+        			// 1- in the plane equation, we replace x, y and z by Px, Py and Pz
+        			// 2- find t
+        			// 3- replace t in Px, Py and Pz to get the coordinate of the intersection
+        			//
 
-        if (ray.direction.dot(plane.direction) !== 0) {
+        			if (ray.direction.dot(plane.direction) !== 0) {
 
-          let t = (plane.direction.x * (plane.origin.x - ray.origin.x) + plane.direction.y * (plane.origin.y - ray.origin.y) + plane.direction.z * (plane.origin.z - ray.origin.z)) /
-          (plane.direction.x * ray.direction.x + plane.direction.y * ray.direction.y + plane.direction.z * ray.direction.z);
+        				let t = (plane.direction.x * (plane.origin.x - ray.origin.x) + plane.direction.y * (plane.origin.y - ray.origin.y) + plane.direction.z * (plane.origin.z - ray.origin.z)) /
+        					(plane.direction.x * ray.direction.x + plane.direction.y * ray.direction.y + plane.direction.z * ray.direction.z);
 
-          let intersection = new THREE.Vector3(
-            ray.origin.x + t * ray.direction.x,
-            ray.origin.y + t * ray.direction.y,
-            ray.origin.z + t * ray.direction.z);
+        				let intersection = new THREE.Vector3(
+        					ray.origin.x + t * ray.direction.x,
+        					ray.origin.y + t * ray.direction.y,
+        					ray.origin.z + t * ray.direction.z);
 
-          return intersection;
+        				return intersection;
 
-        }
+        			}
 
-        return null;
+        			return null;
         
-      }
+      			}
 
 			function onDocumentMouseMove( event ) {
 
@@ -249,17 +249,17 @@
 
 					SELECTED = intersects[ 0 ].object;
 
-          // generate plane!
-          plane = {
-          	origin: intersects[ 0 ].point,
-          	direction: raycaster.ray.direction.clone().negate()
-          }
+        				// generate plane!
+        				plane = {
+          					origin: intersects[ 0 ].point,
+          					direction: raycaster.ray.direction.clone().negate()
+        				}
 
-          var intersection = rayPlaneIntersection(raycaster.ray, plane);
+        				var intersection = rayPlaneIntersection(raycaster.ray, plane);
 
 					if ( intersection != null ) {
 
-					  offset.copy( intersection ).sub( plane.origin );
+						offset.copy( intersection ).sub( plane.origin );
 
 					}
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -26,7 +26,6 @@
 			var container, stats;
 			var camera, controls, scene, renderer;
 			var objects = [];
-			var line = new THREE.Line3();
 			var plane = new THREE.Plane();
 			var raycaster = new THREE.Raycaster();
 			var mouse = new THREE.Vector2(),

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -222,7 +222,7 @@
 						INTERSECTED.currentHex = INTERSECTED.material.color.getHex();
 
 						plane.origin.copy(INTERSECTED.position);
-						plane.direction.set(0, 0, - 1).applyQuaternion( camera.quaternion );
+						plane.direction.copy( camera.getWorldDirection() );
 
 					}
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -277,6 +277,8 @@
 
 				if ( INTERSECTED ) {
 
+					plane.origin.copy(INTERSECTED.position);
+
 					SELECTED = null;
 
 				}

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -148,7 +148,7 @@
 
 					var intersection = plane.intersectRay(raycaster.ray);
 
-					if ( intersection != null ) {
+					if ( intersection ) {
 
 						SELECTED.position.copy( intersection );
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -30,7 +30,6 @@
 				origin: new THREE.Vector3(),
 				direction: new THREE.Vector3()
 			}
-
 			var raycaster = new THREE.Raycaster();
 			var mouse = new THREE.Vector2(),
 			offset = new THREE.Vector3(),
@@ -223,7 +222,7 @@
 						INTERSECTED.currentHex = INTERSECTED.material.color.getHex();
 
 						plane.origin.copy(INTERSECTED.position);
-						plane.direction.copy(camera.position).sub(INTERSECTED.position);
+						plane.direction.copy(camera.position).sub(controls.target);
 
 					}
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -95,12 +95,6 @@
 
 				}
 
-				plane = new THREE.Mesh(
-					new THREE.PlaneBufferGeometry( 2000, 2000, 8, 8 ),
-					new THREE.MeshBasicMaterial( { visible: false } )
-				);
-				scene.add( plane );
-
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setClearColor( 0xf0f0f0 );
 				renderer.setPixelRatio( window.devicePixelRatio );
@@ -142,6 +136,55 @@
 
 			}
 
+			function rayPlaneIntersection(ray, plane) {
+      // ray: {origin, direction}
+      // plane: {origin, direction}
+      //
+      // LOGIC:
+      //
+      // Ray equation: P = P0 + tV
+      // P = <Px, Py, Pz>
+      // P0 = <ray.position.x, ray.position.y, ray.position.z>
+      // V = <ray.direction.x, ray.direction.y, ray.direction.z>
+      //
+      // Therefore:
+      // Px = ray.position.x + t*ray.direction.x
+      // Py = ray.position.y + t*ray.direction.y
+      // Pz = ray.position.z + t*ray.direction.z
+      //
+      //
+      //
+      // Plane equation: ax + by + cz + d = 0
+      // a = plane.direction.x
+      // b = plane.direction.y
+      // c = plane.direction.z
+      // d = -( plane.direction.x*plane.position.x +
+      //        plane.direction.y*plane.position.y +
+      //        plane.direction.z*plane.position.z )
+      //
+      //
+      // 1- in the plane equation, we replace x, y and z by Px, Py and Pz
+      // 2- find t
+      // 3- replace t in Px, Py and Pz to get the coordinate of the intersection
+      //
+
+      if (ray.direction.dot(plane.direction) !== 0) {
+
+        let t = (plane.direction.x * (plane.origin.x - ray.origin.x) + plane.direction.y * (plane.origin.y - ray.origin.y) + plane.direction.z * (plane.origin.z - ray.origin.z)) /
+        (plane.direction.x * ray.direction.x + plane.direction.y * ray.direction.y + plane.direction.z * ray.direction.z);
+
+        let intersection = new THREE.Vector3(
+          ray.origin.x + t * ray.direction.x,
+          ray.origin.y + t * ray.direction.y,
+          ray.origin.z + t * ray.direction.z);
+
+        return intersection;
+
+      }
+
+      return null;
+      }
+
 			function onDocumentMouseMove( event ) {
 
 				event.preventDefault();
@@ -149,17 +192,14 @@
 				mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
 				mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
 
-				//
-
 				raycaster.setFromCamera( mouse, camera );
 
 				if ( SELECTED ) {
 
-					var intersects = raycaster.intersectObject( plane );
+					var intersection = rayPlaneIntersection(raycaster.ray, plane);
+					if ( intersection != null ) {
 
-					if ( intersects.length > 0 ) {
-
-						SELECTED.position.copy( intersects[ 0 ].point.sub( offset ) );
+						SELECTED.position.copy( intersection.sub( offset ) );
 
 					}
 
@@ -177,9 +217,6 @@
 
 						INTERSECTED = intersects[ 0 ].object;
 						INTERSECTED.currentHex = INTERSECTED.material.color.getHex();
-
-						plane.position.copy( INTERSECTED.position );
-						plane.lookAt( camera.position );
 
 					}
 
@@ -211,11 +248,17 @@
 
 					SELECTED = intersects[ 0 ].object;
 
-					var intersects = raycaster.intersectObject( plane );
+          // generate plane!
+          plane = {
+          	origin: intersects[ 0 ].point,
+          	direction: raycaster.ray.direction.clone().negate()
+          }
 
-					if ( intersects.length > 0 ) {
+          var intersection = rayPlaneIntersection(raycaster.ray, plane);
 
-						offset.copy( intersects[ 0 ].point ).sub( plane.position );
+					if ( intersection != null ) {
+
+					  offset.copy( intersection ).sub( plane.origin );
 
 					}
 
@@ -232,8 +275,6 @@
 				controls.enabled = true;
 
 				if ( INTERSECTED ) {
-
-					plane.position.copy( INTERSECTED.position );
 
 					SELECTED = null;
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -222,7 +222,7 @@
 						INTERSECTED.currentHex = INTERSECTED.material.color.getHex();
 
 						plane.origin.copy(INTERSECTED.position);
-						plane.direction.copy(camera.position).sub(controls.target);
+						plane.direction.set(0, 0, - 1).applyQuaternion( camera.quaternion );
 
 					}
 

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -30,6 +30,7 @@
 			var raycaster = new THREE.Raycaster();
 			var mouse = new THREE.Vector2(),
 			offset = new THREE.Vector3(),
+			intersection = new THREE.Vector3(),
 			INTERSECTED, SELECTED;
 
 			init();
@@ -147,9 +148,7 @@
 
 				if ( SELECTED ) {
 
-					var intersection = plane.intersectRay(raycaster.ray);
-
-					if ( intersection ) {
+					if ( plane.intersectRay( raycaster.ray, intersection ) ) {
 
 						SELECTED.position.copy( intersection ).sub( offset );
 
@@ -171,8 +170,8 @@
 						INTERSECTED.currentHex = INTERSECTED.material.color.getHex();
 
 						plane.setFromNormalAndCoplanarPoint(
-							camera.getWorldDirection(),
-							INTERSECTED.position);
+							camera.getWorldDirection( plane.normal ),
+							INTERSECTED.position );
 
 					}
 
@@ -204,9 +203,7 @@
 
 					SELECTED = intersects[ 0 ].object;
 
-					var intersection = plane.intersectRay(raycaster.ray);
-
-					if ( intersection ) {
+					if ( plane.intersectRay( raycaster.ray, intersection ) ) {
 
 						offset.copy( intersection ).sub( SELECTED.position );
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -131,7 +131,7 @@ THREE.Plane.prototype = {
 			direction: this.normal
 		}
 
-		// if not complanar, there is an intersection
+		// if ray and plane not complanar, there is an intersection
 		if (ray.direction.dot(plane.direction) !== 0) {
 
 			var t = (plane.direction.x * (plane.origin.x - ray.origin.x) + plane.direction.y * (plane.origin.y - ray.origin.y) + plane.direction.z * (plane.origin.z - ray.origin.z)) /
@@ -146,18 +146,18 @@ THREE.Plane.prototype = {
 
 		}
 		else{
-			  // ray & plane are coplanar
-				if ( this.distanceToPoint( ray.origin ) === 0 ) {
+			if ( this.distanceToPoint( ray.origin ) === 0 ) {
 
-					return result.copy( ray.origin );
+				// ray & plane are coplanar
+				return result.copy( ray.origin );
 
-				}
+			}
+			else{
+
 				// no intersection
-				else{
+				return undefined;
 
-					return undefined;
-
-				}
+			}
 
 		}
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -122,6 +122,47 @@ THREE.Plane.prototype = {
 
 	},
 
+	intersectRay: function(ray, optionalTarget){
+
+		var result = optionalTarget || new THREE.Vector3();
+
+		var plane = {
+			origin: this.coplanarPoint(),
+			direction: this.normal
+		}
+
+		// if not complanar, there is an intersection
+		if (ray.direction.dot(plane.direction) !== 0) {
+
+			var t = (plane.direction.x * (plane.origin.x - ray.origin.x) + plane.direction.y * (plane.origin.y - ray.origin.y) + plane.direction.z * (plane.origin.z - ray.origin.z)) /
+				(plane.direction.x * ray.direction.x + plane.direction.y * ray.direction.y + plane.direction.z * ray.direction.z);
+
+			var intersection = new THREE.Vector3(
+				ray.origin.x + t * ray.direction.x,
+				ray.origin.y + t * ray.direction.y,
+				ray.origin.z + t * ray.direction.z);
+
+			return result.copy(intersection);
+
+		}
+		else{
+			  // ray & plane are coplanar
+				if ( this.distanceToPoint( ray.origin ) === 0 ) {
+
+					return result.copy( ray.origin );
+
+				}
+				// no intersection
+				else{
+
+					return undefined;
+
+				}
+
+		}
+
+	},
+
 	intersectLine: function () {
 
 		var v1 = new THREE.Vector3();

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -2,7 +2,7 @@
  * @author bhouston / http://clara.io
  */
 
-THREE.Plane = function ( normal, constant ) {
+THREE.Plane = function( normal, constant ) {
 
 	this.normal = ( normal !== undefined ) ? normal : new THREE.Vector3( 1, 0, 0 );
 	this.constant = ( constant !== undefined ) ? constant : 0;
@@ -13,7 +13,7 @@ THREE.Plane.prototype = {
 
 	constructor: THREE.Plane,
 
-	set: function ( normal, constant ) {
+	set: function( normal, constant ) {
 
 		this.normal.copy( normal );
 		this.constant = constant;
@@ -22,7 +22,7 @@ THREE.Plane.prototype = {
 
 	},
 
-	setComponents: function ( x, y, z, w ) {
+	setComponents: function( x, y, z, w ) {
 
 		this.normal.set( x, y, z );
 		this.constant = w;
@@ -31,7 +31,7 @@ THREE.Plane.prototype = {
 
 	},
 
-	setFromNormalAndCoplanarPoint: function ( normal, point ) {
+	setFromNormalAndCoplanarPoint: function( normal, point ) {
 
 		this.normal.copy( normal );
 		this.constant = - point.dot( this.normal );	// must be this.normal, not normal, as this.normal is normalized
@@ -40,12 +40,12 @@ THREE.Plane.prototype = {
 
 	},
 
-	setFromCoplanarPoints: function () {
+	setFromCoplanarPoints: function() {
 
 		var v1 = new THREE.Vector3();
 		var v2 = new THREE.Vector3();
 
-		return function ( a, b, c ) {
+		return function( a, b, c ) {
 
 			var normal = v1.subVectors( c, b ).cross( v2.subVectors( a, b ) ).normalize();
 
@@ -59,13 +59,13 @@ THREE.Plane.prototype = {
 
 	}(),
 
-	clone: function () {
+	clone: function() {
 
 		return new this.constructor().copy( this );
 
 	},
 
-	copy: function ( plane ) {
+	copy: function( plane ) {
 
 		this.normal.copy( plane.normal );
 		this.constant = plane.constant;
@@ -74,7 +74,7 @@ THREE.Plane.prototype = {
 
 	},
 
-	normalize: function () {
+	normalize: function() {
 
 		// Note: will lead to a divide by zero if the plane is invalid.
 
@@ -86,7 +86,7 @@ THREE.Plane.prototype = {
 
 	},
 
-	negate: function () {
+	negate: function() {
 
 		this.constant *= - 1;
 		this.normal.negate();
@@ -95,25 +95,25 @@ THREE.Plane.prototype = {
 
 	},
 
-	distanceToPoint: function ( point ) {
+	distanceToPoint: function( point ) {
 
 		return this.normal.dot( point ) + this.constant;
 
 	},
 
-	distanceToSphere: function ( sphere ) {
+	distanceToSphere: function( sphere ) {
 
 		return this.distanceToPoint( sphere.center ) - sphere.radius;
 
 	},
 
-	projectPoint: function ( point, optionalTarget ) {
+	projectPoint: function( point, optionalTarget ) {
 
 		return this.orthoPoint( point, optionalTarget ).sub( point ).negate();
 
 	},
 
-	orthoPoint: function ( point, optionalTarget ) {
+	orthoPoint: function( point, optionalTarget ) {
 
 		var perpendicularMagnitude = this.distanceToPoint( point );
 
@@ -122,52 +122,56 @@ THREE.Plane.prototype = {
 
 	},
 
-	intersectRay: function(ray, optionalTarget){
+	intersectRay: function( ) {
 
-		var result = optionalTarget || new THREE.Vector3();
+		var origin = new THREE.Vector3();
 
-		var plane = {
-			origin: this.coplanarPoint(),
-			direction: this.normal
-		}
+		return function( ray, optionalTarget ) {
 
-		// if ray and plane not complanar, there is an intersection
-		if (ray.direction.dot(plane.direction) !== 0) {
+			var result = optionalTarget || new THREE.Vector3( );
 
-			var t = (plane.direction.x * (plane.origin.x - ray.origin.x) + plane.direction.y * (plane.origin.y - ray.origin.y) + plane.direction.z * (plane.origin.z - ray.origin.z)) /
-				(plane.direction.x * ray.direction.x + plane.direction.y * ray.direction.y + plane.direction.z * ray.direction.z);
+			this.coplanarPoint( origin );
 
-			var intersection = new THREE.Vector3(
-				ray.origin.x + t * ray.direction.x,
-				ray.origin.y + t * ray.direction.y,
-				ray.origin.z + t * ray.direction.z);
+			// if ray and plane not complanar, there is an intersection
+			if ( ray.direction.dot( this.normal ) !== 0 ) {
 
-			return result.copy(intersection);
+				var t = ( this.normal.x * ( origin.x - ray.origin.x ) + this.normal.y * ( origin.y - ray.origin.y ) + this.normal.z * ( origin.z - ray.origin.z ) ) /
+					( this.normal.x * ray.direction.x + this.normal.y * ray.direction.y + this.normal.z * ray.direction.z );
 
-		}
-		else{
-			if ( this.distanceToPoint( ray.origin ) === 0 ) {
+				result.set(
+					ray.origin.x + t * ray.direction.x,
+					ray.origin.y + t * ray.direction.y,
+					ray.origin.z + t * ray.direction.z );
 
-				// ray & plane are coplanar
-				return result.copy( ray.origin );
+				return result.copy( intersection );
 
 			}
-			else{
+			else {
 
-				// no intersection
-				return undefined;
+				if ( this.distanceToPoint( ray.origin ) === 0 ) {
+
+					// ray & plane are coplanar
+					return result.copy( ray.origin );
+
+				}
+				else {
+
+					// no intersection
+					return undefined;
+
+				}
 
 			}
 
-		}
+		};
 
-	},
+	}(),
 
-	intersectLine: function () {
+	intersectLine: function() {
 
 		var v1 = new THREE.Vector3();
 
-		return function ( line, optionalTarget ) {
+		return function( line, optionalTarget ) {
 
 			var result = optionalTarget || new THREE.Vector3();
 
@@ -203,7 +207,7 @@ THREE.Plane.prototype = {
 
 	}(),
 
-	intersectsLine: function ( line ) {
+	intersectsLine: function( line ) {
 
 		// Note: this tests if a line intersects the plane, not whether it (or its end-points) are coplanar with it.
 
@@ -214,31 +218,31 @@ THREE.Plane.prototype = {
 
 	},
 
-	intersectsBox: function ( box ) {
+	intersectsBox: function( box ) {
 
 		return box.intersectsPlane( this );
 
 	},
 
-	intersectsSphere: function ( sphere ) {
+	intersectsSphere: function( sphere ) {
 
 		return sphere.intersectsPlane( this );
 
 	},
 
-	coplanarPoint: function ( optionalTarget ) {
+	coplanarPoint: function( optionalTarget ) {
 
 		var result = optionalTarget || new THREE.Vector3();
 		return result.copy( this.normal ).multiplyScalar( - this.constant );
 
 	},
 
-	applyMatrix4: function () {
+	applyMatrix4: function() {
 
 		var v1 = new THREE.Vector3();
 		var m1 = new THREE.Matrix3();
 
-		return function ( matrix, optionalNormalMatrix ) {
+		return function( matrix, optionalNormalMatrix ) {
 
 			var referencePoint = this.coplanarPoint( v1 ).applyMatrix4( matrix );
 
@@ -256,7 +260,7 @@ THREE.Plane.prototype = {
 
 	}(),
 
-	translate: function ( offset ) {
+	translate: function( offset ) {
 
 		this.constant = this.constant - offset.dot( this.normal );
 
@@ -264,7 +268,7 @@ THREE.Plane.prototype = {
 
 	},
 
-	equals: function ( plane ) {
+	equals: function( plane ) {
 
 		return plane.normal.equals( this.normal ) && ( plane.constant === this.constant );
 


### PR DESCRIPTION
Do not rely on pre-comupted plane for dragging cubes because if we zoom out too much, the reference plane used for dragging gets too small and dragging stops working.

http://threejs.org/examples/#webgl_interactive_draggablecubes

See https://github.com/mrdoob/three.js/issues/8727
