### PR TITLE
GLTFExporter Fix Morph

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -798,13 +798,21 @@ THREE.GLTFExporter.prototype = {
 
 					var target = {};
 
+					var warned = false;
+
 					for ( var attributeName in geometry.morphAttributes ) {
 
 						// glTF 2.0 morph supports only POSITION/NORMAL/TANGENT.
-						//
-						// @TODO TANGENT support
+						// Three.js doesn't support TANGENT yet.
 
 						if ( attributeName !== 'position' && attributeName !== 'normal' ) {
+
+							if ( ! warned ) {
+
+								console.warn( 'GLTFExporter: Only POSITION and NORMAL morph are supported.' );
+								warned = true;
+
+							}
 
 							continue;
 
@@ -812,20 +820,18 @@ THREE.GLTFExporter.prototype = {
 
 						var attribute = geometry.morphAttributes[ attributeName ][ i ];
 
-						// Three.js morph attribute has absolute values
-						// while the one of glTF has relative values.
-						// So we convert here.
+						// Three.js morph attribute has absolute values while the one of glTF has relative values.
 						//
 						// glTF 2.0 Specification:
 						// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#morph-targets
 
 						var baseAttribute = geometry.attributes[ attributeName ];
 						// Clones attribute not to override
-						var attribute2 = attribute.clone();
+						var relativeAttribute = attribute.clone();
 
 						for ( var j = 0, jl = attribute.count; j < jl; j ++ ) {
 
-							attribute2.setXYZ(
+							relativeAttribute.setXYZ(
 								j,
 								attribute.getX( j ) - baseAttribute.getX( j ),
 								attribute.getY( j ) - baseAttribute.getY( j ),
@@ -834,7 +840,7 @@ THREE.GLTFExporter.prototype = {
 
 						}
 
-						target[ attributeName.toUpperCase() ] = processAccessor( attribute2, geometry );
+						target[ attributeName.toUpperCase() ] = processAccessor( relativeAttribute, geometry );
 
 					}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -800,9 +800,41 @@ THREE.GLTFExporter.prototype = {
 
 					for ( var attributeName in geometry.morphAttributes ) {
 
+						// glTF 2.0 morph supports only POSITION/NORMAL/TANGENT.
+						//
+						// @TODO TANGENT support
+
+						if ( attributeName !== 'position' && attributeName !== 'normal' ) {
+
+							continue;
+
+						}
+
 						var attribute = geometry.morphAttributes[ attributeName ][ i ];
-						attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();
-						target[ attributeName ] = processAccessor( attribute, geometry );
+
+						// Three.js morph attribute has absolute values
+						// while the one of glTF has relative values.
+						// So we convert here.
+						//
+						// glTF 2.0 Specification:
+						// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#morph-targets
+
+						var baseAttribute = geometry.attributes[ attributeName ];
+						// Clones attribute not to override
+						var attribute2 = attribute.clone();
+
+						for ( var j = 0, jl = attribute.count; j < jl; j ++ ) {
+
+							attribute2.setXYZ(
+								j,
+								attribute.getX( j ) - baseAttribute.getX( j ),
+								attribute.getY( j ) - baseAttribute.getY( j ),
+								attribute.getZ( j ) - baseAttribute.getZ( j )
+							);
+
+						}
+
+						target[ attributeName.toUpperCase() ] = processAccessor( attribute2, geometry );
 
 					}
 


### PR DESCRIPTION
This PR fixes `GLTFExporter` Morph.

- glTF 2.0 morph supports only POSITION/NORMAL/TANGENT. So let's skip others.
- Three.js morph attribute has absolute values while the one of glTF has relative values. So we need to convert.

You can see that the second one fixes a morph issue on Don's glTF viewer
https://gltf-viewer.donmccurdy.com/

Without this change [scene.zip](https://github.com/mrdoob/three.js/files/1585993/scene.zip)
With this change [scene_fix.zip](https://github.com/mrdoob/three.js/files/1585994/scene_fix.zip)

Zip files include glTF AnimationMorphCube model loaded with `GLTFLoader` and then exported with `GLTFExporter`

https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/AnimatedMorphCube

/cc @fernandojsg @donmccurdy 