### PR TITLE
Vector4: set default to zero vector

### DIFF
--- a/docs/api/math/Vector4.html
+++ b/docs/api/math/Vector4.html
@@ -39,7 +39,7 @@
 		<code>
 var a = new THREE.Vector4( 0, 1, 0, 0 );
 
-//no arguments; will be initialised to (0, 0, 0, 1)
+//no arguments; will be initialised to (0, 0, 0, 0)
 var b = new THREE.Vector4( );
 
 var d = a.dot( b );
@@ -53,7 +53,7 @@ var d = a.dot( b );
 		[page:Float x] - the x value of the vector. Default is *0*.<br />
 		[page:Float y] -  the y value of the vector. Default is *0*.<br />
 		[page:Float z] - the z value of the vector. Default is *0*.<br />
-		[page:Float w] - the w value of the vector. Default is *1*.<br /><br />
+		[page:Float w] - the w value of the vector. Default is *0*.<br /><br />
 
 		Creates a new [name].
 		</div>

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -11,7 +11,7 @@ function Vector4( x, y, z, w ) {
 	this.x = x || 0;
 	this.y = y || 0;
 	this.z = z || 0;
-	this.w = ( w !== undefined ) ? w : 1;
+	this.w = w || 0;
 
 }
 


### PR DESCRIPTION
...as proposed in https://github.com/mrdoob/three.js/pull/11765#discussion_r127547130.

Make sure this is noted in the migration guide.
```
var vector = new THREE.Vector4(); // initializes to all zeros; previously [ 0, 0, 0, 1 ]
```