### PR TITLE
document lack of xhr progress in TextureLoader

### DIFF
--- a/docs/api/loaders/AnimationLoader.html
+++ b/docs/api/loaders/AnimationLoader.html
@@ -25,16 +25,19 @@
 		loader.load(
 			// resource URL
 			'animations/animation.js',
-			// Function when resource is loaded
+
+			// onLoad callback
 			function ( animations ) {
 				// animations is an array of AnimationClips
 			},
-			// Function called when download progresses
+
+			// onProgress callback
 			function ( xhr ) {
 				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
 			},
-			// Function called when download errors
-			function ( xhr ) {
+
+			// onError callback
+			function ( err ) {
 				console.log( 'An error happened' );
 			}
 		);

--- a/docs/api/loaders/AudioLoader.html
+++ b/docs/api/loaders/AudioLoader.html
@@ -38,7 +38,8 @@
 		loader.load(
 			// resource URL
 			'audio/ambient_ocean.ogg',
-			// Function when resource is loaded
+
+			// onLoad callback
 			function ( audioBuffer ) {
 				// set the audio object buffer to the loaded object
 				oceanAmbientSound.setBuffer( audioBuffer );
@@ -46,12 +47,14 @@
 				// play the audio
 				oceanAmbientSound.play();
 			},
-			// Function called when download progresses
+
+			// onProgress callback
 			function ( xhr ) {
 				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
 			},
-			// Function called when download errors
-			function ( xhr ) {
+
+			// onError callback
+			function ( err ) {
 				console.log( 'An error happened' );
 			}
 		);

--- a/docs/api/loaders/BufferGeometryLoader.html
+++ b/docs/api/loaders/BufferGeometryLoader.html
@@ -27,18 +27,21 @@
 		loader.load(
 			// resource URL
 			'models/json/pressure.json',
-			// Function when resource is loaded
+
+			// onLoad callback
 			function ( geometry ) {
 				var material = new THREE.MeshLambertMaterial( { color: 0xF5F5F5 } );
 				var object = new THREE.Mesh( geometry, material );
 				scene.add( object );
 			},
-			// Function called when download progresses
+
+			// onProgress callback
 			function ( xhr ) {
 				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
 			},
-			// Function called when download errors
-			function ( xhr ) {
+
+			// onError callback
+			function ( err ) {
 				console.log( 'An error happened' );
 			}
 		);

--- a/docs/api/loaders/FileLoader.html
+++ b/docs/api/loaders/FileLoader.html
@@ -22,29 +22,29 @@
 			[example:webgl_morphtargets_human WebGL / morphtargets / human]<br />
 		</div>
 		<code>
-var loader = new THREE.FileLoader();
+		var loader = new THREE.FileLoader();
 
-//load a text file a output the result to the console
-loader.load(
-    // resource URL
-    'example.txt',
+		//load a text file a output the result to the console
+		loader.load(
+			// resource URL
+			'example.txt',
 
-    // Function when resource is loaded
-    function ( data ) {
-        // output the text to the console
-        console.log( data )
-    },
+			// onLoad callback
+			function ( data ) {
+				// output the text to the console
+				console.log( data )
+			},
 
-    // Function called when download progresses
-    function ( xhr ) {
-        console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
-    },
+			// onProgress callback
+			function ( xhr ) {
+				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			},
 
-    // Function called when download errors
-    function ( xhr ) {
-        console.error( 'An error happened' );
-    }
-);
+			// onError callback
+			function ( err ) {
+				console.error( 'An error happened' );
+			}
+		);
 		</code>
 
 		<h2>Constructor</h2>

--- a/docs/api/loaders/FontLoader.html
+++ b/docs/api/loaders/FontLoader.html
@@ -31,17 +31,20 @@
 		var font = loader.load(
 			// resource URL
 			'fonts/helvetiker_bold.typeface.json'
-			// Function when resource is loaded
+
+			// onLoad callback
 			function ( font ) {
 				// do something with the font
 				scene.add( font );
 			},
-			// Function called when download progresses
+
+			// onProgress callback
 			function ( xhr ) {
 				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
 			},
-			// Function called when download errors
-			function ( xhr ) {
+
+			// onError callback
+			function ( err ) {
 				console.log( 'An error happened' );
 			}
 		);

--- a/docs/api/loaders/ImageBitmapLoader.html
+++ b/docs/api/loaders/ImageBitmapLoader.html
@@ -36,10 +36,8 @@
 				var material = new THREE.MeshBasicMaterial( { map: texture } );
 			},
 
-			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
-			},
+			// onProgress callback currently not supported
+			undefined,
 
 			// onError callback
 			function ( err ) {

--- a/docs/api/loaders/ImageBitmapLoader.html
+++ b/docs/api/loaders/ImageBitmapLoader.html
@@ -29,17 +29,20 @@
 		loader.load(
 			// resource URL
 			'textures/skyboxsun25degtest.png',
-			// Function when resource is loaded
+
+			// onLoad callback
 			function ( imageBitmap ) {
 				var texture = new THREE.CanvasTexture( imageBitmap );
 				var material = new THREE.MeshBasicMaterial( { map: texture } );
 			},
-			// Function called when download progresses
+
+			// onProgress callback
 			function ( xhr ) {
 				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
 			},
-			// Function called when download errors
-			function ( xhr ) {
+
+			// onError callback
+			function ( err ) {
 				console.log( 'An error happened' );
 			}
 		);

--- a/docs/api/loaders/ImageLoader.html
+++ b/docs/api/loaders/ImageLoader.html
@@ -51,7 +51,7 @@
 		);
 		</code>
 
-		Please note Three.js version r84 dropped support for ImageLoader progress events. If you are using a more modern version of Three.js, you may wish to use [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639 one of these image loaders].
+		Please note Three.js r84 dropped support for ImageLoader progress events. For an ImageLoader that supports progress events, see [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639 this thread].
 
 		<h2>Constructor</h2>
 

--- a/docs/api/loaders/ImageLoader.html
+++ b/docs/api/loaders/ImageLoader.html
@@ -51,7 +51,7 @@
 		);
 		</code>
 
-		Please note Three.js r84 dropped support for ImageLoader progress events. For an ImageLoader that supports progress events, see [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639 this thread].
+		Please note three.js r84 dropped support for ImageLoader progress events. For an ImageLoader that supports progress events, see [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639 this thread].
 
 		<h2>Constructor</h2>
 

--- a/docs/api/loaders/ImageLoader.html
+++ b/docs/api/loaders/ImageLoader.html
@@ -32,26 +32,26 @@
 		loader.load(
 			// resource URL
 			'textures/skyboxsun25degtest.png',
-			// Function when resource is loaded
-			function ( image ) {
-				// do something with it
 
-				// like drawing a part of it on a canvas
+			// onLoad callback
+			function ( image ) {
+				// use the image, e.g. draw part of it on a canvas
 				var canvas = document.createElement( 'canvas' );
 				var context = canvas.getContext( '2d' );
 				context.drawImage( image, 100, 100 );
 			},
-			// Function called when download progresses
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
-			},
-			// Function called when download errors
-			function ( xhr ) {
-				console.log( 'An error happened' );
+
+			// onProgress callback currently not supported
+			undefined,
+
+			// onError callback
+			function () {
+				console.error( 'An error happened.' );
 			}
 		);
 		</code>
 
+		Please note Three.js version r84 dropped support for ImageLoader progress events. If you are using a more modern version of Three.js, you may wish to use [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639 one of these image loaders].
 
 		<h2>Constructor</h2>
 

--- a/docs/api/loaders/JSONLoader.html
+++ b/docs/api/loaders/JSONLoader.html
@@ -28,18 +28,24 @@
 
 		// load a resource
 		loader.load(
-
 			// resource URL
 			'models/animated/monster/monster.js',
 
-			// Function when resource is loaded
+			// onLoad callback
 			function ( geometry, materials ) {
-
 				var material = materials[ 0 ];
 				var object = new THREE.Mesh( geometry, material );
-
 				scene.add( object );
+			},
 
+			// onProgress callback
+			function ( xhr ) {
+				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			},
+
+			// onError callback
+			function( err ) {
+				console.log( 'An error happened' );
 			}
 		);
 		</code>

--- a/docs/api/loaders/MaterialLoader.html
+++ b/docs/api/loaders/MaterialLoader.html
@@ -26,16 +26,19 @@
 		loader.load(
 			// resource URL
 			'path/to/material.json',
-			// Function when resource is loaded
+
+			// onLoad callback
 			function ( material ) {
 				object.material = material;
 			},
-			// Function called when download progresses
+
+			// onProgress callback
 			function ( xhr ) {
 				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
 			},
-			// Function called when download errors
-			function ( xhr ) {
+
+			// onError callback
+			function ( err ) {
 				console.log( 'An error happened' );
 			}
 		);

--- a/docs/api/loaders/ObjectLoader.html
+++ b/docs/api/loaders/ObjectLoader.html
@@ -29,35 +29,35 @@
 		</div>
 
 		<code>
-var loader = new THREE.ObjectLoader();
+		var loader = new THREE.ObjectLoader();
 
-loader.load(
-    // resource URL
-    "models/json/example.json",
+		loader.load(
+			// resource URL
+			"models/json/example.json",
 
-    // pass the loaded data to the onLoad function.
-		//Here it is assumed to be an object
-    function ( obj ) {
-				//add the loaded object to the scene
-        scene.add( obj );
-    },
+			// onLoad callback
+			// Here the loaded data is assumed to be an object
+			function ( obj ) {
+				// Add the loaded object to the scene
+				scene.add( obj );
+			},
 
-    // Function called when download progresses
-    function ( xhr ) {
-        console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
-    },
+			// onProgress callback
+			function ( err ) {
+				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			},
 
-    // Function called when download errors
-    function ( xhr ) {
-        console.error( 'An error happened' );
-    }
-);
+			// onError callback
+			function ( xhr ) {
+				console.error( 'An error happened' );
+			}
+		);
 
 
-// Alternatively, to parse a previously loaded JSON structure
-var object = loader.parse( a_json_object );
+		// Alternatively, to parse a previously loaded JSON structure
+		var object = loader.parse( a_json_object );
 
-scene.add( object );
+		scene.add( object );
 		</code>
 
 

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -54,7 +54,7 @@
 		);
 		</code>
 
-		Please note that XHR progress events are not triggered as of Three.js version 88. If you need XHR progress events, you may wish to use Three.js version 83 or [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639 use one of these loaders].
+		Please note Three.js version r84 dropped support for TextureLoader progress events. If you are using a more modern version of Three.js, you may wish to use [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639 one of these texture loaders].
 
 		<h2>Constructor</h2>
 

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -55,7 +55,7 @@
 		);
 		</code>
 
-		Please note Three.js version r84 dropped support for TextureLoader progress events. If you are using a more modern version of Three.js, you may wish to use [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639 one of these texture loaders].
+		Please note Three.js r84 dropped support for TextureLoader progress events. For a TextureLoader that supports progress events, see [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-293260145 this thread].
 
 		<h2>Constructor</h2>
 

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -36,20 +36,21 @@
 		loader.load(
 			// resource URL
 			'textures/land_ocean_ice_cloud_2048.jpg',
-			// Function when resource is loaded
+
+			// onLoad callback
 			function ( texture ) {
 				// in this example we create the material when the texture is loaded
 				var material = new THREE.MeshBasicMaterial( {
 					map: texture
 				 } );
 			},
-			// Function called when download progresses
-			function ( xhr ) {
-				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );
-			},
-			// Function called when download errors
-			function ( xhr ) {
-				console.error( 'An error happened' );
+
+			// onProgress callback currently not supported
+			undefined,
+
+			// onError callback
+			function ( err ) {
+				console.error( 'An error happened.' );
 			}
 		);
 		</code>

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -54,6 +54,8 @@
 		);
 		</code>
 
+		Please note that XHR progress events are not triggered as of Three.js version 88. If you need XHR progress events, you may wish to use Three.js version 83 or [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639 use one of these loaders].
+
 		<h2>Constructor</h2>
 
 		<h3>[name]( [page:LoadingManager manager] )</h3>

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -55,7 +55,7 @@
 		);
 		</code>
 
-		Please note Three.js r84 dropped support for TextureLoader progress events. For a TextureLoader that supports progress events, see [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-293260145 this thread].
+		Please note three.js r84 dropped support for TextureLoader progress events. For a TextureLoader that supports progress events, see [link:https://github.com/mrdoob/three.js/issues/10439#issuecomment-293260145 this thread].
 
 		<h2>Constructor</h2>
 


### PR DESCRIPTION
This PR introduces a quick note into the TextureLoader docs to mention that XHR progress is not implemented as of v84. I linked folks to the [thread](https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639) where conversation on loaders and progress has centered.

This is to add clarity to the docs and prevent additional issues like https://github.com/mrdoob/three.js/issues/12313