### PR TITLE
Fix threshold when raycasting with THREE.Points

### DIFF
--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -276,9 +276,11 @@ THREE.Ray.prototype = {
 
 	}(),
 
-	intersectsSphere: function ( sphere ) {
+	intersectsSphere: function ( sphere, threshold ) {
 
-		return this.distanceToPoint( sphere.center ) <= sphere.radius;
+		var radius = sphere.radius + ( threshold || 0 );
+		
+		return this.distanceSqToPoint( sphere.center ) <= ( radius * radius );
 
 	},
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -276,11 +276,9 @@ THREE.Ray.prototype = {
 
 	}(),
 
-	intersectsSphere: function ( sphere, threshold ) {
-
-		var radius = sphere.radius + ( threshold || 0 );
+	intersectsSphere: function ( sphere ) {
 		
-		return this.distanceSqToPoint( sphere.center ) <= ( radius * radius );
+		return this.distanceSqToPoint( sphere.center ) <= ( sphere.radius * sphere.radius );
 
 	},
 

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -37,8 +37,10 @@ THREE.Points.prototype = Object.assign( Object.create( THREE.Object3D.prototype 
 			sphere.copy( geometry.boundingSphere );
 			sphere.applyMatrix4( matrixWorld );
 
-			if ( raycaster.ray.intersectsSphere( sphere, threshold ) === false ) return;
+			var radius = sphere.radius + threshold;
 
+			if ( raycaster.ray.distanceSqToPoint( sphere.center ) > ( radius * radius ) ) return;
+			
 			//
 
 			inverseMatrix.getInverse( matrixWorld );

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -37,7 +37,7 @@ THREE.Points.prototype = Object.assign( Object.create( THREE.Object3D.prototype 
 			sphere.copy( geometry.boundingSphere );
 			sphere.applyMatrix4( matrixWorld );
 
-			if ( raycaster.ray.intersectsSphere( sphere ) === false ) return;
+			if ( raycaster.ray.intersectsSphere( sphere, threshold ) === false ) return;
 
 			//
 


### PR DESCRIPTION
Currently, threshold isn't taken into account when quick rejecting a Points object by checking if the ray intersects with the bounding sphere, thus rejecting points on the edge of the bounding sphere or always if the Points objects has only one vertex.

Additionally changed Ray.intersectsSphere to compare length by the square radius to remove a sqrt function.
