### PR TITLE
Make sure variable isn't redeclared every new object

### DIFF
--- a/src/animation/AnimationObjectGroup.js
+++ b/src/animation/AnimationObjectGroup.js
@@ -95,14 +95,15 @@ Object.assign( AnimationObjectGroup.prototype, {
 			paths = this._paths,
 			parsedPaths = this._parsedPaths,
 			bindings = this._bindings,
-			nBindings = bindings.length;
+			nBindings = bindings.length,
+		    	knownObject = undefined;;
 
 		for ( var i = 0, n = arguments.length; i !== n; ++ i ) {
 
 			var object = arguments[ i ],
 				uuid = object.uuid,
-				index = indicesByUUID[ uuid ],
-				knownObject = undefined;
+				index = indicesByUUID[ uuid ];
+				
 
 			if ( index === undefined ) {
 


### PR DESCRIPTION
knownObject was reset to undefined inside the for-loop which was incorrect.

[LGTM](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/32fd13b241a1001af0045c3263d17dc2e133f482/files/src/animation/AnimationObjectGroup.js?sort=name&dir=ASC&mode=heatmap&excluded=false#xf94deba613c6f9ba:1) was complaining about a useless variable.