### PR TITLE
Fix THREE.SkinnedMesh.clone() bug

### DIFF
--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -172,7 +172,7 @@ THREE.SkinnedMesh.prototype = Object.assign( Object.create( THREE.Mesh.prototype
 
 	clone: function() {
 
-		return new this.constructor( this.geometry, this.material, this.useVertexTexture ).copy( this );
+		return new this.constructor( this.geometry, this.material, this.skeleton.useVertexTexture ).copy( this );
 
 	}
 


### PR DESCRIPTION
I think `THREE.SkinnedMesh` doesn't have `useVertexTexture` property but `THREE.Skeleton` does.
