### PR TITLE
Update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,14 +52,14 @@
   "homepage": "https://threejs.org/",
   "devDependencies": {
     "concurrently": "^3.5.0",
-    "electron": "1.7.11",
+    "electron": "1.8.2",
     "eslint": "^4.1.1",
     "eslint-config-mdcs": "^4.2.2",
-    "google-closure-compiler": "20180101.0.0",
+    "google-closure-compiler": "20180204.0.0",
     "qunit": "^2.4.0",
-    "rollup": "^0.55.1",
+    "rollup": "^0.56.4",
     "rollup-watch": "^4.0.0",
-    "serve": "6.4.9",
+    "serve": "6.5.1",
     "uglify-js": "^3.0.23"
   }
 }


### PR DESCRIPTION
Updated some `dev` dependencies: `electron`, `google-closure-compiler`, `rollup` and `serve`