### PR TITLE
text earcut example: remove duplicate start end points

### DIFF
--- a/examples/webgl_geometry_text_earcut.html
+++ b/examples/webgl_geometry_text_earcut.html
@@ -47,24 +47,24 @@
 		<!-- replace built-in triangulation with Earcut -->
 		<script src="js/libs/earcut.js"></script>
 		<script>
-			
-			function removeDupEndPts(points) {
-				
-				var l = points.length;
-				if ( l > 2 && points[ l - 1 ].equals( points[ 0 ] ) ) {
-					points.pop();
-				}
-			}
-			
-			function addContour( vertices, contour ) {
-				
-				for ( var i = 0; i < contour.length; i++ ) {
-					vertices.push( contour[i].x );
-					vertices.push( contour[i].y );
-				}
-			}
 
 			THREE.ShapeUtils.triangulateShape = function ( contour, holes ) {
+				
+				function removeDupEndPts(points) {
+
+					var l = points.length;
+					if ( l > 2 && points[ l - 1 ].equals( points[ 0 ] ) ) {
+						points.pop();
+					}
+				}
+
+				function addContour( vertices, contour ) {
+
+					for ( var i = 0; i < contour.length; i++ ) {
+						vertices.push( contour[i].x );
+						vertices.push( contour[i].y );
+					}
+				}
 				
 				removeDupEndPts( contour );
 				holes.forEach( removeDupEndPts );

--- a/examples/webgl_geometry_text_earcut.html
+++ b/examples/webgl_geometry_text_earcut.html
@@ -47,50 +47,55 @@
 		<!-- replace built-in triangulation with Earcut -->
 		<script src="js/libs/earcut.js"></script>
 		<script>
-
 			THREE.ShapeUtils.triangulateShape = function ( contour, holes ) {
-				
-				function removeDupEndPts(points) {
+
+				function removeDupEndPts( points ) {
 
 					var l = points.length;
 					if ( l > 2 && points[ l - 1 ].equals( points[ 0 ] ) ) {
+
 						points.pop();
+
 					}
+
 				}
 
 				function addContour( vertices, contour ) {
 
-					for ( var i = 0; i < contour.length; i++ ) {
-						vertices.push( contour[i].x );
-						vertices.push( contour[i].y );
+					for ( var i = 0; i < contour.length; i ++ ) {
+
+						vertices.push( contour[ i ].x );
+						vertices.push( contour[ i ].y );
+
 					}
+
 				}
-				
+
 				removeDupEndPts( contour );
 				holes.forEach( removeDupEndPts );
 
 				var vertices = [];
-
 				addContour( vertices, contour );
-
 				var holeIndices = [];
 				var holeIndex = contour.length;
+				for ( i = 0; i < holes.length; i ++ ) {
 
-				for ( i = 0; i < holes.length; i++ ) {
 					holeIndices.push( holeIndex );
-					holeIndex += holes[i].length;
-					addContour( vertices, holes[i] );
+					holeIndex += holes[ i ].length;
+					addContour( vertices, holes[ i ] );
+
 				}
 
 				var result = earcut( vertices, holeIndices, 2 );
-
 				var grouped = [];
 				for ( var i = 0; i < result.length; i += 3 ) {
+
 					grouped.push( result.slice( i, i + 3 ) );
+
 				}
-				
+
 				return grouped;
-				
+
 			};
 			
 		</script>

--- a/examples/webgl_geometry_text_earcut.html
+++ b/examples/webgl_geometry_text_earcut.html
@@ -47,37 +47,53 @@
 		<!-- replace built-in triangulation with Earcut -->
 		<script src="js/libs/earcut.js"></script>
 		<script>
+			
+			function removeDupEndPts(points) {
+				
+				var l = points.length;
+				if ( l > 2 && points[ l - 1 ].equals( points[ 0 ] ) ) {
+					points.pop();
+				}
+			}
+			
 			function addContour( vertices, contour ) {
-			    for ( var i = 0; i < contour.length; i++ ) {
-			        vertices.push( contour[i].x );
-			        vertices.push( contour[i].y );
-			    }
+				
+				for ( var i = 0; i < contour.length; i++ ) {
+					vertices.push( contour[i].x );
+					vertices.push( contour[i].y );
+				}
 			}
 
 			THREE.ShapeUtils.triangulateShape = function ( contour, holes ) {
-			    var vertices = [];
+				
+				removeDupEndPts( contour );
+				holes.forEach( removeDupEndPts );
 
-			    addContour( vertices, contour );
+				var vertices = [];
 
-			    var holeIndices = [];
-			    var holeIndex = contour.length;
+				addContour( vertices, contour );
 
-			    for ( i = 0; i < holes.length; i++ ) {
-			        holeIndices.push( holeIndex );
-			        holeIndex += holes[i].length;
-			        addContour( vertices, holes[i] );
-			    }
+				var holeIndices = [];
+				var holeIndex = contour.length;
 
-			    var result = earcut( vertices, holeIndices, 2 );
+				for ( i = 0; i < holes.length; i++ ) {
+					holeIndices.push( holeIndex );
+					holeIndex += holes[i].length;
+					addContour( vertices, holes[i] );
+				}
 
-			    var grouped = [];
-			    for ( var i = 0; i < result.length; i += 3 ) {
-			        grouped.push( result.slice( i, i + 3 ) );
-			    }
-			    return grouped;
+				var result = earcut( vertices, holeIndices, 2 );
+
+				var grouped = [];
+				for ( var i = 0; i < result.length; i += 3 ) {
+					grouped.push( result.slice( i, i + 3 ) );
+				}
+				
+				return grouped;
+				
 			};
+			
 		</script>
-
 
 		<script>
 


### PR DESCRIPTION
addresses #10496 : grooves only when bevel is present

See #10438 bottom for discussion

Executive summary: The grooves in the letters were a result of not removing duplicate end/start points which is required for the bevel function to work correctly. This #PR simply removes duplicate start/end points.

Discussion:

Duplicate start/end points are removed using the same function which the native triangulateShape() and PnlTri text example also use. I am not sure if native and PnlTri require this removal to function correctly (more likely) or if including the removal with the triangulation was just a convenient place to ensure that bevel also works correctly (less likely). I know that Earcut does not need this removal because it does its own filtering. This is presumably why the removal has not been included in the example previously (speculation, might have been just an oversight).

Conclusion:

The glitches previously seen in the earcut text example are unrelated to the earcut triangulation method, and only require a small fix. Looking ahead, it appears that both Earcut and PnlTri are viable candidates for replacing the native triangulateShape() function if there is a demand. Earcut benefits include the general benefits of using well-tested libraries and likely better performance for large polygons (complicated fonts, for example). Drawbacks are that some applications may rely on the particular triangulation that native now produces and that there is perhaps neglible dissatisfaction with the current situation.



See #10438 