### PR TITLE
ExtrudeGeometry: Added serialization/ deserialization

### DIFF
--- a/docs/api/geometries/ExtrudeBufferGeometry.html
+++ b/docs/api/geometries/ExtrudeBufferGeometry.html
@@ -77,9 +77,7 @@
 				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
 				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
 				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
-				<li>UVGenerator —  Object. object that provides UV generator functions</li>
+				<li>extrudePath — THREE.Curve. A 3D curve path along which the shape should be extruded. Default is undefined.</li>
 			</ul>
 
 		</div>
@@ -96,47 +94,10 @@
 
 		<h2>Properties</h2>
 
-
-		<h2>Methods</h2>
-
-		<h3>[method:null addShapeList]([page:Array shapes], [page:Object options])</h3>
+		<h3>[property:Object parameters]</h3>
 		<div>
-			shapes — An Array of shapes to add. <br />
-			options — Object that can contain the following parameters.
-			<ul>
-				<li>curveSegments — int. Number of points on the curves. Default is 12.</li>
-				<li>steps — int. Number of points used for subdividing segments along the depth of the extruded spline. Default is 1.</li>
-				<li>amount — int. Depth to extrude the shape. Default is 100.</li>
-				<li>bevelEnabled — bool. Apply beveling to the shape. Default is true.</li>
-				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
-				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
-				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
-				<li>UVGenerator —  Object. object that provides UV generator functions</li>
-			</ul>
+		An object with all of the parameters that were used to generate the geometry.
 		</div>
-		<div>Adds the shapes to the list to extrude.</div>
-
-		<h3>[method:null addShape]([page:Shape shape], [page:Object options])</h3>
-		<div>
-			shape — A shape to add. <br />
-			options — Object that can contain the following parameters.
-			<ul>
-				<li>curveSegments — int. Number of points on the curves. Default is 12.</li>
-				<li>steps — int. Number of points used for subdividing segments along the depth of the extruded spline. Default is 1.</li>
-				<li>amount — int. Depth to extrude the shape. Default is 100.</li>
-				<li>bevelEnabled — bool. Apply beveling to the shape. Default is true.</li>
-				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
-				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
-				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
-				<li>UVGenerator —  Object. object that provides UV generator functions</li>
-			</ul>
-		</div>
-		<div>Add the shape to the list to extrude.</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/api/geometries/ExtrudeGeometry.html
+++ b/docs/api/geometries/ExtrudeGeometry.html
@@ -77,9 +77,7 @@
 				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
 				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
 				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
-				<li>UVGenerator —  Object. object that provides UV generator functions</li>
+				<li>extrudePath — THREE.Curve. A 3D curve path along which the shape should be extruded. Default is undefined.</li>
 			</ul>
 
 		</div>
@@ -96,47 +94,10 @@
 
 		<h2>Properties</h2>
 
-
-		<h2>Methods</h2>
-
-		<h3>[method:null addShapeList]([page:Array shapes], [page:Object options])</h3>
+		<h3>[property:Object parameters]</h3>
 		<div>
-			shapes — An Array of shapes to add. <br />
-			options — Object that can contain the following parameters.
-			<ul>
-				<li>curveSegments — int. Number of points on the curves. Default is 12.</li>
-				<li>steps — int. Number of points used for subdividing segments along the depth of the extruded spline. Default is 1.</li>
-				<li>amount — int. Depth to extrude the shape. Default is 100.</li>
-				<li>bevelEnabled — bool. Apply beveling to the shape. Default is true.</li>
-				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
-				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
-				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
-				<li>UVGenerator —  Object. object that provides UV generator functions</li>
-			</ul>
+		An object with all of the parameters that were used to generate the geometry.
 		</div>
-		<div>Adds the shapes to the list to extrude.</div>
-
-		<h3>[method:null addShape]([page:Shape shape], [page:Object options])</h3>
-		<div>
-			shape — A shape to add. <br />
-			options — Object that can contain the following parameters.
-			<ul>
-				<li>curveSegments — int. Number of points on the curves. Default is 12.</li>
-				<li>steps — int. Number of points used for subdividing segments along the depth of the extruded spline. Default is 1.</li>
-				<li>amount — int. Depth to extrude the shape. Default is 100.</li>
-				<li>bevelEnabled — bool. Apply beveling to the shape. Default is true.</li>
-				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
-				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
-				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
-				<li>UVGenerator —  Object. object that provides UV generator functions</li>
-			</ul>
-		</div>
-		<div>Add the shape to the list to extrude.</div>
-
 
 		<h2>Source</h2>
 

--- a/docs/scenes/js/geometry.js
+++ b/docs/scenes/js/geometry.js
@@ -4,74 +4,6 @@
 
 var twoPi = Math.PI * 2;
 
