### PR TITLE
Use VRDisplays's requestAnimationFrame if VR headset connected

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -233,6 +233,20 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	};
 
+	this.requestAnimationFrame = function ( f ) {
+
+		if ( ! isDeprecatedAPI && vrHMD !== undefined ) {
+
+			vrHMD.requestAnimationFrame( f );
+
+		} else {
+
+			window.requestAnimationFrame( f );
+
+		}
+
+	};
+
 	// render
 
 	var cameraL = new THREE.PerspectiveCamera();

--- a/examples/webvr_cubes.html
+++ b/examples/webvr_cubes.html
@@ -170,7 +170,7 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
+				effect.requestAnimationFrame( animate );
 				render();
 
 			}

--- a/examples/webvr_panorama.html
+++ b/examples/webvr_panorama.html
@@ -145,7 +145,7 @@
 
 			effect.render( scene, camera );
 
-			requestAnimationFrame( animate );
+			effect.requestAnimationFrame( animate );
 
 		}
 

--- a/examples/webvr_rollercoaster.html
+++ b/examples/webvr_rollercoaster.html
@@ -206,7 +206,7 @@
 
 			function animate( time ) {
 
-				requestAnimationFrame( animate );
+				effect.requestAnimationFrame( animate );
 
 				for ( var i = 0; i < funfairs.length; i ++ ) {
 
@@ -239,7 +239,7 @@
 
 			};
 
-			requestAnimationFrame( animate );
+			effect.requestAnimationFrame( animate );
 
 		</script>
 

--- a/examples/webvr_shadow.html
+++ b/examples/webvr_shadow.html
@@ -111,7 +111,7 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
+				effect.requestAnimationFrame( animate );
 				render();
 
 			}

--- a/examples/webvr_video.html
+++ b/examples/webvr_video.html
@@ -172,7 +172,7 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
+				effect.requestAnimationFrame( animate );
 				render();
 
 			}

--- a/examples/webvr_vive.html
+++ b/examples/webvr_vive.html
@@ -219,7 +219,7 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
+				effect.requestAnimationFrame( animate );
 				render();
 
 			}


### PR DESCRIPTION
The WebVR 1.0 spec has a HMD specific requestAnimationFrame that should be called instead when using a HMD in order to ensure running at the native display refresh rate. Note that it functions the same as window's requestAnimationFrame when not presenting. 

https://w3c.github.io/webvr/#dom-vrdisplay-requestanimationframe
