### PR TITLE
Docs: Redirects for subpages implemented

### DIFF
--- a/docs/page.js
+++ b/docs/page.js
@@ -23,6 +23,56 @@ var onDocumentLoad = function ( event ) {
 			break;
 
 	}
+    
+
+    // redirect, if the page is not yet displayed as an iframe (with navigation panel and working links)    
+    
+    if ( !window.frameElement ) {
+        
+        var redirectUrl;
+
+        for ( var mainCategory in list ) {
+            
+            var subCategories = list[ mainCategory ];
+            
+            for ( var subCategory in subCategories ) {
+                
+                var pages = subCategories[ subCategory ]
+                
+                for ( i = 0; i < pages.length; i++ ) {
+                    
+                    var page = pages[ i ];
+
+                    if ( page[ 1 ] === section + '/' + path ) {  
+
+                        redirectUrl = 'index.html#' 
+                                    + mainCategory 
+                                    + '/' 
+                                    + subCategory.replace(/\ \/\ /g, '.').replace(/\ /g, '_') 
+                                    + '/' 
+                                    + page[ 0 ].replace(/\ /g, '_');
+                        break;
+                        
+                    };
+                    
+                };
+                
+            };
+            
+        }; 
+        
+        if ( redirectUrl ) {
+            
+            window.location.replace( redirectUrl );
+            
+        } else {
+            
+            console.warn( 'Unknown URL - page can\'t be displayed as an inline frame.' )
+            
+        }
+        
+    }
+
 
 	var text = document.body.innerHTML;
 

--- a/docs/page.js
+++ b/docs/page.js
@@ -45,7 +45,7 @@ var onDocumentLoad = function ( event ) {
 
                     if ( page[ 1 ] === section + '/' + path ) {  
 
-                        redirectUrl = 'index.html#' 
+                        redirectUrl = '#'
                                     + mainCategory 
                                     + '/' 
                                     + subCategory.replace(/\ \/\ /g, '.').replace(/\ /g, '_') 


### PR DESCRIPTION
Related to #10937

Pages reached from outside (for instance via google) are now correctly displayed (with navigation panel and working links),

by redirecting pages with URLs such as the following ones …

1.	... docs/api/objects/SkinnedMesh.html
2.	... docs/manual/introduction/Detecting-WebGL-and-browser-compatibility.html
3.	... docs/api/core/BufferGeometry.html
4.	... docs/manual/introduction/Animation-system.html
5.	... docs/api/renderers/webgl/plugins/LensFlarePlugin.html
6.	... docs/examples/loaders/OBJLoader.html
7.	... docs/api/animation/tracks/QuaternionKeyframeTrack.html

… to their corresponding iframe-URLs (using docs/list.js for mapping):

1.	... docs/#Reference/Objects/SkinnedMesh
2.	... docs/#Manual/Getting_Started/Detecting_WebGL_and_browser_compatibility
3.	... docs/#Reference/Core/BufferGeometry
4.	... docs/#Manual/Next_Steps/Animation_System
5.	... docs/#Developer_Reference/WebGLRenderer.Plugins/LensFlarePlugin
6.	... docs/#Examples/Loaders/OBJLoader
7.	... docs/#Reference/Animation.Tracks/QuaternionKeyframeTrack
