### PR TITLE
GLTFExporter: CubicSpline interpolation support

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -958,10 +958,10 @@ THREE.GLTFExporter.prototype = {
 
 				var interpolation;
 
-				// Detecting glTF cubic spline interpolant by checking factory method name because
+				// Detecting glTF cubic spline interpolant by checking factory method's special property
 				// GLTFCubicSplineInterpolant is a custom interpolant and doesn't return
-				// valid value from .getInterpolation().
-				if ( track.createInterpolant.name === 'InterpolantFactoryMethodGLTFCubicSpline' ) {
+				// valid value from track.getInterpolation().
+				if ( track.createInterpolant.isInterpolantFactoryMethodGLTFCubicSpline === true ) {
 
 					interpolation = 'CUBICSPLINE';
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -958,9 +958,11 @@ THREE.GLTFExporter.prototype = {
 
 				var interpolation;
 
+				// @TODO export CubicInterpolant(InterpolateSmooth) as CUBICSPLINE
+
 				// Detecting glTF cubic spline interpolant by checking factory method's special property
-				// GLTFCubicSplineInterpolant is a custom interpolant and doesn't return
-				// valid value from track.getInterpolation().
+				// GLTFCubicSplineInterpolant is a custom interpolant and track doesn't return
+				// valid value from .getInterpolation().
 				if ( track.createInterpolant.isInterpolantFactoryMethodGLTFCubicSpline === true ) {
 
 					interpolation = 'CUBICSPLINE';

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2453,7 +2453,7 @@ THREE.GLTFLoader = ( function () {
 							// Overrides .createInterpolant in a factory method which creates custom interpolation.
 							if ( sampler.interpolation === 'CUBICSPLINE' ) {
 
-								track.createInterpolant = function ( result ) {
+								track.createInterpolant = function InterpolantFactoryMethodGLTFCubicSpline( result ) {
 
 									// A CUBICSPLINE keyframe in glTF has three output values for each input value,
 									// representing inTangent, splineVertex, and outTangent. As a result, track.getValueSize()

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2463,6 +2463,10 @@ THREE.GLTFLoader = ( function () {
 
 								};
 
+								// Workaround, provide an alternate way to know if the interpolant type is cubis spline to track.
+								// track.getInterpolation() doesn't return valid value for custom interpolant.
+								track.createInterpolant.isInterpolantFactoryMethodGLTFCubicSpline = true;
+
 							}
 
 							tracks.push( track );


### PR DESCRIPTION
This PR adds CubicSpline interpolation support to `GLTFExporter`.

CubicSpline interpolation isn't in Three.js core yet, so exporting as `CUBICSPLINE` only when a custom interpolation `GLTFCubicSplineInterpolant` declared in `GLTFLoader` is used.

As `GLTFCubicSplineInterpolant` is a custom interpolation `track.getInterpolation()` doesn't return a valid value, it returns Three.js global interpolation type like `THREE.InterpolateLinear` but there's no global type for `GLTFCubicSplineInterpolant`.

Then I named `GLTFCubicSplineInterpolant` factory function and check that name to detect if interpolation is CubicSpline instead of calling `track.getInterpolation()`.