### PR TITLE
replaced javascript keywords with non-conflicting alternatives

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -377,9 +377,9 @@ UI.Select = function () {
 UI.Select.prototype = Object.create( UI.Element.prototype );
 UI.Select.prototype.constructor = UI.Select;
 
-UI.Select.prototype.setMultiple = function ( boolean ) {
+UI.Select.prototype.setMultiple = function ( multiple ) {
 
-	this.dom.multiple = boolean;
+	this.dom.multiple = multiple;
 
 	return this;
 
@@ -432,7 +432,7 @@ UI.Select.prototype.setValue = function ( value ) {
 
 // Checkbox
 
-UI.Checkbox = function ( boolean ) {
+UI.Checkbox = function ( checked ) {
 
 	UI.Element.call( this );
 
@@ -443,7 +443,7 @@ UI.Checkbox = function ( boolean ) {
 	dom.type = 'checkbox';
 
 	this.dom = dom;
-	this.setValue( boolean );
+	this.setValue( checked );
 
 	return this;
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -377,9 +377,9 @@ UI.Select = function () {
 UI.Select.prototype = Object.create( UI.Element.prototype );
 UI.Select.prototype.constructor = UI.Select;
 
-UI.Select.prototype.setMultiple = function ( multiple ) {
+UI.Select.prototype.setMultiple = function ( bool ) {
 
-	this.dom.multiple = multiple;
+	this.dom.multiple = bool;
 
 	return this;
 
@@ -432,7 +432,7 @@ UI.Select.prototype.setValue = function ( value ) {
 
 // Checkbox
 
-UI.Checkbox = function ( checked ) {
+UI.Checkbox = function ( bool ) {
 
 	UI.Element.call( this );
 
@@ -443,7 +443,7 @@ UI.Checkbox = function ( checked ) {
 	dom.type = 'checkbox';
 
 	this.dom = dom;
-	this.setValue( checked );
+	this.setValue( bool );
 
 	return this;
 

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -437,13 +437,13 @@ UI.Outliner.prototype.setValue = function ( value ) {
 
 UI.THREE = {};
 
-UI.THREE.Boolean = function ( value, text ) {
+UI.THREE.Boolean = function ( bool, text ) {
 
 	UI.Span.call( this );
 
 	this.setMarginRight( '10px' );
 
-	this.checkbox = new UI.Checkbox( value );
+	this.checkbox = new UI.Checkbox( bool );
 	this.text = new UI.Text( text ).setMarginLeft( '3px' );
 
 	this.add( this.checkbox );

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -437,13 +437,13 @@ UI.Outliner.prototype.setValue = function ( value ) {
 
 UI.THREE = {};
 
-UI.THREE.Boolean = function ( boolean, text ) {
+UI.THREE.Boolean = function ( value, text ) {
 
 	UI.Span.call( this );
 
 	this.setMarginRight( '10px' );
 
-	this.checkbox = new UI.Checkbox( boolean );
+	this.checkbox = new UI.Checkbox( value );
 	this.text = new UI.Text( text ).setMarginLeft( '3px' );
 
 	this.add( this.checkbox );

--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -502,9 +502,9 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 
 	};
 
-	this.setScissorTest = function ( boolean ) {
+	this.setScissorTest = function ( scissorTest ) {
 
-		renderer.setScissorTest( boolean );
+		renderer.setScissorTest( scissorTest );
 
 	};
 

--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -502,9 +502,9 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 
 	};
 
-	this.setScissorTest = function ( scissorTest ) {
+	this.setScissorTest = function ( bool ) {
 
-		renderer.setScissorTest( scissorTest );
+		renderer.setScissorTest( bool );
 
 	};
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -139,7 +139,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	window.addEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
 
-	this.setFullScreen = function ( boolean ) {
+	this.setFullScreen = function ( fullscreen ) {
 
 		return new Promise( function ( resolve, reject ) {
 
@@ -157,7 +157,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			if ( boolean ) {
+			if ( fullscreen ) {
 
 				resolve( vrDisplay.requestPresent( [ { source: canvas } ] ) );
 

--- a/examples/js/effects/VREffect.js
+++ b/examples/js/effects/VREffect.js
@@ -139,7 +139,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	window.addEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
 
-	this.setFullScreen = function ( fullscreen ) {
+	this.setFullScreen = function ( bool ) {
 
 		return new Promise( function ( resolve, reject ) {
 
@@ -157,7 +157,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			if ( fullscreen ) {
+			if ( bool ) {
 
 				resolve( vrDisplay.requestPresent( [ { source: canvas } ] ) );
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1308,10 +1308,10 @@ Object.assign( WebGLRenderer.prototype, {
 		return this.extensions.get( 'ANGLE_instanced_arrays' );
 
 	},
-	enableScissorTest: function ( scissorTest ) {
+	enableScissorTest: function ( bool ) {
 
 		console.warn( 'THREE.WebGLRenderer: .enableScissorTest() is now .setScissorTest().' );
-		this.setScissorTest( scissorTest );
+		this.setScissorTest( bool );
 
 	},
 	initMaterial: function () {

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1308,10 +1308,10 @@ Object.assign( WebGLRenderer.prototype, {
 		return this.extensions.get( 'ANGLE_instanced_arrays' );
 
 	},
-	enableScissorTest: function ( boolean ) {
+	enableScissorTest: function ( scissorTest ) {
 
 		console.warn( 'THREE.WebGLRenderer: .enableScissorTest() is now .setScissorTest().' );
-		this.setScissorTest( boolean );
+		this.setScissorTest( scissorTest );
 
 	},
 	initMaterial: function () {

--- a/src/extras/core/Font.js
+++ b/src/extras/core/Font.js
@@ -51,16 +51,16 @@ function createPaths( text, size, divisions, data ) {
 
 	for ( var i = 0; i < chars.length; i ++ ) {
 
-		var char = chars[ i ];
+		var character = chars[ i ];
 
-		if ( char === '\n' ) {
+		if ( character === '\n' ) {
 
 			offsetX = 0;
 			offsetY -= line_height;
 
 		} else {
 
-			var ret = createPath( char, divisions, scale, offsetX, offsetY, data );
+			var ret = createPath( character, divisions, scale, offsetX, offsetY, data );
 			offsetX += ret.offsetX;
 			paths.push( ret.path );
 
@@ -72,9 +72,9 @@ function createPaths( text, size, divisions, data ) {
 
 }
 
-function createPath( char, divisions, scale, offsetX, offsetY, data ) {
+function createPath( character, divisions, scale, offsetX, offsetY, data ) {
 
-	var glyph = data.glyphs[ char ] || data.glyphs[ '?' ];
+	var glyph = data.glyphs[ character ] || data.glyphs[ '?' ];
 
 	if ( ! glyph ) return;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -433,9 +433,9 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	this.setScissorTest = function ( scissorTest ) {
+	this.setScissorTest = function ( bool ) {
 
-		state.setScissorTest( _scissorTest = scissorTest );
+		state.setScissorTest( _scissorTest = bool );
 
 	};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -433,9 +433,9 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	this.setScissorTest = function ( boolean ) {
+	this.setScissorTest = function ( scissorTest ) {
 
-		state.setScissorTest( _scissorTest = boolean );
+		state.setScissorTest( _scissorTest = scissorTest );
 
 	};
 


### PR DESCRIPTION
I use the YUI Compressor to generate a compressed version of three.js and the additional files used in my project. YUI Compressor requires a very strictly valid javascript syntax and fails because javascript keywords are used as parameter or variable names in several places of three.js. After my changes the YUI Compressor does no longer complain.
I think I applied all suggested changes from the last try but I also rebased the commit on a current dev branch.