### PR TITLE
Load vertex color buffers from glTF models

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1202,6 +1202,12 @@ THREE.GLTFLoader = ( function () {
 									geometry.addAttribute( 'uv', bufferAttribute );
 									break;
 
+								case 'COLOR_0':
+								case 'COLOR0':
+								case 'COLOR':
+									geometry.addAttribute( 'color', bufferAttribute );
+									break;
+
 								case 'WEIGHT':
 									geometry.addAttribute( 'skinWeight', bufferAttribute );
 									break;


### PR DESCRIPTION
There is an upstream bug that prevents me from properly testing this, but I believe this PR works. If a mesh in a glTF model specifies a color attribute, that attribute is also added to the Three.js geometry.