### PR TITLE
fix unittests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "build-test": "rollup -c test/rollup.unit.config.js -w",
+    "build-test": "rollup -c test/rollup.unit.config.js",
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar node_modules/google-closure-compiler/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"serve --port 8080\"",
     "start": "npm run dev",
     "lint": "eslint src",
-    "test": "qunit test/unit/three.source.unit.js",
+    "test": "npm run build-test && qunit test/unit/three.source.unit.js > report.txt",
     "editor": "electron ./editor/main.js"
   },
   "keywords": [
@@ -55,7 +55,7 @@
     "eslint": "^4.1.1",
     "eslint-config-mdcs": "^4.2.2",
     "google-closure-compiler": "^20170521.0.0",
-    "qunitjs": "^2.4.0",
+    "qunit": "^2.4.0",
     "rollup": "^0.51.0",
     "rollup-watch": "^4.0.0",
     "serve": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"serve --port 8080\"",
     "start": "npm run dev",
     "lint": "eslint src",
-    "test": "npm run build-test && qunit test/unit/three.source.unit.js > report.txt",
+    "test": "npm run build-test && qunit test/unit/three.source.unit.js",
     "editor": "electron ./editor/main.js"
   },
   "keywords": [

--- a/test/unit/UnitTests.html
+++ b/test/unit/UnitTests.html
@@ -1,16 +1,16 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">
         <title>ThreeJS Unit Tests - Using Files in /src</title>
-        <link rel="stylesheet" href="../../node_modules/qunitjs/qunit/qunit.css">
+        <link rel="stylesheet" href="../../node_modules/qunit/qunit/qunit.css">
     </head>
     <body>
 
         <div id="qunit"></div>
         <div id="qunit-fixture"></div>
 
-        <script src="../../node_modules/qunitjs/qunit/qunit.js"></script>
+        <script src="../../node_modules/qunit/qunit/qunit.js"></script>
 
         <!-- We need three.js because qunit-utils cannot be es6 module and use THREE stuff... -->
         <script src="../../build/three.js"></script>

--- a/test/unit/unittests_editor_toRemoveAfterEditorES6Refactoring.html
+++ b/test/unit/unittests_editor_toRemoveAfterEditorES6Refactoring.html
@@ -1,16 +1,16 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
   <title>ThreeJS Unit Tests - Using Files in /editor</title>
-  <link rel="stylesheet" href="../../node_modules/qunitjs/qunit/qunit.css">
+  <link rel="stylesheet" href="../../node_modules/qunit/qunit/qunit.css">
 </head>
 <body>
 
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
 
-  <script src="../../node_modules/qunitjs/qunit/qunit.js"></script>
+  <script src="../../node_modules/qunit/qunit/qunit.js"></script>
   <script src="qunit-utils.js"></script>
   <script src="SmartComparer.js"></script>
 


### PR DESCRIPTION
There are 3 fixes in this commit:
- qunitjs was being deprecated. This has been replaced by qunit.
![image](https://user-images.githubusercontent.com/155535/34461406-2de0cc42-ee29-11e7-9cea-274b5c584bf9.png)
npm WARN deprecated qunitjs@2.4.1: 2.4.1 is the last version where QUnit will be published as 'qunitjs'. To receive future updates, you will need to change the package name to 'qunit'.
- `npm run test` didn't work on his own because the test weren't built. Now `npm run test` runs `npm run build-test` before actually running the tests.
- npm run build-test was watching the src files which didn't make sense since you didn't run any tests afterwards.

@donmccurdy, @Mugen87 
Can you review this one??


