### PR TITLE
Add iOS workaround to documentation pages

### DIFF
--- a/docs/api/extras/geometries/BoxBufferGeometry.html
+++ b/docs/api/extras/geometries/BoxBufferGeometry.html
@@ -14,7 +14,23 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:BoxGeometry].</div>
 
-		<iframe src='scenes/geometry-browser.html#BoxBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#BoxBufferGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Example</h2>
 
@@ -26,7 +42,6 @@
 
 		<h2>Constructor</h2>
 
-
 		<h3>[name]([page:Float width], [page:Float height], [page:Float depth], [page:Integer widthSegments], [page:Integer heightSegments], [page:Integer depthSegments])</h3>
 		<div>
 		width — Width of the sides on the X axis.<br />
@@ -36,7 +51,6 @@
 		heightSegments — Optional. Number of segmented faces along the height of the sides. Default is 1.<br />
 		depthSegments — Optional. Number of segmented faces along the depth of the sides. Default is 1.
 		</div>
-
 
 		<h2>Properties</h2>
 

--- a/docs/api/extras/geometries/CircleBufferGeometry.html
+++ b/docs/api/extras/geometries/CircleBufferGeometry.html
@@ -14,8 +14,6 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:CircleGeometry].</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#CircleBufferGeometry"></iframe>
 
 		<script>
@@ -33,6 +31,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>
 		var geometry = new THREE.CircleBufferGeometry( 5, 32 );

--- a/docs/api/extras/geometries/CircleBufferGeometry.html
+++ b/docs/api/extras/geometries/CircleBufferGeometry.html
@@ -16,7 +16,23 @@
 
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#CircleBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#CircleBufferGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>
 		var geometry = new THREE.CircleBufferGeometry( 5, 32 );
@@ -24,7 +40,6 @@
 		var circle = new THREE.Mesh( geometry, material );
 		scene.add( circle );
 		</code>
-
 
 		<h2>Constructor</h2>
 
@@ -35,7 +50,6 @@
 		thetaStart — Start angle for first segment, default = 0 (three o'clock position).<br />
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete circle.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/CircleGeometry.html
+++ b/docs/api/extras/geometries/CircleGeometry.html
@@ -17,7 +17,23 @@
 
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#CircleGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#CircleGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>
 		var geometry = new THREE.CircleGeometry( 5, 32 );
@@ -25,7 +41,6 @@
 		var circle = new THREE.Mesh( geometry, material );
 		scene.add( circle );
 		</code>
-
 
 		<h2>Constructor</h2>
 
@@ -36,7 +51,6 @@
 		thetaStart — Start angle for first segment, default = 0 (three o'clock position).<br />
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete circle.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/CircleGeometry.html
+++ b/docs/api/extras/geometries/CircleGeometry.html
@@ -15,8 +15,6 @@
 		<div class="desc">CircleGeometry is a simple shape of Euclidean geometry.  It is contructed from a number of triangular segments that are oriented around a central point and extend as far out as a given radius.  It is built counter-clockwise from a start angle and a given central angle.  It can also be used to create regular polygons, where the number of segments determines the number of sides.
 		</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#CircleGeometry"></iframe>
 
 		<script>
@@ -34,6 +32,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>
 		var geometry = new THREE.CircleGeometry( 5, 32 );

--- a/docs/api/extras/geometries/ConeBufferGeometry.html
+++ b/docs/api/extras/geometries/ConeBufferGeometry.html
@@ -14,8 +14,6 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:ConeGeometry].</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#ConeBufferGeometry"></iframe>
 
 		<script>
@@ -33,6 +31,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>var geometry = new THREE.ConeBufferGeometry( 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );

--- a/docs/api/extras/geometries/ConeBufferGeometry.html
+++ b/docs/api/extras/geometries/ConeBufferGeometry.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:ConeGeometry].</div>
 
