### PR TITLE
Fix `MultiMaterial` support in most primitives

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -32,6 +32,7 @@ var files = {
 		"webgl_geometry_hierarchy2",
 		"webgl_geometry_minecraft",
 		"webgl_geometry_minecraft_ao",
+		"webgl_geometry_multimaterial",
 		"webgl_geometry_normals",
 		"webgl_geometry_nurbs",
 		"webgl_geometry_shapes",

--- a/examples/webgl_geometry_multimaterial.html
+++ b/examples/webgl_geometry_multimaterial.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - geometries - multimaterial</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #000;
+				margin: 0px;
+				overflow: hidden;
+			}
+		</style>
+	</head>
+	<body>
+
+		<script src="../build/three.js"></script>
+
+		<script src="js/Detector.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script src="js/CurveExtras.js"></script>
+		<script src="js/ParametricGeometries.js"></script>
+
+		<script>
+
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var container, stats;
+
+			var camera, scene, renderer;
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 2000 );
+				camera.position.y = 400;
+
+				scene = new THREE.Scene();
+
+				var light, object;
+
+				scene.add( new THREE.AmbientLight( 0x404040 ) );
+
+				light = new THREE.DirectionalLight( 0xffffff );
+				light.position.set( 0, 1, 0 );
+				scene.add( light );
+
+				var map = new THREE.TextureLoader().load( 'textures/UV_Grid_Sm.jpg' );
+				map.wrapS = map.wrapT = THREE.RepeatWrapping;
+				map.anisotropy = 16;
+
+				var material = new THREE.MeshLambertMaterial( { map: map, side: THREE.DoubleSide } );
+				var materials = [];
+
+				// BoxGeometry uses 6 materials, one for each face.
+				for ( var i = 0; i < 6; ++i ) {
+					materials.push( material );
+				}
+
+				var multiMaterial = new THREE.MultiMaterial( materials );
+
+				//
+
+				object = new THREE.Mesh( new THREE.SphereGeometry( 75, 20, 10 ), multiMaterial );
+				object.position.set( -400, 0, 200 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.IcosahedronGeometry( 75, 1 ), multiMaterial );
+				object.position.set( -200, 0, 200 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.OctahedronGeometry( 75, 2 ), multiMaterial );
+				object.position.set( 0, 0, 200 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.TetrahedronGeometry( 75, 0 ), multiMaterial );
+				object.position.set( 200, 0, 200 );
+				scene.add( object );
+
+				//
+
+				object = new THREE.Mesh( new THREE.PlaneGeometry( 100, 100, 4, 4 ), multiMaterial );
+				object.position.set( -400, 0, 0 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.BoxGeometry( 100, 100, 100, 4, 4, 4 ), multiMaterial );
+				object.position.set( -200, 0, 0 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.CircleGeometry( 50, 20, 0, Math.PI * 2 ), multiMaterial );
+				object.position.set( 0, 0, 0 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.RingGeometry( 10, 50, 20, 5, 0, Math.PI * 2 ), multiMaterial );
+				object.position.set( 200, 0, 0 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.CylinderGeometry( 25, 75, 100, 40, 5 ), multiMaterial );
+				object.position.set( 400, 0, 0 );
+				scene.add( object );
+
+				//
+
+				var points = [];
+
+				for ( var i = 0; i < 50; i ++ ) {
+
+					points.push( new THREE.Vector2( Math.sin( i * 0.2 ) * Math.sin( i * 0.1 ) * 15 + 50, ( i - 5 ) * 2 ) );
+
+				}
+
+				object = new THREE.Mesh( new THREE.LatheGeometry( points, 20 ), multiMaterial );
+				object.position.set( -400, 0, -200 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.TorusGeometry( 50, 20, 20, 20 ), multiMaterial );
+				object.position.set( -200, 0, -200 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.TorusKnotGeometry( 50, 10, 50, 20 ), multiMaterial );
+				object.position.set( 0, 0, -200 );
+				scene.add( object );
+
+				var grannyKnot = new THREE.Curves.GrannyKnot();
+				object = new THREE.Mesh( new THREE.TubeGeometry( grannyKnot, 100, 4, 8, true, false ), multiMaterial );
+				object.position.set( 200, 0, -200 );
+				object.scale.multiplyScalar( 2 );
+				scene.add( object );
+
+				object = new THREE.Mesh( new THREE.ParametricBufferGeometry( THREE.ParametricGeometries.mobius, 20, 20 ), multiMaterial );
+				object.position.set( 400, 0, -200 );
+				object.scale.multiplyScalar( 20 );
+				scene.add( object );
+
+				//
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				container.appendChild( renderer.domElement );
+
+				stats = new Stats();
+				container.appendChild( stats.dom );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			//
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
+				var timer = Date.now() * 0.0001;
+
+				camera.position.x = Math.cos( timer ) * 800;
+				camera.position.z = Math.sin( timer ) * 800;
+
+				camera.lookAt( scene.position );
+
+				for ( var i = 0, l = scene.children.length; i < l; i ++ ) {
+
+					var object = scene.children[ i ];
+
+					object.rotation.x = timer * 5;
+					object.rotation.y = timer * 2.5;
+
+				}
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/src/geometries/CircleGeometry.js
+++ b/src/geometries/CircleGeometry.js
@@ -112,6 +112,7 @@ function CircleBufferGeometry( radius, segments, thetaStart, thetaLength ) {
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 }

