### PR TITLE
instancedBufferGeometry addGroup fix (materialIndex).

### DIFF
--- a/src/core/InstancedBufferGeometry.js
+++ b/src/core/InstancedBufferGeometry.js
@@ -18,13 +18,13 @@ InstancedBufferGeometry.prototype.constructor = InstancedBufferGeometry;
 
 InstancedBufferGeometry.prototype.isInstancedBufferGeometry = true;
 
-InstancedBufferGeometry.prototype.addGroup = function ( start, count, instances ) {
+InstancedBufferGeometry.prototype.addGroup = function ( start, count, materialIndex ) {
 
 	this.groups.push( {
 
 		start: start,
 		count: count,
-		instances: instances
+		materialIndex: materialIndex
 
 	} );
 
@@ -54,7 +54,7 @@ InstancedBufferGeometry.prototype.copy = function ( source ) {
 	for ( var i = 0, l = groups.length; i < l; i ++ ) {
 
 		var group = groups[ i ];
-		this.addGroup( group.start, group.count, group.instances );
+		this.addGroup( group.start, group.count, group.materialIndex );
 
 	}
 


### PR DESCRIPTION
Related to #8912 and [SO question](http://stackoverflow.com/questions/37281166/three-instancedbuffergeometry-three-multimaterial-and-groups).

This fix repairs `instancedGeometry.addGroup(start, count, materialIndex)`. Without this fix I get runtime error while using instanced geometry with multiMaterial: `Cannot read property 'visible' of undefined` in `projectObject` function. Piece of code where error happens:

```
for ( var i = 0, l = groups.length; i < l; i ++ ) {
    var group = groups[ i ];
    var groupMaterial = materials[ group.materialIndex ];
    if ( groupMaterial.visible === true ) {
        pushRenderItem( object, geometry, groupMaterial, _vector3.z, group );
    }
}
```

Field `instances` of `groups` entry in [InstancedBufferGeometry](https://github.com/mrdoob/three.js/blob/dev/src/core/InstancedBufferGeometry.js) is not used anywhere except this file, so I guess it is a typo.
