### PR TITLE
Prevent ' uninitialized variable' console warning

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
@@ -59,6 +59,8 @@
 
 	float getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {
 
+		float shadow = 1.0;
+
 		shadowCoord.xyz /= shadowCoord.w;
 		shadowCoord.z += shadowBias;
 
@@ -83,7 +85,7 @@
 			float dx1 = + texelSize.x * shadowRadius;
 			float dy1 = + texelSize.y * shadowRadius;
 
-			return (
+			shadow = (
 				texture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, dy0 ), shadowCoord.z ) +
 				texture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy0 ), shadowCoord.z ) +
 				texture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy0 ), shadowCoord.z ) +
@@ -104,7 +106,7 @@
 			float dx1 = + texelSize.x * shadowRadius;
 			float dy1 = + texelSize.y * shadowRadius;
 
-			return (
+			shadow = (
 				texture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx0, dy0 ), shadowCoord.z ) +
 				texture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( 0.0, dy0 ), shadowCoord.z ) +
 				texture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx1, dy0 ), shadowCoord.z ) +
@@ -118,13 +120,13 @@
 
 		#else // no percentage-closer filtering:
 
-			return texture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z );
+			shadow = texture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z );
 
 		#endif
 
 		}
 
-		return 1.0;
+		return shadow;
 
 	}
 


### PR DESCRIPTION
This is a small modification to the GLSL shadow code to remove early return statements which result in this console error for any three.js code that uses shadows;

![x4000](https://user-images.githubusercontent.com/1762580/27319205-a62bc4a2-55d3-11e7-9306-80acf50fe0eb.PNG)

It is possible that this is a Windows/ANGLE only message, as I have only seen this message on windows, but it is a minor change and should not affect anything else.

