### PR TITLE
Object3D: remove getWorldRotation()

### DIFF
--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -254,13 +254,6 @@
 		Returns a quaternion representing the rotation of the object in world space.
 		</div>
 
-		<h3>[method:Euler getWorldRotation]( [param:Euler target] )</h3>
-		<div>
-		[page:Euler target] — the result will be copied into this Euler. <br /><br />
-
-		Returns the euler angles representing the rotation of the object in world space.
-		</div>
-
 		<h3>[method:Vector3 getWorldScale]( [param:Vector3 target] )</h3>
 		<div>
 		[page:Vector3 target] — the result will be copied into this Vector3. <br /><br />

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -865,6 +865,11 @@ Object.assign( Object3D.prototype, {
 		console.warn( 'THREE.Object3D: .translate() has been removed. Use .translateOnAxis( axis, distance ) instead.' );
 		return this.translateOnAxis( axis, distance );
 
+	},
+	getWorldRotation: function () {
+
+		console.error( 'THREE.Object3D: .getWorldRotation() has been removed. Use THREE.Object3D.getWorldQuaternion( target ) instead.' );
+
 	}
 
 } );

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -482,27 +482,6 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	}(),
 
-	getWorldRotation: function () {
-
-		var quaternion = new Quaternion();
-
-		return function getWorldRotation( target ) {
-
-			if ( target === undefined ) {
-
-				console.warn( 'THREE.Object3D: .getWorldRotation() target is now required' );
-				target = new Euler();
-
-			}
-
-			this.getWorldQuaternion( quaternion );
-
-			return target.setFromQuaternion( quaternion, this.rotation.order, false );
-
-		};
-
-	}(),
-
 	getWorldScale: function () {
 
 		var position = new Vector3();


### PR DESCRIPTION
Fixes #13076, and proposed in https://github.com/mrdoob/three.js/issues/13076#issuecomment-356476393.

edit: also fixes #11767.