### PR TITLE
Box3: setFromObject can handle 2D BufferGeometries as well

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -1,3 +1,4 @@
+import { Vector2 } from './Vector2.js';
 import { Vector3 } from './Vector3.js';
 import { Sphere } from './Sphere.js';
 
@@ -250,11 +251,25 @@ Object.assign( Box3.prototype, {
 
 					if ( attribute !== undefined ) {
 
-						for ( i = 0, l = attribute.count; i < l; i ++ ) {
+						if ( attribute.itemSize === 2 ) {
 
-							v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
+							for ( i = 0, l = attribute.count; i < l; i ++ ) {
 
-							scope.expandByPoint( v1 );
+								v1.set( attribute.getX( i ), attribute.getY( i ), 0 ).applyMatrix4( node.matrixWorld );
+
+								scope.expandByPoint( v1 );
+	
+							}
+
+						} else {
+
+							for ( i = 0, l = attribute.count; i < l; i ++ ) {
+
+								v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
+	
+								scope.expandByPoint( v1 );
+	
+							}
 
 						}
 

--- a/test/unit/src/math/Box3.tests.js
+++ b/test/unit/src/math/Box3.tests.js
@@ -8,7 +8,6 @@ import { Box3 } from '../../../../src/math/Box3';
 import { Sphere } from '../../../../src/math/Sphere';
 import { Triangle } from '../../../../src/math/Triangle';
 import { Plane } from '../../../../src/math/Plane';
-import { Vector2 } from '../../../../src/math/Vector2';
 import { Vector3 } from '../../../../src/math/Vector3';
 import { Matrix4 } from '../../../../src/math/Matrix4';
 import { Mesh } from '../../../../src/objects/Mesh';

--- a/test/unit/src/math/Box3.tests.js
+++ b/test/unit/src/math/Box3.tests.js
@@ -8,10 +8,12 @@ import { Box3 } from '../../../../src/math/Box3';
 import { Sphere } from '../../../../src/math/Sphere';
 import { Triangle } from '../../../../src/math/Triangle';
 import { Plane } from '../../../../src/math/Plane';
+import { Vector2 } from '../../../../src/math/Vector2';
 import { Vector3 } from '../../../../src/math/Vector3';
 import { Matrix4 } from '../../../../src/math/Matrix4';
 import { Mesh } from '../../../../src/objects/Mesh';
-import { BufferAttribute } from '../../../../src/core/BufferAttribute';
+import { BufferAttribute, Float32BufferAttribute } from '../../../../src/core/BufferAttribute';
+import { BufferGeometry } from '../../../../src/core/BufferGeometry';
 import {
 	BoxGeometry,
 	BoxBufferGeometry
@@ -161,6 +163,21 @@ export default QUnit.module( 'Maths', () => {
 			a.setFromObject( object );
 			assert.ok( a.min.equals( new Vector3( - 1, - 1, - 1 ) ), "Correct new minimum" );
 			assert.ok( a.max.equals( new Vector3( 1, 1, 1 ) ), "Correct new maximum" );
+
+		} );
+
+		QUnit.test( "setFromObject/BufferGeometry-2D", ( assert ) => {
+
+			var a = new Box3( zero3.clone(), one3.clone() );
+			var object = new Mesh( new BoxBufferGeometry( 2, 2, 2 ) );
+			var buffer2D = new BufferGeometry();
+			buffer2D.addAttribute( "position", new Float32BufferAttribute( [0, 0, 5, 1], 2 ) );
+			var child = new Mesh( buffer2D );
+			object.add( child );
+
+			a.setFromObject( object );
+			assert.ok( a.min.equals( new Vector3( - 1, - 1, - 1 ) ), "Correct new minimum" );
+			assert.ok( a.max.equals( new Vector3( 5, 1, 1 ) ), "Correct new maximum" );
 
 		} );
 


### PR DESCRIPTION
Small change to Box3 so setFromObject will still generate a valid Box3 when there are BufferGeometries in the graph which have an 'itemSize' of 2 for their position attributes. Previously this function was assuming an itemSize of 3, and the box would be set to nan, nan, nan.

The TextGeometry for example will generate a BufferGeometry with an itemSize of 2. So if there was a TextGeometry in the scene then the Box3.setFromObject function wouldnt work.