### PR TITLE
Improved docs for Clock

### DIFF
--- a/docs/api/core/Clock.html
+++ b/docs/api/core/Clock.html
@@ -10,7 +10,10 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">Object for keeping track of time.</div>
+		<div class="desc">
+		Object for keeping track of time. This uses <a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/now">performance.now()</a>
+		if it is available, otherwise it reverts to the less accurate <a href="https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date/now">Date.now()</a>.
+		</div>
 
 
 		<h2>Constructor</h2>
@@ -18,38 +21,36 @@
 
 		<h3>[name]( [page:Boolean autoStart] )</h3>
 		<div>
-		autoStart — Automatically start the clock. Default is true.
+		autoStart — (optional) whether to automatically start the clock. Default is true.
 		</div>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean autoStart]</h3>
 		<div>
-		If set, starts the clock automatically when the first update is called.
+		If set, starts the clock automatically when the first update is called. Default is true.
 		</div>
 
 		<h3>[property:Float startTime]</h3>
 		<div>
-		When the clock is running, It holds the start time of the clock. <br />
-		This counted from the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC.
+		Holds the time at which the clock's [page:Clock.start start] method was last called.
  		</div>
 
 
 		<h3>[property:Float oldTime]</h3>
 		<div>
-		When the clock is running, It holds the previous time from a update.<br />
-		This counted from the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC.
+		Holds the time at which the clock's [page:Clock.start start], [page:Clock.getElapsedTime getElapsedTime] or [page:Clock.getDelta getDelta]
+		methods were last called.
  		</div>
 
 		<h3>[property:Float elapsedTime]</h3>
 		<div>
-		When the clock is running, It holds the time elapsed between the start of the clock to the previous update.<br />
-		This counted from the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC.
+		Keeps track of the total time that the clock has been running.
  		</div>
 
 		<h3>[property:Boolean running]</h3>
 		<div>
-		This property keeps track whether the clock is running or not.
+		Whether the clock is running or not.
  		</div>
 
 
@@ -57,22 +58,25 @@
 
 		<h3>[method:null start]()</h3>
 		<div>
-		Starts clock.
+		Starts clock. Also sets the [page:Clock.startTime startTime] and [page:Clock.oldTime oldTime]
+		to the current time, sets [page:Clock.elapsedTime elapsedTime] to *0* and [page:Clock.running running] to *true*.
 		</div>
 
 		<h3>[method:null stop]()</h3>
 		<div>
-		Stops clock.
+		Stops clock and sets [page:Clock.oldTime oldTime] to the current time.
 		</div>
 
 		<h3>[method:Float getElapsedTime]()</h3>
 		<div>
-		Get the seconds passed since the clock started.
+		Get the seconds passed since the clock started and sets [page:Clock.oldTime oldTime] to the current time.<br />
+		If [page:Clock.autoStart autoStart] is *true* and the clock is not running, also starts the clock.
 		</div>
 
 		<h3>[method:Float getDelta]()</h3>
 		<div>
-		Get the seconds passed since the last call to this method.
+		Get the seconds passed since the time [page:Clock.oldTime oldTime] was set and sets [page:Clock.oldTime oldTime] to the current time.<br />
+		If [page:Clock.autoStart autoStart] is *true* and the clock is not running, also starts the clock.
 		</div>
 
 


### PR DESCRIPTION
Updated description to say that the Clock uses Performance.now() if available

Updated descriptions for properties and methods to more accurately describe how they work