### PR TITLE
Updated Useful Links manual page

### DIFF
--- a/docs/manual/introduction/Useful-links.html
+++ b/docs/manual/introduction/Useful-links.html
@@ -11,16 +11,22 @@
 		<h1>[name]</h1><br />
 
 		<div class="desc">
-			The following is a collection of links that you might find useful when learning Three.<br />
+			The following is a collection of links that you might find useful when learning three.js.<br />
 			If you find something that you'd like to add here, or think that one of the links below is no longer
 			relevant or working, feel free to click the 'edit' button in the top right and make some changes!<br /><br />
 
 			Note also that as three.js is under rapid development, a lot of these links will contain information that is
-			out of date - if something isn't working as you'd expect or one of these links says it should,
-			check the browser console for warnings, the relevant docs pages and especially the [page:DeprecatedList].<br /><br />
+			out of date - if something isn't working as you'd expect or as one of these links says it should,
+			check the browser console for warnings or errors, the relevant docs pages and especially the [page:DeprecatedList].<br /><br />
 
 			In addition to this page, mrdoob maintains a collection of links related to three.js over on Google+.
 			Check them out <a href="https://plus.google.com/+ThreejsOrg">here</a>.
+		</div>
+
+		<h2>Help forums</h2>
+		<div>
+			Three.js officially uses [link:http://stackoverflow.com/tags/three.js/info Stack Overflow] for help requests.
+			If you need assistance with something, that's the place to go. Do NOT open an issue on Github for help requests.
 		</div>
 
 		<h2>Tutorials and courses</h2>
@@ -51,7 +57,7 @@
 			[Link:https://aerotwist.com/tutorials/ Aerotwist] tutorials by [link:https://github.com/paullewis/ Paul Lewis].
 		 </li>
 			 <li>
-			 [link:http://learningthreejs.com/ Learning Three.js] – blog where each post is dedicated to teaching an aspect of three.js
+			 [link:http://learningthreejs.com/ Learning Three.js] – a blog with articles dedicated to teaching three.js
 		 </li>
 		 <li>
 			 [link:http://bkcore.com/blog/3d/webgl-three-js-animated-selective-glow.html Animated selective glow in Three.js]
@@ -74,7 +80,8 @@
 		<h2>More documentation</h2>
 		<ul>
 			<li>
-				[link:http://threejsdoc.appspot.com/doc/index.html threejsdoc] - useful because it links every API element to to every official example that uses it.
+				[link:http://threejsdoc.appspot.com/doc/index.html threejsdoc] - less descriptive than the official docs here, however this is
+				useful because it links every API element to to every official three.js [link:https://threejs.org/examples/ example] that uses it.
 			</li>
 			<li>
 				[link:http://ushiroad.com/3j/ Three.js walking map] - a graphical breakdown of the structure of a three.js scene.
@@ -84,10 +91,10 @@
 		<h2>News and Updates</h2>
 		<ul>
 			<li>
-				[link:http://www.reddit.com/r/threejs/ Three.js] subreddit.
+				[link:http://www.reddit.com/r/threejs/ Three.js on reddit]
 			</li>
 			<li>
-				[link:http://www.reddit.com/r/webgl/ WebGL] subreddit.
+				[link:http://www.reddit.com/r/webgl/ WebGL on reddit]
 			</li>
 			<li>
 				[link:http://learningwebgl.com/blog/ Learning WebGL Blog] – The authoritaive news source for WebGL.
@@ -104,11 +111,11 @@
 				examples built using three.js r60.
 			</li>
 			<li>
-				[link:https://threejs.org/examples/ Official three.js Examples] - these examples are
+				[link:https://threejs.org/examples/ Official three.js examples] - these examples are
 				maintained as part of the three.js repository, and always use the latest version of three.js.
 			</li>
 			<li>
-				[link:https://rawgit.com/mrdoob/three.js/dev/examples/ Official three.js Examples] (dev branch) -
+				[link:https://rawgit.com/mrdoob/three.js/dev/examples/ Official three.js dev branch examples]  -
 				Same as the above, except these use the dev branch of three.js,	and are used to check that
 				everything is working as three.js being is developed.
 			</li>

--- a/docs/manual/introduction/Useful-links.html
+++ b/docs/manual/introduction/Useful-links.html
@@ -17,8 +17,59 @@
 
 			Note also that as three.js is under rapid development, a lot of these links will contain information that is
 			out of date - if something isn't working as you'd expect or one of these links says it should,
-			check the browser console for warning, the relevant docs pages and especially the [page:DeprecatedList].
+			check the browser console for warnings, the relevant docs pages and especially the [page:DeprecatedList].<br /><br />
+
+			In addition to this page, mrdoob maintains a collection of links related to three.js over on Google+.
+			Check them out <a href="https://plus.google.com/+ThreejsOrg">here</a>.
 		</div>
+
+		<h2>Tutorials and courses</h2>
+
+		<h4>Getting started with three.js</h4>
+		<ul>
+			<li>
+				[link:https://codepen.io/rachsmith/post/beginning-with-3d-webgl-pt-1-the-scene Beginning with 3D WebGL] by [link:https://codepen.io/rachsmith/ Rachel Smith].
+			</li>
+			<li>
+				[link:https://www.august.com.au/blog/animating-scenes-with-webgl-three-js/ Animating scenes with WebGL and three.js]
+			</li>
+		</ul>
+
+		<h4>More extensive / advanced articles and courses</h4>
+		<ul>
+			<li>
+				[link:http://blog.cjgammon.com/ Collection of tutorials] by [link:http://www.cjgammon.com/ CJ Gammon].
+			</li>
+			<li>
+				<a href="https://medium.com/@soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857">Glossy spheres in three.js</a>.
+			</li>
+		 <li>
+			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
+			 and uses three.js as it coding tool.
+		 </li>
+		 <li>
+			[Link:https://aerotwist.com/tutorials/ Aerotwist] tutorials by [link:https://github.com/paullewis/ Paul Lewis].
+		 </li>
+			 <li>
+			 [link:http://learningthreejs.com/ Learning Three.js] – blog where each post is dedicated to teaching an aspect of three.js
+		 </li>
+		 <li>
+			 [link:http://bkcore.com/blog/3d/webgl-three-js-animated-selective-glow.html Animated selective glow in Three.js]
+			 by [link:https://github.com/BKcore BKcore]
+		 </li>
+		</ul>
+
+		<h4>Tutorials in other languages</h4>
+		<ul>
+			<li>
+				[link:http://www.natural-science.or.jp/article/20120220155529.php Building A Physics Simulation Environment] - three.js tutorial in Japanese
+			</li>
+			<li>
+		 	 [link:http://www.senaeh.de/einstieg-in-webgl-mit-three-js/ Einstieg in WebGL mit three.js] - three.js tutorial in German
+		  </li>
+
+		</ul>
+
 
 		<h2>More documentation</h2>
 		<ul>
@@ -28,38 +79,21 @@
 			<li>
 				[link:http://ushiroad.com/3j/ Three.js walking map] - a graphical breakdown of the structure of a three.js scene.
 			</li>
+		</ul>
+
+		<h2>News and Updates</h2>
+		<ul>
 			<li>
 				[link:http://www.reddit.com/r/threejs/ Three.js] subreddit.
 			</li>
 			<li>
 				[link:http://www.reddit.com/r/webgl/ WebGL] subreddit.
 			</li>
-		</ul>
-
-		<h2>News and Updates</h2>
-		<ul>
 			<li>
 				[link:http://learningwebgl.com/blog/ Learning WebGL Blog] – The authoritaive news source for WebGL.
 			</li>
 			<li>
 				[link:https://plus.google.com/104300307601542851567/posts Three.js posts] on Google+ – frequent posts on Three.js
-			</li>
-		</ul>
-
-		<h2>Articles</h2>
-		<ul>
-			<li>
-				[link:http://bkcore.com/blog/3d/webgl-three-js-animated-selective-glow.html Animated selective glow in Three.js]
-				by [link:https://github.com/BKcore BKcore]
-			</li>
-			<li>
-
-			</li>
-			<li>
-
-			</li>
-			<li>
-
 			</li>
 		</ul>
 
@@ -98,26 +132,6 @@
 		</li>
 	 </ul>
 
-	 <h2>Tutorials and courses</h2>
-	 <ul>
-		 <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
-			 and uses three.js as it coding tool.
-		 </li>
-		 <li>
-			[Link:https://aerotwist.com/tutorials/ Aerotwist] tutorials by [link:https://github.com/paullewis/ Paul Lewis].
-		 </li>
-		 <li>
-			 [link:http://www.natural-science.or.jp/article/20120220155529.php Building A Physics Simulation Environment] - three.js tutorial in Japanese
-		 </li>
-		 <li>
-			 [link:http://www.senaeh.de/einstieg-in-webgl-mit-three-js/ Einstieg in WebGL mit three.js] - three.js tutorial in German
-		 </li>
-		 <li>
-			 [link:http://learningthreejs.com/ Learning Three.js] – blog where each post is dedicated to teaching an aspect of three.js
-		 </li>
-	 </ul>
-
 	 <h2>Old Links</h2>
 	 <div>
 		These links are kept for historical purposes - you may still find them useful, but be warned that
@@ -147,10 +161,10 @@
 			[link:http://blackjk3.github.io/threefab/ ThreeFab] - scene editor, maintained up until around three.js r50.
 		</li>
 		<li>
-			[link:http://bkcore.com/blog/3d/webgl-three-js-workflow-tips.html Max to Three.js workflow tips and tricks] by https://github.com/BKcore BKcore]
+			[link:http://bkcore.com/blog/3d/webgl-three-js-workflow-tips.html Max to Three.js workflow tips and tricks] by [link:https://github.com/BKcore BKcore]
 		</li>
 		<li>
-			[link:http://12devsofxmas.co.uk/2012/01/webgl-and-three-js/ On the twelfth day of Xmas, take a whirlwind look at Three.js]
+			[link:http://12devsofxmas.co.uk/2012/01/webgl-and-three-js/ A whirlwind look at Three.js]
 			by [link:http://github.com/nrocy Paul King]
 		</li>
 	 </ul>


### PR DESCRIPTION
Reorganised, moved really old links to "Old Links" sections at the bottom of the page, added a couple of new tutorials and a link to mrdoob's G+ page