### PR TITLE
Fix Sprite raycast intersection distance

### DIFF
--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -25,25 +25,25 @@ Sprite.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	raycast: ( function () {
 
+		var intersectPoint = new Vector3();
 		var matrixPosition = new Vector3();
 
 		return function raycast( raycaster, intersects ) {
 
 			matrixPosition.setFromMatrixPosition( this.matrixWorld );
-
-			var distanceSq = raycaster.ray.distanceSqToPoint( matrixPosition );
+			raycaster.ray.closestPointToPoint( matrixPosition, intersectPoint );
 			var guessSizeSq = this.scale.x * this.scale.y / 4;
 
-			if ( distanceSq > guessSizeSq ) {
+			if ( matrixPosition.distanceToSquared( intersectPoint ) > guessSizeSq ) return;
 
-				return;
+			var distance = raycaster.ray.origin.distanceTo( intersectPoint );
 
-			}
+			if ( distance < raycaster.near || distance > raycaster.far ) return;
 
 			intersects.push( {
 
-				distance: Math.sqrt( distanceSq ),
-				point: this.position,
+				distance: distance,
+				point: intersectPoint.clone(),
 				face: null,
 				object: this
 

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -26,15 +26,18 @@ Sprite.prototype = Object.assign( Object.create( Object3D.prototype ), {
 	raycast: ( function () {
 
 		var intersectPoint = new Vector3();
-		var matrixPosition = new Vector3();
+		var worldPosition = new Vector3();
+		var worldScale = new Vector3();
 
 		return function raycast( raycaster, intersects ) {
 
-			matrixPosition.setFromMatrixPosition( this.matrixWorld );
-			raycaster.ray.closestPointToPoint( matrixPosition, intersectPoint );
-			var guessSizeSq = this.scale.x * this.scale.y / 4;
+			worldPosition.setFromMatrixPosition( this.matrixWorld );
+			raycaster.ray.closestPointToPoint( worldPosition, intersectPoint );
 
-			if ( matrixPosition.distanceToSquared( intersectPoint ) > guessSizeSq ) return;
+			worldScale.setFromMatrixScale( this.matrixWorld );
+			var guessSizeSq = worldScale.x * worldScale.y / 4;
+
+			if ( worldPosition.distanceToSquared( intersectPoint ) > guessSizeSq ) return;
 
 			var distance = raycaster.ray.origin.distanceTo( intersectPoint );
 


### PR DESCRIPTION
The existing code used the distance between the sprite and the closest point on the ray. However, this is inconsistent with both the documentation and other objects, which return the distance between the intersection and the ray origin.

The new code is similar to the Point raycast implementation. The closest point on the ray is saved to `intersectionPoint`. An intersection object is created if the following conditions are met:
1. The (squared) distance between `intersectionPoint` and the sprite position is less than the (squared) sprite size.
2. The distance between `intersectionPoint` and the ray origin is within the `near` and `far` bounds.