### PR TITLE
IE: An extra object in data.children in ObjectLoader.parseObject #11432

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -765,9 +765,11 @@ Object.assign( ObjectLoader.prototype, {
 
 			if ( data.children !== undefined ) {
 				
-				for( var i=0; i<data.children.length; i++){
+				var children = data.children;
+				
+				for ( var  i = 0; i < children.length; i ++ ) {
 					
-					object.add( this.parseObject( data.children[i], geometries, materials );
+					object.add( this.parseObject( children[ i ], geometries, materials );
 						   
 				}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -765,11 +765,10 @@ Object.assign( ObjectLoader.prototype, {
 
 			if ( data.children !== undefined ) {
 
-				for ( var child in data.children ) {
-
-					object.add( this.parseObject( data.children[ child ], geometries, materials ) );
-
-				}
+				var that = this;
+				data.children.forEach(function(index, child){
+					object.add( that.parseObject( data.children[ child ], geometries, materials ) );
+				});
 
 			}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -766,7 +766,7 @@ Object.assign( ObjectLoader.prototype, {
 			if ( data.children !== undefined ) {
 				
 				data.children.forEach(function(child){
-					object.add( this.parseObject( data.children[ child ], geometries, materials ) );
+					object.add( this.parseObject( child, geometries, materials ) );
 				}, this);
 
 			}

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -764,11 +764,10 @@ Object.assign( ObjectLoader.prototype, {
 			if ( data.userData !== undefined ) object.userData = data.userData;
 
 			if ( data.children !== undefined ) {
-
-				var that = this;
-				data.children.forEach(function(index, child){
-					object.add( that.parseObject( data.children[ child ], geometries, materials ) );
-				});
+				
+				data.children.forEach(function(child){
+					object.add( this.parseObject( data.children[ child ], geometries, materials ) );
+				}, this);
 
 			}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -765,9 +765,11 @@ Object.assign( ObjectLoader.prototype, {
 
 			if ( data.children !== undefined ) {
 				
-				data.children.forEach(function(child){
-					object.add( this.parseObject( child, geometries, materials ) );
-				}, this);
+				for( var i=0; i<data.children.length; i++){
+					
+					object.add( this.parseObject( data.children[i], geometries, materials );
+						   
+				}
 
 			}
 


### PR DESCRIPTION
Were changed the way of iterating over data.children array in Objectoader.parseObject. Works fine for me. But there is another solution, for example

```js
for ( var child in data.children ) {
    if (data.children.hasOwnProperty(child)) {
        object.add( this.parseObject( data.children[ child ], geometries, materials ) );
    }
}
```

Fixes #11432