### PR TITLE
Remove THREE. prefix from Vector3 in MeshDistanceMaterial

### DIFF
--- a/src/materials/MeshDistanceMaterial.js
+++ b/src/materials/MeshDistanceMaterial.js
@@ -1,4 +1,5 @@
 import { Material } from './Material';
+import { Vector3 } from '../math/Vector3.js';
 
 /**
  * @author WestLangley / http://github.com/WestLangley
@@ -29,7 +30,7 @@ function MeshDistanceMaterial( parameters ) {
 
 	this.type = 'MeshDistanceMaterial';
 
-	this.referencePosition = new THREE.Vector3();
+	this.referencePosition = new Vector3();
 	this.nearDistance = 1;
 	this.farDistance = 1000;
 


### PR DESCRIPTION
A `THREE.` prefix was left in `MeshDistanceMaterial`. It was interfering in a custom rollup build of mine. All good now ;)