### PR TITLE
To detect texture loaded for Loaders

### DIFF
--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -23,13 +23,12 @@ Object.assign( TextureLoader.prototype, {
 		var loader = new ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
-		loader.load( url, function ( image ) {
+		var image = loader.load( url, function ( image ) {
 
 			// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
 			var isJPEG = url.search( /\.(jpg|jpeg)$/ ) > 0 || url.search( /^data\:image\/jpeg/ ) === 0;
 
 			texture.format = isJPEG ? RGBFormat : RGBAFormat;
-			texture.image = image;
 			texture.needsUpdate = true;
 
 			if ( onLoad !== undefined ) {
@@ -40,6 +39,7 @@ Object.assign( TextureLoader.prototype, {
 
 		}, onProgress, onError );
 
+		texture.image = image;
 		return texture;
 
 	},


### PR DESCRIPTION
This PR is to detect texture loaded for Loaders.

There are no way to detect texture loaded via JSON Loader (and others) so far, because `textureLoader` is not exposed [while parsing](https://github.com/yomotsu/three.js/blob/master/src/loaders/Loader.js#L47), and we can't access [onLoad callback](https://github.com/yomotsu/three.js/blob/master/src/loaders/TextureLoader.js#L15) for the textureLoader.

Use case for detecting texture onload:
```javascript
var needsUpdate = true;

loader.load( './model.json', function( geometry, materials ) {

	materials.forEach( function ( mat ) {

		// something like this...but does't exist.
		mat.map.onloadCallback = function () {

			needsUpdate = true;

		}

	} );

	...

} );


( function anim () {

  requestAnimationFrame( anim );

  if ( !needsUpdate ) { return; }

  renderer.render( scene, camera );
  needsUpdate = false;

} )();
```


If [`texture.image`](https://github.com/mrdoob/three.js/blob/dev/src/loaders/TextureLoader.js#L32) could be returned  immediately in `TextureLoader`, texture-image-loaded can be detected.

```javascript
var needsUpdate = true;

loader.load( './model.json', function( geometry, materials ) {

	materials.forEach( function ( mat ) {

		mat.map.image.onload = function () {

			needsUpdate = true;

		}

	} );

	...

} );
```