### PR TITLE
Support for HDR scene background

### DIFF
--- a/src/renderers/shaders/ShaderLib/cube_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/cube_frag.glsl
@@ -6,7 +6,7 @@ varying vec3 vWorldPosition;
 
 void main() {
 
-	gl_FragColor = textureCube( tCube, vec3( tFlip * vWorldPosition.x, vWorldPosition.yz ) );
+	gl_FragColor = mapTexelToLinear( textureCube( tCube, vec3( tFlip * vWorldPosition.x, vWorldPosition.yz ) ) );
 	gl_FragColor.a *= opacity;
 
 }

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -72,6 +72,7 @@ function WebGLBackground( renderer, state, geometries, premultipliedAlpha ) {
 			}
 
 			boxMesh.material.uniforms.tCube.value = background;
+			boxMesh.material.map = background;
 
 			renderList.push( boxMesh, boxMesh.geometry, boxMesh.material, 0, null );
 


### PR DESCRIPTION
Adds support for HDR textures on `scene.background`.

Fixes #11124.

In WebGLBackground, the background texture also needs to be assigned to the background material's `.map` property so that WebGLProgram will look at the texture's encoding and write the appropriate decoder into `mapTexelToLinear()`. Then the fragment shader just needs to call `mapTexelToLinear()`.

To use, just set `scene.background` to a texture as normal. The texture's `.encoding` property should now be correctly interpreted instead of ignored.