### PR TITLE
OrbitControls: added .panSpeed property

### DIFF
--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -96,7 +96,8 @@ function animate() {
 
     <h3>[property:Boolean enableDamping]</h3>
     <div>
-      Set to true to enable damping (inertia), which can be used to give a sense of weight to the controls. Default is false.<br>          Note that if this is enabled, you must call [page:.update] () in your animation loop.
+      Set to true to enable damping (inertia), which can be used to give a sense of weight to the controls. Default is false.<br>
+      Note that if this is enabled, you must call [page:.update] () in your animation loop.
     </div>
 
     <h3>[property:Boolean enableKeys]</h3>
@@ -198,7 +199,20 @@ controls.mouseButtons = {
 
     <h3>[property:Camera object]</h3>
     <div>
-      The camera ( or other object ) that is being controlled.
+      The camera being controlled.
+    </div>
+
+    <h3>[property:Integer panningMode]</h3>
+    <div>
+    Panning mode. Defines how the camera's position is translated when panning.
+    The options are THREE.ScreenSpacePanning, in which the camera pans in screen space,
+    and THREE.HorizontalPanning, in which the camera pans in the plane orthogonal to the camera's up direction.
+    Default is THREE.ScreenSpacePanning.
+    </div>
+
+    <h3>[property:Float panSpeed]</h3>
+    <div>
+      Speed of panning. Default is 1.
     </div>
 
     <h3>[property:Vector3 position0]</h3>

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -59,6 +59,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	// Set to false to disable panning
 	this.enablePan = true;
+	this.panSpeed = 1.0;
 	this.panningMode = THREE.ScreenSpacePanning; // alternate THREE.HorizontalPanning
 	this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
 
@@ -459,15 +460,16 @@ THREE.OrbitControls = function ( object, domElement ) {
 		//console.log( 'handleMouseMoveRotate' );
 
 		rotateEnd.set( event.clientX, event.clientY );
-		rotateDelta.subVectors( rotateEnd, rotateStart );
+
+		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );;
 
 		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
 		// rotating across whole screen goes 360 degrees around
-		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed );
+		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientWidth );
 
 		// rotating up and down along whole screen attempts to go 360, but limited to 180
-		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed );
+		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );
 
 		rotateStart.copy( rotateEnd );
 
@@ -505,7 +507,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		panEnd.set( event.clientX, event.clientY );
 
-		panDelta.subVectors( panEnd, panStart );
+		panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
 
 		pan( panDelta.x, panDelta.y );
 
@@ -603,15 +605,16 @@ THREE.OrbitControls = function ( object, domElement ) {
 		//console.log( 'handleTouchMoveRotate' );
 
 		rotateEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
-		rotateDelta.subVectors( rotateEnd, rotateStart );
+
+		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
 		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
 		// rotating across whole screen goes 360 degrees around
-		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed );
+		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientWidth );
 
 		// rotating up and down along whole screen attempts to go 360, but limited to 180
-		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed );
+		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );
 
 		rotateStart.copy( rotateEnd );
 
@@ -654,7 +657,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		panEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
 
-		panDelta.subVectors( panEnd, panStart );
+		panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
 
 		pan( panDelta.x, panDelta.y );
 


### PR DESCRIPTION
`panSpeed` was not included because the panning speed was (presumably) hardwired to track the mouse/touch.

But with damping enabled, the `panSpeed` can be useful for fine-tuning.

This PR also includes a bit of cleanup, and updates to the docs.
