### PR TITLE
[glTF] Update animation channel targets.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1911,7 +1911,7 @@ THREE.GLTF2Loader = ( function () {
 					if ( sampler ) {
 
 						var target = channel.target;
-						var name = target.id;
+						var name = target.node || target.id; // NOTE: target.id is deprecated.
 						var input = animation.parameters !== undefined ? animation.parameters[ sampler.input ] : sampler.input;
 						var output = animation.parameters !== undefined ? animation.parameters[ sampler.output ] : sampler.output;
 


### PR DESCRIPTION
I've left the older `target.id` syntax in, because there are definitely a few glTF2.0 models lying around that haven't gotten the update yet. But according to the spec [here](https://github.com/KhronosGroup/glTF/tree/2.0/specification/2.0#animations), `target.node` is correct.

Aside, Sketchfab's [Buster Drone](https://sketchfab.com/features/gltf) model works after this fix, and looks pretty great.