### PR TITLE
Update webgl_marchingcubes.html

### DIFF
--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -51,7 +51,7 @@
 	<div id="info">
 		<a href="http://threejs.org" target="_blank">three.js</a> -
 		marching cubes -
-		[based on greggman's <a href="http://webglsamples.googlecode.com/hg/blob/blob.html">blob</a>, original code by Henrik Rydgård]
+		[based on greggman's <a href="https://webglsamples.org/blob/blob.html">blob</a>, original code by Henrik Rydgård]
 	</div>
 
 	<script src="../build/three.js"></script>


### PR DESCRIPTION
Update link to avoid HTTP 404 error.

New: [webgl_marchingcubes](https://rawgit.com/mugen87/three.js/patch-1/examples/webgl_marchingcubes.html)
Old: [webgl_marchingcubes](https://threejs.org/examples/webgl_marchingcubes.html)