### PR TITLE
Pre-slice potentially large ArrayBuffers to avoid RangeErrors from GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1570,8 +1570,9 @@ GLTFParser.prototype.loadNodes = function() {
 										jointNode.skin = mesh;
 										bones.push(jointNode);
 
-										var m = skinEntry.inverseBindMatrices.array;
-										var mat = new THREE.Matrix4().fromArray( m, i * 16 );
+										var matrixOffset = i * 16;
+										var m = skinEntry.inverseBindMatrices.array.slice( matrixOffset, matrixOffset + 16 );
+										var mat = new THREE.Matrix4().fromArray( m );
 										boneInverses.push(mat);
 
 									} else {


### PR DESCRIPTION
This bug fix prevents passing a potentially very large `ArrayBuffer` in to [Float32Array.prototype.set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set). 

By pre-slicing the `ArrayBuffer` object to the required values it prevents the browser from throwing a `RangeError: Source is too large` error in the case that the original un-sliced input `ArrayBuffer` object is too large (when we are are only really interested in a small subset of it).
