### PR TITLE
Matrix3/Matrix4: Refactored .applyToBuffer()

### DIFF
--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -74,9 +74,7 @@ m.elements = [ 11, 21, 31,
 
 		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute], [page:Number offset], [page:Number count] )</h3>
 		<div>
-		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br />
-		[page:Number offset] - (optional) index in the attribute of the first vector. Default is 0.<br />
-		[page:Number count] - (optional) number of vectors that are processed. Default is attribute.count.<br /><br />
+		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
 
 		Multiplies (applies) this matrix to every 3D vector in the [page:BufferAttribute attribute].
 		</div>

--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -76,7 +76,7 @@ m.elements = [ 11, 21, 31,
 		<div>
 		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br />
 		[page:Number offset] - (optional) index in the attribute of the first vector. Default is 0.<br />
-		[page:Number count] - (optional) index in the attribute of the last vector. Default is the last element in the attribute.<br /><br />
+		[page:Number count] - (optional) number of vectors that are processed. Default is attribute.count.<br /><br />
 
 		Multiplies (applies) this matrix to every 3D vector in the [page:BufferAttribute attribute].
 		</div>

--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -72,15 +72,13 @@ m.elements = [ 11, 21, 31,
 
 		<h2>Methods</h2>
 
-		<h3>[method:Array applyToBuffer]( [page:ArrayBuffer buffer], [page:Number offset], [page:Number length] )</h3>
+		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute], [page:Number offset], [page:Number count] )</h3>
 		<div>
-		[page:Array buffer] - An [link:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer ArrayBuffer]
-		of floats in the form [vector1x, vector1y, vector1z, vector2x, vector2y, vector2z, ...], that represent 3D vectors.<br />
-		[page:Number offset] - (optional) index in the array of the first vector's x component. Default is 0.<br />
-		[page:Number length] - (optional) index in the array of the last vector's z component.
-		Default is the last element in the array.<br /><br />
+		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br />
+		[page:Number offset] - (optional) index in the attribute of the first vector. Default is 0.<br />
+		[page:Number count] - (optional) index in the attribute of the last vector. Default is the last element in the attribute.<br /><br />
 
-		Multiplies (applies) this matrix to every 3D vector in the [page:ArrayBuffer buffer].
+		Multiplies (applies) this matrix to every 3D vector in the [page:BufferAttribute attribute].
 		</div>
 
 		<h3>[method:Array applyToVector3Array]( [page:Array array], [page:Number offset], [page:Number length] )</h3>

--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -72,7 +72,7 @@ m.elements = [ 11, 21, 31,
 
 		<h2>Methods</h2>
 
-		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute], [page:Number offset], [page:Number count] )</h3>
+		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute] )</h3>
 		<div>
 		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
 

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -110,15 +110,13 @@ m.elements = [ 11, 21, 31, 41,
 
 		<h2>Methods</h2>
 
-		<h3>[method:Array applyToBuffer]( [page:ArrayBuffer buffer], [page:Number offset], [page:Number length] )</h3>
+		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute], [page:Number offset], [page:Number count] )</h3>
 		<div>
-		[page:Array buffer] - An [link:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer ArrayBuffer]
-		of floats in the form [vector1x, vector1y, vector1z, vector2x, vector2y, vector2z, ...], that represent 3D vectors.<br />
-		[page:Number offset] - (optional) index in the array of the first vector's x component. Default is 0.<br />
-		[page:Number length] - (optional) index in the array of the last vector's z component.
-		Default is the last element in the array.<br /><br />
+		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br />
+		[page:Number offset] - (optional) index in the attribute of the first vector. Default is 0.<br />
+		[page:Number count] - (optional) index in the attribute of the last vector. Default is the last element in the attribute.<br /><br />
 
