### PR TITLE
Update Lensflare.js to be able to dispose textures

### DIFF
--- a/examples/js/objects/Lensflare.js
+++ b/examples/js/objects/Lensflare.js
@@ -127,7 +127,7 @@ THREE.Lensflare = function () {
 
 	//
 
-	var elements = [];
+	this.elements = [];
 
 	var shader = THREE.LensflareElement.Shader;
 
@@ -150,7 +150,7 @@ THREE.Lensflare = function () {
 
 	this.addElement = function ( element ) {
 
-		elements.push( element );
+		this.elements.push( element );
 
 	};
 
@@ -220,9 +220,9 @@ THREE.Lensflare = function () {
 			var vecX = - positionScreen.x * 2;
 			var vecY = - positionScreen.y * 2;
 
-			for ( var i = 0, l = elements.length; i < l; i ++ ) {
+			for ( var i = 0, l = this.elements.length; i < l; i ++ ) {
 
-				var element = elements[ i ];
+				var element = this.elements[ i ];
 
 				var uniforms = material2.uniforms;
 

--- a/examples/js/objects/Lensflare.js
+++ b/examples/js/objects/Lensflare.js
@@ -127,7 +127,7 @@ THREE.Lensflare = function () {
 
 	//
 
-	this.elements = [];
+	elements = [];
 
 	var shader = THREE.LensflareElement.Shader;
 
@@ -150,7 +150,7 @@ THREE.Lensflare = function () {
 
 	this.addElement = function ( element ) {
 
-		this.elements.push( element );
+		elements.push( element );
 
 	};
 
@@ -220,9 +220,9 @@ THREE.Lensflare = function () {
 			var vecX = - positionScreen.x * 2;
 			var vecY = - positionScreen.y * 2;
 
-			for ( var i = 0, l = this.elements.length; i < l; i ++ ) {
+			for ( var i = 0, l = elements.length; i < l; i ++ ) {
 
-				var element = this.elements[ i ];
+				var element = elements[ i ];
 
 				var uniforms = material2.uniforms;
 
@@ -254,6 +254,10 @@ THREE.Lensflare = function () {
 
 		tempMap.dispose();
 		occlusionMap.dispose();
+		
+		for ( var i = 0, l = elements.length; i < l; i ++ ) {
+			elements[i].texture.dispose();
+		}
 
 	};
 


### PR DESCRIPTION
Update Lensflare.js so to be able to properly dispose the textures otherwise we have memory issues...

In order to properly dispose the textures added into the Lensflare ( new THREE.Lensflare()  ) by the ( new THREE.LensflareElement() ) we must place them into the object. So then we can do for example:

```
for( var i = scene.children.length - 1; i >= 0; i-- ) {
  for( var j = 0, n = scene.children[i].elements.length; j <n; j++ ){
    scene.children[i].elements[j].texture.dispose();
  }
}
```

![screenshot from 2018-02-17 23 03 35](https://user-images.githubusercontent.com/518451/36345608-db858a12-1436-11e8-83af-b43c50735c7a.png)

Note: we could probably use  the "children" array to store the THREE.LensflareElement instead of "elements".

Note: the Lensflare dispose method does not dispose textures.
