### PR TITLE
Support webgl2 and GLSL 3.00

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -65,7 +65,9 @@ function WebGLRenderer( parameters ) {
 		_antialias = parameters.antialias !== undefined ? parameters.antialias : false,
 		_premultipliedAlpha = parameters.premultipliedAlpha !== undefined ? parameters.premultipliedAlpha : true,
 		_preserveDrawingBuffer = parameters.preserveDrawingBuffer !== undefined ? parameters.preserveDrawingBuffer : false,
-		_powerPreference = parameters.powerPreference !== undefined ? parameters.powerPreference : 'default';
+		_powerPreference = parameters.powerPreference !== undefined ? parameters.powerPreference : 'default',
+		_webglversion = parameters.webgl2 !== undefined  ? 'webgl2' : 'webgl';
+
 
 	var currentRenderList = null;
 	var currentRenderState = null;
@@ -190,11 +192,11 @@ function WebGLRenderer( parameters ) {
 		_canvas.addEventListener( 'webglcontextlost', onContextLost, false );
 		_canvas.addEventListener( 'webglcontextrestored', onContextRestore, false );
 
-		_gl = _context || _canvas.getContext( 'webgl', contextAttributes ) || _canvas.getContext( 'experimental-webgl', contextAttributes );
+		_gl = _context || _canvas.getContext( _webglversion, contextAttributes );
 
 		if ( _gl === null ) {
 
-			if ( _canvas.getContext( 'webgl' ) !== null ) {
+			if ( _canvas.getContext( _webglversion ) !== null ) {
 
 				throw new Error( 'Error creating WebGL context with your selected attributes.' );
 
@@ -2427,7 +2429,7 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	this.setRenderTarget = function ( renderTarget ) {
+	this.setRenderTarget = function ( renderTarget, optType ) {
 
 		_currentRenderTarget = renderTarget;
 
@@ -2469,7 +2471,7 @@ function WebGLRenderer( parameters ) {
 
 		if ( _currentFramebuffer !== framebuffer ) {
 
-			_gl.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
+			_gl.bindFramebuffer( optType || _gl.FRAMEBUFFER, framebuffer );
 			_currentFramebuffer = framebuffer;
 
 		}

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_pars_fragment.glsl
@@ -1,7 +1,11 @@
 #if NUM_CLIPPING_PLANES > 0
 
 	#if ! defined( PHYSICAL ) && ! defined( PHONG )
+	#if defined(NEEDSGLSL300)
+		in vec3 vViewPosition;
+        #else
 		varying vec3 vViewPosition;
+	#endif
 	#endif
 
 	uniform vec4 clippingPlanes[ NUM_CLIPPING_PLANES ];

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_pars_vertex.glsl
@@ -1,3 +1,7 @@
 #if NUM_CLIPPING_PLANES > 0 && ! defined( PHYSICAL ) && ! defined( PHONG )
+#if defined(NEEDSGLSL300)
+	out vec3 vViewPosition;
+#else
 	varying vec3 vViewPosition;
+#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/color_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/color_pars_fragment.glsl
@@ -1,5 +1,8 @@
 #ifdef USE_COLOR
 
+#if defined(NEEDSGLSL300)
+	in vec3 vColor;
+#else
 	varying vec3 vColor;
-
+#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/color_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/color_pars_vertex.glsl
@@ -1,5 +1,7 @@
 #ifdef USE_COLOR
-
+#if defined(NEEDSGLSL300)
+	out vec3 vColor;
+#else
 	varying vec3 vColor;
-
+#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/common.glsl
+++ b/src/renderers/shaders/ShaderChunk/common.glsl
@@ -93,3 +93,10 @@ float linearToRelativeLuminance( const in vec3 color ) {
 	return dot( weights, color.rgb );
 
 }
+
+#if defined(NEEDSGLSL300)
+vec4 texture2D(sampler2D s, vec2 uv) {
+	return texture(s, uv);
+}
+#endif
+

--- a/src/renderers/shaders/ShaderChunk/dithering_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/dithering_fragment.glsl
@@ -1,5 +1,8 @@
 #if defined( DITHERING )
 
+#if defined(NEEDSGLSL300)
+  glFragColor.rgb = dithering( glFragColor.rgb );
+#else
   gl_FragColor.rgb = dithering( gl_FragColor.rgb );
-
+#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/encodings_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/encodings_fragment.glsl
@@ -1,1 +1,5 @@
+#if defined(NEEDSGLSL300)
+  glFragColor = linearToOutputTexel( glFragColor );
+#else
   gl_FragColor = linearToOutputTexel( gl_FragColor );
+#endif

--- a/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl
@@ -6,7 +6,11 @@
 #ifdef USE_ENVMAP
 
 	#if ! defined( PHYSICAL ) && ( defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) )
+	#if defined(NEEDSGLSL300)
+		in vec3 vWorldPosition;
+	#else
 		varying vec3 vWorldPosition;
+	#endif
 	#endif
 
 	#ifdef ENVMAP_TYPE_CUBE
@@ -20,7 +24,11 @@
 	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) || defined( PHYSICAL )
 		uniform float refractionRatio;
 	#else
+	#if defined(NEEDSGLSL300)
+		in vec3 vReflect;
+	#else
 		varying vec3 vReflect;
+	#endif
 	#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/envmap_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/envmap_pars_vertex.glsl
@@ -1,11 +1,19 @@
 #ifdef USE_ENVMAP
 
 	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )
+	#if defined(NEEDSGLSL300)
+		out vec3 vWorldPosition;
+	#else
 		varying vec3 vWorldPosition;
+	#endif
 
 	#else
 
+	#if defined(NEEDSGLSL300)
+		out vec3 vReflect;
+	#else
 		varying vec3 vReflect;
+	#endif
 		uniform float refractionRatio;
 
 	#endif

--- a/src/renderers/shaders/ShaderChunk/fog_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/fog_fragment.glsl
@@ -10,6 +10,9 @@
 
 	#endif
 
+#if defined(NEEDSGLSL300)
+	glFragColor.rgb = mix( glFragColor.rgb, fogColor, fogFactor );
+#else
 	gl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor );
-
+#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/fog_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/fog_pars_fragment.glsl
@@ -1,7 +1,11 @@
 #ifdef USE_FOG
 
 	uniform vec3 fogColor;
+#if defined(NEEDSGLSL300)
+	in float fogDepth;
+#else
 	varying float fogDepth;
+#endif
 
 	#ifdef FOG_EXP2
 

--- a/src/renderers/shaders/ShaderChunk/fog_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/fog_pars_vertex.glsl
@@ -1,5 +1,9 @@
 #ifdef USE_FOG
 
+#if defined(NEEDSGLSL300)
+  out float fogDepth;
+#else
   varying float fogDepth;
+#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl
@@ -1,8 +1,16 @@
+#if defined(NEEDSGLSL300)
+in vec3 vViewPosition;
+#else
 varying vec3 vViewPosition;
+#endif
 
 #ifndef FLAT_SHADED
 
+#if defined(NEEDSGLSL300)
+	in vec3 vNormal;
+#else
 	varying vec3 vNormal;
+#endif
 
 #endif
 

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl
@@ -4,7 +4,11 @@
 
 	#ifdef USE_LOGDEPTHBUF_EXT
 
+	#if defined(NEEDSGLSL300)
+		in float vFragDepth;
+	#else
 		varying float vFragDepth;
+	#endif
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl
@@ -2,7 +2,11 @@
 
 	#ifdef USE_LOGDEPTHBUF_EXT
 
+	#if defined(NEEDSGLSL300)
+		out float vFragDepth;
+	#else
 		varying float vFragDepth;
+	#endif
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/premultiplied_alpha_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/premultiplied_alpha_fragment.glsl
@@ -1,6 +1,9 @@
 #ifdef PREMULTIPLIED_ALPHA
 
 	// Get get normal blending with premultipled, use with CustomBlending, OneFactor, OneMinusSrcAlphaFactor, AddEquation.
+#if defined(NEEDSGLSL300)
+	glFragColor.rgb *= glFragColor.a;
+#else
 	gl_FragColor.rgb *= gl_FragColor.a;
-
+#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
@@ -3,21 +3,33 @@
 	#if NUM_DIR_LIGHTS > 0
 
 		uniform sampler2D directionalShadowMap[ NUM_DIR_LIGHTS ];
+	#if defined(NEEDSGLSL300)
+		in vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
+	#else
 		varying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
+	#endif
 
 	#endif
 
 	#if NUM_SPOT_LIGHTS > 0
 
 		uniform sampler2D spotShadowMap[ NUM_SPOT_LIGHTS ];
+	#if defined(NEEDSGLSL300)
+		in vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];
+	#else
 		varying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];
+	#endif
 
 	#endif
 
 	#if NUM_POINT_LIGHTS > 0
 
 		uniform sampler2D pointShadowMap[ NUM_POINT_LIGHTS ];
+	#if defined(NEEDSGLSL300)
+		in vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];
+	#else
 		varying vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];
+	#endif
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl
@@ -3,21 +3,33 @@
 	#if NUM_DIR_LIGHTS > 0
 
 		uniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHTS ];
