### PR TITLE
FBXLoader: use Matrix3.getNormalMatrix

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1099,13 +1099,6 @@
 
 			var normalAttribute = new THREE.Float32BufferAttribute( normalBuffer, 3 );
 
-			// var normalsPreTransform = preTransform.clone().setPosition( new THREE.Vector3() );
-
-			// // required when preTransform has a non-uniform scale component
-			// normalsPreTransform.getInverse( normalsPreTransform ).transpose();
-
-			// normalsPreTransform.applyToBufferAttribute( normalAttribute );
-
 			var normalMatrix = new THREE.Matrix3().getNormalMatrix( preTransform );
 			normalMatrix.applyToBufferAttribute( normalAttribute );
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1099,12 +1099,15 @@
 
 			var normalAttribute = new THREE.Float32BufferAttribute( normalBuffer, 3 );
 
-			var normalsPreTransform = preTransform.clone().setPosition( new THREE.Vector3() );
+			// var normalsPreTransform = preTransform.clone().setPosition( new THREE.Vector3() );
 
-			// required when preTransform has a non-uniform scale component
-			normalsPreTransform.getInverse( normalsPreTransform ).transpose();
+			// // required when preTransform has a non-uniform scale component
+			// normalsPreTransform.getInverse( normalsPreTransform ).transpose();
 
-			normalsPreTransform.applyToBufferAttribute( normalAttribute );
+			// normalsPreTransform.applyToBufferAttribute( normalAttribute );
+
+			var normalMatrix = new THREE.Matrix3().getNormalMatrix( preTransform );
+			normalMatrix.applyToBufferAttribute( normalAttribute );
 
 			geo.addAttribute( 'normal', normalAttribute );
 


### PR DESCRIPTION
Switch to `Matrix3().getNormalMatrix` instead of calculating the normal matrix directly.