### PR TITLE
Fix spherical env maps being rotated along with the camera

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_pars.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars.glsl
@@ -282,7 +282,7 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 		#elif defined( ENVMAP_TYPE_SPHERE )
 
-			vec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0,0.0,1.0 ) );
+			vec3 reflectView = normalize( reflectVec + vec3( 0.0,0.0,1.0 ) );
 
 			#ifdef TEXTURE_LOD_EXT
 


### PR DESCRIPTION
By applying the view matrix to the reflection vector, the environment
map is essentially rotated along with the camera, while it should be
static relative to the scene. Thus, we have to remove this
transformation.