### PR TITLE
THREE.Mirror fix

### DIFF
--- a/examples/js/Mirror.js
+++ b/examples/js/Mirror.js
@@ -143,6 +143,8 @@ THREE.Mirror = function ( width, height, options ) {
 
 		mirrorCamera.updateMatrixWorld();
 
+		mirrorCamera.far = camera.far;
+
 		mirrorCamera.projectionMatrix.copy( camera.projectionMatrix );
 
 		// Update the texture matrix

--- a/examples/js/Mirror.js
+++ b/examples/js/Mirror.js
@@ -141,12 +141,9 @@ THREE.Mirror = function ( width, height, options ) {
 		mirrorCamera.up.reflect( normal );
 		mirrorCamera.lookAt( target );
 
-		mirrorCamera.aspect = camera.aspect;
-		mirrorCamera.near = camera.near;
-		mirrorCamera.far = camera.far;
-
 		mirrorCamera.updateMatrixWorld();
-		mirrorCamera.updateProjectionMatrix();
+
+		mirrorCamera.projectionMatrix.copy( camera.projectionMatrix );
 
 		// Update the texture matrix
 		textureMatrix.set(


### PR DESCRIPTION
Hi, 

there is a little fix for THREE.Mirror.

No need to copy all parameters from original to mirror camera and **update projection matrix each frame**, this is not good solution for performance and **this is not correct**  (what in case user change FOV in original camera).

I propose to copy projection matrix instead, in this case we always have correct projection matrix and this is faster and better. 

I've tested all examples after fix, they still works fine.  

