### PR TITLE
FbxLoader base64 image parsing error fix update

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -262,7 +262,7 @@
 		if ( typeof content === 'string' ) {
 
 			// ASCII format sometimes adds an extra character to the end of the content string
-			if ( content.slice( - 1 ) !== '=' ) {
+			if ( content.slice( - 1 ) === ',' ) {
 
 				content = content.slice( 0, - 1 );
 


### PR DESCRIPTION
As discussed in #12318, switched the check from 

`if ( content.slice( - 1 ) !== '=' ) {`

to 

`if ( content.slice( - 1 ) === ',' ) {`
