### PR TITLE
CurvePath, Path, Shape: Improve API

### DIFF
--- a/docs/api/extras/core/Shape.html
+++ b/docs/api/extras/core/Shape.html
@@ -47,7 +47,16 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]()</h3>
+		<h3>[name]( [page:Array points] )</h3>
+		<div>
+		points -- (optional) array of [page:Vector2 Vector2s].<br /><br />
+
+		Creates a Shape from the points. The first point defines the offset, then successive points
+		are added to the [page:CurvePath.curves curves] array as [page:LineCurve LineCurves].<br /><br />
+
+		If no points are specified, an empty shape is created and the [page:.currentPoint] is set to
+		the origin.
+		</div>
 
 
 		<h2>Properties</h2>

--- a/docs/api/extras/core/Shape.html
+++ b/docs/api/extras/core/Shape.html
@@ -68,7 +68,7 @@
 		<h2>Methods</h2>
 		<div>See the base [page:Path] class for common methods.</div>
 
-		<h3>[method:Array extractAllPoints]( [page:Integer divisions] )</h3>
+		<h3>[method:Array extractPoints]( [page:Integer divisions] )</h3>
 		<div>
 		divisions -- The fineness of the result.<br /><br />
 
@@ -81,10 +81,6 @@
 		</code>
 		where shape and holes are arrays of [page:Vector2 Vector2s].
 		</div>
-
-		<h3>[method:Object extractPoints]( [page:Integer divisions] )</h3>
-		<div>This is identical to [page:.extractAllPoints].</div>
-
 
 		<h3>[method:Array getPointsHoles]( [page:Integer divisions] )</h3>
 		<div>

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -960,7 +960,7 @@
           "!type": "array",
           "!doc": "The possible actions that define the path."
         },
-        "fromPoints": {
+        "setFromPoints": {
           "!type": "fn(vectors) -> todo",
           "!doc": "Adds to the Path from the points. The first vector defines the offset. After that the lines get defined."
         },
@@ -1012,23 +1012,7 @@
           "!type": "array",
           "!doc": "todo"
         },
-        "makeGeometry": {
-          "!type": "fn(options: todo) -> todo",
-          "!doc": "Convenience method to return ShapeGeometry"
-        },
-        "extractAllPoints": {
-          "!type": "fn(divisions: todo) -> todo",
-          "!doc": "Get points of shape and holes (keypoints based on segments parameter)"
-        },
-        "extrude": {
-          "!type": "fn(options: todo) -> todo",
-          "!doc": "Convenience method to return ExtrudeGeometry"
-        },
         "extractPoints": {
-          "!type": "fn(divisions: todo) -> todo",
-          "!doc": "todo"
-        },
-        "extractAllSpacedPoints": {
           "!type": "fn(divisions: todo) -> todo",
           "!doc": "todo"
         },
@@ -1036,10 +1020,6 @@
           "!type": "fn(divisions: todo) -> todo",
           "!doc": "Get points of holes"
         },
-        "getSpacedPointsHoles": {
-          "!type": "fn(divisions: todo) -> todo",
-          "!doc": "Get points of holes (spaced by regular distance)"
-        }
       },
       "!doc": "Defines a 2d shape plane using paths.",
       "!type": "fn()"

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -25,6 +25,7 @@ import { Object3D } from './core/Object3D.js';
 import { Uniform } from './core/Uniform.js';
 import { Curve } from './extras/core/Curve.js';
 import { CurvePath } from './extras/core/CurvePath.js';
+import { Path } from './extras/core/Path.js';
 import { CatmullRomCurve3 } from './extras/curves/CatmullRomCurve3.js';
 import { AxesHelper } from './helpers/AxesHelper.js';
 import { BoxHelper } from './helpers/BoxHelper.js';
