### PR TITLE
Update Creating-text.html

### DIFF
--- a/docs/manual/introduction/Creating-text.html
+++ b/docs/manual/introduction/Creating-text.html
@@ -62,8 +62,9 @@
 		<div>
 			<p>
 				Use this method if you prefer to work purely in three.js or create procedural and dynamic 3d
-				text geometries. However, font data files <a href="http://typeface.neocracy.org/fonts.html">http://typeface.neocracy.org/fonts.html</a>
-				in the typeface.js format needs to be loaded.
+				text geometries. However, font data files in THREE.js JSON format needs to be loaded
+				(an example is provided in the 
+				<a href="https://raw.githubusercontent.com/mrdoob/three.js/master/examples/fonts/helvetiker_regular.typeface.json">THREE.js repo</a>).
 			</p>
 			<p>A Text Geometry can then be created with </p>
 			<code>new THREE.TextGeometry( text, parameters );</code>

--- a/docs/manual/introduction/Creating-text.html
+++ b/docs/manual/introduction/Creating-text.html
@@ -63,8 +63,8 @@
 			<p>
 				Use this method if you prefer to work purely in three.js or create procedural and dynamic 3d
 				text geometries. However, font data files in THREE.js JSON format needs to be loaded
-				(an example is provided in the 
-				<a href="https://raw.githubusercontent.com/mrdoob/three.js/master/examples/fonts/helvetiker_regular.typeface.json">THREE.js repo</a>).
+				before this will work.
+				See the [page:TextGeometry] page for examples of JSON fonts.
 			</p>
 			<p>A Text Geometry can then be created with </p>
 			<code>new THREE.TextGeometry( text, parameters );</code>


### PR DESCRIPTION
Since the javascript font specification is being deprecated, and typeface.neocracy.org is no longer operational, update the documentation to link to the JSON format found in the THREE.js git repo.