### PR TITLE
GLTFExporter: fix nodes filter

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -718,6 +718,13 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function processNode ( object ) {
 
+			if ( object instanceof THREE.Light ) {
+
+				console.warn( 'GLTFExporter: Unsupported node type:', object.constructor.name );
+				return false;
+
+			}
+
 			if ( !outputJSON.nodes ) {
 
 				outputJSON.nodes = [];
@@ -803,13 +810,11 @@ THREE.GLTFExporter.prototype = {
 
 					if ( child.visible || options.onlyVisible === false ) {
 
-						if ( child instanceof THREE.Mesh ||
-							child instanceof THREE.Camera ||
-							child instanceof THREE.Group ||
-							child instanceof THREE.Line ||
-							child instanceof THREE.Points) {
+						var node = processNode( child );
 
-							children.push( processNode( child ) );
+						if ( node !== false ) {
+
+							children.push( node );
 
 						}
 
@@ -867,14 +872,11 @@ THREE.GLTFExporter.prototype = {
 
 				if ( child.visible || options.onlyVisible === false ) {
 
-					// @TODO We don't process lights yet
-					if ( child instanceof THREE.Mesh ||
-						child instanceof THREE.Camera ||
-						child instanceof THREE.Group ||
-						child instanceof THREE.Line ||
-						child instanceof THREE.Points) {
+					var node = processNode( child );
 
-						nodes.push( processNode( child ) );
+					if ( node !== false ) {
+
+						nodes.push( node );
 
 					}
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -115,7 +115,7 @@
 
 			var container;
 
-			var camera, scene1, scene2, renderer;
+			var camera, object, scene1, scene2, renderer;
 			var gridHelper, sphere;
 
 			init();
@@ -141,13 +141,16 @@
 				// ---------------------------------------------------------------------
 				// Ambient light
 				// ---------------------------------------------------------------------
-				scene1.add( new THREE.AmbientLight( 0xffffff, 0.2 ) );
+				var light = new THREE.AmbientLight( 0xffffff, 0.2 );
+				light.name = 'AmbientLight';
+				scene1.add( light );
 
 				// ---------------------------------------------------------------------
 				// DirectLight
 				// ---------------------------------------------------------------------
-				var light = new THREE.DirectionalLight( 0xffffff, 1 );
+				light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( 1, 1, 0 );
+				light.name = 'DirectionalLight';
 				scene1.add( light );
 
 				// ---------------------------------------------------------------------


### PR DESCRIPTION
`processNode` now can returns a `false` if it can process the node (by now we're just explicitly skipping lights), and it won't be added to the list of nodes.