### PR TITLE
GLTFLoader: Support morph targets w/ interleaved attributes

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1100,7 +1100,7 @@ THREE.GLTFLoader = ( function () {
 				// So morphTarget value will depend on mesh's position, then cloning attribute
 				// for the case if attribute is shared among two or more meshes.
 
-				positionAttribute = accessors[ target.POSITION ].clone();
+				positionAttribute = cloneBufferAttribute( accessors[ target.POSITION ] );
 				var position = geometry.attributes.position;
 
 				for ( var j = 0, jl = positionAttribute.count; j < jl; j ++ ) {
@@ -1118,7 +1118,7 @@ THREE.GLTFLoader = ( function () {
 
 				// Copying the original position not to affect the final position.
 				// See the formula above.
-				positionAttribute = geometry.attributes.position.clone();
+				positionAttribute = cloneBufferAttribute( geometry.attributes.position );
 
 			}
 
@@ -1135,7 +1135,7 @@ THREE.GLTFLoader = ( function () {
 
 				// see target.POSITION's comment
 
-				normalAttribute = accessors[ target.NORMAL ].clone();
+				normalAttribute = cloneBufferAttribute( accessors[ target.NORMAL ] );
 				var normal = geometry.attributes.normal;
 
 				for ( var j = 0, jl = normalAttribute.count; j < jl; j ++ ) {
@@ -1151,7 +1151,7 @@ THREE.GLTFLoader = ( function () {
 
 			} else if ( geometry.attributes.normal !== undefined ) {
 
-				normalAttribute = geometry.attributes.normal.clone();
+				normalAttribute = cloneBufferAttribute( geometry.attributes.normal );
 
 			}
 
@@ -1228,6 +1228,31 @@ THREE.GLTFLoader = ( function () {
 		}
 
 		return null;
+
+	}
+
+	function cloneBufferAttribute( attribute ) {
+
+		if ( attribute.isInterleavedBufferAttribute ) {
+
+			var count = attribute.count;
+			var itemSize = attribute.itemSize;
+			var array = attribute.array.slice( 0, count * itemSize );
+
+			for ( var i = 0; i < count; ++ i ) {
+
+				array[ i ] = attribute.getX( i );
+				if ( itemSize >= 2 ) array[ i + 1 ] = attribute.getY( i );
+				if ( itemSize >= 3 ) array[ i + 2 ] = attribute.getZ( i );
+				if ( itemSize >= 4 ) array[ i + 3 ] = attribute.getW( i );
+
+			}
+
+			return new THREE.BufferAttribute( array, itemSize, attribute.normalized );
+
+		}
+
+		return attribute.clone();
 
 	}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1100,7 +1100,7 @@ THREE.GLTFLoader = ( function () {
 				// So morphTarget value will depend on mesh's position, then cloning attribute
 				// for the case if attribute is shared among two or more meshes.
 
-				positionAttribute = cloneBufferAttribute( accessors[ target.POSITION ] );
+				positionAttribute = accessors[ target.POSITION ].clone();
 				var position = geometry.attributes.position;
 
 				for ( var j = 0, jl = positionAttribute.count; j < jl; j ++ ) {
@@ -1118,7 +1118,7 @@ THREE.GLTFLoader = ( function () {
 
 				// Copying the original position not to affect the final position.
 				// See the formula above.
-				positionAttribute = cloneBufferAttribute( geometry.attributes.position );
+				positionAttribute = geometry.attributes.position.clone();
 
 			}
 
@@ -1135,7 +1135,7 @@ THREE.GLTFLoader = ( function () {
 
 				// see target.POSITION's comment
 
-				normalAttribute = cloneBufferAttribute( accessors[ target.NORMAL ] );
+				normalAttribute = accessors[ target.NORMAL ].clone();
 				var normal = geometry.attributes.normal;
 
 				for ( var j = 0, jl = normalAttribute.count; j < jl; j ++ ) {
@@ -1151,7 +1151,7 @@ THREE.GLTFLoader = ( function () {
 
 			} else if ( geometry.attributes.normal !== undefined ) {
 
-				normalAttribute = cloneBufferAttribute( geometry.attributes.normal );
+				normalAttribute = geometry.attributes.normal.clone();
 
 			}
 
@@ -1228,31 +1228,6 @@ THREE.GLTFLoader = ( function () {
 		}
 
 		return null;
-
-	}
-
-	function cloneBufferAttribute( attribute ) {
-
-		if ( attribute.isInterleavedBufferAttribute ) {
-
-			var count = attribute.count;
-			var itemSize = attribute.itemSize;
-			var array = attribute.array.slice( 0, count * itemSize );
-
-			for ( var i = 0; i < count; ++ i ) {
-
-				array[ i ] = attribute.getX( i );
-				if ( itemSize >= 2 ) array[ i + 1 ] = attribute.getY( i );
-				if ( itemSize >= 3 ) array[ i + 2 ] = attribute.getZ( i );
-				if ( itemSize >= 4 ) array[ i + 3 ] = attribute.getW( i );
-
-			}
-
-			return new THREE.BufferAttribute( array, itemSize, attribute.normalized );
-
-		}
-
-		return attribute.clone();
 
 	}
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -1,4 +1,3 @@
-import { BufferAttribute } from './BufferAttribute.js';
 import { _Math } from '../math/Math.js';
 
 /**
@@ -134,25 +133,6 @@ Object.assign( InterleavedBufferAttribute.prototype, {
 		this.data.array[ index + 3 ] = w;
 
 		return this;
-
-	},
-
-	clone: function () {
-
-		var count = this.count;
-		var itemSize = this.itemSize;
-		var array = this.data.array.slice( 0, count * itemSize );
-
-		for ( var i = 0; i < count; ++ i ) {
-
-			array[ i ] = this.getX( i );
-			if ( itemSize >= 2 ) array[ i + 1 ] = this.getY( i );
-			if ( itemSize >= 3 ) array[ i + 2 ] = this.getZ( i );
-			if ( itemSize >= 4 ) array[ i + 3 ] = this.getW( i );
-
-		}
-
-		return new BufferAttribute( array, itemSize, this.normalized );
 
 	}
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -1,3 +1,4 @@
+import { BufferAttribute } from './BufferAttribute.js';
 import { _Math } from '../math/Math.js';
 
 /**
@@ -133,6 +134,25 @@ Object.assign( InterleavedBufferAttribute.prototype, {
 		this.data.array[ index + 3 ] = w;
 
 		return this;
+
+	},
+
+	clone: function () {
+
+		var count = this.count;
+		var itemSize = this.itemSize;
+		var array = this.data.array.slice( 0, count * itemSize );
+
+		for ( var i = 0; i < count; ++ i ) {
+
+			array[ i ] = this.getX( i );
+			if ( itemSize >= 2 ) array[ i + 1 ] = this.getY( i );
+			if ( itemSize >= 3 ) array[ i + 2 ] = this.getZ( i );
+			if ( itemSize >= 4 ) array[ i + 3 ] = this.getW( i );
+
+		}
+
+		return new BufferAttribute( array, itemSize, this.normalized );
 
 	}
 


### PR DESCRIPTION
Fixes https://github.com/donmccurdy/three-gltf-viewer/issues/56.

Alternatively, I'd be glad to add this implementation as `InterleavedBufferAttribute.prototype.clone()`, which currently does not exist.

/cc @takahirox 