### PR TITLE
Updated Rollup to ^0.55.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-config-mdcs": "^4.2.2",
     "google-closure-compiler": "20180101.0.0",
     "qunit": "^2.4.0",
-    "rollup": "^0.51.0",
+    "rollup": "^0.55.1",
     "rollup-watch": "^4.0.0",
     "serve": "6.4.9",
     "uglify-js": "^3.0.23"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,6 @@ function glsl() {
 
 export default {
 	input: 'src/Three.js',
-	indent: '\t',
 	plugins: [
 		glsl()
 	],
@@ -34,11 +33,13 @@ export default {
 		{
 			format: 'umd',
 			name: 'THREE',
-			file: 'build/three.js'
+			file: 'build/three.js',
+			indent: '\t'
 		},
 		{
 			format: 'es',
-			file: 'build/three.module.js'
+			file: 'build/three.module.js',
+			indent: '\t'
 		}
 	]
 };


### PR DESCRIPTION
Updated Rollup to the latest version and removed a deprecation warning (`indent is now output.indent`).