### PR TITLE
Editor: Added edit for .renderOrder and .frustumCulled

### DIFF
--- a/editor/js/Sidebar.Object.js
+++ b/editor/js/Sidebar.Object.js
@@ -272,7 +272,7 @@ Sidebar.Object = function ( editor ) {
 	// renderOrder
 
 	var objectRenderOrderRow = new UI.Row();
-	var objectRenderOrder = new UI.Integer().setWidth( '50px' ).setStep( 1 ).setRange( 0, Infinity ).onChange( update );
+	var objectRenderOrder = new UI.Integer().setWidth( '50px' ).onChange( update );
 
 	objectRenderOrderRow.add( new UI.Text( 'Render Order' ).setWidth( '90px' ) );
 	objectRenderOrderRow.add( objectRenderOrder );

--- a/editor/js/Sidebar.Object.js
+++ b/editor/js/Sidebar.Object.js
@@ -259,6 +259,26 @@ Sidebar.Object = function ( editor ) {
 
 	container.add( objectVisibleRow );
 
+	// frustumCulled
+
+	var objectFrustumCulledRow = new UI.Row();
+	var objectFrustumCulled = new UI.Checkbox().onChange( update );
+
+	objectFrustumCulledRow.add( new UI.Text( 'Frustum Culled' ).setWidth( '90px' ) );
+	objectFrustumCulledRow.add( objectFrustumCulled );
+
+	container.add( objectFrustumCulledRow );
+
+	// renderOrder
+
+	var objectRenderOrderRow = new UI.Row();
+	var objectRenderOrder = new UI.Integer().setWidth( '50px' ).setStep( 1 ).setRange( 0, Infinity ).onChange( update );
+
+	objectRenderOrderRow.add( new UI.Text( 'Render Order' ).setWidth( '90px' ) );
+	objectRenderOrderRow.add( objectRenderOrder );
+
+	container.add( objectRenderOrderRow );
+
 	// user data
 
 	var timeout;
@@ -433,6 +453,18 @@ Sidebar.Object = function ( editor ) {
 			if ( object.visible !== objectVisible.getValue() ) {
 
 				editor.execute( new SetValueCommand( object, 'visible', objectVisible.getValue() ) );
+
+			}
+
+			if ( object.frustumCulled !== objectFrustumCulled.getValue() ) {
+
+				editor.execute( new SetValueCommand( object, 'frustumCulled', objectFrustumCulled.getValue() ) );
+
+			}
+
+			if ( object.renderOrder !== objectRenderOrder.getValue() ) {
+
+				editor.execute( new SetValueCommand( object, 'renderOrder', objectRenderOrder.getValue() ) );
 
 			}
 
@@ -654,6 +686,8 @@ Sidebar.Object = function ( editor ) {
 		}
 
 		objectVisible.setValue( object.visible );
+		objectFrustumCulled.setValue( object.frustumCulled );
+		objectRenderOrder.setValue( object.renderOrder );
 
 		try {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -651,6 +651,8 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		if ( this.castShadow === true ) object.castShadow = true;
 		if ( this.receiveShadow === true ) object.receiveShadow = true;
 		if ( this.visible === false ) object.visible = false;
+		if ( this.frustumCulled === false ) object.frustumCulled = false;
+		if ( this.renderOrder !== 0 ) object.renderOrder = this.renderOrder;
 		if ( JSON.stringify( this.userData ) !== '{}' ) object.userData = this.userData;
 
 		object.matrix = this.matrix.toArray();

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -817,6 +817,8 @@ Object.assign( ObjectLoader.prototype, {
 		}
 
 		if ( data.visible !== undefined ) object.visible = data.visible;
+		if ( data.frustumCulled !== undefined ) object.frustumCulled = data.frustumCulled;
+		if ( data.renderOrder !== undefined ) object.renderOrder = data.renderOrder;
 		if ( data.userData !== undefined ) object.userData = data.userData;
 
 		if ( data.children !== undefined ) {


### PR DESCRIPTION
This PR adresses #12884

It adds an edit option for `Object3D.renderOrder` and `Object3D.frustumCulled`. It also ensure, that serialization and deserialization for both properties work correctly.