### PR TITLE
Added THREE.App

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -39126,6 +39126,115 @@
 	};
 
 	/**
+	 * @author Lewy Blue / https://github.com/looeee
+	 *
+	 * parameters = {
+	 *
+	 *  canvas: <canvas> DOM element,
+	 *
+	 *  scene: new THREE.Scene(),
+	 *
+	 *  camera: new THREE.Camera( ... )
+	 *
+	 *  renderer: new THREE.WebGLRenderer( ... )
+	 *
+	 *  autoResize: <bool>
+	 *
+	 *  autoRender: <bool> //setting this to false will prevent calling renderer.render automatically; users can call it manually in the onUpate function instead
+	 *
+	 * }
+	 */
+
+	function App( parameters ) {
+
+		parameters = parameters || {};
+
+		if ( parameters.canvas !== undefined ) {
+
+			this.canvas = parameters.canvas;
+
+		} else {
+
+			this.canvas = document.body.appendChild( document.createElement( 'canvas' ) );
+			this.canvas.style.position = 'absolute';
+			this.canvas.style.width = this.canvas.style.height = '100%';
+
+		}
+
+		this.scene = ( parameters.scene !== undefined ) ? parameters.scene : new THREE.Scene();
+
+		this.camera = ( parameters.camera !== undefined ) ? parameters.camera : new THREE.PerspectiveCamera( 75, this.canvas.clientWidth / this.canvas.clientHeight, 1, 1000 );
+
+		if ( parameters.renderer !== undefined ) {
+
+			this.renderer = parameters.renderer;
+
+		} else {
+
+			this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas, antialias: true } );
+			this.renderer.setPixelRatio( window.devicePixelRatio );
+			this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight, false );
+
+		}
+
+		this.autoResize = ( parameters.autoResize !== undefined ) ? parameters.autoResize : true;
+		window.addEventListener( 'resize', this.onWindowResize.bind( this ), false );
+
+		this.autoRender = ( parameters.autoRender !== undefined ) ? parameters.autoRender : true;
+
+	}
+
+	Object.assign( App.prototype, {
+
+		animate: function () {
+
+			var self = this;
+
+			function animationHandler() {
+
+				self.onUpdate();
+
+				if ( self.autoRender ) self.renderer.render( self.scene, self.camera );
+
+				self.currentAnimationFrameID = requestAnimationFrame( function () { animationHandler(); } );
+
+			}
+
+			animationHandler();
+
+		},
+
+		stopAnimation: function () {
+
+			cancelAnimationFrame( this.currentAnimationFrameID );
+
+		},
+
+		onUpdate: function () {},
+
+		onWindowResize:	function () {
+
+			if ( ! this.autoResize ) return;
+
+			if ( this.camera.type !== 'PerspectiveCamera' ) {
+
+				console.warn( 'THREE.APP: AutoResize only works with PerspectiveCamera' );
+				return;
+
+			}
+
+			var newWidth = this.canvas.clientWidth;
+			var newHeight = this.canvas.clientHeight;
+
+			this.camera.aspect = newWidth / newHeight;
+			this.camera.updateProjectionMatrix();
+			this.renderer.setSize( newWidth, newHeight, false );
+
+		},
+
+	} );
+
+	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author bhouston / http://clara.io/
 	 * @author stephomi / http://stephaneginier.com/
@@ -42914,6 +43023,7 @@
 	exports.InstancedInterleavedBuffer = InstancedInterleavedBuffer;
 	exports.InterleavedBuffer = InterleavedBuffer;
 	exports.InstancedBufferAttribute = InstancedBufferAttribute;
+	exports.App = App;
 	exports.Face3 = Face3;
 	exports.Object3D = Object3D;
 	exports.Raycaster = Raycaster;

--- a/examples/webgl_animation_timeScale.html
+++ b/examples/webgl_animation_timeScale.html
@@ -12,26 +12,58 @@
 				background-color: #000000;
 				overflow: hidden;
 			}
+
+			#info {
+				position: absolute;
+				padding: 10px;
+				width: 100%;
+				text-align: center;
+				color: white;
+				z-index: 0;
+			}
+
+			canvas {
+				z-index: -1;
+			}
 		</style>
 	</head>
 	<body>
 
+		<div id="info">
+			Timescale control demonstration<br />
+			<div>Total Time: <span id="totalTime"></span> Total Unscaled Time: <span id="totalUnscaledTime"></span> Frame Count: <span id="frameCount"></span> </div>
+			<div>Last Frame Time: <span id="lastFrameTime"></span> Min Frame Time: <span id="minFrameTime"></span> Max Frame Time: <span id="maxFrameTime"></span></div>
+			<div></span> Average Frame Time: <span id="avgFrameTime"></span> Average FPS: <span id="fps"></span></div>
+		</div>
+
 		<script src="../build/three.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
+		<script src="js/libs/stats.min.js"></script>
 
 		<script>
+			var total = document.querySelector( '#totalTime' );
+			var totalUnscaled = document.querySelector( '#totalUnscaledTime' );
+			var frameCount = document.querySelector( '#frameCount' );
+			var lastFrameTime = document.querySelector( '#lastFrameTime' );
+			var minFrameTime = document.querySelector( '#minFrameTime' );
+			var maxFrameTime = document.querySelector( '#maxFrameTime' );
+			var avgFrameTime = document.querySelector( '#avgFrameTime' );
+			var fps = document.querySelector( '#fps');
+
+			var stats = new Stats();
+			document.body.appendChild( stats.dom );
+
 			var app;
 
 			init();
 			initGUI();
