### PR TITLE
Add support for glTF emission and specular textures.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1118,8 +1118,6 @@ THREE.GLTFLoader = ( function () {
 
 					materialParams.specularMap = dependencies.textures[ materialValues.specular ];
 
-					delete materialParams.specular;
-
 				}
 
 				if ( materialValues.shininess !== undefined ) {

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1086,15 +1086,29 @@ THREE.GLTFLoader = ( function () {
 
 				if ( Array.isArray( materialValues.emission ) ) {
 
-					materialParams.emissive = new THREE.Color().fromArray( materialValues.emission );
+					if ( materialType === THREE.MeshBasicMaterial ) {
+
+						materialParams.color = new THREE.Color().fromArray( materialValues.emission );
+
+					} else {
+
+						materialParams.emissive = new THREE.Color().fromArray( materialValues.emission );
+
+					}
 
 				} else if ( typeof( materialValues.emission ) === 'string' ) {
 
-					materialParams.map = dependencies.textures[ materialValues.emission ];
+					if ( materialType === THREE.MeshBasicMaterial ) {
+
+						materialParams.map = dependencies.textures[ materialValues.emission ];
+
+					} else {
+
+						materialParams.emissiveMap = dependencies.textures[ materialValues.emission ];
+
+					}
 
 				}
-
-				delete materialParams.emission;
 
 				if ( Array.isArray( materialValues.specular ) ) {
 
@@ -1104,9 +1118,9 @@ THREE.GLTFLoader = ( function () {
 
 					materialParams.specularMap = dependencies.textures[ materialValues.specular ];
 
-				}
+					delete materialParams.specular;
 
-				delete materialParams.specular;
+				}
 
 				if ( materialValues.shininess !== undefined ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1088,7 +1088,13 @@ THREE.GLTFLoader = ( function () {
 
 					materialParams.emissive = new THREE.Color().fromArray( materialValues.emission );
 
+				} else if ( typeof( materialValues.emission ) === 'string' ) {
+
+					materialParams.map = dependencies.textures[ materialValues.emission ];
+
 				}
+
+				delete materialParams.emission;
 
 				if ( Array.isArray( materialValues.specular ) ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1100,7 +1100,13 @@ THREE.GLTFLoader = ( function () {
 
 					materialParams.specular = new THREE.Color().fromArray( materialValues.specular );
 
+				} else if ( typeof( materialValues.specular ) === 'string' ) {
+
+					materialParams.specularMap = dependencies.textures[ materialValues.specular ];
+
 				}
+
+				delete materialParams.specular;
 
 				if ( materialValues.shininess !== undefined ) {
 


### PR DESCRIPTION
As described in #10299 and the glTF specification, the `emission` property may be an RGBA value or a texture ID. For the CONSTANT material technique, which corresponds to THREE.MeshBasicMaterial, this is the expected way to provide a texture. Specifying `diffuse` for a CONSTANT material is considered invalid.

EDIT: Added specularMap binding, while I was here.