### PR TITLE
Set key event handler on control DOM element

### DIFF
--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -266,8 +266,8 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 		this.domElement.removeEventListener( 'mousemove', _onMouseMove, false );
 		this.domElement.removeEventListener( 'mouseup', _onMouseUp, false );
 
-		window.removeEventListener( 'keydown', _onKeyDown, false );
-		window.removeEventListener( 'keyup', _onKeyUp, false );
+		this.domElement.removeEventListener( 'keydown', _onKeyDown, false );
+		this.domElement.removeEventListener( 'keyup', _onKeyUp, false );
 
 	};
 
@@ -282,8 +282,8 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 	this.domElement.addEventListener( 'mousedown', _onMouseDown, false );
 	this.domElement.addEventListener( 'mouseup', _onMouseUp, false );
 
-	window.addEventListener( 'keydown', _onKeyDown, false );
-	window.addEventListener( 'keyup', _onKeyUp, false );
+	this.domElement.addEventListener( 'keydown', _onKeyDown, false );
+	this.domElement.addEventListener( 'keyup', _onKeyUp, false );
 
 	function bind( scope, fn ) {
 

--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -267,8 +267,8 @@ THREE.FlyControls = function ( object, domElement ) {
 		this.domElement.removeEventListener( 'mousemove', _mousemove, false );
 		this.domElement.removeEventListener( 'mouseup', _mouseup, false );
 
-		window.removeEventListener( 'keydown', _keydown, false );
-		window.removeEventListener( 'keyup', _keyup, false );
+		this.domElement.removeEventListener( 'keydown', _keydown, false );
+		this.domElement.removeEventListener( 'keyup', _keyup, false );
 
 	};
 
@@ -284,8 +284,8 @@ THREE.FlyControls = function ( object, domElement ) {
 	this.domElement.addEventListener( 'mousedown', _mousedown, false );
 	this.domElement.addEventListener( 'mouseup',   _mouseup, false );
 
-	window.addEventListener( 'keydown', _keydown, false );
-	window.addEventListener( 'keyup',   _keyup, false );
+	this.domElement.addEventListener( 'keydown', _keydown, false );
+	this.domElement.addEventListener( 'keyup',   _keyup, false );
 
 	this.updateMovementVector();
 	this.updateRotationVector();

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -221,7 +221,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		document.removeEventListener( 'mousemove', onMouseMove, false );
 		document.removeEventListener( 'mouseup', onMouseUp, false );
 
-		window.removeEventListener( 'keydown', onKeyDown, false );
+		scope.domElement.removeEventListener( 'keydown', onKeyDown, false );
 
 		//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
 
@@ -879,7 +879,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
 	scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
 
-	window.addEventListener( 'keydown', onKeyDown, false );
+	scope.domElement.addEventListener( 'keydown', onKeyDown, false );
 
 	// force an update at start
 

--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -379,7 +379,7 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 		if ( _this.enabled === false ) return;
 
-		window.removeEventListener( 'keydown', keydown );
+		_this.domElement.removeEventListener( 'keydown', keydown );
 
 		_prevState = _state;
 
@@ -409,7 +409,7 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 		_state = _prevState;
 
-		window.addEventListener( 'keydown', keydown, false );
+		_this.domElement.addEventListener( 'keydown', keydown, false );
 
 	}
 
@@ -609,8 +609,8 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 		document.removeEventListener( 'mousemove', mousemove, false );
 		document.removeEventListener( 'mouseup', mouseup, false );
 
-		window.removeEventListener( 'keydown', keydown, false );
-		window.removeEventListener( 'keyup', keyup, false );
+		this.domElement.removeEventListener( 'keydown', keydown, false );
+		this.domElement.removeEventListener( 'keyup', keyup, false );
 
 	};
 
@@ -622,8 +622,8 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 	this.domElement.addEventListener( 'touchend', touchend, false );
 	this.domElement.addEventListener( 'touchmove', touchmove, false );
 
-	window.addEventListener( 'keydown', keydown, false );
-	window.addEventListener( 'keyup', keyup, false );
+	this.domElement.addEventListener( 'keydown', keydown, false );
+	this.domElement.addEventListener( 'keyup', keyup, false );
 
 	this.handleResize();
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -356,7 +356,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		if ( _this.enabled === false ) return;
 
-		window.removeEventListener( 'keydown', keydown );
+		_this.domElement.removeEventListener( 'keydown', keydown );
 
 		_prevState = _state;
 
@@ -386,7 +386,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		_state = _prevState;
 
-		window.addEventListener( 'keydown', keydown, false );
+		_this.domElement.addEventListener( 'keydown', keydown, false );
 
 	}
 
@@ -596,8 +596,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 		document.removeEventListener( 'mousemove', mousemove, false );
 		document.removeEventListener( 'mouseup', mouseup, false );
 
-		window.removeEventListener( 'keydown', keydown, false );
-		window.removeEventListener( 'keyup', keyup, false );
+		this.domElement.removeEventListener( 'keydown', keydown, false );
+		this.domElement.removeEventListener( 'keyup', keyup, false );
 
 	};
 
@@ -609,8 +609,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 	this.domElement.addEventListener( 'touchend', touchend, false );
 	this.domElement.addEventListener( 'touchmove', touchmove, false );
 
-	window.addEventListener( 'keydown', keydown, false );
-	window.addEventListener( 'keyup', keyup, false );
+	this.domElement.addEventListener( 'keydown', keydown, false );
+	this.domElement.addEventListener( 'keyup', keyup, false );
 
 	this.handleResize();
 


### PR DESCRIPTION
This PR follows #10302

The controls globally listen to keyup / keydown events. That means that even if an<input> element exists outside of the control, moving the text cursor with the key arrows within this <input> will affect the control.

This PR ensures that key events are properly scoped.