### PR TITLE
GPUParticleSystem: Refactoring

### DIFF
--- a/examples/js/GPUParticleSystem.js
+++ b/examples/js/GPUParticleSystem.js
@@ -133,20 +133,20 @@ THREE.GPUParticleSystem = function( options ) {
 
 			'void main() {',
 
-			'float alpha = 0.;',
+			'	float alpha = 0.;',
 
-			'if( lifeLeft > 0.995 ) {',
+			'	if( lifeLeft > 0.995 ) {',
 
-			'	alpha = scaleLinear( lifeLeft, vec2( 1.0, 0.995 ), vec2( 0.0, 1.0 ) );',
+			'		alpha = scaleLinear( lifeLeft, vec2( 1.0, 0.995 ), vec2( 0.0, 1.0 ) );',
 
-			'} else {',
+			'	} else {',
 
-			'	alpha = lifeLeft * 0.75;',
+			'		alpha = lifeLeft * 0.75;',
 
-			'}',
+			'	}',
 
-			'vec4 tex = texture2D( tSprite, gl_PointCoord );',
-			'gl_FragColor = vec4( vColor.rgb * tex.a, alpha * tex.a );',
+			'	vec4 tex = texture2D( tSprite, gl_PointCoord );',
+			'	gl_FragColor = vec4( vColor.rgb * tex.a, alpha * tex.a );',
 
 			'}'
 


### PR DESCRIPTION
This PR solves the problems mentioned in  #11149

- Added missing `dispose` method
- Introduced a single shader attribute per particle property instead of encoding/decoding float to vector4 and vice versa.
- Clean up and code style

As a compromise you need to maintain more shader attributes than before. However, the code should now much easier to read and understand. Besides the numerical robustness is better than before.
