### PR TITLE
GLTFExporter: Morph Target weights support

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -792,6 +792,7 @@ THREE.GLTFExporter.prototype = {
 			// Morph targets
 			if ( mesh.morphTargetInfluences !== undefined && mesh.morphTargetInfluences.length > 0 ) {
 
+				var weights = [];
 				gltfMesh.primitives[ 0 ].targets = [];
 
 				for ( var i = 0; i < mesh.morphTargetInfluences.length; ++ i ) {
@@ -808,7 +809,11 @@ THREE.GLTFExporter.prototype = {
 
 					gltfMesh.primitives[ 0 ].targets.push( target );
 
+					weights.push( mesh.morphTargetInfluences[ i ] );
+
 				}
+
+				gltfMesh.weights = weights;
 
 			}
 


### PR DESCRIPTION
This PR adds morph target `weights` support to `GLTFExporter`.