### PR TITLE
AnimationUtils: Add .subclip().

### DIFF
--- a/docs/api/en/animation/AnimationUtils.html
+++ b/docs/api/en/animation/AnimationUtils.html
@@ -48,6 +48,10 @@
 		Sorts the array previously returned by [page:AnimationUtils.getKeyframeOrder getKeyframeOrder].
 		</p>
 
+		<h3>[method:AnimationClip subclip]( [param:AnimationClip clip], [param:String name], [param:Number startFrame], [param:Number endFrame], [param:Number fps] )</h3>
+		<div>
+		Creates a new clip, containing only the segment of the original clip between the given frames.
+		</div>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/animation/AnimationUtils.html
+++ b/docs/api/en/animation/AnimationUtils.html
@@ -49,9 +49,9 @@
 		</p>
 
 		<h3>[method:AnimationClip subclip]( [param:AnimationClip clip], [param:String name], [param:Number startFrame], [param:Number endFrame], [param:Number fps] )</h3>
-		<div>
+		<p>
 		Creates a new clip, containing only the segment of the original clip between the given frames.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -409,41 +409,13 @@ Object.assign( AnimationClip.prototype, {
 
 	},
 
-	trim: function ( startTime, endTime ) {
+	trim: function () {
 
-		if ( startTime === undefined ) startTime = 0;
-		if ( endTime === undefined ) endTime = this.duration;
+		for ( var i = 0; i < this.tracks.length; i ++ ) {
 
-		var tracks = [];
-
-		for ( var i = 0; i < this.tracks.length; ++ i ) {
-
-			var track = this.tracks[ i ];
-
-			var hasKeyframe = false;
-
-			// omit tracks without frames between new start/end times
-			for ( var j = 0; j < track.times.length; ++ j ) {
-
-				if ( startTime <= track.times[ j ] && endTime > track.times [ j ] ) {
-
-					hasKeyframe = true;
-
-					break;
-
-				}
-
-			}
-
-			if ( ! hasKeyframe ) continue;
-
-			this.tracks[ i ].trim( startTime, endTime );
-
-			tracks.push( this.tracks[ i ] );
+			this.tracks[ i ].trim( 0, this.duration );
 
 		}
-
-		this.tracks = tracks;
 
 		return this;
 

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -409,13 +409,41 @@ Object.assign( AnimationClip.prototype, {
 
 	},
 
-	trim: function () {
+	trim: function ( startTime, endTime ) {
 
-		for ( var i = 0; i < this.tracks.length; i ++ ) {
+		if ( startTime === undefined ) startTime = 0;
+		if ( endTime === undefined ) endTime = this.duration;
 
-			this.tracks[ i ].trim( 0, this.duration );
+		var tracks = [];
+
+		for ( var i = 0; i < this.tracks.length; ++ i ) {
+
+			var track = this.tracks[ i ];
+
+			var hasKeyframe = false;
+
+			// omit tracks without frames between new start/end times
+			for ( var j = 0; j < track.times.length; ++ j ) {
+
+				if ( startTime <= track.times[ j ] && endTime > track.times [ j ] ) {
+
+					hasKeyframe = true;
+
+					break;
+
+				}
+
+			}
+
+			if ( ! hasKeyframe ) continue;
+
+			this.tracks[ i ].trim( startTime, endTime );
+
+			tracks.push( this.tracks[ i ] );
 
 		}
+
+		this.tracks = tracks;
 
 		return this;
 
@@ -446,7 +474,6 @@ Object.assign( AnimationClip.prototype, {
 		return this;
 
 	},
-
 
 	clone: function () {
 

--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -223,7 +223,7 @@ var AnimationUtils = {
 
 		for ( var i = 0; i < clip.tracks.length; ++ i ) {
 
-			clip.tracks[ i ].shift( -1 * minStartTime );
+			clip.tracks[ i ].shift( - 1 * minStartTime );
 
 		}
 

--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -158,6 +158,79 @@ var AnimationUtils = {
 
 		}
 
+	},
+
+	subclip: function ( sourceClip, name, startFrame, endFrame, fps ) {
+
+		fps = fps || 30;
+
+		var clip = sourceClip.clone();
+
+		clip.name = name;
+
+		var tracks = [];
+
+		for ( var i = 0; i < clip.tracks.length; ++ i ) {
+
+			var track = clip.tracks[ i ];
+			var valueSize = track.getValueSize();
+
+			var times = [];
+			var values = [];
+
+			for ( var j = 0; j < track.times.length; ++ j ) {
+
+				var frame = track.times[ j ] * fps;
+
+				if ( frame < startFrame || frame >= endFrame ) continue;
+
+				times.push( track.times[ j ] );
+
+				for ( var k = 0; k < valueSize; ++ k ) {
+
+					values.push( track.values[ j * valueSize + k ] );
+
+				}
+
+			}
+
+			if ( times.length === 0 ) continue;
+
+			track.times = AnimationUtils.convertArray( times, track.times.constructor );
+			track.values = AnimationUtils.convertArray( values, track.values.constructor );
+
+			tracks.push( track );
+
+		}
+
+		clip.tracks = tracks;
+
+		// find minimum .times value across all tracks in the trimmed clip
+
+		var minStartTime = Infinity;
+
+		for ( var i = 0; i < clip.tracks.length; ++ i ) {
+
+			if ( minStartTime > clip.tracks[ i ].times[ 0 ] ) {
+
+				minStartTime = clip.tracks[ i ].times[ 0 ];
+
+			}
+
+		}
+
+		// shift all tracks such that clip begins at t=0
+
+		for ( var i = 0; i < clip.tracks.length; ++ i ) {
+
+			clip.tracks[ i ].shift( -1 * minStartTime );
+
+		}
+
+		clip.resetDuration();
+
+		return clip;
+
 	}
 
 };

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -347,6 +347,9 @@ Object.assign( KeyframeTrack.prototype, {
 	// (0,0,0,0,1,1,1,0,0,0,0,0,0,0) --> (0,0,1,1,0,0)
 	optimize: function () {
 
+		// TODO: Opt-out of optimization?
+		return this;
+
 		var times = this.times,
 			values = this.values,
 			stride = this.getValueSize(),

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -347,9 +347,6 @@ Object.assign( KeyframeTrack.prototype, {
 	// (0,0,0,0,1,1,1,0,0,0,0,0,0,0) --> (0,0,1,1,0,0)
 	optimize: function () {
 
-		// TODO: Opt-out of optimization?
-		return this;
-
 		var times = this.times,
 			values = this.values,
 			stride = this.getValueSize(),


### PR DESCRIPTION
See discussion in the forums, [ClipAction select range to play](https://discourse.threejs.org/t/clipaction-select-range-to-play/1134/12). The original suggestion was to allow clamping a clip to a particular time span, but I think an API for splitting clips would be best — this makes it possible to play each section of the clip independently, or crossfade between them.

Usage:

***

<details><summary>Previous syntax</summary>

```js
clips = THREE.AnimationUtils.splitClip( clips[ 0 ], [
  { name: 'Idle', startTime: 0 },
  { name: 'Run', startTime: 1 },
  { name: 'Samba', startTime: 2 },
] );

idleAction = mixer.clipAction( clips[ 0 ] );
runAction = mixer.clipAction( clips[ 1 ] );

idleAction.play();
setTimeout( () => {
  idleAction.crossFadeTo( runAction, 1 );
}, 1000 );
```

</details>

***

Updated syntax:

```js
var idleClip = THREE.AnimationUtils.subclip( clip, 'idle', 0, 60 );
var runClip = THREE.AnimationUtils.subclip( clip, 'run', 60, 120 );
var sambaClip = THREE.AnimationUtils.subclip( clip, 'samba', 120, 180 );

idleAction = mixer.clipAction( idleClip );
runAction = mixer.clipAction( runClip );

idleAction.play();
setTimeout( () => {
  idleAction.crossFadeTo( runAction, 1 );
}, 1000 );
```

If this API seems OK, I'm glad to add docs and some unit tests. A few questions first:

* [ ] Should the `.splitClip()` portion be kept out of core, e.g. `AnimationClipCreator.splitClips()`, instead?
* [ ] An example model would be helpful; I suspect frames could be off by one here.
* [ ] There's a warning in the KeyframeTrack source, `IMPORTANT: We do not shift around keys to the start of the track time, because for interpolated keys this will change their values`. I'm not sure what this means, or if it's relevant here. @bhouston do you recall?

/cc @looeee 