### PR TITLE
Fixed View Source to Redirect to Github as a catch all - Issue #9462

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -282,17 +282,7 @@
 		button.textContent = 'View source';
 		button.addEventListener( 'click', function ( event ) {
 
-			try {
-
-				var url = location.href.split( '/' ).slice( 0, - 1 ).join( '/' );
-				window.open( 'view-source:' + url + '/' + selected + '.html' );
-
-			} catch ( e ) {
-
-				window.open( 'https://github.com/mrdoob/three.js/blob/master/examples/' + selected + '.html' );
-				console.log( e );
-
-			}
+			window.open( 'https://github.com/mrdoob/three.js/blob/master/examples/' + selected + '.html' );
 
 		}, false );
 		button.style.display = 'none';


### PR DESCRIPTION
Catch all fix for "View source" on Examples page. When using a redirect and view-source: it throws a security issue on Chrome/Safari/Internet Explorer. Otherwise on Firefox it just falls back to the catch error.

Issue is #9462 
