### PR TITLE
bsdfs.glsl: Added link to publication for F_Schlick()

### DIFF
--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl
@@ -37,6 +37,7 @@ vec3 F_Schlick( const in vec3 specularColor, const in float dotLH ) {
 	// float fresnel = pow( 1.0 - dotLH, 5.0 );
 
 	// Optimized variant (presented by Epic at SIGGRAPH '13)
+	// https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
 	float fresnel = exp2( ( -5.55473 * dotLH - 6.98316 ) * dotLH );
 
 	return ( 1.0 - specularColor ) * fresnel + specularColor;


### PR DESCRIPTION
I'm currently study certain parts of `three.js`s shader code. This PR adds a comment with a link to a publication which explains the implementation of `F_Schlick()` in more detail.  