### PR TITLE
Generalize Reflector geometry

### DIFF
--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -2,9 +2,9 @@
  * @author Slayvin / http://slayvin.net
  */
 
-THREE.Reflector = function ( width, height, options ) {
+THREE.Reflector = function ( geometry, options ) {
 
-	THREE.Mesh.call( this, new THREE.PlaneBufferGeometry( width, height ) );
+	THREE.Mesh.call( this, geometry );
 
 	this.type = 'Reflector';
 

--- a/examples/js/objects/ReflectorRTT.js
+++ b/examples/js/objects/ReflectorRTT.js
@@ -1,6 +1,6 @@
-THREE.ReflectorRTT = function ( width, height, options ) {
+THREE.ReflectorRTT = function ( geometry, options ) {
 
-	THREE.Reflector.call( this, width, height, options );
+	THREE.Reflector.call( this, geometry, options );
 
 	this.geometry.setDrawRange( 0, 0 ); // avoid rendering geometry
 

--- a/examples/js/objects/Refractor.js
+++ b/examples/js/objects/Refractor.js
@@ -3,9 +3,9 @@
  *
  */
 
-THREE.Refractor = function ( width, height, options ) {
+THREE.Refractor = function ( geometry, options ) {
 
-	THREE.Mesh.call( this, new THREE.PlaneBufferGeometry( width, height ) );
+	THREE.Mesh.call( this, geometry );
 
 	this.type = 'Refractor';
 

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -86,9 +86,10 @@
 
 				var planeGeo = new THREE.PlaneBufferGeometry( 100.1, 100.1 );
 
-				// reflector/mirror planes
+				// reflectors/mirrors
 
-				var groundMirror = new THREE.Reflector( 100, 100, {
+				var geometry = new THREE.PlaneBufferGeometry( 100, 100 );
+				var groundMirror = new THREE.Reflector( geometry, {
 					clipBias: 0.003,
 					textureWidth: WIDTH * window.devicePixelRatio,
 					textureHeight: HEIGHT * window.devicePixelRatio,
@@ -98,14 +99,15 @@
 				groundMirror.rotateX( - Math.PI / 2 );
 				scene.add( groundMirror );
 
-				var verticalMirror = new THREE.Reflector( 60, 60, {
+				var geometry = new THREE.CircleBufferGeometry( 40, 6 );
+				var verticalMirror = new THREE.Reflector( geometry, {
 					clipBias: 0.003,
 					textureWidth: WIDTH * window.devicePixelRatio,
 					textureHeight: HEIGHT * window.devicePixelRatio,
 					color: 0x889999,
 					recursion: 1
 				} );
-				verticalMirror.position.y = 35;
+				verticalMirror.position.y = 50;
 				verticalMirror.position.z = -45;
 				scene.add( verticalMirror );
 

--- a/examples/webgl_mirror_nodes.html
+++ b/examples/webgl_mirror_nodes.html
@@ -153,7 +153,8 @@
 				var planeGeo = new THREE.PlaneBufferGeometry( 100.1, 100.1 );
 
 				// reflector/mirror plane
-				var groundMirror = new THREE.ReflectorRTT( 100, 100, { clipBias: 0.003, textureWidth: WIDTH, textureHeight: HEIGHT } );
+				var geometry = new THREE.PlaneBufferGeometry( 100, 100 );
+				var groundMirror = new THREE.ReflectorRTT( geometry, { clipBias: 0.003, textureWidth: WIDTH, textureHeight: HEIGHT } );
 
 				var mask = new THREE.SwitchNode( new THREE.TextureNode( decalDiffuse ), 'w' );
 				var maskFlip = new THREE.Math1Node( mask, THREE.Math1Node.INVERT );

--- a/examples/webvr_sandbox.html
+++ b/examples/webvr_sandbox.html
@@ -85,7 +85,8 @@
 
 				//
 
-				reflector = new THREE.Reflector( 1.4, 1.4, {
+				var geometry = new THREE.PlaneBufferGeometry( 1.4, 1.4 );
+				reflector = new THREE.Reflector( geometry, {
 					textureWidth: window.innerWidth * window.devicePixelRatio,
 					textureHeight: window.innerHeight * window.devicePixelRatio
 				} );


### PR DESCRIPTION
Reflectors do not have to be rectangular. Any planar geometry will work.

The change here is trivial, but this PR will break other examples that depend on `Reflector`.

---

Ugh. There is some weird end-of-line character thingy going on that makes this PR seem bigger than it is.   :/