### PR TITLE
Improved documentation for Constants / Textures

### DIFF
--- a/docs/api/constants/Materials.html
+++ b/docs/api/constants/Materials.html
@@ -12,7 +12,7 @@
 
 		<div class="desc">
 		These constants define properties common to all material types,
-		with the exception of [page:MultiMaterial MultiMaterial] where they are defined for sub-materials.
+		with the exception of Texture Combine Operations which only apply to [page:MeshBasicMaterial.combine MeshBasicMaterial], [page:MeshLambertMaterial.combine MeshLambertMaterial] and [page:MeshPhongMaterial.combine MeshPhongMaterial].<br />
 		</div>
 
 
@@ -87,6 +87,18 @@
 		[page:Materials GreaterDepth] will return true if the incoming pixel Z-depth is greater than the current buffer Z-depth.<br />
 		[page:Materials NotEqualDepth] will return true if the incoming pixel Z-depth is equal to the current buffer Z-depth.<br />
 		</div>
+
+		<h2>Texture Combine Operations</h2>
+		<code>
+		THREE.MultiplyOperation
+		THREE.MixOperation
+		THREE.AddOperation
+		</code>
+		These define how the result of the surface's color is combined with the environment map (if present), for [page:MeshBasicMaterial.combine MeshBasicMaterial], [page:MeshLambertMaterial.combine MeshLambertMaterial] and [page:MeshPhongMaterial.combine MeshPhongMaterial]. <br />
+		[page:Constant MultiplyOperation] is the default and multiplies the environment map color with the surface color.<br />
+		[page:Constant MixOperation] uses reflectivity to blend between the two colors.<br />
+		[page:Constant AddOperation] adds the two colors.
+
 
 		<h2>Source</h2>
 

--- a/docs/api/constants/Textures.html
+++ b/docs/api/constants/Textures.html
@@ -241,6 +241,29 @@
 		just over 13% of WebGL enabled devices support this extenstion.<br /><br />
 		</div>
 
+		<h2>Encoding</h2>
+		<code>
+		THREE.LinearEncoding
+		THREE.sRGBEncoding
+		THREE.GammaEncoding
+		THREE.RGBEEncoding
+		THREE.LogLuvEncoding
+		THREE.RGBM7Encoding
+		THREE.RGBM16Encoding
+		THREE.RGBDEncoding
+		THREE.BasicDepthPacking
+		THREE.RGBADepthPacking
+		</code>
+		<div>
+		For use with a Texture's [page:Texture.encoding encoding]	property.<br /><br />
+
+		If the encoding type is changed after the texture has already been used by a material,
+		you will need to set [page:Material.needsUpdate Material.needsUpdate] to *true* to make the material recompile.<br /><br />
+
+		[page:constant LinearEncoding] is the default.
+		Values other than this are only valid for a material's map, envMap and emissiveMap.
+		</div>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/constants.js src/constants.js]

--- a/docs/api/constants/Textures.html
+++ b/docs/api/constants/Textures.html
@@ -21,6 +21,24 @@
 		THREE.CubeUVReflectionMapping
 		THREE.CubeUVRefractionMapping
 		</code>
+		<div>
+		These define the texture's mapping mode.<br />
+		[page:Constant UVMapping] is the default, and maps the texture using the mesh's UV coordinates.<br /><br />
+
+		The rest define environment mapping types.<br /><br />
+
+		[page:Constant CubeReflectionMapping] and [page:Constant CubeRefractionMapping] are for
+		use with a [page:CubeTexture CubeTexture], which is made up of six textures, one for each face of the cube.<br />
+		[page:Constant CubeReflectionMapping] is the default for a [page:CubeTexture CubeTexture]. <br /><br />
+
+		[page:Constant EquirectangularReflectionMapping] and [page:Constant EquirectangularRefractionMapping]
+		are for use with an equirectangular environment map.<br /><br />
+
+		[page:Constant SphericalReflectionMapping] is for use with a spherical reflection map.<br /><br />
+
+		See the [example:webgl_materials_envmaps materials / envmaps] example.
+		</div>
+
 
 		<h2>Wrapping Modes</h2>
 		<code>
@@ -28,8 +46,38 @@
 		THREE.ClampToEdgeWrapping
 		THREE.MirroredRepeatWrapping
 		</code>
