### PR TITLE
blender exporter invisible object bug

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -115,7 +115,7 @@ def children(obj, valid_types):
     """
     logger.debug('object.children(%s, %s)', obj, valid_types)
     for child in obj.children:
-        if child.type in valid_types:
+        if child.type in valid_types and child.THREE_export:
             yield child.name
 
 
@@ -451,6 +451,10 @@ def extract_mesh(obj, options, recalculate=False):
 
     """
     logger.debug('object.extract_mesh(%s, %s)', obj, options)
+    bpy.context.scene.objects.active = obj
+    hidden_state = obj.hide
+    obj.hide = False
+
     apply_modifiers = options.get(constants.APPLY_MODIFIERS, True)
     if apply_modifiers:
         bpy.ops.object.mode_set(mode='OBJECT')
@@ -466,8 +470,6 @@ def extract_mesh(obj, options, recalculate=False):
     opt_buffer = opt_buffer == constants.BUFFER_GEOMETRY
     prop_buffer = mesh_node.THREE_geometry_type == constants.BUFFER_GEOMETRY
 
-    bpy.context.scene.objects.active = obj
-
     # if doing buffer geometry it is imperative to triangulate the mesh
     if opt_buffer or prop_buffer:
         original_mesh = obj.data
@@ -476,8 +478,6 @@ def extract_mesh(obj, options, recalculate=False):
                      original_mesh.name,
                      mesh_node.name)
 
-        hidden_state = obj.hide
-        obj.hide = False
         bpy.ops.object.mode_set(mode='OBJECT')
         obj.select = True
         bpy.context.scene.objects.active = obj
@@ -487,7 +487,6 @@ def extract_mesh(obj, options, recalculate=False):
                                       modifier='Triangulate')
         obj.data = original_mesh
         obj.select = False
-        obj.hide = hidden_state
 
     # split sharp edges
     original_mesh = obj.data
@@ -499,6 +498,7 @@ def extract_mesh(obj, options, recalculate=False):
     bpy.context.object.modifiers['EdgeSplit'].use_edge_sharp = True
     bpy.ops.object.modifier_apply(apply_as='DATA', modifier='EdgeSplit')
 
+    obj.hide = hidden_state
     obj.select = False
     obj.data = original_mesh
 


### PR DESCRIPTION
Hi
I've found a solution for the bug mentioned here [#6276](https://github.com/mrdoob/three.js/issues/6276), i guess.
In blender if you make an object invisible then you get `"Operator bpy.ops.object.mode_set.poll() failed, context is incorrect"` error. this is because you must make object visible first then apply any modifiers to it. also you have to put `bpy.context.scene.objects.active = obj` in the beginning of `extract mesh` function or you may receive the same error even though you are about extracting next object.
Another bug is about uncheck the Export checkbox for an specific object. in that case the scene will export fine but in object section you'll see your unchecked object but in geometry section there is no geometry for that object. so in `children` method `child.THREE_export` should be checked.
Blender test file: [test1.zip](https://github.com/mrdoob/three.js/files/1112506/test1.zip)
