### PR TITLE
Serialize and load CubeTexture

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -19,6 +19,7 @@ import { OrthographicCamera } from '../cameras/OrthographicCamera';
 import { PerspectiveCamera } from '../cameras/PerspectiveCamera';
 import { Scene } from '../scenes/Scene';
 import { Texture } from '../textures/Texture';
+import { CubeTexture } from '../textures/CubeTexture';
 import { ImageLoader } from './ImageLoader';
 import { LoadingManager, DefaultLoadingManager } from './LoadingManager';
 import { AnimationClip } from '../animation/AnimationClip';
@@ -401,22 +402,41 @@ Object.assign( ObjectLoader.prototype, {
 
 			for ( var i = 0, l = json.length; i < l; i ++ ) {
 
-				var data = json[ i ];
+				var data = json[ i ], texture;
 
-				if ( data.image === undefined ) {
+				if ( data.images !== undefined ) {
+
+					texture = new CubeTexture( data.images.map( function ( image ) {
+
+						if ( images[ image ] === undefined ) {
+
+							console.warn( 'THREE.ObjectLoader: Undefined cube image', image );
+
+						}
+
+						return images[ image ];
+
+					} ) );
+
+				} else if ( data.image !== undefined ) {
+
+					if ( images[ data.image ] === undefined ) {
+
+						console.warn( 'THREE.ObjectLoader: Undefined image', data.image );
+
+					}
+
+					texture = new Texture( images[ data.image ] );
+
+				} else {
 
 					console.warn( 'THREE.ObjectLoader: No "image" specified for', data.uuid );
 
-				}
-
-				if ( images[ data.image ] === undefined ) {
-
-					console.warn( 'THREE.ObjectLoader: Undefined image', data.image );
+					texture = new Texture();
 
 				}
 
-				var texture = new Texture( images[ data.image ] );
-				texture.needsUpdate = true;
+				if ( texture.image !== undefined ) texture.needsUpdate = true;
 
 				texture.uuid = data.uuid;
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -115,7 +115,7 @@ Texture.prototype = {
 
 		}
 
-		function getDataURL( image ) {
+		function getDataURL ( image ) {
 
 			var canvas;
 
@@ -145,6 +145,27 @@ Texture.prototype = {
 
 		}
 
+		function getImageId ( image ) {
+
+				if ( image.uuid === undefined ) {
+
+					image.uuid = _Math.generateUUID(); // UGH
+
+				}
+
+				if ( meta.images[ image.uuid ] === undefined ) {
+
+					meta.images[ image.uuid ] = {
+						uuid: image.uuid,
+						url: getDataURL( image )
+					};
+
+				}
+
+				return image.uuid;
+
+		}
+
 		var output = {
 			metadata: {
 				version: 4.4,
@@ -166,32 +187,20 @@ Texture.prototype = {
 			anisotropy: this.anisotropy,
 
 			flipY: this.flipY
-		};
 
-		if ( this.image !== undefined ) {
+		};
+		
+		if ( this.images !== undefined ) {
+
+			output.images = this.images.map( getImageId );
+
+		} else if ( this.image !== undefined ) {
 
 			// TODO: Move to THREE.Image
 
-			var image = this.image;
+			output.image = getImageId( this.image );
 
-			if ( image.uuid === undefined ) {
-
-				image.uuid = _Math.generateUUID(); // UGH
-
-			}
-
-			if ( meta.images[ image.uuid ] === undefined ) {
-
-				meta.images[ image.uuid ] = {
-					uuid: image.uuid,
-					url: getDataURL( image )
-				};
-
-			}
-
-			output.image = image.uuid;
-
-		}
+		} 
 
 		meta.textures[ this.uuid ] = output;
 


### PR DESCRIPTION
This change to the `ObjectLoader` and `Texture` classes enables serialization and loading of `CubeTexture` to and from JSON.

A serialized `CubeTexture` will look something like this;

```
{
    "uuid": "a38f080d-24d8-5194-93d2-0187cc69e33e",
    "name": "Environment",
    "mapping": 301,
    "images": [
        "edd9314b-dd25-5ca0-9ccc-391e8ccdc11a",
        "fcdd3d58-34d1-4760-9b21-8c851a38dcac",
        [ ... 4 more ]
    ]
}
```

Live action fiddle: https://jsfiddle.net/satori99/Ls7f69pt/
