### PR TITLE
Replace javascript keywords with non-conflicting alternatives

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -377,9 +377,9 @@ UI.Select = function () {
 UI.Select.prototype = Object.create( UI.Element.prototype );
 UI.Select.prototype.constructor = UI.Select;
 
-UI.Select.prototype.setMultiple = function ( boolean ) {
+UI.Select.prototype.setMultiple = function ( multiple ) {
 
-	this.dom.multiple = boolean;
+	this.dom.multiple = multiple;
 
 	return this;
 
@@ -432,7 +432,7 @@ UI.Select.prototype.setValue = function ( value ) {
 
 // Checkbox
 
-UI.Checkbox = function ( boolean ) {
+UI.Checkbox = function ( checked ) {
 
 	UI.Element.call( this );
 
@@ -443,7 +443,7 @@ UI.Checkbox = function ( boolean ) {
 	dom.type = 'checkbox';
 
 	this.dom = dom;
-	this.setValue( boolean );
+	this.setValue( checked );
 
 	return this;
 

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -437,13 +437,13 @@ UI.Outliner.prototype.setValue = function ( value ) {
 
 UI.THREE = {};
 
-UI.THREE.Boolean = function ( boolean, text ) {
+UI.THREE.Boolean = function ( value, text ) {
 
 	UI.Span.call( this );
 
 	this.setMarginRight( '10px' );
 
-	this.checkbox = new UI.Checkbox( boolean );
+	this.checkbox = new UI.Checkbox( value );
 	this.text = new UI.Text( text ).setMarginLeft( '3px' );
 
 	this.add( this.checkbox );

--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -502,9 +502,9 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 
 	};
 
-	this.setScissorTest = function ( boolean ) {
+	this.setScissorTest = function ( scissorTest ) {
 
-		renderer.setScissorTest( boolean );
+		renderer.setScissorTest( scissorTest );
 
 	};
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -139,7 +139,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	window.addEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
 
-	this.setFullScreen = function ( boolean ) {
+	this.setFullScreen = function ( fullscreen ) {
 
 		return new Promise( function ( resolve, reject ) {
 
@@ -157,7 +157,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			if ( boolean ) {
+			if ( fullscreen ) {
 
 				resolve( vrDisplay.requestPresent( [ { source: canvas } ] ) );
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1308,10 +1308,10 @@ Object.assign( WebGLRenderer.prototype, {
 		return this.extensions.get( 'ANGLE_instanced_arrays' );
 
 	},
-	enableScissorTest: function ( boolean ) {
+	enableScissorTest: function ( scissorTest ) {
 
 		console.warn( 'THREE.WebGLRenderer: .enableScissorTest() is now .setScissorTest().' );
-		this.setScissorTest( boolean );
+		this.setScissorTest( scissorTest );
 
 	},
 	initMaterial: function () {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -433,9 +433,9 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	this.setScissorTest = function ( boolean ) {
+	this.setScissorTest = function ( scissorTest ) {
 
-		state.setScissorTest( _scissorTest = boolean );
+		state.setScissorTest( _scissorTest = scissorTest );
 
 	};
 


### PR DESCRIPTION
I use the YUI Compressor to generate a compressed version of three.js and the additional files used in my project. YUI Compressor requires a very strictly valid javascript syntax and fails because javascript keywords are used as parameter or variable names in several places of three.js. After my changes the YUI Compressor does no longer complain.