### PR TITLE
Fbx loader split monolithic parseScene method

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1412,7 +1412,7 @@
 
 	}
 
-// create the main THREE.Group() to be returned by the loader
+	// create the main THREE.Group() to be returned by the loader
 	function parseScene( FBXTree, connections, deformers, geometryMap, materialMap ) {
 
 		var sceneGraph = new THREE.Group();
@@ -1462,7 +1462,7 @@
 
 	}
 
-			// parse nodes in FBXTree.Objects.subNodes.Model
+	// parse nodes in FBXTree.Objects.subNodes.Model
 	function parseModels( FBXTree, deformers, geometryMap, materialMap, connections ) {
 
 		var modelMap = new Map();
@@ -1489,8 +1489,8 @@
 						model = new THREE.Bone();
 						deformer.bones[ subDeformer.index ] = model;
 
-									// seems like we need this not to make non-connected bone, maybe?
-									// TODO: confirm
+						// seems like we need this not to make non-connected bone, maybe?
+						// TODO: confirm
 						if ( model2 !== null ) model.add( model2 );
 
 					}
@@ -1534,7 +1534,7 @@
 
 	}
 
-			// create a THREE.PerspectiveCamera or THREE.OrthographicCamera
+	// create a THREE.PerspectiveCamera or THREE.OrthographicCamera
 	function createCamera( FBXTree, conns ) {
 
 		var model;
@@ -1624,7 +1624,7 @@
 
 	}
 
-			// Create a THREE.DirectionalLight, THREE.PointLight or THREE.SpotLight
+	// Create a THREE.DirectionalLight, THREE.PointLight or THREE.SpotLight
 	function createLight( FBXTree, conns ) {
 
 		var model;
@@ -1652,7 +1652,7 @@
 
 			var type;
 
-					// LightType can be undefined for Point lights
+			// LightType can be undefined for Point lights
 			if ( lightAttribute.LightType === undefined ) {
 
 				type = 0;
@@ -1673,7 +1673,7 @@
 
 			var intensity = ( lightAttribute.Intensity === undefined ) ? 1 : lightAttribute.Intensity.value / 100;
 
-					// light disabled
+			// light disabled
 			if ( lightAttribute.CastLightOnObject !== undefined && lightAttribute.CastLightOnObject.value === 0 ) {
 
 				intensity = 0;
@@ -1695,7 +1695,7 @@
 
 			}
 
-					// TODO: could this be calculated linearly from FarAttenuationStart to FarAttenuationEnd?
+			// TODO: could this be calculated linearly from FarAttenuationStart to FarAttenuationEnd?
 			var decay = 1;
 
 			switch ( type ) {
@@ -1720,9 +1720,9 @@
 					var penumbra = 0;
 					if ( lightAttribute.OuterAngle !== undefined ) {
 
-								// TODO: this is not correct - FBX calculates outer and inner angle in degrees
-								// with OuterAngle > InnerAngle && OuterAngle <= Math.PI
-								// while three.js uses a penumbra between (0, 1) to attenuate the inner angle
+						// TODO: this is not correct - FBX calculates outer and inner angle in degrees
+						// with OuterAngle > InnerAngle && OuterAngle <= Math.PI
+						// while three.js uses a penumbra between (0, 1) to attenuate the inner angle
 						penumbra = THREE.Math.degToRad( lightAttribute.OuterAngle.value );
 						penumbra = Math.max( penumbra, 1 );
 
@@ -2051,7 +2051,9 @@
 		// to attach animations to, since FBX treats animations as animations for the entire scene,
 		// not just for individual objects.
 		sceneGraph.skeleton = {
+
 			bones: Array.from( modelMap.values() ),
+
 		};
 
 	}

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1804,6 +1804,7 @@
 				materials[ materialsIndex ].skinning = true;
 
 			}
+
 			model = new THREE.SkinnedMesh( geometry, material );
 
 		} else {
@@ -1832,13 +1833,13 @@
 
 		}
 
-				// FBX does not list materials for Nurbs lines, so we'll just put our own in here.
+		// FBX does not list materials for Nurbs lines, so we'll just put our own in here.
 		var material = new THREE.LineBasicMaterial( { color: 0x3300ff, linewidth: 1 } );
 		return new THREE.Line( geometry, material );
 
 	}
 
