### PR TITLE
Minor fixes to GPUComputationRenderer and its demos

### DIFF
--- a/examples/webgl_gpgpu_birds.html
+++ b/examples/webgl_gpgpu_birds.html
@@ -108,10 +108,10 @@
 			const float SPEED_LIMIT = 9.0;
 
 			float rand(vec2 co){
-			    return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+				return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
 			}
 
-			void main()	{
+			void main() {
 
 				zoneRadius = seperationDistance + alignmentDistance + cohesionDistance;
 				separationThresh = seperationDistance / zoneRadius;

--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -51,7 +51,7 @@
 
 			#define delta ( 1.0 / 60.0 )
 
-			void main()	{
+			void main() {
 
 				vec2 uv = gl_FragCoord.xy / resolution.xy;
 
@@ -63,7 +63,7 @@
 				float mass = tmpVel.w;
 
 				if ( mass == 0.0 ) {
-				    vel = vec3( 0.0 );
+					vel = vec3( 0.0 );
 				}
 
 				// Dynamics
@@ -109,80 +109,80 @@
 				if ( mass > 0.0 ) {
 				    
 
-				float radius = radiusFromMass( mass );
+					float radius = radiusFromMass( mass );
 
-				vec3 acceleration = vec3( 0.0 );
+					vec3 acceleration = vec3( 0.0 );
 
-				// Gravity interaction
-				for ( float y = 0.0; y < height; y++ ) {
+					// Gravity interaction
+					for ( float y = 0.0; y < height; y++ ) {
 
-					for ( float x = 0.0; x < width; x++ ) {
+						for ( float x = 0.0; x < width; x++ ) {
 
-						vec2 secondParticleCoords = vec2( x + 0.5, y + 0.5 ) / resolution.xy;
-						vec3 pos2 = texture2D( texturePosition, secondParticleCoords ).xyz;
-						vec4 velTemp2 = texture2D( textureVelocity, secondParticleCoords );
-						vec3 vel2 = velTemp2.xyz;
-						float mass2 = velTemp2.w;
+							vec2 secondParticleCoords = vec2( x + 0.5, y + 0.5 ) / resolution.xy;
+							vec3 pos2 = texture2D( texturePosition, secondParticleCoords ).xyz;
+							vec4 velTemp2 = texture2D( textureVelocity, secondParticleCoords );
+							vec3 vel2 = velTemp2.xyz;
+							float mass2 = velTemp2.w;
 
-						float idParticle2 = secondParticleCoords.y * resolution.x + secondParticleCoords.x;
+							float idParticle2 = secondParticleCoords.y * resolution.x + secondParticleCoords.x;
 
-						if ( idParticle == idParticle2 ) {
-							continue;
-						}
+							if ( idParticle == idParticle2 ) {
+								continue;
+							}
 
-						if ( mass2 == 0.0 ) {
-							continue;
-						}
+							if ( mass2 == 0.0 ) {
+								continue;
+							}
 
-						vec3 dPos = pos2 - pos;
-						float distance = length( dPos );
-						float radius2 = radiusFromMass( mass2 );
+							vec3 dPos = pos2 - pos;
+							float distance = length( dPos );
+							float radius2 = radiusFromMass( mass2 );
 
-						if ( distance == 0.0 ) {
-							continue;
-						}
+							if ( distance == 0.0 ) {
+								continue;
+							}
 
-						// Checks collision
+							// Checks collision
 
-						if ( distance < radius + radius2 ) {
-						    
-							if ( idParticle < idParticle2 ) {
+							if ( distance < radius + radius2 ) {
 
-								// This particle is aggregated by the other
-								vel = ( vel * mass + vel2 * mass2 ) / ( mass + mass2 );
-								mass += mass2;
-								radius = radiusFromMass( mass );
+								if ( idParticle < idParticle2 ) {
+
+									// This particle is aggregated by the other
+									vel = ( vel * mass + vel2 * mass2 ) / ( mass + mass2 );
+									mass += mass2;
+									radius = radiusFromMass( mass );
+
+								}
+								else {
+
+									// This particle dies
+									mass = 0.0;
+									radius = 0.0;
+									vel = vec3( 0.0 );
+									break;
+
+								}
 
 							}
-							else {
 
-								// This particle dies
-								mass = 0.0;
-								radius = 0.0;
-								vel = vec3( 0.0 );
-								break;
+							float distanceSq = distance * distance;
 
-							}
-		    
+							float gravityField = gravityConstant * mass2 / distanceSq;
+
+							gravityField = min( gravityField, 1000.0 );
+
+							acceleration += gravityField * normalize( dPos );
+
 						}
 
-						float distanceSq = distance * distance;
-
-						float gravityField = gravityConstant * mass2 / distanceSq;
-
-						gravityField = min( gravityField, 1000.0 );
-
-						acceleration += gravityField * normalize( dPos );
-
+						if ( mass == 0.0 ) {
+							break;
+						}
 					}
 
-					if ( mass == 0.0 ) {
-					    break;
-					}
-				}
-
-				// Dynamics
-				vel += delta * acceleration;
+					// Dynamics
+					vel += delta * acceleration;
 
 				}
 
@@ -253,7 +253,7 @@
 
 				float f = length( gl_PointCoord - vec2( 0.5, 0.5 ) );
 				if ( f > 0.5 ) {
-				    discard;
+					discard;
 				}
 				gl_FragColor = vColor;
 

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -341,8 +341,8 @@
 				var material = new THREE.ShaderMaterial( {
 					uniforms: THREE.UniformsUtils.merge( [
 						THREE.ShaderLib[ 'phong' ].uniforms,
-					    {
-							heightmap: { value: null },
+						{
+							heightmap: { value: null }
 						}
 					] ),
 					vertexShader: document.getElementById( 'waterVertexShader' ).textContent,
@@ -437,7 +437,7 @@
 						var x = i * 128 / WIDTH;
 						var y = j * 128 / WIDTH;
 
-					        pixels[ p + 0 ] = noise( x, y, 0 );
+					        pixels[ p + 0 ] = noise( x, y, 123.4 );
 						pixels[ p + 1 ] = 0;
 						pixels[ p + 2 ] = 0;
 						pixels[ p + 3 ] = 1;


### PR DESCRIPTION
Some minor fixes, mostly clean up:
- Added texture minifier and magnifier filters to variables.
- Added missing null dependencies check in compute()
- Two simple loop optimizations (store count in a variable)
- Water demo: Improved noise appearance by raising noise z parameter.
- Code formatting (indentation) and clean up.
