### PR TITLE
Fix for coplanar distance error

### DIFF
--- a/examples/js/QuickHull.js
+++ b/examples/js/QuickHull.js
@@ -573,7 +573,7 @@
 
 							distance = this.faces[ j ].distanceToPoint( vertex.point );
 
-							if ( distance > maxDistance ) {
+							if ( distance >= maxDistance ) {
 
 								maxDistance = distance;
 								maxFace = this.faces[ j ];


### PR DESCRIPTION
If the convex hull point set has only 4 points, and the distance between the plane (defined on line 474) and the 4th point is 0, the distance check will fail, `v3` will never be set, and the algorithm will crash. The distance check should be `distance >= maxDistance` to account for distances of 0.