### PR TITLE
Remove optionalTarget - part 2

### DIFF
--- a/docs/api/math/Box2.html
+++ b/docs/api/math/Box2.html
@@ -50,11 +50,10 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector2 clampPoint]( [param:Vector2 point], [param:Vector2 optionalTarget] )</h3>
+		<h3>[method:Vector2 clampPoint]( [param:Vector2 point], [param:Vector2 target] )</h3>
 		<div>
 		[page:Vector2 point] - [page:Vector2] to clamp. <br>
-		[page:Vector2 optionalTarget] — (optional) if specified, the result will be copied into this Vector2,
-		otherwise a new Vector2 will be created. <br /><br />
+		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Clamping_(graphics) Clamps] the [page:Vector2 point] within the bounds of this box.<br />
 		</div>
@@ -121,27 +120,24 @@
 		this box will be expanded by the y component of [page:Vector2 vector] in both directions.
 		</div>
 
-		<h3>[method:Vector2 getCenter]( [param:Vector2 optionalTarget] )</h3>
+		<h3>[method:Vector2 getCenter]( [param:Vector2 target] )</h3>
 		<div>
-			[page:Vector2 optionalTarget] — (optional) if specified, the result will be copied into this Vector2,
-			otherwise a new Vector2 will be created. <br /><br />
+		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />
 
 		Returns the center point of the box as a [page:Vector2].
 		</div>
 
-		<h3>[method:Vector2 getParameter]( [param:Vector2 point], [param:Vector2 optionalTarget] ) </h3>
+		<h3>[method:Vector2 getParameter]( [param:Vector2 point], [param:Vector2 target] ) </h3>
 		<div>
 		[page:Vector2 point] - [page:Vector2].<br/>
-		[page:Vector2 optionalTarget] — (optional) if specified, the result will be copied into this Vector2,
-		otherwise a new Vector2 will be created. <br /><br />
+		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />
 
 		Returns a point as a proportion of this box's width and height.
 		</div>
 
-		<h3>[method:Vector2 getSize]( [param:Vector2 optionalTarget] )</h3>
+		<h3>[method:Vector2 getSize]( [param:Vector2 target] )</h3>
 		<div>
-			[page:Vector2 optionalTarget] — (optional) if specified, the result will be copied into this Vector2,
-			otherwise a new Vector2 will be created. <br /><br />
+		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />
 
 		Returns the width and height of this box.
 		</div>

--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -62,11 +62,10 @@
 		Transforms this Box3 with the supplied matrix.
 		</div>
 
-		<h3>[method:Vector3 clampPoint]( [param:Vector3 point], [param:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 clampPoint]( [param:Vector3 point], [param:Vector3 target] )</h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3] to clamp. <br>
-		[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
-		otherwise a new Vector3 will be created. <br /><br />
+		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Clamping_(graphics) Clamps] the [page:Vector3 point] within the bounds of this box.<br />
 		</div>
@@ -146,35 +145,31 @@
 		The depth of this box will be expanded by the z component of *vector* in both directions.
 		</div>
 
-		<h3>[method:Sphere getBoundingSphere]( [param:Sphere optionalTarget] )</h3>
+		<h3>[method:Sphere getBoundingSphere]( [param:Sphere target] )</h3>
 		<div>
-			[page:Sphere optionalTarget] — (optional) if specified, the result will be copied into this Sphere,
-			otherwise a new Sphere will be created. <br /><br />
+		[page:Sphere target] — the result will be copied into this Sphere.<br /><br />
 
 		Gets a [page:Sphere] that bounds the box.
 		</div>
 