+			app.play();
 
 			function init() {
 
 				app = new THREE.App();
 
 				app.camera.position.z = 400;
-
-				// var texture = new THREE.TextureLoader().load( 'textures/crate.gif' );
 
 				var geometry = new THREE.BoxBufferGeometry( 200, 200, 200 );
 				var material = new THREE.MeshStandardMaterial( { color: 0x95cfb8 } );
@@ -50,30 +82,93 @@
 					mesh.rotation.x += 0.0005 * delta;
 					mesh.rotation.y += 0.001 * delta;
 
+					updateStatistics();
+
+					stats.update();
+
 				};
 
-				app.animate();
+			}
+
+			function updateStatistics( delta ) {
+
+
+				total.innerText = ( app.time.totalTime / 1000 ).toFixed( 1 );
+				totalUnscaled.innerText = ( app.time.unscaledTotalTime / 1000 ).toFixed( 1 );
+				frameCount.innerText = app.frameCount;
+
+				if ( delta ) {
+
+					var unscaledDelta = Math.floor( delta / app.time.timeScale );
+
+					if ( unscaledDelta < minFrame )	minFrameTime.innerText = minFrame = unscaledDelta;
+					if ( unscaledDelta > maxFrame ) maxFrameTime.innerText = maxFrame = unscaledDelta;
+
+					lastFrameTime.innerText = unscaledDelta;
+
+				}
+
+				avgFrameTime.innerText = Math.floor( app.averageFrameTime );
+				fps.innerText = ( app.averageFrameTime !== 0 ) ? Math.floor( 1000 / app.averageFrameTime ) : 0;
 
 			}
 
 			function initGUI() {
+
 				var gui = new dat.GUI();
 
+				var animationController = {
 
-				var timeController = {
+					stop: function () {
+
+						if ( ! app.time.running ) app.play();
+						else app.stop();
+
+						updateStatistics();
+
+					},
+					pause: function () {
+
+						if ( ! app.time.running ) return;
+
+						if ( app.time.paused ) app.play();
+						else app.pause();
+
+					},
 					timeScale: 1.0,
-				};
-
-				var valuesChanger = function () {
-
-					app.time.timeScale = timeController.timeScale;
 
 				};
 
-				valuesChanger();
+				var timeScaleChanger = function () {
 
+					app.time.timeScale = animationController.timeScale;
 
-				gui.add( timeController, "timeScale", -10.0, 10.0, 0.1 ).onChange( valuesChanger );
+				};
+
+				gui.add( animationController, 'stop' ).onChange( function () {
+
+					var buttonTextElem = this.domElement.previousSibling;
+
+					if ( buttonTextElem.innerText === 'stop' ) buttonTextElem.innerText = 'play';
+					else buttonTextElem.innerText = 'stop';
+
+					gui.__controllers[ 1 ].domElement.previousSibling.innerText = 'pause';
+
+				} );
+
+				gui.add( animationController, 'pause' ).onChange( function () {
+
+					if ( ! app.time.running ) return;
+
+					var buttonTextElem = this.domElement.previousSibling;
+
+					if ( buttonTextElem.innerText === 'pause' ) buttonTextElem.innerText = 'play';
+					else buttonTextElem.innerText = 'pause';
+
+				} );
+
+				gui.add( animationController, "timeScale", - 10.0, 10.0, 0.1 ).onChange( timeScaleChanger );
+
 			}
 
 

--- a/examples/webgl_animation_timeScale.html
+++ b/examples/webgl_animation_timeScale.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - geometry - cube</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				width: 100%;
+				height: 100%;
+				margin: 0px;
+				background-color: #000000;
+				overflow: hidden;
+			}
+		</style>
+	</head>
+	<body>
+
+		<script src="../build/three.js"></script>
+		<script src="js/libs/dat.gui.min.js"></script>
+
+		<script>
+			var app;
+
+			init();
+			initGUI();
+
+			function init() {
+
+				app = new THREE.App();
+
+				app.camera.position.z = 400;
+
+				// var texture = new THREE.TextureLoader().load( 'textures/crate.gif' );
+
+				var geometry = new THREE.BoxBufferGeometry( 200, 200, 200 );
+				var material = new THREE.MeshStandardMaterial( { color: 0x95cfb8 } );
+
+				var mesh = new THREE.Mesh( geometry, material );
+				app.scene.add( mesh );
+
+				var light = new THREE.HemisphereLight( 0xffffff, 0x000000, 3);
+				app.scene.add( light );
+
+				app.onUpdate = function () {
+
+					//Call this only once per frame!
+					var delta = app.time.delta;
+
+					mesh.rotation.x += 0.0005 * delta;
+					mesh.rotation.y += 0.001 * delta;
+
+				};
+
+				app.animate();
+
+			}
+
+			function initGUI() {
+				var gui = new dat.GUI();
+
+
+				var timeController = {
+					timeScale: 1.0,
+				};
+
+				var valuesChanger = function () {
+
+					app.time.timeScale = timeController.timeScale;
+
+				};
+
+				valuesChanger();
+
+
+				gui.add( timeController, "timeScale", -10.0, 10.0, 0.1 ).onChange( valuesChanger );
+			}
+
+
+		</script>
+
+	</body>
+</html>

--- a/examples/webgl_animation_timeScale.html
+++ b/examples/webgl_animation_timeScale.html
@@ -82,13 +82,16 @@
 					mesh.rotation.x += 0.0005 * delta;
 					mesh.rotation.y += 0.001 * delta;
 
-					updateStatistics();
+					updateStatistics( delta );
 
 					stats.update();
 
 				};
 
 			}
