### PR TITLE
Made THREE.CombinedCamera compatible with THREE.OrbitControls (and THREE.RayCaster)

### DIFF
--- a/examples/canvas_combined_camera_orbit_controls.html
+++ b/examples/canvas_combined_camera_orbit_controls.html
@@ -179,7 +179,6 @@
 				raycaster.setFromCamera( mouse, camera );
 				var intersects = raycaster.intersectObjects( cubes.children );
 				if ( intersects.length > 0 && INTERSECTED.object != intersects[ 0 ].object) {
-					console.log( scene );
 					if( INTERSECTED.object ){
 						INTERSECTED.object.material = meshMaterial;
 					}

--- a/examples/canvas_combined_camera_orbit_controls.html
+++ b/examples/canvas_combined_camera_orbit_controls.html
@@ -89,11 +89,12 @@
 			function init() {
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );
-				camera = new THREE.CombinedCamera( window.innerWidth / 2, window.innerHeight / 2, 70, 1, 1000, - 500, 1000 );
+				camera = new THREE.CombinedCamera( window.innerWidth / 2, window.innerHeight / 2, 70, 1, 10000, - 500, 10000 );
 				camera.position.x = 200;
 				camera.position.y = 100;
 				camera.position.z = 200;
 				scene = new THREE.Scene();
+
 				// Grid
 				var size = 500, step = 50;
 				var geometry = new THREE.Geometry();
@@ -105,14 +106,7 @@
 				}
 				var material = new THREE.LineBasicMaterial( { color: 0x000000, opacity: 0.2 } );
 				var line = new THREE.LineSegments( geometry, material );
-				// Controls
-				controls = new THREE.OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // remove when using animation loop
-				// enable animation loop when using damping or autorotation
-				//controls.enableDamping = true;
-				//controls.dampingFactor = 0.25;
-				controls.enableZoom = false;
-				scene.add( line );
+
 				// Cubes
 				var geometry = new THREE.BoxGeometry( 50, 50, 50 );
 				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, overdraw: 0.5 } );
@@ -124,6 +118,7 @@
 					cube.position.z = Math.floor( ( Math.random() * 1000 - 500 ) / 50 ) * 50 + 25;
 					scene.add(cube);
 				}
+
 				// Lights
 				var ambientLight = new THREE.AmbientLight( Math.random() * 0x10 );
 				scene.add( ambientLight );
@@ -144,6 +139,16 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
+
+				// Controls
+				controls = new THREE.OrbitControls( camera, renderer.domElement );
+				controls.addEventListener( 'change', render ); // remove when using animation loop
+				// enable animation loop when using damping or autorotation
+				//controls.enableDamping = true;
+				//controls.dampingFactor = 0.25;
+				controls.enableZoom = true;
+				scene.add( line );
+
 				stats = new Stats();
 				container.appendChild( stats.dom );
 				window.addEventListener( 'resize', onWindowResize, false );

--- a/examples/canvas_combined_camera_orbit_controls.html
+++ b/examples/canvas_combined_camera_orbit_controls.html
@@ -66,6 +66,10 @@
 		<script>
 			var container, stats;
 			var camera, scene, renderer;
+			var meshMaterial = new THREE.MeshLambertMaterial( { color: 0xffffff, overdraw: 0.5 } );
+			var INTERSECTED = {
+				material: new THREE.MeshBasicMaterial({ color: 0xffff00 }),
+			};
 			var lookAtScene = true;
 			init();
 			animate();
@@ -94,6 +98,8 @@
 				camera.position.y = 100;
 				camera.position.z = 200;
 				scene = new THREE.Scene();
+				cubes = new THREE.Group();
+				scene.add(cubes);
 
 				// Grid
 				var size = 500, step = 50;
@@ -109,14 +115,14 @@
 
 				// Cubes
 				var geometry = new THREE.BoxGeometry( 50, 50, 50 );
-				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, overdraw: 0.5 } );
+
 				for ( var i = 0; i < 100; i ++ ) {
-					var cube = new THREE.Mesh( geometry, material );
+					var cube = new THREE.Mesh( geometry, meshMaterial );
 					cube.scale.y = Math.floor( Math.random() * 2 + 1 );
 					cube.position.x = Math.floor( ( Math.random() * 1000 - 500 ) / 50 ) * 50 + 25;
 					cube.position.y = ( cube.scale.y * 50 ) / 2;
 					cube.position.z = Math.floor( ( Math.random() * 1000 - 500 ) / 50 ) * 50 + 25;
-					scene.add(cube);
+					cubes.add(cube);
 				}
 
 				// Lights