-		<h3>[method:Vector3 getCenter]( [param:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 getCenter]( [param:Vector3 target] )</h3>
 		<div>
-			[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
-			otherwise a new Vector3 will be created. <br /><br />
+		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns the center point of the box as a [page:Vector3].
 		</div>
 
-		<h3>[method:Vector3 getParameter]( [param:Vector3 point], [param:Vector3 optionalTarget] ) </h3>
+		<h3>[method:Vector3 getParameter]( [param:Vector3 point], [param:Vector3 target] ) </h3>
 		<div>
 		[page:Vector3 point] - [page:Vector3].<br/>
-		[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
-		otherwise a new Vector3 will be created. <br /><br />
+		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns a point as a proportion of this box's width and height.
 		</div>
 
-		<h3>[method:Vector3 getSize]( [param:Vector3 optionalTarget] )</h3>
+		<h3>[method:Vector3 getSize]( [param:Vector3 target] )</h3>
 		<div>
-			[page:Vector3 optionalTarget] — (optional) if specified, the result will be copied into this Vector3,
-			otherwise a new Vector3 will be created. <br /><br />
+		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns the width, height and depth of this box.
 		</div>

--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -84,17 +84,29 @@ Object.assign( Box2.prototype, {
 
 	},
 
-	getCenter: function ( optionalTarget ) {
+	getCenter: function ( target ) {
 
-		var result = optionalTarget || new Vector2();
-		return this.isEmpty() ? result.set( 0, 0 ) : result.addVectors( this.min, this.max ).multiplyScalar( 0.5 );
+		if ( target === undefined ) {
+
+			console.warn( 'THREE.Box2: .getCenter() target is now required' );
+			target = new Vector2();
+
+		}
+
+		return this.isEmpty() ? target.set( 0, 0 ) : target.addVectors( this.min, this.max ).multiplyScalar( 0.5 );
 
 	},
 
-	getSize: function ( optionalTarget ) {
+	getSize: function ( target ) {
 
-		var result = optionalTarget || new Vector2();
-		return this.isEmpty() ? result.set( 0, 0 ) : result.subVectors( this.max, this.min );
+		if ( target === undefined ) {
+
+			console.warn( 'THREE.Box2: .getSize() target is now required' );
+			target = new Vector2();
+
+		}
+
+		return this.isEmpty() ? target.set( 0, 0 ) : target.subVectors( this.max, this.min );
 
 	},
 
@@ -139,14 +151,19 @@ Object.assign( Box2.prototype, {
 
 	},
 
-	getParameter: function ( point, optionalTarget ) {
+	getParameter: function ( point, target ) {
 
 		// This can potentially have a divide by zero if the box
 		// has a size dimension of 0.
 
-		var result = optionalTarget || new Vector2();
+		if ( target === undefined ) {
 
-		return result.set(
+			console.warn( 'THREE.Box2: .getParameter() target is now required' );
+			target = new Vector2();
+
+		}
+
+		return target.set(
 			( point.x - this.min.x ) / ( this.max.x - this.min.x ),
 			( point.y - this.min.y ) / ( this.max.y - this.min.y )
 		);
@@ -162,10 +179,16 @@ Object.assign( Box2.prototype, {
 
 	},
 
-	clampPoint: function ( point, optionalTarget ) {
+	clampPoint: function ( point, target ) {
 
-		var result = optionalTarget || new Vector2();
-		return result.copy( point ).clamp( this.min, this.max );
+		if ( target === undefined ) {
+
+			console.warn( 'THREE.Box2: .clampPoint() target is now required' );
+			target = new Vector2();
+
+		}
+
+		return target.copy( point ).clamp( this.min, this.max );
 
 	},
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -163,17 +163,29 @@ Object.assign( Box3.prototype, {
 
 	},
 
-	getCenter: function ( optionalTarget ) {
+	getCenter: function ( target ) {
 
-		var result = optionalTarget || new Vector3();
-		return this.isEmpty() ? result.set( 0, 0, 0 ) : result.addVectors( this.min, this.max ).multiplyScalar( 0.5 );
+		if ( target === undefined ) {
+
+			console.warn( 'THREE.Box3: .getCenter() target is now required' );
+			target = new Vector3();
+
+		}
+
+		return this.isEmpty() ? target.set( 0, 0, 0 ) : target.addVectors( this.min, this.max ).multiplyScalar( 0.5 );
 
 	},
 
-	getSize: function ( optionalTarget ) {
+	getSize: function ( target ) {
 
-		var result = optionalTarget || new Vector3();
-		return this.isEmpty() ? result.set( 0, 0, 0 ) : result.subVectors( this.max, this.min );
+		if ( target === undefined ) {
+
+			console.warn( 'THREE.Box3: .getSize() target is now required' );
+			target = new Vector3();
+
+		}
+
+		return this.isEmpty() ? target.set( 0, 0, 0 ) : target.subVectors( this.max, this.min );
 
 	},
 
@@ -284,14 +296,19 @@ Object.assign( Box3.prototype, {
 
 	},
 
-	getParameter: function ( point, optionalTarget ) {
+	getParameter: function ( point, target ) {
 
 		// This can potentially have a divide by zero if the box
 		// has a size dimension of 0.
 
-		var result = optionalTarget || new Vector3();
+		if ( target === undefined ) {
 
-		return result.set(
+			console.warn( 'THREE.Box3: .getParameter() target is now required' );
+			target = new Vector3();
+
+		}
+
+		return target.set(
 			( point.x - this.min.x ) / ( this.max.x - this.min.x ),
 			( point.y - this.min.y ) / ( this.max.y - this.min.y ),
 			( point.z - this.min.z ) / ( this.max.z - this.min.z )
@@ -472,10 +489,16 @@ Object.assign( Box3.prototype, {
 
 	} )(),
 
-	clampPoint: function ( point, optionalTarget ) {
+	clampPoint: function ( point, target ) {
 
-		var result = optionalTarget || new Vector3();
-		return result.copy( point ).clamp( this.min, this.max );
+		if ( target === undefined ) {
+
+			console.warn( 'THREE.Box3: .clampPoint() target is now required' );
+			target = new Vector3();
+
+		}
+
+		return target.copy( point ).clamp( this.min, this.max );
 
 	},
 
@@ -496,15 +519,20 @@ Object.assign( Box3.prototype, {
 
 		var v1 = new Vector3();
 
-		return function getBoundingSphere( optionalTarget ) {
+		return function getBoundingSphere( target ) {
 
-			var result = optionalTarget || new Sphere();
+			if ( target === undefined ) {
 
-			this.getCenter( result.center );
+				console.warn( 'THREE.Box3: .getBoundingSphere() target is now required' );
+				target = new Sphere();
 
-			result.radius = this.getSize( v1 ).length() * 0.5;
+			}
 
-			return result;
+			this.getCenter( target.center );
+
+			target.radius = this.getSize( v1 ).length() * 0.5;
+
+			return target;
 
 		};
 


### PR DESCRIPTION
As proposed in #12231.  ... a few more classes. Keeping PRs tiny.

Docs do not use consistent indentation patterns, so I picked one.