### PR TITLE
Changed Euler Copy Clone on change test implementation.

### DIFF
--- a/test/unit/src/math/Euler.tests.js
+++ b/test/unit/src/math/Euler.tests.js
@@ -201,25 +201,24 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( "set/get properties, check callbacks", ( assert ) => {
 
-			var a = new Euler();
-			a.onChange( function () {
+            var a = new Euler();
+            a.onChange( function () {
 
-				assert.step( "set: onChange called" );
+                assert.step( "set: onChange called" );
 
-			} );
+            } );
 
-			assert.expect( 8 );
+            a.x = 1;
+            a.y = 2;
+            a.z = 3;
+            a.order = "ZYX";
 
-			// should be 4 calls to onChangeCallback
-			a.x = 1;
-			a.y = 2;
-			a.z = 3;
-			a.order = "ZYX";
+            assert.strictEqual( a.x, 1, "get: check x" );
+            assert.strictEqual( a.y, 2, "get: check y" );
+            assert.strictEqual( a.z, 3, "get: check z" );
+            assert.strictEqual( a.order, "ZYX", "get: check order" );
 
-			assert.strictEqual( a.x, 1, "get: check x" );
-			assert.strictEqual( a.y, 2, "get: check y" );
-			assert.strictEqual( a.z, 3, "get: check z" );
-			assert.strictEqual( a.order, "ZYX", "get: check order" );
+            assert.verifySteps( Array( 4 ).fill( "set: onChange called" ) );
 
 		} );
 
@@ -284,31 +283,31 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( "fromArray", ( assert ) => {
 
-			assert.expect( 10 );
+            var a = new Euler();
+            var array = [ x, y, z ];
+            var cb = function () {
 
-			var a = new Euler();
-			var array = [ x, y, z ];
-			var cb = function () {
+                assert.step( "onChange called" );
 
-				assert.step( "onChange called" );
+            };
+            a.onChange( cb );
 
-			};
-			a.onChange( cb );
+            a.fromArray( array );
+            assert.strictEqual( a.x, x, "No order: check x" );
+            assert.strictEqual( a.y, y, "No order: check y" );
+            assert.strictEqual( a.z, z, "No order: check z" );
+            assert.strictEqual( a.order, "XYZ", "No order: check order" );
 
-			a.fromArray( array );
-			assert.strictEqual( a.x, x, "No order: check x" );
-			assert.strictEqual( a.y, y, "No order: check y" );
-			assert.strictEqual( a.z, z, "No order: check z" );
-			assert.strictEqual( a.order, "XYZ", "No order: check order" );
+            a = new Euler();
+            array = [ x, y, z, "ZXY" ];
+            a.onChange( cb );
+            a.fromArray( array );
+            assert.strictEqual( a.x, x, "With order: check x" );
+            assert.strictEqual( a.y, y, "With order: check y" );
+            assert.strictEqual( a.z, z, "With order: check z" );
+            assert.strictEqual( a.order, "ZXY", "With order: check order" );
 
-			var a = new Euler();
-			var array = [ x, y, z, "ZXY" ];
-			a.onChange( cb );
-			a.fromArray( array );
-			assert.strictEqual( a.x, x, "With order: check x" );
-			assert.strictEqual( a.y, y, "With order: check y" );
-			assert.strictEqual( a.z, z, "With order: check z" );
-			assert.strictEqual( a.order, "ZXY", "With order: check order" );
+            assert.verifySteps( Array( 2 ).fill( "onChange called" ) );
 
 		} );
 

