### PR TITLE
OrbitControls: remove HorizontalPanning nomenclature

### DIFF
--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -202,14 +202,6 @@ controls.mouseButtons = {
       The camera being controlled.
     </div>
 
-    <h3>[property:Integer panningMode]</h3>
-    <div>
-    Panning mode. Defines how the camera's position is translated when panning.
-    The options are THREE.ScreenSpacePanning, in which the camera pans in screen space,
-    and THREE.HorizontalPanning, in which the camera pans in the plane orthogonal to the camera's up direction.
-    Default is THREE.ScreenSpacePanning.
-    </div>
-
     <h3>[property:Float panSpeed]</h3>
     <div>
       Speed of panning. Default is 1.
@@ -223,6 +215,12 @@ controls.mouseButtons = {
     <h3>[property:Float rotateSpeed]</h3>
     <div>
       Speed of rotation. Default is 1.
+    </div>
+
+    <h3>[property:Boolean screenSpacePanning]</h3>
+    <div>
+    Defines how the camera's position is translated when panning. If true, the camera pans in screen space.
+    Otherwise, the camera pans in the plane orthogonal to the camera's up direction. Default is false.
     </div>
 
     <h3>[property:Vector3 target0]</h3>

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -60,7 +60,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// Set to false to disable panning
 	this.enablePan = true;
 	this.panSpeed = 1.0;
-	this.panningMode = THREE.ScreenSpacePanning; // alternate THREE.HorizontalPanning
+	this.screenSpacePanning = false; // if true, pan in screen-space
 	this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
 
 	// Set to true to automatically rotate around the target
@@ -321,18 +321,14 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		return function panUp( distance, objectMatrix ) {
 
-			switch ( scope.panningMode ) {
+			if ( scope.screenSpacePanning === true ) {
 
-				case THREE.ScreenSpacePanning:
+				v.setFromMatrixColumn( objectMatrix, 1 );
 
-					v.setFromMatrixColumn( objectMatrix, 1 );
-					break;
+			} else {
 
-				case THREE.HorizontalPanning:
-
-					v.setFromMatrixColumn( objectMatrix, 0 );
-					v.crossVectors( scope.object.up, v );
-					break;
+				v.setFromMatrixColumn( objectMatrix, 0 );
+				v.crossVectors( scope.object.up, v );
 
 			}
 
@@ -1045,6 +1041,3 @@ Object.defineProperties( THREE.OrbitControls.prototype, {
 	}
 
 } );
-
-THREE.ScreenSpacePanning = 0;
-THREE.HorizontalPanning = 1;

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -76,7 +76,7 @@
 				controls.enableDamping = true; // an animation loop is required when either damping or auto-rotation are enabled
 				controls.dampingFactor = 0.25;
 
-				controls.panningMode = THREE.HorizontalPanning; // default is THREE.ScreenSpacePanning
+				controls.screenSpacePanning = false;
 
 				controls.minDistance = 100;
 				controls.maxDistance = 500

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -168,7 +168,6 @@
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
 				controls.maxPolarAngle = Math.PI * 0.495;
 				controls.target.set( 0, 10, 0 );
-				controls.panningMode = THREE.HorizontalPanning;
 				controls.minDistance = 40.0;
 				controls.maxDistance = 200.0;
 				camera.lookAt( controls.target );


### PR DESCRIPTION
Fixes #13709.

With this change, panning, by default, is now of the "horizontal type". This is a change in behavior.

For the legacy screen-space panning behavior, set:
```javascript
controls.screenSpacePanning = true;
```

