### PR TITLE
Resolves Orientation Controls (watered down version)

### DIFF
--- a/examples/js/controls/DeviceOrientationControls.js
+++ b/examples/js/controls/DeviceOrientationControls.js
@@ -1,101 +1,81 @@
 /**
  * @author richt / http://richt.me
  * @author WestLangley / http://github.com/WestLangley
- *
+ * @author MasterJames / http://master-domain.com
+ * 
  * W3C Device Orientation control (http://w3c.github.io/deviceorientation/spec-source-orientation.html)
  */
 
-THREE.DeviceOrientationControls = function( object ) {
-
+THREE.DeviceOrientationControls = function( camera, autoConnect ) {
 	var scope = this;
+	scope.cam = camera;
+	camera.rotation.reorder( "YXZ" );
 
-	this.object = object;
-	this.object.rotation.reorder( "YXZ" );
+	scope.enabled = true;
 
-	this.enabled = true;
+	scope.screenOrientation = window.orientation || 0;
+	scope.stabilityChecks = 7;
+	scope.checksDone = 0;
+	if( ( navigator.userAgent || "" ).indexOf( "Android 7" ) !== -1 ) scope.deviceLandscapeAlphaOffset = -0.1;
+	else scope.deviceLandscapeAlphaOffset = 0;
 
-	this.deviceOrientation = {};
-	this.screenOrientation = 0;
-
-	this.alphaOffset = 0; // radians
-
-	var onDeviceOrientationChangeEvent = function( event ) {
-
-		scope.deviceOrientation = event;
-
+	var onDeviceChangeEvent = function( evt ) {
+		var chkLimit = scope.stabilityChecks, chksDone = scope.checksDone;
+		if( chksDone < ( chkLimit * 3 ) ) {
+			if( chksDone > ( chkLimit * 2 ) || ( chksDone < chkLimit && ( evt.beta < 88 || evt.beta > 92 ) ) ) {
+				scope.alphaOffset = ( THREE.Math.degToRad( evt.alpha + evt.gamma ) * -1 );
+				var sOrt = Math.abs( scope.screenOrientation );
+				if( sOrt === 90 || sOrt === 270 ) {
+					if( scope.screenOrientation > 0 ) scope.alphaOffset += 0.1;
+					else scope.alphaOffset += scope.deviceLandscapeAlphaOffset;
+				}
+			}
+			scope.checksDone++;
+		}
+		scope.deviceOrientation = evt;
 	};
 
-	var onScreenOrientationChangeEvent = function() {
-
-		scope.screenOrientation = window.orientation || 0;
-
+	var onScreenChangeEvent = function() {
+		scope.screenOrientation = window.orientation;
 	};
 
 	// The angles alpha, beta and gamma form a set of intrinsic Tait-Bryan angles of type Z-X'-Y''
-
-	var setObjectQuaternion = function() {
-
+	var setObjectQuaternion = ( function() {
 		var zee = new THREE.Vector3( 0, 0, 1 );
-
 		var euler = new THREE.Euler();
-
 		var q0 = new THREE.Quaternion();
-
-		var q1 = new THREE.Quaternion( - Math.sqrt( 0.5 ), 0, 0, Math.sqrt( 0.5 ) ); // - PI/2 around the x-axis
+		var q1 = new THREE.Quaternion( (Math.sqrt( 0.5 ) * -1.0), 0, 0, Math.sqrt( 0.5 ) ); // - PI/2 around the x-axis
 
 		return function( quaternion, alpha, beta, gamma, orient ) {
-
-			euler.set( beta, alpha, - gamma, 'YXZ' ); // 'ZXY' for the device, but 'YXZ' for us
-
+			euler.set( beta, alpha, ( gamma * -1.0 ), 'YXZ' ); // 'ZXY' for the device, but 'YXZ' for us
 			quaternion.setFromEuler( euler ); // orient the device
-
 			quaternion.multiply( q1 ); // camera looks out the back of the device, not the top
-
-			quaternion.multiply( q0.setFromAxisAngle( zee, - orient ) ); // adjust for screen orientation
-
+			quaternion.multiply( q0.setFromAxisAngle( zee, ( orient * -1.0 ) ) ); // adjust for screen orientation
 		}
+	}() );
 
-	}();
-
-	this.connect = function() {
-
-		onScreenOrientationChangeEvent(); // run once on load
-
-		window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-		window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
-
+	scope.connect = function() {
+		onScreenChangeEvent(); // run once on load
+		window.addEventListener( 'orientationchange', onScreenChangeEvent, false );
+		window.addEventListener( 'deviceorientation', onDeviceChangeEvent, false );
 		scope.enabled = true;
-
 	};
 
-	this.disconnect = function() {
-
-		window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-		window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
-
+	scope.dispose = scope.disconnect = function() {
+		window.removeEventListener( 'orientationchange', onScreenChangeEvent, false );
+		window.removeEventListener( 'deviceorientation', onDeviceChangeEvent, false );
 		scope.enabled = false;
-
 	};
 
-	this.update = function() {
-
+	scope.update = function() {
 		if ( scope.enabled === false ) return;
-
-		var alpha = scope.deviceOrientation.alpha ? THREE.Math.degToRad( scope.deviceOrientation.alpha ) + this.alphaOffset : 0; // Z
-		var beta = scope.deviceOrientation.beta ? THREE.Math.degToRad( scope.deviceOrientation.beta ) : 0; // X'
-		var gamma = scope.deviceOrientation.gamma ? THREE.Math.degToRad( scope.deviceOrientation.gamma ) : 0; // Y''
-		var orient = scope.screenOrientation ? THREE.Math.degToRad( scope.screenOrientation ) : 0; // O
-
-		setObjectQuaternion( scope.object.quaternion, alpha, beta, gamma, orient );
-
+		var dOrt = scope.deviceOrientation;
+		if( dOrt !== undefined ) {
+			setObjectQuaternion( scope.cam.quaternion, ( THREE.Math.degToRad( dOrt.alpha ) + scope.alphaOffset ),
+				THREE.Math.degToRad( dOrt.beta ), THREE.Math.degToRad( dOrt.gamma ), THREE.Math.degToRad( scope.screenOrientation ) );
+		}
 	};
 
-	this.dispose = function() {
-
-		this.disconnect();
-
-	};
-
-	this.connect();
-
+	if( autoConnect !== false ) scope.connect();
+	return scope;
 };


### PR DESCRIPTION
Here is the watered down version some might prefer.
Original https://github.com/mrdoob/three.js/pull/12959
This **puts the lets back to vars** (I must note that I disagree with this.)
**Removes extra arguments except autoConnect** so the developer can still make adjustments to the scoped/exported/non-private values as needed (I'd prefer to just put all hidden functions values on scope).
I considered adding a reset of checksDone to connect method so onDeviceChangeEvent s start to recalculate when they do a re-connect, but didn't.
The developer can call 'disconnect' adjust values (including checksDone if no autoConnect) and call 'connect' again instead of having an autoConnect argument, but this seems wasteful, so to be able to override it via setting autoConnect to false makes sense to me.

All arguments are optional in JS and so it doesn't matter, it's just limiting and causes more hoops to resolve and wasted cycles having to recall them manually after they fire on creation. You have to explicitly set autoConnect to false to proceed with manual settings/fixes and the calling of 'connect', so it's noted that it is still as none breaking as was the extra argument way.
_I originally put scope as an argument to hammer home the point that you do NOT need let or var at all really. Since you can use 'call' to set 'this' to your own object then you still don't need it in the args or to call DeviceOrientationControls with 'new' even, **so I added that it returns the scope** which is what new does for you (also none breaking and clarifying and provides more options as putting scope as an argument)._

Then you can call it via call (without adding scope as an argument or using new even.)
`ctrls = THREE.DeviceOrientationControls.call( cam, cam );`
or
`ctrls = THREE.DeviceOrientationControls.call( {}, cam );`

_[Of course then maybe you don't need 'scope' and can just use 'this', since you know what it is (via call) and the issues with this being sometimes something else aren't as concerning. (This is still an area I'm unsure of [not being a V8 dev] but it is spoken about by Crockford as better to have your scope explicit, if just to avoid potential proxy confusion probably in more complicated class hierarchy situation I think {when I heard this it was not clarified why}. Anyway you guys had 'scope' initially I just used it instead of 'this' after it's declaration as that seemed logical and possibly more efficient being more clearly within the constructors functions scope, and I hate 'this' because it seems like it should be implied as a hoisting target {I guess that original logic is kind of stymied by strict mode thinking?}.)]_