### PR TITLE
TDSLoader: Fix double 'pathing'

### DIFF
--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -22,7 +22,7 @@ THREE.TDSLoader = function ( manager ) {
 	this.materials = [];
 	this.meshes = [];
 
-	this.path = "";
+	this.path = undefined;
 
 };
 
@@ -43,12 +43,19 @@ THREE.TDSLoader.prototype = {
 
 		var scope = this;
 
-		var path = this.path;
-		if ( this.path === "" )	{
+
+		var path;
+		if ( this.path === undefined ) {
 
 			path = THREE.Loader.prototype.extractUrlBase( url );
+			url = url.replace( path, '' );
+
+		} else {
+
+			path = this.path;
 
 		}
+
 
 		var loader = new THREE.FileLoader( this.manager );
 
@@ -58,7 +65,7 @@ THREE.TDSLoader.prototype = {
 
 		loader.load( url, function ( data ) {
 
-			onLoad( scope.parse( data ) );
+			onLoad( scope.parse( data, path ) );
 
 		}, onProgress, onError );
 
@@ -72,14 +79,14 @@ THREE.TDSLoader.prototype = {
 	 * @param {String} path Path for external resources.
 	 * @return {Object3D} Group loaded from 3ds file.
 	 */
-	parse: function ( arraybuffer ) {
+	parse: function ( arraybuffer, path ) {
 
 		this.group = new THREE.Group();
 		this.position = 0;
 		this.materials = [];
 		this.meshes = [];
 
-		this.readFile( arraybuffer );
+		this.readFile( arraybuffer, path );
 
 		for ( var i = 0; i < this.meshes.length; i ++ ) {
 
@@ -97,7 +104,7 @@ THREE.TDSLoader.prototype = {
 	 * @method readFile
 	 * @param {ArrayBuffer} arraybuffer Arraybuffer data to be loaded.
 	 */
-	readFile: function ( arraybuffer ) {
+	readFile: function ( arraybuffer, path ) {
 
 		var data = new DataView( arraybuffer );
 		var chunk = this.readChunk( data );
@@ -116,7 +123,7 @@ THREE.TDSLoader.prototype = {
 				} else if ( next === MDATA ) {
 
 					this.resetPosition( data );
-					this.readMeshData( data );
+					this.readMeshData( data, path );
 
 				} else {
 
@@ -140,7 +147,7 @@ THREE.TDSLoader.prototype = {
 	 * @method readMeshData
 	 * @param {Dataview} data Dataview in use.
 	 */
-	readMeshData: function ( data ) {
+	readMeshData: function ( data, path ) {
 
 		var chunk = this.readChunk( data );
 		var next = this.nextChunk( data, chunk );
@@ -168,7 +175,7 @@ THREE.TDSLoader.prototype = {
 
 				this.debugMessage( 'Material' );
 				this.resetPosition( data );
-				this.readMaterialEntry( data );
+				this.readMaterialEntry( data, path );
 
 			} else {
 
@@ -224,7 +231,7 @@ THREE.TDSLoader.prototype = {
 	 * @method readMaterialEntry
 	 * @param {Dataview} data Dataview in use.
 	 */
-	readMaterialEntry: function ( data ) {
+	readMaterialEntry: function ( data, path ) {
 
 		var chunk = this.readChunk( data );
 		var next = this.nextChunk( data, chunk );
@@ -283,25 +290,25 @@ THREE.TDSLoader.prototype = {
 
 				this.debugMessage( '   ColorMap' );
 				this.resetPosition( data );
-				material.map = this.readMap( data );
+				material.map = this.readMap( data, path );
 
 			} else if ( next === MAT_BUMPMAP ) {
 
 				this.debugMessage( '   BumpMap' );
 				this.resetPosition( data );
-				material.bumpMap = this.readMap( data );
+				material.bumpMap = this.readMap( data, path );
 
 			} else if ( next === MAT_OPACMAP ) {
 
 				this.debugMessage( '   OpacityMap' );
 				this.resetPosition( data );
-				material.alphaMap = this.readMap( data );
+				material.alphaMap = this.readMap( data, path );
 
 			} else if ( next === MAT_SPECMAP ) {
 
 				this.debugMessage( '   SpecularMap' );
 				this.resetPosition( data );
-				material.specularMap = this.readMap( data );
+				material.specularMap = this.readMap( data, path );
 
 			} else {
 
@@ -570,14 +577,14 @@ THREE.TDSLoader.prototype = {
 	 * @param {Dataview} data Dataview in use.
 	 * @return {Texture} Texture read from this data chunk.
 	 */
-	readMap: function ( data ) {
+	readMap: function ( data, path ) {
 
 		var chunk = this.readChunk( data );
 		var next = this.nextChunk( data, chunk );
 		var texture = {};
 
 		var loader = new THREE.TextureLoader( this.manager );
-		loader.setPath( this.path );
+		loader.setPath( path );
 
 		while ( next !== 0 ) {
 
@@ -586,7 +593,7 @@ THREE.TDSLoader.prototype = {
 				var name = this.readString( data, 128 );
 				texture = loader.load( name );
 
-				this.debugMessage( '      File: ' + this.path + name );
+				this.debugMessage( '      File: ' + path + name );
 
 			} else if ( next === MAT_MAP_UOFFSET ) {
 
@@ -907,11 +914,7 @@ THREE.TDSLoader.prototype = {
 	 */
 	setPath: function ( path ) {
 
-		if ( path !== undefined ) {
-
-			this.path = path;
-
-		}
+		this.path = path;
 
 		return this;
 

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -22,8 +22,6 @@ THREE.TDSLoader = function ( manager ) {
 	this.materials = [];
 	this.meshes = [];
 
-	this.path = undefined;
-
 };
 
 THREE.TDSLoader.prototype = {
@@ -44,24 +42,11 @@ THREE.TDSLoader.prototype = {
 		var scope = this;
 
 
-		var path;
-		if ( this.path === undefined ) {
-
-			path = THREE.Loader.prototype.extractUrlBase( url );
-			url = url.replace( path, '' );
-
-		} else {
-
-			path = this.path;
-
-		}
-
+		var path = this.path !== undefined ? this.path : THREE.Loader.prototype.extractUrlBase( url );
 
 		var loader = new THREE.FileLoader( this.manager );
 
 		loader.setResponseType( 'arraybuffer' );
-
-		loader.setPath( path );
 
 		loader.load( url, function ( data ) {
 


### PR DESCRIPTION
See https://github.com/mrdoob/three.js/issues/12730
Fixed issue with extracting and using the url base of the passed url without changing the url itself, see L51.
Also passed down the ```path``` variable down to the ```TextureLoader```. Still don't like the downpassing of the ```path``` but for now it should fix the issue, until we rewrite the complete TDSLoader. 
Also defaulted the ```this.path``` to ```undefined``` instead of an empty string

@stef-levesque
@Mugen87