### PR TITLE
FBXLoader: Filter object names with PropertyBinding.sanitizeNodeName().

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1737,7 +1737,7 @@
 
 			}
 
-			model.name = node.attrName.replace( /:/, '' ).replace( /_/, '' ).replace( /-/, '' );
+			model.name = THREE.PropertyBinding.sanitizeNodeName( node.attrName );
 			model.FBX_ID = id;
 
 			modelArray.push( model );


### PR DESCRIPTION
Fixes #12295. Dashes and underscores are fine for animation, but `:` should be removed.