### PR TITLE
wwobjloader2 docs and code enhancements

### DIFF
--- a/docs/examples/loaders/OBJLoader2.html
+++ b/docs/examples/loaders/OBJLoader2.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+
+		<h1>[name]</h1>
+
+		<div class="desc">A loader for loading an <em>.obj</em> resource.</div>
+
+		<h2>Example</h2>
+
+		<code>
+		// instantiate the loader
+		var loader = new THREE.OBJLoader2();
+
+		// function called on successful load
+		var intergrateIntoScene = function ( object ) {
+			scene.add( object );
+		};
+
+		// load a resource from provided URL
+		loader.load( 'obj/female02/female02.obj', intergrateIntoScene );
+		</code>
+
+		[example:webgl_loader_obj2]
+
+
+		<h2>Constructor</h2>
+
+		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<div>
+		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
+		</div>
+		<div>
+			Use [name] to load OBJ data from files or to parse OBJ data from arraybuffer or text.
+		</div>
+
+		<h2>Properties</h2>
+
+
+		<h2>Methods</h2>
+
+		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError], [page:Boolean useArrayBuffer] )</h3>
+		<div>
+			[page:String url] — URL of the file to load<br />
+			[page:Function onLoad] — Called after loading was successfully completed. The argument will be the loaded [page:Object3D].<br />
+			[page:Function onProgress] — Called to report progress of loading. The argument will be the XmlHttpRequest instance, that contain .[page:Integer total] and .[page:Integer loaded] bytes.<br />
+			[page:Function onError]  Called after an error occurred during loading.<br />
+			[page:boolean useArrayBuffer] — Set this to false to force string based parsing<br />
+		</div>
+		<div>
+			Use this convenient method to load an OBJ file at the given URL. Per default the fileLoader uses an arraybuffer
+		</div>
+
+		<h3>[method:Object3D parse]( [page:ArrayBuffer arrayBuffer] )</h3>
+		<div>
+			[page:ArrayBuffer arrayBuffer] — OBJ data as Uint8Array
+		</div>
+		<div>
+			Default parse function: Parses OBJ file content stored in arrayBuffer and returns the [page:Object3D sceneGraphBaseNode].
+		</div>
+
+		<h3>[method:Object3D parseText]( [page:String test] )</h3>
+		<div>
+			[page:String text] — OBJ data as string
+		</div>
+		<div>
+			Legacy parse function: Parses OBJ file content stored in string and returns the [page:Object3D sceneGraphBaseNode].
+		</div>
+
+		<h3>[method:null setMaterials] ( Array of [page:Material materials] )</h3>
+		<div>
+			Array of [page:Material materials] — Array of [page:Material Materials] from MTLLoader
+		</div>
+		<div>
+			Set materials loaded by MTLLoader or any other supplier of an Array of [page:Material Materials].
+		</div>
+
+		<h3>[method:null setPath] ( [page:String path] )</h3>
+		<div>
+			[page:String path] — The basePath
+		</div>
+		<div>
+			Base path to use.
+		</div>
+
+		<h3>[method:null setSceneGraphBaseNode] ( [page:Object3D sceneGraphBaseNode] )</h3>
+		<div>
+			[page:Object3D sceneGraphBaseNode] — Scenegraph object where meshes will be attached
+		</div>
+		<div>
+			Set the node where the loaded objects will be attached.
+		</div>
+
+		<h3>[method:null setDebug]( [page:Boolean parserDebug], [page:Boolean meshCreatorDebug] )</h3>
+		<div>
+			[page:Boolean parserDebug] — Internal Parser will produce debug output<br>
+			[page:Boolean meshCreatorDebug] — Internal MeshCreator will produce debug output
+		</div>
+		<div>
+			Allows to set debug mode for the parser and the meshCreator.
+		</div>
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/OBJLoader2.js examples/js/loaders/OBJLoader2.js]
+	</body>
+</html>

--- a/docs/examples/loaders/WWOBJLoader2.html
+++ b/docs/examples/loaders/WWOBJLoader2.html
@@ -16,6 +16,8 @@
 		<h2>Sub-Classes</h2>
 		[page:WWOBJLoader2.PrepDataArrayBuffer]<br>
 		[page:WWOBJLoader2.PrepDataFile]<br>
+		[page:WWOBJLoader2.PrepDataCallbacks]<br>
+		[page:WWOBJLoader2.LoadedMeshUserOverride]<br>
 		[page:WWOBJLoader2.WWOBJLoader2Director]
 
 		<h2>Example</h2>
@@ -131,7 +133,7 @@
 			[page:Function callbackMeshLoaded] — 	Callback function for described functionality
 		</div>
 		<div>
-			Register callback function that is called every time a mesh was loaded. Return altered [page:Material] or null from callback.
+			Register callback function that is called every time a mesh was loaded. Use [page:WWOBJLoader2.LoadedMeshUserOverride] for alteration instructions (geometry, material or disregard mesh).
 		</div>
 
 		<h3>[method:null registerCallbackErrorWhileLoading]( [page:Function callbackErrorWhileLoading] )</h3>
@@ -140,6 +142,12 @@
 		</div>
 		<div>
 			Register callback function that is called to report an error that prevented loading.
+		</div>
+
+
+		<h3>[method:null clearAllCallbacks]()</h3>
+		<div>
+			Clears all registered callbacks.
 		</div>
 
 
@@ -154,12 +162,43 @@
 			[page:Uint8Array objAsArrayBuffer] — OBJ file content as ArrayBuffer<br>
 			[page:String pathTexture] — Path to texture files<br>
 			[page:String mtlAsString] — MTL file content as string
-			[page:Object3D sceneGraphBaseNode] [page:Object3D] where meshes will be attached
-			[page:Boolean streamMeshes] Singles meshes are directly integrated into scene when loaded or later
-			[page:Boolean requestTerminate] Request termination of web worker and free local resources after execution
 		</div>
 		<div>
 			Instruction to configure [page:WWOBJLoader2.prepareRun] to load OBJ from given ArrayBuffer and MTL from given String.
+		</div>
+
+		<h2>Methods</h2>
+
+		<h3>[method:PrepDataCallbacks getCallbacks]()</h3>
+		<div>
+			Returns all callbacks as [page:WWOBJLoader2.PrepDataCallbacks].
+		</div>
+
+
+		<h3>[method:null setRequestTerminate]( [page:Boolean requestTerminate] )</h3>
+		<div>
+			[page:Boolean requestTerminate] — Default is false
+		</div>
+		<div>
+			Request termination of web worker and free local resources after execution.
+		</div>
+
+
+		<h3>[method:null setSceneGraphBaseNode]( [page:THREE.Object3D sceneGraphBaseNode] )</h3>
+		<div>
+			[page:Object3D sceneGraphBaseNode] — Scene graph object
+		</div>
+		<div>
+			[page:Object3D] where meshes will be attached.
+		</div>
+
+
+		<h3>[method:null setStreamMeshes]( [page:Boolean streamMeshes] )</h3>
+		<div>
+			[page:Boolean streamMeshes] — Default is true
+		</div>
+		<div>
+			Singles meshes are directly integrated into scene when loaded or later.
 		</div>
 		<br>
 		<br>
@@ -175,12 +214,116 @@
 			[page:String fileObj] — OBJ file name<br>
 			[page:String pathTexture] — Path to texture files<br>
 			[page:String fileMtl] — MTL file name
-			[page:Object3D sceneGraphBaseNode] [page:Object3D] where meshes will be attached
-			[page:Boolean streamMeshes] Singles meshes are directly integrated into scene when loaded or later
-			[page:Boolean requestTerminate] Request termination of web worker and free local resources after execution
 		</div>
 		<div>
 			Instruction to configure [page:WWOBJLoader2.prepareRun] to load OBJ and MTL from files.
