### PR TITLE
Cameras: update setViewOffset()

### DIFF
--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -53,14 +53,25 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 	setViewOffset: function ( fullWidth, fullHeight, x, y, width, height ) {
 
-		this.view = {
-			fullWidth: fullWidth,
-			fullHeight: fullHeight,
-			offsetX: x,
-			offsetY: y,
-			width: width,
-			height: height
+		if ( this.view === null ) {
+
+			this.view = {
+				fullWidth: 1,
+				fullHeight: 1,
+				offsetX: 0,
+				offsetY: 0,
+				width: 1,
+				height: 1
+			};
+
 		};
+
+		this.view.fullWidth = fullWidth;
+		this.view.fullHeight = fullHeight;
+		this.view.offsetX = x;
+		this.view.offsetY = y;
+		this.view.width = width;
+		this.view.height = height;
 
 		this.updateProjectionMatrix();
 

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -148,14 +148,25 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 		this.aspect = fullWidth / fullHeight;
 
-		this.view = {
-			fullWidth: fullWidth,
-			fullHeight: fullHeight,
-			offsetX: x,
-			offsetY: y,
-			width: width,
-			height: height
+		if ( this.view === null ) {
+
+			this.view = {
+				fullWidth: 1,
+				fullHeight: 1,
+				offsetX: 0,
+				offsetY: 0,
+				width: 1,
+				height: 1
+			};
+
 		};
+
+		this.view.fullWidth = fullWidth;
+		this.view.fullHeight = fullHeight;
+		this.view.offsetX = x;
+		this.view.offsetY = y;
+		this.view.width = width;
+		this.view.height = height;
 
 		this.updateProjectionMatrix();
 


### PR DESCRIPTION
`setViewOffset()` was instantiating a new object every time it was called, which was multiple times per frame in some cases.

It should work fine, now, for something like head tracking, where it would be called every frame.

Thing is, there is still an issue, because `clearViewOffset()` is called every frame in `SSAARenderPass` and `TAARenderPass`.

/ping @bhouston Can the post-processing effects be modified to avoid this issue?

---

Actually, perhaps we should refactor the camera code to continue to lazily-instantiate `viewOffset` in `setViewOffset()`, but add a `viewOffset.enabled` flag, so `clearViewOffset()` would just set the flag to `false`.