### PR TITLE
Fix VREffect support for webvr-polyfill

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -102,7 +102,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	document.addEventListener( fullscreenchange, function () {
 
-		isPresenting = !!vrHMD && ( vrHMD.isPresenting || ( isDeprecatedAPI && ( document.mozFullScreenElement || document.webkitFullscreenElement ) !== undefined ) );
+		isPresenting = vrHMD !== undefined && ( vrHMD.isPresenting || ( isDeprecatedAPI && ( document.mozFullScreenElement || document.webkitFullscreenElement ) !== undefined ) );
 
 		if ( isPresenting ) {
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -102,7 +102,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	document.addEventListener( fullscreenchange, function () {
 
-		isPresenting = vrHMD && ( vrHMD.isPresenting || isDeprecatedAPI && ( document.mozFullScreenElement || document.webkitFullscreenElement ) !== undefined );
+		isPresenting = !!vrHMD && ( vrHMD.isPresenting || ( isDeprecatedAPI && ( document.mozFullScreenElement || document.webkitFullscreenElement ) !== undefined ) );
 
 		if ( isPresenting ) {
 
@@ -113,11 +113,15 @@ THREE.VREffect = function ( renderer, onError ) {
 			var eyeWidth, eyeHeight;
 
 			if ( isDeprecatedAPI ) {
+
 				eyeWidth = eyeParamsL.renderRect.width;
 				eyeHeight = eyeParamsL.renderRect.height;
+
 			} else {
+
 				eyeWidth = eyeParamsL.renderWidth;
 				eyeHeight = eyeParamsL.renderHeight;
+
 			}
 
 			renderer.setPixelRatio( 1 );

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -102,7 +102,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	document.addEventListener( fullscreenchange, function () {
 
-		isPresenting = isDeprecatedAPI && vrHMD && ( document.mozFullScreenElement || document.webkitFullscreenElement ) !== undefined;
+		isPresenting = vrHMD && ( vrHMD.isPresenting || isDeprecatedAPI && ( document.mozFullScreenElement || document.webkitFullscreenElement ) !== undefined );
 
 		if ( isPresenting ) {
 
@@ -110,8 +110,18 @@ THREE.VREffect = function ( renderer, onError ) {
 			rendererSize = renderer.getSize();
 
 			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
+			var eyeWidth, eyeHeight;
+
+			if ( isDeprecatedAPI ) {
+				eyeWidth = eyeParamsL.renderRect.width;
+				eyeHeight = eyeParamsL.renderRect.height;
+			} else {
+				eyeWidth = eyeParamsL.renderWidth;
+				eyeHeight = eyeParamsL.renderHeight;
+			}
+
 			renderer.setPixelRatio( 1 );
-			renderer.setSize( eyeParamsL.renderRect.width * 2, eyeParamsL.renderRect.height, false );
+			renderer.setSize( eyeWidth * 2, eyeHeight, false );
 
 		} else {
 


### PR DESCRIPTION
- fixes #8712
- correctly set `isPresenting` in full screen mode
- webvr-polyfill fires fullscreenchange in VR mode
- fix needed for setting main window to full screen while presenting
