### PR TITLE
Test manually updating video texture in webvr_video

### DIFF
--- a/examples/webvr_video.html
+++ b/examples/webvr_video.html
@@ -65,10 +65,21 @@
 				video.setAttribute( 'webkit-playsinline', 'webkit-playsinline' );
 				video.play();
 
-				texture = new THREE.VideoTexture( video );
+				texture = new THREE.Texture( video );
+				texture.generateMipmaps = false;
 				texture.minFilter = THREE.NearestFilter;
 				texture.maxFilter = THREE.NearestFilter;
 				texture.format = THREE.RGBFormat;
+
+				setInterval( function () {
+
+					if ( video.readyState >= video.HAVE_CURRENT_DATA ) {
+
+						texture.needsUpdate = true;
+
+					}
+
+				}, 1000 / 24 );
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0x101010 );


### PR DESCRIPTION
Manually updating video texture at 24fps to test browsers.
If browser compatibility is good we'll implement this approach directly in `VideoTexture`.

See #13379