### PR TITLE
OBJLoader2 V2.2.0

### DIFF
--- a/docs/examples/loaders/LoaderSupport.html
+++ b/docs/examples/loaders/LoaderSupport.html
@@ -156,10 +156,9 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null validate] ( [page:Function functionCodeBuilder], [page:Boolean forceWorkerReload], Array of [page:String libLocations], [page:String libPath], [page:LoaderSupport.WorkerRunnerRefImpl runnerImpl] )</h3>
+		<h3>[method:null validate] ( [page:Function functionCodeBuilder], Array of [page:String libLocations], [page:String libPath], [page:LoaderSupport.WorkerRunnerRefImpl runnerImpl] )</h3>
 		<div>
 			[page:Function functionCodeBuilder] - Function that is invoked with funcBuildObject and funcBuildSingelton that allows stringification of objects and singletons.<br>
-			[page:Boolean forceWorkerReload] - Force re-build of the worker code.<br>
 			Array of [page:String libLocations] - URL of libraries that shall be added to worker code relative to libPath.<br>
 			[page:String libPath] - Base path used for loading libraries.<br>
 			[page:LoaderSupport.WorkerRunnerRefImpl runnerImpl] - The default worker parser wrapper implementation (communication and execution). An extended class could be passed here.
@@ -175,12 +174,6 @@
 		</div>
 		<div>
 			Request termination of worker once parser is finished.
-		</div>
-
-
-		<h3>[method:null terminateWorker] ()</h3>
-		<div>
-			Terminate the worker and the code.
 		</div>
 
 
@@ -251,7 +244,7 @@
 			- prepareWorkers<br>
 			- enqueueForRun<br>
 			- processQueue<br>
-			- deregister
+			- tearDown
 		</div>
 
 
@@ -283,7 +276,10 @@
 		</div>
 
 
-		<h3>[method:null deregister]()</h3>
+		<h3>[method:null tearDown]( [page:Function callbackOnFinishedProcessing] )</h3>
+		<div>
+			[page:Function callbackOnFinishedProcessing] - Function called once all workers finished processing.
+		</div>
 		<div>
 			Terminate all workers.
 		</div>
@@ -298,6 +294,11 @@
 		<h3>[method:null getMaxWebWorkers]()</h3>
 		<div>
 			Returns the maximum number of workers.
+		</div>
+
+		<h3>[method:Boolean isRunning]()</h3>
+		<div>
+			Returns if any workers are running.
 		</div>
 
 
@@ -543,7 +544,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null isValid]( [page:Object input] )</h3>
+		<h3>[method:Boolean isValid]( [page:Object input] )</h3>
 		<div>
 			[page:Object input] - Can be anything
 		</div>

--- a/examples/webgl_loader_obj2_meshspray.html
+++ b/examples/webgl_loader_obj2_meshspray.html
@@ -142,12 +142,14 @@
 						workerCode += '/**\n';
 						workerCode += '  * This code was constructed by MeshSpray buildCode.\n';
 						workerCode += '  */\n\n';
+						workerCode += funcBuildObject( 'Validator', Validator );
+						workerCode += funcBuildSingelton( 'ConsoleLogger', 'ConsoleLogger', ConsoleLogger );
 						workerCode += funcBuildSingelton( 'Parser', 'Parser', Parser );
 
 						return workerCode;
 					};
 					var libs2Load = [ 'build/three.min.js' ];
