### PR TITLE
STLLoader: Refactoring and clean up

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -56,10 +56,10 @@ THREE.STLLoader.prototype = {
 
 	parse: function ( data ) {
 
-		var isBinary = function () {
+		function isBinary( data ) {
 
 			var expect, face_size, n_faces, reader;
-			reader = new DataView( binData );
+			reader = new DataView( data );
 			face_size = ( 32 / 8 * 3 ) + ( ( 32 / 8 * 3 ) * 3 ) + ( 16 / 8 );
 			n_faces = reader.getUint32( 80, true );
 			expect = 80 + ( 32 / 8 ) + ( n_faces * face_size );
@@ -75,6 +75,7 @@ THREE.STLLoader.prototype = {
 			// plentiful.  So, check the first 5 bytes for 'solid'.
 
 			// US-ASCII ordinal values for 's', 'o', 'l', 'i', 'd'
+
 			var solid = [ 115, 111, 108, 105, 100 ];
 
 			for ( var i = 0; i < 5; i ++ ) {
@@ -87,230 +88,235 @@ THREE.STLLoader.prototype = {
  			}
 
 			// First 5 bytes read "solid"; declare it to be an ASCII STL
+			
 			return false;
-
-		};
-
-		var binData = this.ensureBinary( data );
-
-		return isBinary() ? this.parseBinary( binData ) : this.parseASCII( this.ensureString( data ) );
-
-	},
-
-	parseBinary: function ( data ) {
-
-		var reader = new DataView( data );
-		var faces = reader.getUint32( 80, true );
-
-		var r, g, b, hasColors = false, colors;
-		var defaultR, defaultG, defaultB, alpha;
-
-		// process STL header
-		// check for default color in header ("COLOR=rgba" sequence).
-
-		for ( var index = 0; index < 80 - 10; index ++ ) {
-
-			if ( ( reader.getUint32( index, false ) == 0x434F4C4F /*COLO*/ ) &&
-				( reader.getUint8( index + 4 ) == 0x52 /*'R'*/ ) &&
-				( reader.getUint8( index + 5 ) == 0x3D /*'='*/ ) ) {
-
-				hasColors = true;
-				colors = [];
-
-				defaultR = reader.getUint8( index + 6 ) / 255;
-				defaultG = reader.getUint8( index + 7 ) / 255;
-				defaultB = reader.getUint8( index + 8 ) / 255;
-				alpha = reader.getUint8( index + 9 ) / 255;
-
-			}
 
 		}
 
-		var dataOffset = 84;
-		var faceLength = 12 * 4 + 2;
+		function parseBinary( data ) {
 
-		var geometry = new THREE.BufferGeometry();
+			var reader = new DataView( data );
+			var faces = reader.getUint32( 80, true );
 
-		var vertices = [];
-		var normals = [];
+			var r, g, b, hasColors = false, colors;
+			var defaultR, defaultG, defaultB, alpha;
 
-		for ( var face = 0; face < faces; face ++ ) {
+			// process STL header
+			// check for default color in header ("COLOR=rgba" sequence).
 
-			var start = dataOffset + face * faceLength;
-			var normalX = reader.getFloat32( start, true );
-			var normalY = reader.getFloat32( start + 4, true );
-			var normalZ = reader.getFloat32( start + 8, true );
+			for ( var index = 0; index < 80 - 10; index ++ ) {
 
-			if ( hasColors ) {
+				if ( ( reader.getUint32( index, false ) == 0x434F4C4F /*COLO*/ ) &&
+					( reader.getUint8( index + 4 ) == 0x52 /*'R'*/ ) &&
+					( reader.getUint8( index + 5 ) == 0x3D /*'='*/ ) ) {
 
-				var packedColor = reader.getUint16( start + 48, true );
+					hasColors = true;
+					colors = [];
 
-				if ( ( packedColor & 0x8000 ) === 0 ) {
-
-					// facet has its own unique color
-
-					r = ( packedColor & 0x1F ) / 31;
-					g = ( ( packedColor >> 5 ) & 0x1F ) / 31;
-					b = ( ( packedColor >> 10 ) & 0x1F ) / 31;
-
-				} else {
-
-					r = defaultR;
-					g = defaultG;
-					b = defaultB;
+					defaultR = reader.getUint8( index + 6 ) / 255;
+					defaultG = reader.getUint8( index + 7 ) / 255;
+					defaultB = reader.getUint8( index + 8 ) / 255;
+					alpha = reader.getUint8( index + 9 ) / 255;
 
 				}
 
 			}
 
-			for ( var i = 1; i <= 3; i ++ ) {
+			var dataOffset = 84;
+			var faceLength = 12 * 4 + 2;
 
-				var vertexstart = start + i * 12;
+			var geometry = new THREE.BufferGeometry();
 
-				vertices.push( reader.getFloat32( vertexstart, true ) );
-				vertices.push( reader.getFloat32( vertexstart + 4, true ) );
-				vertices.push( reader.getFloat32( vertexstart + 8, true ) );
+			var vertices = [];
+			var normals = [];
 
-				normals.push( normalX, normalY, normalZ );
+			for ( var face = 0; face < faces; face ++ ) {
+
+				var start = dataOffset + face * faceLength;
+				var normalX = reader.getFloat32( start, true );
+				var normalY = reader.getFloat32( start + 4, true );
+				var normalZ = reader.getFloat32( start + 8, true );
 
 				if ( hasColors ) {
 
-					colors.push( r, g, b );
+					var packedColor = reader.getUint16( start + 48, true );
+
+					if ( ( packedColor & 0x8000 ) === 0 ) {
+
+						// facet has its own unique color
+
+						r = ( packedColor & 0x1F ) / 31;
+						g = ( ( packedColor >> 5 ) & 0x1F ) / 31;
+						b = ( ( packedColor >> 10 ) & 0x1F ) / 31;
+
+					} else {
+
+						r = defaultR;
+						g = defaultG;
+						b = defaultB;
+
+					}
+
+				}
+
+				for ( var i = 1; i <= 3; i ++ ) {
+
+					var vertexstart = start + i * 12;
+
+					vertices.push( reader.getFloat32( vertexstart, true ) );
+					vertices.push( reader.getFloat32( vertexstart + 4, true ) );
+					vertices.push( reader.getFloat32( vertexstart + 8, true ) );
+
+					normals.push( normalX, normalY, normalZ );
+
+					if ( hasColors ) {
+
+						colors.push( r, g, b );
+
+					}
 
 				}
 
 			}
 
-		}
+			geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( vertices ), 3 ) );
+			geometry.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( normals ), 3 ) );
 
-		geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( vertices ), 3 ) );
-		geometry.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( normals ), 3 ) );
+			if ( hasColors ) {
 
-		if ( hasColors ) {
-
-			geometry.addAttribute( 'color', new THREE.BufferAttribute( new Float32Array( colors ), 3 ) );
-			geometry.hasColors = true;
-			geometry.alpha = alpha;
-
-		}
-
-		return geometry;
-
-	},
-
-	parseASCII: function ( data ) {
-
-		var geometry = new THREE.BufferGeometry();
-		var patternFace = /facet([\s\S]*?)endfacet/g;
-		var faceCounter = 0;
-
-		var patternFloat = /[\s]+([+-]?(?:\d+.\d+|\d+.|\d+|.\d+)(?:[eE][+-]?\d+)?)/.source;
-		var patternVertex = new RegExp( 'vertex' + patternFloat + patternFloat + patternFloat, 'g' );
-		var patternNormal = new RegExp( 'normal' + patternFloat + patternFloat + patternFloat, 'g' );
-
-		var vertices = [];
-		var normals = [];
-
-		var normal = new THREE.Vector3();
-
-		var result;
-
-		while ( ( result = patternFace.exec( data ) ) !== null ) {
-
-			var vertexCountPerFace = 0;
-			var normalCountPerFace = 0;
-
-			var text = result[ 0 ];
-
-			while ( ( result = patternNormal.exec( text ) ) !== null ) {
-
-				normal.x = parseFloat( result[ 1 ] );
-				normal.y = parseFloat( result[ 2 ] );
-				normal.z = parseFloat( result[ 3 ] );
-				normalCountPerFace ++;
+				geometry.addAttribute( 'color', new THREE.BufferAttribute( new Float32Array( colors ), 3 ) );
+				geometry.hasColors = true;
+				geometry.alpha = alpha;
 
 			}
 
-			while ( ( result = patternVertex.exec( text ) ) !== null ) {
-
-				vertices.push( parseFloat( result[ 1 ] ), parseFloat( result[ 2 ] ), parseFloat( result[ 3 ] ) );
-				normals.push( normal.x, normal.y, normal.z );
-				vertexCountPerFace ++;
-
-			}
-
-			// Every face have to own ONE valid normal
-			if ( normalCountPerFace !== 1 ) {
-
-				throw new Error( 'Something isn\'t right with the normal of face number ' + faceCounter );
-
-			}
-
-			// Each face have to own THREE valid vertices
-			if ( vertexCountPerFace !== 3 ) {
-
-				throw new Error( 'Something isn\'t right with the vertices of face number ' + faceCounter );
-
-			}
-
-			faceCounter ++;
+			return geometry;
 
 		}
 
-		geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( vertices ), 3 ) );
-		geometry.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( normals ), 3 ) );
+		function parseASCII( data ) {
 
-		return geometry;
+			var geometry = new THREE.BufferGeometry();
+			var patternFace = /facet([\s\S]*?)endfacet/g;
+			var faceCounter = 0;
 
-	},
+			var patternFloat = /[\s]+([+-]?(?:\d+.\d+|\d+.|\d+|.\d+)(?:[eE][+-]?\d+)?)/.source;
+			var patternVertex = new RegExp( 'vertex' + patternFloat + patternFloat + patternFloat, 'g' );
+			var patternNormal = new RegExp( 'normal' + patternFloat + patternFloat + patternFloat, 'g' );
 
