### PR TITLE
Math: Added epsilon param to .equals() of Vector2/3/4

### DIFF
--- a/docs/api/math/Vector2.html
+++ b/docs/api/math/Vector2.html
@@ -175,8 +175,8 @@
 	  vector and [page:Vector2 v].
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Vector2 v] )</h3>
-		<div>Checks for strict equality of this vector and [page:Vector2 v].</div>
+		<h3>[method:Boolean equals]( [page:Vector2 v], [page:Float epsilon] )</h3>
+		<div>Checks for strict equality of this vector and [page:Vector2 v]. If [page:Float epsilon] is given, the method performs a component-wise compare |x - y| < [page:Float epsilon].</div>
 
 		<h3>[method:Vector2 floor]()</h3>
 		<div>The components of the vector are rounded down to the nearest integer value.</div>

--- a/docs/api/math/Vector3.html
+++ b/docs/api/math/Vector3.html
@@ -205,8 +205,8 @@ var d = a.distanceTo( b );
 		vector and [page:Vector3 v].
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Vector3 v] )</h3>
-		<div>Checks for strict equality of this vector and [page:Vector3 v].</div>
+		<h3>[method:Boolean equals]( [page:Vector3 v], [page:Float epsilon] )</h3>
+		<div>Checks for strict equality of this vector and [page:Vector3 v]. If [page:Float epsilon] is given, the method performs a component-wise compare |x - y| < [page:Float epsilon].</div>
 
 		<h3>[method:Vector3 floor]()</h3>
 		<div>The components of the vector are rounded down to the nearest integer value.</div>

--- a/docs/api/math/Vector4.html
+++ b/docs/api/math/Vector4.html
@@ -151,8 +151,8 @@ var d = a.dot( b );
 		vector and [page:Vector4 v].
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Vector4 v] )</h3>
-		<div>Checks for strict equality of this vector and [page:Vector4 v].</div>
+		<h3>[method:Boolean equals]( [page:Vector4 v], [page:Float epsilon] )</h3>
+		<div>Checks for strict equality of this vector and [page:Vector4 v]. If [page:Float epsilon] is given, the method performs a component-wise compare |x - y| < [page:Float epsilon].</div>
 
 		<h3>[method:Vector4 floor]()</h3>
 		<div>The components of the vector are rounded down to the nearest integer value.</div>

