### PR TITLE
Fix glTF Specular-Glossiness material

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -529,6 +529,7 @@ THREE.GLTFLoader = ( function () {
 					'vec3 specularFactor = specular;',
 					'#ifdef USE_SPECULARMAP',
 					'	vec4 texelSpecular = texture2D( specularMap, vUv );',
+					'	texelSpecular = sRGBToLinear( texelSpecular );',
 					'	// reads channel RGB, compatible with a glTF Specular-Glossiness (RGBA) texture',
 					'	specularFactor *= texelSpecular.rgb;',
 					'#endif'


### PR DESCRIPTION
This PR fixes glTF Specular-Glossiness material by converting `specularMap` in sRGB space and fixes #12749.

specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/Khronos/KHR_materials_pbrSpecularGlossiness#specularglossinesstexture

Metallic Roughness
![image](https://user-images.githubusercontent.com/7637832/33237887-b7a1eb36-d2c3-11e7-974d-8d192b1d2225.png)

Specular Glossiness
![image](https://user-images.githubusercontent.com/7637832/33237889-c3394944-d2c3-11e7-91f9-ab6c4df16528.png)

They're very similar now.
