### PR TITLE
MultiMaterial.js cross-frame array support

### DIFF
--- a/src/materials/MultiMaterial.js
+++ b/src/materials/MultiMaterial.js
@@ -10,7 +10,7 @@ function MultiMaterial( materials ) {
 
 	this.type = 'MultiMaterial';
 
-	this.materials = materials instanceof Array ? materials : [];
+	this.materials = Array.isArray(materials) ? materials : [];
 
 	this.visible = true;
 


### PR DESCRIPTION
The MultiMaterial constructor checks an Array with instanceof which can cause complications especially using cross-frame arrays.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_context_(e.g._frames_or_windows)

The instanceof check should be replaced by the Method Array.isArray(obj).
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray