### PR TITLE
add IBL maps to the physical and standard variations

### DIFF
--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -26,13 +26,20 @@
 	<body>
 
 		<div id="container"></div>
-		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - Physical Material Variations by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
+		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - Physical Material Variations by <a href="http://clara.io/" target="_blank">Ben Houston</a>.<br/><br/>
+		Note: Every second sphere has an IBL environment map on it.</div>
 
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
+		<script src="js/loaders/RGBELoader.js"></script>
+		<script src="js/loaders/HDRCubeTextureLoader.js"></script>
+
+		<script src="js/pmrem/PMREMGenerator.js"></script>
+		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
+		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script>
 
@@ -61,54 +68,82 @@
 
 				//
 
-				var reflectionCube = new THREE.CubeTextureLoader()
-					.setPath( 'textures/cube/SwedishRoyalCastle/' )
-					.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
-				reflectionCube.format = THREE.RGBFormat;
+				var genCubeUrls = function( prefix, postfix ) {
+					return [
+						prefix + 'px' + postfix, prefix + 'nx' + postfix,
+						prefix + 'py' + postfix, prefix + 'ny' + postfix,
+						prefix + 'pz' + postfix, prefix + 'nz' + postfix
+					];
+				};
+
+
+				var textureCube = new THREE.CubeTextureLoader()
+					.setPath( 'textures/cube/pisa/' )
+					.load( [ 'px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png' ] );
 
 				scene = new THREE.Scene();
-				scene.background = reflectionCube;
+				scene.background = textureCube;
+				
+				var hdrUrls = genCubeUrls( './textures/cube/pisaHDR/', '.hdr' );
+				var hdrCubeRenderTarget = null;
 
