### PR TITLE
object callbacks

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -91,8 +91,8 @@ function Object3D() {
 
 	this.userData = {};
 
-	this.onBeforeRender = null;
-	this.onAfterRender = null;
+	this.onBeforeRender = function(){}; 
+	this.onAfterRender = function(){};
 
 }
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -92,6 +92,7 @@ function Object3D() {
 	this.userData = {};
 
 	this.onBeforeRender = null;
+	this.onAfterRender = null;
 
 }
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1525,13 +1525,13 @@ function WebGLRenderer( parameters ) {
 
 			} else {
 
-				if ( object.onBeforeRender !== null ) object.onBeforeRender( _this , _gl camera, fog, geometry, material, object, group );
+				object.onBeforeRender( _this , _gl , camera, fog, geometry, material, object, group );
 
 				_this.renderBufferDirect( camera, fog, geometry, material, object, group );
 
 			}
 
-			if ( object.onAfterRender !== null ) object.onAfterRender( _this , _gl camera, fog, geometry, material, object, group );
+			object.onAfterRender( _this , _gl , camera, fog, geometry, material, object, group );
 
 
 		}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1525,11 +1525,14 @@ function WebGLRenderer( parameters ) {
 
 			} else {
 
-				if ( object.onBeforeRender !== null ) object.onBeforeRender();
+				if ( object.onBeforeRender !== null ) object.onBeforeRender( _this , _gl camera, fog, geometry, material, object, group );
 
 				_this.renderBufferDirect( camera, fog, geometry, material, object, group );
 
 			}
+
+			if ( object.onAfterRender !== null ) object.onAfterRender( _this , _gl camera, fog, geometry, material, object, group );
+
 
 		}
 


### PR DESCRIPTION
per previous suggestion:
https://github.com/mrdoob/three.js/pull/7048

per previous pull:
https://github.com/mrdoob/three.js/pull/7806

recent discussion:
https://github.com/mrdoob/three.js/issues/9662
## example (copied)

I didnt have time to come up with a meaningful example, but i did see some other features that were implemented that could also benefit from this.

My usage case would be something like this: 
## stencil buffer management

sequencing two meshes and a mask to render in a specific order and make use of the stencil buffer which has very little exposure in Three.

``` javascript
var maskMesh = new THREE.Mesh( maskGeom , maskMat );
maskMesh.onBeforeRender = function(){
  gl.clearStencil( 0 ); 
  gl.clear( gl.STENCIL_BUFFER_BIT );
  gl.stencilFunc( gl.ALWAYS , 1 , 1 );
  gl.stencilOp( gl.REPLACE , gl.REPLACE , gl.REPLACE );
  gl.colorMask( false , false , false , false ); 
  gl.depthMask( false ); 
}.bind(maskMesh);
maskMesh.renderOrder = SomeOrder + 0;


var meshA = new THREE.Mesh( geomA, matA);
meshA.onBeforeRender = function(){
  gl.depthMask( true ); 
  gl.colorMask( true , true , true , true );
  gl.stencilFunc( gl.EQUAL , 0 , 1 ); 
  gl.stencilOp( gl.KEEP , gl.KEEP , gl.KEEP ); 
}
meshA.renderOrder = someOrder + 1;



var meshB = new THREE.Mesh( geomB , matB);
meshB.onBeforeRender = function(){
  gl.stencilFunc( gl.EQUAL , 1 , 1 );
}
meshB.renderOrder = someOrder + 2;

```
## configuring a material before each call

Another example would be #7048 , but without the dynamic property and modifications to the renderer. 

If there was a callback like this the same could be achieved with:

``` javascript
var sharedMat = new THREE.ShaderMaterial();

var myMesh = new THREE.Mesh( geom , sharedMat );

myMesh.onBeforeRender = function(){
     this.material.uniforms.myUniform.value = this.customData; 
}.bind(myMesh);
```
## transforming objects that rely on other objects being transformed

``` javascript
var skybox = new THREE.Mesh(...);
var camera = new THREE.Camera();

var controls = new Controls( camera );
   ...

updateLoop(){
  controls.update(); 

 //now i want the skybox to "follow" the camera, ie. has the same position (or relative position) but no rotation

  skybox.position.copy( camera.position);

}

```

I wish that i could have one Vector3 be a position that many different objects can reference, but three doesnt work like that. 

With a callback

``` javascript
skybox.onBeforeRender = function(){
   this.position.copy( camera.position );
}.bind(skybox);
```
