### PR TITLE
Implement Transferable object

### DIFF
--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -133,7 +133,7 @@ THREE.CTMLoader.prototype.load = function( url, callback, parameters ) {
 
 					};
 
-					worker.postMessage( { "data": binaryData, "offsets": offsets } );
+					worker.postMessage( { "data": binaryData, "offsets": offsets }, [binaryData.buffer] );
 
 				} else {
 

--- a/examples/js/loaders/ctm/CTMWorker.js
+++ b/examples/js/loaders/ctm/CTMWorker.js
@@ -9,7 +9,7 @@ self.onmessage = function( event ) {
 		var stream = new CTM.Stream( event.data.data );
 		stream.offset = event.data.offsets[ i ];
 
-		files[ i ] = new CTM.File( stream );
+		files[ i ] = new CTM.File( stream, [event.data.data.buffer] );
 
 	}
 


### PR DESCRIPTION
"The Transferable interface represents an object that can be transfered between different execution contexts, like the main thread and Web workers."
from https://developer.mozilla.org/en-US/docs/Web/API/Transferable

In my tests, original code took 5.4 ms to transfer 3.46 MB from main thread to the Worker.
This simple fix brings that to 0.1 ms for the same file.