+	#if defined(NEEDSGLSL300)
+		out vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
+	#else
 		varying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
+	#endif
 
 	#endif
 
 	#if NUM_SPOT_LIGHTS > 0
 
 		uniform mat4 spotShadowMatrix[ NUM_SPOT_LIGHTS ];
+	#if defined(NEEDSGLSL300)
+		out vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];
+	#else
 		varying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];
+	#endif
 
 	#endif
 
 	#if NUM_POINT_LIGHTS > 0
 
 		uniform mat4 pointShadowMatrix[ NUM_POINT_LIGHTS ];
+	#if defined(NEEDSGLSL300)
+		out vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];
+	#else
 		varying vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];
+	#endif
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/tonemapping_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_fragment.glsl
@@ -1,5 +1,9 @@
 #if defined( TONE_MAPPING )
 
+#if defined(NEEDSGLSL300)
+  glFragColor.rgb = toneMapping( glFragColor.rgb );
+#else
   gl_FragColor.rgb = toneMapping( gl_FragColor.rgb );
+#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/uv2_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/uv2_pars_fragment.glsl
@@ -1,5 +1,8 @@
 #if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )
-
+#if defined(NEEDSGLSL300)
+	in vec2 vUv2;
+#else
 	varying vec2 vUv2;
+#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/uv2_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/uv2_pars_vertex.glsl
@@ -1,6 +1,11 @@
 #if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )
 
