### PR TITLE
Fix #9797 - Make sure onError is called if createElementNS fails in ImageLoader.load

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -29,6 +29,7 @@ Object.assign( ImageLoader.prototype, {
 			scope.manager.itemEnd( url );
 
 		};
+		image.onerror = onError; //Catch error in createElementNS
 
 		if ( url.indexOf( 'data:' ) === 0 ) {
 


### PR DESCRIPTION
As discussed in https://github.com/mrdoob/three.js/issues/9797 call ImageLoader.load onError CB if createElementNS fails and invokes image's onError CB. Avoids calls to ImageLoader.load simply disappearing and never calling onLoad or onError
