### PR TITLE
GLTFLoader: Update morph, non-set unnecessary morph

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1197,26 +1197,31 @@ THREE.GLTFLoader = ( function () {
 				//     ...
 				// then we need to convert from relative to absolute here.
 
-				var positionAttribute = cloneBufferAttribute( geometry.attributes.position );
-
 				if ( target.POSITION !== undefined ) {
 
-					var morphPosition = accessors[ target.POSITION ];
+					// Cloning not to pollute original accessor
+					var positionAttribute = cloneBufferAttribute( accessors[ target.POSITION ] );
+					positionAttribute.name = attributeName;
+
+					var position = geometry.attributes.position;
 
 					for ( var j = 0, jl = positionAttribute.count; j < jl; j ++ ) {
 
 						positionAttribute.setXYZ(
 							j,
-							positionAttribute.getX( j ) + morphPosition.getX( j ),
-							positionAttribute.getY( j ) + morphPosition.getY( j ),
-							positionAttribute.getZ( j ) + morphPosition.getZ( j )
+							positionAttribute.getX( j ) + position.getX( j ),
+							positionAttribute.getY( j ) + position.getY( j ),
+							positionAttribute.getZ( j ) + position.getZ( j )
 						);
 
 					}
 
+				} else {
+
+					positionAttribute = geometry.attributes.position;
+
 				}
 
-				positionAttribute.name = attributeName;
 				morphPositions.push( positionAttribute );
 
 			}
@@ -1225,26 +1230,32 @@ THREE.GLTFLoader = ( function () {
 
 				// see target.POSITION's comment
 
-				var normalAttribute = cloneBufferAttribute( geometry.attributes.normal );
+				var normalAttribute;
 
 				if ( target.NORMAL !== undefined ) {
 
-					var morphNormal = geometry.attributes.normal;
+					var normalAttribute = cloneBufferAttribute( accessors[ target.NORMAL ] );
+					normalAttribute.name = attributeName;
+
+					var normal = geometry.attributes.normal;
 
 					for ( var j = 0, jl = normalAttribute.count; j < jl; j ++ ) {
 
 						normalAttribute.setXYZ(
 							j,
-							normalAttribute.getX( j ) + morphNormal.getX( j ),
-							normalAttribute.getY( j ) + morphNormal.getY( j ),
-							normalAttribute.getZ( j ) + morphNormal.getZ( j )
+							normalAttribute.getX( j ) + normal.getX( j ),
+							normalAttribute.getY( j ) + normal.getY( j ),
+							normalAttribute.getZ( j ) + normal.getZ( j )
 						);
 
 					}
 
+				} else {
+
+					normalAttribute = geometry.attributes.normal;
+
 				}
 
-				normalAttribute.name = attributeName;
 				morphNormals.push( normalAttribute );
 
 			}

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1185,19 +1185,17 @@ THREE.GLTFLoader = ( function () {
 
 			if ( hasMorphPosition ) {
 
-				// Three.js morph formula is
-				//   position
-				//     + weight0 * ( morphTarget0 - position )
-				//     + weight1 * ( morphTarget1 - position )
+				// Three.js morph position is absolute value. The formula is
+				//   basePosition
+				//     + weight0 * ( morphPosition0 - basePosition )
+				//     + weight1 * ( morphPosition1 - basePosition )
 				//     ...
-				// while the glTF one is
-				//   position
-				//     + weight0 * morphTarget0
-				//     + weight1 * morphTarget1
+				// while the glTF one is relative
+				//   basePosition
+				//     + weight0 * glTFmorphPosition0
+				//     + weight1 * glTFmorphPosition1
 				//     ...
-				// then adding position to morphTarget.
-				// So morphTarget value will depend on mesh's position, then cloning attribute
-				// for the case if attribute is shared among two or more meshes.
+				// then we need to convert from relative to absolute here.
 
 				var positionAttribute = cloneBufferAttribute( geometry.attributes.position );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1169,10 +1169,6 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
-		// unnecessary to set morph if base attributes don't exist
-		if ( geometry.attributes.position === undefined ) hasMorphPosition = false;
-		if ( geometry.attributes.normal === undefined ) hasMorphNormal = false;
-
 		if ( ! hasMorphPosition && ! hasMorphNormal ) return;
 
 		var morphPositions = [];

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1185,43 +1185,36 @@ THREE.GLTFLoader = ( function () {
 
 			if ( hasMorphPosition ) {
 
-				var positionAttribute;
+				// Three.js morph formula is
+				//   position
+				//     + weight0 * ( morphTarget0 - position )
+				//     + weight1 * ( morphTarget1 - position )
+				//     ...
+				// while the glTF one is
+				//   position
+				//     + weight0 * morphTarget0
+				//     + weight1 * morphTarget1
+				//     ...
+				// then adding position to morphTarget.
+				// So morphTarget value will depend on mesh's position, then cloning attribute
+				// for the case if attribute is shared among two or more meshes.
+
+				var positionAttribute = cloneBufferAttribute( geometry.attributes.position );
 
 				if ( target.POSITION !== undefined ) {
 
-					// Three.js morph formula is
-					//   position
-					//     + weight0 * ( morphTarget0 - position )
-					//     + weight1 * ( morphTarget1 - position )
-					//     ...
-					// while the glTF one is
-					//   position
-					//     + weight0 * morphTarget0
-					//     + weight1 * morphTarget1
-					//     ...
-					// then adding position to morphTarget.
-					// So morphTarget value will depend on mesh's position, then cloning attribute
-					// for the case if attribute is shared among two or more meshes.
-
-					positionAttribute = cloneBufferAttribute( accessors[ target.POSITION ] );
-					var position = geometry.attributes.position;
+					var morphPosition = accessors[ target.POSITION ];
 
 					for ( var j = 0, jl = positionAttribute.count; j < jl; j ++ ) {
 
 						positionAttribute.setXYZ(
 							j,
-							positionAttribute.getX( j ) + position.getX( j ),
-							positionAttribute.getY( j ) + position.getY( j ),
-							positionAttribute.getZ( j ) + position.getZ( j )
+							positionAttribute.getX( j ) + morphPosition.getX( j ),
+							positionAttribute.getY( j ) + morphPosition.getY( j ),
+							positionAttribute.getZ( j ) + morphPosition.getZ( j )
 						);
 
 					}
-
-				} else {
-
-					// Copying the original position not to affect the final position.
-					// See the formula above.
-					positionAttribute = cloneBufferAttribute( geometry.attributes.position );
 
 				}
 
@@ -1232,29 +1225,24 @@ THREE.GLTFLoader = ( function () {
 
 			if ( hasMorphNormal ) {
 
-				var normalAttribute;
+				// see target.POSITION's comment
+
+				var normalAttribute = cloneBufferAttribute( geometry.attributes.normal );
 
 				if ( target.NORMAL !== undefined ) {
 
-					// see target.POSITION's comment
-
-					normalAttribute = cloneBufferAttribute( accessors[ target.NORMAL ] );
-					var normal = geometry.attributes.normal;
+					var morphNormal = geometry.attributes.normal;
 
 					for ( var j = 0, jl = normalAttribute.count; j < jl; j ++ ) {
 
 						normalAttribute.setXYZ(
 							j,
-							normalAttribute.getX( j ) + normal.getX( j ),
-							normalAttribute.getY( j ) + normal.getY( j ),
-							normalAttribute.getZ( j ) + normal.getZ( j )
+							normalAttribute.getX( j ) + morphNormal.getX( j ),
+							normalAttribute.getY( j ) + morphNormal.getY( j ),
+							normalAttribute.getZ( j ) + morphNormal.getZ( j )
 						);
 
 					}
-
-				} else {
-
-					normalAttribute = cloneBufferAttribute( geometry.attributes.normal );
 
 				}
 


### PR DESCRIPTION
This PR updates morph handling of `GLTFLoader`.

In the current implementation, `addMorphTargets()` always set both morph position and morph normal even if just either one of them is defined in glTF. This PR lets `addMorphTargets()` not set unnecessary morph.

Plus, I moved `material.morphTargets/Normals = true` to `loadMesh()` because most of other property, like `.skinning` are set in that method.