### PR TITLE
Fix for wireframe rendering (issue 8729)

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -777,10 +777,12 @@ function WebGLRenderer( parameters ) {
 
 		var index = geometry.index;
 		var position = geometry.attributes.position;
+		var rangeFactor = 1;
 
 		if ( material.wireframe === true ) {
 
 			index = objects.getWireframeAttribute( geometry );
+			rangeFactor = 2;
 
 		}
 
@@ -811,7 +813,6 @@ function WebGLRenderer( parameters ) {
 
 		//
 
-		var dataStart = 0;
 		var dataCount = 0;
 
 		if ( index !== null ) {
@@ -830,8 +831,8 @@ function WebGLRenderer( parameters ) {
 		var groupStart = group !== null ? group.start : 0;
 		var groupCount = group !== null ? group.count : Infinity;
 
-		var drawStart = Math.max( dataStart, rangeStart, groupStart );
-		var drawEnd = Math.min( dataStart + dataCount, rangeStart + rangeCount, groupStart + groupCount ) - 1;
+		var drawStart = Math.max( rangeStart, groupStart ) * rangeFactor;
+		var drawEnd = ( Math.min( dataCount, rangeStart + rangeCount, groupStart + groupCount ) - 1 ) * rangeFactor;
 
 		var drawCount = Math.max( 0, drawEnd - drawStart + 1 );
 

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -157,9 +157,7 @@ function WebGLObjects( gl, properties, info ) {
 				var b = array[ i + 1 ];
 				var c = array[ i + 2 ];
 
-				if ( checkEdge( edges, a, b ) ) indices.push( a, b );
-				if ( checkEdge( edges, b, c ) ) indices.push( b, c );
-				if ( checkEdge( edges, c, a ) ) indices.push( c, a );
+				indices.push( a, b, b, c, c, a );
 
 			}
 
@@ -189,34 +187,6 @@ function WebGLObjects( gl, properties, info ) {
 		property.wireframe = attribute;
 
 		return attribute;
-
-	}
-
-	function checkEdge( edges, a, b ) {
-
-		if ( a > b ) {
-
-			var tmp = a;
-			a = b;
-			b = tmp;
-
-		}
-
-		var list = edges[ a ];
-
-		if ( list === undefined ) {
-
-			edges[ a ] = [ b ];
-			return true;
-
-		} else if ( list.indexOf( b ) === -1 ) {
-
-			list.push( b );
-			return true;
-
-		}
-
-		return false;
 
 	}
 


### PR DESCRIPTION
This commit fixes wireframe rendering when groups and drawRange are in use.

I removed calls to `checkEdge()` in `getWireframeAttribute()` to ensure that the number of wireframe indices is exactly twice the number of non-wireframe indices. This makes it simple to adjust the group and drawRange start/end indices in `WebGLRenderer`.

https://github.com/mrdoob/three.js/issues/8729
