### PR TITLE
WebGLRenderer: added getPhysicalSize()

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -348,6 +348,9 @@
 		<h3>[method:Number getMaxAnisotropy]()</h3>
 		<div>This returns the anisotropy level of the textures.</div>
 
+		<h3>[method:Object getPhysicalSize]()</h3>
+		<div>Returns an object containing the width and height of the renderer's drawing buffer, in pixels.</div>
+
 		<h3>[method:number getPixelRatio]()</h3>
 		<div>Returns current device pixel ratio used.</div>
 
@@ -355,7 +358,7 @@
 		<div>This gets the precision used by the shaders. It returns "highp","mediump" or "lowp".</div>
 
 		<h3>[method:Object getSize]()</h3>
-		<div>Returns an object containing the width and height of the renderer's output canvas, in pixels.</div>
+		<div>Returns an object containing the logical width and height of the renderer's output canvas, in pixels.</div>
 
 		<h3>[method:null resetGLState]( )</h3>
 		<div>Reset the GL state to default. Called internally if the WebGL context is lost.</div>

--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -348,7 +348,7 @@
 		<h3>[method:Number getMaxAnisotropy]()</h3>
 		<div>This returns the anisotropy level of the textures.</div>
 
-		<h3>[method:Object getPhysicalSize]()</h3>
+		<h3>[method:Object getDrawingBufferSize]()</h3>
 		<div>Returns an object containing the width and height of the renderer's drawing buffer, in pixels.</div>
 
 		<h3>[method:number getPixelRatio]()</h3>
@@ -358,7 +358,7 @@
 		<div>This gets the precision used by the shaders. It returns "highp","mediump" or "lowp".</div>
 
 		<h3>[method:Object getSize]()</h3>
-		<div>Returns an object containing the logical width and height of the renderer's output canvas, in pixels.</div>
+		<div>Returns an object containing the width and height of the renderer's output canvas, in pixels.</div>
 
 		<h3>[method:null resetGLState]( )</h3>
 		<div>Reset the GL state to default. Called internally if the WebGL context is lost.</div>

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -415,11 +415,11 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	this.getPhysicalSize = function () {
+	this.getDrawingBufferSize = function () {
 
 		return {
-			width: _canvas.width,
-			height: _canvas.height
+			width: _width * _pixelRatio,
+			height: _height * _pixelRatio
 		};
 
 	};

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -415,6 +415,15 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	this.getPhysicalSize = function () {
+
+		return {
+			width: _canvas.width,
+			height: _canvas.height
+		};
+
+	};
+
 	this.setSize = function ( width, height, updateStyle ) {
 
 		_width = width;


### PR DESCRIPTION
Actually, this method could be renamed to `getDrawingBufferSize()`, as opposed to using the physical/logical nomenclature.

Also, I updated the docs. Those changes may be up for discussion, too.

This PR was posted in response to https://github.com/mrdoob/three.js/issues/10238#issuecomment-302981480.