### PR TITLE
:zap: fog rendering for ShaderTerrain

### DIFF
--- a/examples/js/ShaderTerrain.js
+++ b/examples/js/ShaderTerrain.js
@@ -237,9 +237,9 @@ THREE.ShaderTerrain = {
 
 				"outgoingLight += diffuseColor.xyz * ( totalDiffuseLight + ambientLightColor + totalSpecularLight );",
 
-				THREE.ShaderChunk[ "fog_fragment" ],
-
 				"gl_FragColor = vec4( outgoingLight, diffuseColor.a );",	// TODO, this should be pre-multiplied to allow for bright highlights on very transparent objects
+
+				THREE.ShaderChunk[ "fog_fragment" ],
 
 			"}"
 


### PR DESCRIPTION
Simple re-ordering of shader fragments to allow the fog to render on a ShaderTerrain. 

Basically from this: 
http://rawgit.com/tracend/three.js/6c2627ad2f910b17e1ea8205f471134322d01365/examples/webgl_terrain_dynamic.html

to this: 
http://rawgit.com/tracend/three.js/b396f66d42f1c44e18d57cb8c91998ebff182f5d/examples/webgl_terrain_dynamic.html
