### PR TITLE
Axes added to vive thumbpad event

### DIFF
--- a/examples/js/vr/ViveController.js
+++ b/examples/js/vr/ViveController.js
@@ -89,7 +89,7 @@ THREE.ViveController = function ( id ) {
 			if ( thumbpadIsPressed !== gamepad.buttons[ 0 ].pressed ) {
 
 				thumbpadIsPressed = gamepad.buttons[ 0 ].pressed;
-				scope.dispatchEvent( { type: thumbpadIsPressed ? 'thumbpaddown' : 'thumbpadup' } );
+				scope.dispatchEvent( { type: thumbpadIsPressed ? 'thumbpaddown' : 'thumbpadup', axes: axes } );
 
 			}
 


### PR DESCRIPTION
The axes that are set on the `axischange` event are now passed to the thumbpaddown and thumbpadup event to know the position of the button press.