### PR TITLE
utils: Fixed regression in IE/Edge with PR #11002

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,14 +1,10 @@
 function arrayMin( array ) {
 
-	if ( array.length === 0 ) {
-
-		return Infinity;
-
-	}
+	if ( array.length === 0 ) return Infinity;
 
 	var min = array[ 0 ];
 
-	for ( var i = 1; i < array.length; ++ i ) {
+	for ( var i = 1, length = array.length; i < length; ++ i ) {
 
 		if ( array[ i ] < min ) {
 
@@ -24,15 +20,11 @@ function arrayMin( array ) {
 
 function arrayMax( array ) {
 
-	if ( array.length === 0 ) {
-
-		return - Infinity;
-
-	}
+	if ( array.length === 0 ) return - Infinity;
 
 	var max = array[ 0 ];
 
-	for ( var i = 1; i < array.length; ++ i ) {
+	for ( var i = 1, length = array.length; i < length; ++ i ) {
 
 		if ( array[ i ] > max ) {
 

--- a/test/unit/src/utils.js
+++ b/test/unit/src/utils.js
@@ -9,7 +9,7 @@ QUnit.test( 'arrayMax' , function( assert ) {
 	assert.equal( THREE.arrayMax( [] ), - Infinity );
 	assert.equal( THREE.arrayMax( [ 5 ] ), 5 );
 	assert.equal( THREE.arrayMax( [ 1, 5, 10 ] ), 10 );
-	assert.equal( THREE.arrayMax( [ 5, 1, 10 ] ), 10 );
+	assert.equal( THREE.arrayMax( [ 1, 10, 5 ] ), 10 );
 	assert.equal( THREE.arrayMax( [ 10, 5, 1 ] ), 10 );
 
 });


### PR DESCRIPTION
subsystem: utils

Fixed regression in IE 11 and Microsoft Edge browsers. It was caused due
to a poor optimization in Microsoft browsers while accessing
Array#length attribute in a for condition.

Confirmed that there wasn't any performance change for Node.js, Google Chrome or Firefox. I still need to confirm that the regression was fixed for Microsoft browsers with script bellow.