### PR TITLE
Moved outro to the UMD target

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,6 +33,7 @@ export default {
 	],
 	targets: [
 		{
+			outro: outro,
 			format: 'umd',
 			moduleName: 'THREE',
 			dest: 'build/three.js'
@@ -42,6 +43,5 @@ export default {
 			dest: 'build/three.modules.js'
 		}
 	],
-	outro: outro,
 	sourceMap: true
 };


### PR DESCRIPTION
Instead of completely removing the outro (like in https://github.com/mrdoob/three.js/pull/9901), only the UMD bundle uses it.

That means only the UMD bundle has a `THREE.AudioContext`, and ES bundle users should use `THREE.getAudioContext()` instead.