### PR TITLE
removed '.dot( this.normal )' from the 'translate' function

### DIFF
--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -217,7 +217,7 @@ THREE.Plane.prototype = {
 
 	translate: function ( offset ) {
 
-		this.constant = this.constant - offset.dot( this.normal );
+		this.constant = this.constant - offset;
 
 		return this;
 


### PR DESCRIPTION
Because, why would we want to dot the offset with the normal, before subtracting it from the original constant?
