### PR TITLE
Update material-browser.html

### DIFF
--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -44,7 +44,7 @@
 
 			var gui = new dat.GUI();
 			var scene = new THREE.Scene();
-			var camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 50 );
+			var camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 10, 50 );
 			camera.position.z = 30;
 
 			var renderer = new THREE.WebGLRenderer( { antialias: true } );


### PR DESCRIPTION
Pushed out near plane so depth variation is visible in `MeshDepthMaterial`. Fixes #11837.