### PR TITLE
[DOCS] fix control point numbering typo in Path docs

### DIFF
--- a/docs/api/extras/core/Path.html
+++ b/docs/api/extras/core/Path.html
@@ -92,7 +92,7 @@ var path = new THREE.Path(vectors);
 
 
 		<h3>[method:null bezierCurveTo]( [page:Float cp1X], [page:Float cp1Y], [page:Float cp2X], [page:Float cp2Y], [page:Float x], [page:Float y] )</h3>
-		<div>This creates a bezier curve from [page:.currentPoint] with cp1X, cp1Y and cp1X, cp1Y as control points and updates [page:.currentPoint] to x and y.</div>
+		<div>This creates a bezier curve from [page:.currentPoint] with (cp1X, cp1Y) and (cp2X, cp2Y) as control points and updates [page:.currentPoint] to x and y.</div>
 
 		<h3>[method:null fromPoints]( [page:Array vector2s] )</h3>
 		<div>


### PR DESCRIPTION
I fixed a super-small typo in the Path documentation that accidentally listed the same control point twice. I also wrapped the control points in `()` notation to denote them as point positions.