### PR TITLE
Fix the guard condition of divisions

### DIFF
--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -67,7 +67,7 @@ Curve.prototype = {
 
 	getPoints: function ( divisions ) {
 
-		if ( isNaN( divisions ) ) divisions = 5;
+		if ( typeof divisions !== 'number' ) divisions = 5;
 
 		var points = [];
 
@@ -85,7 +85,7 @@ Curve.prototype = {
 
 	getSpacedPoints: function ( divisions ) {
 
-		if ( isNaN( divisions ) ) divisions = 5;
+		if ( typeof divisions !== 'number' ) divisions = 5;
 
 		var points = [];
 
@@ -112,7 +112,7 @@ Curve.prototype = {
 
 	getLengths: function ( divisions ) {
 
-		if ( isNaN( divisions ) ) divisions = ( this.__arcLengthDivisions ) ? ( this.__arcLengthDivisions ) : 200;
+		if ( typeof divisions !== 'number' ) divisions = ( this.__arcLengthDivisions ) ? ( this.__arcLengthDivisions ) : 200;
 
 		if ( this.cacheArcLengths
 			&& ( this.cacheArcLengths.length === divisions + 1 )

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -139,7 +139,7 @@ CurvePath.prototype = Object.assign( Object.create( Curve.prototype ), {
 
 	getSpacedPoints: function ( divisions ) {
 
-		if ( isNaN( divisions ) ) divisions = 40;
+		if ( typeof divisions !== 'number' ) divisions = 40;
 
 		var points = [];
 


### PR DESCRIPTION
My last fix #10501 does not completely fix the guard condition for ``divisions`` as the document of [``isNaN``](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/isNaN) points out some exceptions. This fix will make sure ``divisions`` is set to its default value when a non-number is passed to the function.