### PR TITLE
FIX IE11 shader compilation - use more selective whitespace matching

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -152,7 +152,7 @@ function replaceLightNums( string, parameters ) {
 
 function parseIncludes( string ) {
 
-	var pattern = /^\s*#include +<([\w\d.]+)>/gm;
+	var pattern = /^[ \t]*#include +<([\w\d.]+)>/gm;
 
 	function replace( match, include ) {
 


### PR DESCRIPTION
Fixes #11143 

( \s matches \n and \r and as a result concatenates #include text onto last non blank line)

/pingf @gero3 - does this look OK?