### PR TITLE
BufferGeometry: Better Compatibility to InterleavedBufferAttribute

### DIFF
--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -103,7 +103,7 @@
 
 		<h3>[method:Box3 setFromBufferAttribute]( [page:BufferAttribute attribute] ) [page:Box3 this]</h3>
 		<div>
-		buffer -- An buffer attribute of position data that the resulting box will envelop.
+		buffer -- A buffer attribute of position data that the resulting box will envelop.
 		</div>
 		<div>
 		Sets the upper and lower bounds of this box to include all of the data in *attribute*.

--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -101,12 +101,12 @@
 		Sets the upper and lower bounds of this box to include all of the data in *array*.
 		</div>
 
-		<h3>[method:Box3 setFromBuffer]( [page:BufferAttribute buffer] ) [page:Box3 this]</h3>
+		<h3>[method:Box3 setFromBufferAttribute]( [page:BufferAttribute attribute] ) [page:Box3 this]</h3>
 		<div>
 		buffer -- An buffer attribute of position data that the resulting box will envelop.
 		</div>
 		<div>
-		Sets the upper and lower bounds of this box to include all of the data in *buffer*.
+		Sets the upper and lower bounds of this box to include all of the data in *attribute*.
 		</div>
 
 		<h3>[method:Box3 setFromPoints]( [page:Array points] ) [page:Box3 this]</h3>

--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -93,12 +93,38 @@
 		Determines whether or not this box intersects *plane*.
 		</div>
 
+		<h3>[method:Box3 setFromArray]( [page:Array array] ) [page:Box3 this]</h3>
+		<div>
+		array -- An array of position data that the resulting box will envelop.
+		</div>
+		<div>
+		Sets the upper and lower bounds of this box to include all of the data in *array*.
+		</div>
+
+		<h3>[method:Box3 setFromBuffer]( [page:BufferAttribute buffer] ) [page:Box3 this]</h3>
+		<div>
+		buffer -- An buffer attribute of position data that the resulting box will envelop.
+		</div>
+		<div>
+		Sets the upper and lower bounds of this box to include all of the data in *buffer*.
+		</div>
+
 		<h3>[method:Box3 setFromPoints]( [page:Array points] ) [page:Box3 this]</h3>
 		<div>
 		points -- Set of points that the resulting box will envelop.
 		</div>
 		<div>
 		Sets the upper and lower bounds of this box to include all of the points in *points*.
+		</div>
+
+		<h3>[method:Box3 setFromCenterAndSize]( [page:Vector3 center], [page:Vector3 size] ) [page:Box3 this]</h3>
+		<div>
+		center -- Desired center position of the box. <br>
+		size -- Desired x, y and z dimensions of the box.
+		</div>
+		<div>
+		Centers this box on *center* and sets this box's width, height and depth to the values specified <br>
+		in *size*.
 		</div>
 
 		<h3>[method:Box3 setFromObject]( [page:Object3D object] ) [page:Box3 this]</h3>
@@ -260,16 +286,6 @@
 		<div>
 		Returns the distance from any edge of this box to the specified point. <br>
 		If the point lies inside of this box, the distance will be 0.
-		</div>
-
-		<h3>[method:Box3 setFromCenterAndSize]( [page:Vector3 center], [page:Vector3 size] ) [page:Box3 this]</h3>
-		<div>
-		center -- Desired center position of the box. <br>
-		size -- Desired x, y and z dimensions of the box.
-		</div>
-		<div>
-		Centers this box on *center* and sets this box's width, height and depth to the values specified <br>
-		in *size*.
 		</div>
 
 		<h2>Source</h2>

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -579,11 +579,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		}
 
-		var positions = this.attributes.position;
+		var position = this.attributes.position;
 
