### PR TITLE
Watershader improvements

### DIFF
--- a/examples/js/WaterShader.js
+++ b/examples/js/WaterShader.js
@@ -297,13 +297,28 @@ THREE.WaterMesh = function ( width, height, options ) {
 
 	scope.add( waterMaterial );
 
-	scope.render = function ( renderer, scene, camera ) { 
+	scope.onBeforeRender = function ( renderer, scene, camera ) { 
 
 		scope.water.updateTextureMatrix( camera );
 
+		var currentRenderTarget = renderer.getRenderTarget();
+
+		var currentVrEnabled = renderer.vr.enabled;
+		var currentShadowAutoUpdate = renderer.shadowMap.autoUpdate;
+
+		scope.visible = false;
+
+		renderer.vr.enabled = false; // Avoid camera modification and recursion
+		renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
+
 		renderer.render( scene, scope.water.mirrorCamera, scope.water.renderTarget, true );
 
-		scope.material.visible = true;
+		scope.visible = true;
+
+		renderer.vr.enabled = currentVrEnabled;
+		renderer.shadowMap.autoUpdate = currentShadowAutoUpdate;
+
+		renderer.setRenderTarget( currentRenderTarget );
 
 	};
 	

--- a/examples/js/WaterShader.js
+++ b/examples/js/WaterShader.js
@@ -10,7 +10,6 @@
 THREE.Water = function ( renderer, camera, scene, options ) {
 
 	THREE.Object3D.call( this );
-	this.name = 'water_' + this.id;
 
 	function optionalParameter( value, defaultValue ) {
 
@@ -19,8 +18,6 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 	}
 
 	options = options || {};
-
-	this.matrixNeedsUpdate = true;
 
 	var width = optionalParameter( options.textureWidth, 512 );
 	var height = optionalParameter( options.textureHeight, 512 );
@@ -68,11 +65,13 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 
 		uniforms: THREE.UniformsUtils.merge( [
 			THREE.UniformsLib[ 'fog' ],
+			THREE.UniformsLib[ 'lights' ],
 			{
 				normalSampler: { value: null },
 				mirrorSampler: { value: null },
 				alpha: { value: 1.0 },
 				time: { value: 0.0 },
+				size: { value: 1.0 },
 				distortionScale: { value: 20.0 },
 				noiseScale: { value: 1.0 },
 				textureMatrix: { value: new THREE.Matrix4() },
@@ -88,28 +87,29 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 			'uniform float time;',
 
 			'varying vec4 mirrorCoord;',
-			'varying vec3 worldPosition;',
+			'varying vec4 worldPosition;',
 
 			THREE.ShaderChunk[ 'fog_pars_vertex' ],
+			THREE.ShaderChunk[ 'shadowmap_pars_vertex' ],
 
 			'void main() {',
 			'	mirrorCoord = modelMatrix * vec4( position, 1.0 );',
-			'	worldPosition = mirrorCoord.xyz;',
+			'	worldPosition = mirrorCoord.xyzw;',
 			'	mirrorCoord = textureMatrix * mirrorCoord;',
 			'	vec4 mvPosition =  modelViewMatrix * vec4( position, 1.0 );',
 			'	gl_Position = projectionMatrix * mvPosition;',
 
 			THREE.ShaderChunk[ 'fog_vertex' ],
+			THREE.ShaderChunk[ 'shadowmap_vertex' ],
 
 			'}'
 		].join( '\n' ),
 
 		fragmentShader: [
-			'precision highp float;',
-
 			'uniform sampler2D mirrorSampler;',
 			'uniform float alpha;',
 			'uniform float time;',
+			'uniform float size;',
 			'uniform float distortionScale;',
 			'uniform sampler2D normalSampler;',
 			'uniform vec3 sunColor;',
@@ -118,7 +118,7 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 			'uniform vec3 waterColor;',
 
 			'varying vec4 mirrorCoord;',
-			'varying vec3 worldPosition;',
+			'varying vec4 worldPosition;',
 
 			'vec4 getNoise( vec2 uv ) {',
 			'	vec2 uv0 = ( uv / 103.0 ) + vec2(time / 17.0, time / 29.0);',
@@ -140,16 +140,21 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 			'}',
 
 			THREE.ShaderChunk[ 'common' ],
+			THREE.ShaderChunk[ 'packing' ],
+			THREE.ShaderChunk[ 'bsdfs' ],
 			THREE.ShaderChunk[ 'fog_pars_fragment' ],
+			THREE.ShaderChunk[ 'lights_pars' ],
+			THREE.ShaderChunk[ 'shadowmap_pars_fragment' ],
+			THREE.ShaderChunk[ 'shadowmask_pars_fragment' ],
 
 			'void main() {',
-			'	vec4 noise = getNoise( worldPosition.xz );',
+			'	vec4 noise = getNoise( worldPosition.xz * size );',
 			'	vec3 surfaceNormal = normalize( noise.xzy * vec3( 1.5, 1.0, 1.5 ) );',
 
 			'	vec3 diffuseLight = vec3(0.0);',
 			'	vec3 specularLight = vec3(0.0);',
 
-			'	vec3 worldToEye = eye-worldPosition;',
+			'	vec3 worldToEye = eye-worldPosition.xyz;',
 			'	vec3 eyeDirection = normalize( worldToEye );',
 			'	sunLight( surfaceNormal, eyeDirection, 100.0, 2.0, 0.5, diffuseLight, specularLight );',
 
@@ -162,10 +167,11 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 			'	float rf0 = 0.3;',
 			'	float reflectance = rf0 + ( 1.0 - rf0 ) * pow( ( 1.0 - theta ), 5.0 );',
 			'	vec3 scatter = max( 0.0, dot( surfaceNormal, eyeDirection ) ) * waterColor;',
-			'	vec3 albedo = mix( sunColor * diffuseLight * 0.3 + scatter, ( vec3( 0.1 ) + reflectionSample * 0.9 + reflectionSample * specularLight ), reflectance );',
+			'	vec3 albedo = mix( ( sunColor * diffuseLight * 0.3 + scatter ) * getShadowMask(), ( vec3( 0.1 ) + reflectionSample * 0.9 + reflectionSample * specularLight ), reflectance);',
 			'	vec3 outgoingLight = albedo;',
 			'	gl_FragColor = vec4( outgoingLight, alpha );',
 
+			THREE.ShaderChunk[ 'tonemapping_fragment' ],
 			THREE.ShaderChunk[ 'fog_fragment' ],
 
 			'}'
@@ -180,6 +186,7 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 		vertexShader: mirrorShader.vertexShader,
 		uniforms: mirrorUniforms,
 		transparent: true,
+		lights: true,
 		side: this.side,
 		fog: this.fog
 	} );
@@ -193,6 +200,7 @@ THREE.Water = function ( renderer, camera, scene, options ) {
 	this.material.uniforms.waterColor.value = this.waterColor;
 	this.material.uniforms.sunDirection.value = this.sunDirection;
 	this.material.uniforms.distortionScale.value = this.distortionScale;
+	this.material.uniforms.size.value = this.size;
 
 	this.material.uniforms.eye.value = this.eye;
 
@@ -215,9 +223,7 @@ THREE.Water.prototype.constructor = THREE.Water;
 
 THREE.Water.prototype.render = function () {
 
-	if ( this.matrixNeedsUpdate ) this.updateTextureMatrix();
-
-	this.matrixNeedsUpdate = true;
+	this.updateTextureMatrix();
 
 	// Render the mirrored view of the current scene into the target texture
 	var scene = this;
@@ -243,8 +249,8 @@ THREE.Water.prototype.render = function () {
 
 THREE.Water.prototype.updateTextureMatrix = function () {
 
-	this.updateMatrixWorld();
-	this.camera.updateMatrixWorld();
+	this.updateMatrixWorld(); 
+	this.camera.updateMatrixWorld(); 
 
 	this.mirrorWorldPosition.setFromMatrixPosition( this.matrixWorld );
 	this.cameraWorldPosition.setFromMatrixPosition( this.camera.matrixWorld );
@@ -260,7 +266,7 @@ THREE.Water.prototype.updateTextureMatrix = function () {
 
 	this.rotationMatrix.extractRotation( this.camera.matrixWorld );
 
-	this.lookAtPosition.set( 0, 0, - 1 );
+	this.lookAtPosition.set( 0, 0, -1 );
 	this.lookAtPosition.applyMatrix4( this.rotationMatrix );
 	this.lookAtPosition.add( this.cameraWorldPosition );
 
@@ -319,4 +325,21 @@ THREE.Water.prototype.updateTextureMatrix = function () {
 	this.eye = worldCoordinates;
 	this.material.uniforms.eye.value = this.eye;
 
+};
+
+THREE.WaterMesh = function ( width, height, renderer, camera, scene, options ) {
+
+	var waterMaterial = new THREE.Water( renderer, camera, scene, options );
+	var waterGeometry = new THREE.PlaneBufferGeometry( width, height );
+
+	var waterMesh = new THREE.Mesh( waterGeometry, waterMaterial.material );
+
+	waterMesh.water = waterMaterial;
+
+	waterMesh.add( waterMaterial );
+
+	waterMesh.render = function () { waterMaterial.render() };
+
+	return waterMesh;
+	
 };

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -270,7 +270,6 @@
 				water.material.uniforms.size.value = parameters.size;
 				water.material.uniforms.distortionScale.value = parameters.distortionScale;
 				water.material.uniforms.alpha.value = parameters.alpha;
-				water.render( renderer, scene, camera );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -37,6 +37,7 @@
 
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
+		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script>
 
@@ -48,17 +49,14 @@
 			}
 
 			var container, stats;
-			var camera, scene, renderer;
-			var controls, water, sphere;
+			var camera, scene, renderer, light;
+			var controls, water, sphere, cubeMap;
 
 			var parameters = {
-				width: 2000,
-				height: 2000,
-				widthSegments: 250,
-				heightSegments: 250,
-				depth: 1500,
-				param: 4,
-				filterparam: 1
+				oceanSide: 2000,
+				size: 0.3,
+				distortionScale: 3.7,
+				alpha: 0.96
 			};
 
 			var waterNormals;
@@ -80,61 +78,106 @@
 				//
 
 				scene = new THREE.Scene();
-				scene.fog = new THREE.FogExp2( 0xaabbbb, 0.0001 );
+				scene.fog = new THREE.FogExp2( 0xaabbbb, 0.001 );
 
 				//
 
-				camera = new THREE.PerspectiveCamera( 55, window.innerWidth / window.innerHeight, 0.5, 3000000 );
-				camera.position.set( 2000, 750, 2000 );
+				camera = new THREE.PerspectiveCamera( 55, window.innerWidth / window.innerHeight, 1, 20000 );
+				camera.position.set( 30, 30, 100 );
 
 				//
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
-				controls.enablePan = false;
-				controls.minDistance = 1000.0;
-				controls.maxDistance = 5000.0;
 				controls.maxPolarAngle = Math.PI * 0.495;
-				controls.target.set( 0, 500, 0 );
-				controls.update();
+				controls.target.set( 0, 10, 0 );
+				controls.enablePan = false;
+				controls.minDistance = 40.0;
+				controls.maxDistance = 200.0;
+				camera.lookAt( controls.target );
 
-				scene.add( new THREE.AmbientLight( 0x444444 ) );
-
-				//
-
-				var light = new THREE.DirectionalLight( 0xffffbb, 1 );
-				light.position.set( - 1, 1, - 1 );
-				scene.add( light );
+				setLighting();
 
 				//
 
-				waterNormals = new THREE.TextureLoader().load( 'textures/waternormals.jpg' );
-				waterNormals.wrapS = waterNormals.wrapT = THREE.RepeatWrapping;
+				setWater();
 
-				water = new THREE.Water( renderer, camera, scene, {
-					textureWidth: 512,
-					textureHeight: 512,
-					waterNormals: waterNormals,
-					alpha: 	1.0,
-					sunDirection: light.position.clone().normalize(),
-					sunColor: 0xffffff,
-					waterColor: 0x001e0f,
-					distortionScale: 50.0,
-					fog: scene.fog != undefined
+				// 
+
+				setSkybox();
+
+				//
+
+				var geometry = new THREE.IcosahedronGeometry( 20, 4 );
+
+				for ( var i = 0, j = geometry.faces.length; i < j; i ++ ) {
+
+					geometry.faces[ i ].color.setHex( Math.random() * 0xffffff );
+
+				}
+
+				var material = new THREE.MeshPhongMaterial( {
+					vertexColors: THREE.FaceColors,
+					shininess: 100,
+					envMap: cubeMap,
+					side: THREE.DoubleSide
 				} );
 
+				sphere = new THREE.Mesh( geometry, material );
+				sphere.castShadow = true;
+				scene.add( sphere );
 
-				var mirrorMesh = new THREE.Mesh(
-					new THREE.PlaneBufferGeometry( parameters.width * 500, parameters.height * 500 ),
-					water.material
+				//
+
+				stats = new Stats();
+				container.appendChild( stats.dom );
+
+				//
+
+				gui = new dat.GUI();
+
+				gui.add( parameters, 'distortionScale', 0, 8, 0.1 );
+				gui.add( parameters, 'size', 0.1, 10, 0.1 );
+				gui.add( parameters, 'alpha', 0.9, 1, .001 );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function setWater() {
+
+				water = new THREE.WaterMesh( 
+					parameters.oceanSide * 5, 
+					parameters.oceanSide * 5, 
+					renderer, 
+					camera, 
+					scene, 
+					{
+						textureWidth: 512,
+						textureHeight: 512,
+						waterNormals: new THREE.TextureLoader().load( 'textures/waternormals.jpg', function ( texture ) {
+							texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+						}),
+						alpha: 	parameters.alpha,
+						sunDirection: light.position.clone().normalize(),
+						sunColor: 0xffffff,
+						waterColor: 0x001e0f,
+						distortionScale: parameters.distortionScale,
+						fog: scene.fog != undefined
+					}
 				);
 
-				mirrorMesh.add( water );
-				mirrorMesh.rotation.x = - Math.PI * 0.5;
-				scene.add( mirrorMesh );
+				water.rotation.x = - Math.PI / 2;
+				water.receiveShadow = true;
 
-				// skybox
+				scene.add( water );
 
-				var cubeMap = new THREE.CubeTexture( [] );
+			}
+
+			function setSkybox() {
+
+				cubeMap = new THREE.CubeTexture( [] );
 				cubeMap.format = THREE.RGBFormat;
 
 				var loader = new THREE.ImageLoader();
@@ -172,44 +215,32 @@
 					fragmentShader: cubeShader.fragmentShader,
 					vertexShader: cubeShader.vertexShader,
 					uniforms: cubeShader.uniforms,
-					depthWrite: false,
 					side: THREE.BackSide
 				} );
 
 				var skyBox = new THREE.Mesh(
-					new THREE.BoxGeometry( 1000000, 1000000, 1000000 ),
+					new THREE.BoxGeometry( parameters.oceanSide * 5 + 100, parameters.oceanSide * 5 + 100, parameters.oceanSide * 5 + 100 ),
 					skyBoxMaterial
 				);
 
 				scene.add( skyBox );
 
-				//
+			}
 
-				var geometry = new THREE.IcosahedronGeometry( 400, 4 );
+			function setLighting() {
 
-				for ( var i = 0, j = geometry.faces.length; i < j; i ++ ) {
+				renderer.shadowMap.enabled = true;
 
-					geometry.faces[ i ].color.setHex( Math.random() * 0xffffff );
+				light = new THREE.DirectionalLight( 0xffffbb, 1 );
+				light.position.set( - 30, 30, - 30 );
+				light.castShadow = true;
+				light.shadow.camera.top = 45;
+				light.shadow.camera.right = 40;
+				light.shadow.camera.left = light.shadow.camera.bottom = -40;
+				light.shadow.camera.near = 1; 
+				light.shadow.camera.far = 200;
 
-				}
-
-				var material = new THREE.MeshPhongMaterial( {
-					vertexColors: THREE.FaceColors,
-					shininess: 100,
-					envMap: cubeMap
-				} );
-
-				sphere = new THREE.Mesh( geometry, material );
-				scene.add( sphere );
-
-				//
-
-				stats = new Stats();
-				container.appendChild( stats.dom );
-
-				//
-
-				window.addEventListener( 'resize', onWindowResize, false );
+				scene.add( light, new THREE.AmbientLight( 0x444444 ) );
 
 			}
 
@@ -222,8 +253,6 @@
 
 			}
 
-			//
-
 			function animate() {
 
 				requestAnimationFrame( animate );
@@ -234,14 +263,18 @@
 
 			function render() {
 
-				var time = performance.now() * 0.001;
+				var time = performance.now() * 0.003;
 
-				sphere.position.y = Math.sin( time ) * 500 + 250;
-				sphere.rotation.x = time * 0.5;
-				sphere.rotation.z = time * 0.51;
+				sphere.position.y = Math.sin( time ) * 2 + 5;
+				sphere.rotation.x = time * 0.1;
+				sphere.rotation.z = time * 0.11;
 
 				water.material.uniforms.time.value += 1.0 / 60.0;
+				water.material.uniforms.size.value = parameters.size;
+				water.material.uniforms.distortionScale.value = parameters.distortionScale;
+				water.material.uniforms.alpha.value = parameters.alpha;
 				water.render();
+
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -149,10 +149,7 @@
 
 				water = new THREE.WaterMesh( 
 					parameters.oceanSide * 5, 
-					parameters.oceanSide * 5, 
-					renderer, 
-					camera, 
-					scene, 
+					parameters.oceanSide * 5,
 					{
 						textureWidth: 512,
 						textureHeight: 512,
@@ -273,7 +270,7 @@
 				water.material.uniforms.size.value = parameters.size;
 				water.material.uniforms.distortionScale.value = parameters.distortionScale;
 				water.material.uniforms.alpha.value = parameters.alpha;
-				water.render();
+				water.render( renderer, scene, camera );
 
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
This PR first changes the settings of the shader_ocean example :
- reduced scene scale (there was a lot of zeros, making it difficult to understand what is at which scale, and difficult to edit)
- added dat gui (to play with the watershader parameters)

It also improves the watershader :
- added the _size_ parameter
- supports shadows
- supports toneMapping

Finally, it also changes the API : 

- instead of creating the water object, then the mirror mesh, appending the former to the latter, and using the object's material... this is hidden in `THREE.WaterMesh`, and we can now just call `water = new THREE.WaterMesh()`.

There still is the weird reflection bias to fix, not sure how to do it. But the icosahedron is now doublesided so it's not visible anymore.