### PR TITLE
GLTFExporter: Use utf-8 encoding for .glb JSON chunk.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -121,9 +121,9 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var buffer = new ArrayBuffer( text.length * 2 ); // 2 bytes per character.
+			var buffer = new ArrayBuffer( text.length );
 
-			var bufferView = new Uint16Array( buffer );
+			var bufferView = new Uint8Array( buffer );
 
 			for ( var i = 0; i < text.length; ++ i ) {
 


### PR DESCRIPTION
Fixes #12708. Bad copy from Stack Overflow on my part.