### PR TITLE
Changed light positions to Object3D.DefaultUp

### DIFF
--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -9,7 +9,7 @@ THREE.DirectionalLight = function ( color, intensity ) {
 
 	this.type = 'DirectionalLight';
 
-	this.position.set( 0, 1, 0 );
+	this.position.copy( THREE.Object3D.DefaultUp );
 	this.updateMatrix();
 
 	this.target = new THREE.Object3D();

--- a/src/lights/HemisphereLight.js
+++ b/src/lights/HemisphereLight.js
@@ -10,7 +10,7 @@ THREE.HemisphereLight = function ( skyColor, groundColor, intensity ) {
 
 	this.castShadow = undefined;
 
-	this.position.set( 0, 1, 0 );
+	this.position.copy( THREE.Object3D.DefaultUp );
 	this.updateMatrix();
 
 	this.groundColor = new THREE.Color( groundColor );

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -8,7 +8,7 @@ THREE.SpotLight = function ( color, intensity, distance, angle, penumbra, decay 
 
 	this.type = 'SpotLight';
 
-	this.position.set( 0, 1, 0 );
+	this.position.copy( THREE.Object3D.DefaultUp );
 	this.updateMatrix();
 
 	this.target = new THREE.Object3D();


### PR DESCRIPTION
When scenes have the z-axis pointing up (so when `Object3D.DefaultUp = (0, 0, 1)`) the default light positions (0, 1, 0) do not make much sense. It can be easily improved by copying default light positions from the `Object3D.DefaultUp` vector.

I made this change in this PR.
