### PR TITLE
Fix #12327, QuickHull failing on coplanar sets of points

### DIFF
--- a/examples/js/QuickHull.js
+++ b/examples/js/QuickHull.js
@@ -470,7 +470,7 @@
 
 				// 3. The next vertex 'v3' is the one farthest to the plane 'v0', 'v1', 'v2'
 
-				maxDistance = 0;
+				maxDistance = -1;
 				plane.setFromCoplanarPoints( v0.point, v1.point, v2.point );
 
 				for ( i = 0, l = this.vertices.length; i < l; i ++ ) {


### PR DESCRIPTION
In step 3 of `computeInitalHull` in QuickHull.js, maxDistance is initialized to the wrong value. If all remaining vertices are 0 distance from the initial plane 'v0', 'v1', 'v2', then no value will be assigned to `v3`, resulting in an error. This effects all 2d objects (coplanar sets of points).

This is incorrect. In this case, any of the remaining points can be assigned to `v3`. If you examine the source code from which this QuickHull implementation was ported from, you can see that maxDistance should be initialized to -1. See [line 299](https://github.com/mauriciopoppe/quickhull3d/blob/master/lib/QuickHull.js#L299).