### PR TITLE
Editor: Fixed autoscrolling

### DIFF
--- a/editor/js/Script.js
+++ b/editor/js/Script.js
@@ -84,7 +84,7 @@ var Script = function ( editor ) {
 
 				if ( value !== currentScript.source ) {
 
-					editor.execute( new SetScriptValueCommand( currentObject, currentScript, 'source', value, codemirror.getCursor() ) );
+					editor.execute( new SetScriptValueCommand( currentObject, currentScript, 'source', value, codemirror.getCursor(), codemirror.getScrollInfo() ) );
 
 				}
 				return;
@@ -422,7 +422,7 @@ var Script = function ( editor ) {
 
 	} );
 
-	signals.refreshScriptEditor.add( function ( object, script, cursorPosition ) {
+	signals.refreshScriptEditor.add( function ( object, script, cursorPosition, scrollInfo ) {
 
 		if ( currentScript !== script ) return;
 
@@ -435,6 +435,7 @@ var Script = function ( editor ) {
 		if ( cursorPosition !== undefined ) {
 
 			codemirror.setCursor( cursorPosition );
+			codemirror.scrollTo( scrollInfo.left, scrollInfo.top );
 
 		}
 		codemirror.setHistory( history ); // setting the history to previous state

--- a/editor/js/commands/SetScriptValueCommand.js
+++ b/editor/js/commands/SetScriptValueCommand.js
@@ -9,10 +9,11 @@
  * @param attributeName string
  * @param newValue string, object
  * @param cursorPosition javascript object with format {line: 2, ch: 3}
+ * @param scrollInfo javascript object with values {left, top, width, height, clientWidth, clientHeight}
  * @constructor
  */
 
-var SetScriptValueCommand = function ( object, script, attributeName, newValue, cursorPosition ) {
+var SetScriptValueCommand = function ( object, script, attributeName, newValue, cursorPosition, scrollInfo ) {
 
 	Command.call( this );
 
@@ -27,6 +28,7 @@ var SetScriptValueCommand = function ( object, script, attributeName, newValue, 
 	this.oldValue = ( script !== undefined ) ? script[ this.attributeName ] : undefined;
 	this.newValue = newValue;
 	this.cursorPosition = cursorPosition;
+	this.scrollInfo = scrollInfo;
 
 };
 
@@ -37,7 +39,7 @@ SetScriptValueCommand.prototype = {
 		this.script[ this.attributeName ] = this.newValue;
 
 		this.editor.signals.scriptChanged.dispatch();
-		this.editor.signals.refreshScriptEditor.dispatch( this.object, this.script, this.cursorPosition );
+		this.editor.signals.refreshScriptEditor.dispatch( this.object, this.script, this.cursorPosition, this.scrollInfo );
 
 	},
 
@@ -46,13 +48,14 @@ SetScriptValueCommand.prototype = {
 		this.script[ this.attributeName ] = this.oldValue;
 
 		this.editor.signals.scriptChanged.dispatch();
-		this.editor.signals.refreshScriptEditor.dispatch( this.object, this.script, this.cursorPosition );
+		this.editor.signals.refreshScriptEditor.dispatch( this.object, this.script, this.cursorPosition, this.scrollInfo );
 
 	},
 
 	update: function ( cmd ) {
 
 		this.cursorPosition = cmd.cursorPosition;
+		this.scrollInfo = cmd.scrollInfo;
 		this.newValue = cmd.newValue;
 
 	},
@@ -67,6 +70,7 @@ SetScriptValueCommand.prototype = {
 		output.oldValue = this.oldValue;
 		output.newValue = this.newValue;
 		output.cursorPosition = this.cursorPosition;
+		output.scrollInfo = this.scrollInfo;
 
 		return output;
 
@@ -82,6 +86,7 @@ SetScriptValueCommand.prototype = {
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.script = this.editor.scripts[ json.objectUuid ][ json.index ];
 		this.cursorPosition = json.cursorPosition;
+		this.scrollInfo = json.scrollInfo;
 
 	}
 


### PR DESCRIPTION
see #10518

The editor now uses the `codemirror` methods `.scrollTo(x: number, y: number)` and `.getScrollInfo()`.

see https://codemirror.net/doc/manual.html#api_sizing