### PR TITLE
glTFLoader improvements

### DIFF
--- a/examples/js/loaders/gltf/glTFLoader.js
+++ b/examples/js/loaders/gltf/glTFLoader.js
@@ -225,6 +225,7 @@ THREE.glTFLoader.prototype.load = function( url, callback ) {
 			for (var i = 0; i < byteString.length; i++) {
 				view[i] = byteString.charCodeAt(i);
 			}
+
 			return buffer;
 		}
 
@@ -1121,7 +1122,7 @@ THREE.glTFLoader.prototype.load = function( url, callback ) {
 				for (var i = 0 ; i < primitivesDescription.length ; i++) {
 					var primitiveDescription = primitivesDescription[i];
 
-					if (primitiveDescription.mode === THREE.GLTFLoaderUtils.WEBGL_CONSTANTS.TRIANGLES) {
+					if (primitiveDescription.mode === THREE.GLTFLoaderUtils.WEBGL_CONSTANTS.TRIANGLES || primitiveDescription.mode === undefined) {
 
 						var geometry = new ClassicGeometry();
 						var materialEntry = this.resources.getEntry(primitiveDescription.material);


### PR DESCRIPTION
I noticed that the glTFLoader assumes a primitive to have indices, but [the specification says they're optional](https://github.com/KhronosGroup/glTF/blob/master/specification/README.md#primitiveindices).

While that may not be extremely important in production, as most people are likely to export with indices, I still think it makes sense for certain cases. We're having multiple normals per vertex and won't be using indexing and I stumbled upon this when exporting without the indices.
