### PR TITLE
Add Clock support in node

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -18,7 +18,7 @@ Object.assign( Clock.prototype, {
 
 	start: function () {
 
-		this.startTime = ( performance || Date ).now();
+		this.startTime = ( typeof performance === 'undefined' ? Date : performance ).now();
 
 		this.oldTime = this.startTime;
 		this.elapsedTime = 0;
@@ -52,7 +52,7 @@ Object.assign( Clock.prototype, {
 
 		if ( this.running ) {
 
-			var newTime = ( performance || Date ).now();
+			var newTime = ( typeof performance === 'undefined' ? Date : performance ).now();
 
 			diff = ( newTime - this.oldTime ) / 1000;
 			this.oldTime = newTime;

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -18,7 +18,7 @@ Object.assign( Clock.prototype, {
 
 	start: function () {
 
-		this.startTime = ( typeof performance === 'undefined' ? Date : performance ).now();
+		this.startTime = ( typeof performance === 'undefined' ? Date : performance ).now(); // see #10732
 
 		this.oldTime = this.startTime;
 		this.elapsedTime = 0;


### PR DESCRIPTION
This pull request is based on issue #8112 
Current usage of `( performance || Date ).now()` breaks node.js with the following error:
```
ReferenceError: performance is not defined
```
I suggest the use of `( typeof performance === 'undefined' ? Date : performance ).now()`. It works in node.js environment as expected.