@@ -149,6 +155,11 @@
 				controls.enableZoom = true;
 				scene.add( line );
 
+				// Raycaster
+				raycaster = new THREE.Raycaster();
+				mouse = new THREE.Vector2();
+				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
+
 				stats = new Stats();
 				container.appendChild( stats.dom );
 				window.addEventListener( 'resize', onWindowResize, false );
@@ -158,13 +169,33 @@
 					renderer.setSize( window.innerWidth, window.innerHeight );
 				}
 			}
-			//
+
+			function onDocumentMouseMove( event ) {
+				event.preventDefault();
+				mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
+				mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+
+				// find intersections
+				raycaster.setFromCamera( mouse, camera );
+				var intersects = raycaster.intersectObjects( cubes.children );
+				if ( intersects.length > 0 && INTERSECTED.object != intersects[ 0 ].object) {
+					console.log( scene );
+					if( INTERSECTED.object ){
+						INTERSECTED.object.material = meshMaterial;
+					}
+						INTERSECTED.object = intersects[ 0 ].object;
+					INTERSECTED.object.material = INTERSECTED.material;
+				}
+
+			}
+
 			function animate() {
 				requestAnimationFrame( animate );
 				stats.begin();
 				render();
 				stats.end();
 			}
+
 			function render() {
 				//var timer = Date.now() * 0.0001;
 				//camera.position.x = Math.cos( timer ) * 200;

--- a/examples/canvas_combinedcamera_orbitcontrols
+++ b/examples/canvas_combinedcamera_orbitcontrols
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js canvas - combo camera - orthographic + perspective</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #f0f0f0;
+				margin: 0px;
+				overflow: hidden;
+				color: purple;
+			}
+			a {
+				color: red;
+			}
+		</style>
+	</head>
+	<body>
+
+		<script src="../build/three.js"></script>
+
+		<script src="js/cameras/CombinedCamera.js"></script>
+
+		<script src="js/renderers/Projector.js"></script>
+		<script src="js/renderers/CanvasRenderer.js"></script>
+
+		<script src="js/libs/stats.min.js"></script>
+
+		<div style="position: absolute; top: 10px; width: 100%; text-align: center; ">
+			<a href="http://threejs.org" target="_blank">three.js</a> - Combo Camera<br>
+			View: <a href="#" onclick="setOrthographic();return false;"> Orthographic</a> |
+				<a href="#" onclick="setPerspective();return false;">Perspective</a><br>
+			Lens: <a href="#" onclick="setLens(12);return false;">12mm</a> |
+				<a href="#" onclick="setLens(16);return false;">16mm</a> |
+				<a href="#" onclick="setLens(24);return false;">24mm</a> |
+				<a href="#" onclick="setLens(35);return false;">35mm</a> |
+				<a href="#" onclick="setLens(50);return false;">50mm</a> |
+				<a href="#" onclick="setLens(60);return false;">60mm</a> |
+				<a href="#" onclick="setLens(85);return false;">85mm</a> |
+				<a href="#" onclick="setLens(105);return false;">105mm</a><br>
+			Fov: <a href="#" onclick="setFov(30);return false;">30°</a> |
+				<a href="#" onclick="setFov(50);return false;">50°</a> |
+				<a href="#" onclick="setFov(70);return false;">70°</a> |
+				<a href="#" onclick="setFov(100);return false;">100°</a><br>
+			Zoom: <a href="#" onclick="camera.setZoom(0.5);return false;">0.5x</a> |
+					<a href="#" onclick="camera.setZoom(1);return false;">1x</a> |
+					<a href="#" onclick="camera.setZoom(2);return false;">2x</a> |
+
+				<br/>
+			Views: <a href="#" onclick="camera.toTopView();lookAtScene=false;return false;">Top view</a> |
+				<a href="#" onclick="camera.toBottomView();lookAtScene=false;return false;">Bottom view</a> |
+				<a href="#" onclick="camera.toLeftView();lookAtScene=false;return false;">Left view</a> |
+				<a href="#" onclick="camera.toRightView();lookAtScene=false;return false;">Right view</a> |
+				<a href="#" onclick="camera.toFrontView();lookAtScene=false;return false;">Front view</a> |
+				<a href="#" onclick="camera.toBackView();lookAtScene=false;return false;">Back view</a> |
+				<a href="#" onclick="lookAtScene=true;return false;">Look at Scene</a>
+				<br/>
+			<div id="fov"></div>
+		</div>
+
+
+
+		<script>
+			var container, stats;
+			var camera, scene, renderer;
+			var lookAtScene = true;
+			init();
+			animate();
+			function setFov( fov ) {
+				camera.setFov( fov );
+				document.getElementById('fov').innerHTML = 'FOV '+ fov.toFixed(2) +'&deg;' ;
+			}
+			function setLens( lens ) {
+				// try adding a tween effect while changing focal length, and it'd be even cooler!
+				var fov = camera.setLens( lens );
+				document.getElementById('fov').innerHTML = 'Converted ' + lens + 'mm lens to FOV '+ fov.toFixed(2) +'&deg;' ;
+			}
+			function setOrthographic() {
+				camera.toOrthographic();
+				document.getElementById('fov').innerHTML = 'Orthographic mode' ;
+			}
+			function setPerspective() {
+				camera.toPerspective();
+				document.getElementById('fov').innerHTML = 'Perspective mode' ;
+			}
+			function init() {
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+				camera = new THREE.CombinedCamera( window.innerWidth / 2, window.innerHeight / 2, 70, 1, 1000, - 500, 1000 );
+				camera.position.x = 200;
+				camera.position.y = 100;
+				camera.position.z = 200;
+				scene = new THREE.Scene();
+				// Grid
+				var size = 500, step = 50;
+				var geometry = new THREE.Geometry();
+				for ( var i = - size; i <= size; i += step ) {
+					geometry.vertices.push( new THREE.Vector3( - size, 0, i ) );
+					geometry.vertices.push( new THREE.Vector3(   size, 0, i ) );
+					geometry.vertices.push( new THREE.Vector3( i, 0, - size ) );
+					geometry.vertices.push( new THREE.Vector3( i, 0,   size ) );
+				}
+				var material = new THREE.LineBasicMaterial( { color: 0x000000, opacity: 0.2 } );
+				var line = new THREE.LineSegments( geometry, material );
+				scene.add( line );
+				// Cubes
+				var geometry = new THREE.BoxGeometry( 50, 50, 50 );
+				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, overdraw: 0.5 } );
+				for ( var i = 0; i < 100; i ++ ) {
+					var cube = new THREE.Mesh( geometry, material );
+					cube.scale.y = Math.floor( Math.random() * 2 + 1 );
+					cube.position.x = Math.floor( ( Math.random() * 1000 - 500 ) / 50 ) * 50 + 25;
+					cube.position.y = ( cube.scale.y * 50 ) / 2;
+					cube.position.z = Math.floor( ( Math.random() * 1000 - 500 ) / 50 ) * 50 + 25;
+					scene.add(cube);
+				}
+				// Lights
+				var ambientLight = new THREE.AmbientLight( Math.random() * 0x10 );
+				scene.add( ambientLight );
+				var directionalLight = new THREE.DirectionalLight( Math.random() * 0xffffff );
+				directionalLight.position.x = Math.random() - 0.5;
+				directionalLight.position.y = Math.random() - 0.5;
+				directionalLight.position.z = Math.random() - 0.5;
+				directionalLight.position.normalize();
+				scene.add( directionalLight );
+				var directionalLight = new THREE.DirectionalLight( Math.random() * 0xffffff );
+				directionalLight.position.x = Math.random() - 0.5;
+				directionalLight.position.y = Math.random() - 0.5;
+				directionalLight.position.z = Math.random() - 0.5;
+				directionalLight.position.normalize();
+				scene.add( directionalLight );
+				renderer = new THREE.CanvasRenderer();
+				renderer.setClearColor( 0xf0f0f0 );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
+				stats = new Stats();
+				container.appendChild( stats.dom );
+				window.addEventListener( 'resize', onWindowResize, false );
+				function onWindowResize(){
+					camera.setSize( window.innerWidth, window.innerHeight );
+					camera.updateProjectionMatrix();
+					renderer.setSize( window.innerWidth, window.innerHeight );
+				}
+			}
+			//
+			function animate() {
+				requestAnimationFrame( animate );
+				stats.begin();
+				render();
+				stats.end();
+			}
+			function render() {
+				var timer = Date.now() * 0.0001;
+				camera.position.x = Math.cos( timer ) * 200;
+				camera.position.z = Math.sin( timer ) * 200;
+				if ( lookAtScene ) camera.lookAt( scene.position );
+				renderer.render( scene, camera );
+			}
+		</script>
+
+	</body>
+</html>

