### PR TITLE
CurvePath: Remove factory methods

### DIFF
--- a/docs/api/core/BufferGeometry.html
+++ b/docs/api/core/BufferGeometry.html
@@ -316,6 +316,9 @@
 		<h3>[method:BufferGeometry setFromObject] ( [page:Object3D object] )</h3>
 		<div>Sets the attributes for this BufferGeometry from an [page:Object3D].</div>
 
+		<h3>[method:BufferGeometry setFromPoints] ( [page:Array points] )</h3>
+		<div>Sets the attributes for this BufferGeometry from an array of points.</div>
+
 		<h3>[method:Object toJSON]()</h3>
 		<div>Returns a JSON object representation of the BufferGeometry.</div>
 

--- a/docs/api/core/Geometry.html
+++ b/docs/api/core/Geometry.html
@@ -315,6 +315,9 @@
 	        Use [page:Object3D.rotation] for typical real-time mesh rotation.
 		</div>
 
+		<h3>[method:Geometry setFromPoints] ( [page:Array points] )</h3>
+		<div>Sets the vertices for this Geometry from an array of points.</div>
+
 		<h3>[method:null sortFacesByMaterialIndex] (  )</h3>
 		<div>
 		Sorts the faces array according to material index. For complex geometries with several materials,

--- a/docs/api/extras/core/CurvePath.html
+++ b/docs/api/extras/core/CurvePath.html
@@ -49,29 +49,6 @@
 		<h3>[method:null closePath]()</h3>
 		<div>Adds a [page:LineCurve lineCurve] to close the path.</div>
 
-		<h3>[method:Geometry createGeometry]( [page:Vector3 points] )</h3>
-		<div>
-		points -- An array of [page:Vector3 Vector3s]<br /><br />
-
-		Creates a geometry from points
-		</div>
-
-		<h3>[method:Geometry createPointsGeometry]( [page:Integer divisions] )</h3>
-		<div>
-		divisions -- How many segments to create. Defaults to *12*.<br /><br />
-
-		Creates a [page:Geometry] object comprised of [page:Vector3 Vector3s], for example
-		to be used with [page:Line] or [page:Points]. Uses [page:Curve.getPoints]() for the division.
-		</div>
-
-		<h3>[method:Geometry createSpacedPointsGeometry]( [page:Integer divisions] )</h3>
-		<div>
-		divisions -- How many segments to create. Defaults to *12*.<br /><br />
-
-		Creates a [page:Geometry] object comprised of [page:Vector3]s that are equidistant, for example
-		to be used with [page:Line] or [page:Points].	Uses [page:Curve.getSpacedPoints]() for the division.
-		</div>
-
 		<h3>[method:Float getCurveLengths]()</h3>
 		<div>Adds together the lengths of the curves in the [page:.curves] array.</div>
 

--- a/docs/api/extras/curves/CatmullRomCurve3.html
+++ b/docs/api/extras/curves/CatmullRomCurve3.html
@@ -27,8 +27,8 @@ var curve = new THREE.CatmullRomCurve3( [
 	new THREE.Vector3( 10, 0, 10 )
 ] );
 
-var geometry = new THREE.Geometry();
-geometry.vertices = curve.getPoints( 50 );
+var points = curve.getPoints( 50 );
+var geometry = new THREE.BufferGeometry().setFromPoints( points );
 
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 

--- a/docs/api/extras/curves/CubicBezierCurve.html
+++ b/docs/api/extras/curves/CubicBezierCurve.html
@@ -28,17 +28,8 @@ var curve = new THREE.CubicBezierCurve(
 	new THREE.Vector2( 10, 0, 0 )
 );
 
-var path = new THREE.Path( curve.getPoints( 50 ) );
-
-var geometry = new THREE.Geometry();
 var points = curve.getPoints( 50 );
-
-for ( var i = 0, l = points.length; i < l; i ++ ) {
-
-	var point = points[ i ];
-	geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
-
-}
+var geometry = new THREE.BufferGeometry().setFromPoints( points );
 
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 

