### PR TITLE
Environment map fragment: normalize reflected vector...

### DIFF
--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl
@@ -30,13 +30,21 @@
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 
 		vec2 sampleUV;
+
+		reflectVec = normalize( reflectVec );
+
 		sampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;
+
 		sampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;
+
 		vec4 envColor = texture2D( envMap, sampleUV );
 
 	#elif defined( ENVMAP_TYPE_SPHERE )
 
+		reflectVec = normalize( reflectVec );
+
 		vec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0, 0.0, 1.0 ) );
+
 		vec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );
 
 	#else


### PR DESCRIPTION
...but only when it is required for correct calculations.

Known issue: refract() can return the zero vector depending on the incidence angle and refraction ratio value. This possibility is not currently handled by the library.