### PR TITLE
use predefined renderer pixel ratio in vreffect

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -74,7 +74,7 @@ THREE.VREffect = function ( renderer, onError ) {
 		if ( scope.isPresenting ) {
 
 			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
-			renderer.setPixelRatio( 1 );
+			renderer.setPixelRatio( rendererPixelRatio );
 
 			if ( isDeprecatedAPI ) {
 
@@ -134,7 +134,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			renderer.setPixelRatio( 1 );
+			renderer.setPixelRatio( rendererPixelRatio );
 			renderer.setSize( eyeWidth * 2, eyeHeight, false );
 
 		} else {


### PR DESCRIPTION
- Caused low resolution on Cardboard on some mobile devices. This at least makes it configurable.