--- a/docs/api/extras/curves/CubicBezierCurve.html
+++ b/docs/api/extras/curves/CubicBezierCurve.html
@@ -30,7 +30,16 @@ var curve = new THREE.CubicBezierCurve(
 
 var path = new THREE.Path( curve.getPoints( 50 ) );
 
-var geometry = path.createPointsGeometry( 50 );
+var geometry = new THREE.Geometry();
+var points = curve.getPoints( 50 );
+
+for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+	var point = points[ i ];
+	geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
+
+}
+
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 
 // Create the final object to add to the scene

--- a/docs/api/extras/curves/CubicBezierCurve3.html
+++ b/docs/api/extras/curves/CubicBezierCurve3.html
@@ -28,8 +28,8 @@ var curve = new THREE.CubicBezierCurve3(
 	new THREE.Vector3( 10, 0, 0 )
 );
 
-var geometry = new THREE.Geometry();
-geometry.vertices = curve.getPoints( 50 );
+var points = curve.getPoints( 50 );
+var geometry = new THREE.BufferGeometry().setFromPoints( points );
 
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 

--- a/docs/api/extras/curves/EllipseCurve.html
+++ b/docs/api/extras/curves/EllipseCurve.html
@@ -28,15 +28,9 @@ var curve = new THREE.EllipseCurve(
 	0                 // aRotation
 );
 
-var geometry = new THREE.Geometry();
 var points = curve.getPoints( 50 );
+var geometry = new THREE.BufferGeometry().setFromPoints( points );
 
-for ( var i = 0, l = points.length; i < l; i ++ ) {
-
-	var point = points[ i ];
-	geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
-
-}
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 
 // Create the final object to add to the scene

--- a/docs/api/extras/curves/EllipseCurve.html
+++ b/docs/api/extras/curves/EllipseCurve.html
@@ -28,8 +28,15 @@ var curve = new THREE.EllipseCurve(
 	0                 // aRotation
 );
 
-var path = new THREE.Path( curve.getPoints( 50 ) );
-var geometry = path.createPointsGeometry( 50 );
+var geometry = new THREE.Geometry();
+var points = curve.getPoints( 50 );
+
+for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+	var point = points[ i ];
+	geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
+
+}
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 
 // Create the final object to add to the scene

--- a/docs/api/extras/curves/QuadraticBezierCurve.html
+++ b/docs/api/extras/curves/QuadraticBezierCurve.html
@@ -27,9 +27,15 @@ var curve = new THREE.QuadraticBezierCurve(
 	new THREE.Vector2( 10, 0 )
 );
 
-var path = new THREE.Path( curve.getPoints( 50 ) );
+var geometry = new THREE.Geometry();
+var points = curve.getPoints( 50 );
 
-var geometry = path.createPointsGeometry( 50 );
+for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+	var point = points[ i ];
+	geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
+
+}
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 
 //Create the final object to add to the scene

--- a/docs/api/extras/curves/QuadraticBezierCurve.html
+++ b/docs/api/extras/curves/QuadraticBezierCurve.html
@@ -27,15 +27,9 @@ var curve = new THREE.QuadraticBezierCurve(
 	new THREE.Vector2( 10, 0 )
 );
 
-var geometry = new THREE.Geometry();
 var points = curve.getPoints( 50 );
+var geometry = new THREE.BufferGeometry().setFromPoints( points );
 
-for ( var i = 0, l = points.length; i < l; i ++ ) {
-
-	var point = points[ i ];
-	geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
-
-}
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 
 //Create the final object to add to the scene

--- a/docs/api/extras/curves/QuadraticBezierCurve3.html
+++ b/docs/api/extras/curves/QuadraticBezierCurve3.html
@@ -27,8 +27,8 @@ var curve = new THREE.QuadraticBezierCurve3(
 	new THREE.Vector3( 10, 0, 0 )
 );
 
-var geometry = new THREE.Geometry();
-geometry.vertices = curve.getPoints( 50 );
+var points = curve.getPoints( 50 );
+var geometry = new THREE.BufferGeometry().setFromPoints( points );
 
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 

--- a/docs/api/extras/curves/SplineCurve.html
+++ b/docs/api/extras/curves/SplineCurve.html
@@ -29,15 +29,9 @@ var curve = new THREE.SplineCurve( [
 	new THREE.Vector2( 10, 0 )
 ] );
 
-var geometry = new THREE.Geometry();
 var points = curve.getPoints( 50 );
+var geometry = new THREE.BufferGeometry().setFromPoints( points );
 
