### PR TITLE
PMREM: Restore previous renderTarget after update()

### DIFF
--- a/examples/js/pmrem/PMREMCubeUVPacker.js
+++ b/examples/js/pmrem/PMREMCubeUVPacker.js
@@ -114,12 +114,15 @@ THREE.PMREMCubeUVPacker.prototype = {
 		var gammaOutput = renderer.gammaOutput;
 		var toneMapping = renderer.toneMapping;
 		var toneMappingExposure = renderer.toneMappingExposure;
+		var renderTarget = renderer.getCurrentRenderTarget();
+		
 		renderer.gammaInput = false;
 		renderer.gammaOutput = false;
 		renderer.toneMapping = THREE.LinearToneMapping;
 		renderer.toneMappingExposure = 1.0;
 		renderer.render( this.scene, this.camera, this.CubeUVRenderTarget, false );
 
+		renderer.setRenderTarget(renderTarget);
 		renderer.toneMapping = toneMapping;
 		renderer.toneMappingExposure = toneMappingExposure;
 		renderer.gammaInput = gammaInput;

--- a/examples/js/pmrem/PMREMCubeUVPacker.js
+++ b/examples/js/pmrem/PMREMCubeUVPacker.js
@@ -114,7 +114,7 @@ THREE.PMREMCubeUVPacker.prototype = {
 		var gammaOutput = renderer.gammaOutput;
 		var toneMapping = renderer.toneMapping;
 		var toneMappingExposure = renderer.toneMappingExposure;
-		var renderTarget = renderer.getRenderTarget();
+		var currentRenderTarget = renderer.getRenderTarget();
 		
 		renderer.gammaInput = false;
 		renderer.gammaOutput = false;
@@ -122,7 +122,7 @@ THREE.PMREMCubeUVPacker.prototype = {
 		renderer.toneMappingExposure = 1.0;
 		renderer.render( this.scene, this.camera, this.CubeUVRenderTarget, false );
 
-		renderer.setRenderTarget(renderTarget);
+		renderer.setRenderTarget( currentRenderTarget );
 		renderer.toneMapping = toneMapping;
 		renderer.toneMappingExposure = toneMappingExposure;
 		renderer.gammaInput = gammaInput;

--- a/examples/js/pmrem/PMREMCubeUVPacker.js
+++ b/examples/js/pmrem/PMREMCubeUVPacker.js
@@ -114,7 +114,7 @@ THREE.PMREMCubeUVPacker.prototype = {
 		var gammaOutput = renderer.gammaOutput;
 		var toneMapping = renderer.toneMapping;
 		var toneMappingExposure = renderer.toneMappingExposure;
-		var renderTarget = renderer.getCurrentRenderTarget();
+		var renderTarget = renderer.getRenderTarget();
 		
 		renderer.gammaInput = false;
 		renderer.gammaOutput = false;

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -90,6 +90,7 @@ THREE.PMREMGenerator.prototype = {
 		var gammaOutput = renderer.gammaOutput;
 		var toneMapping = renderer.toneMapping;
 		var toneMappingExposure = renderer.toneMappingExposure;
+		var renderTarget = renderer.getCurrentRenderTarget();
 
 		renderer.toneMapping = THREE.LinearToneMapping;
 		renderer.toneMappingExposure = 1.0;
@@ -109,6 +110,7 @@ THREE.PMREMGenerator.prototype = {
 
 		}
 
+		renderer.setRenderTarget(renderTarget);
 		renderer.toneMapping = toneMapping;
 		renderer.toneMappingExposure = toneMappingExposure;
 		renderer.gammaInput = gammaInput;

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -90,7 +90,7 @@ THREE.PMREMGenerator.prototype = {
 		var gammaOutput = renderer.gammaOutput;
 		var toneMapping = renderer.toneMapping;
 		var toneMappingExposure = renderer.toneMappingExposure;
-		var renderTarget = renderer.getCurrentRenderTarget();
+		var renderTarget = renderer.getRenderTarget();
 
 		renderer.toneMapping = THREE.LinearToneMapping;
 		renderer.toneMappingExposure = 1.0;

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -90,7 +90,7 @@ THREE.PMREMGenerator.prototype = {
 		var gammaOutput = renderer.gammaOutput;
 		var toneMapping = renderer.toneMapping;
 		var toneMappingExposure = renderer.toneMappingExposure;
-		var renderTarget = renderer.getRenderTarget();
+		var currentRenderTarget = renderer.getRenderTarget();
 
 		renderer.toneMapping = THREE.LinearToneMapping;
 		renderer.toneMappingExposure = 1.0;
@@ -110,7 +110,7 @@ THREE.PMREMGenerator.prototype = {
 
 		}
 
-		renderer.setRenderTarget(renderTarget);
+		renderer.setRenderTarget( currentRenderTarget );
 		renderer.toneMapping = toneMapping;
 		renderer.toneMappingExposure = toneMappingExposure;
 		renderer.gammaInput = gammaInput;


### PR DESCRIPTION
These changes restore the previous `renderTarget` to the renderer after the cube map scene is rendered (in `update()`). In most cases, this isn't necessary, but I noticed in my code, when using `renderer.clear()` (for `scissorTest + setViewport`), it would also clear the contents of `CubeUVRenderTarget`.

Technically, the code only needed to be added to `PMREMCubeUVPacker.js` and not `PMREMGenerator.js` to get it working for my case, but I added in both places for symmetry, and in case somebody else runs into the same problem while but is using `PMREMGenerator` on their own.

Does this make sense / Is it a good idea?