### PR TITLE
Clarify variables in physics/terrain example to be more self documenting 

### DIFF
--- a/examples/webgl_physics_terrain.html
+++ b/examples/webgl_physics_terrain.html
@@ -128,7 +128,7 @@
 
 						controls = new THREE.OrbitControls( camera );
 
-						var geometry = new THREE.PlaneBufferGeometry( 100, 100, terrainWidth - 1, terrainDepth - 1 );
+						var geometry = new THREE.PlaneBufferGeometry( terrainWidthExtents, terrainDepthExtents, terrainWidth - 1, terrainDepth - 1 );
 						geometry.rotateX( -Math.PI / 2 );
 
 						var vertices = geometry.attributes.position.array;


### PR DESCRIPTION
The terrainWidthExtents and terrainDepthExtents variables are used to scale the size of the physical terrain heightmap in Ammo.js. These same values should be used to set the size of the Three.js PlaneBufferGeometry. That way the code is easier to read and understand knowing those values are linked.