### PR TITLE
Use loading manager with THREE.ImageLoader

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -182,7 +182,7 @@ THREE.ColladaLoader.prototype = {
 
 		// image
 
-		var imageLoader = new THREE.ImageLoader();
+		var imageLoader = new THREE.ImageLoader( this.manager );
 		imageLoader.setCrossOrigin( this.crossOrigin );
 
 		function parseImage( xml ) {


### PR DESCRIPTION
I had problem initializing my scene before the Collada models textures had completed loading.
This meant my project ran without error locally, but threw errors when loading from a remote server due to request latency.

This ensures my loading manager has both the model AND all of it's textures before resolving. I can then initialize my scene without a problem.
