### PR TITLE
MMDLoader: Optimize BufferAttribute type for skinIndex

### DIFF
--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -1476,7 +1476,7 @@ THREE.MMDLoader.prototype.createMesh = function ( model, texturePath, onProgress
 		geometry.addAttribute( 'position', new THREE.Float32BufferAttribute( buffer.vertices, 3 ) );
 		geometry.addAttribute( 'normal', new THREE.Float32BufferAttribute( buffer.normals, 3 ) );
 		geometry.addAttribute( 'uv', new THREE.Float32BufferAttribute( buffer.uvs, 2 ) );
-		geometry.addAttribute( 'skinIndex', new THREE.Float32BufferAttribute( buffer.skinIndices, 4 ) );
+		geometry.addAttribute( 'skinIndex', new THREE.Uint16BufferAttribute( buffer.skinIndices, 4 ) );
 		geometry.addAttribute( 'skinWeight', new THREE.Float32BufferAttribute( buffer.skinWeights, 4 ) );
 
 		geometry.computeBoundingSphere();


### PR DESCRIPTION
This PR optimizes `BufferAttribute` type for `skinIndex` in `MMDLoader` by replacing `Float32BufferAttribute` with `Uint16BufferAttribute`.