### PR TITLE
Update Fileloader's judgment to http code.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -176,7 +176,7 @@ Object.assign( FileLoader.prototype, {
 
 				delete loading[ url ];
 
-				if ( this.status >= 200 && this.status < 400 ) {
+				if ( this.status === 200 || this.status === 206 ) {
 
 					for ( var i = 0, il = callbacks.length; i < il; i ++ ) {
 

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -176,7 +176,7 @@ Object.assign( FileLoader.prototype, {
 
 				delete loading[ url ];
 
-				if ( this.status === 200 ) {
+				if ( this.status >= 200 && this.status < 400 ) {
 
 					for ( var i = 0, il = callbacks.length; i < il; i ++ ) {
 


### PR DESCRIPTION
When we use customers http request header such as `Range: 0-` leading http server response resoures without `chunk` mode. Server would response http code not 200 but 206.