### PR TITLE
Travis CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 npm-debug.log
 .jshintrc
 .vs/
+test/unit/three.*.unit.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "8.9.4"
+script:
+  - npm run travis

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "start": "npm run dev",
     "lint": "eslint src",
     "test": "npm run build-test && qunit test/unit/three.source.unit.js",
+    "travis": "npm run lint && npm test",
     "editor": "electron ./editor/main.js"
   },
   "keywords": [

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -31,7 +31,7 @@ var _Math = {
 				lut[ d2 & 0x3f | 0x80 ] + lut[ d2 >> 8 & 0xff ] + '-' + lut[ d2 >> 16 & 0xff ] + lut[ d2 >> 24 & 0xff ] +
 				lut[ d3 & 0xff ] + lut[ d3 >> 8 & 0xff ] + lut[ d3 >> 16 & 0xff ] + lut[ d3 >> 24 & 0xff ];
 
-			// .toUpperCase() here flattens concatenated strings to save heap memory space. 
+			// .toUpperCase() here flattens concatenated strings to save heap memory space.
 			return uuid.toUpperCase();
 
 		};


### PR DESCRIPTION
Closes #13533 

Tests and lint pass on dev branch, making CI integration possible. This PR integrates Travis CI for THREE.js. Travis is a continuous integration provider that is completely free for open source projects.

The [Travis build passes for this branch](https://travis-ci.org/dbkaplun/three.js/builds/359888191), on my fork.

Once this PR is merged, an owner of the mrdoob/three.js repo will need to enable Travis by following steps 1 and 2 [here](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI). This will allow Github to automatically show status of tests (pass/fail) for new PRs. (This can be done in advance without affecting the repository.)

Thanks.
