### PR TITLE
Fix GLTFLoader uncaught exception

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1025,11 +1025,9 @@ THREE.GLTFLoader = ( function () {
 
 				if ( value ) {
 
-					fns.push( value );
-
 					if ( value instanceof Promise ) {
 
-						value.then( function ( key, value ) {
+						value = value.then( function ( key, value ) {
 
 							results[ key ] = value;
 
@@ -1040,6 +1038,8 @@ THREE.GLTFLoader = ( function () {
 						results[ idx ] = value;
 
 					}
+
+					fns.push( value );
 
 				}
 
@@ -1057,11 +1057,9 @@ THREE.GLTFLoader = ( function () {
 
 					if ( value ) {
 
-						fns.push( value );
-
 						if ( value instanceof Promise ) {
 
-							value.then( function ( key, value ) {
+							value = value.then( function ( key, value ) {
 
 								results[ key ] = value;
 
@@ -1072,6 +1070,8 @@ THREE.GLTFLoader = ( function () {
 							results[ key ] = value;
 
 						}
+
+						fns.push( value );
 
 					}
 


### PR DESCRIPTION
This PR fixes `GLTFLoader` uncaught exception.

In the current `GLTFLoader` code, `onError` of `GLTFParser.parse()` can't catch some exceptions caused in Promise.

For example, the followings are the results in the case of removing BoomBox.bin of BoomBox.

Before the change.

![image](https://user-images.githubusercontent.com/7637832/32170433-e108798e-bdb7-11e7-917d-809fa6e6ea16.png)

After the change.

![image](https://user-images.githubusercontent.com/7637832/32170454-f1eaad94-bdb7-11e7-98f8-a1d4d048bbba.png)

/cc @donmccurdy 
