### PR TITLE
GLTFExporter: Multi-material support

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1015,7 +1015,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var forcedIndex = false;
+			var didForceIndices = false;
 
 			if ( geometry.index === null && forceIndices ) {
 
@@ -1029,7 +1029,7 @@ THREE.GLTFExporter.prototype = {
 
 				geometry.index = new THREE.Uint32BufferAttribute( indices, 1 );
 
-				forcedIndex = true;
+				didForceIndices = true;
 
 			}
 
@@ -1063,7 +1063,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			if ( forcedIndex ) {
+			if ( didForceIndices ) {
 
 				geometry.index = null;
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1036,8 +1036,7 @@ THREE.GLTFExporter.prototype = {
 			var materials = isMultiMaterial ? mesh.material : [ mesh.material ] ;
 			var groups = isMultiMaterial ? mesh.geometry.groups : [ { materialIndex: 0, start: undefined, count: undefined } ];
 
-			// assuming materials.length === groups.length
-			for ( var i = 0, il = materials.length; i < il; i ++ ) {
+			for ( var i = 0, il = groups.length; i < il; i ++ ) {
 
 				var primitive = {
 					mode: mode,

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1007,10 +1007,10 @@ THREE.GLTFExporter.prototype = {
 			var forceIndices = options.forceIndices;
 			var isMultiMaterial = Array.isArray( mesh.material );
 
-			if ( ! forceIndices && isMultiMaterial ) {
+			if ( ! forceIndices && geometry.index === null && isMultiMaterial ) {
 
 				// temporal workaround.
-				console.warn( 'THREE.GLTFExporter: Force index for a mesh with multi-material.', mesh );
+				console.warn( 'THREE.GLTFExporter: Creating index for non-indexed multi-material mesh.' );
 				forceIndices = true;
 
 			}

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -168,10 +168,12 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Get the min and max vectors from the given attribute
-		 * @param  {THREE.BufferAttribute} attribute Attribute to find the min/max
+		 * @param  {THREE.BufferAttribute} attribute Attribute to find the min/max in range from start to start + count
+		 * @param  {Integer} start
+		 * @param  {Integer} count
 		 * @return {Object} Object containing the `min` and `max` values (As an array of attribute.itemSize components)
 		 */
-		function getMinMax( attribute ) {
+		function getMinMax( attribute, start, count ) {
 
 			var output = {
 
@@ -180,7 +182,7 @@ THREE.GLTFExporter.prototype = {
 
 			};
 
-			for ( var i = 0; i < attribute.count; i ++ ) {
+			for ( var i = start; i < start + count; i ++ ) {
 
 				for ( var a = 0; a < attribute.itemSize; a ++ ) {
 
@@ -392,9 +394,11 @@ THREE.GLTFExporter.prototype = {
 		 * Process attribute to generate an accessor
 		 * @param  {THREE.BufferAttribute} attribute Attribute to process
 		 * @param  {THREE.BufferGeometry} geometry (Optional) Geometry used for truncated draw range
+		 * @param  {Integer} start (Optional)
+		 * @param  {Integer} count (Optional)
 		 * @return {Integer}           Index of the processed accessor on the "accessors" array
 		 */
-		function processAccessor( attribute, geometry ) {
+		function processAccessor( attribute, geometry, start, count ) {
 
 			if ( ! outputJSON.accessors ) {
 
@@ -433,18 +437,25 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var minMax = getMinMax( attribute );
-
-			var start = 0;
-			var count = attribute.count;
+			if ( start === undefined ) start = 0;
+			if ( count === undefined ) count = attribute.count;
 
 			// @TODO Indexed buffer geometry with drawRange not supported yet
 			if ( options.truncateDrawRange && geometry !== undefined && geometry.index === null ) {
 
-				start = geometry.drawRange.start;
-				count = geometry.drawRange.count !== Infinity ? geometry.drawRange.count : attribute.count;
+				var end = start + count;
+				var end2 = geometry.drawRange.count === Infinity
+						? attribute.count
+						: geometry.drawRange.start + geometry.drawRange.count;
+
+				start = Math.max( start, geometry.drawRange.start );
+				count = Math.min( end, end2 ) - start;
+
+				if ( count < 0 ) count = 0;
 
 			}
+
+			var minMax = getMinMax( attribute, start, count );
 
 			var bufferViewTarget;
 
@@ -452,8 +463,7 @@ THREE.GLTFExporter.prototype = {
 			// animation samplers, target must not be set.
 			if ( geometry !== undefined ) {
 
-				var isVertexAttributes = componentType === WEBGL_CONSTANTS.FLOAT;
-				bufferViewTarget = isVertexAttributes ? WEBGL_CONSTANTS.ARRAY_BUFFER : WEBGL_CONSTANTS.ELEMENT_ARRAY_BUFFER;
+				bufferViewTarget = attribute === geometry.index ? WEBGL_CONSTANTS.ELEMENT_ARRAY_BUFFER : WEBGL_CONSTANTS.ARRAY_BUFFER;
 
 			}
 
@@ -877,43 +887,11 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var gltfMesh = {
-				primitives: [
-					{
-						mode: mode,
-						attributes: {},
-					}
-				]
-			};
+			var gltfMesh = {};
 
-			var material = processMaterial( mesh.material );
-			if ( material !== null ) {
-
-				gltfMesh.primitives[ 0 ].material = material;
-
-			}
-
-
-			if ( geometry.index ) {
-
-				gltfMesh.primitives[ 0 ].indices = processAccessor( geometry.index, geometry );
-
-			} else if ( options.forceIndices ) {
-
-				var numFaces = geometry.attributes.position.count;
-				var indices = new Uint32Array( numFaces );
-				for ( var i = 0; i < numFaces; i ++ ) {
-
-					indices[ i ] = i;
-
-				}
-
-				gltfMesh.primitives[ 0 ].indices = processAccessor( new THREE.Uint32BufferAttribute( indices, 1 ), geometry );
-
-			}
-
-			// We've just one primitive per mesh
-			var gltfAttributes = gltfMesh.primitives[ 0 ].attributes;
+			var attributes = {};
+			var primitives = [];
+			var targets = [];
 
 			// Conversion between attributes names in threejs and gltf spec
 			var nameConversion = {
@@ -935,7 +913,7 @@ THREE.GLTFExporter.prototype = {
 
 				if ( attributeName.substr( 0, 5 ) !== 'MORPH' ) {
 
-					gltfAttributes[ attributeName ] = processAccessor( attribute, geometry );
+					attributes[ attributeName ] = processAccessor( attribute, geometry );
 
 				}
 
@@ -957,8 +935,6 @@ THREE.GLTFExporter.prototype = {
 					}
 
 				}
-
-				gltfMesh.primitives[ 0 ].targets = [];
 
 				for ( var i = 0; i < mesh.morphTargetInfluences.length; ++ i ) {
 
@@ -1010,7 +986,7 @@ THREE.GLTFExporter.prototype = {
 
 					}
 
-					gltfMesh.primitives[ 0 ].targets.push( target );
+					targets.push( target );
 
 					weights.push( mesh.morphTargetInfluences[ i ] );
 					if ( mesh.morphTargetDictionary !== undefined ) targetNames.push( reverseDictionary[ i ] );
@@ -1027,6 +1003,64 @@ THREE.GLTFExporter.prototype = {
 				}
 
 			}
+
+			var forcedIndex = false;
+
+			if ( geometry.index === null && options.forceIndices ) {
+
+				var numFaces = geometry.attributes.position.count;
+				var indices = new Uint32Array( numFaces );
+
+				for ( var i = 0; i < numFaces; i ++ ) {
+
+					indices[ i ] = i;
+
+				}
+
+				geometry.index = new THREE.Uint32BufferAttribute( indices, 1 );
+
+				forcedIndex = true;
+
+			}
+
+			var materials = Array.isArray( mesh.material ) ? mesh.material : [ mesh.material ] ;
+			var groups = Array.isArray( mesh.material ) ? mesh.geometry.groups : [ { materialIndex: 0, start: undefined, count: undefined } ];
+
+			// assuming materials.length === groups.length
+			for ( var i = 0, il = materials.length; i < il; i ++ ) {
+
+				var primitive = {
+					mode: mode,
+					attributes: attributes,
+				};
+
+				if ( targets.length > 0 ) primitive.targets = targets;
+
+				var material = processMaterial( materials[ groups[ i ].materialIndex ] );
+
+				if ( material !== null ) {
+
+					primitive.material = material;
+
+				}
+
+				if ( geometry.index !== null ) {
+
+					primitive.indices = processAccessor( geometry.index, geometry, groups[ i ].start, groups[ i ].count );
+
+				}
+
+				primitives.push( primitive );
+
+			}
+
+			if ( forcedIndex ) {
+
+				geometry.index = null;
+
+			}
+
+			gltfMesh.primitives = primitives;
 
 			outputJSON.meshes.push( gltfMesh );
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1005,8 +1005,9 @@ THREE.GLTFExporter.prototype = {
 			}
 
 			var forceIndices = options.forceIndices;
+			var isMultiMaterial = Array.isArray( mesh.material );
 
-			if ( ! forceIndices && Array.isArray( mesh.material ) ) {
+			if ( ! forceIndices && isMultiMaterial ) {
 
 				// temporal workaround.
 				console.warn( 'THREE.GLTFExporter: Force index for a mesh with multi-material.', mesh );
@@ -1032,8 +1033,8 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var materials = Array.isArray( mesh.material ) ? mesh.material : [ mesh.material ] ;
-			var groups = Array.isArray( mesh.material ) ? mesh.geometry.groups : [ { materialIndex: 0, start: undefined, count: undefined } ];
+			var materials = isMultiMaterial ? mesh.material : [ mesh.material ] ;
+			var groups = isMultiMaterial ? mesh.geometry.groups : [ { materialIndex: 0, start: undefined, count: undefined } ];
 
 			// assuming materials.length === groups.length
 			for ( var i = 0, il = materials.length; i < il; i ++ ) {

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1008,10 +1008,9 @@ THREE.GLTFExporter.prototype = {
 
 			if ( geometry.index === null && options.forceIndices ) {
 
-				var numFaces = geometry.attributes.position.count;
-				var indices = new Uint32Array( numFaces );
+				var indices = new Uint32Array( geometry.attributes.position.count );
 
-				for ( var i = 0; i < numFaces; i ++ ) {
+				for ( var i = 0, il = indices.length; i < il; i ++ ) {
 
 					indices[ i ] = i;
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1004,9 +1004,19 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
+			var forceIndices = options.forceIndices;
+
+			if ( ! forceIndices && Array.isArray( mesh.material ) ) {
+
+				// temporal workaround.
+				console.warn( 'THREE.GLTFExporter: Force index for a mesh with multi-material.', mesh );
+				forceIndices = true;
+
+			}
+
 			var forcedIndex = false;
 
-			if ( geometry.index === null && options.forceIndices ) {
+			if ( geometry.index === null && forceIndices ) {
 
 				var indices = new Uint32Array( geometry.attributes.position.count );
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1019,15 +1019,15 @@ THREE.GLTFExporter.prototype = {
 
 			if ( geometry.index === null && forceIndices ) {
 
-				var indices = new Uint32Array( geometry.attributes.position.count );
+				var indices = [];
 
-				for ( var i = 0, il = indices.length; i < il; i ++ ) {
+				for ( var i = 0, il = geometry.attributes.position.count; i < il; i ++ ) {
 
 					indices[ i ] = i;
 
 				}
 
-				geometry.index = new THREE.Uint32BufferAttribute( indices, 1 );
+				geometry.setIndex( indices );
 
 				didForceIndices = true;
 
@@ -1065,7 +1065,7 @@ THREE.GLTFExporter.prototype = {
 
 			if ( didForceIndices ) {
 
-				geometry.index = null;
+				geometry.setIndex( null );
 
 			}
 


### PR DESCRIPTION
This PR adds multi-material support to `GLTFExporter`. I'm happy if you try with your scene because I haven't verified this change with many enough scenes yet.

The exporter exports a mesh with multi-material as a mesh including the primitives which share the same attributes but have distinct material and indices.

Note that `GLTFLoader` doesn't build a mesh with multi-material from it yet but builds multi meshes in a group. We should update and enable `GLTFLoader` to handle multi-material, too.