### PR TITLE
FBXLoader+LoaderUtils: Optimize getUint8Array().

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3402,14 +3402,8 @@
 
 		getUint8Array: function ( size ) {
 
-			var a = [];
-
-			for ( var i = 0; i < size; i ++ ) {
-
-				a.push( this.getUint8() );
-
-			}
-
+			var a = new Uint8Array( this.dv.buffer, this.offset, size );
+			this.offset += size;
 			return a;
 
 		},
@@ -3650,7 +3644,7 @@
 
 		getString: function ( size ) {
 
-			var a = new Uint8Array( this.getUint8Array( size ) );
+			var a = this.getUint8Array( size );
 			var nullByte = a.indexOf( 0 );
 			if ( nullByte >= 0 ) a = a.slice( 0, nullByte );
 

--- a/src/loaders/LoaderUtils.js
+++ b/src/loaders/LoaderUtils.js
@@ -4,30 +4,38 @@
 
 var LoaderUtils = {
 
-	decodeText: function ( array ) {
+	decodeText: (function () {
 
-		if ( typeof TextDecoder !== 'undefined' ) {
+		var textDecoder;
 
-			return new TextDecoder().decode( array );
+		return function ( array ) {
 
-		}
+			if ( typeof TextDecoder !== 'undefined' ) {
 
-		// Avoid the String.fromCharCode.apply(null, array) shortcut, which
-		// throws a "maximum call stack size exceeded" error for large arrays.
+				if ( !textDecoder ) textDecoder = new TextDecoder();
 
-		var s = '';
+				return textDecoder.decode( array );
 
-		for ( var i = 0, il = array.length; i < il; i ++ ) {
+			}
 
-			// Implicitly assumes little-endian.
-			s += String.fromCharCode( array[ i ] );
+			// Avoid the String.fromCharCode.apply(null, array) shortcut, which
+			// throws a "maximum call stack size exceeded" error for large arrays.
 
-		}
+			var s = '';
 
-		// Merges multi-byte utf-8 characters.
-		return decodeURIComponent( escape( s ) );
+			for ( var i = 0, il = array.length; i < il; i ++ ) {
 
-	},
+				// Implicitly assumes little-endian.
+				s += String.fromCharCode( array[ i ] );
+
+			}
+
+			// Merges multi-byte utf-8 characters.
+			return decodeURIComponent( escape( s ) );
+
+		};
+
+	}()),
 
 	extractUrlBase: function ( url ) {
 


### PR DESCRIPTION
@looeee The only FBX models I have that are invoking this method are also requiring some Inflate.js library, and I can't find a dist file on the [repo](https://github.com/imaya/zlib.js). Do you have a way to test this? In any case the output arrays look the same before and after.

One other thing to note is that if this array were modified (it isn't currently) the underlying dataview would now be altered too; the data isn't copied.