### PR TITLE
Prevent memory leak in WebGLRenderList

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1140,6 +1140,8 @@ function WebGLRenderer( parameters ) {
 
 		projectObject( scene, camera, _this.sortObjects );
 
+		currentRenderList.cleanup();
+
 		if ( _this.sortObjects === true ) {
 
 			currentRenderList.sort();

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -108,12 +108,23 @@ function WebGLRenderList() {
 
 	}
 
+	function cleanup() {
+
+		for ( var i = renderItemsIndex; i < renderItems.length; i++ ) {
+
+			renderItems[i] = undefined;
+
+		}
+
+	}
+
 	return {
 		opaque: opaque,
 		transparent: transparent,
 
 		init: init,
 		push: push,
+		cleanup: cleanup,
 
 		sort: sort
 	};


### PR DESCRIPTION
I noticed that WebGLRenderList was maintaining references to objects I had previously removed from my scene.

This is a problem if your scene currently has less objects than it did in the past.

I see that a dispose() method was added, but that clobbers the entire list, unnecessarily. I don't think it should be up to the three.js user that they should be disposing this renderList, either, it seems very much like an implementation detail.

This PR makes it so that any renderList slots that aren't currently used are cleared out, preventing memory leaks for everybody.