### PR TITLE
Fix: Make STLLoader work in webworkers.

### DIFF
--- a/examples/js/loaders/3MFLoader.js
+++ b/examples/js/loaders/3MFLoader.js
@@ -88,7 +88,7 @@ THREE.ThreeMFLoader.prototype = {
 
 			}
 
-			if ( window.TextDecoder === undefined ) {
+			if ( typeof TextDecoder !== 'undefined' ) {
 
 				console.error( 'THREE.ThreeMFLoader: TextDecoder not present. Please use a TextDecoder polyfill.' );
 				return null;

--- a/examples/js/loaders/AMFLoader.js
+++ b/examples/js/loaders/AMFLoader.js
@@ -87,7 +87,7 @@ THREE.AMFLoader.prototype = {
 
 			}
 
-			if ( window.TextDecoder === undefined ) {
+			if ( typeof TextDecoder !== 'undefined' ) {
 
 				console.log( 'THREE.AMFLoader: TextDecoder not present. Please use TextDecoder polyfill.' );
 				return null;

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3915,7 +3915,7 @@
 
 		var array = new Uint8Array( buffer, from, to );
 
-		if ( window.TextDecoder !== undefined ) {
+		if ( typeof TextDecoder !== 'undefined' ) {
 
 			return new TextDecoder().decode( array );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1133,7 +1133,7 @@ THREE.GLTFLoader = ( function () {
 
 	function convertUint8ArrayToString( array ) {
 
-		if ( window.TextDecoder !== undefined ) {
+		if ( typeof TextDecoder !== 'undefined' ) {
 
 			return new TextDecoder().decode( array );
 

--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -65,7 +65,7 @@ THREE.PLYLoader.prototype = {
 
 			var array_buffer = new Uint8Array( buf );
 
-			if ( window.TextDecoder !== undefined ) {
+			if ( typeof TextDecoder !== 'undefined' ) {
 
 				return new TextDecoder().decode( array_buffer );
 

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -268,7 +268,7 @@ THREE.STLLoader.prototype = {
 
 				var array_buffer = new Uint8Array( buffer );
 
-				if ( window.TextDecoder !== undefined ) {
+				if ( typeof window !== 'undefined' && window.TextDecoder !== undefined ) {
 
 					return new TextDecoder().decode( array_buffer );
 

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -268,7 +268,7 @@ THREE.STLLoader.prototype = {
 
 				var array_buffer = new Uint8Array( buffer );
 
-				if ( typeof window !== 'undefined' && window.TextDecoder !== undefined ) {
+				if ( typeof TextDecoder !== 'undefined' ) {
 
 					return new TextDecoder().decode( array_buffer );
 

--- a/examples/js/loaders/deprecated/LegacyGLTFLoader.js
+++ b/examples/js/loaders/deprecated/LegacyGLTFLoader.js
@@ -666,7 +666,7 @@ THREE.LegacyGLTFLoader = ( function () {
 
 	function convertUint8ArrayToString( array ) {
 
-		if ( window.TextDecoder !== undefined ) {
+		if ( typeof TextDecoder !== 'undefined' ) {
 
 			return new TextDecoder().decode( array );
 

--- a/examples/js/loaders/sea3d/SEA3D.js
+++ b/examples/js/loaders/sea3d/SEA3D.js
@@ -279,7 +279,7 @@ SEA3D.Stream.prototype.readUTF8 = function ( len ) {
 
 	var buffer = this.readBytes( len );
 
-	if ( window.TextDecoder ) {
+	if ( typeof TextDecoder !== 'undefined' ) {
 
 		return new TextDecoder().decode( buffer );
 


### PR DESCRIPTION
In a webworker, the window is not initialized, so this used to throw a ReferenceError. This change will prevent that error and enable it to load normally.