### PR TITLE
Changed 'step' to 'divs'

### DIFF
--- a/docs/api/extras/helpers/GridHelper.html
+++ b/docs/api/extras/helpers/GridHelper.html
@@ -18,9 +18,9 @@
 		<h2>Example</h2>
 
 		<code>var size = 10;
-		var divs = 1;
+		var divisions = 10;
 
-		var gridHelper = new THREE.GridHelper( size, divs );
+		var gridHelper = new THREE.GridHelper( size, divisions );
 		scene.add( gridHelper );
 		</code>
 		[example:webgl_helpers Example using various helpers]
@@ -28,15 +28,15 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:number size], [page:Number divs], [page:Color colorCenterLine], [page:Color colorGrid] )</h3>
+		<h3>[name]( [page:number size], [page:Number divisions], [page:Color colorCenterLine], [page:Color colorGrid] )</h3>
 		<div>
 		size -- The size of the grid <br />
-		divs -- The number of divisions across the grid <br />
+		divisions -- The number of divisions across the grid <br />
 		colorCenterLine -- The color of the centerline. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x444444 <br />
 		colorGrid -- The color of the lines of the grid. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x888888
 		</div>
 		<div>
-		Creates a new [name] of size 'size' and divided into 'divs' segments per side. Colors are optional.
+		Creates a new [name] of size 'size' and divided into 'divisions' segments per side. Colors are optional.
 		</div>
 
 		<h2>Source</h2>

--- a/docs/api/extras/helpers/GridHelper.html
+++ b/docs/api/extras/helpers/GridHelper.html
@@ -18,9 +18,9 @@
 		<h2>Example</h2>
 
 		<code>var size = 10;
-		var step = 1;
+		var divs = 1;
 
-		var gridHelper = new THREE.GridHelper( size, step );
+		var gridHelper = new THREE.GridHelper( size, divs );
 		scene.add( gridHelper );
 		</code>
 		[example:webgl_helpers Example using various helpers]
@@ -28,15 +28,15 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:number size], [page:Number step], [page:Color colorCenterLine], [page:Color colorGrid] )</h3>
+		<h3>[name]( [page:number size], [page:Number divs], [page:Color colorCenterLine], [page:Color colorGrid] )</h3>
 		<div>
 		size -- The size of the grid <br />
-		step -- The size of the step between 2 lines <br />
+		divs -- The number of divisions across the grid <br />
 		colorCenterLine -- The color of the centerline. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x444444 <br />
 		colorGrid -- The color of the lines of the grid. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x888888
 		</div>
 		<div>
-		Creates a new [name] of size 'size' and with steps of size 'step'. Colors are optional.
+		Creates a new [name] of size 'size' and divided into 'divs' segments per side. Colors are optional.
 		</div>
 
 		<h2>Source</h2>


### PR DESCRIPTION
Documents incorrectly stated that grids were divided into a number of segments each equaling size "step". Actual behavior was that the value given for 'step' was actually the number of segments the grid gets divided into (e.g. 10 would be 10 segments on a side drawn with 11 total lines, regardless of overall grid size).

Fixes #9613