### PR TITLE
Examples: Fixed webgl_octree.html

### DIFF
--- a/examples/webgl_octree.html
+++ b/examples/webgl_octree.html
@@ -23,7 +23,7 @@
 				scene,
 				renderer,
 				octree,
-				geometry,
+				geometry = new THREE.BoxGeometry( 50, 50, 50 ),
 				material,
 				mesh,
 				meshes = [],
@@ -121,8 +121,6 @@
 				octree.update();
 
 			}
-
-			var geometry = new THREE.BoxGeometry( 50, 50, 50 );
 
 			function modifyOctree() {
 


### PR DESCRIPTION
see #8951

@mrdoob The internal `BoxGeometry` object for the octree was redefined at a wrong position and therefore `undefined` in the function `modifyOctree`.
