### PR TITLE
RectAreaLight: light intensity is now light brightness

### DIFF
--- a/docs/api/lights/RectAreaLight.html
+++ b/docs/api/lights/RectAreaLight.html
@@ -13,13 +13,10 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-			This light gets emitted uniformly across the face a rectangular plane. This can be
-			used to simulate things like bright windows or strip lighting.<br /><br />
-
-			<em>NOTE:</em> this class is currently under active development and is probably not
-			production ready yet (as of r83). Check back in a month or two! And feel free to try it out in the meantime.
+			RectAreaLight emits light uniformly across the face a rectangular plane. This light type can be
+			used to simulate light sources such as bright windows or strip lighting.<br /><br />
+			RectAreaLight does not support shadows.<br /><br />
 		</div>
-
 
 
 
@@ -29,11 +26,12 @@
 			[example:webgl_lights_rectarealight WebGL / rectarealight ]
 
 			<code>
-var width = 2;
+var width = 10;
 var height = 10;
-var rectLight = new THREE.RectAreaLight( 0xffffff, undefined,  width, height );
-rectLight.intensity = 70.0;
+var intensity = 1;
+var rectLight = new THREE.RectAreaLight( 0xffffff, intensity,  width, height );
 rectLight.position.set( 5, 5, 0 );
+rectLight.lookAt( 0, 0, 0 );
 scene.add( rectLight )
 
 rectLightHelper = new THREE.RectAreaLightHelper( rectLight );
@@ -43,16 +41,13 @@ scene.add( rectLightHelper );
 		</div>
 
 
-
-
-
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [page:Integer color], [page:Float intensity], [page:Float width], [page:Float height] )</h3>
 		<div>
 			[page:Integer color] - (optional) hexadecimal color of the light. Default is 0xffffff (white).<br />
-			[page:Float intensity] - (optional) numeric value of the light's strength/intensity. Default is 1.<br />
+			[page:Float intensity] - (optional) the light's intensity, or brightness. Default is 1.<br />
 			[page:Float width] - (optional) width of the light. Default is 10.<br />
 			[page:Float height] - (optional) height of the light. Default is 10.<br /><br />
 
@@ -64,66 +59,12 @@ scene.add( rectLightHelper );
 			See the base [page:Light Light] class for common properties.
 		</div>
 
-
-		<h3>[property:Boolean castShadow]</h3>
-		<div>
-			<em>Note:</em> this is not yet implemented for this light type! (r83)
-		</div>
-
-		<h3>[property:Float decay]</h3>
-		<div>
-			The amount the light dims along the distance of the light.<br />
-			In [page:WebGLRenderer.physicallyCorrectLights physically correct] mode, decay = 2 leads to
-			physically realistic light falloff. The default is *1*.<br /><br />
-
-			<em>Note:</em> this is not yet implemented for this light type! (r83)
-		</div>
-
-		<h3>[property:Float distance]</h3>
-		<div>
-			If non-zero, light will attenuate linearly from maximum intensity at the light's
-			position down to zero at this distance from the light. Default is *0.0*.<br /><br />
-
-			<em>Note:</em> this is not yet implemented for this light type! (r83)
-		</div>
-
 		<h3>[property:Boolean isRectAreaLight]</h3>
 		<div>
 			Used to check whether this or derived classes are RectAreaLights. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
 		</div>
-
-		<h3>[property:Vector3 position]</h3>
-		<div>
-			This is set equal to [page:Object3D.DefaultUp] (0, 1, 0), so that the light shines from the top down.
-		</div>
-
-		<h3>[property:Object3D target]</h3>
-		<div>
-			The RectAreaLight points from its [page:.position position] to target.position. The default
-			position of the target is *(0, 0, 0)*.<br />
-
-			*Note*: For the the target's position to be changed to anything other than the default,
-			it must be added to the [page:Scene scene] using
-			<code>
-				scene.add( light.target );
-			</code>
-
-			This is so that the target's [page:Object3D.matrixWorld matrixWorld] gets automatically
-			updated each frame.<br /><br />
-
-			It is also possible to set the target to be another object in the scene (anything with a
-			[page:Object3D.position position] property), like so:
-			<code>
-var targetObject = new THREE.Object3D();
-scene.add(targetObject);
-
-light.target = targetObject;
-			</code>
-			The RectAreaLight will now track the target object.
-		</div>
-
 
 		<h2>Methods</h2>
 		<div>

