### PR TITLE
OBJLoader: Reset groupStart to 0 when using previous material

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -195,6 +195,7 @@ THREE.OBJLoader.prototype = {
 
 					var declared = previousMaterial.clone( 0 );
 					declared.inherited = true;
+					declared.groupStart = 0;
 					this.object.materials.push( declared );
 
 				}


### PR DESCRIPTION
groupStart for a previously used material was set the groupEnd for the previous object

This is incorrect and can be demonstrated using an obj file such as

```
usemtl mtl1
g group1
f 1 2 3
f 3 4 5
usemtl mtl2
g group2
f 6 7 8
usemtl mtl3
g group3
f 9 10 11
```

When groupCount is calculated in finalize the count will be negative and the follow will be true 
`
118: if ( previous && ( previous.inherited || previous.groupCount <= 0 ) )`

this will cause the materials list to be incorrect
