### PR TITLE
GLTFExporter: Ensure joints are uint8 or uint16.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -926,6 +926,17 @@ THREE.GLTFExporter.prototype = {
 				var attribute = geometry.attributes[ attributeName ];
 				attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();
 
+				// JOINTS_0 must be UNSIGNED_BYTE or UNSIGNED_SHORT.
+				if ( attributeName === 'JOINTS_0' &&
+						! ( attribute instanceof THREE.Uint16BufferAttribute ) &&
+						! ( attribute instanceof THREE.Uint8BufferAttribute ) ) {
+
+					console.warn( 'GLTFExporter: Attribute "skinIndex" converted to type UNSIGNED_SHORT.' );
+
+					attribute = new THREE.Uint16BufferAttribute( attribute.array, attribute.itemSize, attribute.normalized );
+
+				}
+
 				if ( attributeName.substr( 0, 5 ) !== 'MORPH' ) {
 
 					attributes[ attributeName ] = processAccessor( attribute, geometry );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -927,13 +927,13 @@ THREE.GLTFExporter.prototype = {
 				attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();
 
 				// JOINTS_0 must be UNSIGNED_BYTE or UNSIGNED_SHORT.
+				var array = attribute.array;
 				if ( attributeName === 'JOINTS_0' &&
-						! ( attribute instanceof THREE.Uint16BufferAttribute ) &&
-						! ( attribute instanceof THREE.Uint8BufferAttribute ) ) {
+					! ( array instanceof Uint16Array ) &&
+					! ( array instanceof Uint8Array ) ) {
 
 					console.warn( 'GLTFExporter: Attribute "skinIndex" converted to type UNSIGNED_SHORT.' );
-
-					attribute = new THREE.Uint16BufferAttribute( attribute.array, attribute.itemSize, attribute.normalized );
+					attribute = new THREE.BufferAttribute( new Uint16Array( array ), attribute.itemSize, attribute.normalized );
 
 				}
 


### PR DESCRIPTION
Seeing some models loaded in other formats with e.g. `Float32Array` types for `skinIndex`, so we may want to convert that to the correct type before export.

/cc @looeee