### PR TITLE
Strict path check with undefined in GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -24,7 +24,7 @@ THREE.GLTFLoader = ( function () {
 
 			var scope = this;
 
-			var path = this.path && ( typeof this.path === 'string' ) ? this.path : THREE.Loader.prototype.extractUrlBase( url );
+			var path = this.path !== undefined ? this.path : THREE.Loader.prototype.extractUrlBase( url );
 
 			var loader = new THREE.FileLoader( scope.manager );
 
@@ -122,9 +122,11 @@ THREE.GLTFLoader = ( function () {
 
 			console.time( 'GLTFLoader' );
 
+			if ( path === undefined ) path = this.path !== undefined ? this.path : '';
+
 			var parser = new GLTFParser( json, extensions, {
 
-				path: path || this.path,
+				path: path,
 				crossOrigin: this.crossOrigin,
 				manager: this.manager
 
@@ -1117,7 +1119,7 @@ THREE.GLTFLoader = ( function () {
 		}
 
 		// Relative URL
-		return ( path || '' ) + url;
+		return path + url;
 
 	}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -122,11 +122,9 @@ THREE.GLTFLoader = ( function () {
 
 			console.time( 'GLTFLoader' );
 
-			if ( path === undefined ) path = this.path !== undefined ? this.path : '';
-
 			var parser = new GLTFParser( json, extensions, {
 
-				path: path,
+				path: path || this.path || '',
 				crossOrigin: this.crossOrigin,
 				manager: this.manager
 


### PR DESCRIPTION
I think we need strict `path` check with `undefined` for the case `path` is `''`.
And I don't think we need `( typeof this.path === 'string' )` check, we generally don't check type unless there's any special reasons.

One more thing. `resoveURL()` doesn't need to check `path` if we set default `path` passed to `GLTFParser` as `option` in case both argument `path` and `this.path` are `undefined`. This'd be more straightforward and readable?

/cc @donmccurdy 