### PR TITLE
OBJLoader2 V2.4.0: Parser polishing, ArrayBuffer handling (#13197), LoaderSupport clean-up

### DIFF
--- a/docs/examples/loaders/LoaderSupport.html
+++ b/docs/examples/loaders/LoaderSupport.html
@@ -19,11 +19,10 @@
 		[page:LoaderSupport.WorkerSupport]<br>
 		[page:LoaderSupport.WorkerRunnerRefImpl]<br>
 		[page:LoaderSupport.WorkerDirector]<br>
+		[page:LoaderSupport.ResourceDescriptor]<br>
 		[page:LoaderSupport.PrepData]<br>
-		[page:LoaderSupport.LoaderBase]<br>
 		[page:LoaderSupport.Callbacks]<br>
 		[page:LoaderSupport.Validator]<br>
-		[page:LoaderSupport.ConsoleLogger]
 
 
 		<h2>Example</h2>
@@ -45,6 +44,22 @@
 
 		<h2>Methods</h2>
 
+		<h3>[method:null setLogging] ( [param:Boolean enabled], [param:Boolean debug] )</h3>
+		<div>
+			[page:Boolean enabled] True or false.<br>
+			[page:Boolean debug] True or false.
+		</div>
+		<div>
+			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
+		</div>
+
+
+		<h3>[method:null init] ()</h3>
+		<div>
+			Initializes the Builder (currently only default material initialisation).
+		</div>
+
+
 		<h3>[method:null setMaterials] ( Array of [param:Material materials] )</h3>
 		<div>
 			Array of [page:Material materials] - Array of [page:Material Materials]
@@ -61,8 +76,6 @@
 		<div>
 			Delegates processing of the payload (mesh building or material update) to the corresponding functions (BW-compatibility).
 		</div>
-		<br>
-		<br>
 
 
 		<h3>[method:Array buildMeshes] ( Object meshPayload )</h3>
@@ -72,8 +85,6 @@
 		<div>
 			Builds one or multiple meshes from the data described in the payload (buffers, params, material info).
 		</div>
-		<br>
-		<br>
 
 
 		<h3>[method:null updateMaterials] ( Object materialPayload )</h3>
@@ -83,16 +94,12 @@
 		<div>
 			Updates the materials with contained material objects (sync) or from alteration instructions (async).
 		</div>
-		<br>
-		<br>
 
 
 		<h3>[method:Object getMaterialsJSON] ()</h3>
 		<div>
 			Returns the mapping object of material name and corresponding jsonified material.
 		</div>
-		<br>
-		<br>
 
 
 		<h3>[method:Object getMaterials] ()</h3>
@@ -144,10 +151,7 @@
 		<a name="WorkerSupport"></a><h1>WorkerSupport</h1>
 		<h2>Constructor</h2>
 
-		<h3>WorkerSupport( [param:LoaderSupport.ConsoleLogger logger] )</h3>
-		<div>
-			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
-		</div>
+		<h3>WorkerSupport()</h3>
 		<div>
 			This class provides means to transform existing parser code into a web worker.
 			It defines a simple communication protocol which allows to configure the worker and receive raw mesh data during execution.
@@ -155,6 +159,25 @@
 
 
 		<h2>Methods</h2>
+
+		<h3>[method:null setLogging]( [param:Boolean enabled], [param:Boolean debug] )</h3>
+		<div>
+			[page:Boolean enabled] True or false.<br>
+			[page:Boolean debug] True or false.
+		</div>
+		<div>
+			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
+		</div>
+
+
+		<h3>[method:null setForceWorkerDataCopy]( [param:Boolean forceWorkerDataCopy] )</h3>
+		<div>
+			[page:Boolean forceWorkerDataCopy] True or false.
+		</div>
+		<div>
+			Forces all ArrayBuffers to be transferred to worker to be copied.
+		</div>
+
 
 		<h3>[method:null validate] ( [param:Function functionCodeBuilder], Array of [param:String libLocations], [param:String libPath], [param:LoaderSupport.WorkerRunnerRefImpl runnerImpl] )</h3>
 		<div>
@@ -233,10 +256,9 @@
 		<a name="WorkerDirector"></a><h1>WorkerDirector</h1>
 		<h2>Constructor</h2>
 
-		<h3>WorkerDirector( [param:String classDef], [param:LoaderSupport.ConsoleLogger logger] )</h3>
+		<h3>WorkerDirector( [param:String classDef] )</h3>
 		<div>
-			[page:String classDef] - Class definition to be used for construction<br>
-			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
+			[page:String classDef] - Class definition to be used for construction
 		</div>
 		<div>
 			Orchestrate loading of multiple OBJ files/data from an instruction queue with a configurable amount of workers (1-16).<br>
@@ -249,6 +271,25 @@
 
 
 		<h2>Methods</h2>
+
+		<h3>[method:null setLogging]( [param:Boolean enabled], [param:Boolean debug] )</h3>
+		<div>
+			[page:Boolean enabled] True or false.<br>
+			[page:Boolean debug] True or false.
+		</div>
+		<div>
+			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
+		</div>
+
+
+		<h3>[method:null setForceWorkerDataCopy]( [param:Boolean forceWorkerDataCopy] )</h3>
+		<div>
+			[page:Boolean forceWorkerDataCopy] True or false.
+		</div>
+		<div>
+			Forces all ArrayBuffers to be transferred to worker to be copied.
+		</div>
+
 
 		<h3>[method:null prepareWorkers]( [param:WWOBJLoader2.Callbacks globalCallbacks], [param:Number maxQueueSize], [param:Number maxWebWorkers] )</h3>
 		<div>
@@ -309,6 +350,33 @@
 		<div>
 			Sets the CORS string to be used.
 		</div>
+		<br>
+		<br>
+
+
+		<a name="ResourceDescriptor"></a><h1>ResourceDescriptor</h1>
+		<h2>Constructor</h2>
+
+		<h3>ResourceDescriptor( [param:String url], [param:String extension] )</h3>
+		<div>
+			[page:String url] - URL to the file<br>
+			[page:String extension] - The file extension (type)
+		</div>
+		<div>
+			A resource description used by [page:LoaderSupport.PrepData] and others.
+		</div>
+
+		<h2>Methods</h2>
+
+		<h3>[method:null setContent]( [param:Object content )</h3>
+		<div>
+			[page:Object content] - The file content as ArrayBuffer or text
+		</div>
+		<div>
+			Set the content of this resource
+		</div>
+		<br>
+		<br>
 
 
 		<a name="PrepData"></a><h1>PrepData</h1>
@@ -325,39 +393,13 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setStreamMeshesTo] ( [param:Object3D streamMeshesTo] )</h3>
+		<h3>[method:null setLogging]( [param:Boolean enabled], [param:Boolean debug] )</h3>
 		<div>
-			[page:Object3D streamMeshesTo] - Object already attached to scenegraph where new meshes will be attached to
+			[page:Boolean enabled] True or false.<br>
+			[page:Boolean debug] True or false.
 		</div>
 		<div>
-			Set the node where the loaded objects will be attached directly.
-		</div>
-
-
-		<h3>[method:null setMaterialPerSmoothingGroup] ( [param:boolean materialPerSmoothingGroup] )</h3>
-		<div>
-			[page:boolean materialPerSmoothingGroup]
-		</div>
-		<div>
-			Tells whether a material shall be created per smoothing group.
-		</div>
-
-
-		<h3>[method:null setUseIndices]( [param:Boolean useIndices] )</h3>
-		<div>
-			[page:Boolean useIndices] - Default is false
-		</div>
-		<div>
-			Instructs loaders to create indexed [page:BufferGeometry].
-		</div>
-
-
-		<h3>[method:null setDisregardNormals]( [param:Boolean disregardNormals] )</h3>
-		<div>
-			[page:Boolean disregardNormals]
-		</div>
-		<div>
-			Tells whether normals should be completely disregarded and regenerated.
+			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
 		</div>
 
 
@@ -367,141 +409,29 @@
 		</div>
 
 
-		<h3>[method:null setCrossOrigin]( [param:String crossOrigin] )</h3>
-		<div>
-			[page:String crossOrigin] - CORS value
-		</div>
-		<div>
-			Sets the CORS string to be used.
-		</div>
-
-
 		<h3>[method:null addResource]( [param:LoaderSupport.ResourceDescriptor resource] )</h3>
 		<div>
-			[page:LoaderSupport.ResourceDescriptor resource]
+			[page:LoaderSupport.ResourceDescriptor resource] Adds a [page:LoaderSupport.ResourceDescriptor]
 		</div>
 		<div>
 			Add a resource description.
 		</div>
 
 
-		<h3>[method:null setUseAsync]( [param:Boolean useAsync] )</h3>
+		<h3>[method:null checkResourceDescriptorFiles] ( [param:LoaderSupport.ResourceDescriptor resources], [param:Object fileDesc] )</h3>
 		<div>
-			[page:Boolean useAsync]
-		</div>
-		<div>
-			If true uses async loading with worker, if false loads data synchronously.
-		</div>
-		<br>
-		<br>
-
-
-		<a name="LoaderBase"></a><h1>LoaderBase</h1>
-		<h2>Constructor</h2>
-
-		<h3>LoaderBase( [param:LoadingManager manager], [param:LoaderSupport.ConsoleLogger logger] )</h3>
-		<div>
-			[page:LoadingManager manager] - The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
-			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
-		</div>
-		<div>
-			Base class to be used by Loaders that provide load, parse, parseAsync and run
-		</div>
-
-
-		<h2>Methods</h2>
-
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError], [param:Function onMeshAlter], [param:boolean useAsync] )</h3>
-		<div>
-			[page:String url] - A string containing the path/URL of the file to be loaded.<br>
-			[page:Function onLoad] - A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br>
-			[page:Function onProgress] - (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br>
-			[page:Function onError] - (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br>
-			[page:Function onMeshAlter] - (optional) A function to be called after a new mesh raw data becomes available for alteration.<br>
-			[page:boolean useAsync] - (optional) If true, uses async loading with worker, if false loads data synchronously.
-		</div>
-		<div>
-			Use this convenient method to load a file at the given URL. By default the fileLoader uses an ArrayBuffer.
-		</div>
-
-		<h3>[method:ConsoleLogger checkResourceDescriptorFiles] ( [param:THREE.LoaderSupport.ResourceDescriptor resources], [param:Object fileDesc] )</h3>
-		<div>
-			[page:THREE.LoaderSupport.ResourceDescriptor resources] - Array of {@link THREE.LoaderSupport.ResourceDescriptor}
+			[page:LoaderSupport.ResourceDescriptor resources] - Array of [page:LoaderSupport.ResourceDescriptor]<br>
 			[page:Object fileDesc] - Object describing which resources are of interest (ext, type (string or UInt8Array) and ignore (boolean))
 		</div>
 		<div>
-			Identify files or content of interest from an Array of {@link THREE.LoaderSupport.ResourceDescriptor}. Returns Object with each "ext" and the corresponding {@link THREE.LoaderSupport.ResourceDescriptor}
-	 	</div>
-
-
-		<h3>[method:ConsoleLogger getLogger] ()</h3>
-		<div>
-			Returns [page:LoaderSupport.ConsoleLogger].
+			Identify files or content of interest from an Array of [page:LoaderSupport.ResourceDescriptor].
+			Returns Object with each "ext" and the corresponding [page:LoaderSupport.ResourceDescriptor]
 		</div>
 
 
-		<h3>[method:null setModelName] ( [param:String modelName] )</h3>
+		<h3>[method:PrepData clone] ()</h3>
 		<div>
-			[page:String modelName]
-		</div>
-		<div>
-			Set the name of the model.
-		</div>
-
-
-		<h3>[method:null setPath] ( [param:String path] )</h3>
-		<div>
-			[page:String path] - URL
-		</div>
-		<div>
-			The URL of the base path.
-		</div>
-
-
-		<h3>[method:null setStreamMeshesTo] ( [param:Object3D streamMeshesTo] )</h3>
-		<div>
-			[page:Object3D streamMeshesTo] - Object already attached to scenegraph where new meshes will be attached to
-		</div>
-		<div>
-			Set the node where the loaded objects will be attached directly.
-		</div>
-
-
-		<h3>[method:null setMaterials] ( Array of [param:Material materials] )</h3>
-		<div>
-			Array of [page:Material materials] - Array of [page:Material Materials]
-		</div>
-		<div>
-			Set materials loaded by MTLLoader or any other supplier of an Array of [page:Material Materials].
-		</div>
-
-
-		<h3>[method:null setUseIndices]( [param:Boolean useIndices] )</h3>
-		<div>
-			[page:Boolean useIndices]
-		</div>
-		<div>
-			Instructs loaders to create indexed [page:BufferGeometry].
-		</div>
-
-
-		<h3>[method:null setDisregardNormals]( [param:Boolean disregardNormals] )</h3>
-		<div>
-			[page:Boolean disregardNormals]
-		</div>
-		<div>
-			Tells whether normals should be completely disregarded and regenerated.
-		</div>
-
-
-		<h3>[method:null onProgress]( [param:String type], [param:String text], [param:Number numericalValue] )</h3>
-		<div>
-			[page:String type] - The type of event<br>
-			[page:String text] - Textual description of the event<br>
-			[page:Number numericalValue] - Numerical value describing the progress
-		</div>
-		<div>
-			Announce feedback which is give to the registered [page:LoaderSupport.Callbacks].
+			Clones this object and returns it afterwards. Callbacks and resources are not cloned deep (references!).
 		</div>
 		<br>
 		<br>
@@ -578,114 +508,11 @@
 
 		<h3>[method:null verifyInput]( [param:Object input], [param:Object defaultValue] )</h3>
 		<div>
-			[page:Object input] - Can be anything
+			[page:Object input] - Can be anything<br>
 			[page:Object defaultValue] - Can be anything
 		</div>
 		<div>
 			If given input is null or undefined, the defaultValue is returned otherwise the given input.
-		</div>
-		<br>
-		<br>
-
-
-		<a name="ConsoleLogger"></a><h1>ConsoleLogger</h1>
-		<h2>Constructor</h2>
-
-		<h3>ConsoleLogger( [param:Boolean enabled], [param:Boolean debug] )</h3>
-		<div>
-			[page:Boolean enabled] - Tell if logger is enabled.
-			[page:Boolean debug] - Toggle debug logging.
-		<div>
-			Logging wrapper for console.
-		</div>
-
-
-		<h2>Methods</h2>
-
-		<h3>[method:null setDebug]( [param:Boolean debug] )</h3>
-		<div>
-			[page:Boolean debug] - True or False
-		</div>
-		<div>
-			Enable or disable debug logging.
-		</div>
-
-
-		<h3>[method:Boolean isDebug]()</h3>
-		<div>
-			Returns if is enabled and debug.
-		</div>
-
-		<h3>[method:null setEnabled]( [param:Boolean enabled] )</h3>
-		<div>
-			[page:Boolean enabled] - True or False
-		</div>
-		<div>
-			Enable or disable info, debug and time logging.
-		</div>
-
-
-		<h3>[method:Boolean isEnabled]()</h3>
-		<div>
-			Returns if is enabled.
-		</div>
-
-
-		<h3>[method:null logDebug]( [param:String message], Array of [param:String additional] )</h3>
-		<div>
-			[page:String message] - Message to log
-			Array of [page:String additional] - Array of [page:String strings] containing additional content to be logged
-		</div>
-		<div>
-			Log a debug message if enabled and debug is set.
-		</div>
-
-
-		<h3>[method:null logInfo]( [param:String message], Array of [param:String additional] )</h3>
-		<div>
-			[page:String message] - Message to log
-			Array of [page:String additional] - Array of [page:String strings] containing additional content to be logged
-		</div>
-		<div>
-			Log an info message if enabled.
-		</div>
-
-
-		<h3>[method:null logWarn]( [param:String message], Array of [param:String additional] )</h3>
-		<div>
-			[page:String message] - Message to log
-			Array of [page:String additional] - Array of [page:String strings] containing additional content to be logged
-		</div>
-		<div>
-			Log a warn message (always).
-		</div>
-
-
-		<h3>[method:null logError]( [param:String message], Array of [param:String additional] )</h3>
-		<div>
-			[page:String message] - Message to log
-			Array of [page:String additional] - Array of [page:String strings] containing additional content to be logged
-		</div>
-		<div>
-			Log an error message (always).
-		</div>
-
-
-		<h3>[method:null logTimeStart]( [param:String id] )</h3>
-		<div>
-			[page:String id] - Time identification
-		</div>
-		<div>
-			Start time measurement with provided id.
-		</div>
-
-
-		<h3>[method:null logTimeEnd]( [param:String id] )</h3>
-		<div>
-			[page:String id] - Time identification
-		</div>
-		<div>
-			Stop time measurement started with provided id.
 		</div>
 		<br>
 		<br>

--- a/docs/examples/loaders/OBJLoader2.html
+++ b/docs/examples/loaders/OBJLoader2.html
@@ -71,7 +71,18 @@
 		</div>
 
 
-		<h3>[method:null load] => [param:LoaderSupport.LoaderBase.load]</h3>
+		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError], [param:Function onMeshAlter], [param:boolean useAsync] )</h3>
+		<div>
+			[page:String url] - A string containing the path/URL of the file to be loaded.<br>
+			[page:Function onLoad] - A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br>
+			[page:Function onProgress] - (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br>
+			[page:Function onError] - (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br>
+			[page:Function onMeshAlter] - (optional) A function to be called after a new mesh raw data becomes available for alteration.<br>
+			[page:boolean useAsync] - (optional) If true, uses async loading with worker, if false loads data synchronously.
+		</div>
+		<div>
+			Use this convenient method to load a file at the given URL. By default the fileLoader uses an ArrayBuffer.
+		</div>
 
 
 		<h3>[method:null run]( [param:LoaderSupport.PrepData params], [param:LoaderSupport.WorkerSupport workerSupportExternal] )</h3>
@@ -84,23 +95,13 @@
 		</div>
 
 
-		<h3>[method:Object checkResourceDescriptorFiles] => [param:LoaderSupport.LoaderBase.checkResourceDescriptorFiles]</h3>
-
-
-		<h3>[method:null setMaterialPerSmoothingGroup] ( [param:boolean materialPerSmoothingGroup] )</h3>
+		<h3>[method:null setLogging]( [param:Boolean enabled], [param:Boolean debug] )</h3>
 		<div>
-			[page:boolean materialPerSmoothingGroup]
+			[page:Boolean enabled] True or false.<br>
+			[page:Boolean debug] True or false.
 		</div>
 		<div>
-			Tells whether a material shall be created per smoothing group.
-		</div>
-
-
-		<h2>The following methods are inherited from [page:LoaderSupport.Commons]</h2>
-
-		<h3>[method:ConsoleLogger getLogger] ()</h3>
-		<div>
-			Returns [page:LoaderSupport.ConsoleLogger].
+			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
 		</div>
 
 
@@ -158,12 +159,32 @@
 		</div>
 
 
+		<h3>[method:null setMaterialPerSmoothingGroup] ( [param:boolean materialPerSmoothingGroup] )</h3>
+		<div>
+			[page:boolean materialPerSmoothingGroup]
+		</div>
+		<div>
+			Tells whether a material shall be created per smoothing group.
+		</div>
+
+
+		<h3>[method:null onProgress]( [param:String type], [param:String text], [param:Number numericalValue] )</h3>
+		<div>
+			[page:String type] - The type of event<br>
+			[page:String text] - Textual description of the event<br>
+			[page:Number numericalValue] - Numerical value describing the progress
+		</div>
+		<div>
+			Announce feedback which is give to the registered [page:LoaderSupport.Callbacks].
+		</div>
+
+
 		<h3>[method:null loadMtl]( [param:String url], [param:Object content], [param:Function callbackOnLoad], [param:String crossOrigin], [param:Object materialOptions]) </h3>
 		<div>
-			[page:String url] - URL to the file
-			[page:Object content] - The file content as arraybuffer or text
-			[page:Function callbackOnLoad] - Callback to be called after successful load
-			[page:String crossOrigin] - (optional) CORS value
+			[page:String url] - URL to the file<br>
+			[page:Object content] - The file content as arraybuffer or text<br>
+			[page:Function callbackOnLoad] - Callback to be called after successful load<br>
+			[page:String crossOrigin] - (optional) CORS value<br>
 			[page:Function materialOptions] - (optional) Set material loading options for MTLLoader
 		</div>
 		<div>

--- a/examples/models/obj/verify/verify.html
+++ b/examples/models/obj/verify/verify.html
@@ -160,14 +160,10 @@
 
 						objLoader2.setModelName( modelName );
 						objLoader2.setMaterials( materials );
-						var mats = objLoader2.builder.getMaterials();
-						var defaultPointMaterial = mats[ 'defaultPointMaterial' ];
-						defaultPointMaterial.sizeAttenuation = true;
-
-						objLoader2.getLogger().setDebug( true );
+						objLoader2.setLogging( true, false );
 						objLoader2.load( './verify.obj', callbackOnLoad, null, null, null, false );
 					};
-					objLoader2.loadMtl( './verify.mtl', null, onLoadMtl, null, { invertTrProperty: false } );
+					objLoader2.loadMtl( './verify.mtl', null, onLoadMtl );
 				};
 
 				OBJLoaderVerify.prototype._reportProgress = function( event ) {

--- a/examples/webgl_loader_obj2.html
+++ b/examples/webgl_loader_obj2.html
@@ -152,7 +152,7 @@
 					var onLoadMtl = function ( materials ) {
 						objLoader.setModelName( modelName );
 						objLoader.setMaterials( materials );
-						objLoader.getLogger().setDebug( true );
+						objLoader.setLogging( true, true );
 						objLoader.load( 'models/obj/female02/female02.obj', callbackOnLoad, null, null, null, false );
 					};
 					objLoader.loadMtl( 'models/obj/female02/female02.mtl', null, onLoadMtl );

--- a/examples/webgl_loader_obj2_meshspray.html
+++ b/examples/webgl_loader_obj2_meshspray.html
@@ -85,13 +85,35 @@
 
 			var MeshSpray = (function () {
 
-				MeshSpray.prototype = Object.create( THREE.LoaderSupport.LoaderBase.prototype );
-				MeshSpray.prototype.constructor = MeshSpray;
+				var Validator = THREE.LoaderSupport.Validator;
 
-				function MeshSpray( manager, logger ) {
-					THREE.LoaderSupport.LoaderBase.call( this, manager, logger );
+				function MeshSpray( manager ) {
+					this.manager = Validator.verifyInput( manager, THREE.DefaultLoadingManager );
+					this.logging = {
+						enabled: true,
+						debug: false
+					};
+
+					this.instanceNo = 0;
+					this.loaderRootNode = new THREE.Group();
+
+					this.meshBuilder = new THREE.LoaderSupport.MeshBuilder();
+					this.callbacks = new THREE.LoaderSupport.Callbacks();
 					this.workerSupport = null;
-					this.logger = new THREE.LoaderSupport.ConsoleLogger();
+				}
+
+				MeshSpray.prototype.setLogging = function ( enabled, debug ) {
+					this.logging.enabled = enabled === true;
+					this.logging.debug = debug === true;
+					this.meshBuilder.setLogging( this.logging.enabled, this.logging.debug );
+				};
+
+				MeshSpray.prototype.setStreamMeshesTo = function ( streamMeshesTo ) {
+					this.loaderRootNode = Validator.verifyInput( streamMeshesTo, this.loaderRootNode );
+				};
+
+				MeshSpray.prototype.setForceWorkerDataCopy = function ( forceWorkerDataCopy  ) {
+					// nothing to do here
 				};
 
 				MeshSpray.prototype.run = function ( prepData, workerSupportExternal ) {
@@ -99,21 +121,23 @@
 					if ( THREE.LoaderSupport.Validator.isValid( workerSupportExternal ) ) {
 
 						this.workerSupport = workerSupportExternal;
-						this.logger = workerSupportExternal.logger;
+						this.logging.enabled = this.workerSupport.logging.enabled;
+						this.logging.debug = this.workerSupport.logging.debug;
 
 					} else {
 
 						this.workerSupport = THREE.LoaderSupport.Validator.verifyInput( this.workerSupport, new THREE.LoaderSupport.WorkerSupport() );
 
 					}
-
-					this.logger.logTimeStart( 'MeshSpray' );
+					if ( this.logging.enabled ) console.time( 'MeshSpray' + this.instanceNo );
 
 					this._applyPrepData( prepData );
 
+					this.meshBuilder.init();
+
 					var scope = this;
 					var scopeBuilderFunc = function ( payload ) {
-						var meshes = scope.builder.processPayload( payload );
+						var meshes = scope.meshBuilder.processPayload( payload );
 						var mesh;
 						for ( var i in meshes ) {
 							mesh = meshes[ i ];
@@ -131,7 +155,7 @@
 								}
 							}
 						);
-						scope.logger.logTimeEnd( 'MeshSpray' );
+						if ( scope.logging.enabled ) console.timeEnd( 'MeshSpray' + scope.instanceNo );
 					};
 
 					var buildCode = function ( funcBuildObject, funcBuildSingleton ) {
@@ -141,7 +165,6 @@
 						workerCode += '  */\n\n';
 						workerCode += 'THREE.LoaderSupport = {};\n\n';
 						workerCode += funcBuildObject( 'THREE.LoaderSupport.Validator', THREE.LoaderSupport.Validator );
-						workerCode += funcBuildSingleton( 'THREE.LoaderSupport.ConsoleLogger', THREE.LoaderSupport.ConsoleLogger );
 						workerCode += funcBuildSingleton( 'Parser', Parser );
 
 						return workerCode;
@@ -157,11 +180,11 @@
 								globalObjectCount: prepData.globalObjectCount
 							},
 							materials: {
-								serializedMaterials: this.builder.getMaterialsJSON()
+								serializedMaterials: this.meshBuilder.getMaterialsJSON()
 							},
-							logger: {
-								debug: this.logger.debug,
-								enabled: this.logger.enabled
+							logging: {
+								enabled: this.logging.enabled,
+								debug: this.logging.debug
 							},
 							data: {
 								input: null,
@@ -170,6 +193,28 @@
 						}
 					);
 				};
+
+				MeshSpray.prototype._applyPrepData = function ( prepData ) {
+					if ( Validator.isValid( prepData ) ) {
+
+						this.setLogging( prepData.logging.enabled, prepData.logging.debug );
+						this.setStreamMeshesTo( prepData.streamMeshesTo );
+						this.meshBuilder.setMaterials( prepData.materials );
+						this._setCallbacks( prepData.getCallbacks() );
+
+					}
+				};
+
+				MeshSpray.prototype._setCallbacks = function ( callbacks ) {
+					if ( Validator.isValid( callbacks.onProgress ) ) this.callbacks.setCallbackOnProgress( callbacks.onProgress );
+					if ( Validator.isValid( callbacks.onMeshAlter ) ) this.callbacks.setCallbackOnMeshAlter( callbacks.onMeshAlter );
+					if ( Validator.isValid( callbacks.onLoad ) ) this.callbacks.setCallbackOnLoad( callbacks.onLoad );
+					if ( Validator.isValid( callbacks.onLoadMaterials ) ) this.callbacks.setCallbackOnLoadMaterials( callbacks.onLoadMaterials );
+
+					this.meshBuilder._setCallbacks( this.callbacks );
+				};
+
+
 
 				var Parser  = ( function () {
 
@@ -180,15 +225,18 @@
 						this.debug = false;
 						this.dimension = 200;
 						this.quantity = 1;
-						this.callbackBuilder = null;
+						this.callbackMeshBuilder = null;
 						this.callbackProgress = null;
-						this.logger = new THREE.LoaderSupport.ConsoleLogger();
 						this.serializedMaterials = null;
+						this.logging = {
+							enabled: true,
+							debug: false
+						};
 					};
 
-					Parser.prototype.setLogConfig = function ( enabled, debug ) {
-						this.logger.setEnabled( enabled );
-						this.logger.setDebug( debug );
+					Parser.prototype.setLogging = function ( enabled, debug ) {
+						this.logging.enabled = enabled === true;
+						this.logging.debug = debug === true;
 					};
 
 					Parser.prototype.parse = function () {
@@ -277,10 +325,10 @@
 								serializedMaterials: newSerializedMaterials
 							}
 						};
-						this.callbackBuilder( payload );
+						this.callbackMeshBuilder( payload );
 
 						this.globalObjectCount++;
-						this.callbackBuilder(
+						this.callbackMeshBuilder(
 							{
 								cmd: 'meshData',
 								progress: {
@@ -307,7 +355,7 @@
 							uvFA !== null ? [ uvFA.buffer ] : null
 						);
 
-						this.logger.logInfo( 'Global output object count: ' + this.globalObjectCount );
+						if ( this.logging.enabled ) console.info( 'Global output object count: ' + this.globalObjectCount );
 					};
 
 					return Parser;
@@ -394,16 +442,16 @@
 					var maxQueueSize = 1024;
 					var maxWebWorkers = 4;
 					var radius = 640;
-					var logger = new THREE.LoaderSupport.ConsoleLogger( false );
-					var workerDirector = new THREE.LoaderSupport.WorkerDirector( MeshSpray, logger );
+					var workerDirector = new THREE.LoaderSupport.WorkerDirector( MeshSpray );
+					workerDirector.setLogging( false, false );
 					workerDirector.setCrossOrigin( 'anonymous' );
 
 					var callbackOnLoad = function ( event ) {
-						logger.logInfo( 'Worker #' + event.detail.instanceNo + ': Completed loading. (#' + workerDirector.objectsCompleted + ')' );
+						console.info( 'Worker #' + event.detail.instanceNo + ': Completed loading. (#' + workerDirector.objectsCompleted + ')' );
 					};
 					var reportProgress = function( event ) {
 						document.getElementById( 'feedback' ).innerHTML = event.detail.text;
-						logger.logInfo( event.detail.text );
+						console.info( event.detail.text );
 					};
 					var callbackMeshAlter = function ( event ) {
 						var override = new THREE.LoaderSupport.LoadedMeshUserOverride( false, true );
@@ -439,7 +487,8 @@
 						z = r * Math.cos( t );
 						pivot.position.set( x, y, z );
 						this.scene.add( pivot );
-						prepData.setStreamMeshesTo( pivot );
+						prepData.streamMeshesTo = pivot;
+						prepData.setLogging( false, false );
 
 						prepData.quantity = 8192;
 						prepData.dimension = Math.max( Math.random() * 500, 100 );

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -277,7 +277,7 @@
 					local.position.set( 0, 0, 100 );
 					local.scale.set( 50.0, 50.0, 50.0 );
 					this.pivot.add( local );
-					prepData.setStreamMeshesTo( local );
+					prepData.streamMeshesTo = local;
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/cerberus/Cerberus.obj', 'OBJ' ) );
 					var callbacks = prepData.getCallbacks();
 					callbacks.setCallbackOnProgress( this._reportProgress );
@@ -298,9 +298,9 @@
 					local.position.set( 125, 50, 0 );
 					local.name = 'Pivot_vive-controller';
 					this.pivot.add( local );
-					prepData.setStreamMeshesTo( local );
+					prepData.streamMeshesTo = local;
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/vive-controller/vr_controller_vive_1_5.obj', 'OBJ' ) );
-					prepData.setUseAsync( true );
+					prepData.useAsync = true;
 					var callbacks = prepData.getCallbacks();
 					var callbackMeshAlter = function ( event ) {
 						var override = new THREE.LoaderSupport.LoadedMeshUserOverride( false, true );

--- a/examples/webgl_loader_obj2_run_director.html
+++ b/examples/webgl_loader_obj2_run_director.html
@@ -111,10 +111,14 @@
 					this.camera = null;
 					this.cameraTarget = this.cameraDefaults.posCameraTarget;
 
-					this.logger = new THREE.LoaderSupport.ConsoleLogger();
-					this.logger.setEnabled( false );
-					this.workerDirector = new THREE.LoaderSupport.WorkerDirector( THREE.OBJLoader2, this.logger );
+					this.workerDirector = new THREE.LoaderSupport.WorkerDirector( THREE.OBJLoader2 );
+					this.logging = {
+						enabled: false,
+						debug: false
+					};
+					this.workerDirector.setLogging( this.logging.enabled, this.logging.debug );
 					this.workerDirector.setCrossOrigin( 'anonymous' );
+					this.workerDirector.setForceWorkerDataCopy( true );
 
 					this.controls = null;
 					this.cube = null;
@@ -199,7 +203,7 @@
 					if ( Validator.isValid( content ) && Validator.isValid( content.detail ) ) output = content.detail.text;
 
 					output = Validator.verifyInput( output, '' );
-					this.logger.logInfo( 'Progress:\n\t' + output.replace(/\<br\>/g, '\n\t' ) );
+					if ( this.logging.enabled ) console.info( 'Progress:\n\t' + output.replace(/\<br\>/g, '\n\t' ) );
 					document.getElementById( 'feedback' ).innerHTML = output;
 				};
 
@@ -234,7 +238,7 @@
 						scope.allAssets.push( event.detail.loaderRootNode );
 
 						var msg = 'Worker #' + instanceNo + ': Completed loading: ' + event.detail.modelName + ' (#' + scope.workerDirector.objectsCompleted + ')';
-						scope.logger.logInfo( msg );
+						if ( scope.logging.enabled ) console.info( msg );
 						scope.feedbackArray[ instanceNo ] = msg;
 						scope._reportProgress( scope.feedbackArray.join( '\<br\>' ) );
 
@@ -247,7 +251,7 @@
 
 						if ( scope.reportDonwload[ instanceNo ] ) {
 							var msg = 'Worker #' + instanceNo + ': ' + text;
-							scope.logger.logInfo( msg );
+							if ( scope.logging.enabled ) console.info( msg );
 
 							scope.feedbackArray[ instanceNo ] = msg;
 							scope._reportProgress( scope.feedbackArray.join( '\<br\>' ) );
@@ -279,32 +283,37 @@
 					callbacks.setCallbackOnMeshAlter( callbackMeshAlter );
 
 					this.workerDirector.prepareWorkers( callbacks, maxQueueSize, maxWebWorkers );
-					this.logger.logInfo( 'Configuring WWManager with queue size ' + this.workerDirector.getMaxQueueSize() + ' and ' + this.workerDirector.getMaxWebWorkers() + ' workers.' );
+					if ( this.logging.enabled ) console.info( 'Configuring WWManager with queue size ' + this.workerDirector.getMaxQueueSize() + ' and ' + this.workerDirector.getMaxWebWorkers() + ' workers.' );
 
 					var modelPrepDatas = [];
 					prepData = new THREE.LoaderSupport.PrepData( 'male02' );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/male02/male02.obj', 'OBJ ') );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/male02/male02.mtl', 'MTL' ) );
+					prepData.setLogging( false, false );
 					modelPrepDatas.push( prepData );
 
 					prepData = new THREE.LoaderSupport.PrepData( 'female02' );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/female02/female02.obj', 'OBJ' ) );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/female02/female02.mtl', 'MTL' ) );
+					prepData.setLogging( false, false );
 					modelPrepDatas.push( prepData );
 
 					prepData = new THREE.LoaderSupport.PrepData( 'viveController' );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/vive-controller/vr_controller_vive_1_5.obj', 'OBJ' ) );
+					prepData.setLogging( false, false );
 					prepData.scale = 400.0;
 					modelPrepDatas.push( prepData );
 
 					prepData = new THREE.LoaderSupport.PrepData( 'cerberus' );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/cerberus/Cerberus.obj', 'OBJ' ) );
+					prepData.setLogging( false, false );
 					prepData.scale = 50.0;
 					modelPrepDatas.push( prepData );
 
 					prepData = new THREE.LoaderSupport.PrepData( 'WaltHead' );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/walt/WaltHead.obj', 'OBJ' ) );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/walt/WaltHead.mtl', 'MTL' ) );
+					prepData.setLogging( false, false );
 					modelPrepDatas.push( prepData );
 
 					var pivot;
@@ -319,6 +328,7 @@
 						modelPrepDataIndex = Math.floor( Math.random() * modelPrepDatas.length );
 
 						modelPrepData = modelPrepDatas[ modelPrepDataIndex ];
+						modelPrepData.useAsync = true;
 						scale = Validator.verifyInput( modelPrepData.scale, 0 );
 						modelPrepData = modelPrepData.clone();
 
@@ -330,12 +340,10 @@
 						);
 						if ( scale > 0 ) pivot.scale.set( scale, scale, scale );
 						this.scene.add( pivot );
