### PR TITLE
Document clippingPlanes render setting dependency

### DIFF
--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -85,6 +85,7 @@
 		User-defined clipping planes specified as THREE.Plane objects in world space.
 		These planes apply to the objects this material is attached to.
 		Points in space whose signed distance to the plane is negative are clipped (not rendered).
+		This requires [page:WebGLRenderer.localClippingEnabled] to be *true*.
 		See the [example:webgl_clipping_intersection WebGL / clipping /intersection] example.
 		Default is *null*.
 		</div>


### PR DESCRIPTION
Hello

I was trying out the `clippingPlanes` feature of materials and it was only after carefully examining the example that I found the necessary change to the webglrenderer instance. It would be helpful to reference this in the clipping planes description.