### PR TITLE
Fix Error message in GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1421,7 +1421,7 @@ THREE.GLTFLoader = ( function () {
 
 		if ( bufferDef.type && bufferDef.type !== 'arraybuffer' ) {
 
-			throw new Error( 'THREE.GLTFLoader: %s buffer type is not supported.', bufferDef.type );
+			throw new Error( 'THREE.GLTFLoader: ' + bufferDef.type + ' buffer type is not supported.' );
 
 		}
 


### PR DESCRIPTION
This PR fixes error message in `GLTFLoader`.

`Error` doesn't accept `%s` format while `console.info/log/warn/error` does.

    > console.log( 'abc %s def', 'hoge' );
    < abc hoge def

    > throw new Error( 'abc %s def', 'hoge' );
    < Uncaught Error: abc %s def
            at <anonymous>:1:7

/cc @donmccurdy 