### PR TITLE
Fix materials/nodes 'caustic' example

### DIFF
--- a/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl
@@ -1,4 +1,4 @@
-#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP )
+#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP ) || defined ( PHYSICAL )
 
 	vec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );
 


### PR DESCRIPTION
Fixes #12722 by partially reverting db347605ed00cdf045f88120289056f3f299f088:
A check for `PHYSICAL` was missing.