### PR TITLE
Docs: Set max linewidth to ~100chars.

### DIFF
--- a/docs/manual/introduction/Creating-a-scene.html
+++ b/docs/manual/introduction/Creating-a-scene.html
@@ -10,11 +10,11 @@
 	<body>
 		<h1>[name]</h1><br />
 
-		<div>The goal of this section is to give a brief introduction to three.js. We will start by setting up a scene, with a spinning cube. A working example is provided at the bottom of the page in case you get stuck and need help.</div>
+		<p>The goal of this section is to give a brief introduction to three.js. We will start by setting up a scene, with a spinning cube. A working example is provided at the bottom of the page in case you get stuck and need help.</p>
 
 		<h2>Before we start</h2>
 
-		<div>Before you can use three.js, you need somewhere to display it. Save the following HTML to a file on your computer, along with a copy of <a href="http://threejs.org/build/three.js">three.js</a> in the js/ directory, and open it in your browser.</div>
+		<p>Before you can use three.js, you need somewhere to display it. Save the following HTML to a file on your computer, along with a copy of <a href="http://threejs.org/build/three.js">three.js</a> in the js/ directory, and open it in your browser.</p>
 
 		<code>
 		&lt;!DOCTYPE html&gt;
@@ -36,11 +36,11 @@
 		&lt;/html&gt;
 		</code>
 
-		<div>That's all. All the code below goes into the empty &lt;script&gt; tag.</div>
+		<p>That's all. All the code below goes into the empty &lt;script&gt; tag.</p>
 
 		<h2>Creating the scene</h2>
 
-		<div>To actually be able to display anything with three.js, we need three things: scene, camera and renderer, so that we can render the scene with camera.</div>
+		<p>To actually be able to display anything with three.js, we need three things: scene, camera and renderer, so that we can render the scene with camera.</p>
 
 		<code>
 		var scene = new THREE.Scene();
@@ -51,25 +51,25 @@
 		document.body.appendChild( renderer.domElement );
 		</code>
 
-		<div>Let's take a moment to explain what's going on here. We have now set up the scene, our camera and the renderer.</div>
+		<p>Let's take a moment to explain what's going on here. We have now set up the scene, our camera and the renderer.</p>
 
-		<div>There are a few different cameras in three.js. For now, let's use a <strong>PerspectiveCamera</strong>.</div>
+		<p>There are a few different cameras in three.js. For now, let's use a <strong>PerspectiveCamera</strong>.</p>
 
-		<div>The first attribute is the <strong>field of view</strong>. FOV is the extent of the scene that is seen on the display at any given moment. The value is in degrees.</div>
+		<p>The first attribute is the <strong>field of view</strong>. FOV is the extent of the scene that is seen on the display at any given moment. The value is in degrees.</p>
 
-		<div>The second one is the <strong>aspect ratio</strong>. You almost always want to use the width of the element divided by the height, or you'll get the same result as when you play old movies on a widescreen TV - the image looks squished.</div>
+		<p>The second one is the <strong>aspect ratio</strong>. You almost always want to use the width of the element divided by the height, or you'll get the same result as when you play old movies on a widescreen TV - the image looks squished.</p>
 
-		<div>The next two attributes are the <strong>near</strong> and <strong>far</strong> clipping plane. What that means, is that objects further away from the camera than the value of <strong>far</strong> or closer than <strong>near</strong> won't be rendered. You don't have to worry about this now, but you may want to use other values in your apps to get better performance.</div>
+		<p>The next two attributes are the <strong>near</strong> and <strong>far</strong> clipping plane. What that means, is that objects further away from the camera than the value of <strong>far</strong> or closer than <strong>near</strong> won't be rendered. You don't have to worry about this now, but you may want to use other values in your apps to get better performance.</p>
 
-		<div>Next up is the renderer. This is where the magic happens. In addition to the WebGLRenderer we use here, three.js comes with a few others, often used as fallbacks for users with older browsers or for those who don't have WebGL support for some reason.</div>
+		<p>Next up is the renderer. This is where the magic happens. In addition to the WebGLRenderer we use here, three.js comes with a few others, often used as fallbacks for users with older browsers or for those who don't have WebGL support for some reason.</p>
 
