### PR TITLE
fix error message to say THREE.ObjectLoader instead of THREE.SceneLoader

### DIFF
--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -60,7 +60,7 @@ Object.assign( JSONLoader.prototype, {
 
 					if ( type.toLowerCase() === 'scene' ) {
 
-						console.error( 'THREE.JSONLoader: ' + url + ' should be loaded with THREE.SceneLoader instead.' );
+						console.error( 'THREE.JSONLoader: ' + url + ' should be loaded with THREE.ObjectLoader instead.' );
 						return;
 
 					}


### PR DESCRIPTION
since THREE.SceneLoader is not available in this version of THREE
