### PR TITLE
Make Sphere Mesh be topologically closed.

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -37430,17 +37430,40 @@
 
 		var indices = [];
 
+		var northPoleVertex = vertices[ 0 ][ 0 ];
+		var southPoleVertex = vertices[ heightSegments ][ 0 ];
+		var closedSides = phiLength === 2 * Math.PI;
+		var closedTop = thetaStart === 0;
+		var closedBottom = thetaEnd === Math.PI;
 		for ( var y = 0; y < heightSegments; y ++ ) {
 
 			for ( var x = 0; x < widthSegments; x ++ ) {
 
-				var v1 = vertices[ y ][ x + 1 ];
+				var nextX = closedSides ? ( x + 1 ) % widthSegments : x + 1;
+				var v1 = vertices[ y ][ nextX ];
 				var v2 = vertices[ y ][ x ];
 				var v3 = vertices[ y + 1 ][ x ];
-				var v4 = vertices[ y + 1 ][ x + 1 ];
+				var v4 = vertices[ y + 1 ][ nextX ];
 
-				if ( y !== 0 || thetaStart > 0 ) indices.push( v1, v2, v4 );
-				if ( y !== heightSegments - 1 || thetaEnd < Math.PI ) indices.push( v2, v3, v4 );
+				if ( ( y === 0 && closedTop )
+					|| ( y === heightSegments - 1 && closedBottom ) ) {
+
+					if ( y === 0 ) {
+
+						indices.push( northPoleVertex, v3, v4 );
+
+					} else {
+
+						indices.push( v1, v2, southPoleVertex );
+
+					}
+
+				} else {
+
+					if ( y !== 0 ) indices.push( v1, v2, v4 );
+					if ( y !== heightSegments - 1 ) indices.push( v2, v3, v4 );
+
+				}
 
 			}
 

--- a/src/extras/geometries/SphereBufferGeometry.js
+++ b/src/extras/geometries/SphereBufferGeometry.js
@@ -77,17 +77,40 @@ function SphereBufferGeometry( radius, widthSegments, heightSegments, phiStart, 
 
 	var indices = [];
 
+	var northPoleVertex = vertices[ 0 ][ 0 ];
+	var southPoleVertex = vertices[ heightSegments ][ 0 ];
+	var closedSides = phiLength === 2 * Math.PI;
+	var closedTop = thetaStart === 0;
+	var closedBottom = thetaEnd === Math.PI;
 	for ( var y = 0; y < heightSegments; y ++ ) {
 
 		for ( var x = 0; x < widthSegments; x ++ ) {
 
-			var v1 = vertices[ y ][ x + 1 ];
+			var nextX = closedSides ? ( x + 1 ) % widthSegments : x + 1;
+			var v1 = vertices[ y ][ nextX ];
 			var v2 = vertices[ y ][ x ];
 			var v3 = vertices[ y + 1 ][ x ];
-			var v4 = vertices[ y + 1 ][ x + 1 ];
+			var v4 = vertices[ y + 1 ][ nextX ];
 
-			if ( y !== 0 || thetaStart > 0 ) indices.push( v1, v2, v4 );
-			if ( y !== heightSegments - 1 || thetaEnd < Math.PI ) indices.push( v2, v3, v4 );
+			if ( ( y === 0 && closedTop )
+				|| ( y === heightSegments - 1 && closedBottom ) ) {
+
+				if ( y === 0 ) {
+
+					indices.push( northPoleVertex, v3, v4 );
+
+				} else {
+
+					indices.push( v1, v2, southPoleVertex );
+
+				}
+
+			} else {
+
+				if ( y !== 0 ) indices.push( v1, v2, v4 );
+				if ( y !== heightSegments - 1 ) indices.push( v2, v3, v4 );
+
+			}
 
 		}
 

--- a/test/unit/extras/geometries/SphereBufferGeometry.tests.js
+++ b/test/unit/extras/geometries/SphereBufferGeometry.tests.js
@@ -41,4 +41,86 @@
 
 	});
 
+	function computeFaceAdjacency(geometry) {
+
+		var inverse = new Map();
+		var neighbors = new Map();
+
+		// For each face, look at each vertex and
+		// associate the face with that vertex.
+		for ( var face of geometry.faces ) {
+
+			var faceVertices = [ "a", "b", "c" ];
+
+			for (var vertexIndex of faceVertices) {
+
+				var vertex = face[ vertexIndex ];
+
+				if ( ! (inverse.has( vertex ) ) ) {
+
+					inverse.set( vertex, [] );
+
+				}
+
+				inverse.get( vertex ).push( face );
+			}
+		}
+
+		for ( face of geometry.faces ) {
+
+			neighbors.set(face, []);
+
+		}
+
+		for ( var face of geometry.faces ) {
+
+			var faceVertices = [ "a", "b", "c" ];
+			var adjacents = new Map();
+
+			for ( var vertexIndex of faceVertices ) {
+
+				var vertex = face[vertexIndex];
+
+				for ( var adjacentFace of inverse.get(vertex) ) {
+
+					if ( !adjacents.has(adjacentFace) ) {
+
+						adjacents.set( adjacentFace, 0 );
+
+					}
+
+					adjacents.set( adjacentFace, adjacents.get( adjacentFace ) + 1 );
+				}
+
+			}
+
+			for ( var entry of adjacents ) {
+
+				var adjacentFace = entry[ 0 ];
+				var count = entry[ 1 ];
+
+				if ( count === 2 ) {
+
+					neighbors.get( face ).push( adjacentFace );
+
+				}
+
+			}
+
+		}
+
+		return neighbors;
+
+	}
+
+	QUnit.test( "A closed sphere should have all faces have exactly 3 neighbors", function( assert ) {
+ 
+		var sphere = new THREE.SphereGeometry();
+		var neighborsMap = computeFaceAdjacency(sphere);
+
+		for ( var face of sphere.faces ) {
+			assert.equal(neighborsMap.get(face).length, 3, "Expected face to have three neighbors");
+		}
+    });
+
 })();


### PR DESCRIPTION
This patch consolidates the vertices at north and south poles when
present, and stiches the sides together when the sphere's phi length
is 2 \* Math.PI.

Test added to check that default Sphere is in fact closed.

resolves #9496
