### PR TITLE
Change Line for LineSegments in ObjLoader

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -696,11 +696,11 @@ THREE.OBJLoader.prototype = {
 				}
 
 				var multiMaterial = new THREE.MultiMaterial( createdMaterials );
-				mesh = ( ! isLine ? new THREE.Mesh( buffergeometry, multiMaterial ) : new THREE.Line( buffergeometry, multiMaterial ) );
+				mesh = ( ! isLine ? new THREE.Mesh( buffergeometry, multiMaterial ) : new THREE.LineSegments( buffergeometry, multiMaterial ) );
 
 			} else {
 
-				mesh = ( ! isLine ? new THREE.Mesh( buffergeometry, createdMaterials[ 0 ] ) : new THREE.Line( buffergeometry, createdMaterials[ 0 ] ) );
+				mesh = ( ! isLine ? new THREE.Mesh( buffergeometry, createdMaterials[ 0 ] ) : new THREE.LineSegments( buffergeometry, createdMaterials[ 0 ] ) );
 			}
 
 			mesh.name = object.name;


### PR DESCRIPTION
Change the OBJLoader to use `THREE.LineSegments` instead of `THREE.Line`, as right now it generates incorrect geometry for the lines stored in the obj file as it's assuming they're part of a line strip instead of independent lines as they should be.

With the current loader a line object looks like this:
<img width="226" alt="screenshot 2016-08-17 17 57 01" src="https://cloud.githubusercontent.com/assets/782511/17744228/179ea862-64a7-11e6-830d-c3a190e99d9a.png">

Using `LineSegments` will looks like this:
<img width="234" alt="screenshot 2016-08-17 17 57 09" src="https://cloud.githubusercontent.com/assets/782511/17744247/2a3f8df6-64a7-11e6-8509-b31a580807cd.png">
