### PR TITLE
GLTF(2)Loader: Return scenes[0] as scene if default scene is not specified

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -858,8 +858,6 @@ THREE.GLTF2Loader = ( function () {
 
 		] ).then( function ( dependencies ) {
 
-			var scene = dependencies.scenes[ json.scene ];
-
 			var scenes = [];
 
 			for ( var name in dependencies.scenes ) {
@@ -867,6 +865,8 @@ THREE.GLTF2Loader = ( function () {
 				scenes.push( dependencies.scenes[ name ] );
 
 			}
+
+			var scene = json.scene !== undefined ? dependencies.scenes[ json.scene ] : scenes[ 0 ];
 
 			var cameras = [];
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -882,8 +882,6 @@ THREE.GLTFLoader = ( function () {
 
 		] ).then( function ( dependencies ) {
 
-			var scene = dependencies.scenes[ json.scene ];
-
 			var scenes = [];
 
 			for ( var name in dependencies.scenes ) {
@@ -891,6 +889,8 @@ THREE.GLTFLoader = ( function () {
 				scenes.push( dependencies.scenes[ name ] );
 
 			}
+
+			var scene = json.scene !== undefined ? dependencies.scenes[ json.scene ] : scenes[ 0 ];
 
 			var cameras = [];
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -228,7 +228,7 @@
 
 					gltf = data;
 
-					var object = gltf.scene !== undefined ? gltf.scene : gltf.scenes[ 0 ];
+					var object = gltf.scene;
 
 					status.innerHTML = "Load time: " + ( performance.now() - loadStartTime ).toFixed( 2 ) + " ms.";
 


### PR DESCRIPTION
This PR moves

    var scene = json.scene !== undefined ? dependencies.scenes[ json.scene ] : scenes[ 0 ];

into `GLTF(2)Loader` then user no longer needs to
check if `scene` is `undefined`.