+		</div>
+
+		<h2>Methods</h2>
+
+		<h3>[method:PrepDataCallbacks getCallbacks]()</h3>
+		<div>
+			Returns all callbacks as [page:WWOBJLoader2.PrepDataCallbacks].
+		</div>
+
+
+		<h3>[method:null setRequestTerminate]( [page:Boolean requestTerminate] )</h3>
+		<div>
+			[page:Boolean requestTerminate] — Default is false
+		</div>
+		<div>
+			Request termination of web worker and free local resources after execution.
+		</div>
+
+
+		<h3>[method:null setSceneGraphBaseNode]( [page:THREE.Object3D sceneGraphBaseNode] )</h3>
+		<div>
+			[page:Object3D sceneGraphBaseNode] — Scene graph object
+		</div>
+		<div>
+			[page:Object3D] where meshes will be attached.
+		</div>
+
+
+		<h3>[method:null setStreamMeshes]( [page:Boolean streamMeshes] )</h3>
+		<div>
+			[page:Boolean streamMeshes] — Default is true
+		</div>
+		<div>
+			Singles meshes are directly integrated into scene when loaded or later.
+		</div>
+		<br>
+		<br>
+
+
+		<a name="PrepDataCallbacks"></a><h1>PrepDataCallbacks</h1>
+		<h2>Constructor</h2>
+
+		<h3>PrepDataCallbacks()</h3>
+		<div>
+			Callbacks utilized by functions working with [page:WWOBJLoader2.PrepDataArrayBuffer] or [page:WWOBJLoader2.PrepDataFile].
+		</div>
+
+		<h2>Methods</h2>
+
+		<h3>[method:null registerCallbackCompletedLoading]( [page:Function callbackCompletedLoading] )</h3>
+		<div>
+			[page:Function callbackCompletedLoading] — Callback function for described functionality
+		</div>
+		<div>
+			Register callback function that is called once loading of the complete model is completed.
+		</div>
+
+
+		<h3>[method:null registerCallbackProgress]( [page:Function callbackProgress] )</h3>
+		<div>
+			[page:Function callbackProgress] — Callback function for described functionality
+		</div>
+		<div>
+			Register callback function that is invoked by internal function "_announceProgress" to print feedback.
+		</div>
+
+
+		<h3>[method:null registerCallbackErrorWhileLoading]( [page:Function callbackErrorWhileLoading] )</h3>
+		<div>
+			[page:Function callbackErrorWhileLoading] — Callback function for described functionality
+		</div>
+		<div>
+			Report if an error prevented loading.
+		</div>
+
+
+		<h3>[method:null registerCallbackMaterialsLoaded]( [page:Function callbackMaterialsLoaded] )</h3>
+		<div>
+			[page:Function callbackMaterialsLoaded] — Callback function for described functionality
+		</div>
+		<div>
+			Register callback function that is called once materials have been loaded. It allows to alter and return materials.
+		</div>
+
+
+		<h3>[method:null registerCallbackMeshLoaded]( [page:Function callbackMeshLoaded] )</h3>
+		<div>
+			[page:Function callbackMeshLoaded] — Callback function for described functionality
+		</div>
+		<div>
+			Register callback function that is called every time a mesh was loaded. Use [page:WWOBJLoader2.LoadedMeshUserOverride] for alteration instructions (geometry, material or disregard mesh).
+		</div>
+		<br>
+		<br>
+
+
+		<a name="LoadedMeshUserOverride"></a><h1>LoadedMeshUserOverride</h1>
+		<h2>Constructor</h2>
+
+		<h3>LoadedMeshUserOverride( [page:Boolean disregardMesh], [page:THREE.BufferGeometry bufferGeometry], [page:THREE.Material material] )</h3>
+		<div>
+			[page:Boolean disregardMesh] — Tell [page:WWOBJLoader2] to completely disregard this mesh<br>
+			[page:BufferGeometry bufferGeometry] — The [page:BufferGeometry] to be used<br>
+			[page:Material material] — The [page:Material] to be used
+		</div>
+		<div>
+			Object to return by THREE.OBJLoader2.WWOBJLoader2.callbacks.meshLoaded. Used to adjust bufferGeometry or material or prevent complete loading of mesh.
 		</div>
 		<br>
 		<br>
@@ -199,9 +342,9 @@
 				deregister
 		</div>
 
-		<h3>[method:null prepareWorkers]( Array of [page:Function callbacks], [page:Number maxQueueSize], [page:Number maxWebWorkers] )</h3>
+		<h3>[method:null prepareWorkers]( [page:WWOBJLoader2.PrepDataCallbacks globalCallbacks], [page:Number maxQueueSize], [page:Number maxWebWorkers] )</h3>
 		<div>
-			Array of [page:Function callbacks] — Register callbacks for all web workers: progress, completedLoading, errorWhileLoading, materialsLoaded, meshLoaded<br>
+			[page:WWOBJLoader2.PrepDataCallbacks globalCallbacks] — Register global callbacks used by all web workers<br>
 			[page:Number maxQueueSize] — Set the maximum size of the instruction queue (1-1024)<br>
 			[page:Number maxWebWorkers] — Set the maximum amount of workers (1-16)
 		</div>

--- a/docs/examples/loaders/WWOBJLoader2.html
+++ b/docs/examples/loaders/WWOBJLoader2.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+
+		<h1>[name]</h1>
+
+		<div class="desc">A loader for loading an <em>.obj</em> resource within a web worker.</div>
+
+		<h2>Sub-Classes</h2>
+		[page:WWOBJLoader2.PrepDataArrayBuffer]<br>
+		[page:WWOBJLoader2.PrepDataFile]<br>
+		[page:WWOBJLoader2.WWOBJLoader2Director]
+
+		<h2>Example</h2>
+
+		<code>
+			// instantiate the loader
+			var loader = new THREE.OBJLoader2.WWOBJLoader2();
+
+			// load an OBJ file by providing a name, the path and the file name
+			var prepData = new THREE.OBJLoader2.WWOBJLoader2.PrepDataFile(
+				'female02',
+				'obj/female02/',
+				'female02.obj'
+			);
+
+			// set where to add the loaded data in the scene graph.
+			prepData.setSceneGraphBaseNode( scene );
+
+			// provide the preparation data to the loader and let it run.
+			loader.prepareRun( prepData );
+			loader.run();
+		</code>
+
+		[example:webgl_loader_obj2_ww] — Simple example that allows to load own models via file selection.<br>
+		[example:webgl_loader_obj2_ww_parallels] — Advanced example using [page:WWOBJLoader2.WWOBJLoader2Director] for orchestration of multiple workers.
+
+
+		<h2>Constructor</h2>
+
+		<h3>[name]()</h3>
+		<div>
+			OBJ data will be loaded by dynamically created web worker.<br>
+			First feed instructions with: [page:WWOBJLoader2.prepareRun prepareRun]<br>
+			Then execute with: [page:WWOBJLoader2.run run]
+		</div>
+
+		<h2>Properties</h2>
+
+
+		<h2>Methods</h2>
+
+		<h3>[method:null prepareRun]( [page:Object params] )</h3>
+		<div>
+			[page:Object params] — Either [page:WWOBJLoader2.PrepDataArrayBuffer] or [page:WWOBJLoader2.PrepDataFile]
+		</div>
+		<div>
+			Set all parameters for required for execution of [page:WWOBJLoader2.run run].
+		</div>
+
+
+		<h3>[method:null run]()</h3>
+		<div>
+			Run the loader according the preparation instruction provided in [page:WWOBJLoader2.prepareRun prepareRun].
+		</div>
+
+
+		<h3>[method:null setCrossOrigin]( [page:String crossOrigin] )</h3>
+		<div>
+			[page:String crossOrigin] — CORS value
+		</div>
+		<div>
+			Sets the CORS string to be used.
+		</div>
+
+
+		<h3>[method:null setDebug]( [page:Boolean enabled] )</h3>
+		<div>
+			[page:Boolean enabled] — True or false
+		</div>
+		<div>
+			Enable or disable debug logging.
+		</div>
+
+
+		<h3>[method:null setRequestTerminate]( [page:Boolean requestTerminate] )</h3>
+		<div>
+			[page:Boolean requestTerminate] — True or false
+		</div>
+		<div>
+			Call requestTerminate to terminate the web worker and free local resource after execution.
+		</div>
+
+
+		<h3>[method:null registerCallbackCompletedLoading]( [page:Function callbackCompletedLoading] )</h3>
+		<div>
+			[page:Function callbackCompletedLoading] — 	Callback function for described functionality
+		</div>
+		<div>
+			Register callback function that is called once loading of the complete model is completed.
+		</div>
+
+
+		<h3>[method:null registerCallbackProgress]( [page:Function callbackProgress] )</h3>
+		<div>
+			[page:Function callbackProgress] — 	Callback function for described functionality
+		</div>
+		<div>
+			Register callback function that is invoked by internal function "_announceProgress" to print feedback.
+		</div>
+
+
+		<h3>[method:null registerCallbackMaterialsLoaded]( [page:Function callbackMaterialsLoaded] )</h3>
+		<div>
+			[page:Function callbackMaterialsLoaded] — 	Callback function for described functionality
+		</div>
+		<div>
+			Register callback function that is called once materials have been loaded. It allows to alter and return materials.
+		</div>
+
+
+		<h3>[method:null registerCallbackMeshLoaded]( [page:Function callbackMeshLoaded] )</h3>
+		<div>
+			[page:Function callbackMeshLoaded] — 	Callback function for described functionality
+		</div>
+		<div>
+			Register callback function that is called every time a mesh was loaded. Return altered [page:Material] or null from callback.
+		</div>
+
+		<h3>[method:null registerCallbackErrorWhileLoading]( [page:Function callbackErrorWhileLoading] )</h3>
+		<div>
+			[page:Function callbackErrorWhileLoading] — 	Callback function for described functionality
+		</div>
+		<div>
+			Register callback function that is called to report an error that prevented loading.
+		</div>
+
+
+		<h2>Sub-Classes</h2>
+		<br>
+		<a name="PrepDataArrayBuffer"></a><h1>PrepDataArrayBuffer</h1>
+		<h2>Constructor</h2>
+
+		<h3>PrepDataArrayBuffer( [page:String modelName], [page:Uint8Array objAsArrayBuffer], [page:String pathTexture], [page:String mtlAsString] )</h3>
+		<div>
+			[page:String modelName] — Overall name of the model<br>
+			[page:Uint8Array objAsArrayBuffer] — OBJ file content as ArrayBuffer<br>
+			[page:String pathTexture] — Path to texture files<br>
+			[page:String mtlAsString] — MTL file content as string
+			[page:Object3D sceneGraphBaseNode] [page:Object3D] where meshes will be attached
+			[page:Boolean streamMeshes] Singles meshes are directly integrated into scene when loaded or later
+			[page:Boolean requestTerminate] Request termination of web worker and free local resources after execution
+		</div>
+		<div>
+			Instruction to configure [page:WWOBJLoader2.prepareRun] to load OBJ from given ArrayBuffer and MTL from given String.
+		</div>
+		<br>
+		<br>
+
+
+		<a name="PrepDataFile"></a><h1>PrepDataFile</h1>
+		<h2>Constructor</h2>
+
+		<h3>PrepDataFile( [page:String modelName], [page:String pathObj], [page:String fileObj], [page:String pathTexture], [page:String fileMtl] )</h3>
+		<div>
+			[page:String modelName] — Overall name of the model<br>
+			[page:String pathObj] — Path to OBJ file<br>
+			[page:String fileObj] — OBJ file name<br>
+			[page:String pathTexture] — Path to texture files<br>
+			[page:String fileMtl] — MTL file name
+			[page:Object3D sceneGraphBaseNode] [page:Object3D] where meshes will be attached
+			[page:Boolean streamMeshes] Singles meshes are directly integrated into scene when loaded or later
+			[page:Boolean requestTerminate] Request termination of web worker and free local resources after execution
+		</div>
+		<div>
+			Instruction to configure [page:WWOBJLoader2.prepareRun] to load OBJ and MTL from files.
+		</div>
+		<br>
+		<br>
+
+
+		<a name="WWOBJLoader2Director"></a><h1>WWOBJLoader2Director</h1>
+		<h2>Constructor</h2>
+
+		<h3>WWOBJLoader2Director()</h3>
+		<div>
+			Orchestrate loading of multiple OBJ files/data from an instruction queue with a configurable amount of workers (1-16).<br>
+			Workflow:<br>
+				prepareWorkers<br>
+				enqueueForRun<br>
+				processQueue<br>
+				deregister
+		</div>
+
+		<h3>[method:null prepareWorkers]( Array of [page:Function callbacks], [page:Number maxQueueSize], [page:Number maxWebWorkers] )</h3>
+		<div>
+			Array of [page:Function callbacks] — Register callbacks for all web workers: progress, completedLoading, errorWhileLoading, materialsLoaded, meshLoaded<br>
+			[page:Number maxQueueSize] — Set the maximum size of the instruction queue (1-1024)<br>
+			[page:Number maxWebWorkers] — Set the maximum amount of workers (1-16)
+		</div>
+		<div>
+			Create or destroy workers according limits. Set the name and register callbacks for dynamically created web workers.
+		</div>
+
+
+		<h3>[method:null enqueueForRun]( [page:Object runParams] )</h3>
+		<div>
+			[page:Object runParams] — Either [page:WWOBJLoader2.PrepDataArrayBuffer] or [page:WWOBJLoader2.PrepDataFile]
+		</div>
+		<div>
+			Store run instructions in internal instructionQueue.
+		</div>
+
+
+		<h3>[method:null processQueue]()</h3>
+		<div>
+			Process the instructionQueue until it is depleted.
+		</div>
+
+
+		<h3>[method:null deregister]()</h3>
+		<div>
+			Terminate all workers
+		</div>
+
+
+		<h3>[method:null getMaxQueueSize]()</h3>
+		<div>
+			Returns the maximum length of the instruction queue.
+		</div>
+
+
+		<h3>[method:null getMaxWebWorkers]()</h3>
+		<div>
+			Returns the maximum number of workers.
+		</div>
+
+
+		<h3>[method:null setCrossOrigin]( [page:String crossOrigin] )</h3>
+		<div>
+			[page:String crossOrigin] — CORS value
+		</div>
+		<div>
+			Sets the CORS string to be used.
+		</div>
+
+
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/OBJLoader2.js examples/js/loaders/OBJLoader2.js]
+
+	</body>
+</html>

