### PR TITLE
OBJLoader: Add points support.

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -216,6 +216,15 @@ THREE.OBJLoader = ( function () {
 
 			},
 
+			addVertexPoint: function ( a ) {
+
+				var src = this.vertices;
+				var dst = this.object.geometry.vertices;
+
+				dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
+
+			},
+
 			addVertexLine: function ( a ) {
 
 				var src = this.vertices;
@@ -305,6 +314,20 @@ THREE.OBJLoader = ( function () {
 				if ( this.colors.length > 0 ) {
 
 					this.addColor( ia, ib, ic );
+
+				}
+
+			},
+
+			addPointGeometry: function ( vertices ) {
+
+				this.object.geometry.type = 'Points';
+
+				var vLen = this.vertices.length;
+
+				for ( var vi = 0, l = vertices.length; vi < l; vi ++ ) {
+
+					this.addVertexPoint( this.parseVertexIndex( vertices[ vi ], vLen ) );
 
 				}
 
@@ -524,6 +547,13 @@ THREE.OBJLoader = ( function () {
 					}
 					state.addLineGeometry( lineVertices, lineUVs );
 
+				} else if ( lineFirstChar === 'p' ) {
+
+					var lineData = line.substr( 1 ).trim();
+					var pointData = lineData.split( " " );
+
+					state.addPointGeometry( pointData );
+
 				} else if ( ( result = object_pattern.exec( line ) ) !== null ) {
 
 					// o object_name
@@ -608,6 +638,7 @@ THREE.OBJLoader = ( function () {
 				var geometry = object.geometry;
 				var materials = object.materials;
 				var isLine = ( geometry.type === 'Line' );
+				var isPoints = ( geometry.type === 'Points' );
 				var hasVertexColors = false;
 
 				// Skip o/g line declarations that did not follow with any faces
@@ -661,13 +692,32 @@ THREE.OBJLoader = ( function () {
 							materialLine.lights = false; // TOFIX
 							material = materialLine;
 
+						} else if ( isPoints && material && ! ( material instanceof THREE.PointsMaterial ) ) {
+
+							var materialPoints = new THREE.PointsMaterial( { size: 10, sizeAttenuation: false } );
+							materialLine.copy( material );
+							material = materialPoints;
+
 						}
 
 					}
 
 					if ( ! material ) {
 
-						material = ( ! isLine ? new THREE.MeshPhongMaterial() : new THREE.LineBasicMaterial() );
+						if ( isLine ) {
+
+							material = new THREE.LineBasicMaterial();
+
+						} else if ( isPoints ) {
+
+							material = new THREE.PointsMaterial( { size: 1, sizeAttenuation: false } );
+
+						} else {
+
+							material = new THREE.MeshPhongMaterial();
+
+						}
+
 						material.name = sourceMaterial.name;
 
 					}
@@ -692,11 +742,35 @@ THREE.OBJLoader = ( function () {
 
 					}
 
-					mesh = ( ! isLine ? new THREE.Mesh( buffergeometry, createdMaterials ) : new THREE.LineSegments( buffergeometry, createdMaterials ) );
+					if ( isLine ) {
+
+						mesh = new THREE.LineSegments( buffergeometry, createdMaterials );
+
+					} else if ( isPoints ) {
+
+						mesh = new THREE.Points( buffergeometry, createdMaterials );
+
+					} else {
+
+						mesh = new THREE.Mesh( buffergeometry, createdMaterials );
+
+					}
 
 				} else {
 
-					mesh = ( ! isLine ? new THREE.Mesh( buffergeometry, createdMaterials[ 0 ] ) : new THREE.LineSegments( buffergeometry, createdMaterials[ 0 ] ) );
+					if ( isLine ) {
+
+						mesh = new THREE.LineSegments( buffergeometry, createdMaterials[ 0 ] );
+
+					} else if ( isPoints ) {
+
+						mesh = new THREE.Points( buffergeometry, createdMaterials[ 0 ] );
+
+					} else {
+
+						mesh = new THREE.Mesh( buffergeometry, createdMaterials[ 0 ] );
+
+					}
 
 				}
 

--- a/examples/obj/pointCloudBox/pointCloudBox.obj
+++ b/examples/obj/pointCloudBox/pointCloudBox.obj
@@ -1,0 +1,26 @@
+#                 Vertices: 8
+#                   Points: 0
+#                    Lines: 0
+#                    Faces: 6
+#                Materials: 1
+
+o 1
+
+# Vertex list
+
+v -0.5 -0.5 0.5
+v -0.5 -0.5 -0.5
+v -0.5 0.5 -0.5
+v -0.5 0.5 0.5
+v 0.5 -0.5 0.5
+v 0.5 -0.5 -0.5
+v 0.5 0.5 -0.5
+v 0.5 0.5 0.5
+
+# Point/Line/Face list
+
+usemtl Default
+
+p 1 2 3 4 5 6 7 8
+
+# End of file


### PR DESCRIPTION
<img width="291" alt="screen shot 2018-01-07 at 9 29 22 pm" src="https://user-images.githubusercontent.com/1041278/34657214-18935822-f3f2-11e7-8d3f-83cdcbc16f13.png">

Adds supports to the Obj loader for points.

```
p  v1 v2 v3 . . .

    Polygonal geometry statement.

    Specifies a point element and its vertex. You can specify multiple
    points with this statement. Although points cannot be shaded or
    rendered, they are used by other Advanced Visualizer programs.

    v is the vertex reference number for a point element. Each point
    element requires one vertex. Positive values indicate absolute
    vertex numbers. Negative values indicate relative vertex numbers.
```
http://paulbourke.net/dataformats/obj/

Fixes https://github.com/mrdoob/three.js/issues/13031  

@mrdoob 
  