### PR TITLE
Fix test for property existence in property binding in the case if property is a false boolean or a numeric equal to zero

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -163,7 +163,7 @@ THREE.PropertyBinding.prototype = {
 		// resolve property
 		var nodeProperty = targetObject[ propertyName ];
 
-		if ( ! nodeProperty ) {
+		if ( nodeProperty === undefined ) {
 
 			var nodeName = parsedPath.nodeName;
 


### PR DESCRIPTION
Fix test for property existence in property binding in the case if property is a false boolean or a numeric equal to zero

cf discussion #9057 
