### PR TITLE
GLTFExporter: Ensure normalized normal attribute

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -218,16 +218,12 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
+			var v = new THREE.Vector3();
+
 			for ( var i = 0, il = normal.count; i < il; i ++ ) {
 
-				var x = normal.getX( i );
-				var y = normal.getY( i );
-				var z = normal.getZ( i );
-
-				var length = Math.sqrt( x * x + y * y + z * z );
-
 				// 0.0005 is from glTF-validator
-				if ( Math.abs( length - 1.0 ) > 0.0005 ) return false;
+				if ( Math.abs( v.fromArray( normal.array, i * 3 ).length() - 1.0 ) > 0.0005 ) return false;
 
 			}
 
@@ -256,7 +252,7 @@ THREE.GLTFExporter.prototype = {
 
 			for ( var i = 0, il = attribute.count; i < il; i ++ ) {
 
-				v.set( attribute.getX( i ), attribute.getY( i ), attribute.getZ( i ) );
+				v.fromArray( attribute.array, i * 3 );
 
 				if ( v.x === 0 && v.y === 0 && v.z === 0 ) {
 
@@ -269,9 +265,7 @@ THREE.GLTFExporter.prototype = {
 
 				}
 
-				attribute.setX( i, v.x );
-				attribute.setY( i, v.y );
-				attribute.setZ( i, v.z );
+				v.toArray( attribute.array, i * 3 );
 
 			}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -218,11 +218,11 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			for ( var i = 0, il = normal.array.length; i < il; i += 3 ) {
+			for ( var i = 0, il = normal.count; i < il; i ++ ) {
 
-				var x = normal.array[ i + 0 ];
-				var y = normal.array[ i + 1 ];
-				var z = normal.array[ i + 2 ];
+				var x = normal.getX( i );
+				var y = normal.getY( i );
+				var z = normal.getZ( i );
 
 				var length = Math.sqrt( x * x + y * y + z * z );
 
@@ -252,13 +252,11 @@ THREE.GLTFExporter.prototype = {
 
 			var attribute = normal.clone();
 
-			var array = attribute.array;
-
 			var v = new THREE.Vector3();
 
-			for ( var i = 0, il = array.length; i < il; i += 3 ) {
+			for ( var i = 0, il = attribute.count; i < il; i ++ ) {
 
-				v.set( array[ i ], array[ i + 1 ], array[ i + 2 ] );
+				v.set( attribute.getX( i ), attribute.getY( i ), attribute.getZ( i ) );
 
 				if ( v.x === 0 && v.y === 0 && v.z === 0 ) {
 
@@ -271,9 +269,9 @@ THREE.GLTFExporter.prototype = {
 
 				}
 
-				array[ i ] = v.x;
-				array[ i + 1 ] = v.y;
-				array[ i + 2 ] = v.z;
+				attribute.setX( i, v.x );
+				attribute.setY( i, v.y );
+				attribute.setZ( i, v.z );
 
 			}
 


### PR DESCRIPTION
This PR lets `GLTFExporter` ensure normalized normal attribute. See  https://github.com/mrdoob/three.js/issues/11951#issuecomment-375981553

I still need to evaluate to know if this change (quite) slows the performance because this's our first computation with each vertex but let me first share the PR with you. You can test by yourselves, too, if you want.

@fernandojsg Can you share the model file on which this change can affect the performance if you have? I tested some standard models but I didn't see performance degradation (from same to just a few percents worse).