-		<div>In addition to creating the renderer instance, we also need to set the size at which we want it to render our app. It's a good idea to use the width and height of the area we want to fill with our app - in this case, the width and height of the browser window. For performance intensive apps, you can also give <strong>setSize</strong> smaller values, like <strong>window.innerWidth/2</strong> and <strong>window.innerHeight/2</strong>, which will make the app render at half size.</div>
+		<p>In addition to creating the renderer instance, we also need to set the size at which we want it to render our app. It's a good idea to use the width and height of the area we want to fill with our app - in this case, the width and height of the browser window. For performance intensive apps, you can also give <strong>setSize</strong> smaller values, like <strong>window.innerWidth/2</strong> and <strong>window.innerHeight/2</strong>, which will make the app render at half size.</p>
 
-		<div>If you wish to keep the size of your app but render it at a lower resolution, you can do so by calling <strong>setSize</strong> with false as <strong>updateStyle</strong> (the third argument). For example, <strong>setSize(window.innerWidth/2, window.innerHeight/2, false)</strong> will render your app at half resolution, given that your &lt;canvas&gt; has 100% width and height.</div>
+		<p>If you wish to keep the size of your app but render it at a lower resolution, you can do so by calling <strong>setSize</strong> with false as <strong>updateStyle</strong> (the third argument). For example, <strong>setSize(window.innerWidth/2, window.innerHeight/2, false)</strong> will render your app at half resolution, given that your &lt;canvas&gt; has 100% width and height.</p>
 
-		<div>Last but not least, we add the <strong>renderer</strong> element to our HTML document. This is a &lt;canvas&gt; element the renderer uses to display the scene to us.</div>
+		<p>Last but not least, we add the <strong>renderer</strong> element to our HTML document. This is a &lt;canvas&gt; element the renderer uses to display the scene to us.</p>
 
-		<div><em>"That's all good, but where's that cube you promised?"</em> Let's add it now.</div>
+		<p><em>"That's all good, but where's that cube you promised?"</em> Let's add it now.</p>
 
 		<code>
 		var geometry = new THREE.BoxGeometry( 1, 1, 1 );
@@ -80,17 +80,17 @@
 		camera.position.z = 5;
 		</code>
 
-		<div>To create a cube, we need a <strong>BoxGeometry</strong>. This is an object that contains all the points (<strong>vertices</strong>) and fill (<strong>faces</strong>) of the cube. We'll explore this more in the future.</div>
+		<p>To create a cube, we need a <strong>BoxGeometry</strong>. This is an object that contains all the points (<strong>vertices</strong>) and fill (<strong>faces</strong>) of the cube. We'll explore this more in the future.</p>
 
-		<div>In addition to the geometry, we need a material to color it. Three.js comes with several materials, but we'll stick to the <strong>MeshBasicMaterial</strong> for now. All materials take an object of properties which will be applied to them. To keep things very simple, we only supply a color attribute of <strong>0x00ff00</strong>, which is green. This works the same way that colors work in CSS or Photoshop (<strong>hex colors</strong>).</div>
+		<p>In addition to the geometry, we need a material to color it. Three.js comes with several materials, but we'll stick to the <strong>MeshBasicMaterial</strong> for now. All materials take an object of properties which will be applied to them. To keep things very simple, we only supply a color attribute of <strong>0x00ff00</strong>, which is green. This works the same way that colors work in CSS or Photoshop (<strong>hex colors</strong>).</p>
 
-		<div>The third thing we need is a <strong>Mesh</strong>. A mesh is an object that takes a geometry, and applies a material to it, which we then can insert to our scene, and move freely around.</div>
+		<p>The third thing we need is a <strong>Mesh</strong>. A mesh is an object that takes a geometry, and applies a material to it, which we then can insert to our scene, and move freely around.</p>
 
-		<div>By default, when we call <strong>scene.add()</strong>, the thing we add will be added to the coordinates <strong>(0,0,0)</strong>. This would cause both the camera and the cube to be inside each other. To avoid this, we simply move the camera out a bit.</div>
+		<p>By default, when we call <strong>scene.add()</strong>, the thing we add will be added to the coordinates <strong>(0,0,0)</strong>. This would cause both the camera and the cube to be inside each other. To avoid this, we simply move the camera out a bit.</p>
 
 		<h2>Rendering the scene</h2>
 
