### PR TITLE
WebGLBufferRenderer: Check existence of position attribute

### DIFF
--- a/src/renderers/webgl/WebGLBufferRenderer.js
+++ b/src/renderers/webgl/WebGLBufferRenderer.js
@@ -33,7 +33,7 @@ function WebGLBufferRenderer( gl, extensions, info ) {
 
 		var position = geometry.attributes.position;
 
-		if ( position.isInterleavedBufferAttribute ) {
+		if ( position !== undefined && position.isInterleavedBufferAttribute ) {
 
 			count = position.data.count;
 


### PR DESCRIPTION
Fixes #13719

A simple fix that makes `WebGLBufferRenderer` a little bit more robust.