### PR TITLE
Object3D: add applyQuaternion()

### DIFF
--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -196,7 +196,10 @@
 		</div>
 
 		<h3>[method:null applyMatrix]( [page:Matrix4 matrix] )</h3>
-		<div>This updates the position, rotation and scale with the matrix.</div>
+		<div>Applies the matrix transform to the object and updates the object's position, rotation and scale.</div>
+
+		<h3>[method:Object3D applyQuaternion]( [page:Quaternion quaternion] )</h3>
+		<div>Applies the rotation represented by the quaternion to the object.</div>
 
 		<h3>[method:Object3D clone]( [page:Boolean recursive] )</h3>
 		<div>

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -112,6 +112,14 @@ Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 
 	},
 
+	applyQuaternion: function ( q ) {
+
+		this.quaternion.premultiply( q );
+
+		return this;
+
+	},
+
 	setRotationFromAxisAngle: function ( axis, angle ) {
 
 		// assumes axis is normalized
@@ -272,7 +280,7 @@ Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 
 	lookAt: function () {
 
-		// This routine does not support objects with rotated and/or translated parent(s)
+		// This method does not support objects with rotated and/or translated parent(s)
 
 		var m1 = new Matrix4();
 


### PR DESCRIPTION
This is convenient for use in this pattern:
```
var q = new THREE.Quaternion().setFrom*( args ); // Euler angle, axis-angle, rotation mat, unit vectors

object.applyQuaternion( q );
```
and applies a rotation around a _world_ axis -- as opposed to a local one. (Objects having a rotated parent excluded.)