### PR TITLE
webgl_materials_envmaps: Remove unused variable

### DIFF
--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -211,8 +211,6 @@
 
 			function render() {
 
-				var timer = -0.0002 * Date.now();
-
 				camera.lookAt( scene.position );
 				cameraCube.rotation.copy( camera.rotation );
 


### PR DESCRIPTION
The variable `timer` is written, but never read.