### PR TITLE
Fix Loading an SVG with TextureLoader

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -184,13 +184,12 @@ Object.assign( FileLoader.prototype, {
 			if ( this.responseType !== undefined ) request.responseType = this.responseType;
 			if ( this.withCredentials !== undefined ) request.withCredentials = this.withCredentials;
 
-			if ( ! this.mimeType && this.responseType !== 'blob' ) {
+			// Setting 'text/plain' as the MIME type for SVG files will cause a
+			// problem when the ImageLoader tries to use it as the src of an image,
+			// so explicitly set the SVG MIME type.
+			if ( /\.svg$/.test( url ) ) this.mimeType = 'image/svg+xml';
 
-				this.setMimeType( 'text/plain' );
-
-			}
-
-			if ( this.mimeType && request.overrideMimeType ) request.overrideMimeType( this.mimeType );
+			if ( request.overrideMimeType ) request.overrideMimeType( this.mimeType !== undefined ? this.mimeType : 'text/plain' );
 
 			request.send( null );
 

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -184,7 +184,13 @@ Object.assign( FileLoader.prototype, {
 			if ( this.responseType !== undefined ) request.responseType = this.responseType;
 			if ( this.withCredentials !== undefined ) request.withCredentials = this.withCredentials;
 
-			if ( request.overrideMimeType ) request.overrideMimeType( this.mimeType !== undefined ? this.mimeType : 'text/plain' );
+			if ( ! this.mimeType && this.responseType !== 'blob' ) {
+
+				this.setMimeType( 'text/plain' );
+
+			}
+
+			if ( this.mimeType && request.overrideMimeType ) request.overrideMimeType( this.mimeType );
 
 			request.send( null );
 

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -184,11 +184,6 @@ Object.assign( FileLoader.prototype, {
 			if ( this.responseType !== undefined ) request.responseType = this.responseType;
 			if ( this.withCredentials !== undefined ) request.withCredentials = this.withCredentials;
 
-			// Setting 'text/plain' as the MIME type for SVG files will cause a
-			// problem when the ImageLoader tries to use it as the src of an image,
-			// so explicitly set the SVG MIME type.
-			if ( /\.svg$/.test( url ) ) this.mimeType = 'image/svg+xml';
-
 			if ( request.overrideMimeType ) request.overrideMimeType( this.mimeType !== undefined ? this.mimeType : 'text/plain' );
 
 			request.send( null );

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -48,6 +48,13 @@ Object.assign( ImageLoader.prototype, {
 			loader.setPath( this.path );
 			loader.setResponseType( 'blob' );
 			loader.setWithCredentials( this.withCredentials );
+
+			// By default the FileLoader requests files to be loaded with a MIME
+			// type of `text/plain`. Using `URL.createObjectURL()` with SVGs that
+			// have a MIME type of `text/plain` results in an error, so explicitly
+			// set the SVG MIME type.
+			if ( /\.svg$/.test( url ) ) loader.setMimeType( 'image/svg+xml' );
+
 			loader.load( url, function ( blob ) {
 
 				image.src = URL.createObjectURL( blob );


### PR DESCRIPTION
The problem appears to be happening in the `ImageLoader` when converting the loaded SVG blob into a URL and then making it the src of an image:

~~~js
image.src = URL.createObjectURL( blob );
~~~

With the current code we override the server provided MIME type with `text/plain` (which ends up in `blob.type`).

For some reason creating PNGs and JPGs with a MIME type of `text/plain` works. Perhaps it's because it does not rely on the MIME type and instead derives it from the image binary content? Not sure, but with SVGs it results in an error.

This PR changes the behaviour so it only sets the overriding `text/plain` MIME type when not a blob. 

At the moment only `ImageLoader` requests a blob type so this PR should only affect loading of images. All other loaders should continue to use the `text/plain` MIME type.

Unfortunately I've been unable to reproduce errors/warnings reported by others in my dev environment, perhaps due to different local web servers, but hopefully this PR has a smaller impact that my previous PR (https://github.com/mrdoob/three.js/pull/10329)

As mentioned previously this should fix https://github.com/mrdoob/three.js/issues/9575
