### PR TITLE
Fix Box3 and BufferGeometry boundingBox and Sphere if drawRange is defined

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -582,7 +582,7 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		if ( position !== undefined ) {
 
-			this.boundingBox.setFromBufferAttribute( position );
+			this.boundingBox.setFromBufferAttribute( position, this.drawRange );
 
 		} else {
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -243,8 +243,9 @@ Object.assign( Box3.prototype, {
 						var attribute = geometry.attributes.position;
 
 						if ( attribute !== undefined ) {
+							var count = geometry.drawRange.count === Infinity ? attribute.count : geometry.drawRange.count;
 
-							for ( i = 0, l = attribute.count; i < l; i ++ ) {
+							for ( i = geometry.drawRange.start; i < count; i ++ ) {
 
 								v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -59,7 +59,7 @@ Object.assign( Box3.prototype, {
 
 	},
 
-	setFromBufferAttribute: function ( attribute ) {
+	setFromBufferAttribute: function ( attribute, drawRange ) {
 
 		var minX = + Infinity;
 		var minY = + Infinity;
@@ -69,7 +69,22 @@ Object.assign( Box3.prototype, {
 		var maxY = - Infinity;
 		var maxZ = - Infinity;
 
-		for ( var i = 0, l = attribute.count; i < l; i ++ ) {
+		var start = 0;
+		var count = attribute.count;
+
+		if ( drawRange ) {
+
+			start = drawRange.start;
+
+			if ( drawRange.count !== Infinity ) {
+
+				count = drawRange.count;
+
+			}
+
+		}
+
+		for ( var i = start; i < count; i ++ ) {
 
 			var x = attribute.getX( i );
 			var y = attribute.getY( i );


### PR DESCRIPTION
If we create a `bufferGeometry` with a bigger `bufferAttribute` than the one we're actually painting (For example on https://github.com/mrdoob/three.js/blob/dev/examples/webvr_vive_paint.html) the box helper is computed incorrectly by omiting the `drawRange` values.
So if the buffer is initialized with zeros the box will have always a point in the origin:
![image](https://user-images.githubusercontent.com/782511/29457020-84b862da-8418-11e7-95ae-96581bb2de40.png)

Why the changes the box is created as expected:

![image](https://user-images.githubusercontent.com/782511/29457060-a1acbf08-8418-11e7-8c3e-b8a889500f6d.png)
