### PR TITLE
enables proper orientation discovery on startup

### DIFF
--- a/examples/js/controls/DeviceOrientationControls.js
+++ b/examples/js/controls/DeviceOrientationControls.js
@@ -9,15 +9,16 @@ THREE.DeviceOrientationControls = function( object ) {
 
 	var scope = this;
 
-	this.object = object;
-	this.object.rotation.reorder( "YXZ" );
+	scope.object = object;
+	scope.object.rotation.reorder( "YXZ" );
 
-	this.enabled = true;
+	scope.enabled = true;
 
-	this.deviceOrientation = {};
-	this.screenOrientation = 0;
+	scope.deviceOrientation = {};
+	scope.alphaOffset = THREE.Math.degToRad( 90 );
 
-	this.alphaOffset = 0; // radians
+	scope.screenOrientation = window.orientation || 0;
+	if( scope.screenOrientation === 0 || scope.screenOrientation === -90 ) scope.alphaOffset *= -1.0;
 
 	var onDeviceOrientationChangeEvent = function( event ) {
 


### PR DESCRIPTION
I needed to do this to it but I'm pretty sure my camera's x position is 0 and the target is center 0,0,0. Unfortunately there's no upside down window.orientation.
Now it doesn't matter what orientation you're in at startup.
You can leave the alphaOffset at 0 degrees if you prefer but it seem better then putting radians 1.5708 for 90 degrees as a user friendly option. Note putting 90 degrees seem correct to line up the original Desktop OrbitControls angle the same on my note 8.
On the older Note 3, 0 degree (portrait) orientation is not the same as the note 8? That part I haven't figured out yet, but the newer one wins out I suppose.
Oh the 'scope' I reused instead of 'this', which is also optional but seemed to make more sense to me.
[I didn't include all my replacements of 'var' with 'let', which makes no difference with this issue.]