### PR TITLE
GLTFLoader - Adding support for normalScale as part of the normalTexture

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1613,7 +1613,7 @@ THREE.GLTFLoader = ( function () {
 
 				pending.push( parser.assignTexture( materialParams, 'normalMap', material.normalTexture.index ) );
 
-				if ( material.normalTexture.scale ) {
+				if ( material.normalTexture.scale !== undefined ) {
 
 					materialParams.normalScale = new THREE.Vector2( material.normalTexture.scale, material.normalTexture.scale );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -616,7 +616,7 @@ THREE.GLTFLoader = ( function () {
 				material.bumpScale = 1;
 
 				material.normalMap = params.normalMap === undefined ? null : params.normalMap;
-				material.normalScale = params.normalScale === undefined ? new THREE.Vector2( 1, 1 ) : params.normalScale;
+				if ( params.normalScale ) material.normalScale = params.normalScale;
 
 				material.displacementMap = null;
 				material.displacementScale = 1;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1613,6 +1613,11 @@ THREE.GLTFLoader = ( function () {
 
 				pending.push( parser.assignTexture( materialParams, 'normalMap', material.normalTexture.index ) );
 
+				if ( material.normalTexture.scale ) {
+
+					materialParams.normalScale = new THREE.Vector2( material.normalTexture.scale, material.normalTexture.scale );
+
+				}
 			}
 
 			if ( material.occlusionTexture !== undefined ) {
@@ -1667,7 +1672,7 @@ THREE.GLTFLoader = ( function () {
 
 				// Normal map textures use OpenGL conventions:
 				// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#materialnormaltexture
-				_material.normalScale.x = -1;
+				_material.normalScale.x = -_material.normalScale.x;
 
 				if ( material.extras ) _material.userData = material.extras;
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -616,7 +616,7 @@ THREE.GLTFLoader = ( function () {
 				material.bumpScale = 1;
 
 				material.normalMap = params.normalMap === undefined ? null : params.normalMap;
-				material.normalScale = new THREE.Vector2( 1, 1 );
+				material.normalScale = params.normalScale || new THREE.Vector2( 1, 1 );
 
 				material.displacementMap = null;
 				material.displacementScale = 1;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -616,7 +616,7 @@ THREE.GLTFLoader = ( function () {
 				material.bumpScale = 1;
 
 				material.normalMap = params.normalMap === undefined ? null : params.normalMap;
-				material.normalScale = params.normalScale || new THREE.Vector2( 1, 1 );
+				material.normalScale = params.normalScale === undefined ? new THREE.Vector2( 1, 1 ) : params.normalScale;
 
 				material.displacementMap = null;
 				material.displacementScale = 1;
@@ -1613,9 +1613,11 @@ THREE.GLTFLoader = ( function () {
 
 				pending.push( parser.assignTexture( materialParams, 'normalMap', material.normalTexture.index ) );
 
+				materialParams.normalScale = new THREE.Vector2( 1, 1 );
+
 				if ( material.normalTexture.scale !== undefined ) {
 
-					materialParams.normalScale = new THREE.Vector2( material.normalTexture.scale, material.normalTexture.scale );
+					materialParams.normalScale.set( material.normalTexture.scale, material.normalTexture.scale );
 
 				}
 			}


### PR DESCRIPTION
The Unity > GLTF exporter allows the scales of the normals to be set on the normalTexture. 

I made a sample model with the left sphere at 0.5 scale, the center at 1.0 scale and the right at 2.0 scale.
[Spheres_20170823.zip](https://github.com/mrdoob/three.js/files/1243854/Spheres_20170823.zip)

The view in unity:
![unity](https://user-images.githubusercontent.com/2245579/29594505-cefbc0e6-87f4-11e7-918f-b55c3207223a.JPG)

However this property is not read by the current GLTFLoader
The result in gltf viewer - https://gltf-viewer.donmccurdy.com
![threejs gltf](https://user-images.githubusercontent.com/2245579/29594522-e836f1b6-87f4-11e7-9b13-4676d9eea589.JPG)

I'm adding this small change to read the 'scale' property of a normalTexture:
![threejs gltf - fixed](https://user-images.githubusercontent.com/2245579/29594711-0abbf4c4-87f6-11e7-9970-4339e1b41fc5.JPG)

Let me know what you think,
Clark