### PR TITLE
add getRenderLists() method to WebGLRenderer

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -214,7 +214,7 @@
 
 		<h3>[property:WebGLRenderLists renderLists]</h3>
 		<div>
-		Internal object handling ordering of scene object rendering.
+		Used internally to handle ordering of scene object rendering.
 		</div>
 
 		<h3>[property:WebGLShadowMap shadowMap]</h3>

--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -212,6 +212,11 @@
 		Used internally by the renderer to keep track of various sub object properties.
 		</div>
 
+		<h3>[property:WebGLRenderLists renderLists]</h3>
+		<div>
+		Internal object handling ordering of scene object rendering.
+		</div>
+
 		<h3>[property:WebGLShadowMap shadowMap]</h3>
 		<div>
 		This contains the reference to the shadow map, if used.
@@ -353,9 +358,6 @@
 
 		<h3>[method:string getPrecision]()</h3>
 		<div>This gets the precision used by the shaders. It returns "highp","mediump" or "lowp".</div>
-
-		<h3>[method:WebGLRenderLists getRenderLists]()</h3>
-		<div>Returns the renderer's internal WebGLRenderLists object.</div>
 
 		<h3>[method:Object getSize]()</h3>
 		<div>Returns an object containing the width and height of the renderer's output canvas, in pixels.</div>

--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -354,6 +354,9 @@
 		<h3>[method:string getPrecision]()</h3>
 		<div>This gets the precision used by the shaders. It returns "highp","mediump" or "lowp".</div>
 
+		<h3>[method:WebGLRenderLists getRenderLists]()</h3>
+		<div>Returns the renderer's internal WebGLRenderLists object.</div>
+
 		<h3>[method:Object getSize]()</h3>
 		<div>Returns an object containing the width and height of the renderer's output canvas, in pixels.</div>
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -343,6 +343,7 @@ function WebGLRenderer( parameters ) {
 	this.capabilities = capabilities;
 	this.extensions = extensions;
 	this.properties = properties;
+	this.renderLists = renderLists;
 	this.state = state;
 
 	// shadow map
@@ -403,12 +404,6 @@ function WebGLRenderer( parameters ) {
 		_pixelRatio = value;
 
 		this.setSize( _width, _height, false );
-
-	};
-
-	this.getRenderLists = function () {
-
-		return renderLists;
 
 	};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -406,6 +406,12 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	this.getRenderLists = function () {
+
+		return renderLists;
+
+	};
+
 	this.getSize = function () {
 
 		return {


### PR DESCRIPTION

Allows internal renderer WebGLRendererLists to be accessed.

This allows: _renderer.getRenderLists().dispose()_  to be used to release references to scene objects that are no longer in use but may be retained on the heap.

Ref issue #11478 
