### PR TITLE
FBXLoader: support embedded textures with jpeg extension

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -238,6 +238,7 @@
 				break;
 
 			case 'jpg':
+			case 'jpeg':
 
 				type = 'image/jpeg';
 				break;


### PR DESCRIPTION
Tiny fix for an issue I came across just now. 