### PR TITLE
[glTF] Duplicate UVs when aoMap is present.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2092,6 +2092,15 @@ THREE.GLTF2Loader = ( function () {
 
 						}
 
+						if ( material.aoMap !== undefined
+								&& geometry.attributes.uv2 === undefined
+								&& geometry.attributes.uv !== undefined ) {
+
+							console.log( 'GLTF2Loader: Duplicating UVs to support aoMap.' );
+							geometry.addAttribute( 'uv2', new THREE.BufferAttribute( geometry.attributes.uv.array, 2 ) );
+
+						}
+
 						meshNode = new THREE.Mesh( geometry, material );
 						meshNode.castShadow = true;
 


### PR DESCRIPTION
Fixes #11268. There were more issues originally in that bug, but it looks like the others were solved already in other updates.