### PR TITLE
add unbiased mode to the MSAA render pass.

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -189,6 +189,7 @@ var files = {
 		"webgl_postprocessing_godrays",
 		"webgl_postprocessing_masking",
 		"webgl_postprocessing_msaa",
+		"webgl_postprocessing_msaa_unbiased",
 		"webgl_postprocessing_nodes",
 		"webgl_postprocessing_procedural",
 		"webgl_postprocessing_smaa",

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -97,9 +97,9 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 
 			var sampleWeight = baseSampleWeight;
 			if( this.unbiased ) {
-				// the theory is that equal weights for each sample lead to an accumulation of roudning errors.
-				// The following equation varyings the sampleWeight so that it is varies uniformly across
-				// a range of scaled values so that the rounding errors each other out.
+				// the theory is that equal weights for each sample lead to an accumulation of rounding errors.
+				// The following equation varies the sampleWeight per sample so that it is uniformly distributed
+				// across a range of values whose rounding errors cancel each other out.
 				var uniformCenteredDistribution = ( -0.5 + ( i + 0.5 ) / jitterOffsets.length );
 				sampleWeight += roundingRange * uniformCenteredDistribution;
 			}

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -88,8 +88,8 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 		for ( var i = 0; i < jitterOffsets.length; i ++ ) {
 
 			var jitterOffset = jitterOffsets[i];
-			if ( camera.setViewOffset ) {
-				camera.setViewOffset( width, height,
+			if ( this.camera.setViewOffset ) {
+				this.camera.setViewOffset( width, height,
 					jitterOffset[ 0 ] * 0.0625, jitterOffset[ 1 ] * 0.0625,   // 0.0625 = 1 / 16
 					width, height );
 			}

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -110,7 +110,7 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 
 		}
 
-		if ( this.camera.setViewOffset ) this.camera.setViewOffset( undefined, undefined, undefined, undefined, undefined, undefined );
+		if ( this.camera.clearViewOffset ) this.camera.clearViewOffset();
 
 		renderer.autoClear = autoClear;
 

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -79,7 +79,7 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 		renderer.autoClear = false;
 
 		var baseSampleWeight = 1.0 / jitterOffsets.length;
-		var roundingRange = 1 / 256;
+		var roundingRange = 1 / 32;
 		this.copyUniforms[ "tDiffuse" ].value = this.sampleRenderTarget.texture;
 
 		var width = readBuffer.width, height = readBuffer.height;
@@ -100,7 +100,8 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 				// the theory is that equal weights for each sample lead to an accumulation of roudning errors.
 				// The following equation varyings the sampleWeight so that it is varies uniformly across
 				// a range of scaled values so that the rounding errors each other out.
-				sampleWeight += - ( 1 / 128 ) + ( ( i + 0.5 ) / ( jitterOffsets.length * 64 ) );
+				var uniformCenteredDistribution = ( -0.5 + ( i + 0.5 ) / jitterOffsets.length );
+				sampleWeight += roundingRange * uniformCenteredDistribution;
 			}
 
 			this.copyUniforms[ "opacity" ].value = sampleWeight;

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -18,6 +18,7 @@ THREE.ManualMSAARenderPass = function ( scene, camera ) {
 	this.camera = camera;
 
 	this.sampleLevel = 4; // specified as n, where the number of samples is 2^n, so sampleLevel = 4, is 2^4 samples, 16.
+	this.unbiased = true;
 
 	if ( THREE.CopyShader === undefined ) console.error( "THREE.ManualMSAARenderPass relies on THREE.CopyShader" );
 
@@ -77,8 +78,11 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 		var autoClear = renderer.autoClear;
 		renderer.autoClear = false;
 
-		this.copyUniforms[ "opacity" ].value = 1.0 / jitterOffsets.length;
+		var baseSampleWeight = 1.0 / jitterOffsets.length;
+		var roundingRange = 1 / 256;
 		this.copyUniforms[ "tDiffuse" ].value = this.sampleRenderTarget.texture;
+
+		var width = readBuffer.width, height = readBuffer.height;
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( var i = 0; i < jitterOffsets.length; i ++ ) {
@@ -86,10 +90,20 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 			// only jitters perspective cameras.	TODO: add support for jittering orthogonal cameras
 			var jitterOffset = jitterOffsets[i];
 			if ( camera.setViewOffset ) {
-				camera.setViewOffset( readBuffer.width, readBuffer.height,
+				camera.setViewOffset( width, height,
 					jitterOffset[ 0 ] * 0.0625, jitterOffset[ 1 ] * 0.0625,   // 0.0625 = 1 / 16
-					readBuffer.width, readBuffer.height );
+					width, height );
 			}
+
+			var sampleWeight = baseSampleWeight;
+			if( this.unbiased ) {
+				// the theory is that equal weights for each sample lead to an accumulation of roudning errors.
+				// The following equation varyings the sampleWeight so that it is varies uniformly across
+				// a range of scaled values so that the rounding errors each other out.
+				sampleWeight += - ( 1 / 128 ) + ( ( i + 0.5 ) / ( jitterOffsets.length * 64 ) );
+			}
+
+			this.copyUniforms[ "opacity" ].value = sampleWeight;
 
 			renderer.render( this.scene, this.camera, this.sampleRenderTarget, true );
 			renderer.render( this.scene2, this.camera2, writeBuffer, (i === 0) );

--- a/examples/js/postprocessing/ManualMSAARenderPass.js
+++ b/examples/js/postprocessing/ManualMSAARenderPass.js
@@ -87,7 +87,6 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( var i = 0; i < jitterOffsets.length; i ++ ) {
 
-			// only jitters perspective cameras.	TODO: add support for jittering orthogonal cameras
 			var jitterOffset = jitterOffsets[i];
 			if ( camera.setViewOffset ) {
 				camera.setViewOffset( width, height,
@@ -111,8 +110,7 @@ Object.assign( THREE.ManualMSAARenderPass.prototype, {
 
 		}
 
-		// reset jitter to nothing.	TODO: add support for orthogonal cameras
-		if ( camera.setViewOffset ) camera.setViewOffset( undefined, undefined, undefined, undefined, undefined, undefined );
+		if ( this.camera.setViewOffset ) this.camera.setViewOffset( undefined, undefined, undefined, undefined, undefined, undefined );
 
 		renderer.autoClear = autoClear;
 

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -94,8 +94,8 @@ Object.assign( THREE.TAARenderPass.prototype, {
 				if( this.accumulateIndex >= jitterOffsets.length ) break;
 			}
 
-			if ( this.camera.setViewOffset ) this.camera.setViewOffset( undefined, undefined, undefined, undefined, undefined, undefined );
-
+			if ( this.camera.clearViewOffset ) this.camera.clearViewOffset();
+			
 		}
 
 		var accumulationWeight = this.accumulateIndex * sampleWeight;

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -45,8 +45,6 @@ Object.assign( THREE.TAARenderPass.prototype, {
 
 		var jitterOffsets = THREE.TAARenderPass.JitterVectors[ 5 ];
 
-		var camera = ( this.camera || this.scene.camera );
-
 		if ( ! this.sampleRenderTarget ) {
 
 			this.sampleRenderTarget = new THREE.WebGLRenderTarget( readBuffer.width, readBuffer.height, this.params );
@@ -82,10 +80,9 @@ Object.assign( THREE.TAARenderPass.prototype, {
 			for ( var i = 0; i < numSamplesPerFrame; i ++ ) {
 
 				var j = this.accumulateIndex;
-				// only jitters perspective cameras.	TODO: add support for jittering orthogonal cameras
 				var jitterOffset = jitterOffsets[j];
-				if ( camera.setViewOffset ) {
-					camera.setViewOffset( readBuffer.width, readBuffer.height,
+				if ( this.camera.setViewOffset ) {
+					this.camera.setViewOffset( readBuffer.width, readBuffer.height,
 						jitterOffset[ 0 ] * 0.0625, jitterOffset[ 1 ] * 0.0625,   // 0.0625 = 1 / 16
 						readBuffer.width, readBuffer.height );
 				}
@@ -97,8 +94,7 @@ Object.assign( THREE.TAARenderPass.prototype, {
 				if( this.accumulateIndex >= jitterOffsets.length ) break;
 			}
 
-			// reset jitter to nothing.	TODO: add support for orthogonal cameras
-			if ( camera.setViewOffset ) camera.setViewOffset( undefined, undefined, undefined, undefined, undefined, undefined );
+			if ( this.camera.setViewOffset ) this.camera.setViewOffset( undefined, undefined, undefined, undefined, undefined, undefined );
 
 		}
 

--- a/examples/webgl_postprocessing_msaa_unbiased.html
+++ b/examples/webgl_postprocessing_msaa_unbiased.html
@@ -109,19 +109,19 @@
 				group = new THREE.Object3D();
 				scene.add( group );
 
-				var light = new THREE.PointLight( 0xddffdd, 1.8 );
+				var light = new THREE.PointLight( 0xddffdd, 1.0 );
 				light.position.z = 70;
 				light.position.y = -70;
 				light.position.x = -70;
 				scene.add( light );
 
-				var light2 = new THREE.PointLight( 0xffdddd, 1.8 );
+				var light2 = new THREE.PointLight( 0xffdddd, 1.0 );
 				light2.position.z = 70;
 				light2.position.x = -70;
 				light2.position.y = 70;
 				scene.add( light2 );
 
-				var light3 = new THREE.PointLight( 0xddddff, 1.8 );
+				var light3 = new THREE.PointLight( 0xddddff, 1.0 );
 				light3.position.z = 70;
 				light3.position.x = 70;
 				light3.position.y = -70;

--- a/examples/webgl_postprocessing_msaa_unbiased.html
+++ b/examples/webgl_postprocessing_msaa_unbiased.html
@@ -28,9 +28,9 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="http://threejs.org" target="_blank">three.js</a> - Manual Multi-Sample Anti-Aliasing (MSAA) pass by <a href="https://clara.io" target="_blank">Ben Houston</a><br/><br/>
-			This manual approach to MSAA re-renders the scene ones for each sample with camera jitter and accumulates the results.<br/><br/>
-			Texture interpolation, mipmapping and anistropic sampling is disabled to emphasize<br/> the effect MSAA levels have one the resulting render quality.
+			<a href="http://threejs.org" target="_blank">three.js</a> - Unbiased Manual Multi-Sample Anti-Aliasing (MSAA) pass by <a href="https://clara.io" target="_blank">Ben Houston</a><br/><br/>
+			This example shows how to unbias the rounding errors accumulated using high number of MSAA samples on a 8-bit per channel buffer.<br/><br/>
+			Turn off the "unbiased" feature to see the banding that results from accumulated rounding errors.
 		</div>
 
 		<div id="container"></div>
@@ -54,7 +54,8 @@
 			var gui, stats, texture;
 
 			var param = {
-				sampleLevel: 2
+				sampleLevel: 4,
+				unbiased: true
 			};
 
 			init();
@@ -68,6 +69,7 @@
 
 				gui = new dat.GUI();
 
+				gui.add( param, "unbiased" );
 				gui.add( param, 'sampleLevel', {
 					'Level 0: 1 Sample': 0,
 					'Level 1: 2 Samples': 1,
@@ -85,9 +87,13 @@
 
 				container = document.getElementById( "container" );
 
+				var width = window.innerWidth || 1;
+				var height = window.innerHeight || 1;
+				var devicePixelRatio = window.devicePixelRatio || 1;
+
 				renderer = new THREE.WebGLRenderer( { antialias: false } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setPixelRatio( devicePixelRatio );
+				renderer.setSize( width, height );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -95,36 +101,60 @@
 
 				//
 
-				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.z = 300;
+				camera = new THREE.PerspectiveCamera( 65, width / height, 3, 10 );
+				camera.position.z = 7;
 
 				scene = new THREE.Scene();
 
-				var geometry = new THREE.BoxGeometry( 120, 120, 120 );
-				var material = new THREE.MeshBasicMaterial( { color: 0xffffff, wireframe: true } );
+				group = new THREE.Object3D();
+				scene.add( group );
 
-				var mesh = new THREE.Mesh( geometry, material );
-				mesh.position.x = - 100;
-				scene.add( mesh );
+				var light = new THREE.PointLight( 0xddffdd, 1.8 );
+				light.position.z = 70;
+				light.position.y = -70;
+				light.position.x = -70;
+				scene.add( light );
 
-				var texture = new THREE.TextureLoader().load( "textures/brick_diffuse.jpg" );
-				texture.minFilter = THREE.NearestFilter;
-				texture.magFilter = THREE.NearestFilter;
-				texture.anisotropy = 1;
-				texture.generateMipmaps = false;
+				var light2 = new THREE.PointLight( 0xffdddd, 1.8 );
+				light2.position.z = 70;
+				light2.position.x = -70;
+				light2.position.y = 70;
+				scene.add( light2 );
 
-				var material = new THREE.MeshBasicMaterial( { map: texture } );
+				var light3 = new THREE.PointLight( 0xddddff, 1.8 );
+				light3.position.z = 70;
+				light3.position.x = 70;
+				light3.position.y = -70;
+				scene.add( light3 );
 
-				var mesh = new THREE.Mesh( geometry, material );
-				mesh.position.x = 100;
-				scene.add( mesh );
+				var light3 = new THREE.AmbientLight( 0xffffff, 0.05 );
+				scene.add( light3 );
+
+				var geometry = new THREE.SphereBufferGeometry( 3, 48, 24 );
+				for ( var i = 0; i < 120; i ++ ) {
+
+					var material = new THREE.MeshStandardMaterial();
+					material.roughness = 0.5 * Math.random() + 0.25;
+					material.metalness = 0;
+					material.color.setHSL( Math.random(), 1.0, 0.3 );
+
+					var mesh = new THREE.Mesh( geometry, material );
+					mesh.position.x = Math.random() * 4 - 2;
+					mesh.position.y = Math.random() * 4 - 2;
+					mesh.position.z = Math.random() * 4 - 2;
+					mesh.rotation.x = Math.random();
+					mesh.rotation.y = Math.random();
+					mesh.rotation.z = Math.random();
+
+					mesh.scale.x = mesh.scale.y = mesh.scale.z = Math.random() * 0.2 + 0.05;
+					group.add( mesh );
+				}
 
 				// postprocessing
 
 				composer = new THREE.EffectComposer( renderer );
 
 				msaaRenderPass = new THREE.ManualMSAARenderPass( scene, camera );
-				msaaRenderPass.unbiased = false;
 				composer.addPass( msaaRenderPass );
 
 				copyPass = new THREE.ShaderPass( THREE.CopyShader );
@@ -168,6 +198,7 @@
 				}
 
 				msaaRenderPass.sampleLevel = param.sampleLevel;
+				msaaRenderPass.unbiased = param.unbiased;
 
 				composer.render();
 				stats.end();

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -144,6 +144,7 @@
 				composer = new THREE.EffectComposer( renderer );
 
 				taaRenderPass = new THREE.TAARenderPass( scene, camera );
+				taaRenderPass.unbiased = false;
 				composer.addPass( taaRenderPass );
 
 				renderPass = new THREE.RenderPass( scene, camera );

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -155,6 +155,13 @@ THREE.PerspectiveCamera.prototype = Object.assign( Object.create( THREE.Camera.p
 
 	},
 
+	clearViewOffset: function() {
+
+		this.view = null;
+		this.updateProjectionMatrix();
+
+	},
+
 	updateProjectionMatrix: function () {
 
 		var near = this.near,


### PR DESCRIPTION
One of the issues with the manual MSAA render pass I've noticed is that it uses the same sample weight for each render.  When rendering to a 8-bit-per channel render buffer this means that each sample will likely be rounded the same way, thus accumulating round off errors at high sample counts.

Thus I have added an "unbiased' mode to the ManualMSAARenderPass that varies the sample weight in a uniform distribution such that the rounding errors cancel each other out instead of accumulating.  There is no speed cost and no need to get render into a higher bit-depth render target.

I've created an example that allows one to turn on/off the unbiased MSAA mode.

Here is the old 32 sample MSAA result that accumulated round-off errors:

![image](https://cloud.githubusercontent.com/assets/588541/15396701/3b82eec0-1dab-11e6-98d6-364a7e368357.png)

Here is what the new unbiased MSAA produces with 32 samples:

![image](https://cloud.githubusercontent.com/assets/588541/15396692/2f925d80-1dab-11e6-9622-8a80ed3b6f52.png)
