### PR TITLE
change name of _Math to MathUtils

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -150,7 +150,7 @@ export { CubicInterpolant } from './math/interpolants/CubicInterpolant.js';
 export { Interpolant } from './math/Interpolant.js';
 export { Triangle } from './math/Triangle.js';
 export { Spline } from './math/Spline.js';
-export { _Math as Math } from './math/Math.js';
+export { MathUtils as Math } from './math/Math.js';
 export { Spherical } from './math/Spherical.js';
 export { Plane } from './math/Plane.js';
 export { Frustum } from './math/Frustum.js';

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -3,7 +3,7 @@ import { QuaternionKeyframeTrack } from './tracks/QuaternionKeyframeTrack';
 import { NumberKeyframeTrack } from './tracks/NumberKeyframeTrack';
 import { AnimationUtils } from './AnimationUtils';
 import { KeyframeTrack } from './KeyframeTrack';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  *
@@ -19,7 +19,7 @@ function AnimationClip( name, duration, tracks ) {
 	this.tracks = tracks;
 	this.duration = ( duration !== undefined ) ? duration : -1;
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	// this means it should figure out its duration by scanning the tracks
 	if ( this.duration < 0 ) {

--- a/src/animation/AnimationObjectGroup.js
+++ b/src/animation/AnimationObjectGroup.js
@@ -1,5 +1,5 @@
 import { PropertyBinding } from './PropertyBinding';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  *
@@ -34,7 +34,7 @@ import { _Math } from '../math/Math';
 
 function AnimationObjectGroup( var_args ) {
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	// cached objects followed by the active ones
 	this._objects = Array.prototype.slice.call( arguments );

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -1,6 +1,6 @@
 import { Camera } from './Camera';
 import { Object3D } from '../core/Object3D';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -72,7 +72,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 		// see http://www.bobatkins.com/photography/technical/field_of_view.html
 		var vExtentSlope = 0.5 * this.getFilmHeight() / focalLength;
 
-		this.fov = _Math.RAD2DEG * 2 * Math.atan( vExtentSlope );
+		this.fov = MathUtils.RAD2DEG * 2 * Math.atan( vExtentSlope );
 		this.updateProjectionMatrix();
 
 	},
@@ -82,7 +82,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 	 */
 	getFocalLength: function () {
 
-		var vExtentSlope = Math.tan( _Math.DEG2RAD * 0.5 * this.fov );
+		var vExtentSlope = Math.tan( MathUtils.DEG2RAD * 0.5 * this.fov );
 
 		return 0.5 * this.getFilmHeight() / vExtentSlope;
 
@@ -90,8 +90,8 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	getEffectiveFOV: function () {
 
-		return _Math.RAD2DEG * 2 * Math.atan(
-				Math.tan( _Math.DEG2RAD * 0.5 * this.fov ) / this.zoom );
+		return MathUtils.RAD2DEG * 2 * Math.atan(
+				Math.tan( MathUtils.DEG2RAD * 0.5 * this.fov ) / this.zoom );
 
 	},
 
@@ -172,7 +172,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 		var near = this.near,
 			top = near * Math.tan(
-					_Math.DEG2RAD * 0.5 * this.fov ) / this.zoom,
+					MathUtils.DEG2RAD * 0.5 * this.fov ) / this.zoom,
 			height = 2 * top,
 			width = this.aspect * height,
 			left = - 0.5 * width,

--- a/src/cameras/StereoCamera.js
+++ b/src/cameras/StereoCamera.js
@@ -1,5 +1,5 @@
 import { Matrix4 } from '../math/Matrix4';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 import { PerspectiveCamera } from './PerspectiveCamera';
 
 /**
@@ -53,7 +53,7 @@ Object.assign( StereoCamera.prototype, {
 				var projectionMatrix = camera.projectionMatrix.clone();
 				var eyeSep = this.eyeSep / 2;
 				var eyeSepOnProjection = eyeSep * near / focus;
-				var ymax = near * Math.tan( _Math.DEG2RAD * fov * 0.5 );
+				var ymax = near * Math.tan( MathUtils.DEG2RAD * fov * 0.5 );
 				var xmin, xmax;
 
 				// translate xOffset

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -2,7 +2,7 @@ import { Vector4 } from '../math/Vector4';
 import { Vector3 } from '../math/Vector3';
 import { Vector2 } from '../math/Vector2';
 import { Color } from '../math/Color';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -16,7 +16,7 @@ function BufferAttribute( array, itemSize, normalized ) {
 
 	}
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.array = array;
 	this.itemSize = itemSize;

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -7,7 +7,7 @@ import { DirectGeometry } from './DirectGeometry';
 import { Object3D } from './Object3D';
 import { Matrix4 } from '../math/Matrix4';
 import { Matrix3 } from '../math/Matrix3';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 import { GeometryIdCount } from './Geometry';
 
 /**
@@ -19,7 +19,7 @@ function BufferGeometry() {
 
 	Object.defineProperty( this, 'id', { value: GeometryIdCount() } );
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.name = '';
 	this.type = 'BufferGeometry';

--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -1,7 +1,7 @@
 import { Geometry } from './Geometry';
 import { EventDispatcher } from './EventDispatcher';
 import { Vector2 } from '../math/Vector2';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 import { GeometryIdCount } from './Geometry';
 
 /**
@@ -12,7 +12,7 @@ function DirectGeometry() {
 
 	Object.defineProperty( this, 'id', { value: GeometryIdCount() } );
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.name = '';
 	this.type = 'DirectGeometry';

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -8,7 +8,7 @@ import { Matrix4 } from '../math/Matrix4';
 import { Vector2 } from '../math/Vector2';
 import { Color } from '../math/Color';
 import { Object3D } from './Object3D';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -23,7 +23,7 @@ function Geometry() {
 
 	Object.defineProperty( this, 'id', { value: GeometryIdCount() } );
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.name = '';
 	this.type = 'Geometry';

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -1,4 +1,4 @@
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author benaadams / https://twitter.com/ben_a_adams
@@ -6,7 +6,7 @@ import { _Math } from '../math/Math';
 
 function InterleavedBuffer( array, stride ) {
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.array = array;
 	this.stride = stride;

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -1,4 +1,4 @@
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author benaadams / https://twitter.com/ben_a_adams
@@ -6,7 +6,7 @@ import { _Math } from '../math/Math';
 
 function InterleavedBufferAttribute( interleavedBuffer, itemSize, offset, normalized ) {
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.data = interleavedBuffer;
 	this.itemSize = itemSize;

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -5,7 +5,7 @@ import { EventDispatcher } from './EventDispatcher';
 import { Euler } from '../math/Euler';
 import { Layers } from './Layers';
 import { Matrix3 } from '../math/Matrix3';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -19,7 +19,7 @@ function Object3D() {
 
 	Object.defineProperty( this, 'id', { value: Object3DIdCount() } );
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.name = '';
 	this.type = 'Object3D';

--- a/src/extras/geometries/EdgesGeometry.js
+++ b/src/extras/geometries/EdgesGeometry.js
@@ -1,7 +1,7 @@
 import { BufferGeometry } from '../../core/BufferGeometry';
 import { BufferAttribute } from '../../core/BufferAttribute';
 import { Geometry } from '../../core/Geometry';
-import { _Math } from '../../math/Math';
+import { MathUtils } from '../../math/Math';
 
 /**
  * @author WestLangley / http://github.com/WestLangley
@@ -13,7 +13,7 @@ function EdgesGeometry( geometry, thresholdAngle ) {
 
 	thresholdAngle = ( thresholdAngle !== undefined ) ? thresholdAngle : 1;
 
-	var thresholdDot = Math.cos( _Math.DEG2RAD * thresholdAngle );
+	var thresholdDot = Math.cos( MathUtils.DEG2RAD * thresholdAngle );
 
 	var edge = [ 0, 0 ], hash = {};
 

--- a/src/extras/geometries/LatheBufferGeometry.js
+++ b/src/extras/geometries/LatheBufferGeometry.js
@@ -2,7 +2,7 @@ import { BufferGeometry } from '../../core/BufferGeometry';
 import { Vector3 } from '../../math/Vector3';
 import { Vector2 } from '../../math/Vector2';
 import { BufferAttribute } from '../../core/BufferAttribute';
-import { _Math } from '../../math/Math';
+import { MathUtils } from '../../math/Math';
 
 /**
  * @author Mugen87 / https://github.com/Mugen87
@@ -33,7 +33,7 @@ function LatheBufferGeometry( points, segments, phiStart, phiLength ) {
 	phiLength = phiLength || Math.PI * 2;
 
 	// clamp phiLength so it's in range of [ 0, 2PI ]
-	phiLength = _Math.clamp( phiLength, 0, Math.PI * 2 );
+	phiLength = MathUtils.clamp( phiLength, 0, Math.PI * 2 );
 
 	// these are used to calculate buffer length
 	var vertexCount = ( segments + 1 ) * points.length;

--- a/src/extras/geometries/TubeGeometry.js
+++ b/src/extras/geometries/TubeGeometry.js
@@ -1,5 +1,5 @@
 import { Geometry } from '../../core/Geometry';
-import { _Math } from '../../math/Math';
+import { MathUtils } from '../../math/Math';
 import { Vector3 } from '../../math/Vector3';
 import { Matrix4 } from '../../math/Matrix4';
 import { Face3 } from '../../core/Face3';
@@ -275,7 +275,7 @@ TubeGeometry.FrenetFrames = function ( path, segments, closed ) {
 
 			vec.normalize();
 
-			theta = Math.acos( _Math.clamp( tangents[ i - 1 ].dot( tangents[ i ] ), - 1, 1 ) ); // clamp for floating pt errors
+			theta = Math.acos( MathUtils.clamp( tangents[ i - 1 ].dot( tangents[ i ] ), - 1, 1 ) ); // clamp for floating pt errors
 
 			normals[ i ].applyMatrix4( mat.makeRotationAxis( vec, theta ) );
 
@@ -290,7 +290,7 @@ TubeGeometry.FrenetFrames = function ( path, segments, closed ) {
 
 	if ( closed ) {
 
-		theta = Math.acos( _Math.clamp( normals[ 0 ].dot( normals[ numpoints - 1 ] ), - 1, 1 ) );
+		theta = Math.acos( MathUtils.clamp( normals[ 0 ].dot( normals[ numpoints - 1 ] ), - 1, 1 ) );
 		theta /= ( numpoints - 1 );
 
 		if ( tangents[ 0 ].dot( vec.crossVectors( normals[ 0 ], normals[ numpoints - 1 ] ) ) > 0 ) {

--- a/src/extras/objects/MorphBlendMesh.js
+++ b/src/extras/objects/MorphBlendMesh.js
@@ -1,5 +1,5 @@
 import { Mesh } from '../../objects/Mesh';
-import { _Math } from '../../math/Math';
+import { MathUtils } from '../../math/Math';
 
 /**
  * @author alteredq / http://alteredqualia.com/
@@ -283,7 +283,7 @@ MorphBlendMesh.prototype.update = function ( delta ) {
 
 		}
 
-		var keyframe = animation.start + _Math.clamp( Math.floor( animation.time / frameTime ), 0, animation.length - 1 );
+		var keyframe = animation.start + MathUtils.clamp( Math.floor( animation.time / frameTime ), 0, animation.length - 1 );
 		var weight = animation.weight;
 
 		if ( keyframe !== animation.currentFrame ) {

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -1,5 +1,5 @@
 import { LightShadow } from './LightShadow';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 import { PerspectiveCamera } from '../cameras/PerspectiveCamera';
 
 /**
@@ -20,7 +20,7 @@ SpotLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype 
 
 	update: function ( light ) {
 
-		var fov = _Math.RAD2DEG * 2 * light.angle;
+		var fov = MathUtils.RAD2DEG * 2 * light.angle;
 		var aspect = this.mapSize.width / this.mapSize.height;
 		var far = light.distance || 500;
 

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -1,5 +1,5 @@
 import { FaceColors, VertexColors, DoubleSide, BackSide, MirroredRepeatWrapping, RepeatWrapping } from '../constants';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 import { MaterialLoader } from './MaterialLoader';
 import { TextureLoader } from './TextureLoader';
 import { Color } from '../math/Color';
@@ -111,7 +111,7 @@ Loader.prototype = {
 
 				}
 
-				var uuid = _Math.generateUUID();
+				var uuid = MathUtils.generateUUID();
 
 				textures[ uuid ] = texture;
 
@@ -122,7 +122,7 @@ Loader.prototype = {
 			//
 
 			var json = {
-				uuid: _Math.generateUUID(),
+				uuid: MathUtils.generateUUID(),
 				type: 'MeshLambertMaterial'
 			};
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,6 +1,6 @@
 import { EventDispatcher } from '../core/EventDispatcher';
 import { NoColors, FrontSide, SmoothShading, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor } from '../constants';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -11,7 +11,7 @@ function Material() {
 
 	Object.defineProperty( this, 'id', { value: MaterialIdCount() } );
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.name = '';
 	this.type = 'Material';

--- a/src/materials/MultiMaterial.js
+++ b/src/materials/MultiMaterial.js
@@ -1,4 +1,4 @@
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -6,7 +6,7 @@ import { _Math } from '../math/Math';
 
 function MultiMaterial( materials ) {
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.type = 'MultiMaterial';
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -1,4 +1,4 @@
-import { _Math } from './Math';
+import { MathUtils } from './Math';
 
 var ColorKeywords;
 
@@ -93,9 +93,9 @@ Color.prototype = {
 		return function setHSL( h, s, l ) {
 
 			// h,s,l ranges are in 0.0 - 1.0
-			h = _Math.euclideanModulo( h, 1 );
-			s = _Math.clamp( s, 0, 1 );
-			l = _Math.clamp( l, 0, 1 );
+			h = MathUtils.euclideanModulo( h, 1 );
+			s = MathUtils.clamp( s, 0, 1 );
+			l = MathUtils.clamp( l, 0, 1 );
 
 			if ( s === 0 ) {
 

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -1,7 +1,7 @@
 import { Quaternion } from './Quaternion';
 import { Vector3 } from './Vector3';
 import { Matrix4 } from './Matrix4';
-import { _Math } from './Math';
+import { MathUtils } from './Math';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -114,7 +114,7 @@ Euler.prototype = {
 
 	setFromRotationMatrix: function ( m, order, update ) {
 
-		var clamp = _Math.clamp;
+		var clamp = MathUtils.clamp;
 
 		// assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
 

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -1,5 +1,5 @@
 import { Vector3 } from './Vector3';
-import { _Math } from './Math';
+import { MathUtils } from './Math';
 
 /**
  * @author bhouston / http://clara.io
@@ -91,7 +91,7 @@ Line3.prototype = {
 
 			if ( clampToLine ) {
 
-				t = _Math.clamp( t, 0, 1 );
+				t = MathUtils.clamp( t, 0, 1 );
 
 			}
 

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -1,11 +1,11 @@
-var _Math;
+var MathUtils;
 
 /**
  * @author alteredq / http://alteredqualia.com/
  * @author mrdoob / http://mrdoob.com/
  */
 
-_Math = {
+MathUtils = {
 
 	DEG2RAD: Math.PI / 180,
 	RAD2DEG: 180 / Math.PI,
@@ -127,13 +127,13 @@ _Math = {
 
 	degToRad: function ( degrees ) {
 
-		return degrees * _Math.DEG2RAD;
+		return degrees * MathUtils.DEG2RAD;
 
 	},
 
 	radToDeg: function ( radians ) {
 
-		return radians * _Math.RAD2DEG;
+		return radians * MathUtils.RAD2DEG;
 
 	},
 
@@ -166,4 +166,4 @@ _Math = {
 };
 
 
-export { _Math };
+export { MathUtils };

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -1,4 +1,4 @@
-import { _Math } from './Math';
+import { MathUtils } from './Math';
 import { Vector3 } from './Vector3';
 
 /**
@@ -890,7 +890,7 @@ Matrix4.prototype = {
 
 	makePerspective: function ( fov, aspect, near, far ) {
 
-		var ymax = near * Math.tan( _Math.DEG2RAD * fov * 0.5 );
+		var ymax = near * Math.tan( MathUtils.DEG2RAD * fov * 0.5 );
 		var ymin = - ymax;
 		var xmin = ymin * aspect;
 		var xmax = ymax * aspect;

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -1,4 +1,4 @@
-import { _Math } from './Math';
+import { MathUtils } from './Math';
 
 /**
  * @author bhouston / http://clara.io
@@ -72,7 +72,7 @@ Spherical.prototype = {
 		} else {
 
 			this.theta = Math.atan2( vec3.x, vec3.z ); // equator angle around y-up axis
-			this.phi = Math.acos( _Math.clamp( vec3.y / this.radius, - 1, 1 ) ); // polar angle
+			this.phi = Math.acos( MathUtils.clamp( vec3.y / this.radius, - 1, 1 ) ); // polar angle
 
 		}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -1,4 +1,4 @@
-import { _Math } from './Math';
+import { MathUtils } from './Math';
 import { Matrix4 } from './Matrix4';
 import { Quaternion } from './Quaternion';
 
@@ -647,7 +647,7 @@ Vector3.prototype = {
 
 		// clamp, to handle numerical problems
 
-		return Math.acos( _Math.clamp( theta, - 1, 1 ) );
+		return Math.acos( MathUtils.clamp( theta, - 1, 1 ) );
 
 	},
 

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -1,7 +1,7 @@
 import { Matrix4 } from '../math/Matrix4';
 import { FloatType, RGBAFormat } from '../constants';
 import { DataTexture } from '../textures/DataTexture';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author mikael emtinger / http://gomo.se/
@@ -35,7 +35,7 @@ function Skeleton( bones, boneInverses, useVertexTexture ) {
 
 
 		var size = Math.sqrt( this.bones.length * 4 ); // 4 pixels needed for 1 matrix
-		size = _Math.nextPowerOfTwo( Math.ceil( size ) );
+		size = MathUtils.nextPowerOfTwo( Math.ceil( size ) );
 		size = Math.max( size, 4 );
 
 		this.boneTextureWidth = size;

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -2,7 +2,7 @@ import { EventDispatcher } from '../core/EventDispatcher';
 import { Texture } from '../textures/Texture';
 import { LinearFilter } from '../constants';
 import { Vector4 } from '../math/Vector4';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 
 /**
  * @author szimek / https://github.com/szimek/
@@ -17,7 +17,7 @@ import { _Math } from '../math/Math';
 */
 function WebGLRenderTarget( width, height, options ) {
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.width = width;
 	this.height = height;

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1,5 +1,5 @@
 import { LinearFilter, NearestFilter, RGBFormat, RGBAFormat, DepthFormat, DepthStencilFormat, FloatType, HalfFloatType, ClampToEdgeWrapping, NearestMipMapLinearFilter, NearestMipMapNearestFilter } from '../../constants';
-import { _Math } from '../../math/Math';
+import { MathUtils } from '../../math/Math';
 
 /**
 * @author mrdoob / http://mrdoob.com/
@@ -40,7 +40,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, paramT
 
 	function isPowerOfTwo( image ) {
 
-		return _Math.isPowerOfTwo( image.width ) && _Math.isPowerOfTwo( image.height );
+		return MathUtils.isPowerOfTwo( image.width ) && MathUtils.isPowerOfTwo( image.height );
 
 	}
 
@@ -49,8 +49,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, paramT
 		if ( image instanceof HTMLImageElement || image instanceof HTMLCanvasElement ) {
 
 			var canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
-			canvas.width = _Math.nearestPowerOfTwo( image.width );
-			canvas.height = _Math.nearestPowerOfTwo( image.height );
+			canvas.width = MathUtils.nearestPowerOfTwo( image.width );
+			canvas.height = MathUtils.nearestPowerOfTwo( image.height );
 
 			var context = canvas.getContext( '2d' );
 			context.drawImage( image, 0, 0, canvas.width, canvas.height );

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -1,7 +1,7 @@
 import { EventDispatcher } from '../core/EventDispatcher';
 import { UVMapping } from '../constants';
 import { MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, LinearEncoding, UnsignedByteType, RGBAFormat, LinearMipMapLinearFilter, LinearFilter } from '../constants';
-import { _Math } from '../math/Math';
+import { MathUtils } from '../math/Math';
 import { Vector2 } from '../math/Vector2';
 
 /**
@@ -14,7 +14,7 @@ function Texture( image, mapping, wrapS, wrapT, magFilter, minFilter, format, ty
 
 	Object.defineProperty( this, 'id', { value: TextureIdCount() } );
 
-	this.uuid = _Math.generateUUID();
+	this.uuid = MathUtils.generateUUID();
 
 	this.name = '';
 	this.sourceFile = '';
@@ -176,7 +176,7 @@ Texture.prototype = {
 
 			if ( image.uuid === undefined ) {
 
-				image.uuid = _Math.generateUUID(); // UGH
+				image.uuid = MathUtils.generateUUID(); // UGH
 
 			}
 

--- a/test/unit/unittests_math.html
+++ b/test/unit/unittests_math.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>ThreeJS Unit Tests - Using build/Three-math.js</title>
+  <title>ThreeJS Unit Tests - Using build/Three.js</title>
   <link rel="stylesheet" href="qunit-1.18.0.css">
 </head>
 <body>
@@ -13,7 +13,7 @@
 
   <!-- add sources to test below -->
 
-  <script src="../../build/three-math.js"></script>
+  <script src="../../build/three.js"></script>
 
   <!-- add class-based unit tests below -->
 


### PR DESCRIPTION
As proposed by @bhouston in #9399, this changes the name of `_Math` to `MathUtils`. Not sure if this is something you want @mrdoob but since it was a very quick fix, I figured I might as well send a PR.

This change is only internal, and the class is still exported as `THREE.Math`. ES6 users can do `import {Math as MathUtils} from 'three'` to avoid name collisions.

All examples (that were working before) seem to be working still, which is to be expexted since the build still exports `Math`.

A couple of notes:
- I did not change the name of the file, it is still `Math.js`, should I change it?
- The test in `test/unit/unittests_three-math.html` are not working since the file `build/three-math.js` does not exist. This is true for the dev branch as well though. Is this file generated using the python build pipe or is the test obsolete?
