### PR TITLE
Examples: use .texture of input render targets.

### DIFF
--- a/examples/js/Mirror.js
+++ b/examples/js/Mirror.js
@@ -114,8 +114,8 @@ THREE.Mirror = function ( renderer, camera, options ) {
 
 	var parameters = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBFormat, stencilBuffer: false };
 
-	this.texture = new THREE.WebGLRenderTarget( width, height, parameters );
-	this.tempTexture = new THREE.WebGLRenderTarget( width, height, parameters );
+	this.renderTarget = new THREE.WebGLRenderTarget( width, height, parameters );
+	this.renderTarget2 = new THREE.WebGLRenderTarget( width, height, parameters );
 
 	var mirrorShader = THREE.ShaderLib[ "mirror" ];
 	var mirrorUniforms = THREE.UniformsUtils.clone( mirrorShader.uniforms );
@@ -128,14 +128,14 @@ THREE.Mirror = function ( renderer, camera, options ) {
 
 	} );
 
-	this.material.uniforms.mirrorSampler.value = this.texture;
+	this.material.uniforms.mirrorSampler.value = this.renderTarget.texture;
 	this.material.uniforms.mirrorColor.value = mirrorColor;
 	this.material.uniforms.textureMatrix.value = this.textureMatrix;
 
 	if ( ! THREE.Math.isPowerOfTwo( width ) || ! THREE.Math.isPowerOfTwo( height ) ) {
 
-		this.texture.generateMipmaps = false;
-		this.tempTexture.generateMipmaps = false;
+		this.renderTarget.texture.generateMipmaps = false;
+		this.renderTarget2.texture.generateMipmaps = false;
 
 	}
 
