### PR TITLE
Refactor GPUComputationRenderer.js to handle variables of different sizes

### DIFF
--- a/examples/js/GPUComputationRenderer.js
+++ b/examples/js/GPUComputationRenderer.js
@@ -132,10 +132,7 @@ function GPUComputationRenderer( renderer ) {
 		texture: { value: null }
 	};
 
-	var passThruShader = createShaderMaterial( getPassThroughFragmentShader( sizeX, sizeY ), passThruUniforms );
-
-	// TODO: move this to use the first variables shader. No need for a default shader
-	var mesh = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), passThruShader );
+	var mesh = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), new THREE.MeshBasicMaterial() );
 	scene.add( mesh );
 
 
@@ -152,8 +149,6 @@ function GPUComputationRenderer( renderer ) {
 	}
 
 	this.computeVariable = function ( variable ) {
-
-
 		// Performs the computation for this variable
 		this.doRenderTarget( variable.material, variable.renderTargets[ nextTextureIndex ] );
 

--- a/examples/js/GPUComputationRenderer.js
+++ b/examples/js/GPUComputationRenderer.js
@@ -89,7 +89,7 @@
  * // And compute each frame, before rendering to screen:
  * gpuCompute.doRenderTarget( myFilter1, myRenderTarget );
  * gpuCompute.doRenderTarget( myFilter2, outputRenderTarget );
- * 
+ *
  *
  * @author Sam Stewart http://github.com/samstewart samstewart
  * Added a few improvements:
@@ -118,7 +118,7 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 		texture: { value: null }
 	};
 
-	var passThruShader = createShaderMaterial( getPassThroughFragmentShader(sizeX, sizeY), passThruUniforms );
+	var passThruShader = createShaderMaterial( getPassThroughFragmentShader( sizeX, sizeY ), passThruUniforms );
 
 	var mesh = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), passThruShader );
 	scene.add( mesh );
@@ -126,18 +126,20 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 	this.magFilter = THREE.NearestFilter;
 	this.minFilter = THREE.NearestFilter;
 
