### PR TITLE
Change parameter name to be consistent with code.

### DIFF
--- a/docs/api/geometries/CylinderGeometry.html
+++ b/docs/api/geometries/CylinderGeometry.html
@@ -42,12 +42,12 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radiusTop], [page:Float radiusBottom], [page:Float height], [page:Integer radiusSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([page:Float radiusTop], [page:Float radiusBottom], [page:Float height], [page:Integer radialSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
 		radiusTop — Radius of the cylinder at the top. Default is 1.<br />
 		radiusBottom — Radius of the cylinder at the bottom. Default is 1.<br />
 		height — Height of the cylinder. Default is 1.<br />
-		radiusSegments — Number of segmented faces around the circumference of the cylinder. Default is 8<br />
+		radialSegments — Number of segmented faces around the circumference of the cylinder. Default is 8<br />
 		heightSegments — Number of rows of faces along the height of the cylinder. Default is 1.<br />
 		openEnded — A Boolean indicating whether the ends of the cylinder are open or capped. Default is false, meaning capped.<br />
 		thetaStart — Start angle for first segment, default = 0 (three o'clock position).<br />


### PR DESCRIPTION
GitHub got the hickups, so it's possible this is a duplicate commit.

Both radiusSegment and radialSegments are misleading. I would prefer to call it archSegments, both in code and documentation. For consistency and easier understanding, I think the prefix theta should also be replaced by arch here and in some other places, e.g. Ring(Buffer)Geometry. For easier understanding, I also think phiSegments should be replaced with radialSegments there, where it would be correct. But since these are a bit major changes, at least if implemented in the code, I would like the views of those with a better overview and understanding.