### PR TITLE
Mesh: Remove redundant property .index in .raycast()

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -295,12 +295,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 						intersection = checkBufferGeometryIntersection( this, raycaster, ray, position, uv, a, b, c );
 
-						if ( intersection ) {
-
-							intersection.index = a; // triangle number in positions buffer semantics
-							intersects.push( intersection );
-
-						}
+						if ( intersection ) intersects.push( intersection );
 
 					}
 


### PR DESCRIPTION
see #13598