### PR TITLE
Added note on flat shading to MeshLambertMaterial

### DIFF
--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -186,7 +186,9 @@
 		<h3>[property:Integer shading]</h3>
 		<div>
 		Defines how the material is shaded.
-		This can be either [page:Materials THREE.SmoothShading] (default)	or [page:Materials THREE.FlatShading].
+		This can be either [page:Materials THREE.SmoothShading] (default)	or [page:Materials THREE.FlatShading].<br /><br />
+
+		Note that this has no effect on [page:MeshLambertMaterial], which is always smooth shaded.
 		</div>
 
 		<h3>[property:Integer side]</h3>

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -141,6 +141,11 @@
 		<h3>[property:Float refractionRatio]</h3>
 		<div>The index of refraction for an environment map using [page:Textures THREE.CubeRefractionMapping]. Default is *0.98*.</div>
 
+		<h3>[property:Integer shading]</h3>
+		<div>
+		Changing this to [page:Material SmoothShading] will have no effect - MeshLambertMaterial is always smooth shaded.
+		</div>
+
 		<h3>[property:Boolean skinning]</h3>
 		<div>Define whether the material uses skinning. Default is false.</div>
 


### PR DESCRIPTION
Added a note to MeshLambertMaterial saying that changing the shading type to FlatShading will have no effect. 

#7130