### PR TITLE
Docs ShaderMaterial example: remove attributes property from constructor parameters

### DIFF
--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -86,13 +86,14 @@
 		var material = new THREE.ShaderMaterial( {
 
 			uniforms: {
+
 				time: { value: 1.0 },
 				resolution: { value: new THREE.Vector2() }
+
 			},
-			attributes: {
-				vertexOpacity: { value: [] }
-			},
+
 			vertexShader: document.getElementById( 'vertexShader' ).textContent,
+
 			fragmentShader: document.getElementById( 'fragmentShader' ).textContent
 
 		} );


### PR DESCRIPTION
![attributes](https://cloud.githubusercontent.com/assets/5700294/24865995/3b1b61ba-1e09-11e7-9a0c-b5e2f48bf397.PNG)

Attributes property not supported in ShaderMaterial (since https://github.com/mrdoob/three.js/commit/e2f85057e4c72c70f236293a04aafce45379a329) ?