### PR TITLE
VREffect: unset the rendertarget before clear

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -281,6 +281,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			} else  {
 
+				renderer.setRenderTarget( null );
 				renderer.setScissorTest( true );
 
 			}


### PR DESCRIPTION
This will unset the current rendertarget of the renderer if no rendertarget is specified to the `VREffect.render()`-call.

I spent quite a lot of time yesterday to figure out why my rendertarget-texture disappeared when rendering with VREffect (turned out, I needed to manually unbind the renderTarget before calling `vreffect.render()`). 

I think the proposed behaviour would make more sense now that a renderTarget can be specified to the VREffect and makes this function behave more like `WebGlRenderer.render()`.
