### PR TITLE
DirectGeometry: Remove indices property

### DIFF
--- a/docs/api/core/BufferAttribute.html
+++ b/docs/api/core/BufferAttribute.html
@@ -140,9 +140,6 @@
 		<h3>[method:BufferAttribute copyColorsArray]( colors ) </h3>
 		<div>Copy an array representing RGB color values into [page:BufferAttribute.array array].</div>
 
-		<h3>[method:BufferAttribute copyIndicesArray]( indices ) </h3>
-		<div>Copy an array representing [page:Face3] indices into [page:BufferAttribute.array array].</div>
-
 		<h3>[method:BufferAttribute copyVector2sArray]( vectors ) </h3>
 		<div>Copy an array representing [page:Vector2]s into [page:BufferAttribute.array array].</div>
 

--- a/docs/api/core/DirectGeometry.html
+++ b/docs/api/core/DirectGeometry.html
@@ -34,9 +34,6 @@
 		<h3>[property:Array type]</h3>
 		<div>String 'DirectGeometry'.</div>
 
-		<h3>[property:Array indices]</h3>
-		<div>Initialiased as an empty array, this is populated by [page:.fromGeometry]().</div>
-
 		<h3>[property:Array vertices]</h3>
 		<div>Initialiased as an empty array, this is populated by [page:.fromGeometry]().</div>
 

--- a/docs/api/deprecated/DeprecatedList.html
+++ b/docs/api/deprecated/DeprecatedList.html
@@ -51,6 +51,7 @@
 
 		<h3>[page:BufferAttribute]</h3>
 		<div>BufferAttribute.length has been renamed to [page:BufferAttribute.count].</div>
+		<div>BufferAttribute.copyIndicesArray() has been removed.</div>
 
 
 		<h3>[page:DynamicBufferAttribute]</h3>

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1074,6 +1074,11 @@ Object.defineProperties( BufferAttribute.prototype, {
 			return this.array.length;
 
 		}
+	},
+	copyIndicesArray: function ( /* indices */ ) {
+
+		console.error( 'THREE.BufferAttribute: .copyIndicesArray() has been removed.' );
+
 	}
 
 } );

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -129,24 +129,6 @@ Object.assign( BufferAttribute.prototype, {
 
 	},
 
-	copyIndicesArray: function ( indices ) {
-
-		var array = this.array, offset = 0;
-
-		for ( var i = 0, l = indices.length; i < l; i ++ ) {
-
-			var index = indices[ i ];
-
-			array[ offset ++ ] = index.a;
-			array[ offset ++ ] = index.b;
-			array[ offset ++ ] = index.c;
-
-		}
-
-		return this;
-
-	},
-
 	copyVector2sArray: function ( vectors ) {
 
 		var array = this.array, offset = 0;

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -521,14 +521,6 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
-		if ( geometry.indices.length > 0 ) {
-
-			var TypeArray = arrayMax( geometry.indices ) > 65535 ? Uint32Array : Uint16Array;
-			var indices = new TypeArray( geometry.indices.length * 3 );
-			this.setIndex( new BufferAttribute( indices, 1 ).copyIndicesArray( geometry.indices ) );
-
-		}
-
 		// groups
 
 		this.groups = geometry.groups;

--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -6,7 +6,6 @@ import { Vector2 } from '../math/Vector2.js';
 
 function DirectGeometry() {
 
-	this.indices = [];
 	this.vertices = [];
 	this.normals = [];
 	this.colors = [];


### PR DESCRIPTION
see #13369 

Because `DirectGeometry.fromGeometry()` always creates an unindexed geometry, the `indices` property is obsolete. This PR removes the property and `BufferAttribute.copyIndicesArray()` which was actually never called in `BufferGeometry.fromDirectGeometry()`.