### PR TITLE
Simplify PropertyBinding.findNode() a bit

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -204,29 +204,17 @@ Object.assign( PropertyBinding, {
 		// search into skeleton bones.
 		if ( root.skeleton ) {
 
-			var searchSkeleton = function ( skeleton ) {
+			var skeleton = root.skeleton;
 
-				for ( var i = 0; i < skeleton.bones.length; i ++ ) {
+			for ( var i = 0, il = skeleton.bones.length; i < il; i ++ ) {
 
-					var bone = skeleton.bones[ i ];
+				var bone = skeleton.bones[ i ];
 
-					if ( bone.name === nodeName ) {
+				if ( bone.name === nodeName ) {
 
-						return bone;
-
-					}
+					return bone;
 
 				}
-
-				return null;
-
-			};
-
-			var bone = searchSkeleton( root.skeleton );
-
-			if ( bone ) {
-
-				return bone;
 
 			}
 


### PR DESCRIPTION
I don't see any reasons why `searchSkeleton()` is a function. Let's flat it.
