### PR TITLE
fix buggy prototype usage in Pass derived classes.

### DIFF
--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -125,7 +125,7 @@ THREE.AdaptiveToneMappingPass = function ( adaptive, resolution ) {
 
 THREE.AdaptiveToneMappingPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.AdaptiveToneMappingPass.prototype = {
+Object.assign( THREE.AdaptiveToneMappingPass.prototype, {
 
 	constructor: THREE.AdaptiveToneMappingPass,
 
@@ -317,4 +317,4 @@ THREE.AdaptiveToneMappingPass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -127,8 +127,6 @@ THREE.AdaptiveToneMappingPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.AdaptiveToneMappingPass.prototype, {
 
-	constructor: THREE.AdaptiveToneMappingPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		if ( this.needsInit ) {

--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -75,7 +75,7 @@ THREE.BloomPass = function ( strength, kernelSize, sigma, resolution ) {
 
 THREE.BloomPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.BloomPass.prototype = {
+Object.assign( THREE.BloomPass.prototype, {
 
 	constructor: THREE.BloomPass,
 
@@ -112,7 +112,7 @@ THREE.BloomPass.prototype = {
 
 	}
 
-};
+} );
 
 THREE.BloomPass.blurX = new THREE.Vector2( 0.001953125, 0.0 );
 THREE.BloomPass.blurY = new THREE.Vector2( 0.0, 0.001953125 );

--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -77,8 +77,6 @@ THREE.BloomPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.BloomPass.prototype, {
 
-	constructor: THREE.BloomPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		if ( maskActive ) renderer.context.disable( renderer.context.STENCIL_TEST );

--- a/examples/js/postprocessing/BokehPass.js
+++ b/examples/js/postprocessing/BokehPass.js
@@ -39,7 +39,7 @@ THREE.BokehPass = function ( scene, camera, params ) {
 		console.error( "THREE.BokehPass relies on THREE.BokehShader" );
 
 	}
-	
+
 	var bokehShader = THREE.BokehShader;
 	var bokehUniforms = THREE.UniformsUtils.clone( bokehShader.uniforms );
 
@@ -69,7 +69,7 @@ THREE.BokehPass = function ( scene, camera, params ) {
 
 THREE.BokehPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.BokehPass.prototype = {
+Object.assign( THREE.BokehPass.prototype, {
 
 	constructor: THREE.BokehPass,
 
@@ -101,4 +101,4 @@ THREE.BokehPass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/BokehPass.js
+++ b/examples/js/postprocessing/BokehPass.js
@@ -71,8 +71,6 @@ THREE.BokehPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.BokehPass.prototype, {
 
-	constructor: THREE.BokehPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.quad2.material = this.materialBokeh;

--- a/examples/js/postprocessing/ClearPass.js
+++ b/examples/js/postprocessing/ClearPass.js
@@ -12,7 +12,7 @@ THREE.ClearPass = function () {
 
 THREE.ClearPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.ClearPass.prototype = {
+Object.assign( THREE.ClearPass.prototype, {
 
 	constructor: THREE.ClearPass,
 
@@ -23,4 +23,4 @@ THREE.ClearPass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/ClearPass.js
+++ b/examples/js/postprocessing/ClearPass.js
@@ -14,8 +14,6 @@ THREE.ClearPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.ClearPass.prototype, {
 
-	constructor: THREE.ClearPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		renderer.setRenderTarget( readBuffer );

--- a/examples/js/postprocessing/DotScreenPass.js
+++ b/examples/js/postprocessing/DotScreenPass.js
@@ -35,7 +35,7 @@ THREE.DotScreenPass = function ( center, angle, scale ) {
 
 THREE.DotScreenPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.DotScreenPass.prototype = {
+Object.assign( THREE.DotScreenPass.prototype, {
 
 	constructor: THREE.DotScreenPass,
 
@@ -58,4 +58,4 @@ THREE.DotScreenPass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/DotScreenPass.js
+++ b/examples/js/postprocessing/DotScreenPass.js
@@ -37,8 +37,6 @@ THREE.DotScreenPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.DotScreenPass.prototype, {
 
-	constructor: THREE.DotScreenPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;

--- a/examples/js/postprocessing/FilmPass.js
+++ b/examples/js/postprocessing/FilmPass.js
@@ -36,7 +36,7 @@ THREE.FilmPass = function ( noiseIntensity, scanlinesIntensity, scanlinesCount, 
 
 THREE.FilmPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.FilmPass.prototype = {
+Object.assign( THREE.FilmPass.prototype, {
 
 	constructor: THREE.FilmPass,
 
@@ -59,4 +59,4 @@ THREE.FilmPass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/FilmPass.js
+++ b/examples/js/postprocessing/FilmPass.js
@@ -38,8 +38,6 @@ THREE.FilmPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.FilmPass.prototype, {
 
-	constructor: THREE.FilmPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -37,7 +37,7 @@ THREE.GlitchPass = function ( dt_size ) {
 
 THREE.GlitchPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.GlitchPass.prototype = {
+Object.assign( THREE.GlitchPass.prototype, {
 
 	constructor: THREE.GlitchPass,
 
@@ -114,4 +114,4 @@ THREE.GlitchPass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -39,8 +39,6 @@ THREE.GlitchPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.GlitchPass.prototype, {
 
-	constructor: THREE.GlitchPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -54,7 +54,7 @@ THREE.ManualMSAARenderPass = function ( scene, camera, params ) {
 
 THREE.ManualMSAARenderPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.ManualMSAARenderPass.prototype = {
+Object.assign( THREE.ManualMSAARenderPass.prototype, {
 
 	constructor: THREE.ManualMSAARenderPass,
 
@@ -116,7 +116,7 @@ THREE.ManualMSAARenderPass.prototype = {
 
 	}
 
-};
+} );
 
 // These jitter vectors are specified in integers because it is easier.
 // I am assuming a [-8,8) integer grid, but it needs to be mapped onto [-0.5,0.5)

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -56,8 +56,6 @@ THREE.ManualMSAARenderPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.ManualMSAARenderPass.prototype, {
 
-	constructor: THREE.ManualMSAARenderPass,
-
 	dispose: function() {
 
 		if ( this.sampleRenderTarget ) {
@@ -69,10 +67,9 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 
 	},
 
-
 	setSize: function ( width, height ) {
 
-		if ( this.sampleRenderTarget ) { this.sampleRenderTarget.setSize( width, height ); }
+		if ( this.sampleRenderTarget )	this.sampleRenderTarget.setSize( width, height );
 
 	},
 

--- a/examples/js/postprocessing/MaskPass.js
+++ b/examples/js/postprocessing/MaskPass.js
@@ -83,7 +83,7 @@ THREE.ClearMaskPass = function () {
 
 THREE.ClearMaskPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.ClearMaskPass.prototype = {
+Object.assign( THREE.ClearMaskPass.prototype, {
 
 	constructor: THREE.ClearMaskPass,
 
@@ -93,4 +93,4 @@ THREE.ClearMaskPass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/MaskPass.js
+++ b/examples/js/postprocessing/MaskPass.js
@@ -18,9 +18,7 @@ THREE.MaskPass = function ( scene, camera ) {
 
 THREE.MaskPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.MaskPass.prototype = {
-
-	constructor: THREE.MaskPass,
+Object.assign( THREE.MaskPass.prototype, {
 
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
@@ -70,7 +68,7 @@ THREE.MaskPass.prototype = {
 
 	}
 
-};
+} );
 
 
 THREE.ClearMaskPass = function () {

--- a/examples/js/postprocessing/MaskPass.js
+++ b/examples/js/postprocessing/MaskPass.js
@@ -85,8 +85,6 @@ THREE.ClearMaskPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.ClearMaskPass.prototype, {
 
-	constructor: THREE.ClearMaskPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		renderer.state.setStencilTest( false );

--- a/examples/js/postprocessing/RenderPass.js
+++ b/examples/js/postprocessing/RenderPass.js
@@ -26,8 +26,6 @@ THREE.RenderPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.RenderPass.prototype, {
 
-	constructor: THREE.RenderPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.scene.overrideMaterial = this.overrideMaterial;

--- a/examples/js/postprocessing/RenderPass.js
+++ b/examples/js/postprocessing/RenderPass.js
@@ -24,7 +24,7 @@ THREE.RenderPass = function ( scene, camera, overrideMaterial, clearColor, clear
 
 THREE.RenderPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.RenderPass.prototype = {
+Object.assign( THREE.RenderPass.prototype, {
 
 	constructor: THREE.RenderPass,
 
@@ -53,4 +53,4 @@ THREE.RenderPass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/SMAAPass.js
+++ b/examples/js/postprocessing/SMAAPass.js
@@ -108,8 +108,6 @@ THREE.SMAAPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.SMAAPass.prototype, {
 
-	constructor: THREE.SMAAPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		// pass 1

--- a/examples/js/postprocessing/SMAAPass.js
+++ b/examples/js/postprocessing/SMAAPass.js
@@ -106,7 +106,7 @@ THREE.SMAAPass = function ( width, height ) {
 
 THREE.SMAAPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.SMAAPass.prototype = {
+Object.assign( THREE.SMAAPass.prototype, {
 
 	constructor: THREE.SMAAPass,
 
@@ -163,4 +163,4 @@ THREE.SMAAPass.prototype = {
 		return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEIAAAAhCAAAAABIXyLAAAAAOElEQVRIx2NgGAWjYBSMglEwEICREYRgFBZBqDCSLA2MGPUIVQETE9iNUAqLR5gIeoQKRgwXjwAAGn4AtaFeYLEAAAAASUVORK5CYII=';
 	}
 
-};
+} );

--- a/examples/js/postprocessing/SavePass.js
+++ b/examples/js/postprocessing/SavePass.js
@@ -46,8 +46,6 @@ THREE.SavePass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.SavePass.prototype, {
 
-	constructor: THREE.SavePass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		if ( this.uniforms[ this.textureID ] ) {

--- a/examples/js/postprocessing/SavePass.js
+++ b/examples/js/postprocessing/SavePass.js
@@ -44,7 +44,7 @@ THREE.SavePass = function ( renderTarget ) {
 
 THREE.SavePass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.SavePass.prototype = {
+Object.assign( THREE.SavePass.prototype, {
 
 	constructor: THREE.SavePass,
 
@@ -62,4 +62,4 @@ THREE.SavePass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -40,7 +40,7 @@ THREE.ShaderPass = function( shader, textureID ) {
 
 THREE.ShaderPass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.ShaderPass.prototype = {
+Object.assign( THREE.ShaderPass.prototype, {
 
 	constructor: THREE.ShaderPass,
 
@@ -66,4 +66,4 @@ THREE.ShaderPass.prototype = {
 
 	}
 
-};
+} );

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -42,8 +42,6 @@ THREE.ShaderPass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.ShaderPass.prototype, {
 
-	constructor: THREE.ShaderPass,
-
 	render: function( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		if ( this.uniforms[ this.textureID ] ) {

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -31,8 +31,6 @@ THREE.TAARenderPass.JitterVectors = THREE.ManualMSAARenderPass.JitterVectors;
 THREE.TAARenderPass.prototype = Object.create( THREE.ManualMSAARenderPass.prototype );
 Object.assign( THREE.TAARenderPass.prototype, {
 
-	constructor: THREE.TAARenderPass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta ) {
 
 		if( ! this.accumulate ) {

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -26,96 +26,100 @@ THREE.TAARenderPass = function ( scene, camera, params ) {
 
 };
 
-THREE.TAARenderPass.prototype = Object.create( THREE.ManualMSAARenderPass.prototype );
-THREE.TAARenderPass.prototype.constructor = THREE.TAARenderPass;
 THREE.TAARenderPass.JitterVectors = THREE.ManualMSAARenderPass.JitterVectors;
 
-THREE.TAARenderPass.prototype.render = function ( renderer, writeBuffer, readBuffer, delta ) {
+THREE.TAARenderPass.prototype = Object.create( THREE.ManualMSAARenderPass.prototype );
+Object.assign( THREE.TAARenderPass.prototype, {
 
-	if( ! this.accumulate ) {
+	constructor: THREE.TAARenderPass,
 
-			THREE.ManualMSAARenderPass.prototype.render.call( this, renderer, writeBuffer, readBuffer, delta );
+	render: function ( renderer, writeBuffer, readBuffer, delta ) {
 
-			this.accumulateIndex = -1;
-			return;
+		if( ! this.accumulate ) {
 
-	}
+				THREE.ManualMSAARenderPass.prototype.render.call( this, renderer, writeBuffer, readBuffer, delta );
 
-	var jitterOffsets = THREE.TAARenderPass.JitterVectors[ 5 ];
+				this.accumulateIndex = -1;
+				return;
 
-	var camera = ( this.camera || this.scene.camera );
-
-	if ( ! this.sampleRenderTarget ) {
-
-		this.sampleRenderTarget = new THREE.WebGLRenderTarget( readBuffer.width, readBuffer.height, this.params );
-
-	}
-
-	if ( ! this.holdRenderTarget ) {
-
-		this.holdRenderTarget = new THREE.WebGLRenderTarget( readBuffer.width, readBuffer.height, this.params );
-
-	}
-
-	if( this.accumulate && this.accumulateIndex === -1 ) {
-
-			THREE.ManualMSAARenderPass.prototype.render.call( this, renderer, this.holdRenderTarget, readBuffer, delta );
-
-			this.accumulateIndex = 0;
-
-	}
-
-	var autoClear = renderer.autoClear;
-	renderer.autoClear = false;
-
-	var sampleWeight = 1.0 / ( jitterOffsets.length );
-
-	if( this.accumulateIndex >= 0 && this.accumulateIndex < jitterOffsets.length ) {
-
-		this.compositeUniforms[ "scale" ].value = sampleWeight;
-		this.compositeUniforms[ "tForeground" ].value = writeBuffer.texture;
-
-		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
-		var numSamplesPerFrame = Math.pow( 2, this.sampleLevel );
-		for ( var i = 0; i < numSamplesPerFrame; i ++ ) {
-
-			var j = this.accumulateIndex;
-			// only jitters perspective cameras.	TODO: add support for jittering orthogonal cameras
-			var jitterOffset = jitterOffsets[j];
-			if ( camera.setViewOffset ) {
-				camera.setViewOffset( readBuffer.width, readBuffer.height,
-					jitterOffset[ 0 ] * 0.0625, jitterOffset[ 1 ] * 0.0625,   // 0.0625 = 1 / 16
-					readBuffer.width, readBuffer.height );
-			}
-
-			renderer.render( this.scene, this.camera, writeBuffer, true );
-
-			renderer.render( this.scene2, this.camera2, this.sampleRenderTarget, ( this.accumulateIndex === 0 ) );
-
-			this.accumulateIndex ++;
-			if( this.accumulateIndex >= jitterOffsets.length ) break;
 		}
 
-		// reset jitter to nothing.	TODO: add support for orthogonal cameras
-		if ( camera.setViewOffset ) camera.setViewOffset( undefined, undefined, undefined, undefined, undefined, undefined );
+		var jitterOffsets = THREE.TAARenderPass.JitterVectors[ 5 ];
+
+		var camera = ( this.camera || this.scene.camera );
+
+		if ( ! this.sampleRenderTarget ) {
+
+			this.sampleRenderTarget = new THREE.WebGLRenderTarget( readBuffer.width, readBuffer.height, this.params );
+
+		}
+
+		if ( ! this.holdRenderTarget ) {
+
+			this.holdRenderTarget = new THREE.WebGLRenderTarget( readBuffer.width, readBuffer.height, this.params );
+
+		}
+
+		if( this.accumulate && this.accumulateIndex === -1 ) {
+
+				THREE.ManualMSAARenderPass.prototype.render.call( this, renderer, this.holdRenderTarget, readBuffer, delta );
+
+				this.accumulateIndex = 0;
+
+		}
+
+		var autoClear = renderer.autoClear;
+		renderer.autoClear = false;
+
+		var sampleWeight = 1.0 / ( jitterOffsets.length );
+
+		if( this.accumulateIndex >= 0 && this.accumulateIndex < jitterOffsets.length ) {
+
+			this.compositeUniforms[ "scale" ].value = sampleWeight;
+			this.compositeUniforms[ "tForeground" ].value = writeBuffer.texture;
+
+			// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
+			var numSamplesPerFrame = Math.pow( 2, this.sampleLevel );
+			for ( var i = 0; i < numSamplesPerFrame; i ++ ) {
+
+				var j = this.accumulateIndex;
+				// only jitters perspective cameras.	TODO: add support for jittering orthogonal cameras
+				var jitterOffset = jitterOffsets[j];
+				if ( camera.setViewOffset ) {
+					camera.setViewOffset( readBuffer.width, readBuffer.height,
+						jitterOffset[ 0 ] * 0.0625, jitterOffset[ 1 ] * 0.0625,   // 0.0625 = 1 / 16
+						readBuffer.width, readBuffer.height );
+				}
+
+				renderer.render( this.scene, this.camera, writeBuffer, true );
+
+				renderer.render( this.scene2, this.camera2, this.sampleRenderTarget, ( this.accumulateIndex === 0 ) );
+
+				this.accumulateIndex ++;
+				if( this.accumulateIndex >= jitterOffsets.length ) break;
+			}
+
+			// reset jitter to nothing.	TODO: add support for orthogonal cameras
+			if ( camera.setViewOffset ) camera.setViewOffset( undefined, undefined, undefined, undefined, undefined, undefined );
+
+		}
+
+		var accumulationWeight = this.accumulateIndex * sampleWeight;
+
+		if( accumulationWeight > 0 ) {
+			this.compositeUniforms[ "scale" ].value = 1.0;
+			this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget.texture;
+			renderer.render( this.scene2, this.camera2, writeBuffer, true );
+		}
+
+		if( accumulationWeight < 1.0 ) {
+			this.compositeUniforms[ "scale" ].value = 1.0 - accumulationWeight;
+			this.compositeUniforms[ "tForeground" ].value = this.holdRenderTarget.texture;
+			renderer.render( this.scene2, this.camera2, writeBuffer, ( accumulationWeight === 0 ) );
+		}
+
+		renderer.autoClear = autoClear;
 
 	}
 
-	var accumulationWeight = this.accumulateIndex * sampleWeight;
-
-	if( accumulationWeight > 0 ) {
-		this.compositeUniforms[ "scale" ].value = 1.0;
-		this.compositeUniforms[ "tForeground" ].value = this.sampleRenderTarget.texture;
-		renderer.render( this.scene2, this.camera2, writeBuffer, true );
-	}
-
-	if( accumulationWeight < 1.0 ) {
-		this.compositeUniforms[ "scale" ].value = 1.0 - accumulationWeight;
-		this.compositeUniforms[ "tForeground" ].value = this.holdRenderTarget.texture;
-		renderer.render( this.scene2, this.camera2, writeBuffer, ( accumulationWeight === 0 ) );
-	}
-
-	renderer.autoClear = autoClear;
-
-
-}
+});

--- a/examples/js/postprocessing/TexturePass.js
+++ b/examples/js/postprocessing/TexturePass.js
@@ -38,8 +38,6 @@ THREE.TexturePass.prototype = Object.create( THREE.Pass.prototype );
 
 Object.assign( THREE.TexturePass.prototype, {
 
-	constructor: THREE.TexturePass,
-
 	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 		this.quad.material = this.material;

--- a/examples/js/postprocessing/TexturePass.js
+++ b/examples/js/postprocessing/TexturePass.js
@@ -36,7 +36,7 @@ THREE.TexturePass = function ( texture, opacity ) {
 
 THREE.TexturePass.prototype = Object.create( THREE.Pass.prototype );
 
-THREE.TexturePass.prototype = {
+Object.assign( THREE.TexturePass.prototype, {
 
 	constructor: THREE.TexturePass,
 
@@ -48,4 +48,4 @@ THREE.TexturePass.prototype = {
 
 	}
 
-};
+} );


### PR DESCRIPTION
This is just a simple bug fix.  When the base class Pass was created (see PR #8534 by @Mugen87) we didn't fix up the prototypes of the derived classes to maintain the Pass base class functions.  Thus the base class functions were not actually available on the derived classes.  This PR fixes that oversight.
