### PR TITLE
GLTF Added alphaCutoff support in exporter and loader

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -520,7 +520,13 @@ THREE.GLTFExporter.prototype = {
 			// alphaMode
 			if ( material.transparent ) {
 
-				gltfMaterial.alphaMode = 'BLEND'; // @FIXME We should detect MASK or BLEND
+				gltfMaterial.alphaMode = 'MASK'; // @FIXME We should detect MASK or BLEND
+
+				if ( material.alphaTest !== 0.5 ) {
+
+					gltfMaterial.alphaCutoff = material.alphaTest;
+
+				}
 
 			}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1603,6 +1603,8 @@ THREE.GLTFLoader = ( function () {
 
 				materialParams.transparent = true;
 
+				materialParams.alphaTest = material.alphaCutoff || 0.5;
+
 			} else {
 
 				materialParams.transparent = false;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1603,7 +1603,11 @@ THREE.GLTFLoader = ( function () {
 
 				materialParams.transparent = true;
 
-				materialParams.alphaTest = material.alphaCutoff || 0.5;
+				if ( alphaMode === ALPHA_MODES.MASK ) {
+
+				  materialParams.alphaTest = material.alphaCutoff || 0.5;
+
+				}
 
 			} else {
 


### PR DESCRIPTION
From the [spec](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#alpha-coverage): 

```Specifies the cutoff threshold when in MASK mode.```

| | Type | Description | Required |
| -- | -- | -- | -- |
| alphaCutoff | number | The alpha cutoff value of the material. | No, default: 0.5



