### PR TITLE
Remove usage of THREE.ImageUtils.loadTexture

### DIFF
--- a/examples/js/loaders/AssimpLoader.js
+++ b/examples/js/loaders/AssimpLoader.js
@@ -966,8 +966,7 @@
 				path = path.substr( path.lastIndexOf( "/" ) + 1 );
 
 			}
-
-			return THREE.ImageUtils.loadTexture( baseURL + path );
+			return ( new TextureLoader() ).load( baseURL + path );
 
 		};
 


### PR DESCRIPTION
Don't use deprecated functions in assimpLoader.  