### PR TITLE
BufferGeometryUtils: Add mergeBufferGeometries() helper.

### DIFF
--- a/docs/api/core/BufferGeometry.html
+++ b/docs/api/core/BufferGeometry.html
@@ -134,8 +134,9 @@
 
 			Each group is an object of the form:
 			<code>{ start: Integer, count: Integer, materialIndex: Integer }</code>
-			where start specifies the index of the first vertex in this draw call, count specifies
-			how many vertices are included, and materialIndex specifies the material array index to use.<br /><br />
+			where start specifies the first element in this draw call – the first vertex for non-indexed geometry,
+			otherwise the first triangle index. Count specifies how many vertices (or indices) are included, and
+			materialIndex specifies the material array index to use.<br /><br />
 
 			Use [page:.addGroup] to add groups, rather than modifying this array directly.
 		</div>

--- a/docs/examples/BufferGeometryUtils.html
+++ b/docs/examples/BufferGeometryUtils.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <base href="../" />
+    <script src="list.js"></script>
+    <script src="page.js"></script>
+    <link type="text/css" rel="stylesheet" href="page.css" />
+  </head>
+  <body>
+    <h1>[name]</h1>
+
+    <div class="desc">
+    A class containing utility functions for [page:BufferGeometry BufferGeometry] instances.<br /><br />
+    </div>
+
+
+    <h2>Methods</h2>
+
+    <h3>[method:null computeTangents]( geometry )</h3>
+    <div>
+    geometry -- A [page:BufferGeometry BufferGeometry] instance, which must have index, position, normal, and uv attributes.<br /><br />
+
+    Calculates and adds tangent attribute to a geometry.<br /><br />
+
+    </div>
+
+    <h3>[method:BufferGeometry mergeBufferGeometries]( geometries )</h3>
+    <div>
+    geometries -- Array of [page:BufferGeometry BufferGeometry] instances.<br /><br />
+
+    Merges a set of geometries into a single instance. All geometries must have compatible attributes.
+    If merge does not succeed, the method returns null.<br /><br />
+
+    </div>
+
+    <h3>[method:BufferAttribute mergeBufferAttributes]( attributes )</h3>
+    <div>
+    attributes -- Array of [page:BufferAttribute BufferAttribute] instances.<br /><br />
+
+    Merges a set of attributes into a single instance. All attributes must have compatible properties
+    and types, and [page:InterleavedBufferAttribute InterleavedBufferAttributes] are not supported. If merge does not succeed, the method
+    returns null.
+
+    </div>
+
+    <h2>Source</h2>
+
+    [link:https://github.com/mrdoob/three.js/blob/master/examples/js/BufferGeometryUtils.js examples/js/BufferGeometryUtils.js]
+  </body>
+</html>

--- a/docs/examples/BufferGeometryUtils.html
+++ b/docs/examples/BufferGeometryUtils.html
@@ -17,7 +17,7 @@
 
     <h2>Methods</h2>
 
-    <h3>[method:null computeTangents]( geometry )</h3>
+    <h3>[method:null computeTangents]( [param:BufferGeometry geometry] )</h3>
     <div>
     geometry -- A [page:BufferGeometry BufferGeometry] instance, which must have index, position, normal, and uv attributes.<br /><br />
 
@@ -25,7 +25,7 @@
 
     </div>
 
-    <h3>[method:BufferGeometry mergeBufferGeometries]( geometries )</h3>
+    <h3>[method:BufferGeometry mergeBufferGeometries]( [param:Array geometries] )</h3>
     <div>
     geometries -- Array of [page:BufferGeometry BufferGeometry] instances.<br /><br />
 
@@ -34,7 +34,7 @@
 
     </div>
 
-    <h3>[method:BufferAttribute mergeBufferAttributes]( attributes )</h3>
+    <h3>[method:BufferAttribute mergeBufferAttributes]( [param:Array attributes] )</h3>
     <div>
     attributes -- Array of [page:BufferAttribute BufferAttribute] instances.<br /><br />
 

--- a/docs/list.js
+++ b/docs/list.js
@@ -386,6 +386,7 @@ var list = {
 		},
 
 		"Utils": {
+			"BufferGeometryUtils": "examples/BufferGeometryUtils",
 			"SceneUtils": "examples/utils/SceneUtils"
 		}
 

--- a/examples/js/BufferGeometryUtils.js
+++ b/examples/js/BufferGeometryUtils.js
@@ -182,6 +182,51 @@ THREE.BufferGeometryUtils = {
 
 		}
 
+	},
+
+	/**
+	 * @param  {Array<THREE.BufferAttribute>} attributes
+	 * @return {THREE.BufferAttribute}
+	 */
+	mergeBufferAttributes: function ( attributes ) {
+
+		var TypedArray;
+		var itemSize;
+		var normalized;
+		var arrayLength = 0;
+
+		for ( var i = 0; i < attributes.length; ++ i ) {
+
+			var attribute = attributes[ i ];
+
+			if ( attribute.isInterleavedBufferAttribute ) return null;
+
+			if ( TypedArray === undefined ) TypedArray = attribute.array.constructor;
+			if ( TypedArray !== attribute.array.constructor ) return null;
+
+			if ( itemSize === undefined ) itemSize = attribute.itemSize;
+			if ( itemSize !== attribute.itemSize ) return null;
+
+			if ( normalized === undefined ) normalized = attribute.normalized;
+			if ( normalized !== attribute.normalized ) return null;
+
+			arrayLength += attribute.array.length;
+
+		}
+
+		var array = new TypedArray( arrayLength );
+		var offset = 0;
+
+		for ( var j = 0; j < attributes.length; ++ j ) {
+
+			array.set( attributes[ j ].array, offset );
+
+			offset += attributes[ j ].array.length;
+
+		}
+
+		return new THREE.BufferAttribute( array, itemSize, normalized );
+
 	}
 
 };

