### PR TITLE
Editor: Focus will frame target in view.

### DIFF
--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -37,8 +37,36 @@ THREE.EditorControls = function ( object, domElement ) {
 
 	this.focus = function ( target ) {
 
+		if ( target === undefined || !target.isObject3D ) {
+			return;
+		}
+
 		var box = new THREE.Box3().setFromObject( target );
-		object.lookAt( center.copy( box.getCenter() ) );
+
+		var targetDistance;
+
+		if ( box.isEmpty() ) {
+
+			// Focusing on an empty such as a light.
+
+			target.getWorldPosition( center );
+			targetDistance = 0.5;
+
+		} else {
+
+			center.copy( box.getCenter() );
+			targetDistance = box.getBoundingSphere().radius * 6;
+
+		}
+
+		var forwards = object.getWorldDirection().normalize();
+
+		var targetDelta = forwards.multiplyScalar( -targetDistance );
+
+		var targetWorldPosition = targetDelta.add( center );
+
+		object.position.copy( targetWorldPosition );
+
 		scope.dispatchEvent( changeEvent );
 
 	};

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -37,8 +37,36 @@ THREE.EditorControls = function ( object, domElement ) {
 
 	this.focus = function ( target ) {
 
+		if ( target === undefined || !target.isObject3D ) {
+			return;
+		}
+
 		var box = new THREE.Box3().setFromObject( target );
-		object.lookAt( center.copy( box.getCenter() ) );
+
+		var targetDistance;
+
+		if ( box.isEmpty() ) {
+
+			// Focusing on an empty such as a light.
+
+			target.getWorldPosition( center );
+			targetDistance = 0.5;
+
+		} else {
+
+			center.copy( box.getCenter() );
+			targetDistance = box.getBoundingSphere().radius * 6;
+
+		}
+
+		var forwards = object.getWorldDirection().normalize();
+
+		var targetDelta = forwards.multiplyScalar( -targetDistance );
+
+		var targetWorldPosition = targetDelta.add( center );
+
+		object.position.copy( targetWorldPosition );
+
 		scope.dispatchEvent( changeEvent );
 
 	};
@@ -198,6 +226,8 @@ THREE.EditorControls = function ( object, domElement ) {
 	domElement.addEventListener( 'wheel', onMouseWheel, false );
 
 	// touch
+
+	var touch = new THREE.Vector3();
 
 	var touches = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];
 	var prevTouches = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -37,7 +37,7 @@ THREE.EditorControls = function ( object, domElement ) {
 
 	this.focus = function ( target ) {
 
-		if ( target === undefined || !target.isObject3D ) {
+		if ( target === undefined ) {
 			return;
 		}
 

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -37,36 +37,8 @@ THREE.EditorControls = function ( object, domElement ) {
 
 	this.focus = function ( target ) {
 
-		if ( target === undefined || !target.isObject3D ) {
-			return;
-		}
-
 		var box = new THREE.Box3().setFromObject( target );
-
-		var targetDistance;
-
-		if ( box.isEmpty() ) {
-
-			// Focusing on an empty such as a light.
-
-			target.getWorldPosition( center );
-			targetDistance = 0.5;
-
-		} else {
-
-			center.copy( box.getCenter() );
-			targetDistance = box.getBoundingSphere().radius * 6;
-
-		}
-
-		var forwards = object.getWorldDirection().normalize();
-
-		var targetDelta = forwards.multiplyScalar( -targetDistance );
-
-		var targetWorldPosition = targetDelta.add( center );
-
-		object.position.copy( targetWorldPosition );
-
+		object.lookAt( center.copy( box.getCenter() ) );
 		scope.dispatchEvent( changeEvent );
 
 	};
@@ -226,8 +198,6 @@ THREE.EditorControls = function ( object, domElement ) {
 	domElement.addEventListener( 'wheel', onMouseWheel, false );
 
 	// touch
-
-	var touch = new THREE.Vector3();
 
 	var touches = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];
 	var prevTouches = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];


### PR DESCRIPTION
This changes the EditorControls.focus behaviour in a few ways:

1. Will translate the camera to a distance proportional to the bounding box size of the target to frame it in the viewport.

2. The camera will only translate when focusing instead of rotating due to a lookAt call. I think this behaviour is more standard in 3d programs and I find the lookAt method to be a little disorienting.

3. Fixed a bug where the camera couldn't focus on empties which don't have geometries, such as lights or groups.