### PR TITLE
frustum culling by bounding box

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -89,6 +89,7 @@ function Object3D() {
 	this.receiveShadow = false;
 
 	this.frustumCulled = true;
+	this.cullingBoundsBox = false;
 	this.renderOrder = 0;
 
 	this.userData = {};

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -1,5 +1,6 @@
 import { Vector3 } from './Vector3';
 import { Sphere } from './Sphere';
+import { Box3 } from './Box3';
 import { Plane } from './Plane';
 
 /**
@@ -83,18 +84,33 @@ Object.assign( Frustum.prototype, {
 	intersectsObject: function () {
 
 		var sphere = new Sphere();
+		var box = new Box3();
 
 		return function intersectsObject( object ) {
 
 			var geometry = object.geometry;
 
-			if ( geometry.boundingSphere === null )
-				geometry.computeBoundingSphere();
+			if ( object.cullingBoundsBox ) {
 
-			sphere.copy( geometry.boundingSphere )
-				.applyMatrix4( object.matrixWorld );
+				if ( geometry.boundingBox === null )
+					geometry.computeBoundingBox();
 
-			return this.intersectsSphere( sphere );
+				box.copy( geometry.boundingBox )
+					.applyMatrix4( object.matrixWorld );
+
+				return this.intersectsBox( box );
+
+			} else {
+
+				if ( geometry.boundingSphere === null )
+					geometry.computeBoundingSphere();
+
+				sphere.copy( geometry.boundingSphere )
+					.applyMatrix4( object.matrixWorld );
+
+				return this.intersectsSphere( sphere );
+
+			}
 
 		};
 


### PR DESCRIPTION
PR to demonstrate culling by bounding box instead of bounding sphere in renderer, discussed in #11291.

Lightly tested with examples_geometry_hierarchy, although this does show up in CPU profiles, mainly from the transformation of all 8 vertices to world coordinates, rather than just the sphere centre and radius scaling etc.