### PR TITLE
[gltf] Use flat shading if normals are not included.

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2198,7 +2198,16 @@ THREE.GLTF2Loader = ( function () {
 
 						if ( geometry.attributes.normal === undefined ) {
 
-							material.shading = THREE.FlatShading;
+							if ( material.flatShading !== undefined ) {
+
+								material.flatShading = true;
+
+							} else {
+
+								// TODO: Remove this backwards-compatibility fix after r87 release.
+								material.shading = THREE.FlatShading;
+
+							}
 
 						}
 

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2196,6 +2196,12 @@ THREE.GLTF2Loader = ( function () {
 
 						}
 
+						if ( geometry.attributes.normal === undefined ) {
+
+							material.shading = THREE.FlatShading;
+
+						}
+
 						meshNode = new THREE.Mesh( geometry, material );
 						meshNode.castShadow = true;
 


### PR DESCRIPTION
[From spec](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#meshes):

> Implementation note: When normals are not specified, client implementations should calculate flat normals.

This helps with models created by obj2gltf, which may not always include normals.