### PR TITLE
Blender JSON exporter texture wrapping

### DIFF
--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -257,9 +257,9 @@ URL = 'url'
 WRAP = 'wrap'
 REPEAT = 'repeat'
 WRAPPING = type('Wrapping', (), {
-    'REPEAT': 'RepeatWrapping',
-    'CLAMP': 'ClampToEdgeWrapping',
-    'MIRROR': 'MirroredRepeatWrapping'
+    'REPEAT': 'repeat',
+    'CLAMP': 'clamp',
+    'MIRROR': 'mirror'
 })
 ANISOTROPY = 'anisotropy'
 MAG_FILTER = 'magFilter'


### PR DESCRIPTION
Loader.js loadTexture method looks for 'repeat' or 'mirror' strings but  Blender JSON exporter write them as 'RepeatWrapping' and 'MirrorerRepeatWrapping'.

Loader code:
```
if ( wrap[ 0 ] === 'repeat' ) texture.wrapS = RepeatWrapping;
if ( wrap[ 0 ] === 'mirror' ) texture.wrapS = MirroredRepeatWrapping;

if ( wrap[ 1 ] === 'repeat' ) texture.wrapT = RepeatWrapping;
if ( wrap[ 1 ] === 'mirror' ) texture.wrapT = MirroredRepeatWrapping;
```

Current blender json export output:
     "mapDiffuse":"window.png",
     "mapDiffuseWrap":["RepeatWrapping","RepeatWrapping"], //loaded texture use ClampToEdgeWrapping

Should be:
     "mapDiffuse":"window.png",
     "mapDiffuseWrap":["repeat","repeat"], //loaded texture use RepeatWrapping