### PR TITLE
DRYer texture creation for different map types

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -338,6 +338,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 		// Create material
 
+		var scope = this;
 		var mat = this.materialsInfo[ materialName ];
 		var params = {
 
@@ -358,6 +359,22 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 			return baseUrl + url;
 		};
+		
+		var setMapForType = function ( mapType, value ) {
+
+			if ( params[ mapType ] ) return; // Keep the first encountered texture
+
+			var texParams = scope.getTextureParams( value, params );
+			var map = scope.loadTexture( resolveURL( scope.baseUrl, texParams.url ) );
+			
+			map.repeat.copy( texParams.scale );
+			map.offset.copy( texParams.offset );
+
+			map.wrapS = scope.wrap;
+			map.wrapT = scope.wrap;
+			
+			params[ mapType ] = map;
+		}
 
 		for ( var prop in mat ) {
 
@@ -388,28 +405,24 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					// Diffuse texture map
 
-					if ( params.map ) break; // Keep the first encountered texture
-
-					var texParams = this.getTextureParams( value, params );
-
-					params.map = this.loadTexture( resolveURL( this.baseUrl, texParams.url ) );
-					params.map.repeat.copy( texParams.scale );
-					params.map.offset.copy( texParams.offset );
-
-					params.map.wrapS = this.wrap;
-					params.map.wrapT = this.wrap;
+					setMapForType( "map", value );
 
 					break;
 
 				case 'map_ks':
 
 					// Specular map
+					
+					setMapForType( "specularMap", value );
 
-					if ( params.specularMap ) break; // Keep the first encountered texture
+					break;
 
-					params.specularMap = this.loadTexture( resolveURL( this.baseUrl, value ) );
-					params.specularMap.wrapS = this.wrap;
-					params.specularMap.wrapT = this.wrap;
+				case 'map_bump':
+				case 'bump':
+
+					// Bump texture map				
+					
+					setMapForType( "bumpMap", value );
 
 					break;
 
@@ -441,24 +454,6 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 						params.transparent = true;
 
 					}
-
-					break;
-
-				case 'map_bump':
-				case 'bump':
-
-					// Bump texture map
-
-					if ( params.bumpMap ) break; // Keep the first encountered texture
-
-					var texParams = this.getTextureParams( value, params );					
-
-					params.bumpMap = this.loadTexture( resolveURL( this.baseUrl, texParams.url ) );
-					params.bumpMap.repeat.copy( texParams.scale );
-					params.bumpMap.offset.copy( texParams.offset );
- 
-					params.bumpMap.wrapS = this.wrap;
-					params.bumpMap.wrapT = this.wrap;
 
 					break;
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -360,7 +360,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 			return baseUrl + url;
 		};
 		
-		var setMapForType = function ( mapType, value ) {
+		function setMapForType ( mapType, value ) {
 
 			if ( params[ mapType ] ) return; // Keep the first encountered texture
 


### PR DESCRIPTION
Noticed there was a fair bit of repetition in each map line case. This pulls the case logic out into a reusable function

This also adds support for texture parameters for specular maps as a result. (Expands on #9311 and #9308)
