### PR TITLE
Fix GLTFExporter processAnimation()

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -938,7 +938,7 @@ THREE.GLTFExporter.prototype = {
 
 					input: processAccessor( new THREE.BufferAttribute( track.times, inputItemSize ) ),
 					output: processAccessor( new THREE.BufferAttribute( track.values, outputItemSize ) ),
-					interpolation: track.interpolation === THREE.InterpolateDiscrete ? 'STEP' : 'LINEAR'
+					interpolation: track.getInterpolation() === THREE.InterpolateDiscrete ? 'STEP' : 'LINEAR'
 
 				} );
 


### PR DESCRIPTION
`KeyframeTrack` doesn't have `.interpolation` property.
We need to use `.getInterpolation()` instead.