### PR TITLE
Change incorrect references in Torus docs

### DIFF
--- a/docs/api/geometries/TorusBufferGeometry.html
+++ b/docs/api/geometries/TorusBufferGeometry.html
@@ -44,7 +44,7 @@
 
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Float arc])</h3>
 		<div>
-		radius — Default is 1. <br />
+		radius - Radius of the torus, from the center of the torus to the center of the tube. Default is 1. <br />
 		tube — Radius of the tube.  Default is 0.4. <br />
 		radialSegments — Default is 8 <br />
 		tubularSegments — Default is 6. <br />

--- a/docs/api/geometries/TorusBufferGeometry.html
+++ b/docs/api/geometries/TorusBufferGeometry.html
@@ -45,7 +45,7 @@
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Float arc])</h3>
 		<div>
 		radius — Default is 1. <br />
-		tube — Diameter of the tube.  Default is 0.4. <br />
+		tube — Radius of the tube.  Default is 0.4. <br />
 		radialSegments — Default is 8 <br />
 		tubularSegments — Default is 6. <br />
 		arc — Central angle.  Default is Math.PI * 2.

--- a/docs/api/geometries/TorusGeometry.html
+++ b/docs/api/geometries/TorusGeometry.html
@@ -44,7 +44,7 @@
 
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Float arc])</h3>
 		<div>
-		radius — Default is 1. <br />
+		radius - Radius of the torus, from the center of the torus to the center of the tube. Default is 1. <br />
 		tube — Radius of the tube.  Default is 0.4. <br />
 		radialSegments — Default is 8 <br />
 		tubularSegments — Default is 6. <br />

--- a/docs/api/geometries/TorusGeometry.html
+++ b/docs/api/geometries/TorusGeometry.html
@@ -45,7 +45,7 @@
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Float arc])</h3>
 		<div>
 		radius — Default is 1. <br />
-		tube — Diameter of the tube.  Default is 0.4. <br />
+		tube — Radius of the tube.  Default is 0.4. <br />
 		radialSegments — Default is 8 <br />
 		tubularSegments — Default is 6. <br />
 		arc — Central angle.  Default is Math.PI * 2.

--- a/docs/api/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/geometries/TorusKnotBufferGeometry.html
@@ -46,7 +46,7 @@
 		<div>
 			<ul>
 				<li>radius — Default is 1.</li>
-				<li>tube — Diameter of the tube. Default is 0.4.</li>
+				<li>tube — Radius of the tube. Default is 0.4.</li>
 				<li>tubularSegments — Default is 64.</li>
 				<li>radialSegments — Default is 8.</li>
 				<li>p — This value determines, how many times the geometry winds around its axis of rotational symmetry. Default is 2.</li>

--- a/docs/api/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/geometries/TorusKnotBufferGeometry.html
@@ -45,7 +45,7 @@
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer tubularSegments], [page:Integer radialSegments], [page:Integer p], [page:Integer q])</h3>
 		<div>
 			<ul>
-				<li>radius — Default is 1.</li>
+				<li>radius - Radius of the torus. Default is 1.</li>
 				<li>tube — Radius of the tube. Default is 0.4.</li>
 				<li>tubularSegments — Default is 64.</li>
 				<li>radialSegments — Default is 8.</li>

--- a/docs/api/geometries/TorusKnotGeometry.html
+++ b/docs/api/geometries/TorusKnotGeometry.html
@@ -46,7 +46,7 @@
 		<div>
 			<ul>
 				<li>radius — Default is 1.</li>
-				<li>tube — Diameter of the tube. Default is 0.4.</li>
+				<li>tube — Radius of the tube. Default is 0.4.</li>
 				<li>tubularSegments — Default is 64.</li>
 				<li>radialSegments — Default is 8.</li>
 				<li>p — This value determines, how many times the geometry winds around its axis of rotational symmetry. Default is 2.</li>

--- a/docs/api/geometries/TorusKnotGeometry.html
+++ b/docs/api/geometries/TorusKnotGeometry.html
@@ -45,7 +45,7 @@
 		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer tubularSegments], [page:Integer radialSegments], [page:Integer p], [page:Integer q])</h3>
 		<div>
 			<ul>
-				<li>radius — Default is 1.</li>
+				<li>radius - Radius of the torus. Default is 1.</li>
 				<li>tube — Radius of the tube. Default is 0.4.</li>
 				<li>tubularSegments — Default is 64.</li>
 				<li>radialSegments — Default is 8.</li>


### PR DESCRIPTION
Fixes #13155 

  The tube parameter is actually a radius, not a diameter