### PR TITLE
Update FileLoader.js to use documented way to retrieve XmlHtttpRespon…

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -168,7 +168,7 @@ Object.assign( FileLoader.prototype, {
 
 			request.addEventListener( 'load', function ( event ) {
 
-				var response = event.target.response;
+				var response = this.response;
 
 				Cache.add( url, response );
 


### PR DESCRIPTION
#12858 

The documented way to retrieve the response from a XmlHttpRequest is via the XmlHttpRequest object itself, rather than through the event handler's event argument. This proposed change shows the documented method in the [specs](https://xhr.spec.whatwg.org/#the-response-attribute).