### PR TITLE
Google Closure Compiler Js

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "rollup -c",
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar utils/build/compiler/closure-compiler-v20160713.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
-    "build-closure-js": "node utils/build/closure-build",
+    "build-closure-js": "rollup -c && node utils/build/closure-build",
     "dev": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build": "rollup -c",
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar utils/build/compiler/closure-compiler-v20160713.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
+    "build-closure-js": "node utils/build/closure-build",
     "dev": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -44,6 +45,7 @@
   "homepage": "http://threejs.org/",
   "devDependencies": {
     "argparse": "^1.0.3",
+    "google-closure-compiler-js": "^20160828.0.0",
     "jscs": "^1.13.1",
     "rollup": "^0.34.8",
     "rollup-watch": "^2.5.0",

--- a/utils/build/closure-build.js
+++ b/utils/build/closure-build.js
@@ -1,0 +1,21 @@
+const compile = require('google-closure-compiler-js').compile;
+const fs = require('fs');
+
+function read(filename) {
+	return fs.readFileSync(filename, { encoding: 'utf-8' });
+}
+
+const flags = {
+	jsCode: [{src: read('build/three.js')}],
+	warningLevel: 'VERBOSE',
+	languageIn: 'ECMASCRIPT5_STRICT',
+	languageOut: 'ECMASCRIPT5',
+	compilationLevel: 'ADVANCED',
+	externs: [{src: read('utils/build/externs.js')}]
+};
+
+console.time('compile');
+const out = compile(flags);
+console.timeEnd('compile');
+
+fs.writeFileSync('build/three.min.js', out.compiledCode);

--- a/utils/build/closure-build.js
+++ b/utils/build/closure-build.js
@@ -6,16 +6,13 @@ function read(filename) {
 }
 
 const flags = {
+	// externs: [{src: read('utils/build/externs.js')}],
 	jsCode: [{src: read('build/three.js')}],
 	warningLevel: 'VERBOSE',
-	languageIn: 'ECMASCRIPT5_STRICT',
+	languageIn: 'ECMASCRIPT5',
 	languageOut: 'ECMASCRIPT5',
-	compilationLevel: 'ADVANCED',
-	externs: [{src: read('utils/build/externs.js')}]
+	compilationLevel: 'ADVANCED'
 };
 
-console.time('compile');
 const out = compile(flags);
-console.timeEnd('compile');
-
 fs.writeFileSync('build/three.min.js', out.compiledCode);


### PR DESCRIPTION
Just for the [fun](https://github.com/mrdoob/three.js/pull/9548#issuecomment-242158896) of using [google closure compiler in pure js](https://github.com/google/closure-compiler-js), to build, run

``` sh
npm run build-closure-js
```

Not sure why, but this generates larger builds. If I add externs option, all the variables in THREE namespace gets mangled too :(

cc @gero3 @bhouston 
