### PR TITLE
Fixed INVALID_OPERATION error with WebGL when using linewidth on IE11

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -336,7 +336,9 @@ function WebGLState( gl, extensions, paramThreeToGL ) {
 
 	var maxTextures = gl.getParameter( gl.MAX_TEXTURE_IMAGE_UNITS );
 
-	var lineWidthAvailable = parseFloat(gl.getParameter(gl.VERSION).split(' ')[1]) >= 1.0;
+	var glVersion = gl.getParameter(gl.VERSION).split(' ')[1];
+	var glMajorVersion = glVersion.split('.').slice(0, 2).join('.');
+	var lineWidthAvailable = parseFloat(glMajorVersion) >= 1.0;
 
 	var currentTextureSlot = null;
 	var currentBoundTextures = {};

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -728,9 +728,9 @@ function WebGLState( gl, extensions, paramThreeToGL ) {
 
 	function setLineWidth( width ) {
 
-		if ( lineWidthAvailable && width !== currentLineWidth ) {
+		if ( width !== currentLineWidth ) {
 
-			gl.lineWidth( width );
+			if ( lineWidthAvailable ) gl.lineWidth( width );
 
 			currentLineWidth = width;
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -336,6 +336,8 @@ function WebGLState( gl, extensions, paramThreeToGL ) {
 
 	var maxTextures = gl.getParameter( gl.MAX_TEXTURE_IMAGE_UNITS );
 
+	var lineWidthAvailable = parseFloat(gl.getParameter(gl.VERSION).split(' ')[1]) >= 1.0;
+
 	var currentTextureSlot = null;
 	var currentBoundTextures = {};
 
@@ -724,7 +726,7 @@ function WebGLState( gl, extensions, paramThreeToGL ) {
 
 	function setLineWidth( width ) {
 
-		if ( width !== currentLineWidth ) {
+		if ( lineWidthAvailable && width !== currentLineWidth ) {
 
 			gl.lineWidth( width );
 


### PR DESCRIPTION
When using linewidth attribute of THREE.Material on IE11, console throws a INVALID_OPERATION error. It is due to IE11 using WebGL 0.93, which is a preliminary version of WebGL.

To fix this, I propose to add a flag in WebGLState checking that WebGL version is greater or equals to 1.0. Then the flag is used before calling gl.lineWidth().

This fix makes easy to manage ThreeJS apps when wanting a compatibility with IE11. Otherwise, you have to check yourself when creating a material with linewidth attribute and avoid to set this parameter when OpenGL Version < 1.0.

Note : 
- See https://www.khronos.org/registry/webgl/specs/1.0/#5.14.3 at VERSION for retrieving version number trick
- See https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2 to check it's also compatible with WebGL2 getParameter
