### PR TITLE
Curves: Added type property

### DIFF
--- a/docs/api/extras/curves/CatmullRomCurve3.html
+++ b/docs/api/extras/curves/CatmullRomCurve3.html
@@ -63,7 +63,7 @@ var curveObject = new THREE.Line( geometry, material );
 		<h3>[property:Boolean closed]</h3>
 		<div>The curve will loop back onto itself when this is true. False by default</div>
 
-		<h3>[property:String cureType]</h3>
+		<h3>[property:String curveType]</h3>
 		<div>Possible values are `centripetal` (default), `chordal` and `catmullrom`.</div>
 
 		<h3>[property:float tension]</h3>

--- a/docs/api/extras/curves/CatmullRomCurve3.html
+++ b/docs/api/extras/curves/CatmullRomCurve3.html
@@ -63,7 +63,7 @@ var curveObject = new THREE.Line( geometry, material );
 		<h3>[property:Boolean closed]</h3>
 		<div>The curve will loop back onto itself when this is true. False by default</div>
 
-		<h3>[property:String type]</h3>
+		<h3>[property:String cureType]</h3>
 		<div>Possible values are `centripetal` (default), `chordal` and `catmullrom`.</div>
 
 		<h3>[property:float tension]</h3>

--- a/examples/webgl_geometry_extrude_shapes.html
+++ b/examples/webgl_geometry_extrude_shapes.html
@@ -74,7 +74,7 @@
 					new THREE.Vector3(  60, -100, -60 )
 				] );
 
-				closedSpline.type = 'catmullrom';
+				closedSpline.curveType = 'catmullrom';
 				closedSpline.closed = true;
 
 				var extrudeSettings = {

--- a/examples/webgl_geometry_extrude_splines.html
+++ b/examples/webgl_geometry_extrude_splines.html
@@ -72,7 +72,7 @@
 			new THREE.Vector3( 0, -40, 40 )
 		] );
 
-		sampleClosedSpline.type = 'catmullrom';
+		sampleClosedSpline.curveType = 'catmullrom';
 		sampleClosedSpline.closed = true;
 
 		// Keep a dictionary of Curve instances

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -258,7 +258,7 @@
 				}
 
 				var curve = new THREE.CatmullRomCurve3( positions );
