### PR TITLE
Updating PerspectiveCamera documentaiton to point to correct demo link

### DIFF
--- a/docs/api/cameras/PerspectiveCamera.html
+++ b/docs/api/cameras/PerspectiveCamera.html
@@ -17,7 +17,7 @@
 
 		<h2>Example</h2>
 
-		<div>[example:canvas_effects_stereo effects / stereo ]</div>
+		<div>[example:webgl_effects_stereo effects / stereo ]</div>
 		<div>[example:canvas_geometry_birds geometry / birds ]</div>
 		<div>[example:canvas_geometry_cube geometry / cube ]</div>
 		<div>[example:webgl_animation_skinning_blending animation / skinning / blending ]</div>


### PR DESCRIPTION
canvas_effects_stereo doesn't seem to exist anymore and the only canvas effect I can find links to the webgl version
