### PR TITLE
Fix Spelling in Vector3 Documentation

### DIFF
--- a/docs/api/math/Vector3.html
+++ b/docs/api/math/Vector3.html
@@ -394,7 +394,7 @@
 		normal -- [page:Vector3] the normal to the reflecting plane
 		</div>
 		<div>
-		Reflect incident vector off of plane orthogonal to normal. normal is assumed to have unit length.
+		Reflect incident vector off of plane orthogonal to normal. Normal is assumed to have unit length.
 		</div>
 
 		<h3>[method:Vector3 multiply]( [page:Vector3 v] ) [page:Vector3 this]</h3>
@@ -402,7 +402,7 @@
 		v -- [page:Vector3] <br />
 		</div>
 		<div>
-		Multipies this vector by vector v.
+		Multiplies this vector by vector v.
 		</div>
 
 		<h3>[method:Vector3 applyProjection]( [page:Matrix4 m] ) [page:Vector3 this]</h3>
@@ -418,7 +418,7 @@
 		euler -- [page:Euler]
 		</div>
 		<div>
-		Applies euler transform to this vector by converting the [page:Euler] obect to a [page:Quaternion] and applying.
+		Applies euler transform to this vector by converting the [page:Euler] object to a [page:Quaternion] and applying.
 		</div>
 
 		<h3>[method:Vector3 applyQuaternion]( [page:Quaternion quaternion] ) [page:Vector3 this]</h3>

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -4681,7 +4681,7 @@
         },
         "reflect": {
           "!type": "fn(normal: +THREE.Vector3) -> +THREE.Vector3",
-          "!doc": "Reflect incident vector off of plane orthogonal to normal. normal is assumed to have unit length."
+          "!doc": "Reflect incident vector off of plane orthogonal to normal. Normal is assumed to have unit length."
         },
         "fromArray": {
           "!type": "fn(array: []) -> +THREE.Vector3",
@@ -4689,7 +4689,7 @@
         },
         "multiply": {
           "!type": "fn(v: +THREE.Vector3) -> +THREE.Vector3",
-          "!doc": "Multipies this vector by vector v."
+          "!doc": "Multiplies this vector by vector v."
         },
         "applyProjection": {
           "!type": "fn(m: +THREE.Matrix4) -> +THREE.Vector3",
@@ -4701,7 +4701,7 @@
         },
         "applyEuler": {
           "!type": "fn(euler: +THREE.Euler) -> +THREE.Vector3",
-          "!doc": "Applies euler transform to this vector by converting the [page:Euler] obect to a [page:Quaternion] and applying."
+          "!doc": "Applies euler transform to this vector by converting the [page:Euler] object to a [page:Quaternion] and applying."
         },
         "applyQuaternion": {
           "!type": "fn(quaternion: +THREE.Quaternion) -> +THREE.Vector3",


### PR DESCRIPTION
Just found a few spelling errors.

Noticed that the docs were duplicated in `editor/` for what looks like a `tern` plugin, but I couldn't find a build process script anywhere. Let me know if there is one for documentation.
