### PR TITLE
Avoid getting nAn radius values with computeBoundingSphere in BufferGeometry

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -642,7 +642,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 				for ( var i = 0; i < count; i ++ ) {
 
-					vector.set( position.getX( i ), position.getY( i ), position.getZ( i ) );
+					vector.fromBufferAttribute( position, i );
 
 					var distance = center.distanceToSquared( vector );
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -638,12 +638,11 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 				var maxRadiusSq = 0;
 
-				var array = position.array;
-				var count = array.length;
+				var count = position.count;
 
-				for ( var i = 0; i < count; i += 3 ) {
+				for ( var i = 0; i < count; i ++ ) {
 
-					vector.set( array[ i ], array[ i + 1 ], array[ i + 2 ] );
+					vector.set( position.getX( i ), position.getY( i ), position.getZ( i ) );
 
 					var distance = center.distanceToSquared( vector );
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -616,14 +616,14 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	computeBoundingSphere: function () {
 
-		var box = new THREE.Box3();
-		var vector = new THREE.Vector3();
+		var box = new Box3();
+		var vector = new Vector3();
 
 		return function ()
 		{
 			if ( this.boundingSphere === null ) {
 
-				this.boundingSphere = new THREE.Sphere();
+				this.boundingSphere = new Sphere();
 
 			}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -616,14 +616,14 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	computeBoundingSphere: function () {
 
-		var box = new Box3();
-		var vector = new Vector3();
+		var box = new THREE.Box3();
+		var vector = new THREE.Vector3();
 
-		return function computeBoundingSphere() {
-
+		return function ()
+		{
 			if ( this.boundingSphere === null ) {
 
-				this.boundingSphere = new Sphere();
+				this.boundingSphere = new THREE.Sphere();
 
 			}
 
@@ -636,27 +636,25 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 				box.setFromBufferAttribute( position );
 				box.getCenter( center );
 
-				// hoping to find a boundingSphere with a radius smaller than the
-				// boundingSphere of the boundingBox: sqrt(3) smaller in the best case
-
 				var maxRadiusSq = 0;
 
-				for ( var i = 0, il = position.count; i < il; i ++ ) {
+				var array = position.array;
+				var count = array.length;
 
-					vector.x = position.getX( i );
-					vector.y = position.getY( i );
-					vector.z = position.getZ( i );
-					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+				for ( var i = 0; i < count; i += 3 ) {
 
+					vector.set( array[ i ], array[ i + 1 ], array[ i + 2 ] );
+
+					var distance = center.distanceToSquared( vector );
+
+					if( distance > maxRadiusSq ) {
+
+						maxRadiusSq = distance;
+
+					}
 				}
 
 				this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
-
-				if ( isNaN( this.boundingSphere.radius ) ) {
-
-					console.error( 'THREE.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values.', this );
-
-				}
 
 			}
 


### PR DESCRIPTION
Hi

I was getting nAn values for when calculating the bounding sphere of the geometry obtained using the PCDLoader (THREE.Points) even when no nAn values were present in the  position attribute.

This PR fixes this and allows cases where there are nAn values in the geometry to still obtain a radius ignore the nAn values.

Thanks a lot

Cumps




