### PR TITLE
Fixes NO VR DISPLAY

### DIFF
--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -100,7 +100,7 @@ var WEBVR = {
 		button.style.textAlign = 'center';
 		button.style.zIndex = '999';
 
-		if ( effect.getVRDisplay() ) {
+		if ( this.isAvailable() ) {
 
 			button.textContent = 'ENTER VR';
 			button.onclick = function () {


### PR DESCRIPTION
This fixes an issue with not being able to ENTER VR using WebVR compatible browsers.

`effect.getVRDisplay()` returns `undefined` causing _NO VR DISPLAY_ to be displayed instead of the _ENTER VR_ button.  This is because `navigator.getVRDisplays` in `VREffect` has not yet returned a `VRDisplay` before `effect.getVRDisplay()` is run.   With this PR, we check use the internal `isAvailable()` for VR availability instead.