-		if ( positions !== undefined ) {
+		if ( position !== undefined ) {
 
-			this.boundingBox.setFromBuffer( positions );
+			this.boundingBox.setFromBuffer( position );
 
 		} else {
 
@@ -612,13 +612,13 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 			}
 
-			var positions = this.attributes.position;
+			var position = this.attributes.position;
 
-			if ( positions ) {
+			if ( position ) {
 
 				var center = this.boundingSphere.center;
 
-				box.setFromBuffer( positions );
+				box.setFromBuffer( position );
 				box.getCenter( center );
 
 				// hoping to find a boundingSphere with a radius smaller than the
@@ -626,11 +626,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 				var maxRadiusSq = 0;
 
-				for ( var i = 0, il = positions.count; i < il; i ++ ) {
+				for ( var i = 0, il = position.count; i < il; i ++ ) {
 
-					vector.x = positions.getX( i );
-					vector.y = positions.getY( i );
-					vector.z = positions.getZ( i );
+					vector.x = position.getX( i );
+					vector.y = position.getY( i );
+					vector.z = position.getZ( i );
 					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
 
 				}

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -579,11 +579,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		}
 
-		var positions = this.attributes.position.array;
+		var positions = this.attributes.position;
 
 		if ( positions !== undefined ) {
 
-			this.boundingBox.setFromArray( positions );
+			this.boundingBox.setFromBuffer( positions );
 
 		} else {
 
@@ -616,10 +616,9 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 			if ( positions ) {
 
-				var array = positions.array;
 				var center = this.boundingSphere.center;
 
-				box.setFromArray( array );
+				box.setFromBuffer( positions );
 				box.getCenter( center );
 
 				// hoping to find a boundingSphere with a radius smaller than the
@@ -627,9 +626,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 				var maxRadiusSq = 0;
 
-				for ( var i = 0, il = array.length; i < il; i += 3 ) {
+				for ( var i = 0, il = positions.count; i < il; i ++ ) {
 
-					vector.fromArray( array, i );
+					vector.x = positions.getX( i );
+					vector.y = positions.getY( i );
+					vector.z = positions.getZ( i );
 					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
 
 				}

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -583,7 +583,7 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		if ( position !== undefined ) {
 
-			this.boundingBox.setFromBuffer( position );
+			this.boundingBox.setFromBufferAttribute( position );
 
 		} else {
 
@@ -618,7 +618,7 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 				var center = this.boundingSphere.center;
 
-				box.setFromBuffer( position );
+				box.setFromBufferAttribute( position );
 				box.getCenter( center );
 
 				// hoping to find a boundingSphere with a radius smaller than the

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -59,6 +59,37 @@ Box3.prototype = {
 
 	},
 
+	setFromBuffer: function ( buffer ) {
+
+		var minX = + Infinity;
+		var minY = + Infinity;
+		var minZ = + Infinity;
+
+		var maxX = - Infinity;
+		var maxY = - Infinity;
+		var maxZ = - Infinity;
+
+		for ( var i = 0, l = buffer.count; i < l; i ++ ) {
+
+			var x = buffer.getX( i );
+			var y = buffer.getY( i );
+			var z = buffer.getZ( i );
+
+			if ( x < minX ) minX = x;
+			if ( y < minY ) minY = y;
+			if ( z < minZ ) minZ = z;
+
+			if ( x > maxX ) maxX = x;
+			if ( y > maxY ) maxY = y;
+			if ( z > maxZ ) maxZ = z;
+
+		}
+
+		this.min.set( minX, minY, minZ );
+		this.max.set( maxX, maxY, maxZ );
+
+	},
+
 	setFromPoints: function ( points ) {
 
 		this.makeEmpty();

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -59,7 +59,7 @@ Box3.prototype = {
 
 	},
 
-	setFromBuffer: function ( buffer ) {
+	setFromBufferAttribute: function ( attribute ) {
 
 		var minX = + Infinity;
 		var minY = + Infinity;
@@ -69,11 +69,11 @@ Box3.prototype = {
 		var maxY = - Infinity;
 		var maxZ = - Infinity;
 
-		for ( var i = 0, l = buffer.count; i < l; i ++ ) {
+		for ( var i = 0, l = attribute.count; i < l; i ++ ) {
 
-			var x = buffer.getX( i );
-			var y = buffer.getY( i );
-			var z = buffer.getZ( i );
+			var x = attribute.getX( i );
+			var y = attribute.getY( i );
+			var z = attribute.getZ( i );
 
 			if ( x < minX ) minX = x;
 			if ( y < minY ) minY = y;


### PR DESCRIPTION
see #9711

This PR changed `.computeBoundingBox()` and `.computeBoundingSphere()` of `BufferGeometry`, so they work with `InterleavedBufferAttribute`. Instead of using a plain array for calculating bounding volumes, the implementation now uses the position attribute (`BufferAttribute`) and the new `Box3` method `.setFromBuffer()`. 