### PR TITLE
Add check to make sure device exists

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -43,7 +43,7 @@ function WebVRManager( renderer ) {
 
 	function onVRDisplayPresentChange() {
 
-		if ( device.isPresenting ) {
+		if ( !!device && device.isPresenting ) {
 
 			var eyeParameters = device.getEyeParameters( 'left' );
 			var renderWidth = eyeParameters.renderWidth;


### PR DESCRIPTION
I'm controlling the WebVR presentation manually and I noticed in r86 I get an error when it begins presenting because `onVRDisplayPresentChange` is listening but it's device is never created.