### PR TITLE
Fix Loading an SVG with TextureLoader

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -184,7 +184,7 @@ Object.assign( FileLoader.prototype, {
 			if ( this.responseType !== undefined ) request.responseType = this.responseType;
 			if ( this.withCredentials !== undefined ) request.withCredentials = this.withCredentials;
 
-			if ( request.overrideMimeType ) request.overrideMimeType( this.mimeType !== undefined ? this.mimeType : 'text/plain' );
+			if ( this.mimeType && request.overrideMimeType ) request.overrideMimeType( this.mimeType );
 
 			request.send( null );
 


### PR DESCRIPTION
Currently the `FileLoader` always overrides the server provided mime type with `text/plain`.

It appears this was introduced to handle local web servers that were not serving the correct mime type (or perhaps no mime type?), but this had the side effect of breaking loading SVG files.

This PR changes the behaviour so that the mime type is only overridden if requested and gets SVG loading working again.

This should address:
http://stackoverflow.com/questions/38174693/three-js-loading-svg-with-textureloader-not-working-since-r78

and:
https://github.com/mrdoob/three.js/issues/9575

