### PR TITLE
FBXLoader: Fix clip offset time.

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2177,6 +2177,14 @@
 
 			};
 
+			var offset = animationCurve.times[ 0 ];
+
+			for ( var i = 0; i < animationCurve.times.length; i++ ) {
+
+				animationCurve.times[ i ] -= offset;
+
+			}
+
 			var relationships = connections.get( animationCurve.id );
 
 			if ( relationships !== undefined ) {


### PR DESCRIPTION
Every new clip start time should always start from zero, but not from current frame time.