### PR TITLE
Tests: Fixed fails with "npm run test"

### DIFF
--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -547,6 +547,13 @@ export default QUnit.module( 'Core', () => {
 
 		QUnit.test( "fromGeometry/fromDirectGeometry", ( assert ) => {
 
+			if ( typeof XMLHttpRequest === 'undefined' ) {
+
+				assert.expect( 0 );
+				return;
+
+			}
+
 			assert.timeout( 1000 );
 
 			var a = new BufferGeometry();

--- a/test/unit/src/core/Clock.tests.js
+++ b/test/unit/src/core/Clock.tests.js
@@ -66,6 +66,13 @@ export default QUnit.module( 'Core', () => {
 		// OTHERS
 		QUnit.test( "clock with performance", ( assert ) => {
 
+			if ( typeof performance === 'undefined' ) {
+
+				assert.expect( 0 );
+				return;
+
+			}
+
 			mockPerformance();
 
 			var clock = new Clock( false );

--- a/test/unit/src/core/DirectGeometry.tests.js
+++ b/test/unit/src/core/DirectGeometry.tests.js
@@ -48,6 +48,13 @@ export default QUnit.module( 'Core', () => {
 
 		QUnit.test( "fromGeometry", ( assert ) => {
 
+			if ( typeof XMLHttpRequest === 'undefined' ) {
+
+				assert.expect( 0 );
+				return;
+
+			}
+
 			assert.timeout( 1000 );
 
 			var a = new DirectGeometry();


### PR DESCRIPTION
We skip three tests which can't run in a node environment without polyfills. In this way, `npm run test` is now free of fails, too.