### PR TITLE
utils/converters/fbx: fix bug where fbx converter breaks when flattening fbx models

### DIFF
--- a/utils/converters/fbx/convert_to_threejs.py
+++ b/utils/converters/fbx/convert_to_threejs.py
@@ -1505,7 +1505,8 @@ def generate_non_scene_output(scene):
       'normals' : [] if nnormals <= 0 else normal_values,
       'colors' : [] if ncolors <= 0 else color_values,
       'uvs' : uv_values,
-      'faces' : faces
+      'faces' : faces,
+      'textures': {}
     }
 
     if option_pretty_print:


### PR DESCRIPTION
Used to fail with:

```
Traceback (most recent call last):
  File "../convert_to_threejs.py", line 2181, in <module>
    copy_textures( output_content['textures'] )
KeyError: 'textures'
```
