### PR TITLE
Fix cross product of Vector3 with self

### DIFF
--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -539,6 +539,7 @@ Object.assign( Vector3.prototype, {
 
 		}
 
+		if ( v === this ) v = v.clone();
 		var x = this.x, y = this.y, z = this.z;
 
 		this.x = y * v.z - z * v.y;


### PR DESCRIPTION
Currently the cross product of a three-dimensional vector with itself produces an incorrect result:

```
t = new THREE.Vector3(1,1,1);
t.cross(t);

Vector3 {x: 0, y: -1, z: -1, isVector3: true, set: function, …}
```

The correct answer is zero for all components. I've committed one simple workaround: I'm sure there are others.