### PR TITLE
Expose unrollLoops control for ShaderMaterial

### DIFF
--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -339,11 +339,10 @@ this.extensions = {
 
 		<h3>[property:Boolean unrollLoops]</h3>
 		<div>
-			Used to optimize shader code at runtime, specifically all loops in the shader code will be expanded. Default is *false* for backwards compatibility.<br /><br />
+			Used to optimize shader code at runtime, specifically all loops in the shader code will be expanded. Default is *false*.<br /><br />
 
-			You should set this to true, if you want to avoid problems with modern GPU.
+			You should set this to true, if you want to avoid problems with modern GPUs.
 		</div>
-
 
 		<h3>[property:Boolean lights]</h3>
 		<div>

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -337,7 +337,12 @@ this.extensions = {
 			You should not change this, as it used internally for optimisation.
 		</div>
 
+		<h3>[property:Boolean unrollLoops]</h3>
+		<div>
+			Used to optimize shader code at runtime, specifically all loops in the shader code will be expanded. Default is *false* for backwards compatibility.<br /><br />
 
+			You should set this to true, if you want to avoid problems with modern GPU.
+		</div>
 
 
 		<h3>[property:Boolean lights]</h3>

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -82,6 +82,7 @@ ShaderMaterial.prototype = Object.create( Material.prototype );
 ShaderMaterial.prototype.constructor = ShaderMaterial;
 
 ShaderMaterial.prototype.isShaderMaterial = true;
+ShaderMaterial.prototype.unrollLoops = false;
 
 ShaderMaterial.prototype.copy = function ( source ) {
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -506,8 +506,9 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 	fragmentShader = parseIncludes( fragmentShader );
 	fragmentShader = replaceLightNums( fragmentShader, parameters );
 
-	if ( ! material.isShaderMaterial ) {
 
+
+    if ( material.unrollLoops !== false ) {
 		vertexShader = unrollLoops( vertexShader );
 		fragmentShader = unrollLoops( fragmentShader );
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -506,12 +506,9 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 	fragmentShader = parseIncludes( fragmentShader );
 	fragmentShader = replaceLightNums( fragmentShader, parameters );
 
-
-
     if ( material.unrollLoops !== false ) {
 		vertexShader = unrollLoops( vertexShader );
 		fragmentShader = unrollLoops( fragmentShader );
-
 	}
 
 	var vertexGlsl = prefixVertex + vertexShader;


### PR DESCRIPTION
**Design**
- Related issue #13090
- the `webGlProgram.js` now checks `material.unrollLoops` instead of `material.isShaderMaterial` as a condition to unroll shader loops
- if unrollLoops is not a provided property, it defaults to true 

- The default value has been set to false in ShaderMaterial, as a choice for backwards compatability.