### PR TITLE
Fix for #10582

### DIFF
--- a/examples/js/WaterShader.js
+++ b/examples/js/WaterShader.js
@@ -39,7 +39,8 @@ THREE.ShaderLib[ 'water' ] = {
 		'	mirrorCoord = modelMatrix * vec4( position, 1.0 );',
 		'	worldPosition = mirrorCoord.xyz;',
 		'	mirrorCoord = textureMatrix * mirrorCoord;',
-		'	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
+		'   vec4 mvPosition =  modelViewMatrix * vec4( position, 1.0 );',
+		'	gl_Position = projectionMatrix * mvPosition;',
 
 		THREE.ShaderChunk[ "fog_vertex"],
 
@@ -109,8 +110,10 @@ THREE.ShaderLib[ 'water' ] = {
 		'	vec3 scatter = max( 0.0, dot( surfaceNormal, eyeDirection ) ) * waterColor;',
 		'	vec3 albedo = mix( sunColor * diffuseLight * 0.3 + scatter, ( vec3( 0.1 ) + reflectionSample * 0.9 + reflectionSample * specularLight ), reflectance );',
 		'	vec3 outgoingLight = albedo;',
-			THREE.ShaderChunk[ "fog_fragment" ],
 		'	gl_FragColor = vec4( outgoingLight, alpha );',
+
+			THREE.ShaderChunk[ "fog_fragment" ],
+
 		'}'
 	].join( '\n' )
 

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -79,6 +79,7 @@
 				container.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
+				scene.fog = new THREE.FogExp2(0xaabbbb, 0.0001);
 
 				camera = new THREE.PerspectiveCamera( 55, window.innerWidth / window.innerHeight, 0.5, 3000000 );
 				camera.position.set( 2000, 750, 2000 );
@@ -108,7 +109,8 @@
 					sunDirection: light.position.clone().normalize(),
 					sunColor: 0xffffff,
 					waterColor: 0x001e0f,
-					distortionScale: 50.0
+					distortionScale: 50.0,
+					fog: scene.fog != undefined
 				} );
 
 


### PR DESCRIPTION
Fix for #10582
THREE.ShaderChunk[ "fog_vertex"] needs vec4 mvPosition for calculating fogDepth after #10497,
THREE.ShaderChunk[ "fog_fragment" ] needs to be included after calculating fragColor for applying fog.
Added fog to example for testing.