### PR TITLE
Call renderer.clear() from StereoEffect if renderer.autoClear is true

### DIFF
--- a/examples/js/effects/StereoEffect.js
+++ b/examples/js/effects/StereoEffect.js
@@ -32,7 +32,7 @@ THREE.StereoEffect = function ( renderer ) {
 
 		var size = renderer.getSize();
 
-		renderer.clear();
+		if ( renderer.autoClear ) renderer.clear();
 		renderer.setScissorTest( true );
 
 		renderer.setScissor( 0, 0, size.width / 2, size.height );


### PR DESCRIPTION
This PR enables users to control `autoClear` for `StereoEffect`
by letting `StereoEffect` call `renderer.clear()` only if  `renderer.autoClear` is `true` like `VREffect` does.

I needed this when I attempted to try Outline drawing with `StereoEffect`.

My outline drawing requires two rendering pass with `StereoEffect`
and second pass needs `autoClear` off but I couldn't control it from outside.

```
setupForNormalRendering();
renderer.autoClear = true;
effect.renderer( scene, camera );

setupForOutlineDrawing();
renderer.autoClear = false;
effect.renderer( scene, camera );
```
