### PR TITLE
add customExtensions to RawShaderMaterial

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -291,13 +291,19 @@ function WebGLProgram( renderer, code, material, parameters ) {
 
 		prefixVertex = [
 
-			customDefines
+			customDefines,
+
+			'\n'
 
 		].filter( filterEmptyLine ).join( '\n' );
 
 		prefixFragment = [
 
-			customDefines
+			customExtensions,
+
+			customDefines,
+
+			'\n'
 
 		].filter( filterEmptyLine ).join( '\n' );
 


### PR DESCRIPTION
fix bug where RawShaderMaterial was breaking when using cutomDefines with customExtensions

issue #9546 
