### PR TITLE
Docs: Correct wrong information about camera.getWorldDirection()

### DIFF
--- a/docs/api/cameras/Camera.html
+++ b/docs/api/cameras/Camera.html
@@ -71,9 +71,13 @@
 
 		<h3>[method:Vector3 getWorldDirection]( [page:Vector3 optionalTarget] )</h3>
 		<div>
-		Returns a vector representing the direction in which the camera is looking,
-		in world space. If the [page:Vector3 optionalTarget] is set, returns a vector representing the direction
-		from the camera's position to the [page:Vector3 optionalTarget].
+		Returns a [page:Vector3] representing the world space direction in which the camera is looking.<br /><br />
+		
+		Note: This is not the camera’s positive, but its negative z-axis, in contrast to
+		[page:Object3D.getWorldDirection getWorldDirection] of the base class (Object3D).<br /><br />
+		
+		If an [page:Vector3 optionalTarget] vector is specified, the result will be copied into this vector
+		(which can be reused in this way), otherwise a new vector will be created.
 		</div>
 
 		<h3>[method:null lookAt]( [page:Vector3 target] )</h3>


### PR DESCRIPTION
The optional parameter of this method does **not** affect the calculation of the direction (as the current description says).

It is only a reusable container for the result.

https://github.com/mrdoob/three.js/blob/dev/src/cameras/Camera.js#L40-#L54
