### PR TITLE
Fix possible division by zero in `normalizeNormals`

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -824,7 +824,7 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 			y = normals.getY( i );
 			z = normals.getZ( i );
 
-			n = 1.0 / Math.sqrt( x * x + y * y + z * z );
+			n = 1.0 / ( Math.sqrt( x * x + y * y + z * z ) || 1.0 );
 
 			normals.setXYZ( i, x * n, y * n, z * n );
 


### PR DESCRIPTION
Can only happen when all normal elements are zero.
Avoid the resulting `NaN` none the less.