### PR TITLE
Add typechecking for array argument in BufferAttribute

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -10,6 +10,12 @@ import { _Math } from '../math/Math';
 
 function BufferAttribute( array, itemSize, normalized ) {
 
+	if (array.buffer instanceof ArrayBuffer === false) {
+
+		throw new TypeError( 'THREE.BufferAttribute: array should be an instance of Uint8Array, Int8Array, Uint16Array, Int16Array, or Float32Array.' );
+
+	}
+
 	this.uuid = _Math.generateUUID();
 
 	this.array = array;


### PR DESCRIPTION
Oversaw the required type for the argument and therefore spent some time figuring out why my regular `Array` wasn't working.
