### PR TITLE
[WIP] Examples: Use ES6, build UMD examples.

### DIFF
--- a/examples/js/build.js
+++ b/examples/js/build.js
@@ -1,0 +1,49 @@
+const path = require( 'path' );
+const { spawn } = require( 'child_process' );
+const { StringDecoder } = require( 'string_decoder' );
+
+const ALL_FILES = {
+  GLTFLoader: 'loaders/GLTFLoader.js',
+  curves: 'curves/index.js'
+};
+
+let files = ALL_FILES;
+
+// default to all files, but support `node build.js TargetClass`
+if ( process.argv.length > 2 ) {
+
+  files = {};
+  files[ process.argv[ 2 ] ] = ALL_FILES[ process.argv[ 2 ] ];
+
+}
+
+console.log( 'rollup:' );
+
+Object.keys( files ).forEach( ( name ) => {
+
+  const inputPath = files[ name ];
+  const outputPath = inputPath.replace( path.basename( inputPath ), '' ) + name + '.js';
+
+  const umdTask = spawn( 'rollup', [
+    '-i', `examples/js/${ inputPath }`,
+    '-o', `build/examples/js/${ outputPath }`,
+    '-f', 'umd',
+    '-n', name,
+    '-g', 'three:THREE',
+    '--silent'
+  ] );
+
+  // propagate logs
+  const decoder = new StringDecoder( 'utf8' );
+  umdTask.stdout.on( 'data', ( data ) => console.log( decoder.write( data ) ) );
+  umdTask.stderr.on( 'data', ( data ) => console.warn( decoder.write( data ) ) );
+
+  umdTask.on( 'close', ( code ) => {
+
+    code
+      ? console.error( `  • error building ${ name }!` )
+      : console.info( `  • ${ name }` );
+
+  } );
+
+} );

--- a/examples/js/curves/NURBSCurve.js
+++ b/examples/js/curves/NURBSCurve.js
@@ -8,12 +8,14 @@
  *
  **/
 
+import * as THREE from 'three';
+import { NURBSUtils } from './NURBSUtils';
 
 /**************************************************************
  *	NURBS curve
  **************************************************************/
 
