### PR TITLE
Compact groups in BufferGeometry

### DIFF
--- a/docs/api/core/BufferGeometry.html
+++ b/docs/api/core/BufferGeometry.html
@@ -277,7 +277,7 @@
 		<h3>[method:BufferGeometry mergeGroups]()</h3>
 		<div>Merge groups with common materialIndex values to minimize the number of draw calls required to
 		render the geometery. This will reorder the elements of all attributes.
-		Indexed BufferGeometries or those using an [page:InterleavedBufferAttribute] are not supported.
+		InstancedBufferGeometries or those using an [page:InterleavedBufferAttribute] are not supported.
 		</div>
 
 		<h3>[method:null normalizeNormals]()</h3>

--- a/docs/api/core/BufferGeometry.html
+++ b/docs/api/core/BufferGeometry.html
@@ -274,6 +274,12 @@
 		<h3>[method:null merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
 		<div>Merge in another BufferGeometry with an optional offset of where to start merging in.</div>
 
+		<h3>[method:BufferGeometry mergeGroups]()</h3>
+		<div>Merge groups with common materialIndex values to minimize the number of draw calls required to
+		render the geometery. This will reorder the elements of all attributes.
+		Indexed BufferGeometries or those using an [page:InterleavedBufferAttribute] are not supported.
+		</div>
+
 		<h3>[method:null normalizeNormals]()</h3>
 		<div>
 		Every normal vector in a geometry will have a magnitude of 1.

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -839,9 +839,9 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	mergeGroups: function () {
 
-		if ( this.index !== null ) {
+		if ( this.isInstancedBufferGeometry ) {
 
-			console.warn( 'THREE.BufferGeometry.mergeGroups(): Geometry is indexed.' );
+			console.warn( 'THREE.BufferGeometry.mergeGroups(): Geometry is instanced.' );
 			return this;
 
 		}
@@ -856,14 +856,33 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		} );
 
-		// relay out buffers in material order
+		var index = this.index;
+		var i, group, attributes;
 
-		var attributes = this.attributes;
-		var i, group;
+		if ( index === null ) {
+
+			attributes = this.attributes;
+
+		} else {
+
+			// for indexed geometries only the index values need adjusting
+
+			attributes = [ index ];
+
+		}
+
+		// relay out buffers in material order
 
 		for ( var key in attributes ) {
 
 			var attribute = attributes[ key ];
+
+			if ( attribute.isInterleavedBufferAttribute ) {
+
+				console.warn( 'THREE.BufferGeometry.mergeGroups(): Geometry has an InterleavedBufferAttribute.' );
+				return this;
+
+			}
 
 			var itemSize = attribute.itemSize;
 			var srcArray = attribute.array;

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -920,7 +920,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
-		console.log( 'compact groups: old count:', groups.length, 'new count:', this.groups.length );
+		console.log( 'THREE.BufferGeometry: old count:', groups.length, 'new count:', this.groups.length );
 
 	},
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -922,6 +922,8 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		console.log( 'THREE.BufferGeometry: old count:', groups.length, 'new count:', this.groups.length );
 
+		return this;
+
 	},
 
 	normalizeNormals: function () {

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -590,7 +590,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		// sort by material
 
-		var groups = this.groups.slice().sort( function ( a, b ) {
+		var groups = this.groups.sort( function ( a, b ) {
 
 			if ( a.materialIndex !== b.materialIndex ) return a.materialIndex - b.materialIndex;
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -948,7 +948,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
-		console.log( 'THREE.BufferGeometry: old count:', groups.length, 'new count:', this.groups.length );
+		// console.log( 'THREE.BufferGeometry: old count:', groups.length, 'new count:', this.groups.length );
 
 		return this;
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -839,6 +839,13 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	mergeGroups: function () {
 
+		if ( this.index !== null ) {
+
+			console.warn( 'THREE.BufferGeometry.mergeGroups(): Geometry is indexed.' );
+			return this;
+
+		}
+
 		// sort by material
 
 		var groups = this.groups.sort( function ( a, b ) {

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -882,6 +882,8 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			srcArray.set( targetArray );
 
+			attribute.needsUpdate = true;
+
 		}
 
 		// adjust groups to new layout

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -586,93 +586,6 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	},
 
-	compactGroups: function () {
-
-		// sort by material
-
-		var groups = this.groups.sort( function ( a, b ) {
-
-			if ( a.materialIndex !== b.materialIndex ) return a.materialIndex - b.materialIndex;
-
-			return a.start - b.start;
-
-		} );
-
-		// relay out buffers in material order
-
-		var attributes = this.attributes;
-		var i, group;
-
-		for ( var key in attributes ) {
-
-			var attribute = attributes[ key ];
-
-			var itemSize = attribute.itemSize;
-			var srcArray = attribute.array;
-
-			var targetOffset = 0;
-
-			var targetArray = new srcArray.constructor( srcArray.length );
-
-			for ( i = 0; i < groups.length; i ++ ) {
-
-				group = groups[ i ];
-
-				var groupLength = group.count * itemSize;
-				var groupStart = group.start * itemSize;
-
-				var sub = srcArray.subarray( groupStart, groupStart + groupLength );
-
-				targetArray.set( sub, targetOffset );
-
-				targetOffset += groupLength;
-
-			}
-
-			srcArray.set( targetArray );
-
-		}
-
-		// adjust groups to new layout
-
-		var start = 0;
-
-		for ( i = 0; i < groups.length; i ++ ) {
-
-			group = groups[ i ];
-
-			group.start = start;
-			start += group.count;
-
-		}
-
-		var lastGroup = groups[ 0 ];
-
-		this.groups = [ lastGroup ];
-
-		// merge adjacent groups with same materialIndex
-
-		for ( i = 1; i < groups.length; i ++ ) {
-
-			group = groups[ i ];
-
-			if ( lastGroup.materialIndex === group.materialIndex ) {
-
-				lastGroup.count += group.count;
-
-			} else {
-
-				lastGroup = group;
-				this.groups.push( lastGroup );
-
-			}
-
-		}
-
-		console.log( 'compact groups: old count:', groups.length, 'new count:', this.groups.length );
-
-	},
-
 	computeBoundingBox: function () {
 
 		if ( this.boundingBox === null ) {
@@ -921,6 +834,93 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 		}
 
 		return this;
+
+	},
+
+	mergeGroups: function () {
+
+		// sort by material
+
+		var groups = this.groups.sort( function ( a, b ) {
+
+			if ( a.materialIndex !== b.materialIndex ) return a.materialIndex - b.materialIndex;
+
+			return a.start - b.start;
+
+		} );
+
+		// relay out buffers in material order
+
+		var attributes = this.attributes;
+		var i, group;
+
+		for ( var key in attributes ) {
+
+			var attribute = attributes[ key ];
+
+			var itemSize = attribute.itemSize;
+			var srcArray = attribute.array;
+
+			var targetOffset = 0;
+
+			var targetArray = new srcArray.constructor( srcArray.length );
+
+			for ( i = 0; i < groups.length; i ++ ) {
+
+				group = groups[ i ];
+
+				var groupLength = group.count * itemSize;
+				var groupStart = group.start * itemSize;
+
+				var sub = srcArray.subarray( groupStart, groupStart + groupLength );
+
+				targetArray.set( sub, targetOffset );
+
+				targetOffset += groupLength;
+
+			}
+
+			srcArray.set( targetArray );
+
+		}
+
+		// adjust groups to new layout
+
+		var start = 0;
+
+		for ( i = 0; i < groups.length; i ++ ) {
+
+			group = groups[ i ];
+
+			group.start = start;
+			start += group.count;
+
+		}
+
+		var lastGroup = groups[ 0 ];
+
+		this.groups = [ lastGroup ];
+
+		// merge adjacent groups with same materialIndex
+
+		for ( i = 1; i < groups.length; i ++ ) {
+
+			group = groups[ i ];
+
+			if ( lastGroup.materialIndex === group.materialIndex ) {
+
+				lastGroup.count += group.count;
+
+			} else {
+
+				lastGroup = group;
+				this.groups.push( lastGroup );
+
+			}
+
+		}
+
+		console.log( 'compact groups: old count:', groups.length, 'new count:', this.groups.length );
 
 	},
 

--- a/src/geometries/TextGeometry.js
+++ b/src/geometries/TextGeometry.js
@@ -72,6 +72,8 @@ function TextBufferGeometry( text, parameters ) {
 
 	this.type = 'TextBufferGeometry';
 
+	this.compactGroups();
+
 }
 
 TextBufferGeometry.prototype = Object.create( ExtrudeBufferGeometry.prototype );

--- a/src/geometries/TextGeometry.js
+++ b/src/geometries/TextGeometry.js
@@ -72,7 +72,7 @@ function TextBufferGeometry( text, parameters ) {
 
 	this.type = 'TextBufferGeometry';
 
-	this.compactGroups();
+	this.mergeGroups();
 
 }
 


### PR DESCRIPTION

Speculative attempt to reduce draw calls by sorting and merging groups. Equivalent to Geometry.sortFacesByMaterialIndex() for BufferGeometery.

Example use in TextBufferGeometry() which reduces draw calls from approx 2 * character count to 2 for any text string if different materials are used for face and sides. The geometry/text example illustrates this.

Requires rewritting attribute buffers and the groups list so the user can not make any assumptions about the buffer layout after use.
