### PR TITLE
Shader: Use linear luminance

### DIFF
--- a/examples/js/shaders/BokehShader2.js
+++ b/examples/js/shaders/BokehShader2.js
@@ -220,7 +220,7 @@ THREE.BokehShader = {
 			"col.g = texture2D(tColor,coords + vec2(-0.866,-0.5)*texel*fringe*blur).g;",
 			"col.b = texture2D(tColor,coords + vec2(0.866,-0.5)*texel*fringe*blur).b;",
 
-			"vec3 lumcoeff = vec3(0.299,0.587,0.114);",
+			"vec3 lumcoeff = vec3(0.2126, 0.7152, 0.0722);",
 			"float lum = dot(col.rgb, lumcoeff);",
 			"float thresh = max((lum-threshold)*gain, 0.0);",
 			"return col+mix(vec3(0.0),col,thresh*blur);",

--- a/examples/js/shaders/ColorifyShader.js
+++ b/examples/js/shaders/ColorifyShader.js
@@ -37,7 +37,7 @@ THREE.ColorifyShader = {
 
 			"vec4 texel = texture2D( tDiffuse, vUv );",
 
-			"vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+			"vec3 luma = vec3( 0.2126, 0.7152, 0.0722 );",
 			"float v = dot( texel.xyz, luma );",
 
 			"gl_FragColor = vec4( v * color, texel.w );",

--- a/examples/js/shaders/FXAAShader.js
+++ b/examples/js/shaders/FXAAShader.js
@@ -44,7 +44,7 @@ THREE.FXAAShader = {
 			"vec3 rgbSE = texture2D( tDiffuse, ( gl_FragCoord.xy + vec2( 1.0, 1.0 ) ) * resolution ).xyz;",
 			"vec4 rgbaM  = texture2D( tDiffuse,  gl_FragCoord.xy  * resolution );",
 			"vec3 rgbM  = rgbaM.xyz;",
-			"vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+			"vec3 luma = vec3( 0.2126, 0.7152, 0.0722 );",
 
 			"float lumaNW = dot( rgbNW, luma );",
 			"float lumaNE = dot( rgbNE, luma );",

--- a/examples/js/shaders/LuminosityHighPassShader.js
+++ b/examples/js/shaders/LuminosityHighPassShader.js
@@ -47,7 +47,7 @@ THREE.LuminosityHighPassShader = {
 
 			"vec4 texel = texture2D( tDiffuse, vUv );",
 
-			"vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+			"vec3 luma = vec3( 0.2126, 0.7152, 0.0722 );",
 
 			"float v = dot( texel.xyz, luma );",
 

--- a/examples/js/shaders/LuminosityShader.js
+++ b/examples/js/shaders/LuminosityShader.js
@@ -37,7 +37,7 @@ THREE.LuminosityShader = {
 
 			"vec4 texel = texture2D( tDiffuse, vUv );",
 
-			"vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+			"vec3 luma = vec3( 0.2126, 0.7152, 0.0722 );",
 
 			"float v = dot( texel.xyz, luma );",
 

--- a/examples/js/shaders/SSAOShader.js
+++ b/examples/js/shaders/SSAOShader.js
@@ -212,7 +212,7 @@ THREE.SSAOShader = {
 
 			"vec3 color = texture2D( tDiffuse, vUv ).rgb;",
 
-			"vec3 lumcoeff = vec3( 0.299, 0.587, 0.114 );",
+			"vec3 lumcoeff = vec3( 0.2126, 0.7152, 0.0722 );",
 			"float lum = dot( color.rgb, lumcoeff );",
 			"vec3 luminance = vec3( lum );",
 

--- a/examples/js/shaders/ToneMapShader.js
+++ b/examples/js/shaders/ToneMapShader.js
@@ -43,17 +43,17 @@ THREE.ToneMapShader = {
 		"#else",
 			"uniform float averageLuminance;",
 		"#endif",
-		
-		"const vec3 LUM_CONVERT = vec3(0.299, 0.587, 0.114);",
+
+		"const vec3 LUM_CONVERT = vec3(0.2126, 0.7152, 0.0722);",
 
 		"vec3 ToneMap( vec3 vColor ) {",
 			"#ifdef ADAPTED_LUMINANCE",
-				// Get the calculated average luminance 
+				// Get the calculated average luminance
 				"float fLumAvg = texture2D(luminanceMap, vec2(0.5, 0.5)).r;",
 			"#else",
 				"float fLumAvg = averageLuminance;",
 			"#endif",
-			
+
 			// Calculate the luminance of the current pixel
 			"float fLumPixel = dot(vColor, LUM_CONVERT);",
 
@@ -67,7 +67,7 @@ THREE.ToneMapShader = {
 		"void main() {",
 
 			"vec4 texel = texture2D( tDiffuse, vUv );",
-			
+
 			"gl_FragColor = vec4( ToneMap( texel.xyz ), texel.w );",
 
 		"}"


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/11932#issuecomment-321986329

The shaders now use weights that produce a linear luminance Y (reference: [Wikipedia](https://en.wikipedia.org/wiki/Grayscale)):
![image](https://user-images.githubusercontent.com/12612165/29488387-f487942c-8509-11e7-9506-8a194c43de07.png)

