### PR TITLE
Optimize GPUParticleSystem.geometryUpdate

### DIFF
--- a/examples/js/GPUParticleSystem.js
+++ b/examples/js/GPUParticleSystem.js
@@ -461,6 +461,7 @@ THREE.GPUParticleContainer = function( maxParticles, particleSystem ) {
 				sizeAttribute.updateRange.offset = 0;
 				lifeTimeAttribute.updateRange.offset = 0;
 
+				// Use -1 to update the entire buffer, see https://github.com/mrdoob/three.js/pull/11476
 				positionStartAttribute.updateRange.count = -1;
 				startTimeAttribute.updateRange.count = -1;
 				velocityAttribute.updateRange.count = -1;

--- a/examples/js/GPUParticleSystem.js
+++ b/examples/js/GPUParticleSystem.js
@@ -461,13 +461,13 @@ THREE.GPUParticleContainer = function( maxParticles, particleSystem ) {
 				sizeAttribute.updateRange.offset = 0;
 				lifeTimeAttribute.updateRange.offset = 0;
 
-				positionStartAttribute.updateRange.count = positionStartAttribute.count;
-				startTimeAttribute.updateRange.count = startTimeAttribute.count;
-				velocityAttribute.updateRange.count = velocityAttribute.count;
-				turbulenceAttribute.updateRange.count = turbulenceAttribute.count;
-				colorAttribute.updateRange.count = colorAttribute.count;
-				sizeAttribute.updateRange.count = sizeAttribute.count;
-				lifeTimeAttribute.updateRange.count = lifeTimeAttribute.count;
+				positionStartAttribute.updateRange.count = -1;
+				startTimeAttribute.updateRange.count = -1;
+				velocityAttribute.updateRange.count = -1;
+				turbulenceAttribute.updateRange.count = -1;
+				colorAttribute.updateRange.count = -1;
+				sizeAttribute.updateRange.count = -1;
+				lifeTimeAttribute.updateRange.count = -1;
 
 			}
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -89,7 +89,7 @@ function WebGLAttributes( gl ) {
 			gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
 				array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
 
-			updateRange.count = 0; // reset range
+			updateRange.count = -1; // reset range
 
 		}
 


### PR DESCRIPTION
```positionStartAttribute.updateRange.count = positionStartAttribute.count;``` 
The range count should be ```positionStartAttribute.count * positionStartAttribute.itemSize ```

And set count to -1 will call ```gl.bufferSubData( bufferType, 0, array );``` directly.
if set count to array length , it will call array.subarray. 