### PR TITLE
fix extrude geometry

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -92,13 +92,9 @@ ExtrudeBufferGeometry.prototype.getArrays = function () {
 	var uvAttribute = this.getAttribute( "uv" );
 	var uvArray = uvAttribute ? Array.prototype.slice.call( uvAttribute.array ) : [];
 
-	var IndexAttribute = this.index;
-	var indicesArray = IndexAttribute ? Array.prototype.slice.call( IndexAttribute.array ) : [];
-
 	return {
 		position: verticesArray,
-		uv: uvArray,
-		index: indicesArray
+		uv: uvArray
 	};
 
 };
@@ -115,7 +111,7 @@ ExtrudeBufferGeometry.prototype.addShapeList = function ( shapes, options ) {
 
 	}
 
-	this.setIndex( options.arrays.index );
+	//this.setIndex( options.arrays.index );
 	this.addAttribute( 'position', new Float32BufferAttribute( options.arrays.position, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( options.arrays.uv, 2 ) );
 
@@ -125,7 +121,6 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 	var arrays = options.arrays ? options.arrays : this.getArrays();
 	var verticesArray = arrays.position;
-	var indicesArray = arrays.index;
 	var uvArray = arrays.uv;
 
 	var placeholder = [];
@@ -733,7 +728,6 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 	function addVertex( index ) {
 
-		indicesArray.push( verticesArray.length / 3 );
 		verticesArray.push( placeholder[ index * 3 + 0 ] );
 		verticesArray.push( placeholder[ index * 3 + 1 ] );
 		verticesArray.push( placeholder[ index * 3 + 2 ] );
@@ -750,7 +744,6 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 	if ( ! options.arrays ) {
 
-		this.setIndex( indicesArray );
 		this.addAttribute( 'position', new Float32BufferAttribute( verticesArray, 3 ) );
 		this.addAttribute( 'uv', new Float32BufferAttribute( options.arrays.uv, 2 ) );
 


### PR DESCRIPTION
This makes /examples/webgl_geometry_extrude_shapes.html work again. This was broken due to updating extrudegeometry to buffergeometry in  #10908.