+#if defined(NEEDSGLSL300)
+	in vec2 uv2;
+	out vec2 vUv2;
+#else
 	attribute vec2 uv2;
 	varying vec2 vUv2;
+#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/uv_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/uv_pars_fragment.glsl
@@ -1,5 +1,8 @@
 #if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )
 
+#if defined(NEEDSGLSL300)
+	in vec2 vUv;
+#else
 	varying vec2 vUv;
-
+#endif
 #endif

--- a/src/renderers/shaders/ShaderChunk/uv_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/uv_pars_vertex.glsl
@@ -1,6 +1,10 @@
 #if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )
 
+#if defined(NEEDSGLSL300)
+	out vec2 vUv;
+#else
 	varying vec2 vUv;
+#endif
 	uniform mat3 uvTransform;
 
 #endif

--- a/src/renderers/shaders/ShaderLib/cube_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/cube_frag.glsl
@@ -2,11 +2,24 @@ uniform samplerCube tCube;
 uniform float tFlip;
 uniform float opacity;
 
+#if defined(NEEDSGLSL300)
+in vec3 vWorldPosition;
+#else
 varying vec3 vWorldPosition;
+#endif
+
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
+#endif
 
 void main() {
 
+#if defined(NEEDSGLSL300)
+	glFragColor = textureCube( tCube, vec3( tFlip * vWorldPosition.x, vWorldPosition.yz ) );
+	glFragColor.a *= opacity;
+#else
 	gl_FragColor = textureCube( tCube, vec3( tFlip * vWorldPosition.x, vWorldPosition.yz ) );
 	gl_FragColor.a *= opacity;
+#endif
 
 }

--- a/src/renderers/shaders/ShaderLib/cube_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/cube_vert.glsl
@@ -1,4 +1,8 @@
+#if defined(NEEDSGLSL300)
+out vec3 vWorldPosition;
+#else
 varying vec3 vWorldPosition;
+#endif
 
 #include <common>
 

--- a/src/renderers/shaders/ShaderLib/depth_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/depth_frag.glsl
@@ -12,6 +12,11 @@
 #include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
