### PR TITLE
Change metalness uniform default value from 0 to 0.5

### DIFF
--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -87,7 +87,7 @@ var ShaderLib = {
 			{
 				emissive: { value: new Color( 0x000000 ) },
 				roughness: { value: 0.5 },
-				metalness: { value: 0 },
+				metalness: { value: 0.5 },
 				envMapIntensity: { value: 1 } // temporary
 			}
 		] ),


### PR DESCRIPTION
This PR changes `metalness` uniform default value from 0 to 0.5.
0.5 is `MeshStandardMaterial.metalness` default value.
I think it'd be better (non-confusing) if the default values are same.