### PR TITLE
[gltf] Implement KHR_lights options.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -350,7 +350,7 @@ THREE.GLTF2Loader = ( function () {
 
 				if ( light.quadraticAttenuation !== undefined ) {
 
-					console.warn( 'GLTF2Loader: light.quadraticAttenuation not currently supported.' );
+					lightNode.decay = light.quadraticAttenuation;
 
 				}
 
@@ -362,7 +362,7 @@ THREE.GLTF2Loader = ( function () {
 
 				if ( light.fallOffExponent !== undefined ) {
 
-					lightNode.decay = light.fallOffExponent;
+					console.warn( 'GLTF2Loader: light.fallOffExponent not currently supported.' );
 
 				}
 

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -336,6 +336,36 @@ THREE.GLTF2Loader = ( function () {
 
 			if ( lightNode ) {
 
+				if ( light.constantAttenuation !== undefined ) {
+
+					lightNode.intensity = light.constantAttenuation;
+
+				}
+
+				if ( light.linearAttenuation !== undefined ) {
+
+					lightNode.distance = 1 / light.linearAttenuation;
+
+				}
+
+				if ( light.quadraticAttenuation !== undefined ) {
+
+					console.warn( 'GLTF2Loader: light.quadraticAttenuation not currently supported.' );
+
+				}
+
+				if ( light.fallOffAngle !== undefined ) {
+
+					lightNode.angle = light.fallOffAngle;
+
+				}
+
+				if ( light.fallOffExponent !== undefined ) {
+
+					lightNode.decay = light.fallOffExponent;
+
+				}
+
 				lightNode.name = light.name || ( 'light_' + lightId );
 				this.lights[ lightId ] = lightNode;
 
@@ -2767,13 +2797,11 @@ THREE.GLTF2Loader = ( function () {
 					}
 
 					if ( node.extensions
-							 && node.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ]
-							 && node.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ].light ) {
+							 && node.extensions[ EXTENSIONS.KHR_LIGHTS ]
+							 && node.extensions[ EXTENSIONS.KHR_LIGHTS ].light !== undefined ) {
 
-						var extensionLights = extensions[ EXTENSIONS.KHR_LIGHTS ].lights;
-						var light = extensionLights[ node.extensions[ EXTENSIONS.KHR_LIGHTS ].light ];
-
-						_node.add( light );
+						var lights = extensions[ EXTENSIONS.KHR_LIGHTS ].lights;
+						_node.add( lights[ node.extensions[ EXTENSIONS.KHR_LIGHTS ].light ] );
 
 					}
 
@@ -2858,6 +2886,16 @@ THREE.GLTF2Loader = ( function () {
 					}
 
 				} );
+
+				// Ambient lighting, if present, is always attached to the scene root.
+				if ( scene.extensions
+							 && scene.extensions[ EXTENSIONS.KHR_LIGHTS ]
+							 && scene.extensions[ EXTENSIONS.KHR_LIGHTS ].light !== undefined ) {
+
+					var lights = extensions[ EXTENSIONS.KHR_LIGHTS ].lights;
+					_scene.add( lights[ scene.extensions[ EXTENSIONS.KHR_LIGHTS ].light ] );
+
+				}
 
 				return _scene;
 


### PR DESCRIPTION
Implementing remaining options in KHR_lights. I am not sure whether quadratic attenuation is supported in three.js, so it is ignored with a warning here.

References:

- Proposed schema (https://github.com/KhronosGroup/glTF/issues/945)
- Notes in https://github.com/mrdoob/three.js/pull/5787,   https://github.com/mrdoob/three.js/pull/6255, and https://github.com/mrdoob/three.js/pull/7523
- [Valve: Constant-Linear-Quadratic Falloff](https://developer.valvesoftware.com/wiki/Constant-Linear-Quadratic_Falloff)
- [Quadratic Lights in WebGL](http://dofideas.com/quadratic-lights-webgl/#)

/cc @takahirox 