### PR TITLE
FBXLoader create buffer geometry directly

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -50,9 +50,7 @@
 
 				try {
 
-					console.time( 'parse: ' );
 					var scene = self.parse( buffer, resourceDirectory );
-					console.timeEnd( 'parse: ' );
 					onLoad( scene );
 
 				} catch ( error ) {
@@ -676,13 +674,13 @@
 		var vertexIndices = subNodes.PolygonVertexIndex.properties.a;
 
 		// create arrays to hold the final data used to build the buffergeometry
-		var vertexB = [];
-		var normalB = [];
-		var colorsB = [];
-		var uvsB = [];
-		var materialsB = [];
-		var weightsB = [];
-		var weightsIndicesB = [];
+		var vertexBuffer = [];
+		var normalBuffer = [];
+		var colorsBuffer = [];
+		var uvsBuffer = [];
+		var materialIndexBuffer = [];
+		var vertexWeightsBuffer = [];
+		var weightsIndicesBuffer = [];
 
 		if ( subNodes.LayerElementColor ) {
 
@@ -899,17 +897,17 @@
 
 				for ( var i = 2; i < faceLength; i ++ ) {
 
-					vertexB.push(	vertexPositions[ vertexPositionIndexes[ 0 ] ] );
-					vertexB.push(	vertexPositions[ vertexPositionIndexes[ 1 ] ] );
-					vertexB.push(	vertexPositions[ vertexPositionIndexes[ 2 ] ] );
+					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ 0 ] ] );
+					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ 1 ] ] );
+					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ 2 ] ] );
 
-					vertexB.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 ] ] );
-					vertexB.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 1 ] ] );
-					vertexB.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 2 ] ] );
+					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 ] ] );
+					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 1 ] ] );
+					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 2 ] ] );
 
-					vertexB.push(	vertexPositions[ vertexPositionIndexes[ i * 3 ] ] );
-					vertexB.push(	vertexPositions[ vertexPositionIndexes[ i * 3 + 1 ] ] );
-					vertexB.push(	vertexPositions[ vertexPositionIndexes[ i * 3 + 2 ] ] );
+					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ i * 3 ] ] );
+					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ i * 3 + 1 ] ] );
+					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ i * 3 + 2 ] ] );
 
 				}
 
@@ -917,35 +915,35 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						weightsB.push(	faceWeights[ 0 ] );
-						weightsB.push( faceWeights[ 1 ] );
-						weightsB.push( faceWeights[ 2 ] );
-						weightsB.push( faceWeights[ 3 ] );
+						vertexWeightsBuffer.push(	faceWeights[ 0 ] );
+						vertexWeightsBuffer.push( faceWeights[ 1 ] );
+						vertexWeightsBuffer.push( faceWeights[ 2 ] );
+						vertexWeightsBuffer.push( faceWeights[ 3 ] );
 
-						weightsB.push( faceWeights[ ( i - 1 ) * 4 ] );
-						weightsB.push( faceWeights[ ( i - 1 ) * 4 + 1 ] );
-						weightsB.push( faceWeights[ ( i - 1 ) * 4 + 2 ] );
-						weightsB.push( faceWeights[ ( i - 1 ) * 4 + 3 ] );
+						vertexWeightsBuffer.push( faceWeights[ ( i - 1 ) * 4 ] );
+						vertexWeightsBuffer.push( faceWeights[ ( i - 1 ) * 4 + 1 ] );
+						vertexWeightsBuffer.push( faceWeights[ ( i - 1 ) * 4 + 2 ] );
+						vertexWeightsBuffer.push( faceWeights[ ( i - 1 ) * 4 + 3 ] );
 
-						weightsB.push( faceWeights[ i * 4 ] );
-						weightsB.push( faceWeights[ i * 4 + 1 ] );
-						weightsB.push( faceWeights[ i * 4 + 2 ] );
-						weightsB.push( faceWeights[ i * 4 + 3 ] );
+						vertexWeightsBuffer.push( faceWeights[ i * 4 ] );
+						vertexWeightsBuffer.push( faceWeights[ i * 4 + 1 ] );
+						vertexWeightsBuffer.push( faceWeights[ i * 4 + 2 ] );
+						vertexWeightsBuffer.push( faceWeights[ i * 4 + 3 ] );
 
-						weightsIndicesB.push(	faceWeightIndices[ 0 ] );
-						weightsIndicesB.push(	faceWeightIndices[ 1 ] );
-						weightsIndicesB.push(	faceWeightIndices[ 2 ] );
-						weightsIndicesB.push(	faceWeightIndices[ 3 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ 0 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ 1 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ 2 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ 3 ] );
 
-						weightsIndicesB.push(	faceWeightIndices[ ( i - 1 ) * 4 ] );
-						weightsIndicesB.push(	faceWeightIndices[ ( i - 1 ) * 4 + 1 ] );
-						weightsIndicesB.push(	faceWeightIndices[ ( i - 1 ) * 4 + 2 ] );
-						weightsIndicesB.push(	faceWeightIndices[ ( i - 1 ) * 4 + 3 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ ( i - 1 ) * 4 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ ( i - 1 ) * 4 + 1 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ ( i - 1 ) * 4 + 2 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ ( i - 1 ) * 4 + 3 ] );
 
