### PR TITLE
Docs: Added page for CSS3DRenderer

### DIFF
--- a/docs/examples/renderers/CSS3DRenderer.html
+++ b/docs/examples/renderers/CSS3DRenderer.html
@@ -56,9 +56,9 @@
 			Returns an object containing the width and height of the renderer.
 		</div>
 
-		<h3>[method:null render]( [param:Scene scene], [param:Camera camera] )</h3>
+		<h3>[method:null render]( [param:Scene scene], [param:PerspectiveCamera camera] )</h3>
 		<div>
-			Renders a [page:Scene scene] using a [page:Camera camera].<br />
+			Renders a [page:Scene scene] using a [page:PerspectiveCamera perspective camera].<br />
 		</div>
 
 		<h3>[method:null setSize]([param:Number width], [param:Number height])</h3>

--- a/docs/examples/renderers/CSS3DRenderer.html
+++ b/docs/examples/renderers/CSS3DRenderer.html
@@ -18,7 +18,7 @@
 				<li>It's also not possible to use geometries.</li>
 				<li>Only [page:PerspectiveCamera] is supported right now.</li>
 			</ul>
-			Instead, you have to build your scene with ordinary DOM elements. The elements are wrapped into special objects (*CSS3DObject* or *CSS3DSprite*) and then added to the scene graph.
+			So [name] is just focused on ordinary DOM elements. These elements are wrapped into special objects (*CSS3DObject* or *CSS3DSprite*) and then added to the scene graph.
 		</div>
 
 		<script>

--- a/docs/examples/renderers/CSS3DRenderer.html
+++ b/docs/examples/renderers/CSS3DRenderer.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1>
+
+		<div class="desc">[name] can be used to apply hierarchical 3D transformations to DOM elements via the CSS3 [link:https://www.w3schools.com/cssref/css3_pr_transform.asp transform] property.<br />
+			This renderer is particular interesting if you want to apply 3D effects to a website without canvas based rendering. It can also be used in order to combine DOM elements with WebGL content.<br />
+			There are, however, some important limitations:
+			<ul>
+				<li>It's not possible to use the material system of *three.js*.</li>
+				<li>It's also not possible to use geometries.</li>
+			</ul>
+			Instead, you have to build your scene with ordinary DOM elements. The elements are wrapped into special objects (*CSS3DObject* or *CSS3DSprite*) and then added to the scene graph.
+		</div>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
+
+		<h2>Examples</h2>
+
+		<div>
+			[example:css3d_molecules molecules]<br />
+			[example:css3d_panorama panorama]<br />
+			[example:css3d_periodictable periodictable]<br />
+			[example:css3d_sprites sprites]<br />
+		</div>
+
+		<h2>Constructor</h2>
+
+		<h3>[name]()</h3>
+
+		<h2>Methods</h2>
+
+		<h3>[method:Object getSize]()</h3>
+		<div>
+			Returns an object containing the width and height of the renderer.
+		</div>
+
+		<h3>[method:null render]( [param:Scene scene], [param:Camera camera] )</h3>
+		<div>
+			Renders a [page:Scene scene] using a [page:Camera camera].<br />
+		</div>
+
+		<h3>[method:null setSize]([param:Number width], [param:Number height])</h3>
+		<div>
+			Resizes the renderer to (width, height).
+		</div>
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/[path].js examples/js/[path].js]
+	</body>
+</html>

--- a/docs/examples/renderers/CSS3DRenderer.html
+++ b/docs/examples/renderers/CSS3DRenderer.html
@@ -16,6 +16,7 @@
 			<ul>
 				<li>It's not possible to use the material system of *three.js*.</li>
 				<li>It's also not possible to use geometries.</li>
+				<li>Only [page:PerspectiveCamera] is supported right now.</li>
 			</ul>
 			Instead, you have to build your scene with ordinary DOM elements. The elements are wrapped into special objects (*CSS3DObject* or *CSS3DSprite*) and then added to the scene graph.
 		</div>

--- a/docs/list.js
+++ b/docs/list.js
@@ -382,7 +382,8 @@ var list = {
 		},
 
 		"Renderers": {
-			"CanvasRenderer": "examples/renderers/CanvasRenderer"
+			"CanvasRenderer": "examples/renderers/CanvasRenderer",
+			"CSS3DRenderer": "examples/renderers/CSS3DRenderer"
 		},
 
 		"Utils": {


### PR DESCRIPTION
Added a basic documentation for `CSS3DRenderer`

The following thread motivates me for this PR (thanks to ben 👍):
https://discourse.threejs.org/t/css3drenderer-education-with-three-js/2013