### PR TITLE
Fix typo with stars geometry

### DIFF
--- a/docs/api/materials/PointsMaterial.html
+++ b/docs/api/materials/PointsMaterial.html
@@ -44,13 +44,13 @@ for ( var i = 0; i < 10000; i ++ ) {
 	star.y = THREE.Math.randFloatSpread( 2000 );
 	star.z = THREE.Math.randFloatSpread( 2000 );
 
-	geometry.vertices.push( star );
+	starsGeometry.vertices.push( star )
 
 }
 
 var starsMaterial = new THREE.PointsMaterial( { color: 0x888888 } )
 
-var starField = new THREE.Points( geometry, starsMaterial );
+var starField = new THREE.Points( starsGeometry, starsMaterial );
 
 scene.add( starField );
 		</code>


### PR DESCRIPTION
There was no instance of 'geometry', yet vertices were being added to it, and a mesh was being created from it. I replaced the incorrect variable 'geometry' with 'starGeometry' so the example will function properly. 

Fixes #10418