### PR TITLE
Correct Layers doc typo.

### DIFF
--- a/docs/api/core/Layers.html
+++ b/docs/api/core/Layers.html
@@ -28,7 +28,7 @@
 
 		<h3>[name]()</h3>
 		<div>
-		Create a new Layers object, with an initial mask set to layer 1.
+		Create a new Layers object, with an initial mask set to 1 (layer 0).
 		</div>
 
 		<h2>Properties</h2>


### PR DESCRIPTION
The documentation says objects start out on layer 1, but as far as I can tell, an object's layers are initialized to layer 0, which corresponds to a mask of `1`, perhaps the source of the confusion?