### PR TITLE
fix window rAF invoking vr.submitFrame() and retrieve display from 'vrdisplaypresentchange'

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1008,11 +1008,13 @@ function WebGLRenderer( parameters ) {
 
 	var isAnimating = false;
 	var onAnimationFrame = null;
+	var vrDevice = null;
 
 	function start() {
 
 		if ( isAnimating ) return;
-		( vr.getDevice() || window ).requestAnimationFrame( loop );
+		vrDevice = vr.getDevice();
+		( vrDevice || window ).requestAnimationFrame( loop );
 		isAnimating = true;
 
 	}
@@ -1020,7 +1022,8 @@ function WebGLRenderer( parameters ) {
 	function loop( time ) {
 
 		if ( onAnimationFrame !== null ) onAnimationFrame( time );
-		( vr.getDevice() || window ).requestAnimationFrame( loop );
+		vrDevice = vr.getDevice();
+		( vrDevice || window ).requestAnimationFrame( loop );
 
 	}
 
@@ -1162,7 +1165,7 @@ function WebGLRenderer( parameters ) {
 
 		state.setPolygonOffset( false );
 
-		if ( vr.enabled ) {
+		if ( vr.enabled && vrDevice ) {
 
 			vr.submitFrame();
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -41,7 +41,19 @@ function WebVRManager( renderer ) {
 
 	var currentSize, currentPixelRatio;
 
-	function onVRDisplayPresentChange() {
+	function onVRDisplayPresentChange( event ) {
+
+		if ( event.display ) {
+
+			// In WebVR spec its provided on the event
+			scope.setDevice( event.display );
+
+		} else if ( event.detail && event.detail.display ) {
+
+			// In Polyfill its provided under event.detail
+			scope.setDevice( event.detail.display );
+
+		}
 
 		if ( device !== null && device.isPresenting ) {
 


### PR DESCRIPTION
Hello,

This pull request ensures that `window.requestAnimationFrame` does not try to invoke `vr.submitFrame()` which can occur if a VR device is set in between the time `window.requestAnimationFrame( render )` is invoked and it invokes the render function provided.

This pull request also captures the `VRDisplay` that is provided in the `'vrdisplaypresentchange'` event; removing the need to explicitly call `renderer.vr.setDevice( display )`.