### PR TITLE
Docs: Fix three broken tags in docs

### DIFF
--- a/docs/api/math/Frustum.html
+++ b/docs/api/math/Frustum.html
@@ -98,7 +98,7 @@
 		<div>
 			[page:Matrix4 matrix] - [page:Matrix4] used to set the [page:.planes planes]<br /><br />
 
-			This is used by the [page:WebGLRenderer] to set up the Frustum from a [page:Camera Camera's]
+			This is used by the [page:WebGLRenderer] to set up the Frustum from a [page:Camera Camera]'s
 			[page:Camera.projectionMatrix projectionMatrix] and [page:Camera.matrixWorldInverse matrixWorldInverse].
 		</div>
 

--- a/docs/api/math/Vector4.html
+++ b/docs/api/math/Vector4.html
@@ -231,13 +231,13 @@ var d = a.dot( b );
 
 		<h3>[method:Vector4 max]( [page:Vector4 v] )</h3>
 		<div>
-		If this vector's x, y, z or w value is less than [page:Vector4 v's] x, y, z or w value, replace
+		If this vector's x, y, z or w value is less than [page:Vector4 v]'s x, y, z or w value, replace
 		that value with the corresponding max value.
 		</div>
 
 		<h3>[method:Vector4 min]( [page:Vector4 v] )</h3>
 		<div>
-		If this vector's x, y, z or w value is greater than [page:Vector4 v's] x, y, z or w value, replace
+		If this vector's x, y, z or w value is greater than [page:Vector4 v]'s x, y, z or w value, replace
 		that value with the corresponding min value.
 		</div>
 


### PR DESCRIPTION
The regexes doing the tag parsing for the docs apparently have a political problem with the concept of possession and oppose it everywhere they can, for example in `[page:Camera Camera's]`. To appease them, I moved the `'s` bits outside the tags.