### PR TITLE
Enable using Audio.setBuffer() after having played once

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -12,14 +12,14 @@ function Audio( listener ) {
 	this.type = 'Audio';
 
 	this.context = listener.context;
-	this.source = this.context.createBufferSource();
-	this.source.onended = this.onEnded.bind( this );
 
 	this.gain = this.context.createGain();
 	this.gain.connect( listener.getInput() );
 
 	this.autoplay = false;
 
+	this.buffer = null;
+	this.loop = false;
 	this.startTime = 0;
 	this.playbackRate = 1;
 	this.isPlaying = false;
@@ -53,7 +53,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	setBuffer: function ( audioBuffer ) {
 
-		this.source.buffer = audioBuffer;
+		this.buffer = audioBuffer;
 		this.sourceType = 'buffer';
 
 		if ( this.autoplay ) this.play();
@@ -80,9 +80,9 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		var source = this.context.createBufferSource();
 
-		source.buffer = this.source.buffer;
-		source.loop = this.source.loop;
-		source.onended = this.source.onended;
+		source.buffer = this.buffer;
+		source.loop = this.loop;
+		source.onended = this.onEnded.bind( this );
 		source.start( 0, this.startTime );
 		source.playbackRate.value = this.playbackRate;
 
@@ -256,7 +256,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
-		return this.source.loop;
+		return this.loop;
 
 	},
 
@@ -269,7 +269,15 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
-		this.source.loop = value;
+		this.loop = value;
+
+		if ( this.isPlaying === true ) {
+
+			this.source.loop = this.loop;
+
+		}
+
+		return this;
 
 	},
 

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -83,8 +83,8 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		source.buffer = this.buffer;
 		source.loop = this.loop;
 		source.onended = this.onEnded.bind( this );
+		source.playbackRate.setValueAtTime( this.playbackRate, this.startTime );
 		source.start( 0, this.startTime );
-		source.playbackRate.value = this.playbackRate;
 
 		this.isPlaying = true;
 
@@ -227,7 +227,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		if ( this.isPlaying === true ) {
 
-			this.source.playbackRate.value = this.playbackRate;
+			this.source.playbackRate.setValueAtTime( this.playbackRate, this.context.currentTime );
 
 		}
 


### PR DESCRIPTION
`AudioBufferSourceNode` can only be used once, the current `Audio` implementation already works around this by creating a new source whenever `play()` is called.

Since `setBuffer()` assigns the buffer directly to the source, calls to `setBuffer()` will fail after having played the audio once, making it impossible to use another buffer with the `Audio` instance (at least on Chrome, resulting in "Cannot set buffer after it has been already been set", Safari and Firefox don't mind).

This pull requests stores the buffer as an instance variable, which makes it possible to reuse it with a different buffer.

I removed creating a source in the constructor, avoiding to create a source that is never used because a new one is created later in in `play()`. On the other hand, `bind()` is now called on each invocation of `play()`. Not sure if you would prefer saving the bound callback in an instance variable, I wasn't able to find a precedent in three's source.

Since `loop` also directly forwards to the source, it now also gets saved as an instance variable to avoid errors when calling `setLoop()` before `play()`. This makes the implementations of `setLoop()` and `setPlaybackRate()` consistent, also fixing `setLoop()` not returning `this`.