### PR TITLE
Texture serializer decides to use PNG or JPEG based on image transparency

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -118,6 +118,7 @@ Texture.prototype = {
 		function getDataURL( image ) {
 
 			var canvas;
+			var transparent = false;
 
 			if ( image.toDataURL !== undefined ) {
 
@@ -125,21 +126,35 @@ Texture.prototype = {
 
 			} else {
 
-				canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
+				canvas = document.createElement( 'canvas' );
 				canvas.width = image.width;
 				canvas.height = image.height;
 
-				canvas.getContext( '2d' ).drawImage( image, 0, 0, image.width, image.height );
+				var context = canvas.getContext( '2d' );
+				context.drawImage( image, 0, 0, image.width, image.height );
+
+				var data = context.getImageData( 0, 0, image.width, image.height );
+
+				for( var i = 0; i < data.length; i += 3 ) {
+
+					if( data[i] !== 255 ) {
+
+						transparent = true;
+						break;
+
+					}
+
+				}
 
 			}
 
-			if ( canvas.width > 2048 || canvas.height > 2048 ) {
+			if ( transparent ) {
 
-				return canvas.toDataURL( 'image/jpeg', 0.6 );
+				return canvas.toDataURL( 'image/png' );
 
 			} else {
 
-				return canvas.toDataURL( 'image/png' );
+				return canvas.toDataURL( 'image/jpeg', 0.8 );
 
 			}
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -133,9 +133,9 @@ Texture.prototype = {
 				var context = canvas.getContext( '2d' );
 				context.drawImage( image, 0, 0, image.width, image.height );
 
-				var data = context.getImageData( 0, 0, image.width, image.height );
+				var data = context.getImageData( 0, 0, image.width, image.height ).data;
 
-				for( var i = 0; i < data.length; i += 3 ) {
+				for( var i = 0; i < data.length; i += 4 ) {
 
 					if( data[i] !== 255 ) {
 


### PR DESCRIPTION
Hi
Added code to change what compression method is choosen when serializing images, instead of using JPEG (quality 0.6) only when images where bigger than 2048px, this uses JPEG (quality 0.8) all the time unless transparency is required.

Since most of the times textures don't have an alpha channel and are not made of simple shapes and small amounts of color (which is the best case for PNG encoding), its probably better to use always JPEG encoding for textures.

This allowed me to save more than 50% of space in every test project from nunu Studio.

(I also have working code to create alpha maks from png alpha data, which can save some extra space)
