### PR TITLE
Implement raycast for ArrowHelper

### DIFF
--- a/src/helpers/ArrowHelper.js
+++ b/src/helpers/ArrowHelper.js
@@ -117,5 +117,12 @@ ArrowHelper.prototype.setColor = function ( color ) {
 
 };
 
+ArrowHelper.prototype.raycast = function ( raycaster, intersects ) {
+
+	this.line.raycast( raycaster, intersects );
+	this.cone.raycast( raycaster, intersects );
+
+};
+
 
 export { ArrowHelper };


### PR DESCRIPTION
This adds calls to the raycasting methods of the line and the cone of the ArrowHelper class.

Perhaps there needs to be a discussion of whether other helpers would need this method as well or if this is an undesired feature in the context of helpers. 👌 