--- a/src/geometries/CircleGeometry.js
+++ b/src/geometries/CircleGeometry.js
@@ -111,6 +111,9 @@ function CircleBufferGeometry( radius, segments, thetaStart, thetaLength ) {
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
+
 }
 
 CircleBufferGeometry.prototype = Object.create( BufferGeometry.prototype );

--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -139,6 +139,9 @@ function LatheBufferGeometry( points, segments, phiStart, phiLength ) {
 	this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
+
 	// generate normals
 
 	this.computeVertexNormals();

--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -140,6 +140,7 @@ function LatheBufferGeometry( points, segments, phiStart, phiLength ) {
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 	// generate normals

--- a/src/geometries/ParametricGeometry.js
+++ b/src/geometries/ParametricGeometry.js
@@ -104,6 +104,9 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 	this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
+
 	// generate normals
 
 	this.computeVertexNormals();

--- a/src/geometries/ParametricGeometry.js
+++ b/src/geometries/ParametricGeometry.js
@@ -105,6 +105,7 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 	// generate normals

--- a/src/geometries/PlaneGeometry.js
+++ b/src/geometries/PlaneGeometry.js
@@ -117,6 +117,9 @@ function PlaneBufferGeometry( width, height, widthSegments, heightSegments ) {
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
+
 }
 
 PlaneBufferGeometry.prototype = Object.create( BufferGeometry.prototype );

--- a/src/geometries/PlaneGeometry.js
+++ b/src/geometries/PlaneGeometry.js
@@ -118,6 +118,7 @@ function PlaneBufferGeometry( width, height, widthSegments, heightSegments ) {
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 }

--- a/src/geometries/PolyhedronGeometry.js
+++ b/src/geometries/PolyhedronGeometry.js
@@ -76,6 +76,9 @@ function PolyhedronBufferGeometry( vertices, indices, radius, detail ) {
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvBuffer, 2 ) );
 	this.normalizeNormals();
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, vertexBuffer.length / 3 );
+
 	// helper functions
 
 	function subdivide( detail ) {

--- a/src/geometries/PolyhedronGeometry.js
+++ b/src/geometries/PolyhedronGeometry.js
@@ -77,6 +77,7 @@ function PolyhedronBufferGeometry( vertices, indices, radius, detail ) {
 	this.normalizeNormals();
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, vertexBuffer.length / 3 );
 
 	// helper functions

--- a/src/geometries/RingGeometry.js
+++ b/src/geometries/RingGeometry.js
@@ -143,6 +143,7 @@ function RingBufferGeometry( innerRadius, outerRadius, thetaSegments, phiSegment
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 }

--- a/src/geometries/RingGeometry.js
+++ b/src/geometries/RingGeometry.js
@@ -142,6 +142,9 @@ function RingBufferGeometry( innerRadius, outerRadius, thetaSegments, phiSegment
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
+
 }
 
 RingBufferGeometry.prototype = Object.create( BufferGeometry.prototype );

--- a/src/geometries/ShapeGeometry.js
+++ b/src/geometries/ShapeGeometry.js
@@ -93,6 +93,7 @@ function ShapeBufferGeometry( shapes, curveSegments ) {
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 	// helper functions

--- a/src/geometries/ShapeGeometry.js
+++ b/src/geometries/ShapeGeometry.js
@@ -92,6 +92,8 @@ function ShapeBufferGeometry( shapes, curveSegments ) {
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
 
 	// helper functions
 

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -142,6 +142,9 @@ function SphereBufferGeometry( radius, widthSegments, heightSegments, phiStart, 
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
+
 }
 
 SphereBufferGeometry.prototype = Object.create( BufferGeometry.prototype );

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -143,6 +143,7 @@ function SphereBufferGeometry( radius, widthSegments, heightSegments, phiStart, 
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 }

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -134,6 +134,7 @@ function TorusBufferGeometry( radius, tube, radialSegments, tubularSegments, arc
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 }

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -133,6 +133,9 @@ function TorusBufferGeometry( radius, tube, radialSegments, tubularSegments, arc
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
+
 }
 
 TorusBufferGeometry.prototype = Object.create( BufferGeometry.prototype );

--- a/src/geometries/TorusKnotGeometry.js
+++ b/src/geometries/TorusKnotGeometry.js
@@ -171,6 +171,9 @@ function TorusKnotBufferGeometry( radius, tube, tubularSegments, radialSegments,
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
+
 	// this function calculates the current position on the torus curve
 
 	function calculatePositionOnCurve( u, p, q, radius, position ) {

--- a/src/geometries/TorusKnotGeometry.js
+++ b/src/geometries/TorusKnotGeometry.js
@@ -172,6 +172,7 @@ function TorusKnotBufferGeometry( radius, tube, tubularSegments, radialSegments,
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 	// this function calculates the current position on the torus curve

--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -107,6 +107,7 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	// add a group to the geometry. this will ensure multi material support
+
 	this.addGroup( 0, indices.length );
 
 	// functions

--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -106,6 +106,9 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
+	// add a group to the geometry. this will ensure multi material support
+	this.addGroup( 0, indices.length );
+
 	// functions
 
 	function generateBufferData() {


### PR DESCRIPTION
This commit makes primitive geometries compatible with `MultiMaterial` by adding a single group to each primitive. Some primitives already supported `MultiMaterial` (e.g., `BoxGeometry` and `CylinderGeometry`).

I added a new example that can be used to test the new behavior.