### PR TITLE
Check for lights when loading common materials extension

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -299,7 +299,8 @@ THREE.GLTFLoader = ( function () {
 
 		this.lights = {};
 
-		var lights = json.extensions && json.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ].lights;
+		var exts = json.extensions && json.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ];
+		var lights = ( exts && exts.lights ) || {};
 
 		for ( var lightId in lights ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -299,8 +299,8 @@ THREE.GLTFLoader = ( function () {
 
 		this.lights = {};
 
-		var exts = json.extensions && json.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ];
-		var lights = ( exts && exts.lights ) || {};
+		var extension = ( json.extensions && json.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ] ) || {};
+		var lights = extension.lights || {};
 
 		for ( var lightId in lights ) {
 


### PR DESCRIPTION
You can use the extension for materials but have no lights, yes?