### PR TITLE
 ColladaLoader: Improve node parsing

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -128,6 +128,12 @@ THREE.ColladaLoader.prototype = {
 
 		}
 
+		function generateId() {
+
+			return 'three_default_' + ( count ++ );
+
+		}
+
 		function isEmpty( object ) {
 
 			return Object.keys( object ).length === 0;
@@ -2727,7 +2733,7 @@ THREE.ColladaLoader.prototype = {
 			var data = {
 				name: xml.getAttribute( 'name' ),
 				type: xml.getAttribute( 'type' ),
-				id: xml.getAttribute( 'id' ),
+				id: xml.getAttribute( 'id' ) || generateId(),
 				sid: xml.getAttribute( 'sid' ),
 				matrix: new THREE.Matrix4(),
 				nodes: [],
@@ -2749,13 +2755,8 @@ THREE.ColladaLoader.prototype = {
 
 					case 'node':
 
-						if ( child.hasAttribute( 'id' ) ) {
-
-							data.nodes.push( child.getAttribute( 'id' ) );
-							parseNode( child );
-
-						}
-
+						data.nodes.push( child.getAttribute( 'id' ) || generateId() );
+						parseNode( child );
 						break;
 
 					case 'instance_camera':
@@ -2814,11 +2815,7 @@ THREE.ColladaLoader.prototype = {
 
 			}
 
-			if ( xml.hasAttribute( 'id' ) ) {
-
-				library.nodes[ xml.getAttribute( 'id' ) ] = data;
-
-			}
+			library.nodes[ data.id ] = data;
 
 			return data;
 
@@ -3345,6 +3342,7 @@ THREE.ColladaLoader.prototype = {
 
 		var animations = [];
 		var kinematics = {};
+		var count = 0;
 
 		//
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -2725,6 +2725,26 @@ THREE.ColladaLoader.prototype = {
 
 		// nodes
 
+		function prepareNodes( xml ) {
+
+			var elements = xml.getElementsByTagName( 'node' );
+
+			// ensure all node elements have id attributes
+
+			for ( var i = 0; i < elements.length; i ++ ) {
+
+				var element = elements[ i ];
+
+				if ( element.hasAttribute( 'id' ) === false ) {
+
+					element.setAttribute( 'id', generateId() );
+
+				}
+
+			}
+
+		}
+
 		var matrix = new THREE.Matrix4();
 		var vector = new THREE.Vector3();
 
@@ -2733,7 +2753,7 @@ THREE.ColladaLoader.prototype = {
 			var data = {
 				name: xml.getAttribute( 'name' ),
 				type: xml.getAttribute( 'type' ),
-				id: xml.getAttribute( 'id' ) || generateId(),
+				id: xml.getAttribute( 'id' ),
 				sid: xml.getAttribute( 'sid' ),
 				matrix: new THREE.Matrix4(),
 				nodes: [],
@@ -2754,8 +2774,7 @@ THREE.ColladaLoader.prototype = {
 				switch ( child.nodeName ) {
 
 					case 'node':
-
-						data.nodes.push( child.getAttribute( 'id' ) || generateId() );
+						data.nodes.push( child.getAttribute( 'id' ) );
 						parseNode( child );
 						break;
 
@@ -3216,6 +3235,8 @@ THREE.ColladaLoader.prototype = {
 				name: xml.getAttribute( 'name' ),
 				children: []
 			};
+
+			prepareNodes( xml );
 
 			var elements = getElementsByTagName( xml, 'node' );
 


### PR DESCRIPTION
Solves #12443

The loader ensures now that all nodes have an `ID`  attribute. Missing values are generated with a simple counter.