### PR TITLE
Add guard for IE11 and Edge that don't support lose_context extension.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -373,7 +373,7 @@ function WebGLRenderer( parameters ) {
 
 	this.forceContextLoss = function () {
 
-		if (extensions.get( 'WEBGL_lose_context' )) {
+		if ( extensions.get( 'WEBGL_lose_context' ) ) {
 
 			extensions.get( 'WEBGL_lose_context' ).loseContext();
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -373,7 +373,11 @@ function WebGLRenderer( parameters ) {
 
 	this.forceContextLoss = function () {
 
-		extensions.get( 'WEBGL_lose_context' ).loseContext();
+		if (extensions.get( 'WEBGL_lose_context' )) {
+
+			extensions.get( 'WEBGL_lose_context' ).loseContext();
+
+		}
 
 	};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -373,11 +373,8 @@ function WebGLRenderer( parameters ) {
 
 	this.forceContextLoss = function () {
 
-		if ( extensions.get( 'WEBGL_lose_context' ) ) {
-
-			extensions.get( 'WEBGL_lose_context' ).loseContext();
-
-		}
+		var extension = extensions.get( 'WEBGL_lose_context' );
+		if ( extension ) extension.loseContext();
 
 	};
 


### PR DESCRIPTION
`extensions.get( 'WEBGL_lose_context' ).loseContext();` crashes on IE11 and Edge as they don't have this extension.