-var constants = {
-
-	combine: {
-
-		"THREE.MultiplyOperation" : THREE.MultiplyOperation,
-		"THREE.MixOperation" : THREE.MixOperation,
-		"THREE.AddOperation" : THREE.AddOperation
-
-	},
-
-	side : {
-
-		"THREE.FrontSide" : THREE.FrontSide,
-		"THREE.BackSide" : THREE.BackSide,
-		"THREE.DoubleSide" : THREE.DoubleSide
-
-	},
-
-	colors : {
-
-		"THREE.NoColors" : THREE.NoColors,
-		"THREE.FaceColors" : THREE.FaceColors,
-		"THREE.VertexColors" : THREE.VertexColors
-
-	},
-
-	blendingMode : {
-
-		"THREE.NoBlending" : THREE.NoBlending,
-		"THREE.NormalBlending" : THREE.NormalBlending,
-		"THREE.AdditiveBlending" : THREE.AdditiveBlending,
-		"THREE.SubtractiveBlending" : THREE.SubtractiveBlending,
-		"THREE.MultiplyBlending" : THREE.MultiplyBlending,
-		"THREE.CustomBlending" : THREE.CustomBlending
-
-	},
-
-	equations : {
-
-		"THREE.AddEquation" : THREE.AddEquation,
-		"THREE.SubtractEquation" : THREE.SubtractEquation,
-		"THREE.ReverseSubtractEquation" : THREE.ReverseSubtractEquation
-
-	},
-
-	destinationFactors : {
-
-		"THREE.ZeroFactor" : THREE.ZeroFactor,
-		"THREE.OneFactor" : THREE.OneFactor,
-		"THREE.SrcColorFactor" : THREE.SrcColorFactor,
-		"THREE.OneMinusSrcColorFactor" : THREE.OneMinusSrcColorFactor,
-		"THREE.SrcAlphaFactor" : THREE.SrcAlphaFactor,
-		"THREE.OneMinusSrcAlphaFactor" : THREE.OneMinusSrcAlphaFactor,
-		"THREE.DstAlphaFactor" : THREE.DstAlphaFactor,
-		"THREE.OneMinusDstAlphaFactor" : THREE.OneMinusDstAlphaFactor
-
-	},
-
-	sourceFactors : {
-
-		"THREE.DstColorFactor" : THREE.DstColorFactor,
-		"THREE.OneMinusDstColorFactor" : THREE.OneMinusDstColorFactor,
-		"THREE.SrcAlphaSaturateFactor" : THREE.SrcAlphaSaturateFactor
-
-	}
-
-};
-
 function updateGroupGeometry( mesh, geometry ) {
 
 	mesh.children[ 0 ].geometry.dispose();
@@ -113,7 +45,7 @@ var heartShape = new THREE.Shape();
 
 heartShape.moveTo( x + 5, y + 5 );
 heartShape.bezierCurveTo( x + 5, y + 5, x + 4, y, x, y );
-heartShape.bezierCurveTo( x - 6, y, x - 6, y + 7,x - 6, y + 7 );
+heartShape.bezierCurveTo( x - 6, y, x - 6, y + 7, x - 6, y + 7 );
 heartShape.bezierCurveTo( x - 6, y + 11, x - 3, y + 15.4, x + 5, y + 19 );
 heartShape.bezierCurveTo( x + 12, y + 15.4, x + 16, y + 11, x + 16, y + 7 );
 heartShape.bezierCurveTo( x + 16, y + 7, x + 16, y, x + 10, y );
@@ -121,15 +53,15 @@ heartShape.bezierCurveTo( x + 7, y, x + 5, y + 5, x + 5, y + 5 );
 
 var guis = {
 
-	BoxBufferGeometry : function( mesh ) {
+	BoxBufferGeometry: function ( mesh ) {
 
 		var data = {
-			width : 15,
-			height : 15,
-			depth : 15,
-			widthSegments : 1,
-			heightSegments : 1,
-			depthSegments : 1
+			width: 15,
+			height: 15,
+			depth: 15,
+			widthSegments: 1,
+			heightSegments: 1,
+			depthSegments: 1
 		};
 
 		function generateGeometry() {
@@ -155,15 +87,15 @@ var guis = {
 
 	},
 
-	BoxGeometry : function( mesh ) {
+	BoxGeometry: function ( mesh ) {
 
 		var data = {
-			width : 15,
-			height : 15,
-			depth : 15,
-			widthSegments : 1,
-			heightSegments : 1,
-			depthSegments : 1
+			width: 15,
+			height: 15,
+			depth: 15,
+			widthSegments: 1,
+			heightSegments: 1,
+			depthSegments: 1
 		};
 
 		function generateGeometry() {
@@ -189,17 +121,17 @@ var guis = {
 
 	},
 
-	CylinderBufferGeometry : function( mesh ) {
+	CylinderBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radiusTop : 5,
-			radiusBottom : 5,
-			height : 10,
-			radiusSegments : 8,
-			heightSegments : 1,
-			openEnded : false,
-			thetaStart : 0,
-			thetaLength : twoPi
+			radiusTop: 5,
+			radiusBottom: 5,
+			height: 10,
+			radiusSegments: 8,
+			heightSegments: 1,
+			openEnded: false,
+			thetaStart: 0,
+			thetaLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -235,17 +167,17 @@ var guis = {
 
 	},
 
-	CylinderGeometry : function( mesh ) {
+	CylinderGeometry: function ( mesh ) {
 
 		var data = {
-			radiusTop : 5,
-			radiusBottom : 5,
-			height : 10,
-			radiusSegments : 8,
-			heightSegments : 1,
-			openEnded : false,
-			thetaStart : 0,
-			thetaLength : twoPi
+			radiusTop: 5,
+			radiusBottom: 5,
+			height: 10,
+			radiusSegments: 8,
+			heightSegments: 1,
+			openEnded: false,
+			thetaStart: 0,
+			thetaLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -281,16 +213,16 @@ var guis = {
 
 	},
 
-	ConeBufferGeometry : function( mesh ) {
+	ConeBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 5,
-			height : 10,
-			radiusSegments : 8,
-			heightSegments : 1,
-			openEnded : false,
-			thetaStart : 0,
-			thetaLength : twoPi
+			radius: 5,
+			height: 10,
+			radiusSegments: 8,
+			heightSegments: 1,
+			openEnded: false,
+			thetaStart: 0,
+			thetaLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -324,16 +256,16 @@ var guis = {
 
 	},
 
-	ConeGeometry : function( mesh ) {
+	ConeGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 5,
-			height : 10,
-			radiusSegments : 8,
-			heightSegments : 1,
-			openEnded : false,
-			thetaStart : 0,
-			thetaLength : twoPi
+			radius: 5,
+			height: 10,
+			radiusSegments: 8,
+			heightSegments: 1,
+			openEnded: false,
+			thetaStart: 0,
+			thetaLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -368,13 +300,13 @@ var guis = {
 	},
 
 
-	CircleBufferGeometry : function( mesh ) {
+	CircleBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			segments : 32,
-			thetaStart : 0,
-			thetaLength : twoPi
+			radius: 10,
+			segments: 32,
+			thetaStart: 0,
+			thetaLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -398,13 +330,13 @@ var guis = {
 
 	},
 
-	CircleGeometry : function( mesh ) {
+	CircleGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			segments : 32,
-			thetaStart : 0,
-			thetaLength : twoPi
+			radius: 10,
+			segments: 32,
+			thetaStart: 0,
+			thetaLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -428,11 +360,11 @@ var guis = {
 
 	},
 
-	DodecahedronGeometry : function() {
+	DodecahedronGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			detail : 0
+			radius: 10,
+			detail: 0
 		};
 
 		function generateGeometry() {
@@ -454,11 +386,11 @@ var guis = {
 
 	},
 
-	DodecahedronBufferGeometry : function() {
+	DodecahedronBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			detail : 0
+			radius: 10,
+			detail: 0
 		};
 
 		function generateGeometry() {
@@ -480,11 +412,11 @@ var guis = {
 
 	},
 
-	IcosahedronGeometry : function() {
+	IcosahedronGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			detail : 0
+			radius: 10,
+			detail: 0
 		};
 
 		function generateGeometry() {
@@ -506,11 +438,11 @@ var guis = {
 
 	},
 
-	IcosahedronBufferGeometry : function() {
+	IcosahedronBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			detail : 0
+			radius: 10,
+			detail: 0
 		};
 
 		function generateGeometry() {
@@ -532,7 +464,7 @@ var guis = {
 
 	},
 
-	LatheBufferGeometry : function() {
+	LatheBufferGeometry: function ( mesh ) {
 
 		var points = [];
 
@@ -543,9 +475,9 @@ var guis = {
 		}
 
 		var data = {
-			segments : 12,
-			phiStart : 0,
-			phiLength : twoPi
+			segments: 12,
+			phiStart: 0,
+			phiLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -568,7 +500,7 @@ var guis = {
 
 	},
 
-	LatheGeometry : function() {
+	LatheGeometry: function ( mesh ) {
 
 		var points = [];
 
@@ -579,9 +511,9 @@ var guis = {
 		}
 
 		var data = {
-			segments : 12,
-			phiStart : 0,
-			phiLength : twoPi
+			segments: 12,
+			phiStart: 0,
+			phiLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -604,11 +536,11 @@ var guis = {
 
 	},
 
-	OctahedronGeometry : function() {
+	OctahedronGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			detail : 0
+			radius: 10,
+			detail: 0
 		};
 
 		function generateGeometry() {
@@ -630,11 +562,11 @@ var guis = {
 
 	},
 
-	OctahedronBufferGeometry : function() {
+	OctahedronBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			detail : 0
+			radius: 10,
+			detail: 0
 		};
 
 		function generateGeometry() {
@@ -656,13 +588,13 @@ var guis = {
 
 	},
 
-	PlaneBufferGeometry : function( mesh ) {
+	PlaneBufferGeometry: function ( mesh ) {
 
 		var data = {
-			width : 10,
-			height : 10,
-			widthSegments : 1,
-			heightSegments : 1
+			width: 10,
+			height: 10,
+			widthSegments: 1,
+			heightSegments: 1
 		};
 
 		function generateGeometry() {
@@ -686,13 +618,13 @@ var guis = {
 
 	},
 
-	PlaneGeometry : function( mesh ) {
+	PlaneGeometry: function ( mesh ) {
 
 		var data = {
-			width : 10,
-			height : 10,
-			widthSegments : 1,
-			heightSegments : 1
+			width: 10,
+			height: 10,
+			widthSegments: 1,
+			heightSegments: 1
 		};
 
 		function generateGeometry() {
@@ -716,15 +648,15 @@ var guis = {
 
 	},
 
-	RingBufferGeometry : function( mesh ) {
+	RingBufferGeometry: function ( mesh ) {
 
 		var data = {
-			innerRadius : 5,
-			outerRadius : 10,
-			thetaSegments : 8,
-			phiSegments : 8,
-			thetaStart : 0,
-			thetaLength : twoPi
+			innerRadius: 5,
+			outerRadius: 10,
+			thetaSegments: 8,
+			phiSegments: 8,
+			thetaStart: 0,
+			thetaLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -750,15 +682,15 @@ var guis = {
 
 	},
 
-	RingGeometry : function( mesh ) {
+	RingGeometry: function ( mesh ) {
 
 		var data = {
-			innerRadius : 5,
-			outerRadius : 10,
-			thetaSegments : 8,
-			phiSegments : 8,
-			thetaStart : 0,
-			thetaLength : twoPi
+			innerRadius: 5,
+			outerRadius: 10,
+			thetaSegments: 8,
+			phiSegments: 8,
+			thetaStart: 0,
+			thetaLength: twoPi
 		};
 
 		function generateGeometry() {
@@ -784,16 +716,16 @@ var guis = {
 
 	},
 
-	SphereBufferGeometry : function( mesh ) {
+	SphereBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 15,
-			widthSegments : 8,
-			heightSegments : 6,
-			phiStart : 0,
-			phiLength : twoPi,
-			thetaStart : 0,
-			thetaLength : Math.PI
+			radius: 15,
+			widthSegments: 8,
+			heightSegments: 6,
+			phiStart: 0,
+			phiLength: twoPi,
+			thetaStart: 0,
+			thetaLength: Math.PI
 		};
 
 		function generateGeometry() {
@@ -820,16 +752,16 @@ var guis = {
 
 	},
 
-	SphereGeometry : function( mesh ) {
+	SphereGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 15,
-			widthSegments : 8,
-			heightSegments : 6,
-			phiStart : 0,
-			phiLength : twoPi,
-			thetaStart : 0,
-			thetaLength : Math.PI
+			radius: 15,
+			widthSegments: 8,
+			heightSegments: 6,
+			phiStart: 0,
+			phiLength: twoPi,
+			thetaStart: 0,
+			thetaLength: Math.PI
 		};
 
 		function generateGeometry() {
@@ -856,11 +788,11 @@ var guis = {
 
 	},
 
-	TetrahedronGeometry : function() {
+	TetrahedronGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			detail : 0
+			radius: 10,
+			detail: 0
 		};
 
 		function generateGeometry() {
@@ -882,11 +814,11 @@ var guis = {
 
 	},
 
-	TetrahedronBufferGeometry : function() {
+	TetrahedronBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			detail : 0
+			radius: 10,
+			detail: 0
 		};
 
 		function generateGeometry() {
@@ -908,19 +840,19 @@ var guis = {
 
 	},
 
-	TextGeometry : function( mesh ) {
+	TextGeometry: function ( mesh ) {
 
 		var data = {
-			text : "TextGeometry",
-			size : 5,
-			height : 2,
-			curveSegments : 12,
-			font : "helvetiker",
-			weight : "regular",
-			bevelEnabled : false,
-			bevelThickness : 1,
-			bevelSize : 0.5,
-			bevelSegments : 3
+			text: "TextGeometry",
+			size: 5,
+			height: 2,
+			curveSegments: 12,
+			font: "helvetiker",
+			weight: "regular",
+			bevelEnabled: false,
+			bevelThickness: 1,
+			bevelSize: 0.5,
+			bevelSegments: 3
 		};
 
 		var fonts = [
@@ -977,19 +909,19 @@ var guis = {
 
 	},
 
-	TextBufferGeometry : function( mesh ) {
+	TextBufferGeometry: function ( mesh ) {
 
 		var data = {
-			text : "TextBufferGeometry",
-			size : 5,
-			height : 2,
-			curveSegments : 12,
-			font : "helvetiker",
-			weight : "regular",
-			bevelEnabled : false,
-			bevelThickness : 1,
-			bevelSize : 0.5,
-			bevelSegments : 3
+			text: "TextBufferGeometry",
+			size: 5,
+			height: 2,
+			curveSegments: 12,
+			font: "helvetiker",
+			weight: "regular",
+			bevelEnabled: false,
+			bevelThickness: 1,
+			bevelSize: 0.5,
+			bevelSegments: 3
 		};
 
 		var fonts = [
@@ -1046,14 +978,14 @@ var guis = {
 
 	},
 
-	TorusBufferGeometry : function( mesh ) {
+	TorusBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			tube : 3,
-			radialSegments : 16,
-			tubularSegments : 100,
-			arc : twoPi
+			radius: 10,
+			tube: 3,
+			radialSegments: 16,
+			tubularSegments: 100,
+			arc: twoPi
 		};
 
 		function generateGeometry() {
@@ -1078,14 +1010,14 @@ var guis = {
 
 	},
 
-	TorusGeometry : function( mesh ) {
+	TorusGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			tube : 3,
-			radialSegments : 16,
-			tubularSegments : 100,
-			arc : twoPi
+			radius: 10,
+			tube: 3,
+			radialSegments: 16,
+			tubularSegments: 100,
+			arc: twoPi
 		};
 
 		function generateGeometry() {
@@ -1110,15 +1042,15 @@ var guis = {
 
 	},
 
-	TorusKnotBufferGeometry : function( mesh ) {
+	TorusKnotBufferGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			tube : 3,
-			tubularSegments : 64,
-			radialSegments : 8,
-			p : 2,
-			q : 3
+			radius: 10,
+			tube: 3,
+			tubularSegments: 64,
+			radialSegments: 8,
+			p: 2,
+			q: 3
 		};
 
 		function generateGeometry() {
@@ -1145,15 +1077,15 @@ var guis = {
 
 	},
 
-	TorusKnotGeometry : function( mesh ) {
+	TorusKnotGeometry: function ( mesh ) {
 
 		var data = {
-			radius : 10,
-			tube : 3,
-			tubularSegments : 64,
-			radialSegments : 8,
-			p : 2,
-			q : 3
+			radius: 10,
+			tube: 3,
+			tubularSegments: 64,
+			radialSegments: 8,
+			p: 2,
+			q: 3
 		};
 
 		function generateGeometry() {
@@ -1180,11 +1112,11 @@ var guis = {
 
 	},
 
-	ParametricBufferGeometry : function( mesh ) {
+	ParametricBufferGeometry: function ( mesh ) {
 
 		var data = {
-			slices : 25,
-			stacks : 25
+			slices: 25,
+			stacks: 25
 		};
 
 		function generateGeometry() {
@@ -1204,11 +1136,11 @@ var guis = {
 
 	},
 
-	ParametricGeometry : function( mesh ) {
+	ParametricGeometry: function ( mesh ) {
 
 		var data = {
-			slices : 25,
-			stacks : 25
+			slices: 25,
+			stacks: 25
 		};
 
 		function generateGeometry() {
@@ -1228,11 +1160,11 @@ var guis = {
 
 	},
 
-	TubeGeometry : function( mesh ) {
+	TubeGeometry: function ( mesh ) {
 
 		var data = {
-			segments : 20,
-			radius : 2,
+			segments: 20,
+			radius: 2,
 			radiusSegments: 8
 		};
 
@@ -1256,11 +1188,11 @@ var guis = {
 
 	},
 
-	TubeBufferGeometry : function( mesh ) {
+	TubeBufferGeometry: function ( mesh ) {
 
 		var data = {
-			segments : 20,
-			radius : 2,
+			segments: 20,
+			radius: 2,
 			radiusSegments: 8
 		};
 
@@ -1284,17 +1216,18 @@ var guis = {
 
 	},
 
-	ShapeGeometry: function( mesh ) {
+	ShapeGeometry: function ( mesh ) {
 
 		var data = {
-			segments : 12
+			segments: 12
 		};
 
 		function generateGeometry() {
 
-			updateGroupGeometry( mesh,
-				new THREE.ShapeGeometry( heartShape, data.segments )
-			);
+			var geometry = new THREE.ShapeGeometry( heartShape, data.segments );
+			geometry.center();
+
+			updateGroupGeometry( mesh, geometry );
 
 		}
 
@@ -1305,17 +1238,18 @@ var guis = {
 
 	},
 
-	ShapeBufferGeometry: function( mesh ) {
+	ShapeBufferGeometry: function ( mesh ) {
 
 		var data = {
-			segments : 12
+			segments: 12
 		};
 
 		function generateGeometry() {
 
-			updateGroupGeometry( mesh,
-				new THREE.ShapeBufferGeometry( heartShape, data.segments )
-			);
+			var geometry = new THREE.ShapeBufferGeometry( heartShape, data.segments );
+			geometry.center();
+
+			updateGroupGeometry( mesh, geometry );
 
 		}
 
@@ -1326,7 +1260,7 @@ var guis = {
 
 	},
 
-	ExtrudeGeometry: function( mesh ) {
+	ExtrudeGeometry: function ( mesh ) {
 
 		var data = {
 			steps: 2,
@@ -1340,7 +1274,7 @@ var guis = {
 		var length = 12, width = 8;
 
 		var shape = new THREE.Shape();
-		shape.moveTo( 0,0 );
+		shape.moveTo( 0, 0 );
 		shape.lineTo( 0, width );
 		shape.lineTo( length, width );
 		shape.lineTo( length, 0 );
@@ -1348,9 +1282,10 @@ var guis = {
 
 		function generateGeometry() {
 
-			updateGroupGeometry( mesh,
-				new THREE.ExtrudeGeometry( shape, data )
-			);
+			var geometry = new THREE.ExtrudeGeometry( shape, data );
+			geometry.center();
+
+			updateGroupGeometry( mesh, geometry );
 
 		}
 
@@ -1366,7 +1301,7 @@ var guis = {
 
 	},
 
-	ExtrudeBufferGeometry: function( mesh ) {
+	ExtrudeBufferGeometry: function ( mesh ) {
 
 		var data = {
 			steps: 2,
@@ -1380,7 +1315,7 @@ var guis = {
 		var length = 12, width = 8;
 
 		var shape = new THREE.Shape();
-		shape.moveTo( 0,0 );
+		shape.moveTo( 0, 0 );
 		shape.lineTo( 0, width );
 		shape.lineTo( length, width );
 		shape.lineTo( length, 0 );
@@ -1388,9 +1323,10 @@ var guis = {
 
 		function generateGeometry() {
 
-			updateGroupGeometry( mesh,
-				new THREE.ExtrudeBufferGeometry( shape, data )
-			);
+			var geometry = new THREE.ExtrudeBufferGeometry( shape, data );
+			geometry.center();
+
+			updateGroupGeometry( mesh, geometry );
 
 		}
 
@@ -1408,7 +1344,7 @@ var guis = {
 
 };
 
-function chooseFromHash ( mesh ) {
+function chooseFromHash( mesh ) {
 
 	var selectedGeometry = window.location.hash.substring( 1 ) || "TorusGeometry";
 
@@ -1420,7 +1356,7 @@ function chooseFromHash ( mesh ) {
 
 	if ( selectedGeometry === 'TextGeometry' || selectedGeometry === 'TextBufferGeometry' ) {
 
-		return { fixed : true };
+		return { fixed: true };
 
 	}
 

--- a/examples/webgl_geometry_extrude_shapes.html
+++ b/examples/webgl_geometry_extrude_shapes.html
@@ -78,9 +78,9 @@
 				closedSpline.closed = true;
 
 				var extrudeSettings = {
-					steps			: 100,
-					bevelEnabled	: false,
-					extrudePath		: closedSpline
+					steps: 100,
+					bevelEnabled: false,
+					extrudePath: closedSpline
 				};
 
 
@@ -158,14 +158,12 @@
 				var materials = [ material, material2 ];
 
 				var extrudeSettings = {
-					amount			: 20,
-					steps			: 1,
-					material		: 1,
-					extrudeMaterial : 0,
-					bevelEnabled	: true,
-					bevelThickness  : 2,
-					bevelSize       : 4,
-					bevelSegments   : 1
+					amount: 20,
+					steps: 1,
+					bevelEnabled: true,
+					bevelThickness: 2,
+					bevelSize: 4,
+					bevelSegments: 1
 				};
 
 				var geometry = new THREE.ExtrudeGeometry( shape, extrudeSettings );

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -1,9 +1,9 @@
 /**
  * @author zz85 / http://www.lab4games.net/zz85/blog
  *
- * Creates extruded geometry from a path shape.
+ * Creates extruded geometry from a shape.
  *
- * parameters = {
+ * options = {
  *
  *  curveSegments: <int>, // number of points on the curves
  *  steps: <int>, // number of points for z-side extrusions / used for subdividing segments of extrude spline too
@@ -14,10 +14,7 @@
  *  bevelSize: <float>, // how far from shape outline is bevel
  *  bevelSegments: <int>, // number of bevel layers
  *
- *  extrudePath: <THREE.Curve> // curve to extrude shape along
- *  frames: <Object> // containing arrays of tangents, normals, binormals
- *
- *  UVGenerator: <Object> // object that provides UV generator functions
+ *  extrudePath: <THREE.Curve> // curve to extrude the shape along
  *
  * }
  */
@@ -50,283 +47,247 @@ function ExtrudeGeometry( shapes, options ) {
 ExtrudeGeometry.prototype = Object.create( Geometry.prototype );
 ExtrudeGeometry.prototype.constructor = ExtrudeGeometry;
 
+ExtrudeGeometry.prototype.toJSON = function () {
+
+	var data = Geometry.prototype.toJSON.call( this );
+
+	var shapes = this.parameters.shapes;
+	var options = this.parameters.options;
+
+	return toJSON( shapes, options, data );
+
+};
+
 // ExtrudeBufferGeometry
 
 function ExtrudeBufferGeometry( shapes, options ) {
-
-	if ( typeof ( shapes ) === "undefined" ) {
-
-		return;
-
-	}
 
 	BufferGeometry.call( this );
 
 	this.type = 'ExtrudeBufferGeometry';
 
+	this.parameters = {
+		shapes: shapes,
+		options: options
+	};
+
+	//
+
 	shapes = Array.isArray( shapes ) ? shapes : [ shapes ];
 
-	this.addShapeList( shapes, options );
+	var verticesArray = [];
+	var uvArray = [];
+	var indicesArray = [];
+
+	var scope = this;
+
+	for ( var i = 0, l = shapes.length; i < l; i ++ ) {
+
+		var shape = shapes[ i ];
+		addShape( shape, options );
+
+	}
+
+	// build geometry
+
+	this.setIndex( indicesArray );
+	this.addAttribute( 'position', new Float32BufferAttribute( verticesArray, 3 ) );
+	this.addAttribute( 'uv', new Float32BufferAttribute( uvArray, 2 ) );
 
 	this.computeVertexNormals();
 
-	// can't really use automatic vertex normals
-	// as then front and back sides get smoothed too
-	// should do separate smoothing just for sides
+	// functions
 
-	//this.computeVertexNormals();
+	function addShape( shape ) {
 
-	//console.log( "took", ( Date.now() - startTime ) );
+		var placeholder = [];
 
-}
+		// options
 
-ExtrudeBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
-ExtrudeBufferGeometry.prototype.constructor = ExtrudeBufferGeometry;
+		var curveSegments = options.curveSegments !== undefined ? options.curveSegments : 12;
+		var steps = options.steps !== undefined ? options.steps : 1;
+		var amount = options.amount !== undefined ? options.amount : 100;
 
-ExtrudeBufferGeometry.prototype.getArrays = function () {
+		var bevelEnabled = options.bevelEnabled !== undefined ? options.bevelEnabled : true;
+		var bevelThickness = options.bevelThickness !== undefined ? options.bevelThickness : 6;
+		var bevelSize = options.bevelSize !== undefined ? options.bevelSize : bevelThickness - 2;
+		var bevelSegments = options.bevelSegments !== undefined ? options.bevelSegments : 3;
 
-	var positionAttribute = this.getAttribute( "position" );
-	var verticesArray = positionAttribute ? Array.prototype.slice.call( positionAttribute.array ) : [];
+		var extrudePath = options.extrudePath;
 
-	var uvAttribute = this.getAttribute( "uv" );
-	var uvArray = uvAttribute ? Array.prototype.slice.call( uvAttribute.array ) : [];
+		//
 
-	var IndexAttribute = this.index;
-	var indicesArray = IndexAttribute ? Array.prototype.slice.call( IndexAttribute.array ) : [];
+		var extrudePts, extrudeByPath = false;
 
-	return {
-		position: verticesArray,
-		uv: uvArray,
-		index: indicesArray
-	};
+		var uvgen = ExtrudeGeometry.UVGenerator;
 
-};
+		var splineTube, binormal, normal, position2;
 
-ExtrudeBufferGeometry.prototype.addShapeList = function ( shapes, options ) {
+		if ( extrudePath ) {
 
-	var sl = shapes.length;
-	options.arrays = this.getArrays();
+			extrudePts = extrudePath.getSpacedPoints( steps );
 
-	for ( var s = 0; s < sl; s ++ ) {
+			extrudeByPath = true;
+			bevelEnabled = false; // bevels not supported for path extrusion
 
-		var shape = shapes[ s ];
-		this.addShape( shape, options );
+			// SETUP TNB variables
 
-	}
+			// TODO1 - have a .isClosed in spline?
 
-	this.setIndex( options.arrays.index );
-	this.addAttribute( 'position', new Float32BufferAttribute( options.arrays.position, 3 ) );
-	this.addAttribute( 'uv', new Float32BufferAttribute( options.arrays.uv, 2 ) );
+			splineTube = extrudePath.computeFrenetFrames( steps, false );
 
-};
+			binormal = new Vector3();
+			normal = new Vector3();
+			position2 = new Vector3();
 
-ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
+		}
 
-	var arrays = options.arrays ? options.arrays : this.getArrays();
-	var verticesArray = arrays.position;
-	var indicesArray = arrays.index;
-	var uvArray = arrays.uv;
+		// safeguards if bevels are not enabled
 
-	var placeholder = [];
+		if ( ! bevelEnabled ) {
 
+			bevelSegments = 0;
+			bevelThickness = 0;
+			bevelSize = 0;
 
-	var amount = options.amount !== undefined ? options.amount : 100;
+		}
 
-	var bevelThickness = options.bevelThickness !== undefined ? options.bevelThickness : 6; // 10
-	var bevelSize = options.bevelSize !== undefined ? options.bevelSize : bevelThickness - 2; // 8
-	var bevelSegments = options.bevelSegments !== undefined ? options.bevelSegments : 3;
+		// Variables initialization
 
-	var bevelEnabled = options.bevelEnabled !== undefined ? options.bevelEnabled : true; // false
+		var ahole, h, hl; // looping of holes
 
-	var curveSegments = options.curveSegments !== undefined ? options.curveSegments : 12;
+		var shapePoints = shape.extractPoints( curveSegments );
 
-	var steps = options.steps !== undefined ? options.steps : 1;
+		var vertices = shapePoints.shape;
+		var holes = shapePoints.holes;
 
-	var extrudePath = options.extrudePath;
-	var extrudePts, extrudeByPath = false;
+		var reverse = ! ShapeUtils.isClockWise( vertices );
 
-	// Use default WorldUVGenerator if no UV generators are specified.
-	var uvgen = options.UVGenerator !== undefined ? options.UVGenerator : ExtrudeGeometry.WorldUVGenerator;
+		if ( reverse ) {
 
-	var splineTube, binormal, normal, position2;
-	if ( extrudePath ) {
+			vertices = vertices.reverse();
 
-		extrudePts = extrudePath.getSpacedPoints( steps );
+			// Maybe we should also check if holes are in the opposite direction, just to be safe ...
 
-		extrudeByPath = true;
-		bevelEnabled = false; // bevels not supported for path extrusion
+			for ( h = 0, hl = holes.length; h < hl; h ++ ) {
 
-		// SETUP TNB variables
+				ahole = holes[ h ];
 
-		// TODO1 - have a .isClosed in spline?
+				if ( ShapeUtils.isClockWise( ahole ) ) {
 
-		splineTube = options.frames !== undefined ? options.frames : extrudePath.computeFrenetFrames( steps, false );
+					holes[ h ] = ahole.reverse();
 
-		// console.log(splineTube, 'splineTube', splineTube.normals.length, 'steps', steps, 'extrudePts', extrudePts.length);
-
-		binormal = new Vector3();
-		normal = new Vector3();
-		position2 = new Vector3();
-
-	}
-
-	// Safeguards if bevels are not enabled
-
-	if ( ! bevelEnabled ) {
-
-		bevelSegments = 0;
-		bevelThickness = 0;
-		bevelSize = 0;
-
-	}
-
-	// Variables initialization
-
-	var ahole, h, hl; // looping of holes
-	var scope = this;
-
-	var shapePoints = shape.extractPoints( curveSegments );
-
-	var vertices = shapePoints.shape;
-	var holes = shapePoints.holes;
-
-	var reverse = ! ShapeUtils.isClockWise( vertices );
-
-	if ( reverse ) {
-
-		vertices = vertices.reverse();
-
-		// Maybe we should also check if holes are in the opposite direction, just to be safe ...
-
-		for ( h = 0, hl = holes.length; h < hl; h ++ ) {
-
-			ahole = holes[ h ];
-
-			if ( ShapeUtils.isClockWise( ahole ) ) {
-
-				holes[ h ] = ahole.reverse();
+				}
 
 			}
 
 		}
 
-	}
+
+		var faces = ShapeUtils.triangulateShape( vertices, holes );
+
+		/* Vertices */
+
+		var contour = vertices; // vertices has all points but contour has only points of circumference
+
+		for ( h = 0, hl = holes.length; h < hl; h ++ ) {
+
+			ahole = holes[ h ];
+
+			vertices = vertices.concat( ahole );
+
+		}
 
 
-	var faces = ShapeUtils.triangulateShape( vertices, holes );
+		function scalePt2( pt, vec, size ) {
 
-	/* Vertices */
+			if ( ! vec ) console.error( 'THREE.ExtrudeGeometry: vec does not exist' );
 
-	var contour = vertices; // vertices has all points but contour has only points of circumference
+			return vec.clone().multiplyScalar( size ).add( pt );
 
-	for ( h = 0, hl = holes.length; h < hl; h ++ ) {
+		}
 
-		ahole = holes[ h ];
-
-		vertices = vertices.concat( ahole );
-
-	}
+		var b, bs, t, z,
+			vert, vlen = vertices.length,
+			face, flen = faces.length;
 
 
-	function scalePt2( pt, vec, size ) {
-
-		if ( ! vec ) console.error( "THREE.ExtrudeGeometry: vec does not exist" );
-
-		return vec.clone().multiplyScalar( size ).add( pt );
-
-	}
-
-	var b, bs, t, z,
-		vert, vlen = vertices.length,
-		face, flen = faces.length;
+		// Find directions for point movement
 
 
-	// Find directions for point movement
+		function getBevelVec( inPt, inPrev, inNext ) {
 
+			// computes for inPt the corresponding point inPt' on a new contour
+			// shifted by 1 unit (length of normalized vector) to the left
+			// if we walk along contour clockwise, this new contour is outside the old one
+			//
+			// inPt' is the intersection of the two lines parallel to the two
+			// adjacent edges of inPt at a distance of 1 unit on the left side.
 
-	function getBevelVec( inPt, inPrev, inNext ) {
+			var v_trans_x, v_trans_y, shrink_by; // resulting translation vector for inPt
 
-		// computes for inPt the corresponding point inPt' on a new contour
-		//   shifted by 1 unit (length of normalized vector) to the left
-		// if we walk along contour clockwise, this new contour is outside the old one
-		//
-		// inPt' is the intersection of the two lines parallel to the two
-		//  adjacent edges of inPt at a distance of 1 unit on the left side.
+			// good reading for geometry algorithms (here: line-line intersection)
+			// http://geomalgorithms.com/a05-_intersect-1.html
 
-		var v_trans_x, v_trans_y, shrink_by; // resulting translation vector for inPt
+			var v_prev_x = inPt.x - inPrev.x,
+				v_prev_y = inPt.y - inPrev.y;
+			var v_next_x = inNext.x - inPt.x,
+				v_next_y = inNext.y - inPt.y;
 
-		// good reading for geometry algorithms (here: line-line intersection)
-		// http://geomalgorithms.com/a05-_intersect-1.html
+			var v_prev_lensq = ( v_prev_x * v_prev_x + v_prev_y * v_prev_y );
 
-		var v_prev_x = inPt.x - inPrev.x,
-			v_prev_y = inPt.y - inPrev.y;
-		var v_next_x = inNext.x - inPt.x,
-			v_next_y = inNext.y - inPt.y;
+			// check for collinear edges
+			var collinear0 = ( v_prev_x * v_next_y - v_prev_y * v_next_x );
 
-		var v_prev_lensq = ( v_prev_x * v_prev_x + v_prev_y * v_prev_y );
+			if ( Math.abs( collinear0 ) > Number.EPSILON ) {
 
-		// check for collinear edges
-		var collinear0 = ( v_prev_x * v_next_y - v_prev_y * v_next_x );
+				// not collinear
 
-		if ( Math.abs( collinear0 ) > Number.EPSILON ) {
+				// length of vectors for normalizing
 
-			// not collinear
+				var v_prev_len = Math.sqrt( v_prev_lensq );
+				var v_next_len = Math.sqrt( v_next_x * v_next_x + v_next_y * v_next_y );
 
-			// length of vectors for normalizing
+				// shift adjacent points by unit vectors to the left
 
-			var v_prev_len = Math.sqrt( v_prev_lensq );
-			var v_next_len = Math.sqrt( v_next_x * v_next_x + v_next_y * v_next_y );
+				var ptPrevShift_x = ( inPrev.x - v_prev_y / v_prev_len );
+				var ptPrevShift_y = ( inPrev.y + v_prev_x / v_prev_len );
 
-			// shift adjacent points by unit vectors to the left
+				var ptNextShift_x = ( inNext.x - v_next_y / v_next_len );
+				var ptNextShift_y = ( inNext.y + v_next_x / v_next_len );
 
-			var ptPrevShift_x = ( inPrev.x - v_prev_y / v_prev_len );
-			var ptPrevShift_y = ( inPrev.y + v_prev_x / v_prev_len );
+				// scaling factor for v_prev to intersection point
 
-			var ptNextShift_x = ( inNext.x - v_next_y / v_next_len );
-			var ptNextShift_y = ( inNext.y + v_next_x / v_next_len );
+				var sf = ( ( ptNextShift_x - ptPrevShift_x ) * v_next_y -
+						( ptNextShift_y - ptPrevShift_y ) * v_next_x ) /
+					( v_prev_x * v_next_y - v_prev_y * v_next_x );
 
-			// scaling factor for v_prev to intersection point
+				// vector from inPt to intersection point
 
-			var sf = ( ( ptNextShift_x - ptPrevShift_x ) * v_next_y -
-					( ptNextShift_y - ptPrevShift_y ) * v_next_x ) /
-				( v_prev_x * v_next_y - v_prev_y * v_next_x );
+				v_trans_x = ( ptPrevShift_x + v_prev_x * sf - inPt.x );
+				v_trans_y = ( ptPrevShift_y + v_prev_y * sf - inPt.y );
 
-			// vector from inPt to intersection point
+				// Don't normalize!, otherwise sharp corners become ugly
+				//  but prevent crazy spikes
+				var v_trans_lensq = ( v_trans_x * v_trans_x + v_trans_y * v_trans_y );
+				if ( v_trans_lensq <= 2 ) {
 
-			v_trans_x = ( ptPrevShift_x + v_prev_x * sf - inPt.x );
-			v_trans_y = ( ptPrevShift_y + v_prev_y * sf - inPt.y );
+					return new Vector2( v_trans_x, v_trans_y );
 
-			// Don't normalize!, otherwise sharp corners become ugly
-			//  but prevent crazy spikes
-			var v_trans_lensq = ( v_trans_x * v_trans_x + v_trans_y * v_trans_y );
-			if ( v_trans_lensq <= 2 ) {
+				} else {
 
-				return new Vector2( v_trans_x, v_trans_y );
-
-			} else {
-
-				shrink_by = Math.sqrt( v_trans_lensq / 2 );
-
-			}
-
-		} else {
-
-			// handle special case of collinear edges
-
-			var direction_eq = false; // assumes: opposite
-			if ( v_prev_x > Number.EPSILON ) {
-
-				if ( v_next_x > Number.EPSILON ) {
-
-					direction_eq = true;
+					shrink_by = Math.sqrt( v_trans_lensq / 2 );
 
 				}
 
 			} else {
 
-				if ( v_prev_x < - Number.EPSILON ) {
+				// handle special case of collinear edges
 
-					if ( v_next_x < - Number.EPSILON ) {
+				var direction_eq = false; // assumes: opposite
+				if ( v_prev_x > Number.EPSILON ) {
+
+					if ( v_next_x > Number.EPSILON ) {
 
 						direction_eq = true;
 
@@ -334,150 +295,125 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 				} else {
 
-					if ( Math.sign( v_prev_y ) === Math.sign( v_next_y ) ) {
+					if ( v_prev_x < - Number.EPSILON ) {
 
-						direction_eq = true;
+						if ( v_next_x < - Number.EPSILON ) {
+
+							direction_eq = true;
+
+						}
+
+					} else {
+
+						if ( Math.sign( v_prev_y ) === Math.sign( v_next_y ) ) {
+
+							direction_eq = true;
+
+						}
 
 					}
 
 				}
 
-			}
+				if ( direction_eq ) {
 
-			if ( direction_eq ) {
+					v_trans_x = - v_prev_y;
+					v_trans_y = v_prev_x;
+					shrink_by = Math.sqrt( v_prev_lensq );
 
-				// console.log("Warning: lines are a straight sequence");
-				v_trans_x = - v_prev_y;
-				v_trans_y = v_prev_x;
-				shrink_by = Math.sqrt( v_prev_lensq );
+				} else {
 
-			} else {
+					v_trans_x = v_prev_x;
+					v_trans_y = v_prev_y;
+					shrink_by = Math.sqrt( v_prev_lensq / 2 );
 
-				// console.log("Warning: lines are a straight spike");
-				v_trans_x = v_prev_x;
-				v_trans_y = v_prev_y;
-				shrink_by = Math.sqrt( v_prev_lensq / 2 );
+				}
 
 			}
+
+			return new Vector2( v_trans_x / shrink_by, v_trans_y / shrink_by );
 
 		}
 
-		return new Vector2( v_trans_x / shrink_by, v_trans_y / shrink_by );
 
-	}
+		var contourMovements = [];
 
-
-	var contourMovements = [];
-
-	for ( var i = 0, il = contour.length, j = il - 1, k = i + 1; i < il; i ++, j ++, k ++ ) {
-
-		if ( j === il ) j = 0;
-		if ( k === il ) k = 0;
-
-		//  (j)---(i)---(k)
-		// console.log('i,j,k', i, j , k)
-
-		contourMovements[ i ] = getBevelVec( contour[ i ], contour[ j ], contour[ k ] );
-
-	}
-
-	var holesMovements = [],
-		oneHoleMovements, verticesMovements = contourMovements.concat();
-
-	for ( h = 0, hl = holes.length; h < hl; h ++ ) {
-
-		ahole = holes[ h ];
-
-		oneHoleMovements = [];
-
-		for ( i = 0, il = ahole.length, j = il - 1, k = i + 1; i < il; i ++, j ++, k ++ ) {
+		for ( var i = 0, il = contour.length, j = il - 1, k = i + 1; i < il; i ++, j ++, k ++ ) {
 
 			if ( j === il ) j = 0;
 			if ( k === il ) k = 0;
 
-			//  (j)---(i)---(k)
-			oneHoleMovements[ i ] = getBevelVec( ahole[ i ], ahole[ j ], ahole[ k ] );
+			contourMovements[ i ] = getBevelVec( contour[ i ], contour[ j ], contour[ k ] );
 
 		}
 
-		holesMovements.push( oneHoleMovements );
-		verticesMovements = verticesMovements.concat( oneHoleMovements );
-
-	}
-
-
-	// Loop bevelSegments, 1 for the front, 1 for the back
-
-	for ( b = 0; b < bevelSegments; b ++ ) {
-
-		//for ( b = bevelSegments; b > 0; b -- ) {
-
-		t = b / bevelSegments;
-		z = bevelThickness * Math.cos( t * Math.PI / 2 );
-		bs = bevelSize * Math.sin( t * Math.PI / 2 );
-
-		// contract shape
-
-		for ( i = 0, il = contour.length; i < il; i ++ ) {
-
-			vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
-
-			v( vert.x, vert.y, - z );
-
-		}
-
-		// expand holes
+		var holesMovements = [],
+			oneHoleMovements, verticesMovements = contourMovements.concat();
 
 		for ( h = 0, hl = holes.length; h < hl; h ++ ) {
 
 			ahole = holes[ h ];
-			oneHoleMovements = holesMovements[ h ];
 
-			for ( i = 0, il = ahole.length; i < il; i ++ ) {
+			oneHoleMovements = [];
 
-				vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
+			for ( i = 0, il = ahole.length, j = il - 1, k = i + 1; i < il; i ++, j ++, k ++ ) {
+
+				if ( j === il ) j = 0;
+				if ( k === il ) k = 0;
+
+				//  (j)---(i)---(k)
+				oneHoleMovements[ i ] = getBevelVec( ahole[ i ], ahole[ j ], ahole[ k ] );
+
+			}
+
+			holesMovements.push( oneHoleMovements );
+			verticesMovements = verticesMovements.concat( oneHoleMovements );
+
+		}
+
+
+		// Loop bevelSegments, 1 for the front, 1 for the back
+
+		for ( b = 0; b < bevelSegments; b ++ ) {
+
+			//for ( b = bevelSegments; b > 0; b -- ) {
+
+			t = b / bevelSegments;
+			z = bevelThickness * Math.cos( t * Math.PI / 2 );
+			bs = bevelSize * Math.sin( t * Math.PI / 2 );
+
+			// contract shape
+
+			for ( i = 0, il = contour.length; i < il; i ++ ) {
+
+				vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
 
 				v( vert.x, vert.y, - z );
 
 			}
 
-		}
+			// expand holes
 
-	}
+			for ( h = 0, hl = holes.length; h < hl; h ++ ) {
 
-	bs = bevelSize;
+				ahole = holes[ h ];
+				oneHoleMovements = holesMovements[ h ];
 
-	// Back facing vertices
+				for ( i = 0, il = ahole.length; i < il; i ++ ) {
 
-	for ( i = 0; i < vlen; i ++ ) {
+					vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
 
-		vert = bevelEnabled ? scalePt2( vertices[ i ], verticesMovements[ i ], bs ) : vertices[ i ];
+					v( vert.x, vert.y, - z );
 
-		if ( ! extrudeByPath ) {
+				}
 
-			v( vert.x, vert.y, 0 );
-
-		} else {
-
-			// v( vert.x, vert.y + extrudePts[ 0 ].y, extrudePts[ 0 ].x );
-
-			normal.copy( splineTube.normals[ 0 ] ).multiplyScalar( vert.x );
-			binormal.copy( splineTube.binormals[ 0 ] ).multiplyScalar( vert.y );
-
-			position2.copy( extrudePts[ 0 ] ).add( normal ).add( binormal );
-
-			v( position2.x, position2.y, position2.z );
+			}
 
 		}
 
-	}
+		bs = bevelSize;
 
-	// Add stepped vertices...
-	// Including front facing vertices
-
-	var s;
-
-	for ( s = 1; s <= steps; s ++ ) {
+		// Back facing vertices
 
 		for ( i = 0; i < vlen; i ++ ) {
 
@@ -485,16 +421,16 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 			if ( ! extrudeByPath ) {
 
-				v( vert.x, vert.y, amount / steps * s );
+				v( vert.x, vert.y, 0 );
 
 			} else {
 
-				// v( vert.x, vert.y + extrudePts[ s - 1 ].y, extrudePts[ s - 1 ].x );
+				// v( vert.x, vert.y + extrudePts[ 0 ].y, extrudePts[ 0 ].x );
 
-				normal.copy( splineTube.normals[ s ] ).multiplyScalar( vert.x );
-				binormal.copy( splineTube.binormals[ s ] ).multiplyScalar( vert.y );
+				normal.copy( splineTube.normals[ 0 ] ).multiplyScalar( vert.x );
+				binormal.copy( splineTube.binormals[ 0 ] ).multiplyScalar( vert.y );
 
-				position2.copy( extrudePts[ s ] ).add( normal ).add( binormal );
+				position2.copy( extrudePts[ 0 ] ).add( normal ).add( binormal );
 
 				v( position2.x, position2.y, position2.z );
 
@@ -502,45 +438,31 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 		}
 
-	}
+		// Add stepped vertices...
+		// Including front facing vertices
 
+		var s;
 
-	// Add bevel segments planes
+		for ( s = 1; s <= steps; s ++ ) {
 
-	//for ( b = 1; b <= bevelSegments; b ++ ) {
-	for ( b = bevelSegments - 1; b >= 0; b -- ) {
+			for ( i = 0; i < vlen; i ++ ) {
 
-		t = b / bevelSegments;
-		z = bevelThickness * Math.cos( t * Math.PI / 2 );
-		bs = bevelSize * Math.sin( t * Math.PI / 2 );
-
-		// contract shape
-
-		for ( i = 0, il = contour.length; i < il; i ++ ) {
-
-			vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
-			v( vert.x, vert.y, amount + z );
-
-		}
-
-		// expand holes
-
-		for ( h = 0, hl = holes.length; h < hl; h ++ ) {
-
-			ahole = holes[ h ];
-			oneHoleMovements = holesMovements[ h ];
-
-			for ( i = 0, il = ahole.length; i < il; i ++ ) {
-
-				vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
+				vert = bevelEnabled ? scalePt2( vertices[ i ], verticesMovements[ i ], bs ) : vertices[ i ];
 
 				if ( ! extrudeByPath ) {
 
-					v( vert.x, vert.y, amount + z );
+					v( vert.x, vert.y, amount / steps * s );
 
 				} else {
 
-					v( vert.x, vert.y + extrudePts[ steps - 1 ].y, extrudePts[ steps - 1 ].x + z );
+					// v( vert.x, vert.y + extrudePts[ s - 1 ].y, extrudePts[ s - 1 ].x );
+
+					normal.copy( splineTube.normals[ s ] ).multiplyScalar( vert.x );
+					binormal.copy( splineTube.binormals[ s ] ).multiplyScalar( vert.y );
+
+					position2.copy( extrudePts[ s ] ).add( normal ).add( binormal );
+
+					v( position2.x, position2.y, position2.z );
 
 				}
 
@@ -548,212 +470,261 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 		}
 
-	}
 
-	/* Faces */
+		// Add bevel segments planes
 
-	// Top and bottom faces
+		//for ( b = 1; b <= bevelSegments; b ++ ) {
+		for ( b = bevelSegments - 1; b >= 0; b -- ) {
 
-	buildLidFaces();
+			t = b / bevelSegments;
+			z = bevelThickness * Math.cos( t * Math.PI / 2 );
+			bs = bevelSize * Math.sin( t * Math.PI / 2 );
 
-	// Sides faces
+			// contract shape
 
-	buildSideFaces();
+			for ( i = 0, il = contour.length; i < il; i ++ ) {
 
-
-	/////  Internal functions
-
-	function buildLidFaces() {
-
-		var start = verticesArray.length / 3;
-
-		if ( bevelEnabled ) {
-
-			var layer = 0; // steps + 1
-			var offset = vlen * layer;
-
-			// Bottom faces
-
-			for ( i = 0; i < flen; i ++ ) {
-
-				face = faces[ i ];
-				f3( face[ 2 ] + offset, face[ 1 ] + offset, face[ 0 ] + offset );
+				vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
+				v( vert.x, vert.y, amount + z );
 
 			}
 
-			layer = steps + bevelSegments * 2;
-			offset = vlen * layer;
+			// expand holes
 
-			// Top faces
+			for ( h = 0, hl = holes.length; h < hl; h ++ ) {
 
-			for ( i = 0; i < flen; i ++ ) {
+				ahole = holes[ h ];
+				oneHoleMovements = holesMovements[ h ];
 
-				face = faces[ i ];
-				f3( face[ 0 ] + offset, face[ 1 ] + offset, face[ 2 ] + offset );
+				for ( i = 0, il = ahole.length; i < il; i ++ ) {
 
-			}
+					vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
 
-		} else {
+					if ( ! extrudeByPath ) {
 
-			// Bottom faces
+						v( vert.x, vert.y, amount + z );
 
-			for ( i = 0; i < flen; i ++ ) {
+					} else {
 
-				face = faces[ i ];
-				f3( face[ 2 ], face[ 1 ], face[ 0 ] );
+						v( vert.x, vert.y + extrudePts[ steps - 1 ].y, extrudePts[ steps - 1 ].x + z );
 
-			}
+					}
 
-			// Top faces
-
-			for ( i = 0; i < flen; i ++ ) {
-
-				face = faces[ i ];
-				f3( face[ 0 ] + vlen * steps, face[ 1 ] + vlen * steps, face[ 2 ] + vlen * steps );
+				}
 
 			}
 
 		}
 
-		scope.addGroup( start, verticesArray.length / 3 - start, options.material !== undefined ? options.material : 0 );
+		/* Faces */
 
-	}
+		// Top and bottom faces
 
-	// Create faces for the z-sides of the shape
+		buildLidFaces();
 
-	function buildSideFaces() {
+		// Sides faces
 
-		var start = verticesArray.length / 3;
-		var layeroffset = 0;
-		sidewalls( contour, layeroffset );
-		layeroffset += contour.length;
+		buildSideFaces();
 
-		for ( h = 0, hl = holes.length; h < hl; h ++ ) {
 
-			ahole = holes[ h ];
-			sidewalls( ahole, layeroffset );
+		/////  Internal functions
 
-			//, true
-			layeroffset += ahole.length;
+		function buildLidFaces() {
+
+			var start = verticesArray.length / 3;
+
+			if ( bevelEnabled ) {
+
+				var layer = 0; // steps + 1
+				var offset = vlen * layer;
+
+				// Bottom faces
+
+				for ( i = 0; i < flen; i ++ ) {
+
+					face = faces[ i ];
+					f3( face[ 2 ] + offset, face[ 1 ] + offset, face[ 0 ] + offset );
+
+				}
+
+				layer = steps + bevelSegments * 2;
+				offset = vlen * layer;
+
+				// Top faces
+
+				for ( i = 0; i < flen; i ++ ) {
+
+					face = faces[ i ];
+					f3( face[ 0 ] + offset, face[ 1 ] + offset, face[ 2 ] + offset );
+
+				}
+
+			} else {
+
+				// Bottom faces
+
+				for ( i = 0; i < flen; i ++ ) {
+
+					face = faces[ i ];
+					f3( face[ 2 ], face[ 1 ], face[ 0 ] );
+
+				}
+
+				// Top faces
+
+				for ( i = 0; i < flen; i ++ ) {
+
+					face = faces[ i ];
+					f3( face[ 0 ] + vlen * steps, face[ 1 ] + vlen * steps, face[ 2 ] + vlen * steps );
+
+				}
+
+			}
+
+			scope.addGroup( start, verticesArray.length / 3 - start, options.material !== undefined ? options.material : 0 );
 
 		}
 
+		// Create faces for the z-sides of the shape
 
-		scope.addGroup( start, verticesArray.length / 3 - start, options.extrudeMaterial !== undefined ? options.extrudeMaterial : 1 );
+		function buildSideFaces() {
+
+			var start = verticesArray.length / 3;
+			var layeroffset = 0;
+			sidewalls( contour, layeroffset );
+			layeroffset += contour.length;
+
+			for ( h = 0, hl = holes.length; h < hl; h ++ ) {
+
+				ahole = holes[ h ];
+				sidewalls( ahole, layeroffset );
+
+				//, true
+				layeroffset += ahole.length;
+
+			}
 
 
-	}
+			scope.addGroup( start, verticesArray.length / 3 - start, options.extrudeMaterial !== undefined ? options.extrudeMaterial : 1 );
 
-	function sidewalls( contour, layeroffset ) {
 
-		var j, k;
-		i = contour.length;
+		}
 
-		while ( -- i >= 0 ) {
+		function sidewalls( contour, layeroffset ) {
 
-			j = i;
-			k = i - 1;
-			if ( k < 0 ) k = contour.length - 1;
+			var j, k;
+			i = contour.length;
 
-			//console.log('b', i,j, i-1, k,vertices.length);
+			while ( -- i >= 0 ) {
 
-			var s = 0,
-				sl = steps + bevelSegments * 2;
+				j = i;
+				k = i - 1;
+				if ( k < 0 ) k = contour.length - 1;
 
-			for ( s = 0; s < sl; s ++ ) {
+				var s = 0, sl = steps + bevelSegments * 2;
 
-				var slen1 = vlen * s;
-				var slen2 = vlen * ( s + 1 );
+				for ( s = 0; s < sl; s ++ ) {
 
-				var a = layeroffset + j + slen1,
-					b = layeroffset + k + slen1,
-					c = layeroffset + k + slen2,
-					d = layeroffset + j + slen2;
+					var slen1 = vlen * s;
+					var slen2 = vlen * ( s + 1 );
 
-				f4( a, b, c, d );
+					var a = layeroffset + j + slen1,
+						b = layeroffset + k + slen1,
+						c = layeroffset + k + slen2,
+						d = layeroffset + j + slen2;
+
+					f4( a, b, c, d );
+
+				}
 
 			}
 
 		}
 
-	}
+		function v( x, y, z ) {
 
-	function v( x, y, z ) {
+			placeholder.push( x );
+			placeholder.push( y );
+			placeholder.push( z );
 
-		placeholder.push( x );
-		placeholder.push( y );
-		placeholder.push( z );
-
-	}
+		}
 
 
-	function f3( a, b, c ) {
+		function f3( a, b, c ) {
 
-		addVertex( a );
-		addVertex( b );
-		addVertex( c );
+			addVertex( a );
+			addVertex( b );
+			addVertex( c );
 
-		var nextIndex = verticesArray.length / 3;
-		var uvs = uvgen.generateTopUV( scope, verticesArray, nextIndex - 3, nextIndex - 2, nextIndex - 1 );
+			var nextIndex = verticesArray.length / 3;
+			var uvs = uvgen.generateTopUV( scope, verticesArray, nextIndex - 3, nextIndex - 2, nextIndex - 1 );
 
-		addUV( uvs[ 0 ] );
-		addUV( uvs[ 1 ] );
-		addUV( uvs[ 2 ] );
+			addUV( uvs[ 0 ] );
+			addUV( uvs[ 1 ] );
+			addUV( uvs[ 2 ] );
 
-	}
+		}
 
-	function f4( a, b, c, d ) {
+		function f4( a, b, c, d ) {
 
-		addVertex( a );
-		addVertex( b );
-		addVertex( d );
+			addVertex( a );
+			addVertex( b );
+			addVertex( d );
 
-		addVertex( b );
-		addVertex( c );
-		addVertex( d );
-
-
-		var nextIndex = verticesArray.length / 3;
-		var uvs = uvgen.generateSideWallUV( scope, verticesArray, nextIndex - 6, nextIndex - 3, nextIndex - 2, nextIndex - 1 );
-
-		addUV( uvs[ 0 ] );
-		addUV( uvs[ 1 ] );
-		addUV( uvs[ 3 ] );
-
-		addUV( uvs[ 1 ] );
-		addUV( uvs[ 2 ] );
-		addUV( uvs[ 3 ] );
-
-	}
-
-	function addVertex( index ) {
-
-		indicesArray.push( verticesArray.length / 3 );
-		verticesArray.push( placeholder[ index * 3 + 0 ] );
-		verticesArray.push( placeholder[ index * 3 + 1 ] );
-		verticesArray.push( placeholder[ index * 3 + 2 ] );
-
-	}
+			addVertex( b );
+			addVertex( c );
+			addVertex( d );
 
 
-	function addUV( vector2 ) {
+			var nextIndex = verticesArray.length / 3;
+			var uvs = uvgen.generateSideWallUV( scope, verticesArray, nextIndex - 6, nextIndex - 3, nextIndex - 2, nextIndex - 1 );
 
-		uvArray.push( vector2.x );
-		uvArray.push( vector2.y );
+			addUV( uvs[ 0 ] );
+			addUV( uvs[ 1 ] );
+			addUV( uvs[ 3 ] );
 
-	}
+			addUV( uvs[ 1 ] );
+			addUV( uvs[ 2 ] );
+			addUV( uvs[ 3 ] );
 
-	if ( ! options.arrays ) {
+		}
 
-		this.setIndex( indicesArray );
-		this.addAttribute( 'position', new Float32BufferAttribute( verticesArray, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvArray, 2 ) );
+		function addVertex( index ) {
+
+			indicesArray.push( verticesArray.length / 3 );
+			verticesArray.push( placeholder[ index * 3 + 0 ] );
+			verticesArray.push( placeholder[ index * 3 + 1 ] );
+			verticesArray.push( placeholder[ index * 3 + 2 ] );
+
+		}
+
+
+		function addUV( vector2 ) {
+
+			uvArray.push( vector2.x );
+			uvArray.push( vector2.y );
+
+		}
 
 	}
+
+}
+
+ExtrudeBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
+ExtrudeBufferGeometry.prototype.constructor = ExtrudeBufferGeometry;
+
+ExtrudeBufferGeometry.prototype.toJSON = function () {
+
+	var data = BufferGeometry.prototype.toJSON.call( this );
+
+	var shapes = this.parameters.shapes;
+	var options = this.parameters.options;
+
+	return toJSON( shapes, options, data );
 
 };
 
-ExtrudeGeometry.WorldUVGenerator = {
+ExtrudeGeometry.UVGenerator = {
 
 	generateTopUV: function ( geometry, vertices, indexA, indexB, indexC ) {
 
@@ -809,6 +780,47 @@ ExtrudeGeometry.WorldUVGenerator = {
 
 	}
 };
+
+//
+
+function toJSON( shapes, options, data ) {
+
+	// shapes
+
+	data.shapes = [];
+
+	if ( Array.isArray( shapes ) ) {
+
+		for ( var i = 0, l = shapes.length; i < l; i ++ ) {
+
+			var shape = shapes[ i ];
+
+			data.shapes.push( shape.uuid );
+
+		}
+
+	} else {
+
+		data.shapes.push( shapes.uuid );
+
+	}
+
+	// options
+
+	data.options = {};
+
+	if ( options.curveSegments !== undefined ) data.options.curveSegments = options.curveSegments;
+	if ( options.steps !== undefined ) data.options.steps = options.steps;
+	if ( options.amount !== undefined ) data.options.amount = options.amount;
+	if ( options.bevelEnabled !== undefined ) data.options.bevelEnabled = options.bevelEnabled;
+	if ( options.bevelThickness !== undefined ) data.options.bevelThickness = options.bevelThickness;
+	if ( options.bevelSize !== undefined ) data.options.bevelSize = options.bevelSize;
+	if ( options.bevelSegments !== undefined ) data.options.bevelSegments = options.bevelSegments;
+	if ( options.extrudePath !== undefined ) data.options.extrudePath = options.extrudePath.toJSON();
+
+	return data;
+
+}
 
 
 export { ExtrudeGeometry, ExtrudeBufferGeometry };

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -52,6 +52,7 @@ import { BufferGeometryLoader } from './BufferGeometryLoader.js';
 import { JSONLoader } from './JSONLoader.js';
 import { FileLoader } from './FileLoader.js';
 import * as Geometries from '../geometries/Geometries.js';
+import * as Curves from '../extras/curves/Curves.js';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -364,7 +365,6 @@ Object.assign( ObjectLoader.prototype, {
 						for ( var i = 0, l = data.shapes.length; i < l; i ++ ) {
 
 							var shape = shapes[ data.shapes[ i ] ];
-
 							geometryShapes.push( shape );
 
 						}
@@ -372,6 +372,50 @@ Object.assign( ObjectLoader.prototype, {
 						geometry = new Geometries[ data.type ](
 							geometryShapes,
 							data.curveSegments
+						);
+
+						break;
+
+					case 'ExtrudeGeometry':
+					case 'ExtrudeBufferGeometry':
+
+						// shapes
+
+						var geometryShapes = [];
+
+						for ( var i = 0, l = data.shapes.length; i < l; i ++ ) {
+
+							var shape = shapes[ data.shapes[ i ] ];
+							geometryShapes.push( shape );
+
+						}
+
+						// extrudePath
+
+						var options = data.options;
+						var extrudePath = options.extrudePath;
+						var path;
+
+						if ( extrudePath !== undefined ) {
+
+							path = new Curves[ extrudePath.type ]().fromJSON( extrudePath );
+
+						}
+
+						//
+
+						geometry = new Geometries[ data.type ](
+							geometryShapes,
+							{
+								curveSegments: options.curveSegments,
+								steps: options.steps,
+								amount: options.amount,
+								bevelEnabled: options.bevelEnabled,
+								bevelThickness: options.bevelThickness,
+								bevelSize: options.bevelSize,
+								bevelSegments: options.bevelSegments,
+								extrudePath: path
+							}
 						);
 
 						break;


### PR DESCRIPTION
Follow up to #12797

This PR adds serialization/ deserialization to `ExtrudeGeometry` and `ExtrudeBufferGeometry`. So `ObjectLoader` is now able to load the geometry.

I've used the opportunity and refactored `ExtrudeGeometry` at certain places. The former public methods `.getArrays()`, `.addShapeList()` and `.addShape()` are removed. The code looks now a little bit more like all other geometries.

Besides, I've removed the possibility to add frenet frames data and a custom UVGenerator as a parameter. The default `UVGenerator` can be overwritten by the user, so this is still configurable. The frenet frames thing was most likely not used. In any event, with the new signature the entity is much easier to serialize than before. And all examples still work without adjustments.

Demo: https://jsfiddle.net/j3u9jLj7/3/