### PR TITLE
[glTF] Use default byteOffset=0.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1309,9 +1309,10 @@ THREE.GLTF2Loader = ( function () {
 
 				var arraybuffer = dependencies.buffers[ bufferView.buffer ];
 
-				var byteLength = bufferView.byteLength !== undefined ? bufferView.byteLength : 0;
+				var byteLength = bufferView.byteLength || 0;
+				var byteOffset = bufferView.byteOffset || 0;
 
-				return arraybuffer.slice( bufferView.byteOffset, bufferView.byteOffset + byteLength );
+				return arraybuffer.slice( byteOffset, byteOffset + byteLength );
 
 			} );
 


### PR DESCRIPTION
Fixes an issue in the Corset sample model.