-						weightsIndicesB.push(	faceWeightIndices[ i * 4 ] );
-						weightsIndicesB.push(	faceWeightIndices[ i * 4 + 1 ] );
-						weightsIndicesB.push(	faceWeightIndices[ i * 4 + 2 ] );
-						weightsIndicesB.push(	faceWeightIndices[ i * 4 + 3 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ i * 4 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ i * 4 + 1 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ i * 4 + 2 ] );
+						weightsIndicesBuffer.push(	faceWeightIndices[ i * 4 + 3 ] );
 
 					}
 
@@ -955,17 +953,17 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						normalB.push(	faceNormals[ 0 ] );
-						normalB.push(	faceNormals[ 1 ] );
-						normalB.push(	faceNormals[ 2 ] );
+						normalBuffer.push(	faceNormals[ 0 ] );
+						normalBuffer.push(	faceNormals[ 1 ] );
+						normalBuffer.push(	faceNormals[ 2 ] );
 
-						normalB.push(	faceNormals[ ( i - 1 ) * 3 ] );
-						normalB.push(	faceNormals[ ( i - 1 ) * 3 + 1 ] );
-						normalB.push(	faceNormals[ ( i - 1 ) * 3 + 2 ] );
+						normalBuffer.push(	faceNormals[ ( i - 1 ) * 3 ] );
+						normalBuffer.push(	faceNormals[ ( i - 1 ) * 3 + 1 ] );
+						normalBuffer.push(	faceNormals[ ( i - 1 ) * 3 + 2 ] );
 
-						normalB.push(	faceNormals[ i * 3 ] );
-						normalB.push(	faceNormals[ i * 3 + 1 ] );
-						normalB.push(	faceNormals[ i * 3 + 2 ] );
+						normalBuffer.push(	faceNormals[ i * 3 ] );
+						normalBuffer.push(	faceNormals[ i * 3 + 1 ] );
+						normalBuffer.push(	faceNormals[ i * 3 + 2 ] );
 
 					}
 
@@ -975,18 +973,18 @@
 
 					for ( var j = 0; j < uvInfo.length; j ++ ) {
 
-						if ( uvsB[ j ] === undefined ) uvsB[ j ] = [];
+						if ( uvsBuffer[ j ] === undefined ) uvsBuffer[ j ] = [];
 
 						for ( var i = 2; i < faceLength; i ++ ) {
 
-							uvsB[ j ].push( faceUVs[ j ][ 0 ] );
-							uvsB[ j ].push( faceUVs[ j ][ 1 ] );
+							uvsBuffer[ j ].push( faceUVs[ j ][ 0 ] );
+							uvsBuffer[ j ].push( faceUVs[ j ][ 1 ] );
 
-							uvsB[ j ].push(	faceUVs[ j ][ ( i - 1 ) * 2 ] );
-							uvsB[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 + 1 ] );
+							uvsBuffer[ j ].push(	faceUVs[ j ][ ( i - 1 ) * 2 ] );
+							uvsBuffer[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 + 1 ] );
 
-							uvsB[ j ].push(	faceUVs[ j ][ i * 2 ] );
-							uvsB[ j ].push(	faceUVs[ j ][ i * 2 + 1 ] );
+							uvsBuffer[ j ].push(	faceUVs[ j ][ i * 2 ] );
+							uvsBuffer[ j ].push(	faceUVs[ j ][ i * 2 + 1 ] );
 
 						}
 
@@ -999,17 +997,17 @@
 					for ( var i = 2; i < faceLength; i ++ ) {
 
 
-						colorsB.push(	faceColors[ 0 ] );
-						colorsB.push(	faceColors[ 1 ] );
-						colorsB.push(	faceColors[ 2 ] );
+						colorsBuffer.push(	faceColors[ 0 ] );
+						colorsBuffer.push(	faceColors[ 1 ] );
+						colorsBuffer.push(	faceColors[ 2 ] );
 
-						colorsB.push(	faceColors[ ( i - 1 ) * 3 ] );
-						colorsB.push(	faceColors[ ( i - 1 ) * 3 + 1 ] );
-						colorsB.push(	faceColors[ ( i - 1 ) * 3 + 2 ] );
+						colorsBuffer.push(	faceColors[ ( i - 1 ) * 3 ] );
+						colorsBuffer.push(	faceColors[ ( i - 1 ) * 3 + 1 ] );
+						colorsBuffer.push(	faceColors[ ( i - 1 ) * 3 + 2 ] );
 
-						colorsB.push(	faceColors[ i * 3 ] );
-						colorsB.push(	faceColors[ i * 3 + 1 ] );
-						colorsB.push(	faceColors[ i * 3 + 2 ] );
+						colorsBuffer.push(	faceColors[ i * 3 ] );
+						colorsBuffer.push(	faceColors[ i * 3 + 1 ] );
+						colorsBuffer.push(	faceColors[ i * 3 + 2 ] );
 
 					}
 
