### PR TITLE
Autofocus on filter input box

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -215,7 +215,7 @@
 				<span></span>
 			</a>
 			<div class="filterBlock" >
-				<input type="text" id="filterInput" placeholder="Type to filter"/>
+				<input type="text" id="filterInput" placeholder="Type to filter" autofocus/>
 				<a href="#" id="clearFilterButton" >x</a>
 			</div>
 			<div id="content"></div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -232,7 +232,7 @@
 				<span></span>
 			</a>
 			<div class="filterBlock" >
-				<input type="text" id="filterInput" placeholder="Type to filter"/>
+				<input type="text" id="filterInput" placeholder="Type to filter" autofocus/>
 				<a href="#" id="clearFilterButton" >x</a>
 			</div>
 			<div id="content"></div>


### PR DESCRIPTION
I've found myself clicking to the filter box every time I visit the three.js documentation. I think it will improve usability to give the filter input box focus by default.