### PR TITLE
Fixed Geometry.fromBufferGeometry() incorrectly interpreting colours

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -232,7 +232,9 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		var tempUVs = [];
 		var tempUVs2 = [];
 
-		for ( var i = 0, j = 0; i < positions.length; i += 3, j += 2 ) {
+		var colorStride = colors !== undefined ? attributes.color.itemSize : 3;
+
+		for ( var i = 0, j = 0, k = 0; i < positions.length; i += 3, j += 2, k += colorStride ) {
 
 			scope.vertices.push( new Vector3( positions[ i ], positions[ i + 1 ], positions[ i + 2 ] ) );
 
@@ -244,7 +246,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 			if ( colors !== undefined ) {
 
-				scope.colors.push( new Color( colors[ i ], colors[ i + 1 ], colors[ i + 2 ] ) );
+				scope.colors.push( new Color( colors[ k ], colors[ k + 1 ], colors[ k + 2 ] ) );
 
 			}
 


### PR DESCRIPTION
Some colour attributes have a size of 4 but were interpreted as 3, messing up the vertex colours in the conversion as the colours were getting mixed up with the alpha channel.

For reference, we were importing geometries using the GLTFLoader, then converting BufferGeomety to Geometry for use within our own application.

Right is the BufferGeometry, left is the converted Geometry.

Original:
![image](https://user-images.githubusercontent.com/16712991/35127471-388dd4ee-fd17-11e7-9719-6b801f277696.png)

Fix:
![image](https://user-images.githubusercontent.com/16712991/35127517-55ba2180-fd17-11e7-9e2a-299d4e9a1012.png)

