### PR TITLE
shortcuts for square and cube geometries

### DIFF
--- a/src/extras/geometries/BoxBufferGeometry.js
+++ b/src/extras/geometries/BoxBufferGeometry.js
@@ -17,6 +17,9 @@ THREE.BoxBufferGeometry = function ( width, height, depth, widthSegments, height
 		depthSegments: depthSegments
 	};
 
+	height = height || width;
+	depth = depth || width;
+
 	var scope = this;
 
 	// segments

--- a/src/extras/geometries/PlaneBufferGeometry.js
+++ b/src/extras/geometries/PlaneBufferGeometry.js
@@ -16,6 +16,8 @@ THREE.PlaneBufferGeometry = function ( width, height, widthSegments, heightSegme
 		heightSegments: heightSegments
 	};
 
+	height = height || width;
+
 	var width_half = width / 2;
 	var height_half = height / 2;
 


### PR DESCRIPTION
this is so we could write `new THREE.BoxGeometry (100)` instead of annoying `new THREE.BoxGeometry (100, 100, 100)`; if zero height or depth case is important, you can have === undefined instead
