### PR TITLE
Fix Race Condition inside ImageLoader for base64

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -17,6 +17,8 @@ Object.assign( ImageLoader.prototype, {
 
 		var scope = this;
 
+		scope.manager.itemStart( url );
+
 		var image = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'img' );
 		image.onload = function () {
 
@@ -55,8 +57,6 @@ Object.assign( ImageLoader.prototype, {
 			}, onProgress, onError );
 
 		}
-
-		scope.manager.itemStart( url );
 
 		return image;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -99,16 +99,9 @@ Object.assign( ObjectLoader.prototype, {
 	parse: function ( json, onLoad ) {
 
 		var geometries = this.parseGeometries( json.geometries );
-
-		var images = this.parseImages( json.images, function () {
-
-			if ( onLoad !== undefined ) onLoad( object );
-
-		} );
-
+		var images = this.parseImages( json.images );
 		var textures = this.parseTextures( json.textures, images );
 		var materials = this.parseMaterials( json.materials, textures );
-
 		var object = this.parseObject( json.object, geometries, materials );
 
 		if ( json.animations ) {
@@ -117,11 +110,7 @@ Object.assign( ObjectLoader.prototype, {
 
 		}
 
-		if ( json.images === undefined || json.images.length === 0 ) {
-
-			if ( onLoad !== undefined ) onLoad( object );
-
-		}
+		if ( onLoad !== undefined ) onLoad( object );
 
 		return object;
 


### PR DESCRIPTION
Experienced this while using Node. Basically the issue resides when
using `THREE.ObjectLoader` where the images in the JSON are base64.

On my very fast system, it was called the `THREE.LoadingManager`
`itemEnd` before the `itemStart` . Causing the callback `onLoad` for
the `LoadingManager`to never get called.

When using `THREE.ObjectLoader` it tries to call `parseImages` which
has a load callback. When the machine is too quick, it misses the
synchronization to decide when to fire the `onLoad` and it ends up
in a stale state.  This was tested by monitoring the states and it was 
clearly calling end before start.

By moving the `scope.manager.itemStart( url )` to the start of the
function, that fixes the synchronization.