### PR TITLE
Add multiplication and equality methods to Matrix3

### DIFF
--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -92,6 +92,9 @@ m.elements = [ 11, 21, 31,
 		[link:https://en.wikipedia.org/wiki/Determinant determinant] of this matrix.
 		</div>
 
+		<h3>[method:Boolean equals]( [page:Matrix3 m] )</h3>
+		<div>Return true if this matrix and [page:Matrix3 m] are equal.</div>
+
 		<h3>[method:Matrix3 fromArray]( [page:Array array], [page:Integer offset] )</h3>
 		<div>
 		[page:Array array] - the array to read the elements from.<br />
@@ -132,6 +135,12 @@ m.elements = [ 11, 21, 31,
 
 		</div>
 
+		<h3>[method:Matrix3 multiply]( [page:Matrix3 m] )</h3>
+		<div>Post-multiplies this matrix by [page:Matrix3 m].</div>
+
+		<h3>[method:Matrix3 multiplyMatrices]( [page:Matrix3 a], [page:Matrix3 b] )</h3>
+		<div>Sets this matrix to [page:Matrix3 a] x [page:Matrix3 b].</div>
+
 		<h3>[method:Matrix3 multiplyScalar]( [page:Float s] )</h3>
 		<div>Multiplies every component of the matrix by the scalar value *s*.</div>
 
@@ -153,6 +162,9 @@ m.elements = [ 11, 21, 31,
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order row-major]
 		sequence of values.
 		</div>
+
+		<h3>[method:Matrix3 premultiply]( [page:Matrix3 m] )</h3>
+		<div>Pre-multiplies this matrix by [page:Matrix3 m].</div>
 
 		<h3>[method:Matrix3 setFromMatrix4]( [page:Matrix4 m] )</h3>
 		<div>Set this matrx to the upper 3x3 matrix of the Matrix4 [page:Matrix4 m].</div>

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -156,20 +156,6 @@ Object.assign( Matrix3.prototype, {
 
 	},
 
-	multiplyToArray: function ( a, b, r ) {
-
-		var te = this.elements;
-
-		this.multiplyMatrices( a, b );
-
-		r[ 0 ] = te[ 0 ]; r[ 1 ] = te[ 1 ]; r[ 2 ] = te[ 2 ];
-		r[ 3 ] = te[ 3 ]; r[ 4 ] = te[ 4 ]; r[ 5 ] = te[ 5 ];
-		r[ 6 ] = te[ 6 ]; r[ 7 ] = te[ 7 ]; r[ 8 ] = te[ 8 ];
-
-		return this;
-
-	},
-
 	multiplyScalar: function ( s ) {
 
 		var te = this.elements;

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -114,6 +114,62 @@ Object.assign( Matrix3.prototype, {
 
 	}(),
 
+	multiply: function ( m ) {
+
+		return this.multiplyMatrices( this, m );
+
+	},
+
+	premultiply: function ( m ) {
+
+		return this.multiplyMatrices( m, this );
+
+	},
+
+	multiplyMatrices: function ( a, b ) {
+
+		var ae = a.elements;
+		var be = b.elements;
+		var te = this.elements;
+
+		var a11 = ae[ 0 ], a12 = ae[ 3 ], a13 = ae[ 6 ];
+		var a21 = ae[ 1 ], a22 = ae[ 4 ], a23 = ae[ 7 ];
+		var a31 = ae[ 2 ], a32 = ae[ 5 ], a33 = ae[ 8 ];
+
+		var b11 = be[ 0 ], b12 = be[ 3 ], b13 = be[ 6 ];
+		var b21 = be[ 1 ], b22 = be[ 4 ], b23 = be[ 7 ];
+		var b31 = be[ 2 ], b32 = be[ 5 ], b33 = be[ 8 ];
+
+		te[ 0 ] = a11 * b11 + a12 * b21 + a13 * b31;
+		te[ 3 ] = a11 * b12 + a12 * b22 + a13 * b32;
+		te[ 6 ] = a11 * b13 + a12 * b23 + a13 * b33;
+
+		te[ 1 ] = a21 * b11 + a22 * b21 + a23 * b31;
+		te[ 4 ] = a21 * b12 + a22 * b22 + a23 * b32;
+		te[ 7 ] = a21 * b13 + a22 * b23 + a23 * b33;
+
+		te[ 2 ] = a31 * b11 + a32 * b21 + a33 * b31;
+		te[ 5 ] = a31 * b12 + a32 * b22 + a33 * b32;
+		te[ 8 ] = a31 * b13 + a32 * b23 + a33 * b33;
+
+		return this;
+
+	},
+
+	multiplyToArray: function ( a, b, r ) {
+
+		var te = this.elements;
+
+		this.multiplyMatrices( a, b );
+
+		r[ 0 ] = te[ 0 ]; r[ 1 ] = te[ 1 ]; r[ 2 ] = te[ 2 ];
+		r[ 3 ] = te[ 3 ]; r[ 4 ] = te[ 4 ]; r[ 5 ] = te[ 5 ];
+		r[ 6 ] = te[ 6 ]; r[ 7 ] = te[ 7 ]; r[ 8 ] = te[ 8 ];
+
+		return this;
+
+	},
+
 	multiplyScalar: function ( s ) {
 
 		var te = this.elements;
@@ -228,6 +284,21 @@ Object.assign( Matrix3.prototype, {
 		r[ 8 ] = m[ 8 ];
 
 		return this;
+
+	},
+
+	equals: function ( matrix ) {
+
+		var te = this.elements;
+		var me = matrix.elements;
+
+		for ( var i = 0; i < 9; i ++ ) {
+
+			if ( te[ i ] !== me[ i ] ) return false;
+
+		}
+
+		return true;
 
 	},
 

--- a/test/unit/src/math/Matrix3.js
+++ b/test/unit/src/math/Matrix3.js
@@ -100,6 +100,39 @@ QUnit.test( "identity" , function( assert ) {
 	assert.ok( matrixEquals3( a, b ), "Passed!" );
 });
 
+QUnit.test( "multiplyMatrices" , function ( assert ) {
+	// Reference:
+	//
+	// #!/usr/bin/env python
+	// from __future__ import print_function
+	// import numpy as np
+	// print(
+	//     np.dot(
+	//         np.reshape([2, 3, 5, 7, 11, 13, 17, 19, 23], (3, 3)),
+	//         np.reshape([29, 31, 37, 41, 43, 47, 53, 59, 61], (3, 3))
+	//     )
+	// )
+	//
+	// [[ 446  486  520]
+	//  [1343 1457 1569]
+	//  [2491 2701 2925]]
+	var lhs = new THREE.Matrix3().set( 2, 3, 5, 7, 11, 13, 17, 19, 23 );
+	var rhs = new THREE.Matrix3().set( 29, 31, 37, 41, 43, 47, 53, 59, 61 );
+	var ans = new THREE.Matrix3();
+
+	ans.multiplyMatrices(lhs, rhs);
+
+	assert.ok( ans.elements[0] == 446 );
+	assert.ok( ans.elements[1] == 1343 );
+	assert.ok( ans.elements[2] == 2491 );
+	assert.ok( ans.elements[3] == 486 );
+	assert.ok( ans.elements[4] == 1457 );
+	assert.ok( ans.elements[5] == 2701 );
+	assert.ok( ans.elements[6] == 520 );
+	assert.ok( ans.elements[7] == 1569 );
+	assert.ok( ans.elements[8] == 2925 );
+});
+
 QUnit.test( "multiplyScalar" , function( assert ) {
 	var b = new THREE.Matrix3().set( 0, 1, 2, 3, 4, 5, 6, 7, 8 );
 	assert.ok( b.elements[0] == 0 );

--- a/test/unit/src/math/Matrix4.js
+++ b/test/unit/src/math/Matrix4.js
@@ -103,6 +103,47 @@ QUnit.test( "identity" , function( assert ) {
 	assert.ok( matrixEquals4( a, b ), "Passed!" );
 });
 
+QUnit.test( "multiplyMatrices" , function ( assert ) {
+	// Reference:
+	//
+	// #!/usr/bin/env python
+	// from __future__ import print_function
+	// import numpy as np
+	// print(
+	//     np.dot(
+	//         np.reshape([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53], (4, 4)),
+	//         np.reshape([59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131], (4, 4))
+	//     )
+	// )
+	//
+	// [[ 1585  1655  1787  1861]
+	//  [ 5318  5562  5980  6246]
+	//  [10514 11006 11840 12378]
+	//  [15894 16634 17888 18710]]
+	var lhs = new THREE.Matrix4().set( 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53 );
+	var rhs = new THREE.Matrix4().set( 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131 );
+	var ans = new THREE.Matrix4();
+
+	ans.multiplyMatrices(lhs, rhs);
+
+	assert.ok( ans.elements[0] == 1585 );
+	assert.ok( ans.elements[1] == 5318 );
+	assert.ok( ans.elements[2] == 10514 );
+	assert.ok( ans.elements[3] == 15894 );
+	assert.ok( ans.elements[4] == 1655 );
+	assert.ok( ans.elements[5] == 5562 );
+	assert.ok( ans.elements[6] == 11006 );
+	assert.ok( ans.elements[7] == 16634 );
+	assert.ok( ans.elements[8] == 1787 );
+	assert.ok( ans.elements[9] == 5980 );
+	assert.ok( ans.elements[10] == 11840 );
+	assert.ok( ans.elements[11] == 17888 );
+	assert.ok( ans.elements[12] == 1861 );
+	assert.ok( ans.elements[13] == 6246 );
+	assert.ok( ans.elements[14] == 12378 );
+	assert.ok( ans.elements[15] == 18710 );
+});
+
 QUnit.test( "multiplyScalar" , function( assert ) {
 	var b = new THREE.Matrix4().set( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 );
 	assert.ok( b.elements[0] == 0 );


### PR DESCRIPTION
Adds `multiply(rhs)`, `premultiply(lhs)`, `multiplyMatrices(lhs, rhs)`, `multiplyToArray(lhs, rhs, out)` and `equals(rhs)` to `Matrix3`, bringing its mathematical methods into parity with `Matrix4`. Code style, implementation and method ordering is modeled on `Matrix4` and the style guide.

This is motivated by the use of `Matrix3` instances for calculating 2D affine transforms of the form
```
xx yx tx
xy yy ty
0  0  1
```
which can often go where three.js goes, for composing 2D overlays (UI or otherwise), texture transformation in UV space, or dynamically preparing textures with (say) `CanvasRenderingContext2D`.

Being generic mathematical operations, the 2D motivation remains incidental - it can of course be used for combining normal transforms, non-translated position transforms, etc.

A further enhancement *could* be to add helper methods to initialize 2D translation / scale / rotate matrices, but I've stopped short of that. I'd leave it as an open question of demand, and should maybe be weighed against potential confusion to newcomers at 2D-oriented methods coexisting with the otherwise clearly 3D purpose of Matrix3. 2D transforms are not so hard to create inline where needed.

Unit tests for the `multiplyMatrices` method of both `Matrix3` and `Matrix4` have been added - the latter when I went to look for it as an example, but didn't find.