### PR TITLE
Allow user to abort all active requests managed by a LoadingManager.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -140,7 +140,7 @@ Object.assign( FileLoader.prototype, {
 
 					if ( onLoad ) onLoad( response );
 
-					scope.manager.itemEnd( url );
+					scope.manager.itemEnd( url, request );
 
 				} else if ( this.status === 0 ) {
 
@@ -151,7 +151,7 @@ Object.assign( FileLoader.prototype, {
 
 					if ( onLoad ) onLoad( response );
 
-					scope.manager.itemEnd( url );
+					scope.manager.itemEnd( url, request );
 
 				} else {
 
@@ -190,7 +190,7 @@ Object.assign( FileLoader.prototype, {
 
 		}
 
-		scope.manager.itemStart( url );
+		scope.manager.itemStart( url, request );
 
 		return request;
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -15,8 +15,6 @@ Object.assign( ImageLoader.prototype, {
 
 	load: function ( url, onLoad, onProgress, onError ) {
 
-		var scope = this;
-
 		var image = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'img' );
 		image.onload = function () {
 
@@ -25,8 +23,6 @@ Object.assign( ImageLoader.prototype, {
 			URL.revokeObjectURL( image.src );
 
 			if ( onLoad ) onLoad( image );
-
-			scope.manager.itemEnd( url );
 
 		};
 		image.onerror = onError;
@@ -37,7 +33,7 @@ Object.assign( ImageLoader.prototype, {
 
 		} else {
 
-			var loader = new FileLoader();
+			var loader = new FileLoader( this.manager );
 			loader.setPath( this.path );
 			loader.setResponseType( 'blob' );
 			loader.setWithCredentials( this.withCredentials );
@@ -48,8 +44,6 @@ Object.assign( ImageLoader.prototype, {
 			}, onProgress, onError );
 
 		}
-
-		scope.manager.itemStart( url );
 
 		return image;
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -6,16 +6,22 @@ function LoadingManager( onLoad, onProgress, onError ) {
 
 	var scope = this;
 
-	var isLoading = false, itemsLoaded = 0, itemsTotal = 0;
+	var isLoading = false, itemsLoaded = 0, itemsTotal = 0, items = [];
 
 	this.onStart = undefined;
 	this.onLoad = onLoad;
 	this.onProgress = onProgress;
 	this.onError = onError;
 
-	this.itemStart = function ( url ) {
+	this.itemStart = function ( url, item ) {
 
 		itemsTotal ++;
+
+		if ( item ) {
+
+			items.push( item );
+
+		}
 
 		if ( isLoading === false ) {
 
@@ -31,9 +37,20 @@ function LoadingManager( onLoad, onProgress, onError ) {
 
 	};
 
-	this.itemEnd = function ( url ) {
+	this.itemEnd = function ( url, item ) {
 
 		itemsLoaded ++;
+
+		if ( item ) {
+
+			var index = items.indexOf( item );
+			if ( index >= 0 ) {
+
+				items.splice( index, 1 );
+
+			}
+
+		}
 
 		if ( scope.onProgress !== undefined ) {
 
@@ -62,6 +79,18 @@ function LoadingManager( onLoad, onProgress, onError ) {
 			scope.onError( url );
 
 		}
+
+	};
+
+	this.abortAll = function () {
+
+		for ( var i = 0; i < items.length; i ++ ) {
+
+			items[ i ].abort();
+
+		}
+
+		items = [];
 
 	};
 


### PR DESCRIPTION
I needed this functionality and I think others will find it useful too. The possibility to abort can also be implemented just for a request ( The active request of a Loader). To accomplish this I was thinking about keeping a reference to the current XMLHttpRequest.

Here is an example with React:

```
class Example extends React.Component {

    constructor(props) {

        super(props);
        this.loadingManager = new THREE.LoadingManager();
        var texloader = new THREE.TextureLoader(this.loadingManager);
        // load textures

    }
    componentWillUnmount(){

        this.loadingManager.abortAllActiveRequests();

    }
}
```
