### PR TITLE
FBXLoader: added support for lights

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1500,9 +1500,9 @@
 
 								var temp = lightAttribute.Color.value.split( ',' );
 
-								var r = parseInt( temp[ 0 ], 10 );
-								var g = parseInt( temp[ 1 ], 10 );
-								var b = parseInt( temp[ 1 ], 10 );
+								var r = parseFloat( temp[ 0 ] );
+								var g = parseFloat( temp[ 1 ] );
+								var b = parseFloat( temp[ 1 ] );
 
 								color = new THREE.Color( r, g, b );
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -112,7 +112,7 @@
 
 			}
 
-			// console.log( FBXTree );
+			console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );
@@ -1447,6 +1447,145 @@
 							model = new THREE.Mesh( geometry, material );
 
 						}
+						break;
+
+					case 'Light':
+						/* ***********
+						* Supported light types:
+						* DirectionalLight
+						*	PointLight
+						* SpotLight
+						*
+						* TODO: Support DirectionalLight and SpotLight targets
+						************** */
+
+						var lightAttribute;
+
+						for ( var childrenIndex = 0, childrenLength = conns.children.length; childrenIndex < childrenLength; ++ childrenIndex ) {
+
+							var childID = conns.children[ childrenIndex ].ID;
+
+							var attr = FBXTree.Objects.subNodes.NodeAttribute[ childID ];
+
+							if ( attr !== undefined && attr.properties !== undefined ) {
+
+								lightAttribute = attr.properties;
+
+							}
+
+						}
+
+						if ( lightAttribute === undefined ) {
+
+							model = new THREE.Object3D();
+
+						} else {
+
+							console.log( lightAttribute );
+
+							var type;
+
+							// LightType is undefined for Point lights
+							if ( lightAttribute.LightType === undefined ) {
+
+								type = '0';
+
+							} else {
+
+								type = lightAttribute.LightType.value;
+
+							}
+
+							var color = 0xffffff;
+
+							if ( lightAttribute.Color !== undefined ) {
+
+								var temp = lightAttribute.Color.value.split( ',' );
+
+								var r = parseInt( temp[ 0 ], 10 );
+								var g = parseInt( temp[ 1 ], 10 );
+								var b = parseInt( temp[ 1 ], 10 );
+
+								color = new THREE.Color( r, g, b );
+
+							}
+
+							var intensity = ( lightAttribute.Intensity === undefined ) ? 1 : lightAttribute.Intensity.value / 100;
+
+							// light disabled
+							if ( lightAttribute.CastLightOnObject !== undefined && lightAttribute.CastLightOnObject.value === '0' ) {
+
+								intensity = 0;
+
+							}
+
+							var distance = 0;
+							if ( lightAttribute.FarAttenuationEnd !== undefined ) {
+
+								if ( lightAttribute.EnableFarAttenuation !== undefined && lightAttribute.EnableFarAttenuation.value === '0' ) {
+
+									distance = 0;
+
+								}	else {
+
+									distance = lightAttribute.FarAttenuationEnd.value / 1000;
+
+								}
+
+							}
+
+							// TODO
+							// could be calculated linearly from FarAttenuationStart to FarAttenuationEnd ?
+							var decay = 1;
+
+							switch ( type ) {
+
+								case '0': // Point
+									model = new THREE.PointLight( color, intensity, distance, decay );
+									break;
+
+								case '1': // Directional
+									model = new THREE.DirectionalLight( color, intensity );
+									break;
+
+								case '2': // Spot
+									var angle = Math.PI / 3;
+
+									if ( lightAttribute.InnerAngle !== undefined ) {
+
+										angle = THREE.Math.degToRad( lightAttribute.InnerAngle.value );
+
+									}
+
+									var penumbra = 0; // Falloff / Field
+									if ( lightAttribute.OuterAngle !== undefined ) {
+
+										// note: this is not correct - FBX calculates outer and inner angle in degrees
+										// with OuterAngle > InnerAngle && OuterAngle <= Math.PI
+										// while three.js uses a penumbra between (0, 1) to attenuate the inner angle
+										penumbra = THREE.Math.degToRad( lightAttribute.OuterAngle.value );
+										penumbra = Math.max( penumbra, 1 );
+
+									}
+
+									model = new THREE.SpotLight( color, intensity, distance, angle, penumbra, decay );
+									break;
+
+								default:
+									console.warn( 'THREE.FBXLoader: Unknown light type ' + lightAttribute.LightType + ', defaulting to a THREE.PointLight.' );
+									model = new THREE.PointLight( color, intensity );
+									break;
+
+							}
+
+							if ( lightAttribute.CastShadows !== undefined && lightAttribute.CastShadows.value === '1' ) {
+
+								model.castShadow = true;
+
+							}
+
+						}
+
 						break;
 
 					case 'NurbsCurve':

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -112,7 +112,7 @@
 
 			}
 