+
+			var minFrame = 1000000;
+			var maxFrame = 0;
 
 			function updateStatistics( delta ) {
 

--- a/examples/webgl_geometry_cube.html
+++ b/examples/webgl_geometry_cube.html
@@ -6,6 +6,8 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<style>
 			body {
+				width: 100%;
+				height: 100%;
 				margin: 0px;
 				background-color: #000000;
 				overflow: hidden;
@@ -18,18 +20,13 @@
 
 		<script>
 
-			var camera, scene, renderer;
-			var mesh;
-
 			init();
-			animate();
 
 			function init() {
 
-				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.z = 400;
+				var app = new THREE.App();
 
-				scene = new THREE.Scene();
+				app.camera.position.z = 400;
 
 				var texture = new THREE.TextureLoader().load( 'textures/crate.gif' );
 
@@ -37,36 +34,16 @@
 				var material = new THREE.MeshBasicMaterial( { map: texture } );
 
 				mesh = new THREE.Mesh( geometry, material );
-				scene.add( mesh );
+				app.scene.add( mesh );
 
-				renderer = new THREE.WebGLRenderer();
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				document.body.appendChild( renderer.domElement );
+				app.onUpdate = function () {
 
-				//
+						mesh.rotation.x += 0.005;
+						mesh.rotation.y += 0.01;
 
-				window.addEventListener( 'resize', onWindowResize, false );
+				};
 
-			}
-
-			function onWindowResize() {
-
-				camera.aspect = window.innerWidth / window.innerHeight;
-				camera.updateProjectionMatrix();
-
-				renderer.setSize( window.innerWidth, window.innerHeight );
-
-			}
-
-			function animate() {
-
-				requestAnimationFrame( animate );
-
-				mesh.rotation.x += 0.005;
-				mesh.rotation.y += 0.01;
-
-				renderer.render( scene, camera );
+				app.animate();
 
 			}
 

--- a/examples/webgl_multiple_elements.html
+++ b/examples/webgl_multiple_elements.html
@@ -86,16 +86,16 @@
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
-			var canvas;
-
-			var scenes = [], renderer;
+			var app, scenes = [];
 
 			init();
 			animate();
 
 			function init() {
 
-				canvas = document.getElementById( "c" );
+				app = new THREE.App( {
+					canvas: document.getElementById( "c" ),
+				} );
 
 				var geometries = [
 					new THREE.BoxGeometry( 1, 1, 1 ),
@@ -117,7 +117,7 @@
 					element.innerHTML = template.replace( '$', i + 1 );
 
 					// Look up the element that represents the area
-					// we want to render the scene
+					// we want to render the scene into
 					scene.userData.element = element.querySelector( ".scene" );
 					content.appendChild( element );
 
@@ -156,24 +156,6 @@
 
 				}
 
-
-				renderer = new THREE.WebGLRenderer( { canvas: canvas, antialias: true } );
-				renderer.setClearColor( 0xffffff, 1 );
-				renderer.setPixelRatio( window.devicePixelRatio );
-
-			}
-
-			function updateSize() {
-
-				var width = canvas.clientWidth;
-				var height = canvas.clientHeight;
-
-				if ( canvas.width !== width || canvas.height != height ) {
-
-					renderer.setSize( width, height, false );
-
-				}
-
 			}
 
 			function animate() {
@@ -185,14 +167,12 @@
 
 			function render() {
 
-				updateSize();
+				app.renderer.setClearColor( 0xffffff );
+				app.renderer.setScissorTest( false );
+				app.renderer.clear();
 
-				renderer.setClearColor( 0xffffff );
-				renderer.setScissorTest( false );
-				renderer.clear();
-
-				renderer.setClearColor( 0xe0e0e0 );
-				renderer.setScissorTest( true );
+				app.renderer.setClearColor( 0xe0e0e0 );
+				app.renderer.setScissorTest( true );
 
 				scenes.forEach( function( scene ) {
 
@@ -207,8 +187,8 @@
 					var rect = element.getBoundingClientRect();
 
 					// check if it's offscreen. If so skip it
-					if ( rect.bottom < 0 || rect.top  > renderer.domElement.clientHeight ||
-						 rect.right  < 0 || rect.left > renderer.domElement.clientWidth ) {
+					if ( rect.bottom < 0 || rect.top  > app.renderer.domElement.clientHeight ||
+						 rect.right  < 0 || rect.left > app.renderer.domElement.clientWidth ) {
 
 						return;  // it's off screen
 
@@ -218,19 +198,19 @@
 					var width  = rect.right - rect.left;
 					var height = rect.bottom - rect.top;
 					var left   = rect.left;
-					var bottom = renderer.domElement.clientHeight - rect.bottom;
+					var bottom = app.renderer.domElement.clientHeight - rect.bottom;
 
-					renderer.setViewport( left, bottom, width, height );
-					renderer.setScissor( left, bottom, width, height );
+					app.renderer.setViewport( left, bottom, width, height );
+					app.renderer.setScissor( left, bottom, width, height );
 
 					var camera = scene.userData.camera;
 
 					//camera.aspect = width / height; // not changing in this example
 					//camera.updateProjectionMatrix();
 
-					//scene.userData.controls.update();
+					// scene.userData.controls.update();
 
-					renderer.render( scene, camera );
+					app.renderer.render( scene, camera );
 
 				} );
 

--- a/examples/webgl_multiple_renderers.html
+++ b/examples/webgl_multiple_renderers.html
@@ -16,6 +16,12 @@
 				overflow: hidden;
 			}
 
+			#container {
+				position: absolute;
+				width: 100%;
+				height: 100%;
+			}
+
 			#info {
 				position: absolute;
 				top: 0px; width: 100%;
@@ -30,7 +36,9 @@
 	</head>
 	<body>
 
-		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> webgl - multiple renderers</div>
+		<div id="container">
+			<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> webgl - multiple renderers</div>
+		</div>
 
 		<script src="../build/three.js"></script>
 
@@ -41,13 +49,17 @@
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
-			var camera, scene, renderer1, renderer2;
+			var app1, app2, camera, scene;
 			var group1, group2, group3;
 
 			init();
-			animate();
+
+			app1.animate();
+			app2.animate();
 
 			function init() {
+
+				var container = document.querySelector('#container');
 
 				camera = new THREE.PerspectiveCamera( 20, window.innerWidth / ( window.innerHeight / 2 ), 1, 10000 );
 
@@ -156,27 +168,33 @@
 				group3 = THREE.SceneUtils.createMultiMaterialObject( geometry3, materials );
 				scene.add( group3 );
 
-				//
+				app1 = new THREE.App( {
+					canvas: container.appendChild( document.createElement( 'canvas' ) ),
+					camera: camera,
+					scene: scene,
+				} );
 
-				renderer1 = new THREE.WebGLRenderer( { antialias: true } );
-				renderer1.setClearColor( 0xffffff );
-				renderer1.setPixelRatio( window.devicePixelRatio );
-				renderer1.setSize( window.innerWidth, window.innerHeight / 2 );
-				document.body.appendChild( renderer1.domElement );
+				app2 = new THREE.App( {
+					canvas: container.appendChild( document.createElement( 'canvas' ) ),
+					camera: camera,
+					scene: scene,
+				} );
 
-				renderer2 = new THREE.WebGLRenderer( { antialias: false } );
-				renderer2.setClearColor( 0xffffff );
-				renderer2.setPixelRatio( window.devicePixelRatio );
-				renderer2.setSize( window.innerWidth, window.innerHeight / 2 );
-				document.body.appendChild( renderer2.domElement );
+
+				app1.renderer.setClearColor( 0xffffff );
+				app1.renderer.setSize( window.innerWidth, window.innerHeight / 2, false );
+
+				app2.renderer.setClearColor( 0xffffff );
+				app2.renderer.setSize( window.innerWidth, window.innerHeight / 2, false );
+
+				app1.canvas.style.height = app2.canvas.style.height ='50%';
+				app1.canvas.style.width = app2.canvas.style.width ='100%';
+
+				app1.onUpdate = app2.onUpdate = onUpdate;
 
 			}
 
-			function animate() {
-
-				requestAnimationFrame( animate );
-
-				// update scene
+			function onUpdate() {
 
 				group1.rotation.z += Math.PI / 500;
 				group2.rotation.z += Math.PI / 500;
@@ -186,20 +204,18 @@
 
 				for ( var i = 0; i < geometry.faces.length; i ++ ) {
 
-						var f = geometry.faces[ i ];
+					var f = geometry.faces[ i ];
 
-						for ( var j = 0; j < 3; j ++ ) {
+					for ( var j = 0; j < 3; j ++ ) {
 
-							var color = f.vertexColors[ j ];
-							color.setHex( ( color.getHex() + 0xfdfdfd ) % 0xffffff );
-
-						}
+						var color = f.vertexColors[ j ];
+						color.setHex( ( color.getHex() + 0xfdfdfd ) % 0xffffff );
 
 					}
 
-				geometry.colorsNeedUpdate = true;
+				}
 
-				//
+				geometry.colorsNeedUpdate = true;
 
 				var time = performance.now() / 2000;
 
@@ -207,9 +223,6 @@
 				camera.position.z = Math.cos( time ) * 1800;
 
 				camera.lookAt( scene.position );
-
-				renderer1.render( scene, camera );
-				renderer2.render( scene, camera );
 
 			}
 

--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -106,7 +106,6 @@
 			];
 
 			init();
-			console.log(app);
 			app.animate();
 
 			function init() {

--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -23,8 +23,14 @@
 			}
 
 			a {
-
 				color: #0080ff;
+			}
+
+			canvas {
+				position: absolute;
+				left: 0;
+				width: 100%;
+				height: 100%;
 			}
 
 		</style>
@@ -45,13 +51,11 @@
 
 			var container, stats;
 
-			var views, scene, renderer;
+			var app, views;
 
 			var mesh, group1, group2, group3, light;
 
 			var mouseX = 0, mouseY = 0;
-
-			var windowWidth, windowHeight;
 
 			var views = [
 				{
@@ -102,11 +106,19 @@
 			];
 
 			init();
-			animate();
+			console.log(app);
+			app.animate();
 
 			function init() {
 
 				container = document.getElementById( 'container' );
+
+				app = new THREE.App({
+					canvas: container.appendChild( document.createElement( 'canvas' ) ),
+					autoRender: false,
+				});
+
+				app.onUpdate = onUpdate;
 
 				for (var ii =  0; ii < views.length; ++ii ) {
 
@@ -119,13 +131,12 @@
 					camera.up.y = view.up[ 1 ];
 					camera.up.z = view.up[ 2 ];
 					view.camera = camera;
-				}
 
-				scene = new THREE.Scene();
+				}
 
 				light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 );
-				scene.add( light );
+				app.scene.add( light );
 
 				// shadow
 
@@ -149,19 +160,19 @@
 				mesh = new THREE.Mesh( shadowGeo, shadowMaterial );
 				mesh.position.y = - 250;
 				mesh.rotation.x = - Math. PI / 2;
-				scene.add( mesh );
+				app.scene.add( mesh );
 
 				mesh = new THREE.Mesh( shadowGeo, shadowMaterial );
 				mesh.position.x = - 400;
 				mesh.position.y = - 250;
 				mesh.rotation.x = - Math. PI / 2;
-				scene.add( mesh );
+				app.scene.add( mesh );
 
 				mesh = new THREE.Mesh( shadowGeo, shadowMaterial );
 				mesh.position.x = 400;
 				mesh.position.y = - 250;
 				mesh.rotation.x = - Math. PI / 2;
-				scene.add( mesh );
+				app.scene.add( mesh );
 
 				var faceIndices = [ 'a', 'b', 'c' ];
 
@@ -215,22 +226,17 @@
 				group1 = THREE.SceneUtils.createMultiMaterialObject( geometry, materials );
 				group1.position.x = -400;
 				group1.rotation.x = -1.87;
-				scene.add( group1 );
+				app.scene.add( group1 );
 
 				group2 = THREE.SceneUtils.createMultiMaterialObject( geometry2, materials );
 				group2.position.x = 400;
 				group2.rotation.x = 0;
-				scene.add( group2 );
+				app.scene.add( group2 );
 
 				group3 = THREE.SceneUtils.createMultiMaterialObject( geometry3, materials );
 				group3.position.x = 0;
 				group3.rotation.x = 0;
-				scene.add( group3 );
-
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				container.appendChild( renderer.domElement );
+				app.scene.add( group3 );
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -241,56 +247,36 @@
 
 			function onDocumentMouseMove( event ) {
 
-				mouseX = ( event.clientX - windowWidth / 2 );
-				mouseY = ( event.clientY - windowHeight / 2 );
+				mouseX = ( event.clientX - window.innerWidth / 2 );
+				mouseY = ( event.clientY - window.innerHeight / 2 );
 
 			}
 
-			function updateSize() {
+			function onUpdate() {
 
-				if ( windowWidth != window.innerWidth || windowHeight != window.innerHeight ) {
-
-					windowWidth  = window.innerWidth;
-					windowHeight = window.innerHeight;
-
-					renderer.setSize ( windowWidth, windowHeight );
-
-				}
-
-			}
-
-			function animate() {
-
-				render();
 				stats.update();
-
-				requestAnimationFrame( animate );
-			}
-
-			function render() {
-
-				updateSize();
 
 				for ( var ii = 0; ii < views.length; ++ii ) {
 
 					view = views[ii];
 					camera = view.camera;
 
-					view.updateCamera( camera, scene, mouseX, mouseY );
+					view.updateCamera( camera, app.scene, mouseX, mouseY );
 
-					var left   = Math.floor( windowWidth  * view.left );
-					var bottom = Math.floor( windowHeight * view.bottom );
-					var width  = Math.floor( windowWidth  * view.width );
-					var height = Math.floor( windowHeight * view.height );
-					renderer.setViewport( left, bottom, width, height );
-					renderer.setScissor( left, bottom, width, height );
-					renderer.setScissorTest( true );
-					renderer.setClearColor( view.background );
+					var left   = Math.floor( window.innerWidth  * view.left );
+					var bottom = Math.floor( window.innerHeight * view.bottom );
+					var width  = Math.floor( window.innerWidth  * view.width );
+					var height = Math.floor( window.innerHeight * view.height );
+					app.renderer.setViewport( left, bottom, width, height );
+					app.renderer.setScissor( left, bottom, width, height );
+					app.renderer.setScissorTest( true );
+					app.renderer.setClearColor( view.background );
 
 					camera.aspect = width / height;
 					camera.updateProjectionMatrix();
 
-					renderer.render( scene, camera );
+					app.renderer.render( app.scene, camera );
+
 				}
 
 			}

--- a/src/Three.js
+++ b/src/Three.js
@@ -89,6 +89,7 @@ export { InstancedInterleavedBuffer } from './core/InstancedInterleavedBuffer.js
 export { InterleavedBuffer } from './core/InterleavedBuffer.js';
 export { InstancedBufferAttribute } from './core/InstancedBufferAttribute.js';
 export * from './core/BufferAttribute.js';
+export { App } from './core/App.js';
 export { Face3 } from './core/Face3.js';
 export { Object3D } from './core/Object3D.js';
 export { Raycaster } from './core/Raycaster.js';

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -21,7 +21,7 @@ function App( parameters ) {
 
 	if ( parameters.canvas !== undefined ) {
 
-	  this.canvas = parameters.canvas;
+		this.canvas = parameters.canvas;
 
 	} else {
 
@@ -36,12 +36,12 @@ function App( parameters ) {
 
 	if ( parameters.renderer !== undefined ) {
 
-	  this.renderer = parameters.renderer;
+		this.renderer = parameters.renderer;
 
 	} else {
 
-	  this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas } );
-	  this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight );
+		this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas } );
+		this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight );
 
 	}
 
@@ -51,7 +51,7 @@ Object.assign( App.prototype, {
 
 	animate: function () {
 
-	  var self = this;
+		var self = this;
 
 		function animationHandler() {
 
@@ -61,15 +61,15 @@ Object.assign( App.prototype, {
 
 			self.currentAnimationFrameID = requestAnimationFrame( function () { animationHandler() } );
 
-	  }
+		}
 
-	  animationHandler();
+		animationHandler();
 
 	},
 
 	stopAnimation: function () {
 
-	  cancelAnimationFrame( this.currentAnimationFrameID );
+		cancelAnimationFrame( this.currentAnimationFrameID );
 
 	},
 

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -42,7 +42,7 @@ function App( parameters ) {
 
 	} else {
 
-		this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas } );
+		this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas, antialias: true } );
 		this.renderer.setPixelRatio( window.devicePixelRatio );
 		this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight, false );
 

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -43,6 +43,7 @@ function App( parameters ) {
 	} else {
 
 		this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas } );
