### PR TITLE
OBJLoader2 V2.1.0: New Builder and WorkerSupport features

### DIFF
--- a/docs/examples/loaders/LoaderSupport.html
+++ b/docs/examples/loaders/LoaderSupport.html
@@ -398,10 +398,10 @@
 		<a name="LoaderBase"></a><h1>LoaderBase</h1>
 		<h2>Constructor</h2>
 
-		<h3>LoaderBase( [page:LoaderSupport.ConsoleLogger logger], [page:LoadingManager manager] )</h3>
+		<h3>LoaderBase( [page:LoadingManager manager], [page:LoaderSupport.ConsoleLogger logger] )</h3>
 		<div>
-			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
 			[page:LoadingManager manager] - The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
+			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
 		</div>
 		<div>
 			Base class to be used by loaders.

--- a/docs/examples/loaders/LoaderSupport.html
+++ b/docs/examples/loaders/LoaderSupport.html
@@ -20,7 +20,7 @@
 		[page:LoaderSupport.WorkerRunnerRefImpl]<br>
 		[page:LoaderSupport.WorkerDirector]<br>
 		[page:LoaderSupport.PrepData]<br>
-		[page:LoaderSupport.Commons]<br>
+		[page:LoaderSupport.LoaderBase]<br>
 		[page:LoaderSupport.Callbacks]<br>
 		[page:LoaderSupport.Validator]<br>
 		[page:LoaderSupport.ConsoleLogger]
@@ -54,12 +54,50 @@
 		</div>
 
 
-		<h3>[method:Array buildMeshes] (Object payload)</h3>
+		<h3>[method:Array processPayload] ( Object payload )</h3>
 		<div>
-			[page:Object payload] - Raw mesh description (buffers, params, materials) used to build one to many meshes.
+			[page:Object payload] - Raw Mesh or Material descriptions.
 		</div>
 		<div>
-			Builds one or multiple meshes from the data described in the payload (buffers, params, material info.
+			Delegates processing of the payload (mesh building or material update) to the corresponding functions (BW-compatibility).
+		</div>
+		<br>
+		<br>
+
+
+		<h3>[method:Array buildMeshes] ( Object meshPayload )</h3>
+		<div>
+			[page:Object meshPayload] - Raw mesh description (buffers, params, materials) used to build one to many meshes.
+		</div>
+		<div>
+			Builds one or multiple meshes from the data described in the payload (buffers, params, material info).
+		</div>
+		<br>
+		<br>
+
+
+		<h3>[method:null updateMaterials] ( Object materialPayload )</h3>
+		<div>
+			[page:Object materialPayload] - Material update instructions
+		</div>
+		<div>
+			Updates the materials with contained material objects (sync) or from alteration instructions (async).
+		</div>
+		<br>
+		<br>
+
+
+		<h3>[method:Object getMaterialsJSON] ()</h3>
+		<div>
+			Returns the mapping object of material name and corresponding jsonified material.
+		</div>
+		<br>
+		<br>
+
+
+		<h3>[method:Object getMaterials] ()</h3>
+		<div>
+			Returns the mapping object of material name and corresponding material.
 		</div>
 		<br>
 		<br>
@@ -118,10 +156,12 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null validate] ( [page:Function functionCodeBuilder], [page:Boolean forceWorkerReload], [page:LoaderSupport.WorkerRunnerRefImpl runnerImpl] )</h3>
+		<h3>[method:null validate] ( [page:Function functionCodeBuilder], [page:Boolean forceWorkerReload], Array of [page:String libLocations], [page:String libPath], [page:LoaderSupport.WorkerRunnerRefImpl runnerImpl] )</h3>
 		<div>
-			[page:Function functionCodeBuilder] - Function that is invoked with funcBuildObject and funcBuildSingelton that allows stringification of objects and singletons.
-			[page:Boolean forceWorkerReload] - Force re-build of the worker code.
+			[page:Function functionCodeBuilder] - Function that is invoked with funcBuildObject and funcBuildSingelton that allows stringification of objects and singletons.<br>
+			[page:Boolean forceWorkerReload] - Force re-build of the worker code.<br>
+			Array of [page:String libLocations] - URL of libraries that shall be added to worker code relative to libPath.<br>
+			[page:String libPath] - Base path used for loading libraries.<br>
 			[page:LoaderSupport.WorkerRunnerRefImpl runnerImpl] - The default worker parser wrapper implementation (communication and execution). An extended class could be passed here.
 		</div>
 		<div>
