### PR TITLE
FBXLoader2: Support for PreRotation

### DIFF
--- a/examples/js/loaders/FBXLoader2.js
+++ b/examples/js/loaders/FBXLoader2.js
@@ -59,23 +59,22 @@
 
 			this.fileLoader.load( url, function ( text ) {
 
-				if ( ! isFbxFormatASCII( text ) ) {
+				try {
 
-					console.error( 'FBXLoader: FBX Binary format not supported.' );
-					self.manager.itemError( url );
-					return;
+					var scene = self.parse( text, resourceDirectory );
+					onLoad( scene );
+
+				} catch ( error ) {
+
+					window.setTimeout( function () {
+
+						if ( onError ) onError( error );
+
+						self.manager.itemError( url );
+
+					}, 0 );
 
 				}
-				if ( getFbxVersion( text ) < 7000 ) {
-
-					console.error( 'FBXLoader: FBX version not supported for file at ' + url + ', FileVersion: ' + getFbxVersion( text ) );
-					self.manager.itemError( url );
-					return;
-
-				}
-
-				var scene = self.parse( text, resourceDirectory );
-				onLoad( scene );
 
 			}, onProgress, onError );
 
@@ -92,6 +91,24 @@
 		parse: function ( FBXText, resourceDirectory ) {
 
 			var loader = this;
+
+			if ( ! isFbxFormatASCII( FBXText ) ) {
+
+				throw new Error( 'FBXLoader: FBX Binary format not supported.' );
+				self.manager.itemError( url );
+				return;
+
+				//TODO: Support Binary parsing.  Hopefully in the future,
+				//we call var FBXTree = new BinaryParser().parse( FBXText );
+
+			}
+			if ( getFbxVersion( FBXText ) < 7000 ) {
+
+				throw new Error( 'FBXLoader: FBX version not supported for file at ' + url + ', FileVersion: ' + getFbxVersion( text ) );
+				self.manager.itemError( url );
+				return;
+
+			}
 
 			var FBXTree = new TextParser().parse( FBXText );
 

--- a/examples/js/loaders/FBXLoader2.js
+++ b/examples/js/loaders/FBXLoader2.js
@@ -1947,25 +1947,6 @@
 						}
 
 					}
-					if ( curveNode.preRotations !== null && curveNode.attr === 'R' ) {
-
-						var curves = curveNode.curves;
-						var preRotations = new THREE.Euler().setFromVector3( curveNode.preRotations, 'ZYX' );
-						preRotations = new THREE.Quaternion().setFromEuler( preRotations );
-						var frameRotation = new THREE.Euler();
-						var frameRotationQuaternion = new THREE.Quaternion();
-						for ( var frame = 0; frame < curves.x.times.length; ++ frame ) {
-
-							frameRotation.set( curves.x.values[ frame ], curves.y.values[ frame ], curves.z.values[ frame ], 'ZYX' );
-							frameRotationQuaternion.setFromEuler( frameRotation ).normalize().premultiply( preRotations ).normalize();
-							frameRotation.setFromQuaternion( frameRotationQuaternion, 'ZYX' );
-							curves.x.values[ frame ] = frameRotation.x;
-							curves.y.values[ frame ] = frameRotation.y;
-							curves.z.values[ frame ] = frameRotation.z;
-
-						}
-
-					}
 
 				} );
 

--- a/examples/js/loaders/FBXLoader2.js
+++ b/examples/js/loaders/FBXLoader2.js
@@ -1210,7 +1210,7 @@
 
 					if ( 'Lcl_Rotation' in node.properties ) {
 
-						var rotation = parseFloatArray( node.properties.Lcl_Rotation.value ).map( function ( value ) {
+						var rotation = parseFloatArray( node.properties.Lcl_Rotation.value ).map( function ( value, index ) {
 
 							return value * Math.PI / 180;
 
@@ -1223,6 +1223,15 @@
 					if ( 'Lcl_Scaling' in node.properties ) {
 
 						model.scale.fromArray( parseFloatArray( node.properties.Lcl_Scaling.value ) );
+
+					}
+
+					if ( 'PreRotation' in node.properties ) {
+
+						var preRotations = parseVector3( node.properties.PreRotation ).multiplyScalar( Math.PI / 180 );
+						model.rotation.x += preRotations.x;
+						model.rotation.y += preRotations.y;
+						model.rotation.z += preRotations.z;
 
 					}
 
@@ -1363,6 +1372,15 @@
 					if ( 'Lcl_Scaling' in node.properties ) {
 
 						model.scale.fromArray( parseFloatArray( node.properties.Lcl_Scaling.value ) );
+
+					}
+
+					if ( 'PreRotation' in node.properties ) {
+
+						var preRotations = parseVector3( node.properties.PreRotation ).multiplyScalar( Math.PI / 180 );
+						model.rotation.x += preRotations.x;
+						model.rotation.y += preRotations.y;
+						model.rotation.z += preRotations.z;
 
 					}
 

--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -92,6 +92,9 @@
 				};
 
 				var onError = function( xhr ) {
+
+					console.error( xhr );
+
 				};
 
 				var loader = new THREE.FBXLoader( manager );


### PR DESCRIPTION
The day is here!  The nasty `PreRotation` variable is now properly integrated into the `FBXLoader2.js`.
- Fixed bug where objects relying on `PreRotation` were not properly rotated.
- Fixed bug where animations relying on `PreRotation` were not properly animated.

Full fix for #10703 @filharvey
Partial fix for #10509 . Still need to sort out some extra mapping types not previously documented (unrelated).
Not enough information if #8929 is fixed.