### PR TITLE
Add a callback param to loadParts() to be called if we fail to read t…

### DIFF
--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -41,6 +41,7 @@ THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters, onFa
 					if ( onFailureCallback ) {
 						onFailureCallback();
 					}
+					throw e;
 				}
 
 				var materials = [], geometries = [], counter = 0;

--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -19,7 +19,7 @@ THREE.CTMLoader.prototype.constructor = THREE.CTMLoader;
 
 // Load multiple CTM parts defined in JSON
 
-THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
+THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters, onFailureCallback ) {
 
 	parameters = parameters || {};
 
@@ -35,7 +35,14 @@ THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
 
 			if ( xhr.status === 200 || xhr.status === 0 ) {
 
-				var jsonObject = JSON.parse( xhr.responseText );
+				try {
+					var jsonObject = JSON.parse( xhr.responseText );
+				} catch ( e ) {
+					if ( onFailureCallback ) {
+						onFailureCallback();
+					}
+					throw e;
+				}
 
 				var materials = [], geometries = [], counter = 0;
 

--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -19,7 +19,7 @@ THREE.CTMLoader.prototype.constructor = THREE.CTMLoader;
 
 // Load multiple CTM parts defined in JSON
 
-THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
+THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters, onFailureCallback ) {
 
 	parameters = parameters || {};
 
@@ -35,7 +35,13 @@ THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
 
 			if ( xhr.status === 200 || xhr.status === 0 ) {
 
-				var jsonObject = JSON.parse( xhr.responseText );
+				try {
+					var jsonObject = JSON.parse( xhr.responseText );
+				} catch ( e ) {
+					if ( onFailureCallback ) {
+						onFailureCallback();
+					}
+				}
 
 				var materials = [], geometries = [], counter = 0;
 


### PR DESCRIPTION
…he fetched .json file specified by the url param. Currently a failure like this (lets say the client goes offline, and can't fetch the .json file) is undetectable by the caller of loadParts().