### PR TITLE
FBXLoader: support material colors in files exported from blender

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -97,7 +97,7 @@
 
 			}
 
-			console.log( FBXTree );
+			// console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );
@@ -424,7 +424,6 @@
 	// Also parse the texture map and return any textures associated with the material
 	function parseParameters( FBXTree, properties, textureMap, ID, connections ) {
 
-		console.log( properties)
 		var parameters = {};
 
 		if ( properties.BumpFactor ) {

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -97,7 +97,7 @@
 
 			}
 
-			// console.log( FBXTree );
+			console.log( FBXTree );
 
 			var connections = parseConnections( FBXTree );
 			var images = parseImages( FBXTree );
@@ -424,6 +424,7 @@
 	// Also parse the texture map and return any textures associated with the material
 	function parseParameters( FBXTree, properties, textureMap, ID, connections ) {
 
+		console.log( properties)
 		var parameters = {};
 
 		if ( properties.BumpFactor ) {
@@ -434,6 +435,11 @@
 		if ( properties.Diffuse ) {
 
 			parameters.color = new THREE.Color().fromArray( properties.Diffuse.value );
+
+		} else if ( properties.DiffuseColor && properties.DiffuseColor.type === 'Color' ) {
+
+			// The blender exporter exports diffuse here instead of in properties.Diffuse
+			parameters.color = new THREE.Color().fromArray( properties.DiffuseColor.value );
 
 		}
 		if ( properties.DisplacementFactor ) {
@@ -450,6 +456,11 @@
 
 			parameters.specular = new THREE.Color().fromArray( properties.Specular.value );
 
+		} else if ( properties.SpecularColor && properties.SpecularColor.type === 'Color' ) {
+
+			// The blender exporter exports specular color here instead of in properties.Specular
+			parameters.emissive = new THREE.Color().fromArray( properties.SpecularColor.value );
+
 		}
 		if ( properties.Shininess ) {
 
@@ -459,6 +470,11 @@
 		if ( properties.Emissive ) {
 
 			parameters.emissive = new THREE.Color().fromArray( properties.Emissive.value );
+
+		} else if ( properties.EmissiveColor && properties.EmissiveColor.type === 'Color' ) {
+
+			// The blender exporter exports emissive color here instead of in properties.Emissive
+			parameters.emissive = new THREE.Color().fromArray( properties.EmissiveColor.value );
 
 		}
 		if ( properties.EmissiveFactor ) {


### PR DESCRIPTION
It seems like the blender exporter doesn't do colours quite the same as other exporters. Not sure if it's wrong though, or just unusual 😄  

So I've added support to the loader. This fixes #12649