### PR TITLE
fix wrong parser behavior to Tr option with parameter invertTrProperty in MTLLoader.js

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -464,9 +464,9 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					if ( this.options && this.options.invertTrProperty ) n = 1 - n;
 
-					if ( n < 1 ) {
+					if ( n > 0 ) {
 
-						params.opacity = n;
+						params.opacity = 1 - n;
 						params.transparent = true;
 
 					}


### PR DESCRIPTION
cc #12862

with my apologize for making this issue.

sorry to anyone confused by my mistake.