### PR TITLE
Panorama example: enabled damping

### DIFF
--- a/examples/webgl_panorama_cube.html
+++ b/examples/webgl_panorama_cube.html
@@ -60,9 +60,10 @@
 			camera = new THREE.PerspectiveCamera( 90, window.innerWidth / window.innerHeight, 0.1, 100 );
 			camera.position.z = 0.01;
 
-			controls = new THREE.OrbitControls( camera );
+			controls = new THREE.OrbitControls( camera, renderer.domElement );
 			controls.enableZoom = false;
 			controls.enablePan = false;
+			controls.enableDamping = true;
 
 			var textures = getTexturesFromAtlasFile( "textures/cube/sun_temple_stripe.jpg", 6 );
 
@@ -130,9 +131,11 @@
 
 		function animate() {
 
-			renderer.render( scene, camera );
-
 			requestAnimationFrame( animate );
+
+			controls.update(); // required when damping is enabled
+
+			renderer.render( scene, camera );
 
 		}
 


### PR DESCRIPTION
This example contains a static scene, but uses an animation loop. If we are going to do that, we might as well enable damping in the example.