### PR TITLE
GLTFExporter: Add forcePOT option on the example

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -197,9 +197,9 @@ Menubar.File = function ( editor ) {
 
 			saveArrayBuffer( result, 'scene.glb' );
 
-			// forceIndices: true, forcePowerOfTwoTexture: true
+			// forceIndices: true, forcePowerOfTwoTextures: true
 			// to allow compatibility with facebook
-		}, { binary: true, forceIndices: true, forcePowerOfTwoTexture: true } );
+		}, { binary: true, forceIndices: true, forcePowerOfTwoTextures: true } );
 		
 	} );
 	options.add( option );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -70,7 +70,7 @@ THREE.GLTFExporter.prototype = {
 			embedImages: true,
 			animations: [],
 			forceIndices: false,
-			forcePowerOfTwoTexture: false
+			forcePowerOfTwoTextures: false
 		};
 
 		options = Object.assign( {}, DEFAULT_OPTIONS, options );
@@ -480,7 +480,7 @@ THREE.GLTFExporter.prototype = {
 				canvas.width = map.image.width;
 				canvas.height = map.image.height;
 
-				if ( options.forcePowerOfTwoTexture && ! isPowerOfTwo( map.image ) ) {
+				if ( options.forcePowerOfTwoTextures && ! isPowerOfTwo( map.image ) ) {
 
 					console.warn( 'GLTFExporter: Resized non-power-of-two image.', map.image );
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -56,7 +56,7 @@
 					truncateDrawRange: document.getElementById('option_drawrange').checked,
 					binary: document.getElementById('option_binary').checked,
 					forceIndices: document.getElementById('option_forceindices').checked,
-					forcePowerOfTwoTexture: document.getElementById('option_forcepot').checked
+					forcePowerOfTwoTextures: document.getElementById('option_forcepot').checked
 				};
 				gltfExporter.parse( input, function( result ) {
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -35,6 +35,7 @@
 			<label><input id="option_drawrange" name="visible" type="checkbox" checked="checked"/>Truncate drawRange</label>
 			<label><input id="option_binary" name="visible" type="checkbox">Binary (<code>.glb</code>)</label>
 			<label><input id="option_forceindices" name="visible" type="checkbox">Force indices</label>
+			<label><input id="option_forcepot" name="visible" type="checkbox">Force POT textures</label>
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -54,7 +55,8 @@
 					onlyVisible: document.getElementById('option_visible').checked,
 					truncateDrawRange: document.getElementById('option_drawrange').checked,
 					binary: document.getElementById('option_binary').checked,
-					forceIndices: document.getElementById('option_forceindices').checked
+					forceIndices: document.getElementById('option_forceindices').checked,
+					forcePowerOfTwoTexture: document.getElementById('option_forcepot').checked
 				};
 				gltfExporter.parse( input, function( result ) {
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -440,7 +440,7 @@
 				// ---------------------------------------------------------------------
 				// Ortho camera
 				// ---------------------------------------------------------------------
-				var cameraOrtho = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, - 10, 10 );
+				var cameraOrtho = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, 0.1, 10 );
 				scene1.add( cameraOrtho );
 				cameraOrtho.name = 'OrthographicCamera';
 


### PR DESCRIPTION
Just adding the option that @takahirox implemented on https://github.com/mrdoob/three.js/pull/13424 to the example