### PR TITLE
Optional makeEmpty in THREE.Box3

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -92,9 +92,7 @@ Box3.prototype = {
 
 	},
 
-	setFromPoints: function ( points, makeEmpty ) {
-
-		if (makeEmpty !== false) this.makeEmpty();
+	setFromPoints: function ( points ) {
 
 		for ( var i = 0, il = points.length; i < il; i ++ ) {
 
@@ -123,69 +121,13 @@ Box3.prototype = {
 
 	}(),
 
-	setFromObject: function () {
+	setFromObject: function ( object ) {
 
-		// Computes the world-axis-aligned bounding box of an object (including its children),
-		// accounting for both the object's, and children's, world transforms
+		this.makeEmpty();
 
-		var v1 = new Vector3();
+		this.expandByObject( object );
 
-		return function setFromObject( object, makeEmpty ) {
-
-			var scope = this;
-
-			object.updateMatrixWorld( true );
-
-			if (makeEmpty !== false) this.makeEmpty();
-
-			object.traverse( function ( node ) {
-
-				var i, l;
-
-				var geometry = node.geometry;
-
-				if ( geometry !== undefined ) {
-
-					if ( geometry.isGeometry ) {
-
-						var vertices = geometry.vertices;
-
-						for ( i = 0, l = vertices.length; i < l; i ++ ) {
-
-							v1.copy( vertices[ i ] );
-							v1.applyMatrix4( node.matrixWorld );
-
-							scope.expandByPoint( v1 );
-
-						}
-
-					} else if ( geometry.isBufferGeometry ) {
-
-						var attribute = geometry.attributes.position;
-
-						if ( attribute !== undefined ) {
-
-							for ( i = 0, l = attribute.count; i < l; i ++ ) {
-
-								v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
-
-								scope.expandByPoint( v1 );
-
-							}
-
-						}
-
-					}
-
-				}
-
-			} );
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	clone: function () {
 
@@ -259,6 +201,68 @@ Box3.prototype = {
 		return this;
 
 	},
+
+	expandByObject: function () {
+
+		// Computes the world-axis-aligned bounding box of an object (including its children),
+		// accounting for both the object's, and children's, world transforms
+
+		var v1 = new Vector3();
+
+		return function expandByObject( object ) {
+
+			var scope = this;
+
+			object.updateMatrixWorld( true );
+
+			object.traverse( function ( node ) {
+
+				var i, l;
+
+				var geometry = node.geometry;
+
+				if ( geometry !== undefined ) {
+
+					if ( geometry.isGeometry ) {
+
+						var vertices = geometry.vertices;
+
+						for ( i = 0, l = vertices.length; i < l; i ++ ) {
+
+							v1.copy( vertices[ i ] );
+							v1.applyMatrix4( node.matrixWorld );
+
+							scope.expandByPoint( v1 );
+
+						}
+
+					} else if ( geometry.isBufferGeometry ) {
+
+						var attribute = geometry.attributes.position;
+
+						if ( attribute !== undefined ) {
+
+							for ( i = 0, l = attribute.count; i < l; i ++ ) {
+
+								v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
+
+								scope.expandByPoint( v1 );
+
+							}
+
+						}
+
+					}
+
+				}
+
+			} );
+
+			return this;
+
+		};
+
+	}(),
 
 	containsPoint: function ( point ) {
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -92,9 +92,9 @@ Box3.prototype = {
 
 	},
 
-	setFromPoints: function ( points ) {
+	setFromPoints: function ( points, makeEmpty ) {
 
-		this.makeEmpty();
+		if (makeEmpty !== false) this.makeEmpty();
 
 		for ( var i = 0, il = points.length; i < il; i ++ ) {
 
@@ -130,13 +130,13 @@ Box3.prototype = {
 
 		var v1 = new Vector3();
 
-		return function setFromObject( object ) {
+		return function setFromObject( object, makeEmpty ) {
 
 			var scope = this;
 
 			object.updateMatrixWorld( true );
 
-			this.makeEmpty();
+			if (makeEmpty !== false) this.makeEmpty();
 
 			object.traverse( function ( node ) {
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -57,6 +57,7 @@ Box3.prototype = {
 		this.min.set( minX, minY, minZ );
 		this.max.set( maxX, maxY, maxZ );
 
+		return this;
 	},
 
 	setFromBufferAttribute: function ( attribute ) {

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -96,6 +96,8 @@ Box3.prototype = {
 
 	setFromPoints: function ( points ) {
 
+		this.makeEmpty();
+
 		for ( var i = 0, il = points.length; i < il; i ++ ) {
 
 			this.expandByPoint( points[ i ] );

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -58,6 +58,7 @@ Box3.prototype = {
 		this.max.set( maxX, maxY, maxZ );
 
 		return this;
+
 	},
 
 	setFromBufferAttribute: function ( attribute ) {

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -125,7 +125,7 @@ Box3.prototype = {
 
 		this.makeEmpty();
 
-		this.expandByObject( object );
+		return this.expandByObject( object );
 
 	},
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -90,6 +90,8 @@ Box3.prototype = {
 		this.min.set( minX, minY, minZ );
 		this.max.set( maxX, maxY, maxZ );
 
+		return this;
+
 	},
 
 	setFromPoints: function ( points ) {


### PR DESCRIPTION
Hi.
This solve problems with to collect parallel objects(no relationship) in THREE.Box3.
Otherwise would have to create a `Box3` for each object or add all in an single `Object3D`

```javascript
var meshes = [mesh1, mesh2, ..[n].. ]
var bbox = new THREE.Box3();

for(var i = 0; i < meshes.length; i++) {
	bbox.setFromObject( meshes[i], false ); // false = not call `makeEmpty`
}
```