### PR TITLE
Fix for GLTFExporter.js

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -241,7 +241,7 @@ THREE.GLTFExporter.prototype = {
 
 					} else if ( componentType === WEBGL_CONSTANTS.UNSIGNED_INT ) {
 
-						dataView.setUint8( offset, value, true );
+						dataView.setUint32( offset, value, true );
 
 					} else if ( componentType === WEBGL_CONSTANTS.UNSIGNED_SHORT ) {
 


### PR DESCRIPTION
As described in gltf specification, (UNSIGNED_INT) is 4 bytes. 
This commit solve the fact that the exporter failed to export correctly assets containing faces with vertexe's indexes above than 255.