### PR TITLE
FBXLoader: Simplify skeleton parsing and improve naming

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1559,7 +1559,7 @@
 					case 'NurbsCurve':
 						model = createCurve( relationships, geometryMap );
 						break;
-					case 'LimbNode': // usually associated with a bone, however if one was not created we'll make a Group instead
+					case 'LimbNode': // usually associated with a Bone, however if a Bone was not created we'll make a Group instead
 					case 'Null':
 					default:
 						model = new THREE.Group();
@@ -1982,8 +1982,6 @@
 
 	// parse the model node for transform details and apply them to the model
 	function setModelTransforms( FBXTree, model, modelNode ) {
-
-		// console.log( modelNode, model )
 
 		// http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html
 		if ( 'RotationOrder' in modelNode.properties ) {


### PR DESCRIPTION
Rename Deformer -> skeleton and subDeformer -> bone and simplify the parsing / building of skeletons. 

There's still quite a few bugs in the parsing of skeletons, but they should be easier to track down after this.

*EDIT*: I've added a couple of fixes here too, one where "sub" bones were not having names / ids set and another where the transform of the bone was not being set when there was no associated `poseNode`. 

These fix issues with quite a few problem models I've been testing and resolves #12814