### PR TITLE
Set explicit clear color in documentation scenes for iOS

### DIFF
--- a/docs/scenes/bones-browser.html
+++ b/docs/scenes/bones-browser.html
@@ -59,6 +59,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setClearColor( 0x000000 );
 				document.body.appendChild( renderer.domElement );
 
 				orbit = new THREE.OrbitControls( camera, renderer.domElement );

--- a/docs/scenes/geometry-browser.html
+++ b/docs/scenes/geometry-browser.html
@@ -52,6 +52,7 @@
 			var renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setClearColor( 0x000000 );
 			document.body.appendChild( renderer.domElement );
 
 			var orbit = new THREE.OrbitControls( camera, renderer.domElement );

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -50,6 +50,7 @@
 			var renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setClearColor( 0x000000 );
 			document.body.appendChild( renderer.domElement );
 
 			var ambientLight = new THREE.AmbientLight( 0x000000 );


### PR DESCRIPTION
The default clear color for iOS is inexplicably white, not black. This is a particular problem for MeshDepthMaterial documentation, since the object is white. Setting the clear color explicitly solves the problem for iOS.
