### PR TITLE
Adds scene fog JSON serialization and parsing

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -4,9 +4,12 @@ import { Group } from '../objects/Group';
 import { Sprite } from '../objects/Sprite';
 import { Points } from '../objects/Points';
 import { Line } from '../objects/Line';
+import { LineSegments } from '../objects/LineSegments';
 import { LOD } from '../objects/LOD';
 import { Mesh } from '../objects/Mesh';
 import { SkinnedMesh } from '../objects/SkinnedMesh';
+import { Fog } from '../scenes/Fog';
+import { FogExp2 } from '../scenes/FogExp2';
 import { HemisphereLight } from '../lights/HemisphereLight';
 import { SpotLight } from '../lights/SpotLight';
 import { PointLight } from '../lights/PointLight';
@@ -28,12 +31,12 @@ import { XHRLoader } from './XHRLoader';
  * @author mrdoob / http://mrdoob.com/
  */
 
-function ObjectLoader( manager ) {
+function ObjectLoader ( manager ) {
 
 	this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 	this.texturePath = '';
 
-};
+}
 
 Object.assign( ObjectLoader.prototype, {
 
@@ -482,6 +485,20 @@ Object.assign( ObjectLoader.prototype, {
 
 					object = new Scene();
 
+					
+					if ( data.fog !== undefined ) {
+						
+						if ( data.fog.density !== undefined ) {
+						
+							object.fog = new FogExp2(data.fog.color, data.fog.density);
+							
+						} else {
+						
+							object.fog = new Fog(data.fog.color, data.fog.near, data.fog.far);
+							
+						}
+					}
+
 					break;
 
 				case 'PerspectiveCamera':
@@ -563,7 +580,7 @@ Object.assign( ObjectLoader.prototype, {
 
 				case 'LineSegments':
 
-					object = new THREE.LineSegments( getGeometry( data.geometry ), getMaterial( data.material ) );
+					object = new LineSegments( getGeometry( data.geometry ), getMaterial( data.material ) );
 
 					break;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -488,11 +488,11 @@ Object.assign( ObjectLoader.prototype, {
 					
 					if ( data.fog !== undefined ) {
 						
-						if ( data.fog.density !== undefined ) {
+						if ( data.fog.type === 'FogExp2' ) {
 						
 							object.fog = new FogExp2(data.fog.color, data.fog.density);
 							
-						} else {
+						} else if ( data.fog.type === 'Fog' ) {
 						
 							object.fog = new Fog(data.fog.color, data.fog.near, data.fog.far);
 							

--- a/src/scenes/Fog.js
+++ b/src/scenes/Fog.js
@@ -5,7 +5,7 @@ import { Color } from '../math/Color';
  * @author alteredq / http://alteredqualia.com/
  */
 
-function Fog( color, near, far ) {
+function Fog ( color, near, far ) {
 
 	this.name = '';
 
@@ -14,7 +14,7 @@ function Fog( color, near, far ) {
 	this.near = ( near !== undefined ) ? near : 1;
 	this.far = ( far !== undefined ) ? far : 1000;
 
-};
+}
 
 Fog.prototype.isFog = true;
 
@@ -24,5 +24,14 @@ Fog.prototype.clone = function () {
 
 };
 
+Fog.prototype.toJSON = function ( meta ) {
+
+	return {
+		color: this.color.getHex(),
+		far: this.far,
+		near: this.near
+	};
+
+};
 
 export { Fog };

--- a/src/scenes/Fog.js
+++ b/src/scenes/Fog.js
@@ -27,6 +27,7 @@ Fog.prototype.clone = function () {
 Fog.prototype.toJSON = function ( meta ) {
 
 	return {
+		type: 'Fog',
 		color: this.color.getHex(),
 		near: this.near,
 		far: this.far

--- a/src/scenes/Fog.js
+++ b/src/scenes/Fog.js
@@ -28,8 +28,8 @@ Fog.prototype.toJSON = function ( meta ) {
 
 	return {
 		color: this.color.getHex(),
-		far: this.far,
-		near: this.near
+		near: this.near,
+		far: this.far
 	};
 
 };

--- a/src/scenes/FogExp2.js
+++ b/src/scenes/FogExp2.js
@@ -5,14 +5,14 @@ import { Color } from '../math/Color';
  * @author alteredq / http://alteredqualia.com/
  */
 
-function FogExp2( color, density ) {
+function FogExp2 ( color, density ) {
 
 	this.name = '';
 
 	this.color = new Color( color );
 	this.density = ( density !== undefined ) ? density : 0.00025;
 
-};
+}
 
 FogExp2.prototype.isFogExp2 = true;
 

--- a/src/scenes/FogExp2.js
+++ b/src/scenes/FogExp2.js
@@ -25,6 +25,7 @@ FogExp2.prototype.clone = function () {
 FogExp2.prototype.toJSON = function ( meta ) {
 
 	return {
+		type: 'FogExp2',
 		color: this.color.getHex(),
 		density: this.density
 	};

--- a/src/scenes/FogExp2.js
+++ b/src/scenes/FogExp2.js
@@ -22,5 +22,13 @@ FogExp2.prototype.clone = function () {
 
 };
 
+FogExp2.prototype.toJSON = function ( meta ) {
+
+	return {
+		color: this.color.getHex(),
+		density: this.density
+	};
+
+};
 
 export { FogExp2 };

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -4,8 +4,8 @@ import { Object3D } from '../core/Object3D';
  * @author mrdoob / http://mrdoob.com/
  */
 
-function Scene() {
-
+function Scene () {
+	
 	Object3D.call( this );
 
 	this.type = 'Scene';
@@ -16,9 +16,10 @@ function Scene() {
 
 	this.autoUpdate = true; // checked by the renderer
 
-};
+}
 
 Scene.prototype = Object.create( Object3D.prototype );
+
 Scene.prototype.constructor = Scene;
 
 Scene.prototype.copy = function ( source, recursive ) {
@@ -36,5 +37,22 @@ Scene.prototype.copy = function ( source, recursive ) {
 
 };
 
+Scene.prototype.toJSON = function ( meta ) {
 
+	var data = Object3D.prototype.toJSON.call( this, meta );
+	
+	if ( this.fog != null ) {
+		
+		data.object.fog = this.fog.toJSON();
+
+<<<<<<< HEAD
 export { Scene };
+=======
+	}
+
+	return data;
+
+};
+	
+export { Scene };
+>>>>>>> adds toJSON methods to scene and fog objects

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -45,9 +45,6 @@ Scene.prototype.toJSON = function ( meta ) {
 		
 		data.object.fog = this.fog.toJSON();
 
-<<<<<<< HEAD
-export { Scene };
-=======
 	}
 
 	return data;
@@ -55,4 +52,3 @@ export { Scene };
 };
 	
 export { Scene };
->>>>>>> adds toJSON methods to scene and fog objects


### PR DESCRIPTION
Fixes the first two points of #9227
- Adds `toJSON` methods to `Scene`, `Fog` and `FogExp2`
- Adds fog instantiation to `ObjectLoader.parse` method

Note: In the `parse` method, the kind of fog (`Fog/FogExp2`) is checked by looking for the presence/absence of `density`. A "better", more future proof way would be to add type information to the `Fog/FogExp2` classes and branch on that information instead. As it is now I just wanted to make as little changes as possible to those classes, but let me know if you want me to make that change.
