### PR TITLE
Change parameter name to be consistent with code.

### DIFF
--- a/docs/api/geometries/ConeGeometry.html
+++ b/docs/api/geometries/ConeGeometry.html
@@ -46,7 +46,7 @@
 		<div>
 		radius — Radius of the cone at the base. Default is 20.<br />
 		height — Height of the cone. Default is 100.<br />
-		radiusSegments — Number of segmented faces around the circumference of the cone. Default is 8<br />
+		radialSegments — Number of segmented faces around the circumference of the cone. Default is 8<br />
 		heightSegments — Number of rows of faces along the height of the cone. Default is 1.<br />
 		openEnded — A Boolean indicating whether the base of the cone is open or capped. Default is false, meaning capped.<br />
 		thetaStart — Start angle for first segment, default = 0 (three o'clock position).<br />


### PR DESCRIPTION
Both radiusSegment and radialSegments are misleading. I would prefer to call it archSegments, both in code and documentation. For consistency and easier understanding, I think the prefix theta should also be replaced by arch here and in some other places, e.g. Ring(Buffer)Geometry. For easier understanding, I also think phiSegments should be replaced with radialSegments there, where it would be correct. But since these are a bit major changes, at least if implemented in the code, I would like the views of those with a better overview and understanding.