### PR TITLE
MTLLoader: Support for texture parameters

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -390,7 +390,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( params.map ) break; // Keep the first encountered texture
 
-					texParams = this.getTextureParams( value, params );
+					var texParams = this.getTextureParams( value, params );
 
 					params.map = this.loadTexture( resolveURL( this.baseUrl, texParams.url ) );
 					params.map.repeat.copy( texParams.scale );
@@ -463,7 +463,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 	getTextureParams: function( value, matParams ) {
 
-		texParams = {
+		var texParams = {
 
 			scale: new THREE.Vector2( 1, 1 ),
 			offset: new THREE.Vector2( 0, 0 ),

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -476,7 +476,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 		pos = items.indexOf('-bm');
 		if (pos >= 0) {
 
-			matParams.bumpScale = parseFloat( items[1] );
+			matParams.bumpScale = parseFloat( items[pos+1] );
 			items.splice( pos, 2 );
 
 		}

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -497,7 +497,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 		}
 
-		texParams.url = items.join(' ');
+		texParams.url = items.join(' ').trim();
 		return texParams;
 
 	},

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -390,7 +390,12 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( params.map ) break; // Keep the first encountered texture
 
-					params.map = this.loadTexture( resolveURL( this.baseUrl, value ) );
+					texParams = this.getTextureParams( value );
+
+					params.map = this.loadTexture( resolveURL( this.baseUrl, texParams.url ) );
+					params.map.repeat.copy( texParams.scale );
+					params.map.offset.copy( texParams.offset );
+
 					params.map.wrapS = this.wrap;
 					params.map.wrapT = this.wrap;
 
@@ -434,7 +439,12 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( params.bumpMap ) break; // Keep the first encountered texture
 
-					params.bumpMap = this.loadTexture( resolveURL( this.baseUrl, value ) );
+					var texParams = this.getTextureParams( value );					
+
+					params.bumpMap = this.loadTexture( resolveURL( this.baseUrl, texParams.url ) );
+					params.bumpMap.repeat.copy( texParams.scale );
+					params.bumpMap.offset.copy( texParams.offset );
+ 
 					params.bumpMap.wrapS = this.wrap;
 					params.bumpMap.wrapT = this.wrap;
 
@@ -449,6 +459,46 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 		this.materials[ materialName ] = new THREE.MeshPhongMaterial( params );
 		return this.materials[ materialName ];
+	},
+
+	getTextureParams: function( value, matParams ) {
+
+		texParams = {
+
+			scale: new THREE.Vector2( 1, 1 ),
+			offset: new THREE.Vector2( 0, 0 ),
+
+		 };
+
+		var items = value.split(/\s+/);
+		var pos;
+
+		pos = items.indexOf('-bm');
+		if (pos >= 0) {
+
+			matParams.bumpScale = parseFloat( items[1] );
+			items.splice( pos, 2 );
+
+		}
+
+		pos = items.indexOf('-s');
+		if (pos >= 0) {
+
+			texParams.scale.set( parseFloat( items[pos+1] ), parseFloat( items[pos+2] ) );
+			items.splice( pos, 4 ); // we expect 3 parameters here!
+
+		}
+
+		pos = items.indexOf('-o');
+		if (pos >= 0) {
+
+			texParams.offset.set( parseFloat( items[pos+1] ), parseFloat( items[pos+2] ) );
+			items.splice( pos, 4 ); // we expect 3 parameters here!
+
+		}
+
+		texParams.url = items.join(' ');
+		return texParams;
 
 	},
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -390,7 +390,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( params.map ) break; // Keep the first encountered texture
 
-					texParams = this.getTextureParams( value );
+					texParams = this.getTextureParams( value, params );
 
 					params.map = this.loadTexture( resolveURL( this.baseUrl, texParams.url ) );
 					params.map.repeat.copy( texParams.scale );
@@ -439,7 +439,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( params.bumpMap ) break; // Keep the first encountered texture
 
-					var texParams = this.getTextureParams( value );					
+					var texParams = this.getTextureParams( value, params );					
 
 					params.bumpMap = this.loadTexture( resolveURL( this.baseUrl, texParams.url ) );
 					params.bumpMap.repeat.copy( texParams.scale );


### PR DESCRIPTION
When exporting obj files from blender, I encountered some texture options that were not supported for map_kd and map_bump.

Namely:
- '-s u v w' for texture scale
- '-o u v w' for texture offset
- '-bm s' for bumpmap scale

This would also fix #7943.
