### PR TITLE
OrbitControls: added saveState() method

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -96,6 +96,14 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	};
 
+	this.saveState = function () {
+
+		scope.target0.copy( scope.target );
+		scope.position0.copy( scope.object.position );
+		scope.zoom0 = scope.object.zoom;
+
+	};
+
 	this.reset = function () {
 
 		scope.target.copy( scope.target0 );


### PR DESCRIPTION
As mentioned in the discussion in https://github.com/mrdoob/three.js/issues/4513, `controls.reset()` restores the state previously-saved by `controls.saveState()`.