### PR TITLE
Use VRDisplay's pose when not presenting for magic window

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1038,7 +1038,7 @@ function WebGLRenderer( parameters ) {
 
 		var device = vr.getDevice();
 
-		if ( device && device.isPresenting ) {
+		if ( device && device.requestAnimationFrame ) {
 
 			device.requestAnimationFrame( animationLoop );
 


### PR DESCRIPTION
Call VRDisplay's requestAnimationFrame if it's present regardless of presentation status so that getFrameData can be called inside the display's rAF for magic window.

According to WebVR [spec](https://immersive-web.github.io/webvr/spec/1.1/):
> (getFrameData) Will return false and not populate the VRFrameData object if called outside a VRDisplay.requestAnimationFrame() callback.

While not presenting, the VRDIsplay's rAF is the same as window's rAF:
>  (requestAnimationFrame) Functionally equivalent to window.requestAnimationFrame when the VRDisplay is not presenting.

I ran into this on Chrome m65 trying to figure out why the `VRFrameData` was full of null values -- IIRC, this restriction, while in the spec, wasn't actually enforced previously. This enables magic window tracking (camera responds to device movement) in the WebVR examples. If someone wanted to not use the magic window tracking, they could not enable the VR manager.