### PR TITLE
Added AnimationLoader to exports

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -32,6 +32,7 @@ export { DepthTexture } from './textures/DepthTexture.js';
 export { Texture } from './textures/Texture.js';
 export * from './geometries/Geometries.js';
 export * from './materials/Materials.js';
+export { AnimationLoader } from './loaders/CompressedTextureLoader.js';
 export { CompressedTextureLoader } from './loaders/CompressedTextureLoader.js';
 export { DataTextureLoader } from './loaders/DataTextureLoader.js';
 export { CubeTextureLoader } from './loaders/CubeTextureLoader.js';


### PR DESCRIPTION
The AnimationLoader is not actually included in the build, despite being in the src/loaders folder and having a docs page. 

This might be intentional as it does look somewhat unfinished, but it will be useful to me at least even in this state. 

