### PR TITLE
Fix a couple references to background in WebGLRenderer after context loss/restored

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -437,10 +437,29 @@ function WebGLRenderer( parameters ) {
 
 	// Clearing
 
-	this.getClearColor = background.getClearColor;
-	this.setClearColor = background.setClearColor;
-	this.getClearAlpha = background.getClearAlpha;
-	this.setClearAlpha = background.setClearAlpha;
+	this.getClearColor = function() {
+
+		return background.getClearColor();
+
+	};
+
+	this.setClearColor = function () {
+
+		background.setClearColor.apply( background, arguments );
+
+	};
+
+	this.getClearAlpha = function() {
+
+		return background.getClearAlpha();
+
+	};
+
+	this.setClearAlpha = function() {
+
+		background.setClearAlpha.apply( background, arguments );
+
+	};
 
 	this.clear = function ( color, depth, stencil ) {
 


### PR DESCRIPTION
When restoring the WebGL context, the background object gets recreated. This leads those 4 functions to not reference the proper object anymore so the clear color doesn't get updated.
This is one possible way to fix it, or we can reset those in the `initGLContext` after the background gets recreated. I'm not sure which way would be prefered so I went with that one!