### PR TITLE
package.json: Upgrade electron one more time

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "rollup": "^0.43.0",
     "rollup-watch": "^4.0.0",
     "uglify-js": "^3.0.23",
-    "electron": "^1.6.14"
+    "electron": "1.7.8"
   }
 }


### PR DESCRIPTION
Um, the last PR was not sufficient in order to remove the security warning. The latest stable version of electron and the removal of the `caret`  prefix should solve the issue (see https://nodesecurity.io/advisories/electron_chromium-remote-code-execution)

Tested again with `npm run editor`