### PR TITLE
Geometry toJSON fix

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -1142,13 +1142,11 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 		}
 
-		data.data = {};
-
-		data.data.vertices = vertices;
-		data.data.normals = normals;
-		if ( colors.length > 0 ) data.data.colors = colors;
-		if ( uvs.length > 0 ) data.data.uvs = [ uvs ]; // temporal backward compatibility
-		data.data.faces = faces;
+		data.vertices = vertices;
+		data.normals = normals;
+		if ( colors.length > 0 ) data.colors = colors;
+		if ( uvs.length > 0 ) data.uvs = [ uvs ]; // temporal backward compatibility
+		data.faces = faces;
 
 		return data;
 


### PR DESCRIPTION
Same problem, correct fix #10468
Current geometry.toJSON creates output like this:
```
{
  "uuid":"E1A66209-4A78-4B74-A760-BFF01BC3FA3E",
  "type":"Geometry",
  "data":
  {
    "vertices":[0,0,0,1,0,0,1,1,0,0,1,0],
    "normals":[],
    "faces":[2,0,1,2,0,2,0,2,3,0]
  }
}
```

Should be like this (clara.io and blender exporter use this one):
```
{
  "uuid":"E1A66209-4A78-4B74-A760-BFF01BC3FA3E",
  "type":"Geometry",
  "vertices":[0,0,0,1,0,0,1,1,0,0,1,0],
  "normals":[],
  "faces":[2,0,1,2,0,2,0,2,3,0]
}
```
