### PR TITLE
Fix dropped interpolator in glTF validation.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -282,7 +282,7 @@ THREE.GLTFLoader = ( function () {
 
 			currTime = interp.times[ i ];
 
-			if (prevTime !== null && prevTime <= currTime) {
+			if ( prevTime === null || prevTime <= currTime ) {
 
 				times.push( currTime );
 


### PR DESCRIPTION
The `validateInterpolator` helper was dropping the first interpolator.