### PR TITLE
Update cube sample to take pointerlock...

### DIFF
--- a/examples/webvr_cubes.html
+++ b/examples/webvr_cubes.html
@@ -142,6 +142,8 @@
 
 				//
 
+				window.addEventListener( 'vrdisplaypointerrestricted', onPointerRestricted, false );
+				window.addEventListener( 'vrdisplaypointerunrestricted', onPointerUnrestricted, false );
 				window.addEventListener( 'resize', onWindowResize, false );
 
 			}
@@ -156,6 +158,22 @@
 
 				isMouseDown = false;
 
+			}
+
+			function onPointerRestricted() {
+				var pointerLockElement = renderer.domElement;
+				if ( pointerLockElement && typeof(pointerLockElement.requestPointerLock) === 'function' ) {
+					pointerLockElement.requestPointerLock();
+
+				}
+			}
+
+			function onPointerUnrestricted() {
+				var currentPointerLockElement = document.pointerLockElement;
+				var expectedPointerLockElement = renderer.domElement;
+				if ( currentPointerLockElement && currentPointerLockElement === expectedPointerLockElement && typeof(document.exitPointerLock) === 'function' ) {
+					document.exitPointerLock();
+				}
 			}
 
 			function onWindowResize() {


### PR DESCRIPTION
...in response to vrdisplayrestricted events for mouse input.

Support mouse input in WebVR by handling vrdisplaypointerrestricted and vrdisplaypointerunrestricted events in MS Edge. It is by design that mozPointerLock* and webkitPointerLock* implementations are not included.
•	In response to vrdisplaypointerrestricted perform requestPointerLock on the canvas element that is used for WebVR rendering
•	In response to vrdisplaypointerunrestricted perform document.exitPointerLock if the locked element is the canvas that is used for WebVR rendering
