### PR TITLE
WebGLTexture: Refactored generateMipmaps usage.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -81,14 +81,12 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	}
 
-	function generateMipmap( texture, target ) {
+	function generateMipmap( target, texture, width, height ) {
 
 		_gl.generateMipmap( target );
 
-		// We assume images for cube map have the same size.
-		var image = Array.isArray( texture.image ) ? texture.image[ 0 ] : texture.image;
 		var textureProperties = properties.get( texture );
-		textureProperties.__maxMipLevel = Math.log2( Math.max( image.width, image.height ) );
+		textureProperties.__maxMipLevel = Math.log2( Math.max( width, height ) );
 
 	}
 
@@ -348,7 +346,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				if ( textureNeedsGenerateMipmaps( texture, isPowerOfTwoImage ) ) {
 
-					generateMipmap( texture, _gl.TEXTURE_CUBE_MAP );
+					// We assume images for cube map have the same size.
+					generateMipmap( _gl.TEXTURE_CUBE_MAP, texture, image.width, image.height );
 
 				}
 
@@ -603,7 +602,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( textureNeedsGenerateMipmaps( texture, isPowerOfTwoImage ) ) {
 
-			generateMipmap( texture, _gl.TEXTURE_2D );
+			generateMipmap( _gl.TEXTURE_2D, texture, image.width, image.height );
 
 		}
 
@@ -787,7 +786,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			if ( textureNeedsGenerateMipmaps( renderTarget.texture, isTargetPowerOfTwo ) ) {
 
-				generateMipmap( renderTarget.texture,  _gl.TEXTURE_CUBE_MAP );
+				generateMipmap( _gl.TEXTURE_CUBE_MAP, renderTarget.texture, renderTarget.width, renderTarget.height );
 
 			}
 
@@ -801,7 +800,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			if ( textureNeedsGenerateMipmaps( renderTarget.texture, isTargetPowerOfTwo ) ) {
 
-				generateMipmap( renderTarget.texture, _gl.TEXTURE_2D );
+				generateMipmap( _gl.TEXTURE_2D, renderTarget.texture, renderTarget.width, renderTarget.height );
 
 			}
 
@@ -830,7 +829,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			var webglTexture = properties.get( texture ).__webglTexture;
 
 			state.bindTexture( target, webglTexture );
-			generateMipmap( texture, target );
+			generateMipmap( target, texture, renderTarget.width, renderTarget.height );
 			state.bindTexture( target, null );
 
 		}


### PR DESCRIPTION
The current implementation crashed when the code tried to generate mipmaps for a `WebGLRenderTarget` because `rendertarget.texture.image` is undefined and the code was looking for `rendertarget.texture.image.width`.

FYI @takahirox 