### PR TITLE
Examples: Apply negative scale to geometry instead of mesh

### DIFF
--- a/examples/canvas_geometry_panorama.html
+++ b/examples/canvas_geometry_panorama.html
@@ -81,8 +81,10 @@
 
 				];
 
-				mesh = new THREE.Mesh( new THREE.BoxGeometry( 300, 300, 300, 7, 7, 7 ), materials );
-				mesh.scale.x = - 1;
+				var geometry = new THREE.BoxGeometry( 300, 300, 300, 7, 7, 7 );
+				geometry.scale( - 1, 1, 1 );
+
+				mesh = new THREE.Mesh( geometry, materials );
 				scene.add( mesh );
 
 				renderer = new THREE.CanvasRenderer();

--- a/examples/canvas_geometry_panorama_fisheye.html
+++ b/examples/canvas_geometry_panorama_fisheye.html
@@ -81,8 +81,10 @@
 
 				];
 
-				mesh = new THREE.Mesh( new THREE.BoxGeometry( 300, 300, 300, 7, 7, 7 ), materials );
-				mesh.scale.x = - 1;
+				var geometry = new THREE.BoxGeometry( 300, 300, 300, 7, 7, 7 );
+				geometry.scale( - 1, 1, 1 );
+
+				mesh = new THREE.Mesh( geometry, materials );
 				scene.add( mesh );
 
 				for ( var i = 0, l = mesh.geometry.vertices.length; i < l; i ++ ) {

--- a/examples/webgl_materials_cubemap_dynamic2.html
+++ b/examples/webgl_materials_cubemap_dynamic2.html
@@ -61,7 +61,7 @@
 				scene = new THREE.Scene();
 
 				var mesh = new THREE.Mesh( new THREE.SphereBufferGeometry( 500, 32, 16 ), new THREE.MeshBasicMaterial( { map: texture } ) );
-				mesh.scale.x = -1;
+				mesh.geometry.scale( - 1, 1, 1 );
 				scene.add( mesh );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );


### PR DESCRIPTION
In a future PR, a negative scale applied to a mesh will not invert it -- it will just reflect it. So in preparation for that change, the geometry is inverted, instead.