### PR TITLE
[Docs] Add link to project wiki in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ three.js
 
 The aim of the project is to create an easy to use, lightweight, 3D library. The library provides &lt;canvas&gt;, &lt;svg&gt;, CSS3D and WebGL renderers.
 
-[Examples](http://threejs.org/examples/) — [Documentation](http://threejs.org/docs/) — [Migrating](https://github.com/mrdoob/three.js/wiki/Migration) — [Help](http://stackoverflow.com/questions/tagged/three.js)
-
+[Examples](http://threejs.org/examples/) &mdash;
+[Documentation](http://threejs.org/docs/) &mdash;
+[Wiki](https://github.com/mrdoob/three.js/wiki) &mdash;
+[Migrating](https://github.com/mrdoob/three.js/wiki/Migration) &mdash;
+[Help](http://stackoverflow.com/questions/tagged/three.js)
 
 ### Usage ###
 


### PR DESCRIPTION
Maybe it's just me, but I rarely consider looking for Github wikis when arriving at a project. But it's great that we have one! So I figured adding it to the line of links on the README would serve it well. 

(I also made the Markdown's syntax for em-dashes explicit, as it was initially a bit confusing that that's what was being represented in the rendered version.) 