### PR TITLE
[LoadingManager] Support URL transforms. 

### DIFF
--- a/docs/api/loaders/managers/LoadingManager.html
+++ b/docs/api/loaders/managers/LoadingManager.html
@@ -121,22 +121,22 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setResourceTransform]( [page:Function callback] )</h3>
+		<h3>[method:null setURLModifier]( [page:Function callback] )</h3>
 		<div>
-		[page:Function callback] — transform callback. Called with [page:String url] argument, and
+		[page:Function callback] — URL modifier callback. Called with [page:String url] argument, and
 		must return [page:String resolvedURL].<br /><br />
 
-		If provided, the transform callback will be passed each resource URL before a request is sent.
-		The callback may return the original URL, or a new URL to override loading behavior. This
+		If provided, the callback will be passed each resource URL before a request is sent. The
+		callback may return the original URL, or a new URL to override loading behavior. This
 		behavior can be used to load assets from .ZIP files, drag-and-drop APIs, and Data URIs.
 		</div>
 
-		<h3>[method:String resolveResourceURL]( [page:String url] )</h3>
+		<h3>[method:String resolveURL]( [page:String url] )</h3>
 		<div>
 		[page:String url] — the url to load<br /><br />
 
-		Given a URL, uses the resource transform callback (if any) and returns a resolved URL. If no
-		transform is set, returns the original URL.
+		Given a URL, uses the URL modifier callback (if any) and returns a resolved URL. If no
+		URL modifier is set, returns the original URL.
 		</div>
 
 		<br /><br />

--- a/docs/api/loaders/managers/LoadingManager.html
+++ b/docs/api/loaders/managers/LoadingManager.html
@@ -121,6 +121,25 @@
 
 		<h2>Methods</h2>
 
