### PR TITLE
OBJExporter: log material names

### DIFF
--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -49,6 +49,11 @@ THREE.OBJExporter.prototype = {
 				// name of the mesh object
 				output += 'o ' + mesh.name + '\n';
 
+				// name of the mesh material
+				if ( mesh.material && mesh.material.name ) {
+					output += 'usemtl ' + mesh.material.name + '\n';
+				}
+
 				// vertices
 
 				if( vertices !== undefined ) {


### PR DESCRIPTION
This does not really give us 'material support' yet, since you need to add
```
mtllib name.mtl
```
line, but OBJExporter does not know wanything about mtl file name, so I have to add this line outside of OBJExporter. however, I still feel like ![it's something](https://img.memesuper.com/7c9b8456a25d10dce0305dbc4eeec335_8776183-comment-itssomething-meme_560-461.jpeg) until OBJExporter API changes.