### PR TITLE
Fixed Link

### DIFF
--- a/docs/manual/introduction/Useful-links.html
+++ b/docs/manual/introduction/Useful-links.html
@@ -47,7 +47,7 @@
 				[link:http://blog.cjgammon.com/ Collection of tutorials] by [link:http://www.cjgammon.com/ CJ Gammon].
 			</li>
 			<li>
-				[link:https://medium.com/@soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
+				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		 <li>
 			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,


### PR DESCRIPTION
The '@' in

>  https://medium.com/@soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857

 seemed to cause some sort of issue. Removing the '@' fixed the problem, now the link is working and the text is showing properly.