### PR TITLE
Vector Equals uses Number Epsilon Tolerance

### DIFF
--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -416,7 +416,8 @@ THREE.Vector2.prototype = {
 
 	equals: function ( v ) {
 
-		return ( ( v.x === this.x ) && ( v.y === this.y ) );
+		return Math.abs( v.x - this.x ) < Number.EPSILON &&
+			Math.abs( v.y - this.y ) < Number.EPSILON;
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -597,9 +597,9 @@ THREE.Vector3.prototype = {
 	projectOnVector: function ( vector ) {
 
 		var scalar = vector.dot( this ) / vector.lengthSq();
-	
+
 		return this.copy( vector ).multiplyScalar( scalar );
-	
+
 	},
 
 	projectOnPlane: function () {
@@ -708,7 +708,9 @@ THREE.Vector3.prototype = {
 
 	equals: function ( v ) {
 
-		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
+		return Math.abs( v.x - this.x ) < Number.EPSILON &&
+			Math.abs( v.y - this.y ) < Number.EPSILON &&
+			Math.abs( v.z - this.z ) < Number.EPSILON;
 
 	},
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -576,7 +576,10 @@ THREE.Vector4.prototype = {
 
 	equals: function ( v ) {
 
-		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) && ( v.w === this.w ) );
+		return Math.abs( v.x - this.x ) < Number.EPSILON &&
+			Math.abs( v.y - this.y ) < Number.EPSILON &&
+			Math.abs( v.z - this.z ) < Number.EPSILON &&
+			Math.abs( v.w - this.w ) < Number.EPSILON;
 
 	},
 


### PR DESCRIPTION
- useful for floating point inaccuracies
- API should be backward compatible
- see #7346

@WestLangley 
