### PR TITLE
Fix missing delete loding[ url ] in error case

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -236,6 +236,8 @@ Object.assign( FileLoader.prototype, {
 
 				var callbacks = loading[ url ];
 
+				delete loading[ url ];
+
 				for ( var i = 0, il = callbacks.length; i < il; i ++ ) {
 
 					var callback = callbacks[ i ];


### PR DESCRIPTION
This PR fixes missing `delete loading[ url ]` in error case in `FileLoader`.