### PR TITLE
STLLoader: Buffer Geometry for ASCII files

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -179,12 +179,12 @@ THREE.STLLoader.prototype = {
 
 		}
 
-		geometry.addAttribute( 'position', THREE.Float32Attribute( vertices, 3 ) );
-		geometry.addAttribute( 'normal', THREE.Float32Attribute( normals, 3 ) );
+		geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( vertices ), 3 ) );
+		geometry.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( normals ), 3 ) );
 
 		if ( hasColors ) {
 
-			geometry.addAttribute( 'color', THREE.Float32Attribute( colors, 3 ) );
+			geometry.addAttribute( 'color', new THREE.BufferAttribute( new Float32Array( colors ), 3 ) );
 			geometry.hasColors = true;
 			geometry.alpha = alpha;
 
@@ -229,8 +229,8 @@ THREE.STLLoader.prototype = {
 
 		}
 
-		geometry.addAttribute( 'position', THREE.Float32Attribute( vertices, 3 ) );
-		geometry.addAttribute( 'normal', THREE.Float32Attribute( normals, 3 ) );
+		geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( vertices ), 3 ) );
+		geometry.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( normals ), 3 ) );
 
 		return geometry;
 

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -2,15 +2,18 @@
  * @author aleeper / http://adamleeper.com/
  * @author mrdoob / http://mrdoob.com/
  * @author gero3 / https://github.com/gero3
+ * @author Mugen87 / https://github.com/Mugen87
  *
  * Description: A THREE loader for STL ASCII files, as created by Solidworks and other CAD programs.
  *
  * Supports both binary and ASCII encoded files, with automatic detection of type.
  *
