### PR TITLE
Object bounding box relative to given reference

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -1,5 +1,6 @@
 import { Vector3 } from './Vector3';
 import { Sphere } from './Sphere';
+import { Matrix4 } from './Matrix4';
 
 /**
  * @author bhouston / http://clara.io
@@ -123,11 +124,11 @@ Object.assign( Box3.prototype, {
 
 	}(),
 
-	setFromObject: function (object, reference, excludeInvisibleObjects, excludeInvisibleMaterials) {
+	setFromObject: function (object, reference, excludeInvisibleObjects) {
 		
 		this.makeEmpty();
 
-		return this.expandByObject( object, reference, excludeInvisibleObjects, excludeInvisibleMaterials );
+		return this.expandByObject( object, reference, excludeInvisibleObjects );
 		
 	},
 
@@ -212,45 +213,31 @@ Object.assign( Box3.prototype, {
 		// The two last parameters specify what to do with invisible
 		// parts of the object.
 		
-		var v1 = new THREE.Vector3();
+		var v1 = new Vector3();
 
-		return function expandByObject( object, reference, excludeInvisibleObjects, excludeInvisibleMaterials ) {
+		return function expandByObject( object, reference, excludeInvisibleObjects ) {
 
 			excludeInvisibleObjects = excludeInvisibleObjects || false;
-			excludeInvisibleMaterials = excludeInvisibleMaterials || false;
 			
 			var m;
-			if (reference !== undefined) {
-				m = new THREE.Matrix4();
+			if ( reference !== undefined ) {
+				
+				m = new Matrix4();
 				m.getInverse(reference.matrixWorld);
+
 			}
+			
 			var scope = this;
 
 			object.updateMatrixWorld( true );
 
-			let trav;
-			if (excludeInvisibleObjects) {
-				trav = function(f) {
-					object.traverseVisible(f);					
-				};
-			} else {
-				trav = function(f) {
-					object.traverse(f);					
-				};
-			}
-			
-			trav( function ( node ) {
+			object["traverse"+(excludeInvisibleObjects ? "Visible" : "")]( function ( node ) {
 
 				var i, l;
 
 				var geometry = node.geometry;
 
-				if ( geometry !== undefined 
-					&& (!excludeInvisibleMaterials 
-						|| (excludeInvisibleMaterials
-							//no material is treated as invisible material. OK?
-							&& node.material !== undefined
-							&& node.material.visible==true))) {
+				if ( geometry !== undefined ) {
 					
 					if ( geometry.isGeometry ) {
 
@@ -260,8 +247,10 @@ Object.assign( Box3.prototype, {
 
 							v1.copy( vertices[ i ] );
 							v1.applyMatrix4( node.matrixWorld );
-							if (m !== undefined) {
+							if ( m !== undefined ) {
+								
 								v1.applyMatrix4( m );
+								
 							}
 							scope.expandByPoint( v1 );
 
@@ -276,8 +265,10 @@ Object.assign( Box3.prototype, {
 							for ( i = 0, l = attribute.count; i < l; i ++ ) {
 
 								v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
-								if (m !== undefined) {
+								if ( m !== undefined ) {
+									
 									v1.applyMatrix4( m );
+									
 								}
 								scope.expandByPoint( v1 );
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -213,7 +213,7 @@ Object.assign( Box3.prototype, {
 			
 			if (ref !== undefined) {
 				
-				trans = new THREE.Matrix4().getInverse(ref.matrixWorld);
+				trans = new Matrix4().getInverse(ref.matrixWorld);
 				
 			}
 			
@@ -226,8 +226,8 @@ Object.assign( Box3.prototype, {
 		// accounting for both the object's, and children's, transforms.
 		// excludeInvisibleObjects specifies whether to use traverseVisible instead of traverse.
 		
-		var v1 = new THREE.Vector3();
-		var m1 = new THREE.Matrix4();
+		var v1 = new Vector3();
+		var m1 = new Matrix4();
 
 		return function expandByObject( object, trans, excludeInvisibleObjects ) {
 			

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -206,12 +206,12 @@ Object.assign( Box3.prototype, {
 	},
 
 	expandByObject: function () {
+		
 		// Computes the bounding box of an object (including its children) 
 		// in the given reference object's coordinate system, 
 		// or world coordinates if no reference is specified,
-		// accounting for both the object's, and children's, transforms
-		// The two last parameters specify what to do with invisible
-		// parts of the object.
+		// accounting for both the object's, and children's, transforms.
+		// excludeInvisibleObjects specifies whether to use traverseVisible instead of traverse.
 		
 		var v1 = new Vector3();
 


### PR DESCRIPTION
Added optional arguments to setFromObject and expandByObject that allow generating a bounding box relative to a given reference object's coordinate system. Also added some options regarding invisible objects and materials. I consider this an early sketch of the functionality. It should probably be extended to other methods as well, and the logic for undefined materials is probably not perfect.
Related issue: #8222 (visibility)