### PR TITLE
Curve: Added optionalTarget to .getPoint() and .getPointAt()

### DIFF
--- a/docs/api/extras/core/Curve.html
+++ b/docs/api/extras/core/Curve.html
@@ -31,13 +31,22 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector getPoint]( [page:Float t] )</h3>
-		<div>Returns a vector for point t of the curve where t is between 0 and 1. Must be implemented in the extending curve.</div>
-
-		<h3>[method:Vector getPointAt]( [page:Float u] )</h3>
+		<h3>[method:Vector getPoint]( [page:Float t], [page:Vector optionalTarget] )</h3>
 		<div>
-			Returns a vector for point at a relative position in curve according to arc length.
-			u is in the range [0, 1].
+			[page:Float t] - A position on the curve. Must be in the range [ 0, 1 ]. <br>
+			[page:Vector optionalTarget] — (optional) If specified, the result will be copied into this Vector,
+			otherwise a new Vector will be created. <br /><br />
+
+			Returns a vector for a given position on the curve.
+		</div>
+
+		<h3>[method:Vector getPointAt]( [page:Float u], [page:Vector optionalTarget] )</h3>
+		<div>
+			[page:Float u] - A position on the curve according to the arc length. Must be in the range [ 0, 1 ]. <br>
+			[page:Vector optionalTarget] — (optional) If specified, the result will be copied into this Vector,
+			otherwise a new Vector will be created. <br /><br />
+
+			Returns a vector for a given position on the curve according to the arc length.
 		</div>
 
 		<h3>[method:Array getPoints]( [page:Integer divisions] )</h3>

--- a/docs/api/extras/curves/ArcCurve.html
+++ b/docs/api/extras/curves/ArcCurve.html
@@ -14,6 +14,17 @@
 
 		<div class="desc">Alias for [page:EllipseCurve]</div>
 
+		<h2>Properties</h2>
+		<div>See the [page:EllipseCurve] class for common properties.</div>
+
+		<h3>[property:Boolean isArcCurve]</h3>
+		<div>
+			Used to check whether this or derived classes are ArcCurves. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/extras/curves/CatmullRomCurve3.html
+++ b/docs/api/extras/curves/CatmullRomCurve3.html
@@ -50,6 +50,13 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Properties</h2>
 		<div>See the base [page:Curve] class for common properties.</div>
 
+		<h3>[property:Boolean isCatmullRomCurve3]</h3>
+		<div>
+			Used to check whether this or derived classes are CatmullRomCurve3s. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
 		<h3>[property:Array points]</h3>
 		<div>The array of array of [page:Vector3] points that define the curve.</div>
 

--- a/docs/api/extras/curves/CubicBezierCurve.html
+++ b/docs/api/extras/curves/CubicBezierCurve.html
@@ -51,6 +51,13 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Properties</h2>
 		<div>See the base [page:Curve] class for common properties.</div>
 
+		<h3>[property:Boolean isCubicBezierCurve]</h3>
+		<div>
+			Used to check whether this or derived classes are CubicBezierCurves. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
 		<h3>[property:Vector2 v0]</h3>
 		<div>The starting point.</div>
 

--- a/docs/api/extras/curves/CubicBezierCurve3.html
+++ b/docs/api/extras/curves/CubicBezierCurve3.html
@@ -52,6 +52,13 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Properties</h2>
 		<div>See the base [page:Curve] class for common properties.</div>
 
+		<h3>[property:Boolean isCubicBezierCurve3]</h3>
+		<div>
+			Used to check whether this or derived classes are CubicBezierCurve3s. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
 		<h3>[property:Vector2 v0]</h3>
 		<div>The starting point.</div>
 

--- a/docs/api/extras/curves/EllipseCurve.html
+++ b/docs/api/extras/curves/EllipseCurve.html
@@ -56,6 +56,13 @@ var ellipse = new THREE.Line( geometry, material );
 		<h2>Properties</h2>
 		<div>See the base [page:Curve] class for common properties.</div>
 
+		<h3>[property:Boolean isEllipseCurve]</h3>
+		<div>
+			Used to check whether this or derived classes are EllipseCurves. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
 		<h3>[property:Float aX]</h3>
 		<div>The X center of the ellipse.</div>
 

--- a/docs/api/extras/curves/LineCurve3.html
+++ b/docs/api/extras/curves/LineCurve3.html
@@ -27,6 +27,13 @@
 		<h2>Properties</h2>
 		<div>See the base [page:Curve] class for common properties.</div>
 
+		<h3>[property:Boolean isLineCurve3]</h3>
+		<div>
+			Used to check whether this or derived classes are LineCurve3s. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
 		<h3>[property:Vector3 v1]</h3>
 		<div>The start point.</div>
 

--- a/docs/api/extras/curves/QuadraticBezierCurve.html
+++ b/docs/api/extras/curves/QuadraticBezierCurve.html
@@ -50,6 +50,13 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Properties</h2>
 		<div>See the base [page:Curve] class for common properties.</div>
 
+		<h3>[property:Boolean isQuadraticBezierCurve]</h3>
+		<div>
+			Used to check whether this or derived classes are QuadraticBezierCurves. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
 
 		<h3>[property:Vector2 v0]</h3>
 		<div>The startpoint.</div>

--- a/docs/api/extras/curves/QuadraticBezierCurve3.html
+++ b/docs/api/extras/curves/QuadraticBezierCurve3.html
@@ -51,6 +51,12 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Properties</h2>
 		<div>See the base [page:Curve] class for common properties.</div>
 
