### PR TITLE
Add setPath method to FontLoader

### DIFF
--- a/docs/api/loaders/FontLoader.html
+++ b/docs/api/loaders/FontLoader.html
@@ -63,6 +63,8 @@
 			The [page:LoadingManager loadingManager] the loader is using. Default is [page:DefaultLoadingManager].
 		</div>
 
+		<h3>[property:String path]</h3>
+		<div>The base path from which fonts will be loaded. See [page:.setPath]. Default is *undefined*.</div>
 
 		<h2>Methods</h2>
 
@@ -81,6 +83,12 @@
 		<div>
 		[page:Object json] — The <em>JSON</em> structure to parse.<br /><br />
 		Parse a <em>JSON</em> structure and return a [page:Font].
+		</div>
+
+		<h3>[method:FontLoader setPath]( [page:String path] )</h3>
+		<div>
+			Set the base path or URL from which to load fonts. This can be useful if
+			you are loading many fonts from the same directory.
 		</div>
 
 		<h2>Source</h2>

--- a/src/loaders/FontLoader.js
+++ b/src/loaders/FontLoader.js
@@ -19,6 +19,7 @@ Object.assign( FontLoader.prototype, {
 		var scope = this;
 
 		var loader = new FileLoader( this.manager );
+		loader.setPath( this.path );
 		loader.load( url, function ( text ) {
 
 			var json;
@@ -45,6 +46,13 @@ Object.assign( FontLoader.prototype, {
 	parse: function ( json ) {
 
 		return new Font( json );
+
+	},
+
+	setPath: function ( value ) {
+
+		this.path = value;
+		return this;
 
 	}
 


### PR DESCRIPTION
To make it consistent with other loaders (e.g. `ImageLoader`). Given that `FontLoader` uses `FileLoader` internally, I see no reason why it shouldn't be able to take advantage of its `setPath` method.