### PR TITLE
PCDLoader with Worker support: parseAsync and run

### DIFF
--- a/examples/js/loaders/LoaderSupport.js
+++ b/examples/js/loaders/LoaderSupport.js
@@ -1476,11 +1476,12 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 		return objectString;
 	};
 
-	var buildSingleton = function ( fullName, object, internalName ) {
+	var buildSingleton = function ( fullName, object, internalName, basePrototypeName, ignoreFunctions ) {
 		var objectString = '';
 		var objectName = ( Validator.isValid( internalName ) ) ? internalName : object.name;
 
 		var funcString, objectPart, constructorString;
+		ignoreFunctions = Validator.verifyInput( ignoreFunctions, [] );
 		for ( var name in object.prototype ) {
 
 			objectPart = object.prototype[ name ];
@@ -1492,25 +1493,39 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 
 			} else if ( typeof objectPart === 'function' ) {
 
-				funcString = objectPart.toString();
-				objectString += '\t' + objectName + '.prototype.' + name + ' = ' + funcString + ';\n\n';
+				if ( ignoreFunctions.indexOf( name ) < 0 ) {
+
+					funcString = objectPart.toString();
+					objectString += '\t' + objectName + '.prototype.' + name + ' = ' + funcString + ';\n\n';
+
+				}
 
 			}
 
 		}
 		objectString += '\treturn ' + objectName + ';\n';
 		objectString += '})();\n\n';
+
+		var inheritanceBlock = '';
+		if ( Validator.isValid( basePrototypeName ) ) {
+
+			inheritanceBlock += '\n';
+			inheritanceBlock += objectName + '.prototype = Object.create( ' + basePrototypeName + '.prototype );\n';
+			inheritanceBlock += objectName + '.constructor = ' + objectName + ';\n';
+			inheritanceBlock += '\n';
+		}
 		if ( ! Validator.isValid( constructorString ) ) {
 
 			constructorString = fullName + ' = (function () {\n\n';
-			constructorString += '\t' + object.prototype.constructor.toString() + '\n\n';
+			constructorString += inheritanceBlock + '\t' + object.prototype.constructor.toString() + '\n\n';
 			objectString = constructorString + objectString;
 
 		} else {
 
-			objectString = fullName + ' = (function () {\n\n' + constructorString + objectString;
+			objectString = fullName + ' = (function () {\n\n' + inheritanceBlock + constructorString + objectString;
 
 		}
+
 		return objectString;
 	};
 

--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -38,7 +38,14 @@ THREE.PCDLoader.prototype = {
 		var parser = new THREE.PCDLoader.Parser();
 		parser.setLittleEndian( this.littleEndian );
 
-		return parser.parse( data, url );
+		var mesh = parser.parse( data );
+
+		var name = url.split( '' ).reverse().join( '' );
+		name = /([^\/]*)/.exec( name );
+		name = name[ 1 ].split( '' ).reverse().join( '' );
+		mesh.name = name;
+
+		return mesh;
 	}
 };
 
@@ -58,19 +65,10 @@ THREE.PCDLoader.Parser.prototype = {
 		this.littleEndian = littleEndian === true;
 	},
 
