### PR TITLE
WebGL clipping example: render shadows double-sided

### DIFF
--- a/examples/webgl_clipping.html
+++ b/examples/webgl_clipping.html
@@ -106,6 +106,7 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.shadowMap.enabled = true;
+				renderer.shadowMap.renderSingleSided = false;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				window.addEventListener( 'resize', onWindowResize, false );


### PR DESCRIPTION
A clipped mesh is typically not a closed mesh.