### PR TITLE
Not set crossOrigin for data: URI in ImageLoader

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -68,7 +68,7 @@ Object.assign( ImageLoader.prototype, {
 
 		}, false );
 
-		if ( this.crossOrigin !== undefined ) image.crossOrigin = this.crossOrigin;
+		if ( this.crossOrigin !== undefined && url.indexOf( 'data:' ) !== 0 ) image.crossOrigin = this.crossOrigin;
 
 		scope.manager.itemStart( url );
 


### PR DESCRIPTION
We shouldn't set crossOrigin for data: URI.

#10678
http://stackoverflow.com/questions/31643096/why-does-safari-throw-cors-error-when-setting-base64-data-on-a-crossorigin-an
