### PR TITLE
Update JSONLoader

### DIFF
--- a/docs/api/loaders/JSONLoader.html
+++ b/docs/api/loaders/JSONLoader.html
@@ -11,7 +11,7 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-			A loader for loading objects in JSON format.
+			A loader for loading single objects in JSON format (for loading multiple objects consider using GLTFLoader).
 			This uses the [page:FileLoader] internally for loading files.
 		</div>
 


### PR DESCRIPTION
Hi, I faced the issue that JSONLoader works perfectly, but only for single files.
While loading multiple objects, as for example complete scene, it proposes in console to switch to ObjectLoader.
However, ObjectLoader has multiple bugs (only one material per object, no textures can be used in material), so I found GLTFLoader as alternative.
As many people may face this issue, I propose this correction