+ * The loader returns a non-indexed buffer geometry.
+ *
  * Limitations:
  *  Binary decoding supports "Magics" color format (http://en.wikipedia.org/wiki/STL_(file_format)#Color_in_binary_STL).
  *  There is perhaps some question as to how valid it is to always assume little-endian-ness.
- *  ASCII decoding assumes file is UTF-8. Seems to work for the examples...
+ *  ASCII decoding assumes file is UTF-8.
  *
  * Usage:
  *  var loader = new THREE.STLLoader();
@@ -86,9 +89,7 @@ THREE.STLLoader.prototype = {
 
 		var binData = this.ensureBinary( data );
 
-		return isBinary()
-			? this.parseBinary( binData )
-			: this.parseASCII( this.ensureString( data ) );
+		return isBinary() ? this.parseBinary( binData ) : this.parseASCII( this.ensureString( data ) );
 
 	},
 
@@ -110,7 +111,7 @@ THREE.STLLoader.prototype = {
 				( reader.getUint8( index + 5 ) == 0x3D /*'='*/ ) ) {
 
 				hasColors = true;
-				colors = new Float32Array( faces * 3 * 3 );
+				colors = [];
 
 				defaultR = reader.getUint8( index + 6 ) / 255;
 				defaultG = reader.getUint8( index + 7 ) / 255;
@@ -124,12 +125,10 @@ THREE.STLLoader.prototype = {
 		var dataOffset = 84;
 		var faceLength = 12 * 4 + 2;
 
-		var offset = 0;
-
 		var geometry = new THREE.BufferGeometry();
 
-		var vertices = new Float32Array( faces * 3 * 3 );
-		var normals = new Float32Array( faces * 3 * 3 );
+		var vertices = [];
+		var normals = [];
 
 		for ( var face = 0; face < faces; face ++ ) {
 
@@ -164,34 +163,28 @@ THREE.STLLoader.prototype = {
 
 				var vertexstart = start + i * 12;
 
-				vertices[ offset ] = reader.getFloat32( vertexstart, true );
-				vertices[ offset + 1 ] = reader.getFloat32( vertexstart + 4, true );
-				vertices[ offset + 2 ] = reader.getFloat32( vertexstart + 8, true );
+				vertices.push( reader.getFloat32( vertexstart, true ) );
+				vertices.push( reader.getFloat32( vertexstart + 4, true ) );
+				vertices.push( reader.getFloat32( vertexstart + 8, true ) );
 
-				normals[ offset ] = normalX;
-				normals[ offset + 1 ] = normalY;
-				normals[ offset + 2 ] = normalZ;
+				normals.push( normalX, normalY, normalZ );
 
 				if ( hasColors ) {
 
-					colors[ offset ] = r;
-					colors[ offset + 1 ] = g;
-					colors[ offset + 2 ] = b;
+					colors.push( r, g, b );
 
 				}
-
-				offset += 3;
 
 			}
 
 		}
 
-		geometry.addAttribute( 'position', new THREE.BufferAttribute( vertices, 3 ) );
-		geometry.addAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
+		geometry.addAttribute( 'position', THREE.Float32Attribute( vertices, 3 ) );
+		geometry.addAttribute( 'normal', THREE.Float32Attribute( normals, 3 ) );
 
 		if ( hasColors ) {
 
-			geometry.addAttribute( 'color', new THREE.BufferAttribute( colors, 3 ) );
+			geometry.addAttribute( 'color', THREE.Float32Attribute( colors, 3 ) );
 			geometry.hasColors = true;
 			geometry.alpha = alpha;
 
@@ -203,9 +196,14 @@ THREE.STLLoader.prototype = {
 
 	parseASCII: function ( data ) {
 
-		var geometry, length, normal, patternFace, patternNormal, patternVertex, result, text;
-		geometry = new THREE.Geometry();
+		var geometry, length, patternFace, patternNormal, patternVertex, result, text;
+		geometry = new THREE.BufferGeometry();
 		patternFace = /facet([\s\S]*?)endfacet/g;
+
+		var vertices = [];
+		var normals = [];
+
+		var normal = new THREE.Vector3();
 
 		while ( ( result = patternFace.exec( data ) ) !== null ) {
 
@@ -214,7 +212,9 @@ THREE.STLLoader.prototype = {
 
 			while ( ( result = patternNormal.exec( text ) ) !== null ) {
 
-				normal = new THREE.Vector3( parseFloat( result[ 1 ] ), parseFloat( result[ 3 ] ), parseFloat( result[ 5 ] ) );
+				normal.x = parseFloat( result[ 1 ] );
+				normal.y = parseFloat( result[ 3 ] );
+				normal.z = parseFloat( result[ 5 ] );
 
 			}
 
@@ -222,18 +222,15 @@ THREE.STLLoader.prototype = {
 
 			while ( ( result = patternVertex.exec( text ) ) !== null ) {
 
-				geometry.vertices.push( new THREE.Vector3( parseFloat( result[ 1 ] ), parseFloat( result[ 3 ] ), parseFloat( result[ 5 ] ) ) );
+				vertices.push( parseFloat( result[ 1 ] ), parseFloat( result[ 3 ] ), parseFloat( result[ 5 ] ) );
+				normals.push( normal.x, normal.y, normal.z );
 
 			}
 
-			length = geometry.vertices.length;
-
-			geometry.faces.push( new THREE.Face3( length - 3, length - 2, length - 1, normal ) );
-
 		}
 
-		geometry.computeBoundingBox();
-		geometry.computeBoundingSphere();
+		geometry.addAttribute( 'position', THREE.Float32Attribute( vertices, 3 ) );
+		geometry.addAttribute( 'normal', THREE.Float32Attribute( normals, 3 ) );
 
 		return geometry;
 
@@ -281,211 +278,3 @@ THREE.STLLoader.prototype = {
 	}
 
 };
-
-if ( typeof DataView === 'undefined' ) {
-
-	DataView = function( buffer, byteOffset, byteLength ) {
-
-		this.buffer = buffer;
-		this.byteOffset = byteOffset || 0;
-		this.byteLength = byteLength || buffer.byteLength || buffer.length;
-		this._isString = typeof buffer === "string";
-
-	};
-
-	DataView.prototype = {
-
-		_getCharCodes: function( buffer, start, length ) {
-
-			start = start || 0;
-			length = length || buffer.length;
-			var end = start + length;
-			var codes = [];
-			for ( var i = start; i < end; i ++ ) {
-
-				codes.push( buffer.charCodeAt( i ) & 0xff );
-
-			}
-			return codes;
-
-		},
-
-		_getBytes: function ( length, byteOffset, littleEndian ) {
-
-			var result;
-
-			// Handle the lack of endianness
-			if ( littleEndian === undefined ) {
-
-				littleEndian = this._littleEndian;
-
-			}
-
-			// Handle the lack of byteOffset
-			if ( byteOffset === undefined ) {
-
-				byteOffset = this.byteOffset;
-
-			} else {
-
-				byteOffset = this.byteOffset + byteOffset;
-
-			}
-
-			if ( length === undefined ) {
-
-				length = this.byteLength - byteOffset;
-
-			}
-
-			// Error Checking
-			if ( typeof byteOffset !== 'number' ) {
-
-				throw new TypeError( 'DataView byteOffset is not a number' );
-
-			}
-
-			if ( length < 0 || byteOffset + length > this.byteLength ) {
-
-				throw new Error( 'DataView length or (byteOffset+length) value is out of bounds' );
-
-			}
-
-			if ( this.isString ) {
-
-				result = this._getCharCodes( this.buffer, byteOffset, byteOffset + length );
-
-			} else {
-
-				result = this.buffer.slice( byteOffset, byteOffset + length );
-
-			}
-
-			if ( ! littleEndian && length > 1 ) {
-
-				if ( Array.isArray( result ) === false ) {
-
-					result = Array.prototype.slice.call( result );
-
-				}
-
-				result.reverse();
-
-			}
-
-			return result;
-
-		},
-
-		// Compatibility functions on a String Buffer
-
-		getFloat64: function ( byteOffset, littleEndian ) {
-
-			var b = this._getBytes( 8, byteOffset, littleEndian ),
-
-				sign = 1 - ( 2 * ( b[ 7 ] >> 7 ) ),
-				exponent = ( ( ( ( b[ 7 ] << 1 ) & 0xff ) << 3 ) | ( b[ 6 ] >> 4 ) ) - ( ( 1 << 10 ) - 1 ),
-
-			// Binary operators such as | and << operate on 32 bit values, using + and Math.pow(2) instead
-				mantissa = ( ( b[ 6 ] & 0x0f ) * Math.pow( 2, 48 ) ) + ( b[ 5 ] * Math.pow( 2, 40 ) ) + ( b[ 4 ] * Math.pow( 2, 32 ) ) +
-							( b[ 3 ] * Math.pow( 2, 24 ) ) + ( b[ 2 ] * Math.pow( 2, 16 ) ) + ( b[ 1 ] * Math.pow( 2, 8 ) ) + b[ 0 ];
-
-			if ( exponent === 1024 ) {
-
-				if ( mantissa !== 0 ) {
-
-					return NaN;
-
-				} else {
-
-					return sign * Infinity;
-
-				}
-
-			}
-
-			if ( exponent === - 1023 ) {
-
-				// Denormalized
-				return sign * mantissa * Math.pow( 2, - 1022 - 52 );
-
-			}
-
-			return sign * ( 1 + mantissa * Math.pow( 2, - 52 ) ) * Math.pow( 2, exponent );
-
-		},
-
-		getFloat32: function ( byteOffset, littleEndian ) {
-
-			var b = this._getBytes( 4, byteOffset, littleEndian ),
-
-				sign = 1 - ( 2 * ( b[ 3 ] >> 7 ) ),
-				exponent = ( ( ( b[ 3 ] << 1 ) & 0xff ) | ( b[ 2 ] >> 7 ) ) - 127,
-				mantissa = ( ( b[ 2 ] & 0x7f ) << 16 ) | ( b[ 1 ] << 8 ) | b[ 0 ];
-
-			if ( exponent === 128 ) {
-
-				if ( mantissa !== 0 ) {
-
-					return NaN;
-
-				} else {
-
-					return sign * Infinity;
-
-				}
-
-			}
-
-			if ( exponent === - 127 ) {
-
-				// Denormalized
-				return sign * mantissa * Math.pow( 2, - 126 - 23 );
-
-			}
-
-			return sign * ( 1 + mantissa * Math.pow( 2, - 23 ) ) * Math.pow( 2, exponent );
-
-		},
-
-		getInt32: function ( byteOffset, littleEndian ) {
-
-			var b = this._getBytes( 4, byteOffset, littleEndian );
-			return ( b[ 3 ] << 24 ) | ( b[ 2 ] << 16 ) | ( b[ 1 ] << 8 ) | b[ 0 ];
-
-		},
-
-		getUint32: function ( byteOffset, littleEndian ) {
-
-			return this.getInt32( byteOffset, littleEndian ) >>> 0;
-
-		},
-
-		getInt16: function ( byteOffset, littleEndian ) {
-
-			return ( this.getUint16( byteOffset, littleEndian ) << 16 ) >> 16;
-
-		},
-
-		getUint16: function ( byteOffset, littleEndian ) {
-
-			var b = this._getBytes( 2, byteOffset, littleEndian );
-			return ( b[ 1 ] << 8 ) | b[ 0 ];
-
-		},
-
-		getInt8: function ( byteOffset ) {
-
-			return ( this.getUint8( byteOffset ) << 24 ) >> 24;
-
-		},
-
-		getUint8: function ( byteOffset ) {
-
-			return this._getBytes( 1, byteOffset )[ 0 ];
-
-		}
-
-	 };
-
-}


### PR DESCRIPTION
This PR adds support for `BufferGeometry` and ASCII encodes STL files. Besides, it removes the unnecessary `DataView` polyfill in `STLLoader`. The corresponding example `webgl_loader_stl` works without any adjustments.