### PR TITLE
Add the dev-test command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build-uglify": "rollup -c && uglifyjs build/three.js -cm --preamble \"// threejs.org/license\" > build/three.min.js",
     "build-closure": "rollup -c && java -jar node_modules/google-closure-compiler/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"serve --port 8080\"",
+    "dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"rollup -c test/rollup.unit.config.js -w -m inline\" \"serve --port 8080\"",
     "start": "npm run dev",
     "lint": "eslint src",
     "test": "qunit test/unit/three.source.unit.js",


### PR DESCRIPTION
That is actually a more appropriate solution for this if we want to develop the unittests. I suggest we add the following command to package.json.

"dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"rollup -c test/rollup.unit.config.js -w -m inline\" \"serve --port 8080\"",

Basically it will run the following commands:

- rollup -c -w -m inline
- rollup -c test/rollup.unit.config.js -w -m inline
- serve --port 8080

That way, we run both rollups in watch mode and serve the website.

This is based on how @donmccurdy worked in #13004.