### PR TITLE
Check asset existence to detect glTF version

### DIFF
--- a/examples/js/loaders/GLTF2Loader.js
+++ b/examples/js/loaders/GLTF2Loader.js
@@ -79,7 +79,7 @@ THREE.GLTF2Loader = ( function () {
 
 			var json = JSON.parse( content );
 
-			if ( json.asset.version[0] < 2 ) {
+			if ( json.asset === undefined || json.asset.version[ 0 ] < 2 ) {
 
 				onError( new Error( 'THREE.GLTF2Loader: Legacy glTF detected. Use THREE.GLTFLoader instead.' ) );
 				return;


### PR DESCRIPTION
`asset` isn't required in glTF 1.0
https://github.com/KhronosGroup/glTF/tree/master/specification/1.0#gltf
so we need to check if it exists.

`asset` is required in 2.0, so if it doesn't exist the glTF should be 1.0.
https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#gltf

/cc @donmccurdy 

#11951
