### PR TITLE
Add support for SkinnedMesh and Bone object types to ObjectLoader

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -605,6 +605,21 @@ Object.assign( ObjectLoader.prototype, {
 
 					break;
 
+				case 'SkinnedMesh':
+
+					var geometry = getGeometry( data.geometry );
+					var material = getMaterial( data.material );
+
+					object = new SkinnedMesh( geometry, material );
+
+					break;
+
+				case 'Bone':
+
+					object = new Bone();
+
+					break;
+
 				case 'LOD':
 
 					object = new LOD();


### PR DESCRIPTION
Currently when you call object.toJSON() on an object with Bones and a SkinnedMesh, when you load that with ObjectLoader you just get a big heirarchy of Object3Ds.  This patch makes ObjectLoader aware of those two types, so they're recreated correctly.