### PR TITLE
Raycaster: correct ray origin in SetFromCamera()

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -84,7 +84,7 @@
 
 			} else if ( camera instanceof THREE.OrthographicCamera ) {
 
-				this.ray.origin.set( coords.x, coords.y, - 1 ).unproject( camera );
+				this.ray.origin.set( coords.x, coords.y, ( camera.near + camera.far ) / ( camera.near - camera.far ) ).unproject( camera ); // set origin in plane of camera
 				this.ray.direction.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld );
 
 			} else {


### PR DESCRIPTION
When raycasting using an orthographic camera, the ray origin was previously placed on the near plane of the camera, causing the returned distance to the intersection point to be incorrect.

Now, the ray origin is placed in the plane of the camera itself.

Fixes #9009
