### PR TITLE
First call to Clock.getDelta() should returns 0

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -49,6 +49,7 @@ Clock.prototype = {
 		if ( this.autoStart && ! this.running ) {
 
 			this.start();
+			return 0;
 
 		}
 


### PR DESCRIPTION
If we have a `THREE.Clock` with the default `autoStart = true` the first time we call `getDelta()` it will initialize the counter by setting `startTime` to `performance.now` https://github.com/mrdoob/three.js/blob/master/src/core/Clock.js#L51
But after that it will call again `performance.now` to compare with the just set value https://github.com/mrdoob/three.js/blob/master/src/core/Clock.js#L57-L62
So it will return a very small amount of delta (and elapsedTime) while it should really returns `delta=0` and keep `elapsedTime=0` as initialized because it's really the first call of that function so I couldn't be any time since the last call.