### PR TITLE
PropertyBinding: Organize TODO tests.

### DIFF
--- a/test/unit/src/animation/PropertyBinding.tests.js
+++ b/test/unit/src/animation/PropertyBinding.tests.js
@@ -11,23 +11,23 @@ import { MeshBasicMaterial } from '../../../../src/materials/MeshBasicMaterial';
 
 export default QUnit.module( 'Animation', () => {
 
-	QUnit.module.todo( 'PropertyBinding', () => {
+	QUnit.module( 'PropertyBinding', () => {
 
 		// INSTANCING
-		QUnit.test( "Instancing", ( assert ) => {
+		QUnit.todo( "Instancing", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
 		// STATIC STUFF
-		QUnit.test( "Composite", ( assert ) => {
+		QUnit.todo( "Composite", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
-		QUnit.test( "create", ( assert ) => {
+		QUnit.todo( "create", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
@@ -251,38 +251,38 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
-		QUnit.test( "findNode", ( assert ) => {
+		QUnit.todo( "findNode", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
 		// PUBLIC STUFF
-		QUnit.test( "BindingType", ( assert ) => {
+		QUnit.todo( "BindingType", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
-		QUnit.test( "Versioning", ( assert ) => {
+		QUnit.todo( "Versioning", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
-		QUnit.test( "GetterByBindingType", ( assert ) => {
+		QUnit.todo( "GetterByBindingType", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
-		QUnit.test( "SetterByBindingTypeAndVersioning", ( assert ) => {
+		QUnit.todo( "SetterByBindingTypeAndVersioning", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
-		QUnit.test( "getValue", ( assert ) => {
+		QUnit.todo( "getValue", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
@@ -325,26 +325,13 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
-		QUnit.test( "bind", ( assert ) => {
+		QUnit.todo( "bind", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
-		QUnit.test( "unbind", ( assert ) => {
-
-			assert.ok( false, "everything's gonna be alright" );
-
-		} );
-
-		// OTHERS
-		QUnit.test( "_getValue_unavailable", ( assert ) => {
-
-			assert.ok( false, "everything's gonna be alright" );
-
-		} );
-
-		QUnit.test( "_setValue_unavailable", ( assert ) => {
+		QUnit.todo( "unbind", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 


### PR DESCRIPTION
@Itee I think this is what should happen to all of the tests — mark individual tests as TODO rather than the module, and skip the TODOs for private methods. Does this seem right?

| before | after |
|---|---|
| ![screen shot 2017-11-27 at 5 40 17 pm](https://user-images.githubusercontent.com/1848368/33298295-44305214-d39a-11e7-8641-24cc38e74882.png) | ![screen shot 2017-11-27 at 5 39 48 pm](https://user-images.githubusercontent.com/1848368/33298297-469bc664-d39a-11e7-83dc-b47505979ac2.png) |

Related: #12714, #12759.