+		<div>
+		These define the texture's [page:Texture.wrapS wrapS] and [page:Texture.wrapT wrapT] properties,
+		which define horizontal and vertical texture wrapping.<br /><br />
 
-		<h2>Filters</h2>
+		With [page:constant RepeatWrapping] the texture will simply repeat to infinity.<br /><br />
+
+		[page:constant ClampToEdgeWrapping] is the default.
+		The last pixel of the texture stretches to the edge of the mesh.<br /><br />
+
+		With [page:constant MirroredRepeatWrapping] the texture will repeats to infinity, mirroring on each repeat.<br />
+		</div>
+
+		<h2>Magnification Filters</h2>
+		<code>
+		THREE.NearestFilter
+		THREE.LinearFilter
+		</code>
+		<div>
+		For use with a texture's [page:Texture.magFilter magFilter]	property,
+		these define the texture magnification function to be used when the pixel being textured maps to an
+		area less than or equal to one texture element (texel).<br /><br />
+
+		[page:constant NearestFilter] returns the value of the texture element that is nearest
+		(in Manhattan distance) to the specified texture coordinates.<br /><br />
+
+		[page:constant LinearFilter] is the default and returns the weighted average
+		of the four texture elements that are closest to the specified texture coordinates,
+		and can include items wrapped or repeated from other parts of a texture,
+		depending on the values of [page:Texture.wrapS wrapS] and [page:Texture.wrapT wrapT], and on the exact mapping.
+		</div>
+
+		<h2>Minification Filters</h2>
 		<code>
 		THREE.NearestFilter
 		THREE.NearestMipMapNearestFilter
@@ -38,8 +86,36 @@
 		THREE.LinearMipMapNearestFilter
 		THREE.LinearMipMapLinearFilter
 		</code>
+		<div>
+		For use with a texture's [page:Texture.minFilter minFilter]	property, these define
+		the texture minifying function that is used whenever the pixel being textured maps
+		to an area greater than one texture element (texel).<br /><br />
 
-		<h2>Data Types</h2>
+		In addition to [page:constant NearestFilter] and [page:constant LinearFilter],
+		the following four functions can be used for minification:<br /><br />
+
+		[page:constant NearestMipMapNearestFilter] chooses the mipmap that most closely
+		matches the size of the pixel being textured
+		and uses the [page:constant NearestFilter] criterion (the texel nearest to the
+		center of the pixel) to produce a texture value.<br /><br />
+
+		[page:constant NearestMipMapLinearFilter] chooses the two mipmaps that most closely
+		match the size of the pixel being textured and uses the [page:constant NearestFilter] criterion to produce
+		a texture value from each mipmap. The final texture value is a weighted average of those two values.<br /><br />
+
+		[page:constant LinearMipMapNearestFilter] chooses the mipmap that most closely matches
+		the size of the pixel being textured and uses the [page:constant LinearFilter] criterion
+		(a weighted average of the four texels that are closest to the center of the pixel)
+		to produce a texture value.<br /><br />
+
+		[page:constant LinearMipMapLinearFilter] is the default and chooses the two mipmaps
+		that most closely match the size of the pixel being textured and uses the [page:constant LinearFilter] criterion
+		to produce a texture value from each mipmap. The final texture value is a weighted average of those two values.<br /><br />
+
+		See the [example:webgl_materials_texture_filters materials / texture / filters] example.
+		</div>
+
+		<h2>Types</h2>
 		<code>
 		THREE.UnsignedByteType
 		THREE.ByteType
@@ -49,16 +125,18 @@
 		THREE.UnsignedIntType
 		THREE.FloatType
 		THREE.HalfFloatType
-		</code>
-
-		<h2>Pixel Types</h2>
-		<code>
 		THREE.UnsignedShort4444Type
 		THREE.UnsignedShort5551Type
 		THREE.UnsignedShort565Type
+		THREE.UnsignedInt248Type
 		</code>
+		<div>
+		For use with a texture's [page:Texture.type type]	property, which must correspond to the correct format. See below for details.<br /><br />
 
-		<h2>Pixel Formats</h2>
+		[page:constant UnsignedByteType] is the default.
+		</div>
+
+		<h2>Formats</h2>
 		<code>
 		THREE.AlphaFormat
 		THREE.RGBFormat
