### PR TITLE
Fix OrthographicCamera near parameter in glTF exporter example

### DIFF
--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -428,7 +428,7 @@
 				// ---------------------------------------------------------------------
 				// Ortho camera
 				// ---------------------------------------------------------------------
-				var cameraOrtho = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, - 10, 10 );
+				var cameraOrtho = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, 0, 10 );
 				scene1.add( cameraOrtho );
 				cameraOrtho.name = 'OrthographicCamera';
 


### PR DESCRIPTION
This PR fixes `OrthographicCamera` `near` parameter in glTF exporter example.

`near` should be >=0 in both `Three.js` and `glTF`.

https://threejs.org/docs/#api/cameras/OrthographicCamera.near
https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#orthographicznear-white_check_mark

/cc @fernandojsg 
