### PR TITLE
THREE.TextureLoader - Send 'withCredentials' to `XHRLoader

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -34,6 +34,7 @@ Object.assign( THREE.ImageLoader.prototype, {
 			var loader = new THREE.XHRLoader();
 			loader.setPath( this.path );
 			loader.setResponseType( 'blob' );
+			loader.setWithCredentials( this.withCredentials );
 			loader.load( url, function ( blob ) {
 
 				image.src = URL.createObjectURL( blob );
@@ -51,6 +52,13 @@ Object.assign( THREE.ImageLoader.prototype, {
 	setCrossOrigin: function ( value ) {
 
 		this.crossOrigin = value;
+		return this;
+
+	},
+
+	setWithCredentials: function ( value ) {
+
+		this.withCredentials = value;
 		return this;
 
 	},

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -16,6 +16,7 @@ Object.assign( THREE.TextureLoader.prototype, {
 
 		var loader = new THREE.ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
+		loader.setWithCredentials( this.withCredentials );
 		loader.setPath( this.path );
 		loader.load( url, function ( image ) {
 
@@ -45,11 +46,20 @@ Object.assign( THREE.TextureLoader.prototype, {
 
 	},
 
+	setWithCredentials: function ( value ) {
+
+		this.withCredentials = value;
+		return this;
+
+	},
+
 	setPath: function ( value ) {
 
 		this.path = value;
 		return this;
 
 	}
+
+
 
 } );


### PR DESCRIPTION
#9371 : This PR adds `setWithCredentials` to the `TextureLoader` and `ImageLoader` which now sends the `withCredentials` options to the XHRLoader.
