### PR TITLE
ViveController: tracking events

### DIFF
--- a/examples/js/ViveController.js
+++ b/examples/js/ViveController.js
@@ -84,7 +84,6 @@ THREE.ViveController = function ( id ) {
 
 		if (isTracking !== oldTracking) {
 
-			scope.dispatchEvent( { type: 'trackingchanged' } );
 			scope.dispatchEvent( { type: isTracking ? 'trackingstart' : 'trackingend' } );
 
 		}


### PR DESCRIPTION
Added trackingstart andtrackingend events for controller tracking gained/loss. Added isTracking internal state and turn off controller visibility when tracking is lost. Button updates still occur if possible even when tracking is lost.

Disclaimer: I will not be able to actually TEST these changes until I am back at work. So maybe don't merge yet, or verify the changes work as intended first, before merging.
