### PR TITLE
import `Float32BufferAttribute` since `THREE` is not defined

### DIFF
--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -6,6 +6,7 @@ import { Vector3 } from '../math/Vector3.js';
 import { LineBasicMaterial } from '../materials/LineBasicMaterial.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
 import { LineSegments } from './LineSegments.js';
+import { Float32BufferAttribute } from '../core/BufferAttribute';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -63,7 +64,7 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 					}
 
-					geometry.addAttribute( 'lineDistance', new THREE.Float32BufferAttribute( lineDistances, 1 ) );
+					geometry.addAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
 
 				} else {
 

--- a/src/objects/LineSegments.js
+++ b/src/objects/LineSegments.js
@@ -1,5 +1,6 @@
 import { Line } from './Line.js';
 import { Vector3 } from '../math/Vector3.js';
+import { Float32BufferAttribute } from '../core/BufferAttribute';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -47,7 +48,7 @@ LineSegments.prototype = Object.assign( Object.create( Line.prototype ), {
 
 					}
 
-					geometry.addAttribute( 'lineDistance', new THREE.Float32BufferAttribute( lineDistances, 1 ) );
+					geometry.addAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
 
 				} else {
 


### PR DESCRIPTION
This PR fixes both `Line` and `LineSegments`'s `.computeLineDistances()` method, when the geometry is a `BufferGeometry`.

The bug was that `THREE` is not defined.