### PR TITLE
onBeforeRender/onAfterRender from constructor to prototype

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -92,10 +92,6 @@ function Object3D() {
 	this.renderOrder = 0;
 
 	this.userData = {};
-
-	this.onBeforeRender = function () {};
-	this.onAfterRender = function () {};
-
 }
 
 Object3D.DefaultUp = new Vector3( 0, 1, 0 );
@@ -104,6 +100,9 @@ Object3D.DefaultMatrixAutoUpdate = true;
 Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 
 	isObject3D: true,
+
+	onBeforeRender: function () {},
+	onAfterRender: function () {},
 
 	applyMatrix: function ( matrix ) {
 


### PR DESCRIPTION
Move the default onBeforeRender/onAfterRender empty functions from each instance to the prototype, for constructor speed and retained memory improvement.

Measurements for 100K objects:
- constructor exec time: 1620ms -> 1500ms
- onBeforeRender/onAfterRender call time: 4.5ms -> 1.1ms
- retained size: 133MB -> 121MB