### PR TITLE
Documentation: Adjust iFrame height to avoid overflow

### DIFF
--- a/docs/page.css
+++ b/docs/page.css
@@ -69,7 +69,7 @@ code {
 
 iframe {
 	width: 100%;
-	height: 420px;
+	height: 500px;
 	border:0;
 }
 


### PR DESCRIPTION
The iFrame for the material browser is a little bit too small for displaying all material properties via `Dat.gui`. This PR slightly increases the height of the iFrame to solve this problem.
