### PR TITLE
Fix missing material.skinning in GLTF2Loader

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2013,6 +2013,7 @@ THREE.GLTF2Loader = ( function () {
 
 									var geometry = originalGeometry;
 									var material = originalMaterial;
+									material.skinning = true;
 
 									child = new THREE.SkinnedMesh( geometry, material, false );
 									child.castShadow = true;


### PR DESCRIPTION
This PR fix missing `material.skinning` in `GLTF2Loader`.
It fixes shadow of `loader_gltf` example.

Probably we've forked `GLTF2Loader` from `GLTFLoader` while
`material.skinning` was removed?
