### PR TITLE
Docs: Visible type information.

### DIFF
--- a/docs/api/Template.html
+++ b/docs/api/Template.html
@@ -22,7 +22,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Number todo])</h3>
+		<h3>[name]([param:Number todo])</h3>
 		<div></div>
 
 

--- a/docs/api/animation/AnimationAction.html
+++ b/docs/api/animation/AnimationAction.html
@@ -150,7 +150,7 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:AnimationAction crossFadeFrom]( [page:AnimationAction fadeOutAction], [page:Number durationInSeconds], [page:Boolean warpBoolean] )</h3>
+		<h3>[method:AnimationAction crossFadeFrom]( [param:AnimationAction fadeOutAction], [param:Number durationInSeconds], [param:Boolean warpBoolean] )</h3>
 		<div>
 			Causes this action to [page:.fadeIn fade in], fading out another action simultaneously, within
 			the passed time interval. This method can be chained.<br /><br />
@@ -162,7 +162,7 @@
 
 		</div>
 
-		<h3>[method:AnimationAction crossFadeTo]( [page:AnimationAction fadeInAction], [page:Number durationInSeconds], [page:Boolean warpBoolean] )</h3>
+		<h3>[method:AnimationAction crossFadeTo]( [param:AnimationAction fadeInAction], [param:Number durationInSeconds], [param:Boolean warpBoolean] )</h3>
 		<div>
 			Causes this action to [page:.fadeOut fade out], fading in another action simultaneously, within
 			the passed time interval. This method can be chained.<br /><br />
@@ -172,13 +172,13 @@
 			Note: Like with *fadeIn*/*fadeOut*, the fading starts/ends with a weight of 1.
 		</div>
 
-		<h3>[method:AnimationAction fadeIn]( [page:Number durationInSeconds] )</h3>
+		<h3>[method:AnimationAction fadeIn]( [param:Number durationInSeconds] )</h3>
 		<div>
 			Increases the [page:.weight weight] of this action gradually from 0 to 1, within the passed time
 			interval. This method can be chained.
 		</div>
 
-		<h3>[method:AnimationAction fadeOut]( [page:Number durationInSeconds] )</h3>
+		<h3>[method:AnimationAction fadeOut]( [param:Number durationInSeconds] )</h3>
 		<div>
 			Decreases the [page:.weight weight] of this action gradually from 1 to 0, within the passed time
 			interval. This method can be chained.
@@ -211,7 +211,7 @@
 			Returns the root object on which this action is performed.
 		</div>
 
-		<h3>[method:AnimationAction halt]( [page:Number durationInSeconds] )</h3>
+		<h3>[method:AnimationAction halt]( [param:Number durationInSeconds] )</h3>
 		<div>
 			Decelerates this animation's speed to 0 by decreasing [page:.timeScale timeScale] gradually
 			(starting from its current value), within the passed time interval. This method can be chained.
@@ -261,13 +261,13 @@
 			This means: If you want both, resetting and stopping, don’t call .*reset*; call .*stop* instead.
 		</div>
 
-		<h3>[method:AnimationAction setDuration]( [page:Number durationInSeconds] )</h3>
+		<h3>[method:AnimationAction setDuration]( [param:Number durationInSeconds] )</h3>
 		<div>
 			Sets the duration for a single loop of this action (by adjusting [page:.timeScale timeScale]
 			and stopping any scheduled warping). This method can be chained.
 		</div>
 
-		<h3>[method:AnimationAction setEffectiveTimeScale]( [page:Number timeScale] )</h3>
+		<h3>[method:AnimationAction setEffectiveTimeScale]( [param:Number timeScale] )</h3>
 		<div>
 			Sets the [page:.timeScale timeScale] and stops any scheduled warping. This method can be chained.<br /><br />
 
@@ -279,7 +279,7 @@
 			this method.
 		</div>
 
-		<h3>[method:AnimationAction setEffectiveWeight]( [page:Number weight] )</h3>
+		<h3>[method:AnimationAction setEffectiveWeight]( [param:Number weight] )</h3>
 		<div>
 			Sets the [page:.weight weight] and stops any scheduled fading. This method can be chained.<br /><br />
 
@@ -291,13 +291,13 @@
 			this method.
 		</div>
 
-		<h3>[method:AnimationAction setLoop]( [page:Number loopMode], [page:Number repetitions] )</h3>
+		<h3>[method:AnimationAction setLoop]( [param:Number loopMode], [param:Number repetitions] )</h3>
 		<div>
 			Sets the [page:.loop loop mode] and the number of [page:.repetitions repetitions]. This method
 			can be chained.
 		</div>
 
-		<h3>[method:AnimationAction startAt]( [page:Number startTimeInSeconds] )</h3>
+		<h3>[method:AnimationAction startAt]( [param:Number startTimeInSeconds] )</h3>
 		<div>
 			Defines the time for a delayed start (usually passed as [page:AnimationMixer.time] +
 			deltaTimeInSeconds). This method can be chained.<br /><br />
@@ -313,7 +313,7 @@
 
 			The action will be immediately stopped and completely [page:.reset reset].<br /><br />
 
-			Note: You can stop all active actions on the same mixer in one go via 
+			Note: You can stop all active actions on the same mixer in one go via
 			[page:AnimationMixer.stopAllAction mixer.stopAllAction].
 		</div>
 
@@ -329,7 +329,7 @@
 			chained.
 		</div>
 
-		<h3>[method:AnimationAction syncWith]( [page:AnimationAction otherAction] )</h3>
+		<h3>[method:AnimationAction syncWith]( [param:AnimationAction otherAction] )</h3>
 		<div>
 			Synchronizes this action with the passed other action. This method can be chained.<br /><br />
 
@@ -339,9 +339,9 @@
 			Note: Future changes of the other action's *time* and *timeScale* will not be detected.
 		</div>
 
-		<h3>[method:AnimationAction warp]( [page:Number startTimeScale], [page:Number endTimeScale], [page:Number durationInSeconds] )</h3>
+		<h3>[method:AnimationAction warp]( [param:Number startTimeScale], [param:Number endTimeScale], [param:Number durationInSeconds] )</h3>
 		<div>
-			Changes the playback speed, within the passed time interval, by modifying 
+			Changes the playback speed, within the passed time interval, by modifying
 			[page:.timeScale timeScale] gradually from *startTimeScale* to *endTimeScale*. This method can
 			be chained.
 		</div>

--- a/docs/api/animation/AnimationAction.html
+++ b/docs/api/animation/AnimationAction.html
@@ -24,7 +24,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:AnimationMixer mixer], [page:AnimationClip clip], [page:Object3D localRoot] )</h3>
+		<h3>[name]( [param:AnimationMixer mixer], [param:AnimationClip clip], [param:Object3D localRoot] )</h3>
 		<div>
 			[page:AnimationMixer mixer] - the *AnimationMixer* that is controlled by this action.<br />
 			[page:AnimationClip clip] - the *AnimationClip* that holds the animation data for this action.<br />

--- a/docs/api/animation/AnimationClip.html
+++ b/docs/api/animation/AnimationClip.html
@@ -87,7 +87,7 @@
 		<h2>Static Methods</h2>
 
 
-		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [page:String name], [page:Array morphTargetSequence], [page:Number fps], [page:Boolean noLoop] )</h3>
+		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:String name], [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
 		<div>
 			Returns an array of new AnimationClips created from the [page:Geometry.morphTargets morph
 			target sequences] of a geometry, trying to sort morph target names into animation-group-based
@@ -97,32 +97,32 @@
 			[page:.CreateFromMorphTargetSequence CreateFromMorphTargetSequence].
 		</div>
 
-		<h3>[method:AnimationClip CreateFromMorphTargetSequence]( [page:String name], [page:Array morphTargetSequence], [page:Number fps], [page:Boolean noLoop] )</h3>
+		<h3>[method:AnimationClip CreateFromMorphTargetSequence]( [param:String name], [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
 		<div>
 			Returns a new AnimationClip from the passed [page:Geometry.morphTargets morph targets array]
 			of a geometry, taking a name and the number of frames per second.<br /><br />
 
-			Note: The fps parameter is required, but the animation speed can be overridden in an 
+			Note: The fps parameter is required, but the animation speed can be overridden in an
 			*AnimationAction* via [page:AnimationAction.setDuration animationAction.setDuration].
 		</div>
 
-		<h3>[method:AnimationClip findByName]( [page:Object objectOrClipArray], [page:String name] )</h3>
+		<h3>[method:AnimationClip findByName]( [param:Object objectOrClipArray], [param:String name] )</h3>
 		<div>
 			Searches for an AnimationClip by name, taking as its first parameter either an array of
 			AnimationClips, or a mesh or geometry that contains an array named "animations".
 		</div>
 
-		<h3>[method:AnimationClip parse]( [page:Object json] )</h3>
+		<h3>[method:AnimationClip parse]( [param:Object json] )</h3>
 		<div>
 			Parses a JSON representation of a clip and returns an AnimationClip.
 		</div>
 
-		<h3>[method:AnimationClip parseAnimation]( [page:Object animation], [page:Array bones] )</h3>
+		<h3>[method:AnimationClip parseAnimation]( [param:Object animation], [param:Array bones] )</h3>
 		<div>
 			Parses the animation.hierarchy format and returns an AnimationClip.
 		</div>
 
-		<h3>[method:Object toJSON]( [page:AnimationClip clip] )</h3>
+		<h3>[method:Object toJSON]( [param:AnimationClip clip] )</h3>
 		<div>
 			Takes an AnimationClip and returns a JSON object.
 		</div>

--- a/docs/api/animation/AnimationClip.html
+++ b/docs/api/animation/AnimationClip.html
@@ -21,7 +21,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:String name], [page:Number duration], [page:Array tracks] )</h3>
+		<h3>[name]( [param:String name], [param:Number duration], [param:Array tracks] )</h3>
 		<div>
 			[page:String name] - a name for this clip.<br />
 			[page:Number duration] - the duration of this clip (in seconds). If a negative value is passed,

--- a/docs/api/animation/AnimationMixer.html
+++ b/docs/api/animation/AnimationMixer.html
@@ -23,7 +23,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Object3D rootObject] )</h3>
+		<h3>[name]( [param:Object3D rootObject] )</h3>
 		<div>
 			[page:Object3D rootObject] - the object whose animations shall be played by this mixer.<br />
 		</div>

--- a/docs/api/animation/AnimationMixer.html
+++ b/docs/api/animation/AnimationMixer.html
@@ -49,7 +49,7 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:AnimationAction clipAction]([page:AnimationClip clip], [page:Object3D optionalRoot])</h3>
+		<h3>[method:AnimationAction clipAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
 		<div>
 			Returns an [page:AnimationAction] for the passed clip, optionally using a root object different
 			from the mixer's default root. The first parameter can be either an [page:AnimationClip] object
@@ -57,11 +57,11 @@
 
 			If an action fitting these parameters doesn't yet exist, it will be created by this method.<br /><br />
 
-			Note: Calling this method several times with the same parameters returns always the same clip 
+			Note: Calling this method several times with the same parameters returns always the same clip
 			instance.
 		</div>
 
-		<h3>[method:AnimationAction existingAction]([page:AnimationClip clip], [page:Object3D optionalRoot])</h3>
+		<h3>[method:AnimationAction existingAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
 		<div>
 			Returns an existing [page:AnimationAction] for the passed clip, optionally using a root object
 			different from the mixer's default root.<br /><br />
@@ -79,25 +79,25 @@
 			Deactivates all previously scheduled actions on this mixer.
 		</div>
 
-		<h3>[method:AnimationMixer update]([page:Number deltaTimeInSeconds]) </h3>
+		<h3>[method:AnimationMixer update]([param:Number deltaTimeInSeconds]) </h3>
 		<div>
 			Advances the global mixer time and updates the animation.<br /><br />
 
 			This is usually done in the render loop, passing [page:Clock.getDelta clock.getDelta] scaled by the mixer's [page:.timeScale timeScale]).
 		</div>
 
-		<h3>[method:null uncacheClip]([page:AnimationClip clip])</h3>
+		<h3>[method:null uncacheClip]([param:AnimationClip clip])</h3>
 
 		<div>
 			Deallocates all memory resources for a clip.
 		</div>
 
-		<h3>[method:null uncacheRoot]([page:Object3D root]) </h3>
+		<h3>[method:null uncacheRoot]([param:Object3D root]) </h3>
 		<div>
 			Deallocates all memory resources for a root object.
 		</div>
 
-		<h3>[method:null uncacheAction]([page:AnimationClip clip], [page:Object3D optionalRoot])</h3>
+		<h3>[method:null uncacheAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
 		<div>
 			Deallocates all memory resources for an action.
 		</div>

--- a/docs/api/animation/AnimationObjectGroup.html
+++ b/docs/api/animation/AnimationObjectGroup.html
@@ -38,7 +38,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:object obj1], [page:object obj2], [page:object obj3], ... )</h3>
+		<h3>[name]( [param:object obj1], [param:object obj2], [param:object obj3], ... )</h3>
 		[page:object obj] - an abitrary number of meshes that share the same animation state.<br />
 
 

--- a/docs/api/animation/AnimationObjectGroup.html
+++ b/docs/api/animation/AnimationObjectGroup.html
@@ -61,17 +61,17 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:null add]( [page:object obj1], [page:object obj2], [page:object obj3], ... )</h3>
+		<h3>[method:null add]( [param:object obj1], [param:object obj2], [param:object obj3], ... )</h3>
 		<div>
 			Adds an arbitrary number of objects to this *AnimationObjectGroup*.
 		</div>
 
-		<h3>[method:null remove]( [page:object obj1], [page:object obj2], [page:object obj3], ... )</h3>
+		<h3>[method:null remove]( [param:object obj1], [param:object obj2], [param:object obj3], ... )</h3>
 		<div>
 			Removes an arbitrary number of objects from this *AnimationObjectGroup*.
 		</div>
 
-		<h3>[method:null uncache]( [page:object obj1], [page:object obj2], [page:object obj3], ... )</h3>
+		<h3>[method:null uncache]( [param:object obj1], [param:object obj2], [param:object obj3], ... )</h3>
 		<div>
 			Deallocates all memory resources for the passed objects of this *AnimationObjectGroup*.
 		</div>

--- a/docs/api/animation/KeyframeTrack.html
+++ b/docs/api/animation/KeyframeTrack.html
@@ -192,18 +192,18 @@
 			[page:AnimationClip.CreateFromMorphTargetSequence animationClip.CreateFromMorphTargetSequence]).
 		</div>
 
-		<h3>[method:null setInterpolation]( [page:Constant interpolationType] )</h3>
+		<h3>[method:null setInterpolation]( [param:Constant interpolationType] )</h3>
 		<div>
 			Sets the interpolation type. See [page:Animation Animation Constants] for choices.
 		</div>
 
-		<h3>[method:null shift]( [page:Number timeOffsetInSeconds] )</h3>
+		<h3>[method:null shift]( [param:Number timeOffsetInSeconds] )</h3>
 		<div>
 			Moves all keyframes either forward or backward in time.
 		</div>
 
 
-		<h3>[method:null trim]( [page:Number startTimeInSeconds], [page:Number endTimeInSeconds] )</h3>
+		<h3>[method:null trim]( [param:Number startTimeInSeconds], [param:Number endTimeInSeconds] )</h3>
 		<div>
 			Removes keyframes before *startTime* and after *endTime*,
 			without changing any values within the range [*startTime*, *endTime*].
@@ -218,12 +218,12 @@
 
 		<h2>Static Methods</h2>
 
-		<h3>[method:KeyframeTrack parse]( [page:JSON json] )</h3>
+		<h3>[method:KeyframeTrack parse]( [param:JSON json] )</h3>
 		<div>
 		Parses a JSON object and returns a new keyframe track of the correct type.
 		</div>
 
-		<h3>[method:JSON toJSON]( [page:KeyframeTrack track] )</h3>
+		<h3>[method:JSON toJSON]( [param:KeyframeTrack track] )</h3>
 		<div>
 		Converts the track to JSON.
 		</div>

--- a/docs/api/animation/KeyframeTrack.html
+++ b/docs/api/animation/KeyframeTrack.html
@@ -61,7 +61,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:String name], [page:Array times], [page:Array values], [page:Constant interpolation] )</h3>
+		<h3>[name]( [param:String name], [param:Array times], [param:Array values], [param:Constant interpolation] )</h3>
 		<div>
 			[page:String name] - the identifier for the *KeyframeTrack*.<br />
 			[page:Array times] - an array of keyframe times, converted internally to a

--- a/docs/api/animation/PropertyBinding.html
+++ b/docs/api/animation/PropertyBinding.html
@@ -72,11 +72,11 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null getValue]( [page:Array targetArray], [page:Number offset] )</h3>
+		<h3>[method:null getValue]( [param:Array targetArray], [param:Number offset] )</h3>
 		<div>
 		</div>
 
-		<h3>[method:null setValue]( [page:Array sourceArray], [page:Number offset] )</h3>
+		<h3>[method:null setValue]( [param:Array sourceArray], [param:Number offset] )</h3>
 		<div>
 		</div>
 

--- a/docs/api/animation/PropertyBinding.html
+++ b/docs/api/animation/PropertyBinding.html
@@ -18,7 +18,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Object3D rootNode], path, parsedPath )</h3>
+		<h3>[name]( [param:Object3D rootNode], path, parsedPath )</h3>
 		<div>
 			-- [page:Object3D rootNode]:
 			-- path

--- a/docs/api/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/animation/tracks/BooleanKeyframeTrack.html
@@ -21,7 +21,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:String name], [page:Array times], [page:Array values] )</h3>
+		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<div>
 			[page:String name] - (required) identifier for the KeyframeTrack.<br />
 			[page:Array times] - (required) array of keyframe times.<br />

--- a/docs/api/animation/tracks/ColorKeyframeTrack.html
+++ b/docs/api/animation/tracks/ColorKeyframeTrack.html
@@ -23,7 +23,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:String name], [page:Array times], [page:Array values] )</h3>
+		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<div>
 			[page:String name] - (required) identifier for the KeyframeTrack.<br />
 			[page:Array times] - (required) array of keyframe times.<br />

--- a/docs/api/animation/tracks/NumberKeyframeTrack.html
+++ b/docs/api/animation/tracks/NumberKeyframeTrack.html
@@ -21,7 +21,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:String name], [page:Array times], [page:Array values] )</h3>
+		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<div>
 			[page:String name] - (required) identifier for the KeyframeTrack.<br />
 			[page:Array times] - (required) array of keyframe times.<br />

--- a/docs/api/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/animation/tracks/QuaternionKeyframeTrack.html
@@ -21,7 +21,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:String name], [page:Array times], [page:Array values] )</h3>
+		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<div>
 			[page:String name] (required) identifier for the KeyframeTrack.<br />
 			[page:Array times] (required) array of keyframe times.<br />
@@ -59,8 +59,8 @@
 
 		<h3>[method:null InterpolantFactoryMethodLinear]()</h3>
 		<div>
-			Returns a new [page:QuaternionLinearInterpolant QuaternionLinearInterpolant] based on the 
-			[page:KeyframeTrack.values values], [page:KeyframeTrack.times times] and 
+			Returns a new [page:QuaternionLinearInterpolant QuaternionLinearInterpolant] based on the
+			[page:KeyframeTrack.values values], [page:KeyframeTrack.times times] and
 			[page:KeyframeTrack.valueSize valueSize] of the keyframes.
 		</div>
 

--- a/docs/api/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/animation/tracks/StringKeyframeTrack.html
@@ -21,7 +21,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:String name], [page:Array times], [page:Array values] )</h3>
+		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<div>
 			[page:String name] - (required) identifier for the KeyframeTrack.<br />
 			[page:Array times] - (required) array of keyframe times.<br />

--- a/docs/api/animation/tracks/VectorKeyframeTrack.html
+++ b/docs/api/animation/tracks/VectorKeyframeTrack.html
@@ -21,13 +21,13 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:String name], [page:Array times], [page:Array values] )</h3>
+		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<div>
 			[page:String name] - (required) identifier for the KeyframeTrack.<br />
 			[page:Array times] - (required) array of keyframe times.<br />
 			[page:Array values] - values for the keyframes at the times specified.<br />
-			[page:Constant interpolation] - the type of interpolation to use. See 
-			[page:Animation Animation Constants] for possible values. Default is 
+			[page:Constant interpolation] - the type of interpolation to use. See
+			[page:Animation Animation Constants] for possible values. Default is
 			[page:Animation InterpolateLinear].
 		</div>
 

--- a/docs/api/audio/Audio.html
+++ b/docs/api/audio/Audio.html
@@ -48,7 +48,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:AudioListener listener] )</h3>
+		<h3>[name]( [param:AudioListener listener] )</h3>
 		<div>
 		listener — (required) [page:AudioListener AudioListener] instance.
 		</div>

--- a/docs/api/audio/Audio.html
+++ b/docs/api/audio/Audio.html
@@ -167,13 +167,13 @@
 		Add the filter to the [page:Audio.filters filters] array.
 		</div>
 
-		<h3>[method:Audio setFilters]( [page:Array value] )</h3>
+		<h3>[method:Audio setFilters]( [param:Array value] )</h3>
 		<div>
 		value - arrays of filters.<br />
 		Set the [page:Audio.filters filters] array to *value*.
 		</div>
 
-		<h3>[method:null setLoop]( [page:Boolean value] )</h3>
+		<h3>[method:null setLoop]( [param:Boolean value] )</h3>
 		<div>
 		Set [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loop source.loop] to *value*
 		(whether playback should loop).
@@ -186,12 +186,12 @@
 
 		</div>
 
-		<h3>[method:null setPlaybackRate]( [page:Number value] )</h3>
+		<h3>[method:null setPlaybackRate]( [param:Number value] )</h3>
 		<div>
 		If [page:Audio.hasPlaybackControl hasPlaybackControl] is enabled, set the [page:Audio.playbackRate playbackRate] to *value*.
 		</div>
 
-		<h3>[method:null setVolume]( [page:Number value] )</h3>
+		<h3>[method:null setVolume]( [param:Number value] )</h3>
 		<div>
 		Set the volume.
 		</div>

--- a/docs/api/audio/AudioContext.html
+++ b/docs/api/audio/AudioContext.html
@@ -29,7 +29,7 @@
 		otherwise set it to a new [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext AudioContext].
 		</div>
 
-		<h3>[method:AudioContext setContext]( [page:AudioConetxt value] )</h3>
+		<h3>[method:AudioContext setContext]( [param:AudioConetxt value] )</h3>
 		<div>
 		 Set the variable *context* in the outer scope to *value*.
 		</div>

--- a/docs/api/audio/AudioListener.html
+++ b/docs/api/audio/AudioListener.html
@@ -86,7 +86,7 @@
 		Returns the value of the [page:AudioListener.filter filter] property.
 		</div>
 
-		<h3>[method:null setFilter]( [page:AudioNode value] )</h3>
+		<h3>[method:null setFilter]( [param:AudioNode value] )</h3>
 		<div>
 		Set the [page:AudioListener.filter filter] property to *value*.
 		</div>
@@ -96,7 +96,7 @@
 		Return the volume.
 		</div>
 
-		<h3>[method:null setMasterVolume]( [page:Number value] )</h3>
+		<h3>[method:null setMasterVolume]( [param:Number value] )</h3>
 		<div>
 		Set the volume.
 		</div>

--- a/docs/api/audio/PositionalAudio.html
+++ b/docs/api/audio/PositionalAudio.html
@@ -55,7 +55,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:AudioListener listener] )</h3>
+		<h3>[name]( [param:AudioListener listener] )</h3>
 		<div>
 		listener — (required) [page:AudioListener AudioListener] instance.
 		</div>

--- a/docs/api/audio/PositionalAudio.html
+++ b/docs/api/audio/PositionalAudio.html
@@ -87,7 +87,7 @@
 		Returns the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/refDistance panner.refDistance].
 		</div>
 
-		<h3>[method:PannerNode setRefDistance]( [page:Number value] )</h3>
+		<h3>[method:PannerNode setRefDistance]( [param:Number value] )</h3>
 		<div>
 		Sets the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/refDistance panner.refDistance].
 		</div>
@@ -97,7 +97,7 @@
 		Returns the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/rolloffFactor panner.rolloffFactor].
 		</div>
 
-		<h3>[method:PannerNode setRolloffFactor]( [page:Number value] )</h3>
+		<h3>[method:PannerNode setRolloffFactor]( [param:Number value] )</h3>
 		<div>
 		Sets the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/rolloffFactor panner.rolloffFactor].
 		</div>
@@ -107,7 +107,7 @@
 		Returns the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel panner.distanceModel].
 		</div>
 
-		<h3>[method:String setDistanceModel]( [page:String value] )</h3>
+		<h3>[method:String setDistanceModel]( [param:String value] )</h3>
 		<div>
 		Sets the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel panner.distanceModel].
 		</div>
@@ -117,7 +117,7 @@
 		Returns the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/maxDistance panner.maxDistance].
 		</div>
 
-		<h3>[method:PannerNode setMaxDistance]( [page:Number value] )</h3>
+		<h3>[method:PannerNode setMaxDistance]( [param:Number value] )</h3>
 		<div>
 		Sets the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/maxDistance panner.maxDistance].
 		</div>

--- a/docs/api/cameras/Camera.html
+++ b/docs/api/cameras/Camera.html
@@ -64,18 +64,18 @@
 			Return a new camera with the same properties as this one.
 		</div>
 
-		<h3>[method:Camera copy]( [page:Camera source] )</h3>
+		<h3>[method:Camera copy]( [param:Camera source] )</h3>
 		<div>
 		Copy the properties from the source camera into this one.
 		</div>
 
-		<h3>[method:Vector3 getWorldDirection]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 getWorldDirection]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 		Returns a [page:Vector3] representing the world space direction in which the camera is looking.<br /><br />
-		
+
 		Note: This is not the camera’s positive, but its negative z-axis, in contrast to
 		[page:Object3D.getWorldDirection getWorldDirection] of the base class (Object3D).<br /><br />
-		
+
 		If an [page:Vector3 optionalTarget] vector is specified, the result will be copied into this vector
 		(which can be reused in this way), otherwise a new vector will be created.
 		</div>

--- a/docs/api/cameras/CubeCamera.html
+++ b/docs/api/cameras/CubeCamera.html
@@ -43,7 +43,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Number near], [page:Number far], [page:Number cubeResolution] )</h3>
+		<h3>[name]( [param:Number near], [param:Number far], [param:Number cubeResolution] )</h3>
 		<div>
 		near -- The near clipping distance. <br />
 		far -- The far clipping distance <br />

--- a/docs/api/cameras/CubeCamera.html
+++ b/docs/api/cameras/CubeCamera.html
@@ -67,7 +67,7 @@
 		<div>See the base [page:Object3D] class for common methods.</div>
 
 
-		<h3>[method:null update]( [page:WebGLRenderer renderer], [page:Scene scene] )</h3>
+		<h3>[method:null update]( [param:WebGLRenderer renderer], [param:Scene scene] )</h3>
 		<div>
 		renderer -- The current WebGL renderer <br />
 		scene -- The current scene
@@ -76,7 +76,7 @@
 		Call this to update the [page:CubeCamera.renderTarget renderTarget].
 		</div>
 
-		<h3>[method:null clear]( [page:WebGLRenderer renderer], [page:Boolean color], [page:Boolean depth], [page:Boolean stencil] )</h3>
+		<h3>[method:null clear]( [param:WebGLRenderer renderer], [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
 		<div>
 		Call this to clear the [page:CubeCamera.renderTarget renderTarget] color, depth, and/or stencil buffers.
 		The color buffer is set to the renderer's current clear color. Arguments default to *true*.

--- a/docs/api/cameras/OrthographicCamera.html
+++ b/docs/api/cameras/OrthographicCamera.html
@@ -43,7 +43,7 @@ scene.add( camera );</code>
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Number left], [page:Number right], [page:Number top], [page:Number bottom], [page:Number near], [page:Number far] )</h3>
+		<h3>[name]( [param:Number left], [param:Number right], [param:Number top], [param:Number bottom], [param:Number near], [param:Number far] )</h3>
 		<div>
 		left — Camera frustum left plane.<br />
 		right — Camera frustum right plane.<br />

--- a/docs/api/cameras/OrthographicCamera.html
+++ b/docs/api/cameras/OrthographicCamera.html
@@ -59,7 +59,7 @@ scene.add( camera );</code>
 		<h2>Properties</h2>
 		<div>
 			See the base [page:Camera] class for common properties.<br>
- 			Note that after making changes to most of these properties you will have to call 
+ 			Note that after making changes to most of these properties you will have to call
  			[page:OrthographicCamera.updateProjectionMatrix .updateProjectionMatrix] for the changes to take effect.
 		</div>
 
@@ -107,7 +107,7 @@ scene.add( camera );</code>
 		<h2>Methods</h2>
 		<div>See the base [page:Camera] class for common methods.</div>
 
-		<h3>[method:null setViewOffset]( [page:Float fullWidth], [page:Float fullHeight], [page:Float x], [page:Float y], [page:Float width], [page:Float height] )</h3>
+		<h3>[method:null setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
 		<div>
 		fullWidth — full width of multiview setup<br />
 		fullHeight — full height of multiview setup<br />

--- a/docs/api/cameras/PerspectiveCamera.html
+++ b/docs/api/cameras/PerspectiveCamera.html
@@ -36,7 +36,7 @@ scene.add( camera );</code>
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Number fov], [page:Number aspect], [page:Number near], [page:Number far] )</h3>
+		<h3>[name]( [param:Number fov], [param:Number aspect], [param:Number near], [param:Number far] )</h3>
 		<div>
 		fov — Camera frustum vertical field of view.<br />
 		aspect — Camera frustum aspect ratio.<br />

--- a/docs/api/cameras/PerspectiveCamera.html
+++ b/docs/api/cameras/PerspectiveCamera.html
@@ -50,8 +50,8 @@ scene.add( camera );</code>
 		<h2>Properties</h2>
 		<div>
 			See the base [page:Camera] class for common properties.<br>
-			Note that after making changes to most of these poperties you will have to call 
-			[page:PerspectiveCamera.updateProjectionMatrix .updateProjectionMatrix] for the changes to take effect. 
+			Note that after making changes to most of these poperties you will have to call
+			[page:PerspectiveCamera.updateProjectionMatrix .updateProjectionMatrix] for the changes to take effect.
 		</div>
 
 		<h3>[property:Float aspect]</h3>
@@ -131,14 +131,14 @@ scene.add( camera );</code>
 		<h3>[method:Float getFocalLength]()</h3>
 		<div>Returns the focal length of the current .fov in respect to .filmGauge.</div>
 
-		<h3>[method:null setFocalLength]( [page:Float focalLength] )</h3>
+		<h3>[method:null setFocalLength]( [param:Float focalLength] )</h3>
 		<div>
 		Sets the FOV by focal length in respect to the current [page:PerspectiveCamera.filmGauge .filmGauge].<br /><br />
 
 		By default, the focal length is specified for a 35mm (full frame) camera.
 		</div>
 
-		<h3>[method:null setViewOffset]( [page:Float fullWidth], [page:Float fullHeight], [page:Float x], [page:Float y], [page:Float width], [page:Float height] )</h3>
+		<h3>[method:null setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
 		<div>
 		fullWidth — full width of multiview setup<br />
 		fullHeight — full height of multiview setup<br />

--- a/docs/api/core/BufferAttribute.html
+++ b/docs/api/core/BufferAttribute.html
@@ -21,7 +21,7 @@
 		</div>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:TypedArray array], [page:Integer itemSize], [page:Boolean normalized] )</h3>
+		<h3>[name]( [param:TypedArray array], [param:Integer itemSize], [param:Boolean normalized] )</h3>
 		<div>
 		[page:TypedArray array] -- Must be a [link:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/TypedArray TypedArray].
 		Used to instantiate the buffer. <br />

--- a/docs/api/core/BufferAttribute.html
+++ b/docs/api/core/BufferAttribute.html
@@ -134,7 +134,7 @@
 			for notes on requirements if copying a TypedArray.
 		</div>
 
-		<h3>[method:null copyAt] ( [page:Integer index1], [page:BufferAttribute bufferAttribute], [page:Integer index2] ) </h3>
+		<h3>[method:null copyAt] ( [param:Integer index1], [param:BufferAttribute bufferAttribute], [param:Integer index2] ) </h3>
 		<div>Copy a vector from bufferAttribute[index2] to [page:BufferAttribute.array array][index1].</div>
 
 		<h3>[method:BufferAttribute copyColorsArray]( colors ) </h3>
@@ -164,7 +164,7 @@
 		<h3>[method:Number getW]( index ) </h3>
 		<div>Returns the w component of the vector at the given index.</div>
 
-		<h3>[method:null onUpload]( [page:Function callback] ) </h3>
+		<h3>[method:null onUpload]( [param:Function callback] ) </h3>
 		<div>
 		Sets the value of the onUploadCallback property.<br /><br />
 
@@ -172,7 +172,7 @@
 		after the buffer has been	transfered to the GPU.
 		</div>
 
-		<h3>[method:null set] ( [page:Array value], [page:Integer offset] ) </h3>
+		<h3>[method:null set] ( [param:Array value], [param:Integer offset] ) </h3>
 		<div>
 		value -- an [page:Array] or [page:TypedArray] from which to copy values. <br />
 		offset -- (optional) index of the [page:BufferAttribute.array array] at which to start copying.<br /><br />
@@ -184,14 +184,14 @@
 		being a [page:TypedArray].
 		</div>
 
-		<h3>[method:null setArray] ( [page:TypedArray array] ) </h3>
+		<h3>[method:null setArray] ( [param:TypedArray array] ) </h3>
 		<div>
 		[page:BufferAttribute.array array] to the TypedArray passed in here.<br /><br />
 
 		After setting the array, [page:BufferAttribute.needsUpdate needsUpdate] should be set to true.
 		</div>
 
-		<h3>[method:BufferAttribute setDynamic] ( [page:Boolean value] ) </h3>
+		<h3>[method:BufferAttribute setDynamic] ( [param:Boolean value] ) </h3>
 		<div>Set [page:BufferAttribute.dynamic dynamic] to value.</div>
 
 		<h3>[method:null setX]( index, x ) </h3>

--- a/docs/api/core/BufferGeometry.html
+++ b/docs/api/core/BufferGeometry.html
@@ -99,7 +99,7 @@
 
 		<h2>Properties</h2>
 
-		<h3>[property:Hashmap attributes]</h3>
+		<h3>[property:Object attributes]</h3>
 		<div>
 		This hashmap has as id the name of the attribute to be set and as value the [page:BufferAttribute buffer] to set it to.
 		Rather than accessing this property directly, use [page:.addAttribute] and [page:.getAttribute] to access attributes of this geometry.
@@ -194,21 +194,21 @@
 
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
 
-		<h3>[property:null addAttribute]( [page:String name], [page:BufferAttribute attribute] )</h3>
+		<h3>[method:null addAttribute]( [param:String name], [param:BufferAttribute attribute] )</h3>
 		<div>
 		Adds an attribute to this geometry. Use this rather than the attributes property,
 		because an internal hashmap of [page:.attributes] is maintained to speed up iterating over
 		attributes.
 		</div>
 
-		<h3>[method:null addGroup]( [page:Integer start], [page:Integer count], [page:Integer materialIndex] )</h3>
+		<h3>[method:null addGroup]( [param:Integer start], [param:Integer count], [param:Integer materialIndex] )</h3>
 		<div>
 			Adds a group to this geometry; see the [page:BufferGeometry.groups groups]
 			property for details.
 		</div>
 
 
-		<h3>[method:null applyMatrix]( [page:Matrix4 matrix] )</h3>
+		<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
 		<div>Bakes matrix transform directly into vertex coordinates.</div>
 
 		<h3>[method:null center] ()</h3>
@@ -217,7 +217,7 @@
 		<h3>[method:BufferGeometry clone]()</h3>
 		<div>Creates a clone of this BufferGeometry.</div>
 
-		<h3>[method:BufferGeometry copy]( [page:BufferGeometry bufferGeometry] )</h3>
+		<h3>[method:BufferGeometry copy]( [param:BufferGeometry bufferGeometry] )</h3>
 		<div>Copies another BufferGeometry to this BufferGeometry.</div>
 
 		<h3>[method:null clearGroups]( )</h3>
@@ -225,7 +225,7 @@
 
 		<h3>[method:null computeBoundingBox]()</h3>
 		<div>
-		Computes bounding box of the geometry, updating [page:.boundingBox] attribute.<br />
+		Computes bounding box of the geometry, updating [param:.boundingBox] attribute.<br />
 		Bounding boxes aren't computed by default. They need to be explicitly computed, otherwise they are *null*.
 		</div>
 
@@ -244,7 +244,7 @@
 		You need to call this when you want the bufferGeometry removed while the application is running.
 		</div>
 
-		<h3>[method:BufferGeometry fromDirectGeometry]( [page:Geometry] )</h3>
+		<h3>[method:BufferGeometry fromDirectGeometry]( [param:Geometry] )</h3>
 		<div>
 			Populates this BufferGeometry with data from a [page:DirectGeometry] object.<br /><br />
 
@@ -252,16 +252,16 @@
 			and BufferGeometry.
 		</div>
 
-		<h3>[method:BufferGeometry fromGeometry]( [page:Geometry] )</h3>
+		<h3>[method:BufferGeometry fromGeometry]( [param:Geometry] )</h3>
 		<div>Populates this BufferGeometry with data from a [page:Geometry] object.</div>
 
-		<h3>[method:BufferAttribute getAttribute]( [page:String name] )</h3>
+		<h3>[method:BufferAttribute getAttribute]( [param:String name] )</h3>
 		<div>Returns the [page:BufferAttribute attribute] with the specified name.</div>
 
 		<h3>[method:BufferAttribute getIndex] ()</h3>
 		<div>Return the [page:.index] buffer.</div>
 
-		<h3>[method:BufferGeometry lookAt] ( [page:Vector3 vector] )</h3>
+		<h3>[method:BufferGeometry lookAt] ( [param:Vector3 vector] )</h3>
 		<div>
 		vector - A world vector to look at.<br /><br />
 
@@ -269,7 +269,7 @@
 		Use [page:Object3D.lookAt] for typical real-time mesh usage.
 		</div>
 
-		<h3>[method:null merge]( [page:BufferGeometry bufferGeometry], [page:Integer offset] )</h3>
+		<h3>[method:null merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
 		<div>Merge in another BufferGeometry with an optional offset of where to start merging in.</div>
 
 		<h3>[method:null normalizeNormals]()</h3>
@@ -278,43 +278,43 @@
 		This will correct lighting on the geometry surfaces.
 		</div>
 
-		<h3>[method:BufferAttribute removeAttribute]( [page:String name] )</h3>
+		<h3>[method:BufferAttribute removeAttribute]( [param:String name] )</h3>
 		<div>Removes the [page:BufferAttribute attribute] with the specified name.</div>
 
-		<h3>[method:BufferGeometry rotateX] ( [page:Float radians] )</h3>
+		<h3>[method:BufferGeometry rotateX] ( [param:Float radians] )</h3>
 		<div>
 		Rotate the geometry about the X axis. This is typically done as a one time operation, and not during a loop.
     Use [page:Object3D.rotation] for typical real-time mesh rotation.
 		</div>
 
-		<h3>[method:BufferGeometry rotateY] ( [page:Float radians] )</h3>
+		<h3>[method:BufferGeometry rotateY] ( [param:Float radians] )</h3>
 		<div>
 		Rotate the geometry about the Y axis. This is typically done as a one time operation, and not during a loop.
     Use [page:Object3D.rotation] for typical real-time mesh rotation.
 		</div>
 
-		<h3>[method:BufferGeometry rotateZ] ( [page:Float radians] )</h3>
+		<h3>[method:BufferGeometry rotateZ] ( [param:Float radians] )</h3>
 		<div>
 		Rotate the geometry about the Z axis. This is typically done as a one time operation, and not during a loop.
     Use [page:Object3D.rotation] for typical real-time mesh rotation.
 		</div>
 
-		<h3>[method:BufferGeometry scale] ( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[method:BufferGeometry scale] ( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>
 		Scale the geometry data. This is typically done as a one time operation, and not during a loop.
 		Use [page:Object3D.scale] for typical real-time mesh scaling.
 		</div>
 
-		<h3>[method:null setIndex] ( [page:BufferAttribute index] )</h3>
+		<h3>[method:null setIndex] ( [param:BufferAttribute index] )</h3>
 		<div>Set the [page:.index] buffer.</div>
 
-		<h3>[method:null setDrawRange] ( [page:Integer start], [page:Integer count] )</h3>
+		<h3>[method:null setDrawRange] ( [param:Integer start], [param:Integer count] )</h3>
 		<div>Set the [page:.drawRange] buffer. See that property for details.</div>
 
-		<h3>[method:BufferGeometry setFromObject] ( [page:Object3D object] )</h3>
+		<h3>[method:BufferGeometry setFromObject] ( [param:Object3D object] )</h3>
 		<div>Sets the attributes for this BufferGeometry from an [page:Object3D].</div>
 
-		<h3>[method:BufferGeometry setFromPoints] ( [page:Array points] )</h3>
+		<h3>[method:BufferGeometry setFromPoints] ( [param:Array points] )</h3>
 		<div>Sets the attributes for this BufferGeometry from an array of points.</div>
 
 		<h3>[method:Object toJSON]()</h3>
@@ -323,13 +323,13 @@
 		<h3>[method:BufferGeometry toNonIndexed]()</h3>
 		<div>Return a non-index version of an indexed BufferGeometry.</div>
 
-		<h3>[method:BufferGeometry translate] ( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[method:BufferGeometry translate] ( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>
 		Translate the geometry. This is typically done as a one time operation, and not during a loop.
     Use [page:Object3D.position] for typical real-time mesh translation.
 		</div>
 
-		<h3>[method:BufferGeometry updateFromObject] ( [page:Object3D object] )</h3>
+		<h3>[method:BufferGeometry updateFromObject] ( [param:Object3D object] )</h3>
 		<div>Updates the attributes for this BufferGeometry from an [page:Object3D].</div>
 
 

--- a/docs/api/core/Clock.html
+++ b/docs/api/core/Clock.html
@@ -19,7 +19,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Boolean autoStart] )</h3>
+		<h3>[name]( [param:Boolean autoStart] )</h3>
 		<div>
 		autoStart — (optional) whether to automatically start the clock. Default is true.
 		</div>

--- a/docs/api/core/EventDispatcher.html
+++ b/docs/api/core/EventDispatcher.html
@@ -57,7 +57,7 @@ car.start();
 
 		<h2>Methods</h2>
 
-		<h3>[method:null addEventListener]( [page:String type], [page:Function listener] )</h3>
+		<h3>[method:null addEventListener]( [param:String type], [param:Function listener] )</h3>
 		<div>
 		type - The type of event to listen to.<br />
 		listener - The function that gets called when the event is fired.
@@ -66,7 +66,7 @@ car.start();
 		Adds a listener to an event type.
 		</div>
 
-		<h3>[method:Boolean hasEventListener]( [page:String type], [page:Function listener] )</h3>
+		<h3>[method:Boolean hasEventListener]( [param:String type], [param:Function listener] )</h3>
 		<div>
 		type - The type of event to listen to.<br />
 		listener - The function that gets called when the event is fired.
@@ -75,7 +75,7 @@ car.start();
 		Checks if listener is added to an event type.
 		</div>
 
-		<h3>[method:null removeEventListener]( [page:String type], [page:Function listener] )</h3>
+		<h3>[method:null removeEventListener]( [param:String type], [param:Function listener] )</h3>
 		<div>
 		type - The type of the listener that gets removed.<br />
 		listener - The listener function that gets removed.
@@ -84,7 +84,7 @@ car.start();
 		Removes a listener from an event type.
 		</div>
 
-		<h3>[method:null dispatchEvent]( [page:object event] )</h3>
+		<h3>[method:null dispatchEvent]( [param:object event] )</h3>
 		<div>
 		event - The event that gets fired.
 		</div>

--- a/docs/api/core/Face3.html
+++ b/docs/api/core/Face3.html
@@ -53,7 +53,7 @@ scene.add( new THREE.Mesh( geometry, material ) );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Integer a], [page:Integer b], [page:Integer c], [page:Vector3 normal], [page:Color color], [page:Integer materialIndex] )</h3>
+		<h3>[name]( [param:Integer a], [param:Integer b], [param:Integer c], [param:Vector3 normal], [param:Color color], [param:Integer materialIndex] )</h3>
 		<div>
 		a — Vertex A index.<br />
 		b — Vertex B index.<br />

--- a/docs/api/core/Face3.html
+++ b/docs/api/core/Face3.html
@@ -123,7 +123,7 @@ scene.add( new THREE.Mesh( geometry, material ) );
 		<h3>[method:Face3 clone]()</h3>
 		<div>Creates a new clone of the Face3 object.</div>
 
-		<h3>[method:Face3 copy]( [page:Face3 face3] )</h3>
+		<h3>[method:Face3 copy]( [param:Face3 face3] )</h3>
 		<div>Copy the paramaters of another Face3 into this.</div>
 
 

--- a/docs/api/core/Geometry.html
+++ b/docs/api/core/Geometry.html
@@ -211,7 +211,7 @@
 
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
 
-		<h3>[method:null applyMatrix]( [page:Matrix4 matrix] )</h3>
+		<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
 		<div>Bakes matrix transform directly into vertex coordinates.</div>
 
 		<h3>[method:null center] ()</h3>
@@ -244,7 +244,7 @@
 		<h3>[method:null computeMorphNormals]()</h3>
 		<div>Computes [page:.morphNormals].</div>
 
-		<h3>[method:null computeVertexNormals]( [page:Boolean areaWeighted] )</h3>
+		<h3>[method:null computeVertexNormals]( [param:Boolean areaWeighted] )</h3>
 		<div>
 		areaWeighted - If true the contribution of each face normal to the vertex normal is
 		weighted by the area of the face. Default is true.<br /><br />
@@ -252,7 +252,7 @@
 		Computes vertex normals by averaging face normals.
 		</div>
 
-		<h3>[method:Geometry copy]( [page:Geometry geometry] )</h3>
+		<h3>[method:Geometry copy]( [param:Geometry geometry] )</h3>
 		<div>
 			Copies vertices, faces and uvs into this geometry. It does not copy any other properties of the geometry.
 		</div>
@@ -263,10 +263,10 @@
 		Don't forget to call this method when you remove a geometry because it can cause memory leaks.
 		</div>
 
-		<h3>[method:Geometry fromBufferGeometry]( [page:BufferGeometry geometry] )</h3>
+		<h3>[method:Geometry fromBufferGeometry]( [param:BufferGeometry geometry] )</h3>
 		<div>Convert a [page:BufferGeometry] to a Geometry.</div>
 
-		<h3>[method:Geometry lookAt] ( [page:Vector3 vector] )</h3>
+		<h3>[method:Geometry lookAt] ( [param:Vector3 vector] )</h3>
 		<div>
 		vector - A world vector to look at.<br /><br />
 
@@ -274,10 +274,10 @@
 		Use [page:Object3D.lookAt] for typical real-time mesh usage.
 		</div>
 
-		<h3>[method:null merge]( [page:Geometry geometry], [page:Matrix4 matrix], [page:Integer materialIndexOffset] )</h3>
+		<h3>[method:null merge]( [param:Geometry geometry], [param:Matrix4 matrix], [param:Integer materialIndexOffset] )</h3>
 		<div>Merge two geometries or geometry and geometry from object (using object's transform)</div>
 
-		<h3>[method:null mergeMesh]( [page:Mesh mesh] )</h3>
+		<h3>[method:null mergeMesh]( [param:Mesh mesh] )</h3>
 		<div>Merge the mesh's geometry with this, also applying the mesh's transform.</div>
 
 
@@ -293,25 +293,25 @@
 		Make the geometry centered and have a bounding sphere of radius *1.0*.
 		</div>
 
-		<h3>[method:Geometry rotateX] ( [page:Float radians] )</h3>
+		<h3>[method:Geometry rotateX] ( [param:Float radians] )</h3>
 		<div>
 		Rotate the geometry about the X axis. This is typically done as a one time operation but not during the render loop.<br>
 		Use [page:Object3D.rotation] for typical real-time mesh rotation.
 		</div>
 
-		<h3>[method:Geometry rotateY] ( [page:Float radians] )</h3>
+		<h3>[method:Geometry rotateY] ( [param:Float radians] )</h3>
 		<div>
 		Rotate the geometry about the Y axis. This is typically done as a one time operation but not during the render loop.<br>
     	        Use [page:Object3D.rotation] for typical real-time mesh rotation.
 		</div>
 
-		<h3>[method:Geometry rotateZ] ( [page:Float radians] )</h3>
+		<h3>[method:Geometry rotateZ] ( [param:Float radians] )</h3>
 		<div>
 		Rotate the geometry about the Z axis. This is typically done as a one time operation but not during the render loop.<br>
 	        Use [page:Object3D.rotation] for typical real-time mesh rotation.
 		</div>
 
-		<h3>[method:Geometry setFromPoints] ( [page:Array points] )</h3>
+		<h3>[method:Geometry setFromPoints] ( [param:Array points] )</h3>
 		<div>Sets the vertices for this Geometry from an array of points.</div>
 
 		<h3>[method:null sortFacesByMaterialIndex] (  )</h3>
@@ -320,7 +320,7 @@
 		this can result in reduced draw calls and improved performance.
 		</div>
 
-		<h3>[method:Geometry scale] ( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[method:Geometry scale] ( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>
 		Scale the geometry data. This is typically done as a one time operation but not during the render loop.<br>
 		Use [page:Object3D.scale] for typical real-time mesh scaling.
@@ -329,7 +329,7 @@
 		<h3>[method:JSON toJSON] ( )</h3>
 		<div>Convert the geometry to JSON format.</div>
 
-		<h3>[method:Geometry translate] ( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[method:Geometry translate] ( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>
 		Translate the geometry. This is typically done as a one time operation but not during the render loop.<br>
     	        Use [page:Object3D.position] for typical real-time mesh translation.

--- a/docs/api/core/InstancedBufferAttribute.html
+++ b/docs/api/core/InstancedBufferAttribute.html
@@ -17,7 +17,7 @@
 		</div>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:TypedArray array], [page:Integer itemSize], [page:Number meshPerAttribute] )</h3>
+		<h3>[name]( [param:TypedArray array], [param:Integer itemSize], [param:Number meshPerAttribute] )</h3>
 		<div>
 		</div>
 

--- a/docs/api/core/InstancedInterleavedBuffer.html
+++ b/docs/api/core/InstancedInterleavedBuffer.html
@@ -17,7 +17,7 @@
 		</div>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:TypedArray array], [page:Integer itemSize], [page:Number meshPerAttribute] )</h3>
+		<h3>[name]( [param:TypedArray array], [param:Integer itemSize], [param:Number meshPerAttribute] )</h3>
 		<div>
 		</div>
 

--- a/docs/api/core/InterleavedBuffer.html
+++ b/docs/api/core/InterleavedBuffer.html
@@ -21,7 +21,7 @@
 		<div>[example:webgl_buffergeometry_points_interleaved webgl / buffergeometry / points / interleaved]</div>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:TypedArray array], [page:Integer stride] )</h3>
+		<h3>[name]( [param:TypedArray array], [param:Integer stride] )</h3>
 		<div>
 			[page:TypedArray array] -- A typed array with a shared buffer. Stores the geometry data.<br/>
 			[page:Integer stride] -- The number of typed-array elements per vertex.

--- a/docs/api/core/InterleavedBuffer.html
+++ b/docs/api/core/InterleavedBuffer.html
@@ -81,12 +81,12 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setArray] ( [page:TypedArray array] ) </h3>
+		<h3>[method:null setArray] ( [param:TypedArray array] ) </h3>
 		<div>
 		 array - must be  a Typed Array.
 		</div>
 
-		<h3>[method:InterleavedBuffer setDynamic] ( [page:Boolean value] ) </h3>
+		<h3>[method:InterleavedBuffer setDynamic] ( [param:Boolean value] ) </h3>
 		<div>
 			Set [page:InterleavedBuffer.dynamic dynamic] to value.
 		</div>

--- a/docs/api/core/InterleavedBufferAttribute.html
+++ b/docs/api/core/InterleavedBufferAttribute.html
@@ -16,7 +16,7 @@
 		</div>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:InterleavedBuffer interleavedBuffer], [page:Integer itemSize], [page:Integer offset], [page:Boolean normalized] )</h3>
+		<h3>[name]( [param:InterleavedBuffer interleavedBuffer], [param:Integer itemSize], [param:Integer offset], [param:Boolean normalized] )</h3>
 		<div>
 		</div>
 

--- a/docs/api/core/Layers.html
+++ b/docs/api/core/Layers.html
@@ -40,35 +40,35 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null disable]( [page:Integer layer] )</h3>
+		<h3>[method:null disable]( [param:Integer layer] )</h3>
 		<div>
 			layer - an integer from 0 to 31.<br /><br />
 
 			Remove membership of this *layer*.
 		</div>
 
-		<h3>[method:null enable]( [page:Integer layer] )</h3>
+		<h3>[method:null enable]( [param:Integer layer] )</h3>
 		<div>
 			layer - an integer from 0 to 31.<br /><br />
 
 			Add membership of this *layer*.
 		</div>
 
-		<h3>[method:null set]( [page:Integer layer] )</h3>
+		<h3>[method:null set]( [param:Integer layer] )</h3>
 		<div>
 			layer - an integer from 0 to 31.<br /><br />
 
 			Set membership to *layer*, and remove membership all other layers.
 		</div>
 
-		<h3>[method:Boolean test]( [page:Integer layers] )</h3>
+		<h3>[method:Boolean test]( [param:Integer layers] )</h3>
 		<div>
 			layers - a Layers object<br /><br />
 
 			Returns true if this and the passed *layers* object are members of the same set of layers.
 		</div>
 
-		<h3>[method:null toggle]( [page:Integer layer] )</h3>
+		<h3>[method:null toggle]( [param:Integer layer] )</h3>
 		<div>
 			layer - an integer from 0 to 31.<br /><br />
 

--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -188,34 +188,34 @@
 
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
 
-		<h3>[method:null add]( [page:Object3D object], ... )</h3>
+		<h3>[method:null add]( [param:Object3D object], ... )</h3>
 		<div>
 		Adds *object* as child of this object. An arbitrary number of objects may be added.<br /><br />
 
 		See [page:Group] for info on manually grouping objects.
 		</div>
 
-		<h3>[method:null applyMatrix]( [page:Matrix4 matrix] )</h3>
+		<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
 		<div>Applies the matrix transform to the object and updates the object's position, rotation and scale.</div>
 
-		<h3>[method:Object3D applyQuaternion]( [page:Quaternion quaternion] )</h3>
+		<h3>[method:Object3D applyQuaternion]( [param:Quaternion quaternion] )</h3>
 		<div>Applies the rotation represented by the quaternion to the object.</div>
 
-		<h3>[method:Object3D clone]( [page:Boolean recursive] )</h3>
+		<h3>[method:Object3D clone]( [param:Boolean recursive] )</h3>
 		<div>
 		recursive -- if true, descendants of the object are also cloned. Default is true.<br /><br />
 
 		Returns a clone of this object and optionally all descendants.
 		</div>
 
-		<h3>[method:Object3D copy]( [page:Object3D object], [page:Boolean recursive] )</h3>
+		<h3>[method:Object3D copy]( [param:Object3D object], [param:Boolean recursive] )</h3>
 		<div>
 		recursive -- if true, descendants of the object are also copied. Default is true.<br /><br />
 
 		Copy the given object into this object.
 		</div>
 
-		<h3>[method:Object3D getObjectById]( [page:Integer id] )</h3>
+		<h3>[method:Object3D getObjectById]( [param:Integer id] )</h3>
 		<div>
 		id -- Unique number of the object instance<br /><br />
 
@@ -223,7 +223,7 @@
 		Note that ids are assigned in chronological order: 1, 2, 3, ..., incrementing by one for each new object.
 		</div>
 
-		<h3>[method:Object3D getObjectByName]( [page:String name] )</h3>
+		<h3>[method:Object3D getObjectByName]( [param:String name] )</h3>
 		<div>
 		name -- String to match to the children's Object3D.name property. <br /><br />
 
@@ -232,7 +232,7 @@
 		have to set it manually to make use of this method.
 		</div>
 
-		<h3>[method:Object3D getObjectByProperty]( [page:String name], [page:Float value] )</h3>
+		<h3>[method:Object3D getObjectByProperty]( [param:String name], [param:Float value] )</h3>
 		<div>
 		name -- the property name to search for. <br />
 		value -- value of the given property. <br /><br />
@@ -240,14 +240,14 @@
 		Searches through the object's children and returns the first with a property that matches the value given.
 		</div>
 
-		<h3>[method:Vector3 getWorldPosition]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 getWorldPosition]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 		optionalTarget — (optional) target to set the result. Otherwise, a new [page:Vector3] is instantiated. <br /><br />
 
 		Returns a vector representing the position of the object in world space.
 		</div>
 
-		<h3>[method:Quaternion getWorldQuaternion]( [page:Quaternion optionalTarget] )</h3>
+		<h3>[method:Quaternion getWorldQuaternion]( [param:Quaternion optionalTarget] )</h3>
 		<div>
 		optionalTarget — (optional) if specified, the result will be copied into this Quaternion,
 		otherwise a new Quaternion will be created. <br /><br />
@@ -255,7 +255,7 @@
 		Returns a quaternion representing the rotation of the object in world space.
 		</div>
 
-		<h3>[method:Euler getWorldRotation]( [page:Euler optionalTarget] )</h3>
+		<h3>[method:Euler getWorldRotation]( [param:Euler optionalTarget] )</h3>
 		<div>
 		optionalTarget — (optional) if specified, the result will be copied into this Euler,
 		otherwise a new Euler will be created. <br /><br />
@@ -263,7 +263,7 @@
 		Returns the euler angles representing the rotation of the object in world space.
 		</div>
 
-		<h3>[method:Vector3 getWorldScale]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 getWorldScale]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
 		otherwise a new Vector3 will be created. <br /><br />
@@ -271,7 +271,7 @@
 		Returns a vector of the scaling factors applied to the object for each axis in world space.
 		</div>
 
-		<h3>[method:Vector3 getWorldDirection]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 getWorldDirection]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
 		otherwise a new Vector3 will be created. <br /><br />
@@ -280,15 +280,15 @@
 		</div>
 
 
-		<h3>[method:Vector3 localToWorld]( [page:Vector3 vector] )</h3>
+		<h3>[method:Vector3 localToWorld]( [param:Vector3 vector] )</h3>
 		<div>
 		vector - A vector representing a position in local (object) space.<br /><br />
 
 		Converts the vector from local space to world space.
 		</div>
 
-		<h3>[method:null lookAt]( [page:Vector3 vector] )</br>
-		[method:null lookAt]( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[method:null lookAt]( [param:Vector3 vector] )</br>
+		[method:null lookAt]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>
 		vector - A vector representing a position in world space.<br /><br />
 		Optionally, the [page:.x x], [page:.y y] and [page:.z z] components of the world space position.<br /><br />
@@ -300,19 +300,19 @@
 
 		</div>
 
-		<h3>[method:Array raycast]( [page:Raycaster raycaster], [page:Array intersects] )</h3>
+		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<div>
 		Abstract (empty) method to get intersections between a casted ray and this object.
 		Subclasses such as [page:Mesh], [page:Line], and [page:Points] implement this method in order
 		to use raycasting.
 		</div>
 
-		<h3>[method:null remove]( [page:Object3D object], ... )</h3>
+		<h3>[method:null remove]( [param:Object3D object], ... )</h3>
 		<div>
 		Removes *object* as child of this object. An arbitrary number of objects may be removed.
 		</div>
 
-		<h3>[method:Object3D rotateOnAxis]( [page:Vector3 axis], [page:Float angle] )</h3>
+		<h3>[method:Object3D rotateOnAxis]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<div>
 		axis -- A normalized vector in object space. <br />
 		angle -- The angle in radians.<br /><br />
@@ -320,7 +320,7 @@
 		Rotate an object along an axis in object space. The axis is assumed to be normalized.
 		</div>
 
-		<h3>[method:Object3D rotateOnWorldAxis]( [page:Vector3 axis], [page:Float angle] )</h3>
+		<h3>[method:Object3D rotateOnWorldAxis]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<div>
 		axis -- A normalized vector in world space. <br />
 		angle -- The angle in radians.<br /><br />
@@ -329,28 +329,28 @@
 		Method Assumes no rotated parent.
 		</div>
 
-		<h3>[method:null rotateX]( [page:Float rad] )</h3>
+		<h3>[method:null rotateX]( [param:Float rad] )</h3>
 		<div>
 		rad - the angle to rotate in radians.<br /><br />
 
 		Rotates the object around x axis in local space.
 		</div>
 
-		<h3>[method:null rotateY]( [page:Float rad] )</h3>
+		<h3>[method:null rotateY]( [param:Float rad] )</h3>
 		<div>
 		rad - the angle to rotate in radians.<br /><br />
 
 		Rotates the object around y axis in local space.
 		</div>
 
-		<h3>[method:null rotateZ]( [page:Float rad] )</h3>
+		<h3>[method:null rotateZ]( [param:Float rad] )</h3>
 		<div>
 		rad - the angle to rotate in radians.<br /><br />
 
 		Rotates the object around z axis in local space.
 		</div>
 
-		<h3>[method:null setRotationFromAxisAngle]( [page:Vector3 axis], [page:Float angle] )</h3>
+		<h3>[method:null setRotationFromAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<div>
 			axis -- A normalized vector in object space. <br />
 			angle -- angle in radians<br /><br />
@@ -359,7 +359,7 @@
 			on the [page:.quaternion].
 		</div>
 
-		<h3>[method:null setRotationFromEuler]( [page:Euler euler] )</h3>
+		<h3>[method:null setRotationFromEuler]( [param:Euler euler] )</h3>
 		<div>
 			euler -- Euler angle specifying rotation amount.<br />
 
@@ -367,7 +367,7 @@
 			on the [page:.quaternion].
 		</div>
 
-		<h3>[method:null setRotationFromMatrix]( [page:Matrix4 m] )</h3>
+		<h3>[method:null setRotationFromMatrix]( [param:Matrix4 m] )</h3>
 		<div>
 			m -- rotate the quaternion by the rotation component of the matrix.<br />
 
@@ -377,19 +377,19 @@
 			Note that this assumes that the upper 3x3 of m is a pure rotation matrix (i.e, unscaled).
 		</div>
 
-		<h3>[method:null setRotationFromQuaternion]( [page:Quaternion q] )</h3>
+		<h3>[method:null setRotationFromQuaternion]( [param:Quaternion q] )</h3>
 		<div>
 			q -- normalized Quaternion.<br /><br />
 
 			Copy the given quaternion into [page:.quaternion].
 		</div>
 
-		<h3>[method:null toJSON]( [page:Quaternion q] )</h3>
+		<h3>[method:null toJSON]( [param:Quaternion q] )</h3>
 		<div>
 			Convert the object to JSON format.
 		</div>
 
-		<h3>[method:Object3D translateOnAxis]( [page:Vector3 axis], [page:Float distance] )</h3>
+		<h3>[method:Object3D translateOnAxis]( [param:Vector3 axis], [param:Float distance] )</h3>
 		<div>
 		axis -- A normalized vector in object space.<br />
 		distance -- The distance to translate.<br /><br />
@@ -397,23 +397,23 @@
 		Translate an object by distance along an axis in object space. The axis is assumed to be normalized.
 		</div>
 
-		<h3>[method:null translateX]( [page:Float distance] )</h3>
+		<h3>[method:null translateX]( [param:Float distance] )</h3>
 		<div>Translates object along x axis by *distance* units.</div>
 
-		<h3>[method:null translateY]( [page:Float distance] )</h3>
+		<h3>[method:null translateY]( [param:Float distance] )</h3>
 		<div>Translates object along y axis by *distance* units.</div>
 
-		<h3>[method:null translateZ]( [page:Float distance] )</h3>
+		<h3>[method:null translateZ]( [param:Float distance] )</h3>
 		<div>Translates object along z axis by *distance* units.</div>
 
-		<h3>[method:null traverse]( [page:Function callback] )</h3>
+		<h3>[method:null traverse]( [param:Function callback] )</h3>
 		<div>
 		callback - A function with as first argument an object3D object.<br /><br />
 
 		Executes the callback on this object and all descendants.
 		</div>
 
-		<h3>[method:null traverseVisible]( [page:Function callback] )</h3>
+		<h3>[method:null traverseVisible]( [param:Function callback] )</h3>
 		<div>
 		callback - A function with as first argument an object3D object.<br /><br />
 
@@ -421,7 +421,7 @@
 		Descendants of invisible objects are not traversed.
 		</div>
 
-		<h3>[method:null traverseAncestors]( [page:Function callback] )</h3>
+		<h3>[method:null traverseAncestors]( [param:Function callback] )</h3>
 		<div>
 		callback - A function with as first argument an object3D object.<br /><br />
 
@@ -431,11 +431,11 @@
 		<h3>[method:null updateMatrix]()</h3>
 		<div>Update the local transform.</div>
 
-		<h3>[method:null updateMatrixWorld]( [page:Boolean force] )</h3>
+		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
 		<div>Update the global transform of the object and its children.</div>
 
 
-		<h3>[method:Vector3 worldToLocal]( [page:Vector3 vector] )</h3>
+		<h3>[method:Vector3 worldToLocal]( [param:Vector3 vector] )</h3>
 		<div>
 		vector - A world vector.<br /><br />
 

--- a/docs/api/core/Raycaster.html
+++ b/docs/api/core/Raycaster.html
@@ -73,7 +73,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Vector3 origin], [page:Vector3 direction], [page:Float near], [page:Float far] ) {</h3>
+		<h3>[name]( [param:Vector3 origin], [param:Vector3 direction], [param:Float near], [param:Float far] ) {</h3>
 		<div>
 		[page:Vector3 origin] — The origin vector where the ray casts from.<br />
 		[page:Vector3 direction] — The direction vector that gives direction to the ray. Should be normalized.<br />

--- a/docs/api/core/Raycaster.html
+++ b/docs/api/core/Raycaster.html
@@ -126,7 +126,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null set]( [page:Vector3 origin], [page:Vector3 direction] )</h3>
+		<h3>[method:null set]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
 		<div>
 		[page:Vector3 origin] — The origin vector where the ray casts from.<br />
 		[page:Vector3 direction] — The normalized direction vector that gives direction to the ray.
@@ -135,7 +135,7 @@
 		Updates the ray with a new origin and direction.
 		</div>
 
-		<h3>[method:null setFromCamera]( [page:Vector2 coords], [page:Camera camera] )</h3>
+		<h3>[method:null setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>
 		<div>
 		[page:Vector2 coords] — 2D coordinates of the mouse, in normalized device coordinates (NDC)---X and Y components should be between -1 and 1.<br />
 		[page:Camera camera] — camera from which the ray should originate
@@ -145,7 +145,7 @@
 		</div>
 
 
-		<h3>[method:Array intersectObject]( [page:Object3D object], [page:Boolean recursive] )</h3>
+		<h3>[method:Array intersectObject]( [param:Object3D object], [param:Boolean recursive] )</h3>
 		<div>
 		<p>
 		[page:Object3D object] — The object to check for intersection with the ray.<br />
@@ -177,7 +177,7 @@
 		</p>
 		</div>
 
-		<h3>[method:Array intersectObjects]( [page:Array objects], [page:Boolean recursive] )</h3>
+		<h3>[method:Array intersectObjects]( [param:Array objects], [param:Boolean recursive] )</h3>
 		<div>
 		[page:Array objects] — The objects to check for intersection with the ray.<br />
 		[page:Boolean recursive] — If true, it also checks all descendants of the objects. Otherwise it only checks intersecton with the objects. Default is false.

--- a/docs/api/core/Uniform.html
+++ b/docs/api/core/Uniform.html
@@ -177,14 +177,14 @@
 
 			</tbody>
 		</table>
-		
+
 		<p>
 		(*) Same for an (innermost) array (dimension) of the same GLSL type, containing the components of all vectors or matrices in the array.
 		</p>
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object value] )</h3>
+		<h3>[name]( [param:Object value] )</h3>
 		<div>
 		value -- An object containing the value to set up the uniform. It's type must be one of the Uniform Types described above.
 		</div>

--- a/docs/api/extras/core/Curve.html
+++ b/docs/api/extras/core/Curve.html
@@ -31,7 +31,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector getPoint]( [page:Float t], [page:Vector optionalTarget] )</h3>
+		<h3>[method:Vector getPoint]( [param:Float t], [param:Vector optionalTarget] )</h3>
 		<div>
 			[page:Float t] - A position on the curve. Must be in the range [ 0, 1 ]. <br>
 			[page:Vector optionalTarget] — (optional) If specified, the result will be copied into this Vector,
@@ -40,7 +40,7 @@
 			Returns a vector for a given position on the curve.
 		</div>
 
-		<h3>[method:Vector getPointAt]( [page:Float u], [page:Vector optionalTarget] )</h3>
+		<h3>[method:Vector getPointAt]( [param:Float u], [param:Vector optionalTarget] )</h3>
 		<div>
 			[page:Float u] - A position on the curve according to the arc length. Must be in the range [ 0, 1 ]. <br>
 			[page:Vector optionalTarget] — (optional) If specified, the result will be copied into this Vector,
@@ -49,14 +49,14 @@
 			Returns a vector for a given position on the curve according to the arc length.
 		</div>
 
-		<h3>[method:Array getPoints]( [page:Integer divisions] )</h3>
+		<h3>[method:Array getPoints]( [param:Integer divisions] )</h3>
 		<div>
 			divisions -- number of pieces to divide the curve into. Default is *5*.<br /><br />
 
 			Returns a set of divisions + 1 points using getPoint( t ).
 		</div>
 
-		<h3>[method:Array getSpacedPoints]( [page:Integer divisions] )</h3>
+		<h3>[method:Array getSpacedPoints]( [param:Integer divisions] )</h3>
 		<div>
 			divisions -- number of pieces to divide the curve into. Default is *5*.<br /><br />
 
@@ -66,33 +66,33 @@
 		<h3>[method:Float getLength]()</h3>
 		<div>Get total curve arc length.</div>
 
-		<h3>[method:Array getLengths]( [page:Integer divisions] )</h3>
+		<h3>[method:Array getLengths]( [param:Integer divisions] )</h3>
 		<div>Get list of cumulative segment lengths.</div>
 
 		<h3>[method:null updateArcLengths]()</h3>
 		<div>Update the cumlative segment distance cache.</div>
 
-		<h3>[method:Float getUtoTmapping]( [page:Float u], [page:Float distance] )</h3>
+		<h3>[method:Float getUtoTmapping]( [param:Float u], [param:Float distance] )</h3>
 		<div>
 			Given u in the range ( 0 .. 1 ), returns [page:Float t] also in the range ( 0 .. 1 ).
 			u and t can then be used to give you points which are equidistant from the ends of the curve,
 			using [page:.getPoint].
 		 </div>
 
-		<h3>[method:Vector getTangent]( [page:Float t] )</h3>
+		<h3>[method:Vector getTangent]( [param:Float t] )</h3>
 		<div>
 			Returns a unit vector tangent at t. If the derived curve does not implement its
 			tangent derivation, two points a small delta apart will be used to find its gradient
 			which seems to give a reasonable approximation.
 		</div>
 
-		<h3>[method:Vector getTangentAt]( [page:Float u] )</h3>
+		<h3>[method:Vector getTangentAt]( [param:Float u] )</h3>
 		<div>
 			Returns tangent at a point which is equidistant to the ends of the curve from the
 			point given in [page:.getTangent].
 		</div>
 
-		<h3>[method:Object computeFrenetFrames]( [page:Integer segments], [page:Boolean closed] )</h3>
+		<h3>[method:Object computeFrenetFrames]( [param:Integer segments], [param:Boolean closed] )</h3>
 		<div>
 		Generates the Frenet Frames. Used in geometries like [page:TubeGeometry] or [page:ExtrudeGeometry].
 		</div>
@@ -100,13 +100,13 @@
 		<h3>[method:Curve clone]()</h3>
 		<div>Creates a clone of this instance.</div>
 
-		<h3>[method:Curve copy]( [page:Curve source] )</h3>
+		<h3>[method:Curve copy]( [param:Curve source] )</h3>
 		<div>Copies another [name] object to this instance.</div>
 
 		<h3>[method:Object toJSON]()</h3>
 		<div>Returns a JSON object representation of this instance.</div>
 
-		<h3>[method:Curve fromJSON]( [page:Object json] )</h3>
+		<h3>[method:Curve fromJSON]( [param:Object json] )</h3>
 		<div>Copies the data from the given JSON object to this instance.</div>
 
 		<h2>Source</h2>

--- a/docs/api/extras/core/CurvePath.html
+++ b/docs/api/extras/core/CurvePath.html
@@ -43,7 +43,7 @@
 		<h2>Methods</h2>
 		<div>See the base [page:Curve] class for common methods.</div>
 
-		<h3>[method:null add]( [page:Curve curve] )</h3>
+		<h3>[method:null add]( [param:Curve curve] )</h3>
 		<div>Add a curve to the [page:.curves] array.</div>
 
 		<h3>[method:null closePath]()</h3>

--- a/docs/api/extras/core/Font.html
+++ b/docs/api/extras/core/Font.html
@@ -46,7 +46,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null generateShapes]( [page:String text], [page:Float size], [page:Integer divisions] )</h3>
+		<h3>[method:null generateShapes]( [param:String text], [param:Float size], [param:Integer divisions] )</h3>
 		<div>
 			[page:String text] -- string of text.<br />
 			[page:Float size] -- (optional) scale for the [page:Shape Shapes]. Default is *100*.<br />

--- a/docs/api/extras/core/Interpolations.html
+++ b/docs/api/extras/core/Interpolations.html
@@ -16,7 +16,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Float CatmullRom]( [page:Float t], [page:Float p0], [page:Float p1], [page:Float p2], [page:Float p3] )</h3>
+		<h3>[method:Float CatmullRom]( [param:Float t], [param:Float p0], [param:Float p1], [param:Float p2], [param:Float p3] )</h3>
 		<div>
 		t -- interpolation weight.<br />
 		p0, p1, p2, p3 -- the points defining the spline curve.<br /><br />
@@ -24,7 +24,7 @@
 		Used internally by [page:SplineCurve SplineCurve].
 		</div>
 
-		<h3>[method:Float QuadraticBezier]( [page:Float t], [page:Float p0], [page:Float p1], [page:Float p2] )</h3>
+		<h3>[method:Float QuadraticBezier]( [param:Float t], [param:Float p0], [param:Float p1], [param:Float p2] )</h3>
 		<div>
 		t -- interpolation weight.<br />
 		p0, p1, p2 -- the starting, control and end points defining the curve.<br /><br />
@@ -32,7 +32,7 @@
 		Used internally by [page:QuadraticBezierCurve3 QuadraticBezierCurve3], [page:QuadraticBezierCurve QuadraticBezierCurve] and [page:Font Font].
 		</div>
 
-		<h3>[method:Float CubicBezier]( [page:Float t], [page:Float p0], [page:Float p1], [page:Float p2], [page:Float p3] )</h3>
+		<h3>[method:Float CubicBezier]( [param:Float t], [param:Float p0], [param:Float p1], [param:Float p2], [param:Float p3] )</h3>
 		<div>
 		t -- interpolation weight.<br />
 		p0, p1, p2, p3 -- the starting, control(twice) and end points defining the curve.<br /><br />

--- a/docs/api/extras/core/Path.html
+++ b/docs/api/extras/core/Path.html
@@ -60,7 +60,7 @@
 		<h2>Methods</h2>
 		<div>See the base [page:CurvePath] class for common methods.</div>
 
-		<h3>[method:null absarc]( [page:Float x], [page:Float y], [page:Float radius], [page:Float startAngle], [page:Float endAngle], [page:Float clockwise] )</h3>
+		<h3>[method:null absarc]( [param:Float x], [param:Float y], [param:Float radius], [param:Float startAngle], [param:Float endAngle], [param:Float clockwise] )</h3>
 		<div>
 			x, y -- The absolute center of the arc.<br />
 			radius -- The radius of the arc.<br />
@@ -71,7 +71,7 @@
 			Adds an absolutely positioned [page:EllipseCurve EllipseCurve] to the path.
 		</div>
 
-		<h3>[method:null absellipse]( [page:Float x], [page:Float y], [page:Float xRadius], [page:Float yRadius], [page:Float startAngle], [page:Float endAngle], [page:Float clockwise], [page:Float rotation] )</h3>
+		<h3>[method:null absellipse]( [param:Float x], [param:Float y], [param:Float xRadius], [param:Float yRadius], [param:Float startAngle], [param:Float endAngle], [param:Float clockwise], [param:Float rotation] )</h3>
 		<div>
 			x, y -- The absolute center of the ellipse.<br />
 			xRadius -- The radius of the ellipse in the x axis.<br />
@@ -84,7 +84,7 @@
 			Adds an absolutely positioned [page:EllipseCurve EllipseCurve] to the path.
 		</div>
 
-		<h3>[method:null arc]( [page:Float x], [page:Float y], [page:Float radius], [page:Float startAngle], [page:Float endAngle], [page:Float clockwise] )</h3>
+		<h3>[method:null arc]( [param:Float x], [param:Float y], [param:Float radius], [param:Float startAngle], [param:Float endAngle], [param:Float clockwise] )</h3>
 		<div>
 		x, y -- The center of the arc offset from the last call.<br />
 		radius -- The radius of the arc.<br />
@@ -96,10 +96,10 @@
 		</div>
 
 
-		<h3>[method:null bezierCurveTo]( [page:Float cp1X], [page:Float cp1Y], [page:Float cp2X], [page:Float cp2Y], [page:Float x], [page:Float y] )</h3>
+		<h3>[method:null bezierCurveTo]( [param:Float cp1X], [param:Float cp1Y], [param:Float cp2X], [param:Float cp2Y], [param:Float x], [param:Float y] )</h3>
 		<div>This creates a bezier curve from [page:.currentPoint] with (cp1X, cp1Y) and (cp2X, cp2Y) as control points and updates [page:.currentPoint] to x and y.</div>
 
-		<h3>[method:null ellipse]( [page:Float x], [page:Float y], [page:Float xRadius], [page:Float yRadius], [page:Float startAngle], [page:Float endAngle], [page:Float clockwise], [page:Float rotation] )</h3>
+		<h3>[method:null ellipse]( [param:Float x], [param:Float y], [param:Float xRadius], [param:Float yRadius], [param:Float startAngle], [param:Float endAngle], [param:Float clockwise], [param:Float rotation] )</h3>
 		<div>
 			x, y -- The center of the ellipse offset from the last call.<br />
 			xRadius -- The radius of the ellipse in the x axis.<br />
@@ -112,18 +112,18 @@
 			Adds an [page:EllipseCurve EllipseCurve] to the path, positioned relative to [page:.currentPoint].
 		</div>
 
-		<h3>[method:null lineTo]( [page:Float x], [page:Float y] )</h3>
+		<h3>[method:null lineTo]( [param:Float x], [param:Float y] )</h3>
 		<div>Connects a [page:LineCurve] from [page:.currentPoint] to x, y onto the path.</div>
 
 
-		<h3>[method:null moveTo]( [page:Float x], [page:Float y] )</h3>
+		<h3>[method:null moveTo]( [param:Float x], [param:Float y] )</h3>
 		<div>Move the [page:.currentPoint] to x, y.</div>
 
 
-		<h3>[method:null quadraticCurveTo]( [page:Float cpX], [page:Float cpY], [page:Float x], [page:Float y] )</h3>
+		<h3>[method:null quadraticCurveTo]( [param:Float cpX], [param:Float cpY], [param:Float x], [param:Float y] )</h3>
 		<div>Creates a quadratic curve from [page:.currentPoint] with cpX and cpY as control point and updates [page:.currentPoint] to x and y.</div>
 
-		<h3>[method:null setFromPoints]( [page:Array vector2s] )</h3>
+		<h3>[method:null setFromPoints]( [param:Array vector2s] )</h3>
 		<div>
 			points --  array of [page:Vector2 Vector2s].<br /><br />
 
@@ -131,7 +131,7 @@
 			array as [page:LineCurve LineCurves].
 		</div>
 
-		<h3>[method:null splineThru] ( [page:Array points] ) </h3>
+		<h3>[method:null splineThru] ( [param:Array points] ) </h3>
 		<div>
 			points - An array of [page:Vector2 Vector2s]<br /><br />
 

--- a/docs/api/extras/core/Path.html
+++ b/docs/api/extras/core/Path.html
@@ -38,7 +38,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Array points] )</h3>
+		<h3>[name]( [param:Array points] )</h3>
 		<div>
 		points -- (optional) array of [page:Vector2 Vector2s].<br /><br />
 

--- a/docs/api/extras/core/Shape.html
+++ b/docs/api/extras/core/Shape.html
@@ -47,7 +47,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Array points] )</h3>
+		<h3>[name]( [param:Array points] )</h3>
 		<div>
 		points -- (optional) array of [page:Vector2 Vector2s].<br /><br />
 

--- a/docs/api/extras/core/Shape.html
+++ b/docs/api/extras/core/Shape.html
@@ -73,7 +73,7 @@
 		<h2>Methods</h2>
 		<div>See the base [page:Path] class for common methods.</div>
 
-		<h3>[method:Array extractPoints]( [page:Integer divisions] )</h3>
+		<h3>[method:Array extractPoints]( [param:Integer divisions] )</h3>
 		<div>
 		divisions -- The fineness of the result.<br /><br />
 
@@ -87,7 +87,7 @@
 		where shape and holes are arrays of [page:Vector2 Vector2s].
 		</div>
 
-		<h3>[method:Array getPointsHoles]( [page:Integer divisions] )</h3>
+		<h3>[method:Array getPointsHoles]( [param:Integer divisions] )</h3>
 		<div>
 		divisions -- The fineness of the result.<br /><br />
 

--- a/docs/api/extras/core/ShapePath.html
+++ b/docs/api/extras/core/ShapePath.html
@@ -46,32 +46,32 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null moveTo]( [page:Float x], [page:Float y] )</h3>
+		<h3>[method:null moveTo]( [param:Float x], [param:Float y] )</h3>
 		<div>
 		Starts a new [page:Path] and calls [page:Path.moveTo]( x, y ) on that [page:Path].
 		Also points [page:ShapePath.currentPath currentPath] to that [page:Path].
 		</div>
 
-		<h3>[method:null lineTo]( [page:Float x], [page:Float y] )</h3>
+		<h3>[method:null lineTo]( [param:Float x], [param:Float y] )</h3>
 		<div>This creates a line from the [page:ShapePath.currentPath currentPath]'s
 			offset to X and Y and updates the offset to X and Y.</div>
 
-		<h3>[method:null quadraticCurveTo]( [page:Float cpX], [page:Float cpY], [page:Float x], [page:Float y] )</h3>
+		<h3>[method:null quadraticCurveTo]( [param:Float cpX], [param:Float cpY], [param:Float x], [param:Float y] )</h3>
 		<div>This creates a quadratic curve from the [page:ShapePath.currentPath currentPath]'s
 			offset to x and y with cpX and cpY as control point and updates the [page:ShapePath.currentPath currentPath]'s
 			offset to x and y.</div>
 
-		<h3>[method:null bezierCurveTo]( [page:Float cp1X], [page:Float cp1Y], [page:Float cp2X], [page:Float cp2Y], [page:Float x], [page:Float y] )</h3>
+		<h3>[method:null bezierCurveTo]( [param:Float cp1X], [param:Float cp1Y], [param:Float cp2X], [param:Float cp2Y], [param:Float x], [param:Float y] )</h3>
 		<div>This creates a bezier curve from the [page:ShapePath.currentPath currentPath]'s
 			 offset to x and y with cp1X, cp1Y and cp1X, cp1Y as control points and updates the
 			 [page:ShapePath.currentPath currentPath]'s offset to x and y.</div>
 
-		<h3>[method:null splineThru] ( [page:Array points] ) </h3>
+		<h3>[method:null splineThru] ( [param:Array points] ) </h3>
 		<div>points - An array of [page:Vector2]s</div>
 		<div>Connects a new [page:SplineCurve] onto the [page:ShapePath.currentPath currentPath].</div>
 
 
-		<h3>[method:Array toShapes]( [page:Boolean isCCW], [page:Boolean noHoles] )</h3>
+		<h3>[method:Array toShapes]( [param:Boolean isCCW], [param:Boolean noHoles] )</h3>
 		<div>
 		isCCW -- Changes how solids and holes are generated<br/>
 		noHoles -- Whether or not to generate holes

--- a/docs/api/extras/curves/CatmullRomCurve3.html
+++ b/docs/api/extras/curves/CatmullRomCurve3.html
@@ -41,7 +41,7 @@ var curveObject = new THREE.Line( geometry, material );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Array points], [page:Boolean closed], [page:String curveType], [page:Float tension] )</h3>
+		<h3>[name]( [param:Array points], [param:Boolean closed], [param:String curveType], [param:Float tension] )</h3>
 		<div>
 			points – An array of [page:Vector3] points<br/>
 			closed – Whether the curve is closed. Default is *false*.<br/>

--- a/docs/api/extras/curves/CubicBezierCurve.html
+++ b/docs/api/extras/curves/CubicBezierCurve.html
@@ -40,7 +40,7 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Constructor</h2>
 
 
-		<h3>[name] ( [page:Vector2 v0], [page:Vector2 v1], [page:Vector2 v2], [page:Vector2 v3] )</h3>
+		<h3>[name] ( [param:Vector2 v0], [param:Vector2 v1], [param:Vector2 v2], [param:Vector2 v3] )</h3>
 		<div>
 			[page:Vector2 v0] – The starting point.<br/>
 			[page:Vector2 v1] – The first control point.<br/>

--- a/docs/api/extras/curves/CubicBezierCurve3.html
+++ b/docs/api/extras/curves/CubicBezierCurve3.html
@@ -41,7 +41,7 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector3 v0], [page:Vector3 v1], [page:Vector3 v2], [page:Vector3 v3] )</h3>
+		<h3>[name]( [param:Vector3 v0], [param:Vector3 v1], [param:Vector3 v2], [param:Vector3 v3] )</h3>
 		<div>
 			[page:Vector3 v0] – The starting point.<br/>
 			[page:Vector3 v1] – The first control point.<br/>

--- a/docs/api/extras/curves/EllipseCurve.html
+++ b/docs/api/extras/curves/EllipseCurve.html
@@ -40,7 +40,7 @@ var ellipse = new THREE.Line( geometry, material );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Float aX], [page:Float aY], [page:Float xRadius], [page:Float yRadius], [page:Radians aStartAngle], [page:Radians aEndAngle], [page:Boolean aClockwise], [page:Radians aRotation] )</h3>
+		<h3>[name]( [param:Float aX], [param:Float aY], [param:Float xRadius], [param:Float yRadius], [param:Radians aStartAngle], [param:Radians aEndAngle], [param:Boolean aClockwise], [param:Radians aRotation] )</h3>
 		<div>
 			[page:Float aX] – The X center of the ellipse. Default is *0*.<br/>
 			[page:Float aY] – The Y center of the ellipse. Default is *0*.<br/>

--- a/docs/api/extras/curves/LineCurve.html
+++ b/docs/api/extras/curves/LineCurve.html
@@ -17,7 +17,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector2 v1], [page:Vector2 v2] )</h3>
+		<h3>[name]( [param:Vector2 v1], [param:Vector2 v2] )</h3>
 		<div>
 			[page:Vector2 v1] – The start point.<br/>
 			[page:Vector2 v2] - The end point.

--- a/docs/api/extras/curves/LineCurve3.html
+++ b/docs/api/extras/curves/LineCurve3.html
@@ -17,7 +17,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector3 v1], [page:Vector3 v2] )</h3>
+		<h3>[name]( [param:Vector3 v1], [param:Vector3 v2] )</h3>
 		<div>
 			[page:Vector3 v1] – The start point.<br/>
 			[page:Vector3 v2] - The end point.

--- a/docs/api/extras/curves/QuadraticBezierCurve.html
+++ b/docs/api/extras/curves/QuadraticBezierCurve.html
@@ -39,7 +39,7 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector2 v0], [page:Vector2 v1], [page:Vector2 v2] )</h3>
+		<h3>[name]( [param:Vector2 v0], [param:Vector2 v1], [param:Vector2 v2] )</h3>
 		<div>
 			[page:Vector2 v0] – The startpoint.<br/>
 			[page:Vector2 v1] – The control point.<br/>

--- a/docs/api/extras/curves/QuadraticBezierCurve3.html
+++ b/docs/api/extras/curves/QuadraticBezierCurve3.html
@@ -39,7 +39,7 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector3 v0], [page:Vector3 v1], [page:Vector3 v2] )</h3>
+		<h3>[name]( [param:Vector3 v0], [param:Vector3 v1], [param:Vector3 v2] )</h3>
 		<div>
 			[page:Vector3 v0] – The starting point<br/>
 			[page:Vector3 v1] – The middle control point<br/>

--- a/docs/api/extras/curves/SplineCurve.html
+++ b/docs/api/extras/curves/SplineCurve.html
@@ -41,7 +41,7 @@ var splineObject = new THREE.Line( geometry, material );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Array points] )</h3>
+		<h3>[name]( [param:Array points] )</h3>
 		<div>points – An array of [page:Vector2] points that define the curve.</div>
 
 

--- a/docs/api/extras/objects/ImmediateRenderObject.html
+++ b/docs/api/extras/objects/ImmediateRenderObject.html
@@ -27,7 +27,7 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:null render]([page:Function renderCallback])</h3>
+		<h3>[method:null render]([param:Function renderCallback])</h3>
 		<div>
 		renderCallback -- A function to render the generated object.
 		</div>

--- a/docs/api/geometries/BoxBufferGeometry.html
+++ b/docs/api/geometries/BoxBufferGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float width], [page:Float height], [page:Float depth], [page:Integer widthSegments], [page:Integer heightSegments], [page:Integer depthSegments])</h3>
+		<h3>[name]([param:Float width], [param:Float height], [param:Float depth], [param:Integer widthSegments], [param:Integer heightSegments], [param:Integer depthSegments])</h3>
 		<div>
 		width — Width of the sides on the X axis. Default is 1.<br />
 		height — Height of the sides on the Y axis. Default is 1.<br />

--- a/docs/api/geometries/BoxGeometry.html
+++ b/docs/api/geometries/BoxGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float width], [page:Float height], [page:Float depth], [page:Integer widthSegments], [page:Integer heightSegments], [page:Integer depthSegments])</h3>
+		<h3>[name]([param:Float width], [param:Float height], [param:Float depth], [param:Integer widthSegments], [param:Integer heightSegments], [param:Integer depthSegments])</h3>
 		<div>
 		width — Width of the sides on the X axis. Default is 1.<br />
 		height — Height of the sides on the Y axis. Default is 1.<br />

--- a/docs/api/geometries/CircleBufferGeometry.html
+++ b/docs/api/geometries/CircleBufferGeometry.html
@@ -43,7 +43,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer segments], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float radius], [param:Integer segments], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<div>
 		radius — Radius of the circle, default = 1.<br />
 		segments — Number of segments (triangles), minimum = 3, default = 8.<br />

--- a/docs/api/geometries/CircleGeometry.html
+++ b/docs/api/geometries/CircleGeometry.html
@@ -44,7 +44,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer segments], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float radius], [param:Integer segments], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<div>
 		radius — Radius of the circle, default = 1.<br />
 		segments — Number of segments (triangles), minimum = 3, default = 8.<br />

--- a/docs/api/geometries/ConeBufferGeometry.html
+++ b/docs/api/geometries/ConeBufferGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Float height], [page:Integer radialSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float radius], [param:Float height], [param:Integer radialSegments], [param:Integer heightSegments], [param:Boolean openEnded], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<div>
 		radius — Radius of the cone base. Default is 1.<br />
 		height — Height of the cone. Default is 1.<br />

--- a/docs/api/geometries/ConeGeometry.html
+++ b/docs/api/geometries/ConeGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Float height], [page:Integer radialSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float radius], [param:Float height], [param:Integer radialSegments], [param:Integer heightSegments], [param:Boolean openEnded], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<div>
 		radius — Radius of the cone at the base. Default is 20.<br />
 		height — Height of the cone. Default is 100.<br />

--- a/docs/api/geometries/CylinderBufferGeometry.html
+++ b/docs/api/geometries/CylinderBufferGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radiusTop], [page:Float radiusBottom], [page:Float height], [page:Integer radialSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float radiusTop], [param:Float radiusBottom], [param:Float height], [param:Integer radialSegments], [param:Integer heightSegments], [param:Boolean openEnded], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<div>
 		radiusTop — Radius of the cylinder at the top. Default is 1.<br />
 		radiusBottom — Radius of the cylinder at the bottom. Default is 1.<br />

--- a/docs/api/geometries/CylinderGeometry.html
+++ b/docs/api/geometries/CylinderGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radiusTop], [page:Float radiusBottom], [page:Float height], [page:Integer radialSegments], [page:Integer heightSegments], [page:Boolean openEnded], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float radiusTop], [param:Float radiusBottom], [param:Float height], [param:Integer radialSegments], [param:Integer heightSegments], [param:Boolean openEnded], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<div>
 		radiusTop — Radius of the cylinder at the top. Default is 1.<br />
 		radiusBottom — Radius of the cylinder at the bottom. Default is 1.<br />

--- a/docs/api/geometries/DodecahedronBufferGeometry.html
+++ b/docs/api/geometries/DodecahedronBufferGeometry.html
@@ -34,7 +34,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Float radius], [param:Integer detail])</h3>
 		<div>
 		radius — Radius of the dodecahedron. Default is 1.<br />
 		detail — Default is 0. Setting this to a value greater than 0 adds vertices making it no longer a dodecahedron.

--- a/docs/api/geometries/DodecahedronGeometry.html
+++ b/docs/api/geometries/DodecahedronGeometry.html
@@ -34,7 +34,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Float radius], [param:Integer detail])</h3>
 		<div>
 		radius — Radius of the dodecahedron. Default is 1.<br />
 		detail — Default is 0. Setting this to a value greater than 0 adds vertices making it no longer a dodecahedron.

--- a/docs/api/geometries/EdgesGeometry.html
+++ b/docs/api/geometries/EdgesGeometry.html
@@ -27,7 +27,7 @@ scene.add( line );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Geometry geometry], [page:Integer thresholdAngle] )</h3>
+		<h3>[name]( [param:Geometry geometry], [param:Integer thresholdAngle] )</h3>
 		<div>
 		geometry — Any geometry object.<br />
 		thresholdAngle — An edge is only rendered if the angle (in degrees) between the face normals of the adjoining faces exceeds this value. default = 1 degree.

--- a/docs/api/geometries/ExtrudeBufferGeometry.html
+++ b/docs/api/geometries/ExtrudeBufferGeometry.html
@@ -99,7 +99,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null addShapeList]([page:Array shapes], [page:Object options])</h3>
+		<h3>[method:null addShapeList]([param:Array shapes], [param:Object options])</h3>
 		<div>
 			shapes — An Array of shapes to add. <br />
 			options — Object that can contain the following parameters.
@@ -118,7 +118,7 @@
 		</div>
 		<div>Adds the shapes to the list to extrude.</div>
 
-		<h3>[method:null addShape]([page:Shape shape], [page:Object options])</h3>
+		<h3>[method:null addShape]([param:Shape shape], [param:Object options])</h3>
 		<div>
 			shape — A shape to add. <br />
 			options — Object that can contain the following parameters.

--- a/docs/api/geometries/ExtrudeBufferGeometry.html
+++ b/docs/api/geometries/ExtrudeBufferGeometry.html
@@ -64,7 +64,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Array shapes], [page:Object options])</h3>
+		<h3>[name]([param:Array shapes], [param:Object options])</h3>
 		<div>
 		shapes — Shape or an array of shapes. <br />
 		options — Object that can contain the following parameters.

--- a/docs/api/geometries/ExtrudeGeometry.html
+++ b/docs/api/geometries/ExtrudeGeometry.html
@@ -99,7 +99,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null addShapeList]([page:Array shapes], [page:Object options])</h3>
+		<h3>[method:null addShapeList]([param:Array shapes], [param:Object options])</h3>
 		<div>
 			shapes — An Array of shapes to add. <br />
 			options — Object that can contain the following parameters.
@@ -118,7 +118,7 @@
 		</div>
 		<div>Adds the shapes to the list to extrude.</div>
 
-		<h3>[method:null addShape]([page:Shape shape], [page:Object options])</h3>
+		<h3>[method:null addShape]([param:Shape shape], [param:Object options])</h3>
 		<div>
 			shape — A shape to add. <br />
 			options — Object that can contain the following parameters.

--- a/docs/api/geometries/ExtrudeGeometry.html
+++ b/docs/api/geometries/ExtrudeGeometry.html
@@ -64,7 +64,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Array shapes], [page:Object options])</h3>
+		<h3>[name]([param:Array shapes], [param:Object options])</h3>
 		<div>
 		shapes — Shape or an array of shapes. <br />
 		options — Object that can contain the following parameters.

--- a/docs/api/geometries/IcosahedronBufferGeometry.html
+++ b/docs/api/geometries/IcosahedronBufferGeometry.html
@@ -33,7 +33,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Float radius], [param:Integer detail])</h3>
 		<div>
 		radius — Default is 1. <br />
 		detail — Default is 0.  Setting this to a value greater than 0 adds more vertices making it no longer an icosahedron.  When detail is greater than 1, it's effectively a sphere.

--- a/docs/api/geometries/IcosahedronGeometry.html
+++ b/docs/api/geometries/IcosahedronGeometry.html
@@ -9,7 +9,7 @@
 	</head>
 	<body>
 		[page:Geometry] &rarr;
-		
+
 		<h1>[name]</h1>
 
 		<div class="desc">A class for generating an icosahedron geometry.</div>
@@ -34,7 +34,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Float radius], [param:Integer detail])</h3>
 		<div>
 		radius — Default is 1. <br />
 		detail — Default is 0.  Setting this to a value greater than 0 adds more vertices making it no longer an icosahedron.  When detail is greater than 1, it's effectively a sphere.

--- a/docs/api/geometries/LatheBufferGeometry.html
+++ b/docs/api/geometries/LatheBufferGeometry.html
@@ -47,7 +47,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Array points], [page:Integer segments], [page:Float phiStart], [page:Float phiLength])</h3>
+		<h3>[name]([param:Array points], [param:Integer segments], [param:Float phiStart], [param:Float phiLength])</h3>
 		<div>
 		points — Array of Vector2s. The x-coordinate of each point must be greater than zero.<br />
 		segments — the number of circumference segments to generate. Default is 12.<br />

--- a/docs/api/geometries/LatheGeometry.html
+++ b/docs/api/geometries/LatheGeometry.html
@@ -47,7 +47,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Array points], [page:Integer segments], [page:Float phiStart], [page:Float phiLength])</h3>
+		<h3>[name]([param:Array points], [param:Integer segments], [param:Float phiStart], [param:Float phiLength])</h3>
 		<div>
 		points — Array of Vector2s. The x-coordinate of each point must be greater than zero.<br />
 		segments — the number of circumference segments to generate. Default is 12.<br />

--- a/docs/api/geometries/OctahedronBufferGeometry.html
+++ b/docs/api/geometries/OctahedronBufferGeometry.html
@@ -33,7 +33,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Float radius], [param:Integer detail])</h3>
 		<div>
 		radius — Radius of the octahedron. Default is 1.<br />
 		detail — Default is 0.  Setting this to a value greater than zero add vertices making it no longer an octahedron.

--- a/docs/api/geometries/OctahedronGeometry.html
+++ b/docs/api/geometries/OctahedronGeometry.html
@@ -9,7 +9,7 @@
 	</head>
 	<body>
 		[page:Geometry] &rarr;
-		
+
 		<h1>[name]</h1>
 
 		<div class="desc">A class for generating an octahedron geometry.</div>
@@ -34,7 +34,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Float radius], [param:Integer detail])</h3>
 		<div>
 		radius — Radius of the octahedron. Default is 1.<br />
 		detail — Default is 0.  Setting this to a value greater than zero add vertices making it no longer an octahedron.

--- a/docs/api/geometries/ParametricBufferGeometry.html
+++ b/docs/api/geometries/ParametricBufferGeometry.html
@@ -45,7 +45,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Function func], [page:Integer slices], [page:Integer stacks])</h3>
+		<h3>[name]([param:Function func], [param:Integer slices], [param:Integer stacks])</h3>
 		<div>
 		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and returns a [page:Vector3]<br />
 		slices — The count of slices to use for the parametric function <br />

--- a/docs/api/geometries/ParametricGeometry.html
+++ b/docs/api/geometries/ParametricGeometry.html
@@ -45,7 +45,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Function func], [page:Integer slices], [page:Integer stacks])</h3>
+		<h3>[name]([param:Function func], [param:Integer slices], [param:Integer stacks])</h3>
 		<div>
 		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and returns a [page:Vector3]<br />
 		slices — The count of slices to use for the parametric function <br />

--- a/docs/api/geometries/PlaneBufferGeometry.html
+++ b/docs/api/geometries/PlaneBufferGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float width], [page:Float height], [page:Integer widthSegments], [page:Integer heightSegments])</h3>
+		<h3>[name]([param:Float width], [param:Float height], [param:Integer widthSegments], [param:Integer heightSegments])</h3>
 		<div>
 		width — Width along the X axis. Default is 1.<br />
 		height — Height along the Y axis. Default is 1.<br />

--- a/docs/api/geometries/PlaneGeometry.html
+++ b/docs/api/geometries/PlaneGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float width], [page:Float height], [page:Integer widthSegments], [page:Integer heightSegments])</h3>
+		<h3>[name]([param:Float width], [param:Float height], [param:Integer widthSegments], [param:Integer heightSegments])</h3>
 		<div>
 		width — Width along the X axis. Default is 1.<br />
 		height — Height along the Y axis. Default is 1.<br />

--- a/docs/api/geometries/PolyhedronBufferGeometry.html
+++ b/docs/api/geometries/PolyhedronBufferGeometry.html
@@ -41,7 +41,7 @@ var geometry = new THREE.PolyhedronBufferGeometry( verticesOfCube, indicesOfFace
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Array vertices], [page:Array indices], [page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Array vertices], [param:Array indices], [param:Float radius], [param:Integer detail])</h3>
 		<div>
 		vertices — [page:Array] of points of the form [1,1,1, -1,-1,-1, ... ] <br />
 		indices — [page:Array] of indices that make up the faces of the form [0,1,2, 2,3,0, ... ] <br />

--- a/docs/api/geometries/PolyhedronGeometry.html
+++ b/docs/api/geometries/PolyhedronGeometry.html
@@ -39,7 +39,7 @@ var geometry = new THREE.PolyhedronGeometry( verticesOfCube, indicesOfFaces, 6, 
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Array vertices], [page:Array indices], [page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Array vertices], [param:Array indices], [param:Float radius], [param:Integer detail])</h3>
 		<div>
 		vertices — [page:Array] of points of the form [1,1,1, -1,-1,-1, ... ] <br />
 		indices — [page:Array] of indices that make up the faces of the form [0,1,2, 2,3,0, ... ] <br />

--- a/docs/api/geometries/RingBufferGeometry.html
+++ b/docs/api/geometries/RingBufferGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float innerRadius], [page:Float outerRadius], [page:Integer thetaSegments], [page:Integer phiSegments], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float innerRadius], [param:Float outerRadius], [param:Integer thetaSegments], [param:Integer phiSegments], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<div>
 		innerRadius — Default is 0.5. <br />
 		outerRadius — Default is 1. <br />

--- a/docs/api/geometries/RingGeometry.html
+++ b/docs/api/geometries/RingGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float innerRadius], [page:Float outerRadius], [page:Integer thetaSegments], [page:Integer phiSegments], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float innerRadius], [param:Float outerRadius], [param:Integer thetaSegments], [param:Integer phiSegments], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<div>
 		innerRadius — Default is 0.5. <br />
 		outerRadius — Default is 1. <br />

--- a/docs/api/geometries/ShapeBufferGeometry.html
+++ b/docs/api/geometries/ShapeBufferGeometry.html
@@ -58,7 +58,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Array shapes], [page:Integer curveSegments])</h3>
+		<h3>[name]([param:Array shapes], [param:Integer curveSegments])</h3>
 		<div>
 		shapes — [page:Array] of shapes or a single [page:Shape shape].<br />
 		curveSegments - [page:Integer] - Number of segments per shape. Default is 12.

--- a/docs/api/geometries/ShapeGeometry.html
+++ b/docs/api/geometries/ShapeGeometry.html
@@ -58,7 +58,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Array shapes], [page:Integer curveSegments])</h3>
+		<h3>[name]([param:Array shapes], [param:Integer curveSegments])</h3>
 		<div>
 		shapes — [page:Array] of shapes or a single [page:Shape shape].<br />
 		curveSegments - [page:Integer] - Number of segments per shape. Default is 12.

--- a/docs/api/geometries/SphereBufferGeometry.html
+++ b/docs/api/geometries/SphereBufferGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer widthSegments], [page:Integer heightSegments], [page:Float phiStart], [page:Float phiLength], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float radius], [param:Integer widthSegments], [param:Integer heightSegments], [param:Float phiStart], [param:Float phiLength], [param:Float thetaStart], [param:Float thetaLength])</h3>
 
 		<div>
 		radius — sphere radius. Default is 1.<br />

--- a/docs/api/geometries/SphereGeometry.html
+++ b/docs/api/geometries/SphereGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer widthSegments], [page:Integer heightSegments], [page:Float phiStart], [page:Float phiLength], [page:Float thetaStart], [page:Float thetaLength])</h3>
+		<h3>[name]([param:Float radius], [param:Integer widthSegments], [param:Integer heightSegments], [param:Float phiStart], [param:Float phiLength], [param:Float thetaStart], [param:Float thetaLength])</h3>
 
 		<div>
 		radius — sphere radius. Default is 1.<br />

--- a/docs/api/geometries/TetrahedronBufferGeometry.html
+++ b/docs/api/geometries/TetrahedronBufferGeometry.html
@@ -34,7 +34,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Float radius], [param:Integer detail])</h3>
 		<div>
 		radius — Radius of the tetrahedron. Default is 1.<br />
 		detail — Default is 0. Setting this to a value greater than 0 adds vertices making it no longer a tetrahedron.

--- a/docs/api/geometries/TetrahedronGeometry.html
+++ b/docs/api/geometries/TetrahedronGeometry.html
@@ -34,7 +34,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Integer detail])</h3>
+		<h3>[name]([param:Float radius], [param:Integer detail])</h3>
 		<div>
 		radius — Radius of the tetrahedron. Default is 1.<br />
 		detail — Default is 0. Setting this to a value greater than 0 adds vertices making it no longer a tetrahedron.

--- a/docs/api/geometries/TextBufferGeometry.html
+++ b/docs/api/geometries/TextBufferGeometry.html
@@ -62,7 +62,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:String text], [page:Object parameters])</h3>
+		<h3>[name]([param:String text], [param:Object parameters])</h3>
 		<div>
 		text — The text that needs to be shown. <br />
 		parameters — Object that can contains the following parameters.

--- a/docs/api/geometries/TextGeometry.html
+++ b/docs/api/geometries/TextGeometry.html
@@ -13,7 +13,7 @@
 		<h1>[name]</h1>
 
 		<div class="desc">
-			A class for generating text as a single geometry. It is constructed by providing a string of text, and a hash of 
+			A class for generating text as a single geometry. It is constructed by providing a string of text, and a hash of
 			parameters consisting of a loaded [page:Font] and settings for the geometry's parent [page:ExtrudeGeometry].
 			See the [page:Font], [page:FontLoader] and [page:Creating_Text] pages for additional details.
 		</div>
@@ -44,7 +44,7 @@
 
 		<code>
 		var loader = new THREE.FontLoader();
-		
+
 		loader.load( 'fonts/helvetiker_regular.typeface.json', function ( font ) {
 
 			var geometry = new THREE.TextGeometry( 'Hello three.js!', {
@@ -57,12 +57,12 @@
 				bevelSize: 8,
 				bevelSegments: 5
 			} );
-		} );			
+		} );
 		</code>
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:String text], [page:Object parameters])</h3>
+		<h3>[name]([param:String text], [param:Object parameters])</h3>
 		<div>
 		text — The text that needs to be shown. <br />
 		parameters — Object that can contains the following parameters.

--- a/docs/api/geometries/TorusBufferGeometry.html
+++ b/docs/api/geometries/TorusBufferGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Float arc])</h3>
+		<h3>[name]([param:Float radius], [param:Float tube], [param:Integer radialSegments], [param:Integer tubularSegments], [param:Float arc])</h3>
 		<div>
 		radius - Radius of the torus, from the center of the torus to the center of the tube. Default is 1. <br />
 		tube — Radius of the tube.  Default is 0.4. <br />

--- a/docs/api/geometries/TorusGeometry.html
+++ b/docs/api/geometries/TorusGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer radialSegments], [page:Integer tubularSegments], [page:Float arc])</h3>
+		<h3>[name]([param:Float radius], [param:Float tube], [param:Integer radialSegments], [param:Integer tubularSegments], [param:Float arc])</h3>
 		<div>
 		radius - Radius of the torus, from the center of the torus to the center of the tube. Default is 1. <br />
 		tube — Radius of the tube.  Default is 0.4. <br />

--- a/docs/api/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/geometries/TorusKnotBufferGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer tubularSegments], [page:Integer radialSegments], [page:Integer p], [page:Integer q])</h3>
+		<h3>[name]([param:Float radius], [param:Float tube], [param:Integer tubularSegments], [param:Integer radialSegments], [param:Integer p], [param:Integer q])</h3>
 		<div>
 			<ul>
 				<li>radius - Radius of the torus. Default is 1.</li>

--- a/docs/api/geometries/TorusKnotGeometry.html
+++ b/docs/api/geometries/TorusKnotGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([page:Float radius], [page:Float tube], [page:Integer tubularSegments], [page:Integer radialSegments], [page:Integer p], [page:Integer q])</h3>
+		<h3>[name]([param:Float radius], [param:Float tube], [param:Integer tubularSegments], [param:Integer radialSegments], [param:Integer p], [param:Integer q])</h3>
 		<div>
 			<ul>
 				<li>radius - Radius of the torus. Default is 1.</li>

--- a/docs/api/geometries/TubeBufferGeometry.html
+++ b/docs/api/geometries/TubeBufferGeometry.html
@@ -66,7 +66,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Curve path], [page:Integer tubularSegments], [page:Float radius], [page:Integer radialSegments], [page:Boolean closed])</h3>
+		<h3>[name]([param:Curve path], [param:Integer tubularSegments], [param:Float radius], [param:Integer radialSegments], [param:Boolean closed])</h3>
 		<div>
 		path — [page:Curve] - A path that inherits from the [page:Curve] base class<br />
 		tubularSegments — [page:Integer] - The number of segments that make up the tube, default is 64<br />

--- a/docs/api/geometries/TubeGeometry.html
+++ b/docs/api/geometries/TubeGeometry.html
@@ -66,7 +66,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Curve path], [page:Integer tubularSegments], [page:Float radius], [page:Integer radialSegments], [page:Boolean closed])</h3>
+		<h3>[name]([param:Curve path], [param:Integer tubularSegments], [param:Float radius], [param:Integer radialSegments], [param:Boolean closed])</h3>
 		<div>
 		path — [page:Curve] - A path that inherits from the [page:Curve] base class<br />
 		tubularSegments — [page:Integer] - The number of segments that make up the tube, default is 64<br />

--- a/docs/api/geometries/WireframeGeometry.html
+++ b/docs/api/geometries/WireframeGeometry.html
@@ -51,7 +51,7 @@ scene.add( line );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Geometry geometry] )</h3>
+		<h3>[name]( [param:Geometry geometry] )</h3>
 		<div>
 		geometry — any geometry object.
 		</div>

--- a/docs/api/helpers/ArrowHelper.html
+++ b/docs/api/helpers/ArrowHelper.html
@@ -40,7 +40,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Vector3 dir], [page:Vector3 origin], [page:Number length], [page:Number hex], [page:Number headLength], [page:Number headWidth] )</h3>
+		<h3>[name]([param:Vector3 dir], [param:Vector3 origin], [param:Number length], [param:Number hex], [param:Number headLength], [param:Number headWidth] )</h3>
 		<div>
 		[page:Vector3 dir] -- direction from origin. Must be a unit vector. <br />
 		[page:Vector3 origin] -- Point at which the arrow starts.<br />

--- a/docs/api/helpers/ArrowHelper.html
+++ b/docs/api/helpers/ArrowHelper.html
@@ -68,14 +68,14 @@
 
 
 
-		<h3>[method:null setColor]([page:Number hex])</h3>
+		<h3>[method:null setColor]([param:Number hex])</h3>
 		<div>
 		hex -- The hexadecimal value of the color.<br /><br />
 
 		Sets the color of the arrowHelper.
 		</div>
 
-		<h3>[method:null setLength]([page:Number length], [page:Number headLength], [page:Number headWidth])</h3>
+		<h3>[method:null setLength]([param:Number length], [param:Number headLength], [param:Number headWidth])</h3>
 		<div>
 		length -- The desired length.<br />
 		headLength -- The length of the head of the arrow.<br />
@@ -84,7 +84,7 @@
 		Sets the length of the arrowhelper.
 		</div>
 
-		<h3>[method:null setDirection]([page:Vector3 dir])</h3>
+		<h3>[method:null setDirection]([param:Vector3 dir])</h3>
 		<div>
 		dir -- The desired direction. Must be a unit vector.<br /><br />
 

--- a/docs/api/helpers/AxesHelper.html
+++ b/docs/api/helpers/AxesHelper.html
@@ -33,7 +33,7 @@ scene.add( axesHelper );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Number size] )</h3>
+		<h3>[name]( [param:Number size] )</h3>
 		<div>
 		[page:Number size] -- (optional) size of the lines representing the axes. Default is *1*.
 		</div>

--- a/docs/api/helpers/Box3Helper.html
+++ b/docs/api/helpers/Box3Helper.html
@@ -31,7 +31,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Box3 box], [page:Color color] )</h3>
+		<h3>[name]( [param:Box3 box], [param:Color color] )</h3>
 		<div>
 		[page:Box3 box]  -- the Box3 to show.<br />
 		[page:Color color] --  (optional) the box's color. Default is 0xffff00.<br /><br />

--- a/docs/api/helpers/BoxHelper.html
+++ b/docs/api/helpers/BoxHelper.html
@@ -38,7 +38,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Object3D object], [page:Color color] )</h3>
+		<h3>[name]( [param:Object3D object], [param:Color color] )</h3>
 		<div>
 		[page:Object3D object]  -- (optional) the object3D to show the world-axis-aligned boundingbox.<br />
 		[page:Color color] --  (optional) hexadecimal value that defines the box's color. Default is 0xffff00.<br /><br />

--- a/docs/api/helpers/BoxHelper.html
+++ b/docs/api/helpers/BoxHelper.html
@@ -60,7 +60,7 @@
 			of the object, including any children. See [page:Box3.setFromObject].
 		</div>
 
-		<h3>[method:BoxHelper setFromObject]( [page:Object3D object] )</h3>
+		<h3>[method:BoxHelper setFromObject]( [param:Object3D object] )</h3>
 		<div>
 			[page:Object3D object] - [page:Object3D] to create the helper of.<br /><br />
 

--- a/docs/api/helpers/CameraHelper.html
+++ b/docs/api/helpers/CameraHelper.html
@@ -32,7 +32,7 @@ scene.add( helper );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Camera camera] )</h3>
+		<h3>[name]( [param:Camera camera] )</h3>
 		<div>
 		[page:Camera camera] -- The camera to visualize.<br /><br />
 

--- a/docs/api/helpers/DirectionalLightHelper.html
+++ b/docs/api/helpers/DirectionalLightHelper.html
@@ -32,12 +32,12 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:DirectionalLight light], [page:Number size], [page:Hex color] )</h3>
+		<h3>[name]( [param:DirectionalLight light], [param:Number size], [param:Hex color] )</h3>
 		<div>
 			[page:DirectionalLight light]-- The light to be visualized. <br /><br />
 
 			[page:Number size] -- (optional) dimensions of the plane. Default is *1*.<br /><br />
-			
+
 			[page:Hex color] -- (optional) if this is not the set the helper will take the color of the light.
 		</div>
 
@@ -63,7 +63,7 @@
 
 		<h3>[property:hex color]</h3>
 		<div>
-			The color parameter passed in the constructor. Default is *undefined*. If this is changed, 
+			The color parameter passed in the constructor. Default is *undefined*. If this is changed,
 			the helper's color will update the next time [page:.update update] is called.
 		</div>
 

--- a/docs/api/helpers/FaceNormalsHelper.html
+++ b/docs/api/helpers/FaceNormalsHelper.html
@@ -39,7 +39,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Object3D object], [page:Number size], [page:Color color], [page:Number linewidth] )</h3>
+		<h3>[name]( [param:Object3D object], [param:Number size], [param:Color color], [param:Number linewidth] )</h3>
 		<div>
 		[page:Object3D object] -- object for which to render face normals.<br />
 		[page:Number size] -- (optional) length of the arrows. Default is *1*.<br />

--- a/docs/api/helpers/GridHelper.html
+++ b/docs/api/helpers/GridHelper.html
@@ -28,7 +28,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:number size], [page:Number divisions], [page:Color colorCenterLine], [page:Color colorGrid] )</h3>
+		<h3>[name]( [param:number size], [param:Number divisions], [param:Color colorCenterLine], [param:Color colorGrid] )</h3>
 		<div>
 		size -- The size of the grid. Default is 10. <br />
 		divisions -- The number of divisions across the grid. Default is 10. <br />

--- a/docs/api/helpers/HemisphereLightHelper.html
+++ b/docs/api/helpers/HemisphereLightHelper.html
@@ -29,12 +29,12 @@ scene.add( helper );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:HemisphereLight light], [page:Number sphereSize], [page:Hex color] )</h3>
+		<h3>[name]( [param:HemisphereLight light], [param:Number sphereSize], [param:Hex color] )</h3>
 		<div>
 			[page:HemisphereLight light] -- The light being visualized. <br /><br />
 
 			[page:Number size] -- The size of the mesh used to visualize the light.<br /><br />
-			
+
 			[page:Hex color] -- (optional) if this is not the set the helper will take the color of the light.
 		</div>
 

--- a/docs/api/helpers/PlaneHelper.html
+++ b/docs/api/helpers/PlaneHelper.html
@@ -29,7 +29,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Plane plane], [page:Float size], [page:Color hex] )</h3>
+		<h3>[name]( [param:Plane plane], [param:Float size], [param:Color hex] )</h3>
 		<div>
 		[page:Plane plane] --  the plane to visualize.<br />
 		[page:Float size] -- (optional) side length of plane helper. Default is 1.<br />

--- a/docs/api/helpers/PointLightHelper.html
+++ b/docs/api/helpers/PointLightHelper.html
@@ -37,7 +37,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:PointLight light], [page:Float sphereSize], [page:Hex color] )</h3>
+		<h3>[name]( [param:PointLight light], [param:Float sphereSize], [param:Hex color] )</h3>
 		<div>
 		[page:PointLight light] -- The light to be visualized. <br /><br />
 
@@ -66,7 +66,7 @@
 			 The color parameter passed in the constructor. Default is *undefined*. If this is changed, the helper's color will update
 			the next time [page:.update update] is called.
 		</div>
-		
+
 		<h2>Methods</h2>
 		<div>See the base [page:Mesh] class for common methods.</div>
 

--- a/docs/api/helpers/PolarGridHelper.html
+++ b/docs/api/helpers/PolarGridHelper.html
@@ -30,7 +30,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Number radius], [page:Number radials], [page:Number circles], [page:Number divisions], [page:Color color1], [page:Color color2] )</h3>
+		<h3>[name]( [param:Number radius], [param:Number radials], [param:Number circles], [param:Number divisions], [param:Color color1], [param:Color color2] )</h3>
 		<div>
 		radius -- The radius of the polar grid. This can be any positive number. Default is 10.<br />
 		radials -- The number of radial lines. This can be any positive integer. Default is 16.<br />

--- a/docs/api/helpers/RectAreaLightHelper.html
+++ b/docs/api/helpers/RectAreaLightHelper.html
@@ -29,7 +29,7 @@ scene.add( helper );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:RectAreaLight light], [page:Hex color] )</h3>
+		<h3>[name]( [param:RectAreaLight light], [param:Hex color] )</h3>
 		<div>
 			[page:RectAreaLight light] -- The light being visualized.<br /><br />
 

--- a/docs/api/helpers/SpotLightHelper.html
+++ b/docs/api/helpers/SpotLightHelper.html
@@ -35,11 +35,11 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:SpotLight light], [page:Hex color] )</h3>
+		<h3>[name]( [param:SpotLight light], [param:Hex color] )</h3>
 		<div>
 			[page:SpotLight light] -- The [page:SpotLight] to be visualized. <br /><br/>
-			
-			[page:Hex color] -- (optional) if this is not the set the helper will take the color of the light. 
+
+			[page:Hex color] -- (optional) if this is not the set the helper will take the color of the light.
 		</div>
 
 

--- a/docs/api/helpers/VertexNormalsHelper.html
+++ b/docs/api/helpers/VertexNormalsHelper.html
@@ -39,7 +39,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Object3D object], [page:Number size], [page:Hex color], [page:Number linewidth] )</h3>
+		<h3>[name]( [param:Object3D object], [param:Number size], [param:Hex color], [param:Number linewidth] )</h3>
 		<div>
 			[page:Object3D object] -- object for which to render vertex normals.<br />
 			[page:Number size] -- (optional) length of the arrows. Default is 1.<br />

--- a/docs/api/lights/AmbientLight.html
+++ b/docs/api/lights/AmbientLight.html
@@ -15,7 +15,7 @@
 		<div class="desc">
 			This light globally illuminates all objects in the scene equally.<br /><br />
 
-			This light cannot be used to cast shadows as it does not have a direction. 
+			This light cannot be used to cast shadows as it does not have a direction.
 		</div>
 
 
@@ -34,7 +34,7 @@ scene.add( light );</code>
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Integer color], [page:Float intensity] )</h3>
+		<h3>[name]( [param:Integer color], [param:Float intensity] )</h3>
 		<div>
 		[page:Integer color] — Numeric value of the RGB component of the color. <br />
 		[page:Float intensity] -- Numeric value of the light's strength/intensity.<br /><br />

--- a/docs/api/lights/DirectionalLight.html
+++ b/docs/api/lights/DirectionalLight.html
@@ -60,7 +60,7 @@ scene.add( directionalLight );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Integer color], [page:Float intensity] )</h3>
+		<h3>[name]( [param:Integer color], [param:Float intensity] )</h3>
 		<div>
 			[page:Integer color] - (optional) hexadecimal color of the light. Default is 0xffffff (white).<br />
 			[page:Float intensity] - (optional) numeric value of the light's strength/intensity. Default is 1.<br /><br />

--- a/docs/api/lights/DirectionalLight.html
+++ b/docs/api/lights/DirectionalLight.html
@@ -128,7 +128,7 @@ scene.add( directionalLight );
 
 		See the base [page:Light Light] class for common methods.
 
-		<h3>[method:DirectionalLight copy]( [page:DirectionalLight source] )</h3>
+		<h3>[method:DirectionalLight copy]( [param:DirectionalLight source] )</h3>
 		<div>
 		Copies value of all the properties from the [page:DirectionalLight source] to this
 		DirectionalLight.

--- a/docs/api/lights/HemisphereLight.html
+++ b/docs/api/lights/HemisphereLight.html
@@ -86,7 +86,7 @@ scene.add( light );
 
 		See the base [page:Light Light] class for common methods.
 
-		<h3>[method:HemisphereLight copy]( [page:HemisphereLight source] )</h3>
+		<h3>[method:HemisphereLight copy]( [param:HemisphereLight source] )</h3>
 		<div>
 			Copies the value of [page:.color color], [page:.intensity intensity] and
 			[page:.groundColor groundColor] from the [page:Light source] light into this one.

--- a/docs/api/lights/HemisphereLight.html
+++ b/docs/api/lights/HemisphereLight.html
@@ -36,7 +36,7 @@ scene.add( light );
 </code>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:Integer skyColor], [page:Integer groundColor], [page:Float intensity] )</h3>
+		<h3>[name]( [param:Integer skyColor], [param:Integer groundColor], [param:Float intensity] )</h3>
     <div>
 		[page:Integer skyColor] - (optional) hexadecimal color of the sky. Default is 0xffffff.<br />
 		[page:Integer groundColor] - (optional) hexadecimal color of the ground. Default is 0xffffff.<br />

--- a/docs/api/lights/Light.html
+++ b/docs/api/lights/Light.html
@@ -61,13 +61,13 @@
 		</div>
 
 
-		<h3>[method:Light copy]( [page:Light source] )</h3>
+		<h3>[method:Light copy]( [param:Light source] )</h3>
 		<div>
 		Copies the value of [page:.color color] and [page:.intensity intensity] from the
 		[page:Light source] light into this one.
 		</div>
 
-		<h3>[method:JSON toJSON]( [page:String meta] )</h3>
+		<h3>[method:JSON toJSON]( [param:String meta] )</h3>
 		<div>
 		Return Light data in JSON format.
 		</div>

--- a/docs/api/lights/Light.html
+++ b/docs/api/lights/Light.html
@@ -21,7 +21,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Integer color], [page:float intensity] )</h3>
+		<h3>[name]( [param:Integer color], [param:float intensity] )</h3>
 		<div>
 		[page:Integer color] - (optional) hexadecimal color of the light. Default is 0xffffff (white).<br />
 		[page:Float intensity] - (optional) numeric value of the light's strength/intensity. Default is 1.<br /><br />

--- a/docs/api/lights/PointLight.html
+++ b/docs/api/lights/PointLight.html
@@ -41,7 +41,7 @@ scene.add( light );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Integer color], [page:Float intensity], [page:Number distance], [page:Float decay] )</h3>
+		<h3>[name]( [param:Integer color], [param:Float intensity], [param:Number distance], [param:Float decay] )</h3>
 		<div>
 			[page:Integer color] - (optional) hexadecimal color of the light. Default is 0xffffff (white).<br />
 			[page:Float intensity] - (optional) numeric value of the light's strength/intensity. Default is 1.<br /><br />

--- a/docs/api/lights/PointLight.html
+++ b/docs/api/lights/PointLight.html
@@ -106,7 +106,7 @@ scene.add( light );
 			See the base [page:Light Light] class for common methods.
 		</div>
 
-		<h3>[method:PointLight copy]( [page:PointLight source] )</h3>
+		<h3>[method:PointLight copy]( [param:PointLight source] )</h3>
 		<div>
 		Copies value of all the properties from the [page:PointLight source] to this
 		PointLight.

--- a/docs/api/lights/RectAreaLight.html
+++ b/docs/api/lights/RectAreaLight.html
@@ -72,7 +72,7 @@ scene.add( rectLightHelper );
 		</div>
 
 
-		<h3>[method:RectAreaLight copy]( [page:RectAreaLight source] )</h3>
+		<h3>[method:RectAreaLight copy]( [param:RectAreaLight source] )</h3>
 		<div>
 		Copies value of all the properties from the [page:RectAreaLight source] to this
 		RectAreaLight.

--- a/docs/api/lights/RectAreaLight.html
+++ b/docs/api/lights/RectAreaLight.html
@@ -44,7 +44,7 @@ scene.add( rectLightHelper );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Integer color], [page:Float intensity], [page:Float width], [page:Float height] )</h3>
+		<h3>[name]( [param:Integer color], [param:Float intensity], [param:Float width], [param:Float height] )</h3>
 		<div>
 			[page:Integer color] - (optional) hexadecimal color of the light. Default is 0xffffff (white).<br />
 			[page:Float intensity] - (optional) the light's intensity, or brightness. Default is 1.<br />

--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -67,7 +67,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Integer color], [page:Float intensity], [page:Float distance], [page:Radians angle], [page:Float penumbra], [page:Float decay] )</h3>
+		<h3>[name]( [param:Integer color], [param:Float intensity], [param:Float distance], [param:Radians angle], [param:Float penumbra], [param:Float decay] )</h3>
 		<div>
 			[page:Integer color] - (optional) hexadecimal color of the light. Default is 0xffffff (white).<br />
 			[page:Float intensity] - (optional) numeric value of the light's strength/intensity. Default is 1.<br /><br />

--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -180,7 +180,7 @@ light.target = targetObject;
 
 		See the base [page:Light Light] class for common methods.
 
-		<h3>[method:SpotLight copy]( [page:SpotLight source] )</h3>
+		<h3>[method:SpotLight copy]( [param:SpotLight source] )</h3>
 		<div>
 		Copies value of all the properties from the [page:SpotLight source] to this
 		SpotLight.

--- a/docs/api/lights/shadows/LightShadow.html
+++ b/docs/api/lights/shadows/LightShadow.html
@@ -60,7 +60,7 @@ scene.add( helper );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Camera camera] )</h3>
+		<h3>[name]( [param:Camera camera] )</h3>
 		<div>
 		[page:Camera camera] - the light's view of the world.<br /><br />
 

--- a/docs/api/lights/shadows/LightShadow.html
+++ b/docs/api/lights/shadows/LightShadow.html
@@ -118,7 +118,7 @@ scene.add( helper );
 
 
 		<h2>Methods</h2>
-		<h3>[method:LightShadow copy]( [page:LightShadow source] )</h3>
+		<h3>[method:LightShadow copy]( [param:LightShadow source] )</h3>
 		<div>
 		Copies value of all the properties from the [page:LightShadow source] to this
 		SpotLight.

--- a/docs/api/lights/shadows/SpotLightShadow.html
+++ b/docs/api/lights/shadows/SpotLightShadow.html
@@ -59,7 +59,7 @@ scene.add( helper );
 
 		<h2>Constructor</h2>
 
-		The constructor creates a [page:PerspectiveCamera PerspectiveCamera] to manage the shadow's view of the world.
+		The constructor creates a [param:PerspectiveCamera PerspectiveCamera] to manage the shadow's view of the world.
 
 		<h2>Properties</h2>
 		See the base [page:LightShadow LightShadow] class for common properties.

--- a/docs/api/lights/shadows/SpotLightShadow.html
+++ b/docs/api/lights/shadows/SpotLightShadow.html
@@ -72,11 +72,11 @@ scene.add( helper );
 
 		 The default is a  [page:PerspectiveCamera] with [page:PerspectiveCamera.near near] clipping plane at 0.5.
 		 The [page:PerspectiveCamera.fov fov] will track the [page:SpotLight.angle angle] property of the owning
-		 [page:SpotLight SpotLight] via the [page:SpotLightShadow.update update] method. Similarly, the 
+		 [page:SpotLight SpotLight] via the [page:SpotLightShadow.update update] method. Similarly, the
 		 [page:PerspectiveCamera.aspect aspect] property will track the aspect of the
-		 [page:LightShadow.mapSize mapSize]. If the [page:SpotLight.distance distance] property of the light is 
+		 [page:LightShadow.mapSize mapSize]. If the [page:SpotLight.distance distance] property of the light is
 		 set, the [page:PerspectiveCamera.far far] clipping plane will track that, otherwise it defaults to 500.
-		 
+
 	 </div>
 
 	 <h3>[property:Boolean isSpotLightShadow]</h3>
@@ -89,7 +89,7 @@ scene.add( helper );
 		<h2>Methods</h2>
 		See the base [page:LightShadow LightShadow] class for common methods.
 
-		<h3>[method:SpotLightShadow update]( [page:SpotLight light] )</h3>
+		<h3>[method:SpotLightShadow update]( [param:SpotLight light] )</h3>
 		<div>
 		Updates the internal perspective [page:.camera camera] based on the passed in [page:SpotLight light].
 		</div>

--- a/docs/api/loaders/AnimationLoader.html
+++ b/docs/api/loaders/AnimationLoader.html
@@ -61,7 +61,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -72,7 +72,7 @@
 		Begin loading from url and pass the loaded animation to onLoad.
 		</div>
 
-		<h3>[method:null parse]( [page:JSON json], [page:Function onLoad] )</h3>
+		<h3>[method:null parse]( [param:JSON json], [param:Function onLoad] )</h3>
 		<div>
 		[page:JSON json] — required<br />
 		[page:Function onLoad] — Will be called when parsing completes. <br /><br />

--- a/docs/api/loaders/AnimationLoader.html
+++ b/docs/api/loaders/AnimationLoader.html
@@ -45,7 +45,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />
 

--- a/docs/api/loaders/AudioLoader.html
+++ b/docs/api/loaders/AudioLoader.html
@@ -62,7 +62,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:String context], [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:String context], [param:LoadingManager manager] )</h3>
 		<div>
 		[page:String context] — The [page:String AudioContext] for the loader to use. Default is [page:String window.AudioContext].<br />
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />

--- a/docs/api/loaders/AudioLoader.html
+++ b/docs/api/loaders/AudioLoader.html
@@ -80,7 +80,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/loaders/BufferGeometryLoader.html
+++ b/docs/api/loaders/BufferGeometryLoader.html
@@ -49,7 +49,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/api/loaders/BufferGeometryLoader.html
+++ b/docs/api/loaders/BufferGeometryLoader.html
@@ -67,7 +67,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].d<br />
@@ -79,7 +79,7 @@
 		Begin loading from url and call onLoad with the parsed response content.
 		</div>
 
-		<h3>[method:BufferGeometry parse]( [page:Object json] )</h3>
+		<h3>[method:BufferGeometry parse]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — The <em>JSON</em> structure to parse.<br /><br />
 		Parse a <em>JSON</em> structure and return a [page:BufferGeometry].

--- a/docs/api/loaders/Cache.html
+++ b/docs/api/loaders/Cache.html
@@ -41,7 +41,7 @@ THREE.Cache.enabled = true.
 
 		<h2>Methods</h2>
 
-		<h3>[method:null add]( [page:String key], file )</h3>
+		<h3>[method:null add]( [param:String key], file )</h3>
 		<div>
 		[page:String key] — the [page:String key] to reference the cached file by.<br />
 		[page:Object file] — The file to be cached.<br /><br />
@@ -50,14 +50,14 @@ THREE.Cache.enabled = true.
 		it is overwritten.
 		</div>
 
-		<h3>[method:null get]( [page:String key] )</h3>
+		<h3>[method:null get]( [param:String key] )</h3>
 		<div>
 		[page:String key] — A string key <br /><br />
 
 		Get the value of [page:String key]. If the key does not exist *undefined* is returned.
 		</div>
 
-		<h3>[method:null remove]( [page:String key] )</h3>
+		<h3>[method:null remove]( [param:String key] )</h3>
 		<div>
 		[page:String key] — A string key that references a cached file.<br /><br />
 

--- a/docs/api/loaders/CompressedTextureLoader.html
+++ b/docs/api/loaders/CompressedTextureLoader.html
@@ -48,7 +48,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -60,7 +60,7 @@
 		Begin loading from url and pass the loaded texture to onLoad.
 		</div>
 
-		<h3>[method:FileLoader setPath]( [page:String path] )</h3>
+		<h3>[method:FileLoader setPath]( [param:String path] )</h3>
 		<div>
 			Set the base path or URL from which to load files. This can be useful if
 			you are loading many textures from the same directory.

--- a/docs/api/loaders/CompressedTextureLoader.html
+++ b/docs/api/loaders/CompressedTextureLoader.html
@@ -25,7 +25,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use.
 		Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />

--- a/docs/api/loaders/CubeTextureLoader.html
+++ b/docs/api/loaders/CubeTextureLoader.html
@@ -71,7 +71,7 @@ scene.background = new THREE.CubeTextureLoader()
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String urls], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String urls], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String urls] — array of 6 urls to images, one for each side of the CubeTexture.
 		The urls should be specified in the following order: pos-x, neg-x, pos-y, neg-y, pos-z, neg-z.
@@ -87,10 +87,10 @@ scene.background = new THREE.CubeTextureLoader()
 		Begin loading from url and pass the loaded [page:Texture texture] to onLoad.
 		</div>
 
-		<h3>[method:null setCrossOrigin]( [page:String value] )</h3>
+		<h3>[method:null setCrossOrigin]( [param:String value] )</h3>
 		<div>		Set the [page:.crossOrigin] attribute.</div>
 
-		<h3>[method:FileLoader setPath]( [page:String path] )</h3>
+		<h3>[method:FileLoader setPath]( [param:String path] )</h3>
 		<div>
 			Set the base path or URL from which to load files. This can be useful if
 			you are loading many textures from the same directory.

--- a/docs/api/loaders/CubeTextureLoader.html
+++ b/docs/api/loaders/CubeTextureLoader.html
@@ -42,7 +42,7 @@ scene.background = new THREE.CubeTextureLoader()
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />
 

--- a/docs/api/loaders/DataTextureLoader.html
+++ b/docs/api/loaders/DataTextureLoader.html
@@ -44,7 +44,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/loaders/DataTextureLoader.html
+++ b/docs/api/loaders/DataTextureLoader.html
@@ -25,7 +25,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use.
 		Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />

--- a/docs/api/loaders/FileLoader.html
+++ b/docs/api/loaders/FileLoader.html
@@ -95,7 +95,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -107,19 +107,19 @@
 		Load the URL and pass the response to the onLoad function.
 		</div>
 
-		<h3>[method:FileLoader setMimeType]( [page:String mimeType] )</h3>
+		<h3>[method:FileLoader setMimeType]( [param:String mimeType] )</h3>
 		<div>
 			Set the expected [link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types mimeType]
 			of the file being loaded. Note that in many cases this will be determined automatically, so by default it is *undefined*.
 		</div>
 
-		<h3>[method:FileLoader setPath]( [page:String path] )</h3>
+		<h3>[method:FileLoader setPath]( [param:String path] )</h3>
 		<div>
 			Set the base path or URL from which to load files. This can be useful if
 			you are loading many models from the same directory.
 		</div>
 
-		<h3>[method:FileLoader setResponseType]( [page:String responseType] )</h3>
+		<h3>[method:FileLoader setResponseType]( [param:String responseType] )</h3>
 		<div>
 		[page:String responseType] — Default is '' (empty string).<br /><br />
 
@@ -132,7 +132,7 @@
 
 		</div>
 
-		<h3>[method:FileLoader setWithCredentials]( [page:Boolean value] )</h3>
+		<h3>[method:FileLoader setWithCredentials]( [param:Boolean value] )</h3>
 		Whether the XMLHttpRequest uses credentials such as cookies, authorization headers or
 		TLS client certificates. See
 		[link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials XMLHttpRequest.withCredentials].<br />

--- a/docs/api/loaders/FileLoader.html
+++ b/docs/api/loaders/FileLoader.html
@@ -49,7 +49,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use.
 		Default is [page:DefaultLoadingManager].

--- a/docs/api/loaders/FontLoader.html
+++ b/docs/api/loaders/FontLoader.html
@@ -69,7 +69,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -80,13 +80,13 @@
 		Begin loading from url and pass the loaded [page:Texture texture] to onLoad.
 		</div>
 
-		<h3>[method:Font parse]( [page:Object json] )</h3>
+		<h3>[method:Font parse]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — The <em>JSON</em> structure to parse.<br /><br />
 		Parse a <em>JSON</em> structure and return a [page:Font].
 		</div>
 
-		<h3>[method:FontLoader setPath]( [page:String path] )</h3>
+		<h3>[method:FontLoader setPath]( [param:String path] )</h3>
 		<div>
 			Set the base path or URL from which to load fonts. This can be useful if
 			you are loading many fonts from the same directory.

--- a/docs/api/loaders/FontLoader.html
+++ b/docs/api/loaders/FontLoader.html
@@ -51,7 +51,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />
 		Creates a new [name].

--- a/docs/api/loaders/ImageBitmapLoader.html
+++ b/docs/api/loaders/ImageBitmapLoader.html
@@ -71,7 +71,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -86,12 +86,12 @@
 		<h3>[method:ImageBitmapLoader setCrossOrigin]()</h3>
 		<div>This method exists for compatibility reasons and implements no logic. It ensures that [name] has a similar interface like [page:ImageLoader].</div>
 
-		<h3>[method:ImageBitmapLoader setOptions]( [page:Object options] )</h3>
+		<h3>[method:ImageBitmapLoader setOptions]( [param:Object options] )</h3>
 		<div>
 			Sets the options object for [link:https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap createImageBitmap].
 		</div>
 
-		<h3>[method:ImageBitmapLoader setPath]( [page:String path] )</h3>
+		<h3>[method:ImageBitmapLoader setPath]( [param:String path] )</h3>
 		<div>
 			Sets the base path or URL from which to load files. This can be useful if
 			you are loading many images from the same directory.

--- a/docs/api/loaders/ImageBitmapLoader.html
+++ b/docs/api/loaders/ImageBitmapLoader.html
@@ -49,7 +49,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />
 

--- a/docs/api/loaders/ImageLoader.html
+++ b/docs/api/loaders/ImageLoader.html
@@ -80,7 +80,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -92,10 +92,10 @@
 		Begin loading from url and return the [page:Image image] object that will contain the data.
 		</div>
 
-		<h3>[method:null setCrossOrigin]( [page:String value] )</h3>
+		<h3>[method:null setCrossOrigin]( [param:String value] )</h3>
 		<div>Set the [page:.crossOrigin] attribute.</div>
 
-		<h3>[method:FileLoader setPath]( [page:String path] )</h3>
+		<h3>[method:FileLoader setPath]( [param:String path] )</h3>
 		<div>
 			Set the base path or URL from which to load files. This can be useful if
 			you are loading many images from the same directory.

--- a/docs/api/loaders/ImageLoader.html
+++ b/docs/api/loaders/ImageLoader.html
@@ -55,7 +55,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />
 

--- a/docs/api/loaders/JSONLoader.html
+++ b/docs/api/loaders/JSONLoader.html
@@ -52,7 +52,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/api/loaders/JSONLoader.html
+++ b/docs/api/loaders/JSONLoader.html
@@ -75,7 +75,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI]..<br />
@@ -87,13 +87,13 @@
 		Begin loading from url and pass the <em>JSON</em> to onLoad.
 		</div>
 
-		<h3>[method:null setTexturePath]( [page:String texturePath] )</h3>
+		<h3>[method:null setTexturePath]( [param:String texturePath] )</h3>
 		<div>
 			Set the base path or URL from which to load files. This can be useful if
 			you are loading many files from the same directory.
 		</div>
 
-		<h3>[method:Object3D parse]( [page:Object json], [page:String texturePath] )</h3>
+		<h3>[method:Object3D parse]( [param:Object json], [param:String texturePath] )</h3>
 		<div>
 		[page:String json] — JSON object to parse.<br />
 		[page:String texturePath] — Base path for textures.<br /><br />

--- a/docs/api/loaders/Loader.html
+++ b/docs/api/loaders/Loader.html
@@ -43,7 +43,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Material createMaterial]( [page:object m], [page:string texturePath] )</h3>
+		<h3>[method:Material createMaterial]( [param:object m], [param:string texturePath] )</h3>
 		<div>
 		[page:Object m] — The parameters to create the material. <br />
 		[page:String texturePath] — The base path of the textures.
@@ -52,7 +52,7 @@
 		Creates the Material based on the parameters m.
 		</div>
 
-		<h3>[method:Array initMaterials]( [page:Array materials], [page:string texturePath] )</h3>
+		<h3>[method:Array initMaterials]( [param:Array materials], [param:string texturePath] )</h3>
 		<div>
 		[page:Array materials] — an array of parameters to create materials. <br />
 		[page:String texturePath] —  The base path of the textures.

--- a/docs/api/loaders/LoaderUtils.html
+++ b/docs/api/loaders/LoaderUtils.html
@@ -14,7 +14,7 @@
 
 		<h2>Functions</h2>
 
-		<h3>[method:String decodeText]( [page:TypedArray array] )</h3>
+		<h3>[method:String decodeText]( [param:TypedArray array] )</h3>
 		<div>
 		[page:TypedArray array] —  A stream of bytes as a typed array.
 		</div>
@@ -22,7 +22,7 @@
 		The function takes a stream of bytes as input and returns a string representation.
 		</div>
 
-		<h3>[method:String extractUrlBase]( [page:string url] )</h3>
+		<h3>[method:String extractUrlBase]( [param:string url] )</h3>
 		<div>
 		[page:String url] —  The url to extract the base url from.
 		</div>

--- a/docs/api/loaders/MaterialLoader.html
+++ b/docs/api/loaders/MaterialLoader.html
@@ -47,7 +47,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />
 		Creates a new [name].

--- a/docs/api/loaders/MaterialLoader.html
+++ b/docs/api/loaders/MaterialLoader.html
@@ -66,7 +66,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -77,14 +77,14 @@
 		Begin loading from url and return the [page:Material] object that will contain the data.
 		</div>
 
-		<h3>[method:Material parse]( [page:Object json] )</h3>
+		<h3>[method:Material parse]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — The json object containing the parameters of the Material.<br /><br />
 
 		Parse a <em>JSON</em> structure and create a new [page:Material] of the type [page:String json.type] with parameters defined in the json object.
 		</div>
 
-		<h3>[method:null setTextures]( [page:Object textures] )</h3>
+		<h3>[method:null setTextures]( [param:Object textures] )</h3>
 		<div>
 		[page:Object textures] — object containing any textures used by the material.
 		</div>

--- a/docs/api/loaders/ObjectLoader.html
+++ b/docs/api/loaders/ObjectLoader.html
@@ -94,7 +94,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -107,7 +107,7 @@
 		</div>
 
 
-		<h3>[method:Object3D parse]( [page:Object json], [page:Function onLoad]  )</h3>
+		<h3>[method:Object3D parse]( [param:Object json], [param:Function onLoad]  )</h3>
 		<div>
 		[page:Object json] — required. The JSON source to parse.<br /><br />
 		[page:Function onLoad] — Will be called when parsed completes. The argument will be the parsed [page:Object3D object].<br />
@@ -117,7 +117,7 @@
 		a previously loaded JSON structure.
 		</div>
 
-		<h3>[method:Object3D parseGeometries]( [page:Object json] )</h3>
+		<h3>[method:Object3D parseGeometries]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — required. The JSON source to parse.<br /><br />
 
@@ -125,35 +125,35 @@
 		Internally it uses [page:JSONLoader] for geometries and [page:BufferGeometryLoader] for buffer geometries.
 		</div>
 
-		<h3>[method:Object3D parseMaterials]( [page:Object json] )</h3>
+		<h3>[method:Object3D parseMaterials]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — required. The JSON source to parse.<br /><br />
 
 		This is used [page:.parse] to parse any materials in the JSON structure using [page:MaterialLoader].
 		</div>
 
-		<h3>[method:Object3D parseAnimations]( [page:Object json] )</h3>
+		<h3>[method:Object3D parseAnimations]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — required. The JSON source to parse.<br /><br />
 
 		This is used [page:.parse] to parse any animations in the JSON structure, using [page:AnimationClip.parse].
 		</div>
 
-		<h3>[method:Object3D parseImages]( [page:Object json] )</h3>
+		<h3>[method:Object3D parseImages]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — required. The JSON source to parse.<br /><br />
 
 		This is used [page:.parse] to parse any images in the JSON structure, using [page:ImageLoader].
 		</div>
 
-		<h3>[method:Object3D parseTextures]( [page:Object json] )</h3>
+		<h3>[method:Object3D parseTextures]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — required. The JSON source to parse.<br /><br />
 
 		This is used [page:.parse] to parse any textures in the JSON structure.
 		</div>
 
-		<h3>[method:Object3D parseObject]( [page:Object json] )</h3>
+		<h3>[method:Object3D parseObject]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — required. The JSON source to parse.<br /><br />
 
@@ -213,12 +213,12 @@
 		</ul>
 		</div>
 
-		<h3>[method:null setCrossOrigin]( [page:String value] )</h3>
+		<h3>[method:null setCrossOrigin]( [param:String value] )</h3>
 		<div>
 		[page:String value] — The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS.
 		</div>
 
-		<h3>[method:null setTexturePath]( [page:String value] )</h3>
+		<h3>[method:null setTexturePath]( [param:String value] )</h3>
 		<div>
 		[page:String value] — The base path or URL from which textures will be loaded.<br /><br />
 

--- a/docs/api/loaders/ObjectLoader.html
+++ b/docs/api/loaders/ObjectLoader.html
@@ -64,7 +64,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />
 

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -93,7 +93,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Texture load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:Texture load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -105,16 +105,16 @@
 		If you do it this way, the texture may pop up in your scene once the respective loading process is finished.
 		</div>
 
-		<h3>[method:null setCrossOrigin]( [page:String value] )</h3>
+		<h3>[method:null setCrossOrigin]( [param:String value] )</h3>
 		<div>Set the [page:.crossOrigin] attribute.</div>
 
-		<h3>[method:FileLoader setPath]( [page:String path] )</h3>
+		<h3>[method:FileLoader setPath]( [param:String path] )</h3>
 		<div>
 			Set the base path or URL from which to load files. This can be useful if
 			you are loading many models from the same directory.
 		</div>
 
-		<h3>[method:FileLoader setWithCredentials]( [page:Boolean value] )</h3>
+		<h3>[method:FileLoader setWithCredentials]( [param:Boolean value] )</h3>
 		Whether the XMLHttpRequest uses credentials such as cookies, authorization headers or
 		TLS client certificates. See
 		[link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials XMLHttpRequest.withCredentials].<br />

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -59,7 +59,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br /><br />
 

--- a/docs/api/loaders/managers/LoadingManager.html
+++ b/docs/api/loaders/managers/LoadingManager.html
@@ -160,7 +160,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setURLModifier]( [page:Function callback] )</h3>
+		<h3>[method:null setURLModifier]( [param:Function callback] )</h3>
 		<div>
 		[page:Function callback] — URL modifier callback. Called with [page:String url] argument, and
 		must return [page:String resolvedURL].<br /><br />
@@ -170,7 +170,7 @@
 		behavior can be used to load assets from .ZIP files, drag-and-drop APIs, and Data URIs.
 		</div>
 
-		<h3>[method:String resolveURL]( [page:String url] )</h3>
+		<h3>[method:String resolveURL]( [param:String url] )</h3>
 		<div>
 		[page:String url] — the url to load<br /><br />
 
@@ -184,14 +184,14 @@
 			them directly.</em>
 		</div>
 
-		<h3>[method:null itemStart]( [page:String url] )</h3>
+		<h3>[method:null itemStart]( [param:String url] )</h3>
 		<div>
 		[page:String url] — the url to load<br /><br />
 
 		This should be called by any loader using the manager when the loader starts loading an url.
 		</div>
 
-		<h3>[method:null itemEnd]( [page:String url] )</h3>
+		<h3>[method:null itemEnd]( [param:String url] )</h3>
 		<div>
 		[page:String url] — the loaded url<br /><br />
 
@@ -199,7 +199,7 @@
 		</div>
 
 
-		<h3>[method:null itemError]( [page:String url] )</h3>
+		<h3>[method:null itemError]( [param:String url] )</h3>
 		<div>
 		[page:String url] — the loaded url<br /><br />
 

--- a/docs/api/loaders/managers/LoadingManager.html
+++ b/docs/api/loaders/managers/LoadingManager.html
@@ -109,7 +109,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[name]( [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:Function onLoad] — (optional) this function will be called when all loaders are done.<br />
 		[page:Function onProgress] — (optional) this function will be called when an item is complete.<br />

--- a/docs/api/materials/LineBasicMaterial.html
+++ b/docs/api/materials/LineBasicMaterial.html
@@ -46,7 +46,7 @@ var material = new THREE.LineBasicMaterial( {
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 
 		<div>
 		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.

--- a/docs/api/materials/LineDashedMaterial.html
+++ b/docs/api/materials/LineDashedMaterial.html
@@ -34,7 +34,7 @@ var material = new THREE.LineDashedMaterial( {
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 		Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 

--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -107,17 +107,17 @@
 		(b) using a displacement map, (c) using an alpha map with alphaTest, or (d) using a transparent texture with alphaTest,
 		you must specify a customDepthMaterial for proper shadows. Default is *undefined*.
 		</div>
-		
+
 		<h3>[property:Material customDistanceMaterial]</h3>
 		<div>
 		Same as customDepthMaterial, but used with [page:PointLight]. Default is *undefined*.
 		</div>
-		
+
 		<h3>[property:Object defines]</h3>
 		<div>
 		Custom defines to be injected into the shader. These are passed in form of an object literal, with key/value pairs. { MY_CUSTOM_DEFINE: '' , PI2: Math.PI * 2 }. The pairs are defined in both vertex and fragment shaders.  Default is *undefined*.
 		</div>
-		
+
 		<h3>[property:Integer depthFunc]</h3>
 		<div>
 		Which depth function to use. Default is [page:Materials LessEqualDepth]. See the depth mode [page:Materials constants] for all possible values.
@@ -285,7 +285,7 @@
 		<div>
 		Defines whether this material is visible. Default is *true*.
 		</div>
-		
+
 		<h3>[property:object userData]</h3>
 		<div>
 		An object that can be used to store custom data about the Material. It should not hold
@@ -299,7 +299,7 @@
 		<h3>[method:Material clone]( )</h3>
 		<div>Return a new material with the same parameters as this material.</div>
 
-		<h3>[method:Material copy]( [page:material material] )</h3>
+		<h3>[method:Material copy]( [param:material material] )</h3>
 		<div>Copy the parameters from the passed material into this material.</div>
 
 		<h3>[method:null dispose]()</h3>
@@ -308,13 +308,13 @@
 		These needs to be disposed by [page:Texture Texture].
 		</div>
 
-		<h3>[method:null setValues]( [page:object values] )</h3>
+		<h3>[method:null setValues]( [param:object values] )</h3>
 		<div>
 		values -- a container with parameters.<br />
 		Sets the properties based on the *values*.
 		</div>
 
-		<h3>[method:null toJSON]( [page:object meta] )</h3>
+		<h3>[method:null toJSON]( [param:object meta] )</h3>
 		<div>
 		meta -- object containing metadata such as textures or images for the material.<br />
 		Convert the material to three.js JSON format.
@@ -322,7 +322,7 @@
 
 		<h3>[method:null update]()</h3>
 		<div>
-		Call [method:null dispatchEvent]( { type: '[page:object update]' }) on the material.
+		Call [method:null dispatchEvent]( { type: '[param:object update]' }) on the material.
 		</div>
 
 		<h2>Source</h2>

--- a/docs/api/materials/MeshBasicMaterial.html
+++ b/docs/api/materials/MeshBasicMaterial.html
@@ -39,7 +39,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
@@ -63,7 +63,7 @@
 		</div>
 
 		<h3>[property:Texture aoMap]</h3>
-		<div>The red channel of this texture is used as the ambient occlusion map. Default is null. 
+		<div>The red channel of this texture is used as the ambient occlusion map. Default is null.
 		The aoMap requires a second set of UVs, and consequently will ignore the [page:Texture repeat]
 		and [page:Texture offset] Texture properties.</div>
 
@@ -93,8 +93,8 @@
 		<div>The environment map. Default is null.</div>
 
 		<h3>[property:Texture lightMap]</h3>
-		<div>The light map. Default is null. The lightMap requires a second set of UVs, 
-		and consequently will ignore the [page:Texture repeat] and [page:Texture offset] 
+		<div>The light map. Default is null. The lightMap requires a second set of UVs,
+		and consequently will ignore the [page:Texture repeat] and [page:Texture offset]
 		Texture properties.</div>
 
 		<h3>[property:Float lightMapIntensity]</h3>
@@ -112,7 +112,7 @@
 
 		<h3>[property:Float reflectivity]</h3>
 		<div>
-			How much the environment map affects the surface; also see [page:.combine]. 
+			How much the environment map affects the surface; also see [page:.combine].
 			The default value is 1 and the valid range is between 0 (no reflections) and 1 (full reflections).
 		</div>
 

--- a/docs/api/materials/MeshDepthMaterial.html
+++ b/docs/api/materials/MeshDepthMaterial.html
@@ -34,7 +34,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.

--- a/docs/api/materials/MeshLambertMaterial.html
+++ b/docs/api/materials/MeshLambertMaterial.html
@@ -50,7 +50,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
@@ -74,7 +74,7 @@
 		</div>
 
 		<h3>[property:Texture aoMap]</h3>
-		<div>The red channel of this texture is used as the ambient occlusion map. Default is null. 
+		<div>The red channel of this texture is used as the ambient occlusion map. Default is null.
 		The aoMap requires a second set of UVs, and consequently will ignore the [page:Texture repeat]
 		and [page:Texture offset] Texture properties.</div>
 
@@ -120,8 +120,8 @@
 		</div>
 
 		<h3>[property:Texture lightMap]</h3>
-		<div>The light map. Default is null. The lightMap requires a second set of UVs, 
-		and consequently will ignore the [page:Texture repeat] and [page:Texture offset] 
+		<div>The light map. Default is null. The lightMap requires a second set of UVs,
+		and consequently will ignore the [page:Texture repeat] and [page:Texture offset]
 		Texture properties.</div>
 
 		<h3>[property:Float lightMapIntensity]</h3>

--- a/docs/api/materials/MeshNormalMaterial.html
+++ b/docs/api/materials/MeshNormalMaterial.html
@@ -34,7 +34,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.

--- a/docs/api/materials/MeshPhongMaterial.html
+++ b/docs/api/materials/MeshPhongMaterial.html
@@ -49,7 +49,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
@@ -73,7 +73,7 @@
 		</div>
 
 		<h3>[property:Texture aoMap]</h3>
-		<div>The red channel of this texture is used as the ambient occlusion map. Default is null. 
+		<div>The red channel of this texture is used as the ambient occlusion map. Default is null.
 		The aoMap requires a second set of UVs, and consequently will ignore the [page:Texture repeat]
 		and [page:Texture offset] Texture properties.</div>
 
@@ -153,8 +153,8 @@
 
 
 		<h3>[property:Texture lightMap]</h3>
-		<div>The light map. Default is null. The lightMap requires a second set of UVs, 
-		and consequently will ignore the [page:Texture repeat] and [page:Texture offset] 
+		<div>The light map. Default is null. The lightMap requires a second set of UVs,
+		and consequently will ignore the [page:Texture repeat] and [page:Texture offset]
 		Texture properties.</div>
 
 		<h3>[property:Float lightMapIntensity]</h3>
@@ -187,7 +187,7 @@
 
 		<h3>[property:Float reflectivity]</h3>
 		<div>
-			How much the environment map affects the surface; also see [page:.combine]. 
+			How much the environment map affects the surface; also see [page:.combine].
 			The default value is 1 and the valid range is between 0 (no reflections) and 1 (full reflections).
 		</div>
 

--- a/docs/api/materials/MeshPhysicalMaterial.html
+++ b/docs/api/materials/MeshPhysicalMaterial.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 		Any property of the material (including any property inherited from [page:Material] and [page:MeshStandardMaterial]) can be passed in here.<br /><br />

--- a/docs/api/materials/MeshStandardMaterial.html
+++ b/docs/api/materials/MeshStandardMaterial.html
@@ -73,7 +73,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
@@ -97,7 +97,7 @@
 		</div>
 
 		<h3>[property:Texture aoMap]</h3>
-		<div>The red channel of this texture is used as the ambient occlusion map. Default is null. 
+		<div>The red channel of this texture is used as the ambient occlusion map. Default is null.
 		The aoMap requires a second set of UVs, and consequently will ignore the [page:Texture repeat]
 		and [page:Texture offset] Texture properties.</div>
 
@@ -166,10 +166,10 @@
 		<div>Intensity of the emissive light. Modulates the emissive color. Default is 1.</div>
 
 		<h3>[property:TextureCube envMap]</h3>
-		<div>The environment map. Default is null.  Note that in order for the material roughness 
-		property to correctly blur out the environment map, the shader must have access to mipmaps 
-		of the env texture.  TextureCubes created with default settings are correctly configured; 
-		if adjusting texture parameters manually, ensure minFilter is set to one of the MipMap options, 
+		<div>The environment map. Default is null.  Note that in order for the material roughness
+		property to correctly blur out the environment map, the shader must have access to mipmaps
+		of the env texture.  TextureCubes created with default settings are correctly configured;
+		if adjusting texture parameters manually, ensure minFilter is set to one of the MipMap options,
 		and that mip maps have not been otherwise forcibly disabled.</div>
 
 		<h3>[property:Float envMapIntensity]</h3>
@@ -184,8 +184,8 @@
 
 
 		<h3>[property:Texture lightMap]</h3>
-		<div>The light map. Default is null. The lightMap requires a second set of UVs, 
-		and consequently will ignore the [page:Texture repeat] and [page:Texture offset] 
+		<div>The light map. Default is null. The lightMap requires a second set of UVs,
+		and consequently will ignore the [page:Texture repeat] and [page:Texture offset]
 		Texture properties.</div>
 
 		<h3>[property:Float lightMapIntensity]</h3>

--- a/docs/api/materials/MeshToonMaterial.html
+++ b/docs/api/materials/MeshToonMaterial.html
@@ -37,7 +37,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 		Any property of the material (including any property inherited from [page:Material] and [page:MeshStandardMaterial]) can be passed in here.<br /><br />

--- a/docs/api/materials/RawShaderMaterial.html
+++ b/docs/api/materials/RawShaderMaterial.html
@@ -42,7 +42,7 @@ var material = new THREE.RawShaderMaterial( {
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 			Any property of the material (including any property inherited from [page:Material] and [page:ShaderMaterial]) can be passed in here.<br /><br />

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -269,7 +269,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.

--- a/docs/api/materials/ShaderMaterial.html
+++ b/docs/api/materials/ShaderMaterial.html
@@ -452,7 +452,7 @@ this.extensions = {
 		<h2>Methods</h2>
 		<div>See the base [page:Material] class for common methods.</div>
 
-		<h3>[method:ShaderMaterial clone]() [page:ShaderMaterial this]</h3>
+		<h3>[method:ShaderMaterial clone]() [param:ShaderMaterial this]</h3>
 		<div>
 		Generates a shallow copy of this material. Note that the vertexShader and fragmentShader
 		are copied <em>by reference</em>, as are the definitions of the *attributes*; this means

--- a/docs/api/materials/ShadowMaterial.html
+++ b/docs/api/materials/ShadowMaterial.html
@@ -34,7 +34,7 @@ scene.add( plane );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
 			Any property of the material (including any property inherited from [page:Material] and [page:ShaderMaterial]) can be passed in here.<br /><br />

--- a/docs/api/math/Box2.html
+++ b/docs/api/math/Box2.html
@@ -50,7 +50,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector2 clampPoint]( [page:Vector2 point], [page:Vector2 optionalTarget] )</h3>
+		<h3>[method:Vector2 clampPoint]( [param:Vector2 point], [param:Vector2 optionalTarget] )</h3>
 		<div>
 		[page:Vector2 point] - [page:Vector2] to clamp. <br>
 		[page:Vector2 optionalTarget] — (optional) if specified, the result will be copied into this Vector2,
@@ -62,7 +62,7 @@
 		<h3>[method:Box2 clone]()</h3>
 		<div>Returns a new [page:Box2] with the same [page:.min min] and [page:.max max] as this one.</div>
 
-		<h3>[method:Boolean containsBox]( [page:Box2 box] )</h3>
+		<h3>[method:Boolean containsBox]( [param:Box2 box] )</h3>
 		<div>
 		[page:Box2 box] - [page:Box2 Box2] to test for inclusion.<br /><br />
 
@@ -70,19 +70,19 @@
 		this function also returns true.
 		</div>
 
-		<h3>[method:Boolean containsPoint]( [page:Vector2 point] )</h3>
+		<h3>[method:Boolean containsPoint]( [param:Vector2 point] )</h3>
 		<div>
 		[page:Vector2 point] - [page:Vector2] to check for inclusion.<br /><br />
 
 		Returns true if the specified [page:Vector2 point] lies within or on the boundaries of this box.
 		</div>
 
-		<h3>[method:Box2 copy]( [page:Box2 box] )</h3>
+		<h3>[method:Box2 copy]( [param:Box2 box] )</h3>
 		<div>
 		Copies the [page:.min min] and [page:.max max] from [page:Box2 box] to this box.
 		</div>
 
-		<h3>[method:Float distanceToPoint]( [page:Vector2 point] )</h3>
+		<h3>[method:Float distanceToPoint]( [param:Vector2 point] )</h3>
 		<div>
 		[page:Vector2 point] - [page:Vector2] to measure distance to.<br /><br />
 
@@ -90,21 +90,21 @@
 		If the [page:Vector2 point] lies inside of this box, the distance will be 0.
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Box2 box] )</h3>
+		<h3>[method:Boolean equals]( [param:Box2 box] )</h3>
 		<div>
 		[page:Box2 box] - Box to compare with this one.<br /><br />
 
 		Returns true if this box and [page:Box2 box] share the same lower and upper bounds.
 		</div>
 
-		<h3>[method:Box2 expandByPoint]( [page:Vector2 point] )</h3>
+		<h3>[method:Box2 expandByPoint]( [param:Vector2 point] )</h3>
 		<div>
 		[page:Vector2 point] - [page:Vector2] that should be included in the box.<br /><br />
 
 		Expands the boundaries of this box to include [page:Vector2 point].
 		</div>
 
-		<h3>[method:Box2 expandByScalar]( [page:float scalar] )</h3>
+		<h3>[method:Box2 expandByScalar]( [param:float scalar] )</h3>
 		<div>
 		[page:float scalar] - Distance to expand the box by.<br /><br />
 
@@ -112,7 +112,7 @@
 		will be contracted.
 		</div>
 
-		<h3>[method:Box2 expandByVector]( [page:Vector2 vector] )</h3>
+		<h3>[method:Box2 expandByVector]( [param:Vector2 vector] )</h3>
 		<div>
 		[page:Vector2 vector] - [page:Vector2] to expand the box by.<br /><br />
 
@@ -121,7 +121,7 @@
 		this box will be expanded by the y component of [page:Vector2 vector] in both directions.
 		</div>
 
-		<h3>[method:Vector2 getCenter]( [page:Vector2 optionalTarget] )</h3>
+		<h3>[method:Vector2 getCenter]( [param:Vector2 optionalTarget] )</h3>
 		<div>
 			[page:Vector2 optionalTarget] — (optional) if specified, the result will be copied into this Vector2,
 			otherwise a new Vector2 will be created. <br /><br />
@@ -129,7 +129,7 @@
 		Returns the center point of the box as a [page:Vector2].
 		</div>
 
-		<h3>[method:Vector2 getParameter]( [page:Vector2 point], [page:Vector2 optionalTarget] ) </h3>
+		<h3>[method:Vector2 getParameter]( [param:Vector2 point], [param:Vector2 optionalTarget] ) </h3>
 		<div>
 		[page:Vector2 point] - [page:Vector2].<br/>
 		[page:Vector2 optionalTarget] — (optional) if specified, the result will be copied into this Vector2,
@@ -138,7 +138,7 @@
 		Returns a point as a proportion of this box's width and height.
 		</div>
 
-		<h3>[method:Vector2 getSize]( [page:Vector2 optionalTarget] )</h3>
+		<h3>[method:Vector2 getSize]( [param:Vector2 optionalTarget] )</h3>
 		<div>
 			[page:Vector2 optionalTarget] — (optional) if specified, the result will be copied into this Vector2,
 			otherwise a new Vector2 will be created. <br /><br />
@@ -146,7 +146,7 @@
 		Returns the width and height of this box.
 		</div>
 
-		<h3>[method:Box2 intersect]( [page:Box2 box] )</h3>
+		<h3>[method:Box2 intersect]( [param:Box2 box] )</h3>
 		<div>
 		[page:Box2 box] - Box to intersect with.<br /><br />
 
@@ -155,7 +155,7 @@
 		lower bounds.
 		</div>
 
-		<h3>[method:Boolean intersectsBox]( [page:Box2 box] )</h3>
+		<h3>[method:Boolean intersectsBox]( [param:Box2 box] )</h3>
 		<div>
 		[page:Box2 box] - Box to check for intersection against.<br /><br />
 
@@ -173,7 +173,7 @@
 		<div>Makes this box empty.</div>
 
 
-		<h3>[method:Box2 set]( [page:Vector2 min], [page:Vector2 max] )</h3>
+		<h3>[method:Box2 set]( [param:Vector2 min], [param:Vector2 max] )</h3>
 		<div>
 			[page:Vector2 min] - (required ) [page:Vector2] representing the lower (x, y) boundary of the box. <br>
 			[page:Vector2 max]  - (required) [page:Vector2] representing the lower upper (x, y) boundary of the box. <br /><br />
@@ -181,7 +181,7 @@
 			Sets the lower and upper (x, y) boundaries of this box.
 		</div>
 
-		<h3>[method:Box2 setFromCenterAndSize]( [page:Vector2 center], [page:Vector2 size] )</h3>
+		<h3>[method:Box2 setFromCenterAndSize]( [param:Vector2 center], [param:Vector2 size] )</h3>
 		<div>
 		[page:Vector2 center] - Desired center position of the box ([page:Vector2]). <br>
 		[page:Vector2 size] - Desired x and y dimensions of the box ([page:Vector2]).<br /><br />
@@ -190,14 +190,14 @@
 		in [page:Vector2 size].
 		</div>
 
-		<h3>[method:Box2 setFromPoints]( [page:Array points] )</h3>
+		<h3>[method:Box2 setFromPoints]( [param:Array points] )</h3>
 		<div>
 		[page:Array points] - Array of [page:Vector2 Vector2s] that the resulting box will contain.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the points in [page:Array points].
 		</div>
 
-		<h3>[method:Box2 translate]( [page:Vector2 offset] )</h3>
+		<h3>[method:Box2 translate]( [param:Vector2 offset] )</h3>
 		<div>
 		[page:Vector2 offset] - Direction and distance of offset.<br /><br />
 
@@ -205,7 +205,7 @@
 		[page:Vector2 offset] units in 2D space.
 		</div>
 
-		<h3>[method:Box2 union]( [page:Box2 box] )</h3>
+		<h3>[method:Box2 union]( [param:Box2 box] )</h3>
 		<div>
 		[page:Box2 box] - Box that will be unioned with this box.<br /><br />
 

--- a/docs/api/math/Box2.html
+++ b/docs/api/math/Box2.html
@@ -18,7 +18,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector2 min], [page:Vector2 max] )</h3>
+		<h3>[name]( [param:Vector2 min], [param:Vector2 max] )</h3>
 		<div>
 		[page:Vector2 min] - (optional) [page:Vector2] representing the lower (x, y) boundary of the box.
 		Default is ( + Infinity, + Infinity ).<br>

--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -20,7 +20,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector3 min], [page:Vector3 max] )</h3>
+		<h3>[name]( [param:Vector3 min], [param:Vector3 max] )</h3>
 		[page:Vector3 min] - (optional) [page:Vector3] representing the lower (x, y, z) boundary of the box.
 		Default is ( + Infinity, + Infinity, + Infinity ).<br>
 

--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -55,14 +55,14 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Box3 applyMatrix4]( [page:Matrix4 matrix] )</h3>
+		<h3>[method:Box3 applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<div>
 		[page:Matrix4 matrix] - The [page:Matrix4] to apply<br /><br />
 
 		Transforms this Box3 with the supplied matrix.
 		</div>
 
-		<h3>[method:Vector3 clampPoint]( [page:Vector3 point], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 clampPoint]( [param:Vector3 point], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] to clamp. <br>
 		[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
@@ -74,7 +74,7 @@
 		<h3>[method:Box3 clone]()</h3>
 		<div>Returns a new [page:Box3] with the same [page:.min min] and [page:.max max] as this one.</div>
 
-		<h3>[method:Boolean containsBox]( [page:Box3 box] )</h3>
+		<h3>[method:Boolean containsBox]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - [page:Box3 Box3] to test for inclusion.<br /><br />
 
@@ -82,21 +82,21 @@
 		this function also returns true.
 		</div>
 
-		<h3>[method:Boolean containsPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Boolean containsPoint]( [param:Vector3 point] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] to check for inclusion.<br /><br />
 
 		Returns true if the specified [page:Vector3 point] lies within or on the boundaries of this box.
 		</div>
 
-		<h3>[method:Box3 copy]( [page:Box3 box] )</h3>
+		<h3>[method:Box3 copy]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box]  - [page:Box3] to copy.<br /><br />
 
 		Copies the [page:.min min] and [page:.max max] from [page:Box3 box] to this box.
 		</div>
 
-		<h3>[method:Float distanceToPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] to measure distance to.<br /><br />
 
@@ -105,14 +105,14 @@
 		</div>
 
 
-		<h3>[method:Boolean equals]( [page:Box3 box] )</h3>
+		<h3>[method:Boolean equals]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - Box to compare with this one.<br /><br />
 
 		Returns true if this box and [page:Box3 box] share the same lower and upper bounds.
 		</div>
 
-		<h3>[method:Box3 expandByObject]( [page:Object3D object] )</h3>
+		<h3>[method:Box3 expandByObject]( [param:Object3D object] )</h3>
 		<div>
 		[page:Object3D object] - [page:Object3D] to expand the box by.<br /><br />
 
@@ -121,14 +121,14 @@
 
 		</div>
 
-		<h3>[method:Box3 expandByPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Box3 expandByPoint]( [param:Vector3 point] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] that should be included in the box.<br /><br />
 
 		Expands the boundaries of this box to include [page:Vector3 point].
 		</div>
 
-		<h3>[method:Box3 expandByScalar]( [page:float scalar] )</h3>
+		<h3>[method:Box3 expandByScalar]( [param:float scalar] )</h3>
 		<div>
 		[page:float scalar] - Distance to expand the box by.<br /><br />
 
@@ -136,7 +136,7 @@
 		will be contracted.
 		</div>
 
-		<h3>[method:Box3 expandByVector]( [page:Vector3 vector] )</h3>
+		<h3>[method:Box3 expandByVector]( [param:Vector3 vector] )</h3>
 		<div>
 		[page:Vector3 vector] - [page:Vector3] to expand the box by.<br /><br />
 
@@ -146,7 +146,7 @@
 		The depth of this box will be expanded by the z component of *vector* in both directions.
 		</div>
 
-		<h3>[method:Sphere getBoundingSphere]( [page:Sphere optionalTarget] )</h3>
+		<h3>[method:Sphere getBoundingSphere]( [param:Sphere optionalTarget] )</h3>
 		<div>
 			[page:Sphere optionalTarget] — (optional) if specified, the result will be copied into this Sphere,
 			otherwise a new Sphere will be created. <br /><br />
@@ -154,7 +154,7 @@
 		Gets a [page:Sphere] that bounds the box.
 		</div>
 
-		<h3>[method:Vector3 getCenter]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 getCenter]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 			[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
 			otherwise a new Vector3 will be created. <br /><br />
@@ -162,7 +162,7 @@
 		Returns the center point of the box as a [page:Vector3].
 		</div>
 
-		<h3>[method:Vector3 getParameter]( [page:Vector3 point], [page:Vector3 optionalTarget] ) </h3>
+		<h3>[method:Vector3 getParameter]( [param:Vector3 point], [param:Vector3 optionalTarget] ) </h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3].<br/>
 		[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
@@ -171,7 +171,7 @@
 		Returns a point as a proportion of this box's width and height.
 		</div>
 
-		<h3>[method:Vector3 getSize]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 getSize]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 			[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
 			otherwise a new Vector3 will be created. <br /><br />
@@ -179,7 +179,7 @@
 		Returns the width, height and depth of this box.
 		</div>
 
-		<h3>[method:Box3 intersect]( [page:Box3 box] )</h3>
+		<h3>[method:Box3 intersect]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - Box to intersect with.<br /><br />
 
@@ -188,28 +188,28 @@
 		lower bounds.
 		</div>
 
-		<h3>[method:Boolean intersectsBox]( [page:Box3 box] )</h3>
+		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - Box to check for intersection against.<br /><br />
 
 		Determines whether or not this box intersects [page:Box3 box].
 		</div>
 
-		<h3>[method:Boolean intersectsPlane]( [page:Plane plane] )</h3>
+		<h3>[method:Boolean intersectsPlane]( [param:Plane plane] )</h3>
 		<div>
 		[page:Plane plane] - [page:Plane] to check for intersection against.<br /><br />
 
 		Determines whether or not this box intersects [page:Plane plane].
 		</div>
 
-		<h3>[method:Boolean intersectsSphere]( [page:Sphere sphere] )</h3>
+		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
 		<div>
 		[page:Sphere sphere] - [page:Sphere] to check for intersection against.<br /><br />
 
 		Determines whether or not this box intersects [page:Sphere sphere].
 		</div>
 
-		<h3>[method:Boolean intersectsTriangle]( [page:Triangle triangle] )</h3>
+		<h3>[method:Boolean intersectsTriangle]( [param:Triangle triangle] )</h3>
 		<div>
 		[page:Triangle triangle] - [page:Triangle] to check for intersection against.<br /><br />
 
@@ -226,7 +226,7 @@
 		<h3>[method:Box3 makeEmpty]()</h3>
 		<div>Makes this box empty.</div>
 
-		<h3>[method:Box3 set]( [page:Vector3 min], [page:Vector3 max] )</h3>
+		<h3>[method:Box3 set]( [param:Vector3 min], [param:Vector3 max] )</h3>
 		<div>
 		[page:Vector3 min] - [page:Vector3] representing the lower (x, y, z) boundary of the box.<br />
 		[page:Vector3 max] - [page:Vector3] representing the lower upper (x, y, z) boundary of the box.<br /><br />
@@ -234,21 +234,21 @@
 		Sets the lower and upper (x, y, z) boundaries of this box.
 		</div>
 
-		<h3>[method:Box3 setFromArray]( [page:Array array] ) [page:Box3 this]</h3>
+		<h3>[method:Box3 setFromArray]( [param:Array array] ) [param:Box3 this]</h3>
 		<div>
 		array -- An array of position data that the resulting box will envelop.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the data in *array*.
 		</div>
 
-		<h3>[method:Box3 setFromBufferAttribute]( [page:BufferAttribute attribute] ) [page:Box3 this]</h3>
+		<h3>[method:Box3 setFromBufferAttribute]( [param:BufferAttribute attribute] ) [param:Box3 this]</h3>
 		<div>
 		[page:BufferAttribute attribute] - A buffer attribute of position data that the resulting box will envelop.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the data in [page:BufferAttribute attribute].
 		</div>
 
-		<h3>[method:Box3 setFromCenterAndSize]( [page:Vector3 center], [page:Vector3 size] )</h3>
+		<h3>[method:Box3 setFromCenterAndSize]( [param:Vector3 center], [param:Vector3 size] )</h3>
 		<div>
 		[page:Vector3 center] - Desired center position of the box ([page:Vector3]). <br>
 		[page:Vector3 size] - Desired x, y and z dimensions of the box ([page:Vector3]).<br /><br />
@@ -257,7 +257,7 @@
 		in [page:Vector3 size].
 		</div>
 
-		<h3>[method:Box3 setFromCenterAndSize]( [page:Vector3 center], [page:Vector3 size] ) [page:Box3 this]</h3>
+		<h3>[method:Box3 setFromCenterAndSize]( [param:Vector3 center], [param:Vector3 size] ) [param:Box3 this]</h3>
 		<div>
 		[page:Vector3 center], - Desired center position of the box. <br>
 		[page:Vector3 size] - Desired x, y and z dimensions of the box.<br /><br />
@@ -266,7 +266,7 @@
 		in [page:Vector3 size]
 		</div>
 
-		<h3>[method:Box3 setFromObject]( [page:Object3D object] )</h3>
+		<h3>[method:Box3 setFromObject]( [param:Object3D object] )</h3>
 		<div>
 		[page:Object3D object] - [page:Object3D] to compute the bounding box of.<br /><br />
 
@@ -275,14 +275,14 @@
 
 		</div>
 
-		<h3>[method:Box3 setFromPoints]( [page:Array points] )</h3>
+		<h3>[method:Box3 setFromPoints]( [param:Array points] )</h3>
 		<div>
 		[page:Array points] - Array of [page:Vector3 Vector3s] that the resulting box will contain.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the points in [page:Array points].
 		</div>
 
-		<h3>[method:Box3 translate]( [page:Vector3 offset] )</h3>
+		<h3>[method:Box3 translate]( [param:Vector3 offset] )</h3>
 		<div>
 		[page:Vector3 offset] - Direction and distance of offset.<br /><br />
 
@@ -290,7 +290,7 @@
 		[page:Vector3 offset] units in 3D space.
 		</div>
 
-		<h3>[method:Box3 union]( [page:Box3 box] )</h3>
+		<h3>[method:Box3 union]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - Box that will be unioned with this box.<br /><br />
 

--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -44,7 +44,7 @@ var color = new THREE.Color( 1, 0, 0 );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Color_Hex_or_String r], [page:Float g], [page:Float b] )</h3>
+		<h3>[name]( [param:Color_Hex_or_String r], [param:Float g], [param:Float b] )</h3>
 		<div>
 		[page:Color_Hex_or_String r] - (optional) If arguments [page:Float g] and [page:Float b] are defined, the red component of the color.
 		If they are not defined, it can be a [link:https://en.wikipedia.org/wiki/Web_colors#Hex_triplet hexadecimal triplet] (recommended), a CSS-style string, or another Color instance.<br />

--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -104,19 +104,19 @@ var color = new THREE.Color( 1, 0, 0 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:Color add]( [page:Color color] ) </h3>
+		<h3>[method:Color add]( [param:Color color] ) </h3>
 		<div>Adds the RGB values of [page:Color color] to the RGB values of this color.</div>
 
-		<h3>[method:Color addColors]( [page:Color color1], [page:Color color2] ) </h3>
+		<h3>[method:Color addColors]( [param:Color color1], [param:Color color2] ) </h3>
 		<div>Sets this color's RGB values to the sum of the RGB values of [page:Color color1] and [page:Color color2].</div>
 
-		<h3>[method:Color addScalar]( [page:Number s] ) </h3>
+		<h3>[method:Color addScalar]( [param:Number s] ) </h3>
 		<div>Adds [page:Number s] to the RGB values of this color.</div>
 
 		<h3>[method:Color clone]() </h3>
 		<div>Returns a new Color with the same [page:.r r], [page:.g g] and [page:.b b] values as this one.</div>
 
-		<h3>[method:Color copy]( [page:Color color] ) </h3>
+		<h3>[method:Color copy]( [param:Color color] ) </h3>
 		<div>
 			Copies the [page:.r r], [page:.g g] and [page:.b b] parameters from [page:Color color] in to this color.
 		</div>
@@ -127,7 +127,7 @@ var color = new THREE.Color( 1, 0, 0 );
 		<h3>[method:Color convertLinearToGamma]() </h3>
 		<div>Converts this color from linear to gamma space by taking the square root of [page:.r r], [page:.g g] and [page:.b b]).</div>
 
-		<h3>[method:Color copyGammaToLinear]( [page:Color color], [page:Float gammaFactor] ) </h3>
+		<h3>[method:Color copyGammaToLinear]( [param:Color color], [param:Float gammaFactor] ) </h3>
 		<div>
 		[page:Color color] — Color to copy.<br />
 		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
@@ -136,7 +136,7 @@ var color = new THREE.Color( 1, 0, 0 );
 		by taking [page:.r r], [page:.g g] and [page:.b b] to the power of [page:Float gammaFactor].
 		</div>
 
-		<h3>[method:Color copyLinearToGamma]( [page:Color color], [page:Float gammaFactor] ) </h3>
+		<h3>[method:Color copyLinearToGamma]( [param:Color color], [param:Float gammaFactor] ) </h3>
 		<div>
 		[page:Color color] — Color to copy.<br />
 		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
@@ -145,10 +145,10 @@ var color = new THREE.Color( 1, 0, 0 );
 		by taking [page:.r r], [page:.g g] and [page:.b b] to the power of 1 / [page:Float gammaFactor].
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Color color] ) </h3>
+		<h3>[method:Boolean equals]( [param:Color color] ) </h3>
 		<div>Compares the RGB values of [page:Color color] with those of this object. Returns true if they are the same, false otherwise.</div>
 
-		<h3>[method:Color fromArray]( [page:Array array], [page:Integer offset] ) </h3>
+		<h3>[method:Color fromArray]( [param:Array array], [param:Integer offset] ) </h3>
 		<div>
 		[page:Array array] - [page:Array] of floats in the form [ [page:Float r], [page:Float g], [page:Float b] ].<br />
 		[page:Integer offset] - An optional offset into the array.<br /><br />
@@ -162,7 +162,7 @@ var color = new THREE.Color( 1, 0, 0 );
 		<h3>[method:String getHexString]()</h3>
 		<div>Returns the hexadecimal value of this color as a string (for example, 'FFFFFF').</div>
 
-		<h3>[method:Object getHSL]( [page:Object optionalTarget] )</h3>
+		<h3>[method:Object getHSL]( [param:Object optionalTarget] )</h3>
 		<div>
 			[page:Object optionalTarget] — (optional) if specified, adds h, s and l keys to the object (if not already present)
 			and sets the results there. Otherwise, a new Object will be created. <br /><br />
@@ -179,7 +179,7 @@ var color = new THREE.Color( 1, 0, 0 );
 		<h3>[method:String getStyle]()</h3>
 		<div>Returns the value of this color as a CSS style string. Example: 'rgb(255,0,0)'.</div>
 
-		<h3>[method:Color lerp]( [page:Color color], [page:Float alpha] ) </h3>
+		<h3>[method:Color lerp]( [param:Color color], [param:Float alpha] ) </h3>
 		<div>
 		[page:Color color] - color to converge on.<br />
 		[page:Float alpha] - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -189,20 +189,20 @@ var color = new THREE.Color( 1, 0, 0 );
 		this color and 1.0 is the first argument.
 		</div>
 
-		<h3>[method:Color multiply]( [page:Color color] ) </h3>
+		<h3>[method:Color multiply]( [param:Color color] ) </h3>
 		<div>Multiplies this color's RGB values by the given [page:Color color]'s RGB values.</div>
 
-		<h3>[method:Color multiplyScalar]( [page:Number s] ) </h3>
+		<h3>[method:Color multiplyScalar]( [param:Number s] ) </h3>
 		<div>Multiplies this color's RGB values by [page:Number s].</div>
 
-		<h3>[method:Color offsetHSL]( [page:Float h], [page:Float s], [page:Float l] ) </h3>
+		<h3>[method:Color offsetHSL]( [param:Float h], [param:Float s], [param:Float l] ) </h3>
 		<div>
 			Adds the given [page:Float h], [page:Float s], and [page:Float l] to this color's values.
 			Internally, this converts the color's [page:.r r], [page:.g g] and [page:.b b] values to HSL, adds
 			[page:Float h], [page:Float s], and [page:Float l], and then converts the color back to RGB.
 		</div>
 
-		<h3>[method:Color set]( [page:Color_Hex_or_String value] ) </h3>
+		<h3>[method:Color set]( [param:Color_Hex_or_String value] ) </h3>
 		<div>
 		[page:Color_Hex_or_String value] - Value to set this color to.<br /><br />
 
@@ -210,14 +210,14 @@ var color = new THREE.Color( 1, 0, 0 );
 		Delegates to [page:.copy], [page:.setStyle], or [page:.setHex] depending on input type.
 		</div>
 
-		<h3>[method:Color setHex]( [page:Integer hex] ) </h3>
+		<h3>[method:Color setHex]( [param:Integer hex] ) </h3>
 		<div>
 		[page:Integer hex] — [link:https://en.wikipedia.org/wiki/Web_colors#Hex_triplet hexadecimal triplet] format.<br /><br />
 
 		Sets this color from a hexadecimal value.
 		</div>
 
-		<h3>[method:Color setHSL]( [page:Float h], [page:Float s], [page:Float l] ) </h3>
+		<h3>[method:Color setHSL]( [param:Float h], [param:Float s], [param:Float l] ) </h3>
 		<div>
 		[page:Float h] — hue value between 0.0 and 1.0 <br />
 		[page:Float s] — saturation value between 0.0 and 1.0 <br />
@@ -226,7 +226,7 @@ var color = new THREE.Color( 1, 0, 0 );
 		Sets color from HSL values.
 		</div>
 
-		<h3>[method:Color setRGB]( [page:Float r], [page:Float g], [page:Float b] ) </h3>
+		<h3>[method:Color setRGB]( [param:Float r], [param:Float g], [param:Float b] ) </h3>
 		<div>
 		[page:Float r] — Red channel value between 0.0 and 1.0.<br />
 		[page:Float g] — Green channel value between 0.0 and 1.0.<br />
@@ -235,14 +235,14 @@ var color = new THREE.Color( 1, 0, 0 );
 		Sets this color from RGB values.
 		</div>
 
-		<h3>[method:Color setScalar]( [page:Float scalar] ) </h3>
+		<h3>[method:Color setScalar]( [param:Float scalar] ) </h3>
 		<div>
 		[page:Float scalar] — a value between 0.0 and 1.0.<br /><br />
 
 		Sets all three color components to the value [page:Float scalar].
 		</div>
 
-		<h3>[method:Color setStyle]( [page:String style] ) </h3>
+		<h3>[method:Color setStyle]( [param:String style] ) </h3>
 		<div>
 		[page:String style] — color as a CSS-style string.<br /><br />
 
@@ -261,13 +261,13 @@ var color = new THREE.Color( 1, 0, 0 );
 		Note that for X11 color names, multiple words such as Dark Orange become the string 'darkorange' (all lowercase).
 		</div>
 
-		<h3>[method:Color sub]( [page:Color color] ) </h3>
+		<h3>[method:Color sub]( [param:Color color] ) </h3>
 		<div>
 		Subtracts the RGB components of the given color from the RGB components of this color.
 		If this results in a negative component, that component is set to zero.
 		</div>
 
-		<h3>[method:Array toArray]( [page:Array array], [page:Integer offset] ) </h3>
+		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] ) </h3>
 		<div>
 		[page:Array array] - An optional array to store the color to. <br />
 		[page:Integer offset] - An optional offset into the array.<br /><br />

--- a/docs/api/math/Cylindrical.html
+++ b/docs/api/math/Cylindrical.html
@@ -44,17 +44,17 @@
 		and [page:.y y] properties as this one.
 		</div>
 
-		<h3>[method:Cylindrical copy]( [page:Cylindrical other] )</h3>
+		<h3>[method:Cylindrical copy]( [param:Cylindrical other] )</h3>
 		<div>
 			Copies the values of the passed Cylindrical's [page:.radius radius], [page:.theta theta]
 			and [page:.y y] properties to this cylindrical.
 		</div>
 
-		<h3>[method:Cylindrical set]( [page:Float radius], [page:Float phi], [page:Float theta] )</h3>
+		<h3>[method:Cylindrical set]( [param:Float radius], [param:Float phi], [param:Float theta] )</h3>
 		<div>Sets values of this cylindrical's [page:.radius radius], [page:.theta theta]
 		and [page:.y y] properties.</div>
 
-		<h3>[method:Cylindrical setFromVector3]( [page:Vector3 vec3] )</h3>
+		<h3>[method:Cylindrical setFromVector3]( [param:Vector3 vec3] )</h3>
 		<div>
 			Sets values of this cylindrical's [page:.radius radius], [page:.theta theta]
 			and [page:.y y] properties from the [page:Vector3 Vector3].<br /><br />

--- a/docs/api/math/Cylindrical.html
+++ b/docs/api/math/Cylindrical.html
@@ -17,7 +17,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Float radius], [page:Float theta], [page:Float y] )</h3>
+		<h3>[name]( [param:Float radius], [param:Float theta], [param:Float y] )</h3>
 		<div>
 		[page:Float radius] - distance from the origin to a point in the x-z plane.
 		Default is *1.0*.<br />

--- a/docs/api/math/Euler.html
+++ b/docs/api/math/Euler.html
@@ -28,7 +28,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Float x], [page:Float y], [page:Float z], [page:String order] )</h3>
+		<h3>[name]( [param:Float x], [param:Float y], [param:Float z], [param:String order] )</h3>
 		<div>
 		[page:Float x] - (optional) the angle of the x axis in radians. Default is *0*.<br />
 		[page:Float y] - (optional) the angle of the y axis in radians. Default is *0*.<br />

--- a/docs/api/math/Euler.html
+++ b/docs/api/math/Euler.html
@@ -85,16 +85,16 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Euler copy]( [page:Euler euler] )</h3>
+		<h3>[method:Euler copy]( [param:Euler euler] )</h3>
 		<div>Copies value of [page:Euler euler] to this euler.</div>
 
 		<h3>[method:Euler clone]()</h3>
 		<div>Returns a new Euler with the same parameters as this one.</div>
 
-		<h3>[method:Boolean equals]( [page:Euler euler] )</h3>
+		<h3>[method:Boolean equals]( [param:Euler euler] )</h3>
 		<div>Checks for strict equality of this euler and [page:Euler euler].</div>
 
-		<h3>[method:Euler fromArray]( [page:Array array] )</h3>
+		<h3>[method:Euler fromArray]( [param:Array array] )</h3>
 		<div>
 		[page:Array array] of length 3 or 4. The optional 4th argument corresponds to the [page:.order order].<br /><br />
 
@@ -104,7 +104,7 @@
 		Optionally assigns this euler's [page:.order order] to array[3].
 		</div>
 
-		<h3>[method:Euler onChange]( [page:Function onChangeCallback] )</h3>
+		<h3>[method:Euler onChange]( [param:Function onChangeCallback] )</h3>
 		<div>
 			[page:Function onChangeCallback] - set the value of the onChangeCallback() function.
 		</div>
@@ -116,7 +116,7 @@
 			and also after calling most setter functions (see those for details).
 		</div>
 
-		<h3>[method:Euler reorder]( [page:String newOrder] )</h3>
+		<h3>[method:Euler reorder]( [param:String newOrder] )</h3>
 		<div>
 		Resets the euler angle with a new order by creating a quaternion from this euler angle
 		and then setting this euler angle with the quaternion and the new order. <br /><br />
@@ -124,7 +124,7 @@
 		<em>WARNING</em>: this discards revolution information.
 		</div>
 
-		<h3>[method:Euler set]( [page:Float x], [page:Float y], [page:Float z], [page:String order] )</h3>
+		<h3>[method:Euler set]( [param:Float x], [param:Float y], [param:Float z], [param:String order] )</h3>
 		<div>
 			[page:.x x] - the angle of the x axis in radians.<br />
 			[page:.y y] - the angle of the y axis in radians.<br />
@@ -134,7 +134,7 @@
 			Sets the angles of this euler transform and optionally the [page:.order order] and then call [page:.onChangeCallback onChangeCallback]().
 		</div>
 
-		<h3>[method:Euler setFromRotationMatrix]( [page:Matrix4 m], [page:String order], [page:Boolean update] )</h3>
+		<h3>[method:Euler setFromRotationMatrix]( [param:Matrix4 m], [param:String order], [param:Boolean update] )</h3>
 		<div>
 		[page:Matrix4 m] - a [page:Matrix4] of which the upper 3x3 of matrix is a pure
 		[link:https://en.wikipedia.org/wiki/Rotation_matrix rotation matrix] (i.e. unscaled).<br />
@@ -146,7 +146,7 @@
 		specified by order.
 		</div>
 
-		<h3>[method:Euler setFromQuaternion]( [page:Quaternion q], [page:String order], [page:Boolean update] )</h3>
+		<h3>[method:Euler setFromQuaternion]( [param:Quaternion q], [param:String order], [param:Boolean update] )</h3>
 		<div>
 		[page:Quaternion q] - a normalized quaternion.<br />
 		[page:.order order] - (optional) a string representing the order that the rotations are applied.<br />
@@ -158,7 +158,7 @@
 		</div>
 
 
-		<h3>[method:Euler setFromVector3]( [page:Vector3 vector], [page:String order] )</h3>
+		<h3>[method:Euler setFromVector3]( [param:Vector3 vector], [param:String order] )</h3>
 		<div>
 		[page:Vector3 vector] - [page:Vector3].<br />
 		[page:.order order] - (optional) a string representing the order that the rotations are applied.<br /><br />
@@ -168,7 +168,7 @@
 		</div>
 
 
-		<h3>[method:Array toArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - (optional) array to store the euler in.<br />
 		[page:Integer offset] (optional) offset in the array.<br />

--- a/docs/api/math/Frustum.html
+++ b/docs/api/math/Frustum.html
@@ -48,28 +48,28 @@
 		<div>Return a new Frustum with the same parameters as this one.</div>
 
 
-		<h3>[method:Boolean containsPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Boolean containsPoint]( [param:Vector3 point] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] to test.<br /><br />
 
 		Checks to see if the frustum contains the [page:Vector3 point].
 		</div>
 
-		<h3>[method:Frustum copy]( [page:Frustum frustum] )</h3>
+		<h3>[method:Frustum copy]( [param:Frustum frustum] )</h3>
 		<div>
 		[page:Frustum frustum] - The frustum to copy<br /><br />
 
 		Copies the properties of the passed [page:Frustum frustum] into this one.
 		</div>
 
-		<h3>[method:Boolean intersectsBox]( [page:Box3 box] )</h3>
+		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - [page:Box3] to check for intersection.<br /><br />
 
 	 	Return true if [page:Box3 box] intersects with this frustum.
 		</div>
 
-		<h3>[method:Boolean intersectsObject]( [page:Object3D object] )</h3>
+		<h3>[method:Boolean intersectsObject]( [param:Object3D object] )</h3>
 		<div>
 			Checks whether the [page:Object3D object]'s [page:Geometry.boundingSphere bounding sphere] is intersecting the Frustum.<br /><br />
 
@@ -77,24 +77,24 @@
 			can be calculated.
 		</div>
 
-		<h3>[method:Boolean intersectsSphere]( [page:Sphere sphere] )</h3>
+		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
 		<div>
 		[page:Sphere sphere] - [page:Sphere] to check for intersection.<br /><br />
 
 	 	Return true if [page:Sphere sphere] intersects with this frustum.
 		</div>
 
-		<h3>[method:Boolean intersectsSprite]( [page:Sprite sprite] )</h3>
+		<h3>[method:Boolean intersectsSprite]( [param:Sprite sprite] )</h3>
 		<div>
 			Checks whether the [page:Sprite sprite] is intersecting the Frustum.<br /><br />
 		</div>
 
-		<h3>[method:Frustum set]( [page:Plane p0], [page:Plane p1], [page:Plane p2], [page:Plane p3], [page:Plane p4], [page:Plane p5] )</h3>
+		<h3>[method:Frustum set]( [param:Plane p0], [param:Plane p1], [param:Plane p2], [param:Plane p3], [param:Plane p4], [param:Plane p5] )</h3>
 		<div>
 		Sets the current frustum from the passed planes. No plane order is implicitely implied.
 		</div>
 
-		<h3>[method:Frustum setFromMatrix]( [page:Matrix4 matrix] )</h3>
+		<h3>[method:Frustum setFromMatrix]( [param:Matrix4 matrix] )</h3>
 		<div>
 			[page:Matrix4 matrix] - [page:Matrix4] used to set the [page:.planes planes]<br /><br />
 

--- a/docs/api/math/Frustum.html
+++ b/docs/api/math/Frustum.html
@@ -23,7 +23,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Plane p0], [page:Plane p1], [page:Plane p2], [page:Plane p3], [page:Plane p4], [page:Plane p5])</h3>
+		<h3>[name]([param:Plane p0], [param:Plane p1], [param:Plane p2], [param:Plane p3], [param:Plane p4], [param:Plane p5])</h3>
 		<div>
 			[page:Plane p0] - (optional) defaults to a new [page:Plane].<br />
 			[page:Plane p1] - (optional) defaults to a new [page:Plane].<br />

--- a/docs/api/math/Interpolant.html
+++ b/docs/api/math/Interpolant.html
@@ -72,7 +72,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [page:Number t] )</h3>
+		<h3>[method:null evaluate]( [param:Number t] )</h3>
 		<div>
 		Evaluate the interpolant at position *t*.
 		</div>

--- a/docs/api/math/Line3.html
+++ b/docs/api/math/Line3.html
@@ -39,10 +39,10 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Line3 applyMatrix4]( [page:Matrix4 matrix] )</h3>
+		<h3>[method:Line3 applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<div>Applies a matrix transform to the line segment.</div>
 
-		<h3>[method:Vector3 at]( [page:Float t], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 at]( [param:Float t], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Float t] - Use values 0-1 to return a position along the line segment. <br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
@@ -55,7 +55,7 @@
 		<h3>[method:Line3 clone]()</h3>
 		<div>Returns a new [page:Line3] with the same [page:.start start] and [page:.end end] vectors as this one.</div>
 
-		<h3>[method:Vector3 closestPointToPoint]( [page:Vector3 point], [page:Boolean clampToLine], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 closestPointToPoint]( [param:Vector3 point], [param:Boolean clampToLine], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Vector3 point] - return the closest point on the line to this point.<br />
 		[page:Boolean clampToLine] - whether to clamp the returned value to the line segment.<br />
@@ -66,7 +66,7 @@
 		clamped to the line segment.
 		</div>
 
-		<h3>[method:Float closestPointToPointParameter]( [page:Vector3 point], [page:Boolean clampToLine] )</h3>
+		<h3>[method:Float closestPointToPointParameter]( [param:Vector3 point], [param:Boolean clampToLine] )</h3>
 		<div>
 		[page:Vector3 point] - the point for which to return a point parameter. <br />
 		[page:Boolean clampToLine] - Whether to clamp the result to the range [0, 1].<br /><br />
@@ -75,10 +75,10 @@
 		If [page:Boolean clampToLine] is true, then the returned value will be between 0 and 1.
 		</div>
 
-		<h3>[method:Line3 copy]( [page:Line3 line] )</h3>
+		<h3>[method:Line3 copy]( [param:Line3 line] )</h3>
 		<div>Copies the passed line's [page:.start start] and [page:.end end] vectors to this line.</div>
 
-		<h3>[method:Vector3 delta]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 delta]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 			[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
 			otherwise a new [page:Vector3] will be created.<br /><br />
@@ -97,14 +97,14 @@
 			and [page:.end end] vectors.
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Line3 line] )</h3>
+		<h3>[method:Boolean equals]( [param:Line3 line] )</h3>
 		<div>
 		[page:Line3 line]  - [page:Line3] to compare with this one.<br /><br />
 
 		Returns true if both line's [page:.start start] and [page:.end en] points are equal.
 		</div>
 
-		<h3>[method:Vector3 getCenter]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 getCenter]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 			[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
 			otherwise a new [page:Vector3] will be created.<br /><br />
@@ -112,7 +112,7 @@
 		Returns the center of the line segment.
 		</div>
 
-		<h3>[method:Line3 set]( [page:Vector3 start], [page:Vector3 end] )</h3>
+		<h3>[method:Line3 set]( [param:Vector3 start], [param:Vector3 end] )</h3>
 		<div>
 		[page:Vector3 start] - set the [page:.start start point] of the line.<br />
 		[page:Vector3 end] - set the [page:.end end point] of the line.<br /><br />

--- a/docs/api/math/Line3.html
+++ b/docs/api/math/Line3.html
@@ -16,7 +16,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector3 start], [page:Vector3 end] )</h3>
+		<h3>[name]( [param:Vector3 start], [param:Vector3 end] )</h3>
 		<div>
 		[page:Vector3 start] - Start of the line segment. Default is (0, 0, 0).<br />
 		[page:Vector3 end] - End of the line segment. Default is (0, 0, 0).<br /><br />

--- a/docs/api/math/Math.html
+++ b/docs/api/math/Math.html
@@ -14,7 +14,7 @@
 
 		<h2>Functions</h2>
 
-		<h3>[method:Float clamp]( [page:Float value], [page:Float min], [page:Float max] )</h3>
+		<h3>[method:Float clamp]( [param:Float value], [param:Float min], [param:Float max] )</h3>
 		<div>
 		[page:Float value] — Value to be clamped.<br />
 		[page:Float min] — Minimum value.<br />
@@ -23,10 +23,10 @@
 		Clamps the [page:Float value] to be between [page:Float min] and [page:Float max].
 		</div>
 
-		<h3>[method:Float degToRad]( [page:Float degrees] )</h3>
+		<h3>[method:Float degToRad]( [param:Float degrees] )</h3>
 		<div>Converts degrees to radians.</div>
 
-		<h3>[method:Integer euclideanModulo]( [page:Integer n], [page:Integer m] )</h3>
+		<h3>[method:Integer euclideanModulo]( [param:Integer n], [param:Integer m] )</h3>
 		<div>
 		[page:Integer n], [page:Integer m] - Integers<br /><br />
 
@@ -40,10 +40,10 @@
 		(universally unique identifier).
 		</div>
 
-		<h3>[method:Boolean isPowerOfTwo]( [page:Number n] )</h3>
+		<h3>[method:Boolean isPowerOfTwo]( [param:Number n] )</h3>
 		<div>Return *true* if [page:Number n] is a power of 2.</div>
 
-		<h3>[method:Float lerp]( [page:Float x], [page:Float y], [page:Float t] )</h3>
+		<h3>[method:Float lerp]( [param:Float x], [param:Float y], [param:Float t] )</h3>
 		<div>
 		[page:Float x] - Start point. <br />
 		[page:Float y] - End point. <br />
@@ -70,25 +70,25 @@
 		Linear mapping of [page:Float x] from range [[page:Float a1], [page:Float a2]] to range [[page:Float b1], [page:Float b2]].
 		</div>
 
-		<h3>[method:Integer ceilPowerOfTwo]( [page:Number n] )</h3>
+		<h3>[method:Integer ceilPowerOfTwo]( [param:Number n] )</h3>
 		<div>Returns the smallest power of 2 that is greater than or equal to [page:Number n].</div>
 
-		<h3>[method:Integer floorPowerOfTwo]( [page:Number n] )</h3>
+		<h3>[method:Integer floorPowerOfTwo]( [param:Number n] )</h3>
 		<div>Returns the largest power of 2 that is less than or equal to [page:Number n].</div>
 
-		<h3>[method:Float radToDeg]( [page:Float radians] )</h3>
+		<h3>[method:Float radToDeg]( [param:Float radians] )</h3>
 		<div>Converts radians to degrees.</div>
 
-		<h3>[method:Float randFloat]( [page:Float low], [page:Float high] )</h3>
+		<h3>[method:Float randFloat]( [param:Float low], [param:Float high] )</h3>
 		<div>Random float in the interval [page:Float low] to [page:Float high].</div>
 
-		<h3>[method:Float randFloatSpread]( [page:Float range] )</h3>
+		<h3>[method:Float randFloatSpread]( [param:Float range] )</h3>
 		<div>Random float in the interval *- [page:Float range] / 2* to *[page:Float range] / 2*.</div>
 
-		<h3>[method:Integer randInt]( [page:Integer low], [page:Integer high] )</h3>
+		<h3>[method:Integer randInt]( [param:Integer low], [param:Integer high] )</h3>
 		<div>Random integer in the interval [page:Float low] to [page:Float high].</div>
 
-		<h3>[method:Float smoothstep]( [page:Float x], [page:Float min], [page:Float max] )</h3>
+		<h3>[method:Float smoothstep]( [param:Float x], [param:Float min], [param:Float max] )</h3>
 		<div>
 		[page:Float x] - The value to evaluate based on its position between min and max. <br />
 		[page:Float min] - Any x value below min will be 0.<br />
@@ -100,7 +100,7 @@
 		See [link:http://en.wikipedia.org/wiki/Smoothstep Smoothstep] for details.
 		</div>
 
-		<h3>[method:Float smootherstep]( [page:Float x], [page:Float min], [page:Float max] )</h3>
+		<h3>[method:Float smootherstep]( [param:Float x], [param:Float min], [param:Float max] )</h3>
 		<div>
 		[page:Float x] - The value to evaluate based on its position between min and max. <br />
 		[page:Float min] - Any x value below min will be 0.<br />

--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -72,7 +72,7 @@ m.elements = [ 11, 21, 31,
 
 		<h2>Methods</h2>
 
-		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute] )</h3>
+		<h3>[method:Array applyToBufferAttribute]( [param:BufferAttribute attribute] )</h3>
 		<div>
 		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
 
@@ -83,7 +83,7 @@ m.elements = [ 11, 21, 31,
 		<h3>[method:Matrix3 clone]()</h3>
 		<div>Creates a new Matrix3 and with identical elements to this one.</div>
 
-		<h3>[method:Matrix3 copy]( [page:Matrix3 m] )</h3>
+		<h3>[method:Matrix3 copy]( [param:Matrix3 m] )</h3>
 		<div>Copies the elements of matrix [page:Matrix3 m] into this matrix.</div>
 
 		<h3>[method:Float determinant]()</h3>
@@ -92,10 +92,10 @@ m.elements = [ 11, 21, 31,
 		[link:https://en.wikipedia.org/wiki/Determinant determinant] of this matrix.
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Matrix3 m] )</h3>
+		<h3>[method:Boolean equals]( [param:Matrix3 m] )</h3>
 		<div>Return true if this matrix and [page:Matrix3 m] are equal.</div>
 
-		<h3>[method:Matrix3 fromArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Matrix3 fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - the array to read the elements from.<br />
 		[page:Integer offset] - (optional) index of first element in the array. Default is 0.<br /><br />
@@ -104,7 +104,7 @@ m.elements = [ 11, 21, 31,
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</div>
 
-		<h3>[method:Matrix3 getInverse]( [page:Matrix3 m], [page:Boolean throwOnDegenerate] )</h3>
+		<h3>[method:Matrix3 getInverse]( [param:Matrix3 m], [param:Boolean throwOnDegenerate] )</h3>
 		<div>
 		[page:Matrix3 m] - the matrix to take the inverse of.<br />
 		[page:Boolean throwOnDegenerate] - (optional) If true, throw an error if the matrix is degenerate (not invertible).<br /><br />
@@ -115,7 +115,7 @@ m.elements = [ 11, 21, 31,
 		If [page:Boolean throwOnDegenerate] is not set and the matrix is not invertible, set this to the 3x3 identity matrix.
 		</div>
 
-		<h3>[method:Matrix3 getNormalMatrix]( [page:Matrix4 m] )</h3>
+		<h3>[method:Matrix3 getNormalMatrix]( [param:Matrix4 m] )</h3>
 		<div>
 		[page:Matrix4 m] - [page:Matrix4]<br /><br />
 
@@ -135,13 +135,13 @@ m.elements = [ 11, 21, 31,
 
 		</div>
 
-		<h3>[method:Matrix3 multiply]( [page:Matrix3 m] )</h3>
+		<h3>[method:Matrix3 multiply]( [param:Matrix3 m] )</h3>
 		<div>Post-multiplies this matrix by [page:Matrix3 m].</div>
 
-		<h3>[method:Matrix3 multiplyMatrices]( [page:Matrix3 a], [page:Matrix3 b] )</h3>
+		<h3>[method:Matrix3 multiplyMatrices]( [param:Matrix3 a], [param:Matrix3 b] )</h3>
 		<div>Sets this matrix to [page:Matrix3 a] x [page:Matrix3 b].</div>
 
-		<h3>[method:Matrix3 multiplyScalar]( [page:Float s] )</h3>
+		<h3>[method:Matrix3 multiplyScalar]( [param:Float s] )</h3>
 		<div>Multiplies every component of the matrix by the scalar value *s*.</div>
 
 		<h3>
@@ -163,10 +163,10 @@ m.elements = [ 11, 21, 31,
 		sequence of values.
 		</div>
 
-		<h3>[method:Matrix3 premultiply]( [page:Matrix3 m] )</h3>
+		<h3>[method:Matrix3 premultiply]( [param:Matrix3 m] )</h3>
 		<div>Pre-multiplies this matrix by [page:Matrix3 m].</div>
 
-		<h3>[method:Matrix3 setFromMatrix4]( [page:Matrix4 m] )</h3>
+		<h3>[method:Matrix3 setFromMatrix4]( [param:Matrix4 m] )</h3>
 		<div>Set this matrx to the upper 3x3 matrix of the Matrix4 [page:Matrix4 m].</div>
 
 		<h3>
@@ -186,7 +186,7 @@ m.elements = [ 11, 21, 31,
 		Sets the UV transform matrix from offset, repeat, rotation, and center.
 		</div>
 
-		<h3>[method:Array toArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - (optional) array to store the resulting vector in. If not given a new array will be created.<br />
 		[page:Integer offset] - (optional) offset in the array at which to put the result.<br /><br />
@@ -198,7 +198,7 @@ m.elements = [ 11, 21, 31,
 		<h3>[method:Matrix3 transpose]()</h3>
 		<div>[link:https://en.wikipedia.org/wiki/Transpose Transposes] this matrix in place.</div>
 
-		<h3>[method:Matrix3 transposeIntoArray]( [page:Array array] )</h3>
+		<h3>[method:Matrix3 transposeIntoArray]( [param:Array array] )</h3>
 		<div>
 		[page:Array array] -  array to store the resulting vector in.<br /><br />
 

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -108,7 +108,7 @@ m.elements = [ 11, 21, 31, 41,
 
 		<h2>Methods</h2>
 
-		<h3>[method:Array applyToBufferAttribute]( [page:BufferAttribute attribute] )</h3>
+		<h3>[method:Array applyToBufferAttribute]( [param:BufferAttribute attribute] )</h3>
 		<div>
 		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
 
@@ -119,7 +119,7 @@ m.elements = [ 11, 21, 31, 41,
 		<h3>[method:Matrix4 clone]()</h3>
 		<div>Creates a new Matrix4 with identical [page:.elements elements] to this one.</div>
 
-		<h3>[method:Matrix4 compose]( [page:Vector3 position], [page:Quaternion quaternion], [page:Vector3 scale] )</h3>
+		<h3>[method:Matrix4 compose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
 		<div>
 		Sets this matrix to the transformation composed of [page:Vector3 position],
 		[page:Quaternion quaternion] and [page:Vector3 scale]. Internally this calls
@@ -128,16 +128,16 @@ m.elements = [ 11, 21, 31, 41,
 		[page:.setPosition setPosition]( [page:Vector3 position] ).
 		</div>
 
-		<h3>[method:Matrix4 copy]( [page:Matrix4 m] )</h3>
+		<h3>[method:Matrix4 copy]( [param:Matrix4 m] )</h3>
 		<div>Copies the [page:.elements elements] of matrix [page:Matrix4 m] into this matrix.</div>
 
-		<h3>[method:Matrix4 copyPosition]( [page:Matrix4 m] )</h3>
+		<h3>[method:Matrix4 copyPosition]( [param:Matrix4 m] )</h3>
 		<div>
 		Copies the translation component of the supplied matrix [page:Matrix4 m] into this
 		matrix's translation component.
 		</div>
 
-		<h3>[method:null decompose]( [page:Vector3 position], [page:Quaternion quaternion], [page:Vector3 scale] )</h3>
+		<h3>[method:null decompose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
 		<div>
 		Decomposes this matrix into it's [page:Vector3 position], [page:Quaternion quaternion] and
 		[page:Vector3 scale] components.
@@ -151,10 +151,10 @@ m.elements = [ 11, 21, 31, 41,
 		Based on the method outlined [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm here].
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Matrix4 m] )</h3>
+		<h3>[method:Boolean equals]( [param:Matrix4 m] )</h3>
 		<div>Return true if this matrix and [page:Matrix4 m] are equal.</div>
 
-		<h3>[method:Matrix4 extractBasis]( [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis] )</h3>
+		<h3>[method:Matrix4 extractBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<div>
 		Extracts the [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] of this
 		matrix into the three axis vectors provided. If this matrix is:
@@ -172,13 +172,13 @@ zAxis = (c, g, k)
 		</code>
 		</div>
 
-		<h3>[method:Matrix4 extractRotation]( [page:Matrix4 m] )</h3>
+		<h3>[method:Matrix4 extractRotation]( [param:Matrix4 m] )</h3>
 		<div>
 		Extracts the rotation component of the supplied matrix [page:Matrix4 m] into this matrix's
 		rotation component.
 		</div>
 
-		<h3>[method:Matrix4 fromArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Matrix4 fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - the array to read the elements from.<br />
 		[page:Integer offset] - ( optional ) offset into the array. Default is 0.<br /><br />
@@ -187,7 +187,7 @@ zAxis = (c, g, k)
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</div>
 
-		<h3>[method:Matrix4 getInverse]( [page:Matrix4 m], [page:Boolean throwOnDegenerate] )</h3>
+		<h3>[method:Matrix4 getInverse]( [param:Matrix4 m], [param:Boolean throwOnDegenerate] )</h3>
 		<div>
 		[page:Matrix4 m] - the matrix to take the inverse of.<br />
 		[page:Boolean throwOnDegenerate] - (optional) If true, throw an error if the matrix is degenerate (not invertible).<br /><br />
@@ -205,13 +205,13 @@ zAxis = (c, g, k)
 		<h3>[method:Matrix4 identity]()</h3>
 		<div>Resets this matrix to the [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].</div>
 
-		<h3>[method:Matrix4 lookAt]( [page:Vector3 eye], [page:Vector3 center], [page:Vector3 up], )</h3>
+		<h3>[method:Matrix4 lookAt]( [param:Vector3 eye], [param:Vector3 center], [param:Vector3 up], )</h3>
 		<div>
 			Constructs a rotation matrix, looking from [page:Vector3 eye] towards [page:Vector3 center]
 			oriented by the [page:Vector3 up] vector.
 		</div>
 
-		<h3>[method:Matrix4 makeRotationAxis]( [page:Vector3 axis], [page:Float theta] )</h3>
+		<h3>[method:Matrix4 makeRotationAxis]( [param:Vector3 axis], [param:Float theta] )</h3>
 		<div>
 		[page:Vector3 axis] — Rotation axis, should be normalized.<br />
 		[page:Float theta] — Rotation angle in radians.<br /><br />
@@ -222,7 +222,7 @@ zAxis = (c, g, k)
 		See the discussion [link:http://www.gamedev.net/reference/articles/article1199.asp here].
 		</div>
 
-		<h3>[method:Matrix4 makeBasis]( [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis] )</h3>
+		<h3>[method:Matrix4 makeBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<div>
 		Set this to the [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] matrix consisting
 		of the three provided basis vectors:
@@ -234,26 +234,26 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		</code>
 		</div>
 
-		<h3>[method:Matrix4 makePerspective]( [page:Float left], [page:Float right], [page:Float top], [page:Float bottom], [page:Float near], [page:Float far] )</h3>
+		<h3>[method:Matrix4 makePerspective]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
 		<div>
 			Creates a [link:https://en.wikipedia.org/wiki/3D_projection#Perspective_projection perspective projection] matrix.
 			This is used internally by [page:PerspectiveCamera.updateProjectionMatrix]()
 		</div>
 
-		<h3>[method:Matrix4 makeOrthographic]( [page:Float left], [page:Float right], [page:Float top], [page:Float bottom], [page:Float near], [page:Float far] )</h3>
+		<h3>[method:Matrix4 makeOrthographic]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
 		<div>
 		Creates an [link:https://en.wikipedia.org/wiki/Orthographic_projection orthographic projection] matrix.
 		This is used internally by [page:OrthographicCamera.updateProjectionMatrix]().
 		</div>
 
-		<h3>[method:Matrix4 makeRotationFromEuler]( [page:Euler euler] )</h3>
+		<h3>[method:Matrix4 makeRotationFromEuler]( [param:Euler euler] )</h3>
 		<div>
 		Sets the rotation component (the upper left 3x3 matrix) of this matrix to the rotation specified by the given [page:Euler Euler Angle].
 		The rest of the matrix is set to the identity. Depending on the [page:Euler.order order] of the [page:Euler euler], there are six possible outcomes.
 		See [link:https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix this page] for a complete list.
 		</div>
 
-		<h3>[method:Matrix4 makeRotationFromQuaternion]( [page:Quaternion q] )</h3>
+		<h3>[method:Matrix4 makeRotationFromQuaternion]( [param:Quaternion q] )</h3>
 		<div>
 		Sets the rotation component of this matrix to the rotation specified by [page:Quaternion q], as outlined
 		[link:https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion here].
@@ -266,7 +266,7 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		</code>
 		</div>
 
-		<h3>[method:Matrix4 makeRotationX]( [page:Float theta] )</h3>
+		<h3>[method:Matrix4 makeRotationX]( [param:Float theta] )</h3>
 		<div>
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
@@ -280,7 +280,7 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		</code>
 		</div>
 
-		<h3>[method:Matrix4 makeRotationY]( [page:Float theta] )</h3>
+		<h3>[method:Matrix4 makeRotationY]( [param:Float theta] )</h3>
 		<div>
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
@@ -294,7 +294,7 @@ cos(&theta;)  0 sin(&theta;) 0
 		</code>
 		</div>
 
-		<h3>[method:Matrix4 makeRotationZ]( [page:Float theta] )</h3>
+		<h3>[method:Matrix4 makeRotationZ]( [param:Float theta] )</h3>
 		<div>
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
@@ -308,7 +308,7 @@ sin(&theta;) cos(&theta;)  0 0
 		</code>
 		</div>
 
-		<h3>[method:Matrix4 makeScale]( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[method:Matrix4 makeScale]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>
 			[page:Float x] - the amount to scale in the X axis.<br />
 			[page:Float y] - the amount to scale in the Y axis.<br />
@@ -323,7 +323,7 @@ x, 0, 0, 0,
 			</code>
 		</div>
 
-		<h3>[method:Matrix4 makeShear]( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[method:Matrix4 makeShear]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>
 		[page:Float x] - the amount to shear in the X axis.<br />
 		[page:Float y] - the amount to shear in the Y axis.<br />
@@ -338,7 +338,7 @@ x, y, 1, 0,
 </code>
 		</div>
 
-		<h3>[method:Matrix4 makeTranslation]( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[method:Matrix4 makeTranslation]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>
 			[page:Float x] - the amount to translate in the X axis.<br />
 			[page:Float y] - the amount to translate in the Y axis.<br />
@@ -353,19 +353,19 @@ x, y, 1, 0,
 		</code>
 		</div>
 
-		<h3>[method:Matrix4 multiply]( [page:Matrix4 m] )</h3>
+		<h3>[method:Matrix4 multiply]( [param:Matrix4 m] )</h3>
 		<div>Post-multiplies this matrix by [page:Matrix4 m].</div>
 
-		<h3>[method:Matrix4 multiplyMatrices]( [page:Matrix4 a], [page:Matrix4 b] )</h3>
+		<h3>[method:Matrix4 multiplyMatrices]( [param:Matrix4 a], [param:Matrix4 b] )</h3>
 		<div>Sets this matrix to [page:Matrix4 a] x [page:Matrix4 b].</div>
 
-		<h3>[method:Matrix4 multiplyScalar]( [page:Float s] )</h3>
+		<h3>[method:Matrix4 multiplyScalar]( [param:Float s] )</h3>
 		<div>Multiplies every component of the matrix by a scalar value [page:Float s].</div>
 
-		<h3>[method:Matrix4 premultiply]( [page:Matrix4 m] )</h3>
+		<h3>[method:Matrix4 premultiply]( [param:Matrix4 m] )</h3>
 		<div>Pre-multiplies this matrix by [page:Matrix4 m].</div>
 
-		<h3>[method:Matrix4 scale]( [page:Vector3 v] )</h3>
+		<h3>[method:Matrix4 scale]( [param:Vector3 v] )</h3>
 		<div>Multiplies the columns of this matrix by vector [page:Vector3 v].</div>
 
 		<h3>[method:Matrix4 set](
@@ -378,7 +378,7 @@ x, y, 1, 0,
 			[page:Float n12], ... [page:Float n44].
 		</div>
 
-		<h3>[method:Matrix4 setPosition]( [page:Vector3 v] )</h3>
+		<h3>[method:Matrix4 setPosition]( [param:Vector3 v] )</h3>
 		<div>
 			Sets the position component for this matrix from vector [page:Vector3 v], without affecting the
 			rest of the matrix - i.e. if the matrix is currently:
@@ -397,7 +397,7 @@ m, n, o, p
 </code>
 		</div>
 
-		<h3>[method:Array toArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - (optional) array to store the resulting vector in.<br />
 		[page:Integer offset] - (optional) offset in the array at which to put the result.<br /><br />

--- a/docs/api/math/Plane.html
+++ b/docs/api/math/Plane.html
@@ -19,7 +19,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector3 normal], [page:Float constant] )</h3>
+		<h3>[name]( [param:Vector3 normal], [param:Float constant] )</h3>
 		<div>
 		[page:Vector3 normal] - (optional) a unit length [page:Vector3] defining the normal of the plane. Default is *(1, 0, 0)*.<br />
 		[page:Float constant] - (optional) the signed distance from the origin to the plane. Default is *0*.

--- a/docs/api/math/Plane.html
+++ b/docs/api/math/Plane.html
@@ -34,7 +34,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Plane applyMatrix4]( [page:Matrix4 matrix], [page:Matrix3 optionalNormalMatrix] )</h3>
+		<h3>[method:Plane applyMatrix4]( [param:Matrix4 matrix], [param:Matrix3 optionalNormalMatrix] )</h3>
 		<div>
 		[page:Matrix4 matrix] - the [Page:Matrix4] to apply.<br />
 		[page:Matrix3 optionalNormalMatrix] - (optional) pre-computed normal [Page:Matrix3] of the Matrix4 being applied.<br /><br />
@@ -49,7 +49,7 @@
 		<h3>[method:Plane clone]()</h3>
 		<div>Returns a new plane with the same [page:.normal normal] and [page:.constant constant] as this one.</div>
 
-		<h3>[method:Vector3 coplanarPoint]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 coplanarPoint]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 			[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
 			otherwise a new [page:Vector3] will be created.<br /><br />
@@ -58,25 +58,25 @@
 		normal vector at the origin onto the plane.
 		</div>
 
-		<h3>[method:Plane copy]( [page:Plane plane] )</h3>
+		<h3>[method:Plane copy]( [param:Plane plane] )</h3>
 		<div>
 		Copies the values of the passed plane's [page:.normal normal] and [page:.constant constant]
 		properties to this plane.
 		</div>
 
-		<h3>[method:Float distanceToPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
 		<div>Returns the signed distance from the [page:Vector3 point] to the plane.</div>
 
-		<h3>[method:Float distanceToSphere]( [page:Sphere sphere] )</h3>
+		<h3>[method:Float distanceToSphere]( [param:Sphere sphere] )</h3>
 		<div>Returns the signed distance from the [page:Sphere sphere] to the plane.</div>
 
-		<h3>[method:Boolean equals]( [page:Plane plane] )</h3>
+		<h3>[method:Boolean equals]( [param:Plane plane] )</h3>
 		<div>
 			Checks to see if two planes are equal (their [page:.normal normal] and
 			[page:.constant constant] properties match).
 		</div>
 
-		<h3>[method:Vector3 intersectLine]( [page:Line3 line], [page:Vector3 optionalTarget] ) or [page:undefined]</h3>
+		<h3>[method:Vector3 intersectLine]( [param:Line3 line], [param:Vector3 optionalTarget] ) or [param:undefined]</h3>
 		<div>
 		[page:Line3 line] - the [page:Line3] to check for intersection.<br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
@@ -87,21 +87,21 @@
 		 coplanar with the plane.
 		</div>
 
-		<h3>[method:Boolean intersectsBox]( [page:Box3 box] )</h3>
+		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - the [page:Box3] to check for intersection.<br /><br />
 
 		Determines whether or not this plane intersects [page:Box3 box].
 		</div>
 
-		<h3>[method:Boolean intersectsLine]( [page:Line3 line] )</h3>
+		<h3>[method:Boolean intersectsLine]( [param:Line3 line] )</h3>
 		<div>
 		[page:Line3 line] - the [page:Line3] to check for intersection.<br /><br />
 
 		Tests whether a line segment intersects with (passes through) the plane.
 		</div>
 
-		<h3>[method:Boolean intersectsSphere]( [page:Sphere sphere] )</h3>
+		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
 		<div>
 		[page:Sphere sphere]  - the [page:Sphere] to check for intersection.<br /><br />
 
@@ -119,7 +119,7 @@
 			value accordingly.
 		</div>
 
-		<h3>[method:Vector3 projectPoint]( [page:Vector3 point], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 projectPoint]( [param:Vector3 point], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Vector3 point] - the [page:Vector3] to project onto the plane.<br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
@@ -128,7 +128,7 @@
 		Projects a [page:Vector3 point] onto the plane.
 		</div>
 
-		<h3>[method:Plane set]( [page:Vector3 normal], [page:Float constant] )</h3>
+		<h3>[method:Plane set]( [param:Vector3 normal], [param:Float constant] )</h3>
 		<div>
 			[page:Vector3 normal] - a unit length [page:Vector3] defining the normal of the plane.<br />
 			[page:Float constant] - the signed distance from the origin to the plane. Default is *0*.<br /><br />
@@ -136,7 +136,7 @@
 			 Sets the plane's [page:.normal normal] and [page:.constant constant] properties.
 		</div>
 
-		<h3>[method:Plane setComponents]( [page:Float x], [page:Float y], [page:Float z], [page:Float w] )</h3>
+		<h3>[method:Plane setComponents]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
 		<div>
 		[page:Float x] - x value of the unit length normal vector.<br />
 		[page:Float y] - y value of the unit length normal vector.<br />
@@ -146,7 +146,7 @@
 		Set the individual components that define the plane.
 		</div>
 
-		<h3>[method:Plane setFromCoplanarPoints]( [page:Vector3 a], [page:Vector3 b], [page:Vector3 c] )</h3>
+		<h3>[method:Plane setFromCoplanarPoints]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c] )</h3>
 		<div>
 		 [page:Vector3 a] - first point on the plane.<br />
 		 [page:Vector3 b] - second point on the plane.<br />
@@ -156,7 +156,7 @@
 		and determines the direction of the [page:.normal normal].
 		</div>
 
-		<h3>[method:Plane setFromNormalAndCoplanarPoint]( [page:Vector3 normal], [page:Vector3 point] ) [page:Vector3 this]</h3>
+		<h3>[method:Plane setFromNormalAndCoplanarPoint]( [param:Vector3 normal], [param:Vector3 point] ) [param:Vector3 this]</h3>
 		<div>
 		[page:Vector3 normal] - a unit length [page:Vector3] defining the normal of the plane.<br />
 		[page:Vector3 point] - [page:Vector3]<br /><br />
@@ -164,7 +164,7 @@
 		Sets the plane's properties as defined by a [page:Vector3 normal] and an arbitrary coplanar [page:Vector3 point].
 		</div>
 
-		<h3>[method:Plane translate]( [page:Vector3 offset] )</h3>
+		<h3>[method:Plane translate]( [param:Vector3 offset] )</h3>
 		<div>
 		[page:Vector3 offset] - the amount to move the plane by.<br /><br />
 

--- a/docs/api/math/Quaternion.html
+++ b/docs/api/math/Quaternion.html
@@ -72,13 +72,13 @@
 		represents the same rotation in the opposite direction about the rotational axis.
 		</div>
 
-		<h3>[method:Quaternion copy]( [page:Quaternion q] )</h3>
+		<h3>[method:Quaternion copy]( [param:Quaternion q] )</h3>
 		<div>
 			Copies the [page:.x x], [page:.y y],	[page:.z z] and [page:.w w] properties
 			of [page:Quaternion q] into this quaternion.
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Quaternion v] )</h3>
+		<h3>[method:Boolean equals]( [param:Quaternion v] )</h3>
 		<div>
 		[page:Quaternion v] - Quaternion that this quaternion will be compared to.<br /><br />
 
@@ -87,13 +87,13 @@
 		represent the same rotation.
 		</div>
 
-		<h3>[method:Float dot]( [page:Quaternion v] )</h3>
+		<h3>[method:Float dot]( [param:Quaternion v] )</h3>
 		<div>
 			Calculates the [link:https://en.wikipedia.org/wiki/Dot_product dot product] of
 			quaternions [page:Quaternion v] and this one.
 		</div>
 
-		<h3>[method:Quaternion fromArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Quaternion fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - array of format (x, y, z, w) used to construct the quaternion.<br />
 		[page:Integer offset] - (optional) an offset into the array.<br /><br />
@@ -127,16 +127,16 @@
 		equal to *1*.
 		</div>
 
-		<h3>[method:Quaternion multiply]( [page:Quaternion q] )</h3>
+		<h3>[method:Quaternion multiply]( [param:Quaternion q] )</h3>
 		<div>Multiplies this quaternion by [page:Quaternion q].</div>
 
-		<h3>[method:Quaternion multiplyQuaternions]( [page:Quaternion a], [page:Quaternion b] )</h3>
+		<h3>[method:Quaternion multiplyQuaternions]( [param:Quaternion a], [param:Quaternion b] )</h3>
 		<div>
 		Sets this quaternion to [page:Quaternion a] x [page:Quaternion b].<br />
 		Adapted from the method outlined [link:http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm here].
 		</div>
 
-		<h3>[method:Quaternion onChange]( [page:Function onChangeCallback] )</h3>
+		<h3>[method:Quaternion onChange]( [param:Function onChangeCallback] )</h3>
 		<div>Sets the [page:.onChangeCallback onChangeCallback]() method.</div>
 
 		<h3>[method:Quaternion onChangeCallback]( )</h3>
@@ -162,10 +162,10 @@
 		</div>
 
 
-		<h3>[method:Quaternion premultiply]( [page:Quaternion q] )</h3>
+		<h3>[method:Quaternion premultiply]( [param:Quaternion q] )</h3>
 		<div>Pre-multiplies this quaternion by [page:Quaternion q].</div>
 
-		<h3>[method:Quaternion slerp]( [page:Quaternion qb], [page:float t] )</h3>
+		<h3>[method:Quaternion slerp]( [param:Quaternion qb], [param:float t] )</h3>
 		<div>
 			[page:Quaternion qb] - The other quaternion rotation<br />
 			[page:float t] - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -181,26 +181,26 @@
 			</code>
 		</div>
 
-		<h3>[method:Quaternion set]( [page:Float x], [page:Float y], [page:Float z], [page:Float w] )</h3>
+		<h3>[method:Quaternion set]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
 		<div>Sets [page:.x x], [page:.y y], [page:.z z], [page:.w w] properties of this quaternion.</div>
 
-		<h3>[method:Quaternion setFromAxisAngle]( [page:Vector3 axis], [page:Float angle] )</h3>
+		<h3>[method:Quaternion setFromAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<div>
 		Sets this quaternion from rotation specified by [page:Vector3 axis] and [page:Float angle].<br />
 		Adapted from the method [link:http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm here].<br />
 		*Axis* is assumed to be normalized, *angle* is in radians.
 		</div>
 
-		<h3>[method:Quaternion setFromEuler]( [page:Euler euler] )</h3>
+		<h3>[method:Quaternion setFromEuler]( [param:Euler euler] )</h3>
 		<div>Sets this quaternion from the rotation specified by [page:Euler] angle.</div>
 
-		<h3>[method:Quaternion setFromRotationMatrix]( [page:Matrix4 m] )</h3>
+		<h3>[method:Quaternion setFromRotationMatrix]( [param:Matrix4 m] )</h3>
 		<div>
 		Sets this quaternion from rotation component of [page:Matrix4 m].<br />
 		Adapted from the method [link:http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm here].
 		</div>
 
-		<h3>[method:Quaternion setFromUnitVectors]( [page:Vector3 vFrom], [page:Vector3 vTo] )</h3>
+		<h3>[method:Quaternion setFromUnitVectors]( [param:Vector3 vFrom], [param:Vector3 vTo] )</h3>
 		<div>
 		Sets this quaternion to the rotation required to rotate direction vector [page:Vector3 vFrom] to
 		direction vector [page:Vector3 vTo].<br />
@@ -208,7 +208,7 @@
 		[page:Vector3 vFrom] and [page:Vector3 vTo] are assumed to be normalized.
 		</div>
 
-		<h3>[method:Array toArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - An optional array to store the quaternion. If not specified, a new array will be created.<br/>
 		[page:Integer offset] - (optional) if specified, the result will be copied
@@ -236,7 +236,7 @@ q.slerp( qb, t )
 
 		</div>
 
-		<h3>[method:Quaternion slerp]( [page:Quaternion qStart], [page:Quaternion qEnd], [page:Quaternion qTarget], [page:Float t] )</h3>
+		<h3>[method:Quaternion slerp]( [param:Quaternion qStart], [param:Quaternion qEnd], [param:Quaternion qTarget], [param:Float t] )</h3>
 		<div>
 			[page:Quaternion qStart] - The starting quaternion (where [page:Float t] is 0)<br />
 			[page:Quaternion qEnd] - The ending quaternion (where [page:Float t] is 1)<br />

--- a/docs/api/math/Quaternion.html
+++ b/docs/api/math/Quaternion.html
@@ -33,7 +33,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Float x], [page:Float y], [page:Float z], [page:Float w] )</h3>
+		<h3>[name]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
 		<div>
 		[page:Float x] - x coordinate<br />
 		[page:Float y] - y coordinate<br />

--- a/docs/api/math/Ray.html
+++ b/docs/api/math/Ray.html
@@ -46,14 +46,14 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Ray applyMatrix4]( [page:Matrix4 matrix4] )</h3>
+		<h3>[method:Ray applyMatrix4]( [param:Matrix4 matrix4] )</h3>
 		<div>
 		[page:Matrix4 matrix4] - the [page:Matrix4] to apply to this [page:Ray].<br /><br />
 
 		Transform this [page:Ray] by the [page:Matrix4].
 		</div>
 
-		<h3>[method:Vector3 at]( [page:Float t], [page:Vector3 optionalTarget] ) </h3>
+		<h3>[method:Vector3 at]( [param:Float t], [param:Vector3 optionalTarget] ) </h3>
 		<div>
 		[page:Float t] - the distance along the [page:Ray] to retrieve a position for.<br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
@@ -67,7 +67,7 @@
 			Creates a new Ray with identical [page:.origin origin] and [page:.direction direction]  to this one.
 		</div>
 
-		<h3>[method:Vector3 closestPointToPoint]( [page:Vector3 point], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 closestPointToPoint]( [param:Vector3 point], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Vector3 point] - the point to get the closest approach to. <br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
@@ -76,20 +76,20 @@
 		Get the point along this [page:Ray] that is closest to the [page:Vector3] provided.
 		</div>
 
-		<h3>[method:Ray copy]( [page:Ray ray] )</h3>
+		<h3>[method:Ray copy]( [param:Ray ray] )</h3>
 		<div>
 			Copies the [page:.origin origin] and [page:.direction direction] properties
 			of [page:Ray ray] into this ray.
 		</div>
 
-		<h3>[method:Float distanceSqToPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Float distanceSqToPoint]( [param:Vector3 point] )</h3>
 		<div>
 		[page:Vector3 point] - the [page:Vector3] to compute a distance to.<br /><br />
 
 		Get the squared distance of the closest approach between the [page:Ray] and the [page:Vector3].
 		</div>
 
-		<h3>[method:Float distanceSqToSegment]( [page:Vector3 v0], [page:Vector3 v1], [page:Vector3 optionalPointOnRay], [page:Vector3 optionalPointOnSegment] )</h3>
+		<h3>[method:Float distanceSqToSegment]( [param:Vector3 v0], [param:Vector3 v1], [param:Vector3 optionalPointOnRay], [param:Vector3 optionalPointOnSegment] )</h3>
 		<div>
 		[page:Vector3 v0] - the start of the line segment.<br />
 		[page:Vector3 v1] - the end of the line segment.<br />
@@ -101,14 +101,14 @@
 		Get the squared distance between this [page:Ray] and a line segment.
 		</div>
 
-		<h3>[method:Float distanceToPlane]( [page:Plane plane] )</h3>
+		<h3>[method:Float distanceToPlane]( [param:Plane plane] )</h3>
 		<div>
 		[page:Plane plane] - the [page:Plane] to get the distance to.<br /><br />
 
 		Get the distance from [page:.origin origin] to the [page:Plane], or *null* if the [page:Ray] doesn't intersect the [page:Plane].
 		</div>
 
-		<h3>[method:Float distanceToPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] The [page:Vector3] to compute a distance to.<br /><br />
 
@@ -116,7 +116,7 @@
 		</div>
 
 
-		<h3>[method:Boolean equals]( [page:Ray ray] )</h3>
+		<h3>[method:Boolean equals]( [param:Ray ray] )</h3>
 		<div>
 		[page:Ray ray] - the [page:Ray] to compare to.<br /><br />
 
@@ -124,7 +124,7 @@
 		 and [page:.direction direction].
 		</div>
 
-		<h3>[method:Vector3 intersectBox]( [page:Box3 box], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 intersectBox]( [param:Box3 box], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Box3 box] - the [page:Box3] to intersect with.<br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
@@ -134,7 +134,7 @@
 		*null* if there is no intersection.
 		</div>
 
-		<h3>[method:Vector3 intersectPlane]( [page:Plane plane], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 intersectPlane]( [param:Plane plane], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Plane plane] - the [page:Plane] to intersect with.<br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
@@ -144,7 +144,7 @@
 		*null* if there is no intersection.
 		</div>
 
-		<h3>[method:Vector3 intersectSphere]( [page:Sphere sphere], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 intersectSphere]( [param:Sphere sphere], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Sphere sphere] - the [page:Sphere] to intersect with.<br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
@@ -154,7 +154,7 @@
 		*null* if there is no intersection.
 		</div>
 
-		<h3>[method:Vector3 intersectTriangle]( [page:Vector3 a], [page:Vector3 b], [page:Vector3 c], [page:Boolean backfaceCulling], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 intersectTriangle]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c], [param:Boolean backfaceCulling], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Vector3 a], [page:Vector3 b], [page:Vector3 c] - The [page:Vector3] points making up the triangle.<br />
 		[page:Boolean backfaceCulling] - whether to use backface culling.<br />
@@ -165,42 +165,42 @@
 		if there is no intersection.
 		</div>
 
-		<h3>[method:Boolean intersectsBox]( [page:Box3 box] )</h3>
+		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - the [page:Box3] to intersect with.<br /><br />
 
 		Return true if this [page:Ray] intersects with the [page:Box3].
 		</div>
 
-		<h3>[method:Boolean intersectsPlane]( [page:Plane plane] )</h3>
+		<h3>[method:Boolean intersectsPlane]( [param:Plane plane] )</h3>
 		<div>
 		[page:Plane plane] - the [page:Plane] to intersect with.<br /><br />
 
 		Return true if this [page:Ray] intersects with the [page:Plane].
 		</div>
 
-		<h3>[method:Boolean intersectsSphere]( [page:Sphere sphere] )</h3>
+		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
 		<div>
 		[page:Sphere sphere] - the [page:Sphere] to intersect with.<br /><br />
 
 		Return true if this [page:Ray] intersects with the [page:Sphere].
 		</div>
 
-		<h3>[method:Ray lookAt]( [page:Vector3 v] )</h3>
+		<h3>[method:Ray lookAt]( [param:Vector3 v] )</h3>
 		<div>
 		[page:Vector3 v] - The [page:Vector3] to look at.<br /><br />
 
 		Adjusts the direction of the ray to point at the vector in world coordinates.
 		</div>
 
-		<h3>[method:Ray recast]( [page:Float t] )</h3>
+		<h3>[method:Ray recast]( [param:Float t] )</h3>
 		<div>
 		[page:Float t] - The distance along the [page:Ray] to interpolate.<br /><br />
 
 		Shift the origin of this [page:Ray] along its direction by the distance given.
 		</div>
 
-		<h3>[method:Ray set]( [page:Vector3 origin], [page:Vector3 direction] )</h3>
+		<h3>[method:Ray set]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
 		<div>
 		[page:Vector3 origin] - the [page:.origin origin] of the [page:Ray].<br />
 		[page:Vector3 origin] - the [page:.direction direction] of the [page:Ray].

--- a/docs/api/math/Ray.html
+++ b/docs/api/math/Ray.html
@@ -21,7 +21,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector3 origin], [page:Vector3 direction] )</h3>
+		<h3>[name]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
 		<div>
 		[page:Vector3 origin] - (optional) the origin of the [page:Ray]. Default is a [page:Vector3] at (0, 0, 0).<br />
 		[page:Vector3 direction] - [page:Vector3] The direction of the [page:Ray]. This must be normalized

--- a/docs/api/math/Sphere.html
+++ b/docs/api/math/Sphere.html
@@ -34,14 +34,14 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Sphere applyMatrix4]( [page:Matrix4 matrix] )</h3>
+		<h3>[method:Sphere applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<div>
 			[page:Matrix4 matrix] - the [Page:Matrix4] to apply <br /><br />
 
 			Transforms this sphere with the provided [page:Matrix4].
 		</div>
 
-		<h3>[method:Vector3 clampPoint]( [page:Vector3 point], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 clampPoint]( [param:Vector3 point], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] The point to clamp.<br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3],
@@ -54,7 +54,7 @@
 		<h3>[method:Sphere clone]()</h3>
 		<div>Returns a new sphere with the same [page:.center center] and [page:.radius radius] as this one.</div>
 
-		<h3>[method:Boolean containsPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Boolean containsPoint]( [param:Vector3 point] )</h3>
 		<div>
 		[page:Vector3 point] - the [page:Vector3] to be checked<br /><br />
 
@@ -62,13 +62,13 @@
 		surface of the sphere.
 		</div>
 
-		<h3>[method:Sphere copy]( [page:Sphere sphere] )</h3>
+		<h3>[method:Sphere copy]( [param:Sphere sphere] )</h3>
 		<div>
 		Copies the values of the passed sphere's [page:.center center] and [page:.radius radius]
 		properties to this sphere.
 		</div>
 
-		<h3>[method:Float distanceToPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
 		<div>
 		Returns the closest distance from the boundary of the sphere to the [page:Vector3 point]. If the sphere contains the point,
 		the distance will be negative.
@@ -77,40 +77,40 @@
 		<h3>[method:Boolean empty]()</h3>
 		<div>Checks to see if the sphere is empty (the radius set to 0).</div>
 
-		<h3>[method:Boolean equals]( [page:Sphere sphere] )</h3>
+		<h3>[method:Boolean equals]( [param:Sphere sphere] )</h3>
 		<div>
 		Checks to see if the two spheres' centers and radii are equal.
 		</div>
 
-		<h3>[method:Box3 getBoundingBox]( [page:Box3 optionalTarget] )</h3>
+		<h3>[method:Box3 getBoundingBox]( [param:Box3 optionalTarget] )</h3>
 		<div>
 			[page:Box3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Box3], otherwise a new [page:Box3] will be created.<br /><br />
 
 			Returns a[link:https://en.wikipedia.org/wiki/Minimum_bounding_box Minimum Bounding Box] for the sphere.
 		</div>
 
-		<h3>[method:Boolean intersectsBox]( [page:Box3 box] )</h3>
+		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - [page:Box3] to check for intersection against.<br /><br />
 
 		Determines whether or not this sphere intersects a given [page:Box3 box].
 		</div>
 
-		<h3>[method:Boolean intersectsPlane]( [page:Plane plane] )</h3>
+		<h3>[method:Boolean intersectsPlane]( [param:Plane plane] )</h3>
 		<div>
 		[page:Plane plane] - Plane to check for intersection against.<br /><br />
 
 		Determines whether or not this sphere intersects a given [page:Plane plane].
 		</div>
 
-		<h3>[method:Boolean intersectsSphere]( [page:Sphere sphere] )</h3>
+		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
 		<div>
 		[page:Sphere sphere] - Sphere to check for intersection against.<br /><br />
 
 		Checks to see if two spheres intersect.
 		</div>
 
-		<h3>[method:Sphere set]( [page:Vector3 center], [page:Float radius] )</h3>
+		<h3>[method:Sphere set]( [param:Vector3 center], [param:Float radius] )</h3>
 		<div>
 			[page:Vector3 center] - center of the sphere.<br />
 			[page:Float radius] - radius of the sphere.<br /><br />
@@ -118,7 +118,7 @@
 		Sets the [page:.center center] and [page:.radius radius] properties of this sphere.
 		</div>
 
-		<h3>[method:Sphere setFromPoints]( [page:Array points], [page:Vector3 optionalCenter] )</h3>
+		<h3>[method:Sphere setFromPoints]( [param:Array points], [param:Vector3 optionalCenter] )</h3>
 		<div>
 		[page:Array points] - an [page:Array] of [page:Vector3] positions.<br />
 		[page:Vector3 optionalCenter] - Optional [page:Vector3] position for the sphere's center.<br /><br />
@@ -128,7 +128,7 @@
 		[page:Array points] is calculated.
 		</div>
 
-		<h3>[method:Sphere translate]( [page:Vector3 offset] )</h3>
+		<h3>[method:Sphere translate]( [param:Vector3 offset] )</h3>
 		Translate the sphere's center by the provided offset [page:Vector3].
 		</div>
 

--- a/docs/api/math/Sphere.html
+++ b/docs/api/math/Sphere.html
@@ -13,7 +13,7 @@
 		<div class="desc">A sphere defined by a center and radius.</div>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:Vector3 center], [page:Float radius] )</h3>
+		<h3>[name]( [param:Vector3 center], [param:Float radius] )</h3>
 		<div>
 		[page:Vector3 center] - center of the sphere. Default is a [page:Vector3] at (0, 0, 0). <br />
 		[page:Float radius] - radius of the sphere. Default is 0.<br /><br />

--- a/docs/api/math/Spherical.html
+++ b/docs/api/math/Spherical.html
@@ -16,7 +16,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Float radius], [page:Float phi], [page:Float theta] )</h3>
+		<h3>[name]( [param:Float radius], [param:Float phi], [param:Float theta] )</h3>
 		<div>
 		[page:Float radius] - the radius, or the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
 		(straight-line distance) from the point to the origin. Default is *1.0*.<br />

--- a/docs/api/math/Spherical.html
+++ b/docs/api/math/Spherical.html
@@ -44,7 +44,7 @@
 		and [page:.theta theta] properties as this one.
 		</div>
 
-		<h3>[method:Spherical copy]( [page:Spherical s] )</h3>
+		<h3>[method:Spherical copy]( [param:Spherical s] )</h3>
 		<div>
 			Copies the values of the passed Spherical's [page:.radius radius], [page:.phi phi]
 			and [page:.theta theta] properties to this spherical.
@@ -55,11 +55,11 @@
 		Restricts the polar angle page:.phi phi] to be between 0.000001 and pi - 0.000001.
 		</div>
 
-		<h3>[method:Spherical set]( [page:Float radius], [page:Float phi], [page:Float theta] )</h3>
+		<h3>[method:Spherical set]( [param:Float radius], [param:Float phi], [param:Float theta] )</h3>
 		<div>Sets values of this spherical's [page:.radius radius], [page:.phi phi]
 		and [page:.theta theta] properties.</div>
 
-		<h3>[method:Spherical setFromVector3]( [page:Vector3 vec3] )</h3>
+		<h3>[method:Spherical setFromVector3]( [param:Vector3 vec3] )</h3>
 		<div>
 			Sets values of this spherical's [page:.radius radius], [page:.phi phi]
 			and [page:.theta theta] properties from the [page:Vector3 Vector3].<br /><br />

--- a/docs/api/math/Triangle.html
+++ b/docs/api/math/Triangle.html
@@ -19,7 +19,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector3 a], [page:Vector3 b], [page:Vector3 c] )</h3>
+		<h3>[name]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c] )</h3>
 		<div>
 		[page:Vector3 a] - the first corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).<br />
 		[page:Vector3 b] - the second corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).<br />

--- a/docs/api/math/Triangle.html
+++ b/docs/api/math/Triangle.html
@@ -51,7 +51,7 @@
 		<h3>[method:Float area]()</h3>
 		<div>Return the area of the triangle.</div>
 
-		<h3>[method:Vector3 barycoordFromPoint]( [page:Vector3 point], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 barycoordFromPoint]( [param:Vector3 point], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] <br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3], otherwise a new [page:Vector3] will be created.<br /><br />
@@ -67,7 +67,7 @@
 			Returns a new triangle with the same [page:.a a], [page:.b b] and  [page:.c c] properties as this one.
 		</div>
 
-		<h3>[method:Vector3 closestPointToPoint]( [page:Vector3 point], [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 closestPointToPoint]( [param:Vector3 point], [param:Vector3 optionalTarget] )</h3>
 		<div>
 		point - [page:Vector3] <br />
 		[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3], otherwise a new [page:Vector3] will be created.<br /><br />
@@ -75,58 +75,58 @@
 		Returns the closest point on the triangle to [page:Vector3 point].
 		</div>
 
-		<h3>[method:Boolean containsPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Boolean containsPoint]( [param:Vector3 point] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] to check.<br /><br />
 
 		Returns true if the passed point, when projected onto the plane of the triangle, lies within the triangle.
 		</div>
 
-		<h3>[method:Triangle copy]( [page:Triangle triangle] )</h3>
+		<h3>[method:Triangle copy]( [param:Triangle triangle] )</h3>
 		<div>
 			Copies the values of the passed triangles's [page:.a a], [page:.b b] and [page:.c c]
 			properties to this triangle.
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Triangle triangle] )</h3>
+		<h3>[method:Boolean equals]( [param:Triangle triangle] )</h3>
 		<div>
 		Returns true if the two triangles have identical [page:.a a], [page:.b b] and [page:.c c] properties.
 		</div>
 
-		<h3>[method:Boolean intersectsBox]( [page:Box3 box] )</h3>
+		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
 		<div>
 		[page:Box3 box] - Box to check for intersection against.<br /><br />
 
 		Determines whether or not this triangle intersects [page:Box3 box].
 		</div>
 
-		<h3>[method:Vector3 midpoint]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 midpoint]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 			[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3], otherwise a new [page:Vector3] will be created.<br /><br />
 
 		Calculate the midpoint of the triangle.
 		</div>
 
-		<h3>[method:Vector3 normal]( [page:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 normal]( [param:Vector3 optionalTarget] )</h3>
 		<div>
 			[page:Vector3 optionalTarget] - (optional) if specified, the result will be copied into this [page:Vector3], otherwise a new [page:Vector3] will be created.<br /><br />
 
 		Calculate the [link:https://en.wikipedia.org/wiki/Normal_(geometry) normal vector] of the triangle.
 		</div>
 
-		<h3>[method:Plane plane]( [page:Plane optionalTarget] )</h3>
+		<h3>[method:Plane plane]( [param:Plane optionalTarget] )</h3>
 		<div>
 			[page:Plane optionalTarget] - (optional) if specified, the result will be copied into this [page:Plane], otherwise a new [page:Plane] will be created.<br /><br />
 
 		Create a [page:Plane plane] based on the triangle. .
 		</div>
 
-		<h3>[method:Triangle set]( [page:Vector3 a], [page:Vector3 b], [page:Vector3 c] ) [page:Triangle this]</h3>
+		<h3>[method:Triangle set]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c] ) [param:Triangle this]</h3>
 		<div>
 		Sets the triangle's [page:.a a], [page:.b b] and [page:.c c] properties to the passed [page:vector3 vector3s].
 		</div>
 
-		<h3>[method:Triangle setFromPointsAndIndices]( [page:Array points], [page:Integer i0], [page:Integer i1], [page:Integer i2] ) [page:Triangle this]</h3>
+		<h3>[method:Triangle setFromPointsAndIndices]( [param:Array points], [param:Integer i0], [param:Integer i1], [param:Integer i2] ) [param:Triangle this]</h3>
 		<div>
 		points - [page:Array] of [page:Vector3]s <br />
 		i0 - [page:Integer] index <br />

--- a/docs/api/math/Vector2.html
+++ b/docs/api/math/Vector2.html
@@ -80,16 +80,16 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector2 add]( [page:Vector2 v] )</h3>
+		<h3>[method:Vector2 add]( [param:Vector2 v] )</h3>
 		<div>Adds [page:Vector2 v] to this vector.</div>
 
-		<h3>[method:Vector2 addScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector2 addScalar]( [param:Float s] )</h3>
 		<div>Adds the scalar value [page:Float s] to this vector's [page:.x x] and [page:.y y] values.</div>
 
-		<h3>[method:Vector2 addScaledVector]( [page:Vector2 v], [page:Float s] )</h3>
+		<h3>[method:Vector2 addScaledVector]( [param:Vector2 v], [param:Float s] )</h3>
 		<div>Adds the multiple of [page:Vector2 v] and [page:Float s] to this vector.</div>
 
-		<h3>[method:Vector2 addVectors]( [page:Vector2 a], [page:Vector2 b] )</h3>
+		<h3>[method:Vector2 addVectors]( [param:Vector2 a], [param:Vector2 b] )</h3>
 		<div>Sets this vector to [page:Vector2 a] + [page:Vector2 b].</div>
 
 		<h3>[method:Float angle]()</h3>
@@ -97,7 +97,7 @@
 		Computes the angle in radians of this vector with respect to the positive x-axis.
 		</div>
 
-		<h3>[method:Vector2 applyMatrix3]( [page:Matrix3 m] )</h3>
+		<h3>[method:Vector2 applyMatrix3]( [param:Matrix3 m] )</h3>
 		<div>
 		Multiplies this vector (with an implicit 1 as the 3rd component) by m.
 		</div>
@@ -107,7 +107,7 @@
 		The [page:.x x] and [page:.y y] components of the vector are rounded up to the nearest integer value.
 		</div>
 
-		<h3>[method:Vector2 clamp]( [page:Vector2 min], [page:Vector2 max] )</h3>
+		<h3>[method:Vector2 clamp]( [param:Vector2 min], [param:Vector2 max] )</h3>
 		<div>
 		[page:Vector2 min] - the minimum x and y values.<br />
 		[page:Vector2 max] - the maximum x and y values in the desired range<br /><br />
@@ -116,7 +116,7 @@
 		If this vector's x or y value is less than the min vector's x or y value, it is replaced by the corresponding value.
 		</div>
 
-		<h3>[method:Vector2 clampLength]( [page:Float min], [page:Float max] )</h3>
+		<h3>[method:Vector2 clampLength]( [param:Float min], [param:Float max] )</h3>
 		<div>
 		[page:Float min] - the minimum value the length will be clamped to <br />
 		[page:Float max] - the maximum value the length will be clamped to<br /><br />
@@ -125,7 +125,7 @@
 		If this vector's length is less than the min value, it is replaced by the min value.
 		</div>
 
-		<h3>[method:Vector2 clampScalar]( [page:Float min], [page:Float max] )</h3>
+		<h3>[method:Vector2 clampScalar]( [param:Float min], [param:Float max] )</h3>
 		<div>
 		[page:Float min] - the minimum value the components will be clamped to <br />
 		[page:Float max] - the maximum value the components will be clamped to<br /><br />
@@ -139,49 +139,49 @@
 		Returns a new Vector2 with the same [page:.x x] and [page:.y y] values as this one.
 		</div>
 
-		<h3>[method:Vector2 copy]( [page:Vector2 v] )</h3>
+		<h3>[method:Vector2 copy]( [param:Vector2 v] )</h3>
 		<div>
 			Copies the values of the passed Vector2's [page:.x x] and [page:.y y]
 			properties to this Vector2.
 		</div>
 
-		<h3>[method:Float distanceTo]( [page:Vector2 v] )</h3>
+		<h3>[method:Float distanceTo]( [param:Vector2 v] )</h3>
 		<div>Computes the distance from this vector to [page:Vector2 v].</div>
 
-		<h3>[method:Float manhattanDistanceTo]( [page:Vector2 v] )</h3>
+		<h3>[method:Float manhattanDistanceTo]( [param:Vector2 v] )</h3>
 		<div>
 		Computes the [link:https://en.wikipedia.org/wiki/Taxicab_geometry Manhattan distance] from this vector to [page:Vector2 v].
 		</div>
 
-		<h3>[method:Float distanceToSquared]( [page:Vector2 v] )</h3>
+		<h3>[method:Float distanceToSquared]( [param:Vector2 v] )</h3>
 		<div>
 		Computes the squared distance from this vector to [page:Vector2 v]. If you are just
 		comparing the distance with another distance, you should compare the distance squared instead
 		as it is slightly more efficient to calculate.
 		</div>
 
-		<h3>[method:Vector2 divide]( [page:Vector2 v] )</h3>
+		<h3>[method:Vector2 divide]( [param:Vector2 v] )</h3>
 		<div>Divides this vector by [page:Vector2 v].</div>
 
-		<h3>[method:Vector2 divideScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector2 divideScalar]( [param:Float s] )</h3>
 		<div>
 		Divides this vector by scalar [page:Float s].<br />
 		Sets vector to *( 0, 0 )* if [page:Float s] = 0.
 		</div>
 
-		<h3>[method:Float dot]( [page:Vector2 v] )</h3>
+		<h3>[method:Float dot]( [param:Vector2 v] )</h3>
 		<div>
 		Calculates the [link:https://en.wikipedia.org/wiki/Dot_product dot product] of this
 	  vector and [page:Vector2 v].
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Vector2 v] )</h3>
+		<h3>[method:Boolean equals]( [param:Vector2 v] )</h3>
 		<div>Checks for strict equality of this vector and [page:Vector2 v].</div>
 
 		<h3>[method:Vector2 floor]()</h3>
 		<div>The components of the vector are rounded down to the nearest integer value.</div>
 
-		<h3>[method:Vector2 fromArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Vector2 fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - (optional) offset into the array. Default is 0.<br /><br />
@@ -189,7 +189,7 @@
 		Sets this vector's [page:.x x] value to be array[ offset ] and [page:.y y] value to be array[ offset + 1 ].
 		</div>
 
-		<h3>[method:Vector2 fromBufferAttribute]( [page:BufferAttribute attribute], [page:Integer index] )</h3>
+		<h3>[method:Vector2 fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
 		<div>
 		[page:BufferAttribute attribute] - the source attribute.<br />
 		[page:Integer index] - index in the attribute.<br /><br />
@@ -197,7 +197,7 @@
 		Sets this vector's [page:.x x] and [page:.y y] values from the [page:BufferAttribute attribute].
 		</div>
 
-		<h3>[method:Float getComponent]( [page:Integer index] )</h3>
+		<h3>[method:Float getComponent]( [param:Integer index] )</h3>
 		<div>
 		[page:Integer index] - 0 or 1.<br /><br />
 
@@ -221,7 +221,7 @@
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
 		</div>
 
-		<h3>[method:Vector2 lerp]( [page:Vector2 v], [page:Float alpha] )</h3>
+		<h3>[method:Vector2 lerp]( [param:Vector2 v], [param:Float alpha] )</h3>
 		<div>
 		[page:Vector2 v] - [page:Vector2] to interpolate towards.<br />
 		alpha - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -230,7 +230,7 @@
 		distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector2 v].
 		</div>
 
-		<h3>[method:Vector2 lerpVectors]( [page:Vector2 v1], [page:Vector2 v2], [page:Float alpha] )</h3>
+		<h3>[method:Vector2 lerpVectors]( [param:Vector2 v1], [param:Vector2 v2], [param:Float alpha] )</h3>
 		<div>
 		[page:Vector2 v1] - the starting [page:Vector2].<br />
 		[page:Vector2 v2] - [page:Vector2] to interpolate towards.<br />
@@ -250,26 +250,26 @@
 		as this one, but [page:.length length] 1.
 		</div>
 
-		<h3>[method:Vector2 max]( [page:Vector2 v] )</h3>
+		<h3>[method:Vector2 max]( [param:Vector2 v] )</h3>
 		<div>
 		If this vector's x or y value is less than [page:Vector2 v]'s x or y value, replace
 		that value with the corresponding max value.
 		</div>
 
-		<h3>[method:Vector2 min]( [page:Vector2 v] )</h3>
+		<h3>[method:Vector2 min]( [param:Vector2 v] )</h3>
 		<div>
 		If this vector's x or y value is greater than [page:Vector2 v]'s x or y value, replace
 		that value with the corresponding min value.
 		</div>
 
-		<h3>[method:Vector2 multiply]( [page:Vector2 v] )</h3>
+		<h3>[method:Vector2 multiply]( [param:Vector2 v] )</h3>
 		<div>Multiplies this vector by [page:Vector2 v].</div>
 
 
-		<h3>[method:Vector2 multiplyScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector2 multiplyScalar]( [param:Float s] )</h3>
 		<div>Multiplies this vector by scalar [page:Float s].</div>
 
-		<h3>[method:Vector2 rotateAround]( [page:Vector2 center], [page:float angle] )</h3>
+		<h3>[method:Vector2 rotateAround]( [param:Vector2 center], [param:float angle] )</h3>
 		<div>
 			[page:Vector2 center] - the point around which to rotate.<br />
 			[page:float angle] - the angle to rotate, in radians.<br /><br />
@@ -285,10 +285,10 @@
 		The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.
 		</div>
 
-		<h3>[method:Vector2 set]( [page:Float x], [page:Float y] )</h3>
+		<h3>[method:Vector2 set]( [param:Float x], [param:Float y] )</h3>
 		<div>Sets the [page:.x x] and [page:.y y] components of this vector.</div>
 
-		<h3>[method:null setComponent]( [page:Integer index], [page:Float value] )</h3>
+		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
 		<div>
 		[page:Integer index] - 0 or 1.<br />
 		[page:Float value] - [page:Float]<br /><br />
@@ -297,33 +297,33 @@
 		If index equals 1 set [page:.y y] to [page:Float value]
 		</div>
 
-		<h3>[method:Vector2 setLength]( [page:Float l] )</h3>
+		<h3>[method:Vector2 setLength]( [param:Float l] )</h3>
 		<div>
 		Sets this vector to the vector with the same direction as this one, but [page:.length length]
 		[page:Float l].
 		</div>
 
-		<h3>[method:Vector2 setScalar]( [page:Float scalar] )</h3>
+		<h3>[method:Vector2 setScalar]( [param:Float scalar] )</h3>
 		<div>
 		Sets the [page:.x x] and [page:.y y] values of this vector both equal to [page:Float scalar].
 		</div>
 
-		<h3>[method:Vector2 setX]( [page:Float x] )</h3>
+		<h3>[method:Vector2 setX]( [param:Float x] )</h3>
 		<div>Replaces this vector's [page:.x x] value with [page:Float x].</div>
 
-		<h3>[method:Vector2 setY]( [page:Float y] )</h3>
+		<h3>[method:Vector2 setY]( [param:Float y] )</h3>
 		<div>Replaces this vector's [page:.y y] value with [page:Float y].</div>
 
-		<h3>[method:Vector2 sub]( [page:Vector2 v] )</h3>
+		<h3>[method:Vector2 sub]( [param:Vector2 v] )</h3>
 		<div>Subtracts [page:Vector2 v] from this vector.</div>
 
-		<h3>[method:Vector2 subScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector2 subScalar]( [param:Float s] )</h3>
 		<div>Subtracts [page:Float s]  from this vector's [page:.x x] and [page:.y y] components.</div>
 
-		<h3>[method:Vector2 subVectors]( [page:Vector2 a], [page:Vector2 b] )</h3>
+		<h3>[method:Vector2 subVectors]( [param:Vector2 a], [param:Vector2 b] )</h3>
 		<div>Sets this vector to [page:Vector2 a] - [page:Vector2 b].</div>
 
-		<h3>[method:Array toArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - (optional) array to store the vector to. If this is not provided, a new array will be created.<br />
 		[page:Integer offset] - (optional) optional offset into the array.<br /><br />

--- a/docs/api/math/Vector2.html
+++ b/docs/api/math/Vector2.html
@@ -49,7 +49,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Float x], [page:Float y] )</h3>
+		<h3>[name]( [param:Float x], [param:Float y] )</h3>
 		<div>
 		[page:Float x] - the x value of the vector. Default is *0*.<br />
 		[page:Float y] -  the y value of the vector. Default is *0*.<br /><br />

--- a/docs/api/math/Vector3.html
+++ b/docs/api/math/Vector3.html
@@ -49,7 +49,7 @@ var d = a.distanceTo( b );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[name]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>
 		[page:Float x] - the x value of the vector. Default is *0*.<br />
 		[page:Float y] -  the y value of the vector. Default is *0*.<br />

--- a/docs/api/math/Vector3.html
+++ b/docs/api/math/Vector3.html
@@ -77,19 +77,19 @@ var d = a.distanceTo( b );
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector3 add]( [page:Vector3 v] )</h3>
+		<h3>[method:Vector3 add]( [param:Vector3 v] )</h3>
 		<div>Adds [page:Vector3 v] to this vector.</div>
 
-		<h3>[method:Vector3 addScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector3 addScalar]( [param:Float s] )</h3>
 		<div>Adds the scalar value s to this vector's [page:.x x], [page:.y y] and [page:.z z] values.</div>
 
-		<h3>[method:Vector3 addScaledVector]( [page:Vector3 v], [page:Float s] )</h3>
+		<h3>[method:Vector3 addScaledVector]( [param:Vector3 v], [param:Float s] )</h3>
 		<div>Adds the multiple of [page:Vector3 v] and [page:Float s] to this vector.</div>
 
-		<h3>[method:Vector3 addVectors]( [page:Vector3 a], [page:Vector3 b] )</h3>
+		<h3>[method:Vector3 addVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
 		<div>Sets this vector to [page:Vector3 a] + [page:Vector3 b].</div>
 
-		<h3>[method:Vector3 applyAxisAngle]( [page:Vector3 axis], [page:Float angle] )</h3>
+		<h3>[method:Vector3 applyAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<div>
 		[page:Vector3 axis] - A normalized [page:Vector3].<br />
 		[page:Float angle] - An angle in radians.<br /><br />
@@ -97,27 +97,27 @@ var d = a.distanceTo( b );
 		Applies a rotation specified by an axis and an angle to this vector.
 		</div>
 
-		<h3>[method:Vector3 applyEuler]( [page:Euler euler] )</h3>
+		<h3>[method:Vector3 applyEuler]( [param:Euler euler] )</h3>
 		<div>
 		Applies euler transform to this vector by converting the [page:Euler] object to a
 		[page:Quaternion] and applying.
 		</div>
 
-		<h3>[method:Vector3 applyMatrix3]( [page:Matrix3 m] )</h3>
+		<h3>[method:Vector3 applyMatrix3]( [param:Matrix3 m] )</h3>
 		<div>Multiplies this vector by [page:Matrix3 m]</div>
 
-		<h3>[method:Vector3 applyMatrix4]( [page:Matrix4 m] )</h3>
+		<h3>[method:Vector3 applyMatrix4]( [param:Matrix4 m] )</h3>
 		<div>
 		Multiplies this vector (with an implicit 1 in the 4th dimension) and m, and divides by perspective.
 		</div>
 
-		<h3>[method:Vector3 applyQuaternion]( [page:Quaternion quaternion] )</h3>
+		<h3>[method:Vector3 applyQuaternion]( [param:Quaternion quaternion] )</h3>
 		<div>
 		Applies a [page:Quaternion] transform to this vector.
 		</div>
 
 
-		<h3>[method:Float angleTo]( [page:Vector3 v] )</h3>
+		<h3>[method:Float angleTo]( [param:Vector3 v] )</h3>
 		<div>
 		Returns the angle between this vector and vector [page:Vector3 v] in radians.
 		</div>
@@ -127,7 +127,7 @@ var d = a.distanceTo( b );
 		The [page:.x x], [page:.y y] and [page:.z z] components of the vector are rounded up to the nearest integer value.
 		</div>
 
-		<h3>[method:Vector3 clamp]( [page:Vector3 min], [page:Vector3 max] )</h3>
+		<h3>[method:Vector3 clamp]( [param:Vector3 min], [param:Vector3 max] )</h3>
 		<div>
 		[page:Vector3 min] - the minimum [page:.x x], [page:.y y] and [page:.z z] values.<br />
 		[page:Vector3 max] - the maximum [page:.x x], [page:.y y] and [page:.z z] values in the desired range<br /><br />
@@ -136,7 +136,7 @@ var d = a.distanceTo( b );
 		If this vector's x, y or z value is less than the min vector's x, y or z value, it is replaced by the corresponding value.
 		</div>
 
-		<h3>[method:Vector3 clampLength]( [page:Float min], [page:Float max] )</h3>
+		<h3>[method:Vector3 clampLength]( [param:Float min], [param:Float max] )</h3>
 		<div>
 		[page:Float min] - the minimum value the length will be clamped to <br />
 		[page:Float max] - the maximum value the length will be clamped to<br /><br />
@@ -145,7 +145,7 @@ var d = a.distanceTo( b );
 		If this vector's length is less than the min value, it is replaced by the min value.
 		</div>
 
-		<h3>[method:Vector3 clampScalar]( [page:Float min], [page:Float max] )</h3>
+		<h3>[method:Vector3 clampScalar]( [param:Float min], [param:Float max] )</h3>
 		<div>
 		[page:Float min] - the minimum value the components will be clamped to <br />
 		[page:Float max] - the maximum value the components will be clamped to<br /><br />
@@ -159,59 +159,59 @@ var d = a.distanceTo( b );
 		Returns a new vector3 with the same [page:.x x], [page:.y y] and [page:.z z] values as this one.
 		</div>
 
-		<h3>[method:Vector3 copy]( [page:Vector3 v] )</h3>
+		<h3>[method:Vector3 copy]( [param:Vector3 v] )</h3>
 		<div>
 			Copies the values of the passed vector3's [page:.x x], [page:.y y] and [page:.z z]
 			properties to this vector3.
 		</div>
 
-		<h3>[method:Vector3 cross]( [page:Vector3 v] )</h3>
+		<h3>[method:Vector3 cross]( [param:Vector3 v] )</h3>
 		<div>
 		Sets this vector to [link:https://en.wikipedia.org/wiki/Cross_product cross product] of itself and [page:Vector3 v].
 		</div>
 
-		<h3>[method:Vector3 crossVectors]( [page:Vector3 a], [page:Vector3 b] )</h3>
+		<h3>[method:Vector3 crossVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
 		<div>
 		Sets this vector to [link:https://en.wikipedia.org/wiki/Cross_product cross product] of [page:Vector3 a] and [page:Vector3 b].
 		</div>
 
-		<h3>[method:Float distanceTo]( [page:Vector3 v] )</h3>
+		<h3>[method:Float distanceTo]( [param:Vector3 v] )</h3>
 		<div>Computes the distance from this vector to [page:Vector3 v].</div>
 
-		<h3>[method:Float manhattanDistanceTo]( [page:Vector3 v] )</h3>
+		<h3>[method:Float manhattanDistanceTo]( [param:Vector3 v] )</h3>
 		<div>
 		Computes the [link:https://en.wikipedia.org/wiki/Taxicab_geometry Manhattan distance] from this vector to [page:Vector3 v].
 		</div>
 
-		<h3>[method:Float distanceToSquared]( [page:Vector3 v] )</h3>
+		<h3>[method:Float distanceToSquared]( [param:Vector3 v] )</h3>
 		<div>
 		Computes the squared distance from this vector to [page:Vector3 v]. If you are just
 		comparing the distance with another distance, you should compare the distance squared instead
 		as it is slightly more efficient to calculate.
 		</div>
 
-		<h3>[method:Vector3 divide]( [page:Vector3 v] )</h3>
+		<h3>[method:Vector3 divide]( [param:Vector3 v] )</h3>
 		<div>Divides this vector by [page:Vector3 v].</div>
 
-		<h3>[method:Vector3 divideScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector3 divideScalar]( [param:Float s] )</h3>
 		<div>
 		Divides this vector by scalar [page:Float s].<br />
 		Sets vector to *( 0, 0, 0 )* if *[page:Float s] = 0*.
 		</div>
 
-		<h3>[method:Float dot]( [page:Vector3 v] )</h3>
+		<h3>[method:Float dot]( [param:Vector3 v] )</h3>
 		<div>
 		Calculate the [link:https://en.wikipedia.org/wiki/Dot_product dot product] of this
 		vector and [page:Vector3 v].
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Vector3 v] )</h3>
+		<h3>[method:Boolean equals]( [param:Vector3 v] )</h3>
 		<div>Checks for strict equality of this vector and [page:Vector3 v].</div>
 
 		<h3>[method:Vector3 floor]()</h3>
 		<div>The components of the vector are rounded down to the nearest integer value.</div>
 
-		<h3>[method:Vector3 fromArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Vector3 fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - ( optional) offset into the array. Default is 0.<br /><br />
@@ -220,7 +220,7 @@ var d = a.distanceTo( b );
 		and [page:.z z] value to be array[ offset + 2 ].
 		</div>
 
-		<h3>[method:Vector3 fromBufferAttribute]( [page:BufferAttribute attribute], [page:Integer index] )</h3>
+		<h3>[method:Vector3 fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
 		<div>
 		[page:BufferAttribute attribute] - the source attribute.<br />
 		[page:Integer index] - index in the attribute.<br /><br />
@@ -228,7 +228,7 @@ var d = a.distanceTo( b );
 		Sets this vector's [page:.x x], [page:.y y] and [page:.z z] values from the [page:BufferAttribute attribute].
 		</div>
 
-		<h3>[method:Float getComponent]( [page:Integer index] )</h3>
+		<h3>[method:Float getComponent]( [param:Integer index] )</h3>
 		<div>
 		[page:Integer index] - 0, 1 or 2.<br /><br />
 
@@ -253,7 +253,7 @@ var d = a.distanceTo( b );
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
 		</div>
 
-		<h3>[method:Vector3 lerp]( [page:Vector3 v], [page:Float alpha] )</h3>
+		<h3>[method:Vector3 lerp]( [param:Vector3 v], [param:Float alpha] )</h3>
 		<div>
 		[page:Vector3 v] - [page:Vector3] to interpolate towards.<br />
 		alpha - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -262,7 +262,7 @@ var d = a.distanceTo( b );
 		distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector3 v].
 		</div>
 
-		<h3>[method:Vector3 lerpVectors]( [page:Vector3 v1], [page:Vector3 v2], [page:Float alpha] )</h3>
+		<h3>[method:Vector3 lerpVectors]( [param:Vector3 v1], [param:Vector3 v2], [param:Float alpha] )</h3>
 		<div>
 		[page:Vector3 v1] - the starting [page:Vector3].<br />
 		[page:Vector3 v2] - [page:Vector3] to interpolate towards.<br />
@@ -282,35 +282,35 @@ var d = a.distanceTo( b );
 		as this one, but [page:.length length] 1.
 		</div>
 
-		<h3>[method:Vector3 max]( [page:Vector3 v] )</h3>
+		<h3>[method:Vector3 max]( [param:Vector3 v] )</h3>
 		<div>
 		If this vector's x, y or z value is less than [page:Vector3 v]'s x, y or z value, replace
 		that value with the corresponding max value.
 		</div>
 
-		<h3>[method:Vector3 min]( [page:Vector3 v] )</h3>
+		<h3>[method:Vector3 min]( [param:Vector3 v] )</h3>
 		<div>
 		If this vector's x, y or z value is greater than [page:Vector3 v]'s x, y or z value, replace
 		that value with the corresponding min value.
 		</div>
 
-		<h3>[method:Vector3 multiply]( [page:Vector3 v] )</h3>
+		<h3>[method:Vector3 multiply]( [param:Vector3 v] )</h3>
 		<div>Multiplies this vector by [page:Vector3 v].</div>
 
-		<h3>[method:Vector3 multiplyScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector3 multiplyScalar]( [param:Float s] )</h3>
 		<div>Multiplies this vector by scalar [page:Float s].</div>
 
-		<h3>[method:Vector3 multiplyVectors]( [page:Vector3 a], [page:Vector3 b] )</h3>
+		<h3>[method:Vector3 multiplyVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
 		<div>Sets this vector equal to [page:Vector3 a] * [page:Vector3 b], component-wise.</div>
 
-		<h3>[method:Vector3 project]( [page:Camera camera] )</h3>
+		<h3>[method:Vector3 project]( [param:Camera camera] )</h3>
 		<div>
 		[page:Camera camera] — camera to use in the projection.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Vector_projection Projects] the vector with the camera.
 		</div>
 
-		<h3>[method:Vector3 projectOnPlane]( [page:Vector3 planeNormal] )</h3>
+		<h3>[method:Vector3 projectOnPlane]( [param:Vector3 planeNormal] )</h3>
 		<div>
 		[page:Vector3 planeNormal] - A vector representing a plane normal.<br /><br />
 
@@ -318,10 +318,10 @@ var d = a.distanceTo( b );
 		normal from this vector.
 		</div>
 
-		<h3>[method:Vector3 projectOnVector]( [page:Vector3] )</h3>
+		<h3>[method:Vector3 projectOnVector]( [param:Vector3] )</h3>
 		<div>[link:https://en.wikipedia.org/wiki/Vector_projection Projects] this vector onto another vector.</div>
 
-		<h3>[method:Vector3 reflect]( [page:Vector3 normal] )</h3>
+		<h3>[method:Vector3 reflect]( [param:Vector3 normal] )</h3>
 		<div>
 		[page:Vector3 normal] - the normal to the reflecting plane<br /><br />
 
@@ -337,10 +337,10 @@ var d = a.distanceTo( b );
 		The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.
 		</div>
 
-		<h3>[method:Vector3 set]( [page:Float x], [page:Float y], [page:Float z] )</h3>
+		<h3>[method:Vector3 set]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<div>Sets the [page:.x x], [page:.y y] and [page:.z z] components of this vector.</div>
 
-		<h3>[method:null setComponent]( [page:Integer index], [page:Float value] )</h3>
+		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
 		<div>
 		[page:Integer index] - 0, 1 or 2.<br />
 		[page:Float value] - [page:Float]<br /><br />
@@ -350,64 +350,64 @@ var d = a.distanceTo( b );
 		If index equals 2 set [page:.z z] to [page:Float value]
 		</div>
 
-		<h3>[method:Vector3 setFromCylindrical]( [page:Cylindrical c] )</h3>
+		<h3>[method:Vector3 setFromCylindrical]( [param:Cylindrical c] )</h3>
 		<div>
 		Sets this vector from the cylindrical coordinates [page:Cylindrical c].
 		</div>
 
-		<h3>[method:Vector3 setFromMatrixColumn]( [page:Matrix4 matrix], [page:Integer index] )</h3>
+		<h3>[method:Vector3 setFromMatrixColumn]( [param:Matrix4 matrix], [param:Integer index] )</h3>
 		<div>
 		Sets this vector's [page:.x x], [page:.y y] and [page:.z z] equal to the column of
 		the [page:Matrix4 matrix] specified by the [page:Integer index].
 		</div>
 
-		<h3>[method:Vector3 setFromMatrixPosition]( [page:Matrix4 m] )</h3>
+		<h3>[method:Vector3 setFromMatrixPosition]( [param:Matrix4 m] )</h3>
 		<div>
 		Sets this vector to the position elements of the
 		[link:https://en.wikipedia.org/wiki/Transformation_matrix transformation matrix] [page:Matrix4 m].
 		</div>
 
-		<h3>[method:Vector3 setFromMatrixScale]( [page:Matrix4 m] )</h3>
+		<h3>[method:Vector3 setFromMatrixScale]( [param:Matrix4 m] )</h3>
 		<div>
 		Sets this vector to the scale elements of the
 		[link:https://en.wikipedia.org/wiki/Transformation_matrix transformation matrix] [page:Matrix4 m].
 		</div>
 
-		<h3>[method:Vector3 setFromSpherical]( [page:Spherical s] )</h3>
+		<h3>[method:Vector3 setFromSpherical]( [param:Spherical s] )</h3>
 		<div>
 		Sets this vector from the spherical coordinates [page:Spherical s].
 		</div>
 
-		<h3>[method:Vector3 setLength]( [page:Float l] )</h3>
+		<h3>[method:Vector3 setLength]( [param:Float l] )</h3>
 		<div>
 		Set this vector to the vector with the same direction as this one, but [page:.length length]
 		[page:Float l].
 		</div>
 
-		<h3>[method:Vector3 setScalar]( [page:Float scalar] )</h3>
+		<h3>[method:Vector3 setScalar]( [param:Float scalar] )</h3>
 		<div>
 		Set the [page:.x x], [page:.y y] and [page:.z z] values of this vector both equal to [page:Float scalar].
 		</div>
 
-		<h3>[method:Vector3 setX]( [page:Float x] )</h3>
+		<h3>[method:Vector3 setX]( [param:Float x] )</h3>
 		<div>Replace this vector's [page:.x x] value with [page:Float x].</div>
 
-		<h3>[method:Vector3 setY]( [page:Float y] )</h3>
+		<h3>[method:Vector3 setY]( [param:Float y] )</h3>
 		<div>Replace this vector's [page:.y y] value with [page:Float y].</div>
 
-		<h3>[method:Vector3 setZ]( [page:Float z] )</h3>
+		<h3>[method:Vector3 setZ]( [param:Float z] )</h3>
 		<div>Replace this vector's [page:.z z] value with [page:Float z].</div>
 
-		<h3>[method:Vector3 sub]( [page:Vector3 v] )</h3>
+		<h3>[method:Vector3 sub]( [param:Vector3 v] )</h3>
 		<div>Subtracts [page:Vector3 v] from this vector.</div>
 
-		<h3>[method:Vector3 subScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector3 subScalar]( [param:Float s] )</h3>
 		<div>Subtracts [page:Float s]  from this vector's [page:.x x], [page:.y y] and [page:.z z] compnents.</div>
 
-		<h3>[method:Vector3 subVectors]( [page:Vector3 a], [page:Vector3 b] )</h3>
+		<h3>[method:Vector3 subVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
 		<div>Sets this vector to [page:Vector3 a] - [page:Vector3 b].</div>
 
-		<h3>[method:Array toArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - (optional) array to store the vector to. If this is not provided
 		a new array will be created.<br />
@@ -416,13 +416,13 @@ var d = a.distanceTo( b );
 		Returns an array [x, y, z], or copies x, y and z into the provided [page:Array array].
 		</div>
 
-		<h3>[method:Vector3 transformDirection]( [page:Matrix4 m] )</h3>
+		<h3>[method:Vector3 transformDirection]( [param:Matrix4 m] )</h3>
 		<div>
 		Transforms the direction of this vector by a matrix (the upper left 3 x 3 subset of a [page:Matrix4 m])
 		and then [page:.normalize normalizes] the result.
 		</div>
 
-		<h3>[method:Vector3 unproject]( [page:Camera camera] )</h3>
+		<h3>[method:Vector3 unproject]( [param:Camera camera] )</h3>
 		<div>
 		[page:Camera camera] — camera to use in the projection.<br /><br />
 

--- a/docs/api/math/Vector4.html
+++ b/docs/api/math/Vector4.html
@@ -79,19 +79,19 @@ var d = a.dot( b );
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector4 add]( [page:Vector4 v] )</h3>
+		<h3>[method:Vector4 add]( [param:Vector4 v] )</h3>
 		<div>Adds [page:Vector4 v] to this vector.</div>
 
-		<h3>[method:Vector4 addScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector4 addScalar]( [param:Float s] )</h3>
 		<div>Adds the scalar value s to this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values.</div>
 
-		<h3>[method:Vector4 addScaledVector]( [page:Vector4 v], [page:Float s] )</h3>
+		<h3>[method:Vector4 addScaledVector]( [param:Vector4 v], [param:Float s] )</h3>
 		<div>Adds the multiple of [page:Vector4 v] and [page:Float s] to this vector.</div>
 
-		<h3>[method:Vector4 addVectors]( [page:Vector4 a], [page:Vector4 b] )</h3>
+		<h3>[method:Vector4 addVectors]( [param:Vector4 a], [param:Vector4 b] )</h3>
 		<div>Sets this vector to [page:Vector4 a] + [page:Vector4 b].</div>
 
-		<h3>[method:Vector4 applyMatrix4]( [page:Matrix4 m] )</h3>
+		<h3>[method:Vector4 applyMatrix4]( [param:Matrix4 m] )</h3>
 		<div>
 		Multiplies this vector by 4 x 4 [page:Matrix4 m].
 		</div>
@@ -101,7 +101,7 @@ var d = a.dot( b );
 		The [page:.x x], [page:.y y], [page:.z z] and [page:.w w] components of the vector are rounded up to the nearest integer value.
 		</div>
 
-		<h3>[method:Vector4 clamp]( [page:Vector4 min], [page:Vector4 max] )</h3>
+		<h3>[method:Vector4 clamp]( [param:Vector4 min], [param:Vector4 max] )</h3>
 		<div>
 		[page:Vector4 min] - the minimum [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values.<br />
 		[page:Vector4 max] - the maximum [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values in the desired range<br /><br />
@@ -110,7 +110,7 @@ var d = a.dot( b );
 		If this vector's x, y, z or w value is less than the min vector's x, y, z or w value, it is replaced by the corresponding value.
 		</div>
 
-		<h3>[method:Vector4 clampLength]( [page:Float min], [page:Float max] )</h3>
+		<h3>[method:Vector4 clampLength]( [param:Float min], [param:Float max] )</h3>
 		<div>
 		[page:Float min] - the minimum value the length will be clamped to <br />
 		[page:Float max] - the maximum value the length will be clamped to<br /><br />
@@ -119,7 +119,7 @@ var d = a.dot( b );
 		If this vector's length is less than the min value, it is replaced by the min value.
 		</div>
 
-		<h3>[method:Vector4 clampScalar]( [page:Float min], [page:Float max] )</h3>
+		<h3>[method:Vector4 clampScalar]( [param:Float min], [param:Float max] )</h3>
 		<div>
 		[page:Float min] - the minimum value the components will be clamped to <br />
 		[page:Float max] - the maximum value the components will be clamped to<br /><br />
@@ -133,31 +133,31 @@ var d = a.dot( b );
 		Returns a new Vector4 with the same [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values as this one.
 		</div>
 
-		<h3>[method:Vector4 copy]( [page:Vector4 v] )</h3>
+		<h3>[method:Vector4 copy]( [param:Vector4 v] )</h3>
 		<div>
 			Copies the values of the passed Vector4's [page:.x x], [page:.y y], [page:.z z] and [page:.w w]
 			properties to this Vector4.
 		</div>
 
-		<h3>[method:Vector4 divideScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector4 divideScalar]( [param:Float s] )</h3>
 		<div>
 		Divides this vector by scalar [page:Float s].<br />
 		Sets vector to *( 0, 0, 0, 0 )* if *[page:Float s] = 0*.
 		</div>
 
-		<h3>[method:Float dot]( [page:Vector4 v] )</h3>
+		<h3>[method:Float dot]( [param:Vector4 v] )</h3>
 		<div>
 		Calculates the [link:https://en.wikipedia.org/wiki/Dot_product dot product] of this
 		vector and [page:Vector4 v].
 		</div>
 
-		<h3>[method:Boolean equals]( [page:Vector4 v] )</h3>
+		<h3>[method:Boolean equals]( [param:Vector4 v] )</h3>
 		<div>Checks for strict equality of this vector and [page:Vector4 v].</div>
 
 		<h3>[method:Vector4 floor]()</h3>
 		<div>The components of the vector are rounded down to the nearest integer value.</div>
 
-		<h3>[method:Vector4 fromArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Vector4 fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - (optional) offset into the array. Default is 0.<br /><br />
@@ -166,7 +166,7 @@ var d = a.dot( b );
 		[page:.z z] value to be array[ offset + 2 ] and [page:.w w ] value to be array[ offset + 3 ].
 		</div>
 
-		<h3>[method:Vector4 fromBufferAttribute]( [page:BufferAttribute attribute], [page:Integer index] )</h3>
+		<h3>[method:Vector4 fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
 		<div>
 		[page:BufferAttribute attribute] - the source attribute.<br />
 		[page:Integer index] - index in the attribute.<br /><br />
@@ -174,7 +174,7 @@ var d = a.dot( b );
 		Sets this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values from the [page:BufferAttribute attribute].
 		</div>
 
-		<h3>[method:Float getComponent]( [page:Integer index] )</h3>
+		<h3>[method:Float getComponent]( [param:Integer index] )</h3>
 		<div>
 		[page:Integer index] - 0, 1, 2 or 3.<br /><br />
 
@@ -200,7 +200,7 @@ var d = a.dot( b );
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
 		</div>
 
-		<h3>[method:Vector4 lerp]( [page:Vector4 v], [page:Float alpha] )</h3>
+		<h3>[method:Vector4 lerp]( [param:Vector4 v], [param:Float alpha] )</h3>
 		<div>
 		[page:Vector4 v] - [page:Vector4] to interpolate towards.<br />
 		alpha - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -209,7 +209,7 @@ var d = a.dot( b );
 		distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector4 v].
 		</div>
 
-		<h3>[method:Vector4 lerpVectors]( [page:Vector4 v1], [page:Vector4 v2], [page:Float alpha] )</h3>
+		<h3>[method:Vector4 lerpVectors]( [param:Vector4 v1], [param:Vector4 v2], [param:Float alpha] )</h3>
 		<div>
 		[page:Vector4 v1] - the starting [page:Vector4].<br />
 		[page:Vector4 v2] - [page:Vector4] to interpolate towards.<br />
@@ -229,19 +229,19 @@ var d = a.dot( b );
 		as this one, but [page:.length length] 1.
 		</div>
 
-		<h3>[method:Vector4 max]( [page:Vector4 v] )</h3>
+		<h3>[method:Vector4 max]( [param:Vector4 v] )</h3>
 		<div>
 		If this vector's x, y, z or w value is less than [page:Vector4 v]'s x, y, z or w value, replace
 		that value with the corresponding max value.
 		</div>
 
-		<h3>[method:Vector4 min]( [page:Vector4 v] )</h3>
+		<h3>[method:Vector4 min]( [param:Vector4 v] )</h3>
 		<div>
 		If this vector's x, y, z or w value is greater than [page:Vector4 v]'s x, y, z or w value, replace
 		that value with the corresponding min value.
 		</div>
 
-		<h3>[method:Vector4 multiplyScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector4 multiplyScalar]( [param:Float s] )</h3>
 		<div>Multiplies this vector by scalar [page:Float s].</div>
 
 		<h3>[method:Vector4 round]()</h3>
@@ -252,10 +252,10 @@ var d = a.dot( b );
 		The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.
 		</div>
 
-		<h3>[method:Vector4 set]( [page:Float x], [page:Float y], [page:Float z], [page:Float w] )</h3>
+		<h3>[method:Vector4 set]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
 		<div>Sets the [page:.x x], [page:.y y], [page:.z z] and [page:.w w] components of this vector.</div>
 
-		<h3>[method:Vector4 setAxisAngleFromQuaternion]( [page:Quaterion q] )</h3>
+		<h3>[method:Vector4 setAxisAngleFromQuaternion]( [param:Quaterion q] )</h3>
 		<div>
 			[page:Quaterion q] - a normalized [page:Quaterion]<br /><br />
 
@@ -263,14 +263,14 @@ var d = a.dot( b );
 			quaternion's axis and [page:.w w] to the angle.
 		</div>
 
-		<h3>[method:Vector4 setAxisAngleFromRotationMatrix]( [page:Matrix4 m] )</h3>
+		<h3>[method:Vector4 setAxisAngleFromRotationMatrix]( [param:Matrix4 m] )</h3>
 		<div>
 			 [page:Matrix4 m] - a [page:Matrix4] of which the upper left 3x3 matrix is a pure rotation matrix.<br /><br />
 
 			Sets the [page:.x x], [page:.y y] and [page:.z z] to the axis of rotation and [page:.w w] to the angle.
 		</div>
 
-		<h3>[method:null setComponent]( [page:Integer index], [page:Float value] )</h3>
+		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
 		<div>
 		[page:Integer index] - 0, 1 or 2.<br />
 		[page:Float value] - [page:Float]<br /><br />
@@ -282,39 +282,39 @@ var d = a.dot( b );
 		</div>
 
 
-		<h3>[method:Vector4 setLength]( [page:Float l] )</h3>
+		<h3>[method:Vector4 setLength]( [param:Float l] )</h3>
 		<div>
 		Sets this vector to the vector with the same direction as this one, but [page:.length length]
 		[page:Float l].
 		</div>
 
-		<h3>[method:Vector4 setScalar]( [page:Float scalar] )</h3>
+		<h3>[method:Vector4 setScalar]( [param:Float scalar] )</h3>
 		<div>
 		Sets the [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values of this vector both equal to [page:Float scalar].
 		</div>
 
-		<h3>[method:Vector4 setX]( [page:Float x] )</h3>
+		<h3>[method:Vector4 setX]( [param:Float x] )</h3>
 		<div>Replaces this vector's [page:.x x] value with [page:Float x].</div>
 
-		<h3>[method:Vector4 setY]( [page:Float y] )</h3>
+		<h3>[method:Vector4 setY]( [param:Float y] )</h3>
 		<div>Replaces this vector's [page:.y y] value with [page:Float y].</div>
 
-		<h3>[method:Vector4 setZ]( [page:Float z] )</h3>
+		<h3>[method:Vector4 setZ]( [param:Float z] )</h3>
 		<div>Replaces this vector's [page:.z z] value with [page:Float z].</div>
 
-		<h3>[method:Vector4 setW]( [page:Float w] )</h3>
+		<h3>[method:Vector4 setW]( [param:Float w] )</h3>
 		<div>Replaces this vector's [page:.w w] value with [page:Float w].</div>
 
-		<h3>[method:Vector4 sub]( [page:Vector4 v] )</h3>
+		<h3>[method:Vector4 sub]( [param:Vector4 v] )</h3>
 		<div>Subtracts [page:Vector4 v] from this vector.</div>
 
-		<h3>[method:Vector4 subScalar]( [page:Float s] )</h3>
+		<h3>[method:Vector4 subScalar]( [param:Float s] )</h3>
 		<div>Subtracts [page:Float s]  from this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] compnents.</div>
 
-		<h3>[method:Vector4 subVectors]( [page:Vector4 a], [page:Vector4 b] )</h3>
+		<h3>[method:Vector4 subVectors]( [param:Vector4 a], [param:Vector4 b] )</h3>
 		<div>Sets this vector to [page:Vector4 a] - [page:Vector4 b].</div>
 
-		<h3>[method:Array toArray]( [page:Array array], [page:Integer offset] )</h3>
+		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
 		<div>
 		[page:Array array] - (optional) array to store the vector to. If this is not provided, a new array will be created.<br />
 		[page:Integer offset] - (optional) optional offset into the array.<br /><br />

--- a/docs/api/math/Vector4.html
+++ b/docs/api/math/Vector4.html
@@ -48,7 +48,7 @@ var d = a.dot( b );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Float x], [page:Float y], [page:Float z], [page:Float w] )</h3>
+		<h3>[name]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
 		<div>
 		[page:Float x] - the x value of the vector. Default is *0*.<br />
 		[page:Float y] -  the y value of the vector. Default is *0*.<br />

--- a/docs/api/math/interpolants/CubicInterpolant.html
+++ b/docs/api/math/interpolants/CubicInterpolant.html
@@ -73,7 +73,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [page:Number t] )</h3>
+		<h3>[method:null evaluate]( [param:Number t] )</h3>
 		<div>
 		Evaluate the interpolant at position *t*.
 		</div>

--- a/docs/api/math/interpolants/DiscreteInterpolant.html
+++ b/docs/api/math/interpolants/DiscreteInterpolant.html
@@ -73,7 +73,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [page:Number t] )</h3>
+		<h3>[method:null evaluate]( [param:Number t] )</h3>
 		<div>
 		Evaluate the interpolant at position *t*.
 		</div>

--- a/docs/api/math/interpolants/LinearInterpolant.html
+++ b/docs/api/math/interpolants/LinearInterpolant.html
@@ -73,7 +73,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [page:Number t] )</h3>
+		<h3>[method:null evaluate]( [param:Number t] )</h3>
 		<div>
 		Evaluate the interpolant at position *t*.
 		</div>

--- a/docs/api/math/interpolants/QuaternionLinearInterpolant.html
+++ b/docs/api/math/interpolants/QuaternionLinearInterpolant.html
@@ -73,7 +73,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [page:Number t] )</h3>
+		<h3>[method:null evaluate]( [param:Number t] )</h3>
 		<div>
 		Evaluate the interpolant at position *t*.
 		</div>

--- a/docs/api/objects/LOD.html
+++ b/docs/api/objects/LOD.html
@@ -68,7 +68,7 @@ scene.add( lod );
 		<h2>Methods</h2>
 		<div>See the base [page:Object3D] class for common methods.</div>
 
-		<h3>[method:null addLevel]( [page:Object3D object], [page:Float distance] )</h3>
+		<h3>[method:null addLevel]( [param:Object3D object], [param:Float distance] )</h3>
 		<div>
 		[page:Object3D object] - The [page:Object3D] to display at this level.<br />
 		[page:Float distance] - The distance at which to display this level of detail.<br /><br />
@@ -83,12 +83,12 @@ scene.add( lod );
 		</div>
 
 
-		<h3>[method:Object3D getObjectForDistance]( [page:Float distance] )</h3>
+		<h3>[method:Object3D getObjectForDistance]( [param:Float distance] )</h3>
 		<div>
 		Get a reference to the first [page:Object3D] (mesh) that is greater than [page:Float distance].
 		</div>
 
-		<h3>[method:Array raycast]( [page:Raycaster raycaster], [page:Array intersects] )</h3>
+		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<div>
 		Get intersections between a casted [page:Ray] and this LOD.
 		[page:Raycaster.intersectObject] will call this method.
@@ -101,7 +101,7 @@ scene.add( lod );
 		Create a JSON structure with details of this LOD object.
 		</div>
 
-		<h3>[method:null update]( [page:Camera camera] )</h3>
+		<h3>[method:null update]( [param:Camera camera] )</h3>
 		<div>
 			Set the visibility of each [page:levels level]'s [page:Object3D object] based on
 			distance from the [page:Camera camera]. This needs to be called in the render loop

--- a/docs/api/objects/Line.html
+++ b/docs/api/objects/Line.html
@@ -43,7 +43,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Geometry geometry], [page:Material material] )</h3>
+		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 
 		<div>
 		[page:Geometry geometry] — vertices representing the line segment(s). Default is a new [page:new BufferGeometry].<br />

--- a/docs/api/objects/Line.html
+++ b/docs/api/objects/Line.html
@@ -79,7 +79,7 @@
 		Computes an array of distance values which are necessary for [page:LineDashedMaterial]. For each vertex in the geometry, the method calculates the cumulative length from the current point to the very beginning of the line.
 		</div>
 
-		<h3>[method:Array raycast]( [page:Raycaster raycaster], [page:Array intersects] )</h3>
+		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<div>
 		Get intersections between a casted [page:Ray] and this Line.
 		[page:Raycaster.intersectObject] will call this method.

--- a/docs/api/objects/LineLoop.html
+++ b/docs/api/objects/LineLoop.html
@@ -24,7 +24,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Geometry geometry], [page:Material material] )</h3>
+		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 
 		<div>
 		[page:Geometry geometry] — List of vertices representing points on the line loop.<br />

--- a/docs/api/objects/LineSegments.html
+++ b/docs/api/objects/LineSegments.html
@@ -23,7 +23,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Geometry geometry], [page:Material material] )</h3>
+		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 
 		<div>
 		[page:Geometry geometry] — Pair(s) of vertices representing each line segment(s).<br />

--- a/docs/api/objects/Mesh.html
+++ b/docs/api/objects/Mesh.html
@@ -93,7 +93,7 @@
 		<h3>[method:Mesh clone]()</h3>
 		<div>Returns a clone of this [name] object and its descendants.</div>
 
-		<h3>[method:Array raycast]( [page:Raycaster raycaster], [page:Array intersects] )</h3>
+		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<div>
 		Get intersections between a casted ray and this mesh.
 		[page:Raycaster.intersectObject] will call this method.

--- a/docs/api/objects/Mesh.html
+++ b/docs/api/objects/Mesh.html
@@ -30,7 +30,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Geometry geometry], [page:Material material] )</h3>
+		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 		<div>
 		[page:Geometry geometry] — (optional) an instance of [page:Geometry] or [page:BufferGeometry].
 		  Default is a new [page:BufferGeometry].<br />

--- a/docs/api/objects/Points.html
+++ b/docs/api/objects/Points.html
@@ -21,7 +21,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Geometry geometry], [page:Material material] )</h3>
+		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 		<div>
 			[page:Geometry geometry] — (optional) an instance of [page:Geometry] or [page:BufferGeometry].
 				Default is a new [page:BufferGeometry].<br />

--- a/docs/api/objects/Points.html
+++ b/docs/api/objects/Points.html
@@ -58,7 +58,7 @@
 		<h2>Methods</h2>
 		<div>See the base [page:Object3D] class for common methods.</div>
 
-		<h3>[method:Array raycast]( [page:Raycaster raycaster], [page:Array intersects] )</h3>
+		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<div>
 		Get intersections between a casted ray and this Points.
 		[page:Raycaster.intersectObject] will call this method.

--- a/docs/api/objects/Skeleton.html
+++ b/docs/api/objects/Skeleton.html
@@ -47,7 +47,7 @@ var armSkeleton = new THREE.Skeleton( bones );
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Array bones], [page:Array boneInverses] )</h3>
+		<h3>[name]( [param:Array bones], [param:Array boneInverses] )</h3>
 		<div>
 		[page:Array bones] - The array of [page:Bone bones]. Default is an empty array.<br/>
 		[page:Array boneInverses] - (optional) An array of [page:Matrix4 Matrix4s].<br /><br />

--- a/docs/api/objects/SkinnedMesh.html
+++ b/docs/api/objects/SkinnedMesh.html
@@ -115,7 +115,7 @@
 		<h2>Methods</h2>
 		<div>See the base [page:Mesh] class for common methods.</div>
 
-		<h3>[method:null bind]( [page:Skeleton skeleton], [page:Matrix4 bindMatrix] )</h3>
+		<h3>[method:null bind]( [param:Skeleton skeleton], [param:Matrix4 bindMatrix] )</h3>
 		<div>
 		[page:Skeleton skeleton] - [page:Skeleton] created from a [page:Bone Bones] tree.<br/>
 		[page:Matrix4 bindMatrix] - [page:Matrix4] that represents the base transform of the skeleton.<br /><br />
@@ -141,7 +141,7 @@
 		This method sets the skinned mesh in the rest pose (resets the pose).
 		</div>
 
-		<h3>[method:null updateMatrixWorld]( [page:Boolean force] )</h3>
+		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
 		<div>
 		Updates the [page:Matrix4 MatrixWorld].
 		</div>

--- a/docs/api/objects/SkinnedMesh.html
+++ b/docs/api/objects/SkinnedMesh.html
@@ -66,7 +66,7 @@
 		</code>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:Geometry geometry], [page:Material material] )</h3>
+		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 		<div>
     [page:Geometry geometry] - an instance of [page:Geometry] or [page:BufferGeometry] (recommended).
 		[page:Geometry.skinIndices skinIndices] and [page:Geometry.skinWeights skinWeights] should be set to true on the geometry.<br />

--- a/docs/api/objects/Sprite.html
+++ b/docs/api/objects/Sprite.html
@@ -71,12 +71,12 @@ scene.add( sprite );
 		Returns a clone of this Sprite object and any descendants.
 		</div>
 
-		<h3>[method:Sprite copy]( [page:Sprite sprite] )</h3>
+		<h3>[method:Sprite copy]( [param:Sprite sprite] )</h3>
 		<div>
 		Copies the properties of the passed sprite to this one.
 		</div>
 
-		<h3>[method:Array raycast]( [page:Raycaster raycaster], [page:Array intersects] )</h3>
+		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<div>
 		Get intersections between a casted ray and this sprite.
 		[page:Raycaster.intersectObject] will call this method.

--- a/docs/api/objects/Sprite.html
+++ b/docs/api/objects/Sprite.html
@@ -31,7 +31,7 @@ scene.add( sprite );
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Material material] )</h3>
+		<h3>[name]( [param:Material material] )</h3>
 		<div>
     [page:Material material] - (optional) an instance of [page:SpriteMaterial]. Default is a white [page:SpriteMaterial].<br /><br />
 

--- a/docs/api/renderers/WebGLRenderTarget.html
+++ b/docs/api/renderers/WebGLRenderTarget.html
@@ -21,7 +21,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Number width], [page:Number height], [page:Object options])</h3>
+		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
 
 		<div>
 		[page:Float width] - The width of the renderTarget. <br />

--- a/docs/api/renderers/WebGLRenderTarget.html
+++ b/docs/api/renderers/WebGLRenderTarget.html
@@ -101,7 +101,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setSize]( [page:Number width], [page:Number height] )</h3>
+		<h3>[method:null setSize]( [param:Number width], [param:Number height] )</h3>
 		<div>
 		Sets the size of the render target.
 		</div>
@@ -111,7 +111,7 @@
 		Creates a copy of this render target.
 		</div>
 
-		<h3>[method:WebGLRenderTarget copy]( [page:WebGLRenderTarget source] )</h3>
+		<h3>[method:WebGLRenderTarget copy]( [param:WebGLRenderTarget source] )</h3>
 		<div>
 		Adopts the settings of the given render target.
 		</div>

--- a/docs/api/renderers/WebGLRenderTargetCube.html
+++ b/docs/api/renderers/WebGLRenderTargetCube.html
@@ -24,7 +24,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:Number width], [page:Number height], [page:Object options])</h3>
+		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
 		<div>
 		[page:Float width] - The width of the renderTarget. <br />
 		[page:Float height] - The height of the renderTarget. <br />

--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -286,7 +286,7 @@
 		See [page:WebGLRenderer.capabilities capabilities.maxTextures].
 		</div>
 
-		<h3>[method:null clear]( [page:Boolean color], [page:Boolean depth], [page:Boolean stencil] )</h3>
+		<h3>[method:null clear]( [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
 		<div>
 		Tells the renderer to clear its color, depth or stencil drawing buffer(s).
 			This method initializes the color buffer to the current clear color value.<br />
@@ -302,7 +302,7 @@
 		<h3>[method:null clearStencil]( )</h3>
 		<div>Clear the stencil buffers. Equivalent to calling [page:WebGLRenderer.clear .clear]( false, false, true ).</div>
 
-		<h3>[method:null clearTarget]([page:WebGLRenderTarget renderTarget], [page:boolean color], [page:boolean depth], [page:boolean stencil])</h3>
+		<h3>[method:null clearTarget]([param:WebGLRenderTarget renderTarget], [param:boolean color], [param:boolean depth], [param:boolean stencil])</h3>
 		<div>
 		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be cleared.<br />
 		color -- If set, then the color gets cleared. <br />
@@ -313,16 +313,16 @@
 		This method clears a rendertarget. To do this, it activates the rendertarget.
 		</div>
 
-		<h3>[method:null compile]( [page:Scene scene], [page:Camera camera] )</h3>
+		<h3>[method:null compile]( [param:Scene scene], [param:Camera camera] )</h3>
 		<div>Compiles all materials in the scene with the camera. This is useful to precompile shaders before the first rendering.</div>
 
-		<h3>[method:null copyFramebufferToTexture]( [page:Vector2 position], [page:Texture texture], [page:Number level] )</h3>
+		<h3>[method:null copyFramebufferToTexture]( [param:Vector2 position], [param:Texture texture], [param:Number level] )</h3>
 		<div>Copies pixels from the current WebGLFramebuffer into a 2D texture. Enables access to [link:https://developer.mozilla.org/de/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].</div>
 
 		<h3>[method:null dispose]( )</h3>
 		<div>Dispose of the current rendering context.</div>
 
-		<h3>[method:Object extensions.get]( [page:String extensionName] )</h3>
+		<h3>[method:Object extensions.get]( [param:String extensionName] )</h3>
 		<div>
 		Used to check whether various extensions are supported and returns an object with details of the extension if available.
 		This method can check for the following extensions:<br /><br />
@@ -371,7 +371,7 @@
 		<h3>[method:null resetGLState]( )</h3>
 		<div>Reset the GL state to default. Called internally if the WebGL context is lost.</div>
 
-		<h3>[method:null readRenderTargetPixels]( [page:WebGLRenderTarget renderTarget], [page:Float x], [page:Float y], [page:Float width], [page:Float height], buffer )</h3>
+		<h3>[method:null readRenderTargetPixels]( [param:WebGLRenderTarget renderTarget], [param:Float x], [param:Float y], [param:Float width], [param:Float height], buffer )</h3>
 		<div>Reads the pixel data from the renderTarget into the buffer you pass in.
 			Buffer should be a Javascript Uint8Array instantiated with
 			new Uint8Array( renderTargetWidth * renderTargetWidth * 4 ) to account for size and color
@@ -379,7 +379,7 @@
 		See the [example:webgl_interactive_cubes_gpu interactive / cubes / gpu] example.
 		</div>
 
-		<h3>[method:null render]( [page:Scene scene], [page:Camera camera], [page:WebGLRenderTarget renderTarget], [page:Boolean forceClear] )</h3>
+		<h3>[method:null render]( [param:Scene scene], [param:Camera camera], [param:WebGLRenderTarget renderTarget], [param:Boolean forceClear] )</h3>
 		<div>
 			Render a [page:Scene scene] using a [page:Camera camera].<br />
 
@@ -392,10 +392,10 @@
 			either the [page:WebGLRenderer.autoClearColor autoClearColor], [page:WebGLRenderer.autoClearStencil autoClearStencil] or [page:WebGLRenderer.autoClearDepth autoClearDepth] properties to false.
 		</div>
 
-		<h3>[method:null renderBufferDirect]( [page:Camera camera], [page:Array lights], [page:Fog fog], [page:Material material], [page:Object geometryGroup], [page:Object3D object] )</h3>
+		<h3>[method:null renderBufferDirect]( [param:Camera camera], [param:Array lights], [param:Fog fog], [param:Material material], [param:Object geometryGroup], [param:Object3D object] )</h3>
 		<div>Render a buffer geometry group using the camera and with the specified material.</div>
 
-		<h3>[method:null renderBufferImmediate]( [page:Object3D object], [page:shaderprogram program], [page:Material shading] )</h3>
+		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:shaderprogram program], [param:Material shading] )</h3>
 		<div>object - an instance of [page:Object3D]<br />
 		program - an instance of shaderProgram<br />
 		shading - an instance of Material<br /><br />
@@ -403,27 +403,27 @@
 		Render an immediate buffer. Gets called by renderImmediateObject.
 		</div>
 
-		<h3>[method:null setClearAlpha]( [page:Float alpha] )</h3>
+		<h3>[method:null setClearAlpha]( [param:Float alpha] )</h3>
 		<div>Sets the clear alpha. Valid input is a float between *0.0* and *1.0*.</div>
 
-		<h3>[method:null setClearColor]( [page:Color color], [page:Float alpha] )</h3>
+		<h3>[method:null setClearColor]( [param:Color color], [param:Float alpha] )</h3>
 		<div>Sets the clear color and opacity.</div>
 
-		<h3>[method:null setPixelRatio]( [page:number value] )</h3>
+		<h3>[method:null setPixelRatio]( [param:number value] )</h3>
 		<div>Sets device pixel ratio. This is usually used for HiDPI device to prevent bluring output canvas.</div>
 
-		<h3>[method:null setRenderTarget]( [page:WebGLRenderTarget renderTarget] )</h3>
+		<h3>[method:null setRenderTarget]( [param:WebGLRenderTarget renderTarget] )</h3>
 		<div>
 		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be activated (optional).<br /><br />
 		This method sets the active rendertarget. If the parameter is omitted the canvas is set as the active rendertarget.
 		</div>
 
-		<h3>[method:null setScissor]( [page:Integer x], [page:Integer y], [page:Integer width], [page:Integer height] )</h3>
+		<h3>[method:null setScissor]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
 		<div>
 		Sets the scissor area from (x, y) to (x + width, y + height)
 		</div>
 
-		<h3>[method:null setScissorTest]( [page:Boolean boolean] )</h3>
+		<h3>[method:null setScissorTest]( [param:Boolean boolean] )</h3>
 		<div>
 		Enable or disable the scissor test. When this is enabled, only the pixels within the defined
 			scissor area will be affected by further renderer actions.
@@ -435,14 +435,14 @@
 		This has been deprecated in favour of [page:WebGLRenderer.capabilities capabilities.vertexTexures].
 		</div>
 
-		<h3>[method:null setSize]( [page:Integer width], [page:Integer height], [page:Boolean updateStyle] )</h3>
+		<h3>[method:null setSize]( [param:Integer width], [param:Integer height], [param:Boolean updateStyle] )</h3>
 		<div>
 		Resizes the output canvas to (width, height) with device pixel ratio taken into account,
 			and also sets the viewport to fit that size, starting in (0, 0).
 			Setting [page:Boolean updateStyle] to false prevents any style changes to the output canvas.
 		</div>
 
-		<h3>[method:null setTexture2D]( [page:Texture texture], [page:number slot] )</h3>
+		<h3>[method:null setTexture2D]( [param:Texture texture], [param:number slot] )</h3>
 		<div>
 		texture -- The [page:Texture texture] that needs to be set.<br />
 		slot -- The number indicating which slot should be used by the texture.<br /><br />
@@ -453,7 +453,7 @@
 		Note: This method replaces the older [method:null setTexture] method.
 		</div>
 
-		<h3>[method:null setTextureCube]( [page:CubeTexture cubeTexture], [page:Number slot] )</h3>
+		<h3>[method:null setTextureCube]( [param:CubeTexture cubeTexture], [param:Number slot] )</h3>
 		<div>
 		texture -- The [page:CubeTexture cubeTexture] that needs to be set.<br />
 		slot -- The number indicating which slot should be used by the texture.<br /><br />
@@ -462,7 +462,7 @@
 		The slot number can be found as a value of the uniform of the sampler.
 		</div>
 
-		<h3>[method:null setViewport]( [page:Integer x], [page:Integer y], [page:Integer width], [page:Integer height] )</h3>
+		<h3>[method:null setViewport]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
 		<div>Sets the viewport to render from (x, y) to (x + width, y + height).</div>
 
 		<h2>Source</h2>

--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -17,7 +17,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 		[page:Object parameters] - (optional) object with properties defining the renderer's behaviour.
 			The constructor also accepts no parameters at all. In all cases, it will assume sane defaults

--- a/docs/api/renderers/webgl/WebGLProgram.html
+++ b/docs/api/renderers/webgl/WebGLProgram.html
@@ -106,7 +106,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:WebGLRenderer renderer], [page:Object code], [page:Material material], [page:Object parameters] )</h3>
+		<h3>[name]( [param:WebGLRenderer renderer], [param:Object code], [param:Material material], [param:Object parameters] )</h3>
 		<div>For parameters see [page:WebGLRenderer WebGLRenderer]</div>
 
 		<h2>Properties</h2>

--- a/docs/api/renderers/webgl/WebGLState.html
+++ b/docs/api/renderers/webgl/WebGLState.html
@@ -15,17 +15,17 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null enable]( [page:integer id], [page:boolean boolean] )</h3>
+		<h3>[method:null enable]( [param:integer id], [param:boolean boolean] )</h3>
 		<div>
 		TODO
 		</div>
 
-		<h3>[method:null disable]( [page:integer id], [page:boolean boolean] )</h3>
+		<h3>[method:null disable]( [param:integer id], [param:boolean boolean] )</h3>
 		<div>
 		TODO
 		</div>
 
-		<h3>[method:null setDepthTest]( [page:boolean depthTest] )</h3>
+		<h3>[method:null setDepthTest]( [param:boolean depthTest] )</h3>
 		<div>
 		depthTest -- The boolean to decide if depth of a fragment needs to be tested against the depth buffer . <br />
 		</div>
@@ -33,7 +33,7 @@
 		This sets, based on depthTest, whether or not the depth data needs to be tested against the depth buffer.
 		</div>
 
-		<h3>[method:null setDepthWrite]( [page:boolean depthWrite] )</h3>
+		<h3>[method:null setDepthWrite]( [param:boolean depthWrite] )</h3>
 		<div>
 		depthWrite -- The boolean to decide if depth of a fragment needs to be kept. <br />
 		</div>
@@ -41,7 +41,7 @@
 		This sets, based on depthWrite, whether or not the depth data needs to be written in the depth buffer.
 		</div>
 
-		<h3>[method:null setBlending]( [page:number blending], [page:number blendEquation], [page:number blendSrc], [page:number blendDst] )</h3>
+		<h3>[method:null setBlending]( [param:number blending], [param:number blendEquation], [param:number blendSrc], [param:number blendDst] )</h3>
 		<div>
 		blending -- A number indicating the blending mode. Possible value are THREE.NoBlending, THREE.NormalBlending, THREE.AdditiveBlending, THREE.SubtractiveBlending, THREE.MultiplyBlending or THREE.CustomBlending <br />
 		blendEquation -- When blending is THREE.CustomBlending, then you can set the blendEquation. Possible values are THREE.AddEquation, THREE.SubtractEquation or THREE.ReverseSubtractEquation.<br />

--- a/docs/api/renderers/webgl/plugins/SpritePlugin.html
+++ b/docs/api/renderers/webgl/plugins/SpritePlugin.html
@@ -23,7 +23,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null render]( [page:Scene scene], [page:Camera camera] )</h3>
+		<h3>[method:null render]( [param:Scene scene], [param:Camera camera] )</h3>
 		<div>
 		scene -- The scene to render. <br />
 		camera -- The camera to render.

--- a/docs/api/scenes/Fog.html
+++ b/docs/api/scenes/Fog.html
@@ -16,7 +16,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Integer color], [page:Float near], [page:Float far] )</h3>
+		<h3>[name]( [param:Integer color], [param:Float near], [param:Float far] )</h3>
 		<div>The color parameter is passed to the [page:Color] constructor to set the color property. Color can be a hexadecimal integer or a CSS-style string.</div>
 
 		<h2>Properties</h2>

--- a/docs/api/scenes/FogExp2.html
+++ b/docs/api/scenes/FogExp2.html
@@ -16,7 +16,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Integer color], [page:Float density] )</h3>
+		<h3>[name]( [param:Integer color], [param:Float density] )</h3>
 
 		<div>The color parameter is passed to the [page:Color] constructor to set the color property. Color can be a hexadecimal integer or a CSS-style string.</div>
 		<h2>Properties</h2>

--- a/docs/api/textures/CanvasTexture.html
+++ b/docs/api/textures/CanvasTexture.html
@@ -20,7 +20,7 @@
 
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:HTMLElement canvas], [page:Constant mapping], [page:Constant wrapS], [page:Constant wrapT], [page:Constant magFilter], [page:Constant minFilter], [page:Constant format], [page:Constant type], [page:Number anisotropy] )</h3>
+		<h3>[name]( [param:HTMLElement canvas], [param:Constant mapping], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Constant format], [param:Constant type], [param:Number anisotropy] )</h3>
 		<div>
 		[page:HTMLElement canvas] -- The HTML canvas element from which to load the texture. <br />
 

--- a/docs/api/textures/CompressedTexture.html
+++ b/docs/api/textures/CompressedTexture.html
@@ -15,7 +15,7 @@
 		<div class="desc">
 		Creates a texture based on data in compressed form, for example from a <a href="https://en.wikipedia.org/wiki/DirectDraw_Surface">DDS</a> file.<br /><br />
 
-		
+
 		For use with the [page:CompressedTextureLoader CompressedTextureLoader].
 		</div>
 
@@ -23,7 +23,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Array mipmaps], [page:Number width], [page:Number height], [page:Constant format], [page:Constant type], [page:Constant mapping], [page:Constant wrapS], [page:Constant wrapT], [page:Constant magFilter], [page:Constant minFilter], [page:Number anisotropy] )</h3>
+		<h3>[name]( [param:Array mipmaps], [param:Number width], [param:Number height], [param:Constant format], [param:Constant type], [param:Constant mapping], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Number anisotropy] )</h3>
 		<div>
 		[page:Array mipmaps] -- The mipmaps array should contain objects with data, width and height. The mipmaps should be of the correct format and type.<br />
 

--- a/docs/api/textures/DepthTexture.html
+++ b/docs/api/textures/DepthTexture.html
@@ -26,7 +26,7 @@
     [example:webgl_depth_texture depth / texture]
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:Number width], [page:Number height], [page:Constant type], [page:Constant wrapS], [page:Constant wrapT], [page:Constant magFilter], [page:Constant minFilter], [page:Number anisotropy], [page:Constant format] )</h3>
+		<h3>[name]( [param:Number width], [param:Number height], [param:Constant type], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Number anisotropy], [param:Constant format] )</h3>
 
     <div>
 		[page:Number width] -- width of the texture.<br />

--- a/docs/api/textures/Texture.html
+++ b/docs/api/textures/Texture.html
@@ -130,20 +130,20 @@
 		<h3>[property:Vector2 offset]</h3>
 		<div>
 		How much a single repetition of the texture is offset from the beginning, in each direction U and V.
-		Typical range is *0.0* to *1.0*.  _Note:_ The offset property is a convenience modifier and only affects 
+		Typical range is *0.0* to *1.0*.  _Note:_ The offset property is a convenience modifier and only affects
 		the Texture's application to the first set of UVs on a model.  If the Texture is used as a map requiring
-		additional UV sets (e.g. the aoMap or lightMap of most stock materials), those UVs must be manually 
+		additional UV sets (e.g. the aoMap or lightMap of most stock materials), those UVs must be manually
 		assigned to achieve the desired offset.
 		</div>
 
 		<h3>[property:Vector2 repeat]</h3>
 		<div>
-		How many times the texture is repeated across the surface, in each direction U and V.  If repeat is set 
-		greater than 1 in either direction, the corresponding Wrap parameter should also be set to 
-		[page:Textures THREE.RepeatWrapping] or [page:Textures THREE.MirroredRepeatWrapping] to achieve the desired 
-		tiling effect.  _Note:_ The repeat property is a convenience modifier and only affects 
+		How many times the texture is repeated across the surface, in each direction U and V.  If repeat is set
+		greater than 1 in either direction, the corresponding Wrap parameter should also be set to
+		[page:Textures THREE.RepeatWrapping] or [page:Textures THREE.MirroredRepeatWrapping] to achieve the desired
+		tiling effect.  _Note:_ The repeat property is a convenience modifier and only affects
 		the Texture's application to the first set of UVs on a model.  If the Texture is used as a map requiring
-		additional UV sets (e.g. the aoMap or lightMap of most stock materials), those UVs must be manually 
+		additional UV sets (e.g. the aoMap or lightMap of most stock materials), those UVs must be manually
 		assigned to achieve the desired repetiton.
 		</div>
 
@@ -228,7 +228,7 @@
 
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
 
-		<h3>[method:Texture clone]( [page:Texture texture] )</h3>
+		<h3>[method:Texture clone]( [param:Texture texture] )</h3>
 		<div>
 		Make copy of the texture. Note this is not a "deep copy", the image is shared.
 		</div>

--- a/docs/api/textures/VideoTexture.html
+++ b/docs/api/textures/VideoTexture.html
@@ -34,7 +34,7 @@ texture.format = THREE.RGBFormat;
 
 
 		<h2>Constructor</h2>
-		<h3>[name]( [page:Video video], [page:Constant mapping], [page:Constant wrapS], [page:Constant wrapT], [page:Constant magFilter], [page:Constant minFilter], [page:Constant format], [page:Constant type], [page:Number anisotropy] )</h3>
+		<h3>[name]( [param:Video video], [param:Constant mapping], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Constant format], [param:Constant type], [param:Number anisotropy] )</h3>
 		<div>
 		[page:Video video] -- The video element to use as the texture. <br />
 

--- a/docs/examples/Lut.html
+++ b/docs/examples/Lut.html
@@ -49,7 +49,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null copy]( [page:Lut lut] ) [page:Lut this]</h3>
+		<h3>[method:null copy]( [param:Lut lut] ) [param:Lut this]</h3>
 		<div>
 		color — Lut to copy.
 		</div>
@@ -91,7 +91,7 @@
 		Sets the labels of the legend of this Lut.
 		</div>
 
-		<h3>[method:Lut setminV]( [page:Float minV] )</h3>
+		<h3>[method:Lut setminV]( [param:Float minV] )</h3>
 		<div>
 		minV — The minimum value to be represented with the lookup table.<br />
 		</div>
@@ -99,7 +99,7 @@
 		Sets this Lut with the minimum value to be represented.
 		</div>
 
-		<h3>[method:Lut setmaxV]( [page:Float maxV] )</h3>
+		<h3>[method:Lut setmaxV]( [param:Float maxV] )</h3>
 		<div>
 		maxV — The maximum value to be represented with the lookup table.<br />
 		</div>
@@ -107,7 +107,7 @@
 		Sets this Lut with the maximum value to be represented.
 		</div>
 
-		<h3>[method:Lut changeNumberOfColors]( [page:Float numberOfColors] )</h3>
+		<h3>[method:Lut changeNumberOfColors]( [param:Float numberOfColors] )</h3>
 		<div>
 		numberOfColors — The number of colors to be used to represent the data array.<br />
 		</div>
@@ -115,7 +115,7 @@
 		Sets this Lut with the number of colors to be used.
                 </div>
 
-		<h3>[method:Lut changeColorMap]( [page:Float colorMap] )</h3>
+		<h3>[method:Lut changeColorMap]( [param:Float colorMap] )</h3>
 		<div>
 		colorMap — The name of the color map to be used to represent the data array.<br />
 		</div>
@@ -128,7 +128,7 @@
 		Insert a new color map into the set of available color maps.
 		</div>
 
-		<h3>[method:Lut getColor]( value ) [page:Lut this]</h3>
+		<h3>[method:Lut getColor]( value ) [param:Lut this]</h3>
 		<div>
 		value -- the data value to be displayed as a color.
 		</div>

--- a/docs/examples/SpriteCanvasMaterial.html
+++ b/docs/examples/SpriteCanvasMaterial.html
@@ -18,7 +18,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Object parameters] )</h3>
+		<h3>[name]( [param:Object parameters] )</h3>
 		<div>
 		parameters is an object that can be used to set up the default properties
 		</div>

--- a/docs/examples/SpriteCanvasMaterial.html
+++ b/docs/examples/SpriteCanvasMaterial.html
@@ -41,7 +41,7 @@
 
 
 
-		<h3>[method:null program]([page:CanvasRenderingContext2D context], [page:Color color])</h3>
+		<h3>[method:null program]([param:CanvasRenderingContext2D context], [param:Color color])</h3>
 		<div>
 		context -- The canvas context <br />
 		color -- The color of the sprite

--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -52,7 +52,7 @@ function animate() {
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Camera object], [page:HTMLDOMElement domElement] )</h3>
+		<h3>[name]( [param:Camera object], [param:HTMLDOMElement domElement] )</h3>
 		<div>
       [page:Camera object]: (required) The camera to be controlled.<br><br>
 

--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -47,7 +47,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null parse]( [page:Object input], [page:Function onCompleted], [page:Object options] )</h3>
+		<h3>[method:null parse]( [param:Object input], [param:Function onCompleted], [param:Object options] )</h3>
 		<div>
 		[page:Object input] — Scenes or objects to export. Valid options:<br />
 		<ul>

--- a/docs/examples/geometries/ConvexBufferGeometry.html
+++ b/docs/examples/geometries/ConvexBufferGeometry.html
@@ -44,7 +44,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Array points] )</h3>
+		<h3>[name]( [param:Array points] )</h3>
 		<div>
 		points — Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.
 		</div>

--- a/docs/examples/geometries/ConvexGeometry.html
+++ b/docs/examples/geometries/ConvexGeometry.html
@@ -43,7 +43,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Array points] )</h3>
+		<h3>[name]( [param:Array points] )</h3>
 		<div>
 		points — Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.
 		</div>

--- a/docs/examples/geometries/DecalGeometry.html
+++ b/docs/examples/geometries/DecalGeometry.html
@@ -42,7 +42,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:Mesh mesh], [page:Vector3 position], [page:Euler orientation], [page:Vector3 size] )</h3>
+		<h3>[name]( [param:Mesh mesh], [param:Vector3 position], [param:Euler orientation], [param:Vector3 size] )</h3>
 		<div>
 		mesh — Any mesh object.<br />
 		position — Position of the decal projector.<br />

--- a/docs/examples/loaders/BabylonLoader.html
+++ b/docs/examples/loaders/BabylonLoader.html
@@ -50,7 +50,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/examples/loaders/BabylonLoader.html
+++ b/docs/examples/loaders/BabylonLoader.html
@@ -63,7 +63,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — A string containing the path/URL of the <em>.babylon</em> file.<br />
 		[page:function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives the loaded [page:Object3D] as an argument.<br />
@@ -74,7 +74,7 @@
 		Begin loading from url and call onLoad with the parsed response content.
 		</div>
 
-		<h3>[method:Object3D parse]( [page:Object json] )</h3>
+		<h3>[method:Object3D parse]( [param:Object json] )</h3>
 		<div>
 		[page:Object json] — The <em>JSON</em> structure to parse.
 		</div>

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -109,7 +109,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — A string containing the path/URL of the <em>.gltf</em> or <em>.glb</em> file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed. The function receives the loaded JSON response returned from [page:Function parse].<br />
@@ -120,7 +120,7 @@
 		Begin loading from url and call the callback function with the parsed response content.
 		</div>
 
-		<h3>[method:null setPath]( [page:String path] )</h3>
+		<h3>[method:null setPath]( [param:String path] )</h3>
 		<div>
 		[page:String path] — Base path for loading additional resources e.g. textures and .bin data.
 		</div>
@@ -128,17 +128,17 @@
 		Set the base path for additional resources.
 		</div>
 
-		<h3>[method:null setCrossOrigin]( [page:String value] )</h3>
+		<h3>[method:null setCrossOrigin]( [param:String value] )</h3>
 		<div>
 		[page:String value] — The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS.
 		</div>
 
-		<h3>[method:null setDRACOLoader]( [page:DRACOLoader dracoLoader] )</h3>
+		<h3>[method:null setDRACOLoader]( [param:DRACOLoader dracoLoader] )</h3>
 		<div>
 		[page:DRACOLoader dracoLoader] — Instance of THREE.DRACOLoader, to be used for decoding assets compressed with the KHR_draco_mesh_compression extension.
 		</div>
 
-		<h3>[method:null parse]( [page:ArrayBuffer data], [page:String path], [page:Function onLoad], [page:Function onError] )</h3>
+		<h3>[method:null parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>
 		<div>
 		[page:ArrayBuffer data] — glTF asset to parse, as an ArrayBuffer or <em>JSON</em> string.<br />
 		[page:String path] — The base path from which to find subsequent glTF resources such as textures and .bin data files.<br />

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -96,7 +96,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/examples/loaders/LoaderSupport.html
+++ b/docs/examples/loaders/LoaderSupport.html
@@ -45,7 +45,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setMaterials] ( Array of [page:Material materials] )</h3>
+		<h3>[method:null setMaterials] ( Array of [param:Material materials] )</h3>
 		<div>
 			Array of [page:Material materials] - Array of [page:Material Materials]
 		</div>
@@ -118,7 +118,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null addMesh] ( [page:Mesh mesh] )</h3>
+		<h3>[method:null addMesh] ( [param:Mesh mesh] )</h3>
 		<div>
 			[page:Mesh mesh] - Mesh
 		</div>
@@ -156,7 +156,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null validate] ( [page:Function functionCodeBuilder], Array of [page:String libLocations], [page:String libPath], [page:LoaderSupport.WorkerRunnerRefImpl runnerImpl] )</h3>
+		<h3>[method:null validate] ( [param:Function functionCodeBuilder], Array of [param:String libLocations], [param:String libPath], [param:LoaderSupport.WorkerRunnerRefImpl runnerImpl] )</h3>
 		<div>
 			[page:Function functionCodeBuilder] - Function that is invoked with funcBuildObject and funcBuildSingleton that allows stringification of objects and singletons.<br>
 			Array of [page:String libLocations] - URL of libraries that shall be added to worker code relative to libPath.<br>
@@ -168,7 +168,7 @@
 		</div>
 
 
-		<h3>[method:null setTerminateRequested] ( [page:Boolean terminateRequested] )</h3>
+		<h3>[method:null setTerminateRequested] ( [param:Boolean terminateRequested] )</h3>
 		<div>
 			[page:Boolean terminateRequested] - True or false.
 		</div>
@@ -177,7 +177,7 @@
 		</div>
 
 
-		<h3>[method:null setCallbacks] ( [page:Function builder], [page:Function onLoad] )</h3>
+		<h3>[method:null setCallbacks] ( [param:Function builder], [param:Function onLoad] )</h3>
 		<div>
 			[page:Function builder] - The builder function. Default is [page:LoaderSupport.Builder].<br>
 			[page:Function onLoad] - The function that is called when parsing is complete.
@@ -187,7 +187,7 @@
 		</div>
 
 
-		<h3>[method:null run] ( [page:Object payload] )</h3>
+		<h3>[method:null run] ( [param:Object payload] )</h3>
 		<div>
 			[page:Object payload] - Raw mesh description (buffers, params, materials) used to build one to many meshes.
 		</div>
@@ -209,7 +209,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null applyProperties] ( [page:Object parser], [page:Object params] )</h3>
+		<h3>[method:null applyProperties] ( [param:Object parser], [param:Object params] )</h3>
 		<div>
 			[page:Object parser] - The parser instance<br>
 			[page:Object params] - The parameter object
@@ -219,7 +219,7 @@
 		</div>
 
 
-		<h3>[method:null run] ( [page:Object payload] )</h3>
+		<h3>[method:null run] ( [param:Object payload] )</h3>
 		<div>
 			[page:Object payload] - Raw mesh description (buffers, params, materials) used to build one to many meshes.
 		</div>
@@ -250,7 +250,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null prepareWorkers]( [page:WWOBJLoader2.Callbacks globalCallbacks], [page:Number maxQueueSize], [page:Number maxWebWorkers] )</h3>
+		<h3>[method:null prepareWorkers]( [param:WWOBJLoader2.Callbacks globalCallbacks], [param:Number maxQueueSize], [param:Number maxWebWorkers] )</h3>
 		<div>
 			[page:LoaderSupport.Callbacks globalCallbacks] - Register global callbacks used by all web workers<br>
 			[page:Number maxQueueSize] - Set the maximum size of the instruction queue (1-1024)<br>
@@ -261,7 +261,7 @@
 		</div>
 
 
-		<h3>[method:null enqueueForRun]( [page:LoaderSupport.PrepData runParams] )</h3>
+		<h3>[method:null enqueueForRun]( [param:LoaderSupport.PrepData runParams] )</h3>
 		<div>
 			[page:LoaderSupport.PrepData runParams]
 		</div>
@@ -276,7 +276,7 @@
 		</div>
 
 
-		<h3>[method:null tearDown]( [page:Function callbackOnFinishedProcessing] )</h3>
+		<h3>[method:null tearDown]( [param:Function callbackOnFinishedProcessing] )</h3>
 		<div>
 			[page:Function callbackOnFinishedProcessing] - Function called once all workers finished processing.
 		</div>
@@ -302,7 +302,7 @@
 		</div>
 
 
-		<h3>[method:null setCrossOrigin]( [page:String crossOrigin] )</h3>
+		<h3>[method:null setCrossOrigin]( [param:String crossOrigin] )</h3>
 		<div>
 			[page:String crossOrigin] - CORS value
 		</div>
@@ -325,7 +325,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setStreamMeshesTo] ( [page:Object3D streamMeshesTo] )</h3>
+		<h3>[method:null setStreamMeshesTo] ( [param:Object3D streamMeshesTo] )</h3>
 		<div>
 			[page:Object3D streamMeshesTo] - Object already attached to scenegraph where new meshes will be attached to
 		</div>
@@ -334,7 +334,7 @@
 		</div>
 
 
-		<h3>[method:null setMaterialPerSmoothingGroup] ( [page:boolean materialPerSmoothingGroup] )</h3>
+		<h3>[method:null setMaterialPerSmoothingGroup] ( [param:boolean materialPerSmoothingGroup] )</h3>
 		<div>
 			[page:boolean materialPerSmoothingGroup]
 		</div>
@@ -343,7 +343,7 @@
 		</div>
 
 
-		<h3>[method:null setUseIndices]( [page:Boolean useIndices] )</h3>
+		<h3>[method:null setUseIndices]( [param:Boolean useIndices] )</h3>
 		<div>
 			[page:Boolean useIndices] - Default is false
 		</div>
@@ -352,7 +352,7 @@
 		</div>
 
 
-		<h3>[method:null setDisregardNormals]( [page:Boolean disregardNormals] )</h3>
+		<h3>[method:null setDisregardNormals]( [param:Boolean disregardNormals] )</h3>
 		<div>
 			[page:Boolean disregardNormals]
 		</div>
@@ -367,7 +367,7 @@
 		</div>
 
 
-		<h3>[method:null setCrossOrigin]( [page:String crossOrigin] )</h3>
+		<h3>[method:null setCrossOrigin]( [param:String crossOrigin] )</h3>
 		<div>
 			[page:String crossOrigin] - CORS value
 		</div>
@@ -376,7 +376,7 @@
 		</div>
 
 
-		<h3>[method:null addResource]( [page:LoaderSupport.ResourceDescriptor resource] )</h3>
+		<h3>[method:null addResource]( [param:LoaderSupport.ResourceDescriptor resource] )</h3>
 		<div>
 			[page:LoaderSupport.ResourceDescriptor resource]
 		</div>
@@ -385,7 +385,7 @@
 		</div>
 
 
-		<h3>[method:null setUseAsync]( [page:Boolean useAsync] )</h3>
+		<h3>[method:null setUseAsync]( [param:Boolean useAsync] )</h3>
 		<div>
 			[page:Boolean useAsync]
 		</div>
@@ -410,8 +410,8 @@
 
 
 		<h2>Methods</h2>
-		
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError], [page:Function onMeshAlter], [page:boolean useAsync] )</h3>
+
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError], [param:Function onMeshAlter], [param:boolean useAsync] )</h3>
 		<div>
 			[page:String url] - A string containing the path/URL of the file to be loaded.<br>
 			[page:Function onLoad] - A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br>
@@ -423,8 +423,8 @@
 		<div>
 			Use this convenient method to load a file at the given URL. By default the fileLoader uses an ArrayBuffer.
 		</div>
-		
-		<h3>[method:ConsoleLogger checkResourceDescriptorFiles] ( [page:THREE.LoaderSupport.ResourceDescriptor resources], [page:Object fileDesc] )</h3>
+
+		<h3>[method:ConsoleLogger checkResourceDescriptorFiles] ( [param:THREE.LoaderSupport.ResourceDescriptor resources], [param:Object fileDesc] )</h3>
 		<div>
 			[page:THREE.LoaderSupport.ResourceDescriptor resources] - Array of {@link THREE.LoaderSupport.ResourceDescriptor}
 			[page:Object fileDesc] - Object describing which resources are of interest (ext, type (string or UInt8Array) and ignore (boolean))
@@ -432,15 +432,15 @@
 		<div>
 			Identify files or content of interest from an Array of {@link THREE.LoaderSupport.ResourceDescriptor}. Returns Object with each "ext" and the corresponding {@link THREE.LoaderSupport.ResourceDescriptor}
 	 	</div>
-		
-		
+
+
 		<h3>[method:ConsoleLogger getLogger] ()</h3>
 		<div>
 			Returns [page:LoaderSupport.ConsoleLogger].
 		</div>
 
 
-		<h3>[method:null setModelName] ( [page:String modelName] )</h3>
+		<h3>[method:null setModelName] ( [param:String modelName] )</h3>
 		<div>
 			[page:String modelName]
 		</div>
@@ -449,7 +449,7 @@
 		</div>
 
 
-		<h3>[method:null setPath] ( [page:String path] )</h3>
+		<h3>[method:null setPath] ( [param:String path] )</h3>
 		<div>
 			[page:String path] - URL
 		</div>
@@ -458,7 +458,7 @@
 		</div>
 
 
-		<h3>[method:null setStreamMeshesTo] ( [page:Object3D streamMeshesTo] )</h3>
+		<h3>[method:null setStreamMeshesTo] ( [param:Object3D streamMeshesTo] )</h3>
 		<div>
 			[page:Object3D streamMeshesTo] - Object already attached to scenegraph where new meshes will be attached to
 		</div>
@@ -467,7 +467,7 @@
 		</div>
 
 
-		<h3>[method:null setMaterials] ( Array of [page:Material materials] )</h3>
+		<h3>[method:null setMaterials] ( Array of [param:Material materials] )</h3>
 		<div>
 			Array of [page:Material materials] - Array of [page:Material Materials]
 		</div>
@@ -476,7 +476,7 @@
 		</div>
 
 
-		<h3>[method:null setUseIndices]( [page:Boolean useIndices] )</h3>
+		<h3>[method:null setUseIndices]( [param:Boolean useIndices] )</h3>
 		<div>
 			[page:Boolean useIndices]
 		</div>
@@ -485,7 +485,7 @@
 		</div>
 
 
-		<h3>[method:null setDisregardNormals]( [page:Boolean disregardNormals] )</h3>
+		<h3>[method:null setDisregardNormals]( [param:Boolean disregardNormals] )</h3>
 		<div>
 			[page:Boolean disregardNormals]
 		</div>
@@ -494,7 +494,7 @@
 		</div>
 
 
-		<h3>[method:null onProgress]( [page:String type], [page:String text], [page:Number numericalValue] )</h3>
+		<h3>[method:null onProgress]( [param:String type], [param:String text], [param:Number numericalValue] )</h3>
 		<div>
 			[page:String type] - The type of event<br>
 			[page:String text] - Textual description of the event<br>
@@ -518,7 +518,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setCallbackOnProgress]( [page:Function callbackOnProgress] )</h3>
+		<h3>[method:null setCallbackOnProgress]( [param:Function callbackOnProgress] )</h3>
 		<div>
 			[page:Function callbackOnProgress] - Callback function for described functionality
 		</div>
@@ -527,7 +527,7 @@
 		</div>
 
 
-		<h3>[method:null setCallbackOnMeshAlter]( [page:Function callbackOnMeshAlter] )</h3>
+		<h3>[method:null setCallbackOnMeshAlter]( [param:Function callbackOnMeshAlter] )</h3>
 		<div>
 			[page:Function callbackOnMeshAlter] - Callback function for described functionality
 		</div>
@@ -537,7 +537,7 @@
 		</div>
 
 
-		<h3>[method:null setCallbackOnLoad]( [page:Function callbackOnLoad] )</h3>
+		<h3>[method:null setCallbackOnLoad]( [param:Function callbackOnLoad] )</h3>
 		<div>
 			[page:Function callbackOnLoad] - Callback function for described functionality
 		</div>
@@ -545,7 +545,7 @@
 			Register callback function that is called once loading of the complete OBJ file is completed.
 		</div>
 
-		<h3>[method:null setCallbackOnLoadMaterials]( [page:Function callbackOnLoadMaterials] )</h3>
+		<h3>[method:null setCallbackOnLoadMaterials]( [param:Function callbackOnLoadMaterials] )</h3>
 		<div>
 			[page:Function callbackOnLoadMaterials] - Callback function for described functionality
 		</div>
@@ -567,7 +567,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Boolean isValid]( [page:Object input] )</h3>
+		<h3>[method:Boolean isValid]( [param:Object input] )</h3>
 		<div>
 			[page:Object input] - Can be anything
 		</div>
@@ -576,7 +576,7 @@
 		</div>
 
 
-		<h3>[method:null verifyInput]( [page:Object input], [page:Object defaultValue] )</h3>
+		<h3>[method:null verifyInput]( [param:Object input], [param:Object defaultValue] )</h3>
 		<div>
 			[page:Object input] - Can be anything
 			[page:Object defaultValue] - Can be anything
@@ -602,7 +602,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setDebug]( [page:Boolean debug] )</h3>
+		<h3>[method:null setDebug]( [param:Boolean debug] )</h3>
 		<div>
 			[page:Boolean debug] - True or False
 		</div>
@@ -616,7 +616,7 @@
 			Returns if is enabled and debug.
 		</div>
 
-		<h3>[method:null setEnabled]( [page:Boolean enabled] )</h3>
+		<h3>[method:null setEnabled]( [param:Boolean enabled] )</h3>
 		<div>
 			[page:Boolean enabled] - True or False
 		</div>
@@ -631,7 +631,7 @@
 		</div>
 
 
-		<h3>[method:null logDebug]( [page:String message], Array of [page:String additional] )</h3>
+		<h3>[method:null logDebug]( [param:String message], Array of [param:String additional] )</h3>
 		<div>
 			[page:String message] - Message to log
 			Array of [page:String additional] - Array of [page:String strings] containing additional content to be logged
@@ -641,7 +641,7 @@
 		</div>
 
 
-		<h3>[method:null logInfo]( [page:String message], Array of [page:String additional] )</h3>
+		<h3>[method:null logInfo]( [param:String message], Array of [param:String additional] )</h3>
 		<div>
 			[page:String message] - Message to log
 			Array of [page:String additional] - Array of [page:String strings] containing additional content to be logged
@@ -651,7 +651,7 @@
 		</div>
 
 
-		<h3>[method:null logWarn]( [page:String message], Array of [page:String additional] )</h3>
+		<h3>[method:null logWarn]( [param:String message], Array of [param:String additional] )</h3>
 		<div>
 			[page:String message] - Message to log
 			Array of [page:String additional] - Array of [page:String strings] containing additional content to be logged
@@ -661,7 +661,7 @@
 		</div>
 
 
-		<h3>[method:null logError]( [page:String message], Array of [page:String additional] )</h3>
+		<h3>[method:null logError]( [param:String message], Array of [param:String additional] )</h3>
 		<div>
 			[page:String message] - Message to log
 			Array of [page:String additional] - Array of [page:String strings] containing additional content to be logged
@@ -671,7 +671,7 @@
 		</div>
 
 
-		<h3>[method:null logTimeStart]( [page:String id] )</h3>
+		<h3>[method:null logTimeStart]( [param:String id] )</h3>
 		<div>
 			[page:String id] - Time identification
 		</div>
@@ -680,7 +680,7 @@
 		</div>
 
 
-		<h3>[method:null logTimeEnd]( [page:String id] )</h3>
+		<h3>[method:null logTimeEnd]( [param:String id] )</h3>
 		<div>
 			[page:String id] - Time identification
 		</div>

--- a/docs/examples/loaders/LoaderSupport.html
+++ b/docs/examples/loaders/LoaderSupport.html
@@ -106,7 +106,7 @@
 		<a name="LoadedMeshUserOverride"></a><h1>LoadedMeshUserOverride</h1>
 		<h2>Constructor</h2>
 
-		<h3>LoadedMeshUserOverride( [page:Boolean disregardMesh], [page:BufferGeometry bufferGeometry] )</h3>
+		<h3>LoadedMeshUserOverride( [param:Boolean disregardMesh], [param:BufferGeometry bufferGeometry] )</h3>
 		<div>
 			[page:Boolean disregardMesh] - Tell implementation to completely disregard this mesh<br>
 			[page:Boolean alteredMesh] - Tell implementation that mesh(es) have been altered or added
@@ -144,7 +144,7 @@
 		<a name="WorkerSupport"></a><h1>WorkerSupport</h1>
 		<h2>Constructor</h2>
 
-		<h3>WorkerSupport( [page:LoaderSupport.ConsoleLogger logger] )</h3>
+		<h3>WorkerSupport( [param:LoaderSupport.ConsoleLogger logger] )</h3>
 		<div>
 			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
 		</div>
@@ -233,7 +233,7 @@
 		<a name="WorkerDirector"></a><h1>WorkerDirector</h1>
 		<h2>Constructor</h2>
 
-		<h3>WorkerDirector( [page:String classDef], [page:LoaderSupport.ConsoleLogger logger] )</h3>
+		<h3>WorkerDirector( [param:String classDef], [param:LoaderSupport.ConsoleLogger logger] )</h3>
 		<div>
 			[page:String classDef] - Class definition to be used for construction<br>
 			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
@@ -314,7 +314,7 @@
 		<a name="PrepData"></a><h1>PrepData</h1>
 		<h2>Constructor</h2>
 
-		<h3>PrepData( [page:String modelName] )</h3>
+		<h3>PrepData( [param:String modelName] )</h3>
 		<div>
 			[page:String modelName] - Overall name of the model
 		</div>
@@ -399,7 +399,7 @@
 		<a name="LoaderBase"></a><h1>LoaderBase</h1>
 		<h2>Constructor</h2>
 
-		<h3>LoaderBase( [page:LoadingManager manager], [page:LoaderSupport.ConsoleLogger logger] )</h3>
+		<h3>LoaderBase( [param:LoadingManager manager], [param:LoaderSupport.ConsoleLogger logger] )</h3>
 		<div>
 			[page:LoadingManager manager] - The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
@@ -591,7 +591,7 @@
 		<a name="ConsoleLogger"></a><h1>ConsoleLogger</h1>
 		<h2>Constructor</h2>
 
-		<h3>ConsoleLogger( [page:Boolean enabled], [page:Boolean debug] )</h3>
+		<h3>ConsoleLogger( [param:Boolean enabled], [param:Boolean debug] )</h3>
 		<div>
 			[page:Boolean enabled] - Tell if logger is enabled.
 			[page:Boolean debug] - Toggle debug logging.

--- a/docs/examples/loaders/MTLLoader.html
+++ b/docs/examples/loaders/MTLLoader.html
@@ -32,7 +32,7 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 			[page:String url] — A string containing the path/URL of the <em>.mtl</em> file.<br />
 			[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator] instance.<br />
@@ -44,7 +44,7 @@
 		</div>
 
 
-		<h3>[method:null setPath]( [page:String path] )</h3>
+		<h3>[method:null setPath]( [param:String path] )</h3>
 		<div>
 			[page:String path] — required<br />
 		</div>
@@ -53,7 +53,7 @@
 		</div>
 
 
-		<h3>[method:null setTexturePath]( [page:String path] )</h3>
+		<h3>[method:null setTexturePath]( [param:String path] )</h3>
 		<div>
 			[page:String path] — required<br />
 		</div>
@@ -62,7 +62,7 @@
 		</div>
 
 
-		<h3>[method:null setCrossOrigin]( [page:boolean useCrossOrigin] )</h3>
+		<h3>[method:null setCrossOrigin]( [param:boolean useCrossOrigin] )</h3>
 		<div>
 			[page:boolean useCrossOrigin] — required<br />
 		</div>
@@ -71,7 +71,7 @@
 		</div>
 
 
-		<h3>[method:null setMaterialOptions]( [page:Object options] )</h3>
+		<h3>[method:null setMaterialOptions]( [param:Object options] )</h3>
 		<div>
 			[page:Object options] — required
 			<ul>
@@ -87,7 +87,7 @@
 		</div>
 
 
-		<h3>[method:MTLLoaderMaterialCreator parse]( [page:String text] )</h3>
+		<h3>[method:MTLLoaderMaterialCreator parse]( [param:String text] )</h3>
 		<div>
 			[page:String text] — The textual <em>mtl</em> structure to parse.
 		</div>

--- a/docs/examples/loaders/MTLLoader.html
+++ b/docs/examples/loaders/MTLLoader.html
@@ -18,7 +18,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager loadingManager] )</h3>
+		<h3>[name]( [param:LoadingManager loadingManager] )</h3>
 		<div>
 			[page:LoadingManager loadingManager] — LoadingManager to use. Defaults to [page:DefaultLoadingManager DefaultLoadingManager]<br />
 		</div>

--- a/docs/examples/loaders/OBJLoader.html
+++ b/docs/examples/loaders/OBJLoader.html
@@ -55,7 +55,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/examples/loaders/OBJLoader.html
+++ b/docs/examples/loaders/OBJLoader.html
@@ -12,9 +12,9 @@
 		<h1>[name]</h1>
 
 		<div class="desc">A loader for loading a <em>.obj</em> resource.<br />
-		The <a href="https://en.wikipedia.org/wiki/Wavefront_.obj_file">OBJ file format</a> is a simple data-format 
-		that represents 3D geometry in a human readable format as the position of each vertex, the UV position of 
-		each texture coordinate vertex, vertex normals, and the faces that make each polygon defined as a list of 
+		The <a href="https://en.wikipedia.org/wiki/Wavefront_.obj_file">OBJ file format</a> is a simple data-format
+		that represents 3D geometry in a human readable format as the position of each vertex, the UV position of
+		each texture coordinate vertex, vertex normals, and the faces that make each polygon defined as a list of
 		vertices, and texture vertices.
 		</div>
 
@@ -68,7 +68,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — A string containing the path/URL of the <em>.obj</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:Object3D] as an argument.<br />
@@ -79,7 +79,7 @@
 		Begin loading from url and call onLoad with the parsed response content.
 		</div>
 
-		<h3>[method:Object3D parse]( [page:String text] )</h3>
+		<h3>[method:Object3D parse]( [param:String text] )</h3>
 		<div>
 		[page:String text] — The textual <em>obj</em> structure to parse.
 		</div>

--- a/docs/examples/loaders/OBJLoader2.html
+++ b/docs/examples/loaders/OBJLoader2.html
@@ -40,7 +40,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager], [page:LoaderSupport.ConsoleLogger logger] )</h3>
+		<h3>[name]( [param:LoadingManager manager], [param:LoaderSupport.ConsoleLogger logger] )</h3>
 		<div>
 			[page:LoadingManager manager] - The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br>
 			[page:LoaderSupport.ConsoleLogger logger] - logger to be used

--- a/docs/examples/loaders/OBJLoader2.html
+++ b/docs/examples/loaders/OBJLoader2.html
@@ -52,7 +52,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Object3D parse]( {[page:arraybuffer content]|[page:String content]] )</h3>
+		<h3>[method:Object3D parse]( {[param:arraybuffer content]|[param:String content]] )</h3>
 		<div>
 			[[page:arraybuffer content]|[page:String content]] OBJ data as Uint8Array or String
 		</div>
@@ -61,7 +61,7 @@
 		</div>
 
 
-		<h3>[method:Object3D parseAsync]( [page:arraybuffer content], [page:Function onLoad] )</h3>
+		<h3>[method:Object3D parseAsync]( [param:arraybuffer content], [param:Function onLoad] )</h3>
 		<div>
 			[page:arraybuffer content] - OBJ data as Uint8Array<br>
 			[page:Function onLoad] - Called after worker successfully completed loading<br>
@@ -71,10 +71,10 @@
 		</div>
 
 
-		<h3>[method:null load] => [page:LoaderSupport.LoaderBase.load]</h3>
-		
+		<h3>[method:null load] => [param:LoaderSupport.LoaderBase.load]</h3>
 
-		<h3>[method:null run]( [page:LoaderSupport.PrepData params], [page:LoaderSupport.WorkerSupport workerSupportExternal] )</h3>
+
+		<h3>[method:null run]( [param:LoaderSupport.PrepData params], [param:LoaderSupport.WorkerSupport workerSupportExternal] )</h3>
 		<div>
 			[page:LoaderSupport.PrepData params] - prepData All parameters and resources required for execution<br>
 			[page:LoaderSupport.WorkerSupport workerSupportExternal] - Use pre-existing WorkerSupport
@@ -83,11 +83,11 @@
 			Run the loader according the provided instructions.
 		</div>
 
-		
-		<h3>[method:Object checkResourceDescriptorFiles] => [page:LoaderSupport.LoaderBase.checkResourceDescriptorFiles]</h3>
-		
-		
-		<h3>[method:null setMaterialPerSmoothingGroup] ( [page:boolean materialPerSmoothingGroup] )</h3>
+
+		<h3>[method:Object checkResourceDescriptorFiles] => [param:LoaderSupport.LoaderBase.checkResourceDescriptorFiles]</h3>
+
+
+		<h3>[method:null setMaterialPerSmoothingGroup] ( [param:boolean materialPerSmoothingGroup] )</h3>
 		<div>
 			[page:boolean materialPerSmoothingGroup]
 		</div>
@@ -104,7 +104,7 @@
 		</div>
 
 
-		<h3>[method:null setModelName] ( [page:String modelName] )</h3>
+		<h3>[method:null setModelName] ( [param:String modelName] )</h3>
 		<div>
 			[page:String modelName]
 		</div>
@@ -113,7 +113,7 @@
 		</div>
 
 
-		<h3>[method:null setPath] ( [page:String path] )</h3>
+		<h3>[method:null setPath] ( [param:String path] )</h3>
 		<div>
 			[page:String path] - URL
 		</div>
@@ -122,7 +122,7 @@
 		</div>
 
 
-		<h3>[method:null setStreamMeshesTo] ( [page:Object3D streamMeshesTo] )</h3>
+		<h3>[method:null setStreamMeshesTo] ( [param:Object3D streamMeshesTo] )</h3>
 		<div>
 			[page:Object3D streamMeshesTo] - Object already attached to scenegraph where new meshes will be attached to
 		</div>
@@ -131,7 +131,7 @@
 		</div>
 
 
-		<h3>[method:null setMaterials] ( Array of [page:Material materials] )</h3>
+		<h3>[method:null setMaterials] ( Array of [param:Material materials] )</h3>
 		<div>
 			Array of [page:Material materials] - Array of [page:Material Materials]
 		</div>
@@ -140,7 +140,7 @@
 		</div>
 
 
-		<h3>[method:null setUseIndices]( [page:Boolean useIndices] )</h3>
+		<h3>[method:null setUseIndices]( [param:Boolean useIndices] )</h3>
 		<div>
 			[page:Boolean useIndices]
 		</div>
@@ -149,16 +149,16 @@
 		</div>
 
 
-		<h3>[method:null setDisregardNormals]( [page:Boolean disregardNormals] )</h3>
+		<h3>[method:null setDisregardNormals]( [param:Boolean disregardNormals] )</h3>
 		<div>
 			[page:Boolean disregardNormals]
 		</div>
 		<div>
 			Tells whether normals should be completely disregarded and regenerated.
 		</div>
-		
-		
-		<h3>[method:null loadMtl]( [page:String url], [page:Object content], [page:Function callbackOnLoad], [page:String crossOrigin], [page:Object materialOptions]) </h3>
+
+
+		<h3>[method:null loadMtl]( [param:String url], [param:Object content], [param:Function callbackOnLoad], [param:String crossOrigin], [param:Object materialOptions]) </h3>
 		<div>
 			[page:String url] - URL to the file
 			[page:Object content] - The file content as arraybuffer or text
@@ -170,7 +170,7 @@
 			Utility method for loading an mtl file according resource description. Provide url or content..
 		</div>
 
-		
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/OBJLoader2.js examples/js/loaders/OBJLoader2.js]

--- a/docs/examples/loaders/PCDLoader.html
+++ b/docs/examples/loaders/PCDLoader.html
@@ -53,7 +53,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/examples/loaders/PCDLoader.html
+++ b/docs/examples/loaders/PCDLoader.html
@@ -70,7 +70,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — A string containing the path/URL of the <em>.pcd</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br />
@@ -81,7 +81,7 @@
 		Begin loading from url and call onLoad with the parsed response content.
 		</div>
 
-		<h3>[method:Object3D parse]( [page:Arraybuffer data],[page:String url] )</h3>
+		<h3>[method:Object3D parse]( [param:Arraybuffer data],[param:String url] )</h3>
 		<div>
 		[page:Arraybuffer data] — The binary structure to parse.
 		</div>

--- a/docs/examples/loaders/PDBLoader.html
+++ b/docs/examples/loaders/PDBLoader.html
@@ -55,7 +55,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/examples/loaders/PDBLoader.html
+++ b/docs/examples/loaders/PDBLoader.html
@@ -68,7 +68,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — A string containing the path/URL of the <em>.pdb</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives the object having the following properties. [page:BufferGeometry geometryAtoms], [page:BufferGeometry geometryBonds] and the [page:Object JSON] structure.<br />
@@ -79,7 +79,7 @@
 		Begin loading from url and call onLoad with the parsed response content.
 		</div>
 
-		<h3>[method:Object parse]( [page:String text] )</h3>
+		<h3>[method:Object parse]( [param:String text] )</h3>
 		<div>
 		[page:String text] — The textual <em>pdb</em> structure to parse.
 		</div>

--- a/docs/examples/loaders/PRWMLoader.html
+++ b/docs/examples/loaders/PRWMLoader.html
@@ -69,7 +69,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — A string containing the path/URL of the <em>.prwm</em> file. Any <em>*</em> character in the URL will be automatically replaced by <em>le</em> or <em>be</em> depending on the platform endianness.<br />
 		[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:BufferGeometry] as an argument.<br />
@@ -80,7 +80,7 @@
 		Begin loading from url and call onLoad with the parsed response content.
 		</div>
 
-		<h3>[method:BufferGeometry parse]( [page:ArrayBuffer arrayBuffer] )</h3>
+		<h3>[method:BufferGeometry parse]( [param:ArrayBuffer arrayBuffer] )</h3>
 		<div>
 		[page:ArrayBuffer arrayBuffer] — ArrayBuffer containing the <em>prwm</em> data.
 		</div>

--- a/docs/examples/loaders/PRWMLoader.html
+++ b/docs/examples/loaders/PRWMLoader.html
@@ -56,7 +56,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/examples/loaders/SVGLoader.html
+++ b/docs/examples/loaders/SVGLoader.html
@@ -12,11 +12,11 @@
 		<h1>[name]</h1>
 
 		<div class="desc">A loader for loading a <em>.svg</em> resource.<br >
-		<a href="https://en.wikipedia.org/wiki/Scalable_Vector_Graphics">Scalabe Vector Graphics</a> is an XML-based vector image format for two-dimensional graphics with support for interactivity and animation.			
+		<a href="https://en.wikipedia.org/wiki/Scalable_Vector_Graphics">Scalabe Vector Graphics</a> is an XML-based vector image format for two-dimensional graphics with support for interactivity and animation.
 		</div>
 
 		<h2>Example</h2>
-		
+
 		<code>
 		// instantiate a loader
 		var loader = new THREE.PDBLoader();
@@ -51,7 +51,7 @@
 		</code>
 
 		[example:webgl_loader_svg]
-		
+
 		<h2>Constructor</h2>
 
 		<h3>[name]( [page:LoadingManager manager] )</h3>
@@ -67,7 +67,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — A string containing the path/URL of the <em>.svg</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives the loaded [page:SVGDocument] as an argument.<br />

--- a/docs/examples/loaders/SVGLoader.html
+++ b/docs/examples/loaders/SVGLoader.html
@@ -54,7 +54,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/examples/loaders/TGALoader.html
+++ b/docs/examples/loaders/TGALoader.html
@@ -54,7 +54,7 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [page:LoadingManager manager] )</h3>
+		<h3>[name]( [param:LoadingManager manager] )</h3>
 		<div>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
 		</div>

--- a/docs/examples/loaders/TGALoader.html
+++ b/docs/examples/loaders/TGALoader.html
@@ -43,7 +43,7 @@
 
 			}
 		);
-		
+
 		var material = new THREE.MeshPhongMaterial( {
 			color: 0xffffff,
 			map: texture
@@ -65,7 +65,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:DataTexture load]( [page:String url], [page:Function onLoad], [page:Function onProgress], [page:Function onError] )</h3>
+		<h3>[method:DataTexture load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<div>
 		[page:String url] — A string containing the path/URL of the <em>.tga</em> file. <br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives loaded [page:DataTexture] as an argument.<br />

--- a/docs/examples/objects/Lensflare.html
+++ b/docs/examples/objects/Lensflare.html
@@ -44,7 +44,7 @@ light.add( lensflare );
 		<h2>Constructor</h2>
 
 
-		<h3>LensflareElement( [page:Texture texture], [page:Float size], [page:Float distance], [page:Color color], [page:Materials blending] )</h3>
+		<h3>LensflareElement( [param:Texture texture], [param:Float size], [param:Float distance], [param:Color color], [param:Materials blending] )</h3>
 		<div>
 		[page:Texture texture] - THREE.Texture to use for the flare. <br />
 		[page:Float size] - (optional) size in pixels <br />

--- a/docs/examples/quickhull/Face.html
+++ b/docs/examples/quickhull/Face.html
@@ -61,14 +61,14 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Face create]( [page:VertexNode a], [page:VertexNode b], [page:VertexNode c] )</h3>
+		<h3>[method:Face create]( [param:VertexNode a], [param:VertexNode b], [param:VertexNode c] )</h3>
 		[page:VertexNode a] - First vertex of the face.<br /><br />
 		[page:VertexNode b] - Second vertex of the face.<br /><br />
 		[page:VertexNode c] - Third vertex of the face.<br /><br />
 
 		<div>Creates a face.</div>
 
-		<h3>[method:HalfEdge getEdge]( [page:Integer i] )</h3>
+		<h3>[method:HalfEdge getEdge]( [param:Integer i] )</h3>
 		[page:Integer i] - The index of the edge.<br /><br />
 
 		<div>Returns an edge by the given index.</div>
@@ -77,7 +77,7 @@
 
 		<div>Computes all properties of the face.</div>
 
-		<h3>[method:Float distanceToPoint]( [page:Vector3 point] )</h3>
+		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
 		[page:Vector3 point] - Any point in 3D space.<br /><br />
 
 		<div>Returns the signed distance from a given point to the plane representation of this face.</div>

--- a/docs/examples/quickhull/HalfEdge.html
+++ b/docs/examples/quickhull/HalfEdge.html
@@ -67,7 +67,7 @@
 		<div>Returns the square of the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
 		(straight-line length) of the edge.</div>
 
-		<h3>[method:HalfEdge setTwin]( [page:HalfEdge edge] )</h3>
+		<h3>[method:HalfEdge setTwin]( [param:HalfEdge edge] )</h3>
 		[page:HalfEdge edge] - Any half-edge.<br /><br />
 
 		<div>Sets the twin edge of this half-edge. It also ensures that the twin reference of the given half-edge is correctly set.</div>

--- a/docs/examples/quickhull/HalfEdge.html
+++ b/docs/examples/quickhull/HalfEdge.html
@@ -18,7 +18,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:VertexNode vertex], [page:Face face] )</h3>
+		<h3>[name]( [param:VertexNode vertex], [param:Face face] )</h3>
 		[page:VertexNode vertex] - [page:VertexNode] A reference to its destination vertex.<br /><br />
 		[page:Face face] - [page:Face] A reference to its face.<br />
 

--- a/docs/examples/quickhull/QuickHull.html
+++ b/docs/examples/quickhull/QuickHull.html
@@ -56,12 +56,12 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:QuickHull setFromPoints]( [page:Array points] )</h3>
+		<h3>[method:QuickHull setFromPoints]( [param:Array points] )</h3>
 		[page:Array points] - Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.<br /><br />
 
 		<div>Computes to convex hull for the given array of points.</div>
 
-		<h3>[method:QuickHull setFromObject]( [page:Object3D object] )</h3>
+		<h3>[method:QuickHull setFromObject]( [param:Object3D object] )</h3>
 		[page:Object3D object] - [page:Object3D] to compute the convex hull of.<br /><br />
 
 		<div>Computes the convex hull of an [page:Object3D] (including its children),
@@ -71,24 +71,24 @@
 
 		<div>Makes this convex hull empty.</div>
 
-		<h3>[method:QuickHull addVertexToFace]( [page:VertexNode vertex], [page:Face face]	)</h3>
+		<h3>[method:QuickHull addVertexToFace]( [param:VertexNode vertex], [param:Face face]	)</h3>
 		[page:VertexNodeNode vertex] - The vetex to add.<br /><br />
 		[page:Face face] - The target face.<br /><br />
 
 		<div>Adds a vertex to the 'assigned' list of vertices and assigns it to the given face.</div>
 
-		<h3>[method:QuickHull removeVertexFromFace]( [page:VertexNode vertex], [page:Face face]	)</h3>
+		<h3>[method:QuickHull removeVertexFromFace]( [param:VertexNode vertex], [param:Face face]	)</h3>
 		[page:VertexNode vertex] - The vetex to remove.<br /><br />
 		[page:Face face] - The target face.<br /><br />
 
 		<div>Removes a vertex from the 'assigned' list of vertices and from the given face. It also makes sure that the link from 'face' to the first vertex it sees in 'assigned' is linked correctly after the removal.</div>
 
-		<h3>[method:VertexNode removeAllVerticesFromFace]( [page:Face face]	)</h3>
+		<h3>[method:VertexNode removeAllVerticesFromFace]( [param:Face face]	)</h3>
 		[page:Face face] - The given face.<br /><br />
 
 		<div>Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list.</div>
 
-		<h3>[method:QuickHull deleteFaceVertices]( [page:Face face], [page:Face absorbingFace]	)</h3>
+		<h3>[method:QuickHull deleteFaceVertices]( [param:Face face], [param:Face absorbingFace]	)</h3>
 		[page:Face face] - The given face.<br /><br />
 		[page:Face absorbingFace] - An optional face that tries to absorb the vertices of the first face.<br /><br />
 
@@ -100,7 +100,7 @@
 			</ul>
 		</div>
 
-		<h3>[method:QuickHull resolveUnassignedPoints]( [page:Array newFaces]	)</h3>
+		<h3>[method:QuickHull resolveUnassignedPoints]( [param:Array newFaces]	)</h3>
 		[page:Face newFaces] - An array of new faces.<br /><br />
 
 		<div>Reassigns as many vertices as possible from the unassigned list to the new faces.</div>
@@ -127,7 +127,7 @@
 			</ul>
 		</div>
 
-		<h3>[method:QuickHull computeHorizon]( [page:Vector3 eyePoint], [page:HalfEdge crossEdge], [page:Face face], [page:Array horizon]	)</h3>
+		<h3>[method:QuickHull computeHorizon]( [param:Vector3 eyePoint], [param:HalfEdge crossEdge], [param:Face face], [param:Array horizon]	)</h3>
 		[page:Vector3 eyePoint] - The 3D-coordinates of a point.<br /><br />
 		[page:HalfEdge crossEdge] - The edge used to jump to the current face.<br /><br />
 		[page:Face face] - The current face being tested.<br /><br />
@@ -135,20 +135,20 @@
 
 		<div>Computes a chain of half edges in CCW order called the 'horizon'. For an edge to be part of the horizon it must join a face that can see 'eyePoint' and a face that cannot see 'eyePoint'.</div>
 
-		<h3>[method:HalfEdge addAdjoiningFace]( [page:VertexNode eyeVertex], [page:HalfEdge horizonEdge] )</h3>
+		<h3>[method:HalfEdge addAdjoiningFace]( [param:VertexNode eyeVertex], [param:HalfEdge horizonEdge] )</h3>
 		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
 		[page:HalfEdge horizonEdge] - A single edge of the horizon.<br /><br />
 
 		<div>Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order.
 			All the half edges are created in CCW order thus the face is always pointing outside the hull</div>
 
-		<h3>[method:QuickHull addNewFaces]( [page:VertexNode eyeVertex], [page:HalfEdge horizonEdge] )</h3>
+		<h3>[method:QuickHull addNewFaces]( [param:VertexNode eyeVertex], [param:HalfEdge horizonEdge] )</h3>
 		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
 		[page:HalfEdge horizon] - An array of half-edges that form the horizon.<br /><br />
 
 		<div>Adds 'horizon.length' faces to the hull, each face will be linked with the horizon opposite face and the face on the left/right.</div>
 
-		<h3>[method:QuickHull addVertexToHull]( [page:VertexNode eyeVertex] )</h3>
+		<h3>[method:QuickHull addVertexToHull]( [param:VertexNode eyeVertex] )</h3>
 		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
 
 		<div>Adds a vertex to the hull with the following algorithm

--- a/docs/examples/quickhull/VertexList.html
+++ b/docs/examples/quickhull/VertexList.html
@@ -45,34 +45,34 @@
 		<h3>[method:VertexList clear]()</h3>
 		<div>Clears the linked list.</div>
 
-		<h3>[method:VertexList insertBefore]( [page:Vertex target], [page:Vertex vertex] )</h3>
+		<h3>[method:VertexList insertBefore]( [param:Vertex target], [param:Vertex vertex] )</h3>
 		[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br /><br />
 		[page:Vertex vertex] - The vertex to insert.<br /><br />
 
 		<div>Inserts a vertex <strong>before</strong> a target vertex.</div>
 
-		<h3>[method:VertexList insertAfter]( [page:Vertex target], [page:Vertex vertex] )</h3>
+		<h3>[method:VertexList insertAfter]( [param:Vertex target], [param:Vertex vertex] )</h3>
 		[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br /><br />
 		[page:Vertex vertex] - The vertex to insert.<br /><br />
 
 		<div>Inserts a vertex <strong>after</strong> a target vertex.</div>
 
-		<h3>[method:VertexList append]( [page:Vertex vertex] )</h3>
+		<h3>[method:VertexList append]( [param:Vertex vertex] )</h3>
 		[page:Vertex vertex] - The vertex to append.<br /><br />
 
 		<div>Appends a vertex to the end of the linked list.</div>
 
-		<h3>[method:VertexList appendChain]( [page:Vertex vertex] )</h3>
+		<h3>[method:VertexList appendChain]( [param:Vertex vertex] )</h3>
 		[page:Vertex vertex] - The head vertex of a chain of vertices.<br /><br />
 
 		<div>Appends a chain of vertices where the given vertex is the head.</div>
 
-		<h3>[method:VertexList remove]( [page:Vertex vertex] )</h3>
+		<h3>[method:VertexList remove]( [param:Vertex vertex] )</h3>
 		[page:Vertex vertex] - The vertex to remove.<br /><br />
 
 		<div>Removes a vertex from the linked list.</div>
 
-		<h3>[method:VertexList removeSubList]( [page:Vertex a], [page:Vertex b] )</h3>
+		<h3>[method:VertexList removeSubList]( [param:Vertex a], [param:Vertex b] )</h3>
 		[page:Vertex a] - The head of the sublist.<br /><br />
 		[page:Vertex b] - The tail of the sublist.<br /><br />
 

--- a/docs/examples/quickhull/VertexNode.html
+++ b/docs/examples/quickhull/VertexNode.html
@@ -18,7 +18,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [page:Vector3 point] )</h3>
+		<h3>[name]( [param:Vector3 point] )</h3>
 		[page:Vector3 point] - [page:Vector3] A point (x, y, z) in 3D space.<br /><br />
 
 		</div>

--- a/docs/examples/renderers/CanvasRenderer.html
+++ b/docs/examples/renderers/CanvasRenderer.html
@@ -107,7 +107,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null render]([page:Scene scene], [page:Camera camera])</h3>
+		<h3>[method:null render]([param:Scene scene], [param:Camera camera])</h3>
 		<div>
 			scene -- The scene to render. <br />
 			camera -- the camera to view the scene.
@@ -121,7 +121,7 @@
 			Tells the renderer to clear its color drawing buffer with the clearcolor.
 		</div>
 
-		<h3>[method:null setClearColor]([page:Color color], [page:number alpha])</h3>
+		<h3>[method:null setClearColor]([param:Color color], [param:number alpha])</h3>
 		<div>
 			color -- The color to clear the canvas with. <br />
 			alpha -- The alpha channel to clear the canvas with.
@@ -131,7 +131,7 @@
 		</div>
 
 
-		<h3>[method:null setSize]([page:Number width], [page:Number height])</h3>
+		<h3>[method:null setSize]([param:Number width], [param:Number height])</h3>
 		<div>
 			width -- The width of the drawing canvas. <br />
 			height -- The height of the drawing canvas.
@@ -140,7 +140,7 @@
 			This set the size of the drawing canvas and if updateStyle is set, then the css of the canvas is updated too.
 		</div>
 
-		<h3>[method:null setClearColorHex]([page:number hex], [page:number alpha])</h3>
+		<h3>[method:null setClearColorHex]([param:number hex], [param:number alpha])</h3>
 		<div>
 			hex -- The the hexadecimal value of the color to clear the canvas with. <br />
 	    alpha -- The alpha channel to clear the canvas with.

--- a/docs/examples/renderers/CanvasRenderer.html
+++ b/docs/examples/renderers/CanvasRenderer.html
@@ -51,7 +51,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([page:object parameters])</h3>
+		<h3>[name]([param:object parameters])</h3>
         <div>parameters is an optional object with properties defining the renderer's behaviour. The constructor also accepts no parameters at all. In all cases, it will assume sane defaults when parameters are missing.</div>
 
 		<div>

--- a/docs/examples/utils/SceneUtils.html
+++ b/docs/examples/utils/SceneUtils.html
@@ -16,7 +16,7 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:Group createMultiMaterialObject]( [page:Geometry geometry], [page:Array materials] )</h3>
+		<h3>[method:Group createMultiMaterialObject]( [param:Geometry geometry], [param:Array materials] )</h3>
 		<div>
 		geometry -- The geometry for the set of materials. <br />
 		materials -- The materials for the object.
@@ -26,7 +26,7 @@
 		This is mostly useful for objects that need both a material and a wireframe implementation.
 		</div>
 
-		<h3>[method:null attach]( [page:Object3D child], [page:Object3D scene], [page:Object3D parent] )</h3>
+		<h3>[method:null attach]( [param:Object3D child], [param:Object3D scene], [param:Object3D parent] )</h3>
 		<div>
 		child -- The object to add to the parent  <br />
 		scene -- The scene to detach the object on. <br />
@@ -36,7 +36,7 @@
 		Attaches the object to the parent without the moving the object in the worldspace. Beware that to do this the matrixWorld needs to be updated, this can be done by calling the updateMatrixWorld method on the parent object.
 		</div>
 
-		<h3>[method:null detach]( [page:Object3D child], [page:Object3D parent], [page:Object3D scene] )</h3>
+		<h3>[method:null detach]( [param:Object3D child], [param:Object3D parent], [param:Object3D scene] )</h3>
 		<div>
 		child -- The object to remove from the parent  <br />
 		scene -- The scene to attach the object on. <br />

--- a/docs/page.css
+++ b/docs/page.css
@@ -115,3 +115,12 @@ a.permalink {
 	float: right;
 	margin-left: 5px;
 }
+
+a.param,
+span.param {
+	color: #999;
+}
+
+a.param:hover {
+	color: #777;
+}

--- a/docs/page.js
+++ b/docs/page.js
@@ -61,6 +61,7 @@ function onDocumentLoad( event ) {
 
 	text = text.replace( /\[(member|property|method|param):([\w]+)\]/gi, "[$1:$2 $2]" ); // [member:name] to [member:name title]
 	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]\s*(\(.*\))?/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$2')\" target=\"_parent\" title=\"" + name + ".$2\" class=\"permalink\">#</a> .<a onclick=\"window.parent.setUrlFragment('" + name + ".$2')\" id=\"$2\">$2</a> $3 : <a class=\"param\" onclick=\"window.parent.setUrlFragment('$1')\">$1</a>" );
+	text = text.replace( / : <a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">null<\/a>/gi, '' ); // remove null return types
 	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, "$2 : <a class=\"param\" onclick=\"window.parent.setUrlFragment('$1')\">$1</a>" ); // [param:name title]
 
 	text = text.replace( /\[link:([\w|\:|\/|\.|\-|\_]+)\]/gi, "[link:$1 $1]" ); // [link:url] to [link:url title]
@@ -70,7 +71,7 @@ function onDocumentLoad( event ) {
 	text = text.replace( /\[example:([\w\_]+)\]/gi, "[example:$1 $1]" ); // [example:name] to [example:name title]
 	text = text.replace( /\[example:([\w\_]+) ([\w\:\/\.\-\_ \s]+)\]/gi, "<a href=\"../examples/#$1\"  target=\"_blank\">$2</a>" ); // [example:name title]
 
-	text = text.replace( /<a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">(null|Boolean|Object|Array|Number|String|Integer|Float|TypedArray|ArrayBuffer)<\/a>/gi, '<span class="param">$1</span>' ); // remove links to primitive types
+	text = text.replace( /<a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">(Boolean|Object|Array|Number|String|Integer|Float|TypedArray|ArrayBuffer)<\/a>/gi, '<span class="param">$1</span>' ); // remove links to primitive types
 
 	document.body.innerHTML = text;
 

--- a/docs/page.js
+++ b/docs/page.js
@@ -61,7 +61,6 @@ function onDocumentLoad( event ) {
 
 	text = text.replace( /\[(member|property|method|param):([\w]+)\]/gi, "[$1:$2 $2]" ); // [member:name] to [member:name title]
 	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]\s*(\(.*\))?/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$2')\" target=\"_parent\" title=\"" + name + ".$2\" class=\"permalink\">#</a> .<a onclick=\"window.parent.setUrlFragment('" + name + ".$2')\" id=\"$2\">$2</a> $3 : <a class=\"param\" onclick=\"window.parent.setUrlFragment('$1')\">$1</a>" );
-	text = text.replace( / : <a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">null<\/a>/gi, '' ); // remove null return types
 	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, "$2 : <a class=\"param\" onclick=\"window.parent.setUrlFragment('$1')\">$1</a>" ); // [param:name title]
 
 	text = text.replace( /\[link:([\w|\:|\/|\.|\-|\_]+)\]/gi, "[link:$1 $1]" ); // [link:url] to [link:url title]
@@ -71,7 +70,7 @@ function onDocumentLoad( event ) {
 	text = text.replace( /\[example:([\w\_]+)\]/gi, "[example:$1 $1]" ); // [example:name] to [example:name title]
 	text = text.replace( /\[example:([\w\_]+) ([\w\:\/\.\-\_ \s]+)\]/gi, "<a href=\"../examples/#$1\"  target=\"_blank\">$2</a>" ); // [example:name title]
 
-	text = text.replace( /<a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">(Boolean|Object|Array|Number|String|Integer|Float|TypedArray|ArrayBuffer)<\/a>/gi, '<span class="param">$1</span>' ); // remove links to primitive types
+	text = text.replace( /<a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">(null|Boolean|Object|Array|Number|String|Integer|Float|TypedArray|ArrayBuffer)<\/a>/gi, '<span class="param">$1</span>' ); // remove links to primitive types
 
 	document.body.innerHTML = text;
 

--- a/docs/page.js
+++ b/docs/page.js
@@ -59,8 +59,9 @@ function onDocumentLoad( event ) {
 	text = text.replace( /\[page:([\w\.]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('$1')\" title=\"$1\">$2</a>" ); // [page:name title]
 	// text = text.replace( /\[member:.([\w]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$1')\" title=\"$1\">$2</a>" );
 
-	text = text.replace( /\[(?:member|property|method):([\w]+)\]/gi, "[member:$1 $1]" ); // [member:name] to [member:name title]
-	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$2')\" target=\"_parent\" title=\"" + name + ".$2\" class=\"permalink\">#</a> .<a onclick=\"window.parent.setUrlFragment('$1')\" title=\"$1\" id=\"$2\">$2</a> " );
+	text = text.replace( /\[(member|property|method|param):([\w]+)\]/gi, "[$1:$2 $2]" ); // [member:name] to [member:name title]
+	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]\s*(\(.*\))?/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$2')\" target=\"_parent\" title=\"" + name + ".$2\" class=\"permalink\">#</a> .<a onclick=\"window.parent.setUrlFragment('" + name + ".$2')\" id=\"$2\">$2</a> $3 : <a class=\"param\" onclick=\"window.parent.setUrlFragment('$1')\">$1</a>" );
+	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, "$2 : <a class=\"param\" onclick=\"window.parent.setUrlFragment('$1')\">$1</a>" ); // [param:name title]
 
 	text = text.replace( /\[link:([\w|\:|\/|\.|\-|\_]+)\]/gi, "[link:$1 $1]" ); // [link:url] to [link:url title]
 	text = text.replace( /\[link:([\w|\:|\/|\.|\-|\_|\(|\)|\#|\=]+) ([\w|\:|\/|\.|\-|\_|\s]+)\]/gi, "<a href=\"$1\"  target=\"_blank\">$2</a>" ); // [link:url title]
@@ -69,6 +70,7 @@ function onDocumentLoad( event ) {
 	text = text.replace( /\[example:([\w\_]+)\]/gi, "[example:$1 $1]" ); // [example:name] to [example:name title]
 	text = text.replace( /\[example:([\w\_]+) ([\w\:\/\.\-\_ \s]+)\]/gi, "<a href=\"../examples/#$1\"  target=\"_blank\">$2</a>" ); // [example:name title]
 
+	text = text.replace( /<a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">(null|Boolean|Object|Array|Number|String|Integer|Float)<\/a>/gi, '<span class="param">$1</span>' ); // remove links to primitive types
 
 	document.body.innerHTML = text;
 

--- a/docs/page.js
+++ b/docs/page.js
@@ -70,7 +70,7 @@ function onDocumentLoad( event ) {
 	text = text.replace( /\[example:([\w\_]+)\]/gi, "[example:$1 $1]" ); // [example:name] to [example:name title]
 	text = text.replace( /\[example:([\w\_]+) ([\w\:\/\.\-\_ \s]+)\]/gi, "<a href=\"../examples/#$1\"  target=\"_blank\">$2</a>" ); // [example:name title]
 
-	text = text.replace( /<a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">(null|Boolean|Object|Array|Number|String|Integer|Float)<\/a>/gi, '<span class="param">$1</span>' ); // remove links to primitive types
+	text = text.replace( /<a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">(null|Boolean|Object|Array|Number|String|Integer|Float|TypedArray|ArrayBuffer)<\/a>/gi, '<span class="param">$1</span>' ); // remove links to primitive types
 
 	document.body.innerHTML = text;
 


### PR DESCRIPTION
This came up in an issue at one point, so thought I'd suggest a way of displaying type information in the docs. ~~This just covers BufferGeometry, but I can update other pages if the approach is agreeable.~~ PR now covers all pages. Method/property names would now use their own permalinks, with type information in a low-contrast color afterward.

[Demo — All docs](https://cdn.rawgit.com/donmccurdy/three.js/docs-visible-types/docs/#api/core/BufferGeometry)

| Screenshot|
|--|
| <img width="1181" alt="screen shot 2018-02-12 at 7 43 37 pm" src="https://user-images.githubusercontent.com/1848368/36132675-4f7fb392-102d-11e8-87d3-bc07ec4463fa.png">|

