### PR TITLE
Examples: Refactor webgl_geometry_extrude_splines

### DIFF
--- a/examples/webgl_geometry_extrude_splines.html
+++ b/examples/webgl_geometry_extrude_splines.html
@@ -11,38 +11,41 @@
 				margin: 0px;
 				overflow: hidden;
 			}
+
+			#info {
+				position: absolute;
+				top: 0px;
+				width: 100%;
+				padding: 5px;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+			}
 		</style>
 	</head>
 	<body>
+
+		<div id="container"></div>
+		<div id="info"><a href="https://threejs.org" target="_blank">three.js</a> - geometry - spline extrusion examples by <a href="http://www.lab4games.net/zz85/blog" target="_blank">zz85</a></div>
 
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
 		<!-- where curves formulas are defined -->
+
 		<script src="js/CurveExtras.js"></script>
 
 		<script src="js/libs/stats.min.js"></script>
-
+		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script>
+
 		var container, stats;
 
 		var camera, scene, renderer, splineCamera, cameraHelper, cameraEye;
 
-		var text, plane;
-
-		var targetRotation = 0;
-		var targetRotationOnMouseDown = 0;
-
-		var mouseX = 0;
-		var mouseXOnMouseDown = 0;
-
-		var windowHalfX = window.innerWidth / 2;
-		var windowHalfY = window.innerHeight / 2;
-
 		var binormal = new THREE.Vector3();
 		var normal = new THREE.Vector3();
