### PR TITLE
VRMLLoader: BufferGeometry Support

### DIFF
--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -21,7 +21,12 @@
 				z-index: 100;
 				display:block;
 			}
-			#info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }
+			#info a, .button {
+				color: #f00;
+				font-weight: bold;
+				text-decoration: underline;
+				cursor: pointer
+			}
 		</style>
 	</head>
 
@@ -49,8 +54,6 @@
 
 			var camera, controls, scene, renderer;
 
-			var cross;
-
 			init();
 			animate();
 
@@ -60,9 +63,6 @@
 				camera.position.z = 6;
 
 				controls = new THREE.OrbitControls( camera );
-
-				controls.rotateSpeed = 5.0;
-				controls.zoomSpeed = 5;
 
 				scene = new THREE.Scene();
 				scene.add( camera );


### PR DESCRIPTION
This PR removes all dependencies to `Geometry` from `VRMLLoader`. Besides:

- Removed custom `interpolateColors()` function and use `Color.lerp()` instead
- Adjust logging
- Minor code style and linter issues

I want to highlight that this PR includes no comprehensive refactoring but just a upgrade to `BufferGeoemtry` 😇 . The visual output should be the same like before.

New: http://rawgit.com/mugen87/three.js/vrml/examples/webgl_loader_vrml.html
Old: https://threejs.org/examples/webgl_loader_vrml.html

BTW: I adjusted the zoom and rotate speed of the example because the controls were way too fast. At least on my computer.
