### PR TITLE
bsdfs.glsl: Correct comment in G_GGX_Smith

### DIFF
--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl
@@ -49,7 +49,7 @@ vec3 F_Schlick( const in vec3 specularColor, const in float dotLH ) {
 // alpha is "roughness squared" in Disney’s reparameterization
 float G_GGX_Smith( const in float alpha, const in float dotNL, const in float dotNV ) {
 
-	// geometry term = 4(n⋅l)(n⋅v) / G(l)⋅G(v)
+	// geometry term = G(l)⋅G(v)
 
 	float a2 = pow2( alpha );
 

--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl
@@ -49,7 +49,7 @@ vec3 F_Schlick( const in vec3 specularColor, const in float dotLH ) {
 // alpha is "roughness squared" in Disney’s reparameterization
 float G_GGX_Smith( const in float alpha, const in float dotNL, const in float dotNV ) {
 
-	// geometry term = G(l)⋅G(v) / 4(n⋅l)(n⋅v)
+	// geometry term = 4(n⋅l)(n⋅v) / G(l)⋅G(v)
 
 	float a2 = pow2( alpha );
 

--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl
@@ -49,7 +49,8 @@ vec3 F_Schlick( const in vec3 specularColor, const in float dotLH ) {
 // alpha is "roughness squared" in Disney’s reparameterization
 float G_GGX_Smith( const in float alpha, const in float dotNL, const in float dotNV ) {
 
-	// geometry term = G(l)⋅G(v)
+	// geometry term (normalized) = G(l)⋅G(v) / 4(n⋅l)(n⋅v)
+	// also see #12151
 
 	float a2 = pow2( alpha );
 


### PR DESCRIPTION
The common geometry or shadowing/masking function of a microfacet specular BRDF looks like this: `G(l,v,h)`. `three.js` uses the GGX model based on Smith's method to determine how many microfacets are unshadowed and unmasked so they actually transfer light.

The formal notation is:

`G(l,v,h) = G_GGX(l) * G_ GGX(v)` where `G_GGX` is:

![image](https://user-images.githubusercontent.com/12612165/30213825-97cc9f2e-94aa-11e7-9dbf-efe2268dc637.png)

This formula is basically implemented in `G_GGX_Smith()` although the term in the numerator is not regarded, for good reasons.

While studying the implementation i've noticed that a comment in `G_GGX_Smith()` is not correct. ~I think numerator and denominator need to be switched. Only then `4(n⋅l)(n⋅v)` is canceled in the further process of the calculation, right?~

Sry for asking this question but I just want to clarify some formal aspects of the shading implementation of `three.js`. 😇

[Reference](https://graphicrants.blogspot.de/2013/08/specular-brdf-reference.html) 


