### PR TITLE
Fix example reference in SpotLight docs

### DIFF
--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -55,7 +55,7 @@
 		[example:webgl_materials_bumpmap materials / bumpmap]<br/>
 		[example:webgl_shading_physical shading / physical]<br/>
 		[example:webgl_shadowmap shadowmap]<br/>
-		[example:webgl_shadowmap_viewer shadowmap / performance]<br/>
+		[example:webgl_shadowmap_performance shadowmap / performance]<br/>
 		[example:webgl_shadowmap_viewer shadowmap / viewer]
 		</div>
 


### PR DESCRIPTION
Fix reference to the webgl_shadowmap_performance example