### PR TITLE
GLTFExporter: Add comment for empty strings name

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1086,7 +1086,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			if ( object.name !== undefined ) {
+			if ( object.name ) {
 
 				gltfNode.name = String( object.name );
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1086,7 +1086,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			if ( object.name ) {
+			if ( object.name !== undefined ) {
 
 				gltfNode.name = String( object.name );
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1086,6 +1086,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
+			// We don't export empty strings name because it represents no-name in Three.js.
 			if ( object.name ) {
 
 				gltfNode.name = String( object.name );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1087,7 +1087,7 @@ THREE.GLTFExporter.prototype = {
 			}
 
 			// We don't export empty strings name because it represents no-name in Three.js.
-			if ( object.name ) {
+			if ( object.name !== '' ) {
 
 				gltfNode.name = String( object.name );
 


### PR DESCRIPTION
I think we need to compare `object.name` with `undefined` to allow 0 and empty string as node name in `GLTFExporter`.