### PR TITLE
Improved documentation for materials

### DIFF
--- a/docs/api/materials/LineBasicMaterial.html
+++ b/docs/api/materials/LineBasicMaterial.html
@@ -59,7 +59,7 @@ var material = new THREE.LineBasicMaterial( {
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
-		<h3>[property:Integer color]</h3>
+		<h3>[property:Color color]</h3>
 		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
 
 		<h3>[property:Boolean isLineBasicMaterial]</h3>

--- a/docs/api/materials/LineBasicMaterial.html
+++ b/docs/api/materials/LineBasicMaterial.html
@@ -52,8 +52,8 @@ var material = new THREE.LineBasicMaterial( {
 		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 		Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
-		The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal string and is *0xffffff* (white) by default.<br />
-		[page:Color.set]( color ) is called internally.
+		The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
+		string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
 		</div>
 
 		<h2>Properties</h2>
@@ -86,16 +86,16 @@ var material = new THREE.LineBasicMaterial( {
 			Define appearance of line ends. Possible values are 'butt', 'round' and 'square'.
 			Default is 'round'.<br /><br />
 
-			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2D Canvas lineCap] property
-			and it is ignored with the [page:WebGLRenderer WebGL] renderer.
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2D Canvas lineCap]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
 		</div>
 
 		<h3>[property:String linejoin]</h3>
 		<div>
 			Define appearance of line joints. Possible values are 'round', 'bevel' and 'miter'. Default is 'round'. <br /><br />
 
-			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineJoin 2D Canvas lineJoin] property
-			and it is ignored with the [page:WebGLRenderer WebGL] renderer.
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineJoin 2D Canvas lineJoin]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
 		</div>
 
 

--- a/docs/api/materials/LineBasicMaterial.html
+++ b/docs/api/materials/LineBasicMaterial.html
@@ -36,8 +36,8 @@
 		</div>
 
 		<code>
-var line_material = new THREE.LineBasicMaterial( {
-	color: 0x303030,
+var material = new THREE.LineBasicMaterial( {
+	color: 0xffffff,
 	lineWidth: 1,
 	linecap: 'round', //ignored by WebGLRenderer
 	linejoin:  'round' //ignored by WebGLRenderer
@@ -50,14 +50,17 @@ var line_material = new THREE.LineBasicMaterial( {
 
 		<div>
 		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
-		Any property of the material (including any property inherited from [page:Material]) can be passed in here.
+		Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
+
+		The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal string and is *0xffffff* (white) by default.<br />
+		[page:Color.set]( color ) is called internally.
 		</div>
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Integer color]</h3>
-		<div>Color of the line. Default is 0xffffff.</div>
+		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
 
 		<h3>[property:Boolean isLineBasicMaterial]</h3>
 		<div>
@@ -71,7 +74,7 @@ var line_material = new THREE.LineBasicMaterial( {
 
 		<h3>[property:Float linewidth]</h3>
 		<div>
-			Controls line thickness. Default is 1.<br /><br />
+			Controls line thickness. Default is *1*.<br /><br />
 
 			Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
 			with the [page:WebGLRenderer WebGL] renderer on Windows platforms linewidth will
@@ -83,18 +86,16 @@ var line_material = new THREE.LineBasicMaterial( {
 			Define appearance of line ends. Possible values are 'butt', 'round' and 'square'.
 			Default is 'round'.<br /><br />
 
-			This setting might not have any effect when used with certain renderers.
-			For example, it is ignored with the [page:WebGLRenderer WebGL] renderer,
-			but does work with the [page:CanvasRenderer Canvas] renderer.
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2D Canvas lineCap] property
+			and it is ignored with the [page:WebGLRenderer WebGL] renderer.
 		</div>
 
 		<h3>[property:String linejoin]</h3>
 		<div>
 			Define appearance of line joints. Possible values are 'round', 'bevel' and 'miter'. Default is 'round'. <br /><br />
 
-			This setting might not have any effect when used with certain renderers.
-			For example, it is ignored with the [page:WebGLRenderer WebGL] renderer,
-			but does work with the [page:CanvasRenderer Canvas] renderer.
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineJoin 2D Canvas lineJoin] property
+			and it is ignored with the [page:WebGLRenderer WebGL] renderer.
 		</div>
 
 

--- a/docs/api/materials/LineBasicMaterial.html
+++ b/docs/api/materials/LineBasicMaterial.html
@@ -14,48 +14,92 @@
 
 		<div class="desc">A material for drawing wireframe-style geometries.</div>
 
+		<h2>Examples</h2>
+
+		<div>
+			[example:webgl_buffergeometry_drawcalls WebGL / buffergeometry / drawcalls]<br />
+			[example:webgl_buffergeometry_lines WebGL / buffergeometry / lines]<br />
+			[example:webgl_buffergeometry_lines_indexed WebGL / buffergeometry / lines / indexed]<br />
+			[example:webgl_decals WebGL / decals]<br />
+			[example:webgl_geometry_nurbs WebGL / geometry / nurbs]<br />
+			[example:webgl_geometry_shapes WebGL / geometry / shapes]<br />
+			[example:webgl_geometry_spline_editor WebGL / geometry / spline / editor]<br />
+			[example:webgl_interactive_buffergeometry WebGL / interactive / buffergeometry]<br />
+			[example:webgl_interactive_voxelpainter WebGL / interactive / voxelpainter]<br />
+			[example:webgl_lines_colors WebGL / lines / colors]<br />
+			[example:webgl_lines_cubes WebGL / lines / cubes]<br />
+			[example:webgl_lines_dashed WebGL / lines / dashed]<br />
+			[example:webgl_lines_sphere WebGL / lines / sphere]<br />
+			[example:webgl_lines_splines WebGL / lines / splines]<br />
+			[example:webgl_materials WebGL / materials]<br />
+			[example:webgl_physics_rope WebGL / phyics / rope]
+		</div>
+
+		<code>
+var line_material = new THREE.LineBasicMaterial( {
+	color: 0x303030,
+	lineWidth: 1,
+	linecap: 'round', //ignored by WebGLRenderer
+	linejoin:  'round' //ignored by WebGLRenderer
+} );
+		</code>
 
 		<h2>Constructor</h2>
 
-
 		<h3>[name]( [page:Object parameters] )</h3>
 
-		<div>parameters is an object with one or more properties defining the material's appearance.</div>
 		<div>
-		color — Line color in hexadecimal. Default is 0xffffff.<br />
-		linewidth — Line thickness. Default is 1.<br />
-		linecap — Define appearance of line ends. Default is 'round'.<br />
-		linejoin — Define appearance of line joints. Default is 'round'.<br />
-		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is false.
+		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+		Any property of the material (including any property inherited from [page:Material]) can be passed in here.
 		</div>
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Integer color]</h3>
-		<div>Sets the color of the line. Default is 0xffffff.</div>
+		<div>Color of the line. Default is 0xffffff.</div>
+
+		<h3>[property:Boolean isLineBasicMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are line basic materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
+		<h3>[property:Boolean lights]</h3>
+		<div>Whether the material is affected by lights. Default is *false*.</div>
 
 		<h3>[property:Float linewidth]</h3>
-		<div>Controls line thickness. Default is 1.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, with the [page:WebGLRenderer WebGL] renderer on Windows platforms linewidth will always be 1 regardless of the set value.</div>
+		<div>
+			Controls line thickness. Default is 1.<br /><br />
+
+			Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+			with the [page:WebGLRenderer WebGL] renderer on Windows platforms linewidth will
+			always be 1 regardless of the set value.
+		</div>
 
 		<h3>[property:String linecap]</h3>
-		<div>Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
+		<div>
+			Define appearance of line ends. Possible values are 'butt', 'round' and 'square'.
+			Default is 'round'.<br /><br />
+
+			This setting might not have any effect when used with certain renderers.
+			For example, it is ignored with the [page:WebGLRenderer WebGL] renderer,
+			but does work with the [page:CanvasRenderer Canvas] renderer.
+		</div>
 
 		<h3>[property:String linejoin]</h3>
-		<div>Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
+		<div>
+			Define appearance of line joints. Possible values are 'round', 'bevel' and 'miter'. Default is 'round'. <br /><br />
 
-		<h3>[property:Integer vertexColors]</h3>
-		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
-		<div>This setting might not have any effect when used with certain renderers.</div>
+			This setting might not have any effect when used with certain renderers.
+			For example, it is ignored with the [page:WebGLRenderer WebGL] renderer,
+			but does work with the [page:CanvasRenderer Canvas] renderer.
+		</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
 
+		<h2>Methods</h2>
+		<div>See the base [page:Material] class for common methods.</div>
 
 		<h2>Source</h2>
 

--- a/docs/api/materials/LineDashedMaterial.html
+++ b/docs/api/materials/LineDashedMaterial.html
@@ -38,8 +38,8 @@ var material = new THREE.LineDashedMaterial( {
 		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 		Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
-		The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal string and is *0xffffff* (white) by default.<br />
-		[page:Color.set]( color ) is called internally.
+		The exception is the property [page:Hexadecimal color], which can be passed i	as a hexadecimal
+		string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
 		</div>
 
 
@@ -78,6 +78,7 @@ var material = new THREE.LineDashedMaterial( {
 		<div>The scale of the dashed part of a line. Default is *1*.</div>
 
 		<h2>Methods</h2>
+		<div>See the base [page:Material] class for common methods.</div>
 
 
 

--- a/docs/api/materials/LineDashedMaterial.html
+++ b/docs/api/materials/LineDashedMaterial.html
@@ -46,7 +46,7 @@ var material = new THREE.LineDashedMaterial( {
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
-		<h3>[property:Integer color]</h3>
+		<h3>[property:Color color]</h3>
 		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
 
 		<h3>[property:number dashSize]</h3>

--- a/docs/api/materials/LineDashedMaterial.html
+++ b/docs/api/materials/LineDashedMaterial.html
@@ -14,57 +14,68 @@
 
 		<div class="desc">A material for drawing wireframe-style geometries with dashed lines.</div>
 
+		<h2>Examples</h2>
+
+		<div>
+			[example:webgl_lines_dashed WebGL / lines / dashed]<br />
+			[example:canvas_lines_dashed Canvas / lines /dashed]
+		</div>
+
+		<code>
+var material = new THREE.LineDashedMaterial( {
+	color: 0xffffff,
+	lineWidth: 1,
+	scale: 1,
+	dashSize: 3,
+	gapSize: 1,
+} );
+		</code>
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [page:Object parameters] )</h3>
-		<div>parameters is an object with one or more properties defining the material's appearance.</div>
-		<div>
-		color — Line color in hexadecimal. Default is 0xffffff.<br />
-		linewidth — Line thickness. Default is 1.<br />
-		scale  — The scale of the dashed part of a line. Default is 1.<br />
-		dashSize  — The size of the dash. Default is 3.<br />
-		gapSize - The size of the gap. Default is 1.<br />
-		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is false.
+		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+		Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
+
+		The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal string and is *0xffffff* (white) by default.<br />
+		[page:Color.set]( color ) is called internally.
 		</div>
 
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
-		<h3>[property:Color color]</h3>
-		<div>
-		Sets the color of the line. Default is 0xffffff.
-		</div>
-
-		<h3>[property:number linewidth]</h3>
-		<div>Controls line thickness. Default is 1.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
-
-		<h3>[property:number scale]</h3>
-		<div>
-		The scale of the dashed part of a line.
-		</div>
+		<h3>[property:Integer color]</h3>
+		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
 
 		<h3>[property:number dashSize]</h3>
-		<div>
-		The size of the dash. This is both the gap with the stroke. Default is 3.
-		</div>
+		<div>The size of the dash. This is both the gap with the stroke. Default is *3*.</div>
 
 		<h3>[property:number gapSize]</h3>
+		<div>The size of the gap. Default is *1*.</div>
+
+		<h3>[property:Boolean isLineDashedMaterial]</h3>
 		<div>
-		The size of the gap. Default is 1.
+			Used to check whether this or derived classes are line dashed materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
 		</div>
 
-		<h3>[property:boolean vertexColors]</h3>
-		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
-		<div>This setting might not have any effect when used with certain renderers.</div>
+		<h3>[property:Boolean lights]</h3>
+		<div>Whether the material is affected by lights. Default is *false*.</div>
 
-		<h3>[property:boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
+		<h3>[property:Float linewidth]</h3>
+		<div>
+			Controls line thickness. Default is *1*.<br /><br />
+
+			Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+			with the [page:WebGLRenderer WebGL] renderer on Windows platforms linewidth will
+			always be 1 regardless of the set value.
+		</div>
+
+		<h3>[property:number scale]</h3>
+		<div>The scale of the dashed part of a line. Default is *1*.</div>
 
 		<h2>Methods</h2>
 

--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -11,13 +11,14 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
+		Abstract base class for materials.<br /><br />
+
 		Materials describe the appearance of [page:Object objects].
 		They are defined in a (mostly) renderer-independent way, so you don't have to
 		rewrite materials if you decide to use a different renderer.<br /><br />
 
 		With the exception of [page:MultiMaterial MultiMaterial], the following properties
 		and methods are inherited by all other material types (although they may have different defaults).
-		</P>
 		</div>
 
 		<h2>Constructor</h2>
@@ -157,8 +158,6 @@
 		This is a workaround for cases when gaps appear between triangles when using [page:CanvasRenderer].
 		*0.5* tends to give good results across browsers. Default is *0*.
 		</div>
-
-
 
 		<h3>[property:Boolean polygonOffset]</h3>
 		<div>

--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -11,12 +11,12 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-		<p>
 		Materials describe the appearance of [page:Object objects].
-		They are defined in a (mostly) renderer-independent way, so you don't have to rewrite materials if you decide to use a different renderer.
-		</p>
-		<P>
-		With the exception of [page:MultiMaterial MultiMaterial], the following properties and methods are inherited by all other material types (although they may have different defaults).
+		They are defined in a (mostly) renderer-independent way, so you don't have to
+		rewrite materials if you decide to use a different renderer.<br /><br />
+
+		With the exception of [page:MultiMaterial MultiMaterial], the following properties
+		and methods are inherited by all other material types (although they may have different defaults).
 		</P>
 		</div>
 
@@ -24,76 +24,37 @@
 
 
 		<h3>[name]()</h3>
-		<div>
-		This creates a generic material.
-		</div>
+		<div>This creates a generic material.</div>
 
 
 		<h2>Properties</h2>
 
-		<h3>[property:Integer id]</h3>
+		<h3>[property:Float alphaTest]</h3>
 		<div>
-		Unique number for this material instance.
+		Sets the alpha value to be used when running an alpha test.
+		The material will not be renderered if the opacity is lower than this value.
+		Default is *0*.
 		</div>
 
-		<h3>[property:String name]</h3>
+		<h3>[property:Integer blendDst]</h3>
 		<div>
-		Material name. Default is an empty string.
+		Blending destination. Default is [page:CustomBlendingEquation OneMinusSrcAlphaFactor].
+		See the destination factors [page:CustomBlendingEquation constants] for all possible values.<br />
+		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
 		</div>
 
-		<h3>[property:String type]</h3>
+		<h3>[property:Integer blendDstAlpha]</h3>
+		<div>The tranparency of the [page:.blendDst]. Default is *null*.</div>
+
+		<h3>[property:Integer blendEquation]</h3>
 		<div>
-		Value is the string 'Material'. This shouldn't be changed, and can be used to find all objects of this type in a scene.
+		Blending equation to use when applying blending. Default is [page:CustomBlendingEquation AddEquation].
+		See the blending equation [page:CustomBlendingEquation constants] for all possible values.<br />
+		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
 		</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>
-		Whether the material is affected by fog. Default is *true*.
-		</div>
-
-		<h3>[property:Boolean lights]</h3>
-		<div>
-		Whether the material is affected by lights. Default is *true*.
-		</div>
-
-		<h3>[property:Integer side]</h3>
-		<div>
-		Defines which side of faces will be rendered - front, back or both.
-		Default is [page:Materials THREE.FrontSide].
-		Other options are [page:Materials THREE.BackSide] and [page:Materials THREE.DoubleSide].
-		</div>
-
-		<h3>[property:Integer shading]</h3>
-		<div>
-		Defines how the material is shaded.
-		This can be either [page:Materials THREE.SmoothShading] (default)	or [page:Materials THREE.FlatShading].
-		</div>
-
-		<h3>[property:Integer vertexColors]</h3>
-		<div>
-		Defines whether vertex coloring is used.
-		Default is [page:Materials THREE.NoColors].
-		Other options are [page:Materials THREE.VertexColors] and [page:Materials THREE.FaceColors].
-		</div>
-
-		<h3>[property:Float opacity]</h3>
-		<div>
-		Float in the range of *0.0* - *1.0* indicating how transparent the material is.
-		A value of *0.0* indicates fully transparent, *1.0* is fully opaque.<br />
-		If the material's [property:Boolean transparent] property is not set to *true*, the material will remain
-		fully opaque and this value will only affect its color. <br />
-		Default is *1.0*.
-		</div>
-
-		<h3>[property:Boolean transparent]</h3>
-		<div>
-		Defines whether this material is transparent. This has an effect on rendering
-		as transparent objects need special treatment and are rendered after
-		non-transparent objects. <br />
-		When set to true, the extent to which the material is transparent is
-		controlled by setting it's [property:Float opacity] property. <br />
-		Default is *false*.
-		</div>
+		<h3>[property:Integer blendEquationAlpha]</h3>
+		<div>The tranparency of the [page:.blendEquation]. Default is *null*.</div>
 
 		<h3>[property:Blending blending]</h3>
 		<div>
@@ -109,18 +70,33 @@
 		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
 		</div>
 
-		<h3>[property:Integer blendDst]</h3>
+		<h3>[property:Integer blendSrcAlpha]</h3>
+		<div>The tranparency of the [page:.blendSrc]. Default is *null*.</div>
+
+		<h3>[property:Boolean clipIntersection]</h3>
 		<div>
-		Blending destination. Default is [page:CustomBlendingEquation OneMinusSrcAlphaFactor].
-		See the destination factors [page:CustomBlendingEquation constants] for all possible values.<br />
-		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
+		Changes the behavior of clipping planes so that only their intersection is clipped, rather than their union.
+		Default is *false*.
 		</div>
 
-		<h3>[property:Integer blendEquation]</h3>
+		<h3>[property:Array clippingPlanes]</h3>
 		<div>
-		Blending equation to use when applying blending. Default is [page:CustomBlendingEquation AddEquation].
-		See the blending equation [page:CustomBlendingEquation constants] for all possible values.<br />
-		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
+		User-defined clipping planes specified as THREE.Plane objects in world space.
+		These planes apply to the objects this material is attached to.
+		Points in space whose dot product with the plane is negative are cut away.
+		See the [example:webgl_clipping_intersection WebGL / clipping /intersection] example.
+		Default is *null*.
+		</div>
+
+		<h3>[property:Boolean clipShadows]</h3>
+		<div>
+		Defines whether to clip shadows according to the clipping planes specified on this material. Default is *false*.
+		</div>
+
+		<h3>[property:Boolean colorWrite]</h3>
+		<div>
+		Whether to render the material's color.
+		This can be used in conjunction with a mesh's [property:Integer renderOrder] property to create invisible objects that occlude other objects. Default is *true*.
 		</div>
 
 		<h3>[property:Integer depthFunc]</h3>
@@ -135,71 +111,44 @@
 
 		<h3>[property:Boolean depthWrite]</h3>
 		<div>
-		Whether rendering this material has any effect on the depth buffer. Default is *true*.
-		</div>
-		<div>
+		Whether rendering this material has any effect on the depth buffer. Default is *true*.<br /><br />
+
 		When drawing 2D overlays it can be useful to disable the depth writing in order to layer several things together without creating z-index artifacts.
 		</div>
 
-		<h3>[property:Array clippingPlanes]</h3>
+		<h3>[property:Boolean fog]</h3>
+		<div>Whether the material is affected by fog. Default is *true*.</div>
+
+		<h3>[property:Integer id]</h3>
+		<div>Unique number for this material instance.</div>
+
+		<h3>[property:Boolean isMaterial]</h3>
 		<div>
-		User-defined clipping planes specified as THREE.Plane objects in world space.
-		These planes apply to the objects this material is attached to.
-		Points in space whose dot product with the plane is negative are cut away.
-		See the [example:webgl_clipping_intersection WebGL / clipping /intersection] example.
-		Default is *null*.
+			Used to check whether this or derived classes are materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
 		</div>
 
-		<h3>[property:Boolean clipIntersection]</h3>
+		<h3>[property:Boolean lights]</h3>
+		<div>Whether the material is affected by lights. Default is *true*.</div>
+
+		<h3>[property:String name]</h3>
+		<div>Optional name of the object (doesn't need to be unique). Default is an empty string.</div>
+
+		<h3>[property:Boolean needsUpdate]</h3>
 		<div>
-		Changes the behavior of clipping planes so that only their intersection is clipped, rather than their union.
-		Default is *false*.
+		Specifies that the material needs to be updated at the WebGL level.
+		Set it to true if you made changes that need to be reflected in WebGL.<br />
+		This property is automatically set to *true* when instancing a new material.
 		</div>
 
-		<h3>[property:Boolean clipShadows]</h3>
+		<h3>[property:Float opacity]</h3>
 		<div>
-		Defines whether to clip shadows according to the clipping planes specified on this material. Default is *false*.
-		</div>
-
-		<h3>[property:Boolean colorWrite]</h3>
-		<div>
-		Whether to render the material's color.
-		This can be used in conjunction with a mesh's [property:Integer renderOrder] property to create invisible objects that occlude other objects. Default is *true*.
-		</div>
-
-		<h3>[property:String precision]</h3>
-		<div>
-		Override the renderer's default precision for this material. Can be "*highp*", "*mediump*" or "*lowp*".
-		Defaults for the WebGLRenderer is "*highp*" if supported by the device.
-		</div>
-
-		<h3>[property:Boolean polygonOffset]</h3>
-		<div>
-		Whether to use polygon offset. Default is *false*. This corresponds to the *GL_POLYGON_OFFSET_FILL* WebGL feature.
-		</div>
-
-		<h3>[property:Integer polygonOffsetFactor]</h3>
-		<div>
-		Sets the polygon offset factor. Default is *0*.
-		</div>
-
-		<h3>[property:Integer polygonOffsetUnits]</h3>
-		<div>
-		Sets the polygon offset units. Default is *0*.
-		</div>
-
-		<h3>[property:Float alphaTest]</h3>
-		<div>
-		Sets the alpha value to be used when running an alpha test.
-		The material will not be renderered if the opacity is lower than this value.
-		Default is *0*.
-		</div>
-
-		<h3>[property:Boolean premultipliedAlpha]</h3>
-		<div>
-		Whether to premultiply the alpha (transparency) value.
-		See [Example:webgl_materials_transparency WebGL / Materials / Transparency] for an example of the difference.
-		Default is *false*.
+		Float in the range of *0.0* - *1.0* indicating how transparent the material is.
+		A value of *0.0* indicates fully transparent, *1.0* is fully opaque.<br />
+		If the material's [property:Boolean transparent] property is not set to *true*, the material will remain
+		fully opaque and this value will only affect its color. <br />
+		Default is *1.0*.
 		</div>
 
 		<h3>[property:Float overdraw]</h3>
@@ -209,22 +158,95 @@
 		*0.5* tends to give good results across browsers. Default is *0*.
 		</div>
 
+
+
+		<h3>[property:Boolean polygonOffset]</h3>
+		<div>
+		Whether to use polygon offset. Default is *false*. This corresponds to the *GL_POLYGON_OFFSET_FILL* WebGL feature.
+		</div>
+
+		<h3>[property:Integer polygonOffsetFactor]</h3>
+		<div>Sets the polygon offset factor. Default is *0*.</div>
+
+		<h3>[property:Integer polygonOffsetUnits]</h3>
+		<div>Sets the polygon offset units. Default is *0*.</div>
+
+		<h3>[property:String precision]</h3>
+		<div>
+		Override the renderer's default precision for this material. Can be "*highp*", "*mediump*" or "*lowp*".
+		Defaults is *null*.
+		</div>
+
+		<h3>[property:Boolean premultipliedAlpha]</h3>
+		<div>
+		Whether to premultiply the alpha (transparency) value.
+		See [Example:webgl_materials_transparency WebGL / Materials / Transparency] for an example of the difference.
+		Default is *false*.
+		</div>
+
+		<h3>[property:Integer shading]</h3>
+		<div>
+		Defines how the material is shaded.
+		This can be either [page:Materials THREE.SmoothShading] (default)	or [page:Materials THREE.FlatShading].
+		</div>
+
+		<h3>[property:Integer side]</h3>
+		<div>
+		Defines which side of faces will be rendered - front, back or both.
+		Default is [page:Materials THREE.FrontSide].
+		Other options are [page:Materials THREE.BackSide] and [page:Materials THREE.DoubleSide].
+		</div>
+
+		<h3>[property:Boolean transparent]</h3>
+		<div>
+		Defines whether this material is transparent. This has an effect on rendering
+		as transparent objects need special treatment and are rendered after
+		non-transparent objects. <br />
+		When set to true, the extent to which the material is transparent is
+		controlled by setting it's [property:Float opacity] property. <br />
+		Default is *false*.
+		</div>
+
+		<h3>[property:String type]</h3>
+		<div>
+		Value is the string 'Material'. This shouldn't be changed, and can be used to
+		find all objects of this type in a scene.
+		</div>
+
+		<h3>[property:String uuid]</h3>
+		<div>
+		[link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID] of this material instance.
+		This gets automatically assigned, so this shouldn't be edited.
+		</div>
+
+		<h3>[property:Integer vertexColors]</h3>
+		<div>
+		Defines whether vertex coloring is used.
+		Default is [page:Materials THREE.NoColors].
+		Other options are [page:Materials THREE.VertexColors] and [page:Materials THREE.FaceColors].
+		</div>
+
 		<h3>[property:Boolean visible]</h3>
 		<div>
 		Defines whether this material is visible. Default is *true*.
-		</div>
-
-		<h3>[property:Boolean needsUpdate]</h3>
-		<div>
-		Specifies that the material needs to be updated at the WebGL level.
-		Set it to true if you made changes that need to be reflected in WebGL.<br />
-		This property is automatically set to *true* when instancing a new material.
 		</div>
 
 
 		<h2>Methods</h2>
 
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
+
+		<h3>[method:Material clone]( )</h3>
+		<div>Return a new materials with the same parameters as this material.</div>
+
+		<h3>[method:Material copy]( [page:material material] )</h3>
+		<div>Copy the parameters from the passed material into this material.</div>
+
+		<h3>[method:null dispose]()</h3>
+		<div>
+		This disposes the material. Textures of a material don't get disposed.
+		These needs to be disposed by [page:Texture Texture].
+		</div>
 
 		<h3>[method:null setValues]( [page:object values] )</h3>
 		<div>
@@ -238,21 +260,9 @@
 		Convert the material to Three JSON format.
 		</div>
 
-		<h3>[method:Material clone]( [page:material material] )</h3>
-		<div>
-		material -- this material gets the cloned information (optional).<br />
-		This clones the material in the optional parameter and returns it.
-		</div>
-
 		<h3>[method:null update]()</h3>
 		<div>
 		Call [method:null dispatchEvent]( { type: '[page:object update]' }) on the material.
-		</div>
-
-		<h3>[method:null dispose]()</h3>
-		<div>
-		This disposes the material. Textures of a material don't get disposed.
-		These needs to be disposed by [page:Texture Texture].
 		</div>
 
 		<h2>Source</h2>

--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -68,7 +68,7 @@
 		<h3>[property:Float aoMapIntensity]</h3>
 		<div>Intensity of the ambient occlusion effect. Default is 1. Zero is no occlusion effect.</div>
 
-		<h3>[property:Integer color]</h3>
+		<h3>[property:Color color]</h3>
 		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
 
 		<h3>[property:Integer combine]</h3>

--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -112,9 +112,6 @@
 		<h3>[property:Float refractionRatio]</h3>
 		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
 
-		<h3>[property:String shading]</h3>
-		<div>Define shading type. Default is THREE.SmoothShading.</div>
-
 		<h3>[property:Boolean skinning]</h3>
 		<div>Define whether the material uses skinning. Default is false.</div>
 

--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -12,8 +12,12 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A material for drawing geometries in a simple shaded (flat or wireframe) way.</div>
-		<div class="desc">The default will render as flat polygons. To draw the mesh as wireframe, simply set the 'wireframe' property to true.</div>
+		<div class="desc">
+			A material for drawing geometries in a simple shaded (flat or wireframe) way.<br /><br />
+
+			This material is not affected by lights.
+		</div>
+
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshBasicMaterial"></iframe>
 
@@ -36,109 +40,115 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [page:Object parameters] )</h3>
-
-		<div>parameters is an object with one or more properties defining the material's appearance.</div>
 		<div>
-		color — geometry color in hexadecimal. Default is 0xffffff.<br />
-		map — Set texture map. Default is null <br />
-		lightMap — Set light map. Default is null.<br />
-		lightMapIntensity — Set light map intensity. Default is 1.<br />
-		aoMap — Set ao map. Default is null.<br />
-		aoMapIntensity — Set ao map intensity. Default is 1.<br />
-		specularMap — Set specular map. Default is null.<br />
-		alphaMap — Set alpha map. Default is null.<br />
-		envMap — Set env map. Default is null.<br />
-		combine — Set combine operation. Default is THREE.MultiplyOperation.<br />
-		reflectivity — Set reflectivity. Default is 1.<br />
-		refractionRatio — Set refraction ratio. Default is 0.98.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
-		shading — Define shading type. Default is THREE.SmoothShading.<br />
-		wireframe — render geometry as wireframe. Default is false.<br />
-		wireframeLinewidth — Line thickness. Default is 1.<br />
-		wireframeLinecap — Define appearance of line ends. Default is 'round'.<br />
-		wireframeLinejoin — Define appearance of line joints. Default is 'round'.<br />
-		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
-		skinning — Define whether the material uses skinning. Default is false.<br />
-		morphTargets — Define whether the material uses morphTargets. Default is false.
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
+
+			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
+			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
 		</div>
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
-		<h3>[property:Integer color]</h3>
-		<div>Sets the color of the geometry. Default is 0xffffff.</div>
+		<h3>[property:Texture alphaMap]</h3>
+		<div>The alpha map is a grayscale texture that controls the opacity across the surface
+			(black: fully transparent; white: fully opaque). Default is null.<br /><br />
 
-		<h3>[property:Texture map]</h3>
-		<div>
-		Set texture map. Default is  null.
+			Only the color of the texture is used, ignoring the alpha channel if one exists.
+			For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the
+			green channel when sampling this texture due to the extra bit of precision provided
+			for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
+			luminance/alpha textures will also still work as expected.
 		</div>
 
-		<h3>[property:Texture lightMap]</h3>
-		<div>Set light map. Default is null. The lightMap requires a second set of UVs.</div>
-
-		<h3>[property:Float lightMapIntensity]</h3>
-		<div>Intensity of the baked light. Default is 1.</div>
-
 		<h3>[property:Texture aoMap]</h3>
-		<div>Set ambient occlusion map. Default is null.</div>
+		<div>The ambient occlusion map. Default is null.</div>
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<div>Intensity of the ambient occlusion effect. Default is 1. Zero is no occlusion effect.</div>
 
-		<h3>[property:Texture specularMap]</h3>
-		<div>Set specular map. Default is null.</div>
-
-		<h3>[property:Texture alphaMap]</h3>
-		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
-		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
-
-		<h3>[property:TextureCube envMap]</h3>
-		<div>Set env map. Default is null.</div>
+		<h3>[property:Integer color]</h3>
+		<div>Sets the color of the geometry. Default is 0xffffff.</div>
 
 		<h3>[property:Integer combine]</h3>
-		<div>How to combine the result of the surface's color with the environment map, if any.</div>
+		<div>
+			How to combine the result of the surface's color with the environment map, if any.<br /><br />
 
-		<div>Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation], [page:Materials THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
+			Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation],
+			[page:Materials THREE.AddOperation]. If mix is chosen, the [page:.reflectivity] is used to
+			blend between the two colors.
+		</div>
 
-		<h3>[property:Float reflectivity]</h3>
-		<div>How much the environment map affects the surface; also see "combine".</div>
+		<h3>[property:Boolean isMeshBasicMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are mesh basic materials. Default is *true*.<br /><br />
 
-		<h3>[property:Float refractionRatio]</h3>
-		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
+			You should not change this, as it used internally for optimisation.
+		</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
+		<h3>[property:TextureCube envMap]</h3>
+		<div>The environment map. Default is null.</div>
 
-		<h3>[property:String shading]</h3>
-		<div>Define shading type. Default is THREE.SmoothShading.</div>
+		<h3>[property:Texture lightMap]</h3>
+		<div>The light map. Default is null. The lightMap requires a second set of UVs.</div>
 
-		<h3>[property:Boolean wireframe]</h3>
-		<div>Render geometry as wireframe. Default is false (i.e. render as flat polygons).</div>
+		<h3>[property:Float lightMapIntensity]</h3>
+		<div>Intensity of the baked light. Default is 1.</div>
 
-		<h3>[property:Float wireframeLinewidth]</h3>
-		<div>Controls wireframe thickness. Default is 1.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
+		<h3>[property:Boolean lights]</h3>
+		<div>Whether the material is affected by lights. Default is *false*.</div>
 
-		<h3>[property:String wireframeLinecap]</h3>
-		<div>Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
-
-		<h3>[property:String wireframeLinejoin]</h3>
-		<div>Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
-
-		<h3>[property:Integer vertexColors]</h3>
-		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
-
-		<h3>[property:Boolean skinning]</h3>
-		<div>Define whether the material uses skinning. Default is false.</div>
+		<h3>[property:Texture map]</h3>
+		<div>The color map. Default is  null.</div>
 
 		<h3>[property:Boolean morphTargets]</h3>
 		<div>Define whether the material uses morphTargets. Default is false.</div>
 
+
+		<h3>[property:Float reflectivity]</h3>
+		<div>How much the environment map affects the surface; also see [page:.combine].</div>
+
+		<h3>[property:Float refractionRatio]</h3>
+		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
+
+		<h3>[property:String shading]</h3>
+		<div>Define shading type. Default is THREE.SmoothShading.</div>
+
+		<h3>[property:Boolean skinning]</h3>
+		<div>Define whether the material uses skinning. Default is false.</div>
+
+		<h3>[property:Texture specularMap]</h3>
+		<div>Specular map used by the material. Default is null.</div>
+
+		<h3>[property:Boolean wireframe]</h3>
+		<div>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</div>
+
+		<h3>[property:String wireframeLinecap]</h3>
+		<div>
+			Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.<br /><br />
+
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2D Canvas lineCap]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
+		</div>
+
+		<h3>[property:String wireframeLinejoin]</h3>
+		<div>
+			Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.<br /><br />
+
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineJoin 2D Canvas lineJoin]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
+		</div>
+
+		<h3>[property:Float wireframeLinewidth]</h3>
+		<div>Controls wireframe thickness. Default is 1.<br /><br />
+
+		Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+		on Windows platforms linewidth will always be 1 regardless of the set value.
+		</div>
+
 		<h2>Methods</h2>
+		<div>See the base [page:Material] class for common methods.</div>
 
 		<h2>Source</h2>
 

--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -69,7 +69,7 @@
 		<div>Intensity of the ambient occlusion effect. Default is 1. Zero is no occlusion effect.</div>
 
 		<h3>[property:Integer color]</h3>
-		<div>Sets the color of the geometry. Default is 0xffffff.</div>
+		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
 
 		<h3>[property:Integer combine]</h3>
 		<div>

--- a/docs/api/materials/MeshDepthMaterial.html
+++ b/docs/api/materials/MeshDepthMaterial.html
@@ -58,13 +58,26 @@
 		<div>Encoding for depth packing. Default is [page:Textures BasicDepthPacking].</div>
 
 		<h3>[property:Texture displacementMap]</h3>
-		<div>The displacement map. Default is null.</div>
+		<div>
+			The displacement map affects the position of the mesh's vertices. Unlike other maps
+			which only affect the light and shade of the material the displaced vertices can cast shadows,
+			block other objects, and otherwise act as real geometry. The displacement texture is
+			an image where the value of each pixel (white being the highest) is mapped against,
+			and repositions, the vertices of the mesh.
+		</div>
 
-		<h3>[property:Number displacementMapBias]</h3>
-		<div>The displacement map's bias. Default is *0*.</div>
+		<h3>[property:Float displacementScale]</h3>
+		<div>
+			How much the displacement map affects the mesh (where black is no displacement,
+			and white is maximum displacement). Without a displacement map set, this value is not applied.
+			 Default is 1.
+		</div>
 
-		<h3>[property:Number displacementMapScale]</h3>
-		<div>The displacement map. Default is *1*.</div>
+		<h3>[property:Float displacementBias]</h3>
+		<div>
+			The offset of the displacement map's values on the mesh's vertices.
+			Without a displacement map set, this value is not applied. Default is 0.
+		</div>
 
 		<h3>[property:Boolean fog]</h3>
 		<div>Whether the material is affected by fog. Default is *false*.</div>

--- a/docs/api/materials/MeshDepthMaterial.html
+++ b/docs/api/materials/MeshDepthMaterial.html
@@ -36,32 +36,70 @@
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>
-		parameters is an object with one or more properties defining the material's appearance.
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.
 		</div>
-		<div>
-		morphTargets -- Define whether the material uses morphTargets. Default is false.<br/>
-		wireframe -- Render geometry as wireframe. Default is false (i.e. render as smooth shaded).<br/>
-		wireframeLinewidth -- Controls wireframe thickness. Default is 1.<br/>
-		</div>
-
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
+		<h3>[property:Texture alphaMap]</h3>
+		<div>The alpha map is a grayscale texture that controls the opacity across the surface
+			(black: fully transparent; white: fully opaque). Default is null.<br /><br />
+
+			Only the color of the texture is used, ignoring the alpha channel if one exists.
+			For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the
+			green channel when sampling this texture due to the extra bit of precision provided
+			for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
+			luminance/alpha textures will also still work as expected.
+		</div>
+
+		<h3>[property:Constant depthPacking]</h3>
+		<div>Encoding for depth packing. Default is [page:Textures BasicDepthPacking].</div>
+
+		<h3>[property:Texture displacementMap]</h3>
+		<div>The displacement map. Default is null.</div>
+
+		<h3>[property:Number displacementMapBias]</h3>
+		<div>The displacement map's bias. Default is *0*.</div>
+
+		<h3>[property:Number displacementMapScale]</h3>
+		<div>The displacement map. Default is *1*.</div>
+
+		<h3>[property:Boolean fog]</h3>
+		<div>Whether the material is affected by fog. Default is *false*.</div>
+
+		<h3>[property:Boolean isMeshDepthMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are mesh depth materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
+		<h3>[property:Boolean lights]</h3>
+		<div>Whether the material is affected by lights. Default is *false*.</div>
+
+		<h3>[property:Texture map]</h3>
+		<div>The color map. Default is  null.</div>
+
 		<h3>[property:boolean morphTargets]</h3>
 		<div>Define whether the material uses morphTargets. Default is false.</div>
+
+		<h3>[property:Boolean skinning]</h3>
+		<div>Define whether the material uses skinning. Default is false.</div>
 
 		<h3>[property:boolean wireframe]</h3>
 		<div>Render geometry as wireframe. Default is false (i.e. render as smooth shaded).</div>
 
-		<h3>[property:number wireframeLinewidth]</h3>
-		<div>
-			Controls wireframe thickness. Default is 1.<br/><br/>
-			Due to limitations in the ANGLE layer, on Windows platforms linewidth will always be 1 regardless of the set value.
+		<h3>[property:Float wireframeLinewidth]</h3>
+		<div>Controls wireframe thickness. Default is 1.<br /><br />
+
+		Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+		on Windows platforms linewidth will always be 1 regardless of the set value.
 		</div>
 
 		<h2>Methods</h2>
-
+		<div>See the base [page:Material] class for common methods.</div>
 
 
 		<h2>Source</h2>

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -13,10 +13,21 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-			A material for non-shiny (Lambertian) surfaces. <br />
+			A material for non-shiny surfaces, without specular highlights.<br /><br />
 
-			Unlike the [page:MeshPhongMaterial] which calculates lighting per pixel,
-			lighting is calculated per vertex and interpolated in between.
+			The uses a non-physically based [link:https://en.wikipedia.org/wiki/Lambertian_reflectance Lambertian]
+			model	for calculating reflectance. This can simulate some surfaces (such as untreated wood or stone) well,
+			but cannot simulate shiny surfaces with specular highlights (such as varnished wood).<br /><br />
+
+
+
+			Shading is calculated using a [link:https://en.wikipedia.org/wiki/Gouraud_shading Gouraud] shading model.
+			This calculates shading per vertex (i.e. in the [link:https://en.wikipedia.org/wiki/Shader#Vertex_shaders vertex shader])
+			and interpolates the results over the polygon's faces.<br /><br />
+
+			Due to the simplicity of the reflectance and illumination models, performance will be greater
+			when using this material over the [page:MeshPhongMaterial],	[page:MeshStandardMaterial] or [page:MeshPhysicalMaterial],
+			at the cost of some graphical accuracy.
 		</div>
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshLambertMaterial"></iframe>

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -13,8 +13,10 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-			A material for non-shiny (Lambertian) surfaces. Lighting is calculated
-			per vertex and interpolated in between.
+			A material for non-shiny (Lambertian) surfaces. <br />
+
+			Unlike the [page:MeshPhongMaterial] which calculates lighting per pixel,
+			lighting is calculated per vertex and interpolated in between.
 		</div>
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshLambertMaterial"></iframe>
@@ -66,7 +68,7 @@
 		<h3>[property:Float aoMapIntensity]</h3>
 		<div>Intensity of the ambient occlusion effect. Default is 1. Zero is no occlusion effect.</div>
 
-		<h3>[property:Integer color]</h3>
+		<h3>[property:Color color]</h3>
 		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
 
 		<h3>[property:Integer combine]</h3>
@@ -76,13 +78,6 @@
 			Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation],
 			[page:Materials THREE.AddOperation]. If mix is chosen, the [page:.reflectivity] is used to
 			blend between the two colors.
-		</div>
-
-		<h3>[property:Boolean isMeshLambertMaterial]</h3>
-		<div>
-			Used to check whether this or derived classes are mesh Lambert materials. Default is *true*.<br /><br />
-
-			You should not change this, as it used internally for optimisation.
 		</div>
 
 		<h3>[property:Color emissive]</h3>
@@ -103,6 +98,13 @@
 
 		<h3>[property:TextureCube envMap]</h3>
 		<div>The environment map. Default is null.</div>
+
+		<h3>[property:Boolean isMeshLambertMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are mesh Lambert materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
 
 		<h3>[property:Texture lightMap]</h3>
 		<div>The light map. Default is null. The lightMap requires a second set of UVs.</div>

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -12,7 +12,10 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A material for non-shiny (Lambertian) surfaces, evaluated per vertex.</div>
+		<div class="desc">
+			A material for non-shiny (Lambertian) surfaces. Lighting is calculated
+			per vertex and interpolated in between.
+		</div>
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshLambertMaterial"></iframe>
 
@@ -36,128 +39,132 @@
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>
-		parameters -- parameters is an object with one or more properties defining the material's appearance.
-		</div>
-		<div>
-		color — Line color in hexadecimal. Default is 0xffffff.<br />
-		map — Sets the texture map. Default is null <br />
-		lightMap — Set light map. Default is null.<br />
-		lightMapIntensity — Set light map intensity. Default is 1.<br />
-		aoMap — Set ao map. Default is null.<br />
-		aoMapIntensity — Set ao map intensity. Default is 1.<br />
-		emissive - Set emissive color. Default is 0x000000.<br />
-		emissiveMap — Set emissive map. Default is null.<br />
-		emissiveIntensity — Set emissive map intensity. Default is 1.<br />
-		specularMap — Set specular map. Default is null.<br />
-		alphaMap — Set alpha map. Default is null.<br />
-		envMap — Set env map. Default is null.<br />
-		combine — Set combine operation. Default is THREE.MultiplyOperation.<br />
-		reflectivity — Set reflectivity. Default is 1.<br />
-		refractionRatio — Set refraction ratio. Default is 0.98.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is false.<br />
-		wireframe — Render geometry as wireframe. Default is false (i.e. render as smooth shaded).<br/>
-		wireframeLinewidth — Controls wireframe thickness. Default is 1.<br/>
-		wireframeLinecap — Define appearance of line ends. Default is 'round'.<br />
-		wireframeLinejoin — Define appearance of line joints. Default is 'round'.<br />
-		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
-		skinning — Define whether the material uses skinning. Default is false.<br />
-		morphTargets — Define whether the material uses morphTargets. Default is false.<br />
-		morphNormals — Define whether the material uses morphNormals. Default is false.
-		</div>
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
+			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
+			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+		</div>
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
-		<h3>[property:Color color]</h3>
-		<div>
-		Diffuse color of the material. Default is white.<br />
+		<h3>[property:Texture alphaMap]</h3>
+		<div>The alpha map is a grayscale texture that controls the opacity across the surface
+			(black: fully transparent; white: fully opaque). Default is null.<br /><br />
+
+			Only the color of the texture is used, ignoring the alpha channel if one exists.
+			For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the
+			green channel when sampling this texture due to the extra bit of precision provided
+			for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
+			luminance/alpha textures will also still work as expected.
 		</div>
 
-		<h3>[property:Texture map]</h3>
-		<div>Set color texture map. Default is null.</div>
-
-		<h3>[property:Texture lightMap]</h3>
-		<div>Set light map. Default is null. The lightMap requires a second set of UVs.</div>
-
-		<h3>[property:Float lightMapIntensity]</h3>
-		<div>TODO</div>
-
 		<h3>[property:Texture aoMap]</h3>
-		<div>Set ambient occlusion map. Default is null. The aoMap requires a second set of UVs.</div>
+		<div>The ambient occlusion map. Default is null.</div>
 
 		<h3>[property:Float aoMapIntensity]</h3>
-		<div>TODO</div>
+		<div>Intensity of the ambient occlusion effect. Default is 1. Zero is no occlusion effect.</div>
+
+		<h3>[property:Integer color]</h3>
+		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
+
+		<h3>[property:Integer combine]</h3>
+		<div>
+			How to combine the result of the surface's color with the environment map, if any.<br /><br />
+
+			Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation],
+			[page:Materials THREE.AddOperation]. If mix is chosen, the [page:.reflectivity] is used to
+			blend between the two colors.
+		</div>
+
+		<h3>[property:Boolean isMeshLambertMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are mesh Lambert materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
 
 		<h3>[property:Color emissive]</h3>
 		<div>
-		Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
+		Emissive (light) color of the material, essentially a solid color unaffected by other lighting.
+		Default is black.
 		</div>
 
 		<h3>[property:Texture emissiveMap]</h3>
-		<div>Set emisssive (glow) map. Default is null. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.</div>
+		<div>
+		Set emisssive (glow) map. Default is null. The emissive map color is modulated by
+		the emissive color and the emissive intensity. If you have an emissive map, be sure to
+		set the emissive color to something other than black.
+		</div>
 
 		<h3>[property:Float emissiveIntensity]</h3>
 		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
 
-		<h3>[property:Texture specularMap]</h3>
-		<div>Since this material does not have a specular component, the specular value affects only how much of the environment map affects the surface. Default is null.</div>
-
-		<h3>[property:Texture alphaMap]</h3>
-		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
-		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
-
 		<h3>[property:TextureCube envMap]</h3>
-		<div>Set env map. Default is null.</div>
+		<div>The environment map. Default is null.</div>
 
-		<h3>[property:Integer combine]</h3>
-		<div>How to combine the result of the surface's color with the environment map, if any.</div>
+		<h3>[property:Texture lightMap]</h3>
+		<div>The light map. Default is null. The lightMap requires a second set of UVs.</div>
 
-		<div>Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation], [page:Materials THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
+		<h3>[property:Float lightMapIntensity]</h3>
+		<div>Intensity of the baked light. Default is 1.</div>
+
+		<h3>[property:Texture map]</h3>
+		<div>The color map. Default is  null.</div>
+
+		<h3>[property:boolean morphNormals]</h3>
+		<div>
+			Defines whether the material uses morphNormals. Set as true to pass morphNormal
+			attributes from the [page:Geometry]	to the shader. Default is *false*.
+		</div>
+
+		<h3>[property:Boolean morphTargets]</h3>
+		<div>Define whether the material uses morphTargets. Default is false.</div>
 
 		<h3>[property:Float reflectivity]</h3>
-		<div>How much the environment map affects the surface; also see "combine".</div>
+		<div>How much the environment map affects the surface; also see [page:.combine].</div>
 
 		<h3>[property:Float refractionRatio]</h3>
 		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings. Default is *true*.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
-
-		<h3>[property:Boolean wireframe]</h3>
-		<div>Whether the triangles' edges are displayed instead of surfaces. Default is *false*.</div>
-
-		<h3>[property:Float wireframeLinewidth]</h3>
-		<div>Line thickness for wireframe mode. Default is *1.0*.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
-
-		<h3>[property:String wireframeLinecap]</h3>
-		<div>Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
-
-		<h3>[property:String wireframeLinejoin]</h3>
-		<div>Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
-
-		<h3>[property:Integer vertexColors]</h3>
-		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
+		<h3>[property:String shading]</h3>
+		<div>Define shading type. Default is THREE.SmoothShading.</div>
 
 		<h3>[property:Boolean skinning]</h3>
-		<div>Define whether the material uses skinning. Default is *false*.</div>
+		<div>Define whether the material uses skinning. Default is false.</div>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<div>Define whether the material uses morphTargets. Default is *false*.</div>
+		<h3>[property:Texture specularMap]</h3>
+		<div>Specular map used by the material. Default is null.</div>
 
-		<h3>[property:boolean morphNormals]</h3>
+		<h3>[property:Boolean wireframe]</h3>
+		<div>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</div>
+
+		<h3>[property:String wireframeLinecap]</h3>
 		<div>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal attributes from the [page:Geometry]
-			to the shader. Default is *false*.
+			Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.<br /><br />
+
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2D Canvas lineCap]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
 		</div>
 
+		<h3>[property:String wireframeLinejoin]</h3>
+		<div>
+			Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.<br /><br />
+
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineJoin 2D Canvas lineJoin]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
+		</div>
+
+		<h3>[property:Float wireframeLinewidth]</h3>
+		<div>Controls wireframe thickness. Default is 1.<br /><br />
+
+		Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+		on Windows platforms linewidth will always be 1 regardless of the set value.
+		</div>
 
 		<h2>Methods</h2>
+		<div>See the base [page:Material] class for common methods.</div>
 
 		<h2>Source</h2>
 

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -130,9 +130,6 @@
 		<h3>[property:Float refractionRatio]</h3>
 		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
 
-		<h3>[property:String shading]</h3>
-		<div>Define shading type. Default is THREE.SmoothShading.</div>
-
 		<h3>[property:Boolean skinning]</h3>
 		<div>Define whether the material uses skinning. Default is false.</div>
 

--- a/docs/api/materials/MeshNormalMaterial.html
+++ b/docs/api/materials/MeshNormalMaterial.html
@@ -36,33 +36,44 @@
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>
-		parameters is an object with one or more properties defining the material's appearance.
-		</div>
-		<div>
-		wireframe -- Render geometry as wireframe. Default is false (i.e. render as smooth shaded).<br/>
-		wireframeLinewidth -- Controls wireframe thickness. Default is 1.<br/>
-		morphTargets -- Define whether the material uses morphTargets. Default is false.<br/>
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.
 		</div>
 
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
+		<h3>[property:Boolean fog]</h3>
+		<div>Whether the material is affected by fog. Default is *false*.</div>
+
+		<h3>[property:Boolean isMeshNormalMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are mesh normal materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
+		<h3>[property:Boolean lights]</h3>
+		<div>Whether the material is affected by lights. Default is *false*.</div>
+
+		<h3>[property:boolean morphTargets]</h3>
+		<div>Define whether the material uses morphTargets. Default is false.</div>
+
 		<h3>[property:boolean wireframe]</h3>
 		<div>
 			Render geometry as wireframe. Default is false (i.e. render as smooth shaded).
 		</div>
 
-		<h3>[property:number wireframeLinewidth]</h3>
-		<div>
-			Controls wireframe thickness. Default is 1.<br/><br/>
-			Due to limitations in the ANGLE layer, on Windows platforms linewidth will always be 1 regardless of the set value.
+		<h3>[property:Float wireframeLinewidth]</h3>
+		<div>Controls wireframe thickness. Default is 1.<br /><br />
+
+		Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+		on Windows platforms linewidth will always be 1 regardless of the set value.
 		</div>
 
-		<h3>[property:boolean morphTargets]</h3>
-		<div>Define whether the material uses morphTargets. Default is false.</div>
-
 		<h2>Methods</h2>
+		<div>See the base [page:Material] class for common methods.</div>
 
 
 

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -12,7 +12,12 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A material for shiny surfaces, evaluated per pixel.</div>
+		<div class="desc">
+			A material for shiny surfaces.<br />
+
+			Unlike the [page:MeshLambertMaterial] which calculate lightting per vertex and
+			interpolates in between, lighting is evaluated per pixel.
+		</div>
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshPhongMaterial"></iframe>
 
@@ -36,92 +41,32 @@
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>
-		parameters -- an object with one or more of the material's properties defining the material's appearance.
-		</div>
-		<div>
-		color — geometry color in hexadecimal. Default is 0xffffff.<br />
-		specular — Set specular color. Default is 0x111111 .<br />
-		shininess — Set shininess Default is 30.<br />
-		map — Set texture map. Default is null.<br />
-		lightMap — Set light map. Default is null.<br />
-		lightMapIntensity — Set light map intensity. Default is 1.<br />
-		aoMap — Set ao map. Default is null.<br />
-		aoMapIntensity — Set ao map intensity. Default is 1.<br />
-		emissive - Set emissive color. Default is 0x000000.<br />
-		emissiveMap — Set emissive map. Default is null.<br />
-		emissiveIntensity — Set emissive map intensity. Default is 1.<br />
-		bumpMap — Set bump map. Default is null.<br />
-		bumpScale — Set bump map scale. Default is 1.<br />
-		normalMap — Set normal map. Default is null.<br />
-		normalScale — Set normal map scale. Default is (1, 1).<br />
-		displacementMap — Set displacement map. Default is null.<br />
-		displacementScale — Set displacement scale. Default is 1.<br />
-		displacementBias — Set displacement offset. Default is 0.<br />
-		specularMap — Set specular map. Default is null.<br />
-		alphaMap — Set alpha map. Default is null.<br />
-		envMap — Set env map. Default is null.<br />
-		combine — Set combine operation. Default is THREE.MultiplyOperation.<br />
-		reflectivity — Set reflectivity. Default is 1.<br />
-		refractionRatio — Set refraction ratio. Default is 0.98.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
-		shading — Define shading type. Default is THREE.SmoothShading.<br />
-		wireframe — render geometry as wireframe. Default is false.<br />
-		wireframeLinewidth — Line thickness. Default is 1.<br />
-		wireframeLinecap — Define appearance of line ends. Default is 'round'.<br />
-		wireframeLinejoin — Define appearance of line joints. Default is 'round'.<br />
-		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
-		skinning — Define whether the material uses skinning. Default is false.<br />
-		morphTargets — Define whether the material uses morphTargets. Default is false.<br />
-		morphNormals — Define whether the material uses morphNormals. Default is false.
-		</div>
-		<div>
-		Example:<br>
-		materials.push( new THREE.MeshPhongMaterial( { color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.FlatShading } ) );
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
+			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
+			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
 		</div>
-
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
-		<h3>[property:Color color]</h3>
-		<div>
-		Diffuse color of the material. Default is white.<br />
+		<h3>[property:Texture alphaMap]</h3>
+		<div>The alpha map is a grayscale texture that controls the opacity across the surface
+			(black: fully transparent; white: fully opaque). Default is null.<br /><br />
+
+			Only the color of the texture is used, ignoring the alpha channel if one exists.
+			For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the
+			green channel when sampling this texture due to the extra bit of precision provided
+			for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
+			luminance/alpha textures will also still work as expected.
 		</div>
-
-		<h3>[property:Color specular]</h3>
-		<div>
-		Specular color of the material, i.e., how shiny the material is and the color of its shine. Setting this the same color as the diffuse value (times some intensity) makes the material more metallic-looking; setting this to some gray makes the material look more plastic. Default is dark gray.<br />
-		</div>
-
-		<h3>[property:Float shininess]</h3>
-		<div>How shiny the specular highlight is; a higher value gives a sharper highlight. Default is *30*.</div>
-
-		<h3>[property:Texture map]</h3>
-		<div>Set color texture map. Default is null. The texture map color is modulated by the diffuse color.</div>
-
-		<h3>[property:Texture lightMap]</h3>
-		<div>Set light map. Default is null. The lightMap requires a second set of UVs.</div>
-
-		<h3>[property:Float lightMapIntensity]</h3>
-		<div>TODO</div>
 
 		<h3>[property:Texture aoMap]</h3>
-		<div>Set ambient occlusion map. Default is null. The aoMap requires a second set of UVs.</div>
+		<div>The ambient occlusion map. Default is null.</div>
 
 		<h3>[property:Float aoMapIntensity]</h3>
-		<div>TODO</div>
-
-		<h3>[property:Color emissive]</h3>
-		<div>
-		Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
-		</div>
-
-		<h3>[property:Texture emissiveMap]</h3>
-		<div>Set emisssive (glow) map. Default is null. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.</div>
-
-		<h3>[property:Float emissiveIntensity]</h3>
-		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
+		<div>Intensity of the ambient occlusion effect. Default is 1. Zero is no occlusion effect.</div>
 
 		<h3>[property:Texture bumpMap]</h3>
 		<div>
@@ -131,9 +76,87 @@
 		</div>
 
 		<h3>[property:Float bumpScale]</h3>
+		<div>How much the bump map affects the material. Typical ranges are 0-1. Default is 1.</div>
+
+
+		<h3>[property:Color color]</h3>
+		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
+
+		<h3>[property:Integer combine]</h3>
 		<div>
-			How much the bump map affects the material. Typical ranges are 0-1. Default is 1.
+			How to combine the result of the surface's color with the environment map, if any.<br /><br />
+
+			Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation],
+			[page:Materials THREE.AddOperation]. If mix is chosen, the [page:.reflectivity] is used to
+			blend between the two colors.
 		</div>
+
+		<h3>[property:Texture displacementMap]</h3>
+		<div>
+			The displacement map affects the position of the mesh's vertices. Unlike other maps
+			which only affect the light and shade of the material the displaced vertices can cast shadows,
+			block other objects, and otherwise act as real geometry. The displacement texture is
+			an image where the value of each pixel (white being the highest) is mapped against,
+			and repositions, the vertices of the mesh.
+		</div>
+
+		<h3>[property:Float displacementScale]</h3>
+		<div>
+			How much the displacement map affects the mesh (where black is no displacement,
+			and white is maximum displacement). Without a displacement map set, this value is not applied.
+			 Default is 1.
+		</div>
+
+		<h3>[property:Float displacementBias]</h3>
+		<div>
+			The offset of the displacement map's values on the mesh's vertices.
+			Without a displacement map set, this value is not applied. Default is 0.
+		</div>
+
+		<h3>[property:Color emissive]</h3>
+		<div>
+		Emissive (light) color of the material, essentially a solid color unaffected by other lighting.
+		Default is black.
+		</div>
+
+		<h3>[property:Texture emissiveMap]</h3>
+		<div>
+		Set emisssive (glow) map. Default is null. The emissive map color is modulated by
+		the emissive color and the emissive intensity. If you have an emissive map, be sure to
+		set the emissive color to something other than black.
+		</div>
+
+		<h3>[property:Float emissiveIntensity]</h3>
+		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
+
+		<h3>[property:TextureCube envMap]</h3>
+		<div>The environment map. Default is null.</div>
+
+		<h3>[property:Boolean isMeshPhongMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are mesh Phong materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
+
+		<h3>[property:Texture lightMap]</h3>
+		<div>The light map. Default is null. The lightMap requires a second set of UVs.</div>
+
+		<h3>[property:Float lightMapIntensity]</h3>
+		<div>Intensity of the baked light. Default is 1.</div>
+
+		<h3>[property:Texture map]</h3>
+		<div>The color map. Default is null. The texture map color is modulated by the diffuse [page:.color].</div>
+
+		<h3>[property:boolean morphNormals]</h3>
+		<div>
+			Defines whether the material uses morphNormals. Set as true to pass morphNormal
+			attributes from the [page:Geometry]	to the shader. Default is *false*.
+		</div>
+
+		<h3>[property:Boolean morphTargets]</h3>
+		<div>Define whether the material uses morphTargets. Default is false.</div>
 
 		<h3>[property:Texture normalMap]</h3>
 		<div>
@@ -143,87 +166,70 @@
 
 		<h3>[property:Vector2 normalScale]</h3>
 		<div>
-			How much the normal map affects the material. Typical ranges are 0-1. Default is (1,1).
+			How much the normal map affects the material. Typical ranges are 0-1.
+			Default is a [page:Vector2] set to (1,1).
 		</div>
 
-		<h3>[property:Texture displacementMap]</h3>
-		<div>
-			The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry.
-			The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
-		</div>
-
-		<h3>[property:Float displacementScale]</h3>
-		<div>
-			How much the displacement map affects the mesh (where black is no displacement, and white is maximum displacement). Without a displacement map set, this value is not applied. Default is 1.
-		</div>
-
-		<h3>[property:Float displacementBias]</h3>
-		<div>
-			The offset of the displacement map's values on the mesh's vertices. Without a displacement map set, this value is not applied. Default is 0.
-		</div>
-
-		<h3>[property:Texture specularMap]</h3>
-		<div>The specular map value affects both how much the specular surface highlight contributes and how much of the environment map affects the surface. Default is null.</div>
-
-		<h3>[property:Texture alphaMap]</h3>
-		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
-		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
-
-		<h3>[property:TextureCube envMap]</h3>
-		<div>Set env map. Default is null.</div>
-
-		<h3>[property:Integer combine]</h3>
-		<div>How to combine the result of the surface's color with the environment map, if any.</div>
-
-		<div>Options are [page:Materials THREE.Multiply] (default), [page:Materials THREE.MixOperation], [page:Materials THREE.AddOperation]. If mix is chosen, the reflectivity is used to blend between the two colors.</div>
 
 		<h3>[property:Float reflectivity]</h3>
-		<div>How much the environment map affects the surface; also see "combine".</div>
+		<div>How much the environment map affects the surface; also see [page:.combine].</div>
 
 		<h3>[property:Float refractionRatio]</h3>
 		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings. Default is *true*.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
+		<h3>[property:String shading]</h3>
+		<div>Define shading type. Default is THREE.SmoothShading.</div>
 
-		<h3>[property:Integer shading]</h3>
-		<div>How the triangles of a curved surface are rendered: as a smooth surface, as flat separate facets, or no shading at all.</div>
+		<h3>[property:Float shininess]</h3>
+		<div>How shiny the [page:.specular] highlight is; a higher value gives a sharper highlight. Default is *30*.</div>
 
-		<div>Options are [page:Materials THREE.SmoothShading] (default), [page:Materials THREE.FlatShading].</div>
-
-		<h3>[property:Boolean wireframe]</h3>
-		<div>Whether the triangles' edges are displayed instead of surfaces. Default is *false*.</div>
-
-		<h3>[property:Float wireframeLinewidth]</h3>
-		<div>Line thickness for wireframe mode. Default is *1.0*.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
-
-		<h3>[property:String wireframeLinecap]</h3>
-		<div>Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
-
-		<h3>[property:String wireframeLinejoin]</h3>
-		<div>Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
-
-		<h3>[property:Integer vertexColors]</h3>
-		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
 
 		<h3>[property:Boolean skinning]</h3>
-		<div>Define whether the material uses skinning. Default is *false*.</div>
+		<div>Define whether the material uses skinning. Default is false.</div>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<div>Define whether the material uses morphTargets. Default is *false*.</div>
-
-		<h3>[property:boolean morphNormals]</h3>
+		<h3>[property:Texture specular]</h3>
 		<div>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal attributes from the [page:Geometry]
-			to the shader. Default is *false*.
+			Specular color of the material. Default is a [page:Color] set to *0x111111* (very dark grey).<br /><br />
+
+			This defines how shiny the material is and the color of its shine.
+		</div>
+
+		<h3>[property:Texture specularMap]</h3>
+		<div>
+			The specular map value affects both how much the specular surface highlight
+			contributes and how much of the environment map affects the surface. Default is null.
+		</div>
+
+		<h3>[property:Boolean wireframe]</h3>
+		<div>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</div>
+
+		<h3>[property:String wireframeLinecap]</h3>
+		<div>
+			Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.<br /><br />
+
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2D Canvas lineCap]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
+		</div>
+
+		<h3>[property:String wireframeLinejoin]</h3>
+		<div>
+			Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.<br /><br />
+
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineJoin 2D Canvas lineJoin]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
+		</div>
+
+		<h3>[property:Float wireframeLinewidth]</h3>
+		<div>Controls wireframe thickness. Default is 1.<br /><br />
+
+		Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+		on Windows platforms linewidth will always be 1 regardless of the set value.
 		</div>
 
 		<h2>Methods</h2>
+		<div>See the base [page:Material] class for common methods.</div>
+
+		<h2>Methods</h2> -->
 
 		<h2>Source</h2>
 

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -177,9 +177,6 @@
 		<h3>[property:Float refractionRatio]</h3>
 		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
 
-		<h3>[property:String shading]</h3>
-		<div>Define shading type. Default is THREE.SmoothShading.</div>
-
 		<h3>[property:Float shininess]</h3>
 		<div>How shiny the [page:.specular] highlight is; a higher value gives a sharper highlight. Default is *30*.</div>
 
@@ -228,8 +225,6 @@
 
 		<h2>Methods</h2>
 		<div>See the base [page:Material] class for common methods.</div>
-
-		<h2>Methods</h2> -->
 
 		<h2>Source</h2>
 

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -13,10 +13,20 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-			A material for shiny surfaces.<br />
+			A material for shiny surfaces with specular highlights.<br /><br />
 
-			Unlike the [page:MeshLambertMaterial] which calculate lightting per vertex and
-			interpolates in between, lighting is evaluated per pixel.
+			The uses a non-physically based [link:https://en.wikipedia.org/wiki/LBlinn-Phong_shading_model Blinn-Phong]
+			model	for calculating reflectance. Unlike the Lambertian model used in the [page:MeshLambertMaterial]
+			this can simulate shiny surfaces with specular highlights (such as varnished wood).<br /><br />
+
+			Shading is calculated using a [link:https://en.wikipedia.org/wiki/Phong_shading Phong] shading model.
+			This calculates shading per pixel (i.e. in the [link:https://en.wikipedia.org/wiki/Shader#Pixel_shaders pixel shader], AKA fragment shader)
+			which gives more accurate results than the Gouraud model used by [page:MeshLambertMaterial],
+			at the cost of some performance. The [page:MeshStandardMaterial] and [page:MeshPhysicalMaterial]
+			also use this shading model.<br /><br />
+
+			Performance will generally be greater when using this material over the	[page:MeshStandardMaterial]
+			or [page:MeshPhysicalMaterial], at the cost of some graphical accuracy.
 		</div>
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshPhongMaterial"></iframe>

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -20,8 +20,8 @@
 			this can simulate shiny surfaces with specular highlights (such as varnished wood).<br /><br />
 
 			Shading is calculated using a [link:https://en.wikipedia.org/wiki/Phong_shading Phong] shading model.
-			This calculates shading per pixel (i.e. in the [link:https://en.wikipedia.org/wiki/Shader#Pixel_shaders pixel shader], AKA fragment shader)
-			which gives more accurate results than the Gouraud model used by [page:MeshLambertMaterial],
+			This calculates shading per pixel (i.e. in the [link:https://en.wikipedia.org/wiki/Shader#Pixel_shaders fragment shader],
+			AKA pixel shader)	which gives more accurate results than the Gouraud model used by [page:MeshLambertMaterial],
 			at the cost of some performance. The [page:MeshStandardMaterial] and [page:MeshPhysicalMaterial]
 			also use this shading model.<br /><br />
 

--- a/docs/api/materials/MeshPhysicalMaterial.html
+++ b/docs/api/materials/MeshPhysicalMaterial.html
@@ -40,19 +40,16 @@
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>
-		parameters -- see [page:MeshStandardMaterial]
+		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+		Any property of the material (including any property inherited from [page:Material] and [page:MeshStandardMaterial]) can be passed in here.<br /><br />
+
+		The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
+		string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
 		</div>
 
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] and [page:MeshStandardMaterial] classes for common properties.</div>
-
-		<h3>[property:Float reflectivity]</h3>
-		<div>
-		Degree of reflectivity, from *0.0* to *1.0*. Default is *0.5*.<br />
-			
-		This models the reflectivity of non-metallic materials. It has no effect when [page:MeshStandardMaterial.metalness metalness] is *1.0*
-		</div>
 
 		<h3>[property:Float clearCoat]</h3>
 		<div>
@@ -60,9 +57,35 @@
 		</div>
 
 		<h3>[property:Float clearCoatRoughness]</h3>
+		<div>How rough the clearCoat appears, from *0.0* to *1.0*. Default is *0.0*.</div>
+
+		<h3>[property:Boolean isMeshPhysicalMaterial]</h3>
 		<div>
-		How rough the clearCoat appears, from *0.0* to *1.0*. Default is *0.0*.
+			Used to check whether this or derived classes are mesh physical materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
 		</div>
+
+		<h3>[property:Object defines]</h3>
+		<div>An object of the form:
+			<code>
+				{ 'PHYSICAL': '' };
+			</code>
+
+			This is used by the [page:WebGLRenderer] for selecting shaders.
+		</div>
+
+		<h3>[property:Float reflectivity]</h3>
+		<div>
+		Degree of reflectivity, from *0.0* to *1.0*. Default is *0.5*.<br />
+
+		This models the reflectivity of non-metallic materials. It has no effect when [page:MeshStandardMaterial.metalness metalness] is *1.0*
+		</div>
+
+		<h2>Methods</h2>
+		<h2>Properties</h2>
+		<div>See the base [page:Material] and [page:MeshStandardMaterial] classes for common methods.</div>
+
 
 		<h2>Source</h2>
 

--- a/docs/api/materials/MeshPhysicalMaterial.html
+++ b/docs/api/materials/MeshPhysicalMaterial.html
@@ -15,7 +15,7 @@
 		<div class="desc">
 			An extension of the [page:MeshStandardMaterial] that allows for greater control over reflectivity.<br /><br />
 
-			Note that for best results you should always specify a [page:.envMap environment map] when using this material.
+			Note that for best results you should always specify an [page:.envMap environment map] when using this material.
 		</div>
 
 		<!-- <iframe id="scene" src="scenes/material-browser.html#MeshStandardMaterial"></iframe>

--- a/docs/api/materials/MeshPhysicalMaterial.html
+++ b/docs/api/materials/MeshPhysicalMaterial.html
@@ -12,7 +12,11 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">An extension of the [page:MeshStandardMaterial] that allows for greater control over reflectivity.</div>
+		<div class="desc">
+			An extension of the [page:MeshStandardMaterial] that allows for greater control over reflectivity.<br /><br />
+
+			Note that for best results you should always specify a [page:.envMap environment map] when using this material.
+		</div>
 
 		<!-- <iframe id="scene" src="scenes/material-browser.html#MeshStandardMaterial"></iframe>
 

--- a/docs/api/materials/MeshStandardMaterial.html
+++ b/docs/api/materials/MeshStandardMaterial.html
@@ -12,7 +12,7 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A standard physically-based material</div>
+		<div class="desc">A standard physically-based material.</div>
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshStandardMaterial"></iframe>
 
@@ -36,94 +36,32 @@
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>
-		parameters -- an object with one or more of the material's properties defining the material's appearance.
-		</div>
-		<div>
-		color — geometry color in hexadecimal. Default is 0xffffff.<br />
-		roughness — Set roughness. Default is 0.5.<br />
-		metalness — Set metalness. Default is 0.5.<br />
-		map — Set texture map. Default is null.<br />
-		lightMap — Set light map. Default is null.<br />
-		lightMapIntensity — Set light map intensity. Default is 1.<br />
-		aoMap — Set ao map. Default is null.<br />
-		aoMapIntensity — Set ao map intensity. Default is 1.<br />
-		emissive - Set emissive color. Default is 0x000000.<br />
-		emissiveMap — Set emissive map. Default is null.<br />
-		emissiveIntensity — Set emissive map intensity. Default is 1.<br />
-		bumpMap — Set bump map. Default is null.<br />
-		bumpMapScale — Set bump map scale. Default is 1.<br />
-		normalMap — Set normal map. Default is null.<br />
-		normalScale — Set normal XY scale. Default is (1, 1).<br />
-		displacementMap — Set displacement map. Default is null.<br />
-		displacementScale — Set displacement scale. Default is 1.<br />
-		displacementBias — Set displacement offset. Default is 0.<br />
-		roughnessMap - Set roughness map. Default is null.<br />
-		metalnessMap - Set metalness map. Default is null.<br />
-		alphaMap — Set alpha map. Default is null.<br />
-		envMap — Set env map. Default is null.<br />
-		envMapIntensity — Set env map intensity. Default is 1.0.<br />
-		refractionRatio — Set refraction ratio. Default is 0.98.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
-		shading — Define shading type. Default is THREE.SmoothShading.<br />
-		wireframe — render geometry as wireframe. Default is false.<br />
-		wireframeLinewidth — Line thickness. Default is 1.<br />
-		wireframeLinecap — Define appearance of line ends. Default is 'round'.<br />
-		wireframeLinejoin — Define appearance of line joints. Default is 'round'.<br />
-		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
-		skinning — Define whether the material uses skinning. Default is false.<br />
-		morphTargets — Define whether the material uses morphTargets. Default is false.<br />
-		morphNormals — Define whether the material uses morphNormals. Default is false.
-		</div>
-		<div>
-		Example:<br>
-		materials.push( new THREE.MeshStandardMaterial( { color: 0x550000, envMap: reflectionCube, roughness: 0.1, metalness: 1.0 } ) );
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
+			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
+			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
 		</div>
-
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
-		<h3>[property:Color color]</h3>
-		<div>
-		Diffuse color of the material. Default is white.<br />
+		<h3>[property:Texture alphaMap]</h3>
+		<div>The alpha map is a grayscale texture that controls the opacity across the surface
+			(black: fully transparent; white: fully opaque). Default is null.<br /><br />
+
+			Only the color of the texture is used, ignoring the alpha channel if one exists.
+			For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the
+			green channel when sampling this texture due to the extra bit of precision provided
+			for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
+			luminance/alpha textures will also still work as expected.
 		</div>
-
-		<h3>[property:Float roughness]</h3>
-		<div>
-		How rough the material appears. 0.0 means a smooth mirror reflection, 1.0 means fully diffuse.<br />
-		</div>
-
-		<h3>[property:Float metalness]</h3>
-		<div>
-		How much the material is like a metal. Non-metallic materials such as wood or stone use 0.0, metallic use 1.0, nothing in between. A value between 0.0 and 1.0 could be used for a rusty metal look.<br />
-		</div>
-
-		<h3>[property:Texture map]</h3>
-		<div>Set color texture map. Default is null. The texture map color is modulated by the diffuse color.</div>
-
-		<h3>[property:Texture lightMap]</h3>
-		<div>Set light map, a texture that contains pre-baked diffuse lighting added to the surface. Default is null. The lightMap requires a second set of UVs.</div>
-
-		<h3>[property:Float lightMapIntensity]</h3>
-		<div>A scale factor for the light map's effect, higher being brighter.</div>
 
 		<h3>[property:Texture aoMap]</h3>
-		<div>Set ambient occlusion map, a texture that contains pre-baked darkening due to crevices on the surface. Default is null. The aoMap requires a second set of UVs.</div>
+		<div>The ambient occlusion map. Default is null.</div>
 
 		<h3>[property:Float aoMapIntensity]</h3>
-		<div>A scale factor for the ambient occlusion map's effect, higher being darker and more pronounced.</div>
-
-		<h3>[property:Color emissive]</h3>
-		<div>
-			Emissive (light) color of the material, essentially a solid color unaffected by other lighting. Default is black.<br />
-		</div>
-
-		<h3>[property:Texture emissiveMap]</h3>
-		<div>Set emisssive (glow) map. Default is null. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.</div>
-
-		<h3>[property:Float emissiveIntensity]</h3>
-		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
+		<div>Intensity of the ambient occlusion effect. Default is 1. Zero is no occlusion effect.</div>
 
 		<h3>[property:Texture bumpMap]</h3>
 		<div>
@@ -133,9 +71,98 @@
 		</div>
 
 		<h3>[property:Float bumpScale]</h3>
-		<div>
-			How much the bump map affects the material. Typical ranges are 0-1. Default is 1.
+		<div>How much the bump map affects the material. Typical ranges are 0-1. Default is 1.</div>
+
+
+		<h3>[property:Color color]</h3>
+		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
+
+		<h3>[property:Object defines]</h3>
+		<div>An object of the form:
+			<code>
+				{ 'STANDARD': '' };
+			</code>
+
+			This is used by the [page:WebGLRenderer] for selecting shaders.
 		</div>
+
+		<h3>[property:Texture displacementMap]</h3>
+		<div>
+			The displacement map affects the position of the mesh's vertices. Unlike other maps
+			which only affect the light and shade of the material the displaced vertices can cast shadows,
+			block other objects, and otherwise act as real geometry. The displacement texture is
+			an image where the value of each pixel (white being the highest) is mapped against,
+			and repositions, the vertices of the mesh.
+		</div>
+
+		<h3>[property:Float displacementScale]</h3>
+		<div>
+			How much the displacement map affects the mesh (where black is no displacement,
+			and white is maximum displacement). Without a displacement map set, this value is not applied.
+			 Default is 1.
+		</div>
+
+		<h3>[property:Float displacementBias]</h3>
+		<div>
+			The offset of the displacement map's values on the mesh's vertices.
+			Without a displacement map set, this value is not applied. Default is 0.
+		</div>
+
+		<h3>[property:Color emissive]</h3>
+		<div>
+		Emissive (light) color of the material, essentially a solid color unaffected by other lighting.
+		Default is black.
+		</div>
+
+		<h3>[property:Texture emissiveMap]</h3>
+		<div>
+		Set emisssive (glow) map. Default is null. The emissive map color is modulated by
+		the emissive color and the emissive intensity. If you have an emissive map, be sure to
+		set the emissive color to something other than black.
+		</div>
+
+		<h3>[property:Float emissiveIntensity]</h3>
+		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
+
+		<h3>[property:TextureCube envMap]</h3>
+		<div>The environment map. Default is null.</div>
+
+		<h3>[property:Float envMapIntensity]</h3>
+		<div>Scales the effect of the environment map by multiplying its color.</div>
+
+		<h3>[property:Boolean isMeshStandardMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are mesh standard materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
+
+		<h3>[property:Texture lightMap]</h3>
+		<div>The light map. Default is null. The lightMap requires a second set of UVs.</div>
+
+		<h3>[property:Float lightMapIntensity]</h3>
+		<div>Intensity of the baked light. Default is 1.</div>
+
+		<h3>[property:Texture map]</h3>
+		<div>The color map. Default is null. The texture map color is modulated by the diffuse [page:.color].</div>
+
+		<h3>[property:Float metalness]</h3>
+		<div>
+		How much the material is like a metal. Non-metallic materials such as wood or stone use 0.0, metallic use 1.0, nothing in between. A value between 0.0 and 1.0 could be used for a rusty metal look.<br />
+		</div>
+
+		<h3>[property:Texture metalnessMap]</h3>
+		<div>The red channel of this texture is used to alter the metalness of the material.</div>
+
+		<h3>[property:boolean morphNormals]</h3>
+		<div>
+			Defines whether the material uses morphNormals. Set as true to pass morphNormal
+			attributes from the [page:Geometry]	to the shader. Default is *false*.
+		</div>
+
+		<h3>[property:Boolean morphTargets]</h3>
+		<div>Define whether the material uses morphTargets. Default is false.</div>
 
 		<h3>[property:Texture normalMap]</h3>
 		<div>
@@ -145,87 +172,53 @@
 
 		<h3>[property:Vector2 normalScale]</h3>
 		<div>
-			How much the normal map affects the material. Typical ranges are 0-1. Default is (1, 1).
+			How much the normal map affects the material. Typical ranges are 0-1.
+			Default is a [page:Vector2] set to (1,1).
 		</div>
-
-		<h3>[property:Texture displacementMap]</h3>
-		<div>
-			The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry.
-			The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
-		</div>
-
-		<h3>[property:Float displacementScale]</h3>
-		<div>
-			How much the displacement map affects the mesh (where black is no displacement, and white is maximum displacement). Without a displacement map set, this value is not applied. Default is 1.
-		</div>
-
-		<h3>[property:Float displacementBias]</h3>
-		<div>
-			The offset of the displacement map's values on the mesh's vertices. Without a displacement map set, this value is not applied. Default is 0.
-		</div>
-
-		<h3>[property:Texture roughnessMap]</h3>
-		<div>The red channel of this texture is used to alter the roughness of the material.
-		</div>
-
-		<h3>[property:Texture metalnessMap]</h3>
-		<div>The red channel of this texture is used to alter the metalness of the material.
-		</div>
-
-		<h3>[property:Texture alphaMap]</h3>
-		<div>The alpha map is a grayscale texture that controls the opacity across the surface (black: fully transparent; white: fully opaque). Default is null.</div>
-		<div>Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.</div>
-
-		<h3>[property:TextureCube envMap]</h3>
-		<div>Set env map. Default is null.</div>
-
-		<h3>[property:Float envMapIntensity]</h3>
-		<div>Scales the effect of the environment map by multiplying its color.</div>
 
 		<h3>[property:Float refractionRatio]</h3>
 		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings. Default is *true*.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
+		<h3>[property:Float roughness]</h3>
+		<div>
+		How rough the material appears. 0.0 means a smooth mirror reflection, 1.0 means fully diffuse.
+		</div>
 
-		<h3>[property:Integer shading]</h3>
-		<div>How the triangles of a curved surface are rendered: as a smooth surface, as flat separate facets, or no shading at all.</div>
-
-		<div>Options are [page:Materials THREE.SmoothShading] (default), [page:Materials THREE.FlatShading].</div>
-
-		<h3>[property:Boolean wireframe]</h3>
-		<div>Whether the triangles' edges are displayed instead of surfaces. Default is *false*.</div>
-
-		<h3>[property:Float wireframeLinewidth]</h3>
-		<div>Line thickness for wireframe mode. Default is *1.0*.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
-
-		<h3>[property:String wireframeLinecap]</h3>
-		<div>Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
-
-		<h3>[property:String wireframeLinejoin]</h3>
-		<div>Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:WebGLRenderer WebGL] renderer, but does work with the [page:CanvasRenderer Canvas] renderer.</div>
-
-		<h3>[property:Integer vertexColors]</h3>
-		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
+		<h3>[property:Texture roughnessMap]</h3>
+		<div>The red channel of this texture is used to alter the roughness of the material.</div>
 
 		<h3>[property:Boolean skinning]</h3>
-		<div>Define whether the material uses skinning. Default is *false*.</div>
+		<div>Define whether the material uses skinning. Default is false.</div>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<div>Define whether the material uses morphTargets. Default is *false*.</div>
+		<h3>[property:Boolean wireframe]</h3>
+		<div>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</div>
 
-		<h3>[property:boolean morphNormals]</h3>
+		<h3>[property:String wireframeLinecap]</h3>
 		<div>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal attributes from the [page:Geometry]
-			to the shader. Default is *false*.
+			Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.<br /><br />
+
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2D Canvas lineCap]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
+		</div>
+
+		<h3>[property:String wireframeLinejoin]</h3>
+		<div>
+			Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.<br /><br />
+
+			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineJoin 2D Canvas lineJoin]
+			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
+		</div>
+
+		<h3>[property:Float wireframeLinewidth]</h3>
+		<div>Controls wireframe thickness. Default is 1.<br /><br />
+
+		Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+		on Windows platforms linewidth will always be 1 regardless of the set value.
 		</div>
 
 		<h2>Methods</h2>
+		<div>See the base [page:Material] class for common methods.</div>
+
 
 		<h2>Source</h2>
 

--- a/docs/api/materials/MeshStandardMaterial.html
+++ b/docs/api/materials/MeshStandardMaterial.html
@@ -12,7 +12,21 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A standard physically-based material.</div>
+		<div class="desc">
+			A standard physically-based material.<br /><br />
+
+			A physically based micro-faceted reflectance model is used for this material - this gives a more
+			accurate and realistic looking result than the [page:MeshLambertMaterial] or [page:MeshPhongMaterial],
+			at the cost of being more computationally expensive.<br /><br />
+
+			Shading is calculated using a [link:https://en.wikipedia.org/wiki/Phong_shading Phong] shading model.
+			This calculates shading per pixel (i.e. in the [link:https://en.wikipedia.org/wiki/Shader#Pixel_shaders pixel shader], AKA fragment shader)
+			which gives more accurate results than the Gouraud model used by [page:MeshLambertMaterial],
+			at the cost of some performance. The [page:MeshPhongMaterial] also uses this shading model.<br /><br />
+
+			Note that for best results you should always specify a [page:.envMap environment map] when using this material.
+
+		</div>
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshStandardMaterial"></iframe>
 

--- a/docs/api/materials/MeshStandardMaterial.html
+++ b/docs/api/materials/MeshStandardMaterial.html
@@ -13,19 +13,44 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-			A standard physically-based material.<br /><br />
+			A standard physically based material.<br /><br />
 
-			A physically based micro-faceted reflectance model is used for this material - this gives a more
-			accurate and realistic looking result than the [page:MeshLambertMaterial] or [page:MeshPhongMaterial],
-			at the cost of being more computationally expensive.<br /><br />
+			Physically based rendering (PBR) has recently become the standard in many 3D applications, such as
+			[link:https://blogs.unity3d.com/2014/10/29/physically-based-shading-in-unity-5-a-primer/ Unity],
+			[link:https://docs.unrealengine.com/latest/INT/Engine/Rendering/Materials/PhysicallyBased/ Unreal] and
+			[link:http://area.autodesk.com/blogs/the-3ds-max-blog/what039s-new-for-rendering-in-3ds-max-2017 3D Studio Max].<br /><br />
 
-			Shading is calculated using a [link:https://en.wikipedia.org/wiki/Phong_shading Phong] shading model.
-			This calculates shading per pixel (i.e. in the [link:https://en.wikipedia.org/wiki/Shader#Pixel_shaders pixel shader], AKA fragment shader)
-			which gives more accurate results than the Gouraud model used by [page:MeshLambertMaterial],
-			at the cost of some performance. The [page:MeshPhongMaterial] also uses this shading model.<br /><br />
+			This approach differs from older approaches in that instead of using approximations for the way in which
+			light	interacts with a surface, a physically correct model is used. The idea is that, instead of
+			tweaking materials to look good under specific lighting, a material can	be created that
+			will react 'correctly' under all lighting scenarios.<br /><br />
 
-			Note that for best results you should always specify a [page:.envMap environment map] when using this material.
+			In practice this gives a more	accurate and realistic looking result than the [page:MeshLambertMaterial]
+			or [page:MeshPhongMaterial], at the cost of being somewhat more computationally expensive.<br /><br />
 
+			Shading is calculated in the same way as for the [page:MeshPhongMaterial], using a
+			[link:https://en.wikipedia.org/wiki/Phong_shading Phong] shading model.	This calculates shading
+			per pixel (i.e. in the [link:https://en.wikipedia.org/wiki/Shader#Pixel_shaders fragment shader],
+			AKA pixel shader) which gives more accurate results than the Gouraud model used by
+			[page:MeshLambertMaterial], at the cost of some performance.<br /><br />
+
+			Note that for best results you should always specify an [page:.envMap environment map] when using
+			this material.<br /><br />
+
+			For a non-technical introduction to the concept of PBR and how to set up a PBR material,
+			check out these articles by the people at [link:https://www.marmoset.co marmoset]:
+			<ul>
+				<li>
+					[link:https://www.marmoset.co/posts/basic-theory-of-physically-based-rendering/ Basic Theory of Physically Based Rendering]
+				</li>
+				<li>
+					[link:https://www.marmoset.co/posts/physically-based-rendering-and-you-can-too/ Physically Based Rendering and You Can Too]
+				</li>
+			</ul>
+
+			Technical details of the approach used in Three (and most other PBR systems) can be found is this
+			[link:https://disney-animation.s3.amazonaws.com/library/s2012_pbs_disney_brdf_notes_v2.pdf paper from Disney] (pdf),
+			by Brent Burley.
 		</div>
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshStandardMaterial"></iframe>

--- a/docs/api/materials/MeshToonMaterial.html
+++ b/docs/api/materials/MeshToonMaterial.html
@@ -8,11 +8,11 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Material] &rarr; [page:MeshStandardMaterial] &rarr;
+		[page:Material] &rarr; [page:MeshPhongMaterial] &rarr;
 
 		<h1>[name]</h1>
 
-		<div class="desc">An extension of the [page:MeshStandardMaterial] that allows for greater control over reflectivity.</div>
+		<div class="desc">An extension of the [page:MeshPhongMaterial] with toon shading.</div>
 
 		<!-- <iframe id="scene" src="scenes/material-browser.html#MeshStandardMaterial"></iframe>
 
@@ -33,8 +33,7 @@
 		</script> -->
 
 		<h2>Examples</h2>
-		[example:webgl_materials_variations_physical materials / variations / physical]<br />
-		[example:webgl_materials_reflectivity materials / reflectivity]
+		[example:webgl_materials_variations_toon materials / variations / toon]<br />
 
 		<h2>Constructor</h2>
 
@@ -49,19 +48,14 @@
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Material] and [page:MeshStandardMaterial] classes for common properties.</div>
+		<div>See the base [page:Material] and [page:MeshPhongMaterial] classes for common properties.</div>
 
-		<h3>[property:Float clearCoat]</h3>
+		<h3>[property:Texture gradientMap]</h3>
+		<div>Gradient map for the toon shading. Default is *null*.</div>
+
+		<h3>[property:Boolean isMeshToonMaterial]</h3>
 		<div>
-		ClearCoat level, from *0.0* to *1.0*. Default is *0.0*.
-		</div>
-
-		<h3>[property:Float clearCoatRoughness]</h3>
-		<div>How rough the clearCoat appears, from *0.0* to *1.0*. Default is *0.0*.</div>
-
-		<h3>[property:Boolean isMeshPhysicalMaterial]</h3>
-		<div>
-			Used to check whether this or derived classes are mesh physical materials. Default is *true*.<br /><br />
+			Used to check whether this or derived classes are mesh toon materials. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
 		</div>
@@ -69,21 +63,15 @@
 		<h3>[property:Object defines]</h3>
 		<div>An object of the form:
 			<code>
-				{ 'PHYSICAL': '' };
+				{ 'TOON': '' };
 			</code>
 
 			This is used by the [page:WebGLRenderer] for selecting shaders.
 		</div>
 
-		<h3>[property:Float reflectivity]</h3>
-		<div>
-		Degree of reflectivity, from *0.0* to *1.0*. Default is *0.5*.<br />
-
-		This models the reflectivity of non-metallic materials. It has no effect when [page:MeshStandardMaterial.metalness metalness] is *1.0*
-		</div>
 
 		<h2>Methods</h2>
-		<div>See the base [page:Material] and [page:MeshStandardMaterial] classes for common methods.</div>
+		<div>See the base [page:Material] and [page:MeshPhongMaterial] classes for common methods.</div>
 
 
 		<h2>Source</h2>

--- a/docs/api/materials/MultiMaterial.html
+++ b/docs/api/materials/MultiMaterial.html
@@ -13,7 +13,7 @@
 		<div class="desc">
 		A Material to define multiple materials for the same geometry.
 		The geometry decides which material is used for which faces by the [page:Face3 faces materialindex].
-		The materialindex corresponds with the index of the material in the materials array.
+		The material index corresponds with the index of the material in the [page:.materials] array.
 		</div>
 
 
@@ -22,26 +22,43 @@
 
 		<h3>[name]( [page:Array materials] )</h3>
 		<div>
-		materials -- The materials for the geometry.
-		</div>
-		<div>
-		Creates a MultiMaterial with the correct materials.
+		[page:Array materials] -- an array of [page:Material Materials] to be used in the MultiMaterial.<br /><br />
+
+		Creates a new [name].
 		</div>
 
 
 		<h2>Properties</h2>
 
+		<h3>[property:Boolean isMultiMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are multi materials. Default is *true*.<br /><br />
 
+			You should not change this, as it used internally for optimisation.
+		</div>
 
 		<h3>[property:Array materials]</h3>
+		<div>An array containing the materials being used by the MultiMaterial.</div>
+
+		<h3>[property:String uuid]</h3>
 		<div>
-		Get or set the materials for the geometry.
+		[link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID] of this material instance.
+		This gets automatically assigned, so this shouldn't be edited.
 		</div>
+
+		<h3>[property:Array visible]</h3>
+		<div>Whether or not [page:Mesh meshes] using this material should be rendered.</div>
 
 		<h2>Methods</h2>
 
+		<h3>[method:MultiMaterial clone]()</h3>
+		<div>Return a clone of this MultiMaterial.</div>
 
-
+		<h3>[method:null toJSON]( [page:object meta] )</h3>
+		<div>
+		meta -- object containing metadata such as textures or images for the material.<br />
+		Convert the material to Three JSON format.
+		</div>
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/materials/MultiMaterial.html
+++ b/docs/api/materials/MultiMaterial.html
@@ -39,25 +39,25 @@
 		</div>
 
 		<code>
-			//The following will create a cube with a different material applied to each side
-			var materials = [
+//The following will create a cube with a different material applied to each side
+var materials = [
 
-					new THREE.MeshBasicMaterial( { color: 0xff0000 ) } ), // right
-					new THREE.MeshBasicMaterial( { color: 0x0000ff ) } ), // left
-					new THREE.MeshBasicMaterial( { color: 0x00ff00 ) } ), // top
-					new THREE.MeshBasicMaterial( { color: 0xffff00 ) } ), // bottom
-					new THREE.MeshBasicMaterial( { color: 0x00ffff ) } ), // back
-					new THREE.MeshBasicMaterial( { color: 0xff00ff ) } )  // front
+    new THREE.MeshBasicMaterial( { color: 0xff0000 ) } ), // right
+    new THREE.MeshBasicMaterial( { color: 0x0000ff ) } ), // left
+    new THREE.MeshBasicMaterial( { color: 0x00ff00 ) } ), // top
+    new THREE.MeshBasicMaterial( { color: 0xffff00 ) } ), // bottom
+    new THREE.MeshBasicMaterial( { color: 0x00ffff ) } ), // back
+    new THREE.MeshBasicMaterial( { color: 0xff00ff ) } )  // front
 
-			];
+];
 
-			var cubeSidesMaterial = new THREE.MultiMaterial( materials );
+var cubeSidesMaterial = new THREE.MultiMaterial( materials );
 
-			var cubeGeometry = new THREE.BoxBufferGeometry( 100, 100, 100, 1, 1, 1 );
+var cubeGeometry = new THREE.BoxBufferGeometry( 100, 100, 100, 1, 1, 1 );
 
-			var cubeMesh = new THREE.Mesh( cubeGeometry, cubeSidesMaterial );
+var cubeMesh = new THREE.Mesh( cubeGeometry, cubeSidesMaterial );
 
-			scene.add( cubeMesh );
+scene.add( cubeMesh );
 		</code>
 
 		<h2>Constructor</h2>

--- a/docs/api/materials/MultiMaterial.html
+++ b/docs/api/materials/MultiMaterial.html
@@ -16,6 +16,49 @@
 		The material index corresponds with the index of the material in the [page:.materials] array.
 		</div>
 
+		<h2>Examples</h2>
+		<div>
+			[example:webgl_animation_skinning_morph WebGL / animation / skinning / morph]<br />
+			[example:webgl_effects_parallaxbarrier WebGL / effect / parallaxbarrier]<br />
+			[example:webgl_geometry_colors_blender WebGL / geometry / colors / blender]<br />
+			[example:webgl_geometry_text_earcut WebGL / geometry / text / earcut]<br />
+			[example:webgl_geometry_text_pnltri WebGL / geometry / text / pnltri]<br />
+			[example:webgl_geometry_text WebGL / geometry / text]<br />
+			[example:webgl_loader_ctm_materials WebGL / loader / ctm / materials]<br />
+			[example:webgl_loader_json_blender WebGL / loader / json / blender]<br />
+			[example:webgl_loader_json_objconverter WebGL / loader / json / objconverter]<br />
+			[example:webgl_loader_mmd WebGL / loader / mmd]<br />
+			[example:webgl_materials_cars WebGL / materials / cars]<br />
+			[example:webgl_materials_lightmap  WebGL / materials / lightmap]<br />
+			[example:webgl_materials WebGL / materials /  / ]<br />
+			[example:webgl_nearestneighbour WebGL / nearestneighbour]<br />
+			[example:webgl_objects_update WebGL / objects / update]<br />
+			[example:webgl_panorama_cube WebGL / panorama / cube]<br />
+			[example:webgl_skinning_simple WebGL / skinning / simple]
+
+		</div>
+
+		<code>
+			//The following will create a cube with a different material applied to each side
+			var materials = [
+
+					new THREE.MeshBasicMaterial( { color: 0xff0000 ) } ), // right
+					new THREE.MeshBasicMaterial( { color: 0x0000ff ) } ), // left
+					new THREE.MeshBasicMaterial( { color: 0x00ff00 ) } ), // top
+					new THREE.MeshBasicMaterial( { color: 0xffff00 ) } ), // bottom
+					new THREE.MeshBasicMaterial( { color: 0x00ffff ) } ), // back
+					new THREE.MeshBasicMaterial( { color: 0xff00ff ) } )  // front
+
+			];
+
+			var cubeSidesMaterial = new THREE.MultiMaterial( materials );
+
+			var cubeGeometry = new THREE.BoxBufferGeometry( 100, 100, 100, 1, 1, 1 );
+
+			var cubeMesh = new THREE.Mesh( cubeGeometry, cubeSidesMaterial );
+
+			scene.add( cubeMesh );
+		</code>
 
 		<h2>Constructor</h2>
 

--- a/docs/api/materials/PointsMaterial.html
+++ b/docs/api/materials/PointsMaterial.html
@@ -33,6 +33,28 @@
 			[example:webgl_trails WebGL / trails]
 		</div>
 
+		<code>
+//This will add a starfield to the background of a scene
+var starsGeometry = new THREE.Geometry();
+
+for ( var i = 0; i < 10000; i ++ ) {
+
+	var star = new THREE.Vector3();
+	star.x = THREE.Math.randFloatSpread( 2000 );
+	star.y = THREE.Math.randFloatSpread( 2000 );
+	star.z = THREE.Math.randFloatSpread( 2000 );
+
+	geometry.vertices.push( star );
+
+}
+
+var starsMaterial = new THREE.PointsMaterial( { color: 0x888888 } )
+
+var starField = new THREE.Points( geometry, starsMaterial );
+
+scene.add( starField );
+		</code>
+
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.

--- a/docs/api/materials/PointsMaterial.html
+++ b/docs/api/materials/PointsMaterial.html
@@ -14,49 +14,59 @@
 
 		<div class="desc">The default material used by [page:Points].</div>
 
-
-		<h2>Constructor</h2>
+		<h2>Examples</h2>
+		<div>
+			[example:misc_controls_fly misc / controls / fly]<br />
+			[example:webgl_buffergeometry_drawcalls WebGL / BufferGeometry / drawcalls]<br />
+			[example:webgl_buffergeometry_points WebGL / BufferGeometry / points]<br />
+			[example:webgl_buffergeometry_points_interleaved WebGL / BufferGeometry / points / interleaved]<br />
+			[example:webgl_camera WebGL / camera ]<br />
+			[example:webgl_geometry_convex WebGL / geometry / convex]<br />
+			[example:webgl_geometry_shapes WebGL / geometry / shapes]<br />
+			[example:webgl_interactive_raycasting_points WebGL / interactive / raycasting / points]<br />
+			[example:webgl_multiple_elements_text WebGL / multiple / elements / text]<br />
+			[example:webgl_points_billboards WebGL / points / billboards]<br />
+			[example:webgl_points_billboards_colors WebGL / points / billboards / colors]<br />
+			[example:webgl_points_dynamic WebGL / points / dynamic]<br />
+			[example:webgl_points_random WebGL / points / random]<br />
+			[example:webgl_points_sprites WebGL / points / sprites]<br />
+			[example:webgl_trails WebGL / trails]
+		</div>
 
 		<h3>[name]( [page:Object parameters] )</h3>
-
-		<div>parameters is an object with one or more properties defining the material's appearance.</div>
-
 		<div>
-		color — Points color in hexadecimal. Default is 0xffffff.<br />
-		map — a [page:Texture texture].If defined, then a point has the data from texture as colors. Default is null.<br />
-		size — Define size of points. Default is 1.0.<br />
-		sizeAttenuation — Enable/disable size attenuation with distance.<br />
-		vertexColors — Define whether the material uses vertex colors, or not. Default is false.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is true.
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
+
+			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
+			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
 		</div>
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
-		<h3>[property:Number color]</h3>
+		<h3>[property:Color color]</h3>
+		<div>[page:Color] of the material, by default set to white (0xffffff).</div>
 
-		<div>Sets the color of the points. Default is 0xffffff.</div>
+		<h3>[property:Boolean isPointsMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are points materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
+		<h3>[property:Boolean lights]</h3>
+		<div>Whether the material is affected by lights. Default is *false*.</div>
 
 		<h3>[property:Texture map]</h3>
 
-		<div>Sets the color of the points using data from a texture.</div>
+		<div>Sets the color of the points using data from a [page:Texture].</div>
 
 		<h3>[property:Number size]</h3>
-
 		<div>Sets the size of the points. Default is 1.0.</div>
 
 		<h3>[property:Boolean sizeAttenuation]</h3>
-
 		<div>Specify whether points' size will get smaller with the distance. Default is true.</div>
-
-		<h3>[property:Boolean vertexColors]</h3>
-		<div>Define how the vertices gets colored. Possible values are THREE.NoColors, THREE.FaceColors and THREE.VertexColors. Default is THREE.NoColors.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
-
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings.</div>
-		<div>This setting might not have any effect when used with certain renderers. For example, it is ignored with the [page:CanvasRenderer Canvas] renderer, but does work with the [page:WebGLRenderer WebGL] renderer.</div>
-
 
 		<h2>Methods</h2>
 

--- a/docs/api/materials/RawShaderMaterial.html
+++ b/docs/api/materials/RawShaderMaterial.html
@@ -9,11 +9,61 @@
 	</head>
 	<body>
 		[page:ShaderMaterial] &rarr;
-		
+
 		<h1>[name]</h1>
 
-		<div class="desc">This class works just like [page:ShaderMaterial], except that definitions of built-in uniforms and attributes are not automatically prepended to the GLSL shader code.</div>
-		
+		<div class="desc">
+			This class works just like [page:ShaderMaterial], except that definitions of
+			built-in uniforms and attributes are not automatically prepended to the GLSL shader code.
+		</div>
+
+		<h2>Examples</h2>
+		<div>
+			[example:webgl_buffergeometry_rawshader WebGL / buffergeometry / rawshader]<br />
+			[example:webgl_buffergeometry_instancing_billboards WebGL / buffergeometry / instancing / billboards]<br />
+			[example:webgl_buffergeometry_instancing_dynamic WebGL / buffergeometry / instancing / dynamic]<br />
+			[example:webgl_buffergeometry_instancing_interleaved_dynamic WebGL / buffergeometry / instancing / interleaved / dynamic]<br />
+			[example:webgl_buffergeometry_instancing WebGL / buffergeometry / instancing]<br />
+			[example:webgl_interactive_instances_gpu WebGL / interactive / instances /gpu]<br />
+			[example:webgl_raymarching_reflect WebGL / raymarching / reflect]
+		</div>
+
+		<code>
+var material = new THREE.RawShaderMaterial( {
+
+    uniforms: {
+        time: { value: 1.0 }
+    },
+    vertexShader: document.getElementById( 'vertexShader' ).textContent,
+    fragmentShader: document.getElementById( 'fragmentShader' ).textContent,
+
+} );
+		</code>
+
+		<h2>Constructor</h2>
+
+		<h3>[name]( [page:Object parameters] )</h3>
+		<div>
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material] and [page:ShaderMaterial]) can be passed in here.<br /><br />
+		</div>
+
+
+		<h2>Properties</h2>
+		<div>See the base [page:Material] and [page:ShaderMaterial] classes for common methods.</div>
+
+		<h3>[property:Boolean isRawShaderMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are raw shader materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
+
+		<h2>Methods</h2>
+		<div>See the base [page:Material] and [page:ShaderMaterial] classes for common methods.</div>
+
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -12,7 +12,10 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">Material rendered with custom shaders. A shader is a small program written in [link:https://www.opengl.org/documentation/glsl/ GLSL] to run on the GPU. You may want to use a custom shader if you need to:
+		<div class="desc">
+			A material rendered with custom shaders. A shader is a small program written in
+			[link:https://www.khronos.org/files/opengles_shading_language.pdf_ES GLSL] that runs on the GPU.
+			You may want to use a custom shader if you need to:
 		<ul>
 			<li>implement an effect not included with any of the built-in [page:Material materials]</li>
 			<li>combine many objects into a single [page:Geometry] or [page:BufferGeometry] in order to improve performance</li>
@@ -20,13 +23,64 @@
 		There are the following notes to bear in mind when using a *ShaderMaterial*:
 
 		<ul>
-			<li>A *ShaderMaterial* will only be rendered properly by [page:WebGLRenderer], since the GLSL code in the *vertexShader* and *fragmentShader* properties must be compiled and run on the GPU using WebGL.</li>
-			<li>As of THREE r72, directly assigning attributes in a *ShaderMaterial* is no longer supported. A [page:BufferGeometry] instance (instead of a [page:Geometry] instance) must be used instead, using [page:BufferAttribute] instances to define custom attributes.</li>
-			<li>As of THREE r77, [page:WebGLRenderTarget] or [page:WebGLRenderTargetCube] instances are no longer supposed to be used as uniforms. Their [page:Texture texture] property must be used instead.</li>
+			<li>
+				A *ShaderMaterial* will only be rendered properly by [page:WebGLRenderer],
+				since the GLSL code in the [link:https://en.wikipedia.org/wiki/Shader#Vertex_shaders vertexShader]
+				and [link:https://en.wikipedia.org/wiki/Shader#Pixel_shaders fragmentShader] properties must
+				be compiled and run on the GPU using WebGL.
+			</li>
+			<li>
+				As of THREE r72, directly assigning attributes in a ShaderMaterial is no longer supported.
+				A [page:BufferGeometry] instance (instead of a [page:Geometry] instance) must be used instead,
+				using [page:BufferAttribute] instances to define custom attributes.
+			</li>
+			<li>
+				As of THREE r77, [page:WebGLRenderTarget] or [page:WebGLRenderTargetCube] instances
+				are no longer supposed to be used as uniforms. Their [page:Texture texture] property
+				must be used instead.
+			</li>
+			<li>
+				Built in attributes an uniforms are passed to the shaders along with your code.
+				If you don't want the [page:WebGLProgram] to add anything to your shader code, you can use
+				[page:RawShaderMaterial] instead of this class.
+			</li>
 		</ul>
 		</div>
 
-		<h3>Example</h3>
+		<h2>Examples</h2>
+
+		<div>
+			[example:webgl_animation_cloth webgl / animation / cloth ]<br />
+			[example:webgl_buffergeometry_custom_attributes_particles webgl / buffergeometry / custom / attributes / particles]<br />
+			[example:webgl_buffergeometry_selective_draw webgl / buffergeometry / selective / draw]<br />
+			[example:webgl_custom_attributes webgl / custom / attributes]<br />
+			[example:webgl_custom_attributes_lines webgl / custom / attributes / lines]<br />
+			[example:webgl_custom_attributes_points webgl / custom / attributes / points]<br />
+			[example:webgl_custom_attributes_points2 webgl / custom / attributes / points2]<br />
+			[example:webgl_custom_attributes_points3 webgl / custom / attributes / points3]<br />
+			[example:webgl_depth_texture webgl / depth / texture]<br />
+			[example:webgl_gpgpu_birds webgl / gpgpu / birds]<br />
+			[example:webgl_gpgpu_protoplanet webgl / gpgpu / protoplanet]<br />
+			[example:webgl_gpgpu_water webgl / gpgpu / water]<br />
+			[example:webgl_hdr webgl / hdr]<br />
+			[example:webgl_interactive_points webgl / interactive / points]<br />
+			[example:webgl_kinect webgl / kinect]<br />
+			[example:webgl_lights_hemisphere webgl / lights / hemisphere]<br />
+			[example:webgl_marchingcubes webgl / marchingcubes]<br />
+			[example:webgl_materials_bumpmap_skin webgl / materials / bumpmap / skin]<br />
+			[example:webgl_materials_envmaps webgl / materials / envmaps]<br />
+			[example:webgl_materials_lightmap webgl / materials / lightmap]<br />
+			[example:webgl_materials_parallaxmap webgl / materials / parallaxmap]<br />
+			[example:webgl_materials_shaders_fresnel webgl / materials / shaders / fresnel]<br />
+			[example:webgl_materials_skin webgl_materials / skin]<br />
+			[example:webgl_materials_texture_hdr webgl / materials / texture / hdr]<br />
+			[example:webgl_materials_wireframe webgl / materials / wireframe]<br />
+			[example:webgl_modifier_tessellation webgl / modifier / tessellation]<br />
+			[example:webgl_nearestneighbour webgl / nearestneighbour]<br />
+			[example:webgl_postprocessing_dof2 webgl / postprocessing / dof2]<br />
+			[example:webgl_postprocessing_godrays webgl / postprocessing / godrays]
+
+		</div>
 
 		<code>
 		var material = new THREE.ShaderMaterial( {
@@ -44,118 +98,180 @@
 		} );
 		</code>
 
-		<h3>Vertex shaders and fragment shaders</h3>
-		<p>You can specify two different types of shaders for each material:</p>
-		<ul>
-			<li>The *vertex shader* runs first; it receives *attributes*, calculates/manipulates the position of each individual vertex, and passes additional data (*varying*s) to the fragment shader.</li>
-			<li>The *fragment shader* runs second; it sets the color of each individual "fragment" (pixel) rendered to the screen.</li>
-		</ul>
-		<p>There are three types of variables in shaders: uniforms, attributes, and varyings:</p>
-		<ul>
-			<li>*Uniforms* are variables that have the same value for all vertices---lighting, fog, and shadow maps are examples of data that would be stored in uniforms. Uniforms can be accessed by both the vertex shader and the fragment shader.</li>
-			<li>*Attributes* are variables associated with each vertex---for instance, the vertex position, face normal, and vertex color are all examples of data that would be stored in attributes. Attributes can <em>only</em> be accessed within the vertex shader.</li>
-			<li>*Varyings* are variables that are passed from the vertex shader to the fragment shader. For each fragment, the value of each varying will be smoothly interpolated from the values of adjacent vertices.</li>
-		</ul>
-		<p>Note that <em>within</em> the shader itself, uniforms and attributes act like constants; you can only modify their values by passing different values to the buffers from your JavaScript code.</p>
-		<h3>Built-in attributes and uniforms</h3>
-		<p>
-		[page:WebGLRenderer] provides many attributes and uniforms to shaders by default; definitions of these variables are prepended to your *fragmentShader* and *vertexShader* code by [page:WebGLProgram] when the shader is compiled; you don't need to declare them yourself. These variables are described in [page:WebGLProgram].
-		</p>
-		<p>
-		Some of these uniforms or attributes (e.g. those pertaining lighting, fog, etc.) require properties to be set on the material in order for [page:WebGLRenderer] to copy the appropriate values to the GPU---make sure to set these flags if you want to use these features in your own shader.
-		</p>
-		<p>
-		If you don't want [page:WebGLProgram] to add anything to your shader code, you can use [page:RawShaderMaterial] instead of this class.
-		</p>
+		<h2>Vertex shaders and fragment shaders</h2>
 
-		<h3>Custom attributes and uniforms</h3>
-		<p>Both custom attributes and uniforms must be declared in your GLSL shader code (within *vertexShader* and/or *fragmentShader*). Custom uniforms must be defined in <em>both</em> the *uniforms* property of your *ShaderMaterial*, whereas any custom attributes must be defined via [page:BufferAttribute] instances. Note that *varying*s only need to be declared within the shader code (not within the material).
-		</p>
+		<div>
+			<p>You can specify two different types of shaders for each material:</p>
+			<ul>
+				<li>
+					The vertex shader runs first; it receives *attributes*, calculates / manipulates
+					the position of each individual vertex, and passes additional data (*varying*s) to the fragment shader.
+				</li>
+				<li>
+					The fragment ( or pixel ) shader runs second; it sets the color of each individual "fragment"
+					(pixel) rendered to the screen.
+				</li>
+			</ul>
+			<p>There are three types of variables in shaders: uniforms, attributes, and varyings:</p>
+			<ul>
+				<li>
+					*Uniforms* are variables that have the same value for all vertices - lighting, fog,
+					and shadow maps are examples of data that would be stored in uniforms.
+					Uniforms can be accessed by both the vertex shader and the fragment shader.
+				</li>
+				<li>
+					*Attributes* are variables associated with each vertex---for instance, the vertex position,
+					face normal, and vertex color are all examples of data that would be stored in attributes.
+					Attributes can <em>only</em> be accessed within the vertex shader.
+				</li>
+				<li>
+					*Varyings* are variables that are passed from the vertex shader to the fragment shader.
+					For each fragment, the value of each varying will be smoothly interpolated from the values of adjacent vertices.
+				</li>
+			</ul>
+			<p>
+				Note that <em>within</em> the shader itself, uniforms and attributes act like constants;
+				you can only modify their values by passing different values to the buffers from your JavaScript code.
+			</p>
+		</div>
 
-		<p>To declare a custom attribute, please reference the [page:BufferGeometry] page for an overview, and the [page:BufferAttribute] page for a detailed look at the *BufferAttribute* API.</p>
-		<p>When creating your attributes, each typed array that you create to hold your attribute's data must be a multiple of your data type's size. For example, if your attribute is a [page:Vector3 THREE.Vector3] type, and you have 3000 vertices in your [page:BufferGeometry], your typed array value must be created with a length of 3000 * 3, or 9000 (one value per-component). A table of each data type's size is shown below for reference:</p>
 
-		<table>
-			<caption><a id="attribute-sizes">Attribute sizes</a></caption>
-			<thead>
-				<tr>
-					<th>GLSL type</th>
-					<th>JavaScript type</th>
-					<th>Size</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>float</td>
-					<td>[page:Number]</td>
-					<td>1</td>
-				</tr>
-				<tr>
-					<td>vec2</td>
-					<td>[page:Vector2 THREE.Vector2]</td>
-					<td>2</td>
-				</tr>
-				<tr>
-					<td>vec3</td>
-					<td>[page:Vector3 THREE.Vector3]</td>
-					<td>3</td>
-				</tr>
-				<tr>
-					<td>vec3</td>
-					<td>[page:Color THREE.Color]</td>
-					<td>3</td>
-				</tr>
-				<tr>
-					<td>vec4</td>
-					<td>[page:Vector4 THREE.Vector4]</td>
-					<td>4</td>
-				</tr>
-			</tbody>
-		</table>
+	<h2>Built-in attributes and uniforms</h2>
 
-		<p>Note that attribute buffers are <em>not</em> refreshed automatically when their values change. To update custom attributes, set the *needsUpdate* flag to true on the [page:BufferAttribute] of the geometry (see [page:BufferGeometry] for further details).</p>
+	<div>
+			<p>
+			The [page:WebGLRenderer] provides many attributes and uniforms to shaders by default;
+			definitions of these variables are prepended to your *fragmentShader* and *vertexShader*
+			code by the [page:WebGLProgram] when the shader is compiled; you don't need to declare them yourself.
+			See [page:WebGLProgram] for details of these variables.
+			</p>
+			<p>
+			Some of these uniforms or attributes (e.g. those pertaining lighting, fog, etc.)
+			require properties to be set on the material in order for [page:WebGLRenderer] to copy
+			the appropriate values to the GPU - make sure to set these flags if you want to use these
+			features in your own shader.
+			</p>
+			<p>
+			If you don't want [page:WebGLProgram] to add anything to your shader code, you can use
+			[page:RawShaderMaterial] instead of this class.
+			</p>
+		</div>
 
-		<p>
-		To declare a custom [page:Uniform], use the *uniforms* property:
-		<code>
-		uniforms: {
-			time: { value: 1.0 },
-			resolution: { value: new THREE.Vector2() }
-		}
-		</code>
-		</p>
+
+		<h2>Custom attributes and uniforms</h2>
+
+		<div>
+			<p>
+				Both custom attributes and uniforms must be declared in your GLSL shader code
+				(within *vertexShader* and/or *fragmentShader*). Custom uniforms must be defined in <em>both</em>
+				the *uniforms* property of your *ShaderMaterial*, whereas any custom attributes must be
+				defined via [page:BufferAttribute] instances. Note that *varying*s only need to
+				be declared within the shader code (not within the material).
+			</p>
+			<p>
+				To declare a custom attribute, please reference the [page:BufferGeometry] page for an overview,
+				and the [page:BufferAttribute] page for a detailed look at the *BufferAttribute* API.
+			</p>
+			<p>
+				When creating your attributes, each typed array that you create to hold your
+				attribute's data must be a multiple of your data type's size. For example, if your
+				attribute is a [page:Vector3 THREE.Vector3] type, and you have 3000 vertices in your
+				[page:BufferGeometry], your typed array value must be created with a length of 3000 * 3,
+				or 9000 (one value per-component). A table of each data type's size is shown below for reference:
+			</p>
+
+			<table>
+				<caption><a id="attribute-sizes">Attribute sizes</a></caption>
+				<thead>
+					<tr>
+						<th>GLSL type</th>
+						<th>JavaScript type</th>
+						<th>Size</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>float</td>
+						<td>[page:Number]</td>
+						<td>1</td>
+					</tr>
+					<tr>
+						<td>vec2</td>
+						<td>[page:Vector2 THREE.Vector2]</td>
+						<td>2</td>
+					</tr>
+					<tr>
+						<td>vec3</td>
+						<td>[page:Vector3 THREE.Vector3]</td>
+						<td>3</td>
+					</tr>
+					<tr>
+						<td>vec3</td>
+						<td>[page:Color THREE.Color]</td>
+						<td>3</td>
+					</tr>
+					<tr>
+						<td>vec4</td>
+						<td>[page:Vector4 THREE.Vector4]</td>
+						<td>4</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<p>
+				Note that attribute buffers are <em>not</em> refreshed automatically when their values change. To update custom attributes,
+				set the *needsUpdate* flag to true on the [page:BufferAttribute] of the geometry (see [page:BufferGeometry]
+				for further details).
+			</p>
+
+			<p>
+			To declare a custom [page:Uniform], use the *uniforms* property:
+			<code>
+			uniforms: {
+				time: { value: 1.0 },
+				resolution: { value: new THREE.Vector2() }
+			}
+			</code>
+			</p>
+
+		</div>
 
 		<h2>Constructor</h2>
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>
-		parameters -- An object containing various parameters setting up shaders and their uniforms.
-		</div>
-		<div>
-		shading — Define shading type. Default is THREE.SmoothShading.<br />
-		fog — Define whether the material color is affected by global fog settings. Default is true.<br />
-		wireframe — render geometry as wireframe. Default is false.<br />
-		wireframeLinewidth — Line thickness. Default is 1.<br />
-		vertexColors — Define how the vertices gets colored. Default is THREE.NoColors.<br />
-		skinning — Define whether the material uses skinning. Default is false.<br />
-		morphTargets — Define whether the material uses morphTargets. Default is false.
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.
 		</div>
 
 		<h2>Properties</h2>
 		<div>See the base [page:Material] class for common properties.</div>
 
-		<h3>[property:Object uniforms]</h3>
+		<h3>[property:Boolean clipping]</h3>
 		<div>
-		Object specifying the uniforms to be passed to the shader code; keys are uniform names, values are definitions of the form
-		<code>
-		{ value: 1.0 }
-		</code>
-		where *value* is the value of the uniform. Names must match the name of the uniform, as defined in the GLSL code. Note that uniforms are refreshed on every frame, so updating the value of the uniform will immediately update the value available to the GLSL code.
+		Defines whether this material supports clipping; true to let the renderer pass the clippingPlanes uniform. Default is false.
 		</div>
+
+		<h3>[property:Object defaultAttributeValues]</h3>
+		<div>
+			When the rendered geometry doesn't include these attributes but the material does,
+			 these default values will be passed to the shaders. This avoids errors when buffer data is missing.
+
+			<code>
+this.defaultAttributeValues = {
+	'color': [ 1, 1, 1 ],
+	'uv': [ 0, 0 ],
+	'uv2': [ 0, 0 ]
+};
+			</code>
+
+		</div>
+
 
 		<h3>[property:Object defines]</h3>
 		<div>
-		Defines custom constants using *#define* directives within the GLSL code for both the vertex shader and the fragment shader; each key/value pair yields another directive:
+		Defines custom constants using *#define* directives within the GLSL code for both the
+		vertex shader and the fragment shader; each key/value pair yields another directive:
 		<code>
 		defines: {
 			FOO: 15,
@@ -170,56 +286,64 @@
 		in the GLSL code.
 		</div>
 
-		<h3>[property:String vertexShader]</h3>
+		<h3>[property:Object extensions]</h3>
 		<div>
-		Vertex shader GLSL code.  This is the actual code for the shader. In the example above, the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed as a string directly or loaded via AJAX instead.
+		An object with the folowing properties:
+		<code>
+this.extensions = {
+	derivatives: false, // set to use derivatives
+	fragDepth: false, // set to use fragment depth values
+	drawBuffers: false, // set to use draw buffers
+	shaderTextureLOD: false // set to use shader texture LOD
+};
+		</code>
 		</div>
+
+
+		<h3>[property:Boolean fog]</h3>
+		<div>
+			Define whether the material color is affected by global fog settings; true to pass
+			fog uniforms to the shader. Default is false.
+		</div>
+
 
 		<h3>[property:String fragmentShader]</h3>
 		<div>
-		Fragment shader GLSL code.  This is the actual code for the shader. In the example above, the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed as a string directly or loaded via AJAX instead.
+		Fragment shader GLSL code.  This is the actual code for the shader. In the example above,
+		the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed
+		as a string directly or loaded via AJAX instead.
 		</div>
 
-		<h3>[property:Number shading]</h3>
+		<h3>[property:String index0AttributeName]</h3>
 		<div>
-		Define shading type, which determines whether normals are smoothed between vertices; possible values are [page:Materials THREE.SmoothShading] or [page:Materials THREE.FlatShading]. Default is THREE.SmoothShading.
+			If set, this calls [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindAttribLocation gl.bindAttribLocation]
+			to bind a generic vertex index to an attribute variable.
+			Default is undefined.
+
 		</div>
 
-		<h3>[property:Number linewidth]</h3>
-		<div>Controls line thickness; only effective if the material is attached to a [page:Line]. Default is 1.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
-
-		<h3>[property:Boolean wireframe]</h3>
+		<h3>[property:Boolean isShaderMaterial]</h3>
 		<div>
-		Render geometry as wireframe (using GL_LINES instead of GL_TRIANGLES). Default is false (i.e. render as flat polygons).
+			Used to check whether this or derived classes are shader materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
 		</div>
 
-		<h3>[property:Number wireframeLinewidth]</h3>
-		<div>Controls wireframe thickness; only effective if the material is attached to a [page:Mesh] and *wireframe* is true. Default is 1.</div>
-		<div>Due to limitations in the <a href="https://code.google.com/p/angleproject/" target="_blank">ANGLE layer</a>, on Windows platforms linewidth will always be 1 regardless of the set value.</div>
 
-		<h3>[property:Boolean fog]</h3>
-		<div>Define whether the material color is affected by global fog settings; true to pass fog uniforms to the shader. Default is false.</div>
+
 
 		<h3>[property:Boolean lights]</h3>
 		<div>
 		Defines whether this material uses lighting; true to pass uniform data related to lighting to this shader. Default is false.
 		</div>
 
-		<h3>[property:Boolean clipping]</h3>
-		<div>
-		Defines whether this material supports clipping; true to let the renderer pass the clippingPlanes uniform. Default is false.
+		<h3>[property:Float linewidth]</h3>
+		<div>Controls wireframe thickness. Default is 1.<br /><br />
+
+		Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+		on Windows platforms linewidth will always be 1 regardless of the set value.
 		</div>
 
-		<h3>[property:Number vertexColors]</h3>
-		<div>
-		Define how the vertices are colored, by defining how the *colors* attribute gets populated. Possible values are [page:Materials THREE.NoColors], [page:Materials THREE.FaceColors] and [page:Materials THREE.VertexColors]. Default is THREE.NoColors.
-		</div>
-
-		<h3>[property:Boolean skinning]</h3>
-		<div>
-		Define whether the material uses skinning; true to pass skinning attributes to the shader. Default is false.
-		</div>
 
 		<h3>[property:Boolean morphTargets]</h3>
 		<div>
@@ -232,16 +356,79 @@
 			to the shader. Default is *false*.
 		</div>
 
+
 		<h3>[property:WebGLProgram program]</h3>
 		<div>
-		The compiled shader program associated with this material, generated by [page:WebGLRenderer]. You should not need to access this property.
+		The compiled shader program associated with this material, generated by [page:WebGLRenderer].
+		You should not need to access this property.
 		</div>
 
+		<h3>[property:Number shading]</h3>
+		<div>
+		Define shading type, which determines whether normals are smoothed between vertices;
+		possible values are [page:Materials THREE.SmoothShading] or [page:Materials THREE.FlatShading]. Default is THREE.SmoothShading.
+		</div>
+
+
+		<h3>[property:Boolean skinning]</h3>
+		<div>
+		Define whether the material uses skinning; true to pass skinning attributes to the shader. Default is false.
+		</div>
+
+		<h3>[property:Object uniforms]</h3>
+		<div>
+			An object of the form:
+			<code>
+{ "uniform1": { value: 1.0 }, "uniform2": { value: 2 } }
+			</code>
+		specifying the uniforms to be passed to the shader code; keys are uniform names, values are definitions of the form
+		<code>
+		{ value: 1.0 }
+		</code>
+		where *value* is the value of the uniform. Names must match the name of the uniform,
+		as defined in the GLSL code. Note that uniforms are refreshed on every frame,
+		so updating the value of the uniform will immediately update the value available to the GLSL code.
+		</div>
+
+
+		<h3>[property:Number vertexColors]</h3>
+		<div>
+		Define how the vertices are colored, by defining how the *colors* attribute gets populated.
+		Possible values are [page:Materials THREE.NoColors], [page:Materials THREE.FaceColors] and
+		[page:Materials THREE.VertexColors]. Default is THREE.NoColors.
+		</div>
+
+		<h3>[property:String vertexShader]</h3>
+		<div>
+		Vertex shader GLSL code.  This is the actual code for the shader. In the example above,
+		the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed
+		as a string directly or loaded via AJAX instead.
+		</div>
+
+		<h3>[property:Boolean wireframe]</h3>
+		<div>
+		Render geometry as wireframe (using GL_LINES instead of GL_TRIANGLES). Default is false (i.e. render as flat polygons).
+		</div>
+
+		<h3>[property:Float wireframeLinewidth]</h3>
+		<div>Controls wireframe thickness. Default is 1.<br /><br />
+
+		Due to limitations in the [link:https://code.google.com/p/angleproject ANGLE layer],
+		on Windows platforms linewidth will always be 1 regardless of the set value.
+		</div>
+
+
+
 		<h2>Methods</h2>
+		<div>See the base [page:Material] class for common methods.</div>
 
 		<h3>[method:ShaderMaterial clone]() [page:ShaderMaterial this]</h3>
 		<div>
-		Generates a shallow copy of this material. Note that the vertexShader and fragmentShader are copied <em>by reference</em>, as are the definitions of the *attributes*; this means that clones of the material will share the same compiled [page:WebGLProgram]. However, the *uniforms* are copied <em>by value</em>, which allows you to have different sets of uniforms for different copies of the material.
+		Generates a shallow copy of this material. Note that the vertexShader and fragmentShader
+		are copied <em>by reference</em>, as are the definitions of the *attributes*; this means
+		that clones of the material will share the same compiled [page:WebGLProgram]. However, the
+		*uniforms* are copied <em>by value</em>, which allows you to have different sets of uniforms
+		for different copies of the material.
 		</div>
 
 		<h2>Source</h2>

--- a/docs/api/materials/ShadowMaterial.html
+++ b/docs/api/materials/ShadowMaterial.html
@@ -40,6 +40,13 @@ scene.add( plane );
 		<h2>Properties</h2>
 		<div>See the base [page:Material] and [page:ShaderMaterial] classes for common properties.</div>
 
+		<h3>[property:Boolean isShadowMaterial]</h3>
+		<div>
+			Used to check whether this or derived classes are shadow materials. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
 		<h3>[property:Boolean lights]</h3>
 		<div>Whether the material is affected by lights. Default is *true*.</div>
 

--- a/docs/api/materials/SpriteMaterial.html
+++ b/docs/api/materials/SpriteMaterial.html
@@ -12,21 +12,38 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A material for a [page:Sprite].</div>
+		<div class="desc">A material for a use with a [page:Sprite].</div>
 
+		<h2>Examples</h2>
+		<div>
+			[example:webgl_sprites WebGL / sprites]<br />
+			[example:misc_ubiquity_test misc / ubiquity / test]<br />
+			[example:misc_ubiquity_test2 misc / ubiquity / test2]<br />
+			[example:software_sandbox software / sandbox]<br />
+			[example:svg_sandbox svg / sandbox]<br />
+			[example:webgl_materials_cubemap_dynamic webgl / materials / cubemap / dynamic]
+		</div>
 
-		<h2>Constructor</h2>
+		<code>
+var spriteMap = new THREE.TextureLoader().load( 'textures/sprite.png' );
+
+var spriteMaterial = new THREE.SpriteMaterial( { map: spriteMap, color: 0xffffff } );
+
+var sprite = new THREE.Sprite( spriteMaterial );
+sprite.scale.set(200, 200, 1)
+
+scene.add( sprite );
+
+		</code>
 
 
 		<h3>[name]( [page:Object parameters] )</h3>
 		<div>
-		parameters -- an object defining the the default properties
-		</div>
-		<div>
-		color - color of the sprite<br/>
-		map - the texture map<br/>
-		rotation - the rotation of the sprite<br/>
-		fog - whether or not to use the scene fog<br/>
+			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
+
+			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
+			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
 		</div>
 
 
@@ -34,7 +51,13 @@
 		<div>See the base [page:Material] class for common properties.</div>
 
 		<h3>[property:Color color]</h3>
-		<div>The texture is multiplied by this color. The default is 0xffffff</div>
+		<div>[page:Color] of the material, by default set to white (0xffffff). The [page:.map] is mutiplied by the color.</div>
+
+		<h3>[property:boolean fog]</h3>
+		<div>Whether or not this material affected by the scene's fog. Default is false</div>
+
+		<h3>[property:Boolean lights]</h3>
+		<div>Whether the material is affected by lights. Default is *false*.</div>
 
 		<h3>[property:Texture map]</h3>
 		<div>The texture map. Default is null.</div>
@@ -42,8 +65,8 @@
 		<h3>[property:Radians rotation]</h3>
 		<div>The rotation of the sprite in radians. Default is 0.</div>
 
-		<h3>[property:boolean fog]</h3>
-		<div>Whether or not this material affected by the scene's fog. Default is false</div>
+		<h2>Methods</h2>
+		<div>See the base [page:Material]  class for common methods.</div>
 
 		<h2>Source</h2>
 

--- a/docs/list.js
+++ b/docs/list.js
@@ -226,6 +226,7 @@ var list = {
 			[ "MeshPhongMaterial", "api/materials/MeshPhongMaterial" ],
 			[ "MeshPhysicalMaterial", "api/materials/MeshPhysicalMaterial" ],
 			[ "MeshStandardMaterial", "api/materials/MeshStandardMaterial" ],
+			[ "MeshToonMaterial", "api/materials/MeshToonMaterial" ],
 			[ "MultiMaterial", "api/materials/MultiMaterial" ],
 			[ "PointsMaterial", "api/materials/PointsMaterial" ],
 			[ "RawShaderMaterial", "api/materials/RawShaderMaterial" ],


### PR DESCRIPTION
Created documentation for MeshToonMaterial 


Material:
- alphabetized properties and methods
- added missing properties:
-- blendEquationAlpha
-- blendSrcAlpha
-- isMaterial
-- uuid
- added missing copy() method

LineBasicMaterial 
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added example links and code
- added missing properties:
-- isLineBasicMaterial
-- lights
- removed properties defined in Material (and with identical defaults)
-- fog
-- vertexColors

LineDashedMaterial 
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- updated example code and added links
- added missing properties:
-- isLineDashedMaterial
-- lights
- removed properties defined in Material (and with identical defaults)
-- fog
-- vertexColors

MeshBasicMaterial 
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isMeshBasicMaterial
- removed properties defined in Material (and with identical defaults)
-- fog
-- vertexColors

MeshDepthMaterial 
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isMeshDepthMaterial
-- depthPacking
-- displacementMap
-- displacementMapBias
-- displacementMapScale
-- lights
-- map
-- skinning
- removed properties defined in Material (and with identical defaults)
-- vertexColors

MeshL


MeshDepthMaterial 
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isMeshDepthMaterial
-- depthPacking
-- displacementMap
-- displacementMapBias
-- displacementMapScale
-- lights
-- map
-- skinning
- removed properties defined in Material (and with identical defaults)
-- vertexColors

MeshLambertMaterial 
- updated description, see #10235
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isMeshLambertMaterial
- removed properties defined in Material (and with identical defaults)
-- fog
-- vertexColors

MeshNormaMaterial 
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isMeshNormalMaterial
-- lights

MeshPhongMaterial 
- updated description, see #10235
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isMeshPhongMaterial
- removed properties defined in Material (and with identical defaults)
-- fog
-- vertexColors

MeshPhysicalMaterial 
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isMeshPhysicalMaterial

MeshStandardMaterial 
- updated description, see #10235
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isMeshPhongMaterial
- removed properties defined in Material (and with identical defaults)
-- fog
-- vertexColors

MultiMaterial 
- added example links and code
- added missing properties:
-- isMeshPhongMaterial
-- uuid
-- visible
- added missing methods:
-- clone()
-- toJSON()

PointsMaterial 
- added example links and code
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isPointsMaterial
- removed properties defined in Material (and with identical defaults)
-- fog
-- vertexColors

RawShaderMaterial 
- added example links and code
- alphabetized properties and methods
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- isRawShaderMaterial

ShaderMaterial
- alphabetized properties and methods
- added example links 
- reformatted 
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- defaultAttributeValues 
-- extensions
-- isShaderMaterial

ShadowMaterial
- added missing properties:
-- isShadowMaterial

SpriteMaterial 
- added example links and code
- updated constructor to note that any property of this or Material can be passed in directly
- added missing properties:
-- lights

