### PR TITLE
Video Pano Example: limit zooming to remove distortion

### DIFF
--- a/examples/webgl_video_panorama_equirectangular.html
+++ b/examples/webgl_video_panorama_equirectangular.html
@@ -43,7 +43,7 @@
 			lon = 0, onMouseDownLon = 0,
 			lat = 0, onMouseDownLat = 0,
 			phi = 0, theta = 0,
-			distance = 500,
+			distance = 50,
 			onPointerDownPointerX = 0,
 			onPointerDownPointerY = 0,
 			onPointerDownLon = 0,
@@ -146,7 +146,7 @@
 
 				distance += event.deltaY * 0.05;
 
-				distance = THREE.Math.clamp( distance, 400, 500 );
+				distance = THREE.Math.clamp( distance, 1, 50 );
 
 			}
 
@@ -168,11 +168,6 @@
 				camera.position.z = distance * Math.sin( phi ) * Math.sin( theta );
 
 				camera.lookAt( camera.target );
-
-				/*
-				// distortion
-				camera.position.copy( camera.target ).negate();
-				*/
 
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
Camera must remain reasonably close to the center of the sphere mesh.