### PR TITLE
Updated the manual's menu

### DIFF
--- a/docs/list.js
+++ b/docs/list.js
@@ -1,18 +1,21 @@
 var list = {
 
 	"Manual": {
-		"Introduction": [
+		"Getting Started": [
 			[ "Creating a scene", "manual/introduction/Creating-a-scene" ],
 			[ "Detecting WebGL and browser compatibility", "manual/introduction/Detecting-WebGL-and-browser-compatibility" ],
-			[ "Matrix transformations", "manual/introduction/Matrix-transformations" ],
-			[ "How to update things", "manual/introduction/How-to-update-things" ],
-			[ "Useful links", "manual/introduction/Useful-links" ],
+			[ "How to run things locally", "manual/introduction/How-to-run-thing-locally" ],
 			[ "Drawing Lines", "manual/introduction/Drawing-lines" ],
 			[ "Creating Text", "manual/introduction/Creating-text" ],
-			[ "Code Style Guide", "manual/introduction/Code-style-guide" ],
 			[ "Migration Guide", "manual/introduction/Migration-guide" ],
-			[ "How to run things locally", "manual/introduction/How-to-run-thing-locally" ],
-			[ "FAQ", "manual/introduction/FAQ" ]
+			[ "Code Style Guide", "manual/introduction/Code-style-guide" ],
+			[ "FAQ", "manual/introduction/FAQ" ],
+			[ "Useful links", "manual/introduction/Useful-links" ]
+		],
+
+		"Next Steps": [
+				[ "How to update things", "manual/introduction/How-to-update-things" ],
+			[ "Matrix transformations", "manual/introduction/Matrix-transformations" ]
 		],
 
 		"Build Tools": [

--- a/docs/manual/introduction/FAQ.html
+++ b/docs/manual/introduction/FAQ.html
@@ -12,7 +12,7 @@
 
 		<h2>Which Import Format/Exporter is best supported?</h2>
 		<div>
-TODO 
+TODO
 		</div>
 
 		<h2>Why are there meta viewport tags in examples?</h2>


### PR DESCRIPTION
Nearly everything was lumped into the "Introduction" section - I've seperated it out a bit, so it now looks like:
<br><br>

Getting Started
- Creating a scene
- Detecting WebGL and browser compatibility
- How to run things locally
- Drawing Lines
- Creating Text
- Migration Guide
- Code Style Guide
- FAQ
- Useful links

Next Steps
- How to update things
- Matrix transformations

Build Tools
- Testing with NPM



<br><br>
I'd like to put
- Migration Guide
- Code Style Guide
- FAQ
- Useful links

into a seperate section too, but I'm drawing a blank on the name - anyone have any suggestions? 
