### PR TITLE
Fixes #12201 When using a texture non POT, use the previous POT size

### DIFF
--- a/docs/api/math/Math.html
+++ b/docs/api/math/Math.html
@@ -73,6 +73,9 @@
 		<h3>[method:Integer nearestPowerOfTwo]( [page:Number n] )</h3>
 		<div>	Returns the nearest power of 2 to a given number [page:Number n].</div>
 
+		<h3>[method:Integer previousPowerOfTwo]( [page:Number n] )</h3>
+		<div>Returns the nearest power of 2 that is smaller than [page:Number n].</div>
+
 		<h3>[method:Integer nextPowerOfTwo]( [page:Number n] )</h3>
 		<div>Returns the nearest power of 2 that is bigger than [page:Number n].</div>
 

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -148,6 +148,12 @@ var _Math = {
 
 	},
 
+	previousPowerOfTwo: function ( value ) {
+
+		return Math.pow( 2, Math.floor( Math.log( value ) / Math.LN2 ) );
+
+	},
+
 	nextPowerOfTwo: function ( value ) {
 
 		value --;

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -48,8 +48,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		if ( image instanceof HTMLImageElement || image instanceof HTMLCanvasElement ) {
 
 			var canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
-			canvas.width = _Math.nearestPowerOfTwo( image.width );
-			canvas.height = _Math.nearestPowerOfTwo( image.height );
+			canvas.width = _Math.previousPowerOfTwo( image.width );
+			canvas.height = _Math.previousPowerOfTwo( image.height );
 
 			var context = canvas.getContext( '2d' );
 			context.drawImage( image, 0, 0, canvas.width, canvas.height );


### PR DESCRIPTION
Re https://github.com/mrdoob/three.js/issues/12201