### PR TITLE
CSS3D Sandbox example: Vary element opacity

### DIFF
--- a/examples/css3d_sandbox.html
+++ b/examples/css3d_sandbox.html
@@ -66,7 +66,7 @@
 					var element = document.createElement( 'div' );
 					element.style.width = '100px';
 					element.style.height = '100px';
-					element.style.opacity = 0.5;
+					element.style.opacity = ( i < 5 ) ? 0.5 : 1;
 					element.style.background = new THREE.Color( Math.random() * 0xffffff ).getStyle();
 
 					var object = new THREE.CSS3DObject( element );


### PR DESCRIPTION
Add visual interest. It appears to render without artifacts, too.