### PR TITLE
Clean up GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1015,7 +1015,7 @@ THREE.GLTFLoader = ( function () {
 
 	/* UTILITY FUNCTIONS */
 
-	function _each( object, callback, thisObj ) {
+	function _each( object, callback ) {
 
 		if ( ! object ) {
 
@@ -1034,7 +1034,7 @@ THREE.GLTFLoader = ( function () {
 
 			for ( var idx = 0; idx < length; idx ++ ) {
 
-				var value = callback.call( thisObj || this, object[ idx ], idx );
+				var value = callback( object[ idx ], idx );
 
 				if ( value ) {
 
@@ -1066,7 +1066,7 @@ THREE.GLTFLoader = ( function () {
 
 				if ( object.hasOwnProperty( key ) ) {
 
-					var value = callback.call( thisObj || this, object[ key ], key );
+					var value = callback( object[ key ], key );
 
 					if ( value ) {
 


### PR DESCRIPTION
This PR  cleans up `_each()` function of `GLTFLoader` a bit.

- The third argument `thisObj` of `_each()` isn't used. We can remove.
- In callback functions passed to `_each()`, `this` isn't used. We can replace `callback.call( this, ... )` with `callback( ... )`.

/cc @donmccurdy 