### PR TITLE
Add MrDoob Code Style ESLint support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "mdcs",
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar utils/build/compiler/closure-compiler-v20160713.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
     "dev": "rollup -c -w",
+    "lint": "eslint src",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
@@ -42,6 +43,8 @@
   },
   "homepage": "http://threejs.org/",
   "devDependencies": {
+    "eslint": "^3.10.1",
+    "eslint-config-mdcs": "^4.2.1",
     "rollup": "^0.36.3",
     "rollup-watch": "^2.5.0",
     "uglify-js": "^2.6.0"


### PR DESCRIPTION
Support Mr.doob's Code Style™ linting and autofixing.

## How to use

```sh
# make sure dependencies are updated
npm install

# Complains about code style errors in src
npm run lint 

# Do autofix (Use with care!)
node_modules/eslint/bin/eslint.js --fix src/[path to file]
```

Alternatively, eslint is compatible with many editors

![image](https://cloud.githubusercontent.com/assets/314997/20317059/7a143f7c-ab9f-11e6-8d9b-b9f52cef66ee.png)

Relates:

- https://github.com/zz85/mrdoobapproves/issues/61
- https://github.com/mrdoob/three.js/pull/6007
- https://github.com/mrdoob/three.js/issues/4802
- https://github.com/mrdoob/three.js/pull/8805