@@ -66,7 +144,45 @@
 		THREE.LuminanceFormat
 		THREE.LuminanceAlphaFormat
 		THREE.RGBEFormat
+		THREE.DepthFormat
+		THREE.DepthStencilFormat
 		</code>
+		<div>
+		For use with a texture's [page:Texture.format format]	property, these define
+		how elements of a 2d texture, or *texels*, are read by shaders.<br /><br />
+
+		[page:constant AlphaFormat] discards the red, green and blue components and reads just the alpha component.
+		The [page:Texture.type type] must be [page:constant UnsignedByteType].<br /><br />
+
+		[page:constant RGBFormat] discards the alpha components and reads the red, green and blue components.
+		The [page:Texture.type type] must be [page:constant UnsignedByteType] or [page:constant UnsignedShort565Type].<br /><br />
+
+		[page:constant RGBAFormat] is the default and reads the red, green, blue and alpha components.
+		The [page:Texture.type type] must be [page:constant UnsignedByteType], [page:constant UnsignedShort4444Type] or [page:constant THREE.UnsignedShort5551Type].<br /><br />
+
+		[page:constant LuminanceFormat] reads each element as a single luminance component.
+		 This is then converted to a floating point, clamped to the range [0,1], and then assembled
+		 into an RGBA element by placing the luminance value in the red, green and blue channels,
+		 and attaching 1.0 to the alpha channel. The [page:Texture.type type] must be [page:constant UnsignedByteType].<br /><br />
+
+		[page:constant LuminanceAlphaFormat] reads each element as a luminance/alpha double.
+		The same process occurs as for the [page:constant LuminanceFormat], except that the
+		alpha channel may have values other than *1.0*. The [page:Texture.type type] must be [page:constant UnsignedByteType].<br /><br />
+
+		[page:constant RGBEFormat] is identical to [page:constant RGBAFormat].<br /><br />
+
+		[page:constant DepthFormat] reads each element as a single depth value, converts it to floating point, and clamps to the range [0,1].
+		The [page:Texture.type type] must be [page:constant UnsignedIntType] or [page:constant UnsignedShortType].
+		This is the default for [page:DepthTexture DepthTexture].<br /><br />
+
+		[page:constant DepthStencilFormat] reads each element is a pair of depth and stencil values.
+		The depth component of the pair is interpreted as in [page:constant DepthFormat].
+		The stencil component is interpreted based on the depth + stencil internal format.
+		The [page:Texture.type type] must be [page:constant UnsignedInt248Type].<br /><br />
+
+		Note that the texture must have the correct [page:Texture.type type] set, as described above.
+		See <a href="https://developer.mozilla.org/en/docs/Web/API/WebGLRenderingContext/texImage2D">this page</a> for details.
+		</div>
 
 		<h2>DDS / ST3C Compressed Texture Formats</h2>
 		<code>
@@ -75,6 +191,20 @@
 		THREE.RGBA_S3TC_DXT3_Format
 		THREE.RGBA_S3TC_DXT5_Format
 		</code>
+		<div>
+		For use with a [page:CompressedTexture CompressedTexture]'s [page:Texture.format format]	property,
+		these require support for the
+		<a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/">WEBGL_compressed_texture_s3tc</a>
+		extension. <br />
+		According to <a href="http://webglstats.com/">WebglStats</a>, as of February 2016
+		over 80% of WebGL enabled devices support this extension.<br /><br />
+
+		There are four <a href="https://en.wikipedia.org/wiki/S3_Texture_Compression">S3TC</a> formats available via this extension. These are:<br />
+		[page:constant RGB_S3TC_DXT1_Format]: A DXT1-compressed image in an RGB image format.<br />
+		[page:constant RGBA_S3TC_DXT1_Format]: A DXT1-compressed image in an RGB image format with a simple on/off alpha value.<br />
+		[page:constant RGBA_S3TC_DXT3_Format]: A DXT3-compressed image in an RGBA image format. Compared to a 32-bit RGBA texture, it offers 4:1 compression.<br />
+		[page:constant RGBA_S3TC_DXT5_Format]: A DXT5-compressed image in an RGBA image format. It also provides a 4:1 compression, but differs to the DXT3 compression in how the alpha compression is done.<br />
+		</div>
 
 		<h2>PVRTC Compressed Texture Formats</h2>
 		<code>
