### PR TITLE
Add BSP algorithm for SVGRenderer

### DIFF
--- a/examples/js/renderers/CanvasRenderer.js
+++ b/examples/js/renderers/CanvasRenderer.js
@@ -132,6 +132,7 @@ THREE.CanvasRenderer = function ( parameters ) {
 	this.autoClear = true;
 	this.sortObjects = true;
 	this.sortElements = true;
+	this.useBSP = false;
 
 	this.info = {
 
@@ -327,7 +328,7 @@ THREE.CanvasRenderer = function ( parameters ) {
 		_context.setTransform( _viewportWidth / _canvasWidth, 0, 0, - _viewportHeight / _canvasHeight, _viewportX, _canvasHeight - _viewportY );
 		_context.translate( _canvasWidthHalf, _canvasHeightHalf );
 
-		_renderData = _projector.projectScene( scene, camera, this.sortObjects, this.sortElements );
+		_renderData = _projector.projectScene( scene, camera, this.sortObjects, this.sortElements, this.useBSP );
 		_elements = _renderData.elements;
 		_lights = _renderData.lights;
 		_camera = camera;

--- a/examples/js/renderers/Projector.js
+++ b/examples/js/renderers/Projector.js
@@ -1004,7 +1004,9 @@ THREE.Projector = function () {
 	BSPTree.utils = {
 		createNode: function ( element ) {
 
-			return new ( element.v3 ? BSPTree.TriangleNode : BSPTree.LineNode )( element );
+			if ( element instanceof THREE.RenderableFace ) return new BSPTree.TriangleNode( element );
+			if ( element instanceof THREE.RenderableLine ) return new BSPTree.LineNode( element );
+			throw new Error( 'Current BSP algorithm only supports triangles and lines' );
 
 		},
 		getPointSign: function ( normal, point, pointOnPlane ) {

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -53,6 +53,7 @@ THREE.SVGRenderer = function () {
 	this.autoClear = true;
 	this.sortObjects = true;
 	this.sortElements = true;
+	this.useBSP = false;
 
 	this.info = {
 
@@ -137,7 +138,7 @@ THREE.SVGRenderer = function () {
 		_viewMatrix.copy( camera.matrixWorldInverse.getInverse( camera.matrixWorld ) );
 		_viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, _viewMatrix );
 
-		_renderData = _projector.projectScene( scene, camera, this.sortObjects, this.sortElements );
+		_renderData = _projector.projectScene( scene, camera, this.sortObjects, this.sortElements, this.useBSP );
 		_elements = _renderData.elements;
 		_lights = _renderData.lights;
 


### PR DESCRIPTION
SVGRenderer has some issues with z-sorting: painter sort which is currently used sometimes gives wrong results and it can't deal with intersecting objects. As a solution, I've implemented an algorithm that builds a BSP tree and splits objects into smaller pieces. Here is an [example](https://jsfiddle.net/kpoopxc3/6/) (set `useBSP = false` to see the difference).
It only supports triangles and lines, but it can probably be improved in future.
