### PR TITLE
Add Light Pre-Pass Support to WebGLDeferredRenderer

### DIFF
--- a/examples/js/renderers/WebGLDeferredRenderer.js
+++ b/examples/js/renderers/WebGLDeferredRenderer.js
@@ -7,8 +7,7 @@
  * One is Classic Deferred Rendering and the other one is
  * Light Pre-Pass (Deferred Lighting).
  * Classic Deferred Rendering is default. You can use Light Pre-Pass
- * by passing { lightPrePass: true } parameter to constructor or
- * calling .enableLightPrePass( true ) method.
+ * by calling .enableLightPrePass( true ) method.
  *
  * Dependencies
  *  - THREE.CopyShader
@@ -87,8 +86,6 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		_width = parameters.width !== undefined ? parameters.width : _this.renderer.getSize().width;
 		_height = parameters.height !== undefined ? parameters.height : _this.renderer.getSize().height;
 
-		var lightPrePass = parameters.lightPrePass !== undefined ? parameters.lightPrePass : false;
-
 		var antialias = parameters.antialias !== undefined ? parameters.antialias : false;
 
 		initDepthTexture();
@@ -101,7 +98,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 		_this.setSize( _width, _height );
 		_this.setAntialias( antialias );
-		_this.enableLightPrePass( lightPrePass );
+		_this.enableLightPrePass( false );
 
 	};
 

--- a/examples/js/renderers/WebGLDeferredRenderer.js
+++ b/examples/js/renderers/WebGLDeferredRenderer.js
@@ -3,6 +3,13 @@
  * @author MPanknin / http://www.redplant.de/
  * @author takahiro / https://github.com/takahirox
  *
+ * WebGLDeferredRenderer supports two types of Deferred Renderings.
+ * One is Classic Deferred Rendering and the other one is
+ * Light Pre-Pass (Deferred Lighting).
+ * Classic Deferred Rendering is default. You can use Light Pre-Pass
+ * by passing { lightPrePass: true } parameter to constructor or
+ * calling .enableLightPrePass( true ) method.
+ *
  * Dependencies
  *  - THREE.CopyShader
  *  - THREE.RenderPass
@@ -39,12 +46,23 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	var _width, _height;
 
-	var _compColor, _compNormalDepth, _compLight, _compFinal;
-	var _passColor, _passNormalDepth, _passLight, _passLightFullscreen, _passFinal, _passForward, _passCopy, _passFXAA;
+	// for Classic Deferred Rendering
+	var _compColor;
+	var _passColor, _passForward, _passCopy;
+
+	// for Light Pre-Pass
+	var _compReconstruction;
+	var _passReconstruction;
+
+	// for Common
+	var _compNormalDepth, _compLight, _compFinal;
+	var _passNormalDepth, _passLight, _passLightFullscreen, _passFinal, _passFXAA;
+
+	var _depthTexture;
 
 	var _lightScene, _lightFullscreenScene;
 
-	var _antialias = false, _hasTransparentObject = false;
+	var _antialias = false, _hasTransparentObject = false, _lightPrePass = false;
 
 	var _invisibleMaterial = new THREE.ShaderMaterial( { visible: false } );
 
@@ -69,22 +87,38 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		_width = parameters.width !== undefined ? parameters.width : _this.renderer.getSize().width;
 		_height = parameters.height !== undefined ? parameters.height : _this.renderer.getSize().height;
 
+		var lightPrePass = parameters.lightPrePass !== undefined ? parameters.lightPrePass : false;
+
 		var antialias = parameters.antialias !== undefined ? parameters.antialias : false;
 
-		initPassFXAA();
+		initDepthTexture();
+
 		initPassNormalDepth();
 		initPassColor();
 		initPassLight();
+		initPassReconstruction();
 		initPassFinal();
 
 		_this.setSize( _width, _height );
 		_this.setAntialias( antialias );
+		_this.enableLightPrePass( lightPrePass );
 
 	};
 
-	var initPassFXAA = function () {
+	var initDepthTexture = function () {
 
-		_passFXAA = new THREE.ShaderPass( THREE.FXAAShader );
+		_depthTexture = new THREE.DepthTexture(
+			_width,
+			_height,
+			THREE.UnsignedInt248Type,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			THREE.DepthStencilFormat
+		)
 
 	};
 
@@ -99,18 +133,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 			format: THREE.RGBAFormat,
 			type: THREE.FloatType,
 			stencilBuffer: true,
-			depthTexture: new THREE.DepthTexture(
-				_width,
-				_height,
-				THREE.UnsignedInt248Type,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				THREE.DepthStencilFormat
-			)
+			depthTexture: _depthTexture
 		} );
 
 		rt.texture.generateMipamps = false;
@@ -130,7 +153,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 			magFilter: THREE.NearestFilter,
 			format: THREE.RGBAFormat,
 			type: THREE.FloatType,
-			depthTexture: _compNormalDepth.renderTarget2.depthTexture
+			depthTexture: _depthTexture
 		} );
 
 		rt.texture.generateMipamps = false;
@@ -154,7 +177,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 			magFilter: THREE.NearestFilter,
 			format: THREE.RGBAFormat,
 			type: THREE.FloatType,
-			depthTexture: _compNormalDepth.renderTarget2.depthTexture
+			depthTexture: _depthTexture
 		} );
 
 		rt.texture.generateMipamps = false;
@@ -165,11 +188,31 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	};
 
+	var initPassReconstruction = function () {
+
+		_passReconstruction = new THREE.RenderPass();
+		_passReconstruction.clear = true;
+
+		var rt = new THREE.WebGLRenderTarget( _width, _height, {
+			minFilter: THREE.NearestFilter,
+			magFilter: THREE.NearestFilter,
+			format: THREE.RGBAFormat,
+			type: THREE.FloatType,
+			depthTexture: _depthTexture
+		} );
+
+		rt.texture.generateMipamps = false;
+
+		_compReconstruction = new THREE.EffectComposer( _this.renderer, rt );
+		_compReconstruction.addPass( _passReconstruction );
+
+	};
+
 	var initPassFinal = function () {
 
-		_passFinal = new THREE.ShaderPass( THREE.ShaderDeferred[ 'composite' ] );
+		_passFinal = new THREE.ShaderPass( THREE.ShaderDeferred[ 'final' ] );
 		_passFinal.clear = true;
-		_passFinal.uniforms.samplerLight.value = _compLight.renderTarget2.texture;
+		_passFinal.uniforms.samplerResult.value = _compLight.renderTarget2.texture;
 		_passFinal.material.blending = THREE.NoBlending;
 		_passFinal.material.depthWrite = false;
 		_passFinal.material.depthTest = false;
@@ -179,12 +222,14 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 		_passCopy = new THREE.ShaderPass( THREE.CopyShader );
 
+		_passFXAA = new THREE.ShaderPass( THREE.FXAAShader );
+
 		var rt = new THREE.WebGLRenderTarget( _width, _height, {
 			minFilter: THREE.NearestFilter,
 			magFilter: THREE.LinearFilter,
 			format: THREE.RGBFormat,
 			type: THREE.UnsignedByteType,
-			depthTexture: _compNormalDepth.renderTarget2.depthTexture
+			depthTexture: _depthTexture
 		} );
 
 		rt.texture.generateMipamps = false;
@@ -223,54 +268,84 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		_lightScene = scene.userData.lightScene;
 		_lightFullscreenScene = scene.userData.lightFullscreenScene;
 
-	};
-
-	var initDeferredProperties = function ( object ) {
-
-		if ( object.userData.deferredInitialized === true ) return;
-
-		if ( object.material ) initDeferredMaterials( object );
-
-		if ( object instanceof THREE.Light ) initDeferredLight( object );
-
-		object.userData.deferredInitialized = true;
+		// emissiveLight is only for Classic Deferred Rendering
+		_lightFullscreenScene.userData.emissiveLight.visible = ! _lightPrePass;
 
 	};
 
