### PR TITLE
Docs: Removed remaining links to canvas_camera_orthographic2 example

### DIFF
--- a/docs/api/cameras/OrthographicCamera.html
+++ b/docs/api/cameras/OrthographicCamera.html
@@ -25,7 +25,6 @@
 		<h2>Example</h2>
 
 		<div>[example:canvas_camera_orthographic camera / orthographic ]</div>
-		<div>[example:canvas_camera_orthographic2 camera / orthographic2 ]</div>
 		<div>[example:webgl_camera camera ]</div>
 		<div>[example:webgl_interactive_cubes_ortho interactive / cubes / ortho ]</div>
 		<div>[example:webgl_materials_cubemap_dynamic materials / cubemap / dynamic ]</div>

--- a/examples/files.js
+++ b/examples/files.js
@@ -340,7 +340,6 @@ var files = {
 	"canvas": [
 		"canvas_ascii_effect",
 		"canvas_camera_orthographic",
-		"canvas_camera_orthographic2",
 		"canvas_geometry_birds",
 		"canvas_geometry_cube",
 		"canvas_geometry_earth",


### PR DESCRIPTION
Commit f949419 / PR #12184 missed two references to the deleted `canvas_camera_orthographic2` example.