### PR TITLE
THREE.App work in progress - do not pull

### DIFF
--- a/src/cameras/AutoSizingOrthographicCamera.js
+++ b/src/cameras/AutoSizingOrthographicCamera.js
@@ -1,0 +1,101 @@
+import { Camera } from './Camera';
+import { Object3D } from '../core/Object3D';
+
+/**
+ * @author alteredq / http://alteredqualia.com/
+ * @author arose / http://github.com/arose
+ */
+
+function AutoSizingOrthographicCamera( height, near, far ) {
+
+	Camera.call( this );
+
+	this.type = 'AutoSizingOrthographicCamera';
+
+	this.zoom = 1;
+	this.view = null;
+
+	this.height = height;
+    this.aspect = 1;
+
+	this.near = ( near !== undefined ) ? near : 0.1;
+	this.far = ( far !== undefined ) ? far : 2000;
+
+	this.updateProjectionMatrix();
+
+}
+
+AutoSizingOrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ), {
+
+	constructor: AutoSizingOrthographicCamera,
+
+	isOrthographicCamera: true,
+
+	copy: function ( source ) {
+
+		Camera.prototype.copy.call( this, source );
+
+		this.height = source.height;
+		this.near = source.near;
+		this.far = source.far;
+
+		this.zoom = source.zoom;
+		this.view = source.view === null ? null : Object.assign( {}, source.view );
+
+		return this;
+
+	},
+
+	updateProjectionMatrix: function () {
+
+		var base = this.height;
+		var halfHeight =  base / 2;
+		var halfWidth = halfHeight * this.aspect;
+		var top = halfHeight;
+		var bottom = -halfHeight;
+		var left = -halfWidth;
+		var right = halfWidth;
+
+		var dx = ( right - left ) / ( 2 * this.zoom );
+		var dy = ( top - bottom ) / ( 2 * this.zoom );
+		var cx = ( right + left ) / 2;
+		var cy = ( top + bottom ) / 2;
+
+		var left = cx - dx;
+		var right = cx + dx;
+		var top = cy + dy;
+		var bottom = cy - dy;
+
+		this.projectionMatrix.makeOrthographic( left, right, top, bottom, this.near, this.far );
+
+	},
+
+	updateCameraBasedOnRenderSizes: function ( width, height ) {
+
+		this.aspect = width / height;
+		camera.updateProjectionMatrix();
+
+	}
+
+	toJSON: function ( meta ) {
+
+		var data = Object3D.prototype.toJSON.call( this, meta );
+
+		data.object.zoom = this.zoom;
+		data.object.left = this.left;
+		data.object.right = this.right;
+		data.object.top = this.top;
+		data.object.bottom = this.bottom;
+		data.object.near = this.near;
+		data.object.far = this.far;
+
+		if ( this.view !== null ) data.object.view = Object.assign( {}, this.view );
+
+		return data;
+
+	}
+
+} );
+
+
+export { AutoSizingOrthographicCamera };

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -197,6 +197,13 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	},
 
+	updateBasedOnRenderSize: function ( width, height ) {
+
+		this.aspect = width / height;
+		this.updateProjectionMatrix();
+
+	},
+
 	toJSON: function ( meta ) {
 
 		var data = Object3D.prototype.toJSON.call( this, meta );

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -1,0 +1,73 @@
+import { PerspectiveCamera } from './cameras/PerspectiveCamera';
+import { Scene } from './scenes/Scene';
+import { WebGLRenderer } from './renderers/WebGLRenderer';
+
+function App( parameters ) {
+
+	var canvas;
+	parameters = Object.assign( {}, parameters || {} );
+
+	if ( parameters.canvas !== undefined ) {
+
+	  canvas = parameters.canvas;
+
+	} else {
+
+		canvas = document.body.appendChild( document.createElement( 'canvas' ) );
+		canvas.style.width = this.canvas.style.height = '100%';
+
+	}
+
+	parameters.canvas = canvas;
+
+	this.scene = ( parameters.scene !== undefined ) ? parameters.scene : new Scene();
+	this.camera = ( parameters.camera !== undefined ) ? parameters.camera : new PerspectiveCamera();
+
+	this.renderer = new WebGLRenderer( parameters );
+	this.resizeCanvasAndUpdateCamera();
+
+}
+
+Object.assign( App.prototype, {
+
+	resizeCanvasAndUpdateCamera: function() {
+
+		if ( this.renderer.resizeCanvasToMatchDisplaySize() ) {
+
+			var canvas = this.renderer.domElement;
+			this.camera.updateBasedOnRenderSize( canvas.clientWidth, canvas.clientHeight );
+
+		}
+
+	},
+
+	onRender: function( fn ) {
+
+		var self = this;
+		var then = 0;
+
+		function render( time ) {
+
+			time *= 0.001;  // Just use seconds everwhere?
+			var delta = time - then;
+			then = time;
+
+			self.resizeCanvasAndUpdateCamera();
+
+			if ( fn( time, delta ) !== false ) {
+
+				requestAnimationFrame( render );
+
+			}
+
+		};
+
+		requestAnimationFrame( render );
+
+	},
+
+
+} );
+
+export { App }
+

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -427,6 +427,24 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+    this.resizeCanvasToMatchDisplaySize = function() {
+
+        var canvas = this.domElement;
+        var width = canvas.clientWidth / _pixelRatio | 0;
+        var height = canvas.clientHeight / _pixelRatio | 0;
+
+        var needResize = canvas.width !== width || canvas.height !== height;
+
+        if ( needResize ) {
+
+            this.setSize( width, height, false );
+
+        }
+
+        return needResize;
+
+    }
+
 	this.setViewport = function ( x, y, width, height ) {
 
 		state.viewport( _viewport.set( x, y, width, height ) );


### PR DESCRIPTION
Here's another example related to #10676 . It also points out some issues

`OrthographicCamera` is not really designed to be auto-updated. To be auto updatable you need only one dimension so it can pick the other where as `left`, `right`, `top`, `bottom` don't really fit the idea of auto-updatable orthographic camera.

So, as a proof-of-concept I made `AutoSizingOrthographicCamera` which only takes height and computes the rest. Similarly an auto sizing orthographic camera really has no point in a subview does it. Which direction would it grow? You'd need to specify some anchor point in the larger view and then specify how to grow around that point? Maybe I haven't thought it through but it certainly seems problematic.

Even then, this proof-of-concept auto-sizing camera only handles the origin in the center. If you want the origin on the top left like many 2D apps would probably want you'd need more options. Similarly if you want the scale to stay 1x1 with the size of the canvas (give you more/less space as the canvas changes size vs this one which will stretch/shrink as the canvas changes size) you'd need more options or yet another camera.

I think that might point out some issues with the entire `THREE.App` idea? Or maybe you just don't want to allow Orthographic cameras at all with `THREE.App`? Or something else.

Otherwise I put `resizeCanvasToMatchDisplaySize` on the renderer since it seems legit to be able to call it outside of using `THREE.App`. I'd even argue it should be inside a util class and the renderer should call that util as then you could pass in other canvas.

I also put the `updateToRenderSize` functions on the cameras because arguably you'd want to be able to call those same functions for render targets.

There's a few other cameras, `CubeCamera`, `StereoCamera`, which I have not looked into if they can be hacked to work this way or also need new implementations to deal with the idea of being auto-updatable. 

