### PR TITLE
fix gltf2loader morph target doesn’t work in some case

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2234,8 +2234,21 @@ THREE.GLTF2Loader = ( function () {
 
 									for ( var j = 0, jl = positionAttribute.array.length; j < jl; j ++ ) {
 
-										positionAttribute.array[ j ] += position.array[ j ];
-
+									    // vertex saved in single buffer view
+                                        // p0,n0,t0,w0,p1,n1,t1,w1,...pn,nn,tn,wn in buffer
+                                        // so we need calculate offset & stride
+                                        if (position.data !== undefined) {
+                                            var index = Math.floor(j / position.itemSize) * position.data.stride + position.offset;
+                                            positionAttribute.array[ j ] += position.array[ j%position.itemSize +index];
+                                        }
+                                        // vertex saved in separate buffer
+                                        // view
+                                        // p0,p1,p2...pn,
+                                        // n0,n1,n2...nn,
+                                        // t0,t1,t2...tn
+                                        else {
+                                            positionAttribute.array[ j ] += position.array[ j ];
+                                        }
 									}
 
 								} else {
@@ -2257,8 +2270,13 @@ THREE.GLTF2Loader = ( function () {
 
 									for ( var j = 0, jl = normalAttribute.array.length; j < jl; j ++ ) {
 
-										normalAttribute.array[ j ] += normal.array[ j ];
-
+                                        if (normal.data !== undefined) {
+                                            var index = Math.floor(j / normal.itemSize) * normal.data.stride + normal.offset;
+                                            normalAttribute.array[ j ] += normal.array[ j%normal.itemSize +index];
+                                        }
+                                        else {
+                                            normalAttribute.array[ j ] += normal.array[ j ];
+                                        }
 									}
 
 								} else {
@@ -2692,7 +2710,11 @@ THREE.GLTF2Loader = ( function () {
 										break;
 
 									default:
-										child = new THREE.Mesh( originalGeometry, material );
+									    // save morph targets before replace
+                                        // meshes
+                                        var morph = child.morphTargetInfluences;
+                                        child = new THREE.Mesh( originalGeometry, material );
+                                        child.morphTargetInfluences = morph;
 
 								}
 

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2234,21 +2234,9 @@ THREE.GLTF2Loader = ( function () {
 
 									for ( var j = 0, jl = positionAttribute.array.length; j < jl; j ++ ) {
 
-									    // vertex saved in single buffer view
-                                        // p0,n0,t0,w0,p1,n1,t1,w1,...pn,nn,tn,wn in buffer
-                                        // so we need calculate offset & stride
-                                        if (position.data !== undefined) {
-                                            var index = Math.floor(j / position.itemSize) * position.data.stride + position.offset;
-                                            positionAttribute.array[ j ] += position.array[ j%position.itemSize +index];
-                                        }
-                                        // vertex saved in separate buffer
-                                        // view
-                                        // p0,p1,p2...pn,
-                                        // n0,n1,n2...nn,
-                                        // t0,t1,t2...tn
-                                        else {
-                                            positionAttribute.array[ j ] += position.array[ j ];
-                                        }
+                                        positionAttribute.setXYZ(j,positionAttribute.getX( j ) + position.getX( j ),
+                                            positionAttribute.getY( j ) + position.getY( j ),
+                                            positionAttribute.getZ( j ) + position.getZ( j ));
 									}
 
 								} else {
@@ -2270,13 +2258,9 @@ THREE.GLTF2Loader = ( function () {
 
 									for ( var j = 0, jl = normalAttribute.array.length; j < jl; j ++ ) {
 
-                                        if (normal.data !== undefined) {
-                                            var index = Math.floor(j / normal.itemSize) * normal.data.stride + normal.offset;
-                                            normalAttribute.array[ j ] += normal.array[ j%normal.itemSize +index];
-                                        }
-                                        else {
-                                            normalAttribute.array[ j ] += normal.array[ j ];
-                                        }
+                                        normalAttribute.setXYZ(j,normalAttribute.getX( j ) + normal.getX( j ),
+                                            normalAttribute.getY( j ) + normal.getY( j ),
+                                            normalAttribute.getZ( j ) + normal.getZ( j ));
 									}
 
 								} else {


### PR DESCRIPTION
fix two bugs:
1. If vertexes' attributes saved in a single buffer view, morph targets don't work
2. After load meshes, mesh's morphTargetInfluences will be erased