### PR TITLE
ColladaLoader: Improve parsing of distance unit

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -159,7 +159,15 @@ THREE.ColladaLoader.prototype = {
 
 		function parseAssetUnit( xml ) {
 
-			return xml !== undefined ? parseFloat( xml.getAttribute( 'meter' ) ) : 1;
+			if ( ( xml !== undefined ) && ( xml.hasAttribute( 'meter' ) === true ) ) {
+
+				return parseFloat( xml.getAttribute( 'meter' ) );
+
+			} else {
+
+				return 1; // default 1 meter
+
+			}
 
 		}
 


### PR DESCRIPTION
This PR solves one problem of #13335

The `meter` property of the `unit` tag is optional. If it is not set, you have to use the default value of `1` according to the [spec](https://www.khronos.org/files/collada_spec_1_5.pdf) (see `<asset>` element).