### PR TITLE
Add dispose function to VREffect to prevent memory leak

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -137,6 +137,10 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	window.addEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
 
+	this.dispose = function () {
+		window.removeEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
+	};
+
 	this.setFullScreen = function ( boolean ) {
 
 		return new Promise( function ( resolve, reject ) {


### PR DESCRIPTION
Add dispose function to VREffect. Otherwise it causes a memory leak if it is instantiated several times -> always add eventlistener on window 
