### PR TITLE
FBXLoader: allow BinaryParser.getString to use new LoaderUtils.decodeText method

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3650,11 +3650,15 @@
 
 		getString: function ( size ) {
 
-			var s = THREE.LoaderUtils.decodeText( this.getUint8Array( size ) );
+			var a = new Uint8Array( size );
 
-			this.skip( size );
+			for ( var i = 0; i < size; i ++ ) {
 
-			return s;
+				a[ i ] = this.getUint8();
+
+			}
+
+			return THREE.LoaderUtils.decodeText( a );
 
 		}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3650,13 +3650,13 @@
 
 		getString: function ( size ) {
 
-			var a = new Uint8Array( size );
+			var a = new Uint8Array( this.getUint8Array( size ) );
 
-			for ( var i = 0; i < size; i ++ ) {
+			// for ( var i = 0; i < size; i ++ ) {
 
-				a[ i ] = this.getUint8();
+			// 	a[ i ] = this.getUint8();
 
-			}
+			// }
 
 			return THREE.LoaderUtils.decodeText( a );
 


### PR DESCRIPTION
See #12924 for details