### PR TITLE
Transform controls vs transparency vs fog

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -12,6 +12,7 @@
 
 		this.depthTest = false;
 		this.depthWrite = false;
+		this.fog = false;
 		this.side = THREE.FrontSide;
 		this.transparent = true;
 
@@ -48,6 +49,7 @@
 
 		this.depthTest = false;
 		this.depthWrite = false;
+		this.fog = false;
 		this.transparent = true;
 		this.linewidth = 1;
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -136,6 +136,9 @@
 
 						object.name = name;
 
+						//always render on top of the scene (avoid being hidden by transparent objects)
+						object.renderOrder = Infinity;
+
 						if ( position ) object.position.set( position[ 0 ], position[ 1 ], position[ 2 ] );
 						if ( rotation ) object.rotation.set( rotation[ 0 ], rotation[ 1 ], rotation[ 2 ] );
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -136,7 +136,7 @@
 
 						object.name = name;
 
-						//always render on top of the scene (avoid being hidden by transparent objects)
+						//avoid being hidden by other transparent objects
 						object.renderOrder = Infinity;
 
 						if ( position ) object.position.set( position[ 0 ], position[ 1 ], position[ 2 ] );


### PR DESCRIPTION
The transform controls gizmo currently receives fog and can be hidden by other transparent objects. This PR disables the fog in its materials and puts the `renderOrder` of its lines and meshes to `Infinity`.