### PR TITLE
GLTFExporter Doc: Clean up image formats.

### DIFF
--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -16,7 +16,7 @@
 		<a href="https://www.khronos.org/gltf">glTF</a> (GL Transmission Format) is an
 		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0">open format specification</a>
 		for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf)
-		or binary (.glb) format. External files store textures (.jpg, .png, ...) and additional binary
+		or binary (.glb) format. External files store textures (.jpg, .png) and additional binary
 		data (.bin). A glTF asset may deliver one or more scenes, including meshes, materials,
 		textures, skins, skeletons, morph targets, animations, lights, and/or cameras.
 		</div>


### PR DESCRIPTION
We should clean up image formats description in `GLTFExporter` Doc as we did for `GLTFLoader` Doc in #13413, supported formats are only .png and .jpg.