### PR TITLE
=

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -218,6 +218,8 @@ Menubar.File = function ( editor ) {
 		output.metadata.type = 'App';
 		delete output.history;
 
+		var vr = output.project.vr;
+
 		output = JSON.stringify( output, null, '\t' );
 		output = output.replace( /[\n\t]+([\d\.e\-\[\]]+)/g, '$1' );
 
@@ -234,6 +236,17 @@ Menubar.File = function ( editor ) {
 		var loader = new THREE.XHRLoader( manager );
 		loader.load( 'js/libs/app/index.html', function ( content ) {
 
+			var includes = [];
+
+			if ( vr ) {
+
+				includes.push( '<script src="js/VRControls.js"></script>' );
+				includes.push( '<script src="js/VREffect.js"></script>' );
+
+			}
+
+			content = content.replace( '<!-- includes -->', includes.join( '\n\t\t' ) );
+
 			zip.file( 'index.html', content );
 
 		} );
@@ -248,17 +261,21 @@ Menubar.File = function ( editor ) {
 
 		} );
 
-		loader.load( '../examples/js/controls/VRControls.js', function ( content ) {
+		if ( vr ) {
 
-			zip.file( 'js/VRControls.js', content );
+			loader.load( '../examples/js/controls/VRControls.js', function ( content ) {
 
-		} );
+				zip.file( 'js/VRControls.js', content );
 
-		loader.load( '../examples/js/effects/VREffect.js', function ( content ) {
+			} );
 
-			zip.file( 'js/VREffect.js', content );
+			loader.load( '../examples/js/effects/VREffect.js', function ( content ) {
 
-		} );
+				zip.file( 'js/VREffect.js', content );
+
+			} );
+
+		}
 
 	} );
 	options.add( option );

--- a/editor/js/Storage.js
+++ b/editor/js/Storage.js
@@ -80,6 +80,8 @@ var Storage = function () {
 
 		clear: function () {
 
+			if ( database === undefined ) return;
+
 			var transaction = database.transaction( [ 'states' ], 'readwrite' );
 			var objectStore = transaction.objectStore( 'states' );
 			var request = objectStore.clear();

--- a/editor/js/libs/app/index.html
+++ b/editor/js/libs/app/index.html
@@ -53,7 +53,7 @@
 					button.addEventListener( 'click', function ( event ) {
 
 						var url = location.href.split( '/' ).slice( 0, - 1 ).join( '/' );
-						window.open( 'http://threejs.org/editor/#file=https://crossorigin.me/' + url + '/app.json' );
+						window.open( 'http://threejs.org/editor/#file=' + url + '/app.json' );
 
 					}, false );
 					document.body.appendChild( button );

--- a/editor/js/libs/app/index.html
+++ b/editor/js/libs/app/index.html
@@ -30,8 +30,7 @@
 	<body ontouchstart="">
 		<script src="js/three.min.js"></script>
 		<script src="js/app.js"></script>
-		<script src="js/VRControls.js"></script>
-		<script src="js/VREffect.js"></script>
+		<!-- includes -->
 		<script>
 
 			var loader = new THREE.XHRLoader();

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -98,7 +98,7 @@ THREE.CSS3DRenderer = function () {
 
 	var epsilon = function ( value ) {
 
-		return Math.abs( value ) < Number.EPSILON ? 0 : value;
+		return Math.abs( value ) <= Number.EPSILON ? 0 : value;
 
 	};
 


### PR DESCRIPTION
Apparently in Mobile Safari setting style.transform will fail if EPSILON is part of the transform, which means elements don't render. Filtering out EPSILON fixes that.
