### PR TITLE
Add jsfiddle link to ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,6 +2,12 @@
 
 ##### Description of the problem 
 
+Describe the problem/request in detail.
+Code snippet, screenshot, and small-test help us understand.
+
+You can edit for small-test.
+http://jsfiddle.net/akmcv7Lh/ (current revision)
+http://jsfiddle.net/hw9rcLL8/ (dev)
 
 ##### Three.js version
 


### PR DESCRIPTION
This PR adds jsfiddle link to ISSUE_TEMPLATE.md.

It'll provide notification of small-test to users filing an issue
and lead efficient discussion.

#10723
