### PR TITLE
Modify VREffect to use camera scale and added camera rig example

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -53,7 +53,6 @@ THREE.VREffect = function( renderer, onError ) {
 	//
 
 	this.isPresenting = false;
-	this.scale = 1;
 
 	var scope = this;
 
@@ -307,11 +306,13 @@ THREE.VREffect = function( renderer, onError ) {
 			if ( camera.parent === null ) camera.updateMatrixWorld();
 
 			camera.matrixWorld.decompose( cameraL.position, cameraL.quaternion, cameraL.scale );
-			camera.matrixWorld.decompose( cameraR.position, cameraR.quaternion, cameraR.scale );
+			
+			cameraR.position.copy(cameraL.position);
+			cameraR.quaternion.copy(cameraL.quaternion);
+			cameraR.scale.copy(cameraL.scale);
 
-			var scale = this.scale;
-			cameraL.translateOnAxis( eyeTranslationL, scale );
-			cameraR.translateOnAxis( eyeTranslationR, scale );
+			cameraL.translateOnAxis( eyeTranslationL, cameraL.scale.x );
+			cameraR.translateOnAxis( eyeTranslationR, cameraR.scale.x );
 
 			if ( vrDisplay.getFrameData ) {
 
@@ -454,7 +455,6 @@ THREE.VREffect = function( renderer, onError ) {
 		m[ 3 * 4 + 3 ] = 0.0;
 
 		mobj.transpose();
-
 		return mobj;
 
 	}

--- a/examples/webvr_vive_camerarig.html
+++ b/examples/webvr_vive_camerarig.html
@@ -1,0 +1,342 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webvr - htc vive  - camera rig</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #101010;
+				color: #fff;
+				margin: 0px;
+				overflow: hidden;
+			}
+			a {
+				color: #f00;
+			}
+		</style>
+	</head>
+	<body>
+
+		<script src="../build/three.js"></script>
+
+		<script src="js/controls/VRControls.js"></script>
+		<script src="js/effects/VREffect.js"></script>
+		<script src="js/vr/ViveController.js"></script>
+		<script src="js/vr/WebVR.js"></script>
+
+		<script src="js/loaders/OBJLoader.js"></script>
+
+		<script>
+
+			if ( WEBVR.isAvailable() === false ) {
+
+				document.body.appendChild( WEBVR.getMessage() );
+
+			}
+
+			//
+
+			var clock = new THREE.Clock();
+
+			var container;
+			var cameraRig, camera, scene, renderer;
+			var effect, controls;
+			var controller1, controller2;
+			var scale = 1;
+			var dragging = {
+				left: false,
+				right: false
+			};
+			var dragStartPointLeft = new THREE.Vector3();
+			var dragStartPointRight = new THREE.Vector3();
+
+			var room;
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				var info = document.createElement( 'div' );
+				info.style.position = 'absolute';
+				info.style.top = '10px';
+				info.style.width = '100%';
+				info.style.textAlign = 'center';
+				info.innerHTML = '<a href="http://threejs.org" target="_blank">three.js</a> webgl - htc vive';
+				container.appendChild( info );
+
+				scene = new THREE.Scene();
+
+				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 1000 );
+				cameraRig = new THREE.Group();
+				cameraRig.add( camera );
+				scene.add( cameraRig );
+
+				room = new THREE.Mesh(
+					new THREE.BoxGeometry( 6, 6, 6, 8, 8, 8 ),
+					new THREE.MeshBasicMaterial( { color: 0x404040, wireframe: true } )
+				);
+				room.position.y = 3;
+				scene.add( room );
+
+				scene.add( new THREE.HemisphereLight( 0x606060, 0x404040 ) );
+
+				var light = new THREE.DirectionalLight( 0xffffff );
+				light.position.set( 1, 1, 1 ).normalize();
+				scene.add( light );
+
+				var geometry = new THREE.BoxGeometry( 0.2, 0.2, 0.2 );
+
+				for ( var i = 0; i < 200; i ++ ) {
+
+					var object = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { color: Math.random() * 0xffffff } ) );
+
+					object.position.x = Math.random() * 4 - 2;
+					object.position.y = Math.random() * 4 - 2;
+					object.position.z = Math.random() * 4 - 2;
+
+					object.rotation.x = Math.random() * 2 * Math.PI;
+					object.rotation.y = Math.random() * 2 * Math.PI;
+					object.rotation.z = Math.random() * 2 * Math.PI;
+
+					object.scale.x = Math.random() + 0.5;
+					object.scale.y = Math.random() + 0.5;
+					object.scale.z = Math.random() + 0.5;
+
+					object.userData.velocity = new THREE.Vector3();
+					object.userData.velocity.x = Math.random() * 0.01 - 0.005;
+					object.userData.velocity.y = Math.random() * 0.01 - 0.005;
+					object.userData.velocity.z = Math.random() * 0.01 - 0.005;
+
+					room.add( object );
+
+				}
+
+				var material = new THREE.MeshStandardMaterial();
+
+				var loader = new THREE.OBJLoader();
+				loader.setPath( 'models/obj/cerberus/' );
+				loader.load( 'Cerberus.obj', function ( group ) {
+
+					// var material = new THREE.MeshBasicMaterial( { wireframe: true } );
+
+					var loader = new THREE.TextureLoader();
+					loader.setPath( 'models/obj/cerberus/' );
+
+					material.roughness = 1;
+					material.metalness = 1;
+
+					material.map = loader.load( 'Cerberus_A.jpg' );
+					material.roughnessMap = loader.load( 'Cerberus_R.jpg' );
+					material.metalnessMap = loader.load( 'Cerberus_M.jpg' );
+					material.normalMap = loader.load( 'Cerberus_N.jpg' );
+
+					material.map.wrapS = THREE.RepeatWrapping;
+					material.roughnessMap.wrapS = THREE.RepeatWrapping;
+					material.metalnessMap.wrapS = THREE.RepeatWrapping;
+					material.normalMap.wrapS = THREE.RepeatWrapping;
+
+					group.traverse( function ( child ) {
+
+						if ( child instanceof THREE.Mesh ) {
+
+							child.material = material;
+
+						}
+
+					} );
+
+					group.position.y = - 2;
+					group.rotation.y = - Math.PI / 2;
+					room.add( group );
+
+				} );
+
+				var loader = new THREE.CubeTextureLoader();
+				loader.setPath( 'textures/cube/pisa/' );
+				material.envMap = loader.load( [
+					"px.png", "nx.png",
+					"py.png", "ny.png",
+					"pz.png", "nz.png"
+				] );
+
+				//
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setClearColor( 0x505050 );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.sortObjects = false;
+				container.appendChild( renderer.domElement );
+
+				controls = new THREE.VRControls( camera );
+				controls.standing = true;
+
+				// controllers
+
+				controller1 = new THREE.ViveController( 0 );
+				controller1.standingMatrix = controls.getStandingMatrix();
+				controller1.addEventListener( 'triggerdown', onTriggerDown );
+				controller1.addEventListener( 'triggerup', onTriggerUp );
+				cameraRig.add( controller1 );
+
+				controller2 = new THREE.ViveController( 1 );
+				controller2.standingMatrix = controls.getStandingMatrix();
+				controller2.addEventListener( 'triggerdown', onTriggerDown );
+				controller2.addEventListener( 'triggerup', onTriggerUp );
+				cameraRig.add( controller2 );
+
+				var loader = new THREE.OBJLoader();
+				loader.setPath( 'models/obj/vive-controller/' );
+				loader.load( 'vr_controller_vive_1_5.obj', function ( object ) {
+
+					var loader = new THREE.TextureLoader();
+					loader.setPath( 'models/obj/vive-controller/' );
+
+					var controller = object.children[ 0 ];
+					controller.material.map = loader.load( 'onepointfive_texture.png' );
+					controller.material.specularMap = loader.load( 'onepointfive_spec.png' );
+
+					controller1.add( object.clone() );
+					controller2.add( object.clone() );
+
+				} );
+
+				effect = new THREE.VREffect( renderer );
+
+				if ( WEBVR.isAvailable() === true ) {
+
+					document.body.appendChild( WEBVR.getButton( effect ) );
+
+				}
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				effect.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			//
+
+			function animate() {
+
+				effect.requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
+
+				var delta = clock.getDelta() * 60;
+
+				controller1.update();
+				controller2.update();
+
+				controls.update();
+
+				scaleUpdate();
+
+				for ( var i = 0; i < room.children.length; i ++ ) {
+
+					var cube = room.children[ i ];
+
+					if ( cube.geometry instanceof THREE.BoxGeometry === false ) continue;
+
+					// cube.position.add( cube.userData.velocity );
+
+					if ( cube.position.x < - 3 || cube.position.x > 3 ) {
+
+						cube.position.x = THREE.Math.clamp( cube.position.x, - 3, 3 );
+						cube.userData.velocity.x = - cube.userData.velocity.x;
+
+					}
+
+					if ( cube.position.y < - 3 || cube.position.y > 3 ) {
+
+						cube.position.y = THREE.Math.clamp( cube.position.y, - 3, 3 );
+						cube.userData.velocity.y = - cube.userData.velocity.y;
+
+					}
+
+					if ( cube.position.z < - 3 || cube.position.z > 3 ) {
+
+						cube.position.z = THREE.Math.clamp( cube.position.z, - 3, 3 );
+						cube.userData.velocity.z = - cube.userData.velocity.z;
+
+					}
+
+					cube.rotation.x += 0.01 * delta;
+
+				}
+
+				effect.render( scene, camera );
+
+			}
+
+			var previousControllersSegment = new THREE.Line3();
+			var currentControllersSegment = new THREE.Line3();
+			var deltaPreviousSegment = new THREE.Vector3();
+			var deltaCurrentSegment = new THREE.Vector3();
+			var currentWorldPositionLeft = new THREE.Vector3();
+			var currentWorldPositionRight = new THREE.Vector3();
+
+			function scaleUpdate () {
+				if ( !dragging.left || !dragging.right ) {
+					return false;
+				}
+
+				currentWorldPositionLeft.setFromMatrixPosition( controller1.matrixWorld );
+				currentWorldPositionRight.setFromMatrixPosition( controller2.matrixWorld );
+
+				previousControllersSegment.set( dragStartPointLeft, dragStartPointRight );
+				currentControllersSegment.set( currentWorldPositionLeft, currentWorldPositionRight );
+
+				var dist = ( previousControllersSegment.distance() - currentControllersSegment.distance() );
+
+				scale += dist;
+
+				cameraRig.scale.set( scale, scale, scale );
+
+				dragStartPointLeft.copy( currentWorldPositionLeft );
+				dragStartPointRight.copy( currentWorldPositionRight );
+			}
+
+			function onTriggerDown (event) {
+				var target = event.target;
+				var left = target === controller1;
+				if (left) {
+				  dragging.left = true;
+				} else {
+				  dragging.right = true;
+				}
+
+				dragStartPointLeft.setFromMatrixPosition(controller1.matrixWorld);
+				dragStartPointRight.setFromMatrixPosition(controller2.matrixWorld);
+			}
+
+			function onTriggerUp (event) {
+				var left = event.target === controller1;
+				if (left) {
+				  dragging.left = false;
+				} else {
+				  dragging.right = false;
+				}
+			}
+
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Proposed changes:
- Previously VREffect had a `scale` parameter used to scale the IPD. If you create a cameraRig and want to scale the user, you should scale the rig and you'll need to modify `effect.scale` too, so I believe it's much convenient to get the current scale for the camera and use it to scale the IPD too (For example this is the same way SteamVR plugin in Unity does).
The camera rig would looks like:
  - `CameraRig`
    - `Controller1`
    - `Controller2` 
    - `PerspectiveCamera` with VREffect

  So modifying just the scale of the `CameraRig` will scale the whole player in a very easy and intuitive way.
- I've removed the `camera`'s `decompose` for `cameraR` as it'll be exactly the same as `cameraL` so we could just copy it without recalculating it.
- Added a simple example (https://twitter.com/fernandojsg/status/824596282618576896), basically duplicating `webvr-vive` to show the scale of the `cameraRig` by pressing both `trigger` buttons and moving the controllers close to or away from each other. Probably so simple and not nice to duplicate the previous one, but just to show the effect, I could let it out from the PR and try to create a better example later on.


