### PR TITLE
New THREE.AudioStream

### DIFF
--- a/docs/api/audio/AudioStream.html
+++ b/docs/api/audio/AudioStream.html
@@ -106,14 +106,12 @@
 
 		<h3>[method:null connect]()</h3>
 		<div>
-		Connects to the [page:.source]. This is used internally on initialisation and when
-		setting / removing filters.
+		Connects to the output node.
 		</div>
 
 		<h3>[method:null disconnect]()</h3>
 		<div>
-		Disconnects from the [page:.source]. This is used internally when
-		setting / removing filters.
+		Disconnects from the output node.
 		</div>
 
 		<h2>Source</h2>

--- a/docs/api/audio/AudioStream.html
+++ b/docs/api/audio/AudioStream.html
@@ -94,6 +94,16 @@
 		Sets the current volume.
 		</div>
 
+		<h3>[method:Number getLoop]()</h3>
+		<div>
+		Returns the loop property of the [page:.audioElement].
+		</div>
+
+		<h3>[method:Number setLoop]( value )</h3>
+		<div>
+		Sets the loop property of the [page:.audioElement]. If set to true, the audio will start over again, every time it is finished.
+		</div>
+
 		<h3>[method:null connect]()</h3>
 		<div>
 		Connects to the [page:.source]. This is used internally on initialisation and when

--- a/docs/api/audio/AudioStream.html
+++ b/docs/api/audio/AudioStream.html
@@ -24,7 +24,8 @@
 		camera.add( listener );
 
 		// create an audio stream
-		var audioStream = new THREE.AudioStream( 'myaudio.mp3', listener );
+		var audioStream = new THREE.AudioStream( listener );
+		audioStream.setAudioElement( new Audio( 'myaudio.mp3' ) );
 		audioStream.play();
 
 		</code>
@@ -33,9 +34,8 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:String path], [page:AudioListener listener] )</h3>
+		<h3>[name]( [page:AudioListener listener] )</h3>
 		<div>
-		path — (required) [page:String path] to the audio file.</br>
 		listener — (required) [page:AudioListener AudioListener] instance.
 		</div>
 
@@ -64,12 +64,17 @@
 		Returns the [page:.gain gainNode].
 		</div>
 
