### PR TITLE
Gltf2 material extras

### DIFF
--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -252,7 +252,12 @@
 		<div>
 		Defines whether this material is visible. Default is *true*.
 		</div>
-
+		
+		<h3>[property:object userData]</h3>
+		<div>
+		An object that can be used to store custom data about the Material. It should not hold
+		references to functions as these will not be cloned.
+		</div>
 
 		<h2>Methods</h2>
 

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2107,7 +2107,9 @@ THREE.GLTF2Loader = ( function () {
 				// Normal map textures use OpenGL conventions:
 				// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#materialnormaltexture
 				_material.normalScale.x = -1;
-
+				
+				_material.userData = material.extras;
+				
 				return _material;
 
 			} );

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -62,6 +62,8 @@ function Material() {
 	this.visible = true;
 
 	this.needsUpdate = true;
+	
+	this.userData = {};
 
 }
 
@@ -153,6 +155,7 @@ Object.assign( Material.prototype, EventDispatcher.prototype, {
 		data.type = this.type;
 
 		if ( this.name !== '' ) data.name = this.name;
+		if ( JSON.stringify( this.userData ) !== '{}' ) data.userData = this.userData;
 
 		if ( this.color && this.color.isColor ) data.color = this.color.getHex();
 
@@ -331,6 +334,7 @@ Object.assign( Material.prototype, EventDispatcher.prototype, {
 		}
 
 		this.clippingPlanes = dstPlanes;
+		this.userData = JSON.parse( JSON.stringify( source.userData ) );
 
 		return this;
 


### PR DESCRIPTION
Make GLTF2.Material.Extras accessible 
I added the userData for Matrerial so the extra section of GLTF2 can be representated.

