### PR TITLE
Quaternion: added premultiply() method

### DIFF
--- a/docs/api/math/Quaternion.html
+++ b/docs/api/math/Quaternion.html
@@ -107,9 +107,14 @@
 		Normalizes this quaternion.
 		</div>
 
-		<h3>[method:Quaternion multiply]( [page:Quaternion b] ) [page:Quaternion this]</h3>
+		<h3>[method:Quaternion multiply]( [page:Quaternion q] ) [page:Quaternion this]</h3>
 		<div>
-		Multiplies this quaternion by *b*.
+		Multiplies this quaternion by *q*.
+		</div>
+
+		<h3>[method:Quaternion premultiply]( [page:Quaternion q] ) [page:Quaternion this]</h3>
+		<div>
+		Pre-multiplies this quaternion by *q*.
 		</div>
 
 		<h3>[method:Quaternion multiplyQuaternions]( [page:Quaternion a], [page:Quaternion b] ) [page:Quaternion this]</h3>

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -375,6 +375,12 @@ THREE.Quaternion.prototype = {
 
 	},
 
+	premultiply: function ( q ) {
+
+		return this.multiplyQuaternions( q, this );
+
+	},
+
 	multiplyQuaternions: function ( a, b ) {
 
 		// from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm


### PR DESCRIPTION
Avoids having to use this construct:

``` javascript
object.quaternion.multiplyQuaternions( q, object.quaternion );
```

Now:

``` javascript
object.quaternion.premultiply( q );
```
