### PR TITLE
Add findBoneByName() to Skeleton

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -219,25 +219,7 @@ Object.assign( PropertyBinding, {
 		// search into skeleton bones.
 		if ( root.skeleton ) {
 
-			var searchSkeleton = function ( skeleton ) {
-
-				for ( var i = 0; i < skeleton.bones.length; i ++ ) {
-
-					var bone = skeleton.bones[ i ];
-
-					if ( bone.name === nodeName ) {
-
-						return bone;
-
-					}
-
-				}
-
-				return null;
-
-			};
-
-			var bone = searchSkeleton( root.skeleton );
+			var bone = root.skeleton.findBoneByName( nodeName );
 
 			if ( bone ) {
 

--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -219,9 +219,9 @@ Object.assign( PropertyBinding, {
 		// search into skeleton bones.
 		if ( root.skeleton ) {
 
-			var bone = root.skeleton.findBoneByName( nodeName );
+			var bone = root.skeleton.getBoneByName( nodeName );
 
-			if ( bone ) {
+			if ( bone !== undefined ) {
 
 				return bone;
 

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -154,7 +154,7 @@ Object.assign( Skeleton.prototype, {
 
 	},
 
-	findBoneByName: function ( name ) {
+	getBoneByName: function ( name ) {
 
 		for ( var i = 0, il = this.bones.length; i < il; i ++ ) {
 
@@ -168,7 +168,7 @@ Object.assign( Skeleton.prototype, {
 
 		}
 
-		return null;
+		return undefined;
 
 	}
 

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -152,6 +152,24 @@ Object.assign( Skeleton.prototype, {
 
 		return new Skeleton( this.bones, this.boneInverses );
 
+	},
+
+	findBoneByName: function ( name ) {
+
+		for ( var i = 0, il = this.bones.length; i < il; i ++ ) {
+
+			var bone = this.bones[ i ];
+
+			if ( bone.name === name ) {
+
+				return bone;
+
+			}
+
+		}
+
+		return null;
+
 	}
 
 } );


### PR DESCRIPTION
This PR adds an useful method `findBoneByName()` to `Skeleton`.

At least `PropertyBinding` uses and `GLTFExporter` would use #12975

Do you folks think `SkinnedMesh` also should have that method?