### PR TITLE
Fix: Quaternion Inverse Function.

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -394,8 +394,16 @@ Object.assign( Quaternion.prototype, {
 	}(),
 
 	inverse: function () {
-
-		return this.conjugate().normalize();
+		
+		var lenSq = this.lengthSq();
+		
+		this.conjugate();
+		this._x /= lenSq;
+		this._y /= lenSq;
+		this._z /= lenSq;
+		this._w /= lenSq;
+		
+		return this;
 
 	},
 


### PR DESCRIPTION
Inverse is not defined as the normalized conjugate quaternion.
We need a special normalization: With the applying the length squared.

Sorry, i didn't follow the contributing guidelines, but i hope you can follow this bug fix.

Best regards.