### PR TITLE
clockwise full ellipse

### DIFF
--- a/src/extras/curves/EllipseCurve.js
+++ b/src/extras/curves/EllipseCurve.js
@@ -46,9 +46,17 @@ THREE.EllipseCurve.prototype.getPoint = function( t ) {
 
 	}
 
-	if ( this.aClockwise === true && deltaAngle != twoPi && ! samePoints ) {
+	if ( this.aClockwise === true && ! samePoints ) {
 
-		deltaAngle = deltaAngle - twoPi;
+		if ( deltaAngle === twoPi ) {
+
+			deltaAngle = - twoPi;
+
+		} else {
+
+			deltaAngle = deltaAngle - twoPi;
+
+		}
 
 	}
 


### PR DESCRIPTION
The point returned by getPoint was always reverse clockwise on a full ellipse even when the ellipse is clock wise. The problem only occurs on full ellipse.
See https://github.com/mrdoob/three.js/pull/8952#issuecomment-230361431 for  an explanation
Tested on webgl_geometry_shapes.html and canvas_geometry_shapes.html that use clockwise ellipse.
