### PR TITLE
Use bone position as defined by the track parent

### DIFF
--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -278,7 +278,7 @@ Object.assign( AnimationClip, {
 
 				// ...assume skeletal animation
 
-				var boneName = '.bones[' + bones[ h ].name + ']';
+				var boneName = '.bones[' + bones[hierarchyTracks[h].parent+1].name + ']';
 
 				addNonemptyTrack(
 						VectorKeyframeTrack, boneName + '.position',


### PR DESCRIPTION
io_tresjs doesn't necessarily export every bone into every animation track set so can no longer assume the bones position in the array is h, so use the parent value from the track - which seems to always be set to bone_position_in_array-1 in io_three, and definitely is that in io_tresjs. 
Should have zero impact on animations exported by io_three, and prevents crashes with animations exported by io_tresjs