### PR TITLE
Update GLTFLoader doc for Draco

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -138,7 +138,7 @@
 		[page:DRACOLoader dracoLoader] — Instance of THREE.DRACOLoader, to be used for decoding assets compressed with the KHR_draco_mesh_compression extension.
 		</div>
 		<div>
-		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme page] for the details of Draco and its decoder.
+		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme] for the details of Draco and its decoder.
 		</div>
 
 		<h3>[method:null parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -49,7 +49,7 @@
 			var loader = new THREE.GLTFLoader();
 
 			// Optional: Provide a DRACOLoader instance to decode compressed mesh data
-			THREE.DRACOLoader.setDecoderPath( '/examples/js/loaders/draco' );
+			THREE.DRACOLoader.setDecoderPath( '/examples/js/libs/draco' );
 			loader.setDRACOLoader( new THREE.DRACOLoader() );
 
 			// Load a glTF resource
@@ -136,6 +136,9 @@
 		<h3>[method:null setDRACOLoader]( [param:DRACOLoader dracoLoader] )</h3>
 		<div>
 		[page:DRACOLoader dracoLoader] — Instance of THREE.DRACOLoader, to be used for decoding assets compressed with the KHR_draco_mesh_compression extension.
+		</div>
+		<div>
+		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme page] for the details of Draco and its decoder.
 		</div>
 
 		<h3>[method:null parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>


### PR DESCRIPTION
This PR updates `GLTFLoader` doc a bit for Draco

- Update draco decoder path in the sample code
- Add a link to https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme

/cc @donmccurdy 