### PR TITLE
Flatten mesh.py morph target vertex list format

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -446,7 +446,7 @@ def blend_shapes(mesh, options):
             morph = []
             for d in key_blocks[key].data:
                 co = d.co
-                morph.append([co.x, co.y, co.z])
+                morph.extend([co.x, co.y, co.z])
             manifest.append({
                 constants.NAME: key,
                 constants.VERTICES: morph


### PR DESCRIPTION
Morph target vertices were being saved as an array of vec3s, which were not uploading properly to GPU at runtime.
