### PR TITLE
WebGLProgram: Removed obsolete morphTarget fix

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -522,11 +522,6 @@ function WebGLProgram( renderer, code, material, parameters ) {
 
 		gl.bindAttribLocation( program, 0, material.index0AttributeName );
 
-	} else if ( parameters.morphTargets === true ) {
-
-		// programs with morphTargets displace position out of attribute 0
-		gl.bindAttribLocation( program, 0, 'position' );
-
 	}
 
 	gl.linkProgram( program );


### PR DESCRIPTION
I've noticed that our morph target examples like [webgl_morphtargets](https://threejs.org/examples/webgl_morphtargets.html) throw a warning in Chrome:

_THREE.WebGLProgram: gl.getProgramInfoLog() WARNING: Could not find vertex shader attribute 'position' to match BindAttributeLocation request._

Other browsers like FF or Safari don't log that message. After removing some code in `WebGLProgram` (see commit) the warning disappeared  and the morph target examples still working.

https://github.com/mrdoob/three.js/commit/390ab5b42283f292f550695116bf675e93531afd introduces the logic in order to solve the issue https://github.com/mrdoob/three.js/issues/4469. Maybe this is not needed anymore?