### PR TITLE
support opacity in assimp2json loader

### DIFF
--- a/examples/js/loaders/AssimpJSONLoader.js
+++ b/examples/js/loaders/AssimpJSONLoader.js
@@ -219,6 +219,13 @@ THREE.AssimpJSONLoader.prototype = {
 						material.flatShading = ( value === 1 ) ? true : false;
 						break;
 
+					case '$mat.opacity':
+						if ( value < 1 ) {
+							material.opacity = value;
+							material.transparent = true;
+						}
+						break;
+
 				}
 
 			}


### PR DESCRIPTION
what it says.

without this bit, all materials appear fully opaque.