### PR TITLE
Editor: Fixed broken object delete shortcuts

### DIFF
--- a/editor/js/Sidebar.Settings.Shortcuts.js
+++ b/editor/js/Sidebar.Settings.Shortcuts.js
@@ -89,13 +89,13 @@ Sidebar.Settings.Shortcuts = function ( editor ) {
 
 		switch ( event.key.toLowerCase() ) {
 
-			case 'Backspace':
+			case 'backspace':
 
 				event.preventDefault(); // prevent browser back
 
-				break;
+				// fall-through
 
-			case 'Delete':
+			case 'delete':
 
 				var object = editor.selected;
 


### PR DESCRIPTION
Now both backspace and delete will prompt to delete an object. Previously backspace would fall through to the logic of delete in the switch statement, so I made that explicit in a comment to avoid confusion.