### PR TITLE
Expose when, offset and duration parameters in Audio.play()

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -62,7 +62,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	},
 
-	play: function () {
+	play: function ( when, offset, duration ) {
 
 		if ( this.isPlaying === true ) {
 
@@ -78,13 +78,21 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
+		if ( when === undefined ) when = 0;
+		this.startTime = offset !== undefined ? offset : this.startTime;
+
 		var source = this.context.createBufferSource();
 
 		source.buffer = this.buffer;
 		source.loop = this.loop;
 		source.onended = this.onEnded.bind( this );
 		source.playbackRate.setValueAtTime( this.playbackRate, this.startTime );
-		source.start( 0, this.startTime );
+		
+		if ( duration === undefined ) {
+			source.start( when, this.startTime );
+		} else {
+			source.start( when, this.startTime, duration );
+		}
 
 		this.isPlaying = true;
 


### PR DESCRIPTION
I tried to implemented audio sprites on top of three.js but doing so requires setting the arguments of  `AudioBufferSourceNode.start(when, offset, duration)`, especially `offset` and `duration`.

It would be possible to change the `Audio.startTime` property to influence to offset passed to `start()` but `duration` isn't currently passed at all.

This pull request exposes all three parameters of `start()` – `when`, `offset` and `duration` as parameters of `Audio.play()`.

I don't need `when` for audio sprites but it seemed more consistent to expose all three parameters together. Alternatively, only `duration` could be exposed and I could set `this.startTime` before calling `play()`.