### PR TITLE
According to gltf 2.0 spec, byteStride is a property of bufferView

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1781,17 +1781,17 @@ THREE.GLTF2Loader = ( function () {
 				// For VEC3: itemSize is 3, elementBytes is 4, itemBytes is 12.
 				var elementBytes = TypedArray.BYTES_PER_ELEMENT;
 				var itemBytes = elementBytes * itemSize;
-
+				var byteStride = json.bufferViews[accessor.bufferView].byteStride;	
 				var array;
 
 				// The buffer is not interleaved if the stride is the item size in bytes.
-				if ( accessor.byteStride && accessor.byteStride !== itemBytes ) {
+				if ( byteStride && byteStride !== itemBytes ) {
 
 					// Use the full buffer if it's interleaved.
 					array = new TypedArray( arraybuffer );
 
 					// Integer parameters to IB/IBA are in array elements, not bytes.
-					var ib = new THREE.InterleavedBuffer( array, accessor.byteStride / elementBytes );
+					var ib = new THREE.InterleavedBuffer( array, byteStride / elementBytes );
 
 					return new THREE.InterleavedBufferAttribute( ib, itemSize, accessor.byteOffset / elementBytes );
 


### PR DESCRIPTION
According to gltf 2.0 spec, byteStride is a property of bufferView:

"Buffer view could have byteStride property. It means byte-distance between consequential elements. This field is defined only for buffer views that contain vertex attributes".

In the current GLTF2Loader.js implementation,  byteStride is treated like a property of accessor.

I attach a modified Box sample of the KhronosGroup glTF-Sample-Models repo, where vertex and normal attributes are interleaved. Without this PR, this samples was unable to render correctly.

[Box_Interleaved.zip](https://github.com/mrdoob/three.js/files/1092950/Box_Interleaved.zip)
 