### PR TITLE
FbxLoader base64 image parsing error

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -261,6 +261,12 @@
 
 		if ( typeof content === 'string' ) {
 
+			if ( content.slice( - 1 ) !== '=' ) {
+
+				content = content.slice( 0, - 1 );
+
+			}
+
 			return 'data:' + type + ';base64,' + content;
 
 		} else {

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -261,6 +261,7 @@
 
 		if ( typeof content === 'string' ) {
 
+			// ASCII format sometimes adds an extra character to the end of the content string
 			if ( content.slice( - 1 ) !== '=' ) {
 
 				content = content.slice( 0, - 1 );


### PR DESCRIPTION
I was trying to track down a different issue and came across this, so this one is a bonus! 😆 

In ASCII format the `content` string containing the base64 encoded image sometimes has an extra ',' on the end, this checks for and removes it. 