### PR TITLE
Fix typo in FaceNormalsHelper

### DIFF
--- a/docs/api/helpers/FaceNormalsHelper.html
+++ b/docs/api/helpers/FaceNormalsHelper.html
@@ -32,7 +32,7 @@
 
 		helper = new THREE.FaceNormalsHelper( box, 2, 0x00ff00, 1 );
 
-		scene.add( object );
+		scene.add( box );
 		scene.add( helper );
 		</code>
 


### PR DESCRIPTION
The example add "object" to scene instead of "box"