-		Multiplies (applies) the upper 3x3 matrix of this matrix to every 3D vector in the [page:ArrayBuffer buffer].
+		Multiplies (applies) the upper 3x3 matrix of this matrix to every 3D vector in the [page:BufferAttribute attribute].
 		</div>
 
 

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -110,7 +110,7 @@ m.elements = [ 11, 21, 31, 41,
 
 		<h2>Methods</h2>
 
-		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute], [page:Number offset], [page:Number count] )</h3>
+		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute] )</h3>
 		<div>
 		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
 

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -114,9 +114,9 @@ m.elements = [ 11, 21, 31, 41,
 		<div>
 		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br />
 		[page:Number offset] - (optional) index in the attribute of the first vector. Default is 0.<br />
-		[page:Number count] - (optional) index in the attribute of the last vector. Default is the last element in the attribute.<br /><br />
+		[page:Number count] - (optional) number of vectors that are processed. Default is attribute.count.<br /><br />
 
-		Multiplies (applies) the upper 3x3 matrix of this matrix to every 3D vector in the [page:BufferAttribute attribute].
+		Multiplies (applies) this matrix to every 3D vector in the [page:BufferAttribute attribute].
 		</div>
 
 

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -112,9 +112,7 @@ m.elements = [ 11, 21, 31, 41,
 
 		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute], [page:Number offset], [page:Number count] )</h3>
 		<div>
