### PR TITLE
Box and Plane geometry: specify default values

### DIFF
--- a/docs/api/geometries/BoxBufferGeometry.html
+++ b/docs/api/geometries/BoxBufferGeometry.html
@@ -44,9 +44,9 @@
 
 		<h3>[name]([page:Float width], [page:Float height], [page:Float depth], [page:Integer widthSegments], [page:Integer heightSegments], [page:Integer depthSegments])</h3>
 		<div>
-		width — Width of the sides on the X axis.<br />
-		height — Height of the sides on the Y axis.<br />
-		depth — Depth of the sides on the Z axis.<br />
+		width — Width of the sides on the X axis. Default is 1.<br />
+		height — Height of the sides on the Y axis. Default is 1.<br />
+		depth — Depth of the sides on the Z axis. Default is 1.<br />
 		widthSegments — Optional. Number of segmented faces along the width of the sides. Default is 1.<br />
 		heightSegments — Optional. Number of segmented faces along the height of the sides. Default is 1.<br />
 		depthSegments — Optional. Number of segmented faces along the depth of the sides. Default is 1.

--- a/docs/api/geometries/BoxGeometry.html
+++ b/docs/api/geometries/BoxGeometry.html
@@ -44,9 +44,9 @@
 
 		<h3>[name]([page:Float width], [page:Float height], [page:Float depth], [page:Integer widthSegments], [page:Integer heightSegments], [page:Integer depthSegments])</h3>
 		<div>
-		width — Width of the sides on the X axis.<br />
-		height — Height of the sides on the Y axis.<br />
-		depth — Depth of the sides on the Z axis.<br />
+		width — Width of the sides on the X axis. Default is 1.<br />
+		height — Height of the sides on the Y axis. Default is 1.<br />
+		depth — Depth of the sides on the Z axis. Default is 1.<br />
 		widthSegments — Optional. Number of segmented faces along the width of the sides. Default is 1.<br />
 		heightSegments — Optional. Number of segmented faces along the height of the sides. Default is 1.<br />
 		depthSegments — Optional. Number of segmented faces along the depth of the sides. Default is 1.

--- a/docs/api/geometries/PlaneBufferGeometry.html
+++ b/docs/api/geometries/PlaneBufferGeometry.html
@@ -44,8 +44,8 @@
 
 		<h3>[name]([page:Float width], [page:Float height], [page:Integer widthSegments], [page:Integer heightSegments])</h3>
 		<div>
-		width — Width along the X axis.<br />
-		height — Height along the Y axis.<br />
+		width — Width along the X axis. Default is 1.<br />
+		height — Height along the Y axis. Default is 1.<br />
 		widthSegments — Optional. Default is 1. <br />
 		heightSegments — Optional. Default is 1.
 		</div>

--- a/docs/api/geometries/PlaneGeometry.html
+++ b/docs/api/geometries/PlaneGeometry.html
@@ -44,8 +44,8 @@
 
 		<h3>[name]([page:Float width], [page:Float height], [page:Integer widthSegments], [page:Integer heightSegments])</h3>
 		<div>
-		width — Width along the X axis.<br />
-		height — Height along the Y axis.<br />
+		width — Width along the X axis. Default is 1.<br />
+		height — Height along the Y axis. Default is 1.<br />
 		widthSegments — Optional. Default is 1. <br />
 		heightSegments — Optional. Default is 1.
 		</div>

--- a/src/geometries/BoxGeometry.js
+++ b/src/geometries/BoxGeometry.js
@@ -52,6 +52,10 @@ function BoxBufferGeometry( width, height, depth, widthSegments, heightSegments,
 
 	var scope = this;
 
+	width = width || 1;
+	height = height || 1;
+	depth = depth || 1;
+
 	// segments
 
 	widthSegments = Math.floor( widthSegments ) || 1;

--- a/src/geometries/PlaneGeometry.js
+++ b/src/geometries/PlaneGeometry.js
@@ -45,6 +45,9 @@ function PlaneBufferGeometry( width, height, widthSegments, heightSegments ) {
 		heightSegments: heightSegments
 	};
 
+	width = width || 1;
+	height = height || 1;
+
 	var width_half = width / 2;
 	var height_half = height / 2;
 


### PR DESCRIPTION
As implemented in this PR, degenerate geometries are not allowed. That is, width can't be zero.

Fixes #12395.