### PR TITLE
Stricter glTF texture support

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1072,6 +1072,15 @@ THREE.GLTFLoader = ( function () {
 
 							if ( texture.name !== undefined ) _texture.name = texture.name;
 
+							_texture.format = texture.format !== undefined ? WEBGL_TEXTURE_FORMATS[ texture.format ] : THREE.RGBAFormat;
+
+							if ( texture.internalFormat !== undefined && _texture.format !== WEBGL_TEXTURE_FORMATS[ texture.internalFormat ] ) {
+
+								console.warn( 'THREE.GLTFLoader: Three.js doesn\'t support texture internalFormat which is different from texture format. ' +
+								              'internalFormat will be forced to be the same value as format.' );
+
+							}
+
 							_texture.type = texture.type !== undefined ? WEBGL_TEXTURE_TYPES[ texture.type ] : THREE.UnsignedByteType;
 
 							if ( texture.sampler ) {

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -471,7 +471,7 @@ THREE.GLTFLoader = ( function () {
 		6410: THREE.LuminanceAlphaFormat
 	};
 
-	var WEBGL_TEXTURE_TYPES = {
+	var WEBGL_TEXTURE_DATATYPES = {
 		5121: THREE.UnsignedByteType,
 		32819: THREE.UnsignedShort4444Type,
 		32820: THREE.UnsignedShort5551Type,
@@ -1081,7 +1081,7 @@ THREE.GLTFLoader = ( function () {
 
 							}
 
-							_texture.type = texture.type !== undefined ? WEBGL_TEXTURE_TYPES[ texture.type ] : THREE.UnsignedByteType;
+							_texture.type = texture.type !== undefined ? WEBGL_TEXTURE_DATATYPES[ texture.type ] : THREE.UnsignedByteType;
 
 							if ( texture.sampler ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1070,6 +1070,8 @@ THREE.GLTFLoader = ( function () {
 
 							_texture.flipY = false;
 
+							if ( texture.name !== undefined ) _texture.name = texture.name;
+
 							if ( texture.sampler ) {
 
 								var sampler = json.samplers[ texture.sampler ];

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1072,6 +1072,8 @@ THREE.GLTFLoader = ( function () {
 
 							if ( texture.name !== undefined ) _texture.name = texture.name;
 
+							_texture.type = texture.type !== undefined ? WEBGL_TEXTURE_TYPES[ texture.type ] : THREE.UnsignedByteType;
+
 							if ( texture.sampler ) {
 
 								var sampler = json.samplers[ texture.sampler ];

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -463,6 +463,21 @@ THREE.GLTFLoader = ( function () {
 		10497: THREE.RepeatWrapping
 	};
 
+	var WEBGL_TEXTURE_FORMATS = {
+		6406: THREE.AlphaFormat,
+		6407: THREE.RGBFormat,
+		6408: THREE.RGBAFormat,
+		6409: THREE.LuminanceFormat,
+		6410: THREE.LuminanceAlphaFormat
+	};
+
+	var WEBGL_TEXTURE_TYPES = {
+		5121: THREE.UnsignedByteType,
+		32819: THREE.UnsignedShort4444Type,
+		32820: THREE.UnsignedShort5551Type,
+		33635: THREE.UnsignedShort565Type
+	};
+
 	var WEBGL_SIDES = {
 		1028: THREE.BackSide,  // Culling front
 		1029: THREE.FrontSide  // Culling back


### PR DESCRIPTION
This PR lets `GLTFLoader` support stricter glTF texture parameters.

Refer to https://github.com/KhronosGroup/glTF/tree/master/specification/1.0#texture
