### PR TITLE
Removed Curve.create() from examples and docs

### DIFF
--- a/docs/api/geometries/TubeBufferGeometry.html
+++ b/docs/api/geometries/TubeBufferGeometry.html
@@ -35,25 +35,24 @@
 		<h2>Example</h2>
 
 		<code>
-		var CustomSinCurve = THREE.Curve.create(
+		function CustomSinCurve( scale ){
 
-			function ( scale ) { //custom curve constructor
+			this.scale = ( scale === undefined ) ? 1 : scale;
 
-				this.scale = ( scale === undefined ) ? 1 : scale;
+		}
 
-			},
+		CustomSinCurve.prototype = Object.create( THREE.Curve.prototype );
+		CustomSinCurve.prototype.constructor = CustomSinCurve;
 
-			function ( t ) { //getPoint: t is between 0-1
+		CustomSinCurve.prototype.getPoint = function ( t ) {
 
-				var tx = t * 3 - 1.5;
-				var ty = Math.sin( 2 * Math.PI * t );
-				var tz = 0;
+			var tx = t * 3 - 1.5;
+			var ty = Math.sin( 2 * Math.PI * t );
+			var tz = 0;
 
-				return new THREE.Vector3( tx, ty, tz ).multiplyScalar( this.scale );
+			return new THREE.Vector3( tx, ty, tz ).multiplyScalar( this.scale );
 
-			}
-
-		);
+		};
 
 		var path = new CustomSinCurve( 10 );
 		var geometry = new THREE.TubeBufferGeometry( path, 20, 2, 8, false );

--- a/docs/api/geometries/TubeGeometry.html
+++ b/docs/api/geometries/TubeGeometry.html
@@ -35,25 +35,24 @@
 		<h2>Example</h2>
 
 		<code>
-		var CustomSinCurve = THREE.Curve.create(
+		function CustomSinCurve( scale ){
 
-			function ( scale ) { //custom curve constructor
+			this.scale = ( scale === undefined ) ? 1 : scale;
 
-				this.scale = ( scale === undefined ) ? 1 : scale;
+		}
 
-			},
+		CustomSinCurve.prototype = Object.create( THREE.Curve.prototype );
+		CustomSinCurve.prototype.constructor = CustomSinCurve;
 
-			function ( t ) { //getPoint: t is between 0-1
+		CustomSinCurve.prototype.getPoint = function ( t ) {
 
-				var tx = t * 3 - 1.5;
-				var ty = Math.sin( 2 * Math.PI * t );
-				var tz = 0;
+			var tx = t * 3 - 1.5;
+			var ty = Math.sin( 2 * Math.PI * t );
+			var tz = 0;
 
-				return new THREE.Vector3( tx, ty, tz ).multiplyScalar( this.scale );
+			return new THREE.Vector3( tx, ty, tz ).multiplyScalar( this.scale );
 
-			}
-
-		);
+		};
 
 		var path = new CustomSinCurve( 10 );
 		var geometry = new THREE.TubeGeometry( path, 20, 2, 8, false );

--- a/docs/scenes/js/geometry.js
+++ b/docs/scenes/js/geometry.js
@@ -91,25 +91,24 @@ function updateGroupGeometry( mesh, geometry ) {
 
 }
 
-var CustomSinCurve = THREE.Curve.create(
+function CustomSinCurve( scale ){
 
-	function ( scale ) {
+	this.scale = ( scale === undefined ) ? 1 : scale;
 
-		this.scale = ( scale === undefined ) ? 1 : scale;
+}
 
-	},
+CustomSinCurve.prototype = Object.create( THREE.Curve.prototype );
+CustomSinCurve.prototype.constructor = CustomSinCurve;
 
-	function ( t ) {
+CustomSinCurve.prototype.getPoint = function ( t ) {
 
-		var tx = t * 3 - 1.5;
-		var ty = Math.sin( 2 * Math.PI * t );
-		var tz = 0;
+	var tx = t * 3 - 1.5;
+	var ty = Math.sin( 2 * Math.PI * t );
+	var tz = 0;
 
-		return new THREE.Vector3( tx, ty, tz ).multiplyScalar( this.scale );
+	return new THREE.Vector3( tx, ty, tz ).multiplyScalar( this.scale );
 
-	}
-
-);
+};
 
 // heart shape
 

