### PR TITLE
FBXLoader use builtin array methods

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1250,12 +1250,14 @@
 	}
 
 	// Functions use the infoObject and given indices to return value array of geometry.
-	// infoObject can be materialInfo, normalInfo, UVInfo or colorInfo
-	// polygonVertexIndex - Index of vertex in draw order (which index of the index buffer refers to this vertex).
-	// polygonIndex - Index of polygon in geometry.
-	// vertexIndex - Index of vertex inside vertex buffer (used because some data refers to old index buffer that we don't use anymore).
-	var dataArray = [];
-
+	// Parameters:
+	// 	- polygonVertexIndex - Index of vertex in draw order (which index of the index buffer refers to this vertex).
+	// 	- polygonIndex - Index of polygon in geometry.
+	// 	- vertexIndex - Index of vertex inside vertex buffer (used because some data refers to old index buffer that we don't use anymore).
+	// 	- infoObject: can be materialInfo, normalInfo, UVInfo or colorInfo
+	// Index type:
+	//	- Direct: index is same as polygonVertexIndex
+	//	- IndexToDirect: infoObject has it's own set of indices
 	var GetData = {
 
 		ByPolygonVertex: {
@@ -1265,8 +1267,7 @@
 				var from = ( polygonVertexIndex * infoObject.dataSize );
 				var to = ( polygonVertexIndex * infoObject.dataSize ) + infoObject.dataSize;
 
-				// return infoObject.buffer.slice( from, to );
-				return slice( dataArray, infoObject.buffer, from, to );
+				return infoObject.buffer.slice( from, to );
 
 			},
 
@@ -1276,8 +1277,7 @@
 				var from = ( index * infoObject.dataSize );
 				var to = ( index * infoObject.dataSize ) + infoObject.dataSize;
 
-				// return infoObject.buffer.slice( from, to );
-				return slice( dataArray, infoObject.buffer, from, to );
+				return infoObject.buffer.slice( from, to );
 
 			}
 
@@ -1290,8 +1290,7 @@
 				var from = polygonIndex * infoObject.dataSize;
 				var to = polygonIndex * infoObject.dataSize + infoObject.dataSize;
 
-				// return infoObject.buffer.slice( from, to );
-				return slice( dataArray, infoObject.buffer, from, to );
+				return infoObject.buffer.slice( from, to );
 
 			},
 
@@ -1301,8 +1300,7 @@
 				var from = index * infoObject.dataSize;
 				var to = index * infoObject.dataSize + infoObject.dataSize;
 
-				// return infoObject.buffer.slice( from, to );
-				return slice( dataArray, infoObject.buffer, from, to );
+				return infoObject.buffer.slice( from, to );
 
 			}
 
@@ -1315,8 +1313,7 @@
 				var from = ( vertexIndex * infoObject.dataSize );
 				var to = ( vertexIndex * infoObject.dataSize ) + infoObject.dataSize;
 
-				// return infoObject.buffer.slice( from, to );
-				return slice( dataArray, infoObject.buffer, from, to );
+				return infoObject.buffer.slice( from, to );
 
 			}
 
@@ -1329,8 +1326,7 @@
 				var from = infoObject.indices[ 0 ] * infoObject.dataSize;
 				var to = infoObject.indices[ 0 ] * infoObject.dataSize + infoObject.dataSize;
 
-				// return infoObject.buffer.slice( from, to );
-				return slice( dataArray, infoObject.buffer, from, to );
+				return infoObject.buffer.slice( from, to );
 
 			}
 
@@ -2942,7 +2938,8 @@
 
 				propName = 'connections';
 				propValue = [ from, to ];
-				append( propValue, rest );
+
+				propValue = propValue.concat( rest );
 
 				if ( currentNode.properties[ propName ] === undefined ) {
 
@@ -3957,28 +3954,6 @@
 		}
 
 		return - 1;
-
-	}
-
-	function append( a, b ) {
-
-		for ( var i = 0, j = a.length, l = b.length; i < l; i ++, j ++ ) {
-
-			a[ j ] = b[ i ];
-
-		}
-
-	}
-
-	function slice( a, b, from, to ) {
-
-		for ( var i = from, j = 0; i < to; i ++, j ++ ) {
-
-			a[ j ] = b[ i ];
-
-		}
-
-		return a;
 
 	}
 


### PR DESCRIPTION
Removed custom `append` and `slice` methods, and replace them with 
`Array.prototype.slice()` and `Array.prototype.concat()`.

Also improved comments for `GetData` object.  