-	parse: function ( data, url ) {
+	parse: function ( data ) {
 		var textData = THREE.LoaderUtils.decodeText( data );
-
 		var pcdHeader = this.parseHeader( textData );
-
-		var mesh = this.parseData( pcdHeader, textData, data );
-
-		var name = url.split( '' ).reverse().join( '' );
-		name = /([^\/]*)/.exec( name );
-		name = name[ 1 ].split( '' ).reverse().join( '' );
-		mesh.name = name;
-
-		return mesh;
+		return this.parseData( pcdHeader, textData, data );
 	},
 
 	parseHeader: function ( data ) {

--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -1,6 +1,7 @@
 /**
  * @author Filipe Caixeta / http://filipecaixeta.com.br
  * @author Mugen87 / https://github.com/Mugen87
+ * @author Kai Salmen / https://github.com/kaisalmen
  *
  * Description: A THREE loader for PCD ascii and binary files.
  *
@@ -14,7 +15,6 @@ THREE.PCDLoader = function ( manager ) {
 	this.littleEndian = true;
 
 };
-
 
 THREE.PCDLoader.prototype = {
 
@@ -31,26 +31,63 @@ THREE.PCDLoader.prototype = {
 			onLoad( scope.parse( data, url ) );
 
 		}, onProgress, onError );
-
 	},
 
 	parse: function ( data, url ) {
+		var scope = this;
+		var parser = new THREE.PCDLoader.Parser();
+		parser.setLittleEndian( this.littleEndian );
 
-		function parseHeader( data ) {
+		return parser.parse( data, url );
+	}
+};
 
-			var PCDheader = {};
-			var result1 = data.search( /[\r\n]DATA\s(\S*)\s/i );
-			var result2 = /[\r\n]DATA\s(\S*)\s/i.exec( data.substr( result1 - 1 ) );
+/**
+ * Isolated Parser. It allows an extended class to created the Parser inside a worker
+ * @constructor
+ */
+THREE.PCDLoader.Parser = function () {
+	this.littleEndian = true;
+};
+
+THREE.PCDLoader.Parser.prototype = {
+
+	constructor: THREE.PCDLoader.Parser,
+
+	setLittleEndian: function ( littleEndian ) {
+		this.littleEndian = littleEndian === true;
+	},
+
+	parse: function ( data, url ) {
+		var textData = THREE.LoaderUtils.decodeText( data );
+
+		var pcdHeader = this.parseHeader( textData );
+
+		var mesh = this.parseData( pcdHeader, textData, data );
+
+		var name = url.split( '' ).reverse().join( '' );
+		name = /([^\/]*)/.exec( name );
+		name = name[ 1 ].split( '' ).reverse().join( '' );
+		mesh.name = name;
+
+		return mesh;
+	},
+
+	parseHeader: function ( data ) {
+
+		var PCDheader = {};
+		var result1 = data.search( /[\r\n]DATA\s(\S*)\s/i );
+		var result2 = /[\r\n]DATA\s(\S*)\s/i.exec( data.substr( result1 - 1 ) );
 
 			PCDheader.data = result2[ 1 ];
 			PCDheader.headerLen = result2[ 0 ].length + result1;
 			PCDheader.str = data.substr( 0, PCDheader.headerLen );
 
-			// remove comments
+		// remove comments
 
 			PCDheader.str = PCDheader.str.replace( /\#.*/gi, '' );
 
-			// parse
+		// parse
 
 			PCDheader.version = /VERSION (.*)/i.exec( PCDheader.str );
 			PCDheader.fields = /FIELDS (.*)/i.exec( PCDheader.str );
@@ -62,7 +99,7 @@ THREE.PCDLoader.prototype = {
 			PCDheader.viewpoint = /VIEWPOINT (.*)/i.exec( PCDheader.str );
 			PCDheader.points = /POINTS (.*)/i.exec( PCDheader.str );
 
-			// evaluate
+		// evaluate
 
 			if ( PCDheader.version !== null )
 				PCDheader.version = parseFloat( PCDheader.version[ 1 ] );
@@ -92,21 +129,21 @@ THREE.PCDLoader.prototype = {
 
 				PCDheader.size = PCDheader.size[ 1 ].split( ' ' ).map( function ( x ) {
 
-					return parseInt( x, 10 );
+				return parseInt( x, 10 );
 
-				} );
+			} );
 
-			}
+		}
 
 			if ( PCDheader.count !== null ) {
 
 				PCDheader.count = PCDheader.count[ 1 ].split( ' ' ).map( function ( x ) {
 
-					return parseInt( x, 10 );
+				return parseInt( x, 10 );
 
-				} );
+			} );
 
-			} else {
+		} else {
 
 				PCDheader.count = [];
 
@@ -114,13 +151,13 @@ THREE.PCDLoader.prototype = {
 
 					PCDheader.count.push( 1 );
 
-				}
-
 			}
+
+		}
 
 			PCDheader.offset = {};
 
-			var sizeSum = 0;
+		var sizeSum = 0;
 
 			for ( var i = 0, l = PCDheader.fields.length; i < l; i ++ ) {
 
@@ -128,31 +165,22 @@ THREE.PCDLoader.prototype = {
 
 					PCDheader.offset[ PCDheader.fields[ i ] ] = i;
 
-				} else {
+			} else {
 
 					PCDheader.offset[ PCDheader.fields[ i ] ] = sizeSum;
 					sizeSum += PCDheader.size[ i ];
 
-				}
-
 			}