-	ensureString: function ( buf ) {
+			var vertices = [];
+			var normals = [];
 
-		if ( typeof buf !== "string" ) {
+			var normal = new THREE.Vector3();
 
-			var array_buffer = new Uint8Array( buf );
+			var result;
 
-			if ( window.TextDecoder !== undefined ) {
+			while ( ( result = patternFace.exec( data ) ) !== null ) {
 
-				return new TextDecoder().decode( array_buffer );
+				var vertexCountPerFace = 0;
+				var normalCountPerFace = 0;
+
+				var text = result[ 0 ];
+
+				while ( ( result = patternNormal.exec( text ) ) !== null ) {
+
+					normal.x = parseFloat( result[ 1 ] );
+					normal.y = parseFloat( result[ 2 ] );
+					normal.z = parseFloat( result[ 3 ] );
+					normalCountPerFace ++;
+
+				}
+
+				while ( ( result = patternVertex.exec( text ) ) !== null ) {
+
+					vertices.push( parseFloat( result[ 1 ] ), parseFloat( result[ 2 ] ), parseFloat( result[ 3 ] ) );
+					normals.push( normal.x, normal.y, normal.z );
+					vertexCountPerFace ++;
+
+				}
+
+				// every face have to own ONE valid normal
+
+				if ( normalCountPerFace !== 1 ) {
+
+					console.error( 'THREE.STLLoader: Something isn\'t right with the normal of face number ' + faceCounter );
+
+				}
+
+				// each face have to own THREE valid vertices
+
+				if ( vertexCountPerFace !== 3 ) {
+
+					console.error( 'THREE.STLLoader: Something isn\'t right with the vertices of face number ' + faceCounter );
+
+				}
+
+				faceCounter ++;
 
 			}
 
-			var str = '';
+			geometry.addAttribute( 'position', new THREE.Float32BufferAttribute( vertices, 3 ) );
+			geometry.addAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
 
-			for ( var i = 0, il = buf.byteLength; i < il; i ++ ) {
-
-				str += String.fromCharCode( array_buffer[ i ] ); // implicitly assumes little-endian
-
-			}
-
-			return str;
-
-		} else {
-
-			return buf;
+			return geometry;
 
 		}
 
-	},
+		function ensureString( buffer ) {
 
-	ensureBinary: function ( buf ) {
+			if ( typeof buffer !== 'string' ) {
 
-		if ( typeof buf === "string" ) {
+				var array_buffer = new Uint8Array( buffer );
 
-			var array_buffer = new Uint8Array( buf.length );
-			for ( var i = 0; i < buf.length; i ++ ) {
+				if ( window.TextDecoder !== undefined ) {
 
-				array_buffer[ i ] = buf.charCodeAt( i ) & 0xff; // implicitly assumes little-endian
+					return new TextDecoder().decode( array_buffer );
+
+				}
+
+				var str = '';
+
+				for ( var i = 0, il = buffer.byteLength; i < il; i ++ ) {
+
+					str += String.fromCharCode( array_buffer[ i ] ); // implicitly assumes little-endian
+
+				}
+
+				return str;
+
+			} else {
+
+				return buffer;
 
 			}
-			return array_buffer.buffer || array_buffer;
-
-		} else {
-
-			return buf;
 
 		}
+
+		function ensureBinary( buffer ) {
+
+			if ( typeof buffer === 'string' ) {
+
+				var array_buffer = new Uint8Array( buffer.length );
+				for ( var i = 0; i < buffer.length; i ++ ) {
+
+					array_buffer[ i ] = buffer.charCodeAt( i ) & 0xff; // implicitly assumes little-endian
+
+				}
+				return array_buffer.buffer || array_buffer;
+
+			} else {
+
+				return buffer;
+
+			}
+
+		}
+
+		// start
+
+		var binData = ensureBinary( data );
+
+		return isBinary( binData ) ? parseBinary( binData ) : parseASCII( ensureString( data ) );
 
 	}
 


### PR DESCRIPTION
This PR ensures that `STLLoader` has only two methods `.load()` and `.parse()`. All other methods or now defined as functions like in other recent loaders.