### PR TITLE
GLTFLoader: Method chainable .setDRACOLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -72,6 +72,7 @@ THREE.GLTFLoader = ( function () {
 		setDRACOLoader: function ( dracoLoader ) {
 
 			this.dracoLoader = dracoLoader;
+			return this;
 
 		},
 


### PR DESCRIPTION
This PR enables method chain `.setDRACOLoader` of `GLTFLoader`. `*Loader`'s `.set*` methods return `this`.