### PR TITLE
#8820 -Fixed camera FOV for Blender Exporter

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/camera.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/camera.py
@@ -74,7 +74,7 @@ def fov(camera):
 
     """
     logger.debug("camera.fov(%s)", camera)
-    return camera.lens
+    return camera.angle
 
 
 @_camera


### PR DESCRIPTION
#8820 -Fixed exporter using the focal length of the camera, instead of the FOV-angle
