### PR TITLE
Fixed bug in isEmpty method of THREE.Box3

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -172,7 +172,7 @@ THREE.Box3.prototype = {
 
 		// this is a more robust check for empty than ( volume <= 0 ) because volume can get positive with two negative axes
 
-		return ( this.max.x < this.min.x ) || ( this.max.y < this.min.y ) || ( this.max.z < this.min.z );
+		return ( this.max.x <= this.min.x ) || ( this.max.y <= this.min.y ) || ( this.max.z <= this.min.z );
 
 	},
 


### PR DESCRIPTION
Updated `isEmpty` method to solve [issue 9146](https://github.com/mrdoob/three.js/issues/9146)
