### PR TITLE
Docs: Fixed example in WebGLShader.html

### DIFF
--- a/docs/api/renderers/webgl/WebGLShader.html
+++ b/docs/api/renderers/webgl/WebGLShader.html
@@ -17,8 +17,8 @@
 		<code>
 		var gl = renderer.context;
 
-		var glVertexShader = new THREE.WebGLShader( gl, gl.VERTEX_SHADER, vertexSourceCode );
-		var glFragmentShader = new THREE.WebGLShader( gl, gl.FRAGMENT_SHADER, fragmentSourceCode );
+		var glVertexShader = WebGLShader( gl, gl.VERTEX_SHADER, vertexSourceCode );
+		var glFragmentShader = WebGLShader( gl, gl.FRAGMENT_SHADER, fragmentSourceCode );
 
 		var program = gl.createProgram();
 
@@ -30,16 +30,17 @@
 
 		<h2>Function</h2>
 
-		<h3>[page:WebGLShader objects]([page:WebGLContext gl], [page:WebGLEnum type], [page:String source])</h3>
+		<h3>[page:WebGLShader]( [page:WebGLContext gl], [page:WebGLEnum type], [page:String source] )</h3>
 
 		<div>
-		gl -- The current WebGL context
-		type -- The WebGL type, either gl.VERTEX_SHADER or gl.FRAGMENT_SHADER
+		gl -- The current WebGL context<br />
+		type -- The WebGL type, either gl.VERTEX_SHADER or gl.FRAGMENT_SHADER<br />
 		source -- The source code for the shader
 		</div>
 		<div>
-		This will compile an individual shader, but won't link it to be a complete [page:WebGLProgram]. Note: this
-		is a function so the new operator should not be used.
+		This will compile an individual shader, but won't link it to be a complete [page:WebGLProgram].<br /><br />
+		
+		Note: this is a function, so the *new* operator should not be used.
 		</div>
 
 		<h2>Source</h2>


### PR DESCRIPTION
WebGLShader (though upper case) is not designed to be used as a constructor.

`new THREE.WebGLShader` in the example wouldn’t work.

(+ Some additional adjustments)
