### PR TITLE
Improve the ArrayBuffer/String converting performance with TextDecoder

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -4960,6 +4960,12 @@
 
 		var array = new Uint8Array( buffer, from, to );
 
+		if ( window.TextDecoder !== undefined ) {
+
+			return new TextDecoder().decode( array );
+
+		}
+
 		var s = '';
 
 		for ( var i = 0, il = array.length; i < il; i ++ ) {

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -978,13 +978,20 @@ THREE.GLTF2Loader = ( function () {
 
 	}
 
-	// Avoid the String.fromCharCode.apply(null, array) shortcut, which
-	// throws a "maximum call stack size exceeded" error for large arrays.
 	function convertUint8ArrayToString( array ) {
+
+		if ( window.TextDecoder !== undefined ) {
+
+			return new TextDecoder().decode( array );
+
+		}
+
+		// Avoid the String.fromCharCode.apply(null, array) shortcut, which
+		// throws a "maximum call stack size exceeded" error for large arrays.
 
 		var s = '';
 
-		for ( var i = 0; i < array.length; i ++ ) {
+		for ( var i = 0, il = array.length; i < il; i ++ ) {
 
 			s += String.fromCharCode( array[ i ] );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -662,13 +662,20 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
-	// Avoid the String.fromCharCode.apply(null, array) shortcut, which
-	// throws a "maximum call stack size exceeded" error for large arrays.
 	function convertUint8ArrayToString( array ) {
+
+		if ( window.TextDecoder !== undefined ) {
+
+			//return new TextDecoder().decode( array );
+
+		}
+
+		// Avoid the String.fromCharCode.apply(null, array) shortcut, which
+		// throws a "maximum call stack size exceeded" error for large arrays.
 
 		var s = '';
 
-		for ( var i = 0; i < array.length; i ++ ) {
+		for ( var i = 0, il = array.length; i < il; i ++ ) {
 
 			s += String.fromCharCode( array[ i ] );
 

--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -35,9 +35,16 @@ THREE.PCDLoader.prototype = {
 
 	binarryToStr: function ( data ) {
 
-		var text = "";
 		var charArray = new Uint8Array( data );
-		for ( var i = 0; i < data.byteLength; i ++ ) {
+
+		if ( window.TextDecoder !== undefined ) {
+
+			return new TextDecoder().decode( charArray );
+
+		}
+
+		var text = "";
+		for ( var i = 0, il = data.byteLength; i < il; i ++ ) {
 
 			text += String.fromCharCode( charArray[ i ] );
 

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -245,13 +245,22 @@ THREE.STLLoader.prototype = {
 		if ( typeof buf !== "string" ) {
 
 			var array_buffer = new Uint8Array( buf );
-			var strArray = [];
-			for ( var i = 0; i < buf.byteLength; i ++ ) {
 
-				strArray.push(String.fromCharCode( array_buffer[ i ] )); // implicitly assumes little-endian
+			if ( window.TextDecoder !== undefined ) {
+
+				return new TextDecoder().decode( array_buffer );
 
 			}
-			return strArray.join('');
+
+			var str = '';
+
+			for ( var i = 0, il = buf.byteLength; i < il; i ++ ) {
+
+				str += String.fromCharCode( array_buffer[ i ] ); // implicitly assumes little-endian
+
+			}
+
+			return str;
 
 		} else {
 

--- a/examples/js/loaders/XLoader.js
+++ b/examples/js/loaders/XLoader.js
@@ -362,8 +362,15 @@ THREE.XLoader = function () {
 		if ( typeof buf !== "string" ) {
 
 			var array_buffer = new Uint8Array( buf );
+
+			if ( window.TextDecoder !== undefined ) {
+
+				return new TextDecoder().decode( array_buffer );
+
+			}
+
 			var str = '';
-			for ( var i = 0; i < buf.byteLength; i ++ ) {
+			for ( var i = 0, il = buf.byteLength; i < il; i ++ ) {
 
 				str += String.fromCharCode( array_buffer[ i ] );
 


### PR DESCRIPTION
This PR improves the `.load()` performance 70x (if we ignore network speed)
of the following loaders by using `TextDecoder.decode()`

#11287

- `FBXLoader`
- `GLTF(2)Loader`
- `PCDLoader`
- `PLYLoader`
- `STLLoader`
- `XLoader`

And I tuned a bit for browsers(IE and Edge) which don't support `TextDecoder` yet.