### PR TITLE
Vector3: fix .cross() method

### DIFF
--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -539,13 +539,7 @@ Object.assign( Vector3.prototype, {
 
 		}
 
-		var x = this.x, y = this.y, z = this.z;
-
-		this.x = y * v.z - z * v.y;
-		this.y = z * v.x - x * v.z;
-		this.z = x * v.y - y * v.x;
-
-		return this;
+		return this.crossVectors( this, v );
 
 	},
 


### PR DESCRIPTION
Fixes #12498.