### PR TITLE
X-Loader example: use negative scale to mirror model

### DIFF
--- a/examples/webgl_loader_x.html
+++ b/examples/webgl_loader_x.html
@@ -163,17 +163,22 @@
 
             //download Model file
 
-            loader.load( [ 'models/xfile/SSR06_model.x', { zflag: true } ], function ( object ) {
+            loader.load( [ 'models/xfile/SSR06_model.x', { zflag: false } ], function ( object ) {
 
                 for ( var i = 0; i < object.models.length; i ++ ) {
 
-                    Models.push( object.models[ i ] );
+                    var model = object.models[ i ];
+
+                    model.scale.x *= - 1;
+
+                    Models.push( model );
 
                 }
 
                 loadAnimation( 'stand', 0, () => {
 
                     scene.add( Models[ 0 ] );
+
                     if ( Models[ 0 ] instanceof THREE.SkinnedMesh ) {
 
                         skeletonHelper = new THREE.SkeletonHelper( Models[ 0 ] );
@@ -240,7 +245,7 @@
             } else {
 
                 var loader2 = new THREE.XLoader( manager, Texloader );
-                loader2.load( [ 'models/xfile/' + animeName + '.x', { zflag: true, putPos: false, putScl: false } ], function () {
+                loader2.load( [ 'models/xfile/' + animeName + '.x', { zflag: false, putPos: false, putScl: false } ], function () {
 
                     // !! important!
                     // associate divided model and animation.


### PR DESCRIPTION
With this PR, `mesh.scale.x` is used to mirror the model, rather than the `XLoader` `zflag` option, which is non-conventional.

This PR is based on #12787.

@adrs2002 Please have a look and comment. 