### PR TITLE
FBXLoader: fix missing propertyListLength

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -4065,6 +4065,7 @@
 			// The first three data sizes depends on version.
 			var endOffset = ( version >= 7500 ) ? reader.getUint64() : reader.getUint32();
 			var numProperties = ( version >= 7500 ) ? reader.getUint64() : reader.getUint32();
+			var propertyListLen = ( version >= 7400 ) ? reader.getUint32() : undefined;
 			var nameLen = reader.getUint8();
 			var name = reader.getString( nameLen );
 


### PR DESCRIPTION
 Fix missing property in node parsing that crash every file with version > 7400