### PR TITLE
VREffect and VRControls: Catch error retreiving VR Displays

### DIFF
--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -37,7 +37,11 @@ THREE.VRControls = function ( object, onError ) {
 
 	if ( navigator.getVRDisplays ) {
 
-		navigator.getVRDisplays().then( gotVRDisplays );
+		navigator.getVRDisplays().then( gotVRDisplays ).catch ( function () {
+
+			console.warn( 'THREE.VRControls: Unable to get VR Displays' );
+
+		} );
 
 	}
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -42,7 +42,11 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	if ( navigator.getVRDisplays ) {
 
-		navigator.getVRDisplays().then( gotVRDisplays );
+		navigator.getVRDisplays().then( gotVRDisplays ).catch ( function () {
+
+			console.warn( 'THREE.VREffect: Unable to get VR Displays' );
+
+		} );
 
 	}
 


### PR DESCRIPTION
This can happen if the page is inside an iframe that doesn't have an `allowvr` attribute set or if permission is otherwise denied.

This code is deprecated so it will hopefully go away at some point, but as long as it's still here, it should catch the errors.
