### PR TITLE
ImageLoader: remove image event listeners explicitly

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -46,12 +46,10 @@ Object.assign( ImageLoader.prototype, {
 
 		var image = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'img' );
 
-		var loadListener, errorListener;
+		function onInternalLoad() {
 
-		loadListener = function () {
-
-			image.removeEventListener( 'load', loadListener, false );
-			image.removeEventListener( 'error', errorListener, false );
+			image.removeEventListener( 'load', onInternalLoad, false );
+			image.removeEventListener( 'error', onInternalError, false );
 
 			Cache.add( url, this );
 
@@ -59,21 +57,21 @@ Object.assign( ImageLoader.prototype, {
 
 			scope.manager.itemEnd( url );
 
-		};
+		}
 
-		errorListener = function ( event ) {
+		function onInternalError( event ) {
 
-			image.removeEventListener( 'load', loadListener, false );
-			image.removeEventListener( 'error', errorListener, false );
+			image.removeEventListener( 'load', onInternalLoad, false );
+			image.removeEventListener( 'error', onInternalError, false );
 
 			if ( onError ) onError( event );
 
 			scope.manager.itemEnd( url );
 			scope.manager.itemError( url );
 
-		};
+		}
 
-		image.addEventListener( 'load', loadListener, false );
+		image.addEventListener( 'load', onInternalLoad, false );
 
 		/*
 		image.addEventListener( 'progress', function ( event ) {
@@ -83,7 +81,7 @@ Object.assign( ImageLoader.prototype, {
 		}, false );
 		*/
 
-		image.addEventListener( 'error', errorListener, false );
+		image.addEventListener( 'error', onInternalError, false );
 
 		if ( url.substr( 0, 5 ) !== 'data:' ) {
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -46,7 +46,12 @@ Object.assign( ImageLoader.prototype, {
 
 		var image = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'img' );
 
-		image.addEventListener( 'load', function () {
+		var loadListener, errorListener;
+
+		loadListener = function () {
+
+			image.removeEventListener( 'load', loadListener, false );
+			image.removeEventListener( 'error', errorListener, false );
 
 			Cache.add( url, this );
 
@@ -54,7 +59,21 @@ Object.assign( ImageLoader.prototype, {
 
 			scope.manager.itemEnd( url );
 
-		}, false );
+		};
+
+		errorListener = function ( event ) {
+
+			image.removeEventListener( 'load', loadListener, false );
+			image.removeEventListener( 'error', errorListener, false );
+
+			if ( onError ) onError( event );
+
+			scope.manager.itemEnd( url );
+			scope.manager.itemError( url );
+
+		};
+
+		image.addEventListener( 'load', loadListener, false );
 
 		/*
 		image.addEventListener( 'progress', function ( event ) {
@@ -64,14 +83,7 @@ Object.assign( ImageLoader.prototype, {
 		}, false );
 		*/
 
-		image.addEventListener( 'error', function ( event ) {
-
-			if ( onError ) onError( event );
-
-			scope.manager.itemEnd( url );
-			scope.manager.itemError( url );
-
-		}, false );
+		image.addEventListener( 'error', errorListener, false );
 
 		if ( url.substr( 0, 5 ) !== 'data:' ) {
 


### PR DESCRIPTION
While doing some memory profiling, I found that the `onLoad` callback to `TextureLoader` (and, implicitly, `ImageLoader`) was keeping a reference alive to some seemingly unrelated application objects. Traced this down to the `addEventListener` callbacks in `ImageLoader`.

This change should have no outward impact on behavior, other than to prevent unwanted references to objects. AFAICT, the `image` `'load'` and `'error'` callbacks aren't designed to ever be invoked again.