### PR TITLE
Create Texture.html

### DIFF
--- a/docs/api/textures/Texture.html
+++ b/docs/api/textures/Texture.html
@@ -130,12 +130,21 @@
 		<h3>[property:Vector2 offset]</h3>
 		<div>
 		How much a single repetition of the texture is offset from the beginning, in each direction U and V.
-		Typical range is *0.0* to *1.0*.
+		Typical range is *0.0* to *1.0*.  _Note:_ The offset property is a convenience modifier and only affects 
+		the Texture's application to the first set of UVs on a model.  If the Texture is used as a map requiring
+		additional UV sets (e.g. the aoMap or lightMap of most stock materials), those UVs must be manually 
+		assigned to achieve the desired offset.
 		</div>
 
 		<h3>[property:Vector2 repeat]</h3>
 		<div>
-		How many times the texture is repeated across the surface, in each direction U and V.
+		How many times the texture is repeated across the surface, in each direction U and V.  If repeat is set 
+		greater than 1 in either direction, the corresponding Wrap parameter should also be set to 
+		[page:Textures THREE.RepeatWrapping] or [page:Textures THREE.MirroredRepeatWrapping] to achieve the desired 
+		tiling effect.  _Note:_ The repeat property is a convenience modifier and only affects 
+		the Texture's application to the first set of UVs on a model.  If the Texture is used as a map requiring
+		additional UV sets (e.g. the aoMap or lightMap of most stock materials), those UVs must be manually 
+		assigned to achieve the desired repetiton.
 		</div>
 
 		<h3>[property:boolean generateMipmaps]</h3>


### PR DESCRIPTION
Per https://github.com/mrdoob/three.js/issues/11505#issuecomment-308270666
Clarifying properties that only apply under certain conditions.  Also adding a common-sense note regarding repeat settings, since Clamp tends to be the Wrap method default and that does affect Repeat behavior.

I was going to queue up an additional series of changes to clarify lightMap and aoMap in the individual material pages, but it looks like there is already a reference to multiple UVs in at least the aoMap section of https://github.com/mrdoob/three.js/blob/dev/docs/api/materials/MeshBasicMaterial.html source html that isn't on the live page yet.  Is someone else going through and adding those, or should I proceed?  No sense in 2 people making the same edits...