### PR TITLE
Use the image specific loader when loading images in ObjectLoader

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -318,11 +318,11 @@ Object.assign( THREE.ObjectLoader.prototype, {
 
 		function loadImage( url ) {
 
-			scope.manager.itemStart( url );
+			manager.itemStart( url );
 
 			return loader.load( url, function () {
 
-				scope.manager.itemEnd( url );
+				manager.itemEnd( url );
 
 			} );
 


### PR DESCRIPTION
Previously used scope.loader rather than the image one which caused the
onLoad callback to be called before all images were loaded.

It was then possible that textures referencing the images could be used before
the images were ready (Texture.image.complete == false) causing a console
warning and lack of texture in renders.
