### PR TITLE
Add licensing info to the builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "build-min": "rollup -c && uglifyjs build/three.js -cm > build/three.min.js",
+    "build-min": "rollup -c && uglifyjs build/three.js -cm --comments /threejs.org\\\/license/ > build/three.min.js",
     "dev": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,6 @@ export default {
 	plugins: [
 		glsl()
 	],
-
+	banner: '// threejs.org/license \n',
 	outro: outro
 };


### PR DESCRIPTION
This adds the licensing info to the builds with the new build system.

It now adds `// threejs.org/license` to the top of the build files. It also makes sure that uglifyjs doesn't remove this line by adding it.

Altough it would be better to add the license info as `/*! threejs.org/license */` because that is a 'standard' way to add license info. This makes sure that both uglifyjs and google closure won't remove that comment.

Solves #9310 comment 
