### PR TITLE
[gltf] Sanitize node names.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2540,6 +2540,12 @@ THREE.GLTF2Loader = ( function () {
 
 			}
 
+			if ( _node.name !== undefined ) {
+
+				_node.name = THREE.PropertyBinding.sanitizeNodeName( _node.name );
+
+			}
+
 			if ( node.extras ) _node.userData = node.extras;
 
 			if ( node.matrix !== undefined ) {

--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -102,6 +102,19 @@ Object.assign( PropertyBinding, {
 
 	},
 
+	/**
+	 * Replaces spaces with underscores and removes unsupported characters from
+	 * node names, to ensure compatibility with parseTrackName().
+	 *
+	 * @param  {string} name Node name to be sanitized.
+	 * @return {string}
+	 */
+	sanitizeNodeName: function ( name ) {
+
+		return name.replace( /\s/g, '_' ).replace( /[^\w-]/g, '' );
+
+	},
+
 	parseTrackName: function () {
 
 		// Parent directories, delimited by '/' or ':'. Currently unused, but must

--- a/test/unit/src/animation/PropertyBinding.js
+++ b/test/unit/src/animation/PropertyBinding.js
@@ -198,3 +198,25 @@ QUnit.test( 'parseTrackName' , function( assert ) {
 
 	} );
 });
+
+QUnit.test( 'sanitizeNodeName' , function( assert ) {
+
+	assert.equal(
+		THREE.PropertyBinding.sanitizeNodeName( 'valid-name-123_' ),
+		'valid-name-123_',
+		'Leaves valid name intact.'
+	);
+
+	assert.equal(
+		THREE.PropertyBinding.sanitizeNodeName( 'space separated name 123_ -' ),
+		'space_separated_name_123__-',
+		'Replaces spaces with underscores.'
+	);
+
+	assert.equal(
+		THREE.PropertyBinding.sanitizeNodeName( '"invalid" name %123%_' ),
+		'invalid_name_123_',
+		'Strips invalid characters.'
+	);
+
+} );


### PR DESCRIPTION
Resolves issues with the `Dog.gltf` model in #11460.

![doggo](https://user-images.githubusercontent.com/1848368/27015888-1c40825c-4ece-11e7-8114-8260b526a7a9.gif)
