### PR TITLE
FBXLoader: Added check for presence of GlobalSettings to ambient light

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1923,7 +1923,7 @@
 		addAnimations( sceneGraph, animations );
 
 
-    // Parse ambient color - if it's not set to black (default), create an ambient light
+		// Parse ambient color - if it's not set to black (default), create an ambient light
 		if ( 'GlobalSettings' in FBXTree && 'AmbientColor' in FBXTree.GlobalSettings.properties ) {
 
 			var ambientColor = FBXTree.GlobalSettings.properties.AmbientColor.value;

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1923,18 +1923,23 @@
 		addAnimations( sceneGraph, animations );
 
 
-		// Parse ambient color - if it's not set to black (default), create an ambient light
-		var ambientColor = FBXTree.GlobalSettings.properties.AmbientColor.value;
-		var r = ambientColor[ 0 ];
-		var g = ambientColor[ 1 ];
-		var b = ambientColor[ 2 ];
+    // Parse ambient color - if it's not set to black (default), create an ambient light
+		if ( 'GlobalSettings' in FBXTree && 'AmbientColor' in FBXTree.GlobalSettings.properties ) {
 
-		if ( r !== 0 || g !== 0 || b !== 0 ) {
+			var ambientColor = FBXTree.GlobalSettings.properties.AmbientColor.value;
+			var r = ambientColor[ 0 ];
+			var g = ambientColor[ 1 ];
+			var b = ambientColor[ 2 ];
 
-			var color = new THREE.Color( r, g, b );
-			sceneGraph.add( new THREE.AmbientLight( color, 1 ) );
+			if ( r !== 0 || g !== 0 || b !== 0 ) {
+
+				var color = new THREE.Color( r, g, b );
+				sceneGraph.add( new THREE.AmbientLight( color, 1 ) );
+
+			}
 
 		}
+
 
 		return sceneGraph;
 


### PR DESCRIPTION
Added a check for the presence of GlobalSettings to the code added in #12258 since this property is not always present in FBX files. 