### PR TITLE
Docs: Updated links to old or deleted examples

### DIFF
--- a/docs/api/core/Face3.html
+++ b/docs/api/core/Face3.html
@@ -21,7 +21,7 @@
 
 		<div>[example:misc_ubiquity_test ubiquity / test ]</div>
 		<div>[example:svg_sandbox svg / sandbox ]</div>
-		<div>[example:webgl_exporter_obj WebGL / exporter / obj ]</div>
+		<div>[example:misc_exporter_obj exporter / obj ]</div>
 		<div>[example:webgl_shaders_vector WebGL / shaders / vector ]</div>
 
 

--- a/docs/api/extras/core/Shape.html
+++ b/docs/api/extras/core/Shape.html
@@ -41,7 +41,6 @@
 		[example:webgl_geometry_shapes geometry / shapes ]<br/>
 		[example:webgl_geometry_extrude_shapes geometry / extrude / shapes ]<br/>
 		[example:webgl_geometry_extrude_shapes2 geometry / extrude / shapes2 ]<br/>
-		[example:webgl_particles_shapes particles / shapes ]
 		</div>
 
 

--- a/docs/api/geometries/TextBufferGeometry.html
+++ b/docs/api/geometries/TextBufferGeometry.html
@@ -40,7 +40,7 @@
 
 		<div>
 		[example:webgl_geometry_text geometry / text ]<br/>
-		[example:webgl_geometry_text2 geometry / text2 ]
+		[example:webgl_geometry_text_pnltri geometry / text2 ]
 		</div>
 
 		<code>

--- a/docs/api/lights/PointLight.html
+++ b/docs/api/lights/PointLight.html
@@ -27,9 +27,7 @@
 			[example:webgl_lights_pointlights lights / pointlights ]<br />
 			[example:webgl_lights_pointlights2 lights / pointlights2 ]<br />
 			[example:webgldeferred_animation animation ]<br />
-			[example:webgldeferred_pointlights pointlights ]<br />
 			[example:webgl_effects_anaglyph effects / anaglyph ]<br />
-			[example:webgl_geometry_large_mesh geometry / large / mesh ]<br />
 			[example:webgl_geometry_text geometry / text ]<br />
 			[example:webgl_lensflares lensflares ]
 		</div>

--- a/docs/api/lights/RectAreaLight.html
+++ b/docs/api/lights/RectAreaLight.html
@@ -28,7 +28,6 @@
 		<h2>Examples</h2>
 
 		<div>
-			[example:webgl_lights_arealight WebGL / arealight ]<br />
 			[example:webgl_lights_rectarealight WebGL / rectarealight ]
 
 			<code>

--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -36,7 +36,7 @@
 			[example:webgl_interactive_draggablecubes interactive / draggablecubes ]<br />
 			[example:webgl_materials_bumpmap_skin materials / bumpmap / skin ]<br />
 			[example:webgl_materials_cubemap_dynamic materials / cubemap / dynamic ]<br />
-			[example:webgl_morphtargets_md2 morphtargets / md2 ]<br />
+			[example:webgl_loader_md2 loader / md2 ]<br />
 			[example:webgl_shading_physical shading / physical ]<br />
 			[example:webgl_materials_bumpmap materials / bumpmap]<br/>
 			[example:webgl_shading_physical shading / physical]<br/>

--- a/docs/examples/loaders/ColladaLoader.html
+++ b/docs/examples/loaders/ColladaLoader.html
@@ -34,7 +34,6 @@
 		</code>
 
 		[example:webgl_loader_collada]<br />
-		[example:webgl_loader_collada_keyframe]<br />
 		[example:webgl_loader_collada_skinning]<br />
 		[example:webgl_loader_collada_kinematics]
 


### PR DESCRIPTION
core/Face3: `webgl_exporter_obj` was renamed `misc_exporter_obj` in 8a385f0793d55d8470bf2bf0ca652961acda8a8f

extras/core/Shape: `webgl_particles_shapes` was removed in d3b3b6f00f5797c3249ce977f51570238a2f521f

geometries/TextBufferGeometry: `webgl_geometry_text2` was renamed `webgl_geometry_text_pnltri` in 0593cf4bf9defcb61f6ae5694c5f05f68cd68c8f

lights/PointLight:
`webgldeferred_pointlights` was removed in 43f1e3de9bc3ae98b8dc774b106923732b1704d7  
`webgl_geometry_large_mesh` was removed in 084661a035df89a79bab66a378a941806c07da93

lights/RectAreaLight: `webgl_lights_arealight` was removed in d68323edd8849d2cee48ee03696c04406f316ee5

lights/SpotLight: `webgl_morphtargets_md2` was renamed `webgl_loader_md2` in  87cf8392e8707b710e4260829aec4ddf72fab92e

loaders/ColladaLoader: `webgl_loader_collada_keyframe` was removed in c8b92befe327d373b4eac4961134a4bba4e5f798

In two files, [api/geometries/TextGeometry](https://github.com/mrdoob/three.js/blob/7bdd534f9ec4dfd5db8fc38a4b989915b3d5656d/docs/api/geometries/TextGeometry.html#L41-L44) and [api/loaders/managers/DefaultLoadingManager](https://github.com/mrdoob/three.js/blob/7bdd534f9ec4dfd5db8fc38a4b989915b3d5656d/docs/api/loaders/managers/DefaultLoadingManager.html#L22-L24), all examples are either for a different class or removed. I've left those untouched for now, in case removing all examples from a page might break something.