### PR TITLE
GLTFExporter/Loader: Add basic tests.

### DIFF
--- a/test/rollup.unit.config.js
+++ b/test/rollup.unit.config.js
@@ -26,17 +26,17 @@ function glsl() {
 export default [
 	// editor unit conf
 	{
-		entry: 'test/three.editor.unit.js',
+		input: 'test/three.editor.unit.js',
 		indent: '\t',
 		plugins: [
 			glsl()
 		],
 		// sourceMap: true,
-		targets: [
+		output: [
 			{
 				format: 'umd',
-				moduleName: 'THREE',
-				dest: 'test/unit/three.editor.unit.js',
+				name: 'THREE',
+				file: 'test/unit/three.editor.unit.js',
 				intro: 'QUnit.module( "Editor", () => {',
 				outro: '} );',
 			}
@@ -44,17 +44,17 @@ export default [
 	},
 	// example unit conf
 	{
-		entry: 'test/three.example.unit.js',
+		input: 'test/three.example.unit.js',
 		indent: '\t',
 		plugins: [
 			glsl()
 		],
 		// sourceMap: true,
-		targets: [
+		output: [
 			{
 				format: 'umd',
-				moduleName: 'THREE',
-				dest: 'test/unit/three.example.unit.js',
+				name: 'THREE',
+				file: 'test/unit/three.example.unit.js',
 				intro: 'QUnit.module( "Example", () => {',
 				outro: '} );',
 			}
@@ -62,17 +62,17 @@ export default [
 	},
 	// source unit conf
 	{
-		entry: 'test/three.source.unit.js',
+		input: 'test/three.source.unit.js',
 		indent: '\t',
 		plugins: [
 			glsl()
 		],
 		// sourceMap: true,
-		targets: [
+		output: [
 			{
 				format: 'umd',
-				moduleName: 'THREE',
-				dest: 'test/unit/three.source.unit.js',
+				name: 'THREE',
+				file: 'test/unit/three.source.unit.js',
 				intro: 'QUnit.module( "Source", () => {',
 				outro: '} );',
 			}

--- a/test/three.example.unit.js
+++ b/test/three.example.unit.js
@@ -1,3 +1,6 @@
 /**
  * @author TristanVALCKE / https://github.com/Itee
  */
+
+import './unit/example/exporters/GLTFExporter.tests';
+import './unit/example/loaders/GLTFLoader.tests';

--- a/test/unit/UnitTests.html
+++ b/test/unit/UnitTests.html
@@ -18,9 +18,9 @@
         <script src="qunit-utils.js"></script>
 
         <!-- add sources to test below -->
-        <!--<script src="three.editor.unit.js"></script>-->
-        <!--<script src="three.example.unit.js"></script>-->
+        <!-- <script src="three.editor.unit.js"></script> -->
         <script src="three.source.unit.js"></script>
+        <script src="three.example.unit.js"></script>
 
     </body>
 </html>

--- a/test/unit/example/exporters/GLTFExporter.tests.js
+++ b/test/unit/example/exporters/GLTFExporter.tests.js
@@ -1,0 +1,126 @@
+/**
+ * @author Don McCurdy / https://www.donmccurdy.com
+ */
+/* global QUnit */
+
+import * as GLTFExporter from '../../../../examples/js/exporters/GLTFExporter';
+
+export default QUnit.module( 'Exporters', () => {
+
+  QUnit.module( 'GLTFExporter', () => {
+
+    QUnit.test( 'constructor', ( assert ) => {
+
+      assert.ok( new THREE.GLTFExporter(), 'Can instantiate an exporter.' );
+
+    } );
+
+    QUnit.test( 'parse - metadata', ( assert ) => {
+
+      var done = assert.async();
+
+      var object = new THREE.Object3D()
+
+      var exporter = new THREE.GLTFExporter();
+
+      exporter.parse( object, function ( gltf ) {
+
+        assert.equal( '2.0', gltf.asset.version, 'asset.version' );
+        assert.equal( 'THREE.GLTFExporter', gltf.asset.generator, 'asset.generator' );
+
+        done();
+
+      } );
+
+    } );
+
+    QUnit.test( 'parse - basic', ( assert ) => {
+
+      var done = assert.async();
+
+      var box = new THREE.Mesh(
+        new THREE.CubeGeometry( 1, 1, 1 ),
+        new THREE.MeshStandardMaterial( { color: 0xFF0000 } )
+      );
+
+      var exporter = new THREE.GLTFExporter();
+
+      exporter.parse( box, function ( gltf ) {
+
+        assert.equal( 1, gltf.nodes.length, 'correct number of nodes' );
+        assert.equal( 0, gltf.nodes[ 0 ].mesh, 'node references mesh' );
+        assert.equal( 1, gltf.meshes[ 0 ].primitives.length, 'correct number of primitives' );
+
+        var primitive = gltf.meshes[ 0 ].primitives[ 0 ];
+        var material = gltf.materials[ primitive.material ];
+
+        assert.equal( 4, primitive.mode, 'mesh uses TRIANGLES mode' );
+        assert.ok( primitive.attributes.POSITION !== undefined, 'mesh contains position data' );
+        assert.ok( primitive.attributes.NORMAL !== undefined, 'mesh contains normal data' );
+
+        assert.smartEqual( {
+
+          baseColorFactor: [ 1, 0, 0, 1 ],
+          metallicFactor: 0.5,
+          roughnessFactor: 0.5
+
+        }, material.pbrMetallicRoughness, 'material' );
+
+        done();
+
+      } );
+
+    } );
+
+    QUnit.test( 'parse - animation', ( assert ) => {
+
+      var done = assert.async();
+
+      var mesh1 = new THREE.Mesh();
+      mesh1.name = 'mesh1';
+
+      var mesh2 = new THREE.Mesh();
+      mesh2.name = 'mesh2';
+
+      var mesh3 = new THREE.Mesh();
+      mesh3.name = 'mesh3';
+
+      var scene = new THREE.Scene();
+      scene.add( mesh1, mesh2, mesh3 );
+
+      var clip1 = new THREE.AnimationClip( 'clip1', undefined, [
+
+        new THREE.VectorKeyframeTrack( 'mesh1.position', [ 0, 1, 2 ], [ 0, 0, 0, 30, 0, 0, 0, 0, 0 ] )
+
+      ] );
+
+      var clip2 = new THREE.AnimationClip( 'clip2', undefined, [
+
+        new THREE.VectorKeyframeTrack( 'mesh3.scale', [ 0, 1, 2 ], [ 1, 1, 1, 2, 2, 2, 1, 1, 1 ] )
+
+      ] );
+
+      var exporter = new THREE.GLTFExporter();
+
+      exporter.parse( scene, function ( gltf ) {
+
+        assert.equal( 2, gltf.animations.length, 'one animation per clip' );
+
+        var target1 = gltf.animations[ 0 ].channels[ 0 ].target;
+        var target2 = gltf.animations[ 1 ].channels[ 0 ].target;
+
+        assert.equal( 'mesh1', gltf.nodes[ target1.node ].name, 'clip1 node' );
+        assert.equal( 'translation', target1.path, 'clip1 property' );
+        assert.equal( 'mesh3', gltf.nodes[ target2.node ].name, 'clip2 node' );
+        assert.equal( 'scale', target2.path, 'clip2 property' );
+
+        done();
+
+      }, { animations: [ clip1, clip2 ] } );
+
+    } );
+
+
+  } );
+
+} );

--- a/test/unit/example/loaders/GLTFLoader.tests.js
+++ b/test/unit/example/loaders/GLTFLoader.tests.js
@@ -1,0 +1,108 @@
+/**
+ * @author Don McCurdy / https://www.donmccurdy.com
+ */
+/* global QUnit */
+
+import * as GLTFExporter from '../../../../examples/js/exporters/GLTFExporter';
+import * as GLTFLoader from '../../../../examples/js/loaders/GLTFLoader';
+
+export default QUnit.module( 'Loaders', () => {
+
+	QUnit.module( 'GLTFLoader', () => {
+
+		QUnit.test( 'constructor', ( assert ) => {
+
+			assert.ok( new THREE.GLTFLoader(), 'Can instantiate a loader.' );
+
+		} );
+
+		QUnit.test( 'parse - basic', ( assert ) => {
+
+			var done = assert.async();
+
+			var geometry = new THREE.BufferGeometry();
+			var array = new Float32Array( [
+				- 1, - 1, - 1,
+				1, 1, 1,
+				4, 4, 4
+			] );
+			geometry.addAttribute( 'position', new THREE.BufferAttribute( array, 3 ) );
+
+			var meshIn = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial( { color: 0xFF0000 } ) );
+			meshIn.name = 'test_mesh';
+
+			var exporter = new THREE.GLTFExporter();
+			var loader = new THREE.GLTFLoader();
+
+			exporter.parse( meshIn, function ( binary ) {
+
+				loader.parse( binary, './', function ( gltf ) {
+
+					var meshOut = gltf.scene.children[ 0 ];
+					var attrsIn = meshIn.geometry.attributes;
+					var attrsOut = meshOut.geometry.attributes;
+
+					assert.equal( meshIn.name, meshOut.name, 'loads names' );
+					assert.equal( meshIn.material.color.getHex(), meshOut.material.color.getHex(), 'loads color' );
+					assert.smartEqual( attrsIn.position.array, attrsOut.position.array, 'loads positions' );
+					assert.equal( undefined, attrsOut.normal, 'ignores missing attributes' );
+
+					done();
+
+				}, undefined, function ( e ) {
+
+					console.error(e);
+
+				} );
+
+			}, { binary: true } );
+
+		} );
+
+		QUnit.test( 'parse - animation', ( assert ) => {
+
+			var done = assert.async();
+
+			var node1 = new THREE.Object3D();
+			node1.name = 'node1';
+
+			var node2 = new THREE.Object3D();
+			node2.name = 'node2';
+
+			var scene = new THREE.Scene();
+			scene.add( node1, node2 );
+
+			var clip = new THREE.AnimationClip( 'clip', undefined, [
+
+				new THREE.VectorKeyframeTrack( 'node1.position', [ 0, 1, 2 ], [ 0, 0, 0, 30, 0, 0, 0, 0, 0 ] )
+
+			] );
+
+			var exporter = new THREE.GLTFExporter();
+			var loader = new THREE.GLTFLoader();
+
+			exporter.parse( scene, function ( binary ) {
+
+				loader.parse( binary, './', function ( gltf ) {
+
+					var clipOut = gltf.animations[ 0 ];
+
+					assert.equal( 'node1.position', clipOut.tracks[ 0 ].name, 'track name' );
+					assert.smartEqual( clip.tracks[ 0 ].times, clipOut.tracks[ 0 ].times, 'track times' );
+					assert.smartEqual( clip.tracks[ 0 ].values, clipOut.tracks[ 0 ].values, 'track values' );
+
+					done();
+
+				}, undefined, function ( e ) {
+
+					console.error(e);
+
+				} );
+
+			}, { binary: true, animations: [ clip ] } );
+
+		} );
+
+	} );
+
+} );


### PR DESCRIPTION
Some sanity tests for glTF exporter and loader. The exporter's output is verified directly, and the loader is tested with round trips: `mesh  -> GLTFExporter -> binary -> GLTFLoader -> mesh`.

Also fixes some deprecation warnings in the rollup config.