### PR TITLE
glTF, loading interleaved buffers

### DIFF
--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -15,6 +15,8 @@ function InterleavedBuffer( array, stride ) {
 	this.dynamic = false;
 	this.updateRange = { offset: 0, count: - 1 };
 
+	this.onUploadCallback = function () {};
+
 	this.version = 0;
 
 }
@@ -91,6 +93,14 @@ InterleavedBuffer.prototype = {
 	clone: function () {
 
 		return new this.constructor().copy( this );
+
+	},
+
+	onUpload: function ( callback ) {
+
+		this.onUploadCallback = callback;
+
+		return this;
 
 	}
 


### PR DESCRIPTION
Fixes #10056. I had to duplicate `onUpload` from `BufferAttribute`. Maybe there is a better way. I tested triangle.gltf (from the issue) in the editor and it looks correct.