### PR TITLE
Add crossOrigin support for textuer image in MMDLoader

### DIFF
--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -42,6 +42,7 @@ THREE.MMDLoader = function ( manager ) {
 	THREE.Loader.call( this );
 	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
 	this.parser = new MMDParser.Parser();
+	this.textureCrossOrigin = null;
 
 };
 
@@ -67,6 +68,17 @@ THREE.MMDLoader.prototype.defaultToonTextures = [
 	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=',
 	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII='
 ];
+
+/*
+ * Set 'anonymous' for the the texture image file in other domain
+ * even if server responds with "Access-Control-Allow-Origin: *"
+ * because some image operation fails in MMDLoader.
+ */
+THREE.MMDLoader.prototype.setTextureCrossOrigin = function ( value ) {
+
+	this.textureCrossOrigin = value;
+
+};
 
 THREE.MMDLoader.prototype.load = function ( modelUrl, vmdUrls, callback, onProgress, onError ) {
 
@@ -862,6 +874,8 @@ THREE.MMDLoader.prototype.createMesh = function ( model, texturePath, onProgress
 		var tgaLoader = new THREE.TGALoader( scope.manager );
 		var offset = 0;
 		var materialParams = [];
+
+		if ( scope.textureCrossOrigin !== null ) textureLoader.setCrossOrigin( scope.textureCrossOrigin );
 
 		function loadTexture ( filePath, params ) {
 


### PR DESCRIPTION
This PR enables crossOrigin setting for texture image in `MMDLoader`.