### PR TITLE
GLTFLoader materials only get passed used properties

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1160,7 +1160,18 @@ THREE.GLTFLoader = ( function () {
 
 					}
 
-					Object.assign( materialValues, khr_material.values );
+					// don't copy over unused values to avoid material warning spam
+					var c = ['ambient', 'transparent', 'transparency', 'doubleSided'];
+					var allowedValues = {
+						'CONSTANT': c.concat('emission'),
+						'LAMBERT':  c.concat('emission', 'diffuse'),
+						'BLINN':    c.concat('emission', 'diffuse', 'specular', 'shininess'),
+						'PHONG':    c.concat('emission', 'diffuse', 'specular', 'shininess')
+					};
+
+					allowedValues[khr_material.technique].forEach(function(v){
+						materialValues[v] = khr_material.values[v];
+					});
 
 					if ( khr_material.doubleSided || materialValues.doubleSided ) {
 


### PR DESCRIPTION
glTF common materials only use certain fields, but most exporters still output all of them. Previously, when all those extra fields are applied to the generated material, you get this:

![image](https://cloud.githubusercontent.com/assets/1882376/22710407/08cf4d3c-ed32-11e6-9868-98b49643b1cf.png)

This PR prunes those unused fields, and avoids console spam.