### PR TITLE
Fix damage from removal of UniformsUtils.*

### DIFF
--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -27,7 +27,7 @@ THREE.BloomPass = function ( strength, kernelSize, sigma, resolution ) {
 
 	this.copyUniforms = Object.assign( {}, copyShader.uniforms );
 
-	this.copyUniforms[ "opacity" ].value = strength;
+	this.copyUniforms[ "opacity" ] = { value: strength };
 
 	this.materialCopy = new THREE.ShaderMaterial( {
 
@@ -48,8 +48,8 @@ THREE.BloomPass = function ( strength, kernelSize, sigma, resolution ) {
 
 	this.convolutionUniforms = Object.assign( {}, convolutionShader.uniforms );
 
-	this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurX;
-	this.convolutionUniforms[ "cKernel" ].value = THREE.ConvolutionShader.buildKernel( sigma );
+	this.convolutionUniforms[ "uImageIncrement" ] = { value: THREE.BloomPass.blurX };
+	this.convolutionUniforms[ "cKernel" ] = { value: THREE.ConvolutionShader.buildKernel( sigma ) };
 
 	this.materialConvolution = new THREE.ShaderMaterial( {
 
@@ -85,16 +85,16 @@ THREE.BloomPass.prototype = Object.assign( Object.create( THREE.Pass.prototype )
 
 		this.quad.material = this.materialConvolution;
 
-		this.convolutionUniforms[ "tDiffuse" ].value = readBuffer.texture;
-		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurX;
+		this.convolutionUniforms[ "tDiffuse" ] = { value: readBuffer.texture };
+		this.convolutionUniforms[ "uImageIncrement" ] = { value: THREE.BloomPass.blurX };
 
 		renderer.render( this.scene, this.camera, this.renderTargetX, true );
 
 
 		// Render quad with blured scene into texture (convolution pass 2)
 
-		this.convolutionUniforms[ "tDiffuse" ].value = this.renderTargetX.texture;
-		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurY;
+		this.convolutionUniforms[ "tDiffuse" ] = { value: this.renderTargetX.texture };
+		this.convolutionUniforms[ "uImageIncrement" ] = { value: THREE.BloomPass.blurY };
 
 		renderer.render( this.scene, this.camera, this.renderTargetY, true );
 
@@ -102,7 +102,7 @@ THREE.BloomPass.prototype = Object.assign( Object.create( THREE.Pass.prototype )
 
 		this.quad.material = this.materialCopy;
 
-		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetY.texture;
+		this.copyUniforms[ "tDiffuse" ] = { value: this.renderTargetY.texture };
 
 		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
 

--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -27,7 +27,7 @@ THREE.BloomPass = function ( strength, kernelSize, sigma, resolution ) {
 
 	this.copyUniforms = Object.assign( {}, copyShader.uniforms );
 
-	this.copyUniforms[ "opacity" ] = { value: strength };
+	this.copyUniforms[ "opacity" ] = new THREE.Uniform( strength );
 
 	this.materialCopy = new THREE.ShaderMaterial( {
 
@@ -48,8 +48,8 @@ THREE.BloomPass = function ( strength, kernelSize, sigma, resolution ) {
 
 	this.convolutionUniforms = Object.assign( {}, convolutionShader.uniforms );
 
-	this.convolutionUniforms[ "uImageIncrement" ] = { value: THREE.BloomPass.blurX };
-	this.convolutionUniforms[ "cKernel" ] = { value: THREE.ConvolutionShader.buildKernel( sigma ) };
+	this.convolutionUniforms[ "uImageIncrement" ] = new THREE.Uniform( THREE.BloomPass.blurX );
+	this.convolutionUniforms[ "cKernel" ] = new THREE.Uniform( THREE.ConvolutionShader.buildKernel( sigma ) );
 
 	this.materialConvolution = new THREE.ShaderMaterial( {
 
@@ -85,16 +85,16 @@ THREE.BloomPass.prototype = Object.assign( Object.create( THREE.Pass.prototype )
 
 		this.quad.material = this.materialConvolution;
 
-		this.convolutionUniforms[ "tDiffuse" ] = { value: readBuffer.texture };
-		this.convolutionUniforms[ "uImageIncrement" ] = { value: THREE.BloomPass.blurX };
+		this.convolutionUniforms[ "tDiffuse" ] = new THREE.Uniform( readBuffer.texture );
+		this.convolutionUniforms[ "uImageIncrement" ] = new THREE.Uniform( THREE.BloomPass.blurX );
 
 		renderer.render( this.scene, this.camera, this.renderTargetX, true );
 
 
 		// Render quad with blured scene into texture (convolution pass 2)
 
-		this.convolutionUniforms[ "tDiffuse" ] = { value: this.renderTargetX.texture };
-		this.convolutionUniforms[ "uImageIncrement" ] = { value: THREE.BloomPass.blurY };
+		this.convolutionUniforms[ "tDiffuse" ] = new THREE.Uniform( this.renderTargetX.texture );
+		this.convolutionUniforms[ "uImageIncrement" ] = new THREE.Uniform( THREE.BloomPass.blurY );
 
 		renderer.render( this.scene, this.camera, this.renderTargetY, true );
 
@@ -102,7 +102,7 @@ THREE.BloomPass.prototype = Object.assign( Object.create( THREE.Pass.prototype )
 
 		this.quad.material = this.materialCopy;
 
-		this.copyUniforms[ "tDiffuse" ] = { value: this.renderTargetY.texture };
+		this.copyUniforms[ "tDiffuse" ] = new THREE.Uniform( this.renderTargetY.texture );
 
 		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
 

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -45,7 +45,7 @@ THREE.ShaderPass.prototype = Object.assign( Object.create( THREE.Pass.prototype 
 
 		if ( this.uniforms[ this.textureID ] ) {
 
-			this.uniforms[ this.textureID ].value = readBuffer.texture;
+			this.uniforms[ this.textureID ] = { value: readBuffer.texture };
 
 		}
 

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -45,7 +45,7 @@ THREE.ShaderPass.prototype = Object.assign( Object.create( THREE.Pass.prototype 
 
 		if ( this.uniforms[ this.textureID ] ) {
 
-			this.uniforms[ this.textureID ] = { value: readBuffer.texture };
+			this.uniforms[ this.textureID ] = new THREE.Uniform( readBuffer.texture );
 
 		}
 

--- a/examples/js/postprocessing/TexturePass.js
+++ b/examples/js/postprocessing/TexturePass.js
@@ -47,8 +47,8 @@ THREE.TexturePass.prototype = Object.assign( Object.create( THREE.Pass.prototype
 
 		this.quad.material = this.material;
 
-		this.uniforms[ "opacity" ].value = this.opacity;
-		this.uniforms[ "tDiffuse" ].value = this.map;
+		this.uniforms[ "opacity" ] = { value: this.opacity };
+		this.uniforms[ "tDiffuse" ] = { value: this.map };
 		this.material.transparent = ( this.opacity < 1.0 );
 
 		renderer.render( this.scene, this.camera, this.renderToScreen ? null : readBuffer, this.clear );

--- a/examples/js/postprocessing/TexturePass.js
+++ b/examples/js/postprocessing/TexturePass.js
@@ -47,8 +47,8 @@ THREE.TexturePass.prototype = Object.assign( Object.create( THREE.Pass.prototype
 
 		this.quad.material = this.material;
 
-		this.uniforms[ "opacity" ] = { value: this.opacity };
-		this.uniforms[ "tDiffuse" ] = { value: this.map };
+		this.uniforms[ "opacity" ] = new THREE.Uniform( this.opacity );
+		this.uniforms[ "tDiffuse" ] = new THREE.Uniform( this.map );
 		this.material.transparent = ( this.opacity < 1.0 );
 
 		renderer.render( this.scene, this.camera, this.renderToScreen ? null : readBuffer, this.clear );

--- a/examples/webgl_materials_skin.html
+++ b/examples/webgl_materials_skin.html
@@ -134,10 +134,9 @@
 
 
 				var uniforms = Object.assign( {}, uniformsUV );
-				uniforms[ "tDiffuse" ] = { value: uniformsUV[ "tDiffuse" ].value };
-				uniforms[ "tNormal" ] = { value: uniformsUV[ "tNormal" ].value };
-				uniforms[ "passID" ] = { value: 1 };
-
+				uniforms[ "tDiffuse" ] = new THREE.Uniform( uniformsUV[ "tDiffuse" ].value );
+				uniforms[ "tNormal" ] = new THREE.Uniform( uniformsUV[ "tNormal" ].value );
+				uniforms[ "passID" ] = new THREE.Uniform( 1 );
 
 				var parameters = { fragmentShader: shader.fragmentShader, vertexShader: shader.vertexShader, uniforms: uniforms, lights: true };
 				var parametersUV = { fragmentShader: shader.fragmentShader, vertexShader: shader.vertexShaderUV, uniforms: uniformsUV, lights: true };
@@ -236,12 +235,12 @@
 
 				//
 
-				uniforms[ "tBlur1" ] = { value: composerScene.renderTarget2.texture };
-				uniforms[ "tBlur2" ] = { value: composerUV1.renderTarget2.texture };
-				uniforms[ "tBlur3" ] = { value: composerUV2.renderTarget2.texture };
-				uniforms[ "tBlur4" ] = { value: composerUV3.renderTarget2.texture };
+				uniforms[ "tBlur1" ] = new THREE.Uniform( composerScene.renderTarget2.texture );
+				uniforms[ "tBlur2" ] = new THREE.Uniform( composerUV1.renderTarget2.texture );
+				uniforms[ "tBlur3" ] = new THREE.Uniform( composerUV2.renderTarget2.texture );
+				uniforms[ "tBlur4" ] = new THREE.Uniform( composerUV3.renderTarget2.texture );
 
-				uniforms[ "tBeckmann" ] = { value: composerBeckmann.renderTarget1.texture };
+				uniforms[ "tBeckmann" ] = new THREE.Uniform( composerBeckmann.renderTarget1.texture );
 
 				//
 

--- a/examples/webgl_materials_skin.html
+++ b/examples/webgl_materials_skin.html
@@ -134,9 +134,9 @@
 
 
 				var uniforms = Object.assign( {}, uniformsUV );
-				uniforms[ "tDiffuse" ].value = uniformsUV[ "tDiffuse" ].value;
-				uniforms[ "tNormal" ].value = uniformsUV[ "tNormal" ].value;
-				uniforms[ "passID" ].value = 1;
+				uniforms[ "tDiffuse" ] = { value: uniformsUV[ "tDiffuse" ].value };
+				uniforms[ "tNormal" ] = { value: uniformsUV[ "tNormal" ].value };
+				uniforms[ "passID" ] = { value: 1 };
 
 
 				var parameters = { fragmentShader: shader.fragmentShader, vertexShader: shader.vertexShader, uniforms: uniforms, lights: true };
@@ -236,12 +236,12 @@
 
 				//
 
-				uniforms[ "tBlur1" ].value = composerScene.renderTarget2.texture;
-				uniforms[ "tBlur2" ].value = composerUV1.renderTarget2.texture;
-				uniforms[ "tBlur3" ].value = composerUV2.renderTarget2.texture;
-				uniforms[ "tBlur4" ].value = composerUV3.renderTarget2.texture;
+				uniforms[ "tBlur1" ] = { value: composerScene.renderTarget2.texture };
+				uniforms[ "tBlur2" ] = { value: composerUV1.renderTarget2.texture };
+				uniforms[ "tBlur3" ] = { value: composerUV2.renderTarget2.texture };
+				uniforms[ "tBlur4" ] = { value: composerUV3.renderTarget2.texture };
 
-				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1.texture;
+				uniforms[ "tBeckmann" ] = { value: composerBeckmann.renderTarget1.texture };
 
 				//
 


### PR DESCRIPTION
fix damage from lack of deep copy of Object.assign().

Specifically the damage to materials / skin example with multiple passes sharing textures that they shouldn't etc. I missed this on first run through.

Is it planned to get rid of the:

`uniform = { value: <value> };`

 format eventually and just have 

`uniform = value;`

as was discussed when the "type" specifier was removed?