### PR TITLE
Fix first empty line on RawShaderMaterial shaders

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -291,20 +291,28 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 		prefixVertex = [
 
-			customDefines,
-
-			'\n'
+			customDefines
 
 		].filter( filterEmptyLine ).join( '\n' );
+
+		if ( prefixVertex.length > 0 ) {
+
+			prefixVertex += '\n';
+
+		}
 
 		prefixFragment = [
 
 			customExtensions,
-			customDefines,
-
-			'\n'
+			customDefines
 
 		].filter( filterEmptyLine ).join( '\n' );
+
+		if ( prefixFragment.length > 0 ) {
+
+			prefixFragment += '\n';
+
+		}
 
 	} else {
 


### PR DESCRIPTION
Currently if we have empty `customDefines` and `customExtension` on a `RawShaderMaterial`  we'll include an empty line at the beginning of the vertex or fragment shader.
While this will work on WebGL1, if we're using WebGL2 with GLSL 3.00 ES it's mandatory to include the version definition on the first line, so even if we define the shader correctly, we'll get an error because of the injected extra line:

```html
<script id="vertexShader" type="x-shader/x-vertex">#version 300 es

uniform mat4 projectionMatrix;
uniform mat4 viewMatrix;
...
```

Error:
```
#version directive must occur on the first line of the shader
```


