### PR TITLE
FBXLoader: use Uint16BufferAttribute  for skinIndex

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1108,7 +1108,7 @@
 
 		if ( skeleton ) {
 
-			geo.addAttribute( 'skinIndex', new THREE.Float32BufferAttribute( weightsIndicesBuffer, 4 ) );
+			geo.addAttribute( 'skinIndex', new THREE.Uint16BufferAttribute( weightsIndicesBuffer, 4 ) );
 
 			geo.addAttribute( 'skinWeight', new THREE.Float32BufferAttribute( vertexWeightsBuffer, 4 ) );
 


### PR DESCRIPTION
Now the loaded attributes match the glTF spec defined here:
https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#meshes

See #13609