### PR TITLE
GLTF2Loader: fix drawMode

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2758,6 +2758,7 @@ THREE.GLTF2Loader = ( function () {
 							for ( var childrenId in group.children ) {
 
 								var child = group.children[ childrenId ];
+								var originalChild = child;
 
 								// clone Mesh to add to _node
 
@@ -2798,9 +2799,8 @@ THREE.GLTF2Loader = ( function () {
 										break;
 
 									default:
-										var previousDrawMode = child.drawMode;
 										child = new THREE.Mesh( originalGeometry, material );
-										child.drawMode = previousDrawMode;
+										child.drawMode = originalChild.drawMode;
 
 								}
 

--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -2798,7 +2798,9 @@ THREE.GLTF2Loader = ( function () {
 										break;
 
 									default:
+										var previousDrawMode = child.drawMode;
 										child = new THREE.Mesh( originalGeometry, material );
+										child.drawMode = previousDrawMode;
 
 								}
 


### PR DESCRIPTION
GLTF2Loader creates a clone of the parsed mesh but it doesn't keep the `drawMode` of the original one so it's always `TriangleDrawMode`by default.