### PR TITLE
Update google-closure-compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "electron": "1.7.11",
     "eslint": "^4.1.1",
     "eslint-config-mdcs": "^4.2.2",
-    "google-closure-compiler": "^20170521.0.0",
+    "google-closure-compiler": "20180101.0.0",
     "qunit": "^2.4.0",
     "rollup": "^0.51.0",
     "rollup-watch": "^4.0.0",

--- a/utils/build/externs.js
+++ b/utils/build/externs.js
@@ -3,5 +3,5 @@ var define;
 var module;
 var exports;
 var performance;
-var ImageBitmap, createImageBitmap;
+var createImageBitmap;
 var WebGL2RenderingContext;


### PR DESCRIPTION
This PR updates the google-closure-compiler to the latest stable version.

It was necessary to remove `ImageBitmap` from `externs.js` since it's now defined within the tool.