### PR TITLE
Keep Matrix3 elements in double precision for added precision

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -4345,9 +4345,10 @@
 	var arrayCacheF32 = [];
 	var arrayCacheI32 = [];
 
-	// Float32Array cache used for uploading Matrix4 uniform
+	// Float32Array caches used for uploading Matrix uniforms
 
 	var mat4array = new Float32Array( 16 );
+	var mat3array = new Float32Array( 9 );
 
 	// Flattening for arrays of vectors and matrices
 
@@ -4453,7 +4454,16 @@
 
 	function setValue3fm( gl, v ) {
 
-		gl.uniformMatrix3fv( this.addr, false, v.elements || v );
+		if ( v.elements === undefined ) {
+
+			gl.uniformMatrix3fv( this.addr, false, v );
+
+		} else {
+
+			mat3array.set( v.elements );
+			gl.uniformMatrix3fv( this.addr, false, mat3array );
+
+		}
 
 	}
 
@@ -8334,13 +8344,13 @@
 
 	function Matrix3() {
 
-		this.elements = new Float32Array( [
+		this.elements = [
 
 			1, 0, 0,
 			0, 1, 0,
 			0, 0, 1
 
-		] );
+		];
 
 		if ( arguments.length > 0 ) {
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -4339,9 +4339,10 @@ function UniformContainer() {
 var arrayCacheF32 = [];
 var arrayCacheI32 = [];
 
-// Float32Array cache used for uploading Matrix4 uniform
+// Float32Array caches used for uploading Matrix uniforms
 
 var mat4array = new Float32Array( 16 );
+var mat3array = new Float32Array( 9 );
 
 // Flattening for arrays of vectors and matrices
 
@@ -4447,7 +4448,16 @@ function setValue2fm( gl, v ) {
 
 function setValue3fm( gl, v ) {
 
-	gl.uniformMatrix3fv( this.addr, false, v.elements || v );
+	if ( v.elements === undefined ) {
+
+		gl.uniformMatrix3fv( this.addr, false, v );
+
+	} else {
+
+		mat3array.set( v.elements );
+		gl.uniformMatrix3fv( this.addr, false, mat3array );
+
+	}
 
 }
 
@@ -8328,13 +8338,13 @@ Object.assign( Sphere.prototype, {
 
 function Matrix3() {
 
-	this.elements = new Float32Array( [
+	this.elements = [
 
 		1, 0, 0,
 		0, 1, 0,
 		0, 0, 1
 
-	] );
+	];
 
 	if ( arguments.length > 0 ) {
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -9,13 +9,13 @@ import { Vector3 } from './Vector3';
 
 function Matrix3() {
 
-	this.elements = new Float32Array( [
+	this.elements = [
 
 		1, 0, 0,
 		0, 1, 0,
 		0, 0, 1
 
-	] );
+	];
 
 	if ( arguments.length > 0 ) {
 

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -69,9 +69,10 @@ function UniformContainer() {
 var arrayCacheF32 = [];
 var arrayCacheI32 = [];
 
-// Float32Array cache used for uploading Matrix4 uniform
+// Float32Array caches used for uploading Matrix uniforms
 
 var mat4array = new Float32Array( 16 );
+var mat3array = new Float32Array( 9 );
 
 // Flattening for arrays of vectors and matrices
 
@@ -177,7 +178,16 @@ function setValue2fm( gl, v ) {
 
 function setValue3fm( gl, v ) {
 
-	gl.uniformMatrix3fv( this.addr, false, v.elements || v );
+	if ( v.elements === undefined ) {
+
+		gl.uniformMatrix3fv( this.addr, false, v );
+
+	} else {
+
+		mat3array.set( v.elements );
+		gl.uniformMatrix3fv( this.addr, false, mat3array );
+
+	}
 
 }
 


### PR DESCRIPTION
This is mostly for completeness (see pull request #10702).
Double precision for Matrix3 is not required for rendering large scenes since a matrix3 doesn't represent translation. But Matrix4 is now double precision, so Matrix3 might as well be. No performance degradation is expected from this change.