### PR TITLE
Fix sprite renderer bug

### DIFF
--- a/src/renderers/webgl/WebGLSpriteRenderer.js
+++ b/src/renderers/webgl/WebGLSpriteRenderer.js
@@ -225,6 +225,7 @@ function WebGLSpriteRenderer( renderer, gl, state, textures, capabilities ) {
 			state.setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha, material.premultipliedAlpha );
 			state.buffers.depth.setTest( material.depthTest );
 			state.buffers.depth.setMask( material.depthWrite );
+			state.buffers.color.setMask( material.colorWrite );
 
 			textures.setTexture2D( material.map || texture, 0 );
 


### PR DESCRIPTION
WebGLSpriteRenderer did not use material's colorWrite property. This commit fixes it.