### PR TITLE
(Editor) adds keyboard commands for changing transform mode

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -306,6 +306,22 @@
 							editor.undo();
 
 						}
+						
+						break;
+						
+					case 87: // Register W for translation transform mode
+						editor.signals.transformModeChanged.dispatch( 'translate' );
+						
+						break;
+						
+					case 69: // Register E for rotation transform mode
+						editor.signals.transformModeChanged.dispatch( 'rotate' );
+						
+						break;
+						
+					case 82: // Register R for scaling transform mode
+						editor.signals.transformModeChanged.dispatch( 'scale' );
+						
 						break;
 
 				}


### PR DESCRIPTION
A lot of game engines and 3D modeling tools have keyboard shortcuts for changing the transform mode. This PR adds three of the most common ones:

`W for translation`
`E for rotation`
`R for scaling`

Of the top of my head I can think of Unity3D, Unreal Engine 4 and clara.io that has these. There are additional shortcuts that could be interesting as well, such as for panning, but this is the most straight forward ones I think.

Also, not sure if `index.html` is the best place for these, but that was the place where I found similar code (undo - redo etc)