+		<h3>[method:null setResourceTransform]( [page:Function callback] )</h3>
+		<div>
+		[page:Function callback] — transform callback. Called with [page:String url] argument, and
+		must return [page:String resolvedURL].<br /><br />
+
+		If provided, the transform callback will be passed each resource URL before a request is sent.
+		The callback may return the original URL, or a new URL to override loading behavior. This
+		behavior can be used to load assets from .ZIP files, drag-and-drop APIs, and Data URIs.
+		</div>
+
+		<h3>[method:String resolveResourceURL]( [page:String url] )</h3>
+		<div>
+		[page:String url] — the url to load<br /><br />
+
+		Given a URL, uses the resource transform callback (if any) and returns a resolved URL. If no
+		transform is set, returns the original URL.
+		</div>
+
+		<br /><br />
 		<div>
 			<em>Note: The following methods are designed to be called internally by loaders. You shouldn't call
 			them directly.</em>

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -19,6 +19,8 @@ Object.assign( FileLoader.prototype, {
 
 		if ( this.path !== undefined ) url = this.path + url;
 
+		url = this.manager.resolveResourceURL( url );
+
 		var scope = this;
 
 		var cached = Cache.get( url );

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -19,7 +19,7 @@ Object.assign( FileLoader.prototype, {
 
 		if ( this.path !== undefined ) url = this.path + url;
 
-		url = this.manager.resolveResourceURL( url );
+		url = this.manager.resolveURL( url );
 
 		var scope = this;
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -22,6 +22,8 @@ Object.assign( ImageLoader.prototype, {
 
 		if ( this.path !== undefined ) url = this.path + url;
 
+		url = this.manager.resolveResourceURL( url );
+
 		var scope = this;
 
 		var cached = Cache.get( url );

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -22,7 +22,7 @@ Object.assign( ImageLoader.prototype, {
 
 		if ( this.path !== undefined ) url = this.path + url;
 
-		url = this.manager.resolveResourceURL( url );
+		url = this.manager.resolveURL( url );
 
 		var scope = this;
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -9,7 +9,7 @@ function LoadingManager( onLoad, onProgress, onError ) {
 	var isLoading = false;
 	var itemsLoaded = 0;
 	var itemsTotal = 0;
-	var resourceTransform = undefined;
+	var urlModifier = undefined;
 
 	this.onStart = undefined;
 	this.onLoad = onLoad;
@@ -68,11 +68,11 @@ function LoadingManager( onLoad, onProgress, onError ) {
 
 	};
 
-	this.resolveResourceURL = function ( url ) {
+	this.resolveURL = function ( url ) {
 
-		if ( resourceTransform ) {
+		if ( urlModifier ) {
 
-			return resourceTransform( url );
+			return urlModifier( url );
 
 		}
 
@@ -80,9 +80,9 @@ function LoadingManager( onLoad, onProgress, onError ) {
 
 	};
 
-	this.setResourceTransform = function ( transform ) {
+	this.setURLModifier = function ( transform ) {
 
-		resourceTransform = transform;
+		urlModifier = transform;
 
 	};
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -13,6 +13,8 @@ function LoadingManager( onLoad, onProgress, onError ) {
 	this.onProgress = onProgress;
 	this.onError = onError;
 
+	this.resourceTransform = undefined;
+
 	this.itemStart = function ( url ) {
 
 		itemsTotal ++;
@@ -62,6 +64,24 @@ function LoadingManager( onLoad, onProgress, onError ) {
 			scope.onError( url );
 
 		}
+
+	};
+
+	this.resolveResourceURL = function ( url ) {
+
+		if ( this.resourceTransform ) {
+
+			return this.resourceTransform( url );
+
+		}
+
+		return url;
+
+	};
+
+	this.setResourceTransform = function ( transform ) {
+
+		this.resourceTransform = transform;
 
 	};
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -6,14 +6,15 @@ function LoadingManager( onLoad, onProgress, onError ) {
 
 	var scope = this;
 
-	var isLoading = false, itemsLoaded = 0, itemsTotal = 0;
+	var isLoading = false;
+	var itemsLoaded = 0;
+	var itemsTotal = 0;
+	var resourceTransform = undefined;
 
 	this.onStart = undefined;
 	this.onLoad = onLoad;
 	this.onProgress = onProgress;
 	this.onError = onError;
-
-	this.resourceTransform = undefined;
 
 	this.itemStart = function ( url ) {
 
@@ -69,9 +70,9 @@ function LoadingManager( onLoad, onProgress, onError ) {
 
 	this.resolveResourceURL = function ( url ) {
 
-		if ( this.resourceTransform ) {
+		if ( resourceTransform ) {
 
-			return this.resourceTransform( url );
+			return resourceTransform( url );
 
 		}
 
@@ -81,7 +82,7 @@ function LoadingManager( onLoad, onProgress, onError ) {
 
 	this.setResourceTransform = function ( transform ) {
 
-		this.resourceTransform = transform;
+		resourceTransform = transform;
 
 	};
 

--- a/test/Three.Unit.js
+++ b/test/Three.Unit.js
@@ -98,7 +98,7 @@ export * from '../src/geometries/Geometries.js';
 
 //src/helpers
 export { ArrowHelper } from '../src/helpers/ArrowHelper.js';
-export { AxisHelper } from '../src/helpers/AxisHelper.js';
+export { AxesHelper } from '../src/helpers/AxesHelper.js';
 export { BoxHelper } from '../src/helpers/BoxHelper.js';
 export { Box3Helper } from '../src/helpers/Box3Helper.js';
 export { CameraHelper } from '../src/helpers/CameraHelper.js';

--- a/test/unit/src/helpers/AxesHelper.js
+++ b/test/unit/src/helpers/AxesHelper.js
@@ -3,4 +3,4 @@
  */
 
 //Todo
-console.warn("Todo: Unit tests of AxisHelper")
+console.warn("Todo: Unit tests of AxesHelper")

--- a/test/unit/src/loaders/LoadingManager.js
+++ b/test/unit/src/loaders/LoadingManager.js
@@ -1,6 +1,22 @@
 /**
- * @author TristanVALCKE / https://github.com/TristanVALCKE
+ * @author Don McCurdy / https://github.com/donmccurdy
  */
 
-//Todo
-console.warn("Todo: Unit tests of LoadingManager")
+QUnit.module( "LoadingManager" );
+
+QUnit.test( "setResourceTransform", function( assert ) {
+
+  var manager = new THREE.LoadingManager();
+  var suffix = '?transformed=true';
+
+  manager.setResourceTransform( function ( url ) {
+
+    return url + suffix;
+
+  } );
+
+  var url = 'https://foo.bar/baz';
+  var resolvedURL = manager.resolveResourceURL( url );
+  assert.equal( resolvedURL, url + suffix, 'URL transform is applied' );
+
+});

--- a/test/unit/src/loaders/LoadingManager.js
+++ b/test/unit/src/loaders/LoadingManager.js
@@ -2,21 +2,21 @@
  * @author Don McCurdy / https://github.com/donmccurdy
  */
 
-QUnit.module( "LoadingManager" );
+QUnit.module( 'LoadingManager' );
 
-QUnit.test( "setResourceTransform", function( assert ) {
+QUnit.test( 'setURLModifier', function( assert ) {
 
 	var manager = new THREE.LoadingManager();
 	var suffix = '?transformed=true';
 
-	manager.setResourceTransform( function ( url ) {
+	manager.setURLModifier( function ( url ) {
 
 		return url + suffix;
 
 	} );
 
 	var url = 'https://foo.bar/baz';
-	var resolvedURL = manager.resolveResourceURL( url );
+	var resolvedURL = manager.resolveURL( url );
 	assert.equal( resolvedURL, url + suffix, 'URL transform is applied' );
 
 });

--- a/test/unit/src/loaders/LoadingManager.js
+++ b/test/unit/src/loaders/LoadingManager.js
@@ -6,17 +6,17 @@ QUnit.module( "LoadingManager" );
 
 QUnit.test( "setResourceTransform", function( assert ) {
 
-  var manager = new THREE.LoadingManager();
-  var suffix = '?transformed=true';
+	var manager = new THREE.LoadingManager();
+	var suffix = '?transformed=true';
 
-  manager.setResourceTransform( function ( url ) {
+	manager.setResourceTransform( function ( url ) {
 
-    return url + suffix;
+		return url + suffix;
 
-  } );
+	} );
 
-  var url = 'https://foo.bar/baz';
-  var resolvedURL = manager.resolveResourceURL( url );
-  assert.equal( resolvedURL, url + suffix, 'URL transform is applied' );
+	var url = 'https://foo.bar/baz';
+	var resolvedURL = manager.resolveResourceURL( url );
+	assert.equal( resolvedURL, url + suffix, 'URL transform is applied' );
 
 });


### PR DESCRIPTION
Intended to address #11072 and #10580.

### Problem

Because loaders (and models themselves) have dependencies on relative URLs, certain things are difficult:

1. Load model + textures with drag-and-drop.
2. Load model + textures over WebSocket or WebRTC.
3. Attach a user-specific access token to each resource URL that a model depends on. E.g. `foo.obj?token=ou824h09` should request `foo-texture.png?token=ou824h09`, even though that token is not part of the OBJ or MTL file.

Existing options, AFAIK, are to find/replace URLs in the model's raw content, or to fork the loaders for each format you need to support. While making [this app](https://gltf-viewer.donmccurdy.com/), I forked the glTF loader.

### Proposal

This is a proposal for opt-in URL transformation through the LoadingManager class, which should solve this more generally. In theory this should benefit the three.js editor, as well.

For drag-and-drop, a user would do this:

```js
// Create blob URLs from files dragged into the page.
var urlMap = {};
blobs.forEach( ( blob ) => {

  urlMap[ blob.fullPath ] = URL.createObjectURL( blob );

} );


// Initialize loading manager with URL transform.
var manager = new THREE.LoadingManager();
manager.setURLTransform( ( url ) => urlMap[ url ] );


// Load as usual, then revoke the blob URLs.
var loader = new THREE.GLTF2Loader( manager );
loader.load( blobs[0].fullPath, function (gltf) {

  blobs.forEach( ( blob ) => URL.revokeObjectURL( urlMap[ blob.fullPath ] ) );

});
```

... which should work for any model format, assuming the format reuses its LoadingManager for all requests (which is what the loaders ought to do, anyway). Tested with OBJ and glTF.