### PR TITLE
Fix mesh raycast bug when has multi-material

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -147,10 +147,9 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
-		function checkIntersection( object, raycaster, ray, pA, pB, pC, point ) {
+		function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point ) {
 
 			var intersect;
-			var material = object.material;
 
 			if ( material.side === BackSide ) {
 
@@ -185,7 +184,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			vB.fromBufferAttribute( position, b );
 			vC.fromBufferAttribute( position, c );
 
-			var intersection = checkIntersection( object, raycaster, ray, vA, vB, vC, intersectionPoint );
+			var intersection = checkIntersection( object, object.material, raycaster, ray, vA, vB, vC, intersectionPoint );
 
 			if ( intersection ) {
 
@@ -348,7 +347,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 					}
 
-					intersection = checkIntersection( this, raycaster, ray, fvA, fvB, fvC, intersectionPoint );
+					intersection = checkIntersection( this, faceMaterial, raycaster, ray, fvA, fvB, fvC, intersectionPoint );
 
 					if ( intersection ) {
 


### PR DESCRIPTION
In [`checkIntersection`](https://github.com/mrdoob/three.js/blob/dev/src/objects/Mesh.js#L150), it use object.material.side to check wether or not use cullface. If material is an array it is wrong.

This is the wrong [test demo](https://jsbin.com/wibojig/edit?html,output)
This is the correct [test demo](https://jsbin.com/gisodot/edit?html,output)

