### PR TITLE
added setDrawRange to Object3D

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -91,8 +91,10 @@ function Object3D() {
 
 	this.userData = {};
 
-	this.onBeforeRender = function(){}; 
+	this.onBeforeRender = function(){};
 	this.onAfterRender = function(){};
+
+	this.drawRange = { start: 0, count: Infinity };
 
 }
 
@@ -722,6 +724,13 @@ Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 		}
 
 		return this;
+
+	},
+
+	setDrawRange: function ( start, count ) {
+
+		this.drawRange.start = start;
+		this.drawRange.count = count;
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -825,8 +825,8 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		var rangeStart = geometry.drawRange.start * rangeFactor;
-		var rangeCount = geometry.drawRange.count * rangeFactor;
+		var rangeStart = ( object.drawRange.start || geometry.drawRange.start ) * rangeFactor;
+		var rangeCount = ( object.drawRange.count || geometry.drawRange.count ) * rangeFactor;
 
 		var groupStart = group !== null ? group.start * rangeFactor : 0;
 		var groupCount = group !== null ? group.count * rangeFactor : Infinity;
@@ -1742,7 +1742,7 @@ function WebGLRenderer( parameters ) {
 				material.needsUpdate = true;
 
 			} else if ( materialProperties.numClippingPlanes !== undefined &&
-				( materialProperties.numClippingPlanes !== _clipping.numPlanes || 
+				( materialProperties.numClippingPlanes !== _clipping.numPlanes ||
  				  materialProperties.numIntersection  !== _clipping.numIntersection ) ) {
 
 				material.needsUpdate = true;


### PR DESCRIPTION
Similar to https://github.com/mrdoob/three.js/issues/9662, there are attributes that are assigned at the geometry level that should be at the instance (mesh) level. The onBeforeRender and onAfterRender callback are an extreme solution to something that, as the uniforms defined at mesh level, should be managed internally by the engine.

It's assigned to Object3D since that's the base object that the method accepts, but if there are concerns for overhead, there can be an explicit check that the object supports geometry ranges.
