### PR TITLE
WebGLRenderer: Fix first time skin render

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1781,6 +1781,7 @@ function WebGLRenderer( parameters ) {
 						boneMatrices.set( skeleton.boneMatrices ); // copy current values
 
 						var boneTexture = new DataTexture( boneMatrices, size, size, RGBAFormat, FloatType );
+						boneTexture.needsUpdate = true;
 
 						skeleton.boneMatrices = boneMatrices;
 						skeleton.boneTexture = boneTexture;


### PR DESCRIPTION
Fixes #11940

When the bone texture is created, it's necessary to set `needsUpdate` to `true` in order to trigger the initial texture upload.