### PR TITLE
Release the reference to the current renderList at the end of .render()

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1226,6 +1226,8 @@ function WebGLRenderer( parameters ) {
 
 		// _gl.finish();
 
+		currentRenderList = null;
+
 	};
 
 	/*


### PR DESCRIPTION
Even if I dispose `renderLists` via `.dispose()` in `WebGLRenderer`, an element of `renderLists` referenced by `currentRenderList` won't be released til next `.render()` call.

Releasing the reference at the end of `.render()` fixes this issue.

Or releasing it in `.dispose()` is another solution.

I implemented the former in this PR so far.