### PR TITLE
getElapsedTime() in TREE.Clock returns whole running time and not elapsed time from previous start.

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -30,6 +30,7 @@ Clock.prototype = {
 	stop: function () {
 
 		this.getElapsedTime();
+		this.elapsedTime = 0;
 		this.running = false;
 
 	},

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -23,6 +23,7 @@ Clock.prototype = {
 		this.startTime = ( performance || Date ).now();
 
 		this.oldTime = this.startTime;
+		this.elapsedTime = 0;
 		this.running = true;
 
 	},
@@ -30,7 +31,6 @@ Clock.prototype = {
 	stop: function () {
 
 		this.getElapsedTime();
-		this.elapsedTime = 0;
 		this.running = false;
 
 	},


### PR DESCRIPTION
getElapsedTime() function returns incorrect value after stop() and start(), It returns whole working/running time from first run.
I adde this.elapsedTime = 0 inside stop() function after this.getElapsedTime() line, so after next start() we can get correct elapsed time from last start()

Perhaps it's incorrect and this suggestion need new function, so Clock.js will have two functions:
- first one will return whole running time (as it is now)
- second will return elapsed time from last start
