### PR TITLE
Add support for inverse matrices, per material

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -5,6 +5,7 @@ import { _Math } from '../math/Math';
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author alteredq / http://alteredqualia.com/
+ * @author jcowles / http://visualcore.com/
  */
 
 var materialId = 0;
@@ -61,6 +62,7 @@ function Material() {
 
 	this.visible = true;
 
+	this.needsInverseMatrices;
 	this.needsUpdate = true;
 
 }
@@ -217,6 +219,8 @@ Object.assign( Material.prototype, EventDispatcher.prototype, {
 		if ( this.wireframeLinecap !== 'round' ) data.wireframeLinecap = this.wireframeLinecap;
 		if ( this.wireframeLinejoin !== 'round' ) data.wireframeLinejoin = this.wireframeLinejoin;
 
+		if ( this.needsInverseMatrices !== undefined ) data.needsInverseMatrices = this.needsInverseMatrices;
+
 		data.skinning = this.skinning;
 		data.morphTargets = this.morphTargets;
 
@@ -303,6 +307,7 @@ Object.assign( Material.prototype, EventDispatcher.prototype, {
 		this.overdraw = source.overdraw;
 
 		this.visible = source.visible;
+		this.needsInverseMatrices = source.needsInverseMatrices;
 		this.clipShadows = source.clipShadows;
 		this.clipIntersection = source.clipIntersection;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -43,6 +43,7 @@ import { Color } from '../math/Color';
  * @author alteredq / http://alteredqualia.com/
  * @author szimek / https://github.com/szimek/
  * @author tschw
+ * @author jcowles / http://visualcore.com/
  */
 
 function WebGLRenderer( parameters ) {
@@ -1955,6 +1956,16 @@ function WebGLRenderer( parameters ) {
 		p_uniforms.setValue( _gl, 'modelViewMatrix', object.modelViewMatrix );
 		p_uniforms.setValue( _gl, 'normalMatrix', object.normalMatrix );
 		p_uniforms.setValue( _gl, 'modelMatrix', object.matrixWorld );
+
+
+		// optional inverse matrices
+
+		if (object.material.needsInverseMatrices) {
+			var mvi = new Matrix4( );
+			mvi.getInverse( object.modelViewMatrix );
+			p_uniforms.setValue( _gl, 'modelInverseMatrix', object.matrixWorldInverse );
+			p_uniforms.setValue( _gl, 'modelViewInverseMatrix', mvi );
+		}
 
 		return program;
 


### PR DESCRIPTION
It is occasionally required to have access to inverse model and modelView matrices
in a shader, however setting these matrices from client code requires creating a
unique material for every object which needs the matrix. Additionally, computing the
inverse in the shader is expensive and often runs more frequently than necessary (e.g.
per vertex instead of once for the entire mesh).

Other engines (such as Unity) set inverse matrices automatically in the render loop,
which is the goal of this change.

Now, each material may declare that the inverse matrices are required, so a single
material can be used for multiple objects and the uniform inverse matrices will be
set along with the model/modelView matrix.

Also see issue #11162