+		<h3>[property:Boolean isQuadraticBezierCurve3]</h3>
+		<div>
+			Used to check whether this or derived classes are QuadraticBezierCurve3s. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
 
 		<h3>[property:Vector3 v0]</h3>
 		<div>The startpoint.</div>

--- a/docs/api/extras/curves/SplineCurve.html
+++ b/docs/api/extras/curves/SplineCurve.html
@@ -48,6 +48,13 @@ var splineObject = new THREE.Line( geometry, material );
 		<h2>Properties</h2>
 		<div>See the base [page:Curve] class for common properties.</div>
 
+		<h3>[property:Boolean isSplineCurve]</h3>
+		<div>
+			Used to check whether this or derived classes are SplineCurves. Default is *true*.<br /><br />
+
+			You should not change this, as it used internally for optimisation.
+		</div>
+
 		<h3>[property:Array points]</h3>
 		<div>The array of [page:Vector3] points that define the curve.</div>
 

--- a/examples/canvas_lines_dashed.html
+++ b/examples/canvas_lines_dashed.html
@@ -72,14 +72,11 @@
 
 				var spline = new THREE.CatmullRomCurve3( points );
 				var geometrySpline = new THREE.Geometry();
-				var point = new THREE.Vector3();
 
 				for ( var i = 0; i < points.length * subdivisions; i ++ ) {
 
-					var index = i / ( points.length * subdivisions );
-					spline.getPoint( index, point );
-
-					geometrySpline.vertices[ i ] = new THREE.Vector3( point.x, point.y, point.z );
+					var t = i / ( points.length * subdivisions );
+					geometrySpline.vertices[ i ] = spline.getPoint( t );
 
 				}
 

--- a/examples/canvas_lines_dashed.html
+++ b/examples/canvas_lines_dashed.html
@@ -72,13 +72,14 @@
 
 				var spline = new THREE.CatmullRomCurve3( points );
 				var geometrySpline = new THREE.Geometry();
+				var point = new THREE.Vector3();
 
 				for ( var i = 0; i < points.length * subdivisions; i ++ ) {
 
 					var index = i / ( points.length * subdivisions );
-					var position = spline.getPoint( index );
+					spline.getPoint( index, point );
 
-					geometrySpline.vertices[ i ] = new THREE.Vector3( position.x, position.y, position.z );
+					geometrySpline.vertices[ i ] = new THREE.Vector3( point.x, point.y, point.z );
 
 				}
 

--- a/examples/js/CurveExtras.js
+++ b/examples/js/CurveExtras.js
@@ -11,7 +11,7 @@
  * http://prideout.net/blog/?p=44
  */
 
