### PR TITLE
[examples] Remove unused lines from webgl_postprocessing_outline.html

### DIFF
--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -41,13 +41,11 @@
 		<script src="js/Detector.js"></script>
 
 		<script src="js/shaders/CopyShader.js"></script>
-    <script src="js/postprocessing/EffectComposer.js"></script>
-    <script src="js/postprocessing/MaskPass.js"></script>
-		<script src="js/shaders/CopyShader.js"></script>
+		<script src="js/shaders/FXAAShader.js"></script>
+		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
     <script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/postprocessing/OutlinePass.js"></script>
-		<script src="js/shaders/FXAAShader.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 


### PR DESCRIPTION
[webgl_postprocessing_outline.html](https://github.com/mrdoob/three.js/blob/dev/examples/webgl_postprocessing_outline.html#L43) is loading CopyShader.js twice.

also MaskPass.js is not used.