### PR TITLE
EventDispatcher: Deprecated .apply.

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -10,9 +10,7 @@ THREE.MTLLoader = function( manager ) {
 
 };
 
-THREE.MTLLoader.prototype = {
-
-	constructor: THREE.MTLLoader,
+Object.assign( THREE.MTLLoader.prototype, THREE.EventDispatcher.prototype, {
 
 	/**
 	 * Loads and parses a MTL asset from a URL.
@@ -167,7 +165,7 @@ THREE.MTLLoader.prototype = {
 
 	}
 
-};
+} );
 
 /**
  * Create a new THREE-MTLLoader.MaterialCreator
@@ -476,5 +474,3 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 	}
 
 };
-
-THREE.EventDispatcher.prototype.apply( THREE.MTLLoader.prototype );

--- a/examples/js/loaders/NRRDLoader.js
+++ b/examples/js/loaders/NRRDLoader.js
@@ -5,9 +5,7 @@ THREE.NRRDLoader = function( manager ) {
 
 };
 
-THREE.NRRDLoader.prototype = {
-
-	constructor: THREE.NRRDLoader,
+Object.assign( THREE.NRRDLoader.prototype, THREE.EventDispatcher.prototype, {
 
 	load: function( url, onLoad, onProgress, onError ) {
 
@@ -586,6 +584,4 @@ THREE.NRRDLoader.prototype = {
 		}
 	}
 
-};
-
-THREE.EventDispatcher.prototype.apply( THREE.NRRDLoader.prototype );
+} );

--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -13,9 +13,9 @@ THREE.PCDLoader = function( manager ) {
 	this.littleEndian = true;
 
 };
-THREE.PCDLoader.prototype = {
 
-	constructor: THREE.PCDLoader,
+
+Object.assign( THREE.PCDLoader.prototype, THREE.EventDispatcher.prototype, {
 
 	load: function( url, onLoad, onProgress, onError ) {
 
@@ -246,6 +246,4 @@ THREE.PCDLoader.prototype = {
 
 	},
 
-};
-
-THREE.EventDispatcher.prototype.apply( THREE.PCDLoader.prototype );
+} );

--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -9,9 +9,7 @@ THREE.VTKLoader = function( manager ) {
 
 };
 
-THREE.VTKLoader.prototype = {
-
-	constructor: THREE.VTKLoader,
+Object.assign( THREE.VTKLoader.prototype, THREE.EventDispatcher.prototype, {
 
 	load: function ( url, onLoad, onProgress, onError ) {
 
@@ -1108,6 +1106,4 @@ THREE.VTKLoader.prototype = {
 
 	}
 
-};
-
-THREE.EventDispatcher.prototype.apply( THREE.VTKLoader.prototype );
+} );

--- a/examples/js/renderers/RaytracingRenderer.js
+++ b/examples/js/renderers/RaytracingRenderer.js
@@ -286,4 +286,4 @@ THREE.RaytracingRenderer = function ( parameters ) {
 
 };
 
-THREE.EventDispatcher.prototype.apply( THREE.RaytracingRenderer.prototype );
+Object.assign( THREE.RaytracingRenderer.prototype, THREE.EventDispatcher.prototype );

--- a/examples/js/renderers/RaytracingWorker.js
+++ b/examples/js/renderers/RaytracingWorker.js
@@ -564,4 +564,4 @@ THREE.RaytracingRendererWorker = function ( parameters ) {
 
 };
 
-THREE.EventDispatcher.prototype.apply( THREE.RaytracingRendererWorker.prototype );
+Object.assign( THREE.RaytracingRendererWorker.prototype, THREE.EventDispatcher.prototype );

--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -20,9 +20,7 @@ THREE.AnimationMixer = function( root ) {
 
 };
 
-THREE.AnimationMixer.prototype = {
-
-	constructor: THREE.AnimationMixer,
+Object.assign( THREE.AnimationMixer.prototype, THREE.EventDispatcher.prototype, {
 
 	// return an action for a clip optionally using a custom root target
 	// object (this method allocates a lot of dynamic memory in case a
@@ -267,11 +265,9 @@ THREE.AnimationMixer.prototype = {
 
 	}
 
-};
+} );
 
 THREE.AnimationMixer._Action = THREE.AnimationAction._new;
-
-THREE.EventDispatcher.prototype.apply( THREE.AnimationMixer.prototype );
 
 // Implementation details:
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -26,9 +26,7 @@ THREE.BufferGeometry = function () {
 
 };
 
-THREE.BufferGeometry.prototype = {
-
-	constructor: THREE.BufferGeometry,
+Object.assign( THREE.BufferGeometry.prototype, THREE.EventDispatcher.prototype, {
 
 	getIndex: function () {
 
@@ -1015,8 +1013,6 @@ THREE.BufferGeometry.prototype = {
 
 	}
 
-};
-
-THREE.EventDispatcher.prototype.apply( THREE.BufferGeometry.prototype );
+} );
 
 THREE.BufferGeometry.MaxIndex = 65535;

--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -40,9 +40,7 @@ THREE.DirectGeometry = function () {
 
 };
 
-THREE.DirectGeometry.prototype = {
-
-	constructor: THREE.DirectGeometry,
+Object.assign( THREE.DirectGeometry.prototype, THREE.EventDispatcher.prototype, {
 
 	computeBoundingBox: THREE.Geometry.prototype.computeBoundingBox,
 	computeBoundingSphere: THREE.Geometry.prototype.computeBoundingSphere,
@@ -285,6 +283,4 @@ THREE.DirectGeometry.prototype = {
 
 	}
 
-};
-
-THREE.EventDispatcher.prototype.apply( THREE.DirectGeometry.prototype );
+} );

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -4,18 +4,39 @@
 
 THREE.EventDispatcher = function () {};
 
-THREE.EventDispatcher.prototype = {
+//
+// [Deprecation]
+//
+
+THREE.EventDispatcher.prototype = Object.assign( Object.create( {
 
 	constructor: THREE.EventDispatcher,
 
 	apply: function ( object ) {
+
+		console.warn( "THREE.EventDispatcher: .apply is deprecated, " +
+				"just inherit or Object.assign the prototype to mix-in." );
 
 		object.addEventListener = THREE.EventDispatcher.prototype.addEventListener;
 		object.hasEventListener = THREE.EventDispatcher.prototype.hasEventListener;
 		object.removeEventListener = THREE.EventDispatcher.prototype.removeEventListener;
 		object.dispatchEvent = THREE.EventDispatcher.prototype.dispatchEvent;
 
-	},
+	}
+
+	// Notes:
+	// - The prototype chain ensures that Object.assign will not copy the
+	//   properties within this block.
+	// - When .constructor is not explicitly set, it is not copied either,
+	//   so use the disabled code below so doesn't need to be clobbered.
+
+} ), {
+
+//
+// [/Deprecation]
+//
+
+//Object.assign( THREE.EventDispatcher.prototype, {
 
 	addEventListener: function ( type, listener ) {
 
@@ -104,4 +125,4 @@ THREE.EventDispatcher.prototype = {
 
 	}
 
-};
+} );

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -44,9 +44,7 @@ THREE.Geometry = function () {
 
 };
 
-THREE.Geometry.prototype = {
-
-	constructor: THREE.Geometry,
+Object.assign( THREE.Geometry.prototype, THREE.EventDispatcher.prototype, {
 
 	applyMatrix: function ( matrix ) {
 
@@ -1202,8 +1200,6 @@ THREE.Geometry.prototype = {
 
 	}
 
-};
-
-THREE.EventDispatcher.prototype.apply( THREE.Geometry.prototype );
+} );
 
 THREE.GeometryIdCount = 0;

--- a/src/core/InstancedBufferGeometry.js
+++ b/src/core/InstancedBufferGeometry.js
@@ -57,5 +57,3 @@ THREE.InstancedBufferGeometry.prototype.copy = function ( source ) {
 	return this;
 
 };
-
-THREE.EventDispatcher.prototype.apply( THREE.InstancedBufferGeometry.prototype );

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -89,9 +89,7 @@ THREE.Object3D = function () {
 THREE.Object3D.DefaultUp = new THREE.Vector3( 0, 1, 0 );
 THREE.Object3D.DefaultMatrixAutoUpdate = true;
 
-THREE.Object3D.prototype = {
-
-	constructor: THREE.Object3D,
+Object.assign( THREE.Object3D.prototype, THREE.EventDispatcher.prototype, {
 
 	applyMatrix: function ( matrix ) {
 
@@ -715,8 +713,6 @@ THREE.Object3D.prototype = {
 
 	}
 
-};
-
-THREE.EventDispatcher.prototype.apply( THREE.Object3D.prototype );
+} );
 
 THREE.Object3DIdCount = 0;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -60,16 +60,15 @@ THREE.Material.prototype = {
 
 	constructor: THREE.Material,
 
-	get needsUpdate () {
+	get needsUpdate() {
 
 		return this._needsUpdate;
 
 	},
 
-	set needsUpdate ( value ) {
+	set needsUpdate( value ) {
 
 		if ( value === true ) this.update();
-
 		this._needsUpdate = value;
 
 	},
@@ -320,6 +319,6 @@ THREE.Material.prototype = {
 
 };
 
-THREE.EventDispatcher.prototype.apply( THREE.Material.prototype );
+Object.assign( THREE.Material.prototype, THREE.EventDispatcher.prototype );
 
 THREE.MaterialIdCount = 0;

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -33,9 +33,7 @@ THREE.WebGLRenderTarget = function ( width, height, options ) {
 
 };
 
-THREE.WebGLRenderTarget.prototype = {
-
-	constructor: THREE.WebGLRenderTarget,
+Object.assign( THREE.WebGLRenderTarget.prototype, THREE.EventDispatcher.prototype, {
 
 	setSize: function ( width, height ) {
 
@@ -82,6 +80,4 @@ THREE.WebGLRenderTarget.prototype = {
 
 	}
 
-};
-
-THREE.EventDispatcher.prototype.apply( THREE.WebGLRenderTarget.prototype );
+} );

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -56,7 +56,7 @@ THREE.Texture.prototype = {
 
 	constructor: THREE.Texture,
 
-	set needsUpdate ( value ) {
+	set needsUpdate( value ) {
 
 		if ( value === true ) this.version ++;
 
@@ -274,6 +274,6 @@ THREE.Texture.prototype = {
 
 };
 
-THREE.EventDispatcher.prototype.apply( THREE.Texture.prototype );
+Object.assign( THREE.Texture.prototype, THREE.EventDispatcher.prototype );
 
 THREE.TextureIdCount = 0;

--- a/test/unit/core/EventDispatcher.js
+++ b/test/unit/core/EventDispatcher.js
@@ -4,18 +4,6 @@
 
 module( "EventDispatcher" );
 
-test( "apply", function() {
-	var innocentObject = {};
-	var eventDispatcher = new THREE.EventDispatcher();
-
-	eventDispatcher.apply( innocentObject );
-
-	ok( innocentObject.addEventListener !== undefined &&
-			innocentObject.hasEventListener !== undefined &&
-		innocentObject.removeEventListener !== undefined &&
-		innocentObject.dispatchEvent !== undefined, "events where added to object" );
-});
-
 test( "addEventListener", function() {
 	var eventDispatcher = new THREE.EventDispatcher();
 


### PR DESCRIPTION
Since we polyfill `Object.assign`, we can easily live without it.

Also removed the superfluous `EventDispatcher` mixin from `InstancedBufferGeometry`; it's inherited from `BufferGeometry`.
