### PR TITLE
remove unicode character from EllipseCurve.js

### DIFF
--- a/src/extras/curves/EllipseCurve.js
+++ b/src/extras/curves/EllipseCurve.js
@@ -14,7 +14,7 @@ function EllipseCurve( aX, aY, xRadius, yRadius, aStartAngle, aEndAngle, aClockw
 	this.xRadius = xRadius || 1;
 	this.yRadius = yRadius || 1;
 
-	this.aStartAngle = aStartAngle || 0;
+	this.aStartAngle = aStartAngle || 0;
 	this.aEndAngle = aEndAngle || 2 * Math.PI;
 
 	this.aClockwise = aClockwise || false;


### PR DESCRIPTION
My browser errored on this when I built three.js into a Webpack build.