### PR TITLE
GLTFLoader: Invert normalScale.y, not normalScale.x.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2042,7 +2042,7 @@ THREE.GLTFLoader = ( function () {
 			// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#materialnormaltexture
 			if ( material.normalScale ) {
 
-				material.normalScale.x = - material.normalScale.x;
+				material.normalScale.y = - material.normalScale.y;
 
 			}
 


### PR DESCRIPTION
Followup from #13716. Can't say I have great confidence in why this is correct, but if we're planning to release r92 soon, this should probably be patched...

| example | image |
|---|---|
| boombox_invertx |![boombox_invertx](https://user-images.githubusercontent.com/1848368/38399702-c4b04e46-3900-11e8-8624-ba6d9c69d2fd.png) | 
| boombox_none | ![boombox_none](https://user-images.githubusercontent.com/1848368/38399703-c694895c-3900-11e8-92d7-0f0074e1246f.png) |
| boombox_inverty | ![boombox_inverty](https://user-images.githubusercontent.com/1848368/38399705-c870ad0a-3900-11e8-90cf-f072de6ad05c.png) |
| normaltangenttest_invertx | ![normaltangenttest_invertx](https://user-images.githubusercontent.com/1848368/38399707-ca015e08-3900-11e8-8654-bcf5ac7ddbf0.png) |
| normaltangenttest_none |![normaltangenttest_none](https://user-images.githubusercontent.com/1848368/38399709-cb0fa2be-3900-11e8-8aee-93cd45397342.png) |
| normaltangenttest_inverty | ![normaltangenttest_inverty](https://user-images.githubusercontent.com/1848368/38399710-cc35ddac-3900-11e8-904c-6d9f0d4d9c44.png) |
| normaltangentmirrortest_invertx | ![normaltangentmirrortest_invertx](https://user-images.githubusercontent.com/1848368/38399712-cf9766a0-3900-11e8-83aa-f04065e54718.png) |
| normaltangentmirrortest_none | ![normaltangentmirrortest_none](https://user-images.githubusercontent.com/1848368/38399713-d10031d4-3900-11e8-9456-30432878a9f5.png) |
| normaltangentmirrortest_inverty | ![normaltangentmirrortest_inverty](https://user-images.githubusercontent.com/1848368/38399715-d269c5b2-3900-11e8-844f-cb1c3c3b728b.png) |