-					this.workerSupport.validate( buildCode, false, libs2Load, '../' );
+					this.workerSupport.validate( buildCode, libs2Load, '../' );
 					this.workerSupport.setCallbacks( scopeBuilderFunc, scopeFuncComplete );
 					this.workerSupport.run(
 						{
@@ -173,7 +175,9 @@
 
 				var Parser  = ( function () {
 
-					function Parser( logger ) {
+					var ConsoleLogger = THREE.LoaderSupport.ConsoleLogger;
+
+					function Parser() {
 						this.sizeFactor = 0.5;
 						this.localOffsetFactor = 1.0;
 						this.globalObjectCount = 0;
@@ -181,8 +185,14 @@
 						this.dimension = 200;
 						this.quantity = 1;
 						this.callbackBuilder = null;
-						this.logger = logger;
+						this.callbackProgress = null;
+						this.logger = new ConsoleLogger();
 						this.serializedMaterials = null;
+					};
+
+					Parser.prototype.setLogConfig = function ( enabled, debug ) {
+						this.logger.setEnabled( enabled );
+						this.logger.setDebug( debug );
 					};
 
 					Parser.prototype.parse = function () {
@@ -389,12 +399,11 @@
 					var maxWebWorkers = 4;
 					var radius = 640;
 					var logger = new THREE.LoaderSupport.ConsoleLogger( false );
-					this.workerDirector = new THREE.LoaderSupport.WorkerDirector( MeshSpray, logger );
-					this.workerDirector.setCrossOrigin( 'anonymous' );
+					var workerDirector = new THREE.LoaderSupport.WorkerDirector( MeshSpray, logger );
+					workerDirector.setCrossOrigin( 'anonymous' );
 
-					var scope = this;
 					var callbackOnLoad = function ( event ) {
-						logger.logInfo( 'Worker #' + event.detail.instanceNo + ': Completed loading. (#' + scope.workerDirector.objectsCompleted + ')' );
+						logger.logInfo( 'Worker #' + event.detail.instanceNo + ': Completed loading. (#' + workerDirector.objectsCompleted + ')' );
 					};
 					var reportProgress = function( event ) {
 						document.getElementById( 'feedback' ).innerHTML = event.detail.text;
@@ -416,7 +425,7 @@
 					callbacks.setCallbackOnMeshAlter( callbackMeshAlter );
 					callbacks.setCallbackOnLoad( callbackOnLoad );
 					callbacks.setCallbackOnProgress( reportProgress );
-					this.workerDirector.prepareWorkers( callbacks, maxQueueSize, maxWebWorkers );
+					workerDirector.prepareWorkers( callbacks, maxQueueSize, maxWebWorkers );
 
 					var prepData;
 					var pivot;
@@ -440,9 +449,9 @@
 						prepData.dimension = Math.max( Math.random() * 500, 100 );
 						prepData.globalObjectCount = globalObjectCount++;
 
-						this.workerDirector.enqueueForRun( prepData );
+						workerDirector.enqueueForRun( prepData );
 					}
-					this.workerDirector.processQueue();
+					workerDirector.processQueue();
 				};
 
 				MeshSprayApp.prototype.resizeDisplayGL = function () {

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>three.js webgl - WWOBJLoader2</title>
+		<title>three.js webgl - OBJLoader2 usage options</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 
@@ -243,6 +243,8 @@
 					var scope = this;
 					var objLoader = new THREE.OBJLoader2();
 					var callbackOnLoad = function ( event ) {
+						objLoader.workerSupport.setTerminateRequested( true );
+
 						var local = new THREE.Object3D();
 						local.name = 'Pivot_WaltHead';
 						local.position.set( -125, 50, 0 );
@@ -257,6 +259,7 @@
 					var onLoadMtl = function ( materials ) {
 						objLoader.setModelName( modelName );
 						objLoader.setMaterials( materials );
+						objLoader.terminateWorkerOnLoad = false;
 						objLoader.load( 'obj/walt/WaltHead.obj', callbackOnLoad, null, null, null, true );
 					};
 					objLoader.loadMtl( 'obj/walt//WaltHead.mtl', 'WaltHead.mtl', null, onLoadMtl );

--- a/examples/webgl_loader_obj2_run_director.html
+++ b/examples/webgl_loader_obj2_run_director.html
@@ -113,7 +113,7 @@
 
 					this.logger = new THREE.LoaderSupport.ConsoleLogger();
 					this.logger.setEnabled( false );
-					this.workerDirector = new THREE.LoaderSupport.WorkerDirector( THREE.OBJLoader2, this.logger  );
+					this.workerDirector = new THREE.LoaderSupport.WorkerDirector( THREE.OBJLoader2, this.logger );
 					this.workerDirector.setCrossOrigin( 'anonymous' );
 
 					this.controls = null;
@@ -380,7 +380,24 @@
 				};
 
 				WWParallels.prototype.terminateManager = function () {
-					this.workerDirector.deregister();
+					this.workerDirector.tearDown();
+					this.running = false;
+				};
+
+				WWParallels.prototype.terminateManagerAndClearScene = function () {
+					var scope = this;
+					var scopedClearAllAssests = function (){
+						scope.clearAllAssests();
+					};
+					if ( this.workerDirector.isRunning() ) {
+
+						this.workerDirector.tearDown( scopedClearAllAssests );
+
+					} else {
+
+						scopedClearAllAssests();
+					}
+
 					this.running = false;
 				};
 
@@ -402,8 +419,7 @@
 					app.terminateManager();
 				},
 				clearAllAssests: function () {
-					app.terminateManager();
-					app.clearAllAssests();
+					app.terminateManagerAndClearScene();
 				}
 			};
 			var gui = new dat.GUI( {


### PR DESCRIPTION
This one really is about improving `WorkerSupport` and `WorkerDirector`. Worker lifecycle is more robust especially hard-tear down issues in `WorkerDirector` have been fixed.

See the list of changes:
- WorkerRunnerRefImpl changes: No longer required `THREE.LoaderSupport.Validator` and `THREE.LoaderSupport.ConsoleLogger` which reduces size of worker. Default workers only include WorkerRunnerRefImpl for establishing communication and no longer need the Validator or the ConsoleLogger.
- LoaderWorkerSupport changes: It always ensures logConfig parameters are properly initialized before being passed to worker. Fixed logging problems.
- Original repo issue 25: OBJLoader2 now logs an error if `THREE.LoaderSupport` is not included as script in HTML. The same is true for missing `THRE.MTLLoader`, but only if method `loadMtl` is used.
- Original repo issue 26: `WorkerSuport` now contains a inner private class `LoaderWorker` that encapsulates the native worker. This separates the runtime functionality from the setup and interaction. Workers are now terminated when immediately when they are not running otherwise `LoaderWorker.terminateRequested` ensures termination when final execution status is reached. `WorkerDirector` now properly handles shutdown of workers. Evaluation of status is always performed in `WorkerDirector.processQueue`. `WorkerDirector.callbackOnFinishedProcessing` is called when processing is completed and all workers are terminated. This allows to clear all meshes, for example.
- Updated documentation