### PR TITLE
ColladaLoader - Allow unaccompanied transparency tags

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1182,7 +1182,7 @@ THREE.ColladaLoader = function () {
 				if ( num_materials > 1 ) {
 
 					material = new THREE.MultiMaterial( used_materials_array );
-					
+
 					for ( j = 0; j < geom.faces.length; j ++ ) {
 
 						var face = geom.faces[ j ];
@@ -3656,17 +3656,22 @@ THREE.ColladaLoader = function () {
 
 		var transparent = false;
 
-		if (this['transparency'] !== undefined && this['transparent'] !== undefined) {
-			// convert transparent color RBG to average value
-			var transparentColor = this['transparent'];
-			var transparencyLevel = (this.transparent.color.r + this.transparent.color.g + this.transparent.color.b) / 3 * this.transparency;
+		if (this['transparency'] !== undefined) {
 
-			if (transparencyLevel > 0) {
-				transparent = true;
-				props[ 'transparent' ] = true;
-				props[ 'opacity' ] = 1 - transparencyLevel;
+			if (this['transparent'] !== undefined) {
+				// convert transparent color RBG to average value
+				var transparentColor = this['transparent'];
+				var transparencyLevel = (this.transparent.color.r + this.transparent.color.g + this.transparent.color.b) / 3 * this.transparency;
 
+				if (transparencyLevel > 0) {
+					props[ 'opacity' ] = 1 - transparencyLevel;
+				}
+			} else {
+				props[ 'opacity' ] = this.transparency;
 			}
+
+			transparent = true;
+			props[ 'transparent' ] = true;
 
 		}
 


### PR DESCRIPTION
As per #8835 - this PR allows for a material definition containing a lone `<transparency>` tag, as is produced by Blender.

As an aside, I really don't understand how line 3664 of the PR can work though it was left untouched and should function as it did previously. I don't have a matching model to test it with but as far as I can see an rgb value of '0 0 0' (black) would always result in 0 opacity, regardless of the actual transparency value used. Maybe someone more familiar with the original intention of the code can comment on that.
