### PR TITLE
Improve performance of SVGRenderer

### DIFF
--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -118,10 +118,20 @@ THREE.SVGRenderer = function () {
 
 	}
 
+	function getSvgColor ( color, opacity ) {
+
+		var arg = Math.floor( color.r * 255 ) + ',' + Math.floor( color.g * 255 ) + ',' + Math.floor( color.b * 255 );
+
+		if ( opacity === undefined || opacity === 1 ) return 'rgb(' + arg + ')';
+
+		return 'rgba(' + arg + ',' + opacity + ')';
+
+	}
+
 	this.clear = function () {
 
 		removeChildNodes();
-		_svg.style.backgroundColor = 'rgba(' + Math.floor( _clearColor.r * 255 ) + ',' + Math.floor( _clearColor.g * 255 ) + ',' + Math.floor( _clearColor.b * 255 ) + ',' + _clearAlpha + ')';
+		_svg.style.backgroundColor = getSvgColor( _clearColor, _clearAlpha );
 
 	};
 
@@ -139,7 +149,7 @@ THREE.SVGRenderer = function () {
 		if ( background && background.isColor ) {
 
 			removeChildNodes();
-			_svg.style.backgroundColor = 'rgb(' + Math.floor( background.r * 255 ) + ',' + Math.floor( background.g * 255 ) + ',' + Math.floor( background.b * 255 ) + ')';
+			_svg.style.backgroundColor = getSvgColor( background );
 
 		} else if ( this.autoClear === true ) {
 
@@ -339,7 +349,7 @@ THREE.SVGRenderer = function () {
 
 		if ( material.isSpriteMaterial || material.isPointsMaterial ) {
 
-			style = 'fill:' + material.color.getStyle();
+			style = 'fill:' + getSvgColor( material.color, material.opacity );
 
 		}
 
@@ -353,7 +363,7 @@ THREE.SVGRenderer = function () {
 
 		if ( material instanceof THREE.LineBasicMaterial ) {
 
-			var style = 'fill:none;stroke:' + material.color.getStyle() + ';stroke-width:' + material.linewidth + ';stroke-opacity:' + material.opacity + ';stroke-linecap:' + material.linecap + ';stroke-linejoin:' + material.linejoin;
+			var style = 'fill:none;stroke:' + getSvgColor( material.color, material.opacity ) + ';stroke-width:' + material.linewidth + ';stroke-linecap:' + material.linecap + ';stroke-linejoin:' + material.linejoin;
 
 			addPath( style, path );
 
@@ -407,11 +417,11 @@ THREE.SVGRenderer = function () {
 
 		if ( material.wireframe ) {
 
-			style = 'fill:none;stroke:' + _color.getStyle() + ';stroke-width:' + material.wireframeLinewidth + ';stroke-opacity:' + material.opacity + ';stroke-linecap:' + material.wireframeLinecap + ';stroke-linejoin:' + material.wireframeLinejoin;
+			style = 'fill:none;stroke:' + getSvgColor( _color, material.opacity ) + ';stroke-width:' + material.wireframeLinewidth + ';stroke-linecap:' + material.wireframeLinecap + ';stroke-linejoin:' + material.wireframeLinejoin;
 
 		} else {
 
-			style = 'fill:' + _color.getStyle() + ';fill-opacity:' + material.opacity;
+			style = 'fill:' + getSvgColor( _color, material.opacity );
 
 		}
 

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -334,12 +334,12 @@ THREE.SVGRenderer = function () {
 			scaleY *= material.size;
 		}
 
-		var path = 'M ' + ( v1.x - scaleX * 0.5 ) + ' ' + ( v1.y - scaleY * 0.5 ) + ' h ' + scaleX + ' v ' + scaleY + ' h ' + (-scaleX) + ' z';
+		var path = 'M' + ( v1.x - scaleX * 0.5 ) + ',' + ( v1.y - scaleY * 0.5 ) + 'h' + scaleX + 'v' + scaleY + 'h' + (-scaleX) + 'z';
 		var style = "";
 
 		if ( material.isSpriteMaterial || material.isPointsMaterial ) {
 
-			style = 'fill: ' + material.color.getStyle();
+			style = 'fill:' + material.color.getStyle();
 
 		}
 
@@ -349,11 +349,11 @@ THREE.SVGRenderer = function () {
 
 	function renderLine( v1, v2, element, material ) {
 
-		var path = 'M ' + v1.positionScreen.x + ' ' + v1.positionScreen.y + ' L ' + v2.positionScreen.x + ' ' + v2.positionScreen.y;
+		var path = 'M' + v1.positionScreen.x + ',' + v1.positionScreen.y + 'L' + v2.positionScreen.x + ',' + v2.positionScreen.y;
 
 		if ( material instanceof THREE.LineBasicMaterial ) {
 
-			var style = 'fill: none; stroke: ' + material.color.getStyle() + '; stroke-width: ' + material.linewidth + '; stroke-opacity: ' + material.opacity + '; stroke-linecap: ' + material.linecap + '; stroke-linejoin: ' + material.linejoin;
+			var style = 'fill:none;stroke:' + material.color.getStyle() + ';stroke-width:' + material.linewidth + ';stroke-opacity:' + material.opacity + ';stroke-linecap:' + material.linecap + ';stroke-linejoin:' + material.linejoin;
 
 			addPath( style, path );
 
@@ -366,7 +366,7 @@ THREE.SVGRenderer = function () {
 		_this.info.render.vertices += 3;
 		_this.info.render.faces ++;
 
-		var path = 'M ' + v1.positionScreen.x + ' ' + v1.positionScreen.y + ' L ' + v2.positionScreen.x + ' ' + v2.positionScreen.y + ' L ' + v3.positionScreen.x + ',' + v3.positionScreen.y + 'z';
+		var path = 'M' + v1.positionScreen.x + ',' + v1.positionScreen.y + 'L' + v2.positionScreen.x + ',' + v2.positionScreen.y + 'L' + v3.positionScreen.x + ',' + v3.positionScreen.y + 'z';
 		var style = '';
 
 		if ( material instanceof THREE.MeshBasicMaterial ) {
@@ -407,11 +407,11 @@ THREE.SVGRenderer = function () {
 
 		if ( material.wireframe ) {
 
-			style = 'fill: none; stroke: ' + _color.getStyle() + '; stroke-width: ' + material.wireframeLinewidth + '; stroke-opacity: ' + material.opacity + '; stroke-linecap: ' + material.wireframeLinecap + '; stroke-linejoin: ' + material.wireframeLinejoin;
+			style = 'fill:none;stroke:' + _color.getStyle() + ';stroke-width:' + material.wireframeLinewidth + ';stroke-opacity:' + material.opacity + ';stroke-linecap:' + material.wireframeLinecap + ';stroke-linejoin:' + material.wireframeLinejoin;
 
 		} else {
 
-			style = 'fill: ' + _color.getStyle() + '; fill-opacity: ' + material.opacity;
+			style = 'fill:' + _color.getStyle() + ';fill-opacity:' + material.opacity;
 
 		}
 
@@ -423,7 +423,6 @@ THREE.SVGRenderer = function () {
 
 		if ( _currStyle == style ) {
 
-			if ( _currPath ) _currPath += " ";
 			_currPath += path
 
 		} else {

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -350,12 +350,9 @@ THREE.SVGRenderer = function () {
 
 	function renderLine( v1, v2, element, material ) {
 
-		_svgNode = getLineNode( _lineCount ++ );
+		_svgNode = getPathNode( _pathCount ++ );
 
-		_svgNode.setAttribute( 'x1', v1.positionScreen.x );
-		_svgNode.setAttribute( 'y1', v1.positionScreen.y );
-		_svgNode.setAttribute( 'x2', v2.positionScreen.x );
-		_svgNode.setAttribute( 'y2', v2.positionScreen.y );
+		_svgNode.setAttribute( 'd', 'M ' + v1.positionScreen.x + ' ' + v1.positionScreen.y + ' L ' + v2.positionScreen.x + ' ' + v2.positionScreen.y );
 
 		if ( material instanceof THREE.LineBasicMaterial ) {
 

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -331,12 +331,9 @@ THREE.SVGRenderer = function () {
 			scaleY *= material.size;
 		}
 
-		_svgNode = getRectNode( _rectCount ++ );
+		_svgNode = getPathNode( _pathCount ++ );
 
-		_svgNode.setAttribute( 'x', v1.x - ( scaleX * 0.5 ) );
-		_svgNode.setAttribute( 'y', v1.y - ( scaleY * 0.5 ) );
-		_svgNode.setAttribute( 'width', scaleX );
-		_svgNode.setAttribute( 'height', scaleY );
+		_svgNode.setAttribute( 'd', 'M ' + ( v1.x - scaleX * 0.5 ) + ' ' + ( v1.y - scaleY * 0.5 ) + ' h ' + scaleX + ' v ' + scaleY + ' h ' + (-scaleX) + ' z' );
 
 		if ( material.isSpriteMaterial || material.isPointsMaterial ) {
 

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -44,8 +44,8 @@ THREE.SVGRenderer = function () {
 	_viewMatrix = new THREE.Matrix4(),
 	_viewProjectionMatrix = new THREE.Matrix4(),
 
-	_svgPathPool = [], _svgLinePool = [], _svgRectPool = [],
-	_svgNode, _pathCount = 0, _lineCount = 0, _rectCount = 0,
+	_svgPathPool = [],
+	_svgNode, _pathCount = 0,
 	_quality = 1;
 
 	this.domElement = _svg;
@@ -367,6 +367,7 @@ THREE.SVGRenderer = function () {
 		_this.info.render.faces ++;
 
 		_svgNode = getPathNode( _pathCount ++ );
+
 		_svgNode.setAttribute( 'd', 'M ' + v1.positionScreen.x + ' ' + v1.positionScreen.y + ' L ' + v2.positionScreen.x + ' ' + v2.positionScreen.y + ' L ' + v3.positionScreen.x + ',' + v3.positionScreen.y + 'z' );
 
 		if ( material instanceof THREE.MeshBasicMaterial ) {
@@ -419,26 +420,6 @@ THREE.SVGRenderer = function () {
 
 	}
 
-	function getLineNode( id ) {
-
-		if ( _svgLinePool[ id ] == null ) {
-
-			_svgLinePool[ id ] = document.createElementNS( 'http://www.w3.org/2000/svg', 'line' );
-
-			if ( _quality == 0 ) {
-
-				_svgLinePool[ id ].setAttribute( 'shape-rendering', 'crispEdges' ); //optimizeSpeed
-
-			}
-
-			return _svgLinePool[ id ];
-
-		}
-
-		return _svgLinePool[ id ];
-
-	}
-
 	function getPathNode( id ) {
 
 		if ( _svgPathPool[ id ] == null ) {
@@ -456,26 +437,6 @@ THREE.SVGRenderer = function () {
 		}
 
 		return _svgPathPool[ id ];
-
-	}
-
-	function getRectNode( id ) {
-
-		if ( _svgRectPool[ id ] == null ) {
-
-			_svgRectPool[ id ] = document.createElementNS( 'http://www.w3.org/2000/svg', 'rect' );
-
-			if ( _quality == 0 ) {
-
-				_svgRectPool[ id ].setAttribute( 'shape-rendering', 'crispEdges' ); //optimizeSpeed
-
-			}
-
-			return _svgRectPool[ id ];
-
-		}
-
-		return _svgRectPool[ id ];
 
 	}
 

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -46,7 +46,7 @@ THREE.SVGRenderer = function () {
 
 	_svgPathPool = [],
 	_svgNode, _pathCount = 0, _currPath, _currStyle,
-	_quality = 1, _precision = -1;
+	_quality = 1, _precision = null;
 
 	this.domElement = _svg;
 
@@ -134,7 +134,7 @@ THREE.SVGRenderer = function () {
 
 	function convert ( c ) {
 
-		return _precision < 0 ? c : c.toFixed(_precision);
+		return _precision !== null ? c.toFixed(_precision) : c;
 
 	}
 
@@ -241,7 +241,7 @@ THREE.SVGRenderer = function () {
 
 		}
 
-		addPath ( "!dummy!", ""); // just to flush last svg:path
+		flushPath(); // just to flush last svg:path
 
 		scene.traverseVisible( function ( object ) {
 
@@ -447,20 +447,27 @@ THREE.SVGRenderer = function () {
 
 		} else {
 
-			if ( _currPath ) {
-
-				_svgNode = getPathNode( _pathCount ++ );
-				_svgNode.setAttribute( 'd', _currPath );
-				_svgNode.setAttribute( 'style', _currStyle );
-				_svg.appendChild( _svgNode );
-
-			}
+			flushPath();
 
 			_currStyle = style;
 			_currPath = path;
 
 		}
 
+	}
+
+	function flushPath() {
+
+		if ( _currPath ) {
+
+			_svgNode = getPathNode( _pathCount ++ );
+			_svgNode.setAttribute( 'd', _currPath );
+			_svgNode.setAttribute( 'style', _currStyle );
+			_svg.appendChild( _svgNode );
+
+		}
+
+		_currPath = _currStyle = "";
 	}
 
 	function getPathNode( id ) {

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -46,7 +46,7 @@ THREE.SVGRenderer = function () {
 
 	_svgPathPool = [],
 	_svgNode, _pathCount = 0, _currPath, _currStyle,
-	_quality = 1;
+	_quality = 1, _precision = -1;
 
 	this.domElement = _svg;
 
@@ -104,6 +104,12 @@ THREE.SVGRenderer = function () {
 
 	};
 
+	this.setPrecision = function ( precision ) {
+
+		_precision = precision;
+
+	};
+
 	function removeChildNodes() {
 
 		_pathCount = 0;
@@ -123,6 +129,12 @@ THREE.SVGRenderer = function () {
 		if ( opacity === undefined || opacity === 1 ) return 'rgb(' + arg + ')';
 
 		return 'rgba(' + arg + ',' + opacity + ')';
+
+	}
+
+	function convert ( c ) {
+
+		return _precision < 0 ? c : c.toFixed(_precision);
 
 	}
 
@@ -342,7 +354,7 @@ THREE.SVGRenderer = function () {
 			scaleY *= material.size;
 		}
 
-		var path = 'M' + ( v1.x - scaleX * 0.5 ) + ',' + ( v1.y - scaleY * 0.5 ) + 'h' + scaleX + 'v' + scaleY + 'h' + (-scaleX) + 'z';
+		var path = 'M' + convert( v1.x - scaleX * 0.5 ) + ',' + convert( v1.y - scaleY * 0.5 ) + 'h' + convert( scaleX ) + 'v' + convert( scaleY ) + 'h' + convert(-scaleX) + 'z';
 		var style = "";
 
 		if ( material.isSpriteMaterial || material.isPointsMaterial ) {
@@ -357,7 +369,7 @@ THREE.SVGRenderer = function () {
 
 	function renderLine( v1, v2, element, material ) {
 
-		var path = 'M' + v1.positionScreen.x + ',' + v1.positionScreen.y + 'L' + v2.positionScreen.x + ',' + v2.positionScreen.y;
+		var path = 'M' + convert( v1.positionScreen.x ) + ',' + convert( v1.positionScreen.y ) + 'L' + convert( v2.positionScreen.x ) + ',' + convert( v2.positionScreen.y );
 
 		if ( material instanceof THREE.LineBasicMaterial ) {
 
@@ -374,7 +386,7 @@ THREE.SVGRenderer = function () {
 		_this.info.render.vertices += 3;
 		_this.info.render.faces ++;
 
-		var path = 'M' + v1.positionScreen.x + ',' + v1.positionScreen.y + 'L' + v2.positionScreen.x + ',' + v2.positionScreen.y + 'L' + v3.positionScreen.x + ',' + v3.positionScreen.y + 'z';
+		var path = 'M' + convert( v1.positionScreen.x ) + ',' + convert( v1.positionScreen.y ) + 'L' + convert( v2.positionScreen.x ) + ',' + convert( v2.positionScreen.y ) + 'L' + convert( v3.positionScreen.x ) + ',' + convert( v3.positionScreen.y ) + 'z';
 		var style = '';
 
 		if ( material instanceof THREE.MeshBasicMaterial ) {

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -107,8 +107,6 @@ THREE.SVGRenderer = function () {
 	function removeChildNodes() {
 
 		_pathCount = 0;
-		_lineCount = 0;
-		_rectCount = 0;
 
 		while ( _svg.childNodes.length > 0 ) {
 


### PR DESCRIPTION
Addresses first part of #11356

Main idea - always use svg:path for rect, line or triangle rendering.
If consequent elements have similar style, just concatenate them.
Plus several more optimizations:
- use less number of spaces
- use rgba() instead of separate fill-opacity or stroke-opacity parameters
- optionally precision of SVG coordinates can be configured

Depending from geometry, can speed up SVG generation by factor 20 and reduce SVG size by factor 4