### PR TITLE
Example: Prevent material.needsUpdate being true every frame

### DIFF
--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -63,6 +63,12 @@
 				side: 'double'
 			};
 
+			var sides = {
+				'front': THREE.FrontSide,
+				'back': THREE.BackSide,
+				'double': THREE.DoubleSide
+			};
+
 			var cameraOrtho, cameraPerspective;
 			var controlsOrtho, controlsPerspective;
 
@@ -277,7 +283,7 @@
 
 					}
 
-					if ( params.side !== material.side ) {
+					if ( sides[ params.side ] !== material.side ) {
 
 						switch ( params.side ) {
 


### PR DESCRIPTION
Maybe there is a cleaner way of doing this, but I think this is OK for an example.

The problem was that a string was being compared with an integer.
