### PR TITLE
FBXLoader: support for colors specified as single floats. 

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1589,7 +1589,7 @@
 
 							if ( lightAttribute.Color !== undefined ) {
 
-								color = parseColor( lightAttribute.Color.value );
+								color = parseColor( lightAttribute.Color );
 
 							}
 
@@ -3902,6 +3902,12 @@
 	}
 
 	function parseColor( property ) {
+
+		if ( property.type === 'Color' ) {
+
+			return new THREE.Color( property.value, property.value, property.value );
+
+		}
 
 		return new THREE.Color().fromArray( property.value );
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3916,11 +3916,9 @@
 
 			return color.setScalar( property.value );
 
-		} else {
-
-			return color.fromArray( property.value );
-
 		}
+
+		return color.fromArray( property.value );
 
 	}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3903,13 +3903,17 @@
 
 	function parseColor( property ) {
 
+		var color = new THREE.Color();
+
 		if ( property.type === 'Color' ) {
 
-			return new THREE.Color( property.value, property.value, property.value );
+			return color.setScalar( property.value );
+
+		} else {
+
+			return color.fromArray( property.value );
 
 		}
-
-		return new THREE.Color().fromArray( property.value );
 
 	}
 


### PR DESCRIPTION
Fix for https://github.com/mrdoob/three.js/issues/12067#issuecomment-344218558

Extends the `parseColor` function to support color type `Color` (rather than `ColorRGB`), where the value is a single float rather than an RGB triple. 

Also fix an error when parsing light color. 