### PR TITLE
GLTFLoader: Reuse texture loader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -117,7 +117,8 @@ THREE.GLTFLoader = ( function () {
 			var parser = new GLTFParser( json, extensions, {
 
 				path: path || this.path,
-				crossOrigin: this.crossOrigin
+				crossOrigin: this.crossOrigin,
+				manager: this.manager
 
 			} );
 
@@ -1264,6 +1265,9 @@ THREE.GLTFLoader = ( function () {
 		// loader object cache
 		this.cache = new GLTFRegistry();
 
+		this.textureLoader = new THREE.TextureLoader( this.options.manager );
+		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
+
 	}
 
 	GLTFParser.prototype._withDependencies = function ( dependencies ) {
@@ -1482,6 +1486,7 @@ THREE.GLTFLoader = ( function () {
 		var parser = this;
 		var json = this.json;
 		var options = this.options;
+		var textureLoader = this.textureLoader;
 
 		var URL = window.URL || window.webkitURL;
 
@@ -1510,12 +1515,11 @@ THREE.GLTFLoader = ( function () {
 
 			// Load Texture resource.
 
-			var textureLoader = THREE.Loader.Handlers.get( sourceURI ) || new THREE.TextureLoader();
-			textureLoader.setCrossOrigin( options.crossOrigin );
+			var loader = THREE.Loader.Handlers.get( sourceURI ) || textureLoader;
 
 			return new Promise( function ( resolve, reject ) {
 
-				textureLoader.load( resolveURL( sourceURI, options.path ), resolve, undefined, reject );
+				loader.load( resolveURL( sourceURI, options.path ), resolve, undefined, reject );
 
 			} );
 


### PR DESCRIPTION
This PR ensures that `GLTFLoader` reuses a single instance of `TextureLoader` (like `ColladaLoader` or `FBXLoader`). It also applies the loading manager object to the texture loader. Otherwise the `onLoad` callback of `THREE.LoadingManager` fires too early.