--- a/examples/js/BufferGeometryUtils.js
+++ b/examples/js/BufferGeometryUtils.js
@@ -199,7 +199,6 @@ THREE.BufferGeometryUtils = {
 		var morphAttributes = {};
 
 		var mergedGeometry = new THREE.BufferGeometry();
-		var offset = 0;
 
 		for ( var i = 0; i < geometries.length; ++ i ) {
 
@@ -240,20 +239,6 @@ THREE.BufferGeometryUtils = {
 				mergedGeometry.userData = mergedGeometry.userData || {};
 				mergedGeometry.userData.mergedUserData = mergedGeometry.userData.mergedUserData || [];
 				mergedGeometry.userData.mergedUserData.push( geometry.userData );
-
-			}
-
-			// create new group for this geometry
-
-			if ( isIndexed ) {
-
-				mergedGeometry.addGroup( offset, geometry.index.count, i );
-				offset += geometry.index.count;
-
-			} else {
-
-				mergedGeometry.addGroup( offset, geometry.attributes.position.count, i );
-				offset += geometry.attributes.position.count;
 
 			}
 

--- a/examples/js/BufferGeometryUtils.js
+++ b/examples/js/BufferGeometryUtils.js
@@ -185,7 +185,7 @@ THREE.BufferGeometryUtils = {
 	},
 
 	/**
-	 * @param  {Array<THREE.BufferAttribute>} attributes
+	 * @param {Array<THREE.BufferAttribute>} attributes
 	 * @return {THREE.BufferAttribute}
 	 */
 	mergeBufferAttributes: function ( attributes ) {

--- a/examples/js/BufferGeometryUtils.js
+++ b/examples/js/BufferGeometryUtils.js
@@ -245,8 +245,17 @@ THREE.BufferGeometryUtils = {
 
 			// create new group for this geometry
 
-			mergedGeometry.addGroup( offset, geometry.attributes.position.count, i );
-			offset += geometry.attributes.position.count;
+			if ( isIndexed ) {
+
+				mergedGeometry.addGroup( offset, geometry.index.count, i );
+				offset += geometry.index.count;
+
+			} else {
+
+				mergedGeometry.addGroup( offset, geometry.attributes.position.count, i );
+				offset += geometry.attributes.position.count;
+
+			}
 
 		}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2150,9 +2150,6 @@ THREE.GLTFLoader = ( function () {
 
 			var primitives = meshDef.primitives;
 
-			var typesUsed = new Set();
-			var drawModesUsed = new Set();
-
 			return scope.loadGeometries( primitives ).then( function ( geometries ) {
 
 				for ( var i = 0, il = primitives.length; i < il; i ++ ) {
@@ -2316,63 +2313,21 @@ THREE.GLTFLoader = ( function () {
 
 					}
 
-					if ( primitives.length === 1 ) return mesh;
+					if ( primitives.length > 1 ) {
 
-					mesh.name += '_' + i;
+						mesh.name += '_' + i;
 
-					group.add( mesh );
+						group.add( mesh );
 
-					typesUsed.add( mesh.constructor );
-					drawModesUsed.add( mesh.drawMode );
+					} else {
 
-				}
+						return mesh;
 
-				// Merge primitives into a single mesh with multiple buffer geometry
-				// groups. Merging requires BufferGeometryUtils, and that all primitives
-				// use the constructor, draw mode, and set of attributes. If any
-				// requirements are not met, a THREE.Group is returned instead.
-
-				if ( THREE.BufferGeometryUtils === undefined ) return group;
-
-				if ( typesUsed.size > 1 || drawModesUsed.size > 1 ) return group;
-
-				var TypedMesh = Array.from( typesUsed )[ 0 ];
-				var drawMode = Array.from( drawModesUsed )[ 0 ];
-
-				if ( TypedMesh !== THREE.Mesh && TypedMesh !== THREE.SkinnedMesh ) {
-
-					return group;
+					}
 
 				}
 
-				var groupGeometries = [];
-				var groupMaterials = [];
-
-				for ( var i = 0; i < group.children.length; ++i ) {
-
-					var geometry = group.children[ i ].geometry;
-					var material = group.children[ i ].material;
-
-					// Can't update spec/gloss uniforms on a multi-material mesh,
-					// so skip this case for now.
-					if ( material.isGLTFSpecularGlossinessMaterial ) return group;
-
-					groupGeometries.push( geometry );
-					groupMaterials.push( material );
-
-				}
-
-				var mergedGeometry = THREE.BufferGeometryUtils.mergeBufferGeometries( groupGeometries );
-
-				if ( !mergedGeometry ) return group;
-
-				var mergedMesh = new TypedMesh( mergedGeometry, groupMaterials );
-				mergedMesh.drawMode = drawMode;
-
-				if ( meshDef.name !== undefined ) mergedMesh.name = meshDef.name;
-				if ( meshDef.extras !== undefined ) mergedMesh.userData = meshDef.extras;
-
-				return mergedMesh;
+				return group;
 
 			} );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2174,10 +2174,10 @@ THREE.GLTFLoader = ( function () {
 					}
 
 					// If the material will be modified later on, clone it now.
-					var useSkinning = meshDef.isSkinnedMesh === true;
-					var useMorphTargets = primitive.targets !== undefined;
 					var useVertexColors = geometry.attributes.color !== undefined;
 					var useFlatShading = geometry.attributes.normal === undefined;
+					var useSkinning = meshDef.isSkinnedMesh === true;
+					var useMorphTargets = primitive.targets !== undefined;
 
 					if ( useVertexColors || useFlatShading || useSkinning || useMorphTargets ) {
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -794,7 +794,16 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
-		if ( offset === undefined ) offset = 0;
+		if ( offset === undefined ) {
+
+			offset = 0;
+
+			console.warn(
+				'THREE.BufferGeometry.merge(): Overwriting original geometry, starting at offset=0. '
+				+ 'Use BufferGeometryUtils.mergeBufferGeometries() for lossless merge.'
+			);
+
+		}
 
 		var attributes = this.attributes;
 

--- a/test/three.example.unit.js
+++ b/test/three.example.unit.js
@@ -2,6 +2,7 @@
  * @author TristanVALCKE / https://github.com/Itee
  */
 
+import './unit/example/BufferGeometryUtils.tests';
 import './unit/example/exporters/GLTFExporter.tests';
 import './unit/example/loaders/GLTFLoader.tests';
 import './unit/example/objects/Lensflare.tests';

--- a/test/unit/example/BufferGeometryUtils.tests.js
+++ b/test/unit/example/BufferGeometryUtils.tests.js
@@ -75,7 +75,6 @@ export default QUnit.module( 'BufferGeometryUtils', () => {
     assert.ok( mergedGeometry, 'merge succeeds' );
     assert.smartEqual( Array.from( mergedGeometry.attributes.position.array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
     assert.smartEqual( Array.from( mergedGeometry.index.array ), [ 0, 1, 2, 2, 1, 0, 3, 4, 5 ], 'merges indices' );
-    assert.smartEqual( [ { start: 0, count: 6, materialIndex: 0 }, { start: 6, count: 3, materialIndex: 1 } ], mergedGeometry.groups, 'creates groups' );
     assert.equal( mergedGeometry.attributes.position.itemSize, 1, 'retains .itemSize' );
 
   } );

--- a/test/unit/example/BufferGeometryUtils.tests.js
+++ b/test/unit/example/BufferGeometryUtils.tests.js
@@ -1,0 +1,94 @@
+/**
+ * @author Don McCurdy / https://www.donmccurdy.com
+ */
+/* global QUnit */
+
+import * as BufferGeometryUtils from '../../../examples/js/BufferGeometryUtils';
+
+export default QUnit.module( 'BufferGeometryUtils', () => {
+
+  QUnit.test( 'mergeBufferAttributes - basic', ( assert ) => {
+
+    var array1 = new Float32Array( [ 1, 2, 3, 4 ] );
+    var attr1 = new THREE.BufferAttribute( array1, 2, false );
+
+    var array2 = new Float32Array( [ 5, 6, 7, 8 ] );
+    var attr2 = new THREE.BufferAttribute( array2, 2, false );
+
+    var mergedAttr = THREE.BufferGeometryUtils.mergeBufferAttributes( [ attr1, attr2 ] );
+
+    assert.smartEqual( Array.from( mergedAttr.array ), [ 1, 2, 3, 4, 5, 6, 7, 8 ], 'merges elements' );
+    assert.equal( mergedAttr.itemSize, 2, 'retains .itemSize' );
+    assert.equal( mergedAttr.normalized, false, 'retains .normalized' );
+
+  } );
+
+  QUnit.test( 'mergeBufferAttributes - invalid', ( assert ) => {
+
+    var array1 = new Float32Array( [ 1, 2, 3, 4 ] );
+    var attr1 = new THREE.BufferAttribute( array1, 2, false );
+
+    var array2 = new Float32Array( [ 5, 6, 7, 8 ] );
+    var attr2 = new THREE.BufferAttribute( array2, 4, false );
+
+    assert.equal( THREE.BufferGeometryUtils.mergeBufferAttributes( [ attr1, attr2 ] ), null );
+
+    attr2.itemSize = 2;
+    attr2.normalized = true;
+
+    assert.equal( THREE.BufferGeometryUtils.mergeBufferAttributes( [ attr1, attr2 ] ), null );
+
+    attr2.normalized = false;
+
+    assert.ok( THREE.BufferGeometryUtils.mergeBufferAttributes( [ attr1, attr2 ] ) );
+
+  } );
+
+  QUnit.test( 'mergeBufferGeometries - basic', ( assert ) => {
+
+    var geometry1 = new THREE.BufferGeometry();
+    geometry1.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 1, 2, 3 ] ), 1, false ) );
+
+    var geometry2 = new THREE.BufferGeometry();
+    geometry2.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 4, 5, 6 ] ), 1, false ) );
+
+    var mergedGeometry = THREE.BufferGeometryUtils.mergeBufferGeometries( [ geometry1, geometry2 ] );
+
+    assert.ok( mergedGeometry, 'merge succeeds' );
+    assert.smartEqual( Array.from( mergedGeometry.attributes.position.array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
+    assert.equal( mergedGeometry.attributes.position.itemSize, 1, 'retains .itemSize' );
+
+  } );
+
+  QUnit.test( 'mergeBufferGeometries - indexed', ( assert ) => {
+
+    var geometry1 = new THREE.BufferGeometry();
+    geometry1.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 1, 2, 3 ] ), 1, false ) );
+    geometry1.setIndex( new THREE.BufferAttribute( new Uint16Array( [ 0, 1, 2 ] ), 1, false ) );
+
+    var geometry2 = new THREE.BufferGeometry();
+    geometry2.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 4, 5, 6 ] ), 1, false ) );
+    geometry2.setIndex( new THREE.BufferAttribute( new Uint16Array( [ 0, 1, 2 ] ), 1, false ) );
+
+    var mergedGeometry = THREE.BufferGeometryUtils.mergeBufferGeometries( [ geometry1, geometry2 ] );
+
+    assert.ok( mergedGeometry, 'merge succeeds' );
+    assert.smartEqual( Array.from( mergedGeometry.attributes.position.array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
+    assert.smartEqual( Array.from( mergedGeometry.index.array ), [ 0, 1, 2, 3, 4, 5 ], 'merges indices' );
+    assert.equal( mergedGeometry.attributes.position.itemSize, 1, 'retains .itemSize' );
+
+  } );
+
+  QUnit.todo( 'mergeBufferGeometries - morph targets', ( assert ) => {
+
+
+
+  } );
+
+  QUnit.todo( 'mergeBufferGeometries - invalid', ( assert ) => {
+
+
+
+  } );
+
+} );

