### PR TITLE
[glTF] Support doubleSided=true param with PBR materials.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1589,6 +1589,12 @@ THREE.GLTF2Loader = ( function () {
 
 					}
 
+					if ( material.doubleSided === true ) {
+
+						materialParams.side = THREE.DoubleSide;
+
+					}
+
 					if ( materialParams.opacity !== undefined && materialParams.opacity < 1.0 ||
 					     ( materialParams.map !== undefined &&
 					       ( materialParams.map.format === THREE.AlphaFormat ||


### PR DESCRIPTION
For PBR metal-rough and spec-gloss workflows.