-		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br />
-		[page:Number offset] - (optional) index in the attribute of the first vector. Default is 0.<br />
-		[page:Number count] - (optional) number of vectors that are processed. Default is attribute.count.<br /><br />
+		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
 
 		Multiplies (applies) this matrix to every 3D vector in the [page:BufferAttribute attribute].
 		</div>

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -356,8 +356,8 @@ Object.assign( Matrix3.prototype, {
 	},
 	applyToBuffer: function( buffer, offset, length ) {
 
-		console.warn( 'THREE.Matrix3: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute, offset, count ) instead.' );
-		return this.applyToBufferAttribute( buffer, offset, length );
+		console.warn( 'THREE.Matrix3: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute ) instead.' );
+		return this.applyToBufferAttribute( buffer );
 
 	}
 
@@ -453,8 +453,8 @@ Object.assign( Matrix4.prototype, {
 	},
 	applyToBuffer: function( buffer, offset, length ) {
 
-		console.warn( 'THREE.Matrix4: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute, offset, count ) instead.' );
-		return this.applyToBufferAttribute( buffer, offset, length );
+		console.warn( 'THREE.Matrix4: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute ) instead.' );
+		return this.applyToBufferAttribute( buffer );
 
 	}
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -353,6 +353,11 @@ Object.assign( Matrix3.prototype, {
 		console.warn( 'THREE.Matrix3: .multiplyVector3Array() has been renamed. Use matrix.applyToVector3Array( array ) instead.' );
 		return this.applyToVector3Array( a );
 
+	},
+	applyToBuffer: function( buffer, offset, length ) {
+
+		console.error( 'THREE.Matrix3: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute, offset, count ) instead.' );
+
 	}
 
 } );
@@ -443,6 +448,11 @@ Object.assign( Matrix4.prototype, {
 	rotateByAxis: function () {
 
 		console.error( 'THREE.Matrix4: .rotateByAxis() has been removed.' );
+
+	},
+	applyToBuffer: function( buffer, offset, length ) {
+
+		console.error( 'THREE.Matrix4: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute, offset, count ) instead.' );
 
 	}
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -356,7 +356,8 @@ Object.assign( Matrix3.prototype, {
 	},
 	applyToBuffer: function( buffer, offset, length ) {
 
-		console.error( 'THREE.Matrix3: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute, offset, count ) instead.' );
+		console.warn( 'THREE.Matrix3: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute, offset, count ) instead.' );
+		return this.applyToBufferAttribute( buffer, offset, length );
 
 	}
 
@@ -452,7 +453,8 @@ Object.assign( Matrix4.prototype, {
 	},
 	applyToBuffer: function( buffer, offset, length ) {
 
-		console.error( 'THREE.Matrix4: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute, offset, count ) instead.' );
+		console.warn( 'THREE.Matrix4: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute, offset, count ) instead.' );
+		return this.applyToBufferAttribute( buffer, offset, length );
 
 	}
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -123,21 +123,19 @@ Matrix3.prototype = {
 
 		var v1;
 
-		return function applyToBufferAttribute( attribute, offset, count ) {
+		return function applyToBufferAttribute( attribute ) {
 
 			if ( v1 === undefined ) v1 = new Vector3();
-			if ( offset === undefined ) offset = 0;
-			if ( count === undefined ) count = attribute.count;
 
-			for ( var i = 0, j = offset; i < count; i ++, j ++ ) {
+			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
 
-				v1.x = attribute.getX( j );
-				v1.y = attribute.getY( j );
-				v1.z = attribute.getZ( j );
+				v1.x = attribute.getX( i );
+				v1.y = attribute.getY( i );
+				v1.z = attribute.getZ( i );
 
 				v1.applyMatrix3( this );
 
-				attribute.setXYZ( j, v1.x, v1.y, v1.z );
+				attribute.setXYZ( i, v1.x, v1.y, v1.z );
 
 			}
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -119,29 +119,29 @@ Matrix3.prototype = {
 
 	}(),
 
-	applyToBuffer: function () {
+	applyToBufferAttribute: function () {
 
 		var v1;
 
-		return function applyToBuffer( buffer, offset, length ) {
+		return function applyToBufferAttribute( attribute, offset, count ) {
 
 			if ( v1 === undefined ) v1 = new Vector3();
 			if ( offset === undefined ) offset = 0;
-			if ( length === undefined ) length = buffer.length / buffer.itemSize;
+			if ( count === undefined ) count = attribute.count;
 
-			for ( var i = 0, j = offset; i < length; i ++, j ++ ) {
+			for ( var i = 0, j = offset; i < count; i ++, j ++ ) {
 
-				v1.x = buffer.getX( j );
-				v1.y = buffer.getY( j );
-				v1.z = buffer.getZ( j );
+				v1.x = attribute.getX( j );
+				v1.y = attribute.getY( j );
+				v1.z = attribute.getZ( j );
 
 				v1.applyMatrix3( this );
 
-				buffer.setXYZ( j, v1.x, v1.y, v1.z );
+				attribute.setXYZ( j, v1.x, v1.y, v1.z );
 
 			}
 
-			return buffer;
+			return attribute;
 
 		};
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -472,29 +472,29 @@ Matrix4.prototype = {
 
 	}(),
 
-	applyToBuffer: function () {
+	applyToBufferAttribute: function () {
 
 		var v1;
 
-		return function applyToBuffer( buffer, offset, length ) {
+		return function applyToBufferAttribute( attribute, offset, count ) {
 
 			if ( v1 === undefined ) v1 = new Vector3();
 			if ( offset === undefined ) offset = 0;
-			if ( length === undefined ) length = buffer.length / buffer.itemSize;
+			if ( count === undefined ) count = attribute.count;
 
-			for ( var i = 0, j = offset; i < length; i ++, j ++ ) {
+			for ( var i = 0, j = offset; i < count; i ++, j ++ ) {
 
-				v1.x = buffer.getX( j );
-				v1.y = buffer.getY( j );
-				v1.z = buffer.getZ( j );
+				v1.x = attribute.getX( j );
+				v1.y = attribute.getY( j );
+				v1.z = attribute.getZ( j );
 
 				v1.applyMatrix4( this );
 
-				buffer.setXYZ( j, v1.x, v1.y, v1.z );
+				attribute.setXYZ( j, v1.x, v1.y, v1.z );
 
 			}
 
-			return buffer;
+			return attribute;
 
 		};
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -476,21 +476,19 @@ Matrix4.prototype = {
 
 		var v1;
 
-		return function applyToBufferAttribute( attribute, offset, count ) {
+		return function applyToBufferAttribute( attribute ) {
 
 			if ( v1 === undefined ) v1 = new Vector3();
-			if ( offset === undefined ) offset = 0;
-			if ( count === undefined ) count = attribute.count;
 
-			for ( var i = 0, j = offset; i < count; i ++, j ++ ) {
+			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
 
-				v1.x = attribute.getX( j );
-				v1.y = attribute.getY( j );
-				v1.z = attribute.getZ( j );
+				v1.x = attribute.getX( i );
+				v1.y = attribute.getY( i );
+				v1.z = attribute.getZ( i );
 
 				v1.applyMatrix4( this );
 
-				attribute.setXYZ( j, v1.x, v1.y, v1.z );
+				attribute.setXYZ( i, v1.x, v1.y, v1.z );
 
 			}
 


### PR DESCRIPTION
This PR renames `.applyToBuffer()` to `. applyToBufferAttribute()`. Besides, the methods now support `InterleavedBufferAttribute`.