### PR TITLE
ColladaLoader: Check if mesh exists before working with it

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1760,9 +1760,7 @@ THREE.ColladaLoader.prototype = {
 
 			var mesh = getElementsByTagName( xml, 'mesh' )[ 0 ];
 			
-			if (!mesh) {
-				return;
-			}
+			if ( mesh === undefined ) return;
 
 			for ( var i = 0; i < mesh.childNodes.length; i ++ ) {
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1760,6 +1760,7 @@ THREE.ColladaLoader.prototype = {
 
 			var mesh = getElementsByTagName( xml, 'mesh' )[ 0 ];
 			
+			// the following tags inside geometry are not supported yet (see https://github.com/mrdoob/three.js/pull/12606): convex_mesh, spline, brep
 			if ( mesh === undefined ) return;
 
 			for ( var i = 0; i < mesh.childNodes.length; i ++ ) {

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1759,6 +1759,10 @@ THREE.ColladaLoader.prototype = {
 			};
 
 			var mesh = getElementsByTagName( xml, 'mesh' )[ 0 ];
+			
+			if (!mesh) {
+				return;
+			}
 
 			for ( var i = 0; i < mesh.childNodes.length; i ++ ) {
 


### PR DESCRIPTION

There is the possibility that there isn't a 'mesh' attribute in the 'geometry' one so we should check if we found a mesh before trying to access its properties. 
See Image below with the .dae file on the right and the error when there is no 'mesh' in 'geometry' on the left. 
The used file is attached. (Standing_table.zip)
![image](https://user-images.githubusercontent.com/22448974/32558417-f888cb4c-c4a4-11e7-96b5-5d0b26d9829c.png)

@Mugen87 
Since you are the author of the loader, any opinion? ;)

[Standing_table.zip](https://github.com/mrdoob/three.js/files/1454495/Standing_table.zip)

