### PR TITLE
Add Layers to Raycaster to allow selectively intersecting objects in the scene.

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -1,4 +1,5 @@
 import { Ray } from '../math/Ray';
+import { Layers } from '../math/Layers';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -13,6 +14,10 @@ function Raycaster( origin, direction, near, far ) {
 
 	this.near = near || 0;
 	this.far = far || Infinity;
+
+	this.layers = new Layers();
+	// the default layer mask of 0 turns off layer testing
+	this.layers.mask = 0;
 
 	this.params = {
 		Mesh: {},
@@ -43,7 +48,11 @@ function intersectObject( object, raycaster, intersects, recursive ) {
 
 	if ( object.visible === false ) return;
 
-	object.raycast( raycaster, intersects );
+	if ( raycaster.layers.mask === 0 || raycaster.layers.test( object.layers ) ) {
+
+		object.raycast( raycaster, intersects );
+
+	}
 
 	if ( recursive === true ) {
 


### PR DESCRIPTION
The Raycaster.layers.mask defaults to 0, which disables layer mask testing and matches existing previous behavior.

When Raycaster.layers.mask !== 0, it the raycaster layer mask is tested against each object and skipped if the test fails.  This allows for selectively picking objects in the scene using the Layer mechanism.