### PR TITLE
Update WebGLProgram.html

### DIFF
--- a/docs/api/renderers/webgl/WebGLProgram.html
+++ b/docs/api/renderers/webgl/WebGLProgram.html
@@ -40,7 +40,6 @@
 		attribute vec3 position;
 		attribute vec3 normal;
 		attribute vec2 uv;
-		attribute vec2 uv2;
 		</code>
 		<p>
 		Note that you can therefore calculate the position of a vertex in the vertex shader by:


### PR DESCRIPTION
Adresses #10522

`uv2` is not defined in `WebGLProgram` but in a shader chunk:

https://github.com/mrdoob/three.js/blob/faa51af9be9b604cdebfc29a239175f36de98e12/src/renderers/shaders/ShaderChunk/uv2_pars_vertex.glsl#L1-L6