### PR TITLE
Merge <normal_flip> into <normal_fragment>

### DIFF
--- a/examples/js/nodes/materials/PhongNode.js
+++ b/examples/js/nodes/materials/PhongNode.js
@@ -151,7 +151,6 @@ THREE.PhongNode.prototype.build = function ( builder ) {
 
 		var output = [
 			// prevent undeclared normal
-			"#include <normal_flip>",
 			"#include <normal_fragment>",
 
 			// prevent undeclared material

--- a/examples/js/nodes/materials/StandardNode.js
+++ b/examples/js/nodes/materials/StandardNode.js
@@ -190,7 +190,6 @@ THREE.StandardNode.prototype.build = function ( builder ) {
 
 		var output = [
 				// prevent undeclared normal
-			"	#include <normal_flip>",
 			"	#include <normal_fragment>",
 
 				// prevent undeclared material

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -55,7 +55,6 @@ import metalnessmap_pars_fragment from './ShaderChunk/metalnessmap_pars_fragment
 import morphnormal_vertex from './ShaderChunk/morphnormal_vertex.glsl';
 import morphtarget_pars_vertex from './ShaderChunk/morphtarget_pars_vertex.glsl';
 import morphtarget_vertex from './ShaderChunk/morphtarget_vertex.glsl';
-import normal_flip from './ShaderChunk/normal_flip.glsl';
 import normal_fragment from './ShaderChunk/normal_fragment.glsl';
 import normalmap_pars_fragment from './ShaderChunk/normalmap_pars_fragment.glsl';
 import packing from './ShaderChunk/packing.glsl';
@@ -168,7 +167,6 @@ export var ShaderChunk = {
 	morphnormal_vertex: morphnormal_vertex,
 	morphtarget_pars_vertex: morphtarget_pars_vertex,
 	morphtarget_vertex: morphtarget_vertex,
-	normal_flip: normal_flip,
 	normal_fragment: normal_fragment,
 	normalmap_pars_fragment: normalmap_pars_fragment,
 	packing: packing,

--- a/src/renderers/shaders/ShaderChunk/normal_flip.glsl
+++ b/src/renderers/shaders/ShaderChunk/normal_flip.glsl
@@ -1,5 +1,0 @@
-#ifdef DOUBLE_SIDED
-	float flipNormal = ( float( gl_FrontFacing ) * 2.0 - 1.0 );
-#else
-	float flipNormal = 1.0;
-#endif

--- a/src/renderers/shaders/ShaderChunk/normal_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment.glsl
@@ -8,7 +8,13 @@
 
 #else
 
-	vec3 normal = normalize( vNormal ) * flipNormal;
+	vec3 normal = normalize( vNormal );
+
+	#ifdef DOUBLE_SIDED
+
+		normal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+
+	#endif
 
 #endif
 

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
@@ -44,7 +44,6 @@ void main() {
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
 	#include <specularmap_fragment>
-	#include <normal_flip>
 	#include <normal_fragment>
 	#include <emissivemap_fragment>
 

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
@@ -59,7 +59,6 @@ void main() {
 	#include <alphatest_fragment>
 	#include <roughnessmap_fragment>
 	#include <metalnessmap_fragment>
-	#include <normal_flip>
 	#include <normal_fragment>
 	#include <emissivemap_fragment>
 

--- a/src/renderers/shaders/ShaderLib/normal_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/normal_frag.glsl
@@ -23,7 +23,6 @@ uniform float opacity;
 void main() {
 
 	#include <logdepthbuf_fragment>
-	#include <normal_flip>
 	#include <normal_fragment>
 
 	gl_FragColor = vec4( packNormalToRGB( normal ), opacity );


### PR DESCRIPTION
After recent changes, `<normal_flip>` and `<normal_fragment>` now occur in pairs.

Due to the fragility of the shader chunk code, IMO it is best to combine them into one.