### PR TITLE
Add webgl2 parameter (default:false) to WebGLRenderer parameters.

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -53,6 +53,9 @@
 		[page:Boolean preserveDrawingBuffer] - whether to preserve the buffers until manually cleared
 	  or overwritten. Default is *false*.<br />
 
+		[page:Boolean webgl2] - whether to request a [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext WebGL2RenderingContext].
+		Default is *false*.<br />
+
 		[page:Boolean depth] - whether the drawing buffer has a
 		[link:https://en.wikipedia.org/wiki/Z-buffering depth buffer] of at least 16 bits.
 		Default is *true*.<br />

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -50,6 +50,7 @@ function WebGLRenderer( parameters ) {
 
 		_alpha = parameters.alpha !== undefined ? parameters.alpha : false,
 		_depth = parameters.depth !== undefined ? parameters.depth : true,
+		_webgl2 = parameters.webgl2 !== undefined ? parameters.webgl2 : false,
 		_stencil = parameters.stencil !== undefined ? parameters.stencil : true,
 		_antialias = parameters.antialias !== undefined ? parameters.antialias : false,
 		_premultipliedAlpha = parameters.premultipliedAlpha !== undefined ? parameters.premultipliedAlpha : true,
@@ -229,11 +230,11 @@ function WebGLRenderer( parameters ) {
 			preserveDrawingBuffer: _preserveDrawingBuffer
 		};
 
-		_gl = _context || _canvas.getContext( 'webgl', attributes ) || _canvas.getContext( 'experimental-webgl', attributes );
+		_gl = _context || _canvas.getContext( _webgl2 ? 'webgl2' : 'webgl', attributes ) || _canvas.getContext( 'experimental-webgl', attributes );
 
 		if ( _gl === null ) {
 
-			if ( _canvas.getContext( 'webgl' ) !== null ) {
+			if ( _canvas.getContext( _webgl2 ? 'webgl2' : 'webgl' ) !== null ) {
 
 				throw 'Error creating WebGL context with your selected attributes.';
 


### PR DESCRIPTION
I humbly submit this pull request that adds a `webgl2` boolean parameter to the `WebGLRenderer` constructor. When set to `true` (default is `false`) it will attempt to instance a WebGL2RenderingContext. 

I've read through issue #9965 and understand the want to keep WebGL 2.0 features in `WebGL2Renderer`.

In my use case, I only need the standard WebGL 1.0 context and corresponding three.js interface -- except for a few WebGL 2.0 calls outside three.js.

This PR would allow using the well-tested three.js interface while allowing for experimentation w/ WebGL 2.0.
