### PR TITLE
Fixed migration guide link in manual

### DIFF
--- a/docs/manual/introduction/Migration-guide.html
+++ b/docs/manual/introduction/Migration-guide.html
@@ -14,7 +14,7 @@
 			The migration guide is maintained on the [link:https://github.com/mrdoob/three.js/wiki wiki].
 			It contains a list of changes for each version of three.js going back to r45.<br /><br />
 
-			You can find it [link:https://github.com/mrdoob/three.js/wiki/Migration here].
+			You can find it [link:https://github.com/mrdoob/three.js/wiki/Migration-Guide here].
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
I changed the name of Migration to Migration Guide in the Wiki, just updating the link here.