### PR TITLE
getProgramInfoLog can return '\0' instead of empty string

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -536,7 +536,7 @@ WebGLProgram = ( function () {
 
 			console.error( 'THREE.WebGLProgram: shader error: ', gl.getError(), 'gl.VALIDATE_STATUS', gl.getProgramParameter( program, gl.VALIDATE_STATUS ), 'gl.getProgramInfoLog', programLog, vertexLog, fragmentLog );
 
-		} else if ( programLog !== '' ) {
+		} else if ( programLog !== '' && programLog !== '\0' ) {
 
 			console.warn( 'THREE.WebGLProgram: gl.getProgramInfoLog()', programLog );
 


### PR DESCRIPTION
It seems to happen only on specific versions of Chrome / Chromium, see https://bugs.chromium.org/p/chromium/issues/detail?id=111337.

Fixes #9317
