### PR TITLE
ColladaLoader2: Removed unnecessary clone

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -2345,7 +2345,7 @@ THREE.ColladaLoader.prototype = {
 
 			for ( var i = 0, l = nodes.length; i < l; i ++ ) {
 
-				objects.push( getNode( nodes[ i ] ).clone() );
+				objects.push( getNode( nodes[ i ] ) );
 
 			}
 


### PR DESCRIPTION
A certain call of `.clone()` is actually not necessary when processing the visual scene. It's only important to create new objects for `<instance_*>` childs of a node like lights, cameras or meshes.