--- a/test/unit/example/BufferGeometryUtils.tests.js
+++ b/test/unit/example/BufferGeometryUtils.tests.js
@@ -31,12 +31,12 @@ export default QUnit.module( 'BufferGeometryUtils', () => {
     var array2 = new Float32Array( [ 5, 6, 7, 8 ] );
     var attr2 = new THREE.BufferAttribute( array2, 4, false );
 
-    assert.equal( THREE.BufferGeometryUtils.mergeBufferAttributes( [ attr1, attr2 ] ), null );
+    assert.notOk( THREE.BufferGeometryUtils.mergeBufferAttributes( [ attr1, attr2 ] ) );
 
     attr2.itemSize = 2;
     attr2.normalized = true;
 
-    assert.equal( THREE.BufferGeometryUtils.mergeBufferAttributes( [ attr1, attr2 ] ), null );
+    assert.notOk( THREE.BufferGeometryUtils.mergeBufferAttributes( [ attr1, attr2 ] ) );
 
     attr2.normalized = false;
 
@@ -79,15 +79,50 @@ export default QUnit.module( 'BufferGeometryUtils', () => {
 
   } );
 
-  QUnit.todo( 'mergeBufferGeometries - morph targets', ( assert ) => {
+  QUnit.test( 'mergeBufferGeometries - morph targets', ( assert ) => {
 
+    var geometry1 = new THREE.BufferGeometry();
+    geometry1.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 1, 2, 3 ] ), 1, false ) );
+    geometry1.morphAttributes.position = [
+      new THREE.BufferAttribute( new Float32Array( [ 10, 20, 30 ] ), 1, false ),
+      new THREE.BufferAttribute( new Float32Array( [ 100, 200, 300 ] ), 1, false )
+    ];
 
+    var geometry2 = new THREE.BufferGeometry();
+    geometry2.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 4, 5, 6 ] ), 1, false ) );
+    geometry2.morphAttributes.position = [
+      new THREE.BufferAttribute( new Float32Array( [ 40, 50, 60 ] ), 1, false ),
+      new THREE.BufferAttribute( new Float32Array( [ 400, 500, 600 ] ), 1, false )
+    ];
+
+    var mergedGeometry = THREE.BufferGeometryUtils.mergeBufferGeometries( [ geometry1, geometry2 ] );
+
+    assert.ok( mergedGeometry, 'merge succeeds' );
+    assert.smartEqual( Array.from( mergedGeometry.attributes.position.array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
+    assert.smartEqual( Array.from( mergedGeometry.morphAttributes.position[ 0 ].array ), [ 10, 20, 30, 40, 50, 60 ], 'merges morph targets' );
+    assert.smartEqual( Array.from( mergedGeometry.morphAttributes.position[ 1 ].array ), [ 100, 200, 300, 400, 500, 600 ], 'merges morph targets' );
+    assert.equal( mergedGeometry.attributes.position.itemSize, 1, 'retains .itemSize' );
 
   } );
 
