### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/api/cameras/OrthographicCamera.html
+++ b/docs/api/cameras/OrthographicCamera.html
@@ -59,7 +59,7 @@ scene.add( camera );</code>
 		<h2>Properties</h2>
 		<div>
 			See the base [page:Camera] class for common properties.<br>
- 			Note that after making changes to most of these poperties you will have to call 
+ 			Note that after making changes to most of these properties you will have to call 
  			[page:OrthographicCamera.updateProjectionMatrix .updateProjectionMatrix] for the changes to take effect.
 		</div>
 


### PR DESCRIPTION
`poperties` -> `properties`