### PR TITLE
elementsNeedUpdate flag fix (#9353)

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -328,13 +328,14 @@ Object.assign( THREE.BufferGeometry.prototype, THREE.EventDispatcher.prototype, 
 
 		if ( object instanceof THREE.Mesh ) {
 
-			if( geometry.__directGeometry === undefined || geometry.elementsNeedUpdate ) {
+			var direct = geometry.__directGeometry;
+
+			if( direct === undefined || geometry.elementsNeedUpdate ) {
 
 				this.fromGeometry( geometry );
+				direct = geometry.__directGeometry;
 
 			}
-
-			var direct = geometry.__directGeometry;
 
 			direct.verticesNeedUpdate = geometry.verticesNeedUpdate || geometry.elementsNeedUpdate;
 			direct.normalsNeedUpdate = geometry.normalsNeedUpdate || geometry.elementsNeedUpdate;

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -328,13 +328,13 @@ Object.assign( THREE.BufferGeometry.prototype, THREE.EventDispatcher.prototype, 
 
 		if ( object instanceof THREE.Mesh ) {
 
-			var direct = geometry.__directGeometry;
+			if( geometry.__directGeometry === undefined || geometry.elementsNeedUpdate ) {
 
-			if ( direct === undefined || geometry.elementsNeedUpdate === true ) {
-
-				return this.fromGeometry( geometry );
+				this.fromGeometry( geometry );
 
 			}
+
+			var direct = geometry.__directGeometry;
 
 			direct.verticesNeedUpdate = geometry.verticesNeedUpdate || geometry.elementsNeedUpdate;
 			direct.normalsNeedUpdate = geometry.normalsNeedUpdate || geometry.elementsNeedUpdate;


### PR DESCRIPTION
```
            if ( direct === undefined || geometry.elementsNeedUpdate === true ) {

                return this.fromGeometry( geometry );

            }
```

this block was preventing all the code below from ever being executed:

```

            direct.verticesNeedUpdate = geometry.verticesNeedUpdate || geometry.elementsNeedUpdate;
            direct.normalsNeedUpdate = geometry.normalsNeedUpdate || geometry.elementsNeedUpdate;
            direct.colorsNeedUpdate = geometry.colorsNeedUpdate || geometry.elementsNeedUpdate;
            direct.uvsNeedUpdate = geometry.uvsNeedUpdate || geometry.elementsNeedUpdate;
            direct.groupsNeedUpdate = geometry.groupsNeedUpdate || geometry.elementsNeedUpdate;

```

Is executing `fromGeometry` needed every time when `elementsNeedUpdate` is set to `true`? If not then this condition will be enough:

```
if( geometry.__directGeometry === undefined )

```