-				// Materials
+				new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, hdrUrls, function ( hdrCubeMap ) {
 
-				var cubeWidth = 400;
-				var numberOfSphersPerSide = 5;
-				var sphereRadius = ( cubeWidth / numberOfSphersPerSide ) * 0.8 * 0.5;
-				var stepSize = 1.0 / numberOfSphersPerSide;
+					var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
+					pmremGenerator.update( renderer );
 
-				var geometry = new THREE.SphereBufferGeometry( sphereRadius, 32, 16 );
+					var pmremCubeUVPacker = new THREE.PMREMCubeUVPacker( pmremGenerator.cubeLods );
+					pmremCubeUVPacker.update( renderer );
 
-				for ( var alpha = 0; alpha <= 1.0; alpha += stepSize ) {
+					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+					 
+					// Materials
 
-					for ( var beta = 0; beta <= 1.0; beta += stepSize ) {
+					var cubeWidth = 400;
+					var numberOfSphersPerSide = 5;
+					var sphereRadius = ( cubeWidth / numberOfSphersPerSide ) * 0.8 * 0.5;
+					var stepSize = 1.0 / numberOfSphersPerSide;
 
-						for ( var gamma = 0; gamma <= 1.0; gamma += stepSize ) {
+					var geometry = new THREE.SphereBufferGeometry( sphereRadius, 32, 16 );
 
-							var diffuseColor = new THREE.Color().setHSL( alpha, 0.5, 0.5 );
+					var index = 0;
 
-							var material = new THREE.MeshPhysicalMaterial( {
-								color: diffuseColor,
-								metalness: 0,
-								roughness: 0.5,
-								clearCoat:  1.0 - alpha,
-								clearCoatRoughness: 1.0 - beta,
-								reflectivity: 1.0 - gamma,
-								envMap: reflectionCube
-							} );
+					for ( var alpha = 0; alpha <= 1.0; alpha += stepSize ) {
 
-							var mesh = new THREE.Mesh( geometry, material );
+						for ( var beta = 0; beta <= 1.0; beta += stepSize ) {
 
-							mesh.position.x = alpha * 400 - 200;
-							mesh.position.y = beta * 400 - 200;
-							mesh.position.z = gamma * 400 - 200;
+							for ( var gamma = 0; gamma <= 1.0; gamma += stepSize ) {
 
-							scene.add( mesh );
+								var diffuseColor = new THREE.Color().setHSL( alpha, 0.5, 0.25 );
+
+								var material = new THREE.MeshPhysicalMaterial( {
+									color: diffuseColor,
+									metalness: 0,
+									roughness: 0.5,
+									clearCoat:  1.0 - alpha,
+									clearCoatRoughness: 1.0 - beta,
+									reflectivity: 1.0 - gamma,
+									envMap: ( index % 2 ) == 1 ? hdrCubeRenderTarget.texture : null
+								} );
+
+								index ++;
+
+								var mesh = new THREE.Mesh( geometry, material );
+
+								mesh.position.x = alpha * 400 - 200;
+								mesh.position.y = beta * 400 - 200;
+								mesh.position.z = gamma * 400 - 200;
+
+								scene.add( mesh );
+
+							}
+							index ++;
 
 						}
+						index ++;
 
 					}
-
-				}
+				});
 
 				function addLabel( name, location ) {
 
@@ -161,6 +196,8 @@
 
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
+				renderer.toneMapping = THREE.Uncharted2ToneMapping;
+				renderer.toneMappingExposure = 0.75;
 
 				//
 

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -26,10 +26,16 @@
 	<body>
 
 		<div id="container"></div>
-		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - Standard Material Variations by <a href="http://clara.io/" target="_blank">Ben Houston</a>.</div>
+		<div id="info"><a href="http://threejs.org" target="_blank">three.js</a> - Standard Material Variations by <a href="http://clara.io/" target="_blank">Ben Houston</a>.<br/><br/>
+		Note: Every second sphere has an IBL environment map on it.</div>
 
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
+		<script src="js/loaders/RGBELoader.js"></script>
+		<script src="js/loaders/HDRCubeTextureLoader.js"></script>
+
+		<script src="js/pmrem/PMREMGenerator.js"></script>
+		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
@@ -60,14 +66,23 @@
 				camera.position.set( 0.0, 400, 400 * 3.5 );
 
 				//
+				var genCubeUrls = function( prefix, postfix ) {
+					return [
+						prefix + 'px' + postfix, prefix + 'nx' + postfix,
+						prefix + 'py' + postfix, prefix + 'ny' + postfix,
+						prefix + 'pz' + postfix, prefix + 'nz' + postfix
+					];
+				};
 
-				var reflectionCube = new THREE.CubeTextureLoader()
-					.setPath( 'textures/cube/SwedishRoyalCastle/' )
-					.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
-				reflectionCube.format = THREE.RGBFormat;
+				var textureCube = new THREE.CubeTextureLoader()
+					.setPath( 'textures/cube/pisa/' )
+					.load( [ 'px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png' ] );
 
 				scene = new THREE.Scene();
-				scene.background = reflectionCube;
+				scene.background = textureCube;
+				
+				var hdrUrls = genCubeUrls( './textures/cube/pisaHDR/', '.hdr' );
+				var hdrCubeRenderTarget = null;
 
 				// Materials
 
@@ -76,50 +91,67 @@
 				imgTexture.anisotropy = 16;
 				imgTexture = null;
 
-				var shininess = 50, specular = 0x333333, bumpScale = 1, shading = THREE.SmoothShading;
+				new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, hdrUrls, function ( hdrCubeMap ) {
 
-				var materials = [];
+					var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
+					pmremGenerator.update( renderer );
 
-				var cubeWidth = 400;
-				var numberOfSphersPerSide = 5;
-				var sphereRadius = ( cubeWidth / numberOfSphersPerSide ) * 0.8 * 0.5;
-				var stepSize = 1.0 / numberOfSphersPerSide;
+					var pmremCubeUVPacker = new THREE.PMREMCubeUVPacker( pmremGenerator.cubeLods );
+					pmremCubeUVPacker.update( renderer );
 
-				var geometry = new THREE.SphereBufferGeometry( sphereRadius, 32, 16 );
+					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
 
-				for ( var alpha = 0, alphaIndex = 0; alpha <= 1.0; alpha += stepSize, alphaIndex ++ ) {
+					var shininess = 50, specular = 0x333333, bumpScale = 1, shading = THREE.SmoothShading;
 
-					for ( var beta = 0; beta <= 1.0; beta += stepSize ) {
+					var materials = [];
 
-						for ( var gamma = 0; gamma <= 1.0; gamma += stepSize ) {
+					var cubeWidth = 400;
+					var numberOfSphersPerSide = 5;
+					var sphereRadius = ( cubeWidth / numberOfSphersPerSide ) * 0.8 * 0.5;
+					var stepSize = 1.0 / numberOfSphersPerSide;
+					
+					var geometry = new THREE.SphereBufferGeometry( sphereRadius, 32, 16 );
 
-							// basic monochromatic energy preservation
-							var diffuseColor = new THREE.Color().setHSL( alpha, 0.5, gamma * 0.5 );
+					var index = 0;
 
-							var material = new THREE.MeshStandardMaterial( {
-								map: imgTexture,
-								bumpMap: imgTexture,
-								bumpScale: bumpScale,
-								color: diffuseColor,
-								metalness: beta,
-								roughness: 1.0 - alpha,
-								shading: THREE.SmoothShading,
-								envMap: alphaIndex % 2 === 0 ? null : reflectionCube
-							} );
+					for ( var alpha = 0; alpha <= 1.0; alpha += stepSize ) {
 
-							var mesh = new THREE.Mesh( geometry, material );
+						for ( var beta = 0; beta <= 1.0; beta += stepSize ) {
 
-							mesh.position.x = alpha * 400 - 200;
-							mesh.position.y = beta * 400 - 200;
-							mesh.position.z = gamma * 400 - 200;
+							for ( var gamma = 0; gamma <= 1.0; gamma += stepSize ) {
 
-							scene.add( mesh );
+								// basic monochromatic energy preservation
+								var diffuseColor = new THREE.Color().setHSL( alpha, 0.5, gamma * 0.5 );
 
+								var material = new THREE.MeshStandardMaterial( {
+									map: imgTexture,
+									bumpMap: imgTexture,
+									bumpScale: bumpScale,
+									color: diffuseColor,
+									metalness: beta,
+									roughness: 1.0 - alpha,
+									shading: THREE.SmoothShading,
+									envMap: index % 2 === 0 ? null : hdrCubeRenderTarget.texture						
+								} );
+
+								index ++;
+
+								var mesh = new THREE.Mesh( geometry, material );
+
+								mesh.position.x = alpha * 400 - 200;
+								mesh.position.y = beta * 400 - 200;
+								mesh.position.z = gamma * 400 - 200;
+
+								scene.add( mesh );
+
+							}
+							
 						}
+						
+						index ++;
 
 					}
-
-				}
+				});
 
 				function addLabel( name, location ) {
 
@@ -172,6 +204,8 @@
 
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
+				renderer.toneMapping = THREE.Uncharted2ToneMapping;
+				renderer.toneMappingExposure = 0.75;
 
 				//
 


### PR DESCRIPTION
This PR adds HDR IBL maps to the physical and standard material variations to better catch bugs.  I've seen a bunch of IBL map bugs on various mobiles and moving this from using the LDR environment maps to the HDR environment maps will make this bugs much more obvious to everyone -- and because these variations are parameterized, you will be able to see which parameter change is causing the bug.

This does significnatly change the look of this example, but there was no other choice if I was to move towards an HDR IBL PMREM envMap from the LDR classic envMap.