### PR TITLE
Fix for empty Box3.size() returning (-∞, -∞, -∞) instead of (0, 0, 0)

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -213,7 +213,7 @@ Box3.prototype = {
 		var result = optionalTarget || new Vector3();
 		// If the Box3 has been set to 'empty', a subtraction will result in a wrong
 		// result: (-Infinity, -Infinity, -Infinity) instead of the correct (0, 0, 0)
-		if(equals(this.min, Infinity) && equals(this.max, -Infinity)) {
+		if( equals(this.min, Infinity) && equals(this.max, -Infinity) ) {
 			return new Vector3();
 		}
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -211,6 +211,12 @@ Box3.prototype = {
 	size: function ( optionalTarget ) {
 
 		var result = optionalTarget || new Vector3();
+		// If the Box3 has been set to 'empty', a subtraction will result in a wrong
+		// result: (-Infinity, -Infinity, -Infinity) instead of the correct (0, 0, 0)
+		if(equals(this.min, Infinity) && equals(this.max, -Infinity)) {
+			return new Vector3();
+		}
+
 		return result.subVectors( this.max, this.min );
 
 	},
@@ -477,5 +483,11 @@ Box3.prototype = {
 
 };
 
+
+function equals(vec, value) {
+
+	return (vec.x === value) && (vec.y === value) && (vec.z === value);
+
+}
 
 export { Box3 };

--- a/test/unit/math/Box3.js
+++ b/test/unit/math/Box3.js
@@ -85,7 +85,6 @@ test( "size", function() {
 	ok( a.size().equals( one3 ), "Passed!" );
 
 	a = new THREE.Box3();
-	console.log(new THREE.Box3().size());
 	ok( a.size().equals( zero3 ), "The size of a newly created Box3 should be (0, 0, 0)" );
 });
 

--- a/test/unit/math/Box3.js
+++ b/test/unit/math/Box3.js
@@ -83,6 +83,10 @@ test( "size", function() {
 
 	a = new THREE.Box3( zero3.clone(), one3.clone() );
 	ok( a.size().equals( one3 ), "Passed!" );
+
+	a = new THREE.Box3();
+	console.log(new THREE.Box3().size());
+	ok( a.size().equals( zero3 ), "The size of a newly created Box3 should be (0, 0, 0)" );
 });
 
 test( "expandByPoint", function() {

--- a/test/unit/unittests_three-math.html
+++ b/test/unit/unittests_three-math.html
@@ -13,7 +13,7 @@
 
   <!-- add sources to test below -->
 
-  <script src="../../build/three-math.js"></script>
+  <script src="../../build/three.js"></script>
 
   <!-- add class-based unit tests below -->
 


### PR DESCRIPTION
Newly created Box3 objects have their `min` and `max` properties set to (∞, ∞, ∞) and (-∞, -∞, -∞) respectively. This is convenient but results in wrong results when running `size()` on the object. Instead of returning (0, 0, 0) it returns (-∞, -∞, -∞).

This patch fixes this.

I've also added a new test to the `-math` suite.
