### PR TITLE
Removed unused texture.sourceFile property

### DIFF
--- a/docs/api/textures/Texture.html
+++ b/docs/api/textures/Texture.html
@@ -55,11 +55,6 @@
 		as long as video is playing - the [page:VideoTexture VideoTexture] class handles this automatically.
 		</div>
 
-		<h3>[property:string sourceFile]</h3>
-		<div>
-		This property is currently unused.
-		</div>
-
 		<h3>[property:array mipmaps]</h3>
 		<div>
 		Array of user-specified mipmaps (optional).

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -17,7 +17,6 @@ function Texture( image, mapping, wrapS, wrapT, magFilter, minFilter, format, ty
 	this.uuid = _Math.generateUUID();
 
 	this.name = '';
-	this.sourceFile = '';
 
 	this.image = image !== undefined ? image : Texture.DEFAULT_IMAGE;
 	this.mipmaps = [];


### PR DESCRIPTION
Also removed the reference from the Texture docs

Actually I did find one reference to .sourceFile, in the deprecaded glTFLoader:

https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/deprecated/gltf/glTFLoader.js#L1067