### PR TITLE
Add compressed texture loading to glTF loader

### DIFF
--- a/examples/js/loaders/gltf/glTFLoader.js
+++ b/examples/js/loaders/gltf/glTFLoader.js
@@ -268,7 +268,13 @@ THREE.glTFLoader.prototype.load = function( url, callback ) {
 			return texture;
 		}
 
-		return new THREE.TextureLoader().load(src);
+		var textureLoader = THREE.Loader.Handlers.get(src);
+		if ( textureLoader === null ) {
+			textureLoader = new THREE.TextureLoader();
+		}
+		textureLoader.crossOrigin = true;
+
+		return textureLoader.load(src);
 	}
 
 	function CreateTexture(resources, resource) {


### PR DESCRIPTION
It is possible to register additional texture loaders with THREE.js and it should be possible to use e.g. *.dds, *.pvr and *.tga image formats within glTF files.

This PR checks to see if a texture loader has been registered with `THREE.Loader.Handlers`. If it finds a match then it will use that loader. Otherwise, it will fallback to using the normal `THREE.TextureLoader` (for standard image formats).

New loaders can be registered with `THREE.Loader.Handlers` as follows. e.g.

``` javascript
// Register additional compressed texture loaders for THREE.js
THREE.Loader.Handlers.add( /\.dds$/i, new THREE.DDSLoader() );
THREE.Loader.Handlers.add( /\.pvr$/i, new THREE.PVRLoader() );
THREE.Loader.Handlers.add( /\.tga$/i, new THREE.TGALoader() );
```
