### PR TITLE
Blender Exporter: Fixed rotation for scene export

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -180,7 +180,7 @@ def buffer_normal(mesh, options):
 
             for vertex_index in face.vertices:
                 normal = mesh.vertices[vertex_index].normal
-                vector = flip_axes(normal, _XY_Z) if face.use_smooth else flip_axes(face.normal, _XY_Z)
+                vector = flip_axes(normal, XZ_Y) if face.use_smooth else flip_axes(face.normal, XZ_Y)
                 normals_.extend(vector)
 
         # using JSON Loader with skinned mesh
@@ -249,7 +249,7 @@ def buffer_position(mesh, options):
 
             for vertex_index in face.vertices:
                 vertex = mesh.vertices[vertex_index]
-                vector = flip_axes(vertex.co, _XY_Z)
+                vector = flip_axes(vertex.co, XZ_Y)
                 position.extend(vector)
 
         # using JSON Loader with skinned mesh


### PR DESCRIPTION
Use correct rotation for static meshes when exporting scenes. 

This has been a problem for a while now (See #12806 ). I like the idea to make z-Up an option in the exporter, as described by #12784, but until now the rotation was just plain wrong, unfortunately. There are probably additional issues when it comes to lights and cameras being exported, but this PR at least makes mesh rotation be exported correctly.