### PR TITLE
Fix double flipNormal when double sided in the indirect irradiance calculation

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -172,13 +172,11 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 	vec3 getLightProbeIndirectIrradiance( /*const in SpecularLightProbe specularLightProbe,*/ const in GeometricContext geometry, const in int maxMIPLevel ) {
 
-		#include <normal_flip>
-
 		vec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );
 
 		#ifdef ENVMAP_TYPE_CUBE
 
-			vec3 queryVec = flipNormal * vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
+			vec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
 
 			// TODO: replace with properly filtered cubemaps and access the irradiance LOD level, be it the last LOD level
 			// of a specular cubemap, or just the default level of a specially created irradiance cubemap.
@@ -198,7 +196,7 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 		#elif defined( ENVMAP_TYPE_CUBE_UV )
 
-			vec3 queryVec = flipNormal * vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
+			vec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
 			vec4 envMapColor = textureCubeUV( queryVec, 1.0 );
 
 		#else
@@ -237,15 +235,13 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 		#endif
 
-		#include <normal_flip>
-
 		reflectVec = inverseTransformDirection( reflectVec, viewMatrix );
 
 		float specularMIPLevel = getSpecularMIPLevel( blinnShininessExponent, maxMIPLevel );
 
 		#ifdef ENVMAP_TYPE_CUBE
 
-			vec3 queryReflectVec = flipNormal * vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
+			vec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
 
 			#ifdef TEXTURE_LOD_EXT
 
@@ -261,14 +257,14 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 		#elif defined( ENVMAP_TYPE_CUBE_UV )
 
-			vec3 queryReflectVec = flipNormal * vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
+			vec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
 			vec4 envMapColor = textureCubeUV(queryReflectVec, BlinnExponentToGGXRoughness(blinnShininessExponent));
 
 		#elif defined( ENVMAP_TYPE_EQUIREC )
 
 			vec2 sampleUV;
-			sampleUV.y = saturate( flipNormal * reflectVec.y * 0.5 + 0.5 );
-			sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * RECIPROCAL_PI2 + 0.5;
+			sampleUV.y = saturate( reflectVec.y * 0.5 + 0.5 );
+			sampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;
 
 			#ifdef TEXTURE_LOD_EXT
 
@@ -284,7 +280,7 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 		#elif defined( ENVMAP_TYPE_SPHERE )
 
-			vec3 reflectView = flipNormal * normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0,0.0,1.0 ) );
+			vec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0,0.0,1.0 ) );
 
 			#ifdef TEXTURE_LOD_EXT
 


### PR DESCRIPTION
I found out why we had the flipNormal issue (see #10331) - we were double applying it within the indirect irradiance calculation.  This PR fixes this real bug.

Basically the calculations in the indirect section use geometry.normal which already is flipped.  Thus it was erroneous to use flipNormal to further flip the directions.

What is strange is why did this behavior differ on Adreno and on Desktop GPUs.