### PR TITLE
FBXLoader switch Standard to Phong

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1745,7 +1745,7 @@
 
 						} else {
 
-							material = new THREE.MeshStandardMaterial( { color: 0x3300ff } );
+							material = new THREE.MeshPhongdMaterial( { color: 0xcccccc } );
 							materials.push( material );
 
 						}

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1745,7 +1745,7 @@
 
 						} else {
 
-							material = new THREE.MeshPhongdMaterial( { color: 0xcccccc } );
+							material = new THREE.MeshPhongMaterial( { color: 0xcccccc } );
 							materials.push( material );
 
 						}


### PR DESCRIPTION
FBX format currently doesn't support PBR so switched one last case for default material creation from Standard to Phong. Also changed the color from blue to a neutral grey. 