### PR TITLE
Triangle: Rename methods

### DIFF
--- a/docs/api/deprecated/DeprecatedList.html
+++ b/docs/api/deprecated/DeprecatedList.html
@@ -363,6 +363,15 @@
 			Ray.isIntersectionSphere has been renamed to [page:Ray.intersectsSphere].
 		</div>
 
+		<h3>[page:Triangle]</h3>
+		<div>
+			Triangle.area() has been renamed to [page:Triangle.getArea]().<br /><br />
+			Triangle.barycoordFromPoint() has been renamed to [page:Triangle.getBarycoord]().<br /><br />
+			Triangle.midpoint() has been renamed to [page:Triangle.getMidpoint]().<br /><br />
+			Triangle.normal() has been renamed to [page:Triangle.getNormal]().<br /><br />
+			Triangle.plane() has been renamed to [page:Triangle.getPlane]().
+		</div>
+
 		<h3>[page:Vector2]</h3>
 		<div>
 			Vector2.fromAttribute() has been renamed to [page:Vector2.fromBufferAttribute]().

--- a/docs/api/math/Triangle.html
+++ b/docs/api/math/Triangle.html
@@ -48,20 +48,6 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Float area]()</h3>
-		<div>Return the area of the triangle.</div>
-
-		<h3>[method:Vector3 barycoordFromPoint]( [param:Vector3 point], [param:Vector3 target] )</h3>
-		<div>
-		[page:Vector3 point] - [page:Vector3] <br />
-		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
-
-		Return a [link:https://en.wikipedia.org/wiki/Barycentric_coordinate_system barycentric coordinate]
-		 from the given vector. <br/><br/>
-
-		[link:http://commons.wikimedia.org/wiki/File:Barycentric_coordinates_1.png Picture of barycentric coordinates]
-	</div>
-
 		<h3>[method:Triangle clone]()</h3>
 		<div>
 			Returns a new triangle with the same [page:.a a], [page:.b b] and  [page:.c c] properties as this one.
@@ -69,7 +55,7 @@
 
 		<h3>[method:Vector3 closestPointToPoint]( [param:Vector3 point], [param:Vector3 target] )</h3>
 		<div>
-		point - [page:Vector3] <br />
+		[page:Vector3 point] - [page:Vector3] <br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns the closest point on the triangle to [page:Vector3 point].
@@ -93,32 +79,46 @@
 		Returns true if the two triangles have identical [page:.a a], [page:.b b] and [page:.c c] properties.
 		</div>
 
-		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
-		<div>
-		[page:Box3 box] - Box to check for intersection against.<br /><br />
+		<h3>[method:Float getArea]()</h3>
+		<div>Return the area of the triangle.</div>
 
-		Determines whether or not this triangle intersects [page:Box3 box].
+		<h3>[method:Vector3 getBarycoord]( [param:Vector3 point], [param:Vector3 target] )</h3>
+		<div>
+		[page:Vector3 point] - [page:Vector3] <br />
+		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
+
+		Return a [link:https://en.wikipedia.org/wiki/Barycentric_coordinate_system barycentric coordinate]
+		 from the given vector. <br/><br/>
+
+		[link:http://commons.wikimedia.org/wiki/File:Barycentric_coordinates_1.png Picture of barycentric coordinates]
 		</div>
 
-		<h3>[method:Vector3 midpoint]( [param:Vector3 target] )</h3>
+		<h3>[method:Vector3 getMidpoint]( [param:Vector3 target] )</h3>
 		<div>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Calculate the midpoint of the triangle.
 		</div>
 
-		<h3>[method:Vector3 normal]( [param:Vector3 target] )</h3>
+		<h3>[method:Vector3 getNormal]( [param:Vector3 target] )</h3>
 		<div>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Calculate the [link:https://en.wikipedia.org/wiki/Normal_(geometry) normal vector] of the triangle.
 		</div>
 
-		<h3>[method:Plane plane]( [param:Plane target] )</h3>
+		<h3>[method:Plane getPlane]( [param:Plane target] )</h3>
 		<div>
-		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
+		[page:Vector3 target] — the result will be copied into this Plane.<br /><br />
 
-		Create a [page:Plane plane] based on the triangle. .
+		Calculate a [page:Plane plane] based on the triangle. .
+		</div>
+
+		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
+		<div>
+		[page:Box3 box] - Box to check for intersection against.<br /><br />
+
+		Determines whether or not this triangle intersects [page:Box3 box].
 		</div>
 
 		<h3>[method:Triangle set]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c] ) [param:Triangle this]</h3>

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -3702,11 +3702,11 @@
           "!type": "fn(a: +THREE.Vector3, b: +THREE.Vector3, c: +THREE.Vector3) -> +THREE.Triangle",
           "!doc": "Sets the triangle's vectors to the passed vectors."
         },
-        "normal": {
+        "getNormal": {
           "!type": "fn(optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
           "!doc": "Return the calculated normal of the triangle."
         },
-        "barycoordFromPoint": {
+        "getBarycoord": {
           "!type": "fn(point: +THREE.Vector3, optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
           "!doc": "Return a barycentric coordinate from the given vector. <br><br>\n\t\t[link:http://commons.wikimedia.org/wiki/File:Barycentric_coordinates_1.png](Picture of barycentric coordinates)"
         },
@@ -3714,11 +3714,11 @@
           "!type": "fn() -> +THREE.Triangle",
           "!doc": "Return a new copy of this triangle."
         },
-        "area": {
+        "getArea": {
           "!type": "fn() -> number",
           "!doc": "Return the area of the triangle."
         },
-        "midpoint": {
+        "getMidpoint": {
           "!type": "fn(optionalTarget: +THREE.Vector3) -> +THREE.Vector3",
           "!doc": "Return the midpoint of the triangle. Optionally sets a target vector."
         },
@@ -3726,7 +3726,7 @@
           "!type": "fn(triangle: +THREE.Triangle) -> bool",
           "!doc": "Checks to see if two triangles are equal (share the same vectors)."
         },
-        "plane": {
+        "getPlane": {
           "!type": "fn(optionalTarget: +THREE.Plane) -> +THREE.Plane",
           "!doc": "Return a [page:Plane plane] based on the triangle. Optionally sets a target plane."
         },

--- a/examples/js/QuickHull.js
+++ b/examples/js/QuickHull.js
@@ -917,9 +917,9 @@
 
 				triangle.set( a.point, b.point, c.point );
 
-				triangle.normal( this.normal );
-				triangle.midpoint( this.midpoint );
-				this.area = triangle.area();
+				triangle.getNormal( this.normal );
+				triangle.getMidpoint( this.midpoint );
+				this.area = triangle.getArea();
 
 				this.constant = this.normal.dot( this.midpoint );
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -59,6 +59,7 @@ import { Matrix4 } from './math/Matrix4.js';
 import { Plane } from './math/Plane.js';
 import { Quaternion } from './math/Quaternion.js';
 import { Ray } from './math/Ray.js';
+import { Triangle } from './math/Triangle.js';
 import { Vector2 } from './math/Vector2.js';
 import { Vector3 } from './math/Vector3.js';
 import { Vector4 } from './math/Vector4.js';
@@ -705,6 +706,58 @@ Object.assign( Ray.prototype, {
 
 		console.warn( 'THREE.Ray: .isIntersectionSphere() has been renamed to .intersectsSphere().' );
 		return this.intersectsSphere( sphere );
+
+	}
+
+} );
+
+Object.assign( Triangle.prototype, {
+
+	area: function () {
+
+		console.warn( 'THREE.Triangle: .area() has been renamed to .getArea().' );
+		return this.getArea();
+
+	},
+	barycoordFromPoint: function ( point, target ) {
+
+		console.warn( 'THREE.Triangle: .barycoordFromPoint() has been renamed to .getBarycoord().' );
+		return this.getBarycoord( point, target );
+
+	},
+	midpoint: function ( target ) {
+
+		console.warn( 'THREE.Triangle: .midpoint() has been renamed to .getMidpoint().' );
+		return this.getMidpoint( target );
+
+	},
+	normal: function ( target ) {
+
+		console.warn( 'THREE.Triangle: .normal() has been renamed to .getNormal().' );
+		return this.getNormal( target );
+
+	},
+	plane: function ( target ) {
+
+		console.warn( 'THREE.Triangle: .plane() has been renamed to .getPlane().' );
+		return this.getPlane( target );
+
+	}
+
+} );
+
+Object.assign( Triangle, {
+
+	barycoordFromPoint: function ( point, a, b, c, target ) {
+
+		console.warn( 'THREE.Triangle: .barycoordFromPoint() has been renamed to .getBarycoord().' );
+		return Triangle.getBarycoord( point, a, b, c, target );
+
+	},
+	normal: function ( a, b, c, target ) {
+
+		console.warn( 'THREE.Triangle: .normal() has been renamed to .getNormal().' );
+		return Triangle.getNormal( a, b, c, target );
 
 	}
 

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -17,15 +17,15 @@ function Triangle( a, b, c ) {
 
 Object.assign( Triangle, {
 
-	normal: function () {
+	getNormal: function () {
 
 		var v0 = new Vector3();
 
-		return function normal( a, b, c, target ) {
+		return function getNormal( a, b, c, target ) {
 
 			if ( target === undefined ) {
 
-				console.warn( 'THREE.Triangle: .normal() target is now required' );
+				console.warn( 'THREE.Triangle: .getNormal() target is now required' );
 				target = new Vector3();
 
 			}
@@ -49,13 +49,13 @@ Object.assign( Triangle, {
 
 	// static/instance method to calculate barycentric coordinates
 	// based on: http://www.blackpawn.com/texts/pointinpoly/default.html
-	barycoordFromPoint: function () {
+	getBarycoord: function () {
 
 		var v0 = new Vector3();
 		var v1 = new Vector3();
 		var v2 = new Vector3();
 
-		return function barycoordFromPoint( point, a, b, c, target ) {
+		return function getBarycoord( point, a, b, c, target ) {
 
 			v0.subVectors( c, a );
 			v1.subVectors( b, a );
@@ -71,7 +71,7 @@ Object.assign( Triangle, {
 
 			if ( target === undefined ) {
 
-				console.warn( 'THREE.Triangle: .barycoordFromPoint() target is now required' );
+				console.warn( 'THREE.Triangle: .getBarycoord() target is now required' );
 				target = new Vector3();
 
 			}
@@ -102,7 +102,7 @@ Object.assign( Triangle, {
 
 		return function containsPoint( point, a, b, c ) {
 
-			Triangle.barycoordFromPoint( point, a, b, c, v1 );
+			Triangle.getBarycoord( point, a, b, c, v1 );
 
 			return ( v1.x >= 0 ) && ( v1.y >= 0 ) && ( ( v1.x + v1.y ) <= 1 );
 
@@ -150,12 +150,12 @@ Object.assign( Triangle.prototype, {
 
 	},
 
-	area: function () {
+	getArea: function () {
 
 		var v0 = new Vector3();
 		var v1 = new Vector3();
 
-		return function area() {
+		return function getArea() {
 
 			v0.subVectors( this.c, this.b );
 			v1.subVectors( this.a, this.b );
@@ -166,11 +166,11 @@ Object.assign( Triangle.prototype, {
 
 	}(),
 
-	midpoint: function ( target ) {
+	getMidpoint: function ( target ) {
 
 		if ( target === undefined ) {
 
-			console.warn( 'THREE.Triangle: .midpoint() target is now required' );
+			console.warn( 'THREE.Triangle: .getMidpoint() target is now required' );
 			target = new Vector3();
 
 		}
@@ -179,17 +179,17 @@ Object.assign( Triangle.prototype, {
 
 	},
 
-	normal: function ( target ) {
+	getNormal: function ( target ) {
 
-		return Triangle.normal( this.a, this.b, this.c, target );
+		return Triangle.getNormal( this.a, this.b, this.c, target );
 
 	},
 
-	plane: function ( target ) {
+	getPlane: function ( target ) {
 
 		if ( target === undefined ) {
 
-			console.warn( 'THREE.Triangle: .plane() target is now required' );
+			console.warn( 'THREE.Triangle: .getPlane() target is now required' );
 			target = new Vector3();
 
 		}
@@ -198,9 +198,9 @@ Object.assign( Triangle.prototype, {
 
 	},
 
-	barycoordFromPoint: function ( point, target ) {
+	getBarycoord: function ( point, target ) {
 
-		return Triangle.barycoordFromPoint( point, this.a, this.b, this.c, target );
+		return Triangle.getBarycoord( point, this.a, this.b, this.c, target );
 
 	},
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -147,7 +147,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		function uvIntersection( point, p1, p2, p3, uv1, uv2, uv3 ) {
 
-			Triangle.barycoordFromPoint( point, p1, p2, p3, barycoord );
+			Triangle.getBarycoord( point, p1, p2, p3, barycoord );
 
 			uv1.multiplyScalar( barycoord.x );
 			uv2.multiplyScalar( barycoord.y );
@@ -211,7 +211,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 				}
 
 				var face = new Face3( a, b, c );
-				Triangle.normal( vA, vB, vC, face.normal );
+				Triangle.getNormal( vA, vB, vC, face.normal );
 
 				intersection.face = face;
 				intersection.faceIndex = a;

--- a/test/unit/src/math/Triangle.tests.js
+++ b/test/unit/src/math/Triangle.tests.js
@@ -123,16 +123,13 @@ export default QUnit.module( 'Maths', () => {
 			var a = new Triangle();
 			var midpoint = new Vector3();
 
-			a.getMidpoint( midpoint );
-			assert.ok( midpoint.equals( new Vector3( 0, 0, 0 ) ), "Passed!" );
+			assert.ok( a.getMidpoint( midpoint ).equals( new Vector3( 0, 0, 0 ) ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
-			a.getMidpoint( midpoint );
-			assert.ok( midpoint.equals( new Vector3( 1 / 3, 1 / 3, 0 ) ), "Passed!" );
+			assert.ok( a.getMidpoint( midpoint ).equals( new Vector3( 1 / 3, 1 / 3, 0 ) ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 2 ) );
-			a.getMidpoint( midpoint );
-			assert.ok( midpoint.equals( new Vector3( 2 / 3, 0, 2 / 3 ) ), "Passed!" );
+			assert.ok( a.getMidpoint( midpoint ).equals( new Vector3( 2 / 3, 0, 2 / 3 ) ), "Passed!" );
 
 		} );
 
@@ -141,16 +138,13 @@ export default QUnit.module( 'Maths', () => {
 			var a = new Triangle();
 			var normal = new Vector3();
 
-			a.getNormal( normal );
-			assert.ok( normal.equals( new Vector3( 0, 0, 0 ) ), "Passed!" );
+			assert.ok( a.getNormal( normal ).equals( new Vector3( 0, 0, 0 ) ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
-			a.getNormal( normal );
-			assert.ok( normal.equals( new Vector3( 0, 0, 1 ) ), "Passed!" );
+			assert.ok( a.getNormal( normal ).equals( new Vector3( 0, 0, 1 ) ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 2 ) );
-			a.getNormal( normal );
-			assert.ok( normal.equals( new Vector3( 0, 1, 0 ) ), "Passed!" );
+			assert.ok( a.getNormal( normal ).equals( new Vector3( 0, 1, 0 ) ), "Passed!" );
 
 		} );
 

--- a/test/unit/src/math/Triangle.tests.js
+++ b/test/unit/src/math/Triangle.tests.js
@@ -6,6 +6,7 @@
 
 import { Triangle } from '../../../../src/math/Triangle';
 import { Box3 } from '../../../../src/math/Box3';
+import { Plane } from '../../../../src/math/Plane';
 import { Vector3 } from '../../../../src/math/Vector3';
 import {
 	zero3,
@@ -33,13 +34,13 @@ export default QUnit.module( 'Maths', () => {
 		} );
 
 		// STATIC STUFF
-		QUnit.todo( "normal", ( assert ) => {
+		QUnit.todo( "getNormal", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
-		QUnit.todo( "barycoordFromPoint", ( assert ) => {
+		QUnit.todo( "getBarycoord", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
@@ -99,123 +100,158 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( "area", ( assert ) => {
+		QUnit.test( "getArea", ( assert ) => {
 
 			var a = new Triangle();
 
-			assert.ok( a.area() == 0, "Passed!" );
+			assert.ok( a.getArea() == 0, "Passed!" );
 
 			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
-			assert.ok( a.area() == 0.5, "Passed!" );
+			assert.ok( a.getArea() == 0.5, "Passed!" );
 
 			var a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 2 ) );
-			assert.ok( a.area() == 2, "Passed!" );
+			assert.ok( a.getArea() == 2, "Passed!" );
 
 			// colinear triangle.
 			var a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 3, 0, 0 ) );
-			assert.ok( a.area() == 0, "Passed!" );
+			assert.ok( a.getArea() == 0, "Passed!" );
 
 		} );
 
-		QUnit.test( "midpoint", ( assert ) => {
+		QUnit.test( "getMidpoint", ( assert ) => {
 
 			var a = new Triangle();
+			var midpoint = new Vector3();
 
-			assert.ok( a.midpoint().equals( new Vector3( 0, 0, 0 ) ), "Passed!" );
+			a.getMidpoint( midpoint );
+			assert.ok( midpoint.equals( new Vector3( 0, 0, 0 ) ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
-			assert.ok( a.midpoint().equals( new Vector3( 1 / 3, 1 / 3, 0 ) ), "Passed!" );
+			a.getMidpoint( midpoint );
+			assert.ok( midpoint.equals( new Vector3( 1 / 3, 1 / 3, 0 ) ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 2 ) );
-			assert.ok( a.midpoint().equals( new Vector3( 2 / 3, 0, 2 / 3 ) ), "Passed!" );
+			a.getMidpoint( midpoint );
+			assert.ok( midpoint.equals( new Vector3( 2 / 3, 0, 2 / 3 ) ), "Passed!" );
 
 		} );
 
-		QUnit.test( "normal", ( assert ) => {
+		QUnit.test( "getNormal", ( assert ) => {
 
 			var a = new Triangle();
+			var normal = new Vector3();
 
-			assert.ok( a.normal().equals( new Vector3( 0, 0, 0 ) ), "Passed!" );
+			a.getNormal( normal );
+			assert.ok( normal.equals( new Vector3( 0, 0, 0 ) ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
-			assert.ok( a.normal().equals( new Vector3( 0, 0, 1 ) ), "Passed!" );
+			a.getNormal( normal );
+			assert.ok( normal.equals( new Vector3( 0, 0, 1 ) ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 2 ) );
-			assert.ok( a.normal().equals( new Vector3( 0, 1, 0 ) ), "Passed!" );
+			a.getNormal( normal );
+			assert.ok( normal.equals( new Vector3( 0, 1, 0 ) ), "Passed!" );
 
 		} );
 
-		QUnit.test( "plane", ( assert ) => {
+		QUnit.test( "getPlane", ( assert ) => {
 
 			var a = new Triangle();
+			var plane = new Plane();
+			var normal = new Vector3();
 
-			assert.notOk( isNaN( a.plane().distanceToPoint( a.a ) ), "Passed!" );
-			assert.notOk( isNaN( a.plane().distanceToPoint( a.b ) ), "Passed!" );
-			assert.notOk( isNaN( a.plane().distanceToPoint( a.c ) ), "Passed!" );
-			assert.notPropEqual( a.plane().normal, {
+			a.getPlane( plane );
+			assert.notOk( isNaN( plane.distanceToPoint( a.a ) ), "Passed!" );
+			assert.notOk( isNaN( plane.distanceToPoint( a.b ) ), "Passed!" );
+			assert.notOk( isNaN( plane.distanceToPoint( a.c ) ), "Passed!" );
+			assert.notPropEqual( plane.normal, {
 				x: NaN,
 				y: NaN,
 				z: NaN
 			}, "Passed!" );
 
 			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
-			assert.ok( a.plane().distanceToPoint( a.a ) == 0, "Passed!" );
-			assert.ok( a.plane().distanceToPoint( a.b ) == 0, "Passed!" );
-			assert.ok( a.plane().distanceToPoint( a.c ) == 0, "Passed!" );
-			assert.ok( a.plane().normal.equals( a.normal() ), "Passed!" );
+			a.getPlane( plane );
+			a.getNormal( normal );
+			assert.ok( plane.distanceToPoint( a.a ) == 0, "Passed!" );
+			assert.ok( plane.distanceToPoint( a.b ) == 0, "Passed!" );
+			assert.ok( plane.distanceToPoint( a.c ) == 0, "Passed!" );
+			assert.ok( plane.normal.equals( normal ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 2 ) );
-			assert.ok( a.plane().distanceToPoint( a.a ) == 0, "Passed!" );
-			assert.ok( a.plane().distanceToPoint( a.b ) == 0, "Passed!" );
-			assert.ok( a.plane().distanceToPoint( a.c ) == 0, "Passed!" );
-			assert.ok( a.plane().normal.clone().normalize().equals( a.normal() ), "Passed!" );
+			a.getPlane( plane );
+			a.getNormal( normal );
+			assert.ok( plane.distanceToPoint( a.a ) == 0, "Passed!" );
+			assert.ok( plane.distanceToPoint( a.b ) == 0, "Passed!" );
+			assert.ok( plane.distanceToPoint( a.c ) == 0, "Passed!" );
+			assert.ok( plane.normal.clone().normalize().equals( normal ), "Passed!" );
 
 		} );
 
-		QUnit.test( "barycoordFromPoint", ( assert ) => {
+		QUnit.test( "getBarycoord", ( assert ) => {
 
 			var a = new Triangle();
 
 			var bad = new Vector3( - 2, - 1, - 1 );
+			var barycoord = new Vector3();
+			var midpoint = new Vector3();
 
-			assert.ok( a.barycoordFromPoint( a.a ).equals( bad ), "Passed!" );
-			assert.ok( a.barycoordFromPoint( a.b ).equals( bad ), "Passed!" );
-			assert.ok( a.barycoordFromPoint( a.c ).equals( bad ), "Passed!" );
+			a.getBarycoord( a.a, barycoord );
+			assert.ok( barycoord.equals( bad ), "Passed!" );
+			a.getBarycoord( a.b, barycoord );
+			assert.ok( barycoord.equals( bad ), "Passed!" );
+			a.getBarycoord( a.c, barycoord );
+			assert.ok( barycoord.equals( bad ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
-			assert.ok( a.barycoordFromPoint( a.a ).equals( new Vector3( 1, 0, 0 ) ), "Passed!" );
-			assert.ok( a.barycoordFromPoint( a.b ).equals( new Vector3( 0, 1, 0 ) ), "Passed!" );
-			assert.ok( a.barycoordFromPoint( a.c ).equals( new Vector3( 0, 0, 1 ) ), "Passed!" );
-			assert.ok( a.barycoordFromPoint( a.midpoint() ).distanceTo( new Vector3( 1 / 3, 1 / 3, 1 / 3 ) ) < 0.0001, "Passed!" );
+			a.getMidpoint( midpoint );
+
+			a.getBarycoord( a.a, barycoord );
+			assert.ok( barycoord.equals( new Vector3( 1, 0, 0 ) ), "Passed!" );
+			a.getBarycoord( a.b, barycoord );
+			assert.ok( barycoord.equals( new Vector3( 0, 1, 0 ) ), "Passed!" );
+			a.getBarycoord( a.c, barycoord );
+			assert.ok( barycoord.equals( new Vector3( 0, 0, 1 ) ), "Passed!" );
+			a.getBarycoord( midpoint, barycoord );
+			assert.ok( barycoord.distanceTo( new Vector3( 1 / 3, 1 / 3, 1 / 3 ) ) < 0.0001, "Passed!" );
 
 			var a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 2 ) );
-			assert.ok( a.barycoordFromPoint( a.a ).equals( new Vector3( 1, 0, 0 ) ), "Passed!" );
-			assert.ok( a.barycoordFromPoint( a.b ).equals( new Vector3( 0, 1, 0 ) ), "Passed!" );
-			assert.ok( a.barycoordFromPoint( a.c ).equals( new Vector3( 0, 0, 1 ) ), "Passed!" );
-			assert.ok( a.barycoordFromPoint( a.midpoint() ).distanceTo( new Vector3( 1 / 3, 1 / 3, 1 / 3 ) ) < 0.0001, "Passed!" );
+			a.getMidpoint( midpoint );
+
+			a.getBarycoord( a.a, barycoord );
+			assert.ok( barycoord.equals( new Vector3( 1, 0, 0 ) ), "Passed!" );
+			a.getBarycoord( a.b, barycoord );
+			assert.ok( barycoord.equals( new Vector3( 0, 1, 0 ) ), "Passed!" );
+			a.getBarycoord( a.c, barycoord );
+			assert.ok( barycoord.equals( new Vector3( 0, 0, 1 ) ), "Passed!" );
+			a.getBarycoord( midpoint, barycoord );
+			assert.ok( barycoord.distanceTo( new Vector3( 1 / 3, 1 / 3, 1 / 3 ) ) < 0.0001, "Passed!" );
 
 		} );
 
 		QUnit.test( "containsPoint", ( assert ) => {
 
 			var a = new Triangle();
+			var midpoint = new Vector3();
 
 			assert.ok( ! a.containsPoint( a.a ), "Passed!" );
 			assert.ok( ! a.containsPoint( a.b ), "Passed!" );
 			assert.ok( ! a.containsPoint( a.c ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
+			a.getMidpoint( midpoint );
 			assert.ok( a.containsPoint( a.a ), "Passed!" );
 			assert.ok( a.containsPoint( a.b ), "Passed!" );
 			assert.ok( a.containsPoint( a.c ), "Passed!" );
-			assert.ok( a.containsPoint( a.midpoint() ), "Passed!" );
+			assert.ok( a.containsPoint( midpoint ), "Passed!" );
 			assert.ok( ! a.containsPoint( new Vector3( - 1, - 1, - 1 ) ), "Passed!" );
 
 			var a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 2 ) );
+			a.getMidpoint( midpoint );
 			assert.ok( a.containsPoint( a.a ), "Passed!" );
 			assert.ok( a.containsPoint( a.b ), "Passed!" );
 			assert.ok( a.containsPoint( a.c ), "Passed!" );
-			assert.ok( a.containsPoint( a.midpoint() ), "Passed!" );
+			assert.ok( a.containsPoint( midpoint ), "Passed!" );
 			assert.ok( ! a.containsPoint( new Vector3( - 1, - 1, - 1 ) ), "Passed!" );
 
 		} );


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/13530#discussion_r173154870

Renames the following methods:

- `Triangle.area()` to `Triangle.getArea()`
- `Triangle.barycoordFromPoint()` to `Triangle.getBarycoord()`
- `Triangle.midpoint()` to `Triangle.getMidpoint()`
- `Triangle.normal()` to `Triangle.getNormal()`
- `Triangle.plane()` to `Triangle.getPlane()`