### PR TITLE
Fix FBXLoader2 animation bug

### DIFF
--- a/examples/js/loaders/FBXLoader2.js
+++ b/examples/js/loaders/FBXLoader2.js
@@ -2954,7 +2954,7 @@
 
 					}
 
-					for ( var frame = 0; frame < stack.frames; frame ++ ) {
+					for ( var frame = 0; frame <= stack.frames; frame ++ ) {
 
 						for ( var bonesIndex = 0, bonesLength = bones.length; bonesIndex < bonesLength; ++ bonesIndex ) {
 


### PR DESCRIPTION
last frame in animation was ignored. This is a fix for it.