### PR TITLE
[gltf] Fix parsing of Bone nodes.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2531,28 +2531,34 @@ THREE.GLTF2Loader = ( function () {
 		var extensions = this.extensions;
 		var scope = this;
 
+		var nodes = json.nodes || [];
+
+		// Nothing in the node definition indicates whether it is a Bone or an
+		// Object3D. So, traverse the hierarchy once in advance, using node.skins
+		// references to mark bones.
+		nodes.forEach( function ( node ) {
+
+			if ( node.skin !== undefined ) {
+
+				json.skins[ node.skin ].joints.forEach( function ( id ) {
+
+					nodes[ id ].isBone = true;
+
+				} );
+
+			}
+
+		} );
+
 		return _each( json.nodes, function ( node ) {
 
 			var matrix = new THREE.Matrix4();
 
-			var _node;
+			var _node = node.isBone === true ? new THREE.Bone() : new THREE.Object3D();
 
-			if ( node.jointName ) {
+			if ( node.name !== undefined ) {
 
-				_node = new THREE.Bone();
-				_node.name = node.name !== undefined ? node.name : node.jointName;
-				_node.jointName = node.jointName;
-
-			} else {
-
-				_node = new THREE.Object3D();
-				if ( node.name !== undefined ) _node.name = node.name;
-
-			}
-
-			if ( _node.name !== undefined ) {
-
-				_node.name = THREE.PropertyBinding.sanitizeNodeName( _node.name );
+				_node.name = THREE.PropertyBinding.sanitizeNodeName( node.name );
 
 			}
 

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2532,21 +2532,17 @@ THREE.GLTF2Loader = ( function () {
 		var scope = this;
 
 		var nodes = json.nodes || [];
+		var skins = json.skins || [];
 
 		// Nothing in the node definition indicates whether it is a Bone or an
-		// Object3D. So, traverse the hierarchy once in advance, using node.skins
-		// references to mark bones.
-		nodes.forEach( function ( node ) {
+		// Object3D. Use the skins' joint references to mark bones.
+		skins.forEach( function ( skin ) {
 
-			if ( node.skin !== undefined ) {
+			skin.joints.forEach( function ( id ) {
 
-				json.skins[ node.skin ].joints.forEach( function ( id ) {
+				nodes[ id ].isBone = true;
 
-					nodes[ id ].isBone = true;
-
-				} );
-
-			}
+			} );
 
 		} );
 


### PR DESCRIPTION
Fun fact: apparently all the animated examples still work if their bones are turned to `Object3D`.

But SkeletonHelper is less happy, so this fixes that.

![404e2547-c421-4eea-a237-bdc7ff97c599-67635-000250d3b29d7255](https://user-images.githubusercontent.com/1848368/27209934-b90e2a8e-5203-11e7-9853-31f1d6a3c59d.gif)
