### PR TITLE
FBXLoader: fix undefined connection bug in parseAnimations

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2224,32 +2224,39 @@
 		for ( var nodeID in rawLayers ) {
 
 			var layer = [];
-			var children = connections.get( parseInt( nodeID ) ).children;
 
-			for ( var childIndex = 0; childIndex < children.length; childIndex ++ ) {
+			var connection = connections.get( parseInt( nodeID ) );
 
-				// Skip lockInfluenceWeights
-				if ( tmpMap.has( children[ childIndex ].ID ) ) {
+			if ( connection !== undefined ) {
 
-					var curveNode = tmpMap.get( children[ childIndex ].ID );
-					var boneID = curveNode.containerBoneID;
-					if ( layer[ boneID ] === undefined ) {
+				var children = connection.children;
 
-						layer[ boneID ] = {
-							T: null,
-							R: null,
-							S: null
-						};
+				for ( var childIndex = 0; childIndex < children.length; childIndex ++ ) {
+
+					// Skip lockInfluenceWeights
+					if ( tmpMap.has( children[ childIndex ].ID ) ) {
+
+						var curveNode = tmpMap.get( children[ childIndex ].ID );
+						var boneID = curveNode.containerBoneID;
+						if ( layer[ boneID ] === undefined ) {
+
+							layer[ boneID ] = {
+								T: null,
+								R: null,
+								S: null
+							};
+
+						}
+
+						layer[ boneID ][ curveNode.attr ] = curveNode;
 
 					}
 
-					layer[ boneID ][ curveNode.attr ] = curveNode;
-
 				}
 
-			}
+				returnObject.layers[ nodeID ] = layer;
 
-			returnObject.layers[ nodeID ] = layer;
+			}
 
 		}
 


### PR DESCRIPTION
Added a check in case connection is undefined in parseAnimation.

Test model from https://github.com/mrdoob/three.js/issues/11553#issuecomment-311045372
[m1911_finalFire.fbx.zip](https://github.com/mrdoob/three.js/files/1473310/m1911_finalFire.fbx.zip)
