### PR TITLE
Geometries: Added missing .mergeVertices() calls

### DIFF
--- a/src/geometries/CircleGeometry.js
+++ b/src/geometries/CircleGeometry.js
@@ -18,6 +18,7 @@ function CircleGeometry( radius, segments, thetaStart, thetaLength ) {
 	};
 
 	this.fromBufferGeometry( new CircleBufferGeometry( radius, segments, thetaStart, thetaLength ) );
+	this.mergeVertices();
 
 }
 

--- a/src/geometries/PlaneGeometry.js
+++ b/src/geometries/PlaneGeometry.js
@@ -19,6 +19,7 @@ function PlaneGeometry( width, height, widthSegments, heightSegments ) {
 	};
 
 	this.fromBufferGeometry( new PlaneBufferGeometry( width, height, widthSegments, heightSegments ) );
+	this.mergeVertices();
 
 }
 

--- a/src/geometries/RingGeometry.js
+++ b/src/geometries/RingGeometry.js
@@ -20,6 +20,7 @@ function RingGeometry( innerRadius, outerRadius, thetaSegments, phiSegments, the
 	};
 
 	this.fromBufferGeometry( new RingBufferGeometry( innerRadius, outerRadius, thetaSegments, phiSegments, thetaStart, thetaLength ) );
+	this.mergeVertices();
 
 }
 

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -21,6 +21,7 @@ function SphereGeometry( radius, widthSegments, heightSegments, phiStart, phiLen
 	};
 
 	this.fromBufferGeometry( new SphereBufferGeometry( radius, widthSegments, heightSegments, phiStart, phiLength, thetaStart, thetaLength ) );
+	this.mergeVertices();
 
 }
 

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -21,6 +21,7 @@ function TorusGeometry( radius, tube, radialSegments, tubularSegments, arc ) {
 	};
 
 	this.fromBufferGeometry( new TorusBufferGeometry( radius, tube, radialSegments, tubularSegments, arc ) );
+	this.mergeVertices();
 
 }
 


### PR DESCRIPTION
Some geometries did not use `.mergeVertices()` in order to reduce their amount of vertices.