### PR TITLE
Fix perturbNormal2Arb() + DoubleSide

### DIFF
--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl
@@ -16,12 +16,7 @@
 		vec2 st1 = dFdy( vUv.st );
 
 		float scale = sign( st1.t * st0.s - st0.t * st1.s ); // we do not care about the magnitude
-
-		#ifdef DOUBLE_SIDED
-
-			scale *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
-
-		#endif
+		scale *= float( gl_FrontFacing ) * 2.0 - 1.0;
 
 		vec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );
 		vec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl
@@ -16,6 +16,13 @@
 		vec2 st1 = dFdy( vUv.st );
 
 		float scale = sign( st1.t * st0.s - st0.t * st1.s ); // we do not care about the magnitude
+
+		#ifdef DOUBLE_SIDED
+
+			scale *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+
+		#endif
+
 		vec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );
 		vec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );
 		vec3 N = normalize( surf_norm );


### PR DESCRIPTION
Solution from #13716 handles front faces, but must be inverted with THREE.DoubleSide. Issue can be seen on the backs of glTF NormalTangentTest and NormalTangentMirrorTest models.

| method | screenshot |
|---|---|
| before | ![screen shot 2018-04-06 at 6 02 56 pm](https://user-images.githubusercontent.com/1848368/38449505-d34b9158-39c4-11e8-8db0-5a0f7b2d3543.png) |
| after | ![screen shot 2018-04-06 at 6 02 39 pm](https://user-images.githubusercontent.com/1848368/38449502-cd6c4264-39c4-11e8-9439-35f55fdccf4d.png) |