### PR TITLE
FBXLoader better fix for ASCII base64 image parsing error

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -262,14 +262,6 @@
 
 		if ( typeof content === 'string' ) {
 
-			// ASCII format sometimes an extra ',' gets added to the end of the content string
-			// TODO: Investigate why the parser is adding this character
-			if ( content.slice( - 1 ) === ',' ) {
-
-				content = content.slice( 0, - 1 );
-
-			}
-
 			return 'data:' + type + ';base64,' + content;
 
 		} else {
@@ -4144,7 +4136,7 @@
 					//	 "iVB..."
 					if ( propName === 'Content' && propValue === ',' ) {
 
-						propValue = split[ ++ lineNum ].replace( /"/g, '' ).trim();
+            propValue = split[ ++ lineNum ].replace( /"/g, '' ).replace( /,$/, '' ).trim();
 
 					}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -4136,7 +4136,7 @@
 					//	 "iVB..."
 					if ( propName === 'Content' && propValue === ',' ) {
 
-            propValue = split[ ++ lineNum ].replace( /"/g, '' ).replace( /,$/, '' ).trim();
+						propValue = split[ ++ lineNum ].replace( /"/g, '' ).replace( /,$/, '' ).trim();
 
 					}
 


### PR DESCRIPTION
See #12318

Strip the trailing comma in the TextParser.