### PR TITLE
Added missing 'addDrawMode()' method to mesh doc

### DIFF
--- a/docs/api/objects/Mesh.html
+++ b/docs/api/objects/Mesh.html
@@ -66,6 +66,11 @@
 
 		<h2>Methods</h2>
 
+		<h3>[method:null setDrawMode]( mode )</h3>
+		<div>
+		Set the draw mode for the mesh. See the draw mode [page:DrawModes constants] for all possible values.
+		</div>
+
 		<h3>[method:null updateMorphTargets]()</h3>
 		<div>
 		Updates the morphtargets to have no influence on the object. Resets the


### PR DESCRIPTION
As there is already an exposed Mesh.drawMode parameter, is there a reason why this method exists? 