### PR TITLE
FBXLoader: Moved geometric transforms to genGeo method

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -96,7 +96,7 @@
 
 			}
 
-			console.log( FBXTree );
+			// console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );


### PR DESCRIPTION
Moved application of geometric transforms from mesh generation methods to geometry generation methods. It makes a bit more sense to do it there, and also sets the groundwork for dealing with geometric transformations when geometries are shared between meshes, if this comes up. 