--- a/examples/js/CurveExtras.js
+++ b/examples/js/CurveExtras.js
@@ -13,9 +13,9 @@
 
 ( function( Curves ) {
 
-// GrannyKnot
+	// GrannyKnot
 
-function GrannyKnot() {}
+	function GrannyKnot() {}
 
 	GrannyKnot.prototype = Object.create( THREE.Curve.prototype );
 	GrannyKnot.prototype.constructor = GrannyKnot;

--- a/examples/js/ParametricGeometries.js
+++ b/examples/js/ParametricGeometries.js
@@ -5,7 +5,6 @@
  *
  */
 
-
 THREE.ParametricGeometries = {
 
 	klein: function ( v, u ) {
@@ -181,32 +180,30 @@ THREE.ParametricGeometries.TorusKnotGeometry = function ( radius, tube, segments
 	this.p = p || 2;
 	this.q = q || 3;
 
-	var TorusKnotCurve = THREE.Curve.create(
+	function TorusKnotCurve() {}
 
-		function() {
-		},
+	TorusKnotCurve.prototype = Object.create( THREE.Curve.prototype );
+	TorusKnotCurve.prototype.constructor = TorusKnotCurve;
 
-		function( t ) {
+	TorusKnotCurve.prototype.getPoint = function( t ){
 
-			t *= Math.PI * 2;
+		t *= Math.PI * 2;
 
-			var r = 0.5;
+		var r = 0.5;
 
-			var tx = ( 1 + r * Math.cos( q * t ) ) * Math.cos( p * t ),
-				ty = ( 1 + r * Math.cos( q * t ) ) * Math.sin( p * t ),
-				tz = r * Math.sin( q * t );
+		var tx = ( 1 + r * Math.cos( q * t ) ) * Math.cos( p * t ),
+			ty = ( 1 + r * Math.cos( q * t ) ) * Math.sin( p * t ),
+			tz = r * Math.sin( q * t );
 
-			return new THREE.Vector3( tx, ty, tz ).multiplyScalar( radius );
+		return new THREE.Vector3( tx, ty, tz ).multiplyScalar( radius );
 
-		}
+	};
 
-	);
 	var segments = segmentsT;
 	var radiusSegments = segmentsR;
 	var extrudePath = new TorusKnotCurve();
 
 	THREE.ParametricGeometries.TubeGeometry.call( this, extrudePath, segments, tube, radiusSegments, true, false );
-
 
 };
 

--- a/examples/js/ParametricGeometries.js
+++ b/examples/js/ParametricGeometries.js
@@ -191,11 +191,11 @@ THREE.ParametricGeometries.TorusKnotGeometry = function ( radius, tube, segments
 
 		var r = 0.5;
 
-		var tx = ( 1 + r * Math.cos( q * t ) ) * Math.cos( p * t ),
-			ty = ( 1 + r * Math.cos( q * t ) ) * Math.sin( p * t ),
-			tz = r * Math.sin( q * t );
+		var x = ( 1 + r * Math.cos( q * t ) ) * Math.cos( p * t );
+		var y = ( 1 + r * Math.cos( q * t ) ) * Math.sin( p * t );
+		var z = r * Math.sin( q * t );
 
-		return new THREE.Vector3( tx, ty, tz ).multiplyScalar( radius );
+		return new THREE.Vector3( x, y, z ).multiplyScalar( radius );
 
 	};
 


### PR DESCRIPTION
This PR removes the remaining references to `Curve .create()`.