### PR TITLE
NodeMaterial update

### DIFF
--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -82,7 +82,9 @@ THREE.NodeMaterial.prototype.build = function() {
 	this.uniforms = {};
 	this.attributes = {};
 
-	this.nodeData = {};
+	this.extensions = {};
+
+	this.nodeData = {};	
 
 	this.vertexUniform = [];
 	this.fragmentUniform = [];
@@ -115,21 +117,24 @@ THREE.NodeMaterial.prototype.build = function() {
 	this.prefixCode = [
 	"#ifdef GL_EXT_shader_texture_lod",
 
-		"#define texCube(a, b) textureCube(a, b)",
-		"#define texCubeBias(a, b, c) textureCubeLodEXT(a, b, c)",
+	"	#define texCube(a, b) textureCube(a, b)",
+	"	#define texCubeBias(a, b, c) textureCubeLodEXT(a, b, c)",
 
-		"#define tex2D(a, b) texture2D(a, b)",
-		"#define tex2DBias(a, b, c) texture2DLodEXT(a, b, c)",
+	"	#define tex2D(a, b) texture2D(a, b)",
+	"	#define tex2DBias(a, b, c) texture2DLodEXT(a, b, c)",
 
 	"#else",
 
-		"#define texCube(a, b) textureCube(a, b)",
-		"#define texCubeBias(a, b, c) textureCube(a, b, c)",
+	"	#define texCube(a, b) textureCube(a, b)",
+	"	#define texCubeBias(a, b, c) textureCube(a, b, c)",
 
-		"#define tex2D(a, b) texture2D(a, b)",
-		"#define tex2DBias(a, b, c) texture2D(a, b, c)",
+	"	#define tex2D(a, b) texture2D(a, b)",
+	"	#define tex2DBias(a, b, c) texture2D(a, b, c)",
 
-	"#endif"
+	"#endif",
+
+	"#include <packing>"
+
 	].join( "\n" );
 
 	var builder = new THREE.NodeBuilder( this );

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -212,7 +212,7 @@ THREE.NodeMaterial.prototype.build = function() {
 	}
 
 	this.lights = this.requestAttribs.light;
-	this.transparent = this.requestAttribs.transparent || this.blendMode > THREE.NormalBlending;
+	this.transparent = this.requestAttribs.transparent || this.blending > THREE.NormalBlending;
 
 	this.vertexShader = [
 		this.prefixCode,

--- a/examples/js/nodes/TempNode.js
+++ b/examples/js/nodes/TempNode.js
@@ -49,6 +49,12 @@ THREE.TempNode.prototype.build = function( builder, output, uuid, ns ) {
 
 			return THREE.GLNode.prototype.build.call( this, builder, output, uuid );
 
+		} else if ( isUnique ) {
+
+			data.name = data.name || THREE.GLNode.prototype.build.call( this, builder, output, uuid )
+
+			return data.name;
+
 		} else if ( ! builder.optimize || data.deps == 1 ) {
 
 			return THREE.GLNode.prototype.build.call( this, builder, output, uuid );

--- a/examples/js/nodes/materials/PhongNode.js
+++ b/examples/js/nodes/materials/PhongNode.js
@@ -32,7 +32,6 @@ THREE.PhongNode.prototype.build = function( builder ) {
 		material.mergeUniform( Object.assign( {},
 
 			THREE.UniformsLib[ "fog" ],
-			THREE.UniformsLib[ "ambient" ],
 			THREE.UniformsLib[ "lights" ]
 
 		) );
@@ -93,8 +92,7 @@ THREE.PhongNode.prototype.build = function( builder ) {
 
 		code = output.join( "\n" );
 
-	}
-	else {
+	} else {
 
 		// parse all nodes to reuse generate codes
 
@@ -103,16 +101,16 @@ THREE.PhongNode.prototype.build = function( builder ) {
 		this.shininess.parse( builder );
 
 		if ( this.alpha ) this.alpha.parse( builder );
-
+		
+		if ( this.normal ) this.normal.parse( builder );
+		if ( this.normalScale && this.normal ) this.normalScale.parse( builder );
+		
 		if ( this.light ) this.light.parse( builder, { cache : 'light' } );
 
 		if ( this.ao ) this.ao.parse( builder );
 		if ( this.ambient ) this.ambient.parse( builder );
 		if ( this.shadow ) this.shadow.parse( builder );
 		if ( this.emissive ) this.emissive.parse( builder, { slot : 'emissive' } );
-
-		if ( this.normal ) this.normal.parse( builder );
-		if ( this.normalScale && this.normal ) this.normalScale.parse( builder );
 
 		if ( this.environment ) this.environment.parse( builder, { slot : 'environment' } );
 		if ( this.environmentAlpha && this.environment ) this.environmentAlpha.parse( builder );
@@ -124,16 +122,16 @@ THREE.PhongNode.prototype.build = function( builder ) {
 		var shininess = this.shininess.buildCode( builder, 'fv1' );
 
 		var alpha = this.alpha ? this.alpha.buildCode( builder, 'fv1' ) : undefined;
-
+		
+		var normal = this.normal ? this.normal.buildCode( builder, 'v3' ) : undefined;
+		var normalScale = this.normalScale && this.normal ? this.normalScale.buildCode( builder, 'v2' ) : undefined;
+		
 		var light = this.light ? this.light.buildCode( builder, 'v3', { cache : 'light' } ) : undefined;
 
 		var ao = this.ao ? this.ao.buildCode( builder, 'fv1' ) : undefined;
 		var ambient = this.ambient ? this.ambient.buildCode( builder, 'c' ) : undefined;
 		var shadow = this.shadow ? this.shadow.buildCode( builder, 'c' ) : undefined;
 		var emissive = this.emissive ? this.emissive.buildCode( builder, 'c', { slot : 'emissive' } ) : undefined;
-
-		var normal = this.normal ? this.normal.buildCode( builder, 'v3' ) : undefined;
-		var normalScale = this.normalScale && this.normal ? this.normalScale.buildCode( builder, 'v2' ) : undefined;
 
 		var environment = this.environment ? this.environment.buildCode( builder, 'c', { slot : 'environment' } ) : undefined;
 		var environmentAlpha = this.environmentAlpha && this.environment ? this.environmentAlpha.buildCode( builder, 'fv1' ) : undefined;
@@ -278,8 +276,7 @@ THREE.PhongNode.prototype.build = function( builder ) {
 					"outgoingLight = mix( outgoingLight, " + environment.result + ", " + environmentAlpha.result + " );"
 				);
 
-			}
-			else {
+			} else {
 
 				output.push( "outgoingLight = " + environment.result + ";" );
 
@@ -291,8 +288,7 @@ THREE.PhongNode.prototype.build = function( builder ) {
 
 			output.push( "gl_FragColor = vec4( outgoingLight, " + alpha.result + " );" );
 
-		}
-		else {
+		} else {
 
 			output.push( "gl_FragColor = vec4( outgoingLight, 1.0 );" );
 

--- a/examples/js/nodes/materials/StandardNode.js
+++ b/examples/js/nodes/materials/StandardNode.js
@@ -20,11 +20,15 @@ THREE.StandardNode.prototype.build = function( builder ) {
 	var material = builder.material;
 	var code;
 
-	material.define( 'STANDARD' );
 	material.define( 'PHYSICAL' );
+
+	if ( !this.clearCoat && !this.clearCoatRoughness ) material.define( 'STANDARD' );
+
 	material.define( 'ALPHATEST', '0.0' );
 
 	material.requestAttribs.light = true;
+
+	material.extensions.shaderTextureLOD = true;
 
 	if ( builder.isShader( 'vertex' ) ) {
 
@@ -33,7 +37,6 @@ THREE.StandardNode.prototype.build = function( builder ) {
 		material.mergeUniform( Object.assign( {},
 
 			THREE.UniformsLib[ "fog" ],
-			THREE.UniformsLib[ "ambient" ],
 			THREE.UniformsLib[ "lights" ]
 
 		) );
@@ -56,11 +59,11 @@ THREE.StandardNode.prototype.build = function( builder ) {
 		].join( "\n" ) );
 
 		var output = [
-				THREE.ShaderChunk[ "beginnormal_vertex" ],
-				THREE.ShaderChunk[ "morphnormal_vertex" ],
-				THREE.ShaderChunk[ "skinbase_vertex" ],
-				THREE.ShaderChunk[ "skinnormal_vertex" ],
-				THREE.ShaderChunk[ "defaultnormal_vertex" ],
+			THREE.ShaderChunk[ "beginnormal_vertex" ],
+			THREE.ShaderChunk[ "morphnormal_vertex" ],
+			THREE.ShaderChunk[ "skinbase_vertex" ],
+			THREE.ShaderChunk[ "skinnormal_vertex" ],
+			THREE.ShaderChunk[ "defaultnormal_vertex" ],
 
 			"#ifndef FLAT_SHADED", // Normal computed with derivatives when FLAT_SHADED
 
@@ -68,7 +71,7 @@ THREE.StandardNode.prototype.build = function( builder ) {
 
 			"#endif",
 
-				THREE.ShaderChunk[ "begin_vertex" ]
+			THREE.ShaderChunk[ "begin_vertex" ]
 		];
 
 		if ( transform ) {
@@ -81,21 +84,20 @@ THREE.StandardNode.prototype.build = function( builder ) {
 		}
 
 		output.push(
-				THREE.ShaderChunk[ "morphtarget_vertex" ],
-				THREE.ShaderChunk[ "skinning_vertex" ],
-				THREE.ShaderChunk[ "project_vertex" ],
-				THREE.ShaderChunk[ "logdepthbuf_vertex" ],
+			THREE.ShaderChunk[ "morphtarget_vertex" ],
+			THREE.ShaderChunk[ "skinning_vertex" ],
+			THREE.ShaderChunk[ "project_vertex" ],
+			THREE.ShaderChunk[ "logdepthbuf_vertex" ],
 
 			"	vViewPosition = - mvPosition.xyz;",
 
-				THREE.ShaderChunk[ "worldpos_vertex" ],
-				THREE.ShaderChunk[ "shadowmap_vertex" ]
+			THREE.ShaderChunk[ "worldpos_vertex" ],
+			THREE.ShaderChunk[ "shadowmap_vertex" ]
 		);
 
 		code = output.join( "\n" );
 
-	}
-	else {
+	} else {
 
 		// blur textures for PBR effect
 
@@ -105,6 +107,8 @@ THREE.StandardNode.prototype.build = function( builder ) {
 			offsetV : 0
 		};
 
+		var useClearCoat = !material.isDefined( 'STANDARD' );
+		
 		// parse all nodes to reuse generate codes
 
 		this.color.parse( builder, { slot : 'color' } );
@@ -112,6 +116,14 @@ THREE.StandardNode.prototype.build = function( builder ) {
 		this.metalness.parse( builder );
 
 		if ( this.alpha ) this.alpha.parse( builder );
+		
+		if ( this.normal ) this.normal.parse( builder );
+		if ( this.normalScale && this.normal ) this.normalScale.parse( builder );
+		
+		if (this.clearCoat) this.clearCoat.parse( builder );
+		if (this.clearCoatRoughness) this.clearCoatRoughness.parse( builder );
+		
+		if ( this.reflectivity ) this.reflectivity.parse( builder );
 
 		if ( this.light ) this.light.parse( builder, { cache : 'light' } );
 
@@ -119,9 +131,6 @@ THREE.StandardNode.prototype.build = function( builder ) {
 		if ( this.ambient ) this.ambient.parse( builder );
 		if ( this.shadow ) this.shadow.parse( builder );
 		if ( this.emissive ) this.emissive.parse( builder, { slot : 'emissive' } );
-
-		if ( this.normal ) this.normal.parse( builder );
-		if ( this.normalScale && this.normal ) this.normalScale.parse( builder );
 
 		if ( this.environment ) this.environment.parse( builder, { cache : 'env', requires : requires, slot : 'environment' } ); // isolate environment from others inputs ( see TextureNode, CubeTextureNode )
 
@@ -131,9 +140,15 @@ THREE.StandardNode.prototype.build = function( builder ) {
 		var roughness = this.roughness.buildCode( builder, 'fv1' );
 		var metalness = this.metalness.buildCode( builder, 'fv1' );
 
-		var reflectivity = this.reflectivity ? this.reflectivity.buildCode( builder, 'fv1' ) : undefined;
-
 		var alpha = this.alpha ? this.alpha.buildCode( builder, 'fv1' ) : undefined;
+		
+		var normal = this.normal ? this.normal.buildCode( builder, 'v3' ) : undefined;
+		var normalScale = this.normalScale && this.normal ? this.normalScale.buildCode( builder, 'v2' ) : undefined;
+		
+		var clearCoat = this.clearCoat ? this.clearCoat.buildCode( builder, 'fv1' ) : undefined;
+		var clearCoatRoughness = this.clearCoatRoughness ? this.clearCoatRoughness.buildCode( builder, 'fv1' ) : undefined;
+		
+		var reflectivity = this.reflectivity ? this.reflectivity.buildCode( builder, 'fv1' ) : undefined;
 
 		var light = this.light ? this.light.buildCode( builder, 'v3', { cache : 'light' } ) : undefined;
 
@@ -142,10 +157,9 @@ THREE.StandardNode.prototype.build = function( builder ) {
 		var shadow = this.shadow ? this.shadow.buildCode( builder, 'c' ) : undefined;
 		var emissive = this.emissive ? this.emissive.buildCode( builder, 'c', { slot : 'emissive' } ) : undefined;
 
-		var normal = this.normal ? this.normal.buildCode( builder, 'v3' ) : undefined;
-		var normalScale = this.normalScale && this.normal ? this.normalScale.buildCode( builder, 'v2' ) : undefined;
-
 		var environment = this.environment ? this.environment.buildCode( builder, 'c', { cache : 'env', requires : requires, slot : 'environment' } ) : undefined;
+
+		var clearCoatEnv = useClearCoat && environment ? this.environment.buildCode( builder, 'c', { cache : 'clearCoat', requires : requires, slot : 'environment' } ) : undefined;
 
 		material.requestAttribs.transparent = alpha != undefined;
 
@@ -222,20 +236,46 @@ THREE.StandardNode.prototype.build = function( builder ) {
 
 		output.push(
 			// accumulation
-			'material.specularRoughness = clamp( roughnessFactor, 0.04, 1.0 );' // disney's remapping of [ 0, 1 ] roughness to [ 0.001, 1 ]
+			'material.specularRoughness = clamp( roughnessFactor, DEFAULT_SPECULAR_COEFFICIENT, 1.0 );' // disney's remapping of [ 0, 1 ] roughness to [ 0.001, 1 ]
 		);
-
+		
+		if (clearCoat) {
+			
+			output.push(
+				clearCoat.code,
+				'material.clearCoat = saturate( ' + clearCoat.result + ' );'
+			);
+			
+		} else if (useClearCoat) {
+			
+			output.push( 'material.clearCoat = 0.0;' );
+			
+		}
+		
+		if (clearCoatRoughness) {
+			
+			output.push(
+				clearCoatRoughness.code,
+				'material.clearCoatRoughness = clamp( ' + clearCoatRoughness.result + ', DEFAULT_SPECULAR_COEFFICIENT, 1.0 );'
+			);
+			
+		} else if (useClearCoat) {
+			
+			output.push( 'material.clearCoatRoughness = 0.0;' );
+			
+		}
+		
 		if ( reflectivity ) {
 
 			output.push(
-				'material.specularColor = mix( vec3( 0.16 * pow2( ' + reflectivity.builder( builder, 'fv1' ) + ' ) ), diffuseColor, metalnessFactor );'
+				reflectivity.code,
+				'material.specularColor = mix( vec3( MAXIMUM_SPECULAR_COEFFICIENT * pow2( ' + reflectivity.result + ' ) ), diffuseColor, metalnessFactor );'
 			);
 
-		}
-		else {
+		} else {
 
 			output.push(
-				'material.specularColor = mix( vec3( 0.04 ), diffuseColor, metalnessFactor );'
+				'material.specularColor = mix( vec3( DEFAULT_SPECULAR_COEFFICIENT ), diffuseColor, metalnessFactor );'
 			);
 
 		}
@@ -303,10 +343,22 @@ THREE.StandardNode.prototype.build = function( builder ) {
 
 		if ( environment ) {
 
-			output.push(
-				environment.code,
-				"RE_IndirectSpecular_Physical(" + environment.result + ", vec3( 0.0 ), geometry, material, reflectedLight );"
-			);
+			output.push( environment.code );
+
+			if (clearCoatEnv) {
+
+				output.push(
+					clearCoatEnv.code,
+					"vec3 clearCoatRadiance = " + clearCoatEnv.result + ";"
+				);
+
+			} else {
+
+				output.push("vec3 clearCoatRadiance = vec3( 0.0 );");
+
+			}
+
+			output.push( "RE_IndirectSpecular(" + environment.result + ", clearCoatRadiance, geometry, material, reflectedLight );" );
 
 		}
 
@@ -316,8 +368,7 @@ THREE.StandardNode.prototype.build = function( builder ) {
 
 			output.push( "gl_FragColor = vec4( outgoingLight, " + alpha.result + " );" );
 
-		}
-		else {
+		} else {
 
 			output.push( "gl_FragColor = vec4( outgoingLight, 1.0 );" );
 

--- a/examples/js/nodes/materials/StandardNodeMaterial.js
+++ b/examples/js/nodes/materials/StandardNodeMaterial.js
@@ -14,4 +14,4 @@ THREE.StandardNodeMaterial.prototype = Object.create( THREE.NodeMaterial.prototy
 THREE.StandardNodeMaterial.prototype.constructor = THREE.StandardNodeMaterial;
 
 THREE.NodeMaterial.addShortcuts( THREE.StandardNodeMaterial.prototype, 'node',
-[ 'color', 'alpha', 'roughness', 'metalness', 'normal', 'normalScale', 'emissive', 'ambient', 'light', 'shadow', 'ao', 'environment', 'transform' ] );
+[ 'color', 'alpha', 'roughness', 'metalness', 'reflectivity', 'clearCoat', 'clearCoatRoughness', 'normal', 'normalScale', 'emissive', 'ambient', 'light', 'shadow', 'ao', 'environment', 'transform' ] );

--- a/examples/js/nodes/utils/RoughnessToBlinnExponentNode.js
+++ b/examples/js/nodes/utils/RoughnessToBlinnExponentNode.js
@@ -35,7 +35,15 @@ THREE.RoughnessToBlinnExponentNode.prototype.generate = function( builder, outpu
 
 			builder.include( THREE.RoughnessToBlinnExponentNode.getSpecularMIPLevel );
 
-			return builder.format( 'getSpecularMIPLevel( Material_BlinnShininessExponent( material ), 8 )', this.type, output );
+			if ( builder.isCache( 'clearCoat' ) ) {
+
+				return builder.format( 'getSpecularMIPLevel( Material_ClearCoat_BlinnShininessExponent( material ), 8 )', this.type, output );
+
+			} else {
+				
+				return builder.format( 'getSpecularMIPLevel( Material_BlinnShininessExponent( material ), 8 )', this.type, output );
+				
+			}
 
 		} else {
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -205,7 +205,8 @@
 			gui = new dat.GUI();
 
 			var example = gui.add( param, 'example', {
-				'basic / standard (PBR)': 'standard',
+				'basic / standard': 'standard',
+				'basic / physical': 'physical',
 				'basic / phong': 'phong',
 				'basic / layers': 'layers',
 				'basic / rim': 'rim',
@@ -391,7 +392,7 @@
 						THREE.OperatorNode.MUL
 					);
 
-					mtl.color = new THREE.ColorNode( 0xFFFFFF );
+					mtl.color = new THREE.ColorNode( 0xEEEEEE );
 					mtl.roughness = roughness;
 					mtl.metalness = metalness;
 					mtl.environment = new THREE.CubeTextureNode( cubemap );
@@ -435,6 +436,131 @@
 						normalScale.number = val;
 
 					}, false, 0, 1 );
+
+					break;
+
+					case 'physical':
+
+						// MATERIAL
+
+						mtl = new THREE.StandardNodeMaterial();
+
+						//mtl.color = // albedo (vec3)
+						//mtl.alpha = // opacity (float)
+						//mtl.roughness = // roughness (float)
+						//mtl.metalness = // metalness (float)
+						//mtl.reflectivity = // reflectivity (float)
+						//mtl.clearCoat = // clearCoat (float)
+						//mtl.clearCoatRoughness = // clearCoatRoughness (float)
+						//mtl.normal = // normalmap (vec3)
+						//mtl.normalScale = // normalmap scale (vec2)
+						//mtl.emissive = // emissive color (vec3)
+						//mtl.ambient = // ambient color (vec3)
+						//mtl.shadow = // shadowmap (vec3)
+						//mtl.light = // custom-light (vec3)
+						//mtl.ao = // ambient occlusion (float)
+						//mtl.environment = // reflection/refraction (vec3)
+						//mtl.transform = // vertex transformation (vec3)
+
+						var mask = new THREE.SwitchNode( new THREE.TextureNode( getTexture( "decalDiffuse" ) ), 'w' );
+
+						var normalScale = new THREE.FloatNode( .3 );
+
+						var roughnessA = new THREE.FloatNode( .5 );
+						var metalnessA = new THREE.FloatNode( .5 );
+
+						var roughnessB = new THREE.FloatNode( 0 );
+						var metalnessB = new THREE.FloatNode( 1 );
+
+						var reflectivity = new THREE.FloatNode( 0 );
+						var clearCoat = new THREE.FloatNode( 1 );
+						var clearCoatRoughness = new THREE.FloatNode( 1 );
+
+						var roughness = new THREE.Math3Node(
+							roughnessA,
+							roughnessB,
+							mask,
+							THREE.Math3Node.MIX
+						);
+
+						var metalness = new THREE.Math3Node(
+							metalnessA,
+							metalnessB,
+							mask,
+							THREE.Math3Node.MIX
+						);
+
+						var normalMask = new THREE.OperatorNode(
+							new THREE.Math1Node( mask, THREE.Math1Node.INVERT ),
+							normalScale,
+							THREE.OperatorNode.MUL
+						);
+
+						mtl.color = new THREE.ColorNode( 0xEEEEEE );
+						mtl.roughness = roughness;
+						mtl.metalness = metalness;
+						mtl.reflectivity = reflectivity;
+						mtl.clearCoat = clearCoat;
+						mtl.clearCoatRoughness = clearCoatRoughness;
+						mtl.environment = new THREE.CubeTextureNode( cubemap );
+						mtl.normal = new THREE.TextureNode( getTexture( "grassNormal" ) );
+						mtl.normalScale = normalMask;
+
+						// GUI
+
+						addGui( 'color', mtl.color.value.getHex(), function( val ) {
+
+							mtl.color.value.setHex( val );
+
+						}, true );
+
+						addGui( 'reflectivity', reflectivity.number, function( val ) {
+
+							 reflectivity.number = val;
+
+						}, false, 0, 1 );
+
+						addGui( 'clearCoat', clearCoat.number, function( val ) {
+
+							 clearCoat.number = val;
+
+						}, false, 0, 1 );
+
+						addGui( 'clearCoatRoughness', clearCoatRoughness.number, function( val ) {
+
+							 clearCoatRoughness.number = val;
+
+						}, false, 0, 1 );
+
+						addGui( 'roughnessA', roughnessA.number, function( val ) {
+
+							 roughnessA.number = val;
+
+						}, false, 0, 1 );
+
+						addGui( 'metalnessA', metalnessA.number, function( val ) {
+
+							metalnessA.number = val;
+
+						}, false, 0, 1 );
+
+						addGui( 'roughnessB', roughnessB.number, function( val ) {
+
+							 roughnessB.number = val;
+
+						}, false, 0, 1 );
+
+						addGui( 'metalnessB', metalnessB.number, function( val ) {
+
+							metalnessB.number = val;
+
+						}, false, 0, 1 );
+
+						addGui( 'normalScale', normalScale.number, function( val ) {
+
+							normalScale.number = val;
+
+						}, false, 0, 1 );
 
 					break;
 
@@ -902,7 +1028,6 @@
 					//saturation.inputs[1] = sat;
 
 					mtl.color = saturation;
-					mtl.environment = new THREE.CubeTextureNode( cubemap ); // optional
 
 					// GUI
 
@@ -1519,8 +1644,11 @@
 
 						// StandardNodeMaterial
 
-						mtl.metalness = new THREE.FloatNode( .05 );
-						mtl.roughness = new THREE.FloatNode( .5 );
+						mtl.metalness = new THREE.FloatNode( 0 );
+						mtl.roughness = new THREE.FloatNode( 1 );
+						mtl.reflectivity = new THREE.FloatNode( 0 );
+						mtl.clearCoat = new THREE.FloatNode( .2 );
+						mtl.clearCoatRoughness = new THREE.FloatNode( .3 );
 						mtl.environment = new THREE.CubeTextureNode( cubemap );
 
 					} else {
@@ -1528,7 +1656,7 @@
 						// PhongNodeMaterial
 
 						mtl.specular = new THREE.ColorNode( 0x2f2e2d );
-						mtl.shininess = new THREE.FloatNode( 10 );
+						mtl.shininess = new THREE.FloatNode( 15 );
 
 					}
 


### PR DESCRIPTION
- add `clearCoat`, `clearCoatRoughness` and `reflectivity` slots
- add `physical` example
- optimize if `alpha <= 0`
- fix `textureLod` **This is for sure will present better results (equal core materials) but possibly different of old `StandardNodeMaterial` version**
- fix unique node
- fix auto transparency