### PR TITLE
Converted 'View Source' button to an anchor element in Examples section

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -87,7 +87,7 @@
 				overflow: auto;
 			}
 
-			#button {
+			#viewSrcButton {
 				position: fixed;
 				bottom: 20px;
 				right: 20px;
@@ -97,7 +97,7 @@
 				opacity: 0.7;
 			}
 
-			#button:hover {
+			#viewSrcButton:hover {
 				cursor: pointer;
 				opacity: 1;
 			}
@@ -277,16 +277,12 @@
 		var container = document.createElement( 'div' );
 		content.appendChild( container );
 
-		var button = document.createElement( 'div' );
-		button.id = 'button';
-		button.textContent = 'View source';
-		button.addEventListener( 'click', function ( event ) {
-
-			window.open( 'https://github.com/mrdoob/three.js/blob/master/examples/' + selected + '.html' );
-
-		}, false );
-		button.style.display = 'none';
-		document.body.appendChild( button );
+		var viewSrcButton = document.createElement( 'a' );
+		viewSrcButton.id = 'viewSrcButton';
+		viewSrcButton.target = '_blank';
+		viewSrcButton.textContent = 'View source';
+		viewSrcButton.style.display = 'none';
+		document.body.appendChild( viewSrcButton );
 
 		var links = {};
 		var selected = null;
@@ -350,10 +346,14 @@
 			window.location.hash = file;
 			viewer.focus();
 
-			button.style.display = '';
 			panel.classList.toggle( 'collapsed' );
 
 			selected = file;
+
+			// Reveal "View source" button and set attributes to this example
+			viewSrcButton.style.display = '';
+			viewSrcButton.href = 'https://github.com/mrdoob/three.js/blob/master/examples/' + selected + '.html';
+			viewSrcButton.title = 'View source code for ' + getName(selected) + ' on GitHub';
 
 		}
 


### PR DESCRIPTION
An easy fix to a mildly frustrating interface issue.  #12305 