### PR TITLE
WebGLShadowMap: fix spotlight shadow updating

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -134,6 +134,12 @@ function WebGLShadowMap( _renderer, _lights, _objects, capabilities ) {
 
 			}
 
+			if ( shadow.isSpotLightShadow ) {
+
+				shadow.update( light );
+
+			}
+
 			var shadowCamera = shadow.camera;
 			var shadowMatrix = shadow.matrix;
 
@@ -218,12 +224,6 @@ function WebGLShadowMap( _renderer, _lights, _objects, capabilities ) {
 				shadow.map.texture.name = light.name + ".shadowMap";
 
 				shadowCamera.updateProjectionMatrix();
-
-			}
-
-			if ( shadow.isSpotLightShadow ) {
-
-				shadow.update( light );
 
 			}
 


### PR DESCRIPTION
A fix for https://github.com/mrdoob/three.js/issues/11273

The shadow camera's projection matrix is used before it is first initialized with the `shadow.update` method. This bad ordering was introduced with my previous pull request, https://github.com/mrdoob/three.js/pull/11198

I apologize for the carelessness. The code was tested with the [lights  / spotlights](https://threejs.org/examples/?q=spot#webgl_lights_spotlight) example, but I wasn't diligent enough to check that the render function was being called only once, and not twice as it is in that example.