### PR TITLE
Automatically set needsUpdate for selected Material properties

### DIFF
--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -462,7 +462,7 @@
 					gpuCompute.doRenderTarget( smoothShader, currentRenderTarget );
 
 				}
-				
+
 			}
 
 

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -462,7 +462,7 @@
 					gpuCompute.doRenderTarget( smoothShader, currentRenderTarget );
 
 				}
-
+				
 			}
 
 

--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -290,8 +290,6 @@
 
 						}
 
-						material.needsUpdate = true;
-
 					}
 
 					mesh.material = material;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -415,8 +415,6 @@ Material.prototype = {
 
 	update: function () {
 
-		console.log( 'Material update called' );
-
 		this.dispatchEvent( { type: 'update' } );
 
 	},

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -23,7 +23,6 @@ function Material() {
 
 	this.blending = NormalBlending;
 	this.shading = SmoothShading; // THREE.FlatShading, THREE.SmoothShading
-	this.vertexColors = NoColors; // THREE.NoColors, THREE.VertexColors, THREE.FaceColors
 
 	this.opacity = 1;
 	this.transparent = false;
@@ -62,6 +61,7 @@ function Material() {
 	this._fog = true;
 	this._needsUpdate = true;
 	this._side = FrontSide;
+	this._vertexColors = NoColors; // THREE.NoColors, THREE.VertexColors, THREE.FaceColors
 
 }
 
@@ -129,6 +129,23 @@ Material.prototype = {
 		if ( value !== this._side ) {
 
 			this._side = value;
+			this.needsUpdate = true;
+
+		}
+
+	},
+
+	get vertexColors() {
+
+		return this._vertexColors;
+
+	},
+
+	set vertexColors( value ) {
+
+		if ( value !== this._vertexColors ) {
+
+			this._vertexColors = value;
 			this.needsUpdate = true;
 
 		}

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -18,7 +18,6 @@ function Material() {
 	this.name = '';
 	this.type = 'Material';
 
-	this.fog = true;
 	this.lights = true;
 
 	this.blending = NormalBlending;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -22,7 +22,6 @@ function Material() {
 	this.lights = true;
 
 	this.blending = NormalBlending;
-	this.side = FrontSide;
 	this.shading = SmoothShading; // THREE.FlatShading, THREE.SmoothShading
 	this.vertexColors = NoColors; // THREE.NoColors, THREE.VertexColors, THREE.FaceColors
 
@@ -52,14 +51,16 @@ function Material() {
 	this.polygonOffsetFactor = 0;
 	this.polygonOffsetUnits = 0;
 
-	this.alphaTest = 0;
 	this.premultipliedAlpha = false;
 
 	this.overdraw = 0; // Overdrawn pixels (typically between 0 and 1) for fixing antialiasing gaps in CanvasRenderer
 
 	this.visible = true;
 
+	//Private properties
+	this._alphaTest = 0;
 	this._needsUpdate = true;
+	this._side = FrontSide;
 
 }
 
@@ -68,6 +69,40 @@ Material.prototype = {
 	constructor: Material,
 
 	isMaterial: true,
+
+	get alphaTest() {
+
+		return this._alphaTest;
+
+	},
+
+	set alphaTest( value ) {
+
+		if ( value !== this._alphaTest ) {
+
+			this._alphaTest = value;
+			this.needsUpdate = true;
+
+		}
+
+	},
+
+	get side() {
+
+		return this._side;
+
+	},
+
+	set side( value ) {
+
+		if ( value !== this._side ) {
+
+			this._side = value;
+			this.needsUpdate = true;
+
+		}
+
+	},
 
 	get needsUpdate() {
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -59,6 +59,7 @@ function Material() {
 
 	//Private properties
 	this._alphaTest = 0;
+	this._fog = true;
 	this._needsUpdate = true;
 	this._side = FrontSide;
 
@@ -87,17 +88,17 @@ Material.prototype = {
 
 	},
 
-	get side() {
+	get fog() {
 
-		return this._side;
+		return this._fog;
 
 	},
 
-	set side( value ) {
+	set fog( value ) {
 
-		if ( value !== this._side ) {
+		if ( value !== this._fog ) {
 
-			this._side = value;
+			this._fog = value;
 			this.needsUpdate = true;
 
 		}
@@ -117,6 +118,23 @@ Material.prototype = {
 
 	},
 
+	get side() {
+
+		return this._side;
+
+	},
+
+	set side( value ) {
+
+		if ( value !== this._side ) {
+
+			this._side = value;
+			this.needsUpdate = true;
+
+		}
+
+	},
+
 	setValues: function ( values ) {
 
 		if ( values === undefined ) return;
@@ -128,6 +146,15 @@ Material.prototype = {
 			if ( newValue === undefined ) {
 
 				console.warn( "THREE.Material: '" + key + "' parameter is undefined." );
+				continue;
+
+			}
+
+			//Check if there is a private version of the parameter and if so set that directly.
+			//This is to prevent needsUpdate being set multiple times on material creation
+			if ( this.hasOwnProperty( '_' + key ) ) {
+
+				this[ '_' + key ] = newValue;
 				continue;
 
 			}
@@ -370,6 +397,8 @@ Material.prototype = {
 	},
 
 	update: function () {
+
+		console.log( 'Material update called' );
 
 		this.dispatchEvent( { type: 'update' } );
 


### PR DESCRIPTION
Added setters and getters for the following material properties, which as far as I can tell will always need ```Material.needsUpdate``` set if they are changed after shader compilation:
- alphaTest
- fog
- side
- vertexColors

Changed ```Material.setValues``` method to accommodate the new private properties:
```js 
if ( this.hasOwnProperty( '_' + key ) ) {

    this[ '_' + key ] = newValue;
    continue;
}
```
This means that if there is a private version of the property (say ```Material._side``` ) it will set that instead of calling the setter for ```Material.side``` - this is to prevent ```Material.update``` being called several times by the constructor.