### PR TITLE
GLTFExporter: force node names to be strings.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1070,7 +1070,7 @@ THREE.GLTFExporter.prototype = {
 
 			if ( object.name ) {
 
-				gltfNode.name = String(object.name);
+				gltfNode.name = String( object.name );
 
 			}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1070,7 +1070,7 @@ THREE.GLTFExporter.prototype = {
 
 			if ( object.name ) {
 
-				gltfNode.name = object.name;
+				gltfNode.name = String(object.name);
 
 			}
 


### PR DESCRIPTION
If an object name is a number it is currently copied to the gltfNode as a number. This results in gltf validator errors:

 "code": "TYPE_MISMATCH",
                "message": "Type mismatch. Property value 26 is not a 'string'.",
                "severity": 0,
                "pointer": "/nodes/1/name"

This change ensures gltfNode.name is a string in all cases.