### PR TITLE
Fix casing of `UVGenerator` in ExtrudeGeometry comments

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -23,7 +23,7 @@ import { ShapeUtils } from '../extras/ShapeUtils';
  *  extrudePath: <THREE.Curve> // curve to extrude shape along
  *  frames: <Object> // containing arrays of tangents, normals, binormals
  *
- *  uvGenerator: <Object> // object that provides UV generator functions
+ *  UVGenerator: <Object> // object that provides UV generator functions
  *
  * }
  **/


### PR DESCRIPTION
#8537 addressed this for the `ExtrudeGeometry` documentation, but it looks like we missed a spot in the source code comments. Here's a quick fix 😄.