### PR TITLE
removal double assignements

### DIFF
--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -251,8 +251,6 @@ CAST_SHADOW = 'castShadow'
 RECEIVE_SHADOW = 'receiveShadow'
 QUAD = 'quad'
 
-USER_DATA = 'userData'
-
 MASK = {
     QUAD: 0,
     MATERIALS: 1,

--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -353,7 +353,6 @@ THREE_PHONG = 'MeshPhongMaterial'
 
 INTENSITY = 'intensity'
 DISTANCE = 'distance'
-ASPECT = 'aspect'
 ANGLE = 'angle'
 DECAY = 'decayExponent'
 


### PR DESCRIPTION
This removes double assignments found by [lgtm] (https://lgtm.com/projects/g/mrdoob/three.js/snapshot/109bbfaeab1a0768acf40151648acfdf37a1949f/files/utils/exporters/blender/addons/io_three/constants.py?sort=entity-kind&dir=ASC#xc22aa9cbed64a45a:1) and [lgtm](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/109bbfaeab1a0768acf40151648acfdf37a1949f/files/utils/exporters/blender/addons/io_three/constants.py?sort=entity-kind&dir=ASC#x831657c1e9abf0ba%3A1)