### PR TITLE
Fixed webgl_materials_video in Firefox ESR

### DIFF
--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -50,8 +50,8 @@
 		<script src="js/Detector.js"></script>
 
 		<video id="video" autoplay loop webkit-playsinline style="display:none">
-			<source src="textures/sintel.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'>
 			<source src="textures/sintel.ogv" type='video/ogg; codecs="theora, vorbis"'>
+			<source src="textures/sintel.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'>
 		</video>
 
 		<script>


### PR DESCRIPTION
Firefox ESR does not like MP4.for video.
WEBM and OGV only.