### PR TITLE
allow index attributes to be dropped using index.onUpload() mechanism.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -784,11 +784,14 @@ function WebGLRenderer( parameters ) {
 		}
 
 		var renderer = bufferRenderer;
+		var indexProperties;
 
 		if ( index !== null ) {
 
+			indexProperties = attributes.get( index );
+
 			renderer = indexedBufferRenderer;
-			renderer.setIndex( index );
+			renderer.setIndex( indexProperties );
 
 		}
 
@@ -798,7 +801,7 @@ function WebGLRenderer( parameters ) {
 
 			if ( index !== null ) {
 
-				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attributes.get( index ).buffer );
+				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, indexProperties.buffer );
 
 			}
 

--- a/src/renderers/webgl/WebGLIndexedBufferRenderer.js
+++ b/src/renderers/webgl/WebGLIndexedBufferRenderer.js
@@ -14,24 +14,10 @@ function WebGLIndexedBufferRenderer( gl, extensions, infoRender ) {
 
 	var type, size;
 
-	function setIndex( index ) {
+	function setIndex( indexProperties ) {
 
-		if ( index.array instanceof Uint32Array && extensions.get( 'OES_element_index_uint' ) ) {
-
-			type = gl.UNSIGNED_INT;
-			size = 4;
-
-		} else if ( index.array instanceof Uint16Array ) {
-
-			type = gl.UNSIGNED_SHORT;
-			size = 2;
-
-		} else {
-
-			type = gl.UNSIGNED_BYTE;
-			size = 1;
-
-		}
+		type = indexProperties.type;
+		size = indexProperties.bytesPerElement;
 
 	}
 


### PR DESCRIPTION
allow index attribute typed arrays to be dropped from javascript memory after upload to GPU.

Removes check of OES_index_element_uint, AFAICS if this check fails the index is treated as a byte array which won't produce the expected results anyway.