### PR TITLE
Fix cubic bezier curves to use vec3s for points instead of vec2s

### DIFF
--- a/src/extras/curves/CubicBezierCurve.js
+++ b/src/extras/curves/CubicBezierCurve.js
@@ -1,6 +1,6 @@
 import { Curve } from '../core/Curve';
 import { CubicBezier } from '../core/Interpolations';
-import { Vector2 } from '../../math/Vector2';
+import { Vector3 } from '../../math/Vector3';
 
 
 function CubicBezierCurve( v0, v1, v2, v3 ) {
@@ -21,9 +21,10 @@ CubicBezierCurve.prototype.getPoint = function ( t ) {
 
 	var v0 = this.v0, v1 = this.v1, v2 = this.v2, v3 = this.v3;
 
-	return new Vector2(
+	return new Vector3(
 		CubicBezier( t, v0.x, v1.x, v2.x, v3.x ),
-		CubicBezier( t, v0.y, v1.y, v2.y, v3.y )
+		CubicBezier( t, v0.y, v1.y, v2.y, v3.y ),
+		CubicBezier( t, v0.z, v1.z, v2.z, v3.z )
 	);
 
 };


### PR DESCRIPTION
I was trying to use CubicBezierCurve as a path for TubeGeometry and ExtrudeGeometry and it was failing due to returning Vector2's with no z component instead of Vector3's.  This fixes that.