### PR TITLE
VREffect: expose eye cameras

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -332,7 +332,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			this.cameras = cameras;
+			scope.cameras = cameras;
 
 			// render left eye
 			if ( renderTarget ) {
@@ -394,7 +394,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 		// Regular render mode if not HMD
 
-		this.cameras = null;
+		scope.cameras = null;
 		renderer.render( scene, camera, renderTarget, forceClear );
 
 	};

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -228,8 +228,9 @@ THREE.VREffect = function ( renderer, onError ) {
 	var cameraR = new THREE.PerspectiveCamera();
 	cameraR.layers.enable( 2 );
 
-	this.cameraL = null;
-	this.cameraR = null;
+	// For use by view dependant post processing effects
+	this.cameraL = cameraL;
+	this.cameraR = cameraR;
 
 	this.render = function ( scene, camera, renderTarget, forceClear ) {
 
@@ -387,16 +388,9 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			// For use by view dependant post processing effects
-			scope.cameraL = cameraL;
-			scope.cameraR = cameraR;
-
 			return;
 
 		}
-
-		scope.cameraL = null;
-		scope.cameraR = null;
 
 		// Regular render mode if not HMD
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -228,6 +228,9 @@ THREE.VREffect = function ( renderer, onError ) {
 	var cameraR = new THREE.PerspectiveCamera();
 	cameraR.layers.enable( 2 );
 
+	this.cameraL = null;
+	this.cameraR = null;
+
 	this.render = function ( scene, camera, renderTarget, forceClear ) {
 
 		if ( vrDisplay && scope.isPresenting ) {
@@ -265,8 +268,8 @@ THREE.VREffect = function ( renderer, onError ) {
 
 				var layer = layers[ 0 ];
 
-				leftBounds = layer.leftBounds !== null && layer.leftBounds.length === 4 ? layer.leftBounds : defaultLeftBounds;
-				rightBounds = layer.rightBounds !== null && layer.rightBounds.length === 4 ? layer.rightBounds : defaultRightBounds;
+				leftBounds = layer.leftBounds && layer.leftBounds.length === 4 ? layer.leftBounds : defaultLeftBounds;
+				rightBounds = layer.rightBounds && layer.rightBounds.length === 4 ? layer.rightBounds : defaultRightBounds;
 
 			} else {
 
@@ -384,9 +387,16 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
+			// For use by view dependant post processing effects
+			scope.cameraL = cameraL;
+			scope.cameraR = cameraR;
+
 			return;
 
 		}
+
+		scope.cameraL = null;
+		scope.cameraR = null;
 
 		// Regular render mode if not HMD
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -228,9 +228,7 @@ THREE.VREffect = function ( renderer, onError ) {
 	var cameraR = new THREE.PerspectiveCamera();
 	cameraR.layers.enable( 2 );
 
-	// For use by view dependant post processing effects
-	this.cameraL = cameraL;
-	this.cameraR = cameraR;
+	var cameras = [cameraL, cameraR];
 
 	this.render = function ( scene, camera, renderTarget, forceClear ) {
 
@@ -334,6 +332,8 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
+			this.cameras = cameras;
+
 			// render left eye
 			if ( renderTarget ) {
 
@@ -394,6 +394,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 		// Regular render mode if not HMD
 
+		this.cameras = null;
 		renderer.render( scene, camera, renderTarget, forceClear );
 
 	};


### PR DESCRIPTION
Exposes cameraL and cameraR from VREffect in a VREffect.cameras array, if presenting for the current frame. This is useful to support eg. godrays and other post processing effects that depend on the view.
