### PR TITLE
Add rollup-watch to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "chokidar-cli": "1.2.0",
     "jscs": "^1.13.1",
     "rollup": "^0.34.8",
+    "rollup-watch": "^2.5.0",
     "uglify-js": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"\/\/ threejs.org\/license\" > build/three.min.js",
+    "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar utils/build/compiler/closure-compiler-v20160713.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
     "dev": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -44,7 +44,6 @@
   "homepage": "http://threejs.org/",
   "devDependencies": {
     "argparse": "^1.0.3",
-    "chokidar-cli": "1.2.0",
     "jscs": "^1.13.1",
     "rollup": "^0.34.8",
     "rollup-watch": "^2.5.0",


### PR DESCRIPTION
- so `npm run dev` works.

Relates to #9310, #9598
