### PR TITLE
allow to look around by drag when activeLook = false

### DIFF
--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -214,7 +214,7 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 
 		var actualLookSpeed = delta * this.lookSpeed;
 
-		if ( ! this.activeLook ) {
+		if ( ! ( this.activeLook || this.mouseDragOn ) ) {
 
 			actualLookSpeed = 0;
 


### PR DESCRIPTION
atm FirstPersonControls are in drunk mode by defult and, if you set activeLook to false, you cant turn your head at all. mouse drag flag is there but not used - this fixes it.