### PR TITLE
CanvasRenderer: Account for sprite rotation when computing clear area.

### DIFF
--- a/examples/js/renderers/CanvasRenderer.js
+++ b/examples/js/renderers/CanvasRenderer.js
@@ -517,7 +517,7 @@ THREE.CanvasRenderer = function ( parameters ) {
 		var scaleX = element.scale.x * _canvasWidthHalf;
 		var scaleY = element.scale.y * _canvasHeightHalf;
 
-		var dist = 0.5 * Math.sqrt( scaleX * scaleX + scaleY * scaleY ); // allow for rotated sprite
+		var dist = Math.sqrt( scaleX * scaleX + scaleY * scaleY ); // allow for rotated sprite
 		_elemBox.min.set( v1.x - dist, v1.y - dist );
 		_elemBox.max.set( v1.x + dist, v1.y + dist );
 


### PR DESCRIPTION
The previous code, implemented in #4144, assumed that `SpriteCanvasMaterial.program()` must draw inside a box of [size 1 x 1](https://github.com/mrdoob/three.js/issues/4178#issuecomment-29952578). (For example, a circle of radius 0.5.)

Now, we are allowing the box size to be [2 x 2](https://github.com/mrdoob/three.js/issues/355#issuecomment-27069154), so a material program that draws a circle of radius 1 is acceptable.

Ref: [stackoverflow issue](http://stackoverflow.com/questions/42612053/three-canvasrenderer-rendering-issue-circles-leave-a-trace-even-though-setcle)

