### PR TITLE
Improve compatibility in SVGRenderer

### DIFF
--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -131,7 +131,7 @@ THREE.SVGRenderer = function () {
 
 		if ( opacity === undefined || opacity === 1 ) return 'rgb(' + arg + ')';
 
-		return 'rgba(' + arg + ',' + opacity + ')';
+		return 'rgb(' + arg + '); fill-opacity: ' + opacity;
 
 	}
 


### PR DESCRIPTION
The opacity attribute for an object was encoded as rgba (only if the opacity was not 0 or 1). This worked OK if the SVG document was rendered in a browser, but not when rendered using Inkscape or Illustrator. In those programs a transparent object would be rendered as black since the rgba attribute is not recognized there. Using fill-opacity, like in previous versions of SVGRenderer, makes the transparent objects render as expected.