### PR TITLE
Update innerRadius defaults in RingGeometry docs

### DIFF
--- a/docs/api/geometries/RingBufferGeometry.html
+++ b/docs/api/geometries/RingBufferGeometry.html
@@ -44,7 +44,7 @@
 
 		<h3>[name]([page:Float innerRadius], [page:Float outerRadius], [page:Integer thetaSegments], [page:Integer phiSegments], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
-		innerRadius — Default is 0, but it doesn't work right when innerRadius is set to 0.<br />
+		innerRadius — Default is 20. <br />
 		outerRadius — Default is 50. <br />
 		thetaSegments — Number of segments.  A higher number means the ring will be more round.  Minimum is 3.  Default is 8. <br />
 		phiSegments — Minimum is 1.  Default is 8.<br />

--- a/docs/api/geometries/RingGeometry.html
+++ b/docs/api/geometries/RingGeometry.html
@@ -44,7 +44,7 @@
 
 		<h3>[name]([page:Float innerRadius], [page:Float outerRadius], [page:Integer thetaSegments], [page:Integer phiSegments], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
-		innerRadius — Default is 0, but it doesn't work right when innerRadius is set to 0.<br />
+		innerRadius — Default is 20. <br />
 		outerRadius — Default is 50. <br />
 		thetaSegments — Number of segments.  A higher number means the ring will be more round.  Minimum is 3.  Default is 8. <br />
 		phiSegments — Minimum is 1.  Default is 8.<br />


### PR DESCRIPTION
Just a small fix to bring the documentation in line with the behaviour here: https://github.com/mrdoob/three.js/blob/master/src/geometries/RingGeometry.js#L54