### PR TITLE
Docs: Fix small Vector2 typo in CubicBezierCurve

### DIFF
--- a/docs/api/extras/curves/CubicBezierCurve.html
+++ b/docs/api/extras/curves/CubicBezierCurve.html
@@ -22,10 +22,10 @@
 
 <code>
 var curve = new THREE.CubicBezierCurve(
-	new THREE.Vector2( -10, 0, 0 ),
-	new THREE.Vector2( -5, 15, 0 ),
-	new THREE.Vector2( 20, 15, 0 ),
-	new THREE.Vector2( 10, 0, 0 )
+	new THREE.Vector2( -10, 0 ),
+	new THREE.Vector2( -5, 15 ),
+	new THREE.Vector2( 20, 15 ),
+	new THREE.Vector2( 10, 0 )
 );
 
 var path = new THREE.Path( curve.getPoints( 50 ) );


### PR DESCRIPTION
When `Vector3` was changed to `Vector2` in 1a8328f5772bf5893e27acae3136fc8fdb5135dd, the `z` component wasn't removed (e.g. `new THREE.Vector2( -10, 0, 0 )` instead of `new THREE.Vector2( -10, 0 )`)