### PR TITLE
Check for OES_texture_float when reading Float pixel data (#9513)

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2677,7 +2677,7 @@ function WebGLRenderer( parameters ) {
 
 				if ( texture.type !== UnsignedByteType &&
 				     paramThreeToGL( texture.type ) !== _gl.getParameter( _gl.IMPLEMENTATION_COLOR_READ_TYPE ) &&
-				     ! ( texture.type === FloatType && extensions.get( 'WEBGL_color_buffer_float' ) ) &&
+				     ! ( texture.type === FloatType && ( extensions.get( 'OES_texture_float' ) || extensions.get('WEBGL_color_buffer_float') ) ) &&
 				     ! ( texture.type === HalfFloatType && extensions.get( 'EXT_color_buffer_half_float' ) ) ) {
 
 					console.error( 'THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.' );


### PR DESCRIPTION
Fixes #9513.
- Fix reading Float type pixel data in Chrome > 52 and other browsers that do not support `WEBGL_color_buffer_float`.

I think this is a valid fix for #9513 because according to the [OES_texture_float spec](https://www.khronos.org/registry/webgl/extensions/OES_texture_float/):

> Implementations supporting float rendering via this extension will implicitly enable the WEBGL_color_buffer_float extension and follow its requirements.
