### PR TITLE
Cleanup duplicate () and remove redundant checks - introduced by modularisation

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -518,7 +518,7 @@ PropertyBinding.Composite.prototype = {
 
 PropertyBinding.create = function( root, path, parsedPath ) {
 
-	if ( ! ( (root && root.isAnimationObjectGroup) ) ) {
+	if ( ! ( root && root.isAnimationObjectGroup ) ) {
 
 		return new PropertyBinding( root, path, parsedPath );
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -294,7 +294,7 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		var geometry = object.geometry;
 
-		if ( (object && object.isPoints) || (object && object.isLine) ) {
+		if ( object.isPoints || object.isLine ) {
 
 			var positions = new Float32Attribute( geometry.vertices.length * 3, 3 );
 			var colors = new Float32Attribute( geometry.colors.length * 3, 3 );
@@ -322,9 +322,9 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 			}
 
-		} else if ( (object && object.isMesh) ) {
+		} else if ( object.isMesh ) {
 
-			if ( (geometry && geometry.isGeometry) ) {
+			if ( geometry && geometry.isGeometry ) {
 
 				this.fromGeometry( geometry );
 
@@ -340,7 +340,7 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		var geometry = object.geometry;
 
-		if ( (object && object.isMesh) ) {
+		if ( object.isMesh ) {
 
 			var direct = geometry.__directGeometry;
 

--- a/src/extras/helpers/BoxHelper.js
+++ b/src/extras/helpers/BoxHelper.js
@@ -38,7 +38,7 @@ BoxHelper.prototype.update = ( function () {
 
 	return function update( object ) {
 
-		if ( (object && object.isBox3) ) {
+		if ( object && object.isBox3 ) {
 
 			box.copy( object );
 

--- a/src/extras/helpers/FaceNormalsHelper.js
+++ b/src/extras/helpers/FaceNormalsHelper.js
@@ -28,7 +28,7 @@ function FaceNormalsHelper( object, size, hex, linewidth ) {
 
 	var objGeometry = this.object.geometry;
 
-	if ( (objGeometry && objGeometry.isGeometry) ) {
+	if ( objGeometry && objGeometry.isGeometry ) {
 
 		nNormals = objGeometry.faces.length;
 

--- a/src/extras/helpers/SkeletonHelper.js
+++ b/src/extras/helpers/SkeletonHelper.js
@@ -23,7 +23,7 @@ function SkeletonHelper( object ) {
 
 		var bone = this.bones[ i ];
 
-		if ( (bone.parent && bone.parent.isBone) ) {
+		if ( bone.parent && bone.parent.isBone ) {
 
 			geometry.vertices.push( new Vector3() );
 			geometry.vertices.push( new Vector3() );
@@ -57,7 +57,7 @@ SkeletonHelper.prototype.getBoneList = function( object ) {
 
 	var boneList = [];
 
-	if ( (object && object.isBone) ) {
+	if ( object && object.isBone ) {
 
 		boneList.push( object );
 
@@ -87,7 +87,7 @@ SkeletonHelper.prototype.update = function () {
 
 		var bone = this.bones[ i ];
 
-		if ( (bone.parent && bone.parent.isBone) ) {
+		if ( bone.parent && bone.parent.isBone ) {
 
 			boneMatrix.multiplyMatrices( matrixWorldInv, bone.matrixWorld );
 			geometry.vertices[ j ].setFromMatrixPosition( boneMatrix );

--- a/src/extras/helpers/VertexNormalsHelper.js
+++ b/src/extras/helpers/VertexNormalsHelper.js
@@ -26,11 +26,11 @@ function VertexNormalsHelper( object, size, hex, linewidth ) {
 
 	var objGeometry = this.object.geometry;
 
-	if ( (objGeometry && objGeometry.isGeometry) ) {
+	if ( objGeometry && objGeometry.isGeometry ) {
 
 		nNormals = objGeometry.faces.length * 3;
 
-	} else if ( (objGeometry && objGeometry.isBufferGeometry) ) {
+	} else if ( objGeometry && objGeometry.isBufferGeometry ) {
 
 		nNormals = objGeometry.attributes.normal.count;
 
@@ -79,7 +79,7 @@ VertexNormalsHelper.prototype.update = ( function () {
 
 		var objGeometry = this.object.geometry;
 
-		if ( (objGeometry && objGeometry.isGeometry) ) {
+		if ( objGeometry && objGeometry.isGeometry ) {
 
 			var vertices = objGeometry.vertices;
 
@@ -113,7 +113,7 @@ VertexNormalsHelper.prototype.update = ( function () {
 
 			}
 
-		} else if ( (objGeometry && objGeometry.isBufferGeometry) ) {
+		} else if ( objGeometry && objGeometry.isBufferGeometry ) {
 
 			var objPos = objGeometry.attributes.position;
 

--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -27,7 +27,7 @@ function EdgesGeometry( geometry, thresholdAngle ) {
 
 	var geometry2;
 
-	if ( (geometry && geometry.isBufferGeometry) ) {
+	if ( geometry.isBufferGeometry ) {
 
 		geometry2 = new Geometry();
 		geometry2.fromBufferGeometry( geometry );

--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -19,7 +19,7 @@ function WireframeGeometry( geometry ) {
 
 	var keys = [ 'a', 'b', 'c' ];
 
-	if ( (geometry && geometry.isGeometry) ) {
+	if ( geometry && geometry.isGeometry ) {
 
 		var vertices = geometry.vertices;
 		var faces = geometry.faces;
@@ -72,7 +72,7 @@ function WireframeGeometry( geometry ) {
 
 		this.addAttribute( 'position', new BufferAttribute( coords, 3 ) );
 
-	} else if ( (geometry && geometry.isBufferGeometry) ) {
+	} else if ( geometry && geometry.isBufferGeometry ) {
 
 		if ( geometry.index !== null ) {
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -104,7 +104,7 @@ Material.prototype = {
 
 			}
 
-			if ( (currentValue && currentValue.isColor) ) {
+			if ( currentValue && currentValue.isColor ) {
 
 				currentValue.set( newValue );
 
@@ -154,44 +154,44 @@ Material.prototype = {
 
 		if ( this.name !== '' ) data.name = this.name;
 
-		if ( (this.color && this.color.isColor) ) data.color = this.color.getHex();
+		if ( this.color && this.color.isColor ) data.color = this.color.getHex();
 
 		if ( this.roughness !== undefined ) data.roughness = this.roughness;
 		if ( this.metalness !== undefined ) data.metalness = this.metalness;
 
-		if ( (this.emissive && this.emissive.isColor) ) data.emissive = this.emissive.getHex();
-		if ( (this.specular && this.specular.isColor) ) data.specular = this.specular.getHex();
+		if ( this.emissive && this.emissive.isColor ) data.emissive = this.emissive.getHex();
+		if ( this.specular && this.specular.isColor ) data.specular = this.specular.getHex();
 		if ( this.shininess !== undefined ) data.shininess = this.shininess;
 
-		if ( (this.map && this.map.isTexture) ) data.map = this.map.toJSON( meta ).uuid;
-		if ( (this.alphaMap && this.alphaMap.isTexture) ) data.alphaMap = this.alphaMap.toJSON( meta ).uuid;
-		if ( (this.lightMap && this.lightMap.isTexture) ) data.lightMap = this.lightMap.toJSON( meta ).uuid;
-		if ( (this.bumpMap && this.bumpMap.isTexture) ) {
+		if ( this.map && this.map.isTexture ) data.map = this.map.toJSON( meta ).uuid;
+		if ( this.alphaMap && this.alphaMap.isTexture ) data.alphaMap = this.alphaMap.toJSON( meta ).uuid;
+		if ( this.lightMap && this.lightMap.isTexture ) data.lightMap = this.lightMap.toJSON( meta ).uuid;
+		if ( this.bumpMap && this.bumpMap.isTexture ) {
 
 			data.bumpMap = this.bumpMap.toJSON( meta ).uuid;
 			data.bumpScale = this.bumpScale;
 
 		}
-		if ( (this.normalMap && this.normalMap.isTexture) ) {
+		if ( this.normalMap && this.normalMap.isTexture ) {
 
 			data.normalMap = this.normalMap.toJSON( meta ).uuid;
 			data.normalScale = this.normalScale.toArray();
 
 		}
-		if ( (this.displacementMap && this.displacementMap.isTexture) ) {
+		if ( this.displacementMap && this.displacementMap.isTexture ) {
 
 			data.displacementMap = this.displacementMap.toJSON( meta ).uuid;
 			data.displacementScale = this.displacementScale;
 			data.displacementBias = this.displacementBias;
 
 		}
-		if ( (this.roughnessMap && this.roughnessMap.isTexture) ) data.roughnessMap = this.roughnessMap.toJSON( meta ).uuid;
-		if ( (this.metalnessMap && this.metalnessMap.isTexture) ) data.metalnessMap = this.metalnessMap.toJSON( meta ).uuid;
+		if ( this.roughnessMap && this.roughnessMap.isTexture ) data.roughnessMap = this.roughnessMap.toJSON( meta ).uuid;
+		if ( this.metalnessMap && this.metalnessMap.isTexture ) data.metalnessMap = this.metalnessMap.toJSON( meta ).uuid;
 
-		if ( (this.emissiveMap && this.emissiveMap.isTexture) ) data.emissiveMap = this.emissiveMap.toJSON( meta ).uuid;
-		if ( (this.specularMap && this.specularMap.isTexture) ) data.specularMap = this.specularMap.toJSON( meta ).uuid;
+		if ( this.emissiveMap && this.emissiveMap.isTexture ) data.emissiveMap = this.emissiveMap.toJSON( meta ).uuid;
+		if ( this.specularMap && this.specularMap.isTexture ) data.specularMap = this.specularMap.toJSON( meta ).uuid;
 
-		if ( (this.envMap && this.envMap.isTexture) ) {
+		if ( this.envMap && this.envMap.isTexture ) {
 
 			data.envMap = this.envMap.toJSON( meta ).uuid;
 			data.reflectivity = this.reflectivity; // Scale behind envMap

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -111,7 +111,7 @@ Box3.prototype = {
 
 				if ( geometry !== undefined ) {
 
-					if ( (geometry && geometry.isGeometry) ) {
+					if ( geometry.isGeometry ) {
 
 						var vertices = geometry.vertices;
 
@@ -124,7 +124,7 @@ Box3.prototype = {
 
 						}
 
-					} else if ( (geometry && geometry.isBufferGeometry) ) {
+					} else if ( geometry.isBufferGeometry ) {
 
 						var attribute = geometry.attributes.position;
 
@@ -132,7 +132,7 @@ Box3.prototype = {
 
 							var array, offset, stride;
 
-							if ( (attribute && attribute.isInterleavedBufferAttribute) ) {
+							if ( attribute.isInterleavedBufferAttribute ) {
 
 								array = attribute.data.array;
 								offset = attribute.offset;

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -27,7 +27,7 @@ Color.prototype = {
 
 	set: function ( value ) {
 
-		if ( (value && value.isColor) ) {
+		if ( value && value.isColor ) {
 
 			this.copy( value );
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -173,7 +173,7 @@ Matrix3.prototype = {
 
 	getInverse: function ( matrix, throwOnDegenerate ) {
 
-		if ( (matrix && matrix.isMatrix4) ) {
+		if ( matrix && matrix.isMatrix4 ) {
 
 			console.error( "THREE.Matrix3.getInverse no longer takes a Matrix4 argument." );
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -69,7 +69,7 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			var interRay = new Vector3();
 			var step = (this && this.isLineSegments) ? 2 : 1;
 
-			if ( (geometry && geometry.isBufferGeometry) ) {
+			if ( geometry.isBufferGeometry ) {
 
 				var index = geometry.index;
 				var attributes = geometry.attributes;
@@ -146,7 +146,7 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 				}
 
-			} else if ( (geometry && geometry.isGeometry) ) {
+			} else if ( geometry.isGeometry ) {
 
 				var vertices = geometry.vertices;
 				var nbVertices = vertices.length;

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -204,7 +204,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			var uvs, intersection;
 
-			if ( (geometry && geometry.isBufferGeometry) ) {
+			if ( geometry.isBufferGeometry ) {
 
 				var a, b, c;
 				var index = geometry.index;
@@ -260,7 +260,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 				}
 
-			} else if ( (geometry && geometry.isGeometry) ) {
+			} else if ( geometry.isGeometry ) {
 
 				var fvA, fvB, fvC;
 				var isFaceMaterial = (material && material.isMultiMaterial);

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -86,7 +86,7 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			}
 
-			if ( (geometry && geometry.isBufferGeometry) ) {
+			if ( geometry.isBufferGeometry ) {
 
 				var index = geometry.index;
 				var attributes = geometry.attributes;

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -128,7 +128,7 @@ Object.assign( Skeleton.prototype, {
 
 			if ( bone ) {
 
-				if ( (bone.parent && bone.parent.isBone) ) {
+				if ( bone.parent && bone.parent.isBone ) {
 
 					bone.matrix.getInverse( bone.parent.matrixWorld );
 					bone.matrix.multiply( bone.matrixWorld );

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -105,7 +105,7 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 	normalizeSkinWeights: function () {
 
-		if ( (this.geometry && this.geometry.isGeometry) ) {
+		if ( this.geometry && this.geometry.isGeometry ) {
 
 			for ( var i = 0; i < this.geometry.skinWeights.length; i ++ ) {
 
@@ -125,7 +125,7 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 			}
 
-		} else if ( (this.geometry && this.geometry.isBufferGeometry) ) {
+		} else if ( this.geometry && this.geometry.isBufferGeometry ) {
 
 			var vec = new Vector4();
 


### PR DESCRIPTION
Remove some of the noise from the module conversion automated substitution of:

`object instanceof foo -> (object && object.isFoo)`

where object is already known to exist this becomes `object.isFoo`, otherwise just remove excess () to preserve error case behaviour.

(all areas except src/renderer)