### PR TITLE
TransformControls: Remove warning when activate rotate

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -422,10 +422,12 @@
 			],
 
 			XYZE: [
-				[ new THREE.Mesh() ]// TODO
+				[ new THREE.Mesh( new THREE.TorusBufferGeometry( 1, 0.12, 2, 24 ), pickerMaterial ) ]
 			]
 
 		};
+
+		this.pickerGizmos.XYZE[ 0 ][ 0 ].visible = false; // disable XYZE picker gizmo
 
 		this.setActivePlane = function ( axis ) {
 


### PR DESCRIPTION
Currently, `TransformControls` produces a warning when switching into "rotate" mode.

> [.Offscreen-For-WebGL-0x7fc831865a00]RENDER WARNING: Render count or primcount is 0.

The warning was produced by a picker gizmo with an empty geometry.
 
Before: https://threejs.org/examples/misc_controls_transform.html
After: https://rawgit.com/Mugen87/three.js/dev11/examples/misc_controls_transform.html