### PR TITLE
Remove invalid check for extension materials on root glTF object.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1107,10 +1107,6 @@ THREE.GLTFLoader = ( function () {
 
 					khr_material = material.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ];
 
-				} else if ( json.extensions && json.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ] ) {
-
-					khr_material = json.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ];
-
 				}
 
 				if ( khr_material ) {


### PR DESCRIPTION
Fixes #10572.

/cc @cx20 @takahirox 

If I'm reading the [extension spec](https://github.com/KhronosGroup/glTF/tree/master/extensions/Khronos/KHR_materials_common) correctly, extension materials are attached to default material objects, not to the top-level glTF object:

> Common materials are defined by adding an extensions property to any glTF material, and defining its KHR_materials_common property.

Lights can be attached to that top-level object, but there's no equivalent global material or anything. So, I think that looking for a material in `material.extensions` is correct but `json.extensions` is not.