### PR TITLE
Added Basic Oculus Touch Support to HTC Vive Controller WebVR Examples

### DIFF
--- a/examples/js/vr/ViveController.js
+++ b/examples/js/vr/ViveController.js
@@ -27,7 +27,7 @@ THREE.ViveController = function ( id ) {
 
 			var gamepad = gamepads[ i ];
 
-			if ( gamepad && gamepad.id === 'OpenVR Gamepad' ) {
+			if ( gamepad && (gamepad.id === 'OpenVR Gamepad' || gamepad.id === 'Oculus Touch (Left)' || gamepad.id === 'Oculus Touch (Right)') ) {
 
 				if ( j === id ) return gamepad;
 

--- a/examples/js/vr/ViveController.js
+++ b/examples/js/vr/ViveController.js
@@ -27,7 +27,7 @@ THREE.ViveController = function ( id ) {
 
 			var gamepad = gamepads[ i ];
 
-			if ( gamepad && (gamepad.id === 'OpenVR Gamepad' || gamepad.id === 'Oculus Touch (Left)' || gamepad.id === 'Oculus Touch (Right)') ) {
+			if ( gamepad && ( gamepad.id === 'OpenVR Gamepad' || gamepad.id === 'Oculus Touch (Left)' || gamepad.id === 'Oculus Touch (Right)' ) ) {
 
 				if ( j === id ) return gamepad;
 


### PR DESCRIPTION
Basic Oculus Touch support added to HTC Vive examples.

Tested using chromium_webvr_v1.1_win.zip from https://webvr.info/get-chrome/ on Windows 10 with a GTX 970 and using Oculus Rift CV1 and Oculus Touch.

Tested with all 4 current vive examples.

The support is not perfect. Notably the Vive Controller models are still displayed but the alignment is correct and the controller bindings are logical.