-for ( var i = 0, l = points.length; i < l; i ++ ) {
-
-	var point = points[ i ];
-	geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
-
-}
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 
 // Create the final object to add to the scene

--- a/docs/api/extras/curves/SplineCurve.html
+++ b/docs/api/extras/curves/SplineCurve.html
@@ -29,9 +29,15 @@ var curve = new THREE.SplineCurve( [
 	new THREE.Vector2( 10, 0 )
 ] );
 
-var path = new THREE.Path( curve.getPoints( 50 ) );
+var geometry = new THREE.Geometry();
+var points = curve.getPoints( 50 );
 
-var geometry = path.createPointsGeometry( 50 );
+for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+	var point = points[ i ];
+	geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
+
+}
 var material = new THREE.LineBasicMaterial( { color : 0xff0000 } );
 
 // Create the final object to add to the scene

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -924,32 +924,8 @@
           "!type": "boolean",
           "!doc": "todo"
         },
-        "getWrapPoints": {
-          "!type": "fn(oldPts: todo, path: todo) -> todo",
-          "!doc": "todo"
-        },
-        "createPointsGeometry": {
-          "!type": "fn(divisions: todo) -> todo",
-          "!doc": "todo"
-        },
-        "addWrapPath": {
-          "!type": "fn(bendpath: todo) -> todo",
-          "!doc": "todo"
-        },
-        "createGeometry": {
-          "!type": "fn(points: todo) -> todo",
-          "!doc": "todo"
-        },
         "add": {
           "!type": "fn(curve: todo) -> todo",
-          "!doc": "todo"
-        },
-        "getTransformedSpacedPoints": {
-          "!type": "fn(segments: todo, bends: todo) -> todo",
-          "!doc": "todo"
-        },
-        "createSpacedPointsGeometry": {
-          "!type": "fn(divisions: todo) -> todo",
           "!doc": "todo"
         },
         "closePath": {
@@ -961,14 +937,6 @@
           "!doc": "todo"
         },
         "getCurveLengths": {
-          "!type": "fn() -> todo",
-          "!doc": "todo"
-        },
-        "getTransformedPoints": {
-          "!type": "fn(segments: todo, bends: todo) -> todo",
-          "!doc": "todo"
-        },
-        "checkConnection": {
           "!type": "fn() -> todo",
           "!doc": "todo"
         }

--- a/examples/canvas_geometry_shapes.html
+++ b/examples/canvas_geometry_shapes.html
@@ -82,15 +82,8 @@
 
 					// line
 
-					var geometry = new THREE.Geometry();
 					var points = shape.getPoints();
-
-					for ( var i = 0, l = points.length; i < l; i ++ ) {
-
-						var point = points[ i ];
-						geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
-
-					}
+					var geometry = new THREE.Geometry().setFromPoints( points );
 
 					var material = new THREE.LineBasicMaterial( { linewidth: 10, color: 0x333333, transparent: true } );
 

--- a/examples/canvas_geometry_shapes.html
+++ b/examples/canvas_geometry_shapes.html
@@ -82,8 +82,15 @@
 
 					// line
 
-					var geometry = shape.createPointsGeometry();
-					geometry.vertices.push( geometry.vertices[ 0 ].clone() );
+					var geometry = new THREE.Geometry();
+					var points = shape.getPoints();
+
+					for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+						var point = points[ i ];
+						geometry.vertices.push( new THREE.Vector3( point.x, point.y, 0 ) );
+
+					}
 
 					var material = new THREE.LineBasicMaterial( { linewidth: 10, color: 0x333333, transparent: true } );
 

--- a/examples/webgl_geometry_shapes.html
+++ b/examples/webgl_geometry_shapes.html
@@ -111,15 +111,44 @@
 
 				function addLineShape( shape, color, x, y, z, rx, ry, rz, s ) {
 
+					var geometryPoints = new THREE.BufferGeometry();
+					var geometrySpacedPoints = new THREE.BufferGeometry();
+
 					// lines
 
 					shape.autoClose = true;
-					var points = shape.createPointsGeometry();
-					var spacedPoints = shape.createSpacedPointsGeometry( 50 );
+					var points = shape.getPoints();
+					var spacedPoints = shape.getSpacedPoints( 50 );
+
+					// points
+
+					var position = [];
+
+					for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+						var point = points[ i ];
+						position.push( point.x, point.y, 0 );
+
+					}
+
+					geometryPoints.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
+
+					// spaced points
+
+					position = [];
+
+					for ( var i = 0, l = spacedPoints.length; i < l; i ++ ) {
+
+						var point = spacedPoints[ i ];
+						position.push( point.x, point.y, 0 );
+
+					}
+
+					geometrySpacedPoints.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
 
 					// solid line
 
