### PR TITLE
include packing in points_frag.glsl to fix compile error

### DIFF
--- a/src/renderers/shaders/ShaderLib/points_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/points_frag.glsl
@@ -2,6 +2,7 @@ uniform vec3 diffuse;
 uniform float opacity;
 
 #include <common>
+#include <packing>
 #include <color_pars_fragment>
 #include <map_particle_pars_fragment>
 #include <fog_pars_fragment>


### PR DESCRIPTION
Without this fix, when using a PointsMaterial:

```
THREE.WebGLShader: gl.getShaderInfoLog() fragment ERROR: 0:269: 'unpackRGBAToDepth' : no matching overloaded function found
```

due to a reference to `unpackRGBAToDepth` [on line 26 of shadowmap_pars_fragment.glsl ](https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl#L26)
