### PR TITLE
Fix no json parsing check

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -59,7 +59,7 @@ Object.assign( ObjectLoader.prototype, {
 
 				json = JSON.parse( text );
 
-                        } catch(error) {
+                        } catch( error ) {
 
 				console.log(err.message);
 				onError(loader);

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -53,7 +53,24 @@ Object.assign( ObjectLoader.prototype, {
 		var loader = new XHRLoader( scope.manager );
 		loader.load( url, function ( text ) {
 
-			scope.parse( JSON.parse( text ), onLoad );
+			var json = null;
+			
+			try {
+
+				json = JSON.parse( text );
+
+                        } catch(error) {
+
+				console.log(err.message);
+				onError(loader);
+
+                        }
+
+			if ( json ) {
+
+                            scope.parse( json, onLoad );
+
+                        }
 
 		}, onProgress, onError );
 


### PR DESCRIPTION
The ObjectLoader didn't check for JSON parsing errors : if such an error happened, the onError callback wouldn't be called. This patch encloses the JSON parsing in try / catch block that calls onError in case of error.