@@ -1021,9 +1019,9 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						materialsB.push(	materialIndex );
-						materialsB.push(	materialIndex );
-						materialsB.push(	materialIndex );
+						materialIndexBuffer.push(	materialIndex );
+						materialIndexBuffer.push(	materialIndex );
+						materialIndexBuffer.push(	materialIndex );
 
 					}
 
@@ -1039,8 +1037,8 @@
 				faceNormals = [];
 				faceColors = [];
 				faceUVs = [];
-    		faceWeights = [];
-    		faceWeightIndices = [];
+				faceWeights = [];
+				faceWeightIndices = [];
 
 			}
 
@@ -1049,33 +1047,33 @@
 		var geo = new THREE.BufferGeometry();
 		geo.name = geometryNode.name;
 
-		geo.addAttribute( 'position', new THREE.Float32BufferAttribute( vertexB, 3 ) );
+		geo.addAttribute( 'position', new THREE.Float32BufferAttribute( vertexBuffer, 3 ) );
 
-		if ( colorsB.length > 0 ) {
+		if ( colorsBuffer.length > 0 ) {
 
-			geo.addAttribute( 'color', new THREE.Float32BufferAttribute( colorsB, 3 ) );
+			geo.addAttribute( 'color', new THREE.Float32BufferAttribute( colorsBuffer, 3 ) );
 
 		}
 
 		if ( deformer ) {
 
-			geo.addAttribute( 'skinIndex', new THREE.Float32BufferAttribute( weightsIndicesB, 4 ) );
+			geo.addAttribute( 'skinIndex', new THREE.Float32BufferAttribute( weightsIndicesBuffer, 4 ) );
 
-			geo.addAttribute( 'skinWeight', new THREE.Float32BufferAttribute( weightsB, 4 ) );
+			geo.addAttribute( 'skinWeight', new THREE.Float32BufferAttribute( vertexWeightsBuffer, 4 ) );
 
 			// used later to bind the skeleton to the model
 			geo.FBX_Deformer = deformer;
 
 		}
 
-		if ( normalB.length > 0 ) {
+		if ( normalBuffer.length > 0 ) {
 
-			geo.addAttribute( 'normal', new THREE.Float32BufferAttribute( normalB, 3 ) );
+			geo.addAttribute( 'normal', new THREE.Float32BufferAttribute( normalBuffer, 3 ) );
 
 		}
-		if ( uvsB.length > 0 ) {
+		if ( uvsBuffer.length > 0 ) {
 
-			for ( var i = 0; i < uvsB.length; i ++ ) {
+			for ( var i = 0; i < uvsBuffer.length; i ++ ) {
 
 				var name = 'uv' + ( i + 1 ).toString();
 				if ( i == 0 ) {
@@ -1084,7 +1082,7 @@
 
 				}
 
-				geo.addAttribute( name, new THREE.Float32BufferAttribute( uvsB[ i ], 2 ) );
+				geo.addAttribute( name, new THREE.Float32BufferAttribute( uvsBuffer[ i ], 2 ) );
 
 			}
 
@@ -1093,7 +1091,6 @@
 		if ( materialInfo && materialInfo.mappingType !== 'AllSame' ) {
 
 			// Convert the material indices of each vertex into rendering groups on the geometry.
-			var materialIndexBuffer = materialsB;
 			var prevMaterialIndex = materialIndexBuffer[ 0 ];
 			var startIndex = 0;
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -897,17 +897,17 @@
 
 				for ( var i = 2; i < faceLength; i ++ ) {
 
-					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ 0 ] ] );
-					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ 1 ] ] );
-					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ 2 ] ] );
+					vertexBuffer.push( vertexPositions[ vertexPositionIndexes[ 0 ] ] );
+					vertexBuffer.push( vertexPositions[ vertexPositionIndexes[ 1 ] ] );
+					vertexBuffer.push( vertexPositions[ vertexPositionIndexes[ 2 ] ] );
 
-					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 ] ] );
-					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 1 ] ] );
-					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 2 ] ] );
+					vertexBuffer.push( vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 ] ] );
+					vertexBuffer.push( vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 1 ] ] );
+					vertexBuffer.push( vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 2 ] ] );
 
-					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ i * 3 ] ] );
-					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ i * 3 + 1 ] ] );
-					vertexBuffer.push(	vertexPositions[ vertexPositionIndexes[ i * 3 + 2 ] ] );
+					vertexBuffer.push( vertexPositions[ vertexPositionIndexes[ i * 3 ] ] );
+					vertexBuffer.push( vertexPositions[ vertexPositionIndexes[ i * 3 + 1 ] ] );
+					vertexBuffer.push( vertexPositions[ vertexPositionIndexes[ i * 3 + 2 ] ] );
 
 				}
 
@@ -915,7 +915,7 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						vertexWeightsBuffer.push(	faceWeights[ 0 ] );
+						vertexWeightsBuffer.push( faceWeights[ 0 ] );
 						vertexWeightsBuffer.push( faceWeights[ 1 ] );
 						vertexWeightsBuffer.push( faceWeights[ 2 ] );
 						vertexWeightsBuffer.push( faceWeights[ 3 ] );
@@ -930,20 +930,20 @@
 						vertexWeightsBuffer.push( faceWeights[ i * 4 + 2 ] );
 						vertexWeightsBuffer.push( faceWeights[ i * 4 + 3 ] );
 
