### PR TITLE
maxTextures use gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -340,7 +340,7 @@ function WebGLState( gl, extensions, paramThreeToGL ) {
 
 	var currentScissorTest = null;
 
-	var maxTextures = gl.getParameter( gl.MAX_TEXTURE_IMAGE_UNITS );
+	var maxTextures = gl.getParameter( gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS );
 
 	var version = parseFloat( /^WebGL\ ([0-9])/.exec( gl.getParameter( gl.VERSION ) )[ 1 ] );
 	var lineWidthAvailable = parseFloat( version ) >= 1.0;


### PR DESCRIPTION
The maxTextures should use gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS instead of gl.MAX_TEXTURE_IMAGE_UNITS.

See https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/activeTexture#Parameters