### PR TITLE
Docs: Add note about barycentric coordinates in triangle.containsPoint() docs

### DIFF
--- a/docs/api/math/Triangle.html
+++ b/docs/api/math/Triangle.html
@@ -79,9 +79,7 @@
 		<div>
 		[page:Vector3 point] - [page:Vector3] to check.<br /><br />
 
-		Returns true if the passed vector is within the triangle in
-		[link:https://en.wikipedia.org/wiki/Barycentric_coordinate_system barycentric coordinates]
-		(the vector is projected onto the plane of the triangle before checking containment).
+		Returns true if the passed point lies within the triangle, when projected onto the plane of the triangle.
 		</div>
 
 		<h3>[method:Triangle copy]( [page:Triangle triangle] )</h3>

--- a/docs/api/math/Triangle.html
+++ b/docs/api/math/Triangle.html
@@ -79,7 +79,7 @@
 		<div>
 		[page:Vector3 point] - [page:Vector3] to check.<br /><br />
 
-		Returns true if the passed point lies within the triangle, when projected onto the plane of the triangle.
+		Returns true if the passed point, when projected onto the plane of the triangle, lies within the triangle.
 		</div>
 
 		<h3>[method:Triangle copy]( [page:Triangle triangle] )</h3>

--- a/docs/api/math/Triangle.html
+++ b/docs/api/math/Triangle.html
@@ -79,7 +79,9 @@
 		<div>
 		[page:Vector3 point] - [page:Vector3] to check.<br /><br />
 
-		Returns true if the passed vector is within the triangle.
+		Returns true if the passed vector is within the triangle in
+		[link:https://en.wikipedia.org/wiki/Barycentric_coordinate_system barycentric coordinates]
+		(the vector is projected onto the plane of the triangle before checking containment).
 		</div>
 
 		<h3>[method:Triangle copy]( [page:Triangle triangle] )</h3>


### PR DESCRIPTION
Open to better ways of explaining this.. I assumed incorrectly that `triangle.containsPoint(v)` would always return false for points distant from the plane of the triangle.