@@ -83,6 +213,33 @@
 		THREE.RGBA_PVRTC_4BPPV1_Format
 		THREE.RGBA_PVRTC_2BPPV1_Format
 		</code>
+		<div>
+		For use with a [page:CompressedTexture CompressedTexture]'s [page:Texture.format format]	property,
+		these require support for the <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/">WEBGL_compressed_texture_pvrtc</a>
+		extension. <br />
+		According to <a href="http://webglstats.com/">WebglStats</a>, as of February 2016
+		less than 8% of WebGL enabled devices support this extenstion.
+		PVRTC is typically only available on mobile devices with PowerVR chipsets,
+		which are mainly Apple devices.<br /><br />
+
+		There are four <a href="https://en.wikipedia.org/wiki/PVRTC">PVRTC</a> formats available via this extension. These are:<br />
+		[page:constant RGB_PVRTC_4BPPV1_Format]: RGB compression in 4-bit mode. One block for each 4×4 pixels.<br />
+		[page:constant RGB_PVRTC_2BPPV1_Format]: RGB compression in 2-bit mode. One block for each 8×4 pixels.<br />
+		[page:constant RGBA_PVRTC_4BPPV1_Format]: RGBA compression in 4-bit mode. One block for each 4×4 pixels.<br />
+		[page:constant RGBA_PVRTC_2BPPV1_Format]: RGBA compression in 2-bit mode. One block for each 8×4 pixels.<br />
+		</div>
+
+		<h2>ETC Compressed Texture Format</h2>
+		<code>
+		THREE.RGB_ETC1_Format
+		</code>
+		<div>
+		For use with a [page:CompressedTexture CompressedTexture]'s [page:Texture.format format]	property,
+		these require support for the <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/">WEBGL_compressed_texture_etc1</a>
+		extension. <br />
+		According to <a href="http://webglstats.com/">WebglStats</a>, as of February 2016
+		just over 13% of WebGL enabled devices support this extenstion.<br /><br />
+		</div>
 
 		<h2>Source</h2>
 

--- a/docs/api/constants/Textures.html
+++ b/docs/api/constants/Textures.html
@@ -10,84 +10,79 @@
 	<body>
 		<h1>Texture Constants</h1>
 
-		<h2>Operations</h2>
-		<div>
-		THREE.MultiplyOperation<br />
-		THREE.MixOperation<br />
-		THREE.AddOperation
-		</div>
-
 		<h2>Mapping Modes</h2>
-		<div>
-		THREE.UVMapping<br />
-		THREE.CubeReflectionMapping<br />
-		THREE.CubeRefractionMapping<br />
-		THREE.EquirectangularReflectionMapping<br />
-		THREE.EquirectangularRefractionMapping<br />
+		<code>
+		THREE.UVMapping
+		THREE.CubeReflectionMapping
+		THREE.CubeRefractionMapping
+		THREE.EquirectangularReflectionMapping
+		THREE.EquirectangularRefractionMapping
 		THREE.SphericalReflectionMapping
-		</div>
+		THREE.CubeUVReflectionMapping
+		THREE.CubeUVRefractionMapping
+		</code>
 
 		<h2>Wrapping Modes</h2>
-		<div>
-		THREE.RepeatWrapping<br />
-		THREE.ClampToEdgeWrapping<br />
+		<code>
+		THREE.RepeatWrapping
+		THREE.ClampToEdgeWrapping
 		THREE.MirroredRepeatWrapping
-		</div>
+		</code>
 
 		<h2>Filters</h2>
-		<div>
-		THREE.NearestFilter<br />
-		THREE.NearestMipMapNearestFilter<br />
-		THREE.NearestMipMapLinearFilter<br />
-		THREE.LinearFilter<br />
-		THREE.LinearMipMapNearestFilter<br />
+		<code>
+		THREE.NearestFilter
+		THREE.NearestMipMapNearestFilter
+		THREE.NearestMipMapLinearFilter
+		THREE.LinearFilter
+		THREE.LinearMipMapNearestFilter
 		THREE.LinearMipMapLinearFilter
