### PR TITLE
Equirect shader: fixed equirectangular projection

### DIFF
--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -172,15 +172,10 @@ var ShaderLib = {
 
 	},
 
-	/* -------------------------------------------------------------------------
-	//	Cube map shader
-	 ------------------------------------------------------------------------- */
-
 	equirect: {
 
 		uniforms: {
 			tEquirect: { value: null },
-			tFlip: { value: - 1 }
 		},
 
 		vertexShader: ShaderChunk.equirect_vert,

--- a/src/renderers/shaders/ShaderLib/equirect_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/equirect_frag.glsl
@@ -1,5 +1,4 @@
 uniform sampler2D tEquirect;
-uniform float tFlip;
 
 varying vec3 vWorldPosition;
 
@@ -7,11 +6,14 @@ varying vec3 vWorldPosition;
 
 void main() {
 
-	// 	gl_FragColor = textureCube( tCube, vec3( tFlip * vWorldPosition.x, vWorldPosition.yz ) );
 	vec3 direction = normalize( vWorldPosition );
+
 	vec2 sampleUV;
-	sampleUV.y = saturate( tFlip * direction.y * -0.5 + 0.5 );
+
+	sampleUV.y = asin( clamp( direction.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;
+
 	sampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_PI2 + 0.5;
+
 	gl_FragColor = texture2D( tEquirect, sampleUV );
 
 }


### PR DESCRIPTION
The equirectangular map distortion in `webgl_materials_envmaps.html` is now fixed.