### PR TITLE
Handle getVRDisplays rejection for the case where the API is present,…

### DIFF
--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -32,6 +32,10 @@ var WEBVR = {
 
 					}
 
+				}, function () {
+
+					reject( 'Your browser does not support WebVR. See <a href="https://webvr.info">webvr.info</a> for assistance.' );
+				
 				} );
 
 			} else {


### PR DESCRIPTION
… but WebVR is not supported

Reject checkAvailability promise if navigator.getVRDisplays() rejects.