-		</div>
+		</code>
 
 		<h2>Data Types</h2>
-		<div>
-		THREE.UnsignedByteType<br />
-		THREE.ByteType<br />
-		THREE.ShortType<br />
-		THREE.UnsignedShortType<br />
-		THREE.IntType<br />
-		THREE.UnsignedIntType<br />
-		THREE.FloatType<br />
+		<code>
+		THREE.UnsignedByteType
+		THREE.ByteType
+		THREE.ShortType
+		THREE.UnsignedShortType
+		THREE.IntType
+		THREE.UnsignedIntType
+		THREE.FloatType
 		THREE.HalfFloatType
-		</div>
+		</code>
 
 		<h2>Pixel Types</h2>
-		<div>
-		THREE.UnsignedShort4444Type<br />
-		THREE.UnsignedShort5551Type<br />
+		<code>
+		THREE.UnsignedShort4444Type
+		THREE.UnsignedShort5551Type
 		THREE.UnsignedShort565Type
-		</div>
+		</code>
 
 		<h2>Pixel Formats</h2>
-		<div>
-		THREE.AlphaFormat<br />
-		THREE.RGBFormat<br />
-		THREE.RGBAFormat<br />
-		THREE.LuminanceFormat<br />
-		THREE.LuminanceAlphaFormat<br />
+		<code>
+		THREE.AlphaFormat
+		THREE.RGBFormat
+		THREE.RGBAFormat
+		THREE.LuminanceFormat
+		THREE.LuminanceAlphaFormat
 		THREE.RGBEFormat
-		</div>
+		</code>
 
 		<h2>DDS / ST3C Compressed Texture Formats</h2>
-		<div>
-		THREE.RGB_S3TC_DXT1_Format<br />
-		THREE.RGBA_S3TC_DXT1_Format<br />
-		THREE.RGBA_S3TC_DXT3_Format<br />
+		<code>
+		THREE.RGB_S3TC_DXT1_Format
+		THREE.RGBA_S3TC_DXT1_Format
+		THREE.RGBA_S3TC_DXT3_Format
 		THREE.RGBA_S3TC_DXT5_Format
-		</div>
+		</code>
 
 		<h2>PVRTC Compressed Texture Formats</h2>
-		<div>
-		THREE.RGB_PVRTC_4BPPV1_Format<br />
-		THREE.RGB_PVRTC_2BPPV1_Format<br />
-		THREE.RGBA_PVRTC_4BPPV1_Format<br />
+		<code>
+		THREE.RGB_PVRTC_4BPPV1_Format
+		THREE.RGB_PVRTC_2BPPV1_Format
+		THREE.RGBA_PVRTC_4BPPV1_Format
 		THREE.RGBA_PVRTC_2BPPV1_Format
-		</div>
+		</code>
 
 		<h2>Source</h2>
 

--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -10,8 +10,15 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">Materials describe the appearance of [page:Object objects]. They are defined in a (mostly) renderer-independent way, so you don't have to rewrite materials if you decide to use a different renderer.</div>
-
+		<div class="desc">
+		<p>
+		Materials describe the appearance of [page:Object objects].
+		They are defined in a (mostly) renderer-independent way, so you don't have to rewrite materials if you decide to use a different renderer.
+		</p>
+		<P>
+		With the exception of [page:MultiMaterial MultiMaterial], the following properties and methods are inherited by all other material types (although they may have different defaults).
+		</P>
+		</div>
 
 		<h2>Constructor</h2>
 
@@ -34,55 +41,96 @@
 		Material name. Default is an empty string.
 		</div>
 
