### PR TITLE
POC: volatile eye materials

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1674,6 +1674,10 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		if ( material.volatile ) {
+			refreshMaterial = true;
+		}
+
 		if ( refreshProgram || camera !== _currentCamera ) {
 
 			p_uniforms.setValue( _gl, 'projectionMatrix', camera.projectionMatrix );


### PR DESCRIPTION
Currently with WebVRManager/ArrayCamera it seems you can't twiddle uniforms between eyes w/ `onBeforeRender` and such. That would a useful ability for tricks like 3d envmap/mirror shaders that pass different texture data to each eye.

I get that this array camera cache here is for performance, but I'm wondering if it makes sense to have a material `volatile`/`arrayVolatile` (or something with a better name) that lets you override the check and force the uniform update when you really want to...

Or does THREE.js have a better way to support this use case?