### PR TITLE
AudioLoader: Clone buffer prior to decoding to allow reuse

### DIFF
--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -20,9 +20,12 @@ Object.assign( AudioLoader.prototype, {
 		loader.setResponseType( 'arraybuffer' );
 		loader.load( url, function ( buffer ) {
 
-			var context = AudioContext.getContext();
+			// Create a copy of the buffer. The `decodeAudioData` method
+			// detaches the buffer when complete, preventing reuse.
+			var bufferCopy = buffer.slice( 0 );
 
-			context.decodeAudioData( buffer, function ( audioBuffer ) {
+			var context = AudioContext.getContext();
+			context.decodeAudioData( bufferCopy, function ( audioBuffer ) {
 
 				onLoad( audioBuffer );
 


### PR DESCRIPTION
We upgraded to the new A-Frame release and discovered that reusing the same audio source url across multiple `sound` components stopped working and would only successfully play the expected sound on the first one initialized. Our console had errors coming from [this line](https://github.com/mrdoob/three.js/blob/35a26f178c523514673d992da1aece23c1cfca6e/src/loaders/AudioLoader.js#L25) in three's `AudioLoader`.

The error: `Uncaught (in promise) DOMException: Cannot decode detached ArrayBuffer`

A reproduction can be found [here](https://github.com/meatwallace/audioloader-buffer-repro), and it occurs with and without three's `Cache` being enabled, as the original buffer is stored in the cache.

As described in [this issue](https://github.com/WebAudio/web-audio-api/issues/1175), the Web Audio API spec requires that browsers detach the buffer after decoding.

This PR adds a line of code that copies the loaded audio's `ArrayBuffer` before decoding.

This almost certainly increases audio loading time and memory consumption. I don't have strong knowledge of three/WebAudio; I'm not sure if the existing behaviour is intentional, if this "fix" is required, or if there is a pattern that A-Frame needs to adopt to work around this.

The only other solution I see is storing the decoded `AudioBuffer` for reuse, either in three's `Cache` (instead of the `ArrayBuffer`) or it be left up to the library consumer. I believe this would increase memory consumption even further, but remove performance hit of clone the original `ArrayBuffer`. If three's `Cache` is disabled or the consumer doesn't handle it themselves, then the issue would persist.

Sorry if this is off the mark. Really appreciate any feedback/assistance anyone can provide.

Thanks!