### PR TITLE
remove-math.sign-doc

### DIFF
--- a/docs/api/math/Math.html
+++ b/docs/api/math/Math.html
@@ -59,11 +59,6 @@
 		Random float from *- range / 2* to *range / 2* interval.
 		</div>
 
-		<h3>[method:Float sign]( [page:Float x] )</h3>
-		<div>
-		Returns -1 if *x* is less than 0, 1 if *x* is greater than 0, and 0 if *x* is zero.
-		</div>
-
 		<h3>[method:Float degToRad]([page:Float degrees])</h3>
 		<div>
 		degrees -- [page:Float]


### PR DESCRIPTION
Math.sign() function was removed in 2014 
