### PR TITLE
Update ImageLoader.js

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -35,8 +35,12 @@ THREE.ImageLoader.prototype = {
 				}, 0 );
 
 			} else {
-
-				scope.manager.itemEnd( url );
+				
+				setTimeout( function () {
+					
+					scope.manager.itemEnd( url );
+				
+				}, 0 );
 
 			}
 

--- a/src/loaders/XHRLoader.js
+++ b/src/loaders/XHRLoader.js
@@ -22,15 +22,15 @@ THREE.XHRLoader.prototype = {
 
 		if ( cached !== undefined ) {
 
-			if ( onLoad ) {
-
-				setTimeout( function () {
-
-					onLoad( cached );
-
-				}, 0 );
-
-			}
+			scope.manager.itemStart( url );
+			
+			setTimeout( function () {
+				
+				if ( onLoad ) onLoad( cached );
+				
+				scope.manager.itemEnd( url );
+				
+			}, 0 );
 
 			return cached;
 


### PR DESCRIPTION
call itemEnd asynchronously. otherwise it will result in error in onload call that rely on the objects initialized following like ObjectLoader.parse.
