### PR TITLE
3MFLoader: Fix TextDecoder check

### DIFF
--- a/examples/js/loaders/3MFLoader.js
+++ b/examples/js/loaders/3MFLoader.js
@@ -88,6 +88,13 @@ THREE.ThreeMFLoader.prototype = {
 
 			}
 
+			if ( window.TextDecoder === undefined ) {
+
+				console.error( 'THREE.ThreeMFLoader: TextDecoder not present. Please use a TextDecoder polyfill.' );
+				return null;
+
+			}
+
 			var relsView = new DataView( zip.file( relsName ).asArrayBuffer() );
 			var relsFileText = new TextDecoder( 'utf-8' ).decode( relsView );
 			rels = parseRelsXml( relsFileText );
@@ -96,13 +103,6 @@ THREE.ThreeMFLoader.prototype = {
 
 				var modelPart = modelPartNames[ i ];
 				var view = new DataView( zip.file( modelPart ).asArrayBuffer() );
-
-				if ( TextDecoder === undefined ) {
-
-					console.error( 'THREE.ThreeMFLoader: TextDecoder not present. Please use a TextDecoder polyfill.' );
-					return null;
-
-				}
 
 				var fileText = new TextDecoder( 'utf-8' ).decode( view );
 				var xmlData = new DOMParser().parseFromString( fileText, 'application/xml' );


### PR DESCRIPTION
The check for `TextDecoder` is performed too late in the code. Instead of an error message, users get a runtime error.