### PR TITLE
Docs: Added page for CSS2DRenderer

### DIFF
--- a/docs/examples/renderers/CSS2DRenderer.html
+++ b/docs/examples/renderers/CSS2DRenderer.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1>
+
+		<div class="desc">[name] is a simplified version of [page:CSS3DRenderer]. The only transformation that is supported is translation.<br />
+			The renderer is very useful if you want to combine HTML based labels with 3D objects. Here too, the respective DOM elements are wrapped into an instance of *CSS2DObject* and added to the scene graph.<br />
+			Unlike [page:CSS3DRenderer], orthographic cameras are supported.
+		</div>
+
+		<script>
+
+		// iOS iframe auto-resize workaround
+
+		if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
+
+			var scene = document.getElementById( 'scene' );
+
+			scene.style.width = getComputedStyle( scene ).width;
+			scene.style.height = getComputedStyle( scene ).height;
+			scene.setAttribute( 'scrolling', 'no' );
+
+		}
+
+		</script>
+
+		<h2>Examples</h2>
+
+		<div>
+			[example:webgl_loader_pdb molecules]
+		</div>
+
+		<h2>Constructor</h2>
+
+		<h3>[name]()</h3>
+
+		<h2>Methods</h2>
+
+		<h3>[method:Object getSize]()</h3>
+		<div>
+			Returns an object containing the width and height of the renderer.
+		</div>
+
+		<h3>[method:null render]( [param:Scene scene], [param:Camera camera] )</h3>
+		<div>
+			Renders a [page:Scene scene] using a [page:Camera camera].<br />
+		</div>
+
+		<h3>[method:null setSize]([param:Number width], [param:Number height])</h3>
+		<div>
+			Resizes the renderer to (width, height).
+		</div>
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/[path].js examples/js/[path].js]
+	</body>
+</html>

--- a/docs/list.js
+++ b/docs/list.js
@@ -383,7 +383,8 @@ var list = {
 
 		"Renderers": {
 			"CanvasRenderer": "examples/renderers/CanvasRenderer",
-			"CSS3DRenderer": "examples/renderers/CSS3DRenderer"
+			"CSS3DRenderer": "examples/renderers/CSS3DRenderer",
+			"CSS2DRenderer": "examples/renderers/CSS2DRenderer"
 		},
 
 		"Utils": {

--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -42,6 +42,15 @@ THREE.CSS2DRenderer = function () {
 
 	this.domElement = domElement;
 
+	this.getSize = function () {
+
+		return {
+			width: _width,
+			height: _height
+		};
+
+	};
+
 	this.setSize = function ( width, height ) {
 
 		_width = width;


### PR DESCRIPTION
For the sake of completeness, this PR adds the doc page for `CSS2DRenderer`.

To be consistent with `CSS3DRenderer`, i've added the missing method `CSS2DRenderer.getSize()`.