### PR TITLE
adds jsnext:main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.79.0",
   "description": "JavaScript 3D library",
   "main": "build/three.js",
+  "jsnext:main": "src/Three.js",
   "files": [
     "package.json",
     "LICENSE",


### PR DESCRIPTION
Was surprised that the `jsnext:main` field was not added with #9310, so this PR adds it.

Adding this field will allow tools such as [rollup](https://github.com/rollup/rollup) (which is now used to bundle `three.js` itself) to perform tree-shaking optimization which might reduce bundle size considerably. [See this](https://github.com/rollup/rollup/wiki/jsnext:main).

@Rich-Harris I know you have been pushing for `jsnext:main` usage a lot, was there a specific reason why you left this out from your PR?
