### PR TITLE
Examples: Clean up

### DIFF
--- a/examples/webgl_interactive_raycasting_points.html
+++ b/examples/webgl_interactive_raycasting_points.html
@@ -217,8 +217,9 @@
 				clock = new THREE.Clock();
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 10000 );
-				camera.applyMatrix( new THREE.Matrix4().makeTranslation( 0,0,20 ) );
-				camera.applyMatrix( new THREE.Matrix4().makeRotationX( -0.5 ) );
+				camera.position.set( 10, 10, 10 );
+				camera.lookAt( scene.position );
+				camera.updateMatrix();
 
 				//
 

--- a/examples/webgl_panorama_cube.html
+++ b/examples/webgl_panorama_cube.html
@@ -75,7 +75,7 @@
 			}
 
 			var skyBox = new THREE.Mesh( new THREE.CubeGeometry( 1, 1, 1 ), materials );
-			skyBox.applyMatrix( new THREE.Matrix4().makeScale( 1, 1, - 1 ) );
+			skyBox.geometry.scale( 1, 1, - 1 );
 			scene.add( skyBox );
 
 			window.addEventListener( 'resize', onWindowResize, false );

--- a/examples/webvr_panorama.html
+++ b/examples/webvr_panorama.html
@@ -48,6 +48,7 @@
 			camera.layers.enable( 1 );
 
 			var geometry = new THREE.CubeGeometry( 100, 100, 100 );
+			geometry.scale( 1, 1, - 1 );
 			var textures = getTexturesFromAtlasFile( "textures/cube/sun_temple_stripe_stereo.jpg", 12 );
 
 			var materials = [];
@@ -59,7 +60,6 @@
 			}
 
 			var skyBox = new THREE.Mesh( geometry, materials );
-			skyBox.applyMatrix( new THREE.Matrix4().makeScale( 1, 1, - 1 ) );
 			skyBox.layers.set( 1 );
 			scene.add( skyBox );
 
@@ -73,7 +73,6 @@
 			}
 
 			var skyBoxR = new THREE.Mesh( geometry, materialsR );
-			skyBoxR.applyMatrix( new THREE.Matrix4().makeScale( 1, 1, - 1 ) );
 			skyBoxR.layers.set( 2 );
 			scene.add( skyBoxR );
 

--- a/examples/webvr_rollercoaster.html
+++ b/examples/webvr_rollercoaster.html
@@ -55,7 +55,7 @@
 			// environment
 
 			var geometry = new THREE.PlaneBufferGeometry( 500, 500, 15, 15 );
-			geometry.applyMatrix( new THREE.Matrix4().makeRotationX( - Math.PI / 2 ) );
+			geometry.rotateX( - Math.PI / 2 );
 
 			var positions = geometry.attributes.position.array;
 			var vertex = new THREE.Vector3();


### PR DESCRIPTION
Removed use of `applyMatrix()` in favor of alternative methods.

Note: unable to test webvr changes in this PR.