### PR TITLE
Object3D performance/memory improvements

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -92,10 +92,6 @@ function Object3D() {
 	this.renderOrder = 0;
 
 	this.userData = {};
-
-	this.onBeforeRender = function () {};
-	this.onAfterRender = function () {};
-
 }
 
 Object3D.DefaultUp = new Vector3( 0, 1, 0 );
@@ -104,6 +100,9 @@ Object3D.DefaultMatrixAutoUpdate = true;
 Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 
 	isObject3D: true,
+
+	onBeforeRender: function () {},
+	onAfterRender: function () {},
 
 	applyMatrix: function ( matrix ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -32,24 +32,14 @@ function Object3D() {
 	this.up = Object3D.DefaultUp.clone();
 
 	var position = new Vector3();
-	var rotation = new Euler();
-	var quaternion = new Quaternion();
 	var scale = new Vector3( 1, 1, 1 );
 
-	function onRotationChange() {
-
-		quaternion.setFromEuler( rotation, false );
-
-	}
-
-	function onQuaternionChange() {
-
-		rotation.setFromQuaternion( quaternion, undefined, false );
-
-	}
-
-	rotation.onChange( onRotationChange );
-	quaternion.onChange( onQuaternionChange );
+	var rotation = new Euler();
+	var quaternion = new Quaternion();
+	rotation._object3DQuaternion = quaternion;
+	quaternion._object3DRotation = rotation;
+	rotation.onChange( syncRotationToQuaternion );
+	quaternion.onChange( syncQuaternionToRotation );
 
 	Object.defineProperties( this, {
 		position: {
@@ -752,6 +742,19 @@ Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 	}
 
 } );
+
+
+function syncQuaternionToRotation() {
+
+	this._object3DRotation.setFromQuaternion( this, undefined, false );
+
+}
+
+function syncRotationToQuaternion() {
+
+	this._object3DQuaternion.setFromEuler( this, false );
+
+}
 
 
 export { Object3D };


### PR DESCRIPTION
My project requires the creation of large numbers of Object3D instances, so I've made some speed and memory usage improvements for that scenario. This first submission is in two parts, both dealing with reducing closures within the Object3D constructor.

The first commit is simply moving the default onBeforeRender/onAfterRender empty callback functions to the prototype. Surprisingly this also increases their call speed per frame as well, presumably since it allows the JS engine to optimize away the empty functions better.

The second commit changes the quaternion/rotation synchronization to utilize member cross-references and shared onChangeCallback functions rather than two closures per pair. This relies on the onChangeCallback being executed with the proper `this` but that appears to always be the case.

Combined measurements, using 100K Object3D instances:
- constructor exec time: 1620ms -> 1200ms
- onBeforeRender/onAfterRender call time: 4.5ms -> 1.1ms
- retained size: 133MB -> 101MB
