### PR TITLE
Removed DirectionalLightShadow params from src and docs

### DIFF
--- a/docs/api/lights/shadows/DirectionalLightShadow.html
+++ b/docs/api/lights/shadows/DirectionalLightShadow.html
@@ -62,7 +62,7 @@ scene.add( helper );
 		</div>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:Integer hex], [page:Float intensity] )</h3>
+		<h3>[name]( )</h3>
 		<div>
 			Creates a new [name]. This is not intended to be called directly - it is called
 			internally by [page:DirectionalLight].

--- a/src/lights/DirectionalLightShadow.js
+++ b/src/lights/DirectionalLightShadow.js
@@ -5,7 +5,7 @@ import { OrthographicCamera } from '../cameras/OrthographicCamera';
  * @author mrdoob / http://mrdoob.com/
  */
 
-function DirectionalLightShadow( light ) {
+function DirectionalLightShadow( ) {
 
 	LightShadow.call( this, new OrthographicCamera( - 5, 5, 5, - 5, 0.5, 500 ) );
 


### PR DESCRIPTION
See #10437

In the src was:

    function DirectionalLightShadow( light ) { ... }

In the docs was:

    DirectionalLightShadow( hex, intensity )

Actually the ```DirectionalLightShadow``` takes no params, so I removed ```light``` from src and ``` hex, intensity``` frm docs.
