### PR TITLE
Add sourcemaps to NPM 'dev' script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build-test": "rollup -c test/rollup.unit.config.js",
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar utils/build/compiler/closure-compiler-v20160713.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
-    "dev": "rollup -c -w",
+    "dev": "rollup -c -w -m inline",
     "lint": "eslint src",
     "test": "rollup -c test/rollup.unit.config.js -w"
   },


### PR DESCRIPTION
I find the sourcemap very helpful when debugging in a browser; any reason not to enable this when using `npm run dev`?

(I can also happily just continue running `rollup -c -w -m inline` manually)