### PR TITLE
DirectGeometry: remove boundingBox & boundingSphere properties

### DIFF
--- a/docs/api/core/DirectGeometry.html
+++ b/docs/api/core/DirectGeometry.html
@@ -61,18 +61,6 @@
 		<h3>[property:Array skinIndices]</h3>
 		<div>Initialiased as an empty array, this is populated by [page:.fromGeometry]().</div>
 
-		<h3>[property:Box3 boundingBox]</h3>
-		<div>
-			Bounding box for the bufferGeometry, which can be calculated with
-			[page:.computeBoundingBox](). Default is *null*.
-		</div>
-
-		<h3>[property:Sphere boundingSphere]</h3>
-		<div>
-			Bounding sphere for the bufferGeometry, which can be calculated with
-			[page:.computeBoundingSphere](). Default is *null*.
-		</div>
-
 		<h3>[property:Boolean verticesNeedUpdate]</h3>
 		<div>Default is false.</div>
 
@@ -91,28 +79,10 @@
 
 		<h2>Methods</h2>
 
-		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
-
-		<h3>[property:null computeBoundingBox](  )</h3>
-		<div>
-		 See [page:Geometry.computeBoundingBox].
-		</div>
-
-		<h3>[property:null computeBoundingSphere](  )</h3>
-		<div>
-		 See [page:Geometry.computeBoundingSphere].
-		</div>
-
 		<h3>[property:null computeGroups]( [page:Geometry geometry] )</h3>
 		<div>
 			Compute the parts of the geometry that have different materialIndex.
 			See [page:BufferGeometry.groups].
-		</div>
-
-		<h3>[method:null dispose]()</h3>
-		<div>
-		Disposes the object from memory. <br />
-		You need to call this when you want the directGeometry removed while the application is running.
 		</div>
 
 		<h3>[property:null fromGeometry]( [page:Geometry geometry] )</h3>

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -562,7 +562,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
-		//
+		/*
 
 		if ( geometry.boundingSphere !== null ) {
 
@@ -575,6 +575,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 			this.boundingBox = geometry.boundingBox.clone();
 
 		}
+		*/
 
 		return this;
 

--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -21,8 +21,8 @@ function DirectGeometry() {
 
 	// this.lineDistances = [];
 
-	this.boundingBox = null;
-	this.boundingSphere = null;
+	// this.boundingBox = null;
+	// this.boundingSphere = null;
 
 	// update flags
 


### PR DESCRIPTION
https://github.com/mrdoob/three.js/blob/4966686e9bce8b762f08deb317fc8ab6894aa48e/src/core/DirectGeometry.js#L25-L26
 Are these two properties ever used?
https://github.com/mrdoob/three.js/blob/4966686e9bce8b762f08deb317fc8ab6894aa48e/docs/api/core/DirectGeometry.html#L68-L77
The doc says they can be calculated, but no such functions are found for `DirectGeometry`.
https://github.com/mrdoob/three.js/blob/4966686e9bce8b762f08deb317fc8ab6894aa48e/docs/api/core/DirectGeometry.html#L99-L107
Here too.
https://github.com/mrdoob/three.js/blob/4966686e9bce8b762f08deb317fc8ab6894aa48e/docs/api/core/DirectGeometry.html#L97
And this is not true.