### PR TITLE
GLTFLoader: Remove extra Object3D wrappers on nodes.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1807,12 +1807,9 @@ THREE.GLTFLoader = ( function () {
 
 		] ).then( function ( dependencies ) {
 
-			return _each( json.meshes, function ( meshDef ) {
+			return _each( json.meshes, function ( meshDef, meshIndex ) {
 
 				var group = new THREE.Group();
-
-				if ( meshDef.name !== undefined ) group.name = meshDef.name;
-				if ( meshDef.extras ) group.userData = meshDef.extras;
 
 				var primitives = meshDef.primitives || [];
 
@@ -1896,7 +1893,8 @@ THREE.GLTFLoader = ( function () {
 
 						}
 
-						mesh.name = group.name + ( i > 0 ? ( '_' + i ) : '' );
+						mesh.name = meshDef.name || ( 'mesh_' + meshIndex );
+						mesh.name += i > 0 ? ( '_' + i ) : '';
 
 						if ( primitive.targets !== undefined ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1197,6 +1197,59 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
+	/**
+	 * TODO(donmccurdy): Why is all this necessary, again?
+	 * @param {GLTF.Node} nodeDef
+	 * @param {THREE.Group} group
+	 * @param {Array<THREE.Object3D>} nodes
+	 * @param {Array<Object} skins
+	 */
+	function deepCloneMeshGroup( group ) {
+
+		// Clone group's children manually.
+		var clonedGroup = group.clone( false );
+
+		for ( var i = 0; i < group.children.length; i ++ ) {
+
+			var child = group.children[ i ];
+			var clonedChild;
+
+			switch ( child.type ) {
+
+				case 'LineSegments':
+					clonedChild = new THREE.LineSegments( child.geometry, child.material );
+					break;
+
+				case 'LineLoop':
+					clonedChild = new THREE.LineLoop( child.geometry, child.material );
+					break;
+
+				case 'Line':
+					clonedChild = new THREE.Line( child.geometry, child.material );
+					break;
+
+				case 'Points':
+					clonedChild = new THREE.Points( child.geometry, child.material );
+					break;
+
+				default:
+					clonedChild = new THREE.Mesh( child.geometry, child.material );
+					clonedChild.drawMode = child.drawMode;
+
+			}
+
+			clonedChild.morphTargetInfluences = child.morphTargetInfluences;
+			clonedChild.userData = child.userData;
+			clonedChild.name = child.name;
+
+			clonedGroup.add( clonedChild );
+
+		}
+
+		return clonedGroup;
+
+	}
+
 	/* GLTF PARSER */
 
 	function GLTFParser( json, extensions, options ) {
@@ -2133,198 +2186,137 @@ THREE.GLTFLoader = ( function () {
 
 		} );
 
-		return _each( json.nodes, function ( node ) {
+		return scope._withDependencies( [
 
-			var matrix = new THREE.Matrix4();
+			'meshes',
+			'skins',
+			'cameras'
 
-			var _node = node.isBone === true ? new THREE.Bone() : new THREE.Object3D();
+		] ).then( function ( dependencies ) {
 
-			if ( node.name !== undefined ) {
+			return _each( json.nodes, function ( nodeDef ) {
 
-				_node.name = THREE.PropertyBinding.sanitizeNodeName( node.name );
+				if ( nodeDef.isBone === true ) {
 
-			}
+					return new THREE.Bone();
 
-			if ( node.extras ) _node.userData = node.extras;
+				} else if ( nodeDef.mesh !== undefined ) {
 
-			if ( node.matrix !== undefined ) {
+					return deepCloneMeshGroup( dependencies.meshes[ nodeDef.mesh ] );
 
-				matrix.fromArray( node.matrix );
-				_node.applyMatrix( matrix );
+				} else if ( nodeDef.camera !== undefined ) {
 
-			} else {
+					return dependencies.cameras[ nodeDef.camera ];
 
-				if ( node.translation !== undefined ) {
+				} else if ( nodeDef.extensions
+								 && nodeDef.extensions[ EXTENSIONS.KHR_LIGHTS ]
+								 && nodeDef.extensions[ EXTENSIONS.KHR_LIGHTS ].light !== undefined ) {
 
-					_node.position.fromArray( node.translation );
+					var lights = extensions[ EXTENSIONS.KHR_LIGHTS ].lights;
+					return lights[ nodeDef.extensions[ EXTENSIONS.KHR_LIGHTS ].light ];
 
-				}
+				} else {
 
-				if ( node.rotation !== undefined ) {
-
-					_node.quaternion.fromArray( node.rotation );
-
-				}
-
-				if ( node.scale !== undefined ) {
-
-					_node.scale.fromArray( node.scale );
+					return new THREE.Object3D();
 
 				}
 
-			}
+			} ).then( function ( __nodes ) {
 
-			return _node;
+				return _each( __nodes, function ( node, nodeIndex ) {
 
-		} ).then( function ( __nodes ) {
+					var nodeDef = json.nodes[ nodeIndex ];
 
-			return scope._withDependencies( [
+					if ( nodeDef.name !== undefined ) {
 
-				'meshes',
-				'skins',
-				'cameras'
+						node.name = THREE.PropertyBinding.sanitizeNodeName( nodeDef.name );
 
-			] ).then( function ( dependencies ) {
+					}
 
-				return _each( __nodes, function ( _node, nodeId ) {
+					if ( nodeDef.extras ) node.userData = nodeDef.extras;
 
-					var node = json.nodes[ nodeId ];
+					if ( nodeDef.matrix !== undefined ) {
 
-					var mesh = node.mesh;
+						var matrix = new THREE.Matrix4();
+						matrix.fromArray( nodeDef.matrix );
+						node.applyMatrix( matrix );
 
-					if ( mesh !== undefined ) {
+					} else {
 
-						var group = dependencies.meshes[ mesh ];
+						if ( nodeDef.translation !== undefined ) {
 
-						if ( group !== undefined ) {
+							node.position.fromArray( nodeDef.translation );
 
-							// do not clone children as they will be replaced anyway
-							var clonedgroup = group.clone( false );
+						}
 
-							for ( var i = 0; i < group.children.length; i ++ ) {
+						if ( nodeDef.rotation !== undefined ) {
 
-								var child = group.children[ i ];
-								var originalChild = child;
+							node.quaternion.fromArray( nodeDef.rotation );
 
-								// clone Mesh to add to _node
+						}
 
-								var originalMaterial = child.material;
-								var originalGeometry = child.geometry;
-								var originalInfluences = child.morphTargetInfluences;
-								var originalUserData = child.userData;
-								var originalName = child.name;
+						if ( nodeDef.scale !== undefined ) {
 
-								var material = originalMaterial;
-
-								switch ( child.type ) {
-
-									case 'LineSegments':
-										child = new THREE.LineSegments( originalGeometry, material );
-										break;
-
-									case 'LineLoop':
-										child = new THREE.LineLoop( originalGeometry, material );
-										break;
-
-									case 'Line':
-										child = new THREE.Line( originalGeometry, material );
-										break;
-
-									case 'Points':
-										child = new THREE.Points( originalGeometry, material );
-										break;
-
-									default:
-										child = new THREE.Mesh( originalGeometry, material );
-										child.drawMode = originalChild.drawMode;
-
-								}
-
-								child.castShadow = true;
-								child.morphTargetInfluences = originalInfluences;
-								child.userData = originalUserData;
-								child.name = originalName;
-
-								var skinEntry;
-
-								if ( node.skin !== undefined ) {
-
-									skinEntry = dependencies.skins[ node.skin ];
-
-								}
-
-								// Replace Mesh with SkinnedMesh in library
-								if ( skinEntry ) {
-
-									var geometry = originalGeometry;
-									material = originalMaterial;
-									material.skinning = true;
-
-									child = new THREE.SkinnedMesh( geometry, material );
-									child.castShadow = true;
-									child.userData = originalUserData;
-									child.name = originalName;
-
-									var bones = [];
-									var boneInverses = [];
-
-									for ( var i = 0, l = skinEntry.joints.length; i < l; i ++ ) {
-
-										var jointId = skinEntry.joints[ i ];
-										var jointNode = __nodes[ jointId ];
-
-										if ( jointNode ) {
-
-											bones.push( jointNode );
-
-											var m = skinEntry.inverseBindMatrices.array;
-											var mat = new THREE.Matrix4().fromArray( m, i * 16 );
-											boneInverses.push( mat );
-
-										} else {
-
-											console.warn( 'THREE.GLTFLoader: Joint "%s" could not be found.', jointId );
-
-										}
-
-									}
-
-									child.bind( new THREE.Skeleton( bones, boneInverses ), child.matrixWorld );
-
-								}
-
-								clonedgroup.add( child );
-
-							}
-
-							_node.add( clonedgroup );
-
-						} else {
-
-							console.warn( 'THREE.GLTFLoader: Could not find node "' + mesh + '".' );
+							node.scale.fromArray( nodeDef.scale );
 
 						}
 
 					}
 
-					if ( node.camera !== undefined ) {
+					if ( nodeDef.skin !== undefined ) {
 
-						var camera = dependencies.cameras[ node.camera ];
+						var skinnedMeshes = [];
 
-						_node.add( camera );
+						for ( var i = 0; i < node.children.length; i ++ ) {
+
+							var skinEntry = dependencies.skins[ nodeDef.skin ];
+
+							// Replace Mesh with SkinnedMesh.
+							var geometry = node.children[ i ].geometry;
+							var material = node.children[ i ].material;
+							material.skinning = true;
+
+							var child = new THREE.SkinnedMesh( geometry, material );
+							child.morphTargetInfluences = node.children[ i ].morphTargetInfluences;
+							child.userData = node.children[ i ].userData;
+							child.name = node.children[ i ].name;
+
+							var bones = [];
+							var boneInverses = [];
+
+							for ( var j = 0, l = skinEntry.joints.length; j < l; j ++ ) {
+
+								var jointId = skinEntry.joints[ j ];
+								var jointNode = __nodes[ jointId ];
+
+								if ( jointNode ) {
+
+									bones.push( jointNode );
+
+									var m = skinEntry.inverseBindMatrices.array;
+									var mat = new THREE.Matrix4().fromArray( m, j * 16 );
+									boneInverses.push( mat );
+
+								} else {
+
+									console.warn( 'THREE.GLTFLoader: Joint "%s" could not be found.', jointId );
+
+								}
+
+							}
+
+							child.bind( new THREE.Skeleton( bones, boneInverses ), child.matrixWorld );
+
+							skinnedMeshes.push( child );
+
+						}
+
+						node.remove.apply( node, node.children );
+						node.add.apply( node, skinnedMeshes );
 
 					}
 
-					if ( node.extensions
-							 && node.extensions[ EXTENSIONS.KHR_LIGHTS ]
-							 && node.extensions[ EXTENSIONS.KHR_LIGHTS ].light !== undefined ) {
-
-						var lights = extensions[ EXTENSIONS.KHR_LIGHTS ].lights;
-						_node.add( lights[ node.extensions[ EXTENSIONS.KHR_LIGHTS ].light ] );
-
-					}
-
-					return _node;
+					return node;
 
 				} );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1896,7 +1896,7 @@ THREE.GLTFLoader = ( function () {
 
 						}
 
-						mesh.name = group.name + '_' + i;
+						mesh.name = group.name + ( i > 0 ? ( '_' + i ) : '' );
 
 						if ( primitive.targets !== undefined ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1197,59 +1197,6 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
-	/**
-	 * TODO(donmccurdy): Why is all this necessary, again?
-	 * @param {GLTF.Node} nodeDef
-	 * @param {THREE.Group} group
-	 * @param {Array<THREE.Object3D>} nodes
-	 * @param {Array<Object} skins
-	 */
-	function deepCloneMeshGroup( group ) {
-
-		// Clone group's children manually.
-		var clonedGroup = group.clone( false );
-
-		for ( var i = 0; i < group.children.length; i ++ ) {
-
-			var child = group.children[ i ];
-			var clonedChild;
-
-			switch ( child.type ) {
-
-				case 'LineSegments':
-					clonedChild = new THREE.LineSegments( child.geometry, child.material );
-					break;
-
-				case 'LineLoop':
-					clonedChild = new THREE.LineLoop( child.geometry, child.material );
-					break;
-
-				case 'Line':
-					clonedChild = new THREE.Line( child.geometry, child.material );
-					break;
-
-				case 'Points':
-					clonedChild = new THREE.Points( child.geometry, child.material );
-					break;
-
-				default:
-					clonedChild = new THREE.Mesh( child.geometry, child.material );
-					clonedChild.drawMode = child.drawMode;
-
-			}
-
-			clonedChild.morphTargetInfluences = child.morphTargetInfluences;
-			clonedChild.userData = child.userData;
-			clonedChild.name = child.name;
-
-			clonedGroup.add( clonedChild );
-
-		}
-
-		return clonedGroup;
-
-	}
-
 	/* GLTF PARSER */
 
 	function GLTFParser( json, extensions, options ) {
@@ -2202,7 +2149,7 @@ THREE.GLTFLoader = ( function () {
 
 				} else if ( nodeDef.mesh !== undefined ) {
 
-					return deepCloneMeshGroup( dependencies.meshes[ nodeDef.mesh ] );
+					return dependencies.meshes[ nodeDef.mesh ].clone();
 
 				} else if ( nodeDef.camera !== undefined ) {
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -274,6 +274,12 @@
 
 					}
 
+					object.traverse( function ( node ) {
+
+						if ( node.isMesh ) node.castShadow = true;
+
+					} );
+
 					cameraIndex = 0;
 					cameras = [];
 					cameraNames = [];
@@ -332,7 +338,11 @@
 					scene.add( object );
 					onWindowResize();
 
-				});
+				}, undefined, function ( error ) {
+
+					console.error( error );
+
+				} );
 
 			orbitControls = new THREE.OrbitControls(defaultCamera, renderer.domElement);
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -50,6 +50,18 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		this.drawMode = source.drawMode;
 
+		if ( source.morphTargetInfluences !== undefined ) {
+
+			this.morphTargetInfluences = source.morphTargetInfluences.slice();
+
+		}
+
+		if ( source.morphTargetDictionary !== undefined ) {
+
+			this.morphTargetDictionary = Object.assign( {}, source.morphTargetDictionary );
+
+		}
+
 		return this;
 
 	},


### PR DESCRIPTION
Partial solution for #11944, and fixes some animation regressions. Using AnimatedMorphCube.gltf:

| Before | After |
|--------|------|
| ![screen shot 2017-09-20 at 10 08 55 pm](https://user-images.githubusercontent.com/1848368/30679738-633bddba-9e50-11e7-803b-550a9ac45023.png) | ![screen shot 2017-09-20 at 10 25 49 pm](https://user-images.githubusercontent.com/1848368/30680113-b73f7aaa-9e52-11e7-939e-10c86e95c5fb.png) |

We were previously cloning meshes manually, without calling `mesh.clone()`, and I have no idea why. The only difference I can spot between the [loader's code](https://github.com/mrdoob/three.js/blob/r87/examples/js/loaders/GLTFLoader.js#L2196-L2236) and a normal `clone()` is that morph target properties were included, so I've added those to `Mesh.prototype.copy`.

It may be possible to replace the `THREE.Group`with a grouped BufferGeometry, as well, but that's another PR. :)

Here's a version of my viewer running the code from this change: https://three-gltf-viewer-afsyhsshii.now.sh/