### PR TITLE
FBXLoader: remove duplicated arrays from binary parser

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3560,7 +3560,6 @@
 
 					if ( Array.isArray( value ) ) {
 
-						node.properties[ node.name ] = node.propertyList[ 0 ];
 						subNodes[ node.name ] = node;
 
 						node.properties.a = value;


### PR DESCRIPTION
Before:

![1](https://user-images.githubusercontent.com/5307958/32281396-4818ef42-bf51-11e7-9e75-a500d1cfc0b2.jpg)

After:

![2](https://user-images.githubusercontent.com/5307958/32281401-4b90616e-bf51-11e7-89a1-9eb127b5fc69.jpg)

The `Edges` array was a duplicate of the `a` array and is not used - this was occurring with lots of properties in the FBXTree. The array is still copied in a couple of other places - in particular in the `id` property for some reason. 