### PR TITLE
Fix export for multiple materials per mesh.

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -98,11 +98,12 @@ def cast_shadow(obj):
             ret = None
         return ret
     elif obj.type == MESH:
-        mat = material(obj)
-        if mat:
-            return data.materials[mat].use_cast_shadows
-        else:
-            return False
+        mats = material(obj)
+        if mats:
+            for m in mats:
+                if data.materials[m].use_cast_shadows:
+                    return True
+        return False
 
 
 @_object
@@ -127,8 +128,10 @@ def material(obj):
 
     """
     logger.debug('object.material(%s)', obj)
+
     try:
-        return obj.material_slots[0].name
+        matName = obj.material_slots[0].name # manthrax: Make this throw an error on an empty material array, resulting in non-material
+        return [o.name for o in obj.material_slots]
     except IndexError:
         pass
 
@@ -361,13 +364,15 @@ def receive_shadow(obj):
 
     """
     if obj.type == MESH:
-        mat = material(obj)
-        if mat:
-            return data.materials[mat].use_shadows
-        else:
-            return False
+        mats = material(obj)
+        if mats:
+            for m in mats:
+                if data.materials[m].use_shadows:
+                    return True
+        return False
 
-AXIS_CONVERSION = axis_conversion(to_forward='Z', to_up='Y').to_4x4()
+# manthrax: TODO: Would like to evaluate wether this axis conversion stuff is still neccesary AXIS_CONVERSION = mathutils.Matrix()
+AXIS_CONVERSION = axis_conversion(to_forward='Z', to_up='Y').to_4x4() 
 
 @_object
 def matrix(obj, options):

--- a/utils/exporters/blender/addons/io_three/exporter/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/object.py
@@ -90,13 +90,21 @@ class Object(base_classes.BaseNode):
 
         if self.options.get(constants.MATERIALS):
             logger.info("Parsing materials for %s", self.node)
-            material_name = api.object.material(self.node)
-            if material_name:
-                logger.info("Material found %s", material_name)
-                material_inst = self.scene.material(material_name)
-                self[constants.MATERIAL] = material_inst[constants.UUID]
+
+
+            material_names = api.object.material(self.node) #manthrax: changes for multimaterial start here
+            if material_names:
+                logger.info("Got material names for this object:",material_names);
+                materialArray = [self.scene.material(objname)[constants.UUID] for objname in material_names]
+                if len(materialArray) == 0:  # If no materials.. dont export a material entry
+                    materialArray = None
+                elif len(materialArray) == 1: # If only one material, export material UUID singly, not as array
+                    materialArray = materialArray[0]
+                # else export array of material uuids
+                self[constants.MATERIAL] = materialArray
+                logger.info("materials:",self[constants.MATERIAL]);
             else:
-                logger.info("%s has no materials", self.node)
+                logger.info("%s has no materials", self.node) #manthrax: end multimaterial
 
         # TODO (abelnation): handle Area lights
         casts_shadow = (constants.MESH,


### PR DESCRIPTION
I've expanded the exporters material processing to deal with all materials assigned to an object.
In the case of no material, no material field is emitted.
In the case of 1 material, a single uuids is emitted.
In the case of >1 material, an array of material uuids is emitted.

Closes #11793