### PR TITLE
Bottom mapping ok from outside

### DIFF
--- a/src/extras/geometries/CylinderBufferGeometry.js
+++ b/src/extras/geometries/CylinderBufferGeometry.js
@@ -273,7 +273,7 @@ THREE.CylinderBufferGeometry = function( radiusTop, radiusBottom, height, radial
 
 			// uv
 			uv.x = ( cosTheta * 0.5 ) + 0.5;
-			uv.y = ( sinTheta * 0.5 ) + 0.5;
+			uv.y = ( sinTheta * 0.5 * sign ) + 0.5;
 			uvs.setXY( index, uv.x, uv.y );
 
 			// increase index


### PR DESCRIPTION
The original mapping on the bottom cap is ok when you look inside of the cylinder.
But by default the bottom cap is not visible inside, but is visible outside, so the texture is not correctly mapped.
