### PR TITLE
Update Periodic Table Example

### DIFF
--- a/examples/css3d_periodictable.html
+++ b/examples/css3d_periodictable.html
@@ -228,12 +228,12 @@
 				"Ds", "Darmstadium", "(281)", 10, 7,
 				"Rg", "Roentgenium", "(280)", 11, 7,
 				"Cn", "Copernicium", "(285)", 12, 7,
-				"Uut", "Unutrium", "(284)", 13, 7,
+				"Nh", "Nihonium", "(286)", 13, 7,
 				"Fl", "Flerovium", "(289)", 14, 7,
-				"Uup", "Ununpentium", "(288)", 15, 7,
+				"Mc", "Moscovium", "(290)", 15, 7,
 				"Lv", "Livermorium", "(293)", 16, 7,
-				"Uus", "Ununseptium", "(294)", 17, 7,
-				"Uuo", "Ununoctium", "(294)", 18, 7
+				"Ts", "Tennessine", "(294)", 17, 7,
+				"Og", "Oganesson", "(294)", 18, 7
 			];
 
 			var camera, scene, renderer;


### PR DESCRIPTION
Recently new names for the outstanding "un" elements have been ratified.  Updated the the periodic table example to include the new names and symbols.