### PR TITLE
Blender Exporter: Custom Properties for Empty objects (#9202)

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -250,7 +250,7 @@ def custom_properties(obj):
     # Grab any properties except those marked private (by underscore
     # prefix) or those with types that would be rejected by the JSON
     # serializer object model.
-    return {kvp[0]: kvp[1] for kvp in obj.data.items() if kvp[0][:1] != '_' and isinstance(kvp[1], constants.VALID_DATA_TYPES)}
+    return {K: obj[K] for K in obj.keys() if K[:1] != '_' and isinstance(obj[K], constants.VALID_DATA_TYPES)}  # 'Empty' Blender objects do not use obj.data.items() for custom properties, using obj.keys()
 
 @_object
 def mesh(obj, options):


### PR DESCRIPTION
Fixes #9202 

Replaced `obj.data.items()` with `obj.keys()` for reading the custom properties in `api/object.py`.
