### PR TITLE
Examples: Fix Resize Behaviour of ShadowMapViewer

### DIFF
--- a/examples/js/utils/ShadowMapViewer.js
+++ b/examples/js/utils/ShadowMapViewer.js
@@ -170,7 +170,9 @@ THREE.ShadowMapViewer = function ( light ) {
 			 camera.right = window.innerWidth / 2;
 			 camera.top = window.innerHeight / 2;
 			 camera.bottom = window.innerHeight / - 2;
+			 camera.updateProjectionMatrix();
 
+			 this.update();
 		}
 
 	};


### PR DESCRIPTION
Hello,
this is an easy fix for the ShadowMapViewer which can't handle a resize very well at the moment. 

See for yourself: 
1. Open https://threejs.org/examples/#webgl_shadowmap_viewer
2. Make the window smaller or larger

The two shadow HUDs in the top left will be stretched as the involved OrthographicCamera is not updated properly. My PR fixes this by updating the camera projection matrix and it also validates the size and position at the same place.

I tested it locally with the same example. Attached two gifs for demonstration purpose. Before and after.

Thanks.
Regards George

![resize-current](https://user-images.githubusercontent.com/1701755/27840936-7ddcf432-60fd-11e7-905e-71a162c0384d.gif)
![resize-fixed](https://user-images.githubusercontent.com/1701755/27840937-7dde0a0c-60fd-11e7-9a57-ddfc3b8a011b.gif)

