### PR TITLE
Fixed document typo

### DIFF
--- a/docs/api/constants/CustomBlendingEquations.html
+++ b/docs/api/constants/CustomBlendingEquations.html
@@ -22,7 +22,7 @@
 		material.blending = THREE.CustomBlending;
 		material.blendEquation = THREE.AddEquation; //default
 		material.blendSrc = THREE.SrcAlphaFactor; //default
-		material.blendDst = THREE.OneMinusDstAlphaFactor; //default
+		material.blendDst = THREE.OneMinusSrcAlphaFactor; //default
 		</code>
 
 		<h2>Blending Equations</h2>


### PR DESCRIPTION
`material.blendDst` should be `THREE.OneMinusSrcAlphaFactor` by default