### PR TITLE
fix ios9 TypedArray.subarray(from, undefined) bug

### DIFF
--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -11,7 +11,9 @@ var AnimationUtils = {
 
 		if ( AnimationUtils.isTypedArray( array ) ) {
 
-			return new array.constructor( array.subarray( from, to ) );
+			// in ios9 array.subarray(from, undefined) will return empty array
+			// but array.subarray(from) or array.subarray(from, len) is correct
+			return new array.constructor( array.subarray( from, to || array.length ) );
 
 		}
 


### PR DESCRIPTION
In ios9 array.subarray(from, undefined) will return empty array, but array.subarray(from) or array.subarray(from, len) is correct.

The test case is here: https://jsfiddle.net/v7h3prez/