### PR TITLE
BufferGeometryUtils: Add .mergeBufferAttributes().

### DIFF
--- a/examples/js/BufferGeometryUtils.js
+++ b/examples/js/BufferGeometryUtils.js
@@ -182,6 +182,51 @@ THREE.BufferGeometryUtils = {
 
 		}
 
+	},
+
+	/**
+	 * @param  {Array<THREE.BufferAttribute>} attributes
+	 * @return {THREE.BufferAttribute}
+	 */
+	mergeBufferAttributes: function ( attributes ) {
+
+		var TypedArray;
+		var itemSize;
+		var normalized;
+		var arrayLength = 0;
+
+		for ( var i = 0; i < attributes.length; ++ i ) {
+
+			var attribute = attributes[ i ];
+
+			if ( attribute.isInterleavedBufferAttribute ) return null;
+
+			if ( TypedArray === undefined ) TypedArray = attribute.array.constructor;
+			if ( TypedArray !== attribute.array.constructor ) return null;
+
+			if ( itemSize === undefined ) itemSize = attribute.itemSize;
+			if ( itemSize !== attribute.itemSize ) return null;
+
+			if ( normalized === undefined ) normalized = attribute.normalized;
+			if ( normalized !== attribute.normalized ) return null;
+
+			arrayLength += attribute.array.length;
+
+		}
+
+		var array = new TypedArray( arrayLength );
+		var offset = 0;
+
+		for ( var j = 0; j < attributes.length; ++ j ) {
+
+			array.set( attributes[ j ].array, offset );
+
+			offset += attributes[ j ].array.length;
+
+		}
+
+		return new THREE.BufferAttribute( array, itemSize, normalized );
+
 	}
 
 };

--- a/examples/js/BufferGeometryUtils.js
+++ b/examples/js/BufferGeometryUtils.js
@@ -185,7 +185,7 @@ THREE.BufferGeometryUtils = {
 	},
 
 	/**
-	 * @param  {Array<THREE.BufferAttribute>} attributes
+	 * @param {Array<THREE.BufferAttribute>} attributes
 	 * @return {THREE.BufferAttribute}
 	 */
 	mergeBufferAttributes: function ( attributes ) {


### PR DESCRIPTION
I wanted to suggest this as a partial alternative to #8162 and #9529, as a utility to help with merging geometries. Merging arbitrary BufferGeometries in their entirety has many edge cases, but merging BufferAttributes is simpler. This has been helpful to me while working on merging glTF primitives into a single multi-group geometry (see #11944) rather than separate meshes.