### PR TITLE
Fix cinematic camera example

### DIFF
--- a/examples/js/cameras/CinematicCamera.js
+++ b/examples/js/cameras/CinematicCamera.js
@@ -18,6 +18,7 @@ THREE.CinematicCamera = function( fov, aspect, near, far ) {
 	};
 
 	this.material_depth = new THREE.MeshDepthMaterial();
+	this.material_depth.depthPacking = THREE.RGBADepthPacking;
 
 	// In case of cinematicCamera, having a default lens set is important
 	this.setLens();
@@ -152,7 +153,7 @@ THREE.CinematicCamera.prototype.initPostProcessing = function () {
 			defines: {
 				RINGS: this.shaderSettings.rings,
 				SAMPLES: this.shaderSettings.samples,
-				DEPTH_PACKING: this.material_depth.depthPacking
+				DEPTH_PACKING: 1
 			}
 		} );
 

--- a/examples/js/cameras/CinematicCamera.js
+++ b/examples/js/cameras/CinematicCamera.js
@@ -151,7 +151,8 @@ THREE.CinematicCamera.prototype.initPostProcessing = function () {
 			fragmentShader: bokeh_shader.fragmentShader,
 			defines: {
 				RINGS: this.shaderSettings.rings,
-				SAMPLES: this.shaderSettings.samples
+				SAMPLES: this.shaderSettings.samples,
+				DEPTH_PACKING: this.material_depth.depthPacking
 			}
 		} );
 


### PR DESCRIPTION
This PR fixes broken cinemaric camera example #13729

@Mugen87 

Why DEPTH_PACKING comparison in fragment shader of `BokehShader2` is not

	#if DEPTH_PACKING == 3201

but

	#if DEPTH_PACKING == 1

?

3201 is `THREE.RGBADepthPacking`.