@@ -146,7 +186,7 @@
 
 		<h3>[method:null setCallbacks] ( [page:Function builder], [page:Function onLoad] )</h3>
 		<div>
-			[page:Function builder] - The builder function. Default is [page:LoaderSupport.Builder].
+			[page:Function builder] - The builder function. Default is [page:LoaderSupport.Builder].<br>
 			[page:Function onLoad] - The function that is called when parsing is complete.
 		</div>
 		<div>
@@ -178,7 +218,7 @@
 
 		<h3>[method:null applyProperties] ( [page:Object parser], [page:Object params] )</h3>
 		<div>
-			[page:Object parser] - The parser instance
+			[page:Object parser] - The parser instance<br>
 			[page:Object params] - The parameter object
 		</div>
 		<div>
@@ -355,10 +395,10 @@
 		<br>
 
 
-		<a name="Commons"></a><h1>Commons</h1>
+		<a name="LoaderBase"></a><h1>LoaderBase</h1>
 		<h2>Constructor</h2>
 
-		<h3>Commons( [page:LoaderSupport.ConsoleLogger logger], [page:LoadingManager manager] )</h3>
+		<h3>LoaderBase( [page:LoaderSupport.ConsoleLogger logger], [page:LoadingManager manager] )</h3>
 		<div>
 			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
 			[page:LoadingManager manager] - The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].

--- a/docs/examples/loaders/OBJLoader2.html
+++ b/docs/examples/loaders/OBJLoader2.html
@@ -12,10 +12,10 @@
 		<h1>[name]</h1>
 
 		<div class="desc">A loader for loading a <em>.obj</em> resource. <br />
-		The <a href="https://en.wikipedia.org/wiki/Wavefront_.obj_file">OBJ file format</a> is a simple data-format 
-		that represents 3D geometry in a human redeable format as, the position of each vertex, the UV position of 
-		each texture coordinate vertex, vertex normals, and the faces that make each polygon defined as a list of 
-		vertices, and texture vertices.
+			The <a href="https://en.wikipedia.org/wiki/Wavefront_.obj_file">OBJ file format</a> is a simple data-format
+			that represents 3D geometry in a human redeable format as, the position of each vertex, the UV position of
+			each texture coordinate vertex, vertex normals, and the faces that make each polygon defined as a list of
+			vertices, and texture vertices.
 		</div>
 
 		<h2>Examples</h2>
@@ -40,9 +40,10 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [page:LoadingManager manager], [page:LoaderSupport.ConsoleLogger logger] )</h3>
 		<div>
 			[page:LoadingManager manager] - The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
+			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
 		</div>
 		<div>
 			Use [name] to load OBJ data from files or to parse OBJ data from arraybuffer or text.
@@ -73,7 +74,7 @@
 		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError], [page:Function onMeshAlter], [page:boolean useAsync] )</h3>
 		<div>
 			[page:String url] - A string containing the path/URL of the <em>.obj</em> file.<br>
