### PR TITLE
Blender exporter improve

### DIFF
--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -551,7 +551,7 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
     option_faces = BoolProperty(
         name="Faces",
-        description="Export faces",
+        description="Export faces (Geometry only)",
         default=constants.EXPORT_OPTIONS[constants.FACES])
 
     option_normals = BoolProperty(
@@ -581,7 +581,7 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
     option_face_materials = BoolProperty(
         name="Face Materials",
-        description="Face mapping materials",
+        description="Face mapping materials (Geometry only)",
         default=constants.EXPORT_OPTIONS[constants.FACE_MATERIALS])
 
     option_maps = BoolProperty(
@@ -821,6 +821,9 @@ class ExportThree(bpy.types.Operator, ExportHelper):
         :param context:
 
         """
+
+        using_geometry = self.option_geometry_type == constants.GEOMETRY
+
         layout = self.layout
 
         ## Geometry {
@@ -829,7 +832,9 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
         row = layout.row()
         row.prop(self.properties, 'option_vertices')
-        row.prop(self.properties, 'option_faces')
+        col = row.column()
+        col.prop(self.properties, 'option_faces')
+        col.enabled = using_geometry
 
         row = layout.row()
         row.prop(self.properties, 'option_normals')
@@ -841,6 +846,7 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
         row = layout.row()
         row.prop(self.properties, 'option_extra_vgroups')
+        row.enabled = not using_geometry
 
         row = layout.row()
         row.prop(self.properties, 'option_apply_modifiers')
@@ -861,6 +867,7 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
         row = layout.row()
         row.prop(self.properties, 'option_face_materials')
+        row.enabled = using_geometry
 
         row = layout.row()
         row.prop(self.properties, 'option_colors')

--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -134,6 +134,23 @@ def bones(mesh, options):
 
 
 @_mesh
+def buffer_color(mesh, options):
+    """
+
+    :param mesh:
+    :rtype: []
+
+    """
+    colors_ = []
+
+    vertex_colors_ = mesh.vertex_colors[0]  # only supports one set
+    for color_data in vertex_colors_.data:
+        colors_.extend(tuple(color_data.color))
+
+    return colors_
+
+
+@_mesh
 def buffer_normal(mesh, options):
     """
 

--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -143,7 +143,10 @@ def buffer_color(mesh, options):
     """
     colors_ = []
 
-    vertex_colors_ = mesh.vertex_colors[0]  # only supports one set
+    try:
+        vertex_colors_ = mesh.vertex_colors[0]  # only supports one set
+    except IndexError:
+        return []  # no colors found
     for color_data in vertex_colors_.data:
         colors_.extend(tuple(color_data.color))
 

--- a/utils/exporters/blender/addons/io_three/exporter/geometry.py
+++ b/utils/exporters/blender/addons/io_three/exporter/geometry.py
@@ -369,6 +369,7 @@ class Geometry(base_classes.BaseNode):
         options_vertices = self.options.get(constants.VERTICES)
         option_normals = self.options.get(constants.NORMALS)
         option_uvs = self.options.get(constants.UVS)
+        option_colors = self.options.get(constants.COLORS)
         option_extra_vgroups = self.options.get(constants.EXTRA_VGROUPS)
         option_index_type = self.options.get(constants.INDEX_TYPE)
 
@@ -380,7 +381,9 @@ class Geometry(base_classes.BaseNode):
                      lambda m: api.mesh.buffer_uv(m, layer=1), 2)
         normals_tuple = (constants.NORMAL, option_normals,
                          lambda m: api.mesh.buffer_normal(m, self.options), 3)
-        dispatch = (pos_tuple, uvs_tuple, uvs2_tuple, normals_tuple)
+        colors_tuple = (constants.COLOR, option_colors,
+                        lambda m: api.mesh.buffer_color(m, self.options), 3)
+        dispatch = (pos_tuple, uvs_tuple, uvs2_tuple, normals_tuple, colors_tuple)
 
         for key, option, func, size in dispatch:
 

--- a/utils/exporters/blender/addons/io_three/exporter/material.py
+++ b/utils/exporters/blender/addons/io_three/exporter/material.py
@@ -16,6 +16,9 @@ class Material(base_classes.BaseNode):
         textures = self.parent.options.get(constants.MAPS)
         if textures:
             self._update_maps()
+        skinning = self.parent.options.get(constants.SKINNING)
+        if skinning:
+            self[constants.SKINNING] = True
 
     def _common_attributes(self):
         """Parse the common material attributes"""


### PR DESCRIPTION
improve usability by greying out options that have no effect and added tooltip
set the 'skinning' flag in material json (when enabled)
export vertex color attribute data for BufferGeometry exporter
![capture1_annotated](https://cloud.githubusercontent.com/assets/6990640/25296916/7997f67e-26e2-11e7-86bd-825892e1eece.PNG)![capture_annotated](https://cloud.githubusercontent.com/assets/6990640/25296925/8716465c-26e2-11e7-9429-2e0843e6d306.PNG)
![capture2_annotated](https://cloud.githubusercontent.com/assets/6990640/25296934/96844300-26e2-11e7-84d3-3a9fff6f94b6.PNG)
![capture3](https://cloud.githubusercontent.com/assets/6990640/25296935/968bd728-26e2-11e7-80ac-837ba3dac599.PNG)