-				curve.type = 'catmullrom';
+				curve.curveType = 'catmullrom';
 				curve.mesh = new THREE.Line( geometry.clone(), new THREE.LineBasicMaterial( {
 					color: 0xff0000,
 					opacity: 0.35,
@@ -268,7 +268,7 @@
 				splines.uniform = curve;
 
 				curve = new THREE.CatmullRomCurve3( positions );
-				curve.type = 'centripetal';
+				curve.curveType = 'centripetal';
 				curve.mesh = new THREE.Line( geometry.clone(), new THREE.LineBasicMaterial( {
 					color: 0x00ff00,
 					opacity: 0.35,
@@ -278,7 +278,7 @@
 				splines.centripetal = curve;
 
 				curve = new THREE.CatmullRomCurve3( positions );
-				curve.type = 'chordal';
+				curve.curveType = 'chordal';
 				curve.mesh = new THREE.Line( geometry.clone(), new THREE.LineBasicMaterial( {
 					color: 0x0000ff,
 					opacity: 0.35,

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -39,6 +39,8 @@ import { Matrix4 } from '../../math/Matrix4.js';
 
 function Curve() {
 
+	this.type = 'Curve';
+
 	this.arcLengthDivisions = 200;
 
 }

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -17,8 +17,9 @@ function CurvePath() {
 
 	Curve.call( this );
 
-	this.curves = [];
+	this.type = 'CurvePath';
 
+	this.curves = [];
 	this.autoClose = false; // Automatically closes the path
 
 }

--- a/src/extras/core/Font.js
+++ b/src/extras/core/Font.js
@@ -9,6 +9,8 @@ import { ShapePath } from './ShapePath.js';
 
 function Font( data ) {
 
+	this.type = 'Font';
+
 	this.data = data;
 
 }

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -11,6 +11,9 @@ import { CurvePath } from './CurvePath.js';
 function Path( points ) {
 
 	CurvePath.call( this );
+
+	this.type = 'Path';
+
 	this.currentPoint = new Vector2();
 
 	if ( points ) {

--- a/src/extras/core/Shape.js
+++ b/src/extras/core/Shape.js
@@ -16,6 +16,8 @@ function Shape() {
 
 	Path.apply( this, arguments );
 
+	this.type = 'Shape';
+
 	this.holes = [];
 
 }

--- a/src/extras/core/ShapePath.js
+++ b/src/extras/core/ShapePath.js
@@ -9,6 +9,8 @@ import { ShapeUtils } from '../ShapeUtils.js';
 
 function ShapePath() {
 
+	this.type = 'ShapePath';
+
 	this.subPaths = [];
 	this.currentPath = null;
 

--- a/src/extras/curves/ArcCurve.js
+++ b/src/extras/curves/ArcCurve.js
@@ -5,6 +5,8 @@ function ArcCurve( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
 
 	EllipseCurve.call( this, aX, aY, aRadius, aRadius, aStartAngle, aEndAngle, aClockwise );
 
+	this.type = 'ArcCurve';
+
 }
 
 ArcCurve.prototype = Object.create( EllipseCurve.prototype );

--- a/src/extras/curves/CatmullRomCurve3.js
+++ b/src/extras/curves/CatmullRomCurve3.js
@@ -87,10 +87,13 @@ function CatmullRomCurve3( points ) {
 
 	Curve.call( this );
 
+	this.type = 'CatmullRomCurve3';
+
 	if ( points.length < 2 ) console.warn( 'THREE.CatmullRomCurve3: Points array needs at least two entries.' );
 
 	this.points = points || [];
 	this.closed = false;
+	this.curveType = 'centripetal';
 
 }
 
@@ -150,10 +153,10 @@ CatmullRomCurve3.prototype.getPoint = function ( t, optionalTarget ) {
 
 	}
 
-	if ( this.type === undefined || this.type === 'centripetal' || this.type === 'chordal' ) {
+	if ( this.curveType === 'centripetal' || this.curveType === 'chordal' ) {
 
 		// init Centripetal / Chordal Catmull-Rom
-		var pow = this.type === 'chordal' ? 0.5 : 0.25;
+		var pow = this.curveType === 'chordal' ? 0.5 : 0.25;
 		var dt0 = Math.pow( p0.distanceToSquared( p1 ), pow );
 		var dt1 = Math.pow( p1.distanceToSquared( p2 ), pow );
 		var dt2 = Math.pow( p2.distanceToSquared( p3 ), pow );
@@ -167,7 +170,7 @@ CatmullRomCurve3.prototype.getPoint = function ( t, optionalTarget ) {
 		py.initNonuniformCatmullRom( p0.y, p1.y, p2.y, p3.y, dt0, dt1, dt2 );
 		pz.initNonuniformCatmullRom( p0.z, p1.z, p2.z, p3.z, dt0, dt1, dt2 );
 
-	} else if ( this.type === 'catmullrom' ) {
+	} else if ( this.curveType === 'catmullrom' ) {
 
 		var tension = this.tension !== undefined ? this.tension : 0.5;
 		px.initCatmullRom( p0.x, p1.x, p2.x, p3.x, tension );

--- a/src/extras/curves/CubicBezierCurve.js
+++ b/src/extras/curves/CubicBezierCurve.js
@@ -7,6 +7,8 @@ function CubicBezierCurve( v0, v1, v2, v3 ) {
 
 	Curve.call( this );
 
+	this.type = 'CubicBezierCurve';
+
 	this.v0 = v0;
 	this.v1 = v1;
 	this.v2 = v2;

--- a/src/extras/curves/CubicBezierCurve3.js
+++ b/src/extras/curves/CubicBezierCurve3.js
@@ -7,6 +7,8 @@ function CubicBezierCurve3( v0, v1, v2, v3 ) {
 
 	Curve.call( this );
 
+	this.type = 'CubicBezierCurve3';
+
 	this.v0 = v0;
 	this.v1 = v1;
 	this.v2 = v2;

--- a/src/extras/curves/EllipseCurve.js
+++ b/src/extras/curves/EllipseCurve.js
@@ -6,6 +6,8 @@ function EllipseCurve( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockw
 
 	Curve.call( this );
 
+	this.type = 'EllipseCurve';
+
 	this.aX = aX;
 	this.aY = aY;
 

--- a/src/extras/curves/LineCurve.js
+++ b/src/extras/curves/LineCurve.js
@@ -6,6 +6,8 @@ function LineCurve( v1, v2 ) {
 
 	Curve.call( this );
 
+	this.type = 'LineCurve';
+
 	this.v1 = v1;
 	this.v2 = v2;
 

--- a/src/extras/curves/LineCurve3.js
+++ b/src/extras/curves/LineCurve3.js
@@ -6,6 +6,8 @@ function LineCurve3( v1, v2 ) {
 
 	Curve.call( this );
 
+	this.type = 'LineCurve3';
+
 	this.v1 = v1;
 	this.v2 = v2;
 

--- a/src/extras/curves/QuadraticBezierCurve.js
+++ b/src/extras/curves/QuadraticBezierCurve.js
@@ -7,6 +7,8 @@ function QuadraticBezierCurve( v0, v1, v2 ) {
 
 	Curve.call( this );
 
+	this.type = 'QuadraticBezierCurve';
+
 	this.v0 = v0;
 	this.v1 = v1;
 	this.v2 = v2;

--- a/src/extras/curves/QuadraticBezierCurve3.js
+++ b/src/extras/curves/QuadraticBezierCurve3.js
@@ -7,6 +7,8 @@ function QuadraticBezierCurve3( v0, v1, v2 ) {
 
 	Curve.call( this );
 
+	this.type = 'QuadraticBezierCurve3';
+
 	this.v0 = v0;
 	this.v1 = v1;
 	this.v2 = v2;

--- a/src/extras/curves/SplineCurve.js
+++ b/src/extras/curves/SplineCurve.js
@@ -7,6 +7,8 @@ function SplineCurve( points /* array of Vector2 */ ) {
 
 	Curve.call( this );
 
+	this.type = 'SplineCurve';
+
 	this.points = ( points === undefined ) ? [] : points;
 
 }


### PR DESCRIPTION
see #11599

This PR adds a `type` attribute to all curve related entities (preparation for serialization/deserialization). The already existing `type` property of `CatmullRomCurve3` is renamed to `curveType`.

I want to keep the PR small so further enhancements (missing `copy()` and `clone()` methods) goes in an other PR.