### PR TITLE
This allow scripts to be added to the camera

### DIFF
--- a/editor/js/Sidebar.Script.js
+++ b/editor/js/Sidebar.Script.js
@@ -102,7 +102,7 @@ Sidebar.Script = function ( editor ) {
 
 	signals.objectSelected.add( function ( object ) {
 
-		if ( object !== null ) {
+		if ( object !== null && editor.camera !== object ) {
 
 			container.setDisplay( 'block' );
 


### PR DESCRIPTION
fixes #10854
This makes it possible for scripts to be added to the camera object that isn't part of the scene.
This wasn't possible in the  editor.