### PR TITLE
GLTFLoader: Expand getDependency()

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1482,8 +1482,57 @@ THREE.GLTFLoader = ( function () {
 
 		if ( ! dependency ) {
 
-			var fnName = 'load' + type.charAt( 0 ).toUpperCase() + type.slice( 1 );
-			dependency = this[ fnName ]( index );
+			switch ( type ) {
+
+				case 'scene':
+					dependency = this.loadScene( index );
+					break;
+
+				case 'node':
+					dependency = this.loadNode( index );
+					break;
+
+				case 'mesh':
+					dependency = this.loadMesh( index );
+					break;
+
+				case 'accessor':
+					dependency = this.loadAccessor( index );
+					break;
+
+				case 'bufferView':
+					dependency = this.loadBufferView( index );
+					break;
+
+				case 'buffer':
+					dependency = this.loadBuffer( index );
+					break;
+
+				case 'material':
+					dependency = this.loadMaterial( index );
+					break;
+
+				case 'texture':
+					dependency = this.loadTexture( index );
+					break;
+
+				case 'skin':
+					dependency = this.loadSkin( index );
+					break;
+
+				case 'animation':
+					dependency = this.loadAnimation( index );
+					break;
+
+				case 'camera':
+					dependency = this.loadCamera( index );
+					break;
+
+				default:
+					throw new Error( 'Unknown type: ' + type );
+
+			}
+
 			this.cache.add( cacheKey, dependency );
 
 		}


### PR DESCRIPTION
    var fnName = 'load' + type.charAt( 0 ).toUpperCase() + type.slice( 1 );
    dependency = this[ fnName ]( index );

This style is a bit hard to read through the code especially for new devs because of statically unknown function reference, [actually seems like some IDEs can't follow the reference](https://twitter.com/as_kuya/status/981825246956142592) (A tweet in Japanese)

So I think it'd better to expand tho lines# will increase

    switch( type ) {

        case 'scene':
            dependency = this.loadScene( index );
            break;

        ....

    }

Let me know if you have any better ideas.