### PR TITLE
I moved the build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The aim of the project is to create an easy to use, lightweight, 3D library. The
 ### Usage ###
 
 Download the [minified library](http://threejs.org/build/three.min.js) and include it in your html.
-Alternatively see [how to build the library yourself](https://github.com/mrdoob/three.js/wiki/build.py,-or-how-to-generate-a-compressed-Three.js-file).
+Alternatively see [how to build the library yourself](https://github.com/mrdoob/three.js/wiki/Build-instructions).
 
 ```html
 <script src="js/three.min.js"></script>


### PR DESCRIPTION
Moved from:
https://github.com/mrdoob/three.js/wiki/build.py,-or-how-to-generate-a-compressed-Three.js-file

to:
https://github.com/mrdoob/three.js/wiki/Build-instructions
