### PR TITLE
fixing editor example jsons

### DIFF
--- a/editor/examples/arkanoid.app.json
+++ b/editor/examples/arkanoid.app.json
@@ -1,5 +1,10 @@
 {
+	"metadata": {
+		"type": "App"
+	},
 	"project": {
+		"shadows": true,
+		"editable": true,
 		"vr": false
 	},
 	"camera": {

--- a/editor/examples/camera.app.json
+++ b/editor/examples/camera.app.json
@@ -1,4 +1,12 @@
 {
+	"metadata": {
+		"type": "App"
+	},
+	"project": {
+		"shadows": true,
+		"editable": true,
+		"vr": false
+	},
 	"camera": {
 		"metadata": {
 			"version": 4.3,


### PR DESCRIPTION
The examples provided for the editor would not load on the website.  I think it is because of the missing header information that I added in this commit.  These new files load on the live website for me now.