--- a/examples/webgl_lights_rectarealight.html
+++ b/examples/webgl_lights_rectarealight.html
@@ -125,15 +125,11 @@
 
 				camera.position.set( 0, 20, 35 );
 
-				rectLight = new THREE.RectAreaLight( 0xffffff, 200, 10, 10 );
+				rectLight = new THREE.RectAreaLight( 0xffffff, 1, 10, 10 );
 				rectLight.position.set( 5, 5, 0 );
-
-				// TODO: ensure RectAreaLight handles target param correctly
 
 				rectLightHelper = new THREE.RectAreaLightHelper( rectLight );
 				scene.add( rectLightHelper );
-
-				// TODO (abelnation): rect light shadow
 
 				scene.add( camera );
 				scene.add( origin );
@@ -246,13 +242,13 @@
 
 				var lightFolder = gui.addFolder( 'Light' );
 
-				lightFolder.add( param, 'width', 0.1, 20 ).onChange( function ( val ) {
+				lightFolder.add( param, 'width', 1, 20 ).step( 0.1 ).onChange( function ( val ) {
 
 					rectLight.width = val;
 
 				} );
 
-				lightFolder.add( param, 'height', 0.1, 20 ).onChange( function ( val ) {
+				lightFolder.add( param, 'height', 1, 20 ).step( 0.1 ).onChange( function ( val ) {
 
 					rectLight.height = val;
 
@@ -264,7 +260,7 @@
 
 				} );
 
-				lightFolder.add( param, 'intensity', 0.0, 400 ).onChange( function ( val ) {
+				lightFolder.add( param, 'intensity', 0.0, 2 ).step( 0.01 ).onChange( function ( val ) {
 
 					rectLight.intensity = val;
 

--- a/src/lights/RectAreaLight.js
+++ b/src/lights/RectAreaLight.js
@@ -10,21 +10,11 @@ function RectAreaLight( color, intensity, width, height ) {
 
 	this.type = 'RectAreaLight';
 
-	this.position.set( 0, 1, 0 );
-	this.updateMatrix();
-
 	this.width = ( width !== undefined ) ? width : 10;
 	this.height = ( height !== undefined ) ? height : 10;
 
-	// TODO (abelnation): distance/decay
-
-	// TODO (abelnation): update method for RectAreaLight to update transform to lookat target
-
-	// TODO (abelnation): shadows
-
 }
 
-// TODO (abelnation): RectAreaLight update when light shape is changed
 RectAreaLight.prototype = Object.assign( Object.create( Light.prototype ), {
 
 	constructor: RectAreaLight,

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -224,13 +224,11 @@ function WebGLLights() {
 
 				var uniforms = cache.get( light );
 
-				// (a) intensity controls irradiance of entire light
-				uniforms.color
-					.copy( color )
-					.multiplyScalar( intensity / ( light.width * light.height ) );
+				// (a) intensity is the total visible light emitted
+				//uniforms.color.copy( color ).multiplyScalar( intensity / ( light.width * light.height * Math.PI ) );
 
-				// (b) intensity controls the radiance per light area
-				// uniforms.color.copy( color ).multiplyScalar( intensity );
+				// (b) intensity is the brightness of the light
+				uniforms.color.copy( color ).multiplyScalar( intensity );
 
 				uniforms.position.setFromMatrixPosition( light.matrixWorld );
 				uniforms.position.applyMatrix4( viewMatrix );


### PR DESCRIPTION
I have changed the units of `RectAreaLight.intensity` from units of total power (for example, watts) to units of brightness.

Previously, users have had to set the light's intensity to a quantity in the hundreds for the light to have a visible effect. Changing the size of the light had no effect on the light output.

Now, since intensity means "brightness", an intensity value of 1 will "just work" -- regardless of the dimensions of the light. A larger light will now cast more light.

I feel this parameterization is more user-friendly.

I also corrected the docs.

(There is no live example to link to since a rebuild of the library is required.)