-						modelPrepData.setStreamMeshesTo( pivot );
-						modelPrepData.setUseAsync( true );
+						modelPrepData.streamMeshesTo = pivot;
 
 						this.workerDirector.enqueueForRun( modelPrepData );
 					}
-
 					this.workerDirector.processQueue();
 				};
 
@@ -349,7 +357,7 @@
 
 							if ( storedObject3d === object3d ) return;
 
-							scope.logger.logInfo( 'Removing ' + object3d.name );
+							if ( scope.logging.enabled ) console.info( 'Removing ' + object3d.name );
 							scope.scene.remove( object3d );
 
 							if ( object3d.hasOwnProperty( 'geometry' ) ) object3d.geometry.dispose();


### PR DESCRIPTION
These are the things addressed:
- three.js issue #13197:
  - Added forceWorkerDataCopy to THREE.LoaderSupport.WorkerSupport and THREE.LoaderSupport.WorkerDirector
  - THREE.OBJLoader2 handles cached resources properly. This increases overall performance as no unnecessary reloads are requested.
- THREE.OBJLoader2: Reduced Parser complexity:
  - Simplified slash counting used for face type detection
  - One buildFace function is used for all four face types, lines and points including indices (=vertex reduction) creation if wanted.
  - String processing (o, g, mtllib and usemtl) just concatenates chars
  - Overall speed improvements due simpler code paths
- Removed THREE.LoaderSupport.ConsoleLogger: Added setLogging function as replacement where. Console logging is behind boolean flags.
- Removed THREE.LoaderSupport.LoaderBase: Many functions are coupled with OBJLoader2. It was simply not generic enough and added unneeded complexity.
- Reduced THREE.LoaderSupport.PrepData to minimum set of generic functions. Simple properties are added by demand and are no longer enforced.
- Renamed THREE.LoaderSupport.Builder to THREE.LoaderSupport.MeshBuilder
- Updated documentation

@mrdoob Existing examples, verify.obj and gathered OBJ models during bug-fixing are looking good. There are no obvious regressions. Performance was slightly improved, especially parallel usage. OBJ Parser code is really condensed now and I hope it is easier to follow and understand for others.

This represents an intermediate step. My idea for the future: Make OBJLoader2 independent of LoaderSupport. LoaderSupport or pieces of it and parts of OBJLoader2 become generic WorkerLoader. OBJLoader2 replaces OBJLoader. Of course, this requires further discussions and prototyping (R92 seems a good candidate, I personally would like to speed up things more, but this is a spare time activity, currently :blush: )