### PR TITLE
Update files.js

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -277,9 +277,9 @@ var files = {
 	"webgl deferred": [
 		"webgldeferred_animation"
 	],
-	"webgl2": [
-		"webgl2_sandbox"
-	],
+	//"webgl2": [
+		//"webgl2_sandbox"
+	//],
 	"webvr": [
 		"webvr_cubes",
 		"webvr_daydream",


### PR DESCRIPTION
Removes `webgl2_sandbox` example from the list in order to avoid confusion, see #11363.