### PR TITLE
Lazy uuid generation and avoid uuid use in main renderer

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -16,7 +16,6 @@ function BufferAttribute( array, itemSize, normalized ) {
 
 	}
 
-	this.uuid = _Math.generateUUID();
 	this.name = '';
 
 	this.array = array;
@@ -42,6 +41,8 @@ Object.defineProperty( BufferAttribute.prototype, 'needsUpdate', {
 	}
 
 } );
+
+Object.defineProperties( BufferAttribute.prototype, Object.getOwnPropertyDescriptors( _Math.lazyUUID ) );
 
 Object.assign( BufferAttribute.prototype, {
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -21,8 +21,6 @@ function BufferGeometry() {
 
 	Object.defineProperty( this, 'id', { value: bufferGeometryId += 2 } );
 
-	this.uuid = _Math.generateUUID();
-
 	this.name = '';
 	this.type = 'BufferGeometry';
 
@@ -1119,5 +1117,6 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 } );
 
+Object.defineProperties( BufferGeometry.prototype, Object.getOwnPropertyDescriptors( _Math.lazyUUID ) );
 
 export { BufferGeometry };

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -25,8 +25,6 @@ function Geometry() {
 
 	Object.defineProperty( this, 'id', { value: geometryId += 2 } );
 
-	this.uuid = _Math.generateUUID();
-
 	this.name = '';
 	this.type = 'Geometry';
 
@@ -1450,5 +1448,6 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 } );
 
+Object.defineProperties( Geometry.prototype, Object.getOwnPropertyDescriptors( _Math.lazyUUID ) );
 
 export { Geometry };

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -6,8 +6,6 @@ import { _Math } from '../math/Math.js';
 
 function InterleavedBuffer( array, stride ) {
 
-	this.uuid = _Math.generateUUID();
-
 	this.array = array;
 	this.stride = stride;
 	this.count = array !== undefined ? array.length / stride : 0;
@@ -108,5 +106,6 @@ Object.assign( InterleavedBuffer.prototype, {
 
 } );
 
+Object.defineProperties( InterleavedBuffer.prototype, Object.getOwnPropertyDescriptors( _Math.lazyUUID ) );
 
 export { InterleavedBuffer };

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -6,8 +6,6 @@ import { _Math } from '../math/Math.js';
 
 function InterleavedBufferAttribute( interleavedBuffer, itemSize, offset, normalized ) {
 
-	this.uuid = _Math.generateUUID();
-
 	this.data = interleavedBuffer;
 	this.itemSize = itemSize;
 	this.offset = offset;
@@ -138,5 +136,6 @@ Object.assign( InterleavedBufferAttribute.prototype, {
 
 } );
 
+Object.defineProperties( InterleavedBufferAttribute.prototype, Object.getOwnPropertyDescriptors( _Math.lazyUUID ) );
 
 export { InterleavedBufferAttribute };

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -21,8 +21,6 @@ function Object3D() {
 
 	Object.defineProperty( this, 'id', { value: object3DId ++ } );
 
-	this.uuid = _Math.generateUUID();
-
 	this.name = '';
 	this.type = 'Object3D';
 
@@ -826,5 +824,6 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 } );
 
+Object.defineProperties( Object3D.prototype, Object.getOwnPropertyDescriptors( _Math.lazyUUID ) );
 
 export { Object3D };

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -13,8 +13,6 @@ function Material() {
 
 	Object.defineProperty( this, 'id', { value: materialId ++ } );
 
-	this.uuid = _Math.generateUUID();
-
 	this.name = '';
 	this.type = 'Material';
 
@@ -363,5 +361,6 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 } );
 
+Object.defineProperties( Material.prototype, Object.getOwnPropertyDescriptors( _Math.lazyUUID ) );
 
 export { Material };

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -20,6 +20,8 @@ var _Math = {
 
 		}
 
+		return function generateUUID() { return null };
+		/*
 		return function generateUUID() {
 
 			var d0 = Math.random() * 0xffffffff | 0;
@@ -32,7 +34,7 @@ var _Math = {
 				lut[ d3 & 0xff ] + lut[ d3 >> 8 & 0xff ] + lut[ d3 >> 16 & 0xff ] + lut[ d3 >> 24 & 0xff ];
 
 		};
-
+*/
 	} )(),
 
 	clamp: function ( value, min, max ) {

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -20,8 +20,6 @@ var _Math = {
 
 		}
 
-		return function generateUUID() { return null };
-		/*
 		return function generateUUID() {
 
 			var d0 = Math.random() * 0xffffffff | 0;
@@ -34,7 +32,7 @@ var _Math = {
 				lut[ d3 & 0xff ] + lut[ d3 >> 8 & 0xff ] + lut[ d3 >> 16 & 0xff ] + lut[ d3 >> 24 & 0xff ];
 
 		};
-*/
+
 	} )(),
 
 	clamp: function ( value, min, max ) {
@@ -144,9 +142,42 @@ var _Math = {
 
 		return Math.pow( 2, Math.floor( Math.log( value ) / Math.LN2 ) );
 
-	}
+	},
+
+	lazyUUID: {}
 
 };
