### PR TITLE
fix grammar in CompressedTexture docs

### DIFF
--- a/docs/api/textures/CompressedTexture.html
+++ b/docs/api/textures/CompressedTexture.html
@@ -25,11 +25,11 @@
 
 		<h3>[name]( [page:Array mipmaps], [page:Number width], [page:Number height], [page:Constant format], [page:Constant type], [page:Constant mapping], [page:Constant wrapS], [page:Constant wrapT], [page:Constant magFilter], [page:Constant minFilter], [page:Number anisotropy] )</h3>
 		<div>
-		[page:Array mipmaps] -- The mipmaps array should contains objects with data, width and height. The mipmaps should be from of the correct format and type. <br />
+		[page:Array mipmaps] -- The mipmaps array should contain objects with data, width and height. The mipmaps should be of the correct format and type.<br />
 
-		[page:Number width] -- The width of the biggest mipmap<br />
+		[page:Number width] -- The width of the biggest mipmap.<br />
 
-		[page:Number height] -- The height of the biggest mipmap <br />
+		[page:Number height] -- The height of the biggest mipmap.<br />
 
 		[page:Constant format] -- The format used in the mipmaps.
 		See [page:Textures ST3C Compressed Texture Formats],


### PR DESCRIPTION
- "array should contains objects" to "array should contain"
- "should be from of" to "should be of". I assume that was the intent, and not "should be from"
- add missing periods and remove white space before breaks for consistency