### PR TITLE
fix typo Mixin => Mixing

### DIFF
--- a/docs/api/core/EventDispatcher.html
+++ b/docs/api/core/EventDispatcher.html
@@ -30,7 +30,7 @@ var Car = function () {
 
 };
 
-// Mixin the EventDispatcher.prototype with the custom object prototype
+// Mixing the EventDispatcher.prototype with the custom object prototype
 
 Object.assign( Car.prototype, EventDispatcher.prototype );
 


### PR DESCRIPTION
For some reason, GitHub decided to change every line instead of just the one (33) i fixed. I can't see the reason, but perhaps some line break or other invisible character change?