### PR TITLE
ColladaLoader2: Fix buildVisualScene

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -3097,7 +3097,17 @@ THREE.ColladaLoader.prototype = {
 
 				var child = children[ i ];
 
-				group.add( getNode( child.id ) );
+				if ( child.id === null ) {
+
+					group.add( buildNode( child ) );
+
+				} else {
+
+					// if there is an ID, let's try to get the finished build (e.g. joints are already build)
+
+					group.add( getNode( child.id ) );
+
+				}
 
 			}
 


### PR DESCRIPTION
In some cases nodes don't have IDs. Nodes without IDs are definitely not build when `.buildVisualScene()` is called. So for these nodes we execute a build now. In all other cases we try to fetch the finished build with `.getNode( id )`.

I've encountered this problem here: #11807