### PR TITLE
Remove special casing for `node.meshes` in GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2171,37 +2171,16 @@ THREE.GLTFLoader = ( function () {
 			] ).then( function ( dependencies ) {
 
 				return _each( __nodes, function ( _node, nodeId ) {
-
+	
 					var node = json.nodes[ nodeId ];
 
-					var meshes;
+					var mesh = node.mesh;
 
-					if ( node.mesh !== undefined) {
+					if ( mesh !== undefined) {
 
-						meshes = [ node.mesh ];
+						var group = dependencies.meshes[ mesh ];
 
-					} else if ( node.meshes !== undefined ) {
-
-						console.warn( 'THREE.GLTFLoader: Legacy glTF file detected. Nodes may have no more than one mesh.' );
-
-						meshes = node.meshes;
-
-					}
-
-					if ( meshes !== undefined ) {
-
-						for ( var meshId in meshes ) {
-
-							var mesh = meshes[ meshId ];
-							var group = dependencies.meshes[ mesh ];
-
-							if ( group === undefined ) {
-
-								console.warn( 'THREE.GLTFLoader: Could not find node "' + mesh + '".' );
-								continue;
-
-							}
-
+						if ( group !== undefined ) {
 							// do not clone children as they will be replaced anyway
 							var clonedgroup = group.clone( false );
 
@@ -2302,8 +2281,11 @@ THREE.GLTFLoader = ( function () {
 							}
 
 							_node.add( clonedgroup );
+						} else {
 
-						}
+							console.warn( 'THREE.GLTFLoader: Could not find node "' + mesh + '".' );
+
+						}                            
 
 					}
 


### PR DESCRIPTION
This might be a holdover from copying the glTF v1 loader into glTF v2.

Now, the loader expects meshes defined only on `node.mesh` (as per glTF2 spec). This removes a fair bit of code, and removes a loop. It also removes the legacy warning logging, as no exporter should† be outputting `meshes`.

--- 

Note 1: I implemented these changes in the Github web editor, so hopefully everything lines up / there's no formatting issues. I copy+pasted this into my local build, and everything works as expected.

---

† I spotted this problem when I was outputting gltf2 files with assimp - the dev version is currently exporting a node's mesh inside of `meshes`. I'm working on a fix for that. AFAIK, no other exporter is behaving this way.