### PR TITLE
GLTFExporter: Compare .name with empty strings for the consistency

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -801,7 +801,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			if ( material.name ) {
+			if ( material.name !== '' ) {
 
 				gltfMaterial.name = material.name;
 
@@ -1079,7 +1079,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			if ( camera.name ) {
+			if ( camera.name !== '' ) {
 
 				gltfCamera.name = camera.type;
 
@@ -1401,7 +1401,7 @@ THREE.GLTFExporter.prototype = {
 
 			};
 
-			if ( scene.name ) {
+			if ( scene.name !== '' ) {
 
 				gltfScene.name = scene.name;
 


### PR DESCRIPTION
I think we should replace `if ( something.name )` with `if ( something.name !== '' )` in `GLTFExporter` for the code consistency in the exporter and across the modules.