-
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#ConeBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#ConeBufferGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>var geometry = new THREE.ConeBufferGeometry( 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );
@@ -25,9 +40,7 @@
 		scene.add( cone );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Float height], [page:Integer radiusSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
@@ -40,13 +53,11 @@
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete cone.
 		</div>
 
-
 		<h2>Properties</h2>
 
 		<div>
 		Each of the constructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/ConeGeometry.html
+++ b/docs/api/extras/geometries/ConeGeometry.html
@@ -14,8 +14,6 @@
 
 		<div class="desc">A class for generating cone geometries</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#ConeGeometry"></iframe>
 
 		<script>
@@ -33,6 +31,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>var geometry = new THREE.ConeGeometry( 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );

--- a/docs/api/extras/geometries/ConeGeometry.html
+++ b/docs/api/extras/geometries/ConeGeometry.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">A class for generating cone geometries</div>
 
-
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#ConeGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#ConeGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>var geometry = new THREE.ConeGeometry( 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );
@@ -25,9 +40,7 @@
 		scene.add( cone );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Float height], [page:Integer radiusSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
@@ -40,13 +53,11 @@
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete cone.
 		</div>
 
-
 		<h2>Properties</h2>
 
 		<div>
 		Each of the constructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/CylinderBufferGeometry.html
+++ b/docs/api/extras/geometries/CylinderBufferGeometry.html
@@ -14,8 +14,6 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:CylinderGeometry].</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#CylinderBufferGeometry"></iframe>
 
 		<script>
@@ -33,6 +31,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>var geometry = new THREE.CylinderBufferGeometry( 5, 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );

--- a/docs/api/extras/geometries/CylinderBufferGeometry.html
+++ b/docs/api/extras/geometries/CylinderBufferGeometry.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:CylinderGeometry].</div>
 
-
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#CylinderBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#CylinderBufferGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>var geometry = new THREE.CylinderBufferGeometry( 5, 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );
@@ -25,9 +40,7 @@
 		scene.add( cylinder );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radiusTop], [page:Float radiusBottom], [page:Float height], [page:Integer radiusSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
@@ -41,13 +54,11 @@
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete cylinder.
 		</div>
 
-
 		<h2>Properties</h2>
 
 		<div>
 		Each of the constructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/CylinderGeometry.html
+++ b/docs/api/extras/geometries/CylinderGeometry.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">A class for generating cylinder geometries</div>
 
-
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#CylinderGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#CylinderGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>var geometry = new THREE.CylinderGeometry( 5, 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );
@@ -25,9 +40,7 @@
 		scene.add( cylinder );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radiusTop], [page:Float radiusBottom], [page:Float height], [page:Integer radiusSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
@@ -41,13 +54,11 @@
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete cylinder.
 		</div>
 
-
 		<h2>Properties</h2>
 
 		<div>
 		Each of the constructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/CylinderGeometry.html
+++ b/docs/api/extras/geometries/CylinderGeometry.html
@@ -14,8 +14,6 @@
 
 		<div class="desc">A class for generating cylinder geometries</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#CylinderGeometry"></iframe>
 
 		<script>
@@ -33,6 +31,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>var geometry = new THREE.CylinderGeometry( 5, 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );

--- a/docs/api/extras/geometries/DodecahedronGeometry.html
+++ b/docs/api/extras/geometries/DodecahedronGeometry.html
@@ -14,11 +14,25 @@
 
 		<div class="desc">A class for generating a dodecahedron geometries.</div>
 
-		<iframe src='scenes/geometry-browser.html#DodecahedronGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#DodecahedronGeometry"></iframe>
 
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
 		<div>
@@ -26,14 +40,12 @@
 		detail — Default is 0. Setting this to a value greater than 0 adds vertices making it no longer a dodecahedron.
 		</div>
 
-
 		<h2>Properties</h2>
 
 		<h3>[property:Object parameters]</h3>
 		<div>
 		An object with all of the parameters that were used to generate the geometry.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/IcosahedronGeometry.html
+++ b/docs/api/extras/geometries/IcosahedronGeometry.html
@@ -13,10 +13,25 @@
 
 		<div class="desc">A class for generating an icosahedron geometry.</div>
 
-		<iframe src='scenes/geometry-browser.html#IcosahedronGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#IcosahedronGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
 		<div>
@@ -24,14 +39,12 @@
 		detail — Default is 0.  Setting this to a value greater than 0 adds more vertices making it no longer an icosahedron.  When detail is greater than 1, it's effectively a sphere.
 		</div>
 
-
 		<h2>Properties</h2>
 
 		<h3>[property:Object parameters]</h3>
 		<div>
 		An object with all of the parameters that were used to generate the geometry.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/LatheBufferGeometry.html
+++ b/docs/api/extras/geometries/LatheBufferGeometry.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:LatheGeometry].</div>
 
-
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#LatheBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#LatheBufferGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>
 		var points = [];
@@ -32,7 +47,6 @@
 
 		<h2>Constructor</h2>
 
