### PR TITLE
GLTFLoader: Don't ignore extras from meshDef

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2080,7 +2080,19 @@ THREE.GLTFLoader = ( function () {
 
 						}
 
-						Object.assign(mesh.userData, JSON.parse(JSON.stringify(meshDef.extras)), JSON.parse(JSON.stringify(primitive.extras)));
+						if ( meshDef.extras !== undefined ) mesh.userData = meshDef.extras;
+
+						if ( primitive.extras !== undefined ) {
+
+						  mesh.userData = mesh.userData || {};
+
+						  for ( var key in primitive.extras ) {
+
+							if ( mesh.userData[ key ] === undefined ) mesh.userData[ key ] = primitive.extras[ key ];
+
+						  }
+
+						}
 
 						if ( primitives.length > 1 ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2080,7 +2080,7 @@ THREE.GLTFLoader = ( function () {
 
 						}
 
-						if ( primitive.extras ) mesh.userData = primitive.extras;
+						Object.assign(mesh.userData, JSON.parse(JSON.stringify(meshDef.extras)), JSON.parse(JSON.stringify(primitive.extras)));
 
 						if ( primitives.length > 1 ) {
 


### PR DESCRIPTION
The reason why I use ```JSON.parse(JSON.stringify(...))``` is that the object being merged is only referenced instead of copied if it is deep.

See following code for clarity: (reference [MDN Object.assign()]( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) )
```javascript
var mesh = new THREE.Mesh();
var testObj = {
	a: {
		c : 5
	}
};

// "NORMAL" CLONE => REFERENCE
Object.assign(mesh.userData, testObj);
console.log(JSON.stringify(mesh.userData)); // {"a":{"c":5}}
testObj.a.c = 2;
console.log(JSON.stringify(mesh.userData)); // {"a":{"c":2}}

// RESET
mesh.userData = {}; 
testObj.a.c = 5;

// DEEP CLONE => REAL COPY
Object.assign(mesh.userData, JSON.parse(JSON.stringify(testObj)));
console.log(JSON.stringify(mesh.userData)); // {"a":{"c":5}}
testObj.a.c = 2;
console.log(JSON.stringify(mesh.userData)); // {"a":{"c":5}}
```

I would prefer this way over the one without json parse and stringify for safety reasons.
