### PR TITLE
WebGLRenderer: Fixed #12883

### DIFF
--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -168,6 +168,8 @@ THREE.Reflector = function ( geometry, options ) {
 
 		renderer.setRenderTarget( currentRenderTarget );
 
+		renderer.updateLights( camera ); // rebuild light uniforms, see #12883
+
 		// Restore viewport
 
 		var bounds = camera.bounds;

--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -168,7 +168,7 @@ THREE.Reflector = function ( geometry, options ) {
 
 		renderer.setRenderTarget( currentRenderTarget );
 
-		renderer.updateLights( camera ); // rebuild light uniforms, see #12883
+		renderer.setupLights( camera ); // rebuild light uniforms, see #12883
 
 		// Restore viewport
 

--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -162,13 +162,12 @@ THREE.Reflector = function ( geometry, options ) {
 		renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
 
 		renderer.render( scene, virtualCamera, renderTarget, true );
+		renderer.setupLights( camera ); // rebuild light uniforms, see #12883
 
 		renderer.vr.enabled = currentVrEnabled;
 		renderer.shadowMap.autoUpdate = currentShadowAutoUpdate;
 
 		renderer.setRenderTarget( currentRenderTarget );
-
-		renderer.setupLights( camera ); // rebuild light uniforms, see #12883
 
 		// Restore viewport
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2560,7 +2560,7 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	this.updateLights = function ( camera ) {
+	this.setupLights = function ( camera ) {
 
 		lights.setup( lightsArray, shadowsArray, camera );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2560,6 +2560,12 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	this.updateLights = function ( camera ) {
+
+		lights.setup( lightsArray, shadowsArray, camera );
+
+	};
+
 }
 
 


### PR DESCRIPTION
Not the best solution but at least we don't have to misuse `renderOrder`.

Fixes #12883.