### PR TITLE
Ignore npm-debug.log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .project
 node_modules
 .idea/
+npm-debug.log


### PR DESCRIPTION
Would you mind also ignoring `npm-debug.log` files?



