### PR TITLE
Matrix4 .multiplyToArray: Clean up

### DIFF
--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -363,14 +363,6 @@ x, y, 1, 0,
 		<h3>[method:Matrix4 multiplyScalar]( [page:Float s] )</h3>
 		<div>Multiplies every component of the matrix by a scalar value [page:Float s].</div>
 
-		<h3>[method:Matrix4 multiplyToArray]( [page:Matrix4 a], [page:Matrix4 b], [page:Array r] )</h3>
-		<div>
-		Sets this matrix to [page:Matrix4 a] x [page:Matrix4 b] and stores the result into the flat array [page:Array r],
-		in [link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] order.
-
-		[page:Array r] can be either a regular Array or a [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays TypedArray].
-		</div>
-
 		<h3>[method:Matrix4 premultiply]( [page:Matrix4 m] )</h3>
 		<div>Pre-multiplies this matrix by [page:Matrix4 m].</div>
 

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -3831,10 +3831,6 @@
           "!type": "fn(a: +THREE.Matrix4, b: +THREE.Matrix4) -> +THREE.Matrix4",
           "!doc": "Sets this matrix to *a x b*."
         },
-        "multiplyToArray": {
-          "!type": "fn(a: +THREE.Matrix4, b: +THREE.Matrix4, r: []) -> +THREE.Matrix4",
-          "!doc": "Sets this matrix to *a x b* and stores the result into the flat array *r*.<br>\n\t\t*r* can be either a regular Array or a TypedArray."
-        },
         "multiplyScalar": {
           "!type": "fn(s: number) -> +THREE.Matrix4",
           "!doc": "Multiplies this matrix by *s*."


### PR DESCRIPTION
Cleans up some remaining references to `. multiplyToArray()`.