### PR TITLE
envmap_frag.glsl: clamp prior to taking asin

### DIFF
--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -30,7 +30,7 @@
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 
 		vec2 sampleUV;
-		sampleUV.y = asin( flipNormal * reflectVec.y ) * RECIPROCAL_PI + 0.5;
+		sampleUV.y = asin( clamp( flipNormal * reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;
 		sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * RECIPROCAL_PI2 + 0.5;
 		vec4 envColor = texture2D( envMap, sampleUV );
 


### PR DESCRIPTION
As mentioned in https://github.com/mrdoob/three.js/pull/11508#issuecomment-308473269, this is good practice before calling `asin()`. We have had this problem before.