### PR TITLE
Resolves Orientation Issues (more device control)

### DIFF
--- a/examples/js/controls/DeviceOrientationControls.js
+++ b/examples/js/controls/DeviceOrientationControls.js
@@ -1,101 +1,85 @@
 /**
  * @author richt / http://richt.me
  * @author WestLangley / http://github.com/WestLangley
- *
+ * @author MasterJames / http://master-domain.com
+ * 
  * W3C Device Orientation control (http://w3c.github.io/deviceorientation/spec-source-orientation.html)
  */
 
-THREE.DeviceOrientationControls = function( object ) {
+THREE.DeviceOrientationControls = function( camera, autoConnect, deviceLandscapeAlphaOffset, stabilityChecks, scope ) {
+	if( scope === undefined ) scope = this; // could be {} aka Object.create(null) and new becomes meaningless
+								// maybe scope should probably just be set to camera though then the next line goes too
+	scope.cam = camera;
+	camera.rotation.reorder( "YXZ" );
 
-	var scope = this;
+	scope.enabled = true;
 
-	this.object = object;
-	this.object.rotation.reorder( "YXZ" );
+	scope.screenOrientation = window.orientation || 0;
+	if( stabilityChecks !== undefined && stabilityChecks.constructor === Number ) scope.stabilityChecks = stabilityChecks;
+	else scope.stabilityChecks = 7;
+	scope.checksDone = 0;
+	if( deviceLandscapeAlphaOffset !== undefined  && deviceLandscapeAlphaOffset.constructor === Number ) scope.deviceLandscapeAlphaOffset =  deviceLandscapeAlphaOffset;
+	else {
+		if( ( navigator.userAgent || "" ).indexOf( "Android 7" ) !== -1 ) scope.deviceLandscapeAlphaOffset = -0.1;
+		else scope.deviceLandscapeAlphaOffset = 0;
+	}
 
-	this.enabled = true;
-
-	this.deviceOrientation = {};
-	this.screenOrientation = 0;
-
-	this.alphaOffset = 0; // radians
-
-	var onDeviceOrientationChangeEvent = function( event ) {
-
-		scope.deviceOrientation = event;
-
+	let onDeviceChangeEvent = function( evt ) {
+		let chkLimit = scope.stabilityChecks, chksDone = scope.checksDone;
+		if( chksDone < ( chkLimit * 3 ) ) {
+			if( chksDone > ( chkLimit * 2 ) || ( chksDone < chkLimit && ( evt.beta < 88 || evt.beta > 92 ) ) ) {
+				scope.alphaOffset = ( THREE.Math.degToRad( evt.alpha + evt.gamma ) * -1 );
+				let sOrt = Math.abs( scope.screenOrientation );
+				if( sOrt === 90 || sOrt === 270 ) {
+					if( scope.screenOrientation > 0 ) scope.alphaOffset += 0.1;
+					else scope.alphaOffset += scope.deviceLandscapeAlphaOffset;
+				}
+			}
+			scope.checksDone++;
+		}
+		scope.deviceOrientation = evt;
 	};
 
-	var onScreenOrientationChangeEvent = function() {
-
-		scope.screenOrientation = window.orientation || 0;
-
+	let onScreenChangeEvent = function() {
+		scope.screenOrientation = window.orientation;
 	};
 
 	// The angles alpha, beta and gamma form a set of intrinsic Tait-Bryan angles of type Z-X'-Y''
-
-	var setObjectQuaternion = function() {
-
-		var zee = new THREE.Vector3( 0, 0, 1 );
-
-		var euler = new THREE.Euler();
-
-		var q0 = new THREE.Quaternion();
-
-		var q1 = new THREE.Quaternion( - Math.sqrt( 0.5 ), 0, 0, Math.sqrt( 0.5 ) ); // - PI/2 around the x-axis
+	let setObjectQuaternion = ( function() {
+		let zee = new THREE.Vector3( 0, 0, 1 );
+		let euler = new THREE.Euler();
+		let q0 = new THREE.Quaternion();
+		let q1 = new THREE.Quaternion( (Math.sqrt( 0.5 ) * -1.0), 0, 0, Math.sqrt( 0.5 ) ); // - PI/2 around the x-axis
 
 		return function( quaternion, alpha, beta, gamma, orient ) {
-
-			euler.set( beta, alpha, - gamma, 'YXZ' ); // 'ZXY' for the device, but 'YXZ' for us
-
+			euler.set( beta, alpha, ( gamma * -1.0 ), 'YXZ' ); // 'ZXY' for the device, but 'YXZ' for us
 			quaternion.setFromEuler( euler ); // orient the device
-
 			quaternion.multiply( q1 ); // camera looks out the back of the device, not the top
-
-			quaternion.multiply( q0.setFromAxisAngle( zee, - orient ) ); // adjust for screen orientation
-
+			quaternion.multiply( q0.setFromAxisAngle( zee, ( orient * -1.0 ) ) ); // adjust for screen orientation
 		}
+	}() );
 
-	}();
-
-	this.connect = function() {
-
-		onScreenOrientationChangeEvent(); // run once on load
-
-		window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-		window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
-
+	scope.connect = function() {
+		onScreenChangeEvent(); // run once on load
+		window.addEventListener( 'orientationchange', onScreenChangeEvent, false );
+		window.addEventListener( 'deviceorientation', onDeviceChangeEvent, false );
 		scope.enabled = true;
-
 	};
 
-	this.disconnect = function() {
-
-		window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-		window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
-
+	scope.dispose = scope.disconnect = function() {
+		window.removeEventListener( 'orientationchange', onScreenChangeEvent, false );
+		window.removeEventListener( 'deviceorientation', onDeviceChangeEvent, false );
 		scope.enabled = false;
-
 	};
 
-	this.update = function() {
-
+	scope.update = function() {
 		if ( scope.enabled === false ) return;
-
-		var alpha = scope.deviceOrientation.alpha ? THREE.Math.degToRad( scope.deviceOrientation.alpha ) + this.alphaOffset : 0; // Z
-		var beta = scope.deviceOrientation.beta ? THREE.Math.degToRad( scope.deviceOrientation.beta ) : 0; // X'
-		var gamma = scope.deviceOrientation.gamma ? THREE.Math.degToRad( scope.deviceOrientation.gamma ) : 0; // Y''
-		var orient = scope.screenOrientation ? THREE.Math.degToRad( scope.screenOrientation ) : 0; // O
-
-		setObjectQuaternion( scope.object.quaternion, alpha, beta, gamma, orient );
-
+		let dOrt = scope.deviceOrientation;
+		if( dOrt !== undefined ) {
+			setObjectQuaternion( scope.cam.quaternion, ( THREE.Math.degToRad( dOrt.alpha ) + scope.alphaOffset ),
+				THREE.Math.degToRad( dOrt.beta ), THREE.Math.degToRad( dOrt.gamma ), THREE.Math.degToRad( scope.screenOrientation ) );
+		}
 	};
 
-	this.dispose = function() {
-
-		this.disconnect();
-
-	};
-
-	this.connect();
-
+	if( autoConnect !== false ) scope.connect();
 };


### PR DESCRIPTION
_[ We live in complicated fluctuating times, that have complicated problems, which require complicated solutions, that are complicated to explain, so please bare with me here (before 'tldr'ing it), thanks. - MJ ]_
{**Update**: after sleeping on this I've made extra changes to allow more arguments for better patching of device specific issues.
changed offChks to checksDone and made stabilityChecks an argument for the limit of checks done. added autoConnect to aid if you wish to disable it and set custom settings and call 'connect' yourself. More updates in the description below.}
https://github.com/mrdoob/three.js/commit/9447ec6b30c09df5bfb9214f8946b245b216deaf

Okay so now I finally got this one sorted out a little better. For a number of years it seems this has been dysfunctional and some of that has been related to spec and browser stability, which seems likely to remain ongoing.
My recent path of discovery uncovering this in part #12789
and initial attempts to resolve this for the record are here
https://github.com/mrdoob/three.js/pull/12798  https://github.com/mrdoob/three.js/pull/12850
That's the one @WestLangley requested to be resubmitted, which this does. {edit: actually it puts back let's}

Here's also a small list of seemingly related issues that have come up on this in the past and appear when searching on the mysterious hard to reproduce problem for cross-reference, (that seems to occur for all people platforms languages etc. )
https://github.com/mrdoob/three.js/issues/7502  https://github.com/mrdoob/three.js/issues/10552
https://stackoverflow.com/questions/36314415/add-offset-to-deviceorientationcontrols-in-three-js
{**Update**: thanks for the supportive comment there.}

**The bad user experience is that the normal 'front and center' of the browser experience or initial camera positioning is random and not predictable or stable on startup.**

**_The problem is actually three-fold:_**
**First** (and not as obvious possibly 'weakest [slowest legacy device] link' issue) when a scene is starting-up/initializing, **the device orientation (or angles of the rotational positioning of the device) are not initially stable**, so this PR adds a little delay on updating the computing the initial alphaOffset (waiting for accumulated stability in the readings),
_[ It is not related to 'absolute' magnetic compass orientation as that is not desired and added more recently to help with these issues. What we want is for the user to get the correct initial camera orientation intended you get with the browser "face-forward" regardless of their actual physical orientation.
newer 'absolute' spec reference https://developer.mozilla.org/en-US/docs/Web/API/Detecting_device_orientation ]_

The **second** issue is that **alpha offset is greatly affected by gamma or tilt** _(so z-rotation or camera direction rotations)_ {being tangled into it's Quaternion aka matrix of course they are correlated let me explain further.}
**Overall when the device is well balanced the alpha/heading fluctuates wildly** (spinning on it's well centered Y-axis). If this is set as the alphaOffset on start up it can be essentially random, without skipping those perfectly balanced beta values (aka y-axis, vertical with gravity) that in the Matrix (Quaternion) they are associated with cause random alpha values it will cause this kind of random heading problem. Note that because this is extremely difficult or rare over a few samples it is never perfectly vertical in practice and so not only fine to skip those but essential.
The **third** has to do with  **Portrait vs Landscape  screen orientation**. On my Galaxy Note 8 (Android 7) but not the Note 3 (Android 5) _[which also doesn't support WebVR]_ there is a slight offset still needed in landscape mode compared with portrait mode. Maybe that's a bug to report as well? Alas it seems there could be a need for device & OS version specific offsets?! _[I'm not sure how these can be calibrated and validated on the browser/spec hardware level, but feel it's lacking and needed.]_
The gist of this is I added a deviceLandscapeAlphaOffset that can be set via 'your' code externally, which I suppose is kind of like alphaOffset was intended but we want this calculated correctly for us on startup, I'm thinking 100% of the time and so setting alphaOffset manually at start would require setting stabilityChecks above 7 which is the number of times I randomly choose to hopefully achieve stable readings (so that too is available on scope).
I'm assuming the screenOrientation values sent are based on averages, so I didn't do an averaging in this code myself as that would never achieve the correct setting, while waiting too long is also not desired if it is correct out of the gate, but it needs to be set relatively quickly and not change henceforth.
{Update: besides realizing you might want to turn that off or extend it so it became an argument I also realized if you do have a perfect balance it wouldn't start properly/hang until you tilted past the limit (which I tightened down a couple less degrees). After twice the stability Check limit it will attempt to do the best it can even though it's typically wildly random, after 3 times the limit you get whatever it thought was best in that phase (still not averaged but there that might be better still). I can imagine when supported you could option to use the 'absolute' compass heading as well but this is not doing that. or alternately you could ask the user to tilt for calibration. It also demonstrates a device specific patch for Android 7, I only have Note 3 = Android 5 and Note 8 = Android 7, and so might report a bug there (still temporary patching is needed) [I suspect it's off by an aspect ratio difference (which I also have not attempted to validate why it's different in the latest version).]
Maybe a device specific patch list can be slowly accumulated from testers over time here too, which in turn will be submissible evidence as calibration flaws to the manufactures/OS etc.}

**_[I know it's like I say at the top not an pretty fix to a complicated and messy problem.]_**

In the future maybe the stabilityChecks for stability is flaky and becomes obsolete with better system orientation awareness (maybe more bug reports would help there too). Also one hopes there's a calibration process or the spec maintainers provide a better way to provide consistency and stability across devices. Then deviceLandscapeAlphaOffset would seem less nessecary.
{Update: for now you can disable the checking system or do it your own way (ask for calibration tilt or use compare/absolute etc.) so also adding the autoConnect argument made more sense to be able to set to false (true and undefined are both not false and default).}

**Final words about other changes to this file:**
I {originally} left 'var's as that was requested (in my previous attempt at solving this disaster) but I really believe strongly in the none verbatim words of Crockford "Sorry 'var' was bad we fixed it with 'let', but it breaks things so 'var' had to stay broken {and let was created}, but please don't use var moving forward because it's bad." New performance tests also show in the latest iterations of V8/Chrome 'let' is also picoseconds better then 'var'. I think this is a perfect place to start allowing 'let' to become standard practice.

Also I liked the use of 'scope' over 'this' so I stomped all 'this' with scope throughout, from what I understand it's more reliable/better too.
To further abolish the usage of the "var vs let" issue I use the 'scope' variable to set/export the functions like 'update' 'connect' etc.
Variables used twice or more get a local copy (typically in my books & code), in the same token things used once even for clarity don't get stored locally inside a function call (see changes to update function).

I left your setObjectQuaternion function scope wrapper with private 'var's for zee, euler & Quaternions. [discussion points omitted here]
Reduced some redundancy in naming convention lengths and empty line spaces to increase legibility being only a pages worth.

The previous version had compact 'if' statements in the 'update' function and I'm pretty sure are not needed thanks to the low probability deviceOrientation is only partially set that would be a browser spec bug and simply redundant to check per variable. Anyway works fine without it in my tests (much nicer/cleaner declaration setting checking solution now). Maybe it was a legacy issue, but it seemed cumbersome, undoubtedly slower and totally redundant at this point. Alas I'm the first to say initially set all argument's to 'defaults' mainly so all functions never fail and even expend that notion to external caching for things like zee in setObjectQuaternion if that shows performance enhancements, especially without the other fundamental design improvements therein, without stack loading scope wrapped argument values etc. [despite it flying in the face of functional programming logic, because we know those values are not changing {further it allows resetting of cached values passable as arguments...being JS is single threaded all this seemingly Socratic reverse thinking is fine. {Alas there is no "advanced class" on that stuff, so I leave it to the reader to contemplate}].

**Anyway this works better in many ways for me and hopefully others. Although it's complicated and slightly ugly it does work to get a face-forward (browser consistent) user experience when a scene loads with orientation controls**. I'm not saying it's perfect, just better for me and felt compelled to share {Update: this newer patch/PR is a couple steps closer albeit more complicated as well}.

{**Update**: after sleeping on it (to stress these Socratic points further) I thought I would add the scope in the arguments as well and if undefined set it to 'this'. It's kind of like using call or a proxy like extending Object (by returning a Proxy in it's constructor etc.). Anyway it maybe should be that scope is set to the first argument, always a 'camera' right (was object)?, or again you now have total control, so one could pass {} or Object.create(null), but it demonstrates how you don't even need really to use new, let or var on anything ever and it follows my instinct which some might know (as I'm recently discovering myself via an on going study of the history of computing) the Little Schemer's first commandment; check for undefined aka (null?). _[note: const = lol, I might actual define/hack that too like I do und for undefined but I don't use const because in an object it's over-writable unless defined properly otherwise]_ I've also put the 'let's back because this seemingly disconnected for THREE core 'example' is the right place to start introduce let in THREE finally. If you really really want me to put another commit/PR with those _ var's back I will. (I just can't resist to try once again to Socratic-ly push the voice of reason.) }

Sorry I missed 89r on this one.
{Update: Oh actually this isn't part of the core stuff for some reason anyway? maybe because it's so broken without this resolving patch, which remains messy but working. Note: so far I got one grateful comment of thanks in SO from someone clearly deeply concerned for a long hopeless time over this.}

**Congratulations on 89r and I wish for many Happy Thankful Holidays to all supporting "THREE js ~ The future of computing today."**