### PR TITLE
SpotLightShadow: Fixed #11158

### DIFF
--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -20,11 +20,11 @@ SpotLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype 
 
 	update: function ( light ) {
 
+		var camera = this.camera;
+
 		var fov = _Math.RAD2DEG * 2 * light.angle;
 		var aspect = this.mapSize.width / this.mapSize.height;
-		var far = light.distance || 500;
-
-		var camera = this.camera;
+		var far = light.distance || camera.far;
 
 		if ( fov !== camera.fov || aspect !== camera.aspect || far !== camera.far ) {
 


### PR DESCRIPTION
If `light.distance` is zero, `camera.far` is used instead of a fix value of `500`.

BTW: Default value of `camera.far` is `500`, see [here](https://github.com/Mugen87/three.js/blob/dcef2d51ebf865d7d75c432287eecfd0608b7386/src/lights/SpotLightShadow.js#L11).

Fixes #11158