### PR TITLE
WebGLRenderer: reimplement onBeforeRender()

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1108,6 +1108,14 @@ function WebGLRenderer( parameters ) {
 		_currentMaterialId = - 1;
 		_currentCamera = null;
 
+		// onBeforeRender
+
+		scene.traverse( function( node ) {
+
+			node.onBeforeRender( _this, scene, camera );
+
+		} );
+
 		// update scene graph
 
 		if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
@@ -1439,7 +1447,7 @@ function WebGLRenderer( parameters ) {
 
 	function renderObject( object, scene, camera, geometry, material, group ) {
 
-		object.onBeforeRender( _this, scene, camera, geometry, material, group );
+		//object.onBeforeRender( _this, scene, camera, geometry, material, group );
 
 		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
 		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );

--- a/src/renderers/webgl/plugins/SpritePlugin.js
+++ b/src/renderers/webgl/plugins/SpritePlugin.js
@@ -182,7 +182,7 @@ function SpritePlugin( renderer, sprites ) {
 
 			if ( material.visible === false ) continue;
 
-			sprite.onBeforeRender( renderer, scene, camera, undefined, material, undefined );
+			//sprite.onBeforeRender( renderer, scene, camera, undefined, material, undefined );
 
 			gl.uniform1f( uniforms.alphaTest, material.alphaTest );
 			gl.uniformMatrix4fv( uniforms.modelViewMatrix, false, sprite.modelViewMatrix.elements );


### PR DESCRIPTION
`onBeforeRender()` is not called for objects that are not renderable, such as a light helper that has only renderable children.

With this change, the light helpers can be implemented using `onBeforeRender()`, instead of requiring the user to call `update()`. See https://github.com/mrdoob/three.js/pull/11515#issuecomment-311222622.

`onAfterRender()` can be implemented in a similar fashion -- or removed.