### PR TITLE
remove inline fn in Box3.expandByObject to reduce GC

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -211,46 +211,40 @@ Object.assign( Box3.prototype, {
 
 		var v1 = new Vector3();
 
-		return function expandByObject( object ) {
+		var scope;
 
-			var scope = this;
+		function traverse ( node ) {
 
-			object.updateMatrixWorld( true );
+			var i, l;
 
-			object.traverse( function ( node ) {
+			var geometry = node.geometry;
 
-				var i, l;
+			if ( geometry !== undefined ) {
 
-				var geometry = node.geometry;
+				if ( geometry.isGeometry ) {
 
-				if ( geometry !== undefined ) {
+					var vertices = geometry.vertices;
 
-					if ( geometry.isGeometry ) {
+					for ( i = 0, l = vertices.length; i < l; i ++ ) {
 
-						var vertices = geometry.vertices;
+						v1.copy( vertices[ i ] );
+						v1.applyMatrix4( node.matrixWorld );
 
-						for ( i = 0, l = vertices.length; i < l; i ++ ) {
+						scope.expandByPoint( v1 );
 
-							v1.copy( vertices[ i ] );
-							v1.applyMatrix4( node.matrixWorld );
+					}
+
+				} else if ( geometry.isBufferGeometry ) {
+
+					var attribute = geometry.attributes.position;
+
+					if ( attribute !== undefined ) {
+
+						for ( i = 0, l = attribute.count; i < l; i ++ ) {
+
+							v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
 
 							scope.expandByPoint( v1 );
-
-						}
-
-					} else if ( geometry.isBufferGeometry ) {
-
-						var attribute = geometry.attributes.position;
-
-						if ( attribute !== undefined ) {
-
-							for ( i = 0, l = attribute.count; i < l; i ++ ) {
-
-								v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
-
-								scope.expandByPoint( v1 );
-
-							}
 
 						}
 
@@ -258,7 +252,17 @@ Object.assign( Box3.prototype, {
 
 				}
 
-			} );
+			}
+
+		}
+
+		return function expandByObject( object ) {
+
+			scope = this;
+
+			object.updateMatrixWorld( true );
+
+			object.traverse( traverse );
 
 			return this;
 


### PR DESCRIPTION
If frequently re-calculating AABBs, the memory from the inline function in `Math.Box3.expandFromObject`'s `traverse` causes lots of garbage collection cycles. In my case, over a few seconds, it allocated 20KB of memory.

This PR moves the inline function into the parent scope, and uses a closure to maintain `this` scope on the traverse.

## Before

The function allocates lot of memory.

<img width="1250" alt="screen shot 2017-10-10 at 3 45 00 pm" src="https://user-images.githubusercontent.com/674727/31389971-e3f8f3d4-add2-11e7-9fe7-8e2f005c9668.png">

## After

The function no longer shows up on the frequent memory allocating calls.

<img width="1251" alt="screen shot 2017-10-10 at 3 44 07 pm" src="https://user-images.githubusercontent.com/674727/31389980-e9f2eb28-add2-11e7-9a75-e28538d93b3b.png">
