### PR TITLE
Editor: Fixed texture load issues.

### DIFF
--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -893,7 +893,7 @@ Sidebar.Material = function ( editor ) {
 
 			}
 
-			signals.materialChanged.dispatch( material );
+			refreshUI();
 
 		}
 

--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -893,6 +893,8 @@ Sidebar.Material = function ( editor ) {
 
 			}
 
+			signals.materialChanged.dispatch( material );
+
 		}
 
 		if ( textureWarning ) {

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -44,6 +44,11 @@ UI.Texture = function ( mapping ) {
 	name.style.border = '1px solid #ccc';
 	dom.appendChild( name );
 
+	var form = document.createElement( 'form' );
+	form.appendChild( input );
+	form.style.display = 'none';
+	dom.appendChild( form );
+
 	var loadFile = function ( file ) {
 
 		if ( file.type.match( 'image.*' ) ) {
@@ -58,6 +63,7 @@ UI.Texture = function ( mapping ) {
 
 					var texture = new THREE.CanvasTexture( canvas, mapping );
 					texture.sourceFile = file.name;
+					form.reset();
 
 					scope.setValue( texture );
 
@@ -79,6 +85,7 @@ UI.Texture = function ( mapping ) {
 						texture.needsUpdate = true;
 
 						scope.setValue( texture );
+						form.reset();
 
 						if ( scope.onChangeCallback ) scope.onChangeCallback();
 


### PR DESCRIPTION
Apparently, the file input element won't fire a change event unless reset. Because of this, the editor won't allow loading the same texture after it has been loaded before, which makes the control irresponsive in some cases.

Reproduction (Chrome):
- Load a model
- Load a texture, but don't enable it
- Add a light source
- Switch back to the model 

At this point the texture is forgotten (which is fine, since it's only remembered in the GUI components) but it can't be reloaded because the invisible file input control won't see the change.

This patch adds a form element around the file input control to properly reset it when an image has been loaded. This way, the same image can be loaded multiple times. It also prevents textures that don't exist from being enabled in the editor, because it doesn't make sense.
