### PR TITLE
ExtrudeGeometry: Remove options material and extrudeMaterial

### DIFF
--- a/examples/webgl_geometry_extrude_shapes.html
+++ b/examples/webgl_geometry_extrude_shapes.html
@@ -159,8 +159,6 @@
 				var extrudeSettings = {
 					amount: 20,
 					steps: 1,
-					material: 1,
-					extrudeMaterial: 0,
 					bevelEnabled: true,
 					bevelThickness : 2,
 					bevelSize: 4,

--- a/examples/webgl_geometry_text.html
+++ b/examples/webgl_geometry_text.html
@@ -373,10 +373,7 @@
 
 					bevelThickness: bevelThickness,
 					bevelSize: bevelSize,
-					bevelEnabled: bevelEnabled,
-
-					material: 0,
-					extrudeMaterial: 1
+					bevelEnabled: bevelEnabled
 
 				});
 

--- a/examples/webgl_loader_ttf.html
+++ b/examples/webgl_loader_ttf.html
@@ -213,10 +213,7 @@
 
 					bevelThickness: bevelThickness,
 					bevelSize: bevelSize,
-					bevelEnabled: true,
-
-					material: 0,
-					extrudeMaterial: 1
+					bevelEnabled: true
 
 				});
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -615,7 +615,7 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 		}
 
-		scope.addGroup( start, verticesArray.length / 3 - start, options.material !== undefined ? options.material : 0 );
+		scope.addGroup( start, verticesArray.length / 3 - start, 0 );
 
 	}
 
@@ -639,7 +639,7 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 		}
 
 
-		scope.addGroup( start, verticesArray.length / 3 - start, options.extrudeMaterial !== undefined ? options.extrudeMaterial : 1 );
+		scope.addGroup( start, verticesArray.length / 3 - start, 1 );
 
 
 	}


### PR DESCRIPTION
This PR removes two options of `ExtrudeGeometry`: `material` and `extrudeMaterial`.

It was possible to change the material indices of the side and lid faces. Since all other geometry generators have fixed material indices, I vote to remove this option.

Both options were never documented, so there is no need to change the docs.