### PR TITLE
Editor: Added a new panel for editing key bindings

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -127,6 +127,7 @@
 		<script src="js/Sidebar.Animation.js"></script>
 		<script src="js/Sidebar.Script.js"></script>
 		<script src="js/Sidebar.History.js"></script>
+		<script src="js/Sidebar.Controls.js"></script>
 		<script src="js/Toolbar.js"></script>
 		<script src="js/Viewport.js"></script>
 		<script src="js/Viewport.Info.js"></script>

--- a/editor/index.html
+++ b/editor/index.html
@@ -164,8 +164,6 @@
 			window.URL = window.URL || window.webkitURL;
 			window.BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
 
-			const IS_MAC = navigator.platform.toUpperCase().indexOf( 'MAC' ) >= 0;
-
 			Number.prototype.format = function (){
 				return this.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,");
 			};
@@ -288,67 +286,6 @@
 				if ( event.dataTransfer.files.length > 0 ) {
 
 					editor.loader.loadFile( event.dataTransfer.files[ 0 ] );
-
-				}
-
-			}, false );
-
-			document.addEventListener( 'keydown', function ( event ) {
-
-				switch ( event.keyCode ) {
-
-					case 8: // backspace
-
-						event.preventDefault(); // prevent browser back
-
-					case 46: // delete
-
-						var object = editor.selected;
-
-						if ( confirm( 'Delete ' + object.name + '?' ) === false ) return;
-
-						var parent = object.parent;
-						if ( parent !== null ) editor.execute( new RemoveObjectCommand( object ) );
-
-						break;
-
-					case 90: // Register Ctrl-Z for Undo, Ctrl-Shift-Z for Redo
-
-						if ( IS_MAC ? event.metaKey : event.ctrlKey ) {
-
-							event.preventDefault(); // Prevent Safari from opening/closing tabs
-
-							if ( event.shiftKey ) {
-
-								editor.redo();
-
-							} else {
-
-								editor.undo();
-
-							}
-
-						}
-
-						break;
-
-					case 87: // Register W for translation transform mode
-
-						editor.signals.transformModeChanged.dispatch( 'translate' );
-
-						break;
-
-					case 69: // Register E for rotation transform mode
-
-						editor.signals.transformModeChanged.dispatch( 'rotate' );
-
-						break;
-
-					case 82: // Register R for scaling transform mode
-
-						editor.signals.transformModeChanged.dispatch( 'scale' );
-
-						break;
 
 				}
 

--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -23,7 +23,8 @@ var Config = function ( name ) {
 
 		'controls/translate': 'w',
 		'controls/rotate': 'e',
-		'controls/scale': 'r'
+		'controls/scale': 'r',
+		'controls/undo': 'z'
 	};
 
 	if ( window.localStorage[ name ] === undefined ) {

--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -19,7 +19,11 @@ var Config = function ( name ) {
 
 		'project/vr': false,
 
-		'settings/history': false
+		'settings/history': false,
+
+		'controls/translate': 'w',
+		'controls/rotate': 'r',
+		'controls/scale': 'w'
 	};
 
 	if ( window.localStorage[ name ] === undefined ) {

--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -22,8 +22,8 @@ var Config = function ( name ) {
 		'settings/history': false,
 
 		'controls/translate': 'w',
-		'controls/rotate': 'r',
-		'controls/scale': 'w'
+		'controls/rotate': 'e',
+		'controls/scale': 'r'
 	};
 
 	if ( window.localStorage[ name ] === undefined ) {

--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -21,10 +21,10 @@ var Config = function ( name ) {
 
 		'settings/history': false,
 
-		'controls/translate': 'w',
-		'controls/rotate': 'e',
-		'controls/scale': 'r',
-		'controls/undo': 'z'
+		'settings/controls/translate': 'w',
+		'settings/controls/rotate': 'e',
+		'settings/controls/scale': 'r',
+		'settings/controls/undo': 'z'
 	};
 
 	if ( window.localStorage[ name ] === undefined ) {

--- a/editor/js/Sidebar.Controls.js
+++ b/editor/js/Sidebar.Controls.js
@@ -11,7 +11,7 @@ Sidebar.Controls = function ( editor ) {
 
 	var isValidKeyBinding = function ( key ) {
 
-		return key.match( /^[A-Za-z0-9]$/i );
+		return key.match( /^[A-Za-z0-9]$/i ); // Can't use z currently due to undo/redo
 
 	};
 
@@ -27,7 +27,7 @@ Sidebar.Controls = function ( editor ) {
 		'scale'
 	];
 
-	for ( var i = 0; i < controlNames.length; i++ ) {
+	for ( var i = 0; i < controlNames.length; i ++ ) {
 
 		let name = controlNames[ i ];
 		let configName = 'controls/' + name;
@@ -35,7 +35,7 @@ Sidebar.Controls = function ( editor ) {
 
 		let controlInput = new UI.Input().setWidth( '150px' ).setFontSize( '12px' ).onChange( function () {
 
-			if( isValidKeyBinding( controlInput.getValue() ) ) {
+			if ( isValidKeyBinding( controlInput.getValue() ) ) {
 
 				config.setKey( configName, controlInput.getValue()[ 0 ] );
 
@@ -54,7 +54,7 @@ Sidebar.Controls = function ( editor ) {
 		// to contain the key binding stored in config
 		controlInput.dom.addEventListener( 'blur', function () {
 
-			if( ! isValidKeyBinding( controlInput.getValue() ) ) {
+			if ( ! isValidKeyBinding( controlInput.getValue() ) ) {
 
 				controlInput.setValue( config.getKey( configName ) );
 
@@ -65,7 +65,7 @@ Sidebar.Controls = function ( editor ) {
 		// If a valid key binding character is entered, blur the input field
 		controlInput.dom.addEventListener( 'keyup', function ( event ) {
 
-			if( isValidKeyBinding( event.key ) ) {
+			if ( isValidKeyBinding( event.key ) ) {
 
 				controlInput.dom.blur();
 
@@ -73,7 +73,7 @@ Sidebar.Controls = function ( editor ) {
 
 		} );
 
-		if( config.getKey( configName ) !== undefined ) {
+		if ( config.getKey( configName ) !== undefined ) {
 
 			controlInput.setValue( config.getKey( configName ) );
 
@@ -105,23 +105,25 @@ Sidebar.Controls = function ( editor ) {
 
 				break;
 
-			case 'z': // Register Ctrl/Command-Z for Undo
+			case 'z': // Register Ctrl/Command-Z for Undo and Ctrl/Command-Shift-Z for Redo
+			case 'Z': // Safari and Firefox register lowercase z when Ctrl-Shift-Z is pressed
 
 				if ( IS_MAC ? event.metaKey : event.ctrlKey ) {
 
-					editor.undo();
+					if ( event.shiftKey ) {
+
+						editor.redo();
+
+					}					else {
+
+						event.preventDefault(); // Prevent Safari reopen last tab
+						editor.undo();
+
+					}
 
 				}
 
 				break;
-
-			case 'Z': // Register Ctrl/Command-Shift-Z for Redo
-
-				if ( IS_MAC ? event.metaKey : event.ctrlKey ) {
-
-					editor.redo();
-
-				}
 
 			case editor.config.getKey( 'controls/translate' ): // Translation transform mode
 

--- a/editor/js/Sidebar.Controls.js
+++ b/editor/js/Sidebar.Controls.js
@@ -7,6 +7,8 @@ Sidebar.Controls = function ( editor ) {
 	var config = editor.config;
 	var signals = editor.signals;
 
+	const IS_MAC = navigator.platform.toUpperCase().indexOf( 'MAC' ) >= 0;
+
 	var container = new UI.Panel();
 	container.add( new UI.Text( 'CONTROLS' ) );
 
@@ -48,6 +50,65 @@ Sidebar.Controls = function ( editor ) {
 		container.add( controlRow );
 
 	}
+
+	document.addEventListener( 'keydown', function ( event ) {
+
+		switch ( event.key ) {
+
+			case 'Backspace':
+
+				event.preventDefault(); // prevent browser back
+
+			case 'Delete':
+
+				var object = editor.selected;
+
+				if ( confirm( 'Delete ' + object.name + '?' ) === false ) return;
+
+				var parent = object.parent;
+				if ( parent !== null ) editor.execute( new RemoveObjectCommand( object ) );
+
+				break;
+
+			case 'z': // Register Ctrl/Command-Z for Undo
+
+				if ( IS_MAC ? event.metaKey : event.ctrlKey ) {
+
+					editor.undo();
+
+				}
+
+				break;
+
+			case 'Z': // Register Ctrl/Command-Shift-Z for Redo
+
+				if ( IS_MAC ? event.metaKey : event.ctrlKey ) {
+
+					editor.redo();
+
+				}
+
+			case editor.config.getKey( 'controls/translate' ): // Translation transform mode
+
+				editor.signals.transformModeChanged.dispatch( 'translate' );
+
+				break;
+
+			case editor.config.getKey( 'controls/rotate' ): // Rotation transform mode
+
+				editor.signals.transformModeChanged.dispatch( 'rotate' );
+
+				break;
+
+			case editor.config.getKey( 'controls/scale' ): // Scaling transform mode
+
+				editor.signals.transformModeChanged.dispatch( 'scale' );
+
+				break;
+
+		}
+
+	}, false );
 
 	return container;
 

--- a/editor/js/Sidebar.Controls.js
+++ b/editor/js/Sidebar.Controls.js
@@ -24,7 +24,8 @@ Sidebar.Controls = function ( editor ) {
 	var controlNames = [
 		'translate',
 		'rotate',
-		'scale'
+		'scale',
+		'undo'
 	];
 
 	for ( var i = 0; i < controlNames.length; i ++ ) {
@@ -105,26 +106,6 @@ Sidebar.Controls = function ( editor ) {
 
 				break;
 
-			case 'z': // Register Ctrl/Command-Z for Undo and Ctrl/Command-Shift-Z for Redo
-			case 'Z': // Safari and Firefox register lowercase z when Ctrl-Shift-Z is pressed
-
-				if ( IS_MAC ? event.metaKey : event.ctrlKey ) {
-
-					if ( event.shiftKey ) {
-
-						editor.redo();
-
-					}					else {
-
-						event.preventDefault(); // Prevent Safari reopen last tab
-						editor.undo();
-
-					}
-
-				}
-
-				break;
-
 			case editor.config.getKey( 'controls/translate' ): // Translation transform mode
 
 				editor.signals.transformModeChanged.dispatch( 'translate' );
@@ -140,6 +121,27 @@ Sidebar.Controls = function ( editor ) {
 			case editor.config.getKey( 'controls/scale' ): // Scaling transform mode
 
 				editor.signals.transformModeChanged.dispatch( 'scale' );
+
+				break;
+
+			case editor.config.getKey( 'controls/undo' ).toLowerCase(): // Register Ctrl/Command-Z for Undo and Ctrl/Command-Shift-Z for Redo
+			case editor.config.getKey( 'controls/undo' ).toUpperCase(): // Safari and Firefox register lowercase z when Ctrl-Shift-Z is pressed
+
+				if ( IS_MAC ? event.metaKey : event.ctrlKey ) {
+
+					event.preventDefault(); // Prevent browser specific hotkeys
+
+					if ( event.shiftKey ) {
+
+						editor.redo();
+
+					} else {
+
+						editor.undo();
+
+					}
+
+				}
 
 				break;
 

--- a/editor/js/Sidebar.Controls.js
+++ b/editor/js/Sidebar.Controls.js
@@ -9,6 +9,12 @@ Sidebar.Controls = function ( editor ) {
 
 	const IS_MAC = navigator.platform.toUpperCase().indexOf( 'MAC' ) >= 0;
 
+	var isValidKeyBinding = function ( key ) {
+
+		return key.match( /^[A-Za-z0-9]$/i );
+
+	};
+
 	var container = new UI.Panel();
 	container.add( new UI.Text( 'CONTROLS' ) );
 
@@ -29,17 +35,37 @@ Sidebar.Controls = function ( editor ) {
 
 		let controlInput = new UI.Input().setWidth( '150px' ).setFontSize( '12px' ).onChange( function () {
 
-			config.setKey( configName, controlInput.getValue()[ 0 ] );
+			if( isValidKeyBinding( controlInput.getValue() ) ) {
+
+				config.setKey( configName, controlInput.getValue()[ 0 ] );
+
+			}
 
 		} );
+
+		// Automatically highlight when selecting an input field
 		controlInput.dom.addEventListener( 'focus', function () {
 
 			controlInput.dom.select();
 
 		} );
-		controlInput.dom.addEventListener( 'keyup', function () {
 
-			if(event.key.match(/^[A-Za-z0-9]+$/i)) {
+		// If the value of the input field is invalid, revert the input field
+		// to contain the key binding stored in config
+		controlInput.dom.addEventListener( 'blur', function () {
+
+			if( ! isValidKeyBinding( controlInput.getValue() ) ) {
+
+				controlInput.setValue( config.getKey( configName ) );
+
+			}
+
+		} );
+
+		// If a valid key binding character is entered, blur the input field
+		controlInput.dom.addEventListener( 'keyup', function ( event ) {
+
+			if( isValidKeyBinding( event.key ) ) {
 
 				controlInput.dom.blur();
 

--- a/editor/js/Sidebar.Controls.js
+++ b/editor/js/Sidebar.Controls.js
@@ -8,10 +8,10 @@ Sidebar.Controls = function ( editor ) {
 	var signals = editor.signals;
 
 	var container = new UI.Panel();
-	container.setBorderTop( '0' );
-	container.setPaddingTop( '20px' );
-
 	container.add( new UI.Text( 'CONTROLS' ) );
+
+	// Use this to add a line break above the panel
+	container.add( new UI.Break(), new UI.Break() );
 
 	var controlNames = [
 		'translate',
@@ -19,11 +19,33 @@ Sidebar.Controls = function ( editor ) {
 		'scale'
 	];
 
-	// Create rows here
+	for ( var i = 0; i < controlNames.length; i++ ) {
 
-	if ( config.getKey( 'controls/translate' ) !== undefined ) {
+		let name = controlNames[ i ];
+		let configName = 'controls/' + name;
+		let controlRow = new UI.Row();
 
+		let controlInput = new UI.Input().setWidth( '150px' ).setFontSize( '12px' ).onChange( function () {
 
+			config.setKey( configName, controlInput.getValue()[ 0 ] );
+
+		} );
+		controlInput.dom.addEventListener( 'focus', function () {
+
+			controlInput.dom.select();
+
+		} );
+
+		if( config.getKey( configName ) !== undefined ) {
+
+			controlInput.setValue( config.getKey( configName ) );
+
+		}
+
+		controlInput.dom.maxLength = 1;
+		controlRow.add( new UI.Text( name.charAt( 0 ).toUpperCase() + name.slice( 1 ) ).setWidth( '90px' ) );
+		controlRow.add( controlInput );
+		container.add( controlRow );
 
 	}
 

--- a/editor/js/Sidebar.Controls.js
+++ b/editor/js/Sidebar.Controls.js
@@ -1,0 +1,32 @@
+/**
+ * @author TyLindberg / https://github.com/TyLindberg
+ */
+
+Sidebar.Controls = function ( editor ) {
+
+	var config = editor.config;
+	var signals = editor.signals;
+
+	var container = new UI.Panel();
+	container.setBorderTop( '0' );
+	container.setPaddingTop( '20px' );
+
+	container.add( new UI.Text( 'CONTROLS' ) );
+
+	var controlNames = [
+		'translate',
+		'rotate',
+		'scale'
+	];
+
+	// Create rows here
+
+	if ( config.getKey( 'controls/translate' ) !== undefined ) {
+
+
+
+	}
+
+	return container;
+
+};

--- a/editor/js/Sidebar.Controls.js
+++ b/editor/js/Sidebar.Controls.js
@@ -37,6 +37,15 @@ Sidebar.Controls = function ( editor ) {
 			controlInput.dom.select();
 
 		} );
+		controlInput.dom.addEventListener( 'keyup', function () {
+
+			if(event.key.match(/^[A-Za-z0-9]+$/i)) {
+
+				controlInput.dom.blur();
+
+			}
+
+		} );
 
 		if( config.getKey( configName ) !== undefined ) {
 

--- a/editor/js/Sidebar.Controls.js
+++ b/editor/js/Sidebar.Controls.js
@@ -31,7 +31,7 @@ Sidebar.Controls = function ( editor ) {
 	for ( var i = 0; i < controlNames.length; i ++ ) {
 
 		let name = controlNames[ i ];
-		let configName = 'controls/' + name;
+		let configName = 'settings/controls/' + name;
 		let controlRow = new UI.Row();
 
 		let controlInput = new UI.Input().setWidth( '150px' ).setFontSize( '12px' ).onChange( function () {
@@ -106,26 +106,26 @@ Sidebar.Controls = function ( editor ) {
 
 				break;
 
-			case editor.config.getKey( 'controls/translate' ): // Translation transform mode
+			case editor.config.getKey( 'settings/controls/translate' ): // Translation transform mode
 
 				editor.signals.transformModeChanged.dispatch( 'translate' );
 
 				break;
 
-			case editor.config.getKey( 'controls/rotate' ): // Rotation transform mode
+			case editor.config.getKey( 'settings/controls/rotate' ): // Rotation transform mode
 
 				editor.signals.transformModeChanged.dispatch( 'rotate' );
 
 				break;
 
-			case editor.config.getKey( 'controls/scale' ): // Scaling transform mode
+			case editor.config.getKey( 'settings/controls/scale' ): // Scaling transform mode
 
 				editor.signals.transformModeChanged.dispatch( 'scale' );
 
 				break;
 
-			case editor.config.getKey( 'controls/undo' ).toLowerCase(): // Register Ctrl/Command-Z for Undo and Ctrl/Command-Shift-Z for Redo
-			case editor.config.getKey( 'controls/undo' ).toUpperCase(): // Safari and Firefox register lowercase z when Ctrl-Shift-Z is pressed
+			case editor.config.getKey( 'settings/controls/undo' ).toLowerCase(): // Register Ctrl/Command-Z for Undo and Ctrl/Command-Shift-Z for Redo
+			case editor.config.getKey( 'settings/controls/undo' ).toUpperCase(): // Safari and Firefox register lowercase z when Ctrl-Shift-Z is pressed
 
 				if ( IS_MAC ? event.metaKey : event.ctrlKey ) {
 

--- a/editor/js/Sidebar.js
+++ b/editor/js/Sidebar.js
@@ -41,7 +41,8 @@ var Sidebar = function ( editor ) {
 
 	var settings = new UI.Span().add(
 		new Sidebar.Settings( editor ),
-		new Sidebar.History( editor )
+		new Sidebar.History( editor ),
+		new Sidebar.Controls( editor )
 	);
 	container.add( settings );
 


### PR DESCRIPTION
By adding this panel, users now have the ability to edit key bindings for the translate, rotate, scale, and undo buttons. This could be useful for those with different keyboard configurations and also allows more key bindings to be easily added without cluttering index.html. Currently, I called the panel 'CONTROLS' and didn't allow for the binding of modifier keys such as Command/Control.

Here is an image of what the panel looks like:
![screenshot-2017-11-9 three js editor](https://user-images.githubusercontent.com/12196053/32598532-ddbdb2ba-c4ee-11e7-86d0-eaca14339933.png)

There are a bunch of changes that can be made with this, so definitely let me know your thoughts. Hopefully we can leverage this to add more commands to the editor in the future.
