### PR TITLE
make names consistent: orthographic and perspective

### DIFF
--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -67,7 +67,7 @@
       float readDepth (sampler2D depthSampler, vec2 coord) {
         float fragCoordZ = texture2D(depthSampler, coord).x;
         float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );
-        return viewZToOrthoDepth( viewZ, cameraNear, cameraFar );
+        return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );
       }
 
       void main() {

--- a/src/renderers/shaders/ShaderChunk/packing.glsl
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl
@@ -30,10 +30,10 @@ float unpackRGBAToDepth( const in vec4 v ) {
 
 // NOTE: viewZ/eyeZ is < 0 when in front of the camera per OpenGL conventions
 
-float viewZToOrthoDepth( const in float viewZ, const in float near, const in float far ) {
+float viewZToOrthographicDepth( const in float viewZ, const in float near, const in float far ) {
   return ( viewZ + near ) / ( near - far );
 }
-float OrthoDepthToViewZ( const in float linearClipZ, const in float near, const in float far ) {
+float orthographicDepthToViewZ( const in float linearClipZ, const in float near, const in float far ) {
   return linearClipZ * ( near - far ) - near;
 }
 


### PR DESCRIPTION
Just make the use of orthographic and perspective consistent in the packing.glsl.  Before this PR, we were using the short form "ortho" and the long form "perspective" and also Ortho was capitlized while perspective wasn't.  This PR makes using the long names consistent and the capitalization consistent.
