### PR TITLE
WebGLProgram: Introduce loop unrolling via pragma

### DIFF
--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -44,6 +44,10 @@
 				If you don't want the [page:WebGLProgram] to add anything to your shader code, you can use
 				[page:RawShaderMaterial] instead of this class.
 			</li>
+			<li>
+				You can use the directive #pragma unroll_loop in order to unroll a *for* loop in GLSL by the shader preprocessor.
+				The directive has to be placed right above the loop. The loop itself has to be normalized/well-behaved.
+			</li>
 		</ul>
 		</div>
 

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -46,13 +46,16 @@
 			</li>
 			<li>
 				You can use the directive #pragma unroll_loop in order to unroll a *for* loop in GLSL by the shader preprocessor.
-				The directive has to be placed right above the loop. The loop itself has to correspond to a defined standard.
+				The directive has to be placed right above the loop. The loop formatting has to correspond to a defined standard.
 				<ul>
 					<li>
-						The loop has to be [link:https://en.wikipedia.org/wiki/Normalized_loop normalized/well-behaved].
+						The loop has to be [link:https://en.wikipedia.org/wiki/Normalized_loop normalized].
 					</li>
 					<li>
-						The loop variable must be *i*.
+						The loop variable has to be *i*.
+					</li>
+					<li>
+						The loop has to use a certain whitespace formatting.
 					</li>
 				</ul>
 				<code>

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -49,12 +49,20 @@
 				The directive has to be placed right above the loop. The loop itself has to correspond to a defined standard.
 				<ul>
 					<li>
-						The loop has to be normalized/well-behaved.
+						The loop has to be [link:https://en.wikipedia.org/wiki/Normalized_loop normalized/well-behaved].
 					</li>
 					<li>
 						The loop variable must be *i*.
 					</li>
 				</ul>
+				<code>
+		#pragma unroll_loop
+		for ( int i = 0; i < 10; i ++ ) {
+
+			// ...
+
+		}
+				</code>
 			</li>
 		</ul>
 		</div>

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -46,7 +46,15 @@
 			</li>
 			<li>
 				You can use the directive #pragma unroll_loop in order to unroll a *for* loop in GLSL by the shader preprocessor.
-				The directive has to be placed right above the loop. The loop itself has to be normalized/well-behaved.
+				The directive has to be placed right above the loop. The loop itself has to correspond to a defined standard.
+				<ul>
+					<li>
+						The loop has to be normalized/well-behaved.
+					</li>
+					<li>
+						The loop variable must be *i*.
+					</li>
+				</ul>
 			</li>
 		</ul>
 		</div>

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_fragment.glsl
@@ -1,22 +1,29 @@
 #if NUM_CLIPPING_PLANES > 0
 
-	for ( int i = 0; i < UNION_CLIPPING_PLANES; ++ i ) {
+	vec4 plane;
 
-		vec4 plane = clippingPlanes[ i ];
+	#pragma unroll_loop
+	for ( int i = 0; i < UNION_CLIPPING_PLANES; i ++ ) {
+
+		plane = clippingPlanes[ i ];
 		if ( dot( vViewPosition, plane.xyz ) > plane.w ) discard;
 
 	}
-		
+
 	#if UNION_CLIPPING_PLANES < NUM_CLIPPING_PLANES
 
 		bool clipped = true;
-		for ( int i = UNION_CLIPPING_PLANES; i < NUM_CLIPPING_PLANES; ++ i ) {
-			vec4 plane = clippingPlanes[ i ];
+
+		#pragma unroll_loop
+		for ( int i = UNION_CLIPPING_PLANES; i < NUM_CLIPPING_PLANES; i ++ ) {
+
+			plane = clippingPlanes[ i ];
 			clipped = ( dot( vViewPosition, plane.xyz ) > plane.w ) && clipped;
+
 		}
 
 		if ( clipped ) discard;
-	
+
 	#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -22,7 +22,7 @@ vec3 directLightColor_Diffuse;
 
 #if NUM_POINT_LIGHTS > 0
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
 		getPointDirectLightIrradiance( pointLights[ i ], geometry, directLight );
@@ -44,7 +44,7 @@ vec3 directLightColor_Diffuse;
 
 #if NUM_SPOT_LIGHTS > 0
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
 		getSpotDirectLightIrradiance( spotLights[ i ], geometry, directLight );
@@ -77,7 +77,7 @@ vec3 directLightColor_Diffuse;
 
 #if NUM_DIR_LIGHTS > 0
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		getDirectionalDirectLightIrradiance( directionalLights[ i ], geometry, directLight );
@@ -99,7 +99,7 @@ vec3 directLightColor_Diffuse;
 
 #if NUM_HEMI_LIGHTS > 0
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
 		vLightFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl
@@ -22,6 +22,7 @@ vec3 directLightColor_Diffuse;
 
 #if NUM_POINT_LIGHTS > 0
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
 		getPointDirectLightIrradiance( pointLights[ i ], geometry, directLight );
@@ -43,6 +44,7 @@ vec3 directLightColor_Diffuse;
 
 #if NUM_SPOT_LIGHTS > 0
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
 		getSpotDirectLightIrradiance( spotLights[ i ], geometry, directLight );
@@ -75,6 +77,7 @@ vec3 directLightColor_Diffuse;
 
 #if NUM_DIR_LIGHTS > 0
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		getDirectionalDirectLightIrradiance( directionalLights[ i ], geometry, directLight );
@@ -96,6 +99,7 @@ vec3 directLightColor_Diffuse;
 
 #if NUM_HEMI_LIGHTS > 0
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
 		vLightFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );

--- a/src/renderers/shaders/ShaderChunk/lights_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_template.glsl
@@ -25,7 +25,7 @@ IncidentLight directLight;
 
 	PointLight pointLight;
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
 		pointLight = pointLights[ i ];
@@ -46,7 +46,7 @@ IncidentLight directLight;
 
 	SpotLight spotLight;
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
 		spotLight = spotLights[ i ];
@@ -67,7 +67,7 @@ IncidentLight directLight;
 
 	DirectionalLight directionalLight;
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		directionalLight = directionalLights[ i ];
@@ -88,7 +88,7 @@ IncidentLight directLight;
 
 	RectAreaLight rectAreaLight;
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_RECT_AREA_LIGHTS; i ++ ) {
 
 		rectAreaLight = rectAreaLights[ i ];
@@ -118,7 +118,7 @@ IncidentLight directLight;
 
 	#if ( NUM_HEMI_LIGHTS > 0 )
 
-		#pragma three unroll
+		#pragma unroll_loop
 		for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
 			irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );

--- a/src/renderers/shaders/ShaderChunk/lights_template.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_template.glsl
@@ -25,6 +25,7 @@ IncidentLight directLight;
 
 	PointLight pointLight;
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
 		pointLight = pointLights[ i ];
@@ -45,6 +46,7 @@ IncidentLight directLight;
 
 	SpotLight spotLight;
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
 		spotLight = spotLights[ i ];
@@ -65,6 +67,7 @@ IncidentLight directLight;
 
 	DirectionalLight directionalLight;
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		directionalLight = directionalLights[ i ];
@@ -85,6 +88,7 @@ IncidentLight directLight;
 
 	RectAreaLight rectAreaLight;
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_RECT_AREA_LIGHTS; i ++ ) {
 
 		rectAreaLight = rectAreaLights[ i ];
@@ -114,6 +118,7 @@ IncidentLight directLight;
 
 	#if ( NUM_HEMI_LIGHTS > 0 )
 
+		#pragma three unroll
 		for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
 			irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );

--- a/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl
@@ -2,7 +2,7 @@
 
 	#if NUM_DIR_LIGHTS > 0
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		vDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * worldPosition;
@@ -13,7 +13,7 @@
 
 	#if NUM_SPOT_LIGHTS > 0
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
 		vSpotShadowCoord[ i ] = spotShadowMatrix[ i ] * worldPosition;
@@ -24,7 +24,7 @@
 
 	#if NUM_POINT_LIGHTS > 0
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
 		vPointShadowCoord[ i ] = pointShadowMatrix[ i ] * worldPosition;

--- a/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl
@@ -2,6 +2,7 @@
 
 	#if NUM_DIR_LIGHTS > 0
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		vDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * worldPosition;
@@ -12,6 +13,7 @@
 
 	#if NUM_SPOT_LIGHTS > 0
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
 		vSpotShadowCoord[ i ] = spotShadowMatrix[ i ] * worldPosition;
@@ -22,6 +24,7 @@
 
 	#if NUM_POINT_LIGHTS > 0
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
 		vPointShadowCoord[ i ] = pointShadowMatrix[ i ] * worldPosition;

--- a/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl
@@ -8,6 +8,7 @@ float getShadowMask() {
 
 	DirectionalLight directionalLight;
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		directionalLight = directionalLights[ i ];
@@ -21,6 +22,7 @@ float getShadowMask() {
 
 	SpotLight spotLight;
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
 		spotLight = spotLights[ i ];
@@ -34,6 +36,7 @@ float getShadowMask() {
 
 	PointLight pointLight;
 
+	#pragma three unroll
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
 		pointLight = pointLights[ i ];

--- a/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl
@@ -8,7 +8,7 @@ float getShadowMask() {
 
 	DirectionalLight directionalLight;
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		directionalLight = directionalLights[ i ];
@@ -22,7 +22,7 @@ float getShadowMask() {
 
 	SpotLight spotLight;
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
 		spotLight = spotLights[ i ];
@@ -36,7 +36,7 @@ float getShadowMask() {
 
 	PointLight pointLight;
 
-	#pragma three unroll
+	#pragma unroll_loop
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
 		pointLight = pointLights[ i ];

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -174,7 +174,7 @@ function parseIncludes( string ) {
 
 function unrollLoops( string ) {
 
-	var pattern = /#pragma three unroll[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
+	var pattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
 
 	function replace( match, start, end, snippet ) {
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -174,7 +174,7 @@ function parseIncludes( string ) {
 
 function unrollLoops( string ) {
 
-	var pattern = /for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
+	var pattern = /#pragma three unroll[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
 
 	function replace( match, start, end, snippet ) {
 
@@ -506,12 +506,8 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 	fragmentShader = parseIncludes( fragmentShader );
 	fragmentShader = replaceLightNums( fragmentShader, parameters );
 
-	if ( ! material.isShaderMaterial ) {
-
-		vertexShader = unrollLoops( vertexShader );
-		fragmentShader = unrollLoops( fragmentShader );
-
-	}
+	vertexShader = unrollLoops( vertexShader );
+	fragmentShader = unrollLoops( fragmentShader );
 
 	var vertexGlsl = prefixVertex + vertexShader;
 	var fragmentGlsl = prefixFragment + fragmentShader;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -150,6 +150,14 @@ function replaceLightNums( string, parameters ) {
 
 }
 
+function replaceClippingPlaneNums( string, parameters ) {
+
+	return string
+		.replace( /NUM_CLIPPING_PLANES/g, parameters.numClippingPlanes )
+		.replace( /UNION_CLIPPING_PLANES/g, ( parameters.numClippingPlanes - parameters.numClipIntersection ) );
+
+}
+
 function parseIncludes( string ) {
 
 	var pattern = /^[ \t]*#include +<([\w\d.]+)>/gm;
@@ -358,8 +366,6 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 			parameters.doubleSided ? '#define DOUBLE_SIDED' : '',
 			parameters.flipSided ? '#define FLIP_SIDED' : '',
 
-			'#define NUM_CLIPPING_PLANES ' + parameters.numClippingPlanes,
-
 			parameters.shadowMapEnabled ? '#define USE_SHADOWMAP' : '',
 			parameters.shadowMapEnabled ? '#define ' + shadowMapTypeDefine : '',
 
@@ -462,9 +468,6 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 			parameters.doubleSided ? '#define DOUBLE_SIDED' : '',
 			parameters.flipSided ? '#define FLIP_SIDED' : '',
 
-			'#define NUM_CLIPPING_PLANES ' + parameters.numClippingPlanes,
-			'#define UNION_CLIPPING_PLANES ' + ( parameters.numClippingPlanes - parameters.numClipIntersection ),
-
 			parameters.shadowMapEnabled ? '#define USE_SHADOWMAP' : '',
 			parameters.shadowMapEnabled ? '#define ' + shadowMapTypeDefine : '',
 
@@ -502,9 +505,11 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 	vertexShader = parseIncludes( vertexShader );
 	vertexShader = replaceLightNums( vertexShader, parameters );
+	vertexShader = replaceClippingPlaneNums( vertexShader, parameters );
 
 	fragmentShader = parseIncludes( fragmentShader );
 	fragmentShader = replaceLightNums( fragmentShader, parameters );
+	fragmentShader = replaceClippingPlaneNums( fragmentShader, parameters );
 
 	vertexShader = unrollLoops( vertexShader );
 	fragmentShader = unrollLoops( fragmentShader );


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/13124#issuecomment-358986915

The unrolling of loops is now controlled via `#pragma three unroll`. It must be placed right before a `for` loop to trigger the unroll. The PR also activates loop unrolling for `ShaderMaterial`.

I've created this PR so we get a better impression of this kind of solution.

Fixes #13090