### PR TITLE
Update TransformControls.js - Ability to individually enable/disable the handles/pickers.

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -745,6 +745,72 @@
 
 		};
 
+		this.setControlAll = function( gizmoType, value ) {
+
+			function setVisiblity( meshList, value ) {
+
+				for ( var mesh in meshList ) {
+
+					meshList[ mesh ].visible = value;
+
+				}
+
+			};
+
+			setVisiblity( _gizmo[ gizmoType ].handles.children, value );
+			setVisiblity( _gizmo[ gizmoType ].pickers.children, value );
+
+			this.update();
+			scope.dispatchEvent( changeEvent );
+
+		};
+
+		this.setControl = function( gizmoType, axes, value ) {
+
+			var axesArray = ( axes instanceof Array ) ? axes : [ axes ];
+
+			function setVisiblity( meshList, name, value ) {
+
+				for ( var mesh in meshList ) {
+
+					if (meshList[ mesh ].name === name) {
+
+						meshList[ mesh ].visible = value;
+
+					}
+
+				}
+
+			};
+
+			for ( var axis in axesArray) {
+
+				setVisiblity( _gizmo[ gizmoType ].handles.children, axesArray[ axis ], value );
+				setVisiblity( _gizmo[ gizmoType ].pickers.children, axesArray[ axis ], value );
+
+			}
+
+			this.update();
+			scope.dispatchEvent( changeEvent );
+
+		};
+
+		this.getControl = function( gizmoType, axis) {
+
+			var meshList = _gizmo[ gizmoType ].handles.children;
+
+			for ( var mesh in meshList ) {
+
+				if (meshList[ mesh ].name === axis) {
+
+					return meshList[ mesh ].visible;
+
+				}
+
+			}
+
+		};
+
 		this.setTranslationSnap = function ( translationSnap ) {
 
 			scope.translationSnap = translationSnap;


### PR DESCRIPTION
Noob here on GitHub, so my apologies if my etiquette is coarse...

Am proposing changes to TransformControls.js to permit individually disabling / enabling the various handles / pickers, something I noticed others on StackExchange have sought. In short, have added some helper functions to alter the visibility of the meshes / lines that make up the handles / pickers, to permit control over which handles are visible / available for transforming the associated object. Additionally, by adding helper functions, backwards compatibility is maintained.

In short the functions of getControl, setControlAll, and setControl are passed the gizmo ("translate", "rotate", or "scale"), and the handle / picker to enable / disable (eg, "X", "Y", "Z", "XY", "XYZ", etc).  Am open to constructive criticism on this three function API, as I'm not quite sure if there is a defacto function / parameter convention within the THREE framework...

Have updated corresponding TransformControls.html example to show the capabilities of controlling the handles / pickers.

Tested on Chrome, IE11, and Edge.