### PR TITLE
GLTFShader: Update scene and camera matrices once, globally.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -107,6 +107,15 @@ THREE.GLTFLoader = ( function () {
 
 			update: function ( scene, camera ) {
 
+				// update scene graph
+
+				scene.updateMatrixWorld();
+
+				// update camera matrices and frustum
+
+				camera.updateMatrixWorld();
+				camera.matrixWorldInverse.getInverse( camera.matrixWorld );
+
 				for ( var name in objects ) {
 
 					var object = objects[ name ];
@@ -173,15 +182,6 @@ THREE.GLTFLoader = ( function () {
 
 	// Update - update all the uniform values
 	GLTFShader.prototype.update = function ( scene, camera ) {
-
-		// update scene graph
-
-		scene.updateMatrixWorld();
-
-		// update camera matrices and frustum
-
-		camera.updateMatrixWorld();
-		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
 
 		var boundUniforms = this.boundUniforms;
 


### PR DESCRIPTION
Fixes #8431.

^Or I assume so. I don't have a scene that really reproduces the issue, but this seems like the low-hanging optimization.