### PR TITLE
WebGLColorBuffer: reset currentColorClear without creating new Vector4

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -683,7 +683,7 @@ function WebGLColorBuffer( gl, state ) {
 		locked = false;
 
 		currentColorMask = null;
-		currentColorClear = new Vector4();
+		currentColorClear.set(0, 0, 0, 1);
 
 	};
 


### PR DESCRIPTION
`WebGLColorBuffer.reset()` gets called every frame, with `currentColorClear = new Vector4()`, it creates large amount of new `Vector4` instances. Use `currentColorClear.set(0, 0, 0, 1)` instead.
