### PR TITLE
VREffect should continue to set correct CSS size on the renderer domElement.

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -82,6 +82,8 @@ THREE.VREffect = function ( renderer, onError ) {
 			} else {
 
 				renderer.setSize( eyeParamsL.renderWidth * 2, eyeParamsL.renderHeight, false );
+        renderer.domElement.style.width = width + 'px';
+        renderer.domElement.style.height = height + 'px';
 
 			}
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -82,8 +82,8 @@ THREE.VREffect = function ( renderer, onError ) {
 			} else {
 
 				renderer.setSize( eyeParamsL.renderWidth * 2, eyeParamsL.renderHeight, false );
-        renderer.domElement.style.width = width + 'px';
-        renderer.domElement.style.height = height + 'px';
+				renderer.domElement.style.width = width + 'px';
+				renderer.domElement.style.height = height + 'px';
 
 			}
 


### PR DESCRIPTION
We are dealing with two different dimensions. 
1. Size of the actual canvas we're rendering to.
2. CSS size of the canvas element.

`setSize` doesn't make this difference explicit. 

`renderer.setSize` has a `updateStyle` param which we set to false, but then the CSS width is never set at all. This is clearly the right place to set both, but I don't like that we are breaking into the domElement directly. This can be remedied by adding a setCssSize() or similar on the renderer.
