### PR TITLE
Add sourcemaps

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,5 +42,6 @@ export default {
 			dest: 'build/three.modules.js'
 		}
 	],
-	outro: outro
+	outro: outro,
+	sourceMap: true
 };


### PR DESCRIPTION
This would create `build/three.js.map` and `build/three.modules.js.map` alongside the bundles. If you wanted inline sourcemaps instead (not recommended, but possible!) you would use `sourceMap: 'inline'`.

Ref https://github.com/mrdoob/three.js/issues/9941
