### PR TITLE
Correct case in gltf2 example

### DIFF
--- a/examples/webgl_loader_gltf2.html
+++ b/examples/webgl_loader_gltf2.html
@@ -432,7 +432,7 @@
 					addEnvMap: true
 				},
 				{
-					name : 'Duck', url : './models/gltf/Duck/%s/duck.gltf',
+					name : 'Duck', url : './models/gltf/Duck/%s/Duck.gltf',
 					cameraPos: new THREE.Vector3(0, 3, 5),
 					addLights:true,
 					addGround:true,


### PR DESCRIPTION
Duck model still can't be loaded in glTF2 example because of wrong case.
This PR renames `duck.gltf` with `Duck.gltf` in glTF2 example and fixes this issue.

This PR should be in r86 and `gh-pages` in addition to `dev`.

#11622

/cc @donmccurdy 