### PR TITLE
Not update renderer property for ArrayCamera render

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1232,12 +1232,6 @@ function WebGLRenderer( parameters ) {
 		state.buffers.depth.setMask( true );
 		state.buffers.color.setMask( true );
 
-		if ( camera.isArrayCamera && camera.enabled ) {
-
-			_this.setScissorTest( false );
-
-		}
-
 		camera.onAfterRender( _this );
 
 		// _gl.finish();
@@ -1414,15 +1408,19 @@ function WebGLRenderer( parameters ) {
 
 					var camera2 = cameras[ j ];
 					var bounds = camera2.bounds;
-					_this.setViewport(
-						bounds.x * _width * _pixelRatio, bounds.y * _height * _pixelRatio,
-						bounds.z * _width * _pixelRatio, bounds.w * _height * _pixelRatio
+					state.viewport(
+						_currentViewport.set(
+							bounds.x * _width * _pixelRatio, bounds.y * _height * _pixelRatio,
+							bounds.z * _width * _pixelRatio, bounds.w * _height * _pixelRatio
+						)
 					);
-					_this.setScissor(
-						bounds.x * _width * _pixelRatio, bounds.y * _height * _pixelRatio,
-						bounds.z * _width * _pixelRatio, bounds.w * _height * _pixelRatio
+					state.scissor(
+						_currentScissor.set(
+							bounds.x * _width * _pixelRatio, bounds.y * _height * _pixelRatio,
+							bounds.z * _width * _pixelRatio, bounds.w * _height * _pixelRatio
+						)
 					);
-					_this.setScissorTest( true );
+					state.setScissorTest( true );
 					renderObject( object, scene, camera2, geometry, material, group );
 
 				}


### PR DESCRIPTION
This PR provides proper property update for rendering with `ArrayCamera` and
enables Post Processing with VR.

If I'm right, we shouldn't update `WebGLRenderer` properties for rendering with `ArrayCamera`
because it affects next render call. Updating state is good enough.

For example, assume we render with `EffectComposer`,
first pass is render pass with `WebVRCamera(ArrayCamera)` and
second pass is shader pass  with `OrthographicCamera`.

The `WebGLRenderer` viewport/scissor property update of first render pass affects
the second shader pass so it results in rendering left/right into right side.

Current
![image](https://cloud.githubusercontent.com/assets/7637832/24281163/a4a28d9c-1013-11e7-8f46-4ffeb35cd008.png)

With this change
![image](https://cloud.githubusercontent.com/assets/7637832/24281210/0b7f914a-1014-11e7-9dbe-4fcbe47cbfc5.png)
