### PR TITLE
Matrix4.lookAt(): accommodate z-up edge case

### DIFF
--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -340,9 +340,19 @@ Object.assign( Matrix4.prototype, {
 
 			if ( x.lengthSq() === 0 ) {
 
-				// eye and target are in the same vertical
+				// up and z are parallel
 
-				z.z += 0.0001;
+				if ( Math.abs( up.z ) === 1 ) {
+
+					z.x += 0.0001;
+
+				} else {
+
+					z.z += 0.0001;
+
+				}
+
+				z.normalize();
 				x.crossVectors( up, z );
 
 			}


### PR DESCRIPTION
`lookAt()` is ill-defined when the look-direction is the same as -- or parallel to -- the up-direction. We do something arbitrary, but not unreasonable.

Fixes #11436