### PR TITLE
Add ray in ViveControllerObject

### DIFF
--- a/examples/js/ViveController.js
+++ b/examples/js/ViveController.js
@@ -4,6 +4,10 @@ THREE.ViveController = function ( id ) {
 
 	this.matrixAutoUpdate = false;
 	this.standingMatrix = new THREE.Matrix4();
+	
+	this.ray = new THREE.ArrowHelper(new THREE.Vector3(0, 0, -1),
+		new THREE.Vector3(0, 0, 0), 100, 0x000000, 1, 1);
+	this.add(this.ray);		
 
 	var scope = this;
 

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -77,13 +77,8 @@ Object.assign( MaterialLoader.prototype, {
 		if ( json.colorWrite !== undefined ) material.colorWrite = json.colorWrite;
 		if ( json.wireframe !== undefined ) material.wireframe = json.wireframe;
 		if ( json.wireframeLinewidth !== undefined ) material.wireframeLinewidth = json.wireframeLinewidth;
-		if ( json.wireframeLinecap !== undefined ) material.wireframeLinecap = json.wireframeLinecap;
-		if ( json.wireframeLinejoin !== undefined ) material.wireframeLinejoin = json.wireframeLinejoin;
-		if ( json.skinning !== undefined ) material.skinning = json.skinning;
-		if ( json.morphTargets !== undefined ) material.wireframe = json.morphTargets;
 
 		// for PointsMaterial
-
 		if ( json.size !== undefined ) material.size = json.size;
 		if ( json.sizeAttenuation !== undefined ) material.sizeAttenuation = json.sizeAttenuation;
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -216,11 +216,6 @@ Material.prototype = {
 		if ( this.premultipliedAlpha === true ) data.premultipliedAlpha = this.premultipliedAlpha;
 		if ( this.wireframe === true ) data.wireframe = this.wireframe;
 		if ( this.wireframeLinewidth > 1 ) data.wireframeLinewidth = this.wireframeLinewidth;
-		if ( this.wireframeLinecap !== 'round' ) data.wireframeLinecap = this.wireframeLinecap;
-		if ( this.wireframeLinejoin !== 'round' ) data.wireframeLinejoin = this.wireframeLinejoin;
-
-		data.skinning = this.skinning;
-		data.morphTargets = this.morphTargets;
 
 		// TODO: Copied from Object3D.toJSON
 


### PR DESCRIPTION
I suggest to add a ray in the ViveControllerObject as simple interaction concept. This ray is an easy understandable gesture (as shown by Valve's Steam Overlay) and mandatory for many interactions. It can be used for ray intersection, but still belongs to the visualization. You can obviously hide it via .visible, e.g. on an occurring event.

WebVR is fairly new and attracts many developers at the moment. This litte addition can guide these people.

As an addition, I suggest to extend the [ViveController example](https://github.com/mrdoob/three.js/blob/dev/examples/webvr_vive.html) with this concept and raycasting. If requested, I will create a pull request for this as well. 

If you think this is not necessary, then how about adding this functionality as addition to the above example. That means: Don't change this file and put all required logic in the example. I would create a PR for this as well.
