### PR TITLE
WebGLRenderer: Made MultiMaterial more robust

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1434,32 +1434,34 @@ function WebGLRenderer( parameters ) {
 							var groups = geometry.groups;
 							var materials = material.materials;
 
-							if ( groups.length === 0 ) {
+							if ( groups.length > 0 ) {
 
-								console.warn( 'THREE.WebGLRenderer: MultiMaterial can not be used without groups.' );
+								// push a render item for each group of the geometry
 
-							}
+								for ( var i = 0, l = groups.length; i < l; i ++ ) {
 
-							// push a render item for each group of the geometry
+									var group = groups[ i ];
+									var groupMaterial = materials[ group.materialIndex ];
 
-							for ( var i = 0, l = groups.length; i < l; i ++ ) {
+									if ( groupMaterial === undefined ) {
 
-								var group = groups[ i ];
-								var groupMaterial = materials[ group.materialIndex ];
+										console.warn( 'THREE.WebGLRenderer: MultiMaterial has insufficient amount of materials for geometry. %i material(s) expected but only %i provided.', groups.length, materials.length );
 
-								if ( groupMaterial === undefined ) {
+									} else {
 
-									console.warn( 'THREE.WebGLRenderer: MultiMaterial has insufficient amount of materials for geometry. %i material(s) expected but only %i provided.', groups.length, materials.length );
+										if ( groupMaterial.visible === true ) {
 
-								} else {
+											pushRenderItem( object, geometry, groupMaterial, _vector3.z, group );
 
-									if ( groupMaterial.visible === true ) {
-
-										pushRenderItem( object, geometry, groupMaterial, _vector3.z, group );
+										}
 
 									}
 
 								}
+
+							} else {
+
+								console.warn( 'THREE.WebGLRenderer: MultiMaterial can not be used without groups.' );
 
 							}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1434,23 +1434,9 @@ function WebGLRenderer( parameters ) {
 							var groups = geometry.groups;
 							var materials = material.materials;
 
-							// there must be at least one group if a MultiMaterial is used
-
 							if ( groups.length === 0 ) {
 
-								if ( geometry.index !== null ) {
-
-									// indexed geometry
-
-									geometry.addGroup( 0, geometry.index.count );
-
-								} else {
-
-									// non-indexed geometry
-
-									geometry.addGroup( 0, geometry.attributes.position.count );
-
-								}
+								console.warn( 'THREE.WebGLRenderer: MultiMaterial can not be used without groups.' );
 
 							}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1438,7 +1438,7 @@ function WebGLRenderer( parameters ) {
 
 							if ( groups.length === 0 ) {
 
-								if ( geometry.index !== undefined ) {
+								if ( geometry.index !== null ) {
 
 									// indexed geometry
 
@@ -1448,7 +1448,7 @@ function WebGLRenderer( parameters ) {
 
 									// non-indexed geometry
 
-									geometry.addGroup( 0, geometry.position.count / 3 );
+									geometry.addGroup( 0, geometry.attributes.position.count );
 
 								}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1434,14 +1434,44 @@ function WebGLRenderer( parameters ) {
 							var groups = geometry.groups;
 							var materials = material.materials;
 
+							// there must be at least one group if a MultiMaterial is used
+
+							if ( groups.length === 0 ) {
+
+								if ( geometry.index !== undefined ) {
+
+									// indexed geometry
+
+									geometry.addGroup( 0, geometry.index.count );
+
+								} else {
+
+									// non-indexed geometry
+
+									geometry.addGroup( 0, geometry.position.count / 3 );
+
+								}
+
+							}
+
+							// push a render item for each group of the geometry
+
 							for ( var i = 0, l = groups.length; i < l; i ++ ) {
 
 								var group = groups[ i ];
 								var groupMaterial = materials[ group.materialIndex ];
 
-								if ( groupMaterial.visible === true ) {
+								if ( groupMaterial === undefined ) {
 
-									pushRenderItem( object, geometry, groupMaterial, _vector3.z, group );
+									console.warn( 'THREE.WebGLRenderer: MultiMaterial has insufficient amount of materials for geometry. %i material(s) expected but only %i provided.', groups.length, materials.length );
+
+								} else {
+
+									if ( groupMaterial.visible === true ) {
+
+										pushRenderItem( object, geometry, groupMaterial, _vector3.z, group );
+
+									}
 
 								}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1447,13 +1447,9 @@ function WebGLRenderer( parameters ) {
 
 										console.warn( 'THREE.WebGLRenderer: MultiMaterial has insufficient amount of materials for geometry. %i material(s) expected but only %i provided.', groups.length, materials.length );
 
-									} else {
+									} else if ( groupMaterial.visible === true ) {
 
-										if ( groupMaterial.visible === true ) {
-
-											pushRenderItem( object, geometry, groupMaterial, _vector3.z, group );
-
-										}
+										pushRenderItem( object, geometry, groupMaterial, _vector3.z, group );
 
 									}
 


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/10636#issuecomment-276531885

This PR changes two things in `.projectObject()`:

1. If the user provides a `MultiMaterial` with less materials than expected, the user gets informed with a new warning. This avoids a runtime error mentioned in the linked PR.

2. If a geometry with no groups is used in combination with `MultiMaterial`, the method now creates a default group. This avoids no rendered objects like in this case: https://jsfiddle.net/oooao6qb/6/