### PR TITLE
[gltf] Avoid duplicate mesh/parent names.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2345,7 +2345,7 @@ THREE.GLTF2Loader = ( function () {
 
 					}
 
-					meshNode.name = ( name === "0" ? group.name : group.name + name );
+					meshNode.name = group.name + '_' + name;
 
 					if ( primitive.extras ) meshNode.userData = primitive.extras;
 


### PR DESCRIPTION
Fixes #11784.

A previous PR retained the group wrapping meshes (to avoid dropping any `extras` set on it), but that introduces some duplicate names, causing animations to mistarget.