### PR TITLE
Update SkyShader.js to fix random dark sky due to float precision

### DIFF
--- a/examples/js/SkyShader.js
+++ b/examples/js/SkyShader.js
@@ -66,6 +66,7 @@ THREE.ShaderLib[ 'sky' ] = {
 
 		"float sunIntensity(float zenithAngleCos)",
 		"{",
+		    	"zenithAngleCos = clamp(zenithAngleCos, -1.0, 1.0);",
 			"return EE * max(0.0, 1.0 - pow(e, -((cutoffAngle - acos(zenithAngleCos))/steepness)));",
 		"}",
 


### PR DESCRIPTION
- Previously if you put sun at vec3(0.0, 1.0, 0.0) and move it along the Y axis, the sky will suddenly become super dark at some random position. Further investigation shows the value passed into function sunIntensity is slightly larger than 1.0 due to float precision issue. Add a clamp will help get rid of such problems.
