### PR TITLE
Fix an offset bug in BinaryLoader

### DIFF
--- a/examples/js/loaders/BinaryLoader.js
+++ b/examples/js/loaders/BinaryLoader.js
@@ -250,7 +250,7 @@ THREE.BinaryLoader.prototype = {
 
 				for ( var i = 0; i < length; i ++ ) {
 
-					text += String.fromCharCode( charArray[ offset + i ] );
+					text += String.fromCharCode( charArray[ i ] );
 
 				}
 


### PR DESCRIPTION
This PR fixes an offset bug in `BinaryLoader`.

`offset` is already applied to `charArray` when it's created so
I don't think `offset` should be applied to `charArray` index.