### PR TITLE
Querying clientHeight forcing synchronous layout

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2091,7 +2091,7 @@ function WebGLRenderer( parameters ) {
 		uniforms.diffuse.value = material.color;
 		uniforms.opacity.value = material.opacity;
 		uniforms.size.value = material.size * _pixelRatio;
-		uniforms.scale.value = _canvas.clientHeight * 0.5;
+		uniforms.scale.value = _height * 0.5;
 
 		uniforms.map.value = material.map;
 


### PR DESCRIPTION
Reading clientHeight of canvas during every rAF causes layout thrashing and results in frame drops. Instead re-use the _height local variable available in current scope.
