### PR TITLE
Clean up GLTFLoader Doc

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -15,7 +15,7 @@
 		<a href="https://www.khronos.org/gltf">glTF</a> (GL Transmission Format) is an
 		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0">open format specification</a>
 		for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf)
-		or binary (.glb) format. External files store textures (.jpg, .png, ...) and additional binary
+		or binary (.glb) format. External files store textures (.jpg, .png) and additional binary
 		data (.bin). A glTF asset may deliver one or more scenes, including meshes, materials,
 		textures, skins, skeletons, morph targets, animations, lights, and/or cameras.
 		</div>


### PR DESCRIPTION
The image formats glTF supports are jpg and png.

https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#imageuri

> The image format must be jpg or png.

I think we can remove '...' from the sentence "External files store textures (.jpg, .png, ...)" in `GLTFLoader` doc.