### PR TITLE
GLTFLoader: Support morph targetNames

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1205,6 +1205,17 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
+		// .extras has user defined data so just in case cheking if .extras.targetNames is array.
+		if ( meshDef.extras && Array.isArray( meshDef.extras.targetNames ) ) {
+
+			for ( var i = 0, il = meshDef.extras.targetNames.length; i < il; i ++ ) {
+
+				mesh.morphTargetDictionary[ meshDef.extras.targetNames[ i ] ] = i;
+
+			}
+
+		}
+
 	}
 
 	function isPrimitiveEqual( a, b ) {

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1205,7 +1205,7 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
-		// .extras has user defined data so just in case cheking if .extras.targetNames is array.
+		// .extras has user-defined data, so check that .extras.targetNames is an array.
 		if ( meshDef.extras && Array.isArray( meshDef.extras.targetNames ) ) {
 
 			for ( var i = 0, il = meshDef.extras.targetNames.length; i < il; i ++ ) {


### PR DESCRIPTION
Blender and `GLTFExporter` store morph target names into mesh.extra as suggested in glTF spec issue thread. It isn't glTF core spec yet but I wanna enable `GLTFLoader` to load it.

#13366
https://github.com/KhronosGroup/glTF-Blender-Exporter/pull/153
https://github.com/KhronosGroup/glTF/issues/1036