### PR TITLE
envmap_fragment.glsl: Remove double-counted flipNormal

### DIFF
--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -25,18 +25,18 @@
 
 	#ifdef ENVMAP_TYPE_CUBE
 
-		vec4 envColor = textureCube( envMap, flipNormal * vec3( flipEnvMap * reflectVec.x, reflectVec.yz ) );
+		vec4 envColor = textureCube( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ) );
 
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 
 		vec2 sampleUV;
-		sampleUV.y = asin( clamp( flipNormal * reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;
-		sampleUV.x = atan( flipNormal * reflectVec.z, flipNormal * reflectVec.x ) * RECIPROCAL_PI2 + 0.5;
+		sampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;
+		sampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;
 		vec4 envColor = texture2D( envMap, sampleUV );
 
 	#elif defined( ENVMAP_TYPE_SPHERE )
 
-		vec3 reflectView = flipNormal * normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0, 0.0, 1.0 ) );
+		vec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0, 0.0, 1.0 ) );
 		vec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );
 
 	#else


### PR DESCRIPTION
This is the same issue as addressed in #10332, except as applied to `MeshBasicMaterial` and `MeshLambertMaterial`. Environment reflections should now be correct for these materials.

This change leaves _refractions_ incorrect on back-faces of double-sided `MeshBasicMaterial` and `MeshLambertMaterial ` (i.e., when `CubeRefractionMapping` is specified). Dealing with that is a separate issue.