### PR TITLE
OrbitControls : pan damping + zoom damping

### DIFF
--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -239,6 +239,13 @@ controls.mouseButtons = {
       Used internally by the [method:saveState] and [method:reset] methods.
     </div>
 
+    <h3>
+      [property:Float zoomDampingFactor]</h3>
+    <div>
+      The damping inertia for zoom, used if [property:Boolean enableDamping] is set to true.<br> Note that for this to work, you must
+      call [page:.update] () in your animation loop.
+    </div>
+
     <h3>[property:Float zoomSpeed]</h3>
     <div>
       Speed of zooming / dollying. Default is 1.

--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -30,7 +30,7 @@ document.body.appendChild( renderer.domElement );
 
 var scene = new THREE.Scene();
 
-var  camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 10000 );
+var camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 10000 );
 
 var controls = new THREE.OrbitControls( camera );
 
@@ -74,13 +74,6 @@ function animate() {
       How fast to rotate around the target if [property:Boolean autoRotate] is true. Default is 2.0, which equates to 30 seconds
       per rotation at 60fps.<br> Note that if [property:Boolean autoRotate] is enabled, you must call [page:.update]
       () in your animation loop.
-    </div>
-
-    <h3>
-      [property:Float dampingFactor]</h3>
-    <div>
-      The damping inertia used if [property:Boolean enableDamping] is set to true.<br> Note that for this to work, you must
-      call [page:.update] () in your animation loop.
     </div>
 
     <h3>[property:HTMLDOMElement domElement]</h3>
@@ -201,9 +194,28 @@ controls.mouseButtons = {
       The camera ( or other object ) that is being controlled.
     </div>
 
+    <h3>
+      [property:Float panDampingFactor]</h3>
+    <div>
+      The damping inertia for pan, used if [property:Boolean enableDamping] is set to true.<br> Note that for this to work, you must
+      call [page:.update] () in your animation loop.
+    </div>
+
+    <h3>[property:Float panSpeed]</h3>
+    <div>
+      Speed of pan. Default is 1.
+    </div>
+
     <h3>[property:Vector3 position0]</h3>
     <div>
       Used internally by the [method:saveState] and [method:reset] methods.
+    </div>
+
+    <h3>
+      [property:Float rotateDampingFactor]</h3>
+    <div>
+      The damping inertia for rotation, used if [property:Boolean enableDamping] is set to true.<br> Note that for this to work, you must
+      call [page:.update] () in your animation loop.
     </div>
 
     <h3>[property:Float rotateSpeed]</h3>

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -464,7 +464,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
 		//the zoom happens per event, but while scrolling we call 1 event per gesture,
 		//much more happen for mousemove/touchmove. So they need to scale less.
-		dolly( 0.05 * scope.zoomSpeed * ( scope.enableDamping ? 0.4 : 1 ), zoomSign );
+		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * ( scope.enableDamping ? 0.4 : 1 ), zoomSign );
 
 		dollyStart.copy( dollyEnd );
 
@@ -500,7 +500,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var zoomSign = event.deltaY < 0 ? -1 : 1;
 
-		dolly( 0.05 * scope.zoomSpeed, zoomSign );
+		dolly( 1 - Math.pow( 0.95, scope.zoomSpeed ), zoomSign );
 
 		scope.update();
 
@@ -604,7 +604,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
 		//the zoom happens per event, but while scrolling we call 1 event per gesture,
 		//much more happen for mousemove/touchmove. So they need to scale less.
-		dolly( 0.05 * scope.zoomSpeed * ( scope.enableDamping ? 0.4 : 1 ), zoomSign );
+		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * ( scope.enableDamping ? 0.4 : 1 ), zoomSign );
 
 		dollyStart.copy( dollyEnd );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -166,7 +166,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 			spherical.makeSafe();
 
 
-			spherical.radius *= ( 1 + scaleDelta );
+			spherical.radius *= ( 1 + distanceDelta );
 
 			// restrict radius to be between desired limits
 			spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius ) );
@@ -202,14 +202,14 @@ THREE.OrbitControls = function ( object, domElement ) {
 				sphericalDelta.theta *= ( 1 - scope.rotateDampingFactor );
 				sphericalDelta.phi *= ( 1 - scope.rotateDampingFactor );
 				panOffset.multiplyScalar( 1 - scope.panDampingFactor );
-				scaleDelta *= ( 1 - scope.zoomDampingFactor );
+				distanceDelta *= ( 1 - scope.zoomDampingFactor );
 				zoomDelta *= ( 1 - scope.zoomDampingFactor );
 
 			} else {
 
 				sphericalDelta.set( 0, 0, 0 );
 				panOffset.set( 0, 0, 0 );
-				scaleDelta = 0;
+				distanceDelta = 0;
 				zoomDelta = 0;
 
 			}
@@ -277,7 +277,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	var spherical = new THREE.Spherical();
 	var sphericalDelta = new THREE.Spherical();
 