-						weightsIndicesBuffer.push(	faceWeightIndices[ 0 ] );
-						weightsIndicesBuffer.push(	faceWeightIndices[ 1 ] );
-						weightsIndicesBuffer.push(	faceWeightIndices[ 2 ] );
-						weightsIndicesBuffer.push(	faceWeightIndices[ 3 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ 0 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ 1 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ 2 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ 3 ] );
 
-						weightsIndicesBuffer.push(	faceWeightIndices[ ( i - 1 ) * 4 ] );
-						weightsIndicesBuffer.push(	faceWeightIndices[ ( i - 1 ) * 4 + 1 ] );
-						weightsIndicesBuffer.push(	faceWeightIndices[ ( i - 1 ) * 4 + 2 ] );
-						weightsIndicesBuffer.push(	faceWeightIndices[ ( i - 1 ) * 4 + 3 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ ( i - 1 ) * 4 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ ( i - 1 ) * 4 + 1 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ ( i - 1 ) * 4 + 2 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ ( i - 1 ) * 4 + 3 ] );
 
-						weightsIndicesBuffer.push(	faceWeightIndices[ i * 4 ] );
-						weightsIndicesBuffer.push(	faceWeightIndices[ i * 4 + 1 ] );
-						weightsIndicesBuffer.push(	faceWeightIndices[ i * 4 + 2 ] );
-						weightsIndicesBuffer.push(	faceWeightIndices[ i * 4 + 3 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ i * 4 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ i * 4 + 1 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ i * 4 + 2 ] );
+						weightsIndicesBuffer.push( faceWeightIndices[ i * 4 + 3 ] );
 
 					}
 
@@ -953,17 +953,17 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						normalBuffer.push(	faceNormals[ 0 ] );
-						normalBuffer.push(	faceNormals[ 1 ] );
-						normalBuffer.push(	faceNormals[ 2 ] );
+						normalBuffer.push( faceNormals[ 0 ] );
+						normalBuffer.push( faceNormals[ 1 ] );
+						normalBuffer.push( faceNormals[ 2 ] );
 
-						normalBuffer.push(	faceNormals[ ( i - 1 ) * 3 ] );
-						normalBuffer.push(	faceNormals[ ( i - 1 ) * 3 + 1 ] );
-						normalBuffer.push(	faceNormals[ ( i - 1 ) * 3 + 2 ] );
+						normalBuffer.push( faceNormals[ ( i - 1 ) * 3 ] );
+						normalBuffer.push( faceNormals[ ( i - 1 ) * 3 + 1 ] );
+						normalBuffer.push( faceNormals[ ( i - 1 ) * 3 + 2 ] );
 
-						normalBuffer.push(	faceNormals[ i * 3 ] );
-						normalBuffer.push(	faceNormals[ i * 3 + 1 ] );
-						normalBuffer.push(	faceNormals[ i * 3 + 2 ] );
+						normalBuffer.push( faceNormals[ i * 3 ] );
+						normalBuffer.push( faceNormals[ i * 3 + 1 ] );
+						normalBuffer.push( faceNormals[ i * 3 + 2 ] );
 
 					}
 
@@ -980,11 +980,11 @@
 							uvsBuffer[ j ].push( faceUVs[ j ][ 0 ] );
 							uvsBuffer[ j ].push( faceUVs[ j ][ 1 ] );
 
-							uvsBuffer[ j ].push(	faceUVs[ j ][ ( i - 1 ) * 2 ] );
+							uvsBuffer[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 ] );
 							uvsBuffer[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 + 1 ] );
 
-							uvsBuffer[ j ].push(	faceUVs[ j ][ i * 2 ] );
-							uvsBuffer[ j ].push(	faceUVs[ j ][ i * 2 + 1 ] );
+							uvsBuffer[ j ].push( faceUVs[ j ][ i * 2 ] );
+							uvsBuffer[ j ].push( faceUVs[ j ][ i * 2 + 1 ] );
 
 						}
 
@@ -997,17 +997,17 @@
 					for ( var i = 2; i < faceLength; i ++ ) {
 
 
-						colorsBuffer.push(	faceColors[ 0 ] );
-						colorsBuffer.push(	faceColors[ 1 ] );
-						colorsBuffer.push(	faceColors[ 2 ] );
+						colorsBuffer.push( faceColors[ 0 ] );
+						colorsBuffer.push( faceColors[ 1 ] );
+						colorsBuffer.push( faceColors[ 2 ] );
 
-						colorsBuffer.push(	faceColors[ ( i - 1 ) * 3 ] );
-						colorsBuffer.push(	faceColors[ ( i - 1 ) * 3 + 1 ] );
-						colorsBuffer.push(	faceColors[ ( i - 1 ) * 3 + 2 ] );
+						colorsBuffer.push( faceColors[ ( i - 1 ) * 3 ] );
+						colorsBuffer.push( faceColors[ ( i - 1 ) * 3 + 1 ] );
+						colorsBuffer.push( faceColors[ ( i - 1 ) * 3 + 2 ] );
 
-						colorsBuffer.push(	faceColors[ i * 3 ] );
-						colorsBuffer.push(	faceColors[ i * 3 + 1 ] );
-						colorsBuffer.push(	faceColors[ i * 3 + 2 ] );
+						colorsBuffer.push( faceColors[ i * 3 ] );
+						colorsBuffer.push( faceColors[ i * 3 + 1 ] );
+						colorsBuffer.push( faceColors[ i * 3 + 2 ] );
 
 					}
 
