### PR TITLE
When a 6DOF HMD does not have room-scale setup we need to update…

### DIFF
--- a/examples/js/controls/VRControls.js
+++ b/examples/js/controls/VRControls.js
@@ -129,6 +129,7 @@ THREE.VRControls = function ( object, onError ) {
 				} else {
 
 					object.position.setY( object.position.y + this.userHeight );
+					standingMatrix.elements[ 13 ] = this.userHeight;
 
 				}
 


### PR DESCRIPTION
…the `THREE.VRControls.standingMatrix`'s y value based on the set `THREE.VRControls.userHeight`. FYI: you need:

+ A 6DOF headset and its corresponding controllers. I tested this on Windows MR Samsung Odyssey
+ You need to *not* setup room-scale, but seated mode for the HMD
+ Set `controls.standing = true;`  in your application

The reason for this -- I believe -- is because various controllers from the Gamepad API look at a standing matrix. But, if we're arbitrarily setting our controls based on parameters ( because when you don't have room-scale setup the value `vrDisplay.stageParameters` is `null` ) like the `VRControls.userHeight` then we need to propagate those settings to the `standingMatrix`.