### PR TITLE
Optimize Outline rendering of MMD

### DIFF
--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -4427,7 +4427,7 @@ THREE.MMDHelper.prototype = {
 
 				setInvisible = function ( object ) {
 
-					if ( ! object.visible ) return;
+					if ( ! object.visible || ! object.layers.test( camera.layers ) ) return;
 
 					// any types else to skip?
 					if ( object instanceof THREE.Scene ||
@@ -4447,7 +4447,7 @@ THREE.MMDHelper.prototype = {
 
 					}
 
-					object.visible = false;
+					object.layers.mask &= ~ camera.layers.mask;
 					invisibledObjects.push( object );
 
 				};
@@ -4460,7 +4460,7 @@ THREE.MMDHelper.prototype = {
 
 					for ( var i = 0, il = invisibledObjects.length; i < il; i ++ ) {
 
-						invisibledObjects[ i ].visible = true;
+						invisibledObjects[ i ].layers.mask |= camera.layers.mask;
 
 					}
 


### PR DESCRIPTION
In outline rendering pass, I set `visible` = false for the objects not to be needed rendering outline
like the stage of `webgl_loader_mmd_audio` example.
