### PR TITLE
Replace 'http-server' with 'serve'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build-test": "rollup -c test/rollup.unit.config.js",
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar node_modules/google-closure-compiler/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
-    "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"http-server\"",
+    "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"serve --port 8080\"",
     "start": "npm run dev",
     "lint": "eslint src",
     "test": "rollup -c test/rollup.unit.config.js -w",
@@ -55,10 +55,10 @@
     "eslint": "^4.1.1",
     "eslint-config-mdcs": "^4.2.2",
     "google-closure-compiler": "^20170521.0.0",
-    "http-server": "^0.10.0",
     "qunitjs": "^2.1.1",
     "rollup": "^0.43.0",
     "rollup-watch": "^4.0.0",
+    "serve": "^6.3.1",
     "uglify-js": "^3.0.23"
   }
 }


### PR DESCRIPTION
I just spent a silly amount of time stuck on what turned out to be [incorrect content-type encoding](https://github.com/indexzero/http-server/issues/296) added  by the `http-server` module, while trying to test out the ImageBitmapLoader example. 😫

The bug has been open a while, so to save others this particular future pain I suggest changing to [zeit/serve](https://github.com/zeit/serve). It also has slightly prettier formatting, for what that's worth:


![screen shot 2017-10-20 at 6 00 11 pm](https://user-images.githubusercontent.com/1848368/31846437-8de872f8-b5c0-11e7-87dc-5f73a2066e07.png)
