### PR TITLE
Editor determines GLTF version and uses appropriate loader

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -24,6 +24,7 @@
 		<script src="../examples/js/loaders/ColladaLoader.js"></script>
 		<script src="../examples/js/loaders/FBXLoader.js"></script>
 		<script src="../examples/js/loaders/GLTFLoader.js"></script>
+		<script src="../examples/js/loaders/deprecated/LegacyGLTFLoader.js"></script>
 		<script src="../examples/js/loaders/KMZLoader.js"></script>
 		<script src="../examples/js/loaders/MD2Loader.js"></script>
 		<script src="../examples/js/loaders/OBJLoader.js"></script>

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -176,7 +176,18 @@ var Loader = function ( editor ) {
 
 					var contents = event.target.result;
 
-					var loader = new THREE.GLTFLoader();
+					var loader;
+
+					if ( isGltf1( contents ) ) {
+
+						loader = new THREE.LegacyGLTFLoader();
+
+					} else {
+
+						loader = new THREE.GLTFLoader();
+
+					}
+
 					loader.parse( contents, '', function ( result ) {
 
 						result.scene.name = filename;
@@ -569,6 +580,47 @@ var Loader = function ( editor ) {
 				break;
 
 		}
+
+	}
+
+	function isGltf1( contents ) {
+
+		var resultContent;
+
+		if ( typeof contents === 'string' ) {
+
+			resultContent = contents;
+
+		} else {
+
+			var magic = THREE.LoaderUtils.decodeText( new Uint8Array( contents, 0, 4 ) );
+
+			if ( magic === 'glTF' ) {
+
+				try {
+
+					extensions[ EXTENSIONS.KHR_BINARY_GLTF ] = new GLTFBinaryExtension( contents );
+
+				} catch ( error ) {
+
+					// dunno what it is, but it's definitely not OK
+					return false;
+
+				}
+
+				resultContent = extensions[ EXTENSIONS.KHR_BINARY_GLTF ].content;
+
+			} else {
+
+				resultContent = THREE.LoaderUtils.decodeText( new Uint8Array( contents ) );
+
+			}
+
+		}
+
+		var json = JSON.parse( resultContent );
+
+		return ( json.asset != undefined && json.asset.version[ 0 ] < 2 );
 
 	}
 


### PR DESCRIPTION
Hi! In my first pull request, I expanded the LegacyGLTFLoader's ability to handle vertex attributes (that is, that code's on another git branch), and tested it by slightly modifying the three.js editor (that's the code on this git branch).

The argument order for the parse() function's second and third arguments was reversed between the editor's and the legacy loader's code, so in order to test with the editor, I patched that in the other branch.

This branch contains the editor changes that allow it to open both GLTF 1 and 2 files. Please note that will only work if the parse() argument-swap in the other branch is in place, so if you decide not to accept my previous pull request, you can ignore this pull request.