### PR TITLE
FBXLoader refactor animation and conditional animation parsing

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2203,10 +2203,10 @@
 					if ( curveNodesMap.has( children[ childIndex ].ID ) ) {
 
 						var curveNode = curveNodesMap.get( children[ childIndex ].ID );
-						var boneID = curveNode.containerBoneID;
-						if ( layer[ boneID ] === undefined ) {
+						var modelID = curveNode.containerModelID;
+						if ( layer[ modelID ] === undefined ) {
 
-							layer[ boneID ] = {
+							layer[ modelID ] = {
 								T: null,
 								R: null,
 								S: null
@@ -2214,7 +2214,7 @@
 
 						}
 
-						layer[ boneID ][ curveNode.attr ] = curveNode;
+						layer[ modelID ][ curveNode.attr ] = curveNode;
 
 					}
 
@@ -2285,7 +2285,7 @@
 
 			id: animationCurveNode.id,
 			attr: animationCurveNode.attrName,
-			containerBoneID: - 1,
+			containerModelID: - 1,
 			curves: {
 				x: null,
 				y: null,
@@ -2310,7 +2310,7 @@
 
 			if ( modelID > - 1 ) {
 
-				returnObject.containerBoneID = modelID;
+				returnObject.containerModelID = modelID;
 
 				var model = rawModels[ containerIndices[ containerIndicesIndex ].ID.toString() ];
 
@@ -2452,7 +2452,7 @@
 
 	function addAnimations( FBXTree, connections, sceneGraph, modelMap ) {
 
-		// create a flattened array of all bones and models in the scene
+		// create a flattened array of all models and bones in the scene
 		var modelsArray = Array.from( modelMap.values() );
 
 		sceneGraph.animations = [];
@@ -2531,21 +2531,20 @@
 	var euler = new THREE.Euler();
 	var quaternion = new THREE.Quaternion();
 
-	function generateKey( fps, animationNode, bone, frame ) {
+	function generateKey( fps, animationNode, model, frame ) {
 
 		var key = {
 
 			time: frame / fps,
-			pos: bone.position.toArray(),
-			rot: bone.quaternion.toArray(),
-			scl: bone.scale.toArray(),
+			pos: model.position.toArray(),
+			rot: model.quaternion.toArray(),
+			scl: model.scale.toArray(),
 
 		};
 
 		if ( animationNode === undefined ) return key;
 
-		euler.setFromQuaternion( bone.quaternion, 'ZYX', false );
-
+		euler.setFromQuaternion( model.quaternion, 'ZYX', false );
 
 		if ( hasCurve( animationNode, 'T' ) && hasKeyOnFrame( animationNode.T, frame ) ) {
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2302,15 +2302,15 @@
 
 		for ( var containerIndicesIndex = containerIndices.length - 1; containerIndicesIndex >= 0; -- containerIndicesIndex ) {
 
-			var boneID = findIndex( modelsArray, function ( bone ) {
+			var modelID = findIndex( modelsArray, function ( model ) {
 
-				return bone.FBX_ID === containerIndices[ containerIndicesIndex ].ID;
+				return model.FBX_ID === containerIndices[ containerIndicesIndex ].ID;
 
 			} );
 
-			if ( boneID > - 1 ) {
+			if ( modelID > - 1 ) {
 
-				returnObject.containerBoneID = boneID;
+				returnObject.containerBoneID = modelID;
 
 				var model = rawModels[ containerIndices[ containerIndicesIndex ].ID.toString() ];
 


### PR DESCRIPTION
* Simplify internal animation parsing (functions were passing around quite a few unused objects and parameter, removed these).
* Better naming in animation functions: everything was being called a "bone" even though animation can be for meshes, groups, bones etc. so renamed "bone" to "model" 
* Actual animations data is stored in `FBXTree.Objects.subNodes.AnimationCurve` - if this is undefined we can safely assume that the file contains no animation.
* Internal functions no longer depend on `SceneGraph.skeleton.bones` - since this is added as a hack and ideally can be removed at some point, other functions should not depend on this array existing. Also, if there are no animations this no longer gets added. 

Note: aside from skipping animation parsing if `FBXTree.Objects.subNodes.AnimationCurve` is undefined, this is just refactoring and internal simplification. Actual animations returned should still be identical. 