### PR TITLE
add Math.log2 polyfill to undo IE11 breakage

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -19,6 +19,19 @@ if ( Number.isInteger === undefined ) {
 
 }
 
+if ( Math.log2 === undefined ) {
+
+	// Missing in IE
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2
+
+	Math.log2 = function ( value ) {
+
+		return Math.log( value ) * Math.LOG2E;
+
+	};
+
+}
+
 //
 
 if ( Math.sign === undefined ) {


### PR DESCRIPTION

Math.log isn't supported by IE11. Used by the commit 065d7b0bcc200875c93c1b7d541cb061d051f55d

Add polyfill.