### PR TITLE
THREE.SectionHelper class to fake the cutting plane of a sliced geometry

### DIFF
--- a/src/extras/helpers/SectionHelper.js
+++ b/src/extras/helpers/SectionHelper.js
@@ -2,7 +2,7 @@
  * Will draw a mesh with backside material or color set to the passed value.
  * Can be used for faking the cutting plane of a sliced geometry.
  *
- * @author wilt
+ * @author Wilt
  * Based on THREE.EdgesHelper by WestLangley / http://github.com/WestLangley
  * @param {THREE.Mesh} object THREE.Mesh whose geometry will be used
  * @param {string|THREE.Material} hexOrMaterial line color

--- a/src/extras/helpers/SectionHelper.js
+++ b/src/extras/helpers/SectionHelper.js
@@ -1,7 +1,6 @@
 /**
  * Will draw a mesh with backside material or color set to the passed value.
- * Can be used for faking a sliced geometry.
- * A demo can be found here:
+ * Can be used for faking the cutting plane of a sliced geometry.
  *
  * @author wilt
  * Based on THREE.EdgesHelper by WestLangley / http://github.com/WestLangley

--- a/src/extras/helpers/SectionHelper.js
+++ b/src/extras/helpers/SectionHelper.js
@@ -1,0 +1,33 @@
+/**
+ * Will draw a mesh with backside material or color set to the passed value.
+ * Can be used for faking a sliced geometry.
+ * A demo can be found here:
+ *
+ * @author wilt
+ * Based on THREE.EdgesHelper by WestLangley / http://github.com/WestLangley
+ * @param {THREE.Mesh} object THREE.Mesh whose geometry will be used
+ * @param {string|THREE.Material} hexOrMaterial line color
+ */
+THREE.SectionHelper = function( object, hexOrMaterial ) {
+
+    var material;
+    if ( hexOrMaterial instanceof THREE.MeshBasicMaterial ) {
+
+        material = hexOrMaterial;
+
+    } else {
+
+        var color = ( hexOrMaterial !== undefined ) ? hexOrMaterial : 0xffffff;
+        material = new THREE.MeshBasicMaterial( { color: color, side: THREE.BackSide } );
+
+    }
+
+    THREE.Mesh.call( this, object.geometry, material );
+
+    this.matrix = object.matrixWorld;
+    this.matrixAutoUpdate = false;
+
+};
+
+THREE.SectionHelper.prototype = Object.create( THREE.Mesh.prototype );
+THREE.SectionHelper.prototype.constructor = THREE.SectionHelper;


### PR DESCRIPTION
This class is very similar to the `THREE.EdgesHelper`. This will draw a mesh with backside material or color set to the passed value. It can be used for faking the cutting plane of a sliced geometry.

A demonstration here: https://jsfiddle.net/wilt/qo869tb3/
