### PR TITLE
Fix GLTF Skinning bug

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -217,12 +217,13 @@ THREE.GLTFLoader = ( function () {
 
 						// So it goes like this:
 						// SkinnedMesh world matrix is already baked into MODELVIEW;
-						// ransform joints to local space,
+						// transform joints to local space,
 						// then transform using joint's inverse
 						m4v[ mi ]
 							.getInverse( boundUniform.sourceNode.matrixWorld )
 							.multiply( boundUniform.targetNode.skeleton.bones[ mi ].matrixWorld )
-							.multiply( boundUniform.targetNode.skeleton.boneInverses[ mi ] );
+							.multiply( boundUniform.targetNode.skeleton.boneInverses[ mi ] )
+							.multiply( boundUniform.targetNode.bindMatrix );
 
 					}
 


### PR DESCRIPTION
It seems like we need to apply `SkinnedMesh.bindMatrix` to `JOINTMATRIX`.

Without this change.

![image](https://cloud.githubusercontent.com/assets/7637832/21038255/01cfc670-bd89-11e6-9a6c-3568fe8a6aa4.png)

With this change.

![image](https://cloud.githubusercontent.com/assets/7637832/21038258/0833ded4-bd89-11e6-8d34-11f8459fa18e.png)

Model is https://github.com/cx20/gltf-test/tree/master/sampleModels/WalkingLady
