### PR TITLE
Added lookAt to DirectionalLight (for discussion)

### DIFF
--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -16,7 +16,14 @@ function DirectionalLight( color, intensity ) {
 	this.position.copy( Object3D.DefaultUp );
 	this.updateMatrix();
 
-	this.target = new Object3D();
+	//If lookAt is called after the target has been set to a different
+	//object in the scene, it will be reset to this internal target.
+	//This will prevent accidentally making changes to another object's position
+	var internalTarget = new Object3D();
+	internalTarget.name = this.uuid + '_target';
+	Object.defineProperty( this, 'internalTarget', { value: internalTarget } );
+
+	this.target = this.internalTarget;
 
 	this.shadow = new DirectionalLightShadow();
 
@@ -37,6 +44,33 @@ DirectionalLight.prototype = Object.assign( Object.create( Light.prototype ), {
 		this.shadow = source.shadow.clone();
 
 		return this;
+
+	},
+
+	lookAt( point ) {
+
+		//reset the target if it has been changed
+		if ( this.target.name !== this.uuid + '_target' ) {
+
+			this.target = this.internalTarget;
+
+		}
+
+		if ( point.isVector3 ) {
+
+			this.target.position.copy( point );
+			this.target.updateMatrixWorld();
+
+		}	else if ( point.isObject3D ) {
+
+			this.target.position.copy( point.position );
+			this.target.updateMatrixWorld();
+
+		}	else {
+
+			console.error( 'DirectionalLight.lookAt: the argument must be a Vector3 or Object3D' );
+
+		}
 
 	}
 


### PR DESCRIPTION
 #10220, #5555

Basic idea for a lookAt function for DirectionalLight - I've done some minor testing and it seems to work as expected. 

The current ability to assign another scene object to the target shouldn't be affected, and if lookAt is called after doing so, it will just reset the target back to the original (internal) target. 

It can take a Vector3 or Object3D and copies the position into the target, then updates the target's matrixWorld. 

Of course this overwrites the inherited Object3D.lookAt, but that function doesn't work for a directional light anyway as the rotation of the light has no effect on where it shines. 