### PR TITLE
#9663: Fix radius bug in CylinderBufferGeometry

### DIFF
--- a/src/extras/geometries/CylinderBufferGeometry.js
+++ b/src/extras/geometries/CylinderBufferGeometry.js
@@ -153,7 +153,7 @@ function CylinderBufferGeometry( radiusTop, radiusBottom, height, radialSegments
 
 				// handle special case if radiusTop/radiusBottom is zero
 
-				if ( ( radiusTop === 0 && y === 0 ) || ( radiusBottom === 0 && y === heightSegments ) ) {
+				if ( ( radiusTop < Number.EPSILON && y === 0 ) || ( radiusBottom < Number.EPSILON && y === heightSegments ) ) {
 
 					normal.x = Math.sin( u * thetaLength + thetaStart );
 					normal.z = Math.cos( u * thetaLength + thetaStart );

--- a/src/extras/geometries/CylinderBufferGeometry.js
+++ b/src/extras/geometries/CylinderBufferGeometry.js
@@ -149,18 +149,10 @@ function CylinderBufferGeometry( radiusTop, radiusBottom, height, radialSegments
 				vertices.setXYZ( index, vertex.x, vertex.y, vertex.z );
 
 				// normal
-				normal.copy( vertex );
-
-				// handle special case if radiusTop/radiusBottom is zero
-
-				if ( ( radiusTop < Number.EPSILON && y === 0 ) || ( radiusBottom < Number.EPSILON && y === heightSegments ) ) {
-
-					normal.x = Math.sin( u * thetaLength + thetaStart );
-					normal.z = Math.cos( u * thetaLength + thetaStart );
-
-				}
-
-				normal.setY( Math.sqrt( normal.x * normal.x + normal.z * normal.z ) * tanTheta ).normalize();
+				normal.x = Math.sin( u * thetaLength + thetaStart );
+				normal.z = Math.cos( u * thetaLength + thetaStart );
+				normal.y = Math.sqrt( normal.x * normal.x + normal.z * normal.z ) * tanTheta;
+				normal.normalize();
 				normals.setXYZ( index, normal.x, normal.y, normal.z );
 
 				// uv

--- a/src/extras/geometries/CylinderBufferGeometry.js
+++ b/src/extras/geometries/CylinderBufferGeometry.js
@@ -142,17 +142,19 @@ function CylinderBufferGeometry( radiusTop, radiusBottom, height, radialSegments
 
 				var u = x / radialSegments;
 
+				var theta = u * thetaLength + thetaStart;
+
+				var sinTheta = Math.sin( theta );
+				var cosTheta = Math.cos( theta );
+
 				// vertex
-				vertex.x = radius * Math.sin( u * thetaLength + thetaStart );
+				vertex.x = radius * sinTheta;
 				vertex.y = - v * height + halfHeight;
-				vertex.z = radius * Math.cos( u * thetaLength + thetaStart );
+				vertex.z = radius * cosTheta;
 				vertices.setXYZ( index, vertex.x, vertex.y, vertex.z );
 
 				// normal
-				normal.x = Math.sin( u * thetaLength + thetaStart );
-				normal.z = Math.cos( u * thetaLength + thetaStart );
-				normal.y = Math.sqrt( normal.x * normal.x + normal.z * normal.z ) * tanTheta;
-				normal.normalize();
+				normal.set( sinTheta, tanTheta, cosTheta ).normalize();
 				normals.setXYZ( index, normal.x, normal.y, normal.z );
 
 				// uv

--- a/src/extras/geometries/CylinderBufferGeometry.js
+++ b/src/extras/geometries/CylinderBufferGeometry.js
@@ -125,7 +125,7 @@ function CylinderBufferGeometry( radiusTop, radiusBottom, height, radialSegments
 		var groupCount = 0;
 
 		// this will be used to calculate the normal
-		var tanTheta = ( radiusBottom - radiusTop ) / height;
+		var slope = ( radiusBottom - radiusTop ) / height;
 
 		// generate vertices, normals and uvs
 
@@ -154,7 +154,7 @@ function CylinderBufferGeometry( radiusTop, radiusBottom, height, radialSegments
 				vertices.setXYZ( index, vertex.x, vertex.y, vertex.z );
 
 				// normal
-				normal.set( sinTheta, tanTheta, cosTheta ).normalize();
+				normal.set( sinTheta, slope, cosTheta ).normalize();
 				normals.setXYZ( index, normal.x, normal.y, normal.z );
 
 				// uv


### PR DESCRIPTION
See #9663.

The zero comparison does not work in some special cases with radius values very close to zero. Instead we now using a tolerance value (Number.EPSILON). 
