### PR TITLE
Render sort order should consider shared shaders to minimize switching

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1042,6 +1042,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 			return a.object.renderOrder - b.object.renderOrder;
 
+		} else if ( a.material.program && b.material.program && a.material.program !== b.material.program ) {
+
+			return a.material.program.id - b.material.program.id;
+
 		} else if ( a.material.id !== b.material.id ) {
 
 			return a.material.id - b.material.id;


### PR DESCRIPTION
The `painterSortStable` function sorts objects to be rendered by material to minimize switching between materials. However, it doesn't consider that now different materials can share a common shader program. The result is that the renderer may be switching out shader programs more often than necessary.

I put together a rough benchmark to test this patch. Here is one using the existing code:
http://output.jsbin.com/tuneso

And here is one using the patched code:
http://output.jsbin.com/nogovi

In Chrome on my Late 2013 MacBook Pro, with 10,000 objects, I'm seeing ~4 fps unpatched and ~13 fps patched. On my new PC w/ GeForce 980, I get ~26 fps vs ~38 fps. Please adjust the object count on your system accordingly.

This is related to #8849.
