### PR TITLE
Fix for samplers in struct uniforms

### DIFF
--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -392,17 +392,14 @@ function StructuredUniform( id ) {
 
 }
 
-StructuredUniform.prototype.setValue = function ( gl, value ) {
-
-	// Note: Don't need an extra 'renderer' parameter, since samplers
-	// are not allowed in structured uniforms.
+StructuredUniform.prototype.setValue = function ( gl, value, renderer ) {
 
 	var seq = this.seq;
 
 	for ( var i = 0, n = seq.length; i !== n; ++ i ) {
 
 		var u = seq[ i ];
-		u.setValue( gl, value[ u.id ] );
+		u.setValue( gl, value[ u.id ], renderer );
 
 	}
 


### PR DESCRIPTION
Forward `renderer` argument in `StructuredUniform.setValue` to allow uniform structs to contain samplers. 

Reported in issue #11787

Contrary to what the removed comment says, having samplers in structs is allowed, but only if the struct is created as a uniform. 

This works in all WebGL browsers I've tested, except in IE and Edge (see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12874198/)..

As you can see, the change is pretty small and I see no reason why it shouldn't be there.

Example shader:

```c
struct DataTexture {
  sampler2D texture;
  float offset;
  float scale;
};

uniform DataTexture myDataUniform;

void main() {
  // ...
}
```

JavaScript: 

```javascript
const material = new THREE.ShaderMaterial({
    uniforms: {
        myDataUniform: {
            value: {
                texture: { type: "t", value: new THREE.Texture() },
                offset: { value: 10000.0 },
                scale: { value: 1000.0 },
            }
        }
    },
    // ...
});
```