### PR TITLE
Update constants.py

### DIFF
--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -246,8 +246,6 @@ NORMAL = 'normal'
 ITEM_SIZE = 'itemSize'
 ARRAY = 'array'
 
-FLOAT_32 = 'Float32Array'
-
 VISIBLE = 'visible'
 CAST_SHADOW = 'castShadow'
 RECEIVE_SHADOW = 'receiveShadow'


### PR DESCRIPTION
This assignment to 'FLOAT_32' is unnecessary as it is redefined [here](https://github.com/mrdoob/three.js/blob/5404a034c66c15249005bd43844b1f11548aa922/utils/exporters/blender/addons/io_three/constants.py#L138) before this value is used.
=>
[lgtm issue](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/109bbfaeab1a0768acf40151648acfdf37a1949f/files/utils/exporters/blender/addons/io_three/constants.py?sort=entity-kind&dir=ASC)