### PR TITLE
Created doc for BufferAttribute types

### DIFF
--- a/docs/api/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		[page:BufferAttribute] &rarr;
+
+		<h1>BufferAttribute Types</h1>
+
+		<div class="desc">
+		There are nine types of [page:BufferAttribute] available in Three. These correspond to the JavaScript
+		[link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Syntax Typed Arrays].
+		</div>
+
+		<code>
+		THREE.Float64BufferAttribute
+		THREE.Float32BufferAttribute
+		THREE.Uint32BufferAttribute
+		THREE.Int32BufferAttribute
+		THREE.Uint16BufferAttribute
+		THREE.Int16BufferAttribute
+		THREE.Uint8ClampedBufferAttribute
+		THREE.Uint8BufferAttribute
+		THREE.Int8BufferAttribute
+		</code>
+
+		<h2>Constructor</h2>
+
+		All of the above are called in the same way.
+		<h3>TypedBufferAttribute( [page:Array array], [page:Integer itemSize] )</h3>
+		<div>
+			array -- this can be a typed or untyped (normal) array. It will be converted to the Type specified.<br /><br />
+
+			itemSize -- the number of values of the array that should be associated with a particular vertex.
+		</div>
+
+		<h2>Properties</h2>
+
+		See the [page:BufferAttribute] page for inherited properties.
+
+		<h2>Methods</h2>
+
+		See the [page:BufferAttribute] page for inherited methods.
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/src/core/BufferAttribute.js src/core/BufferAttribute.js]
+	</body>
+</html>

--- a/docs/list.js
+++ b/docs/list.js
@@ -68,6 +68,10 @@ var list = {
 			[ "Uniform", "api/core/Uniform"]
 		],
 
+		"Core / BufferAttributes": [
+			[ "BufferAttribute Types", "api/core/bufferAttributeTypes/BufferAttributeTypes" ]
+		],
+
 		"Deprecated": [
 			[ "DeprecatedList", "api/deprecated/DeprecatedList" ]
 		],


### PR DESCRIPTION
Added a page that lists the BufferAttribute Types:
- Float32Attribute
- Float64Attribute
- Int16Attribute
- Int32Attribute
- Int8Attribute
- Uint16Attribute
- Uint32Attribute
- Uint8Attribute
- Uint8ClampedAttribute