--- a/src/extras/core/PathPrototype.js
+++ b/src/extras/core/PathPrototype.js
@@ -109,7 +109,7 @@ var PathPrototype = Object.assign( Object.create( CurvePath.prototype ), {
 			// if a previous curve is present, attempt to join
 			var firstPoint = curve.getPoint( 0 );
 
-			if ( ! firstPoint.equals( this.currentPoint ) ) {
+			if ( ! firstPoint.equals( this.currentPoint, Number.EPSILON ) ) {
 
 				this.lineTo( firstPoint.x, firstPoint.y );
 

--- a/src/extras/core/PathPrototype.js
+++ b/src/extras/core/PathPrototype.js
@@ -109,7 +109,7 @@ var PathPrototype = Object.assign( Object.create( CurvePath.prototype ), {
 			// if a previous curve is present, attempt to join
 			var firstPoint = curve.getPoint( 0 );
 
-			if ( ! firstPoint.equals( this.currentPoint, Number.EPSILON ) ) {
+			if ( ! firstPoint.equals( this.currentPoint, 0.00001 ) ) {
 
 				this.lineTo( firstPoint.x, firstPoint.y );
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -437,10 +437,7 @@ Object.assign( Vector2.prototype, {
 
 		} else {
 
-			var x = Math.abs( this.x - v.x );
-			var y = Math.abs( this.y - v.y );
-
-			return ( ( x < epsilon ) && ( y < epsilon ) );
+			return ( ( Math.abs( v.x - this.x ) < epsilon ) && ( Math.abs( v.y - this.y ) < epsilon ) );
 
 		}
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -429,11 +429,27 @@ Object.assign( Vector2.prototype, {
 
 	},
 
-	equals: function ( v ) {
+	equals: function () {
 
-		return ( ( v.x === this.x ) && ( v.y === this.y ) );
+		var v1 = new Vector2();
 
-	},
+		return function equals( v, epsilon ) {
+
+			if ( epsilon === undefined ) {
+
+				return ( ( v.x === this.x ) && ( v.y === this.y ) );
+
+			} else {
+
+				v1.subVectors( this, v );
+
+				return ( ( v1.x < epsilon ) && ( v1.y < epsilon ) );
+
+			}
+
+		};
+
+	}(),
 
 	fromArray: function ( array, offset ) {
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -429,27 +429,22 @@ Object.assign( Vector2.prototype, {
 
 	},
 
-	equals: function () {
+	equals: function ( v, epsilon ) {
 
-		var v1 = new Vector2();
+		if ( epsilon === undefined ) {
 
-		return function equals( v, epsilon ) {
+			return ( ( v.x === this.x ) && ( v.y === this.y ) );
 
-			if ( epsilon === undefined ) {
+		} else {
 
-				return ( ( v.x === this.x ) && ( v.y === this.y ) );
+			var x = Math.abs( this.x - v.x );
+			var y = Math.abs( this.y - v.y );
 
-			} else {
+			return ( ( x < epsilon ) && ( y < epsilon ) );
 
-				v1.subVectors( this, v );
+		}
 
-				return ( ( Math.abs( v1.x ) < epsilon ) && ( Math.abs( v1.y ) < epsilon ) );
-
-			}
-
-		};
-
-	}(),
+	},
 
 	fromArray: function ( array, offset ) {
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -443,7 +443,7 @@ Object.assign( Vector2.prototype, {
 
 				v1.subVectors( this, v );
 
-				return ( ( v1.x < epsilon ) && ( v1.y < epsilon ) );
+				return ( ( Math.abs( v1.x ) < epsilon ) && ( Math.abs( v1.y ) < epsilon ) );
 
 			}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -691,11 +691,7 @@ Object.assign( Vector3.prototype, {
 
 		} else {
 
-			var x = Math.abs( this.x - v.x );
-			var y = Math.abs( this.y - v.y );
-			var z = Math.abs( this.z - v.z );
-
-			return ( ( x < epsilon ) && ( y < epsilon ) && ( z < epsilon ) );
+			return ( ( Math.abs( v.x - this.x ) < epsilon ) && ( Math.abs( v.y - this.y ) < epsilon ) && ( Math.abs( v.z - this.z ) < epsilon ) );
 
 		}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -697,7 +697,7 @@ Object.assign( Vector3.prototype, {
 
 				v1.subVectors( this, v );
 
-				return ( ( v1.x < epsilon ) && ( v1.y < epsilon ) && ( v1.z < epsilon ) );
+				return ( ( Math.abs( v1.x ) < epsilon ) && ( Math.abs( v1.y ) < epsilon ) && ( Math.abs( v1.z ) < epsilon ) );
 
 			}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -683,11 +683,27 @@ Object.assign( Vector3.prototype, {
 
 	},
 
-	equals: function ( v ) {
+	equals: function () {
 
-		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
+		var v1 = new Vector3();
 
-	},
+		return function equals( v, epsilon ) {
+
+			if ( epsilon === undefined ) {
+
+				return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
+
+			} else {
+
+				v1.subVectors( this, v );
+
+				return ( ( v1.x < epsilon ) && ( v1.y < epsilon ) && ( v1.z < epsilon ) );
+
+			}
+
+		};
+
+	}(),
 
 	fromArray: function ( array, offset ) {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -683,27 +683,23 @@ Object.assign( Vector3.prototype, {
 
 	},
 
-	equals: function () {
+	equals: function ( v, epsilon ) {
 
-		var v1 = new Vector3();
+		if ( epsilon === undefined ) {
 
-		return function equals( v, epsilon ) {
+			return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
 
-			if ( epsilon === undefined ) {
+		} else {
 
-				return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
+			var x = Math.abs( this.x - v.x );
+			var y = Math.abs( this.y - v.y );
+			var z = Math.abs( this.z - v.z );
 
-			} else {
+			return ( ( x < epsilon ) && ( y < epsilon ) && ( z < epsilon ) );
 
-				v1.subVectors( this, v );
+		}
 
-				return ( ( Math.abs( v1.x ) < epsilon ) && ( Math.abs( v1.y ) < epsilon ) && ( Math.abs( v1.z ) < epsilon ) );
-
-			}
-
-		};
-
-	}(),
+	},
 
 	fromArray: function ( array, offset ) {
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -581,12 +581,7 @@ Object.assign( Vector4.prototype, {
 
 		} else {
 
-			var x = Math.abs( this.x - v.x );
-			var y = Math.abs( this.y - v.y );
-			var z = Math.abs( this.z - v.z );
-			var w = Math.abs( this.w - v.w );
-
-			return ( ( x < epsilon ) && ( y < epsilon ) && ( z < epsilon ) && ( w < epsilon ) );
+			return ( ( Math.abs( v.x - this.x ) < epsilon ) && ( Math.abs( v.y - this.y ) < epsilon ) && ( Math.abs( v.z - this.z ) < epsilon ) && ( Math.abs( v.w - this.w ) < epsilon ) );
 
 		}
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -587,7 +587,7 @@ Object.assign( Vector4.prototype, {
 
 				v1.subVectors( this, v );
 
-				return ( ( v1.x < epsilon ) && ( v1.y < epsilon ) && ( v1.z < epsilon ) && ( v1.w < epsilon ) );
+				return ( ( Math.abs( v1.x ) < epsilon ) && ( Math.abs( v1.y ) < epsilon ) && ( Math.abs( v1.z ) < epsilon ) && ( Math.abs( v1.w ) < epsilon ) );
 
 			}
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -573,27 +573,24 @@ Object.assign( Vector4.prototype, {
 
 	},
 
-	equals: function () {
+	equals: function ( v, epsilon ) {
 
-		var v1 = new Vector4();
+		if ( epsilon === undefined ) {
 
-		return function equals( v, epsilon ) {
+			return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) && ( v.w === this.w ) );
 
-			if ( epsilon === undefined ) {
+		} else {
 
-				return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) && ( v.w === this.w ) );
+			var x = Math.abs( this.x - v.x );
+			var y = Math.abs( this.y - v.y );
+			var z = Math.abs( this.z - v.z );
+			var w = Math.abs( this.w - v.w );
 
-			} else {
+			return ( ( x < epsilon ) && ( y < epsilon ) && ( z < epsilon ) && ( w < epsilon ) );
 
-				v1.subVectors( this, v );
+		}
 
-				return ( ( Math.abs( v1.x ) < epsilon ) && ( Math.abs( v1.y ) < epsilon ) && ( Math.abs( v1.z ) < epsilon ) && ( Math.abs( v1.w ) < epsilon ) );
-
-			}
-
-		};
-
-	}(),
+	},
 
 	fromArray: function ( array, offset ) {
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -573,11 +573,27 @@ Object.assign( Vector4.prototype, {
 
 	},
 
-	equals: function ( v ) {
+	equals: function () {
 
-		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) && ( v.w === this.w ) );
+		var v1 = new Vector4();
 
-	},
+		return function equals( v, epsilon ) {
+
+			if ( epsilon === undefined ) {
+
+				return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) && ( v.w === this.w ) );
+
+			} else {
+
+				v1.subVectors( this, v );
+
+				return ( ( v1.x < epsilon ) && ( v1.y < epsilon ) && ( v1.z < epsilon ) && ( v1.w < epsilon ) );
+
+			}
+
+		};
+
+	}(),
 
 	fromArray: function ( array, offset ) {
 


### PR DESCRIPTION
Solves #12165

This PR might be useful in other cases where strict equality checks lead to bad results because of floating point inaccuracies. PR is backward compatible and does not affect calls of `.equals()` without epsilon parameter.