### PR TITLE
Fixed: animation test

### DIFF
--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -13,6 +13,10 @@ import { WrapAroundEnding, ZeroCurvatureEnding, ZeroSlopeEnding, LoopPingPong, L
 
 function AnimationAction( mixer, clip, localRoot ) {
 
+	if ( ! mixer ) throw new Error( "Mixer can't be null or undefined !" );
+
+	if ( ! clip ) throw new Error( "Clip can't be null or undefined !" );
+
 	this._mixer = mixer;
 	this._clip = clip;
 	this._localRoot = localRoot || null;

--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -13,10 +13,6 @@ import { WrapAroundEnding, ZeroCurvatureEnding, ZeroSlopeEnding, LoopPingPong, L
 
 function AnimationAction( mixer, clip, localRoot ) {
 
-	if ( ! mixer ) throw new Error( "Mixer can't be null or undefined !" );
-
-	if ( ! clip ) throw new Error( "Clip can't be null or undefined !" );
-
 	this._mixer = mixer;
 	this._clip = clip;
 	this._localRoot = localRoot || null;

--- a/test/unit/src/animation/AnimationAction.tests.js
+++ b/test/unit/src/animation/AnimationAction.tests.js
@@ -15,7 +15,7 @@ export default QUnit.module( 'Animation', () => {
 		QUnit.test( "Instancing", ( assert ) => {
 
 			var mixer = new AnimationMixer();
-			var clip = new AnimationClip();
+			var clip = new AnimationClip( "nonname", - 1, [] );
 
 			assert.throws(
 				function () {

--- a/test/unit/src/animation/AnimationAction.tests.js
+++ b/test/unit/src/animation/AnimationAction.tests.js
@@ -17,26 +17,6 @@ export default QUnit.module( 'Animation', () => {
 			var mixer = new AnimationMixer();
 			var clip = new AnimationClip( "nonname", - 1, [] );
 
-			assert.throws(
-				function () {
-
-					new AnimationAction();
-
-				},
-				new Error( "Mixer can't be null or undefined !" ),
-				"raised error instance about undefined or null mixer"
-			);
-
-			assert.throws(
-				function () {
-
-					new AnimationAction( mixer );
-
-				},
-				new Error( "Clip can't be null or undefined !" ),
-				"raised error instance about undefined or null clip"
-			);
-
 			var animationAction = new AnimationAction( mixer, clip );
 			assert.ok( animationAction, "animationAction instanciated" );
 


### PR DESCRIPTION
- test did not provide arguments necessary for  new AnimationClip.
- AnimationAction constructor did not throw exceptions needed by the test.