### PR TITLE
Last spline coordinates not stored in actions

### DIFF
--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -113,6 +113,10 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 		var curve = new THREE.SplineCurve( npts );
 		this.curves.push( curve );
 
+		var lastPoint = pts[ pts.length - 1 ];
+		args.push( lastPoint.x );
+		args.push( lastPoint.y );
+
 		this.actions.push( { action: 'splineThru', args: args } );
 
 	},


### PR DESCRIPTION
In the actions array of the Path, the last elements of the args array
need to be the x and y of the last point of the segment added to the
path.
Not the case with splineThru => cause an exception if you add an other
segment after the pline (without a moveTo).
Used the same trick as absellipse does.
