### PR TITLE
Docs: Added answer for "Which 3D model format is best supported?"

### DIFF
--- a/docs/manual/introduction/FAQ.html
+++ b/docs/manual/introduction/FAQ.html
@@ -10,9 +10,14 @@
 	<body>
 		<h1>[name]</h1>
 
-		<h2>Which Import Format/Exporter is best supported?</h2>
+		<h2>Which 3D model format is best supported?</h2>
 		<div>
-TODO
+			<p>
+				The recommended format for importing and exporting assets is glTF (GL Transmission Format). Because glTF is focused on runtime asset delivery, it is compact to transmit and fast to load.
+			</p>
+			<p>
+				three.js provides loaders for many other popular formats like FBX, Collada or OBJ as well. Nevertheless, you should always try to establish a glTF based workflow in your projects first.
+			</p>
 		</div>
 
 		<h2>Why are there meta viewport tags in examples?</h2>


### PR DESCRIPTION
see #13508

A brief statement about 3D formats. If users have no clue about this topic, they are now lead to `glTF`.