### PR TITLE
TransformControls: Set axis before triggering mouseDownEvent

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -856,9 +856,9 @@
 					event.preventDefault();
 					event.stopPropagation();
 
-					scope.dispatchEvent( mouseDownEvent );
-
 					scope.axis = intersect.object.name;
+
+					scope.dispatchEvent( mouseDownEvent );
 
 					scope.update();
 


### PR DESCRIPTION
In my case for example I have a listener to the mousedown event. In this listener I check for the current set axis. But of course it is ```null``` because it is set just after the event was triggered.
So my suggestion is to set the axis and AFTERWARDS trigger the event.