### PR TITLE
GLTFLoader: More robust de-duping of mesh/node names, morph target fixes, etc.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -760,18 +760,36 @@ THREE.GLTFLoader = ( function () {
 
 					}
 
-					if ( uvScaleMap.matrixAutoUpdate === true ) {
+					var offset;
+					var repeat;
 
-						var offset = uvScaleMap.offset;
-						var repeat = uvScaleMap.repeat;
-						var rotation = uvScaleMap.rotation;
-						var center = uvScaleMap.center;
+					if ( uvScaleMap.matrix !== undefined ) {
 
-						uvScaleMap.matrix.setUvTransform( offset.x, offset.y, repeat.x, repeat.y, rotation, center.x, center.y );
+						// > r88.
+
+						if ( uvScaleMap.matrixAutoUpdate === true ) {
+
+							offset = uvScaleMap.offset;
+							repeat = uvScaleMap.repeat;
+							var rotation = uvScaleMap.rotation;
+							var center = uvScaleMap.center;
+
+							uvScaleMap.matrix.setUvTransform( offset.x, offset.y, repeat.x, repeat.y, rotation, center.x, center.y );
+
+						}
+
+						uniforms.uvTransform.value.copy( uvScaleMap.matrix );
+
+					} else {
+
+							// <= r87. Remove when reasonable.
+
+							offset = uvScaleMap.offset;
+							repeat = uvScaleMap.repeat;
+
+							uniforms.offsetRepeat.value.set( offset.x, offset.y, repeat.x, repeat.y );
 
 					}
-
-					uniforms.uvTransform.value.copy( uvScaleMap.matrix );
 
 				}
 


### PR DESCRIPTION
Changes:
- Make uvScaleMap updates backwards-compatible
- Fix error in morph targets if normal attributes are undefined (the frog ROME model broke here)
- Flatten a THREE.Group if it only contains a single Mesh
- Try to eliminate more cases where names might be duplicated, breaking animation. Examples:
  - Parent `node` and child `mesh` share the same name in source glTF
  - Mesh is reused by multiple nodes (see: CesiumMilkTruck)

This fixes all of the ROME examples, although they still require THREE.DoubleSide.

Demo: https://gltf-viewer-experimental.donmccurdy.com/

The demo will print a tree of mesh names coming out of the loader. Examples:

| AnimatedMorphSphere | CesiumMilkTruck |
|--|--|
| ![screen shot 2017-10-09 at 7 02 19 pm](https://user-images.githubusercontent.com/1848368/31366346-516d1b38-ad25-11e7-961e-f2f4457a8626.png) |  ![screen shot 2017-10-09 at 7 07 30 pm](https://user-images.githubusercontent.com/1848368/31366349-52704992-ad25-11e7-8d59-7730079fa409.png) |

- Fixes #12368. Problems with ROME models were related to (1) missing normals in one model, and (2) nodes and meshes sharing names in many models.
- Improves #11944, although there's still more we can do to flatten the output.
- Polly (#12364) still does not work completely; the head disappears at odd intervals. Looks like an animation problem, or some ambiguity in the glTF spec.