### PR TITLE
check if rawObjectDescriptions has own property

### DIFF
--- a/examples/js/loaders/OBJLoader2.js
+++ b/examples/js/loaders/OBJLoader2.js
@@ -724,6 +724,12 @@ THREE.OBJLoader2 = (function () {
 
 			for ( var name in this.rawObjectDescriptions ) {
 
+				if ( ! this.rawObjectDescriptions.hasOwnProperty( name ) ) {
+
+					continue;
+
+				}
+
 				rawObjectDescription = this.rawObjectDescriptions[ name ];
 				if ( rawObjectDescription.vertices.length > 0 ) {
 
@@ -939,6 +945,13 @@ THREE.OBJLoader2 = (function () {
 			}
 
 			for ( var oodIndex in rawObjectDescriptions ) {
+
+				if ( ! rawObjectDescriptions.hasOwnProperty( oodIndex ) ) {
+
+					continue;
+
+				}
+
 				rawObjectDescription = rawObjectDescriptions[ oodIndex ];
 
 				materialName = rawObjectDescription.materialName;


### PR DESCRIPTION
Switching from OBJLoader to OBJLoader2 I encountered a bug related to some functions I added to `Array` (`Array.prototype.swap = function(a, b) { //swap it; }`).
Adding a check using `hasOwnProperty` in the for loops iterating over `rawObjectDescriptions` fixed it for me.

Hope it's helpful for others too.