### PR TITLE
FBXLoader switch default type from Object3D to Group

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1730,7 +1730,7 @@
 						break;
 
 					default:
-						model = new THREE.Object3D();
+						model = new THREE.Group();
 						break;
 
 				}


### PR DESCRIPTION
FBXLoader creates a lot of hierarchies, and every parent except for the very top level is created as an Object3D. I've just switched that to a Group here. 

Note that default objects are still created for unknown camera or light types, I've left those as they are for now. 