-
 		<h3>[name]([page:Array points], [page:Integer segments], [page:Float phiStart], [page:Float phiLength])</h3>
 		<div>
 		points — Array of Vector2s. The x-coordinate of each point must be greater than zero.<br />
@@ -43,7 +57,6 @@
 		<div>
 		This creates a LatheBufferGeometry based on the parameters.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/LatheBufferGeometry.html
+++ b/docs/api/extras/geometries/LatheBufferGeometry.html
@@ -14,8 +14,6 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:LatheGeometry].</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#LatheBufferGeometry"></iframe>
 
 		<script>
@@ -33,6 +31,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>
 		var points = [];

--- a/docs/api/extras/geometries/LatheGeometry.html
+++ b/docs/api/extras/geometries/LatheGeometry.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">Class for generating meshes with axial symmetry. Possible uses include donuts, pipes, vases etc. The lathe rotate around the Y axis.</div>
 
-
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#LatheGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#LatheGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>
 		var points = [];
@@ -32,7 +47,6 @@
 
 		<h2>Constructor</h2>
 
-
 		<h3>[name]([page:Array points], [page:Integer segments], [page:Float phiStart], [page:Float phiLength])</h3>
 		<div>
 		points — Array of Vector2s. The x-coordinate of each point must be greater than zero.<br />
@@ -43,7 +57,6 @@
 		<div>
 		This creates a LatheBufferGeometry based on the parameters.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/LatheGeometry.html
+++ b/docs/api/extras/geometries/LatheGeometry.html
@@ -14,8 +14,6 @@
 
 		<div class="desc">Class for generating meshes with axial symmetry. Possible uses include donuts, pipes, vases etc. The lathe rotate around the Y axis.</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#LatheGeometry"></iframe>
 
 		<script>
@@ -33,6 +31,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>
 		var points = [];

--- a/docs/api/extras/geometries/OctahedronGeometry.html
+++ b/docs/api/extras/geometries/OctahedronGeometry.html
@@ -13,17 +13,31 @@
 
 		<div class="desc">A class for generating an octahedron geometry.</div>
 
-		<iframe src='scenes/geometry-browser.html#OctahedronGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#OctahedronGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
 		<div>
 		radius — Radius of the octahedron. Default is 1.<br />
 		detail — Default is 0.  Setting this to a value greater than zero add vertices making it no longer an octahedron.
 		</div>
-
 
 		<h2>Properties</h2>
 

--- a/docs/api/extras/geometries/PlaneBufferGeometry.html
+++ b/docs/api/extras/geometries/PlaneBufferGeometry.html
@@ -16,7 +16,23 @@
 
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#PlaneBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#PlaneBufferGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>var geometry = new THREE.PlaneBufferGeometry( 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00, side: THREE.DoubleSide} );
@@ -24,9 +40,7 @@
 		scene.add( plane );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float width], [page:Float height], [page:Integer widthSegments], [page:Integer heightSegments])</h3>
 		<div>
@@ -35,7 +49,6 @@
 		widthSegments — Optional. Default is 1. <br />
 		heightSegments — Optional. Default is 1.
 		</div>
-
 
 		<h2>Properties</h2>
 

--- a/docs/api/extras/geometries/PlaneBufferGeometry.html
+++ b/docs/api/extras/geometries/PlaneBufferGeometry.html
@@ -14,8 +14,6 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:PlaneGeometry].</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#PlaneBufferGeometry"></iframe>
 
 		<script>
@@ -33,6 +31,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>var geometry = new THREE.PlaneBufferGeometry( 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00, side: THREE.DoubleSide} );

--- a/docs/api/extras/geometries/PlaneGeometry.html
+++ b/docs/api/extras/geometries/PlaneGeometry.html
@@ -14,8 +14,6 @@
 
 		<div class="desc">A class for generating plane geometries</div>
 
-		<h2>Example</h2>
-
 		<iframe id="scene" src="scenes/geometry-browser.html#PlaneGeometry"></iframe>
 
 		<script>
@@ -33,6 +31,8 @@
 		}
 
 		</script>
+
+		<h2>Example</h2>
 
 		<code>var geometry = new THREE.PlaneGeometry( 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00, side: THREE.DoubleSide} );

--- a/docs/api/extras/geometries/PlaneGeometry.html
+++ b/docs/api/extras/geometries/PlaneGeometry.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">A class for generating plane geometries</div>
 
-
 		<h2>Example</h2>
 
