### PR TITLE
Added multiple offset update functionality to the BufferAttributes

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -25,7 +25,7 @@ function BufferAttribute( array, itemSize, normalized ) {
 	this.normalized = normalized === true;
 
 	this.dynamic = false;
-	this.updateRange = { offset: 0, count: - 1 };
+	this.updateRange = [];
 
 	this.onUploadCallback = function () {};
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -75,20 +75,20 @@ function WebGLAttributes( gl ) {
 			gl.bufferData( bufferType, array, gl.STATIC_DRAW );
 
 		} else if ( typeof updateRange.offset == "undefined" &&
-																	typeof updateRange.count == "undefined" ){
+																	typeof updateRange.count == "undefined" ) {
 
 			// updateRange is an array of {offset: x, count: y}
 
-			for ( var i = 0; i < updateRange.length; i++ ) {
+			for ( var i = 0; i < updateRange.length; i ++ ) {
 
 				var curCount = updateRange[ i ].count;
 				var curOffset = updateRange[ i ].offset;
 
-				if ( curCount != 0 && curCount != -1 ) {
+				if ( curCount != 0 && curCount != - 1 ) {
 
 					if ( curOffset >= array.length || curCount > array.length ) {
 
-						console.error ( 'THREE.WebGLObjects.updateBuffer: Buffer overflow.' );
+						console.error( 'THREE.WebGLObjects.updateBuffer: Buffer overflow.' );
 
 					} else {
 
@@ -101,7 +101,7 @@ function WebGLAttributes( gl ) {
 
 				} else if ( updateRange == 0 ) {
 
-					console.error( 'THREE.WebGLObjects.updateBuffer: dynamic THREE.BufferAttribute marked as needsUpdate but updateRange.count is 0 for index '+ i +', ensure you are using set methods or updating manually.' );
+					console.error( 'THREE.WebGLObjects.updateBuffer: dynamic THREE.BufferAttribute marked as needsUpdate but updateRange.count is 0 for index ' + i + ', ensure you are using set methods or updating manually.' );
 
 				}
 
@@ -120,7 +120,7 @@ function WebGLAttributes( gl ) {
 
 			// updateRange is {offset: x, count: y}
 
-			if ( updateRange.count === -1 )  {
+			if ( updateRange.count === - 1 ) {
 
 				// Not using update ranges
 
@@ -133,9 +133,9 @@ function WebGLAttributes( gl ) {
 			} else {
 
 				gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
-							array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
+				     array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
 
-				updateRange.count = -1; // reset range
+				updateRange.count = - 1; // reset range
 
 			}
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -64,7 +64,6 @@ function WebGLAttributes( gl ) {
 	}
 
 	function updateBuffer( buffer, attribute, bufferType ) {
-
 		var array = attribute.array;
 		var updateRange = attribute.updateRange;
 
@@ -74,25 +73,74 @@ function WebGLAttributes( gl ) {
 
 			gl.bufferData( bufferType, array, gl.STATIC_DRAW );
 
-		} else if ( updateRange.count === - 1 ) {
-
-			// Not using update ranges
-
-			gl.bufferSubData( bufferType, 0, array );
-
-		} else if ( updateRange.count === 0 ) {
-
-			console.error( 'THREE.WebGLObjects.updateBuffer: dynamic THREE.BufferAttribute marked as needsUpdate but updateRange.count is 0, ensure you are using set methods or updating manually.' );
-
 		} else {
 
-			gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
-				array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
+			var subTypedArrays = [];
+			var totalLength = 0;
 
-			updateRange.count = - 1; // reset range
+			for (var i = 0; i<updateRange.length; i++){
+
+				var curUpdateRange = updateRange[i];
+				var curOffset = curUpdateRange.offset;
+				var curCount = curUpdateRange.count;
+
+				if (curCount != -1 && curCount != 0){
+
+					// Store each subarray in subTypedArrays, we'll concat these arrays later
+					subTypedArrays.push(
+						array.subarray(curOffset, curOffset + curCount)
+					);
+					totalLength += curCount;
+
+					if (totalLength > array.length){
+
+						console.error( 'THREE.WebGLObjects.updateBuffer: Tried to update more indices than the size of the buffer.' );
+						subTypedArrays = null;
+						return;
+
+					}
+
+				} else if (curCount == 0){
+
+					console.error( 'THREE.WebGLObjects.updateBuffer: dynamic THREE.BufferAttribute marked as needsUpdate but updateRange.count is 0 for index '+i+', ensure you are using set methods or updating manually.' );
+
+				}
+
+			}
+
+			if (subTypedArrays.length == 0){
+
+				gl.bufferSubData(bufferType, 0, array);
+
+			}else{
+
+				// This typed array will contain the sub typed arrays
+				// After we put this to the WebGL buffer, we'll set this to null to prevent possible memory issues
+				var abstractTypedArray = new array.constructor(totalLength);
+
+				// Merge
+				var indexOffset = 0;
+				for (var x = 0; x<subTypedArrays.length; x++){
+
+						abstractTypedArray.set(subTypedArrays[x], indexOffset);
+
+						indexOffset += subTypedArrays[x].length;
+
+				}
+
+				// Call WebGL
+				gl.bufferSubData(bufferType, 0, abstractTypedArray);
+
+				// Reset the updateRange property
+				attribute.updateRange = [];
+
+				// Set the references to null so that the GC collects them
+				subTypedArrays = null;
+				abstractTypedArray = null;
+
+			}
 
 		}
-
 	}
 
 	//

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -74,7 +74,10 @@ function WebGLAttributes( gl ) {
 
 			gl.bufferData( bufferType, array, gl.STATIC_DRAW );
 
-		} else {
+		} else if (typeof updateRange.offset == "undefined" &&
+																	typeof updateRange.count == "undefined"){
+
+			// updateRange is an array of {offset: x, count: y}
 
 			var updatedRange = false;
 
@@ -114,9 +117,33 @@ function WebGLAttributes( gl ) {
 
 			}
 
-		}
+			// Reset update ranges
+			attribute.updateRange = [];
 
-		attribute.updateRange = [];
+		} else {
+
+			// updateRange is {offset: x, count: y}
+
+			if (updateRange.count === -1){
+
+				// Not using update ranges
+
+				gl.bufferSubData(bufferType, 0, array);
+
+			} else if (updateRange.count === 0){
+
+				console.error( 'THREE.WebGLObjects.updateBuffer: dynamic THREE.BufferAttribute marked as needsUpdate but updateRange.count is 0, ensure you are using set methods or updating manually.' );
+
+			} else {
+
+				gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
+							array.subarray(updateRange.offset, updateRange.offset + updateRange.count));
+
+				updateRange.count = -1; // reset range
+
+			}
+
+		}
 
 	}
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -74,36 +74,32 @@ function WebGLAttributes( gl ) {
 
 			gl.bufferData( bufferType, array, gl.STATIC_DRAW );
 
-		} else if (typeof updateRange.offset == "undefined" &&
-																	typeof updateRange.count == "undefined"){
+		} else if ( typeof updateRange.offset == "undefined" &&
+																	typeof updateRange.count == "undefined" ){
 
 			// updateRange is an array of {offset: x, count: y}
 
-			var updatedRange = false;
+			for ( var i = 0; i < updateRange.length; i++ ) {
 
-			for (var i = 0; i < updateRange.length; i++){
+				var curCount = updateRange[ i ].count;
+				var curOffset = updateRange[ i ].offset;
 
-				var curCount = updateRange[i].count;
-				var curOffset = updateRange[i].offset;
+				if ( curCount != 0 && curCount != -1 ) {
 
-				if (curCount != 0 && curCount != -1){
-
-					updatedRange = true;
-
-					if (curOffset >= array.length || curCount > array.length){
+					if ( curOffset >= array.length || curCount > array.length ) {
 
 						console.error ( 'THREE.WebGLObjects.updateBuffer: Buffer overflow.' );
 
-					}else{
+					} else {
 
 						gl.bufferSubData(
 							bufferType, curOffset * array.BYTES_PER_ELEMENT,
-							array.subarray(curOffset, curOffset + curCount)
+							array.subarray( curOffset, curOffset + curCount )
 						);
 
 					}
 
-				} else if (updateRange == 0){
+				} else if ( updateRange == 0 ) {
 
 					console.error( 'THREE.WebGLObjects.updateBuffer: dynamic THREE.BufferAttribute marked as needsUpdate but updateRange.count is 0 for index '+ i +', ensure you are using set methods or updating manually.' );
 
@@ -111,33 +107,33 @@ function WebGLAttributes( gl ) {
 
 			}
 
-			if (!updateRange){
+			if ( ! updateRange ) {
 
-				gl.bufferSubData(bufferType, 0, array);
+				gl.bufferSubData( bufferType, 0, array );
 
 			}
 
 			// Reset update ranges
-			attribute.updateRange = [];
+			attribute.updateRange = [ ];
 
 		} else {
 
 			// updateRange is {offset: x, count: y}
 
-			if (updateRange.count === -1){
+			if ( updateRange.count === -1 )  {
 
 				// Not using update ranges
 
-				gl.bufferSubData(bufferType, 0, array);
+				gl.bufferSubData( bufferType, 0, array );
 
-			} else if (updateRange.count === 0){
+			} else if ( updateRange.count === 0 ) {
 
 				console.error( 'THREE.WebGLObjects.updateBuffer: dynamic THREE.BufferAttribute marked as needsUpdate but updateRange.count is 0, ensure you are using set methods or updating manually.' );
 
 			} else {
 
 				gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
-							array.subarray(updateRange.offset, updateRange.offset + updateRange.count));
+							array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
 
 				updateRange.count = -1; // reset range
 


### PR DESCRIPTION
I added multiple offset update functionality to the BufferAttributes mentioned in the issue #9981 

In this modification, updateRange property of BufferAttributes is now an array. Each member of this array should have {offset: x, count:y} as the format. The user may push different offsets and counts to this array using this format. If the user tries to update more indices than the size of the related buffer, an error is printed in the console so that the user is warned. 

For instance, given a particle system with X particles:

geometry.attributes.[attribute].updateRange.push({offset:a, count:1});
geometry.attributes.[attribute].updateRange.push({offset:b, count:1});

updates only the 2 of the attributes.

The method works fine in most of the cases, however for geometries containing thousands of vertices/indices this may work slow only if the user does something like this:

for (var i = 0; i<A_BIG_INTEGER; i++)
     geometry.attributes.[attribute].updateRange.push({offset:i, count1})

instead of updating them all at once.
