### PR TITLE
STLLoader: Improved parsing for scientific notation

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -212,7 +212,7 @@ THREE.STLLoader.prototype = {
 			var patternFace = /facet([\s\S]*?)endfacet/g;
 			var faceCounter = 0;
 
-			var patternFloat = /[\s]+([+-]?(?:\d+.\d+|\d+.|\d+|.\d+)(?:[eE][+-]?\d+)?)/.source;
+			var patternFloat = /[\s]+([+-]?(?:\d*)(?:\.\d*)?(?:[eE][+-]?\d+)?)/.source;
 			var patternVertex = new RegExp( 'vertex' + patternFloat + patternFloat + patternFloat, 'g' );
 			var patternNormal = new RegExp( 'normal' + patternFloat + patternFloat + patternFloat, 'g' );
 


### PR DESCRIPTION
Solves #13612

This regex is a somewhat more tolerant than the previous one. It allows values like `-2e-08` or even `-.2e-08` in an STL file. Both are valid numbers in JavaScript.