### PR TITLE
Fix missing sampleValues or resultBuffer for copySampleValue_

### DIFF
--- a/src/math/Interpolant.js
+++ b/src/math/Interpolant.js
@@ -219,6 +219,12 @@ Interpolant.prototype = {
 			stride = this.valueSize,
 			offset = index * stride;
 
+		if ( !Array.isArray( result ) || !Array.isArray( values ) ) {
+			
+			return [];
+
+		}
+
 		for ( var i = 0; i !== stride; ++ i ) {
 
 			result[ i ] = values[ offset + i ];

--- a/test/unit/math/Interpolant.js
+++ b/test/unit/math/Interpolant.js
@@ -70,6 +70,10 @@ test( "copySampleValue_", function() {
 	deepEqual( interpolant.copySampleValue_( 1 ), [ 2, 22 ], "sample fetch (1)" );
 	deepEqual( interpolant.copySampleValue_( 2 ), [ 3, 33 ], "first sample (2)" );
 
+	interpolant = new Mock( [ 11, 22, 33 ], null, 1, null );
+
+	deepEqual( interpolant.copySampleValue_( 0 ), [ ], "first sample (0) with no result buffer" );
+	
 } );
 
 test( "evaluate -> intervalChanged_ / interpolate_", function() {


### PR DESCRIPTION
When either the ``sampleValues`` or the ``resultBuffer`` of the function ``copySampleValue_``  is not supplied the following hard crash occurs. Added a fix that returns an empty array if either one is missing and the corresponding test case to reproduce the problem.

```
				result[ i ] = values[ offset + i ];
				                    ^

TypeError: Cannot read property '0' of null
    at Mock.copySampleValue_ (/path/three.js:30511:25)
```