### PR TITLE
Docs: add ES6/Webpack boilerplate to Getting Started docs

### DIFF
--- a/docs/list.js
+++ b/docs/list.js
@@ -3,6 +3,7 @@ var list = {
 	"Manual": {
 
 		"Getting Started": {
+			"Quickstart Project": "manual/introduction/Quick-start-project",
 			"Creating a scene": "manual/introduction/Creating-a-scene",
 			"Import via modules": "manual/introduction/Import-via-modules",
 			"Browser support": "manual/introduction/Browser-support",

--- a/docs/manual/introduction/Quick-start-project.html
+++ b/docs/manual/introduction/Quick-start-project.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1><br />
+		<p>
+			The <a href="https://github.com/edwinwebb/three-seed/">three-seed</a> project is designed 
+			to get you started with three.js development using modern tools. Use it to quickly get 
+			going on your next three.js project or a easy environment to start playing with the 
+			library. 
+		</p>
+		<h2>What's included</h2>
+		<p>
+			Included in the project is code for a Camera, Scene and Renderer. It's also easy to manage 
+			file imports and has examples of loading models and updating the scene. The project will 
+			also set up a local development server which automatically updates the browser.
+		</p>
+		<h2>Getting started</h2>
+		<p>
+			You will need some basic experience with terminal and will need to install Node.js to 
+			access the Node Package Manager. These are common tools for the modern javascript developer 
+			and are well worth learning.
+		</p>
+		<p>
+			Follow the instructions at [link:https://github.com/edwinwebb/three-seed/] to get started. 
+		</p>
+		<p>
+
+		</p>
+	</body>
+</html>

--- a/docs/manual/introduction/Useful-links.html
+++ b/docs/manual/introduction/Useful-links.html
@@ -92,6 +92,9 @@
 		<h2>Examples</h2>
 		<ul>
 			<li>
+				[link:https://github.com/edwinwebb/three-seed three-seed] - three.js starter project with ES6 and Webpack
+			</li>
+			<li>
 				[link:http://stemkoski.github.io/Three.js/index.html Professor Stemkoskis Examples] - a collection of beginner friendly
 				examples built using three.js r60.
 			</li>


### PR DESCRIPTION
I've been working on a three starter project / boilerplate project using Webpack and Three.js for the past few years. I've been using it for my own projects but think it will be useful for anyone wanting to get started with three.js.

https://github.com/edwinwebb/three-seed/

In this PR I've added links to the project and a section in the Getting Started guide.

I hope the project will get some help new developers get started with three.js using modern tools. I have some free time to rework the getting started guides to use this project as a base.  