### PR TITLE
Examples: Clean up Refractor and Water (see #12631)

### DIFF
--- a/examples/js/objects/Water.js
+++ b/examples/js/objects/Water.js
@@ -7,9 +7,9 @@
  * @author Jonas Wagner / http://29a.ch/ && http://29a.ch/slides/2012/webglwater/ : Water shader explanations in WebGL
  */
 
-THREE.Water = function ( width, height, options ) {
+THREE.Water = function ( geometry, options ) {
 
-	THREE.Mesh.call( this, new THREE.PlaneBufferGeometry( width, height ) );
+	THREE.Mesh.call( this, geometry );
 
 	var scope = this;
 

--- a/examples/js/objects/Water2.js
+++ b/examples/js/objects/Water2.js
@@ -7,9 +7,9 @@
  *
  */
 
-THREE.Water = function ( width, height, options ) {
+THREE.Water = function ( geometry, options ) {
 
-	THREE.Mesh.call( this, new THREE.PlaneBufferGeometry( width, height ) );
+	THREE.Mesh.call( this, geometry );
 
 	this.type = 'Water';
 
@@ -54,13 +54,13 @@ THREE.Water = function ( width, height, options ) {
 
 	}
 
-	var reflector = new THREE.Reflector( width, height, {
+	var reflector = new THREE.Reflector( geometry, {
 		textureWidth: textureWidth,
 		textureHeight: textureHeight,
 		clipBias: clipBias
 	} );
 
-	var refractor = new THREE.Refractor( width, height, {
+	var refractor = new THREE.Refractor( geometry, {
 		textureWidth: textureWidth,
 		textureHeight: textureHeight,
 		clipBias: clipBias

--- a/examples/webgl_refraction.html
+++ b/examples/webgl_refraction.html
@@ -77,7 +77,9 @@
 
 			// refractor
 
-			refractor = new THREE.Refractor( 10, 10, {
+			var refractorGeometry = new THREE.PlaneBufferGeometry( 10, 10 );
+
+			refractor = new THREE.Refractor( refractorGeometry, {
 				color: 0x999999,
 				textureWidth: 1024,
 				textureHeight: 1024,

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -154,9 +154,10 @@
 
 			function setWater() {
 
+				var waterGeometry = new THREE.PlaneBufferGeometry( parameters.oceanSide * 5, parameters.oceanSide * 5 );
+
 				water = new THREE.Water(
-					parameters.oceanSide * 5,
-					parameters.oceanSide * 5,
+					waterGeometry,
 					{
 						textureWidth: 512,
 						textureHeight: 512,

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -109,7 +109,9 @@
 
 			// water
 
-			water = new THREE.Water( 20, 20, {
+			var waterGeometry = new THREE.PlaneBufferGeometry( 20, 20 );
+
+			water = new THREE.Water( waterGeometry, {
 				color: params.color,
 				scale: params.scale,
 				flowDirection: new THREE.Vector2( params.flowX, params.flowY ),

--- a/examples/webgl_water_flowmap.html
+++ b/examples/webgl_water_flowmap.html
@@ -86,9 +86,10 @@
 
 			// water
 
+			var waterGeometry = new THREE.PlaneBufferGeometry( 20, 20 );
 			var flowMap = textureLoader.load( 'textures/water/Water_1_M_Flow.jpg' );
 
-			water = new THREE.Water( 20, 20, {
+			water = new THREE.Water( waterGeometry, {
 				scale: 2,
 				textureWidth: 1024,
 				textureHeight: 1024,


### PR DESCRIPTION
This PR cleans up `Water`  and makes `Water2` consistent to its depended components (`Reflector`  and `Refractor`). It also fixes all related examples.

See #12631