### PR TITLE
Geometry: Move computeLineDistance() to Line/LineSegments

### DIFF
--- a/docs/api/core/Geometry.html
+++ b/docs/api/core/Geometry.html
@@ -107,8 +107,7 @@
 		<h3>[property:array lineDistances]</h3>
 		<div>
 		An array containing distances between vertices for Line geometries.
-		This is required for [page:LineSegments] / [page:LineDashedMaterial] to render correctly.
-		Line distances can be generated automatically with [page:.computeLineDistances].
+		This is required for [page:LineDashedMaterial] to render correctly.
 		</div>
 
 		<h3>[property:Array morphTargets]</h3>
@@ -241,9 +240,6 @@
 
 		<h3>[method:null computeFlatVertexNormals]()</h3>
 		<div>Computes flat [page:Face3.vertexNormals vertex normals]. Sets the vertex normal of each vertex of each face to be the same as the face's normal.</div>
-
-		<h3>[method:null computeLineDistances]()</h3>
-		<div>Compute [page:.lineDistances].</div>
 
 		<h3>[method:null computeMorphNormals]()</h3>
 		<div>Computes [page:.morphNormals].</div>

--- a/docs/api/deprecated/DeprecatedList.html
+++ b/docs/api/deprecated/DeprecatedList.html
@@ -153,6 +153,12 @@
 
 		<h2>Geometry</h2>
 
+		<div>
+			Geometry.computeTangents() has been removed.<br /><br />
+
+			Geometry.computeLineDistances() has been removed. Use [page:Line.computeLineDistances] instead.<br /><br />
+		</div>
+
 		<h3>[page:BufferGeometry]</h3>
 		<div>
 			BufferGeometry.addIndex has been renamed to [page:BufferGeometry.setIndex].<br /><br />

--- a/docs/api/objects/Line.html
+++ b/docs/api/objects/Line.html
@@ -76,7 +76,7 @@
 
 		<h3>[method:Line computeLineDistances]()</h3>
 		<div>
-		Computes an array of distance values which are necessary for [page:LineDashedMaterial]. The method calculates for each point in the geometry the distance to the very beginning of the line.
+		Computes an array of distance values which are necessary for [page:LineDashedMaterial]. For each vertex in the geometry, the method calculates the cumulative length from the current point to the very beginning of the line.
 		</div>
 
 		<h3>[method:Array raycast]( [page:Raycaster raycaster], [page:Array intersects] )</h3>

--- a/docs/api/objects/Line.html
+++ b/docs/api/objects/Line.html
@@ -74,6 +74,11 @@
 		<h2>Methods</h2>
 		<div>See the base [page:Object3D] class for common methods.</div>
 
+		<h3>[method:Line computeLineDistances]()</h3>
+		<div>
+		Computes an array of distance values which are necessary for [page:LineDashedMaterial]. The method calculates for each point in the geometry the distance to the very beginning of the line.
+		</div>
+
 		<h3>[method:Array raycast]( [page:Raycaster raycaster], [page:Array intersects] )</h3>
 		<div>
 		Get intersections between a casted [page:Ray] and this Line.

--- a/examples/canvas_lines_dashed.html
+++ b/examples/canvas_lines_dashed.html
@@ -49,8 +49,7 @@
 			var objects = [];
 
 
-			var WIDTH = window.innerWidth,
-				HEIGHT = window.innerHeight;
+			var WIDTH = window.innerWidth, HEIGHT = window.innerHeight;
 
 			init();
 			animate();
@@ -63,27 +62,16 @@
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0x111111 );
 
-				root = new THREE.Object3D();
-
 				var subdivisions = 6;
 				var recursion = 1;
 
 				var points = hilbert3D( new THREE.Vector3( 0,0,0 ), 25.0, recursion, 0, 1, 2, 3, 4, 5, 6, 7 );
-
 				var spline = new THREE.CatmullRomCurve3( points );
-				var geometrySpline = new THREE.Geometry();
 
