### PR TITLE
Fixed spelling colour => color

### DIFF
--- a/docs/api/objects/Mesh.html
+++ b/docs/api/objects/Mesh.html
@@ -68,7 +68,7 @@
 		<h3>[property:Material material]</h3>
 		<div>
 			An instance of material derived from the [page:Material] base class or an array of materials, defining the
-			object's appearance. Default is a [page:MeshBasicMaterial] with a random colour.
+			object's appearance. Default is a [page:MeshBasicMaterial] with a random color.
 		</div>
 
 		<h3>[property:Array morphTargetInfluences]</h3>

--- a/docs/api/objects/Points.html
+++ b/docs/api/objects/Points.html
@@ -51,7 +51,7 @@
 		<h3>[property:Material material]</h3>
 		<div>
 			An instance of [page:Material], defining the object's appearance.
-			Default is a [page:PointsMaterial] with a random colour.
+			Default is a [page:PointsMaterial] with a random color.
 		</div>
 
 

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -4424,7 +4424,7 @@
         },
         "material": {
           "!type": "+THREE.Material",
-          "!doc": "An instance of [page:Material], defining the object's appearance. Default is a [page:MeshBasicMaterial] with wireframe mode enabled and randomised colour."
+          "!doc": "An instance of [page:Material], defining the object's appearance. Default is a [page:MeshBasicMaterial] with wireframe mode enabled and randomised color."
         },
         "getMorphTargetIndexByName": {
           "!type": "fn(name: string) -> number",
@@ -4528,7 +4528,7 @@
         },
         "material": {
           "!type": "+THREE.Material",
-          "!doc": "An instance of [page:Material], defining the object's appearance. Default is a [page:PointCloudMaterial] with randomised colour."
+          "!doc": "An instance of [page:Material], defining the object's appearance. Default is a [page:PointCloudMaterial] with randomised color."
         },
         "clone": {
           "!type": "fn() -> +THREE.PointCloud",

--- a/examples/js/ShaderGodRays.js
+++ b/examples/js/ShaderGodRays.js
@@ -109,7 +109,7 @@ THREE.ShaderGodRays = {
 					// Accumulate samples, making sure we dont walk past the light source.
 
 					// The check for uv.y < 1 would not be necessary with "border" UV wrap
-					// mode, with a black border colour. I don't think this is currently
+					// mode, with a black border color. I don't think this is currently
 					// exposed by three.js. As a result there might be artifacts when the
 					// sun is to the left, right or bottom of screen as these cases are
 					// not specifically handled.

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -185,8 +185,8 @@
 							"float viewDot = abs(dot( normal, viewPosition ));",
 							"viewDot = clamp( pow( viewDot + 0.6, 10.0 ), 0.0, 1.0);",
 
-							"vec3 colour = vec3( 0.05, 0.09, 0.13 ) * dirDiffuse;",
-							"gl_FragColor = vec4( colour, viewDot );",
+							"vec3 color = vec3( 0.05, 0.09, 0.13 ) * dirDiffuse;",
+							"gl_FragColor = vec4( color, viewDot );",
 
 						"}"
 
@@ -272,9 +272,9 @@
 					"void main() {",
 
 						"vec2 sampleUV = vUv;",
-						"vec4 colour = texture2D( map, sampleUV, 0.0 );",
+						"vec4 color = texture2D( map, sampleUV, 0.0 );",
 
-						"gl_FragColor = vec4( colour.xyz, 1.0 );",
+						"gl_FragColor = vec4( color.xyz, 1.0 );",
 
 					"}"
 


### PR DESCRIPTION
Not a real error, but many frowns at mixing British and US English, so I thought it's better to keep it consistent US English, especially since color is also a common keyword.