### PR TITLE
Add specular map support to the MTL Loader.

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -396,6 +396,17 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					break;
 
+				case 'map_ks':
+
+					// Specular map
+
+					if ( params.specularMap ) break; // Keep the first encountered texture
+					params.specularMap = this.loadTexture( resolveURL( this.baseUrl, value ) );
+					params.specularMap.wrapS = this.wrap;
+					params.specularMap.wrapT = this.wrap;
+
+					break;
+
 				case 'ns':
 
 					// The specular exponent (defines the focus of the specular highlight)


### PR DESCRIPTION
Noticed mtl loader wasn't playing with map_Ks and that there was no reason for it not to, so I added it. Works too!
