### PR TITLE
update rollup to 0.34.8, to avoid parsing slowdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "argparse": "^1.0.3",
     "chokidar-cli": "1.2.0",
     "jscs": "^1.13.1",
-    "rollup": "^0.33.1",
+    "rollup": "^0.34.8",
     "uglify-js": "^2.6.0"
   }
 }


### PR DESCRIPTION
See https://github.com/mrdoob/three.js/pull/9310#issuecomment-239642854 – this was tracked down to https://github.com/rollup/rollup/pull/774, which is now merged.

This _doesn't_ address the fact that UglifyJS will remove the parens enclosing the factory function – some clues [here](https://github.com/mishoo/UglifyJS2/issues/886), though for whatever reason I haven't yet managed to disable `negate_iife` – so while the unminified build now parses faster, the minified build is currently still affected.
