### PR TITLE
FBXLoader: Removed envMapIntensity parameter

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -503,7 +503,6 @@
 		}
 		if ( properties.ReflectionFactor ) {
 
-			parameters.envMapIntensity = parseFloat( properties.ReflectionFactor.value );
 			parameters.reflectivity = parseFloat( properties.ReflectionFactor.value );
 
 		}


### PR DESCRIPTION
I added support for the `material.envMapIntensity` in #12317, but it's causing a console warning when Phong materials are created so I've removed it for now. 

I plan to add proper support for `MeshStandardMaterial`, wich will require refactoring of the `parseParameters` function.  I'll add this parameter back then. 