### PR TITLE
[WIP] [SkinnedMesh] Clone skeleton when copying or cloning SkinnedMesh.

### DIFF
--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -81,7 +81,33 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 		Mesh.prototype.copy.call( this, source );
 
-		this.bind( source.skeleton.clone(), this.matrixWorld );
+		var hasOwnBones = false;
+
+		source.traverse( function ( node ) {
+
+			if ( node.type === 'Bone' ) {
+
+				hasOwnBones = true;
+
+			}
+
+		} );
+
+		if ( hasOwnBones ) {
+
+			// If bones are children of the source mesh, copying the mesh should
+			// require (1) cloning these bones, and (2) constructing a new Skeleton
+			// from the resulting tree.
+			console.warn( 'SkinnedMesh: .copy() is not yet fully implemented.' );
+
+		} else {
+
+			// If bones are _not_ children of the source mesh, assume that they are
+			// part of a separate armature. The new SkinnedMesh should be bound to the
+			// same Skeleton, not a cloned copy, to match the source mesh.
+			this.bind( source.skeleton );
+
+		}
 
 		return this;
 

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -77,6 +77,16 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 	isSkinnedMesh: true,
 
+	copy: function ( source ) {
+
+		Mesh.prototype.copy.call( this, source );
+
+		this.bind( source.skeleton.clone(), this.matrixWorld );
+
+		return this;
+
+	},
+
 	bind: function ( skeleton, bindMatrix ) {
 
 		this.skeleton = skeleton;


### PR DESCRIPTION
A cloned SkinnedMesh seems to receive an empty skeleton (no `.bones` or `.boneInverses`).

I think this is part of the problem in #8869 and #5878, but (at least in the glTF case) there are some remaining issues. I can clone the glTF-MaterialsCommon/CesiumMan.glTF model, but it is weirdly rotated.

glTF models that don't use MaterialsCommon extension can't be cloned for a separate reasons, related to GLTFShaders.