### PR TITLE
Cameras: add viewOffset.enabled flag

### DIFF
--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -56,6 +56,7 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 		if ( this.view === null ) {
 
 			this.view = {
+				enabled: true,
 				fullWidth: 1,
 				fullHeight: 1,
 				offsetX: 0,
@@ -66,6 +67,7 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 		}
 
+		this.view.enabled = true;
 		this.view.fullWidth = fullWidth;
 		this.view.fullHeight = fullHeight;
 		this.view.offsetX = x;
@@ -79,7 +81,12 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 	clearViewOffset: function () {
 
-		this.view = null;
+		if ( this.view !== null ) {
+
+			this.view.enabled = false;
+
+		}
+
 		this.updateProjectionMatrix();
 
 	},
@@ -96,7 +103,7 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 		var top = cy + dy;
 		var bottom = cy - dy;
 
-		if ( this.view !== null ) {
+		if ( this.view !== null && this.view.enabled ) {
 
 			var zoomW = this.zoom / ( this.view.width / this.view.fullWidth );
 			var zoomH = this.zoom / ( this.view.height / this.view.fullHeight );

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -151,6 +151,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 		if ( this.view === null ) {
 
 			this.view = {
+				enabled: true,
 				fullWidth: 1,
 				fullHeight: 1,
 				offsetX: 0,
@@ -161,6 +162,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 		}
 
+		this.view.enabled = true;
 		this.view.fullWidth = fullWidth;
 		this.view.fullHeight = fullHeight;
 		this.view.offsetX = x;
@@ -174,7 +176,12 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	clearViewOffset: function () {
 
-		this.view = null;
+		if ( this.view !== null ) {
+
+			this.view.enabled = false;
+
+		}
+
 		this.updateProjectionMatrix();
 
 	},
@@ -189,7 +196,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 			left = - 0.5 * width,
 			view = this.view;
 
-		if ( view !== null ) {
+		if ( this.view !== null && this.view.enabled ) {
 
 			var fullWidth = view.fullWidth,
 				fullHeight = view.fullHeight;


### PR DESCRIPTION
... as proposed in https://github.com/mrdoob/three.js/pull/12158#issue-256453616.

Note that `CombinedCamera` is broken in this regard. I do not want to spend any time with this if `CombinedCamera` is going to be removed. Actually, I would be surprised if anyone is using `viewOffset` with combined camera.



