### PR TITLE
WebGLProgram: No longer prepends newlines to shader programs unconditionally

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -90,7 +90,15 @@ function generateExtensions( extensions, parameters, rendererExtensions ) {
 		( extensions.shaderTextureLOD || parameters.envMap ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
 	];
 
-	return chunks.filter( filterEmptyLine ).join( '\n' );
+	var joined = chunks.filter( filterEmptyLine ).join( '\n' );
+
+	if ( '' !== joined ) {
+
+		joined += '\n';
+
+	}
+
+	return joined;
 
 }
 
@@ -108,7 +116,15 @@ function generateDefines( defines ) {
 
 	}
 
-	return chunks.join( '\n' );
+	var joined = chunks.join( '\n' );
+
+	if ( '' !== joined ) {
+
+		joined += '\n';
+
+	}
+
+	return joined;
 
 }
 
@@ -294,16 +310,12 @@ function WebGLProgram( renderer, code, material, parameters ) {
 
 			customDefines,
 
-			'\n'
-
 		].filter( filterEmptyLine ).join( '\n' );
 
 		prefixFragment = [
 
 			customExtensions,
 			customDefines,
-
-			'\n'
 
 		].filter( filterEmptyLine ).join( '\n' );
 


### PR DESCRIPTION
The previous behaviour was to prepend a newline to *every* shader regardless of defines and extensions. This can cause problems with shader code.

##### Example Issue
A webgl2 shader may state the desired version. E.g., `#version 300 es`. This version string must occur on the very first line of the shader. This was simply not possible in three.js because of the prepended newline. My pull request fixes this.

##### Related Issues

I'm aware of #9546 and have inserted conditional newlines to not re-introduce this issue.

##### Discussion

At some point I think that three.js should introduce a `version` parameter along with the existing `defines` and `extensions` parameters. Currently, it is not possible to use the `defines` and/or `extensions` parameters with a `#version 300 es` shader since the defines and extensions will be prepended to the entire shader source string. I.e., the `#version` pragma will not be on the first line and the shader won't compile.

Fixing this, however, is out of scope of this pull request. I'll leave that as an exercise for the maintainers. :)