### PR TITLE
Return UV vector from Texture.transformUv method

### DIFF
--- a/docs/api/textures/Texture.html
+++ b/docs/api/textures/Texture.html
@@ -213,7 +213,7 @@
 		<h3>[method:null transformUv]( uv )</h3>
 		<div>
 		Transform the uv based on the value of this texture's [page:Texture.repeat .repeat], [page:Texture.offset .offset],
-		[page:Texture.wrapS .wrapS], [page:Texture.wrapT .wrapT] and [page:Texture.flipY .flipY] properties.
+		[page:Texture.wrapS .wrapS], [page:Texture.wrapT .wrapT] and [page:Texture.flipY .flipY] properties. Returns the uv.
 		</div>
 
 		<h2>Source</h2>

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -213,7 +213,7 @@ Object.assign( Texture.prototype, EventDispatcher.prototype, {
 
 	transformUv: function ( uv ) {
 
-		if ( this.mapping !== UVMapping ) return;
+		if ( this.mapping !== UVMapping ) return uv;
 
 		uv.multiply( this.repeat );
 		uv.add( this.offset );
@@ -285,6 +285,8 @@ Object.assign( Texture.prototype, EventDispatcher.prototype, {
 			uv.y = 1 - uv.y;
 
 		}
+
+		return uv;
 
 	}
 


### PR DESCRIPTION
This makes the method consistent with most other vector transformations, and will make it easier to include it in a chain of operations.