### PR TITLE
Enable accessing accessors[0] in GLTF2Loader for indices, textures, and skin

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1999,7 +1999,7 @@ THREE.GLTF2Loader = ( function () {
 
 								var skinEntry;
 
-								if ( node.skin ) {
+								if ( node.skin !== undefined ) {
 
 									skinEntry = dependencies.skins[ node.skin ];
 

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1063,7 +1063,7 @@ THREE.GLTF2Loader = ( function () {
 
 			return _each( json.textures, function ( texture ) {
 
-				if ( texture.source ) {
+				if ( texture.source !== undefined ) {
 
 					return new Promise( function ( resolve ) {
 
@@ -1103,7 +1103,7 @@ THREE.GLTF2Loader = ( function () {
 
 							_texture.type = texture.type !== undefined ? WEBGL_TEXTURE_DATATYPES[ texture.type ] : THREE.UnsignedByteType;
 
-							if ( texture.sampler ) {
+							if ( texture.sampler !== undefined ) {
 
 								var sampler = json.samplers[ texture.sampler ];
 

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1632,7 +1632,7 @@ THREE.GLTF2Loader = ( function () {
 
 						}
 
-						if ( primitive.indices ) {
+						if ( primitive.indices !== undefined ) {
 
 							geometry.setIndex( dependencies.accessors[ primitive.indices ] );
 
@@ -1682,7 +1682,7 @@ THREE.GLTF2Loader = ( function () {
 
 						var meshNode;
 
-						if ( primitive.indices ) {
+						if ( primitive.indices !== undefined ) {
 
 							geometry.setIndex( dependencies.accessors[ primitive.indices ] );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1644,7 +1644,7 @@ THREE.GLTFLoader = ( function () {
 
 						}
 
-						if ( primitive.indices ) {
+						if ( primitive.indices !== undefined ) {
 
 							geometry.setIndex( dependencies.accessors[ primitive.indices ] );
 
@@ -1694,7 +1694,7 @@ THREE.GLTFLoader = ( function () {
 
 						var meshNode;
 
-						if ( primitive.indices ) {
+						if ( primitive.indices !== undefined ) {
 
 							geometry.setIndex( dependencies.accessors[ primitive.indices ] );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1644,7 +1644,7 @@ THREE.GLTFLoader = ( function () {
 
 						}
 
-						if ( primitive.indices !== undefined ) {
+						if ( primitive.indices ) {
 
 							geometry.setIndex( dependencies.accessors[ primitive.indices ] );
 
@@ -1694,7 +1694,7 @@ THREE.GLTFLoader = ( function () {
 
 						var meshNode;
 
-						if ( primitive.indices !== undefined ) {
+						if ( primitive.indices ) {
 
 							geometry.setIndex( dependencies.accessors[ primitive.indices ] );
 


### PR DESCRIPTION
This PR fixes zero value `mesh.primitive.indices` issue in `GLTF(2)Loader`.
This change enables `GLTF2Loader` to load gltf 2.0 simple box model.

https://github.com/cx20/gltf-test/tree/2.0

In glTF 2.0, `accessors` became an array so accessing id will be equal to or greater than 0 integer.

    if ( primitive.indices )

will be false if `indices` is 0.
We should explicitly compare with `undefined`.

I think the same change is necessary in glTF 1.0 loader to access named "0" accessor.

Update:
I realized that this's glTF 2.0 specific issue because
glTF 1.0 `mesh.primitive.indices` is `strings` whose length is > 0.
`if ("0")` will be true, so only 2.0 loader needs to take care of it.

Update2:
I applied the same change to `texture.sampler/source` in `GLTF2Loader`.
This change enables it to load glTF 2.0 textured box in the like above.
`texture.sampler/source` props are required even in 1.0,
so we could remove `if (texture.sampler/source)` line.