### PR TITLE
Use unit norm when finding plane distanceToPoint

### DIFF
--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -98,7 +98,7 @@ Object.assign( Plane.prototype, {
 
 	distanceToPoint: function ( point ) {
 
-		return this.normal.dot( point ) + this.constant;
+		return this.normal.dot( point ) / this.normal.length() + this.constant;
 
 	},
 


### PR DESCRIPTION
In case the normal supplied is not of unit length.