### PR TITLE
Fix markup typos in WebGLRenderTarget doc

### DIFF
--- a/docs/api/renderers/WebGLRenderTarget.html
+++ b/docs/api/renderers/WebGLRenderTarget.html
@@ -26,7 +26,7 @@
 		<div>
 		[page:Float width] - The width of the renderTarget. <br />
 		[page:Float height] - The height of the renderTarget.<br />
-		options - (optional0 object that holds texture parameters for an auto-generated target
+		options - (optional object that holds texture parameters for an auto-generated target
 		texture and depthBuffer/stencilBuffer booleans.
 
 		For an explanation of the texture parameters see [page:Texture Texture]. The following are
@@ -43,7 +43,7 @@
 		[page:Boolean depthBuffer] - default is *true*. Set this to false if you don't need it. <br />
 		[page:Boolean stencilBuffer] - default is *true*. Set this to false if you don't need it.<br /><br />
 
-		Creates a new [name]]
+		Creates a new [name]
 		</div>
 
 		<h2>Properties</h2>


### PR DESCRIPTION
Re. the diff: I edited this on Github, and I think it may have used a different set of line endings: