### PR TITLE
Options to particleNoiseTex and particleSpriteText

### DIFF
--- a/examples/js/GPUParticleSystem.js
+++ b/examples/js/GPUParticleSystem.js
@@ -23,6 +23,10 @@ THREE.GPUParticleSystem = function(options) {
 	// parse options and use defaults
 	self.PARTICLE_COUNT = options.maxParticles || 1000000;
 	self.PARTICLE_CONTAINERS = options.containerCount || 1;
+	
+	self.PARTICLE_NOISE_TEXTURE = options.particleNoiseTex || null;
+	self.PARTICLE_SPRITE_TEXTURE = options.particleSpriteTex || null;
+	
 	self.PARTICLES_PER_CONTAINER = Math.ceil(self.PARTICLE_COUNT / self.PARTICLE_CONTAINERS);
 	self.PARTICLE_CURSOR = 0;
 	self.time = 0;
@@ -200,10 +204,10 @@ THREE.GPUParticleSystem = function(options) {
 
 	var textureLoader = new THREE.TextureLoader();
 
-	self.particleNoiseTex = textureLoader.load("textures/perlin-512.png");
+	self.particleNoiseTex = self.PARTICLE_NOISE_TEXTURE || textureLoader.load("textures/perlin-512.png");
 	self.particleNoiseTex.wrapS = self.particleNoiseTex.wrapT = THREE.RepeatWrapping;
 
-	self.particleSpriteTex = textureLoader.load("textures/particle2.png");
+	self.particleSpriteTex = self.PARTICLE_SPRITE_TEXTURE || textureLoader.load("textures/particle2.png");
 	self.particleSpriteTex.wrapS = self.particleSpriteTex.wrapT = THREE.RepeatWrapping;
 
 	self.particleShaderMat = new THREE.ShaderMaterial({


### PR DESCRIPTION
Added support to options particleNoiseTex and particleSpriteTex. In this way it is possible to load a texture before and use it always in  all instances.  

Dunno if you will agree with this pull request, but the reason to create it is because I'm using a lot of GPUParticleSystem instances and I need to improve all the requests to textures that this component is doing. 

Now I just need to do: 

``` js
// .... 
var textureLoader = new THREE.TextureLoader();
var particleNoiseTex = textureLoader.load("images/perlin-512.png");
var particleSpriteTex = textureLoader.load("images/particle2.png");

// ... 
// each time I need to instance GPUParticleSystem 

    var particleSystem = new THREE.GPUParticleSystem({
            maxParticles: 200,
            particleNoiseTex: particleNoiseTex, 
            particleSpriteTex: particleSpriteTex
        });
// .... 
```
