### PR TITLE
common.glsl: Rename transpose() to transposeMatrix3()

### DIFF
--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl
@@ -191,7 +191,7 @@ vec3 LTC_Evaluate( const in vec3 N, const in vec3 V, const in vec3 P, const in m
 	T2 = - cross( N, T1 ); // negated from paper; possibly due to a different assumed handedness of world coordinate system
 
 	// compute transform
-	mat3 mat = mInv * transposeMatrix3( mat3( T1, T2, N ) );
+	mat3 mat = mInv * transposeMat3( mat3( T1, T2, N ) );
 
 	// transform rect
 	vec3 coords[ 4 ];

--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl
@@ -191,7 +191,7 @@ vec3 LTC_Evaluate( const in vec3 N, const in vec3 V, const in vec3 P, const in m
 	T2 = - cross( N, T1 ); // negated from paper; possibly due to a different assumed handedness of world coordinate system
 
 	// compute transform
-	mat3 mat = mInv * transpose( mat3( T1, T2, N ) );
+	mat3 mat = mInv * transposeMatrix3( mat3( T1, T2, N ) );
 
 	// transform rect
 	vec3 coords[ 4 ];

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -73,13 +73,13 @@ vec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 poi
 
 }
 
-mat3 transposeMatrix3( const in mat3 v ) {
+mat3 transposeMat3( const in mat3 m ) {
 
 	mat3 tmp;
 
-	tmp[ 0 ] = vec3( v[ 0 ].x, v[ 1 ].x, v[ 2 ].x );
-	tmp[ 1 ] = vec3( v[ 0 ].y, v[ 1 ].y, v[ 2 ].y );
-	tmp[ 2 ] = vec3( v[ 0 ].z, v[ 1 ].z, v[ 2 ].z );
+	tmp[ 0 ] = vec3( m[ 0 ].x, m[ 1 ].x, m[ 2 ].x );
+	tmp[ 1 ] = vec3( m[ 0 ].y, m[ 1 ].y, m[ 2 ].y );
+	tmp[ 2 ] = vec3( m[ 0 ].z, m[ 1 ].z, m[ 2 ].z );
 
 	return tmp;
 

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -73,12 +73,13 @@ vec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 poi
 
 }
 
-mat3 transpose( const in mat3 v ) {
+mat3 transposeMatrix3( const in mat3 v ) {
 
 	mat3 tmp;
-	tmp[0] = vec3(v[0].x, v[1].x, v[2].x);
-	tmp[1] = vec3(v[0].y, v[1].y, v[2].y);
-	tmp[2] = vec3(v[0].z, v[1].z, v[2].z);
+
+	tmp[ 0 ] = vec3( v[ 0 ].x, v[ 1 ].x, v[ 2 ].x );
+	tmp[ 1 ] = vec3( v[ 0 ].y, v[ 1 ].y, v[ 2 ].y );
+	tmp[ 2 ] = vec3( v[ 0 ].z, v[ 1 ].z, v[ 2 ].z );
 
 	return tmp;
 


### PR DESCRIPTION
This PR renames `transpose()` to `transposeMatrix3()` to avoid conflicts with the built-in transpose function in [GLSL ES 3.0](https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf).

#11906 
https://github.com/expo/expo-three/issues/2#issuecomment-325203638
https://github.com/Microsoft/HoloJS/issues/16#issuecomment-269076640

The shader implementation for `RectAreaLight` was the only place where `transpose()` is used. If the project switches to WebGL2 at some point, the code can use the built-in function.