### PR TITLE
WebGLRenderer: Enable rendering without index and position attribute

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -772,6 +772,8 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		var useDataCount = ( index !== null || position !== undefined );
+
 		var rangeStart = geometry.drawRange.start * rangeFactor;
 		var rangeCount = geometry.drawRange.count * rangeFactor;
 
@@ -779,7 +781,7 @@ function WebGLRenderer( parameters ) {
 		var groupCount = group !== null ? group.count * rangeFactor : Infinity;
 
 		var drawStart = Math.max( rangeStart, groupStart );
-		var drawEnd = Math.min( dataCount, rangeStart + rangeCount, groupStart + groupCount ) - 1;
+		var drawEnd = Math.min( ( useDataCount ? dataCount : Infinity ), rangeStart + rangeCount, groupStart + groupCount ) - 1;
 
 		var drawCount = Math.max( 0, drawEnd - drawStart + 1 );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -760,7 +760,7 @@ function WebGLRenderer( parameters ) {
 
 		//
 
-		var dataCount = 0;
+		var dataCount = Infinity;
 
 		if ( index !== null ) {
 
@@ -772,8 +772,6 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		var useDataCount = ( index !== null || position !== undefined );
-
 		var rangeStart = geometry.drawRange.start * rangeFactor;
 		var rangeCount = geometry.drawRange.count * rangeFactor;
 
@@ -781,7 +779,7 @@ function WebGLRenderer( parameters ) {
 		var groupCount = group !== null ? group.count * rangeFactor : Infinity;
 
 		var drawStart = Math.max( rangeStart, groupStart );
-		var drawEnd = Math.min( ( useDataCount ? dataCount : Infinity ), rangeStart + rangeCount, groupStart + groupCount ) - 1;
+		var drawEnd = Math.min( dataCount, rangeStart + rangeCount, groupStart + groupCount ) - 1;
 
 		var drawCount = Math.max( 0, drawEnd - drawStart + 1 );
 


### PR DESCRIPTION
Fixes #10751

We only use `dataCount` in order to determine `drawEnd` if an index or a position attribute is present. Otherwise, it will use `Infinity` inside the `Math.min` statement.

Like mentioned in the issue, it's necessary to specify `drawRange` (or `group`) if a geometry consists only of custom attributes.