### PR TITLE
Compute ParametricGeometry normals from tangent vectors

### DIFF
--- a/src/geometries/ParametricGeometry.js
+++ b/src/geometries/ParametricGeometry.js
@@ -84,7 +84,7 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 
 			// cross product of tangent plane vectors returns surface normal
 
-			normal.crossVectors( pu, pv );
+			normal.crossVectors( pu, pv ).normalize();
 			normals.push( normal.x, normal.y, normal.z );
 
 			uvs.push( u, v );
@@ -119,9 +119,6 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 	this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
-
-	this.normalizeNormals();
-
 }
 
 ParametricBufferGeometry.prototype = Object.create( BufferGeometry.prototype );

--- a/src/geometries/ParametricGeometry.js
+++ b/src/geometries/ParametricGeometry.js
@@ -77,12 +77,29 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 			var p = func( u, v );
 			vertices.push( p.x, p.y, p.z );
 
-			// approximate tangent plane vectors via central difference
+			// approximate tangent vectors via finite differences
 
-			pu.subVectors( func( u + EPS, v ), func( u - EPS, v ) );
-			pv.subVectors( func( u, v + EPS ), func( u, v - EPS ) );
+			if ( u - EPS >= 0 ) {
 
-			// cross product of tangent plane vectors returns surface normal
+				pu.subVectors( p, func( u - EPS, v ) );
+
+			} else {
+
+				pu.subVectors( func( u + EPS, v ), p );
+
+			}
+
+			if ( v - EPS >= 0 ) {
+
+				pv.subVectors( p, func( u, v - EPS ) );
+
+			} else {
+
+				pv.subVectors( func( u, v + EPS ), p );
+
+			}
+
+			// cross product of tangent vectors returns surface normal
 
 			normal.crossVectors( pu, pv ).normalize();
 			normals.push( normal.x, normal.y, normal.z );
@@ -119,6 +136,7 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 	this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 	this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+
 }
 
 ParametricBufferGeometry.prototype = Object.create( BufferGeometry.prototype );


### PR DESCRIPTION
The ParametricGeometry class generates vertex normals as usual from the geometry's faces. However, this method leads to incorrectly computed normals for closed parametric surfaces. Where two ends of a surface meet, a seam is created since the positions along the edge are shared, but the indices of the geometry aren't.

For example, here you can see two seams on this torus created using ParametricGeometry:
![normals from faces](https://cloud.githubusercontent.com/assets/4411068/24320581/b7305f12-10fd-11e7-855a-716ef35898a4.png)

This PR attempts to solve the problem. These seams are removed if you calculate the normals from the parametric equation itself.
![normals from derivatives](https://cloud.githubusercontent.com/assets/4411068/24320595/20016f2c-10fe-11e7-9b89-2a576339ad24.png)
By approximating tangent vectors for each vertex via the finite difference method and taking the cross product of the vectors, a correct surface normal is retrieved.

I have a few concerns about my code.
* The `computeVertexNormals` method remains untouched, so if this method is called, the normals will be computed from the geometry faces again. The method could be overridden in ParametricGeometry and made to compute normals from the parametric equation, but the overridden method would contain a lot of duplicated code, since the method would still function very similarly. I'm not sure how to proceed.


