### PR TITLE
Remove  use of Geometry._bufferGeometry

### DIFF
--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -72,13 +72,7 @@ function WebGLGeometries( gl, attributes, info ) {
 
 		} else if ( geometry.isGeometry ) {
 
-			if ( geometry._bufferGeometry === undefined ) {
-
-				geometry._bufferGeometry = new BufferGeometry().setFromObject( object );
-
-			}
-
-			buffergeometry = geometry._bufferGeometry;
+			buffergeometry = new BufferGeometry().setFromObject( object );
 
 		}
 


### PR DESCRIPTION
renderer internals exposed.

This property seems redundant since we lookup bufferGeometry s in the WebGLGemoetries.geometries.

(presumably old mechanism)
