### PR TITLE
Broken link to code style guide fixed

### DIFF
--- a/docs/manual/introduction/Code-style-guide.html
+++ b/docs/manual/introduction/Code-style-guide.html
@@ -16,7 +16,7 @@
 			if you are adding code to the library or examples then you must follow this guide.<br /><br />
 
 			You can find details
-			<a href="https://github.com/mrdoob/three.js/wiki/Mr.doob%27s-Code-Style%E2%84%A2">here</a>.
+			<a href="https://github.com/mrdoob/three.js/wiki/Mr.doob%27s-Code-Style%E2%84%A2" target="_blank">here</a>.
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
The link from the docs to the code style guide (sceenshot) doesn’t work because the target does not allow framing. 

![codestylelink](https://cloud.githubusercontent.com/assets/5700294/24356593/edc9f958-12fa-11e7-93e1-12f25252201a.PNG)

On my machine (Windows 10) Chrome and FF show an error in the console, and Edge displays a security message in the iframe on the screen.

The simplest fix would be to insert  `target="_blank` (as done in this mini-PR).

---

Note: An alternative, using the doc’s special pattern for external links …

`You can find details [link:https://github.com/mrdoob/three.js/wiki/Mr.doob%27s-Code-Style%E2%84%A2 here].`

would require to include the percent sign in the regular expressions here: https://github.com/mrdoob/three.js/blob/dev/docs/page.js#L39-L40
