### PR TITLE
Traverse materials

### DIFF
--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -252,20 +252,20 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 	function setOutlineMaterial( object ) {
 
 		if ( object.material === undefined ) return;
-
-		if ( Array.isArray( object.material ) ) {
-
-			for ( var i = 0, il = object.material.length; i < il; i ++ ) {
-
-				object.material[ i ] = getOutlineMaterial( object.material[ i ] );
-
+		
+		object.traverseMaterials( function( material, index, isArray ) {
+			
+			var outlineMaterial = getOutlineMaterial(material);
+			if ( isArray ) {
+				
+				object.material[ index ] = outlineMaterial;
+				
+			} else {
+				
+				object.material = outlineMaterial;
+				
 			}
-
-		} else {
-
-			object.material = getOutlineMaterial( object.material );
-
-		}
+		});
 
 		originalOnBeforeRenders[ object.uuid ] = object.onBeforeRender;
 		object.onBeforeRender = onBeforeRender;
@@ -276,19 +276,19 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 
 		if ( object.material === undefined ) return;
 
-		if ( Array.isArray( object.material ) ) {
-
-			for ( var i = 0, il = object.material.length; i < il; i ++ ) {
-
-				object.material[ i ] = originalMaterials[ object.material[ i ].uuid ];
-
+		object.traverseMaterials( function( material, index, isArray ) {
+			
+			var originalMaterial = originalMaterials[ material.uuid ];
+			if ( isArray ) {
+				
+				object.material[ index ] = originalMaterial;
+				
+			} else {
+				
+				object.material = originalMaterial;
+				
 			}
-
-		} else {
-
-			object.material = originalMaterials[ object.material.uuid ];
-
-		}
+		});
 
 		object.onBeforeRender = originalOnBeforeRenders[ object.uuid ];
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -53,6 +53,27 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		return this;
 
 	},
+	
+	traverseMaterials: function( fn ){
+		
+		var material = this.material;
+		var isArray = Array.isArray( material );
+				
+		if ( isArray ) {
+					
+			for ( var i = 0; i < material.length; i ++ ) {
+				
+				fn( material[i], i ); 
+				
+			}
+			
+		} else {
+			
+			fn( material[i], -1 ); 
+			
+		}
+		
+	},
 
 	updateMorphTargets: function () {
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -63,13 +63,13 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 					
 			for ( var i = 0; i < material.length; i ++ ) {
 				
-				fn( material[i], i ); 
+				fn( material[i], i, isArray ); 
 				
 			}
 			
 		} else {
 			
-			fn( material[i], -1 ); 
+			fn( material[i], -1, isArray ); 
 			
 		}
 		


### PR DESCRIPTION
This is a small utility function that can be used to traverse the materials on a mesh. Even when it is a multimaterial mesh.  

This would simplify the code in #10960 ([code](https://github.com/gero3/three.js/blob/ba79e7ce7745f5d6e7cbda305d1d7e6302cd8f54/src/renderers/WebGLRenderer.js#L1061-L1073)) to the following:

    object.traverseMaterials( function ( material ) {
        
        initMaterial( material, scene.fog, object ); 
        
    });