### PR TITLE
Audio: Removed deprecation warnings.

### DIFF
--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -130,7 +130,7 @@
 				var sound3 = new THREE.PositionalAudio( listener );
 				var oscillator = listener.context.createOscillator();
 				oscillator.type = 'sine';
-				oscillator.frequency.value = 144;
+				oscillator.frequency.setTargetAtTime( 144, sound3.context.currentTime, 0.01 );
 				oscillator.start(0);
 				sound3.setNodeSource(oscillator);
 				sound3.setRefDistance( 20 );

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -130,7 +130,7 @@
 				var sound3 = new THREE.PositionalAudio( listener );
 				var oscillator = listener.context.createOscillator();
 				oscillator.type = 'sine';
-				oscillator.frequency.setTargetAtTime( 144, sound3.context.currentTime, 0.01 );
+				oscillator.frequency.setValueAtTime( 144, sound3.context.currentTime );
 				oscillator.start(0);
 				sound3.setNodeSource(oscillator);
 				sound3.setRefDistance( 20 );

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -295,7 +295,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	setVolume: function ( value ) {
 
-		this.gain.gain.value = value;
+		this.gain.gain.setTargetAtTime( value, this.context.currentTime, 0.01 );
 
 		return this;
 

--- a/src/audio/AudioListener.js
+++ b/src/audio/AudioListener.js
@@ -78,7 +78,7 @@ AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	setMasterVolume: function ( value ) {
 
-		this.gain.gain.value = value;
+		this.gain.gain.setTargetAtTime( value, this.context.currentTime, 0.01 );
 
 	},
 


### PR DESCRIPTION
Fixes #12510.

The mentioned deprecation warnings are now gone. The implementation uses a hard coded value for `timeConstant` (0.01).