--- a/test/unit/src/math/Euler.tests.js
+++ b/test/unit/src/math/Euler.tests.js
@@ -225,27 +225,32 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( "clone/copy, check callbacks", ( assert ) => {
 
-			assert.expect( 3 );
-
-			var a = new Euler( 1, 2, 3, "ZXY" );
+            var a = new Euler( 1, 2, 3, "ZXY" );
 			var b = new Euler( 4, 5, 6, "XZY" );
-			var cb = function () {
+			var cbSucceed = function () {
 
-				assert.step( "onChange called" );
+    			assert.ok( true );
+    			assert.step( "onChange called" );
 
 			};
-			a.onChange( cb );
-			b.onChange( cb );
+			var cbFail = function () {
+
+			    assert.ok( false );
+
+			};
+			a.onChange( cbFail );
+			b.onChange( cbFail );
 
 			// clone doesn't trigger onChange
-			var a = b.clone();
+			a = b.clone();
 			assert.ok( a.equals( b ), "clone: check if a equals b" );
 
 			// copy triggers onChange once
-			var a = new Euler( 1, 2, 3, "ZXY" );
-			a.onChange( cb );
+			a = new Euler( 1, 2, 3, "ZXY" );
+			a.onChange( cbSucceed );
 			a.copy( b );
 			assert.ok( a.equals( b ), "copy: check if a equals b" );
+			assert.verifySteps( [ "onChange called" ] );
 
 		} );
 

--- a/test/unit/src/math/Euler.tests.js
+++ b/test/unit/src/math/Euler.tests.js
@@ -201,40 +201,40 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( "set/get properties, check callbacks", ( assert ) => {
 
-            var a = new Euler();
-            a.onChange( function () {
+			var a = new Euler();
+			a.onChange( function () {
 
-                assert.step( "set: onChange called" );
+				assert.step( "set: onChange called" );
 
-            } );
+			} );
 
-            a.x = 1;
-            a.y = 2;
-            a.z = 3;
-            a.order = "ZYX";
+			a.x = 1;
+			a.y = 2;
+			a.z = 3;
+			a.order = "ZYX";
 
-            assert.strictEqual( a.x, 1, "get: check x" );
-            assert.strictEqual( a.y, 2, "get: check y" );
-            assert.strictEqual( a.z, 3, "get: check z" );
-            assert.strictEqual( a.order, "ZYX", "get: check order" );
+			assert.strictEqual( a.x, 1, "get: check x" );
+			assert.strictEqual( a.y, 2, "get: check y" );
+			assert.strictEqual( a.z, 3, "get: check z" );
+			assert.strictEqual( a.order, "ZYX", "get: check order" );
 
-            assert.verifySteps( Array( 4 ).fill( "set: onChange called" ) );
+			assert.verifySteps( Array( 4 ).fill( "set: onChange called" ) );
 
 		} );
 
 		QUnit.test( "clone/copy, check callbacks", ( assert ) => {
 
-            var a = new Euler( 1, 2, 3, "ZXY" );
+			var a = new Euler( 1, 2, 3, "ZXY" );
 			var b = new Euler( 4, 5, 6, "XZY" );
 			var cbSucceed = function () {
 
-    			assert.ok( true );
-    			assert.step( "onChange called" );
+				assert.ok( true );
+				assert.step( "onChange called" );
 
 			};
 			var cbFail = function () {
 
-			    assert.ok( false );
+				assert.ok( false );
 
 			};
 			a.onChange( cbFail );
@@ -283,31 +283,31 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( "fromArray", ( assert ) => {
 
-            var a = new Euler();
-            var array = [ x, y, z ];
-            var cb = function () {
+			var a = new Euler();
+			var array = [ x, y, z ];
+			var cb = function () {
 
-                assert.step( "onChange called" );
+				assert.step( "onChange called" );
 
-            };
-            a.onChange( cb );
+			};
+			a.onChange( cb );
 
-            a.fromArray( array );
-            assert.strictEqual( a.x, x, "No order: check x" );
-            assert.strictEqual( a.y, y, "No order: check y" );
-            assert.strictEqual( a.z, z, "No order: check z" );
-            assert.strictEqual( a.order, "XYZ", "No order: check order" );
+			a.fromArray( array );
+			assert.strictEqual( a.x, x, "No order: check x" );
+			assert.strictEqual( a.y, y, "No order: check y" );
+			assert.strictEqual( a.z, z, "No order: check z" );
+			assert.strictEqual( a.order, "XYZ", "No order: check order" );
 
-            a = new Euler();
-            array = [ x, y, z, "ZXY" ];
-            a.onChange( cb );
-            a.fromArray( array );
-            assert.strictEqual( a.x, x, "With order: check x" );
-            assert.strictEqual( a.y, y, "With order: check y" );
-            assert.strictEqual( a.z, z, "With order: check z" );
-            assert.strictEqual( a.order, "ZXY", "With order: check order" );
+			a = new Euler();
+			array = [ x, y, z, "ZXY" ];
+			a.onChange( cb );
+			a.fromArray( array );
+			assert.strictEqual( a.x, x, "With order: check x" );
+			assert.strictEqual( a.y, y, "With order: check y" );
+			assert.strictEqual( a.z, z, "With order: check z" );
+			assert.strictEqual( a.order, "ZXY", "With order: check order" );
 
-            assert.verifySteps( Array( 2 ).fill( "onChange called" ) );
+			assert.verifySteps( Array( 2 ).fill( "onChange called" ) );
 
 		} );
 


### PR DESCRIPTION
The previous implementation of the Euler Copy/Clone, FromArray and Set/Get property tests gave inconsistent behavior due to the QUnit step behavior. This test is rewritten to successfully test the behavior. It is related to this issue: https://github.com/mrdoob/three.js/issues/13606