### PR TITLE
Generalize GLTFLoader buffer loading failure message

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1438,7 +1438,7 @@ THREE.GLTFLoader = ( function () {
 
 			loader.load( resolveURL( bufferDef.uri, options.path ), resolve, undefined, function () {
 
-				reject( new Error( 'THREE.GLTFLoader: Buffer "' + bufferDef.uri + '" not found.' ) );
+				reject( new Error( 'THREE.GLTFLoader: Failed to load Buffer "' + bufferDef.uri + '".' ) );
 
 			} );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1438,7 +1438,7 @@ THREE.GLTFLoader = ( function () {
 
 			loader.load( resolveURL( bufferDef.uri, options.path ), resolve, undefined, function () {
 
-				reject( new Error( 'THREE.GLTFLoader: Failed to load Buffer "' + bufferDef.uri + '".' ) );
+				reject( new Error( 'THREE.GLTFLoader: Failed to load buffer "' + bufferDef.uri + '".' ) );
 
 			} );
 


### PR DESCRIPTION
I think `GLTFLoader` buffer loading failure message should be more general because failure can occur not only by "not found" but also by other reasons, for example crossOrigin.

Another option is making message from error passed from `FileLoader`

/cc @donmccurdy 