### PR TITLE
Added logarithmic depth buffer support to SSAO postprocessing shader

### DIFF
--- a/examples/js/shaders/SSAOShader.js
+++ b/examples/js/shaders/SSAOShader.js
@@ -44,6 +44,9 @@ THREE.SSAOShader = {
 
 		"uniform float cameraNear;",
 		"uniform float cameraFar;",
+		"#ifdef USE_LOGDEPTHBUF",
+			"uniform float logDepthBufFC;",
+		"#endif",
 
 		"uniform bool onlyAO;",      // use only ambient occlusion pass?
 
@@ -109,8 +112,19 @@ THREE.SSAOShader = {
 			"float cameraFarMinusNear = cameraFar - cameraNear;",
 			"float cameraCoef = 2.0 * cameraNear;",
 
-			// "return ( 2.0 * cameraNear ) / ( cameraFar + cameraNear - unpackDepth( texture2D( tDepth, coord ) ) * ( cameraFar - cameraNear ) );",
-			"return cameraCoef / ( cameraFarPlusNear - unpackRGBAToDepth( texture2D( tDepth, coord ) ) * cameraFarMinusNear );",
+			"#ifdef USE_LOGDEPTHBUF",
+
+				"float logz = unpackRGBAToDepth( texture2D( tDepth, coord ) );",
+				"float w = pow(2.0, (logz / logDepthBufFC)) - 1.0;",
+				"float z = (logz / w) + 1.0;",
+
+			"#else",
+
+				"float z = unpackRGBAToDepth( texture2D( tDepth, coord ) );",
+
+			"#endif",
+
+			"return cameraCoef / ( cameraFarPlusNear - z * cameraFarMinusNear );",
 
 
 		"}",


### PR DESCRIPTION
This adds some code which reverses the z-buffer transformation that the logarithmic depth buffer feature performs in the vertex shader.  Note that logarithmic depth buffer trades off z-buffer accuracy for z-buffer range, so the transformed values have lost a lot of precision, leading to lower quality SSAO when compared with the regular, linear z-buffer.

@alteredq would you mind taking a look at this to see if there's anything I'm doing obviously wrong which would be making this look worse than it should?  

Here's a side-by-side shot of ```examples/webgl_postprocessing_ssao.html``` with logarithmicDepthBuffer set to true on the left:
![image](https://cloud.githubusercontent.com/assets/251610/20587982/6919a810-b1c6-11e6-8119-b769e7a8069a.png)
