### PR TITLE
UnrealBloomPass enable renderToScreen

### DIFF
--- a/examples/js/postprocessing/UnrealBloomPass.js
+++ b/examples/js/postprocessing/UnrealBloomPass.js
@@ -1,9 +1,9 @@
 /**
  * @author spidersharma / http://eduperiment.com/
- Inspired from Unreal Engine::
- https://docs.unrealengine.com/latest/INT/Engine/Rendering/PostProcessEffects/Bloom/
+ * 
+ * Inspired from Unreal Engine
+ * https://docs.unrealengine.com/latest/INT/Engine/Rendering/PostProcessEffects/Bloom/
  */
-
 THREE.UnrealBloomPass = function ( resolution, strength, radius, threshold ) {
 
 	THREE.Pass.call( this );
@@ -195,7 +195,7 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 
 		// Render input to screen
 
-		if( this.renderToScreen ) {
+		if ( this.renderToScreen ) {
 
 			this.quad.material = this.basic;
 			this.basic.map = readBuffer.texture;
@@ -203,7 +203,6 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 			renderer.render( this.scene, this.camera, undefined, true );
 
 		}
-
 
 		// 1. Extract Bright Areas
 
@@ -222,15 +221,11 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 			this.quad.material = this.separableBlurMaterials[ i ];
 
 			this.separableBlurMaterials[ i ].uniforms[ "colorTexture" ].value = inputRenderTarget.texture;
-
 			this.separableBlurMaterials[ i ].uniforms[ "direction" ].value = THREE.UnrealBloomPass.BlurDirectionX;
-
 			renderer.render( this.scene, this.camera, this.renderTargetsHorizontal[ i ], true );
 
 			this.separableBlurMaterials[ i ].uniforms[ "colorTexture" ].value = this.renderTargetsHorizontal[ i ].texture;
-
 			this.separableBlurMaterials[ i ].uniforms[ "direction" ].value = THREE.UnrealBloomPass.BlurDirectionY;
-
 			renderer.render( this.scene, this.camera, this.renderTargetsVertical[ i ], true );
 
 			inputRenderTarget = this.renderTargetsVertical[ i ];
@@ -254,7 +249,7 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
 
 
-		if( this.renderToScreen ) {
+		if ( this.renderToScreen ) {
 
 			renderer.render( this.scene, this.camera, undefined, false );
 

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -144,6 +144,7 @@
 					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
 
 				} );
+
 				// Lights
 
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
@@ -188,14 +189,14 @@
 
 				gui.add( params, 'exposure', 0.1, 2 );
 				gui.add( params, 'bloomThreshold', 0.0, 1.0 ).onChange( function(value) {
-				bloomPass.threshold = Number(value);
-			});
+					bloomPass.threshold = Number(value);
+				});
 				gui.add( params, 'bloomStrength', 0.0, 3.0 ).onChange( function(value) {
-				bloomPass.strength = Number(value);
-			});
+					bloomPass.strength = Number(value);
+				});
 				gui.add( params, 'bloomRadius', 0.0, 1.0 ).onChange( function(value) {
-				bloomPass.radius = Number(value);
-			});
+					bloomPass.radius = Number(value);
+				});
 				gui.open();
 
 			}

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -162,21 +162,18 @@
 
 				renderScene = new THREE.RenderPass(scene, camera);
 
-		    // renderScene.clear = true;
-		    effectFXAA = new THREE.ShaderPass(THREE.FXAAShader);
-		    effectFXAA.uniforms['resolution'].value.set(1 / window.innerWidth, 1 / window.innerHeight );
+				effectFXAA = new THREE.ShaderPass(THREE.FXAAShader);
+				effectFXAA.uniforms['resolution'].value.set(1 / window.innerWidth, 1 / window.innerHeight );
 
-				var copyShader = new THREE.ShaderPass(THREE.CopyShader);
-				copyShader.renderToScreen = true;
+		    	bloomPass = new THREE.UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 1.5, 0.4, 0.85);//1.0, 9, 0.5, 512);
+				bloomPass.renderToScreen = true;
 
-		    bloomPass = new THREE.UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 1.5, 0.4, 0.85);//1.0, 9, 0.5, 512);
 				composer = new THREE.EffectComposer(renderer);
-		    composer.setSize(window.innerWidth, window.innerHeight);
-		    composer.addPass(renderScene);
+		    	composer.setSize(window.innerWidth, window.innerHeight);
+		   		composer.addPass(renderScene);
 				composer.addPass(effectFXAA);
-		    composer.addPass(bloomPass);
-				composer.addPass(copyShader);
-				//renderer.toneMapping = THREE.ReinhardToneMapping;
+		    	composer.addPass(bloomPass);
+
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 
@@ -261,7 +258,6 @@
 
 				}
 
-				// renderer.render( scene, camera );
 				composer.render();
 			}
 

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -165,14 +165,14 @@
 				effectFXAA = new THREE.ShaderPass(THREE.FXAAShader);
 				effectFXAA.uniforms['resolution'].value.set(1 / window.innerWidth, 1 / window.innerHeight );
 
-		    	bloomPass = new THREE.UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 1.5, 0.4, 0.85);//1.0, 9, 0.5, 512);
+				bloomPass = new THREE.UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 1.5, 0.4, 0.85);//1.0, 9, 0.5, 512);
 				bloomPass.renderToScreen = true;
 
 				composer = new THREE.EffectComposer(renderer);
-		    	composer.setSize(window.innerWidth, window.innerHeight);
-		   		composer.addPass(renderScene);
+				composer.setSize(window.innerWidth, window.innerHeight);
+				composer.addPass(renderScene);
 				composer.addPass(effectFXAA);
-		    	composer.addPass(bloomPass);
+				composer.addPass(bloomPass);
 
 				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
@@ -188,14 +188,14 @@
 
 				gui.add( params, 'exposure', 0.1, 2 );
 				gui.add( params, 'bloomThreshold', 0.0, 1.0 ).onChange( function(value) {
-		        bloomPass.threshold = Number(value);
-		    });
+				bloomPass.threshold = Number(value);
+			});
 				gui.add( params, 'bloomStrength', 0.0, 3.0 ).onChange( function(value) {
-		        bloomPass.strength = Number(value);
-		    });
+				bloomPass.strength = Number(value);
+			});
 				gui.add( params, 'bloomRadius', 0.0, 1.0 ).onChange( function(value) {
-		        bloomPass.radius = Number(value);
-		    });
+				bloomPass.radius = Number(value);
+			});
 				gui.open();
 
 			}


### PR DESCRIPTION
Hi

This PR enabled the use of renderToScreen flag in the UnrealBloomPass postprocessing effect.

Also simplified example (removed the copyShader pass).

Cumps