### PR TITLE
Modified output of Line.raycast and Points.raycast. Updated docs for RayCaster.

### DIFF
--- a/docs/api/core/Raycaster.html
+++ b/docs/api/core/Raycaster.html
@@ -144,7 +144,7 @@
         [page:Vector3 point] – point of intersection, in world coordinates<br />
         [page:Face3 face] – intersected face. This will be *null* when intersecting [page:Line] and [page:Points].<br />
         [page:Integer faceIndex] – index of the intersected face. Will be *null* when intersecting [page:Line] and [page:Points].<br />
-        [page:Array indices] – array of indices of vertices comprising the intersected face. When intersecting [page:Line] or [page:Points], the array will contain a single index of the intersected vertex.<br />
+        [page:Array indices] – indices of vertices comprising the intersected face. When intersecting [page:Line] or [page:Points], the array will contain a single index of the intersected vertex.<br />
         [page:Object3D object] – the intersected object<br />
         [page:Vector2 uv] - U,V coordinates at point of intersection. Not set when intersecting [page:Line] or [page:Points].
     	</p>

--- a/docs/api/core/Raycaster.html
+++ b/docs/api/core/Raycaster.html
@@ -140,12 +140,13 @@
         </code>
         <p>
         [page:Float distance] – distance between the origin of the ray and the intersection<br />
+        [page:Float distanceToRay] - Shortest distance between the object and the ray. Set when intersecting one-dimensional objects like [page:Line] and [page:Points].<br />
         [page:Vector3 point] – point of intersection, in world coordinates<br />
-        [page:Face3 face] – intersected face<br />
-        [page:Integer faceIndex] – index of the intersected face<br />
-        [page:Array indices] – indices of vertices comprising the intersected face<br />
+        [page:Face3 face] – intersected face. This will be *null* when intersecting [page:Line] and [page:Points].<br />
+        [page:Integer faceIndex] – index of the intersected face. Will be *null* when intersecting [page:Line] and [page:Points].<br />
+        [page:Array indices] – array of indices of vertices comprising the intersected face. When intersecting [page:Line] or [page:Points], the array will contain a single index of the intersected vertex.<br />
         [page:Object3D object] – the intersected object<br />
-        [page:Vector2 uv] - U,V coordinates at point of intersection
+        [page:Vector2 uv] - U,V coordinates at point of intersection. Not set when intersecting [page:Line] or [page:Points].
     	</p>
         <p>
         When intersecting a [page:Mesh] with a [page:BufferGeometry], the *faceIndex* will be *undefined*, and *indices* will be set; when intersecting a [page:Mesh] with a [page:Geometry], *indices* will be *undefined*. 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -100,10 +100,11 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 						intersects.push( {
 
 							distance: distance,
+                            distanceToRay: Math.sqrt( distSq ),
 							// What do we want? intersection point on the ray or on the segment??
 							// point: raycaster.ray.at( distance ),
 							point: interSegment.clone().applyMatrix4( this.matrixWorld ),
-							index: i,
+							indices: [ i ],
 							face: null,
 							faceIndex: null,
 							object: this
@@ -166,10 +167,11 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 					intersects.push( {
 
 						distance: distance,
+                        distanceToRay: Math.sqrt( distSq ),
 						// What do we want? intersection point on the ray or on the segment??
 						// point: raycaster.ray.at( distance ),
 						point: interSegment.clone().applyMatrix4( this.matrixWorld ),
-						index: i,
+						indices: [ i ],
 						face: null,
 						faceIndex: null,
 						object: this

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -100,7 +100,7 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 						intersects.push( {
 
 							distance: distance,
-                            distanceToRay: Math.sqrt( distSq ),
+                            				distanceToRay: Math.sqrt( distSq ),
 							// What do we want? intersection point on the ray or on the segment??
 							// point: raycaster.ray.at( distance ),
 							point: interSegment.clone().applyMatrix4( this.matrixWorld ),
@@ -133,6 +133,7 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 						intersects.push( {
 
 							distance: distance,
+                            				distanceToRay: Math.sqrt( distSq ),
 							// What do we want? intersection point on the ray or on the segment??
 							// point: raycaster.ray.at( distance ),
 							point: interSegment.clone().applyMatrix4( this.matrixWorld ),
@@ -167,7 +168,7 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 					intersects.push( {
 
 						distance: distance,
-                        distanceToRay: Math.sqrt( distSq ),
+		                        	distanceToRay: Math.sqrt( distSq ),
 						// What do we want? intersection point on the ray or on the segment??
 						// point: raycaster.ray.at( distance ),
 						point: interSegment.clone().applyMatrix4( this.matrixWorld ),

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -76,9 +76,10 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 						distance: distance,
 						distanceToRay: Math.sqrt( rayPointDistanceSq ),
 						point: intersectPoint.clone(),
-						index: index,
+						indices: [ index ],
 						face: null,
-						object: object
+						object: object,
+                        faceIndex: null,
 
 					} );
 


### PR DESCRIPTION
Made the return value of `Line.raycast()` and `Points.raycast()` include `indices` array with a single vertex index, instead of scalar `index`. Included `distanceToRay` in the same return value for `Line.raycast()`. Updated docs for `RayCaster.intersectObject()` to reflect the changes.
