### PR TITLE
Remove z-index of #info style from MMD examples

### DIFF
--- a/examples/webgl_loader_mmd.html
+++ b/examples/webgl_loader_mmd.html
@@ -18,7 +18,6 @@
 				top: 10px;
 				width: 100%;
 				text-align: center;
-				z-index: 100;
 				display:block;
 			}
 			#info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }

--- a/examples/webgl_loader_mmd_audio.html
+++ b/examples/webgl_loader_mmd_audio.html
@@ -18,7 +18,6 @@
 				top: 10px;
 				width: 100%;
 				text-align: center;
-				z-index: 100;
 				display:block;
 			}
 			#info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }

--- a/examples/webgl_loader_mmd_pose.html
+++ b/examples/webgl_loader_mmd_pose.html
@@ -18,7 +18,6 @@
 				top: 10px;
 				width: 100%;
 				text-align: center;
-				z-index: 100;
 				display:block;
 			}
 			#info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }


### PR DESCRIPTION
Let me remove `z-index` of #info style in MMD examples.
Sometimes dat.gui can't be controlled because they hide it.