-				for ( var i = 0; i < points.length * subdivisions; i ++ ) {
-
-					var t = i / ( points.length * subdivisions );
-					geometrySpline.vertices[ i ] = spline.getPoint( t );
-
-				}
+				var samples = spline.getPoints( points.length * subdivisions );
+				var geometrySpline = new THREE.BufferGeometry().setFromPoints( samples );
 
 				var geometryCube = cube( 50 );
-
-				geometryCube.computeLineDistances();
-				geometrySpline.computeLineDistances();
 
 				var object = new THREE.Line( geometrySpline, new THREE.LineDashedMaterial( { color: 0xffffff, dashSize: 1, gapSize: 0.5 } ) );
 
@@ -186,7 +174,6 @@
 
 					var object = objects[ i ];
 
-					//object.rotation.x = 0.25 * time * ( i%2 == 1 ? 1 : -1);
 					object.rotation.x = 0.25 * time;
 					object.rotation.y = 0.25 * time;
 

--- a/examples/canvas_lines_dashed.html
+++ b/examples/canvas_lines_dashed.html
@@ -69,7 +69,7 @@
 				var spline = new THREE.CatmullRomCurve3( points );
 
 				var samples = spline.getPoints( points.length * subdivisions );
-				var geometrySpline = new THREE.BufferGeometry().setFromPoints( samples );
+				var geometrySpline = new THREE.Geometry().setFromPoints( samples );
 
 				var geometryCube = cube( 50 );
 

--- a/examples/webgl_lines_dashed.html
+++ b/examples/webgl_lines_dashed.html
@@ -66,7 +66,7 @@
 				var spline = new THREE.CatmullRomCurve3( points );
 
 				var samples = spline.getPoints( points.length * subdivisions );
-				var geometrySpline = new THREE.BufferGeometry().setFromPoints( samples );
+				var geometrySpline = new THREE.Geometry().setFromPoints( samples );
 
 				var line = new THREE.Line( geometrySpline, new THREE.LineDashedMaterial( { color: 0xffffff, dashSize: 1, gapSize: 0.5 } ) );
 				line.computeLineDistances();

--- a/examples/webgl_lines_dashed.html
+++ b/examples/webgl_lines_dashed.html
@@ -45,9 +45,7 @@
 			var renderer, scene, camera, stats;
 			var objects = [];
 
-
-			var WIDTH = window.innerWidth,
-				HEIGHT = window.innerHeight;
+			var WIDTH = window.innerWidth, HEIGHT = window.innerHeight;
 
 			init();
 			animate();
@@ -61,37 +59,28 @@
 				scene.background = new THREE.Color( 0x111111 );
 				scene.fog = new THREE.Fog( 0x111111, 150, 200 );
 
-				root = new THREE.Object3D();
-
 				var subdivisions = 6;
 				var recursion = 1;
 
-				var points = hilbert3D( new THREE.Vector3( 0,0,0 ), 25.0, recursion, 0, 1, 2, 3, 4, 5, 6, 7 );
-
+				var points = hilbert3D( new THREE.Vector3( 0, 0, 0 ), 25.0, recursion, 0, 1, 2, 3, 4, 5, 6, 7 );
 				var spline = new THREE.CatmullRomCurve3( points );
-				var geometrySpline = new THREE.Geometry();
 
-				for ( var i = 0; i < points.length * subdivisions; i ++ ) {
+				var samples = spline.getPoints( points.length * subdivisions );
+				var geometrySpline = new THREE.BufferGeometry().setFromPoints( samples );
 
-					var t = i / ( points.length * subdivisions );
-					geometrySpline.vertices[ i ] = spline.getPoint( t );
+				var line = new THREE.Line( geometrySpline, new THREE.LineDashedMaterial( { color: 0xffffff, dashSize: 1, gapSize: 0.5 } ) );
+				line.computeLineDistances();
 
-				}
+				objects.push( line );
+				scene.add( line );
 
 				var geometryCube = cube( 50 );
 
