### PR TITLE
fix video-textures for cached/fast video-loads

### DIFF
--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -21,7 +21,15 @@ function VideoTexture( video, mapping, wrapS, wrapT, magFilter, minFilter, forma
 
 	}
 
-	video.addEventListener( 'loadeddata', onLoaded, false );
+	if( video.readyState >= video.HAVE_CURRENT_DATA ) {
+
+		scope.needsUpdate = true;
+
+	} else {
+
+		video.addEventListener( 'loadeddata', onLoaded, false );
+
+	}
 
 }
 


### PR DESCRIPTION
When creating a video-texture from an existing video-element on the
page, the video might have already reached a playable state. In this
case, the `loadeddata` event has already been fired before the
video-texture was created and the texture will never become renderable.

This can be detected if the video has a `readyState >= 2`
(HAVE_CURRENT_DATA) when initializing the texture.