### PR TITLE
GLTFLoader: Throw unhandled errors.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -40,8 +40,11 @@ THREE.GLTFLoader = ( function () {
 
 					if ( onError !== undefined ) {
 
-						// For SyntaxError or TypeError, return a generic failure message.
-						onError( e.constructor === Error ? e : new Error( 'THREE.GLTFLoader: Unable to parse model.' ) );
+						onError( e );
+
+					} else {
+
+						throw e;
 
 					}
 


### PR DESCRIPTION
Removes the "generic" failure message and instead always returns the original error. Also, throws if no error handler is given, so errors are not unintentionally missed.

See: https://github.com/mrdoob/three.js/issues/12683