### PR TITLE
FBXLoader: fix bug where last material index group is not added

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -112,7 +112,7 @@
 
 			}
 
-			console.log( FBXTree );
+			// console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -112,7 +112,7 @@
 
 			}
 
-			// console.log( FBXTree );
+			console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );
@@ -1059,6 +1059,27 @@
 				startIndex = i;
 
 			}
+
+		}
+
+		// the loop above doesn't add the last group, do that here.
+		if ( geo.groups.length > 0 ) {
+
+			var lastGroup = geo.groups[ geo.groups.length - 1 ];
+			var lastIndex = lastGroup.start + lastGroup.count;
+
+			if ( lastIndex !== materialIndexBuffer.length ) {
+
+				geo.addGroup( lastIndex, materialIndexBuffer.length - lastIndex, prevMaterialIndex );
+
+			}
+
+		}
+
+		// catch case where the whole geometry has a single non-zero index
+		if ( geo.groups.length === 0 && materialIndexBuffer[ 0 ] !== 0 ) {
+
+			geo.addGroup( 0, materialIndexBuffer.length, materialIndexBuffer[ 0 ] );
 
 		}
 


### PR DESCRIPTION
Sometimes a mesh with multiple materials displays weirdly when loaded by the FBXLoader:

![pre](https://user-images.githubusercontent.com/5307958/31808829-16ef634e-b59f-11e7-9719-ab1be7376382.jpg)

The head here is a single mesh with multiple materials - everything displays correctly (...nearly! ) except for the few missing poly's in the front. 

What's happening is that the last group doesn't get added to the buffergeometry, so the last few triangles that should have material index 3 are defaulting to material index 0.

After this fix:

![post](https://user-images.githubusercontent.com/5307958/31808897-7eb8a6f2-b59f-11e7-8273-c0df2dfd101b.jpg)

Additionally, I've added a check for an edge case where the entire geometry has a non-zero material index - previously no group at all was created, so that, for example, a geometry that was entirely material index 3 would always be loaded with default material index 0. 

Test model for both scenarios here:
[fbx_material_index_test.zip](https://github.com/mrdoob/three.js/files/1401009/fbx_material_index_test.zip)

