### PR TITLE
Issue #9826. Response type as a parameter in TextureLoader and ImageLoader.

### DIFF
--- a/docs/api/constants/Textures.html
+++ b/docs/api/constants/Textures.html
@@ -88,6 +88,12 @@
 		THREE.RGBA_PVRTC_4BPPV1_Format<br />
 		THREE.RGBA_PVRTC_2BPPV1_Format
 		</div>
+		
+		<h2>TextureLoader and ImageLoader Response Types</h2>
+		<div>
+		THREE.ResponseType.Blob<br />
+		THREE.ResponseType.ArrayBuffer
+		</div>
 
 		<h2>Source</h2>
 

--- a/docs/api/constants/Textures.html
+++ b/docs/api/constants/Textures.html
@@ -88,12 +88,6 @@
 		THREE.RGBA_PVRTC_4BPPV1_Format<br />
 		THREE.RGBA_PVRTC_2BPPV1_Format
 		</div>
-		
-		<h2>TextureLoader and ImageLoader Response Types</h2>
-		<div>
-		THREE.ResponseType.Blob<br />
-		THREE.ResponseType.ArrayBuffer
-		</div>
 
 		<h2>Source</h2>
 

--- a/docs/api/loaders/ImageLoader.html
+++ b/docs/api/loaders/ImageLoader.html
@@ -50,6 +50,14 @@
 		<div>
 		The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS.
 		</div>
+		
+		<h3>[method:null setResponseType]( [page:Enum value] )</h3>
+		<div>
+		[page:Enum value] — The response type of the XHR request. Can be THREE.ResponseType.Blob (default) or THREE.ResponseType.ArrayBuffer.
+		</div>
+		<div>
+		When loading images from a web server to a local script, the default "blob" response type may be restricted for security reasons.
+		</div>
 
 		<h2>Example</h2>
 

--- a/docs/api/loaders/ImageLoader.html
+++ b/docs/api/loaders/ImageLoader.html
@@ -51,9 +51,9 @@
 		The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS.
 		</div>
 		
-		<h3>[method:null setResponseType]( [page:Enum value] )</h3>
+		<h3>[method:null setResponseType]( [page:String value] )</h3>
 		<div>
-		[page:Enum value] — The response type of the XHR request. Can be THREE.ResponseType.Blob (default) or THREE.ResponseType.ArrayBuffer.
+		[page:String value] — The response type of the XHR request. Can be a string "blob" (default) or "arraybuffer".
 		</div>
 		<div>
 		When loading images from a web server to a local script, the default "blob" response type may be restricted for security reasons.

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -46,9 +46,9 @@
 		Begin loading from url and pass the loaded [page:Texture texture] to onLoad.
 		</div>
 
-		<h3>[method:null setResponseType]( [page:Enum value] )</h3>
+		<h3>[method:null setResponseType]( [page:String value] )</h3>
 		<div>
-		[page:Enum value] — The response type of the XHR request. Can be THREE.ResponseType.Blob (default) or THREE.ResponseType.ArrayBuffer.
+		[page:String value] — The response type of the XHR request. Can be a string "blob" (default) or "arraybuffer".
 		</div>
 		<div>
 		When loading texture images from a web server to a local script, the default "blob" response type may be restricted for security reasons.

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -46,7 +46,13 @@
 		Begin loading from url and pass the loaded [page:Texture texture] to onLoad.
 		</div>
 
-
+		<h3>[method:null setResponseType]( [page:Enum value] )</h3>
+		<div>
+		[page:Enum value] — The response type of the XHR request. Can be THREE.ResponseType.Blob (default) or THREE.ResponseType.ArrayBuffer.
+		</div>
+		<div>
+		When loading texture images from a web server to a local script, the default "blob" response type may be restricted for security reasons.
+		</div>
 
 		<h2>Example</h2>
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -154,3 +154,9 @@ export var RGBM16Encoding = 3005;
 export var RGBDEncoding = 3006;
 export var BasicDepthPacking = 3200;
 export var RGBADepthPacking = 3201;
+export var ResponseTypeBlob = "blob";
+export var ResponseTypeArrayBuffer = "arraybuffer";
+export var ResponseType = {
+	Blob: ResponseTypeBlob,
+	ArrayBuffer: ResponseTypeArrayBuffer
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -154,9 +154,3 @@ export var RGBM16Encoding = 3005;
 export var RGBDEncoding = 3006;
 export var BasicDepthPacking = 3200;
 export var RGBADepthPacking = 3201;
-export var ResponseTypeBlob = "blob";
-export var ResponseTypeArrayBuffer = "arraybuffer";
-export var ResponseType = {
-	Blob: ResponseTypeBlob,
-	ArrayBuffer: ResponseTypeArrayBuffer
-};

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -43,18 +43,18 @@ Object.assign( ImageLoader.prototype, {
 			loader.setWithCredentials( this.withCredentials );
 			loader.load( url, function ( response ) {
 
-				if (loader.responseType == THREE.ResponseType.Blob) {
+				if (loader.responseType == 'blob') {
 				
 					image.src = URL.createObjectURL( response );
 					
-				} else if (loader.responseType == THREE.ResponseType.ArrayBuffer) {
+				} else if (loader.responseType == 'arraybuffer') {
 				
 					var bytes = new Uint8Array(response);
 					var binary = '';
 					var len = bytes.byteLength;
-					var chunkSize = 32768;
+					var chunkSize = Math.min(len, 32768);
 					for (var i = 0; i < len; i += chunkSize) {
-						binary += String.fromCharCode.apply( bytes.subarray( i, i + chunkSize) );
+						binary += String.fromCharCode.apply( null, bytes.subarray( i, i + chunkSize) );
 					}
 					var b64 = btoa(binary);
 					var dataURL = "data:image/png;base64," + b64;

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -23,6 +23,7 @@ Object.assign( TextureLoader.prototype, {
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setWithCredentials( this.withCredentials );
 		loader.setPath( this.path );
+		loader.setResponseType( this.responseType );
 		loader.load( url, function ( image ) {
 
 			// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
@@ -63,9 +64,13 @@ Object.assign( TextureLoader.prototype, {
 		this.path = value;
 		return this;
 
-	}
+	},
 
-
+	setResponseType: function ( value ) {
+	
+		this.responseType = value;
+		return this;
+	},
 
 } );
 


### PR DESCRIPTION
Added response type to be a parameter for `ImageLoader` and `TextureLoader`. Added constants for `ResponseType.Blob` and `ResponseType.ArrayBuffer`. Implemented `arraybuffer` response parsing in `ImageLoader`. Updated docs.
