### PR TITLE
fix AnimationUtils.arraySlice bug

### DIFF
--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -13,7 +13,7 @@ var AnimationUtils = {
 
 			// in ios9 array.subarray(from, undefined) will return empty array
 			// but array.subarray(from) or array.subarray(from, len) is correct
-			return new array.constructor( array.subarray( from, to || array.length ) );
+			return new array.constructor( array.subarray( from, to === undefined ? array.length : to) );
 
 		}
 


### PR DESCRIPTION
```
return new array.constructor( array.subarray( from, to || array.length ) );
```
if to is 0, to will be array.length, it's wrong