### PR TITLE
fix groups in extrudebuffergeometry

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -641,11 +641,9 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 		}
 		
-		if (options.extrudeMaterial !== undefined){
-			
-			scope.addGroup( start, verticesArray.length/3 -start, options.extrudeMaterial !== undefined ? options.extrudeMaterial : 1);
-			
-		}
+
+		scope.addGroup( start, verticesArray.length/3 -start, options.extrudeMaterial !== undefined ? options.extrudeMaterial : 1);
+
 
 	}
 


### PR DESCRIPTION
This makes /examples/webgl_geometry_extrude_shapes.html work again. This was broken due to updating extrudegeometry to buffergeometry in #10908.