### PR TITLE
WebVR.js: Automatically enter VR on vrdisplayactivate event.

### DIFF
--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -93,6 +93,12 @@ var WEBVR = {
 
 			}, false );
 
+			window.addEventListener( 'vrdisplayactivate', function ( event ) {
+
+				event.display.requestPresent( [ { source: renderer.domElement } ] );
+
+			}, false );
+
 			navigator.getVRDisplays()
 				.then( function ( displays ) {
 


### PR DESCRIPTION
Propagate VR-mode upon link traversal so the the user doesn't have
to manually click on the 'enter VR' button each time.

Fixes #13105