@@ -1019,9 +1019,9 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						materialIndexBuffer.push(	materialIndex );
-						materialIndexBuffer.push(	materialIndex );
-						materialIndexBuffer.push(	materialIndex );
+						materialIndexBuffer.push( materialIndex );
+						materialIndexBuffer.push( materialIndex );
+						materialIndexBuffer.push( materialIndex );
 
 					}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -717,7 +717,7 @@
 
 			var materialInfo = getMaterials( subNodes.LayerElementMaterial[ 0 ] );
 
-			console.log( materialInfo)
+			// console.log( materialInfo)
 
 		}
 
@@ -897,7 +897,7 @@
 			if ( endOfFace ) {
 
 				var face = new Face();
-				face.genTrianglesFromVertices( faceVertexBuffer );
+        face.genTrianglesFromVertices( faceVertexBuffer );
 
 				for ( var i = 2; i < faceLength; i ++ ) {
 
@@ -913,7 +913,7 @@
 						vertexBuffer[ vertexPositionIndexes[ i * 3 ] ],
 						vertexBuffer[ vertexPositionIndexes[ i * 3 + 1 ] ],
 						vertexBuffer[ vertexPositionIndexes[ i * 3 + 2 ] ]
-					);
+          );
 
 				}
 
@@ -988,20 +988,19 @@
 
 				}
 
-				if ( materialInfo !== undefined ) {
+        if( materialInfo && materialInfo.mappingType !== 'AllSame' ) {
 
-					var materials = getData( polygonVertexIndex, polygonIndex, vertexIndex, materialInfo );
+					var materi = getData( polygonVertexIndex, polygonIndex, vertexIndex, materialInfo );
 
-					console.log( materials)
-					face.materialIndex = materials[ 0 ];
-					materialsB.push( materials[ 0 ] )
+          face.materialIndex = materi[ 0 ];
 
-				} else {
+          var materialIndex = getData(polygonVertexIndex, polygonIndex, vertexIndex, materialInfo)[0];
 
-					// if the mapping type is 'AllSame' then materialInfo is undefined and all faces use index 0
-					face.materialIndex = 0;
-					materialsB.push( 0 );
+          for (var i = 2; i < faceLength; i++) {
 
+            materialsB.push(materialIndex, materialIndex, materialIndex);
+
+          }
 				}
 
 				geometry.faces.push( face );
@@ -1024,16 +1023,16 @@
 
 		// console.log(geometry)
 
-		// console.log( bufferInfo.materialIndexBuffer );
-		// console.log( materialsB );
+		// console.log( 'original', bufferInfo.materialIndexBuffer );
+		// console.log( 'new', materialsB );
 
-		var is_same = (bufferInfo.materialIndexBuffer.length == materialsB.length) && bufferInfo.materialIndexBuffer.every( function ( element, index ) {
+		// var is_same = (bufferInfo.materialIndexBuffer.length == materialsB.length) && bufferInfo.materialIndexBuffer.every( function ( element, index ) {
 
-			return element === materialsB[ index ];
+		// 	return element === materialsB[ index ];
 
-		} );
+		// } );
 
-		console.log( is_same );
+		// console.log( is_same );
 
 
 		var geo = new THREE.BufferGeometry();
@@ -1081,7 +1080,7 @@
 		if ( materialInfo && materialInfo.mappingType !== 'AllSame' ) {
 
 			// Convert the material indices of each vertex into rendering groups on the geometry.
-			var materialIndexBuffer = bufferInfo.materialIndexBuffer;
+      var materialIndexBuffer = materialsB;
 			var prevMaterialIndex = materialIndexBuffer[ 0 ];
 			var startIndex = 0;
 
@@ -3150,7 +3149,7 @@
 			for ( var i = 0, l = triangles.length; i < l; ++ i ) {
 
 				triangles[ i ].flattenToBuffers( vertexBuffer, normalBuffer, uvBuffers, colorBuffer, skinIndexBuffer, skinWeightBuffer );
-				append( materialIndexBuffer, [ materialIndex, materialIndex, materialIndex ] );
+        append( materialIndexBuffer, [ materialIndex, materialIndex, materialIndex ] );
 
 			}
 
@@ -3195,11 +3194,11 @@
 			return {
 				// vertexBuffer: vertexBuffer,
 				// normalBuffer: normalBuffer,
-				uvBuffers: uvBuffers,
+				// uvBuffers: uvBuffers,
 				// colorBuffer: colorBuffer,
 				skinIndexBuffer: skinIndexBuffer,
 				skinWeightBuffer: skinWeightBuffer,
-				materialIndexBuffer: materialIndexBuffer
+				// materialIndexBuffer: materialIndexBuffer
 			};
 
 		}

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -98,7 +98,7 @@
 
 			}
 
