### PR TITLE
Cloth Animation example: set shadowMap.renderSingleSided to false

### DIFF
--- a/examples/webgl_animation_cloth.html
+++ b/examples/webgl_animation_cloth.html
@@ -272,6 +272,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setClearColor( scene.fog.color );
+				renderer.shadowMap.renderSingleSided = false;
 
 				container.appendChild( renderer.domElement );
 


### PR DESCRIPTION
... required in this case because the cloth is double-sided.