### PR TITLE
Fix Skeleton.pose() bug

### DIFF
--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -123,7 +123,7 @@ Object.assign( THREE.Skeleton.prototype, {
 
 			if ( bone ) {
 
-				if ( bone.parent ) {
+				if ( bone.parent && bone.parent instanceof THREE.Bone ) {
 
 					bone.matrix.getInverse( bone.parent.matrixWorld );
 					bone.matrix.multiply( bone.matrixWorld );

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -123,7 +123,7 @@ Object.assign( THREE.Skeleton.prototype, {
 
 			if ( bone ) {
 
-				if ( bone.parent && bone.parent instanceof THREE.Bone ) {
+				if ( bone.parent instanceof THREE.Bone ) {
 
 					bone.matrix.getInverse( bone.parent.matrixWorld );
 					bone.matrix.multiply( bone.matrixWorld );


### PR DESCRIPTION
If I'm right, `THREE.Skeleton.pose()` should see only `THREE.Bone` to calculate bind-pose matrix
because it's weird that matrixWorld of skin(bone's parent) affects bone's local matrix.

You can see the issue on this example.

http://threejs.org/examples/webgl_animation_skinning_morph.html

Run the following commands on console with/without this change.

> mixer.existingAction('Action').paused = true
> mesh.pose()
