### PR TITLE
Support wrap mode of texture in FBXLoader

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -362,6 +362,18 @@
 		texture.name = name;
 		texture.FBX_ID = FBX_ID;
 
+		var wrapModeU = textureNode.properties.WrapModeU;
+		var wrapModeV = textureNode.properties.WrapModeV;
+
+		var valueU = wrapModeU !== undefined ? wrapModeU.value : 0;
+		var valueV = wrapModeV !== undefined ? wrapModeV.value : 0;
+
+		// http://download.autodesk.com/us/fbx/SDKdocs/FBX_SDK_Help/files/fbxsdkref/class_k_fbx_texture.html#889640e63e2e681259ea81061b85143a
+		// 0: repeat(default), 1: clamp
+
+		texture.wrapS = valueU === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+		texture.wrapT = valueV === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+
 		loader.setPath( currentPath );
 
 		return texture;


### PR DESCRIPTION
This PR lets `FBXLoader` support wrap mode for texture and fixes #11467

According to [this page](http://download.autodesk.com/us/fbx/SDKdocs/FBX_SDK_Help/files/fbxsdkref/class_k_fbx_texture.html#889640e63e2e681259ea81061b85143a), seems like `wrapModeU/V.value` => 0: repeat, 1: clamp,
and default value would be 0 because the FBX file @llwslc shared doesn't include `wrapModeU/V` but
it requires texture being repeat wrap mode.
