### PR TITLE
ColladaLoader2: Added axis conversion support

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -1314,8 +1314,7 @@ THREE.ColladaLoader.prototype = {
 
 					case 'scale':
 						var array = parseFloats( child.textContent );
-						convertVector3( vector.fromArray( array ), 1 );
-						data.matrix.scale( vector );
+						data.matrix.scale( convertVector3( vector.fromArray( array ), 1 ) );
 						break;
 
 					case 'extra':

--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -1515,6 +1515,8 @@ THREE.ColladaLoader.prototype = {
 
 		// conversion
 
+		var convertVector3;
+
 		function setupConversion() {
 
 			if ( scope.options.convertUpAxis === true ) {
@@ -1522,15 +1524,29 @@ THREE.ColladaLoader.prototype = {
 				switch ( asset.upAxis ) {
 
 					case 'X_UP':
-						asset.upConversion = 'X-Y';
+						convertVector3 = function ( vector, sign ) {
+							if ( sign === undefined ) sign = - 1;
+							var tmp = vector.x;
+							vector.x = sign * vector.y;
+							vector.y = tmp;
+							return vector;
+						};
 						break;
 
 					case 'Y_UP':
-						asset.upConversion = 'NONE';
+						convertVector3 = function ( vector, sign ) {
+							return vector;
+						};
 						break;
 
 					case 'Z_UP':
-						asset.upConversion = 'Z-Y';
+						convertVector3 = function ( vector, sign ) {
+							if ( sign === undefined ) sign = - 1;
+							var tmp = vector.y;
+							vector.y = vector.z;
+							vector.z = sign * tmp;
+							return vector;
+						};
 						break;
 
 					default:
@@ -1539,40 +1555,6 @@ THREE.ColladaLoader.prototype = {
 				}
 
 			}
-
-		}
-
-		function convertVector3( vector, sign ) {
-
-			if ( sign === undefined ) sign = - 1;
-
-			if ( scope.options.convertUpAxis === true ) {
-
-				switch ( asset.upConversion ) {
-
-					case 'X-Y':
-						var tmp = vector.x;
-						vector.x = sign * vector.y;
-						vector.y = tmp;
-						break;
-
-					case 'Z-Y':
-						var tmp = vector.y;
-						vector.y = vector.z;
-						vector.z = sign * tmp;
-						break;
-
-					case 'NONE':
-						break;
-
-					default:
-						console.error( 'THREE.ColladaLoader: Invalid up axis conversion:', asset.upAxis );
-
-				}
-
-			}
-
-			return vector;
 
 		}
 

--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -1518,9 +1518,7 @@ THREE.ColladaLoader.prototype = {
 
 		function setupConversion() {
 
-			var options = scope.options;
-
-			if ( options.convertUpAxis === true ) {
+			if ( scope.options.convertUpAxis === true ) {
 
 				switch ( asset.upAxis ) {
 


### PR DESCRIPTION
This PR introduces axis conversion support for `ColladaLoader2`. So when the user sets the option `.convertUpAxis` to `true`, the loader will automatically convert the data to the `three.js` standard (`Y_UP`).

The example shows the default Blender starter scene (mesh, point light, camera, `Z_UP`) with correct position and orientation.