### PR TITLE
fix OrbitControls cannot be correctly disabled between mousedown/mouseup

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -745,8 +745,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function onMouseUp( event ) {
 
-		if ( scope.enabled === false ) return;
-
 		handleMouseUp( event );
 
 		document.removeEventListener( 'mousemove', onMouseMove, false );


### PR DESCRIPTION
That `if`-statement could only be triggered if someone disabled orbitcontrols between mousedown and mouseup. If that someone would reenable it again, then orbit controls would think that whatever operation it was doing before is still in progress, even though user already released mouse button.