### PR TITLE
GLTFExporter: Fix JSON chunk padding issue.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -141,17 +141,18 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var buffer = new ArrayBuffer( text.length );
+			var array = new Uint8Array( new ArrayBuffer( text.length ) );
 
-			var bufferView = new Uint8Array( buffer );
+			for ( var i = 0, il = text.length; i < il; i ++ ) {
 
-			for ( var i = 0; i < text.length; ++ i ) {
+				var value = text.charCodeAt( i );
 
-				bufferView[ i ] = text.charCodeAt( i );
+				// Replacing multi-byte character with space(0x20).
+				array[ i ] = value > 0xFF ? 0x20 : value
 
 			}
 
-			return buffer;
+			return array.buffer;
 
 		}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -227,9 +227,12 @@ THREE.GLTFExporter.prototype = {
 		 * Returns a buffer aligned to 4-byte boundary.
 		 *
 		 * @param {ArrayBuffer} arrayBuffer Buffer to pad
+		 * @param {Integer} padByte (Optional)
 		 * @returns {ArrayBuffer} The same buffer if it's already aligned to 4-byte boundary or a new buffer
 		 */
-		function getPaddedArrayBuffer( arrayBuffer ) {
+		function getPaddedArrayBuffer( arrayBuffer, padByte ) {
+
+			padByte = padByte || 0;
 
 			var paddedLength = getPaddedBufferSize( arrayBuffer.byteLength );
 
@@ -237,6 +240,17 @@ THREE.GLTFExporter.prototype = {
 
 				var array = new Uint8Array( paddedLength );
 				array.set( new Uint8Array( arrayBuffer ) );
+
+				if ( padByte !== 0 ) {
+
+					for ( var i = arrayBuffer.byteLength; i < paddedLength; i < il ) {
+
+						array[ i ] = padByte;
+
+					}
+
+				}
+
 				return array.buffer;
 
 			}

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -217,12 +217,12 @@ THREE.GLTFExporter.prototype = {
 		 * Returns a buffer aligned to 4-byte boundary.
 		 *
 		 * @param {ArrayBuffer} arrayBuffer Buffer to pad
-		 * @param {Integer} padByte (Optional)
+		 * @param {Integer} paddingByte (Optional)
 		 * @returns {ArrayBuffer} The same buffer if it's already aligned to 4-byte boundary or a new buffer
 		 */
-		function getPaddedArrayBuffer( arrayBuffer, padByte ) {
+		function getPaddedArrayBuffer( arrayBuffer, paddingByte ) {
 
-			padByte = padByte || 0;
+			paddingByte = paddingByte || 0;
 
 			var paddedLength = getPaddedBufferSize( arrayBuffer.byteLength );
 
@@ -231,11 +231,11 @@ THREE.GLTFExporter.prototype = {
 				var array = new Uint8Array( paddedLength );
 				array.set( new Uint8Array( arrayBuffer ) );
 
-				if ( padByte !== 0 ) {
+				if ( paddingByte !== 0 ) {
 
 					for ( var i = arrayBuffer.byteLength; i < paddedLength; i ++ ) {
 
-						array[ i ] = padByte;
+						array[ i ] = paddingByte;
 
 					}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -131,69 +131,38 @@ THREE.GLTFExporter.prototype = {
 		/**
 		 * Converts a string to an ArrayBuffer.
 		 * @param  {string} text
-		 * @param  {Boolean} padded
 		 * @return {ArrayBuffer}
 		 */
 		function stringToArrayBuffer( text, padded ) {
+			if ( padded ) {
 
-			var spaceCode = ' '.charCodeAt( 0 );
+				var pad = getPaddedBufferSize( text.length ) - text.length;
+
+				for ( var i = 0; i < pad; i++ ) {
+
+					text += ' ';
+
+				}
+
+			}
 
 			if ( window.TextEncoder !== undefined ) {
 
-				var view = new TextEncoder().encode( text );
-
-				if ( ! padded || ( view.length % 4 ) === 0 ) return view.buffer;
-
-				var view2 = new Uint8Array( new ArrayBuffer( getPaddedBufferSize( view.length ) ) );
-
-				for ( var i = 0, il = view.length; i < il; i ++ ) {
-
-					view2[ i ] = view[ i ];
-
-				}
-
-				// pad with space
-				for ( var i = view.length, il = view2.length; i < il; i ++ ) {
-
-					view2[ i ] = spaceCode;
-
-				}
-
-				return view2.buffer;
-
-			} else {
-
-				var length = padded ? getPaddedBufferSize( text.length ) : text.length;
-
-				var view = new Uint8Array( new ArrayBuffer( length ) );
-
-				for ( var i = 0, il = text.length; i < il; i ++ ) {
-
-					var value = text.charCodeAt( i );
-
-					if ( value > 0xFF ) {
-
-						// replace multi-byte string with space
-						view[ i ] = spaceCode;
-
-					} else {
-
-						view[ i ] = value;
-
-					}
-
-				}
-
-				// pad with space
-				for ( var i = text.length; i < length; i ++ ) {
-
-					view[ i ] = spaceCode;
-
-				}
-
-				return view.buffer;
+				return new TextEncoder().encode( text ).buffer;
 
 			}
+
+			var buffer = new ArrayBuffer( text.length );
+
+			var bufferView = new Uint8Array( buffer );
+
+			for ( var i = 0; i < text.length; ++ i ) {
+
+				bufferView[ i ] = text.charCodeAt( i );
+
+			}
+
+			return buffer;
 
 		}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -264,11 +264,11 @@ THREE.GLTFExporter.prototype = {
 
 			var paddedLength = getPaddedBufferSize( arrayBuffer.byteLength );
 
-			if (paddedLength !== arrayBuffer.byteLength ) {
+			if ( paddedLength !== arrayBuffer.byteLength ) {
 
-				var paddedBuffer = new ArrayBuffer( paddedLength );
-				new Uint8Array( paddedBuffer ).set(new Uint8Array(arrayBuffer));
-				return paddedBuffer;
+				var array = new Uint8Array( paddedLength );
+				array.set( new Uint8Array( arrayBuffer ) );
+				return array.buffer;
 
 			}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -233,7 +233,7 @@ THREE.GLTFExporter.prototype = {
 
 				if ( padByte !== 0 ) {
 
-					for ( var i = arrayBuffer.byteLength; i < paddedLength; i < il ) {
+					for ( var i = arrayBuffer.byteLength; i < paddedLength; i ++ ) {
 
 						array[ i ] = padByte;
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1548,7 +1548,7 @@ THREE.GLTFExporter.prototype = {
 						binaryChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_BIN, true );
 
 						// JSON chunk.
-						var jsonChunk = stringToArrayBuffer( JSON.stringify( outputJSON ), true );
+						var jsonChunk = getPaddedArrayBuffer( stringToArrayBuffer( JSON.stringify( outputJSON ), true ), 0x20 );
 						var jsonChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
 						jsonChunkPrefix.setUint32( 0, jsonChunk.byteLength, true );
 						jsonChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_JSON, true );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -133,18 +133,7 @@ THREE.GLTFExporter.prototype = {
 		 * @param  {string} text
 		 * @return {ArrayBuffer}
 		 */
-		function stringToArrayBuffer( text, padded ) {
-			if ( padded ) {
-
-				var pad = getPaddedBufferSize( text.length ) - text.length;
-
-				for ( var i = 0; i < pad; i++ ) {
-
-					text += ' ';
-
-				}
-
-			}
+		function stringToArrayBuffer( text ) {
 
 			if ( window.TextEncoder !== undefined ) {
 
@@ -1548,7 +1537,7 @@ THREE.GLTFExporter.prototype = {
 						binaryChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_BIN, true );
 
 						// JSON chunk.
-						var jsonChunk = getPaddedArrayBuffer( stringToArrayBuffer( JSON.stringify( outputJSON ), true ), 0x20 );
+						var jsonChunk = getPaddedArrayBuffer( stringToArrayBuffer( JSON.stringify( outputJSON ) ), 0x20 );
 						var jsonChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
 						jsonChunkPrefix.setUint32( 0, jsonChunk.byteLength, true );
 						jsonChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_JSON, true );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -131,38 +131,69 @@ THREE.GLTFExporter.prototype = {
 		/**
 		 * Converts a string to an ArrayBuffer.
 		 * @param  {string} text
+		 * @param  {Boolean} padded
 		 * @return {ArrayBuffer}
 		 */
 		function stringToArrayBuffer( text, padded ) {
-			if ( padded ) {
 
-				var pad = getPaddedBufferSize( text.length ) - text.length;
-
-				for ( var i = 0; i < pad; i++ ) {
-
-					text += ' ';
-
-				}
-
-			}
+			var spaceCode = ' '.charCodeAt( 0 );
 
 			if ( window.TextEncoder !== undefined ) {
 
-				return new TextEncoder().encode( text ).buffer;
+				var view = new TextEncoder().encode( text );
+
+				if ( ! padded || ( view.length % 4 ) === 0 ) return view.buffer;
+
+				var view2 = new Uint8Array( new ArrayBuffer( getPaddedBufferSize( view.length ) ) );
+
+				for ( var i = 0, il = view.length; i < il; i ++ ) {
+
+					view2[ i ] = view[ i ];
+
+				}
+
+				// pad with space
+				for ( var i = view.length, il = view2.length; i < il; i ++ ) {
+
+					view2[ i ] = spaceCode;
+
+				}
+
+				return view2.buffer;
+
+			} else {
+
+				var length = padded ? getPaddedBufferSize( text.length ) : text.length;
+
+				var view = new Uint8Array( new ArrayBuffer( length ) );
+
+				for ( var i = 0, il = text.length; i < il; i ++ ) {
+
+					var value = text.charCodeAt( i );
+
+					if ( value > 0xFF ) {
+
+						// replace multi-byte string with space
+						view[ i ] = spaceCode;
+
+					} else {
+
+						view[ i ] = value;
+
+					}
+
+				}
+
+				// pad with space
+				for ( var i = text.length; i < length; i ++ ) {
+
+					view[ i ] = spaceCode;
+
+				}
+
+				return view.buffer;
 
 			}
-
-			var buffer = new ArrayBuffer( text.length );
-
-			var bufferView = new Uint8Array( buffer );
-
-			for ( var i = 0; i < text.length; ++ i ) {
-
-				bufferView[ i ] = text.charCodeAt( i );
-
-			}
-
-			return buffer;
 
 		}
 


### PR DESCRIPTION
This PR fixes padding logic in `stringToArrayBuffer()` of `GLTFExporter` for multi-byte strings. The current logic doesn't take account of the possibility that `.name` can be multi-byte strings.