-	if ( renderer.extensions.get('OES_texture_float_linear') ) {
+	if ( renderer.extensions.get( 'OES_texture_float_linear' ) ) {
+
 		// use bilinear interpolation if it is available
 		this.magFilter = THREE.LinearFilter;
+
 	}
 
-	this.addVariable = function( variableName, computeFragmentShader, initialValueTexture ) {
+	this.addVariable = function ( variableName, computeFragmentShader, initialValueTexture ) {
 
 		var material = this.createShaderMaterial( computeFragmentShader, {}, initialValueTexture.image.width, initialValueTexture.image.height );
 
 		var passThruUniforms = {
 			texture: { value: null }
-		}; 
+		};
 
 		var variable = {
 			name: variableName,
@@ -154,27 +156,27 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 			sizeY: initialValueTexture.image.height
 		};
 
-		variable.passThruShader = createShaderMaterial( 
-			getPassThroughFragmentShader( variable.sizeX, variable.sizeY ), 
+		variable.passThruShader = createShaderMaterial(
+			getPassThroughFragmentShader( variable.sizeX, variable.sizeY ),
 			passThruUniforms );
-	
+
 		this.variables.push( variable );
 
 		return variable;
-		
+
 	};
 
 
 
-	this.setVariableDependencies = function( variable, dependencies ) {
+	this.setVariableDependencies = function ( variable, dependencies ) {
 
 		variable.dependencies = dependencies;
 
 	};
 
-	this.init = function() {
+	this.init = function () {
 
-		
+
 
 		if ( ! renderer.extensions.get( "OES_texture_float" ) ) {
 
@@ -188,7 +190,7 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 		}
 
-		for ( var i = 0; i < this.variables.length; i++ ) {
+		for ( var i = 0; i < this.variables.length; i ++ ) {
 
 			var variable = this.variables[ i ];
 
@@ -197,11 +199,13 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 			// Creates rendertargets and initializes the two buffers with input texture
 
-			for (var k = 0; k < 2; k++) {
+			for ( var k = 0; k < 2; k ++ ) {
+
 				variable.renderTargets[ k ] = this.createRenderTarget( variable.sizeX, variable.sizeY, variable.wrapS, variable.wrapT, variable.minFilter, variable.magFilter );
 				this.renderTexture( variable.initialValueTexture, variable.renderTargets[ k ], variable.passThruShader );
+
 			}
-			
+
 
 			// Adds dependencies uniforms to the ShaderMaterial
 			var material = variable.material;
@@ -211,7 +215,7 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 			if ( variable.dependencies !== null ) {
 
-				for ( var d = 0; d < variable.dependencies.length; d++ ) {
+				for ( var d = 0; d < variable.dependencies.length; d ++ ) {
 
 					var depVar = variable.dependencies[ d ];
 
@@ -219,16 +223,20 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 						// Checks if variable exists
 						var found = false;
-						for ( var j = 0; j < this.variables.length; j++ ) {
+						for ( var j = 0; j < this.variables.length; j ++ ) {
 
 							if ( depVar.name === this.variables[ j ].name ) {
+
 								found = true;
 								break;
+
 							}
 
 						}
 						if ( ! found ) {
+
 							return "Variable dependency not found. Variable=" + variable.name + ", dependency=" + depVar.name;
+
 						}
 
 					}
@@ -239,14 +247,17 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 					material.fragmentShader = "\nuniform sampler2D " + depVar.name + ";\n" + material.fragmentShader;
 
 				}
+
 			}
+
 		}
 
 		return null;
 
 	};
 
-	this.computeVariable = function( variable ) {
+	this.computeVariable = function ( variable ) {
+
 		// flip between the two buffers for the variable
 		var currentTextureIndex = variable.currentTextureIndex;
 		var nextTextureIndex = variable.currentTextureIndex === 0 ? 1 : 0;
@@ -257,11 +268,12 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 			var uniforms = variable.material.uniforms;
 
-			for ( var d = 0, dl = variable.dependencies.length; d < dl; d++ ) {
+			for ( var d = 0, dl = variable.dependencies.length; d < dl; d ++ ) {
 
 				var depVar = variable.dependencies[ d ];
 
 				uniforms[ depVar.name ].value = depVar.renderTargets[ currentTextureIndex ].texture;
+
 			}
 
 		}
@@ -270,37 +282,42 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 		this.doRenderTarget( variable.material, variable.renderTargets[ nextTextureIndex ] );
 
 		variable.currentTextureIndex = nextTextureIndex;
-	}
 
-	this.compute = function() {
+	};
 
-		for ( var i = 0, il = this.variables.length; i < il; i++ ) {
-			this.computeVariable(this.variables[ i ]);
+	this.compute = function () {
+
+		for ( var i = 0, il = this.variables.length; i < il; i ++ ) {
+
+			this.computeVariable( this.variables[ i ] );
+
 		}
 
 	};
 
-	this.getCurrentRenderTarget = function( variable ) {
+	this.getCurrentRenderTarget = function ( variable ) {
 
 		return variable.renderTargets[ variable.currentTextureIndex ];
 
 	};
 
-	this.getAlternateRenderTarget = function( variable ) {
+	this.getAlternateRenderTarget = function ( variable ) {
 
 		return variable.renderTargets[ variable.currentTextureIndex === 0 ? 1 : 0 ];
 
 	};
 
-	function getResolutionDefineString(w, h) {
-		return "\n#define resolution vec2(" + w.toFixed(1) + ", " + h.toFixed(1) + ")\n";
+	function getResolutionDefineString( w, h ) {
+
+		return "\n#define resolution vec2(" + w.toFixed( 1 ) + ", " + h.toFixed( 1 ) + ")\n";
+
 	}
 
 	this.getResolutionDefineString = getResolutionDefineString;
 
 	// The following functions can be used to compute things manually
 
-	function createShaderMaterial( computeFragmentShader, uniforms, sizeVariableX, sizeVariableY) {
+	function createShaderMaterial( computeFragmentShader, uniforms, sizeVariableX, sizeVariableY ) {
 
 		uniforms = uniforms || {};
 
@@ -309,7 +326,7 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 		sizeVariableY = sizeVariableY || sizeY;
 
 		// add the resolution parameter
-		computeFragmentShader = getResolutionDefineString(sizeVariableX, sizeVariableY) + computeFragmentShader;
+		computeFragmentShader = getResolutionDefineString( sizeVariableX, sizeVariableY ) + computeFragmentShader;
 
 		var material = new THREE.ShaderMaterial( {
 			uniforms: uniforms,
@@ -318,11 +335,12 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 		} );
 
 		return material;
+
 	}
 
 	this.createShaderMaterial = createShaderMaterial;
 
-	this.createRenderTarget = function( sizeXTexture, sizeYTexture, wrapS, wrapT, minFilter, magFilter ) {
+	this.createRenderTarget = function ( sizeXTexture, sizeYTexture, wrapS, wrapT, minFilter, magFilter ) {
 
 		sizeXTexture = sizeXTexture || sizeX;
 		sizeYTexture = sizeYTexture || sizeY;
@@ -347,16 +365,17 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 	};
 
-	this.createTexture = function( sizeXTexture, sizeYTexture ) {
+	this.createTexture = function ( sizeXTexture, sizeYTexture ) {
+
 		sizeXTexture = sizeXTexture || sizeX;
 		sizeYTexture = sizeYTexture || sizeY;
 
 		var a 		= new Float32Array( sizeXTexture * sizeYTexture * 4 );
-		var texture = new THREE.DataTexture( 
-			a, 
-			sizeXTexture, 
-			sizeYTexture, 
-			THREE.RGBAFormat, 
+		var texture = new THREE.DataTexture(
+			a,
+			sizeXTexture,
+			sizeYTexture,
+			THREE.RGBAFormat,
 			THREE.FloatType,
 			THREE.UVMapping,
 			THREE.ClampToEdgeWrapping,
@@ -366,12 +385,13 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 			);
 
 		texture.needsUpdate = true;
-		
+
 
 		return texture;
+
 	};
-    
-	this.renderTexture = function( input, output, passThruShader) {
+
+	this.renderTexture = function ( input, output, passThruShader ) {
 
 		// Takes a texture, and render out in rendertarget
 		// input = Texture
@@ -381,19 +401,23 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 		passThruShader.uniforms.texture.value = input;
 
-		this.doRenderTarget( passThruShader, output);
+		this.doRenderTarget( passThruShader, output );
 
 		passThruShader.uniforms.texture.value = null;
+
 	};
 
-	this.doRenderTarget = function( material, output ) {
+	this.doRenderTarget = function ( material, output ) {
+
 		mesh.material = material;
 		this.renderer.render( scene, camera, output );
+
 	};
 
 	// Shaders
 
 	function getPassThroughVertexShader() {
+
 		return	"void main()	{\n" +
 				"\n" +
 				"	gl_Position = vec4( position, 1.0 );\n" +
@@ -402,9 +426,9 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 	}
 
-	function getPassThroughFragmentShader(w,h) {
+	function getPassThroughFragmentShader( w, h ) {
 
-		return	getResolutionDefineString(w, h) +
+		return	getResolutionDefineString( w, h ) +
 				"\nuniform sampler2D texture;\n\n" +
 				"void main() {\n" +
 				"\n" +

--- a/examples/js/GPUComputationRendererVariable.js
+++ b/examples/js/GPUComputationRendererVariable.js
@@ -1,0 +1,58 @@
+function GPUComputationRendererVariable(sizeX, sizeY, name, updateShader) {
+
+	this.sizeX = sizeX;
+	this.sizeY = sizeY;
+	this.magFilter = THREE.NearestFilter;
+	this.minFilter = THREE.NearestFilter;
+
+	this.computationRenderer = null;
+
+	// the list of variables that we depend upon
+	this.dependenciesVariables = [];
+
+	this.initializeWithShader = function(initialShader) {
+
+	}
+
+	this.initializeWithTexture = function(initialTexture) {
+
+	}
+
+	this.addDependency = function(variable) {
+
+	}
+
+	//////////////////////////////////////////
+	/////// Internal functions ///////
+	//////////////////////////////////////////
+	function getResolutionDefineString() {
+
+		return "\n#define resolution vec2(" + this.sizeX.toFixed( 1 ) + ", " + this.sizeY.toFixed( 1 ) + ")\n";
+
+	}
+
+	function getPassThroughVertexShader() {
+
+		return	"void main()	{\n" +
+				"\n" +
+				"	gl_Position = vec4( position, 1.0 );\n" +
+				"\n" +
+				"}\n";
+
+	}
+
+	function getPassThroughFragmentShader() {
+
+		return	getResolutionDefineString() +
+				"\nuniform sampler2D texture;\n\n" +
+				"void main() {\n" +
+				"\n" +
+				"	vec2 uv = gl_FragCoord.xy / resolution.xy;\n" +
+				"\n" +
+				"	gl_FragColor = texture2D(texture, uv);\n" +
+				"\n" +
+				"}\n";
+
+	}
+
+}

--- a/examples/js/RandomNoiseTexture.js
+++ b/examples/js/RandomNoiseTexture.js
@@ -1,0 +1,9 @@
+/** Generates a data texture filled with uniform random noise in [0, 1] */
+function randomNoiseTexture(w, h) {
+	var data = new Float32Array( 3 * w * h );
+	for (var i = 0; i < data.length; i++) {
+		data[i] = Math.random();
+	}
+
+	return new THREE.DataTexture(data, w, h, THREE.RGBAFormat);
+}

--- a/examples/test_gpu_computation_renderer.html
+++ b/examples/test_gpu_computation_renderer.html
@@ -45,63 +45,6 @@
 
 		<script src="js/GPUComputationRenderer.js"></script>
 
-		<!-- Fragment shader for filling initial velocity field -->
-		<script id="initialVelocity" type="x-shader/x-fragment">
-
-			uniform float maxVel;
-			uniform float velExponent;
-			uniform float randVel;
-			uniform float maxMass;
-
-			uniform sampler2D initialPosition;
-			// the initial SimplexNoise random data bound to range [-1, 1] for first three coordinates
-			// and the range [0, 1] for the last coordinate
-			uniform sampler2D randomSeed;
-
-			void main() {
-
-				// Velocity
-				float rr = pow(initialPosition.x, 2) + pow(initialPosition.y, 2);
-
-				float vel = maxVel * pow( rr, velExponent );
-
-				// fill with the three random coordinates and 'mass' in the final coordinate
-				gl_FragColor = vec4(
-					vel * z + randomSeed.x * randVel,
-					randomSeed.y * randVel * 0.05,
-					- vel * x + randomSeed.z * randVel,
-					randomSeed.w * maxMass + 1
-					);
-			}
-
-		</script>
-
-		<!-- Fragment shader for filling initial position field -->
-		<script id="initialPosition" type="x-shader/x-fragment">
-			uniform float radius;
-			uniform float exponent;
-			uniform float height;
-
-			// the points x,z sampled in a disk so radius will be less than one.
-			// point y in range [-1, 1] and w doesn't matter.
-			uniform sampler2D randomSeed;
-
-			void main() {
-				x = randomSeed.x;
-				z = randomSeed.z;
-				rr = x * x + z * z;
-
-				rr = Math.sqrt( rr );
-
-				var rExp = radius * Math.pow( rr, exponent );
-
-				x *= rExp;
-				z *= rExp;
-				y = randomSeed.y * height;
-
-				gl_FragColor = vec4(x, y, z, 1);
-			}
-		</script>
 
 		<!-- Fragment shader for protoplanet's position -->
 		<script id="computeShaderPosition" type="x-shader/x-fragment">
@@ -413,40 +356,17 @@
 
 			}
 
-			function generateVelocityRandomSeedTexture() {
-
-			}
-
-			function generatePositionRandomSeedTexture() {
-
-			}
-
 			function initComputeRenderer() {
 
-    			gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
+    				gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
 
-    			// use the shaders to setup the initial distribution of positions and velocities.
-    			// Easier than creating and filling textures.
-				
+				var dtPosition = gpuCompute.createTexture();
+				var dtVelocity = gpuCompute.createTexture();
 
-				positionVariable = gpuCompute.addVariable( "texturePosition", 
-					document.getElementById( 'computeShaderPosition' ).textContent, 
-					{
-						shader: document.getElementById( 'initialPosition' ).textContent,
-						width: WIDTH,
-						height: HEIGHT
-					});
+				fillTextures( dtPosition, dtVelocity );
 
-				velocityVariable = gpuCompute.addVariable( "textureVelocity", 
-					document.getElementById( 'computeShaderVelocity' ).textContent, 
-					{
-						shader: document.getElementById( 'initialVelocity' ).textContent,
-						uniforms: {
-							initialPosition:
-						}
-						width: WIDTH,
-						height: HEIGHT
-					} );
+				velocityVariable = gpuCompute.addVariable( "textureVelocity", document.getElementById( 'computeShaderVelocity' ).textContent, dtVelocity );
+				positionVariable = gpuCompute.addVariable( "texturePosition", document.getElementById( 'computeShaderPosition' ).textContent, dtPosition );
 
 				gpuCompute.setVariableDependencies( velocityVariable, [ positionVariable, velocityVariable ] );
 				gpuCompute.setVariableDependencies( positionVariable, [ positionVariable, velocityVariable ] );
@@ -466,10 +386,15 @@
 
 			function restartSimulation() {
 
-				gpuCompute.renderInitialTexture( positionVariable, 0 );
-				gpuCompute.renderInitialTexture( positionVariable, 1 );
-				gpuCompute.renderInitialTexture( velocityVariable, 0 );
-				gpuCompute.renderInitialTexture( velocityVariable, 1 );
+				var dtPosition = gpuCompute.createTexture();
+				var dtVelocity = gpuCompute.createTexture();
+
+				fillTextures( dtPosition, dtVelocity );
+
+				gpuCompute.renderTexture( dtPosition, positionVariable.renderTargets[ 0 ] );
+				gpuCompute.renderTexture( dtPosition, positionVariable.renderTargets[ 1 ] );
+				gpuCompute.renderTexture( dtVelocity, velocityVariable.renderTargets[ 0 ] );
+				gpuCompute.renderTexture( dtVelocity, velocityVariable.renderTargets[ 1 ] );
 
 			}
 
@@ -526,7 +451,6 @@
 
 			function fillTextures( texturePosition, textureVelocity ) {
 
-				// TODO: pass these into the initial shader
 				var posArray = texturePosition.image.data;
 				var velArray = textureVelocity.image.data;
 
@@ -537,6 +461,47 @@
 				var maxVel = effectController.velocity;
 				var velExponent = effectController.velocityExponent;
 				var randVel = effectController.randVelocity;
+
+				for ( var k = 0, kl = posArray.length; k < kl; k += 4 ) {
+
+					// Position
+					var x, y, z, rr;
+
+					do {
+						x = ( Math.random() * 2 - 1 );
+						z = ( Math.random() * 2 - 1 );
+						rr = x * x + z * z;
+					} while ( rr > 1 );
+
+					rr = Math.sqrt( rr );
+
+					var rExp = radius * Math.pow( rr, exponent );
+
+					// Velocity
+					var vel = maxVel * Math.pow( rr, velExponent );
+
+					var vx = vel * z + ( Math.random() * 2 - 1 ) * randVel;
+					var vy = ( Math.random() * 2 - 1 ) * randVel * 0.05;
+					var vz = - vel * x + ( Math.random() * 2 - 1 ) * randVel;
+
+					x *= rExp;
+					z *= rExp;
+					y = ( Math.random() * 2 - 1 ) * height;
+
+					var mass = Math.random() * maxMass + 1;
+
+					// Fill in texture values
+					posArray[ k + 0 ] = x;
+					posArray[ k + 1 ] = y;
+					posArray[ k + 2 ] = z;
+					posArray[ k + 3 ] = 1;
+
+					velArray[ k + 0 ] = vx;
+					velArray[ k + 1 ] = vy;
+					velArray[ k + 2 ] = vz;
+					velArray[ k + 3 ] = mass;
+
+				}
 
 			}
 

--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -41,10 +41,11 @@
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
+		<script src="js/RandomNoiseTexture.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/GPUComputationRenderer.js"></script>
-
+		<script src="js/GPUComputationRendererVariable.js"></script>
 		<!-- Fragment shader for filling initial velocity field -->
 		<script id="initialVelocity" type="x-shader/x-fragment">
 
@@ -54,23 +55,27 @@
 			uniform float maxMass;
 
 			uniform sampler2D initialPosition;
-			// the initial SimplexNoise random data bound to range [-1, 1] for first three coordinates
-			// and the range [0, 1] for the last coordinate
 			uniform sampler2D randomSeed;
 
 			void main() {
+
+				vec2 uv = gl_FragCoord.xy / resolution.xy;
+				vec4 random = texture2D(randomSeed, uv);
 
 				// Velocity
 				float rr = pow(initialPosition.x, 2) + pow(initialPosition.y, 2);
 
 				float vel = maxVel * pow( rr, velExponent );
 
+				// put in the range [-1, 1]
+				random.xyz = (2 * random.xyz - 1);
+
 				// fill with the three random coordinates and 'mass' in the final coordinate
 				gl_FragColor = vec4(
-					vel * z + randomSeed.x * randVel,
-					randomSeed.y * randVel * 0.05,
-					- vel * x + randomSeed.z * randVel,
-					randomSeed.w * maxMass + 1
+					vel * z + random.x * randVel,
+					random.y * randVel * 0.05,
+					- vel * x + random.z * randVel,
+					random.w * maxMass + 1
 					);
 			}
 
@@ -87,17 +92,18 @@
 			uniform sampler2D randomSeed;
 
 			void main() {
-				x = randomSeed.x;
-				z = randomSeed.z;
-				rr = x * x + z * z;
+				vec2 uv = gl_FragCoord.xy / resolution.xy;
 
-				rr = Math.sqrt( rr );
+				float x = texture2D(randomSeed, uv).x;
+				float z = texture2D(randomSeed, uv).z;
+				float rr = sqrt( x * x + z * z );
 
-				var rExp = radius * Math.pow( rr, exponent );
+
+				float rExp = radius * pow( rr, exponent );
 
 				x *= rExp;
 				z *= rExp;
-				y = randomSeed.y * height;
+				float y = texture2D(randomSeed, uv).y * height;
 
 				gl_FragColor = vec4(x, y, z, 1);
 			}
@@ -355,9 +361,8 @@
 			var gpuCompute;
 			var velocityVariable;
 			var positionVariable;
-			var positionUniforms;
-			var velocityUniforms;
 			var particleUniforms;
+
 			var effectController;
 
 			init();
@@ -386,7 +391,6 @@
 					// Can be changed dynamically
 					gravityConstant: 100.0,
 					density: 0.45,
-
 					// Must restart simulation
 					radius: 300,
 					height: 8,
@@ -395,7 +399,6 @@
 					velocity: 70,
 					velocityExponent: 0.2,
 					randVelocity: 0.001
-
 				};
 
 				initComputeRenderer();
@@ -413,64 +416,61 @@
 
 			}
 
-			function generateVelocityRandomSeedTexture() {
-
-			}
-
-			function generatePositionRandomSeedTexture() {
-
-			}
-
 			function initComputeRenderer() {
 
-    			gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
+    			gpuCompute = new GPUComputationRenderer( renderer );
 
+    			var initialPositionShader = document.getElementById( 'initialPosition' ).textContent;
+    			var initialVelocityShader = document.getElementById( 'initialVelocity' ).textContent;
+
+    			var positionShader = document.getElementById( 'computeShaderPosition' ).textContent
+    			var velocityShader = document.getElementById( 'computeShaderVelocity' ).textContent
     			// use the shaders to setup the initial distribution of positions and velocities.
     			// Easier than creating and filling textures.
+    			// create the position field
+				positionVariable = new GPUComputationRendererVariable( WIDTH, WIDTH, 'positionVariable');
+				gpuCompute.addVariable(positionVariable);
 				
+				var uniforms = {
+					radius: { value: effectController.radius},
+					exponent: { value: effectController.exponent},
+					height: { value: effectController.height },
+					randomSeed: { value: randomNoiseTexture(WIDTH, WIDTH) }
+				};
 
-				positionVariable = gpuCompute.addVariable( "texturePosition", 
-					document.getElementById( 'computeShaderPosition' ).textContent, 
-					{
-						shader: document.getElementById( 'initialPosition' ).textContent,
-						width: WIDTH,
-						height: HEIGHT
-					});
+				positionVariable.initializeWithShader(initialPositionShader, uniforms);
 
-				velocityVariable = gpuCompute.addVariable( "textureVelocity", 
-					document.getElementById( 'computeShaderVelocity' ).textContent, 
-					{
-						shader: document.getElementById( 'initialVelocity' ).textContent,
-						uniforms: {
-							initialPosition:
-						}
-						width: WIDTH,
-						height: HEIGHT
-					} );
+				// create the velocity field
+				velocityVariable = new GPUComputationRendererVariable( WIDTH, WIDTH, 'velocityVariable');
+				gpuCompute.addVariable(velocityVariable);
 
-				gpuCompute.setVariableDependencies( velocityVariable, [ positionVariable, velocityVariable ] );
-				gpuCompute.setVariableDependencies( positionVariable, [ positionVariable, velocityVariable ] );
+				var uniforms = {
+					gravityConstant: { value: 0.0 },
+					density: { value: 0.0 },
+					maxVel: { value: effectController.velocity},
+					valExponent: { value: effectController.velocityExponent },
+					randVel: { value: effectController.randVelocity},
+					maxMass: { value: effectController.maxMass * 1024 / PARTICLES },
+					randomSeed: { value: randomNoiseTexture(WIDTH, WIDTH)  }
+				};
 
-				positionUniforms = positionVariable.material.uniforms;
-				velocityUniforms = velocityVariable.material.uniforms;
+				// add the already calculated position variable.
+				velocityVariable.addDependency(positionVariable);
 
-				velocityUniforms.gravityConstant = { value: 0.0 };
-				velocityUniforms.density = { value: 0.0 };
+				positionVariable.initializeWithShader(initialVelocityShader, uniforms);
+				// setup the dependencies among the variables *after* initialization to avoid annoying cycles.
+				positionVariable.addDependency(velocityVariable);
 
-				var error = gpuCompute.init();
-				if ( error !== null ) {
-				    console.error( error );
-				}
+				positionVariable.setComputeShader(positionShader);
+				velocityVariable.setComputeShader(velocityShader);
 
+				
 			}
 
 			function restartSimulation() {
+				initComputeRenderer();
 
-				gpuCompute.renderInitialTexture( positionVariable, 0 );
-				gpuCompute.renderInitialTexture( positionVariable, 1 );
-				gpuCompute.renderInitialTexture( velocityVariable, 0 );
-				gpuCompute.renderInitialTexture( velocityVariable, 1 );
-
+				initProtoplanets();
 			}
 
 			function initProtoplanets() {
@@ -499,11 +499,11 @@
 				}
 
 				geometry.addAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
-				geometry.addAttribute( 'uv', new THREE.BufferAttribute( uvs, 2 ) );
+				geometry.addAttribute( 'uv', 	   new THREE.BufferAttribute( uvs, 2 ) );
 
 				particleUniforms = {
-					texturePosition: { value: null },
-					textureVelocity: { value: null },
+					texturePosition: { value: positionVariable.getRenderedOutput() },
+					textureVelocity: { value: velocityVariable.getRenderedOutput() },
 					cameraConstant: { value: getCameraConstant( camera ) },
 					density: { value: 0.0 }
 				};
@@ -514,6 +514,7 @@
 					vertexShader:   document.getElementById( 'particleVertexShader' ).textContent,
 					fragmentShader: document.getElementById( 'particleFragmentShader' ).textContent
 				} );
+
 				material.extensions.drawBuffers = true;
 
 				var particles = new THREE.Points( geometry, material );
@@ -521,22 +522,6 @@
 				particles.updateMatrix();
 
 				scene.add( particles );
-
-			}
-
-			function fillTextures( texturePosition, textureVelocity ) {
-
-				// TODO: pass these into the initial shader
-				var posArray = texturePosition.image.data;
-				var velArray = textureVelocity.image.data;
-
-				var radius = effectController.radius;
-				var height = effectController.height;
-				var exponent = effectController.exponent;
-				var maxMass = effectController.maxMass * 1024 / PARTICLES;
-				var maxVel = effectController.velocity;
-				var velExponent = effectController.velocityExponent;
-				var randVel = effectController.randVelocity;
 
 			}
 
@@ -553,9 +538,9 @@
 
 			function dynamicValuesChanger() {
 
-				velocityUniforms.gravityConstant.value = effectController.gravityConstant;
-				velocityUniforms.density.value = effectController.density;
-				particleUniforms.density.value = effectController.density;
+				velocityVariable.material.uniforms.gravityConstant.value = effectController.gravityConstant;
+				velocityVariable.material.uniforms.density.value 		 = effectController.density;
+				particleUniforms.density.value 							 = effectController.density;
 
 			}
 
@@ -616,8 +601,9 @@
 
 				gpuCompute.compute();
 
-				particleUniforms.texturePosition.value = gpuCompute.getCurrentRenderTarget( positionVariable ).texture;
-				particleUniforms.textureVelocity.value = gpuCompute.getCurrentRenderTarget( velocityVariable ).texture;
+				// update the particle locations.
+				particleUniforms.texturePosition = positionVariable.getRenderedOutput();
+				particleUniforms.textureVelocity = velocityVariable.getRenderedOutput();
 
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
I refactored the GPUComputationRenderer.js class as follows.
1. One can now store variables with *different* underlying texture sizes.
2. One can render variables *individually* (useful for iterative schemes) as well as collectively.
