### PR TITLE
GLTFExporter: Add forcePowerOfTwoTexture option

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -197,9 +197,9 @@ Menubar.File = function ( editor ) {
 
 			saveArrayBuffer( result, 'scene.glb' );
 
-			// forceIndices: true to allow compatibility with facebook
-			// https://github.com/mrdoob/three.js/issues/13397
-		}, { binary: true, forceIndices: true } );
+			// forceIndices: true, forcePowerOfTwoTexture: true
+			// to allow compatibility with facebook
+		}, { binary: true, forceIndices: true, forcePowerOfTwoTexture: true } );
 		
 	} );
 	options.add( option );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -473,20 +473,16 @@ THREE.GLTFExporter.prototype = {
 			var mimeType = map.format === THREE.RGBAFormat ? 'image/png' : 'image/jpeg';
 			var gltfImage = { mimeType: mimeType };
 
-			if ( options.embedImages || ( options.forcePowerOfTwoTexture && ! isPowerOfTwo( map.image ) ) ) {
+			if ( options.embedImages ) {
 
 				var canvas = cachedCanvas = cachedCanvas || document.createElement( 'canvas' );
 
 				canvas.width = map.image.width;
 				canvas.height = map.image.height;
 
-				if ( options.forcePowerOfTwoTexture ) {
+				if ( options.forcePowerOfTwoTexture && ! isPowerOfTwo( map.image ) ) {
 
-					if ( ! options.embedImages ) {
-
-						console.warn( 'GLTFExporter: image is not power of two. Resized and embedded.', image );
-
-					}
+					console.warn( 'GLTFExporter: Resized non-power-of-two image.', map.image );
 
 					canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
 					canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );


### PR DESCRIPTION
https://github.com/mrdoob/three.js/issues/13397#issuecomment-368256557

This PR adds `forcePowerOfTwoTexture` option to `GLTFExporter`.