### PR TITLE
Fixed code example error: there's no method distanceTo for Vector4

### DIFF
--- a/docs/api/math/Vector4.html
+++ b/docs/api/math/Vector4.html
@@ -42,7 +42,7 @@ var a = new THREE.Vector4( 0, 1, 0, 0 );
 //no arguments; will be initialised to (0, 0, 0, 1)
 var b = new THREE.Vector4( );
 
-var d = a.distanceTo( b );
+var d = a.dot( b );
 		</code>
 
 


### PR DESCRIPTION
There is no method `distanceTo` for Vector4, so just use `dot` instead.