### PR TITLE
Updated clippingPlanes default value in docs

### DIFF
--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -111,7 +111,7 @@
 		<h3>[property:Array clippingPlanes]</h3>
 
 		<div>
-		User-defined clipping planes specified as THREE.Plane objects in world space. These planes apply to the objects this material is attached to. Points in space whose dot product with the plane is negative are cut away. Default is [].
+		User-defined clipping planes specified as THREE.Plane objects in world space. These planes apply to the objects this material is attached to. Points in space whose dot product with the plane is negative are cut away. Default is null.
 		</div>
 
 		<h3>[property:Boolean clipShadows]</h3>


### PR DESCRIPTION
Updated `clippingPlanes` default value in docs
From `[]` to `null`
