### PR TITLE
Add MDCS eslintConfig to package.json and remove .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "mdcs",
-  "parserOptions": {
-    "sourceType": "module"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "example": "examples",
     "test": "test"
   },
+  "eslintConfig": {
+    "extends": "mdcs"
+  },
   "scripts": {
     "build": "rollup -c",
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
@@ -44,7 +47,7 @@
   "homepage": "http://threejs.org/",
   "devDependencies": {
     "eslint": "^3.10.1",
-    "eslint-config-mdcs": "^4.2.1",
+    "eslint-config-mdcs": "^4.2.2",
     "rollup": "^0.36.3",
     "rollup-watch": "^2.5.0",
     "uglify-js": "^2.6.0"


### PR DESCRIPTION
I think mrdoob typically doesn't like additional files (though it's sometimes nice to see an .eslintrc file so people know that there's an eslint rule for the project)

https://github.com/mrdoob/three.js/pull/10129#issuecomment-260758195