### PR TITLE
Docs: index.html refactored

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -1,205 +1,205 @@
 @font-face {
-    font-family: 'inconsolata';
-    src: url('files/inconsolata.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
+	font-family: 'inconsolata';
+	src: url('files/inconsolata.woff') format('woff');
+	font-weight: normal;
+	font-style: normal;
 }
 
 *{
-    box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 html {
-    height: 100%;
+	height: 100%;
 }
 
 body {
-    background-color: #ffffff;
-    margin: 0px;
-    height: 100%;
-    color: #555;
-    font-family: 'inconsolata';
-    font-size: 15px;
-    line-height: 18px;
-    overflow: hidden;
+	background-color: #ffffff;
+	margin: 0px;
+	height: 100%;
+	color: #555;
+	font-family: 'inconsolata';
+	font-size: 15px;
+	line-height: 18px;
+	overflow: hidden;
 }
 
 h1 {
-    margin-top: 30px;
-    margin-bottom: 40px;
-    margin-left: 20px;
-    font-size: 25px;
-    font-weight: normal;
+	margin-top: 30px;
+	margin-bottom: 40px;
+	margin-left: 20px;
+	font-size: 25px;
+	font-weight: normal;
 }
 
 h2 {
-    color: #454545;
-    font-size: 18px;
-    font-weight: normal;
+	color: #454545;
+	font-size: 18px;
+	font-weight: normal;
 
-    margin-top: 20px;
-    margin-left: 20px;
+	margin-top: 20px;
+	margin-left: 20px;
 }
 
 h3 {
-    color: #666;
-    font-size: 16px;
-    font-weight: normal;
+	color: #666;
+	font-size: 16px;
+	font-weight: normal;
 
-    margin-top: 20px;
-    margin-left: 20px;
+	margin-top: 20px;
+	margin-left: 20px;
 }
 
 a {
-    color: #2194CE;
-    text-decoration: none;
+	color: #2194CE;
+	text-decoration: none;
 }
 
 #panel {
-    position: fixed;
-    left: 0px;
-    width: 260px;
-    height: 100%;
-    overflow: auto;
-    background: #fafafa;
+	position: fixed;
+	left: 0px;
+	width: 260px;
+	height: 100%;
+	overflow: auto;
+	background: #fafafa;
 }
 
 #panel ul {
-    list-style-type: none;
-    padding: 0px;
-    margin-left: 20px;
+	list-style-type: none;
+	padding: 0px;
+	margin-left: 20px;
 }
 
 iframe {
-    position: absolute;
-    border: 0px;
-    left: 260px;
-    width: calc(100% - 260px);
-    height: 100%;
-    overflow: auto;
+	position: absolute;
+	border: 0px;
+	left: 260px;
+	width: calc(100% - 260px);
+	height: 100%;
+	overflow: auto;
 }
 
 .filterBlock{
-    margin: 20px;
-    position: relative;
+	margin: 20px;
+	position: relative;
 }
 
 .filterBlock p {
-    margin: 0;
+	margin: 0;
 }
 
 #filterInput {
-    width: 100%;
-    padding: 5px;
-    font-family: inherit;
-    font-size: 15px;
-    outline: none;
-    border: 1px solid #dedede;
+	width: 100%;
+	padding: 5px;
+	font-family: inherit;
+	font-size: 15px;
+	outline: none;
+	border: 1px solid #dedede;
 }
 
 #filterInput:focus{
-    border: 1px solid #2194CE;
+	border: 1px solid #2194CE;
 }
 
 #clearFilterButton {
-    position: absolute;
-    right: 6px;
-    top: 50%;
-    margin-top: -8px;
-    width: 16px;
-    height: 16px;
-    font-size: 14px;
-    color: grey;
-    text-align: center;
-    line-height: 0;
-    padding-top: 7px;
-    opacity: .5;
+	position: absolute;
+	right: 6px;
+	top: 50%;
+	margin-top: -8px;
+	width: 16px;
+	height: 16px;
+	font-size: 14px;
+	color: grey;
+	text-align: center;
+	line-height: 0;
+	padding-top: 7px;
+	opacity: .5;
 }
 
 #clearFilterButton:hover {
-    opacity: 1;
+	opacity: 1;
 }
 
 .hidden {
-    display: none;
+	display: none;
 }
 
 #panel li b {
-    font-weight: bold;
+	font-weight: bold;
 }
 
 /* mobile */
 
 #expandButton {
-    display: none;
-    position: absolute;
-    right: 20px;
-    top: 12px;
-    width: 32px;
-    height: 32px;
+	display: none;
+	position: absolute;
+	right: 20px;
+	top: 12px;
+	width: 32px;
+	height: 32px;
 }
 
 #expandButton span {
-    height: 2px;
-    background-color: #2194CE;
-    width: 16px;
-    position: absolute;
-    left: 8px;
-    top: 10px;
+	height: 2px;
+	background-color: #2194CE;
+	width: 16px;
+	position: absolute;
+	left: 8px;
+	top: 10px;
 }
 
 #expandButton span:nth-child(1) {
-    top: 16px;
+	top: 16px;
 }
 
 #expandButton span:nth-child(2) {
-    top: 22px;
+	top: 22px;
 }
 
 @media all and ( max-width: 640px ) {
-    
-    h1{
-        margin-top: 20px;
-        margin-bottom: 20px;
-    }
-    
-    #panel{
-        position: absolute;
-        left: 0;
-        top: 0;
-        height: 480px;
-        width: 100%;
-        right: 0;
-        z-index: 100;
-        overflow: hidden;
-        border-bottom: 1px solid #dedede;
-    }
-    
-    #navigation{
-        position: absolute;
-        left: 0;
-        top: 90px;
-        right: 0;
-        bottom: 0;
-        font-size: 17px;
-        line-height: 22px;
-        overflow: auto;
-    }
-    
-    iframe{
-        position: absolute;
-        left: 0;
-        top: 56px;
-        width: 100%;
-        height: calc(100% - 56px);
-    }
-    
-    #expandButton{
-        display: block;
-    }
-    
-    #panel.collapsed{
-        height: 56px;
-    }
-    
+
+	h1{
+		margin-top: 20px;
+		margin-bottom: 20px;
+	}
+
+	#panel{
+		position: absolute;
+		left: 0;
+		top: 0;
+		height: 480px;
+		width: 100%;
+		right: 0;
+		z-index: 100;
+		overflow: hidden;
+		border-bottom: 1px solid #dedede;
+	}
+
+	#navigation{
+		position: absolute;
+		left: 0;
+		top: 90px;
+		right: 0;
+		bottom: 0;
+		font-size: 17px;
+		line-height: 22px;
+		overflow: auto;
+	}
+
+	iframe{
+		position: absolute;
+		left: 0;
+		top: 56px;
+		width: 100%;
+		height: calc(100% - 56px);
+	}
+
+	#expandButton{
+		display: block;
+	}
+
+	#panel.collapsed{
+		height: 56px;
+	}
+
 }

--- a/docs/index.css
+++ b/docs/index.css
@@ -50,16 +50,9 @@ h3 {
     margin-left: 20px;
 }
 
-a, li span {
-    color: #2194CE;
-}
-
 a {
+    color: #2194CE;
     text-decoration: none;
-}
-
-li span {
-    cursor: pointer;
 }
 
 #panel {

--- a/docs/index.css
+++ b/docs/index.css
@@ -1,0 +1,212 @@
+@font-face {
+    font-family: 'inconsolata';
+    src: url('files/inconsolata.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+
+*{
+    box-sizing: border-box;
+}
+
+html {
+    height: 100%;
+}
+
+body {
+    background-color: #ffffff;
+    margin: 0px;
+    height: 100%;
+    color: #555;
+    font-family: 'inconsolata';
+    font-size: 15px;
+    line-height: 18px;
+    overflow: hidden;
+}
+
+h1 {
+    margin-top: 30px;
+    margin-bottom: 40px;
+    margin-left: 20px;
+    font-size: 25px;
+    font-weight: normal;
+}
+
+h2 {
+    color: #454545;
+    font-size: 18px;
+    font-weight: normal;
+
+    margin-top: 20px;
+    margin-left: 20px;
+}
+
+h3 {
+    color: #666;
+    font-size: 16px;
+    font-weight: normal;
+
+    margin-top: 20px;
+    margin-left: 20px;
+}
+
+a, li span {
+    color: #2194CE;
+}
+
+a {
+    text-decoration: none;
+}
+
+li span {
+    cursor: pointer;
+}
+
+#panel {
+    position: fixed;
+    left: 0px;
+    width: 260px;
+    height: 100%;
+    overflow: auto;
+    background: #fafafa;
+}
+
+#panel ul {
+    list-style-type: none;
+    padding: 0px;
+    margin-left: 20px;
+}
+
+iframe {
+    position: absolute;
+    border: 0px;
+    left: 260px;
+    width: calc(100% - 260px);
+    height: 100%;
+    overflow: auto;
+}
+
+.filterBlock{
+    margin: 20px;
+    position: relative;
+}
+
+.filterBlock p {
+    margin: 0;
+}
+
+#filterInput {
+    width: 100%;
+    padding: 5px;
+    font-family: inherit;
+    font-size: 15px;
+    outline: none;
+    border: 1px solid #dedede;
+}
+
+#filterInput:focus{
+    border: 1px solid #2194CE;
+}
+
+#clearFilterButton {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    margin-top: -8px;
+    width: 16px;
+    height: 16px;
+    font-size: 14px;
+    color: grey;
+    text-align: center;
+    line-height: 0;
+    padding-top: 7px;
+    opacity: .5;
+}
+
+#clearFilterButton:hover {
+    opacity: 1;
+}
+
+.hidden {
+    display: none;
+}
+
+#panel li b {
+    font-weight: bold;
+}
+
+/* mobile */
+
+#expandButton {
+    display: none;
+    position: absolute;
+    right: 20px;
+    top: 12px;
+    width: 32px;
+    height: 32px;
+}
+
+#expandButton span {
+    height: 2px;
+    background-color: #2194CE;
+    width: 16px;
+    position: absolute;
+    left: 8px;
+    top: 10px;
+}
+
+#expandButton span:nth-child(1) {
+    top: 16px;
+}
+
+#expandButton span:nth-child(2) {
+    top: 22px;
+}
+
+@media all and ( max-width: 640px ) {
+    
+    h1{
+        margin-top: 20px;
+        margin-bottom: 20px;
+    }
+    
+    #panel{
+        position: absolute;
+        left: 0;
+        top: 0;
+        height: 480px;
+        width: 100%;
+        right: 0;
+        z-index: 100;
+        overflow: hidden;
+        border-bottom: 1px solid #dedede;
+    }
+    
+    #navigation{
+        position: absolute;
+        left: 0;
+        top: 90px;
+        right: 0;
+        bottom: 0;
+        font-size: 17px;
+        line-height: 22px;
+        overflow: auto;
+    }
+    
+    iframe{
+        position: absolute;
+        left: 0;
+        top: 56px;
+        width: 100%;
+        height: calc(100% - 56px);
+    }
+    
+    #expandButton{
+        display: block;
+    }
+    
+    #panel.collapsed{
+        height: 56px;
+    }
+    
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,45 +1,45 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>three.js / documentation</title>
-    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-    <link type="text/css" rel="stylesheet" href="index.css">
-</head>
-<body>
+	<head>
+		<meta charset="utf-8">
+		<title>three.js / documentation</title>
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="index.css">
+	</head>
+	<body>
 
-    <div id="panel" class="collapsed">
+		<div id="panel" class="collapsed">
 
-        <h1><a href="http://threejs.org">three.js</a> / docs</h1>
+			<h1><a href="http://threejs.org">three.js</a> / docs</h1>
 
-        <a id="expandButton" href="#">
-            <span></span>
-            <span></span>
-            <span></span>
-        </a>
+			<a id="expandButton" href="#">
+				<span></span>
+				<span></span>
+				<span></span>
+			</a>
 
-        <div class="filterBlock" >
-            <input type="text" id="filterInput" placeholder="Type to filter">
-            <a href="#" id="clearFilterButton">x</a>
-        </div>
+			<div class="filterBlock" >
+				<input type="text" id="filterInput" placeholder="Type to filter">
+				<a href="#" id="clearFilterButton">x</a>
+			</div>
 
-    </div>
+		</div>
 
-    <iframe></iframe>
+		<iframe></iframe>
 
-    <script src="list.js"></script>
+		<script src="list.js"></script>
 
-    <script>
+		<script>
 
-        var panel = document.getElementById( 'panel' );
-        var clearFilterButton = document.getElementById( 'clearFilterButton' );
-        var expandButton = document.getElementById( 'expandButton' );
-        var filterInput = document.getElementById( 'filterInput' );
-        var iframe = document.querySelector( 'iframe' );
+			var panel = document.getElementById( 'panel' );
+			var clearFilterButton = document.getElementById( 'clearFilterButton' );
+			var expandButton = document.getElementById( 'expandButton' );
+			var filterInput = document.getElementById( 'filterInput' );
+			var iframe = document.querySelector( 'iframe' );
 
-        var pageProperties = {};
-        var titles = {};
-        var categoryElements = [];
+			var pageProperties = {};
+			var titles = {};
+			var categoryElements = [];
 
 
 // ----------------------------------------------------------------------------
@@ -47,46 +47,46 @@
 // ----------------------------------------------------------------------------
 
 
-        // Functionality for hamburger button (on small devices)
+			// Functionality for hamburger button (on small devices)
 
-        expandButton.onclick = function ( event ) {
+			expandButton.onclick = function ( event ) {
 
-            event.preventDefault();
-            panel.classList.toggle( 'collapsed' );
+				event.preventDefault();
+				panel.classList.toggle( 'collapsed' );
 
-        };
-
-
-        // Functionality for search/filter input field
-
-        filterInput.oninput = function ( event ) {
-
-            updateFilter();
-
-        };
+			};
 
 
-        // Functionality for filter clear button
+			// Functionality for search/filter input field
 
-        clearFilterButton.onclick = function ( event ) {
+			filterInput.oninput = function ( event ) {
 
-            event.preventDefault();
+				updateFilter();
 
-            filterInput.value = '';
-            updateFilter();
-
-        };
+			};
 
 
-        // Activate content and title change on browser navigation
+			// Functionality for filter clear button
 
-        window.onpopstate = createNewIframe;
+			clearFilterButton.onclick = function ( event ) {
+
+				event.preventDefault();
+
+				filterInput.value = '';
+				updateFilter();
+
+			};
 
 
-        // Create the navigation panel and configure the iframe
+			// Activate content and title change on browser navigation
 
-        createNavigation();
-        createNewIframe();
+			window.onpopstate = createNewIframe;
+
+
+			// Create the navigation panel and configure the iframe
+
+			createNavigation();
+			createNewIframe();
 
 
 // ----------------------------------------------------------------------------
@@ -94,106 +94,106 @@
 // ----------------------------------------------------------------------------
 
 
-        function createNavigation () {
+			function createNavigation () {
 
-            // Create the navigation panel using data from list.js
+				// Create the navigation panel using data from list.js
 
-            var navigation = createAndAppendDOMElement( { type: 'div', parent: panel } );
+				var navigation = createAndAppendDOMElement( { type: 'div', parent: panel } );
 
-            for ( var section in list ) {
+				for ( var section in list ) {
 
-                // Create sections
+					// Create sections
 
-                var categories = list[ section ];
+					var categories = list[ section ];
 
-                var sectionHead = createAndAppendDOMElement( { type: 'h2', parent: navigation, content: section } )
+					var sectionHead = createAndAppendDOMElement( { type: 'h2', parent: navigation, content: section } )
 
-                for ( var category in categories ) {
+					for ( var category in categories ) {
 
-                    // Create categories
+						// Create categories
 
-                    var pages = categories[ category ];
+						var pages = categories[ category ];
 
-                    var categoryContainer = createAndAppendDOMElement( { type: 'div', parent: navigation } );
-                    var categoryHead = createAndAppendDOMElement( { type: 'h3', parent: categoryContainer, content: category } );
-                    var categoryContent = createAndAppendDOMElement( { type: 'ul', parent: categoryContainer } );
+						var categoryContainer = createAndAppendDOMElement( { type: 'div', parent: navigation } );
+						var categoryHead = createAndAppendDOMElement( { type: 'h3', parent: categoryContainer, content: category } );
+						var categoryContent = createAndAppendDOMElement( { type: 'ul', parent: categoryContainer } );
 
-                    for ( var pageName in pages ) {
+						for ( var pageName in pages ) {
 
-                        // Create page links
+							// Create page links
 
-                        var pageURL = pages[ pageName ];
+							var pageURL = pages[ pageName ];
 
-                        var listElement = createAndAppendDOMElement( { type: 'li', parent: categoryContent } );
-                        var linkElement = createAndAppendDOMElement( { type: 'a', parent: listElement, content: pageName } );
+							var listElement = createAndAppendDOMElement( { type: 'li', parent: categoryContent } );
+							var linkElement = createAndAppendDOMElement( { type: 'a', parent: listElement, content: pageName } );
 
-                        // The href attribute is only used for the option to create a new tab by right click
+							// The href attribute is only used for the option to create a new tab by right click
 
-                        linkElement.setAttribute( 'href', '#' + pageURL );
+							linkElement.setAttribute( 'href', '#' + pageURL );
 
-                        addClickHandlers( linkElement, pageURL );
+							addClickHandlers( linkElement, pageURL );
 
-                        // Gather the main properties for the current subpage
+							// Gather the main properties for the current subpage
 
-                        pageProperties[ pageName ] = {
-                            section: section,
-                            category: category,
-                            pageURL: pageURL,
-                            linkElement: linkElement
-                        };
+							pageProperties[ pageName ] = {
+								section: section,
+								category: category,
+								pageURL: pageURL,
+								linkElement: linkElement
+							};
 
-                    // Gather the document titles (used for easy access on browser navigation)
+						// Gather the document titles (used for easy access on browser navigation)
 
-                    titles[ pageURL ] = pageName;
+						titles[ pageURL ] = pageName;
 
-                    }
+						}
 
-                    // Gather the category elements for easy access on filtering
+						// Gather the category elements for easy access on filtering
 
-                    categoryElements.push( categoryContent );
+						categoryElements.push( categoryContent );
 
-                }
+					}
 
-            }
+				}
 
-        };
-
-
-        function createAndAppendDOMElement( properties ) {
-
-            // Helper function for creating and appending new DOM elements
-
-            var newElement = document.createElement( properties.type );
-
-            properties.parent.appendChild( newElement );
-
-            if ( properties.content ) {
-
-                newElement.textContent = properties.content;
-
-            }
-
-            return newElement;
-
-        }
+			};
 
 
-        function addClickHandlers ( linkElement, pageURL ) {
+			function createAndAppendDOMElement( properties ) {
 
-            // Helper function for adding ClickHandlers to the page links
+				// Helper function for creating and appending new DOM elements
 
-            linkElement.onclick = function ( event ) {
+				var newElement = document.createElement( properties.type );
 
-                event.preventDefault();
+				properties.parent.appendChild( newElement );
 
-                window.location.hash = pageURL;
-                createNewIframe();
+				if ( properties.content ) {
 
-                panel.classList.add( 'collapsed' );
+					newElement.textContent = properties.content;
 
-            };
+				}
 
-        };
+				return newElement;
+
+			}
+
+
+			function addClickHandlers ( linkElement, pageURL ) {
+
+				// Helper function for adding ClickHandlers to the page links
+
+				linkElement.onclick = function ( event ) {
+
+					event.preventDefault();
+
+					window.location.hash = pageURL;
+					createNewIframe();
+
+					panel.classList.add( 'collapsed' );
+
+				};
+
+			};
 
 
 // ----------------------------------------------------------------------------