-			[page:Function onLoad] - (optional) A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br>
+			[page:Function onLoad] - A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br>
 			[page:Function onProgress] - (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br>
 			[page:Function onError] - (optional) A function to be called if an error occurrs during loading. The function receives the error as an argument.<br>
 			[page:Function onMeshAlter] - (optional) A function to be called after a new mesh raw data becomes available for alteration.<br>

--- a/examples/js/loaders/LoaderSupport.js
+++ b/examples/js/loaders/LoaderSupport.js
@@ -714,17 +714,17 @@ THREE.LoaderSupport.Builder = (function () {
  * Base class to be used by loaders.
  * @class
  *
- * @param {THREE.LoaderSupport.ConsoleLogger} logger logger to be used
  * @param {THREE.DefaultLoadingManager} [manager] The loadingManager for the loader to use. Default is {@link THREE.DefaultLoadingManager}
+ * @param {THREE.LoaderSupport.ConsoleLogger} logger logger to be used
  */
 THREE.LoaderSupport.LoaderBase = (function () {
 
 	var Validator = THREE.LoaderSupport.Validator;
 	var ConsoleLogger = THREE.LoaderSupport.ConsoleLogger;
 
-	function LoaderBase( logger, manager ) {
-		this.logger = Validator.verifyInput( logger, new ConsoleLogger() );
+	function LoaderBase( manager, logger ) {
 		this.manager = Validator.verifyInput( manager, THREE.DefaultLoadingManager );
+		this.logger = Validator.verifyInput( logger, new ConsoleLogger() );
 
 		this.modelName = '';
 		this.instanceNo = 0;
@@ -1429,7 +1429,7 @@ THREE.LoaderSupport.WorkerDirector = (function () {
 	WorkerDirector.prototype._buildLoader = function ( instanceNo ) {
 		var classDef = this.workerDescription.classDef;
 		var loader = Object.create( classDef.prototype );
-		this.workerDescription.classDef.call( loader, this.logger );
+		this.workerDescription.classDef.call( loader, null, this.logger );
 
 		// verify that all required functions are implemented
 		if ( ! loader.hasOwnProperty( 'instanceNo' ) ) throw classDef.name + ' has no property "instanceNo".';

--- a/examples/js/loaders/OBJLoader2.js
+++ b/examples/js/loaders/OBJLoader2.js
@@ -12,6 +12,7 @@ if ( THREE.OBJLoader2 === undefined ) { THREE.OBJLoader2 = {} }
  * @class
  *
  * @param {THREE.DefaultLoadingManager} [manager] The loadingManager for the loader to use. Default is {@link THREE.DefaultLoadingManager}
+ * @param {THREE.LoaderSupport.ConsoleLogger} logger logger to be used
  */
 THREE.OBJLoader2 = (function () {
 
@@ -23,8 +24,8 @@ THREE.OBJLoader2 = (function () {
 	OBJLoader2.prototype = Object.create( THREE.LoaderSupport.LoaderBase.prototype );
 	OBJLoader2.prototype.constructor = OBJLoader2;
 
-	function OBJLoader2( logger, manager ) {
-		THREE.LoaderSupport.LoaderBase.call( this, logger, manager );
+	function OBJLoader2( manager, logger ) {
+		THREE.LoaderSupport.LoaderBase.call( this, manager, logger );
 		this.logger.logInfo( 'Using THREE.OBJLoader2 version: ' + OBJLOADER2_VERSION );
 
 		this.materialPerSmoothingGroup = false;
@@ -45,15 +46,15 @@ THREE.OBJLoader2 = (function () {
 	};
 
 	/**
-	 * Use this convenient method to load an OBJ file at the given URL. Per default the fileLoader uses an arraybuffer.
+	 * Use this convenient method to load an OBJ file at the given URL. By default the fileLoader uses an arraybuffer.
 	 * @memberOf THREE.OBJLoader2
 	 *
-	 * @param {string} url URL of the file to load
-	 * @param {callback} onLoad Called after loading was successfully completed
-	 * @param {callback} onProgress Called to report progress of loading. The argument will be the XMLHttpRequest instance, which contains {integer total} and {integer loaded} bytes.
-	 * @param {callback} onError Called after an error occurred during loading
-	 * @param {callback} onMeshAlter Called after a new mesh raw data becomes available to allow alteration
-	 * @param {boolean} useAsync If true uses async loading with worker, if false loads data synchronously
+	 * @param {string}  url A string containing the path/URL of the .obj file.
+	 * @param {callback} onLoad A function to be called after loading is successfully completed. The function receives loaded Object3D as an argument.
+	 * @param {callback} [onProgress] A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains total and Integer bytes.
+	 * @param {callback} [onError] A function to be called if an error occurs during loading. The function receives the error as an argument.
+	 * @param {callback} [onMeshAlter] A function to be called after a new mesh raw data becomes available for alteration.
+	 * @param {boolean} [useAsync] If true, uses async loading with worker, if false loads data synchronously.
 	 */
 	OBJLoader2.prototype.load = function ( url, onLoad, onProgress, onError, onMeshAlter, useAsync ) {
 		var scope = this;

--- a/examples/webgl_loader_obj2_meshspray.html
+++ b/examples/webgl_loader_obj2_meshspray.html
@@ -91,8 +91,8 @@
 				MeshSpray.prototype = Object.create( THREE.LoaderSupport.LoaderBase.prototype );
 				MeshSpray.prototype.constructor = MeshSpray;
 
-				function MeshSpray( manager ) {
-					THREE.LoaderSupport.LoaderBase.call( this, manager );
+				function MeshSpray( manager, logger ) {
+					THREE.LoaderSupport.LoaderBase.call( this, manager, logger );
 					this.workerSupport = null;
 					this.logger = new ConsoleLogger();
 				};

--- a/examples/webgl_loader_obj2_meshspray.html
+++ b/examples/webgl_loader_obj2_meshspray.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>Mesh Spray - Worker based mesh spray</title>
+		<title>three.js webgl - Mesh Spray</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 
@@ -88,11 +88,11 @@
 				var Validator = THREE.LoaderSupport.Validator;
 				var ConsoleLogger = THREE.LoaderSupport.ConsoleLogger;
 
-				MeshSpray.prototype = Object.create( THREE.LoaderSupport.Commons.prototype );
+				MeshSpray.prototype = Object.create( THREE.LoaderSupport.LoaderBase.prototype );
 				MeshSpray.prototype.constructor = MeshSpray;
 
 				function MeshSpray( manager ) {
-					THREE.LoaderSupport.Commons.call( this, manager );
+					THREE.LoaderSupport.LoaderBase.call( this, manager );
 					this.workerSupport = null;
 					this.logger = new ConsoleLogger();
 				};
@@ -116,7 +116,7 @@
 
 					var scope = this;
 					var scopeBuilderFunc = function ( payload ) {
-						var meshes = scope.builder.buildMeshes( payload );
+						var meshes = scope.builder.processPayload( payload );
 						var mesh;
 						for ( var i in meshes ) {
 							mesh = meshes[ i ];
@@ -148,24 +148,23 @@
 
 						return workerCode;
 					};
-					this.workerSupport.validate( buildCode, false );
+					var libs2Load = [ 'build/three.min.js' ];
+					this.workerSupport.validate( buildCode, false, libs2Load, '../' );
 					this.workerSupport.setCallbacks( scopeBuilderFunc, scopeFuncComplete );
 					this.workerSupport.run(
 						{
 							cmd: 'run',
 							params: {
-								debug: this.debug,
-								enableLogging: this.logger.enabled,
 								dimension: prepData.dimension,
 								quantity: prepData.quantity,
 								globalObjectCount: prepData.globalObjectCount
 							},
+							materials: {
+								serializedMaterials: this.builder.getMaterialsJSON()
+							},
 							logger: {
 								debug: this.logger.debug,
 								enabled: this.logger.enabled
-							},
-							materials: {
-								materialNames: this.builder.materialNames
 							},
 							buffers: {
 								input: null
@@ -185,21 +184,10 @@
 						this.quantity = 1;
 						this.callbackBuilder = null;
 						this.logger = logger;
+						this.serializedMaterials = null;
 					};
 
 					Parser.prototype.parse = function () {
-						var materialDescription;
-						var materialDescriptions = [];
-						var materialGroups = [];
-
-						materialDescription = {
-							name: 'Gen',
-							flat: false,
-							vertexColors: true,
-							default: true
-						};
-						materialDescriptions.push( materialDescription );
-
 						var baseTriangle = [ 1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 0.0, -1.0, 1.0 ];
 						var vertices = [];
 						var colors = [];
@@ -263,6 +251,30 @@
 
 						}
 
+						/*
+						 * This demonstrates the usage of embedded three.js in the worker blob and
+						 * the serialization of materials back to the Builder outside the worker.
+						 *
+						 * This is not the most effective way, but outlining possibilities
+						 */
+						var materialName = 'vertexColorMaterial_double';
+						var vertexColorMaterialJson = this.serializedMaterials[ 'vertexColorMaterial' ];
+						var loader = new THREE.MaterialLoader();
+
+						var vertexColorMaterialDouble = loader.parse( vertexColorMaterialJson );
+						vertexColorMaterialDouble.name = materialName;
+						vertexColorMaterialDouble.side = THREE.DoubleSide;
+
+						var newSerializedMaterials = {};
+						newSerializedMaterials[ materialName ] = vertexColorMaterialDouble.toJSON();
+						var payload = {
+							cmd: 'materialData',
+							materials: {
+								serializedMaterials: newSerializedMaterials
+							}
+						};
+						this.callbackBuilder( payload );
+
 						this.globalObjectCount++;
 						this.callbackBuilder(
 							{
@@ -275,8 +287,8 @@
 								},
 								materials: {
 									multiMaterial: false,
-									materialDescriptions: materialDescriptions,
-									materialGroups: materialGroups
+									materialNames: [ materialName ],
+									materialGroups: []
 								},
 								buffers: {
 									vertices: vertexFA,
@@ -297,13 +309,20 @@
 					return Parser;
 				})();
 
+
+				Parser.prototype.setSerializedMaterials = function ( serializedMaterials ) {
+					if ( Validator.isValid( serializedMaterials ) ) {
+
+						this.serializedMaterials = serializedMaterials;
+
+					}
+				};
+
 				return MeshSpray;
 
 			})();
 
 			var MeshSprayApp = (function () {
-
-				var Validator = THREE.LoaderSupport.Validator;
 
 				function MeshSprayApp( elementToBindTo ) {
 					this.renderer = null;

--- a/examples/webgl_loader_obj2_run_director.html
+++ b/examples/webgl_loader_obj2_run_director.html
@@ -111,9 +111,9 @@
 					this.camera = null;
 					this.cameraTarget = this.cameraDefaults.posCameraTarget;
 
-					var logger = new THREE.LoaderSupport.ConsoleLogger();
-					logger.setEnabled( false );
-					this.workerDirector = new THREE.LoaderSupport.WorkerDirector( THREE.OBJLoader2, logger  );
+					this.logger = new THREE.LoaderSupport.ConsoleLogger();
+					this.logger.setEnabled( false );
+					this.workerDirector = new THREE.LoaderSupport.WorkerDirector( THREE.OBJLoader2, this.logger  );
 					this.workerDirector.setCrossOrigin( 'anonymous' );
 
 					this.controls = null;
@@ -199,7 +199,7 @@
 					if ( Validator.isValid( content ) && Validator.isValid( content.detail ) ) output = content.detail.text;
 
 					output = Validator.verifyInput( output, '' );
-					console.log( 'Progress:\n\t' + output.replace(/\<br\>/g, '\n\t' ) );
+					this.logger.logInfo( 'Progress:\n\t' + output.replace(/\<br\>/g, '\n\t' ) );
 					document.getElementById( 'feedback' ).innerHTML = output;
 				};
 
@@ -234,7 +234,7 @@
 						scope.allAssets.push( event.detail.loaderRootNode );
 
 						var msg = 'Worker #' + instanceNo + ': Completed loading: ' + event.detail.modelName + ' (#' + scope.workerDirector.objectsCompleted + ')';
-						console.log( msg );
+						scope.logger.logInfo( msg );
 						scope.feedbackArray[ instanceNo ] = msg;
 						scope._reportProgress( scope.feedbackArray.join( '\<br\>' ) );
 
@@ -247,7 +247,7 @@
 
 						if ( scope.reportDonwload[ instanceNo ] ) {
 							var msg = 'Worker #' + instanceNo + ': ' + text;
-							console.log( msg );
+							scope.logger.logInfo( msg );
 
 							scope.feedbackArray[ instanceNo ] = msg;
 							scope._reportProgress( scope.feedbackArray.join( '\<br\>' ) );
@@ -279,7 +279,7 @@
 					callbacks.setCallbackOnMeshAlter( callbackMeshAlter );
 
 					this.workerDirector.prepareWorkers( callbacks, maxQueueSize, maxWebWorkers );
-					console.log( 'Configuring WWManager with queue size ' + this.workerDirector.getMaxQueueSize() + ' and ' + this.workerDirector.getMaxWebWorkers() + ' workers.' );
+					this.logger.logInfo( 'Configuring WWManager with queue size ' + this.workerDirector.getMaxQueueSize() + ' and ' + this.workerDirector.getMaxWebWorkers() + ' workers.' );
 
 					var modelPrepDatas = [];
 					prepData = new THREE.LoaderSupport.PrepData( 'male02' );
@@ -349,7 +349,7 @@
 
 							if ( storedObject3d === object3d ) return;
 
-							console.log( 'Removing ' + object3d.name );
+							scope.logger.logInfo( 'Removing ' + object3d.name );
 							scope.scene.remove( object3d );
 
 							if ( object3d.hasOwnProperty( 'geometry' ) ) object3d.geometry.dispose();


### PR DESCRIPTION
Hi @mrdoob,

finally, Material handling is properly done in the `Builder`! This was the last missing feature on the original merge request #12048.
Another, really cool things is that `WorkerSupport` provides the means to integrated any file based resource (js library like three.js) into the Worker Blob. 
Don't know how far of R88 is, but having this on board would be superb. I changed the order within LoaderSupport.js (Builder and LoaderBase moved), therefore changes appear greater than they really are.

**List of changes:**
- Builder enhancements:
  - Materials can be added to it as regular objects, as jsonified objects (e.g. from worker) and as clone instruction (map of property and value)
  - Separated mesh processing from material processing
  - Builder no longer defines default materials. This is no the responsibility of the user (loader)
- WorkerSupport is now **able to load arbitrary js files into Blob** used to create the Worker (as exemplary shown and used in MeshSpray)
- `THREE.LoaderSupport.Commons` has been renamed to `THREE.LoaderSupport.LoaderBase`.
- Updated documentation
