### PR TITLE
docs/index.html: Prevent the browser from flooding the DOM with empty tags

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -350,7 +350,10 @@
 						nameCategoryMap[ j ].element.parentElement.classList.remove( 'filtered' );
 						var str = nameCategoryMap[ j ].name;
 						for( var i = 0; i < res.length; i++ ) {
-							str = str.replace( res[ i ], '<b>' + res[ i ] + '</b>' );
+							var resI = res[ i ];
+							if ( resI !== '' ) {
+							    str = str.replace( resI, '<b>' + resI + '</b>' );
+							}
 						}
 						nameCategoryMap[ j ].element.innerHTML = str;
 					} else {


### PR DESCRIPTION
A little fix for this issue:

On pageload of https://threejs.org/docs/, and each time the search field is emptied, about 4000 empty `<b>`-tags get appended to the DOM – harmless, but a little ugly ;)

Screenshot Chrome (the same in Edge; but Firefox seems to limit the empty tags by itself):

![btags](https://cloud.githubusercontent.com/assets/5700294/24255833/d1c02726-0fe6-11e7-83ab-5cabb81b7c74.PNG)

