### PR TITLE
Logarithmic depth buffer vertex shader simplification

### DIFF
--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl
@@ -1,5 +1,5 @@
-#if defined(USE_LOGDEPTHBUF) && defined(USE_LOGDEPTHBUF_EXT)
+#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )
 
-	gl_FragDepthEXT = log2(vFragDepth) * logDepthBufFC * 0.5;
+	gl_FragDepthEXT = log2( vFragDepth ) * logDepthBufFC * 0.5;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl
@@ -1,14 +1,14 @@
 #ifdef USE_LOGDEPTHBUF
 
-	gl_Position.z = log2(max( EPSILON, gl_Position.w + 1.0 )) * logDepthBufFC;
-
 	#ifdef USE_LOGDEPTHBUF_EXT
 
 		vFragDepth = 1.0 + gl_Position.w;
 
 	#else
 
-		gl_Position.z = (gl_Position.z - 1.0) * gl_Position.w;
+		gl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;
+
+		gl_Position.z *= gl_Position.w;
 
 	#endif
 


### PR DESCRIPTION
`gl_Position.z` should only be overwritten if both (1) a logarithmic depth buffer is desired, and (2) the EXT_frag_depth extension is not available.