### PR TITLE
Improve raymarching example v2

### DIFF
--- a/examples/webgl_raymarching_reflect.html
+++ b/examples/webgl_raymarching_reflect.html
@@ -345,8 +345,6 @@
 
 				if ( camera.position.y < 0 ) camera.position.y = 0;
 
-				material.uniforms.resolution.value.set( canvas.width, canvas.height );
-				material.uniforms.cameraProjectionMatrixInverse.value.getInverse( camera.projectionMatrix );
 
 				renderer.render( scene, camera );
 
@@ -376,6 +374,9 @@
 
 				camera.aspect = canvas.width / canvas.height;
 				camera.updateProjectionMatrix();
+
+				material.uniforms.resolution.value.set( canvas.width, canvas.height );
+				material.uniforms.cameraProjectionMatrixInverse.value.getInverse( camera.projectionMatrix );
 
 			}
 

--- a/examples/webgl_raymarching_reflect.html
+++ b/examples/webgl_raymarching_reflect.html
@@ -202,10 +202,13 @@
 			void main(void) {
 
 				// screen position
-				vec2 screenPos = ( gl_FragCoord.xy * 2.0 - resolution ) / min( resolution.x, resolution.y );
+				vec2 screenPos = ( gl_FragCoord.xy * 2.0 - resolution ) / resolution;
 
-				// convert ray direction from screen coordinate to world coordinate
-				vec3 ray = (cameraWorldMatrix * cameraProjectionMatrixInverse * vec4( screenPos.xy, 1.0, 1.0 )).xyz;
+				// ray direction in normalized device coordinate
+				vec4 ndcRay = vec4( screenPos.xy, 1.0, 1.0 );
+
+				// convert ray direction from normalized device coordinate to world coordinate
+				vec3 ray = ( cameraWorldMatrix * cameraProjectionMatrixInverse * ndcRay ).xyz;
 				ray = normalize( ray );
 
 				// camera position
@@ -370,6 +373,9 @@
 					renderer.setSize( config.resolution, config.resolution );
 
 				}
+
+				camera.aspect = canvas.width / canvas.height;
+				camera.updateProjectionMatrix();
 
 			}
 


### PR DESCRIPTION
I came up with a way to make it more efficient.

- Update ProjectionMatrix on change aspect
  - To process aspect ratio by ProjectionMatrix instead of shader
- Update uniforms only when onWindowResize
  - To avoid calling `getInverse` every frame

Related Pull Requests:

- https://github.com/mrdoob/three.js/pull/12793
- https://github.com/mrdoob/three.js/pull/12792
- https://github.com/mrdoob/three.js/pull/7860
- https://github.com/mrdoob/three.js/pull/7863