### PR TITLE
Issue #10883: STLLoader's binary check trips up

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -70,6 +70,42 @@ THREE.STLLoader.prototype = {
 
 			}
 
+			// Do we see 'solid' in the first few bytes of the data?
+
+			// An ASCII STL data must begin with 'solid ' as the first six bytes.
+			// However, ASCII STLs lacking the SPACE after the 'd' are known to be
+			// plentiful.
+
+			// This check can likely be restricted to the first 6 bytes of
+			// the STL data.  It's here applied to the first 50 bytes for
+			// no particular good reason.
+
+			var fileLength = reader.byteLength;
+			if ( fileLength > 50 ) fileLength = 50;
+
+			// US-ASCII ordinal values for 's', 'o', 'l', 'i', 'd'
+			var solid = [ 115, 111, 108, 105, 100 ];
+        
+ 			var i = 0;
+ 			for ( var index = 0; index < fileLength; index ++ ) {
+				if ( reader.getUint8( index, false ) == solid[i] ) {
+
+ 			 		i++;
+
+ 			 		if ( i == 5 ) {
+
+ 			 			// 'solid' seen near the start of the file
+ 			 			return false;
+
+ 			 		}
+
+				} else {
+
+ 			 		i = 0;
+
+				}
+ 			}
+
 			// some binary files will have different size from expected,
 			// checking characters higher than ASCII to confirm is binary
 			var fileLength = reader.byteLength;

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -70,55 +70,23 @@ THREE.STLLoader.prototype = {
 
 			}
 
-			// Do we see 'solid' in the first few bytes of the data?
-
 			// An ASCII STL data must begin with 'solid ' as the first six bytes.
 			// However, ASCII STLs lacking the SPACE after the 'd' are known to be
-			// plentiful.
-
-			// This check can likely be restricted to the first 6 bytes of
-			// the STL data.  It's here applied to the first 50 bytes for
-			// no particular good reason.
-
-			var fileLength = reader.byteLength;
-			if ( fileLength > 50 ) fileLength = 50;
+			// plentiful.  So, check the first 5 bytes for 'solid'.
 
 			// US-ASCII ordinal values for 's', 'o', 'l', 'i', 'd'
 			var solid = [ 115, 111, 108, 105, 100 ];
-        
- 			var i = 0;
- 			for ( var index = 0; index < fileLength; index ++ ) {
-				if ( reader.getUint8( index, false ) == solid[i] ) {
 
- 			 		i++;
+			for ( var i = 0; i < 5; i ++ ) {
 
- 			 		if ( i == 5 ) {
+				// If solid[ i ] does not match the i-th byte, then it is not an
+				// ASCII STL; hence, it is binary and return true.
 
- 			 			// 'solid' seen near the start of the file
- 			 			return false;
+				if ( solid[ i ] != reader.getUint8( i, false ) ) return true;
 
- 			 		}
-
-				} else {
-
- 			 		i = 0;
-
-				}
  			}
 
-			// some binary files will have different size from expected,
-			// checking characters higher than ASCII to confirm is binary
-			var fileLength = reader.byteLength;
-			for ( var index = 0; index < fileLength; index ++ ) {
-
-				if ( reader.getUint8( index, false ) > 127 ) {
-
-					return true;
-
-				}
-
-			}
-
+			// First 5 bytes read "solid"; declare it to be an ASCII STL
 			return false;
 
 		};


### PR DESCRIPTION
This commit addresses Issue #10883 in which the isBinary() check of an STL data stream can incorrectly identify a syntactically invalid but still useful ASCII STL as being binary.  Namely, the ASCII STL will be identified as binary if the ASCII STL data presents a non-US-ASCII 'name' field parameter with the 'solid' or 'endsolid' keywords.  E.g.,

    solid 穿山甲
    facet normal 0.7071067717164974 -0.00016366188967739515 0.707106771716591
      outer loop
        vertex 135.89921424250542 449.7206946618269 58.1296582226351
    ...
        endloop
    endfacet
    endsolid 穿山甲

Note that as ASCII STLs must be in US-ASCII, they may contain no characters with the high bit set.  As such, the example above is syntactically invalid.  However, more and more such ASCII STLs are appearing.  Moreover, the isBinary() check itself is tripping up as it tries to accommodate a potentially incorrect binary STL for which the computed data length disagrees with the observed data length.  So, it's something of a juggling act as the code attempts to accommodate different, broken inputs.

This commit attempts to address this issue while making minimal disruption to the present code.  After the data length is computed but found to not agree, this change next looks for the US-ASCII phrase 'solid' at/near the start of the data.  If it is found, then the STL is declared to NOT be binary.  Then, the existing check of the data for any non US-ASCII characters is performed. That is, a new check has been inserted between the length check and the 8bit character check.  A more robust change might be to look for 'solid' in the first five bytes of the data and, if found, declare it ASCII from the get go.