-		<div>If you copied the code from above into the HTML file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a <strong>render or animate loop</strong>.</div>
+		<p>If you copied the code from above into the HTML file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a <strong>render or animate loop</strong>.</p>
 
 		<code>
 		function animate() {
@@ -100,26 +100,26 @@
 		animate();
 		</code>
 
-		<div>This will create a loop that causes the renderer to draw the scene every time the screen is refreshed (on a typical screen this means 60 times per second). If you're new to writing games in the browser, you might say <em>"why don't we just create a setInterval ?"</em> The thing is - we could, but <strong>requestAnimationFrame</strong> has a number of advantages. Perhaps the most important one is that it pauses when the user navigates to another browser tab, hence not wasting their precious processing power and battery life.</div>
+		<p>This will create a loop that causes the renderer to draw the scene every time the screen is refreshed (on a typical screen this means 60 times per second). If you're new to writing games in the browser, you might say <em>"why don't we just create a setInterval ?"</em> The thing is - we could, but <strong>requestAnimationFrame</strong> has a number of advantages. Perhaps the most important one is that it pauses when the user navigates to another browser tab, hence not wasting their precious processing power and battery life.</p>
 
 		<h2>Animating the cube</h2>
 
-		<div>If you insert all the code above into the file you created before we began, you should see a green box. Let's make it all a little more interesting by rotating it.</div>
+		<p>If you insert all the code above into the file you created before we began, you should see a green box. Let's make it all a little more interesting by rotating it.</p>
 
-		<div>Add the following right above the <strong>renderer.render</strong> call in your <strong>animate</strong> function:</div>
+		<p>Add the following right above the <strong>renderer.render</strong> call in your <strong>animate</strong> function:</p>
 
 		<code>
 		cube.rotation.x += 0.1;
 		cube.rotation.y += 0.1;
 		</code>
 
-		<div>This will be run every frame (normally 60 times per second), and give the cube a nice rotation animation. Basically, anything you want to move or change while the app is running has to go through the animate loop. You can of course call other functions from there, so that you don't end up with a <strong>animate</strong> function that's hundreds of lines.
+		<p>This will be run every frame (normally 60 times per second), and give the cube a nice rotation animation. Basically, anything you want to move or change while the app is running has to go through the animate loop. You can of course call other functions from there, so that you don't end up with a <strong>animate</strong> function that's hundreds of p.
 		</div>
 
 		<h2>The result</h2>
-		<div>Congratulations! You have now completed your first three.js application. It's simple, you have to start somewhere.</div>
+		<p>Congratulations! You have now completed your first three.js application. It's simple, you have to start somewhere.</p>
 
-		<div>The full code is available below. Play around with it to get a better understanding of how it works.</div>
+		<p>The full code is available below. Play around with it to get a better understanding of how it works.</p>
 
 		<code>
 		&lt;html&gt;

--- a/docs/page.css
+++ b/docs/page.css
@@ -45,6 +45,12 @@ h3 {
 	margin-top: 40px;
 }
 
+p {
+	margin-top: 0;
+	margin-bottom: 20px;
+	max-width: 780px;
+}
+
 div {
 	/* padding-left: 30px; */
 	margin-bottom: 20px;


### PR DESCRIPTION
I find the line widths in our documentation a bit too much, and [typography best practice is about 50-75 characters per line](https://baymard.com/blog/line-length-readability). This PR would reduce line widths to ~100 characters, trying not to go _too_ crazy here. If this looks OK I'll update other pages. 😅

| [Before](https://threejs.org/docs/#manual/introduction/Creating-a-scene) | [After](https://rawgit.com/donmccurdy/three.js/docs-max-line-width/docs/#manual/introduction/Creating-a-scene) |
|--|--|
| ![screen shot 2018-03-24 at 4 57 13 pm](https://user-images.githubusercontent.com/1848368/37870179-72325e00-2f84-11e8-9534-a62ff8f33f17.png) | ![screen shot 2018-03-24 at 4 57 15 pm](https://user-images.githubusercontent.com/1848368/37870180-73d00dca-2f84-11e8-9bb4-0592395242a0.png) |
