### PR TITLE
No longer export AnimationAction and remove the _new construction. See #9395

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -114,7 +114,6 @@ export { AnimationUtils } from './animation/AnimationUtils.js';
 export { AnimationObjectGroup } from './animation/AnimationObjectGroup.js';
 export { AnimationMixer } from './animation/AnimationMixer.js';
 export { AnimationClip } from './animation/AnimationClip.js';
-export { AnimationAction } from './animation/AnimationAction.js';
 export { Uniform } from './core/Uniform.js';
 export { InstancedBufferGeometry } from './core/InstancedBufferGeometry.js';
 export { BufferGeometry } from './core/BufferGeometry.js';

--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -11,15 +11,7 @@ import { WrapAroundEnding, ZeroCurvatureEnding, ZeroSlopeEnding, LoopPingPong, L
  *
  */
 
-function AnimationAction() {
-
-	throw new Error( "THREE.AnimationAction: " +
-			"Use mixer.clipAction for construction." );
-
-}
-
-AnimationAction._new =
-		function AnimationAction( mixer, clip, localRoot ) {
+function AnimationAction( mixer, clip, localRoot ) {
 
 	this._mixer = mixer;
 	this._clip = clip;
@@ -84,9 +76,9 @@ AnimationAction._new =
 
 };
 
-AnimationAction._new.prototype = {
+AnimationAction.prototype = {
 
-	constructor: AnimationAction._new,
+	constructor: AnimationAction,
 
 	// State & Scheduling
 
@@ -660,7 +652,6 @@ AnimationAction._new.prototype = {
 	}
 
 };
-
 
 
 export { AnimationAction };

--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -70,7 +70,7 @@ Object.assign( AnimationMixer.prototype, EventDispatcher.prototype, {
 		if ( clipObject === null ) return null;
 
 		// allocate all resources required to run it
-		var newAction = new AnimationMixer._Action( this, clipObject, optionalRoot );
+		var newAction = new AnimationAction( this, clipObject, optionalRoot );
 
 		this._bindAction( newAction, prototypeAction );
 
@@ -275,8 +275,6 @@ Object.assign( AnimationMixer.prototype, EventDispatcher.prototype, {
 
 } );
 
-AnimationMixer._Action = AnimationAction._new;
-
 // Implementation details:
 
 Object.assign( AnimationMixer.prototype, {
@@ -426,8 +424,8 @@ Object.assign( AnimationMixer.prototype, {
 		this._actionsByClip = {};
 		// inside:
 		// {
-		// 		knownActions: Array< _Action >	- used as prototypes
-		// 		actionByRoot: _Action			- lookup
+		// 		knownActions: Array< AnimationAction >	- used as prototypes
+		// 		actionByRoot: AnimationAction			- lookup
 		// }
 
 
@@ -461,7 +459,7 @@ Object.assign( AnimationMixer.prototype, {
 
 	},
 
-	// Memory management for _Action objects
+	// Memory management for AnimationAction objects
 
 	_isActiveAction: function( action ) {
 


### PR DESCRIPTION
As it says on the tin, see #9395 for more context.
