### PR TITLE
CSS Renderer: supports for IE10 and IE11

### DIFF
--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -63,10 +63,7 @@ THREE.CSS3DRenderer = function () {
 
 	domElement.appendChild( cameraElement );
 
-	// Should we replace to feature detection?
-	// https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css/transformstylepreserve3d.js
-	// So far, we use `document.documentMode` to detect IE
-	var isFlatTransform = !! document.documentMode;
+	var isIE = /Trident/i.test( navigator.userAgent )
 
 	this.setClearColor = function () {};
 
@@ -147,16 +144,16 @@ THREE.CSS3DRenderer = function () {
 			epsilon( elements[ 15 ] ) +
 		')';
 
-		if ( ! isFlatTransform ) {
+		if ( isIE ) {
 
-			return 'translate(-50%,-50%)' + matrix3d;
+			return 'translate(-50%,-50%)' +
+				'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)' +
+				cameraCSSMatrix +
+				matrix3d;
 
 		}
 
-		return 'translate(-50%,-50%)' +
-			'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)' +
-			cameraCSSMatrix +
-			matrix3d;
+		return 'translate(-50%,-50%)' + matrix3d;
 
 	}
 
@@ -199,7 +196,7 @@ THREE.CSS3DRenderer = function () {
 
 				cache.objects[ object.id ] = { style: style };
 
-				if ( isFlatTransform ) {
+				if ( isIE ) {
 
 					cache.objects[ object.id ].distanceToCameraSquared = getDistanceToSquared( camera, object );
 
@@ -293,7 +290,7 @@ THREE.CSS3DRenderer = function () {
 		var style = cameraCSSMatrix +
 			'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';
 
-		if ( ! isFlatTransform && cache.camera.style !== style ) {
+		if ( cache.camera.style !== style && ! isIE ) {
 
 			cameraElement.style.WebkitTransform = style;
 			cameraElement.style.MozTransform = style;
@@ -305,7 +302,7 @@ THREE.CSS3DRenderer = function () {
 
 		renderObject( scene, camera, cameraCSSMatrix );
 
-		if ( isFlatTransform ) {
+		if ( isIE ) {
 
 			// IE10 and 11 does not support 'preserve-3d'.
 			// Thus, z-order in 3D will not work.

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -59,7 +59,6 @@ THREE.CSS3DRenderer = function () {
 
 	cameraElement.style.WebkitTransformStyle = 'preserve-3d';
 	cameraElement.style.MozTransformStyle = 'preserve-3d';
-	cameraElement.style.oTransformStyle = 'preserve-3d';
 	cameraElement.style.transformStyle = 'preserve-3d';
 
 	domElement.appendChild( cameraElement );
@@ -197,7 +196,6 @@ THREE.CSS3DRenderer = function () {
 
 				element.style.WebkitTransform = style;
 				element.style.MozTransform = style;
-				element.style.oTransform = style;
 				element.style.transform = style;
 
 				cache.objects[ object.id ] = { style: style };
@@ -278,7 +276,6 @@ THREE.CSS3DRenderer = function () {
 
 			domElement.style.WebkitPerspective = fov + 'px';
 			domElement.style.MozPerspective = fov + 'px';
-			domElement.style.oPerspective = fov + 'px';
 			domElement.style.perspective = fov + 'px';
 
 			cache.camera.fov = fov;
@@ -298,11 +295,10 @@ THREE.CSS3DRenderer = function () {
 		var style = cameraCSSMatrix +
 			'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';
 
-		if ( !isFlatTransform && cache.camera.style !== style ) {
+		if ( ! isFlatTransform && cache.camera.style !== style ) {
 
 			cameraElement.style.WebkitTransform = style;
 			cameraElement.style.MozTransform = style;
-			cameraElement.style.oTransform = style;
 			cameraElement.style.transform = style;
 
 			cache.camera.style = style;

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -298,7 +298,7 @@ THREE.CSS3DRenderer = function () {
 		var style = cameraCSSMatrix +
 			'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';
 
-		if ( cache.camera.style !== style ) {
+		if ( !isFlatTransform && cache.camera.style !== style ) {
 
 			cameraElement.style.WebkitTransform = style;
 			cameraElement.style.MozTransform = style;

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -154,8 +154,8 @@ THREE.CSS3DRenderer = function () {
 		}
 
 		return 'translate(-50%,-50%)' +
-			cameraCSSMatrix +
 			'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)' +
+			cameraCSSMatrix +
 			matrix3d;
 
 	}

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -82,7 +82,6 @@ THREE.CSS3DRenderer = function () {
 
 		_width = width;
 		_height = height;
-
 		_widthHalf = _width / 2;
 		_heightHalf = _height / 2;
 
@@ -203,14 +202,19 @@ THREE.CSS3DRenderer = function () {
 			var cachedStyle = cache.objects[ object.id ] && cache.objects[ object.id ].style;
 
 			if ( cachedStyle === undefined || cachedStyle !== style ) {
-			       
+
 				element.style.WebkitTransform = style;
 				element.style.MozTransform = style;
 				element.style.oTransform = style;
 				element.style.transform = style;
 
 				cache.objects[ object.id ] = { style: style };
-				if ( isIE ) cache.objects[ object.id ].distanceToCameraSquared = getDistanceToSquared( camera, object );
+
+				if ( isIE ) {
+
+					cache.objects[ object.id ].distanceToCameraSquared = getDistanceToSquared( camera, object );
+
+				}
 
 			}
 
@@ -270,7 +274,11 @@ THREE.CSS3DRenderer = function () {
 
 		scene.updateMatrixWorld();
 
-		if ( camera.parent === null ) camera.updateMatrixWorld();
+		if ( camera.parent === null ) {
+
+			camera.updateMatrixWorld();
+
+		}
 
 		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
 
@@ -280,7 +288,11 @@ THREE.CSS3DRenderer = function () {
 
 		renderObject( scene, camera, style );
 
-		if ( isIE ) this.zOrder( scene );
+		if ( isIE ) {
+
+			this.zOrder( scene );
+
+		}
 
 	};
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -96,7 +96,7 @@ THREE.CSS3DRenderer = function () {
 
 	function epsilon( value ) {
 
-		return Math.abs( value ) <  1e-10 ? 0 : value;
+		return Math.abs( value ) < 1e-10 ? 0 : value;
 
 	}
 
@@ -171,20 +171,20 @@ THREE.CSS3DRenderer = function () {
 				matrix.elements[ 15 ] = 1;
 
 				style = ! isFlatTransform ?
-					'translate3d(-50%,-50%,0)' +
+					'translate(-50%,-50%)' +
 					getObjectCSSMatrix( matrix ) :
-					'translate3d(-50%,-50%,0)' +
-					'translate3d(' + _widthHalf + 'px,' + _heightHalf + 'px,0)' +
+					'translate(-50%,-50%)' +
+					'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)' +
 					cameraCSSMatrix +
 					getObjectCSSMatrix( matrix );
 
 			} else {
 
 				style = ! isFlatTransform ?
-					'translate3d(-50%,-50%,0)' +
+					'translate(-50%,-50%)' +
 					getObjectCSSMatrix( object.matrixWorld ) :
-					'translate3d(-50%,-50%,0)' +
-					'translate3d(' + _widthHalf + 'px,' + _heightHalf + 'px,0)' +
+					'translate(-50%,-50%)' +
+					'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)' +
 					cameraCSSMatrix +
 					getObjectCSSMatrix( object.matrixWorld );
 
@@ -292,11 +292,11 @@ THREE.CSS3DRenderer = function () {
 		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
 
 		var cameraCSSMatrix =
-			'translateZ(' + fov + 'px) ' +
+			'translateZ(' + fov + 'px)' +
 			getCameraCSSMatrix( camera.matrixWorldInverse );
 
 		var style = cameraCSSMatrix +
-			'translate3d(' + _widthHalf + 'px,' + _heightHalf + 'px, 0)';
+			'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';
 
 		if ( cache.camera.style !== style ) {
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -63,7 +63,7 @@ THREE.CSS3DRenderer = function () {
 
 	domElement.appendChild( cameraElement );
 
-	var isIE = /Trident/i.test( navigator.userAgent )
+	var isIE = /Trident/i.test( navigator.userAgent );
 
 	this.setClearColor = function () {};
 
@@ -227,13 +227,8 @@ THREE.CSS3DRenderer = function () {
 
 		return function ( object1, object2 ) {
 
-			a.x = object1.matrixWorld.elements[ 12 ];
-			a.y = object1.matrixWorld.elements[ 13 ];
-			a.z = object1.matrixWorld.elements[ 14 ];
-
-			b.x = object2.matrixWorld.elements[ 12 ];
-			b.y = object2.matrixWorld.elements[ 13 ];
-			b.z = object2.matrixWorld.elements[ 14 ];
+			a.setFromMatrixPosition( object1.matrixWorld );
+			b.setFromMatrixPosition( object2.matrixWorld );
 
 			return a.distanceToSquared( b );
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -153,16 +153,13 @@ THREE.CSS3DRenderer = function () {
 
 		return function ( object1, object2 ) {
 
-			a.set(
-				object1.matrixWorld.elements[ 12 ],
-				object1.matrixWorld.elements[ 13 ],
-				object1.matrixWorld.elements[ 14 ]
-			);
-			b.set(
-				object2.matrixWorld.elements[ 12 ],
-				object2.matrixWorld.elements[ 13 ],
-				object2.matrixWorld.elements[ 14 ]
-			);
+			a.x = object1.matrixWorld.elements[ 12 ];
+			a.y = object1.matrixWorld.elements[ 13 ];
+			a.z = object1.matrixWorld.elements[ 14 ];
+
+			b.x = object2.matrixWorld.elements[ 12 ];
+			b.y = object2.matrixWorld.elements[ 13 ];
+			b.z = object2.matrixWorld.elements[ 14 ];
 
 			return a.distanceToSquared( b );
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -144,7 +144,7 @@ THREE.CSS3DRenderer = function () {
 			epsilon( elements[ 15 ] ) +
 		')';
 
-	};
+	}
 
 	var getDistanceToSquared = function () {
 
@@ -229,9 +229,9 @@ THREE.CSS3DRenderer = function () {
 
 		}
 
-	};
+	}
 
-	this.zOrder = function ( scene ) {
+	function zOrder ( scene ) {
 
 		var order = Object.keys( cache.objects ).sort( function ( a, b ) {
 
@@ -280,14 +280,14 @@ THREE.CSS3DRenderer = function () {
 		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
 
 		var style = 'translate3d(-50%,-50%,0) ' +
-					'translate3d(' + _widthHalf + 'px,' + _heightHalf + 'px, ' + fov  + 'px) ' +
+		            'translate3d(' + _widthHalf + 'px,' + _heightHalf + 'px, ' + fov  + 'px) ' +
 		            getCameraCSSMatrix( camera.matrixWorldInverse );
 
 		renderObject( scene, camera, style );
 
 		if ( isIE ) {
 
-			this.zOrder( scene );
+			zOrder( scene );
 
 		}
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -66,7 +66,7 @@ THREE.CSS3DRenderer = function () {
 	domElement.appendChild( cameraElement );
 
 	// Should we replace to feature detection?
-	// https://github.com/Modernizr/Modernizr/issues/762
+	// https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css/transformstylepreserve3d.js
 	var isIE = !!document.documentMode;
 
 	this.setClearColor = function () {};
@@ -262,10 +262,10 @@ THREE.CSS3DRenderer = function () {
 
 		if ( cache.camera.fov !== fov ) {
 
-			domElement.style.WebkitPerspective = fov + "px";
-			domElement.style.MozPerspective = fov + "px";
-			domElement.style.oPerspective = fov + "px";
-			domElement.style.perspective = fov + "px";
+			domElement.style.WebkitPerspective = fov + 'px';
+			domElement.style.MozPerspective = fov + 'px';
+			domElement.style.oPerspective = fov + 'px';
+			domElement.style.perspective = fov + 'px';
 
 			cache.camera.fov = fov;
 
@@ -278,8 +278,8 @@ THREE.CSS3DRenderer = function () {
 		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
 
 		var style = 'translate3d(-50%,-50%,0) ' +
-		            'translate3d(' + _widthHalf + 'px,' + _heightHalf + 'px, ' + fov  + 'px) ' +
-		            getCameraCSSMatrix( camera.matrixWorldInverse );
+			'translate3d(' + _widthHalf + 'px,' + _heightHalf + 'px,' + fov  + 'px) ' +
+			getCameraCSSMatrix( camera.matrixWorldInverse );
 
 		renderObject( scene, camera, style );
 


### PR DESCRIPTION
This PR is support for IE10 and 11 on CSS Renderer and solve issue https://github.com/mrdoob/three.js/issues/10965

The problem is that IE doesn't support `transform-style: preserve-3d` and nested elements will be rendered in "flat".

To solve it:

- Place all CSS3DObjects in flat (and each object should have world matrix transform including camera transform)
- Calc z-order for IE manually (with distance from camera)

Also, I removed `cameraElement` (no needed anymore)

![1](https://cloud.githubusercontent.com/assets/212837/23823847/6041737a-06ae-11e7-8ec1-b14e6392942c.gif)

left: IE11 with **current** CSSRenderer
center: IE11 with **modified** CSSRenderer
right Chrome with **modified** CSSRenderer