### PR TITLE
Pass MouseEvents and "oldPosition" from DragControls / TransformCont…

### DIFF
--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -75,7 +75,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			}
 
-			scope.dispatchEvent( { type: 'drag', object: _selected } );
+			scope.dispatchEvent( { type: 'drag', object: _selected, pointer: event } );
 
 			return;
 
@@ -93,7 +93,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _hovered !== object ) {
 
-				scope.dispatchEvent( { type: 'hoveron', object: object } );
+				scope.dispatchEvent( { type: 'hoveron', object: object, pointer: event } );
 
 				_domElement.style.cursor = 'pointer';
 				_hovered = object;
@@ -104,7 +104,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _hovered !== null ) {
 
-				scope.dispatchEvent( { type: 'hoveroff', object: _hovered } );
+				scope.dispatchEvent( { type: 'hoveroff', object: _hovered, pointer: event } );
 
 				_domElement.style.cursor = 'auto';
 				_hovered = null;
@@ -135,7 +135,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			_domElement.style.cursor = 'move';
 
-			scope.dispatchEvent( { type: 'dragstart', object: _selected } );
+			scope.dispatchEvent( { type: 'dragstart', object: _selected, pointer: event } );
 
 		}
 
@@ -148,7 +148,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 		if ( _selected ) {
 
-			scope.dispatchEvent( { type: 'dragend', object: _selected } );
+			scope.dispatchEvent( { type: 'dragend', object: _selected, pointer: event } );
 
 			_selected = null;
 
@@ -178,7 +178,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			}
 
-			scope.dispatchEvent( { type: 'drag', object: _selected } );
+			scope.dispatchEvent( { type: 'drag', object: _selected, pointer: event } );
 
 			return;
 
@@ -214,7 +214,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			_domElement.style.cursor = 'move';
 
-			scope.dispatchEvent( { type: 'dragstart', object: _selected } );
+			scope.dispatchEvent( { type: 'dragstart', object: _selected, pointer: event } );
 
 		}
 
@@ -227,7 +227,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 		if ( _selected ) {
 
-			scope.dispatchEvent( { type: 'dragend', object: _selected } );
+			scope.dispatchEvent( { type: 'dragend', object: _selected, pointer: event } );
 
 			_selected = null;
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -633,10 +633,10 @@
 		}
 
 		var changeEvent = { type: "change" };
-		var mouseDownEvent = { type: "mouseDown" };
-		var mouseUpEvent = { type: "mouseUp", mode: _mode };
-		var objectChangeEvent = { type: "objectChange" };
-
+		var mouseDownEvent = { type: "mouseDown", pointer: null };
+		var mouseUpEvent = { type: "mouseUp", mode: _mode, pointer: null };
+		var objectChangeEvent = { type: "objectChange", pointer: null };
+		
 		var ray = new THREE.Raycaster();
 		var pointerVector = new THREE.Vector2();
 
@@ -856,6 +856,7 @@
 					event.preventDefault();
 					event.stopPropagation();
 
+					mouseDownEvent.pointer = pointer;
 					scope.dispatchEvent( mouseDownEvent );
 
 					scope.axis = intersect.object.name;
@@ -1092,6 +1093,11 @@
 
 			scope.update();
 			scope.dispatchEvent( changeEvent );
+				
+			objectChangeEvent.pointer = pointer;
+			objectChangeEvent.oldPosition = oldPosition;
+			objectChangeEvent.oldScale = oldScale;
+			objectChangeEvent.oldRotationMatrix = oldRotationMatrix;
 			scope.dispatchEvent( objectChangeEvent );
 
 		}
@@ -1105,6 +1111,7 @@
 			if ( _dragging && ( scope.axis !== null ) ) {
 
 				mouseUpEvent.mode = _mode;
+				mouseUpEvent.pointer = event;
 				scope.dispatchEvent( mouseUpEvent );
 
 			}

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -60,7 +60,12 @@
 			var options;
 
 			var geometry = new THREE.BoxGeometry( 20, 20, 20 );
