### PR TITLE
Accept animation target.node=0 in GLTF2Loader

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2309,7 +2309,7 @@ THREE.GLTF2Loader = ( function () {
 					if ( sampler ) {
 
 						var target = channel.target;
-						var name = target.node || target.id; // NOTE: target.id is deprecated.
+						var name = target.node !== undefined ? target.node : target.id; // NOTE: target.id is deprecated.
 						var input = animation.parameters !== undefined ? animation.parameters[ sampler.input ] : sampler.input;
 						var output = animation.parameters !== undefined ? animation.parameters[ sampler.output ] : sampler.output;
 


### PR DESCRIPTION
This PR fixes a bug in `GLTF2Loader`.
`target.node` of animation can be 0 in glTF 2.0 so `target.node || target.id` goes wrong.