-  QUnit.todo( 'mergeBufferGeometries - invalid', ( assert ) => {
+  QUnit.test( 'mergeBufferGeometries - invalid', ( assert ) => {
 
+    var geometry1 = new THREE.BufferGeometry();
+    geometry1.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 1, 2, 3 ] ), 1, false ) );
+    geometry1.setIndex( new THREE.BufferAttribute( new Uint16Array( [ 0, 1, 2 ] ), 1, false ) );
 
+    var geometry2 = new THREE.BufferGeometry();
+    geometry2.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 4, 5, 6 ] ), 1, false ) );
+
+    assert.notOk( THREE.BufferGeometryUtils.mergeBufferGeometries( [ geometry1, geometry2 ] ) );
+
+    geometry2.setIndex( new THREE.BufferAttribute( new Uint16Array( [ 0, 1, 2 ] ), 1, false ) );
+
+    assert.ok( THREE.BufferGeometryUtils.mergeBufferGeometries( [ geometry1, geometry2 ] ) );
+
+    geometry2.addAttribute( 'foo', new THREE.BufferAttribute( new Float32Array( [ 1, 2, 3 ] ), 1, false ) );
+
+    assert.notOk( THREE.BufferGeometryUtils.mergeBufferGeometries( [ geometry1, geometry2 ] ) );
 
   } );
 

