### PR TITLE
Fixing a typo on ImageLoader

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -30,7 +30,7 @@ Object.assign( ImageLoader.prototype, {
 
 		};
 
-		if ( url.indexOf( 'data:' ) === 0 ) {
+		if ( url.indexOf( 'data:' ) === -1 ) {
 
 			image.src = url;
 


### PR DESCRIPTION
If I understood the logic correctly, you want to use the `Blob` loader only on the `data:` URLs. If that's true, then there is a typo on the `indexOf` check.
