### PR TITLE
Extend glTF Loader API

### DIFF
--- a/docs/api/loaders/glTFLoader.html
+++ b/docs/api/loaders/glTFLoader.html
@@ -20,7 +20,10 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( )</h3>
+		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<div>
+		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
+		</div>
 		<div>
 		Creates a new [name].
 		</div>
@@ -30,13 +33,38 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Object3D load]( [page:String url], [page:Function callback] )</h3>
+		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
 		<div>
 		[page:String url] — required<br />
-		[page:Function callback] — Will be called when load completes. The argument will be an [page:Object] containing the loaded .[page:Object3D scene],  .[page:Array cameras] and .[page:Array animations].<br />
+		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded JSON response returned from [page:Function parse].<br />
+		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
+		[page:Function onError] — Will be called when load errors.<br />
 		</div>
 		<div>
 		Begin loading from url and call the callback function with the parsed response content.
+		</div>
+
+		<h3>[method:null setTexturePath]( [page:String texturePath] )</h3>
+		<div>
+		[page:String texturePath] — Base path for textures.
+		</div>
+		<div>
+		Set the base path for textures.
+		</div>
+
+		<h3>[method:null setCrossOrigin]( [page:String value] )</h3>
+		<div>
+		[page:String value] — The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS.
+		</div>
+
+		<h3>[method:null parse]( [page:Object json], [page:Function callBack], [page:String texturePath] )</h3>
+		<div>
+		[page:Object json] — <em>JSON</em> object to parse.<br />
+		[page:Function callBack] — Will be called when parse completes.<br />
+		[page:String texturePath] — The base path from which to find subsequent texture resources.<br />
+		</div>
+		<div>
+		Parse a glTF-based <em>JSON</em> structure and fire [page:Function callback] when complete. The argument to [page:Function callback] will be an [page:object] that contains loaded parts: .[page:Scene scene], .[page:Array cameras], .[page:Array animations] and .[page:Array shaders]
 		</div>
 
 

--- a/examples/js/loaders/gltf/glTF-parser.js
+++ b/examples/js/loaders/gltf/glTF-parser.js
@@ -102,7 +102,7 @@ var global = window;
 				if (isDataUriRegex.test(path)) {
 					return path;
 				}
-				
+
 				return this.baseURL + path;
 			}
 		},
