### PR TITLE
Material: colorMask and depthMask

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -378,7 +378,7 @@ Object.defineProperties( THREE.Material.prototype, {
 		}
 	},
 	depthWrite: {
-  	get: function () {
+		get: function () {
 			console.warn( 'THREE.' + this.type + ': .depthWrite is now .depthMask.' );
 			return this.depthMask;
 		},
@@ -388,7 +388,7 @@ Object.defineProperties( THREE.Material.prototype, {
 		}
   },
 	colorWrite: {
-  	get: function () {
+		get: function () {
 			console.warn( 'THREE.' + this.type + ': .colorWrite is now .colorMask.' );
 			return this.colorMask.r;
 		},

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -376,7 +376,27 @@ Object.defineProperties( THREE.Material.prototype, {
 			console.warn( 'THREE.' + this.type + ': .wrapRGB has been removed.' );
 			return new THREE.Color();
 		}
-	}
+	},
+	depthWrite: {
+  	get: function () {
+			console.warn( 'THREE.' + this.type + ': .depthWrite is now .depthMask.' );
+			return this.depthMask;
+		},
+		set: function ( value ) {
+			console.warn( 'THREE.' + this.type + ': depthWrite is now .depthMask.' );
+			this.depthMask = value;
+		}
+  },
+	colorWrite: {
+  	get: function () {
+			console.warn( 'THREE.' + this.type + ': .colorWrite is now .colorMask.' );
+			return this.colorMask.r;
+		},
+		set: function ( value ) {
+			console.warn( 'THREE.' + this.type + ': .colorWrite is now .colorMask.' );
+			this.colorMask.set( value, value, value, value );
+		}
+  }
 } );
 
 Object.defineProperties( THREE.MeshPhongMaterial.prototype, {

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -229,8 +229,9 @@ THREE.Loader.prototype = {
 						json.opacity = value;
 						break;
 					case 'depthTest':
-					case 'depthWrite':
-					case 'colorWrite':
+					case 'depthWrite':	// deprecated
+					case 'depthMask':
+					case 'colorWrite':	// deprecated
 					case 'opacity':
 					case 'reflectivity':
 					case 'transparent':

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -48,7 +48,7 @@ THREE.MaterialLoader.prototype = {
 
 	parse: function ( json ) {
 
-		var material = new THREE[ json.type ];
+		var material = new THREE[ json.type ]();
 
 		if ( json.uuid !== undefined ) material.uuid = json.uuid;
 		if ( json.name !== undefined ) material.name = json.name;
@@ -69,10 +69,13 @@ THREE.MaterialLoader.prototype = {
 		if ( json.transparent !== undefined ) material.transparent = json.transparent;
 		if ( json.alphaTest !== undefined ) material.alphaTest = json.alphaTest;
 		if ( json.depthTest !== undefined ) material.depthTest = json.depthTest;
-		if ( json.depthWrite !== undefined ) material.depthWrite = json.depthWrite;
-		if ( json.colorWrite !== undefined ) material.colorWrite = json.colorWrite;
+		if ( json.depthMask !== undefined ) material.depthMask = json.depthMask;
 		if ( json.wireframe !== undefined ) material.wireframe = json.wireframe;
 		if ( json.wireframeLinewidth !== undefined ) material.wireframeLinewidth = json.wireframeLinewidth;
+
+		// deprecated
+		if ( json.depthWrite !== undefined ) material.depthWrite = json.depthWrite;
+		if ( json.colorWrite !== undefined ) material.colorWrite = json.colorWrite;
 
 		// for PointsMaterial
 		if ( json.size !== undefined ) material.size = json.size;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -32,12 +32,12 @@ THREE.Material = function () {
 
 	this.depthFunc = THREE.LessEqualDepth;
 	this.depthTest = true;
-	this.depthWrite = true;
+	this.depthMask = true;
 
 	this.clippingPlanes = null;
 	this.clipShadows = false;
 
-	this.colorWrite = true;
+	this.colorMask = new THREE.WebGLColorMask();
 
 	this.precision = null; // override the renderer's default precision for this material
 
@@ -102,6 +102,10 @@ THREE.Material.prototype = {
 				currentValue.set( newValue );
 
 			} else if ( currentValue instanceof THREE.Vector3 && newValue instanceof THREE.Vector3 ) {
+
+				currentValue.copy( newValue );
+
+			} else if ( currentValue instanceof THREE.WebGLColorMask && newValue instanceof THREE.WebGLColorMask ) {
 
 				currentValue.copy( newValue );
 
@@ -267,9 +271,9 @@ THREE.Material.prototype = {
 
 		this.depthFunc = source.depthFunc;
 		this.depthTest = source.depthTest;
-		this.depthWrite = source.depthWrite;
+		this.depthMask = source.depthMask;
 
-		this.colorWrite = source.colorWrite;
+		this.colorMask.copy( source.colorMask );
 
 		this.precision = source.precision;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1709,8 +1709,8 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		state.setDepthFunc( material.depthFunc );
 		state.setDepthTest( material.depthTest );
-		state.setDepthWrite( material.depthWrite );
-		state.setColorWrite( material.colorWrite );
+		state.setDepthWrite( material.depthMask );
+		state.setColorWrite( material.colorMask );
 		state.setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
 	}

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -326,11 +326,27 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 
 	// TODO Deprecate
 
-	this.setColorWrite = function ( colorWrite ) {
+	this.setColorWrite = ( function () {
 
-		this.buffers.color.setMask( colorWrite );
+		var m = new THREE.WebGLColorMask();
 
-	};
+		return function ( colorWrite ) {
+
+			if( typeof( colorWrite ) === "boolean" ){
+
+				m.set( colorWrite, colorWrite, colorWrite, colorWrite );
+
+				this.buffers.color.setMask( m );
+
+			} else {
+
+				this.buffers.color.setMask( colorWrite );
+
+			}
+
+		};
+
+	} () );
 
 	this.setDepthTest = function ( depthTest ) {
 
@@ -642,15 +658,15 @@ THREE.WebGLColorBuffer = function ( gl, state ) {
 	var locked = false;
 
 	var color = new THREE.Vector4();
-	var currentColorMask = null;
 	var currentColorClear = new THREE.Vector4();
+	var currentColorMask = new THREE.WebGLColorMask();
 
 	this.setMask = function ( colorMask ) {
 
-		if ( currentColorMask !== colorMask && ! locked ) {
+		if ( currentColorMask.equals( colorMask ) === false && ! locked ) {
 
-			gl.colorMask( colorMask, colorMask, colorMask, colorMask );
-			currentColorMask = colorMask;
+			gl.colorMask( colorMask.r, colorMask.g, colorMask.b, colorMask.a );
+			currentColorMask.copy( colorMask );
 
 		}
 
@@ -679,7 +695,7 @@ THREE.WebGLColorBuffer = function ( gl, state ) {
 
 		locked = false;
 
-		currentColorMask = null;
+		currentColorMask = new THREE.WebGLColorMask();
 		currentColorClear = new THREE.Vector4();
 
 	};
@@ -913,6 +929,43 @@ THREE.WebGLStencilBuffer = function ( gl, state ) {
 		currentStencilZFail = null;
 		currentStencilZPass = null;
 		currentStencilClear = null;
+
+	};
+
+};
+
+THREE.WebGLColorMask = function ( r, g, b, a ) {
+
+	this.r = r || true;
+	this.g = g || true;
+	this.b = b || true;
+	this.a = a || true;
+
+	this.set = function ( r, g, b, a ) {
+
+		this.r = r;
+		this.g = g;
+		this.b = b;
+		this.a = a;
+
+		return this;
+
+	};
+
+	this.equals = function ( m ) {
+
+		return ( ( m.r === this.r ) && ( m.g === this.g ) && ( m.b === this.b ) && ( m.a === this.a ) );
+
+	};
+
+	this.copy = function ( m ) {
+
+		this.r = m.r;
+		this.g = m.g;
+		this.b = m.b;
+		this.a = m.a;
+
+		return this;
 
 	};
 

--- a/src/renderers/webgl/plugins/SpritePlugin.js
+++ b/src/renderers/webgl/plugins/SpritePlugin.js
@@ -219,7 +219,7 @@ THREE.SpritePlugin = function ( renderer, sprites ) {
 
 			state.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst );
 			state.setDepthTest( material.depthTest );
-			state.setDepthWrite( material.depthWrite );
+			state.setDepthWrite( material.depthMask );
 
 			if ( material.map ) {
 
@@ -351,7 +351,7 @@ THREE.SpritePlugin = function ( renderer, sprites ) {
 	}
 
 	function painterSortStable ( a, b ) {
-		
+
 		if ( a.renderOrder !== b.renderOrder ) {
 
 			return a.renderOrder - b.renderOrder;


### PR DESCRIPTION
This PR is a first attempt for introducing `colorMask` and `depthMask` properties as a substitution for `colorWrite` and `depthWrite`. 

I've created a new entity `THREE.WebGLColorMask` in `WebGLState` with four boolean properties (`r`, `g`, `b`, `a`) to handle the color mask (see #8934). The current implementation is not complete e.g. there is missing the serialization/deserialization logic in `MaterialLoader` and `Loader` or the refactoring of examples.
