### PR TITLE
Daydream: Added Origin Trial Token

### DIFF
--- a/examples/webvr_daydream.html
+++ b/examples/webvr_daydream.html
@@ -4,6 +4,8 @@
 		<title>three.js webvr - daydream</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+		<!-- Origin Trial Token, feature = WebVR, origin = https://threejs.org, expires = 2017-03-13 -->
+		<meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-03-13" content="Any7HFKv+fkg+mBnJBBFIYyFbQgDyum3bNsVUXBInRDadbhafI6F0hXq/cStNqdi29167TYlkDuH/JE5ZZSI6gcAAABKeyJvcmlnaW4iOiJodHRwczovL3RocmVlanMub3JnOjQ0MyIsImZlYXR1cmUiOiJXZWJWUiIsImV4cGlyeSI6MTQ4OTQxNzU2OX0=">
 		<style>
 			body {
 				font-family: Monospace;


### PR DESCRIPTION
I've ordered a origin trial token so it's easier for other developers to use the daydream example. The token is valid for the entire `https://threejs.org` domain. So other possible examples can also use it...

More information: https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md