### PR TITLE
[gltf] Morph target bug fixes.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2237,21 +2237,9 @@ THREE.GLTF2Loader = ( function () {
 
 									for ( var j = 0, jl = positionAttribute.array.length; j < jl; j ++ ) {
 
-									    // vertex saved in single buffer view
-                                        // p0,n0,t0,w0,p1,n1,t1,w1,...pn,nn,tn,wn in buffer
-                                        // so we need calculate offset & stride
-                                        if (position.data !== undefined) {
-                                            var index = Math.floor(j / position.itemSize) * position.data.stride + position.offset;
-                                            positionAttribute.array[ j ] += position.array[ j%position.itemSize +index];
-                                        }
-                                        // vertex saved in separate buffer
-                                        // view
-                                        // p0,p1,p2...pn,
-                                        // n0,n1,n2...nn,
-                                        // t0,t1,t2...tn
-                                        else {
-                                            positionAttribute.array[ j ] += position.array[ j ];
-                                        }
+                                        positionAttribute.setXYZ(j,positionAttribute.getX( j ) + position.getX( j ),
+                                            positionAttribute.getY( j ) + position.getY( j ),
+                                            positionAttribute.getZ( j ) + position.getZ( j ));
 									}
 
 								} else {
@@ -2273,13 +2261,9 @@ THREE.GLTF2Loader = ( function () {
 
 									for ( var j = 0, jl = normalAttribute.array.length; j < jl; j ++ ) {
 
-                                        if (normal.data !== undefined) {
-                                            var index = Math.floor(j / normal.itemSize) * normal.data.stride + normal.offset;
-                                            normalAttribute.array[ j ] += normal.array[ j%normal.itemSize +index];
-                                        }
-                                        else {
-                                            normalAttribute.array[ j ] += normal.array[ j ];
-                                        }
+                                        normalAttribute.setXYZ(j,normalAttribute.getX( j ) + normal.getX( j ),
+                                            normalAttribute.getY( j ) + normal.getY( j ),
+                                            normalAttribute.getZ( j ) + normal.getZ( j ));
 									}
 
 								} else {

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1911,7 +1911,7 @@ THREE.GLTF2Loader = ( function () {
 							var sampler = samplers[ texture.sampler ] || {};
 
 							_texture.magFilter = WEBGL_FILTERS[ sampler.magFilter ] || THREE.LinearFilter;
-							_texture.minFilter = WEBGL_FILTERS[ sampler.minFilter ] || THREE.NearestMipMapLinearFilter;
+							_texture.minFilter = WEBGL_FILTERS[ sampler.minFilter ] || THREE.LinearMipMapLinearFilter;
 							_texture.wrapS = WEBGL_WRAPPINGS[ sampler.wrapS ] || THREE.RepeatWrapping;
 							_texture.wrapT = WEBGL_WRAPPINGS[ sampler.wrapT ] || THREE.RepeatWrapping;
 
@@ -2235,14 +2235,18 @@ THREE.GLTF2Loader = ( function () {
 									positionAttribute = dependencies.accessors[ target.POSITION ].clone();
 									var position = geometry.attributes.position;
 
-									for ( var j = 0, jl = positionAttribute.array.length; j < jl; j ++ ) {
+									for ( var j = 0, jl = positionAttribute.count; j < jl; j ++ ) {
 
-                                        positionAttribute.setXYZ(j,positionAttribute.getX( j ) + position.getX( j ),
-                                            positionAttribute.getY( j ) + position.getY( j ),
-                                            positionAttribute.getZ( j ) + position.getZ( j ));
+										positionAttribute.setXYZ(
+											j,
+											positionAttribute.getX( j ) + position.getX( j ),
+											positionAttribute.getY( j ) + position.getY( j ),
+											positionAttribute.getZ( j ) + position.getZ( j )
+										);
+
 									}
 
-								} else {
+								} else if ( geometry.attributes.position ) {
 
 									// Copying the original position not to affect the final position.
 									// See the formula above.
@@ -2259,14 +2263,18 @@ THREE.GLTF2Loader = ( function () {
 									normalAttribute = dependencies.accessors[ target.NORMAL ].clone();
 									var normal = geometry.attributes.normal;
 
-									for ( var j = 0, jl = normalAttribute.array.length; j < jl; j ++ ) {
+									for ( var j = 0, jl = normalAttribute.count; j < jl; j ++ ) {
 
-                                        normalAttribute.setXYZ(j,normalAttribute.getX( j ) + normal.getX( j ),
-                                            normalAttribute.getY( j ) + normal.getY( j ),
-                                            normalAttribute.getZ( j ) + normal.getZ( j ));
+										normalAttribute.setXYZ(
+											j,
+											normalAttribute.getX( j ) + normal.getX( j ),
+											normalAttribute.getY( j ) + normal.getY( j ),
+											normalAttribute.getZ( j ) + normal.getZ( j )
+										);
+
 									}
 
-								} else {
+								} else if ( geometry.attributes.normal ) {
 
 									normalAttribute = geometry.attributes.normal.clone();
 
@@ -2277,11 +2285,19 @@ THREE.GLTF2Loader = ( function () {
 
 								}
 
-								positionAttribute.name = attributeName;
-								normalAttribute.name = attributeName;
+								if ( positionAttribute ) {
 
-								morphAttributes.position.push( positionAttribute );
-								morphAttributes.normal.push( normalAttribute );
+									positionAttribute.name = attributeName;
+									morphAttributes.position.push( positionAttribute );
+
+								}
+
+								if ( normalAttribute ) {
+
+									normalAttribute.name = attributeName;
+									morphAttributes.normal.push( normalAttribute );
+
+								}
 
 							}
 
@@ -2698,11 +2714,7 @@ THREE.GLTF2Loader = ( function () {
 										break;
 
 									default:
-									    // save morph targets before replace
-                                        // meshes
-                                        var morph = child.morphTargetInfluences;
-                                        child = new THREE.Mesh( originalGeometry, material );
-                                        child.morphTargetInfluences = morph;
+										child = new THREE.Mesh( originalGeometry, material );
 
 								}
 

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2237,8 +2237,21 @@ THREE.GLTF2Loader = ( function () {
 
 									for ( var j = 0, jl = positionAttribute.array.length; j < jl; j ++ ) {
 
-										positionAttribute.array[ j ] += position.array[ j ];
-
+									    // vertex saved in single buffer view
+                                        // p0,n0,t0,w0,p1,n1,t1,w1,...pn,nn,tn,wn in buffer
+                                        // so we need calculate offset & stride
+                                        if (position.data !== undefined) {
+                                            var index = Math.floor(j / position.itemSize) * position.data.stride + position.offset;
+                                            positionAttribute.array[ j ] += position.array[ j%position.itemSize +index];
+                                        }
+                                        // vertex saved in separate buffer
+                                        // view
+                                        // p0,p1,p2...pn,
+                                        // n0,n1,n2...nn,
+                                        // t0,t1,t2...tn
+                                        else {
+                                            positionAttribute.array[ j ] += position.array[ j ];
+                                        }
 									}
 
 								} else {
@@ -2260,8 +2273,13 @@ THREE.GLTF2Loader = ( function () {
 
 									for ( var j = 0, jl = normalAttribute.array.length; j < jl; j ++ ) {
 
-										normalAttribute.array[ j ] += normal.array[ j ];
-
+                                        if (normal.data !== undefined) {
+                                            var index = Math.floor(j / normal.itemSize) * normal.data.stride + normal.offset;
+                                            normalAttribute.array[ j ] += normal.array[ j%normal.itemSize +index];
+                                        }
+                                        else {
+                                            normalAttribute.array[ j ] += normal.array[ j ];
+                                        }
 									}
 
 								} else {
@@ -2696,7 +2714,11 @@ THREE.GLTF2Loader = ( function () {
 										break;
 
 									default:
-										child = new THREE.Mesh( originalGeometry, material );
+									    // save morph targets before replace
+                                        // meshes
+                                        var morph = child.morphTargetInfluences;
+                                        child = new THREE.Mesh( originalGeometry, material );
+                                        child.morphTargetInfluences = morph;
 
 								}
 


### PR DESCRIPTION
- Allow morph targets to include positions without normals and vice versa (fixes https://github.com/donmccurdy/three-gltf-viewer/issues/25)
- Allow interleaved buffers in morph targets (this PR includes #11786, with two commits by @samwei12 )
- Changes texture default to `minFilter = THREE.LinearMipMapLinearFilter`. glTF spec says engine should decide unless specified in the file, and this is three.js's default anyway.