### PR TITLE
Update to LoadingManager.html (doc)

### DIFF
--- a/docs/api/loaders/managers/LoadingManager.html
+++ b/docs/api/loaders/managers/LoadingManager.html
@@ -130,14 +130,14 @@
 		<div>
 		[page:String url] — the url to load<br /><br />
 
-		This should be called by any loader used by the manager when the loader starts loading an url.
+		This should be called by any loader using the manager when the loader starts loading an url.
 		</div>
 
 		<h3>[method:null itemEnd]( [page:String url] )</h3>
 		<div>
 		[page:String url] — the loaded url<br /><br />
 
-		This should be called by any loader used by the manager when the loader ended loading an url.
+		This should be called by any loader using the manager when the loader ended loading an url.
 		</div>
 
 
@@ -145,7 +145,7 @@
 		<div>
 		[page:String url] — the loaded url<br /><br />
 
-		This should be called by any loader used by the manager when the loader errors loading an url.
+		This should be called by any loader using the manager when the loader errors loading an url.
 		</div>
 
 		<h2>Source</h2>


### PR DESCRIPTION
I think language should be a bit more precise.  The LoadingManager is used by the a Specific Loader.
IMHO,  ***loader using the manager***  rather than used by the manager is bit more precise and clearer to understand.