+		<h3>[property:String type]</h3>
+		<div>
+		Value is the string 'Material'. This shouldn't be changed, and can be used to find all objects of this type in a scene.
+		</div>
+
+		<h3>[property:Boolean fog]</h3>
+		<div>
+		Whether the material is affected by fog. Default is *true*.
+		</div>
+
+		<h3>[property:Boolean lights]</h3>
+		<div>
+		Whether the material is affected by lights. Default is *true*.
+		</div>
+
+		<h3>[property:Integer side]</h3>
+		<div>
+		Defines which side of faces will be rendered - front, back or both.
+		Default is [page:Materials THREE.FrontSide].
+		Other options are [page:Materials THREE.BackSide] and [page:Materials THREE.DoubleSide].
+		</div>
+
+		<h3>[property:Integer shading]</h3>
+		<div>
+		Defines how the material is shaded.
+		This can be either [page:Materials THREE.SmoothShading] (default)	or [page:Materials THREE.FlatShading].
+		</div>
+
+		<h3>[property:Integer vertexColors]</h3>
+		<div>
+		Defines whether vertex coloring is used.
+		Default is [page:Materials THREE.NoColors].
+		Other options are [page:Materials THREE.VertexColors] and [page:Materials THREE.FaceColors].
+		</div>
+
 		<h3>[property:Float opacity]</h3>
 		<div>
-		Float in the range of 0.0 - 1.0 indicating how transparent the material is.
-		A value of 0.0 indicates fully transparent, 1.0 is fully opaque. If
-		*transparent* is not set to true for the material, the material will remain
-		fully opaque and this value will only affect its color.
+		Float in the range of *0.0* - *1.0* indicating how transparent the material is.
+		A value of *0.0* indicates fully transparent, *1.0* is fully opaque.<br />
+		If the material's [property:Boolean transparent] property is not set to *true*, the material will remain
+		fully opaque and this value will only affect its color. <br />
+		Default is *1.0*.
 		</div>
-		<div>Default is *1.0*.</div>
 
 		<h3>[property:Boolean transparent]</h3>
 		<div>
 		Defines whether this material is transparent. This has an effect on rendering
-		as transparent objects need special treatment and are rendered after 
-		non-transparent objects. For a working example of this behaviour, check the
-		[page:WebGLRenderer WebGLRenderer] code.<br />
+		as transparent objects need special treatment and are rendered after
+		non-transparent objects. <br />
 		When set to true, the extent to which the material is transparent is
-		controlled by setting *opacity*.
+		controlled by setting it's [property:Float opacity] property. <br />
+		Default is *false*.
 		</div>
-		<div>Default is *false*.</div>
 
 		<h3>[property:Blending blending]</h3>
 		<div>
-		Which blending to use when displaying objects with this material. Default is [page:Materials NormalBlending]. See the blending mode [page:Materials constants] for all possible values.
-
+		Which blending to use when displaying objects with this material. <br />
+		This must be set to [page:Materials CustomBlending] to use custom [property:Constant blendSrc], [property:Constant blendDst] or [property:Constant blendEquation].<br />
+		See the blending mode [page:Materials constants] for all possible values. Default is [page:Materials NormalBlending].
 		</div>
 
 		<h3>[property:Integer blendSrc]</h3>
 		<div>
-		Blending source. It's one of the blending mode constants defined in Three.js. Default is [page:CustomBlendingEquation SrcAlphaFactor]. See the destination factors [page:CustomBlendingEquation constants] for all possible values.
+		Blending source. Default is [page:CustomBlendingEquation SrcAlphaFactor].
+		See the source factors [page:CustomBlendingEquation constants] for all possible values.<br />
+		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
 		</div>
 
 		<h3>[property:Integer blendDst]</h3>
 		<div>
-		Blending destination. It's one of the blending mode constants defined in [page:Three Three.js]. Default is [page:CustomBlendingEquation OneMinusSrcAlphaFactor].
+		Blending destination. Default is [page:CustomBlendingEquation OneMinusSrcAlphaFactor].
+		See the destination factors [page:CustomBlendingEquation constants] for all possible values.<br />
+		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
 		</div>
 
 		<h3>[property:Integer blendEquation]</h3>
 		<div>
-		Blending equation to use when applying blending. It's one of the constants defined in [page:Three Three.js]. Default is [page:CustomBlendingEquation AddEquation.]
+		Blending equation to use when applying blending. Default is [page:CustomBlendingEquation AddEquation].
+		See the blending equation [page:CustomBlendingEquation constants] for all possible values.<br />
+		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
+		</div>
+
+		<h3>[property:Integer depthFunc]</h3>
+		<div>
+		Which depth function to use. Default is [page:Materials LessEqualDepth]. See the depth mode [page:Materials constants] for all possible values.
 		</div>
 
 		<h3>[property:Boolean depthTest]</h3>
 		<div>
 		Whether to have depth test enabled when rendering this material. Default is *true*.
