### PR TITLE
build.js ux improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "test"
   },
   "scripts": {
-    "build": "cd ./utils/build && node build.js --include common --include extras",
+    "build": "node utils/build/build.js --include common --include extras",
+    "build-min": "node utils/build/build.js --include common --include extras --minify",
     "dev": "chokidar \"./src/**/*.*\" \"./utils/build/includes/*.*\" --initial -c \"npm run build\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -45,5 +46,5 @@
     "chokidar-cli": "1.2.0",
     "jscs": "^1.13.1",
     "uglify-js": "^2.6.0"
-    }
+  }
 }


### PR DESCRIPTION
Addresses #8831 

Allows easier and more flexible invocation of the build script.  

Changes made
- Script can be run from any directory, uses script dir to determine
  relative paths to other needed files
- By default, determine minified file name from `output` file name (e.g.
  three.js -> three.min.js). minified file name can be explicitly set
  directly via a new option `minifiedoutput`
- If `minify` is true, still build un-minified file.
- Ensure sourcemap url refers to actual minified file name, (before,
  three.min.js was hard-coded)
- Some variable name cleanup to have clearer var names
