### PR TITLE
GLTFExpporter: Support morph targetNames

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -811,6 +811,19 @@ THREE.GLTFExporter.prototype = {
 			if ( mesh.morphTargetInfluences !== undefined && mesh.morphTargetInfluences.length > 0 ) {
 
 				var weights = [];
+				var targetNames = [];
+				var reverseDictionary = {};
+
+				if ( mesh.morphTargetDictionary !== undefined ) {
+
+					for ( var key in mesh.morphTargetDictionary ) {
+
+						reverseDictionary[ mesh.morphTargetDictionary[ key ] ] = key;
+
+					}
+
+				}
+
 				gltfMesh.primitives[ 0 ].targets = [];
 
 				for ( var i = 0; i < mesh.morphTargetInfluences.length; ++ i ) {
@@ -828,10 +841,18 @@ THREE.GLTFExporter.prototype = {
 					gltfMesh.primitives[ 0 ].targets.push( target );
 
 					weights.push( mesh.morphTargetInfluences[ i ] );
+					if ( mesh.morphTargetDictionary !== undefined ) targetNames.push( reverseDictionary[ i ] );
 
 				}
 
 				gltfMesh.weights = weights;
+
+				if ( targetNames.length > 0 ) {
+
+					gltfMesh.extras = {};
+					gltfMesh.extras.targetNames = targetNames;
+
+				}
 
 			}
 


### PR DESCRIPTION
glTF 2.0 doesn't have morph target names in core spec.
But storing them into mesh.extra is suggested in glTF spec issue thread https://github.com/KhronosGroup/glTF/issues/1036

Let's do that so far in `GLTFExporter` til morph target names is supported in core (maybe glTF next?) not to lose useful information.

Blender does it, too. https://github.com/KhronosGroup/glTF-Blender-Exporter/pull/153