--- a/examples/canvas_combinedcamera_orbitcontrols
+++ b/examples/canvas_combinedcamera_orbitcontrols
@@ -22,6 +22,7 @@
 		<script src="../build/three.js"></script>
 
 		<script src="js/cameras/CombinedCamera.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/renderers/Projector.js"></script>
 		<script src="js/renderers/CanvasRenderer.js"></script>
@@ -104,6 +105,13 @@
 				}
 				var material = new THREE.LineBasicMaterial( { color: 0x000000, opacity: 0.2 } );
 				var line = new THREE.LineSegments( geometry, material );
+				// Controls
+				controls = new THREE.OrbitControls( camera, renderer.domElement );
+				controls.addEventListener( 'change', render ); // remove when using animation loop
+				// enable animation loop when using damping or autorotation
+				//controls.enableDamping = true;
+				//controls.dampingFactor = 0.25;
+				controls.enableZoom = false;
 				scene.add( line );
 				// Cubes
 				var geometry = new THREE.BoxGeometry( 50, 50, 50 );
@@ -153,10 +161,10 @@
 				stats.end();
 			}
 			function render() {
-				var timer = Date.now() * 0.0001;
-				camera.position.x = Math.cos( timer ) * 200;
-				camera.position.z = Math.sin( timer ) * 200;
-				if ( lookAtScene ) camera.lookAt( scene.position );
+				//var timer = Date.now() * 0.0001;
+				//camera.position.x = Math.cos( timer ) * 200;
+				//camera.position.z = Math.sin( timer ) * 200;
+				//if ( lookAtScene ) camera.lookAt( scene.position );
 				renderer.render( scene, camera );
 			}
 		</script>

