### PR TITLE
Don't do unneeded stuff if we have no lights

### DIFF
--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -128,7 +128,10 @@ function WebGLLights() {
 	var matrix42 = new Matrix4();
 
 	function setup( lights, shadows, camera ) {
-
+		if(!lights.length) {
+			return;
+		}
+		
 		var r = 0, g = 0, b = 0;
 
 		var directionalLength = 0;


### PR DESCRIPTION
Don't do so much stuff if we have no lights.
In my case for example I render about 5,000 objects (which is an heavy task in itself) and according to the JavaScript Profiler in the Chrome Developer Tools the "setup()" function costs me 6.8ms EACH frame, sure it is called about 5,000 times.
Since I do the lightning completely via shaders and don't have any light object in my scene it is totaly unneeded.