### PR TITLE
Update envmap_fragment.glsl

### DIFF
--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -30,7 +30,7 @@
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 
 		vec2 sampleUV;
-		sampleUV.y = saturate( flipNormal * reflectVec.y * 0.5 + 0.5 );
+		sampleUV.y = asin( flipNormal * reflectVec.y) * RECIPROCAL_PI + 0.5;
 		sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * RECIPROCAL_PI2 + 0.5;
 		vec4 envColor = texture2D( envMap, sampleUV );
 


### PR DESCRIPTION
Per https://github.com/mrdoob/three.js/issues/11367#issuecomment-308303716
Equirectangular U sampling update to intuitively equiangular-per-raster sampling.

A quick visual test shows no change from the old version, which worries me a bit, since I'm not getting the trig-on-paper to give identical results.  If the math DOES work out provably identically, the original version is certainly more efficient.

Edit: Ok, I'm dumb.  Was looking at a straight-up UV-mapped skysphere, not an actual reflection map :-P  Change in a proper reflection is subtle, but I think it's there.