### PR TITLE
Consistent getPoints and getSpacedPoints on ellipse

### DIFF
--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -66,7 +66,13 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 				var diff = curveLengths[ i ] - d;
 				var curve = this.curves[ i ];
 
-				var u = 1 - diff / curve.getLength();
+				var segmentLength = curve.getLength();
+				var u = 0;
+				if ( segmentLength !== 0 ) {
+
+				  u = 1 - diff / curve.getLength();
+
+				}
 
 				return curve.getPointAt( u );
 

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -151,7 +151,8 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 			xRadius, yRadius,
 			aStartAngle, aEndAngle,
 			aClockwise,
-			aRotation || 0 // aRotation is optional.
+			aRotation || 0, // aRotation is optional.
+			this.curves.length
 		];
 
 		var curve = new THREE.EllipseCurve( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation );
@@ -171,7 +172,7 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 		var points = [];
 
-		for ( var i = 0; i < divisions; i ++ ) {
+		for ( var i = 0; i <= divisions; i ++ ) {
 
 			points.push( this.getPoint( i / divisions ) );
 
@@ -321,42 +322,6 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 				break;
 
-			case 'arc':
-
-				var aX = args[ 0 ], aY = args[ 1 ],
-					aRadius = args[ 2 ],
-					aStartAngle = args[ 3 ], aEndAngle = args[ 4 ],
-					aClockwise = !! args[ 5 ];
-
-				var deltaAngle = aEndAngle - aStartAngle;
-				var angle;
-				var tdivisions = divisions * 2;
-
-				for ( var j = 1; j <= tdivisions; j ++ ) {
-
-					var t = j / tdivisions;
-
-					if ( ! aClockwise ) {
-
-						t = 1 - t;
-
-					}
-
-					angle = aStartAngle + t * deltaAngle;
-
-					tx = aX + aRadius * Math.cos( angle );
-					ty = aY + aRadius * Math.sin( angle );
-
-					//console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
-
-					points.push( new THREE.Vector2( tx, ty ) );
-
-				}
-
-				//console.log(points);
-
-				break;
-
 			case 'ellipse':
 
 				var aX = args[ 0 ], aY = args[ 1 ],
@@ -364,49 +329,16 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 					yRadius = args[ 3 ],
 					aStartAngle = args[ 4 ], aEndAngle = args[ 5 ],
 					aClockwise = !! args[ 6 ],
-					aRotation = args[ 7 ];
+					aRotation = args[ 7 ],
+					curveIndex = args[8];
 
+				var ellipse = this.curves[ curveIndex ];
 
-				var deltaAngle = aEndAngle - aStartAngle;
-				var angle;
-				var tdivisions = divisions * 2;
+				for ( var j = 0; j <= divisions; j++ ) {
 
-				var cos, sin;
-				if ( aRotation !== 0 ) {
+					var t = j / divisions;
 
-					cos = Math.cos( aRotation );
-					sin = Math.sin( aRotation );
-
-				}
-
-				for ( var j = 1; j <= tdivisions; j ++ ) {
-
-					var t = j / tdivisions;
-
-					if ( ! aClockwise ) {
-
-						t = 1 - t;
-
-					}
-
-					angle = aStartAngle + t * deltaAngle;
-
-					tx = aX + xRadius * Math.cos( angle );
-					ty = aY + yRadius * Math.sin( angle );
-
-					if ( aRotation !== 0 ) {
-
-						var x = tx, y = ty;
-
-						// Rotate the point about the center of the ellipse.
-						tx = ( x - aX ) * cos - ( y - aY ) * sin + aX;
-						ty = ( x - aX ) * sin + ( y - aY ) * cos + aY;
-
-					}
-
-					//console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
-
-					points.push( new THREE.Vector2( tx, ty ) );
+					points.push( ellipse.getPoint( t ) );
 
 				}
 

--- a/src/extras/curves/EllipseCurve.js
+++ b/src/extras/curves/EllipseCurve.js
@@ -24,23 +24,41 @@ THREE.EllipseCurve.prototype.constructor = THREE.EllipseCurve;
 
 THREE.EllipseCurve.prototype.getPoint = function ( t ) {
 
-	var deltaAngle = this.aEndAngle - this.aStartAngle;
+	// Calculate deltaAngle just once.
+	var twoPi = Math.PI * 2;
+	if ( this.deltaAngle === undefined ) {
 
-	if ( deltaAngle < 0 ) deltaAngle += Math.PI * 2;
-	if ( deltaAngle > Math.PI * 2 ) deltaAngle -= Math.PI * 2;
+		var deltaAngle = this.aEndAngle - this.aStartAngle;
+		var samePoints = Math.abs( deltaAngle ) < Number.EPSILON;
 
-	var angle;
+		while ( deltaAngle < 0 ) deltaAngle += twoPi;
+		while ( deltaAngle > twoPi ) deltaAngle -= twoPi;
 
-	if ( this.aClockwise === true ) {
+		if ( deltaAngle < Number.EPSILON ) {
 
-		angle = this.aEndAngle + ( 1 - t ) * ( Math.PI * 2 - deltaAngle );
+			if ( samePoints ) {
 
-	} else {
+				deltaAngle = 0;
 
-		angle = this.aStartAngle + t * deltaAngle;
+			} else {
+
+				deltaAngle = twoPi;
+
+			}
+
+		}
+
+		if ( this.aClockwise === true && deltaAngle != twoPi && !samePoints ) {
+
+			deltaAngle = deltaAngle - twoPi;
+
+		}
+
+		this.deltaAngle = deltaAngle;
 
 	}
 	
+	var angle = this.aStartAngle + t * this.deltaAngle;
 	var x = this.aX + this.xRadius * Math.cos( angle );
 	var y = this.aY + this.yRadius * Math.sin( angle );
 


### PR DESCRIPTION
This is a correction for issue https://github.com/mrdoob/three.js/issues/8897

getPoints and getSpacedPoints work as getSpacedPoints used to (but with the final point). The arc between aStartAngle and aEndAngle is always forced in the 0, 2*PI area, as getSpacedPoints did (but not getPoints)

This pull request doesn't adress the 2 problems found yesturday (removal of the last point by getPoints when to close of the first and point defined by moveTo not used by getSpacedPoints when defined before an ellipse)

I modified my fiddle to facilitate the vision on the two paths. The new one is https://jsfiddle.net/wdsmy9k3/3/ You may choose angle in a larger ares and you can choose which path you want to see.
