### PR TITLE
Fix default value for divisions

### DIFF
--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -67,7 +67,7 @@ Curve.prototype = {
 
 	getPoints: function ( divisions ) {
 
-		if ( ! divisions ) divisions = 5;
+		if ( isNaN( divisions ) ) divisions = 5;
 
 		var points = [];
 
@@ -85,7 +85,7 @@ Curve.prototype = {
 
 	getSpacedPoints: function ( divisions ) {
 
-		if ( ! divisions ) divisions = 5;
+		if ( isNaN( divisions ) ) divisions = 5;
 
 		var points = [];
 
@@ -112,7 +112,7 @@ Curve.prototype = {
 
 	getLengths: function ( divisions ) {
 
-		if ( ! divisions ) divisions = ( this.__arcLengthDivisions ) ? ( this.__arcLengthDivisions ) : 200;
+		if ( isNaN( divisions ) ) divisions = ( this.__arcLengthDivisions ) ? ( this.__arcLengthDivisions ) : 200;
 
 		if ( this.cacheArcLengths
 			&& ( this.cacheArcLengths.length === divisions + 1 )

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -139,7 +139,7 @@ CurvePath.prototype = Object.assign( Object.create( Curve.prototype ), {
 
 	getSpacedPoints: function ( divisions ) {
 
-		if ( ! divisions ) divisions = 40;
+		if ( isNaN( divisions ) ) divisions = 40;
 
 		var points = [];
 


### PR DESCRIPTION
I was using the ``getPoints`` function from ``Curve`` and I accidentally passed a string to the function and encountered a hard crash. Here is a simple test case to reproduce the problem.

```js
var curve = new THREE.CatmullRomCurve3( [
	new THREE.Vector3( -10, 0, 10 ),
	new THREE.Vector3( -5, 5, 5 ),
	new THREE.Vector3( 0, 0, 0 ),
	new THREE.Vector3( 5, -5, 5 ),
	new THREE.Vector3( 10, 0, 10 )
] );

curve.getPoints( ' ' );
```

Here is the stack trace from the crash:
```
var dx = this.x - v.x, dy = this.y - v.y, dz = this.z - v.z;
			                   ^
TypeError: Cannot read property 'x' of undefined
    at Vector3.distanceToSquared (/path/three.js:3213:23)
    at CatmullRomCurve3.getPoint (/path/three.js:41184:27)
    at CatmullRomCurve3.getPoints (/path/three/three.js:33754:23)
```

I notice from the API that ``divisions`` should be an integer and the guard condition ``! divisions`` set ``divisions`` to 5 for any non-integer values. However, a non-empty string evaluates to true and hence ``divisions`` is not set to the default value 5. Using ``isNaN`` as the guard condition can prevent the above problem.