### PR TITLE
Cleanup Example webgl_interactive_instances_gpu

### DIFF
--- a/examples/webgl_interactive_instances_gpu.html
+++ b/examples/webgl_interactive_instances_gpu.html
@@ -151,21 +151,23 @@
 			attribute vec3 pickingColor;
 		#else
 			attribute vec3 color;
+			varying vec3 vPosition;
 		#endif
 
 		varying vec3 vColor;
-		varying vec3 vPosition;
 
 		void main()	{
+
+			vec3 positionEye = ( modelViewMatrix * vec4( position, 1.0 ) ).xyz;
 
 			#ifdef PICKING
 				vColor = pickingColor;
 			#else
 				vColor = color;
+				vPosition = positionEye;
 			#endif
-			vPosition = ( modelViewMatrix * vec4( position, 1.0 ) ).xyz;
 
-			gl_Position = projectionMatrix * vec4( vPosition, 1.0 );
+			gl_Position = projectionMatrix * vec4( positionEye, 1.0 );
 
 		}
 
@@ -179,7 +181,10 @@
 		precision highp float;
 
 		varying vec3 vColor;
-		varying vec3 vPosition;
+
+		#ifndef PICKING
+			varying vec3 vPosition;
+		#endif
 
 		void main()	{
 
@@ -187,9 +192,9 @@
 				gl_FragColor = vec4( vColor, 1.0 );
 			#else
 				vec3 fdx = dFdx( vPosition );
-	            vec3 fdy = dFdy( vPosition );
-	            vec3 normal = normalize( cross( fdx, fdy ) );
-	            float diffuse = dot( normal, vec3( 0.0, 0.0, 1.0 ) );
+				vec3 fdy = dFdy( vPosition );
+				vec3 normal = normalize( cross( fdx, fdy ) );
+				float diffuse = dot( normal, vec3( 0.0, 0.0, 1.0 ) );
 
 				gl_FragColor = vec4( diffuse * vColor, 1.0 );
 			#endif
@@ -207,19 +212,19 @@
 		uniform mat4 projectionMatrix;
 
 		attribute vec3 position;
-		// attribute mat4 matrix;
 		attribute vec3 mcol0;
 		attribute vec3 mcol1;
 		attribute vec3 mcol2;
 		attribute vec3 mcol3;
+
 		#ifdef PICKING
 			attribute vec3 pickingColor;
 		#else
 			attribute vec3 color;
+			varying vec3 vPosition;
 		#endif
 
 		varying vec3 vColor;
-		varying vec3 vPosition;
 
 		void main()	{
 
@@ -230,14 +235,16 @@
 				vec4( mcol3, 1 )
 			);
 
+			vec3 positionEye = ( modelViewMatrix * matrix * vec4( position, 1.0 ) ).xyz;
+
 			#ifdef PICKING
 				vColor = pickingColor;
 			#else
 				vColor = color;
+				vPosition = positionEye;
 			#endif
-			vPosition = ( modelViewMatrix * matrix * vec4( position, 1.0 ) ).xyz;
 
-			gl_Position = projectionMatrix * vec4( vPosition, 1.0 );
+			gl_Position = projectionMatrix * vec4( positionEye, 1.0 );
 
 		}
 
@@ -251,7 +258,10 @@
 		precision highp float;
 
 		varying vec3 vColor;
-		varying vec3 vPosition;
+
+		#ifndef PICKING
+			varying vec3 vPosition;
+		#endif
 
 		void main()	{
 
@@ -259,9 +269,9 @@
 				gl_FragColor = vec4( vColor, 1.0 );
 			#else
 				vec3 fdx = dFdx( vPosition );
-	            vec3 fdy = dFdy( vPosition );
-	            vec3 normal = normalize( cross( fdx, fdy ) );
-	            float diffuse = dot( normal, vec3( 0.0, 0.0, 1.0 ) );
+				vec3 fdy = dFdy( vPosition );
+				vec3 normal = normalize( cross( fdx, fdy ) );
+				float diffuse = dot( normal, vec3( 0.0, 0.0, 1.0 ) );
 
 				gl_FragColor = vec4( diffuse * vColor, 1.0 );
 			#endif
@@ -280,13 +290,19 @@
 
 		attribute vec3 position;
 
-		varying vec3 vPosition;
+		#ifndef PICKING
+			varying vec3 vPosition;
+		#endif
 
 		void main()	{
 
-			vPosition = ( modelViewMatrix * vec4( position, 1.0 ) ).xyz;
+			vec3 positionEye = ( modelViewMatrix * vec4( position, 1.0 ) ).xyz;
 
-			gl_Position = projectionMatrix * vec4( vPosition, 1.0 );
+			#ifndef PICKING
+				vPosition = positionEye;
+			#endif
+
+			gl_Position = projectionMatrix * vec4( positionEye, 1.0 );
 
 		}
 
@@ -303,9 +319,8 @@
 			uniform vec3 pickingColor;
 		#else
 			uniform vec3 color;
+			varying vec3 vPosition;
 		#endif
-
-		varying vec3 vPosition;
 
 		void main()	{
 
@@ -313,9 +328,9 @@
 				gl_FragColor = vec4( pickingColor, 1.0 );
 			#else
 				vec3 fdx = dFdx( vPosition );
-	            vec3 fdy = dFdy( vPosition );
-	            vec3 normal = normalize( cross( fdx, fdy ) );
-	            float diffuse = dot( normal, vec3( 0.0, 0.0, 1.0 ) );
+				vec3 fdy = dFdy( vPosition );
+				vec3 normal = normalize( cross( fdx, fdy ) );
+				float diffuse = dot( normal, vec3( 0.0, 0.0, 1.0 ) );
 
 				gl_FragColor = vec4( diffuse * color, 1.0 );
 			#endif
@@ -486,13 +501,9 @@
 			loader.load( 'obj/Suzanne.js', function ( geo ) {
 
 				geo.computeBoundingBox();
-				geometrySize = geo.boundingBox.size();
+				geometrySize = geo.boundingBox.getSize();
 				geometryList.push( geo );
 
-				console.log( "method:", method );
-				console.log( "instanceCount:", instanceCount );
-
-				console.time( "init mesh" );
 				var start = window.performance.now();
 
 				switch ( method ){
@@ -517,14 +528,7 @@
 
 				render();
 
-				console.timeEnd( "init mesh", method );
 				var end = window.performance.now();
-
-				console.log( "material count:", materialList.length );
-				console.log( "geometry count:", geometryList.length );
-				console.log( "object count:", objectCount );
-				console.log( renderer.info.memory )
-				console.log( renderer.info.render )
 
 				document.getElementById( 'materialCount' ).innerText = materialList.length;
 				document.getElementById( 'objectCount' ).innerText = objectCount;
@@ -971,6 +975,7 @@
 			camera.updateProjectionMatrix();
 
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			pickingRenderTarget.setSize( window.innerWidth, window.innerHeight );
 
 		}
 


### PR DESCRIPTION
- removed all shader program warnings
- fixed resize bug (the example didn't work correctly if you resized the window)
- refactored `Box3.size`
- cleanup console logs
