### PR TITLE
Fixed: Integer.setStep was misspelled as Number.setStep

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -863,9 +863,8 @@ UI.Integer.prototype.setValue = function ( value ) {
 };
 
 UI.Integer.prototype.setStep = function ( step ) {
-
-	step = Math.max(step, Math.floor(step)); // Checks that step is an integer
-	this.step = step; 
+	
+	this.step = parseInt( step ); 
 	
 	return this;
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -862,10 +862,11 @@ UI.Integer.prototype.setValue = function ( value ) {
 
 };
 
-UI.Number.prototype.setStep = function ( step ) {
+UI.Integer.prototype.setStep = function ( step ) {
 
-	this.step = step;
-
+	step = Math.max(step, Math.floor(step)); // Checks that step is an integer
+	this.step = step; 
+	
 	return this;
 
 };


### PR DESCRIPTION
Instead of Integer.setStep, Number.setStep was written. Changed this and added a check to make sure the step is an integer too.