### PR TITLE
Initial electron version of the editor

### DIFF
--- a/editor/main.js
+++ b/editor/main.js
@@ -1,0 +1,63 @@
+const electron = require('electron')
+// Module to control application life.
+const app = electron.app
+// Module to create native browser window.
+const BrowserWindow = electron.BrowserWindow
+
+const path = require('path')
+const url = require('url')
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow
+
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({width: 800, height: 600,   webPreferences: {
+    nodeIntegration: false
+  }});
+  mainWindow.maximize();
+  mainWindow.setMenu(null);
+  // and load the index.html of the app.
+  mainWindow.loadURL(url.format({
+    pathname: path.join(__dirname, 'index.html'),
+    protocol: 'file:',
+    slashes: true
+  }))
+
+  // Open the DevTools.
+  //mainWindow.webContents.openDevTools()
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+})
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.

--- a/editor/main.js
+++ b/editor/main.js
@@ -1,63 +1,55 @@
-const electron = require('electron')
-// Module to control application life.
-const app = electron.app
-// Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow
+const electron = require( 'electron' );
+const app = electron.app;
+const BrowserWindow = electron.BrowserWindow;
 
-const path = require('path')
-const url = require('url')
+const path = require( 'path' );
+const url = require( 'url' );
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow
+let mainWindow;
 
-function createWindow () {
-  // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600,   webPreferences: {
-    nodeIntegration: false
-  }});
-  mainWindow.maximize();
-  mainWindow.setMenu(null);
-  // and load the index.html of the app.
-  mainWindow.loadURL(url.format({
-    pathname: path.join(__dirname, 'index.html'),
-    protocol: 'file:',
-    slashes: true
-  }))
+function createWindow() {
 
-  // Open the DevTools.
-  //mainWindow.webContents.openDevTools()
+	mainWindow = new BrowserWindow( { webPreferences: {
+		nodeIntegration: false
+	} } );
 
-  // Emitted when the window is closed.
-  mainWindow.on('closed', function () {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    mainWindow = null
-  })
+	mainWindow.maximize();
+	mainWindow.setMenu( null );
+
+	mainWindow.loadURL( url.format( {
+		pathname: path.join( __dirname, 'index.html' ),
+		protocol: 'file:',
+		slashes: true
+	} ) );
+
+	mainWindow.on( 'closed', function () {
+
+		mainWindow = null;
+
+	} );
+
 }
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+app.on( 'ready', createWindow );
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function () {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
-})
+app.on( 'window-all-closed', function () {
 
-app.on('activate', function () {
-  // On OS X it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow()
-  }
-})
+	if ( process.platform !== 'darwin' ) {
 
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.
+		app.quit();
+
+	}
+
+} );
+
+app.on( 'activate', function () {
+
+	if ( mainWindow === null ) {
+
+		createWindow();
+
+	}
+
+} );

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,0 +1,5 @@
+{
+  "name"    : "your-app",
+  "version" : "0.1.0",
+  "main"    : "main.js"
+}

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,5 +1,0 @@
-{
-  "name"    : "your-app",
-  "version" : "0.1.0",
-  "main"    : "main.js"
-}

--- a/package.json
+++ b/package.json
@@ -54,9 +54,7 @@
     "qunitjs": "^2.1.1",
     "rollup": "^0.41.4",
     "rollup-watch": "^3.2.2",
-    "uglify-js": "^2.6.0"
-  },
-  "dependencies": {
+    "uglify-js": "^2.6.0",
     "electron": "^1.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "build-closure": "rollup -c && java -jar utils/build/compiler/closure-compiler-v20160713.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
     "dev": "rollup -c -w",
     "lint": "eslint src",
-    "test": "rollup -c test/rollup.unit.config.js -w"
+    "test": "rollup -c test/rollup.unit.config.js -w",
+    "editor-start": "electron ./editor/"
   },
   "keywords": [
     "three",
@@ -54,5 +55,8 @@
     "rollup": "^0.41.4",
     "rollup-watch": "^3.2.2",
     "uglify-js": "^2.6.0"
+  },
+  "dependencies": {
+    "electron": "^1.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev": "rollup -c -w",
     "lint": "eslint src",
     "test": "rollup -c test/rollup.unit.config.js -w",
-    "editor-start": "electron ./editor/"
+    "editor-start": "electron ./editor/main.js"
   },
   "keywords": [
     "three",


### PR DESCRIPTION
This is a standalone version of the editor. It uses  [electron](https://electron.atom.io/) as engine to power this standalone version. It works just the same as the webpage but it allows usage of the files on local PC.

This should work in linux, Mac OS & Windows. But this has only been tested in windows. 

To use it right now you need to execute `npm run editor-start`. 

