### PR TITLE
Prettyprint matrices to the console

### DIFF
--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -266,7 +266,26 @@ Object.assign( Matrix3.prototype, {
 
 		return array;
 
-	}
+	},
+    
+    log: function ( decimals ) {
+            
+        Matrix4.prototype.log.call( this, decimals );
+
+    },
+
+    _consoleOutput: function ( color1, color2, format ) {
+
+        for ( var i = 0; i < 3; i ++ ) {    
+
+            console.log( '%c'    + format ( 0 + i ) + 
+                         '%c %c' + format ( 3 + i ) + 
+                         '%c %c' + format ( 6 + i ),
+                         color1, color2, color1, color2, color1 );
+
+        }                
+
+    }
 
 } );
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -908,7 +908,78 @@ Object.assign( Matrix4.prototype, {
 
 		return array;
 
-	}
+	},
+    
+    log: function ( decimals ) {    
+
+        var elementsData = [];
+        var maxLength = 0;
+
+        var white = 'background: #fff';
+        var grey = 'background: #ddd; color: #000';
+
+        for ( var i = 0; i < this.elements.length; i ++ ) {
+
+            var element = this.elements[ i ];
+            var elementString;
+            var elementLength;
+            var elementData;
+
+            if ( decimals === undefined || decimals <0 || decimals > 20) {
+
+                elementString = element.toString();
+
+            } else {
+
+                elementString = element.toFixed( decimals );
+
+            }
+
+            elementLength = elementString.length;
+
+            elementData = { string: elementString, length: elementLength };
+
+            elementsData.push ( elementData );
+
+            maxLength = Math.max( elementLength, maxLength );
+
+        };
+
+        function formatCell ( index ) {
+
+            var currentElement = elementsData[index];
+            var str = ' ';
+            var spaces = maxLength - currentElement.length;
+
+            for ( var i = 0; i < spaces; i ++ ) {
+
+                str += ' ';
+
+            }
+
+            return str + currentElement.string + ' ';
+
+        }
+
+        console.log( '\n', this );
+
+        this._consoleOutput( grey, white, formatCell );
+
+    },
+
+    _consoleOutput: function( color1, color2, formatCell ) {
+
+        for ( var i = 0; i < 4; i ++ ) {    
+
+            console.log ( '%c'    + formatCell( 0 + i ) + 
+                          '%c %c' + formatCell( 4 + i ) + 
+                          '%c %c' + formatCell( 8 + i ) + 
+                          '%c %c' + formatCell( 12 + i ),
+                          color1, color2, color1, color2, color1, color2, color1 );
+
+        }
+
+    }
 
 } );
 


### PR DESCRIPTION
For my own three.js studies I created this little matrix.log() method, since I missed a possibility of lucidly outputting matrices to the console for debugging, learning and educational purposes.
 
Perhaps something similar could be integrated into three.js? But maybe there is a more elegant way?

Usage: 

- Calling `matrix.log()` without parameter will display the elements arranged in a square, retaining the same precision you would get calling `console.log(matrix.elements)`, - as shown below with a very ugly (nonsense) matrix. 
- By passing a parameter you can limit the number of decimals - as shown below with the same matrix. 
- Same usage for Matrix4 and Matrix3.

![matrix_log](https://cloud.githubusercontent.com/assets/5700294/24081747/95598eec-0cb9-11e7-944b-71cc3ddc4480.PNG)
It doesn’t work in Edge, but I think that doesn’t matter in the case of a developer tool?