-		<h3>[method:null play]()</h3>
+		<h3>[method:AudioStream setAudioElement]( audioElement )</h3>
+		<div>
+		Sets the [link:https://developer.mozilla.org/de/docs/Web/API/HTMLAudioElement HTMLAudioElement].
+		</div>
+
+		<h3>[method:AudioStream play]()</h3>
 		<div>
 		Starts playback.
 		</div>
 
-		<h3>[method:null pause]()</h3>
+		<h3>[method:AudioStream pause]()</h3>
 		<div>
 		Pauses playback.
 		</div>
@@ -79,7 +84,7 @@
 		Returns the current time of the audio.
 		</div>
 
-		<h3>[method:Number setCurrentTime]( value )</h3>
+		<h3>[method:AudioStream setCurrentTime]( value )</h3>
 		<div>
 		Sets the current time of the audio.
 		</div>
@@ -89,7 +94,7 @@
 		Returns the current volume.
 		</div>
 
-		<h3>[method:Number setVolume]( value )</h3>
+		<h3>[method:AudioStream setVolume]( value )</h3>
 		<div>
 		Sets the current volume.
 		</div>
@@ -99,17 +104,17 @@
 		Returns the loop property of the [page:.audioElement].
 		</div>
 
-		<h3>[method:Number setLoop]( value )</h3>
+		<h3>[method:AudioStream setLoop]( value )</h3>
 		<div>
 		Sets the loop property of the [page:.audioElement]. If set to true, the audio will start over again, every time it is finished.
 		</div>
 
-		<h3>[method:null connect]()</h3>
+		<h3>[method:AudioStream connect]()</h3>
 		<div>
 		Connects to the output node.
 		</div>
 
-		<h3>[method:null disconnect]()</h3>
+		<h3>[method:AudioStream disconnect]()</h3>
 		<div>
 		Disconnects from the output node.
 		</div>

--- a/docs/api/audio/AudioStream.html
+++ b/docs/api/audio/AudioStream.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1>
+
+		<div class="desc">
+			Wrapper for a HTML5 audio stream.
+		</div>
+
+
+		<h2>Example</h2>
+
+		<div>[example:misc_sound_stream misc / sound_stream ]</div>
+		<code>
+		// create an AudioListener and add it to the camera
+		var listener = new THREE.AudioListener();
+		camera.add( listener );
+
+		// create an audio stream
+		var audioStream = new THREE.AudioStream( 'myaudio.mp3', listener );
+		audioStream.play();
+
+		</code>
+
+
+		<h2>Constructor</h2>
+
+
+		<h3>[name]( [page:String path], [page:AudioListener listener] )</h3>
+		<div>
+		path — (required) [page:String path] to the audio file.</br>
+		listener — (required) [page:AudioListener AudioListener] instance.
+		</div>
+
+
+		<h2>Properties</h2>
+
+		<h3>[property:HTMLAudioElement audioElement]</h3>
+		<div>The [link:https://developer.mozilla.org/de/docs/Web/API/HTMLAudioElement HTMLAudioElement] that represents the actual stream.</div>
+
+		<h3>[property:AudioContext context]</h3>
+		<div>The [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext AudioContext] of the [page:AudioListener listener] given in the constructor.</div>
+
+		<h3>[property:GainNode gain]</h3>
+		<div>A [link:https://developer.mozilla.org/en-US/docs/Web/API/GainNode GainNode] created
+		using [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createGain AudioContext.createGain]().</div>
+
+		<h3>[property:String source]</h3>
+		<div>An [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode] created
+		using [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createBufferSource AudioContext.createBufferSource]().</div>
+
+
+		<h2>Methods</h2>
+
+		<h3>[method:GainNode getOutput]()</h3>
+		<div>
+		Returns the [page:.gain gainNode].
+		</div>
+
+		<h3>[method:null play]()</h3>
+		<div>
+		Starts playback.
+		</div>
+
+		<h3>[method:null pause]()</h3>
+		<div>
+		Pauses playback.
+		</div>
+
+		<h3>[method:Number getCurrentTime]()</h3>
+		<div>
+		Returns the current time of the audio.
+		</div>
+
+		<h3>[method:Number setCurrentTime]( value )</h3>
+		<div>
+		Sets the current time of the audio.
+		</div>
+
+		<h3>[method:Number getVolume]()</h3>
+		<div>
+		Returns the current volume.
+		</div>
+
+		<h3>[method:Number setVolume]( value )</h3>
+		<div>
+		Sets the current volume.
+		</div>
+
+		<h3>[method:null connect]()</h3>
+		<div>
+		Connects to the [page:.source]. This is used internally on initialisation and when
+		setting / removing filters.
+		</div>
+
+		<h3>[method:null disconnect]()</h3>
+		<div>
+		Disconnects from the [page:.source]. This is used internally when
+		setting / removing filters.
+		</div>
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+	</body>
+</html>

--- a/docs/list.js
+++ b/docs/list.js
@@ -53,6 +53,7 @@ var list = {
 			"AudioAnalyser": "api/audio/AudioAnalyser",
 			"AudioContext": "api/audio/AudioContext",
 			"AudioListener": "api/audio/AudioListener",
+			"AudioStream": "api/audio/AudioStream",
 			"PositionalAudio": "api/audio/PositionalAudio"
 		},
 

--- a/examples/files.js
+++ b/examples/files.js
@@ -312,6 +312,7 @@ var files = {
 		"misc_lights_test",
 		"misc_lookat",
 		"misc_sound",
+		"misc_sound_stream",
 		"misc_ubiquity_test",
 		"misc_ubiquity_test2",
 		"misc_uv_tests"

--- a/examples/misc_sound_stream.html
+++ b/examples/misc_sound_stream.html
@@ -45,7 +45,7 @@
 
 		<script id="fragmentShader" type="x-shader/x-fragment">
 
-			uniform sampler2D tDiffuse;
+			uniform sampler2D tAudioData;
 			uniform vec2 resolution;
 
 			void main()	{
@@ -53,16 +53,17 @@
 				vec2 uv = gl_FragCoord.xy / resolution.xy;
 
 				vec3 backgroundColor = vec3( 0.0 );
-				vec3 finalColor = vec3( 1.0, 0.0, 0.0 );
+				vec3 color = vec3( 1.0, 0.0, 0.0 );
 
-				float f = texture2D( tDiffuse, vec2( uv.x, 0 ) ).r; // sample data texture, only the red channel is relevant
-				float i = step( uv.y, f ); // this will be used to draw the bars
+				float f = texture2D( tAudioData, vec2( uv.x, 0 ) ).r; // sample data texture, only the red channel is relevant
+				float i = step( uv.y, f );
 
-				gl_FragColor = vec4( mix( backgroundColor, finalColor, i ), 1.0 );
+				gl_FragColor = vec4( mix( backgroundColor, color, i ), 1.0 );
 
 			}
 
 		</script>
+
 	</head>
 <body>
 
@@ -125,7 +126,7 @@
 		var size = fftSize / 2;
 
 		uniforms = {
-			tDiffuse: { value: new THREE.DataTexture( new Uint8Array( size * 3 ), size, 1, THREE.RGBFormat ) },
+			tAudioData: { value: new THREE.DataTexture( new Uint8Array( size * 3 ), size, 1, THREE.RGBFormat ) },
 			resolution: { value: new THREE.Vector2( renderer.domElement.width, renderer.domElement.height ) }
 		};
 
@@ -179,11 +180,11 @@
 
 		for ( var i = 0, l = data.length; i < l; i ++ ) {
 
-			uniforms.tDiffuse.value.image.data[ i * 3 ] = data[ i ];
+			uniforms.tAudioData.value.image.data[ i * 3 ] = data[ i ];
 
 		}
 
-		uniforms.tDiffuse.value.needsUpdate = true;
+		uniforms.tAudioData.value.needsUpdate = true;
 
 		renderer.render( scene, camera );
 

--- a/examples/misc_sound_stream.html
+++ b/examples/misc_sound_stream.html
@@ -68,7 +68,10 @@
 <body>
 
 	<div id="container"></div>
-	<div id="info"><a href="https://threejs.org" target="_blank">three.js</a> - misc - sound stream</div>
+	<div id="info">
+		<a href="https://threejs.org" target="_blank">three.js</a> - misc - sound stream -
+		music by <a href="http://www.newgrounds.com/audio/listen/358232" target="_blank">larrylarrybb</a>
+	</div>
 
 	<script>
 

--- a/examples/misc_sound_stream.html
+++ b/examples/misc_sound_stream.html
@@ -113,6 +113,7 @@
 		// audio stream and analyzer
 
 		var audioStream = new THREE.AudioStream( 'sounds/358232_j_s_song.mp3', listener );
+		audioStream.setLoop( true );
 		analyser = new THREE.AudioAnalyser( audioStream, fftSize );
 
 		audioStream.play();

--- a/examples/misc_sound_stream.html
+++ b/examples/misc_sound_stream.html
@@ -112,10 +112,11 @@
 
 		// audio stream and analyzer
 
-		var audioStream = new THREE.AudioStream( 'sounds/358232_j_s_song.mp3', listener );
-		audioStream.setLoop( true );
+		var audioStream = new THREE.AudioStream( listener );
 		analyser = new THREE.AudioAnalyser( audioStream, fftSize );
 
+		audioStream.setAudioElement( new Audio( 'sounds/358232_j_s_song.mp3' ) );
+		audioStream.setLoop( true );
 		audioStream.play();
 
 		// geometry

--- a/examples/misc_sound_stream.html
+++ b/examples/misc_sound_stream.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js misc - sound stream</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				background:#777;
+				padding:0;
+				margin:0;
+				font-weight: bold;
+				overflow:hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0px;
+				width: 100%;
+				color: #ffffff;
+				padding: 5px;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+			}
+
+			a {
+				color: #ffffff;
+			}
+		</style>
+
+		<script src="../build/three.js"></script>
+		<script src="js/Detector.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script id="vertexShader" type="x-shader/x-vertex">
+
+			void main()	{
+
+				gl_Position = vec4( position, 1.0 );
+
+			}
+
+		</script>
+
+		<script id="fragmentShader" type="x-shader/x-fragment">
+
+			uniform sampler2D tDiffuse;
+			uniform vec2 resolution;
+
+			void main()	{
+
+				vec2 uv = gl_FragCoord.xy / resolution.xy;
+
+				vec3 backgroundColor = vec3( 0.0 );
+				vec3 finalColor = vec3( 1.0, 0.0, 0.0 );
+
+				float f = texture2D( tDiffuse, vec2( uv.x, 0 ) ).r; // sample data texture, only the red channel is relevant
+				float i = step( uv.y, f ); // this will be used to draw the bars
+
+				gl_FragColor = vec4( mix( backgroundColor, finalColor, i ), 1.0 );
+
+			}
+
+		</script>
+	</head>
+<body>
+
+	<div id="container"></div>
+	<div id="info"><a href="https://threejs.org" target="_blank">three.js</a> - misc - sound stream</div>
+
+	<script>
+
+	if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+	var scene, camera, renderer, analyser, uniforms;
+	var container, stats;
+
+	init();
+	animate();
+
+	function init() {
+
+		var fftSize = 2048;
+
+		// container
+
+		container = document.getElementById( 'container' );
+
+		// scene
+
+		scene = new THREE.Scene();
+
+		// renderer
+
+		renderer = new THREE.WebGLRenderer( { antialias: true } );
+		renderer.setSize( window.innerWidth, window.innerHeight );
+		renderer.setClearColor( 0x20252f );
+		renderer.setPixelRatio( window.devicePixelRatio );
+		container.appendChild( renderer.domElement );
+
+		// camera
+
+		camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 1000 );
+		camera.position.set( 0, 5, 50 );
+
+		// audio listener
+
+		var listener = new THREE.AudioListener();
+		camera.add( listener );
+
+		// audio stream and analyzer
+
+		var audioStream = new THREE.AudioStream( 'sounds/358232_j_s_song.mp3', listener );
+		analyser = new THREE.AudioAnalyser( audioStream, fftSize );
+
+		audioStream.play();
+
+		// geometry
+
+		var geometry = new THREE.PlaneBufferGeometry( 2, 2 );
+
+		// custom shader material
+
+		var size = fftSize / 2;
+
+		uniforms = {
+			tDiffuse: { value: new THREE.DataTexture( new Uint8Array( size * 3 ), size, 1, THREE.RGBFormat ) },
+			resolution: { value: new THREE.Vector2( renderer.domElement.width, renderer.domElement.height ) }
+		};
+
+		var material = new THREE.ShaderMaterial( {
+
+			uniforms: uniforms,
+			vertexShader: document.getElementById( 'vertexShader' ).textContent,
+			fragmentShader: document.getElementById( 'fragmentShader' ).textContent
+
+		} );
+
+		// mesh
+
+		var mesh = new THREE.Mesh( geometry, material );
+		scene.add( mesh );
+
+		// stats.js
+
+		stats = new Stats();
+		container.appendChild( stats.dom );
+
+		// event listener
+
+		window.addEventListener( 'resize', onResize, false );
+
+	}
+
+	function onResize() {
+
+		renderer.setSize( window.innerWidth, window.innerHeight );
+
+		uniforms.resolution.value.x = renderer.domElement.width;
+		uniforms.resolution.value.y = renderer.domElement.height;
+
+	}
+
+	function animate() {
+
+		requestAnimationFrame( animate );
+
+		render();
+		stats.update();
+
+	}
+
+	function render() {
+
+		var data = analyser.getFrequencyData();
+
+		// transfer all frequency data to our data texture so we can use them in the fragment shader
+
+		for ( var i = 0, l = data.length; i < l; i ++ ) {
+
+			uniforms.tDiffuse.value.image.data[ i * 3 ] = data[ i ];
+
+		}
+
+		uniforms.tDiffuse.value.needsUpdate = true;
+
+		renderer.render( scene, camera );
+
+	}
+
+	</script>
+
+</body>
+</html>

--- a/src/Three.js
+++ b/src/Three.js
@@ -65,6 +65,7 @@ export { ArrayCamera } from './cameras/ArrayCamera.js';
 export { Camera } from './cameras/Camera.js';
 export { AudioListener } from './audio/AudioListener.js';
 export { PositionalAudio } from './audio/PositionalAudio.js';
+export { AudioStream } from './audio/AudioStream.js';
 export { AudioContext } from './audio/AudioContext.js';
 export { AudioAnalyser } from './audio/AudioAnalyser.js';
 export { Audio } from './audio/Audio.js';

--- a/src/audio/AudioStream.js
+++ b/src/audio/AudioStream.js
@@ -68,6 +68,20 @@ Object.assign( AudioStream.prototype, {
 
 	},
 
+	getLoop: function () {
+
+		return this.audioElement.loop;
+
+	},
+
+	setLoop: function ( value ) {
+
+		this.audioElement.loop = value;
+
+		return this;
+
+	},
+
 	connect: function () {
 
 		this.source.connect( this.getOutput() );

--- a/src/audio/AudioStream.js
+++ b/src/audio/AudioStream.js
@@ -1,0 +1,89 @@
+/**
+ * @author Mugen87 / https://github.com/Mugen87
+ */
+
+function AudioStream( path, listener ) {
+
+	this.audioElement = new Audio( path );
+	this.context = listener.context;
+
+	this.gain = this.context.createGain();
+	this.gain.connect( listener.getInput() );
+
+	this.source = listener.context.createMediaElementSource( this.audioElement );
+
+	this.connect();
+
+}
+
+Object.assign( AudioStream.prototype, {
+
+	getOutput: function () {
+
+		return this.gain;
+
+	},
+
+	play: function () {
+
+		this.audioElement.play();
+
+		return this;
+
+	},
+
+	pause: function () {
+
+		this.audioElement.pause();
+
+		return this;
+
+	},
+
+	getCurrentTime: function () {
+
+		return this.audioElement.currentTime;
+
+	},
+
+	setCurrentTime: function ( value ) {
+
+		this.audioElement.currentTime = value;
+
+		return this;
+
+	},
+
+	getVolume: function () {
+
+		return this.gain.gain.value;
+
+	},
+
+	setVolume: function ( value ) {
+
+		this.gain.gain.value = value;
+
+		return this;
+
+	},
+
+	connect: function () {
+
+		this.source.connect( this.getOutput() );
+
+		return this;
+
+	},
+
+	disconnect: function () {
+
+		this.source.disconnect( this.getOutput() );
+
+		return this;
+
+	}
+
+} );
+
+export { AudioStream };

--- a/src/audio/AudioStream.js
+++ b/src/audio/AudioStream.js
@@ -4,7 +4,7 @@
 
 function AudioStream( path, listener ) {
 
-	this.audioElement = new Audio( path );
+	this.audioElement = new Audio( path ); // HTML5 Audio
 	this.context = listener.context;
 
 	this.gain = this.context.createGain();

--- a/src/audio/AudioStream.js
+++ b/src/audio/AudioStream.js
@@ -2,17 +2,12 @@
  * @author Mugen87 / https://github.com/Mugen87
  */
 
-function AudioStream( path, listener ) {
+function AudioStream( listener ) {
 
-	this.audioElement = new Audio( path ); // HTML5 Audio
 	this.context = listener.context;
 
 	this.gain = this.context.createGain();
 	this.gain.connect( listener.getInput() );
-
-	this.source = listener.context.createMediaElementSource( this.audioElement );
-
-	this.connect();
 
 }
 
@@ -21,6 +16,15 @@ Object.assign( AudioStream.prototype, {
 	getOutput: function () {
 
 		return this.gain;
+
+	},
+
+	setAudioElement: function ( audioElement ) {
+
+		this.audioElement = audioElement;
+		this.source = this.context.createMediaElementSource( audioElement );
+
+		return this.connect();
 
 	},
 


### PR DESCRIPTION
This PR adds the possibility to use audio streams based on [HTMLAudioElement](https://developer.mozilla.org/de/docs/Web/API/HTMLAudioElement).

You can check out and debug the corresponding (simple) example right **[here](https://yume.human-interactive.org/examples/audio/misc_sound_stream.html)**. It uses `THREE.AudioAnalyser`to visualize the data of the stream.

`THREE.AudioStream` integrates nicely in the existing audio API.

```javascript
var listener = new THREE.AudioListener();
camera.add( listener );

var audioStream = new THREE.AudioStream( 'mysong.ogg', listener );
var analyser = new THREE.AudioAnalyser( audioStream );

audioStream.play();
```