### PR TITLE
npm run build-watch - automatically rebuild three.js when changes made

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "build": "cd ./utils/build && node build.js --include common --include extras",
+    "build-watch": "chokidar \"./src/**/*.*\" -c \"npm run build\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -41,7 +42,8 @@
   "homepage": "http://threejs.org/",
   "devDependencies": {
     "argparse": "^1.0.3",
+    "chokidar-cli": "1.2.0",
     "jscs": "^1.13.1",
     "uglify-js": "^2.6.0"
-  }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "cd ./utils/build && node build.js --include common --include extras",
-    "build-watch": "chokidar \"./src/**/*.*\" \"./utils/build/includes/*.*\" --initial -c \"npm run build\"",
+    "dev": "chokidar \"./src/**/*.*\" \"./utils/build/includes/*.*\" --initial -c \"npm run build\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "cd ./utils/build && node build.js --include common --include extras",
-    "build-watch": "chokidar \"./src/**/*.*\" --initial -c \"npm run build\"",
+    "build-watch": "chokidar \"./src/**/*.*\" \"./utils/build/includes/*.*\" --initial -c \"npm run build\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "cd ./utils/build && node build.js --include common --include extras",
-    "build-watch": "chokidar \"./src/**/*.*\" -c \"npm run build\"",
+    "build-watch": "chokidar \"./src/**/*.*\" --initial -c \"npm run build\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -20,8 +20,11 @@ function main() {
 	var args = parser.parseArgs();
 	
 	var output = args.output;
-	console.log(' * Building ' + output);
+
+	console.log('Building ' + output + ':');
 	
+	var startMS = Date.now();
+
 	var sourcemap = '';
 	var sourcemapping = '';
 
@@ -39,6 +42,8 @@ function main() {
 		buffer.push('function ( root, factory ) {\n\n\tif ( typeof define === \'function\' && define.amd ) {\n\n\t\tdefine( [ \'exports\' ], factory );\n\n\t} else if ( typeof exports === \'object\' ) {\n\n\t\tfactory( exports );\n\n\t} else {\n\n\t\tfactory( root );\n\n\t}\n\n}( this, function ( exports ) {\n\n');
 	};
 	
+	console.log( '  Collecting source files.' );
+
 	for ( var i = 0; i < args.include.length; i ++ ){
 		
 		var contents = fs.readFileSync( './includes/' + args.include[i] + '.json', 'utf8' );
@@ -76,9 +81,13 @@ function main() {
 	
 	if ( !args.minify ){
 
+		console.log( '  Writing output.' );
+
 		fs.writeFileSync( output, temp, 'utf8' );
 
 	} else {
+
+		console.log( '  Uglyifying.' );
 
 		var LICENSE = "threejs.org/license";
 
@@ -125,15 +134,22 @@ function main() {
 		compressed_ast.print( stream );
 		var code = stream.toString();
 
+		console.log( '  Writing output.' );
+
 		fs.writeFileSync( output, code + sourcemapping, 'utf8' );
 
 		if ( args.sourcemaps ) {
+
+			console.log( '  Writing source map.' );
 
 			fs.writeFileSync( sourcemap, source_map.toString(), 'utf8' );
 
 		}
 
 	}
+
+	var deltaMS = Date.now() - startMS;
+	console.log( "  --- Build time: " + ( deltaMS / 1000 ) + "s" );
 
 }
 


### PR DESCRIPTION
This adds a new npm run script - "build-watch".  To run it go to the root three.js directory and type in:

```
npm run build-watch
```

What this script does is that it continues to watch the /src/ directory and if it notices any changes its run "npm run build" to build a new version of build/three.js.  This means if you use this, you just need to make changes to your js or glsl, save and refresh your three.js example page -- no need to manually run build.bat all the time.

Personally, I love this work flow.

NOTE: requires "npm install" for chokidar.
