### PR TITLE
[DOCS] Update documentation for `SceneUtils.createMultiMaterialObject`

### DIFF
--- a/docs/api/extras/SceneUtils.html
+++ b/docs/api/extras/SceneUtils.html
@@ -16,14 +16,14 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:Object3D createMultiMaterialObject]( [page:Geometry geometry], [page:Array materials] )</h3>
+		<h3>[method:Group createMultiMaterialObject]( [page:Geometry geometry], [page:Array materials] )</h3>
 		<div>
-		geometry -- The geometry for the Object. <br />
+		geometry -- The geometry for the set of materials. <br />
 		materials -- The materials for the object.
 		</div>
 		<div>
-		Creates an new Object3D an new mesh for each material defined in materials. Beware that this is not the same as MultiMaterial which defines multiple material for 1 mesh.<br />
-		This is mostly useful for object that need a material and a wireframe implementation.
+		Creates a new Group that contains a new mesh for each material defined in materials. Beware that this is not the same as MultiMaterial which defines multiple material for 1 mesh.<br />
+		This is mostly useful for objects that need both a material and a wireframe implementation.
 		</div>
 
 		<h3>[method:null attach]( [page:Object3D child], [page:Object3D scene], [page:Object3D parent] )</h3>


### PR DESCRIPTION
As of 8fe9093d8151152d67802d996ebb5553de774a30,  `SceneUtils.createMultiMaterialObject` returns a `Group` instead of an `Object3D`. 

I updated the documentation to reflect this -- and also fixed some minor grammatical typos while I was at it.