### PR TITLE
Fix fromGeometry() retain element names for morphTarget & morphNormal

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -542,9 +542,10 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 				var morphTarget = morphTargets[ i ];
 
-				var attribute = new Float32BufferAttribute( morphTarget.length * 3, 3 );
+				var attribute = new Float32BufferAttribute( morphTarget.array.length * 3, 3 );
+				attribute.name = morphTarget.name;
 
-				array.push( attribute.copyVector3sArray( morphTarget ) );
+				array.push( attribute.copyVector3sArray( morphTarget.array ) );
 
 			}
 

--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -103,7 +103,7 @@ Object.assign( DirectGeometry.prototype, {
 
 			for ( var i = 0; i < morphTargetsLength; i ++ ) {
 
-				morphTargetsPosition[ i ] = [];
+				morphTargetsPosition[ i ] = { name: morphTargets[i].name, array: [] };
 
 			}
 
@@ -122,7 +122,7 @@ Object.assign( DirectGeometry.prototype, {
 
 			for ( var i = 0; i < morphNormalsLength; i ++ ) {
 
-				morphTargetsNormal[ i ] = [];
+				morphTargetsNormal[ i ] = { name: morphNormals[i].name, array: [] };
 
 			}
 
@@ -216,7 +216,7 @@ Object.assign( DirectGeometry.prototype, {
 
 				var morphTarget = morphTargets[ j ].vertices;
 
-				morphTargetsPosition[ j ].push( morphTarget[ face.a ], morphTarget[ face.b ], morphTarget[ face.c ] );
+				morphTargetsPosition[ j ].array.push( morphTarget[ face.a ], morphTarget[ face.b ], morphTarget[ face.c ] );
 
 			}
 
@@ -224,7 +224,7 @@ Object.assign( DirectGeometry.prototype, {
 
 				var morphNormal = morphNormals[ j ].vertexNormals[ i ];
 
-				morphTargetsNormal[ j ].push( morphNormal.a, morphNormal.b, morphNormal.c );
+				morphTargetsNormal[ j ].array.push( morphNormal.a, morphNormal.b, morphNormal.c );
 
 			}
 

--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -103,7 +103,7 @@ Object.assign( DirectGeometry.prototype, {
 
 			for ( var i = 0; i < morphTargetsLength; i ++ ) {
 
-				morphTargetsPosition[ i ] = { name: morphTargets[i].name, array: [] };
+				morphTargetsPosition[ i ] = { name: morphTargets[ i ].name, array: [] };
 
 			}
 
@@ -122,7 +122,7 @@ Object.assign( DirectGeometry.prototype, {
 
 			for ( var i = 0; i < morphNormalsLength; i ++ ) {
 
-				morphTargetsNormal[ i ] = { name: morphNormals[i].name, array: [] };
+				morphTargetsNormal[ i ] = { name: morphNormals[ i ].name, array: [] };
 
 			}
 


### PR DESCRIPTION
First time contributing, so hopefully I've followed instructions correctly, please let me know if not :)

This fixes element names of morphTargets and morphNormals being lost when converting a Geometry to a GeometryBuffer, using: 

`THREE.BufferGeometry().fromGeometry(geometry)`

I've rebuilt and tested using 'models/animated/horse.js' which does includes morph targets and the names are now included.