### PR TITLE
GLTFExporter: Prevent exporting empty geometry

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1070,6 +1070,8 @@ THREE.GLTFExporter.prototype = {
 			var forceIndices = options.forceIndices;
 			var isMultiMaterial = Array.isArray( mesh.material );
 
+			if ( isMultiMaterial && mesh.geometry.groups.length === 0 ) return null;
+
 			if ( ! forceIndices && geometry.index === null && isMultiMaterial ) {
 
 				// temporal workaround.
@@ -1129,12 +1131,6 @@ THREE.GLTFExporter.prototype = {
 			if ( didForceIndices ) {
 
 				geometry.setIndex( null );
-
-			}
-
-			if ( primitives.length === 0 ) {
-
-				return null;
 
 			}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -149,7 +149,7 @@ THREE.GLTFExporter.prototype = {
 				var value = text.charCodeAt( i );
 
 				// Replacing multi-byte character with space(0x20).
-				array[ i ] = value > 0xFF ? 0x20 : value
+				array[ i ] = value > 0xFF ? 0x20 : value;
 
 			}
 
@@ -479,7 +479,7 @@ THREE.GLTFExporter.prototype = {
 			}
 
 			// Skip creating an accessor if the attribute doesn't have data to export
-			if ( count === 0) {
+			if ( count === 0 ) {
 
 				return null;
 
@@ -963,7 +963,7 @@ THREE.GLTFExporter.prototype = {
 				}
 
 				if ( attributeName.substr( 0, 5 ) !== 'MORPH' ) {
-					
+
 					var accessor = processAccessor( attribute, geometry );
 					if ( accessor !== null ) {
 
@@ -1089,7 +1089,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var materials = isMultiMaterial ? mesh.material : [ mesh.material ] ;
+			var materials = isMultiMaterial ? mesh.material : [ mesh.material ];
 			var groups = isMultiMaterial ? mesh.geometry.groups : [ { materialIndex: 0, start: undefined, count: undefined } ];
 
 			for ( var i = 0, il = groups.length; i < il; i ++ ) {
@@ -1108,16 +1108,16 @@ THREE.GLTFExporter.prototype = {
 				}
 
 				// Skip meshes without exportable attributes
-				if ( Object.keys(primitive.attributes).length > 0 ) {
+				if ( Object.keys( primitive.attributes ).length > 0 ) {
 
 					var material = processMaterial( materials[ groups[ i ].materialIndex ] );
 
 					if ( material !== null ) {
-	
+
 						primitive.material = material;
-	
+
 					}
-	
+
 					primitives.push( primitive );
 
 				}
@@ -1143,7 +1143,7 @@ THREE.GLTFExporter.prototype = {
 				outputJSON.meshes = [];
 
 			}
-			
+
 			outputJSON.meshes.push( gltfMesh );
 
 			return outputJSON.meshes.length - 1;

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -975,6 +975,13 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
+			// Skip if no exportable attributes found
+			if ( Object.keys( attributes ).length === 0 ) {
+
+				return null;
+
+			}
+
 			// Morph targets
 			if ( mesh.morphTargetInfluences !== undefined && mesh.morphTargetInfluences.length > 0 ) {
 
@@ -1107,20 +1114,15 @@ THREE.GLTFExporter.prototype = {
 
 				}
 
-				// Skip meshes without exportable attributes
-				if ( Object.keys( primitive.attributes ).length > 0 ) {
+				var material = processMaterial( materials[ groups[ i ].materialIndex ] );
 
-					var material = processMaterial( materials[ groups[ i ].materialIndex ] );
+				if ( material !== null ) {
 
-					if ( material !== null ) {
-
-						primitive.material = material;
-
-					}
-
-					primitives.push( primitive );
+					primitive.material = material;
 
 				}
+
+				primitives.push( primitive );
 
 			}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1101,14 +1101,6 @@ THREE.GLTFExporter.prototype = {
 
 				if ( targets.length > 0 ) primitive.targets = targets;
 
-				var material = processMaterial( materials[ groups[ i ].materialIndex ] );
-
-				if ( material !== null ) {
-
-					primitive.material = material;
-
-				}
-
 				if ( geometry.index !== null ) {
 
 					primitive.indices = processAccessor( geometry.index, geometry, groups[ i ].start, groups[ i ].count );
@@ -1118,6 +1110,14 @@ THREE.GLTFExporter.prototype = {
 				// Skip meshes without exportable attributes
 				if ( Object.keys(primitive.attributes).length > 0 ) {
 
+					var material = processMaterial( materials[ groups[ i ].materialIndex ] );
+
+					if ( material !== null ) {
+	
+						primitive.material = material;
+	
+					}
+	
 					primitives.push( primitive );
 
 				}

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -481,7 +481,7 @@ THREE.GLTFExporter.prototype = {
 			// Skip creating an accessor if the attribute doesn't have data to export
 			if ( count === 0) {
 
-				return -1;
+				return null;
 
 			}
 
@@ -965,7 +965,7 @@ THREE.GLTFExporter.prototype = {
 				if ( attributeName.substr( 0, 5 ) !== 'MORPH' ) {
 					
 					var accessor = processAccessor( attribute, geometry );
-					if ( accessor !== -1 ) {
+					if ( accessor !== null ) {
 
 						attributes[ attributeName ] = accessor;
 
@@ -1132,7 +1132,7 @@ THREE.GLTFExporter.prototype = {
 
 			if ( primitives.length === 0 ) {
 
-				return -1;
+				return null;
 
 			}
 
@@ -1445,7 +1445,7 @@ THREE.GLTFExporter.prototype = {
 
 				var mesh = processMesh( object );
 
-				if ( mesh !== -1 ) {
+				if ( mesh !== null ) {
 
 					gltfNode.mesh = mesh;
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -26,6 +26,7 @@
 			<button id="export_scene">Export Scene1</button>
 			<button id="export_scenes">Export Scene1 and Scene 2</button>
 			<button id="export_object">Export Sphere</button>
+			<button id="export_empty">Export empty geometry</button>
 			<button id="export_obj">Export WaltHead</button>
 			<button id="export_objects">Export Sphere and Grid</button>
 			<button id="export_scene_object">Export Scene1 and Sphere</button>
@@ -88,6 +89,13 @@
 
 			} );
 
+
+			document.getElementById( 'export_empty' ).addEventListener( 'click', function () {
+
+			exportGLTF( empty );
+
+			} );
+
 			document.getElementById( 'export_object' ).addEventListener( 'click', function () {
 
 				exportGLTF( sphere );
@@ -145,7 +153,7 @@
 			var container;
 
 			var camera, object, scene1, scene2, renderer;
-			var gridHelper, sphere, waltHead;
+			var gridHelper, sphere, waltHead, empty;
 
 			init();
 			animate();
@@ -416,6 +424,24 @@
 				object.position.set( 340, -40, -200 );
 
 				scene1.add( object );
+
+				// ---------------------------------------------------------------------
+				// Empty buffer geometry
+				// ---------------------------------------------------------------------
+				var geometry = new THREE.BufferGeometry();
+				var numElements = 6;
+
+				var positions = new Float32Array( ( numElements ) * 3 );
+				var colors = new Float32Array( ( numElements ) * 3 );
+
+				geometry.addAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
+				geometry.addAttribute( 'color', new THREE.BufferAttribute( colors, 3 ) );
+				geometry.setDrawRange( 0, 0 );
+
+				empty = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( { side: THREE.DoubleSide, vertexColors: THREE.VertexColors } ) );
+				empty.name = 'Custom buffered empty (drawrange)';
+				scene1.add( empty );
+
 
 				// ---------------------------------------------------------------------
 				// Points

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -26,7 +26,6 @@
 			<button id="export_scene">Export Scene1</button>
 			<button id="export_scenes">Export Scene1 and Scene 2</button>
 			<button id="export_object">Export Sphere</button>
-			<button id="export_empty">Export empty geometry</button>
 			<button id="export_obj">Export WaltHead</button>
 			<button id="export_objects">Export Sphere and Grid</button>
 			<button id="export_scene_object">Export Scene1 and Sphere</button>
@@ -89,13 +88,6 @@
 
 			} );
 
-
-			document.getElementById( 'export_empty' ).addEventListener( 'click', function () {
-
-			exportGLTF( empty );
-
-			} );
-
 			document.getElementById( 'export_object' ).addEventListener( 'click', function () {
 
 				exportGLTF( sphere );
@@ -153,7 +145,7 @@
 			var container;
 
 			var camera, object, scene1, scene2, renderer;
-			var gridHelper, sphere, waltHead, empty;
+			var gridHelper, sphere, waltHead;
 
 			init();
 			animate();
@@ -424,24 +416,6 @@
 				object.position.set( 340, -40, -200 );
 
 				scene1.add( object );
-
-				// ---------------------------------------------------------------------
-				// Empty buffer geometry
-				// ---------------------------------------------------------------------
-				var geometry = new THREE.BufferGeometry();
-				var numElements = 6;
-
-				var positions = new Float32Array( ( numElements ) * 3 );
-				var colors = new Float32Array( ( numElements ) * 3 );
-
-				geometry.addAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
-				geometry.addAttribute( 'color', new THREE.BufferAttribute( colors, 3 ) );
-				geometry.setDrawRange( 0, 0 );
-
-				empty = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( { side: THREE.DoubleSide, vertexColors: THREE.VertexColors } ) );
-				empty.name = 'Custom buffered empty (drawrange)';
-				scene1.add( empty );
-
 
 				// ---------------------------------------------------------------------
 				// Points

--- a/test/unit/example/exporters/GLTFExporter.tests.js
+++ b/test/unit/example/exporters/GLTFExporter.tests.js
@@ -19,7 +19,7 @@ export default QUnit.module( 'Exporters', () => {
 
       var done = assert.async();
 
-      var object = new THREE.Object3D()
+      var object = new THREE.Object3D();
 
       var exporter = new THREE.GLTFExporter();
 
@@ -120,6 +120,41 @@ export default QUnit.module( 'Exporters', () => {
 
     } );
 
+    QUnit.test( 'parse - empty buffergeometry', ( assert ) => {
+
+      var done = assert.async();
+
+      var scene = new THREE.Scene();
+      var geometry = new THREE.BufferGeometry();
+      var numElements = 6;
+
+      var positions = new Float32Array( ( numElements ) * 3 );
+      var colors = new Float32Array( ( numElements ) * 3 );
+
+      geometry.addAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
+      geometry.addAttribute( 'color', new THREE.BufferAttribute( colors, 3 ) );
+      geometry.setDrawRange( 0, 0 );
+
+      var empty = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( { side: THREE.DoubleSide, vertexColors: THREE.VertexColors } ) );
+      empty.name = 'Custom buffered empty (drawrange)';
+      scene.add( empty );
+
+      var exporter = new THREE.GLTFExporter();
+
+      exporter.parse( scene, function ( gltf ) {
+
+        assert.equal( result.meshes, undefined, 'empty meshes');
+        assert.equal( result.materials, undefined, 'empty materials');
+        assert.equal( result.bufferViews, undefined, 'empty bufferViews');
+        assert.equal( result.buffers, undefined, 'buffers');
+        assert.equal( result.accessors, undefined, 'accessors');
+        assert.equal( result.nodes[0].mesh, undefined, 'nodes[0].mesh');
+
+        done();
+
+      });
+
+    } );
 
   } );
 

--- a/test/unit/example/exporters/GLTFExporter.tests.js
+++ b/test/unit/example/exporters/GLTFExporter.tests.js
@@ -143,12 +143,12 @@ export default QUnit.module( 'Exporters', () => {
 
       exporter.parse( scene, function ( gltf ) {
 
-        assert.equal( result.meshes, undefined, 'empty meshes');
-        assert.equal( result.materials, undefined, 'empty materials');
-        assert.equal( result.bufferViews, undefined, 'empty bufferViews');
-        assert.equal( result.buffers, undefined, 'buffers');
-        assert.equal( result.accessors, undefined, 'accessors');
-        assert.equal( result.nodes[0].mesh, undefined, 'nodes[0].mesh');
+        assert.equal( gltf.meshes, undefined, 'empty meshes');
+        assert.equal( gltf.materials, undefined, 'empty materials');
+        assert.equal( gltf.bufferViews, undefined, 'empty bufferViews');
+        assert.equal( gltf.buffers, undefined, 'buffers');
+        assert.equal( gltf.accessors, undefined, 'accessors');
+        assert.equal( gltf.nodes[0].mesh, undefined, 'nodes[0].mesh');
 
         done();
 


### PR DESCRIPTION
I've just found a bug when exporting empty buffer geometries. eg in a-painter I create a buffer geometry for each kind of material but maybe I don't use one of them so drawRange will be 0. If you try to export it it will generate the following glTF:
```json
{
  "asset": {
    "version": "2.0",
    "generator": "THREE.GLTFExporter"
  },
  "scenes": [
    {
      "nodes": [
        0
      ],
      "name": "AuxScene"
    }
  ],
  "scene": 0,
  "nodes": [
    {
      "name": "Custom buffered empty (drawrange)",
      "mesh": 0
    }
  ],
  "bufferViews": [
    {
      "buffer": 0,
      "byteOffset": 0,
      "byteLength": 0,
      "target": 34962,
      "byteStride": 12
    },
    {
      "buffer": 0,
      "byteOffset": 0,
      "byteLength": 0,
      "target": 34962,
      "byteStride": 12
    }
  ],
  "buffers": [
    {
      "byteLength": 0,
      "uri": "data:"
    }
  ],
  "accessors": [
    {
      "bufferView": 0,
      "componentType": 5126,
      "count": 0,
      "max": [
        null,
        null,
        null
      ],
      "min": [
        null,
        null,
        null
      ],
      "type": "VEC3"
    },
    {
      "bufferView": 1,
      "componentType": 5126,
      "count": 0,
      "max": [
        null,
        null,
        null
      ],
      "min": [
        null,
        null,
        null
      ],
      "type": "VEC3"
    }
  ],
  "materials": [
    {
      "pbrMetallicRoughness": {
        "metallicFactor": 0,
        "roughnessFactor": 0.9
      },
      "extensions": {
        "KHR_materials_unlit": {}
      },
      "doubleSided": true
    }
  ],
  "meshes": [
    {
      "primitives": [
        {
          "mode": 4,
          "attributes": {
            "POSITION": 0,
            "COLOR_0": 1
          },
          "material": 0
        }
      ]
    }
  ],
  "extensionsUsed": [
    "KHR_materials_unlit"
  ]
}
```

The accessors has an invalid range and the bufferviews are empty.

This PR prevents it to happens by skipping attributes that has no values, and primitives that has no attributes, and meshes that has no primitives.

I added a empty node and a button to test it. The expected output for the previous example will be:
```
{
  "asset": {
    "version": "2.0",
    "generator": "THREE.GLTFExporter"
  },
  "scenes": [
    {
      "nodes": [
        0
      ],
      "name": "AuxScene"
    }
  ],
  "scene": 0,
  "nodes": [
    {
      "name": "Custom buffered empty (drawrange)"
    }
  ]
}
```