### PR TITLE
add support for Lightimport in VRML (to DEV)

### DIFF
--- a/examples/js/loaders/VRMLLoader.js
+++ b/examples/js/loaders/VRMLLoader.js
@@ -415,7 +415,9 @@ THREE.VRMLLoader.prototype = {
 							};
 
 							break;
-
+							
++						case 'location':
++						case 'direction':
 						case 'translation':
 						case 'scale':
 						case 'size':
@@ -434,6 +436,8 @@ THREE.VRMLLoader.prototype = {
 
 							break;
 
+						case 'intensity':				
+						case 'cutOffAngle':
 						case 'radius':
 						case 'topRadius':
 						case 'bottomRadius':
@@ -468,7 +472,8 @@ THREE.VRMLLoader.prototype = {
 							};
 
 							break;
-
+							
+						case 'on':
 						case 'ccw':
 						case 'solid':
 						case 'colorPerVertex':
@@ -623,6 +628,85 @@ THREE.VRMLLoader.prototype = {
 
 				var object = parent;
 
+				if(data.string.indexOf("AmbientLight")>-1 && data.nodeType=='PointLight'){
+					//wenn im Namen "AmbientLight" vorkommt und es ein PointLight ist, 
+					//diesen Typ in 'AmbientLight' ändern
+					data.nodeType='AmbientLight';	
+				}
+				
+				l_visible=data.on;
+				if(l_visible==undefined)l_visible=true;
+				l_intensity=data.intensity;
+				if(l_intensity==undefined)l_intensity=true;
+				if(data.color!=undefined)
+					l_color= new THREE.Color(data.color.r, data.color.g,data.color.b );
+					else
+					l_color= new THREE.Color(0, 0,0);
+				
+				
+				
+				if('AmbientLight' === data.nodeType){
+					object=new THREE.AmbientLight( 
+								l_color.getHex(), 
+								l_intensity
+								);
+					object.visible=l_visible;
+					
+					parent.add( object );
+					
+				}
+				else
+				if('PointLight' === data.nodeType){
+						l_distance =0;	//0="unendlich" ...1000
+						l_decay=0;		//-1.. ?
+						
+						if(data.radius!=undefined && data.radius<1000){
+							//l_radius=data.radius;
+							l_distance=data.radius;
+							l_decay=1;
+						}
+						object=new THREE.PointLight( 
+								l_color.getHex(), 
+								l_intensity, 
+								l_distance);
+						object.visible=l_visible;
+						
+						parent.add( object );
+				}
+				else
+				if('SpotLight' === data.nodeType){						
+						l_intensity=1;
+						l_distance =0;//0="unendlich"=1000
+						l_angle=Math.PI/3;
+						l_penumbra=0.0;//0..1
+						l_decay=0;//-1.. ?
+						l_visible=true;
+						
+						if(data.radius!=undefined && data.radius<1000){
+							//l_radius=data.radius;
+							l_distance=data.radius;
+							l_decay=1;
+						}
+						if(data.cutOffAngle!=undefined)l_angle=data.cutOffAngle;
+						
+						object = new THREE.SpotLight(
+									l_color.getHex(),
+									l_intensity,
+									l_distance,
+									l_angle,
+									l_penumbra,
+									l_decay
+									);
+						object.visible=l_visible;						
+						parent.add( object );
+						/*
+						var lightHelper = new THREE.SpotLightHelper( object );
+						parent.parent.add( lightHelper );
+						lightHelper.update();
+						*/
+				}
+				else				
+				
 				if ( 'Transform' === data.nodeType || 'Group' === data.nodeType ) {
 
 					object = new THREE.Object3D();


### PR DESCRIPTION
for import PointLight and SpotLight. An AmbientLight is emitted when in the name "AmbientLight" occurs.
exampel: vrml-Code:

```
DEF Licht_AmbientLight Transform {
  translation 0 4.274257 0
  children [ 
    DEF LIGHT_Licht_AmbientLight PointLight {
      location 0 0 0
      radius 100000000
      color 0.34902 0.34902 1
      intensity 0.23
      on TRUE
    }
  ]
}

DEF Licht_1spot Transform {
  translation -56.342838 57.6591 -58.975361
  rotation -0.244504 0.769274 0.590284 -0.987861
  children [ 
    DEF LIGHT_Licht_1spot SpotLight {
      location 0 0 0
      direction 1 0 0
      cutOffAngle 0.587197
      radius 100000000
      color 0.47451 0.823529 1
      intensity 1
      on TRUE
    }
  ]
}

DEF Licht Transform {
  translation -49.414658 88.717239 51.611542
  children [ 
    DEF LIGHT_Licht PointLight {
      location 0 0 0
      radius 100000000
      color 1 0.807843 0.560784
      intensity 1
      on TRUE
    }
  ]
}
```