### PR TITLE
added allowvr to example iframe

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -237,7 +237,7 @@
 			</div>
 			<div id="content"></div>
 		</div>
-		<iframe id="viewer" name="viewer" allowfullscreen onmousewheel=""></iframe>
+		<iframe id="viewer" name="viewer" allowfullscreen allowvr onmousewheel=""></iframe>
 
 		<script src="files.js"></script>
 


### PR DESCRIPTION
So navigator.getVRDisplays won't fail with `DOMException: Access to VR devices is not allowed in this context`
