### PR TITLE
Docs: Fix navigation panel responsivity

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -167,12 +167,23 @@ iframe {
 		position: absolute;
 		left: 0;
 		top: 0;
-		height: 480px;
+		height: 100%;
 		width: 100%;
 		right: 0;
 		z-index: 100;
 		overflow: hidden;
 		border-bottom: 1px solid #dedede;
+	}
+
+	#content{
+		position: absolute;
+		left: 0;
+		top: 90px;
+		right: 0;
+		bottom: 0;
+		font-size: 17px;
+		line-height: 22px;
+		overflow: auto;
 	}
 
 	#navigation{

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,7 @@
 				<input type="text" id="filterInput" placeholder="Type to filter">
 				<a href="#" id="clearFilterButton">x</a>
 			</div>
+			<div id="content"></div>
 
 		</div>
 
@@ -32,6 +33,7 @@
 		<script>
 
 			var panel = document.getElementById( 'panel' );
+			var content = document.getElementById( 'content' );
 			var clearFilterButton = document.getElementById( 'clearFilterButton' );
 			var expandButton = document.getElementById( 'expandButton' );
 			var filterInput = document.getElementById( 'filterInput' );
@@ -98,7 +100,7 @@
 
 				// Create the navigation panel using data from list.js
 
-				var navigation = createAndAppendDOMElement( { type: 'div', parent: panel } );
+				var navigation = createAndAppendDOMElement( { type: 'div', parent: content } );
 
 				for ( var section in list ) {
 


### PR DESCRIPTION
Fix for https://github.com/mrdoob/three.js/issues/11204#issuecomment-296129452

Fortunately I had only to revitalize the former empty `div id="content"` for this purpose.

Now I noticed, that in the [r84 version of the docs](https://rawgit.com/mrdoob/three.js/f8c7f708c04c6c6ea35c2cf88f9e5cd7da070ed3/docs/index.html) the navigation panel had a fixed height of 480px, so that - dependent on the screen height - either a white space remained at the bottom (fig. 1) or the scrollbar thumb disappeared under the bottom border of the viewport (fig. 2).

Screenshots from r84:

![mobile1](https://cloud.githubusercontent.com/assets/5700294/25274221/565873bc-268f-11e7-8ae3-4a3a2dbe6c19.JPG)
![mobile2](https://cloud.githubusercontent.com/assets/5700294/25274225/5a6c6012-268f-11e7-94b0-f9b40191661f.JPG)

Thus I didn’t revert to the fixed panel height from r84, but to 100% height.

@Mugen87 Would you please test it? – I can’t really do that for the same reason like [here](https://github.com/mrdoob/three.js/pull/11190#issuecomment-294904096), you know  ;-)

https://rawgit.com/jostschmithals/three.js/fixDocsMobile/docs/index.html
