### PR TITLE
SceneUtils.attach bug fix

### DIFF
--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -41,6 +41,52 @@ SceneUtils = {
 		scene.remove( child );
 		parent.add( child );
 
+	},
+
+	updateMatrixWorldOfAncestors: function ( obj ) {
+
+		var ancestors = [];
+
+		for ( var a = obj; a !== null; a = a.parent) ancestors.push( a );
+
+		for ( var a = ancestors.pop() ; a !== undefined ; a = ancestors.pop() ){
+
+			a.matrix.compose( a.position, a.quaternion, a.scale );
+
+			if ( a.parent === null) a.matrixWorld.copy ( a.matrix );
+
+			if ( a.parent !== null) a.matrixWorld.multiplyMatrices( a.parent.matrixWorld, a.matrix );
+
+		}
+
+	},
+
+	detach: function ( child ) {
+
+		if (child.parent == null) return;
+
+		SceneUtils.updateMatrixWorldOfAncestors( child );
+		
+		child.matrix.copy( child.matrixWorld );
+
+		child.matrix.decompose( child.position, child.quaternion, child.scale );
+
+		child.parent.remove( child )
+	
+	},
+
+	attach: function ( child, parent ) {
+
+		SceneUtils.updateMatrixWorldOfAncestors( child );
+
+		SceneUtils.updateMatrixWorldOfAncestors( parent );
+
+		child.matrix.getInverse( parent.matrixWorld ).multiply( child.matrixWorld  );
+		 
+		child.matrix.decompose( child.position, child.quaternion, child.scale );
+
+		parent.add( child )
+
 	}
 
 };

--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -24,25 +24,6 @@ SceneUtils = {
 
 	},
 
-	detach: function ( child, parent, scene ) {
-
-		child.applyMatrix( parent.matrixWorld );
-		parent.remove( child );
-		scene.add( child );
-
-	},
-
-	attach: function ( child, scene, parent ) {
-
-		var matrixWorldInverse = new Matrix4();
-		matrixWorldInverse.getInverse( parent.matrixWorld );
-		child.applyMatrix( matrixWorldInverse );
-
-		scene.remove( child );
-		parent.add( child );
-
-	},
-
 	updateMatrixWorldOfAncestors: function ( obj ) {
 
 		var ancestors = [];


### PR DESCRIPTION
In current release the following snippet would produce unexpected result, because mesh.matrixWorld is not up to date.

```
mesh.position.set( 100,0,0  )
SceneUtils.detach(  mesh, parent, scene )
```

In this PR the attach/detach calls SceneUtils.updateMaxtrixWorldOfAncestors() before doing other things.   

To make things clear, the current SceneUtils.detach/attach is buggy when it uses an outdated matrixWorld. This happens when:  
(1) One of the applied object's ancestor is moved/rotated
(2) Then detach/attach is applied before next `renderer.render()` call. ( Otherwise `renderer.render()` calls `scene.updateMatrixWorld()`, updating all its descendants. )

By the way, `Object3D.prototype.getWorldPosition()` has the same issue.
