### PR TITLE
Reintroduce standing matrix

### DIFF
--- a/examples/js/vr/ViveController.js
+++ b/examples/js/vr/ViveController.js
@@ -72,7 +72,7 @@ THREE.ViveController = function ( id ) {
 			if ( pose.position !== null ) scope.position.fromArray( pose.position );
 			if ( pose.orientation !== null ) scope.quaternion.fromArray( pose.orientation );
 			scope.matrix.compose( scope.position, scope.quaternion, scope.scale );
-			scope.matrix.multiplyMatrices( scope.standingMatrix, scope.matrix );
+			scope.matrix.premultiply( scope.standingMatrix );	
 			scope.matrixWorldNeedsUpdate = true;
 			scope.visible = true;
 

--- a/examples/js/vr/ViveController.js
+++ b/examples/js/vr/ViveController.js
@@ -40,6 +40,7 @@ THREE.ViveController = function ( id ) {
 	}
 
 	this.matrixAutoUpdate = false;
+	this.standingMatrix = new THREE.Matrix4();
 
 	this.getGamepad = function () {
 
@@ -71,6 +72,7 @@ THREE.ViveController = function ( id ) {
 			if ( pose.position !== null ) scope.position.fromArray( pose.position );
 			if ( pose.orientation !== null ) scope.quaternion.fromArray( pose.orientation );
 			scope.matrix.compose( scope.position, scope.quaternion, scope.scale );
+			scope.matrix.multiplyMatrices( scope.standingMatrix, scope.matrix );
 			scope.matrixWorldNeedsUpdate = true;
 			scope.visible = true;
 

--- a/examples/webvr_sandbox.html
+++ b/examples/webvr_sandbox.html
@@ -24,7 +24,7 @@
 
 		<script>
 
-			var camera, scene, renderer;
+			var box, camera, scene, renderer, poseTarget;
 
 			var reflector;
 
@@ -123,6 +123,15 @@
 				mesh.receiveShadow = true;
 				reflector.add( mesh );
 
+
+				box = new THREE.Mesh(new THREE.BoxGeometry());
+				var boxPivot = new THREE.Object3D();
+				boxPivot.add(box);
+				boxPivot.position.z = -3;
+				scene.add(boxPivot);
+
+				poseTarget = new THREE.Object3D();
+
 				//
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
@@ -131,6 +140,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;
 				renderer.vr.enabled = true;
+				renderer.vr.setPoseTarget(poseTarget);
 				document.body.appendChild( renderer.domElement );
 
 				document.body.appendChild( WEBVR.createButton( renderer ) );
@@ -138,7 +148,6 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize, false );
-
 			}
 
 			function onWindowResize() {
@@ -162,6 +171,9 @@
 				var mesh = scene.children[ 1 ];
 				mesh.rotation.x = time * 2;
 				mesh.rotation.y = time * 5;
+
+				box.position.setFromMatrixPosition(poseTarget.matrixWorld);
+				box.quaternion.setFromRotationMatrix(poseTarget.matrixWorld);
 
 				renderer.render( scene, camera );
 

--- a/examples/webvr_sandbox.html
+++ b/examples/webvr_sandbox.html
@@ -24,7 +24,7 @@
 
 		<script>
 
-			var box, camera, scene, renderer, poseTarget;
+			var camera, scene, renderer;
 
 			var reflector;
 
@@ -123,15 +123,6 @@
 				mesh.receiveShadow = true;
 				reflector.add( mesh );
 
-
-				box = new THREE.Mesh(new THREE.BoxGeometry());
-				var boxPivot = new THREE.Object3D();
-				boxPivot.add(box);
-				boxPivot.position.z = -3;
-				scene.add(boxPivot);
-
-				poseTarget = new THREE.Object3D();
-
 				//
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
@@ -140,7 +131,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;
 				renderer.vr.enabled = true;
-				renderer.vr.setPoseTarget(poseTarget);
 				document.body.appendChild( renderer.domElement );
 
 				document.body.appendChild( WEBVR.createButton( renderer ) );
@@ -148,6 +138,7 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize, false );
+
 			}
 
 			function onWindowResize() {
@@ -171,9 +162,6 @@
 				var mesh = scene.children[ 1 ];
 				mesh.rotation.x = time * 2;
 				mesh.rotation.y = time * 5;
-
-				box.position.setFromMatrixPosition(poseTarget.matrixWorld);
-				box.quaternion.setFromRotationMatrix(poseTarget.matrixWorld);
 
 				renderer.render( scene, camera );
 

--- a/examples/webvr_vive.html
+++ b/examples/webvr_vive.html
@@ -58,7 +58,6 @@
 				scene.background = new THREE.Color( 0x505050 );
 
 				var user = new THREE.Group();
-				user.position.set( 0, 1.6, 0 );
 				scene.add( user );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
@@ -165,9 +164,11 @@
 				// controllers
 
 				controller1 = new THREE.ViveController( 0 );
+				controller1.standingMatrix = renderer.vr.getStandingMatrix();
 				user.add( controller1 );
 
 				controller2 = new THREE.ViveController( 1 );
+				controller2.standingMatrix = renderer.vr.getStandingMatrix();
 				user.add( controller2 );
 
 				var loader = new THREE.OBJLoader();

--- a/examples/webvr_vive_dragging.html
+++ b/examples/webvr_vive_dragging.html
@@ -59,7 +59,6 @@
 				scene.background = new THREE.Color( 0x808080 );
 
 				var user = new THREE.Group();
-				user.position.set( 0, 1.6, 0 );
 				scene.add( user );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
@@ -143,11 +142,13 @@
 				// controllers
 
 				controller1 = new THREE.ViveController( 0 );
+				controller1.standingMatrix = renderer.vr.getStandingMatrix();
 				controller1.addEventListener( 'triggerdown', onTriggerDown );
 				controller1.addEventListener( 'triggerup', onTriggerUp );
 				user.add( controller1 );
 
 				controller2 = new THREE.ViveController( 1 );
+				controller2.standingMatrix = renderer.vr.getStandingMatrix();
 				controller2.addEventListener( 'triggerdown', onTriggerDown );
 				controller2.addEventListener( 'triggerup', onTriggerUp );
 				user.add( controller2 );

--- a/examples/webvr_vive_paint.html
+++ b/examples/webvr_vive_paint.html
@@ -70,7 +70,6 @@
 				scene.background = new THREE.Color( 0x222222 );
 
 				var user = new THREE.Group();
-				user.position.set( 0, 1.6, 0 );
 				scene.add( user );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
@@ -142,11 +141,13 @@
 				// controllers
 
 				controller1 = new THREE.PaintViveController( 0 );
+				controller1.standingMatrix = renderer.vr.getStandingMatrix();
 				controller1.userData.points = [ new THREE.Vector3(), new THREE.Vector3() ];
 				controller1.userData.matrices = [ new THREE.Matrix4(), new THREE.Matrix4() ];
 				user.add( controller1 );
 
 				controller2 = new THREE.PaintViveController( 1 );
+				controller2.standingMatrix = renderer.vr.getStandingMatrix();
 				controller2.userData.points = [ new THREE.Vector3(), new THREE.Vector3() ];
 				controller2.userData.matrices = [ new THREE.Matrix4(), new THREE.Matrix4() ];
 				user.add( controller2 );

--- a/examples/webvr_vive_sculpt.html
+++ b/examples/webvr_vive_sculpt.html
@@ -60,7 +60,6 @@
 				scene.background = new THREE.Color( 0x222222 );
 
 				var user = new THREE.Group();
-				user.position.set( 0, 1.6, 0 );
 				scene.add( user );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
@@ -124,9 +123,11 @@
 				// controllers
 
 				controller1 = new THREE.ViveController( 0 );
+				controller1.standingMatrix = renderer.vr.getStandingMatrix();
 				user.add( controller1 );
 
 				controller2 = new THREE.ViveController( 1 );
+				controller2.standingMatrix = renderer.vr.getStandingMatrix();
 				user.add( controller2 );
 
 				var loader = new THREE.OBJLoader();

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1587,16 +1587,6 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 
 //
 
-Object.assign( WebVRManager.prototype, {
-
-	getStandingMatrix: function () {
-
-		console.warn( 'THREE.WebVRManager: .getStandingMatrix() has been removed.' );
-
-	}
-
-} );
-
 Object.defineProperties( WebVRManager.prototype, {
 
 	standing: {

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -112,7 +112,7 @@ function WebVRManager( renderer ) {
 
 			poseObject.position.fromArray( pose.position );
 
-		} 
+		}
 
 		if ( pose.orientation !== null ) {
 
@@ -120,10 +120,8 @@ function WebVRManager( renderer ) {
 
 		}
 
-		poseObject.updateMatrixWorld();
-
 		var stageParameters = device.stageParameters;
-		
+
 		if (stageParameters) {
 		  standingMatrix.fromArray( stageParameters.sittingToStandingTransform );
 		} else {
@@ -131,7 +129,8 @@ function WebVRManager( renderer ) {
 		}
 
 		standingMatrixInverse.getInverse( standingMatrix );
-		poseObject.matrixWorld.multiply( standingMatrix );
+		poseObject.position.applyMatrix4( standingMatrix );
+		poseObject.updateMatrixWorld();
 		camera.matrixWorldInverse.multiply( standingMatrixInverse );
 
 		if ( device.isPresenting === false ) return camera;

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -112,6 +112,10 @@ function WebVRManager( renderer ) {
 
 			poseObject.position.fromArray( pose.position );
 
+		} else {
+
+			poseObject.position.set( 0, 0, 0 );
+
 		}
 
 		if ( pose.orientation !== null ) {
@@ -128,10 +132,8 @@ function WebVRManager( renderer ) {
 		  standingMatrix.makeTranslation(0, scope.userHeight, 0);
 		}
 
-		standingMatrixInverse.getInverse( standingMatrix );
 		poseObject.position.applyMatrix4( standingMatrix );
 		poseObject.updateMatrixWorld();
-		camera.matrixWorldInverse.multiply( standingMatrixInverse );
 
 		if ( device.isPresenting === false ) return camera;
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -16,6 +16,11 @@ function WebVRManager( renderer ) {
 
 	var poseTarget = null;
 
+	var standingMatrix = new Matrix4();
+	var standingMatrixInverse = new Matrix4();
+
+	scope.userHeight = 1.6;
+
 	if ( typeof window !== 'undefined' && 'VRFrameData' in window ) {
 
 		frameData = new window.VRFrameData();
@@ -109,7 +114,7 @@ function WebVRManager( renderer ) {
 
 		} else {
 
-			poseObject.position.set( 0, 0, 0 );
+			poseObject.position.set( 0, scope.userHeight, 0 );
 
 		}
 
@@ -120,6 +125,18 @@ function WebVRManager( renderer ) {
 		}
 
 		poseObject.updateMatrixWorld();
+
+		var stageParameters = device.stageParameters;
+		
+		if (stageParameters) {
+		  standingMatrix.fromArray( stageParameters.sittingToStandingTransform );
+		} else {
+		  standingMatrix.makeTranslation(0, scope.userHeight, 0);
+		}
+
+		standingMatrixInverse.getInverse( standingMatrix );
+		poseObject.matrixWorld.multiply( standingMatrix );
+		camera.matrixWorldInverse.multiply( standingMatrixInverse );
 
 		if ( device.isPresenting === false ) return camera;
 
@@ -136,6 +153,9 @@ function WebVRManager( renderer ) {
 
 		cameraL.matrixWorldInverse.fromArray( frameData.leftViewMatrix );
 		cameraR.matrixWorldInverse.fromArray( frameData.rightViewMatrix );
+
+		cameraL.matrixWorldInverse.multiply( standingMatrixInverse );
+		cameraR.matrixWorldInverse.multiply( standingMatrixInverse );
 
 		var parent = poseObject.parent;
 
@@ -184,6 +204,12 @@ function WebVRManager( renderer ) {
 		}
 
 		return cameraVR;
+
+	};
+
+	this.getStandingMatrix = function () {
+
+		return standingMatrix;
 
 	};
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -132,6 +132,7 @@ function WebVRManager( renderer ) {
 		  standingMatrix.makeTranslation(0, scope.userHeight, 0);
 		}
 
+		standingMatrixInverse.getInverse( standingMatrix );
 		poseObject.position.applyMatrix4( standingMatrix );
 		poseObject.updateMatrixWorld();
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -112,11 +112,7 @@ function WebVRManager( renderer ) {
 
 			poseObject.position.fromArray( pose.position );
 
-		} else {
-
-			poseObject.position.set( 0, scope.userHeight, 0 );
-
-		}
+		} 
 
 		if ( pose.orientation !== null ) {
 


### PR DESCRIPTION
The Vive examples are currently broken. The assigned user height from the camera rig adds up to the height coming from the VRDisplay pose resulting in a camera that it's much higher than expected. Oculus and Vive tracking systems are different. Oculus Rift does not have the notion of ground and the position is always relative to where the sensors start reading or are reset by the user (The same applies to Windows MR). On the other hand, Vive knows the position relative to the ground and you always get the user real height. A way to normalize this is always consider standing coordinates by applying the sittingToStandingTransform. I never fully understood the purpose of sitting experiences. In standing coordinates you can use Oculus both sitting and standing. I don't see any limitations when it comes to content creation. By always transforming to standing coordinates both Oculus and Vive behave the same way for the content developer. The only difference is that Vive returns the real height of the user thanks to Lighthouse tracking capabilities and Oculus calculates the height based on the value introduced by the user when calibrating the headset. Tested on:

- [x] Windows Mixed Reality
- [x] Oculus Rift
- [x] Vive