-			console.log( FBXTree );
+			// console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );
@@ -644,6 +644,10 @@
 				return parseNurbsGeometry( geometryNode );
 				break;
 
+			default:
+				console.error( 'FBXLoader: Unsupported geometry type %s', geometryNode.attrType );
+				return THREE.BufferGeometry();
+
 		}
 
 	}
@@ -758,13 +762,13 @@
 
 			var endOfFace = false;
 
-      // Face index and vertex index arrays are combined in a single array
-      // A cube with quad faces looks like this:
-      // PolygonVertexIndex: *24 {
-      //  a: 0, 1, 3, -3, 2, 3, 5, -5, 4, 5, 7, -7, 6, 7, 1, -1, 1, 7, 5, -4, 6, 0, 2, -5
-      //  }
-      // Negative numbers mark the end of a face - first face here is 0, 1, 3, -3
-      // to find index of last vertex multiply by -1 and subtract 1: -3 * - 1 - 1 = 2
+			// Face index and vertex index arrays are combined in a single array
+			// A cube with quad faces looks like this:
+			// PolygonVertexIndex: *24 {
+			//  a: 0, 1, 3, -3, 2, 3, 5, -5, 4, 5, 7, -7, 6, 7, 1, -1, 1, 7, 5, -4, 6, 0, 2, -5
+			//  }
+			// Negative numbers mark the end of a face - first face here is 0, 1, 3, -3
+			// to find index of last vertex multiply by -1 and subtract 1: -3 * - 1 - 1 = 2
 			if ( vertexIndex < 0 ) {
 
 				vertexIndex = vertexIndex ^ - 1; // equivalent to ( x * -1 ) - 1
@@ -795,7 +799,6 @@
 					for ( var j = 0, jl = array.length; j < jl; j ++ ) {
 
 						weights.push( array[ j ].weight );
-
 						weightIndices.push( array[ j ].id );
 
 					}
@@ -872,12 +875,16 @@
 
 					var data = getData( polygonVertexIndex, polygonIndex, vertexIndex, uvInfo[ i ] );
 
-					if ( faceUVs[ i ] === undefined ) faceUVs[ i ] = [];
+					if ( faceUVs[ i ] === undefined ) {
+
+						faceUVs[ i ] = [];
+
+					}
 
 					faceUVs[ i ].push(
-              data[ 0 ],
-              data[ 1 ]
-            );
+						data[ 0 ],
+						data[ 1 ]
+					);
 
 				}
 
@@ -903,7 +910,7 @@
 						vertexPositions[ vertexPositionIndexes[ i * 3 ] ],
 						vertexPositions[ vertexPositionIndexes[ i * 3 + 1 ] ],
 						vertexPositions[ vertexPositionIndexes[ i * 3 + 2 ] ]
-          );
+					);
 
 				}
 
@@ -912,38 +919,38 @@
 					for ( var i = 2; i < faceLength; i ++ ) {
 
 						weightsB.push(
-              faceWeights[ 0 ],
-              faceWeights[ 1 ],
-              faceWeights[ 2 ],
-              faceWeights[ 3 ],
+							faceWeights[ 0 ],
+							faceWeights[ 1 ],
+							faceWeights[ 2 ],
+							faceWeights[ 3 ],
 
-              faceWeights[ ( i - 1 ) * 4 ],
-              faceWeights[ ( i - 1 ) * 4 + 1 ],
-              faceWeights[ ( i - 1 ) * 4 + 2 ],
-              faceWeights[ ( i - 1 ) * 4 + 3 ],
+							faceWeights[ ( i - 1 ) * 4 ],
+							faceWeights[ ( i - 1 ) * 4 + 1 ],
+							faceWeights[ ( i - 1 ) * 4 + 2 ],
+							faceWeights[ ( i - 1 ) * 4 + 3 ],
 
-              faceWeights[ i * 4 ],
-              faceWeights[ i * 4 + 1 ],
-              faceWeights[ i * 4 + 2 ],
-              faceWeights[ i * 4 + 3 ]
+							faceWeights[ i * 4 ],
+							faceWeights[ i * 4 + 1 ],
+							faceWeights[ i * 4 + 2 ],
+							faceWeights[ i * 4 + 3 ]
             );
 
 						weightsIndicesB.push(
-              faceWeightIndices[ 0 ],
-              faceWeightIndices[ 1 ],
-              faceWeightIndices[ 2 ],
-              faceWeightIndices[ 3 ],
+							faceWeightIndices[ 0 ],
+							faceWeightIndices[ 1 ],
+							faceWeightIndices[ 2 ],
+							faceWeightIndices[ 3 ],
 
-              faceWeightIndices[ ( i - 1 ) * 4 ],
-              faceWeightIndices[ ( i - 1 ) * 4 + 1 ],
-              faceWeightIndices[ ( i - 1 ) * 4 + 2 ],
-              faceWeightIndices[ ( i - 1 ) * 4 + 3 ],
+							faceWeightIndices[ ( i - 1 ) * 4 ],
+							faceWeightIndices[ ( i - 1 ) * 4 + 1 ],
+							faceWeightIndices[ ( i - 1 ) * 4 + 2 ],
+							faceWeightIndices[ ( i - 1 ) * 4 + 3 ],
 
-              faceWeightIndices[ i * 4 ],
-              faceWeightIndices[ i * 4 + 1 ],
-              faceWeightIndices[ i * 4 + 2 ],
-              faceWeightIndices[ i * 4 + 3 ]
-            );
+							faceWeightIndices[ i * 4 ],
+							faceWeightIndices[ i * 4 + 1 ],
+							faceWeightIndices[ i * 4 + 2 ],
+							faceWeightIndices[ i * 4 + 3 ]
+						);
 
 					}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -50,8 +50,9 @@
 
 				try {
 
+					console.time( 'parse: ' );
 					var scene = self.parse( buffer, resourceDirectory );
-
+					console.timeEnd( 'parse: ' );
 					onLoad( scene );
 
 				} catch ( error ) {
@@ -898,19 +899,17 @@
 
 				for ( var i = 2; i < faceLength; i ++ ) {
 
-					vertexB.push(
-						vertexPositions[ vertexPositionIndexes[ 0 ] ],
-						vertexPositions[ vertexPositionIndexes[ 1 ] ],
-						vertexPositions[ vertexPositionIndexes[ 2 ] ],
+					vertexB.push(	vertexPositions[ vertexPositionIndexes[ 0 ] ] );
+					vertexB.push(	vertexPositions[ vertexPositionIndexes[ 1 ] ] );
+					vertexB.push(	vertexPositions[ vertexPositionIndexes[ 2 ] ] );
 
-						vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 ] ],
-						vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 1 ] ],
-						vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 2 ] ],
+					vertexB.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 ] ] );
+					vertexB.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 1 ] ] );
+					vertexB.push(	vertexPositions[ vertexPositionIndexes[ ( i - 1 ) * 3 + 2 ] ] );
 
