### PR TITLE
ParametricGeometry: Optimize code

### DIFF
--- a/examples/js/ParametricGeometries.js
+++ b/examples/js/ParametricGeometries.js
@@ -7,7 +7,9 @@
 
 THREE.ParametricGeometries = {
 
-	klein: function ( v, u ) {
+	klein: function ( v, u, optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Vector3();
 
 		u *= Math.PI;
 		v *= 2 * Math.PI;
@@ -28,25 +30,29 @@ THREE.ParametricGeometries = {
 
 		y = - 2 * ( 1 - Math.cos( u ) / 2 ) * Math.sin( v );
 
-		return new THREE.Vector3( x, y, z );
+		return result.set( x, y, z );
 
 	},
 
 	plane: function ( width, height ) {
 
-		return function( u, v ) {
+		return function( u, v, optionalTarget ) {
+
+			var result = optionalTarget || new THREE.Vector3();
 
 			var x = u * width;
 			var y = 0;
 			var z = v * height;
 
-			return new THREE.Vector3( x, y, z );
+			return result.set( x, y, z );
 
 		};
 
 	},
 
-	mobius: function( u, t ) {
+	mobius: function( u, t, optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Vector3();
 
 		// flat mobius strip
 		// http://www.wolframalpha.com/input/?i=M%C3%B6bius+strip+parametric+equations&lk=1&a=ClashPrefs_*Surface.MoebiusStrip.SurfaceProperty.ParametricEquations-
@@ -56,28 +62,36 @@ THREE.ParametricGeometries = {
 		var x, y, z;
 
 		var a = 2;
+
 		x = Math.cos( v ) * ( a + u * Math.cos( v / 2 ) );
 		y = Math.sin( v ) * ( a + u * Math.cos( v / 2 ) );
 		z = u * Math.sin( v / 2 );
-		return new THREE.Vector3( x, y, z );
+
+		return result.set( x, y, z );
 
 	},
 
-	mobius3d: function( u, t ) {
+	mobius3d: function( u, t, optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Vector3();
 
 		// volumetric mobius strip
+
 		u *= Math.PI;
 		t *= 2 * Math.PI;
 
 		u = u * 2;
 		var phi = u / 2;
 		var major = 2.25, a = 0.125, b = 0.65;
+
 		var x, y, z;
+
 		x = a * Math.cos( t ) * Math.cos( phi ) - b * Math.sin( t ) * Math.sin( phi );
 		z = a * Math.cos( t ) * Math.sin( phi ) + b * Math.sin( t ) * Math.cos( phi );
 		y = ( major + x ) * Math.sin( u );
 		x = ( major + x ) * Math.cos( u );
-		return new THREE.Vector3( x, y, z );
+
+		return result.set( x, y, z );
 
 	}
 
@@ -123,7 +137,9 @@ THREE.ParametricGeometries.TubeGeometry = function( path, segments, radius, segm
 
 
 
-	var ParametricTube = function( u, v ) {
+	var ParametricTube = function( u, v, optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Vector3();
 
 		v *= 2 * Math.PI;
 
@@ -152,7 +168,7 @@ THREE.ParametricGeometries.TubeGeometry = function( path, segments, radius, segm
 		pos2.y += cx * normal.y + cy * binormal.y;
 		pos2.z += cx * normal.z + cy * binormal.z;
 
-		return pos2.clone();
+		return result.copy( pos2 );
 
 	};
 
@@ -222,7 +238,9 @@ THREE.ParametricGeometries.TorusKnotGeometry.prototype.constructor = THREE.Param
   *********************************************/
 THREE.ParametricGeometries.SphereGeometry = function( size, u, v ) {
 
-	function sphere( u, v ) {
+	function sphere( u, v, optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Vector3();
 
 		u *= Math.PI;
 		v *= 2 * Math.PI;
@@ -231,8 +249,7 @@ THREE.ParametricGeometries.SphereGeometry = function( size, u, v ) {
 		var y = size * Math.sin( u ) * Math.sin( v );
 		var z = size * Math.cos( u );
 
-
-		return new THREE.Vector3( x, y, z );
+		return result.set( x, y, z );
 
 	}
 
@@ -252,13 +269,15 @@ THREE.ParametricGeometries.SphereGeometry.prototype.constructor = THREE.Parametr
 
 THREE.ParametricGeometries.PlaneGeometry = function( width, depth, segmentsWidth, segmentsDepth ) {
 
-	function plane( u, v ) {
+	function plane( u, v, optionalTarget ) {
+
+		var result = optionalTarget || new THREE.Vector3();
 
 		var x = u * width;
 		var y = 0;
 		var z = v * depth;
 
-		return new THREE.Vector3( x, y, z );
+		return result.set( x, y, z );
 
 	}
 

--- a/examples/js/ParametricGeometries.js
+++ b/examples/js/ParametricGeometries.js
@@ -122,7 +122,7 @@ THREE.ParametricGeometries.TubeGeometry = function( path, segments, radius, segm
 
 		x, y, z, tx, ty, tz, u, v,
 
-		cx, cy, pos, pos2 = new THREE.Vector3(),
+		cx, cy, pos,
 		i, j, ip, jp, a, b, c, d, uva, uvb, uvc, uvd;
 
 	var frames = path.computeFrenetFrames( segments, closed ),
@@ -163,12 +163,11 @@ THREE.ParametricGeometries.TubeGeometry = function( path, segments, radius, segm
 		cx = - scope.radius * Math.cos( v ); // TODO: Hack: Negating it so it faces outside.
 		cy = scope.radius * Math.sin( v );
 
-		pos2.copy( pos );
-		pos2.x += cx * normal.x + cy * binormal.x;
-		pos2.y += cx * normal.y + cy * binormal.y;
-		pos2.z += cx * normal.z + cy * binormal.z;
+		pos.x += cx * normal.x + cy * binormal.x;
+		pos.y += cx * normal.y + cy * binormal.y;
+		pos.z += cx * normal.z + cy * binormal.z;
 
-		return result.copy( pos2 );
+		return result.copy( pos );
 
 	};
 

--- a/src/geometries/ParametricGeometry.js
+++ b/src/geometries/ParametricGeometry.js
@@ -58,7 +58,11 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 	var uvs = [];
 
 	var EPS = 0.00001;
-	var pu = new Vector3(), pv = new Vector3(), normal = new Vector3();
+
+	var normal = new Vector3();
+
+	var p0 = new Vector3(), p1 = new Vector3();
+	var pu = new Vector3(), pv = new Vector3();
 
 	var i, j;
 
@@ -74,28 +78,36 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 
 			var u = j / slices;
 
-			var p = func( u, v );
-			vertices.push( p.x, p.y, p.z );
+			// vertex
+
+			p0 = func( u, v, p0 );
+			vertices.push( p0.x, p0.y, p0.z );
+
+			// normal
 
 			// approximate tangent vectors via finite differences
 
 			if ( u - EPS >= 0 ) {
 
-				pu.subVectors( p, func( u - EPS, v ) );
+				p1 = func( u - EPS, v, p1 );
+				pu.subVectors( p0, p1 );
 
 			} else {
 
-				pu.subVectors( func( u + EPS, v ), p );
+				p1 = func( u + EPS, v, p1 );
+				pu.subVectors( p1, p0 );
 
 			}
 
 			if ( v - EPS >= 0 ) {
 
-				pv.subVectors( p, func( u, v - EPS ) );
+				p1 = func( u, v - EPS, p1 );
+				pv.subVectors( p0, p1 );
 
 			} else {
 
-				pv.subVectors( func( u, v + EPS ), p );
+				p1 = func( u, v + EPS, p1 );
+				pv.subVectors( p1, p0 );
 
 			}
 
@@ -103,6 +115,8 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 
 			normal.crossVectors( pu, pv ).normalize();
 			normals.push( normal.x, normal.y, normal.z );
+
+			// uv
 
 			uvs.push( u, v );
 


### PR DESCRIPTION
This PR implements some feedback of @WestLangley see https://github.com/mrdoob/three.js/pull/11056#discussion_r108036765

`ParametricGeometry` can now use functions that have an `optionalTarget` parameter. In this way less objects (`Vector3`) are created during the geometry generation. Besides, the new code is backward compatible.

@WestLangley Do you think the implementation is okay like this?