### PR TITLE
Curve: Refactoring

### DIFF
--- a/docs/api/extras/core/Curve.html
+++ b/docs/api/extras/core/Curve.html
@@ -11,13 +11,9 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-		An abstract base class for creating a curve object that contains methods for interpolation.
-		For an array of Curves see [page:CurvePath].
+		An abstract base class for creating a [name] object that contains methods for interpolation.
+		For an array of [name]s see [page:CurvePath].
 		</div>
-
-		<h2>Examples</h2>
-
-		<h3>[example:webgl_geometry_extrude_splines geometry / extrude / splines ]</h3>
 
 		<h2>Constructor</h2>
 
@@ -27,26 +23,31 @@
 		This constructor creates a new [name].
 		</div>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Integer arcLengthDivisions]</h3>
+		<div>This value determines the amount of divisions when calculating the cumulative segment lengths of a curve via [page:.getLengths].
+			To ensure precision when using methods like [page:.getSpacedPoints], it is recommended to increase [page:.arcLengthDivisions] if the curve is very large. Default is 200.</div>
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector getPoint]( [page:Number t] )</h3>
-		<div>Returns a vector for point t of the curve where t is between 0 and 1. Must be implemented in the extending class.</div>
+		<h3>[method:Vector getPoint]( [page:Float t] )</h3>
+		<div>Returns a vector for point t of the curve where t is between 0 and 1. Must be implemented in the extending curve.</div>
 
-		<h3>[method:Vector getPointAt]( [page:Number u] )</h3>
+		<h3>[method:Vector getPointAt]( [page:Float u] )</h3>
 		<div>
 			Returns a vector for point at a relative position in curve according to arc length.
 			u is in the range [0, 1].
 		</div>
 
-		<h3>[method:Array getPoints]( [page:integer divisions] )</h3>
+		<h3>[method:Array getPoints]( [page:Integer divisions] )</h3>
 		<div>
 			divisions -- number of pieces to divide the curve into. Default is *5*.<br /><br />
 
 			Returns a set of divisions + 1 points using getPoint( t ).
 		</div>
 
-		<h3>[method:Array getSpacedPoints]( divisions )</h3>
+		<h3>[method:Array getSpacedPoints]( [page:Integer divisions] )</h3>
 		<div>
 			divisions -- number of pieces to divide the curve into. Default is *5*.<br /><br />
 
@@ -56,33 +57,33 @@
 		<h3>[method:Float getLength]()</h3>
 		<div>Get total curve arc length.</div>
 
-		<h3>[method:Array getLengths]( divisions )</h3>
+		<h3>[method:Array getLengths]( [page:Integer divisions] )</h3>
 		<div>Get list of cumulative segment lengths.</div>
 
 		<h3>[method:null updateArcLengths]()</h3>
 		<div>Update the cumlative segment distance cache.</div>
 
-		<h3>[method:Float getUtoTmapping]( [page:Number u], distance )</h3>
+		<h3>[method:Float getUtoTmapping]( [page:Float u], [page:Float distance] )</h3>
 		<div>
-			Given u in the range ( 0 .. 1 ), returns [page:Number t] also in the range ( 0 .. 1 ).
+			Given u in the range ( 0 .. 1 ), returns [page:Float t] also in the range ( 0 .. 1 ).
 			u and t can then be used to give you points which are equidistant from the ends of the curve,
 			using [page:.getPoint].
 		 </div>
 
-		<h3>[method:Vector getTangent]( [page:Number t] )</h3>
+		<h3>[method:Vector getTangent]( [page:Float t] )</h3>
 		<div>
-			Returns a unit vector tangent at t. If the subclassed curve do not implement its
-			tangent derivation, 2 points a small delta apart will be used to find its gradient
-			which seems to give a reasonable approximation
+			Returns a unit vector tangent at t. If the derived curve does not implement its
+			tangent derivation, two points a small delta apart will be used to find its gradient
+			which seems to give a reasonable approximation.
 		</div>
 
-		<h3>[method:Vector getTangentAt]( [page:Number u] )</h3>
+		<h3>[method:Vector getTangentAt]( [page:Float u] )</h3>
 		<div>
 			Returns tangent at a point which is equidistant to the ends of the curve from the
 			point given in [page:.getTangent].
 		</div>
 
