### PR TITLE
FBXLoader: Added map support

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -112,7 +112,7 @@
 
 			}
 
-			console.log( FBXTree );
+			// console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -314,7 +314,7 @@
 
 		var FBX_ID = textureNode.id;
 
-		var name = textureNode.name;
+		var name = textureNode.attrName;
 
 		var fileName;
 
@@ -528,14 +528,25 @@
 
 			switch ( type ) {
 
+				case 'Bump':
+				case ' "Bump':
+					parameters.bumpMap = textureMap.get( relationship.ID );
+					break;
+
 				case 'DiffuseColor':
 				case ' "DiffuseColor':
 					parameters.map = textureMap.get( relationship.ID );
 					break;
 
-				case 'Bump':
-				case ' "Bump':
-					parameters.bumpMap = textureMap.get( relationship.ID );
+				case 'DisplacementColor':
+				case ' "DisplacementColor':
+					parameters.displacementMap = textureMap.get( relationship.ID );
+					break;
+
+
+				case 'EmissiveColor':
+				case ' "EmissiveColor':
+					parameters.emissiveMap = textureMap.get( relationship.ID );
 					break;
 
 				case 'NormalMap':
@@ -543,12 +554,32 @@
 					parameters.normalMap = textureMap.get( relationship.ID );
 					break;
 
+				case 'SpecularColor':
+				case ' "SpecularColor':
+					parameters.specularMap = textureMap.get( relationship.ID );
+					break;
+
+				case 'TransparentColor':
+				case ' "TransparentColor':
+					parameters.alphaMap = textureMap.get( relationship.ID );
+					parameters.transparent = true;
+					break;
+
+				case 'ReflectionColor':
+				case ' "ReflectionColor':
+					console.warn( 'THREE.FBXLoader: Environment maps are currently not supported.' );
+					break;
+
 				case 'AmbientColor':
-				case 'EmissiveColor':
 				case ' "AmbientColor':
-				case ' "EmissiveColor':
+				case 'ShininessExponent': // AKA glossiness map
+				case ' "ShininessExponent':
+				case 'SpecularFactor': // AKA specularLevel
+				case ' "SpecularFactor':
+				case 'VectorDisplacementColor': // NOTE: Seems to be a copy of DisplacementColor
+				case ' "VectorDisplacementColor':
 				default:
-					console.warn( 'THREE.FBXLoader: Unknown texture application of type %s, skipping texture.', type );
+					console.warn( 'THREE.FBXLoader: %s map is not supported in three.js, skipping texture.', type );
 					break;
 
 			}

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -489,6 +489,11 @@
 			parameters.color = parseColor( properties.Diffuse );
 
 		}
+		if ( properties.DisplacementFactor ) {
+
+			parameters.displacementScale = parseFloat( properties.DisplacementFactor );
+
+		}
 		if ( properties.Specular ) {
 
 			parameters.specular = parseColor( properties.Specular );
@@ -496,7 +501,7 @@
 		}
 		if ( properties.Shininess ) {
 
-			parameters.shininess = properties.Shininess.value;
+			parameters.shininess = parseFloat( properties.Shininess.value );
 
 		}
 		if ( properties.Emissive ) {
@@ -511,7 +516,7 @@
 		}
 		if ( properties.Opacity ) {
 
-			parameters.opacity = properties.Opacity.value;
+			parameters.opacity = parseFloat( properties.Opacity.value );
 
 		}
 		if ( parameters.opacity < 1.0 ) {

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -112,7 +112,7 @@
 
 			}
 
-			// console.log( FBXTree );
+			console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );
@@ -491,7 +491,13 @@
 		}
 		if ( properties.DisplacementFactor ) {
 
-			parameters.displacementScale = parseFloat( properties.DisplacementFactor );
+			parameters.displacementScale = parseFloat( properties.DisplacementFactor.value );
+
+		}
+		if ( properties.ReflectionFactor ) {
+
+			parameters.envMapIntensity = parseFloat( properties.ReflectionFactor.value );
+			parameters.reflectivity = parseFloat( properties.ReflectionFactor.value );
 
 		}
 		if ( properties.Specular ) {
@@ -559,6 +565,12 @@
 					parameters.normalMap = textureMap.get( relationship.ID );
 					break;
 
+				case 'ReflectionColor':
+				case ' "ReflectionColor':
+					parameters.envMap = textureMap.get( relationship.ID );
+					parameters.envMap.mapping = THREE.EquirectangularReflectionMapping;
+					break;
+
 				case 'SpecularColor':
 				case ' "SpecularColor':
 					parameters.specularMap = textureMap.get( relationship.ID );
@@ -568,11 +580,6 @@
 				case ' "TransparentColor':
 					parameters.alphaMap = textureMap.get( relationship.ID );
 					parameters.transparent = true;
-					break;
-
-				case 'ReflectionColor':
-				case ' "ReflectionColor':
-					console.warn( 'THREE.FBXLoader: Environment maps are currently not supported.' );
 					break;
 
 				case 'AmbientColor':


### PR DESCRIPTION
Added support for the following map types to FBXLoader: 

* displacementMap 
* emissiveMap 
* specularMap 
* alphaMap 

Improved warnings for unsupported map types. 

Switch texture.name from the `name` property (which is always just 'Texture') to `attrName` which holds the actual texture name. 

~~Environment maps are not directly supported in FBX format, however it looks like it may be possible to support them via the `ReflectionColor` map.~~

Added env map support, see comment below. 

~~There are two remaining maps in three.js that I haven't worked out how to support yet:~~
There is no support for the following two map types
* aoMap
* lightMap 