### PR TITLE
VREffect improvements & optimizations

### DIFF
--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -89,7 +89,8 @@ THREE.VREffect = function ( renderer, onError ) {
 		if ( scope.isPresenting ) {
 
 			var eyeParamsL = vrDisplay.getEyeParameters( 'left' );
-			renderer.setPixelRatio( 1 );
+			
+			if (renderer.getPixelRatio() !== 1) renderer.setPixelRatio(1);
 			renderer.setSize( eyeParamsL.renderWidth * 2  * vrResolutionRatio, eyeParamsL.renderHeight  * vrResolutionRatio, false );
 
 		} else {
@@ -125,7 +126,7 @@ THREE.VREffect = function ( renderer, onError ) {
 				rendererPixelRatio = renderer.getPixelRatio();
 				rendererSize = renderer.getSize();
 
-				renderer.setPixelRatio( 1 );
+				if (rendererPixelRatio !== 1) renderer.setPixelRatio(1);
 				renderer.setSize( eyeWidth * 2 * vrResolutionRatio, eyeHeight * vrResolutionRatio, false);
 
 				scope.setVRResolutionRatio(vrResolutionRatio)

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -106,6 +106,7 @@ THREE.VREffect = function ( renderer, onError ) {
 	var canvas = renderer.domElement;
 	var defaultLeftBounds = [ 0.0, 0.0, 0.5, 1.0 ];
 	var defaultRightBounds = [ 0.5, 0.0, 0.5, 1.0 ];
+	var fovRenderRatio = 1.0;
 
 	function onVRDisplayPresentChange() {
 
@@ -138,6 +139,19 @@ THREE.VREffect = function ( renderer, onError ) {
 	}
 
 	window.addEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
+
+	// Set the ratio of the eye FOV you want to render. This basically leaves a black border to the outside
+	// of the view, reducing the amount of pixels that need to be rendered each frame
+	this.setFOVRenderRatio = function (ratio) {
+
+		fovRenderRatio = THREE.Math.clamp(ratio, 0, 1.0);
+
+	}
+	this.getFOVRenderRatio = function () {
+
+		return fovRenderRatio;
+
+	}
 
 	this.setFullScreen = function ( boolean ) {
 
@@ -348,29 +362,41 @@ THREE.VREffect = function ( renderer, onError ) {
 			}
 
 			// render left eye
+			var leftEyeFOVReductionBorderWidth = renderRectL.width * (1 - fovRenderRatio) * 0.5;
+			var leftEyeFOVReductionBorderHeight = renderRectL.height * (1 - fovRenderRatio) * 0.5;
+			var leftEyeScissor = [ renderRectL.x + leftEyeFOVReductionBorderWidth, 
+									 renderRectL.y + leftEyeFOVReductionBorderHeight, 
+									 renderRectL.width - leftEyeFOVReductionBorderWidth * 2, 
+									 renderRectL.height - leftEyeFOVReductionBorderHeight * 2]
 			if ( renderTarget ) {
-
+				
 				renderTarget.viewport.set( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
-				renderTarget.scissor.set( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
+				renderTarget.scissor.set( leftEyeScissor[0], leftEyeScissor[1], leftEyeScissor[2], leftEyeScissor[3] );
 
 			} else {
 
 				renderer.setViewport( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
-				renderer.setScissor( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
+				renderer.setScissor( leftEyeScissor[0], leftEyeScissor[1], leftEyeScissor[2], leftEyeScissor[3] );
 
 			}
 			renderer.render( scene, cameraL, renderTarget );
 
 			// render right eye
+			var rightEyeFOVReductionBorderWidth = renderRectR.width * (1 - fovRenderRatio) * 0.5;
+			var rightEyeFOVReductionBorderHeight = renderRectR.height * (1 - fovRenderRatio) * 0.5;
+			var rightEyeScissor = [ renderRectR.x + rightEyeFOVReductionBorderWidth, 
+									 renderRectR.y + rightEyeFOVReductionBorderHeight, 
+									 renderRectR.width - rightEyeFOVReductionBorderWidth * 2, 
+									 renderRectR.height - rightEyeFOVReductionBorderHeight * 2]
 			if ( renderTarget ) {
 
 				renderTarget.viewport.set( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
-				renderTarget.scissor.set( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
+				renderTarget.scissor.set( rightEyeScissor[0], rightEyeScissor[1], rightEyeScissor[2], rightEyeScissor[3] );
 
 			} else {
 
 				renderer.setViewport( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
-				renderer.setScissor( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
+				renderer.setScissor( rightEyeScissor[0], rightEyeScissor[1], rightEyeScissor[2], rightEyeScissor[3] );
 
 			}
 			renderer.render( scene, cameraR, renderTarget );

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -251,6 +251,11 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
+			// do one clear for both eyes
+			if ( renderer.autoClear || forceClear ) renderer.clear();
+			const rendererAutoClear = renderer.autoClear;
+			renderer.autoClear = false;
+
 			// When rendering we don't care what the recommended size is, only what the actual size
 			// of the backbuffer is.
 			var size = renderer.getSize();
@@ -297,7 +302,6 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			if ( renderer.autoClear || forceClear ) renderer.clear();
 
 			if ( camera.parent === null ) camera.updateMatrixWorld();
 
@@ -355,7 +359,7 @@ THREE.VREffect = function ( renderer, onError ) {
 				renderer.setScissor( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
 
 			}
-			renderer.render( scene, cameraL, renderTarget, forceClear );
+			renderer.render( scene, cameraL, renderTarget );
 
 			// render right eye
 			if ( renderTarget ) {
@@ -369,8 +373,8 @@ THREE.VREffect = function ( renderer, onError ) {
 				renderer.setScissor( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
 
 			}
-			renderer.render( scene, cameraR, renderTarget, forceClear );
-
+			renderer.render( scene, cameraR, renderTarget );
+			
 			if ( renderTarget ) {
 
 				renderTarget.viewport.set( 0, 0, size.width, size.height );
@@ -396,6 +400,8 @@ THREE.VREffect = function ( renderer, onError ) {
 				scope.submitFrame();
 
 			}
+
+			renderer.autoClear = rendererAutoClear;
 
 			return;
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -213,6 +213,10 @@ THREE.VREffect = function ( renderer, onError ) {
 				resolve( requestPresentToVRDisplay() );
 
 			} else {
+				if (!vrDisplay.isPresenting) {
+					resolve();
+					return;
+				}
 
 				resolve( vrDisplay.exitPresent() );
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -268,7 +268,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	this.submitFrame = function () {
 
-		if ( vrDisplay !== undefined && scope.isPresenting ) {
+		if ( vrDisplay !== undefined && vrDisplay.isPresenting ) {
 
 			vrDisplay.submitFrame();
 


### PR DESCRIPTION
This PR includes all the performance optomizations and improvements we made to VREffect for our WebVR project [Dance Tonite](http://tonite.dance). I know VREffect is on the way out in favor of `renderer.vr`, but I wanted to put this PR out there in hopes that it can help others.

The biggest optimization we made was [removing unnecessary `clear` calls](https://github.com/customlogic/three.js/commit/2d80b0417711b04de6fa58db992e5deaf515b0db). Before, the VREffect was doing an extra clear for each eye. According to @klausw, doing a partial clear (for left and right eye) is extra expensive because the GPU can't do an optimized full screen clear. This fix got us a 5-10fps boost on mobile devices with large displays (Pixel XL, Samsung Galaxy S8, etc)

I added a feature to render at a lower resolution to the HMD. For example, if you call `vreeffect.setVRResolutionRatio(0.1)`, this will render VR at 10% of the resolution the device reports. Setting to 0.8 or 0.9 will get you a decent performance boost with minimal loss of quality.

![res_compare](https://user-images.githubusercontent.com/1166244/29899181-c8b963f0-8d9e-11e7-8945-10603f1455c9.png)

I also added a feature to render at a lower Field of View for the HMD. For example, if you call `vreeffect.setVRFOVRatio(0.7)`, this will render 70% of each eye in VR. This effectively creates a black border around each eye that you don't have to render, saving time. On most headsets, a ratio of 0.9 isn't noticeable, but as you go lower you start to see the black edges in VR.

![fov_compare](https://user-images.githubusercontent.com/1166244/29899322-89d4be54-8d9f-11e7-8bac-80fbe7abee2b.png)

We also made a minor improvement to save about 300ms when changing presentation mode by only changing pixel ratio when necessary.