### PR TITLE
Fixed error handling in FBXLoader

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -58,7 +58,7 @@
 
 				try {
 
-					var scene = self.parse( buffer, resourceDirectory );
+					var scene = self.parse( buffer, resourceDirectory, url );
 
 					onLoad( scene );
 
@@ -86,7 +86,7 @@
 		 * @param {string} resourceDirectory - Directory to load external assets (e.g. textures ) from.
 		 * @returns {THREE.Group}
 		 */
-		parse: function ( FBXBuffer, resourceDirectory ) {
+		parse: function ( FBXBuffer, resourceDirectory, url ) {
 
 			var FBXTree;
 
@@ -100,14 +100,14 @@
 
 				if ( ! isFbxFormatASCII( FBXText ) ) {
 
-					self.manager.itemError( url );
+					this.manager.itemError( url );
 					throw new Error( 'FBXLoader: Unknown format.' );
 
 				}
 
 				if ( getFbxVersion( FBXText ) < 7000 ) {
 
-					self.manager.itemError( url );
+					this.manager.itemError( url );
 					throw new Error( 'FBXLoader: FBX version not supported for file at ' + url + ', FileVersion: ' + getFbxVersion( FBXText ) );
 
 				}


### PR DESCRIPTION
The error handling in FBXLoader doesn’t work as intended because of two little mistakes:

1.
In `FBXLoader.parse` the variable `self` doesn’t point to the loader but to the window object (since it has not been set to the value of `this`). In these places `this` could be used directly (as opposed to the `.load` function, where the reference is used inside a `window.setTimeout`, so that the correct scope has to be stored in a variable there).

2.
The variable `url`, which is used for the error messages, is undefined in `.parse`, because it is not passed when `.parse` is called by `.load`.
