### PR TITLE
OBJLoader2: Fixed wrong scope in case of error in loadMtl

### DIFF
--- a/examples/js/loaders/OBJLoader2.js
+++ b/examples/js/loaders/OBJLoader2.js
@@ -1361,7 +1361,7 @@ THREE.OBJLoader2 = (function () {
 
 				var onError = function ( event ) {
 					var output = 'Error occurred while downloading "' + resource.url + '"';
-					this.logger.logError( output + ': ' + event );
+					scope.logger.logError( output + ': ' + event );
 					throw output;
 				};
 


### PR DESCRIPTION
This is a one-line bugfix for #12900