### PR TITLE
Use quatEquals on quaternions

### DIFF
--- a/test/unit/src/math/Euler.js
+++ b/test/unit/src/math/Euler.js
@@ -80,7 +80,7 @@ QUnit.test( "Quaternion.setFromEuler/Euler.fromQuaternion", function( assert ) {
 
 		var v2 = new THREE.Euler().setFromQuaternion( q, v.order );
 		var q2 = new THREE.Quaternion().setFromEuler( v2 );
-		assert.ok( eulerEquals( q, q2 ), "Passed!" );
+		assert.ok( quatEquals( q, q2 ), "Passed!" );
 	}
 });
 


### PR DESCRIPTION
eulerEquals was being used to compare quaternions. The fix should have no effects on behaviour.