@@ -201,36 +201,36 @@
 // ----------------------------------------------------------------------------
 
 
-//        (uncomment the following lines and the first line in updateFilter(), if you want query strings):
+//			(uncomment the following lines and the first line in updateFilter(), if you want query strings):
 
-//        filterInput.value = extractFromQueryString();
-//        updateFilter();
+//			filterInput.value = extractFromQueryString();
+//			updateFilter();
 //
 //
-//        function extractFromQueryString() {
+//			function extractFromQueryString() {
 //
-//            var queryString = window.location.search;
+//				var queryString = window.location.search;
 //
-//            if ( queryString.indexOf( '?q=' ) === -1 ) return '';
+//				if ( queryString.indexOf( '?q=' ) === -1 ) return '';
 //
-//            return queryString.substr( 3 );
+//				return queryString.substr( 3 );
 //
-//        }
+//			}
 //
-//        function updateQueryString() {
+//			function updateQueryString() {
 //
-//            var searchString = filterInput.value;
-//            var query = '';
+//				var searchString = filterInput.value;
+//				var query = '';
 //
-//            if (searchString !== '') {
+//				if (searchString !== '') {
 //
-//                query = '?q=' + searchString;
+//					query = '?q=' + searchString;
 //
-//            }
+//				}
 //
-//            window.history.replaceState( {} , '', window.location.pathname + query + window.location.hash ); 
+//				window.history.replaceState( {} , '', window.location.pathname + query + window.location.hash ); 
 //
-//        }
+//			}
 
 
 // ----------------------------------------------------------------------------
@@ -238,91 +238,91 @@
 // ----------------------------------------------------------------------------
 
 
-        function updateFilter() {
+			function updateFilter() {
 
-//            (uncomment the following line and the "Query strings" section, if you want query strings):
-//            updateQueryString();
+//			(uncomment the following line and the "Query strings" section, if you want query strings):
+//			updateQueryString();
 
-            var regExp = new RegExp( filterInput.value, 'gi' );
+				var regExp = new RegExp( filterInput.value, 'gi' );
 
-            for ( var pageName in pageProperties ) {
- 
-                var linkElement = pageProperties[ pageName ].linkElement;
-                var categoryClassList = linkElement.parentElement.classList;
-                var filterResults = pageName.match( regExp );
+				for ( var pageName in pageProperties ) {
 
-                if ( filterResults && filterResults.length > 0 ) {
+					var linkElement = pageProperties[ pageName ].linkElement;
+					var categoryClassList = linkElement.parentElement.classList;
+					var filterResults = pageName.match( regExp );
 
-                    // Accentuate matching characters
+					if ( filterResults && filterResults.length > 0 ) {
 
-                    for ( var i = 0; i < filterResults.length; i++ ) {
+						// Accentuate matching characters
 
-                        var result = filterResults[ i ];
+						for ( var i = 0; i < filterResults.length; i++ ) {
 
-                        if ( result !== '' ) {
-                            pageName = pageName.replace( result, '<b>' + result + '</b>' );
-                        }
+							var result = filterResults[ i ];
 
-                    }
+							if ( result !== '' ) {
+								pageName = pageName.replace( result, '<b>' + result + '</b>' );
+							}
 
-                    categoryClassList.remove( 'hidden' );
-                    linkElement.innerHTML = pageName;
+						}
 
-                } else {
+						categoryClassList.remove( 'hidden' );
+						linkElement.innerHTML = pageName;
 
-                    // Hide all non-matching page names
+					} else {
 
-                    categoryClassList.add( 'hidden' );
+						// Hide all non-matching page names
 
-                }
+						categoryClassList.add( 'hidden' );
 
-            }
+					}
 
-            displayFilteredPanel();
+				}
 
-        }
+				displayFilteredPanel();
+
+			}
 
 
-        function displayFilteredPanel() {
+			function displayFilteredPanel() {
 
-            // Show/hide categories depending on their content
-            // First check if at least one page in this category is not hidden
+				// Show/hide categories depending on their content
+				// First check if at least one page in this category is not hidden
 
-            categoryElements.forEach( function ( category ) {
+				categoryElements.forEach( function ( category ) {
 
-                var pages = category.children;
-                var pagesLength = pages.length;
-                var sectionClassList = category.parentElement.classList;
+					var pages = category.children;
+					var pagesLength = pages.length;
+					var sectionClassList = category.parentElement.classList;
 
-                var hideCategory = true;
+					var hideCategory = true;
 
-                for ( var i = 0; i < pagesLength; i ++ ) {
+					for ( var i = 0; i < pagesLength; i ++ ) {
 
-                    var pageClassList = pages[ i ].classList;
+						var pageClassList = pages[ i ].classList;
 
-                    if ( ! pageClassList.contains( 'hidden' ) ) {
+						if ( ! pageClassList.contains( 'hidden' ) ) {
 
-                        hideCategory = false;
+							hideCategory = false;
 
-                    }
+						}
 
-                }
+					}
 
-                // If and only if all page names are hidden, hide the whole category
+					// If and only if all page names are hidden, hide the whole category
 
-                if ( hideCategory ) {
+					if ( hideCategory ) {
 
-                    sectionClassList.add( 'hidden' );
+						sectionClassList.add( 'hidden' );
 
-                } else {
+					} else {
 
-                    sectionClassList.remove( 'hidden' );
+						sectionClassList.remove( 'hidden' );
 
-                }
+					}
 
-            } );
+				} );
 
-        }
+			}
 
 
 // ----------------------------------------------------------------------------
@@ -330,92 +330,92 @@
 // ----------------------------------------------------------------------------
 
 
-        function setUrlFragment( pageName ) {
+			function setUrlFragment( pageName ) {
 
-            // Handle navigation from the subpages (iframes):
-            // First separate the memeber (if existing) from the page name,
-            // then identify the subpage's URL and set it as URL fragment (re-adding the member)
+				// Handle navigation from the subpages (iframes):
+				// First separate the memeber (if existing) from the page name,
+				// then identify the subpage's URL and set it as URL fragment (re-adding the member)
 
-            var splitPageName = decomposePageName( pageName, '.', '.' );
+				var splitPageName = decomposePageName( pageName, '.', '.' );
 
-            var currentProperties = pageProperties[ splitPageName[ 0 ] ];
+				var currentProperties = pageProperties[ splitPageName[ 0 ] ];
 
-            if ( currentProperties ) {
+				if ( currentProperties ) {
 
-                window.location.hash = currentProperties.pageURL + splitPageName[ 1 ];
+					window.location.hash = currentProperties.pageURL + splitPageName[ 1 ];
 
-                createNewIframe();
+					createNewIframe();
 
-            }
+				}
 
-        }
-
-
-        function createNewIframe() {
-
-            // Change the content displayed in the iframe
-            // First separate the member part of the fragment (if existing)
-
-            var hash = window.location.hash.substring( 1 );
-            var splitHash = decomposePageName( hash, '.', '#' );
-
-            // Creating a new Iframe instead of assigning a new src is
-            // a cross-browser solution to allow normal browser navigation;
-            // - only assigning a new src would result in two history states each time.
-
-            // Note: iframe.contentWindow.location.replace(hash) should work, too,
-            // but it doesn't work in Edge with links from the subpages!
-
-            var oldIframe;
-            var subtitle;
-
-            oldIframe = iframe;
-            iframe = oldIframe.cloneNode();
-
-            if(hash) {
-
-                iframe.src = splitHash[ 0 ] + '.html' + splitHash[ 1 ];
-                subtitle = ' - ' + titles[ splitHash[ 0 ] ] + splitHash[ 1 ];
-
-            } else {
-
-                iframe.src = '';
-                subtitle = '';
-
-            }
-
-            document.body.replaceChild( iframe, oldIframe );
-            document.title = 'three.js docs' + subtitle;
-
-        }
+			}
 
 
-        function decomposePageName ( pageName, oldDelimiter, newDelimiter ) {
+			function createNewIframe() {
 
-            // Helper function for separating the member (if existing) from the pageName
-            // For example: 'Geometry.morphTarget' can be converted to 
-            // ['Geometry', '.morphTarget'] or ['Geometry', '#morphTarget']
-            // Note: According RFC 3986 no '#' allowed inside of an URL fragment!
+				// Change the content displayed in the iframe
+				// First separate the member part of the fragment (if existing)
 
-            var parts = [];
+				var hash = window.location.hash.substring( 1 );
+				var splitHash = decomposePageName( hash, '.', '#' );
 
-            var dotIndex = pageName.indexOf( oldDelimiter );
+				// Creating a new Iframe instead of assigning a new src is
+				// a cross-browser solution to allow normal browser navigation;
+				// - only assigning a new src would result in two history states each time.
 
-            if ( dotIndex !== -1 ) {
+				// Note: iframe.contentWindow.location.replace(hash) should work, too,
+				// but it doesn't work in Edge with links from the subpages!
 
-                parts = pageName.split( oldDelimiter );
-                parts[ 1 ] = newDelimiter + parts[ 1 ];
+				var oldIframe;
+				var subtitle;
 
-            } else {
+				oldIframe = iframe;
+				iframe = oldIframe.cloneNode();
 
-                parts[ 0 ] = pageName;
-                parts[ 1 ] = '';
+				if(hash) {
 
-            }
+					iframe.src = splitHash[ 0 ] + '.html' + splitHash[ 1 ];
+					subtitle = ' - ' + titles[ splitHash[ 0 ] ] + splitHash[ 1 ];
 
-            return parts;
+				} else {
 
-        }
+					iframe.src = '';
+					subtitle = '';
+
+				}
+
+				document.body.replaceChild( iframe, oldIframe );
+				document.title = 'three.js docs' + subtitle;
+
+			}
+
+
+			function decomposePageName ( pageName, oldDelimiter, newDelimiter ) {
+
+				// Helper function for separating the member (if existing) from the pageName
+				// For example: 'Geometry.morphTarget' can be converted to 
+				// ['Geometry', '.morphTarget'] or ['Geometry', '#morphTarget']
+				// Note: According RFC 3986 no '#' allowed inside of an URL fragment!
+
+				var parts = [];
+
+				var dotIndex = pageName.indexOf( oldDelimiter );
+
+				if ( dotIndex !== -1 ) {
+
+					parts = pageName.split( oldDelimiter );
+					parts[ 1 ] = newDelimiter + parts[ 1 ];
+
+				} else {
+
+					parts[ 0 ] = pageName;
+					parts[ 1 ] = '';
+
+				}
+
+				return parts;
+
+			}
 
 
 // ----------------------------------------------------------------------------
@@ -423,20 +423,20 @@
 // ----------------------------------------------------------------------------
 
 
-        console.log( [
-            '    __     __',
-            ' __/ __\\  / __\\__   ____   _____   _____',
-            '/ __/  /\\/ /  /___\\/ ____\\/ _____\\/ _____\\',
-            '\\/_   __/ /   _   / /  __/ / __  / / __  /_   __   _____',
-            '/ /  / / /  / /  / /  / / /  ___/ /  ___/\\ _\\/ __\\/ _____\\',
-            '\\/__/  \\/__/\\/__/\\/__/  \\/_____/\\/_____/\\/__/ /  / /  ___/',
-            '                                         / __/  /  \\__  \\',
-            '                                         \\/____/\\/_____/'
-        ].join( '\n' ) );
+			console.log([
+				'    __     __',
+				' __/ __\\  / __\\__   ____   _____   _____',
+				'/ __/  /\\/ /  /___\\/ ____\\/ _____\\/ _____\\',
+				'\\/_   __/ /   _   / /  __/ / __  / / __  /_   __   _____',
+				'/ /  / / /  / /  / /  / / /  ___/ /  ___/\\ _\\/ __\\/ _____\\',
+				'\\/__/  \\/__/\\/__/\\/__/  \\/_____/\\/_____/\\/__/ /  / /  ___/',
+				'                                         / __/  /  \\__  \\',
+				'                                         \\/____/\\/_____/'
+			].join('\n'));
 
 
-    </script>
+		</script>
 
 
-</body>
+	</body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -437,6 +437,8 @@
 
 		</script>
 
+		<script src="../build/three.min.js"></script> <!-- console sandbox -->
 
 	</body>
+
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,7 +125,11 @@
                         var pageURL = pages[ pageName ];
 
                         var listElement = createAndAppendDOMElement( { type: 'li', parent: categoryContent } );
