### PR TITLE
Update Textures.html

### DIFF
--- a/docs/api/constants/Textures.html
+++ b/docs/api/constants/Textures.html
@@ -33,9 +33,14 @@
 		[page:Constant CubeReflectionMapping] is the default for a [page:CubeTexture CubeTexture]. <br /><br />
 
 		[page:Constant EquirectangularReflectionMapping] and [page:Constant EquirectangularRefractionMapping]
-		are for use with an equirectangular environment map.<br /><br />
+		are for use with an equirectangular environment map.  Also called a lat-long map, an equirectangular 
+		texture represents a 360-degree view along the horizontal centerline, and a 180-degree view along the 
+		vertical axis, with the top and bottom edges of the image corresponding to the north and south poles 
+		of a mapped sphere.<br /><br />
 
-		[page:Constant SphericalReflectionMapping] is for use with a spherical reflection map.<br /><br />
+		[page:Constant SphericalReflectionMapping] is for use with a spherical reflection map such as may be obtained
+		by cropping a photograph of a mirrored ball.  Sphere maps will be rendered "facing" the camera, irrespective
+		of the position of the camera relative to the cubemapped object or surface.<br /><br />
 
 		See the [example:webgl_materials_envmaps materials / envmaps] example.
 		</div>


### PR DESCRIPTION
Disambiguation re: https://github.com/mrdoob/three.js/issues/11367#issuecomment-306245201
Clearly describe the expected format of each type of cubemap image, and the resulting render.  The Cube*Mapping settings were detailed explicitly enough, but users coming from other contexts may know the other two by different names.  E.g. in the popular Unity and Unreal game engines, "spherical" reflection and HDRI maps implicitly mean lat-long.