### PR TITLE
Fixed typos in WebGLRenderTarget and WebGLRenderTargetCube docs

### DIFF
--- a/docs/api/renderers/WebGLRenderTarget.html
+++ b/docs/api/renderers/WebGLRenderTarget.html
@@ -40,8 +40,8 @@
 		[page:Constant type] - default is [page:Textures UnsignedByteType]. <br />
 		[page:Number anisotropy] - default is *1*. See [page:Texture.anistropy]<br />
 		[page:Constant encoding] - default is [page:Textures LinearEncoding]. <br />
-		[page:BooleandepthBuffer] - default is *true*. Set this to false if you don't need it. <br />
-		[page:BooleanstencilBuffer] - default is *true*. Set this to false if you don't need it.<br /><br />
+		[page:Boolean depthBuffer] - default is *true*. Set this to false if you don't need it. <br />
+		[page:Boolean stencilBuffer] - default is *true*. Set this to false if you don't need it.<br /><br />
 
 		Creates a new [name]]
 		</div>

--- a/docs/api/renderers/WebGLRenderTargetCube.html
+++ b/docs/api/renderers/WebGLRenderTargetCube.html
@@ -42,8 +42,8 @@
 		[page:Constant type] - default is [page:Textures UnsignedByteType]. <br />
 		[page:Number anisotropy] - default is *1*. See [page:Texture.anistropy]<br />
 		[page:Constant encoding] - default is [page:Textures LinearEncoding]. <br />
-		[page:BooleandepthBuffer] - default is *true*. Set this to false if you don't need it. <br />
-		[page:BooleanstencilBuffer] - default is *true*. Set this to false if you don't need it.<br /><br />
+		[page:Boolean depthBuffer] - default is *true*. Set this to false if you don't need it. <br />
+		[page:Boolean stencilBuffer] - default is *true*. Set this to false if you don't need it.<br /><br />
 
 		Creates a new [name]]
 		</div>


### PR DESCRIPTION
BooleandepthBuffer -> Boolean depthBuffer
and
BooleanstencilBuffer -> Boolean stencilBuffer