### PR TITLE
GLTFLoader: Docs update for supported extensions.

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -23,23 +23,15 @@
 		<h2>Extensions</h2>
 
 		<div>
-		GLTFLoader supports the following glTF extensions:
+			GLTFLoader supports the following
+			<a target="_blank" href="https://github.com/KhronosGroup/glTF/tree/master/extensions/">glTF 2.0 extensions</a>:
 		</div>
 
 		<ul>
-			<li>
-				<a target="_blank" href="https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness">
-					KHR_materials_pbrSpecularGlossiness
-				</a>
-			</li>
-			<li>
-				<a target="_blank" href="https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression">
-					KHR_draco_mesh_compression
-				</a>
-			</li>
-			<li>
-				KHR_lights (experimental)
-			</li>
+			<li>KHR_draco_mesh_compression</li>
+			<li>KHR_materials_pbrSpecularGlossiness</li>
+			<li>KHR_materials_unlit</li>
+			<li>KHR_lights (experimental)</li>
 		</ul>
 
 		<h2>Example</h2>


### PR DESCRIPTION
Removing links to individual extensions and just linking to the main list, since that will be more up to date.