-			// Parse ambient color in FBXTree.GlobalSettings.properties - if it's not set to black (default), create an ambient light
+	// Parse ambient color in FBXTree.GlobalSettings.properties - if it's not set to black (default), create an ambient light
 	function createAmbientLight( FBXTree, sceneGraph ) {
 
 		if ( 'GlobalSettings' in FBXTree && 'AmbientColor' in FBXTree.GlobalSettings.properties ) {
@@ -1859,7 +1860,7 @@
 
 	}
 
-			// parse the model node for transform details and apply them to the model
+	// parse the model node for transform details and apply them to the model
 	function setModelTransforms( FBXTree, model, modelNode, connections, sceneGraph ) {
 
 		if ( 'Lcl_Translation' in modelNode.properties ) {
@@ -1896,7 +1897,7 @@
 
 		}
 
-				// allow transformed pivots - see https://github.com/mrdoob/three.js/issues/11895
+		// allow transformed pivots - see https://github.com/mrdoob/three.js/issues/11895
 		if ( 'GeometricTranslation' in modelNode.properties ) {
 
 			var array = modelNode.properties.GeometricTranslation.value;
@@ -1929,7 +1930,7 @@
 
 						var pos = lookAtTarget.properties.Lcl_Translation.value;
 
-											// DirectionalLight, SpotLight
+						// DirectionalLight, SpotLight
 						if ( model.target !== undefined ) {
 
 							model.target.position.set( pos[ 0 ], pos[ 1 ], pos[ 2 ] );
@@ -1954,12 +1955,12 @@
 
 	function bindSkeleton( FBXTree, deformers, geometryMap, modelMap, connections, sceneGraph ) {
 
-				// Now with the bones created, we can update the skeletons and bind them to the skinned meshes.
+		// Now with the bones created, we can update the skeletons and bind them to the skinned meshes.
 		sceneGraph.updateMatrixWorld( true );
 
 		var worldMatrices = new Map();
 
-				// Put skeleton into bind pose.
+		// Put skeleton into bind pose.
 		if ( 'Pose' in FBXTree.Objects.subNodes ) {
 
 			var BindPoseNode = FBXTree.Objects.subNodes.Pose;
@@ -2009,7 +2010,7 @@
 
 			}
 
-							// Now that skeleton is in bind pose, bind to model.
+			// Now that skeleton is in bind pose, bind to model.
 			deformer.skeleton = new THREE.Skeleton( deformer.bones );
 
 			var conns = connections.get( deformer.FBX_ID );
@@ -2043,12 +2044,12 @@
 
 		}
 
-				//Skeleton is now bound, return objects to starting world positions.
+		//Skeleton is now bound, return objects to starting world positions.
 		sceneGraph.updateMatrixWorld( true );
 
-				// Silly hack with the animation parsing. We're gonna pretend the scene graph has a skeleton
-				// to attach animations to, since FBX treats animations as animations for the entire scene,
-				// not just for individual objects.
+		// Silly hack with the animation parsing. We're gonna pretend the scene graph has a skeleton
+		// to attach animations to, since FBX treats animations as animations for the entire scene,
+		// not just for individual objects.
 		sceneGraph.skeleton = {
 			bones: Array.from( modelMap.values() ),
 		};


### PR DESCRIPTION
The `parseScene` method was 600 lines long and very hard to read. I've split in into smaller more specific functions. The structure now looks like

parseScene:
    - parseModels
       -- createCamera
       -- createLight
       -- createMesh
       -- createCurve
    - setModelTransforms
    - bindSkeleton
    - addAnimations (already existed)
        -- parseAnimations (ditto)
    - createAmbientLight

The code is *slightly* simplified (in particular there was a `modelArray` and a `modelMap` which I have combined into just `modelMap` ) but is otherwise unchanged. 