### PR TITLE
TrackBallControls: mousewheel handler should take in consideration noZoom flag

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -469,6 +469,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 	function mousewheel( event ) {
 
 		if ( _this.enabled === false ) return;
+		
+		if ( _this.noZoom === true ) return;
 
 		event.preventDefault();
 		event.stopPropagation();


### PR DESCRIPTION
TrackBallControls - mousewheel handler should take in consideration noZoom flag.

Currently only the enabled flag is checked and _zoomStart.y is changing even if when noZoom is set to true.

I added this check :
if (_this.noZoom === true) return;

Fixes #12343