-
-			// for binary only
-
-			PCDheader.rowSize = sizeSum;
-
-			return PCDheader;
 
 		}
 
-		var textData = THREE.LoaderUtils.decodeText( data );
+		// for binary only
+		PCDheader.rowSize = sizeSum;
 
-		// parse header (always ascii format)
+		return PCDheader;
+	},
 
-		var PCDheader = parseHeader( textData );
-
-		// parse data
-
+	parseData: function ( PCDheader, textData, data ) {
 		var position = [];
 		var normal = [];
 		var color = [];
@@ -243,6 +271,12 @@ THREE.PCDLoader.prototype = {
 
 		}
 
+		return this.buildMesh( position, normal, color );
+	},
+
+
+	buildMesh: function ( position, normal, color ) {
+
 		// build geometry
 
 		var geometry = new THREE.BufferGeometry();
@@ -267,16 +301,7 @@ THREE.PCDLoader.prototype = {
 
 		}
 
-		// build mesh
-
-		var mesh = new THREE.Points( geometry, material );
-		var name = url.split( '' ).reverse().join( '' );
-		name = /([^\/]*)/.exec( name );
-		name = name[ 1 ].split( '' ).reverse().join( '' );
-		mesh.name = name;
-
-		return mesh;
-
+		return new THREE.Points( geometry, material );
 	}
 
 };