-						vertexPositions[ vertexPositionIndexes[ i * 3 ] ],
-						vertexPositions[ vertexPositionIndexes[ i * 3 + 1 ] ],
-						vertexPositions[ vertexPositionIndexes[ i * 3 + 2 ] ]
-					);
+					vertexB.push(	vertexPositions[ vertexPositionIndexes[ i * 3 ] ] );
+					vertexB.push(	vertexPositions[ vertexPositionIndexes[ i * 3 + 1 ] ] );
+					vertexB.push(	vertexPositions[ vertexPositionIndexes[ i * 3 + 2 ] ] );
 
 				}
 
@@ -918,39 +917,35 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						weightsB.push(
-							faceWeights[ 0 ],
-							faceWeights[ 1 ],
-							faceWeights[ 2 ],
-							faceWeights[ 3 ],
+						weightsB.push(	faceWeights[ 0 ] );
+						weightsB.push( faceWeights[ 1 ] );
+						weightsB.push( faceWeights[ 2 ] );
+						weightsB.push( faceWeights[ 3 ] );
 
-							faceWeights[ ( i - 1 ) * 4 ],
-							faceWeights[ ( i - 1 ) * 4 + 1 ],
-							faceWeights[ ( i - 1 ) * 4 + 2 ],
-							faceWeights[ ( i - 1 ) * 4 + 3 ],
+						weightsB.push( faceWeights[ ( i - 1 ) * 4 ] );
+						weightsB.push( faceWeights[ ( i - 1 ) * 4 + 1 ] );
+						weightsB.push( faceWeights[ ( i - 1 ) * 4 + 2 ] );
+						weightsB.push( faceWeights[ ( i - 1 ) * 4 + 3 ] );
 
-							faceWeights[ i * 4 ],
-							faceWeights[ i * 4 + 1 ],
-							faceWeights[ i * 4 + 2 ],
-							faceWeights[ i * 4 + 3 ]
-            );
+						weightsB.push( faceWeights[ i * 4 ] );
+						weightsB.push( faceWeights[ i * 4 + 1 ] );
+						weightsB.push( faceWeights[ i * 4 + 2 ] );
+						weightsB.push( faceWeights[ i * 4 + 3 ] );
 
-						weightsIndicesB.push(
-							faceWeightIndices[ 0 ],
-							faceWeightIndices[ 1 ],
-							faceWeightIndices[ 2 ],
-							faceWeightIndices[ 3 ],
+						weightsIndicesB.push(	faceWeightIndices[ 0 ] );
+						weightsIndicesB.push(	faceWeightIndices[ 1 ] );
+						weightsIndicesB.push(	faceWeightIndices[ 2 ] );
+						weightsIndicesB.push(	faceWeightIndices[ 3 ] );
 
-							faceWeightIndices[ ( i - 1 ) * 4 ],
-							faceWeightIndices[ ( i - 1 ) * 4 + 1 ],
-							faceWeightIndices[ ( i - 1 ) * 4 + 2 ],
-							faceWeightIndices[ ( i - 1 ) * 4 + 3 ],
+						weightsIndicesB.push(	faceWeightIndices[ ( i - 1 ) * 4 ] );
+						weightsIndicesB.push(	faceWeightIndices[ ( i - 1 ) * 4 + 1 ] );
+						weightsIndicesB.push(	faceWeightIndices[ ( i - 1 ) * 4 + 2 ] );
+						weightsIndicesB.push(	faceWeightIndices[ ( i - 1 ) * 4 + 3 ] );
 
-							faceWeightIndices[ i * 4 ],
-							faceWeightIndices[ i * 4 + 1 ],
-							faceWeightIndices[ i * 4 + 2 ],
-							faceWeightIndices[ i * 4 + 3 ]
-						);
+						weightsIndicesB.push(	faceWeightIndices[ i * 4 ] );
+						weightsIndicesB.push(	faceWeightIndices[ i * 4 + 1 ] );
+						weightsIndicesB.push(	faceWeightIndices[ i * 4 + 2 ] );
+						weightsIndicesB.push(	faceWeightIndices[ i * 4 + 3 ] );
 
 					}
 
