### PR TITLE
CurvePath.getPoints() for Arcs resolution should be doubled

### DIFF
--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -164,7 +164,9 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 
 			var curve = curves[ i ];
 			var resolution = curve instanceof THREE.EllipseCurve ? divisions * 2
-				: curve instanceof THREE.LineCurve ? 1 : divisions;
+				: curve instanceof THREE.LineCurve ? 1
+				: curve instanceof THREE.SplineCurve ? divisions * curves.points.length
+				: divisions;
 
 			var pts = curve.getPoints( resolution );
 

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -163,7 +163,10 @@ THREE.CurvePath.prototype = Object.assign( Object.create( THREE.Curve.prototype 
 		for ( var i = 0, curves = this.curves; i < curves.length; i ++ ) {
 
 			var curve = curves[ i ];
-			var pts = curve.getPoints( curve instanceof THREE.LineCurve ? 1 : divisions );
+			var resolution = curve instanceof THREE.EllipseCurve ? divisions * 2
+				: curve instanceof THREE.LineCurve ? 1 : divisions;
+
+			var pts = curve.getPoints( resolution );
 
 			for ( var j = 0; j < pts.length; j++ ) {
 


### PR DESCRIPTION
- like previous behaviour
- see #9079
