### PR TITLE
remove THREE prefixes

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -161,8 +161,9 @@ function WebGLRenderer( parameters ) {
 
 		_projScreenMatrix = new Matrix4(),
 
-	_vector3 = new THREE.Vector3(),
-	_matrix4 = new THREE.Matrix4(), _matrix42 = new THREE.Matrix4(),
+		_vector3 = new Vector3(),
+		_matrix4 = new Matrix4(), 
+		_matrix42 = new Matrix4(),
 
 		// light arrays cache
 


### PR DESCRIPTION
Some THREE's crept in with #10041, breaks modular use at least.