### PR TITLE
Added example Software_lines_splines to menu

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -348,6 +348,7 @@ var files = {
 	],
 	"software": [
 		"software_geometry_earth",
+		"software_lines_splines",
 		"software_sandbox"
 	],
 	"svg": [


### PR DESCRIPTION
The example Software_lines_splines is not listed in the menu, although it seems to be working fine. 
Added it here.