### PR TITLE
make Object3D properties (pos,rot,quat,scale) configurable

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -53,18 +53,22 @@ function Object3D() {
 
 	Object.defineProperties( this, {
 		position: {
+			configurable: true,
 			enumerable: true,
 			value: position
 		},
 		rotation: {
+			configurable: true,
 			enumerable: true,
 			value: rotation
 		},
 		quaternion: {
+			configurable: true,
 			enumerable: true,
 			value: quaternion
 		},
 		scale: {
+			configurable: true,
 			enumerable: true,
 			value: scale
 		},


### PR DESCRIPTION
make Object3D properties (pos,rot,quat,scale) configurable to allow extensions by subclasses and proxies, per discussion in issue #11092 
