### PR TITLE
Add default material technique support to glTFLoader.js

### DIFF
--- a/examples/js/loaders/gltf/glTFLoader.js
+++ b/examples/js/loaders/gltf/glTFLoader.js
@@ -982,12 +982,35 @@ THREE.glTFLoader.prototype.load = function( url, callback ) {
 					}
 
 				}
-				else {
-					var technique = material.technique ?
-						this.resources.getEntry(material.technique) :
-						null;
+				else if (material.technique === undefined) {
 
-					values = material.values;
+					materialType = THREE.MeshPhongMaterial;
+
+					if (material.doubleSided)
+					{
+						params.side = THREE.DoubleSide;
+					}
+
+					if (material.transparent)
+					{
+						params.transparent = true;
+					}
+
+					values = {};
+					for (var prop in material.values) {
+						values[prop] = material.values[prop];
+					}
+
+				}
+				else {
+
+					var technique = this.resources.getEntry(material.technique);
+
+					values = {};
+					for (var prop in material.values) {
+						values[prop] = material.values[prop];
+					}
+
 					var description = technique.description;
 
 					if (++description.refCount > 1) {
@@ -1002,6 +1025,7 @@ THREE.glTFLoader.prototype.load = function( url, callback ) {
 					if (loadshaders) {
 						materialType = Material;
 					}
+
 				}
 
 				if (values.diffuse && typeof(values.diffuse) == 'string') {
@@ -1870,16 +1894,16 @@ THREE.glTFLoader.prototype.load = function( url, callback ) {
 
 	var self = this;
 
-	var loader = Object.create(ThreeGLTFLoader);
-	loader.initWithPath(url);
-	loader.load(new Context(rootObj,
+	this.callback = callback;
+	this.rootObj = rootObj;
+
+	this.loader = Object.create(ThreeGLTFLoader);
+	this.loader.initWithPath(url);
+	this.loader.load(new Context(rootObj,
 						function(obj) {
 						}),
 				null);
 
-	this.loader = loader;
-	this.callback = callback;
-	this.rootObj = rootObj;
 	return rootObj;
 }
 


### PR DESCRIPTION
The [glTF specification](https://github.com/KhronosGroup/glTF/tree/master/specification) says the following:

> The technique property is optional; if it is not supplied, and no extension is present that defines material properties, then the object will be rendered using a default material with 50% gray emissive color. See Appendix A.

In [Appendix A](https://github.com/KhronosGroup/glTF/tree/master/specification#appendix-a) of the spec the default material is also discussed.

This PR adds a default material `technique` in the case that one is not supplied in a glTF file.

ping @tparisi for review.
