### PR TITLE
add offset to Matrix4.fromArray for consistency with all other fromArray functions

### DIFF
--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -274,7 +274,13 @@ Matrix3.prototype = {
 
 	fromArray: function ( array ) {
 
-		this.elements.set( array );
+		if ( offset === undefined ) offset = 0;
+
+		for( var i = 0; i < 9; i ++ ) {
+
+			this.elements[ i ] = array[ i + offset ];
+
+		}
 
 		return this;
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -936,7 +936,7 @@ Matrix4.prototype = {
 
 	fromArray: function ( array, offset ) {
 
-		if ( offset === undefined ) offset = 0;	
+		if ( offset === undefined ) offset = 0;
 
 		for( var i = 0; i < 16; i ++ ) {
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -934,9 +934,15 @@ Matrix4.prototype = {
 
 	},
 
-	fromArray: function ( array ) {
+	fromArray: function ( array, offset ) {
 
-		this.elements.set( array );
+		if ( offset === undefined ) offset = 0;	
+
+		for( var i = 0; i < 16; i ++ ) {
+
+			this.elements[ i ] = array[ i + offset ];
+
+		}
 
 		return this;
 


### PR DESCRIPTION
We noticed here at Exocortex/Clara.io that the Matrix4 fromArray function didn't allow one to specify offsets.  This is very useful functionality when Matrix4s are packed into an ArrayBuffer for things like transfering of bone data from a binary file format.
