### PR TITLE
Allow right clicking when TrackballControls are disabled

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -579,6 +579,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	function contextmenu( event ) {
 
+		if ( _this.enabled === false ) return;
+
 		event.preventDefault();
 
 	}


### PR DESCRIPTION
I was hoping that I could disable the TrackballControls so that I could right click and "Save Image", but this event handler was missing the enabled check.