-			console.log( FBXTree );
+			// console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );
@@ -1481,7 +1481,7 @@
 
 						} else {
 
-							console.log( lightAttribute );
+							// console.log( lightAttribute );
 
 							var type;
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1453,7 +1453,7 @@
 						/* ***********
 						* Supported light types:
 						* DirectionalLight
-						*	PointLight
+						* PointLight
 						* SpotLight
 						*
 						* TODO: Support DirectionalLight and SpotLight targets
@@ -1480,8 +1480,6 @@
 							model = new THREE.Object3D();
 
 						} else {
-
-							// console.log( lightAttribute );
 
 							var type;
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1485,10 +1485,10 @@
 
 							var type;
 
-							// LightType is undefined for Point lights
+							// LightType can be undefined for Point lights
 							if ( lightAttribute.LightType === undefined ) {
 
-								type = '0';
+								type = 0;
 
 							} else {
 
@@ -1513,7 +1513,7 @@
 							var intensity = ( lightAttribute.Intensity === undefined ) ? 1 : lightAttribute.Intensity.value / 100;
 
 							// light disabled
-							if ( lightAttribute.CastLightOnObject !== undefined && lightAttribute.CastLightOnObject.value === '0' ) {
+							if ( lightAttribute.CastLightOnObject !== undefined && ( lightAttribute.CastLightOnObject.value === '0' || lightAttribute.CastLightOnObject.value === 0 ) ) {
 
 								intensity = 0;
 
@@ -1522,7 +1522,7 @@
 							var distance = 0;
 							if ( lightAttribute.FarAttenuationEnd !== undefined ) {
 
-								if ( lightAttribute.EnableFarAttenuation !== undefined && lightAttribute.EnableFarAttenuation.value === '0' ) {
+								if ( lightAttribute.EnableFarAttenuation !== undefined && ( lightAttribute.EnableFarAttenuation.value === '0' || lightAttribute.EnableFarAttenuation.value === 0 ) ) {
 
 									distance = 0;
 
@@ -1535,7 +1535,7 @@
 							}
 
 							// TODO
-							// could be calculated linearly from FarAttenuationStart to FarAttenuationEnd ?
+							// could be calculated linearly from FarAttenuationStart to FarAttenuationEnd?
 							var decay = 1;
 
 							switch ( type ) {
@@ -1563,7 +1563,7 @@
 									var penumbra = 0; // Falloff / Field
 									if ( lightAttribute.OuterAngle !== undefined ) {
 
-										// note: this is not correct - FBX calculates outer and inner angle in degrees
+										// TODO: this is not correct - FBX calculates outer and inner angle in degrees
 										// with OuterAngle > InnerAngle && OuterAngle <= Math.PI
 										// while three.js uses a penumbra between (0, 1) to attenuate the inner angle
 										penumbra = THREE.Math.degToRad( lightAttribute.OuterAngle.value );
@@ -1581,7 +1581,7 @@
 
 							}
 
-							if ( lightAttribute.CastShadows !== undefined && lightAttribute.CastShadows.value === '1' ) {
+							if ( lightAttribute.CastShadows !== undefined && ( lightAttribute.CastShadows.value === '1' || lightAttribute.CastShadows.value === 1 ) ) {
 
 								model.castShadow = true;
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1560,7 +1560,7 @@
 
 									}
 
-									var penumbra = 0; // Falloff / Field
+									var penumbra = 0;
 									if ( lightAttribute.OuterAngle !== undefined ) {
 
 										// TODO: this is not correct - FBX calculates outer and inner angle in degrees

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1541,14 +1541,17 @@
 							switch ( type ) {
 
 								case '0': // Point
+								case 0:
 									model = new THREE.PointLight( color, intensity, distance, decay );
 									break;
 
 								case '1': // Directional
+								case 1:
 									model = new THREE.DirectionalLight( color, intensity );
 									break;
 
 								case '2': // Spot
+								case 2:
 									var angle = Math.PI / 3;
 
 									if ( lightAttribute.InnerAngle !== undefined ) {
@@ -1572,7 +1575,7 @@
 									break;
 
 								default:
-									console.warn( 'THREE.FBXLoader: Unknown light type ' + lightAttribute.LightType + ', defaulting to a THREE.PointLight.' );
+									console.warn( 'THREE.FBXLoader: Unknown light type ' + lightAttribute.LightType.value + ', defaulting to a THREE.PointLight.' );
 									model = new THREE.PointLight( color, intensity );
 									break;
 


### PR DESCRIPTION
Added support for the following light types to FBXLoader:

* DirectionalLight
* PointLight
* SpotLight

These are the only light types directly supported by the FBX format ( no HemisphereLight! ).

Ambient lights can be supported, but they are included in the GlobalSettings section of the FBX file, so leaving that for a seperate PR. 

*Not yet supported / tested*: 

* Light targets 
* Decay is set to the default value of 1 since there is no obvious equivalent value in the FBX file
* SpotLight.penumbra calculation is incorrect 
* Shadows are enabled, but untested