### PR TITLE
Use 2D noise in webgl_gpgpu_water demo

### DIFF
--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -421,7 +421,7 @@
 					var mult = 0.025;
 					var r = 0;
 					for ( var i = 0; i < 15; i++ ) {
-						r += multR * simplex.noise3d( x * mult, y * mult, z * mult );
+						r += multR * simplex.noise( x * mult, y * mult );
 						multR *= 0.53 + 0.025 * i;
 						mult *= 1.25;
 					}


### PR DESCRIPTION
Using 3D or higher simplex noise (for example, using 3D simplex noise in the demo) may be problematic because of [U.S. 6067776](https://www.google.com/patents/US6867776).  (I am not a lawyer.)  Fortunately, the demo doesn't appear to rely on 3D noise and can just use 2D noise instead, which I have done here. Alternatively, the demo can use OpenSimplex noise instead, but that seems too considerable an effort for me to propose for now.