### PR TITLE
Fixed link in docs to polyfills page and src

### DIFF
--- a/docs/api/Polyfills.html
+++ b/docs/api/Polyfills.html
@@ -41,6 +41,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/polyfills.js src/polyfills.js]
 	</body>
 </html>

--- a/docs/list.js
+++ b/docs/list.js
@@ -360,7 +360,7 @@ var list = {
 
 	"Developer Reference": {
 		"Polyfills": [
-			[ "Polyfills", "api/polyfills" ]
+			[ "Polyfills", "api/Polyfills" ]
 		],
 
 		"WebGLRenderer": [


### PR DESCRIPTION
Minor error in list.js: api/polyfills -> api/Polyfills

Strangely enough my local version of the docs which I am running with Apache loaded the page fine...

Also updated the src link.