### PR TITLE
ColladaLoader2: Added orthographic camera support

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -771,7 +771,21 @@ THREE.ColladaLoader.prototype = {
 					break;
 
 				case 'orthographic':
-					camera = new THREE.OrthographicCamera( /* TODO */ );
+					var ymag = data.optics.parameters.ymag;
+					var xmag = data.optics.parameters.xmag;
+					var aspectRatio = data.optics.parameters.aspect_ratio;
+
+					xmag = ( xmag === undefined ) ? ( ymag * aspectRatio ) : xmag;
+					ymag = ( ymag === undefined ) ? ( xmag / aspectRatio ) : ymag;
+
+					xmag *= 0.5;
+					ymag *= 0.5;
+
+					camera = new THREE.OrthographicCamera(
+						- xmag, xmag, ymag, - ymag, // left, right, top, bottom
+						data.optics.parameters.znear,
+						data.optics.parameters.zfar
+					);
 					break;
 
 				default:


### PR DESCRIPTION
I'd like to pimp `ColladaLoader2` a little bit. This PR enhances the `buildCamera()` function so orthographic cameras are now supported.