### PR TITLE
fix "Source and destination textures of the draw …"

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2474,7 +2474,16 @@ function WebGLRenderer( parameters ) {
 
 			}
 
-			textures.setTexture2D( texture, slot );
+			if ( _currentRenderTarget && _currentRenderTarget.texture === texture ) {
+
+				state.activeTexture( _gl.TEXTURE0 + slot );
+				state.bindTexture( _gl.TEXTURE_2D, null );
+
+			} else {
+
+				textures.setTexture2D( texture, slot );
+
+			}
 
 		};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2476,8 +2476,7 @@ function WebGLRenderer( parameters ) {
 
 			if ( _currentRenderTarget && _currentRenderTarget.texture === texture ) {
 
-				state.activeTexture( _gl.TEXTURE0 + slot );
-				state.bindTexture( _gl.TEXTURE_2D, null );
+				textures.unsetTexture2D( slot );
 
 			} else {
 
@@ -2521,8 +2520,7 @@ function WebGLRenderer( parameters ) {
 
 			if ( _currentRenderTarget && _currentRenderTarget.texture === texture ) {
 
-				state.activeTexture( _gl.TEXTURE0 + slot );
-				state.bindTexture( _gl.TEXTURE_CUBE_MAP, null );
+				textures.unsetTextureCube( slot );
 
 			} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2489,24 +2489,15 @@ function WebGLRenderer( parameters ) {
 
 	}() );
 
-	this.setTexture = ( function () {
+	this.setTexture = function () {
 
-		var warned = false;
+		console.warn( "THREE.WebGLRenderer: .setTexture is deprecated, use setTexture2D instead." );
 
-		return function setTexture( texture, slot ) {
+		_this.setTexture = _this.setTexture2D; // replace function after first warn
 
-			if ( ! warned ) {
+		_this.setTexture2D( texture, slot );
 
-				console.warn( "THREE.WebGLRenderer: .setTexture is deprecated, use setTexture2D instead." );
-				warned = true;
-
-			}
-
-			textures.setTexture2D( texture, slot );
-
-		};
-
-	}() );
+	};
 
 	this.setTextureCube = ( function () {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2488,7 +2488,7 @@ function WebGLRenderer( parameters ) {
 
 	}() );
 
-	this.setTexture = function () {
+	this.setTexture = function ( texture, slot ) {
 
 		console.warn( "THREE.WebGLRenderer: .setTexture is deprecated, use setTexture2D instead." );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2528,21 +2528,30 @@ function WebGLRenderer( parameters ) {
 
 			}
 
-			// currently relying on the fact that WebGLRenderTargetCube.texture is a Texture and NOT a CubeTexture
-			// TODO: unify these code paths
-			if ( ( texture && texture.isCubeTexture ) ||
-				( Array.isArray( texture.image ) && texture.image.length === 6 ) ) {
+			if ( _currentRenderTarget && _currentRenderTarget.texture === texture ) {
 
-				// CompressedTexture can have Array in image :/
-
-				// this function alone should take care of cube textures
-				textures.setTextureCube( texture, slot );
+				state.activeTexture( _gl.TEXTURE0 + slot );
+				state.bindTexture( _gl.TEXTURE_CUBE_MAP, null );
 
 			} else {
 
-				// assumed: texture property of THREE.WebGLRenderTargetCube
+				// currently relying on the fact that WebGLRenderTargetCube.texture is a Texture and NOT a CubeTexture
+				// TODO: unify these code paths
+				if ( ( texture && texture.isCubeTexture ) ||
+					( Array.isArray( texture.image ) && texture.image.length === 6 ) ) {
 
-				textures.setTextureCubeDynamic( texture, slot );
+					// CompressedTexture can have Array in image :/
+
+					// this function alone should take care of cube textures
+					textures.setTextureCube( texture, slot );
+
+				} else {
+
+					// assumed: texture property of THREE.WebGLRenderTargetCube
+
+					textures.setTextureCubeDynamic( texture, slot );
+
+				}
 
 			}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -213,6 +213,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, paramT
 
 	}
 
+	function unsetTexture2D( slot ) {
+
+		state.activeTexture( _gl.TEXTURE0 + slot );
+		state.bindTexture( _gl.TEXTURE_2D, null );
+
+	}
+
 	function setTextureCube( texture, slot ) {
 
 		var textureProperties = properties.get( texture );
@@ -333,6 +340,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, paramT
 
 		state.activeTexture( _gl.TEXTURE0 + slot );
 		state.bindTexture( _gl.TEXTURE_CUBE_MAP, properties.get( texture ).__webglTexture );
+
+	}
+
+	function unsetTextureCube( slot ) {
+
+		state.activeTexture( _gl.TEXTURE0 + slot );
+		state.bindTexture( _gl.TEXTURE_CUBE_MAP, null );
 
 	}
 
@@ -779,8 +793,10 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, paramT
 	}
 
 	this.setTexture2D = setTexture2D;
+	this.unsetTexture2D = unsetTexture2D;
 	this.setTextureCube = setTextureCube;
 	this.setTextureCubeDynamic = setTextureCubeDynamic;
+	this.unsetTextureCube = unsetTextureCube;
 	this.setupRenderTarget = setupRenderTarget;
 	this.updateRenderTargetMipmap = updateRenderTargetMipmap;
 


### PR DESCRIPTION
It fix the `mirror_nodes` example and too prevent others problems related.

About the code, if you want I can add a `textures.unsetTexture...` functions.

Updated!!

![nodematerial-fixed](https://cloud.githubusercontent.com/assets/502810/23646011/b4e6a9e6-02ed-11e7-82a0-b336bf8f3918.jpg)
