### PR TITLE
force Rollup to use correct indentation

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,6 +29,7 @@ export default {
 	dest: 'build/three.js',
 	moduleName: 'THREE',
 	format: 'umd',
+	indent: '\t',
 	plugins: [
 		glsl()
 	],


### PR DESCRIPTION
Via https://github.com/mrdoob/three.js/pull/9310#issuecomment-235555390 – seems Rollup is failing to auto-detect the correct indentation. Not sure why. Anyway, this fixes it by forcing it to use tabs. The UMD block at the top still uses two spaces, we'll have to fix that in Rollup
