### PR TITLE
remove comments and unnecessary newlines from glsl files

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "chokidar-cli": "1.2.0",
     "jscs": "^1.13.1",
     "rollup": "^0.33.1",
-    "rollup-plugin-string": "^2.0.2",
     "uglify-js": "^2.6.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import string from 'rollup-plugin-string';
 
 var outro = `
 Object.defineProperty( exports, 'AudioContext', {
@@ -10,15 +9,28 @@ Object.defineProperty( exports, 'AudioContext', {
 
 var footer = fs.readFileSync( 'src/Three.Legacy.js', 'utf-8' );
 
+function glsl () {
+	return {
+		transform ( code, id ) {
+			if ( !/\.glsl$/.test( id ) ) return;
+
+			return 'export default ' + JSON.stringify(
+				code
+					.replace( /[ \t]*\/\/.*\n/g, '' )
+					.replace( /[ \t]*\/\*[\s\S]*?\*\//g, '' )
+					.replace( /\n{2,}/g, '\n' )
+			) + ';';
+		}
+	};
+}
+
 export default {
 	entry: 'src/Three.js',
 	dest: 'build/three.js',
 	moduleName: 'THREE',
 	format: 'umd',
 	plugins: [
-		string({
-			include: '**/*.glsl'
-		})
+		glsl()
 	],
 
 	outro: outro,


### PR DESCRIPTION
Via https://github.com/mrdoob/three.js/pull/9381#issuecomment-234681602. This is something that could conceivably be moved into a Rollup plugin (rollup-plugin-glsl), though I thought it would be easier to start with an inline transformer – perhaps ultimately a plugin could handle other forms of minification and optimisation (via https://github.com/aras-p/glsl-optimizer perhaps?) though I'm not familiar with enough with the various options to have an opinion.