--- a/examples/js/cameras/CombinedCamera.js
+++ b/examples/js/cameras/CombinedCamera.js
@@ -23,7 +23,7 @@ THREE.CombinedCamera = function ( width, height, fov, near, far, orthoNear, orth
 	this.top = height / 2;
 	this.bottom = - height / 2;
 
-	this.aspect =  width / height;
+	this.aspect = width / height;
 	this.zoom = 1;
 	this.view = null;
 	// We could also handle the projectionMatrix internally, but just wanted to test nested camera objects
@@ -46,7 +46,7 @@ THREE.CombinedCamera.prototype.toPerspective = function () {
 	this.far = this.cameraP.far;
 
 	this.cameraP.aspect = this.aspect;
-	this.cameraP.fov =  this.fov / this.zoom ;
+	this.cameraP.fov = this.fov / this.zoom;
 	this.cameraP.view = this.view;
 
 	this.cameraP.updateProjectionMatrix();
@@ -121,7 +121,7 @@ THREE.CombinedCamera.prototype.copy = function ( source ) {
 
 };
 
-THREE.CombinedCamera.prototype.setViewOffset = function( fullWidth, fullHeight, x, y, width, height ) {
+THREE.CombinedCamera.prototype.setViewOffset = function ( fullWidth, fullHeight, x, y, width, height ) {
 
 	this.view = {
 		fullWidth: fullWidth,
@@ -146,14 +146,14 @@ THREE.CombinedCamera.prototype.setViewOffset = function( fullWidth, fullHeight, 
 
 };
 
-THREE.CombinedCamera.prototype.clearViewOffset = function() {
+THREE.CombinedCamera.prototype.clearViewOffset = function () {
 
 	this.view = null;
 	this.updateProjectionMatrix();
 
 };
 
-THREE.CombinedCamera.prototype.setSize = function( width, height ) {
+THREE.CombinedCamera.prototype.setSize = function ( width, height ) {
 
 	this.cameraP.aspect = width / height;
 	this.left = - width / 2;
@@ -164,7 +164,7 @@ THREE.CombinedCamera.prototype.setSize = function( width, height ) {
 };
 
 
-THREE.CombinedCamera.prototype.setFov = function( fov ) {
+THREE.CombinedCamera.prototype.setFov = function ( fov ) {
 
 	this.fov = fov;
 
@@ -182,7 +182,7 @@ THREE.CombinedCamera.prototype.setFov = function( fov ) {
 
 // For maintaining similar API with PerspectiveCamera
 
-THREE.CombinedCamera.prototype.updateProjectionMatrix = function() {
+THREE.CombinedCamera.prototype.updateProjectionMatrix = function () {
 
 	if ( this.isPerspectiveCamera ) {
 
@@ -198,16 +198,16 @@ THREE.CombinedCamera.prototype.updateProjectionMatrix = function() {
 };
 
 /*
-* Uses Focal Length (in mm) to estimate and set FOV
-* 35mm (full frame) camera is used if frame size is not specified;
-* Formula based on http://www.bobatkins.com/photography/technical/field_of_view.html
-*/
+ * Uses Focal Length (in mm) to estimate and set FOV
+ * 35mm (full frame) camera is used if frame size is not specified;
+ * Formula based on http://www.bobatkins.com/photography/technical/field_of_view.html
+ */
 THREE.CombinedCamera.prototype.setLens = function ( focalLength, filmGauge ) {
 
 	if ( filmGauge === undefined ) filmGauge = 35;
 
 	var vExtentSlope = 0.5 * filmGauge /
-			( focalLength * Math.max( this.cameraP.aspect, 1 ) );
+		( focalLength * Math.max( this.cameraP.aspect, 1 ) );
 
 	var fov = THREE.Math.RAD2DEG * 2 * Math.atan( vExtentSlope );
 
@@ -218,7 +218,7 @@ THREE.CombinedCamera.prototype.setLens = function ( focalLength, filmGauge ) {
 };
 
 
-THREE.CombinedCamera.prototype.setZoom = function( zoom ) {
+THREE.CombinedCamera.prototype.setZoom = function ( zoom ) {
 
 	this.zoom = zoom;
 
@@ -234,7 +234,7 @@ THREE.CombinedCamera.prototype.setZoom = function( zoom ) {
 
 };
 
-THREE.CombinedCamera.prototype.toFrontView = function() {
+THREE.CombinedCamera.prototype.toFrontView = function () {
 
 	this.rotation.x = 0;
 	this.rotation.y = 0;
@@ -244,7 +244,7 @@ THREE.CombinedCamera.prototype.toFrontView = function() {
 
 };
 
-THREE.CombinedCamera.prototype.toBackView = function() {
+THREE.CombinedCamera.prototype.toBackView = function () {
 
 	this.rotation.x = 0;
 	this.rotation.y = Math.PI;
@@ -252,7 +252,7 @@ THREE.CombinedCamera.prototype.toBackView = function() {
 
 };
 
-THREE.CombinedCamera.prototype.toLeftView = function() {
+THREE.CombinedCamera.prototype.toLeftView = function () {
 
 	this.rotation.x = 0;
 	this.rotation.y = - Math.PI / 2;
@@ -260,7 +260,7 @@ THREE.CombinedCamera.prototype.toLeftView = function() {
 
 };
 
-THREE.CombinedCamera.prototype.toRightView = function() {
+THREE.CombinedCamera.prototype.toRightView = function () {
 
 	this.rotation.x = 0;
 	this.rotation.y = Math.PI / 2;
@@ -268,7 +268,7 @@ THREE.CombinedCamera.prototype.toRightView = function() {
 
 };
 
-THREE.CombinedCamera.prototype.toTopView = function() {
+THREE.CombinedCamera.prototype.toTopView = function () {
 
 	this.rotation.x = - Math.PI / 2;
 	this.rotation.y = 0;
@@ -276,7 +276,7 @@ THREE.CombinedCamera.prototype.toTopView = function() {
 
 };
 
-THREE.CombinedCamera.prototype.toBottomView = function() {
+THREE.CombinedCamera.prototype.toBottomView = function () {
 
 	this.rotation.x = Math.PI / 2;
 	this.rotation.y = 0;

--- a/examples/js/cameras/CombinedCamera.js
+++ b/examples/js/cameras/CombinedCamera.js
@@ -53,8 +53,8 @@ THREE.CombinedCamera.prototype.toPerspective = function () {
 
 	this.projectionMatrix = this.cameraP.projectionMatrix;
 
-	this.inPerspectiveMode = true;
-	this.inOrthographicMode = false;
+	this.isPerspectiveCamera = true;
+	this.isOrthographicCamera = false;
 
 };
 
@@ -89,8 +89,8 @@ THREE.CombinedCamera.prototype.toOrthographic = function () {
 	this.far = this.cameraO.far;
 	this.projectionMatrix = this.cameraO.projectionMatrix;
 
-	this.inPerspectiveMode = false;
-	this.inOrthographicMode = true;
+	this.isPerspectiveCamera = false;
+	this.isOrthographicCamera = true;
 
 };
 
@@ -114,8 +114,8 @@ THREE.CombinedCamera.prototype.copy = function ( source ) {
 	this.cameraO.copy( source.cameraO );
 	this.cameraP.copy( source.cameraP );
 
-	this.inOrthographicMode = source.inOrthographicMode;
-	this.inPerspectiveMode = source.inPerspectiveMode;
+	this.isOrthographicCamera = source.isOrthographicCamera;
+	this.isPerspectiveCamera = source.isPerspectiveCamera;
 
 	return this;
 
@@ -168,7 +168,7 @@ THREE.CombinedCamera.prototype.setFov = function( fov ) {
 
 	this.fov = fov;
 
-	if ( this.inPerspectiveMode ) {
+	if ( this.isPerspectiveCamera ) {
 
 		this.toPerspective();
 
@@ -184,7 +184,7 @@ THREE.CombinedCamera.prototype.setFov = function( fov ) {
 
 THREE.CombinedCamera.prototype.updateProjectionMatrix = function() {
 
-	if ( this.inPerspectiveMode ) {
+	if ( this.isPerspectiveCamera ) {
 
 		this.toPerspective();
 
@@ -222,7 +222,7 @@ THREE.CombinedCamera.prototype.setZoom = function( zoom ) {
 
 	this.zoom = zoom;
 
-	if ( this.inPerspectiveMode ) {
+	if ( this.isPerspectiveCamera ) {
 
 		this.toPerspective();
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -326,7 +326,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
-			if ( scope.object instanceof THREE.PerspectiveCamera ) {
+			if ( scope.object.isPerspectiveCamera ) {
 
 				// perspective
 				var position = scope.object.position;
@@ -340,7 +340,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 				panLeft( 2 * deltaX * targetDistance / element.clientHeight, scope.object.matrix );
 				panUp( 2 * deltaY * targetDistance / element.clientHeight, scope.object.matrix );
 
-			} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+			} else if ( scope.object.isOrthographicCamera ) {
 
 				// orthographic
 				panLeft( deltaX * ( scope.object.right - scope.object.left ) / scope.object.zoom / element.clientWidth, scope.object.matrix );
@@ -360,11 +360,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function dollyIn( dollyScale ) {
 
-		if ( scope.object instanceof THREE.PerspectiveCamera ) {
+		if ( scope.object.isPerspectiveCamera ) {
 
 			scale /= dollyScale;
 
-		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+		} else if ( scope.object.isOrthographicCamera ) {
 
 			scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom * dollyScale ) );
 			scope.object.updateProjectionMatrix();
@@ -381,11 +381,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function dollyOut( dollyScale ) {
 
-		if ( scope.object instanceof THREE.PerspectiveCamera ) {
+		if ( scope.object.isPerspectiveCamera ) {
 
 			scale *= dollyScale;
 
-		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+		} else if ( scope.object.isOrthographicCamera ) {
 
 			scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / dollyScale ) );
 			scope.object.updateProjectionMatrix();


### PR DESCRIPTION
The `THREE.CombinedCamera` class can currently not be used with the `THREE.OrbitControls` class because there are `instanceof` checks inside the `dollyIn` and `pan` methods of `THREE.OrbitControls`.

I refactored `THREE.OrbitControls` to use the `isPerspectiveCamera` and `isOrthographicCamera` values instead so the class will be compatible with `THREE.CombinedCamera`. In the `THREE.CombinedCamera` [there are currently similar fields on line](https://github.com/mrdoob/three.js/blob/master/examples/js/cameras/CombinedCamera.js#L50-L51):

`````
this.inPerspectiveMode = true;
this.inOrthographicMode = false;
`````
Those fields are now renamed to `isOrthographicCamera` and `isPerspectiveCamera` and because of these small changes the combined camera is now compatible with the `THREE.OrbitControls`.

A test/demonstration/example has been added added here:

[/examples/canvas_combined_camera_orbit_controls.html](https://rawgit.com/wilt/three.js/patch-3/examples/canvas_combined_camera_orbit_controls.html)

**Note1:**
I removed the original `inPerspectiveMode` in favor of  `isPerspectiveCamera` and I removed `inOrthographicMode` in favor of `isOrthographicCamera`. This could create problems for those who used this fields in their custom code. I thought removing them would be cleaner, but I could add a warning or add those fields again for backwards compatibility.

**Note2:**
Currently I am not 100% sure if using these fields inside `CombinedCamera` might lead to problems elsewhere in the library. Maybe @MrDoob or @WestLangley or someone else could shine some light on possible issues that might occur somewhere else...

