### PR TITLE
Docs: References to MultiMaterial removed

### DIFF
--- a/docs/api/core/BufferGeometry.html
+++ b/docs/api/core/BufferGeometry.html
@@ -138,12 +138,12 @@
 		<h3>[property:Array groups]</h3>
 		<div>
 			Split the geometry into groups, each of which will be rendered in a separate WebGL draw call.
-			This allows a [page:MultiMaterial] to be used with the bufferGeometry.<br /><br />
+			This allows an array of materials to be used with the bufferGeometry.<br /><br />
 
 			Each group is an object of the form:
 			<code>{ start: Integer, count: Integer, materialIndex: Integer }</code>
 			where start specifies the index of the first vertex in this draw call, count specifies
-			how many vertices are included, and materialIndex specifies the [page:MultiMaterial] index to use.<br /><br />
+			how many vertices are included, and materialIndex specifies the material array index to use.<br /><br />
 
 			Use [page:.addGroup] to add groups, rather than modifying this array directly.
 		</div>

--- a/docs/api/core/Face3.html
+++ b/docs/api/core/Face3.html
@@ -67,7 +67,7 @@ scene.add( new THREE.Mesh( geometry, material ) );
 		If a single vector is passed in, this sets [page:.color], otherwise if an array of three
 		vectors is passed in this sets [page:.vertexColors]<br /><br />
 
-		materialIndex — (optional) which index of a [page:MultiMaterial] to associate
+		materialIndex — (optional) which index of an array of materials to associate
 		with the face.
 		</div>
 
@@ -115,7 +115,7 @@ scene.add( new THREE.Mesh( geometry, material ) );
 
 		<h3>[property:Integer materialIndex]</h3>
 		<div>
-		Material index (points to [page:MultiMaterial MultiMaterial.materials]). Default is *0*.
+		Material index (points to an index in the associated array of materials). Default is *0*.
 		</div>
 
 		<h2>Methods</h2>

--- a/docs/api/deprecated/DeprecatedList.html
+++ b/docs/api/deprecated/DeprecatedList.html
@@ -411,7 +411,10 @@
 		</div>
 
 		<h3>[page:MeshFaceMaterial]</h3>
-		<div>MeshFaceMaterial has been removed. Use [page:MultiMaterial] instead.</div>
+		<div>MeshFaceMaterial has been removed. Use an array of materials instead.</div>
+
+		<h3>[page:MultiMaterial]</h3>
+		<div>MultiMaterial has been removed. Use an array of materials instead.</div>
 
 		<h3>[page:MeshPhongMaterial]</h3>
 		<div>MeshPhongMaterial.metal has been removed. Use [page:MeshStandardMaterial] instead.</div>

--- a/docs/api/extras/SceneUtils.html
+++ b/docs/api/extras/SceneUtils.html
@@ -22,7 +22,7 @@
 		materials -- The materials for the object.
 		</div>
 		<div>
-		Creates a new Group that contains a new mesh for each material defined in materials. Beware that this is not the same as MultiMaterial which defines multiple material for 1 mesh.<br />
+		Creates a new Group that contains a new mesh for each material defined in materials. Beware that this is not the same as an array of materials which defines multiple materials for 1 mesh.<br />
 		This is mostly useful for objects that need both a material and a wireframe implementation.
 		</div>
 

--- a/docs/api/loaders/JSONLoader.html
+++ b/docs/api/loaders/JSONLoader.html
@@ -28,13 +28,18 @@
 
 		// load a resource
 		loader.load(
+
 			// resource URL
 			'models/animated/monster/monster.js',
+
 			// Function when resource is loaded
 			function ( geometry, materials ) {
-				var material = new THREE.MultiMaterial( materials );
+
+				var material = materials[ 0 ];
 				var object = new THREE.Mesh( geometry, material );
+
 				scene.add( object );
+
 			}
 		);
 		</code>

--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -17,8 +17,8 @@
 		They are defined in a (mostly) renderer-independent way, so you don't have to
 		rewrite materials if you decide to use a different renderer.<br /><br />
 
-		With the exception of [page:MultiMaterial MultiMaterial], the following properties
-		and methods are inherited by all other material types (although they may have different defaults).
+		The following properties and methods are inherited by all other material types
+		(although they may have different defaults).
 		</div>
 
 		<h2>Constructor</h2>

--- a/docs/examples/loaders/OBJLoader.html
+++ b/docs/examples/loaders/OBJLoader.html
@@ -67,7 +67,7 @@
 		<div>
 		Returns an [page:Object3D]. It contains the parsed meshes as [page:Mesh] and lines as [page:LineSegments].<br />
 		All geometry is created as [page:BufferGeometry]. Default materials are created as [page:MeshPhongMaterial].<br />
-		If an <em>obj</em> object or group uses multiple materials while declaring faces geometry groups and a [page:MultiMaterial] is used.
+		If an <em>obj</em> object or group uses multiple materials while declaring faces geometry groups and an array of materials are used.
 		</div>
 
 		<h2>Source</h2>


### PR DESCRIPTION
The MultiMaterial article was removed from the docs with https://github.com/mrdoob/three.js/commit/ef608bfeefbb9ea7e63eada82384dd43fe0d651b, but there are some further references in the docs, which are removed by this PR.

BTW: I noticed that there are still a lot of MultiMaterial references in the loaders, converters etc.. I don't know, which of them are relevant/could cause problems:

MaterialLoader.js
Loader.js
BabylonLoader.js
ColladaLoader.js
FBXLoader.js
FBXLoader2.js
OBJLoader.js
OBJLoader2.js
WWOBJLoader2.js
XLoader.js
convert_to_threejs.py
convert_obj_three.py
convert_obj_three_for_python3.py
ThreeJSExporter.ms
ThreeJSAnimationExporter.ms
ThreeJSExporter_MorphTargets_v0.ms
threejs.js
