### PR TITLE
fix: Meshes with PlaneGeometry were not casting shadows

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -396,6 +396,18 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 			if ( object.castShadow && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
 
+				var type = object.geometry.type;
+				
+				if ( object.isMesh && ( type === 'PlaneGeometry' || type === 'PlaneBufferGeometry' ) ) {
+
+					scope.renderReverseSided = false;
+
+				} else {
+
+					scope.renderReverseSided = true;
+
+				}
+
 				object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
 
 				var geometry = _objects.update( object );


### PR DESCRIPTION
Not tested yet.


**This is still WIP, not to be merged yet, just coming up with ideas.**

Maybe this helps make Meshes with PlaneGeometry cast shadows? The only thing is it cancels out the ability to manually set `renderReverseSided`. Do we need that? What other way can it be done?