### PR TITLE
Remove unnecessary "#include <specularmap_fragment>" from meshphysical_frag.glsl

### DIFF
--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
@@ -57,7 +57,6 @@ void main() {
 	#include <color_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
-	#include <specularmap_fragment>
 	#include <roughnessmap_fragment>
 	#include <metalnessmap_fragment>
 	#include <normal_flip>

--- a/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl
@@ -17,7 +17,6 @@ varying vec3 vViewPosition;
 #include <morphtarget_pars_vertex>
 #include <skinning_pars_vertex>
 #include <shadowmap_pars_vertex>
-#include <specularmap_pars_fragment>
 #include <logdepthbuf_pars_vertex>
 #include <clipping_planes_pars_vertex>
 


### PR DESCRIPTION
This PR removes unnecessary `#include <specularmap_fragment>` from `meshphysical_frag.glsl` which is shader for `MeshStandardMaterial` and `MeshPhysicalMaterial`.

If I'm right, `meshphysical_frag.glsl` doesn't need to include `specularmap_fragment`.

`specularmap_fragment.glsl` is a shader chunk for `specularStrength`.
`specularStrength` is used only in `envmap_fragment.glsl` and `lights_phong_[pars_]fragment.glsl` but
`meshphysical_frag.glsl` doesn't include them.