-		<iframe src='scenes/geometry-browser.html#PlaneGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#PlaneGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<code>var geometry = new THREE.PlaneGeometry( 5, 20, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00, side: THREE.DoubleSide} );
@@ -25,9 +40,7 @@
 		scene.add( plane );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float width], [page:Float height], [page:Integer widthSegments], [page:Integer heightSegments])</h3>
 		<div>
@@ -36,7 +49,6 @@
 		widthSegments — Optional. Default is 1. <br />
 		heightSegments — Optional. Default is 1.
 		</div>
-
 
 		<h2>Properties</h2>
 

--- a/docs/api/extras/geometries/RingBufferGeometry.html
+++ b/docs/api/extras/geometries/RingBufferGeometry.html
@@ -14,7 +14,23 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:RingGeometry].</div>
 
-		<iframe src='scenes/geometry-browser.html#RingBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#RingBufferGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Example</h2>
 
@@ -26,7 +42,6 @@
 
 		<h2>Constructor</h2>
 
-
 		<h3>[name]([page:Float innerRadius], [page:Float outerRadius], [page:Integer thetaSegments], [page:Integer phiSegments], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
 		innerRadius — Default is 0, but it doesn't work right when innerRadius is set to 0.<br />
@@ -36,7 +51,6 @@
 		thetaStart — Starting angle. Default is 0. <br />
 		thetaLength — Central angle.  Default is Math.PI * 2.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/RingGeometry.html
+++ b/docs/api/extras/geometries/RingGeometry.html
@@ -14,7 +14,23 @@
 
 		<div class="desc">A class for generating a two-dimensional ring geometry.</div>
 
-		<iframe src='scenes/geometry-browser.html#RingGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#RingGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Example</h2>
 
@@ -26,7 +42,6 @@
 
 		<h2>Constructor</h2>
 
-
 		<h3>[name]([page:Float innerRadius], [page:Float outerRadius], [page:Integer thetaSegments], [page:Integer phiSegments], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
 		innerRadius — Default is 0, but it doesn't work right when innerRadius is set to 0.<br />
@@ -36,7 +51,6 @@
 		thetaStart — Starting angle. Default is 0. <br />
 		thetaLength — Central angle.  Default is Math.PI * 2.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/SphereBufferGeometry.html
+++ b/docs/api/extras/geometries/SphereBufferGeometry.html
@@ -14,7 +14,23 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:SphereGeometry].</div>
 
-		<iframe src='scenes/geometry-browser.html#SphereBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#SphereBufferGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Example</h2>
 
@@ -25,7 +41,6 @@
 		</code>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Integer widthSegments], [page:Integer heightSegments], [page:Float phiStart], [page:Float phiLength], [page:Float thetaStart], [page:Float thetaLength])</h3>
 
@@ -42,7 +57,6 @@
 		<div>
 		The geometry is created by sweeping and calculating vertexes around the Y axis (horizontal sweep) and the Z axis (vertical sweep). Thus, incomplete spheres (akin to <em>'sphere slices'</em>) can be created through the use of different values of phiStart, phiLength, thetaStart and thetaLength, in order to define the points in which we start (or end) calculating those vertices.
 		</div>
-
 
 		<h2>Properties</h2>
 

--- a/docs/api/extras/geometries/SphereBufferGeometry.html
+++ b/docs/api/extras/geometries/SphereBufferGeometry.html
@@ -14,9 +14,9 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:SphereGeometry].</div>
 
-		<h2>Example</h2>
-
 		<iframe src='scenes/geometry-browser.html#SphereBufferGeometry'></iframe>
+
+		<h2>Example</h2>
 
 		<code>var geometry = new THREE.SphereBufferGeometry( 5, 32, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );

--- a/docs/api/extras/geometries/SphereGeometry.html
+++ b/docs/api/extras/geometries/SphereGeometry.html
@@ -14,9 +14,9 @@
 
 		<div class="desc">A class for generating sphere geometries</div>
 
-		<h2>Example</h2>
-
 		<iframe src='scenes/geometry-browser.html#SphereGeometry'></iframe>
+
+		<h2>Example</h2>
 
 		<code>var geometry = new THREE.SphereGeometry( 5, 32, 32 );
 		var material = new THREE.MeshBasicMaterial( {color: 0xffff00} );

--- a/docs/api/extras/geometries/SphereGeometry.html
+++ b/docs/api/extras/geometries/SphereGeometry.html
@@ -14,7 +14,23 @@
 
 		<div class="desc">A class for generating sphere geometries</div>
 
-		<iframe src='scenes/geometry-browser.html#SphereGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#SphereGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Example</h2>
 
