### PR TITLE
FBXLoader: Use texture scaling as a texture repeat value

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -386,17 +386,13 @@
 		texture.wrapS = valueU === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
 		texture.wrapT = valueV === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
 
-		if ( textureNode.properties.Scaling ) {
+		if ( 'Scaling' in textureNode.properties ) {
 
 			values = textureNode.properties.Scaling.value;
 
 			if ( typeof values === 'string' ) {
 
-				values = values.split( ',' ).map( function( number ) {
-
-					return parseFloat( number );
-
-				} );
+				values = parseFloatArray( values );
 
 			}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -385,6 +385,21 @@
 
 		texture.wrapS = valueU === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
 		texture.wrapT = valueV === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+        
+        if ( textureNode.properties.Scaling ) {
+
+            var values = textureNode.properties.Scaling.value
+
+            if ( typeof values === "string" ) {
+                values = values.split(",").map(function(number) {
+                    return parseFloat(number);
+                })
+            }
+            
+            texture.repeat.x = values[0]
+            texture.repeat.y = values[1]
+            
+        }
 
 		loader.setPath( currentPath );
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -388,7 +388,7 @@
 
 		if ( 'Scaling' in textureNode.properties ) {
 
-			values = textureNode.properties.Scaling.value;
+			var values = textureNode.properties.Scaling.value;
 
 			if ( typeof values === 'string' ) {
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -385,21 +385,25 @@
 
 		texture.wrapS = valueU === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
 		texture.wrapT = valueV === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
-        
-        if ( textureNode.properties.Scaling ) {
 
-            var values = textureNode.properties.Scaling.value
+		if ( textureNode.properties.Scaling ) {
 
-            if ( typeof values === "string" ) {
-                values = values.split(",").map(function(number) {
-                    return parseFloat(number);
-                })
-            }
-            
-            texture.repeat.x = values[0]
-            texture.repeat.y = values[1]
-            
-        }
+			values = textureNode.properties.Scaling.value;
+
+			if ( typeof values === 'string' ) {
+
+				values = values.split( ',' ).map( function( number ) {
+
+					return parseFloat( number );
+
+				} );
+
+			}
+
+			texture.repeat.x = values[ 0 ];
+			texture.repeat.y = values[ 1 ];
+
+		}
 
 		loader.setPath( currentPath );
 


### PR DESCRIPTION
In some 3d modelling softwares it is possible to specify texture repeat value. Currently this is not utilized in Three.js / FBXLoader.

These changes were tested with simple FBX-models made with Blender 2.78 and Modo 11.1v1.