### PR TITLE
Fix Adaptive Tone Map issue on very dark (initial) scene

### DIFF
--- a/examples/js/shaders/ToneMapShader.js
+++ b/examples/js/shaders/ToneMapShader.js
@@ -1,7 +1,7 @@
 /**
  * @author miibond
  *
- * Full-screen tone-mapping shader based on http://www.graphics.cornell.edu/~jaf/publications/sig02_paper.pdf
+ * Full-screen tone-mapping shader based on http://www.cis.rit.edu/people/faculty/ferwerda/publications/sig02_paper.pdf
  */
 
 THREE.ToneMapShader = {
@@ -12,6 +12,7 @@ THREE.ToneMapShader = {
 		"averageLuminance":  { value: 1.0 },
 		"luminanceMap":  { value: null },
 		"maxLuminance":  { value: 16.0 },
+		"minLuminance":  { value: 0.01 },
 		"middleGrey":  { value: 0.6 }
 	},
 
@@ -35,6 +36,7 @@ THREE.ToneMapShader = {
 		"varying vec2 vUv;",
 
 		"uniform float middleGrey;",
+		"uniform float minLuminance;",
 		"uniform float maxLuminance;",
 		"#ifdef ADAPTED_LUMINANCE",
 			"uniform sampler2D luminanceMap;",
@@ -56,7 +58,7 @@ THREE.ToneMapShader = {
 			"float fLumPixel = dot(vColor, LUM_CONVERT);",
 
 			// Apply the modified operator (Eq. 4)
-			"float fLumScaled = (fLumPixel * middleGrey) / fLumAvg;",
+			"float fLumScaled = (fLumPixel * middleGrey) / max( minLuminance, fLumAvg );",
 
 			"float fLumCompressed = (fLumScaled * (1.0 + (fLumScaled / (maxLuminance * maxLuminance)))) / (1.0 + fLumScaled);",
 			"return fLumCompressed * vColor;",


### PR DESCRIPTION
When last luminance is zero and time delta also very small,
chances are that the output luminance is still zero on the
next run, even when current luminance is rather high. The
reason behind is that luminance value is stored on the red
channel of a 1x1 texture. Therefore computed values below
~0.002 get rounded down to zero again (1/255 => ~0.004).

There is also no reason to write to all color channels when
only the red channel is used (ToneMapShader uses red too).

Additionally implements `renderToScreen` composer flag.