### PR TITLE
Remove z_up axis hack.

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3430,12 +3430,6 @@ THREE.ColladaLoader.prototype = {
 
 		var scene = parseScene( getElementsByTagName( collada, 'scene' )[ 0 ] );
 
-		if ( asset.upAxis === 'Z_UP' ) {
-
-			scene.rotation.x = - Math.PI / 2;
-
-		}
-
 		scene.scale.multiplyScalar( asset.unit );
 
 		console.timeEnd( 'THREE.ColladaLoader' );


### PR DESCRIPTION
[These meshes](https://github.com/turtlebot/turtlebot/blob/kinetic/turtlebot_description/meshes/stacks/hexagons/plate_top.dae) were 90 degrees rotated.

**Before patch**
![rotated](https://user-images.githubusercontent.com/1556736/33837366-6219939c-de8c-11e7-93b6-cd6c64653977.png)

**After patch**
![robot](https://user-images.githubusercontent.com/1556736/33837397-797e6198-de8c-11e7-85b2-f268ab913acb.png)

cc: RobotWebTools/ros3djs#202