### PR TITLE
Reference 2.7x addons path in docs

### DIFF
--- a/utils/exporters/blender/README.md
+++ b/utils/exporters/blender/README.md
@@ -43,7 +43,11 @@ By default, this should look like:
 For Ubuntu users who installed Blender 2.68 via apt-get, this is the location:
 
     /usr/lib/blender/scripts/addons
-    
+
+For Ubuntu users who installed Blender 2.7x via apt-get, this is the location:
+
+    /usr/share/blender/scripts/addons
+
 
 ## Usage
 


### PR DESCRIPTION
The path for addons is different for 2.76, after searching my filesystem
this is the location I found for my addons directory