### PR TITLE
FBXLoader2: Fixed loading issues with Model reported in 10509.

### DIFF
--- a/examples/js/loaders/FBXLoader2.js
+++ b/examples/js/loaders/FBXLoader2.js
@@ -403,14 +403,13 @@
 							var type = relationship.relationship;
 							switch ( type ) {
 
-								case " \"AmbientColor":
-									//TODO: Support AmbientColor textures
-									break;
-
 								case " \"DiffuseColor":
 									parameters.map = textureMap.get( relationship.ID );
 									break;
 
+								case " \"AmbientColor":
+								case " \"Bump":
+								case " \"EmissiveColor":
 								default:
 									console.warn( 'Unknown texture application of type ' + type + ', skipping texture' );
 									break;
@@ -949,6 +948,16 @@
 
 									},
 
+									ByVertice: {
+
+										Direct: function ( polygonVertexIndex, polygonIndex, vertexIndex, infoObject ) {
+
+											return infoObject.buffer.slice( ( vertexIndex * infoObject.dataSize ), ( vertexIndex * infoObject.dataSize ) + infoObject.dataSize );
+
+										}
+
+									},
+
 									AllSame: {
 
 										/**
@@ -998,6 +1007,16 @@
 
 							console.error( "FBXLoader: Invalid Order " + geometryNode.properties.Order + " given for geometry ID: " + geometryNode.id );
 							return new THREE.BufferGeometry();
+
+						}
+
+						if ( geometryNode.properties.Form === 'Periodic' ) {
+
+							console.error( "FBXLoader: Currently no support for Periodic Nurbs Curves for geometry ID: " + geometryNode.id + ", using empty geometry buffer." );
+							return new THREE.BufferGeometry();
+
+							//TODO: Support Periodic NURBS curves.
+							//Info Link: https://knowledge.autodesk.com/support/maya/learn-explore/caas/CloudHelp/cloudhelp/2015/ENU/Maya/files/NURBS-overview-Periodic-closed-and-open-geometry-htm.html
 
 						}
 


### PR DESCRIPTION
Believed to have fixed issues with Model in issue #10509 .  Hard to determine if all bugs are fixed until the original model reduces the maximum skinning weights per vertex down to 4.
- Issues not fixed should be reported for the most part.
- Skinning for model does not look correct, assumed due to more than 4 skinning weights per vertex.

Things that still need to be fixed:
- Support for periodic NURBS curves (I don't have the expertise to generate the right code.  Looking for insight on importing NURBS @LouisBrunner. ).

Things that cannot be fixed from the `FBXLoader2.js` itself:
- Support for Bump maps and Emissive Color maps.