### PR TITLE
Normals error

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -166,16 +166,16 @@ THREE.STLLoader.prototype = {
 					vertices.push( reader.getFloat32( vertexstart, true ) );
 					vertices.push( reader.getFloat32( vertexstart + 4, true ) );
 					vertices.push( reader.getFloat32( vertexstart + 8, true ) );
+				}
 
-					normals.push( normalX, normalY, normalZ );
+				normals.push( normalX, normalY, normalZ );
 
-					if ( hasColors ) {
+				if ( hasColors ) {
 
-						colors.push( r, g, b );
-
-					}
+					colors.push( r, g, b );
 
 				}
+
 
 			}
 


### PR DESCRIPTION
Browsing the binary parse of STL I noticed that normal and color are pushed three times per face instead of one. I took these pushes out of the loop.

Maybe it causes no trouble as it was but I think this is the correct (and efficient) way of doing it.

Only one normal and one color per face!!!