### PR TITLE
Support uniform updates from onBeforeRender callback

### DIFF
--- a/src/core/Uniform.js
+++ b/src/core/Uniform.js
@@ -11,8 +11,34 @@ function Uniform( value ) {
 
 	}
 
-	this.value = value;
+	this._value = value;
+
+	this.needsUpdate = true;
 
 }
+
+Uniform.prototype = {
+
+	constructor: Uniform,
+
+	get value() {
+
+		return this._value;
+
+	},
+
+	set value( value ) {
+
+		if ( this.needsUpdate === false && value !== this._value ) {
+
+			this.needsUpdate = true;
+
+		}
+
+		this._value = value;
+
+	}
+
+};
 
 export { Uniform };

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1874,7 +1874,20 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		var uniformsList = materialProperties.uniformsList;
+
 		if ( refreshMaterial ) {
+
+			// flag all material uniforms for update
+
+			// a material or program switch typically necessitates uploading all
+			// material uniforms
+
+			for ( var i = 0, n = uniformsList.length; i < n; ++ i ) {
+
+				m_uniforms[ uniformsList[ i ].id ].needsUpdate = true;
+
+			}
 
 			if ( material.lights ) {
 
@@ -1959,8 +1972,23 @@ function WebGLRenderer( parameters ) {
 			WebGLUniforms.upload(
 					_gl, materialProperties.uniformsList, m_uniforms, _this );
 
-		}
+		} else {
 
+			// upload updated uniforms
+
+			// onBeforeRender creates the possibility that a material uniform
+			// is modified even when the current material or program hasn't
+			// switched
+
+			var updatedUniforms = WebGLUniforms.updatedList( uniformsList, m_uniforms );
+
+			if ( updatedUniforms !== null ) {
+
+				WebGLUniforms.upload( _gl, updatedUniforms, m_uniforms, _this );
+
+			}
+
+		}
 
 		// common matrices
 

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -518,6 +518,8 @@ WebGLUniforms.upload = function( gl, seq, values, renderer ) {
 
 			u.setValue( gl, v.value, renderer );
 
+			v.needsUpdate = false;
+
 		}
 
 	}
@@ -532,6 +534,29 @@ WebGLUniforms.seqWithValue = function( seq, values ) {
 
 		var u = seq[ i ];
 		if ( u.id in values ) r.push( u );
+
+	}
+
+	return r;
+
+};
+
+WebGLUniforms.updatedList = function( seq, values ) {
+
+	var r = null,
+		n = seq.length;
+
+	for ( var i = 0; i !== n; ++ i ) {
+
+		var u = seq[ i ],
+			v = values[ u.id ];
+
+		if ( v && v.needsUpdate === true ) {
+
+			if ( r === null ) r = [];
+			r.push( u );
+
+		}
 
 	}
 


### PR DESCRIPTION
Per issue #9870 and as highlighted by @arose here: https://github.com/mrdoob/three.js/issues/9662#issuecomment-249395529, this PR creates a mechanism to support updating / uploading uniform values that are modified by `onBeforeRender` callbacks.

The basic gist of this PR is that `THREE.Uniform.value` is now a getter/setter, and the setter handles flagging a changed value as dirty. I've updated `THREE.WebGLRenderer` and `THREE.WebGLUniforms` to support managing the dirty state over the course of rendering.

I've tested several examples to verify they still work--including various lighting examples, as lighting uniforms seem to make use of `.needsUpdate` on `THREE.Uniform`.

Possibly a better solution would be to keep an `uploadedValue` property around in `THREE.Uniform` to track the last value uploaded to the GPU, and change the `THREE.Uniform.value` setter to compare against `uploadedValue` when setting `needsUpdate`.