@@ -960,19 +955,17 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						normalB.push(
-							faceNormals[ 0 ],
-							faceNormals[ 1 ],
-							faceNormals[ 2 ],
+						normalB.push(	faceNormals[ 0 ] );
+						normalB.push(	faceNormals[ 1 ] );
+						normalB.push(	faceNormals[ 2 ] );
 
-							faceNormals[ ( i - 1 ) * 3 ],
-							faceNormals[ ( i - 1 ) * 3 + 1 ],
-							faceNormals[ ( i - 1 ) * 3 + 2 ],
+						normalB.push(	faceNormals[ ( i - 1 ) * 3 ] );
+						normalB.push(	faceNormals[ ( i - 1 ) * 3 + 1 ] );
+						normalB.push(	faceNormals[ ( i - 1 ) * 3 + 2 ] );
 
-							faceNormals[ i * 3 ],
-							faceNormals[ i * 3 + 1 ],
-							faceNormals[ i * 3 + 2 ]
-						);
+						normalB.push(	faceNormals[ i * 3 ] );
+						normalB.push(	faceNormals[ i * 3 + 1 ] );
+						normalB.push(	faceNormals[ i * 3 + 2 ] );
 
 					}
 
@@ -986,18 +979,14 @@
 
 						for ( var i = 2; i < faceLength; i ++ ) {
 
-							uvsB[ j ].push(
+							uvsB[ j ].push( faceUVs[ j ][ 0 ] );
+							uvsB[ j ].push( faceUVs[ j ][ 1 ] );
 
-								faceUVs[ j ][ 0 ],
-								faceUVs[ j ][ 1 ],
+							uvsB[ j ].push(	faceUVs[ j ][ ( i - 1 ) * 2 ] );
+							uvsB[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 + 1 ] );
 
-								faceUVs[ j ][ ( i - 1 ) * 2 ],
-								faceUVs[ j ][ ( i - 1 ) * 2 + 1 ],
-
-								faceUVs[ j ][ i * 2 ],
-								faceUVs[ j ][ i * 2 + 1 ]
-
-							);
+							uvsB[ j ].push(	faceUVs[ j ][ i * 2 ] );
+							uvsB[ j ].push(	faceUVs[ j ][ i * 2 + 1 ] );
 
 						}
 
@@ -1009,19 +998,18 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						colorsB.push(
-							faceColors[ 0 ],
-							faceColors[ 1 ],
-							faceColors[ 2 ],
 
-							faceColors[ ( i - 1 ) * 3 ],
-							faceColors[ ( i - 1 ) * 3 + 1 ],
-							faceColors[ ( i - 1 ) * 3 + 2 ],
+						colorsB.push(	faceColors[ 0 ] );
+						colorsB.push(	faceColors[ 1 ] );
+						colorsB.push(	faceColors[ 2 ] );
 
-							faceColors[ i * 3 ],
-							faceColors[ i * 3 + 1 ],
-							faceColors[ i * 3 + 2 ]
-						);
+						colorsB.push(	faceColors[ ( i - 1 ) * 3 ] );
+						colorsB.push(	faceColors[ ( i - 1 ) * 3 + 1 ] );
+						colorsB.push(	faceColors[ ( i - 1 ) * 3 + 2 ] );
+
+						colorsB.push(	faceColors[ i * 3 ] );
+						colorsB.push(	faceColors[ i * 3 + 1 ] );
+						colorsB.push(	faceColors[ i * 3 + 2 ] );
 
 					}
 
@@ -1033,11 +1021,9 @@
 
 					for ( var i = 2; i < faceLength; i ++ ) {
 
-						materialsB.push(
-							materialIndex,
-							materialIndex,
-							materialIndex
-						);
+						materialsB.push(	materialIndex );
+						materialsB.push(	materialIndex );
+						materialsB.push(	materialIndex );
 
 					}
 
@@ -1077,6 +1063,7 @@
 
 			geo.addAttribute( 'skinWeight', new THREE.Float32BufferAttribute( weightsB, 4 ) );
 
+			// used later to bind the skeleton to the model
 			geo.FBX_Deformer = deformer;
 
 		}


### PR DESCRIPTION
The loader was using a set of custom objects as intermediaries between the FBX format and the buffer geometry. The custom objects were:

* Geometry
* Face
* Triangle
* Vertex

I presume these were left over from when the loader returned a geometry rather than a buffer geometry. 
Switched to creating a buffer geometry directly and removed the intermediate data structure. 
