### PR TITLE
VREffect: Correctly set display bounds (see #9732)

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -113,8 +113,8 @@ THREE.VREffect = function ( renderer, onError ) {
 
 				var layer = layers[0];
 
-				leftBounds = layer.leftBounds !== null && layer.leftBounds.length === 4 ? leftBounds : [ 0.0, 0.0, 0.5, 1.0 ];
-				rightBounds = layer.rightBounds !== null && layer.rightBounds.length === 4 ? rightBounds : [ 0.5, 0.0, 0.5, 1.0 ];
+				leftBounds = layer.leftBounds !== null && layer.leftBounds.length === 4 ? layer.leftBounds : [ 0.0, 0.0, 0.5, 1.0 ];
+				rightBounds = layer.rightBounds !== null && layer.rightBounds.length === 4 ? layer.rightBounds : [ 0.5, 0.0, 0.5, 1.0 ];
 
 			}
 


### PR DESCRIPTION
Well, this is embarrassing. After all that fuss last night with the hotfix, the code that I wrote and a couple of you guys reviewed is 💩. After a proper night's sleep and some testing, here is an update.

The previous patch, which is currently in master, will work just fine as long as you don't try to actually set any values on `leftBounds` or `rightBounds`. This should fix that.

Apologies to everyone. cc @toji, @dmarcos, @kearwood.
