### PR TITLE
Propagate error during loading of STL files via onError callback

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -48,7 +48,20 @@ THREE.STLLoader.prototype = {
 		loader.setResponseType( 'arraybuffer' );
 		loader.load( url, function ( text ) {
 
-			onLoad( scope.parse( text ) );
+		    try {
+
+				onLoad( scope.parse( text ) );
+
+			} catch ( exception ) {
+
+		        if ( onError ) {
+
+		            onError( exception );
+
+				}
+
+		    }
+
 
 		}, onProgress, onError );
 

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -48,20 +48,19 @@ THREE.STLLoader.prototype = {
 		loader.setResponseType( 'arraybuffer' );
 		loader.load( url, function ( text ) {
 
-		    try {
+			try {
 
 				onLoad( scope.parse( text ) );
 
 			} catch ( exception ) {
 
-		        if ( onError ) {
+				if ( onError ) {
 
-		            onError( exception );
+					onError( exception );
 
 				}
 
-		    }
-
+			}
 
 		}, onProgress, onError );
 


### PR DESCRIPTION
The STL-Loader example does not contain proper error handling via the onError callback and thus it is not possible to react on those errors in a consistent manner. 

This PR adds support for the onError callback. 