### PR TITLE
Fix BufferAttributeTypes doc, replace page with param

### DIFF
--- a/docs/api/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -32,7 +32,7 @@
 		<h2>Constructor</h2>
 
 		All of the above are called in the same way.
-		<h3>TypedBufferAttribute( [page:Array array], [page:Integer itemSize] )</h3>
+		<h3>TypedBufferAttribute( [param:Array array], [param:Integer itemSize] )</h3>
 		<div>
 			array -- this can be a typed or untyped (normal) array. It will be converted to the Type specified.<br /><br />
 


### PR DESCRIPTION
This PR fixes `BufferAttributeTypes` doc. Arguments in method should be listed with `param:`, not `page:`.