### PR TITLE
Allow commenting out #includes

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -152,7 +152,7 @@ function replaceLightNums( string, parameters ) {
 
 function parseIncludes( string ) {
 
-	var pattern = /#include +<([\w\d.]+)>/g;
+	var pattern = /^\s*#include +<([\w\d.]+)>/gm;
 
 	function replace( match, include ) {
 


### PR DESCRIPTION
Fixes #11037

This makes it possible to comment out the includes in a shader program. 