### PR TITLE
Modify subcameras positions in the arraycamera example

### DIFF
--- a/examples/webgl_camera_array.html
+++ b/examples/webgl_camera_array.html
@@ -26,7 +26,7 @@
 
 			function init() {
 
-				var AMOUNT = 6;
+				var AMOUNT = 5;
 				var SIZE = 1 / AMOUNT;
 				var ASPECT_RATIO = window.innerWidth / window.innerHeight;
 
@@ -36,13 +36,14 @@
 
 					for ( var x = 0; x < AMOUNT; x ++ ) {
 
+						var xx = x / AMOUNT;
+						var yy = 1 - ( ( y + 1 ) / AMOUNT ); // TODO Make this saner in WebGLRenderer?
+
 						var subcamera = new THREE.PerspectiveCamera( 40, ASPECT_RATIO, 0.1, 10 );
-						subcamera.bounds = new THREE.Vector4( x / AMOUNT, y / AMOUNT, SIZE, SIZE );
-						subcamera.position.x = ( x / AMOUNT ) - 0.5;
-						subcamera.position.y = 0.5 - ( y / AMOUNT );
-						subcamera.position.z = 1.5;
-						subcamera.position.multiplyScalar( 2 );
-						subcamera.lookAt( new THREE.Vector3() );
+						subcamera.bounds = new THREE.Vector4( xx, yy, SIZE, SIZE );
+						subcamera.position.x = ( ( AMOUNT - 1 ) / 2 - x ) * 0.2;
+						subcamera.position.y = ( ( AMOUNT - 1 ) / 2 - y ) * 0.2;
+						subcamera.position.z = 3;
 						subcamera.updateMatrixWorld();
 						cameras.push( subcamera );
 


### PR DESCRIPTION
Just a slight modification on the array camera example to move each camera to make it obvious that each square represents a completely different camera not just duplicating the same one.

![image](https://user-images.githubusercontent.com/782511/27155807-a438087c-515a-11e7-9af9-0f6bc8a5c9e8.png)