--- a/test/unit/example/BufferGeometryUtils.tests.js
+++ b/test/unit/example/BufferGeometryUtils.tests.js
@@ -64,7 +64,7 @@ export default QUnit.module( 'BufferGeometryUtils', () => {
 
     var geometry1 = new THREE.BufferGeometry();
     geometry1.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 1, 2, 3 ] ), 1, false ) );
-    geometry1.setIndex( new THREE.BufferAttribute( new Uint16Array( [ 0, 1, 2 ] ), 1, false ) );
+    geometry1.setIndex( new THREE.BufferAttribute( new Uint16Array( [ 0, 1, 2, 2, 1, 0 ] ), 1, false ) );
 
     var geometry2 = new THREE.BufferGeometry();
     geometry2.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( [ 4, 5, 6 ] ), 1, false ) );
@@ -74,7 +74,8 @@ export default QUnit.module( 'BufferGeometryUtils', () => {
 
     assert.ok( mergedGeometry, 'merge succeeds' );
     assert.smartEqual( Array.from( mergedGeometry.attributes.position.array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
-    assert.smartEqual( Array.from( mergedGeometry.index.array ), [ 0, 1, 2, 3, 4, 5 ], 'merges indices' );
+    assert.smartEqual( Array.from( mergedGeometry.index.array ), [ 0, 1, 2, 2, 1, 0, 3, 4, 5 ], 'merges indices' );
+    assert.smartEqual( [ { start: 0, count: 6, materialIndex: 0 }, { start: 6, count: 3, materialIndex: 1 } ], mergedGeometry.groups, 'creates groups' );
     assert.equal( mergedGeometry.attributes.position.itemSize, 1, 'retains .itemSize' );
 
   } );


### PR DESCRIPTION
Fixes #9468, #6188, and partially addresses #11944.

Alternative to #8162, #9529, #12795, and #12804.

I'd like to have this utility for GLTFLoader, so that primitives can be loaded as BufferGeometry groups. Adds a warning to `BufferGeometry.prototype.merge()` when it is called without an offset, as I believe the current behavior is probably not what many are expecting.

I think this approach is comparatively complete, covering indexed and non-indexed geometry, preserving morph targets, ~~and creating geometry groups. Users who do not want the groups may simply call `.clearGroups()` on the result. Although, perhaps a better name would be `groupBufferGeometries( geometries )`?~~