-( function( Curves ) {
+( function ( Curves ) {
 
 	// GrannyKnot
 
@@ -24,7 +24,9 @@
 	GrannyKnot.prototype = Object.create( THREE.Curve.prototype );
 	GrannyKnot.prototype.constructor = GrannyKnot;
 
-	GrannyKnot.prototype.getPoint = function( t ) {
+	GrannyKnot.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		t = 2 * Math.PI * t;
 
@@ -32,7 +34,7 @@
 		var y = - 0.1 * Math.cos( 2 * t ) - 0.27 * Math.sin( 2 * t ) + 0.38 * Math.cos( 4 * t ) + 0.46 * Math.sin( 4 * t );
 		var z = 0.7 * Math.cos( 3 * t ) - 0.4 * Math.sin( 3 * t );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( 20 );
+		return point.set( x, y, z ).multiplyScalar( 20 );
 
 	};
 
@@ -49,7 +51,9 @@
 	HeartCurve.prototype = Object.create( THREE.Curve.prototype );
 	HeartCurve.prototype.constructor = HeartCurve;
 
-	HeartCurve.prototype.getPoint = function( t ) {
+	HeartCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		t *= 2 * Math.PI;
 
@@ -57,7 +61,7 @@
 		var y = 13 * Math.cos( t ) - 5 * Math.cos( 2 * t ) - 2 * Math.cos( 3 * t ) - Math.cos( 4 * t );
 		var z = 0;
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
@@ -74,7 +78,9 @@
 	VivianiCurve.prototype = Object.create( THREE.Curve.prototype );
 	VivianiCurve.prototype.constructor = VivianiCurve;
 
-	VivianiCurve.prototype.getPoint = function( t ) {
+	VivianiCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		t = t * 4 * Math.PI; // normalized to 0..1
 		var a = this.radius / 2;
@@ -83,7 +89,7 @@
 		var y = a * Math.sin( t );
 		var z = 2 * a * Math.sin( t / 2 );
 
-		return new THREE.Vector3( x, y, z );
+		return point.set( x, y, z );
 
 	};
 
@@ -98,7 +104,9 @@
 	KnotCurve.prototype = Object.create( THREE.Curve.prototype );
 	KnotCurve.prototype.constructor = KnotCurve;
 
-	KnotCurve.prototype.getPoint = function( t ) {
+	KnotCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		t *= 2 * Math.PI;
 
@@ -109,7 +117,7 @@
 		var y = Math.cos( t ) * ( R + s * Math.cos( t ) );
 		var z = Math.sin( t ) * ( R + s * Math.cos( t ) );
 
-		return new THREE.Vector3( x, y, z );
+		return point.set( x, y, z );
 
 	};
 
@@ -124,7 +132,9 @@
 	HelixCurve.prototype = Object.create( THREE.Curve.prototype );
 	HelixCurve.prototype.constructor = HelixCurve;
 
-	HelixCurve.prototype.getPoint = function( t ) {
+	HelixCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		var a = 30; // radius
 		var b = 150; // height
@@ -135,7 +145,7 @@
 		var y = Math.sin( t2 ) * a;
 		var z = b * t;
 
-		return new THREE.Vector3( x, y, z );
+		return point.set( x, y, z );
 
 	};
 
@@ -152,7 +162,9 @@
 	TrefoilKnot.prototype = Object.create( THREE.Curve.prototype );
 	TrefoilKnot.prototype.constructor = TrefoilKnot;
 
-	TrefoilKnot.prototype.getPoint = function( t ) {
+	TrefoilKnot.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		t *= Math.PI * 2;
 
@@ -160,7 +172,7 @@
 		var y = ( 2 + Math.cos( 3 * t ) ) * Math.sin( 2 * t );
 		var z = Math.sin( 3 * t );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
@@ -177,7 +189,9 @@
 	TorusKnot.prototype = Object.create( THREE.Curve.prototype );
 	TorusKnot.prototype.constructor = TorusKnot;
 
-	TorusKnot.prototype.getPoint = function( t ) {
+	TorusKnot.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		var p = 3;
 		var q = 4;
@@ -188,7 +202,7 @@
 		var y = ( 2 + Math.cos( q * t ) ) * Math.sin( p * t );
 		var z = Math.sin( q * t );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
@@ -205,7 +219,9 @@
 	CinquefoilKnot.prototype = Object.create( THREE.Curve.prototype );
 	CinquefoilKnot.prototype.constructor = CinquefoilKnot;
 
-	CinquefoilKnot.prototype.getPoint = function( t ) {
+	CinquefoilKnot.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		var p = 2;
 		var q = 5;
@@ -216,7 +232,7 @@
 		var y = ( 2 + Math.cos( q * t ) ) * Math.sin( p * t );
 		var z = Math.sin( q * t );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
@@ -233,7 +249,9 @@
 	TrefoilPolynomialKnot.prototype = Object.create( THREE.Curve.prototype );
 	TrefoilPolynomialKnot.prototype.constructor = TrefoilPolynomialKnot;
 
-	TrefoilPolynomialKnot.prototype.getPoint = function( t ) {
+	TrefoilPolynomialKnot.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		t = t * 4 - 2;
 
@@ -241,11 +259,11 @@
 		var y = Math.pow( t, 4 ) - 4 * t * t;
 		var z = 1 / 5 * Math.pow( t, 5 ) - 2 * t;
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
-	var scaleTo = function( x, y, t ) {
+	var scaleTo = function ( x, y, t ) {
 
 		var r = y - x;
 		return t * r + x;
@@ -265,7 +283,9 @@
 	FigureEightPolynomialKnot.prototype = Object.create( THREE.Curve.prototype );
 	FigureEightPolynomialKnot.prototype.constructor = FigureEightPolynomialKnot;
 
-	FigureEightPolynomialKnot.prototype.getPoint = function( t ) {
+	FigureEightPolynomialKnot.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		t = scaleTo( - 4, 4, t );
 
@@ -273,7 +293,7 @@
 		var y = Math.pow( t, 4 ) - 13 * t * t;
 		var z = 1 / 10 * t * ( t * t - 4 ) * ( t * t - 9 ) * ( t * t - 12 );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
@@ -290,7 +310,9 @@
 	DecoratedTorusKnot4a.prototype = Object.create( THREE.Curve.prototype );
 	DecoratedTorusKnot4a.prototype.constructor = DecoratedTorusKnot4a;
 
-	DecoratedTorusKnot4a.prototype.getPoint = function( t ) {
+	DecoratedTorusKnot4a.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		t *= Math.PI * 2;
 
@@ -298,7 +320,7 @@
 		var y = Math.sin( 2 * t ) * ( 1 + 0.6 * ( Math.cos( 5 * t ) + 0.75 * Math.cos( 10 * t ) ) );
 		var z = 0.35 * Math.sin( 5 * t );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
@@ -315,7 +337,9 @@
 	DecoratedTorusKnot4b.prototype = Object.create( THREE.Curve.prototype );
 	DecoratedTorusKnot4b.prototype.constructor = DecoratedTorusKnot4b;
 
-	DecoratedTorusKnot4b.prototype.getPoint = function( t ) {
+	DecoratedTorusKnot4b.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		var fi = t * Math.PI * 2;
 
@@ -323,7 +347,7 @@
 		var y = Math.sin( 2 * fi ) * ( 1 + 0.45 * Math.cos( 3 * fi ) + 0.4 * Math.cos( 9 * fi ) );
 		var z = 0.2 * Math.sin( 9 * fi );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
@@ -340,7 +364,9 @@
 	DecoratedTorusKnot5a.prototype = Object.create( THREE.Curve.prototype );
 	DecoratedTorusKnot5a.prototype.constructor = DecoratedTorusKnot5a;
 
-	DecoratedTorusKnot5a.prototype.getPoint = function( t ) {
+	DecoratedTorusKnot5a.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		var fi = t * Math.PI * 2;
 
@@ -348,7 +374,7 @@
 		var y = Math.sin( 3 * fi ) * ( 1 + 0.3 * Math.cos( 5 * fi ) + 0.5 * Math.cos( 10 * fi ) );
 		var z = 0.2 * Math.sin( 20 * fi );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
@@ -365,7 +391,9 @@
 	DecoratedTorusKnot5c.prototype = Object.create( THREE.Curve.prototype );
 	DecoratedTorusKnot5c.prototype.constructor = DecoratedTorusKnot5c;
 
-	DecoratedTorusKnot5c.prototype.getPoint = function( t ) {
+	DecoratedTorusKnot5c.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		var fi = t * Math.PI * 2;
 
@@ -373,7 +401,7 @@
 		var y = Math.sin( 4 * fi ) * ( 1 + 0.5 * ( Math.cos( 5 * fi ) + 0.4 * Math.cos( 20 * fi ) ) );
 		var z = 0.35 * Math.sin( 15 * fi );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( this.scale );
+		return point.set( x, y, z ).multiplyScalar( this.scale );
 
 	};
 
@@ -394,4 +422,4 @@
 	Curves.DecoratedTorusKnot5a = DecoratedTorusKnot5a;
 	Curves.DecoratedTorusKnot5c = DecoratedTorusKnot5c;
 
-} ) ( THREE.Curves = THREE.Curves || {} );
+} )( THREE.Curves = THREE.Curves || {} );

--- a/examples/js/ParametricGeometries.js
+++ b/examples/js/ParametricGeometries.js
@@ -191,7 +191,9 @@ THREE.ParametricGeometries.TorusKnotGeometry = function ( radius, tube, segments
 	TorusKnotCurve.prototype = Object.create( THREE.Curve.prototype );
 	TorusKnotCurve.prototype.constructor = TorusKnotCurve;
 
-	TorusKnotCurve.prototype.getPoint = function ( t ) {
+	TorusKnotCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+		var point = optionalTarget || new THREE.Vector3();
 
 		t *= Math.PI * 2;
 
@@ -201,7 +203,7 @@ THREE.ParametricGeometries.TorusKnotGeometry = function ( radius, tube, segments
 		var y = ( 1 + r * Math.cos( q * t ) ) * Math.sin( p * t );
 		var z = r * Math.sin( q * t );
 
-		return new THREE.Vector3( x, y, z ).multiplyScalar( radius );
+		return point.set( x, y, z ).multiplyScalar( radius );
 
 	};
 

--- a/examples/software_lines_splines.html
+++ b/examples/software_lines_splines.html
@@ -97,10 +97,8 @@
 
 				for ( i = 0; i < points.length * subdivisions; i ++ ) {
 
-					var index = i / ( points.length * subdivisions );
-					spline.getPoint( index, point );
-
-					geometry.vertices[ i ] = new THREE.Vector3( point.x, point.y, point.z );
+					var t = i / ( points.length * subdivisions );
+					geometry.vertices[ i ] = spline.getPoint( t );
 
 					colors[ i ] = new THREE.Color( 0xffffff );
 					colors[ i ].setHSL( 0.6, 1.0, Math.max( 0, - point.x / 200 ) + 0.5 );

--- a/examples/software_lines_splines.html
+++ b/examples/software_lines_splines.html
@@ -69,7 +69,7 @@
 
 			function init() {
 
-				var i, n_sub, container;
+				var i, container;
 
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );
@@ -87,30 +87,29 @@
 				var geometry = new THREE.Geometry(),
 				geometry2 = new THREE.Geometry(),
 				geometry3 = new THREE.Geometry(),
-				points = hilbert3D( new THREE.Vector3( 0,0,0 ), 200.0, 1, 0, 1, 2, 3, 4, 5, 6, 7 ),
+				points = hilbert3D( new THREE.Vector3(), 200.0, 1, 0, 1, 2, 3, 4, 5, 6, 7 ),
 				colors = [], colors2 = [], colors3 = [];
 
-				n_sub = 6;
-
-				var position, index;
+				var subdivisions = 6;
 
 				var spline = new THREE.CatmullRomCurve3( points );
+				var point = new THREE.Vector3();
 
-				for ( i = 0; i < points.length * n_sub; i ++ ) {
+				for ( i = 0; i < points.length * subdivisions; i ++ ) {
 
-					index = i / ( points.length * n_sub );
-					position = spline.getPoint( index );
+					var index = i / ( points.length * subdivisions );
+					spline.getPoint( index, point );
 
-					geometry.vertices[ i ] = new THREE.Vector3( position.x, position.y, position.z );
+					geometry.vertices[ i ] = new THREE.Vector3( point.x, point.y, point.z );
 
 					colors[ i ] = new THREE.Color( 0xffffff );
-					colors[ i ].setHSL( 0.6, 1.0, Math.max( 0, - position.x / 200 ) + 0.5 );
+					colors[ i ].setHSL( 0.6, 1.0, Math.max( 0, - point.x / 200 ) + 0.5 );
 
 					colors2[ i ] = new THREE.Color( 0xffffff );
-					colors2[ i ].setHSL( 0.9, 1.0, Math.max( 0, - position.y / 200 ) + 0.5 );
+					colors2[ i ].setHSL( 0.9, 1.0, Math.max( 0, - point.y / 200 ) + 0.5 );
 
 					colors3[ i ] = new THREE.Color( 0xffffff );
-					colors3[ i ].setHSL( i / ( points.length * n_sub ), 1.0, 0.5 );
+					colors3[ i ].setHSL( i / ( points.length * subdivisions ), 1.0, 0.5 );
 
 				}
 

--- a/examples/software_sandbox.html
+++ b/examples/software_sandbox.html
@@ -110,9 +110,8 @@
 
 				for ( var i = 0; i < points.length * n_sub; i ++ ) {
 
-					var index = i / ( points.length * n_sub );
-
-					vertices[ i ] = spline.getPoint( index );
+					var t = i / ( points.length * n_sub );
+					vertices[ i ] = spline.getPoint( t );
 					colors[ i ] = new THREE.Color( 0x88aaff );
 
 				}

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -353,6 +353,8 @@
 
 			function updateSplineOutline() {
 
+				var point = new THREE.Vector3();
+
 				for ( var k in splines ) {
 
 					var spline = splines[ k ];
@@ -362,14 +364,15 @@
 					for ( var i = 0; i < ARC_SEGMENTS; i ++ ) {
 
 						var p = splineMesh.geometry.vertices[ i ];
-						p.copy( spline.getPoint( i /  ( ARC_SEGMENTS - 1 ) ) );
+						var t = i /  ( ARC_SEGMENTS - 1 );
+						spline.getPoint( t, point )
+						p.copy( point );
 
 					}
 
 					splineMesh.geometry.verticesNeedUpdate = true;
 
 				}
-
 
 			}
 

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -353,8 +353,6 @@
 
 			function updateSplineOutline() {
 
-				var point = new THREE.Vector3();
-
 				for ( var k in splines ) {
 
 					var spline = splines[ k ];
@@ -365,8 +363,7 @@
 
 						var p = splineMesh.geometry.vertices[ i ];
 						var t = i /  ( ARC_SEGMENTS - 1 );
-						spline.getPoint( t, point )
-						p.copy( point );
+						spline.getPoint( t, p );
 
 					}
 

--- a/examples/webgl_lines_dashed.html
+++ b/examples/webgl_lines_dashed.html
@@ -70,14 +70,11 @@
 
 				var spline = new THREE.CatmullRomCurve3( points );
 				var geometrySpline = new THREE.Geometry();
-				var point = new THREE.Vector3();
 
 				for ( var i = 0; i < points.length * subdivisions; i ++ ) {
 
-					var index = i / ( points.length * subdivisions );
-					spline.getPoint( index, point );
-
-					geometrySpline.vertices[ i ] = new THREE.Vector3( point.x, point.y, point.z );
+					var t = i / ( points.length * subdivisions );
+					geometrySpline.vertices[ i ] = spline.getPoint( t );
 
 				}
 

--- a/examples/webgl_lines_dashed.html
+++ b/examples/webgl_lines_dashed.html
@@ -70,13 +70,14 @@
 
 				var spline = new THREE.CatmullRomCurve3( points );
 				var geometrySpline = new THREE.Geometry();
+				var point = new THREE.Vector3();
 
 				for ( var i = 0; i < points.length * subdivisions; i ++ ) {
 
 					var index = i / ( points.length * subdivisions );
-					var position = spline.getPoint( index );
+					spline.getPoint( index, point );
 
-					geometrySpline.vertices[ i ] = new THREE.Vector3( position.x, position.y, position.z );
+					geometrySpline.vertices[ i ] = new THREE.Vector3( point.x, point.y, point.z );
 
 				}
 
@@ -186,7 +187,6 @@
 
 					var object = objects[ i ];
 
-					//object.rotation.x = 0.25 * time * ( i%2 == 1 ? 1 : -1);
 					object.rotation.x = 0.25 * time;
 					object.rotation.y = 0.25 * time;
 

--- a/examples/webgl_lines_splines.html
+++ b/examples/webgl_lines_splines.html
@@ -49,7 +49,6 @@
 		<script src="js/geometries/hilbert3D.js"></script>
 
 		<script src="js/Detector.js"></script>
-		<script src="js/libs/stats.min.js"></script>
 
 		<script>
 
@@ -67,7 +66,7 @@
 
 			function init() {
 
-				var i, n_sub, container;
+				var i, container;
 
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );
@@ -82,42 +81,48 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				var geometry = new THREE.Geometry(),
-					geometry2 = new THREE.Geometry(),
-					geometry3 = new THREE.Geometry(),
-					points = hilbert3D( new THREE.Vector3( 0,0,0 ), 200.0, 1, 0, 1, 2, 3, 4, 5, 6, 7 ),
-					colors = [], colors2 = [], colors3 = [];
+				var geometry0 = new THREE.BufferGeometry(),
+					geometry1 = new THREE.BufferGeometry(),
+					geometry2 = new THREE.BufferGeometry(),
+					points = hilbert3D( new THREE.Vector3( 0,0,0 ), 200.0, 1, 0, 1, 2, 3, 4, 5, 6, 7 );
 
-				n_sub = 6;
+				var subdivisions = 6;
 
-				var position, index;
+				var position = [];
+				var color0 = [];
+				var color1 = [];
+				var color2 = [];
+
+				var point = new THREE.Vector3();
+				var color = new THREE.Color();
 
 				var spline = new THREE.CatmullRomCurve3( points );
 
-				for ( i = 0; i < points.length * n_sub; i ++ ) {
+				for ( i = 0; i < points.length * subdivisions; i ++ ) {
 
-					index = i / ( points.length * n_sub );
-					position = spline.getPoint( index );
+					var index = i / ( points.length * subdivisions );
+					spline.getPoint( index, point );
 
-					geometry.vertices[ i ] = new THREE.Vector3( position.x, position.y, position.z );
+					position.push( point.x, point.y, point.z );
 
-					colors[ i ] = new THREE.Color( 0xffffff );
-					colors[ i ].setHSL( 0.6, 1.0, Math.max( 0, - position.x / 200 ) + 0.5 );
+					color.setHSL( 0.6, 1.0, Math.max( 0, - point.x / 200 ) + 0.5 );
+					color0.push( color.r, color.g, color.b );
 
-					colors2[ i ] = new THREE.Color( 0xffffff );
-					colors2[ i ].setHSL( 0.9, 1.0, Math.max( 0, - position.y / 200 ) + 0.5 );
+					color.setHSL( 0.9, 1.0, Math.max( 0, - point.y / 200 ) + 0.5 );
+					color1.push( color.r, color.g, color.b );
 
-					colors3[ i ] = new THREE.Color( 0xffffff );
-					colors3[ i ].setHSL( i / ( points.length * n_sub ), 1.0, 0.5 );
-
+					color.setHSL( i / ( points.length * subdivisions ), 1.0, 0.5 );
+					color2.push( color.r, color.g, color.b );
 
 				}
 
-				geometry2.vertices = geometry3.vertices = geometry.vertices;
+				geometry0.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
+				geometry1.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
+				geometry2.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
 
-				geometry.colors = colors;
-				geometry2.colors = colors2;
-				geometry3.colors = colors3;
+				geometry0.addAttribute( 'color', new THREE.Float32BufferAttribute( color0, 3 ) );
+				geometry1.addAttribute( 'color', new THREE.Float32BufferAttribute( color1, 3 ) );
+				geometry2.addAttribute( 'color', new THREE.Float32BufferAttribute( color2, 3 ) );
 
 				// lines
 
@@ -125,9 +130,9 @@
 
 				var line, p, scale = 0.3, d = 225;
 				var parameters =  [
-					[ material, scale*1.5, [-d,0,0],  geometry ],
-					[ material, scale*1.5, [0,0,0],  geometry2 ],
-					[ material, scale*1.5, [d,0,0],  geometry3 ]
+					[ material, scale * 1.5, [ - d, 0, 0 ], geometry0 ],
+					[ material, scale * 1.5, [ 0, 0, 0 ],  geometry1 ],
+					[ material, scale * 1.5, [ d, 0, 0 ],  geometry2 ]
 				];
 
 				for ( i = 0; i < parameters.length; ++ i ) {
@@ -141,11 +146,6 @@
 					scene.add( line );
 
 				}
-
-
-				stats = new Stats();
-				//container.appendChild(stats.dom);
-
 
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 				document.addEventListener( 'touchstart', onDocumentTouchStart, false );

--- a/examples/webgl_lines_splines.html
+++ b/examples/webgl_lines_splines.html
@@ -100,8 +100,8 @@
 
 				for ( i = 0; i < points.length * subdivisions; i ++ ) {
 
-					var index = i / ( points.length * subdivisions );
-					spline.getPoint( index, point );
+					var t = i / ( points.length * subdivisions );
+					spline.getPoint( t, point );
 
 					position.push( point.x, point.y, point.z );
 

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -7,8 +7,8 @@ import { Matrix4 } from '../../math/Matrix4.js';
  * Extensible curve object
  *
  * Some common of curve methods:
- * .getPoint(t), getTangent(t)
- * .getPointAt(u), getTangentAt(u)
+ * .getPoint( t, optionalTarget ), .getTangent( t )
+ * .getPointAt( u, optionalTarget ), .getTangentAt( u )
  * .getPoints(), .getSpacedPoints()
  * .getLength()
  * .updateArcLengths()
@@ -48,7 +48,7 @@ Object.assign( Curve.prototype, {
 	// Virtual base class method to overwrite and implement in subclasses
 	//	- t [0 .. 1]
 
-	getPoint: function () {
+	getPoint: function ( /* t, optionalTarget */ ) {
 
 		console.warn( 'THREE.Curve: .getPoint() not implemented.' );
 		return null;
@@ -58,10 +58,10 @@ Object.assign( Curve.prototype, {
 	// Get point at relative position in curve according to arc length
 	// - u [0 .. 1]
 
-	getPointAt: function ( u ) {
+	getPointAt: function ( u, optionalTarget ) {
 
 		var t = this.getUtoTmapping( u );
-		return this.getPoint( t );
+		return this.getPoint( t, optionalTarget );
 
 	},
 

--- a/src/extras/curves/ArcCurve.js
+++ b/src/extras/curves/ArcCurve.js
@@ -10,5 +10,7 @@ function ArcCurve( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
 ArcCurve.prototype = Object.create( EllipseCurve.prototype );
 ArcCurve.prototype.constructor = ArcCurve;
 
+ArcCurve.prototype.isArcCurve = true;
+
 
 export { ArcCurve };

--- a/src/extras/curves/CatmullRomCurve3.js
+++ b/src/extras/curves/CatmullRomCurve3.js
@@ -97,14 +97,18 @@ function CatmullRomCurve3( points ) {
 CatmullRomCurve3.prototype = Object.create( Curve.prototype );
 CatmullRomCurve3.prototype.constructor = CatmullRomCurve3;
 
-CatmullRomCurve3.prototype.getPoint = function ( t ) {
+CatmullRomCurve3.prototype.isCatmullRomCurve3 = true;
+
+CatmullRomCurve3.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector3();
 
 	var points = this.points;
 	var l = points.length;
 
-	var point = ( l - ( this.closed ? 0 : 1 ) ) * t;
-	var intPoint = Math.floor( point );
-	var weight = point - intPoint;
+	var p = ( l - ( this.closed ? 0 : 1 ) ) * t;
+	var intPoint = Math.floor( p );
+	var weight = p - intPoint;
 
 	if ( this.closed ) {
 
@@ -172,7 +176,13 @@ CatmullRomCurve3.prototype.getPoint = function ( t ) {
 
 	}
 
-	return new Vector3( px.calc( weight ), py.calc( weight ), pz.calc( weight ) );
+	point.set(
+		px.calc( weight ),
+		py.calc( weight ),
+		pz.calc( weight )
+	);
+
+	return point;
 
 };
 

--- a/src/extras/curves/CubicBezierCurve.js
+++ b/src/extras/curves/CubicBezierCurve.js
@@ -17,14 +17,20 @@ function CubicBezierCurve( v0, v1, v2, v3 ) {
 CubicBezierCurve.prototype = Object.create( Curve.prototype );
 CubicBezierCurve.prototype.constructor = CubicBezierCurve;
 
-CubicBezierCurve.prototype.getPoint = function ( t ) {
+CubicBezierCurve.prototype.isCubicBezierCurve = true;
+
+CubicBezierCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector2();
 
 	var v0 = this.v0, v1 = this.v1, v2 = this.v2, v3 = this.v3;
 
-	return new Vector2(
+	point.set(
 		CubicBezier( t, v0.x, v1.x, v2.x, v3.x ),
 		CubicBezier( t, v0.y, v1.y, v2.y, v3.y )
 	);
+
+	return point;
 
 };
 

--- a/src/extras/curves/CubicBezierCurve3.js
+++ b/src/extras/curves/CubicBezierCurve3.js
@@ -17,15 +17,21 @@ function CubicBezierCurve3( v0, v1, v2, v3 ) {
 CubicBezierCurve3.prototype = Object.create( Curve.prototype );
 CubicBezierCurve3.prototype.constructor = CubicBezierCurve3;
 
-CubicBezierCurve3.prototype.getPoint = function ( t ) {
+CubicBezierCurve3.prototype.isCubicBezierCurve3 = true;
+
+CubicBezierCurve3.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector3();
 
 	var v0 = this.v0, v1 = this.v1, v2 = this.v2, v3 = this.v3;
 
-	return new Vector3(
+	point.set(
 		CubicBezier( t, v0.x, v1.x, v2.x, v3.x ),
 		CubicBezier( t, v0.y, v1.y, v2.y, v3.y ),
 		CubicBezier( t, v0.z, v1.z, v2.z, v3.z )
 	);
+
+	return point;
 
 };
 

--- a/src/extras/curves/EllipseCurve.js
+++ b/src/extras/curves/EllipseCurve.js
@@ -26,7 +26,9 @@ EllipseCurve.prototype.constructor = EllipseCurve;
 
 EllipseCurve.prototype.isEllipseCurve = true;
 
-EllipseCurve.prototype.getPoint = function ( t ) {
+EllipseCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector2();
 
 	var twoPi = Math.PI * 2;
 	var deltaAngle = this.aEndAngle - this.aStartAngle;
@@ -82,7 +84,7 @@ EllipseCurve.prototype.getPoint = function ( t ) {
 
 	}
 
-	return new Vector2( x, y );
+	return point.set( x, y );
 
 };
 

--- a/src/extras/curves/LineCurve.js
+++ b/src/extras/curves/LineCurve.js
@@ -1,3 +1,4 @@
+import { Vector2 } from '../../math/Vector2.js';
 import { Curve } from '../core/Curve.js';
 
 
@@ -15,16 +16,20 @@ LineCurve.prototype.constructor = LineCurve;
 
 LineCurve.prototype.isLineCurve = true;
 
-LineCurve.prototype.getPoint = function ( t ) {
+LineCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector2();
 
 	if ( t === 1 ) {
 
-		return this.v2.clone();
+		point.copy( this.v2 );
+
+	} else {
+
+		point.copy( this.v2 ).sub( this.v1 );
+		point.multiplyScalar( t ).add( this.v1 );
 
 	}
-
-	var point = this.v2.clone().sub( this.v1 );
-	point.multiplyScalar( t ).add( this.v1 );
 
 	return point;
 
@@ -32,9 +37,9 @@ LineCurve.prototype.getPoint = function ( t ) {
 
 // Line curve is linear, so we can overwrite default getPointAt
 
-LineCurve.prototype.getPointAt = function ( u ) {
+LineCurve.prototype.getPointAt = function ( u, optionalTarget ) {
 
-	return this.getPoint( u );
+	return this.getPoint( u, optionalTarget );
 
 };
 

--- a/src/extras/curves/LineCurve3.js
+++ b/src/extras/curves/LineCurve3.js
@@ -14,21 +14,32 @@ function LineCurve3( v1, v2 ) {
 LineCurve3.prototype = Object.create( Curve.prototype );
 LineCurve3.prototype.constructor = LineCurve3;
 
-LineCurve3.prototype.getPoint = function ( t ) {
+LineCurve3.prototype.isLineCurve3 = true;
+
+LineCurve3.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector3();
 
 	if ( t === 1 ) {
 
-		return this.v2.clone();
+		point.copy( this.v2 );
+
+	} else {
+
+		point.copy( this.v2 ).sub( this.v1 );
+		point.multiplyScalar( t ).add( this.v1 );
 
 	}
 
-	var vector = new Vector3();
+	return point;
 
-	vector.subVectors( this.v2, this.v1 ); // diff
-	vector.multiplyScalar( t );
-	vector.add( this.v1 );
+};
 
-	return vector;
+// Line curve is linear, so we can overwrite default getPointAt
+
+LineCurve3.prototype.getPointAt = function ( u, optionalTarget ) {
+
+	return this.getPoint( u, optionalTarget );
 
 };
 

--- a/src/extras/curves/QuadraticBezierCurve.js
+++ b/src/extras/curves/QuadraticBezierCurve.js
@@ -16,14 +16,20 @@ function QuadraticBezierCurve( v0, v1, v2 ) {
 QuadraticBezierCurve.prototype = Object.create( Curve.prototype );
 QuadraticBezierCurve.prototype.constructor = QuadraticBezierCurve;
 
-QuadraticBezierCurve.prototype.getPoint = function ( t ) {
+QuadraticBezierCurve.prototype.isQuadraticBezierCurve = true;
+
+QuadraticBezierCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector2();
 
 	var v0 = this.v0, v1 = this.v1, v2 = this.v2;
 
-	return new Vector2(
+	point.set(
 		QuadraticBezier( t, v0.x, v1.x, v2.x ),
 		QuadraticBezier( t, v0.y, v1.y, v2.y )
 	);
+
+	return point;
 
 };
 

--- a/src/extras/curves/QuadraticBezierCurve3.js
+++ b/src/extras/curves/QuadraticBezierCurve3.js
@@ -16,15 +16,21 @@ function QuadraticBezierCurve3( v0, v1, v2 ) {
 QuadraticBezierCurve3.prototype = Object.create( Curve.prototype );
 QuadraticBezierCurve3.prototype.constructor = QuadraticBezierCurve3;
 
-QuadraticBezierCurve3.prototype.getPoint = function ( t ) {
+QuadraticBezierCurve3.prototype.isQuadraticBezierCurve3 = true;
+
+QuadraticBezierCurve3.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector3();
 
 	var v0 = this.v0, v1 = this.v1, v2 = this.v2;
 
-	return new Vector3(
+	point.set(
 		QuadraticBezier( t, v0.x, v1.x, v2.x ),
 		QuadraticBezier( t, v0.y, v1.y, v2.y ),
 		QuadraticBezier( t, v0.z, v1.z, v2.z )
 	);
+
+	return point;
 
 };
 

--- a/src/extras/curves/SplineCurve.js
+++ b/src/extras/curves/SplineCurve.js
@@ -16,23 +16,27 @@ SplineCurve.prototype.constructor = SplineCurve;
 
 SplineCurve.prototype.isSplineCurve = true;
 
-SplineCurve.prototype.getPoint = function ( t ) {
+SplineCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector2();
 
 	var points = this.points;
-	var point = ( points.length - 1 ) * t;
+	var p = ( points.length - 1 ) * t;
 
-	var intPoint = Math.floor( point );
-	var weight = point - intPoint;
+	var intPoint = Math.floor( p );
+	var weight = p - intPoint;
 
-	var point0 = points[ intPoint === 0 ? intPoint : intPoint - 1 ];
-	var point1 = points[ intPoint ];
-	var point2 = points[ intPoint > points.length - 2 ? points.length - 1 : intPoint + 1 ];
-	var point3 = points[ intPoint > points.length - 3 ? points.length - 1 : intPoint + 2 ];
+	var p0 = points[ intPoint === 0 ? intPoint : intPoint - 1 ];
+	var p1 = points[ intPoint ];
+	var p2 = points[ intPoint > points.length - 2 ? points.length - 1 : intPoint + 1 ];
+	var p3 = points[ intPoint > points.length - 3 ? points.length - 1 : intPoint + 2 ];
 
-	return new Vector2(
-		CatmullRom( weight, point0.x, point1.x, point2.x, point3.x ),
-		CatmullRom( weight, point0.y, point1.y, point2.y, point3.y )
+	point.set(
+		CatmullRom( weight, p0.x, p1.x, p2.x, p3.x ),
+		CatmullRom( weight, p0.y, p1.y, p2.y, p3.y )
 	);
+
+	return point;
 
 };
 

--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -84,6 +84,7 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 	var vertex = new Vector3();
 	var normal = new Vector3();
 	var uv = new Vector2();
+	var P = new Vector3();
 
 	var i, j;
 
@@ -137,7 +138,7 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 
 		// we use getPointAt to sample evenly distributed points from the given path
 
-		var P = path.getPointAt( i / tubularSegments );
+		P = path.getPointAt( i / tubularSegments, P );
 
 		// retrieve corresponding normal and binormal
 


### PR DESCRIPTION
First of all, this PR is backward compatible 😊 . It introduces an `optionalTarget` parameter to `Curve .getPoint()` and `Curve .getPointAt()` and all overwritten methods in derived entities. This ensures that no object creation is performed if `optionalTarget` is provided. Besides, the PR does some minor clean up in the context of curves and the corresponding docs. Some examples also use the new logic now.