### PR TITLE
Add "set" functions to allow changes to viewport and scissoring

### DIFF
--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -77,6 +77,14 @@
 				pickingTexture = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight );
 				pickingTexture.texture.minFilter = THREE.LinearFilter;
 
+				// set the scissor test for the off-screen render target (also see the scissor set command in the "pick()" render loop)
+				pickingTexture.scissorTest = true;
+
+				// TODO: After adding scissor methods to the "WebGLRenderTarget" object, the above line should be:
+				// pickingTexture.setScissorTest(true);
+				// This use of the "setScissorTest" method on the WebGLRenderTarget mirrors the "setScissorTest" method of the WebGLRenderer, which does not apply the scissor to the non-null render target
+
+
 				scene.add( new THREE.AmbientLight( 0x555555 ) );
 
 				var light = new THREE.SpotLight( 0xffffff, 1.5 );
@@ -197,8 +205,14 @@
 
 			function pick() {
 
-				//render the picking scene off-screen
+				// set the scissor on the off-screen render target to the pixel under the mouse (that will be picked) - this disables the fragment shader for the pixels that will not be picked (reducing rendering time)
+				pickingTexture.scissor.set(mouse.x, pickingTexture.height - mouse.y, 1, 1);
 
+				// TODO: After adding scissor methods to the "WebGLRenderTarget" object, the above line should be:
+				// pickingTexture.setScissor(mouse.x, pickingTexture.height - mouse.y, 1, 1);
+				// This use of the "setScissor" method on the WebGLRenderTarget mirrors the "setScissor" method of the WebGLRenderer, which does not apply the scissor to the non-null render target
+
+				//render the picking scene off-screen
 				renderer.render( pickingScene, camera, pickingTexture );
 
 				//create buffer for reading single pixel

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -59,6 +59,24 @@ Object.assign( WebGLRenderTarget.prototype, EventDispatcher.prototype, {
 
 	},
 
+	setViewport: function ( x, y, width, height ) {
+
+		this.viewport.set( x, y, width, height );
+
+	},
+
+	setScissor: function ( x, y, width, height ) {
+
+		this.scissor.set( x, y, width, height );
+
+	},
+
+	setScissorTest: function ( boolean ) {
+
+		this.setScissorTest = boolean;
+
+	},
+
 	clone: function () {
 
 		return new this.constructor().copy( this );


### PR DESCRIPTION
Adding the ability to set scissoring (and viewport) to `WebGLRenderTarget`, as currently the `setRenderTarget` method of `WebGLRenderer` uses the original values for `scissor` and `scissorTest` and `WebGLRenderTarget` provides no methods to change them (although the properties are not private).

This change allows the use of `myWebGLRenderTarget.setScissor(x, y, width, height);` instead of having to call `myWebGLRenderTarget.scissor.set(x, y, width, height);` before any `myWebGLRenderer.render(scene, camera, myWebGLRenderTarget);` (otherwise the scissor for the originally created render target overwrites the context scisssor every render).

Using scissoring in my off-screen render target gains significant FPS when I render a scene for pixel-picking and I only care about one pixel or a few pixels e.g. under the mouse pointer. I simply update a vector of mouse X & Y coordinates `onmousemove` and pass these as `x` & `y` to `myWebGLRenderTarget.scissorSet(x, y, 1, 1);` before `myWebGLRenderer.render(myPickSceneWithObjectIDsEncodedInFragColor, camera, myWebGLRenderTarget)`, with the obvious `myWebGLRenderer.readRenderTargetPixels(myWebGLRenderTarget, x, y, 1, 1, pickPixel);` using the same `x` & `y`. Whilst this example changes the scissor every render pass, it seems better to use the same scissoring methods against the render target as I do against the renderer.