### PR TITLE
WebGLRenderer: Introduce WebGLInfo

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -180,9 +180,9 @@
 			<li>render:
 				<ul>
 					<li>calls</li>
-					<li>vertices</li>
 					<li>faces</li>
 					<li>points</li>
+					<li>segments</li>
 				</ul>
 			</li>
 			<li>programs

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -29,6 +29,7 @@ import { Frustum } from '../math/Frustum.js';
 import { Vector4 } from '../math/Vector4.js';
 import { WebGLUtils } from './webgl/WebGLUtils.js';
 import { WebGLRenderStates } from './webgl/WebGLRenderStates.js';
+import { WebGLInfo } from './webgl/WebGLInfo.js';
 
 /**
  * @author supereggbert / http://www.paulbrunt.co.uk/
@@ -149,44 +150,7 @@ function WebGLRenderer( parameters ) {
 
 		_projScreenMatrix = new Matrix4(),
 
-		_vector3 = new Vector3(),
-
-		// info
-
-		_infoMemory = {
-			geometries: 0,
-			textures: 0
-		},
-
-		_infoRender = {
-
-			frame: 0,
-			calls: 0,
-			vertices: 0,
-			faces: 0,
-			points: 0
-
-		};
-
-	this.info = {
-
-		render: _infoRender,
-		memory: _infoMemory,
-		programs: null,
-		autoReset: true,
-		reset: resetInfo
-
-	};
-
-	function resetInfo() {
-
-		_infoRender.frame ++;
-		_infoRender.calls = 0;
-		_infoRender.vertices = 0;
-		_infoRender.faces = 0;
-		_infoRender.points = 0;
-
-	}
+		_vector3 = new Vector3();
 
 	function getTargetPixelRatio() {
 
@@ -249,7 +213,7 @@ function WebGLRenderer( parameters ) {
 
 	}
 
-	var extensions, capabilities, state;
+	var extensions, capabilities, state, info;
 	var properties, textures, attributes, geometries, objects;
 	var programCache, renderLists, renderStates;
 
@@ -278,11 +242,12 @@ function WebGLRenderer( parameters ) {
 		state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ) );
 		state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ) );
 
+		info = new WebGLInfo( _gl );
 		properties = new WebGLProperties();
-		textures = new WebGLTextures( _gl, extensions, state, properties, capabilities, utils, _infoMemory, _infoRender );
+		textures = new WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info );
 		attributes = new WebGLAttributes( _gl );
-		geometries = new WebGLGeometries( _gl, attributes, _infoMemory );
-		objects = new WebGLObjects( geometries, _infoRender );
+		geometries = new WebGLGeometries( _gl, attributes, info );
+		objects = new WebGLObjects( geometries, info );
 		morphtargets = new WebGLMorphtargets( _gl );
 		programCache = new WebGLPrograms( _this, extensions, capabilities );
 		renderLists = new WebGLRenderLists();
@@ -290,12 +255,12 @@ function WebGLRenderer( parameters ) {
 
 		background = new WebGLBackground( _this, state, geometries, _premultipliedAlpha );
 
-		bufferRenderer = new WebGLBufferRenderer( _gl, extensions, _infoRender );
-		indexedBufferRenderer = new WebGLIndexedBufferRenderer( _gl, extensions, _infoRender );
+		bufferRenderer = new WebGLBufferRenderer( _gl, extensions, info );
+		indexedBufferRenderer = new WebGLIndexedBufferRenderer( _gl, extensions, info );
 
 		spriteRenderer = new WebGLSpriteRenderer( _this, _gl, state, textures, capabilities );
 
-		_this.info.programs = programCache.programs;
+		info.programs = programCache.programs;
 
 		_this.context = _gl;
 		_this.capabilities = capabilities;
@@ -303,6 +268,7 @@ function WebGLRenderer( parameters ) {
 		_this.properties = properties;
 		_this.renderLists = renderLists;
 		_this.state = state;
+		_this.info = info;
 
 	}
 

--- a/src/renderers/webgl/WebGLBufferRenderer.js
+++ b/src/renderers/webgl/WebGLBufferRenderer.js
@@ -2,7 +2,7 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-function WebGLBufferRenderer( gl, extensions, infoRender ) {
+function WebGLBufferRenderer( gl, extensions, info ) {
 
 	var mode;
 
@@ -16,11 +16,7 @@ function WebGLBufferRenderer( gl, extensions, infoRender ) {
 
 		gl.drawArrays( mode, start, count );
 
-		infoRender.calls ++;
-		infoRender.vertices += count;
-
-		if ( mode === gl.TRIANGLES ) infoRender.faces += count / 3;
-		else if ( mode === gl.POINTS ) infoRender.points += count;
+		info.update( count, mode );
 
 	}
 
@@ -49,11 +45,7 @@ function WebGLBufferRenderer( gl, extensions, infoRender ) {
 
 		}
 
-		infoRender.calls ++;
-		infoRender.vertices += count * geometry.maxInstancedCount;
-
-		if ( mode === gl.TRIANGLES ) infoRender.faces += geometry.maxInstancedCount * count / 3;
-		else if ( mode === gl.POINTS ) infoRender.points += geometry.maxInstancedCount * count;
+		info.update( count, mode, geometry.maxInstancedCount );
 
 	}
 

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -6,7 +6,7 @@ import { Uint16BufferAttribute, Uint32BufferAttribute } from '../../core/BufferA
 import { BufferGeometry } from '../../core/BufferGeometry.js';
 import { arrayMax } from '../../utils.js';
 
-function WebGLGeometries( gl, attributes, infoMemory ) {
+function WebGLGeometries( gl, attributes, info ) {
 
 	var geometries = {};
 	var wireframeAttributes = {};
@@ -54,7 +54,7 @@ function WebGLGeometries( gl, attributes, infoMemory ) {
 
 		//
 
-		infoMemory.geometries --;
+		info.memory.geometries --;
 
 	}
 
@@ -84,7 +84,7 @@ function WebGLGeometries( gl, attributes, infoMemory ) {
 
 		geometries[ geometry.id ] = buffergeometry;
 
-		infoMemory.geometries ++;
+		info.memory.geometries ++;
 
 		return buffergeometry;
 

--- a/src/renderers/webgl/WebGLIndexedBufferRenderer.js
+++ b/src/renderers/webgl/WebGLIndexedBufferRenderer.js
@@ -2,7 +2,7 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-function WebGLIndexedBufferRenderer( gl, extensions, infoRender ) {
+function WebGLIndexedBufferRenderer( gl, extensions, info ) {
 
 	var mode;
 
@@ -25,11 +25,7 @@ function WebGLIndexedBufferRenderer( gl, extensions, infoRender ) {
 
 		gl.drawElements( mode, count, type, start * bytesPerElement );
 
-		infoRender.calls ++;
-		infoRender.vertices += count;
-
-		if ( mode === gl.TRIANGLES ) infoRender.faces += count / 3;
-		else if ( mode === gl.POINTS ) infoRender.points += count;
+		info.update( count, mode );
 
 	}
 
@@ -46,11 +42,7 @@ function WebGLIndexedBufferRenderer( gl, extensions, infoRender ) {
 
 		extension.drawElementsInstancedANGLE( mode, count, type, start * bytesPerElement, geometry.maxInstancedCount );
 
-		infoRender.calls ++;
-		infoRender.vertices += count * geometry.maxInstancedCount;
-
-		if ( mode === gl.TRIANGLES ) infoRender.faces += geometry.maxInstancedCount * count / 3;
-		else if ( mode === gl.POINTS ) infoRender.points += geometry.maxInstancedCount * count;
+		info.update( count, mode, geometry.maxInstancedCount );
 
 	}
 

--- a/src/renderers/webgl/WebGLInfo.js
+++ b/src/renderers/webgl/WebGLInfo.js
@@ -1,0 +1,78 @@
+/**
+ * @author Mugen87 / https://github.com/Mugen87
+ */
+
+function WebGLInfo( gl ) {
+
+	var memory = {
+		geometries: 0,
+		textures: 0
+	};
+
+	var render = {
+		frame: 0,
+		calls: 0,
+		faces: 0,
+		points: 0,
+		segments: 0
+	};
+
+	function update( count, mode, instanceCount ) {
+
+		instanceCount = instanceCount || 1;
+
+		render.calls ++;
+
+		switch ( mode ) {
+
+			case gl.TRIANGLES:
+				render.faces += instanceCount * ( count / 3 );
+				break;
+
+			case gl.LINES:
+				render.segments += instanceCount * ( count / 2 );
+				break;
+
+			case gl.LINE_STRIP:
+				render.segments += instanceCount * ( count - 1 );
+				break;
+
+			case gl.LINE_LOOP:
+				render.segments += instanceCount * count;
+				break;
+
+			case gl.POINTS:
+				render.points += instanceCount * count;
+				break;
+
+			default:
+				console.error( 'THREE.WebGLInfo: Unknown draw mode:', mode );
+				break;
+
+		}
+
+	}
+
+	function reset() {
+
+		render.frame ++;
+		render.calls = 0;
+		render.faces = 0;
+		render.points = 0;
+		render.segments = 0;
+
+	}
+
+	return {
+		memory: memory,
+		render: render,
+		programs: null,
+		autoReset: true,
+		reset: reset,
+		update: update
+	};
+
+}
+
+
+export { WebGLInfo };

