### PR TITLE
add Object3D traverseReverse method

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -484,6 +484,20 @@ Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 
 	},
 
+	traverseReverse: function ( callback ) {
+
+		var children = this.children;
+
+		for ( var i = children.length; i -- ; ) {
+
+			children[ i ].traverseReverse( callback );
+
+		}
+
+		callback( this );
+
+	},
+
 	traverseVisible: function ( callback ) {
 
 		if ( this.visible === false ) return;


### PR DESCRIPTION
Because you can never have enough traversal methods.

I find this useful for tearing down parts of the scene graph where I want to make sure the Object3D removed Event listeners are called. Depth first and in reverse child order so objects can be removed during traversal. 

I'll document if wanted, if you are not interested I'll delete the PR.
