### PR TITLE
OBJLoader is not a constructor

### DIFF
--- a/examples/webgl_materials_reflectivity.html
+++ b/examples/webgl_materials_reflectivity.html
@@ -121,7 +121,7 @@
 
 				};
 
-				var loader = new THREE.OBJLoader( manager );
+				var loader = new THREE.ObjectLoader( manager );
 				loader.load( 'models/obj/emerald.obj', function ( object ) {
 
 					object.traverse( function ( child ) {


### PR DESCRIPTION
we are calling THREE.OBJLoader constructor but I believe this has changed in threeJS to THREE.ObjectLoader - the error I encounter when trying to use THREE.OBJLoader is "OBJLoader is not a contructor" - no error is encountered when using ObjectLoader