### PR TITLE
Added license url in Rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,6 +29,7 @@ export default {
 	plugins: [
 		glsl()
 	],
+	intro: '/** @license threejs.org/license */',
 	// sourceMap: true,
 	targets: [
 		{


### PR DESCRIPTION
The `@license` JSDoc tag tells Closure Compiler to preserve the comment even in the minified version: https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#license-preserve-description