+
+Object.defineProperties( _Math.lazyUUID, {
+
+	_uuid: {
+		value: null,
+		writable: true
+	},
+
+	uuid: {
+
+		get: function () {
+
+			if ( this._uuid === null ) {
+
+				this._uuid = _Math.generateUUID();
+
+			}
+
+			return this._uuid;
+
+		},
+
+		set: function ( value ) {
+
+			this._uuid = value;
+
+		}
+
+	}
+
+} );
 
 
 export { _Math };

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -109,13 +109,13 @@ function WebGLAttributes( gl ) {
 
 		if ( attribute.isInterleavedBufferAttribute ) attribute = attribute.data;
 
-		var data = buffers.get( attribute.uuid );
+		var data = buffers.get( attribute );
 
 		if ( data ) {
 
 			gl.deleteBuffer( data.buffer );
 
-			buffers.delete( attribute.uuid );
+			buffers.delete( attribute );
 
 		}
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -4,7 +4,7 @@
 
 function WebGLAttributes( gl ) {
 
-	var buffers = {};
+	var buffers = new WeakMap();
 
 	function createBuffer( attribute, bufferType ) {
 
@@ -101,7 +101,7 @@ function WebGLAttributes( gl ) {
 
 		if ( attribute.isInterleavedBufferAttribute ) attribute = attribute.data;
 
-		return buffers[ attribute.uuid ];
+		return buffers.get( attribute );
 
 	}
 
@@ -109,13 +109,13 @@ function WebGLAttributes( gl ) {
 
 		if ( attribute.isInterleavedBufferAttribute ) attribute = attribute.data;
 
-		var data = buffers[ attribute.uuid ];
+		var data = buffers.get( attribute.uuid );
 
 		if ( data ) {
 
 			gl.deleteBuffer( data.buffer );
 
-			delete buffers[ attribute.uuid ];
+			buffers.delete( attribute.uuid );
 
 		}
 
@@ -125,11 +125,11 @@ function WebGLAttributes( gl ) {
 
 		if ( attribute.isInterleavedBufferAttribute ) attribute = attribute.data;
 
-		var data = buffers[ attribute.uuid ];
+		var data = buffers.get( attribute );
 
 		if ( data === undefined ) {
 
-			buffers[ attribute.uuid ] = createBuffer( attribute, bufferType );
+			buffers.set( attribute, createBuffer( attribute, bufferType ) );
 
 		} else if ( data.version < attribute.version ) {
 

--- a/src/renderers/webgl/WebGLProperties.js
+++ b/src/renderers/webgl/WebGLProperties.js
@@ -4,17 +4,16 @@
 
 function WebGLProperties() {
 
-	var properties = {};
+	var properties = new WeakMap();
 
 	function get( object ) {
 
-		var uuid = object.uuid;
-		var map = properties[ uuid ];
+		var map = properties.get( object );
 
 		if ( map === undefined ) {
 
 			map = {};
-			properties[ uuid ] = map;
+			properties.set( object, map );
 
 		}
 
@@ -24,13 +23,13 @@ function WebGLProperties() {
 
 	function remove( object ) {
 
-		delete properties[ object.uuid ];
+		properties.delete( object );
 
 	}
 
 	function dispose() {
 
-		properties = {};
+		properties =  new WeakMap();
 
 	}
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -17,8 +17,6 @@ function Texture( image, mapping, wrapS, wrapT, magFilter, minFilter, format, ty
 
 	Object.defineProperty( this, 'id', { value: textureId ++ } );
 
-	this.uuid = _Math.generateUUID();
-
 	this.name = '';
 
 	this.image = image !== undefined ? image : Texture.DEFAULT_IMAGE;
@@ -319,5 +317,6 @@ Object.defineProperty( Texture.prototype, "needsUpdate", {
 
 } );
 
+Object.defineProperties( Texture.prototype, Object.getOwnPropertyDescriptors( _Math.lazyUUID ) );
 
 export { Texture };


### PR DESCRIPTION

An alternative approach to solve #13069.

Use a WeakMap in WebGLAttributes and WebGLProperties keyed by objects instead of the objects uuids.
(removes need for uuid's in core rendering code). 

Add lazy generation as suggested previously by @takahirox  and others, using a source object in _Math to avoid duplicated code (most of base three.js converted).

Lightly tested with examples, editor and own application, no significant performance changes other than reduced memory usage, uuid's generated only when required.
