### PR TITLE
Added property "module" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/three.js",
   "repository": "mrdoob/three.js",
   "jsnext:main": "build/three.modules.js",
+  "module": "build/three.modules.js",
   "files": [
     "package.json",
     "LICENSE",


### PR DESCRIPTION
Webpack 2 has moved from `jsnext:main` to `module` for the property in package.json that points to the ES Module file: https://github.com/webpack/webpack/issues/1979

I stumbled on the issue during https://github.com/mrdoob/three.js/issues/10328, that's why the example imports `three/build/three.modules` instead of just `three` for now.