### PR TITLE
Add TTFLoader (using opentype)

### DIFF
--- a/examples/js/loaders/TTFLoader.js
+++ b/examples/js/loaders/TTFLoader.js
@@ -1,0 +1,175 @@
+/**
+ * @author gero3 / https://github.com/gero3
+ * Requires opentype.js to be included in the project
+ * Loads TTF files and converts them into typeface JSON that can be used directly to create THREE.Font objects 
+ */
+
+"use strict";
+
+function THREE.TTFLoader(manager)
+{
+	this.manager = (manager !== undefined) ? manager : THREE.DefaultLoadingManager;
+	this.reversed = false;
+}
+
+THREE.TTFLoader.prototype.load = function(url, onLoad, onProgress, onError)
+{
+	var self = this;
+	var loader = new THREE.XHRLoader(this.manager);
+	loader.setResponseType("arraybuffer");
+	loader.load(url, function(buffer)
+	{
+		var json = scope.parse( buffer );
+		if(onLoad !== undefined)
+		{
+			onLoad(json);
+		}
+	}, onProgress, onError);
+}
+
+THREE.TTFLoader.prototype.parse = function(arraybuffer)
+{
+	var font = opentype.parse(arraybuffer);
+	return THREE.TTFLoader.convert(font, this.reversed);
+}
+
+THREE.TTFLoader.convert = function(font, reversed)
+{
+	var scale = (1000 * 100) / ((font.unitsPerEm || 2048) * 72);
+	var result = {};
+	result.glyphs = {};
+
+	font.glyphs.forEach(function(glyph)
+	{
+		if(glyph.unicode !== undefined)
+		{
+			var token = {};
+			token.ha = Math.round(glyph.advanceWidth * scale);
+			token.x_min = Math.round(glyph.xMin * scale);
+			token.x_max = Math.round(glyph.xMax * scale);
+			token.o = ""
+			
+			if(reversed)
+			{
+				glyph.path.commands = THREE.TTFLoader.reverseCommands(glyph.path.commands);
+			}
+
+			glyph.path.commands.forEach(function(command, i)
+			{
+				if(command.type.toLowerCase() === "c")
+				{
+					command.type = "b";
+				}
+				
+				token.o += command.type.toLowerCase();
+				token.o += " "
+				
+				if(command.x !== undefined && command.y !== undefined){
+					token.o += Math.round(command.x * scale);
+					token.o += " "
+					token.o += Math.round(command.y * scale);
+					token.o += " "
+				}
+				if(command.x1 !== undefined && command.y1 !== undefined)
+				{
+					token.o += Math.round(command.x1 * scale);
+					token.o += " "
+					token.o += Math.round(command.y1 * scale);
+					token.o += " "
+				}
+				if(command.x2 !== undefined && command.y2 !== undefined)
+				{
+					token.o += Math.round(command.x2 * scale);
+					token.o += " "
+					token.o += Math.round(command.y2 * scale);
+					token.o += " "
+				}
+			});
+			result.glyphs[String.fromCharCode(glyph.unicode)] = token;
+		}
+	});
+
+	result.familyName = font.familyName;
+	result.ascender = Math.round(font.ascender * scale);
+	result.descender = Math.round(font.descender * scale);
+	result.underlinePosition = font.tables.post.underlinePosition;
+	result.underlineThickness = font.tables.post.underlineThickness;
+	result.boundingBox =
+	{
+		"yMin": font.tables.head.yMin,
+		"xMin": font.tables.head.xMin,
+		"yMax": font.tables.head.yMax,
+		"xMax": font.tables.head.xMax
+	};
+
+	result.resolution = 1000;
+	result.original_font_information = font.tables.name;
+	if(font.styleName.toLowerCase().indexOf("bold") > -1)
+	{
+		result.cssFontWeight = "bold";
+	}
+	else
+	{
+		result.cssFontWeight = "normal";
+	}
+
+	if(font.styleName.toLowerCase().indexOf("italic") > -1)
+	{
+		result.cssFontStyle = "italic";
+	}
+	else
+	{
+		result.cssFontStyle = "normal";
+	}
+
+	return result;
+}
+
+THREE.TTFLoader.reverseCommands = function(commands)
+{
+	var paths = [];
+	var path;
+	
+	commands.forEach(function(c)
+	{
+		if(c.type.toLowerCase() === "m")
+		{
+			path = [c];
+			paths.push(path);
+		}
+		else if(c.type.toLowerCase() !== "z")
+		{
+			path.push(c);
+		}
+	});
+	
+	var reversed = [];
+	paths.forEach(function(p)
+	{
+		var result = {"type":"m" , "x" : p[p.length-1].x, "y": p[p.length-1].y};
+		reversed.push(result);
+		
+		for(var i = p.length - 1; i > 0; i--)
+		{
+			var command = p[i];
+			result = {"type":command.type};
+			if(command.x2 !== undefined && command.y2 !== undefined)
+			{
+				result.x1 = command.x2;
+				result.y1 = command.y2;
+				result.x2 = command.x1;
+				result.y2 = command.y1;
+			}
+			else if(command.x1 !== undefined && command.y1 !== undefined)
+			{
+				result.x1 = command.x1;
+				result.y1 = command.y1;
+			}
+			result.x =  p[i-1].x;
+			result.y =  p[i-1].y;
+			reversed.push(result);
+		}
+	});
+	
+	return reversed;	
+}

--- a/examples/js/loaders/TTFLoader.js
+++ b/examples/js/loaders/TTFLoader.js
@@ -35,7 +35,7 @@ THREE.TTFLoader.prototype.parse = function(arraybuffer)
 
 THREE.TTFLoader.convert = function(font, reversed)
 {
-	if(typeof opentype === undefined)
+	if(opentype === undefined)
 	{
 		throw new Error("TTFLoader requires opentype.js Make sure it\'s included before using the loader");
 		return;

--- a/examples/js/loaders/TTFLoader.js
+++ b/examples/js/loaders/TTFLoader.js
@@ -35,6 +35,12 @@ THREE.TTFLoader.prototype.parse = function(arraybuffer)
 
 THREE.TTFLoader.convert = function(font, reversed)
 {
+	if(typeof opentype === undefined)
+	{
+		throw new Error("TTFLoader requires opentype.js Make sure it\'s included before using the loader");
+		return;
+	}
+
 	var scale = (1000 * 100) / ((font.unitsPerEm || 2048) * 72);
 	var result = {};
 	result.glyphs = {};


### PR DESCRIPTION
Hi

This PR adds a true type font loader to examples/js/loaders/TTFLoader.js, it requires opentype to be included in the project where is being used.

The loader is based on @gero3 code on facetype.js so all credit goes to him on this
