### PR TITLE
Fix: Improve rendering performance in VR

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -399,12 +399,12 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			return;
 
+		} else {
+			
+			// Regular render mode if not HMD
+			renderer.render( scene, camera, renderTarget, forceClear );
+			
 		}
-
-		// Regular render mode if not HMD
-
-		renderer.render( scene, camera, renderTarget, forceClear );
-
 	};
 
 	this.dispose = function () {


### PR DESCRIPTION
Currently when you're in VR, VREffect is rendering the entire scene unnecessarily. Every frame! The performance hit is most noticeable on mobile devices