### PR TITLE
[DOCS] Improve documentation of TextGeometry usage

### DIFF
--- a/docs/api/geometries/TextGeometry.html
+++ b/docs/api/geometries/TextGeometry.html
@@ -12,7 +12,11 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">This object creates a 3D object of text as a single object.</div>
+		<div class="desc">
+			A class for generating text as a single geometry. It is constructed by providing a string of text, and a hash of 
+			parameters consisting of a loaded [page:Font] and settings for the geometry's parent [page:ExtrudeGeometry].
+			See the [page:Font], [page:FontLoader] and [page:Creating_Text] pages for additional details.
+		</div>
 
 		<iframe id="scene" src="scenes/geometry-browser.html#TextGeometry"></iframe>
 
@@ -32,12 +36,30 @@
 
 		</script>
 
-		<h2>Example</h2>
+		<h2>Examples</h2>
 
 		<div>
 		[example:webgl_geometry_text geometry / text ]<br/>
 		[example:webgl_geometry_text2 geometry / text2 ]
 		</div>
+
+		<code>
+		var loader = new THREE.FontLoader();
+		
+		loader.load( 'fonts/helvetiker_regular.typeface.json', function ( font ) {
+
+			var geometry = new THREE.TextGeometry( 'Hello three.js!', {
+				font: font,
+				size: 80,
+				height: 5,
+				curveSegments: 12,
+				bevelEnabled: true,
+				bevelThickness: 10,
+				bevelSize: 8,
+				bevelSegments: 5
+			} );
+		} );			
+		</code>
 
 		<h2>Constructor</h2>
 
@@ -46,8 +68,8 @@
 		text — The text that needs to be shown. <br />
 		parameters — Object that can contains the following parameters.
 		<ul>
-			<li>font — THREE.Font.</li>
-			<li>size — Float. Size of the text.</li>
+			<li>font — an instance of THREE.Font.</li>
+			<li>size — Float. Size of the text. Default is 100.</li>
 			<li>height — Float. Thickness to extrude text.  Default is 50.</li>
 			<li>curveSegments — Integer. Number of points on the curves. Default is 12.</li>
 			<li>bevelEnabled — Boolean. Turn on bevel. Default is False.</li>

--- a/docs/manual/introduction/Creating-text.html
+++ b/docs/manual/introduction/Creating-text.html
@@ -61,13 +61,19 @@
 		<h2>4. Procedural Text Geometry</h2>
 		<div>
 			<p>
-				Use this method if you prefer to work purely in three.js or create procedural and dynamic 3d
-				text geometries. However, font data files in THREE.js JSON format need to be loaded
-				before this will work.
-				See the [page:TextGeometry] page for examples of JSON fonts.
+				If you prefer to work purely in THREE.js or to create procedural and dynamic 3D
+				text geometries, you can create a mesh whose geometry is an instance of THREE.TextGeometry:
 			</p>
-			<p>A Text Geometry can then be created with </p>
-			<code>new THREE.TextGeometry( text, parameters );</code>
+			<p>
+				<code>new THREE.TextGeometry( text, parameters );</code>
+			</p>
+			<p>
+				In order for this to work, however, your TextGeomety will need an instance of THREE.Font 
+				to be set on its "font" parameter.
+
+				See the [page:TextGeometry] page for more info on how this can be done, descriptions of each
+				accepted parameter, and a list of the JSON fonts that come with the THREE.js distribution itself.
+			</p>
 
 			<h3>Examples</h3>
 			[example:webgl_geometry_text WebGL / geometry / text]<br />


### PR DESCRIPTION
I feel like the documentation for `TextGeometry` could really be helped if we showed how creating a `TextGeometry` instance usually goes hand-in-hand with loading a `THREE.Font` instance ([I'm also not alone](https://medium.com/@patsul12/font-loading-in-three-js-e9306042dded#.40z6fwnz8) 😃). 

In addition to adding said example, I also alluded to this process in the "Creating Text" manual section.