### PR TITLE
Clean up GLTFLoader doc, removing extra indents from sample code

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -45,43 +45,43 @@
 		<h2>Example</h2>
 
 		<code>
-			// Instantiate a loader
-			var loader = new THREE.GLTFLoader();
+		// Instantiate a loader
+		var loader = new THREE.GLTFLoader();
 
-			// Optional: Provide a DRACOLoader instance to decode compressed mesh data
-			THREE.DRACOLoader.setDecoderPath( '/examples/js/libs/draco' );
-			loader.setDRACOLoader( new THREE.DRACOLoader() );
+		// Optional: Provide a DRACOLoader instance to decode compressed mesh data
+		THREE.DRACOLoader.setDecoderPath( '/examples/js/libs/draco' );
+		loader.setDRACOLoader( new THREE.DRACOLoader() );
 
-			// Load a glTF resource
-			loader.load(
-				// resource URL
-				'models/gltf/duck/duck.gltf',
-				// called when the resource is loaded
-				function ( gltf ) {
+		// Load a glTF resource
+		loader.load(
+			// resource URL
+			'models/gltf/duck/duck.gltf',
+			// called when the resource is loaded
+			function ( gltf ) {
 
-					scene.add( gltf.scene );
+				scene.add( gltf.scene );
 
-					gltf.animations; // Array&lt;THREE.AnimationClip&gt;
-					gltf.scene; // THREE.Scene
-					gltf.scenes; // Array&lt;THREE.Scene&gt;
-					gltf.cameras; // Array&lt;THREE.Camera&gt;
-					gltf.asset; // Object
+				gltf.animations; // Array&lt;THREE.AnimationClip&gt;
+				gltf.scene; // THREE.Scene
+				gltf.scenes; // Array&lt;THREE.Scene&gt;
+				gltf.cameras; // Array&lt;THREE.Camera&gt;
+				gltf.asset; // Object
 
-				},
-				// called when loading is in progresses
-				function ( xhr ) {
+			},
+			// called when loading is in progresses
+			function ( xhr ) {
 
-					console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );
+				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );
 
-				},
-				// called when loading has errors
-				function ( error ) {
+			},
+			// called when loading has errors
+			function ( error ) {
 
-					console.log( 'An error happened' );
+				console.log( 'An error happened' );
 
-				}
-			);
-			</code>
+			}
+		);
+		</code>
 
 		[example:webgl_loader_gltf]
 


### PR DESCRIPTION
I think we should remove extra indentations from sample code in `GLTFLoader` doc for the consistency.

I checked some other doc pages, and it seems we don't need an extra indentation from \<code> indentation level.

