### PR TITLE
Fix reference error

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -20,7 +20,7 @@ Clock.prototype = {
 
 	start: function () {
 
-		this.startTime = ( performance || Date ).now();
+		this.startTime = ( window.performance || Date ).now();
 
 		this.oldTime = this.startTime;
 		this.running = true;
@@ -53,7 +53,7 @@ Clock.prototype = {
 
 		if ( this.running ) {
 
-			var newTime = ( performance || Date ).now();
+			var newTime = ( window.performance || Date ).now();
 
 			diff = ( newTime - this.oldTime ) / 1000;
 			this.oldTime = newTime;


### PR DESCRIPTION
I got this error when trying something out on the iPad 2.

Check the commit to see what I'm talking about.

Is there a case where `( performance || Date ).now();` ever would have worked? Accessing an undefined variable should always throw an error, right?
