### PR TITLE
GLTFLoader regex word boundary matchers around regular expressions

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -664,7 +664,7 @@ var replaceTHREEShaderAttributes = function( shaderText, technique ) {
 
 		var semantic = param.semantic;
 
-		var regEx = new RegExp( pname, "g" );
+		var regEx = new RegExp( "\\b" + pname + "\\b", "g" );
 
 		switch ( semantic ) {
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/9890.
