### PR TITLE
Docs: Change Glossy spheres in three.js link to <a> tag

### DIFF
--- a/docs/manual/introduction/Useful-links.html
+++ b/docs/manual/introduction/Useful-links.html
@@ -47,7 +47,7 @@
 				[link:http://blog.cjgammon.com/ Collection of tutorials] by [link:http://www.cjgammon.com/ CJ Gammon].
 			</li>
 			<li>
-				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
+				<a href="https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857">Glossy spheres in three.js.</a>
 			</li>
 		 <li>
 			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,


### PR DESCRIPTION
The markdown [link] parsed error in final output html. So change it to <a> tag