### PR TITLE
remove  suspected typos in VRML loader

### DIFF
--- a/examples/js/loaders/VRMLLoader.js
+++ b/examples/js/loaders/VRMLLoader.js
@@ -416,8 +416,8 @@ THREE.VRMLLoader.prototype = {
 
 							break;
 							
-+						case 'location':
-+						case 'direction':
+						case 'location':
+						case 'direction':
 						case 'translation':
 						case 'scale':
 						case 'size':


### PR DESCRIPTION
I'm assuming these were typos/faulty diff in #10177, that stop the VRML loader example working.