### PR TITLE
[gltf] Use opaque alpha mode by default.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1262,6 +1262,12 @@ THREE.GLTF2Loader = ( function () {
 		32926: 'SAMPLE_ALPHA_TO_COVERAGE'
 	};
 
+	var ALPHA_MODES = {
+		OPAQUE: 'OPAQUE',
+		MASK: 'MASK',
+		BLEND: 'BLEND'
+	};
+
 	/* UTILITY FUNCTIONS */
 
 	function _each( object, callback, thisObj ) {
@@ -1951,6 +1957,14 @@ THREE.GLTF2Loader = ( function () {
 
 						materialParams.map = dependencies.textures[ metallicRoughness.baseColorTexture.index ];
 
+						var alphaMode = metallicRoughness.baseColorTexture.alphaMode || ALPHA_MODES.OPAQUE;
+
+						if ( alphaMode !== ALPHA_MODES.OPAQUE ) {
+
+							materialParams.transparent = true;
+
+						}
+
 					}
 
 					materialParams.metalness = metallicRoughness.metallicFactor !== undefined ? metallicRoughness.metallicFactor : 1.0;
@@ -1976,11 +1990,7 @@ THREE.GLTF2Loader = ( function () {
 
 				}
 
-				if ( materialParams.opacity !== undefined && materialParams.opacity < 1.0 ||
-							( materialParams.map !== undefined &&
-							( materialParams.map.format === THREE.AlphaFormat ||
-								 materialParams.map.format === THREE.RGBAFormat ||
-								 materialParams.map.format === THREE.LuminanceAlphaFormat ) ) ) {
+				if ( materialParams.opacity !== undefined && materialParams.opacity < 1.0 ) {
 
 					materialParams.transparent = true;
 


### PR DESCRIPTION
See: https://github.com/KhronosGroup/glTF-WebGL-PBR/issues/20

@takahirox it sounds like transparency in PNGs should be ignored by default, and only applied if the `alphaMode` is set to something other than OPAQUE.

| Before | After |
|--|--|
|  ![screen shot 2017-06-12 at 7 45 52 pm](https://user-images.githubusercontent.com/1848368/27063702-1f33fda6-4fa8-11e7-92d1-0d3af733f378.png)  |  ![screen shot 2017-06-12 at 7 45 42 pm](https://user-images.githubusercontent.com/1848368/27063703-21c3c2a4-4fa8-11e7-97fb-a7b0914e1aa7.png)  |

^Fins are should be opaque, in this example, because `alphaMode` is not set at all, and defaults to OPAQUE.