### PR TITLE
Use proper imports instead of using the "THREE" alias internally

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -50,6 +50,7 @@ export { AudioLoader } from './loaders/AudioLoader.js';
 export { SpotLightShadow } from './lights/SpotLightShadow.js';
 export { SpotLight } from './lights/SpotLight.js';
 export { PointLight } from './lights/PointLight.js';
+export { RectAreaLightShadow } from './lights/RectAreaLightShadow.js';
 export { RectAreaLight } from './lights/RectAreaLight.js';
 export { HemisphereLight } from './lights/HemisphereLight.js';
 export { DirectionalLightShadow } from './lights/DirectionalLightShadow.js';

--- a/src/lights/RectAreaLightShadow.js
+++ b/src/lights/RectAreaLightShadow.js
@@ -1,18 +1,26 @@
+import { LightShadow } from './LightShadow';
+import { PerspectiveCamera } from '../cameras/PerspectiveCamera';
+
 /**
  * @author aallison / http://github.com/abelnation
  */
 
-THREE.RectAreaLightShadow = function () {
+function RectAreaLightShadow() {
 
-	THREE.LightShadow.call( this, new THREE.PerspectiveCamera( 50, 1, 0.5, 500 ) );
+	LightShadow.call( this, new PerspectiveCamera( 50, 1, 0.5, 500 ) );
 
 };
 
-THREE.RectAreaLightShadow.prototype = Object.create( THREE.LightShadow.prototype );
-THREE.RectAreaLightShadow.prototype.constructor = THREE.RectAreaLightShadow;
+RectAreaLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype ), {
 
-THREE.RectAreaLightShadow.prototype.update = function ( light ) {
+	constructor: RectAreaLightShadow,
+
+	update: function ( light ) {
 
 	// TODO (abelnation): implement
 
-};
+	}
+
+});
+
+export { RectAreaLightShadow };

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3,6 +3,7 @@ import { _Math } from '../math/Math';
 import { Matrix4 } from '../math/Matrix4';
 import { DataTexture } from '../textures/DataTexture';
 import { WebGLUniforms } from './webgl/WebGLUniforms';
+import { UniformsLib } from './shaders/UniformsLib';
 import { UniformsUtils } from './shaders/UniformsUtils';
 import { ShaderLib } from './shaders/ShaderLib';
 import { LensFlarePlugin } from './webgl/plugins/LensFlarePlugin';
@@ -1959,8 +1960,8 @@ function WebGLRenderer( parameters ) {
 			// RectAreaLight Texture
 			// TODO (mrdoob): Find a nicer implementation
 
-			if ( m_uniforms.ltcMat !== undefined ) m_uniforms.ltcMat.value = THREE.UniformsLib.LTC_MAT_TEXTURE;
-			if ( m_uniforms.ltcMag !== undefined ) m_uniforms.ltcMag.value = THREE.UniformsLib.LTC_MAG_TEXTURE;
+			if ( m_uniforms.ltcMat !== undefined ) m_uniforms.ltcMat.value = UniformsLib.LTC_MAT_TEXTURE;
+			if ( m_uniforms.ltcMag !== undefined ) m_uniforms.ltcMag.value = UniformsLib.LTC_MAG_TEXTURE;
 
 			WebGLUniforms.upload(
 				_gl, materialProperties.uniformsList, m_uniforms, _this );


### PR DESCRIPTION
Using the THREE alias makes things fail when trying to use three.js
with e.g. webpack which will assign some alias other than "THREE" to
the module.