### PR TITLE
PolyhedronGeometry: Compute flat normals when detail is zero

### DIFF
--- a/src/geometries/PolyhedronGeometry.js
+++ b/src/geometries/PolyhedronGeometry.js
@@ -74,7 +74,16 @@ function PolyhedronBufferGeometry( vertices, indices, radius, detail ) {
 	this.addAttribute( 'position', new Float32BufferAttribute( vertexBuffer, 3 ) );
 	this.addAttribute( 'normal', new Float32BufferAttribute( vertexBuffer.slice(), 3 ) );
 	this.addAttribute( 'uv', new Float32BufferAttribute( uvBuffer, 2 ) );
-	this.normalizeNormals();
+
+	if ( detail === 0 ) {
+
+		BufferGeometry.prototype.computeVertexNormals.call( this ); // flat normals
+
+	} else {
+
+		this.normalizeNormals(); // smooth normals
+
+	}
 
 	// helper functions
 

--- a/src/geometries/PolyhedronGeometry.js
+++ b/src/geometries/PolyhedronGeometry.js
@@ -77,7 +77,7 @@ function PolyhedronBufferGeometry( vertices, indices, radius, detail ) {
 
 	if ( detail === 0 ) {
 
-		BufferGeometry.prototype.computeVertexNormals.call( this ); // flat normals
+		this.computeVertexNormals(); // flat normals
 
 	} else {
 


### PR DESCRIPTION
Previously, smooth normals were computed all the time.

However, flat normals are more appropriate when the `detail` parameter is zero, resulting in a regular polyhedron.

When `detail` is greater than zero, the geometry is tessellated. Personally, I think flat normals are more appropriate in that case, too. However, I believe some users are using `IcosahedronGeometry` as a stand-in for a sphere, and would object to the change. Consequently, this PR retains smooth normals when `detail` is non-zero. I do not see the point in adding an optional flag.

/ping @Mugen87 
