### PR TITLE
GLTF2Exporter: Allow single object and list of objects instead of just scenes

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -805,10 +805,13 @@ THREE.GLTFExporter.prototype = {
 		function processObjects ( objects ) {
 
 			var scene = new THREE.Scene();
+			scene.name = 'AuxScene';
 
 			for ( var i = 0; i < objects.length; i++ ) {
 
-				scene.add( objects[ i ] );
+				// We push directly to children instead of calling `add` to prevent
+				// modify the .parent and break its original scene and hierarchy
+				scene.children.push( objects[ i ] );
 
 			}
 
@@ -816,43 +819,34 @@ THREE.GLTFExporter.prototype = {
 
 		}
 
+		function processInput( input ) {
 
-		if ( input instanceof Array ) {
+			input = input instanceof Array ? input : [ input ];
 
-			var allScenes = false;
+			var objectsWithoutScene = [];
 			for ( i = 0; i < input.length; i++ ) {
 
-				allScenes &= input instanceof THREE.Scene;
-
-			}
-
-			if ( allScenes ) {
-
-				for ( i = 0; i < input.length; i++ ) {
+				if ( input[ i ] instanceof THREE.Scene ) {
 
 					processScene( input[ i ] );
 
+				} else {
+
+					objectsWithoutScene.push( input[ i ] );
+
 				}
-
-			} else {
-
-				processObjects( input );
 
 			}
 
-		} else {
+			if ( objectsWithoutScene.length > 0 ) {
 
-			if ( input instanceof THREE.Scene ) {
-
-				processScene( input );
-
-			} else {
-
-				processObjects( [ input ] );
+				processObjects( objectsWithoutScene );
 
 			}
 
 		}
+
+		processInput( input );
 
 		// Generate buffer
 		// Create a new blob with all the dataviews from the buffers

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -798,18 +798,59 @@ THREE.GLTFExporter.prototype = {
 
 		}
 
-		// Process the scene/s
+		/**
+		 * Creates a THREE.Scene to hold a list of objects and parse it
+		 * @param  {Array} objects List of objects to process
+		 */
+		function processObjects ( objects ) {
+
+			var scene = new THREE.Scene();
+
+			for ( var i = 0; i < objects.length; i++ ) {
+
+				scene.add( objects[ i ] );
+
+			}
+
+			processScene( scene );
+
+		}
+
+
 		if ( input instanceof Array ) {
 
+			var allScenes = false;
 			for ( i = 0; i < input.length; i++ ) {
 
-				processScene( input[ i ] );
+				allScenes &= input instanceof THREE.Scene;
+
+			}
+
+			if ( allScenes ) {
+
+				for ( i = 0; i < input.length; i++ ) {
+
+					processScene( input[ i ] );
+
+				}
+
+			} else {
+
+				processObjects( input );
 
 			}
 
 		} else {
 
-			processScene( input );
+			if ( input instanceof THREE.Scene ) {
+
+				processScene( input );
+
+			} else {
+
+				processObjects( [ input ] );
+
+			}
 
 		}
 

--- a/examples/webgl_exporter_gltf2.html
+++ b/examples/webgl_exporter_gltf2.html
@@ -12,6 +12,7 @@
 				overflow: hidden;
 			}
 			#info {
+				color: #ccc;
 				text-align: center;
 				position: absolute;
 				top: 0px; width: 100%;
@@ -21,7 +22,12 @@
 	</head>
 	<body>
 		<div id="info">
-			<button id="export">Export scene to .GLTF</button>
+			GLTF2 Exporter<br/>
+			<button id="export_scene">Export Scene1</button>
+			<button id="export_scenes">Export Scene1 and Scene 2</button>
+			<button id="export_object">Export Sphere</button>
+			<button id="export_objects">Export Sphere and Grid</button>
+			<button id="export_scene_object">Export Scene1 and Sphere</button>
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -31,11 +37,11 @@
 
 		<script>
 
-			document.getElementById( 'export' ).addEventListener( 'click', function () {
+			function exportGLTF( input ) {
 
 				var gltfExporter = new THREE.GLTFExporter( renderer );
 
-				gltfExporter.parse( [ scene1 ], function( result ) {
+				gltfExporter.parse( input, function( result ) {
 
 					var output = JSON.stringify( result, null, 2 );
 					console.log( output );
@@ -43,7 +49,38 @@
 
 				} );
 
+			}
+
+			document.getElementById( 'export_scene' ).addEventListener( 'click', function () {
+
+				exportGLTF( scene1 );
+
 			} );
+
+			document.getElementById( 'export_scenes' ).addEventListener( 'click', function () {
+
+				exportGLTF( [ scene1, scene2 ] );
+
+			} );
+
+			document.getElementById( 'export_object' ).addEventListener( 'click', function () {
+
+				exportGLTF( sphere );
+
+			} );
+
+			document.getElementById( 'export_objects' ).addEventListener( 'click', function () {
+
+				exportGLTF( [ sphere, gridHelper ] );
+
+			} );
+
+			document.getElementById( 'export_scene_object' ).addEventListener( 'click', function () {
+
+				exportGLTF( [ scene1, gridHelper ] );
+
+			} );
+
 
 			var link = document.createElement( 'a' );
 			link.style.display = 'none';
@@ -69,13 +106,13 @@
 
 			var container;
 
-			var camera, scene1, renderer;
+			var camera, scene1, scene2, renderer;
+			var gridHelper, sphere;
 
 			init();
 			animate();
 
 			function init() {
-				var object;
 
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );
@@ -107,7 +144,7 @@
 				// ---------------------------------------------------------------------
 				// Grid
 				// ---------------------------------------------------------------------
-				var gridHelper = new THREE.GridHelper( 2000, 20 );
+				gridHelper = new THREE.GridHelper( 2000, 20 );
 				gridHelper.position.y = -50;
 				gridHelper.name = "Grid";
 				scene1.add( gridHelper );
@@ -167,10 +204,10 @@
 					roughness: 1.0,
 					flatShading: true
 				} );
-				object = new THREE.Mesh( new THREE.SphereBufferGeometry( 70, 10, 10 ), material );
-				object.position.set( 0, 0, 0 );
-				object.name = "Sphere";
-				scene1.add( object );
+				sphere = new THREE.Mesh( new THREE.SphereBufferGeometry( 70, 10, 10 ), material );
+				sphere.position.set( 0, 0, 0 );
+				sphere.name = "Sphere";
+				scene1.add( sphere );
 
 				// Cylinder
 				material = new THREE.MeshStandardMaterial( {
@@ -362,7 +399,7 @@
 				// ---------------------------------------------------------------------
 				// 2nd Scene
 				// ---------------------------------------------------------------------
-				var scene2 = new THREE.Scene();
+				scene2 = new THREE.Scene();
 				object = new THREE.Mesh( new THREE.BoxBufferGeometry( 100, 100, 100 ), material );
 				object.position.set( 0, 0, 0 );
 				object.name = "Cube2ndScene";


### PR DESCRIPTION
It lets you to export single objects instead of the whole scene:

Valid options:
- Export scenes
```javascript
gltfExporter.parse( scene1, ...)
gltfExporter.parse( [ scene1, scene2 ], ...)
```

- Export objects (It will create a new Scene to hold them all inside)
```js
gltfExporter.parse( object1, ...)
gltfExporter.parse( [ object1, object2 ], ...)
```

- Mix scenes and objects (It will export the scenes as usual but it will create a new scene to hold all the single objects).
```js
gltfExporter.parse( [ scene1, object1, object2, scene2 ], ...)
```

Added new buttons to test this functionality:
![image](https://user-images.githubusercontent.com/782511/29311202-29b8a728-81b1-11e7-92c0-544eb50f2057.png)



