### PR TITLE
FBXLoader: fix FarAttenuationEnd parsing

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1741,7 +1741,7 @@
 
 				} else {
 
-					distance = lightAttribute.FarAttenuationEnd.value / 1000;
+					distance = lightAttribute.FarAttenuationEnd.value;
 
 				}
 


### PR DESCRIPTION
As @HoldenCa  noted in #13179 the the light's FarAttenuationEnd  was incorrectly being divided by 1000, 