### PR TITLE
Fix the comparison with the result of processMaterial in GLTFExporter

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -612,7 +612,7 @@ THREE.GLTFExporter.prototype = {
 			};
 
 			var material = processMaterial( mesh.material );
-			if ( material ) {
+			if ( material !== null ) {
 
 				gltfMesh.primitives[ 0 ].material = material;
 


### PR DESCRIPTION
If I'm right, we should compare the result of `processMaterial()` with `null` in `GLTFExporter` because it returns the index of array.

The index can be zero, in such a case

    if ( material )

will be false.

/cc @fernandojsg 