### PR TITLE
Fix syntax error on older builds of IE11

### DIFF
--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -93,7 +93,7 @@ Object.assign( BufferGeometryLoader.prototype, {
 var TYPED_ARRAYS = {
 	Int8Array: Int8Array,
 	Uint8Array: Uint8Array,
-	Uint8ClampedArray: Uint8ClampedArray,
+	Uint8ClampedArray: typeof Uint8ClampedArray !== 'undefined' ? Uint8ClampedArray : Uint8Array,
 	Int16Array: Int16Array,
 	Uint16Array: Uint16Array,
 	Int32Array: Int32Array,


### PR DESCRIPTION
Issue: #11440 
Fix syntax error on older version of IE11 (prior `KB2929437`) where `Uint8ClampedArray` is not supported.

Before:
<img width="1434" alt="screen shot 2017-06-07 at 22 24 01" src="https://user-images.githubusercontent.com/61326/26901600-b8b539d4-4bd6-11e7-9d6d-9c3eafde0e20.png">

After:
<img width="1426" alt="screen shot 2017-06-07 at 22 44 08" src="https://user-images.githubusercontent.com/61326/26901606-bf199a90-4bd6-11e7-9b5d-5e5b00059f51.png">

