### PR TITLE
Add warning about MeshStandardMaterial

### DIFF
--- a/docs/api/lights/RectAreaLight.html
+++ b/docs/api/lights/RectAreaLight.html
@@ -20,6 +20,7 @@
 
 			<em>NOTE:</em> this class is currently under active development and is probably not
 			production ready yet (as of r83). Check back in a month or two! And feel free to try it out in the meantime.
+			<em>NOTE:</em> works only with [page:MeshStandardMaterial].
 		</div>
 
 


### PR DESCRIPTION
As I tested - `RectAreaLight` doesn't work with `MeshPhongMaterial` atm. Let's add this note to prevent people from being confused. Is the `MeshStandardMaterial` only material that works with `RectAreaLight`?