### PR TITLE
Remove mouseout handlers from OrbitControls

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -221,7 +221,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
-		document.removeEventListener( 'mouseout', onMouseUp, false );
 
 		window.removeEventListener( 'keydown', onKeyDown, false );
 
@@ -702,7 +701,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			document.addEventListener( 'mousemove', onMouseMove, false );
 			document.addEventListener( 'mouseup', onMouseUp, false );
-			document.addEventListener( 'mouseout', onMouseUp, false );
 
 			scope.dispatchEvent( startEvent );
 
@@ -746,7 +744,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
-		document.removeEventListener( 'mouseout', onMouseUp, false );
 
 		scope.dispatchEvent( endEvent );
 


### PR DESCRIPTION
(re: https://github.com/mrdoob/three.js/issues/8157 )

The mouseout handler in OrbitControls was added here: https://github.com/mrdoob/three.js/pull/7434

The change makes no sense because it disables the built-in mouse capturing behavior in OrbitControls, creating a lot of dead code. After removing the mouseout handlers, I can't reproduce any sticky mouse behavior in OS X Chrome, Safari or Firefox:

http://acko.net/files/dump/orbitcontrols/error.html
http://acko.net/files/dump/orbitcontrols/fixed.html

This is particularly bad when you have elements overlapping the renderer, because they also trigger mouseout, e.g. http://acko.net/files/dump/orbitcontrols/overlay.html

So either the original request was due to another browser/OS failing to fire the mouseup event, or a specific situation where mouseup is not firing (iframes?). Either way, the current behavior is not usable nor consistent and this change should be reverted.
