### PR TITLE
fix operator precedence bug in WWOBJLoader2.js

### DIFF
--- a/examples/js/loaders/WWOBJLoader2.js
+++ b/examples/js/loaders/WWOBJLoader2.js
@@ -208,7 +208,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 		if ( this.dataAvailable ) {
 
 			// fast-fail on bad type
-			if ( ! params.objAsArrayBuffer instanceof Uint8Array ) {
+			if ( ! ( params.objAsArrayBuffer instanceof Uint8Array ) ) {
 				throw 'Provided input is not of type arraybuffer! Aborting...';
 			}
 


### PR DESCRIPTION
I'm writing a static analyzer for JavaScript and I noticed an operator precedence bug in this library during my testing. It turns out `!a instanceof b` is parsed `(!a) instanceof b` instead of `!(a instanceof b)`. You need to use parentheses around the operands to get it to parse correctly. I know it's a bug in one of the examples and not in the core library, but I figured you'd still appreciate me sending in a fix for it :)
