### PR TITLE
Editor: Prevent Command-Z from triggering tabs to open/close on Safari

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -315,6 +315,8 @@
 
 						if ( IS_MAC ? event.metaKey : event.ctrlKey ) {
 
+							event.preventDefault(); // Prevent Safari from opening/closing tabs
+
 							if ( event.shiftKey ) {
 
 								editor.redo();


### PR DESCRIPTION
On Safari Command-Z is a hotkey for reopening the last closed tab, and Command-Shift-Z is used to close that opened tab. Need to prevent that event from being triggered when the user is trying to undo their last action with Command-Z.