-		</div>
-
-		<h3>[property:Integer depthFunc]</h3>
-		<div>
-		What depth function to use. Default is [page:Materials THREE.LessEqualDepth].
 		</div>
 
 		<h3>[property:Boolean depthWrite]</h3>
@@ -93,9 +141,41 @@
 		When drawing 2D overlays it can be useful to disable the depth writing in order to layer several things together without creating z-index artifacts.
 		</div>
 
+		<h3>[property:Array clippingPlanes]</h3>
+		<div>
+		User-defined clipping planes specified as THREE.Plane objects in world space.
+		These planes apply to the objects this material is attached to.
+		Points in space whose dot product with the plane is negative are cut away.
+		See the [example:webgl_clipping_intersection WebGL / clipping /intersection] example.
+		Default is *null*.
+		</div>
+
+		<h3>[property:Boolean clipIntersection]</h3>
+		<div>
+		Changes the behavior of clipping planes so that only their intersection is clipped, rather than their union.
+		Default is *false*.
+		</div>
+
+		<h3>[property:Boolean clipShadows]</h3>
+		<div>
+		Defines whether to clip shadows according to the clipping planes specified on this material. Default is *false*.
+		</div>
+
+		<h3>[property:Boolean colorWrite]</h3>
+		<div>
+		Whether to render the material's color.
+		This can be used in conjunction with a mesh's [property:Integer renderOrder] property to create invisible objects that occlude other objects. Default is *true*.
+		</div>
+
+		<h3>[property:String precision]</h3>
+		<div>
+		Override the renderer's default precision for this material. Can be "*highp*", "*mediump*" or "*lowp*".
+		Defaults for the WebGLRenderer is "*highp*" if supported by the device.
+		</div>
+
 		<h3>[property:Boolean polygonOffset]</h3>
 		<div>
-		Whether to use polygon offset. Default is *false*. This corresponds to the *POLYGON_OFFSET_FILL* WebGL feature.
+		Whether to use polygon offset. Default is *false*. This corresponds to the *GL_POLYGON_OFFSET_FILL* WebGL feature.
 		</div>
 
 		<h3>[property:Integer polygonOffsetFactor]</h3>
@@ -108,29 +188,25 @@
 		Sets the polygon offset units. Default is *0*.
 		</div>
 
-		<h3>[property:Number alphaTest]</h3>
+		<h3>[property:Float alphaTest]</h3>
 		<div>
-		Sets the alpha value to be used when running an alpha test. Default is *0*.
+		Sets the alpha value to be used when running an alpha test.
+		The material will not be renderered if the opacity is lower than this value.
+		Default is *0*.
 		</div>
 
-		<h3>[property:Array clippingPlanes]</h3>
-
+		<h3>[property:Boolean premultipliedAlpha]</h3>
 		<div>
-		User-defined clipping planes specified as THREE.Plane objects in world space. These planes apply to the objects this material is attached to. Points in space whose dot product with the plane is negative are cut away. Default is null.
-		</div>
-
-		<h3>[property:Boolean clipIntersection]</h3>
-
-		<div>Changes the behavior of clipping planes so that only their intersection is clipped, rather than their union. Default is false. See <a href="http://threejs.org/examples/#webgl_clipping_intersection">example</a> </div>
-
-		<h3>[property:Boolean clipShadows]</h3>
-		<div>
-		Defines whether to clip shadows according to the clipping planes specified on this material. Default is false.
+		Whether to premultiply the alpha (transparency) value.
+		See [Example:webgl_materials_transparency WebGL / Materials / Transparency] for an example of the difference.
+		Default is *false*.
 		</div>
 
 		<h3>[property:Float overdraw]</h3>
 		<div>
-		Amount of triangle expansion at draw time. This is a workaround for cases when gaps appear between triangles when using [page:CanvasRenderer]. *0.5* tends to give good results across browsers. Default is *0*.
+		Amount of triangle expansion at draw time.
+		This is a workaround for cases when gaps appear between triangles when using [page:CanvasRenderer].
+		*0.5* tends to give good results across browsers. Default is *0*.
 		</div>
 
 		<h3>[property:Boolean visible]</h3>
