### PR TITLE
FBXLoader: Restore break condition to getString

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3650,15 +3650,25 @@
 
 		getString: function ( size ) {
 
-			var a = new Uint8Array( this.getUint8Array( size ) );
+			var a = [];
 
-			// for ( var i = 0; i < size; i ++ ) {
+			while ( size > 0 ) {
 
-			// 	a[ i ] = this.getUint8();
+				var value = this.getUint8();
+				size --;
 
-			// }
+				if ( value === 0 ) {
 
-			return THREE.LoaderUtils.decodeText( a );
+					this.skip( size );
+					break;
+
+				}
+
+				a.push( value );
+
+			}
+
+			return THREE.LoaderUtils.decodeText( new Uint8Array( a ) );
 
 		}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3650,25 +3650,11 @@
 
 		getString: function ( size ) {
 
-			var a = [];
+			var a = new Uint8Array( this.getUint8Array( size ) );
+			var nullByte = a.indexOf( 0 );
+			if ( nullByte >= 0 ) a = a.slice( 0, nullByte );
 
-			while ( size > 0 ) {
-
-				var value = this.getUint8();
-				size --;
-
-				if ( value === 0 ) {
-
-					this.skip( size );
-					break;
-
-				}
-
-				a.push( value );
-
-			}
-
-			return THREE.LoaderUtils.decodeText( new Uint8Array( a ) );
+			return THREE.LoaderUtils.decodeText( a );
 
 		}
 


### PR DESCRIPTION
Seems like I was a bit presumptious in removing the `break` condition from this method. 

At this point, the method is nearly identical to what it was before the `THREE.LoaderUtils.decodeText` was introduced in the first place, and since we are parsing many short strings with this method (all names, attributes etc for the loaded models pass through here individually), I think that instantiating a new TextDecoder instance for each is likely to be less efficient, not more. 

@donmccurdy if this method is called, say, 800 times during load and every string is <100 characters, do you think it would be more efficient to stick with the for loop using `String.fromCharCode` here?