### PR TITLE
Remove reference to THREE in IcosahedronGeometry.js

### DIFF
--- a/src/geometries/DodecahedronGeometry.js
+++ b/src/geometries/DodecahedronGeometry.js
@@ -16,7 +16,7 @@ function DodecahedronGeometry( radius, detail ) {
 		detail: detail
 	};
 
-	this.fromBufferGeometry( new THREE.DodecahedronBufferGeometry( radius, detail ) );
+	this.fromBufferGeometry( new DodecahedronBufferGeometry( radius, detail ) );
 	this.mergeVertices();
 
 }

--- a/src/geometries/IcosahedronGeometry.js
+++ b/src/geometries/IcosahedronGeometry.js
@@ -16,7 +16,7 @@ function IcosahedronGeometry( radius, detail ) {
 		detail: detail
 	};
 
-	this.fromBufferGeometry( new THREE.IcosahedronBufferGeometry( radius, detail ) );
+	this.fromBufferGeometry( new IcosahedronBufferGeometry( radius, detail ) );
 	this.mergeVertices();
 
 }

--- a/src/geometries/OctahedronGeometry.js
+++ b/src/geometries/OctahedronGeometry.js
@@ -16,7 +16,7 @@ function OctahedronGeometry( radius, detail ) {
 		detail: detail
 	};
 
-	this.fromBufferGeometry( new THREE.OctahedronBufferGeometry( radius, detail ) );
+	this.fromBufferGeometry( new OctahedronBufferGeometry( radius, detail ) );
 	this.mergeVertices();
 
 }

--- a/src/geometries/TetrahedronGeometry.js
+++ b/src/geometries/TetrahedronGeometry.js
@@ -16,7 +16,7 @@ function TetrahedronGeometry( radius, detail ) {
 		detail: detail
 	};
 
-	this.fromBufferGeometry( new THREE.TetrahedronBufferGeometry( radius, detail ) );
+	this.fromBufferGeometry( new TetrahedronBufferGeometry( radius, detail ) );
 	this.mergeVertices();
 
 }


### PR DESCRIPTION
Remove old reference to the THREE namespace.
