### PR TITLE
ExtrudeGeometry: Remove option "frames"

### DIFF
--- a/docs/api/geometries/ExtrudeBufferGeometry.html
+++ b/docs/api/geometries/ExtrudeBufferGeometry.html
@@ -77,8 +77,7 @@
 				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
 				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
 				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
+				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded.</li>
 				<li>UVGenerator —  Object. object that provides UV generator functions</li>
 			</ul>
 
@@ -111,8 +110,7 @@
 				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
 				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
 				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
+				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded.</li>
 				<li>UVGenerator —  Object. object that provides UV generator functions</li>
 			</ul>
 		</div>
@@ -130,8 +128,7 @@
 				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
 				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
 				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
+				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded.</li>
 				<li>UVGenerator —  Object. object that provides UV generator functions</li>
 			</ul>
 		</div>

--- a/docs/api/geometries/ExtrudeGeometry.html
+++ b/docs/api/geometries/ExtrudeGeometry.html
@@ -77,8 +77,7 @@
 				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
 				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
 				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
+				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded.</li>
 				<li>UVGenerator —  Object. object that provides UV generator functions</li>
 			</ul>
 
@@ -111,8 +110,7 @@
 				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
 				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
 				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
+				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded.</li>
 				<li>UVGenerator —  Object. object that provides UV generator functions</li>
 			</ul>
 		</div>
@@ -130,8 +128,7 @@
 				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
 				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
 				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
-				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded (creates Frames if frames aren't defined).</li>
-				<li>frames — An object containing arrays of tangents, normals, binormals for each step along the extrudePath. </li>
+				<li>extrudePath — THREE.CurvePath. A 3D spline path along which the shape should be extruded.</li>
 				<li>UVGenerator —  Object. object that provides UV generator functions</li>
 			</ul>
 		</div>

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -15,7 +15,6 @@
  *  bevelSegments: <int>, // number of bevel layers
  *
  *  extrudePath: <THREE.Curve> // curve to extrude shape along
- *  frames: <Object> // containing arrays of tangents, normals, binormals
  *
  *  UVGenerator: <Object> // object that provides UV generator functions
  *
@@ -160,7 +159,7 @@ ExtrudeBufferGeometry.prototype.addShape = function ( shape, options ) {
 
 		// TODO1 - have a .isClosed in spline?
 
-		splineTube = options.frames !== undefined ? options.frames : extrudePath.computeFrenetFrames( steps, false );
+		splineTube = extrudePath.computeFrenetFrames( steps, false );
 
 		// console.log(splineTube, 'splineTube', splineTube.normals.length, 'steps', steps, 'extrudePts', extrudePts.length);
 


### PR DESCRIPTION
I'd like to suggest another simplification of `ExtrudeGeometry`: The removal of `options.frames` or the possibility to apply custom Frenet–Serret frames to the constructor. 

Analogous to `TubeGeometry` frames are now always calculated by the given curve via [Curve.computeFrenetFrames](https://threejs.org/docs/index.html#api/extras/core/Curve.computeFrenetFrames).

https://github.com/mrdoob/three.js/blob/0c6c0050982cf3697005bb7ca419b4dbd6a9279a/src/geometries/TubeGeometry.js#L74

`option.frames` was never used in the examples so there is no need for modifications.
