### PR TITLE
Fix gltf parser sampler default values

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1090,10 +1090,10 @@ THREE.GLTFLoader = ( function () {
 
 								var sampler = json.samplers[ texture.sampler ];
 
-								_texture.magFilter = WEBGL_FILTERS[ sampler.magFilter || 9729 ];
-								_texture.minFilter = WEBGL_FILTERS[ sampler.minFilter || 9986 ];
-								_texture.wrapS = WEBGL_WRAPPINGS[ sampler.wrapS || 10497 ];
-								_texture.wrapT = WEBGL_WRAPPINGS[ sampler.wrapT || 10497 ];
+								_texture.magFilter = WEBGL_FILTERS[ sampler.magFilter ] || THREE.LinearFilter;
+								_texture.minFilter = WEBGL_FILTERS[ sampler.minFilter ] || THREE.NearestMipMapLinearFilter;
+								_texture.wrapS = WEBGL_WRAPPINGS[ sampler.wrapS ] || THREE.RepeatWrapping;
+								_texture.wrapT = WEBGL_WRAPPINGS[ sampler.wrapT ] || THREE.RepeatWrapping;
 
 							}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1090,10 +1090,10 @@ THREE.GLTFLoader = ( function () {
 
 								var sampler = json.samplers[ texture.sampler ];
 
-								_texture.magFilter = WEBGL_FILTERS[ sampler.magFilter ];
-								_texture.minFilter = WEBGL_FILTERS[ sampler.minFilter ];
-								_texture.wrapS = WEBGL_WRAPPINGS[ sampler.wrapS ];
-								_texture.wrapT = WEBGL_WRAPPINGS[ sampler.wrapT ];
+								_texture.magFilter = WEBGL_FILTERS[ sampler.magFilter || 9729 ];
+								_texture.minFilter = WEBGL_FILTERS[ sampler.minFilter || 9986 ];
+								_texture.wrapS = WEBGL_WRAPPINGS[ sampler.wrapS || 10497 ];
+								_texture.wrapT = WEBGL_WRAPPINGS[ sampler.wrapT || 10497 ];
 
 							}
 


### PR DESCRIPTION
The glTF format specification lists default values for sampler wrap and filter settings, but they were not implemented before.