### PR TITLE
Fix logarithmicDepthBuffer bug

### DIFF
--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -66,7 +66,7 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 
 	}
 
-	var logarithmicDepthBuffer = parameters.logarithmicDepthBuffer === true && !! extensions.get( 'EXT_frag_depth' );
+	var logarithmicDepthBuffer = parameters.logarithmicDepthBuffer === true;
 
 	var maxTextures = gl.getParameter( gl.MAX_TEXTURE_IMAGE_UNITS );
 	var maxVertexTextures = gl.getParameter( gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS );


### PR DESCRIPTION
This PR fixes a bug which allowed support for a logarithmic depth buffer only if the `EXT_frag_depth` extension was available.

With this PR, a logarithmic depth buffer should be supported whether the extension is available or not.

As an aside, `WebGLCapabilities` may want to be refactored, as now the property `logarithmicDepthBuffer` is not a "capability"; it is just a user request.