### PR TITLE
updated SEA3D examples to not access matrix elements directly

### DIFF
--- a/examples/js/loaders/sea3d/SEA3DLoader.js
+++ b/examples/js/loaders/sea3d/SEA3DLoader.js
@@ -1603,7 +1603,7 @@ THREE.SEA3D.prototype.updateTransform = function ( obj3d, sea ) {
 
 	var mtx = THREE.SEA3D.MTXBUF, vec = THREE.SEA3D.VECBUF;
 
-	if ( sea.transform ) mtx.elements.set( sea.transform );
+	if ( sea.transform ) mtx.fromArray( sea.transform );
 	else mtx.makeTranslation( sea.position.x, sea.position.y, sea.position.z );
 
 	// matrix

--- a/examples/js/loaders/sea3d/physics/SEA3DAmmoLoader.js
+++ b/examples/js/loaders/sea3d/physics/SEA3DAmmoLoader.js
@@ -159,7 +159,7 @@ THREE.SEA3D.prototype.readRigidBodyBase = function ( sea ) {
 
 	} else {
 
-		THREE.SEA3D.MTXBUF.elements.set( sea.transform );
+		THREE.SEA3D.MTXBUF.fromArray( sea.transform );
 
 		transform = SEA3D.AMMO.getTransformFromMatrix( THREE.SEA3D.MTXBUF );
 
@@ -265,7 +265,7 @@ THREE.SEA3D.prototype.readCarController = function ( sea ) {
 			if ( wheel.offset ) {
 
 				var offset = new THREE.Matrix4();
-				offset.elements.set( wheel.offset );
+				offset.fromArray( wheel.offset );
 
 				target.physics.offset = offset;
 


### PR DESCRIPTION
Moving away from using a float32 array in Matrix4 broke some client code. This is a fix for that.