### PR TITLE
Fixed document typo

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -441,7 +441,7 @@
 
 		<h3>[method:null setSize]( [page:Integer width], [page:Integer height], [page:Boolean updateStyle] )</h3>
 		<div>
-		Resizes the output canvas to (width, height) with device pixel ratio taken into account,
+		Resizes the output canvas to (width, height) without device pixel ratio taken into account,
 			and also sets the viewport to fit that size, starting in (0, 0).
 			Setting [page:Boolean updateStyle] to true adds explicit pixel units to the output canvas style.
 		</div>


### PR DESCRIPTION
I guess `renderer.setSize` shouldn't take device pixel ratio into account. It doesn't work well when I multiply `window.innerWidth` and `window.innerHeight` by `window.devicePixelRatio` using Retina screen, whose `window.devicePixelRatio` equals to `2`.