### PR TITLE
Set null to scene.background for second pass of OutlineEffect

### DIFF
--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -273,9 +273,11 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 
 		// 2. render outline
 		var currentSceneAutoUpdate = scene.autoUpdate;
+		var currentSceneBackground = scene.background;
 		var currentShadowMapEnabled = renderer.shadowMap.enabled;
 
 		scene.autoUpdate = false;
+		scene.background = null;
 		renderer.autoClear = false;
 		renderer.shadowMap.enabled = false;
 
@@ -286,6 +288,7 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 		scene.traverse( restoreOriginalMaterial );
 
 		scene.autoUpdate = currentSceneAutoUpdate;
+		scene.background = currentSceneBackground;
 		renderer.autoClear = currentAutoClear;
 		renderer.shadowMap.enabled = currentShadowMapEnabled;
 


### PR DESCRIPTION
I set `null` to `scene.background` for second pass of `OutlineEffect`
because the second pass needs to prevent `renderer.clear()` call.
