### PR TITLE
Automatic Geometry instancing

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -242,6 +242,7 @@ var files = {
 		"webgl_video_panorama_equirectangular"
 	],
 	"webgl / advanced": [
+		"webgl_autoinstancing",
 		"webgl_buffergeometry",
 		"webgl_buffergeometry_constructed_from_geometry",
 		"webgl_buffergeometry_custom_attributes_particles",

--- a/examples/webgl_autoinstancing.html
+++ b/examples/webgl_autoinstancing.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - interactive cubes</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #f0f0f0;
+				margin: 0px;
+				overflow: hidden;
+			}
+		</style>
+	</head>
+	<body>
+
+		<script src="../build/three.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script>
+
+			var container, stats;
+			var camera, scene, renderer;
+			var radius = 800, theta = 0;
+			var groups = [];
+
+			var geometries = [
+				new THREE.BoxBufferGeometry( 10, 10, 10 ),
+				new THREE.BoxBufferGeometry( 5, 5, 5 ),
+				new THREE.BoxBufferGeometry( 15, 15, 15 ),
+				new THREE.BoxBufferGeometry( 2, 2, 2 )
+			];
+			var materials = [
+				new THREE.MeshLambertMaterial( {color: 0xcc0000} ),
+				new THREE.MeshLambertMaterial( {color: 0x00cc00} ),
+				new THREE.MeshLambertMaterial( {color: 0x0000cc} )
+			];
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				var info = document.createElement( 'div' );
+				info.style.position = 'absolute';
+				info.style.top = '10px';
+				info.style.width = '100%';
+				info.style.textAlign = 'center';
+				info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> webgl - autoInstancing: ' +
+					'<form id="controls" style="float:right; text-align:left; padding:1em; background:#fff;">' +
+						'<p><label><input type="radio" name="autoInstancingMode" value="1" checked onclick="changeAutoInstancing(event)" /> AutoInstancingAttributes</label></p>' +
+						'<p><label><input type="radio" name="autoInstancingMode" value="2" onclick="changeAutoInstancing(event)" /> AutoInstancingTexture</label></p>' +
+						'<p><label><input type="radio" name="autoInstancingMode" value="0" onclick="changeAutoInstancing(event)" /> AutoInstancingDisabled</label></p>' +
+						'<p><label><input type="checkbox" checked onchange="toggleInstancable(event)" /> instanceable objects?</label></p>' +
+					'</form>'
+				container.appendChild( info );
+
+				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 10000 );
+
+				scene = new THREE.Scene();
+
+				var light = new THREE.DirectionalLight( 0xffffff, 1 );
+				light.position.set( 1, 1, 1 ).normalize();
+				scene.add( light );
+				scene.add( new THREE.AmbientLight( 0x999999 ) )
+
+				for ( var g = 0; g < 9; g++ ) {
+					var group = new THREE.Group();
+					group.position.x = 300 * (g % 3) - 300;
+					group.position.y = 300 * Math.floor(g / 3) - 300;
+
+					for ( var i = 0; i < 1000; i ++ ) {
+
+						var object = new THREE.Mesh( geometries[i % 4], materials[i % 3] );
+
+						object.position.x = Math.random() * 200 - 100;
+						object.position.y = Math.random() * 200 - 100;
+						object.position.z = Math.random() * 200 - 100;
+
+						object.rotation.x = Math.random() * 2 * Math.PI;
+						object.rotation.y = Math.random() * 2 * Math.PI;
+						object.rotation.z = Math.random() * 2 * Math.PI;
+
+						object.scale.x = Math.random() + 0.5;
+						object.scale.y = Math.random() + 0.5;
+						object.scale.z = Math.random() + 0.5;
+
+						group.add( object );
+					}
+					scene.add( group );
+					groups.push( group );
+				}
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.setClearColor( 0xf0f0f0 );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild(renderer.domElement);
+
+				stats = new Stats();
+				stats.showPanel( 1 );
+				container.appendChild( stats.dom );
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			//
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function changeAutoInstancing(e) {
+				renderer.configAutoInstancing(+e.target.form.autoInstancingMode.value);
+			}
+
+			function toggleInstancable(e) {
+				var instanceable = e.target.checked
+				groups.forEach(function (group) {
+					group.children.forEach(function (obj, i) {
+						obj.material = instanceable ? materials[i % 3] : materials[i % 3].clone()
+					})
+				})
+			}
+
+			function render() {
+
+				theta += 0.5;
+				var angle = THREE.Math.degToRad( theta )
+
+				camera.position.x = radius * Math.sin( angle );
+				camera.position.y = radius * Math.sin( angle );
+				camera.position.z = radius * Math.cos( angle );
+				camera.lookAt( scene.position );
+
+				for (var g = groups.length; g--;) {
+					var group = groups[g];
+					group.rotation.x = angle;
+					group.rotation.y = angle;
+					for (var i = group.children.length; i--;) {
+						group.children[i].rotation.z += 0.1;
+					}
+				}
+
+				camera.updateMatrixWorld();
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/examples/webgl_autoinstancing.html
+++ b/examples/webgl_autoinstancing.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>three.js webgl - interactive cubes</title>
+		<title>three.js webgl - automatic geometry instancing</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<style>

--- a/src/constants.js
+++ b/src/constants.js
@@ -123,3 +123,6 @@ export var RGBM16Encoding = 3005;
 export var RGBDEncoding = 3006;
 export var BasicDepthPacking = 3200;
 export var RGBADepthPacking = 3201;
+export var AutoInstancingDisabled = 0;
+export var AutoInstancingAttributes = 1;
+export var AutoInstancingTexture = 2;

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1,3 +1,4 @@
+import { TrianglesDrawMode } from '../constants';
 import { Vector3 } from '../math/Vector3';
 import { Box3 } from '../math/Box3';
 import { EventDispatcher } from './EventDispatcher';
@@ -36,6 +37,7 @@ function BufferGeometry() {
 	this.boundingSphere = null;
 
 	this.drawRange = { start: 0, count: Infinity };
+	this.drawMode = TrianglesDrawMode;
 
 }
 
@@ -44,6 +46,12 @@ BufferGeometry.MaxIndex = 65535;
 Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 	isBufferGeometry: true,
+
+	setDrawMode: function ( value ) {
+
+		this.drawMode = value;
+
+	},
 
 	getIndex: function () {
 
@@ -1086,6 +1094,10 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		this.drawRange.start = source.drawRange.start;
 		this.drawRange.count = source.drawRange.count;
+
+		// draw mode
+
+		this.drawMode = source.drawMode;
 
 		return this;
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -1,5 +1,6 @@
 import { EventDispatcher } from './EventDispatcher';
 import { Face3 } from './Face3';
+import { TrianglesDrawMode } from '../constants';
 import { Matrix3 } from '../math/Matrix3';
 import { Sphere } from '../math/Sphere';
 import { Box3 } from '../math/Box3';
@@ -47,6 +48,8 @@ function Geometry() {
 	this.boundingBox = null;
 	this.boundingSphere = null;
 
+	this.drawMode = TrianglesDrawMode;
+
 	// update flags
 
 	this.elementsNeedUpdate = false;
@@ -62,6 +65,12 @@ function Geometry() {
 Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 	isGeometry: true,
+
+	setDrawMode: function ( value ) {
+
+		this.drawMode = value;
+
+	},
 
 	applyMatrix: function ( matrix ) {
 
@@ -1413,6 +1422,10 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 		this.colorsNeedUpdate = source.colorsNeedUpdate;
 		this.lineDistancesNeedUpdate = source.lineDistancesNeedUpdate;
 		this.groupsNeedUpdate = source.groupsNeedUpdate;
+
+		// draw mode
+
+		this.drawMode = source.drawMode;
 
 		return this;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -93,8 +93,8 @@ function Object3D() {
 
 	this.userData = {};
 
-	this.onBeforeRender = function () {};
-	this.onAfterRender = function () {};
+	this.onBeforeRender = null;
+	this.onAfterRender = null;
 
 }
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -26,7 +26,7 @@ function Mesh( geometry, material ) {
 	this.geometry = geometry !== undefined ? geometry : new BufferGeometry();
 	this.material = material !== undefined ? material : new MeshBasicMaterial( { color: Math.random() * 0xffffff } );
 
-	this.drawMode = TrianglesDrawMode;
+	this.drawMode = undefined;
 
 	this.updateMorphTargets();
 
@@ -37,6 +37,8 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 	constructor: Mesh,
 
 	isMesh: true,
+
+	// Deprecated
 
 	setDrawMode: function ( value ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -824,19 +824,43 @@ function WebGLRenderer( parameters ) {
 
 			} else {
 
-				switch ( object.drawMode ) {
+				if ( object.drawMode ) {
 
-					case TrianglesDrawMode:
-						renderer.setMode( _gl.TRIANGLES );
-						break;
+					// backwards compatibility
 
-					case TriangleStripDrawMode:
-						renderer.setMode( _gl.TRIANGLE_STRIP );
-						break;
+					switch ( object.drawMode ) {
 
-					case TriangleFanDrawMode:
-						renderer.setMode( _gl.TRIANGLE_FAN );
-						break;
+						case TrianglesDrawMode:
+							renderer.setMode( _gl.TRIANGLES );
+							break;
+
+						case TriangleStripDrawMode:
+							renderer.setMode( _gl.TRIANGLE_STRIP );
+							break;
+
+						case TriangleFanDrawMode:
+							renderer.setMode( _gl.TRIANGLE_FAN );
+							break;
+
+					}
+
+				} else {
+
+					switch ( geometry.drawMode ) {
+
+						case TrianglesDrawMode:
+							renderer.setMode(_gl.TRIANGLES);
+							break;
+
+						case TriangleStripDrawMode:
+							renderer.setMode(_gl.TRIANGLE_STRIP);
+							break;
+
+						case TriangleFanDrawMode:
+							renderer.setMode(_gl.TRIANGLE_FAN);
+							break;
+
+					}
 
 				}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1,4 +1,4 @@
-import { REVISION, MaxEquation, MinEquation, RGB_ETC1_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, SrcAlphaSaturateFactor, OneMinusDstColorFactor, DstColorFactor, OneMinusDstAlphaFactor, DstAlphaFactor, OneMinusSrcAlphaFactor, SrcAlphaFactor, OneMinusSrcColorFactor, SrcColorFactor, OneFactor, ZeroFactor, ReverseSubtractEquation, SubtractEquation, AddEquation, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RGBAFormat, RGBFormat, AlphaFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort565Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, LinearMipMapLinearFilter, LinearMipMapNearestFilter, LinearFilter, NearestMipMapLinearFilter, NearestMipMapNearestFilter, NearestFilter, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, FrontFaceDirectionCW, NoBlending, BackSide, DoubleSide, TriangleFanDrawMode, TriangleStripDrawMode, TrianglesDrawMode, NoColors, FlatShading, LinearToneMapping } from '../constants';
+import { REVISION, MaxEquation, MinEquation, RGB_ETC1_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, SrcAlphaSaturateFactor, OneMinusDstColorFactor, DstColorFactor, OneMinusDstAlphaFactor, DstAlphaFactor, OneMinusSrcAlphaFactor, SrcAlphaFactor, OneMinusSrcColorFactor, SrcColorFactor, OneFactor, ZeroFactor, ReverseSubtractEquation, SubtractEquation, AddEquation, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RGBAFormat, RGBFormat, AlphaFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort565Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, LinearMipMapLinearFilter, LinearMipMapNearestFilter, LinearFilter, NearestMipMapLinearFilter, NearestMipMapNearestFilter, NearestFilter, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, FrontFaceDirectionCW, NoBlending, BackSide, DoubleSide, TriangleFanDrawMode, TriangleStripDrawMode, TrianglesDrawMode, NoColors, FlatShading, LinearToneMapping, AutoInstancingDisabled, AutoInstancingAttributes, AutoInstancingTexture } from '../constants';
 import { Matrix4 } from '../math/Matrix4';
 import { WebGLUniforms } from './webgl/WebGLUniforms';
 import { UniformsUtils } from './shaders/UniformsUtils';
@@ -22,7 +22,9 @@ import { WebGLTextures } from './webgl/WebGLTextures';
 import { WebGLProperties } from './webgl/WebGLProperties';
 import { WebGLState } from './webgl/WebGLState';
 import { WebGLCapabilities } from './webgl/WebGLCapabilities';
+import { BufferAttribute } from '../core/BufferAttribute';
 import { BufferGeometry } from '../core/BufferGeometry';
+import { DataTexture } from '../textures/DataTexture';
 import { WebGLExtensions } from './webgl/WebGLExtensions';
 import { Vector3 } from '../math/Vector3';
 import { Sphere } from '../math/Sphere';
@@ -30,6 +32,7 @@ import { WebGLClipping } from './webgl/WebGLClipping';
 import { Frustum } from '../math/Frustum';
 import { Vector4 } from '../math/Vector4';
 import { Color } from '../math/Color';
+import { _Math } from '../math/Math';
 
 /**
  * @author supereggbert / http://www.paulbrunt.co.uk/
@@ -57,8 +60,11 @@ function WebGLRenderer( parameters ) {
 
 	var lights = [];
 
+	var opaqueInstancedGeometryMap = {};
 	var opaqueObjects = [];
 	var opaqueObjectsLastIndex = - 1;
+
+	var transparentInstancedGeometryMap = {};
 	var transparentObjects = [];
 	var transparentObjectsLastIndex = - 1;
 
@@ -81,7 +87,8 @@ function WebGLRenderer( parameters ) {
 
 	// scene graph
 
-	this.sortObjects = true;
+	this.sortOpaqueObjects = false;
+	this.sortTransparentObjects = true;
 
 	// user-defined clipping
 
@@ -173,18 +180,18 @@ function WebGLRenderer( parameters ) {
 
 			hash: '',
 
-		ambient: [ 0, 0, 0 ],
-		directional: [],
-		directionalShadowMap: [],
-		directionalShadowMatrix: [],
-		spot: [],
-		spotShadowMap: [],
-		spotShadowMatrix: [],
-		rectArea: [],
-		point: [],
-		pointShadowMap: [],
-		pointShadowMatrix: [],
-		hemi: [],
+			ambient: [ 0, 0, 0 ],
+			directional: [],
+			directionalShadowMap: [],
+			directionalShadowMatrix: [],
+			spot: [],
+			spotShadowMap: [],
+			spotShadowMatrix: [],
+			rectArea: [],
+			point: [],
+			pointShadowMap: [],
+			pointShadowMatrix: [],
+			hemi: [],
 
 			shadows: []
 
@@ -274,13 +281,6 @@ function WebGLRenderer( parameters ) {
 	extensions.get( 'OES_texture_half_float' );
 	extensions.get( 'OES_texture_half_float_linear' );
 	extensions.get( 'OES_standard_derivatives' );
-	extensions.get( 'ANGLE_instanced_arrays' );
-
-	if ( extensions.get( 'OES_element_index_uint' ) ) {
-
-		BufferGeometry.MaxIndex = 4294967296;
-
-	}
 
 	var capabilities = new WebGLCapabilities( _gl, extensions, parameters );
 
@@ -297,6 +297,23 @@ function WebGLRenderer( parameters ) {
 	var indexedBufferRenderer = new WebGLIndexedBufferRenderer( _gl, extensions, _infoRender );
 
 	//
+
+	if ( extensions.get( 'OES_element_index_uint' ) ) {
+
+		BufferGeometry.MaxIndex = 4294967296;
+
+	}
+
+	// automatic geometry instancing
+
+	var autoInstancingMode = extensions.get( 'ANGLE_instanced_arrays' ) ? AutoInstancingAttributes : AutoInstancingDisabled;
+	var autoInstancingMinBatchSize = 20;
+	var autoInstancingMaxBatchSize = 2000;
+
+	var autoInstancingTexture = null;
+	var autoInstancingTextureSize = 64;
+
+	var autoInstancingAttributes = {};
 
 	var backgroundPlaneCamera, backgroundPlaneMesh;
 	var backgroundBoxCamera, backgroundBoxMesh;
@@ -446,6 +463,86 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	// Instancing
+
+	this.getAutoInstancingMinBatchSize = function () {
+
+		return autoInstancingMinBatchSize;
+
+	};
+
+	this.getAutoInstancingMaxBatchSize = function () {
+
+		return autoInstancingMaxBatchSize;
+
+	};
+
+	this.getAutoInstancingMode = function () {
+
+		return autoInstancingMode;
+
+	};
+
+	this.configAutoInstancing = function ( mode, desiredMaxBatchSize, desiredMinBatchSize ) {
+
+		switch ( mode ) {
+
+			case AutoInstancingAttributes:
+
+				if ( desiredMaxBatchSize !== undefined ) {
+
+					autoInstancingMaxBatchSize = desiredMaxBatchSize;
+
+				}
+				break;
+
+			case AutoInstancingTexture:
+
+				if ( ! capabilities.floatVertexTextures ) {
+
+					return false;
+
+				}
+
+				if ( desiredMaxBatchSize === undefined ) {
+
+					desiredMaxBatchSize = autoInstancingMaxBatchSize;
+
+				}
+
+				autoInstancingTextureSize = Math.pow( 2, Math.round( Math.log( Math.sqrt( desiredMaxBatchSize * 7 ) ) / Math.log( 2 ) ) );
+				autoInstancingMaxBatchSize = Math.floor( autoInstancingTextureSize * autoInstancingTextureSize / 7 );
+
+				if ( desiredMinBatchSize === undefined ) {
+
+					autoInstancingMinBatchSize = Math.min ( autoInstancingMaxBatchSize, Math.max ( 32, autoInstancingMinBatchSize ));
+
+				}
+
+				break;
+
+			case AutoInstancingDisabled:
+
+				break;
+
+			default:
+
+				return false;
+
+		}
+
+		autoInstancingMode = mode;
+
+		if ( desiredMinBatchSize !== undefined ) {
+
+			autoInstancingMinBatchSize = Math.min( autoInstancingMaxBatchSize, desiredMinBatchSize );
+
+		}
+
+		return true;
+
+	};
+
 	// Clearing
 
 	this.getClearColor = function () {
@@ -521,8 +618,11 @@ function WebGLRenderer( parameters ) {
 
 	this.dispose = function() {
 
+		transparentInstancedGeometryMap = {};
 		transparentObjects = [];
 		transparentObjectsLastIndex = -1;
+
+		opaqueInstancedGeometryMap = {};
 		opaqueObjects = [];
 		opaqueObjectsLastIndex = -1;
 
@@ -557,22 +657,28 @@ function WebGLRenderer( parameters ) {
 
 	function deallocateMaterial( material ) {
 
-		releaseMaterialProgramReference( material );
+		releaseMaterialProgramReferences( material );
 
 		properties.delete( material );
 
 	}
 
 
-	function releaseMaterialProgramReference( material ) {
+	function releaseMaterialProgramReferences( material ) {
 
-		var programInfo = properties.get( material ).program;
+		var materialProperties = properties.get( material );
 
 		material.program = undefined;
 
-		if ( programInfo !== undefined ) {
+		if ( materialProperties.program !== undefined ) {
 
-			programCache.releaseProgram( programInfo );
+			programCache.releaseProgram( materialProperties.program );
+
+		}
+
+		if ( materialProperties.instancingProgram !== undefined ) {
+
+			programCache.releaseProgram( materialProperties.instancingProgram );
 
 		}
 
@@ -678,6 +784,7 @@ function WebGLRenderer( parameters ) {
 
 		setMaterial( material );
 
+		var instancing = Array.isArray( object );
 		var program = setProgram( camera, fog, material, object );
 
 		var updateBuffers = false;
@@ -694,7 +801,7 @@ function WebGLRenderer( parameters ) {
 
 		var morphTargetInfluences = object.morphTargetInfluences;
 
-		if ( morphTargetInfluences !== undefined ) {
+		if ( morphTargetInfluences !== undefined && material.morphTargets ) {
 
 			var activeInfluences = [];
 
@@ -745,6 +852,7 @@ function WebGLRenderer( parameters ) {
 			program.getUniforms().setValue(
 				_gl, 'morphTargetInfluences', morphInfluences );
 
+
 			updateBuffers = true;
 
 		}
@@ -775,13 +883,89 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		// attributes
+
 		if ( updateBuffers ) {
 
-			setupVertexAttributes( material, program, geometry );
+			setupVertexAttributes( material, program, geometry, instancing ? object.length : undefined );
 
 			if ( index !== null ) {
 
 				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, objects.getAttributeBuffer( index ) );
+
+			}
+
+		}
+
+		if ( instancing && autoInstancingMode == AutoInstancingAttributes ) {
+
+			var world1Buffer = autoInstancingAttributes.instanceWorld1.array;
+			var world2Buffer = autoInstancingAttributes.instanceWorld2.array;
+			var world3Buffer = autoInstancingAttributes.instanceWorld3.array;
+			var world4Buffer = autoInstancingAttributes.instanceWorld4.array;
+
+			var normal1Buffer = autoInstancingAttributes.instanceNormal1.array;
+			var normal2Buffer = autoInstancingAttributes.instanceNormal2.array;
+			var normal3Buffer = autoInstancingAttributes.instanceNormal3.array;
+
+			for ( var i = 0, l = object.length; i < l; i++ ) {
+
+				var instance = object[ i ];
+
+				var worldMatrix = instance.matrixWorld.elements;
+				var worldOffset = 4 * i;
+
+				world1Buffer[ worldOffset ] = worldMatrix[ 0 ];
+				world1Buffer[ worldOffset + 1 ] = worldMatrix[ 1 ];
+				world1Buffer[ worldOffset + 2 ] = worldMatrix[ 2 ];
+				world1Buffer[ worldOffset + 3 ] = worldMatrix[ 3 ];
+
+				world2Buffer[ worldOffset ] = worldMatrix[ 4 ];
+				world2Buffer[ worldOffset + 1 ] = worldMatrix[ 5 ];
+				world2Buffer[ worldOffset + 2 ] = worldMatrix[ 6 ];
+				world2Buffer[ worldOffset + 3 ] = worldMatrix[ 7 ];
+
+				world3Buffer[ worldOffset ] = worldMatrix[ 8 ];
+				world3Buffer[ worldOffset + 1 ] = worldMatrix[ 9 ];
+				world3Buffer[ worldOffset + 2 ] = worldMatrix[ 10 ];
+				world3Buffer[ worldOffset + 3 ] = worldMatrix[ 11 ];
+
+				world4Buffer[ worldOffset ] = worldMatrix[ 12 ];
+				world4Buffer[ worldOffset + 1 ] = worldMatrix[ 13 ];
+				world4Buffer[ worldOffset + 2 ] = worldMatrix[ 14 ];
+				world4Buffer[ worldOffset + 3 ] = worldMatrix[ 15 ];
+
+				var normalMatrix = instance.normalMatrix.elements;
+				var normalOffset = 3 * i;
+
+				normal1Buffer[ normalOffset ] = normalMatrix[ 0 ];
+				normal1Buffer[ normalOffset + 1 ] = normalMatrix[ 1 ];
+				normal1Buffer[ normalOffset + 2 ] = normalMatrix[ 2 ];
+
+				normal2Buffer[ normalOffset ] = normalMatrix[ 3 ];
+				normal2Buffer[ normalOffset + 1 ] = normalMatrix[ 4 ];
+				normal2Buffer[ normalOffset + 2 ] = normalMatrix[ 5 ];
+
+				normal3Buffer[ normalOffset ] = normalMatrix[ 6 ];
+				normal3Buffer[ normalOffset + 1 ] = normalMatrix[ 7 ];
+				normal3Buffer[ normalOffset + 2 ] = normalMatrix[ 8 ];
+
+			}
+
+			for ( var attributeName in autoInstancingAttributes ) {
+
+				if ( autoInstancingAttributes.hasOwnProperty( attributeName ) ) {
+
+					var attribute = autoInstancingAttributes[ attributeName ];
+
+					if ( attribute.dynamic ) {
+
+						attribute.needsUpdate = true;
+						objects.updateAttribute( attribute, _gl.ARRAY_BUFFER );
+
+					}
+
+				}
 
 			}
 
@@ -816,7 +1000,25 @@ function WebGLRenderer( parameters ) {
 
 		//
 
-		if ( object.isMesh ) {
+		if ( instancing ) {
+
+			switch ( geometry.drawMode ) {
+
+				case TrianglesDrawMode:
+					renderer.setMode( _gl.TRIANGLES );
+					break;
+
+				case TriangleStripDrawMode:
+					renderer.setMode( _gl.TRIANGLE_STRIP );
+					break;
+
+				case TriangleFanDrawMode:
+					renderer.setMode( _gl.TRIANGLE_FAN );
+					break;
+
+			}
+
+		} else if ( object.isMesh ) {
 
 			if ( material.wireframe === true ) {
 
@@ -900,9 +1102,13 @@ function WebGLRenderer( parameters ) {
 
 			if ( geometry.maxInstancedCount > 0 ) {
 
-				renderer.renderInstances( geometry, drawStart, drawCount );
+				renderer.renderInstances( geometry, geometry.maxInstancedCount, drawStart, drawCount );
 
 			}
+
+		} else if ( instancing ) {
+
+			renderer.renderInstances( geometry, object.length, drawStart, drawCount );
 
 		} else {
 
@@ -912,11 +1118,11 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	function setupVertexAttributes( material, program, geometry, startIndex ) {
+	function setupVertexAttributes( material, program, geometry, instanceCount, startIndex ) {
 
 		var extension;
 
-		if ( geometry && geometry.isInstancedBufferGeometry ) {
+		if ( geometry && ( geometry.isInstancedBufferGeometry || instanceCount !== undefined ) ) {
 
 			extension = extensions.get( 'ANGLE_instanced_arrays' );
 
@@ -1006,6 +1212,54 @@ function WebGLRenderer( parameters ) {
 
 					}
 
+				} else if ( name === 'instanceIndex' || /instanceWorld[1-4]/.test( name ) || /instanceNormal[1-3]/.test( name ) ) {
+
+					var instancingAttribute = autoInstancingAttributes[ name ];
+
+					if ( ! instancingAttribute || instancingAttribute.count !== autoInstancingMaxBatchSize ) {
+
+						if ( instancingAttribute ) {
+
+							properties.delete( instancingAttribute );
+
+						}
+
+						var isInstanceIndex = name === 'instanceIndex';
+						var itemSize = isInstanceIndex ? 1 : name.indexOf( 'World' ) >= 0 ? 4 : 3;
+
+						instancingAttribute = new BufferAttribute( new Float32Array( autoInstancingMaxBatchSize * itemSize ), itemSize );
+
+						if ( isInstanceIndex ) {
+
+							var indexArray = instancingAttribute.array;
+
+							for ( var index = 0; index < autoInstancingMaxBatchSize; index++ ) {
+
+								indexArray[ index ] = index;
+
+							}
+
+						} else {
+
+							instancingAttribute.setDynamic( true );
+
+						}
+
+						objects.updateAttribute( instancingAttribute, _gl.ARRAY_BUFFER );
+
+						autoInstancingAttributes[ name ] = instancingAttribute;
+
+					}
+
+					var buffer = objects.getAttributeBuffer( instancingAttribute );
+					var normalized = instancingAttribute.normalized;
+					var itemSize = instancingAttribute.itemSize;
+
+					state.enableAttributeAndDivisor( programAttribute, 1, extension );
+
+					_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
+					_gl.vertexAttribPointer( programAttribute, itemSize, _gl.FLOAT, normalized, 0, startIndex * itemSize * instancingAttribute.array.BYTES_PER_ELEMENT );
+
 				} else if ( materialDefaultAttributeValues !== undefined ) {
 
 					var value = materialDefaultAttributeValues[ name ];
@@ -1071,7 +1325,7 @@ function WebGLRenderer( parameters ) {
 
 		} else {
 
-			return a.id - b.id;
+			return a.object.id - b.object.id;
 
 		}
 
@@ -1089,7 +1343,7 @@ function WebGLRenderer( parameters ) {
 
 		} else {
 
-			return a.id - b.id;
+			return a.object.id - b.object.id;
 
 		}
 
@@ -1130,6 +1384,9 @@ function WebGLRenderer( parameters ) {
 		opaqueObjectsLastIndex = - 1;
 		transparentObjectsLastIndex = - 1;
 
+		resetInstancedGeometryMap( opaqueInstancedGeometryMap );
+		resetInstancedGeometryMap( transparentInstancedGeometryMap );
+
 		sprites.length = 0;
 		lensFlares.length = 0;
 
@@ -1138,12 +1395,16 @@ function WebGLRenderer( parameters ) {
 
 		projectObject( scene, camera );
 
-		opaqueObjects.length = opaqueObjectsLastIndex + 1;
-		transparentObjects.length = transparentObjectsLastIndex + 1;
+		if ( _this.sortOpaqueObjects === true ) {
 
-		if ( _this.sortObjects === true ) {
-
+			opaqueObjects.length = opaqueObjectsLastIndex + 1;
 			opaqueObjects.sort( painterSortStable );
+
+		}
+
+		if ( _this.sortTransparentObjects === true ) {
+
+			transparentObjects.length = transparentObjectsLastIndex + 1;
 			transparentObjects.sort( reversePainterSortStable );
 
 		}
@@ -1226,7 +1487,7 @@ function WebGLRenderer( parameters ) {
 			backgroundBoxMesh.material.uniforms[ "tCube" ].value = background;
 			backgroundBoxMesh.modelViewMatrix.multiplyMatrices( backgroundBoxCamera.matrixWorldInverse, backgroundBoxMesh.matrixWorld );
 
-			objects.update( backgroundBoxMesh );
+			objects.updateObject( backgroundBoxMesh );
 
 			_this.renderBufferDirect( backgroundBoxCamera, null, backgroundBoxMesh.geometry, backgroundBoxMesh.material, backgroundBoxMesh, null );
 
@@ -1245,7 +1506,7 @@ function WebGLRenderer( parameters ) {
 
 			backgroundPlaneMesh.material.map = background;
 
-			objects.update( backgroundPlaneMesh );
+			objects.updateObject( backgroundPlaneMesh );
 
 			_this.renderBufferDirect( backgroundPlaneCamera, null, backgroundPlaneMesh.geometry, backgroundPlaneMesh.material, backgroundPlaneMesh, null );
 
@@ -1253,25 +1514,21 @@ function WebGLRenderer( parameters ) {
 
 		//
 
-		if ( scene.overrideMaterial ) {
-
-			var overrideMaterial = scene.overrideMaterial;
-
-			renderObjects( opaqueObjects, scene, camera, overrideMaterial );
-			renderObjects( transparentObjects, scene, camera, overrideMaterial );
-
-		} else {
-
-			// opaque pass (front-to-back order)
+		if ( !scene.overrideMaterial ) {
 
 			state.setBlending( NoBlending );
-			renderObjects( opaqueObjects, scene, camera );
-
-			// transparent pass (back-to-front order)
-
-			renderObjects( transparentObjects, scene, camera );
 
 		}
+
+		// opaque pass
+
+		renderInstancedGeometryMap( opaqueInstancedGeometryMap, scene, camera, scene.overrideMaterial );
+		renderObjectList( opaqueObjects, opaqueObjectsLastIndex + 1, scene, camera, scene.overrideMaterial );
+
+		// transparent pass
+
+		renderObjectList( transparentObjects, transparentObjectsLastIndex + 1, scene, camera, scene.overrideMaterial );
+		renderInstancedGeometryMap( transparentInstancedGeometryMap, scene, camera, scene.overrideMaterial );
 
 		// custom render plugins (post pass)
 
@@ -1296,50 +1553,130 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	function pushRenderItem( object, geometry, material, z, group ) {
+	function resetInstancedGeometryMap ( instanceGeometryMap ) {
 
-		var array, index;
+		for ( var uuid in instanceGeometryMap ) {
 
-		// allocate the next position in the appropriate array
+			if ( instanceGeometryMap.hasOwnProperty( uuid ) ) {
 
-		if ( material.transparent ) {
+				var instancedGeometry = instanceGeometryMap[ uuid ];
 
-			array = transparentObjects;
-			index = ++ transparentObjectsLastIndex;
+				if ( instancedGeometry.objects.length == 0 ) {
 
-		} else {
+					delete instanceGeometryMap[ uuid ];
 
-			array = opaqueObjects;
-			index = ++ opaqueObjectsLastIndex;
+				} else {
+
+					instancedGeometry.objects = [];
+
+					if ( instancedGeometry.groups ) {
+
+						for ( var i = 0, l = instancedGeometry.groups.length; i < l; i++ ) {
+
+							instancedGeometry.groups[ i ] = [];
+
+						}
+
+					}
+
+				}
+			}
 
 		}
 
-		// recycle existing render item or grow the array
+	}
 
-		var renderItem = array[ index ];
+	function pushRenderItem( object, geometry, material, z, groupIndex ) {
 
-		if ( renderItem !== undefined ) {
+		if ( autoInstancingMode != AutoInstancingDisabled && isObjectInstanceable( object, material, geometry, groupIndex ) ) {
 
-			renderItem.id = object.id;
-			renderItem.object = object;
-			renderItem.geometry = geometry;
-			renderItem.material = material;
-			renderItem.z = _vector3.z;
-			renderItem.group = group;
+			var map = material.transparent ? transparentInstancedGeometryMap : opaqueInstancedGeometryMap;
+			var key = geometry.uuid + material.uuid;
+
+			var instancedGeometry = map[ key ];
+
+			if ( ! instancedGeometry ) {
+
+				instancedGeometry = {
+					geometry: geometry,
+					material: material,
+					objects: []
+				};
+
+
+				if ( geometry.groups ) {
+
+					var groups = [];
+					groups.length = geometry.groups.length;
+
+					for ( var i = 0; i < groups.length; i++ ) {
+
+						groups[ i ] = [];
+
+					}
+
+					instancedGeometry.groups = groups;
+
+				}
+
+				map[ key ] = instancedGeometry;
+
+			}
+
+			if ( groupIndex !== null ) {
+
+				instancedGeometry.groups[ groupIndex ].push( object );
+
+			} else {
+
+				instancedGeometry.objects.push( object );
+
+			}
 
 		} else {
 
-			renderItem = {
-				id: object.id,
-				object: object,
-				geometry: geometry,
-				material: material,
-				z: _vector3.z,
-				group: group
-			};
+			var array, index;
 
-			// assert( index === array.length );
-			array.push( renderItem );
+			// allocate the next position in the appropriate array
+
+			if ( material.transparent ) {
+
+				array = transparentObjects;
+				index = ++ transparentObjectsLastIndex;
+
+			} else {
+
+				array = opaqueObjects;
+				index = ++ opaqueObjectsLastIndex;
+
+			}
+
+			// recycle existing render item or grow the array
+
+			var renderItem = array[ index ];
+
+			if ( renderItem !== undefined ) {
+
+				renderItem.object = object;
+				renderItem.geometry = geometry;
+				renderItem.material = material;
+				renderItem.z = z;
+				renderItem.groupIndex = groupIndex;
+
+			} else {
+
+				renderItem = {
+					object: object,
+					geometry: geometry,
+					material: material,
+					z: z,
+					groupIndex: groupIndex
+				};
+
+				// assert( index === array.length );
+				array.push( renderItem );
+
+			}
 
 		}
 
@@ -1396,6 +1733,86 @@ function WebGLRenderer( parameters ) {
 
 	}
 
+	function isMaterialSorted ( material, geometry, groupIndex ) {
+
+		if ( material.transparent ) {
+
+			return _this.sortTransparentObjects;
+
+		} else if ( geometry && material.isMultiMaterial ) {
+
+			var groups = geometry.groups;
+			var materials = material.materials;
+			var groupMaterial;
+
+			if ( groupIndex !== undefined ) {
+
+				groupMaterial = materials[ groups[ groupIndex ].materialIndex ];
+
+				if ( groupMaterial.visible && groupMaterial.transparent ) {
+
+					return _this.sortTransparentObjects;
+
+				}
+
+			} else {
+
+				for ( var i = 0, l = groups.length; i < l; i ++ ) {
+
+					groupMaterial = materials[ groups[ i ].materialIndex ];
+
+					if ( groupMaterial.visible && groupMaterial.transparent ) {
+
+						return _this.sortTransparentObjects;
+
+					}
+
+				}
+
+			}
+		}
+
+		return _this.sortOpaqueObjects;
+
+	}
+
+	function isObjectInstanceable ( object, material, geometry, groupIndex ) {
+
+		return geometry &&
+			! (
+				// CPU draw call sorting is inherently incompatible with instancing, which uses just one draw call.
+
+				isMaterialSorted( material, geometry, groupIndex ) ||
+
+				// onBeforeRender() and onAfterRender() are specifically designed for messing with the renderer's
+				// state (namely uniforms). If they're set then we assume instancing is not an option.
+
+				object.onBeforeRender ||
+				object.onAfterRender ||
+
+				// Skinned meshes pull their bone matrices from objects (specifically Mesh).
+
+				( object.isSkinnedMesh && material.skinning ) ||
+
+				// Morph pull their influences from objects (specifically Mesh).
+
+				( object.morphTargetInfluences && material.morphTargets ) ||
+
+				// InstancedBufferGeometry is manually instanced by the user, not one instance per "object".
+
+				geometry.isInstancedBufferGeometry ||
+
+				// Instanced objects are rendered according to the Geometry draw mode (Mesh.drawMode has been deprecated).
+
+				object.drawMode
+			);
+
+		// Instancing support for dynamic uniforms (coupled with objects), morph target influences and bone matrices could
+		// be made possible by packing the data into an array (or texture) and requiring shaders to look up values with
+		// the instance ID (like our world matrices). However, this could get a bit hairy and isn't supported at present.
+
+	}
+
 	function projectObject( object, camera ) {
 
 		if ( object.visible === false ) return;
@@ -1422,7 +1839,7 @@ function WebGLRenderer( parameters ) {
 
 			} else if ( object.isImmediateRenderObject ) {
 
-				if ( _this.sortObjects === true ) {
+				if ( isMaterialSorted( object.material ) ) {
 
 					_vector3.setFromMatrixPosition( object.matrixWorld );
 					_vector3.applyMatrix4( _projScreenMatrix );
@@ -1445,16 +1862,16 @@ function WebGLRenderer( parameters ) {
 
 					if ( material.visible === true ) {
 
-						if ( _this.sortObjects === true ) {
+						var geometry = objects.updateObject( object );
+
+						if ( isMaterialSorted( object.material, geometry ) ) {
 
 							_vector3.setFromMatrixPosition( object.matrixWorld );
 							_vector3.applyMatrix4( _projScreenMatrix );
 
 						}
 
-						var geometry = objects.update( object );
-
-						if ( material.isMultiMaterial ) {
+						if ( material.materials ) {
 
 							var groups = geometry.groups;
 							var materials = material.materials;
@@ -1474,7 +1891,7 @@ function WebGLRenderer( parameters ) {
 
 									} else if ( groupMaterial.visible === true ) {
 
-										pushRenderItem( object, geometry, groupMaterial, _vector3.z, group );
+										pushRenderItem( object, geometry, groupMaterial, _vector3.z, i );
 
 									}
 
@@ -1510,21 +1927,25 @@ function WebGLRenderer( parameters ) {
 
 	}
 
-	function renderObjects( renderList, scene, camera, overrideMaterial ) {
+	function renderObjectList( renderList, renderListLength, scene, camera, overrideMaterial ) {
 
-		for ( var i = 0, l = renderList.length; i < l; i ++ ) {
+		for ( var i = 0; i < renderListLength; i ++ ) {
 
 			var renderItem = renderList[ i ];
 
 			var object = renderItem.object;
 			var geometry = renderItem.geometry;
-			var material = overrideMaterial === undefined ? renderItem.material : overrideMaterial;
-			var group = renderItem.group;
+			var material = overrideMaterial ? overrideMaterial : renderItem.material;
+			var group = geometry.groups[ renderItem.groupIndex ] || null;
 
 			object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
 			object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
 
-			object.onBeforeRender( _this, scene, camera, geometry, material, group );
+			if ( object.onBeforeRender ) {
+
+				object.onBeforeRender( _this, scene, camera, geometry, material, group );
+
+			}
 
 			if ( object.isImmediateRenderObject ) {
 
@@ -1542,12 +1963,88 @@ function WebGLRenderer( parameters ) {
 
 			} else {
 
-				_this.renderBufferDirect( camera, scene.fog, geometry, material, object, group );
+				var instanceCount = undefined;
+
+				if ( geometry && geometry.isInstancedBufferGeometry && geometry.maxInstancedCount > 0 ) {
+
+					instanceCount = geometry.maxInstancedCount;
+
+				}
+
+				_this.renderBufferDirect( camera, scene.fog, geometry, material, object, group, instanceCount );
 
 			}
 
-			object.onAfterRender( _this, scene, camera, geometry, material, group );
+			if ( object.onAfterRender ) {
 
+				object.onAfterRender( _this, scene, camera, geometry, material, group );
+
+			}
+
+		}
+
+	}
+
+	function renderInstancedObjects ( objects, geometry, group, scene, camera, material ) {
+
+		if ( objects.length > 0 ) {
+
+			for ( var i = 0, l = objects.length; i < l; i++ ) {
+
+				var object = objects[ i ];
+
+				object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
+				object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
+
+			}
+
+			if ( objects.length < autoInstancingMinBatchSize ) {
+
+				for ( var i = 0, l = objects.length; i < l; i++ ) {
+
+					_this.renderBufferDirect( camera, scene.fog, geometry, material, objects[ i ], group );
+
+				}
+
+			} else {
+
+				for ( var batchOffset = 0; batchOffset < objects.length; batchOffset += autoInstancingMaxBatchSize ) {
+
+					var batch = objects.slice( batchOffset, batchOffset + Math.min( objects.length - batchOffset, autoInstancingMaxBatchSize ) );
+					_this.renderBufferDirect( camera, scene.fog, geometry, material, batch, group );
+
+				}
+
+			}
+
+		}
+
+	}
+
+	function renderInstancedGeometryMap ( instancedGeometryMap, scene, camera, overrideMaterial ) {
+
+		for ( var uuid in instancedGeometryMap ) {
+
+			if ( instancedGeometryMap.hasOwnProperty( uuid ) ) {
+
+				var instancedGeometry = instancedGeometryMap[ uuid ];
+				var geometry = instancedGeometry.geometry;
+
+				if ( instancedGeometry.groups ) {
+
+					for ( var groupIndex = 0, groupCount = instancedGeometry.groups.length; groupIndex < groupCount; groupIndex++ ) {
+
+						var objects = instancedGeometry.groups[ groupIndex ];
+						var group = geometry.groups[ groupIndex ];
+
+						renderInstancedObjects( objects, geometry, group, scene, camera, overrideMaterial || instancedGeometry.material );
+					}
+
+				}
+
+				renderInstancedObjects( instancedGeometry.objects, geometry, null, scene, camera, overrideMaterial || instancedGeometry.material );
+
+			}
 
 		}
 
@@ -1562,25 +2059,32 @@ function WebGLRenderer( parameters ) {
 
 		var code = programCache.getProgramCode( material, parameters );
 
-		var program = materialProperties.program;
+		var instancing = Array.isArray( object );
+		var program = instancing ? materialProperties.instancingProgram : materialProperties.program;
 		var programChange = true;
 
 		if ( program === undefined ) {
 
-			// new material
-			material.addEventListener( 'dispose', onMaterialDispose );
+			if ( materialProperties.program === undefined && materialProperties.instancingProgram === undefined ) {
+
+				// new material
+				material.addEventListener( 'dispose', onMaterialDispose );
+
+			}
 
 		} else if ( program.code !== code ) {
 
 			// changed glsl or parameters
-			releaseMaterialProgramReference( material );
+			programCache.releaseProgram( program );
 
-		} else if ( parameters.shaderID !== undefined ) {
+		} else if ( material.program === program ) {
 
-			// same glsl and uniform list
-			return;
+			if ( parameters.shaderID !== undefined ) {
 
-		} else {
+				// same glsl and uniform list
+				return;
+
+			}
 
 			// only rebuild uniform list
 			programChange = false;
@@ -1615,7 +2119,16 @@ function WebGLRenderer( parameters ) {
 
 			program = programCache.acquireProgram( material, parameters, code );
 
-			materialProperties.program = program;
+			if ( instancing ) {
+
+				materialProperties.instancingProgram = program;
+
+			} else {
+
+				materialProperties.program = program;
+
+			}
+
 			material.program = program;
 
 		}
@@ -1667,6 +2180,13 @@ function WebGLRenderer( parameters ) {
 		}
 
 		materialProperties.fog = fog;
+		materialProperties.instancingMode = Array.isArray( object ) ? autoInstancingMode : AutoInstancingDisabled;
+
+		if ( materialProperties.instancingMode != AutoInstancingDisabled ) {
+
+			materialProperties.maxInstances = autoInstancingMaxBatchSize;
+
+		}
 
 		// store the light setup it was created for
 
@@ -1693,25 +2213,41 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		var progUniforms = materialProperties.program.getUniforms(),
+		var progUniforms = program.getUniforms(),
 			uniformsList =
 				WebGLUniforms.seqWithValue( progUniforms.seq, uniforms );
 
-		materialProperties.uniformsList = uniformsList;
+		if ( instancing ) {
+			materialProperties.instancingUniformsList = uniformsList;
+		} else {
+			materialProperties.uniformsList = uniformsList;
+		}
 
 	}
 
 	function setMaterial( material ) {
 
-		material.side === DoubleSide
-			? state.disable( _gl.CULL_FACE )
-			: state.enable( _gl.CULL_FACE );
+		if ( material.side !== DoubleSide ) {
+
+			state.enable( _gl.CULL_FACE );
+
+		} else {
+
+			state.disable( _gl.CULL_FACE );
+
+		}
 
 		state.setFlipSided( material.side === BackSide );
 
-		material.transparent === true
-			? state.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha, material.premultipliedAlpha )
-			: state.setBlending( NoBlending );
+		if ( material.transparent === true ) {
+
+			state.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha, material.premultipliedAlpha );
+
+		} else {
+
+			state.setBlending( NoBlending );
+
+		}
 
 		state.setDepthFunc( material.depthFunc );
 		state.setDepthTest( material.depthTest );
@@ -1721,7 +2257,7 @@ function WebGLRenderer( parameters ) {
 
 	}
 
-	function setProgram( camera, fog, material, object ) {
+	function updateMaterial( material, camera, fog, object ) {
 
 		var materialProperties = properties.get( material );
 
@@ -1746,7 +2282,25 @@ function WebGLRenderer( parameters ) {
 
 		if ( material.needsUpdate === false ) {
 
-			if ( materialProperties.program === undefined ) {
+			var program, activeAutoInstancingMode;
+
+			if ( Array.isArray( object ) ) {
+
+				program = materialProperties.instancingProgram;
+				activeAutoInstancingMode = autoInstancingMode;
+
+			} else {
+
+				program = materialProperties.program;
+				activeAutoInstancingMode = AutoInstancingDisabled;
+
+			}
+
+			if ( program === undefined ) {
+
+				material.needsUpdate = true;
+
+			} else if ( materialProperties.instancingMode != activeAutoInstancingMode ) {
 
 				material.needsUpdate = true;
 
@@ -1764,6 +2318,10 @@ function WebGLRenderer( parameters ) {
 
 				material.needsUpdate = true;
 
+			} else if ( activeAutoInstancingMode != AutoInstancingDisabled && materialProperties.maxInstances !== autoInstancingMaxBatchSize ) {
+
+				material.needsUpdate = true;
+
 			}
 
 		}
@@ -1775,11 +2333,21 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		return materialProperties;
+
+	}
+
+	function setProgram( camera, fog, material, object ) {
+
+		var materialProperties = updateMaterial( material, camera, fog, object );
+
 		var refreshProgram = false;
 		var refreshMaterial = false;
 		var refreshLights = false;
 
-		var program = materialProperties.program,
+		var instancing = Array.isArray( object );
+
+		var program = instancing ? materialProperties.instancingProgram : materialProperties.program,
 			p_uniforms = program.getUniforms(),
 			m_uniforms = materialProperties.__webglShader.uniforms;
 
@@ -1987,17 +2555,97 @@ function WebGLRenderer( parameters ) {
 			if ( m_uniforms.ltcMat !== undefined ) m_uniforms.ltcMat.value = THREE.UniformsLib.LTC_MAT_TEXTURE;
 			if ( m_uniforms.ltcMag !== undefined ) m_uniforms.ltcMag.value = THREE.UniformsLib.LTC_MAG_TEXTURE;
 
-			WebGLUniforms.upload(
-				_gl, materialProperties.uniformsList, m_uniforms, _this );
+			var uniformsList = instancing ? materialProperties.instancingUniformsList : materialProperties.uniformsList;
+			WebGLUniforms.upload(_gl, uniformsList, m_uniforms, _this );
 
 		}
 
-
 		// common matrices
 
-		p_uniforms.set( _gl, object, 'modelViewMatrix' );
-		p_uniforms.set( _gl, object, 'normalMatrix' );
-		p_uniforms.setValue( _gl, 'modelMatrix', object.matrixWorld );
+		if ( instancing && autoInstancingMode == AutoInstancingTexture ) {
+
+			var modelMatrices = [];
+			var normalMatrices = [];
+
+			for ( var i = 0, l = object.length; i < l; i++ ) {
+
+				var instance = object[ i ];
+
+				modelMatrices[ i ] = instance.matrixWorld;
+				normalMatrices[ i ] = instance.normalMatrix;
+
+			}
+
+			var instancingBuffer;
+
+			if ( ! autoInstancingTexture || autoInstancingTexture.image.width !== autoInstancingTextureSize ) {
+
+				instancingBuffer = new Float32Array( autoInstancingTextureSize * autoInstancingTextureSize * 4 );
+				autoInstancingTexture = new DataTexture( instancingBuffer, autoInstancingTextureSize, autoInstancingTextureSize, RGBAFormat, FloatType );
+
+			} else {
+
+				instancingBuffer = autoInstancingTexture.image.data;
+
+			}
+
+			for ( var i = 0, l = object.length; i < l; i++ ) {
+
+				var modelMatrix = modelMatrices[ i ].elements;
+				var offset = i * 16;
+
+				instancingBuffer[ offset ] = modelMatrix[ 0 ];
+				instancingBuffer[ offset + 1 ] = modelMatrix[ 1 ];
+				instancingBuffer[ offset + 2 ] = modelMatrix[ 2 ];
+				instancingBuffer[ offset + 3 ] = modelMatrix[ 3 ];
+
+				instancingBuffer[ offset + 4 ] = modelMatrix[ 4 ];
+				instancingBuffer[ offset + 5 ] = modelMatrix[ 5 ];
+				instancingBuffer[ offset + 6 ] = modelMatrix[ 6 ];
+				instancingBuffer[ offset + 7 ] = modelMatrix[ 7 ];
+
+				instancingBuffer[ offset + 8 ]  = modelMatrix[ 8 ];
+				instancingBuffer[ offset + 9 ]  = modelMatrix[ 9 ];
+				instancingBuffer[ offset + 10 ] = modelMatrix[ 10 ];
+				instancingBuffer[ offset + 11 ] = modelMatrix[ 11 ];
+
+				instancingBuffer[ offset + 12 ] = modelMatrix[ 12 ];
+				instancingBuffer[ offset + 13 ] = modelMatrix[ 13 ];
+				instancingBuffer[ offset + 14 ] = modelMatrix[ 14 ];
+				instancingBuffer[ offset + 15 ] = modelMatrix[ 15 ];
+
+				var normalMatrix = normalMatrices[ i ].elements;
+				var normalOffset = autoInstancingMaxBatchSize * 16 + i * 12;
+
+				instancingBuffer[ normalOffset ] = normalMatrix[ 0 ];
+				instancingBuffer[ normalOffset + 1 ] = normalMatrix[ 1 ];
+				instancingBuffer[ normalOffset + 2 ] = normalMatrix[ 2 ];
+				instancingBuffer[ normalOffset + 3 ] = 0;
+
+				instancingBuffer[ normalOffset + 4 ] = normalMatrix[ 3 ];
+				instancingBuffer[ normalOffset + 5 ] = normalMatrix[ 4 ];
+				instancingBuffer[ normalOffset + 6 ] = normalMatrix[ 5 ];
+				instancingBuffer[ normalOffset + 7 ] = 0;
+
+				instancingBuffer[ normalOffset + 8 ] = normalMatrix[ 6 ];
+				instancingBuffer[ normalOffset + 9 ] = normalMatrix[ 7 ];
+				instancingBuffer[ normalOffset + 10 ] = normalMatrix[ 8 ];
+				instancingBuffer[ normalOffset + 11 ] = 0;
+
+			}
+
+			autoInstancingTexture.needsUpdate = true;
+
+			p_uniforms.setValue( _gl, 'instancingTexture', autoInstancingTexture );
+			p_uniforms.setValue( _gl, 'instancingTextureSize', autoInstancingTextureSize );
+
+		} else {
+
+			p_uniforms.set( _gl, object, 'modelViewMatrix' );
+			p_uniforms.set( _gl, object, 'normalMatrix' );
+			p_uniforms.setValue( _gl, 'modelMatrix', object.matrixWorld );
+
+		}
 
 		return program;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -129,6 +129,7 @@ function WebGLRenderer( parameters ) {
 
 		//
 
+		_textureUnitMap = {},
 		_usedTextureUnits = 0,
 
 		//
@@ -1722,8 +1723,6 @@ function WebGLRenderer( parameters ) {
 
 	function setProgram( camera, fog, material, object ) {
 
-		_usedTextureUnits = 0;
-
 		var materialProperties = properties.get( material );
 
 		if ( _clippingEnabled ) {
@@ -1788,6 +1787,9 @@ function WebGLRenderer( parameters ) {
 
 			_gl.useProgram( program.program );
 			_currentProgram = program.id;
+
+			_usedTextureUnits = 0;
+			_textureUnitMap = {};
 
 			refreshProgram = true;
 			refreshMaterial = true;
@@ -2545,17 +2547,21 @@ function WebGLRenderer( parameters ) {
 
 	// Textures
 
-	function allocTextureUnit() {
+	function allocTextureUnit( identifier ) {
 
-		var textureUnit = _usedTextureUnits;
+		var textureUnit = _textureUnitMap[ identifier ];
 
-		if ( textureUnit >= capabilities.maxTextures ) {
+		if ( textureUnit === undefined ) {
 
-			console.warn( 'WebGLRenderer: trying to use ' + textureUnit + ' texture units while this GPU supports only ' + capabilities.maxTextures );
+			textureUnit = _textureUnitMap[ identifier ] = ++ _usedTextureUnits;
+
+			if ( textureUnit >= capabilities.maxTextures ) {
+
+				console.warn( 'WebGLRenderer: trying to use ' + textureUnit + ' texture units while this GPU supports only ' + capabilities.maxTextures );
+
+			}
 
 		}
-
-		_usedTextureUnits += 1;
 
 		return textureUnit;
 

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -16,6 +16,7 @@ import color_pars_fragment from './ShaderChunk/color_pars_fragment.glsl';
 import color_pars_vertex from './ShaderChunk/color_pars_vertex.glsl';
 import color_vertex from './ShaderChunk/color_vertex.glsl';
 import common from './ShaderChunk/common.glsl';
+import common_vertex from './ShaderChunk/common_vertex.glsl';
 import cube_uv_reflection_fragment from './ShaderChunk/cube_uv_reflection_fragment.glsl';
 import defaultnormal_vertex from './ShaderChunk/defaultnormal_vertex.glsl';
 import displacementmap_pars_vertex from './ShaderChunk/displacementmap_pars_vertex.glsl';
@@ -52,6 +53,7 @@ import map_particle_fragment from './ShaderChunk/map_particle_fragment.glsl';
 import map_particle_pars_fragment from './ShaderChunk/map_particle_pars_fragment.glsl';
 import metalnessmap_fragment from './ShaderChunk/metalnessmap_fragment.glsl';
 import metalnessmap_pars_fragment from './ShaderChunk/metalnessmap_pars_fragment.glsl';
+import model_matrix_pars_vertex from './ShaderChunk/model_matrix_pars_vertex.glsl';
 import morphnormal_vertex from './ShaderChunk/morphnormal_vertex.glsl';
 import morphtarget_pars_vertex from './ShaderChunk/morphtarget_pars_vertex.glsl';
 import morphtarget_vertex from './ShaderChunk/morphtarget_vertex.glsl';
@@ -127,6 +129,7 @@ export var ShaderChunk = {
 	color_pars_vertex: color_pars_vertex,
 	color_vertex: color_vertex,
 	common: common,
+	common_vertex: common_vertex,
 	cube_uv_reflection_fragment: cube_uv_reflection_fragment,
 	defaultnormal_vertex: defaultnormal_vertex,
 	displacementmap_pars_vertex: displacementmap_pars_vertex,
@@ -163,6 +166,7 @@ export var ShaderChunk = {
 	map_particle_pars_fragment: map_particle_pars_fragment,
 	metalnessmap_fragment: metalnessmap_fragment,
 	metalnessmap_pars_fragment: metalnessmap_pars_fragment,
+	model_matrix_pars_vertex: model_matrix_pars_vertex,
 	morphnormal_vertex: morphnormal_vertex,
 	morphtarget_pars_vertex: morphtarget_pars_vertex,
 	morphtarget_vertex: morphtarget_vertex,

--- a/src/renderers/shaders/ShaderChunk/common_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/common_vertex.glsl
@@ -1,0 +1,7 @@
+#ifdef USE_INSTANCING
+
+    mat4 modelMatrix = getModelMatrix();
+    mat4 modelViewMatrix = viewMatrix * modelMatrix;
+    mat3 normalMatrix = getNormalMatrix();
+
+#endif

--- a/src/renderers/shaders/ShaderChunk/model_matrix_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/model_matrix_pars_vertex.glsl
@@ -1,0 +1,75 @@
+#ifdef USE_INSTANCING
+
+	#ifdef USE_INSTANCING_TEXTURE
+
+		uniform sampler2D instancingTexture;
+		uniform int instancingTextureSize;
+
+		mat4 getModelMatrix() {
+
+			float dx = 1.0 / float( instancingTextureSize );
+			float dy = 1.0 / float( instancingTextureSize );
+
+			float j = instanceIndex * 4.0;
+			float x = mod( j, float( instancingTextureSize ) );
+			float y = floor( j * dy );
+
+			y = dy * ( y + 0.5 );
+
+			vec4 v1 = texture2D( instancingTexture, vec2( dx * ( x + 0.5 ), y ) );
+			vec4 v2 = texture2D( instancingTexture, vec2( dx * ( x + 1.5 ), y ) );
+			vec4 v3 = texture2D( instancingTexture, vec2( dx * ( x + 2.5 ), y ) );
+			vec4 v4 = texture2D( instancingTexture, vec2( dx * ( x + 3.5 ), y ) );
+
+			return mat4( v1, v2, v3, v4 );
+
+		}
+
+		mat3 getNormalMatrix() {
+
+			float j = float( MAX_INSTANCES ) * 4.0 + instanceIndex * 3.0;
+
+			float dx = 1.0 / float( instancingTextureSize );
+			float dy = dx;
+
+			vec2 coord;
+
+			coord.x = dx * ( mod( j, float( instancingTextureSize ) ) + 0.5 );
+			coord.y = dy * ( floor( j * dy ) + 0.5 );
+			vec3 v1 = texture2D( instancingTexture, coord ).xyz;
+
+			coord.x = dx * ( mod( j + 1.0, float( instancingTextureSize ) ) + 0.5 );
+			coord.y = dy * ( floor( ( j + 1.0 ) * dy ) + 0.5 );
+			vec3 v2 = texture2D( instancingTexture, coord ).xyz;
+
+			coord.x = dx * ( mod( j + 2.0, float( instancingTextureSize ) ) + 0.5 );
+			coord.y = dy * ( floor( ( j + 2.0 ) * dy ) + 0.5 );
+			vec3 v3 = texture2D( instancingTexture, coord ).xyz;
+
+			return mat3( v1, v2, v3 );
+
+		}
+
+	#elif defined USE_INSTANCING_ATTRIBUTES
+
+		mat4 getModelMatrix() {
+
+			return mat4( instanceWorld1, instanceWorld2, instanceWorld3, instanceWorld4 );
+
+		}
+
+		mat3 getNormalMatrix() {
+
+			return mat3( instanceNormal1, instanceNormal2, instanceNormal3 );
+
+		}
+
+	#endif
+
+#else
+
+	uniform mat4 modelMatrix;
+	uniform mat4 modelViewMatrix;
+	uniform mat3 normalMatrix;
+
+#endif

--- a/src/renderers/shaders/ShaderLib/cube_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/cube_vert.glsl
@@ -4,9 +4,11 @@ varying vec3 vWorldPosition;
 
 void main() {
 
+	#include <common_vertex>
+	#include <begin_vertex>
+
 	vWorldPosition = transformDirection( position, modelMatrix );
 
-	#include <begin_vertex>
 	#include <project_vertex>
 
 }

--- a/src/renderers/shaders/ShaderLib/depth_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_vert.glsl
@@ -8,6 +8,7 @@
 
 void main() {
 
+	#include <common_vertex>
 	#include <uv_vertex>
 
 	#include <skinbase_vertex>

--- a/src/renderers/shaders/ShaderLib/distanceRGBA_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/distanceRGBA_vert.glsl
@@ -7,6 +7,7 @@ varying vec4 vWorldPosition;
 
 void main() {
 
+	#include <common_vertex>
 	#include <skinbase_vertex>
 	#include <begin_vertex>
 	#include <morphtarget_vertex>

--- a/src/renderers/shaders/ShaderLib/equirect_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/equirect_vert.glsl
@@ -4,9 +4,11 @@ varying vec3 vWorldPosition;
 
 void main() {
 
+	#include <common_vertex>
+	#include <begin_vertex>
+
 	vWorldPosition = transformDirection( position, modelMatrix );
 
-	#include <begin_vertex>
 	#include <project_vertex>
 
 }

--- a/src/renderers/shaders/ShaderLib/linedashed_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/linedashed_vert.glsl
@@ -11,6 +11,7 @@ varying float vLineDistance;
 
 void main() {
 
+	#include <common_vertex>
 	#include <color_vertex>
 
 	vLineDistance = scale * lineDistance;

--- a/src/renderers/shaders/ShaderLib/meshbasic_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshbasic_vert.glsl
@@ -11,6 +11,7 @@
 
 void main() {
 
+	#include <common_vertex>
 	#include <uv_vertex>
 	#include <uv2_vertex>
 	#include <color_vertex>

--- a/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl
@@ -24,6 +24,7 @@ varying vec3 vLightFront;
 
 void main() {
 
+	#include <common_vertex>
 	#include <uv_vertex>
 	#include <uv2_vertex>
 	#include <color_vertex>

--- a/src/renderers/shaders/ShaderLib/meshphong_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphong_vert.glsl
@@ -23,6 +23,7 @@ varying vec3 vViewPosition;
 
 void main() {
 
+	#include <common_vertex>
 	#include <uv_vertex>
 	#include <uv2_vertex>
 	#include <color_vertex>

--- a/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl
@@ -23,6 +23,7 @@ varying vec3 vViewPosition;
 
 void main() {
 
+	#include <common_vertex>
 	#include <uv_vertex>
 	#include <uv2_vertex>
 	#include <color_vertex>

--- a/src/renderers/shaders/ShaderLib/normal_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/normal_vert.glsl
@@ -20,19 +20,9 @@
 
 void main() {
 
-	#include <uv_vertex>
+	#include <common_vertex>
 
-	#include <beginnormal_vertex>
-	#include <morphnormal_vertex>
-	#include <skinbase_vertex>
-	#include <skinnormal_vertex>
-	#include <defaultnormal_vertex>
-
-#ifndef FLAT_SHADED // Normal computed with derivatives when FLAT_SHADED
-
-	vNormal = normalize( transformedNormal );
-
-#endif
+	vNormal = normalize( normalMatrix * normal );
 
 	#include <begin_vertex>
 	#include <displacementmap_vertex>

--- a/src/renderers/shaders/ShaderLib/points_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/points_vert.glsl
@@ -10,6 +10,7 @@ uniform float scale;
 
 void main() {
 
+	#include <common_vertex>
 	#include <color_vertex>
 	#include <begin_vertex>
 	#include <project_vertex>

--- a/src/renderers/shaders/ShaderLib/shadow_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/shadow_vert.glsl
@@ -2,6 +2,7 @@
 
 void main() {
 
+	#include <common_vertex>
 	#include <begin_vertex>
 	#include <project_vertex>
 	#include <worldpos_vertex>

--- a/src/renderers/webgl/WebGLBufferRenderer.js
+++ b/src/renderers/webgl/WebGLBufferRenderer.js
@@ -23,7 +23,7 @@ function WebGLBufferRenderer( gl, extensions, infoRender ) {
 
 	}
 
-	function renderInstances( geometry ) {
+	function renderInstances( geometry, instanceCount, start, vertexCount ) {
 
 		var extension = extensions.get( 'ANGLE_instanced_arrays' );
 
@@ -34,28 +34,12 @@ function WebGLBufferRenderer( gl, extensions, infoRender ) {
 
 		}
 
-		var position = geometry.attributes.position;
-
-		var count = 0;
-
-		if ( position.isInterleavedBufferAttribute ) {
-
-			count = position.data.count;
-
-			extension.drawArraysInstancedANGLE( mode, 0, count, geometry.maxInstancedCount );
-
-		} else {
-
-			count = position.count;
-
-			extension.drawArraysInstancedANGLE( mode, 0, count, geometry.maxInstancedCount );
-
-		}
+		extension.drawArraysInstancedANGLE( mode, start, vertexCount, instanceCount );
 
 		infoRender.calls ++;
-		infoRender.vertices += count * geometry.maxInstancedCount;
+		infoRender.vertices += vertexCount * instanceCount;
 
-		if ( mode === gl.TRIANGLES ) infoRender.faces += geometry.maxInstancedCount * count / 3;
+		if ( mode === gl.TRIANGLES ) infoRender.faces += instanceCount * vertexCount / 3;
 
 	}
 

--- a/src/renderers/webgl/WebGLIndexedBufferRenderer.js
+++ b/src/renderers/webgl/WebGLIndexedBufferRenderer.js
@@ -46,7 +46,7 @@ function WebGLIndexedBufferRenderer( gl, extensions, infoRender ) {
 
 	}
 
-	function renderInstances( geometry, start, count ) {
+	function renderInstances( geometry, instanceCount, start, vertexCount ) {
 
 		var extension = extensions.get( 'ANGLE_instanced_arrays' );
 
@@ -57,13 +57,12 @@ function WebGLIndexedBufferRenderer( gl, extensions, infoRender ) {
 
 		}
 
-		extension.drawElementsInstancedANGLE( mode, count, type, start * size, geometry.maxInstancedCount );
+		extension.drawElementsInstancedANGLE( mode, vertexCount, type, start * size, instanceCount );
 
 		infoRender.calls ++;
-		infoRender.vertices += count * geometry.maxInstancedCount;
+		infoRender.vertices += vertexCount * instanceCount;
 
-		if ( mode === gl.TRIANGLES ) infoRender.faces += geometry.maxInstancedCount * count / 3;
-
+		if ( mode === gl.TRIANGLES ) infoRender.faces += instanceCount * vertexCount / 3;
 	}
 
 	return {

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -12,7 +12,7 @@ function WebGLObjects( gl, properties, info ) {
 
 	//
 
-	function update( object ) {
+	function updateObject( object ) {
 
 		// TODO: Avoid updating twice (when using shadowMap). Maybe add frame counter.
 
@@ -251,7 +251,8 @@ function WebGLObjects( gl, properties, info ) {
 		getAttributeProperties: getAttributeProperties,
 		getWireframeAttribute: getWireframeAttribute,
 
-		update: update
+		updateAttribute: updateAttribute,
+		updateObject: updateObject
 
 	};
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -5,7 +5,7 @@
 import { WebGLUniforms } from './WebGLUniforms';
 import { WebGLShader } from './WebGLShader';
 import { ShaderChunk } from '../shaders/ShaderChunk';
-import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, EquirectangularRefractionMapping, CubeRefractionMapping, SphericalReflectionMapping, EquirectangularReflectionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, CineonToneMapping, Uncharted2ToneMapping, ReinhardToneMapping, LinearToneMapping, GammaEncoding, RGBDEncoding, RGBM16Encoding, RGBM7Encoding, RGBEEncoding, sRGBEncoding, LinearEncoding } from '../../constants';
+import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, EquirectangularRefractionMapping, CubeRefractionMapping, SphericalReflectionMapping, EquirectangularReflectionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, CineonToneMapping, Uncharted2ToneMapping, ReinhardToneMapping, LinearToneMapping, GammaEncoding, RGBDEncoding, RGBM16Encoding, RGBM7Encoding, RGBEEncoding, sRGBEncoding, LinearEncoding, AutoInstancingDisabled, AutoInstancingAttributes, AutoInstancingTexture } from '../../constants';
 
 var programIdCount = 0;
 
@@ -311,7 +311,7 @@ function WebGLProgram( renderer, code, material, parameters ) {
 
 		prefixVertex = [
 
-        
+
 			'precision ' + parameters.precision + ' float;',
 			'precision ' + parameters.precision + ' int;',
 
@@ -324,9 +324,14 @@ function WebGLProgram( renderer, code, material, parameters ) {
 			'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 			'#define MAX_BONES ' + parameters.maxBones,
+			'#define MAX_INSTANCES ' + parameters.maxInstances,
+
+			parameters.instancingMode != AutoInstancingDisabled ? '#define USE_INSTANCING' : '',
+			parameters.instancingMode == AutoInstancingTexture ? '#define USE_INSTANCING_TEXTURE' : '',
+			parameters.instancingMode == AutoInstancingAttributes ? '#define USE_INSTANCING_ATTRIBUTES' : '',
+
 			( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
 			( parameters.useFog && parameters.fogExp ) ? '#define FOG_EXP2' : '',
-
 
 			parameters.map ? '#define USE_MAP' : '',
 			parameters.envMap ? '#define USE_ENVMAP' : '',
@@ -363,11 +368,8 @@ function WebGLProgram( renderer, code, material, parameters ) {
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
 			parameters.logarithmicDepthBuffer && renderer.extensions.get( 'EXT_frag_depth' ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-			'uniform mat4 modelMatrix;',
-			'uniform mat4 modelViewMatrix;',
 			'uniform mat4 projectionMatrix;',
 			'uniform mat4 viewMatrix;',
-			'uniform mat3 normalMatrix;',
 			'uniform vec3 cameraPosition;',
 
 			'attribute vec3 position;',
@@ -411,6 +413,29 @@ function WebGLProgram( renderer, code, material, parameters ) {
 			'	attribute vec4 skinWeight;',
 
 			'#endif',
+
+			'#ifdef USE_INSTANCING',
+
+			'	#ifdef USE_INSTANCING_ATTRIBUTES',
+
+			'		attribute vec4 instanceWorld1;',
+			'		attribute vec4 instanceWorld2;',
+			'		attribute vec4 instanceWorld3;',
+			'		attribute vec4 instanceWorld4;',
+
+			'		attribute vec3 instanceNormal1;',
+			'		attribute vec3 instanceNormal2;',
+			'		attribute vec3 instanceNormal3;',
+
+			'	#else',
+
+			'		attribute float instanceIndex;',
+
+			'	#endif',
+
+			'#endif',
+
+			ShaderChunk[ 'model_matrix_pars_vertex' ],
 
 			'\n'
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -3,7 +3,7 @@
  */
 
 import { WebGLProgram } from './WebGLProgram';
-import { BackSide, DoubleSide, FlatShading, CubeUVRefractionMapping, CubeUVReflectionMapping, GammaEncoding, LinearEncoding } from '../../constants';
+import { BackSide, DoubleSide, FlatShading, CubeUVRefractionMapping, CubeUVReflectionMapping, GammaEncoding, LinearEncoding, AutoInstancingDisabled } from '../../constants';
 
 function WebGLPrograms( renderer, capabilities ) {
 
@@ -24,7 +24,7 @@ function WebGLPrograms( renderer, capabilities ) {
 	};
 
 	var parameterNames = [
-		"precision", "supportsVertexTextures", "map", "mapEncoding", "envMap", "envMapMode", "envMapEncoding",
+		"instancingMode", "precision", "supportsVertexTextures", "map", "mapEncoding", "envMap", "envMapMode", "envMapEncoding",
 		"lightMap", "aoMap", "emissiveMap", "emissiveMapEncoding", "bumpMap", "normalMap", "displacementMap", "specularMap",
 		"roughnessMap", "metalnessMap", "gradientMap",
 		"alphaMap", "combine", "vertexColors", "fog", "useFog", "fogExp",
@@ -112,7 +112,10 @@ function WebGLPrograms( renderer, capabilities ) {
 		// heuristics to create shader parameters according to lights in the scene
 		// (not to blow over maxLights budget)
 
-		var maxBones = allocateBones( object );
+		var instancing = Array.isArray( object );
+
+		var maxBones = instancing ? 0 : allocateBones( object );
+
 		var precision = renderer.getPrecision();
 
 		if ( material.precision !== null ) {
@@ -127,11 +130,39 @@ function WebGLPrograms( renderer, capabilities ) {
 
 		}
 
+		var shadowMapEnabled = false;
+
+		if ( renderer.shadowMap.enabled && lights.shadows.length > 0 ) {
+
+			if ( instancing ) {
+
+				for ( var i = 0, l = object.length; i < l; i++ ) {
+
+					if ( object[ i ].receiveShadow ) {
+
+						shadowMapEnabled = true;
+						break;
+
+					}
+
+				}
+
+			} else if ( object.receiveShadow ) {
+
+				shadowMapEnabled = true;
+
+			}
+
+		}
+
 		var currentRenderTarget = renderer.getCurrentRenderTarget();
 
 		var parameters = {
 
 			shaderID: shaderID,
+
+			instancingMode: instancing ? renderer.getAutoInstancingMode() : AutoInstancingDisabled,
+			maxInstances: renderer.getAutoInstancingMaxBatchSize(),
 
 			precision: precision,
 			supportsVertexTextures: capabilities.vertexTextures,
@@ -171,7 +202,7 @@ function WebGLPrograms( renderer, capabilities ) {
 
 			skinning: material.skinning,
 			maxBones: maxBones,
-			useVertexTexture: capabilities.floatVertexTextures && object && object.skeleton && object.skeleton.useVertexTexture,
+			useVertexTexture: capabilities.floatVertexTextures && object.skeleton && object.skeleton.useVertexTexture,
 
 			morphTargets: material.morphTargets,
 			morphNormals: material.morphNormals,
@@ -187,7 +218,7 @@ function WebGLPrograms( renderer, capabilities ) {
 			numClippingPlanes: nClipPlanes,
 			numClipIntersection: nClipIntersection,
 
-			shadowMapEnabled: renderer.shadowMap.enabled && object.receiveShadow && lights.shadows.length > 0,
+			shadowMapEnabled: shadowMapEnabled,
 			shadowMapType: renderer.shadowMap.type,
 
 			toneMapping: renderer.toneMapping,

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -272,7 +272,7 @@ function WebGLShadowMap( _renderer, _lights, _objects, capabilities ) {
 				for ( var j = 0, jl = _renderList.length; j < jl; j ++ ) {
 
 					var object = _renderList[ j ];
-					var geometry = _objects.update( object );
+					var geometry = _objects.updateObject( object );
 					var material = object.material;
 
 					if ( material && material.isMultiMaterial ) {

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -49,6 +49,7 @@
 
 import { CubeTexture } from '../../textures/CubeTexture';
 import { Texture } from '../../textures/Texture';
+import { _Math } from '../../math/Math';
 
 var emptyTexture = new Texture();
 var emptyCubeTexture = new CubeTexture();
@@ -109,7 +110,7 @@ function flatten( array, nBlocks, blockSize ) {
 
 // Texture unit allocation
 
-function allocTexUnits( renderer, n ) {
+function allocTexUnits( renderer, uuid, n ) {
 
 	var r = arrayCacheI32[ n ];
 
@@ -121,7 +122,7 @@ function allocTexUnits( renderer, n ) {
 	}
 
 	for ( var i = 0; i !== n; ++ i )
-		r[ i ] = renderer.allocTextureUnit();
+		r[ i ] = renderer.allocTextureUnit( uuid + n );
 
 	return r;
 
@@ -188,7 +189,7 @@ function setValue4fm( gl, v ) {
 
 function setValueT1( gl, v, renderer ) {
 
-	var unit = renderer.allocTextureUnit();
+	var unit = renderer.allocTextureUnit( this.uuid );
 	gl.uniform1i( this.addr, unit );
 	renderer.setTexture2D( v || emptyTexture, unit );
 
@@ -196,7 +197,7 @@ function setValueT1( gl, v, renderer ) {
 
 function setValueT6( gl, v, renderer ) {
 
-	var unit = renderer.allocTextureUnit();
+	var unit = renderer.allocTextureUnit( this.uuid );
 	gl.uniform1i( this.addr, unit );
 	renderer.setTextureCube( v || emptyCubeTexture, unit );
 
@@ -285,7 +286,7 @@ function setValueM4a( gl, v ) {
 function setValueT1a( gl, v, renderer ) {
 
 	var n = v.length,
-		units = allocTexUnits( renderer, n );
+		units = allocTexUnits( renderer, this.uuid, n );
 
 	gl.uniform1iv( this.addr, units );
 
@@ -300,7 +301,7 @@ function setValueT1a( gl, v, renderer ) {
 function setValueT6a( gl, v, renderer ) {
 
 	var n = v.length,
-		units = allocTexUnits( renderer, n );
+		units = allocTexUnits( renderer, this.uuid, n );
 
 	gl.uniform1iv( this.addr, units );
 
@@ -343,6 +344,7 @@ function getPureArraySetter( type ) {
 
 function SingleUniform( id, activeInfo, addr ) {
 
+	this.uuid = _Math.generateUUID();
 	this.id = id;
 	this.addr = addr;
 	this.setValue = getSingularSetter( activeInfo.type );
@@ -353,6 +355,7 @@ function SingleUniform( id, activeInfo, addr ) {
 
 function PureArrayUniform( id, activeInfo, addr ) {
 
+	this.uuid = _Math.generateUUID();
 	this.id = id;
 	this.addr = addr;
 	this.size = activeInfo.size;
@@ -364,6 +367,7 @@ function PureArrayUniform( id, activeInfo, addr ) {
 
 function StructuredUniform( id ) {
 
+	this.uuid = _Math.generateUUID();
 	this.id = id;
 
 	UniformContainer.call( this ); // mix-in

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -73,6 +73,7 @@ var arrayCacheI32 = [];
 
 function flatten( array, nBlocks, blockSize ) {
 
+	nBlocks = Math.min( nBlocks, array.length );
 	var firstElem = array[ 0 ];
 
 	if ( firstElem <= 0 || firstElem > 0 ) return array;


### PR DESCRIPTION
When I first started using three.js I read that it supported instancing. It wasn't until I'd been using it for a while that I realised that you were supposed to use `InstancedBufferGeometry` to enable instancing. However, the issue with that is that your instances aren't actually part of the normal scene work-flow, it's pretty complicated for most users.

This on the other hand is turned on by default. Geometry will be batched and submitted to the GPU in one go as long as a browser supports the necessary extensions. An "instancing texture" is used (world and normal matrices encoded) when floating point vertex-shader accessible textures are available. On systems that don't support this, then the number of available uniforms will be detected and the necessary matrices will be pushed as arrays.

I've tried to be careful not to break backwards compatibility. The only slight issue will be for those whom are using their own shaders. They'll want to add:

```
#include <common_vertex>
```

to the top their vertex shader `main` function. This has been done already for all built-in shaders.

**EDIT**: ... _unless they're using dynamic uniforms (object render callbacks), in which case the implementation will detect that and won't turn on instancing for that object, so the user will be unaffected._

Instancing is turned on by default for opaque objects, but off for transparent ones. This is because in-order to effectively batch geometry you don't want to worry about z-sorting. Batching can be enabled for transparent objects if desired.

Performance can be tweaked by increasing the instancing texture size (`setInstancingTextureSize( size )`. By default it's 64x64, which gives you batches of size 585. Bumping it to 128x128 will use ever so slightly more VRAM, but will allow for 2340 instances per batch.

The increased VRAM is pretty negligible, but pushing a larger texture can itself be less performant than a smaller one if most of your geometry only has a few instances. For this reason, there's `minInstancingBatchSize` which will cause geometry to be rendered without batching (no texture pushing) if there's less than `minInstancingBatchSize` instances viewable in a given frame.

These properties can be changed safely between rendering frames if desired.

Sensible defaults have been chosen.

Of course, instancing can be disabled altogether by setting `autoInstancing` to `false`.