### PR TITLE
Improves support for collada models with non-integer joint indices

### DIFF
--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -2165,7 +2165,7 @@ THREE.ColladaLoader.prototype = {
 
 			var data = {
 				name: xml.getAttribute( 'name' ) || '',
-				joints: [],
+				joints: {},
 				links: []
 			};
 
@@ -2453,8 +2453,7 @@ THREE.ColladaLoader.prototype = {
 						var param = child.getElementsByTagName( 'param' )[ 0 ];
 						data.axis = param.textContent;
 						var tmpJointIndex = data.axis.split( 'inst_' ).pop().split( 'axis' )[ 0 ];
-						tmpJointIndex = tmpJointIndex.substr(0, tmpJointIndex.length - 1);
-						data.jointIndex = tmpJointIndex;
+						data.jointIndex = tmpJointIndex.substr( 0, tmpJointIndex.length - 1 );
 						break;
 
 				}

--- a/examples/js/loaders/ColladaLoader2.js
+++ b/examples/js/loaders/ColladaLoader2.js
@@ -2214,7 +2214,7 @@ THREE.ColladaLoader.prototype = {
 				switch ( child.nodeName ) {
 
 					case 'joint':
-						data.joints.push( parseKinematicsJoint( child ) );
+						data.joints[ child.getAttribute( 'sid' ) ] = parseKinematicsJoint( child );
 						break;
 
 					case 'link':
@@ -2452,7 +2452,9 @@ THREE.ColladaLoader.prototype = {
 					case 'axis':
 						var param = child.getElementsByTagName( 'param' )[ 0 ];
 						data.axis = param.textContent;
-						data.jointIndex = parseInt( data.axis.split( 'joint' ).pop().split( '.' )[ 0 ] );
+						var tmpJointIndex = data.axis.split( 'inst_' ).pop().split( 'axis' )[ 0 ];
+						tmpJointIndex = tmpJointIndex.substr(0, tmpJointIndex.length - 1);
+						data.jointIndex = tmpJointIndex;
 						break;
 
 				}
@@ -2591,7 +2593,7 @@ THREE.ColladaLoader.prototype = {
 
 								// if there is a connection of the transform node with a joint, apply the joint value
 
-								if ( transform.sid && transform.sid.indexOf( 'joint' + jointIndex ) !== -1 ) {
+								if ( transform.sid && transform.sid.indexOf( jointIndex ) !== -1 ) {
 
 									switch ( joint.type ) {
 

--- a/examples/webgl_loader_collada_kinematics.html
+++ b/examples/webgl_loader_collada_kinematics.html
@@ -58,7 +58,8 @@
 
 			var loader = new THREE.ColladaLoader();
 			loader.options.convertUpAxis = true;
-			loader.load( './models/collada/kawada-hironx.dae', function ( collada ) {
+			// loader.load( './models/collada/kawada-hironx.dae', function ( collada ) {
+			loader.load( './models/collada/abb_irb52_7_120.dae', function ( collada ) {
 
 				dae = collada.scene;
 
@@ -135,17 +136,25 @@
 
 				var target = {};
 
-				for ( var i = 0; i < kinematics.joints.length; i ++ ) {
+				for ( var prop in kinematics.joints ) {
 
-					var joint = kinematics.joints[ i ];
+					if ( kinematics.joints.hasOwnProperty( prop ) ) {
 
-					var old = tweenParameters[ i ];
+						if ( ! kinematics.joints[ prop ].static ) {
 
-					var position = old ? old : joint.zeroPosition;
+							var joint = kinematics.joints[ prop ];
 
-					tweenParameters[ i ] = position;
+							var old = tweenParameters[ prop ];
 
-					target[ i ] = THREE.Math.randInt( joint.limits.min, joint.limits.max )
+							var position = old ? old : joint.zeroPosition;
+
+							tweenParameters[ prop ] = position;
+
+							target[ prop ] = THREE.Math.randInt( joint.limits.min, joint.limits.max )
+
+						}
+
+					}
 
 				}
 
@@ -153,9 +162,17 @@
 
 				kinematicsTween.onUpdate( function() {
 
-					for ( var i = 0; i < kinematics.joints.length; i ++ ) {
+					for ( var prop in kinematics.joints ) {
 
-						kinematics.setJointValue( i, this[ i ] );
+						if ( kinematics.joints.hasOwnProperty( prop ) ) {
+
+							if ( ! kinematics.joints[ prop ].static ) {
+
+								kinematics.setJointValue( prop, this[ prop ] );
+
+							}
+
+						}
 
 					}
 
@@ -192,11 +209,11 @@
 
 				var timer = Date.now() * 0.0001;
 
-				camera.position.x = Math.cos( timer ) * 17;
+				camera.position.x = Math.cos( timer ) * 20;
 				camera.position.y = 10;
-				camera.position.z = Math.sin( timer ) * 17;
+				camera.position.z = Math.sin( timer ) * 20;
 
-				camera.lookAt( scene.position );
+				camera.lookAt( new THREE.Vector3( 0, 5, 0 ) );
 
 				particleLight.position.x = Math.sin( timer * 4 ) * 3009;
 				particleLight.position.y = Math.cos( timer * 5 ) * 4000;


### PR DESCRIPTION
Concerning #12059,

Sorry for the delay committing this, @Mugen87... I went for vacation and completely forgot to push.

I have changed a couple of lines of code so that joint ids of collada models are stored in a `map` rather than in an integer array (some models like the one I added from ABB do use `strings` to identify joints).
In addition, I also changed a bit the tween setup and joint updates for the example demo itself.

I tested with many different robot collada models and everything seems to work fine. The old demo with the Kawada HiroNX still works. I hope I didn't miss/mess anything!