### PR TITLE
Added ArrayFrustum

### DIFF
--- a/src/cameras/ArrayCamera.js
+++ b/src/cameras/ArrayCamera.js
@@ -3,6 +3,100 @@
  */
 
 import { PerspectiveCamera } from './PerspectiveCamera';
+import { Frustum } from '../math/Frustum';
+
+function ArrayFrustum() {
+
+	this.frustumList = [];
+
+}
+
+ArrayFrustum.prototype = Object.assign( Object.create( Frustum.prototype ), {
+
+	constructor: ArrayFrustum,
+
+	intersectsObject: function ( object ) {
+
+		for ( var i = 0; i < this.frustumList.length; ++i ) {
+
+			if ( this.frustumList[i].intersectsObject( object ) ) {
+
+				return true;
+
+			}
+
+		}
+
+		return false;
+
+	},
+
+	intersectsSprite: function ( sprite ) {
+
+		for ( var i = 0; i < this.frustumList.length; ++i ) {
+
+			if ( this.frustumList[i].intersectsSprite( sprite ) ) {
+
+				return true;
+
+			}
+
+		}
+
+		return false;
+
+	},
+
+	intersectsSphere: function ( sphere ) {
+
+		for ( var i = 0; i < this.frustumList.length; ++i ) {
+
+			if ( this.frustumList[i].intersectsSphere( sphere ) ) {
+
+				return true;
+
+			}
+
+		}
+
+		return false;
+
+	},
+
+	intersectsBox: function ( box ) {
+
+		for ( var i = 0; i < this.frustumList.length; ++i ) {
+
+			if ( this.frustumList[i].intersectsBox( box ) ) {
+
+				return true;
+
+			}
+
+		}
+
+		return false;
+
+	},
+
+	containsPoint: function ( point ) {
+
+		for ( var i = 0; i < this.frustumList.length; ++i ) {
+
+			if ( this.frustumList[i].containsPoint( point ) ) {
+
+				return true;
+
+			}
+
+		}
+
+		return false;
+
+	}
+
+} );
+
 
 function ArrayCamera( array ) {
 
@@ -16,7 +110,33 @@ ArrayCamera.prototype = Object.assign( Object.create( PerspectiveCamera.prototyp
 
 	constructor: ArrayCamera,
 
-	isArrayCamera: true
+	isArrayCamera: true,
+
+	_cullingVolume: null,
+
+	getCullingVolume: function () {
+
+		return function getCullingVolume() {
+
+			if (! this._cullingVolume ) {
+
+				this._cullingVolume = new ArrayFrustum();
+
+			}
+
+			this._cullingVolume.frustumList.length = this.cameras.length;
+
+			for ( var i = 0; i < this.cameras.length; ++i ) {
+
+				this._cullingVolume.frustumList[ i ] = this.cameras[ i ].getCullingVolume();
+
+			}
+
+			return this._cullingVolume;
+
+		};
+
+	}()
 
 } );
 

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -8,6 +8,7 @@ import { Matrix4 } from '../math/Matrix4';
 import { Quaternion } from '../math/Quaternion';
 import { Object3D } from '../core/Object3D';
 import { Vector3 } from '../math/Vector3';
+import { Frustum } from '../math/Frustum';
 
 function Camera() {
 
@@ -26,6 +27,8 @@ Camera.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	isCamera: true,
 
+	_cullingVolume: null,
+	
 	copy: function ( source, recursive ) {
 
 		Object3D.prototype.copy.call( this, source, recursive );
@@ -65,8 +68,24 @@ Camera.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		return new this.constructor().copy( this );
 
-	}
+	},
 
+	getCullingVolume: function () {
+
+		var projScreenMatrix = new Matrix4();
+
+		return function getCullingVolume() {
+
+			if (!this._cullingVolume) {
+				this._cullingVolume = new Frustum();
+			}
+
+			projScreenMatrix.multiplyMatrices( this.projectionMatrix, this.matrixWorldInverse );
+
+			return this._cullingVolume.setFromMatrix( projScreenMatrix );
+
+		}
+	}()
 } );
 
 export { Camera };

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -145,7 +145,7 @@ function WebGLRenderer( parameters ) {
 
 		// frustum
 
-		_frustum = new Frustum(),
+		_cullingVolume = null,
 
 		// clipping
 
@@ -1132,7 +1132,7 @@ function WebGLRenderer( parameters ) {
 		}
 
 		_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-		_frustum.setFromMatrix( _projScreenMatrix );
+		_cullingVolume = camera.getCullingVolume();
 
 		lights.length = 0;
 		sprites.length = 0;
@@ -1276,7 +1276,7 @@ function WebGLRenderer( parameters ) {
 
 	function isSphereViewable( sphere ) {
 
-		if ( ! _frustum.intersectsSphere( sphere ) ) return false;
+		if ( ! _cullingVolume.intersectsSphere( sphere ) ) return false;
 
 		var numPlanes = _clipping.numPlanes;
 
@@ -1314,7 +1314,7 @@ function WebGLRenderer( parameters ) {
 
 			} else if ( object.isSprite ) {
 
-				if ( ! object.frustumCulled || _frustum.intersectsSprite( object ) ) {
+				if ( ! object.frustumCulled || _cullingVolume.intersectsSprite( object ) ) {
 
 					sprites.push( object );
 
@@ -1343,7 +1343,7 @@ function WebGLRenderer( parameters ) {
 
 				}
 
-				if ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) {
+				if ( ! object.frustumCulled || _cullingVolume.intersectsObject( object ) ) {
 
 					if ( sortObjects ) {
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -160,13 +160,6 @@ function WebVRManager( renderer ) {
 		cameraL.projectionMatrix.fromArray( frameData.leftProjectionMatrix );
 		cameraR.projectionMatrix.fromArray( frameData.rightProjectionMatrix );
 
-		// HACK @mrdoob
-		// https://github.com/w3c/webvr/issues/203
-
-		cameraVR.projectionMatrix.copy( cameraL.projectionMatrix );
-
-		//
-
 		var layers = device.getLayers();
 
 		if ( layers.length ) {


### PR DESCRIPTION
*Credit for this code goes to @toji (https://github.com/mrdoob/three.js/issues/10927#issuecomment-287930720) I've just slightly modified it.*

I just wanted to kick off the implementation as right now the `ArrayCamera` example (daydream) is using just the right frustum for culling both eyes.

Basically the idea behind this is to forget about using the frustum directly in the `WebGLRenderer` to use a `cullingVolume` instead. 
The `cullingVolume` could be implemented in several ways depending on the kind of camera/cameras.

By default we've added `getCullingVolume` to `Camera`, and it replaces basically the previous code from the renderer (https://github.com/mrdoob/three.js/blob/dev/src/renderers/WebGLRenderer.js#L1134). Probably we could just pass the `projScreenMatrix` instead of compute it again, as we already have it on the renderer.
On the other hand `ArrayCamera` uses `ArrayFrustum` as its default `cullingVolume`, and basically it's an array with the frustums of each subcamera and it overrides the frustum methods to test against each frustum in the array.

Of course is not the most optimal way to check against a combined frustum like for example on stereo rendering, but it just works as a default generic use case.

After that we could keep adding optimized version of the `getCullingVolume`. For example for stereo rendering with WebVR we could generate the combined frustum and test just one time against it. That could be done on the `WebVRManager`.


