### PR TITLE
GridHelper: Clean up

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -283,11 +283,15 @@ var Viewport = function ( editor ) {
 		switch ( value ) {
 
 			case 'css/light.css':
-				grid.setColors( 0x444444, 0x888888 );
+				sceneHelpers.remove( grid );
+				grid = new THREE.GridHelper( 30, 1, 0x444444, 0x888888 );
+				sceneHelpers.add( grid );
 				clearColor = 0xaaaaaa;
 				break;
 			case 'css/dark.css':
-				grid.setColors( 0xbbbbbb, 0x888888 );
+				sceneHelpers.remove( grid );
+				grid = new THREE.GridHelper( 30, 1, 0xbbbbbb, 0x888888 );
+				sceneHelpers.add( grid );
 				clearColor = 0x333333;
 				break;
 

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -1884,11 +1884,7 @@
     "GridHelper": {
       "!url": "http://threejs.org/docs/#Reference/extras/helpers/GridHelper",
       "prototype": {
-        "!proto": "THREE.Line.prototype",
-        "setColors": {
-          "!type": "fn(colorCenterLine: number, colorGrid: number)",
-          "!doc": "Updates the color of the grid lines."
-        }
+        "!proto": "THREE.Line.prototype"
       },
       "!doc": "The GridHelper is an object to define grids. Grids are two-dimensional arrays of lines.",
       "!type": "fn(size: number, step: number)"

--- a/examples/webgl_loader_amf.html
+++ b/examples/webgl_loader_amf.html
@@ -74,8 +74,7 @@
 
 				scene.add( camera );
 
-				var grid = new THREE.GridHelper( 25, 1.0 );
-				grid.setColors( 0xffffff, 0x555555 );
+				var grid = new THREE.GridHelper( 25, 1.0, 0xffffff, 0x555555 );
 				grid.rotateOnAxis( new THREE.Vector3( 1, 0, 0 ), 90 * ( Math.PI/180 ) );
 				scene.add( grid );
 

--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -62,8 +62,7 @@
 				scene = new THREE.Scene();
 
 				// grid
-				var gridHelper = new THREE.GridHelper( 14, 1 );
-				gridHelper.setColors( 0x303030, 0x303030 );
+				var gridHelper = new THREE.GridHelper( 14, 1, 0x303030, 0x303030 );
 				gridHelper.position.set( 0, - 0.04, 0 );
 				scene.add( gridHelper );
 


### PR DESCRIPTION
This PR cleans up some overlooked `setColors` method calls and fixes the theme change in the editor (the grid has now the correct color again).
