### PR TITLE
audio.js - set isPlaying to false on stop()

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -116,7 +116,8 @@ THREE.Audio.prototype = Object.assign( Object.create( THREE.Object3D.prototype )
 			return;
 
 		}
-
+		
+		this.isPlaying = false;
 		this.source.stop();
 		this.startTime = 0;
 


### PR DESCRIPTION
The boolean 'isPlaying' gets set to true in 'play()', but never gets set to false in 'stop()'

Added line to set 'isPlaying' to false in 'stop()'.
