### PR TITLE
Fix WebGLCapabilities.logarithmicDepthBuffer

### DIFF
--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -66,7 +66,7 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 
 	}
 
-	var logarithmicDepthBuffer = parameters.logarithmicDepthBuffer === true;
+	var logarithmicDepthBuffer = parameters.logarithmicDepthBuffer === true && extensions.get( 'EXT_frag_depth' ) !== null;
 
 	var maxTextures = gl.getParameter( gl.MAX_TEXTURE_IMAGE_UNITS );
 	var maxVertexTextures = gl.getParameter( gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS );


### PR DESCRIPTION
Hi,

I have an issue caused by https://github.com/mrdoob/three.js/pull/11995

I am dealing with huge differences in scale in a single scene, so I need to enable logarithmicDepthBuffer. 

When I open it on my browser I got this
![image](https://user-images.githubusercontent.com/4658821/38348268-60da03f8-38d3-11e8-8dd6-66c17384e599.png)

But when I open it on my smarthphone I got this:
![screenshot_20180405-131632](https://user-images.githubusercontent.com/4658821/38348496-bd9fe462-38d4-11e8-9d48-0a41e21c2368.png)


With this fix the texture is now displayed properly
![screenshot_20180405-131820](https://user-images.githubusercontent.com/4658821/38348489-b9a23fcc-38d4-11e8-9d10-6676473f7bc8.png)


And according to the [doc](https://threejs.org/docs/#api/renderers/WebGLRenderer.capabilities) it should be true 

> if the # .logarithmicDepthBuffer : parameterwas set to true in the constructor and the context supports the EXT_frag_depth extension

Thanks,