### PR TITLE
Docs: Re-enable browsing local

### DIFF
--- a/docs/page.js
+++ b/docs/page.js
@@ -1,4 +1,4 @@
-if ( !window.frameElement ) {
+if ( !window.frameElement && window.location.protocol !== 'file:' ) {
 
 	// If the page is not yet displayed as an iframe of the index page (navigation panel/working links),
 	// redirect to the index page (using the current URL without extension as the new fragment).


### PR DESCRIPTION
As @Mugen87 stated (#11100), after the changes of the docs main files (#11078) browsing the docs directly from the file system does no longer work in Chrome.

The reason is that in Chrome `window.frameElement` is `null` when the site is run directly from the file system: http://stackoverflow.com/questions/17950598/using-iframe-with-local-files-in-chrome

So I have now restricted the redirection from the subpages to the main page to protocols other than `file:`. This should be no problem since the redirection was only designed to handle links from outside anyways.

---
Note: There is an additional security restriction when running local files in Chrome and without a local server (https://github.com/mrdoob/three.js/issues/11100#issuecomment-290920705). But this has nothing to do with the recent changes of the docs.
