### PR TITLE
Editor: make UI inputs nudgeable

### DIFF
--- a/editor/js/Sidebar.Geometry.js
+++ b/editor/js/Sidebar.Geometry.js
@@ -138,6 +138,10 @@ Sidebar.Geometry = function ( editor ) {
 	var parameters = new UI.Span();
 	container.add( parameters );
 
+	// Keep track of the geometry type that we last used to
+	// populate parameters so that we avoid re-creating them
+	// when unnecessary.
+	var lastGeometryType = null;
 
 	//
 
@@ -158,16 +162,21 @@ Sidebar.Geometry = function ( editor ) {
 
 			//
 
-			parameters.clear();
+			var newGeometryType = geometry.type;
+			if (newGeometryType !== lastGeometryType) {
+				lastGeometryType = newGeometryType;
 
-			if ( geometry.type === 'BufferGeometry' || geometry.type === 'Geometry' ) {
+				parameters.clear();
 
-				parameters.add( new Sidebar.Geometry.Modifiers( editor, object ) );
+				if ( geometry.type === 'BufferGeometry' || geometry.type === 'Geometry' ) {
 
-			} else if ( Sidebar.Geometry[ geometry.type ] !== undefined ) {
+					parameters.add( new Sidebar.Geometry.Modifiers( editor, object ) );
 
-				parameters.add( new Sidebar.Geometry[ geometry.type ]( editor, object ) );
+				} else if ( Sidebar.Geometry[ geometry.type ] !== undefined ) {
 
+					parameters.add( new Sidebar.Geometry[ geometry.type ]( editor, object ) );
+
+				}
 			}
 
 		} else {

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -534,6 +534,25 @@ UI.Color.prototype.setHexValue = function ( hex ) {
 
 // Number
 
+UI.nudgeNumericValue = function ( originalValue, keyCode, shiftKeyDown ) {
+	var parsedValue = -1;
+	try {
+		parsedValue = parseFloat( originalValue );
+	} catch ( e ) {
+		return originalValue;
+	}
+
+	var direction = 0;
+	if (keyCode === 38) {
+		direction = 1;
+	} else if (keyCode === 40) {
+		direction = -1;
+	}
+
+	var nudgeAmount = shiftKeyDown ? 10 : 1;
+	return parsedValue + direction * nudgeAmount;
+}
+
 UI.Number = function ( number ) {
 
 	UI.Element.call( this );
@@ -543,14 +562,6 @@ UI.Number = function ( number ) {
 	var dom = document.createElement( 'input' );
 	dom.className = 'Number';
 	dom.value = '0.00';
-
-	dom.addEventListener( 'keydown', function ( event ) {
-
-		event.stopPropagation();
-
-		if ( event.keyCode === 13 ) dom.blur();
-
-	}, false );
 
 	this.value = 0;
 
@@ -573,6 +584,23 @@ UI.Number = function ( number ) {
 
 	var pointer = [ 0, 0 ];
 	var prevPointer = [ 0, 0 ];
+
+	dom.addEventListener( 'keydown', function ( event ) {
+
+		event.stopPropagation();
+
+		if ( event.keyCode === 13 ) {
+			dom.blur();
+		}
+
+		if ( event.keyCode === 38 || event.keyCode === 40 ) {
+			var nudgedValue = UI.nudgeNumericValue( scope.getValue(), event.keyCode, event.shiftKey )
+			scope.setValue( nudgedValue );
+			event.preventDefault();
+			dom.dispatchEvent( changeEvent );
+		};
+
+	}, false );
 
 	function onMouseDown( event ) {
 
@@ -730,12 +758,6 @@ UI.Integer = function ( number ) {
 	dom.className = 'Number';
 	dom.value = '0';
 
-	dom.addEventListener( 'keydown', function ( event ) {
-
-		event.stopPropagation();
-
-	}, false );
-
 	this.value = 0;
 
 	this.min = - Infinity;
@@ -755,6 +777,19 @@ UI.Integer = function ( number ) {
 
 	var pointer = [ 0, 0 ];
 	var prevPointer = [ 0, 0 ];
+
+	dom.addEventListener( 'keydown', function ( event ) {
+
+		event.stopPropagation();
+
+		if ( event.keyCode === 38 || event.keyCode === 40 ) {
+			var nudgedValue = UI.nudgeNumericValue( scope.getValue(), event.keyCode, event.shiftKey )
+			scope.setValue( nudgedValue );
+			event.preventDefault();
+			dom.dispatchEvent( changeEvent );
+		};
+
+	}, false );
 
 	function onMouseDown( event ) {
 


### PR DESCRIPTION
This PR addresses issue https://github.com/mrdoob/three.js/issues/12916

Short description: in Chrome dev tools, you can select a CSS value like `10px` and hit the up key on your keyboard to change it to `11px`, or shift + up to change it to `20px`. Likewise for down. This PR implements similar functionality in the Three JS editor.

Here is a demo of it working:

![nudgeable-inputs-demo](https://user-images.githubusercontent.com/945937/34191576-efbdfed8-e4fc-11e7-8b5f-2e6a99540e99.gif)
