### PR TITLE
ImageLoader crossOrigin support

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -35,6 +35,11 @@ Object.assign( ImageLoader.prototype, {
 
 			image.src = url;
 
+		} else if ( this.crossOrigin !== undefined ) {
+
+			image.crossOrigin = this.crossOrigin;
+			image.src = url;
+
 		} else {
 
 			var loader = new FileLoader();


### PR DESCRIPTION
This PR enables `ImageLoader` support `crossOrigin`.
See #10099
