### PR TITLE
ObjectLoader lacking support for some geometries, Docs update

### DIFF
--- a/docs/api/geometries/PolyhedronBufferGeometry.html
+++ b/docs/api/geometries/PolyhedronBufferGeometry.html
@@ -41,10 +41,10 @@ var geometry = new THREE.PolyhedronBufferGeometry( verticesOfCube, indicesOfFace
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Array vertices], [page:Array faces], [page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([page:Array vertices], [page:Array indices], [page:Float radius], [page:Integer detail])</h3>
 		<div>
 		vertices — [page:Array] of points of the form [1,1,1, -1,-1,-1, ... ] <br />
-		faces — [page:Array] of indices that make up the faces of the form [0,1,2, 2,3,0, ... ] <br />
+		indices — [page:Array] of indices that make up the faces of the form [0,1,2, 2,3,0, ... ] <br />
 		radius — [page:Float] - The radius of the final shape <br />
 		detail — [page:Integer] - How many levels to subdivide the geometry. The more detail, the smoother the shape.
 		</div>

--- a/docs/api/geometries/PolyhedronGeometry.html
+++ b/docs/api/geometries/PolyhedronGeometry.html
@@ -39,10 +39,10 @@ var geometry = new THREE.PolyhedronGeometry( verticesOfCube, indicesOfFaces, 6, 
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Array vertices], [page:Array faces], [page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([page:Array vertices], [page:Array indices], [page:Float radius], [page:Integer detail])</h3>
 		<div>
 		vertices — [page:Array] of points of the form [1,1,1, -1,-1,-1, ... ] <br />
-		faces — [page:Array] of indices that make up the faces of the form [0,1,2, 2,3,0, ... ] <br />
+		indices — [page:Array] of indices that make up the faces of the form [0,1,2, 2,3,0, ... ] <br />
 		radius — [page:Float] - The radius of the final shape <br />
 		detail — [page:Integer] - How many levels to subdivide the geometry. The more detail, the smoother the shape.
 		</div>

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -254,9 +254,13 @@ Object.assign( ObjectLoader.prototype, {
 						break;
 
 					case 'DodecahedronGeometry':
+					case 'DodecahedronBufferGeometry':
 					case 'IcosahedronGeometry':
+					case 'IcosahedronBufferGeometry':
 					case 'OctahedronGeometry':
+					case 'OctahedronBufferGeometry':
 					case 'TetrahedronGeometry':
+					case 'TetrahedronBufferGeometry':
 
 						geometry = new Geometries[ data.type ](
 							data.radius,
@@ -314,6 +318,18 @@ Object.assign( ObjectLoader.prototype, {
 							data.segments,
 							data.phiStart,
 							data.phiLength
+						);
+
+						break;
+
+					case 'PolyhedronGeometry':
+					case 'PolyhedronBufferGeometry':
+
+						geometry = new Geometries[ data.type ](
+							data.vertices,
+							data.indices,
+							data.radius,
+							data.details
 						);
 
 						break;


### PR DESCRIPTION
1) Updated the docs for `Polyhedron(Buffer)Geometry`. They still refer to `indices` as `faces`, which was changed in 91ae0eb70abe950b0897449e96694f735d843785.
2) `ObjectLoader` currently lacks support for `PolyhedronGeometry` and `PolyhedronBufferGeometry` as well as the related `DodecahedronBufferGeometry`, `IcosahedronBufferGeometry`, `OctahedronBufferGeometry` and `TetrahedronBufferGeometry` - the non-buffered variants already work.
https://github.com/mrdoob/three.js/blob/67bfa4f92bd1ef301331801d53efd477f2de06ab/src/loaders/ObjectLoader.js#L256-L266
The last time someone touched that bit of code - save for some clean up stuff - was two years ago in fc78eb265a6302db5b6d7532a4e45c10dc37a7f6 when there were barely any `*BufferGeometry` to begin with, so I'm guessing it simply fell thru the cracks. Still, I've split this PR into two commits to make cherry-picking easier in case there is a technical reason to keep `ObjectLoader` this way.