-
 
 		var pipeSpline = new THREE.CatmullRomCurve3( [
 				new THREE.Vector3( 0, 10, -10 ), new THREE.Vector3( 10, 0, -10 ),
@@ -92,41 +95,26 @@
 			SampleClosedSpline: sampleClosedSpline
 		};
 
-		extrudePath = new THREE.Curves.TrefoilKnot();
+		var parent, tube, tubeMesh;
 
-		var dropdown = '<select id="dropdown" onchange="addTube(this.value)">';
-
-		var s;
-		for ( s in splines ) {
-
-			dropdown += '<option value="' + s + '"';
-			dropdown += '>' + s + '</option>';
-
-		}
-
-		dropdown += '</select>';
-
-		var closed2 = true;
-		var parent;
-		var tube, tubeMesh;
-		var animation = false, lookAhead = false;
-		var scale;
-		var showCameraHelper = false;
+		var params = {
+			spline: 'GrannyKnot',
+			scale: 4,
+			extrusionSegments: 100,
+			radiusSegments: 3,
+			closed: true,
+			animationView: false,
+			lookAhead: false,
+			cameraHelper: false,
+		};
 
 		function addTube() {
 
-			var value = document.getElementById( 'dropdown' ).value;
-
-			var segments = parseInt( document.getElementById( 'segments' ).value );
-			closed2 = document.getElementById( 'closed' ).checked;
-
-			var radiusSegments = parseInt( document.getElementById( 'radiusSegments' ).value );
-
 			if ( tubeMesh !== undefined ) parent.remove( tubeMesh );
 
-			extrudePath = splines[ value ];
+			extrudePath = splines[ params.spline ];
 
-			tube = new THREE.TubeBufferGeometry( extrudePath, segments, 2, radiusSegments, closed2 );
+			tube = new THREE.TubeBufferGeometry( extrudePath, params.extrusionSegments, 2, params.radiusSegments, params.closed );
 
 			addGeometry( tube, 0xff00ff );
 			setScale();
@@ -135,15 +123,14 @@
 
 		function setScale() {
 
-			scale = parseInt( document.getElementById( 'scale' ).value );
-			tubeMesh.scale.set( scale, scale, scale );
+			tubeMesh.scale.set( params.scale, params.scale, params.scale );
 
 		}
 
 
 		function addGeometry( geometry, color ) {
 
-			// 3d shape
+			// 3D shape
 
 			tubeMesh = THREE.SceneUtils.createMultiMaterialObject( geometry, [
 				new THREE.MeshLambertMaterial( {
@@ -160,21 +147,10 @@
 
 		}
 
-		function animateCamera( toggle ) {
+		function animateCamera() {
 
-			if ( toggle === true ) {
-
-				animation = animation === false;
-				document.getElementById( 'animation' ).value = 'Camera Spline Animation View: ' + ( animation ? 'ON' : 'OFF' );
-
-			}
-
-			lookAhead = document.getElementById( 'lookAhead' ).checked;
-
-			showCameraHelper = document.getElementById( 'cameraHelper' ).checked;
-
-			cameraHelper.visible = showCameraHelper;
-			cameraEye.visible = showCameraHelper;
+			cameraHelper.visible = params.cameraHelper;
+			cameraEye.visible = params.cameraHelper;
 
 		}
 
@@ -183,37 +159,24 @@
 
 		function init() {
 
-			container = document.createElement( 'div' );
-			document.body.appendChild( container );
+			container = document.getElementById( 'container' );
 
-			var info = document.createElement( 'div' );
-			info.style.position = 'absolute';
-			info.style.top = '10px';
-			info.style.width = '100%';
-			info.style.textAlign = 'center';
-			info.innerHTML = 'Spline Extrusion Examples by <a href="http://www.lab4games.net/zz85/blog">zz85</a><br/>Select spline:';
-
-			info.innerHTML += dropdown;
-
-			info.innerHTML += '<br/>Scale: <select id="scale" onchange="setScale()"><option>1</option><option>2</option><option selected>4</option><option>6</option><option>10</option></select>';
-			info.innerHTML += '<br/>Extrusion Segments: <select onchange="addTube()" id="segments"><option>50</option><option selected>100</option><option>200</option><option>400</option></select>';
-			info.innerHTML += '<br/>Radius Segments: <select id="radiusSegments" onchange="addTube()"><option>1</option><option>2</option><option selected>3</option><option>4</option><option>5</option><option>6</option><option>8</option><option>12</option></select>';
-			info.innerHTML += '<br/>Closed:<input id="closed" onchange="addTube()" type="checkbox" checked />';
-
-			info.innerHTML += '<br/><br/><input id="animation" type="button" onclick="animateCamera(true)" value="Camera Spline Animation View: OFF"/><br/> Look Ahead <input id="lookAhead" type="checkbox" onchange="animateCamera()" /> Camera Helper <input id="cameraHelper" type="checkbox" onchange="animateCamera()" />';
-
-			container.appendChild( info );
-
-			//
+			// camera
 
 			camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.01, 10000 );
 			camera.position.set( 0, 50, 500 );
 
+			// scene
+
 			scene = new THREE.Scene();
+
+			// light
 
 			var light = new THREE.DirectionalLight( 0xffffff );
 			light.position.set( 0, 0, 1 );
 			scene.add( light );
+
+			// tube
 
 			parent = new THREE.Object3D();
 			scene.add( parent );
@@ -231,10 +194,10 @@
 			cameraEye = new THREE.Mesh( new THREE.SphereGeometry( 5 ), new THREE.MeshBasicMaterial( { color: 0xdddddd } ) );
 			parent.add( cameraEye );
 
-			cameraHelper.visible = showCameraHelper;
-			cameraEye.visible = showCameraHelper;
+			cameraHelper.visible = params.cameraHelper;
+			cameraEye.visible = params.cameraHelper;
 
-			//
+			// renderer
 
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setClearColor( 0xf0f0f0 );
@@ -242,23 +205,40 @@
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			container.appendChild( renderer.domElement );
 
+			// stats
+
 			stats = new Stats();
 			container.appendChild( stats.dom );
 
-			//
+			// dat.GUI
+
+			var gui = new dat.GUI( { width: 300 } );
+
+			var folderGeometry = gui.addFolder( 'Geometry' );
+			folderGeometry.add( params, 'spline', Object.keys( splines ) ).onChange( function( value ) { addTube(); } );
+			folderGeometry.add( params, 'scale', 2, 10 ).step( 2 ).onChange( function( value ) { setScale(); } );
+			folderGeometry.add( params, 'extrusionSegments', 50, 500 ).step( 50 ).onChange( function( value ) { addTube(); } );
+			folderGeometry.add( params, 'radiusSegments', 2, 12 ).step( 1 ).onChange( function( value ) { addTube(); } );
+			folderGeometry.add( params, 'closed').onChange( function( value ) { addTube(); } );
+			folderGeometry.open();
+
+			var folderCamera = gui.addFolder( 'Camera' );
+			folderCamera.add( params, 'animationView').onChange( function( value ) { animateCamera( true ); } );
+			folderCamera.add( params, 'lookAhead').onChange( function( value ) { animateCamera(); } );
+			folderCamera.add( params, 'cameraHelper').onChange( function( value ) { animateCamera(); } );
+			folderCamera.open();
+
+			// controls
 
 			controls = new THREE.OrbitControls( camera, renderer.domElement );
 
-			//
+			// event listener
 
 			window.addEventListener( 'resize', onWindowResize, false );
 
 		}
 
 		function onWindowResize() {
-
-			windowHalfX = window.innerWidth / 2;
-			windowHalfY = window.innerHeight / 2;
 
 			camera.aspect = window.innerWidth / window.innerHeight;
 			camera.updateProjectionMatrix();
@@ -280,15 +260,17 @@
 
 		function render() {
 
-			// Try Animate Camera Along Spline
+			// animate camera along spline
+
 			var time = Date.now();
 			var looptime = 20 * 1000;
 			var t = ( time % looptime ) / looptime;
 
 			var pos = tube.parameters.path.getPointAt( t );
-			pos.multiplyScalar( scale );
+			pos.multiplyScalar( params.scale );
 
 			// interpolation
+
 			var segments = tube.tangents.length;
 			var pickt = t * segments;
 			var pick = Math.floor( pickt );
@@ -297,33 +279,34 @@
 			binormal.subVectors( tube.binormals[ pickNext ], tube.binormals[ pick ] );
 			binormal.multiplyScalar( pickt - pick ).add( tube.binormals[ pick ] );
 
-
 			var dir = tube.parameters.path.getTangentAt( t );
-
 			var offset = 15;
 
 			normal.copy( binormal ).cross( dir );
 
-			// We move on a offset on its binormal
+			// we move on a offset on its binormal
+
 			pos.add( normal.clone().multiplyScalar( offset ) );
 
 			splineCamera.position.copy( pos );
 			cameraEye.position.copy( pos );
 
-			// Using arclength for stablization in look ahead.
-			var lookAt = tube.parameters.path.getPointAt( ( t + 30 / tube.parameters.path.getLength() ) % 1 ).multiplyScalar( scale );
+			// using arclength for stablization in look ahead
 
-			// Camera Orientation 2 - up orientation via normal
-			if ( !lookAhead ) lookAt.copy( pos ).add( dir );
-			splineCamera.matrix.lookAt(splineCamera.position, lookAt, normal);
+			var lookAt = tube.parameters.path.getPointAt( ( t + 30 / tube.parameters.path.getLength() ) % 1 ).multiplyScalar( params.scale );
+
+			// camera orientation 2 - up orientation via normal
+
+			if ( ! params.lookAhead ) lookAt.copy( pos ).add( dir );
+			splineCamera.matrix.lookAt( splineCamera.position, lookAt, normal );
 			splineCamera.rotation.setFromRotationMatrix( splineCamera.matrix, splineCamera.rotation.order );
 
 			cameraHelper.update();
 
-			renderer.render( scene, animation === true ? splineCamera : camera );
+			renderer.render( scene, params.animationView === true ? splineCamera : camera );
 
 		}
-	</script>
 
+	</script>
 	</body>
 </html>


### PR DESCRIPTION
- Usage of `dat.gui`
- Simplify code and clean up

New: [webgl_geometry_extrude_splines](https://rawgit.com/mugen87/three.js/examples/examples/webgl_geometry_extrude_splines.html)
Old: [webgl_geometry_extrude_splines](https://threejs.org/examples/webgl_geometry_extrude_splines.html)