### PR TITLE
DirectGeometry: clone bounding volumes in fromGeometry method

### DIFF
--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -252,6 +252,18 @@ Object.assign( DirectGeometry.prototype, {
 		this.uvsNeedUpdate = geometry.uvsNeedUpdate;
 		this.groupsNeedUpdate = geometry.groupsNeedUpdate;
 
+		if ( geometry.boundingSphere !== null ) {
+
+			this.boundingSphere = geometry.boundingSphere.clone();
+
+		}
+
+		if ( geometry.boundingBox !== null ) {
+
+			this.boundingBox = geometry.boundingBox.clone();
+
+		}
+
 		return this;
 
 	}


### PR DESCRIPTION
See #13420 for detail.
@Mugen87 The doc may need to be fixed, but I'm not sure whether to remove all the information about `EventDispatcher` in it or to make `DirectGeometry` extend `EventDispatcher` and add `dispose` method ( like `BufferGeometry` and `Geometry` ).

As I mentioned in PR 13420, The same code may need to be added in `BufferGeometry.updateFromObject` for Mesh and Points.