### PR TITLE
Update Useful-links.html

### DIFF
--- a/docs/manual/introduction/Useful-links.html
+++ b/docs/manual/introduction/Useful-links.html
@@ -70,19 +70,12 @@
 			<li>
 				[link:http://www.natural-science.or.jp/article/20120220155529.php Building A Physics Simulation Environment] - three.js tutorial in Japanese
 			</li>
-			<li>
-		 	 [link:http://www.senaeh.de/einstieg-in-webgl-mit-three-js/ Einstieg in WebGL mit three.js] - three.js tutorial in German
-		  </li>
 
 		</ul>
 
 
 		<h2>More documentation</h2>
 		<ul>
-			<li>
-				[link:http://threejsdoc.appspot.com/doc/index.html threejsdoc] - less descriptive than the official docs here, however this is
-				useful because it links every API element to every official three.js [link:https://threejs.org/examples/ example] that uses it.
-			</li>
 			<li>
 				[link:http://ushiroad.com/3j/ Three.js walking map] - a graphical breakdown of the structure of a three.js scene.
 			</li>


### PR DESCRIPTION
- http://threejsdoc.appspot.com/doc/index.html is broken 
- three.js tutorial in german is deprecated