### PR TITLE
Docs: AnimationSystem.html - fixed link to GLTF2Loader

### DIFF
--- a/docs/manual/introduction/Animation-system.html
+++ b/docs/manual/introduction/Animation-system.html
@@ -112,7 +112,7 @@
 				<li>THREE.BVHLoader</li>
 				<li>THREE.FBXLoader</li>
 				<li>THREE.FBXLoader2</li>
-				<li>[page:GLTFLoader THREE.GLTFLoader]</li>
+				<li>[page:GLTF2Loader THREE.GLTF2Loader]</li>
 				<li>THREE.MMDLoader</li>
 				<li>THREE.SEA3DLoader</li>
 			</ul>


### PR DESCRIPTION
GLTFLoader.html was removed from the docs with #10972