### PR TITLE
Allow Box3 as input for BoxHelper (reimplemtation of pull #8609)

### DIFF
--- a/src/helpers/BoxHelper.js
+++ b/src/helpers/BoxHelper.js
@@ -45,7 +45,11 @@ BoxHelper.prototype.update = ( function () {
 
 		}
 
-		if ( this.object !== undefined ) {
+		if ( this.object instanceof Box3 ) {
+
+			box.copy( this.object );
+
+		} else if ( this.object !== undefined ) {
 
 			box.setFromObject( this.object );
 


### PR DESCRIPTION
Hi,

In this [PR](https://github.com/mrdoob/three.js/pull/8609) the option was added to `BoxHelper` to accept a `Box3` instance. Due to some refactoring it is removed in this commit: https://github.com/mrdoob/three.js/commit/745e567fd3166151c1e8f878462b15746c2dc6bf .

My usecase is that I want to resize the Box3. I want the BoxHelper to update to the Box3 size accordingly.