@@ -25,7 +41,6 @@
 		</code>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Integer widthSegments], [page:Integer heightSegments], [page:Float phiStart], [page:Float phiLength], [page:Float thetaStart], [page:Float thetaLength])</h3>
 
@@ -42,7 +57,6 @@
 		<div>
 		The geometry is created by sweeping and calculating vertexes around the Y axis (horizontal sweep) and the Z axis (vertical sweep). Thus, incomplete spheres (akin to <em>'sphere slices'</em>) can be created through the use of different values of phiStart, phiLength, thetaStart and thetaLength, in order to define the points in which we start (or end) calculating those vertices.
 		</div>
-
 
 		<h2>Properties</h2>
 

--- a/docs/api/extras/geometries/TetrahedronGeometry.html
+++ b/docs/api/extras/geometries/TetrahedronGeometry.html
@@ -14,11 +14,25 @@
 
 		<div class="desc">A class for generating a tetrahedron geometries.</div>
 
-		<iframe src='scenes/geometry-browser.html#TetrahedronGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#TetrahedronGeometry"></iframe>
 
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
 		<div>
@@ -26,14 +40,12 @@
 		detail — Default is 0. Setting this to a value greater than 0 adds vertices making it no longer a tetrahedron.
 		</div>
 
-
 		<h2>Properties</h2>
 
 		<h3>[property:Object parameters]</h3>
 		<div>
 		An object with all of the parameters that were used to generate the geometry.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/TextGeometry.html
+++ b/docs/api/extras/geometries/TextGeometry.html
@@ -14,9 +14,25 @@
 
 		<div class="desc">This object creates a 3D object of text as a single object.</div>
 
-		<h2>Example</h2>
+		<iframe id="scene" src="scenes/geometry-browser.html#TextGeometry"></iframe>
 
-		<iframe src='scenes/geometry-browser.html#TextGeometry'></iframe>
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
+
+		<h2>Example</h2>
 
 		<div>
 		[example:webgl_geometry_text geometry / text ]<br/>
@@ -24,7 +40,6 @@
 		</div>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:String text], [page:Object parameters])</h3>
 		<div>

--- a/docs/api/extras/geometries/TorusBufferGeometry.html
+++ b/docs/api/extras/geometries/TorusBufferGeometry.html
@@ -14,7 +14,23 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:TorusGeometry].</div>
 
-		<iframe src='scenes/geometry-browser.html#TorusBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#TorusBufferGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Example</h2>
 
@@ -24,9 +40,7 @@
 		scene.add( torus );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Float arc])</h3>
 		<div>
@@ -36,7 +50,6 @@
 		tubularSegments — Default is 6. <br />
 		arc — Central angle.  Default is Math.PI * 2.
 		</div>
-
 
 		<h2>Properties</h2>
 

--- a/docs/api/extras/geometries/TorusGeometry.html
+++ b/docs/api/extras/geometries/TorusGeometry.html
@@ -14,7 +14,23 @@
 
 		<div class="desc">A class for generating torus geometries</div>
 
-		<iframe src='scenes/geometry-browser.html#TorusGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#TorusGeometry"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Example</h2>
 
@@ -24,9 +40,7 @@
 		scene.add( torus );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Float arc])</h3>
 		<div>
@@ -36,7 +50,6 @@
 		tubularSegments — Default is 6. <br />
 		arc — Central angle.  Default is Math.PI * 2.
 		</div>
-
 
 		<h2>Properties</h2>
 

--- a/docs/api/extras/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/extras/geometries/TorusKnotBufferGeometry.html
@@ -14,8 +14,23 @@
 
 		<div class="desc">This is the [page:BufferGeometry] port of [page:TorusKnotGeometry].</div>
 
-		<iframe src='scenes/geometry-browser.html#TorusKnotBufferGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#TorusKnotBufferGeometry"></iframe>
 
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Example</h2>
 
@@ -25,9 +40,7 @@
 		scene.add( torusKnot );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer tubularSegments], [page:Integer radialSegments], [page:Integer p], [page:Integer q])</h3>
 		<div>
@@ -41,14 +54,11 @@
 			</ul>
 		</div>
 
-
 		<h2>Properties</h2>
-
 
 		<div>
 		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/extras/geometries/TorusKnotGeometry.html
+++ b/docs/api/extras/geometries/TorusKnotGeometry.html
@@ -14,8 +14,23 @@
 
 		<div class="desc">Creates a torus knot, the particular shape of which is defined by a pair of coprime integers, p and q.  If p and q are not coprime, the result will be a torus link.</div>
 
