### PR TITLE
Add option in blender exporter to bake keyframe animation

### DIFF
--- a/utils/exporters/blender/addons/io_three/__init__.py
+++ b/utils/exporters/blender/addons/io_three/__init__.py
@@ -434,6 +434,10 @@ def restore_export_settings(properties, settings):
         constants.KEYFRAMES,
         constants.EXPORT_OPTIONS[constants.KEYFRAMES])
 
+    properties.option_bake_keyframes = settings.get(
+        constants.BAKE_KEYFRAMES,
+        constants.EXPORT_OPTIONS[constants.BAKE_KEYFRAMES])
+
     properties.option_frame_step = settings.get(
         constants.FRAME_STEP,
         constants.EXPORT_OPTIONS[constants.FRAME_STEP])
@@ -491,6 +495,7 @@ def set_settings(properties):
         constants.BLEND_SHAPES: properties.option_blend_shape,
         constants.ANIMATION: properties.option_animation_skeletal,
         constants.KEYFRAMES: properties.option_keyframes,
+        constants.BAKE_KEYFRAMES: properties.option_bake_keyframes,
         constants.FRAME_STEP: properties.option_frame_step,
         constants.FRAME_INDEX_AS_TIME: properties.option_frame_index_as_time,
         constants.INFLUENCES_PER_VERTEX: properties.option_influences
@@ -736,6 +741,11 @@ class ExportThree(bpy.types.Operator, ExportHelper):
         description="Export animation (keyframes)",
         default=constants.EXPORT_OPTIONS[constants.KEYFRAMES])
 
+    option_bake_keyframes = BoolProperty(
+        name="Bake keyframe animation",
+        description="Bake keyframe animation each frame step",
+        default=constants.EXPORT_OPTIONS[constants.BAKE_KEYFRAMES])
+
     option_frame_index_as_time = BoolProperty(
         name="Frame index as time",
         description="Use (original) frame index as frame time",
@@ -960,6 +970,9 @@ class ExportThree(bpy.types.Operator, ExportHelper):
 
         row = box.row()
         row.prop(self.properties, 'option_keyframes')
+
+        row = box.row()
+        row.prop(self.properties, 'option_bake_keyframes')
 
         row = box.row()
         row.prop(self.properties, 'option_influences')

--- a/utils/exporters/blender/addons/io_three/constants.py
+++ b/utils/exporters/blender/addons/io_three/constants.py
@@ -93,6 +93,7 @@ FRAME_INDEX_AS_TIME = 'frameIndexAsTime'
 ANIMATION = 'animations'
 CLIPS="clips"
 KEYFRAMES = 'tracks'
+BAKE_KEYFRAMES = 'bake_tracks'
 MORPH_TARGETS = 'morphTargets'
 MORPH_TARGETS_ANIM = 'morphTargetsAnimation'
 BLEND_SHAPES = 'blendShapes'
@@ -161,6 +162,7 @@ EXPORT_OPTIONS = {
     MAPS: False,
     ANIMATION: OFF,
     KEYFRAMES: False,
+    BAKE_KEYFRAMES: False,
     BONES: False,
     SKINNING: False,
     MORPH_TARGETS: False,

--- a/utils/exporters/blender/addons/io_three/exporter/api/object.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/object.py
@@ -231,6 +231,12 @@ def animated_xform(obj, options):
     inverted_fallback = mathutils.Matrix() if use_inverted else None
     convert_matrix = AXIS_CONVERSION    # matrix to convert the exported matrix
     original_frame = context.scene.frame_current
+
+    if options.get(constants.BAKE_KEYFRAMES):
+        frame_step = options.get(constants.FRAME_STEP, 1)
+        logger.info("Baking keyframes, frame_step=%d", frame_step)
+        times = range(context.scene.frame_start, context.scene.frame_end+1, frame_step)
+
     for time in times:
         context.scene.frame_set(time, 0.0)
         if use_inverted:  # need to use the inverted, parent matrix might have chance


### PR DESCRIPTION
Before keyframe animation only exported points in time where the fcurves had keys and as such would disregard any interpolotaion before, after or between keys.

This adds a bake option to export animations every frame-step frame.