### PR TITLE
GLTFLoader: Allow alphaTest to be 0

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1700,7 +1700,7 @@ THREE.GLTFLoader = ( function () {
 
 				if ( alphaMode === ALPHA_MODES.MASK ) {
 
-					materialParams.alphaTest = material.alphaCutoff || 0.5;
+					materialParams.alphaTest = material.alphaCutoff !== undefined ? material.alphaCutoff : 0.5;
 
 				}
 


### PR DESCRIPTION
If the alphaCutoff is set to 0 in the glTF file, alphaTest will be set to 0.5.