### PR TITLE
Fix MMDPhysics: replace Vector3 with Euler for currentRotation

### DIFF
--- a/examples/js/animation/MMDPhysics.js
+++ b/examples/js/animation/MMDPhysics.js
@@ -59,7 +59,7 @@ THREE.MMDPhysics.prototype = {
 
 		var helper = this.helper;
 		var currentPosition = helper.allocThreeVector3();
-		var currentRotation = helper.allocThreeVector3();
+		var currentRotation = helper.allocThreeEuler();
 		var currentScale = helper.allocThreeVector3();
 
 		currentPosition.copy( mesh.position );
@@ -91,7 +91,7 @@ THREE.MMDPhysics.prototype = {
 		this.reset();
 
 		helper.freeThreeVector3( currentPosition );
-		helper.freeThreeVector3( currentRotation );
+		helper.freeThreeEuler( currentRotation );
 		helper.freeThreeVector3( currentScale );
 
 	},


### PR DESCRIPTION
This PR fixes `MMDPhysics` bug.

I should've used `Euler`, not `Vector3`, for `.rotation`.