### PR TITLE
SceneUtils: Added up axis conversion support

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -6,6 +6,9 @@
 THREE.ColladaLoader = function ( manager ) {
 
 	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+	this.options = {
+		convertUpAxis: false
+	};
 
 };
 
@@ -27,16 +30,6 @@ THREE.ColladaLoader.prototype = {
 			onLoad( scope.parse( text, resourceDirectory ) );
 
 		}, onProgress, onError );
-
-	},
-
-	options: {
-
-		set convertUpAxis( value ) {
-
-			console.log( 'THREE.ColladaLoader.options.convertUpAxis: TODO' );
-
-		}
 
 	},
 
@@ -2660,9 +2653,13 @@ THREE.ColladaLoader.prototype = {
 
 		var scene = parseScene( getElementsByTagName( collada, 'scene' )[ 0 ] );
 
-		if ( asset.upAxis === 'Z_UP' ) {
+		if ( this.options.convertUpAxis === true ) {
 
-			scene.rotation.x = - Math.PI / 2;
+			if ( asset.upAxis === 'Z_UP' ) {
+
+				THREE.SceneUtils.convertFromZUp( scene, animations );
+
+			}
 
 		}
 

--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -58,20 +58,20 @@ var SceneUtils = {
 			0,   0,   0,   1
 		);
 
-		var converter = new CoordSystemConverter( matrix );
+		var converter = new BasisConverter( matrix );
 		converter.convert( root, animations );
 
 	}
 
 };
 
