### PR TITLE
Handle line continuation character in OBJs

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -415,6 +415,13 @@ THREE.OBJLoader.prototype = {
 			text = text.replace( /\r\n/g, '\n' );
 
 		}
+		
+		if ( text.indexOf( '\\\n' ) !== - 1) {
+
+			// join lines separated by a line continuation character (\)
+			text = text.replace( /\\\n/g, '' );
+
+		}
 
 		var lines = text.split( '\n' );
 		var line = '', lineFirstChar = '', lineSecondChar = '';


### PR DESCRIPTION
This targets separate but logically joined lines (separated by a continuation character, e.g. `\`) and joins them.

This does not, however, strip out extra whitespace on either side of the continuation character, which is okay, since the line regex patterns handle multiple whitespace characters. It's better/safer to have extra whitespace chars than to accidentally remove too many.

---

Line continuation characters occur when some exporters break lines early for `max-width` purposes (Rhino does this, I believe), or for formatting reasons (e.g. a `bmat` line that aligns matrix elements into 4 columns).
## Example:

``` obj
v 1 1 \
 -1
```

will be transformed into and interpreted as: 

``` obj
v 1 1  -1
```

---
## Resources

The continuation character is mentioned on the [Wavefront OBJ File Format Summary](http://www.fileformat.info/format/wavefrontobj/egff.htm), and is demonstrated on [Paul Bourke's page on OBJs](http://paulbourke.net/dataformats/obj/)
