### PR TITLE
Uncomment usage of TextDecoder in GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -666,7 +666,7 @@ THREE.GLTFLoader = ( function () {
 
 		if ( window.TextDecoder !== undefined ) {
 
-			//return new TextDecoder().decode( array );
+			return new TextDecoder().decode( array );
 
 		}
 


### PR DESCRIPTION
The TextDecoder block was added in d681e0f08177659871afda2494e32075f35afc78, but it seems to have been commented out (for debugging purposes, maybe?) in the GLTFLoader.