### PR TITLE
Count triangle taking account of draw mode

### DIFF
--- a/editor/js/Viewport.Info.js
+++ b/editor/js/Viewport.Info.js
@@ -45,11 +45,12 @@ Viewport.Info = function ( editor ) {
 				if ( object instanceof THREE.Mesh ) {
 
 					var geometry = object.geometry;
+					var indexCount;
 
 					if ( geometry instanceof THREE.Geometry ) {
 
 						vertices += geometry.vertices.length;
-						triangles += geometry.faces.length;
+						indexCount = geometry.faces.length * 3;
 
 					} else if ( geometry instanceof THREE.BufferGeometry ) {
 
@@ -57,13 +58,23 @@ Viewport.Info = function ( editor ) {
 
 						if ( geometry.index !== null ) {
 
-							triangles += geometry.index.count / 3;
+							indexCount = geometry.index.count;
 
 						} else {
 
-							triangles += geometry.attributes.position.count / 3;
+							indexCount = geometry.attributes.position.count;
 
 						}
+
+					}
+
+					if ( object.drawMode === THREE.TrianglesDrawMode ) {
+
+						triangles += indexCount / 3;
+
+					} else {
+
+						triangles += indexCount - 2;
 
 					}
 

--- a/src/renderers/webgl/WebGLBufferRenderer.js
+++ b/src/renderers/webgl/WebGLBufferRenderer.js
@@ -19,8 +19,19 @@ function WebGLBufferRenderer( gl, extensions, infoRender ) {
 		infoRender.calls ++;
 		infoRender.vertices += count;
 
-		if ( mode === gl.TRIANGLES ) infoRender.faces += count / 3;
-		else if ( mode === gl.POINTS ) infoRender.points += count;
+		if ( mode === gl.TRIANGLES ) {
+
+			infoRender.faces += count / 3;
+
+		} else if ( mode === gl.TRIANGLE_STRIP || mode === gl.TRIANGLE_FAN ) {
+
+			infoRender.faces += count - 2;
+
+		} else if ( mode === gl.POINTS ) {
+
+			infoRender.points += count;
+
+		}
 
 	}
 
@@ -52,8 +63,19 @@ function WebGLBufferRenderer( gl, extensions, infoRender ) {
 		infoRender.calls ++;
 		infoRender.vertices += count * geometry.maxInstancedCount;
 
-		if ( mode === gl.TRIANGLES ) infoRender.faces += geometry.maxInstancedCount * count / 3;
-		else if ( mode === gl.POINTS ) infoRender.points += geometry.maxInstancedCount * count;
+		if ( mode === gl.TRIANGLES ) {
+
+			infoRender.faces += geometry.maxInstancedCount * count / 3;
+
+		} else if ( mode === gl.TRIANGLE_STRIP || mode === gl.TRIANGLE_FAN ) {
+
+			infoRender.faces += geometry.maxInstancedCount * ( count - 2 );
+
+		} else if ( mode === gl.POINTS ) {
+
+			infoRender.points += geometry.maxInstancedCount * count;
+
+		}
 
 	}
 

--- a/src/renderers/webgl/WebGLIndexedBufferRenderer.js
+++ b/src/renderers/webgl/WebGLIndexedBufferRenderer.js
@@ -28,8 +28,19 @@ function WebGLIndexedBufferRenderer( gl, extensions, infoRender ) {
 		infoRender.calls ++;
 		infoRender.vertices += count;
 
-		if ( mode === gl.TRIANGLES ) infoRender.faces += count / 3;
-		else if ( mode === gl.POINTS ) infoRender.points += count;
+		if ( mode === gl.TRIANGLES ) {
+
+			infoRender.faces += count / 3;
+
+		} else if ( mode === gl.TRIANGLE_STRIP || mode === gl.TRIANGLE_FAN ) {
+
+			infoRender.faces += count - 2;
+
+		} else if ( mode === gl.POINTS ) {
+
+			infoRender.points += count;
+
+		}
 
 	}
 
@@ -49,8 +60,19 @@ function WebGLIndexedBufferRenderer( gl, extensions, infoRender ) {
 		infoRender.calls ++;
 		infoRender.vertices += count * geometry.maxInstancedCount;
 
-		if ( mode === gl.TRIANGLES ) infoRender.faces += geometry.maxInstancedCount * count / 3;
-		else if ( mode === gl.POINTS ) infoRender.points += geometry.maxInstancedCount * count;
+		if ( mode === gl.TRIANGLES ) {
+
+			infoRender.faces += geometry.maxInstancedCount * count / 3;
+
+		} else if ( mode === gl.TRIANGLE_STRIP || mode === gl.TRIANGLE_FAN ) {
+
+			infoRender.faces += geometry.maxInstancedCount * ( count - 2 );
+
+		} else if ( mode === gl.POINTS ) {
+
+			infoRender.points += geometry.maxInstancedCount * count;
+
+		}
 
 	}
 


### PR DESCRIPTION
This PR fixes triangle count for `.infoRender` and `Editor`.
`Editor` doesn't have draw mode change API yet but let's fix now just in case.

Questions, a bit off topic tho. Is there any special reasons why 
- `Mesh.drawMode` isn't serialized in `Mesh.toJSON()`?
- `.indoRender` doesn't have `lines(line count)`?

If not, I wanna make another PR to fix them.
