### PR TITLE
Fix geometry.mergeMesh & merge check bug

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -700,7 +700,7 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 	merge: function ( geometry, matrix, materialIndexOffset ) {
 
-		if ( ( geometry && geometry.isGeometry ) === false ) {
+		if ( !geometry || !geometry.isGeometry ) {
 
 			console.error( 'THREE.Geometry.merge(): geometry not an instance of THREE.Geometry.', geometry );
 			return;

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -820,7 +820,7 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 	mergeMesh: function ( mesh ) {
 
-		if ( ( mesh && mesh.isMesh ) === false ) {
+		if ( !mesh || !mesh.isMesh ) {
 
 			console.error( 'THREE.Geometry.mergeMesh(): mesh not an instance of THREE.Mesh.', mesh );
 			return;


### PR DESCRIPTION
```(mesh && mesh.isMesh)```  will return mesh.isMesh, it maybe undefined.
```(geometry && geometry.isGeometry)```  is the same situation.