### PR TITLE
added support for THREE.Camera

### DIFF
--- a/src/extras/helpers/CameraHelper.js
+++ b/src/extras/helpers/CameraHelper.js
@@ -94,7 +94,7 @@ THREE.CameraHelper = function ( camera ) {
 	THREE.LineSegments.call( this, geometry, material );
 
 	this.camera = camera;
-	this.camera.updateProjectionMatrix();
+	if( this.camera.updateProjectionMatrix ) this.camera.updateProjectionMatrix();
 
 	this.matrix = camera.matrixWorld;
 	this.matrixAutoUpdate = false;


### PR DESCRIPTION
Currently THREE.CameraHelper() implies the camera has a `.updateProjectMatrix()` which isnt true for [three.camera](https://github.com/mrdoob/three.js/blob/master/src/cameras/Camera.js).

This small changes add `THREE.Camera` support to the helper

i hit this issue when doing AR, in this case, the projection matrix is dictated by the lens of your physical camera.

What do you think ?
