### PR TITLE
WebGLSpriteRenderer: Use actual depth in fog formula

### DIFF
--- a/src/renderers/webgl/WebGLSpriteRenderer.js
+++ b/src/renderers/webgl/WebGLSpriteRenderer.js
@@ -69,6 +69,7 @@ function WebGLSpriteRenderer( renderer, gl, state, textures, capabilities ) {
 			fogNear:			gl.getUniformLocation( program, 'fogNear' ),
 			fogFar:				gl.getUniformLocation( program, 'fogFar' ),
 			fogColor:			gl.getUniformLocation( program, 'fogColor' ),
+			fogDepth:			gl.getUniformLocation( program, 'fogDepth' ),
 
 			alphaTest:			gl.getUniformLocation( program, 'alphaTest' )
 		};
@@ -265,6 +266,7 @@ function WebGLSpriteRenderer( renderer, gl, state, textures, capabilities ) {
 			'attribute vec2 uv;',
 
 			'varying vec2 vUV;',
+			'varying float fogDepth;',
 
 			'void main() {',
 
@@ -276,13 +278,14 @@ function WebGLSpriteRenderer( renderer, gl, state, textures, capabilities ) {
 				'rotatedPosition.x = cos( rotation ) * alignedPosition.x - sin( rotation ) * alignedPosition.y;',
 				'rotatedPosition.y = sin( rotation ) * alignedPosition.x + cos( rotation ) * alignedPosition.y;',
 
-				'vec4 finalPosition;',
+				'vec4 mvPosition;',
 
-				'finalPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );',
-				'finalPosition.xy += rotatedPosition;',
-				'finalPosition = projectionMatrix * finalPosition;',
+				'mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );',
+				'mvPosition.xy += rotatedPosition;',
 
-				'gl_Position = finalPosition;',
+				'gl_Position = projectionMatrix * mvPosition;',
+
+				'fogDepth = - mvPosition.z;',
 
 			'}'
 
@@ -306,6 +309,7 @@ function WebGLSpriteRenderer( renderer, gl, state, textures, capabilities ) {
 			'uniform float alphaTest;',
 
 			'varying vec2 vUV;',
+			'varying float fogDepth;',
 
 			'void main() {',
 
@@ -317,22 +321,21 @@ function WebGLSpriteRenderer( renderer, gl, state, textures, capabilities ) {
 
 				'if ( fogType > 0 ) {',
 
-					'float depth = gl_FragCoord.z / gl_FragCoord.w;',
 					'float fogFactor = 0.0;',
 
 					'if ( fogType == 1 ) {',
 
-						'fogFactor = smoothstep( fogNear, fogFar, depth );',
+						'fogFactor = smoothstep( fogNear, fogFar, fogDepth );',
 
 					'} else {',
 
 						'const float LOG2 = 1.442695;',
-						'fogFactor = exp2( - fogDensity * fogDensity * depth * depth * LOG2 );',
+						'fogFactor = exp2( - fogDensity * fogDensity * fogDepth * fogDepth * LOG2 );',
 						'fogFactor = 1.0 - clamp( fogFactor, 0.0, 1.0 );',
 
 					'}',
 
-					'gl_FragColor = mix( gl_FragColor, vec4( fogColor, gl_FragColor.w ), fogFactor );',
+					'gl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor );',
 
 				'}',
 


### PR DESCRIPTION
This PR applies to sprites the same fog calculation used for meshes.

I initially tried using the fog shader Chunks directly, but that turned out to be problematic because the Chunks rely on `ifdef`s, and the sprite shader uses uniforms.

Since there is not much code here, I think this is OK.