### PR TITLE
Typo in Object3D docs

### DIFF
--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -273,7 +273,7 @@
 
 		<h3>[method:Vector3 localToWorld]( [page:Vector3 vector] )</h3>
 		<div>
-		vector - A vector representing a position in local (object) spave.<br /><br />
+		vector - A vector representing a position in local (object) space.<br /><br />
 
 		Converts the vector from local space to world space.
 		</div>


### PR DESCRIPTION
Hi

Fixed a small typo in the Object3D docs page.

