### PR TITLE
GLTFExporter: Support metallicRoughnessTexture

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -613,6 +613,25 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
+			// pbrMetallicRoughness.metallicRoughnessTexture
+			if ( material.metalnessMap || material.roughnessMap ) {
+
+				if ( material.metalnessMap === material.roughnessMap ) {
+
+					gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture = {
+
+						index: processTexture( material.metalnessMap )
+
+					};
+
+				} else {
+
+					console.warn( 'THREE.GLTFExporter: Ignoring metalnessMap and roughnessMap because they are not the same Texture.' );
+
+				}
+
+			}
+
 			// pbrMetallicRoughness.baseColorTexture
 			if ( material.map ) {
 


### PR DESCRIPTION
This PR adds `metallicRoughnessTexture` support to `GLTFExporter`.

In Three.js metalnessMap and roughnessMap can be different textures but can't be in glTF 2.0. So exporting only if they are the same texture.