-THREE.NURBSCurve = function ( degree, knots /* array of reals */, controlPoints /* array of Vector(2|3|4) */, startKnot /* index in knots */, endKnot /* index in knots */ ) {
+var NURBSCurve = function ( degree, knots /* array of reals */, controlPoints /* array of Vector(2|3|4) */, startKnot /* index in knots */, endKnot /* index in knots */ ) {
 
 	THREE.Curve.call( this );
 
@@ -34,16 +36,16 @@ THREE.NURBSCurve = function ( degree, knots /* array of reals */, controlPoints 
 };
 
 
-THREE.NURBSCurve.prototype = Object.create( THREE.Curve.prototype );
-THREE.NURBSCurve.prototype.constructor = THREE.NURBSCurve;
+NURBSCurve.prototype = Object.create( THREE.Curve.prototype );
+NURBSCurve.prototype.constructor = NURBSCurve;
 
 
-THREE.NURBSCurve.prototype.getPoint = function ( t ) {
+NURBSCurve.prototype.getPoint = function ( t ) {
 
 	var u = this.knots[ this.startKnot ] + t * ( this.knots[ this.endKnot ] - this.knots[ this.startKnot ] ); // linear mapping t->u
 
 	// following results in (wx, wy, wz, w) homogeneous point
-	var hpoint = THREE.NURBSUtils.calcBSplinePoint( this.degree, this.knots, this.controlPoints, u );
+	var hpoint = NURBSUtils.calcBSplinePoint( this.degree, this.knots, this.controlPoints, u );
 
 	if ( hpoint.w != 1.0 ) {
 
@@ -57,13 +59,15 @@ THREE.NURBSCurve.prototype.getPoint = function ( t ) {
 };
 
 
-THREE.NURBSCurve.prototype.getTangent = function ( t ) {
+NURBSCurve.prototype.getTangent = function ( t ) {
 
 	var u = this.knots[ 0 ] + t * ( this.knots[ this.knots.length - 1 ] - this.knots[ 0 ] );
-	var ders = THREE.NURBSUtils.calcNURBSDerivatives( this.degree, this.knots, this.controlPoints, u, 1 );
+	var ders = NURBSUtils.calcNURBSDerivatives( this.degree, this.knots, this.controlPoints, u, 1 );
 	var tangent = ders[ 1 ].clone();
 	tangent.normalize();
 
 	return tangent;
 
 };
+
+export { NURBSCurve };

--- a/examples/js/curves/NURBSSurface.js
+++ b/examples/js/curves/NURBSSurface.js
@@ -6,12 +6,14 @@
  *
  **/
 
+import * as THREE from 'three';
+import { NURBSUtils } from './NURBSUtils';
 
 /**************************************************************
  *	NURBS surface
  **************************************************************/
 
-THREE.NURBSSurface = function ( degree1, degree2, knots1, knots2 /* arrays of reals */, controlPoints /* array^2 of Vector(2|3|4) */ ) {
+var NURBSSurface = function ( degree1, degree2, knots1, knots2 /* arrays of reals */, controlPoints /* array^2 of Vector(2|3|4) */ ) {
 
 	this.degree1 = degree1;
 	this.degree2 = degree2;
@@ -38,18 +40,18 @@ THREE.NURBSSurface = function ( degree1, degree2, knots1, knots2 /* arrays of re
 };
 
 
-THREE.NURBSSurface.prototype = {
+NURBSSurface.prototype = {
 
-	constructor: THREE.NURBSSurface,
+	constructor: NURBSSurface,
 
 	getPoint: function ( t1, t2 ) {
 
 		var u = this.knots1[ 0 ] + t1 * ( this.knots1[ this.knots1.length - 1 ] - this.knots1[ 0 ] ); // linear mapping t1->u
 		var v = this.knots2[ 0 ] + t2 * ( this.knots2[ this.knots2.length - 1 ] - this.knots2[ 0 ] ); // linear mapping t2->u
 
-		return THREE.NURBSUtils.calcSurfacePoint( this.degree1, this.degree2, this.knots1, this.knots2, this.controlPoints, u, v );
+		return NURBSUtils.calcSurfacePoint( this.degree1, this.degree2, this.knots1, this.knots2, this.controlPoints, u, v );
 
 	}
 };
 
-
+export { NURBSSurface };

--- a/examples/js/curves/NURBSUtils.js
+++ b/examples/js/curves/NURBSUtils.js
@@ -6,12 +6,13 @@
  *
  **/
 
+import * as THREE from 'three';
 
 /**************************************************************
  *	NURBS Utils
  **************************************************************/
 
-THREE.NURBSUtils = {
+var NURBSUtils = {
 
 	/*
 	Finds knot vector span.
@@ -19,7 +20,7 @@ THREE.NURBSUtils = {
 	p : degree
 	u : parametric value
 	U : knot vector
-	
+
 	returns the span
 	*/
 	findSpan: function( p,  u,  U ) {
@@ -43,7 +44,7 @@ THREE.NURBSUtils = {
 		var mid = Math.floor( ( low + high ) / 2 );
 
 		while ( u < U[ mid ] || u >= U[ mid + 1 ] ) {
-		  
+
 			if ( u < U[ mid ] ) {
 
 				high = mid;
@@ -61,16 +62,16 @@ THREE.NURBSUtils = {
 		return mid;
 
 	},
-    
-		
+
+
 	/*
 	Calculate basis functions. See The NURBS Book, page 70, algorithm A2.2
-   
+
 	span : span in which u lies
 	u    : parametric point
 	p    : degree
 	U    : knot vector
-	
+
 	returns array[p+1] with basis functions values.
 	*/
 	calcBasisFunctions: function( span, u, p, U ) {
@@ -81,7 +82,7 @@ THREE.NURBSUtils = {
 		N[ 0 ] = 1.0;
 
 		for ( var j = 1; j <= p; ++ j ) {
-	   
+
 			left[ j ] = u - U[ span + 1 - j ];
 			right[ j ] = U[ span + j ] - u;
 
@@ -108,7 +109,7 @@ THREE.NURBSUtils = {
 
 	/*
 	Calculate B-Spline curve points. See The NURBS Book, page 82, algorithm A3.1.
- 
+
 	p : degree of B-Spline
 	U : knot vector
 	P : control points (x, y, z, w)
@@ -422,7 +423,7 @@ THREE.NURBSUtils = {
 
 	/*
 	Calculate rational B-Spline surface point. See The NURBS Book, page 134, algorithm A4.3.
- 
+
 	p1, p2 : degrees of B-Spline surface
 	U1, U2 : knot vectors
 	P      : control points (x, y, z, w)
@@ -468,5 +469,4 @@ THREE.NURBSUtils = {
 
 };
 
-
-
+export { NURBSUtils };

--- a/examples/js/curves/index.js
+++ b/examples/js/curves/index.js
@@ -1,0 +1,9 @@
+import { NURBSCurve } from './NURBSCurve';
+import { NURBSSurface } from './NURBSSurface';
+import { NURBSUtils } from './NURBSUtils';
+
+export {
+  NURBSCurve,
+  NURBSSurface,
+  NURBSUtils
+};

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -5,8 +5,9 @@
  * @author Takahiro / https://github.com/takahirox
  * @author Don McCurdy / https://www.donmccurdy.com
  */
+import * as THREE from 'three';
 
-THREE.GLTFLoader = ( function () {
+var GLTFLoader = ( function () {
 
 	function GLTFLoader( manager ) {
 
@@ -2797,3 +2798,5 @@ THREE.GLTFLoader = ( function () {
 	return GLTFLoader;
 
 } )();
+
+export { GLTFLoader };


### PR DESCRIPTION
For #9562. I'm guessing this is more build process than we want, and no worries if that's the case, but I wanted to suggest this as an alternative to the other way around (write UMD, build ES6) because it has some interesting pros/cons.

I manually changed a couple examples to ES6 modules, then wrote a script to compile them to UMD modules. The UMD modules work in script tags or CommonJS. Build created as follows:

```shell
# build all
node examples/js/build.js 

# build GLTFLoader.js
node examples/js/build.js GLTFLoader
```

**Pros:**
- Examples can be written like the rest of the library.
- Examples can depend on other examples.
- Examples can be bundled:

```html
<script src="build/examples/js/nodes/nodes.js"></script>
```
```js
import { NodeMaterial, InputNode } from 'three/examples/js/nodes/'
```
**Cons:**
- `threejs.org/examples/*.html` must point at `build/examples/js/*.js`, and won't "just work" for testing PRs with RawGit.
- Examples must be rebuilt with each release, or on some other cycle.