### PR TITLE
PolyhedronGeometry: pass in material indices, rather than hardwire them

### DIFF
--- a/src/extras/geometries/DodecahedronGeometry.js
+++ b/src/extras/geometries/DodecahedronGeometry.js
@@ -43,7 +43,9 @@ THREE.DodecahedronGeometry = function ( radius, detail ) {
 		 1, 12, 14,      1, 14,  5,      1,  5,  9
 	];
 
-	THREE.PolyhedronGeometry.call( this, vertices, indices, radius, detail );
+	var materialIndices = [ 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10, 11, 11, 11 ];
+
+	THREE.PolyhedronGeometry.call( this, vertices, indices, radius, detail, materialIndices );
 
 	this.type = 'DodecahedronGeometry';
 

--- a/src/extras/geometries/IcosahedronGeometry.js
+++ b/src/extras/geometries/IcosahedronGeometry.js
@@ -19,7 +19,9 @@ THREE.IcosahedronGeometry = function ( radius, detail ) {
 		 4,  9,  5,    2,  4, 11,    6,  2, 10,    8,  6,  7,    9,  8,  1
 	];
 
-	THREE.PolyhedronGeometry.call( this, vertices, indices, radius, detail );
+	var materialIndices = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ];
+
+	THREE.PolyhedronGeometry.call( this, vertices, indices, radius, detail, materialIndices );
 
 	this.type = 'IcosahedronGeometry';
 

--- a/src/extras/geometries/OctahedronGeometry.js
+++ b/src/extras/geometries/OctahedronGeometry.js
@@ -12,7 +12,9 @@ THREE.OctahedronGeometry = function ( radius, detail ) {
 		0, 2, 4,    0, 4, 3,    0, 3, 5,    0, 5, 2,    1, 2, 5,    1, 5, 3,    1, 3, 4,    1, 4, 2
 	];
 
-	THREE.PolyhedronGeometry.call( this, vertices, indices, radius, detail );
+	var materialIndices = [ 0, 1, 2, 3, 4, 5, 6, 7 ];
+
+	THREE.PolyhedronGeometry.call( this, vertices, indices, radius, detail, materialIndices );
 
 	this.type = 'OctahedronGeometry';
 

--- a/src/extras/geometries/PolyhedronGeometry.js
+++ b/src/extras/geometries/PolyhedronGeometry.js
@@ -4,7 +4,7 @@
  * @author WestLangley / http://github.com/WestLangley
 */
 
-THREE.PolyhedronGeometry = function ( vertices, indices, radius, detail ) {
+THREE.PolyhedronGeometry = function ( vertices, indices, radius, detail, materialIndices ) {
 
 	THREE.Geometry.call( this );
 
@@ -14,7 +14,8 @@ THREE.PolyhedronGeometry = function ( vertices, indices, radius, detail ) {
 		vertices: vertices,
 		indices: indices,
 		radius: radius,
-		detail: detail
+		detail: detail,
+		materialIndices: materialIndices
 	};
 
 	radius = radius || 1;
@@ -38,7 +39,9 @@ THREE.PolyhedronGeometry = function ( vertices, indices, radius, detail ) {
 		var v2 = p[ indices[ i + 1 ] ];
 		var v3 = p[ indices[ i + 2 ] ];
 
-		faces[ j ] = new THREE.Face3( v1.index, v2.index, v3.index, [ v1.clone(), v2.clone(), v3.clone() ], undefined, j );
+		var materialIndex = ( materialIndices !== undefined && materialIndices.length > j ) ? materialIndices[ j ] : 0;
+
+		faces[ j ] = new THREE.Face3( v1.index, v2.index, v3.index, [ v1.clone(), v2.clone(), v3.clone() ], undefined, materialIndex );
 
 	}
 

--- a/src/extras/geometries/TetrahedronGeometry.js
+++ b/src/extras/geometries/TetrahedronGeometry.js
@@ -12,7 +12,9 @@ THREE.TetrahedronGeometry = function ( radius, detail ) {
 		 2,  1,  0,    0,  3,  2,    1,  3,  0,    2,  3,  1
 	];
 
-	THREE.PolyhedronGeometry.call( this, vertices, indices, radius, detail );
+	var materialIndices = [ 0, 1, 2, 3 ];
+
+	THREE.PolyhedronGeometry.call( this, vertices, indices, radius, detail, materialIndices );
 
 	this.type = 'TetrahedronGeometry';
 


### PR DESCRIPTION
Fixes an issue discussed in #8027.

Now, rather than a separate material for each triangular face in `DodecahedronGeometry`, all triangles that are coplanar use the same material.

@mrdoob I am ambivalent to this PR, or simply removing material index from `PolyhedronGeometry` all-together.

EDIT: fiddle: http://jsfiddle.net/mg6m7xm6/

/ping @rfm1201 
