### PR TITLE
fix switched shortcut keys on buttons

### DIFF
--- a/editor/js/Toolbar.js
+++ b/editor/js/Toolbar.js
@@ -14,14 +14,14 @@ var Toolbar = function ( editor ) {
 
 	// translate / rotate / scale
 
-	var translate = new UI.Button( 'translate ( e )' ).onClick( function () {
+	var translate = new UI.Button( 'translate ( w )' ).onClick( function () {
 
 		signals.transformModeChanged.dispatch( 'translate' );
 
 	} );
 	buttons.add( translate );
 
-	var rotate = new UI.Button( 'rotate ( w )' ).onClick( function () {
+	var rotate = new UI.Button( 'rotate ( e )' ).onClick( function () {
 
 		signals.transformModeChanged.dispatch( 'rotate' );
 


### PR DESCRIPTION
Inlining the shortcuts i accidently switched translation (w) and rotation (e). Sorry for the trouble.
