### PR TITLE
Shortcut descriptions

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -63,6 +63,13 @@ textarea, input { outline: none; } /* osx */
 		border-top-color: #bbb;
 	}
 
+	.Button .Shortcut {
+		position: relative;
+		top: -1px;
+		left: 2px;
+		color: #555;
+	}
+	
 	.Panel.Collapsible.collapsed .Content {
 		display: none;
 	}

--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -62,13 +62,6 @@ textarea, input { outline: none; } /* osx */
 		margin-top: 6px;
 		border-top-color: #bbb;
 	}
-
-	.Button .Shortcut {
-		position: relative;
-		top: -1px;
-		left: 2px;
-		color: #555;
-	}
 	
 	.Panel.Collapsible.collapsed .Content {
 		display: none;

--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -62,7 +62,7 @@ textarea, input { outline: none; } /* osx */
 		margin-top: 6px;
 		border-top-color: #bbb;
 	}
-	
+
 	.Panel.Collapsible.collapsed .Content {
 		display: none;
 	}

--- a/editor/index.html
+++ b/editor/index.html
@@ -285,9 +285,10 @@
 				switch ( event.keyCode ) {
 
 					case 8: // backspace
+					
 						event.preventDefault(); // prevent browser back
 
-                                        case 46: // delete
+                    case 46: // delete
 
 						var object = editor.selected;
 
@@ -313,16 +314,19 @@
 						break;
 
 					case 87: // Register W for translation transform mode
+					
 						editor.signals.transformModeChanged.dispatch( 'translate' );
 
 						break;
 
 					case 69: // Register E for rotation transform mode
+					
 						editor.signals.transformModeChanged.dispatch( 'rotate' );
 
 						break;
 
 					case 82: // Register R for scaling transform mode
+					
 						editor.signals.transformModeChanged.dispatch( 'scale' );
 
 						break;

--- a/editor/index.html
+++ b/editor/index.html
@@ -287,8 +287,8 @@
 					case 8: // backspace
 					
 						event.preventDefault(); // prevent browser back
-
-                    case 46: // delete
+					
+					case 46: // delete
 
 						var object = editor.selected;
 

--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -104,7 +104,7 @@ Menubar.Edit = function ( editor ) {
 
 	var option = new UI.Row();
 	option.setClass( 'option' );
-	option.setTextContent( 'Delete' );
+	option.setTextContent( 'Delete (Del)' );
 	option.onClick( function () {
 
 		var object = editor.selected;

--- a/editor/js/Toolbar.js
+++ b/editor/js/Toolbar.js
@@ -14,21 +14,21 @@ var Toolbar = function ( editor ) {
 
 	// translate / rotate / scale
 
-	var translate = new UI.Button( 'translate' ).onClick( function () {
+	var translate = new UI.Button( 'translate', 'e' ).onClick( function () {
 
 		signals.transformModeChanged.dispatch( 'translate' );
 
 	} );
 	buttons.add( translate );
 
-	var rotate = new UI.Button( 'rotate' ).onClick( function () {
+	var rotate = new UI.Button( 'rotate', 'w' ).onClick( function () {
 
 		signals.transformModeChanged.dispatch( 'rotate' );
 
 	} );
 	buttons.add( rotate );
 
-	var scale = new UI.Button( 'scale' ).onClick( function () {
+	var scale = new UI.Button( 'scale', 'r' ).onClick( function () {
 
 		signals.transformModeChanged.dispatch( 'scale' );
 

--- a/editor/js/Toolbar.js
+++ b/editor/js/Toolbar.js
@@ -14,21 +14,21 @@ var Toolbar = function ( editor ) {
 
 	// translate / rotate / scale
 
-	var translate = new UI.Button( 'translate', 'e' ).onClick( function () {
+	var translate = new UI.Button( 'translate ( e )' ).onClick( function () {
 
 		signals.transformModeChanged.dispatch( 'translate' );
 
 	} );
 	buttons.add( translate );
 
-	var rotate = new UI.Button( 'rotate', 'w' ).onClick( function () {
+	var rotate = new UI.Button( 'rotate ( w )' ).onClick( function () {
 
 		signals.transformModeChanged.dispatch( 'rotate' );
 
 	} );
 	buttons.add( rotate );
 
-	var scale = new UI.Button( 'scale', 'r' ).onClick( function () {
+	var scale = new UI.Button( 'scale ( r )' ).onClick( function () {
 
 		signals.transformModeChanged.dispatch( 'scale' );
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -1041,18 +1041,27 @@ UI.HorizontalRule.prototype.constructor = UI.HorizontalRule;
 
 // Button
 
-UI.Button = function ( value ) {
+UI.Button = function ( value, shortcut ) {
 
 	UI.Element.call( this );
-
-	var scope = this;
 
 	var dom = document.createElement( 'button' );
 	dom.className = 'Button';
 
 	this.dom = dom;
 	this.dom.textContent = value;
-
+	
+	if ( shortcut != null ) {
+		
+		var shortcutDom = document.createElement( 'span' );
+		
+		shortcutDom.className = 'Shortcut';
+		shortcutDom.textContent = '( ' + shortcut + ' )';
+		
+		this.dom.appendChild( shortcutDom );
+		
+	}
+	
 	return this;
 
 };

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -1041,7 +1041,7 @@ UI.HorizontalRule.prototype.constructor = UI.HorizontalRule;
 
 // Button
 
-UI.Button = function ( value, shortcut ) {
+UI.Button = function ( value ) {
 
 	UI.Element.call( this );
 
@@ -1050,17 +1050,6 @@ UI.Button = function ( value, shortcut ) {
 
 	this.dom = dom;
 	this.dom.textContent = value;
-	
-	if ( shortcut != null ) {
-		
-		var shortcutDom = document.createElement( 'span' );
-		
-		shortcutDom.className = 'Shortcut';
-		shortcutDom.textContent = '( ' + shortcut + ' )';
-		
-		this.dom.appendChild( shortcutDom );
-		
-	}
 	
 	return this;
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -1050,7 +1050,7 @@ UI.Button = function ( value ) {
 
 	this.dom = dom;
 	this.dom.textContent = value;
-	
+
 	return this;
 
 };


### PR DESCRIPTION
This adds keyboard shortcuts to the Delete menu item as well as to the transformation mode buttons (just like Undo / Redo menu items have their shortcuts specified).

Not super happy with the `shortcut` argument addition to the `UI.Button` class, since it might be a bit too specific for a generic button. Problem was I had to be able to position the shortcut text induvidually from the description text to make it look decent. 

On a related note, there is the potential for a lot more shortcuts to be added. IMO, it is often a lot easier to use the keyboard for commands and the mouse for scene manipulation. Is this something you would like to see happen @mrdoob, and if so, do you think we should move shortcut registration to its own file or do you want to keep it in the html file?
