### PR TITLE
FBXLoader: switched default material type to Phong

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -261,8 +261,8 @@
 
 		if ( typeof content === 'string' ) {
 
-      // ASCII format sometimes an extra character get added to the end of the content string
-      // TODO: Investigate wht the parser is adding this character
+			// ASCII format sometimes an extra character get added to the end of the content string
+			// TODO: Investigate wht the parser is adding this character
 			if ( content.slice( - 1 ) === ',' ) {
 
 				content = content.slice( 0, - 1 );

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -254,14 +254,15 @@
 
 			default:
 
-				console.warn( 'FBXLoader: No support image type ' + extension );
+				console.warn( 'FBXLoader: Image type "' + extension + '" is not supported.' );
 				return;
 
 		}
 
 		if ( typeof content === 'string' ) {
 
-			// ASCII format sometimes adds an extra character to the end of the content string
+      // ASCII format sometimes an extra character get added to the end of the content string
+      // TODO: Investigate wht the parser is adding this character
 			if ( content.slice( - 1 ) === ',' ) {
 
 				content = content.slice( 0, - 1 );
@@ -457,8 +458,8 @@
 				material = new THREE.MeshLambertMaterial();
 				break;
 			default:
-				console.warn( 'THREE.FBXLoader: No implementation given for material type %s in FBXLoader.js. Defaulting to standard material.', type );
-				material = new THREE.MeshStandardMaterial( { color: 0x3300ff } );
+				console.warn( 'THREE.FBXLoader: unknown material type "%s". Defaulting to MeshPhongMaterial.', type );
+				material = new THREE.MeshPhongMaterial( { color: 0x3300ff } );
 				break;
 
 		}

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -261,8 +261,8 @@
 
 		if ( typeof content === 'string' ) {
 
-			// ASCII format sometimes an extra character get added to the end of the content string
-			// TODO: Investigate wht the parser is adding this character
+			// ASCII format sometimes an extra ',' gets added to the end of the content string
+			// TODO: Investigate why the parser is adding this character
 			if ( content.slice( - 1 ) === ',' ) {
 
 				content = content.slice( 0, - 1 );


### PR DESCRIPTION
See #12361

FBX format only support Lambert and Phong materials, with a strong preference for Phong, so in the case that the material type is unknown it makes more sense to create a Phong material rather than a Standard material. 

Also clarified a couple of comments and console logs