### PR TITLE
Add morphAttributes serialization support to BufferGeometry

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -907,7 +907,7 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		}
 
-		data.data = { attributes: {} };
+		data.data = { attributes: {}, morphAttributes: {} };
 
 		var index = this.index;
 
@@ -936,6 +936,32 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 				array: array,
 				normalized: attribute.normalized
 			};
+
+		}
+
+		var morphAttributes = this.morphAttributes;
+
+		for ( var key in morphAttributes ) {
+
+			var attributeArray = this.morphAttributes[ key ];
+
+			var array = [];
+
+			for ( var i = 0, il = attributeArray.length; i < il; i ++ ) {
+
+				var attribute = attributeArray[ i ];
+
+				array.push( {
+					name: attribute.name,
+					itemSize: attribute.itemSize,
+					type: attribute.array.constructor.name,
+					array: Array.prototype.slice.call( attribute.array ),
+					normalized: attribute.normalized
+				} );
+
+			}
+
+			data.data.morphAttributes[ key ] = array;
 
 		}
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -54,6 +54,29 @@ Object.assign( BufferGeometryLoader.prototype, {
 
 		}
 
+		var morphAttributes = json.data.morphAttributes;
+
+		for ( var key in morphAttributes ) {
+
+			var attributeArray = morphAttributes[ key ];
+
+			var array = [];
+
+			for ( var i = 0, il = attributeArray.length; i < il; i ++ ) {
+
+				var attribute = attributeArray[ i ];
+				var typedArray = new TYPED_ARRAYS[ attribute.type ]( attribute.array );
+
+				var bufferAttribute = new BufferAttribute( typedArray, attribute.itemSize, attribute.normalized );
+				if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
+				array.push( bufferAttribute );
+
+			}
+
+			geometry.morphAttributes[ key ] = array;
+
+		}
+
 		var groups = json.data.groups || json.data.drawcalls || json.data.offsets;
 
 		if ( groups !== undefined ) {


### PR DESCRIPTION
This PR adds `morphAttributes` serialization support to `BufferGeometry`/`BufferGeometryLoader`.