### PR TITLE
Audio: Fix start time and offset

### DIFF
--- a/docs/api/audio/Audio.html
+++ b/docs/api/audio/Audio.html
@@ -35,8 +35,8 @@
 		//Load a sound and set it as the Audio object's buffer
 		audioLoader.load( 'sounds/ambient.ogg', function( buffer ) {
 			sound.setBuffer( buffer );
-			sound.setLoop(true);
-			sound.setVolume(0.5);
+			sound.setLoop( true );
+			sound.setVolume( 0.5 );
 			sound.play();
 		});
 		</code>
@@ -77,7 +77,10 @@
 		<div>Whether the audio is currently playing.</div>
 
 		<h3>[property:Number startTime]</h3>
-		<div>Point at which to start playback. Default is *0*.</div>
+		<div>The time at which the sound should begin to play. Same as the *when* paramter of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). Default is *0*.</div>
+
+		<h3>[property:Number offset]</h3>
+		<div>An offset to the time within the audio buffer that playback should begin. Same as the *offset* paramter of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). Default is *0*.</div>
 
 		<h3>[property:String source]</h3>
 		<div>An [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode] created

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -21,6 +21,7 @@ function Audio( listener ) {
 	this.buffer = null;
 	this.loop = false;
 	this.startTime = 0;
+	this.offset = 0;
 	this.playbackRate = 1;
 	this.isPlaying = false;
 	this.hasPlaybackControl = true;
@@ -84,7 +85,8 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		source.loop = this.loop;
 		source.onended = this.onEnded.bind( this );
 		source.playbackRate.setValueAtTime( this.playbackRate, this.startTime );
-		source.start( 0, this.startTime );
+		this.startTime = this.context.currentTime;
+		source.start( this.startTime, this.offset );
 
 		this.isPlaying = true;
 
@@ -103,9 +105,13 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
-		this.source.stop();
-		this.startTime = this.context.currentTime;
-		this.isPlaying = false;
+		if ( this.isPlaying === true ) {
+
+			this.source.stop();
+			this.offset += this.context.currentTime - this.startTime;
+			this.isPlaying = false;
+
+		}
 
 		return this;
 
@@ -121,7 +127,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		}
 
 		this.source.stop();
-		this.startTime = 0;
+		this.offset = 0;
 		this.isPlaying = false;
 
 		return this;

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -108,7 +108,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		if ( this.isPlaying === true ) {
 
 			this.source.stop();
-			this.offset += this.context.currentTime - this.startTime;
+			this.offset += ( this.context.currentTime - this.startTime ) * this.playbackRate;
 			this.isPlaying = false;
 
 		}


### PR DESCRIPTION
This PR ensures, that the playback of a `AudioBufferSourceNode` starts at the correct position in the audio buffer after a call of `.pause()`.

see #11876