### PR TITLE
Change variable name from cube to klein

### DIFF
--- a/docs/api/geometries/ParametricGeometry.html
+++ b/docs/api/geometries/ParametricGeometry.html
@@ -37,8 +37,8 @@
 		<code>
 		var geometry = new THREE.ParametricGeometry( THREE.ParametricGeometries.klein, 25, 25 );
 		var material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
-		var cube = new THREE.Mesh( geometry, material );
-		scene.add( cube );
+		var klein = new THREE.Mesh( geometry, material );
+		scene.add( klein );
 		</code>
 
 


### PR DESCRIPTION
Because the object is not a cube, it's a klein bottle. (It was probably a copy/paste error.)