### PR TITLE
Replace GLTF2Loader with GLTFExporter in BrowserSupport doc

### DIFF
--- a/docs/manual/introduction/Browser-support.html
+++ b/docs/manual/introduction/Browser-support.html
@@ -64,7 +64,7 @@
 				<tr>
 					<td>Promise</td>
 					<td>Examples</td>
-					<td>GLTFLoader, GLTF2Loader, WebVR, VREffect, etc.</td>
+					<td>GLTFLoader, GLTFExporter, WebVR, VREffect, etc.</td>
 				</tr>
 				<tr>
 					<td>Fetch</td>


### PR DESCRIPTION
`GLTF2Loader` no longer exists. Let's replace it with `GLTFExporter` in polyfills section of Browser Support Doc because `GLTFExporter` started to use `Promise`.