@@ -273,11 +273,8 @@ var global = window;
 				var self = this;
 				//FIXME: handle error
 				if (!this._json)  {
-					var jsonPath = this._path;
-					var i = jsonPath.lastIndexOf("/");
-					this.baseURL = (i !== 0) ? jsonPath.substring(0, i + 1) : '';
 					var jsonfile = new XMLHttpRequest();
-					jsonfile.open("GET", jsonPath, true);
+					jsonfile.open("GET", this._path, true);
 					jsonfile.onreadystatechange = function() {
 						if (jsonfile.readyState == 4) {
 							if (jsonfile.status == 200) {
@@ -378,8 +375,8 @@ var global = window;
 
 		initWithJSON: {
 			value: function(json, baseURL) {
-				this.json = json;
 				this.baseURL = baseURL;
+				this.json = json;
 				if (!baseURL) {
 					console.log("WARNING: no base URL passed to Reader:initWithJSON");
 				}

--- a/examples/js/loaders/gltf/glTFAnimation.js
+++ b/examples/js/loaders/gltf/glTFAnimation.js
@@ -24,7 +24,7 @@ THREE.glTFAnimator = ( function () {
 
 		update : function()
 		{
-			for (i = 0; i < animators.length; i++)
+			for (var i = 0; i < animators.length; i++)
 			{
 				animators[i].update();
 			}
@@ -40,7 +40,7 @@ THREE.glTFAnimation = function(interps)
 	this.duration = 0;
 	this.startTime = 0;
 	this.interps = [];
-	
+
 	if (interps)
 	{
 		this.createInterpolators(interps);
@@ -63,7 +63,7 @@ THREE.glTFAnimation.prototype.play = function()
 {
 	if (this.running)
 		return;
-	
+
 	this.startTime = Date.now();
 	this.running = true;
 	THREE.glTFAnimator.add(this);
@@ -80,12 +80,12 @@ THREE.glTFAnimation.prototype.update = function()
 {
 	if (!this.running)
 		return;
-	
+
 	var now = Date.now();
 	var deltat = (now - this.startTime) / 1000;
 	var t = deltat % this.duration;
 	var nCycles = Math.floor(deltat / this.duration);
-	
+
 	if (nCycles >= 1 && !this.loop)
 	{
 		this.running = false;
@@ -109,20 +109,20 @@ THREE.glTFAnimation.prototype.update = function()
 
 //Interpolator class
 //Construction/initialization
-THREE.glTFInterpolator = function(param) 
-{	    		
+THREE.glTFInterpolator = function(param)
+{
 	this.keys = param.keys;
 	this.values = param.values;
 	this.count = param.count;
 	this.type = param.type;
 	this.path = param.path;
 	this.isRot = false;
-	
+
 	var node = param.target;
 	node.updateMatrix();
 	node.matrixAutoUpdate = true;
 	this.targetNode = node;
-	
+
 	switch (param.path) {
 		case "translation" :
 			this.target = node.position;
@@ -138,9 +138,9 @@ THREE.glTFInterpolator = function(param)
 			this.originalValue = node.scale.clone();
 			break;
 	}
-	
+
 	this.duration = this.keys[this.count - 1];
-	
+
 	this.vec1 = new THREE.Vector3;
 	this.vec2 = new THREE.Vector3;
 	this.vec3 = new THREE.Vector3;
@@ -189,13 +189,13 @@ THREE.glTFInterpolator.prototype.interp = function(t)
 	else if (t >= this.keys[this.count - 1])
 	{
 		if (this.isRot) {
-			this.quat3.set(this.values[(this.count - 1) * 4], 
+			this.quat3.set(this.values[(this.count - 1) * 4],
 					this.values[(this.count - 1) * 4 + 1],
 					this.values[(this.count - 1) * 4 + 2],
 					this.values[(this.count - 1) * 4 + 3]);
 		}
 		else {
-			this.vec3.set(this.values[(this.count - 1) * 3], 
+			this.vec3.set(this.values[(this.count - 1) * 3],
 					this.values[(this.count - 1) * 3 + 1],
 					this.values[(this.count - 1) * 3 + 2]);
 		}
@@ -206,7 +206,7 @@ THREE.glTFInterpolator.prototype.interp = function(t)
 		{
 			var key1 = this.keys[i];
 			var key2 = this.keys[i + 1];
-	
+
 			if (t >= key1 && t <= key2)
 			{
 				if (this.isRot) {
@@ -227,13 +227,13 @@ THREE.glTFInterpolator.prototype.interp = function(t)
 					this.vec2.set(this.values[(i + 1) * 3],
 							this.values[(i + 1) * 3 + 1],
 							this.values[(i + 1) * 3 + 2]);
-	
+
 					this.vec3.lerp(this.vec2, (t - key1) / (key2 - key1));
 				}
 			}
 		}
 	}
-	
+
 	if (this.target)
 	{
 		this.copyValue(this.target);
@@ -241,11 +241,11 @@ THREE.glTFInterpolator.prototype.interp = function(t)
 }
 
 THREE.glTFInterpolator.prototype.copyValue = function(target) {
-	
+
 	if (this.isRot) {
 		target.copy(this.quat3);
 	}
 	else {
 		target.copy(this.vec3);
-	}		
+	}
 }

--- a/examples/js/loaders/gltf/glTFLoader.js
+++ b/examples/js/loaders/gltf/glTFLoader.js
@@ -1573,8 +1573,8 @@ THREE.glTFLoader.prototype.parse = function( json, callback, texturePath ) {
 											boneInverses, false ), skin.bindShapeMatrix );
 
 										//threeMesh.bindMode = "detached";
-										threeMesh.normalizeSkinWeights();
-										threeMesh.pose();
+										//threeMesh.normalizeSkinWeights();
+										//threeMesh.pose();
 									}
 
 									if (threeMesh) {
@@ -1667,7 +1667,7 @@ THREE.glTFLoader.prototype.parse = function( json, callback, texturePath ) {
 			value : function() {
 				for (var name in this.nodeAnimationChannels) {
 					var nodeAnimationChannels = this.nodeAnimationChannels[name];
-					var len = nodeAnimationChannels.length;
+					//var len = nodeAnimationChannels.length;
 					//console.log(" animation channels for node " + name);
 					//for (var i = 0; i < len; i++) {
 					//  console.log(nodeAnimationChannels[i]);

--- a/examples/js/loaders/gltf/glTFLoaderUtils.js
+++ b/examples/js/loaders/gltf/glTFLoaderUtils.js
@@ -156,11 +156,9 @@ THREE.GLTFLoaderUtils = Object.create(Object, {
             xhr.setRequestHeader("If-Modified-Since", "Sat, 01 Jan 1970 00:00:00 GMT");
             xhr.onload = function(e) {
                 if ((xhr.status == 200) || (xhr.status == 206)) {
-
                     delegate.streamAvailable(path, xhr.response);
-
                 } else {
-                    delegate.handleError(THREE.GLTFLoaderUtils.XMLHTTPREQUEST_STATUS_ERROR, this.status);
+                    delegate.handleError(THREE.GLTFLoaderUtils.XMLHTTPREQUEST_STATUS_ERROR, xhr.status);
                 }
             };
             xhr.send(null);
@@ -221,7 +219,6 @@ THREE.GLTFLoaderUtils = Object.create(Object, {
 
     _elementSizeForGLType: {
         value: function(componentType, type) {
-
     		var nElements = 0;
     		switch(type) {
 	            case "SCALAR" :
@@ -270,7 +267,6 @@ THREE.GLTFLoaderUtils = Object.create(Object, {
             var buffer = bufferView.buffer;
             var byteOffset = wrappedBufferView.byteOffset + bufferView.description.byteOffset;
             var range = [byteOffset , (this._elementSizeForGLType(wrappedBufferView.componentType, wrappedBufferView.type) * wrappedBufferView.count) + byteOffset];
-
             this._handleRequest({   "id" : wrappedBufferView.id,
                                     "range" : range,
                                     "type" : buffer.description.type,


### PR DESCRIPTION
This PR adds `parse`, `setCrossOrigin` and `setTexturePath` methods to `glTFLoader.js` (+ also updates the glTFParser API documentation to include these methods).

This PR also includes other minor fixes to code syntax in gltf loader files (e.g. missing `var` declarations).

These changes are backward-compatible with the existing API.

Here's an example of glTFLoader API usage with these additions:

``` javascript
const loader = new THREE.glTFLoader();
loader.setCrossOrigin(true);
loader.setTexturePath("http://bar.org/cross-origin-textures/");
loader.parse(/* glTF JSON object */, function(gltf) {
  // ...
  // scene.add(gltf.scene);
  // ...
});
```