--- a/examples/js/loaders/WorkerPCDLoader.js
+++ b/examples/js/loaders/WorkerPCDLoader.js
@@ -1,0 +1,209 @@
+/**
+ * Description: An extension to THREE.PCDLoader that allows parsingto be performed in a worker.
+ *
+ * @author Kai Salmen / https://github.com/kaisalmen
+ */
+
+if ( THREE.PCDLoader === undefined ) console.error( '"THREE.PCDLoader" is not available. "THREE.WorkerPCDLoader" requires it. Please include "PCDLoader.js" in your HTML.' );
+if ( THREE.LoaderSupport === undefined ) console.error( '"THREE.LoaderSupport" is not available. "THREE.OBJLoader2" requires it. Please include "LoaderSupport.js" in your HTML.' );
+
+THREE.WorkerPCDLoader = function ( manager ) {
+
+	THREE.PCDLoader.call( this, manager );
+	this.builder = new THREE.LoaderSupport.Builder();
+	this.loaderRootNode = new THREE.Group();
+	this.workerSupport = null;
+	this.logger = new THREE.LoaderSupport.ConsoleLogger();
+
+	// required for load
+	this.fileLoader = new THREE.FileLoader( this.manager );
+	this.fileLoader.setResponseType( 'arraybuffer' );
+	this.callbacks = new THREE.LoaderSupport.Callbacks();
+};
+
+THREE.WorkerPCDLoader.prototype = Object.create( THREE.PCDLoader.prototype );
+THREE.WorkerPCDLoader.prototype.constructor = THREE.WorkerPCDLoader;
+
+THREE.WorkerPCDLoader.prototype[ 'onProgress' ] = THREE.LoaderSupport.LoaderBase.prototype[ 'onProgress' ];
+
+/**
+ * Use this convenient method to load a file at the given URL. By default the fileLoader uses an ArrayBuffer.
+ * @memberOf THREE.LoaderSupport.LoaderBase
+ *
+ * @param {string}  url A string containing the path/URL of the file to be loaded.
+ * @param {callback} onLoad A function to be called after loading is successfully completed. The function receives loaded Object3D as an argument.
+ * @param {callback} [onProgress] A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains total and Integer bytes.
+ * @param {callback} [onError] A function to be called if an error occurs during loading. The function receives the error as an argument.
+ * @param {callback} [onMeshAlter] A function to be called after a new mesh raw data becomes available for alteration.
+ * @param {boolean} [useAsync] If true, uses async loading with worker, if false loads data synchronously.
+ */
+THREE.WorkerPCDLoader.prototype.load = function ( url, onLoad, onProgress, onError, onMeshAlter, useAsync ) {
+	var scope = this;
+	if ( ! THREE.LoaderSupport.Validator.isValid( onProgress ) ) {
+		var numericalValueRef = 0;
+		var numericalValue = 0;
+		onProgress = function ( event ) {
+			if ( ! event.lengthComputable ) return;
+
+			numericalValue = event.loaded / event.total;
+			if ( numericalValue > numericalValueRef ) {
+
+				numericalValueRef = numericalValue;
+				var output = 'Download of "' + url + '": ' + ( numericalValue * 100 ).toFixed( 2 ) + '%';
+				scope.onProgress( 'progressLoad', output, numericalValue );
+
+			}
+		};
+	}
+
+	if ( ! THREE.LoaderSupport.Validator.isValid( onError ) ) {
+		onError = function ( event ) {
+			var output = 'Error occurred while downloading "' + url + '"';
+			scope.logger.logError( output + ': ' + event );
+			scope.onProgress( 'error', output, -1 );
+		};
+	}
+
+	this.fileLoader.setPath( this.path );
+	this.fileLoader.load( url, function ( content ) {
+		if ( useAsync ) {
+
+			scope.parseAsync( content, onLoad );
+
+		} else {
+
+			onLoad( scope.parse( content ) );
+
+		}
+
+	}, onProgress, onError );
+
+};
+
+THREE.WorkerPCDLoader.prototype.parse = function ( data, url ) {
+	var scope = this;
+	var parser = new THREE.WorkerPCDLoader.Parser();
+	parser.setLittleEndian( this.littleEndian );
+
+	var onMeshLoaded = function ( payload ) {
+		var meshes = scope.builder.processPayload( payload );
+		// no mesh alteration, therefore short-cut
+		var mesh;
+		for ( var i in meshes ) {
+			mesh = meshes[ i ];
+			scope.loaderRootNode.add( mesh );
+		}
+
+		return scope.loaderRootNode;
+	};
+	parser.setCallbackBuilder( onMeshLoaded );
+	parser.parse( data, url );
+
+	return scope.loaderRootNode;
+};
+
+/**
+ * Parses a PCD binary structure asynchronously from given ArrayBuffer. Calls onLoad once loading is complete.
+ * A new Group containing the object is passed to onLoad. The object is converted to Points with a BufferGeometry
+ * and a PointsMaterial.
+ * @memberOf THREE.PCDLoader
+ *
+ * @param {arraybuffer} data PCD data as Uint8Array
+ * @param {callback} onLoad Called after worker successfully completed loading
+ */
+THREE.WorkerPCDLoader.prototype.parseAsync = function ( data, onLoad ) {
+	var scope = this;
+	var scopedOnLoad = function () {
+		onLoad( scope.loaderRootNode );
+	};
+	var scopedOnMeshLoaded = function ( payload ) {
+		var meshes = scope.builder.processPayload( payload );
+		var mesh;
+		for ( var i in meshes ) {
+			mesh = meshes[ i ];
+			scope.loaderRootNode.add( mesh );
+		}
+	};
+
+	this.workerSupport = THREE.LoaderSupport.Validator.verifyInput( this.workerSupport, new THREE.LoaderSupport.WorkerSupport() );
+	var buildCode = function ( funcBuildObject, funcBuildSingleton ) {
+		var workerCode = '';
+		workerCode += '/**\n';
+		workerCode += '  * This code was constructed by WorkerPCDLoader.buildCode.\n';
+		workerCode += '  */\n\n';
+		workerCode += 'THREE = {\n\tLoaderSupport: {},\n\tPCDLoader: {},\n\tWorkerPCDLoader: {}\n};\n\n';
+		workerCode += funcBuildObject( 'THREE.LoaderUtils', THREE.LoaderUtils );
+		workerCode += funcBuildSingleton( 'THREE.PCDLoader.Parser', THREE.PCDLoader.Parser, 'Parser', null,[ 'buildMesh' ] );
+		workerCode += funcBuildSingleton( 'THREE.WorkerPCDLoader.Parser', THREE.WorkerPCDLoader.Parser, 'Parser', 'THREE.PCDLoader.Parser', [ 'parseData', 'parseHeader', 'setLittleEndian' ] );
+		return workerCode;
+	};
+	this.workerSupport.validate( buildCode, 'THREE.WorkerPCDLoader.Parser' );
+	this.workerSupport.setCallbacks( scopedOnMeshLoaded, scopedOnLoad );
+	if ( scope.terminateWorkerOnLoad ) this.workerSupport.setTerminateRequested( true );
+
+	this.workerSupport.run(
+		{
+			params: {
+				littleEndian: this.littleEndian
+			},
+			// there is currently no need to send any material properties or logging config to the Parser
+			data: {
+				input: data,
+				options: null
+			}
+		}
+	);
+};
+
+
+THREE.WorkerPCDLoader.Parser = function ( manager ) {
+
+	THREE.PCDLoader.Parser.call( this );
+	this.callbackBuilder = null;
+
+};
+
+THREE.WorkerPCDLoader.Parser.prototype = Object.create( THREE.PCDLoader.Parser.prototype );
+THREE.WorkerPCDLoader.Parser.prototype.constructor = THREE.WorkerPCDLoader.Parser;
+
+
+THREE.WorkerPCDLoader.Parser.prototype.setCallbackBuilder = function ( callbackBuilder ) {
+	if ( callbackBuilder === null || callbackBuilder === undefined ) throw 'Unable to run as no "builder" callback is set.';
+	this.callbackBuilder = callbackBuilder;
+};
+
+THREE.WorkerPCDLoader.Parser.prototype.buildMesh = function ( position, normal, color ) {
+	var vertexFA = new Float32Array( position );
+	var normalFA = normal.length > 0 ? new Float32Array( normal ) : null;
+	var colorFA = color.length > 0 ? new Float32Array( color ) : null;
+
+	var mesh = this.callbackBuilder( {
+			cmd: 'meshData',
+			progress: {
+				numericalValue: 100
+			},
+			params: {},
+			materials: {
+				multiMaterial: false,
+				materialNames: [ color.length > 0 ? 'defaultVertexColorMaterial' : 'defaultPointMaterial' ],
+				materialGroups: null
+			},
+			buffers: {
+				vertices: vertexFA,
+				indices: null,
+				colors: colorFA,
+				normals: normalFA,
+				uvs: null
+			},
+			// 0: mesh, 1: line, 2: point
+			geometryType: 2
+		},
+		[ vertexFA.buffer ],
+		null,
+		colorFA !== null ? [ colorFA.buffer ] : null,
+		normalFA !== null ? [ normalFA.buffer ] : null,
+		null
+	);
+
+	return mesh;
+}