-                        var linkElement = createAndAppendDOMElement( { type: 'span', parent: listElement, content: pageName } );
+                        var linkElement = createAndAppendDOMElement( { type: 'a', parent: listElement, content: pageName } );
+
+                        // The href attribute is only used for the option to create a new tab by right click
+
+                        linkElement.setAttribute( 'href', '#' + pageURL );
 
                         addClickHandlers( linkElement, pageURL );
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,443 +1,438 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<title>three.js / documentation</title>
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<style>
-
-			@font-face {
-				font-family: 'inconsolata';
-				src: url('files/inconsolata.woff') format('woff');
-				font-weight: normal;
-				font-style: normal;
-			}
-
-			*{
-				box-sizing: border-box;
-			}
-
-			html {
-				height: 100%;
-			}
-
-			body {
-				background-color: #ffffff;
-				margin: 0px;
-				height: 100%;
-				color: #555;
-				font-family: 'inconsolata';
-				font-size: 15px;
-				line-height: 18px;
-				overflow: hidden;
-			}
-
-				h1 {
-					margin-top: 30px;
-					margin-bottom: 40px;
-					margin-left: 20px;
-					font-size: 25px;
-					font-weight: normal;
-				}
-
-				h2 {
-					color: #454545;
-					font-size: 18px;
-					font-weight: normal;
-
-					margin-top: 20px;
-					margin-left: 20px;
-				}
-
-				h3 {
-					color: #666;
-					font-size: 16px;
-					font-weight: normal;
-
-					margin-top: 20px;
-					margin-left: 20px;
-				}
-
-			a {
-				color: #2194CE;
-				text-decoration: none;
-			}
-
-			#panel {
-				position: fixed;
-				left: 0px;
-				width: 260px;
-				height: 100%;
-				overflow: auto;
-				background: #fafafa;
-			}
-
-				#panel ul {
-					list-style-type: none;
-					padding: 0px;
-					margin-left: 20px;
-				}
-
-			#viewer {
-				position: absolute;
-				border: 0px;
-				left: 260px;
-				width: calc(100% - 260px);
-				height: 100%;
-				overflow: auto;
-			}
-
-			.filterBlock{
-				margin: 20px;
-				position: relative;
-			}
-			.filterBlock p {
-				margin: 0;
-			}
-
-			#filterInput {
-				width: 100%;
-				padding: 5px;
-				font-family: inherit;
-				font-size: 15px;
-				outline: none;
-				border: 1px solid #dedede;
-			}
-
-			#filterInput:focus{
-				border: 1px solid #2194CE;
-			}
-
-			#clearFilterButton {
-				position: absolute;
-				right: 6px;
-				top: 50%;
-				margin-top: -8px;
-				width: 16px;
-				height: 16px;
-				font-size: 14px;
-				color: grey;
-				text-align: center;
-				line-height: 0;
-				padding-top: 7px;
-				opacity: .5;
-			}
-
-			#clearFilterButton:hover {
-				opacity: 1;
-			}
-
-			.filtered {
-				display: none;
-			}
-
-			#panel li b {
-				font-weight: bold;
-			}
-
-			/* mobile */
-
-			#expandButton {
-				display: none;
-				position: absolute;
-				right: 20px;
-				top: 12px;
-				width: 32px;
-				height: 32px;
-			}
-
-				#expandButton span {
-					height: 2px;
-					background-color: #2194CE;
-					width: 16px;
-					position: absolute;
-					left: 8px;
-					top: 10px;
-				}
-
-				#expandButton span:nth-child(1) {
-					top: 16px;
-				}
-
-				#expandButton span:nth-child(2) {
-					top: 22px;
-				}
-
-			@media all and ( max-width: 640px ) {
-				h1{
-					margin-top: 20px;
-					margin-bottom: 20px;
-				}
-				#panel{
-					position: absolute;
-					left: 0;
-					top: 0;
-					height: 480px;
-					width: 100%;
-					right: 0;
-					z-index: 100;
-					overflow: hidden;
-					border-bottom: 1px solid #dedede;
-				}
-				#content{
-					position: absolute;
-					left: 0;
-					top: 90px;
-					right: 0;
-					bottom: 0;
-					font-size: 17px;
-					line-height: 22px;
-					overflow: auto;
-				}
-				#viewer{
-					position: absolute;
-					left: 0;
-					top: 56px;
-					width: 100%;
-					height: calc(100% - 56px);
-				}
-				#expandButton{
-					display: block;
-				}
-				#panel.collapsed{
-					height: 56px;
-				}
-			}
-		</style>
-	</head>
-	<body>
-
-		<div id="panel" class="collapsed">
-			<h1><a href="http://threejs.org">three.js</a> / docs</h1>
-			<a id="expandButton" href="#">
-				<span></span>
-				<span></span>
-				<span></span>
-			</a>
-			<div class="filterBlock" >
-				<input type="text" id="filterInput" placeholder="Type to filter"/>
-				<a href="#" id="clearFilterButton" >x</a>
-			</div>
-			<div id="content"></div>
-		</div>
-		<iframe id="viewer"></iframe>
-
-		<script src="list.js"></script>
-		<script>
-
-			function extractQuery() {
-				var p = window.location.search.indexOf( '?q=' );
-				if( p !== -1 ) {
-					return window.location.search.substr( 3 );
-				}
-				return ''
-			}
-
-			var panel = document.getElementById( 'panel' );
-			var viewer = document.getElementById( 'viewer' );
-
-			var expandButton = document.getElementById( 'expandButton' );
-			expandButton.addEventListener( 'click', function ( event ) {
-				panel.classList.toggle( 'collapsed' );
-				event.preventDefault();
-			} );
-
-			var filterInput = document.getElementById( 'filterInput' );
-			var clearFilterButton = document.getElementById( 'clearFilterButton' );
-
-			var DELIMITER = '/';
-			var MEMBER_DELIMITER = '.';
-			var nameCategoryMap = {};
-			var sections = [];
-
-			var content = document.getElementById( 'content' );
-
-			for ( var section in list ) {
-
-				var h2 = document.createElement( 'h2' );
-				h2.textContent = section;
-
-				content.appendChild( h2 );
-
-				for ( var category in list[ section ] ) {
-
-					var div = document.createElement( 'div' );
-
-					var h3 = document.createElement( 'h3' );
-					h3.textContent = category;
-
-					div.appendChild( h3 );
-
-					var ul = document.createElement( 'ul' );
-					div.appendChild( ul );
-
-					for ( var i = 0; i < list[ section ][ category ].length; i ++ ) {
-
-						var page = list[ section ][ category ][ i ];
-
-						var li = document.createElement( 'li' );
-						var a = document.createElement( 'a' );
-						a.setAttribute( 'href', '#' );
-						( function( s, c, p ) {
-							a.addEventListener( 'click', function( e ) {
-								goTo( s, c, p );
-								e.preventDefault();
-							} )
-						} )( section, category, page[ 0 ] );
-						a.textContent = page[ 0 ];
-						li.appendChild( a );
-						ul.appendChild( li );
-
-						nameCategoryMap[page[0]] = {
-							section: section,
-							category: category,
-							name: page[0],
-							element: a
-						};
-
-					}
-
-					content.appendChild( div );
-					sections.push( ul );
-
-				}
-
-
-			}
-
-			panel.appendChild( content );
-
-			function layoutList() {
-
-				sections.forEach( function( el ) {
-					var collapsed = true;
-					Array.prototype.slice.apply( el.children ).forEach( function( item ) {
-						if( !item.classList.contains( 'filtered' ) ) {
-							collapsed = false;
-						}
-					} );
-					if( collapsed ) {
-						el.parentElement.classList.add( 'filtered' );
-					} else {
-						el.parentElement.classList.remove( 'filtered' );
-					}
-				} );
-			}
-
-			filterInput.addEventListener( 'input', function( e ) {
-				updateFilter();
-			} );
-
-			clearFilterButton.addEventListener( 'click', function( e ) {
-				filterInput.value = '';
-				updateFilter();
-				e.preventDefault();
-			} );
-
-			function updateFilter() {
-
-				var v = filterInput.value;
-				if( v !== '' ) {
-					window.history.replaceState( {} , '', '?q=' + v + window.location.hash );
-				} else {
-					window.history.replaceState( {} , '', window.location.pathname + window.location.hash );
-				}
-
-				var exp = new RegExp( filterInput.value, 'gi' );
-				for( var j in nameCategoryMap ) {
-					var res = nameCategoryMap[ j ].name.match( exp );
-					if( res && res.length > 0 ) {
-						nameCategoryMap[ j ].element.parentElement.classList.remove( 'filtered' );
-						var str = nameCategoryMap[ j ].name;
-						for( var i = 0; i < res.length; i++ ) {
-							var resI = res[ i ];
-							if ( resI !== '' ) {
-							    str = str.replace( resI, '<b>' + resI + '</b>' );
-							}
-						}
-						nameCategoryMap[ j ].element.innerHTML = str;
-					} else {
-						nameCategoryMap[ j ].element.parentElement.classList.add( 'filtered' );
-						nameCategoryMap[ j ].element.textContent = nameCategoryMap[ j ].name;
-					}
-				}
-				layoutList();
-
-			}
-
-			function encodeUrl( path ) {
-
-				return path.replace(/\ \/\ /g, '.').replace(/\ /g, '_');
-
-			}
-
-			function decodeUrl( path ) {
-
-				return path.replace(/_/g, ' ').replace(/\./g, ' / ');
-
-			}
-
-			// Page loading
-
-			function goTo( section, category, name, member ) {
-				var parts, location;
-
-				// Fully resolve links that only provide a name
-				if(arguments.length == 1) {
-
-					// Resolve links of the form 'Class.member'
-					if(section.indexOf(MEMBER_DELIMITER) !== -1) {
-						parts = section.split(MEMBER_DELIMITER);
-						section = parts[0];
-						member = parts[1];
-					}
-
-					location = nameCategoryMap[section];
-					if (!location) return;
-					section = location.section;
-					category = location.category;
-					name = location.name;
-				}
-
-				var title = 'three.js - documentation - ' + section + ' - ' + name;
-				var url = encodeUrl(section) + DELIMITER + encodeUrl( category ) + DELIMITER + encodeUrl(name) + (!!member ? MEMBER_DELIMITER + encodeUrl(member) : '');
-
-				window.location.hash = url;
-				window.document.title = title;
-
-				viewer.src = pages[ section ][ category ][ name ] + '.html' + (!!member ? '#'+member : '');
-
-				panel.classList.add( 'collapsed' );
-
-			}
-
-			function goToHash() {
-
-				var hash = window.location.hash.substring( 1 ).split(DELIMITER);
-				var member = hash[2].split(MEMBER_DELIMITER);
-				goTo( decodeUrl(hash[0]), decodeUrl(hash[1]), decodeUrl(member[0]), decodeUrl(member.length > 1 ? member[1] : '') );
-
-			}
-
-			window.addEventListener( 'hashchange', goToHash, false );
-
-			if ( window.location.hash.length > 0 ) goToHash();
-
-			console.log([
-				'    __     __',
-				' __/ __\\  / __\\__   ____   _____   _____',
-				'/ __/  /\\/ /  /___\\/ ____\\/ _____\\/ _____\\',
-				'\\/_   __/ /   _   / /  __/ / __  / / __  /_   __   _____',
-				'/ /  / / /  / /  / /  / / /  ___/ /  ___/\\ _\\/ __\\/ _____\\',
-				'\\/__/  \\/__/\\/__/\\/__/  \\/_____/\\/_____/\\/__/ /  / /  ___/',
-				'                                         / __/  /  \\__  \\',
-				'                                         \\/____/\\/_____/'
-			].join('\n'));
-
-			filterInput.value = extractQuery();
-			updateFilter( )
-
-		</script>
-		<script src="../build/three.min.js"></script> <!-- console sandbox -->
-	</body>
+<head>
+    <meta charset="utf-8">
+    <title>three.js / documentation</title>
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <link type="text/css" rel="stylesheet" href="index.css">
+</head>
+<body>
+
+    <div id="panel" class="collapsed">
+
+        <h1><a href="http://threejs.org">three.js</a> / docs</h1>
+
+        <a id="expandButton" href="#">
+            <span></span>
+            <span></span>
+            <span></span>
+        </a>
+
+        <div class="filterBlock" >
+            <input type="text" id="filterInput" placeholder="Type to filter">
+            <a href="#" id="clearFilterButton">x</a>
+        </div>
+
+    </div>
+
+    <iframe></iframe>
+
+    <script src="list.js"></script>
+
+    <script>
+
+        var panel = document.getElementById( 'panel' );
+        var clearFilterButton = document.getElementById( 'clearFilterButton' );
+        var expandButton = document.getElementById( 'expandButton' );
+        var filterInput = document.getElementById( 'filterInput' );
+        var iframe = document.querySelector( 'iframe' );
+
+        var pageProperties = {};
+        var titles = {};
+        var categoryElements = [];
+
+
+// ----------------------------------------------------------------------------
+// Initialization
+// ----------------------------------------------------------------------------
+
+
+        // Functionality for hamburger button (on small devices)
+
+        expandButton.onclick = function ( event ) {
+
+            event.preventDefault();
+            panel.classList.toggle( 'collapsed' );
+
+        };
+
+
+        // Functionality for search/filter input field
+
+        filterInput.oninput = function ( event ) {
+
+            updateFilter();
+
+        };
+
+
+        // Functionality for filter clear button
+
+        clearFilterButton.onclick = function ( event ) {
+
+            event.preventDefault();
+
+            filterInput.value = '';
+            updateFilter();
+
+        };
+
+
+        // Activate content and title change on browser navigation
+
+        window.onpopstate = createNewIframe;
+
+
+        // Create the navigation panel and configure the iframe
+
+        createNavigation();
+        createNewIframe();
+
+
+// ----------------------------------------------------------------------------
+// Navigation Panel
+// ----------------------------------------------------------------------------
+
+
+        function createNavigation () {
+
+            // Create the navigation panel using data from list.js
+
+            var navigation = createAndAppendDOMElement( { type: 'div', parent: panel } );
+
+            for ( var section in list ) {
+
+                // Create sections
+
+                var categories = list[ section ];
+
+                var sectionHead = createAndAppendDOMElement( { type: 'h2', parent: navigation, content: section } )
+
+                for ( var category in categories ) {
+
+                    // Create categories
+
+                    var pages = categories[ category ];
+
+                    var categoryContainer = createAndAppendDOMElement( { type: 'div', parent: navigation } );
+                    var categoryHead = createAndAppendDOMElement( { type: 'h3', parent: categoryContainer, content: category } );
+                    var categoryContent = createAndAppendDOMElement( { type: 'ul', parent: categoryContainer } );
+
+                    for ( var pageName in pages ) {
+
+                        // Create page links
+
+                        var pageURL = pages[ pageName ];
+
+                        var listElement = createAndAppendDOMElement( { type: 'li', parent: categoryContent } );
+                        var linkElement = createAndAppendDOMElement( { type: 'span', parent: listElement, content: pageName } );
+
+                        addClickHandlers( linkElement, pageURL );
+
+                        // Gather the main properties for the current subpage
+
+                        pageProperties[ pageName ] = {
+                            section: section,
+                            category: category,
+                            pageURL: pageURL,
+                            linkElement: linkElement
+                        };
+
+                    // Gather the document titles (used for easy access on browser navigation)
+
+                    titles[ pageURL ] = pageName;
+
+                    }
+
+                    // Gather the category elements for easy access on filtering
+
+                    categoryElements.push( categoryContent );
+
+                }
+
+            }
+
+        };
+
+
+        function createAndAppendDOMElement( properties ) {
+
+            // Helper function for creating and appending new DOM elements
+
+            var newElement = document.createElement( properties.type );
+
+            properties.parent.appendChild( newElement );
+
+            if ( properties.content ) {
+
+                newElement.textContent = properties.content;
+
+            }
+
+            return newElement;
+
+        }
+
+
+        function addClickHandlers ( linkElement, pageURL ) {
+
+            // Helper function for adding ClickHandlers to the page links
+
+            linkElement.onclick = function ( event ) {
+
+                event.preventDefault();
+
+                window.location.hash = pageURL;
+                createNewIframe();
+
+                panel.classList.add( 'collapsed' );
+
+            };
+
+        };
+
+
+// ----------------------------------------------------------------------------
+// Query Strings (optional)
+// ----------------------------------------------------------------------------
+
+
+//        (uncomment the following lines and the first line in updateFilter(), if you want query strings):
+
+//        filterInput.value = extractFromQueryString();
+//        updateFilter();
+//
+//
+//        function extractFromQueryString() {
+//
+//            var queryString = window.location.search;
+//
+//            if ( queryString.indexOf( '?q=' ) === -1 ) return '';
+//
+//            return queryString.substr( 3 );
+//
+//        }
+//
+//        function updateQueryString() {
+//
+//            var searchString = filterInput.value;
+//            var query = '';
+//
+//            if (searchString !== '') {
+//
+//                query = '?q=' + searchString;
+//
+//            }
+//
+//            window.history.replaceState( {} , '', window.location.pathname + query + window.location.hash ); 
+//
+//        }
+
+
+// ----------------------------------------------------------------------------
+// Filtering
+// ----------------------------------------------------------------------------
+
+
+        function updateFilter() {
+
+//            (uncomment the following line and the "Query strings" section, if you want query strings):
+//            updateQueryString();
+
+            var regExp = new RegExp( filterInput.value, 'gi' );
+
+            for ( var pageName in pageProperties ) {
+ 
+                var linkElement = pageProperties[ pageName ].linkElement;
+                var categoryClassList = linkElement.parentElement.classList;
+                var filterResults = pageName.match( regExp );
+
+                if ( filterResults && filterResults.length > 0 ) {
+
+                    // Accentuate matching characters
+
+                    for ( var i = 0; i < filterResults.length; i++ ) {
+
+                        var result = filterResults[ i ];
+
+                        if ( result !== '' ) {
+                            pageName = pageName.replace( result, '<b>' + result + '</b>' );
+                        }
+
+                    }
+
+                    categoryClassList.remove( 'hidden' );
+                    linkElement.innerHTML = pageName;
+
+                } else {
+
+                    // Hide all non-matching page names
+
+                    categoryClassList.add( 'hidden' );
+
+                }
+
+            }
+
+            displayFilteredPanel();
+
+        }
+
+
+        function displayFilteredPanel() {
+
+            // Show/hide categories depending on their content
+            // First check if at least one page in this category is not hidden
+
+            categoryElements.forEach( function ( category ) {
+
+                var pages = category.children;
+                var pagesLength = pages.length;
+                var sectionClassList = category.parentElement.classList;
+
+                var hideCategory = true;
+
+                for ( var i = 0; i < pagesLength; i ++ ) {
+
+                    var pageClassList = pages[ i ].classList;
+
+                    if ( ! pageClassList.contains( 'hidden' ) ) {
+
+                        hideCategory = false;
+
+                    }
+
+                }
+
+                // If and only if all page names are hidden, hide the whole category
+
+                if ( hideCategory ) {
+
+                    sectionClassList.add( 'hidden' );
+
+                } else {
+
+                    sectionClassList.remove( 'hidden' );
+
+                }
+
+            } );
+
+        }
+
+
+// ----------------------------------------------------------------------------
+// Routing
+// ----------------------------------------------------------------------------
+
+
+        function setUrlFragment( pageName ) {
+
+            // Handle navigation from the subpages (iframes):
+            // First separate the memeber (if existing) from the page name,
+            // then identify the subpage's URL and set it as URL fragment (re-adding the member)
+
+            var splitPageName = decomposePageName( pageName, '.', '.' );
+
+            var currentProperties = pageProperties[ splitPageName[ 0 ] ];
+
+            if ( currentProperties ) {
+
+                window.location.hash = currentProperties.pageURL + splitPageName[ 1 ];
+
+                createNewIframe();
+
+            }
+
+        }
+
+
+        function createNewIframe() {
+
+            // Change the content displayed in the iframe
+            // First separate the member part of the fragment (if existing)
+
+            var hash = window.location.hash.substring( 1 );
+            var splitHash = decomposePageName( hash, '.', '#' );
+
+            // Creating a new Iframe instead of assigning a new src is
+            // a cross-browser solution to allow normal browser navigation;
+            // - only assigning a new src would result in two history states each time.
+
+            // Note: iframe.contentWindow.location.replace(hash) should work, too,
+            // but it doesn't work in Edge with links from the subpages!
+
+            var oldIframe;
+            var subtitle;
+
+            oldIframe = iframe;
+            iframe = oldIframe.cloneNode();
+
+            if(hash) {
+
+                iframe.src = splitHash[ 0 ] + '.html' + splitHash[ 1 ];
+                subtitle = ' - ' + titles[ splitHash[ 0 ] ] + splitHash[ 1 ];
+
+            } else {
+
+                iframe.src = '';
+                subtitle = '';
+
+            }
+
+            document.body.replaceChild( iframe, oldIframe );
+            document.title = 'three.js docs' + subtitle;
+
+        }
+
+
+        function decomposePageName ( pageName, oldDelimiter, newDelimiter ) {
+
+            // Helper function for separating the member (if existing) from the pageName
+            // For example: 'Geometry.morphTarget' can be converted to 
+            // ['Geometry', '.morphTarget'] or ['Geometry', '#morphTarget']
+            // Note: According RFC 3986 no '#' allowed inside of an URL fragment!
+
+            var parts = [];
+
+            var dotIndex = pageName.indexOf( oldDelimiter );
+
+            if ( dotIndex !== -1 ) {
+
+                parts = pageName.split( oldDelimiter );
+                parts[ 1 ] = newDelimiter + parts[ 1 ];
+
+            } else {
+
+                parts[ 0 ] = pageName;
+                parts[ 1 ] = '';
+
+            }
+
+            return parts;
+
+        }
+
+
+// ----------------------------------------------------------------------------
+// ASCII Art ;-)
+// ----------------------------------------------------------------------------
+
+
+        console.log( [
+            '    __     __',
+            ' __/ __\\  / __\\__   ____   _____   _____',
+            '/ __/  /\\/ /  /___\\/ ____\\/ _____\\/ _____\\',
+            '\\/_   __/ /   _   / /  __/ / __  / / __  /_   __   _____',
+            '/ /  / / /  / /  / /  / / /  ___/ /  ___/\\ _\\/ __\\/ _____\\',
+            '\\/__/  \\/__/\\/__/\\/__/  \\/_____/\\/_____/\\/__/ /  / /  ___/',
+            '                                         / __/  /  \\__  \\',
+            '                                         \\/____/\\/_____/'
+        ].join( '\n' ) );
+
+
+    </script>
+
+
+</body>
 </html>

