### PR TITLE
Updated raycast function for indexed buffer geometry with multi material

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -154,13 +154,13 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			
 			if ( material.length && faceIndex ) {
 				
-				let groups = object.geometry.groups;
+				var groups = object.geometry.groups;
 				
 				if ( groups ) {
 					
-					for ( let i = 0; i < groups.length; i++ ) {
+					for ( var i = 0; i < groups.length; i++ ) {
 						
-						let group = groups[ i ];
+						var group = groups[ i ];
 						
 						if ( faceIndex >= group.start && faceIndex <= group.start + group.count ) {
 							
@@ -172,13 +172,11 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 						
 					}
 					
-				} else {
-					
-					faceMaterial = material;
-					
 				}
 				
-			} else {
+			}
+			
+			if ( faceMaterial === undefined ) {
 				
 				faceMaterial = material;
 				

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -147,17 +147,50 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
-		function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point ) {
+		function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point, faceIndex ) {
 
 			var intersect;
+			var faceMaterial;
+			
+			if ( material.length && faceIndex ) {
+				
+				let groups = object.geometry.groups;
+				
+				if ( groups ) {
+					
+					for ( let i = 0; i < groups.length; i++ ) {
+						
+						let group = groups[ i ];
+						
+						if ( faceIndex >= group.start && faceIndex <= group.start + group.count ) {
+							
+							faceMaterial = object.materials[ i ];
+							
+							break;
+							
+						}
+						
+					}
+					
+				} else {
+					
+					faceMaterial = material;
+					
+				}
+				
+			} else {
+				
+				faceMaterial = material;
+				
+			}
 
-			if ( material.side === BackSide ) {
+			if ( faceMaterial.side === BackSide ) {
 
 				intersect = ray.intersectTriangle( pC, pB, pA, true, point );
 
 			} else {
 
-				intersect = ray.intersectTriangle( pA, pB, pC, material.side !== DoubleSide, point );
+				intersect = ray.intersectTriangle( pA, pB, pC, faceMaterial.side !== DoubleSide, point );
 
 			}
 
@@ -178,13 +211,13 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
-		function checkBufferGeometryIntersection( object, raycaster, ray, position, uv, a, b, c ) {
+		function checkBufferGeometryIntersection( object, raycaster, ray, position, uv, a, b, c, faceIndex ) {
 
 			vA.fromBufferAttribute( position, a );
 			vB.fromBufferAttribute( position, b );
 			vC.fromBufferAttribute( position, c );
 
-			var intersection = checkIntersection( object, object.material, raycaster, ray, vA, vB, vC, intersectionPoint );
+			var intersection = checkIntersection( object, object.material, raycaster, ray, vA, vB, vC, intersectionPoint, faceIndex );
 
 			if ( intersection ) {
 
@@ -257,7 +290,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 						b = index.getX( i + 1 );
 						c = index.getX( i + 2 );
 
-						intersection = checkBufferGeometryIntersection( this, raycaster, ray, position, uv, a, b, c );
+						intersection = checkBufferGeometryIntersection( this, raycaster, ray, position, uv, a, b, c, i );
 
 						if ( intersection ) {
 


### PR DESCRIPTION
For indexed buffer geometry using multi-materials the current intersect objects functions neglects the material side property ( material.side === undefined ) forcing backface culling. This causes faces to be missed regardless of if the material side property is set to THREE.DoubleSide. The proposed solution alters the functions checkIntersection, checkBufferGeometryIntersection, and Mesh.raycast. The faceIndex of the current triangle being checked is sent to checkBufferGeometryIntersection which forwards it to checkIntersection. In checkIntersection the material is tested to see if it is a multi-material and also if a faceIndex is passed in ( to avoid conflict with non indexed buffer geometry ). If it is a multi material the function then checks the groups associated with the geometry ( if any ) and determines which material is being targeted by the faceIndex. This allows the function to accurately get the material.side value to give a proper backface culling value.