### PR TITLE
add .vscode directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 .project
 node_modules
 .idea/
+.vscode/
 npm-debug.log
+


### PR DESCRIPTION
Since VSCode follows a similar convention to IntelliJ for [custom workspace settings](https://code.visualstudio.com/Docs/customization/userandworkspace), I'd like to propose accounting for it in our `.gitignore` the same way we account for the `.idea` directory. 

This could come in handy for contributors who use VSCode religiously 😉.