-	var scaleDelta = 0;
+	var distanceDelta = 0;
 	var zoomDelta = 0;
 	var panOffset = new THREE.Vector3();
 	var zoomChanged = false;
@@ -383,15 +383,15 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	}();
 
-	function dolly( dollyScale, zoomSign ) {
+	function dolly( dollyDistance ) {
 
 		if ( scope.object instanceof THREE.PerspectiveCamera ) {
 
-			scaleDelta = zoomSign * dollyScale;
+			distanceDelta = dollyDistance;
 
 		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
 
-			zoomDelta = zoomSign * dollyScale;
+			zoomDelta = dollyDistance;
 
 		} else {
 
@@ -460,7 +460,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 		dollyDelta.subVectors( dollyEnd, dollyStart );
 
 		var zoomSign = dollyDelta.y < 0 ? -1 : dollyDelta.y > 0 ? 1 : 0;
-		dolly( 1 - Math.pow( 0.95, scope.zoomSpeed ), zoomSign );
+
+		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
 
 		dollyStart.copy( dollyEnd );
 
@@ -499,7 +500,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		//1.5 : arbitrarily increase the zoom scale when zoom from mousewheel : the zoom happens
 		//per event, but while a gesture would call 10-15 events with mousemove/touchmove,
 		//scrolling we call 3-5. So it needs to scale more.
-		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * 1.5, zoomSign );
+		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * 1.5 * zoomSign );
 
 		scope.update();
 
@@ -600,7 +601,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var zoomSign = dollyDelta.y > 0 ? -1 : dollyDelta.y < 0 ? 1 : 0;
 
-		dolly( 1 - Math.pow( 0.95, scope.zoomSpeed ), zoomSign );
+		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
 
 		dollyStart.copy( dollyEnd );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -383,15 +383,15 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	}();
 
