### PR TITLE
Set mapping property of envMap at proper timing in MMDLoader

### DIFF
--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -947,12 +947,6 @@ THREE.MMDLoader.prototype.createMesh = function ( model, texturePath, onProgress
 				t.wrapS = THREE.RepeatWrapping;
 				t.wrapT = THREE.RepeatWrapping;
 
-				if ( params.sphericalReflectionMapping === true ) {
-
-					t.mapping = THREE.SphericalReflectionMapping;
-
-				}
-
 				for ( var i = 0; i < texture.readyCallbacks.length; i++ ) {
 
 					texture.readyCallbacks[ i ]( texture );
@@ -962,6 +956,12 @@ THREE.MMDLoader.prototype.createMesh = function ( model, texturePath, onProgress
 				delete texture.readyCallbacks;
 
 			}, onProgress, onError );
+
+			if ( params.sphericalReflectionMapping === true ) {
+
+				texture.mapping = THREE.SphericalReflectionMapping;
+
+			}
 
 			texture.readyCallbacks = [];
 
@@ -1257,13 +1257,6 @@ THREE.MMDLoader.prototype.createMesh = function ( model, texturePath, onProgress
 
 				m.envMap = getTexture( p.envMap, textures );
 				m.combine = p.envMapType;
-
-				// TODO: WebGLRenderer should automatically update?
-				m.envMap.readyCallbacks.push( function ( t ) {
-
-					m.needsUpdate = true;
-
-				} );
 
 			}
 


### PR DESCRIPTION
This PR lets `MMDLoader` set `mapping` property  of `envMap` at proper timing and we can remove `material.needsUpdate=true` which is no longer necessary.