### PR TITLE
FBXloader: removed parseGeometry default case

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -640,7 +640,7 @@
 				return parseMeshGeometry( geometryNode, relationships, deformers );
 				break;
 
-      case 'NurbsCurve':
+			case 'NurbsCurve':
 				return parseNurbsGeometry( geometryNode );
 				break;
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -640,13 +640,9 @@
 				return parseMeshGeometry( geometryNode, relationships, deformers );
 				break;
 
-			case 'NurbsCurve':
+      case 'NurbsCurve':
 				return parseNurbsGeometry( geometryNode );
 				break;
-
-			default:
-				console.error( 'FBXLoader: Unsupported geometry type %s', geometryNode.attrType );
-				return THREE.BufferGeometry();
 
 		}
 


### PR DESCRIPTION
Adding a default case to parseGeometry throws errors with Xsi man model since it has some geometries defined as 'nurb' type.

Should have checked this more carefully 😅 