### PR TITLE
FBXLoader: Correctly apply bind matrices

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2048,7 +2048,6 @@
 
 		var bindMatrices = {};
 
-		// Put skeleton into bind pose.
 		if ( 'Pose' in FBXTree.Objects ) {
 
 			var BindPoseNode = FBXTree.Objects.Pose;

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2017,7 +2017,7 @@
 
 			var parents = connections.get( parseInt( skeleton.ID ) ).parents;
 
-			parents.forEach( function ( parent, i ) {
+			parents.forEach( function ( parent ) {
 
 				if ( geometryMap.has( parent.ID ) ) {
 
@@ -2030,8 +2030,7 @@
 
 							var model = modelMap.get( geoConnParent.ID );
 
-							if ( geoConnParent.ID in bindMatrices ) model.bind( new THREE.Skeleton( skeleton.bones ), bindMatrices[ geoConnParent.ID ] );
-							else model.bind( new THREE.Skeleton( skeleton.bones ), model.matrixWorld );
+							model.bind( new THREE.Skeleton( skeleton.bones ), bindMatrices[ geoConnParent.ID ] );
 
 						}
 


### PR DESCRIPTION
...at least, I hope so!

It seems I was a bit hasty in removing `poseNode` parsing in #13045. 

So here's what I understand now: `poseNodes` can be either `restNodes`, or `bindNodes`. 

`restNodes` seem to be used to set up static poses so we can ignore those. 

In the case of `bindNodes`, they set up the position of the skeleton _before_ it is bound to the skin. 

Here we have two cases: 
* Sometimes there is a single `bindNode` - in this case it is the `skinnedMesh.bindMatrix`.
* Sometimes there is an array of `bindNode`s, one for each bone and one for the `skinnedMesh.bindMatrix`. 

However, the nodes related to bones can be ignored, since the `poseNode.matrix` should be equal to the `rawBone.transformLink`, so the bone's transforms are already set.
