### PR TITLE
Fixed for non-HTML documents

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -758,7 +758,7 @@ THREE.CanvasRenderer = function () {
 
 	console.error( 'THREE.CanvasRenderer has been moved to /examples/js/renderers/CanvasRenderer.js' );
 
-	this.domElement = document.createElement( 'canvas' );
+	this.domElement = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
 	this.clear = function () {};
 	this.render = function () {};
 	this.setClearColor = function () {};

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -44,7 +44,7 @@ THREE.ImageLoader.prototype = {
 
 		}
 
-		var image = document.createElement( 'img' );
+		var image = new Image();
 
 		image.addEventListener( 'load', function ( event ) {
 

--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -28,7 +28,7 @@ THREE.JSONLoader.prototype = {
 
 		if ( this._statusDomElement === undefined ) {
 
-			this._statusDomElement = document.createElement( 'div' );
+			this._statusDomElement = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'div' );
 
 		}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -12,7 +12,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 	parameters = parameters || {};
 
-	var _canvas = parameters.canvas !== undefined ? parameters.canvas : document.createElement( 'canvas' ),
+	var _canvas = parameters.canvas !== undefined ? parameters.canvas : document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' ),
 	_context = parameters.context !== undefined ? parameters.context : null,
 
 	_alpha = parameters.alpha !== undefined ? parameters.alpha : false,
@@ -2727,7 +2727,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			var scale = maxSize / Math.max( image.width, image.height );
 
-			var canvas = document.createElement( 'canvas' );
+			var canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
 			canvas.width = Math.floor( image.width * scale );
 			canvas.height = Math.floor( image.height * scale );
 
@@ -2763,7 +2763,7 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		if ( image instanceof HTMLImageElement || image instanceof HTMLCanvasElement ) {
 
-			var canvas = document.createElement( 'canvas' );
+			var canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
 			canvas.width = THREE.Math.nearestPowerOfTwo( image.width );
 			canvas.height = THREE.Math.nearestPowerOfTwo( image.height );
 

--- a/src/renderers/webgl/plugins/SpritePlugin.js
+++ b/src/renderers/webgl/plugins/SpritePlugin.js
@@ -72,7 +72,7 @@ THREE.SpritePlugin = function ( renderer, sprites ) {
 			alphaTest:			gl.getUniformLocation( program, 'alphaTest' )
 		};
 
-		var canvas = document.createElement( 'canvas' );
+		var canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
 		canvas.width = 8;
 		canvas.height = 8;
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -117,7 +117,7 @@ THREE.Texture.prototype = {
 
 			} else {
 
-				canvas = document.createElement( 'canvas' );
+				canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
 				canvas.width = image.width;
 				canvas.height = image.height;
 


### PR DESCRIPTION
Fixes #9026.

I fixed your `document.createElement` calls to explicitly specify the HTML namespace. These changes will not affect execution in normal HTML documents for any browsers.
