### PR TITLE
OrbitControls: multiple functions on same mousebutton possible

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -662,25 +662,19 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		event.preventDefault();
 
-		if ( event.button === scope.mouseButtons.ORBIT ) {
-
-			if ( scope.enableRotate === false ) return;
+		if ( scope.enableRotate === true && event.button === scope.mouseButtons.ORBIT ) {
 
 			handleMouseDownRotate( event );
 
 			state = STATE.ROTATE;
 
-		} else if ( event.button === scope.mouseButtons.ZOOM ) {
-
-			if ( scope.enableZoom === false ) return;
+		} else if ( scope.enableZoom === true && event.button === scope.mouseButtons.ZOOM ) {
 
 			handleMouseDownDolly( event );
 
 			state = STATE.DOLLY;
 
-		} else if ( event.button === scope.mouseButtons.PAN ) {
-
-			if ( scope.enablePan === false ) return;
+		} else if ( scope.enablePan === true && event.button === scope.mouseButtons.PAN ) {
 
 			handleMouseDownPan( event );
 


### PR DESCRIPTION
I wanted to utilize a key to switch one mousebutton to function as either pan or orbit

so i overwrote controls.mouseButtons, and in keydown/keyup eventlisteners i set controls.enableRotate/controls.enablePan

but OrbitControls onMouseDown handler won't try another state after the first mousebutton has matched the configuration (else-if chain),
even if the event it tests is disabled (enableRotate gets checked and returns from onMouseDown, panning is never tried)

this patch fixes this behaviour by checking for 'enabled' first