+#endif
+
+
 void main() {
 
 	#include <clipping_planes_fragment>
@@ -32,11 +37,19 @@ void main() {
 
 	#if DEPTH_PACKING == 3200
 
+#if defined(NEEDSGLSL300)
+		glFragColor = vec4( vec3( gl_FragCoord.z ), opacity );
+#else
 		gl_FragColor = vec4( vec3( 1.0 - gl_FragCoord.z ), opacity );
+#endif
 
 	#elif DEPTH_PACKING == 3201
 
+#if defined(NEEDSGLSL300)
+		glFragColor = packDepthToRGBA( gl_FragCoord.z );
+#else
 		gl_FragColor = packDepthToRGBA( gl_FragCoord.z );
+#endif
 
 	#endif
 

--- a/src/renderers/shaders/ShaderLib/distanceRGBA_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/distanceRGBA_frag.glsl
@@ -3,7 +3,11 @@
 uniform vec3 referencePosition;
 uniform float nearDistance;
 uniform float farDistance;
+#if defined(NEEDSGLSL300)
+in vec3 vWorldPosition;
+#else
 varying vec3 vWorldPosition;
+#endif
 
 #include <common>
 #include <packing>
@@ -26,6 +30,10 @@ void main () {
 	dist = ( dist - nearDistance ) / ( farDistance - nearDistance );
 	dist = saturate( dist ); // clamp to [ 0, 1 ]
 
+#if defined(NEEDSGLSL300)
+	glFragColor = packDepthToRGBA( dist );
+#else
 	gl_FragColor = packDepthToRGBA( dist );
+#endif
 
 }

--- a/src/renderers/shaders/ShaderLib/distanceRGBA_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/distanceRGBA_vert.glsl
@@ -1,6 +1,10 @@
 #define DISTANCE
 
+#if defined(NEEDSGLSL300)
+out vec3 vWorldPosition;
+#else
 varying vec3 vWorldPosition;
+#endif
 
 #include <common>
 #include <uv_pars_vertex>

--- a/src/renderers/shaders/ShaderLib/equirect_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/equirect_frag.glsl
@@ -1,6 +1,14 @@
 uniform sampler2D tEquirect;
 
+#if defined(NEEDSGLSL300)
+in vec3 vWorldPosition;
+#else
 varying vec3 vWorldPosition;
+#endif
+
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
+#endif
 
 #include <common>
 
@@ -14,6 +22,10 @@ void main() {
 
 	sampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_PI2 + 0.5;
 
+#if defined(NEEDSGLSL300)
+	glFragColor = texture2D( tEquirect, sampleUV );
+#else
 	gl_FragColor = texture2D( tEquirect, sampleUV );
+#endif
 
 }

--- a/src/renderers/shaders/ShaderLib/equirect_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/equirect_vert.glsl
@@ -1,4 +1,8 @@
+#if defined(NEEDSGLSL300)
+out vec3 vWorldPosition;
+#else
 varying vec3 vWorldPosition;
+#endif
 
 #include <common>
 

--- a/src/renderers/shaders/ShaderLib/linedashed_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/linedashed_frag.glsl
@@ -4,7 +4,15 @@ uniform float opacity;
 uniform float dashSize;
 uniform float totalSize;
 
+#if defined(NEEDSGLSL300)
+in float vLineDistance;
+#else
 varying float vLineDistance;
+#endif
+
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
+#endif
 
 #include <common>
 #include <color_pars_fragment>
@@ -30,8 +38,11 @@ void main() {
 
 	outgoingLight = diffuseColor.rgb; // simple shader
 
+#if defined(NEEDSGLSL300)
+	glFragColor = vec4( outgoingLight, diffuseColor.a );
+#else
 	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+#endif
 	#include <premultiplied_alpha_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>

--- a/src/renderers/shaders/ShaderLib/linedashed_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/linedashed_vert.glsl
@@ -1,7 +1,15 @@
 uniform float scale;
+#if defined(NEEDSGLSL300)
+in float lineDistance;
+#else
 attribute float lineDistance;
+#endif
 
+#if defined(NEEDSGLSL300)
+out float vLineDistance;
+#else
 varying float vLineDistance;
+#endif
 
 #include <common>
 #include <color_pars_vertex>

--- a/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl
@@ -3,9 +3,18 @@ uniform float opacity;
 
 #ifndef FLAT_SHADED
 
+#if defined(NEEDSGLSL300)
+	in vec3 vNormal;
+#else
 	varying vec3 vNormal;
+#endif
 
 #endif
+
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
+#endif
+
 
 #include <common>
 #include <color_pars_fragment>
@@ -56,7 +65,11 @@ void main() {
 
 	#include <envmap_fragment>
 
+#if defined(NEEDSGLSL300)
+	glFragColor = vec4( outgoingLight, diffuseColor.a );
+#else
 	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
+#endif
 
 	#include <premultiplied_alpha_fragment>
 	#include <tonemapping_fragment>

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl
@@ -2,13 +2,26 @@ uniform vec3 diffuse;
 uniform vec3 emissive;
 uniform float opacity;
 
+#if defined(NEEDSGLSL300)
+in vec3 vLightFront;
+#else
 varying vec3 vLightFront;
+#endif
 
 #ifdef DOUBLE_SIDED
 
+#if defined(NEEDSGLSL300)
+	in vec3 vLightBack;
+#else
 	varying vec3 vLightBack;
+#endif
 
 #endif
+
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
+#endif
+
 
 #include <common>
 #include <packing>
@@ -74,7 +87,11 @@ void main() {
 
 	#include <envmap_fragment>
 
+#if defined(NEEDSGLSL300)
+	glFragColor = vec4( outgoingLight, diffuseColor.a );
+#else
 	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
+#endif
 
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>

--- a/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl
@@ -1,10 +1,18 @@
 #define LAMBERT
 
+#if defined(NEEDSGLSL300)
+out vec3 vLightFront;
+#else
 varying vec3 vLightFront;
+#endif
 
 #ifdef DOUBLE_SIDED
 
+#if defined(NEEDSGLSL300)
+	out vec3 vLightBack;
+#else
 	varying vec3 vLightBack;
+#endif
 
 #endif
 

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
@@ -31,6 +31,10 @@ uniform float opacity;
 #include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
+#endif
+
 void main() {
 
 	#include <clipping_planes_fragment>
@@ -62,7 +66,11 @@ void main() {
 
 	#include <envmap_fragment>
 
+#if defined(NEEDSGLSL300)
+	glFragColor = vec4( outgoingLight, diffuseColor.a );
+#else
 	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
+#endif
 
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphong_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphong_vert.glsl
@@ -1,10 +1,18 @@
 #define PHONG
 
+#if defined(NEEDSGLSL300)
+out vec3 vViewPosition;
+#else
 varying vec3 vViewPosition;
+#endif
 
 #ifndef FLAT_SHADED
 
+#if defined(NEEDSGLSL300)
+	out vec3 vNormal;
+#else
 	varying vec3 vNormal;
+#endif
 
 #endif
 

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl
@@ -11,12 +11,24 @@ uniform float opacity;
 	uniform float clearCoatRoughness;
 #endif
 
+#if defined(NEEDSGLSL300)
+in vec3 vViewPosition;
+#else
 varying vec3 vViewPosition;
+#endif
 
 #ifndef FLAT_SHADED
 
+#if defined(NEEDSGLSL300)
+	in vec3 vNormal;
+#else
 	varying vec3 vNormal;
+#endif
 
+#endif
+
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
 #endif
 
 #include <common>
@@ -75,7 +87,11 @@ void main() {
 
 	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;
 
+#if defined(NEEDSGLSL300)
+	glFragColor = vec4( outgoingLight, diffuseColor.a );
+#else
 	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
+#endif
 
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl
@@ -1,10 +1,18 @@
 #define PHYSICAL
 
+#if defined(NEEDSGLSL300)
+out vec3 vViewPosition;
+#else
 varying vec3 vViewPosition;
+#endif
 
 #ifndef FLAT_SHADED
 
+#if defined(NEEDSGLSL300)
+	out vec3 vNormal;
+#else
 	varying vec3 vNormal;
+#endif
 
 #endif
 

--- a/src/renderers/shaders/ShaderLib/normal_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/normal_frag.glsl
@@ -4,14 +4,26 @@ uniform float opacity;
 
 #if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP )
 
+#if defined(NEEDSGLSL300)
+	in vec3 vViewPosition;
+#else
 	varying vec3 vViewPosition;
+#endif
 
 #endif
 
 #ifndef FLAT_SHADED
 
+#if defined(NEEDSGLSL300)
+	in vec3 vNormal;
+#else
 	varying vec3 vNormal;
+#endif
 
+#endif
+
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
 #endif
 
 #include <packing>
@@ -26,6 +38,10 @@ void main() {
 	#include <normal_fragment_begin>
 	#include <normal_fragment_maps>
 
+#if defined(NEEDSGLSL300)
+	glFragColor = vec4( packNormalToRGB( normal ), opacity );
+#else
 	gl_FragColor = vec4( packNormalToRGB( normal ), opacity );
+#endif
 
 }

--- a/src/renderers/shaders/ShaderLib/normal_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/normal_vert.glsl
@@ -2,13 +2,21 @@
 
 #if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP )
 
+#if defined(NEEDSGLSL300)
+	out vec3 vViewPosition;
+#else
 	varying vec3 vViewPosition;
+#endif
 
 #endif
 
 #ifndef FLAT_SHADED
 
+#if defined(NEEDSGLSL300)
+	out vec3 vNormal;
+#else
 	varying vec3 vNormal;
+#endif
 
 #endif
 

--- a/src/renderers/shaders/ShaderLib/points_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/points_frag.glsl
@@ -1,6 +1,10 @@
 uniform vec3 diffuse;
 uniform float opacity;
 
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
+#endif
+
 #include <common>
 #include <packing>
 #include <color_pars_fragment>
@@ -24,7 +28,11 @@ void main() {
 
 	outgoingLight = diffuseColor.rgb;
 
+#if defined(NEEDSGLSL300)
+	glFragColor = vec4( outgoingLight, diffuseColor.a );
+#else
 	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
+#endif
 
 	#include <premultiplied_alpha_fragment>
 	#include <tonemapping_fragment>

--- a/src/renderers/shaders/ShaderLib/shadow_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/shadow_frag.glsl
@@ -1,6 +1,10 @@
 uniform vec3 color;
 uniform float opacity;
 
+#if defined(NEEDSGLSL300)
+out vec4 glFragColor;
+#endif
+
 #include <common>
 #include <packing>
 #include <fog_pars_fragment>
@@ -11,7 +15,11 @@ uniform float opacity;
 
 void main() {
 
+#if defined(NEEDSGLSL300)
+	glFragColor = vec4( color, opacity * ( 1.0 - getShadowMask() ) );
+#else
 	gl_FragColor = vec4( color, opacity * ( 1.0 - getShadowMask() ) );
+#endif
 
 	#include <fog_fragment>
 

--- a/src/renderers/webgl/WebGLExtensions.js
+++ b/src/renderers/webgl/WebGLExtensions.js
@@ -6,6 +6,8 @@ function WebGLExtensions( gl ) {
 
 	var extensions = {};
 
+	var isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext );
+
 	return {
 
 		get: function ( name ) {
@@ -21,7 +23,11 @@ function WebGLExtensions( gl ) {
 			switch ( name ) {
 
 				case 'WEBGL_depth_texture':
-					extension = gl.getExtension( 'WEBGL_depth_texture' ) || gl.getExtension( 'MOZ_WEBGL_depth_texture' ) || gl.getExtension( 'WEBKIT_WEBGL_depth_texture' );
+					if (isWebGL2) {
+					    extension = gl;
+					} else {
+					    extension = gl.getExtension( 'WEBGL_depth_texture' ) || gl.getExtension( 'MOZ_WEBGL_depth_texture' ) || gl.getExtension( 'WEBKIT_WEBGL_depth_texture' );
+					}
 					break;
 
 				case 'EXT_texture_filter_anisotropic':
@@ -41,8 +47,17 @@ function WebGLExtensions( gl ) {
 					break;
 
 				default:
-					extension = gl.getExtension( name );
-
+					if (isWebGL2) {
+						var builtin = ['ANGLE_instanced_arrays', 'OES_texture_float', 'OES_texture_half_float', 'OES_texture_half_float_linear', 'OES_element_index_uint', 'OES_standard_derivatives'];
+						if (builtin.indexOf(name) >= 0) {
+							extension = gl;
+						} else {
+							extension = gl.getExtension( name );
+						}
+					} else {
+					    extension = gl.getExtension( name );
+					}
+				break;
 			}
 
 			if ( extension === null ) {

--- a/src/renderers/webgl/WebGLSpriteRenderer.js
+++ b/src/renderers/webgl/WebGLSpriteRenderer.js
@@ -251,6 +251,10 @@ function WebGLSpriteRenderer( renderer, gl, state, textures, capabilities ) {
 
 	function createProgram() {
 
+		var attribute = renderer.needsGLSL300 ? 'in' : 'attribute';
+		var varying = renderer.needsGLSL300 ? 'out' : 'varying';
+
+
 		var program = gl.createProgram();
 
 		var vertexShader = gl.createShader( gl.VERTEX_SHADER );
@@ -270,11 +274,11 @@ function WebGLSpriteRenderer( renderer, gl, state, textures, capabilities ) {
 			'uniform vec2 uvOffset;',
 			'uniform vec2 uvScale;',
 
-			'attribute vec2 position;',
-			'attribute vec2 uv;',
+			attribute + ' vec2 position;',
+			attribute + ' vec2 uv;',
 
-			'varying vec2 vUV;',
-			'varying float fogDepth;',
+			varying + ' vec2 vUV;',
+			varying + ' float fogDepth;',
 
 			'void main() {',
 
@@ -316,8 +320,8 @@ function WebGLSpriteRenderer( renderer, gl, state, textures, capabilities ) {
 			'uniform float fogFar;',
 			'uniform float alphaTest;',
 
-			'varying vec2 vUV;',
-			'varying float fogDepth;',
+			varying + ' vec2 vUV;',
+			varying + ' float fogDepth;',
 
 			'void main() {',
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -626,11 +626,32 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		var glFormat = utils.convert( renderTarget.texture.format );
 		var glType = utils.convert( renderTarget.texture.type );
+
+/*
 		state.texImage2D( textureTarget, 0, glFormat, renderTarget.width, renderTarget.height, 0, glFormat, glType, null );
 		_gl.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
 		_gl.framebufferTexture2D( _gl.FRAMEBUFFER, attachment, textureTarget, properties.get( renderTarget.texture ).__webglTexture, 0 );
 		_gl.bindFramebuffer( _gl.FRAMEBUFFER, null );
+*/
 
+		var glInternalFormat = glFormat;
+
+		if (_isWebGL2 && glFormat == _gl.RGBA && glType == _gl.FLOAT) {
+			glInternalFormat = _gl.RGBA32F;
+		} else if (_isWebGL2 && glFormat == _gl.RGBA && glType == _gl.HALF_FLOAT) {
+			glInternalFormat = _gl.RGBA16F;
+		}
+
+		if (_isWebGL2) {
+			var ary = new Uint8Array(renderTarget.width * renderTarget.height * 4);
+		} else {
+			var ary = null;
+		}
+		state.texImage2D( textureTarget, 0, glInternalFormat, renderTarget.width, renderTarget.height, 0, glFormat, glType, ary );
+		_gl.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
+		var t = properties.get( renderTarget.texture );
+		_gl.framebufferTexture2D( _gl.FRAMEBUFFER, attachment, textureTarget, t.__webglTexture, 0 );
+		_gl.bindFramebuffer( _gl.FRAMEBUFFER, null );
 	}
 
 	// Setup storage for internal depth/stencil buffers and bind to correct framebuffer

--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -38,7 +38,11 @@ function WebGLUtils( gl, extensions ) {
 
 			extension = extensions.get( 'OES_texture_half_float' );
 
-			if ( extension !== null ) return extension.HALF_FLOAT_OES;
+			if ( extension !== null ) {
+				var isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext );
+
+				return isWebGL2 ? gl.HALF_FLOAT : extension.HALF_FLOAT_OES;
+			}
 
 		}
 


### PR DESCRIPTION
Another attempt to support WebGL2RenderingContext and GLSL 3.00.

- WebGLRenderer.js parameter may specify to call getContext() with argument 'webgl2'.
- Such a renderer allows to use GLSL 3.00.
- The share code in ShaderChunk and ShaderLib has #ifdef to switch between "varying/attribute" vs. "in/out".
- Multiple Render Target can be specified from the client code.
- extensions natively supported by WebGL2RenderingContext are handled.

(For our project, we have a GPGPU framework that uses GLSL3.00 features such as texelFetch and new buffer types such as R32F.  This patch allows integrating the framework with Three.js.  It's been working well for our purpose, and hopefully it  is useful for others who are trying a similar stuff.)