### PR TITLE
BufferGeometry: support per group renderOrder

### DIFF
--- a/docs/api/core/BufferGeometry.html
+++ b/docs/api/core/BufferGeometry.html
@@ -133,10 +133,10 @@
 			This allows an array of materials to be used with the bufferGeometry.<br /><br />
 
 			Each group is an object of the form:
-			<code>{ start: Integer, count: Integer, materialIndex: Integer }</code>
+			<code>{ start: Integer, count: Integer, materialIndex: Integer, renderOrder: Integer }</code>
 			where start specifies the first element in this draw call – the first vertex for non-indexed geometry,
 			otherwise the first triangle index. Count specifies how many vertices (or indices) are included, and
-			materialIndex specifies the material array index to use.<br /><br />
+			materialIndex specifies the material array index to use. RenderOrder is optional, and if defined it overrides [page:Object3D.renderOrder].<br /><br />
 
 			Use [page:.addGroup] to add groups, rather than modifying this array directly.
 		</div>
@@ -202,7 +202,7 @@
 		attributes.
 		</div>
 
-		<h3>[method:null addGroup]( [param:Integer start], [param:Integer count], [param:Integer materialIndex] )</h3>
+		<h3>[method:null addGroup]( [param:Integer start], [param:Integer count], [param:Integer materialIndex], [param:Integer renderOrder] )</h3>
 		<div>
 			Adds a group to this geometry; see the [page:BufferGeometry.groups groups]
 			property for details.

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -107,14 +107,14 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	},
 
-	addGroup: function ( start, count, materialIndex ) {
+	addGroup: function ( start, count, materialIndex, renderOrder ) {
 
 		this.groups.push( {
 
 			start: start,
 			count: count,
-			materialIndex: materialIndex !== undefined ? materialIndex : 0
-
+			materialIndex: materialIndex !== undefined ? materialIndex : 0,
+			renderOrder: renderOrder
 		} );
 
 	},

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -95,6 +95,10 @@ function WebGLRenderList() {
 
 		}
 
+		if (group && group.renderOrder !== undefined) {
+			renderItem.renderOrder = group.renderOrder;
+		}
+
 		( material.transparent === true ? transparent : opaque ).push( renderItem );
 
 		renderItemsIndex ++;


### PR DESCRIPTION
This commits allows to specify a `renderOrder` per group, instead of only allowing per mesh `renderOrder`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrdoob/three.js/13465)
<!-- Reviewable:end -->
