### PR TITLE
Remove unused boolean property from Object3D

### DIFF
--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -128,14 +128,6 @@
 		default – false
 		</div>
 
-		<h3>[property:Boolean rotationAutoUpdate]</h3>
-		<div>
-		When this is set, then the rotationMatrix gets calculated every frame.
-		</div>
-		<div>
-		default – true
-		</div>
-
 		<h3>[property:object userData]</h3>
 		<div>
 		An object that can be used to store custom data about the Object3d. It should not hold references to functions as these will not be cloned.

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -580,10 +580,6 @@
           "!type": "bool",
           "!doc": "default – false"
         },
-        "rotationAutoUpdate": {
-          "!type": "bool",
-          "!doc": "default – true"
-        },
         "userData": {
           "!type": "object",
           "!doc": "An object that can be used to store custom data about the Object3d. It should not hold references to functions as these will not be cloned."

--- a/examples/js/cameras/CombinedCamera.js
+++ b/examples/js/cameras/CombinedCamera.js
@@ -189,8 +189,6 @@ THREE.CombinedCamera.prototype.toFrontView = function() {
 
 	// should we be modifing the matrix instead?
 
-	this.rotationAutoUpdate = false;
-
 };
 
 THREE.CombinedCamera.prototype.toBackView = function() {
@@ -198,7 +196,6 @@ THREE.CombinedCamera.prototype.toBackView = function() {
 	this.rotation.x = 0;
 	this.rotation.y = Math.PI;
 	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
 
 };
 
@@ -207,7 +204,6 @@ THREE.CombinedCamera.prototype.toLeftView = function() {
 	this.rotation.x = 0;
 	this.rotation.y = - Math.PI / 2;
 	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
 
 };
 
@@ -216,7 +212,6 @@ THREE.CombinedCamera.prototype.toRightView = function() {
 	this.rotation.x = 0;
 	this.rotation.y = Math.PI / 2;
 	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
 
 };
 
@@ -225,7 +220,6 @@ THREE.CombinedCamera.prototype.toTopView = function() {
 	this.rotation.x = - Math.PI / 2;
 	this.rotation.y = 0;
 	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
 
 };
 
@@ -234,6 +228,5 @@ THREE.CombinedCamera.prototype.toBottomView = function() {
 	this.rotation.x = Math.PI / 2;
 	this.rotation.y = 0;
 	this.rotation.z = 0;
-	this.rotationAutoUpdate = false;
 
 };

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -65,8 +65,6 @@ THREE.Object3D = function () {
 		}
 	} );
 
-	this.rotationAutoUpdate = true;
-
 	this.matrix = new THREE.Matrix4();
 	this.matrixWorld = new THREE.Matrix4();
 
@@ -679,8 +677,6 @@ Object.assign( THREE.Object3D.prototype, THREE.EventDispatcher.prototype, {
 		this.position.copy( source.position );
 		this.quaternion.copy( source.quaternion );
 		this.scale.copy( source.scale );
-
-		this.rotationAutoUpdate = source.rotationAutoUpdate;
 
 		this.matrix.copy( source.matrix );
 		this.matrixWorld.copy( source.matrixWorld );


### PR DESCRIPTION
rotationAutoUpdate has not has a purpose since Feb 2013 according to git
history of object3D.js and camera.js unless ive missed something.
