### PR TITLE
SkeletonHelper: update() renamed onBeforeRender()

### DIFF
--- a/docs/api/helpers/SkeletonHelper.html
+++ b/docs/api/helpers/SkeletonHelper.html
@@ -63,11 +63,6 @@ scene.add( helper );
 		This is called automatically to generate a list of bones from the object passed in the constructor.
 		</div>
 
-		<h3>[method:null update]()</h3>
-		<div>
-		Update the helper. Call in the render loop if animating the model.
-		</div>
-
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/scenes/bones-browser.html
+++ b/docs/scenes/bones-browser.html
@@ -253,8 +253,6 @@
 
 				}
 
-				skeletonHelper.update();
-
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_animation_skinning_blending.html
+++ b/examples/webgl_animation_skinning_blending.html
@@ -524,10 +524,10 @@
 
 				}
 
-				// Update the animation mixer, the skeleton and the stats panel, and render this frame
+				// Update the animation mixer, the stats panel, and render this frame
 
 				mixer.update( mixerUpdateDelta );
-				skeleton.update();
+
 				stats.update();
 
 				renderer.render( scene, camera );

--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -655,8 +655,9 @@
 				camera.lookAt( scene.position );
 
 				if( mixer ) {
+
 					mixer.update( delta );
-					helper.update();
+
 				}
 
 				renderer.render( scene, camera );

--- a/examples/webgl_loader_bvh.html
+++ b/examples/webgl_loader_bvh.html
@@ -101,7 +101,6 @@
 				var delta = clock.getDelta();
 
 				if ( mixer ) mixer.update( delta );
-				if ( skeletonHelper ) skeletonHelper.update();
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_x.html
+++ b/examples/webgl_loader_x.html
@@ -261,8 +261,6 @@
 
             }
 
-            if (Models != null && Models.length > 0 && skeletonHelper != null) { skeletonHelper.update(); }
-
             stats.update();
             render();
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -54,7 +54,7 @@ function SkeletonHelper( object ) {
 	this.matrix = object.matrixWorld;
 	this.matrixAutoUpdate = false;
 
-	this.update();
+	this.onBeforeRender();
 
 }
 
@@ -82,14 +82,14 @@ SkeletonHelper.prototype.getBoneList = function( object ) {
 
 };
 
-SkeletonHelper.prototype.update = function () {
+SkeletonHelper.prototype.onBeforeRender = function () {
 
 	var vector = new Vector3();
 
 	var boneMatrix = new Matrix4();
 	var matrixWorldInv = new Matrix4();
 
-	return function update() {
+	return function onBeforeRender() {
 
 		var geometry = this.geometry;
 		var position = geometry.getAttribute( 'position' );
@@ -122,5 +122,10 @@ SkeletonHelper.prototype.update = function () {
 
 }();
 
+SkeletonHelper.prototype.update = function () {
+
+	// backwards compatability
+
+};
 
 export { SkeletonHelper };


### PR DESCRIPTION
With this change, `sheletonHelper.update()` no longer needs to be called in the render loop.

This coding pattern was proposed by @mrdoob in https://github.com/mrdoob/three.js/pull/11382#issuecomment-304104490.