### PR TITLE
ShadowMaterial: Added .copy()

### DIFF
--- a/src/materials/ShadowMaterial.js
+++ b/src/materials/ShadowMaterial.js
@@ -2,8 +2,7 @@
  * @author mrdoob / http://mrdoob.com/
  *
  * parameters = {
- *  color: <THREE.Color>,
- *  opacity: <float>
+ *  color: <THREE.Color>
  * }
  */
 
@@ -17,9 +16,6 @@ function ShadowMaterial( parameters ) {
 	this.type = 'ShadowMaterial';
 
 	this.color = new Color( 0x000000 );
-	this.opacity = 1.0;
-
-	this.lights = true;
 	this.transparent = true;
 
 	this.setValues( parameters );
@@ -30,6 +26,16 @@ ShadowMaterial.prototype = Object.create( Material.prototype );
 ShadowMaterial.prototype.constructor = ShadowMaterial;
 
 ShadowMaterial.prototype.isShadowMaterial = true;
+
+ShadowMaterial.prototype.copy = function ( source ) {
+
+	Material.prototype.copy.call( this, source );
+
+	this.color.copy( source.color );
+
+	return this;
+
+};
 
 
 export { ShadowMaterial };


### PR DESCRIPTION
An attentive user in the forum noticed that `ShadowMaterial` does not implement a `.copy()` method although `.color` is defined in the constructor. The PR adds the method and removes two unnecessary assignments since `.opacity` and `.lights` already have the intended value.
 
https://discourse.threejs.org/t/question-about-fromdirectgeometry-function-of-buffergeometry/1890/3?u=mugen87