### PR TITLE
Fix Helpers docs paths

### DIFF
--- a/docs/api/helpers/ArrowHelper.html
+++ b/docs/api/helpers/ArrowHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/AxisHelper.html
+++ b/docs/api/helpers/AxisHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/BoxHelper.html
+++ b/docs/api/helpers/BoxHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/CameraHelper.html
+++ b/docs/api/helpers/CameraHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/DirectionalLightHelper.html
+++ b/docs/api/helpers/DirectionalLightHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/FaceNormalsHelper.html
+++ b/docs/api/helpers/FaceNormalsHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/GridHelper.html
+++ b/docs/api/helpers/GridHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/HemisphereLightHelper.html
+++ b/docs/api/helpers/HemisphereLightHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/PointLightHelper.html
+++ b/docs/api/helpers/PointLightHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/PolarGridHelper.html
+++ b/docs/api/helpers/PolarGridHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/RectAreaLightHelper.html
+++ b/docs/api/helpers/RectAreaLightHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/SkeletonHelper.html
+++ b/docs/api/helpers/SkeletonHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/SpotLightHelper.html
+++ b/docs/api/helpers/SpotLightHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/api/helpers/VertexNormalsHelper.html
+++ b/docs/api/helpers/VertexNormalsHelper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<base href="../../../" />
+		<base href="../../" />
 		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/list.js
+++ b/docs/list.js
@@ -174,7 +174,7 @@ var list = {
 			[ "WireframeGeometry", "api/geometries/WireframeGeometry" ]
 		],
 
-		"Extras / Helpers": [
+		"Helpers": [
 			[ "ArrowHelper", "api/helpers/ArrowHelper" ],
 			[ "AxisHelper", "api/helpers/AxisHelper" ],
 			[ "BoxHelper", "api/helpers/BoxHelper" ],

--- a/docs/list.js
+++ b/docs/list.js
@@ -126,23 +126,6 @@ var list = {
 			[ "SplineCurve", "api/extras/curves/SplineCurve" ]
 		],
 
-		"Extras / Helpers": [
-			[ "ArrowHelper", "api/extras/helpers/ArrowHelper" ],
-			[ "AxisHelper", "api/extras/helpers/AxisHelper" ],
-			[ "BoxHelper", "api/extras/helpers/BoxHelper" ],
-			[ "CameraHelper", "api/extras/helpers/CameraHelper" ],
-			[ "DirectionalLightHelper", "api/extras/helpers/DirectionalLightHelper" ],
-			[ "FaceNormalsHelper", "api/extras/helpers/FaceNormalsHelper" ],
-			[ "GridHelper", "api/extras/helpers/GridHelper" ],
-			[ "PolarGridHelper", "api/extras/helpers/PolarGridHelper"],
-			[ "HemisphereLightHelper", "api/extras/helpers/HemisphereLightHelper" ],
-			[ "PointLightHelper", "api/extras/helpers/PointLightHelper" ],
-			[ "RectAreaLightHelper", "api/extras/helpers/RectAreaLightHelper" ],
-			[ "SkeletonHelper", "api/extras/helpers/SkeletonHelper" ],
-			[ "SpotLightHelper", "api/extras/helpers/SpotLightHelper" ],
-			[ "VertexNormalsHelper", "api/extras/helpers/VertexNormalsHelper" ]
-		],
-
 		"Extras / Objects": [
 			[ "ImmediateRenderObject", "api/extras/objects/ImmediateRenderObject" ],
 			[ "MorphBlendMesh", "api/extras/objects/MorphBlendMesh" ]
@@ -189,6 +172,23 @@ var list = {
 			[ "TubeGeometry", "api/geometries/TubeGeometry" ],
 			[ "TubeBufferGeometry", "api/geometries/TubeBufferGeometry" ],
 			[ "WireframeGeometry", "api/geometries/WireframeGeometry" ]
+		],
+
+		"Extras / Helpers": [
+			[ "ArrowHelper", "api/helpers/ArrowHelper" ],
+			[ "AxisHelper", "api/helpers/AxisHelper" ],
+			[ "BoxHelper", "api/helpers/BoxHelper" ],
+			[ "CameraHelper", "api/helpers/CameraHelper" ],
+			[ "DirectionalLightHelper", "api/helpers/DirectionalLightHelper" ],
+			[ "FaceNormalsHelper", "api/helpers/FaceNormalsHelper" ],
+			[ "GridHelper", "api/helpers/GridHelper" ],
+			[ "PolarGridHelper", "api/helpers/PolarGridHelper" ],
+			[ "HemisphereLightHelper", "api/helpers/HemisphereLightHelper" ],
+			[ "PointLightHelper", "api/helpers/PointLightHelper" ],
+			[ "RectAreaLightHelper", "api/helpers/RectAreaLightHelper" ],
+			[ "SkeletonHelper", "api/helpers/SkeletonHelper" ],
+			[ "SpotLightHelper", "api/helpers/SpotLightHelper" ],
+			[ "VertexNormalsHelper", "api/helpers/VertexNormalsHelper" ]
 		],
 
 		"Lights": [


### PR DESCRIPTION
Fixes the broken `Source` links on the Helpers pages.

* Renames  `Extras / Helpers` to `Helpers`.
* Moved under `Geometries`
