### PR TITLE
BufferGeometry: honor groups in toNonIndexed()

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -895,6 +895,15 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
+		var groups = this.groups;
+
+		for ( var i = 0, l = groups.length; i < l; i ++ ) {
+
+			var group = groups[ i ];
+			geometry2.addGroup( group.start, group.count, group.materialIndex );
+
+		}
+
 		return geometry2;
 
 	},


### PR DESCRIPTION
I was a bit surprised that, when converting from indexed-geometry to non-indexed-geometry, the groups do not need to be changed. Apparently it is true.

/ping @Mugen87 for 2nd opinion, please