### PR TITLE
Loaders: set .quaternion instead of .rotation

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3607,7 +3607,7 @@ THREE.ColladaLoader.prototype = {
 
 		if ( asset.upAxis === 'Z_UP' ) {
 
-			scene.rotation.x = - Math.PI / 2;
+			scene.quaternion.setFromEuler( new THREE.Euler( - Math.PI / 2, 0, 0 ) );
 
 		}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1989,7 +1989,7 @@
 
 			var rotation = modelNode.Lcl_Rotation.value.map( THREE.Math.degToRad );
 			rotation.push( 'ZYX' );
-			model.rotation.fromArray( rotation );
+			model.quaternion.setFromEuler( new THREE.Euler().fromArray( rotation ) );
 
 		}
 
@@ -2007,9 +2007,7 @@
 			var preRotations = new THREE.Euler().fromArray( array );
 
 			preRotations = new THREE.Quaternion().setFromEuler( preRotations );
-			var currentRotation = new THREE.Quaternion().setFromEuler( model.rotation );
-			preRotations.multiply( currentRotation );
-			model.rotation.setFromQuaternion( preRotations, 'ZYX' );
+			model.quaternion.premultiply( preRotations );
 
 		}
 

--- a/examples/js/loaders/GCodeLoader.js
+++ b/examples/js/loaders/GCodeLoader.js
@@ -210,7 +210,7 @@ THREE.GCodeLoader.prototype.parse = function ( data ) {
 
 	}
 
-	object.rotation.set( - Math.PI / 2, 0, 0 );
+	object.quaternion.setFromEuler( new THREE.Euler( - Math.PI / 2, 0, 0 ) );
 
 	return object;
 

--- a/examples/js/loaders/PlayCanvasLoader.js
+++ b/examples/js/loaders/PlayCanvasLoader.js
@@ -140,7 +140,7 @@ THREE.PlayCanvasLoader.prototype = {
 			object.name = data.name;
 
 			object.position.fromArray( data.position );
-			object.rotation.fromArray( data.rotation );
+			object.quaternion.setFromEuler( new THREE.Euler().fromArray( data.rotation ) );
 			object.scale.fromArray( data.scale );
 
 			data._object = object;

--- a/examples/js/loaders/sea3d/SEA3DLoader.js
+++ b/examples/js/loaders/sea3d/SEA3DLoader.js
@@ -1695,7 +1695,7 @@ THREE.SEA3D.prototype.updateTransform = function ( obj3d, sea ) {
 
 	// ignore rotation scale
 
-	obj3d.rotation.setFromRotationMatrix( THREE.SEA3D.identityMatrixScale( mtx ) );
+	obj3d.quaternion.setFromRotationMatrix( THREE.SEA3D.identityMatrixScale( mtx ) );
 
 	// optimize if is static
 

--- a/examples/js/loaders/sea3d/physics/SEA3DAmmoLoader.js
+++ b/examples/js/loaders/sea3d/physics/SEA3DAmmoLoader.js
@@ -441,7 +441,7 @@ THREE.SEA3D.Domain.prototype.applyContainerTransform = function () {
 	var matrix = this.container.matrix.clone();
 
 	this.container.position.set( 0, 0, 0 );
-	this.container.rotation.set( 0, 0, 0 );
+	this.container.quaternion.set( 0, 0, 0, 1 );
 	this.container.scale.set( 1, 1, 1 );
 
 	this.applyTransform( matrix );
@@ -491,7 +491,7 @@ THREE.SEA3D.Domain.prototype.applyTransform = function ( matrix ) {
 		// ignore rotation scale
 
 		mtx.scale( vec.set( 1 / obj3d.scale.x, 1 / obj3d.scale.y, 1 / obj3d.scale.z ) );
-		obj3d.rotation.setFromRotationMatrix( mtx );
+		obj3d.quaternion.setFromRotationMatrix( mtx );
 
 	}
 


### PR DESCRIPTION
Trying this to see what this change looks like... Not too bad, actually.

The idea is that at some point, `Object3d.rotation` may be removed, but the `Euler` class would be retained.

Feedback requested.