### PR TITLE
GLTFExporter: Texture cache

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -448,7 +448,7 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function processImage( map ) {
 
-			// @QUESTION Needs image cache for the case where two different textures share the same image?
+			// @TODO Cache
 
 			if ( ! outputJSON.images ) {
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -448,6 +448,8 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function processImage( map ) {
 
+			// @QUESTION Needs image cache for the case where two different textures share the same image?
+
 			if ( ! outputJSON.images ) {
 
 				outputJSON.images = [];

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -99,7 +99,8 @@ THREE.GLTFExporter.prototype = {
 		var cachedData = {
 
 			images: {},
-			materials: {}
+			materials: {},
+			textures: {}
 
 		};
 
@@ -533,6 +534,12 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function processTexture( map ) {
 
+			if ( cachedData.textures[ map.uuid ] !== undefined ) {
+
+				return cachedData.textures[ map.uuid ];
+
+			}
+
 			if ( ! outputJSON.textures ) {
 
 				outputJSON.textures = [];
@@ -548,7 +555,10 @@ THREE.GLTFExporter.prototype = {
 
 			outputJSON.textures.push( gltfTexture );
 
-			return outputJSON.textures.length - 1;
+			var index = outputJSON.textures.length - 1;
+			cachedData.textures[ map.uuid ] = index;
+
+			return index;
 
 		}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -98,7 +98,6 @@ THREE.GLTFExporter.prototype = {
 		var skins = [];
 		var cachedData = {
 
-			images: {},
 			materials: {},
 			textures: {}
 
@@ -449,12 +448,6 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function processImage( map ) {
 
-			if ( cachedData.images[ map.uuid ] !== undefined ) {
-
-				return cachedData.images[ map.uuid ];
-
-			}
-
 			if ( ! outputJSON.images ) {
 
 				outputJSON.images = [];
@@ -492,10 +485,7 @@ THREE.GLTFExporter.prototype = {
 
 			outputJSON.images.push( gltfImage );
 
-			var index = outputJSON.images.length - 1;
-			cachedData.images[ map.uuid ] = index;
-
-			return index;
+			return outputJSON.images.length - 1;
 
 		}
 


### PR DESCRIPTION
This PR adds texture cache support to `GLTFExporter` and fixes https://github.com/mrdoob/three.js/pull/13415#issuecomment-368120932