### PR TITLE
Make Color.setScalar returns this.

### DIFF
--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -53,6 +53,8 @@ Color.prototype = {
 		this.g = scalar;
 		this.b = scalar;
 
+		return this;
+
 	},
 
 	setHex: function ( hex ) {


### PR DESCRIPTION
Color.setScalar() doesn't return _this_ unlike all the other set\* methods.
Assuming this is an oversight, fix it - now it matches the documentation.