-					var line = new THREE.Line( points, new THREE.LineBasicMaterial( { color: color, linewidth: 3 } ) );
+					var line = new THREE.Line( geometryPoints, new THREE.LineBasicMaterial( { color: color, linewidth: 3 } ) );
 					line.position.set( x, y, z - 25 );
 					line.rotation.set( rx, ry, rz );
 					line.scale.set( s, s, s );
@@ -127,7 +156,7 @@
 
 					// line from equidistance sampled points
 
-					var line = new THREE.Line( spacedPoints, new THREE.LineBasicMaterial( { color: color, linewidth: 3 } ) );
+					var line = new THREE.Line( geometrySpacedPoints, new THREE.LineBasicMaterial( { color: color, linewidth: 3 } ) );
 					line.position.set( x, y, z + 25 );
 					line.rotation.set( rx, ry, rz );
 					line.scale.set( s, s, s );
@@ -135,7 +164,7 @@
 
 					// vertices from real points
 
-					var particles = new THREE.Points( points, new THREE.PointsMaterial( { color: color, size: 4 } ) );
+					var particles = new THREE.Points( geometryPoints, new THREE.PointsMaterial( { color: color, size: 4 } ) );
 					particles.position.set( x, y, z + 75 );
 					particles.rotation.set( rx, ry, rz );
 					particles.scale.set( s, s, s );
@@ -143,7 +172,7 @@
 
 					// equidistance sampled points
 
-					var particles = new THREE.Points( spacedPoints, new THREE.PointsMaterial( { color: color, size: 4 } ) );
+					var particles = new THREE.Points( geometrySpacedPoints, new THREE.PointsMaterial( { color: color, size: 4 } ) );
 					particles.position.set( x, y, z + 125 );
 					particles.rotation.set( rx, ry, rz );
 					particles.scale.set( s, s, s );

--- a/examples/webgl_geometry_shapes.html
+++ b/examples/webgl_geometry_shapes.html
@@ -118,12 +118,9 @@
 					var points = shape.getPoints();
 					var spacedPoints = shape.getSpacedPoints( 50 );
 
-					var geometryPoints = new THREE.BufferGeometry();
-					geometryPoints.setFromPoints( points );
+					var geometryPoints = new THREE.BufferGeometry().setFromPoints( points );
+					var geometrySpacedPoints = new THREE.BufferGeometry().setFromPoints( spacedPoints );
 
-					var geometrySpacedPoints = new THREE.BufferGeometry();
-					geometrySpacedPoints.setFromPoints( spacedPoints );
-					
 					// solid line
 
 					var line = new THREE.Line( geometryPoints, new THREE.LineBasicMaterial( { color: color, linewidth: 3 } ) );

