### PR TITLE
Typo: unline > unlike

### DIFF
--- a/docs/api/helpers/VertexNormalsHelper.html
+++ b/docs/api/helpers/VertexNormalsHelper.html
@@ -17,7 +17,7 @@
 			Requires that normals have been specified in a [page:BufferAttribute custom attribute] or
 			have been calculated using [page:Geometry.computeVertexNormals computeVertexNormals].<br /><br />
 
-			Unline [page:FaceNormalsHelper], this works with [page:BufferGeometry].
+			Unlike [page:FaceNormalsHelper], this works with [page:BufferGeometry].
 		</div>
 
 		<h2>Example</h2>


### PR DESCRIPTION
The phrase "Unline FaceNormalsHelper, this works with BufferGeometry." should be "Unlike FaceNormalsHelper, this works with BufferGeometry."