+			var OBJECT_COLOR = 0xffffff;
+			var OBJECT_COLOR_SELECTED = 0xff0000;
+			var OBJECT_COLOR_XOR = OBJECT_COLOR ^ OBJECT_COLOR_SELECTED;
+			
 			var transformControl;
+			var timeToLive = null;
 
 			var ARC_SEGMENTS = 200;
 			var splineMesh;
@@ -149,87 +154,58 @@
 				controls.damping = 0.2;
 				controls.addEventListener( 'change', render );
 
-				controls.addEventListener( 'start', function() {
-
-					cancelHideTransorm();
-
-				} );
-
-				controls.addEventListener( 'end', function() {
-
-					delayHideTransform();
-
-				} );
-
 				transformControl = new THREE.TransformControls( camera, renderer.domElement );
 				transformControl.addEventListener( 'change', render );
 				scene.add( transformControl );
-
-				// Hiding transform situation is a little in a mess :()
-				transformControl.addEventListener( 'change', function( e ) {
-
-					cancelHideTransorm();
-
-				} );
-
 				transformControl.addEventListener( 'mouseDown', function( e ) {
 
-					cancelHideTransorm();
+					setOldPositions();
 
 				} );
+				
+				transformControl.addEventListener( 'change', function( e ) {
 
-				transformControl.addEventListener( 'mouseUp', function( e ) {
-
-					delayHideTransform();
+					timeToLive = performance.now() + 2500;
 
 				} );
 
 				transformControl.addEventListener( 'objectChange', function( e ) {
 
+					if ( e.target.object.material.color.getHex() === OBJECT_COLOR ) {
+					
+						clearSelected();
+					
+					}
+					
+					adjustAllSelectedExcept( e.target.object, e.oldPosition, e.target.position);
 					updateSplineOutline();
 
 				} );
 
-				var dragcontrols = new THREE.DragControls( splineHelperObjects, camera, renderer.domElement ); //
+				var dragcontrols = new THREE.DragControls( splineHelperObjects, camera, renderer.domElement );
 				dragcontrols.enabled = false;
 				dragcontrols.addEventListener( 'hoveron', function ( event ) {
+				
+					if ( !event.pointer.ctrlKey ) {
+					
+						transformControl.attach( event.object );
 
-					transformControl.attach( event.object );
-					cancelHideTransorm();
-
+					}
+					
 				} );
 
-				dragcontrols.addEventListener( 'hoveroff', function ( event ) {
+				dragcontrols.addEventListener( 'dragstart', function ( event ) {
 
-					delayHideTransform();
+					if (event.pointer.ctrlKey) {
+					
+						if (event.pointer.buttons === 1) {
+						
+							event.object.material.color.setHex( event.object.material.color.getHex() ^ OBJECT_COLOR_XOR );
+						
+						}
+					}
 
 				} );
-
-				var hiding;
-
-				function delayHideTransform() {
-
-					cancelHideTransorm();
-					hideTransform();
-
-				}
-
-				function hideTransform() {
-
-					hiding = setTimeout( function() {
-
-						transformControl.detach( transformControl.object );
-
-					}, 2500 )
-
-				}
-
-				function cancelHideTransorm() {
-
-					if ( hiding ) clearTimeout( hiding );
-
-				}
-
 
 				/*******
 				 * Curves
@@ -303,7 +279,7 @@
 
 			function addSplineObject( position ) {
 
-				var material = new THREE.MeshLambertMaterial( { color: Math.random() * 0xffffff } );
+				var material = new THREE.MeshLambertMaterial( { color: OBJECT_COLOR } );
 				var object = new THREE.Mesh( geometry, material );
 
 				if ( position ) {
@@ -317,6 +293,9 @@
 					object.position.z = Math.random() * 800 - 400;
 
 				}
+				
+				object.oldPosition = new THREE.Vector3();
+				object.oldPosition.copy( object.position );
 
 				object.castShadow = true;
 				object.receiveShadow = true;
@@ -370,7 +349,6 @@
 
 				}
 
-
 			}
 
 			function exportSpline() {
@@ -387,6 +365,40 @@
 				console.log( strplace.join( ',\n' ) );
 				var code = '[' + ( strplace.join( ',\n\t' ) ) + ']';
 				prompt( 'copy and paste code', code );
+
+			}
+
+			function clearSelected () {
+
+				for ( var i = 0; i < splinePointsLength; i ++ ) {
+
+					splineHelperObjects[ i ].material.color.setHex( OBJECT_COLOR );
+
+				}
+
+			}
+
+			function setOldPositions () {
+
+				for ( var i = 0; i < splinePointsLength; i ++ ) {
+
+						splineHelperObjects[ i ].oldPosition.copy( splineHelperObjects[ i ].position );
+
+				}
+
+			}
+
+			function adjustAllSelectedExcept( object, oldPosition, position) {
+
+				for ( var i = 0; i < splinePointsLength; i ++ ) {
+
+					if ( splineHelperObjects[ i ] !== object && splineHelperObjects[ i ].material.color.getHex() === OBJECT_COLOR_SELECTED ) {
+
+						splineHelperObjects[ i ].position.copy( splineHelperObjects[ i ].oldPosition ).add( position ).sub( oldPosition );
+
+					}
+
+				}
 
 			}
 
@@ -419,6 +431,14 @@
 				requestAnimationFrame( animate );
 				render();
 				stats.update();
+
+				if ( timeToLive !== null && timeToLive < performance.now() ) {
+
+					transformControl.detach( transformControl.object );
+					timeToLive = null;
+
+				}
+
 				transformControl.update();
 
 			}


### PR DESCRIPTION
…rols back to Event Listener

Am looking to use webgl_geometry_spline_editor as a basis for crafting a CNC pattern editor, and in doing so, am proposing some changes to webgl_geometry_spline_editor, TransformControls.js and DragControls.js in order to permit envisioned functionality associated with manipulating polygons.  In short, this pull request includes the following changes:

1) webgl_geometry_spline_editor now accepts a Ctrl + Left Mouse Click to select / de-select the spline vertices.  Unselected vertices are white, and selected vertices are red.  Without the Ctrl key down, hovering over a vertex is the same as before, attaching the transform controls to the vertex.

2) webgl_geometry_spline_editor now moves all selected vertices as a group.

3) DragControls.js has been modified to pass the MouseEvent object to the user event listeners, in order to permit the use of the MouseEvent by the user application to define more functionality within the application.  In this particular use case, now within webgl_geometry_spline_editor, when holding down the Ctrl +  Left Mouse Click on a spline vertex, the vertex is toggled as a selected object so that multiple vertices can be selected at once, and moved together.

The passing of the MouseEvent object has been applied to all appropriate DragControl dispatchEvents for consistency and potential use by the calling application.

In order to ensure maximum backward compatibility, the MouseEvent object has been added as a property to the dispatchEvent parameter.

4) TransformControls.js has been modified to pass the oldPosition, oldSize, and oldRotationMatrix to the user event listener, so that the relative changes to the object associated with the transform control can be applied to other objects.  Ie, this permits the transform control to be attached to a single object, and now the user application event listener can determine the type and amount of recent change of the transform control, and then apply the same transformational changes to other objects within the scene.

Additionally, like the DragControls, the MouseEvent is also included when the dispatchEvent is called, in order to provide flexibility to the user application to define different actions within the event listener, triggered by special key or mouse events.

In order to ensure maximum backward compatibility, the MouseEvent, oldPosition, oldSize, and oldRotationMatrix objects have been added as a properties to the dispatchEvent parameter.

5) webgl_geometry_spline_editor included a timer to turn off the transform controls, and the comments within the js indicated it was a bit of a mess.  This has been cleaned up and simplified.

R, Jon