### PR TITLE
For key frame animations, default scale is (1, 1, 1)

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/animation.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/animation.py
@@ -515,7 +515,7 @@ def _scale(bone, frame, action, armature_matrix):
     :param armature_matrix:
 
     """
-    scale = mathutils.Vector((0.0, 0.0, 0.0))
+    scale = mathutils.Vector((1.0, 1.0, 1.0))
 
     change = False
 


### PR DESCRIPTION
If an animation key doesn't explicitly define the scale value, it is set to (1, 1, 1) instead of (0, 0, 0). With the old behavior, if we didn't explicitly key the scale, the scale would default to zero and the mesh would disappear. 