### PR TITLE
Fix DragControls for containers not at (0,0)

### DIFF
--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -52,8 +52,10 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 		event.preventDefault();
 
-		_mouse.x = ( event.clientX / _domElement.clientWidth ) * 2 - 1;
-		_mouse.y = - ( event.clientY / _domElement.clientHeight ) * 2 + 1;
+		var rect = _domElement.getBoundingClientRect();
+
+		_mouse.x = ( (event.clientX - rect.left) / rect.width ) * 2 - 1;
+		_mouse.y = - ( (event.clientY - rect.top) / rect.height ) * 2 + 1;
 
 		_raycaster.setFromCamera( _mouse, _camera );
 


### PR DESCRIPTION
If the container (renderer.domElement) is not at the top-left corner of the browser/iframe,
the hit-test will always fail due to the offset.
The `TransformControl` is using the correct way, so it doesn't have such issue.