### PR TITLE
Added Code Style and Migration guide links to manual

### DIFF
--- a/docs/list.js
+++ b/docs/list.js
@@ -5,6 +5,8 @@ var list = {
 			[ "Creating a scene", "manual/introduction/Creating-a-scene" ],
 			[ "Drawing Lines", "manual/introduction/Drawing-lines" ],
 			[ "Creating Text", "manual/introduction/Creating-text" ],
+			[ "Code Style Guide", "manual/introduction/Code-style-guide" ],
+			[ "Migration Guide", "manual/introduction/Migration-guide" ],
 			[ "Matrix transformations", "manual/introduction/Matrix-transformations" ]
 		],
 

--- a/docs/manual/introduction/Code-style-guide.html
+++ b/docs/manual/introduction/Code-style-guide.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</a></h1>
+
+		<div class="desc">
+			All code and examples in three.js are written using Mr.doob's Code Style.
+			Of course you are free to use whatever style you prefer for your own work, but
+			if you are adding code to the library or examples then you must follow this guide.<br /><br />
+
+			You can find details
+			<a href="https://github.com/mrdoob/three.js/wiki/Mr.doob%27s-Code-Style%E2%84%A2">here</a>.
+		</div>
+	</body>
+</html>

--- a/docs/manual/introduction/Migration-guide.html
+++ b/docs/manual/introduction/Migration-guide.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</a></h1>
+
+		<div class="desc">
+			The migration guide is maintained on the [link:https://github.com/mrdoob/three.js/wiki wiki].
+			It contains a list of changes for each version of three.js going back to r45.<br /><br />
+
+			You can find it [link:https://github.com/mrdoob/three.js/wiki/Migration here].
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
I've added pages to the docs that link to these pages on the wiki with minimal explanation. 

Ideally the page would redirect automatically to the Wiki, but unfortunately Github uses a content security policy of frame-ancestors: 'none', which prevents iframes from loading up their pages. 

I also tried scraping the wiki page using Ajax (this would be the ideal solution, as just the relevant portion could be displayed in the page) but the request requires authentication and I'd rather not spend my day learning about Ajax authentication! I might come back to this at some point, or if someone else want to have a go that would be great. 

But in the meantime this should suffice. 



