### PR TITLE
Faster projectOnVector function

### DIFF
--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -596,21 +596,15 @@ THREE.Vector3.prototype = {
 
 	projectOnVector: function () {
 
-		var v1, dot;
+		var length = vector.length();
+	
+		var scalar = vector.dot(this) / ( length * length );
+	
+		this.copy( vector );
+	
+		return this.multiplyScalar( scalar );
 
-		return function projectOnVector( vector ) {
-
-			if ( v1 === undefined ) v1 = new THREE.Vector3();
-
-			v1.copy( vector ).normalize();
-
-			dot = this.dot( v1 );
-
-			return this.copy( v1 ).multiplyScalar( dot );
-
-		};
-
-	}(),
+	},
 
 	projectOnPlane: function () {
 


### PR DESCRIPTION
This implementation of projectOnVector avoids allocating an intermediate Vector3, avoids having a closure and reduces the number of function calls from 5 to 4.

I have tested it with these 6 test cases (using QUnit):

```
test('THREE.Vector3.prototype.projectOnVector2( vector ) should project vector \'this\' onto argument \'vector\', without allocating new memory', function( a ) {
    var x1y0z0 = new THREE.Vector3(1, 0, 0);
    var v1 = new THREE.Vector3(1, 0, 0);
    a.vector3(v1.projectOnVector2 ( new THREE.Vector3(1, 0, 0) ), x1y0z0);
    var v2 = new THREE.Vector3(-1, 0, 0);
    a.vector3(v2.projectOnVector2 ( new THREE.Vector3(1, 0, 0)), v2);
    var v3 = new THREE.Vector3(0, 1, 0);
    a.vector3(v3.projectOnVector2 ( new THREE.Vector3(1, 0, 0)), new THREE.Vector3( 0, 0, 0 ));
    var v4 = new THREE.Vector3(1, 1, 0);
    a.vector3(v4.projectOnVector2 ( new THREE.Vector3(1, 0, 0), true), x1y0z0);
    var v5 = new THREE.Vector3(-1, 1, 0);
    a.vector3(v5.projectOnVector2 ( new THREE.Vector3(1, 0, 0)), v2);
    var v6 = new THREE.Vector3(-1, -1, 0);
    a.vector3(v6.projectOnVector2 ( new THREE.Vector3(1, 0, 0)), v2);
} );
```
