### PR TITLE
gl.SAMPLE_ALPHA_TO_COVERAGE support

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -57,6 +57,8 @@ function Material() {
 	this.alphaTest = 0;
 	this.premultipliedAlpha = false;
 
+	this.alphaToCoverage = false;
+
 	this.overdraw = 0; // Overdrawn pixels (typically between 0 and 1) for fixing antialiasing gaps in CanvasRenderer
 
 	this.visible = true;
@@ -238,6 +240,8 @@ Object.assign( Material.prototype, EventDispatcher.prototype, {
 		if ( this.alphaTest > 0 ) data.alphaTest = this.alphaTest;
 		if ( this.premultipliedAlpha === true ) data.premultipliedAlpha = this.premultipliedAlpha;
 
+		if ( this.alphaToCoverage === true ) data.alphaToCoverage = this.alphaToCoverage;
+
 		if ( this.wireframe === true ) data.wireframe = this.wireframe;
 		if ( this.wireframeLinewidth > 1 ) data.wireframeLinewidth = this.wireframeLinewidth;
 		if ( this.wireframeLinecap !== 'round' ) data.wireframeLinecap = this.wireframeLinecap;
@@ -325,6 +329,8 @@ Object.assign( Material.prototype, EventDispatcher.prototype, {
 
 		this.alphaTest = source.alphaTest;
 		this.premultipliedAlpha = source.premultipliedAlpha;
+
+		this.alphaToCoverage = source.alphaToCoverage;
 
 		this.overdraw = source.overdraw;
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -665,6 +665,10 @@ function WebGLState( gl, extensions, utils ) {
 
 		setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
+		material.alphaToCoverage === true
+			? enable( gl.SAMPLE_ALPHA_TO_COVERAGE )
+			: disable( gl.SAMPLE_ALPHA_TO_COVERAGE );
+
 	}
 
 	//


### PR DESCRIPTION
#12438

This PR adds `gl.SAMPLE_ALPHA_TO_COVERAGE` support. User can control it with `material.alphaToCoverage`.

I'm not familiar with sample coverage, do you folks think we also need `gl.SAMPLE_COVERAGE` and `gl.sampleCoverage()`?

/cc @mattdesl 
