### PR TITLE
FBXLoader: Fixed check of  material type

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -421,7 +421,7 @@
 
 		var material;
 
-		switch ( type ) {
+		switch ( type.toLowerCase() ) {
 
 			case 'phong':
 				material = new THREE.MeshPhongMaterial();


### PR DESCRIPTION
I've noticed that Blender (2.74) exports FBX files with material types written like this `Phong`. `FBXLoader` currently assumes that the `type` value is written in lowercase. Therefore this PR introduces a little fix in `.parseMaterial()` that converts the type string to lowercase letters so the material is parsed correctly.

/ping @takahirox for review

[FBX File (Blender Export).zip](https://github.com/mrdoob/three.js/files/1038792/test.zip)