@@ -138,46 +214,45 @@
 		Defines whether this material is visible. Default is *true*.
 		</div>
 
-		<h3>[property:Enum side]</h3>
-		<div>
-		Defines which of the face sides will be rendered - front, back or both.
-		</div>
-		<div>
-		Default is [page:Materials THREE.FrontSide]. Other options are [page:Materials THREE.BackSide] and [page:Materials THREE.DoubleSide].
-		</div>
-
 		<h3>[property:Boolean needsUpdate]</h3>
 		<div>
-		Specifies that the material needs to be updated at the WebGL level. Set it to true if you made changes that need to be reflected in WebGL.
-		</div>
-		<div>
+		Specifies that the material needs to be updated at the WebGL level.
+		Set it to true if you made changes that need to be reflected in WebGL.<br />
 		This property is automatically set to *true* when instancing a new material.
 		</div>
 
-		
+
 		<h2>Methods</h2>
-		
+
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
-		
+
+		<h3>[method:null setValues]( [page:object values] )</h3>
+		<div>
+		values -- a container with parameters.<br />
+		Sets the properties based on the *values*.
+		</div>
+
+		<h3>[method:null toJSON]( [page:object meta] )</h3>
+		<div>
+		meta -- object containing metadata such as textures or images for the material.<br />
+		Convert the material to Three JSON format.
+		</div>
+
 		<h3>[method:Material clone]( [page:material material] )</h3>
 		<div>
-		material -- this material gets the cloned information (optional). 
-		</div>
-		<div>
+		material -- this material gets the cloned information (optional).<br />
 		This clones the material in the optional parameter and returns it.
+		</div>
+
+		<h3>[method:null update]()</h3>
+		<div>
+		Call [method:null dispatchEvent]( { type: '[page:object update]' }) on the material.
 		</div>
 
 		<h3>[method:null dispose]()</h3>
 		<div>
-		This disposes the material. Textures of a material don't get disposed. These needs to be disposed by [page:Texture Texture]. 
-		</div>
-
-		<h3>[method:null setValues]( [page:object values] )</h3>
-		<div>
-		values -- a container with parameters.
-		</div>
-		<div>
-		Sets the properties based on the *values*.
+		This disposes the material. Textures of a material don't get disposed.
+		These needs to be disposed by [page:Texture Texture].
 		</div>
 
 		<h2>Source</h2>

--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -90,7 +90,7 @@
 		<h3>[property:Integer combine]</h3>
 		<div>How to combine the result of the surface's color with the environment map, if any.</div>
 
-		<div>Options are [page:Textures THREE.Multiply] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
+		<div>Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation], [page:Materials THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
 
 		<h3>[property:Float reflectivity]</h3>
 		<div>How much the environment map affects the surface; also see "combine".</div>

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -113,7 +113,7 @@
 		<h3>[property:Integer combine]</h3>
 		<div>How to combine the result of the surface's color with the environment map, if any.</div>
 
-		<div>Options are [page:Textures THREE.Multiply] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
+		<div>Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation], [page:Materials THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
 
 		<h3>[property:Float reflectivity]</h3>
 		<div>How much the environment map affects the surface; also see "combine".</div>

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -175,7 +175,7 @@
 		<h3>[property:Integer combine]</h3>
 		<div>How to combine the result of the surface's color with the environment map, if any.</div>
 
-		<div>Options are [page:Textures THREE.MultiplyOperation] (default), [page:Textures THREE.MixOperation], [page:Textures THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
+		<div>Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation], [page:Materials THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
 
 		<h3>[property:Float reflectivity]</h3>
 		<div>How much the environment map affects the surface; also see "combine".</div>


### PR DESCRIPTION
Moved Texture Combine Operations to constants / materials as they relate to the .combine property of MeshPhongMaterial, MeshLambertMaterial, and MeshBasicMaterial materials.

Updated docs for .combine property of MeshPhongMaterial, MeshLambertMaterial and MeshBasicMaterial to point to that page

Added missing constants to Constants / Textures page
- CubeUVReflectionMapping
- CubeUVRefractionMapping
- UnsignedInt248Type
- DepthFormat
- DepthStencilFormat
- RGB_ETC1_Format

Added basic explanation for what most of the constants do.
