### PR TITLE
Sky radius as argument of THREE.Sky

### DIFF
--- a/examples/js/SkyShader.js
+++ b/examples/js/SkyShader.js
@@ -14,7 +14,7 @@
  * Three.js integration by zz85 http://twitter.com/blurspline
 */
 
-THREE.Sky = function () {
+THREE.Sky = function ( radius ) {
 
 	var skyShader = THREE.Sky.SkyShader;
 
@@ -27,7 +27,9 @@ THREE.Sky = function () {
 		side: THREE.BackSide
 	} );
 
-	var skyGeo = new THREE.SphereBufferGeometry( 450000, 32, 15 );
+	var radius = radius !== undefined ? radius : 450000;
+
+	var skyGeo = new THREE.SphereBufferGeometry( radius, 32, 15 );
 	var skyMesh = new THREE.Mesh( skyGeo, skyMat );
 
 	// Expose variables

--- a/examples/js/SkyShader.js
+++ b/examples/js/SkyShader.js
@@ -14,7 +14,7 @@
  * Three.js integration by zz85 http://twitter.com/blurspline
 */
 
-THREE.Sky = function ( radius ) {
+THREE.Sky = function () {
 
 	var skyShader = THREE.Sky.SkyShader;
 
@@ -27,9 +27,7 @@ THREE.Sky = function ( radius ) {
 		side: THREE.BackSide
 	} );
 
-	var radius = radius !== undefined ? radius : 450000;
-
-	var skyGeo = new THREE.SphereBufferGeometry( radius, 32, 15 );
+	var skyGeo = new THREE.SphereBufferGeometry( 1, 32, 15 );
 	var skyMesh = new THREE.Mesh( skyGeo, skyMat );
 
 	// Expose variables

--- a/examples/webgl_shaders_sky.html
+++ b/examples/webgl_shaders_sky.html
@@ -65,8 +65,11 @@
 
 			function initSky() {
 
-				// Add Sky Mesh of radius 450000
-				sky = new THREE.Sky( 450000 );
+				// Add Sky Mesh
+				sky = new THREE.Sky();
+				sky.mesh.scale.setScalar( 450000 );
+				sky.mesh.matrixAutoUpdate = false;//The sky is still (see https://threejs.org/docs/#manual/introduction/How-to-update-things)
+				sky.mesh.updateMatrixWorld();//So only compute its matrix now.
 				scene.add( sky.mesh );
 
 				// Add Sun Helper

--- a/examples/webgl_shaders_sky.html
+++ b/examples/webgl_shaders_sky.html
@@ -65,8 +65,8 @@
 
 			function initSky() {
 
-				// Add Sky Mesh
-				sky = new THREE.Sky();
+				// Add Sky Mesh of radius 450000
+				sky = new THREE.Sky( 450000 );
 				scene.add( sky.mesh );
 
 				// Add Sun Helper


### PR DESCRIPTION
The current default radius of the sky sphere is 450000, forcing the user to set a far plane of more than that value. With this PR we can now call `var sky = new THREE.Sky( radius )`.