--- a/examples/webgl_loader_pcd.html
+++ b/examples/webgl_loader_pcd.html
@@ -48,6 +48,8 @@
 
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/PCDLoader.js"></script>
+		<script src="js/loaders/LoaderSupport.js"></script>
+		<script src="js/loaders/WorkerPCDLoader.js"></script>
 		<script src="js/controls/TrackballControls.js"></script>
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
@@ -93,7 +95,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				var loader = new THREE.PCDLoader();
+				var loader = new THREE.WorkerPCDLoader();
 				loader.load( './models/pcd/binary/Zaghetto.pcd', function ( mesh ) {
 
 					scene.add( mesh );
@@ -101,7 +103,7 @@
 					controls.target.set( center.x, center.y, center.z);
 					controls.update();
 
-				} );
+				}, null, null, null, true );
 
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );


### PR DESCRIPTION
This whole work was motivated by two things:

1.  I wanted to apply the whole common functionality (Builder, WorkerSupport, WorkerDirector, LoaderBase) I extracted in the past from `OBJLoader2` into `LoaderSupport` and show that it really works in a different loader.  `PCDLoader` was a fairly easy target.

2. Someone really asked for this feature (https://github.com/kaisalmen/WWOBJLoader/issues/10) months before `OBJLoader2` V2.x.x was completed and available here (R88), but I only lately had time to work on it.

What has been done to `PCDLoader`?
 - The Parser has been isolated into its own object/class. This can be used inside the worker.
 - The loader is based on `THREE.LoaderSupport.LoaderBase` to be able to re-use common functions (load function became completely generic)
 - `THREE.LoaderSupport.Builder` is commonly used to build meshes
 - `THREE.LoaderSupport.WorkerSupport` is used to build the Worker code and handle execution
 - It is now possible to use `THREE.LoaderSupport.WorkerDirector` to automate loading of files (my idea is to enhance the obj2_parallels example with two or more different loaders.

Two important things:
 - The code requires the latest `LoaderSupport` from #13156  that why this PR is based on that branch
 -  #13197 needs to be fixed otherwise the one of the three identical PCDs is not loaded 

Please review, let me know what you think?
Thanks you,

Kai