### PR TITLE
GLTFLoader: only refresh uniforms on correct material

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -714,7 +714,7 @@ THREE.GLTFLoader = ( function () {
 			// Here's based on refreshUniformsCommon() and refreshUniformsStandard() in WebGLRenderer.
 			refreshUniforms: function ( renderer, scene, camera, geometry, material, group ) {
 
-				if ( material.isGLTFSpecularGlossinessMaterial !== true) {
+				if ( material.isGLTFSpecularGlossinessMaterial !== true ) {
 
 					return;
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -714,7 +714,7 @@ THREE.GLTFLoader = ( function () {
 			// Here's based on refreshUniformsCommon() and refreshUniformsStandard() in WebGLRenderer.
 			refreshUniforms: function ( renderer, scene, camera, geometry, material, group ) {
 
-				if ( !material.isGLTFSpecularGlossinessMaterial) {
+				if ( material.isGLTFSpecularGlossinessMaterial !== true) {
 
 					return;
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -714,6 +714,12 @@ THREE.GLTFLoader = ( function () {
 			// Here's based on refreshUniformsCommon() and refreshUniformsStandard() in WebGLRenderer.
 			refreshUniforms: function ( renderer, scene, camera, geometry, material, group ) {
 
+				if ( !material.isGLTFSpecularGlossinessMaterial) {
+
+					return;
+
+				}
+
 				var uniforms = material.uniforms;
 				var defines = material.defines;
 


### PR DESCRIPTION
Simple case: 
1. Load GLTF File with Specular-Glosiness-Material so the ```refreshUnfiorms``` function is being set ```mesh.onBeforeRender = extensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ].refreshUniforms;``` 
2. Use an override material for the scene to render, for example use the SAOPass.
3. Get error because u try to work with uniforms of a material which doesn't have any (see image)
![image](https://user-images.githubusercontent.com/22448974/35430111-29191932-0277-11e8-9969-dcd8356f365b.png)

Suggestion:
Simple check if the material has the property ```isGLTFSpecularGlossinessMaterial``` and it is true. Because the ```refreshUniforms``` function is only set if it is true.