### PR TITLE
SVGRenderer: produce string with HTML code instead of SVG elements creation

### DIFF
--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -22,7 +22,7 @@ THREE.SVGRenderer = function ( parameters ) {
 	var _this = this,
 	_renderData, _elements, _lights,
 	_projector = new THREE.Projector(),
-	_svg = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' ),
+	_svg = parameters.astext ? null : document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' ),
 	_svgWidth, _svgHeight, _svgWidthHalf, _svgHeightHalf,
 
 	_v1, _v2, _v3, _v4,
@@ -51,9 +51,12 @@ THREE.SVGRenderer = function ( parameters ) {
 
 	_currentPath, _currentStyle,
 
-	_quality = 1, _precision = parameters.precision !== undefined ? parameters.precision : null;
+	_quality = 1,
+	_precision = parameters.precision !== undefined ? parameters.precision : null,
+	_textSizeAttr = '', _textClearAttr = '', _accumulatedPath;
 
 	this.domElement = _svg;
+	if ( parameters.astext ) this.outerHTML = ""; // can be used to identify text mode
 
 	this.autoClear = true;
 	this.sortObjects = true;
@@ -100,9 +103,14 @@ THREE.SVGRenderer = function ( parameters ) {
 		_svgWidth = width; _svgHeight = height;
 		_svgWidthHalf = _svgWidth / 2; _svgHeightHalf = _svgHeight / 2;
 
-		_svg.setAttribute( 'viewBox', ( - _svgWidthHalf ) + ' ' + ( - _svgHeightHalf ) + ' ' + _svgWidth + ' ' + _svgHeight );
-		_svg.setAttribute( 'width', _svgWidth );
-		_svg.setAttribute( 'height', _svgHeight );
+		if ( _svg ) {
+			_svg.setAttribute( 'viewBox', ( - _svgWidthHalf ) + ' ' + ( - _svgHeightHalf ) + ' ' + _svgWidth + ' ' + _svgHeight );
+			_svg.setAttribute( 'width', _svgWidth );
+			_svg.setAttribute( 'height', _svgHeight );
+		} else {
+			_textSizeAttr = ' viewBox="' + ( - _svgWidthHalf ) + ' ' + ( - _svgHeightHalf ) + ' ' + _svgWidth + ' ' + _svgHeight + '" ' +
+					'width="' + _svgWidth + '" height="' + _svgHeight + '"';
+		}
 
 		_clipBox.min.set( - _svgWidthHalf, - _svgHeightHalf );
 		_clipBox.max.set( _svgWidthHalf, _svgHeightHalf );
@@ -116,6 +124,8 @@ THREE.SVGRenderer = function ( parameters ) {
 	};
 
 	function removeChildNodes() {
+
+		if ( ! _svg ) return;
 
 		_pathCount = 0;
 
@@ -146,7 +156,10 @@ THREE.SVGRenderer = function ( parameters ) {
 	this.clear = function () {
 
 		removeChildNodes();
-		_svg.style.backgroundColor = getSvgColor( _clearColor, _clearAlpha );
+		if ( _svg )
+			_svg.style.backgroundColor = getSvgColor( _clearColor, _clearAlpha );
+		else
+			_textClearAttr = ' style="background:' + getSvgColor( _clearColor, _clearAlpha ) + '"';
 
 	};
 
@@ -164,7 +177,10 @@ THREE.SVGRenderer = function ( parameters ) {
 		if ( background && background.isColor ) {
 
 			removeChildNodes();
-			_svg.style.backgroundColor = getSvgColor( background );
+			if ( _svg )
+				_svg.style.backgroundColor = getSvgColor( background );
+			else
+				_textClearAttr = ' style="background:' + getSvgColor( background ) + '"';
 
 		} else if ( this.autoClear === true ) {
 
@@ -190,6 +206,7 @@ THREE.SVGRenderer = function ( parameters ) {
 
 		_currentPath = '';
 		_currentStyle = '';
+		_accumulatedPath = '';
 
 		for ( var e = 0, el = _elements.length; e < el; e ++ ) {
 
@@ -263,13 +280,17 @@ THREE.SVGRenderer = function ( parameters ) {
 				var y = - _vector3.y * _svgHeightHalf;
 
 				var node = object.node;
-				node.setAttribute( 'transform', 'translate(' + x + ',' + y + ')' );
+				node.setAttribute( 'transform', 'translate(' + convert( x ) + ',' + convert( y ) + ')' );
 
-				_svg.appendChild( node );
+				if ( _svg ) _svg.appendChild( node );
+				else _accumulatedPath += node.outerHTML;
 
 			}
 
 		} );
+
+		if ( ! _svg )
+			this.outerHTML = '<svg xmlns="http://www.w3.org/2000/svg"' + _textSizeAttr  + _textClearAttr + '>' + _accumulatedPath + '</svg>';
 
 	};
 
@@ -469,10 +490,14 @@ THREE.SVGRenderer = function ( parameters ) {
 
 		if ( _currentPath ) {
 
-			_svgNode = getPathNode( _pathCount ++ );
-			_svgNode.setAttribute( 'd', _currentPath );
-			_svgNode.setAttribute( 'style', _currentStyle );
-			_svg.appendChild( _svgNode );
+			if ( _svg ) {
+				_svgNode = getPathNode( _pathCount ++ );
+				_svgNode.setAttribute( 'd', _currentPath );
+				_svgNode.setAttribute( 'style', _currentStyle );
+				_svg.appendChild( _svgNode );
+			} else {
+				_accumulatedPath += '<path style="' + _currentStyle + '" d="' + _currentPath + '"/>';
+			}
 
 		}
 

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -129,9 +129,17 @@ THREE.SVGRenderer = function ( parameters ) {
 
 		_pathCount = 0;
 
-		while ( _svg.childNodes.length > 0 ) {
+		if ( typeof _svg.innerHTML !== 'undefined' ) {
 
-			_svg.removeChild( _svg.childNodes[ 0 ] );
+			_svg.innerHTML = '';
+
+		} else {
+
+			while ( _svg.childNodes.length > 0 ) {
+
+				_svg.removeChild( _svg.childNodes[ 0 ] );
+
+			}
 
 		}
 

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -13,9 +13,11 @@ THREE.SVGObject = function ( node ) {
 THREE.SVGObject.prototype = Object.create( THREE.Object3D.prototype );
 THREE.SVGObject.prototype.constructor = THREE.SVGObject;
 
-THREE.SVGRenderer = function () {
+THREE.SVGRenderer = function ( parameters ) {
 
 	console.log( 'THREE.SVGRenderer', THREE.REVISION );
+
+	parameters = parameters || {};
 
 	var _this = this,
 	_renderData, _elements, _lights,
@@ -49,7 +51,7 @@ THREE.SVGRenderer = function () {
 
 	_currentPath, _currentStyle,
 
-	_quality = 1, _precision = null;
+	_quality = 1, _precision = parameters.precision !== undefined ? parameters.precision : null;
 
 	this.domElement = _svg;
 
@@ -450,7 +452,7 @@ THREE.SVGRenderer = function () {
 
 		if ( _currentStyle === style ) {
 
-			_currentPath += path
+			_currentPath += path;
 
 		} else {
 


### PR DESCRIPTION
Starting from certain level of complexity (~100K faces) creation of SVG elements dominates rendering time, especially with node.js and jsdom. In batch mode I only require SVG file, therefore usage of text mode will speed up significantly my performance.

Plus there is very large performance penalty of current SVGRenderer.clear() function. 
Just check with current code here:

https://jsfiddle.net/x8c3ubt7/

In my browser first rendering takes ~2.5 sec, while clear takes ~25 sec.
Usage of `element.innerHTML = ""` speeds up significantly.

Here same example, but with code provided in this PR:

https://jsfiddle.net/x8c3ubt7/1/

Clear time is only 0.3 seconds and SVG file is smaller (due to reduced precision)

And when using text mode, one can skip creation of HTML elements at all.
Or can use producing string to set innerHTML property directly:

https://jsfiddle.net/x8c3ubt7/2/

Produced string can be used to create SVG elements directly:

    var renderer = new THREE.SVGRenderer( { astext:true } );
    renderer.setSize( window.innerWidth, window.innerHeight );
    renderer.render( scene, camera );
    var elem = document.createElement('div');
    elem.innerHTML = renderer.outerHTML;

