### PR TITLE
Modify orbit controls example to de-emphasize animation loop

### DIFF
--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -53,6 +53,7 @@
 			var camera, controls, scene, renderer;
 
 			init();
+			render(); // remove when using next line for animation loop (requestAnimationFrame)
 			//animate();
 
 			function init() {
@@ -72,7 +73,7 @@
 				camera.position.z = 500;
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // remove when using animation loop (requestAnimationFrame)
+				controls.addEventListener( 'change', render ); // remove when using animation loop
 				// enable animation loop when using damping or autorotation
 				//controls.enableDamping = true;
 				//controls.dampingFactor = 0.25;

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -53,7 +53,7 @@
 			var camera, controls, scene, renderer;
 
 			init();
-			animate();
+			//animate();
 
 			function init() {
 
@@ -72,9 +72,10 @@
 				camera.position.z = 500;
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
-				//controls.addEventListener( 'change', render ); // add this only if there is no animation loop (requestAnimationFrame)
-				controls.enableDamping = true;
-				controls.dampingFactor = 0.25;
+				controls.addEventListener( 'change', render ); // remove when using animation loop (requestAnimationFrame)
+				// enable animation loop when using damping or autorotation
+				//controls.enableDamping = true;
+				//controls.dampingFactor = 0.25;
 				controls.enableZoom = false;
 
 				// world


### PR DESCRIPTION
In the process of resolving an issue for a new Three.js [backend](https://trac.sagemath.org/ticket/12402) I wrote for SageMath, I came across #7670 and was pleasantly surprised to learn that an animation loop is unnecessary for static scenes. Since the only live example I could find of this was @WestLangley's fiddle referenced in the issue, I thought it would be instructive to modify the orbit controls example to de-emphasize the animation loop. This makes explicit that the orbit controls do not depend on a continuously running background loop.