### PR TITLE
let planes cast shadows when rendering reverse-sided

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -92,6 +92,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 	this.type = PCFShadowMap;
 
 	this.renderReverseSided = true;
+	this.planesCastShadows = false;
 	this.renderSingleSided = true;
 
 	this.render = function ( lights, scene, camera ) {
@@ -360,8 +361,27 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 		if ( scope.renderReverseSided ) {
 
-			if ( side === FrontSide ) side = BackSide;
-			else if ( side === BackSide ) side = FrontSide;
+			// if planes don't cast shadows (default), render them reverse sided like previous versions of Three
+			if ( ! scope.planesCastShadows ) {
+
+				if ( side === FrontSide ) side = BackSide;
+				else if ( side === BackSide ) side = FrontSide;
+
+			}
+			else {
+
+				var type = geometry.type;
+				var isPlane = object.isMesh && ( type === 'PlaneGeometry' || type === 'PlaneBufferGeometry' );
+
+				// if planes cast shadows, don't render them reverse sided
+				if ( ! isPlane ) {
+
+					if ( side === FrontSide ) side = BackSide;
+					else if ( side === BackSide ) side = FrontSide;
+
+				}
+
+			}
 
 		}
 


### PR DESCRIPTION
Continuing from #12830.

#12830 is not desirable because sometimes it would leave the user's `renderReverseSided` option modified after rendering.

This new PR introduces a new property for specifying if Planes should cast shadows (i.e. not render reverse sided).

The new `planesCastShadows` option is only checked if `renderReverseSided` is true, otherwise Planes will cast shadows anyways.

`planesCastShadows` is set to `false` by default so that this change is not a breaking change. Previous apps will work exactly like before.

If planes don't cast shadows, we don't need to perform the extra `isPlane` check, therefore we skip that for performance. Otherwise, we could've avoided having the inner conditional statement's `else` block, but it would mean that `isPlane` would be checked in every case, decreasing performance. For example, it could've been written something like:

```js
		if ( scope.renderReverseSided ) {

			var type = geometry.type;
			var isPlane = object.isMesh && ( type === 'PlaneGeometry' || type === 'PlaneBufferGeometry' );

			if ( ! ( isPlane && scope.planesCastShadows ) ) {

				if ( side === FrontSide ) side = BackSide;
				else if ( side === BackSide ) side = FrontSide;

			}
		}
```

Which do you prefer?