### PR TITLE
StereoCamera: Fix distortion when zoom is not equal to one.

### DIFF
--- a/src/cameras/StereoCamera.js
+++ b/src/cameras/StereoCamera.js
@@ -53,7 +53,7 @@ Object.assign( StereoCamera.prototype, {
 				var projectionMatrix = camera.projectionMatrix.clone();
 				var eyeSep = this.eyeSep / 2;
 				var eyeSepOnProjection = eyeSep * near / focus;
-				var ymax = near * Math.tan( _Math.DEG2RAD * fov * 0.5 );
+				var ymax = near * Math.tan( _Math.DEG2RAD * fov * 0.5 ) / camera.zoom;
 				var xmin, xmax;
 
 				// translate xOffset

--- a/src/cameras/StereoCamera.js
+++ b/src/cameras/StereoCamera.js
@@ -53,7 +53,7 @@ Object.assign( StereoCamera.prototype, {
 				var projectionMatrix = camera.projectionMatrix.clone();
 				var eyeSep = this.eyeSep / 2;
 				var eyeSepOnProjection = eyeSep * near / focus;
-				var ymax = near * Math.tan( _Math.DEG2RAD * fov * 0.5 ) / camera.zoom;
+				var ymax = ( near * Math.tan( _Math.DEG2RAD * fov * 0.5 ) ) / camera.zoom;
 				var xmin, xmax;
 
 				// translate xOffset

--- a/src/cameras/StereoCamera.js
+++ b/src/cameras/StereoCamera.js
@@ -28,7 +28,7 @@ Object.assign( StereoCamera.prototype, {
 
 	update: ( function () {
 
-		var focus, fov, aspect, near, far;
+		var focus, fov, aspect, near, far, zoom;
 
 		var eyeRight = new Matrix4();
 		var eyeLeft = new Matrix4();
@@ -37,7 +37,7 @@ Object.assign( StereoCamera.prototype, {
 
 			var needsUpdate = focus !== camera.focus || fov !== camera.fov ||
 												aspect !== camera.aspect * this.aspect || near !== camera.near ||
-												far !== camera.far;
+												far !== camera.far || zoom !== camera.zoom;
 
 			if ( needsUpdate ) {
 
@@ -46,6 +46,7 @@ Object.assign( StereoCamera.prototype, {
 				aspect = camera.aspect * this.aspect;
 				near = camera.near;
 				far = camera.far;
+				zoom = camera.zoom;
 
 				// Off-axis stereoscopic effect based on
 				// http://paulbourke.net/stereographics/stereorender/
@@ -53,7 +54,7 @@ Object.assign( StereoCamera.prototype, {
 				var projectionMatrix = camera.projectionMatrix.clone();
 				var eyeSep = this.eyeSep / 2;
 				var eyeSepOnProjection = eyeSep * near / focus;
-				var ymax = ( near * Math.tan( _Math.DEG2RAD * fov * 0.5 ) ) / camera.zoom;
+				var ymax = ( near * Math.tan( _Math.DEG2RAD * fov * 0.5 ) ) / zoom;
 				var xmin, xmax;
 
 				// translate xOffset


### PR DESCRIPTION
Fixes StereoCamera.update(camera) does not take the camera.zoom into consideration when new projection matrix for left and right camera is calculated.
