### PR TITLE
ColladaLoader2 load external file references

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -1812,8 +1812,7 @@ THREE.ColladaLoader.prototype = {
 
 		var result = {};
 
-		console.log( refId );
-
+		console.log(refId)
 
 		if ( refId.length == 0 ) { //no refId give, build the Main visual scene
 
@@ -1822,8 +1821,7 @@ THREE.ColladaLoader.prototype = {
 				result = {
 					animations: [],
 					kinematics: { joints: [] },
-					scene: scene,
-					reference: functions
+					scene: scene
 				};
 
 				if ( cb ) { // just return the result, if no cb is given
@@ -1843,8 +1841,7 @@ THREE.ColladaLoader.prototype = {
 					result = {
 						animations: [],
 						kinematics: { joints: [] },
-						node: node,
-						reference: functions
+						node: node
 					};
 
 					if ( cb ) {
@@ -1862,8 +1859,7 @@ THREE.ColladaLoader.prototype = {
 				result = {
 					animations: [],
 					kinematics: { joints: [] },
-					node: node,
-					reference: functions
+					node: node
 				};
 
 				if ( cb ) {

--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -1787,7 +1787,7 @@ THREE.ColladaLoader.prototype = {
 
 				if ( asset.upAxis === 'Z_UP' ) {
 
-					//scene.rotation.x = - Math.PI / 2;
+					scene.rotation.x = - Math.PI / 2;
 
 				}
 


### PR DESCRIPTION
In continuation to #8989 
I removed the __functions_ and instantiated a new ColladaLoader for each subrequest, as you suggested.
There is still room for performance improvements: when a file contains multiple references to the same remote file. I'm thinking of some sort of cache, that keeps track of the already requested files and waits for the request to complete instead of requesting the same file a couple of times.

The current implementation does not break BC, but extends the functionality of `load()` and  `parse()`

``` js
loader.load( "path/CATPart.dae#38745", ( obj )=> {
    var dae = obj.node; // <- node instead of scene, when requesting a specific node
    scene.add( dae );
 } );

loader.load( "path/CATPart.dae", ( obj )=> {
    var dae = obj.scene;
    scene.add( dae );
} );
```

`load()` accepts a path including a reference to a specific node. This was needed to address certain nodes when resolving the instance nodes url. 

``` js
var xhrLoader = new THREE.XHRLoader();
xhrLoader.load( "path/CATPart_799.dae", function ( text ) {
    var loader = new THREE.ColladaLoader();
    var dae = loader.parse( text, '#node.1001' )
    scene.add( dae.node );

    var dae = loader.parse( text )
    scene.add( dae.scene );
});
```

The parser can still be used synchronously, if no remote reference is in the parsed document. 

Is there a set of collada files to test against? I'm using ~100 files to test, but I'm not sure if they cover every edge case of the collada spec.
