### PR TITLE
Improve Object3D `add` and `remove`

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -335,7 +335,7 @@ Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 			this.children.push( object );
 
 			object.dispatchEvent( { type: 'added' } );
-			this.dispatchEvent( { type: 'add', child: object } );
+			this.dispatchEvent( { type: 'childAdded', child: object } );
 
 		} else {
 
@@ -367,7 +367,7 @@ Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 			this.children.splice( index, 1 );
 
 			object.dispatchEvent( { type: 'removed' } );
-			this.dispatchEvent( { type: 'remove', child: object } );
+			this.dispatchEvent( { type: 'childRemoved', child: object } );
 
 		}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -332,9 +332,10 @@ Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 			}
 
 			object.parent = this;
-			object.dispatchEvent( { type: 'added' } );
-
 			this.children.push( object );
+
+			object.dispatchEvent( { type: 'added' } );
+			this.dispatchEvent( { type: 'add', child: object } );
 
 		} else {
 
@@ -363,10 +364,10 @@ Object.assign( Object3D.prototype, EventDispatcher.prototype, {
 		if ( index !== - 1 ) {
 
 			object.parent = null;
+			this.children.splice( index, 1 );
 
 			object.dispatchEvent( { type: 'removed' } );
-
-			this.children.splice( index, 1 );
+			this.dispatchEvent( { type: 'remove', child: object } );
 
 		}
 

--- a/test/unit/src/core/Object3D.js
+++ b/test/unit/src/core/Object3D.js
@@ -80,3 +80,45 @@ QUnit.test( "getWorldRotation" , function( assert ) {
 	obj.lookAt(new THREE.Vector3(1, 0, 0));
 	assert.numEqual( obj.getWorldRotation().y * RadToDeg, 90, "y is equal" );
 });
+
+QUnit.test( "add" , function( assert ) {
+	assert.expect( 14 );
+
+	var parent = new THREE.Object3D();
+	var child = new THREE.Object3D();
+
+	function parentAdd() {
+		assert.success( "parent dispatches 'add' event when adding a child" );
+		assert.strictEqual( parent.children[0], child, "parent has child when 'add' event dispatched" );
+		assert.strictEqual( parent, child.parent, "child has parent when 'add' event dispatched" );
+	}
+
+	function parentRemove() {
+		assert.success( "parent dispatches 'remove' event when removing a child" );
+		assert.strictEqual( parent.children.length, 0, "child removed from parent when 'remove' event dispatched" );
+		assert.strictEqual( child.parent, null, "child has no parent when 'remove' event dispatched" );
+	}
+
+	function childAdded() {
+		assert.success( "child dispatches 'added' event when adding to a parent object" );
+		assert.strictEqual( parent.children[0], child, "parent has child when 'added' event dispatched" );
+		assert.strictEqual( parent, child.parent, "child has parent when 'added' event dispatched" );
+	}
+
+	function childRemoved() {
+		assert.success( "child dispatches 'removed' event when removing from parent" );
+		assert.strictEqual( parent.children.length, 0, "child removed from parent when 'removed' event dispatched" );
+		assert.strictEqual( child.parent, null, "child has no parent when 'removed' event dispatched" );
+	}
+
+	parent.addEventListener( "add", parentAdd );
+	parent.addEventListener( "remove", parentRemove );
+	parent.addEventListener( "add", childAdded );
+	parent.addEventListener( "remove", childRemoved );
+
+	parent.add( child );
+	assert.strictEqual( parent.children[0], child, "parent has child after parent.add( child )" );
+	assert.strictEqual( parent, child.parent, "child has parent after parent.add( child )" );
+
+	parent.remove( child );
+});

--- a/test/unit/src/core/Object3D.js
+++ b/test/unit/src/core/Object3D.js
@@ -82,43 +82,51 @@ QUnit.test( "getWorldRotation" , function( assert ) {
 });
 
 QUnit.test( "add" , function( assert ) {
-	assert.expect( 14 );
+	assert.expect( 16 );
 
 	var parent = new THREE.Object3D();
 	var child = new THREE.Object3D();
 
-	function parentAdd() {
-		assert.success( "parent dispatches 'add' event when adding a child" );
+	function parentAdd( evt ) {
+		assert.success( "parent dispatches 'childAdded' event when adding a child" );
+		assert.strictEqual( evt.child, child, "childAdded event passes child object" );
 		assert.strictEqual( parent.children[0], child, "parent has child when 'add' event dispatched" );
 		assert.strictEqual( parent, child.parent, "child has parent when 'add' event dispatched" );
 	}
 
-	function parentRemove() {
-		assert.success( "parent dispatches 'remove' event when removing a child" );
+	function parentRemove( evt ) {
+		assert.success( "parent dispatches 'childRemoved' event when removing a child" );
+		assert.strictEqual( evt.child, child, "childRemoved event passes child object" );
 		assert.strictEqual( parent.children.length, 0, "child removed from parent when 'remove' event dispatched" );
 		assert.strictEqual( child.parent, null, "child has no parent when 'remove' event dispatched" );
 	}
 
-	function childAdded() {
+	function childAdd() {
 		assert.success( "child dispatches 'added' event when adding to a parent object" );
 		assert.strictEqual( parent.children[0], child, "parent has child when 'added' event dispatched" );
 		assert.strictEqual( parent, child.parent, "child has parent when 'added' event dispatched" );
 	}
 
-	function childRemoved() {
+	function childRemove() {
 		assert.success( "child dispatches 'removed' event when removing from parent" );
 		assert.strictEqual( parent.children.length, 0, "child removed from parent when 'removed' event dispatched" );
 		assert.strictEqual( child.parent, null, "child has no parent when 'removed' event dispatched" );
 	}
 
-	parent.addEventListener( "add", parentAdd );
-	parent.addEventListener( "remove", parentRemove );
-	parent.addEventListener( "add", childAdded );
-	parent.addEventListener( "remove", childRemoved );
+	parent.addEventListener( "childAdded", parentAdd );
+	parent.addEventListener( "childRemoved", parentRemove );
+	child.addEventListener( "added", childAdd );
+	child.addEventListener( "removed", childRemove );
 
 	parent.add( child );
 	assert.strictEqual( parent.children[0], child, "parent has child after parent.add( child )" );
 	assert.strictEqual( parent, child.parent, "child has parent after parent.add( child )" );
 
 	parent.remove( child );
+
+	// clean up
+	parent.removeEventListener( "childAdded", parentAdd );
+	parent.removeEventListener( "childRemoved", parentRemove );
+	child.removeEventListener( "add", childAdd );
+	child.removeEventListener( "removed", childRemove );
 });


### PR DESCRIPTION
- Dispatch "add" and "remove" events on parents in addition to child so new child objects can be monitored
- Moved "added" and "removed" dispatch after children array is modified so the operation is complete before the event fires
- Added unit test for all the above