### PR TITLE
TransformControls: Added scaleSpeed parameter to change scaling sensitivity

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -620,6 +620,7 @@
 		this.space = "world";
 		this.size = 1;
 		this.axis = null;
+		this.scaleSpeed = 1.0;
 
 		var scope = this;
 
@@ -978,7 +979,7 @@
 
 					if ( scope.axis === "XYZ" ) {
 
-						scale = 1 + ( ( point.y ) / Math.max( oldScale.x, oldScale.y, oldScale.z ) );
+						scale = 1 + ( ( point.y ) / Math.max( oldScale.x, oldScale.y, oldScale.z ) ) * scope.scaleSpeed;
 
 						scope.object.scale.x = oldScale.x * scale;
 						scope.object.scale.y = oldScale.y * scale;
@@ -988,9 +989,9 @@
 
 						point.applyMatrix4( tempMatrix.getInverse( worldRotationMatrix ) );
 
-						if ( scope.axis === "X" ) scope.object.scale.x = oldScale.x * ( 1 + point.x / oldScale.x );
-						if ( scope.axis === "Y" ) scope.object.scale.y = oldScale.y * ( 1 + point.y / oldScale.y );
-						if ( scope.axis === "Z" ) scope.object.scale.z = oldScale.z * ( 1 + point.z / oldScale.z );
+						if ( scope.axis === "X" ) scope.object.scale.x = oldScale.x * ( 1 + point.x / oldScale.x * scope.scaleSpeed);
+						if ( scope.axis === "Y" ) scope.object.scale.y = oldScale.y * ( 1 + point.y / oldScale.y * scope.scaleSpeed);
+						if ( scope.axis === "Z" ) scope.object.scale.z = oldScale.z * ( 1 + point.z / oldScale.z * scope.scaleSpeed);
 
 					}
 

--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -69,6 +69,7 @@
 				var material = new THREE.MeshLambertMaterial( { map: texture } );
 
 				control = new THREE.TransformControls( camera, renderer.domElement );
+				control.scaleSpeed = 0.1;
 				control.addEventListener( 'change', render );
 
 				var mesh = new THREE.Mesh( geometry, material );


### PR DESCRIPTION
This adds a `scaleSpeed` parameter to the `TransformControls` to let users change the sensitivity of the overall scaling.

I chose `scaleSpeed` because the other controls are also using `*Speed` for translation and rotation speeds. Not sure though if it is a good name. Maybe `scaleSensitivity`?

See issue #5489 
