### PR TITLE
Consider the case when vrdisplaypresentchange fires but device is null.

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -43,7 +43,7 @@ function WebVRManager( renderer ) {
 
 	function onVRDisplayPresentChange() {
 
-		if ( device.isPresenting ) {
+		if ( device !== null && device.isPresenting ) {
 
 			var eyeParameters = device.getEyeParameters( 'left' );
 			var renderWidth = eyeParameters.renderWidth;


### PR DESCRIPTION
A `vrdisplaypresentchange ` event might fire without a device being set in the `WebVRManager`