### PR TITLE
removed mistaken THREE from recent revert

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -44,7 +44,7 @@ Object.assign( ImageLoader.prototype, {
 
 		image.addEventListener( 'load', function () {
 
-			THREE.Cache.add( url, this );
+			Cache.add( url, this );
 
 			if ( onLoad ) onLoad( this );
 


### PR DESCRIPTION
noticed this when merging in the latest dev branch.

This was put in here recently e7f7d330b975b1e7d3b760a3b943976406bfa814

I am guessing that the `THREE` is not supposed to be there?