### PR TITLE
Fix GLTFLoader joint search bug

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1463,10 +1463,26 @@ THREE.GLTFLoader = ( function () {
 									var bones = [];
 									var boneInverses = [];
 
+									var keys = Object.keys( __nodes );
+
 									for ( var i = 0, l = skinEntry.jointNames.length; i < l; i ++ ) {
 
 										var jointId = skinEntry.jointNames[ i ];
-										var jointNode = __nodes[ jointId ];
+
+										var jointNode;
+
+										for ( var j = 0, jl = keys.length; j < jl; j ++ ) {
+
+											var node = __nodes[ keys[ j ] ];
+
+											if ( node.jointName === jointId ) {
+
+												jointNode = node;
+												break;
+
+											}
+
+										}
 
 										if ( jointNode ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1473,11 +1473,11 @@ THREE.GLTFLoader = ( function () {
 
 										for ( var j = 0, jl = keys.length; j < jl; j ++ ) {
 
-											var node = __nodes[ keys[ j ] ];
+											var n = __nodes[ keys[ j ] ];
 
-											if ( node.jointName === jointId ) {
+											if ( n.jointName === jointId ) {
 
-												jointNode = node;
+												jointNode = n;
 												break;
 
 											}


### PR DESCRIPTION
Elements in `jointNames` should correspond to `jointName` property of objects in `nodes` , not keys of `nodes`.

https://github.com/KhronosGroup/glTF/tree/master/specification/1.0#joint-hierarchy
