### PR TITLE
Editor: Fixed #10601

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -379,7 +379,7 @@ var Viewport = function ( editor ) {
 		selectionBox.visible = false;
 		transformControls.detach();
 
-		if ( object !== null && object !== scene ) {
+		if ( object !== null && object !== scene && object !== camera ) {
 
 			box.setFromObject( object );
 


### PR DESCRIPTION
Like with the `scene`object, we don't want to update `transformControls` when the editor camera is selected.

#10601