--- a/src/renderers/webgl/WebGLInfo.js
+++ b/src/renderers/webgl/WebGLInfo.js
@@ -29,6 +29,11 @@ function WebGLInfo( gl ) {
 				render.faces += instanceCount * ( count / 3 );
 				break;
 
+			case gl.TRIANGLE_STRIP:
+			case gl.TRIANGLE_FAN:
+				render.faces += instanceCount * ( count - 2 );
+				break;
+
 			case gl.LINES:
 				render.segments += instanceCount * ( count / 2 );
 				break;

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -2,13 +2,13 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-function WebGLObjects( geometries, infoRender ) {
+function WebGLObjects( geometries, info ) {
 
 	var updateList = {};
 
 	function update( object ) {
 
-		var frame = infoRender.frame;
+		var frame = info.render.frame;
 
 		var geometry = object.geometry;
 		var buffergeometry = geometries.get( object, geometry );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -5,7 +5,7 @@
 import { LinearFilter, NearestFilter, RGBFormat, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, ClampToEdgeWrapping, NearestMipMapLinearFilter, NearestMipMapNearestFilter } from '../../constants.js';
 import { _Math } from '../../math/Math.js';
 
-function WebGLTextures( _gl, extensions, state, properties, capabilities, utils, infoMemory, infoRender ) {
+function WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info ) {
 
 	var _isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && _gl instanceof WebGL2RenderingContext );
 	var _videoTextures = {};
@@ -111,7 +111,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		infoMemory.textures --;
+		info.memory.textures --;
 
 	}
 
@@ -123,7 +123,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		deallocateRenderTarget( renderTarget );
 
-		infoMemory.textures --;
+		info.memory.textures --;
 
 	}
 
@@ -244,7 +244,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					textureProperties.__image__webglTextureCube = _gl.createTexture();
 
-					infoMemory.textures ++;
+					info.memory.textures ++;
 
 				}
 
@@ -415,7 +415,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			textureProperties.__webglTexture = _gl.createTexture();
 
-			infoMemory.textures ++;
+			info.memory.textures ++;
 
 		}
 
@@ -718,7 +718,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		textureProperties.__webglTexture = _gl.createTexture();
 
-		infoMemory.textures ++;
+		info.memory.textures ++;
 
 		var isCube = ( renderTarget.isWebGLRenderTargetCube === true );
 		var isTargetPowerOfTwo = isPowerOfTwo( renderTarget );
@@ -799,7 +799,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 	function updateVideoTexture( texture ) {
 
 		var id = texture.id;
-		var frame = infoRender.frame;
+		var frame = info.render.frame;
 
 		// Check the last frame we updated the VideoTexture
 


### PR DESCRIPTION
This PR does two things:

- It removes `vertices` from `info.render` since it does not work correctly with indexed geometries, see #13316. Instead `info.render` now contains the rendered primitives (`faces`, `points` and `segments`).
- It refactors all info related code in `WebGLRenderer` by creating `WebGLInfo`.