### PR TITLE
FBXLoader refactor parseAnimation and remove unused entities from return object

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2654,15 +2654,9 @@
 
 		return AXES.every( function ( key ) {
 
-			return isKeyExistOnFrame( attributeNode.curves[ key ], frame );
+			return attributeNode.curves[ key ].values[ frame ] !== undefined;
 
 		} );
-
-	}
-
-	function isKeyExistOnFrame( curve, frame ) {
-
-		return curve.values[ frame ] !== undefined;
 
 	}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2500,8 +2500,6 @@
 
 			}
 
-			var prevKey = null;
-
 			for ( var frame = 0; frame <= stack.frames; frame ++ ) {
 
 				for ( var bonesIndex = 0, bonesLength = bones.length; bonesIndex < bonesLength; ++ bonesIndex ) {
@@ -2517,23 +2515,7 @@
 
 						if ( node.name === bone.name ) {
 
-							var newKey = generateKey( animations, animationNode, bone, frame, prevKey );
-
-							// push first key
-							if ( prevKey === null ) {
-
-								node.keys.push( newKey );
-
-							}
-
-							// For subsequent keys, if the key is identical to the last key then skip it
-							else if ( ! prevKey.equals( newKey ) ) {
-
-								node.keys.push( newKey );
-
-							}
-
-							prevKey = newKey;
+							node.keys.push( generateKey( animations, animationNode, bone, frame ) );
 
 						}
 
@@ -2552,22 +2534,15 @@
 	var euler = new THREE.Euler();
 	var quaternion = new THREE.Quaternion();
 
-	function generateKey( animations, animationNode, bone, frame, prevKey ) {
+	function generateKey( animations, animationNode, bone, frame ) {
 
 		var key = {
+
 			time: frame / animations.fps,
 			pos: bone.position.toArray(),
 			rot: bone.quaternion.toArray(),
 			scl: bone.scale.toArray(),
-			equals: function ( k ) {
 
-				var posEqual = arraysAreEqual( this.pos, k.pos );
-				var rotEqual = arraysAreEqual( this.rot, k.rot );
-				var sclEqual = arraysAreEqual( this.scl, k.scl );
-
-				return posEqual && rotEqual && sclEqual;
-
-			},
 		};
 
 		if ( animationNode === undefined ) return key;
@@ -4013,17 +3988,6 @@
 		}
 
 		return a;
-
-	}
-
-	function arraysAreEqual( a, b ) {
-
-		return a.reduce( function ( current, val, i ) {
-
-			if ( current === false ) return current;
-			return val === b[ i ];
-
-		} );
 
 	}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2549,83 +2549,74 @@
 
 		euler.setFromQuaternion( bone.quaternion, 'ZYX', false );
 
-		try {
 
-			if ( hasCurve( animationNode, 'T' ) && hasKeyOnFrame( animationNode.T, frame ) ) {
+		if ( hasCurve( animationNode, 'T' ) && hasKeyOnFrame( animationNode.T, frame ) ) {
 
-				if ( animationNode.T.curves.x.values[ frame ] ) {
+			if ( animationNode.T.curves.x.values[ frame ] ) {
 
-					key.pos[ 0 ] = animationNode.T.curves.x.values[ frame ];
-
-				}
-
-				if ( animationNode.T.curves.y.values[ frame ] ) {
-
-					key.pos[ 1 ] = animationNode.T.curves.y.values[ frame ];
-
-				}
-
-				if ( animationNode.T.curves.z.values[ frame ] ) {
-
-					key.pos[ 2 ] = animationNode.T.curves.z.values[ frame ];
-
-				}
+				key.pos[ 0 ] = animationNode.T.curves.x.values[ frame ];
 
 			}
 
-			if ( hasCurve( animationNode, 'R' ) && hasKeyOnFrame( animationNode.R, frame ) ) {
+			if ( animationNode.T.curves.y.values[ frame ] ) {
 
-				// Only update the euler's values if rotation is defined for the axis on this frame
-				if ( animationNode.R.curves.x.values[ frame ] ) {
-
-					euler.x = animationNode.R.curves.x.values[ frame ];
-
-				}
-
-				if ( animationNode.R.curves.y.values[ frame ] ) {
-
-					euler.y = animationNode.R.curves.y.values[ frame ];
-
-				}
-
-				if ( animationNode.R.curves.z.values[ frame ] ) {
-
-					euler.z = animationNode.R.curves.z.values[ frame ];
-
-				}
-
-				quaternion.setFromEuler( euler );
-				key.rot = quaternion.toArray();
+				key.pos[ 1 ] = animationNode.T.curves.y.values[ frame ];
 
 			}
 
-			if ( hasCurve( animationNode, 'S' ) && hasKeyOnFrame( animationNode.S, frame ) ) {
+			if ( animationNode.T.curves.z.values[ frame ] ) {
 
-				if ( animationNode.T.curves.x.values[ frame ] ) {
-
-					key.scl[ 0 ] = animationNode.S.curves.x.values[ frame ];
-
-				}
-
-				if ( animationNode.T.curves.y.values[ frame ] ) {
-
-					key.scl[ 1 ] = animationNode.S.curves.y.values[ frame ];
-
-				}
-
-				if ( animationNode.T.curves.z.values[ frame ] ) {
-
-					key.scl[ 2 ] = animationNode.S.curves.z.values[ frame ];
-
-				}
+				key.pos[ 2 ] = animationNode.T.curves.z.values[ frame ];
 
 			}
 
-		} catch ( error ) {
+		}
 
-			// Curve is not fully plotted.
-			console.log( 'THREE.FBXLoader: ', bone );
-			console.log( 'THREE.FBXLoader: ', error );
+		if ( hasCurve( animationNode, 'R' ) && hasKeyOnFrame( animationNode.R, frame ) ) {
+
+			// Only update the euler's values if rotation is defined for the axis on this frame
+			if ( animationNode.R.curves.x.values[ frame ] ) {
+
+				euler.x = animationNode.R.curves.x.values[ frame ];
+
+			}
+
+			if ( animationNode.R.curves.y.values[ frame ] ) {
+
+				euler.y = animationNode.R.curves.y.values[ frame ];
+
+			}
+
+			if ( animationNode.R.curves.z.values[ frame ] ) {
+
+				euler.z = animationNode.R.curves.z.values[ frame ];
+
+			}
+
+			quaternion.setFromEuler( euler );
+			key.rot = quaternion.toArray();
+
+		}
+
+		if ( hasCurve( animationNode, 'S' ) && hasKeyOnFrame( animationNode.S, frame ) ) {
+
+			if ( animationNode.T.curves.x.values[ frame ] ) {
+
+				key.scl[ 0 ] = animationNode.S.curves.x.values[ frame ];
+
+			}
+
+			if ( animationNode.T.curves.y.values[ frame ] ) {
+
+				key.scl[ 1 ] = animationNode.S.curves.y.values[ frame ];
+
+			}
+
+			if ( animationNode.T.curves.z.values[ frame ] ) {
+
+				key.scl[ 2 ] = animationNode.S.curves.z.values[ frame ];
+
+			}
 
 		}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -96,7 +96,7 @@
 
 			}
 
-			console.log( FBXTree );
+			// console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );


### PR DESCRIPTION
Previously animations keys were being created by looping over the frames and creating one key for each frame, even if there was no change to the model between the frames. 

With this change, keys are checked against the key from the previous frame and skipped if the position, rotation and scale are all identical. 

Also:
* clarified and expanded  `parseAnimations` comments
* minor refactoring: created `getFrameRate`, renamed  `parseAnimationNode` -> `parseAnimationCurveNode`
* added a utility function `arraysAreEqual` for checking the keys `pos`, `rot` and `scl` arrays against each other. 