### PR TITLE
Simplified RectAreaLightHelper

### DIFF
--- a/docs/api/lights/RectAreaLight.html
+++ b/docs/api/lights/RectAreaLight.html
@@ -35,13 +35,13 @@
 var width = 2;
 var height = 10;
 var rectLight = new THREE.RectAreaLight( 0xffffff, undefined,  width, height );
-rectLight.matrixAutoUpdate = true;
 rectLight.intensity = 70.0;
 rectLight.position.set( 5, 5, 0 );
-rectLightHelper = new THREE.RectAreaLightHelper( rectLight );
-rectLight.add( rectLightHelper );
+scene.add( rectLight )
 
-scene.add(rectLight)
+rectLightHelper = new THREE.RectAreaLightHelper( rectLight );
+scene.add( rectLightHelper );
+
 			</code>
 		</div>
 

--- a/examples/webgl_lights_rectarealight.html
+++ b/examples/webgl_lights_rectarealight.html
@@ -135,7 +135,7 @@
 				// rectLight.target = mshPhongBox;
 
 				rectLightHelper = new THREE.RectAreaLightHelper( rectLight );
-				rectLight.add( rectLightHelper );
+				scn.add( rectLightHelper );
 
 				// TODO (abelnation): rect light shadow
 

--- a/src/helpers/RectAreaLightHelper.js
+++ b/src/helpers/RectAreaLightHelper.js
@@ -1,12 +1,13 @@
 /**
  * @author abelnation / http://github.com/abelnation
  * @author Mugen87 / http://github.com/Mugen87
+ * @author WestLangley / http://github.com/WestLangley
  */
 
 import { Object3D } from '../core/Object3D';
 import { Vector3 } from '../math/Vector3';
-import { Mesh } from '../objects/Mesh';
-import { MeshBasicMaterial } from '../materials/MeshBasicMaterial';
+import { Line } from '../objects/Line';
+import { LineBasicMaterial } from '../materials/LineBasicMaterial';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { BufferAttribute } from '../core/BufferAttribute';
 
@@ -17,28 +18,16 @@ function RectAreaLightHelper( light ) {
 	this.light = light;
 	this.light.updateMatrixWorld();
 
-	var materialFront = new MeshBasicMaterial( {
-		color: light.color,
-		fog: false
-	} );
+	this.matrix = light.matrixWorld;
+	this.matrixAutoUpdate = false;
 
-	var materialBack = new MeshBasicMaterial( {
-		color: light.color,
-		fog: false,
-		wireframe: true
-	} );
+	var material = new LineBasicMaterial( { color: light.color } );
 
 	var geometry = new BufferGeometry();
 
-	geometry.addAttribute( 'position', new BufferAttribute( new Float32Array( 6 * 3 ), 3 ) );
+	geometry.addAttribute( 'position', new BufferAttribute( new Float32Array( 5 * 3 ), 3 ) );
 
-	// shows the "front" of the light, e.g. where light comes from
-
-	this.add( new Mesh( geometry, materialFront ) );
-
-	// shows the "back" of the light, which does not emit light
-
-	this.add( new Mesh( geometry, materialBack ) );
+	this.add( new Line( geometry, material ) );
 
 	this.update();
 
@@ -51,8 +40,6 @@ RectAreaLightHelper.prototype.dispose = function () {
 
 	this.children[ 0 ].geometry.dispose();
 	this.children[ 0 ].material.dispose();
-	this.children[ 1 ].geometry.dispose();
-	this.children[ 1 ].material.dispose();
 
 };
 
@@ -63,46 +50,27 @@ RectAreaLightHelper.prototype.update = function () {
 
 	return function update() {
 
-		var mesh1 = this.children[ 0 ];
-		var mesh2 = this.children[ 1 ];
+		var line = this.children[ 0 ];
 
-		if ( this.light.target ) {
+		// update material
 
-			vector1.setFromMatrixPosition( this.light.matrixWorld );
-			vector2.setFromMatrixPosition( this.light.target.matrixWorld );
-
-			var lookVec = vector2.clone().sub( vector1 );
-			mesh1.lookAt( lookVec );
-			mesh2.lookAt( lookVec );
-
-		}
-
-		// update materials
-
-		mesh1.material.color.copy( this.light.color ).multiplyScalar( this.light.intensity );
-		mesh2.material.color.copy( this.light.color ).multiplyScalar( this.light.intensity );
+		line.material.color.copy( this.light.color );
 
 		// calculate new dimensions of the helper
 
 		var hx = this.light.width * 0.5;
 		var hy = this.light.height * 0.5;
 
-		// because the buffer attribute is shared over both geometries, we only have to update once
-
-		var position = mesh1.geometry.getAttribute( 'position' );
+		var position = line.geometry.attributes.position;
 		var array = position.array;
 
-		// first face
+		// update vertices
 
 		array[  0 ] =   hx; array[  1 ] = - hy; array[  2 ] = 0;
 		array[  3 ] =   hx; array[  4 ] =   hy; array[  5 ] = 0;
 		array[  6 ] = - hx; array[  7 ] =   hy; array[  8 ] = 0;
-
-		// second face
-
-		array[  9 ] = - hx; array[ 10 ] =   hy; array[ 11 ] = 0;
-		array[ 12 ] = - hx; array[ 13 ] = - hy; array[ 14 ] = 0;
-		array[ 15 ] =   hx; array[ 16 ] = - hy; array[ 17 ] = 0;
+		array[  9 ] = - hx; array[ 10 ] = - hy; array[ 11 ] = 0;
+		array[ 12 ] =   hx; array[ 13 ] = - hy; array[ 14 ] = 0;
 
 		position.needsUpdate = true;
 


### PR DESCRIPTION
The other helpers must be added a child of the scene, and this helper was the only exception, so I made this helper compatible with the others. (Maybe someday we can change this limitation.)

I also simplified the helper to be a simple wireframe outline, rather than a plane mesh, because the helper was blocking view of the scene.

Finally, we can't set the color of the helper to be the product of the light color and light intensity as long as lights intensities are allowed to be arbitrarily greater then one. This is a change we should make to all the light helpers, in fact.