@@ -281,6 +282,19 @@ Object.assign( CurvePath.prototype, {
 		}
 
 		return geometry;
+
+	}
+
+} );
+
+//
+
+Object.assign( Path.prototype, {
+
+	fromPoints: function ( points ) {
+
+		console.warn( 'THREE.Path: .fromPoints() has been renamed to .setFromPoints().' );
+		this.setFromPoints( points );
 
 	}
 
@@ -684,6 +698,12 @@ Object.assign( Ray.prototype, {
 
 Object.assign( Shape.prototype, {
 
+	extractAllPoints: function ( divisions ) {
+
+		console.warn( 'THREE.Shape: .extractAllPoints() has been removed. Use .extractPoints() instead.' );
+		return this.extractPoints( divisions );
+
+	},
 	extrude: function ( options ) {
 
 		console.warn( 'THREE.Shape: .extrude() has been removed. Use ExtrudeGeometry() instead.' );

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -197,6 +197,26 @@ CurvePath.prototype = Object.assign( Object.create( Curve.prototype ), {
 
 		return points;
 
+	},
+
+	copy: function ( source ) {
+
+		Curve.prototype.copy.call( this, source );
+
+		this.curves = [];
+
+		for ( var i = 0, l = source.curves.length; i < l; i ++ ) {
+
+			var curve = source.curves[ i ];
+
+			this.curves.push( curve.clone() );
+
+		}
+
+		this.autoClose = source.autoClose;
+
+		return this;
+
 	}
 
 } );

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -18,7 +18,7 @@ function Path( points ) {
 
 	if ( points ) {
 
-		this.fromPoints( points );
+		this.setFromPoints( points );
 
 	}
 

--- a/src/extras/core/PathPrototype.js
+++ b/src/extras/core/PathPrototype.js
@@ -8,13 +8,13 @@ import { LineCurve } from '../curves/LineCurve.js';
 
 var PathPrototype = Object.assign( Object.create( CurvePath.prototype ), {
 
-	fromPoints: function ( vectors ) {
+	setFromPoints: function ( points ) {
 
-		this.moveTo( vectors[ 0 ].x, vectors[ 0 ].y );
+		this.moveTo( points[ 0 ].x, points[ 0 ].y );
 
-		for ( var i = 1, l = vectors.length; i < l; i ++ ) {
+		for ( var i = 1, l = points.length; i < l; i ++ ) {
 
-			this.lineTo( vectors[ i ].x, vectors[ i ].y );
+			this.lineTo( points[ i ].x, points[ i ].y );
 
 		}
 

--- a/src/extras/core/PathPrototype.js
+++ b/src/extras/core/PathPrototype.js
@@ -122,6 +122,16 @@ var PathPrototype = Object.assign( Object.create( CurvePath.prototype ), {
 		var lastPoint = curve.getPoint( 1 );
 		this.currentPoint.copy( lastPoint );
 
+	},
+
+	copy: function ( source ) {
+
+		CurvePath.prototype.copy.call( this, source );
+
+		this.currentPoint.copy( source.currentPoint );
+
+		return this;
+
 	}
 
 } );

--- a/src/extras/core/Shape.js
+++ b/src/extras/core/Shape.js
@@ -40,9 +40,9 @@ Shape.prototype = Object.assign( Object.create( PathPrototype ), {
 
 	},
 
-	// Get points of shape and holes (keypoints based on segments parameter)
+	// get points of shape and holes (keypoints based on segments parameter)
 
-	extractAllPoints: function ( divisions ) {
+	extractPoints: function ( divisions ) {
 
 		return {
 
@@ -50,12 +50,6 @@ Shape.prototype = Object.assign( Object.create( PathPrototype ), {
 			holes: this.getPointsHoles( divisions )
 
 		};
-
-	},
-
-	extractPoints: function ( divisions ) {
-
-		return this.extractAllPoints( divisions );
 
 	},
 

--- a/src/extras/core/Shape.js
+++ b/src/extras/core/Shape.js
@@ -12,9 +12,9 @@ import { Path } from './Path.js';
 // STEP 3a - Extract points from each shape, turn to vertices
 // STEP 3b - Triangulate each shape, add faces.
 
-function Shape() {
+function Shape( points ) {
 
-	Path.apply( this, arguments );
+	Path.call( this, points );
 
 	this.type = 'Shape';
 
@@ -56,6 +56,24 @@ Shape.prototype = Object.assign( Object.create( PathPrototype ), {
 	extractPoints: function ( divisions ) {
 
 		return this.extractAllPoints( divisions );
+
+	},
+
+	copy: function ( source ) {
+
+		Path.prototype.copy.call( this, source );
+
+		this.holes = [];
+
+		for ( var i = 0, l = source.holes.length; i < l; i ++ ) {
+
+			var hole = source.holes[ i ];
+
+			this.holes.push( hole.clone() );
+
+		}
+
+		return this;
 
 	}
 


### PR DESCRIPTION
This PR enhances the remaining derivations of `Curve` with `.copy()` and `.clone()` methods. That means `CurvePath`, `Path` and `Shape`.

It also harmonizes the constructor of `Shape`.