### PR TITLE
fix sample direction cubemap

### DIFF
--- a/examples/js/pmrem/PMREMCubeUVPacker.js
+++ b/examples/js/pmrem/PMREMCubeUVPacker.js
@@ -156,17 +156,17 @@ THREE.PMREMCubeUVPacker.prototype = {
 					uv = uv * 2.0 - 1.0;\
 					uv.y *= -1.0;\
 					if(faceIndex == 0) {\
-						sampleDirection = normalize(vec3(1.0, uv.y, -uv.x));\
+						sampleDirection = normalize(vec3(-1.0, uv.y, -uv.x));\
 					} else if(faceIndex == 1) {\
-						sampleDirection = normalize(vec3(uv.x, 1.0, uv.y));\
+						sampleDirection = normalize(vec3(-uv.x, 1.0, uv.y));\
 					} else if(faceIndex == 2) {\
-						sampleDirection = normalize(vec3(uv.x, uv.y, 1.0));\
+						sampleDirection = normalize(vec3(-uv.x, uv.y, 1.0));\
 					} else if(faceIndex == 3) {\
-						sampleDirection = normalize(vec3(-1.0, uv.y, uv.x));\
+						sampleDirection = normalize(vec3(1.0, uv.y, uv.x));\
 					} else if(faceIndex == 4) {\
-						sampleDirection = normalize(vec3(uv.x, -1.0, -uv.y));\
+						sampleDirection = normalize(vec3(-uv.x, -1.0, -uv.y));\
 					} else {\
-						sampleDirection = normalize(vec3(-uv.x, uv.y, -1.0));\
+						sampleDirection = normalize(vec3(uv.x, uv.y, -1.0));\
 					}\
 					vec4 color = envMapTexelToLinear( textureCube( envMap, sampleDirection ) );\
 					gl_FragColor = linearToOutputTexel( color );\


### PR DESCRIPTION
Testing pbr examples with a simple cube, i saw that there is a bug with face orientation in prefiltered mipmaped radiance environment maps.

Wrong example:
http://www.neveroccurs.com/lab/wrong_hdrcubemap/

Correct example:
http://www.neveroccurs.com/lab/correct_hdrcubemap/

This pull request match orientation with non prefiltered cube maps that are looking correct to me

 