### PR TITLE
Use renderer.domElement.addEventListener instead of window.addEventListener

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -62,11 +62,7 @@ function WebVRManager( renderer ) {
 
 	}
 
-	if ( typeof window !== 'undefined' ) {
-
-		window.addEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
-
-	}
+	renderer.domElement.addEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
 
 	//
 
@@ -215,7 +211,7 @@ function WebVRManager( renderer ) {
 
 	this.dispose = function () {
 
-		window.removeEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange );
+		renderer.domElement.removeEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange );
 
 	};
 


### PR DESCRIPTION
We're doing some experiments with running three.js in ReactNative with the help of [react-native-webgl](https://github.com/react-community/react-native-webgl). 

The latest release and the tip of `dev` branch fails when `WebVRManager` tries to invoke `window.addEventListener` when we initialise `WebGLRenderer`. There is a check for type of window but it fails on ReactNative as we have a `window` object but it doesn't have `addEventListener` methods. 

I noticed that you don't invoke `window.addEventListener` in WebGLRenderer but rather use methods on the provided context object. I thus changed `WebVRManager` to use the same `addEventListener` methods on the provider `renderer.domElement`

I wasn't sure if this PR should include changes to `build`. I can remove those if you only add those on actual releases.