### PR TITLE
TDSLoader: Use path and manager for all Loaders

### DIFF
--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -43,13 +43,17 @@ THREE.TDSLoader.prototype = {
 
 		var scope = this;
 
-		var path = scope.path === undefined ? THREE.Loader.prototype.extractUrlBase( url ) : scope.path;
-		
-		var loader = new THREE.FileLoader( scope.manager );
+		if ( this.path === "" )	{
+
+			this.path = THREE.Loader.prototype.extractUrlBase( url );
+
+		}
+
+		var loader = new THREE.FileLoader( this.manager );
 
 		loader.setResponseType( 'arraybuffer' );
-		
-		loader.setPath( path );
+
+		loader.setPath( this.path );
 
 		loader.load( url, function ( data ) {
 

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -46,6 +46,8 @@ THREE.TDSLoader.prototype = {
 		var loader = new THREE.FileLoader( this.manager );
 
 		loader.setResponseType( 'arraybuffer' );
+		
+		loader.setPath( this.path );
 
 		loader.load( url, function ( data ) {
 
@@ -567,7 +569,7 @@ THREE.TDSLoader.prototype = {
 		var next = this.nextChunk( data, chunk );
 		var texture = {};
 
-		var loader = new THREE.TextureLoader();
+		var loader = new THREE.TextureLoader( this.manager );
 		loader.setPath( this.path );
 
 		while ( next !== 0 ) {

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -43,9 +43,10 @@ THREE.TDSLoader.prototype = {
 
 		var scope = this;
 
+		var path = this.path;
 		if ( this.path === "" )	{
 
-			this.path = THREE.Loader.prototype.extractUrlBase( url );
+			path = THREE.Loader.prototype.extractUrlBase( url );
 
 		}
 
@@ -53,7 +54,7 @@ THREE.TDSLoader.prototype = {
 
 		loader.setResponseType( 'arraybuffer' );
 
-		loader.setPath( this.path );
+		loader.setPath( path );
 
 		loader.load( url, function ( data ) {
 

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -43,11 +43,13 @@ THREE.TDSLoader.prototype = {
 
 		var scope = this;
 
-		var loader = new THREE.FileLoader( this.manager );
+		var path = scope.path === undefined ? THREE.Loader.prototype.extractUrlBase( url ) : scope.path;
+		
+		var loader = new THREE.FileLoader( scope.manager );
 
 		loader.setResponseType( 'arraybuffer' );
 		
-		loader.setPath( this.path );
+		loader.setPath( path );
 
 		loader.load( url, function ( data ) {
 


### PR DESCRIPTION
If a path and a manager is given I can't understand why the path is only used for textures and the manager only used for the .3ds file...
If a loading manager is available, there is no reason to not use it in all loaders. Especially when I pass an LoadingManager to an Loader instance/class I would assume that it is used for all Loaders, not for just some.

If for whatever reason you need two different loading managers then another function for setting the second one should be created.

@tentone 

@Mugen87 , got another one here, all loaders behave different... :/ 