### PR TITLE
Example webgl_materials_normalmap: clean up

### DIFF
--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -71,8 +71,6 @@
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
-			var statsEnabled = true;
-
 			var container, stats, loader;
 
 			var camera, scene, renderer;
@@ -147,12 +145,9 @@
 
 				//
 
-				if ( statsEnabled ) {
+				stats = new Stats();
+				container.appendChild( stats.dom );
 
-					stats = new Stats();
-					container.appendChild( stats.dom );
-
-				}
 
 				// COMPOSER
 
@@ -216,7 +211,7 @@
 				composer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 
 				effectFXAA.uniforms[ 'resolution' ].value.set( 1 / SCREEN_WIDTH, 1 / SCREEN_HEIGHT );
-				
+
 			}
 
 			function onDocumentMouseMove(event) {
@@ -233,7 +228,8 @@
 				requestAnimationFrame( animate );
 
 				render();
-				if ( statsEnabled ) stats.update();
+
+				stats.update();
 
 			}
 
@@ -242,7 +238,7 @@
 				targetX = mouseX * .001;
 				targetY = mouseY * .001;
 
-				if( mesh ) {
+				if ( mesh ) {
 
 					mesh.rotation.y += 0.05 * ( targetX - mesh.rotation.y );
 					mesh.rotation.x += 0.05 * ( targetY - mesh.rotation.x );

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -67,7 +67,6 @@
 		<script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>
 
-
 		<script>
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
@@ -78,13 +77,15 @@
 
 			var camera, scene, renderer;
 
-			var mesh, zmesh, lightMesh, geometry;
-			var mesh1;
+			var mesh;
 
 			var directionalLight, pointLight, ambientLight;
 
 			var mouseX = 0;
 			var mouseY = 0;
+
+			var targetX = 0;
+			var targetY = 0;
 
 			var windowHalfX = window.innerWidth / 2;
 			var windowHalfY = window.innerHeight / 2;
@@ -162,25 +163,26 @@
 				var effectBleach = new THREE.ShaderPass( THREE.BleachBypassShader );
 				var effectColor = new THREE.ShaderPass( THREE.ColorCorrectionShader );
 				effectFXAA = new THREE.ShaderPass( THREE.FXAAShader );
+				var effectCopy = new THREE.ShaderPass( THREE.CopyShader );
 
 				var canvas = renderer.context.canvas;
 
-				effectFXAA.uniforms[ 'resolution' ].value.set( 1 / canvas.width, 1 / canvas.height );
+				effectFXAA.uniforms[ 'resolution' ].value.set( 1 / window.innerWidth, 1 / window.innerHeight );
 
 				effectBleach.uniforms[ 'opacity' ].value = 0.4;
 
 				effectColor.uniforms[ 'powRGB' ].value.set( 1.4, 1.45, 1.45 );
 				effectColor.uniforms[ 'mulRGB' ].value.set( 1.1, 1.1, 1.1 );
 
-				effectFXAA.renderToScreen = true;
+				effectCopy.renderToScreen = true;
 
 				composer = new THREE.EffectComposer( renderer );
 
 				composer.addPass( renderModel );
-
+				composer.addPass( effectFXAA );
 				composer.addPass( effectBleach );
 				composer.addPass( effectColor );
-				composer.addPass( effectFXAA );
+				composer.addPass( effectCopy );
 
 				// EVENTS
 
@@ -191,12 +193,12 @@
 
 			function createScene( geometry, scale, material ) {
 
-				mesh1 = new THREE.Mesh( geometry, material );
+				mesh = new THREE.Mesh( geometry, material );
 
-				mesh1.position.y = - 50;
-				mesh1.scale.x = mesh1.scale.y = mesh1.scale.z = scale;
+				mesh.position.y = - 50;
+				mesh.scale.x = mesh.scale.y = mesh.scale.z = scale;
 
-				scene.add( mesh1 );
+				scene.add( mesh );
 
 			}
 
@@ -207,21 +209,20 @@
 				SCREEN_WIDTH = window.innerWidth;
 				SCREEN_HEIGHT = window.innerHeight;
 
-				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-
 				camera.aspect = SCREEN_WIDTH / SCREEN_HEIGHT;
 				camera.updateProjectionMatrix();
 
-				composer.reset();
+				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
+				composer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 
 				effectFXAA.uniforms[ 'resolution' ].value.set( 1 / SCREEN_WIDTH, 1 / SCREEN_HEIGHT );
-
+				
 			}
 
 			function onDocumentMouseMove(event) {
 
-				mouseX = ( event.clientX - windowHalfX ) * 10;
-				mouseY = ( event.clientY - windowHalfY ) * 10;
+				mouseX = ( event.clientX - windowHalfX );
+				mouseY = ( event.clientY - windowHalfY );
 
 			}
 
@@ -238,16 +239,16 @@
 
 			function render() {
 
-				var ry = mouseX * 0.0003, rx = mouseY * 0.0003;
+				targetX = mouseX * .001;
+				targetY = mouseY * .001;
 
-				if( mesh1 ) {
+				if( mesh ) {
 
-					mesh1.rotation.y = ry;
-					mesh1.rotation.x = rx;
+					mesh.rotation.y += 0.05 * ( targetX - mesh.rotation.y );
+					mesh.rotation.x += 0.05 * ( targetY - mesh.rotation.x );
 
 				}
 
-				//renderer.render( scene, camera );
 				composer.render();
 
 			}

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -158,7 +158,6 @@
 				var effectBleach = new THREE.ShaderPass( THREE.BleachBypassShader );
 				var effectColor = new THREE.ShaderPass( THREE.ColorCorrectionShader );
 				effectFXAA = new THREE.ShaderPass( THREE.FXAAShader );
-				var effectCopy = new THREE.ShaderPass( THREE.CopyShader );
 
 				var canvas = renderer.context.canvas;
 
@@ -169,7 +168,7 @@
 				effectColor.uniforms[ 'powRGB' ].value.set( 1.4, 1.45, 1.45 );
 				effectColor.uniforms[ 'mulRGB' ].value.set( 1.1, 1.1, 1.1 );
 
-				effectCopy.renderToScreen = true;
+				effectColor.renderToScreen = true;
 
 				composer = new THREE.EffectComposer( renderer );
 
@@ -177,7 +176,6 @@
 				composer.addPass( effectFXAA );
 				composer.addPass( effectBleach );
 				composer.addPass( effectColor );
-				composer.addPass( effectCopy );
 
 				// EVENTS
 


### PR DESCRIPTION
- removed unused variables
- fixed resize in post processing (did not work properly before)
- aligned controls to other material examples