### PR TITLE
add optionalTarget parameter to Raycaster.intersectObject(s) to allow array reuse

### DIFF
--- a/docs/api/core/Raycaster.html
+++ b/docs/api/core/Raycaster.html
@@ -144,12 +144,12 @@
 		Updates the ray with a new origin and direction.
 		</div>
 
-
-		<h3>[method:Array intersectObject]( [param:Object3D object], [param:Boolean recursive] )</h3>
+		<h3>[method:Array intersectObject]( [page:Object3D object], [param:Boolean recursive], [param:Array optionalTarget] )</h3>
 		<div>
 		<p>
 		[page:Object3D object] — The object to check for intersection with the ray.<br />
-		[page:Boolean recursive] — If true, it also checks all descendants. Otherwise it only checks intersecton with the object. Default is false.
+		[page:Boolean recursive] — If true, it also checks all descendants. Otherwise it only checks intersecton with the object. Default is false.<br />
+		[page:Array optionalTarget] — (optional) target to set the result. Otherwise a new [page:Array] is instantiated. If set, you must clear this array prior to each call (i.e., array.length = 0;).
 		</p>
 		</div>
 		<div>
@@ -177,10 +177,11 @@
 		</p>
 		</div>
 
-		<h3>[method:Array intersectObjects]( [param:Array objects], [param:Boolean recursive] )</h3>
+		<h3>[method:Array intersectObjects]( [param:Array objects], [param:Boolean recursive], [param:Array optionalTarget] )</h3>
 		<div>
 		[page:Array objects] — The objects to check for intersection with the ray.<br />
-		[page:Boolean recursive] — If true, it also checks all descendants of the objects. Otherwise it only checks intersecton with the objects. Default is false.
+		[page:Boolean recursive] — If true, it also checks all descendants of the objects. Otherwise it only checks intersecton with the objects. Default is false.<br />
+		[page:Array optionalTarget] — (optional) target to set the result. Otherwise a new [page:Array] is instantiated. If set, you must clear this array prior to each call (i.e., array.length = 0;).
 		</div>
 		<div>
 		Checks all intersection between the ray and the objects with or without the descendants. Intersections are returned sorted by distance, closest first. Intersections are of the same form as those returned by [page:.intersectObject].

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -93,9 +93,9 @@ Object.assign( Raycaster.prototype, {
 
 	},
 
-	intersectObject: function ( object, recursive ) {
+	intersectObject: function ( object, recursive, optionalTarget ) {
 
-		var intersects = [];
+		var intersects = optionalTarget || [];
 
 		intersectObject( object, this, intersects, recursive );
 
@@ -105,9 +105,9 @@ Object.assign( Raycaster.prototype, {
 
 	},
 
-	intersectObjects: function ( objects, recursive ) {
+	intersectObjects: function ( objects, recursive, optionalTarget ) {
 
-		var intersects = [];
+		var intersects = optionalTarget || [];
 
 		if ( Array.isArray( objects ) === false ) {
 


### PR DESCRIPTION
#### Description of the Problem

Allow `optionalTarget` for `raycaster.intersectObject` and `raycaster.intersectObjects`. This lets developers reuse array and reduce array instantiations. 

For A-Frame/WebVR, an application often has two raycasters, one for each hand, updating up to 90 times a second. Two hands would have 180 raycaster intersects per second. So this could save 180 array instantiations per second for us.