### PR TITLE
Add Object3D rotate documentation

### DIFF
--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -175,6 +175,30 @@
 		Translates object along z axis by distance.
 		</div>
 
+		<h3>[method:null rotateX]( [page:Float rad] )</h3>
+		<div>
+		rad - the angle to rotate in radians.<br />
+		</div>
+		<div>
+		Rotates the object around x axis in local space.
+		</div>
+
+		<h3>[method:null rotateY]( [page:Float rad] )</h3>
+		<div>
+		rad - the angle to rotate in radians.<br />
+		</div>
+		<div>
+		Rotates the object around y axis in local space.
+		</div>
+
+		<h3>[method:null rotateZ]( [page:Float rad] )</h3>
+		<div>
+		rad - the angle to rotate in radians.<br />
+		</div>
+		<div>
+		Rotates the object around z axis in local space.
+		</div>
+
 		<h3>[method:Vector3 localToWorld]( [page:Vector3 vector] )</h3>
 		<div>
 		vector - A local vector.<br />


### PR DESCRIPTION
rotateX, Y and Z was removed in r58 (https://github.com/mrdoob/three.js/releases/tag/r58)
and readded in r72 (https://github.com/mrdoob/three.js/releases/tag/r72).

The docu doesn't tell a story about that, so it's time to add this methods to docu again.
