### PR TITLE
InputNode readonly option

### DIFF
--- a/examples/js/loaders/NodeMaterialLoader.js
+++ b/examples/js/loaders/NodeMaterialLoader.js
@@ -125,7 +125,14 @@ Object.assign( THREE.NodeMaterialLoader.prototype, {
 
 				this.names[ object.name ] = object;
 
+			} else {
+
+				// ignore "uniform" shader input ( for optimization )
+				object.readonly = true;
+
 			}
+
+			if ( node.readonly !== undefined ) object.readonly = node.readonly;
 
 			this.nodes[ uuid ] = object;
 

--- a/examples/js/nodes/InputNode.js
+++ b/examples/js/nodes/InputNode.js
@@ -9,6 +9,8 @@ THREE.InputNode = function ( type, params ) {
 
 	THREE.TempNode.call( this, type, params );
 
+	this.readonly = false;
+
 };
 
 THREE.InputNode.prototype = Object.create( THREE.TempNode.prototype );
@@ -21,27 +23,36 @@ THREE.InputNode.prototype.generate = function ( builder, output, uuid, type, ns,
 	uuid = builder.getUuid( uuid || this.getUuid() );
 	type = type || this.getType( builder );
 
-	var data = material.getDataNode( uuid );
+	var data = material.getDataNode( uuid ),
+		readonly = this.readonly && this.generateReadonly !== undefined;
 
-	if ( builder.isShader( 'vertex' ) ) {
+	if ( readonly ) {
 
-		if ( ! data.vertex ) {
-
-			data.vertex = material.createVertexUniform( type, this.value, ns, needsUpdate );
-
-		}
-
-		return builder.format( data.vertex.name, type, output );
+		return this.generateReadonly( builder, output, uuid, type, ns, needsUpdate );
 
 	} else {
 
-		if ( ! data.fragment ) {
+		if ( builder.isShader( 'vertex' ) ) {
 
-			data.fragment = material.createFragmentUniform( type, this.value, ns, needsUpdate );
+			if ( ! data.vertex ) {
+
+				data.vertex = material.createVertexUniform( type, this.value, ns, needsUpdate );
+
+			}
+
+			return builder.format( data.vertex.name, type, output );
+
+		} else {
+
+			if ( ! data.fragment ) {
+
+				data.fragment = material.createFragmentUniform( type, this.value, ns, needsUpdate );
+
+			}
+
+			return builder.format( data.fragment.name, type, output );
 
 		}
-
-		return builder.format( data.fragment.name, type, output );
 
 	}
 

--- a/examples/js/nodes/InputNode.js
+++ b/examples/js/nodes/InputNode.js
@@ -16,6 +16,12 @@ THREE.InputNode = function ( type, params ) {
 THREE.InputNode.prototype = Object.create( THREE.TempNode.prototype );
 THREE.InputNode.prototype.constructor = THREE.InputNode;
 
+THREE.InputNode.prototype.isReadonly = function ( builder ) {
+
+	return this.readonly;
+
+};
+
 THREE.InputNode.prototype.generate = function ( builder, output, uuid, type, ns, needsUpdate ) {
 
 	var material = builder.material;
@@ -24,7 +30,7 @@ THREE.InputNode.prototype.generate = function ( builder, output, uuid, type, ns,
 	type = type || this.getType( builder );
 
 	var data = material.getDataNode( uuid ),
-		readonly = this.readonly && this.generateReadonly !== undefined;
+		readonly = this.isReadonly( builder ) && this.generateReadonly !== undefined;
 
 	if ( readonly ) {
 

--- a/examples/js/nodes/NodeFrame.js
+++ b/examples/js/nodes/NodeFrame.js
@@ -21,7 +21,7 @@ THREE.NodeFrame.prototype.update = function ( delta ) {
 
 };
 
-THREE.NodeFrame.prototype.updateFrame = function ( node ) {
+THREE.NodeFrame.prototype.updateNode = function ( node ) {
 
 	if ( node.frameId === this.frameId ) return this;
 

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -72,7 +72,7 @@ THREE.NodeMaterial.prototype.updateFrame = function ( frame ) {
 
 	for ( var i = 0; i < this.updaters.length; ++ i ) {
 
-		frame.updateFrame( this.updaters[ i ] );
+		frame.updateNode( this.updaters[ i ] );
 
 	}
 

--- a/examples/js/nodes/inputs/ColorNode.js
+++ b/examples/js/nodes/inputs/ColorNode.js
@@ -34,7 +34,7 @@ THREE.ColorNode.prototype.toJSON = function ( meta ) {
 		data.g = this.g;
 		data.b = this.b;
 
-		if ( this.readyonly === true ) data.readyonly = true;
+		if ( this.readonly === true ) data.readonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/ColorNode.js
+++ b/examples/js/nodes/inputs/ColorNode.js
@@ -16,6 +16,12 @@ THREE.ColorNode.prototype.nodeType = "Color";
 
 THREE.NodeMaterial.addShortcuts( THREE.ColorNode.prototype, 'value', [ 'r', 'g', 'b' ] );
 
+THREE.ColorNode.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
+
+	return builder.format( "vec3( " + this.r + ", " + this.g + ", " + this.b + " )", type, output );
+
+};
+
 THREE.ColorNode.prototype.toJSON = function ( meta ) {
 
 	var data = this.getJSONNode( meta );
@@ -27,6 +33,8 @@ THREE.ColorNode.prototype.toJSON = function ( meta ) {
 		data.r = this.r;
 		data.g = this.g;
 		data.b = this.b;
+
+		if ( this.readyonly === true ) data.readyonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/FloatNode.js
+++ b/examples/js/nodes/inputs/FloatNode.js
@@ -33,7 +33,7 @@ THREE.FloatNode.prototype.generateReadonly = function ( builder, output, uuid, t
 
 	var value = this.number;
 
-	return builder.format( ~~value !== value ? value : value + ".0", type, output );
+	return builder.format( Math.floor( value ) !== value ? value : value + ".0", type, output );
 
 };
 

--- a/examples/js/nodes/inputs/FloatNode.js
+++ b/examples/js/nodes/inputs/FloatNode.js
@@ -29,6 +29,14 @@ Object.defineProperties( THREE.FloatNode.prototype, {
 	}
 } );
 
+THREE.FloatNode.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
+
+	var value = this.number;
+
+	return builder.format( ~~value !== value ? value : value + ".0", type, output );
+
+};
+
 THREE.FloatNode.prototype.toJSON = function ( meta ) {
 
 	var data = this.getJSONNode( meta );
@@ -38,6 +46,8 @@ THREE.FloatNode.prototype.toJSON = function ( meta ) {
 		data = this.createJSONNode( meta );
 
 		data.number = this.number;
+
+		if ( this.readyonly === true ) data.readyonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/FloatNode.js
+++ b/examples/js/nodes/inputs/FloatNode.js
@@ -47,7 +47,7 @@ THREE.FloatNode.prototype.toJSON = function ( meta ) {
 
 		data.number = this.number;
 
-		if ( this.readyonly === true ) data.readyonly = true;
+		if ( this.readonly === true ) data.readonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/IntNode.js
+++ b/examples/js/nodes/inputs/IntNode.js
@@ -29,6 +29,12 @@ Object.defineProperties( THREE.IntNode.prototype, {
 	}
 } );
 
+THREE.IntNode.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
+
+	return builder.format( this.number, type, output );
+
+};
+
 THREE.IntNode.prototype.toJSON = function ( meta ) {
 
 	var data = this.getJSONNode( meta );
@@ -38,6 +44,8 @@ THREE.IntNode.prototype.toJSON = function ( meta ) {
 		data = this.createJSONNode( meta );
 
 		data.number = this.number;
+
+		if ( this.readyonly === true ) data.readyonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/IntNode.js
+++ b/examples/js/nodes/inputs/IntNode.js
@@ -45,7 +45,7 @@ THREE.IntNode.prototype.toJSON = function ( meta ) {
 
 		data.number = this.number;
 
-		if ( this.readyonly === true ) data.readyonly = true;
+		if ( this.readonly === true ) data.readonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Matrix3Node.js
+++ b/examples/js/nodes/inputs/Matrix3Node.js
@@ -14,6 +14,12 @@ THREE.Matrix3Node.prototype = Object.create( THREE.InputNode.prototype );
 THREE.Matrix3Node.prototype.constructor = THREE.Matrix3Node;
 THREE.Matrix3Node.prototype.nodeType = "Matrix3";
 
+THREE.Matrix3Node.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
+
+	return builder.format( "mat3( " + this.value.elements.joint( ", " ) + " )", type, output );
+
+};
+
 THREE.Matrix3Node.prototype.toJSON = function ( meta ) {
 
 	var data = this.getJSONNode( meta );
@@ -23,6 +29,8 @@ THREE.Matrix3Node.prototype.toJSON = function ( meta ) {
 		data = this.createJSONNode( meta );
 
 		data.elements = this.value.elements.concat();
+
+		if ( this.readyonly === true ) data.readyonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Matrix3Node.js
+++ b/examples/js/nodes/inputs/Matrix3Node.js
@@ -16,7 +16,7 @@ THREE.Matrix3Node.prototype.nodeType = "Matrix3";
 
 THREE.Matrix3Node.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
 
-	return builder.format( "mat3( " + this.value.elements.joint( ", " ) + " )", type, output );
+	return builder.format( "mat3( " + this.value.elements.join( ", " ) + " )", type, output );
 
 };
 
@@ -30,7 +30,7 @@ THREE.Matrix3Node.prototype.toJSON = function ( meta ) {
 
 		data.elements = this.value.elements.concat();
 
-		if ( this.readyonly === true ) data.readyonly = true;
+		if ( this.readonly === true ) data.readonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Matrix4Node.js
+++ b/examples/js/nodes/inputs/Matrix4Node.js
@@ -16,7 +16,7 @@ THREE.Matrix4Node.prototype.nodeType = "Matrix4";
 
 THREE.Matrix4Node.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
 
-	return builder.format( "mat4( " + this.value.elements.joint( ", " ) + " )", type, output );
+	return builder.format( "mat4( " + this.value.elements.join( ", " ) + " )", type, output );
 
 };
 
@@ -30,7 +30,7 @@ THREE.Matrix4Node.prototype.toJSON = function ( meta ) {
 
 		data.elements = this.value.elements.concat();
 
-		if ( this.readyonly === true ) data.readyonly = true;
+		if ( this.readonly === true ) data.readonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Matrix4Node.js
+++ b/examples/js/nodes/inputs/Matrix4Node.js
@@ -14,6 +14,12 @@ THREE.Matrix4Node.prototype = Object.create( THREE.InputNode.prototype );
 THREE.Matrix4Node.prototype.constructor = THREE.Matrix4Node;
 THREE.Matrix4Node.prototype.nodeType = "Matrix4";
 
+THREE.Matrix4Node.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
+
+	return builder.format( "mat4( " + this.value.elements.joint( ", " ) + " )", type, output );
+
+};
+
 THREE.Matrix4Node.prototype.toJSON = function ( meta ) {
 
 	var data = this.getJSONNode( meta );
@@ -23,6 +29,8 @@ THREE.Matrix4Node.prototype.toJSON = function ( meta ) {
 		data = this.createJSONNode( meta );
 
 		data.elements = this.value.elements.concat();
+
+		if ( this.readyonly === true ) data.readyonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Vector2Node.js
+++ b/examples/js/nodes/inputs/Vector2Node.js
@@ -16,6 +16,12 @@ THREE.Vector2Node.prototype.nodeType = "Vector2";
 
 THREE.NodeMaterial.addShortcuts( THREE.Vector2Node.prototype, 'value', [ 'x', 'y' ] );
 
+THREE.Vector2Node.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
+
+	return builder.format( "vec2( " + this.x + ", " + this.y + " )", type, output );
+
+};
+
 THREE.Vector2Node.prototype.toJSON = function ( meta ) {
 
 	var data = this.getJSONNode( meta );
@@ -26,6 +32,8 @@ THREE.Vector2Node.prototype.toJSON = function ( meta ) {
 
 		data.x = this.x;
 		data.y = this.y;
+
+		if ( this.readyonly === true ) data.readyonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Vector2Node.js
+++ b/examples/js/nodes/inputs/Vector2Node.js
@@ -33,7 +33,7 @@ THREE.Vector2Node.prototype.toJSON = function ( meta ) {
 		data.x = this.x;
 		data.y = this.y;
 
-		if ( this.readyonly === true ) data.readyonly = true;
+		if ( this.readonly === true ) data.readonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Vector3Node.js
+++ b/examples/js/nodes/inputs/Vector3Node.js
@@ -35,7 +35,7 @@ THREE.Vector3Node.prototype.toJSON = function ( meta ) {
 		data.y = this.y;
 		data.z = this.z;
 
-		if ( this.readyonly === true ) data.readyonly = true;
+		if ( this.readonly === true ) data.readonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Vector3Node.js
+++ b/examples/js/nodes/inputs/Vector3Node.js
@@ -17,6 +17,12 @@ THREE.Vector3Node.prototype.nodeType = "Vector3";
 
 THREE.NodeMaterial.addShortcuts( THREE.Vector3Node.prototype, 'value', [ 'x', 'y', 'z' ] );
 
+THREE.Vector3Node.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
+
+	return builder.format( "vec3( " + this.x + ", " + this.y + ", " + this.z + " )", type, output );
+
+};
+
 THREE.Vector3Node.prototype.toJSON = function ( meta ) {
 
 	var data = this.getJSONNode( meta );
@@ -28,6 +34,8 @@ THREE.Vector3Node.prototype.toJSON = function ( meta ) {
 		data.x = this.x;
 		data.y = this.y;
 		data.z = this.z;
+
+		if ( this.readyonly === true ) data.readyonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Vector4Node.js
+++ b/examples/js/nodes/inputs/Vector4Node.js
@@ -16,6 +16,12 @@ THREE.Vector4Node.prototype.nodeType = "Vector4";
 
 THREE.NodeMaterial.addShortcuts( THREE.Vector4Node.prototype, 'value', [ 'x', 'y', 'z', 'w' ] );
 
+THREE.Vector4Node.prototype.generateReadonly = function ( builder, output, uuid, type, ns, needsUpdate ) {
+
+	return builder.format( "vec4( " + this.x + ", " + this.y + ", " + this.z + ", " + this.w + " )", type, output );
+
+};
+
 THREE.Vector4Node.prototype.toJSON = function ( meta ) {
 
 	var data = this.getJSONNode( meta );
@@ -28,6 +34,8 @@ THREE.Vector4Node.prototype.toJSON = function ( meta ) {
 		data.y = this.y;
 		data.z = this.z;
 		data.w = this.w;
+
+		if ( this.readyonly === true ) data.readyonly = true;
 
 	}
 

--- a/examples/js/nodes/inputs/Vector4Node.js
+++ b/examples/js/nodes/inputs/Vector4Node.js
@@ -35,7 +35,7 @@ THREE.Vector4Node.prototype.toJSON = function ( meta ) {
 		data.z = this.z;
 		data.w = this.w;
 
-		if ( this.readyonly === true ) data.readyonly = true;
+		if ( this.readonly === true ) data.readonly = true;
 
 	}
 

--- a/examples/js/nodes/utils/TimerNode.js
+++ b/examples/js/nodes/utils/TimerNode.js
@@ -2,12 +2,12 @@
  * @author sunag / http://www.sunag.com.br/
  */
 
-THREE.TimerNode = function ( scope, scale ) {
+THREE.TimerNode = function ( scale, scope ) {
 
 	THREE.FloatNode.call( this );
 
-	this.scope = scope || THREE.TimerNode.GLOBAL;
 	this.scale = scale !== undefined ? scale : 1;
+	this.scope = scope || THREE.TimerNode.GLOBAL;
 
 };
 

--- a/examples/js/nodes/utils/TimerNode.js
+++ b/examples/js/nodes/utils/TimerNode.js
@@ -21,6 +21,12 @@ THREE.TimerNode.prototype = Object.create( THREE.FloatNode.prototype );
 THREE.TimerNode.prototype.constructor = THREE.TimerNode;
 THREE.TimerNode.prototype.nodeType = "Timer";
 
+THREE.TimerNode.prototype.isReadonly = function ( builder ) {
+
+	return false;
+
+};
+
 THREE.TimerNode.prototype.isUnique = function ( builder ) {
 
 	// share TimerNode "uniform" input if is used on more time with others TimerNode

--- a/examples/js/nodes/utils/TimerNode.js
+++ b/examples/js/nodes/utils/TimerNode.js
@@ -9,6 +9,8 @@ THREE.TimerNode = function ( scale, scope ) {
 	this.scale = scale !== undefined ? scale : 1;
 	this.scope = scope || THREE.TimerNode.GLOBAL;
 
+	this.timeScale = this.scale !== 1;
+
 };
 
 THREE.TimerNode.GLOBAL = 'global';
@@ -19,25 +21,34 @@ THREE.TimerNode.prototype = Object.create( THREE.FloatNode.prototype );
 THREE.TimerNode.prototype.constructor = THREE.TimerNode;
 THREE.TimerNode.prototype.nodeType = "Timer";
 
+THREE.TimerNode.prototype.isUnique = function ( builder ) {
+
+	// share TimerNode "uniform" input if is used on more time with others TimerNode
+	return this.timeScale && ( this.scope === THREE.TimerNode.GLOBAL || this.scope === THREE.TimerNode.DELTA );
+
+};
+
 THREE.TimerNode.prototype.updateFrame = function ( frame ) {
+
+	var scale = this.timeScale ? this.scale : 1;
 
 	switch( this.scope ) {
 
 		case THREE.TimerNode.LOCAL:
 
-			this.number += frame.delta * this.scale;
+			this.number += frame.delta * scale;
 
 			break;
 
 		case THREE.TimerNode.DELTA:
 
-			this.number = frame.delta * this.scale;
+			this.number = frame.delta * scale;
 
 			break;
 
 		default:
 
-			this.number = frame.time * this.scale;
+			this.number = frame.time * scale;
 
 	}
 
@@ -53,6 +64,7 @@ THREE.TimerNode.prototype.toJSON = function ( meta ) {
 
 		data.scope = this.scope;
 		data.scale = this.scale;
+		data.timeScale = this.timeScale;
 
 	}
 

--- a/examples/js/nodes/utils/VelocityNode.js
+++ b/examples/js/nodes/utils/VelocityNode.js
@@ -19,6 +19,12 @@ THREE.VelocityNode.prototype = Object.create( THREE.Vector3Node.prototype );
 THREE.VelocityNode.prototype.constructor = THREE.VelocityNode;
 THREE.VelocityNode.prototype.nodeType = "Velocity";
 
+THREE.VelocityNode.prototype.isReadonly = function ( builder ) {
+
+	return false;
+
+};
+
 THREE.VelocityNode.prototype.setParams = function ( params ) {
 
 	switch ( this.params.type ) {

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -243,6 +243,10 @@
 			
 				if (time) {
 				
+					time.timeScale = true;
+					
+					loader.material.build();
+				
 					addGui( 'timeScale', time.scale, function ( val ) {
 
 						time.scale = val;

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -274,7 +274,7 @@
 			var delta = clock.getDelta();
 
 			// update material animation and/or gpu calcs (pre-renderer)
-			if ( mesh.material instanceof THREE.NodeMaterial ) frame.update( delta ).updateFrame( mesh.material );
+			if ( mesh.material instanceof THREE.NodeMaterial ) frame.update( delta ).updateNode( mesh.material );
 
 			renderer.render( scene, camera );
 

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -224,7 +224,7 @@
 
 		}
 
-		
+
 		function updateMaterial() {
 
 			if ( mesh.material ) mesh.material.dispose();
@@ -234,31 +234,31 @@
 			var url = "nodes/" + param.load + ".json";
 
 			var library = {
-				"cloud" : cloud
+				"cloud": cloud
 			};
 
 			var loader = new THREE.NodeMaterialLoader( undefined, library ).load( url, function () {
 
-				var time = loader.getObjectByName("time");
-			
-				if (time) {
-				
+				var time = loader.getObjectByName( "time" );
+
+				if ( time ) {
+
 					// enable time scale
-					
+
 					time.timeScale = true;
 
 					loader.material.build();
-					
+
 					// gui
-				
+
 					addGui( 'timeScale', time.scale, function ( val ) {
 
 						time.scale = val;
 
-					}, false, -2, 2 );
-				
+					}, false, - 2, 2 );
+
 				}
-			
+
 				// set material
 				mesh.material = loader.material;
 

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -243,9 +243,13 @@
 			
 				if (time) {
 				
-					time.timeScale = true;
+					// enable time scale
 					
+					time.timeScale = true;
+
 					loader.material.build();
+					
+					// gui
 				
 					addGui( 'timeScale', time.scale, function ( val ) {
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -256,6 +256,7 @@
 				'misc / firefly': 'firefly',
 				'misc / reserved-keywords': 'reserved-keywords',
 				'misc / varying': 'varying',
+				'misc / readonly': 'readonly',
 				'misc / custom-attribute': 'custom-attribute'
 			} ).onFinishChange( function () {
 
@@ -2016,6 +2017,22 @@
 
 					mtl.transform = transform;
 					mtl.color = varying;
+
+					break;
+
+				case 'readonly':
+
+					mtl = new THREE.PhongNodeMaterial();
+
+					mtl.color = new THREE.ColorNode( 0xFFFFFF );
+					mtl.specular = new THREE.FloatNode( .5 );
+					mtl.shininess = new THREE.FloatNode( 15 );
+
+					// not use "uniform" input ( for optimization ) 
+					// instead use explicit declaration example: 
+					// vec3( 1.0, 1.0, 1.0 ) instead "uniform vec3"
+					// but not allow change the value after build the shader material
+					mtl.color.readonly = mtl.specular.readonly = mtl.shininess.readonly = true;
 
 					break;
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -2031,7 +2031,7 @@
 					// not use "uniform" input ( for optimization ) 
 					// instead use explicit declaration, for example: 
 					// vec3( 1.0, 1.0, 1.0 ) instead "uniform vec3"
-					// but not allow change the value after build the shader material
+					// if readonly is true not allow change the value after build the shader material
 					mtl.color.readonly = mtl.specular.readonly = mtl.shininess.readonly = true;
 
 					break;

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -2029,7 +2029,7 @@
 					mtl.shininess = new THREE.FloatNode( 15 );
 
 					// not use "uniform" input ( for optimization ) 
-					// instead use explicit declaration example: 
+					// instead use explicit declaration, for example: 
 					// vec3( 1.0, 1.0, 1.0 ) instead "uniform vec3"
 					// but not allow change the value after build the shader material
 					mtl.color.readonly = mtl.specular.readonly = mtl.shininess.readonly = true;

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -2391,7 +2391,7 @@
 			//mesh.rotation.z += .01;
 
 			// update material animation and/or gpu calcs (pre-renderer)
-			frame.update( delta ).updateFrame( mesh.material );
+			frame.update( delta ).updateNode( mesh.material );
 
 			// render to texture for sss/translucent material only
 			if ( rtTexture ) {

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -2022,6 +2022,8 @@
 
 				case 'readonly':
 
+					// MATERIAL
+
 					mtl = new THREE.PhongNodeMaterial();
 
 					mtl.color = new THREE.ColorNode( 0xFFFFFF );

--- a/examples/webgl_mirror_nodes.html
+++ b/examples/webgl_mirror_nodes.html
@@ -325,7 +325,7 @@
 			smallSphere.rotation.y = ( Math.PI / 2 ) - timer * 0.1;
 			smallSphere.rotation.z = timer * 0.8;
 
-			frame.update( delta ).updateFrame( groundMirrorMaterial );
+			frame.update( delta ).updateNode( groundMirrorMaterial );
 
 			render();
 

--- a/examples/webgl_postprocessing_nodes.html
+++ b/examples/webgl_postprocessing_nodes.html
@@ -591,7 +591,7 @@
 				object.rotation.x += 0.005;
 				object.rotation.y += 0.01;
 
-				frame.update( delta ).updateFrame( nodepass.node );
+				frame.update( delta ).updateNode( nodepass.node );
 
 				composer.render();
 

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -215,7 +215,7 @@
 			// horizontal zigzag sprite
 			sprite2.material.transform = new THREE.OperatorNode(
 				new THREE.OperatorNode(
-					new THREE.Math1Node( new THREE.TimerNode( 0, 3 ), THREE.Math1Node.SIN ), // 3 is speed (time scale)
+					new THREE.Math1Node( new THREE.TimerNode( 3 ), THREE.Math1Node.SIN ), // 3 is speed (time scale)
 					new THREE.Vector2Node( .3, 0 ), // horizontal scale (position)
 					THREE.OperatorNode.MUL
 				),

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -302,9 +302,9 @@
 
 			// update material animation and/or gpu calcs (pre-renderer)
 			frame.update( delta )
-				.updateFrame( sprite1.material )
-				.updateFrame( sprite2.material )
-				.updateFrame( sprite3.material );
+				.updateNode( sprite1.material )
+				.updateNode( sprite2.material )
+				.updateNode( sprite3.material );
 
 			// rotate sprite
 			sprite3.rotation.z -= Math.PI * .005;


### PR DESCRIPTION
Not use `uniform` input if `readonly` is true in `InputNode`. ( for optimization )

in `new THREE.Vector3Node( 1, 1, 1 )` instead use explicit declaration, for example:
```glsl
// readonly = true
vec3( 1.0, 1.0, 1.0 )

// readonly = false (default)
uniform vec3 nV0;
```

Of course. `readonly` not allow change the value after build the shader material.

---

In `NodeFrame` I rename `updateFrame` to `updateNode` which is more suggestive but keeping `updateFrame` in nodes.