### PR TITLE
Add node.js fast-path to THREE.LoaderUtils.decodeText

### DIFF
--- a/src/loaders/LoaderUtils.js
+++ b/src/loaders/LoaderUtils.js
@@ -12,6 +12,12 @@ var LoaderUtils = {
 
 		}
 
+		if ( typeof Buffer !== 'undefined' ) {
+
+			return new Buffer( array ).toString();
+
+		}
+
 		// Avoid the String.fromCharCode.apply(null, array) shortcut, which
 		// throws a "maximum call stack size exceeded" error for large arrays.
 


### PR DESCRIPTION
This gets a 70-megabyte ASCII STL file working for Wikimedia's
thumbnail rendering service, that previously errored out with
OOM conditions in the binary to string conversion.

Fixes https://github.com/mrdoob/three.js/issues/13540