### PR TITLE
Added expandByObject to THREE.Box3

### DIFF
--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -94,7 +94,13 @@
 		accounting for both the object's, and childrens', world transforms
 		</div>
 
-
+		<h3>[method:Box3 getCorners]( optionalTarget ) THREE.Vector3[]</h3>
+		<div>
+			optionalTarget -- an array with 8 vertices; if specified, the result will be copied here.
+		</div>
+		<div>
+			Returns an array of 8 [page:Vector3 vertices] that represent the corners of the bounding box.
+		</div>
 
 		<h3>[method:Vector3 size]( [page:Vector3 optionalTarget] ) [page:Box3 this]</h3>
 		<div>

--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -208,6 +208,14 @@
 		both directions.
 		</div>
 
+		<h3>[method:Box3 expandByObject]( [page:Object3D object] ) [page:Box3 this]</h3>
+		<div>
+		object -- Object that should be included in the box.
+		</div>
+		<div>
+		Expands the boundaries of this box to include *object*.
+		</div>
+
 		<h3>[method:Box3 copy]( [page:Box3 box] ) [page:Box3 this]</h3>
 		<div>
 		box -- Box to copy.

--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -94,13 +94,7 @@
 		accounting for both the object's, and childrens', world transforms
 		</div>
 
-		<h3>[method:Box3 getCorners]( optionalTarget ) THREE.Vector3[]</h3>
-		<div>
-			optionalTarget -- an array with 8 vertices; if specified, the result will be copied here.
-		</div>
-		<div>
-			Returns an array of 8 [page:Vector3 vertices] that represent the corners of the bounding box.
-		</div>
+
 
 		<h3>[method:Vector3 size]( [page:Vector3 optionalTarget] ) [page:Box3 this]</h3>
 		<div>

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -87,6 +87,9 @@ THREE.Box3.prototype = {
 
 	setFromObject: function ( object ) {
 
+		// Computes the world-axis-aligned bounding box of an object (including its children),
+		// accounting for both the object's, and children's, world transforms
+
 		this.makeEmpty();
 
 		this.expandByObject( object );
@@ -96,9 +99,6 @@ THREE.Box3.prototype = {
 	},
 
 	expandByObject: function () {
-
-		// Computes the world-axis-aligned bounding box of an object (including its children),
-		// accounting for both the object's, and children's, world transforms
 
 		var v1 = new THREE.Vector3();
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -102,7 +102,7 @@ THREE.Box3.prototype = {
 
 		var v1 = new THREE.Vector3();
 
-		return function setFromObject( object ) {
+		return function expandByObject( object ) {
 
 			var scope = this;
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -85,7 +85,17 @@ THREE.Box3.prototype = {
 
 	}(),
 
-	setFromObject: function () {
+	setFromObject: function ( object ) {
+
+		this.makeEmpty();
+
+		this.expandByObject( object );
+
+		return this;
+
+	},
+
+	expandByObject: function () {
 
 		// Computes the world-axis-aligned bounding box of an object (including its children),
 		// accounting for both the object's, and children's, world transforms
@@ -97,8 +107,6 @@ THREE.Box3.prototype = {
 			var scope = this;
 
 			object.updateMatrixWorld( true );
-
-			this.makeEmpty();
 
 			object.traverse( function ( node ) {
 


### PR DESCRIPTION
It was not possible to expand a `THREE.Box3` instance for adding objects to an existing bounding-box. By simply moving the `this.makeEmpty()` call outside of `setFromObject` it was simple to add such functionality with a minimum of code.

The method name `expandByObject` corresponds to methods like `expandByPoint`, `expandByVector`, and `expandByScalar`.
