### PR TITLE
LoaderUtils: Clean up

### DIFF
--- a/docs/api/loaders/Loader.html
+++ b/docs/api/loaders/Loader.html
@@ -61,14 +61,6 @@
 		Creates an array of [page:Material] based on the array of parameters m. The index of the parameters decide the correct index of the materials.
 		</div>
 
-		<h3>[method:String extractUrlBase]( [page:string url] )</h3>
-		<div>
-		[page:String url] —  The url to extract the base url from.
-		</div>
-		<div>
-		Extract the base from the URL.
-		</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/loaders/LoaderUtils.html
+++ b/docs/api/loaders/LoaderUtils.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1>
+
+		<div class="desc">An object with several loader utility functions.</div>
+
+		<h2>Functions</h2>
+
+		<h3>[method:String decodeText]( [page:TypedArray array] )</h3>
+		<div>
+		[page:TypedArray array] —  A stream of bytes as a typed array.
+		</div>
+		<div>
+		The function takes a stream of bytes as input and returns a string representation.
+		</div>
+
+		<h3>[method:String extractUrlBase]( [page:string url] )</h3>
+		<div>
+		[page:String url] —  The url to extract the base url from.
+		</div>
+		<div>
+		Extract the base from the URL.
+		</div>
+
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+	</body>
+</html>

--- a/docs/list.js
+++ b/docs/list.js
@@ -230,6 +230,7 @@ var list = {
 			"ImageLoader": "api/loaders/ImageLoader",
 			"JSONLoader": "api/loaders/JSONLoader",
 			"Loader": "api/loaders/Loader",
+			"LoaderUtils": "api/loaders/LoaderUtils",
 			"MaterialLoader": "api/loaders/MaterialLoader",
 			"ObjectLoader": "api/loaders/ObjectLoader",
 			"TextureLoader": "api/loaders/TextureLoader"

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -1814,10 +1814,6 @@
         "initMaterials": {
           "!type": "fn(materials: [], texturePath: string) -> []",
           "!doc": "Creates an array of [page:Material] based on the array of parameters m. The index of the parameters decide the correct index of the materials."
-        },
-        "extractUrlBase": {
-          "!type": "fn(url: string) -> string",
-          "!doc": "Extract the base from the URL."
         }
       },
       "!doc": "Base class for implementing loaders.",

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -41,8 +41,7 @@ THREE.TDSLoader.prototype = {
 
 		var scope = this;
 
-
-		var path = this.path !== undefined ? this.path : THREE.Loader.prototype.extractUrlBase( url );
+		var path = this.path !== undefined ? this.path : THREE.LoaderUtils.extractUrlBase( url );
 
 		var loader = new THREE.FileLoader( this.manager );
 

--- a/src/loaders/JSONLoader.js
+++ b/src/loaders/JSONLoader.js
@@ -1,4 +1,5 @@
 import { Loader } from './Loader.js';
+import { LoaderUtils } from './LoaderUtils.js';
 import { AnimationClip } from '../animation/AnimationClip.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
@@ -35,7 +36,7 @@ Object.assign( JSONLoader.prototype, {
 
 		var scope = this;
 
-		var texturePath = this.texturePath && ( typeof this.texturePath === "string" ) ? this.texturePath : Loader.prototype.extractUrlBase( url );
+		var texturePath = this.texturePath && ( typeof this.texturePath === 'string' ) ? this.texturePath : LoaderUtils.extractUrlBase( url );
 
 		var loader = new FileLoader( this.manager );
 		loader.setWithCredentials( this.withCredentials );

--- a/utils/exporters/blender/tests/scripts/js/review.js
+++ b/utils/exporters/blender/tests/scripts/js/review.js
@@ -123,7 +123,7 @@ function loadObject( data ) {
 function loadGeometry( data, url ) {
 
     var loader = new THREE.JSONLoader();
-    var texturePath = THREE.Loader.prototype.extractUrlBase( url );
+    var texturePath = THREE.LoaderUtils.extractUrlBase( url );
     data = loader.parse( data, texturePath );
 
     if ( data.materials === undefined ) {


### PR DESCRIPTION
Added docs for `LoaderUtils` and removes all remaining references to `Loader.prototype.extractUrlBase`.