### PR TITLE
Editor: Added shortcut ('f') for focusing on selection

### DIFF
--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -24,7 +24,8 @@ var Config = function ( name ) {
 		'settings/shortcuts/translate': 'w',
 		'settings/shortcuts/rotate': 'e',
 		'settings/shortcuts/scale': 'r',
-		'settings/shortcuts/undo': 'z'
+		'settings/shortcuts/undo': 'z',
+		'settings/shortcuts/focus': 'f'
 	};
 
 	if ( window.localStorage[ name ] === undefined ) {

--- a/editor/js/Sidebar.Settings.Shortcuts.js
+++ b/editor/js/Sidebar.Settings.Shortcuts.js
@@ -149,7 +149,7 @@ Sidebar.Settings.Shortcuts = function ( editor ) {
 
 				if ( editor.selected !== null ) {
 
-					editor.focusById( editor.selected.id );
+					editor.focus( editor.selected );
 
 				}
 

--- a/editor/js/Sidebar.Settings.Shortcuts.js
+++ b/editor/js/Sidebar.Settings.Shortcuts.js
@@ -18,7 +18,7 @@ Sidebar.Settings.Shortcuts = function ( editor ) {
 	var container = new UI.Div();
 	container.add( new UI.Break() );
 
-	var shortcuts = [ 'translate', 'rotate', 'scale', 'undo' ];
+	var shortcuts = [ 'translate', 'rotate', 'scale', 'undo', 'focus' ];
 
 	for ( var i = 0; i < shortcuts.length; i ++ ) {
 
@@ -140,6 +140,16 @@ Sidebar.Settings.Shortcuts = function ( editor ) {
 						editor.undo();
 
 					}
+
+				}
+
+				break;
+
+			case config.getKey( 'settings/shortcuts/focus' ):
+
+				if ( editor.selected !== null ) {
+
+					editor.focusById( editor.selected.id );
 
 				}
 


### PR DESCRIPTION
In many 3D applications such as Unity or Maya, the 'f' key is used as a shortcut to focus on the current selection. I figured adding that shortcut to the three.js editor would increase the productivity of those familiar with 3D applications.