### PR TITLE
GPUComputationRenderer: fix createTexture and disable depthBuffer

### DIFF
--- a/examples/js/GPUComputationRenderer.js
+++ b/examples/js/GPUComputationRenderer.js
@@ -306,13 +306,10 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 	};
 
-	this.createTexture = function( sizeXTexture, sizeYTexture ) {
+	this.createTexture = function() {
 
-		sizeXTexture = sizeXTexture || sizeX;
-		sizeYTexture = sizeYTexture || sizeY;
-
-		var a = new Float32Array( sizeXTexture * sizeYTexture * 4 );
-		var texture = new THREE.DataTexture( a, sizeXTexture, sizeYTexture, THREE.RGBAFormat, THREE.FloatType );
+		var a = new Float32Array( sizeX * sizeY * 4 );
+		var texture = new THREE.DataTexture( a, sizeX, sizeY, THREE.RGBAFormat, THREE.FloatType );
 		texture.needsUpdate = true;
 
 		return texture;

--- a/examples/js/GPUComputationRenderer.js
+++ b/examples/js/GPUComputationRenderer.js
@@ -305,13 +305,13 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 
 	};
 
-    this.createTexture = function( sizeXTexture, sizeYTexture ) {
+	this.createTexture = function( sizeXTexture, sizeYTexture ) {
 
 		sizeXTexture = sizeXTexture || sizeX;
 		sizeYTexture = sizeYTexture || sizeY;
 
 		var a = new Float32Array( sizeXTexture * sizeYTexture * 4 );
-		var texture = new THREE.DataTexture( a, sizeX, sizeY, THREE.RGBAFormat, THREE.FloatType );
+		var texture = new THREE.DataTexture( a, sizeXTexture, sizeYTexture, THREE.RGBAFormat, THREE.FloatType );
 		texture.needsUpdate = true;
 
 		return texture;

--- a/examples/js/GPUComputationRenderer.js
+++ b/examples/js/GPUComputationRenderer.js
@@ -298,7 +298,8 @@ function GPUComputationRenderer( sizeX, sizeY, renderer ) {
 			magFilter: magFilter,
 			format: THREE.RGBAFormat,
 			type: ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) ? THREE.HalfFloatType : THREE.FloatType,
-			stencilBuffer: false
+			stencilBuffer: false,
+			depthBuffer: false
 		} );
 
 		return renderTarget;


### PR DESCRIPTION
The size params this function passes to THREE.DataTexture were wrong. Also fixed the indentation 🌈

Edit: disabled depthBuffer on another commit too, it isn't needed by GPUComputationRenderer right?