### PR TITLE
Copy matrix values for child objects in case matrixAutoUpdate isn't used

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -1046,7 +1046,8 @@ THREE.ColladaLoader.prototype = {
 
 					case 'input':
 						var id = parseId( child.getAttribute( 'source' ) );
-						var semantic = child.getAttribute( 'semantic' );
+						var set = child.getAttribute( 'set' );
+						var semantic = child.getAttribute( 'semantic' ) + set;
 						var offset = parseInt( child.getAttribute( 'offset' ) );
 						primitive.inputs[ semantic ] = { id: id, offset: offset };
 						primitive.stride = Math.max( primitive.stride, offset + 1 );
@@ -1113,7 +1114,12 @@ THREE.ColladaLoader.prototype = {
 							break;
 
 						case 'TEXCOORD':
+						case 'TEXCOORD0':
 							geometry.addAttribute( 'uv', buildGeometryAttribute( primitive, sources[ input.id ], input.offset ) );
+							break;
+
+						case 'TEXCOORD1':
+							geometry.addAttribute( 'uv2', buildGeometryAttribute( primitive, sources[ input.id ], input.offset ) );
 							break;
 
 					}

--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -1046,8 +1046,7 @@ THREE.ColladaLoader.prototype = {
 
 					case 'input':
 						var id = parseId( child.getAttribute( 'source' ) );
-						var set = child.getAttribute( 'set' );
-						var semantic = child.getAttribute( 'semantic' ) + set;
+						var semantic = child.getAttribute( 'semantic' );
 						var offset = parseInt( child.getAttribute( 'offset' ) );
 						primitive.inputs[ semantic ] = { id: id, offset: offset };
 						primitive.stride = Math.max( primitive.stride, offset + 1 );
@@ -1114,12 +1113,7 @@ THREE.ColladaLoader.prototype = {
 							break;
 
 						case 'TEXCOORD':
-						case 'TEXCOORD0':
 							geometry.addAttribute( 'uv', buildGeometryAttribute( primitive, sources[ input.id ], input.offset ) );
-							break;
-
-						case 'TEXCOORD1':
-							geometry.addAttribute( 'uv2', buildGeometryAttribute( primitive, sources[ input.id ], input.offset ) );
 							break;
 
 					}

--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -1439,6 +1439,7 @@ THREE.ColladaLoader.prototype = {
 			}
 
 			object.name = data.name;
+			object.matrix.copy( matrix );
 			matrix.decompose( object.position, object.quaternion, object.scale );
 
 			return object;


### PR DESCRIPTION
ColladaLoader2 currently populates `object.position`, `object.rotation`, and `object.scale` by decomposing the matrix that's specified in the COLLADA file, but it doesn't populate `object.matrix`.  This works fine if you're using the `matrixAutoUpdate`  system since the matrix will be populated on the first frame, but if you're managing this yourself then all objects remain at their default positions.

This patch fixes that by copying the matrix values over to the new object as well.