### PR TITLE
Fix broken RawShaderMaterials when using defines

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -393,9 +393,7 @@ THREE.WebGLProgram = ( function () {
 				'	attribute vec4 skinIndex;',
 				'	attribute vec4 skinWeight;',
 
-				'#endif',
-
-				'\n'
+				'#endif'
 
 			].filter( filterEmptyLine ).join( '\n' );
 
@@ -465,9 +463,7 @@ THREE.WebGLProgram = ( function () {
 				parameters.emissiveMapEncoding ? getTexelDecodingFunction( 'emissiveMapTexelToLinear', parameters.emissiveMapEncoding ) : '',
 				parameters.outputEncoding ? getTexelEncodingFunction( "linearToOutputTexel", parameters.outputEncoding ) : '',
 
-				parameters.depthPacking ? "#define DEPTH_PACKING " + material.depthPacking : '',
-
-				'\n'
+				parameters.depthPacking ? "#define DEPTH_PACKING " + material.depthPacking : ''
 
 			].filter( filterEmptyLine ).join( '\n' );
 
@@ -486,8 +482,19 @@ THREE.WebGLProgram = ( function () {
 
 		}
 
-		var vertexGlsl = prefixVertex + vertexShader;
-		var fragmentGlsl = prefixFragment + fragmentShader;
+		var vertexGlsl = [
+
+			prefixVertex,
+			vertexShader
+
+		].join( '\n' );
+
+		var fragmentGlsl = [
+
+			prefixFragment,
+			fragmentShader
+
+		].join( '\n' );
 
 		// console.log( '*VERTEX*', vertexGlsl );
 		// console.log( '*FRAGMENT*', fragmentGlsl );


### PR DESCRIPTION
Currently instantiating a raw shader material like:

``` js
material = new THREE.RawShaderMaterial( {
  defines: {
    DUMMY_DEFINE: true
  },
  vertexShader: "precision highp float;\n....",
  fragmentShader: "precision highp float;\n....",
} );
```

...will always construct invalid shader code. Now I have to use a workaround where I need to prepend the shader code with a newline.

Anyway, I fixed this by always joining the shader prefixes and bodies with a newline. Another approach would have been to append the `prefixVertex` and `prefixFragment` strings with a newline for raw shaders, but I figured the current approach is more scalable. 
