### PR TITLE
POTCanvas and clampCanvas array

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -5,13 +5,15 @@
 import { LinearFilter, NearestFilter, RGBFormat, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, ClampToEdgeWrapping, NearestMipMapLinearFilter, NearestMipMapNearestFilter } from '../../constants';
 import { _Math } from '../../math/Math';
 
+var POTCanvas, clampCanvas = [];
+
 function WebGLTextures( _gl, extensions, state, properties, capabilities, paramThreeToGL, infoMemory ) {
 
 	var _isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && _gl instanceof WebGL2RenderingContext );
+	
+	function clampToMaxSize( image, maxSize, canvasIndex ) {
 
-	//
-
-	function clampToMaxSize( image, maxSize ) {
+		canvasIndex = canvasIndex || 0;
 
 		if ( image.width > maxSize || image.height > maxSize ) {
 
@@ -20,16 +22,23 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, paramT
 
 			var scale = maxSize / Math.max( image.width, image.height );
 
-			var canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
-			canvas.width = Math.floor( image.width * scale );
-			canvas.height = Math.floor( image.height * scale );
+			if ( ! clampCanvas[ canvasIndex ] ) {
 
-			var context = canvas.getContext( '2d' );
-			context.drawImage( image, 0, 0, image.width, image.height, 0, 0, canvas.width, canvas.height );
+				clampCanvas[ canvasIndex ] = document.createElementNS('http://www.w3.org/1999/xhtml', 'canvas');
 
-			console.warn( 'THREE.WebGLRenderer: image is too big (' + image.width + 'x' + image.height + '). Resized to ' + canvas.width + 'x' + canvas.height, image );
+			}
 
-			return canvas;
+			clampCanvas[ canvasIndex ].width = Math.floor( image.width * scale );
+			clampCanvas[ canvasIndex ].height = Math.floor( image.height * scale );
+
+			var context = clampCanvas[ canvasIndex ].getContext( '2d' );
+			context.drawImage( image, 0, 0, image.width, image.height, 0, 0, clampCanvas[ canvasIndex ].width,
+				clampCanvas[ canvasIndex ].height );
+
+			console.warn( 'THREE.WebGLRenderer: image is too big (' + image.width + 'x' + image.height +
+				'). Resized to ' + clampCanvas[ canvasIndex ].width + 'x' + clampCanvas[ canvasIndex ].height, image );
+
+			return clampCanvas[ canvasIndex ];
 
 		}
 
@@ -47,16 +56,22 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, paramT
 
 		if ( image instanceof HTMLImageElement || image instanceof HTMLCanvasElement ) {
 
-			var canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
-			canvas.width = _Math.nearestPowerOfTwo( image.width );
-			canvas.height = _Math.nearestPowerOfTwo( image.height );
+			if ( ! POTCanvas ) {
 
-			var context = canvas.getContext( '2d' );
-			context.drawImage( image, 0, 0, canvas.width, canvas.height );
+				POTCanvas = document.createElementNS('http://www.w3.org/1999/xhtml', 'canvas');
 
-			console.warn( 'THREE.WebGLRenderer: image is not power of two (' + image.width + 'x' + image.height + '). Resized to ' + canvas.width + 'x' + canvas.height, image );
+			}
 
-			return canvas;
+			POTCanvas.width = _Math.nearestPowerOfTwo( image.width );
+			POTCanvas.height = _Math.nearestPowerOfTwo( image.height );
+
+			var context = POTCanvas.getContext( '2d' );
+			context.drawImage( image, 0, 0, POTCanvas.width, POTCanvas.height );
+
+			console.warn( 'THREE.WebGLRenderer: image is not power of two (' + image.width + 'x' +
+				image.height + '). Resized to ' + POTCanvas.width + 'x' + POTCanvas.height, image );
+
+			return POTCanvas;
 
 		}
 
@@ -252,7 +267,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, paramT
 
 					if ( ! isCompressed && ! isDataTexture ) {
 
-						cubeImage[ i ] = clampToMaxSize( texture.image[ i ], capabilities.maxCubemapSize );
+						cubeImage[ i ] = clampToMaxSize( texture.image[ i ], capabilities.maxCubemapSize, i );
 
 					} else {
 


### PR DESCRIPTION
Use a single canvas for makePowerOfTwo and an array of canvases for clampToMaxSize. This stops the memory leak.

Fixes https://github.com/mrdoob/three.js/issues/11378

