### PR TITLE
Blender exporter: Fix reference to missing constant

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -314,7 +314,7 @@ def node_type(obj):
             POINT: constants.POINT_LIGHT,
             SUN: constants.DIRECTIONAL_LIGHT,
             SPOT: constants.SPOT_LIGHT,
-            AREA: constants.AREA_LIGHT,
+            AREA: constants.RECT_AREA_LIGHT,
             HEMI: constants.HEMISPHERE_LIGHT
         },
         CAMERA: {


### PR DESCRIPTION
Hi, I noticed the blender exporter was broken on `dev` when exporting scenes with lights due to a wrongly named reference to a constant. This fixes it.