### PR TITLE
CSS3D Renderer: Number.EPSILON is too small for Safari

### DIFF
--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -95,7 +95,7 @@ THREE.CSS3DRenderer = function () {
 
 	function epsilon( value ) {
 
-		return Math.abs( value ) < Number.EPSILON ? 0 : value;
+		return Math.abs( value ) < 1e-10 ? 0 : value;
 
 	}
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -95,6 +95,8 @@ THREE.CSS3DRenderer = function () {
 
 	function epsilon( value ) {
 
+		// Number.EPSILON is too small for Safari.
+		// Use small number instead
 		return Math.abs( value ) < 1e-10 ? 0 : value;
 
 	}


### PR DESCRIPTION
While Im working on [another PR](https://github.com/mrdoob/three.js/pull/10988), I found extra problem.

It seems, `Number.EPSILON` is too small for Safari and cannot recognise the matrix in CSS.

dev
![screen shot 2017-03-14 at 2 39 17 pm](https://cloud.githubusercontent.com/assets/212837/23887881/d0e1e6c6-08c7-11e7-8046-9e229edbaf58.png)

my branch
![screen shot 2017-03-14 at 2 39 29 pm](https://cloud.githubusercontent.com/assets/212837/23887882/d0e44628-08c7-11e7-8e9a-a8d6dcd3a7d2.png)

dev
![screen shot 2017-03-14 at 3 04 16 pm](https://cloud.githubusercontent.com/assets/212837/23887885/d65477c2-08c7-11e7-9679-827b20f33ac4.png)

my branch
![screen shot 2017-03-14 at 3 04 05 pm](https://cloud.githubusercontent.com/assets/212837/23887884/d6389818-08c7-11e7-9d07-87e362a086d1.png)