+		this.renderer.setPixelRatio( window.devicePixelRatio );
 		this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight, false );
 
 	}

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -27,6 +27,7 @@ function App( parameters ) {
 	} else {
 
 		this.canvas = document.body.appendChild( document.createElement( 'canvas' ) );
+		this.canvas.style.position = 'absolute';
 		this.canvas.style.width = this.canvas.style.height = '100%';
 
 	}
@@ -42,7 +43,7 @@ function App( parameters ) {
 	} else {
 
 		this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas } );
-		this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight );
+		this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight, false );
 
 	}
 
@@ -95,7 +96,7 @@ Object.assign( App.prototype, {
 
 		this.camera.aspect = newWidth / newHeight;
 		this.camera.updateProjectionMatrix();
-		this.renderer.setSize( newWidth, newHeight );
+		this.renderer.setSize( newWidth, newHeight, false );
 
 	},
 

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -13,6 +13,8 @@
  *
  *  autoResize: <bool>
  *
+ *  autoRender: <bool> //setting this to false will prevent calling renderer.render automatically; users can call it manually in the onUpate function instead
+ *
  * }
  */
 
@@ -51,6 +53,8 @@ function App( parameters ) {
 	this.autoResize = ( parameters.autoResize !== undefined ) ? parameters.autoResize : true;
 	window.addEventListener( 'resize', this.onWindowResize.bind( this ), false );
 
+	this.autoRender = ( parameters.autoRender !== undefined ) ? parameters.autoRender : true;
+
 }
 
 Object.assign( App.prototype, {
@@ -63,7 +67,7 @@ Object.assign( App.prototype, {
 
 			self.onUpdate();
 
-			self.renderer.render( self.scene, self.camera );
+			if ( self.autoRender ) self.renderer.render( self.scene, self.camera );
 
 			self.currentAnimationFrameID = requestAnimationFrame( function () { animationHandler() } );
 

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -1,65 +1,121 @@
+import { Time } from './Time.js';
+
 /**
  * @author Lewy Blue / https://github.com/looeee
  *
- * parameters = {
- *
- *  canvas: <canvas> DOM element,
- *
- *  scene: new THREE.Scene(),
- *
- *  camera: new THREE.Camera( ... )
- *
- *  renderer: new THREE.WebGLRenderer( ... )
- *
- *  autoResize: <bool>
- *
- *  autoRender: <bool> //setting this to false will prevent calling renderer.render automatically; users can call it manually in the onUpate function instead
- *
- * }
  */
 
-function App( parameters ) {
+function App( canvas ) {
 
-	parameters = parameters || {};
+	var _canvas, _scene, _camera, _renderer;
 
-	if ( parameters.canvas !== undefined ) {
+	var _currentAnimationFrameID;
 
-		this.canvas = parameters.canvas;
+	if ( canvas !== undefined ) this.canvas = canvas;
 
-	} else {
+	this.autoRender = true;
 
-		this.canvas = document.body.appendChild( document.createElement( 'canvas' ) );
-		this.canvas.style.position = 'absolute';
-		this.canvas.style.width = this.canvas.style.height = '100%';
+	this.autoResize = true;
 
-	}
+	this.time = new Time();
 
-	this.scene = ( parameters.scene !== undefined ) ? parameters.scene : new THREE.Scene();
+	Object.defineProperties( this, {
 
-	this.camera = ( parameters.camera !== undefined ) ? parameters.camera : new THREE.PerspectiveCamera( 75, this.canvas.clientWidth / this.canvas.clientHeight, 1, 1000 );
+		'canvas': {
 
-	if ( parameters.renderer !== undefined ) {
+			get: function () {
 
-		this.renderer = parameters.renderer;
+				if ( _canvas === undefined ) {
 
-	} else {
+					_canvas = document.body.appendChild( document.createElement( 'canvas' ) );
+					_canvas.style.position = 'absolute';
+					_canvas.style.width = _canvas.style.height = '100%';
 
-		this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas, antialias: true } );
-		this.renderer.setPixelRatio( window.devicePixelRatio );
-		this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight, false );
+				}
 
-	}
+				return _canvas;
 
-	this.autoResize = ( parameters.autoResize !== undefined ) ? parameters.autoResize : true;
-	window.addEventListener( 'resize', this.onWindowResize.bind( this ), false );
+			},
 
-	this.autoRender = ( parameters.autoRender !== undefined ) ? parameters.autoRender : true;
+			set: function ( canvas ) {
 
-}
+				_canvas = canvas;
 
-Object.assign( App.prototype, {
+			},
+		},
 
-	animate: function () {
+		'camera': {
+
+			get: function () {
+
+				if ( _camera === undefined ) {
+
+					_camera = new THREE.PerspectiveCamera( 75, this.canvas.clientWidth / this.canvas.clientHeight, 1, 1000 );
+
+				}
+
+				return _camera;
+
+			},
+
+			set: function ( camera ) {
+
+				_camera = camera;
+
+			},
+		},
+
+		'scene': {
+
+			get: function () {
+
+				if ( _scene === undefined ) {
+
+					_scene = new THREE.Scene();
+
+				}
+
+				return _scene;
+
+			},
+
+			set: function ( scene ) {
+
+				_scene = scene;
+
+			},
+		},
+
+		'renderer': {
+
+			get: function () {
+
+				if ( _renderer === undefined ) {
+
+					_renderer = new THREE.WebGLRenderer( { canvas: this.canvas, antialias: true } );
+					_renderer.setPixelRatio( window.devicePixelRatio );
+					_renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight, false );
+					_renderer.setSize( window.innerWidth, window.innerHeight, false );
+
+				}
+
+				return _renderer;
+
+			},
+
+			set: function ( renderer ) {
+
+				_renderer = renderer;
+
+			},
+
+		},
+
+	} );
+
+	this.animate = function () {
+
+		this.time.start();
 
 		var self = this;
 
@@ -75,17 +131,17 @@ Object.assign( App.prototype, {
 
 		animationHandler();
 
-	},
+	};
 
-	stopAnimation: function () {
+	this.stopAnimation = function () {
 
-		cancelAnimationFrame( this.currentAnimationFrameID );
+		cancelAnimationFrame( _currentAnimationFrameID );
 
-	},
+	};
 
-	onUpdate: function () {},
+	this.onUpdate = function () {};
 
-	onWindowResize:	function () {
+	this.onWindowResize =	function () {
 
 		if ( ! this.autoResize ) return;
 
@@ -103,9 +159,10 @@ Object.assign( App.prototype, {
 		this.camera.updateProjectionMatrix();
 		this.renderer.setSize( newWidth, newHeight, false );
 
-	},
+	};
 
-} );
+	window.addEventListener( 'resize', this.onWindowResize.bind( this ), false );
 
+}
 
 export { App };

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -17,6 +17,8 @@ function App( canvas ) {
 
 	this.autoResize = true;
 
+	this.frameCount = 0;
+
 	this.time = new Time();
 
 	Object.defineProperties( this, {
@@ -95,7 +97,6 @@ function App( canvas ) {
 					_renderer = new THREE.WebGLRenderer( { canvas: this.canvas, antialias: true } );
 					_renderer.setPixelRatio( window.devicePixelRatio );
 					_renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight, false );
-					_renderer.setSize( window.innerWidth, window.innerHeight, false );
 
 				}
 
@@ -111,9 +112,19 @@ function App( canvas ) {
 
 		},
 
+		"averageFrameTime": {
+
+			get: function () {
+
+				return ( this.frameCount !== 0 ) ? this.time.unscaledTotalTime / this.frameCount : 0;
+
+			}
+
+		}
+
 	} );
 
-	this.animate = function () {
+	this.play = function () {
 
 		this.time.start();
 
@@ -121,11 +132,13 @@ function App( canvas ) {
 
 		function animationHandler() {
 
+			self.frameCount ++;
+
 			self.onUpdate();
 
 			if ( self.autoRender ) self.renderer.render( self.scene, self.camera );
 
-			self.currentAnimationFrameID = requestAnimationFrame( function () { animationHandler() } );
+			_currentAnimationFrameID = requestAnimationFrame( function () { animationHandler() } );
 
 		}
 
@@ -133,7 +146,18 @@ function App( canvas ) {
 
 	};
 
-	this.stopAnimation = function () {
+	this.pause = function () {
+
+		this.time.pause();
+
+		cancelAnimationFrame( _currentAnimationFrameID );
+
+	}
+
+	this.stop = function () {
+
+		this.time.stop();
+		this.frameCount = 0;
 
 		cancelAnimationFrame( _currentAnimationFrameID );
 

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -11,6 +11,7 @@
  *
  *  renderer: new THREE.WebGLRenderer( ... )
  *
+ *
  * }
  */
 
@@ -22,7 +23,7 @@ function App( parameters ) {
 
 	  this.canvas = parameters.canvas;
 
-	}	else {
+	} else {
 
 		this.canvas = document.body.appendChild( document.createElement( 'canvas' ) );
 		this.canvas.style.width = this.canvas.style.height = '100%';
@@ -37,7 +38,7 @@ function App( parameters ) {
 
 	  this.renderer = parameters.renderer;
 
-	}	else {
+	} else {
 
 	  this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas } );
 	  this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight );
@@ -52,13 +53,13 @@ Object.assign( App.prototype, {
 
 	  var self = this;
 
-	  function animationHandler() {
-
-	    self.currentAnimationFrameID = requestAnimationFrame( function () { animationHandler() } );
+		function animationHandler() {
 
 	    self.onUpdate();
 
 	    self.renderer.render( self.scene, self.camera );
+
+			self.currentAnimationFrameID = requestAnimationFrame( function () { animationHandler() } );
 
 	  }
 
@@ -73,7 +74,6 @@ Object.assign( App.prototype, {
 	},
 
 	onUpdate: function () {},
-
 
 } );
 

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -1,0 +1,81 @@
+/**
+ * @author Lewy Blue / https://github.com/looeee
+ *
+ * parameters = {
+ *
+ *  canvas: <canvas> DOM element,
+ *
+ *  scene: new THREE.Scene(),
+ *
+ *  camera: new THREE.Camera( ... )
+ *
+ *  renderer: new THREE.WebGLRenderer( ... )
+ *
+ * }
+ */
+
+function App( parameters ) {
+
+	parameters = parameters || {};
+
+	if ( parameters.canvas !== undefined ) {
+
+	  this.canvas = parameters.canvas;
+
+	}	else {
+
+		this.canvas = document.body.appendChild( document.createElement( 'canvas' ) );
+		this.canvas.style.width = this.canvas.style.height = '100%';
+
+	}
+
+	this.scene = ( parameters.scene !== undefined ) ? parameters.scene : new THREE.Scene();
+
+	this.camera = ( parameters.camera !== undefined ) ? parameters.camera : new THREE.PerspectiveCamera( 75, this.canvas.clientWidth / this.canvas.clientHeight, 1, 1000 );
+
+	if ( parameters.renderer !== undefined ) {
+
+	  this.renderer = parameters.renderer;
+
+	}	else {
+
+	  this.renderer = new THREE.WebGLRenderer( { canvas: this.canvas } );
+	  this.renderer.setSize( this.canvas.clientWidth, this.canvas.clientHeight );
+
+	}
+
+}
+
+Object.assign( App.prototype, {
+
+	animate: function () {
+
+	  var self = this;
+
+	  function animationHandler() {
+
+	    self.currentAnimationFrameID = requestAnimationFrame( function () { animationHandler() } );
+
+	    self.onUpdate();
+
+	    self.renderer.render( self.scene, self.camera );
+
+	  }
+
+	  animationHandler();
+
+	},
+
+	stopAnimation: function () {
+
+	  cancelAnimationFrame( this.currentAnimationFrameID );
+
+	},
+
+	onUpdate: function () {},
+
+
+} );
+
+
+export { App };

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -11,6 +11,7 @@
  *
  *  renderer: new THREE.WebGLRenderer( ... )
  *
+ *  autoResize: <bool>
  *
  * }
  */
@@ -45,6 +46,9 @@ function App( parameters ) {
 
 	}
 
+	this.autoResize = ( parameters.autoResize !== undefined ) ? parameters.autoResize : true;
+	window.addEventListener( 'resize', this.onWindowResize.bind( this ), false );
+
 }
 
 Object.assign( App.prototype, {
@@ -74,6 +78,26 @@ Object.assign( App.prototype, {
 	},
 
 	onUpdate: function () {},
+
+	onWindowResize:	function () {
+
+		if ( ! this.autoResize ) return;
+
+		if ( this.camera.type !== 'PerspectiveCamera' ) {
+
+			console.warn( 'THREE.APP: AutoResize only works with PerspectiveCamera' );
+			return;
+
+		}
+
+		var newWidth = this.canvas.clientWidth;
+		var newHeight = this.canvas.clientHeight;
+
+		this.camera.aspect = newWidth / newHeight;
+		this.camera.updateProjectionMatrix();
+		this.renderer.setSize( newWidth, newHeight );
+
+	},
 
 } );
 

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -55,9 +55,9 @@ Object.assign( App.prototype, {
 
 		function animationHandler() {
 
-	    self.onUpdate();
+			self.onUpdate();
 
-	    self.renderer.render( self.scene, self.camera );
+			self.renderer.render( self.scene, self.camera );
 
 			self.currentAnimationFrameID = requestAnimationFrame( function () { animationHandler() } );
 

--- a/src/core/Time.js
+++ b/src/core/Time.js
@@ -1,0 +1,113 @@
+/**
+ * @author Lewy Blue / https://github.com/looeee
+ */
+
+function Time() {
+
+	//Keep track of time when pause() was called
+	var _pauseTime;
+
+	//Keep track of time when delta was last checked
+	var _lastDelta = 0;
+
+	//Hold the time when start() was called
+	//There is no point in exposing this as it's essentially a random number
+	//and will be different depending on whether performance.now or Date.now is used
+	var _startTime = 0;
+
+	this.running = false;
+	this.paused = false;
+
+	//The scale at which the time is passing. This can be used for slow motion effects.
+	this.timeScale = 1.0;
+
+	Object.defineProperties( this, {
+
+		"now": {
+
+			get: function () {
+
+				return ( performance || Date ).now();
+
+			}
+
+		},
+
+		"unscaledTotalTime": {
+
+			get: function () {
+
+				return ( this.running ) ? this.now - _startTime : 0;
+
+			}
+
+		},
+
+		"totalTime": {
+
+			get: function () {
+
+				return this.unscaledTotalTime * this.timeScale;
+
+			}
+
+		},
+
+		//Unscaled time since delta was last checked
+		"unscaledDelta": {
+
+			get: function () {
+
+				var diff = this.now - _lastDelta;
+				_lastDelta = this.now;
+
+				return diff;
+
+			}
+
+		},
+
+		//Scaled time since delta was last checked
+		"delta": {
+
+			get: function () {
+
+				return this.unscaledDelta * this.timeScale;
+
+			}
+
+		}
+
+	} );
+
+	this.start = function () {
+
+		if ( this.paused ) _startTime = _startTime - ( ( this.now - _pauseTime ) * this.timeScale );
+
+		else if ( ! this.running ) _startTime = _lastDelta = this.now;
+
+		this.running = true;
+		this.paused = false;
+
+	};
+
+	//Reset and stop clock
+	this.stop = function () {
+
+		_startTime = 0;
+
+		this.running = false;
+
+	};
+
+	this.pause = function () {
+
+		_pauseTime = this.totalTime;
+
+		this.paused = true;
+
+	};
+
+}
+
+export { Time };

--- a/src/core/Time.js
+++ b/src/core/Time.js
@@ -18,7 +18,7 @@ function Time() {
 	this.running = false;
 	this.paused = false;
 
-	//The scale at which the time is passing. This can be used for slow motion effects.
+
 	var _timeScale = 1.0;
 	//Keep track of scaled time across scale changes
 	var _totalTimeAtLastScaleChange = 0;
@@ -36,6 +36,7 @@ function Time() {
 
 		},
 
+		//The scale at which the time is passing. This can be used for slow motion effects.
 		"timeScale": {
 
 			get: function () {


### PR DESCRIPTION
Based on @mrdoob's suggestion here #10676

Using this a default scene can be set up like so

```js
const app = new THREE.App();

const geometry = new THREE.BoxBufferGeometry(2, 2, 2);
const material = new THREE.MeshStandardMaterial({ color: 0xdddddd });

const light = new THREE.HemisphereLight(0xffffff, 0x000000, 1);
app.scene.add(light);

const mesh = new THREE.Mesh(geometry, material);
mesh.position.set(0, 0, -5);

app.scene.add(mesh);

app.onUpdate = function () {
  mesh.rotation.x += 0.01;
  mesh.rotation.y += 0.01;
};

app.animate();

window.addEventListener( 'click', function () { app.stopAnimation(); }, false );
```

The main issue I came across was how best to set the renderer size. I decided on the following: 
If a canvas is passed in, use its ```canvas.clientWidth``` and ```canvas.clientHeight```, otherwise create a new canvas element, set it's style.width and style.height to 100% then use the ```canvas.clientWidth``` and ```canvas.clientHeight``` of that for the renderer. 

~~This approach makes auto-resizing a little more involved though as clientWidth / Height doesn't get updated on window resize so some calculations would be required. Nothing too complex  but I've left it out for now for simplicity.~~ Added autoResize, see below. 

One other point to address the main issues being brought up in #10676:
This is just boilerplate - the idea is to make the basic setup used in the majority of scenes easier, especially for beginners. However for more complex situations you can still do things the old way, so there is no reduction in functionality for advanced use cases here. 