### PR TITLE
 split normal_fragment to normal_fragment_begin and normal_fragment_maps 

### DIFF
--- a/examples/js/nodes/materials/PhongNode.js
+++ b/examples/js/nodes/materials/PhongNode.js
@@ -152,7 +152,7 @@ THREE.PhongNode.prototype.build = function ( builder ) {
 
 		var output = [
 			// prevent undeclared normal
-			"#include <normal_fragment>",
+			"#include <normal_fragment_begin>",
 
 			// prevent undeclared material
 			"	BlinnPhongMaterial material;",

--- a/examples/js/nodes/materials/StandardNode.js
+++ b/examples/js/nodes/materials/StandardNode.js
@@ -191,7 +191,7 @@ THREE.StandardNode.prototype.build = function ( builder ) {
 
 		var output = [
 			// prevent undeclared normal
-			"	#include <normal_fragment>",
+			"	#include <normal_fragment_begin>",
 
 			// prevent undeclared material
 			"	PhysicalMaterial material;",

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -58,7 +58,8 @@ import metalnessmap_pars_fragment from './ShaderChunk/metalnessmap_pars_fragment
 import morphnormal_vertex from './ShaderChunk/morphnormal_vertex.glsl';
 import morphtarget_pars_vertex from './ShaderChunk/morphtarget_pars_vertex.glsl';
 import morphtarget_vertex from './ShaderChunk/morphtarget_vertex.glsl';
-import normal_fragment from './ShaderChunk/normal_fragment.glsl';
+import normal_fragment_begin from './ShaderChunk/normal_fragment_begin.glsl';
+import normal_fragment_maps from './ShaderChunk/normal_fragment_maps.glsl';
 import normalmap_pars_fragment from './ShaderChunk/normalmap_pars_fragment.glsl';
 import packing from './ShaderChunk/packing.glsl';
 import premultiplied_alpha_fragment from './ShaderChunk/premultiplied_alpha_fragment.glsl';
@@ -173,7 +174,8 @@ export var ShaderChunk = {
 	morphnormal_vertex: morphnormal_vertex,
 	morphtarget_pars_vertex: morphtarget_pars_vertex,
 	morphtarget_vertex: morphtarget_vertex,
-	normal_fragment: normal_fragment,
+	normal_fragment_begin: normal_fragment_begin,
+	normal_fragment_maps: normal_fragment_maps,
 	normalmap_pars_fragment: normalmap_pars_fragment,
 	packing: packing,
 	premultiplied_alpha_fragment: premultiplied_alpha_fragment,

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl
@@ -17,13 +17,3 @@
 	#endif
 
 #endif
-
-#ifdef USE_NORMALMAP
-
-	normal = perturbNormal2Arb( -vViewPosition, normal );
-
-#elif defined( USE_BUMPMAP )
-
-	normal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() );
-
-#endif

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl
@@ -1,0 +1,9 @@
+#ifdef USE_NORMALMAP
+
+	normal = perturbNormal2Arb( -vViewPosition, normal );
+
+#elif defined( USE_BUMPMAP )
+
+	normal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() );
+
+#endif

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
@@ -45,7 +45,8 @@ void main() {
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
 	#include <specularmap_fragment>
-	#include <normal_fragment>
+	#include <normal_fragment_begin>
+	#include <normal_fragment_maps>
 	#include <emissivemap_fragment>
 
 	// accumulation

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
@@ -60,7 +60,8 @@ void main() {
 	#include <alphatest_fragment>
 	#include <roughnessmap_fragment>
 	#include <metalnessmap_fragment>
-	#include <normal_fragment>
+	#include <normal_fragment_begin>
+	#include <normal_fragment_maps>
 	#include <emissivemap_fragment>
 
 	// accumulation

--- a/src/renderers/shaders/ShaderLib/normal_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/normal_frag.glsl
@@ -23,7 +23,8 @@ uniform float opacity;
 void main() {
 
 	#include <logdepthbuf_fragment>
-	#include <normal_fragment>
+	#include <normal_fragment_begin>
+	#include <normal_fragment_maps>
 
 	gl_FragColor = vec4( packNormalToRGB( normal ), opacity );
 


### PR DESCRIPTION
Follow the same logic of this PR https://github.com/mrdoob/three.js/pull/13277

The problem happen when I use the properties `normalMap` and/or `bumpMap` with other code but needing the `normal` core code.

```
normal_fragment.glsl -> normal_fragment_begin.glsl + normal_fragment_maps.glsl
```