### PR TITLE
[Docs] Add badging to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 three.js
 ========
 
+[![Latest NPM release][npm-badge]][npm-badge-url]
+[![License][license-badge]][license-badge-url]
+[![Dependencies][dependencies-badge]][dependencies-badge-url]
+[![Dev Dependencies][devDependencies-badge]][devDependencies-badge-url]
+
 #### JavaScript 3D library ####
 
 The aim of the project is to create an easy to use, lightweight, 3D library. The library provides &lt;canvas&gt;, &lt;svg&gt;, CSS3D and WebGL renderers.
@@ -63,3 +68,14 @@ If everything went well you should see [this](http://jsfiddle.net/hfj7gm6t/).
 ### Change log ###
 
 [releases](https://github.com/mrdoob/three.js/releases)
+
+
+
+[npm-badge]: https://img.shields.io/npm/v/three.svg
+[npm-badge-url]: https://www.npmjs.com/package/three
+[license-badge]: https://img.shields.io/npm/l/three.svg
+[license-badge-url]: ./LICENSE
+[dependencies-badge]: https://img.shields.io/david/mrdoob/three.js.svg
+[dependencies-badge-url]: https://david-dm.org/mrdoob/three.js
+[devDependencies-badge]: https://img.shields.io/david/dev/mrdoob/three.js.svg
+[devDependencies-badge-url]: https://david-dm.org/mrdoob/three.js#info=devDependencies


### PR DESCRIPTION
It might be nice if we could display a few status badges on the README related to the latest NPM release, the state of the project's dependencies, the license, etc.

I'm open to modifying the PR for including as many or as few as desired, but I wanted to start with the four I think we'd be able to display right away as an initial proposal. 