### PR TITLE
Prevent 2 closures for every Object3D in quaternion/euler syncing

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -53,18 +53,8 @@ function Object3D() {
 	var quaternion = new Quaternion();
 	var scale = new Vector3( 1, 1, 1 );
 
-	function onRotationChange() {
-
-		quaternion.setFromEuler( rotation, false );
-
-	}
-
-	function onQuaternionChange() {
-
-		rotation.setFromQuaternion( quaternion, undefined, false );
-
-	}
-
+	rotation._quaternion = quaternion;
+	quaternion._rotation = rotation;
 	rotation._onChange( onRotationChange );
 	quaternion._onChange( onQuaternionChange );
 
@@ -853,6 +843,19 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	}
 
 } );
+
+
+function onRotationChange() {
+
+	this._quaternion.setFromEuler( this, false );
+
+}
+
+function onQuaternionChange() {
+
+	this._rotation.setFromQuaternion( this, undefined, false );
+
+}
 
 
 export { Object3D };


### PR DESCRIPTION
Change quaternion/rotation syncing to avoid creating a closure per Object3D, for constructor speed and retained memory improvement.

Measurements for 100K objects:
- constructor exec time: 1500ms -> 1200ms
- retained size: 121MB -> 101MB