### PR TITLE
Fixed cloning BufferAttribute

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -331,7 +331,7 @@ BufferAttribute.prototype = {
 
 	clone: function () {
 
-		return new this.constructor().copy( this );
+		return new this.constructor( this.array, this.itemSize ).copy( this );
 
 	}
 


### PR DESCRIPTION
When wanting to clone some BufferAttributes (like Float32BufferAttribute), ThreeJS is running into an error because the constructor is not providing any array and itemSize. With the Float32BufferAttribute example, it leads to not be able to construct a Float32Array during construction here :
```javascript
function Float32BufferAttribute( array, itemSize ) {

	BufferAttribute.call( this, new Float32Array( array ), itemSize );

}
```

This modification fixes the problem.

I'm not sure if it is the right solution, but it seems to be the simpler to implement.