### PR TITLE
FBXLoader fix Euler.fromArray syntax

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1796,7 +1796,11 @@
 
 			if ( 'PreRotation' in node.properties ) {
 
-				var preRotations = new THREE.Euler().fromArray( node.properties.PreRotation.value.map( THREE.Math.degToRad ), 'ZYX' );
+				var array = node.properties.PreRotation.value.map( THREE.Math.degToRad );
+				array[ 3 ] = 'ZYX';
+
+				var preRotations = new THREE.Euler().fromArray( array );
+
 				preRotations = new THREE.Quaternion().setFromEuler( preRotations );
 				var currentRotation = new THREE.Quaternion().setFromEuler( model.rotation );
 				preRotations.multiply( currentRotation );


### PR DESCRIPTION
Just a quick fix for a bug created since `Euler.fromArray` doesn't work in the way my intuition expected. 

I expected:

```js
var array = [eulerX, eulerY, eulerZ, nextEulerX, nextEulerY, nextEulerZ, ... ];

euler.fromArray( array, optionalEulerOrder, optionalOffset );

```

While it should have been: 
```js
var array = [eulerX, eulerY, eulerZ, optionalEulerOrder];

euler.fromArray( array );

```

... and there's no way to set an `optionalOffset`. So you can't, for example, use a single large array to set lots different object's rotations (at least without splitting it up as you go).