@@ -159,14 +159,14 @@ THREE.Mirror.prototype.renderWithMirror = function ( otherMirror ) {
 
 	// render the other mirror in temp texture
 	otherMirror.renderTemp();
-	otherMirror.material.uniforms.mirrorSampler.value = otherMirror.tempTexture;
+	otherMirror.material.uniforms.mirrorSampler.value = otherMirror.renderTarget2.texture;
 
 	// render the current mirror
 	this.render();
 	this.matrixNeedsUpdate = true;
 
 	// restore material and camera of other mirror
-	otherMirror.material.uniforms.mirrorSampler.value = otherMirror.texture;
+	otherMirror.material.uniforms.mirrorSampler.value = otherMirror.renderTarget.texture;
 	otherMirror.camera = tempCamera;
 
 	// restore texture matrix of other mirror
@@ -269,7 +269,7 @@ THREE.Mirror.prototype.render = function () {
 		var visible = this.material.visible;
 		this.material.visible = false;
 
-		this.renderer.render( scene, this.mirrorCamera, this.texture, true );
+		this.renderer.render( scene, this.mirrorCamera, this.renderTarget, true );
 
 		this.material.visible = visible;
 
@@ -294,7 +294,7 @@ THREE.Mirror.prototype.renderTemp = function () {
 
 	if ( scene !== undefined && scene instanceof THREE.Scene ) {
 
-		this.renderer.render( scene, this.mirrorCamera, this.tempTexture, true );
+		this.renderer.render( scene, this.mirrorCamera, this.renderTarget2, true );
 
 	}
 

--- a/examples/js/Ocean.js
+++ b/examples/js/Ocean.js
@@ -172,8 +172,8 @@
 	} );
 	// this.materialOcean.wireframe = true;
 	this.materialOcean.uniforms.u_geometrySize = { type: "f", value: this.resolution };
-	this.materialOcean.uniforms.u_displacementMap = { type: "t", value: this.displacementMapFramebuffer };
-	this.materialOcean.uniforms.u_normalMap = { type: "t", value: this.normalMapFramebuffer };
+	this.materialOcean.uniforms.u_displacementMap = { type: "t", value: this.displacementMapFramebuffer.texture };
+	this.materialOcean.uniforms.u_normalMap = { type: "t", value: this.normalMapFramebuffer.texture };
 	this.materialOcean.uniforms.u_oceanColor = { type: "v3", value: this.oceanColor };
 	this.materialOcean.uniforms.u_skyColor = { type: "v3", value: this.skyColor };
 	this.materialOcean.uniforms.u_sunDirection = { type: "v3", value: new THREE.Vector3( this.sunDirectionX, this.sunDirectionY, this.sunDirectionZ ) };
@@ -271,7 +271,7 @@ THREE.Ocean.prototype.renderWavePhase = function () {
 
 	}else {
 
-		this.materialPhase.uniforms.u_phases.value = this.pingPhase ? this.pingPhaseFramebuffer  : this.pongPhaseFramebuffer;
+		this.materialPhase.uniforms.u_phases.value = this.pingPhase ? this.pingPhaseFramebuffer.texture : this.pongPhaseFramebuffer.texture;
 
 	}
 	this.materialPhase.uniforms.u_deltaTime.value = this.deltaTime;
@@ -284,10 +284,10 @@ THREE.Ocean.prototype.renderWavePhase = function () {
 THREE.Ocean.prototype.renderSpectrum = function () {
 
 	this.scene.overrideMaterial = this.materialSpectrum;
-	this.materialSpectrum.uniforms.u_initialSpectrum.value = this.initialSpectrumFramebuffer;
-	this.materialSpectrum.uniforms.u_phases.value = this.pingPhase ? this.pingPhaseFramebuffer : this.pongPhaseFramebuffer;
-	this.materialSpectrum.uniforms.u_choppiness.value = this.choppiness ;
-	this.materialSpectrum.uniforms.u_size.value = this.size ;
+	this.materialSpectrum.uniforms.u_initialSpectrum.value = this.initialSpectrumFramebuffer.texture;
+	this.materialSpectrum.uniforms.u_phases.value = this.pingPhase ? this.pingPhaseFramebuffer.texture : this.pongPhaseFramebuffer.texture;
+	this.materialSpectrum.uniforms.u_choppiness.value = this.choppiness;
+	this.materialSpectrum.uniforms.u_size.value = this.size;
 	this.renderer.render( this.scene, this.oceanCamera, this.spectrumFramebuffer );
 
 };
@@ -303,19 +303,19 @@ THREE.Ocean.prototype.renderSpectrumFFT = function() {
 
 		if ( i === 0 ) {
 
-			this.materialOceanHorizontal.uniforms.u_input.value = this.spectrumFramebuffer;
+			this.materialOceanHorizontal.uniforms.u_input.value = this.spectrumFramebuffer.texture;
 			this.materialOceanHorizontal.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pingTransformFramebuffer );
 
 		} else if ( i % 2 === 1 ) {
 
-			this.materialOceanHorizontal.uniforms.u_input.value = this.pingTransformFramebuffer;
+			this.materialOceanHorizontal.uniforms.u_input.value = this.pingTransformFramebuffer.texture;
 			this.materialOceanHorizontal.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pongTransformFramebuffer );
 
 		} else {
 
-			this.materialOceanHorizontal.uniforms.u_input.value = this.pongTransformFramebuffer;
+			this.materialOceanHorizontal.uniforms.u_input.value = this.pongTransformFramebuffer.texture;
 			this.materialOceanHorizontal.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pingTransformFramebuffer );
 
@@ -327,19 +327,19 @@ THREE.Ocean.prototype.renderSpectrumFFT = function() {
 
 		if ( i === iterations * 2 - 1 ) {
 
-			this.materialOceanVertical.uniforms.u_input.value = ( iterations % 2 === 0 ) ? this.pingTransformFramebuffer : this.pongTransformFramebuffer;
+			this.materialOceanVertical.uniforms.u_input.value = ( iterations % 2 === 0 ) ? this.pingTransformFramebuffer.texture : this.pongTransformFramebuffer.texture;
 			this.materialOceanVertical.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.displacementMapFramebuffer );
 
 		} else if ( i % 2 === 1 ) {
 
-			this.materialOceanVertical.uniforms.u_input.value = this.pingTransformFramebuffer;
+			this.materialOceanVertical.uniforms.u_input.value = this.pingTransformFramebuffer.texture;
 			this.materialOceanVertical.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pongTransformFramebuffer );
 
 		} else {
 
-			this.materialOceanVertical.uniforms.u_input.value = this.pongTransformFramebuffer;
+			this.materialOceanVertical.uniforms.u_input.value = this.pongTransformFramebuffer.texture;
 			this.materialOceanVertical.uniforms.u_subtransformSize.value = Math.pow( 2, ( i % ( iterations ) ) + 1 );
 			this.renderer.render( this.scene, this.oceanCamera, this.pingTransformFramebuffer );
 
@@ -353,7 +353,7 @@ THREE.Ocean.prototype.renderNormalMap = function () {
 
 	this.scene.overrideMaterial = this.materialNormal;
 	if ( this.changed ) this.materialNormal.uniforms.u_size.value = this.size;
-	this.materialNormal.uniforms.u_displacementMap.value = this.displacementMapFramebuffer;
+	this.materialNormal.uniforms.u_displacementMap.value = this.displacementMapFramebuffer.texture;
 	this.renderer.render( this.scene, this.oceanCamera, this.normalMapFramebuffer, true );
 
 };

--- a/examples/js/SimulationRenderer.js
+++ b/examples/js/SimulationRenderer.js
@@ -103,10 +103,10 @@ function SimulationRenderer( WIDTH, renderer ) {
 		rtVelocity2 = rtVelocity1.clone();
 
 		simulator.renderTexture( dtPosition, rtPosition1 );
-		simulator.renderTexture( rtPosition1, rtPosition2 );
+		simulator.renderTexture( rtPosition1.texture, rtPosition2 );
 
 		simulator.renderTexture( dtVelocity, rtVelocity1 );
-		simulator.renderTexture( rtVelocity1, rtVelocity2 );
+		simulator.renderTexture( rtVelocity1.texture, rtVelocity2 );
 
 		simulator.velocityUniforms.testing.value = 10;
 
@@ -168,13 +168,13 @@ function SimulationRenderer( WIDTH, renderer ) {
 
 		if ( flipflop ) {
 
-			simulator.renderVelocity( rtPosition1, rtVelocity1, rtVelocity2, delta );
-			simulator.renderPosition( rtPosition1, rtVelocity2, rtPosition2, delta );
+			simulator.renderVelocity( rtPosition1.texture, rtVelocity1.texture, rtVelocity2, delta );
+			simulator.renderPosition( rtPosition1.texture, rtVelocity2.texture, rtPosition2, delta );
 
 		} else {
 
-			simulator.renderVelocity( rtPosition2, rtVelocity2, rtVelocity1, delta );
-			simulator.renderPosition( rtPosition2, rtVelocity1, rtPosition1, delta );
+			simulator.renderVelocity( rtPosition2.texture, rtVelocity2.texture, rtVelocity1, delta );
+			simulator.renderPosition( rtPosition2.texture, rtVelocity1.texture, rtPosition1, delta );
 
 		}
 

--- a/examples/js/WaterShader.js
+++ b/examples/js/WaterShader.js
@@ -150,9 +150,11 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 	this.lookAtPosition = new THREE.Vector3( 0, 0, - 1 );
 	this.clipPlane = new THREE.Vector4();
 
-	if ( camera instanceof THREE.PerspectiveCamera )
+	if ( camera instanceof THREE.PerspectiveCamera ) {
+
 		this.camera = camera;
-	else {
+
+	} else {
 
 		this.camera = new THREE.PerspectiveCamera();
 		console.log( this.name + ': camera is not a Perspective Camera!' );
@@ -163,8 +165,8 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 
 	this.mirrorCamera = this.camera.clone();
 
-	this.texture = new THREE.WebGLRenderTarget( width, height );
-	this.tempTexture = new THREE.WebGLRenderTarget( width, height );
+	this.renderTarget = new THREE.WebGLRenderTarget( width, height );
+	this.renderTarget2 = new THREE.WebGLRenderTarget( width, height );
 
 	var mirrorShader = THREE.ShaderLib[ "water" ];
 	var mirrorUniforms = THREE.UniformsUtils.clone( mirrorShader.uniforms );
@@ -178,7 +180,7 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 		fog: this.fog
 	} );
 
-	this.material.uniforms.mirrorSampler.value = this.texture;
+	this.material.uniforms.mirrorSampler.value = this.renderTarget.texture;
 	this.material.uniforms.textureMatrix.value = this.textureMatrix;
 	this.material.uniforms.alpha.value = this.alpha;
 	this.material.uniforms.time.value = this.time;
@@ -192,10 +194,10 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 
 	if ( ! THREE.Math.isPowerOfTwo( width ) || ! THREE.Math.isPowerOfTwo( height ) ) {
 
-		this.texture.generateMipmaps = false;
-		this.texture.minFilter = THREE.LinearFilter;
-		this.tempTexture.generateMipmaps = false;
-		this.tempTexture.minFilter = THREE.LinearFilter;
+		this.renderTarget.texture.generateMipmaps = false;
+		this.renderTarget.texture.minFilter = THREE.LinearFilter;
+		this.renderTarget2.texture.generateMipmaps = false;
+		this.renderTarget2.texture.minFilter = THREE.LinearFilter;
 
 	}
 

--- a/examples/js/cameras/CinematicCamera.js
+++ b/examples/js/cameras/CinematicCamera.js
@@ -123,8 +123,8 @@ THREE.CinematicCamera.prototype.initPostProcessing = function () {
 
 		this.postprocessing.bokeh_uniforms = THREE.UniformsUtils.clone( bokeh_shader.uniforms );
 
-		this.postprocessing.bokeh_uniforms[ "tColor" ].value = this.postprocessing.rtTextureColor;
-		this.postprocessing.bokeh_uniforms[ "tDepth" ].value = this.postprocessing.rtTextureDepth;
+		this.postprocessing.bokeh_uniforms[ "tColor" ].value = this.postprocessing.rtTextureColor.texture;
+		this.postprocessing.bokeh_uniforms[ "tDepth" ].value = this.postprocessing.rtTextureDepth.texture;
 
 		this.postprocessing.bokeh_uniforms[ "manualdof" ].value = 0;
 		this.postprocessing.bokeh_uniforms[ "shaderFocus" ].value = 0;

--- a/examples/js/crossfade/transition.js
+++ b/examples/js/crossfade/transition.js
@@ -94,8 +94,8 @@ function Transition ( sceneA, sceneB ) {
 	this.sceneA = sceneA;
 	this.sceneB = sceneB;
 
-	this.quadmaterial.uniforms.tDiffuse1.value = sceneA.fbo;
-	this.quadmaterial.uniforms.tDiffuse2.value = sceneB.fbo;
+	this.quadmaterial.uniforms.tDiffuse1.value = sceneA.fbo.texture;
+	this.quadmaterial.uniforms.tDiffuse2.value = sceneB.fbo.texture;
 
 	this.needChange = false;
 

--- a/examples/js/effects/AnaglyphEffect.js
+++ b/examples/js/effects/AnaglyphEffect.js
@@ -46,8 +46,8 @@ THREE.AnaglyphEffect = function ( renderer, width, height ) {
 
 		uniforms: {
 
-			"mapLeft": { type: "t", value: _renderTargetL },
-			"mapRight": { type: "t", value: _renderTargetR },
+			"mapLeft": { type: "t", value: _renderTargetL.texture },
+			"mapRight": { type: "t", value: _renderTargetR.texture },
 
 			"colorMatrixLeft": { type: "m3", value: this.colorMatrixLeft },
 			"colorMatrixRight": { type: "m3", value: this.colorMatrixRight }

--- a/examples/js/effects/ParallaxBarrierEffect.js
+++ b/examples/js/effects/ParallaxBarrierEffect.js
@@ -21,8 +21,8 @@ THREE.ParallaxBarrierEffect = function ( renderer ) {
 
 		uniforms: {
 
-			"mapLeft": { type: "t", value: _renderTargetL },
-			"mapRight": { type: "t", value: _renderTargetR }
+			"mapLeft": { type: "t", value: _renderTargetL.texture },
+			"mapRight": { type: "t", value: _renderTargetR.texture }
 
 		},
 

--- a/examples/js/pmrem/PMREMCubeUVPacker.js
+++ b/examples/js/pmrem/PMREMCubeUVPacker.js
@@ -32,7 +32,7 @@ THREE.PMREMCubeUVPacker = function( cubeTextureLods, numLods ) {
 	};
 
 	this.CubeUVRenderTarget = new THREE.WebGLRenderTarget( size, size, params );
-	this.CubeUVRenderTarget.mapping = THREE.CubeUVReflectionMapping;
+	this.CubeUVRenderTarget.texture.mapping = THREE.CubeUVReflectionMapping;
 	this.camera = new THREE.OrthographicCamera( - size * 0.5, size * 0.5, - size * 0.5, size * 0.5, 0.0, 1000 );
 
 	this.scene = new THREE.Scene();
@@ -71,8 +71,8 @@ THREE.PMREMCubeUVPacker = function( cubeTextureLods, numLods ) {
 
 				// 6 Cube Faces
 				var material = this.getShader();
-				material.uniforms[ 'envMap' ].value = this.cubeLods[ i ];
-				material.envMap = this.cubeLods[ i ]
+				material.uniforms[ 'envMap' ].value = this.cubeLods[ i ].texture;
+				material.envMap = this.cubeLods[ i ].texture;
 				material.uniforms[ 'faceIndex' ].value = k;
 				material.uniforms[ 'mapSize' ].value = mipSize;
 				var color = material.uniforms[ 'testColor' ].value;

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -101,7 +101,7 @@ THREE.PMREMGenerator.prototype = {
 			this.shader.uniforms[ 'mapSize' ].value = size;
 			this.renderToCubeMapTarget( renderer, this.cubeLods[ i ] );
 
-			if ( i < 5 ) this.shader.uniforms[ 'envMap' ].value = this.cubeLods[ i ];
+			if ( i < 5 ) this.shader.uniforms[ 'envMap' ].value = this.cubeLods[ i ].texture;
 
 		}
 

--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -146,26 +146,26 @@ THREE.AdaptiveToneMappingPass.prototype = {
 
 			//Render the luminance of the current scene into a render target with mipmapping enabled
 			this.quad.material = this.materialLuminance;
-			this.materialLuminance.uniforms.tDiffuse.value = readBuffer;
+			this.materialLuminance.uniforms.tDiffuse.value = readBuffer.texture;
 			renderer.render( this.scene, this.camera, this.currentLuminanceRT );
 
 			//Use the new luminance values, the previous luminance and the frame delta to
 			//adapt the luminance over time.
 			this.quad.material = this.materialAdaptiveLum;
 			this.materialAdaptiveLum.uniforms.delta.value = delta;
-			this.materialAdaptiveLum.uniforms.lastLum.value = this.previousLuminanceRT;
-			this.materialAdaptiveLum.uniforms.currentLum.value = this.currentLuminanceRT;
+			this.materialAdaptiveLum.uniforms.lastLum.value = this.previousLuminanceRT.texture;
+			this.materialAdaptiveLum.uniforms.currentLum.value = this.currentLuminanceRT.texture;
 			renderer.render( this.scene, this.camera, this.luminanceRT );
 
 			//Copy the new adapted luminance value so that it can be used by the next frame.
 			this.quad.material = this.materialCopy;
-			this.copyUniforms.tDiffuse.value = this.luminanceRT;
+			this.copyUniforms.tDiffuse.value = this.luminanceRT.texture;
 			renderer.render( this.scene, this.camera, this.previousLuminanceRT );
 
 		}
 
 		this.quad.material = this.materialToneMap;
-		this.materialToneMap.uniforms.tDiffuse.value = readBuffer;
+		this.materialToneMap.uniforms.tDiffuse.value = readBuffer.texture;
 		renderer.render( this.scene, this.camera, writeBuffer, this.clear );
 
 	},
@@ -204,7 +204,7 @@ THREE.AdaptiveToneMappingPass.prototype = {
 		if ( this.adaptive ) {
 
 			this.materialToneMap.defines[ "ADAPTED_LUMINANCE" ] = "";
-			this.materialToneMap.uniforms.luminanceMap.value = this.luminanceRT;
+			this.materialToneMap.uniforms.luminanceMap.value = this.luminanceRT.texture;
 
 		}
 		//Put something in the adaptive luminance texture so that the scene can render initially
@@ -224,13 +224,13 @@ THREE.AdaptiveToneMappingPass.prototype = {
 
 			this.adaptive = true;
 			this.materialToneMap.defines[ "ADAPTED_LUMINANCE" ] = "";
-			this.materialToneMap.uniforms.luminanceMap.value = this.luminanceRT;
+			this.materialToneMap.uniforms.luminanceMap.value = this.luminanceRT.texture;
 
 		} else {
 
 			this.adaptive = false;
 			delete this.materialToneMap.defines[ "ADAPTED_LUMINANCE" ];
-			this.materialToneMap.uniforms.luminanceMap.value = undefined;
+			this.materialToneMap.uniforms.luminanceMap.value = null;
 
 		}
 		this.materialToneMap.needsUpdate = true;

--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -87,7 +87,7 @@ THREE.BloomPass.prototype = {
 
 		this.quad.material = this.materialConvolution;
 
-		this.convolutionUniforms[ "tDiffuse" ].value = readBuffer;
+		this.convolutionUniforms[ "tDiffuse" ].value = readBuffer.texture;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurX;
 
 		renderer.render( this.scene, this.camera, this.renderTargetX, true );
@@ -95,7 +95,7 @@ THREE.BloomPass.prototype = {
 
 		// Render quad with blured scene into texture (convolution pass 2)
 
-		this.convolutionUniforms[ "tDiffuse" ].value = this.renderTargetX;
+		this.convolutionUniforms[ "tDiffuse" ].value = this.renderTargetX.texture;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurY;
 
 		renderer.render( this.scene, this.camera, this.renderTargetY, true );
@@ -104,7 +104,7 @@ THREE.BloomPass.prototype = {
 
 		this.quad.material = this.materialCopy;
 
-		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetY;
+		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetY.texture;
 
 		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
 

--- a/examples/js/postprocessing/BokehPass.js
+++ b/examples/js/postprocessing/BokehPass.js
@@ -43,7 +43,7 @@ THREE.BokehPass = function ( scene, camera, params ) {
 	var bokehShader = THREE.BokehShader;
 	var bokehUniforms = THREE.UniformsUtils.clone( bokehShader.uniforms );
 
-	bokehUniforms[ "tDepth" ].value = this.renderTargetDepth;
+	bokehUniforms[ "tDepth" ].value = this.renderTargetDepth.texture;
 
 	bokehUniforms[ "focus" ].value = focus;
 	bokehUniforms[ "aspect" ].value = aspect;
@@ -85,7 +85,7 @@ THREE.BokehPass.prototype = {
 
 		// Render bokeh composite
 
-		this.uniforms[ "tColor" ].value = readBuffer;
+		this.uniforms[ "tColor" ].value = readBuffer.texture;
 
 		if ( this.renderToScreen ) {
 

--- a/examples/js/postprocessing/DotScreenPass.js
+++ b/examples/js/postprocessing/DotScreenPass.js
@@ -41,7 +41,7 @@ THREE.DotScreenPass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
-		this.uniforms[ "tDiffuse" ].value = readBuffer;
+		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;
 		this.uniforms[ "tSize" ].value.set( readBuffer.width, readBuffer.height );
 
 		this.quad.material = this.material;

--- a/examples/js/postprocessing/FilmPass.js
+++ b/examples/js/postprocessing/FilmPass.js
@@ -42,7 +42,7 @@ THREE.FilmPass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
-		this.uniforms[ "tDiffuse" ].value = readBuffer;
+		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;
 		this.uniforms[ "time" ].value += delta;
 
 		this.quad.material = this.material;

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -43,7 +43,7 @@ THREE.GlitchPass.prototype = {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
-		this.uniforms[ "tDiffuse" ].value = readBuffer;
+		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;
 		this.uniforms[ 'seed' ].value = Math.random();//default seeding
 		this.uniforms[ 'byp' ].value = 0;
 

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -102,7 +102,7 @@ THREE.ManualMSAARenderPass.prototype = {
 		renderer.autoClear = false;
 
 		this.compositeUniforms[ "scale" ].value = 1.0 / ( jitterOffsets.length );
-		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget;
+		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget.texture;
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( var i = 0; i < jitterOffsets.length; i ++ ) {

--- a/examples/js/postprocessing/SMAAPass.js
+++ b/examples/js/postprocessing/SMAAPass.js
@@ -70,7 +70,7 @@ THREE.SMAAPass = function ( width, height ) {
 	this.uniformsWeights = THREE.UniformsUtils.clone( THREE.SMAAShader[1].uniforms );
 
 	this.uniformsWeights[ "resolution" ].value.set( 1 / width, 1 / height );
-	this.uniformsWeights[ "tDiffuse" ].value = this.edgesRT;
+	this.uniformsWeights[ "tDiffuse" ].value = this.edgesRT.texture;
 	this.uniformsWeights[ "tArea" ].value = this.areaTexture;
 	this.uniformsWeights[ "tSearch" ].value = this.searchTexture;
 
@@ -86,7 +86,7 @@ THREE.SMAAPass = function ( width, height ) {
 	this.uniformsBlend = THREE.UniformsUtils.clone( THREE.SMAAShader[2].uniforms );
 
 	this.uniformsBlend[ "resolution" ].value.set( 1 / width, 1 / height );
-	this.uniformsBlend[ "tDiffuse" ].value = this.weightsRT;
+	this.uniformsBlend[ "tDiffuse" ].value = this.weightsRT.texture;
 
 	this.materialBlend = new THREE.ShaderMaterial( {
 		uniforms: this.uniformsBlend,
@@ -114,7 +114,7 @@ THREE.SMAAPass.prototype = {
 
 		// pass 1
 
-		this.uniformsEdges[ "tDiffuse" ].value = readBuffer;
+		this.uniformsEdges[ "tDiffuse" ].value = readBuffer.texture;
 
 		this.quad.material = this.materialEdges;
 
@@ -128,7 +128,7 @@ THREE.SMAAPass.prototype = {
 
 		// pass 3
 
-		this.uniformsBlend[ "tColor" ].value = readBuffer;
+		this.uniformsBlend[ "tColor" ].value = readBuffer.texture;
 
 		this.quad.material = this.materialBlend;
 

--- a/examples/js/postprocessing/SavePass.js
+++ b/examples/js/postprocessing/SavePass.js
@@ -52,7 +52,7 @@ THREE.SavePass.prototype = {
 
 		if ( this.uniforms[ this.textureID ] ) {
 
-			this.uniforms[ this.textureID ].value = readBuffer;
+			this.uniforms[ this.textureID ].value = readBuffer.texture;
 
 		}
 

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -48,7 +48,7 @@ THREE.ShaderPass.prototype = {
 
 		if ( this.uniforms[ this.textureID ] ) {
 
-			this.uniforms[ this.textureID ].value = readBuffer;
+			this.uniforms[ this.textureID ].value = readBuffer.texture;
 
 		}
 

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -73,7 +73,7 @@ THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuf
 	if( this.accumulateIndex >= 0 && this.accumulateIndex < jitterOffsets.length ) {
 
 		this.compositeUniforms[ "scale" ].value = sampleWeight;
-		this.compositeUniforms[ "tForeground" ].value = writeBuffer;
+		this.compositeUniforms[ "tForeground" ].value = writeBuffer.texture;
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		var numSamplesPerFrame = Math.pow( 2, this.sampleLevel );
@@ -105,13 +105,13 @@ THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuf
 
 	if( accumulationWeight > 0 ) {
 		this.compositeUniforms[ "scale" ].value = 1.0;
-		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget;
+		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget.texture;
 		renderer.render( this.scene2, this.camera2, writeBuffer, true );
 	}
 
 	if( accumulationWeight < 1.0 ) {
 		this.compositeUniforms[ "scale" ].value = 1.0 - accumulationWeight;
-		this.compositeUniforms[ "tForeground" ].value = this.holdRenderTarget;
+		this.compositeUniforms[ "tForeground" ].value = this.holdRenderTarget.texture;
 		renderer.render( this.scene2, this.camera2, writeBuffer, ( accumulationWeight === 0 ) );
 	}
 

--- a/examples/js/utils/ShadowMapViewer.js
+++ b/examples/js/utils/ShadowMapViewer.js
@@ -150,7 +150,7 @@ THREE.ShadowMapViewer = function ( light ) {
 			//always end up with the scene's first added shadow casting light's shadowMap
 			//in the shader
 			//See: https://github.com/mrdoob/three.js/issues/5932
-			uniforms.tDiffuse.value = light.shadow.map;
+			uniforms.tDiffuse.value = light.shadow.map.texture;
 
 			userAutoClearSetting = renderer.autoClear;
 			renderer.autoClear = false; // To allow render overlay

--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -179,7 +179,7 @@
           uniforms: {
             cameraNear: { type: 'f', value: camera.near },
             cameraFar: { type: 'f', value: camera.far },
-            tDiffuse: { type: 't', value: target },
+            tDiffuse: { type: 't', value: target.texture },
             tDepth: { type: 't', value: target.depthTexture }
           }
         });

--- a/examples/webgl_materials_bumpmap_skin.html
+++ b/examples/webgl_materials_bumpmap_skin.html
@@ -216,7 +216,7 @@
 				uniforms[ "enableBump" ].value = true;
 				uniforms[ "enableSpecular" ].value = true;
 
-				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1;
+				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1.texture;
 				uniforms[ "tDiffuse" ].value = mapColor;
 
 				uniforms[ "bumpMap" ].value = mapHeight;

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -199,37 +199,37 @@
 
 				// MATERIALS
 
-				var cubeTarget = cubeCamera.renderTarget;
+				var cubeTexture = cubeCamera.renderTarget.texture;
 
 				mlib = {
 
 					body: [],
 
-					"Chrome": new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: cubeTarget  } ),
+					"Chrome": new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: cubeTexture  } ),
 
-					"Dark chrome": new THREE.MeshLambertMaterial( { color: 0x444444, envMap: cubeTarget } ),
+					"Dark chrome": new THREE.MeshLambertMaterial( { color: 0x444444, envMap: cubeTexture } ),
 
 					"Black rough": new THREE.MeshLambertMaterial( { color: 0x050505, } ),
 
-					"Dark glass": new THREE.MeshLambertMaterial( { color: 0x101020, envMap: cubeTarget, opacity: 0.5, transparent: true } ),
+					"Dark glass": new THREE.MeshLambertMaterial( { color: 0x101020, envMap: cubeTexture, opacity: 0.5, transparent: true } ),
 					"Orange glass": new THREE.MeshLambertMaterial( { color: 0xffbb00, opacity: 0.5, transparent: true } ),
 					"Red glass": new THREE.MeshLambertMaterial( { color: 0xff0000, opacity: 0.5, transparent: true } ),
 
-					"Black metal": new THREE.MeshLambertMaterial( { color: 0x222222, envMap: cubeTarget, combine: THREE.MultiplyOperation } ),
-					"Orange metal": new THREE.MeshLambertMaterial( { color: 0xff6600, envMap: cubeTarget, combine: THREE.MultiplyOperation } )
+					"Black metal": new THREE.MeshLambertMaterial( { color: 0x222222, envMap: cubeTexture, combine: THREE.MultiplyOperation } ),
+					"Orange metal": new THREE.MeshLambertMaterial( { color: 0xff6600, envMap: cubeTexture, combine: THREE.MultiplyOperation } )
 
 				};
 
-				mlib.body.push( [ "Orange", new THREE.MeshLambertMaterial( { color: 0x883300, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
-				mlib.body.push( [ "Blue", new THREE.MeshLambertMaterial( { color: 0x113355, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
-				mlib.body.push( [ "Red", new THREE.MeshLambertMaterial( { color: 0x660000, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
-				mlib.body.push( [ "Black", new THREE.MeshLambertMaterial( { color: 0x000000, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
-				mlib.body.push( [ "White", new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
+				mlib.body.push( [ "Orange", new THREE.MeshLambertMaterial( { color: 0x883300, envMap: cubeTexture, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
+				mlib.body.push( [ "Blue", new THREE.MeshLambertMaterial( { color: 0x113355, envMap: cubeTexture, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
+				mlib.body.push( [ "Red", new THREE.MeshLambertMaterial( { color: 0x660000, envMap: cubeTexture, combine: THREE.MixOperation, reflectivity: 0.1 } ) ] );
+				mlib.body.push( [ "Black", new THREE.MeshLambertMaterial( { color: 0x000000, envMap: cubeTexture, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
+				mlib.body.push( [ "White", new THREE.MeshLambertMaterial( { color: 0xffffff, envMap: cubeTexture, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
 
-				mlib.body.push( [ "Carmine", new THREE.MeshPhongMaterial( { color: 0x770000, specular: 0xffaaaa, envMap: cubeTarget, combine: THREE.MultiplyOperation } ) ] );
-				mlib.body.push( [ "Gold", new THREE.MeshPhongMaterial( { color: 0xaa9944, specular: 0xbbaa99, shininess: 50, envMap: cubeTarget, combine: THREE.MultiplyOperation } ) ] );
-				mlib.body.push( [ "Bronze", new THREE.MeshPhongMaterial( { color: 0x150505, specular: 0xee6600, shininess: 10, envMap: cubeTarget, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
-				mlib.body.push( [ "Chrome", new THREE.MeshPhongMaterial( { color: 0xffffff, specular: 0xffffff, envMap: cubeTarget, combine: THREE.MultiplyOperation } ) ] );
+				mlib.body.push( [ "Carmine", new THREE.MeshPhongMaterial( { color: 0x770000, specular: 0xffaaaa, envMap: cubeTexture, combine: THREE.MultiplyOperation } ) ] );
+				mlib.body.push( [ "Gold", new THREE.MeshPhongMaterial( { color: 0xaa9944, specular: 0xbbaa99, shininess: 50, envMap: cubeTexture, combine: THREE.MultiplyOperation } ) ] );
+				mlib.body.push( [ "Bronze", new THREE.MeshPhongMaterial( { color: 0x150505, specular: 0xee6600, shininess: 10, envMap: cubeTexture, combine: THREE.MixOperation, reflectivity: 0.2 } ) ] );
+				mlib.body.push( [ "Chrome", new THREE.MeshPhongMaterial( { color: 0xffffff, specular: 0xffffff, envMap: cubeTexture, combine: THREE.MultiplyOperation } ) ] );
 
 				// FLARES
 				var textureLoader = new THREE.TextureLoader();
@@ -440,7 +440,7 @@
 
 				// motion blur
 
-				effectBlend.uniforms[ 'tDiffuse2' ].value = effectSave.renderTarget;
+				effectBlend.uniforms[ 'tDiffuse2' ].value = effectSave.renderTarget.texture;
 				effectBlend.uniforms[ 'mixRatio' ].value = 0.65;
 
 				var renderModel = new THREE.RenderPass( scene, camera );
@@ -671,7 +671,7 @@
 
 				var shadowPlane = new THREE.PlaneBufferGeometry( shadowWidth, shadowHeight );
 				var shadowMaterial = new THREE.MeshBasicMaterial( {
-					color: 0xffffff, opacity: 0.5, transparent: true, map: shadowTexture,
+					color: 0xffffff, opacity: 0.5, transparent: true, map: shadowTexture.texture,
 					polygonOffset: false, polygonOffsetFactor: -0.5, polygonOffsetUnits: 1
 				} );
 

--- a/examples/webgl_materials_cubemap_dynamic2.html
+++ b/examples/webgl_materials_cubemap_dynamic2.html
@@ -78,7 +78,7 @@
 
 				//
 
-				var material = new THREE.MeshBasicMaterial( { envMap: cubeCamera.renderTarget } );
+				var material = new THREE.MeshBasicMaterial( { envMap: cubeCamera.renderTarget.texture } );
 
 				sphere = new THREE.Mesh( new THREE.SphereGeometry( 20, 30, 15 ), material );
 				scene.add( sphere );

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -152,6 +152,7 @@
 					pmremCubeUVPacker.update( renderer );
 
 					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+
 				} );
 
 				var ldrUrls = genCubeUrls( "./textures/cube/pisa/", ".png" );
@@ -166,6 +167,7 @@
 					pmremCubeUVPacker.update( renderer );
 
 					ldrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+
 				} );
 
 
@@ -181,6 +183,7 @@
 					pmremCubeUVPacker.update( renderer );
 
 					rgbmCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+
 				} );
 
 				// Lights
@@ -252,20 +255,28 @@
 
 					standardMaterial.roughness = params.roughness;
 					standardMaterial.bumpScale = - 0.05 * params.bumpScale;
+
 					var newEnvMap = standardMaterial.envMap;
+
 					switch( params.envMap ) {
+
 						case 'None': newEnvMap = null; break;
-						case 'LDR': newEnvMap = ldrCubeRenderTarget; break;
-						case 'HDR': newEnvMap = hdrCubeRenderTarget; break;
-						case 'RGBM16': newEnvMap = rgbmCubeRenderTarget; break;
+						case 'LDR': newEnvMap = ldrCubeRenderTarget ? ldrCubeRenderTarget.texture : undefined; break;
+						case 'HDR': newEnvMap = hdrCubeRenderTarget ? hdrCubeRenderTarget.texture : undefined; break;
+						case 'RGBM16': newEnvMap = rgbmCubeRenderTarget ? rgbmCubeRenderTarget.texture : undefined; break;
+
 					}
+
 					if( newEnvMap !== standardMaterial.envMap ) {
+
 						standardMaterial.envMap = newEnvMap;
 						standardMaterial.needsUpdate = true;
 						floorMaterial.emissive = new THREE.Color( 1, 1, 1 );
 						floorMaterial.emissiveMap = newEnvMap;
 						floorMaterial.needsUpdate = true;
+
 					}
+
 				}
 
 				renderer.toneMappingExposure = Math.pow( params.exposure, 4.0 );

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -261,9 +261,9 @@
 					switch( params.envMap ) {
 
 						case 'None': newEnvMap = null; break;
-						case 'LDR': newEnvMap = ldrCubeRenderTarget ? ldrCubeRenderTarget.texture : undefined; break;
-						case 'HDR': newEnvMap = hdrCubeRenderTarget ? hdrCubeRenderTarget.texture : undefined; break;
-						case 'RGBM16': newEnvMap = rgbmCubeRenderTarget ? rgbmCubeRenderTarget.texture : undefined; break;
+						case 'LDR': newEnvMap = ldrCubeRenderTarget ? ldrCubeRenderTarget.texture : null; break;
+						case 'HDR': newEnvMap = hdrCubeRenderTarget ? hdrCubeRenderTarget.texture : null; break;
+						case 'RGBM16': newEnvMap = rgbmCubeRenderTarget ? rgbmCubeRenderTarget.texture : null; break;
 
 					}
 

--- a/examples/webgl_materials_reflectivity.html
+++ b/examples/webgl_materials_reflectivity.html
@@ -167,8 +167,9 @@
 
 					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
 
-					gemFrontMaterial.envMap = gemBackMaterial.envMap = hdrCubeRenderTarget;
+					gemFrontMaterial.envMap = gemBackMaterial.envMap = hdrCubeRenderTarget.texture;
 					gemFrontMaterial.needsUpdate = gemBackMaterial.needsUpdate = true;
+
 				} );
 
 

--- a/examples/webgl_materials_skin.html
+++ b/examples/webgl_materials_skin.html
@@ -209,7 +209,7 @@
 				composerScene = new THREE.EffectComposer( renderer, new THREE.WebGLRenderTarget( rtwidth, rtheight, pars ) );
 				composerScene.addPass( renderModelUV );
 
-				renderScene = new THREE.TexturePass( composerScene.renderTarget2 );
+				renderScene = new THREE.TexturePass( composerScene.renderTarget2.texture );
 
 				//
 
@@ -236,12 +236,12 @@
 
 				//
 
-				uniforms[ "tBlur1" ].value = composerScene.renderTarget2;
-				uniforms[ "tBlur2" ].value = composerUV1.renderTarget2;
-				uniforms[ "tBlur3" ].value = composerUV2.renderTarget2;
-				uniforms[ "tBlur4" ].value = composerUV3.renderTarget2;
+				uniforms[ "tBlur1" ].value = composerScene.renderTarget2.texture;
+				uniforms[ "tBlur2" ].value = composerUV1.renderTarget2.texture;
+				uniforms[ "tBlur3" ].value = composerUV2.renderTarget2.texture;
+				uniforms[ "tBlur4" ].value = composerUV3.renderTarget2.texture;
 
-				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1;
+				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1.texture;
 
 				//
 

--- a/examples/webgl_materials_standard.html
+++ b/examples/webgl_materials_standard.html
@@ -200,8 +200,9 @@
 
 					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
 
-					material.envMap = hdrCubeRenderTarget;
+					material.envMap = hdrCubeRenderTarget.texture;
 					material.needsUpdate = true;
+
 				} );
 
 				//

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -234,7 +234,7 @@
 
 				//
 
-				renderScene = new THREE.TexturePass( composerScene.renderTarget2 );
+				renderScene = new THREE.TexturePass( composerScene.renderTarget2.texture );
 
 				//
 
@@ -287,7 +287,7 @@
 
 				//onWindowResize();
 
-				renderScene.uniforms[ "tDiffuse" ].value = composerScene.renderTarget2;
+				renderScene.uniforms[ "tDiffuse" ].value = composerScene.renderTarget2.texture;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
@@ -317,7 +317,7 @@
 				composer3.setSize( halfWidth, halfHeight );
 				composer4.setSize( halfWidth, halfHeight );
 
-				renderScene.uniforms[ "tDiffuse" ].value = composerScene.renderTarget2;
+				renderScene.uniforms[ "tDiffuse" ].value = composerScene.renderTarget2.texture;
 
 				quadBG.scale.set( window.innerWidth, window.innerHeight, 1 );
 				quadMask.scale.set( window.innerWidth / 2, window.innerHeight / 2, 1 );

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -409,8 +409,8 @@ Use WEBGL Depth buffer support?
 
 				postprocessing.bokeh_uniforms = THREE.UniformsUtils.clone( bokeh_shader.uniforms );
 
-				postprocessing.bokeh_uniforms[ "tColor" ].value = postprocessing.rtTextureColor;
-				postprocessing.bokeh_uniforms[ "tDepth" ].value = postprocessing.rtTextureDepth;
+				postprocessing.bokeh_uniforms[ "tColor" ].value = postprocessing.rtTextureColor.texture;
+				postprocessing.bokeh_uniforms[ "tDepth" ].value = postprocessing.rtTextureDepth.texture;
 
 				postprocessing.bokeh_uniforms[ "textureWidth" ].value = window.innerWidth;
 

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -345,7 +345,7 @@
 					var stepLen = filterLen * Math.pow( TAPS_PER_PASS, -pass );
 
 					postprocessing.godrayGenUniforms[ "fStepSize" ].value = stepLen;
-					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureDepth;
+					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureDepth.texture;
 
 					postprocessing.scene.overrideMaterial = postprocessing.materialGodraysGenerate;
 
@@ -357,7 +357,7 @@
 					stepLen = filterLen * Math.pow( TAPS_PER_PASS, -pass );
 
 					postprocessing.godrayGenUniforms[ "fStepSize" ].value = stepLen;
-					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureGodRays2;
+					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureGodRays2.texture;
 
 					renderer.render( postprocessing.scene, postprocessing.camera, postprocessing.rtTextureGodRays1  );
 
@@ -367,14 +367,14 @@
 					stepLen = filterLen * Math.pow( TAPS_PER_PASS, -pass );
 
 					postprocessing.godrayGenUniforms[ "fStepSize" ].value = stepLen;
-					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureGodRays1;
+					postprocessing.godrayGenUniforms[ "tInput" ].value = postprocessing.rtTextureGodRays1.texture;
 
 					renderer.render( postprocessing.scene, postprocessing.camera , postprocessing.rtTextureGodRays2  );
 
 					// final pass - composite god-rays onto colors
 
-					postprocessing.godrayCombineUniforms["tColors"].value = postprocessing.rtTextureColors;
-					postprocessing.godrayCombineUniforms["tGodRays"].value = postprocessing.rtTextureGodRays2;
+					postprocessing.godrayCombineUniforms["tColors"].value = postprocessing.rtTextureColors.texture;
+					postprocessing.godrayCombineUniforms["tGodRays"].value = postprocessing.rtTextureGodRays2.texture;
 
 					postprocessing.scene.overrideMaterial = postprocessing.materialGodraysCombine;
 

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -185,7 +185,7 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 				ssaoPass = new THREE.ShaderPass( THREE.SSAOShader );
 				ssaoPass.renderToScreen = true;
 				//ssaoPass.uniforms[ "tDiffuse" ].value will be set by ShaderPass
-				ssaoPass.uniforms[ "tDepth" ].value = depthRenderTarget;
+				ssaoPass.uniforms[ "tDepth" ].value = depthRenderTarget.texture;
 				ssaoPass.uniforms[ 'size' ].value.set( window.innerWidth, window.innerHeight );
 				ssaoPass.uniforms[ 'cameraNear' ].value = camera.near;
 				ssaoPass.uniforms[ 'cameraFar' ].value = camera.far;

--- a/examples/webgl_read_float_buffer.html
+++ b/examples/webgl_read_float_buffer.html
@@ -136,7 +136,7 @@
 
 				var materialScreen = new THREE.ShaderMaterial( {
 
-					uniforms: { tDiffuse: { type: "t", value: rtTexture } },
+					uniforms: { tDiffuse: { type: "t", value: rtTexture.texture } },
 					vertexShader: document.getElementById( 'vertexShader' ).textContent,
 					fragmentShader: document.getElementById( 'fragment_shader_screen' ).textContent,
 

--- a/examples/webgl_rtt.html
+++ b/examples/webgl_rtt.html
@@ -139,7 +139,7 @@
 
 				var materialScreen = new THREE.ShaderMaterial( {
 
-					uniforms: { tDiffuse: { type: "t", value: rtTexture } },
+					uniforms: { tDiffuse: { type: "t", value: rtTexture.texture } },
 					vertexShader: document.getElementById( 'vertexShader' ).textContent,
 					fragmentShader: document.getElementById( 'fragment_shader_screen' ).textContent,
 
@@ -174,7 +174,7 @@
 
 				var n = 5,
 					geometry = new THREE.SphereGeometry( 10, 64, 32 ),
-					material2 = new THREE.MeshBasicMaterial( { color: 0xffffff, map: rtTexture } );
+					material2 = new THREE.MeshBasicMaterial( { color: 0xffffff, map: rtTexture.texture } );
 
 				for( var j = 0; j < n; j ++ ) {
 

--- a/examples/webgl_shaders_ocean2.html
+++ b/examples/webgl_shaders_ocean2.html
@@ -176,10 +176,10 @@
 						this.ms_Ocean.materialOcean.uniforms.u_exposure.value = this.ms_Ocean.exposure;
 						this.ms_Ocean.changed = false;
 					}
-					this.ms_Ocean.materialOcean.uniforms.u_normalMap.value = this.ms_Ocean.normalMapFramebuffer ;
-					this.ms_Ocean.materialOcean.uniforms.u_displacementMap.value = this.ms_Ocean.displacementMapFramebuffer ;
-					this.ms_Ocean.materialOcean.uniforms.u_projectionMatrix.value = this.ms_Camera.projectionMatrix ;
-					this.ms_Ocean.materialOcean.uniforms.u_viewMatrix.value = this.ms_Camera.matrixWorldInverse ;
+					this.ms_Ocean.materialOcean.uniforms.u_normalMap.value = this.ms_Ocean.normalMapFramebuffer.texture;
+					this.ms_Ocean.materialOcean.uniforms.u_displacementMap.value = this.ms_Ocean.displacementMapFramebuffer.texture;
+					this.ms_Ocean.materialOcean.uniforms.u_projectionMatrix.value = this.ms_Camera.projectionMatrix;
+					this.ms_Ocean.materialOcean.uniforms.u_viewMatrix.value = this.ms_Camera.matrixWorldInverse;
 					this.ms_Ocean.materialOcean.uniforms.u_cameraPosition.value = this.ms_Camera.position;
 					this.ms_Ocean.materialOcean.depthTest = true;
 					//this.ms_Scene.__lights[1].position.x = this.ms_Scene.__lights[1].position.x + 0.01;

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -143,7 +143,7 @@
 
 				var materialLambert = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, map: textureNoiseColor } );
 				var materialPhong = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, specular: 0x999999, map: textureLava } );
-				var materialPhongCube = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, specular: 0x999999, envMap: cubeCamera.renderTarget } );
+				var materialPhongCube = new THREE.MeshPhongMaterial( { shininess: 50, color: 0xffffff, specular: 0x999999, envMap: cubeCamera.renderTarget.texture } );
 
 				// OBJECTS
 

--- a/examples/webgl_terrain_dynamic.html
+++ b/examples/webgl_terrain_dynamic.html
@@ -308,7 +308,7 @@
 
 				uniformsNormal.height.value = 0.05;
 				uniformsNormal.resolution.value.set( rx, ry );
-				uniformsNormal.heightMap.value = heightMap;
+				uniformsNormal.heightMap.value = heightMap.texture;
 
 				var vertexShader = document.getElementById( 'vertexShader' ).textContent;
 
@@ -337,14 +337,14 @@
 
 				uniformsTerrain = THREE.UniformsUtils.clone( terrainShader.uniforms );
 
-				uniformsTerrain[ 'tNormal' ].value = normalMap;
+				uniformsTerrain[ 'tNormal' ].value = normalMap.texture;
 				uniformsTerrain[ 'uNormalScale' ].value = 3.5;
 
-				uniformsTerrain[ 'tDisplacement' ].value = heightMap;
+				uniformsTerrain[ 'tDisplacement' ].value = heightMap.texture;
 
 				uniformsTerrain[ 'tDiffuse1' ].value = diffuseTexture1;
 				uniformsTerrain[ 'tDiffuse2' ].value = diffuseTexture2;
-				uniformsTerrain[ 'tSpecular' ].value = specularMap;
+				uniformsTerrain[ 'tSpecular' ].value = specularMap.texture;
 				uniformsTerrain[ 'tDetail' ].value = detailTexture;
 
 				uniformsTerrain[ 'enableDiffuse1' ].value = true;

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -176,7 +176,7 @@
 					var pmremCubeUVPacker = new THREE.PMREMCubeUVPacker( pmremGenerator.cubeLods );
 					pmremCubeUVPacker.update( renderer );
 
-					standardMaterial.envMap = pmremCubeUVPacker.CubeUVRenderTarget;
+					standardMaterial.envMap = pmremCubeUVPacker.CubeUVRenderTarget.texture;
 					standardMaterial.needsUpdate = true;
 
 				} );


### PR DESCRIPTION
Updated examples according to the changes in #8658.
