### PR TITLE
OBJLoader2 V2.1.1

### DIFF
--- a/examples/js/loaders/LoaderSupport.js
+++ b/examples/js/loaders/LoaderSupport.js
@@ -891,7 +891,7 @@ THREE.LoaderSupport.WorkerRunnerRefImpl = (function () {
 	function WorkerRunnerRefImpl() {
 		var scope = this;
 		var scopedRunner = function( event ) {
-			scope.run( event.data );
+			scope.processMessage( event.data );
 		};
 		self.addEventListener( 'message', scopedRunner, false );
 	}
@@ -927,12 +927,15 @@ THREE.LoaderSupport.WorkerRunnerRefImpl = (function () {
 	 *
 	 * @param {Object} payload Raw mesh description (buffers, params, materials) used to build one to many meshes.
 	 */
-	WorkerRunnerRefImpl.prototype.run = function ( payload ) {
-		var logger = new ConsoleLogger( payload.logger.enabled, payload.logger.debug );
+	WorkerRunnerRefImpl.prototype.processMessage = function ( payload ) {
+		var logger = new ConsoleLogger();
+		if ( Validator.isValid( payload.logger ) ) {
 
+			logger.setEnabled( payload.logger.enabled );
+			logger.setDebug( payload.logger.debug );
+
+		}
 		if ( payload.cmd === 'run' ) {
-
-			logger.logInfo( 'WorkerRunner: Starting Run...' );
 
 			var callbacks = {
 				callbackBuilder: function ( payload ) {
@@ -948,7 +951,8 @@ THREE.LoaderSupport.WorkerRunnerRefImpl = (function () {
 			this.applyProperties( parser, payload.params );
 			this.applyProperties( parser, payload.materials );
 			this.applyProperties( parser, callbacks );
-			parser.parse( payload.buffers.input );
+			parser.workerScope = self;
+			parser.parse( payload.data.input, payload.data.options );
 
 			logger.logInfo( 'WorkerRunner: Run complete!' );
 
@@ -976,7 +980,7 @@ THREE.LoaderSupport.WorkerRunnerRefImpl = (function () {
  */
 THREE.LoaderSupport.WorkerSupport = (function () {
 
-	var WORKER_SUPPORT_VERSION = '1.1.0';
+	var WORKER_SUPPORT_VERSION = '1.1.1';
 
 	var Validator = THREE.LoaderSupport.Validator;
 
@@ -1046,11 +1050,17 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 			var scope = this;
 			var buildWorkerCode = function ( baseWorkerCode ) {
 				scope.workerCode = baseWorkerCode;
+				if ( workerRunner == THREE.LoaderSupport.WorkerRunnerRefImpl ) {
+
+					scope.workerCode += buildObject( 'Validator', THREE.LoaderSupport.Validator );
+					scope.workerCode += buildSingelton( 'ConsoleLogger', 'ConsoleLogger', THREE.LoaderSupport.ConsoleLogger );
+
+				}
 				scope.workerCode += functionCodeBuilder( buildObject, buildSingelton );
 				scope.workerCode += buildSingelton( workerRunner.name, workerRunner.name, workerRunner );
 				scope.workerCode += 'new ' + workerRunner.name + '();\n\n';
 
-				var blob = new Blob( [ scope.workerCode ], { type: 'text/plain' } );
+				var blob = new Blob( [ scope.workerCode ], { type: 'application/javascript' } );
 				scope.worker = new Worker( window.URL.createObjectURL( blob ) );
 				scope.logger.logTimeEnd( 'buildWebWorkerCode' );
 
@@ -1059,10 +1069,8 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 
 					switch ( payload.cmd ) {
 						case 'meshData':
-							scope.callbacks.builder( payload );
-							break;
-
 						case 'materialData':
+						case 'imageData':
 							scope.callbacks.builder( payload );
 							break;
 
@@ -1072,14 +1080,18 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 
 							if ( scope.terminateRequested ) {
 
-								scope.logger.logInfo( 'WorkerSupport: Run is complete. Terminating application on request!' );
+								scope.logger.logInfo( 'WorkerSupport [' + workerRunner + ']: Run is complete. Terminating application on request!' );
 								scope.terminateWorker();
 
 							}
 							break;
 
+						case 'error':
+							scope.logger.logError( 'WorkerSupport [' + workerRunner + ']: Reported error: ' + payload.msg );
+							break;
+
 						default:
-							scope.logger.logError( 'WorkerSupport: Received unknown command: ' + payload.cmd );
+							scope.logger.logError( 'WorkerSupport [' + workerRunner + ']: Received unknown command: ' + payload.cmd );
 							break;
 
 					}
@@ -1183,6 +1195,7 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 	var buildSingelton = function ( fullName, internalName, object ) {
 		var objectString = fullName + ' = (function () {\n\n';
 		objectString += '\t' + object.prototype.constructor.toString() + '\n\n';
+		objectString = objectString.replace( object.name, internalName );
 
 		var funcString;
 		var objectPart;
@@ -1223,8 +1236,9 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 		if ( ! Validator.isValid( this.callbacks.builder ) ) throw 'Unable to run as no "builder" callback is set.';
 		if ( ! Validator.isValid( this.callbacks.onLoad ) ) throw 'Unable to run as no "onLoad" callback is set.';
 		if ( Validator.isValid( this.worker ) || this.loading ) {
-			this.running = true;
+			if ( payload.cmd !== 'run' ) payload.cmd = 'run';
 			this.queuedMessage = payload;
+			this.running = true;
 			this._postMessage();
 
 		}

--- a/examples/webgl_loader_obj2.html
+++ b/examples/webgl_loader_obj2.html
@@ -139,14 +139,14 @@
 
 				OBJLoader2Example.prototype.initContent = function () {
 					var modelName = 'female02';
-					this._reportProgress( 'Loading: ' + modelName );
+					this._reportProgress( { detail: { text: 'Loading: ' + modelName } } );
 
 					var scope = this;
 					var objLoader = new THREE.OBJLoader2();
 					var callbackOnLoad = function ( event ) {
 						scope.scene.add( event.detail.loaderRootNode );
 						console.log( 'Loading complete: ' + event.detail.modelName );
-						scope._reportProgress( '' );
+						scope._reportProgress( { detail: { text: '' } } );
 					};
 
 					var onLoadMtl = function ( materials ) {
@@ -160,9 +160,10 @@
 					objLoader.loadMtl( 'obj/female02/female02.mtl', 'female02.mtl', null, onLoadMtl );
 				};
 
-				OBJLoader2Example.prototype._reportProgress = function( content ) {
-					console.log( 'Progress: ' + content );
-					document.getElementById( 'feedback' ).innerHTML = Validator.isValid( content ) ? content : '';
+				OBJLoader2Example.prototype._reportProgress = function( event ) {
+					var output = Validator.verifyInput( event.detail.text, '' );
+					console.log( 'Progress: ' + output );
+					document.getElementById( 'feedback' ).innerHTML = output;
 				};
 
 				OBJLoader2Example.prototype.resizeDisplayGL = function () {

--- a/examples/webgl_loader_obj2_meshspray.html
+++ b/examples/webgl_loader_obj2_meshspray.html
@@ -140,10 +140,8 @@
 					var buildCode = function ( funcBuildObject, funcBuildSingelton ) {
 						var workerCode = '';
 						workerCode += '/**\n';
-						workerCode += '  * This code was constructed by MeshSpray buildWorkerCode.\n';
+						workerCode += '  * This code was constructed by MeshSpray buildCode.\n';
 						workerCode += '  */\n\n';
-						workerCode += funcBuildObject( 'Validator', Validator );
-						workerCode += funcBuildSingelton( 'ConsoleLogger', 'ConsoleLogger', ConsoleLogger );
 						workerCode += funcBuildSingelton( 'Parser', 'Parser', Parser );
 
 						return workerCode;
@@ -153,7 +151,6 @@
 					this.workerSupport.setCallbacks( scopeBuilderFunc, scopeFuncComplete );
 					this.workerSupport.run(
 						{
-							cmd: 'run',
 							params: {
 								dimension: prepData.dimension,
 								quantity: prepData.quantity,
@@ -166,8 +163,9 @@
 								debug: this.logger.debug,
 								enabled: this.logger.enabled
 							},
-							buffers: {
-								input: null
+							data: {
+								input: null,
+								options: null
 							}
 						}
 					);


### PR DESCRIPTION
Bugs:
- Issue 21 from development repository: Fixed 'o' or 'g' declaration lead to early cleanup of stored vertex data

Enhancements:
- WorkerSupport: Added worker payloads "imageData" and "error". These are useful changes resulting from `ImageBitmapLoader` experiments. They should be incorporated independent of whether LoaderSupport is used in that context.