### PR TITLE
added flatShadedGeometry

### DIFF
--- a/examples/js/FlatShadedGeometry.js
+++ b/examples/js/FlatShadedGeometry.js
@@ -1,0 +1,74 @@
+/**
+ * @author astrak / astrak.github.io
+ */
+ /*
+ This is the very basics to allow a flat shaded look on THREE.MeshLambertMaterial. The function loops through the faces of an instance of THREE.Geometry and duplicates every vertices, including identical vertices on different faces.
+ */
+
+THREE.FlatShadedGeometry = function ( geometry ) {
+
+	var flatShadedGeometry = geometry.clone();
+
+	var vertices = [], 
+		faces = [],
+		morphTargets = [];
+
+	if ( geometry.morphTargets ) {
+
+		for ( var i = 0 ; i < geometry.morphTargets.length ; i++ ) {
+
+			morphTargets[ i ] = { name : geometry.morphTargets.name, vertices : [] };
+
+		}
+
+	}
+
+	for ( var i = 0 ; i < geometry.faces.length ; i++ ) {
+
+		var f = geometry.faces[ i ];
+
+		vertices[ i * 3 ] = geometry.vertices[ f.a ].clone();
+		vertices[ i * 3 + 1 ] = geometry.vertices[ f.b ].clone();
+		vertices[ i * 3 + 2 ] = geometry.vertices[ f.c ].clone();
+
+		faces.push( f.clone() );
+
+		faces[ i ].a = i * 3;
+		faces[ i ].b = i * 3 + 1;
+		faces[ i ].c = i * 3 + 2;
+
+		faces[ i ].vertexNormals[ 0 ] = f.normal.clone();
+		faces[ i ].vertexNormals[ 1 ] = f.normal.clone();
+		faces[ i ].vertexNormals[ 2 ] = f.normal.clone();
+
+		if ( geometry.morphTargets ) {
+
+			for ( var j = 0 ; j < geometry.morphTargets.length ; j++ ) {
+
+				morphTargets[ j ].vertices[ i * 3 ] = geometry.morphTargets[ j ].vertices[ f.a ].clone();
+				morphTargets[ j ].vertices[ i * 3 + 1 ] = geometry.morphTargets[ j ].vertices[ f.b ].clone();
+				morphTargets[ j ].vertices[ i * 3 + 2 ] = geometry.morphTargets[ j ].vertices[ f.c ].clone();
+
+			}
+
+		}
+
+	}
+
+	flatShadedGeometry.vertices = vertices;
+
+	flatShadedGeometry.faces = faces;
+
+	if ( geometry.morphTargets ) {
+		
+		flatShadedGeometry.morphTargets = morphTargets;
+
+		flatShadedGeometry.computeVertexNormals();
+
+		flatShadedGeometry.computeMorphNormals();
+
+	}
+
+	return flatShadedGeometry;
+
+};


### PR DESCRIPTION
2.5th contribution here, still learning github, I hope the PR is fine !

This PR finally re-creates the flatshading feature one could need with Lambert material using `new THREE.FlatShadedGeometry( geometry )` as suggested by @mrdoob in #7130. There were other propositions : 
- implement it the same way it is in Phong material, and compute the flat normals in the fragment shader. That was impossible for me as I need 60fps on mobile.
- change the normal attribute value depending on flat/smooth shading.... I am not sure to understand, since to me vertices along edges still have to be duplicated to get flat shading
- create `MeshFlatMaterial` that seemed interesting but was not cited in the long discussion that followed.

After 9 months I thought I had to finally give birth to my last year's project and chosed the first idea :) It works as much as can be seen [here](https://astrak.github.io/citychanges), it is used for all the basements and the ground.

It takes a `THREE.Geometry` instance in argument and basically does the following :
- duplicates it
- loops through the faces and duplicates the vertices, same for morphTargets if present
- then compute the new face normals, same for morphNormals.

It does not check if faces with same normals share vertices so it increases their number, possibly more than needed, depending on the geometry. But that does not seem really important to me in most cases. It works and is totally necessary in this kind of scenes where Phong material would slower everything, and lighting is still needed.

The file is placed in `examples/js`.
