### PR TITLE
Added deprecation warning to WebGLRenderer/.supportsVertexTextures()

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -575,6 +575,7 @@ Object.assign( WebGLRenderer.prototype, {
 		return this.extensions.get( 'EXT_blend_minmax' );
 	},
 	supportsVertexTextures: function () {
+		console.warn( 'THREE.WebGLRenderer: .supportsVertexTextures() is now .capabilities.vertexTextures.' );
 		return this.capabilities.vertexTextures;
 	},
 	supportsInstancedArrays: function () {


### PR DESCRIPTION
Fixes  issue #10029