### PR TITLE
GLTFLoader: Add renderer.gammaOutput=true to examples.

### DIFF
--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -171,6 +171,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.gammaOutput = true;
 
 				if (sceneInfo.shadows) {
 					renderer.shadowMap.enabled = true;


### PR DESCRIPTION
Fixes #12554. See #11110.