### PR TITLE
In Geometry, allows to select the UV sets that will be exposed to shaders as uvs and uvs2.

### DIFF
--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -114,8 +114,11 @@ Object.assign( DirectGeometry.prototype, EventDispatcher.prototype, {
 		var vertices = geometry.vertices;
 		var faceVertexUvs = geometry.faceVertexUvs;
 
-		var hasFaceVertexUv = faceVertexUvs[ 0 ] && faceVertexUvs[ 0 ].length > 0;
-		var hasFaceVertexUv2 = faceVertexUvs[ 1 ] && faceVertexUvs[ 1 ].length > 0;
+		var primaryUvsIndex = geometry.primaryUvsIndex;
+		var secondaryUvsIndex = geometry.secondaryUvsIndex;
+
+		var hasFaceVertexUv = faceVertexUvs[ primaryUvsIndex ] && faceVertexUvs[ primaryUvsIndex ].length > 0;
+		var hasFaceVertexUv2 = faceVertexUvs[ secondaryUvsIndex ] && faceVertexUvs[ secondaryUvsIndex ].length > 0;
 
 		// morphs
 
@@ -203,7 +206,7 @@ Object.assign( DirectGeometry.prototype, EventDispatcher.prototype, {
 
 			if ( hasFaceVertexUv === true ) {
 
-				var vertexUvs = faceVertexUvs[ 0 ][ i ];
+				var vertexUvs = faceVertexUvs[ primaryUvsIndex ][ i ];
 
 				if ( vertexUvs !== undefined ) {
 
@@ -221,7 +224,7 @@ Object.assign( DirectGeometry.prototype, EventDispatcher.prototype, {
 
 			if ( hasFaceVertexUv2 === true ) {
 
-				var vertexUvs = faceVertexUvs[ 1 ][ i ];
+				var vertexUvs = faceVertexUvs[ secondaryUvsIndex ][ i ];
 
 				if ( vertexUvs !== undefined ) {
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -951,8 +951,12 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 		this.primaryUvsIndex = primaryUvsIndex;
 		this.secondaryUvsIndex = secondaryUvsIndex;
 
-		this.uvsNeedUpdate = uvsNeedUpdate;
-		this.elementsNeedUpdate = uvsNeedUpdate;
+		if ( uvsNeedUpdate ) {
+
+			this.uvsNeedUpdate = uvsNeedUpdate;
+			this.elementsNeedUpdate = uvsNeedUpdate;
+		}
+		
 	},
 
 	toJSON: function () {

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -952,6 +952,7 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 		this.secondaryUvsIndex = secondaryUvsIndex;
 
 		this.uvsNeedUpdate = uvsNeedUpdate;
+		this.elementsNeedUpdate = uvsNeedUpdate;
 	},
 
 	toJSON: function () {

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -955,6 +955,7 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 			this.uvsNeedUpdate = uvsNeedUpdate;
 			this.elementsNeedUpdate = uvsNeedUpdate;
+
 		}
 		
 	},

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -33,6 +33,9 @@ function Geometry() {
 	this.faces = [];
 	this.faceVertexUvs = [ [] ];
 
+	this.primaryUvsIndex = 0;
+	this.secondaryUvsIndex = 1;
+
 	this.morphTargets = [];
 	this.morphNormals = [];
 
@@ -234,7 +237,18 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 		var uvs = attributes.uv !== undefined ? attributes.uv.array : undefined;
 		var uvs2 = attributes.uv2 !== undefined ? attributes.uv2.array : undefined;
 
-		if ( uvs2 !== undefined ) this.faceVertexUvs[ 1 ] = [];
+		if ( uvs !== undefined ) {
+
+			this.primaryUvsIndex = 0;
+
+		}
+
+		if ( uvs2 !== undefined ) {
+
+			this.faceVertexUvs[ 1 ] = [];
+			this.secondaryUvsIndex = 1;
+
+		}
 
 		var tempNormals = [];
 		var tempUVs = [];
@@ -365,7 +379,6 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 	},
 
 	normalize: function () {
-
 		this.computeBoundingSphere();
 
 		var center = this.boundingSphere.center;
@@ -929,6 +942,16 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 		if ( newUvs1 ) this.faceVertexUvs[ 0 ] = newUvs1;
 		if ( newUvs2 ) this.faceVertexUvs[ 1 ] = newUvs2;
 
+	},
+
+	setPrincipalUvsIndices: function( primaryUvsIndex, secondaryUvsIndex ) {
+
+		var uvsNeedUpdate = ( this.primaryUvsIndex !== primaryUvsIndex ) || ( this.secondaryUvsIndex !== secondaryUvsIndex);
+
+		this.primaryUvsIndex = primaryUvsIndex;
+		this.secondaryUvsIndex = secondaryUvsIndex;
+
+		this.uvsNeedUpdate = uvsNeedUpdate;
 	},
 
 	toJSON: function () {

--- a/test/unit/core/Geometry.js
+++ b/test/unit/core/Geometry.js
@@ -89,6 +89,26 @@ test( "normalize", function() {
 	ok( distances[2] === Math.sqrt( 0.5 * 0.5 + 1 ) + distances[1], "distance from the 1st to the 3nd is sqrt(3rd - 2nd) + distance - 1" );
 });
 
+test ( "setPrincipalUvsIndices", function() {
+	var geometry = getGeometry();
+
+	var faceVertexUvs = geometry.faceVertexUvs;
+
+	geometry.uvsNeedUpdate = false;
+
+	geometry.setPrincipalUvsIndices(2, 0);
+
+	ok( geometry.uvsNeedUpdate, "Changed Uvs need update" );
+
+	var directGeometry = new THREE.DirectGeometry().fromGeometry(geometry);
+
+	uv = directGeometry.uvs[0];
+	ok( uv.x ===  2 && uv.y === 0, "DirectGeometry uvs received Geometry.primaryUvsIndex");
+
+	uv = directGeometry.uvs2[0];
+	ok( uv.x ===  0 && uv.y === 0, "DirectGeometry uvs2 received Geometry.secondaryUvsIndex");
+});
+
 function getGeometryByParams( x1, y1, z1, x2, y2, z2, x3, y3, z3 ) {
 	var geometry = new THREE.Geometry();
 
@@ -98,6 +118,26 @@ function getGeometryByParams( x1, y1, z1, x2, y2, z2, x3, y3, z3 ) {
 		new THREE.Vector3( x2, y2, z2 ),
 		new THREE.Vector3( x3, y3, z3 )
 	];
+
+	geometry.faceVertexUvs = [
+		[
+			[new THREE.Vector2( 0, 0 ),
+			 new THREE.Vector2( 0, 1 ),
+			 new THREE.Vector2( 0, 2 )]
+		],
+		[
+			[new THREE.Vector2( 1, 0 ),
+			 new THREE.Vector2( 1, 1 ),
+			 new THREE.Vector2( 1, 2 )]
+		],
+		[
+			[new THREE.Vector2( 2, 0 ),
+			 new THREE.Vector2( 2, 1 ),
+			 new THREE.Vector2( 2, 2 )]
+		],
+	]
+
+	geometry.faces.push( new THREE.Face3( 0, 1, 2 ));
 
 	return geometry;
 }


### PR DESCRIPTION
At render time, Geometry are converted into DirectGeometry. DirecGeometry had hardcoded indices to look up the UV sets from Geometry.
This patch adds two new properties to Geometry and a setter:
- primaryUvsIndex
- secondaryUvsIndex
- setPrincipalUvsIndices( primaryUvsIndex, secondaryUvsIndex )