-function CoordSystemConverter( matrix ) {
+function BasisConverter( matrix ) {
 
 	this.matrix = matrix;
 
 }
 
-Object.assign( CoordSystemConverter.prototype, {
+Object.assign( BasisConverter.prototype, {
 
 	convert: function ( root, animations ) {
 

--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -268,9 +268,9 @@ Object.assign( UpAxisConverter.prototype, {
 
 					break;
 
-				}
+			}
 
-			};
+		};
 
 	} (),
 

--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -1,9 +1,13 @@
+import { Vector3 } from '../math/Vector3';
+import { Quaternion } from '../math/Quaternion';
 import { Matrix4 } from '../math/Matrix4';
 import { Mesh } from '../objects/Mesh';
 import { Group } from '../objects/Group';
+import { PropertyBinding } from '../animation/PropertyBinding';
 
 /**
  * @author alteredq / http://alteredqualia.com/
+ * @author Mugen87 / https://github.com/Mugen87
  */
 
 var SceneUtils = {
@@ -37,9 +41,240 @@ var SceneUtils = {
 		scene.remove( child );
 		parent.add( child );
 
+	},
+
+	convertFromZUp: function ( root, animations ) {
+
+		// see https://gamedev.stackexchange.com/a/7932
+
+		var conversionMatrix = new Matrix4().set(
+			1,   0,   0,   0,
+			0,   0,   1,   0,
+			0, - 1,   0,   0,
+			0,   0,   0,   1
+		);
+
+		var converter = new UpAxisConverter( conversionMatrix );
+		converter.convert( root, animations );
+
 	}
 
 };
+
+// up axis converter
+
+function UpAxisConverter( conversionMatrix ) {
+
+	this.conversionMatrix = conversionMatrix;
+
+}
+
+Object.assign( UpAxisConverter.prototype, {
+
+	convert: function ( root, animations ) {
+
+		var scope = this;
+
+		root.traverse( function( object ) {
+
+			// position, quaternion, scale
+
+			scope.convertMatrix4( object.matrix );
+			object.matrix.decompose( object.position, object.quaternion, object.scale );
+
+			// geometry
+
+			var geometry = object.geometry;
+
+			if ( geometry !== undefined &&  geometry.isBufferGeometry === true ) {
+
+				var position = geometry.attributes.position;
+				var normal = geometry.attributes.normal;
+
+				if ( position !== null ) scope.conversionMatrix.applyToBufferAttribute( position );
+				if ( normal !== null ) scope.conversionMatrix.applyToBufferAttribute( normal );
+
+			}
+
+			// skinned mesh
+
+			if ( object.isSkinnedMesh ) {
+
+				scope.convertMatrix4( object.bindMatrix );
+				scope.convertMatrix4( object.bindMatrixInverse );
+
+				var boneInverses = object.skeleton.boneInverses;
+
+				for ( var i = 0, il = boneInverses.length; i < il; i ++ ) {
+
+					scope.convertMatrix4( boneInverses[ i ] );
+
+				}
+
+				// bones are already converted within the scene hierarchy
+
+			}
+
+		} );
+
+		// animations
+
+		if ( animations !== undefined ) {
+
+			for ( var i = 0, il = animations.length; i < il; i ++ ) {
+
+				var clip = animations[ i ];
+				var tracks = clip.tracks;
+
+				for ( var j = 0, jl = tracks.length; j < jl; j ++ ) {
+
+					this.convertKeyframeTrack( tracks[ j ] );
+
+				}
+
+			}
+
+		}
+
+	},
+
+	convertMatrix4: function() {
+
+		var xAxis = new Vector3();
+		var yAxis = new Vector3();
+		var zAxis = new Vector3();
+		var translation = new Vector3();
+
+		return function convertMatrix4( matrix ) {
+
+			// columns first
+
+			xAxis.setFromMatrixColumn( matrix, 0 );
+			yAxis.setFromMatrixColumn( matrix, 1 );
+			zAxis.setFromMatrixColumn( matrix, 2 );
+			translation.setFromMatrixColumn( matrix, 3 );
+
+			xAxis.applyMatrix4( this.conversionMatrix );
+			yAxis.applyMatrix4( this.conversionMatrix );
+			zAxis.applyMatrix4( this.conversionMatrix );
+
+			matrix.set(
+				xAxis.x, yAxis.x, zAxis.x, 0,
+				xAxis.y, yAxis.y, zAxis.y, 0,
+				xAxis.z, yAxis.z, zAxis.z, 0,
+				0,       0,       0,       1
+			);
+
+			// then rows
+
+			matrix.transpose();
+
+			xAxis.setFromMatrixColumn( matrix, 0 );
+			yAxis.setFromMatrixColumn( matrix, 1 );
+			zAxis.setFromMatrixColumn( matrix, 2 );
+
+			xAxis.applyMatrix4( this.conversionMatrix );
+			yAxis.applyMatrix4( this.conversionMatrix );
+			zAxis.applyMatrix4( this.conversionMatrix );
+
+			matrix.set(
+				xAxis.x, yAxis.x, zAxis.x, 0,
+				xAxis.y, yAxis.y, zAxis.y, 0,
+				xAxis.z, yAxis.z, zAxis.z, 0,
+				0,       0,       0,       1
+			);
+
+			matrix.transpose();
+
+			// translation at the end
+
+			translation.applyMatrix4( this.conversionMatrix );
+
+			matrix.elements[ 12 ] = translation.x;
+			matrix.elements[ 13 ] = translation.y;
+			matrix.elements[ 14 ] = translation.z;
+
+			return matrix;
+
+		};
+
+	} (),
+
+	convertKeyframeTrack: function() {
+
+		var vector = new Vector3();
+		var quaternion = new Quaternion();
+		var rotationMatrix = new Matrix4();
+
+		return function convertKeyframeTrack( track ) {
+
+			var result = PropertyBinding.parseTrackName( track.name );
+			var propertyName = result.propertyName;
+
+			var values = track.values;
+			var stride = track.values.length / track.times.length;
+
+			var i, il, j, jl;
+
+			switch ( propertyName ) {
+
+				case 'position':
+
+					for ( i = 0, il = values.length; i < il; i += stride ) {
+
+						vector.fromArray( values, i ).applyMatrix4( this.conversionMatrix );
+
+						for ( j = 0, jl = stride; j < jl; j ++ ) {
+
+							values[ i + j ] = vector.getComponent( j );
+
+						}
+
+					}
+
+					break;
+
+				case 'scale':
+
+					for ( i = 0, il = values.length; i < il; i += stride ) {
+
+						vector.fromArray( values, i ).applyMatrix4( this.conversionMatrix );
+
+						for ( j = 0, jl = stride; j < jl; j ++ ) {
+
+							values[ i + j ] =  Math.abs( vector.getComponent( j ) );
+
+						}
+
+					}
+
+					break;
+
+				case 'quaternion':
+
+					for ( i = 0, il = values.length; i < il; i += stride ) {
+
+						quaternion.fromArray( values, i );
+						rotationMatrix.makeRotationFromQuaternion( quaternion );
+						this.convertMatrix4( rotationMatrix );
+						quaternion.setFromRotationMatrix( rotationMatrix );
+
+						values[ i + 0 ] = quaternion.x;
+						values[ i + 1 ] = quaternion.y;
+						values[ i + 2 ] = quaternion.z;
+						values[ i + 3 ] = quaternion.w;
+
+					}
+
+					break;
+
+				}
+
+			};
+
+	} (),
+
+} );
 
 
 export { SceneUtils };

--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -71,7 +71,7 @@ function BasisConverter( matrix ) {
 	this.matrix = matrix;
 
 	// because the change-of-basis matrix is orthonormal, the inverse of
-	// this.matrix is the transposition of this.matrix
+	// this.matrix is its transposition
 
 	this.matrixInverse = this.matrix.clone().transpose();
 

--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -212,7 +212,8 @@ Object.assign( UpAxisConverter.prototype, {
 			var propertyName = result.propertyName;
 
 			var values = track.values;
-			var stride = track.values.length / track.times.length;
+			var times = track.times;
+			var stride = values.length / times.length;
 
 			var i, il, j, jl;
 

--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -45,10 +45,8 @@ var SceneUtils = {
 
 	convertFromZUp: function ( root, animations ) {
 
-		// see https://gamedev.stackexchange.com/a/7932
-
-		// this matrix will change the coordinate system of an object hierarchy and
-		// animations (optional) from right-handed Z-up to right-handed Y-up
+		// this change-of-basis matrix performs a change-of basis from right-handed Z-up to right-handed Y-up
+		// for a given object hierarchy and animations (optional)
 
 		var matrix = new Matrix4().set(
 			1,   0,   0,   0,
@@ -71,7 +69,7 @@ function BasisConverter( matrix ) {
 	this.matrix = matrix;
 
 	// because the change-of-basis matrix is orthonormal, the inverse of
-	// this.matrix is its transposition
+	// this.matrix is its transpose
 
 	this.matrixInverse = this.matrix.clone().transpose();
 

--- a/src/extras/SceneUtils.js
+++ b/src/extras/SceneUtils.js
@@ -1,6 +1,7 @@
 import { Vector3 } from '../math/Vector3';
 import { Quaternion } from '../math/Quaternion';
 import { Matrix4 } from '../math/Matrix4';
+import { Matrix3 } from '../math/Matrix3';
 import { Mesh } from '../objects/Mesh';
 import { Group } from '../objects/Group';
 import { PropertyBinding } from '../animation/PropertyBinding';
@@ -91,8 +92,20 @@ Object.assign( UpAxisConverter.prototype, {
 				var position = geometry.attributes.position;
 				var normal = geometry.attributes.normal;
 
-				if ( position !== null ) scope.conversionMatrix.applyToBufferAttribute( position );
-				if ( normal !== null ) scope.conversionMatrix.applyToBufferAttribute( normal );
+				var conversionMatrix = scope.conversionMatrix;
+
+				if ( position !== null ) {
+
+					conversionMatrix.applyToBufferAttribute( position );
+
+				}
+
+				if ( normal !== null ) {
+
+					var normalMatrix = new Matrix3().setFromMatrix4( conversionMatrix );
+					normalMatrix.applyToBufferAttribute( normal );
+
+				}
 
 			}
 


### PR DESCRIPTION
This PR introduces `SceneUtils.convertFromZUp()` that converts the up axis of a hierarchy of objects and corresponding animations to the `three.js` standard (`Y up`). I've developed this in a way, so it is easy to create more conversion methods. You only have to define a conversion matrix and create a new instance of `UpAxisConverter`. Just have a look at the implementation of `SceneUtils. convertFromZUp()`.