### PR TITLE
Fix for potential missing update of current blending mode variable in…

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -641,6 +641,7 @@ function WebGLState( gl, extensions, paramThreeToGL ) {
 		}
 
 		currentBlending = blending;
+		
 	}
 
 	function setMaterial( material ) {

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -599,7 +599,6 @@ function WebGLState( gl, extensions, paramThreeToGL ) {
 
 			}
 
-			currentBlending = blending;
 			currentPremultipledAlpha = premultipliedAlpha;
 
 		}
@@ -641,6 +640,7 @@ function WebGLState( gl, extensions, paramThreeToGL ) {
 
 		}
 
+		currentBlending = blending;
 	}
 
 	function setMaterial( material ) {


### PR DESCRIPTION
There is a code path in the function <code>setBlending()</code> where the <code>currentBlendingMode</code> may remain unchanged, causing subsequent calls of said function to fail to set blending modes properly.

Only the first part of the function body that handles all cases except the <code>CustomBlending</code> mode updates the variable, the second part does not.

For example, consider the following chain of calls with the parameter of 

1. <code>NormalBlending</code> --- so far so good, 
2. then with <code>CustomBlending</code> --- sets everything properly through gl calls, but <code>currentBlendingMode</code> remains erroneously as <code>NormalBlending</code>,
3. <code>NormalBlending</code> --- will cause the function to think it's a repeated call, and consequently, we are in the same mode, so no gl calls are invoked to switch back from custom blending mode.

To avoid duplicate code, instead of simply setting the variable in the second part as well, I moved out the whole thing and put it at the end of the function.

This bug exists in the latest release (r86) as well as in the current dev branch.