### PR TITLE
Quick fix nexus5 point/spot light issues

### DIFF
--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl
@@ -1,9 +1,3 @@
-bool testLightInRange( const in float lightDistance, const in float cutoffDistance ) {
-
-	return any( bvec2( lightDistance == 0.0, lightDistance < cutoffDistance ) );
-
-}
-
 float calcLightAttenuation( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {
 
 	if ( decayExponent > 0.0 ) {

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -65,7 +65,7 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 		directLight.color = pointLight.color;
 		directLight.color *= punctualLightIntensityToIrradianceFactor( lightDistance, pointLight.distance, pointLight.decay );
-		directLight.visible = ( directLight.color != vec3( 0.0, 0.0, 0.0 ) );
+		directLight.visible = ( directLight.color != vec3( 0.0 ) );
 
 	}
 
@@ -106,7 +106,7 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 			directLight.color = spotLight.color;
 			directLight.color *= spotEffect * punctualLightIntensityToIrradianceFactor( lightDistance, spotLight.distance, spotLight.decay );
-			directLight.visible = ( directLight.color != vec3( 0.0, 0.0, 0.0 ) );
+			directLight.visible = ( directLight.color != vec3( 0.0 ) );
 
 		} else {
 

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -51,16 +51,8 @@
 
 		float lightDistance = length( lVector );
 
-		if ( testLightInRange( lightDistance, pointLight.distance ) ) {
-
-			directLight.color = pointLight.color;
-			directLight.color *= calcLightAttenuation( lightDistance, pointLight.distance, pointLight.decay );
-
-		} else {
-
-			directLight.color = vec3( 0.0 );
-
-		}
+		directLight.color = pointLight.color;
+		directLight.color *= calcLightAttenuation( lightDistance, pointLight.distance, pointLight.decay );
 
 		return directLight;
 
@@ -98,7 +90,7 @@
 		float lightDistance = length( lVector );
 		float spotEffect = dot( directLight.direction, spotLight.direction );
 
-		if ( all( bvec2( spotEffect > spotLight.angleCos, testLightInRange( lightDistance, spotLight.distance ) ) ) ) {
+		if ( spotEffect > spotLight.angleCos ) {
 
 			float spotEffect = dot( spotLight.direction, directLight.direction );
 			spotEffect *= clamp( ( spotEffect - spotLight.angleCos ) / spotLight.penumbra, 0.0, 1.0 );

--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -100,13 +100,13 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 		float lightDistance = length( lVector );
 		float angleCos = dot( directLight.direction, spotLight.direction );
 
-		if ( spotEffect > spotLight.angleCos ) {
+		if ( angleCos > spotLight.coneCos ) {
 
 			float spotEffect = smoothstep( spotLight.coneCos, spotLight.penumbraCos, angleCos );
 
 			directLight.color = spotLight.color;
 			directLight.color *= spotEffect * punctualLightIntensityToIrradianceFactor( lightDistance, spotLight.distance, spotLight.decay );
-			directLight.visible = ( directLight.color != vec3( 0.0 ) );
+			directLight.visible = true;//( directLight.color != vec3( 0.0 ) );
 
 		} else {
 


### PR DESCRIPTION
This PR fixes the issue with more than one point or spot light not working on Nexus 5 devices, addressing long standing issues #9100 #9871.

To fix this I removed the testLightInRange function which was added in this commit: https://github.com/mrdoob/three.js/commit/3adb436bad83f879592b299b6155f3c9dc3a746f 

I doubt this is really the best fix.  I know that the testLightInRange function does hvae issues in that it doesn't look at decayExponent in the same way that it is used in punctualLightIntensityToIrradianceFactor.  Basically testLightInRange is a more stringent of a test.

To be specific in punctualLightIntensityToIrradianceFactor, decayExponent must be > 0 for the cutoffDistance to matter.  But testLightInRange always uses cutoffDistance whether or not the light is decaying.

I think there is something else going on at the same time. I will investigate a bit more today to see if there is a better fix -- I suspect that an array of uniforms (either cutoffDistance or decayExponent) is not being initialized properly, otherwise why would this only affect the lights after the first....
