### PR TITLE
Clear cacheLengths

### DIFF
--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -93,6 +93,15 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 
 	},
 
+	// cacheLengths must be recalculated.
+	updateArcLengths: function () {
+
+		this.needsUpdate = true;
+		this.cacheLengths = null;
+		this.getLengths();
+
+	},
+
 	// Compute lengths and cache them
 	// We cannot overwrite getLengths() because UtoT mapping uses it.
 


### PR DESCRIPTION
the updateArcLengths in CurvePath must clear the local cache, cacheLengths

See https://github.com/mrdoob/three.js/pull/8952 for the explanation
