### PR TITLE
GLTFExporter: Added TRS and onlyVisible options

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -836,10 +836,11 @@ THREE.GLTFExporter.prototype = {
 
 			outputJSON.scenes.push( gltfScene );
 
+			var nodes = [];
+
 			for ( var i = 0, l = scene.children.length; i < l; i ++ ) {
 
 				var child = scene.children[ i ];
-				var nodes = [];
 
 				// @TODO We don't process lights yet
 				if ( child instanceof THREE.Mesh ||
@@ -852,11 +853,11 @@ THREE.GLTFExporter.prototype = {
 
 				}
 
-				if ( nodes.length > 0 ) {
+			}
 
-					gltfScene.nodes = nodes;
+			if ( nodes.length > 0 ) {
 
-				}
+				gltfScene.nodes = nodes;
 
 			}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -57,6 +57,13 @@ THREE.GLTFExporter.prototype = {
 	 */
 	parse: function ( input, onDone, options ) {
 
+		var DEFAULT_OPTIONS = {
+			trs: false,
+			onlyVisible: true
+		};
+
+		options = Object.assign( {}, DEFAULT_OPTIONS, options );
+
 		var outputJSON = {
 
 			asset: {

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -57,8 +57,6 @@ THREE.GLTFExporter.prototype = {
 	 */
 	parse: function ( input, onDone, options ) {
 
-		options = options || {};
-
 		var outputJSON = {
 
 			asset: {

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -29,7 +29,8 @@
 			<button id="export_objects">Export Sphere and Grid</button>
 			<button id="export_scene_object">Export Scene1 and Sphere</button>
 			<br/>
-			<input id="option_trs" type="checkbox" value="trs"/> TRS
+			<label><input id="option_trs" name="trs" type="checkbox"/>TRS</label>
+			<label><input id="option_visible" name="visible" type="checkbox" checked="checked"/>Only Visible</label>
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -44,7 +45,8 @@
 				var gltfExporter = new THREE.GLTFExporter();
 
 				var options = {
-					trs: document.getElementById('option_trs').checked
+					trs: document.getElementById('option_trs').checked,
+					onlyVisible: document.getElementById('option_visible').checked,
 				}
 				gltfExporter.parse( input, function( result ) {
 
@@ -400,6 +402,17 @@
 				object.position.set( 200, 0, 400 );
 				scene1.add( object );
 
+				// ---------------------------------------------------------------------
+				// Big red box hidden just for testing `onlyVisible` option
+				// ---------------------------------------------------------------------
+				material = new THREE.MeshBasicMaterial( {
+					color: 0xff0000
+				} );
+				object = new THREE.Mesh( new THREE.BoxBufferGeometry( 200, 200, 200 ), material );
+				object.position.set( 0, 0, 0 );
+				object.name = "CubeHidden";
+				object.visible = false;
+				scene1.add( object );
 
 				// ---------------------------------------------------------------------
 				// 2nd Scene

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -28,6 +28,8 @@
 			<button id="export_object">Export Sphere</button>
 			<button id="export_objects">Export Sphere and Grid</button>
 			<button id="export_scene_object">Export Scene1 and Sphere</button>
+			<br/>
+			<input id="option_trs" type="checkbox" value="trs"/> TRS
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -41,13 +43,16 @@
 
 				var gltfExporter = new THREE.GLTFExporter();
 
+				var options = {
+					trs: document.getElementById('option_trs').checked
+				}
 				gltfExporter.parse( input, function( result ) {
 
 					var output = JSON.stringify( result, null, 2 );
 					console.log( output );
 					saveString( output, 'scene.gltf' );
 
-				} );
+				}, options );
 
 			}
 


### PR DESCRIPTION
Added two options to the exporter:
- `trs` (Default: `false`): Export `translation`, `rotation` and `scale` instead of `matrix`.
- `onlyVisible` (Default: `true`): Export only the nodes that are visible.