### PR TITLE
Issue-#9905 objectloader parse fonts

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -122,7 +122,7 @@ Object.assign( ObjectLoader.prototype, {
 
 	},
 
-    parse: function ( json, onLoad ) {
+    	parse: function ( json, onLoad ) {
 
 		var fonts = this.parseFonts( json.fonts, function () {
 
@@ -163,34 +163,34 @@ Object.assign( ObjectLoader.prototype, {
 
 	},
 
-    parseFonts: function ( json, onLoad ) {
+    	parseFonts: function ( json, onLoad ) {
 
-        var scope = this;
-        var fonts = {};
+        	var scope = this;
+        	var fonts = {};
 
-        if ( json !== undefined && json.length > 0 ) {
+        	if ( json !== undefined && json.length > 0 ) {
 
-            var manager = new LoadingManager( onLoad );
+            		var manager = new LoadingManager( onLoad );
 
-            var loader = new FontLoader( manager );
+            		var loader = new FontLoader( manager );
 
-            for ( var i = 0, l = json.length; i < l; i++ ) {
+            		for ( var i = 0, l = json.length; i < l; i++ ) {
 
-                var font = json[i];
+                		var font = json[i];
 
-                if ( font.glyphs.hasOwnProperty( 'glyphs' )) {
+                		if ( font.glyphs.hasOwnProperty( 'glyphs' )) {
 
-                    fonts[ font.uuid ] = loader.parse( font.glyphs );
+                    		fonts[ font.uuid ] = loader.parse( font.glyphs );
 
-                }
+                		}
 
-            }
+            		}
 
-        }
+        	}
 
-        return fonts;
+        	return fonts;
 
-    },
+    	},
 
 	parseGeometries: function ( json, fonts ) {
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -159,7 +159,7 @@ Object.assign( ObjectLoader.prototype, {
 
 	},
 	
-	parseFonts: function ( json ) {
+	parseFonts: function ( json, onLoad ) {
 		
 		var fonts = {};
 		

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -162,16 +162,18 @@ Object.assign( ObjectLoader.prototype, {
 		
 		var fonts = {};
 		
-		if ( json !== undefined ) {
+		if ( json !== undefined && json.length > 0 ) {
 			
-			var fontLoader = new FontLoader();
+			var manager = new LoadingManager( onLoad );
+			
+			var fontLoader = new FontLoader( manager );
 			
 			for ( var i = 0, l = json.length; i < l; i ++ ) {
 				
 				var font;
 				var data = json[ i ];
 				
-				//
+				font = fontLoader.parse( data );
 				
 				font.uuid = data.uuid;
 				
@@ -312,6 +314,16 @@ Object.assign( ObjectLoader.prototype, {
 							data.thetaLength
 						);
 
+						break;
+						
+					case 'TextGeometry':
+					case 'TextBufferGeometry':
+					
+						geometry = new Geometries[ data.type ](
+							data.text,
+							data.parameters
+						);
+					
 						break;
 
 					case 'TorusGeometry':

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -50,6 +50,7 @@ import { MaterialLoader } from './MaterialLoader';
 import { BufferGeometryLoader } from './BufferGeometryLoader';
 import { JSONLoader } from './JSONLoader';
 import { FileLoader } from './FileLoader';
+import { FontLoader } from './FontLoader';
 import * as Geometries from '../geometries/Geometries';
 
 /**
@@ -173,7 +174,7 @@ Object.assign( ObjectLoader.prototype, {
 				var font;
 				var data = json[ i ];
 				
-				font = fontLoader.parse( data );
+				font = fontLoader.parse( data.glyphs ); //TODO, extend to file resource someFont.json
 				
 				font.uuid = data.uuid;
 				
@@ -318,6 +319,8 @@ Object.assign( ObjectLoader.prototype, {
 						
 					case 'TextGeometry':
 					case 'TextBufferGeometry':
+					
+						data.parameters.font = fonts[ data.parameters.glyphs ];
 					
 						geometry = new Geometries[ data.type ](
 							data.text,

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -123,7 +123,7 @@ Object.assign( ObjectLoader.prototype, {
 	},
 
 	parse: function ( json, onLoad ) {
-		
+
         var fonts = this.parseFonts( json.fonts, function () {
 
             if ( onLoad !== undefined ) onLoad( object );
@@ -131,10 +131,10 @@ Object.assign( ObjectLoader.prototype, {
         } );
 
 		var geometries = this.parseGeometries( json.geometries, fonts, function () {
-			
-			if ( onLoad !== undefined ) onLoad( object );			
-			
-		} );
+
+            if ( onLoad !== undefined ) onLoad( object );
+
+        });
 
 		var images = this.parseImages( json.images, function () {
 
@@ -162,35 +162,35 @@ Object.assign( ObjectLoader.prototype, {
 		return object;
 
 	},
-	
-	parseFonts: function ( json, onLoad ) {
+
+    parseFonts: function ( json, onLoad ) {
 
         var scope = this;
         var fonts = {};
 
 		if ( json !== undefined && json.length > 0 ) {
-			
-			var manager = new LoadingManager( onLoad );
-			
+
+            var manager = new LoadingManager( onLoad );
+
             var loader = new FontLoader( manager );
-			
-			for ( var i = 0, l = json.length; i < l; i ++ ) {
-				
-				var font = json[ i ];
+
+            for ( var i = 0, l = json.length; i < l; i++ ) {
+
+                var font = json[i];
 
                 if ( font.glyphs.hasOwnProperty( 'glyphs' )) {
 
                     fonts[ font.uuid ] = loader.parse( font.glyphs );
 
                 }
-				
-			}
-			
-		}
+
+            }
+
+        }
 
 		return fonts;
-		
-	},
+
+    },
 
 	parseGeometries: function ( json, fonts ) {
 
@@ -318,18 +318,18 @@ Object.assign( ObjectLoader.prototype, {
 						);
 
 						break;
-						
-					case 'TextGeometry':
+
+                    case 'TextGeometry':
 					case 'TextBufferGeometry':
-					
-						data.parameters.font = fonts[ data.parameters.glyphs ];
-					
-						geometry = new Geometries[ data.type ](
+
+                        data.parameters.font = fonts[data.parameters.glyphs];
+
+                        geometry = new Geometries[data.type](
 							data.text,
 							data.parameters
 						);
-					
-						break;
+
+                        break;
 
 					case 'TorusGeometry':
 					case 'TorusBufferGeometry':

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -151,7 +151,7 @@ Object.assign( ObjectLoader.prototype, {
 
 			object.animations = this.parseAnimations( json.animations );
 
-		}
+        }
 
 		if ( json.images === undefined || json.images.length === 0 ) {
 
@@ -168,20 +168,6 @@ Object.assign( ObjectLoader.prototype, {
         var scope = this;
         var fonts = {};
 
-        function loadFont(url) {
-
-            scope.manager.itemStart(url);
-
-            return loader.load(url, function ( response ) {
-
-                scope.manager.itemEnd(url);
-
-                //setFont(response);
-
-            });
-
-        }
-
 		if ( json !== undefined && json.length > 0 ) {
 			
 			var manager = new LoadingManager( onLoad );
@@ -192,20 +178,16 @@ Object.assign( ObjectLoader.prototype, {
 				
 				var font = json[ i ];
 
-                if ( font.glyphs.hasOwnProperty( 'glyphs' ) ) {
+                if ( font.glyphs.hasOwnProperty( 'glyphs' )) {
 
                     fonts[ font.uuid ] = loader.parse( font.glyphs );
-
-                } else {
-
-                    fonts[font.uuid] = loader.load(font.glyphs);
 
                 }
 				
 			}
 			
 		}
-		
+
 		return fonts;
 		
 	},

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -122,8 +122,14 @@ Object.assign( ObjectLoader.prototype, {
 	},
 
 	parse: function ( json, onLoad ) {
+		
+		var fonts = this.parseFonts( json.fonts );
 
-		var geometries = this.parseGeometries( json.geometries );
+		var geometries = this.parseGeometries( json.geometries, fonts, function () {
+			
+			if ( onLoad !== undefined ) onLoad( object );			
+			
+		} );
 
 		var images = this.parseImages( json.images, function () {
 
@@ -151,8 +157,37 @@ Object.assign( ObjectLoader.prototype, {
 		return object;
 
 	},
+	
+	parseFonts: function ( json ) {
+		
+		var fonts = {};
+		
+		if ( json !== undefined ) {
+			
+			var fontLoader = new FontLoader();
+			
+			for ( var i = 0, l = json.length; i < l; i ++ ) {
+				
+				var font;
+				var data = json[ i ];
+				
+				//
+				
+				font.uuid = data.uuid;
+				
+				if ( data.name !== undefined ) font.name = data.name;
 
-	parseGeometries: function ( json ) {
+				fonts[ data.uuid ] = font;
+				
+			}
+			
+		}
+		
+		return fonts;
+		
+	},
+
+	parseGeometries: function ( json, fonts ) {
 
 		var geometries = {};
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -122,7 +122,7 @@ Object.assign( ObjectLoader.prototype, {
 
 	},
 
-	parse: function ( json, onLoad ) {
+    parse: function ( json, onLoad ) {
 
         var fonts = this.parseFonts( json.fonts, function () {
 
@@ -130,7 +130,7 @@ Object.assign( ObjectLoader.prototype, {
 
         } );
 
-		var geometries = this.parseGeometries( json.geometries, fonts, function () {
+        var geometries = this.parseGeometries( json.geometries, fonts, function () {
 
             if ( onLoad !== undefined ) onLoad( object );
 
@@ -168,7 +168,7 @@ Object.assign( ObjectLoader.prototype, {
         var scope = this;
         var fonts = {};
 
-		if ( json !== undefined && json.length > 0 ) {
+        if ( json !== undefined && json.length > 0 ) {
 
             var manager = new LoadingManager( onLoad );
 
@@ -188,7 +188,7 @@ Object.assign( ObjectLoader.prototype, {
 
         }
 
-		return fonts;
+        return fonts;
 
     },
 
@@ -320,14 +320,14 @@ Object.assign( ObjectLoader.prototype, {
 						break;
 
                     case 'TextGeometry':
-					case 'TextBufferGeometry':
+                    case 'TextBufferGeometry':
 
                         data.parameters.font = fonts[data.parameters.glyphs];
 
                         geometry = new Geometries[data.type](
-							data.text,
-							data.parameters
-						);
+                            data.text,
+                            data.parameters
+                        );
 
                         break;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -124,17 +124,17 @@ Object.assign( ObjectLoader.prototype, {
 
     parse: function ( json, onLoad ) {
 
-        var fonts = this.parseFonts( json.fonts, function () {
+		var fonts = this.parseFonts( json.fonts, function () {
 
-            if ( onLoad !== undefined ) onLoad( object );
+			if ( onLoad !== undefined ) onLoad( object );
 
-        } );
+		} );
 
-        var geometries = this.parseGeometries( json.geometries, fonts, function () {
+		var geometries = this.parseGeometries( json.geometries, fonts, function () {
 
-            if ( onLoad !== undefined ) onLoad( object );
+			if ( onLoad !== undefined ) onLoad( object );
 
-        });
+		});
 
 		var images = this.parseImages( json.images, function () {
 
@@ -151,7 +151,7 @@ Object.assign( ObjectLoader.prototype, {
 
 			object.animations = this.parseAnimations( json.animations );
 
-        }
+		}
 
 		if ( json.images === undefined || json.images.length === 0 ) {
 
@@ -319,17 +319,19 @@ Object.assign( ObjectLoader.prototype, {
 
 						break;
 
-                    case 'TextGeometry':
-                    case 'TextBufferGeometry':
+					case 'TextGeometry':
+					case 'TextBufferGeometry':
 
-                        data.parameters.font = fonts[data.parameters.glyphs];
+						data.parameters.font = fonts[data.parameters.glyphs];
 
-                        geometry = new Geometries[data.type](
-                            data.text,
-                            data.parameters
-                        );
+						geometry = new Geometries[data.type](
 
-                        break;
+							data.text,
+							data.parameters
+
+						);
+
+						break;
 
 					case 'TorusGeometry':
 					case 'TorusBufferGeometry':


### PR DESCRIPTION
This PR is a first attempt to resolve issue #9905, namely, parsing fonts in order to be able to load `TextGeometry` through `ObjectLoader`.  This only parses an embedded js object in the form of glyphs.  These can be attained by running a font through: https://gero3.github.io/facetype.js/  A subsequent version should add loading the json from a path.

An example json file which has been tested to work can be found here: https://gist.github.com/fraguada/46ffef2a262d7ebc5ab4170a436234f9