--- a/docs/list.js
+++ b/docs/list.js
@@ -1,5 +1,7 @@
 var list = {
+
     "Manual": {
+
         "Getting Started": {
             "Creating a scene": "manual/introduction/Creating-a-scene",
             "Detecting WebGL and browser compatibility": "manual/introduction/Detecting-WebGL-and-browser-compatibility",
@@ -11,16 +13,21 @@ var list = {
             "FAQ": "manual/introduction/FAQ",
             "Useful links": "manual/introduction/Useful-links"
         },
+
         "Next Steps": {
             "How to update things": "manual/introduction/How-to-update-things",
             "Matrix transformations": "manual/introduction/Matrix-transformations",
             "Animation System": "manual/introduction/Animation-system"
         },
+
         "Build Tools": {
             "Testing with NPM": "manual/buildTools/Testing-with-NPM"
         }
+
     },
+
     "Reference": {
+
         "Animation": {
             "AnimationAction": "api/animation/AnimationAction",
             "AnimationClip": "api/animation/AnimationClip",
@@ -31,6 +38,7 @@ var list = {
             "PropertyBinding": "api/animation/PropertyBinding",
             "PropertyMixer": "api/animation/PropertyMixer"
         },
+
         "Animation / Tracks": {
             "BooleanKeyframeTrack": "api/animation/tracks/BooleanKeyframeTrack",
             "ColorKeyframeTrack": "api/animation/tracks/ColorKeyframeTrack",
@@ -39,6 +47,7 @@ var list = {
             "StringKeyframeTrack": "api/animation/tracks/StringKeyframeTrack",
             "VectorKeyframeTrack": "api/animation/tracks/VectorKeyframeTrack"
         },
+
         "Audio": {
             "Audio": "api/audio/Audio",
             "AudioAnalyser": "api/audio/AudioAnalyser",
@@ -46,6 +55,7 @@ var list = {
             "AudioListener": "api/audio/AudioListener",
             "PositionalAudio": "api/audio/PositionalAudio"
         },
+
         "Cameras": {
             "Camera": "api/cameras/Camera",
             "CubeCamera": "api/cameras/CubeCamera",
@@ -53,6 +63,7 @@ var list = {
             "PerspectiveCamera": "api/cameras/PerspectiveCamera",
             "StereoCamera": "api/cameras/StereoCamera"
         },
+
         "Constants": {
             "Animation": "api/constants/Animation",
             "Core": "api/constants/Core",
@@ -62,6 +73,7 @@ var list = {
             "Renderer": "api/constants/Renderer",
             "Textures": "api/constants/Textures"
         },
+
         "Core": {
             "BufferAttribute": "api/core/BufferAttribute",
             "BufferGeometry": "api/core/BufferGeometry",
@@ -80,17 +92,21 @@ var list = {
             "Raycaster": "api/core/Raycaster",
             "Uniform": "api/core/Uniform"
         },
+
         "Core / BufferAttributes": {
             "BufferAttribute Types": "api/core/bufferAttributeTypes/BufferAttributeTypes"
         },
+
         "Deprecated": {
             "DeprecatedList": "api/deprecated/DeprecatedList"
         },
+
         "Extras": {
             "CurveUtils": "api/extras/CurveUtils",
             "SceneUtils": "api/extras/SceneUtils",
             "ShapeUtils": "api/extras/ShapeUtils"
         },
+
         "Extras / Core": {
             "Curve": "api/extras/core/Curve",
             "CurvePath": "api/extras/core/CurvePath",
@@ -99,6 +115,7 @@ var list = {
             "Shape": "api/extras/core/Shape",
             "ShapePath": "api/extras/core/ShapePath"
         },
+
         "Extras / Curves": {
             "ArcCurve": "api/extras/curves/ArcCurve",
             "CatmullRomCurve3": "api/extras/curves/CatmullRomCurve3",
@@ -111,10 +128,12 @@ var list = {
             "QuadraticBezierCurve3": "api/extras/curves/QuadraticBezierCurve3",
             "SplineCurve": "api/extras/curves/SplineCurve"
         },
+
         "Extras / Objects": {
             "ImmediateRenderObject": "api/extras/objects/ImmediateRenderObject",
             "MorphBlendMesh": "api/extras/objects/MorphBlendMesh"
         },
+
         "Geometries": {
             "BoxBufferGeometry": "api/geometries/BoxBufferGeometry",
             "BoxGeometry": "api/geometries/BoxGeometry",
@@ -158,6 +177,7 @@ var list = {
             "TubeBufferGeometry": "api/geometries/TubeBufferGeometry",
             "WireframeGeometry": "api/geometries/WireframeGeometry"
         },
+
         "Helpers": {
             "ArrowHelper": "api/helpers/ArrowHelper",
             "AxisHelper": "api/helpers/AxisHelper",
@@ -174,6 +194,7 @@ var list = {
             "SpotLightHelper": "api/helpers/SpotLightHelper",
             "VertexNormalsHelper": "api/helpers/VertexNormalsHelper"
         },
+
         "Lights": {
             "AmbientLight": "api/lights/AmbientLight",
             "DirectionalLight": "api/lights/DirectionalLight",
@@ -183,12 +204,14 @@ var list = {
             "RectAreaLight": "api/lights/RectAreaLight",
             "SpotLight": "api/lights/SpotLight"
         },
+
         "Lights / Shadows": {
             "DirectionalLightShadow": "api/lights/shadows/DirectionalLightShadow",
             "LightShadow": "api/lights/shadows/LightShadow",
             "RectAreaLightShadow": "api/lights/shadows/RectAreaLightShadow",
             "SpotLightShadow": "api/lights/shadows/SpotLightShadow"
         },
+
         "Loaders": {
             "AnimationLoader": "api/loaders/AnimationLoader",
             "AudioLoader": "api/loaders/AudioLoader",
@@ -206,10 +229,12 @@ var list = {
             "ObjectLoader": "api/loaders/ObjectLoader",
             "TextureLoader": "api/loaders/TextureLoader"
         },
+
         "Loaders / Managers": {
             "DefaultLoadingManager": "api/loaders/managers/DefaultLoadingManager",
             "LoadingManager": "api/loaders/managers/LoadingManager"
         },
+
         "Materials": {
             "LineBasicMaterial": "api/materials/LineBasicMaterial",
             "LineDashedMaterial": "api/materials/LineDashedMaterial",
@@ -228,6 +253,7 @@ var list = {
             "ShadowMaterial": "api/materials/ShadowMaterial",
             "SpriteMaterial": "api/materials/SpriteMaterial"
         },
+
         "Math": {
             "Box2": "api/math/Box2",
             "Box3": "api/math/Box3",
@@ -250,12 +276,14 @@ var list = {
             "Vector3": "api/math/Vector3",
             "Vector4": "api/math/Vector4"
         },
+
         "Math / Interpolants": {
             "CubicInterpolant": "api/math/interpolants/CubicInterpolant",
             "DiscreteInterpolant": "api/math/interpolants/DiscreteInterpolant",
             "LinearInterpolant": "api/math/interpolants/LinearInterpolant",
             "QuaternionLinearInterpolant": "api/math/interpolants/QuaternionLinearInterpolant"
         },
+
         "Objects": {
             "Bone": "api/objects/Bone",
             "Group": "api/objects/Group",
@@ -270,22 +298,26 @@ var list = {
             "SkinnedMesh": "api/objects/SkinnedMesh",
             "Sprite": "api/objects/Sprite"
         },
+
         "Renderers": {
             "WebGLRenderer": "api/renderers/WebGLRenderer",
             "WebGLRenderTarget": "api/renderers/WebGLRenderTarget",
             "WebGLRenderTargetCube": "api/renderers/WebGLRenderTargetCube"
         },
+
         "Renderers / Shaders": {
             "ShaderChunk": "api/renderers/shaders/ShaderChunk",
             "ShaderLib": "api/renderers/shaders/ShaderLib",
             "UniformsLib": "api/renderers/shaders/UniformsLib",
             "UniformsUtils": "api/renderers/shaders/UniformsUtils"
         },
+
         "Scenes": {
             "Fog": "api/scenes/Fog",
             "FogExp2": "api/scenes/FogExp2",
             "Scene": "api/scenes/Scene"
         },
+
         "Textures": {
             "CanvasTexture": "api/textures/CanvasTexture",
             "CompressedTexture": "api/textures/CompressedTexture",
@@ -295,17 +327,22 @@ var list = {
             "Texture": "api/textures/Texture",
             "VideoTexture": "api/textures/VideoTexture"
         }
+
     },
+
     "Examples": {
+
         "Collada Animation": {
             "ColladaAnimation": "examples/collada/Animation",
             "AnimationHandler": "examples/collada/AnimationHandler",
             "KeyFrameAnimation": "examples/collada/KeyFrameAnimation"
         },
+
         "Geometries": {
             "ConvexBufferGeometry": "examples/geometries/ConvexBufferGeometry",
             "ConvexGeometry": "examples/geometries/ConvexGeometry"
         },
+
         "Loaders": {
             "BabylonLoader": "examples/loaders/BabylonLoader",
             "ColladaLoader": "examples/loaders/ColladaLoader",
@@ -317,11 +354,13 @@ var list = {
             "SVGLoader": "examples/loaders/SVGLoader",
             "TGALoader": "examples/loaders/TGALoader"
         },
+
         "Plugins": {
             "CombinedCamera": "examples/cameras/CombinedCamera",
             "LookupTable": "examples/Lut",
             "SpriteCanvasMaterial": "examples/SpriteCanvasMaterial"
         },
+
         "QuickHull": {
             "Face": "examples/quickhull/Face",
             "HalfEdge": "examples/quickhull/HalfEdge",
@@ -329,22 +368,30 @@ var list = {
             "VertexNode": "examples/quickhull/VertexNode",
             "VertexList": "examples/quickhull/VertexList"
         },
+
         "Renderers": {
             "CanvasRenderer": "examples/renderers/CanvasRenderer"
         }
+
     },
+
     "Developer Reference": {
+
         "Polyfills": {
             "Polyfills": "api/Polyfills"
         },
+
         "WebGLRenderer": {
             "WebGLProgram": "api/renderers/webgl/WebGLProgram",
             "WebGLShader": "api/renderers/webgl/WebGLShader",
             "WebGLState": "api/renderers/webgl/WebGLState"
         },
+
         "WebGLRenderer / Plugins": {
             "LensFlarePlugin": "api/renderers/webgl/plugins/LensFlarePlugin",
             "SpritePlugin": "api/renderers/webgl/plugins/SpritePlugin"
         }
+
     }
+
 }

--- a/docs/list.js
+++ b/docs/list.js
@@ -1,415 +1,350 @@
 var list = {
-
-	"Manual": {
-		"Getting Started": [
-			[ "Creating a scene", "manual/introduction/Creating-a-scene" ],
-			[ "Detecting WebGL and browser compatibility", "manual/introduction/Detecting-WebGL-and-browser-compatibility" ],
-			[ "How to run things locally", "manual/introduction/How-to-run-thing-locally" ],
-			[ "Drawing Lines", "manual/introduction/Drawing-lines" ],
-			[ "Creating Text", "manual/introduction/Creating-text" ],
-			[ "Migration Guide", "manual/introduction/Migration-guide" ],
-			[ "Code Style Guide", "manual/introduction/Code-style-guide" ],
-			[ "FAQ", "manual/introduction/FAQ" ],
-			[ "Useful links", "manual/introduction/Useful-links" ]
-		],
-
-		"Next Steps": [
-			[ "How to update things", "manual/introduction/How-to-update-things" ],
-			[ "Matrix transformations", "manual/introduction/Matrix-transformations" ],
-            [ "Animation System", "manual/introduction/Animation-system" ]
-		],
-
-		"Build Tools": [
-			[ "Testing with NPM", "manual/buildTools/Testing-with-NPM" ]
-		]
-	},
-
-	"Reference": {
-
-		"Animation": [
-			[ "AnimationAction", "api/animation/AnimationAction" ],
-			[ "AnimationClip", "api/animation/AnimationClip" ],
-			[ "AnimationMixer", "api/animation/AnimationMixer" ],
-			[ "AnimationObjectGroup", "api/animation/AnimationObjectGroup" ],
-			[ "AnimationUtils", "api/animation/AnimationUtils" ],
-			[ "KeyframeTrack", "api/animation/KeyframeTrack" ],
-			[ "PropertyBinding", "api/animation/PropertyBinding" ],
-			[ "PropertyMixer", "api/animation/PropertyMixer" ]
-		],
-
-		"Animation / Tracks": [
-		  [ "BooleanKeyframeTrack", "api/animation/tracks/BooleanKeyframeTrack" ],
-		  [ "ColorKeyframeTrack", "api/animation/tracks/ColorKeyframeTrack" ],
-		  [ "NumberKeyframeTrack", "api/animation/tracks/NumberKeyframeTrack" ],
-		  [ "QuaternionKeyframeTrack", "api/animation/tracks/QuaternionKeyframeTrack" ],
-		  [ "StringKeyframeTrack", "api/animation/tracks/StringKeyframeTrack" ],
-		  [ "VectorKeyframeTrack", "api/animation/tracks/VectorKeyframeTrack" ]
-		],
-
-		"Audio": [
-			[ "Audio", "api/audio/Audio" ],
-			[ "AudioAnalyser", "api/audio/AudioAnalyser" ],
-			[ "AudioContext", "api/audio/AudioContext" ],
-			[ "AudioListener", "api/audio/AudioListener" ],
-			[ "PositionalAudio", "api/audio/PositionalAudio" ]
-		],
-
-		"Cameras": [
-			[ "Camera", "api/cameras/Camera" ],
-			[ "CubeCamera", "api/cameras/CubeCamera" ],
-			[ "OrthographicCamera", "api/cameras/OrthographicCamera" ],
-			[ "PerspectiveCamera", "api/cameras/PerspectiveCamera" ],
-			[ "StereoCamera", "api/cameras/StereoCamera" ]
-		],
-
-		"Constants": [
-			[ "Animation", "api/constants/Animation" ],
-			[ "Core", "api/constants/Core" ],
-			[ "CustomBlendingEquation", "api/constants/CustomBlendingEquations" ],
-			[ "DrawModes", "api/constants/DrawModes" ],
-			[ "Materials", "api/constants/Materials" ],
-			[ "Renderer", "api/constants/Renderer" ],
-			[ "Textures", "api/constants/Textures" ]
-		],
-
-		"Core": [
-			[ "BufferAttribute", "api/core/BufferAttribute" ],
-			[ "BufferGeometry", "api/core/BufferGeometry" ],
-			[ "Clock", "api/core/Clock" ],
-			[ "DirectGeometry", "api/core/DirectGeometry" ],
-			[ "EventDispatcher", "api/core/EventDispatcher" ],
-			[ "Face3", "api/core/Face3" ],
-			[ "Geometry", "api/core/Geometry" ],
-			[ "InstancedBufferAttribute", "api/core/InstancedBufferAttribute" ],
-			[ "InstancedBufferGeometry", "api/core/InstancedBufferGeometry" ],
-			[ "InstancedInterleavedBuffer", "api/core/InstancedInterleavedBuffer" ],
-			[ "InterleavedBuffer", "api/core/InterleavedBuffer" ],
-			[ "InterleavedBufferAttribute", "api/core/InterleavedBufferAttribute" ],
-			[ "Layers", "api/core/Layers" ],
-			[ "Object3D", "api/core/Object3D" ],
-			[ "Raycaster", "api/core/Raycaster" ],
-			[ "Uniform", "api/core/Uniform" ]
-		],
-
-		"Core / BufferAttributes": [
-			[ "BufferAttribute Types", "api/core/bufferAttributeTypes/BufferAttributeTypes" ]
-		],
-
-		"Deprecated": [
-			[ "DeprecatedList", "api/deprecated/DeprecatedList" ]
-		],
-
-		"Extras": [
-			[ "CurveUtils", "api/extras/CurveUtils" ],
-			[ "SceneUtils", "api/extras/SceneUtils" ],
-			[ "ShapeUtils", "api/extras/ShapeUtils" ]
-		],
-
-		"Extras / Core": [
-			[ "Curve", "api/extras/core/Curve" ],
-			[ "CurvePath", "api/extras/core/CurvePath" ],
-			[ "Font", "api/extras/core/Font" ],
-			[ "Path", "api/extras/core/Path" ],
-			[ "Shape", "api/extras/core/Shape" ],
-			[ "ShapePath", "api/extras/core/ShapePath" ]
-		],
-
-		"Extras / Curves": [
-			[ "ArcCurve", "api/extras/curves/ArcCurve" ],
-			[ "CatmullRomCurve3", "api/extras/curves/CatmullRomCurve3" ],
-			[ "CubicBezierCurve", "api/extras/curves/CubicBezierCurve" ],
-			[ "CubicBezierCurve3", "api/extras/curves/CubicBezierCurve3" ],
-			[ "EllipseCurve", "api/extras/curves/EllipseCurve" ],
-			[ "LineCurve", "api/extras/curves/LineCurve" ],
-			[ "LineCurve3", "api/extras/curves/LineCurve3" ],
-			[ "QuadraticBezierCurve", "api/extras/curves/QuadraticBezierCurve" ],
-			[ "QuadraticBezierCurve3", "api/extras/curves/QuadraticBezierCurve3" ],
-			[ "SplineCurve", "api/extras/curves/SplineCurve" ]
-		],
-
-		"Extras / Objects": [
-			[ "ImmediateRenderObject", "api/extras/objects/ImmediateRenderObject" ],
-			[ "MorphBlendMesh", "api/extras/objects/MorphBlendMesh" ]
-		],
-
-		"Geometries": [
-			[ "BoxBufferGeometry", "api/geometries/BoxBufferGeometry" ],
-			[ "BoxGeometry", "api/geometries/BoxGeometry" ],
-			[ "CircleBufferGeometry", "api/geometries/CircleBufferGeometry" ],
-			[ "CircleGeometry", "api/geometries/CircleGeometry" ],
-			[ "ConeBufferGeometry", "api/geometries/ConeBufferGeometry" ],
-			[ "ConeGeometry", "api/geometries/ConeGeometry" ],
-			[ "CylinderBufferGeometry", "api/geometries/CylinderBufferGeometry" ],
-			[ "CylinderGeometry", "api/geometries/CylinderGeometry" ],
-			[ "DodecahedronBufferGeometry", "api/geometries/DodecahedronBufferGeometry" ],
-			[ "DodecahedronGeometry", "api/geometries/DodecahedronGeometry" ],
-			[ "EdgesGeometry", "api/geometries/EdgesGeometry" ],
-			[ "ExtrudeGeometry", "api/geometries/ExtrudeGeometry" ],
-			[ "ExtrudeBufferGeometry", "api/geometries/ExtrudeBufferGeometry" ],
-			[ "IcosahedronBufferGeometry", "api/geometries/IcosahedronBufferGeometry" ],
-			[ "IcosahedronGeometry", "api/geometries/IcosahedronGeometry" ],
-			[ "LatheBufferGeometry", "api/geometries/LatheBufferGeometry" ],
-			[ "LatheGeometry", "api/geometries/LatheGeometry" ],
-			[ "OctahedronBufferGeometry", "api/geometries/OctahedronBufferGeometry" ],
-			[ "OctahedronGeometry", "api/geometries/OctahedronGeometry" ],
-			[ "ParametricBufferGeometry", "api/geometries/ParametricBufferGeometry" ],
-			[ "ParametricGeometry", "api/geometries/ParametricGeometry" ],
-			[ "PlaneBufferGeometry", "api/geometries/PlaneBufferGeometry" ],
-			[ "PlaneGeometry", "api/geometries/PlaneGeometry" ],
-			[ "PolyhedronBufferGeometry", "api/geometries/PolyhedronBufferGeometry" ],
-			[ "PolyhedronGeometry", "api/geometries/PolyhedronGeometry" ],
-			[ "RingBufferGeometry", "api/geometries/RingBufferGeometry" ],
-			[ "RingGeometry", "api/geometries/RingGeometry" ],
-			[ "ShapeBufferGeometry", "api/geometries/ShapeBufferGeometry" ],
-			[ "ShapeGeometry", "api/geometries/ShapeGeometry" ],
-			[ "SphereBufferGeometry", "api/geometries/SphereBufferGeometry" ],
-			[ "SphereGeometry", "api/geometries/SphereGeometry" ],
-			[ "TetrahedronBufferGeometry", "api/geometries/TetrahedronBufferGeometry" ],
-			[ "TetrahedronGeometry", "api/geometries/TetrahedronGeometry" ],
-			[ "TextGeometry", "api/geometries/TextGeometry" ],
-			[ "TorusBufferGeometry", "api/geometries/TorusBufferGeometry" ],
-			[ "TorusGeometry", "api/geometries/TorusGeometry" ],
-			[ "TorusKnotBufferGeometry", "api/geometries/TorusKnotBufferGeometry" ],
-			[ "TorusKnotGeometry", "api/geometries/TorusKnotGeometry" ],
-			[ "TubeGeometry", "api/geometries/TubeGeometry" ],
-			[ "TubeBufferGeometry", "api/geometries/TubeBufferGeometry" ],
-			[ "WireframeGeometry", "api/geometries/WireframeGeometry" ]
-		],
-
-		"Helpers": [
-			[ "ArrowHelper", "api/helpers/ArrowHelper" ],
-			[ "AxisHelper", "api/helpers/AxisHelper" ],
-			[ "BoxHelper", "api/helpers/BoxHelper" ],
-			[ "CameraHelper", "api/helpers/CameraHelper" ],
-			[ "DirectionalLightHelper", "api/helpers/DirectionalLightHelper" ],
-			[ "FaceNormalsHelper", "api/helpers/FaceNormalsHelper" ],
-			[ "GridHelper", "api/helpers/GridHelper" ],
-			[ "PolarGridHelper", "api/helpers/PolarGridHelper" ],
-			[ "HemisphereLightHelper", "api/helpers/HemisphereLightHelper" ],
-			[ "PointLightHelper", "api/helpers/PointLightHelper" ],
-			[ "RectAreaLightHelper", "api/helpers/RectAreaLightHelper" ],
-			[ "SkeletonHelper", "api/helpers/SkeletonHelper" ],
-			[ "SpotLightHelper", "api/helpers/SpotLightHelper" ],
-			[ "VertexNormalsHelper", "api/helpers/VertexNormalsHelper" ]
-		],
-
-		"Lights": [
-			[ "AmbientLight", "api/lights/AmbientLight" ],
-			[ "DirectionalLight", "api/lights/DirectionalLight" ],
-			[ "HemisphereLight", "api/lights/HemisphereLight" ],
-			[ "Light", "api/lights/Light" ],
-			[ "PointLight", "api/lights/PointLight" ],
-			[ "RectAreaLight", "api/lights/RectAreaLight" ],
-			[ "SpotLight", "api/lights/SpotLight" ]
-		],
-
-		"Lights / Shadows": [
-			[ "DirectionalLightShadow", "api/lights/shadows/DirectionalLightShadow" ],
-			[ "LightShadow", "api/lights/shadows/LightShadow" ],
-			[ "RectAreaLightShadow", "api/lights/shadows/RectAreaLightShadow" ],
-			[ "SpotLightShadow", "api/lights/shadows/SpotLightShadow" ]
-		],
-
-		"Loaders": [
-			[ "AnimationLoader", "api/loaders/AnimationLoader" ],
-			[ "AudioLoader", "api/loaders/AudioLoader" ],
-			[ "BufferGeometryLoader", "api/loaders/BufferGeometryLoader" ],
-			[ "Cache", "api/loaders/Cache" ],
-			[ "CompressedTextureLoader", "api/loaders/CompressedTextureLoader" ],
-			[ "CubeTextureLoader", "api/loaders/CubeTextureLoader" ],
-			[ "DataTextureLoader", "api/loaders/DataTextureLoader" ],
-			[ "FileLoader", "api/loaders/FileLoader" ],
-			[ "FontLoader", "api/loaders/FontLoader" ],
-			[ "ImageLoader", "api/loaders/ImageLoader" ],
-			[ "JSONLoader", "api/loaders/JSONLoader" ],
-			[ "Loader", "api/loaders/Loader" ],
-			[ "MaterialLoader", "api/loaders/MaterialLoader" ],
-			[ "ObjectLoader", "api/loaders/ObjectLoader" ],
-			[ "TextureLoader", "api/loaders/TextureLoader" ]
-		],
-
-		"Loaders / Managers": [
-			[ "DefaultLoadingManager", "api/loaders/managers/DefaultLoadingManager" ],
-			[ "LoadingManager", "api/loaders/managers/LoadingManager" ]
-		],
-
-		"Materials": [
-			[ "LineBasicMaterial", "api/materials/LineBasicMaterial" ],
-			[ "LineDashedMaterial", "api/materials/LineDashedMaterial" ],
-			[ "Material", "api/materials/Material" ],
-			[ "MeshBasicMaterial", "api/materials/MeshBasicMaterial" ],
-			[ "MeshDepthMaterial", "api/materials/MeshDepthMaterial" ],
-			[ "MeshLambertMaterial", "api/materials/MeshLambertMaterial" ],
-			[ "MeshNormalMaterial", "api/materials/MeshNormalMaterial" ],
-			[ "MeshPhongMaterial", "api/materials/MeshPhongMaterial" ],
-			[ "MeshPhysicalMaterial", "api/materials/MeshPhysicalMaterial" ],
-			[ "MeshStandardMaterial", "api/materials/MeshStandardMaterial" ],
-			[ "MeshToonMaterial", "api/materials/MeshToonMaterial" ],
-			[ "PointsMaterial", "api/materials/PointsMaterial" ],
-			[ "RawShaderMaterial", "api/materials/RawShaderMaterial" ],
-			[ "ShaderMaterial", "api/materials/ShaderMaterial" ],
-			[ "ShadowMaterial", "api/materials/ShadowMaterial" ],
-			[ "SpriteMaterial", "api/materials/SpriteMaterial" ]
-		],
-
-		"Math": [
-			[ "Box2", "api/math/Box2" ],
-			[ "Box3", "api/math/Box3" ],
-			[ "Color", "api/math/Color" ],
-			[ "Cylindrical", "api/math/Cylindrical" ],
-			[ "Euler", "api/math/Euler" ],
-			[ "Frustum", "api/math/Frustum" ],
-			[ "Interpolant", "api/math/Interpolant" ],
-			[ "Line3", "api/math/Line3" ],
-			[ "Math", "api/math/Math" ],
-			[ "Matrix3", "api/math/Matrix3" ],
-			[ "Matrix4", "api/math/Matrix4" ],
-			[ "Plane", "api/math/Plane" ],
-			[ "Quaternion", "api/math/Quaternion" ],
-			[ "Ray", "api/math/Ray" ],
-			[ "Sphere", "api/math/Sphere" ],
-			[ "Spherical", "api/math/Spherical" ],
-			[ "Triangle", "api/math/Triangle" ],
-			[ "Vector2", "api/math/Vector2" ],
-			[ "Vector3", "api/math/Vector3" ],
-			[ "Vector4", "api/math/Vector4" ]
-		],
-
-		"Math / Interpolants": [
-			[ "CubicInterpolant", "api/math/interpolants/CubicInterpolant" ],
-			[ "DiscreteInterpolant", "api/math/interpolants/DiscreteInterpolant" ],
-			[ "LinearInterpolant", "api/math/interpolants/LinearInterpolant" ],
-			[ "QuaternionLinearInterpolant", "api/math/interpolants/QuaternionLinearInterpolant" ]
-		],
-
-		"Objects": [
-			[ "Bone", "api/objects/Bone" ],
-			[ "Group", "api/objects/Group" ],
-			[ "LensFlare", "api/objects/LensFlare" ],
-			[ "Line", "api/objects/Line" ],
-			[ "LineLoop", "api/objects/LineLoop" ],
-			[ "LineSegments", "api/objects/LineSegments" ],
-			[ "LOD", "api/objects/LOD" ],
-			[ "Mesh", "api/objects/Mesh" ],
-			[ "Points", "api/objects/Points" ],
-			[ "Skeleton", "api/objects/Skeleton" ],
-			[ "SkinnedMesh", "api/objects/SkinnedMesh" ],
-			[ "Sprite", "api/objects/Sprite" ]
-		],
-
-		"Renderers": [
-			[ "WebGLRenderer", "api/renderers/WebGLRenderer" ],
-			[ "WebGLRenderTarget", "api/renderers/WebGLRenderTarget" ],
-			[ "WebGLRenderTargetCube", "api/renderers/WebGLRenderTargetCube" ]
-		],
-
-		"Renderers / Shaders": [
-			[ "ShaderChunk", "api/renderers/shaders/ShaderChunk" ],
-			[ "ShaderLib", "api/renderers/shaders/ShaderLib" ],
-			[ "UniformsLib", "api/renderers/shaders/UniformsLib" ],
-			[ "UniformsUtils", "api/renderers/shaders/UniformsUtils" ]
-		],
-
-		"Scenes": [
-			[ "Fog", "api/scenes/Fog" ],
-			[ "FogExp2", "api/scenes/FogExp2" ],
-			[ "Scene", "api/scenes/Scene" ]
-		],
-
-		"Textures": [
-			[ "CanvasTexture", "api/textures/CanvasTexture" ],
-			[ "CompressedTexture", "api/textures/CompressedTexture" ],
-			[ "CubeTexture", "api/textures/CubeTexture" ],
-			[ "DataTexture", "api/textures/DataTexture" ],
-			[ "DepthTexture", "api/textures/DepthTexture" ],
-			[ "Texture", "api/textures/Texture" ],
-			[ "VideoTexture", "api/textures/VideoTexture" ]
-		]
-
-	},
-
-	"Examples": {
-
-		"Collada Animation": [
-			[ "ColladaAnimation", "examples/collada/Animation" ],
-			[ "AnimationHandler", "examples/collada/AnimationHandler" ],
-			[ "KeyFrameAnimation", "examples/collada/KeyFrameAnimation" ]
-		],
-
-		"Geometries": [
-			[ "ConvexBufferGeometry", "examples/geometries/ConvexBufferGeometry" ],
-			[ "ConvexGeometry", "examples/geometries/ConvexGeometry" ]
-		],
-
-		"Loaders": [
-			[ "BabylonLoader", "examples/loaders/BabylonLoader" ],
-			[ "ColladaLoader", "examples/loaders/ColladaLoader" ],
-			[ "GLTF2Loader", "examples/loaders/GLTF2Loader" ],
-			[ "MTLLoader", "examples/loaders/MTLLoader" ],
-			[ "OBJLoader", "examples/loaders/OBJLoader" ],
-			[ "PCDLoader", "examples/loaders/PCDLoader" ],
-			[ "PDBLoader", "examples/loaders/PDBLoader" ],
-			[ "SVGLoader", "examples/loaders/SVGLoader" ],
-			[ "TGALoader", "examples/loaders/TGALoader" ]
-		],
-
-		"Plugins": [
-			[ "CombinedCamera", "examples/cameras/CombinedCamera" ],
-			[ "LookupTable", "examples/Lut" ],
-			[ "SpriteCanvasMaterial", "examples/SpriteCanvasMaterial" ]
-		],
-
-		"QuickHull": [
-			[ "Face", "examples/quickhull/Face" ],
-			[ "HalfEdge", "examples/quickhull/HalfEdge" ],
-			[ "QuickHull", "examples/quickhull/QuickHull" ],
-			[ "VertexNode", "examples/quickhull/VertexNode" ],
-			[ "VertexList", "examples/quickhull/VertexList" ]
-		],
-
-		"Renderers": [
-			[ "CanvasRenderer", "examples/renderers/CanvasRenderer" ]
-		]
-
-	},
-
-	"Developer Reference": {
-		"Polyfills": [
-			[ "Polyfills", "api/Polyfills" ]
-		],
-
-		"WebGLRenderer": [
-			[ "WebGLProgram", "api/renderers/webgl/WebGLProgram" ],
-			[ "WebGLShader", "api/renderers/webgl/WebGLShader" ],
-			[ "WebGLState", "api/renderers/webgl/WebGLState" ]
-		],
-
-		"WebGLRenderer / Plugins": [
-			[ "LensFlarePlugin", "api/renderers/webgl/plugins/LensFlarePlugin" ],
-			[ "SpritePlugin", "api/renderers/webgl/plugins/SpritePlugin" ]
-		]
-
-	}
-
-};
-
-var pages = {};
-
-for ( var section in list ) {
-
-	pages[ section ] = {};
-
-	for ( var category in list[ section ] ) {
-
-		pages[ section ][ category ] = {};
-
-		for ( var i = 0; i < list[ section ][ category ].length; i ++ ) {
-
-			var page = list[ section ][ category ][ i ];
-			pages[ section ][ category ][ page[ 0 ] ] = page[ 1 ];
-
-		}
-
-	}
-
+    "Manual": {
+        "Getting Started": {
+            "Creating a scene": "manual/introduction/Creating-a-scene",
+            "Detecting WebGL and browser compatibility": "manual/introduction/Detecting-WebGL-and-browser-compatibility",
+            "How to run things locally": "manual/introduction/How-to-run-thing-locally",
+            "Drawing Lines": "manual/introduction/Drawing-lines",
+            "Creating Text": "manual/introduction/Creating-text",
+            "Migration Guide": "manual/introduction/Migration-guide",
+            "Code Style Guide": "manual/introduction/Code-style-guide",
+            "FAQ": "manual/introduction/FAQ",
+            "Useful links": "manual/introduction/Useful-links"
+        },
+        "Next Steps": {
+            "How to update things": "manual/introduction/How-to-update-things",
+            "Matrix transformations": "manual/introduction/Matrix-transformations",
+            "Animation System": "manual/introduction/Animation-system"
+        },
+        "Build Tools": {
+            "Testing with NPM": "manual/buildTools/Testing-with-NPM"
+        }
+    },
+    "Reference": {
+        "Animation": {
+            "AnimationAction": "api/animation/AnimationAction",
+            "AnimationClip": "api/animation/AnimationClip",
+            "AnimationMixer": "api/animation/AnimationMixer",
+            "AnimationObjectGroup": "api/animation/AnimationObjectGroup",
+            "AnimationUtils": "api/animation/AnimationUtils",
+            "KeyframeTrack": "api/animation/KeyframeTrack",
+            "PropertyBinding": "api/animation/PropertyBinding",
+            "PropertyMixer": "api/animation/PropertyMixer"
+        },
+        "Animation / Tracks": {
+            "BooleanKeyframeTrack": "api/animation/tracks/BooleanKeyframeTrack",
+            "ColorKeyframeTrack": "api/animation/tracks/ColorKeyframeTrack",
+            "NumberKeyframeTrack": "api/animation/tracks/NumberKeyframeTrack",
+            "QuaternionKeyframeTrack": "api/animation/tracks/QuaternionKeyframeTrack",
+            "StringKeyframeTrack": "api/animation/tracks/StringKeyframeTrack",
+            "VectorKeyframeTrack": "api/animation/tracks/VectorKeyframeTrack"
+        },
+        "Audio": {
+            "Audio": "api/audio/Audio",
+            "AudioAnalyser": "api/audio/AudioAnalyser",
+            "AudioContext": "api/audio/AudioContext",
+            "AudioListener": "api/audio/AudioListener",
+            "PositionalAudio": "api/audio/PositionalAudio"
+        },
+        "Cameras": {
+            "Camera": "api/cameras/Camera",
+            "CubeCamera": "api/cameras/CubeCamera",
+            "OrthographicCamera": "api/cameras/OrthographicCamera",
+            "PerspectiveCamera": "api/cameras/PerspectiveCamera",
+            "StereoCamera": "api/cameras/StereoCamera"
+        },
+        "Constants": {
+            "Animation": "api/constants/Animation",
+            "Core": "api/constants/Core",
+            "CustomBlendingEquation": "api/constants/CustomBlendingEquations",
+            "DrawModes": "api/constants/DrawModes",
+            "Materials": "api/constants/Materials",
+            "Renderer": "api/constants/Renderer",
+            "Textures": "api/constants/Textures"
+        },
+        "Core": {
+            "BufferAttribute": "api/core/BufferAttribute",
+            "BufferGeometry": "api/core/BufferGeometry",
+            "Clock": "api/core/Clock",
+            "DirectGeometry": "api/core/DirectGeometry",
+            "EventDispatcher": "api/core/EventDispatcher",
+            "Face3": "api/core/Face3",
+            "Geometry": "api/core/Geometry",
+            "InstancedBufferAttribute": "api/core/InstancedBufferAttribute",
+            "InstancedBufferGeometry": "api/core/InstancedBufferGeometry",
+            "InstancedInterleavedBuffer": "api/core/InstancedInterleavedBuffer",
+            "InterleavedBuffer": "api/core/InterleavedBuffer",
+            "InterleavedBufferAttribute": "api/core/InterleavedBufferAttribute",
+            "Layers": "api/core/Layers",
+            "Object3D": "api/core/Object3D",
+            "Raycaster": "api/core/Raycaster",
+            "Uniform": "api/core/Uniform"
+        },
+        "Core / BufferAttributes": {
+            "BufferAttribute Types": "api/core/bufferAttributeTypes/BufferAttributeTypes"
+        },
+        "Deprecated": {
+            "DeprecatedList": "api/deprecated/DeprecatedList"
+        },
+        "Extras": {
+            "CurveUtils": "api/extras/CurveUtils",
+            "SceneUtils": "api/extras/SceneUtils",
+            "ShapeUtils": "api/extras/ShapeUtils"
+        },
+        "Extras / Core": {
+            "Curve": "api/extras/core/Curve",
+            "CurvePath": "api/extras/core/CurvePath",
+            "Font": "api/extras/core/Font",
+            "Path": "api/extras/core/Path",
+            "Shape": "api/extras/core/Shape",
+            "ShapePath": "api/extras/core/ShapePath"
+        },
+        "Extras / Curves": {
+            "ArcCurve": "api/extras/curves/ArcCurve",
+            "CatmullRomCurve3": "api/extras/curves/CatmullRomCurve3",
+            "CubicBezierCurve": "api/extras/curves/CubicBezierCurve",
+            "CubicBezierCurve3": "api/extras/curves/CubicBezierCurve3",
+            "EllipseCurve": "api/extras/curves/EllipseCurve",
+            "LineCurve": "api/extras/curves/LineCurve",
+            "LineCurve3": "api/extras/curves/LineCurve3",
+            "QuadraticBezierCurve": "api/extras/curves/QuadraticBezierCurve",
+            "QuadraticBezierCurve3": "api/extras/curves/QuadraticBezierCurve3",
+            "SplineCurve": "api/extras/curves/SplineCurve"
+        },
+        "Extras / Objects": {
+            "ImmediateRenderObject": "api/extras/objects/ImmediateRenderObject",
+            "MorphBlendMesh": "api/extras/objects/MorphBlendMesh"
+        },
+        "Geometries": {
+            "BoxBufferGeometry": "api/geometries/BoxBufferGeometry",
+            "BoxGeometry": "api/geometries/BoxGeometry",
+            "CircleBufferGeometry": "api/geometries/CircleBufferGeometry",
+            "CircleGeometry": "api/geometries/CircleGeometry",
+            "ConeBufferGeometry": "api/geometries/ConeBufferGeometry",
+            "ConeGeometry": "api/geometries/ConeGeometry",
+            "CylinderBufferGeometry": "api/geometries/CylinderBufferGeometry",
+            "CylinderGeometry": "api/geometries/CylinderGeometry",
+            "DodecahedronBufferGeometry": "api/geometries/DodecahedronBufferGeometry",
+            "DodecahedronGeometry": "api/geometries/DodecahedronGeometry",
+            "EdgesGeometry": "api/geometries/EdgesGeometry",
+            "ExtrudeGeometry": "api/geometries/ExtrudeGeometry",
+            "ExtrudeBufferGeometry": "api/geometries/ExtrudeBufferGeometry",
+            "IcosahedronBufferGeometry": "api/geometries/IcosahedronBufferGeometry",
+            "IcosahedronGeometry": "api/geometries/IcosahedronGeometry",
+            "LatheBufferGeometry": "api/geometries/LatheBufferGeometry",
+            "LatheGeometry": "api/geometries/LatheGeometry",
+            "OctahedronBufferGeometry": "api/geometries/OctahedronBufferGeometry",
+            "OctahedronGeometry": "api/geometries/OctahedronGeometry",
+            "ParametricBufferGeometry": "api/geometries/ParametricBufferGeometry",
+            "ParametricGeometry": "api/geometries/ParametricGeometry",
+            "PlaneBufferGeometry": "api/geometries/PlaneBufferGeometry",
+            "PlaneGeometry": "api/geometries/PlaneGeometry",
+            "PolyhedronBufferGeometry": "api/geometries/PolyhedronBufferGeometry",
+            "PolyhedronGeometry": "api/geometries/PolyhedronGeometry",
+            "RingBufferGeometry": "api/geometries/RingBufferGeometry",
+            "RingGeometry": "api/geometries/RingGeometry",
+            "ShapeBufferGeometry": "api/geometries/ShapeBufferGeometry",
+            "ShapeGeometry": "api/geometries/ShapeGeometry",
+            "SphereBufferGeometry": "api/geometries/SphereBufferGeometry",
+            "SphereGeometry": "api/geometries/SphereGeometry",
+            "TetrahedronBufferGeometry": "api/geometries/TetrahedronBufferGeometry",
+            "TetrahedronGeometry": "api/geometries/TetrahedronGeometry",
+            "TextGeometry": "api/geometries/TextGeometry",
+            "TorusBufferGeometry": "api/geometries/TorusBufferGeometry",
+            "TorusGeometry": "api/geometries/TorusGeometry",
+            "TorusKnotBufferGeometry": "api/geometries/TorusKnotBufferGeometry",
+            "TorusKnotGeometry": "api/geometries/TorusKnotGeometry",
+            "TubeGeometry": "api/geometries/TubeGeometry",
+            "TubeBufferGeometry": "api/geometries/TubeBufferGeometry",
+            "WireframeGeometry": "api/geometries/WireframeGeometry"
+        },
+        "Helpers": {
+            "ArrowHelper": "api/helpers/ArrowHelper",
+            "AxisHelper": "api/helpers/AxisHelper",
+            "BoxHelper": "api/helpers/BoxHelper",
+            "CameraHelper": "api/helpers/CameraHelper",
+            "DirectionalLightHelper": "api/helpers/DirectionalLightHelper",
+            "FaceNormalsHelper": "api/helpers/FaceNormalsHelper",
+            "GridHelper": "api/helpers/GridHelper",
+            "PolarGridHelper": "api/helpers/PolarGridHelper",
+            "HemisphereLightHelper": "api/helpers/HemisphereLightHelper",
+            "PointLightHelper": "api/helpers/PointLightHelper",
+            "RectAreaLightHelper": "api/helpers/RectAreaLightHelper",
+            "SkeletonHelper": "api/helpers/SkeletonHelper",
+            "SpotLightHelper": "api/helpers/SpotLightHelper",
+            "VertexNormalsHelper": "api/helpers/VertexNormalsHelper"
+        },
+        "Lights": {
+            "AmbientLight": "api/lights/AmbientLight",
+            "DirectionalLight": "api/lights/DirectionalLight",
+            "HemisphereLight": "api/lights/HemisphereLight",
+            "Light": "api/lights/Light",
+            "PointLight": "api/lights/PointLight",
+            "RectAreaLight": "api/lights/RectAreaLight",
+            "SpotLight": "api/lights/SpotLight"
+        },
+        "Lights / Shadows": {
+            "DirectionalLightShadow": "api/lights/shadows/DirectionalLightShadow",
+            "LightShadow": "api/lights/shadows/LightShadow",
+            "RectAreaLightShadow": "api/lights/shadows/RectAreaLightShadow",
+            "SpotLightShadow": "api/lights/shadows/SpotLightShadow"
+        },
+        "Loaders": {
+            "AnimationLoader": "api/loaders/AnimationLoader",
+            "AudioLoader": "api/loaders/AudioLoader",
+            "BufferGeometryLoader": "api/loaders/BufferGeometryLoader",
+            "Cache": "api/loaders/Cache",
+            "CompressedTextureLoader": "api/loaders/CompressedTextureLoader",
+            "CubeTextureLoader": "api/loaders/CubeTextureLoader",
+            "DataTextureLoader": "api/loaders/DataTextureLoader",
+            "FileLoader": "api/loaders/FileLoader",
+            "FontLoader": "api/loaders/FontLoader",
+            "ImageLoader": "api/loaders/ImageLoader",
+            "JSONLoader": "api/loaders/JSONLoader",
+            "Loader": "api/loaders/Loader",
+            "MaterialLoader": "api/loaders/MaterialLoader",
+            "ObjectLoader": "api/loaders/ObjectLoader",
+            "TextureLoader": "api/loaders/TextureLoader"
+        },
+        "Loaders / Managers": {
+            "DefaultLoadingManager": "api/loaders/managers/DefaultLoadingManager",
+            "LoadingManager": "api/loaders/managers/LoadingManager"
+        },
+        "Materials": {
+            "LineBasicMaterial": "api/materials/LineBasicMaterial",
+            "LineDashedMaterial": "api/materials/LineDashedMaterial",
+            "Material": "api/materials/Material",
+            "MeshBasicMaterial": "api/materials/MeshBasicMaterial",
+            "MeshDepthMaterial": "api/materials/MeshDepthMaterial",
+            "MeshLambertMaterial": "api/materials/MeshLambertMaterial",
+            "MeshNormalMaterial": "api/materials/MeshNormalMaterial",
+            "MeshPhongMaterial": "api/materials/MeshPhongMaterial",
+            "MeshPhysicalMaterial": "api/materials/MeshPhysicalMaterial",
+            "MeshStandardMaterial": "api/materials/MeshStandardMaterial",
+            "MeshToonMaterial": "api/materials/MeshToonMaterial",
+            "PointsMaterial": "api/materials/PointsMaterial",
+            "RawShaderMaterial": "api/materials/RawShaderMaterial",
+            "ShaderMaterial": "api/materials/ShaderMaterial",
+            "ShadowMaterial": "api/materials/ShadowMaterial",
+            "SpriteMaterial": "api/materials/SpriteMaterial"
+        },
+        "Math": {
+            "Box2": "api/math/Box2",
+            "Box3": "api/math/Box3",
+            "Color": "api/math/Color",
+            "Cylindrical": "api/math/Cylindrical",
+            "Euler": "api/math/Euler",
+            "Frustum": "api/math/Frustum",
+            "Interpolant": "api/math/Interpolant",
+            "Line3": "api/math/Line3",
+            "Math": "api/math/Math",
+            "Matrix3": "api/math/Matrix3",
+            "Matrix4": "api/math/Matrix4",
+            "Plane": "api/math/Plane",
+            "Quaternion": "api/math/Quaternion",
+            "Ray": "api/math/Ray",
+            "Sphere": "api/math/Sphere",
+            "Spherical": "api/math/Spherical",
+            "Triangle": "api/math/Triangle",
+            "Vector2": "api/math/Vector2",
+            "Vector3": "api/math/Vector3",
+            "Vector4": "api/math/Vector4"
+        },
+        "Math / Interpolants": {
+            "CubicInterpolant": "api/math/interpolants/CubicInterpolant",
+            "DiscreteInterpolant": "api/math/interpolants/DiscreteInterpolant",
+            "LinearInterpolant": "api/math/interpolants/LinearInterpolant",
+            "QuaternionLinearInterpolant": "api/math/interpolants/QuaternionLinearInterpolant"
+        },
+        "Objects": {
+            "Bone": "api/objects/Bone",
+            "Group": "api/objects/Group",
+            "LensFlare": "api/objects/LensFlare",
+            "Line": "api/objects/Line",
+            "LineLoop": "api/objects/LineLoop",
+            "LineSegments": "api/objects/LineSegments",
+            "LOD": "api/objects/LOD",
+            "Mesh": "api/objects/Mesh",
+            "Points": "api/objects/Points",
+            "Skeleton": "api/objects/Skeleton",
+            "SkinnedMesh": "api/objects/SkinnedMesh",
+            "Sprite": "api/objects/Sprite"
+        },
+        "Renderers": {
+            "WebGLRenderer": "api/renderers/WebGLRenderer",
+            "WebGLRenderTarget": "api/renderers/WebGLRenderTarget",
+            "WebGLRenderTargetCube": "api/renderers/WebGLRenderTargetCube"
+        },
+        "Renderers / Shaders": {
+            "ShaderChunk": "api/renderers/shaders/ShaderChunk",
+            "ShaderLib": "api/renderers/shaders/ShaderLib",
+            "UniformsLib": "api/renderers/shaders/UniformsLib",
+            "UniformsUtils": "api/renderers/shaders/UniformsUtils"
+        },
+        "Scenes": {
+            "Fog": "api/scenes/Fog",
+            "FogExp2": "api/scenes/FogExp2",
+            "Scene": "api/scenes/Scene"
+        },
+        "Textures": {
+            "CanvasTexture": "api/textures/CanvasTexture",
+            "CompressedTexture": "api/textures/CompressedTexture",
+            "CubeTexture": "api/textures/CubeTexture",
+            "DataTexture": "api/textures/DataTexture",
+            "DepthTexture": "api/textures/DepthTexture",
+            "Texture": "api/textures/Texture",
+            "VideoTexture": "api/textures/VideoTexture"
+        }
+    },
+    "Examples": {
+        "Collada Animation": {
+            "ColladaAnimation": "examples/collada/Animation",
+            "AnimationHandler": "examples/collada/AnimationHandler",
+            "KeyFrameAnimation": "examples/collada/KeyFrameAnimation"
+        },
+        "Geometries": {
+            "ConvexBufferGeometry": "examples/geometries/ConvexBufferGeometry",
+            "ConvexGeometry": "examples/geometries/ConvexGeometry"
+        },
+        "Loaders": {
+            "BabylonLoader": "examples/loaders/BabylonLoader",
+            "ColladaLoader": "examples/loaders/ColladaLoader",
+            "GLTF2Loader": "examples/loaders/GLTF2Loader",
+            "MTLLoader": "examples/loaders/MTLLoader",
+            "OBJLoader": "examples/loaders/OBJLoader",
+            "PCDLoader": "examples/loaders/PCDLoader",
+            "PDBLoader": "examples/loaders/PDBLoader",
+            "SVGLoader": "examples/loaders/SVGLoader",
+            "TGALoader": "examples/loaders/TGALoader"
+        },
+        "Plugins": {
+            "CombinedCamera": "examples/cameras/CombinedCamera",
+            "LookupTable": "examples/Lut",
+            "SpriteCanvasMaterial": "examples/SpriteCanvasMaterial"
+        },
+        "QuickHull": {
+            "Face": "examples/quickhull/Face",
+            "HalfEdge": "examples/quickhull/HalfEdge",
+            "QuickHull": "examples/quickhull/QuickHull",
+            "VertexNode": "examples/quickhull/VertexNode",
+            "VertexList": "examples/quickhull/VertexList"
+        },
+        "Renderers": {
+            "CanvasRenderer": "examples/renderers/CanvasRenderer"
+        }
+    },
+    "Developer Reference": {
+        "Polyfills": {
+            "Polyfills": "api/Polyfills"
+        },
+        "WebGLRenderer": {
+            "WebGLProgram": "api/renderers/webgl/WebGLProgram",
+            "WebGLShader": "api/renderers/webgl/WebGLShader",
+            "WebGLState": "api/renderers/webgl/WebGLState"
+        },
+        "WebGLRenderer / Plugins": {
+            "LensFlarePlugin": "api/renderers/webgl/plugins/LensFlarePlugin",
+            "SpritePlugin": "api/renderers/webgl/plugins/SpritePlugin"
+        }
+    }
 }

--- a/docs/list.js
+++ b/docs/list.js
@@ -1,397 +1,397 @@
 var list = {
 
-    "Manual": {
+	"Manual": {
 
-        "Getting Started": {
-            "Creating a scene": "manual/introduction/Creating-a-scene",
-            "Detecting WebGL and browser compatibility": "manual/introduction/Detecting-WebGL-and-browser-compatibility",
-            "How to run things locally": "manual/introduction/How-to-run-thing-locally",
-            "Drawing Lines": "manual/introduction/Drawing-lines",
-            "Creating Text": "manual/introduction/Creating-text",
-            "Migration Guide": "manual/introduction/Migration-guide",
-            "Code Style Guide": "manual/introduction/Code-style-guide",
-            "FAQ": "manual/introduction/FAQ",
-            "Useful links": "manual/introduction/Useful-links"
-        },
+		"Getting Started": {
+			"Creating a scene": "manual/introduction/Creating-a-scene",
+			"Detecting WebGL and browser compatibility": "manual/introduction/Detecting-WebGL-and-browser-compatibility",
+			"How to run things locally": "manual/introduction/How-to-run-thing-locally",
+			"Drawing Lines": "manual/introduction/Drawing-lines",
+			"Creating Text": "manual/introduction/Creating-text",
+			"Migration Guide": "manual/introduction/Migration-guide",
+			"Code Style Guide": "manual/introduction/Code-style-guide",
+			"FAQ": "manual/introduction/FAQ",
+			"Useful links": "manual/introduction/Useful-links"
+		},
 
-        "Next Steps": {
-            "How to update things": "manual/introduction/How-to-update-things",
-            "Matrix transformations": "manual/introduction/Matrix-transformations",
-            "Animation System": "manual/introduction/Animation-system"
-        },
+		"Next Steps": {
+			"How to update things": "manual/introduction/How-to-update-things",
+			"Matrix transformations": "manual/introduction/Matrix-transformations",
+			"Animation System": "manual/introduction/Animation-system"
+		},
 
-        "Build Tools": {
-            "Testing with NPM": "manual/buildTools/Testing-with-NPM"
-        }
+		"Build Tools": {
+			"Testing with NPM": "manual/buildTools/Testing-with-NPM"
+		}
 
-    },
+	},
 
-    "Reference": {
+	"Reference": {
 
-        "Animation": {
-            "AnimationAction": "api/animation/AnimationAction",
-            "AnimationClip": "api/animation/AnimationClip",
-            "AnimationMixer": "api/animation/AnimationMixer",
-            "AnimationObjectGroup": "api/animation/AnimationObjectGroup",
-            "AnimationUtils": "api/animation/AnimationUtils",
-            "KeyframeTrack": "api/animation/KeyframeTrack",
-            "PropertyBinding": "api/animation/PropertyBinding",
-            "PropertyMixer": "api/animation/PropertyMixer"
-        },
+		"Animation": {
+			"AnimationAction": "api/animation/AnimationAction",
+			"AnimationClip": "api/animation/AnimationClip",
+			"AnimationMixer": "api/animation/AnimationMixer",
+			"AnimationObjectGroup": "api/animation/AnimationObjectGroup",
+			"AnimationUtils": "api/animation/AnimationUtils",
+			"KeyframeTrack": "api/animation/KeyframeTrack",
+			"PropertyBinding": "api/animation/PropertyBinding",
+			"PropertyMixer": "api/animation/PropertyMixer"
+		},
 
-        "Animation / Tracks": {
-            "BooleanKeyframeTrack": "api/animation/tracks/BooleanKeyframeTrack",
-            "ColorKeyframeTrack": "api/animation/tracks/ColorKeyframeTrack",
-            "NumberKeyframeTrack": "api/animation/tracks/NumberKeyframeTrack",
-            "QuaternionKeyframeTrack": "api/animation/tracks/QuaternionKeyframeTrack",
-            "StringKeyframeTrack": "api/animation/tracks/StringKeyframeTrack",
-            "VectorKeyframeTrack": "api/animation/tracks/VectorKeyframeTrack"
-        },
+		"Animation / Tracks": {
+			"BooleanKeyframeTrack": "api/animation/tracks/BooleanKeyframeTrack",
+			"ColorKeyframeTrack": "api/animation/tracks/ColorKeyframeTrack",
+			"NumberKeyframeTrack": "api/animation/tracks/NumberKeyframeTrack",
+			"QuaternionKeyframeTrack": "api/animation/tracks/QuaternionKeyframeTrack",
+			"StringKeyframeTrack": "api/animation/tracks/StringKeyframeTrack",
+			"VectorKeyframeTrack": "api/animation/tracks/VectorKeyframeTrack"
+		},
 
-        "Audio": {
-            "Audio": "api/audio/Audio",
-            "AudioAnalyser": "api/audio/AudioAnalyser",
-            "AudioContext": "api/audio/AudioContext",
-            "AudioListener": "api/audio/AudioListener",
-            "PositionalAudio": "api/audio/PositionalAudio"
-        },
+		"Audio": {
+			"Audio": "api/audio/Audio",
+			"AudioAnalyser": "api/audio/AudioAnalyser",
+			"AudioContext": "api/audio/AudioContext",
+			"AudioListener": "api/audio/AudioListener",
+			"PositionalAudio": "api/audio/PositionalAudio"
+		},
 
-        "Cameras": {
-            "Camera": "api/cameras/Camera",
-            "CubeCamera": "api/cameras/CubeCamera",
-            "OrthographicCamera": "api/cameras/OrthographicCamera",
-            "PerspectiveCamera": "api/cameras/PerspectiveCamera",
-            "StereoCamera": "api/cameras/StereoCamera"
-        },
+		"Cameras": {
+			"Camera": "api/cameras/Camera",
+			"CubeCamera": "api/cameras/CubeCamera",
+			"OrthographicCamera": "api/cameras/OrthographicCamera",
+			"PerspectiveCamera": "api/cameras/PerspectiveCamera",
+			"StereoCamera": "api/cameras/StereoCamera"
+		},
 
-        "Constants": {
-            "Animation": "api/constants/Animation",
-            "Core": "api/constants/Core",
-            "CustomBlendingEquation": "api/constants/CustomBlendingEquations",
-            "DrawModes": "api/constants/DrawModes",
-            "Materials": "api/constants/Materials",
-            "Renderer": "api/constants/Renderer",
-            "Textures": "api/constants/Textures"
-        },
+		"Constants": {
+			"Animation": "api/constants/Animation",
+			"Core": "api/constants/Core",
+			"CustomBlendingEquation": "api/constants/CustomBlendingEquations",
+			"DrawModes": "api/constants/DrawModes",
+			"Materials": "api/constants/Materials",
+			"Renderer": "api/constants/Renderer",
+			"Textures": "api/constants/Textures"
+		},
 
-        "Core": {
-            "BufferAttribute": "api/core/BufferAttribute",
-            "BufferGeometry": "api/core/BufferGeometry",
-            "Clock": "api/core/Clock",
-            "DirectGeometry": "api/core/DirectGeometry",
-            "EventDispatcher": "api/core/EventDispatcher",
-            "Face3": "api/core/Face3",
-            "Geometry": "api/core/Geometry",
-            "InstancedBufferAttribute": "api/core/InstancedBufferAttribute",
-            "InstancedBufferGeometry": "api/core/InstancedBufferGeometry",
-            "InstancedInterleavedBuffer": "api/core/InstancedInterleavedBuffer",
-            "InterleavedBuffer": "api/core/InterleavedBuffer",
-            "InterleavedBufferAttribute": "api/core/InterleavedBufferAttribute",
-            "Layers": "api/core/Layers",
-            "Object3D": "api/core/Object3D",
-            "Raycaster": "api/core/Raycaster",
-            "Uniform": "api/core/Uniform"
-        },
+		"Core": {
+			"BufferAttribute": "api/core/BufferAttribute",
+			"BufferGeometry": "api/core/BufferGeometry",
+			"Clock": "api/core/Clock",
+			"DirectGeometry": "api/core/DirectGeometry",
+			"EventDispatcher": "api/core/EventDispatcher",
+			"Face3": "api/core/Face3",
+			"Geometry": "api/core/Geometry",
+			"InstancedBufferAttribute": "api/core/InstancedBufferAttribute",
+			"InstancedBufferGeometry": "api/core/InstancedBufferGeometry",
+			"InstancedInterleavedBuffer": "api/core/InstancedInterleavedBuffer",
+			"InterleavedBuffer": "api/core/InterleavedBuffer",
+			"InterleavedBufferAttribute": "api/core/InterleavedBufferAttribute",
+			"Layers": "api/core/Layers",
+			"Object3D": "api/core/Object3D",
+			"Raycaster": "api/core/Raycaster",
+			"Uniform": "api/core/Uniform"
+		},
 
-        "Core / BufferAttributes": {
-            "BufferAttribute Types": "api/core/bufferAttributeTypes/BufferAttributeTypes"
-        },
+		"Core / BufferAttributes": {
+			"BufferAttribute Types": "api/core/bufferAttributeTypes/BufferAttributeTypes"
+		},
 
-        "Deprecated": {
-            "DeprecatedList": "api/deprecated/DeprecatedList"
-        },
+		"Deprecated": {
+			"DeprecatedList": "api/deprecated/DeprecatedList"
+		},
 
-        "Extras": {
-            "CurveUtils": "api/extras/CurveUtils",
-            "SceneUtils": "api/extras/SceneUtils",
-            "ShapeUtils": "api/extras/ShapeUtils"
-        },
+		"Extras": {
+			"CurveUtils": "api/extras/CurveUtils",
+			"SceneUtils": "api/extras/SceneUtils",
+			"ShapeUtils": "api/extras/ShapeUtils"
+		},
 
-        "Extras / Core": {
-            "Curve": "api/extras/core/Curve",
-            "CurvePath": "api/extras/core/CurvePath",
-            "Font": "api/extras/core/Font",
-            "Path": "api/extras/core/Path",
-            "Shape": "api/extras/core/Shape",
-            "ShapePath": "api/extras/core/ShapePath"
-        },
+		"Extras / Core": {
+			"Curve": "api/extras/core/Curve",
+			"CurvePath": "api/extras/core/CurvePath",
+			"Font": "api/extras/core/Font",
+			"Path": "api/extras/core/Path",
+			"Shape": "api/extras/core/Shape",
+			"ShapePath": "api/extras/core/ShapePath"
+		},
 
-        "Extras / Curves": {
-            "ArcCurve": "api/extras/curves/ArcCurve",
-            "CatmullRomCurve3": "api/extras/curves/CatmullRomCurve3",
-            "CubicBezierCurve": "api/extras/curves/CubicBezierCurve",
-            "CubicBezierCurve3": "api/extras/curves/CubicBezierCurve3",
-            "EllipseCurve": "api/extras/curves/EllipseCurve",
-            "LineCurve": "api/extras/curves/LineCurve",
-            "LineCurve3": "api/extras/curves/LineCurve3",
-            "QuadraticBezierCurve": "api/extras/curves/QuadraticBezierCurve",
-            "QuadraticBezierCurve3": "api/extras/curves/QuadraticBezierCurve3",
-            "SplineCurve": "api/extras/curves/SplineCurve"
-        },
+		"Extras / Curves": {
+			"ArcCurve": "api/extras/curves/ArcCurve",
+			"CatmullRomCurve3": "api/extras/curves/CatmullRomCurve3",
+			"CubicBezierCurve": "api/extras/curves/CubicBezierCurve",
+			"CubicBezierCurve3": "api/extras/curves/CubicBezierCurve3",
+			"EllipseCurve": "api/extras/curves/EllipseCurve",
+			"LineCurve": "api/extras/curves/LineCurve",
+			"LineCurve3": "api/extras/curves/LineCurve3",
+			"QuadraticBezierCurve": "api/extras/curves/QuadraticBezierCurve",
+			"QuadraticBezierCurve3": "api/extras/curves/QuadraticBezierCurve3",
+			"SplineCurve": "api/extras/curves/SplineCurve"
+		},
 
-        "Extras / Objects": {
-            "ImmediateRenderObject": "api/extras/objects/ImmediateRenderObject",
-            "MorphBlendMesh": "api/extras/objects/MorphBlendMesh"
-        },
+		"Extras / Objects": {
+			"ImmediateRenderObject": "api/extras/objects/ImmediateRenderObject",
+			"MorphBlendMesh": "api/extras/objects/MorphBlendMesh"
+		},
 
-        "Geometries": {
-            "BoxBufferGeometry": "api/geometries/BoxBufferGeometry",
-            "BoxGeometry": "api/geometries/BoxGeometry",
-            "CircleBufferGeometry": "api/geometries/CircleBufferGeometry",
-            "CircleGeometry": "api/geometries/CircleGeometry",
-            "ConeBufferGeometry": "api/geometries/ConeBufferGeometry",
-            "ConeGeometry": "api/geometries/ConeGeometry",
-            "CylinderBufferGeometry": "api/geometries/CylinderBufferGeometry",
-            "CylinderGeometry": "api/geometries/CylinderGeometry",
-            "DodecahedronBufferGeometry": "api/geometries/DodecahedronBufferGeometry",
-            "DodecahedronGeometry": "api/geometries/DodecahedronGeometry",
-            "EdgesGeometry": "api/geometries/EdgesGeometry",
-            "ExtrudeGeometry": "api/geometries/ExtrudeGeometry",
-            "ExtrudeBufferGeometry": "api/geometries/ExtrudeBufferGeometry",
-            "IcosahedronBufferGeometry": "api/geometries/IcosahedronBufferGeometry",
-            "IcosahedronGeometry": "api/geometries/IcosahedronGeometry",
-            "LatheBufferGeometry": "api/geometries/LatheBufferGeometry",
-            "LatheGeometry": "api/geometries/LatheGeometry",
-            "OctahedronBufferGeometry": "api/geometries/OctahedronBufferGeometry",
-            "OctahedronGeometry": "api/geometries/OctahedronGeometry",
-            "ParametricBufferGeometry": "api/geometries/ParametricBufferGeometry",
-            "ParametricGeometry": "api/geometries/ParametricGeometry",
-            "PlaneBufferGeometry": "api/geometries/PlaneBufferGeometry",
-            "PlaneGeometry": "api/geometries/PlaneGeometry",
-            "PolyhedronBufferGeometry": "api/geometries/PolyhedronBufferGeometry",
-            "PolyhedronGeometry": "api/geometries/PolyhedronGeometry",
-            "RingBufferGeometry": "api/geometries/RingBufferGeometry",
-            "RingGeometry": "api/geometries/RingGeometry",
-            "ShapeBufferGeometry": "api/geometries/ShapeBufferGeometry",
-            "ShapeGeometry": "api/geometries/ShapeGeometry",
-            "SphereBufferGeometry": "api/geometries/SphereBufferGeometry",
-            "SphereGeometry": "api/geometries/SphereGeometry",
-            "TetrahedronBufferGeometry": "api/geometries/TetrahedronBufferGeometry",
-            "TetrahedronGeometry": "api/geometries/TetrahedronGeometry",
-            "TextGeometry": "api/geometries/TextGeometry",
-            "TorusBufferGeometry": "api/geometries/TorusBufferGeometry",
-            "TorusGeometry": "api/geometries/TorusGeometry",
-            "TorusKnotBufferGeometry": "api/geometries/TorusKnotBufferGeometry",
-            "TorusKnotGeometry": "api/geometries/TorusKnotGeometry",
-            "TubeGeometry": "api/geometries/TubeGeometry",
-            "TubeBufferGeometry": "api/geometries/TubeBufferGeometry",
-            "WireframeGeometry": "api/geometries/WireframeGeometry"
-        },
+		"Geometries": {
+			"BoxBufferGeometry": "api/geometries/BoxBufferGeometry",
+			"BoxGeometry": "api/geometries/BoxGeometry",
+			"CircleBufferGeometry": "api/geometries/CircleBufferGeometry",
+			"CircleGeometry": "api/geometries/CircleGeometry",
+			"ConeBufferGeometry": "api/geometries/ConeBufferGeometry",
+			"ConeGeometry": "api/geometries/ConeGeometry",
+			"CylinderBufferGeometry": "api/geometries/CylinderBufferGeometry",
+			"CylinderGeometry": "api/geometries/CylinderGeometry",
+			"DodecahedronBufferGeometry": "api/geometries/DodecahedronBufferGeometry",
+			"DodecahedronGeometry": "api/geometries/DodecahedronGeometry",
+			"EdgesGeometry": "api/geometries/EdgesGeometry",
+			"ExtrudeGeometry": "api/geometries/ExtrudeGeometry",
+			"ExtrudeBufferGeometry": "api/geometries/ExtrudeBufferGeometry",
+			"IcosahedronBufferGeometry": "api/geometries/IcosahedronBufferGeometry",
+			"IcosahedronGeometry": "api/geometries/IcosahedronGeometry",
+			"LatheBufferGeometry": "api/geometries/LatheBufferGeometry",
+			"LatheGeometry": "api/geometries/LatheGeometry",
+			"OctahedronBufferGeometry": "api/geometries/OctahedronBufferGeometry",
+			"OctahedronGeometry": "api/geometries/OctahedronGeometry",
+			"ParametricBufferGeometry": "api/geometries/ParametricBufferGeometry",
+			"ParametricGeometry": "api/geometries/ParametricGeometry",
+			"PlaneBufferGeometry": "api/geometries/PlaneBufferGeometry",
+			"PlaneGeometry": "api/geometries/PlaneGeometry",
+			"PolyhedronBufferGeometry": "api/geometries/PolyhedronBufferGeometry",
+			"PolyhedronGeometry": "api/geometries/PolyhedronGeometry",
+			"RingBufferGeometry": "api/geometries/RingBufferGeometry",
+			"RingGeometry": "api/geometries/RingGeometry",
+			"ShapeBufferGeometry": "api/geometries/ShapeBufferGeometry",
+			"ShapeGeometry": "api/geometries/ShapeGeometry",
+			"SphereBufferGeometry": "api/geometries/SphereBufferGeometry",
+			"SphereGeometry": "api/geometries/SphereGeometry",
+			"TetrahedronBufferGeometry": "api/geometries/TetrahedronBufferGeometry",
+			"TetrahedronGeometry": "api/geometries/TetrahedronGeometry",
+			"TextGeometry": "api/geometries/TextGeometry",
+			"TorusBufferGeometry": "api/geometries/TorusBufferGeometry",
+			"TorusGeometry": "api/geometries/TorusGeometry",
+			"TorusKnotBufferGeometry": "api/geometries/TorusKnotBufferGeometry",
+			"TorusKnotGeometry": "api/geometries/TorusKnotGeometry",
+			"TubeGeometry": "api/geometries/TubeGeometry",
+			"TubeBufferGeometry": "api/geometries/TubeBufferGeometry",
+			"WireframeGeometry": "api/geometries/WireframeGeometry"
+		},
 
-        "Helpers": {
-            "ArrowHelper": "api/helpers/ArrowHelper",
-            "AxisHelper": "api/helpers/AxisHelper",
-            "BoxHelper": "api/helpers/BoxHelper",
-            "CameraHelper": "api/helpers/CameraHelper",
-            "DirectionalLightHelper": "api/helpers/DirectionalLightHelper",
-            "FaceNormalsHelper": "api/helpers/FaceNormalsHelper",
-            "GridHelper": "api/helpers/GridHelper",
-            "PolarGridHelper": "api/helpers/PolarGridHelper",
-            "HemisphereLightHelper": "api/helpers/HemisphereLightHelper",
-            "PointLightHelper": "api/helpers/PointLightHelper",
-            "RectAreaLightHelper": "api/helpers/RectAreaLightHelper",
-            "SkeletonHelper": "api/helpers/SkeletonHelper",
-            "SpotLightHelper": "api/helpers/SpotLightHelper",
-            "VertexNormalsHelper": "api/helpers/VertexNormalsHelper"
-        },
+		"Helpers": {
+			"ArrowHelper": "api/helpers/ArrowHelper",
+			"AxisHelper": "api/helpers/AxisHelper",
+			"BoxHelper": "api/helpers/BoxHelper",
+			"CameraHelper": "api/helpers/CameraHelper",
+			"DirectionalLightHelper": "api/helpers/DirectionalLightHelper",
+			"FaceNormalsHelper": "api/helpers/FaceNormalsHelper",
+			"GridHelper": "api/helpers/GridHelper",
+			"PolarGridHelper": "api/helpers/PolarGridHelper",
+			"HemisphereLightHelper": "api/helpers/HemisphereLightHelper",
+			"PointLightHelper": "api/helpers/PointLightHelper",
+			"RectAreaLightHelper": "api/helpers/RectAreaLightHelper",
+			"SkeletonHelper": "api/helpers/SkeletonHelper",
+			"SpotLightHelper": "api/helpers/SpotLightHelper",
+			"VertexNormalsHelper": "api/helpers/VertexNormalsHelper"
+		},
 
-        "Lights": {
-            "AmbientLight": "api/lights/AmbientLight",
-            "DirectionalLight": "api/lights/DirectionalLight",
-            "HemisphereLight": "api/lights/HemisphereLight",
-            "Light": "api/lights/Light",
-            "PointLight": "api/lights/PointLight",
-            "RectAreaLight": "api/lights/RectAreaLight",
-            "SpotLight": "api/lights/SpotLight"
-        },
+		"Lights": {
+			"AmbientLight": "api/lights/AmbientLight",
+			"DirectionalLight": "api/lights/DirectionalLight",
+			"HemisphereLight": "api/lights/HemisphereLight",
+			"Light": "api/lights/Light",
+			"PointLight": "api/lights/PointLight",
+			"RectAreaLight": "api/lights/RectAreaLight",
+			"SpotLight": "api/lights/SpotLight"
+		},
 
-        "Lights / Shadows": {
-            "DirectionalLightShadow": "api/lights/shadows/DirectionalLightShadow",
-            "LightShadow": "api/lights/shadows/LightShadow",
-            "RectAreaLightShadow": "api/lights/shadows/RectAreaLightShadow",
-            "SpotLightShadow": "api/lights/shadows/SpotLightShadow"
-        },
+		"Lights / Shadows": {
+			"DirectionalLightShadow": "api/lights/shadows/DirectionalLightShadow",
+			"LightShadow": "api/lights/shadows/LightShadow",
+			"RectAreaLightShadow": "api/lights/shadows/RectAreaLightShadow",
+			"SpotLightShadow": "api/lights/shadows/SpotLightShadow"
+		},
 
-        "Loaders": {
-            "AnimationLoader": "api/loaders/AnimationLoader",
-            "AudioLoader": "api/loaders/AudioLoader",
-            "BufferGeometryLoader": "api/loaders/BufferGeometryLoader",
-            "Cache": "api/loaders/Cache",
-            "CompressedTextureLoader": "api/loaders/CompressedTextureLoader",
-            "CubeTextureLoader": "api/loaders/CubeTextureLoader",
-            "DataTextureLoader": "api/loaders/DataTextureLoader",
-            "FileLoader": "api/loaders/FileLoader",
-            "FontLoader": "api/loaders/FontLoader",
-            "ImageLoader": "api/loaders/ImageLoader",
-            "JSONLoader": "api/loaders/JSONLoader",
-            "Loader": "api/loaders/Loader",
-            "MaterialLoader": "api/loaders/MaterialLoader",
-            "ObjectLoader": "api/loaders/ObjectLoader",
-            "TextureLoader": "api/loaders/TextureLoader"
-        },
+		"Loaders": {
+			"AnimationLoader": "api/loaders/AnimationLoader",
+			"AudioLoader": "api/loaders/AudioLoader",
+			"BufferGeometryLoader": "api/loaders/BufferGeometryLoader",
+			"Cache": "api/loaders/Cache",
+			"CompressedTextureLoader": "api/loaders/CompressedTextureLoader",
+			"CubeTextureLoader": "api/loaders/CubeTextureLoader",
+			"DataTextureLoader": "api/loaders/DataTextureLoader",
+			"FileLoader": "api/loaders/FileLoader",
+			"FontLoader": "api/loaders/FontLoader",
+			"ImageLoader": "api/loaders/ImageLoader",
+			"JSONLoader": "api/loaders/JSONLoader",
+			"Loader": "api/loaders/Loader",
+			"MaterialLoader": "api/loaders/MaterialLoader",
+			"ObjectLoader": "api/loaders/ObjectLoader",
+			"TextureLoader": "api/loaders/TextureLoader"
+		},
 
-        "Loaders / Managers": {
-            "DefaultLoadingManager": "api/loaders/managers/DefaultLoadingManager",
-            "LoadingManager": "api/loaders/managers/LoadingManager"
-        },
+		"Loaders / Managers": {
+			"DefaultLoadingManager": "api/loaders/managers/DefaultLoadingManager",
+			"LoadingManager": "api/loaders/managers/LoadingManager"
+		},
 
-        "Materials": {
-            "LineBasicMaterial": "api/materials/LineBasicMaterial",
-            "LineDashedMaterial": "api/materials/LineDashedMaterial",
-            "Material": "api/materials/Material",
-            "MeshBasicMaterial": "api/materials/MeshBasicMaterial",
-            "MeshDepthMaterial": "api/materials/MeshDepthMaterial",
-            "MeshLambertMaterial": "api/materials/MeshLambertMaterial",
-            "MeshNormalMaterial": "api/materials/MeshNormalMaterial",
-            "MeshPhongMaterial": "api/materials/MeshPhongMaterial",
-            "MeshPhysicalMaterial": "api/materials/MeshPhysicalMaterial",
-            "MeshStandardMaterial": "api/materials/MeshStandardMaterial",
-            "MeshToonMaterial": "api/materials/MeshToonMaterial",
-            "PointsMaterial": "api/materials/PointsMaterial",
-            "RawShaderMaterial": "api/materials/RawShaderMaterial",
-            "ShaderMaterial": "api/materials/ShaderMaterial",
-            "ShadowMaterial": "api/materials/ShadowMaterial",
-            "SpriteMaterial": "api/materials/SpriteMaterial"
-        },
+		"Materials": {
+			"LineBasicMaterial": "api/materials/LineBasicMaterial",
+			"LineDashedMaterial": "api/materials/LineDashedMaterial",
+			"Material": "api/materials/Material",
+			"MeshBasicMaterial": "api/materials/MeshBasicMaterial",
+			"MeshDepthMaterial": "api/materials/MeshDepthMaterial",
+			"MeshLambertMaterial": "api/materials/MeshLambertMaterial",
+			"MeshNormalMaterial": "api/materials/MeshNormalMaterial",
+			"MeshPhongMaterial": "api/materials/MeshPhongMaterial",
+			"MeshPhysicalMaterial": "api/materials/MeshPhysicalMaterial",
+			"MeshStandardMaterial": "api/materials/MeshStandardMaterial",
+			"MeshToonMaterial": "api/materials/MeshToonMaterial",
+			"PointsMaterial": "api/materials/PointsMaterial",
+			"RawShaderMaterial": "api/materials/RawShaderMaterial",
+			"ShaderMaterial": "api/materials/ShaderMaterial",
+			"ShadowMaterial": "api/materials/ShadowMaterial",
+			"SpriteMaterial": "api/materials/SpriteMaterial"
+		},
 
-        "Math": {
-            "Box2": "api/math/Box2",
-            "Box3": "api/math/Box3",
-            "Color": "api/math/Color",
-            "Cylindrical": "api/math/Cylindrical",
-            "Euler": "api/math/Euler",
-            "Frustum": "api/math/Frustum",
-            "Interpolant": "api/math/Interpolant",
-            "Line3": "api/math/Line3",
-            "Math": "api/math/Math",
-            "Matrix3": "api/math/Matrix3",
-            "Matrix4": "api/math/Matrix4",
-            "Plane": "api/math/Plane",
-            "Quaternion": "api/math/Quaternion",
-            "Ray": "api/math/Ray",
-            "Sphere": "api/math/Sphere",
-            "Spherical": "api/math/Spherical",
-            "Triangle": "api/math/Triangle",
-            "Vector2": "api/math/Vector2",
-            "Vector3": "api/math/Vector3",
-            "Vector4": "api/math/Vector4"
-        },
+		"Math": {
+			"Box2": "api/math/Box2",
+			"Box3": "api/math/Box3",
+			"Color": "api/math/Color",
+			"Cylindrical": "api/math/Cylindrical",
+			"Euler": "api/math/Euler",
+			"Frustum": "api/math/Frustum",
+			"Interpolant": "api/math/Interpolant",
+			"Line3": "api/math/Line3",
+			"Math": "api/math/Math",
+			"Matrix3": "api/math/Matrix3",
+			"Matrix4": "api/math/Matrix4",
+			"Plane": "api/math/Plane",
+			"Quaternion": "api/math/Quaternion",
+			"Ray": "api/math/Ray",
+			"Sphere": "api/math/Sphere",
+			"Spherical": "api/math/Spherical",
+			"Triangle": "api/math/Triangle",
+			"Vector2": "api/math/Vector2",
+			"Vector3": "api/math/Vector3",
+			"Vector4": "api/math/Vector4"
+		},
 
-        "Math / Interpolants": {
-            "CubicInterpolant": "api/math/interpolants/CubicInterpolant",
-            "DiscreteInterpolant": "api/math/interpolants/DiscreteInterpolant",
-            "LinearInterpolant": "api/math/interpolants/LinearInterpolant",
-            "QuaternionLinearInterpolant": "api/math/interpolants/QuaternionLinearInterpolant"
-        },
+		"Math / Interpolants": {
+			"CubicInterpolant": "api/math/interpolants/CubicInterpolant",
+			"DiscreteInterpolant": "api/math/interpolants/DiscreteInterpolant",
+			"LinearInterpolant": "api/math/interpolants/LinearInterpolant",
+			"QuaternionLinearInterpolant": "api/math/interpolants/QuaternionLinearInterpolant"
+		},
 
-        "Objects": {
-            "Bone": "api/objects/Bone",
-            "Group": "api/objects/Group",
-            "LensFlare": "api/objects/LensFlare",
-            "Line": "api/objects/Line",
-            "LineLoop": "api/objects/LineLoop",
-            "LineSegments": "api/objects/LineSegments",
-            "LOD": "api/objects/LOD",
-            "Mesh": "api/objects/Mesh",
-            "Points": "api/objects/Points",
-            "Skeleton": "api/objects/Skeleton",
-            "SkinnedMesh": "api/objects/SkinnedMesh",
-            "Sprite": "api/objects/Sprite"
-        },
+		"Objects": {
+			"Bone": "api/objects/Bone",
+			"Group": "api/objects/Group",
+			"LensFlare": "api/objects/LensFlare",
+			"Line": "api/objects/Line",
+			"LineLoop": "api/objects/LineLoop",
+			"LineSegments": "api/objects/LineSegments",
+			"LOD": "api/objects/LOD",
+			"Mesh": "api/objects/Mesh",
+			"Points": "api/objects/Points",
+			"Skeleton": "api/objects/Skeleton",
+			"SkinnedMesh": "api/objects/SkinnedMesh",
+			"Sprite": "api/objects/Sprite"
+		},
 
-        "Renderers": {
-            "WebGLRenderer": "api/renderers/WebGLRenderer",
-            "WebGLRenderTarget": "api/renderers/WebGLRenderTarget",
-            "WebGLRenderTargetCube": "api/renderers/WebGLRenderTargetCube"
-        },
+		"Renderers": {
+			"WebGLRenderer": "api/renderers/WebGLRenderer",
+			"WebGLRenderTarget": "api/renderers/WebGLRenderTarget",
+			"WebGLRenderTargetCube": "api/renderers/WebGLRenderTargetCube"
+		},
 
-        "Renderers / Shaders": {
-            "ShaderChunk": "api/renderers/shaders/ShaderChunk",
-            "ShaderLib": "api/renderers/shaders/ShaderLib",
-            "UniformsLib": "api/renderers/shaders/UniformsLib",
-            "UniformsUtils": "api/renderers/shaders/UniformsUtils"
-        },
+		"Renderers / Shaders": {
+			"ShaderChunk": "api/renderers/shaders/ShaderChunk",
+			"ShaderLib": "api/renderers/shaders/ShaderLib",
+			"UniformsLib": "api/renderers/shaders/UniformsLib",
+			"UniformsUtils": "api/renderers/shaders/UniformsUtils"
+		},
 
-        "Scenes": {
-            "Fog": "api/scenes/Fog",
-            "FogExp2": "api/scenes/FogExp2",
-            "Scene": "api/scenes/Scene"
-        },
+		"Scenes": {
+			"Fog": "api/scenes/Fog",
+			"FogExp2": "api/scenes/FogExp2",
+			"Scene": "api/scenes/Scene"
+		},
 
-        "Textures": {
-            "CanvasTexture": "api/textures/CanvasTexture",
-            "CompressedTexture": "api/textures/CompressedTexture",
-            "CubeTexture": "api/textures/CubeTexture",
-            "DataTexture": "api/textures/DataTexture",
-            "DepthTexture": "api/textures/DepthTexture",
-            "Texture": "api/textures/Texture",
-            "VideoTexture": "api/textures/VideoTexture"
-        }
+		"Textures": {
+			"CanvasTexture": "api/textures/CanvasTexture",
+			"CompressedTexture": "api/textures/CompressedTexture",
+			"CubeTexture": "api/textures/CubeTexture",
+			"DataTexture": "api/textures/DataTexture",
+			"DepthTexture": "api/textures/DepthTexture",
+			"Texture": "api/textures/Texture",
+			"VideoTexture": "api/textures/VideoTexture"
+		}
 
-    },
+	},
 
-    "Examples": {
+	"Examples": {
 
-        "Collada Animation": {
-            "ColladaAnimation": "examples/collada/Animation",
-            "AnimationHandler": "examples/collada/AnimationHandler",
-            "KeyFrameAnimation": "examples/collada/KeyFrameAnimation"
-        },
+		"Collada Animation": {
+			"ColladaAnimation": "examples/collada/Animation",
+			"AnimationHandler": "examples/collada/AnimationHandler",
+			"KeyFrameAnimation": "examples/collada/KeyFrameAnimation"
+		},
 
-        "Geometries": {
-            "ConvexBufferGeometry": "examples/geometries/ConvexBufferGeometry",
-            "ConvexGeometry": "examples/geometries/ConvexGeometry"
-        },
+		"Geometries": {
+			"ConvexBufferGeometry": "examples/geometries/ConvexBufferGeometry",
+			"ConvexGeometry": "examples/geometries/ConvexGeometry"
+		},
 
-        "Loaders": {
-            "BabylonLoader": "examples/loaders/BabylonLoader",
-            "ColladaLoader": "examples/loaders/ColladaLoader",
-            "GLTF2Loader": "examples/loaders/GLTF2Loader",
-            "MTLLoader": "examples/loaders/MTLLoader",
-            "OBJLoader": "examples/loaders/OBJLoader",
-            "PCDLoader": "examples/loaders/PCDLoader",
-            "PDBLoader": "examples/loaders/PDBLoader",
-            "SVGLoader": "examples/loaders/SVGLoader",
-            "TGALoader": "examples/loaders/TGALoader"
-        },
+		"Loaders": {
+			"BabylonLoader": "examples/loaders/BabylonLoader",
+			"ColladaLoader": "examples/loaders/ColladaLoader",
+			"GLTF2Loader": "examples/loaders/GLTF2Loader",
+			"MTLLoader": "examples/loaders/MTLLoader",
+			"OBJLoader": "examples/loaders/OBJLoader",
+			"PCDLoader": "examples/loaders/PCDLoader",
+			"PDBLoader": "examples/loaders/PDBLoader",
+			"SVGLoader": "examples/loaders/SVGLoader",
+			"TGALoader": "examples/loaders/TGALoader"
+		},
 
-        "Plugins": {
-            "CombinedCamera": "examples/cameras/CombinedCamera",
-            "LookupTable": "examples/Lut",
-            "SpriteCanvasMaterial": "examples/SpriteCanvasMaterial"
-        },
+		"Plugins": {
+			"CombinedCamera": "examples/cameras/CombinedCamera",
+			"LookupTable": "examples/Lut",
+			"SpriteCanvasMaterial": "examples/SpriteCanvasMaterial"
+		},
 
-        "QuickHull": {
-            "Face": "examples/quickhull/Face",
-            "HalfEdge": "examples/quickhull/HalfEdge",
-            "QuickHull": "examples/quickhull/QuickHull",
-            "VertexNode": "examples/quickhull/VertexNode",
-            "VertexList": "examples/quickhull/VertexList"
-        },
+		"QuickHull": {
+			"Face": "examples/quickhull/Face",
+			"HalfEdge": "examples/quickhull/HalfEdge",
+			"QuickHull": "examples/quickhull/QuickHull",
+			"VertexNode": "examples/quickhull/VertexNode",
+			"VertexList": "examples/quickhull/VertexList"
+		},
 
-        "Renderers": {
-            "CanvasRenderer": "examples/renderers/CanvasRenderer"
-        }
+		"Renderers": {
+			"CanvasRenderer": "examples/renderers/CanvasRenderer"
+		}
 
-    },
+	},
 
-    "Developer Reference": {
+	"Developer Reference": {
 
-        "Polyfills": {
-            "Polyfills": "api/Polyfills"
-        },
+		"Polyfills": {
+			"Polyfills": "api/Polyfills"
+		},
 
-        "WebGLRenderer": {
-            "WebGLProgram": "api/renderers/webgl/WebGLProgram",
-            "WebGLShader": "api/renderers/webgl/WebGLShader",
-            "WebGLState": "api/renderers/webgl/WebGLState"
-        },
+		"WebGLRenderer": {
+			"WebGLProgram": "api/renderers/webgl/WebGLProgram",
+			"WebGLShader": "api/renderers/webgl/WebGLShader",
+			"WebGLState": "api/renderers/webgl/WebGLState"
+		},
 
-        "WebGLRenderer / Plugins": {
-            "LensFlarePlugin": "api/renderers/webgl/plugins/LensFlarePlugin",
-            "SpritePlugin": "api/renderers/webgl/plugins/SpritePlugin"
-        }
+		"WebGLRenderer / Plugins": {
+			"LensFlarePlugin": "api/renderers/webgl/plugins/LensFlarePlugin",
+			"SpritePlugin": "api/renderers/webgl/plugins/SpritePlugin"
+		}
 
-    }
+	}
 
 }

--- a/docs/page.css
+++ b/docs/page.css
@@ -17,8 +17,8 @@ body {
 
 a {
 	color: #1184CE;
-    cursor: pointer;
-    text-decoration: underline;
+	cursor: pointer;
+	text-decoration: underline;
 }
 
 h1 {
@@ -107,8 +107,8 @@ strong {
 }
 
 #button:hover {
-    cursor: pointer;
-    opacity: 1;
+	cursor: pointer;
+	opacity: 1;
 }
 
 a.permalink {

--- a/docs/page.css
+++ b/docs/page.css
@@ -17,6 +17,8 @@ body {
 
 a {
 	color: #1184CE;
+    cursor: pointer;
+    text-decoration: underline;
 }
 
 h1 {
@@ -56,6 +58,7 @@ pre, code {
 	margin-top: 20px;
 	margin-bottom: 20px;
 }
+
 code {
 	display: block;
 	width: -webkit-calc( 100% - 40px );
@@ -77,6 +80,7 @@ th {
 	padding: 10px;
 	text-decoration: underline;
 }
+
 td {
 	text-align: center;
 }
@@ -102,10 +106,10 @@ strong {
 	opacity: 0.5;
 }
 
-	#button:hover {
-		cursor: pointer;
-		opacity: 1;
-	}
+#button:hover {
+    cursor: pointer;
+    opacity: 1;
+}
 
 a.permalink {
 	float: right;

--- a/docs/page.js
+++ b/docs/page.js
@@ -1,18 +1,25 @@
 if ( !window.frameElement ) {
 
-// If the page is not yet displayed as an iframe of the index page (navigation panel/working links),
-// redirect to the index page (using the current URL without extension as the new fragment).
-// If this URL itself has a fragment, append it with a dot (since '#' in an URL fragment is not allowed).
+    // If the page is not yet displayed as an iframe of the index page (navigation panel/working links),
+    // redirect to the index page (using the current URL without extension as the new fragment).
+    // If this URL itself has a fragment, append it with a dot (since '#' in an URL fragment is not allowed).
 
-    var hash = window.location.hash.substr( 1 );
+    var href = window.location.href;
+    var splitIndex = href.lastIndexOf( '/docs/' ) + 6;
+    var docsBaseURL = href.substr( 0, splitIndex );
 
-    if (hash !== '') {
+    var hash = window.location.hash;
 
-        hash = '.' + hash;
+    if ( hash !== '' ) {
+
+        href = href.replace( hash, '' );
+        hash = hash.replace( '#', '.' );
 
     }
 
-    window.location.replace( window.location.origin + '/docs/#' + window.location.pathname.slice(6, -5) + hash );
+    var pathSnippet = href.slice( splitIndex, -5 );
+
+    window.location.replace( docsBaseURL + '#' + pathSnippet + hash );
 
 }
 

--- a/docs/page.js
+++ b/docs/page.js
@@ -1,25 +1,25 @@
 if ( !window.frameElement ) {
 
-    // If the page is not yet displayed as an iframe of the index page (navigation panel/working links),
-    // redirect to the index page (using the current URL without extension as the new fragment).
-    // If this URL itself has a fragment, append it with a dot (since '#' in an URL fragment is not allowed).
+	// If the page is not yet displayed as an iframe of the index page (navigation panel/working links),
+	// redirect to the index page (using the current URL without extension as the new fragment).
+	// If this URL itself has a fragment, append it with a dot (since '#' in an URL fragment is not allowed).
 
-    var href = window.location.href;
-    var splitIndex = href.lastIndexOf( '/docs/' ) + 6;
-    var docsBaseURL = href.substr( 0, splitIndex );
+	var href = window.location.href;
+	var splitIndex = href.lastIndexOf( '/docs/' ) + 6;
+	var docsBaseURL = href.substr( 0, splitIndex );
 
-    var hash = window.location.hash;
+	var hash = window.location.hash;
 
-    if ( hash !== '' ) {
+	if ( hash !== '' ) {
 
-        href = href.replace( hash, '' );
-        hash = hash.replace( '#', '.' );
+		href = href.replace( hash, '' );
+		hash = hash.replace( '#', '.' );
 
-    }
+	}
 
-    var pathSnippet = href.slice( splitIndex, -5 );
+	var pathSnippet = href.slice( splitIndex, -5 );
 
-    window.location.replace( docsBaseURL + '#' + pathSnippet + hash );
+	window.location.replace( docsBaseURL + '#' + pathSnippet + hash );
 
 }
 

--- a/docs/page.js
+++ b/docs/page.js
@@ -1,3 +1,22 @@
+if ( !window.frameElement ) {
+
+// If the page is not yet displayed as an iframe of the index page (navigation panel/working links),
+// redirect to the index page (using the current URL without extension as the new fragment).
+// If this URL itself has a fragment, append it with a dot (since '#' in an URL fragment is not allowed).
+
+    var hash = window.location.hash.substr( 1 );
+
+    if (hash !== '') {
+
+        hash = '.' + hash;
+
+    }
+
+    window.location.replace( window.location.origin + '/docs/#' + window.location.pathname.slice(6, -5) + hash );
+
+}
+
+
 var onDocumentLoad = function ( event ) {
 
 	var path;
@@ -30,11 +49,11 @@ var onDocumentLoad = function ( event ) {
 	text = text.replace( /\[path\]/gi, path );
 	text = text.replace( /\[page:([\w\.]+)\]/gi, "[page:$1 $1]" ); // [page:name] to [page:name title]
 	text = text.replace( /\[page:\.([\w\.]+) ([\w\.\s]+)\]/gi, "[page:" + name + ".$1 $2]" ); // [page:.member title] to [page:name.member title]
-	text = text.replace( /\[page:([\w\.]+) ([\w\.\s]+)\]/gi, "<a href=\"javascript:window.parent.goTo('$1')\" title=\"$1\">$2</a>" ); // [page:name title]
-	// text = text.replace( /\[member:.([\w]+) ([\w\.\s]+)\]/gi, "<a href=\"javascript:window.parent.goTo('" + name + ".$1')\" title=\"$1\">$2</a>" );
+	text = text.replace( /\[page:([\w\.]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('$1')\" title=\"$1\">$2</a>" ); // [page:name title]
+	// text = text.replace( /\[member:.([\w]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$1')\" title=\"$1\">$2</a>" );
 
 	text = text.replace( /\[(?:member|property|method):([\w]+)\]/gi, "[member:$1 $1]" ); // [member:name] to [member:name title]
-	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]/gi, "<a href=\"javascript:window.parent.goTo('" + name + ".$2')\" target=\"_parent\" title=\"" + name + ".$2\" class=\"permalink\">#</a> .<a href=\"javascript:window.parent.goTo('$1')\" title=\"$1\" id=\"$2\">$2</a> " );
+	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$2')\" target=\"_parent\" title=\"" + name + ".$2\" class=\"permalink\">#</a> .<a onclick=\"window.parent.setUrlFragment('$1')\" title=\"$1\" id=\"$2\">$2</a> " );
 
 	text = text.replace( /\[link:([\w|\:|\/|\.|\-|\_]+)\]/gi, "[link:$1 $1]" ); // [link:url] to [link:url title]
 	text = text.replace( /\[link:([\w|\:|\/|\.|\-|\_|\(|\)|\#]+) ([\w|\:|\/|\.|\-|\_|\s]+)\]/gi, "<a href=\"$1\"  target=\"_blank\">$2</a>" ); // [link:url title]


### PR DESCRIPTION
This PR with a complete refactoring of the doc’s index.html (and some additional changes in the associated files) was done to handle the following issues:

-	Visitors coming from google are trapped on the subpages (links not working, no navigation panel) #10937
-	The path structure of the URL fragments used by index.html for the iframes is different from the original path structure of the subpages (for example ... docs/api/renderers/webgl/plugins/LensFlarePlugin.html 
vs. … docs/#Developer_Reference/WebGLRenderer.Plugins/LensFlarePlugin https://github.com/mrdoob/three.js/pull/10948#issuecomment-288449044
-	Browser navigation (back/forward arrows) is not working #11052
- Right click on a link in the navigation panel displays in the new tab only the navigation panel with a blank content area, instead of the correct content
-	The status bar displays `https://threejs.org.docs/#`, when clicking a link in the navigation panel (which is useless), and it displays `javascript:window.parent.goTo(‘…’)`, when clicking on a link in the content area - which is irritating especially in those cases where instead of moving to another content  only a tooltip with the basic JavaScript type (“Float”, “Array”) is displayed
-	Some other (minor) issues

_(List edited after review)_

On this occasion I tried to make the whole code structure more transparent and to improve the code style, too (see #11073).

Especially Edge was behaving differently in several cases. So there are some things in the code a little more inconvenient than it actually should have been. I hope, this is now working in all browsers (not only on Windows?). 

Please test it and find the bugs ;-) 

-----

Links to subpages without navigation like
… `docs/api/core/Geometry.html`
are now displayed as iframes of the index page, the URL fragment reflecting the original path structure:
... `docs/#api/core/Geometry`

Links to anchors in subpages like 
… `docs/api/core/Geometry.html#morphTargets`
are now displayed as 
... `docs/#api/core/Geometry.morphTargets`
since '#' is not allowed inside an URL fragment (according to RFC 3986)

