### PR TITLE
Fix rotation animation bug of GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -271,7 +271,9 @@ THREE.GLTFLoader = ( function () {
 			interp.target.updateMatrix();
 			interp.target.matrixAutoUpdate = true;
 
-			tracks.push( new THREE.KeyframeTrack(
+			var trackType = /\.quaternion/.test( interp.name ) ? 'QuaternionKeyframeTrack' : 'VectorKeyframeTrack';
+
+			tracks.push( new THREE[ trackType ](
 				interp.name,
 				interp.times,
 				interp.values,


### PR DESCRIPTION
This PR fixes rotation animation bug of `GLTFLoader`.

This change fixes #10528