--- a/examples/webgl_geometry_shapes.html
+++ b/examples/webgl_geometry_shapes.html
@@ -111,41 +111,19 @@
 
 				function addLineShape( shape, color, x, y, z, rx, ry, rz, s ) {
 
-					var geometryPoints = new THREE.BufferGeometry();
-					var geometrySpacedPoints = new THREE.BufferGeometry();
-
 					// lines
 
 					shape.autoClose = true;
+
 					var points = shape.getPoints();
 					var spacedPoints = shape.getSpacedPoints( 50 );
 
-					// points
+					var geometryPoints = new THREE.BufferGeometry();
+					geometryPoints.setFromPoints( points );
 
-					var position = [];
-
-					for ( var i = 0, l = points.length; i < l; i ++ ) {
-
-						var point = points[ i ];
-						position.push( point.x, point.y, 0 );
-
-					}
-
-					geometryPoints.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
-
-					// spaced points
-
-					position = [];
-
-					for ( var i = 0, l = spacedPoints.length; i < l; i ++ ) {
-
-						var point = spacedPoints[ i ];
-						position.push( point.x, point.y, 0 );
-
-					}
-
-					geometrySpacedPoints.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
-
+					var geometrySpacedPoints = new THREE.BufferGeometry();
+					geometrySpacedPoints.setFromPoints( spacedPoints );
+					
 					// solid line
 
 					var line = new THREE.Line( geometryPoints, new THREE.LineBasicMaterial( { color: color, linewidth: 3 } ) );

--- a/examples/webgl_geometry_text_shapes.html
+++ b/examples/webgl_geometry_text_shapes.html
@@ -115,12 +115,22 @@
 					for ( var i = 0; i < shapes.length; i ++ ) {
 
 						var shape = shapes[ i ];
+						var points = shape.getPoints();
 
-						var lineGeometry = shape.createPointsGeometry();
+						var geometry = new THREE.BufferGeometry();
+						var position = [];
 
-						lineGeometry.translate( xMid, 0, 0 );
+						for ( var j = 0; j < points.length; j ++ ) {
 
-						var lineMesh = new THREE.Line( lineGeometry, matDark );
+							var point = points[ j ];
+							position.push( point.x, point.y, 0 );
+
+						}
+
+						geometry.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
+						geometry.translate( xMid, 0, 0 );
+
+						var lineMesh = new THREE.Line( geometry, matDark );
 						lineText.add( lineMesh );
 
 					}

--- a/examples/webgl_geometry_text_shapes.html
+++ b/examples/webgl_geometry_text_shapes.html
@@ -117,9 +117,9 @@
 						var shape = shapes[ i ];
 
 						var points = shape.getPoints();
-						var geometry = new THREE.BufferGeometry();
-
-						geometry.setFromPoints( points ).translate( xMid, 0, 0 );
+						var geometry = new THREE.BufferGeometry().setFromPoints( points );
+						
+						geometry.translate( xMid, 0, 0 );
 
 						var lineMesh = new THREE.Line( geometry, matDark );
 						lineText.add( lineMesh );

--- a/examples/webgl_geometry_text_shapes.html
+++ b/examples/webgl_geometry_text_shapes.html
@@ -115,20 +115,11 @@
 					for ( var i = 0; i < shapes.length; i ++ ) {
 
 						var shape = shapes[ i ];
+
 						var points = shape.getPoints();
-
 						var geometry = new THREE.BufferGeometry();
-						var position = [];
 
-						for ( var j = 0; j < points.length; j ++ ) {
-
-							var point = points[ j ];
-							position.push( point.x, point.y, 0 );
-
-						}
-
-						geometry.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
-						geometry.translate( xMid, 0, 0 );
+						geometry.setFromPoints( points ).translate( xMid, 0, 0 );
 
 						var lineMesh = new THREE.Line( geometry, matDark );
 						lineText.add( lineMesh );

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -247,7 +247,7 @@ Object.assign( CurvePath.prototype, {
 
 	createPointsGeometry: function ( divisions ) {
 
-		console.warn( 'THREE.CurvePath: .createPointsGeometry() has been removed.' );
+		console.warn( 'THREE.CurvePath: .createPointsGeometry() has been removed. Use new THREE.Geometry().setFromPoints( points ) instead.' );
 
 		// generate geometry from path points (for Line or Points objects)
 
@@ -258,7 +258,7 @@ Object.assign( CurvePath.prototype, {
 
 	createSpacedPointsGeometry: function ( divisions ) {
 
-		console.warn( 'THREE.CurvePath: .createSpacedPointsGeometry() has been removed.' );
+		console.warn( 'THREE.CurvePath: .createSpacedPointsGeometry() has been removed. Use new THREE.Geometry().setFromPoints( points ) instead.' );
 
 		// generate geometry from equidistant sampling along the path
 
@@ -269,7 +269,7 @@ Object.assign( CurvePath.prototype, {
 
 	createGeometry: function ( points ) {
 
-		console.warn( 'THREE.CurvePath: .createGeometry() has been removed.' );
+		console.warn( 'THREE.CurvePath: .createGeometry() has been removed. Use new THREE.Geometry().setFromPoints( points ) instead.' );
 
 		var geometry = new Geometry();
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -24,6 +24,7 @@ import { Geometry } from './core/Geometry.js';
 import { Object3D } from './core/Object3D.js';
 import { Uniform } from './core/Uniform.js';
 import { Curve } from './extras/core/Curve.js';
+import { CurvePath } from './extras/core/CurvePath.js';
 import { CatmullRomCurve3 } from './extras/curves/CatmullRomCurve3.js';
 import { AxesHelper } from './helpers/AxesHelper.js';
 import { BoxHelper } from './helpers/BoxHelper.js';
@@ -239,6 +240,51 @@ Curve.create = function ( construct, getPoint ) {
 	return construct;
 
 };
+
+//
+
+Object.assign( CurvePath.prototype, {
+
+	createPointsGeometry: function ( divisions ) {
+
+		console.warn( 'THREE.CurvePath: .createPointsGeometry() has been removed.' );
+
+		// generate geometry from path points (for Line or Points objects)
+
+		var pts = this.getPoints( divisions );
+		return this.createGeometry( pts );
+
+	},
+
+	createSpacedPointsGeometry: function ( divisions ) {
+
+		console.warn( 'THREE.CurvePath: .createSpacedPointsGeometry() has been removed.' );
+
+		// generate geometry from equidistant sampling along the path
+
+		var pts = this.getSpacedPoints( divisions );
+		return this.createGeometry( pts );
+
+	},
+
+	createGeometry: function ( points ) {
+
+		console.warn( 'THREE.CurvePath: .createGeometry() has been removed.' );
+
+		var geometry = new Geometry();
+
+		for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+			var point = points[ i ];
+			geometry.vertices.push( new Vector3( point.x, point.y, point.z || 0 ) );
+
+		}
+
+		return geometry;
+
+	}
+
+} );
 
 //
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -345,7 +345,7 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		}
 
-		this.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( position, 3 ) );
 
 		return this;
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -341,7 +341,7 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 		for ( var i = 0, l = points.length; i < l; i ++ ) {
 
 			var point = points[ i ];
-			position.push( point.x, point.y, 0 );
+			position.push( point.x, point.y, point.z || 0 );
 
 		}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -334,6 +334,23 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 	},
 
+	setFromPoints: function ( points ) {
+
+		var position = [];
+
+		for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+			var point = points[ i ];
+			position.push( point.x, point.y, 0 );
+
+		}
+
+		this.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
+
+		return this;
+
+	},
+
 	updateFromObject: function ( object ) {
 
 		var geometry = object.geometry;

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -921,6 +921,21 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 	},
 
+	setFromPoints: function ( points ) {
+
+		this.vertices = [];
+
+		for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+			var point = points[ i ];
+			this.vertices.push( new Vector3( point.x, point.y, point.z || 0 ) );
+
+		}
+
+		return this;
+
+	},
+
 	sortFacesByMaterialIndex: function () {
 
 		var faces = this.faces;

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -1,6 +1,4 @@
 import { Curve } from './Curve.js';
-import { Vector3 } from '../../math/Vector3.js';
-import { Geometry } from '../../core/Geometry.js';
 import { LineCurve } from '../curves/LineCurve.js';
 
 /**
@@ -197,43 +195,6 @@ CurvePath.prototype = Object.assign( Object.create( Curve.prototype ), {
 		}
 
 		return points;
-
-	},
-
-	/**************************************************************
-	 *	Create Geometries Helpers
-	 **************************************************************/
-
-	/// Generate geometry from path points (for Line or Points objects)
-
-	createPointsGeometry: function ( divisions ) {
-
-		var pts = this.getPoints( divisions );
-		return this.createGeometry( pts );
-
-	},
-
-	// Generate geometry from equidistant sampling along the path
-
-	createSpacedPointsGeometry: function ( divisions ) {
-
-		var pts = this.getSpacedPoints( divisions );
-		return this.createGeometry( pts );
-
-	},
-
-	createGeometry: function ( points ) {
-
-		var geometry = new Geometry();
-
-		for ( var i = 0, l = points.length; i < l; i ++ ) {
-
-			var point = points[ i ];
-			geometry.vertices.push( new Vector3( point.x, point.y, point.z || 0 ) );
-
-		}
-
-		return geometry;
 
 	}
 


### PR DESCRIPTION
This PR does some refactoring in `CurvePath`. It removes factory methods that were used to create geometries from a series of sample points. This design pattern is unusual for the library and also creates an unpleasant dependency from `CurvePath` to `Geometry`.

These methods are now deprecated and the geometry generation is done in the examples.