### PR TITLE
Add link from MMD examples to MMD assets license

### DIFF
--- a/examples/models/mmd/Readme.txt
+++ b/examples/models/mmd/Readme.txt
@@ -1,6 +1,6 @@
 The files under this directory are NOT under MIT license, but other licenses.
-If you want to use them in your work, get original data, read readme, and follow
-their licenses.
+If you want to use them in your work, get original archive file, read readme,
+and follow their licenses.
 
 
 1. Vocaloid stuffs
@@ -14,17 +14,17 @@ For detail, see http://piapro.net/en_for_creators.html
 
 2. MMD stuffs
 
-In MMD, there is no unified license. If you want to use MMD works (models,
-songs, dances, and so on), read readme included in archive file and follow the
-license the author set.
+In MMD, there is no unified license. If you want to use MMD assets (models,
+songs, dances, and so on), read readme included in the original archive file
+and follow the license the author set.
 
-If the works are fan works, you must follow the original work's license. (For
+If the assets are fan works, you must follow the original work's license. (For
 example, you also need to follow the license set by Crypton, not only the
-license the author set, to use a Miku MMD model)
+license the author set, to use a fan Miku MMD model)
 
-For your information, generally MMD works are very restricted to use.
+For your information, generally MMD assets are very restricted to use.
 
-Most MMD works are NOT allowed for
+Most MMD assets are NOT allowed for
 - redistribution
 - porn use
 - commercial use

--- a/examples/webgl_loader_mmd.html
+++ b/examples/webgl_loader_mmd.html
@@ -28,6 +28,7 @@
 	<body>
 		<div id="info">
 		<a href="http://threejs.org" target="_blank">three.js</a> - MMDLoader test<br />
+		<a href="https://github.com/mrdoob/three.js/tree/master/examples/models/mmd#readme">MMD Assets license</a><br />
 		Copyright
 		<a href="http://www.geocities.jp/higuchuu4/index_e.htm" target="_blank">Model Data</a>
 		<a href="http://www.nicovideo.jp/watch/sm13147122" target="_blank">Dance Data</a>

--- a/examples/webgl_loader_mmd_audio.html
+++ b/examples/webgl_loader_mmd_audio.html
@@ -28,6 +28,7 @@
 	<body>
 		<div id="info">
 		<a href="http://threejs.org" target="_blank">three.js</a> - MMDLoader test<br />
+		<a href="https://github.com/mrdoob/three.js/tree/master/examples/models/mmd#readme">MMD Assets license</a><br />
 		Copyright
 		<a href="http://www.geocities.jp/higuchuu4/index_e.htm" target="_blank">Model Data</a>
 		<a href="http://www.nicovideo.jp/watch/sm13147122" target="_blank">Dance Data</a>

--- a/examples/webgl_loader_mmd_pose.html
+++ b/examples/webgl_loader_mmd_pose.html
@@ -28,6 +28,7 @@
 	<body>
 		<div id="info">
 		<a href="http://threejs.org" target="_blank">three.js</a> - MMDLoader test<br />
+		<a href="https://github.com/mrdoob/three.js/tree/master/examples/models/mmd#readme">MMD Assets license</a><br />
 		Copyright
 		<a href="http://www.geocities.jp/higuchuu4/index_e.htm" target="_blank">Model Data</a>
 		<a href="http://seiga.nicovideo.jp/seiga/im5162984" target="_blank">Pose Data</a>


### PR DESCRIPTION
Let me add link from MMD examples to MMD assets license.
And I've updated MMD assets readme a bit.