### PR TITLE
Added "start" command to run http-server and npm run dev concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "build-test": "rollup -c test/rollup.unit.config.js",
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar node_modules/google-closure-compiler/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
-    "dev": "rollup -c -w -m inline",
-    "start": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"npm run dev\" \"http-server\"",
+    "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"http-server\"",
+    "start": "npm run dev",
     "lint": "eslint src",
     "test": "rollup -c test/rollup.unit.config.js -w",
     "editor": "electron ./editor/main.js"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar node_modules/google-closure-compiler/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
     "dev": "rollup -c -w -m inline",
+    "start": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"npm run dev\" \"http-server\"",
     "lint": "eslint src",
     "test": "rollup -c test/rollup.unit.config.js -w",
     "editor": "electron ./editor/main.js"
@@ -49,13 +50,15 @@
   },
   "homepage": "http://threejs.org/",
   "devDependencies": {
+    "concurrently": "^3.5.0",
+    "electron": "1.7.8",
     "eslint": "^4.1.1",
     "eslint-config-mdcs": "^4.2.2",
     "google-closure-compiler": "^20170521.0.0",
+    "http-server": "^0.10.0",
     "qunitjs": "^2.1.1",
     "rollup": "^0.43.0",
     "rollup-watch": "^4.0.0",
-    "uglify-js": "^3.0.23",
-    "electron": "1.7.8"
+    "uglify-js": "^3.0.23"
   }
 }


### PR DESCRIPTION
Added `http-server` as a `devdependency` and `concurrently` so we could have a command (`start`) that runs `npm run dev` and `http-server` in the same terminal getting both output with different colors

![image](https://user-images.githubusercontent.com/782511/30994041-25e0a0a0-a4b2-11e7-9774-b5519187216f.png)
