### PR TITLE
VREffect: handle empty arrays for display bounds

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -111,8 +111,10 @@ THREE.VREffect = function ( renderer, onError ) {
 			var layers = vrDisplay.getLayers();
 			if ( layers.length ) {
 
-				leftBounds = layers[0].leftBounds || [ 0.0, 0.0, 0.5, 1.0 ];
-				rightBounds = layers[0].rightBounds || [ 0.5, 0.0, 0.5, 1.0 ];
+				var layer = layers[0];
+
+				leftBounds = layer.leftBounds !== null && layer.leftBounds.length === 4 ? leftBounds : [ 0.0, 0.0, 0.5, 1.0 ];
+				rightBounds = layer.rightBounds !== null && layer.rightBounds.length === 4 ? rightBounds : [ 0.5, 0.0, 0.5, 1.0 ];
 
 			}
 


### PR DESCRIPTION
The spec has been updated so that `requestPresent` can accept empty arrays for `leftBounds` and `rightBounds`. Though Chromium returns `null` for these properties by default, Firefox returns empty arrays, and there is a proposal to make those non-nullable. This patch should fix rendering for Firefox, which is currently broken.

For reference:
https://github.com/w3c/webvr/issues/95
https://github.com/w3c/webvr/issues/89