-		<iframe src='scenes/geometry-browser.html#TorusKnotGeometry'></iframe>
+		<iframe id="scene" src="scenes/geometry-browser.html#TorusKnotGeometry"></iframe>
 
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Example</h2>
 
@@ -25,9 +40,7 @@
 		scene.add( torusKnot );
 		</code>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer tubularSegments], [page:Integer radialSegments], [page:Integer p], [page:Integer q])</h3>
 		<div>
@@ -41,14 +54,11 @@
 			</ul>
 		</div>
 
-
 		<h2>Properties</h2>
-
 
 		<div>
 		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
 		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -15,10 +15,25 @@
 		<div class="desc">A material for drawing geometries in a simple shaded (flat or wireframe) way.</div>
 		<div class="desc">The default will render as flat polygons. To draw the mesh as wireframe, simply set the 'wireframe' property to true.</div>
 
-		<iframe src='scenes/material-browser.html#MeshBasicMaterial'></iframe>
+		<iframe id="scene" src="scenes/material-browser.html#MeshBasicMaterial"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]( [page:Object parameters] )</h3>
 

--- a/docs/api/materials/MeshDepthMaterial.html
+++ b/docs/api/materials/MeshDepthMaterial.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">A material for drawing geometry by depth. Depth is based off of the camera near and far plane. White is nearest, black is farthest.</div>
 
-		<iframe src='scenes/material-browser.html#MeshDepthMaterial'></iframe>
+		<iframe id="scene" src="scenes/material-browser.html#MeshDepthMaterial"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">A material for non-shiny (Lambertian) surfaces, evaluated per vertex.</div>
 
-		<iframe src='scenes/material-browser.html#MeshLambertMaterial'></iframe>
+		<iframe id="scene" src="scenes/material-browser.html#MeshLambertMaterial"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>

--- a/docs/api/materials/MeshNormalMaterial.html
+++ b/docs/api/materials/MeshNormalMaterial.html
@@ -14,11 +14,25 @@
 
 		<div class="desc">A material that maps the normal vectors to RGB colors.</div>
 
-		<iframe src='scenes/material-browser.html#MeshNormalMaterial'></iframe>
+		<iframe id="scene" src="scenes/material-browser.html#MeshNormalMaterial"></iframe>
 
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">A material for shiny surfaces, evaluated per pixel.</div>
 
-		<iframe src='scenes/material-browser.html#MeshPhongMaterial'></iframe>
+		<iframe id="scene" src="scenes/material-browser.html#MeshPhongMaterial"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>

--- a/docs/api/materials/MeshStandardMaterial.html
+++ b/docs/api/materials/MeshStandardMaterial.html
@@ -14,10 +14,25 @@
 
 		<div class="desc">TODO</div>
 
-		<iframe src='scenes/material-browser.html#MeshStandardMaterial'></iframe>
+		<iframe id="scene" src="scenes/material-browser.html#MeshStandardMaterial"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
 
 		<h2>Constructor</h2>
-
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>

--- a/docs/api/objects/SkinnedMesh.html
+++ b/docs/api/objects/SkinnedMesh.html
@@ -14,9 +14,25 @@
 
 		<div class="desc">A mesh that has a [page:Skeleton] with [page:Bone bones] that can then be used to animate the vertices of the geometry.</div>
 
+		<iframe id="scene" src="scenes/bones-browser.html"></iframe>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
+
 		<h2>Example</h2>
-		
-		<iframe src='scenes/bones-browser.html'></iframe>
 		
 		<code>
 		var geometry = new THREE.CylinderGeometry( 5, 5, 5, 5, 15, 5, 30 );
@@ -49,9 +65,7 @@
 		armSkeleton.bones[ 1 ].rotation.x = 0.2;
 		</code>
 		
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]( [page:Geometry geometry], [page:Material material], [page:boolean useVertexTexture] )</h3>
 		<div>
@@ -60,9 +74,7 @@
 		useVertexTexture -- Defines whether a vertex texture can be used (optional).
 		</div>
 
-
 		<h2>Properties</h2>
-
 
 		<h3>[property:array bones]</h3>
 		<div>
@@ -135,7 +147,6 @@
 		Returns a clone of this SkinnedMesh object and its descendants.
 		</div>
 
-		
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]


### PR DESCRIPTION
As per our discussion on #9196. These files all use one of the browsers in docs/scenes.
