### PR TITLE
Shapes refactor

### DIFF
--- a/examples/webgl_geometry_extrude_shapes2.html
+++ b/examples/webgl_geometry_extrude_shapes2.html
@@ -44,7 +44,7 @@ const DIGIT_0 = 48, DIGIT_9 = 57, COMMA = 44, SPACE = 32, PERIOD = 46, MINUS = 4
 
 exports.transformSVGPath =
 function transformSVGPath(pathStr) {
-	var path = new THREE.Shape();
+	var path = new THREE.ShapePath();
 
 	var idx = 1, len = pathStr.length, activeCmd,
 		x = 0, y = 0, nx = 0, ny = 0, firstX = null, firstY = null,

--- a/src/extras/ShapeUtils.js
+++ b/src/extras/ShapeUtils.js
@@ -628,7 +628,7 @@ THREE.ShapeUtils = {
 
 			if ( allPointsMap[ key ] !== undefined ) {
 
-				console.warn( "THREE.Shape: Duplicate point", key );
+				console.warn( "THREE.ShapeUtils: Duplicate point", key, i );
 
 			}
 

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -66,7 +66,13 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 				var diff = curveLengths[ i ] - d;
 				var curve = this.curves[ i ];
 
-				var u = 1 - diff / curve.getLength();
+				var segmentLength = curve.getLength();
+				var u = 0;
+				if ( segmentLength !== 0 ) {
+
+				  u = 1 - diff / curve.getLength();
+
+				}
 
 				return curve.getPointAt( u );
 

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -139,6 +139,84 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 
 	},
 
+	getSpacedPoints: function ( divisions ) {
+
+		if ( ! divisions ) divisions = 40;
+
+		var points = [];
+
+		for ( var i = 0; i < divisions; i ++ ) {
+
+			points.push( this.getPoint( i / divisions ) );
+
+		}
+
+		if ( this.autoClose ) {
+
+			points.push( points[ 0 ] );
+
+		}
+
+		return points;
+
+	},
+
+	getPoints: function ( divisions ) {
+
+		divisions = divisions || 12;
+
+		var points = [], tmp, last;
+
+		this.curves.forEach(function(curve) {
+
+			var pts = curve instanceof THREE.LineCurve ? 1 : divisions;
+			tmp = curve.getPoints(pts);
+			points = points.concat(tmp);
+
+		});
+
+		if ( this.autoClose ) {
+
+			points.push( points[ 0 ] );
+
+		}
+
+		points = this.removeDuplicatesInAPath( points );
+
+		return points;
+
+	},
+
+
+	/* Ensures consecutive vectors of a path
+	 * have no duplicates.
+	 * Arguments: Path is an array of Vector2
+	 */
+	removeDuplicatesInAPath: function ( points ) {
+
+		if ( points.length === 0 ) return points;
+
+		var lastPoint = points[0];
+		var newPath = [ lastPoint ];
+
+		for (var i = 1; i < points.length; i++) {
+			if (lastPoint.distanceTo(points[ i ]) > Number.EPSILON) {
+				lastPoint = points[ i ];
+
+				if ( i !== points.length - 1 || points[0].distanceTo( lastPoint ) > Number.EPSILON ) {
+					newPath.push( lastPoint );
+					// remove last point if it's the same as the first point
+					// TODO Move this to shapeutils only
+				}
+			} else {
+				// console.log('duplicate points at ', i - 1, i);
+			}
+		}
+
+		return newPath;
+
+	},
+
 	/**************************************************************
 	 *	Create Geometries Helpers
 	 **************************************************************/

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -67,12 +67,7 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 				var curve = this.curves[ i ];
 
 				var segmentLength = curve.getLength();
-				var u = 0;
-				if ( segmentLength !== 0 ) {
-
-				  u = 1 - diff / curve.getLength();
-
-				}
+				var u = segmentLength === 0 ? 0 : 1 - diff / segmentLength;
 
 				return curve.getPointAt( u );
 
@@ -145,7 +140,7 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 
 		var points = [];
 
-		for ( var i = 0; i < divisions; i ++ ) {
+		for ( var i = 0; i <= divisions; i ++ ) {
 
 			points.push( this.getPoint( i / divisions ) );
 

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -28,8 +28,6 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 
 	closePath: function () {
 
-		// TODO Test
-		// and verify for vector3 (needs to implement equals)
 		// Add a line curve if start and end of lines are not connected
 		var startPoint = this.curves[ 0 ].getPoint( 0 );
 		var endPoint = this.curves[ this.curves.length - 1 ].getPoint( 1 );
@@ -160,15 +158,29 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 
 		divisions = divisions || 12;
 
-		var points = [], tmp, last;
+		var points = [], tmp, last, curve;
 
-		this.curves.forEach(function(curve) {
+		for ( var i = 0, curves = this.curves; i < curves.length; i ++ ) {
 
+			curve = curves[i];
 			var pts = curve instanceof THREE.LineCurve ? 1 : divisions;
 			tmp = curve.getPoints(pts);
-			points = points.concat(tmp);
+			if ( last && last.equals( tmp[ 0 ] ) ) {
 
-		});
+				tmp = tmp.slice(1);
+
+			}
+
+			points = points.concat(tmp);
+			last = points[ points.length - 1 ];
+
+		}
+
+		if ( points[ points.length - 1 ].equals( points[ 0 ] ) ) {
+
+			points.pop();
+
+		}
 
 		if ( this.autoClose ) {
 
@@ -176,39 +188,7 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 
 		}
 
-		points = this.removeDuplicatesInAPath( points );
-
 		return points;
-
-	},
-
-
-	/* Ensures consecutive vectors of a path
-	 * have no duplicates.
-	 * Arguments: Path is an array of Vector2
-	 */
-	removeDuplicatesInAPath: function ( points ) {
-
-		if ( points.length === 0 ) return points;
-
-		var lastPoint = points[0];
-		var newPath = [ lastPoint ];
-
-		for (var i = 1; i < points.length; i++) {
-			if (lastPoint.distanceTo(points[ i ]) > Number.EPSILON) {
-				lastPoint = points[ i ];
-
-				if ( i !== points.length - 1 || points[0].distanceTo( lastPoint ) > Number.EPSILON ) {
-					newPath.push( lastPoint );
-					// remove last point if it's the same as the first point
-					// TODO Move this to shapeutils only
-				}
-			} else {
-				// console.log('duplicate points at ', i - 1, i);
-			}
-		}
-
-		return newPath;
 
 	},
 

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -163,16 +163,16 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 		for ( var i = 0, curves = this.curves; i < curves.length; i ++ ) {
 
 			curve = curves[i];
-			var pts = curve instanceof THREE.LineCurve ? 1 : divisions;
-			tmp = curve.getPoints(pts);
-			if ( last && last.equals( tmp[ 0 ] ) ) {
+			var pts = curve.getPoints( curve instanceof THREE.LineCurve ? 1 : divisions );
 
-				tmp = tmp.slice(1);
+			for ( var j = 0; j < pts.length; j++ ) {
+
+				var tmp = pts[ j ];
+				if ( last && last.equals( tmp ) ) continue; // ensures no consecutive points are duplicates
+				points.push( tmp );
+				last = tmp;
 
 			}
-
-			points = points.concat(tmp);
-			last = points[ points.length - 1 ];
 
 		}
 

--- a/src/extras/core/Font.js
+++ b/src/extras/core/Font.js
@@ -40,7 +40,7 @@ Object.assign( THREE.Font.prototype, {
 
 			if ( ! glyph ) return;
 
-			var path = new THREE.Path();
+			var path = new THREE.ShapePath();
 
 			var pts = [], b2 = THREE.ShapeUtils.b2, b3 = THREE.ShapeUtils.b3;
 			var x, y, cpx, cpy, cpx0, cpy0, cpx1, cpy1, cpx2, cpy2, laste;

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -172,14 +172,11 @@ THREE.ShapePath.prototype = {
 				var tmpPath = inSubpaths[ i ];
 
 				var tmpShape = new THREE.Shape();
-				tmpShape.actions = tmpPath.actions;
 				tmpShape.curves = tmpPath.curves;
 
 				shapes.push( tmpShape );
 
 			}
-
-			//console.log("shape", shapes);
 
 			return shapes;
 
@@ -258,7 +255,6 @@ THREE.ShapePath.prototype = {
 
 			tmpPath = subPaths[ 0 ];
 			tmpShape = new THREE.Shape();
-			tmpShape.actions = tmpPath.actions;
 			tmpShape.curves = tmpPath.curves;
 			shapes.push( tmpShape );
 			return shapes;
@@ -291,7 +287,6 @@ THREE.ShapePath.prototype = {
 				if ( ( ! holesFirst ) && ( newShapes[ mainIdx ] ) )	mainIdx ++;
 
 				newShapes[ mainIdx ] = { s: new THREE.Shape(), p: tmpPoints };
-				newShapes[ mainIdx ].s.actions = tmpPath.actions;
 				newShapes[ mainIdx ].s.curves = tmpPath.curves;
 
 				if ( holesFirst )	mainIdx ++;

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -155,7 +155,8 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 			xRadius, yRadius,
 			aStartAngle, aEndAngle,
 			aClockwise,
-			aRotation || 0 // aRotation is optional.
+			aRotation || 0, // aRotation is optional.
+			this.curves.length
 		];
 
 		var curve = new THREE.EllipseCurve( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation );
@@ -175,7 +176,7 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 		var points = [];
 
-		for ( var i = 0; i < divisions; i ++ ) {
+		for ( var i = 0; i <= divisions; i ++ ) {
 
 			points.push( this.getPoint( i / divisions ) );
 
@@ -325,42 +326,6 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 				break;
 
-			case 'arc':
-
-				var aX = args[ 0 ], aY = args[ 1 ],
-					aRadius = args[ 2 ],
-					aStartAngle = args[ 3 ], aEndAngle = args[ 4 ],
-					aClockwise = !! args[ 5 ];
-
-				var deltaAngle = aEndAngle - aStartAngle;
-				var angle;
-				var tdivisions = divisions * 2;
-
-				for ( var j = 1; j <= tdivisions; j ++ ) {
-
-					var t = j / tdivisions;
-
-					if ( ! aClockwise ) {
-
-						t = 1 - t;
-
-					}
-
-					angle = aStartAngle + t * deltaAngle;
-
-					tx = aX + aRadius * Math.cos( angle );
-					ty = aY + aRadius * Math.sin( angle );
-
-					//console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
-
-					points.push( new THREE.Vector2( tx, ty ) );
-
-				}
-
-				//console.log(points);
-
-				break;
-
 			case 'ellipse':
 
 				var aX = args[ 0 ], aY = args[ 1 ],
@@ -368,49 +333,16 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 					yRadius = args[ 3 ],
 					aStartAngle = args[ 4 ], aEndAngle = args[ 5 ],
 					aClockwise = !! args[ 6 ],
-					aRotation = args[ 7 ];
+					aRotation = args[ 7 ],
+					curveIndex = args[8];
 
+				var ellipse = this.curves[ curveIndex ];
 
-				var deltaAngle = aEndAngle - aStartAngle;
-				var angle;
-				var tdivisions = divisions * 2;
+				for ( var j = 0; j <= divisions; j++ ) {
 
-				var cos, sin;
-				if ( aRotation !== 0 ) {
+					var t = j / divisions;
 
-					cos = Math.cos( aRotation );
-					sin = Math.sin( aRotation );
-
-				}
-
-				for ( var j = 1; j <= tdivisions; j ++ ) {
-
-					var t = j / tdivisions;
-
-					if ( ! aClockwise ) {
-
-						t = 1 - t;
-
-					}
-
-					angle = aStartAngle + t * deltaAngle;
-
-					tx = aX + xRadius * Math.cos( angle );
-					ty = aY + yRadius * Math.sin( angle );
-
-					if ( aRotation !== 0 ) {
-
-						var x = tx, y = ty;
-
-						// Rotate the point about the center of the ellipse.
-						tx = ( x - aX ) * cos - ( y - aY ) * sin + aX;
-						ty = ( x - aX ) * sin + ( y - aY ) * cos + aY;
-
-					}
-
-					//console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
-
-					points.push( new THREE.Vector2( tx, ty ) );
+					points.push( ellipse.getPoint( t ) );
 
 				}
 

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -7,8 +7,7 @@
 THREE.Path = function ( points ) {
 
 	THREE.CurvePath.call( this );
-
-	this.actions = [];
+	this.currentPoint = new THREE.Vector2();
 
 	if ( points ) {
 
@@ -22,11 +21,8 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 	constructor: THREE.Path,
 
-	// TODO Clean up PATH API
-
 	// Create path using straight lines to connect all points
 	// - vectors: array of Vector2
-
 	fromPoints: function ( vectors ) {
 
 		this.moveTo( vectors[ 0 ].x, vectors[ 0 ].y );
@@ -41,30 +37,26 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 	moveTo: function ( x, y ) {
 
-		this.actions.push( { action: 'moveTo', args: [ x, y ] } );
+		this.currentPoint.set( x, y ); // TODO consider referencing vectors instead of copying?
 
 	},
 
 	lineTo: function ( x, y ) {
 
-		var lastargs = this.actions[ this.actions.length - 1 ].args;
-
-		var x0 = lastargs[ lastargs.length - 2 ];
-		var y0 = lastargs[ lastargs.length - 1 ];
+		var x0 = this.currentPoint.x;
+		var y0 = this.currentPoint.y;
 
 		var curve = new THREE.LineCurve( new THREE.Vector2( x0, y0 ), new THREE.Vector2( x, y ) );
 		this.curves.push( curve );
 
-		this.actions.push( { action: 'lineTo', args: [ x, y ] } );
+		this.currentPoint.set( x, y );
 
 	},
 
 	quadraticCurveTo: function ( aCPx, aCPy, aX, aY ) {
 
-		var lastargs = this.actions[ this.actions.length - 1 ].args;
-
-		var x0 = lastargs[ lastargs.length - 2 ];
-		var y0 = lastargs[ lastargs.length - 1 ];
+		var x0 = this.currentPoint.x;
+		var y0 = this.currentPoint.y;
 
 		var curve = new THREE.QuadraticBezierCurve(
 			new THREE.Vector2( x0, y0 ),
@@ -74,16 +66,14 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 		this.curves.push( curve );
 
-		this.actions.push( { action: 'quadraticCurveTo', args: [ aCPx, aCPy, aX, aY ] } );
+		this.currentPoint.set( aX, aY );
 
 	},
 
 	bezierCurveTo: function ( aCP1x, aCP1y, aCP2x, aCP2y, aX, aY ) {
 
-		var lastargs = this.actions[ this.actions.length - 1 ].args;
-
-		var x0 = lastargs[ lastargs.length - 2 ];
-		var y0 = lastargs[ lastargs.length - 1 ];
+		var x0 = this.currentPoint.x;
+		var y0 = this.currentPoint.y;
 
 		var curve = new THREE.CubicBezierCurve(
 			new THREE.Vector2( x0, y0 ),
@@ -94,38 +84,26 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 		this.curves.push( curve );
 
-		this.actions.push( { action: 'bezierCurveTo', args: [ aCP1x, aCP1y, aCP2x, aCP2y, aX, aY ] } );
+		this.currentPoint.set( aX, aY );
 
 	},
 
 	splineThru: function ( pts /*Array of Vector*/ ) {
 
-		var args = Array.prototype.slice.call( arguments );
+		var x0 = this.currentPoint.x;
+		var y0 = this.currentPoint.y;
 
-		var lastargs = this.actions[ this.actions.length - 1 ].args;
-
-		var x0 = lastargs[ lastargs.length - 2 ];
-		var y0 = lastargs[ lastargs.length - 1 ];
-
-		var npts = [ new THREE.Vector2( x0, y0 ) ];
-		Array.prototype.push.apply( npts, pts );
+		var npts = [ new THREE.Vector2( x0, y0 ) ].concat( pts );
 
 		var curve = new THREE.SplineCurve( npts );
 		this.curves.push( curve );
-
-		var lastPoint = pts[ pts.length - 1 ];
-		args.push( lastPoint.x );
-		args.push( lastPoint.y );
-
-		this.actions.push( { action: 'splineThru', args: args } );
 
 	},
 
 	arc: function ( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
 
-		var lastargs = this.actions[ this.actions.length - 1 ].args;
-		var x0 = lastargs[ lastargs.length - 2 ];
-		var y0 = lastargs[ lastargs.length - 1 ];
+		var x0 = this.currentPoint.x;
+		var y0 = this.currentPoint.y;
 
 		this.absarc( aX + x0, aY + y0, aRadius,
 			aStartAngle, aEndAngle, aClockwise );
@@ -140,9 +118,8 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 	ellipse: function ( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation ) {
 
-		var lastargs = this.actions[ this.actions.length - 1 ].args;
-		var x0 = lastargs[ lastargs.length - 2 ];
-		var y0 = lastargs[ lastargs.length - 1 ];
+		var x0 = this.currentPoint.x;
+		var y0 = this.currentPoint.y;
 
 		this.absellipse( aX + x0, aY + y0, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation );
 
@@ -150,267 +127,43 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 	absellipse: function ( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation ) {
 
-		var args = [
-			aX, aY,
-			xRadius, yRadius,
-			aStartAngle, aEndAngle,
-			aClockwise,
-			aRotation || 0, // aRotation is optional.
-			this.curves.length
-		];
-
 		var curve = new THREE.EllipseCurve( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation );
 		this.curves.push( curve );
 
 		var lastPoint = curve.getPoint( 1 );
-		args.push( lastPoint.x );
-		args.push( lastPoint.y );
+		this.currentPoint.copy( lastPoint );
 
-		this.actions.push( { action: 'ellipse', args: args } );
+	}
 
+} );
+
+
+// minimal class for proxing functions to Path. Replaces old "extractSubpaths()"
+THREE.ShapePath = function() {
+	this.subPaths = [];
+	this.currentPath = null;
+}
+
+THREE.ShapePath.prototype = {
+	moveTo: function ( x, y ) {
+		this.currentPath = new THREE.Path();
+		this.subPaths.push(this.currentPath);
+		this.currentPath.moveTo( x, y );
 	},
-
-	getSpacedPoints: function ( divisions ) {
-
-		if ( ! divisions ) divisions = 40;
-
-		var points = [];
-
-		for ( var i = 0; i <= divisions; i ++ ) {
-
-			points.push( this.getPoint( i / divisions ) );
-
-			//if ( !this.getPoint( i / divisions ) ) throw "DIE";
-
-		}
-
-		if ( this.autoClose ) {
-
-			points.push( points[ 0 ] );
-
-		}
-
-		return points;
-
+	lineTo: function ( x, y ) {
+		this.currentPath.lineTo( x, y );
 	},
-
-	getPoints: function ( divisions ) {
-
-		divisions = divisions || 12;
-
-		var b2 = THREE.ShapeUtils.b2;
-		var b3 = THREE.ShapeUtils.b3;
-
-		var points = [];
-
-		var cpx, cpy, cpx2, cpy2, cpx1, cpy1, cpx0, cpy0,
-			laste, tx, ty;
-
-		for ( var i = 0, l = this.actions.length; i < l; i ++ ) {
-
-			var item = this.actions[ i ];
-
-			var action = item.action;
-			var args = item.args;
-
-			switch ( action ) {
-
-			case 'moveTo':
-
-				points.push( new THREE.Vector2( args[ 0 ], args[ 1 ] ) );
-
-				break;
-
-			case 'lineTo':
-
-				points.push( new THREE.Vector2( args[ 0 ], args[ 1 ] ) );
-
-				break;
-
-			case 'quadraticCurveTo':
-
-				cpx  = args[ 2 ];
-				cpy  = args[ 3 ];
-
-				cpx1 = args[ 0 ];
-				cpy1 = args[ 1 ];
-
-				if ( points.length > 0 ) {
-
-					laste = points[ points.length - 1 ];
-
-					cpx0 = laste.x;
-					cpy0 = laste.y;
-
-				} else {
-
-					laste = this.actions[ i - 1 ].args;
-
-					cpx0 = laste[ laste.length - 2 ];
-					cpy0 = laste[ laste.length - 1 ];
-
-				}
-
-				for ( var j = 1; j <= divisions; j ++ ) {
-
-					var t = j / divisions;
-
-					tx = b2( t, cpx0, cpx1, cpx );
-					ty = b2( t, cpy0, cpy1, cpy );
-
-					points.push( new THREE.Vector2( tx, ty ) );
-
-				}
-
-				break;
-
-			case 'bezierCurveTo':
-
-				cpx  = args[ 4 ];
-				cpy  = args[ 5 ];
-
-				cpx1 = args[ 0 ];
-				cpy1 = args[ 1 ];
-
-				cpx2 = args[ 2 ];
-				cpy2 = args[ 3 ];
-
-				if ( points.length > 0 ) {
-
-					laste = points[ points.length - 1 ];
-
-					cpx0 = laste.x;
-					cpy0 = laste.y;
-
-				} else {
-
-					laste = this.actions[ i - 1 ].args;
-
-					cpx0 = laste[ laste.length - 2 ];
-					cpy0 = laste[ laste.length - 1 ];
-
-				}
-
-
-				for ( var j = 1; j <= divisions; j ++ ) {
-
-					var t = j / divisions;
-
-					tx = b3( t, cpx0, cpx1, cpx2, cpx );
-					ty = b3( t, cpy0, cpy1, cpy2, cpy );
-
-					points.push( new THREE.Vector2( tx, ty ) );
-
-				}
-
-				break;
-
-			case 'splineThru':
-
-				laste = this.actions[ i - 1 ].args;
-
-				var last = new THREE.Vector2( laste[ laste.length - 2 ], laste[ laste.length - 1 ] );
-				var spts = [ last ];
-
-				var n = divisions * args[ 0 ].length;
-
-				spts = spts.concat( args[ 0 ] );
-
-				var spline = new THREE.SplineCurve( spts );
-
-				for ( var j = 1; j <= n; j ++ ) {
-
-					points.push( spline.getPointAt( j / n ) );
-
-				}
-
-				break;
-
-			case 'ellipse':
-
-				var aX = args[ 0 ], aY = args[ 1 ],
-					xRadius = args[ 2 ],
-					yRadius = args[ 3 ],
-					aStartAngle = args[ 4 ], aEndAngle = args[ 5 ],
-					aClockwise = !! args[ 6 ],
-					aRotation = args[ 7 ],
-					curveIndex = args[8];
-
-				var ellipse = this.curves[ curveIndex ];
-
-				for ( var j = 0; j <= divisions; j++ ) {
-
-					var t = j / divisions;
-
-					points.push( ellipse.getPoint( t ) );
-
-				}
-
-				//console.log(points);
-
-				break;
-
-			} // end switch
-
-		}
-
-
-
-		// Normalize to remove the closing point by default.
-		var lastPoint = points[ points.length - 1 ];
-		if ( Math.abs( lastPoint.x - points[ 0 ].x ) < Number.EPSILON &&
-				 Math.abs( lastPoint.y - points[ 0 ].y ) < Number.EPSILON )
-			points.splice( points.length - 1, 1 );
-
-		if ( this.autoClose ) {
-
-			points.push( points[ 0 ] );
-
-		}
-
-		return points;
-
+	quadraticCurveTo: function ( aCPx, aCPy, aX, aY ) {
+		this.currentPath.quadraticCurveTo( aCPx, aCPy, aX, aY );
+	},
+	bezierCurveTo: function ( aCP1x, aCP1y, aCP2x, aCP2y, aX, aY ) {
+		this.currentPath.bezierCurveTo( aCP1x, aCP1y, aCP2x, aCP2y, aX, aY );
+	},
+	splineThru: function ( pts ) {
+		this.currentPath.splineThru( pts );
 	},
 
 	toShapes: function ( isCCW, noHoles ) {
-
-		function extractSubpaths( inActions ) {
-
-			var subPaths = [], lastPath = new THREE.Path();
-
-			for ( var i = 0, l = inActions.length; i < l; i ++ ) {
-
-				var item = inActions[ i ];
-
-				var args = item.args;
-				var action = item.action;
-
-				if ( action === 'moveTo' ) {
-
-					if ( lastPath.actions.length !== 0 ) {
-
-						subPaths.push( lastPath );
-						lastPath = new THREE.Path();
-
-					}
-
-				}
-
-				lastPath[ action ].apply( lastPath, args );
-
-			}
-
-			if ( lastPath.actions.length !== 0 ) {
-
-				subPaths.push( lastPath );
-
-			}
-
-			// console.log(subPaths);
-
-			return	subPaths;
-
-		}
 
 		function toShapesNoHoles( inSubpaths ) {
 
@@ -495,7 +248,7 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 		var isClockWise = THREE.ShapeUtils.isClockWise;
 
-		var subPaths = extractSubpaths( this.actions );
+		var subPaths = this.subPaths;
 		if ( subPaths.length === 0 ) return [];
 
 		if ( noHoles === true )	return	toShapesNoHoles( subPaths );
@@ -641,5 +394,4 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 		return shapes;
 
 	}
-
-} );
+}

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -43,10 +43,7 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 	lineTo: function ( x, y ) {
 
-		var x0 = this.currentPoint.x;
-		var y0 = this.currentPoint.y;
-
-		var curve = new THREE.LineCurve( new THREE.Vector2( x0, y0 ), new THREE.Vector2( x, y ) );
+		var curve = new THREE.LineCurve( this.currentPoint.clone(), new THREE.Vector2( x, y ) );
 		this.curves.push( curve );
 
 		this.currentPoint.set( x, y );
@@ -55,11 +52,8 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 	quadraticCurveTo: function ( aCPx, aCPy, aX, aY ) {
 
-		var x0 = this.currentPoint.x;
-		var y0 = this.currentPoint.y;
-
 		var curve = new THREE.QuadraticBezierCurve(
-			new THREE.Vector2( x0, y0 ),
+			this.currentPoint.clone(),
 			new THREE.Vector2( aCPx, aCPy ),
 			new THREE.Vector2( aX, aY )
 		);
@@ -72,11 +66,8 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 	bezierCurveTo: function ( aCP1x, aCP1y, aCP2x, aCP2y, aX, aY ) {
 
-		var x0 = this.currentPoint.x;
-		var y0 = this.currentPoint.y;
-
 		var curve = new THREE.CubicBezierCurve(
-			new THREE.Vector2( x0, y0 ),
+			this.currentPoint.clone(),
 			new THREE.Vector2( aCP1x, aCP1y ),
 			new THREE.Vector2( aCP2x, aCP2y ),
 			new THREE.Vector2( aX, aY )
@@ -90,10 +81,7 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 
 	splineThru: function ( pts /*Array of Vector*/ ) {
 
-		var x0 = this.currentPoint.x;
-		var y0 = this.currentPoint.y;
-
-		var npts = [ new THREE.Vector2( x0, y0 ) ].concat( pts );
+		var npts = [ this.currentPoint.clone() ].concat( pts );
 
 		var curve = new THREE.SplineCurve( npts );
 		this.curves.push( curve );

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -118,11 +118,17 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 	absellipse: function ( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation ) {
 
 		var curve = new THREE.EllipseCurve( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation );
-		var firstPoint = curve.getPoint( 0 );
 
-		if ( ! firstPoint.equals( this.currentPoint ) ) {
+		if ( this.curves.length > 0 ) {
 
-			this.lineTo( firstPoint.x, firstPoint.y );
+			// if a previous curve is present, attempt to join
+			var firstPoint = curve.getPoint( 0 );
+
+			if ( ! firstPoint.equals( this.currentPoint ) ) {
+
+				this.lineTo( firstPoint.x, firstPoint.y );
+
+			}
 
 		}
 

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -86,6 +86,8 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 		var curve = new THREE.SplineCurve( npts );
 		this.curves.push( curve );
 
+		this.currentPoint.copy( pts[ pts.length - 1 ] );
+
 	},
 
 	arc: function ( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
@@ -116,6 +118,14 @@ THREE.Path.prototype = Object.assign( Object.create( THREE.CurvePath.prototype )
 	absellipse: function ( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation ) {
 
 		var curve = new THREE.EllipseCurve( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation );
+		var firstPoint = curve.getPoint( 0 );
+
+		if ( ! firstPoint.equals( this.currentPoint ) ) {
+
+			this.lineTo( firstPoint.x, firstPoint.y );
+
+		}
+
 		this.curves.push( curve );
 
 		var lastPoint = curve.getPoint( 1 );

--- a/src/extras/curves/EllipseCurve.js
+++ b/src/extras/curves/EllipseCurve.js
@@ -24,23 +24,41 @@ THREE.EllipseCurve.prototype.constructor = THREE.EllipseCurve;
 
 THREE.EllipseCurve.prototype.getPoint = function ( t ) {
 
-	var deltaAngle = this.aEndAngle - this.aStartAngle;
+	// Calculate deltaAngle just once.
+	var twoPi = Math.PI * 2;
+	if ( this.deltaAngle === undefined ) {
 
-	if ( deltaAngle < 0 ) deltaAngle += Math.PI * 2;
-	if ( deltaAngle > Math.PI * 2 ) deltaAngle -= Math.PI * 2;
+		var deltaAngle = this.aEndAngle - this.aStartAngle;
+		var samePoints = Math.abs( deltaAngle ) < Number.EPSILON;
 
-	var angle;
+		while ( deltaAngle < 0 ) deltaAngle += twoPi;
+		while ( deltaAngle > twoPi ) deltaAngle -= twoPi;
 
-	if ( this.aClockwise === true ) {
+		if ( deltaAngle < Number.EPSILON ) {
 
-		angle = this.aEndAngle + ( 1 - t ) * ( Math.PI * 2 - deltaAngle );
+			if ( samePoints ) {
 
-	} else {
+				deltaAngle = 0;
 
-		angle = this.aStartAngle + t * deltaAngle;
+			} else {
+
+				deltaAngle = twoPi;
+
+			}
+
+		}
+
+		if ( this.aClockwise === true && deltaAngle != twoPi && !samePoints ) {
+
+			deltaAngle = deltaAngle - twoPi;
+
+		}
+
+		this.deltaAngle = deltaAngle;
 
 	}
 	
+	var angle = this.aStartAngle + t * this.deltaAngle;
 	var x = this.aX + this.xRadius * Math.cos( angle );
 	var y = this.aY + this.yRadius * Math.sin( angle );
 

--- a/src/extras/curves/EllipseCurve.js
+++ b/src/extras/curves/EllipseCurve.js
@@ -2,7 +2,7 @@
  *	Ellipse curve
  **************************************************************/
 
-THREE.EllipseCurve = function ( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation ) {
+THREE.EllipseCurve = function( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation ) {
 
 	this.aX = aX;
 	this.aY = aY;
@@ -14,7 +14,7 @@ THREE.EllipseCurve = function ( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle
 	this.aEndAngle = aEndAngle;
 
 	this.aClockwise = aClockwise;
-	
+
 	this.aRotation = aRotation || 0;
 
 };
@@ -22,43 +22,37 @@ THREE.EllipseCurve = function ( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle
 THREE.EllipseCurve.prototype = Object.create( THREE.Curve.prototype );
 THREE.EllipseCurve.prototype.constructor = THREE.EllipseCurve;
 
-THREE.EllipseCurve.prototype.getPoint = function ( t ) {
+THREE.EllipseCurve.prototype.getPoint = function( t ) {
 
-	// Calculate deltaAngle just once.
 	var twoPi = Math.PI * 2;
-	if ( this.deltaAngle === undefined ) {
+	var deltaAngle = this.aEndAngle - this.aStartAngle;
+	var samePoints = Math.abs( deltaAngle ) < Number.EPSILON;
 
-		var deltaAngle = this.aEndAngle - this.aStartAngle;
-		var samePoints = Math.abs( deltaAngle ) < Number.EPSILON;
+	// ensures that deltaAngle is 0 .. 2 PI
+	while ( deltaAngle < 0 ) deltaAngle += twoPi;
+	while ( deltaAngle > twoPi ) deltaAngle -= twoPi;
 
-		while ( deltaAngle < 0 ) deltaAngle += twoPi;
-		while ( deltaAngle > twoPi ) deltaAngle -= twoPi;
+	if ( deltaAngle < Number.EPSILON ) {
 
-		if ( deltaAngle < Number.EPSILON ) {
+		if ( samePoints ) {
 
-			if ( samePoints ) {
+			deltaAngle = 0;
 
-				deltaAngle = 0;
+		} else {
 
-			} else {
-
-				deltaAngle = twoPi;
-
-			}
+			deltaAngle = twoPi;
 
 		}
-
-		if ( this.aClockwise === true && deltaAngle != twoPi && !samePoints ) {
-
-			deltaAngle = deltaAngle - twoPi;
-
-		}
-
-		this.deltaAngle = deltaAngle;
 
 	}
-	
-	var angle = this.aStartAngle + t * this.deltaAngle;
+
+	if ( this.aClockwise === true && deltaAngle != twoPi && ! samePoints ) {
+
+		deltaAngle = deltaAngle - twoPi;
+
+	}
+
+	var angle = this.aStartAngle + t * deltaAngle;
 	var x = this.aX + this.xRadius * Math.cos( angle );
 	var y = this.aY + this.yRadius * Math.sin( angle );
 
@@ -67,11 +61,12 @@ THREE.EllipseCurve.prototype.getPoint = function ( t ) {
 		var cos = Math.cos( this.aRotation );
 		var sin = Math.sin( this.aRotation );
 
-		var tx = x, ty = y;
+		var tx = x - this.aX;
+		var ty = y - this.aY;
 
 		// Rotate the point about the center of the ellipse.
-		x = ( tx - this.aX ) * cos - ( ty - this.aY ) * sin + this.aX;
-		y = ( tx - this.aX ) * sin + ( ty - this.aY ) * cos + this.aY;
+		x = tx * cos - ty * sin + this.aX;
+		y = tx * sin + ty * cos + this.aY;
 
 	}
 

--- a/src/extras/curves/LineCurve.js
+++ b/src/extras/curves/LineCurve.js
@@ -14,6 +14,12 @@ THREE.LineCurve.prototype.constructor = THREE.LineCurve;
 
 THREE.LineCurve.prototype.getPoint = function ( t ) {
 
+	if ( t === 1 ) {
+
+		return this.v2.clone();
+
+	}
+
 	var point = this.v2.clone().sub( this.v1 );
 	point.multiplyScalar( t ).add( this.v1 );
 

--- a/src/extras/curves/LineCurve3.js
+++ b/src/extras/curves/LineCurve3.js
@@ -13,6 +13,12 @@ THREE.LineCurve3 = THREE.Curve.create(
 
 	function ( t ) {
 
+		if ( t === 1 ) {
+
+			return this.v2.clone();
+
+		}
+
 		var vector = new THREE.Vector3();
 
 		vector.subVectors( this.v2, this.v1 ); // diff


### PR DESCRIPTION
Changes to `Path`
- got rid of `.actions` (yay)
- `getPoints()` moved to `CurvePath`
- `toShapes()` moved to new class `ShapePath`

Includes @rfm1201's commit in #8952 and related to #8897, and fixes the weird arc API in https://twitter.com/mrdoob/status/669400362835681280 / http://bl.ocks.org/mbostock/8bee9cf362d56d9cb19f/507166861adc3d52038ba43c934e6073937eb13c

TODO / some things for consideration before merging
- [ ] update docs and migration
- [ ] does API make more sense now?
- [ ] move point deduplication to ShapeUtils as suggested by rfm1201
- [ ] code format
