### PR TITLE
VREffect: Support layer bounds

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -116,8 +116,8 @@ THREE.VREffect = function ( renderer, onError ) {
 	var requestFullscreen;
 	var exitFullscreen;
 	var fullscreenElement;
-	var leftBounds = [0.0, 0.0, 0.5, 0.5];
-	var rightBounds = [0.5, 0.0, 0.5, 1.0];
+	var leftBounds = [ 0.0, 0.0, 0.5, 0.5 ];
+	var rightBounds = [ 0.5, 0.0, 0.5, 1.0 ];
 
 	function onFullscreenChange () {
 
@@ -134,11 +134,14 @@ THREE.VREffect = function ( renderer, onError ) {
 				eyeWidth = eyeParamsL.renderWidth;
 				eyeHeight = eyeParamsL.renderHeight;
 
-				if ( vrHMD.getLayers ) {
+				if ( vrDisplay.getLayers ) {
+
 					var layers = vrHMD.getLayers();
 					if (layers.length) {
-						leftBounds = layers[0].leftBounds || [0.0, 0.0, 0.5, 1.0];
-						rightBounds = layers[0].rightBounds || [0.5, 0.0, 0.5, 1.0];
+
+						leftBounds = layers[0].leftBounds || [ 0.0, 0.0, 0.5, 1.0 ];
+						rightBounds = layers[0].rightBounds || [ 0.5, 0.0, 0.5, 1.0 ];
+
 					}
 				}
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -116,7 +116,7 @@ THREE.VREffect = function ( renderer, onError ) {
 	var requestFullscreen;
 	var exitFullscreen;
 	var fullscreenElement;
-	var leftBounds = [ 0.0, 0.0, 0.5, 0.5 ];
+	var leftBounds = [ 0.0, 0.0, 0.5, 1.0 ];
 	var rightBounds = [ 0.5, 0.0, 0.5, 1.0 ];
 
 	function onFullscreenChange () {

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -116,22 +116,15 @@ THREE.VREffect = function ( renderer, onError ) {
 	var requestFullscreen;
 	var exitFullscreen;
 	var fullscreenElement;
+	var leftBounds = [0.0, 0.0, 0.5, 0.5];
+	var rightBounds = [0.5, 0.0, 0.5, 1.0];
 
 	function onFullscreenChange () {
 
 		var wasPresenting = scope.isPresenting;
 		scope.isPresenting = vrDisplay !== undefined && ( vrDisplay.isPresenting || ( ! isWebVR1 && document[ fullscreenElement ] instanceof window.HTMLElement ) );
 
-		if ( wasPresenting === scope.isPresenting ) {
-
-			return;
-
-		}
-
 		if ( scope.isPresenting ) {
-
-			rendererPixelRatio = renderer.getPixelRatio();
-			rendererSize = renderer.getSize();
 
 			var eyeParamsL = vrDisplay.getEyeParameters( 'left' );
 			var eyeWidth, eyeHeight;
@@ -141,6 +134,14 @@ THREE.VREffect = function ( renderer, onError ) {
 				eyeWidth = eyeParamsL.renderWidth;
 				eyeHeight = eyeParamsL.renderHeight;
 
+				if ( vrHMD.getLayers ) {
+					var layers = vrHMD.getLayers();
+					if (layers.length) {
+						leftBounds = layers[0].leftBounds || [0.0, 0.0, 0.5, 1.0];
+						rightBounds = layers[0].rightBounds || [0.5, 0.0, 0.5, 1.0];
+					}
+				}
+
 			} else {
 
 				eyeWidth = eyeParamsL.renderRect.width;
@@ -148,10 +149,17 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			renderer.setPixelRatio( 1 );
-			renderer.setSize( eyeWidth * 2, eyeHeight, false );
+			if ( !wasPresenting ) {
 
-		} else {
+				rendererPixelRatio = renderer.getPixelRatio();
+				rendererSize = renderer.getSize();
+
+				renderer.setPixelRatio( 1 );
+				renderer.setSize( eyeWidth * 2, eyeHeight, false );
+
+			}
+
+		} else if ( wasPresenting ) {
 
 			renderer.setPixelRatio( rendererPixelRatio );
 			renderer.setSize( rendererSize.width, rendererSize.height );
@@ -311,8 +319,18 @@ THREE.VREffect = function ( renderer, onError ) {
 			// When rendering we don't care what the recommended size is, only what the actual size
 			// of the backbuffer is.
 			var size = renderer.getSize();
-			renderRectL = { x: 0, y: 0, width: size.width / 2, height: size.height };
-			renderRectR = { x: size.width / 2, y: 0, width: size.width / 2, height: size.height };
+			renderRectL = {
+				x: Math.round( size.width * leftBounds[ 0 ] ),
+				y: Math.round( size.height * leftBounds[ 1 ] ),
+				width: Math.round( size.width * leftBounds[ 2 ] ),
+				height:  Math.round(size.height * leftBounds[ 3 ] )
+			};
+			renderRectR = {
+				x: Math.round( size.width * rightBounds[ 0 ] ),
+				y: Math.round( size.height * rightBounds[ 1 ] ),
+				width: Math.round( size.width * rightBounds[ 2 ] ),
+				height:  Math.round(size.height * rightBounds[ 3 ] )
+			};
 
 			renderer.setScissorTest( true );
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -136,7 +136,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 				if ( vrDisplay.getLayers ) {
 
-					var layers = vrHMD.getLayers();
+					var layers = vrDisplay.getLayers();
 					if (layers.length) {
 
 						leftBounds = layers[0].leftBounds || [ 0.0, 0.0, 0.5, 1.0 ];


### PR DESCRIPTION
- Retrieve left and right eye layer bounds on vrdisplaypresentchange event
- Set viewport to layer bounds when rendering stereo

There is a test example here http://output.jsbin.com/fohuqen
The example changes the output resolution every 2 seconds just to show that it works, though this is not how it would be done in practice. This will work in the WebVR Chrome build, though there is currently a [bug](https://github.com/toji/chrome-webvr-issues/issues/79) that causes the view to reset every time the resolution changes. @toji said he's working on it.

This will also work with the polyfill. My example uses code that I will be submitting as a pull request to fix dynamic resolution support there.
