### PR TITLE
Improve Vive controller detection example

### DIFF
--- a/examples/js/vr/ViveController.js
+++ b/examples/js/vr/ViveController.js
@@ -23,11 +23,14 @@ THREE.ViveController = function ( id ) {
 
 		var gamepads = navigator.getGamepads();
 
-		for ( var i = 0, j = 0; i < 4; i ++ ) {
+		for ( var i = 0, j = 0; i < gamepads.length; i ++ ) {
 
 			var gamepad = gamepads[ i ];
 
-			if ( gamepad && gamepad.id === 'OpenVR Gamepad' ) {
+			if ( gamepad && gamepad.id === 'OpenVR Gamepad' ||
+			     gamepad && gamepad.buttons &&
+			     gamepad.buttons.length >= 4 &&
+			     gamepad.buttons.length <= 7 ) {
 
 				if ( j === id ) return gamepad;
 


### PR DESCRIPTION
> Check all the gamepads.  Detect controllers by number of buttons, in
> addition to the current, but fragile, id string.  The Vive controller
> has 4 buttons.  The Occulus touch looks like 6.  An upper limit of 7
> avoids traditional gamepads.

I'm running a custom webvr stack, and my Vive controllers weren't being found.

The id string match was failing, because they aren't OpenVR gamepads.  Thus the additional functional check.  I kept the string match only because I can't run and regression test OpenVR.

Only 3 gamepads were being checked, since gamepads[0] is spec'ed to be null.  So with a headset (the Vive HMD has a button), and a single traditional gamepad, only one controller could be seen.  Add two Vive base stations (for their pose, and mode button), and a controller's odds weren't good.

The button test may give a false positive on the Samsung Gear VR HMD.  It functionally looks a lot like a Vive controller.  But, baby steps.

Thank you for your work.