-	function dolly( dollyDistance ) {
+	function assignZoom( zoomValue ) {
 
 		if ( scope.object instanceof THREE.PerspectiveCamera ) {
 
-			distanceDelta = dollyDistance;
+			distanceDelta = zoomValue;
 
 		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
 
-			zoomDelta = dollyDistance;
+			zoomDelta = zoomValue;
 
 		} else {
 
@@ -461,7 +461,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var zoomSign = dollyDelta.y < 0 ? -1 : dollyDelta.y > 0 ? 1 : 0;
 
-		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
+		assignZoom( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
 
 		dollyStart.copy( dollyEnd );
 
@@ -497,7 +497,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var zoomSign = event.deltaY < 0 ? -1 : event.deltaY > 0 ? 1 : 0;
 
-		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
+		assignZoom( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
 
 		scope.update();
 
@@ -598,7 +598,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var zoomSign = dollyDelta.y > 0 ? -1 : dollyDelta.y < 0 ? 1 : 0;
 
-		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
+		assignZoom( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
 
 		dollyStart.copy( dollyEnd );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -497,10 +497,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var zoomSign = event.deltaY < 0 ? -1 : event.deltaY > 0 ? 1 : 0;
 
-		//1.5 : arbitrarily increase the zoom scale when zoom from mousewheel : the zoom happens
-		//per event, but while a gesture would call 10-15 events with mousemove/touchmove,
-		//scrolling we call 3-5. So it needs to scale more.
-		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * 1.5 * zoomSign );
+		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
 
 		scope.update();
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -460,11 +460,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		dollyDelta.subVectors( dollyEnd, dollyStart );
 
 		var zoomSign = dollyDelta.y < 0 ? -1 : dollyDelta.y > 0 ? 1 : 0;
-
-		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
-		//the zoom happens per event, but while scrolling we call 1 event per gesture,
-		//much more happen for mousemove/touchmove. So they need to scale less.
-		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * ( scope.enableDamping ? 0.4 : 1 ), zoomSign );
+		dolly( 1 - Math.pow( 0.95, scope.zoomSpeed ), zoomSign );
 
 		dollyStart.copy( dollyEnd );
 
@@ -500,7 +496,10 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var zoomSign = event.deltaY < 0 ? -1 : event.deltaY > 0 ? 1 : 0;
 
-		dolly( 1 - Math.pow( 0.95, scope.zoomSpeed ), zoomSign );
+		//1.5 : arbitrarily increase the zoom scale when zoom from mousewheel : the zoom happens
+		//per event, but while a gesture would call 10-15 events with mousemove/touchmove,
+		//scrolling we call 3-5. So it needs to scale more.
+		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * 1.5, zoomSign );
 
 		scope.update();
 
@@ -601,10 +600,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var zoomSign = dollyDelta.y > 0 ? -1 : dollyDelta.y < 0 ? 1 : 0;
 
-		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
-		//the zoom happens per event, but while scrolling we call 1 event per gesture,
-		//much more happen for mousemove/touchmove. So they need to scale less.
-		dolly( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * ( scope.enableDamping ? 0.4 : 1 ), zoomSign );
+		dolly( 1 - Math.pow( 0.95, scope.zoomSpeed ), zoomSign );
 
 		dollyStart.copy( dollyEnd );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -182,15 +182,16 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 				sphericalDelta.theta *= ( 1 - scope.dampingFactor );
 				sphericalDelta.phi *= ( 1 - scope.dampingFactor );
+				panOffset.multiplyScalar( 1 - scope.dampingFactor );
 
 			} else {
 
 				sphericalDelta.set( 0, 0, 0 );
+				panOffset.set( 0, 0, 0 );
 
 			}
 
 			scale = 1;
-			panOffset.set( 0, 0, 0 );
 
 			// update condition is:
 			// min(camera displacement, camera rotation in radians)^2 > EPS

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -183,9 +183,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			scope.object.lookAt( scope.target );
 
-			if ( Math.abs( zoomDelta ) > EPS ) {//zoomDelta is only changed for orthographic camera
+			if ( Math.abs( orthographicZoomDelta ) > EPS ) {//orthographicZoomDelta is only changed for orthographic camera
 				
-				zoom = Math.min( scope.maxZoom, Math.max( scope.minZoom, scope.object.zoom * ( 1 - zoomDelta ) ) );
+				zoom = Math.min( scope.maxZoom, Math.max( scope.minZoom, scope.object.zoom * ( 1 - orthographicZoomDelta ) ) );
 				
 				if ( zoom !== scope.object.zoom ) {
 
@@ -203,14 +203,14 @@ THREE.OrbitControls = function ( object, domElement ) {
 				sphericalDelta.phi *= ( 1 - scope.rotateDampingFactor );
 				panOffset.multiplyScalar( 1 - scope.panDampingFactor );
 				distanceDelta *= ( 1 - scope.zoomDampingFactor );
-				zoomDelta *= ( 1 - scope.zoomDampingFactor );
+				orthographicZoomDelta *= ( 1 - scope.zoomDampingFactor );
 
 			} else {
 
 				sphericalDelta.set( 0, 0, 0 );
 				panOffset.set( 0, 0, 0 );
 				distanceDelta = 0;
-				zoomDelta = 0;
+				orthographicZoomDelta = 0;
 
 			}
 
@@ -278,7 +278,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	var sphericalDelta = new THREE.Spherical();
 
 	var distanceDelta = 0;
-	var zoomDelta = 0;
+	var orthographicZoomDelta = 0;
 	var panOffset = new THREE.Vector3();
 	var zoomChanged = false;
 
@@ -290,9 +290,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 	var panEnd = new THREE.Vector2();
 	var panDelta = new THREE.Vector2();
 
-	var dollyStart = new THREE.Vector2();
-	var dollyEnd = new THREE.Vector2();
-	var dollyDelta = new THREE.Vector2();
+	var zoomStart = new THREE.Vector2();
+	var zoomEnd = new THREE.Vector2();
+	var zoomDelta = new THREE.Vector2();
 
 	function getAutoRotationAngle() {
 
@@ -391,7 +391,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
 
-			zoomDelta = zoomValue;
+			orthographicZoomDelta = zoomValue;
 
 		} else {
 
@@ -418,7 +418,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		//console.log( 'handleMouseDownDolly' );
 
-		dollyStart.set( event.clientX, event.clientY );
+		zoomStart.set( event.clientX, event.clientY );
 
 	}
 
@@ -455,15 +455,15 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		//console.log( 'handleMouseMoveDolly' );
 
-		dollyEnd.set( event.clientX, event.clientY );
+		zoomEnd.set( event.clientX, event.clientY );
 
-		dollyDelta.subVectors( dollyEnd, dollyStart );
+		zoomDelta.subVectors( zoomEnd, zoomStart );
 
-		var zoomSign = dollyDelta.y < 0 ? -1 : dollyDelta.y > 0 ? 1 : 0;
+		var zoomSign = zoomDelta.y < 0 ? -1 : zoomDelta.y > 0 ? 1 : 0;
 
 		assignZoom( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
 
-		dollyStart.copy( dollyEnd );
+		zoomStart.copy( zoomEnd );
 
 		scope.update();
 
@@ -550,7 +550,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var distance = Math.sqrt( dx * dx + dy * dy );
 
-		dollyStart.set( 0, distance );
+		zoomStart.set( 0, distance );
 
 	}
 
@@ -592,15 +592,15 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		var distance = Math.sqrt( dx * dx + dy * dy );
 
-		dollyEnd.set( 0, distance );
+		zoomEnd.set( 0, distance );
 
-		dollyDelta.subVectors( dollyEnd, dollyStart );
+		zoomDelta.subVectors( zoomEnd, zoomStart );
 
-		var zoomSign = dollyDelta.y > 0 ? -1 : dollyDelta.y < 0 ? 1 : 0;
+		var zoomSign = zoomDelta.y > 0 ? -1 : zoomDelta.y < 0 ? 1 : 0;
 
 		assignZoom( ( 1 - Math.pow( 0.95, scope.zoomSpeed ) ) * zoomSign );
 
-		dollyStart.copy( dollyEnd );
+		zoomStart.copy( zoomEnd );
 
 		scope.update();
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -46,7 +46,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// Set to true to enable damping (inertia)
 	// If damping is enabled, you must call controls.update() in your animation loop
 	this.enableDamping = false;
-	this.dampingFactor = 0.25;
+	this.rotateDampingFactor = 0.1;
+	this.panDampingFactor = 0.1;
 
 	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
 	// Set to false to disable zooming
@@ -59,6 +60,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	// Set to false to disable panning
 	this.enablePan = true;
+	this.panSpeed = 1.0;
 	this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
 
 	// Set to true to automatically rotate around the target
@@ -180,9 +182,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			if ( scope.enableDamping === true ) {
 
-				sphericalDelta.theta *= ( 1 - scope.dampingFactor );
-				sphericalDelta.phi *= ( 1 - scope.dampingFactor );
-				panOffset.multiplyScalar( 1 - scope.dampingFactor );
+				sphericalDelta.theta *= ( 1 - scope.rotateDampingFactor );
+				sphericalDelta.phi *= ( 1 - scope.rotateDampingFactor );
+				panOffset.multiplyScalar( 1 - scope.panDampingFactor );
 
 			} else {
 
@@ -303,7 +305,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		return function panLeft( distance, objectMatrix ) {
 
 			v.setFromMatrixColumn( objectMatrix, 0 ); // get X column of objectMatrix
-			v.multiplyScalar( - distance );
+			v.multiplyScalar( - distance * scope.panSpeed );
 
 			panOffset.add( v );
 
@@ -318,7 +320,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		return function panUp( distance, objectMatrix ) {
 
 			v.setFromMatrixColumn( objectMatrix, 1 ); // get Y column of objectMatrix
-			v.multiplyScalar( distance );
+			v.multiplyScalar( distance * scope.panSpeed );
 
 			panOffset.add( v );
 
@@ -1026,15 +1028,33 @@ Object.defineProperties( THREE.OrbitControls.prototype, {
 
 		get: function () {
 
-			console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
-			return this.dampingFactor;
+			console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .rotateDampingFactor instead.' );
+			return this.rotateDampingFactor;
 
 		},
 
 		set: function ( value ) {
 
-			console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
-			this.dampingFactor = value;
+			console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .rotateDampingFactor instead.' );
+			this.rotateDampingFactor = value;
+
+		}
+
+	},
+
+	dampingFactor: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .dampingFactor has been renamed. Use .rotateDampingFactor instead.' );
+			return this.rotateDampingFactor;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .dampingFactor has been renamed. Use .rotateDampingFactor instead.' );
+			this.rotateDampingFactor = value;
 
 		}
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -319,7 +319,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		return function panLeft( distance, objectMatrix ) {
 
 			v.setFromMatrixColumn( objectMatrix, 0 ); // get X column of objectMatrix
-			v.multiplyScalar( - distance * scope.panSpeed );
+			v.multiplyScalar( - distance );
 
 			panOffset.add( v );
 
@@ -334,7 +334,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		return function panUp( distance, objectMatrix ) {
 
 			v.setFromMatrixColumn( objectMatrix, 1 ); // get Y column of objectMatrix
-			v.multiplyScalar( distance * scope.panSpeed );
+			v.multiplyScalar( distance );
 
 			panOffset.add( v );
 
@@ -475,7 +475,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		panEnd.set( event.clientX, event.clientY );
 
-		panDelta.subVectors( panEnd, panStart );
+		panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
 
 		pan( panDelta.x, panDelta.y );
 
@@ -615,7 +615,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		panEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
 
-		panDelta.subVectors( panEnd, panStart );
+		panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
 
 		pan( panDelta.x, panDelta.y );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -459,7 +459,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		dollyDelta.subVectors( dollyEnd, dollyStart );
 
-		var zoomSign = dollyDelta.y < 0 ? -1 : 1;
+		var zoomSign = dollyDelta.y < 0 ? -1 : dollyDelta.y > 0 ? 1 : 0;
 
 		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
 		//the zoom happens per event, but while scrolling we call 1 event per gesture,
@@ -498,7 +498,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		// console.log( 'handleMouseWheel' );
 
-		var zoomSign = event.deltaY < 0 ? -1 : 1;
+		var zoomSign = event.deltaY < 0 ? -1 : event.deltaY > 0 ? 1 : 0;
 
 		dolly( 1 - Math.pow( 0.95, scope.zoomSpeed ), zoomSign );
 
@@ -599,7 +599,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		dollyDelta.subVectors( dollyEnd, dollyStart );
 
-		var zoomSign = dollyDelta.y > 0 ? -1 : 1;
+		var zoomSign = dollyDelta.y > 0 ? -1 : dollyDelta.y < 0 ? 1 : 0;
 
 		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
 		//the zoom happens per event, but while scrolling we call 1 event per gesture,

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -383,15 +383,15 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	}();
 
-	function dolly( dollyScale, zoomOut ) {
+	function dolly( dollyScale, zoomSign ) {
 
 		if ( scope.object instanceof THREE.PerspectiveCamera ) {
 
-			scaleDelta = zoomOut ? - dollyScale : dollyScale;
+			scaleDelta = zoomSign * dollyScale;
 
 		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
 
-			zoomDelta = zoomOut ? - dollyScale : dollyScale;
+			zoomDelta = zoomSign * dollyScale;
 
 		} else {
 
@@ -459,10 +459,12 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		dollyDelta.subVectors( dollyEnd, dollyStart );
 
+		var zoomSign = dollyDelta.y < 0 ? -1 : 1;
+
 		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
 		//the zoom happens per event, but while scrolling we call 1 event per gesture,
 		//much more happen for mousemove/touchmove. So they need to scale less.
-		dolly( 0.05 * scope.zoomSpeed * ( scope.enableDamping ? 0.4 : 1 ), dollyDelta.y < 0 );
+		dolly( 0.05 * scope.zoomSpeed * ( scope.enableDamping ? 0.4 : 1 ), zoomSign );
 
 		dollyStart.copy( dollyEnd );
 
@@ -496,7 +498,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		// console.log( 'handleMouseWheel' );
 
-		dolly( 0.05 * scope.zoomSpeed, event.deltaY < 0 );
+		var zoomSign = event.deltaY < 0 ? -1 : 1;
+
+		dolly( 0.05 * scope.zoomSpeed, zoomSign );
 
 		scope.update();
 
@@ -595,10 +599,12 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		dollyDelta.subVectors( dollyEnd, dollyStart );
 
+		var zoomSign = dollyDelta.y > 0 ? -1 : 1;
+
 		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
 		//the zoom happens per event, but while scrolling we call 1 event per gesture,
 		//much more happen for mousemove/touchmove. So they need to scale less.
-		dolly( 0.05 * scope.zoomSpeed * ( scope.enableDamping ? 0.4 : 1 ), dollyDelta.y > 0 );
+		dolly( 0.05 * scope.zoomSpeed * ( scope.enableDamping ? 0.4 : 1 ), zoomSign );
 
 		dollyStart.copy( dollyEnd );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -300,12 +300,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	}
 
-	function getZoomScale() {
-
-		return 0.05 * scope.zoomSpeed;
-
-	}
-
 	function rotateLeft( angle ) {
 
 		sphericalDelta.theta -= angle;
@@ -468,7 +462,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
 		//the zoom happens per event, but while scrolling we call 1 event per gesture,
 		//much more happen for mousemove/touchmove. So they need to scale less.
-		dolly( getZoomScale() * ( scope.enableDamping ? 0.4 : 1 ), dollyDelta.y < 0 );
+		dolly( 0.05 * scope.zoomSpeed * ( scope.enableDamping ? 0.4 : 1 ), dollyDelta.y < 0 );
 
 		dollyStart.copy( dollyEnd );
 
@@ -502,7 +496,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		// console.log( 'handleMouseWheel' );
 
-		dolly( getZoomScale(), event.deltaY < 0 );
+		dolly( 0.05 * scope.zoomSpeed, event.deltaY < 0 );
 
 		scope.update();
 
@@ -604,7 +598,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 		//Arbitrary lower the zoom scale when damping enabled and zoom called from touch and move :
 		//the zoom happens per event, but while scrolling we call 1 event per gesture,
 		//much more happen for mousemove/touchmove. So they need to scale less.
-		dolly( getZoomScale() * ( scope.enableDamping ? 0.4 : 1 ), dollyDelta.y > 0 );
+		dolly( 0.05 * scope.zoomSpeed * ( scope.enableDamping ? 0.4 : 1 ), dollyDelta.y > 0 );
 
 		dollyStart.copy( dollyEnd );
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -166,6 +166,8 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
+				update = true;//Let the render be called from the render loop, when the browser is ready.
+
 			}
 
 			function animate() {

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -42,19 +42,42 @@
 		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/Detector.js"></script>
-		<script src="js/libs/stats.min.js"></script>
+		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script>
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
-			var stats;
+			var gui;
 
 			var camera, controls, scene, renderer;
 
+			var update = true;
+
+			var params = {
+				enableDamping: false,
+				rotation: {
+					enableRotate: true,
+					autoRotate: false,
+					rotateDampingFactor: 0.1,
+					rotateSpeed: 1.0
+				},
+				pan: {
+					enablePan: true,
+					panSpeed: 1.0,
+					panDampingFactor: 0.1,
+				},
+				zoom: {
+					enableZoom: true,
+					zoomDampingFactor: 0.1,
+					zoomSpeed: 1.0,
+					maxDistance: 1000,
+					minDistance: 10					
+				}
+			};
+
 			init();
-			render(); // remove when using next line for animation loop (requestAnimationFrame)
-			//animate();
+			animate();
 
 			function init() {
 
@@ -73,8 +96,11 @@
 				camera.position.z = 500;
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // remove when using animation loop
-				// enable animation loop when using damping or autorotation
+				controls.addEventListener( 'change', function () {
+					//Don't call a render here, but rather in the render loop.
+					update = true; 
+				} );
+				//Enable animation loop when using damping (or autorotation).
 				//controls.enableDamping = true;
 				//controls.rotateDampingFactor = 0.25;
 				controls.enableZoom = false;
@@ -111,8 +137,21 @@
 
 				//
 
-				stats = new Stats();
-				container.appendChild( stats.dom );
+				gui = new dat.GUI();
+
+				gui.add( controls, 'enableDamping' );
+				var rotateFolder = gui.addFolder( 'rotation' );
+				rotateFolder.add( controls, 'enableRotate' );
+				rotateFolder.add( controls, 'rotateSpeed', 0.1, 3.0 );
+				rotateFolder.add( controls, 'rotateDampingFactor', 0.01, 0.3 );
+				var panFolder = gui.addFolder( 'pan' );
+				panFolder.add( controls, 'enablePan' );
+				panFolder.add( controls, 'panSpeed', 0.1, 3.0 );
+				panFolder.add( controls, 'panDampingFactor', 0.01, 0.3 );
+				var zoomFolder = gui.addFolder( 'zoom' );
+				zoomFolder.add( controls, 'enableZoom' );
+				zoomFolder.add( controls, 'zoomSpeed', 0.1, 3.0 );
+				zoomFolder.add( controls, 'zoomDampingFactor', 0.01, 0.3 );
 
 				//
 
@@ -135,9 +174,13 @@
 
 				controls.update(); // required if controls.enableDamping = true, or if controls.autoRotate = true
 
-				stats.update();
+				if ( update ) {
 
-				render();
+					render();
+
+					update = false;
+
+				}
 
 			}
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -76,7 +76,7 @@
 				controls.addEventListener( 'change', render ); // remove when using animation loop
 				// enable animation loop when using damping or autorotation
 				//controls.enableDamping = true;
-				//controls.dampingFactor = 0.25;
+				//controls.rotateDampingFactor = 0.25;
 				controls.enableZoom = false;
 
 				// world

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -34,7 +34,8 @@
 	<body>
 		<div id="container"></div>
 		<div id="info">
-			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - orbit controls example
+			<p><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - orbit controls example</p>
+			<p>No animate loop</p>
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -42,20 +43,16 @@
 		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/Detector.js"></script>
-		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script>
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
-			var gui;
-
 			var camera, controls, scene, renderer;
 
-			var update = true;
-
 			init();
-			animate();
+			render(); // remove when using next line for animation loop (requestAnimationFrame)
+			//animate();
 
 			function init() {
 
@@ -74,11 +71,8 @@
 				camera.position.z = 500;
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', function () {
-					//Don't call a render here, but rather in the render loop.
-					update = true; 
-				} );
-				//Enable animation loop when using damping (or autorotation).
+				controls.addEventListener( 'change', render ); // remove when using animation loop
+				// enable animation loop when using damping or autorotation
 				//controls.enableDamping = true;
 				//controls.rotateDampingFactor = 0.25;
 				controls.enableZoom = false;
@@ -115,26 +109,6 @@
 
 				//
 
-				gui = new dat.GUI();
-
-				gui.add( controls, 'enableDamping' );
-				var rotateFolder = gui.addFolder( 'rotation' );
-				rotateFolder.add( controls, 'enableRotate' );
-				rotateFolder.add( controls, 'rotateSpeed', 0.1, 3.0 );
-				rotateFolder.add( controls, 'rotateDampingFactor', 0.01, 0.3 );
-				rotateFolder.add( controls, 'autoRotate' );
-				rotateFolder.add( controls, 'autoRotateSpeed', 0.1, 5.0 );
-				var panFolder = gui.addFolder( 'pan' );
-				panFolder.add( controls, 'enablePan' );
-				panFolder.add( controls, 'panSpeed', 0.1, 3.0 );
-				panFolder.add( controls, 'panDampingFactor', 0.01, 0.3 );
-				var zoomFolder = gui.addFolder( 'zoom' );
-				zoomFolder.add( controls, 'enableZoom' );
-				zoomFolder.add( controls, 'zoomSpeed', 0.1, 3.0 );
-				zoomFolder.add( controls, 'zoomDampingFactor', 0.01, 0.3 );
-
-				//
-
 				window.addEventListener( 'resize', onWindowResize, false );
 
 			}
@@ -146,8 +120,6 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				update = true;//Let the render be called from the render loop, when the browser is ready.
-
 			}
 
 			function animate() {
@@ -156,13 +128,7 @@
 
 				controls.update(); // required if controls.enableDamping = true, or if controls.autoRotate = true
 
-				if ( update ) {
-
-					render();
-
-					update = false;
-
-				}
+				render();
 
 			}
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -54,28 +54,6 @@
 
 			var update = true;
 
-			var params = {
-				enableDamping: false,
-				rotation: {
-					enableRotate: true,
-					autoRotate: false,
-					rotateDampingFactor: 0.1,
-					rotateSpeed: 1.0
-				},
-				pan: {
-					enablePan: true,
-					panSpeed: 1.0,
-					panDampingFactor: 0.1,
-				},
-				zoom: {
-					enableZoom: true,
-					zoomDampingFactor: 0.1,
-					zoomSpeed: 1.0,
-					maxDistance: 1000,
-					minDistance: 10					
-				}
-			};
-
 			init();
 			animate();
 
@@ -144,6 +122,8 @@
 				rotateFolder.add( controls, 'enableRotate' );
 				rotateFolder.add( controls, 'rotateSpeed', 0.1, 3.0 );
 				rotateFolder.add( controls, 'rotateDampingFactor', 0.01, 0.3 );
+				rotateFolder.add( controls, 'autoRotate' );
+				rotateFolder.add( controls, 'autoRotateSpeed', 0.1, 5.0 );
 				var panFolder = gui.addFolder( 'pan' );
 				panFolder.add( controls, 'enablePan' );
 				panFolder.add( controls, 'panSpeed', 0.1, 3.0 );

--- a/examples/misc_controls_orbit2.html
+++ b/examples/misc_controls_orbit2.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - orbit controls</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #000;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+				font-weight: bold;
+
+				background-color: #fff;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			#info {
+				color:#000;
+				position: absolute;
+				top: 0px; width: 100%;
+				padding: 5px;
+
+			}
+
+			a {
+				color: red;
+			}
+		</style>
+	</head>
+
+	<body>
+		<div id="container"></div>
+		<div id="info">
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - orbit controls example
+		</div>
+
+		<script src="../build/three.js"></script>
+
+		<script src="js/controls/OrbitControls.js"></script>
+
+		<script src="js/Detector.js"></script>
+		<script src="js/libs/dat.gui.min.js"></script>
+
+		<script>
+
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var gui;
+
+			var camera, controls, scene, renderer;
+
+			var update = true;
+
+			init();
+			animate();
+
+			function init() {
+
+				scene = new THREE.Scene();
+				scene.background = new THREE.Color( 0xcccccc );
+				scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				var container = document.getElementById( 'container' );
+				container.appendChild( renderer.domElement );
+
+				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.z = 500;
+
+				controls = new THREE.OrbitControls( camera, renderer.domElement );
+				controls.addEventListener( 'change', function () { update = true; } );
+
+				// world
+
+				var geometry = new THREE.CylinderGeometry( 0, 10, 30, 4, 1 );
+				var material = new THREE.MeshPhongMaterial( { color: 0xffffff, flatShading: true } );
+
+				for ( var i = 0; i < 500; i ++ ) {
+
+					var mesh = new THREE.Mesh( geometry, material );
+					mesh.position.x = ( Math.random() - 0.5 ) * 1000;
+					mesh.position.y = ( Math.random() - 0.5 ) * 1000;
+					mesh.position.z = ( Math.random() - 0.5 ) * 1000;
+					mesh.updateMatrix();
+					mesh.matrixAutoUpdate = false;
+					scene.add( mesh );
+
+				}
+
+				// lights
+
+				var light = new THREE.DirectionalLight( 0xffffff );
+				light.position.set( 1, 1, 1 );
+				scene.add( light );
+
+				var light = new THREE.DirectionalLight( 0x002288 );
+				light.position.set( -1, -1, -1 );
+				scene.add( light );
+
+				var light = new THREE.AmbientLight( 0x222222 );
+				scene.add( light );
+
+				//
+
+				gui = new dat.GUI();
+
+				gui.add( controls, 'enableDamping' );
+				var rotateFolder = gui.addFolder( 'rotation' );
+				rotateFolder.add( controls, 'enableRotate' );
+				rotateFolder.add( controls, 'rotateSpeed', 0.1, 3.0 );
+				rotateFolder.add( controls, 'rotateDampingFactor', 0.01, 0.3 );
+				rotateFolder.add( controls, 'autoRotate' );
+				rotateFolder.add( controls, 'autoRotateSpeed', 0.1, 5.0 );
+				var panFolder = gui.addFolder( 'pan' );
+				panFolder.add( controls, 'enablePan' );
+				panFolder.add( controls, 'panSpeed', 0.1, 3.0 );
+				panFolder.add( controls, 'panDampingFactor', 0.01, 0.3 );
+				var zoomFolder = gui.addFolder( 'zoom' );
+				zoomFolder.add( controls, 'enableZoom' );
+				zoomFolder.add( controls, 'zoomSpeed', 0.1, 3.0 );
+				zoomFolder.add( controls, 'zoomDampingFactor', 0.01, 0.3 );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				update = true;
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				controls.update(); // required if controls.enableDamping = true, or if controls.autoRotate = true
+
+				if ( update ) {
+
+					render();
+
+					update = false;
+
+				}
+
+			}
+
+			function render() {
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/examples/misc_controls_orbit2.html
+++ b/examples/misc_controls_orbit2.html
@@ -34,7 +34,8 @@
 	<body>
 		<div id="container"></div>
 		<div id="info">
-			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - orbit controls example
+			<p><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - orbit controls example 2</p>
+			<p>with animate loop</p>
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -113,10 +114,14 @@
 				gui.add( controls, 'enableDamping' );
 				var rotateFolder = gui.addFolder( 'rotation' );
 				rotateFolder.add( controls, 'enableRotate' );
-				rotateFolder.add( controls, 'rotateSpeed', 0.1, 3.0 );
-				rotateFolder.add( controls, 'rotateDampingFactor', 0.01, 0.3 );
 				rotateFolder.add( controls, 'autoRotate' );
 				rotateFolder.add( controls, 'autoRotateSpeed', 0.1, 5.0 );
+				rotateFolder.add( controls, 'rotateSpeed', 0.1, 3.0 );
+				rotateFolder.add( controls, 'rotateDampingFactor', 0.01, 0.3 );
+				rotateFolder.add( controls, 'minPolarAngle', 0, Math.PI );
+				rotateFolder.add( controls, 'maxPolarAngle', 0, Math.PI );
+				rotateFolder.add( controls, 'minAzimuthAngle', 0, Math.PI );
+				rotateFolder.add( controls, 'maxAzimuthAngle', 0, Math.PI );
 				var panFolder = gui.addFolder( 'pan' );
 				panFolder.add( controls, 'enablePan' );
 				panFolder.add( controls, 'panSpeed', 0.1, 3.0 );
@@ -125,6 +130,8 @@
 				zoomFolder.add( controls, 'enableZoom' );
 				zoomFolder.add( controls, 'zoomSpeed', 0.1, 3.0 );
 				zoomFolder.add( controls, 'zoomDampingFactor', 0.01, 0.3 );
+				zoomFolder.add( controls, 'minDistance', 0, 1000 );
+				zoomFolder.add( controls, 'maxDistance', 1, 1000 );
 
 				//
 

--- a/examples/misc_controls_orbit2.html
+++ b/examples/misc_controls_orbit2.html
@@ -120,8 +120,8 @@
 				rotateFolder.add( controls, 'rotateDampingFactor', 0.01, 0.3 );
 				rotateFolder.add( controls, 'minPolarAngle', 0, Math.PI );
 				rotateFolder.add( controls, 'maxPolarAngle', 0, Math.PI );
-				rotateFolder.add( controls, 'minAzimuthAngle', 0, Math.PI );
-				rotateFolder.add( controls, 'maxAzimuthAngle', 0, Math.PI );
+				rotateFolder.add( controls, 'minAzimuthAngle', 0, Math.PI * 2 );
+				rotateFolder.add( controls, 'maxAzimuthAngle', 0, Math.PI * 2 );
 				var panFolder = gui.addFolder( 'pan' );
 				panFolder.add( controls, 'enablePan' );
 				panFolder.add( controls, 'panSpeed', 0.1, 3.0 );

--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -132,7 +132,7 @@
 
 				var controls = new THREE.OrbitControls( camera, renderer.domElement );
 				controls.enableDamping = true;
-				controls.dampingFactor = 0.25;
+				controls.rotateDampingFactor = 0.25;
 				controls.rotateSpeed = 0.35;
 
 				// Create a multi render target with Float buffers

--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -161,7 +161,7 @@
 				controls.maxDistance = 20;
 				controls.enablePan = false;
 				controls.enableDamping = true;
-				controls.dampingFactor = 0.25;
+				controls.rotateDampingFactor = 0.25;
 
 				//
 


### PR DESCRIPTION
These changes provide OrbitControls with pan damping and zoom damping (for both perspective and orthographic cameras). You can check the [current orbitcontrols example](http://rawgit.com/Astrak/three.js/orbitControls-panDamping-zoomDamping/examples/misc_controls_orbit.html), which behaviour is unchanged. [A second OrbitControls example](http://rawgit.com/Astrak/three.js/orbitControls-panDamping-zoomDamping/examples/misc_controls_orbit2.html) (that may need refinements in the scene) shows the differences, when clicking `enableDamping` in the GUI.

The API has changed with `dampingFactor` now thus being only `rotateDampingFactor`, but this is handled internally as the rest of the old APIs, so no break when migrating.

Changes : 
- `dampingFactor` > `rotateDampingFactor`
- added pan damping and the `panDampingFactor` property (since there is `panSpeed`)
- added zoom damping and the `zoomDampingFactor` property (since there is `zoomSpeed`)
- new example orbit2.html, it uses a new pattern which mixes the 2 current patterns with orbitccontrols to make the most of the 'change' event listener without damping, and of the rAF with damping.
- OrbitControls doc updated
- internally, `dollyIn` and `dollyOut` have been merged in a single function renamed `assignZoom`, and the zoom change it was handling for the Orthographic Camera case is now handled in the `update` method, so zoom damping can work for that camera too.

Notes : 
- Main motivation : UX improvement (to my mind obviously). It also makes OrbitControls' behaviour consistent with TrackballControls, that do have damping for pan/rotate/zoom, and where `staticMoving` enables/disables damping for them all.
- In the first commits, the `zoomSpeed` was modified arbitrarily to answer some specific cases when called from a mousewheel event, this is now removed (I believe it should be discussed elsewhere to simplify the PR).