### PR TITLE
Fixes #13483 exporting normal maps from Blender

### DIFF
--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -253,7 +253,7 @@ Object.assign( Loader.prototype, {
 						json.normalMap = loadTexture( value, m.mapNormalRepeat, m.mapNormalOffset, m.mapNormalWrap, m.mapNormalAnisotropy );
 						break;
 					case 'mapNormalFactor':
-						json.normalScale = [ value, value ];
+						json.normalScale = value;
 						break;
 					case 'mapNormalRepeat':
 					case 'mapNormalOffset':


### PR DESCRIPTION
Fixing issue when exporting normal maps from latest blender 2.79 with JSONLoader.  I'm not 100% confident that this will not affect other loaders...