### PR TITLE
Patch over circular dep between Box3 and Sphere

### DIFF
--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -32,7 +32,7 @@ Sphere.prototype = {
 
 		return function setFromPoints( points, optionalCenter ) {
 
-			box = box || new Box3();
+			if ( box === undefined ) box = new Box3(); // see #10547
 
 			var center = this.center;
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -28,9 +28,11 @@ Sphere.prototype = {
 
 	setFromPoints: function () {
 
-		var box = new Box3();
+		var box;
 
 		return function setFromPoints( points, optionalCenter ) {
+
+			box = box || new Box3();
 
 			var center = this.center;
 


### PR DESCRIPTION
Box3 relies on Sphere, and Sphere relies on Box3 to instantiate an instance of Box3 and use that instance's methods inside `setFromPoints`. This is a fairly naive patch to resolve the circular dependency so that we can load three.js source files using webpack / babel.