### PR TITLE
BufferGeometry itemsize conflicts between docs and examples

### DIFF
--- a/docs/api/core/BufferGeometry.html
+++ b/docs/api/core/BufferGeometry.html
@@ -76,8 +76,8 @@
 		Set by [page:.fromGeometry]().
 		</div>
 
-		<h4>[page:BufferAttribute index] (itemSize: 3)</h4>
-		Allows for vertices to be re-used across multiple triangles; this is called using "indexed triangles," and works much the same as it does in [page:Geometry]: each triangle is associated with the index of three vertices. This attribute therefore stores the index of each vertex for each triangular face.
+		<h4>[page:BufferAttribute index] (itemSize: 1)</h4>
+		Allows for vertices to be re-used across multiple triangles; this is called using "indexed triangles," and works much the same as it does in [page:Geometry]: each triangle is associated with the index of three vertices. Each face is therefore defined by three consecutive vertex indices in this attribute.
 
 		If this attribute is not set, the [page:WebGLRenderer renderer] assumes that each three contiguous positions represent a single triangle.
 		</div>


### PR DESCRIPTION
In all the examples, the itemsize of Buffer Geometry is 1 (both for lines and triangles), which contradicts the docs. From this I guess (but did not confirm by reading through the code) that three consecutive numbers define a triangle or two consecutive numbers a line, depending on how the geometry is used.

Compare to the following examples:
https://github.com/mrdoob/three.js/blob/master/examples/webgl_buffergeometry_lines_indexed.html#L184
https://github.com/mrdoob/three.js/blob/master/examples/webgl_buffergeometry_uint.html#L190
