### PR TITLE
ObjectLoader reports image load errors to LoadingManager

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -353,6 +353,10 @@ Object.assign( ObjectLoader.prototype, {
 
 				scope.manager.itemEnd( url );
 
+			}, undefined, function () {
+
+				scope.manager.itemError( url );
+
 			} );
 
 		}


### PR DESCRIPTION
This change ensures that `ObjectLoader` doesn't fail silently when an image load error occurs when loading a JSON object file.

The`LoadingManager` `onError` event will now fire with the failed url if an image defined in JSON cannot be loaded.
