### PR TITLE
Docs: Fixed annoying behaviour in Safari when filtering docs.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
 			</a>
 
 			<div class="filterBlock" >
-				<input type="text" id="filterInput" placeholder="Type to filter">
+				<input type="text" id="filterInput" placeholder="Type to filter" autocorrect="off" autocapitalize="off" spellcheck="false">
 				<a href="#" id="clearFilterButton">x</a>
 			</div>
 			<div id="content"></div>


### PR DESCRIPTION
Quite often when searching the docs Safari would helpfully change my search term. This fix stops that happening. See attached screenshot. 
![autocorrect](https://user-images.githubusercontent.com/867444/36102892-9e209ebc-1005-11e8-803d-692c21ce2835.png)
