### PR TITLE
Fix WebGLRenderer side effect caused by ArrayCamera rendering

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1229,12 +1229,6 @@ function WebGLRenderer( parameters ) {
 		state.buffers.depth.setMask( true );
 		state.buffers.color.setMask( true );
 
-		if ( camera.isArrayCamera ) {
-
-			_this.setScissorTest( false );
-
-		}
-
 		if ( vr.enabled ) {
 
 			vr.submitFrame();
@@ -1424,9 +1418,9 @@ function WebGLRenderer( parameters ) {
 						var width = bounds.z * _width;
 						var height = bounds.w * _height;
 
-						_this.setViewport( x, y, width, height );
-						_this.setScissor( x, y, width, height );
-						_this.setScissorTest( true );
+						state.viewport( _currentViewport.set( x, y, width, height ) );
+						state.scissor( _currentScissor.set( x, y, width, height ) );
+						state.setScissorTest( true );
 
 						renderObject( object, scene, camera2, geometry, material, group );
 


### PR DESCRIPTION
I made a new PR because #11051 is too old.

The current `WebGLRenderer` has a problem; rendering with `ArrayCamera` has `viewport`/`scissor` side effects and they're propagated to the following rendering with other cameras.

example http://jsfiddle.net/o5rvfg9x/2/

```javascript
renderer.autoClear = true;
renderer.render( scene, arrayCamera ); // should render left and right
renderer.autoClear = false;
renderer.render( scene, camera ); // should render center
```

It should render three spheres (left, right, and center) but it renders the two(left and right) because `renderer.render( scene, arrayCamera );` has side effect of `renderer` `viewport`/`scissor` and it's propagated to `renderer.render( scene, camera );` then the second `.render()` unexpectedly renders right overlay.

So this PR lets `WebGLRenderer` update `state` instead of `WebGLRenderer` instance property for rendering with `ArrayCamera`.
