### PR TITLE
Add uniform type for SAMPLER_EXTERNAL_OES uniform types

### DIFF
--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -245,7 +245,7 @@ function getSingularSetter( type ) {
 		case 0x8b5b: return setValue3fm; // _MAT3
 		case 0x8b5c: return setValue4fm; // _MAT4
 
-		case 0x8b5e: return setValueT1; // SAMPLER_2D
+		case 0x8b5e: case 0x8d66: return setValueT1; // SAMPLER_2D, SAMPLER_EXTERNAL_OES
 		case 0x8b60: return setValueT6; // SAMPLER_CUBE
 
 		case 0x1404: case 0x8b56: return setValue1i; // INT, BOOL


### PR DESCRIPTION
This uniform setter is for non-standard browser usage (forked versions of Chromium) using video textures and would be a huge help in our development process. Thanks!

https://www.khronos.org/registry/OpenGL/extensions/OES/OES_EGL_image_external.txt