### PR TITLE
Updated OBJLoader2 API and demos to remove unused parameter

### DIFF
--- a/examples/js/loaders/OBJLoader2.js
+++ b/examples/js/loaders/OBJLoader2.js
@@ -1348,12 +1348,11 @@ THREE.OBJLoader2 = (function () {
 	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {string} url URL to the file
-	 * @param {string} name The name of the object
 	 * @param {Object} content The file content as arraybuffer or text
 	 * @param {function} callbackOnLoad
 	 * @param {string} [crossOrigin] CORS value
 	 */
-	OBJLoader2.prototype.loadMtl = function ( url, name, content, callbackOnLoad, crossOrigin ) {
+	OBJLoader2.prototype.loadMtl = function ( url, content, callbackOnLoad, crossOrigin ) {
 		var resource = new THREE.LoaderSupport.ResourceDescriptor( url, 'MTL' );
 		resource.setContent( content );
 		this._loadMtl( resource, callbackOnLoad, crossOrigin );

--- a/examples/webgl_loader_obj2.html
+++ b/examples/webgl_loader_obj2.html
@@ -157,7 +157,7 @@
 						objLoader.getLogger().setDebug( true );
 						objLoader.load( 'obj/female02/female02.obj', callbackOnLoad, null, null, null, false );
 					};
-					objLoader.loadMtl( 'obj/female02/female02.mtl', 'female02.mtl', null, onLoadMtl );
+					objLoader.loadMtl( 'obj/female02/female02.mtl', null, onLoadMtl );
 				};
 
 				OBJLoader2Example.prototype._reportProgress = function( event ) {

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -178,7 +178,7 @@
 							}
 						);
 					};
-					objLoader.loadMtl( 'obj/female02/female02.mtl', 'female02.mtl', null, onLoadMtl );
+					objLoader.loadMtl( 'obj/female02/female02.mtl', null, onLoadMtl );
 				};
 
 


### PR DESCRIPTION
As I was digging into using the OBJLoader2, I noticed that the `name` argument for the `loadMtl` helper function is not used.

The API and demos were updated to reflect this change.