### PR TITLE
Fix AssimpLoader error in google closure.

### DIFF
--- a/examples/js/loaders/AssimpLoader.js
+++ b/examples/js/loaders/AssimpLoader.js
@@ -1021,17 +1021,6 @@ THREE.AssimpLoader.prototype = {
 
 		};
 
-		var nameTexMapping = {
-
-			"$tex.ambient": "ambientMap",
-			"$clr.diffuse": "map",
-			"$clr.specular": "specMap",
-			"$clr.emissive": "emissive",
-			"$clr.transparent": "alphaMap",
-			"$clr.reflective": "reflectMap",
-
-		};
-
 		var nameTypeMapping = {
 
 			"?mat.name": "string",


### PR DESCRIPTION
Hi

AssimpLoader was causing an error in closure compiler.

```
INTERNAL COMPILER ERROR.
Please report this problem.

Invalid name 'JSCompiler_object_inline_$tex.ambient_2359'. Did you mean to use NodeUtil.newQName?
  Node(RETURN): ../nunu.editor.js.temp:81906:2
[source unknown]
```

I removed nameTexMapping variable which is not used anyway, seems to fix the problem.

Thanks