### PR TITLE
Moved non-API pages to "Developer Reference" section

### DIFF
--- a/docs/list.js
+++ b/docs/list.js
@@ -280,10 +280,6 @@ var list = {
 			[ "Sprite", "api/objects/Sprite" ]
 		],
 
-		"Polyfills": [
-			[ "Polyfills", "api/polyfills" ]
-		],
-
 		"Renderers": [
 			[ "WebGLRenderer", "api/renderers/WebGLRenderer" ],
 			[ "WebGLRenderTarget", "api/renderers/WebGLRenderTarget" ],
@@ -295,17 +291,6 @@ var list = {
 			[ "ShaderLib", "api/renderers/shaders/ShaderLib" ],
 			[ "UniformsLib", "api/renderers/shaders/UniformsLib" ],
 			[ "UniformsUtils", "api/renderers/shaders/UniformsUtils" ]
-		],
-
-		"Renderers / WebGL": [
-			[ "WebGLProgram", "api/renderers/webgl/WebGLProgram" ],
-			[ "WebGLShader", "api/renderers/webgl/WebGLShader" ],
-			[ "WebGLState", "api/renderers/webgl/WebGLState" ]
-		],
-
-		"Renderers / WebGL / Plugins": [
-			[ "LensFlarePlugin", "api/renderers/webgl/plugins/LensFlarePlugin" ],
-			[ "SpritePlugin", "api/renderers/webgl/plugins/SpritePlugin" ]
 		],
 
 		"Scenes": [
@@ -354,6 +339,24 @@ var list = {
 
 		"Renderers": [
 			[ "CanvasRenderer", "examples/renderers/CanvasRenderer" ]
+		]
+
+	},
+
+	"Developer Reference": {
+		"Polyfills": [
+			[ "Polyfills", "api/polyfills" ]
+		],
+
+		"WebGLRenderer": [
+			[ "WebGLProgram", "api/renderers/webgl/WebGLProgram" ],
+			[ "WebGLShader", "api/renderers/webgl/WebGLShader" ],
+			[ "WebGLState", "api/renderers/webgl/WebGLState" ]
+		],
+
+		"WebGLRenderer / Plugins": [
+			[ "LensFlarePlugin", "api/renderers/webgl/plugins/LensFlarePlugin" ],
+			[ "SpritePlugin", "api/renderers/webgl/plugins/SpritePlugin" ]
 		]
 
 	}


### PR DESCRIPTION
Following on from the discussion here #10089

There are a couple of pages in the API Reference docs that are not part of the API and are also not very complete, specifically:

- WebGLProgram
- WebGLShader
- WebGLState

Having these lumped in with the rest of the API reference is likely to confuse people so I moved them to a seperate "Developer Reference" section at the bottom of the menu, along with the Polyfills page