### PR TITLE
Don't use `eval` in GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -664,7 +664,7 @@ var replaceTHREEShaderAttributes = function( shaderText, technique ) {
 
 		var semantic = param.semantic;
 
-		var regEx = eval( "/" + pname + "/g" );
+		var regEx = new RegExp( pname, "g" );
 
 		switch ( semantic ) {
 


### PR DESCRIPTION
Eval was being used to construct a regex pattern. This replaces that with the RegExp constructor.
