### PR TITLE
FBXLoader2: Multi-Material Skinning / VertexColor Fix

### DIFF
--- a/examples/js/loaders/FBXLoader2.js
+++ b/examples/js/loaders/FBXLoader2.js
@@ -1226,12 +1226,9 @@
 
 									for ( var materialsIndex = 0, materialsLength = materials.length; materialsIndex < materialsLength; ++ materialsIndex ) {
 
-										var material = materials[ materialsIndex ];
-
-										material.skinning = true;
+										materials[ materialsIndex ].skinning = true;
 
 									}
-									material.skinning = true;
 									model = new THREE.SkinnedMesh( geometry, material );
 
 								} else {

--- a/examples/js/loaders/FBXLoader2.js
+++ b/examples/js/loaders/FBXLoader2.js
@@ -1210,11 +1210,16 @@
 								} else {
 
 									material = new THREE.MeshBasicMaterial( { color: 0x3300ff } );
+									materials.push( material );
 
 								}
 								if ( 'color' in geometry.attributes ) {
 
-									material.vertexColors = THREE.VertexColors;
+									for ( var materialIndex = 0, numMaterials = materials.length; materialIndex < numMaterials; ++materialIndex ) {
+
+										materials[ materialIndex ].vertexColors = THREE.VertexColors;
+
+									}
 
 								}
 								if ( geometry.FBX_Deformer ) {


### PR DESCRIPTION
Fixed bug where if no material was present, the resulting default material would not have appropriate vertexColors or skinning attributes applied ( As per comment on code of #10781 ).

EDIT: Fixed bug where if a multi-material was present on a skinned mesh, only the last material would be applied to the mesh.