### PR TITLE
Update default radii for CylinderBufferGeometry

### DIFF
--- a/docs/api/geometries/CylinderBufferGeometry.html
+++ b/docs/api/geometries/CylinderBufferGeometry.html
@@ -44,9 +44,9 @@
 
 		<h3>[name]([page:Float radiusTop], [page:Float radiusBottom], [page:Float height], [page:Integer radialSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
 		<div>
-		radiusTop — Radius of the cylinder at the top. Default is 20.<br />
-		radiusBottom — Radius of the cylinder at the bottom. Default is 20.<br />
-		height — Height of the cylinder. Default is 100.<br />
+		radiusTop — Radius of the cylinder at the top. Default is 1.<br />
+		radiusBottom — Radius of the cylinder at the bottom. Default is 1.<br />
+		height — Height of the cylinder. Default is 1.<br />
 		radialSegments — Number of segmented faces around the circumference of the cylinder. Default is 8<br />
 		heightSegments — Number of rows of faces along the height of the cylinder. Default is 1.<br />
 		openEnded — A Boolean indicating whether the ends of the cylinder are open or capped. Default is false, meaning capped.<br />


### PR DESCRIPTION
Hi,

While poking around the docs I noticed that the default radiusTop/Bottom and heights for CylinderBufferGeometry didn't match the source.

source - 
https://github.com/mrdoob/three.js/blob/08ea2852c1b85f29379d4a9fb8f6cbc78878c1ae/src/geometries/CylinderGeometry.js#L60

docs - 
https://github.com/mrdoob/three.js/blob/5cf3febe62aca494910fea0da686ea67a0235136/docs/api/geometries/CylinderBufferGeometry.html#L47