--- a/docs/list.js
+++ b/docs/list.js
@@ -349,6 +349,8 @@ var list = {
 			"GLTF2Loader": "examples/loaders/GLTF2Loader",
 			"MTLLoader": "examples/loaders/MTLLoader",
 			"OBJLoader": "examples/loaders/OBJLoader",
+			"OBJLoader2": "examples/loaders/OBJLoader2",
+			"WWOBJLoader2": "examples/loaders/WWOBJLoader2",
 			"PCDLoader": "examples/loaders/PCDLoader",
 			"PDBLoader": "examples/loaders/PDBLoader",
 			"SVGLoader": "examples/loaders/SVGLoader",

--- a/examples/js/loaders/OBJLoader2.js
+++ b/examples/js/loaders/OBJLoader2.js
@@ -6,18 +6,18 @@
 'use strict';
 
 if ( THREE.OBJLoader2 === undefined ) { THREE.OBJLoader2 = {} }
-THREE.OBJLoader2.version = '1.1.0';
+THREE.OBJLoader2.version = '1.2.1';
 
 /**
  * Use this class to load OBJ data from files or to parse OBJ data from arraybuffer or text
  * @class
  *
- * @param {THREE.DefaultLoadingManager} [manager] Extension of {@link THREE.DefaultLoadingManager}
+ * @param {THREE.DefaultLoadingManager} [manager] The loadingManager for the loader to use. Default is {@link THREE.DefaultLoadingManager}
  */
 THREE.OBJLoader2 = (function () {
 
 	function OBJLoader2( manager ) {
-		this.manager = ( manager == null ) ? THREE.DefaultLoadingManager : manager;
+		this.manager = ! Boolean( manager ) ? THREE.DefaultLoadingManager : manager;
 
 		this.path = '';
 		this.fileLoader = new THREE.FileLoader( this.manager );
@@ -29,17 +29,17 @@ THREE.OBJLoader2 = (function () {
 	}
 
 	/**
-	 * Base path to use
+	 * Base path to use.
 	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {string} path The basepath
 	 */
 	OBJLoader2.prototype.setPath = function ( path ) {
-		this.path = ( path == null ) ? this.path : path;
+		this.path = Boolean( path ) ? path : this.path;
 	};
 
 	/**
-	 * Set the node where the loaded objects will be attached
+	 * Set the node where the loaded objects will be attached.
 	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {THREE.Object3D} sceneGraphBaseNode Scenegraph object where meshes will be attached
@@ -49,21 +49,21 @@ THREE.OBJLoader2 = (function () {
 	};
 
 	/**
-	 * Set materials loaded by MTLLoader
+	 * Set materials loaded by MTLLoader or any other supplier of an Array of {@link THREE.Material}.
 	 * @memberOf THREE.OBJLoader2
 	 *
-	 * @param {THREE.MTLLoader.MaterialCreator.materials[]} materials {@link THREE.MTLLoader.MaterialCreator.materials}
+	 * @param {THREE.Material[]} materials  Array of {@link THREE.Material} from MTLLoader
 	 */
 	OBJLoader2.prototype.setMaterials = function ( materials ) {
 		this.meshCreator.setMaterials( materials );
 	};
 
 	/**
-	 * Allows to set debug mode for the parser and the meshCreator
+	 * Allows to set debug mode for the parser and the meshCreator.
 	 * @memberOf THREE.OBJLoader2
 	 *
-	 * @param {boolean} parserDebug {@link Parser} will produce debug output
-	 * @param {boolean} meshCreatorDebug {@link THREE.OBJLoader2.MeshCreator} will produce debug output
+	 * @param {boolean} parserDebug Internal Parser will produce debug output
+	 * @param {boolean} meshCreatorDebug Internal MeshCreator will produce debug output
 	 */
 	OBJLoader2.prototype.setDebug = function ( parserDebug, meshCreatorDebug ) {
 		this.parser.setDebug( parserDebug );
@@ -76,20 +76,20 @@ THREE.OBJLoader2 = (function () {
 	 *
 	 * @param {string} url URL of the file to load
 	 * @param {callback} onLoad Called after loading was successfully completed
-	 * @param {callback} onProgress Called to report progress of loading
+	 * @param {callback} onProgress Called to report progress of loading. The argument will be the XmlHttpRequest instance, that contain {integer total} and {integer loaded} bytes.
 	 * @param {callback} onError Called after an error occurred during loading
 	 * @param {boolean} [useArrayBuffer=true] Set this to false to force string based parsing
 	 */
 	OBJLoader2.prototype.load = function ( url, onLoad, onProgress, onError, useArrayBuffer ) {
 		this._validate();
 		this.fileLoader.setPath( this.path );
-		this.fileLoader.setResponseType( ( useArrayBuffer || useArrayBuffer == null ) ? 'arraybuffer' : 'text' );
+		this.fileLoader.setResponseType( ( useArrayBuffer || useArrayBuffer === null || useArrayBuffer === undefined ) ? 'arraybuffer' : 'text' );
 
 		var scope = this;
 		scope.fileLoader.load( url, function ( content ) {
 
 			// only use parseText if useArrayBuffer is explicitly set to false
-			onLoad( ( useArrayBuffer || useArrayBuffer == null ) ? scope.parse( content ) : scope.parseText( content ) );
+			onLoad( ( useArrayBuffer || useArrayBuffer === null || useArrayBuffer === undefined ) ? scope.parse( content ) : scope.parseText( content ) );
 
 		}, onProgress, onError );
 	};
@@ -147,8 +147,7 @@ THREE.OBJLoader2 = (function () {
 	OBJLoader2.prototype._validate = function () {
 		if ( this.validated ) return;
 
-		this.fileLoader = ( this.fileLoader == null ) ? new THREE.FileLoader( this.manager ) : this.fileLoader;
-		this.setPath();
+		this.fileLoader = Boolean( this.fileLoader ) ? this.fileLoader : new THREE.FileLoader( this.manager );
 		this.parser.validate();
 		this.meshCreator.validate();
 
@@ -221,7 +220,7 @@ THREE.OBJLoader2 = (function () {
 		}
 
 		Parser.prototype.setDebug = function ( debug ) {
-			this.debug = ( debug == null ) ? this.debug : debug;
+			this.debug = Boolean( debug ) ? debug : this.debug;
 		};
 
 		Parser.prototype.validate = function () {
@@ -487,9 +486,9 @@ THREE.OBJLoader2 = (function () {
 			this.uvs = [];
 
 			// faces are stored according combined index of group, material and smoothingGroup (0 or not)
-			this.mtllibName = ( mtllibName != null ) ? mtllibName : 'none';
-			this.objectName = ( objectName != null ) ? objectName : 'none';
-			this.groupName = ( groupName != null ) ? groupName : 'none';
+			this.mtllibName = Boolean( mtllibName ) ? mtllibName : 'none';
+			this.objectName = Boolean( objectName ) ? objectName : 'none';
+			this.groupName = Boolean( groupName ) ? groupName : 'none';
 			this.activeMtlName = 'none';
 			this.activeSmoothingGroup = 1;
 
@@ -563,7 +562,7 @@ THREE.OBJLoader2 = (function () {
 		};
 
 		RawObject.prototype.pushUsemtl = function ( mtlName ) {
-			if ( this.activeMtlName === mtlName || mtlName == null ) return;
+			if ( this.activeMtlName === mtlName || mtlName === null || mtlName === undefined ) return;
 			this.activeMtlName = mtlName;
 			this.mtlCount++;
 
@@ -581,16 +580,11 @@ THREE.OBJLoader2 = (function () {
 
 		RawObject.prototype.verifyIndex = function () {
 			var index = this.buildIndex( this.activeMtlName, ( this.activeSmoothingGroup === 0 ) ? 0 : 1 );
-			if ( this.rawObjectDescriptions[ index ] == null ) {
+			this.rawObjectDescriptionInUse = this.rawObjectDescriptions[ index ];
+			if ( ! Boolean( this.rawObjectDescriptionInUse ) ) {
 
-				this.rawObjectDescriptionInUse = this.rawObjectDescriptions[ index ] =
-					new RawObjectDescription(
-						this.objectName, this.groupName, this.activeMtlName, this.activeSmoothingGroup
-					);
-
-			} else {
-
-				this.rawObjectDescriptionInUse = this.rawObjectDescriptions[ index ];
+				this.rawObjectDescriptionInUse = new RawObjectDescription( this.objectName, this.groupName, this.activeMtlName, this.activeSmoothingGroup );
+				this.rawObjectDescriptions[ index ] = this.rawObjectDescriptionInUse;
 
 			}
 		};
@@ -815,15 +809,15 @@ THREE.OBJLoader2 = (function () {
 		}
 
 		MeshCreator.prototype.setSceneGraphBaseNode = function ( sceneGraphBaseNode ) {
-			this.sceneGraphBaseNode = ( sceneGraphBaseNode == null ) ? ( this.sceneGraphBaseNode == null ? new THREE.Group() : this.sceneGraphBaseNode ) : sceneGraphBaseNode;
+			this.sceneGraphBaseNode = Boolean( sceneGraphBaseNode ) ? sceneGraphBaseNode : ( Boolean( this.sceneGraphBaseNode ) ? this.sceneGraphBaseNode : new THREE.Group() );
 		};
 
 		MeshCreator.prototype.setMaterials = function ( materials ) {
-			this.materials = ( materials == null ) ? ( this.materials == null ? { materials: [] } : this.materials ) : materials;
+			this.materials = Boolean( materials ) ? materials : ( Boolean( this.materials ) ? this.materials : { materials: [] } );
 		};
 
 		MeshCreator.prototype.setDebug = function ( debug ) {
-			this.debug = ( debug == null ) ? this.debug : debug;
+			this.debug = Boolean( debug ) ? debug : this.debug;
 		};
 
 		MeshCreator.prototype.validate = function () {

--- a/examples/js/loaders/WWOBJLoader2.js
+++ b/examples/js/loaders/WWOBJLoader2.js
@@ -6,7 +6,6 @@
 'use strict';
 
 if ( THREE.OBJLoader2 === undefined ) { THREE.OBJLoader2 = {} }
-THREE.OBJLoader2.version = '1.2.1';
 
 /**
  * OBJ data will be loaded by dynamically created web worker.
@@ -16,11 +15,17 @@ THREE.OBJLoader2.version = '1.2.1';
  */
 THREE.OBJLoader2.WWOBJLoader2 = (function () {
 
+	var WWOBJLOADER2_VERSION = '1.2.1';
+
+	var Validator = THREE.OBJLoader2.prototype._getValidator();
+
 	function WWOBJLoader2() {
 		this._init();
 	}
 
 	WWOBJLoader2.prototype._init = function () {
+		console.log( "Using THREE.OBJLoader2.WWOBJLoader2 version: " + WWOBJLOADER2_VERSION );
+		
 		// check worker support first
 		if ( window.Worker === undefined ) throw "This browser does not support web workers!";
 		if ( window.Blob === undefined  ) throw "This browser does not support Blob!";
@@ -86,7 +91,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 	 * @param {callback} callbackProgress Callback function for described functionality
 	 */
 	WWOBJLoader2.prototype.registerCallbackProgress = function ( callbackProgress ) {
-		if ( Boolean( callbackProgress ) ) this.callbacks.progress.push( callbackProgress );
+		if ( Validator.isValid( callbackProgress ) ) this.callbacks.progress.push( callbackProgress );
 	};
 
 	/**
@@ -96,7 +101,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 	 * @param {callback} callbackCompletedLoading Callback function for described functionality
 	 */
 	WWOBJLoader2.prototype.registerCallbackCompletedLoading = function ( callbackCompletedLoading ) {
-		if ( Boolean( callbackCompletedLoading ) ) this.callbacks.completedLoading.push( callbackCompletedLoading );
+		if ( Validator.isValid( callbackCompletedLoading ) ) this.callbacks.completedLoading.push( callbackCompletedLoading );
 	};
 
 	/**
@@ -106,7 +111,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 	 * @param {callback} callbackMaterialsLoaded Callback function for described functionality
 	 */
 	WWOBJLoader2.prototype.registerCallbackMaterialsLoaded = function ( callbackMaterialsLoaded ) {
-		if ( Boolean( callbackMaterialsLoaded ) ) this.callbacks.materialsLoaded.push( callbackMaterialsLoaded );
+		if ( Validator.isValid( callbackMaterialsLoaded ) ) this.callbacks.materialsLoaded.push( callbackMaterialsLoaded );
 	};
 
 	/**
@@ -117,7 +122,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 	 * @param {callback} callbackMeshLoaded Callback function for described functionality
 	 */
 	WWOBJLoader2.prototype.registerCallbackMeshLoaded = function ( callbackMeshLoaded ) {
-		if ( Boolean( callbackMeshLoaded ) ) this.callbacks.meshLoaded.push( callbackMeshLoaded );
+		if ( Validator.isValid( callbackMeshLoaded ) ) this.callbacks.meshLoaded.push( callbackMeshLoaded );
 	};
 
 	/**
@@ -127,7 +132,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 	 * @param {callback} callbackErrorWhileLoading Callback function for described functionality
 	 */
 	WWOBJLoader2.prototype.registerCallbackErrorWhileLoading = function ( callbackErrorWhileLoading ) {
-		if ( Boolean( callbackErrorWhileLoading ) ) this.callbacks.errorWhileLoading.push( callbackErrorWhileLoading );
+		if ( Validator.isValid( callbackErrorWhileLoading ) ) this.callbacks.errorWhileLoading.push( callbackErrorWhileLoading );
 	};
 
 	/**
@@ -151,12 +156,12 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 	 * @param {boolean} requestTerminate True or false
 	 */
 	WWOBJLoader2.prototype.setRequestTerminate = function ( requestTerminate ) {
-		this.requestTerminate = Boolean( requestTerminate );
+		this.requestTerminate = requestTerminate === true;
 	};
 
 	WWOBJLoader2.prototype._validate = function () {
 		if ( this.validated ) return;
-		if ( ! Boolean( this.worker ) ) {
+		if ( ! Validator.isValid( this.worker ) ) {
 
 			this._buildWebWorkerCode();
 			var blob = new Blob( [ this.workerCode ], { type: 'text/plain' } );
@@ -178,9 +183,9 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 		this.running = true;
 		this.requestTerminate = false;
 
-		this.fileLoader = Boolean( this.fileLoader ) ? this.fileLoader : new THREE.FileLoader( this.manager );
-		this.mtlLoader = Boolean( this.mtlLoader ) ? this.mtlLoader : new THREE.MTLLoader();
-		if ( Boolean( this.crossOrigin ) ) this.mtlLoader.setCrossOrigin( this.crossOrigin );
+		this.fileLoader = Validator.verifyInput( this.fileLoader, new THREE.FileLoader( this.manager ) );
+		this.mtlLoader = Validator.verifyInput( this.mtlLoader, new THREE.MTLLoader() );
+		if ( Validator.isValid( this.crossOrigin ) ) this.mtlLoader.setCrossOrigin( this.crossOrigin );
 
 		this.dataAvailable = false;
 		this.fileObj = null;
@@ -258,7 +263,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 		var processLoadedMaterials = function ( materialCreator ) {
 			var materialCreatorMaterials = [];
 			var materialNames = [];
-			if ( Boolean( materialCreator ) ) {
+			if ( Validator.isValid( materialCreator ) ) {
 
 				materialCreator.preload();
 				materialCreatorMaterials = materialCreator.materials;
@@ -285,7 +290,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 
 				callbackMaterialsLoaded = scope.callbacks.materialsLoaded[ index ];
 				materialsFromCallback = callbackMaterialsLoaded( scope.materials );
-				if ( Boolean( materialsFromCallback ) ) scope.materials = materialsFromCallback;
+				if ( Validator.isValid( materialsFromCallback ) ) scope.materials = materialsFromCallback;
 
 			}
 			if ( scope.dataAvailable && scope.objAsArrayBuffer ) {
@@ -344,11 +349,11 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 		this.mtlLoader.setPath( this.pathTexture );
 		if ( this.dataAvailable ) {
 
-			processLoadedMaterials( Boolean( this.mtlAsString ) ? this.mtlLoader.parse( this.mtlAsString ) : null );
+			processLoadedMaterials( Validator.isValid( this.mtlAsString ) ? this.mtlLoader.parse( this.mtlAsString ) : null );
 
 		} else {
 
-			if ( Boolean( this.fileMtl ) ) {
+			if ( Validator.isValid( this.fileMtl ) ) {
 
 				var onError = function ( event ) {
 					output = 'Error occurred while downloading "' + scope.fileMtl + '"';
@@ -379,7 +384,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 
 				var bufferGeometry = new THREE.BufferGeometry();
 				bufferGeometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( payload.vertices ), 3 ) );
-				if ( payload.normals !== null ) {
+				if ( Validator.isValid( payload.normals ) ) {
 
 					bufferGeometry.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( payload.normals ), 3 ) );
 
@@ -388,7 +393,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 					bufferGeometry.computeVertexNormals();
 
 				}
-				if ( payload.uvs !== null ) {
+				if ( Validator.isValid( payload.uvs ) ) {
 
 					bufferGeometry.addAttribute( 'uv', new THREE.BufferAttribute( new Float32Array( payload.uvs ), 2 ) );
 
@@ -454,7 +459,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 					callbackMeshLoaded = this.callbacks.meshLoaded[ index ];
 					callbackMeshLoadedResult = callbackMeshLoaded( meshName, bufferGeometry, material );
 
-					if ( Boolean( callbackMeshLoadedResult ) ) {
+					if ( Validator.isValid( callbackMeshLoadedResult ) ) {
 
 						if ( callbackMeshLoadedResult.disregardMesh ) {
 
@@ -506,7 +511,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 				}
 
 				console.timeEnd( 'WWOBJLoader2' );
-				if ( Boolean( payload.msg ) ) {
+				if ( Validator.isValid( payload.msg ) ) {
 
 					this._announceProgress( payload.msg );
 
@@ -531,7 +536,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 	};
 
 	WWOBJLoader2.prototype._terminate = function () {
-		if ( Boolean( this.worker ) ) {
+		if ( Validator.isValid( this.worker ) ) {
 
 			if ( this.running ) throw 'Unable to gracefully terminate worker as it is currently running!';
 
@@ -579,8 +584,8 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 	};
 
 	WWOBJLoader2.prototype._announceProgress = function ( baseText, text ) {
-		var output = ( Boolean( baseText ) ) ? baseText: "";
-		output = ( Boolean( text ) ) ? output + " " + text : output;
+		var output = Validator.isValid( baseText ) ? baseText: "";
+		output = Validator.isValid( text ) ? output + " " + text : output;
 
 		var callbackProgress;
 		for ( var index in this.callbacks.progress ) {
@@ -594,8 +599,8 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 	};
 
 	WWOBJLoader2.prototype._buildWebWorkerCode = function ( existingWorkerCode ) {
-		if ( Boolean( existingWorkerCode ) ) this.workerCode = existingWorkerCode;
-		if ( ! Boolean( this.workerCode ) ) {
+		if ( Validator.isValid( existingWorkerCode ) ) this.workerCode = existingWorkerCode;
+		if ( ! Validator.isValid( this.workerCode ) ) {
 
 			console.time( 'buildWebWorkerCode' );
 			var wwDef = (function () {
@@ -690,11 +695,12 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 				}
 
 				WWMeshCreator.prototype.setMaterials = function ( materials ) {
-					this.materials = Boolean( materials ) ? materials : ( Boolean( this.materials ) ? this.materials : { materials: [] } );
+					this.materials = Validator.verifyInput( materials, this.materials );
+					this.materials = Validator.verifyInput( this.materials, { materials: [] } );
 				};
 
 				WWMeshCreator.prototype.setDebug = function ( debug ) {
-					this.debug = Boolean( debug ) ? debug : this.debug;
+					if ( debug === true || debug === false ) this.debug = debug;
 				};
 
 				WWMeshCreator.prototype.validate = function () {
@@ -923,8 +929,7 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
 			this.workerCode += '  */\n\n';
 
 			// parser re-construction
-			var objLoaderHelper = new THREE.OBJLoader2();
-			this.workerCode += objLoaderHelper._buildWebWorkerCode( buildObject, buildSingelton );
+			this.workerCode += THREE.OBJLoader2.prototype._buildWebWorkerCode( buildObject, buildSingelton );
 
 			// web worker construction
 			this.workerCode += buildSingelton( 'WWOBJLoader', 'WWOBJLoader', wwDef );
@@ -955,6 +960,9 @@ THREE.OBJLoader2.WWOBJLoader2 = (function () {
  * @constructor
  */
 THREE.OBJLoader2.WWOBJLoader2.PrepDataArrayBuffer = function ( modelName, objAsArrayBuffer, pathTexture, mtlAsString ) {
+
+	var Validator = THREE.OBJLoader2.prototype._getValidator();
+
 	return {
 
 		/**
@@ -964,7 +972,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataArrayBuffer = function ( modelName, objAsA
 		 * @param {THREE.Object3D} sceneGraphBaseNode Scene graph object
 		 */
 		setSceneGraphBaseNode: function ( sceneGraphBaseNode ) {
-			this.sceneGraphBaseNode = Boolean( sceneGraphBaseNode ) ? sceneGraphBaseNode : null;
+			this.sceneGraphBaseNode = Validator.verifyInput( sceneGraphBaseNode, null );
 		},
 
 		/**
@@ -974,7 +982,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataArrayBuffer = function ( modelName, objAsA
 		 * @param {boolean} streamMeshes=true Default is true
 		 */
 		setStreamMeshes: function ( streamMeshes ) {
-			this.streamMeshes = ( streamMeshes === null || streamMeshes === undefined ) ? true : streamMeshes;
+			this.streamMeshes = streamMeshes !== false;
 		},
 
 		/**
@@ -984,7 +992,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataArrayBuffer = function ( modelName, objAsA
 		 * @param {boolean} requestTerminate=false Default is false
 		 */
 		setRequestTerminate: function ( requestTerminate ) {
-			this.requestTerminate = Boolean( requestTerminate );
+			this.requestTerminate = requestTerminate === true;
 		},
 
 		/**
@@ -996,11 +1004,11 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataArrayBuffer = function ( modelName, objAsA
 		getCallbacks: function () {
 			return this.callbacks;
 		},
-		modelName: Boolean( modelName ) ? modelName : 'none',
+		modelName: Validator.verifyInput( modelName, 'none' ),
 		dataAvailable: true,
-		objAsArrayBuffer: Boolean( objAsArrayBuffer ) ? objAsArrayBuffer : null,
-		pathTexture: Boolean( pathTexture ) ? pathTexture : null,
-		mtlAsString: Boolean( mtlAsString ) ? mtlAsString : null,
+		objAsArrayBuffer: Validator.verifyInput( objAsArrayBuffer, null ),
+		pathTexture: Validator.verifyInput( pathTexture, null ),
+		mtlAsString: Validator.verifyInput( mtlAsString, null ),
 		sceneGraphBaseNode: null,
 		streamMeshes: true,
 		requestTerminate: false,
@@ -1021,6 +1029,9 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataArrayBuffer = function ( modelName, objAsA
  * @constructor
  */
 THREE.OBJLoader2.WWOBJLoader2.PrepDataFile = function ( modelName, pathObj, fileObj, pathTexture, fileMtl ) {
+
+	var Validator = THREE.OBJLoader2.prototype._getValidator();
+
 	return {
 
 		/**
@@ -1030,7 +1041,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataFile = function ( modelName, pathObj, file
 		 * @param {THREE.Object3D} sceneGraphBaseNode Scene graph object
 		 */
 		setSceneGraphBaseNode: function ( sceneGraphBaseNode ) {
-			this.sceneGraphBaseNode = Boolean( sceneGraphBaseNode ) ? sceneGraphBaseNode : null;
+			this.sceneGraphBaseNode = Validator.verifyInput( sceneGraphBaseNode, null );
 		},
 
 		/**
@@ -1040,7 +1051,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataFile = function ( modelName, pathObj, file
 		 * @param {boolean} streamMeshes=true Default is true
 		 */
 		setStreamMeshes: function ( streamMeshes ) {
-			this.streamMeshes = ( streamMeshes === null || streamMeshes === undefined ) ? true : streamMeshes;
+			this.streamMeshes = streamMeshes !== false;
 		},
 
 		/**
@@ -1050,7 +1061,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataFile = function ( modelName, pathObj, file
 		 * @param {boolean} requestTerminate=false Default is false
 		 */
 		setRequestTerminate: function ( requestTerminate ) {
-			this.requestTerminate = Boolean( requestTerminate );
+			this.requestTerminate = requestTerminate === true;
 		},
 
 		/**
@@ -1062,12 +1073,12 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataFile = function ( modelName, pathObj, file
 		getCallbacks: function () {
 			return this.callbacks;
 		},
-		modelName: Boolean( modelName ) ? modelName : 'none',
+		modelName: Validator.verifyInput( modelName, 'none' ),
 		dataAvailable: false,
-		pathObj: Boolean( pathObj ) ? pathObj : null,
-		fileObj: Boolean( fileObj ) ? fileObj : null,
-		pathTexture: Boolean( pathTexture ) ? pathTexture : null,
-		fileMtl: Boolean( fileMtl ) ? fileMtl : null,
+		pathObj: Validator.verifyInput( pathObj, null ),
+		fileObj: Validator.verifyInput( fileObj, null ),
+		pathTexture: Validator.verifyInput( pathTexture, null ),
+		fileMtl: Validator.verifyInput( fileMtl, null ),
 		sceneGraphBaseNode: null,
 		streamMeshes: true,
 		requestTerminate: false,
@@ -1082,6 +1093,9 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataFile = function ( modelName, pathObj, file
  * @constructor
  */
 THREE.OBJLoader2.WWOBJLoader2.PrepDataCallbacks = function () {
+
+	var Validator = THREE.OBJLoader2.prototype._getValidator();
+
 	return {
 		/**
 		 * Register callback function that is invoked by internal function "_announceProgress" to print feedback.
@@ -1090,7 +1104,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataCallbacks = function () {
 		 * @param {callback} callbackProgress Callback function for described functionality
 		 */
 		registerCallbackProgress: function ( callbackProgress ) {
-			if ( Boolean( callbackProgress ) ) this.progress = callbackProgress;
+			if ( Validator.isValid( callbackProgress ) ) this.progress = callbackProgress;
 		},
 
 		/**
@@ -1100,7 +1114,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataCallbacks = function () {
 		 * @param {callback} callbackCompletedLoading Callback function for described functionality
 		 */
 		registerCallbackCompletedLoading: function ( callbackCompletedLoading ) {
-			if ( Boolean( callbackCompletedLoading ) ) this.completedLoading = callbackCompletedLoading;
+			if ( Validator.isValid( callbackCompletedLoading ) ) this.completedLoading = callbackCompletedLoading;
 		},
 
 		/**
@@ -1110,7 +1124,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataCallbacks = function () {
 		 * @param {callback} callbackMaterialsLoaded Callback function for described functionality
 		 */
 		registerCallbackMaterialsLoaded: function ( callbackMaterialsLoaded ) {
-			if ( Boolean( callbackMaterialsLoaded ) ) this.materialsLoaded = callbackMaterialsLoaded;
+			if ( Validator.isValid( callbackMaterialsLoaded ) ) this.materialsLoaded = callbackMaterialsLoaded;
 		},
 
 		/**
@@ -1121,7 +1135,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataCallbacks = function () {
 		 * @param {callback} callbackMeshLoaded Callback function for described functionality
 		 */
 		registerCallbackMeshLoaded: function ( callbackMeshLoaded ) {
-			if ( Boolean( callbackMeshLoaded ) ) this.meshLoaded = callbackMeshLoaded;
+			if ( Validator.isValid( callbackMeshLoaded ) ) this.meshLoaded = callbackMeshLoaded;
 		},
 
 		/**
@@ -1131,7 +1145,7 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataCallbacks = function () {
 		 * @param {callback} callbackErrorWhileLoading Callback function for described functionality
 		 */
 		registerCallbackErrorWhileLoading: function ( callbackErrorWhileLoading ) {
-			if ( Boolean( callbackErrorWhileLoading ) ) this.errorWhileLoading = callbackErrorWhileLoading;
+			if ( Validator.isValid( callbackErrorWhileLoading ) ) this.errorWhileLoading = callbackErrorWhileLoading;
 		},
 
 		progress: null,
@@ -1154,12 +1168,15 @@ THREE.OBJLoader2.WWOBJLoader2.PrepDataCallbacks = function () {
  * @constructor
  */
 THREE.OBJLoader2.WWOBJLoader2.LoadedMeshUserOverride = function ( disregardMesh, bufferGeometry, material ) {
+
+	var Validator = THREE.OBJLoader2.prototype._getValidator();
+
 	return {
-		disregardMesh: Boolean( disregardMesh ),
-		replaceBufferGeometry: Boolean( bufferGeometry ),
-		bufferGeometry: Boolean( bufferGeometry ) ? bufferGeometry : null,
-		replaceMaterial: Boolean( material ),
-		material: Boolean( material ) ? material : null
+		disregardMesh: disregardMesh === true,
+		replaceBufferGeometry: Validator.isValid( bufferGeometry ),
+		bufferGeometry: Validator.verifyInput( bufferGeometry, null ),
+		replaceMaterial: Validator.isValid( material ),
+		material: Validator.verifyInput( material, null )
 	};
 };
 
@@ -1174,6 +1191,8 @@ THREE.OBJLoader2.WWOBJLoader2.LoadedMeshUserOverride = function ( disregardMesh,
  * @class
  */
 THREE.OBJLoader2.WWOBJLoader2Director = (function () {
+
+	var Validator = THREE.OBJLoader2.prototype._getValidator();
 
 	var MAX_WEB_WORKER = 16;
 	var MAX_QUEUE_SIZE = 1024;
@@ -1232,7 +1251,7 @@ THREE.OBJLoader2.WWOBJLoader2Director = (function () {
 	 * @param {number} maxWebWorkers Set the maximum amount of workers (1-16)
 	 */
 	WWOBJLoader2Director.prototype.prepareWorkers = function ( globalCallbacks, maxQueueSize, maxWebWorkers ) {
-		if ( Boolean( globalCallbacks ) ) this.workerDescription.globalCallbacks = globalCallbacks;
+		if ( Validator.isValid( globalCallbacks ) ) this.workerDescription.globalCallbacks = globalCallbacks;
 		this.maxQueueSize = Math.min( maxQueueSize, MAX_QUEUE_SIZE );
 		this.maxWebWorkers = Math.min( maxWebWorkers, MAX_WEB_WORKER );
 		this.objectsCompleted = 0;
@@ -1301,18 +1320,18 @@ THREE.OBJLoader2.WWOBJLoader2Director = (function () {
 			if ( workerCallbacks.hasOwnProperty( key ) && globalCallbacks.hasOwnProperty( key ) ) {
 
 				selectedGlobalCallback = globalCallbacks[ key ];
-				if ( Boolean( selectedGlobalCallback ) ) workerCallbacks[ key ].push( selectedGlobalCallback );
+				if ( Validator.isValid( selectedGlobalCallback ) ) workerCallbacks[ key ].push( selectedGlobalCallback );
 
 			}
 
 		}
 		// register per object callbacks
 		var runCallbacks = runParams.callbacks;
-		if ( Boolean( runCallbacks ) ) {
+		if ( Validator.isValid( runCallbacks ) ) {
 
 			for ( key in runCallbacks ) {
 
-				if ( workerCallbacks.hasOwnProperty( key ) && runCallbacks.hasOwnProperty( key ) && Boolean( runCallbacks[ key ] ) ) {
+				if ( workerCallbacks.hasOwnProperty( key ) && runCallbacks.hasOwnProperty( key ) && Validator.isValid( runCallbacks[ key ] ) ) {
 
 					workerCallbacks[ key ].push( runCallbacks[ key ] );
 
@@ -1329,7 +1348,7 @@ THREE.OBJLoader2.WWOBJLoader2Director = (function () {
 
 				var worker = scope.workerDescription.webWorkers[ instanceNo ];
 				var runParams = scope.instructionQueue[ 0 ];
-				if ( Boolean( runParams ) ) {
+				if ( Validator.isValid( runParams ) ) {
 
 					console.log( '\nAssigning next item from queue to worker (queue length: ' + scope.instructionQueue.length + ')\n\n' );
 					scope._kickWebWorkerRun( worker, runParams );
@@ -1348,10 +1367,10 @@ THREE.OBJLoader2.WWOBJLoader2Director = (function () {
 	WWOBJLoader2Director.prototype._buildWebWorker = function () {
 		var webWorker = Object.create( this.workerDescription.prototypeDef );
 		webWorker._init();
-		if ( Boolean( this.crossOrigin ) ) webWorker.setCrossOrigin( this.crossOrigin );
+		if ( Validator.isValid( this.crossOrigin ) ) webWorker.setCrossOrigin( this.crossOrigin );
 
 		// Ensure code string is built once and then it is just passed on to every new instance
-		if ( Boolean( this.workerDescription.codeBuffer ) ) {
+		if ( Validator.isValid( this.workerDescription.codeBuffer ) ) {
 
 			webWorker._buildWebWorkerCode( this.workerDescription.codeBuffer );
 

--- a/examples/webgl_loader_obj2.html
+++ b/examples/webgl_loader_obj2.html
@@ -264,9 +264,10 @@
 
 					if ( object3d.material instanceof THREE.MultiMaterial ) {
 
-						for ( var matName in object3d.material.materials ) {
+						var materials = object3d.material.materials;
+						for ( var name in materials ) {
 
-							this.traversalFunction( object3d.material.materials[ matName ] );
+							if ( materials.hasOwnProperty( name ) )	this.traversalFunction( materials[ name ] );
 
 						}
 

--- a/examples/webgl_loader_obj2_ww.html
+++ b/examples/webgl_loader_obj2_ww.html
@@ -181,12 +181,11 @@
 						console.log( 'Progress: ' + content );
 					};
 					var materialsLoaded = function ( materials ) {
-						var count = 0;
-						console.log( 'The following materials have been loaded:' );
-						for ( var mat in materials ) {
-							count++;
-						}
+						var count = Boolean( materials ) ? materials.length : 0;
 						console.log( 'Loaded #' + count + ' materials.' );
+					};
+					var meshLoaded = function ( name, bufferGeometry, material ) {
+						console.log( 'Loaded mesh: ' + name + ' Material name: ' + material.name );
 					};
 					var completedLoading = function () {
 						console.log( 'Loading complete!' );
@@ -194,13 +193,14 @@
 					this.wwObjLoader2.registerCallbackProgress( reportProgress );
 					this.wwObjLoader2.registerCallbackCompletedLoading( completedLoading );
 					this.wwObjLoader2.registerCallbackMaterialsLoaded( materialsLoaded );
+					this.wwObjLoader2.registerCallbackMeshLoaded( meshLoaded );
 
 					return true;
 				};
 
 				WWOBJLoader2Example.prototype.loadFiles = function ( prepData ) {
-					prepData.sceneGraphBaseNode = this.pivot;
-					prepData.streamMeshes = this.streamMeshes;
+					prepData.setSceneGraphBaseNode( this.pivot );
+					prepData.setStreamMeshes( this.streamMeshes );
 					this.wwObjLoader2.prepareRun( prepData );
 					this.wwObjLoader2.run();
 				};
@@ -222,7 +222,7 @@
 
 					}
 
-					if ( fileObj == null ) {
+					if ( ! Boolean( fileObj ) ) {
 						alert( 'Unable to load OBJ file from given files.' );
 					}
 
@@ -261,8 +261,10 @@
 
 				WWOBJLoader2Example.prototype.loadFilesUser = function ( objDef ) {
 					var prepData = new THREE.OBJLoader2.WWOBJLoader2.PrepDataArrayBuffer(
-						objDef.name, objDef.objAsArrayBuffer, objDef.pathTexture, objDef.mtlAsString, this.pivot, this.streamMeshes
+						objDef.name, objDef.objAsArrayBuffer, objDef.pathTexture, objDef.mtlAsString
 					);
+					prepData.setSceneGraphBaseNode( this.pivot );
+					prepData.setStreamMeshes( this.streamMeshes );
 					this.wwObjLoader2.prepareRun( prepData );
 					this.wwObjLoader2.run();
 				};
@@ -340,9 +342,10 @@
 
 					if ( object3d.material instanceof THREE.MultiMaterial ) {
 
-						for ( var matName in object3d.material.materials ) {
+						var materials = object3d.material.materials;
+						for ( var name in materials ) {
 
-							this.traversalFunction( object3d.material.materials[ matName ] );
+							if ( materials.hasOwnProperty( name ) )	this.traversalFunction( materials[ name ] );
 
 						}
 
@@ -372,8 +375,11 @@
 							var mat = object3d.material;
 							if ( mat.hasOwnProperty( 'materials' ) ) {
 
-								for ( var mmat in mat.materials ) {
-									mat.materials[ mmat ].dispose();
+								var materials = mat.materials;
+								for ( var name in materials ) {
+
+									if ( materials.hasOwnProperty( name ) ) materials[ name ].dispose();
+
 								}
 							}
 						}

--- a/examples/webgl_loader_obj2_ww.html
+++ b/examples/webgl_loader_obj2_ww.html
@@ -90,6 +90,8 @@
 
 			var WWOBJLoader2Example = (function () {
 
+				var Validator = THREE.OBJLoader2.prototype._getValidator();
+
 				function WWOBJLoader2Example( elementToBindTo ) {
 					this.renderer = null;
 					this.canvas = elementToBindTo;
@@ -181,7 +183,7 @@
 						console.log( 'Progress: ' + content );
 					};
 					var materialsLoaded = function ( materials ) {
-						var count = Boolean( materials ) ? materials.length : 0;
+						var count = Validator.isValid( materials ) ? materials.length : 0;
 						console.log( 'Loaded #' + count + ' materials.' );
 					};
 					var meshLoaded = function ( name, bufferGeometry, material ) {
@@ -222,7 +224,7 @@
 
 					}
 
-					if ( ! Boolean( fileObj ) ) {
+					if ( ! Validator.isValid( fileObj ) ) {
 						alert( 'Unable to load OBJ file from given files.' );
 					}
 

--- a/examples/webgl_loader_obj2_ww_parallels.html
+++ b/examples/webgl_loader_obj2_ww_parallels.html
@@ -92,6 +92,8 @@
 
 			var WWParallels = (function () {
 
+				var Validator = THREE.OBJLoader2.prototype._getValidator();
+
 				function WWParallels( elementToBindTo ) {
 					this.renderer = null;
 					this.canvas = elementToBindTo;
@@ -117,6 +119,8 @@
 
 					this.allAssets = [];
 					this.feedbackArray = null;
+
+					this.running = false;
 				}
 
 				WWParallels.prototype.initGL = function () {
@@ -192,6 +196,15 @@
 				};
 
 				WWParallels.prototype.enqueueAllAssests = function ( maxQueueSize, maxWebWorkers, streamMeshes ) {
+					if ( this.running ) {
+
+						return;
+
+					} else {
+
+						this.running = true;
+
+					}
 					var scope = this;
 					scope.wwDirector.objectsCompleted = 0;
 					scope.feedbackArray = new Array( maxWebWorkers );
@@ -209,12 +222,14 @@
 						console.log( msg );
 						scope.feedbackArray[ instanceNo ] = msg;
 						scope.reportProgress( scope.feedbackArray.join( '\<br\>' ) );
+
+						if ( scope.wwDirector.objectsCompleted + 1 === maxQueueSize ) scope.running = false;
 					};
 
 					var callbackMeshLoaded = function ( name, bufferGeometry, material ) {
 						var materialOverride;
 
-						if ( Boolean( material ) && material.name === 'defaultMaterial' || name === 'Mesh_Mesh_head_geo.001' ) {
+						if ( Validator.isValid( material ) && material.name === 'defaultMaterial' || name === 'Mesh_Mesh_head_geo.001' ) {
 
 							materialOverride = material;
 							materialOverride.color = new THREE.Color( Math.random(), Math.random(), Math.random() );
@@ -294,7 +309,7 @@
 							distributionBase + distributionMax * Math.random(),
 							distributionBase + distributionMax * Math.random()
 						);
-						if ( Boolean( model.scale ) ) pivot.scale.set( model.scale, model.scale, model.scale );
+						if ( Validator.isValid( model.scale ) ) pivot.scale.set( model.scale, model.scale, model.scale );
 
 						this.scene.add( pivot );
 

--- a/examples/webgl_loader_obj2_ww_parallels.html
+++ b/examples/webgl_loader_obj2_ww_parallels.html
@@ -58,9 +58,9 @@
 			#dat {
 				user-select: none;
 				position: absolute;
-				left: 0px;
-				top: 0px;
-				z-Index: 2;
+				left: 0;
+				top: 0;
+				z-Index: 200;
 			}
 		</style>
 	</head>
@@ -195,8 +195,12 @@
 					var scope = this;
 					scope.wwDirector.objectsCompleted = 0;
 					scope.feedbackArray = new Array( maxWebWorkers );
-					for ( var i = 0; i < maxWebWorkers; i++ ) {
+
+					var i;
+					for ( i = 0; i < maxWebWorkers; i++ ) {
+
 						scope.feedbackArray[ i ] = 'Worker #' + i + ': Awaiting feedback';
+
 					}
 					scope.reportProgress( scope.feedbackArray.join( '\<br\>' ) );
 
@@ -206,26 +210,29 @@
 						scope.feedbackArray[ instanceNo ] = msg;
 						scope.reportProgress( scope.feedbackArray.join( '\<br\>' ) );
 					};
-					var callbackMeshLoaded = function ( meshName, material ) {
-						var replacedMaterial = null;
 
-						if ( material != null && material.name === 'defaultMaterial' || meshName === 'Mesh_Mesh_head_geo.001' ) {
-							replacedMaterial = material;
-							replacedMaterial.color = new THREE.Color( Math.random(), Math.random(), Math.random() );
+					var callbackMeshLoaded = function ( name, bufferGeometry, material ) {
+						var materialOverride;
+
+						if ( Boolean( material ) && material.name === 'defaultMaterial' || name === 'Mesh_Mesh_head_geo.001' ) {
+
+							materialOverride = material;
+							materialOverride.color = new THREE.Color( Math.random(), Math.random(), Math.random() );
+
 						}
 
-						return replacedMaterial;
+						return new THREE.OBJLoader2.WWOBJLoader2.LoadedMeshUserOverride( false, undefined, materialOverride );
 					};
 
-					this.wwDirector.prepareWorkers(
-						{
-							completedLoading: callbackCompletedLoading,
-							meshLoaded: callbackMeshLoaded
-						},
-						maxQueueSize,
-						maxWebWorkers
-					);
+					var globalCallbacks = new THREE.OBJLoader2.WWOBJLoader2.PrepDataCallbacks();
+					globalCallbacks.registerCallbackCompletedLoading( callbackCompletedLoading );
+					globalCallbacks.registerCallbackMeshLoaded( callbackMeshLoaded );
+					this.wwDirector.prepareWorkers( globalCallbacks, maxQueueSize, maxWebWorkers );
 					console.log( 'Configuring WWManager with queue size ' + this.wwDirector.getMaxQueueSize() + ' and ' + this.wwDirector.getMaxWebWorkers() + ' workers.' );
+
+					var callbackCompletedLoadingWalt = function () {
+						console.log( 'Callback check: WALT was loaded (#' + scope.wwDirector.objectsCompleted + ')' );
+					};
 
 					var models = [];
 					models.push( {
@@ -262,7 +269,7 @@
 						scale: 50.0
 					} );
 					models.push( {
-						modelName:'WaltHead',
+						modelName: 'WaltHead',
 						dataAvailable: false,
 						pathObj: 'obj/walt/',
 						fileObj: 'WaltHead.obj',
@@ -276,9 +283,9 @@
 					var modelIndex = 0;
 					var model;
 					var runParams;
-					for ( var i = 0; i < maxQueueSize; i++ ) {
+					for ( i = 0; i < maxQueueSize; i++ ) {
 
-						modelIndex = Math.floor( Math.random() * 5 );
+						modelIndex = Math.floor( Math.random() * models.length );
 						model = models[ modelIndex ];
 
 						pivot = new THREE.Object3D();
@@ -287,15 +294,21 @@
 							distributionBase + distributionMax * Math.random(),
 							distributionBase + distributionMax * Math.random()
 						);
-						if ( model.scale != null ) pivot.scale.set( model.scale, model.scale, model.scale );
+						if ( Boolean( model.scale ) ) pivot.scale.set( model.scale, model.scale, model.scale );
 
 						this.scene.add( pivot );
 
 						model.sceneGraphBaseNode = pivot;
 
 						runParams = new THREE.OBJLoader2.WWOBJLoader2.PrepDataFile(
-							model.modelName, model.pathObj, model.fileObj, model.pathTexture, model.fileMtl, model.sceneGraphBaseNode, streamMeshes
+							model.modelName, model.pathObj, model.fileObj, model.pathTexture, model.fileMtl
 						);
+						runParams.setSceneGraphBaseNode( model.sceneGraphBaseNode );
+						runParams.setStreamMeshes( streamMeshes );
+						if ( model.modelName === 'WaltHead' ) {
+							runParams.getCallbacks().registerCallbackCompletedLoading( callbackCompletedLoadingWalt );
+						}
+
 						this.wwDirector.enqueueForRun( runParams );
 						this.allAssets.push( runParams );
 					}
@@ -308,32 +321,29 @@
 					var scope = this;
 
 					for ( var asset in this.allAssets ) {
-						ref = this.allAssets[asset];
+						ref = this.allAssets[ asset ];
 
 						var remover = function ( object3d ) {
 
-							if ( object3d === ref.sceneGraphBaseNode ) {
-								return;
-							}
+							if ( object3d === ref.sceneGraphBaseNode ) return;
 							console.log( 'Removing ' + object3d.name );
 							scope.scene.remove( object3d );
 
-							if ( object3d.hasOwnProperty( 'geometry' ) ) {
-								object3d.geometry.dispose();
-							}
+							if ( object3d.hasOwnProperty( 'geometry' ) ) object3d.geometry.dispose();
 							if ( object3d.hasOwnProperty( 'material' ) ) {
 
 								var mat = object3d.material;
 								if ( mat.hasOwnProperty( 'materials' ) ) {
 
-									for ( var mmat in mat.materials ) {
-										mat.materials[mmat].dispose();
+									var materials = mat.materials;
+									for ( var name in materials ) {
+
+										if ( materials.hasOwnProperty( name ) ) materials[ name ].dispose();
+
 									}
 								}
 							}
-							if ( object3d.hasOwnProperty( 'texture' ) ) {
-								object3d.texture.dispose();
-							}
+							if ( object3d.hasOwnProperty( 'texture' ) ) object3d.texture.dispose();
 						};
 						scope.scene.remove( ref.sceneGraphBaseNode );
 						ref.sceneGraphBaseNode.traverse( remover );


### PR DESCRIPTION
Hello @mrdoob, I finally managed to add the missing documentation for `OBJLoader2` and `WWOBJLoader2`. That is the first commit: 8e29b6f55def41e956a986844c413e46a35554be

Then, there are improvements to the code based on community enhancement request (including me) from repo [WWOBJLoader](https://github.com/kaisalmen/WWOBJLoader): 4ebf28ba8807c81568630dde05251b446d03c63c
It seems to be more then it really is (changelog is below). Don't know when release 85 is due, but it'll be nice if this could make it as well. Just released [wwobjloader2 npm compatible with R84](https://www.npmjs.com/package/wwobjloader2). Docs on current code are separated, so you can merge it independently if you have any objections. Thanks! :smile:

See the changelog:
Updated code to version V1.2.1 and updated docs accordingly.
#### Code related changes
##### THREE.OBJLoader2.WWOBJLoader2
- Function `_receiveWorkerMessage` now uses a meshDescription that allows to override material or bufferGeometry or to completely disregard the mesh. `THREE.OBJLoader2.WWOBJLoader2.LoadedMeshUserOverride` was introduced for this.
- Allow usage of multiple callbacks per callback type
- `THREE.OBJLoader2.WWOBJLoader2.PrepDataArrayBuffer` and `THREE.OBJLoader2.WWOBJLoader2.PrepDataFile` require less mandatory parameters. Setters are introduced to handle optional things

##### THREE.OBJLoader2.WWOBJLoader2Director
- Added per queue object callbacks
- Global callbacks in `prepareWorkers` will be specified with new object `OBJLoader2.WWOBJLoader2.PrepDataCallbacks`. This object is also used in both PrepData objects for defining extra per model callbacks in addition to the global ones  
- Callbacks will be reset and reassigned for every run

##### All
- Improve code quality and logging: Replaced != or == with Boolean() or ! Boolean() where applicable
- Improve logging and comments
