### PR TITLE
Examples: Remove sortObjects = false

### DIFF
--- a/examples/misc_animation_authoring.html
+++ b/examples/misc_animation_authoring.html
@@ -47,7 +47,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				document.body.appendChild( renderer.domElement );
 
 				//

--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -215,7 +215,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.sortObjects = false;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -45,7 +45,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				document.body.appendChild( renderer.domElement );
 
 				//

--- a/examples/misc_lookat.html
+++ b/examples/misc_lookat.html
@@ -89,7 +89,6 @@
 				renderer.setClearColor( 0xffffff );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/webgl_camera_cinematic.html
+++ b/examples/webgl_camera_cinematic.html
@@ -82,7 +82,6 @@
 				renderer.setClearColor( 0xf0f0f0 );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild(renderer.domElement);
 
 				stats = new Stats();

--- a/examples/webgl_geometry_hierarchy.html
+++ b/examples/webgl_geometry_hierarchy.html
@@ -76,7 +76,6 @@
 				renderer.setClearColor( 0xffffff );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_geometry_hierarchy2.html
+++ b/examples/webgl_geometry_hierarchy2.html
@@ -130,7 +130,6 @@
 				renderer.setClearColor( 0xffffff );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/webgl_interactive_cubes.html
+++ b/examples/webgl_interactive_cubes.html
@@ -79,7 +79,6 @@
 				renderer.setClearColor( 0xf0f0f0 );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild(renderer.domElement);
 
 				stats = new Stats();

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -167,7 +167,6 @@
 				renderer.setClearColor( 0xffffff );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/webgl_interactive_cubes_ortho.html
+++ b/examples/webgl_interactive_cubes_ortho.html
@@ -81,7 +81,6 @@
 				renderer.setClearColor( 0xf0f0f0 );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild(renderer.domElement);
 
 				stats = new Stats();

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -95,7 +95,6 @@
 				renderer.setClearColor( 0xf0f0f0 );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFShadowMap;

--- a/examples/webgl_interactive_instances_gpu.html
+++ b/examples/webgl_interactive_instances_gpu.html
@@ -959,7 +959,7 @@
 			renderer.setClearColor( 0xffffff );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.sortObjects = false;
+			//renderer.sortObjects = false;
 			container.appendChild( renderer.domElement );
 
 			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === false ) {

--- a/examples/webgl_loader_collada_skinning.html
+++ b/examples/webgl_loader_collada_skinning.html
@@ -98,7 +98,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				//

--- a/examples/webgl_lod.html
+++ b/examples/webgl_lod.html
@@ -123,7 +123,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				//

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -138,7 +138,6 @@
 				renderer.setClearColor( 0x222222 );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				//

--- a/examples/webgl_performance_static.html
+++ b/examples/webgl_performance_static.html
@@ -78,7 +78,7 @@
 				renderer.setClearColor( 0xffffff );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
+				//renderer.sortObjects = false;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_points_dynamic.html
+++ b/examples/webgl_points_dynamic.html
@@ -127,7 +127,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 				renderer.autoClear = false;
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				//

--- a/examples/webgl_postprocessing_crossfade.html
+++ b/examples/webgl_postprocessing_crossfade.html
@@ -62,7 +62,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -93,8 +93,6 @@
 				renderer.setSize( width, height );
 				container.appendChild( renderer.domElement );
 
-				renderer.sortObjects = false;
-
 				var path = "textures/cube/SwedishRoyalCastle/";
 				var format = '.jpg';
 				var urls = [

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -96,7 +96,7 @@ Use WEBGL Depth buffer support?
 				renderer = new THREE.WebGLRenderer( { antialias: false } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, height );
-				renderer.sortObjects = false;
+				//renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				material_depth = new THREE.MeshDepthMaterial();

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -116,7 +116,6 @@
 				container.appendChild( renderer.domElement );
 
 				renderer.autoClear = false;
-				renderer.sortObjects = false;
 
 				//
 

--- a/examples/webgl_trails.html
+++ b/examples/webgl_trails.html
@@ -67,7 +67,6 @@
 				renderer = new THREE.WebGLRenderer( { preserveDrawingBuffer: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				renderer.autoClearColor = false;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webvr_cubes.html
+++ b/examples/webvr_cubes.html
@@ -123,7 +123,6 @@
 				renderer.setClearColor( 0x505050 );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				renderer.vr.enabled = true;

--- a/examples/webvr_daydream.html
+++ b/examples/webvr_daydream.html
@@ -115,7 +115,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				renderer.vr.enabled = true;

--- a/examples/webvr_vive.html
+++ b/examples/webvr_vive.html
@@ -159,7 +159,6 @@
 				renderer.setClearColor( 0x505050 );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				renderer.vr.enabled = true;

--- a/examples/webvr_vive_camerarig.html
+++ b/examples/webvr_vive_camerarig.html
@@ -168,7 +168,6 @@
 				renderer.setClearColor( 0x505050 );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				container.appendChild( renderer.domElement );
 
 				renderer.vr.enabled = true;

--- a/examples/webvr_vive_paint.html
+++ b/examples/webvr_vive_paint.html
@@ -133,7 +133,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				renderer.shadowMap.enabled = true;
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;

--- a/examples/webvr_vive_sculpt.html
+++ b/examples/webvr_vive_sculpt.html
@@ -115,7 +115,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.sortObjects = false;
 				renderer.shadowMap.enabled = true;
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;


### PR DESCRIPTION
... as proposed in https://github.com/mrdoob/three.js/pull/11660#issuecomment-312448788.

I either removed the line or commented it out -- a purely subjective decision.

Perhaps someone can identify a use case for which not sorting is beneficial.

Maybe one of these examples demonstrates such a use case and we can revert.