### PR TITLE
Passes variable name to be consistent with Other passes

### DIFF
--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -117,12 +117,12 @@ THREE.AdaptiveToneMappingPass = function ( adaptive, resolution ) {
 		blending: THREE.NoBlending
 	} );
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene2  = new THREE.Scene();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 };
 
@@ -148,7 +148,7 @@ THREE.AdaptiveToneMappingPass.prototype = Object.assign( Object.create( THREE.Pa
 			//Render the luminance of the current scene into a render target with mipmapping enabled
 			this.quad.material = this.materialLuminance;
 			this.materialLuminance.uniforms.tDiffuse.value = readBuffer.texture;
-			renderer.render( this.scene, this.camera, this.currentLuminanceRT );
+			renderer.render( this.scene2, this.camera2, this.currentLuminanceRT );
 
 			//Use the new luminance values, the previous luminance and the frame delta to
 			//adapt the luminance over time.
@@ -156,12 +156,12 @@ THREE.AdaptiveToneMappingPass.prototype = Object.assign( Object.create( THREE.Pa
 			this.materialAdaptiveLum.uniforms.delta.value = delta;
 			this.materialAdaptiveLum.uniforms.lastLum.value = this.previousLuminanceRT.texture;
 			this.materialAdaptiveLum.uniforms.currentLum.value = this.currentLuminanceRT.texture;
-			renderer.render( this.scene, this.camera, this.luminanceRT );
+			renderer.render( this.scene2, this.camera2, this.luminanceRT );
 
 			//Copy the new adapted luminance value so that it can be used by the next frame.
 			this.quad.material = this.materialCopy;
 			this.copyUniforms.tDiffuse.value = this.luminanceRT.texture;
-			renderer.render( this.scene, this.camera, this.previousLuminanceRT );
+			renderer.render( this.scene2, this.camera2, this.previousLuminanceRT );
 
 		}
 
@@ -170,11 +170,11 @@ THREE.AdaptiveToneMappingPass.prototype = Object.assign( Object.create( THREE.Pa
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( this.scene, this.camera );
+			renderer.render( this.scene2, this.camera2 );
 
 		} else {
 
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
+			renderer.render( this.scene2, this.camera2, writeBuffer, this.clear );
 
 		}
 
@@ -225,9 +225,9 @@ THREE.AdaptiveToneMappingPass.prototype = Object.assign( Object.create( THREE.Pa
 		this.materialLuminance.needsUpdate = true;
 		this.materialAdaptiveLum.needsUpdate = true;
 		this.materialToneMap.needsUpdate = true;
-		// renderer.render( this.scene, this.camera, this.luminanceRT );
-		// renderer.render( this.scene, this.camera, this.previousLuminanceRT );
-		// renderer.render( this.scene, this.camera, this.currentLuminanceRT );
+		// renderer.render( this.scene2, this.camera2, this.luminanceRT );
+		// renderer.render( this.scene2, this.camera2, this.previousLuminanceRT );
+		// renderer.render( this.scene2, this.camera2, this.currentLuminanceRT );
 
 	},
 

--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -67,12 +67,12 @@ THREE.BloomPass = function ( strength, kernelSize, sigma, resolution ) {
 
 	this.needsSwap = false;
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene2  = new THREE.Scene();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 };
 
@@ -91,7 +91,7 @@ THREE.BloomPass.prototype = Object.assign( Object.create( THREE.Pass.prototype )
 		this.convolutionUniforms[ "tDiffuse" ].value = readBuffer.texture;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurX;
 
-		renderer.render( this.scene, this.camera, this.renderTargetX, true );
+		renderer.render( this.scene2, this.camera2, this.renderTargetX, true );
 
 
 		// Render quad with blured scene into texture (convolution pass 2)
@@ -99,7 +99,7 @@ THREE.BloomPass.prototype = Object.assign( Object.create( THREE.Pass.prototype )
 		this.convolutionUniforms[ "tDiffuse" ].value = this.renderTargetX.texture;
 		this.convolutionUniforms[ "uImageIncrement" ].value = THREE.BloomPass.blurY;
 
-		renderer.render( this.scene, this.camera, this.renderTargetY, true );
+		renderer.render( this.scene2, this.camera2, this.renderTargetY, true );
 
 		// Render original scene with superimposed blur to texture
 
@@ -109,7 +109,7 @@ THREE.BloomPass.prototype = Object.assign( Object.create( THREE.Pass.prototype )
 
 		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
 
-		renderer.render( this.scene, this.camera, readBuffer, this.clear );
+		renderer.render( this.scene2, this.camera2, readBuffer, this.clear );
 
 	}
 

--- a/examples/js/postprocessing/DotScreenPass.js
+++ b/examples/js/postprocessing/DotScreenPass.js
@@ -25,12 +25,12 @@ THREE.DotScreenPass = function ( center, angle, scale ) {
 
 	} );
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene2  = new THREE.Scene();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 };
 
@@ -47,11 +47,11 @@ THREE.DotScreenPass.prototype = Object.assign( Object.create( THREE.Pass.prototy
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( this.scene, this.camera );
+			renderer.render( this.scene2, this.camera2 );
 
 		} else {
 
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
+			renderer.render( this.scene2, this.camera2, writeBuffer, this.clear );
 
 		}
 

--- a/examples/js/postprocessing/FilmPass.js
+++ b/examples/js/postprocessing/FilmPass.js
@@ -26,12 +26,12 @@ THREE.FilmPass = function ( noiseIntensity, scanlinesIntensity, scanlinesCount, 
 	if ( scanlinesIntensity !== undefined ) this.uniforms.sIntensity.value = scanlinesIntensity;
 	if ( scanlinesCount !== undefined ) this.uniforms.sCount.value = scanlinesCount;
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene2  = new THREE.Scene();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 };
 
@@ -48,11 +48,11 @@ THREE.FilmPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ),
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( this.scene, this.camera );
+			renderer.render( this.scene2, this.camera2 );
 
 		} else {
 
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
+			renderer.render( this.scene2, this.camera2, writeBuffer, this.clear );
 
 		}
 

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -23,12 +23,12 @@ THREE.GlitchPass = function ( dt_size ) {
 		fragmentShader: shader.fragmentShader
 	} );
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene2  = new THREE.Scene();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 	this.goWild = false;
 	this.curF = 0;
@@ -77,11 +77,11 @@ THREE.GlitchPass.prototype = Object.assign( Object.create( THREE.Pass.prototype 
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( this.scene, this.camera );
+			renderer.render( this.scene2, this.camera2 );
 
 		} else {
 
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
+			renderer.render( this.scene2, this.camera2, writeBuffer, this.clear );
 
 		}
 

--- a/examples/js/postprocessing/SMAAPass.js
+++ b/examples/js/postprocessing/SMAAPass.js
@@ -100,12 +100,12 @@ THREE.SMAAPass = function ( width, height ) {
 
 	this.needsSwap = false;
 
-	this.camera = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
-	this.scene  = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( -1, 1, 1, -1, 0, 1 );
+	this.scene2  = new THREE.Scene();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 };
 
@@ -121,13 +121,13 @@ THREE.SMAAPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ),
 
 		this.quad.material = this.materialEdges;
 
-		renderer.render( this.scene, this.camera, this.edgesRT, this.clear );
+		renderer.render( this.scene2, this.camera2, this.edgesRT, this.clear );
 
 		// pass 2
 
 		this.quad.material = this.materialWeights;
 
-		renderer.render( this.scene, this.camera, this.weightsRT, this.clear );
+		renderer.render( this.scene2, this.camera2, this.weightsRT, this.clear );
 
 		// pass 3
 
@@ -137,11 +137,11 @@ THREE.SMAAPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ),
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( this.scene, this.camera );
+			renderer.render( this.scene2, this.camera2 );
 
 		} else {
 
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
+			renderer.render( this.scene2, this.camera2, writeBuffer, this.clear );
 
 		}
 

--- a/examples/js/postprocessing/SSAOPass.js
+++ b/examples/js/postprocessing/SSAOPass.js
@@ -35,8 +35,8 @@ THREE.SSAOPass = function ( scene, camera, width, height ) {
 
 	this.renderToScreen = false;
 
-	this.camera2 = camera;
-	this.scene2 = scene;
+	this.camera = camera;
+	this.scene = scene;
 
 	//Depth material
 	this.depthMaterial = new THREE.MeshDepthMaterial();
@@ -50,8 +50,8 @@ THREE.SSAOPass = function ( scene, camera, width, height ) {
 	//Shader uniforms
 	this.uniforms[ 'tDepth' ].value = this.depthRenderTarget.texture;
 	this.uniforms[ 'size' ].value.set( this.width, this.height );
-	this.uniforms[ 'cameraNear' ].value = this.camera2.near;
-	this.uniforms[ 'cameraFar' ].value = this.camera2.far;
+	this.uniforms[ 'cameraNear' ].value = this.camera.near;
+	this.uniforms[ 'cameraFar' ].value = this.camera.far;
 
 	this.uniforms[ 'radius' ].value = 4;
 	this.uniforms[ 'onlyAO' ].value = false;
@@ -100,11 +100,11 @@ THREE.SSAOPass.prototype = Object.create( THREE.ShaderPass.prototype );
 THREE.SSAOPass.prototype.render = function( renderer, writeBuffer, readBuffer, delta, maskActive ) {
 
 	//Render depth into depthRenderTarget
-	this.scene2.overrideMaterial = this.depthMaterial;
+	this.scene.overrideMaterial = this.depthMaterial;
 	
-	renderer.render( this.scene2, this.camera2, this.depthRenderTarget, true );
+	renderer.render( this.scene, this.camera, this.depthRenderTarget, true );
 	
-	this.scene2.overrideMaterial = null;
+	this.scene.overrideMaterial = null;
 
 
 	//SSAO shaderPass
@@ -120,7 +120,7 @@ THREE.SSAOPass.prototype.render = function( renderer, writeBuffer, readBuffer, d
  */
 THREE.SSAOPass.prototype.setScene = function(scene) {
 	
-	this.scene2 = scene;
+	this.scene = scene;
 
 };
 
@@ -132,10 +132,10 @@ THREE.SSAOPass.prototype.setScene = function(scene) {
  */
 THREE.SSAOPass.prototype.setCamera = function( camera ) {
 
-	this.camera2 = camera;
+	this.camera = camera;
 
-	this.uniforms[ 'cameraNear' ].value = this.camera2.near;
-	this.uniforms[ 'cameraFar' ].value = this.camera2.far;
+	this.uniforms[ 'cameraNear' ].value = this.camera.near;
+	this.uniforms[ 'cameraFar' ].value = this.camera.far;
 
 };
 

--- a/examples/js/postprocessing/SavePass.js
+++ b/examples/js/postprocessing/SavePass.js
@@ -34,12 +34,12 @@ THREE.SavePass = function ( renderTarget ) {
 
 	this.needsSwap = false;
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene2 = new THREE.Scene();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 };
 
@@ -57,7 +57,7 @@ THREE.SavePass.prototype = Object.assign( Object.create( THREE.Pass.prototype ),
 
 		this.quad.material = this.material;
 
-		renderer.render( this.scene, this.camera, this.renderTarget, this.clear );
+		renderer.render( this.scene2, this.camera2, this.renderTarget, this.clear );
 
 	}
 

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -29,12 +29,12 @@ THREE.ShaderPass = function ( shader, textureID ) {
 
 	}
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene2 = new THREE.Scene();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 };
 
@@ -54,11 +54,11 @@ THREE.ShaderPass.prototype = Object.assign( Object.create( THREE.Pass.prototype 
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( this.scene, this.camera );
+			renderer.render( this.scene2, this.camera2 );
 
 		} else {
 
-			renderer.render( this.scene, this.camera, writeBuffer, this.clear );
+			renderer.render( this.scene2, this.camera2, writeBuffer, this.clear );
 
 		}
 

--- a/examples/js/postprocessing/TexturePass.js
+++ b/examples/js/postprocessing/TexturePass.js
@@ -28,12 +28,12 @@ THREE.TexturePass = function ( map, opacity ) {
 
 	this.needsSwap = false;
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene  = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene2  = new THREE.Scene();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 };
 
@@ -52,7 +52,7 @@ THREE.TexturePass.prototype = Object.assign( Object.create( THREE.Pass.prototype
 		this.uniforms[ "tDiffuse" ].value = this.map;
 		this.material.transparent = ( this.opacity < 1.0 );
 
-		renderer.render( this.scene, this.camera, this.renderToScreen ? null : readBuffer, this.clear );
+		renderer.render( this.scene2, this.camera2, this.renderToScreen ? null : readBuffer, this.clear );
 
 		renderer.autoClear = oldAutoClear;
 	}

--- a/examples/js/postprocessing/UnrealBloomPass.js
+++ b/examples/js/postprocessing/UnrealBloomPass.js
@@ -128,14 +128,14 @@ THREE.UnrealBloomPass = function ( resolution, strength, radius, threshold ) {
 	this.oldClearColor = new THREE.Color();
 	this.oldClearAlpha = 1;
 
-	this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	this.scene = new THREE.Scene();
+	this.camera2 = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.scene2 = new THREE.Scene();
 
 	this.basic = new THREE.MeshBasicMaterial();
 
 	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
 	this.quad.frustumCulled = false; // Avoid getting clipped
-	this.scene.add( this.quad );
+	this.scene2.add( this.quad );
 
 };
 
@@ -200,7 +200,7 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 			this.quad.material = this.basic;
 			this.basic.map = readBuffer.texture;
 
-			renderer.render( this.scene, this.camera, undefined, true );
+			renderer.render( this.scene2, this.camera2, undefined, true );
 
 		}
 
@@ -210,7 +210,7 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 		this.highPassUniforms[ "luminosityThreshold" ].value = this.threshold;
 		this.quad.material = this.materialHighPassFilter;
 
-		renderer.render( this.scene, this.camera, this.renderTargetBright, true );
+		renderer.render( this.scene2, this.camera2, this.renderTargetBright, true );
 
 		// 2. Blur All the mips progressively
 
@@ -222,11 +222,11 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 
 			this.separableBlurMaterials[ i ].uniforms[ "colorTexture" ].value = inputRenderTarget.texture;
 			this.separableBlurMaterials[ i ].uniforms[ "direction" ].value = THREE.UnrealBloomPass.BlurDirectionX;
-			renderer.render( this.scene, this.camera, this.renderTargetsHorizontal[ i ], true );
+			renderer.render( this.scene2, this.camera2, this.renderTargetsHorizontal[ i ], true );
 
 			this.separableBlurMaterials[ i ].uniforms[ "colorTexture" ].value = this.renderTargetsHorizontal[ i ].texture;
 			this.separableBlurMaterials[ i ].uniforms[ "direction" ].value = THREE.UnrealBloomPass.BlurDirectionY;
-			renderer.render( this.scene, this.camera, this.renderTargetsVertical[ i ], true );
+			renderer.render( this.scene2, this.camera2, this.renderTargetsVertical[ i ], true );
 
 			inputRenderTarget = this.renderTargetsVertical[ i ];
 
@@ -239,7 +239,7 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 		this.compositeMaterial.uniforms[ "bloomRadius" ].value = this.radius;
 		this.compositeMaterial.uniforms[ "bloomTintColors" ].value = this.bloomTintColors;
 
-		renderer.render( this.scene, this.camera, this.renderTargetsHorizontal[ 0 ], true );
+		renderer.render( this.scene2, this.camera2, this.renderTargetsHorizontal[ 0 ], true );
 
 		// Blend it additively over the input texture
 
@@ -251,11 +251,11 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 
 		if ( this.renderToScreen ) {
 
-			renderer.render( this.scene, this.camera, undefined, false );
+			renderer.render( this.scene2, this.camera2, undefined, false );
 
 		} else {
 
-			renderer.render( this.scene, this.camera, readBuffer, false );
+			renderer.render( this.scene2, this.camera2, readBuffer, false );
 
 		}
 


### PR DESCRIPTION
I use many camera and postprocessing pass on the scene.
When I change each camera or each scene, Code was inefficient, because they were not consistent.
```
## Currently Example

EffectComposer.passes.map((pass, i) => {
      if (pass instanceof THREE.RenderPass) {
        pass.camera = changedCamera;
      }

      if (pass instanceof THREE.OutlinePass) {
        pass.renderCamera = changedCamera;
      }

     if (pass instanceof THREE.SSAOPass)) {
        pass.camera2= changedCamera;
      }
});

```

It can be changed efficiently

when It get from parameter,
this.scene, renderScene, scene2 => this.scene
this.camera, renderCamera, camera2  => this.camera

when It generated new object,
this.scene  => this.scene2
this.camera => this.camera2
