### PR TITLE
Fix "saturate" macro redefined error

### DIFF
--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl
@@ -1,5 +1,3 @@
-#define saturate(a) clamp( a, 0.0, 1.0 )
-
 uniform float toneMappingExposure;
 uniform float toneMappingWhitePoint;
 


### PR DESCRIPTION
Only on some mobile GPU. (eg. Mali-720T)