### PR TITLE
FBX Converter now exports in a ObjectLoader compatible format

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -289,6 +289,58 @@ Object.assign( THREE.ObjectLoader.prototype, {
 
 			}
 
+			var resolveReferences = function ( material, uuidStack ) {
+
+				if ( material.materials !== undefined ) {
+
+					for ( var i = 0, l = material.materials.length; i < l; i ++ ) {
+
+						var submaterial = material.materials[ i ];
+
+						if ( submaterial instanceof THREE.Reference ) {
+
+							if ( uuidStack.indexOf( submaterial.uuid ) < 0 ) {
+
+								var resolvedMaterial = materials[ submaterial.uuid ];
+
+								if ( resolvedMaterial ) {
+
+									material.materials[ i ] = resolvedMaterial;
+
+								} else {
+
+									console.warn( 'THREE.ObjectLoader.parseMaterials: Failed to resolve referenced material', submaterial.uuid );
+
+								}
+
+							} else {
+
+								console.warn( 'THREE.ObjectLoader.parseMaterials: Cyclic material reference detected', submaterial.uuid );
+
+							}
+
+
+						} else {
+
+							resolveReferences( material, uuidStack.concat( submaterial.uuid ) );
+
+						}
+
+					}
+
+				}
+
+			};
+
+			for ( var key in materials ) {
+
+				if ( materials.hasOwnProperty( key ) ) {
+
+					resolveReferences( materials[ key ], [ key ] );
+
+				}
+
+			}
 		}
 
 		return materials;

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -530,6 +530,12 @@ Object.assign( THREE.ObjectLoader.prototype, {
 
 					break;
 
+				case 'LineSegments':
+
+					object = new THREE.LineSegments( getGeometry( data.geometry ), getMaterial( data.material ) );
+
+					break;
+
 				case 'PointCloud':
 				case 'Points':
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -566,7 +566,17 @@ Object.assign( THREE.ObjectLoader.prototype, {
 			} else {
 
 				if ( data.position !== undefined ) object.position.fromArray( data.position );
-				if ( data.rotation !== undefined ) object.rotation.fromArray( data.rotation );
+
+				if ( data.rotation !== undefined ) {
+
+					object.rotation.fromArray( data.rotation );
+
+				} else if ( data.quaternion !== undefined ) {
+
+					object.quaternion.fromArray( data.quaternion );
+
+				}
+
 				if ( data.scale !== undefined ) object.scale.fromArray( data.scale );
 
 			}

--- a/src/loaders/Reference.js
+++ b/src/loaders/Reference.js
@@ -1,0 +1,47 @@
+/**
+ * @author Benjamin-Dobell / http://glassechidna.com.au/
+ */
+
+THREE.Reference = function ( uuid ) {
+
+	this.uuid = uuid;
+	this.type = 'Reference';
+
+};
+
+THREE.Reference.prototype = {
+
+	constructor: THREE.Reference,
+
+	toJSON: function ( meta ) {
+
+		var data = {
+			metadata: {
+				version: 4.4,
+				type: 'Reference',
+				generator: 'Reference.toJSON'
+			}
+		};
+
+		data.uuid = this.uuid;
+		data.type = this.type;
+
+		return data;
+
+	},
+
+	clone: function () {
+
+		return new this.constructor().copy( this );
+
+	},
+
+	copy: function ( source ) {
+
+		this.uuid = source.uuid;
+
+		return this;
+
+	}
+
+};

--- a/utils/build/includes/common.json
+++ b/utils/build/includes/common.json
@@ -83,6 +83,7 @@
 	"src/loaders/LoadingManager.js",
 	"src/loaders/BufferGeometryLoader.js",
 	"src/loaders/MaterialLoader.js",
+	"src/loaders/Reference.js",
 	"src/loaders/ObjectLoader.js",
 	"src/loaders/TextureLoader.js",
 	"src/loaders/CubeTextureLoader.js",


### PR DESCRIPTION
@mrdoob I'd appreciate it immensely if this could be reviewed/merged fairly quickly. The break-neck speed of development (a good thing) meant my last pull request (https://github.com/mrdoob/three.js/pull/7046) adding this functionality (almost a year ago) was unmergable pretty fast!

The converter in this pull request doesn't yet support `BufferGeometry` - I've actually been converting from `Geometry` to `BufferGeometry` on the fly (in the `ObjectLoader`) in my three.js fork. This is great because all scenes (old ones too) benefit from the newer `BufferGeometry` functionality - mind you it's not something I'd ever submit a pull request for, in its current state it's quite crude.

If I get a chance I'll submit a further pull request that adds `BufferGeometry` output as an additional command line switch. Although admittedly this isn't something I'll use myself, I prefer deciding at load time which geometry should be in a buffer or not (some geometry I modify or read at runtime).

---

FBX converter now exports to an ObjectLoader compatible format.

In addition to making the output ObjectLoader compatible, I've also added or
improved a bunch of functionality:
- Fixed oddity whereby textures were output to a 'maps/' directory but only
  referenced by filename. The relative path is now stored in JSON.
- Added texture filename collision detection which aborts conversion when two
  textures would be copied over each other. The abortion behavior can be
  replaced with a printed warning by specifying --ignore-texture-collisions
  (-i).
- Textures can now be saved to directories other than 'maps/' by specifying
  --texture-output-dir (-o). This path is relative to the output JSON file and
  file references in the JSON are updated accordingly.
- Materials whose textures contain a non-empty alpha channel now automatically
  have 'transparent' set to true (Requires ImageMagick). This can be disabled
  by specifying --no-transparency-detection (-a).
- Non web compatible textures are now automatically converted to PNG or JPEG
  files, the former if they contain alpha (Requires ImageMagick). If
  ImageMagick is not available a warning is reported and we gracefully fall
  back to the old behavior.
- Existing --pretty-print (-p) behavior has now been extended to print JSON
  properties in the order 'metadata', 'type', 'uuid', <other keys>, 'data',
  'children'.
- Redirected errors and warnings to stderr rather than printing to stdout.
- Fixed FBX -> three.js texture bindings.
- Added support for LineSegments.
- Added duplicate geometry detection functionality enabled by specifying
  --optimize-geometry (-g). This just does a brute force search for identical
  geometry and removes the duplicates, replacing node geometry references
  accordingly.

Also performed general refactoring which included:
- Deleted lots of dead and commented-out code.
- Made method naming consistent (using underscores).
- Deleted unused/pointless variables.
- Replaced manual path string manipulation with native python methods (which
  fixed a couple of obscure bugs).

The following functionality has been removed:
- Scene flattening, --flatten-scene (-f), has been removed as it made a heap
  of assumptions and doesn't really make sense in a _converter_. The task is
  better performed in a 3D modelling package, or even in three.js itself after
  a Scene has been loaded.
