### PR TITLE
Add .getBoneByName() to Skeleton Doc

### DIFF
--- a/docs/api/objects/Skeleton.html
+++ b/docs/api/objects/Skeleton.html
@@ -103,6 +103,13 @@ var armSkeleton = new THREE.Skeleton( bones );
 		This is called automatically by the [page:WebGLRenderer] if the skeleton is used with a [page:SkinnedMesh].
 		</div>
 
+		<h3>[method:Bone getBoneByName]( [param:String name] )</h3>
+		<div>
+		name -- String to match to the Bone's .name property. <br /><br />
+
+		Searches through the skeleton's bone array and returns the first with a matching name.<br />
+		</div>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]


### PR DESCRIPTION
This PR adds `.getBoneByName()` to `Skeleton` Doc.