### PR TITLE
Remove redundant code from WebGLGeometries

### DIFF
--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -32,17 +32,6 @@ function WebGLGeometries( gl, attributes, info ) {
 
 		delete geometries[ geometry.id ];
 
-		// TODO Remove duplicate code
-
-		var attribute = wireframeAttributes[ geometry.id ];
-
-		if ( attribute ) {
-
-			attributes.remove( attribute );
-			delete wireframeAttributes[ geometry.id ];
-
-		}
-
 		attribute = wireframeAttributes[ buffergeometry.id ];
 
 		if ( attribute ) {


### PR DESCRIPTION
getWireframeAttribute is only called with a bufferGeometry.