### PR TITLE
fix an MTK device bug

### DIFF
--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -467,7 +467,7 @@ function WebGLUniforms( gl, program, renderer ) {
 
 	var n = gl.getProgramParameter( program, gl.ACTIVE_UNIFORMS );
 
-	for ( var i = 0; i !== n; ++ i ) {
+	for ( var i = 0; i < n; ++ i ) {
 
 		var info = gl.getActiveUniform( program, i ),
 			path = info.name,


### PR DESCRIPTION
In some Chinese MTK android device,like Redmi Note 2, gl.getProgramParameter( program, gl.ACTIVE_UNIFORMS ) will return null but not 0, which will thow an Error. 
This Commit can fix it.