### PR TITLE
GLTFLoader scenes support

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -54,12 +54,13 @@ THREE.GLTFLoader = ( function () {
 
 			} );
 
-			parser.parse( function ( scene, cameras, animations ) {
+			parser.parse( function ( scene, scenes, cameras, animations ) {
 
 				console.timeEnd( 'GLTFLoader' );
 
 				var glTF = {
 					"scene": scene,
+					"scenes": scenes,
 					"cameras": cameras,
 					"animations": animations
 				};
@@ -632,6 +633,14 @@ THREE.GLTFLoader = ( function () {
 
 			var scene = dependencies.scenes[ json.scene ];
 
+			var scenes = [];
+
+			for ( var name in dependencies.scenes ) {
+
+				scenes.push( dependencies.scenes[ name ] );
+
+			}
+
 			var cameras = [];
 
 			for ( var name in dependencies.cameras ) {
@@ -649,7 +658,7 @@ THREE.GLTFLoader = ( function () {
 
 			}
 
-			callback( scene, cameras, animations );
+			callback( scene, scenes, cameras, animations );
 
 		} );
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -250,7 +250,7 @@
 
 					gltf = data;
 
-					var object = gltf.scene;
+					var object = gltf.scene !== undefined ? gltf.scene : gltf.scenes[ 0 ];
 
 					var loadEndTime = Date.now();
 


### PR DESCRIPTION
In glTF, `scenes` can have multiple scenes and `scene` which identifies a default scene in `scenes` is optional.

https://github.com/KhronosGroup/glTF/tree/master/specification/1.0#scenes

But current `GLTFLoader` implementation expects glTF must have `scene` and
returns only one scene object specified by `scene` of glTF.

This issue is one of the reasons that some models in #10257 can't be loaded.

This PR lets `GLTFLoader` return all scenes objects specified by `scenes` of glTF
and enables users to select a scene object from them even if default scene isn't specified in glTF.
