### PR TITLE
Orbit control settings for mouseout

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -74,6 +74,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	// Mouse buttons
 	this.mouseButtons = { ORBIT: THREE.MOUSE.LEFT, ZOOM: THREE.MOUSE.MIDDLE, PAN: THREE.MOUSE.RIGHT };
+	
+	// For mouseout so you can keep on spinning no matter where you go with that mouse cursor
+	this.trackMouseOutsideScene = false;
 
 	// for reset
 	this.target0 = this.target.clone();
@@ -221,6 +224,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
+
+		if (this.trackMouseOutsideScene === false)
+			document.removeEventListener( 'mouseout', onMouseUp, false );
 
 		window.removeEventListener( 'keydown', onKeyDown, false );
 
@@ -702,6 +708,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 			document.addEventListener( 'mousemove', onMouseMove, false );
 			document.addEventListener( 'mouseup', onMouseUp, false );
 
+			if (this.trackMouseOutsideScene === false)
+				document.addEventListener( 'mouseout', onMouseUp, false );
+
 			scope.dispatchEvent( startEvent );
 
 		}
@@ -744,6 +753,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
+		
+		if (this.trackMouseOutsideScene === false)
+			document.removeEventListener( 'mouseout', onMouseUp, false );
 
 		scope.dispatchEvent( endEvent );
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -396,18 +396,6 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					break;
 
-				case 'map_ks':
-
-					// Specular map
-
-					if ( params.specularMap ) break; // Keep the first encountered texture
-					console.log("here");
-					params.specularMap = this.loadTexture( resolveURL( this.baseUrl, value ) );
-					params.specularMap.wrapS = this.wrap;
-					params.specularMap.wrapT = this.wrap;
-
-					break;
-
 				case 'ns':
 
 					// The specular exponent (defines the focus of the specular highlight)

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -396,6 +396,18 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					break;
 
+				case 'map_ks':
+
+					// Specular map
+
+					if ( params.specularMap ) break; // Keep the first encountered texture
+					console.log("here");
+					params.specularMap = this.loadTexture( resolveURL( this.baseUrl, value ) );
+					params.specularMap.wrapS = this.wrap;
+					params.specularMap.wrapT = this.wrap;
+
+					break;
+
 				case 'ns':
 
 					// The specular exponent (defines the focus of the specular highlight)


### PR DESCRIPTION
Click and drag and keep on dragging and the camera will keep on spinning. Gone are the days of your camera stopping after your cursor exits the canvas or window.

Setting OrbitControls `trackMouseOutsideScene` to `true` will let you run wild with your spinning. Don't set it and don't worry because the default will leave everything like you left it.