-	var initDeferredMaterials = function ( object ) {
+	var setMaterialNormalDepth = function ( object ) {
 
-		if ( object.material instanceof THREE.MultiMaterial ) {
+		if ( object.material === undefined ) return;
 
-			var normalDepthMaterials = [];
-			var colorMaterials = [];
-			var forwardMaterials = [];
+		object.material = getNormalDepthMaterial( object );
 
-			var materials = object.material.materials;
+		if ( object.userData.originalMaterial.isMultiMaterial === true ) {
 
-			for ( var i = 0, il = materials.length; i < il; i ++ ) {
+			for ( var i = 0, il = object.userData.originalMaterial.materials.length; i < il; i ++ ) {
 
-				normalDepthMaterials.push( createDeferredNormalDepthMaterial( materials[ i ] ) );
-				colorMaterials.push( createDeferredColorMaterial( materials[ i ] ) );
-				forwardMaterials.push( _invisibleMaterial );
+				updateDeferredNormalDepthMaterial( object.material.materials[ i ], object.userData.originalMaterial.materials[ i ], _lightPrePass );
 
 			}
 
-			object.userData.normalDepthMaterial = new THREE.MultiMaterial( normalDepthMaterials );
-			object.userData.colorMaterial = new THREE.MultiMaterial( colorMaterials );
-			object.userData.forwardMaterial = new THREE.MultiMaterial( forwardMaterials );
-
 		} else {
 
-			object.userData.normalDepthMaterial = createDeferredNormalDepthMaterial( object.material );
-			object.userData.colorMaterial = createDeferredColorMaterial( object.material );
+			updateDeferredNormalDepthMaterial( object.material, object.userData.originalMaterial, _lightPrePass );
 
 		}
 
 	};
 
-	var createDeferredNormalDepthMaterial = function ( originalMaterial ) {
+	var getNormalDepthMaterial = function ( object ) {
 
-		var shader = THREE.ShaderDeferred[ 'normalDepth' ];
+		if ( ( _lightPrePass && object.userData.normalDepthShininessMaterial === undefined ) ||
+		     ( ! _lightPrePass && object.userData.normalDepthMaterial === undefined ) ) {
+
+			initDeferredNormalDepthMaterial( object, _lightPrePass );
+
+		}
+
+		return ( _lightPrePass ) ? object.userData.normalDepthShininessMaterial : object.userData.normalDepthMaterial;
+
+	};
+
+	var initDeferredNormalDepthMaterial = function ( object, isLightPrePass ) {
+
+		var originalMaterial = object.userData.originalMaterial;
+		var material;
+
+		if ( originalMaterial.isMultiMaterial === true ) {
+
+			var materials = [];
+
+			for ( var i = 0, il = originalMaterial.materials.length; i < il; i ++ ) {
+
+				materials.push( createDeferredNormalDepthMaterial( originalMaterial.materials[ i ], isLightPrePass ) );
+
+			}
+
+			material = new THREE.MultiMaterial( materials );
+
+		} else {
+
+			material = createDeferredNormalDepthMaterial( originalMaterial, isLightPrePass );
+
+		}
+
+		if ( isLightPrePass ) {
+
+			object.userData.normalDepthShininessMaterial = material;
+
+		} else {
+
+			object.userData.normalDepthMaterial = material;
+
+		}
+
+	};
+
+	var createDeferredNormalDepthMaterial = function ( originalMaterial, isLightPrePass ) {
+
+		var shader = ( isLightPrePass ) ? THREE.ShaderDeferred[ 'normalDepthShininess' ] : THREE.ShaderDeferred[ 'normalDepth' ];
 
 		var material = new THREE.ShaderMaterial( {
 			uniforms: THREE.UniformsUtils.clone( shader.uniforms ),
@@ -283,10 +358,24 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	};
 
-	var updateDeferredNormalDepthMaterial = function ( material, originalMaterial ) {
+	var updateDeferredNormalDepthMaterial = function ( material, originalMaterial, isLightPrePass ) {
 
 		if ( originalMaterial.skinning !== undefined ) material.skinning = originalMaterial.skinning;
 		if ( originalMaterial.morphTargets !== undefined ) material.morphTargets = originalMaterial.morphTargets;
+
+		if ( isLightPrePass ) {
+
+			var shininess = originalMaterial.shininess;
+
+			if ( ( originalMaterial.isShaderMaterial === true ) && originalMaterial.uniforms !== undefined ) {
+
+				if ( shininess === undefined && originalMaterial.uniforms.shininess !== undefined ) shininess = originalMaterial.uniforms.shininess.value;
+
+			}
+
+			if ( shininess !== undefined ) material.uniforms.shininess.value = shininess;
+
+		}
 
 		if ( originalMaterial.visible === true ) {
 
@@ -295,6 +384,64 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		} else {
 
 			material.visible = false;
+
+		}
+
+	};
+
+	var setMaterialColor = function ( object ) {
+
+		if ( object.material === undefined ) return;
+
+		object.material = getColorMaterial( object );
+
+		if ( object.userData.originalMaterial.isMultiMaterial === true ) {
+
+			for ( var i = 0, il = object.userData.originalMaterial.materials.length; i < il; i ++ ) {
+
+				updateDeferredColorMaterial( object.material.materials[ i ], object.userData.originalMaterial.materials[ i ] );
+
+			}
+
+		} else {
+
+			updateDeferredColorMaterial( object.material, object.userData.originalMaterial );
+
+		}
+
+	};
+
+	var getColorMaterial = function ( object ) {
+
+		if ( object.userData.colorMaterial === undefined ) {
+
+			initDeferredColorMaterial( object );
+
+		}
+
+		return object.userData.colorMaterial;
+
+	};
+
+	var initDeferredColorMaterial = function ( object ) {
+
+		var originalMaterial = object.userData.originalMaterial;
+
+		if ( originalMaterial.isMultiMaterial === true ) {
+
+			var materials = [];
+
+			for ( var i = 0, il = originalMaterial.materials.length; i < il; i ++ ) {
+
+				materials.push( createDeferredColorMaterial( originalMaterial.materials[ i ] ) );
+
+			}
+
+			object.userData.colorMaterial = new THREE.MultiMaterial( materials );
+
+		} else {
+
+			object.userData.colorMaterial = createDeferredColorMaterial( originalMaterial );
 
 		}
 
@@ -321,7 +468,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 		var diffuse, emissive;
 
-		if ( originalMaterial instanceof THREE.MeshBasicMaterial ) {
+		if ( originalMaterial.isMeshBasicMaterial === true ) {
 
 			emissive = originalMaterial.color;
 
@@ -336,7 +483,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		var shininess = originalMaterial.shininess;
 		var map = originalMaterial.map;
 
-		if ( ( originalMaterial instanceof THREE.ShaderMaterial ) && originalMaterial.uniforms !== undefined ) {
+		if ( originalMaterial.isShaderMaterial === true && originalMaterial.uniforms !== undefined ) {
 
 			if ( diffuse === undefined && originalMaterial.uniforms.diffuse !== undefined ) diffuse = originalMaterial.uniforms.diffuse.value;
 			if ( emissive === undefined && originalMaterial.uniforms.emissive !== undefined ) emissive = originalMaterial.uniforms.emissive.value;
@@ -348,7 +495,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		if ( diffuse !== undefined ) material.uniforms.diffuse.value.copy( diffuse );
 		if ( emissive !== undefined ) material.uniforms.emissive.value.copy( emissive );
 		if ( specular !== undefined ) material.uniforms.specular.value.copy( specular );
-		if ( shininess !== undefined ) material.uniforms.shininess.value = shininess;
+		if ( shininess !== undefined && material.uniforms.shininess !== undefined ) material.uniforms.shininess.value = shininess;
 
 		if ( map !== undefined ) {
 
@@ -372,6 +519,146 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	};
 
+	var setMaterialReconstruction = function ( object ) {
+
+		if ( object.material === undefined ) return;
+
+		if ( object.userData.originalMaterial.transparent === true ) {
+
+			object.material = object.userData.originalMaterial;
+
+			return;
+
+		}
+
+		object.material = getReconstructionMaterial( object );
+
+		if ( object.userData.originalMaterial.isMultiMaterial === true ) {
+
+			for ( var i = 0, il = object.userData.originalMaterial.materials.length; i < il; i ++ ) {
+
+				updateDeferredReconstructionMaterial( object.material.materials[ i ], object.userData.originalMaterial.materials[ i ] );
+
+			}
+
+		} else {
+
+			updateDeferredReconstructionMaterial( object.material, object.userData.originalMaterial );
+
+		}
+
+	};
+
+	var getReconstructionMaterial = function ( object ) {
+
+		if ( object.userData.reconstructionMaterial === undefined ) {
+
+			initDeferredReconstructionMaterial( object );
+
+		}
+
+		return object.userData.reconstructionMaterial;
+
+	};
+
+	var initDeferredReconstructionMaterial = function ( object ) {
+
+		var originalMaterial = object.userData.originalMaterial;
+
+		if ( originalMaterial.isMultiMaterial === true ) {
+
+			var materials = [];
+
+			for ( var i = 0, il = originalMaterial.materials.length; i < il; i ++ ) {
+
+				materials.push( createDeferredReconstructionMaterial( originalMaterial.materials[ i ] ) );
+
+			}
+
+			object.userData.reconstructionMaterial = new THREE.MultiMaterial( materials );
+
+		} else {
+
+			object.userData.reconstructionMaterial = createDeferredReconstructionMaterial( originalMaterial );
+
+		}
+
+	};
+
+	var createDeferredReconstructionMaterial = function ( originalMaterial ) {
+
+		var shader = THREE.ShaderDeferred[ 'reconstruction' ];
+
+		var material = new THREE.ShaderMaterial( {
+			uniforms: THREE.UniformsUtils.clone( shader.uniforms ),
+			fragmentShader: shader.fragmentShader,
+			vertexShader: shader.vertexShader,
+			blending: THREE.NoBlending
+		} );
+
+		if ( originalMaterial.map !== undefined ) material.map = originalMaterial.map;
+
+		material.uniforms.samplerLight.value = _compLight.renderTarget2.texture;
+
+		return material;
+
+	};
+
+	var updateDeferredReconstructionMaterial = function ( material, originalMaterial ) {
+
+		updateDeferredColorMaterial( material, originalMaterial );
+
+		material.uniforms.viewWidth.value = _width;
+		material.uniforms.viewHeight.value = _height;
+
+	};
+
+	var setMaterialForwardRendering = function ( object ) {
+
+		if ( object.material === undefined ) return;
+
+		if ( object.userData.originalMaterial.isMultiMaterial === true ) {
+
+			if ( object.userData.forwardMaterial === undefined ) {
+
+				initInvisibleMaterial( object );
+
+			}
+
+			object.material = object.userData.forwardMaterial;
+
+			for ( var i = 0, il = object.userData.originalMaterial.materials.length; i < il; i ++ ) {
+
+				object.material.materials[ i ] = getForwardRenderingMaterial( object.userData.originalMaterial.materials[ i ] );
+
+			}
+
+		} else {
+
+			object.material = getForwardRenderingMaterial( object.userData.originalMaterial );
+
+		}
+
+	};
+
+	var initInvisibleMaterial = function ( object ) {
+
+		if ( object.userData.originalMaterial.isMultiMaterial === true ) {
+
+			var materials = [];
+
+			for ( var i = 0, il = object.userData.originalMaterial.materials.length; i < il; i ++ ) {
+
+				materials.push( _invisibleMaterial );
+
+			}
+
+			object.userData.forwardMaterial = new THREE.MultiMaterial( materials );
+
+		}
+
+	};
+
 	var getForwardRenderingMaterial = function ( originalMaterial ) {
 
 		if ( originalMaterial.transparent === true && originalMaterial.visible === true ) {
@@ -381,48 +668,6 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		} else {
 
 			return _invisibleMaterial;
-
-		}
-
-	};
-
-	var initDeferredLight = function ( light ) {
-
-		var deferredLight;
-
-		if ( light instanceof THREE.PointLight ) {
-
-			deferredLight = createDeferredPointLight( light );
-
-		} else if ( light instanceof THREE.SpotLight ) {
-
-			deferredLight = createDeferredSpotLight( light );
-
-		} else if ( light instanceof THREE.DirectionalLight ) {
-
-			deferredLight = createDeferredDirectionalLight( light );
-
-		}
-
-		light.userData.deferredLight = deferredLight;
-
-	};
-
-	var updateDeferredLight = function ( light, camera ) {
-
-		var originalLight = light.userData.originalLight;
-
-		if ( originalLight instanceof THREE.PointLight ) {
-
-			updateDeferredPointLight( light, camera );
-
-		} else if ( originalLight instanceof THREE.SpotLight ) {
-
-			updateDeferredSpotLight( light, camera );
-
-		} else if ( originalLight instanceof THREE.DirectionalLight ) {
-
-			updateDeferredDirectionalLight( light, camera );
 
 		}
 
@@ -458,30 +703,157 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	};
 
-	var createDeferredPointLight = function ( light ) {
+	var initDeferredLight = function ( light ) {
 
-		var shader = THREE.ShaderDeferred[ 'pointLight' ];
+		var deferredLight;
+
+		if ( light.isPointLight ) {
+
+			deferredLight = createDeferredPointLight( light );
+
+		} else if ( light.isSpotLight ) {
+
+			deferredLight = createDeferredSpotLight( light );
+
+		} else if ( light.isDirectionalLight ) {
+
+			deferredLight = createDeferredDirectionalLight( light );
+
+		} else {
+
+			deferredLight = null;
+
+		}
+
+		light.userData.deferredLight = deferredLight;
+
+	};
+
+	var initDeferredLightMaterial = function ( light, isLightPrePass ) {
+
+		var originalLight = light.userData.originalLight;
+		var material;
+
+		if ( originalLight.isPointLight ) {
+
+			material = createDeferredPointLightMaterial( isLightPrePass );
+
+		} else if ( originalLight.isSpotLight ) {
+
+			material = createDeferredSpotLightMaterial( isLightPrePass );
+
+		} else if ( originalLight.isDirectionalLight ) {
+
+			material = createDeferredDirectionalLightMaterial( isLightPrePass );
+
+		} else {
+
+			material = null;
+
+		}
+
+		if ( isLightPrePass ) {
+
+			light.userData.materialLightPrePass = material;
+
+		} else {
+
+			light.userData.materialClassic = material;
+
+		}
+
+	};
+
+	var getDeferredLightMaterial = function ( light ) {
+
+		if ( ( _lightPrePass && light.userData.materialLightPrePass === undefined ) ||
+		     ( ! _lightPrePass && light.userData.materialClassic === undefined ) ) {
+
+			initDeferredLightMaterial( light, _lightPrePass );
+
+		}
+
+		return ( _lightPrePass ) ? light.userData.materialLightPrePass : light.userData.materialClassic;
+
+	};
+
+	var updateDeferredLight = function ( light, camera ) {
+
+		var originalLight = light.userData.originalLight;
+
+		if ( originalLight.isPointLight ) {
+
+			updateDeferredPointLight( light, camera );
+
+		} else if ( originalLight.isSpotLight ) {
+
+			updateDeferredSpotLight( light, camera );
+
+		} else if ( originalLight.isDirectionalLight ) {
+
+			updateDeferredDirectionalLight( light, camera );
+
+		}
+
+	};
+
+	var createDeferredLightMesh = function ( light, geometry ) {
+
+		var mesh = new THREE.Mesh( geometry, _invisibleMaterial );
+
+		mesh.userData.originalLight = light;
+
+		return mesh;
+
+	};
+
+	var createDeferredLightMaterial = function ( shader, isLightPrePass ) {
 
 		var material = new THREE.ShaderMaterial( {
 			uniforms: THREE.UniformsUtils.clone( shader.uniforms ),
 			vertexShader: shader.vertexShader,
 			fragmentShader: shader.fragmentShader,
 			transparent: true,
-			side: THREE.BackSide,
 			blending: THREE.AdditiveBlending,
-			depthWrite: false,
-			depthFunc: THREE.GreaterEqualDepth
+			depthWrite: false
 		} );
 
-		material.uniforms.samplerNormalDepth.value = _compNormalDepth.renderTarget2.texture;
-		material.uniforms.samplerColor.value = _compColor.renderTarget2.texture;
+		if ( isLightPrePass ) {
 
-		var geometry = new THREE.SphereGeometry( 1, 16, 8 );
-		var mesh = new THREE.Mesh( geometry, material );
+			material.premultipliedAlpha = true;
+			material.uniforms.samplerNormalDepthShininess.value = _compNormalDepth.renderTarget2.texture;
 
-		mesh.userData.originalLight = light;
+		} else {
 
-		return mesh;
+			material.uniforms.samplerNormalDepth.value = _compNormalDepth.renderTarget2.texture;
+			material.uniforms.samplerColor.value = _compColor.renderTarget2.texture;
+
+		}
+
+		return material;
+
+	};
+
+	var createDeferredPointLight = function ( light ) {
+
+		return createDeferredLightMesh( light, new THREE.SphereGeometry( 1, 16, 8 ) );
+
+	};
+
+	/*
+	 * optimization:
+	 * Renders PointLight only back face with stencil test.
+	 */
+	var createDeferredPointLightMaterial = function ( isLightPrePass ) {
+
+		var shader = ( isLightPrePass ) ? THREE.ShaderDeferred[ 'pointLightPre' ] : THREE.ShaderDeferred[ 'pointLight' ];
+
+		var material = createDeferredLightMaterial( shader, isLightPrePass );
+
+		material.side = THREE.BackSide;
+		material.depthFunc = THREE.GreaterEqualDepth;
+
+		return material;
 
 	};
 
@@ -514,27 +886,19 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	var createDeferredSpotLight = function ( light ) {
 
-		var shader = THREE.ShaderDeferred[ 'spotLight' ];
+		return createDeferredLightMesh(	light, new THREE.PlaneBufferGeometry( 2, 2 ) );
 
-		var material = new THREE.ShaderMaterial( {
-			uniforms: THREE.UniformsUtils.clone( shader.uniforms ),
-			vertexShader: shader.vertexShader,
-			fragmentShader: shader.fragmentShader,
-			transparent: true,
-			blending: THREE.AdditiveBlending,
-			depthWrite: false,
-			depthTest: false
-		} );
+	};
 
-		material.uniforms.samplerNormalDepth.value = _compNormalDepth.renderTarget2.texture;
-		material.uniforms.samplerColor.value = _compColor.renderTarget2.texture;
+	var createDeferredSpotLightMaterial = function ( isLightPrePass ) {
 
-		var geometry = new THREE.PlaneBufferGeometry( 2, 2 );
-		var mesh = new THREE.Mesh( geometry, material );
+		var shader = ( isLightPrePass ) ? THREE.ShaderDeferred[ 'spotLightPre' ] : THREE.ShaderDeferred[ 'spotLight' ];
 
-		mesh.userData.originalLight = light;
+		var material = createDeferredLightMaterial( shader, isLightPrePass );
 
-		return mesh;
+		material.depthTest = false;
+
+		return material;
 
 	};
 
@@ -562,27 +926,19 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	var createDeferredDirectionalLight = function ( light ) {
 
-		var shader = THREE.ShaderDeferred[ 'directionalLight' ];
+		return createDeferredLightMesh(	light, new THREE.PlaneBufferGeometry( 2, 2 ) );
 
-		var material = new THREE.ShaderMaterial( {
-			uniforms: THREE.UniformsUtils.clone( shader.uniforms ),
-			vertexShader: shader.vertexShader,
-			fragmentShader: shader.fragmentShader,
-			transparent: true,
-			blending: THREE.AdditiveBlending,
-			depthWrite: false,
-			depthTest: false
-		} );
+	};
 
-		material.uniforms.samplerNormalDepth.value = _compNormalDepth.renderTarget2.texture;
-		material.uniforms.samplerColor.value = _compColor.renderTarget2.texture;
+	var createDeferredDirectionalLightMaterial = function ( isLightPrePass ) {
 
-		var geometry = new THREE.PlaneBufferGeometry( 2, 2 );
-		var mesh = new THREE.Mesh( geometry, material );
+		var shader = ( isLightPrePass ) ? THREE.ShaderDeferred[ 'directionalLightPre' ] : THREE.ShaderDeferred[ 'directionalLight' ];
 
-		mesh.userData.originalLight = light;
+		var material = createDeferredLightMaterial( shader, isLightPrePass );
 
-		return mesh;
+		material.depthTest = false;
+
+		return material;
 
 	};
 
@@ -606,91 +962,24 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	};
 
-	var setMaterialNormalDepth = function ( object ) {
-
-		if ( object.material === undefined ) return;
-
-		if ( object.userData.normalDepthMaterial !== undefined ) {
-
-			object.material = object.userData.normalDepthMaterial;
-
-			if ( object.userData.originalMaterial instanceof THREE.MultiMaterial ) {
-
-				for ( var i = 0, il = object.userData.originalMaterial.materials.length; i < il; i ++ ) {
-
-					updateDeferredNormalDepthMaterial( object.material.materials[ i ], object.userData.originalMaterial.materials[ i ] );
-
-				}
-
-			} else {
-
-				updateDeferredNormalDepthMaterial( object.material, object.userData.originalMaterial );
-
-			}
-
-		}
-
-	};
-
-	var setMaterialColor = function ( object ) {
-
-		if ( object.material === undefined ) return;
-
-		if ( object.userData.colorMaterial !== undefined ) {
-
-			object.material = object.userData.colorMaterial;
-
-			if ( object.userData.originalMaterial instanceof THREE.MultiMaterial ) {
-
-				for ( var i = 0, il = object.userData.originalMaterial.materials.length; i < il; i ++ ) {
-
-					updateDeferredColorMaterial( object.material.materials[ i ], object.userData.originalMaterial.materials[ i ] );
-
-				}
-
-			} else {
-
-				updateDeferredColorMaterial( object.material, object.userData.originalMaterial );
-
-			}
-
-		}
-
-	};
-
-	var setMaterialForwardRendering = function ( object ) {
-
-		if ( object.material === undefined ) return;
-
-		if ( object.userData.originalMaterial instanceof THREE.MultiMaterial ) {
-
-			object.material = object.userData.forwardMaterial;
-
-			for ( var i = 0, il = object.userData.originalMaterial.materials.length; i < il; i ++ ) {
-
-				object.material.materials[ i ] = getForwardRenderingMaterial( object.userData.originalMaterial.materials[ i ] );
-
-			}
-
-		} else {
-
-			object.material = getForwardRenderingMaterial( object.userData.originalMaterial );
-
-		}
-
-	};
-
 	var saveOriginalMaterialAndCheckTransparency = function ( object ) {
 
 		if ( object.material !== undefined ) {
 
 			object.userData.originalMaterial = object.material;
 
-			if ( object.material instanceof THREE.MultiMaterial ) {
+			if ( _hasTransparentObject ) return;
+
+			if ( object.material.isMultiMaterial === true ) {
 
 				for ( var i = 0, il = object.material.materials.length; i < il; i ++ ) {
 
-					if ( object.material.materials[ i ].transparent === true ) _hasTransparentObject = true;
+					if ( object.material.materials[ i ].transparent === true ) {
+
+						_hasTransparentObject = true;
+						break;
+
+					}
 
 				}
 
@@ -710,109 +999,36 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	};
 
-	var enableCompositePasses = function () {
+	var addDeferredLightsToLightScene = function ( object ) {
 
-		if ( _hasTransparentObject ) {
+		if ( object.isLight !== true ) return;
 
-			if ( _antialias ) {
+		if ( object.userData.deferredLight === undefined ) {
 
-				_passFinal.renderToScreen = false;
-
-				_passForward.renderToScreen = false;
-				_passForward.enabled = true;
-
-				_passCopy.renderToScreen = false;
-				_passCopy.enabled = false;
-
-				_passFXAA.renderToScreen = true;
-				_passFXAA.enabled = true;
-
-
-			} else {
-
-				_passFinal.renderToScreen = false;
-
-				_passForward.renderToScreen = false;
-				_passForward.enabled = true;
-
-				_passCopy.renderToScreen = true;
-				_passCopy.enabled = true;
-
-				_passFXAA.renderToScreen = false;
-				_passFXAA.enabled = false;
-
-			}
-
-		} else {
-
-			if ( _antialias ) {
-
-				_passFinal.renderToScreen = false;
-
-				_passForward.renderToScreen = false;
-				_passForward.enabled = false;
-
-				_passCopy.renderToScreen = false;
-				_passCopy.enabled = false;
-
-				_passFXAA.renderToScreen = true;
-				_passFXAA.enabled = true;
-
-			} else {
-
-				_passFinal.renderToScreen = true;
-
-				_passForward.renderToScreen = false;
-				_passForward.enabled = false;
-
-				_passCopy.renderToScreen = false;
-				_passCopy.enabled = false;
-
-				_passFXAA.renderToScreen = false;
-				_passFXAA.enabled = false;
-
-			}
+			initDeferredLight( object );
 
 		}
-
-	};
-
-	var addDeferredLightsToLightScene = function ( object ) {
 
 		var light = object.userData.deferredLight;
 
-		if ( light !== undefined ) {
+		if ( light === null ) return;
 
-			var originalLight = light.userData.originalLight;
-			var scene;
+		var scene = ( object.isPointLight === true ) ? _lightScene : _lightFullscreenScene;
 
-			if ( originalLight instanceof THREE.PointLight ) {
+		var lights = scene.userData.lights;
 
-				scene = _lightScene;
+		if ( lights[ light.uuid ] === undefined ) {
 
-			} else {
+			scene.add( light );
 
-				scene = _lightFullscreenScene;
-
-			}
-
-			var lights = scene.userData.lights;
-
-			if ( lights[ light.uuid ] === undefined ) {
-
-				scene.add( light );
-
-				lights[ light.uuid ] = {
-					light: light,
-					found: true
-				};
-
-			}
-
-			lights[ light.uuid ].found = true;
-
+			lights[ light.uuid ] = {
+				light: light,
+				found: true
+			};
 
 		}
+
+		lights[ light.uuid ].found = true;
 
 	};
 
@@ -832,7 +1048,11 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 			} else {
 
-				updateDeferredLight( lights[ key ].light, camera );
+				var light = lights[ key ].light;
+				var material = getDeferredLightMaterial( light );
+				light.material = material;
+
+				updateDeferredLight( light, camera );
 				lights[ key ].found = false;
 
 			}
@@ -841,10 +1061,115 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 	};
 
+	var enableFinalPasses = function () {
+
+		if ( _lightPrePass ) {
+
+			_passForward.renderToScreen = false;
+			_passForward.enabled = false;
+
+			_passCopy.renderToScreen = false;
+			_passCopy.enabled = false;
+
+			if ( _antialias ) {
+
+				_passFinal.renderToScreen = false;
+
+				_passFXAA.renderToScreen = true;
+				_passFXAA.enabled = true;
+
+			} else {
+
+				_passFinal.renderToScreen = true;
+
+				_passFXAA.renderToScreen = false;
+				_passFXAA.enabled = false;
+
+			}
+
+		} else {
+
+			if ( _hasTransparentObject ) {
+
+				if ( _antialias ) {
+
+					_passFinal.renderToScreen = false;
+
+					_passForward.renderToScreen = false;
+					_passForward.enabled = true;
+
+					_passCopy.renderToScreen = false;
+					_passCopy.enabled = false;
+
+					_passFXAA.renderToScreen = true;
+					_passFXAA.enabled = true;
+
+				} else {
+
+					_passFinal.renderToScreen = false;
+
+					_passForward.renderToScreen = false;
+					_passForward.enabled = true;
+
+					_passCopy.renderToScreen = true;
+					_passCopy.enabled = true;
+
+					_passFXAA.renderToScreen = false;
+					_passFXAA.enabled = false;
+
+				}
+
+			} else {
+
+				if ( _antialias ) {
+
+					_passFinal.renderToScreen = false;
+
+					_passForward.renderToScreen = false;
+					_passForward.enabled = false;
+
+					_passCopy.renderToScreen = false;
+					_passCopy.enabled = false;
+
+					_passFXAA.renderToScreen = true;
+					_passFXAA.enabled = true;
+
+				} else {
+
+					_passFinal.renderToScreen = true;
+
+					_passForward.renderToScreen = false;
+					_passForward.enabled = false;
+
+					_passCopy.renderToScreen = false;
+					_passCopy.enabled = false;
+
+					_passFXAA.renderToScreen = false;
+					_passFXAA.enabled = false;
+
+				}
+
+			}
+
+		}
+
+	};
+
 	/*
+	 * Classic Deferred Rendering
+	 *
 	 * 1) g-buffer normal + depth pass
 	 *
 	 * RGB: normal
+	 *   A: depth
+	 *
+	 *
+	 * Light Pre-Pass Rendering
+	 *
+	 * 1') g-buffer normal + depth pass + shininess
+	 *
+	 *   R: normal
+	 *   B: shininess
 	 *   A: depth
 	 */
 
@@ -867,6 +1192,8 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 	};
 
 	/*
+	 * Classic Deferred Rendering
+	 *
 	 * 2) g-buffer color pass
 	 *
 	 * R: diffuse
@@ -893,10 +1220,9 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 	};
 
 	/*
-	 * 3) light pass
+	 * Classic Deferred Rendering
 	 *
-	 * optimization:
-	 * Here renders PointLight only back face with stencil test.
+	 * 3) light pass
 	 */
 
 	var renderLight = function ( scene, camera ) {
@@ -923,20 +1249,84 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 	};
 
 	/*
-	 * 4) composite pass
+	 * Light Pre-Pass Rendering
+	 *
+	 * 2') Light pre pass
+	 */
+
+	var renderLightPre = function ( scene, camera ) {
+
+		scene.traverse( addDeferredLightsToLightScene );
+
+		updateDeferredLightsInLightScene( _lightScene, camera );
+		updateDeferredLightsInLightScene( _lightFullscreenScene, camera );
+
+		_passLight.scene = _lightScene;
+		_passLight.camera = camera;
+
+		_passLightFullscreen.scene = _lightFullscreenScene;
+
+		_this.renderer.autoClearDepth = false;
+		_this.renderer.autoClearStencil = false;
+
+		_gl.stencilFunc( _gl.EQUAL, 1, 0xffffffff );
+		_gl.stencilOp( _gl.KEEP, _gl.KEEP, _gl.KEEP );
+
+		_compLight.render();
+
+	};
+
+	/*
+	 * Light Pre-Pass Rendering
+	 *
+	 * 3') Reconstruction pass
+	 *
+	 * Transprency handling:
+	 * Here renders transparent objects with normal forward rendering.
+	 */
+
+	var renderReconstruction = function ( scene, camera ) {
+
+		scene.traverse( setMaterialReconstruction );
+
+		_passReconstruction.scene = scene;
+		_passReconstruction.camera = camera;
+
+		_this.renderer.autoClearDepth = false;
+		_this.renderer.autoClearStencil = false;
+
+		_compReconstruction.render();
+
+		_gl.disable( _gl.STENCIL_TEST );
+
+	};
+
+	/*
+	 * Classic Deferred Rendering
+	 *
+	 * 4) Final pass
 	 *
 	 * transparency handling:
 	 * If there's any transparent objects, here renders them on the deferred rendering result
-	 * with forward rendering. This may be the easist way but heavy.
+	 * with normal forward rendering. This may be the easist way but heavy.
 	 * We should consider any better ways someday.
+	 *
+	 *
+	 * Light Pre-Pass Rendering
+	 *
+	 * 4') Final pass
+	 *
+	 *
+	 * Common
 	 *
 	 * antialias handling:
 	 * Here uses postprocessing FXAA for antialias.
+	 *
 	 */
 
-	var renderComposite = function ( scene, camera ) {
+	var renderFinal = function ( scene, camera ) {
 
-		if ( _hasTransparentObject ) {
+		if ( ! _lightPrePass && _hasTransparentObject ) {
 
 			scene.traverse( setMaterialForwardRendering );
 
@@ -945,7 +1335,7 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 		}
 
-		enableCompositePasses();
+		enableFinalPasses();
 
 		_this.renderer.autoClearDepth = false;
 		_this.renderer.autoClearStencil = false;
@@ -966,11 +1356,12 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		_compNormalDepth.setSize( _width, _height );
 		_compColor.setSize( _width, _height );
 		_compLight.setSize( _width, _height );
+		_compReconstruction.setSize( _width, _height );
 		_compFinal.setSize( _width, _height );
 
-		_compNormalDepth.renderTarget2.depthTexture.image.width = _width;
-		_compNormalDepth.renderTarget2.depthTexture.image.height = _height;
-		_compNormalDepth.renderTarget2.depthTexture.needsUpdate = true;
+		_depthTexture.image.width = _width;
+		_depthTexture.image.height = _height;
+		_depthTexture.needsUpdate = true;
 
 		_passFXAA.uniforms.resolution.value.set( 1 / _width, 1 / _height );
 
@@ -979,6 +1370,14 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 	this.setAntialias = function ( enabled ) {
 
 		_antialias = enabled;
+
+	};
+
+	this.enableLightPrePass = function ( enabled ) {
+
+		_lightPrePass = enabled;
+
+		_passFinal.uniforms.samplerResult.value = ( _lightPrePass ) ? _compReconstruction.renderTarget2.texture : _compLight.renderTarget2.texture;
 
 	};
 
@@ -1005,13 +1404,23 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 
 		_hasTransparentObject = false;
 
-		scene.traverse( initDeferredProperties );
 		scene.traverse( saveOriginalMaterialAndCheckTransparency );
 
 		renderNormalDepth( scene, camera );
-		renderColor( scene, camera );
-		renderLight( scene, camera );
-		renderComposite( scene, camera );
+
+		if ( _lightPrePass ) {
+
+			renderLightPre( scene, camera );
+			renderReconstruction( scene, camera );
+
+		} else {
+
+			renderColor( scene, camera );
+			renderLight( scene, camera );
+
+		}
+
+		renderFinal( scene, camera );
 
 		scene.traverse( restoreOriginalMaterial );
 
@@ -1083,10 +1492,33 @@ THREE.DeferredShaderChunk = {
 
 	].join( "\n" ),
 
+	// TODO: optimize normal packing. reference http://aras-p.info/texts/CompactNormalStorage.html
+	packNormalDepthShininess: [
+
+		"vec4 packedNormalDepthShininess;",
+		"packedNormalDepthShininess.x = vec3_to_float( normal * 0.5 + 0.5 );",
+		"packedNormalDepthShininess.z = shininess;",
+		"packedNormalDepthShininess.w = position.z / position.w;"
+
+	].join( "\n" ),
+
+	unpackNormalDepthShininess: [
+
+		"vec4 normalDepthMap = texture2D( samplerNormalDepthShininess, texCoord );",
+		"float depth = normalDepthMap.w;",
+
+		"if ( depth == 0.0 ) discard;",
+
+		"vec3 normal = float_to_vec3( normalDepthMap.x ) * 2.0 - 1.0;",
+		"float shininess = normalDepthMap.z;"
+
+
+	].join( "\n" ),
+
 	packColor: [
 
 		"vec4 packedColor;",
-		"packedColor.x = vec3_to_float( diffuseColor );",
+		"packedColor.x = vec3_to_float( diffuseColor.rgb );",
 		"packedColor.y = vec3_to_float( emissiveColor );",
 		"packedColor.z = vec3_to_float( specularColor );",
 		"packedColor.w = shininess;"
@@ -1103,6 +1535,14 @@ THREE.DeferredShaderChunk = {
 
 	].join( "\n" ),
 
+	packLight: [
+
+		"vec4 packedLight;",
+		"packedLight.xyz = lightIntensity * lightColor * max( dot( lightVector, normal ), 0.0 ) * attenuation;",
+		"packedLight.w = lightIntensity * specular * max( dot( lightVector, normal ), 0.0 ) * attenuation;",
+
+	].join( "\n" ),
+
 	computeVertexPositionVS: [
 
 		"vec2 xy = texCoord * 2.0 - 1.0;",
@@ -1113,21 +1553,18 @@ THREE.DeferredShaderChunk = {
 
 	].join( "\n" ),
 
+	// TODO: calculate schlick
 	computeSpecular: [
 
 		"vec3 halfVector = normalize( lightVector - normalize( vertexPositionVS.xyz ) );",
 		"float dotNormalHalf = max( dot( normal, halfVector ), 0.0 );",
-
-		"float specularNormalization = ( shininess + 2.0001 ) / 8.0;",
-
-		"vec3 schlick = specularColor + vec3( 1.0 - specularColor ) * pow( 1.0 - dot( lightVector, halfVector ), 5.0 );",
-		"vec3 specular = schlick * max( pow( dotNormalHalf, shininess ), 0.0 ) * diffuseColor * max( dot( normal, lightVector ), 0.0 ) * specularNormalization;"
+		"float specular = 0.31830988618 * ( shininess * 0.5 + 1.0 ) * pow( dotNormalHalf, shininess );",
 
 	].join( "\n" ),
 
 	combine: [
 
-		"gl_FragColor = vec4( lightIntensity * lightColor * ( diffuseColor * max( dot( normal, lightVector ), 0.0 ) + specular ), attenuation );"
+		"gl_FragColor = vec4( lightIntensity * lightColor * max( dot( lightVector, normal ), 0.0 ) * ( diffuseColor + specular * specularColor ) * attenuation, 1.0 );"
 
 	].join( "\n" )
 
@@ -1189,13 +1626,13 @@ THREE.ShaderDeferred = {
 
 		uniforms: {
 
-				map: { type: "t", value: null },
-				offsetRepeat: { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+			map: { type: "t", value: null },
+			offsetRepeat: { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
 
-				diffuse: { type: "c", value: new THREE.Color( 0x000000 ) },
-				emissive: { type: "c", value: new THREE.Color( 0x000000 ) },
-				specular: { type: "c", value: new THREE.Color( 0x000000 ) },
-				shininess: { type: "f", value: 30.0 }
+			diffuse: { type: "c", value: new THREE.Color( 0x000000 ) },
+			emissive: { type: "c", value: new THREE.Color( 0x000000 ) },
+			specular: { type: "c", value: new THREE.Color( 0x000000 ) },
+			shininess: { type: "f", value: 30.0 }
 
 		},
 
@@ -1234,7 +1671,7 @@ THREE.ShaderDeferred = {
 
 			"void main() {",
 
-				"vec3 diffuseColor = diffuse;",
+				"vec4 diffuseColor = vec4( diffuse, 1.0 );",
 				"vec3 emissiveColor = emissive;",
 				"vec3 specularColor = specular;",
 
@@ -1534,11 +1971,380 @@ THREE.ShaderDeferred = {
 
 	},
 
-	composite: {
+	normalDepthShininess: {
 
 		uniforms: {
 
-			samplerLight: { type: "t", value: null }
+			shininess: { type: "f", value: 30.0 }
+
+		},
+
+		vertexShader: [
+
+			"varying vec3 vNormal;",
+			"varying vec4 vPosition;",
+
+			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
+			THREE.ShaderChunk[ "skinning_pars_vertex" ],
+
+			"void main() {",
+
+				THREE.ShaderChunk[ "begin_vertex" ],
+				THREE.ShaderChunk[ "beginnormal_vertex" ],
+				THREE.ShaderChunk[ "skinbase_vertex" ],
+				THREE.ShaderChunk[ "skinnormal_vertex" ],
+				THREE.ShaderChunk[ "defaultnormal_vertex" ],
+				THREE.ShaderChunk[ "morphtarget_vertex" ],
+				THREE.ShaderChunk[ "skinning_vertex" ],
+				THREE.ShaderChunk[ "project_vertex" ],
+
+				"vNormal = normalize( normalMatrix * objectNormal );",
+				"vPosition = gl_Position;",
+
+			"}"
+
+		].join( "\n" ),
+
+		fragmentShader: [
+
+			"varying vec3 vNormal;",
+			"varying vec4 vPosition;",
+
+			"uniform float shininess;",
+
+			THREE.DeferredShaderChunk[ "packVector3" ],
+
+			"void main() {",
+
+				"vec3 normal = vNormal;",
+				"vec4 position = vPosition;",
+
+				THREE.DeferredShaderChunk[ "packNormalDepthShininess" ],
+
+				"gl_FragColor = packedNormalDepthShininess;",
+
+			"}"
+
+		].join( "\n" )
+
+	},
+
+	pointLightPre: {
+
+		uniforms: {
+
+			samplerNormalDepthShininess: { type: "t", value: null },
+
+			matProjInverse: { type: "m4", value: new THREE.Matrix4() },
+
+			viewWidth: { type: "f", value: 800 },
+			viewHeight: { type: "f", value: 600 },
+
+			lightColor: { type: "c", value: new THREE.Color( 0x000000 ) },
+			lightPositionVS: { type: "v3", value: new THREE.Vector3( 0, 1, 0 ) },
+			lightIntensity: { type: "f", value: 1.0 },
+			lightRadius: { type: "f", value: 1.0 }
+
+		},
+
+		vertexShader: [
+
+			"void main() {",
+
+				"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+
+			"}"
+
+		].join( "\n" ),
+
+		fragmentShader: [
+
+			"uniform sampler2D samplerNormalDepthShininess;",
+
+			"uniform float viewHeight;",
+			"uniform float viewWidth;",
+
+			"uniform vec3 lightColor;",
+			"uniform vec3 lightPositionVS;",
+			"uniform float lightIntensity;",
+			"uniform float lightRadius;",
+
+			"uniform mat4 matProjInverse;",
+
+			THREE.DeferredShaderChunk[ "unpackFloat" ],
+
+			"void main() {",
+
+				THREE.DeferredShaderChunk[ "computeTextureCoord" ],
+				THREE.DeferredShaderChunk[ "unpackNormalDepthShininess" ],
+				THREE.DeferredShaderChunk[ "computeVertexPositionVS" ],
+
+				"vec3 lightVector = lightPositionVS - vertexPositionVS.xyz;",
+				"float distance = length( lightVector );",
+
+				"if ( distance > lightRadius ) discard;",
+
+				"lightVector = normalize( lightVector );",
+
+				THREE.DeferredShaderChunk[ "computeSpecular" ],
+
+				"float attenuation = saturate( -distance / lightRadius + 1.0 );",
+
+				THREE.DeferredShaderChunk[ "packLight" ],
+
+				"gl_FragColor = packedLight;",
+
+			"}"
+
+		].join( "\n" )
+
+	},
+
+	spotLightPre: {
+
+		uniforms: {
+
+			samplerNormalDepthShininess: { type: "t", value: null },
+
+			matProjInverse: { type: "m4", value: new THREE.Matrix4() },
+
+			viewWidth: { type: "f", value: 800 },
+			viewHeight: { type: "f", value: 600 },
+
+			lightColor: { type: "c", value: new THREE.Color( 0x000000 ) },
+			lightDirectionVS: { type: "v3", value: new THREE.Vector3( 0, 1, 0 ) },
+			lightPositionVS: { type: "v3", value: new THREE.Vector3( 0, 1, 0 ) },
+			lightAngle: { type: "f", value: 1.0 },
+			lightIntensity: { type: "f", value: 1.0 }
+
+		},
+
+		vertexShader: [
+
+			"void main() { ",
+
+				"gl_Position = vec4( sign( position.xy ), 0.0, 1.0 );",
+
+			"}"
+
+		].join( "\n" ),
+
+		fragmentShader: [
+
+			"uniform sampler2D samplerNormalDepthShininess;",
+
+			"uniform float viewHeight;",
+			"uniform float viewWidth;",
+
+			"uniform vec3 lightColor;",
+			"uniform vec3 lightPositionVS;",
+			"uniform vec3 lightDirectionVS;",
+			"uniform float lightAngle;",
+			"uniform float lightIntensity;",
+
+			"uniform mat4 matProjInverse;",
+
+			THREE.DeferredShaderChunk[ "unpackFloat" ],
+
+			"void main() {",
+
+				THREE.DeferredShaderChunk[ "computeTextureCoord" ],
+				THREE.DeferredShaderChunk[ "unpackNormalDepthShininess" ],
+				THREE.DeferredShaderChunk[ "computeVertexPositionVS" ],
+
+				"vec3 lightVector = normalize( lightPositionVS.xyz - vertexPositionVS.xyz );",
+
+				"float rho = dot( lightDirectionVS, lightVector );",
+				"float rhoMax = cos( lightAngle * 0.5 );",
+
+				"if ( rho <= rhoMax ) discard;",
+
+				"float theta = rhoMax + 0.0001;",
+				"float phi = rhoMax + 0.05;",
+				"float falloff = 4.0;",
+
+				"float spot = 0.0;",
+
+				"if ( rho >= phi ) {",
+
+					"spot = 1.0;",
+
+				"} else if ( rho <= theta ) {",
+
+					"spot = 0.0;",
+
+				"} else { ",
+
+					"spot = pow( ( rho - theta ) / ( phi - theta ), falloff );",
+
+				"}",
+
+				THREE.DeferredShaderChunk[ "computeSpecular" ],
+
+				"const float attenuation = 1.0;",
+
+				THREE.DeferredShaderChunk[ "packLight" ],
+
+				"gl_FragColor = spot * packedLight;",
+
+			"}"
+
+		].join( "\n" )
+
+	},
+
+	directionalLightPre: {
+
+		uniforms: {
+
+			samplerNormalDepthShininess: { type: "t", value: null },
+
+			matProjInverse: { type: "m4", value: new THREE.Matrix4() },
+
+			viewWidth: { type: "f", value: 800 },
+			viewHeight: { type: "f", value: 600 },
+
+			lightColor: { type: "c", value: new THREE.Color( 0x000000 ) },
+			lightDirectionVS : { type: "v3", value: new THREE.Vector3( 0, 1, 0 ) },
+			lightIntensity: { type: "f", value: 1.0 }
+
+		},
+
+		vertexShader: [
+
+			"void main() { ",
+
+				"gl_Position = vec4( sign( position.xy ), 0.0, 1.0 );",
+
+			"}"
+
+		].join( '\n' ),
+
+		fragmentShader: [
+
+			"uniform sampler2D samplerNormalDepthShininess;",
+
+			"uniform float viewHeight;",
+			"uniform float viewWidth;",
+
+			"uniform vec3 lightColor;",
+			"uniform vec3 lightDirectionVS;",
+			"uniform float lightIntensity;",
+
+			"uniform mat4 matProjInverse;",
+
+			THREE.DeferredShaderChunk[ "unpackFloat" ],
+
+			"void main() {",
+
+				THREE.DeferredShaderChunk[ "computeTextureCoord" ],
+				THREE.DeferredShaderChunk[ "unpackNormalDepthShininess" ],
+				THREE.DeferredShaderChunk[ "computeVertexPositionVS" ],
+
+				"vec3 lightVector = normalize( lightDirectionVS );",
+
+				THREE.DeferredShaderChunk[ "computeSpecular" ],
+
+				"const float attenuation = 1.0;",
+
+				THREE.DeferredShaderChunk[ "packLight" ],
+
+				"gl_FragColor = packedLight;",
+
+			"}"
+
+		].join( '\n' ),
+
+	},
+
+	reconstruction: {
+
+		uniforms: {
+
+			samplerLight: { type: "t", value: null },
+
+			map: { type: "t", value: null },
+			offsetRepeat: { type: "v4", value: new THREE.Vector4( 0, 0, 1, 1 ) },
+
+			viewWidth: { type: "f", value: 800 },
+			viewHeight: { type: "f", value: 600 },
+
+			diffuse: { type: "c", value: new THREE.Color( 0x000000 ) },
+			emissive: { type: "c", value: new THREE.Color( 0x000000 ) },
+			specular: { type: "c", value: new THREE.Color( 0x000000 ) },
+			shininess: { type: "f", value: 30.0 }
+
+		},
+
+		vertexShader: [
+
+			THREE.ShaderChunk[ "uv_pars_vertex" ],
+			THREE.ShaderChunk[ "morphtarget_pars_vertex" ],
+			THREE.ShaderChunk[ "skinning_pars_vertex" ],
+
+			"void main() {",
+
+				THREE.ShaderChunk[ "uv_vertex" ],
+				THREE.ShaderChunk[ "begin_vertex" ],
+				THREE.ShaderChunk[ "beginnormal_vertex" ],
+				THREE.ShaderChunk[ "skinbase_vertex" ],
+				THREE.ShaderChunk[ "skinnormal_vertex" ],
+				THREE.ShaderChunk[ "defaultnormal_vertex" ],
+				THREE.ShaderChunk[ "morphtarget_vertex" ],
+				THREE.ShaderChunk[ "skinning_vertex" ],
+				THREE.ShaderChunk[ "project_vertex" ],
+
+			"}"
+
+		].join( "\n" ),
+
+		fragmentShader: [
+
+			"uniform sampler2D samplerLight;",
+
+			"uniform vec3 diffuse;",
+			"uniform vec3 emissive;",
+			"uniform vec3 specular;",
+			"uniform float shininess;",
+
+			"uniform float viewHeight;",
+			"uniform float viewWidth;",
+
+			THREE.ShaderChunk[ "uv_pars_fragment" ],
+			THREE.ShaderChunk[ "map_pars_fragment" ],
+
+			THREE.DeferredShaderChunk[ "unpackFloat" ],
+
+			"void main() {",
+
+				"vec4 diffuseColor = vec4( diffuse, 1.0 );",
+				"vec3 emissiveColor = emissive;",
+				"vec3 specularColor = specular;",
+
+				THREE.DeferredShaderChunk[ "computeTextureCoord" ],
+
+				"vec4 light = texture2D( samplerLight, texCoord );",
+
+				THREE.ShaderChunk[ "map_fragment" ],
+
+				"vec3 diffuseFinal = diffuseColor.rgb * light.rgb;",
+				"vec3 emissiveFinal = emissiveColor;",
+				"vec3 specularFinal = specularColor * light.rgb * ( light.a / ( 0.2126 * light.r + 0.7152 * light.g + 0.0722 * light.b + 0.00001 ) );",
+
+				"gl_FragColor = vec4( diffuseFinal + emissiveFinal + specularFinal, 1.0 );",
+
+			"}"
+
+		].join( "\n" )
+
+	},
+
+	// TODO: implement tone mapping
+	final: {
+
+		uniforms: {
+
+			samplerResult: { type: "t", value: null }
 
 		},
 
@@ -1559,11 +2365,11 @@ THREE.ShaderDeferred = {
 		fragmentShader: [
 
 			"varying vec2 texCoord;",
-			"uniform sampler2D samplerLight;",
+			"uniform sampler2D samplerResult;",
 
 			"void main() {",
 
-				"gl_FragColor = texture2D( samplerLight, texCoord );",
+				"gl_FragColor = texture2D( samplerResult, texCoord );",
 
 			"}"
 


### PR DESCRIPTION
I added Light Pre-Pass (Deferred Lighting) support to `WebGLDeferredRenderer`.

Now `WebGLDeferredRenderer` supports two types of Deferred Renderings.
One is Classic Deferred Rendering and the other one is
Light Pre-Pass (Deferred Lighting).

Classic Deferred Rendering is default. You can use Light Pre-Pass
by passing `{ lightPrePass: true }` parameter to constructor or
calling `.enableLightPrePass( true )` method.
