### PR TITLE
Save memory by loading JPEGs as RGB by default

### DIFF
--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -19,6 +19,12 @@ Object.assign( THREE.TextureLoader.prototype, {
 		loader.setPath( this.path );
 		loader.load( url, function ( image ) {
 
+			// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
+			var isJPEG = url.search(/\.(jpg|jpeg)$/) > 0;
+			if (!isJPEG) {
+				isJPEG = url.search(/^data\:image\/jpeg/) == 0;
+			}
+			texture.format = isJPEG ? THREE.RGBFormat : THREE.RGBAFormat;
 			texture.image = image;
 			texture.needsUpdate = true;
 


### PR DESCRIPTION
JPEGs can't have an alpha channel, so it's optimal to load them as RGB
textures instead of RGBA. This saves 25% of texture memory on
OpenGL-based WebGL implementations. The optimization is especially
significant on memory-constrained mobile platforms.
