### PR TITLE
Geometries: standardize default values

### DIFF
--- a/docs/api/geometries/CircleGeometry.html
+++ b/docs/api/geometries/CircleGeometry.html
@@ -46,7 +46,7 @@
 
 		<h3>[name]([page:Float radius], [page:Integer segments], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
-		radius — Radius of the circle, default = 50.<br />
+		radius — Radius of the circle, default = 1.<br />
 		segments — Number of segments (triangles), minimum = 3, default = 8.<br />
 		thetaStart — Start angle for first segment, default = 0 (three o'clock position).<br />
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete circle.

--- a/docs/api/geometries/CylinderGeometry.html
+++ b/docs/api/geometries/CylinderGeometry.html
@@ -44,9 +44,9 @@
 
 		<h3>[name]([page:Float radiusTop], [page:Float radiusBottom], [page:Float height], [page:Integer radiusSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
-		radiusTop — Radius of the cylinder at the top. Default is 20.<br />
-		radiusBottom — Radius of the cylinder at the bottom. Default is 20.<br />
-		height — Height of the cylinder. Default is 100.<br />
+		radiusTop — Radius of the cylinder at the top. Default is 1.<br />
+		radiusBottom — Radius of the cylinder at the bottom. Default is 1.<br />
+		height — Height of the cylinder. Default is 1.<br />
 		radiusSegments — Number of segmented faces around the circumference of the cylinder. Default is 8<br />
 		heightSegments — Number of rows of faces along the height of the cylinder. Default is 1.<br />
 		openEnded — A Boolean indicating whether the ends of the cylinder are open or capped. Default is false, meaning capped.<br />

--- a/docs/api/geometries/RingGeometry.html
+++ b/docs/api/geometries/RingGeometry.html
@@ -44,8 +44,8 @@
 
 		<h3>[name]([page:Float innerRadius], [page:Float outerRadius], [page:Integer thetaSegments], [page:Integer phiSegments], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
-		innerRadius — Default is 20. <br />
-		outerRadius — Default is 50. <br />
+		innerRadius — Default is 0.5. <br />
+		outerRadius — Default is 1. <br />
 		thetaSegments — Number of segments.  A higher number means the ring will be more round.  Minimum is 3.  Default is 8. <br />
 		phiSegments — Minimum is 1.  Default is 8.<br />
 		thetaStart — Starting angle. Default is 0. <br />

--- a/docs/api/geometries/SphereGeometry.html
+++ b/docs/api/geometries/SphereGeometry.html
@@ -45,7 +45,7 @@
 		<h3>[name]([page:Float radius], [page:Integer widthSegments], [page:Integer heightSegments], [page:Float phiStart], [page:Float phiLength], [page:Float thetaStart], [page:Float thetaLength])</h3>
 
 		<div>
-		radius — sphere radius. Default is 50.<br />
+		radius — sphere radius. Default is 1.<br />
 		widthSegments — number of horizontal segments. Minimum value is 3, and the default is 8.<br />
 		heightSegments — number of vertical segments. Minimum value is 2, and the default is 6.<br />
 		phiStart — specify horizontal starting angle. Default is 0.<br />

--- a/docs/api/geometries/TorusGeometry.html
+++ b/docs/api/geometries/TorusGeometry.html
@@ -44,8 +44,8 @@
 
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Float arc])</h3>
 		<div>
-		radius — Default is 100. <br />
-		tube — Diameter of the tube.  Default is 40. <br />
+		radius — Default is 1. <br />
+		tube — Diameter of the tube.  Default is 0.4. <br />
 		radialSegments — Default is 8 <br />
 		tubularSegments — Default is 6. <br />
 		arc — Central angle.  Default is Math.PI * 2.

--- a/docs/api/geometries/TorusKnotGeometry.html
+++ b/docs/api/geometries/TorusKnotGeometry.html
@@ -45,8 +45,8 @@
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer tubularSegments], [page:Integer radialSegments], [page:Integer p], [page:Integer q])</h3>
 		<div>
 			<ul>
-				<li>radius — Default is 100.</li>
-				<li>tube — Diameter of the tube. Default is 40.</li>
+				<li>radius — Default is 1.</li>
+				<li>tube — Diameter of the tube. Default is 0.4.</li>
 				<li>tubularSegments — Default is 64.</li>
 				<li>radialSegments — Default is 8.</li>
 				<li>p — This value determines, how many times the geometry winds around its axis of rotational symmetry. Default is 2.</li>

--- a/src/geometries/CircleGeometry.js
+++ b/src/geometries/CircleGeometry.js
@@ -48,7 +48,7 @@ function CircleBufferGeometry( radius, segments, thetaStart, thetaLength ) {
 		thetaLength: thetaLength
 	};
 
-	radius = radius || 50;
+	radius = radius || 1;
 	segments = segments !== undefined ? Math.max( 3, segments ) : 8;
 
 	thetaStart = thetaStart !== undefined ? thetaStart : 0;

--- a/src/geometries/CylinderGeometry.js
+++ b/src/geometries/CylinderGeometry.js
@@ -57,9 +57,9 @@ function CylinderBufferGeometry( radiusTop, radiusBottom, height, radialSegments
 
 	var scope = this;
 
-	radiusTop = radiusTop !== undefined ? radiusTop : 20;
-	radiusBottom = radiusBottom !== undefined ? radiusBottom : 20;
-	height = height !== undefined ? height : 100;
+	radiusTop = radiusTop !== undefined ? radiusTop : 1;
+	radiusBottom = radiusBottom !== undefined ? radiusBottom : 1;
+	height = height || 1;
 
 	radialSegments = Math.floor( radialSegments ) || 8;
 	heightSegments = Math.floor( heightSegments ) || 1;

--- a/src/geometries/RingGeometry.js
+++ b/src/geometries/RingGeometry.js
@@ -51,8 +51,8 @@ function RingBufferGeometry( innerRadius, outerRadius, thetaSegments, phiSegment
 		thetaLength: thetaLength
 	};
 
-	innerRadius = innerRadius || 20;
-	outerRadius = outerRadius || 50;
+	innerRadius = innerRadius || 0.5;
+	outerRadius = outerRadius || 1;
 
 	thetaStart = thetaStart !== undefined ? thetaStart : 0;
 	thetaLength = thetaLength !== undefined ? thetaLength : Math.PI * 2;

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -53,7 +53,7 @@ function SphereBufferGeometry( radius, widthSegments, heightSegments, phiStart, 
 		thetaLength: thetaLength
 	};
 
-	radius = radius || 50;
+	radius = radius || 1;
 
 	widthSegments = Math.max( 3, Math.floor( widthSegments ) || 8 );
 	heightSegments = Math.max( 2, Math.floor( heightSegments ) || 6 );

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -49,8 +49,8 @@ function TorusBufferGeometry( radius, tube, radialSegments, tubularSegments, arc
 		arc: arc
 	};
 
-	radius = radius || 100;
-	tube = tube || 40;
+	radius = radius || 1;
+	tube = tube || 0.4;
 	radialSegments = Math.floor( radialSegments ) || 8;
 	tubularSegments = Math.floor( tubularSegments ) || 6;
 	arc = arc || Math.PI * 2;

--- a/src/geometries/TorusKnotGeometry.js
+++ b/src/geometries/TorusKnotGeometry.js
@@ -54,8 +54,8 @@ function TorusKnotBufferGeometry( radius, tube, tubularSegments, radialSegments,
 		q: q
 	};
 
-	radius = radius || 100;
-	tube = tube || 40;
+	radius = radius || 1;
+	tube = tube || 0.4;
 	tubularSegments = Math.floor( tubularSegments ) || 64;
 	radialSegments = Math.floor( radialSegments ) || 8;
 	p = p || 2;


### PR DESCRIPTION
I would hope that this pattern is not frequently used
```javascript
var geometry = new THREE.CircleGeometry(); // no args
```
so this change should have little effect.