### PR TITLE
HemisphereLightHelper: Refactoring

### DIFF
--- a/docs/api/extras/helpers/HemisphereLightHelper.html
+++ b/docs/api/extras/helpers/HemisphereLightHelper.html
@@ -32,7 +32,7 @@ scene.add( helper );
 		<h3>[name]([page:HemisphereLight light], [page:Number sphereSize])</h3>
 		<div>
 		[page:HemisphereLight light] -- The light being visualized. <br />
-		[page:Number sphereSize] -- The size of the sphere used to visualize te light.
+		[page:Number size] -- The size of the mesh used to visualize the light.
 		</div>
 
 
@@ -41,9 +41,6 @@ scene.add( helper );
 
 		<h3>[property:HemisphereLight light]</h3>
 		<div>Reference to the HemisphereLight being visualized.</div>
-
-		<h3>[property:Mesh lightSphere]</h3>
-		<div>The sphere mesh that shows the location of the hemispherelight.</div>
 
 		<h3>[property:object matrix]</h3>
 		<div>Reference to the hemisphereLight's [page:Object3D.matrixWorld matrixWorld].</div>


### PR DESCRIPTION
- usage of `OctahedronBufferGeometry` instead of `SphereGeometry`
- renamed `sphereSize` to `size`
- removed `lightSphere` from public interface

I hope nobody loses a foot with this PR! :wink:

Besides, if this PR gets merged, all helpers are based on `BufferGeometry` (yay:tada:). 