### PR TITLE
Cache parallel requests

### DIFF
--- a/src/loaders/Cache.js
+++ b/src/loaders/Cache.js
@@ -13,18 +13,21 @@ var Cache = {
 		if ( this.enabled === false ) return;
 
 		this.entries[ key ] = { value: value };
+
 	},
 
 	get: function ( key ) {
 
-		if ( this.enabled === false || this.entries[key] === undefined ) return;
+		if ( this.enabled === false || this.entries[ key ] === undefined ) return;
 
-		return this.entries[key].value;
+		return this.entries[ key ].value;
+
 	},
 
 	remove: function ( key ) {
 
 		delete this.entries[ key ];
+
 	},
 
 	clear: function () {
@@ -33,64 +36,92 @@ var Cache = {
 
 	},
 
-	retrieve: function(key, resolver, onLoad, onProgress, onError) {
+	retrieve: function ( key, resolver, onLoad, onProgress, onError ) {
+
 		if ( this.enabled === false ) {
-			resolver(onLoad, onProgress, onError);
+
+			resolver( onLoad, onProgress, onError );
 			return;
+
 		}
 
-		var entry = this.entries[key];
+		var entry = this.entries[ key ];
 
-		if (entry === undefined) {
+		if ( entry === undefined ) {
+
 			entry = {
-				pending: [{onLoad: onLoad, onProgress: onProgress, onError: onError}]
+				pending: [ { onLoad: onLoad, onProgress: onProgress, onError: onError } ]
 			};
-			this.entries[key] = entry;
+			this.entries[ key ] = entry;
 
-			var resolveLoad = function(value) {
+			var resolveLoad = function ( value ) {
+
 				entry.value = value;
 
-				for (var i = 0; i<entry.pending.length; i++) {
-					if (entry.pending[i].onLoad !== undefined) {
-						entry.pending[i].onLoad(value);
+				for ( var i = 0; i < entry.pending.length; i ++ ) {
+
+					if ( entry.pending[ i ].onLoad !== undefined ) {
+
+						entry.pending[ i ].onLoad( value );
+
 					}
+
 				}
 
 				delete entry.pending;
+
 			};
 
-			var resolveProgress = function(progress) {
-				for (var i = 0; i<entry.pending.length; i++) {
-					if (entry.pending[i].onProgress !== undefined) {
-						entry.pending[i].onProgress(progress);
+			var resolveProgress = function ( progress ) {
+
+				for ( var i = 0; i < entry.pending.length; i ++ ) {
+
+					if ( entry.pending[ i ].onProgress !== undefined ) {
+
+						entry.pending[ i ].onProgress( progress );
+
 					}
+
 				}
+
 			};
-			var resolveError = function(error) {
+			var resolveError = function ( error ) {
+
 				entry.error = error;
 
-				for (var i = 0; i<entry.pending.length; i++) {
-					if (entry.pending[i].onError !== undefined) {
-						entry.pending[i].onError(error);
+				for ( var i = 0; i < entry.pending.length; i ++ ) {
+
+					if ( entry.pending[ i ].onError !== undefined ) {
+
+						entry.pending[ i ].onError( error );
+
 					}
+
 				}
 
 				delete entry.pending;
+
 			};
-			return resolver(resolveLoad, resolveProgress, resolveError);
+			return resolver( resolveLoad, resolveProgress, resolveError );
+
+		} else if ( entry.pending !== undefined ) {
+
+			entry.pending.push( { onLoad: onLoad, onProgress: onProgress, onError: onError } );
+
+		} else if ( entry.value !== undefined ) {
+
+			onLoad( entry.value );
+
+		} else if ( entry.error !== undefined ) {
+
+			onError( entry.error );
+
+		} else {
+
+			throw new Error( "Invalid state in cache" );
+
 		}
-		else if (entry.pending !== undefined) {
-			entry.pending.push({onLoad: onLoad, onProgress: onProgress, onError: onError});
-		}
-		else if (entry.value !== undefined) {
-			onLoad(entry.value);
-		}
-		else if (entry.error !== undefined) {
-			onError(entry.error);
-		}
-		else {
-			throw new Error("Invalid state in cache");
-		}
+
 	},
 
 };

--- a/src/loaders/Cache.js
+++ b/src/loaders/Cache.js
@@ -6,39 +6,92 @@ var Cache = {
 
 	enabled: false,
 
-	files: {},
+	entries: {},
 
-	add: function ( key, file ) {
+	add: function ( key, value ) {
 
 		if ( this.enabled === false ) return;
 
-		// console.log( 'THREE.Cache', 'Adding key:', key );
-
-		this.files[ key ] = file;
-
+		this.entries[ key ] = { value: value };
 	},
 
 	get: function ( key ) {
 
-		if ( this.enabled === false ) return;
+		if ( this.enabled === false || this.entries[key] === undefined ) return;
 
-		// console.log( 'THREE.Cache', 'Checking key:', key );
-
-		return this.files[ key ];
-
+		return this.entries[key].value;
 	},
 
 	remove: function ( key ) {
 
-		delete this.files[ key ];
-
+		delete this.entries[ key ];
 	},
 
 	clear: function () {
 
-		this.files = {};
+		this.entries = {};
 
-	}
+	},
+
+	retrieve: function(key, resolver, onLoad, onProgress, onError) {
+		if ( this.enabled === false ) {
+			resolver(onLoad, onProgress, onError);
+			return;
+		}
+
+		var entry = this.entries[key];
+
+		if (entry === undefined) {
+			entry = {
+				pending: [{onLoad: onLoad, onProgress: onProgress, onError: onError}]
+			};
+			this.entries[key] = entry;
+
+			var resolveLoad = function(value) {
+				entry.value = value;
+
+				for (var i = 0; i<entry.pending.length; i++) {
+					if (entry.pending[i].onLoad !== undefined) {
+						entry.pending[i].onLoad(value);
+					}
+				}
+
+				delete entry.pending;
+			};
+
+			var resolveProgress = function(progress) {
+				for (var i = 0; i<entry.pending.length; i++) {
+					if (entry.pending[i].onProgress !== undefined) {
+						entry.pending[i].onProgress(progress);
+					}
+				}
+			};
+			var resolveError = function(error) {
+				entry.error = error;
+
+				for (var i = 0; i<entry.pending.length; i++) {
+					if (entry.pending[i].onError !== undefined) {
+						entry.pending[i].onError(error);
+					}
+				}
+
+				delete entry.pending;
+			};
+			return resolver(resolveLoad, resolveProgress, resolveError);
+		}
+		else if (entry.pending !== undefined) {
+			entry.pending.push({onLoad: onLoad, onProgress: onProgress, onError: onError});
+		}
+		else if (entry.value !== undefined) {
+			onLoad(entry.value);
+		}
+		else if (entry.error !== undefined) {
+			onError(entry.error);
+		}
+		else {
+			throw new Error("Invalid state in cache");
+		}
+	},
 
 };
 

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -112,74 +112,78 @@ Object.assign( FileLoader.prototype, {
 
 		} else {
 
-			return Cache.retrieve(url, function(_onLoad, _onProgress, _onError) {
+			return Cache.retrieve( url, function ( _onLoad, _onProgress, _onError ) {
 
 				var request = new XMLHttpRequest();
-				request.open('GET', url, true);
+				request.open( 'GET', url, true );
 
-				request.addEventListener('load', function (event) {
+				request.addEventListener( 'load', function ( event ) {
 
 					var response = event.target.response;
 
-					if (this.status === 200) {
+					if ( this.status === 200 ) {
 
-						_onLoad(response);
+						_onLoad( response );
 
-						scope.manager.itemEnd(url);
+						scope.manager.itemEnd( url );
 
-					} else if (this.status === 0) {
+					} else if ( this.status === 0 ) {
 
 						// Some browsers return HTTP Status 0 when using non-http protocol
 						// e.g. 'file://' or 'data://'. Handle as success.
 
-						console.warn('THREE.FileLoader: HTTP Status 0 received.');
+						console.warn( 'THREE.FileLoader: HTTP Status 0 received.' );
 
-						_onLoad(response);
+						_onLoad( response );
 
-						scope.manager.itemEnd(url);
+						scope.manager.itemEnd( url );
 
 					} else {
 
-						_onError(event);
+						_onError( event );
 
-						scope.manager.itemEnd(url);
-						scope.manager.itemError(url);
+						scope.manager.itemEnd( url );
+						scope.manager.itemError( url );
 
 					}
 
-				}, false);
+				}, false );
 
 
-				request.addEventListener('progress', function (event) {
+				request.addEventListener( 'progress', function ( event ) {
 
-					_onProgress(event);
+					_onProgress( event );
 
-				}, false);
+				}, false );
 
 
-				request.addEventListener('error', function (event) {
+				request.addEventListener( 'error', function ( event ) {
 
-					_onError(event);
+					_onError( event );
 
-					scope.manager.itemEnd(url);
-					scope.manager.itemError(url);
+					scope.manager.itemEnd( url );
+					scope.manager.itemError( url );
 
-				}, false);
+				}, false );
 
-				if (scope.responseType !== undefined) request.responseType = scope.responseType;
-				if (scope.withCredentials !== undefined) request.withCredentials = scope.withCredentials;
+				if ( scope.responseType !== undefined ) request.responseType = scope.responseType;
+				if ( scope.withCredentials !== undefined ) request.withCredentials = scope.withCredentials;
 
-				if (request.overrideMimeType) request.overrideMimeType(scope.mimeType !== undefined ? scope.mimeType : 'text/plain');
+				if ( request.overrideMimeType ) request.overrideMimeType( scope.mimeType !== undefined ? scope.mimeType : 'text/plain' );
 
-				for (var header in scope.requestHeader) {
+				for ( var header in scope.requestHeader ) {
 
-					request.setRequestHeader(header, scope.requestHeader[header]);
+					request.setRequestHeader( header, scope.requestHeader[ header ] );
+
 				}
 
-				request.send(null);
+				request.send( null );
 				scope.manager.itemStart( url );
-			}, onLoad, onProgress, onError);
+
+			}, onLoad, onProgress, onError );
+
 		}
+
 	},
 
 	setPath: function ( value ) {

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -21,24 +21,6 @@ Object.assign( FileLoader.prototype, {
 
 		var scope = this;
 
-		var cached = Cache.get( url );
-
-		if ( cached !== undefined ) {
-
-			scope.manager.itemStart( url );
-
-			setTimeout( function () {
-
-				if ( onLoad ) onLoad( cached );
-
-				scope.manager.itemEnd( url );
-
-			}, 0 );
-
-			return cached;
-
-		}
-
 		// Check for data: URI
 		var dataUriRegex = /^data:(.*?)(;base64)?,(.*)$/;
 		var dataUriRegexResult = url.match( dataUriRegex );
@@ -130,81 +112,74 @@ Object.assign( FileLoader.prototype, {
 
 		} else {
 
-			var request = new XMLHttpRequest();
-			request.open( 'GET', url, true );
+			return Cache.retrieve(url, function(_onLoad, _onProgress, _onError) {
 
-			request.addEventListener( 'load', function ( event ) {
+				var request = new XMLHttpRequest();
+				request.open('GET', url, true);
 
-				var response = event.target.response;
+				request.addEventListener('load', function (event) {
 
-				Cache.add( url, response );
+					var response = event.target.response;
 
-				if ( this.status === 200 ) {
+					if (this.status === 200) {
 
-					if ( onLoad ) onLoad( response );
+						_onLoad(response);
 
-					scope.manager.itemEnd( url );
+						scope.manager.itemEnd(url);
 
-				} else if ( this.status === 0 ) {
+					} else if (this.status === 0) {
 
-					// Some browsers return HTTP Status 0 when using non-http protocol
-					// e.g. 'file://' or 'data://'. Handle as success.
+						// Some browsers return HTTP Status 0 when using non-http protocol
+						// e.g. 'file://' or 'data://'. Handle as success.
 
-					console.warn( 'THREE.FileLoader: HTTP Status 0 received.' );
+						console.warn('THREE.FileLoader: HTTP Status 0 received.');
 
-					if ( onLoad ) onLoad( response );
+						_onLoad(response);
 
-					scope.manager.itemEnd( url );
+						scope.manager.itemEnd(url);
 
-				} else {
+					} else {
 
-					if ( onError ) onError( event );
+						_onError(event);
 
-					scope.manager.itemEnd( url );
-					scope.manager.itemError( url );
+						scope.manager.itemEnd(url);
+						scope.manager.itemError(url);
 
+					}
+
+				}, false);
+
+
+				request.addEventListener('progress', function (event) {
+
+					_onProgress(event);
+
+				}, false);
+
+
+				request.addEventListener('error', function (event) {
+
+					_onError(event);
+
+					scope.manager.itemEnd(url);
+					scope.manager.itemError(url);
+
+				}, false);
+
+				if (scope.responseType !== undefined) request.responseType = scope.responseType;
+				if (scope.withCredentials !== undefined) request.withCredentials = scope.withCredentials;
+
+				if (request.overrideMimeType) request.overrideMimeType(scope.mimeType !== undefined ? scope.mimeType : 'text/plain');
+
+				for (var header in scope.requestHeader) {
+
+					request.setRequestHeader(header, scope.requestHeader[header]);
 				}
 
-			}, false );
-
-			if ( onProgress !== undefined ) {
-
-				request.addEventListener( 'progress', function ( event ) {
-
-					onProgress( event );
-
-				}, false );
-
-			}
-
-			request.addEventListener( 'error', function ( event ) {
-
-				if ( onError ) onError( event );
-
-				scope.manager.itemEnd( url );
-				scope.manager.itemError( url );
-
-			}, false );
-
-			if ( this.responseType !== undefined ) request.responseType = this.responseType;
-			if ( this.withCredentials !== undefined ) request.withCredentials = this.withCredentials;
-
-			if ( request.overrideMimeType ) request.overrideMimeType( this.mimeType !== undefined ? this.mimeType : 'text/plain' );
-
-			for ( var header in this.requestHeader ) {
-
-				request.setRequestHeader( header, this.requestHeader[ header ] );
-
-			}
-
-			request.send( null );
-
+				request.send(null);
+				scope.manager.itemStart( url );
+			}, onLoad, onProgress, onError);
 		}
-
-		scope.manager.itemStart( url );
-
-		return request;
-
 	},
 
 	setPath: function ( value ) {

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -123,7 +123,11 @@ Object.assign( FileLoader.prototype, {
 
 					if ( this.status === 200 ) {
 
-						_onLoad( response );
+						if( _onLoad !== undefined ) {
+
+							_onLoad( response );
+
+						}
 
 						scope.manager.itemEnd( url );
 
@@ -134,13 +138,21 @@ Object.assign( FileLoader.prototype, {
 
 						console.warn( 'THREE.FileLoader: HTTP Status 0 received.' );
 
-						_onLoad( response );
+						if( _onLoad !== undefined ) {
+
+							_onLoad( response );
+
+						}
 
 						scope.manager.itemEnd( url );
 
 					} else {
 
-						_onError( event );
+						if( _onError !== undefined ) {
+
+							_onError( event );
+
+						}
 
 						scope.manager.itemEnd( url );
 						scope.manager.itemError( url );
@@ -152,14 +164,22 @@ Object.assign( FileLoader.prototype, {
 
 				request.addEventListener( 'progress', function ( event ) {
 
-					_onProgress( event );
+					if( _onProgress !== undefined) {
+
+						_onProgress( event );
+
+					}
 
 				}, false );
 
 
 				request.addEventListener( 'error', function ( event ) {
 
-					_onError( event );
+					if( _onError !== undefined ) {
+
+						_onError( event );
+
+					}
 
 					scope.manager.itemEnd( url );
 					scope.manager.itemError( url );

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -24,65 +24,47 @@ Object.assign( ImageLoader.prototype, {
 
 		var scope = this;
 
-		var cached = Cache.get( url );
+		return Cache.retrieve(url, function(_onLoad, _onProgress, _onError) {
 
-		if ( cached !== undefined ) {
+			var image = document.createElementNS('http://www.w3.org/1999/xhtml', 'img');
 
-			scope.manager.itemStart( url );
+			image.addEventListener('load', function () {
 
-			setTimeout( function () {
+				_onLoad(this);
 
-				if ( onLoad ) onLoad( cached );
+				scope.manager.itemEnd(url);
 
-				scope.manager.itemEnd( url );
+			}, false);
 
-			}, 0 );
+			/*
+			image.addEventListener( 'progress', function ( event ) {
 
-			return cached;
+				if ( onProgress ) onProgress( event );
 
-		}
+			}, false );
+			*/
 
-		var image = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'img' );
+			image.addEventListener('error', function (event) {
 
-		image.addEventListener( 'load', function () {
+				_onError(event);
 
-			Cache.add( url, this );
+				scope.manager.itemEnd(url);
+				scope.manager.itemError(url);
 
-			if ( onLoad ) onLoad( this );
+			}, false);
 
-			scope.manager.itemEnd( url );
+			if (url.substr(0, 5) !== 'data:') {
 
-		}, false );
+				if (scope.crossOrigin !== undefined) image.crossOrigin = scope.crossOrigin;
 
-		/*
-		image.addEventListener( 'progress', function ( event ) {
+			}
 
-			if ( onProgress ) onProgress( event );
+			scope.manager.itemStart(url);
 
-		}, false );
-		*/
+			image.src = url;
 
-		image.addEventListener( 'error', function ( event ) {
-
-			if ( onError ) onError( event );
-
-			scope.manager.itemEnd( url );
-			scope.manager.itemError( url );
-
-		}, false );
-
-		if ( url.substr( 0, 5 ) !== 'data:' ) {
-
-			if ( this.crossOrigin !== undefined ) image.crossOrigin = this.crossOrigin;
-
-		}
-
-		scope.manager.itemStart( url );
-
-		image.src = url;
-
-		return image;
-
+			return image;
+		}, onLoad, onProgress, onError);
 	},
 
 	setCrossOrigin: function ( value ) {

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -24,17 +24,17 @@ Object.assign( ImageLoader.prototype, {
 
 		var scope = this;
 
-		return Cache.retrieve(url, function(_onLoad, _onProgress, _onError) {
+		return Cache.retrieve( url, function ( _onLoad, _onProgress, _onError ) {
 
-			var image = document.createElementNS('http://www.w3.org/1999/xhtml', 'img');
+			var image = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'img' );
 
-			image.addEventListener('load', function () {
+			image.addEventListener( 'load', function () {
 
-				_onLoad(this);
+				_onLoad( this );
 
-				scope.manager.itemEnd(url);
+				scope.manager.itemEnd( url );
 
-			}, false);
+			}, false );
 
 			/*
 			image.addEventListener( 'progress', function ( event ) {
@@ -44,27 +44,29 @@ Object.assign( ImageLoader.prototype, {
 			}, false );
 			*/
 
-			image.addEventListener('error', function (event) {
+			image.addEventListener( 'error', function ( event ) {
 
-				_onError(event);
+				_onError( event );
 
-				scope.manager.itemEnd(url);
-				scope.manager.itemError(url);
+				scope.manager.itemEnd( url );
+				scope.manager.itemError( url );
 
-			}, false);
+			}, false );
 
-			if (url.substr(0, 5) !== 'data:') {
+			if ( url.substr( 0, 5 ) !== 'data:' ) {
 
-				if (scope.crossOrigin !== undefined) image.crossOrigin = scope.crossOrigin;
+				if ( scope.crossOrigin !== undefined ) image.crossOrigin = scope.crossOrigin;
 
 			}
 
-			scope.manager.itemStart(url);
+			scope.manager.itemStart( url );
 
 			image.src = url;
 
 			return image;
-		}, onLoad, onProgress, onError);
+
+		}, onLoad, onProgress, onError );
+
 	},
 
 	setCrossOrigin: function ( value ) {

--- a/test/Three.Unit.js
+++ b/test/Three.Unit.js
@@ -98,7 +98,7 @@ export * from '../src/geometries/Geometries.js';
 
 //src/helpers
 export { ArrowHelper } from '../src/helpers/ArrowHelper.js';
-export { AxisHelper } from '../src/helpers/AxisHelper.js';
+export { AxesHelper } from '../src/helpers/AxesHelper.js';
 export { BoxHelper } from '../src/helpers/BoxHelper.js';
 export { Box3Helper } from '../src/helpers/Box3Helper.js';
 export { CameraHelper } from '../src/helpers/CameraHelper.js';

--- a/test/unit/src/loaders/Cache.js
+++ b/test/unit/src/loaders/Cache.js
@@ -1,6 +1,155 @@
 /**
- * @author TristanVALCKE / https://github.com/TristanVALCKE
+ * @author Philip Frank / https://github.com/bananer
  */
+(function () {
 
-//Todo
-console.warn("Todo: Unit tests of Cache")
+	'use strict';
+
+	QUnit.module('Loaders - Cache', {
+		before: function () {
+			THREE.Cache.enabled = true;
+		},
+		after: function () {
+			THREE.Cache.enabled = false;
+		}
+	});
+
+	QUnit.test('simple', function (assert) {
+		var done = assert.async();
+		THREE.Cache.retrieve('simple', function (onLoad) {
+			setTimeout(function () {
+				onLoad('result');
+			}, 1);
+		}, function (result) {
+			assert.equal(result, 'result');
+			done();
+		})
+	});
+
+	QUnit.test('multiple', function (assert) {
+		var resolverDone = assert.async();
+		var resolver = function (onLoad) {
+			setTimeout(function () {
+				onLoad('result');
+				resolverDone();
+			}, 1);
+		};
+
+		var retriever1Done = assert.async();
+		THREE.Cache.retrieve('multiple', resolver, function (result) {
+			assert.equal(result, 'result');
+			retriever1Done();
+		});
+
+		var retriever2Done = assert.async();
+		THREE.Cache.retrieve('multiple', resolver, function (result) {
+			assert.equal(result, 'result');
+			retriever2Done();
+		});
+
+		var retriever3Done = assert.async();
+		THREE.Cache.retrieve('multiple', resolver, function (result) {
+			assert.equal(result, 'result');
+			retriever3Done();
+		})
+	});
+
+	QUnit.test('multiple-delay', function (assert) {
+		assert.timeout( 1000 );
+		var resolverDone = assert.async();
+		var resolver = function (onLoad) {
+			setTimeout(function () {
+				onLoad('result');
+				resolverDone();
+			}, 1);
+		};
+
+		var retriever1Done = assert.async();
+		THREE.Cache.retrieve('multiple-delay', resolver, function (result) {
+			assert.equal(result, 'result');
+			retriever1Done();
+		});
+
+		var retriever2Done = assert.async();
+		setTimeout(function () {
+			THREE.Cache.retrieve('multiple-delay', resolver, function (result) {
+				assert.equal(result, 'result');
+				retriever2Done();
+			});
+		}, 10);
+	});
+
+	QUnit.test('progress-error', function(assert) {
+		assert.timeout( 1000 );
+		var progress1 = assert.async(2);
+		var error1 = assert.async();
+		var error2 = assert.async();
+		var resolver = function (onLoad, onProgress, onError) {
+			setTimeout(function () {
+				onProgress(20);
+			}, 1);
+			setTimeout(function () {
+				onProgress(80);
+			}, 10);
+			setTimeout(function () {
+				onError('error');
+			}, 20);
+		};
+
+		THREE.Cache.retrieve(
+			'progress-error',
+			resolver,
+			assert.fail,
+			progress1,
+			function(error) {
+				assert.equal(error, 'error');
+				error1();
+			}
+		);
+		setTimeout(function () {
+			THREE.Cache.retrieve(
+				'progress-error',
+				resolver,
+				assert.fail,
+				undefined,
+				function(error) {
+					assert.equal(error, 'error');
+					error2();
+				});
+		}, 10);
+	});
+
+	QUnit.test('disabled', function(assert) {
+		assert.timeout( 1000 );
+		THREE.Cache.enabled = false;
+
+		var retriever1 = assert.async();
+		var retriever2 = assert.async();
+
+		THREE.Cache.retrieve(
+			'disabled',
+			function(onLoad) {
+				setTimeout(function() {
+					onLoad('result1');
+				}, 1);
+			},
+			function(result) {
+				assert.equal(result, 'result1');
+				retriever1();
+			}
+		);
+
+		THREE.Cache.retrieve(
+			'disabled',
+			function(onLoad) {
+				setTimeout(function() {
+					onLoad('result2');
+				}, 1);
+			},
+			function(result) {
+				assert.equal(result, 'result2');
+				retriever2();
+			}
+		);
+	});
+})();


### PR DESCRIPTION
When using `FileLoader` with Caching enabled, a second call to `load(…)` for a url previously requested would still trigger another request, if the first request has not finished, because the result is only written to the cache after the first request completes.

With this pull request, I would like to improve the behaviour of `FileLoader` in such situations, so there will only ever be one request to a specific url.

This is accomplised by introducing `Cache.retrieve(key, resolver, onLoad, onProgress, onError)`, where `resolver` should be a function which will only be called if the cache key is to be received for the first time.

I have implemented the usage of `Cache.retrieve` in `FileLoader` and `ImageLoader`, and added unit tests that demonstrate its behaviour.