### PR TITLE
Re-add "accessors" as mesh dependency

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -1772,6 +1772,7 @@ THREE.GLTF2Loader = ( function () {
 
 		return this._withDependencies( [
 
+			'accessors',
 			'materials'
 
 		] ).then( function ( dependencies ) {


### PR DESCRIPTION
Needed for `addMorphTargets`, which accesses `accessors` on `dependencies`