### PR TITLE
remove warnings from CubeUV shader

### DIFF
--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl
@@ -1,6 +1,6 @@
 #ifdef ENVMAP_TYPE_CUBE_UV
 
-const float cubeUV_textureSize = 1024.0;
+#define cubeUV_textureSize (1024.0)
 
 int getFaceFromDirection(vec3 direction) {
 	vec3 absDirection = abs(direction);
@@ -19,8 +19,8 @@ int getFaceFromDirection(vec3 direction) {
 	}
 	return face;
 }
-float cubeUV_maxLods1 = log2(cubeUV_textureSize*0.25) - 1.0;
-float cubeUV_rangeClamp = exp2((6.0 - 1.0) * 2.0);
+#define cubeUV_maxLods1  (log2(cubeUV_textureSize*0.25) - 1.0)
+#define cubeUV_rangeClamp (exp2((6.0 - 1.0) * 2.0))
 
 vec2 MipLevelInfo( vec3 vec, float roughnessLevel, float roughness ) {
 	float scale = exp2(cubeUV_maxLods1 - roughnessLevel);
@@ -35,8 +35,8 @@ vec2 MipLevelInfo( vec3 vec, float roughnessLevel, float roughness ) {
 	return vec2(floor(mipLevel), fract(mipLevel));
 }
 
-float cubeUV_maxLods2 = log2(cubeUV_textureSize*0.25) - 2.0;
-const float cubeUV_rcpTextureSize = 1.0 / cubeUV_textureSize;
+#define cubeUV_maxLods2 (log2(cubeUV_textureSize*0.25) - 2.0)
+#define cubeUV_rcpTextureSize (1.0 / cubeUV_textureSize)
 
 vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
 	mipLevel = roughnessLevel > cubeUV_maxLods2 - 3.0 ? 0.0 : mipLevel;
@@ -97,7 +97,7 @@ vec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {
 	return base + s * ( scale - 2.0 * texelOffset );
 }
 
-float cubeUV_maxLods3 = log2(cubeUV_textureSize*0.25) - 3.0;
+#define cubeUV_maxLods3 (log2(cubeUV_textureSize*0.25) - 3.0)
 
 vec4 textureCubeUV(vec3 reflectedDirection, float roughness ) {
 	float roughnessVal = roughness* cubeUV_maxLods3;


### PR DESCRIPTION
I've removed the float consts in the cubeUV shader and replaced them with defines.  It was producing warnings the other way, even though they all should have been const.  Hopefully with these defines, the compiler will precompute the constants.
