### PR TITLE
ColladaLoader: Fallback if material doesn't match

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3191,8 +3191,11 @@ THREE.ColladaLoader.prototype = {
 
 				var id = instanceMaterials[ keys[ i ] ];
 
-				if( id === undefined ) { // Fallback if no material matches
-					id = instanceMaterials[Object.keys(instanceMaterials)[0]] // take simply the first material 
+				if ( id === undefined ) {
+
+					console.warn( 'THREE.ColladaLoader: Material with key %s not found. Apply fallback material.', keys[ i ] );
+					id = instanceMaterials[ Object.keys( instanceMaterials )[ 0 ] ];
+
 				}
 
 				materials.push( getMaterial( id ) );

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3183,6 +3183,8 @@ THREE.ColladaLoader.prototype = {
 
 		}
 
+		var fallbackMaterial = new THREE.MeshPhongMaterial( { color: 0xff00ff ) };
+
 		function resolveMaterialBinding( keys, instanceMaterials ) {
 
 			var materials = [];
@@ -3194,11 +3196,13 @@ THREE.ColladaLoader.prototype = {
 				if ( id === undefined ) {
 
 					console.warn( 'THREE.ColladaLoader: Material with key %s not found. Apply fallback material.', keys[ i ] );
-					id = instanceMaterials[ Object.keys( instanceMaterials )[ 0 ] ];
+					materials.push( fallbackMaterial );
+
+				} else {
+
+					materials.push( getMaterial( id ) );
 
 				}
-
-				materials.push( getMaterial( id ) );
 
 			}
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3190,6 +3190,11 @@ THREE.ColladaLoader.prototype = {
 			for ( var i = 0, l = keys.length; i < l; i ++ ) {
 
 				var id = instanceMaterials[ keys[ i ] ];
+
+				if( id === undefined ) { // Fallback if no material matches
+					id = instanceMaterials[Object.keys(instanceMaterials)[0]] // take simply the first material 
+				}
+
 				materials.push( getMaterial( id ) );
 
 			}

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3183,7 +3183,7 @@ THREE.ColladaLoader.prototype = {
 
 		}
 
-		var fallbackMaterial = new THREE.MeshPhongMaterial( { color: 0xff00ff ) };
+		var fallbackMaterial = new THREE.MeshBasicMaterial( { color: 0xff00ff ) };
 
 		function resolveMaterialBinding( keys, instanceMaterials ) {
 


### PR DESCRIPTION
If no material is found the loader errors.
For example when you download a model as .dae from mecabricks it seems that the reference symbol defined in the "instance_material" often doesn't match the one of the material property of the polylist of the linked geometry.
BUT for example Blender doesn't care and show the model with the correct materials. Even though it ignores the specification, but at least it doesn't errors. So I suggest that we still keep conform with the specification BUT if the model is a bit wrong with linking the correct materials we should at least fallback to some defined material. In my case I would fallback to the "first" (should be sorted alpha-numeric with ```Object.keys``` ) material. So the user can see that something is wrong with his materials when the model is displayed.

Attached some demo model.
Check out the node with id "Part_14". It uses "3023-mesh" as geometry and tries to map symbol "194:::-material" in instance_material but "3023-mesh" only has "199:::-material" defined as symbol. Check out the images below.

With the PR code we still try first to map the symbol according to the specification but if we don't find it we just fallback to the "target" of instance_material which in this case displays the model correct.

![image](https://user-images.githubusercontent.com/22448974/35382437-842aaef2-01bf-11e8-8f8a-650de46bfd24.png)

![image](https://user-images.githubusercontent.com/22448974/35382411-6f6db4dc-01bf-11e8-871c-ccbefcb9a8dd.png)



[venator class star destroyer.zip](https://github.com/mrdoob/three.js/files/1663447/venator.class.star.destroyer.zip)

/ping @mrdoob  @Mugen87 