-		<h3>[method:Object computeFrenetFrames]( segments, closed )</h3>
+		<h3>[method:Object computeFrenetFrames]( [page:Integer segments], [page:Boolean closed] )</h3>
 		<div>
 		Generates the Frenet Frames. Used in geometries like [page:TubeGeometry] or [page:ExtrudeGeometry].
 		</div>

--- a/examples/js/CurveExtras.js
+++ b/examples/js/CurveExtras.js
@@ -15,7 +15,11 @@
 
 	// GrannyKnot
 
-	function GrannyKnot() {}
+	function GrannyKnot() {
+
+		THREE.Curve.call( this );
+
+	}
 
 	GrannyKnot.prototype = Object.create( THREE.Curve.prototype );
 	GrannyKnot.prototype.constructor = GrannyKnot;
@@ -35,6 +39,8 @@
 	// HeartCurve
 
 	function HeartCurve( s ) {
+
+		THREE.Curve.call( this );
 
 		this.scale = ( s === undefined ) ? 5 : s;
 
@@ -59,6 +65,8 @@
 
 	function VivianiCurve( radius ) {
 
+		THREE.Curve.call( this );
+
 		this.radius = radius;
 
 	}
@@ -81,7 +89,11 @@
 
 	// KnotCurve
 
-	function KnotCurve() {}
+	function KnotCurve() {
+
+		THREE.Curve.call( this );
+
+	}
 
 	KnotCurve.prototype = Object.create( THREE.Curve.prototype );
 	KnotCurve.prototype.constructor = KnotCurve;
@@ -103,7 +115,11 @@
 
 	// HelixCurve
 
-	function HelixCurve() {}
+	function HelixCurve() {
+
+		THREE.Curve.call( this );
+
+	}
 
 	HelixCurve.prototype = Object.create( THREE.Curve.prototype );
 	HelixCurve.prototype.constructor = HelixCurve;
@@ -127,6 +143,8 @@
 
 	function TrefoilKnot( s ) {
 
+		THREE.Curve.call( this );
+
 		this.scale = ( s === undefined ) ? 10 : s;
 
 	}
@@ -149,6 +167,8 @@
 	// TorusKnot
 
 	function TorusKnot( s ) {
+
+		THREE.Curve.call( this );
 
 		this.scale = ( s === undefined ) ? 10 : s;
 
@@ -176,6 +196,8 @@
 
 	function CinquefoilKnot( s ) {
 
+		THREE.Curve.call( this );
+
 		this.scale = ( s === undefined ) ? 10 : s;
 
 	}
@@ -201,6 +223,8 @@
 	// TrefoilPolynomialKnot
 
 	function TrefoilPolynomialKnot( s ) {
+
+		THREE.Curve.call( this );
 
 		this.scale = ( s === undefined ) ? 10 : s;
 
@@ -232,6 +256,8 @@
 
 	function FigureEightPolynomialKnot( s ) {
 
+		THREE.Curve.call( this );
+
 		this.scale = ( s === undefined ) ? 1 : s;
 
 	}
@@ -254,6 +280,8 @@
 	// DecoratedTorusKnot4a
 
 	function DecoratedTorusKnot4a( s ) {
+
+		THREE.Curve.call( this );
 
 		this.scale = ( s === undefined ) ? 40 : s;
 
@@ -278,6 +306,8 @@
 
 	function DecoratedTorusKnot4b( s ) {
 
+		THREE.Curve.call( this );
+
 		this.scale = ( s === undefined ) ? 40 : s;
 
 	}
@@ -301,6 +331,8 @@
 
 	function DecoratedTorusKnot5a( s ) {
 
+		THREE.Curve.call( this );
+
 		this.scale = ( s === undefined ) ? 40 : s;
 
 	}
@@ -323,6 +355,8 @@
 	// DecoratedTorusKnot5c
 
 	function DecoratedTorusKnot5c( s ) {
+
+		THREE.Curve.call( this );
 
 		this.scale = ( s === undefined ) ? 40 : s;
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -776,6 +776,23 @@ Object.defineProperty( Skeleton.prototype, 'useVertexTexture', {
 
 } );
 
+Object.defineProperty( Curve.prototype, '__arcLengthDivisions', {
+
+	get: function () {
+
+		console.warn( 'THREE.Curve: .__arcLengthDivisions is now .arcLengthDivisions.' );
+		return this.arcLengthDivisions;
+
+	},
+	set: function ( value ) {
+
+		console.warn( 'THREE.Curve: .__arcLengthDivisions is now .arcLengthDivisions.' );
+		this.arcLengthDivisions = value;
+
+	}
+
+} );
+
 //
 
 PerspectiveCamera.prototype.setLens = function ( focalLength, filmGauge ) {

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -6,30 +6,30 @@ import { Matrix4 } from '../../math/Matrix4';
  * @author zz85 / http://www.lab4games.net/zz85/blog
  * Extensible curve object
  *
- * Some common of Curve methods
+ * Some common of curve methods:
  * .getPoint(t), getTangent(t)
  * .getPointAt(u), getTangentAt(u)
  * .getPoints(), .getSpacedPoints()
  * .getLength()
  * .updateArcLengths()
  *
- * This following classes subclasses THREE.Curve:
+ * This following curves inherit from THREE.Curve:
  *
- * -- 2d classes --
+ * -- 2D curves --
+ * THREE.ArcCurve
+ * THREE.CubicBezierCurve
+ * THREE.EllipseCurve
  * THREE.LineCurve
  * THREE.QuadraticBezierCurve
- * THREE.CubicBezierCurve
  * THREE.SplineCurve
- * THREE.ArcCurve
- * THREE.EllipseCurve
  *
- * -- 3d classes --
+ * -- 3D curves --
+ * THREE.CatmullRomCurve3
+ * THREE.CubicBezierCurve3
  * THREE.LineCurve3
  * THREE.QuadraticBezierCurve3
- * THREE.CubicBezierCurve3
- * THREE.CatmullRomCurve3
  *
- * A series of curves can be represented as a THREE.CurvePath
+ * A series of curves can be represented as a THREE.CurvePath.
  *
  **/
 
@@ -37,7 +37,11 @@ import { Matrix4 } from '../../math/Matrix4';
  *	Abstract Curve base class
  **************************************************************/
 
-function Curve() {}
+function Curve() {
+
+	this.arcLengthDivisions = 200;
+
+}
 
 Object.assign( Curve.prototype, {
 
@@ -46,7 +50,7 @@ Object.assign( Curve.prototype, {
 
 	getPoint: function () {
 
-		console.warn( "THREE.Curve: Warning, getPoint() not implemented!" );
+		console.warn( 'THREE.Curve: .getPoint() not implemented.' );
 		return null;
 
 	},
@@ -110,13 +114,12 @@ Object.assign( Curve.prototype, {
 
 	getLengths: function ( divisions ) {
 
-		if ( divisions === undefined ) divisions = ( this.__arcLengthDivisions ) ? ( this.__arcLengthDivisions ) : 200;
+		if ( divisions === undefined ) divisions = this.arcLengthDivisions;
 
-		if ( this.cacheArcLengths
-			&& ( this.cacheArcLengths.length === divisions + 1 )
-			&& ! this.needsUpdate ) {
+		if ( this.cacheArcLengths &&
+			( this.cacheArcLengths.length === divisions + 1 ) &&
+			! this.needsUpdate ) {
 
-			//console.log( "cached", this.cacheArcLengths );
 			return this.cacheArcLengths;
 
 		}
@@ -140,7 +143,7 @@ Object.assign( Curve.prototype, {
 
 		this.cacheArcLengths = cache;
 
-		return cache; // { sums: cache, sum:sum }; Sum is in the last element.
+		return cache; // { sums: cache, sum: sum }; Sum is in the last element.
 
 	},
 
@@ -170,8 +173,6 @@ Object.assign( Curve.prototype, {
 			targetArcLength = u * arcLengths[ il - 1 ];
 
 		}
-
-		//var time = Date.now();
 
 		// binary search for the index with largest value smaller than target u distance
 
@@ -204,12 +205,9 @@ Object.assign( Curve.prototype, {
 
 		i = high;
 
-		//console.log('b' , i, low, high, Date.now()- time);
-
 		if ( arcLengths[ i ] === targetArcLength ) {
 
-			var t = i / ( il - 1 );
-			return t;
+			return i / ( il - 1 );
 
 		}
 

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -15,6 +15,8 @@ import { LineCurve } from '../curves/LineCurve';
 
 function CurvePath() {
 
+	Curve.call( this );
+
 	this.curves = [];
 
 	this.autoClose = false; // Automatically closes the path
@@ -102,7 +104,7 @@ CurvePath.prototype = Object.assign( Object.create( Curve.prototype ), {
 
 		this.needsUpdate = true;
 		this.cacheLengths = null;
-		this.getLengths();
+		this.getCurveLengths();
 
 	},
 

--- a/src/extras/curves/CatmullRomCurve3.js
+++ b/src/extras/curves/CatmullRomCurve3.js
@@ -85,6 +85,8 @@ var px = new CubicPoly(), py = new CubicPoly(), pz = new CubicPoly();
 
 function CatmullRomCurve3( p /* array of Vector3 */ ) {
 
+	Curve.call( this );
+
 	this.points = p || [];
 	this.closed = false;
 

--- a/src/extras/curves/CubicBezierCurve.js
+++ b/src/extras/curves/CubicBezierCurve.js
@@ -5,6 +5,8 @@ import { Vector2 } from '../../math/Vector2';
 
 function CubicBezierCurve( v0, v1, v2, v3 ) {
 
+	Curve.call( this );
+
 	this.v0 = v0;
 	this.v1 = v1;
 	this.v2 = v2;

--- a/src/extras/curves/CubicBezierCurve3.js
+++ b/src/extras/curves/CubicBezierCurve3.js
@@ -5,6 +5,8 @@ import { Vector3 } from '../../math/Vector3';
 
 function CubicBezierCurve3( v0, v1, v2, v3 ) {
 
+	Curve.call( this );
+
 	this.v0 = v0;
 	this.v1 = v1;
 	this.v2 = v2;

--- a/src/extras/curves/EllipseCurve.js
+++ b/src/extras/curves/EllipseCurve.js
@@ -4,6 +4,8 @@ import { Vector2 } from '../../math/Vector2';
 
 function EllipseCurve( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation ) {
 
+	Curve.call( this );
+
 	this.aX = aX;
 	this.aY = aY;
 

--- a/src/extras/curves/LineCurve.js
+++ b/src/extras/curves/LineCurve.js
@@ -3,6 +3,8 @@ import { Curve } from '../core/Curve';
 
 function LineCurve( v1, v2 ) {
 
+	Curve.call( this );
+
 	this.v1 = v1;
 	this.v2 = v2;
 

--- a/src/extras/curves/LineCurve3.js
+++ b/src/extras/curves/LineCurve3.js
@@ -4,6 +4,8 @@ import { Curve } from '../core/Curve';
 
 function LineCurve3( v1, v2 ) {
 
+	Curve.call( this );
+
 	this.v1 = v1;
 	this.v2 = v2;
 

--- a/src/extras/curves/QuadraticBezierCurve.js
+++ b/src/extras/curves/QuadraticBezierCurve.js
@@ -5,6 +5,8 @@ import { Vector2 } from '../../math/Vector2';
 
 function QuadraticBezierCurve( v0, v1, v2 ) {
 
+	Curve.call( this );
+
 	this.v0 = v0;
 	this.v1 = v1;
 	this.v2 = v2;

--- a/src/extras/curves/QuadraticBezierCurve3.js
+++ b/src/extras/curves/QuadraticBezierCurve3.js
@@ -5,6 +5,8 @@ import { Vector3 } from '../../math/Vector3';
 
 function QuadraticBezierCurve3( v0, v1, v2 ) {
 
+	Curve.call( this );
+
 	this.v0 = v0;
 	this.v1 = v1;
 	this.v2 = v2;

--- a/src/extras/curves/SplineCurve.js
+++ b/src/extras/curves/SplineCurve.js
@@ -5,6 +5,8 @@ import { Vector2 } from '../../math/Vector2';
 
 function SplineCurve( points /* array of Vector2 */ ) {
 
+	Curve.call( this );
+
 	this.points = ( points === undefined ) ? [] : points;
 
 }


### PR DESCRIPTION
This PR does the following:

- Makes `__arcLengthDivisions` to a "public" property (see #10432)
- Corrects the inheritance of curves
- Fixes `updateArcLengths` in `CurvePath`
- Updates docs