-				geometryCube.computeLineDistances();
-				geometrySpline.computeLineDistances();
+				var lineSegments = new THREE.LineSegments( geometryCube, new THREE.LineDashedMaterial( { color: 0xffaa00, dashSize: 3, gapSize: 1, linewidth: 2 } ) );
+				lineSegments.computeLineDistances();
 
-				var object = new THREE.Line( geometrySpline, new THREE.LineDashedMaterial( { color: 0xffffff, dashSize: 1, gapSize: 0.5 } ) );
-
-				objects.push( object );
-				scene.add( object );
-
-				var object = new THREE.LineSegments( geometryCube, new THREE.LineDashedMaterial( { color: 0xffaa00, dashSize: 3, gapSize: 1, linewidth: 2 } ) );
-
-				objects.push( object );
-				scene.add( object );
+				objects.push( lineSegments );
+				scene.add( lineSegments );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
@@ -113,46 +102,48 @@
 
 				var h = size * 0.5;
 
-				var geometry = new THREE.Geometry();
+				var geometry = new THREE.BufferGeometry();
+				var position = [];
 
-				geometry.vertices.push(
-					new THREE.Vector3( -h, -h, -h ),
-					new THREE.Vector3( -h, h, -h ),
+				position.push(
+					-h, -h, -h,
+					-h, h, -h,
 
-					new THREE.Vector3( -h, h, -h ),
-					new THREE.Vector3( h, h, -h ),
+					-h, h, -h,
+					h, h, -h,
 
-					new THREE.Vector3( h, h, -h ),
-					new THREE.Vector3( h, -h, -h ),
+					h, h, -h,
+					h, -h, -h,
 
-					new THREE.Vector3( h, -h, -h ),
-					new THREE.Vector3( -h, -h, -h ),
+					h, -h, -h,
+					-h, -h, -h,
 
+					-h, -h, h,
+					-h, h, h,
 
-					new THREE.Vector3( -h, -h, h ),
-					new THREE.Vector3( -h, h, h ),
+					-h, h, h,
+					h, h, h,
 
-					new THREE.Vector3( -h, h, h ),
-					new THREE.Vector3( h, h, h ),
+					h, h, h,
+					h, -h, h,
 
-					new THREE.Vector3( h, h, h ),
-					new THREE.Vector3( h, -h, h ),
+					h, -h, h,
+					-h, -h, h,
 
-					new THREE.Vector3( h, -h, h ),
-					new THREE.Vector3( -h, -h, h ),
+					-h, -h, -h,
+					-h, -h, h,
 
-					new THREE.Vector3( -h, -h, -h ),
-					new THREE.Vector3( -h, -h, h ),
+					-h, h, -h,
+					-h, h, h,
 
-					new THREE.Vector3( -h, h, -h ),
-					new THREE.Vector3( -h, h, h ),
+					h, h, -h,
+					h, h, h,
 
-					new THREE.Vector3( h, h, -h ),
-					new THREE.Vector3( h, h, h ),
-
-					new THREE.Vector3( h, -h, -h ),
-					new THREE.Vector3( h, -h, h )
+					h, -h, -h,
+					h, -h, h
 				 );
+
+				geometry.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
 
 				return geometry;
 
@@ -180,14 +171,16 @@
 
 				var time = Date.now() * 0.001;
 
-				for ( var i = 0; i < objects.length; i ++ ) {
+				scene.traverse( function( object ) {
 
-					var object = objects[ i ];
+					if ( object.isLine ) {
 
-					object.rotation.x = 0.25 * time;
-					object.rotation.y = 0.25 * time;
+						object.rotation.x = 0.25 * time;
+						object.rotation.y = 0.25 * time;
 
-				}
+					}
+
+				} );
 
 				renderer.render( scene, camera );
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -832,11 +832,20 @@ Object.assign( Vector4.prototype, {
 
 //
 
-Geometry.prototype.computeTangents = function () {
+Object.assign( Geometry.prototype, {
 
-	console.warn( 'THREE.Geometry: .computeTangents() has been removed.' );
+	computeTangents: function () {
 
-};
+		console.error( 'THREE.Geometry: .computeTangents() has been removed.' );
+
+	},
+	computeLineDistances: function () {
+
+		console.error( 'THREE.Geometry: .computeLineDistances() has been removed. Use THREE.Line.computeLineDistances() instead.' );
+
+	}
+
+} );
 
 Object.assign( Object3D.prototype, {
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -656,25 +656,6 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
-	computeLineDistances: function () {
-
-		var d = 0;
-		var vertices = this.vertices;
-
-		for ( var i = 0, il = vertices.length; i < il; i ++ ) {
-
-			if ( i > 0 ) {
-
-				d += vertices[ i ].distanceTo( vertices[ i - 1 ] );
-
-			}
-
-			this.lineDistances[ i ] = d;
-
-		}
-
-	},
-
 	computeBoundingBox: function () {
 
 		if ( this.boundingBox === null ) {

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -35,6 +35,67 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	isLine: true,
 
+	computeLineDistances: ( function () {
+
+		var start = new Vector3();
+		var end = new Vector3();
+
+		return function computeLineDistances() {
+
+			var distance = 0;
+			var geometry = this.geometry;
+
+			if ( geometry.isBufferGeometry ) {
+
+				// we assume non-indexed geometry
+
+				var positionAttribute = geometry.attributes.position;
+				var lineDistances = [];
+
+				for ( var i = 0, l = positionAttribute.count; i < l; i ++ ) {
+
+					if ( i > 0 ) {
+
+						start.fromBufferAttribute( positionAttribute, i - 1 );
+						end.fromBufferAttribute( positionAttribute, i );
+
+						distance += start.distanceTo( end );
+
+					}
+
+					lineDistances.push( distance );
+
+				}
+
+				geometry.addAttribute( 'lineDistance', new THREE.Float32BufferAttribute( lineDistances, 1 ) );
+
+			} else if ( geometry.isGeometry ) {
+
+				var vertices = geometry.vertices;
+
+				for ( var i = 0, l = vertices.length; i < l; i ++ ) {
+
+					if ( i > 0 ) {
+
+						start.copy( vertices[ i - 1 ] );
+						end.copy( vertices[ i ] );
+
+						distance += start.distanceTo( end );
+
+					}
+
+					geometry.lineDistances[ i ] = distance;
+
+				}
+
+			}
+
+			return this;
+
+		};
+
+	}() ),
+
 	raycast: ( function () {
 
 		var inverseMatrix = new Matrix4();

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -65,7 +65,7 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 						}
 
-						lineDistances.push( distance );
+						lineDistances[ i ] = distance;
 
 					}
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -42,7 +42,6 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		return function computeLineDistances() {
 
-			var distance = 0;
 			var geometry = this.geometry;
 
 			if ( geometry.isBufferGeometry ) {
@@ -52,20 +51,15 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 				if ( geometry.index === null ) {
 
 					var positionAttribute = geometry.attributes.position;
-					var lineDistances = [];
+					var lineDistances = [ 0 ];
 
-					for ( var i = 0, l = positionAttribute.count; i < l; i ++ ) {
+					for ( var i = 1, l = positionAttribute.count; i < l; i ++ ) {
 
-						if ( i > 0 ) {
+						start.fromBufferAttribute( positionAttribute, i - 1 );
+						end.fromBufferAttribute( positionAttribute, i );
 
-							start.fromBufferAttribute( positionAttribute, i - 1 );
-							end.fromBufferAttribute( positionAttribute, i );
-
-							distance += start.distanceTo( end );
-
-						}
-
-						lineDistances[ i ] = distance;
+						lineDistances[ i ] = lineDistances[ i - 1 ];
+						lineDistances[ i ] += start.distanceTo( end );
 
 					}
 
@@ -80,19 +74,14 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			} else if ( geometry.isGeometry ) {
 
 				var vertices = geometry.vertices;
+				var lineDistances = geometry.lineDistances;
 
-				for ( var i = 0, l = vertices.length; i < l; i ++ ) {
+				lineDistances[ 0 ] = 0;
 
-					if ( i > 0 ) {
+				for ( var i = 1, l = vertices.length; i < l; i ++ ) {
 
-						start.copy( vertices[ i - 1 ] );
-						end.copy( vertices[ i ] );
-
-						distance += start.distanceTo( end );
-
-					}
-
-					geometry.lineDistances[ i ] = distance;
+					lineDistances[ i ] = lineDistances[ i - 1 ];
+					lineDistances[ i ] += vertices[ i - 1 ].distanceTo( vertices[ i ] );
 
 				}
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -49,25 +49,33 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 				// we assume non-indexed geometry
 
-				var positionAttribute = geometry.attributes.position;
-				var lineDistances = [];
+				if ( geometry.index === null ) {
 
-				for ( var i = 0, l = positionAttribute.count; i < l; i ++ ) {
+					var positionAttribute = geometry.attributes.position;
+					var lineDistances = [];
 
-					if ( i > 0 ) {
+					for ( var i = 0, l = positionAttribute.count; i < l; i ++ ) {
 
-						start.fromBufferAttribute( positionAttribute, i - 1 );
-						end.fromBufferAttribute( positionAttribute, i );
+						if ( i > 0 ) {
 
-						distance += start.distanceTo( end );
+							start.fromBufferAttribute( positionAttribute, i - 1 );
+							end.fromBufferAttribute( positionAttribute, i );
+
+							distance += start.distanceTo( end );
+
+						}
+
+						lineDistances.push( distance );
 
 					}
 
-					lineDistances.push( distance );
+					geometry.addAttribute( 'lineDistance', new THREE.Float32BufferAttribute( lineDistances, 1 ) );
+
+				} else {
+
+					console.warn( 'THREE.Line.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
 
 				}
-
-				geometry.addAttribute( 'lineDistance', new THREE.Float32BufferAttribute( lineDistances, 1 ) );
 
 			} else if ( geometry.isGeometry ) {
 

--- a/src/objects/LineSegments.js
+++ b/src/objects/LineSegments.js
@@ -26,7 +26,6 @@ LineSegments.prototype = Object.assign( Object.create( Line.prototype ), {
 
 		return function computeLineDistances() {
 
-			var distance = 0;
 			var geometry = this.geometry;
 
 			if ( geometry.isBufferGeometry ) {
@@ -43,10 +42,8 @@ LineSegments.prototype = Object.assign( Object.create( Line.prototype ), {
 						start.fromBufferAttribute( positionAttribute, i );
 						end.fromBufferAttribute( positionAttribute, i + 1 );
 
-						distance += start.distanceTo( end );
-
 						lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
-						lineDistances[ i + 1 ] = distance;
+						lineDistances[ i + 1 ] = lineDistances[ i ] + start.distanceTo( end );
 
 					}
 
@@ -61,16 +58,15 @@ LineSegments.prototype = Object.assign( Object.create( Line.prototype ), {
 			} else if ( geometry.isGeometry ) {
 
 				var vertices = geometry.vertices;
+				var lineDistances = geometry.lineDistances;
 
 				for ( var i = 0, l = vertices.length; i < l; i += 2 ) {
 
 					start.copy( vertices[ i ] );
 					end.copy( vertices[ i + 1 ] );
 
-					distance += start.distanceTo( end );
-
-					geometry.lineDistances[ i ] = ( i === 0 ) ? 0 : geometry.lineDistances[ i - 1 ];
-					geometry.lineDistances[ i + 1 ] = distance;
+					lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
+					lineDistances[ i + 1 ] = lineDistances[ i ] + start.distanceTo( end );
 
 				}
 

--- a/src/objects/LineSegments.js
+++ b/src/objects/LineSegments.js
@@ -54,7 +54,7 @@ LineSegments.prototype = Object.assign( Object.create( Line.prototype ), {
 
 				} else {
 
-					console.warn( 'THREE.Line.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
+					console.warn( 'THREE.LineSegments.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
 
 				}
 

--- a/src/objects/LineSegments.js
+++ b/src/objects/LineSegments.js
@@ -1,4 +1,5 @@
 import { Line } from './Line.js';
+import { Vector3 } from '../math/Vector3.js';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -16,7 +17,70 @@ LineSegments.prototype = Object.assign( Object.create( Line.prototype ), {
 
 	constructor: LineSegments,
 
-	isLineSegments: true
+	isLineSegments: true,
+
+	computeLineDistances: ( function () {
+
+		var start = new Vector3();
+		var end = new Vector3();
+
+		return function computeLineDistances() {
+
+			var distance = 0;
+			var geometry = this.geometry;
+
+			if ( geometry.isBufferGeometry ) {
+
+				// we assume non-indexed geometry
+
+				if ( geometry.index === null ) {
+
+					var positionAttribute = geometry.attributes.position;
+					var lineDistances = [];
+
+					for ( var i = 0, l = positionAttribute.count; i < l; i += 2 ) {
+
+						start.fromBufferAttribute( positionAttribute, i );
+						end.fromBufferAttribute( positionAttribute, i + 1 );
+
+						distance += start.distanceTo( end );
+
+						lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
+						lineDistances[ i + 1 ] = distance;
+
+					}
+
+					geometry.addAttribute( 'lineDistance', new THREE.Float32BufferAttribute( lineDistances, 1 ) );
+
+				} else {
+
+					console.warn( 'THREE.Line.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
+
+				}
+
+			} else if ( geometry.isGeometry ) {
+
+				var vertices = geometry.vertices;
+
+				for ( var i = 0, l = vertices.length; i < l; i += 2 ) {
+
+					start.copy( vertices[ i ] );
+					end.copy( vertices[ i + 1 ] );
+
+					distance += start.distanceTo( end );
+
+					geometry.lineDistances[ i ] = ( i === 0 ) ? 0 : geometry.lineDistances[ i - 1 ];
+					geometry.lineDistances[ i + 1 ] = distance;
+
+				}
+
+			}
+
+			return this;
+
+		};
+
+	}() )
 
 } );
 

--- a/test/unit/src/core/Geometry.tests.js
+++ b/test/unit/src/core/Geometry.tests.js
@@ -272,18 +272,6 @@ export default QUnit.module( 'Core', () => {
 
 		QUnit.test( "normalize", ( assert ) => {
 
-			var geometry = getGeometry();
-			geometry.computeLineDistances();
-
-			var distances = geometry.lineDistances;
-			assert.ok( distances[ 0 ] === 0, "distance to the 1st point is 0" );
-			assert.ok( distances[ 1 ] === 1 + distances[ 0 ], "distance from the 1st to the 2nd is sqrt(2nd - 1st) + distance - 1" );
-			assert.ok( distances[ 2 ] === Math.sqrt( 0.5 * 0.5 + 1 ) + distances[ 1 ], "distance from the 1st to the 3nd is sqrt(3rd - 2nd) + distance - 1" );
-
-		} );
-
-		QUnit.test( "normalize (actual)", ( assert ) => {
-
 			var a = getGeometry();
 			var sqrt = 0.5 * Math.sqrt( 2 );
 			var expected = [
@@ -328,12 +316,6 @@ export default QUnit.module( 'Core', () => {
 		} );
 
 		QUnit.todo( "computeMorphNormals", ( assert ) => {
-
-			assert.ok( false, "everything's gonna be alright" );
-
-		} );
-
-		QUnit.todo( "computeLineDistances", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 


### PR DESCRIPTION
This PR moves `.computeLineDistance()` to `Line` and adds support for (non-indexed) `BufferGeometry`. The combination of `LineDashedMaterial` and `BufferGeometry` does work now. This feature was frequently asked by users, e.g.

https://discourse.threejs.org/t/computelinedistances-with-buffergeometry/644 or
#7013 

The implementation is based on @WestLangley's suggestion, see https://github.com/mrdoob/three.js/issues/7013#issuecomment-132382890