### PR TITLE
Fix reflectivity check in MaterialLoader

### DIFF
--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -128,7 +128,7 @@ THREE.MaterialLoader.prototype = {
 
 		}
 
-		if ( json.reflectivity ) material.reflectivity = json.reflectivity;
+		if ( json.reflectivity !== undefined ) material.reflectivity = json.reflectivity;
 
 		if ( json.lightMap !== undefined ) material.lightMap = this.getTexture( json.lightMap );
 		if ( json.lightMapIntensity !== undefined ) material.lightMapIntensity = json.lightMapIntensity;


### PR DESCRIPTION
The current code does not set the reflectivity property correctly in the MaterialLoader.
It only checks if `json.reflectivity` exists but not if it is defined.

If `json.reflectivity` is 0 then the default reflectivity of 1 will be stored in the material instead of 0.

This changes the MaterialLoader to check if `json.reflectivity` is `undefined` and then sets the property if so.
