### PR TITLE
When gl.VERSION without `WebGL` , check `OpenGL ES`.

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -342,9 +342,21 @@ function WebGLState( gl, extensions, utils ) {
 
 	var maxTextures = gl.getParameter( gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS );
 
-	var version = /^WebGL\ ([0-9])/.exec( gl.getParameter( gl.VERSION ) );
-	version = version ? parseFloat( version[ 1 ] ) : 1.0;
-	var lineWidthAvailable = version >= 1.0;
+	var lineWidthAvailable = false;
+	var version = 0;
+	var glVersion = gl.getParameter( gl.VERSION );
+
+	if ( glVersion.indexOf( 'WebGL' ) !== - 1 ) {
+
+	   version = parseFloat( /^WebGL\ ([0-9])/.exec( glVersion )[ 1 ] );
+	   lineWidthAvailable = ( version >= 1.0 );
+
+	} else if ( glVersion.indexOf( 'OpenGL ES' ) !== - 1 ) {
+
+	   version = parseFloat( /^OpenGL\ ES\ ([0-9])/.exec( glVersion )[ 1 ] );
+	   lineWidthAvailable = ( version >= 2.0 );
+
+	}
 
 	var currentTextureSlot = null;
 	var currentBoundTextures = {};

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -342,8 +342,9 @@ function WebGLState( gl, extensions, utils ) {
 
 	var maxTextures = gl.getParameter( gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS );
 
-	var version = parseFloat( /^WebGL\ ([0-9])/.exec( gl.getParameter( gl.VERSION ) )[ 1 ] );
-	var lineWidthAvailable = parseFloat( version ) >= 1.0;
+	var version = /^WebGL\ ([0-9])/.exec( gl.getParameter( gl.VERSION ) );
+	version = version ? parseFloat( version[ 1 ] ) : 1.0;
+	var lineWidthAvailable = version >= 1.0;
 
 	var currentTextureSlot = null;
 	var currentBoundTextures = {};


### PR DESCRIPTION
more details at : https://github.com/mrdoob/three.js/issues/13210