### PR TITLE
Simply changed 'The' to 'This'

### DIFF
--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -15,8 +15,8 @@
 		<div class="desc">
 			A material for non-shiny surfaces, without specular highlights.<br /><br />
 
-			The uses a non-physically based [link:https://en.wikipedia.org/wiki/Lambertian_reflectance Lambertian]
-			model	for calculating reflectance. This can simulate some surfaces (such as untreated wood or stone) well,
+			This uses a non-physically based [link:https://en.wikipedia.org/wiki/Lambertian_reflectance Lambertian]
+			model for calculating reflectance. This can simulate some surfaces (such as untreated wood or stone) well,
 			but cannot simulate shiny surfaces with specular highlights (such as varnished wood).<br /><br />
 
 


### PR DESCRIPTION
Simply changed 'The' to 'This' as 'The' is usually an article for a noun and therefore 'The uses a' doesn't make sense but as it is referencing the function, 'This uses a', does (if it is not referencing this function, please clarify).