### PR TITLE
Add clearDepth attribute to RenderPass

### DIFF
--- a/examples/js/postprocessing/RenderPass.js
+++ b/examples/js/postprocessing/RenderPass.js
@@ -15,6 +15,7 @@ THREE.RenderPass = function ( scene, camera, overrideMaterial, clearColor, clear
 	this.clearAlpha = ( clearAlpha !== undefined ) ? clearAlpha : 0;
 
 	this.clear = true;
+	this.clearDepth = false;
 	this.needsSwap = false;
 
 };
@@ -38,6 +39,12 @@ THREE.RenderPass.prototype = Object.assign( Object.create( THREE.Pass.prototype 
 			oldClearAlpha = renderer.getClearAlpha();
 
 			renderer.setClearColor( this.clearColor, this.clearAlpha );
+
+		}
+
+		if ( this.clearDepth ) {
+
+			renderer.clearDepth();
 
 		}
 


### PR DESCRIPTION
This makes it possible to clear the depth buffer before a RenderPass, which is useful when trying to render overlays using a second scene. I was struggling with this limitation myself when I came across an unanswered Stack Overflow question with the exact same issue: http://stackoverflow.com/questions/40548144/multiple-scenes-rendering-using-three-renderpass

This solution works for our use case, and seems like it would be useful for at least *one* other person, so I figured I'd open a PR. It's very likely that there's some way to solve this using the WebGLRenderer options as is, but I haven't found it yet.