### PR TITLE
Fix ANGLE_instanced_arrays extension support check in instancing examples

### DIFF
--- a/examples/webgl_buffergeometry_instancing.html
+++ b/examples/webgl_buffergeometry_instancing.html
@@ -207,7 +207,7 @@
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			container.appendChild( renderer.domElement );
 
-			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === false ) {
+			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
 
 				document.getElementById( 'notSupported' ).style.display = '';
 				return;

--- a/examples/webgl_buffergeometry_instancing2.html
+++ b/examples/webgl_buffergeometry_instancing2.html
@@ -200,7 +200,7 @@
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			container.appendChild( renderer.domElement );
 
-			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === false ) {
+			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
 
 				document.getElementById( 'notSupported' ).style.display = '';
 				return;

--- a/examples/webgl_buffergeometry_instancing_billboards.html
+++ b/examples/webgl_buffergeometry_instancing_billboards.html
@@ -125,7 +125,7 @@
 
 			renderer = new THREE.WebGLRenderer();
 
-			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === false ) {
+			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
 				document.getElementById( 'notSupported' ).style.display = '';
 				return false;
 			}

--- a/examples/webgl_buffergeometry_instancing_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_dynamic.html
@@ -192,7 +192,7 @@
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			container.appendChild( renderer.domElement );
 
-			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === false ) {
+			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
 
 				document.getElementById( 'notSupported' ).style.display = '';
 				return;

--- a/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
@@ -233,7 +233,7 @@
 		scene.add( mesh );
 
 
-		if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === false ) {
+		if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
 			document.getElementById( "notSupported" ).style.display = "";
 			return;
 		}

--- a/examples/webgl_interactive_instances_gpu.html
+++ b/examples/webgl_interactive_instances_gpu.html
@@ -965,7 +965,7 @@
 				antialias: true,
 				alpha: true
 			} );
-			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === false ) {
+			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
 
 				document.getElementById( "notSupported" ).style.display = "";
 				return;
@@ -976,7 +976,7 @@
 			//renderer.sortObjects = false;
 			container.appendChild( renderer.domElement );
 
-			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === false ) {
+			if ( renderer.extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
 
 				throw 'ANGLE_instanced_arrays not supported';
 


### PR DESCRIPTION
`renderer.extensions.get()` doesn't return boolean but returns extension or null.