### PR TITLE
Fix VREffect handling of full screen state

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -98,11 +98,19 @@ THREE.VREffect = function ( renderer, onError ) {
 	// fullscreen
 
 	var canvas = renderer.domElement;
-	var fullscreenchange = canvas.mozRequestFullScreen ? 'mozfullscreenchange' : 'webkitfullscreenchange';
+	var requestFullscreen;
+	var fullscreenElement;
 
-	document.addEventListener( fullscreenchange, function () {
+	function onFullscreenChange() {
 
-		isPresenting = vrHMD !== undefined && ( vrHMD.isPresenting || ( isDeprecatedAPI && ( document.mozFullScreenElement || document.webkitFullscreenElement ) !== undefined ) );
+		var wasPresenting = isPresenting;
+		isPresenting = vrHMD !== undefined && ( vrHMD.isPresenting || ( isDeprecatedAPI && document[fullscreenElement] instanceof window.HTMLElement ) );
+
+		if ( wasPresenting === isPresenting ) {
+
+			return;
+
+		}
 
 		if ( isPresenting ) {
 
@@ -134,29 +142,29 @@ THREE.VREffect = function ( renderer, onError ) {
 
 		}
 
-	}, false );
+	}
 
-	window.addEventListener( 'vrdisplaypresentchange', function () {
+	if ( canvas.requestFullscreen ) {
 
-		isPresenting = vrHMD && vrHMD.isPresenting;
+		requestFullscreen = 'requestFullscreen';
+		fullscreenElement = 'fullscreenElement';
 
-		if ( isPresenting ) {
+	} else if ( canvas.mozRequestFullScreen ) {
 
-			rendererPixelRatio = renderer.getPixelRatio();
-			rendererSize = renderer.getSize();
+		requestFullscreen = 'mozRequestFullScreen';
+		fullscreenElement = 'mozFullScreenElement'
+		document.addEventListener( 'mozfullscreenchange', onFullscreenChange, false );
 
-			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
-			renderer.setPixelRatio( 1 );
-			renderer.setSize( eyeParamsL.renderWidth * 2, eyeParamsL.renderHeight, false );
+	} else {
 
-		} else {
+		requestFullscreen = 'webkitRequestFullscreen';
+		fullscreenElement = 'webkitFullscreenElement';
+		document.addEventListener( 'webkitfullscreenchange', onFullscreenChange, false );
 
-			renderer.setPixelRatio( rendererPixelRatio );
-			renderer.setSize( rendererSize.width, rendererSize.height );
+	}
 
-		}
-
-	}, false );
+	document.addEventListener( 'fullscreenchange', onFullscreenChange, false );
+	window.addEventListener( 'vrdisplaypresentchange', onFullscreenChange, false );
 
 	this.setFullScreen = function ( boolean ) {
 
@@ -189,14 +197,9 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			} else {
 
-				if ( canvas.mozRequestFullScreen ) {
+				if ( canvas[requestFullscreen] ) {
 
-					canvas.mozRequestFullScreen( { vrDisplay: vrHMD } );
-					resolve();
-
-				} else if ( canvas.webkitRequestFullscreen ) {
-
-					canvas.webkitRequestFullscreen( { vrDisplay: vrHMD } );
+					canvas[requestFullscreen]( { vrDisplay: vrHMD } );
 					resolve();
 
 				} else {


### PR DESCRIPTION
- Use unprefixed Fullscreen API in `VREffect` if available #8568
- Prevent over-writing of backup value for pixel ratio #8776

This code listens on both prefixed and un-prefixed events. Firefox Nightly on Windows currently only fires one of these events, depending on whether the prefixed version of `requestFullscreen` was used. Since it's possible that full screen may be requested outside of this module (e.g. webvr-boilerplate), we use both events to be safe.

This has been tested on:
- iPhone, polyfill
- Android Chrome, polyfill
- Windows Chrome, WebVR 1.0
- Windows/Mac Firefox, WebVR Deprecated
