### PR TITLE
SEA3D and AnimationClip update 

### DIFF
--- a/examples/js/loaders/sea3d/SEA3DLoader.js
+++ b/examples/js/loaders/sea3d/SEA3DLoader.js
@@ -1393,7 +1393,7 @@ THREE.SEA3D.prototype.readAnimation = function( sea ) {
 				case SEA3D.Stream.DOUBLE:
 				case SEA3D.Stream.DECIMAL:
 
-					var values = data.slice( start, end );
+					var values = data.subarray( start, end );
 					var times = new Float32Array( values.length );
 
 					for ( var k = 0, t = 0; k < times.length; k ++ ) {
@@ -1409,7 +1409,7 @@ THREE.SEA3D.prototype.readAnimation = function( sea ) {
 
 				case SEA3D.Stream.VECTOR3D:
 
-					var values = data.slice( start, end );
+					var values = data.subarray( start, end );
 					var times = new Float32Array( values.length / anm.blockSize );
 
 					for ( var k = 0, t = 0; k < times.length; k ++ ) {
@@ -1425,7 +1425,7 @@ THREE.SEA3D.prototype.readAnimation = function( sea ) {
 
 				case SEA3D.Stream.VECTOR4D:
 
-					var values = data.slice( start, end );
+					var values = data.subarray( start, end );
 					var times = new Float32Array( values.length / anm.blockSize );
 
 					for ( var k = 0, t = 0; k < times.length; k ++ ) {

--- a/examples/js/loaders/sea3d/SEA3DLoader.js
+++ b/examples/js/loaders/sea3d/SEA3DLoader.js
@@ -462,17 +462,15 @@ THREE.SEA3D.ScriptHandler.dispatchUpdate = function( delta ) {
 //	Animator
 //
 
-THREE.SEA3D.Animator = function( clips, mixer ) {
+THREE.SEA3D.Animator = function( clips, animationTarget ) {
 
 	this.clips = clips;
 
-	this.updateAnimations( mixer );
+	this.updateAnimations( animationTarget );
 
 };
 
-THREE.SEA3D.Animator.prototype.update = function( dt ) {
-
-	this.mixer.update( dt );
+THREE.SEA3D.Animator.prototype.update = function() {
 
 	if ( ! this.currentAnimationAction.enabled && ! this.currentAnimationData.completed ) {
 
@@ -484,18 +482,18 @@ THREE.SEA3D.Animator.prototype.update = function( dt ) {
 
 };
 
-THREE.SEA3D.Animator.prototype.updateAnimations = function( mixer ) {
+THREE.SEA3D.Animator.prototype.updateAnimations = function( animationTarget ) {
 
 	if ( this.playing ) this.stop();
 
-	if ( this.mixer ) THREE.SEA3D.AnimationHandler.removeAnimator( this );
+	if ( this.animationTarget ) THREE.SEA3D.AnimationHandler.removeAnimator( this );
 
-	this.mixer = mixer;
+	this.animationTarget = animationTarget;
 
 	this.relative = false;
 	this.playing = false;
 
-	this.setTimeScale( 1 );
+	this.timeScale = 1;
 
 	this.animations = [];
 	this.animationsData = {};
@@ -551,15 +549,21 @@ THREE.SEA3D.Animator.prototype.resume = function() {
 
 THREE.SEA3D.Animator.prototype.setTimeScale = function( val ) {
 
-	this.mixer._timeScale = val;
+	this.timeScale = val;
 
-	this.mixer.timeScale = val * ( this.currentAnimation ? this.currentAnimation.timeScale : 1 );
+	if ( this.currentAnimationAction ) this.updateTimeScale();
 
 };
 
 THREE.SEA3D.Animator.prototype.getTimeScale = function() {
 
-	return this.mixer._timeScale;
+	return this.timeScale;
+
+};
+
+THREE.SEA3D.Animator.prototype.updateTimeScale = function() {
+
+	this.currentAnimationAction.setEffectiveTimeScale( this.timeScale * ( this.currentAnimation ? this.currentAnimation.timeScale : 1 ) );
 
 };
 
@@ -575,7 +579,7 @@ THREE.SEA3D.Animator.prototype.play = function( name, crossfade, offset, weight 
 	this.currentAnimation = animation;
 
 	this.previousAnimationAction = this.currentAnimationAction;
-	this.currentAnimationAction = this.mixer.clipAction( animation ).setLoop( animation.loop ? THREE.LoopRepeat : THREE.LoopOnce, Infinity ).reset();
+	this.currentAnimationAction = THREE.SEA3D.AnimationHandler.mixer.clipAction( animation, this.animationTarget ).setLoop( animation.loop ? THREE.LoopRepeat : THREE.LoopOnce, Infinity ).reset();
 
 	this.previousAnimationData = this.currentAnimationData;
 	this.currentAnimationData = this.animationsData[ name ];
@@ -584,17 +588,19 @@ THREE.SEA3D.Animator.prototype.play = function( name, crossfade, offset, weight 
 
 	if ( weight !== undefined ) this.currentAnimationAction.setEffectiveWeight( weight );
 
+	this.updateTimeScale();
+
 	this.currentAnimationAction.play();
 
-	this.mixer.timeScale = this.mixer._timeScale * this.currentAnimation.timeScale;
-
-	if ( ! this.playing ) this.mixer.update( 0 );
+	if ( ! this.playing ) THREE.SEA3D.AnimationHandler.mixer.update( 0 );
 
 	this.playing = true;
 
 	if ( this.previousAnimation ) {
 
-		this.mixer.clipAction( this.previousAnimation ).crossFadeTo( this.mixer.clipAction( this.currentAnimation ), crossfade || 0, true );
+		var toAction = THREE.SEA3D.AnimationHandler.mixer.clipAction( this.currentAnimation, this.animationTarget );
+
+		THREE.SEA3D.AnimationHandler.mixer.clipAction( this.previousAnimation, this.animationTarget ).crossFadeTo( toAction, crossfade || 0, true );
 
 	}
 
@@ -681,7 +687,7 @@ THREE.SEA3D.Object3DAnimator.prototype.setRelative = function( val ) {
 
 	this.object3d.setAnimator( this.relative );
 
-	this.updateAnimations( new THREE.AnimationMixer( this.relative ? this.object3d.animate : this.object3d ) );
+	this.updateAnimations( this.relative ? this.object3d.animate : this.object3d );
 
 };
 
@@ -882,7 +888,7 @@ THREE.SEA3D.SkinnedMesh = function( geometry, material, useVertexTexture ) {
 
 	THREE.SkinnedMesh.call( this, geometry, material, useVertexTexture );
 
-	this.updateAnimations( new THREE.AnimationMixer( this ) );
+	this.updateAnimations( this );
 
 };
 
@@ -929,7 +935,7 @@ THREE.SEA3D.VertexAnimationMesh = function( geometry, material ) {
 
 	this.type = 'MorphAnimMesh';
 
-	this.updateAnimations( new THREE.AnimationMixer( this ) );
+	this.updateAnimations( this );
 
 };
 
@@ -1043,15 +1049,19 @@ THREE.SEA3D.PointLight.prototype.copy = function( source ) {
 
 THREE.SEA3D.AnimationHandler = {
 
+	mixer : new THREE.AnimationMixer(),
+
 	animators : [],
 
 	update : function( dt ) {
+
+		this.mixer.update( dt );
 
 		var i = 0;
 
 		while ( i < this.animators.length ) {
 
-			this.animators[ i ++ ].update( dt );
+			this.animators[ i ++ ].update();
 
 		}
 
@@ -2290,11 +2300,7 @@ THREE.SEA3D.prototype.readDirectionalLight = function( sea ) {
 	var light = new THREE.DirectionalLight( sea.color, sea.multiplier * this.config.multiplier );
 	light.name = sea.name;
 
-	if ( sea.shadow ) {
-
-		this.setShadowMap( light );
-
-	}
+	if ( sea.shadow ) this.setShadowMap( light );
 
 	this.domain.lights = this.lights = this.lights || [];
 	this.lights.push( this.objects[ "lht/" + sea.name ] = sea.tag = light );

--- a/examples/js/loaders/sea3d/SEA3DLoader.js
+++ b/examples/js/loaders/sea3d/SEA3DLoader.js
@@ -1785,7 +1785,12 @@ THREE.SEA3D.prototype.readSoundPoint = function( sea ) {
 
 	var sound3d = new THREE.PositionalAudio( this.audioListener );
 
-	sound3d.load( sea.sound.tag );
+	new THREE.AudioLoader().load( sea.sound.tag, function ( buffer ) {
+
+		sound3d.setBuffer( buffer );
+
+	} );
+
 	sound3d.autoplay = sea.autoPlay;
 	sound3d.setLoop( sea.autoPlay );
 	sound3d.setVolume( sea.volume );

--- a/examples/webgl_loader_sea3d_hierarchy.html
+++ b/examples/webgl_loader_sea3d_hierarchy.html
@@ -118,7 +118,6 @@
 				renderer.setClearColor( 0x333333, 1 );
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-				renderer.shadowMap.cullFace = THREE.CullFaceBack;
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/webgl_loader_sea3d_skinning.html
+++ b/examples/webgl_loader_sea3d_skinning.html
@@ -30,7 +30,7 @@
 		<div id="info">
 			<a href="http://threejs.org" target="_blank">three.js</a> - asset by <a href="https://github.com/sunag/sea3d" style="color:#FFFFF" target="_blank">sea3d</a>
 			<br/>BoneObject: Object3D attached in a Bone
-			<br/>Click to hidden/show the hat - Right click to run
+			<br/>Left Click to hidden/show the hat - Right click to run - Middle click to clone
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -118,6 +118,30 @@
 
 			//
 
+			var cloneAsset = function() {
+
+				var count = 0, size = 50;
+
+				return function() {
+
+					var angle = ( Math.PI / 4 ) * count++;
+
+					var container = new THREE.Object3D();
+					container.position.z = ( size * count ) * Math.cos( angle );
+					container.position.x = ( size * count ) * Math.sin( angle );
+
+					scene.add( container );
+					
+					var domain = loader.clone( { 
+						autoPlay : true, 
+						container : container, 
+						lights : false 
+					});
+
+				}
+
+			}();
+
 			function init() {
 
 				scene = new THREE.Scene();
@@ -125,7 +149,7 @@
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );
 
-				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 2000 );
+				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 20000 );
 				camera.position.set( 1000, - 300, 1000 );
 
 				renderer = new THREE.WebGLRenderer();
@@ -179,10 +203,15 @@
 
 			function onMouseClick( e ) {
 
-				if (e.button != 0) return;
+				if (e.button === 0) {
 
-				var hat = loader.getMesh("Hat");
-				hat.visible = !hat.visible;
+					hat.visible = !hat.visible;
+
+				} else if (e.button === 1) {
+
+					cloneAsset();
+
+				}
 
 			}
 

--- a/examples/webgl_loader_sea3d_sound.html
+++ b/examples/webgl_loader_sea3d_sound.html
@@ -458,8 +458,8 @@
 				updateSoundFilter();
 
 				// light intensity from sound amplitude
-				lightOutside.intensity = soundOutsideAnalyser.getAverage() / 100;
-				lightArea.intensity = soundAreaAnalyser.getAverage() / 50;
+				lightOutside.intensity = soundOutsideAnalyser.getAverageFrequency() / 100;
+				lightArea.intensity = soundAreaAnalyser.getAverageFrequency() / 50;
 
 				// Update SEA3D Animations
 				THREE.SEA3D.AnimationHandler.update( delta );

--- a/examples/webgl_loader_sea3d_sound.html
+++ b/examples/webgl_loader_sea3d_sound.html
@@ -151,7 +151,7 @@
 				lightOutside = loader.getLight("Light1");
 
 				soundOutside = loader.getSound3D("Point001");
-				soundOutsideAnalyser = new THREE.AudioAnalyser( soundOutside, 512 );
+				soundOutsideAnalyser = new THREE.AudioAnalyser( soundOutside, 32 );
 
 				// sound asset 2 + area
 
@@ -458,7 +458,7 @@
 				updateSoundFilter();
 
 				// light intensity from sound amplitude
-				lightOutside.intensity = soundOutsideAnalyser.getAverage() / 50;
+				lightOutside.intensity = soundOutsideAnalyser.getAverage() / 100;
 				lightArea.intensity = soundAreaAnalyser.getAverage() / 50;
 
 				// Update SEA3D Animations

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -8,9 +8,11 @@
 
 THREE.AnimationClip = function ( name, duration, tracks ) {
 
-	this.name = name || THREE.Math.generateUUID();
+	this.name = name;
 	this.tracks = tracks;
 	this.duration = ( duration !== undefined ) ? duration : -1;
+
+	this.uuid = THREE.Math.generateUUID();
 
 	// this means it should figure out its duration by scanning the tracks
 	if ( this.duration < 0 ) {

--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -29,7 +29,7 @@ Object.assign( THREE.AnimationMixer.prototype, THREE.EventDispatcher.prototype, 
 
 		var root = optionalRoot || this._root,
 			rootUuid = root.uuid,
-			clipObject = typeof clip === 'string' ? this.getClipByName( clip ) : clip,
+			clipObject = typeof clip === 'string' ? this._getClipByNameAndRoot( clip, rootUuid ) : clip,
 			clipUuid = clipObject ? clipObject.uuid : clip,
 
 			actionsForClip = this._actionsByClip[ clipUuid ],
@@ -83,7 +83,7 @@ Object.assign( THREE.AnimationMixer.prototype, THREE.EventDispatcher.prototype, 
 
 		var root = optionalRoot || this._root,
 			rootUuid = root.uuid,
-			clipObject = typeof clip === 'string' ? this.getClipByName( clip ) : clip,
+			clipObject = typeof clip === 'string' ? this._getClipByNameAndRoot( clip, rootUuid ) : clip,
 			clipUuid = clipObject ? clipObject.uuid : clip,
 
 			actionsForClip = this._actionsByClip[ clipUuid ];
@@ -164,17 +164,6 @@ Object.assign( THREE.AnimationMixer.prototype, THREE.EventDispatcher.prototype, 
 		}
 
 		return this;
-
-	},
-
-	// return the first clip with the name
-	getClipByName: function( name ) {
-
-		for ( var i = 0, acts = this._actions; i < acts.length; ++ i ) {
-
-			if ( acts[ i ]._clip.name === name ) return acts[ i ]._clip;
-
-		}
 
 	},
 
@@ -567,6 +556,20 @@ Object.assign( THREE.AnimationMixer.prototype, {
 				this._removeInactiveBinding( binding );
 
 			}
+
+		}
+
+	},
+
+	_getClipByNameAndRoot: function( name, rootUuid ) {
+
+		// return the first clip with the name
+
+		for ( var i = 0, acts = this._actions, actsByClip = this._actionsByClip; i < acts.length; ++ i ) {
+
+			var clip = acts[ i ]._clip;
+
+			if ( clip.name === name && actsByClip[ clip.uuid ] && actsByClip[ clip.uuid ].actionByRoot[ rootUuid ] ) return clip;
 
 		}
 


### PR DESCRIPTION
- Optimization: Unify SEA3D `AnimationMixer`
- `THREE.AnimationMixer` dictionary based in `AnimationClip.uuid` preventing name conflicts
- Fix cross-browser data.slice to data.subarray
- New features in `webgl_loader_sea3d_skinning` complex clone with middle click ( compatible with sea3d script ).
- Fix deprecated `warns` in set `shadow` and `sound` loader

The `AnimationMixer` update is compatible with the previous examples. 
The recommendation is always use:

``` javascript
mixer.clipAction( animationClip ).. .play()
```

and not:

``` javascript
mixer.clipAction( "animationName" ).. .play()
```

Mainly if the `mixer` have many `animation clips`.
