### PR TITLE
Support ImageDate Texture serialization

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -135,7 +135,17 @@ Object.assign( Texture.prototype, EventDispatcher.prototype, {
 				canvas.width = image.width;
 				canvas.height = image.height;
 
-				canvas.getContext( '2d' ).drawImage( image, 0, 0, image.width, image.height );
+				var context = canvas.getContext( '2d' );
+
+				if ( image instanceof ImageData ) {
+
+					context.putImageData( image, 0, 0 );
+
+				} else {
+
+					context.drawImage( image, 0, 0, image.width, image.height );
+
+				}
 
 			}
 


### PR DESCRIPTION
`Texture` `image` can be `ImageData` (in other words, [`gl.texImage2D()` can accept `ImageData`](https://developer.mozilla.org/en/docs/Web/API/WebGLRenderingContext/texImage2D)).
But `Texture.toJSON()` fails if `image` is `ImageData`.
This PR fixes this issue.