### PR TITLE
Renderers: Clean up

### DIFF
--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -433,12 +433,6 @@
 			scissor area will be affected by further renderer actions.
 		</div>
 
-		<h3>[method:Boolean supportsVertexTextures]()</h3>
-		<div>
-		Return a [page:Boolean] true if the context supports vertex textures.
-		This has been deprecated in favour of [page:WebGLRenderer.capabilities capabilities.vertexTexures].
-		</div>
-
 		<h3>[method:null setSize]( [param:Integer width], [param:Integer height], [param:Boolean updateStyle] )</h3>
 		<div>
 		Resizes the output canvas to (width, height) with device pixel ratio taken into account,

--- a/docs/examples/renderers/CanvasRenderer.html
+++ b/docs/examples/renderers/CanvasRenderer.html
@@ -164,8 +164,6 @@
 			[method:null clearColor]()<br/>
 			[method:null clearDepth]()<br/>
 			[method:null clearStencil]()<br/>
-			[method:null setFaceCulling]()<br/>
-			[method:null supportsVertexTextures]()<br/>
 			[method:number getMaxAnisotropy]() - returns 1 <br/>
 		</div>
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -65,8 +65,6 @@ THREE.CSS3DRenderer = function () {
 
 	var isIE = /Trident/i.test( navigator.userAgent );
 
-	this.setClearColor = function () {};
-
 	this.getSize = function () {
 
 		return {

--- a/examples/js/renderers/CanvasRenderer.js
+++ b/examples/js/renderers/CanvasRenderer.js
@@ -136,11 +136,6 @@ THREE.CanvasRenderer = function ( parameters ) {
 
 	};
 
-	// WebGLRenderer compatibility
-
-	this.supportsVertexTextures = function () {};
-	this.setFaceCulling = function () {};
-
 	// API
 
 	this.getContext = function () {

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -79,11 +79,6 @@ THREE.SVGRenderer = function () {
 
 	};
 
-	// WebGLRenderer compatibility
-
-	this.supportsVertexTextures = function () {};
-	this.setFaceCulling = function () {};
-
 	this.setClearColor = function ( color, alpha ) {
 
 		_clearColor.set( color );

--- a/examples/js/renderers/SoftwareRenderer.js
+++ b/examples/js/renderers/SoftwareRenderer.js
@@ -73,11 +73,6 @@ THREE.SoftwareRenderer = function ( parameters ) {
 
 	this.autoClear = true;
 
-	// WebGLRenderer compatibility
-
-	this.supportsVertexTextures = function () {};
-	this.setFaceCulling = function () {};
-
 	this.setClearColor = function ( color ) {
 
 		clearColor.set( color );


### PR DESCRIPTION
Removes some obsolete code in context of `.setFaceCulling()` and `.supportsVertexTextures()` (both methods are deprecated). It also removes the unnecessary method `.setClearColor()` from `CSS3DRenderer`. 