### PR TITLE
Default to "clearAlpha" value for alpha in `renderer.setClearColor`

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -116,7 +116,7 @@ function WebGLBackground( renderer, state, geometries, premultipliedAlpha ) {
 		setClearColor: function ( color, alpha ) {
 
 			clearColor.set( color );
-			clearAlpha = alpha !== undefined ? alpha : 1;
+			clearAlpha = alpha !== undefined ? alpha : clearAlpha;
 			setClear( clearColor, clearAlpha );
 
 		},

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -15,7 +15,7 @@ import { ShaderLib } from '../shaders/ShaderLib.js';
 function WebGLBackground( renderer, state, geometries, premultipliedAlpha ) {
 
 	var clearColor = new Color( 0x000000 );
-	var clearAlpha = 0;
+	var clearAlpha = 1;
 
 	var planeCamera, planeMesh;
 	var boxMesh;


### PR DESCRIPTION
This is more intuitive IMHO, because we can omit the last argument without introducing sideeffects: if we set only the color, then we only modify the color, otherwise if we set both color and alpha then we modify both. It's easier to think about it that way.


For example, this is intuitive:
```js
// Hmm, let me set alpha
renderer.setClearAlpha(0.5)

// and let me set the color
renderer.setClearColor(new Color(...))

// now let's render
renderer.render(...)

// Wait, what the??? Why is the background alpha not 0.5?
```