### PR TITLE
Docs: Don't fire hashchange event when typing in filter query

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -249,7 +249,6 @@
 			var MEMBER_DELIMITER = '.';
 			var nameCategoryMap = {};
 			var sections = [];
-			var selected = null;
 
 			var content = document.getElementById( 'content' );
 
@@ -339,11 +338,10 @@
 
 				var v = filterInput.value;
 				if( v !== '' ) {
-					window.history.replaceState( {} , '', '?q=' + v );
+					window.history.replaceState( {} , '', '?q=' + v + window.location.hash );
 				} else {
-					window.history.replaceState( {} , '', window.location.pathname );
+					window.history.replaceState( {} , '', window.location.pathname + window.location.hash );
 				}
-				if( selected ) window.location.hash = selected;
 
 				var exp = new RegExp( filterInput.value, 'gi' );
 				for( var j in nameCategoryMap ) {
@@ -400,7 +398,6 @@
 
 				var title = 'three.js - documentation - ' + section + ' - ' + name;
 				var url = encodeUrl(section) + DELIMITER + encodeUrl( category ) + DELIMITER + encodeUrl(name) + (!!member ? MEMBER_DELIMITER + encodeUrl(member) : '');
-				selected = url;
 
 				window.location.hash = url;
 				window.document.title = title;

--- a/examples/index.html
+++ b/examples/index.html
@@ -379,11 +379,10 @@
 
 			var v = filterInput.value;
 			if( v !== '' ) {
-				window.history.replaceState( {} , '', '?q=' + v );
+				window.history.replaceState( {} , '', '?q=' + v + window.location.hash );
 			} else {
-				window.history.replaceState( {} , '', window.location.pathname );
+				window.history.replaceState( {} , '', window.location.pathname + window.location.hash );
 			}
-			if( selected ) window.location.hash = selected;
 
 			var exp = new RegExp( v, 'gi' );
 


### PR DESCRIPTION
This PR fixes a bug in the docs site where the filter bar can lose focus as you're typing in it. It also suppresses the annoying redraw flash on each keypress.

To reproduce the bug:
*  Load a docs page that links to an anchor within the page, e.g. [PerspectiveCamera.aspect](https://threejs.org/docs/index.html#Reference/Cameras/PerspectiveCamera.aspect).
* Type into the page filter input. Every keypress annoyingly shifts focus back to the anchor link.

This is an issue in Mac Chrome but seems to not affect Safari.