### PR TITLE
Fix object flickering with CanvasRenderer

### DIFF
--- a/examples/js/renderers/Projector.js
+++ b/examples/js/renderers/Projector.js
@@ -444,9 +444,9 @@ THREE.Projector = function () {
 
 						if ( groups.length > 0 ) {
 
-							for ( var o = 0; o < groups.length; o ++ ) {
+							for ( var g = 0; g < groups.length; g ++ ) {
 
-								var group = groups[ o ];
+								var group = groups[ g ];
 
 								for ( var i = group.start, l = group.start + group.count; i < l; i += 3 ) {
 


### PR DESCRIPTION
`Projector` loops over all visible objects using `o` as the loop variable, but another loop inside that one also uses `o`.  Since `var`s are function-scoped, not block-scoped, this can prematurely advance the outer loop and skip rendering some objects entirely.