### PR TITLE
Add mousedown handler on document to OrbitControls

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -222,6 +222,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
 
+		document.removeEventListener( 'mousedown', onDocumentMouseDown, false );
+
 		window.removeEventListener( 'keydown', onKeyDown, false );
 
 		//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
@@ -665,6 +667,10 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// event handlers - FSM: listen for events and reset state
 	//
 
+	function onDocumentMouseDown( event ) {
+		scope.enabled = event.target == scope.domElement;
+	}
+
 	function onMouseDown( event ) {
 
 		if ( scope.enabled === false ) return;
@@ -896,6 +902,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 	scope.domElement.addEventListener( 'touchstart', onTouchStart, false );
 	scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
 	scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
+
+	document.addEventListener( 'mousedown', onDocumentMouseDown, false );
 
 	window.addEventListener( 'keydown', onKeyDown, false );
 


### PR DESCRIPTION
On our application we have a select list and a div where a 3D object was displayed.

When we click on the 3D object, we can move the scene with arrow keys but when we click on the select list and we use the arrow keys, the selection changed in the list but also move the 3D view...

With this fix, and when we click on other dom element, 3D view was disabled...

I don't know if it is the good way to resolve the problem (probably must add an other variable to check) for all but it's work for us.
