### PR TITLE
ColladaLoader: Fix transparency handling for alphaMaps

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1575,7 +1575,6 @@ THREE.ColladaLoader.prototype = {
 				if ( transparent.data.texture ) {
 
 					material.alphaMap = getTexture( transparent.data.texture );
-					material.transparent = true;
 
 				} else {
 
@@ -1600,9 +1599,9 @@ THREE.ColladaLoader.prototype = {
 
 					}
 
-					if ( material.opacity < 1 ) material.transparent = true;
-
 				}
+					
+				if ( material.opacity < 1 ) material.transparent = true;
 
 			}
 


### PR DESCRIPTION
ColladaLoader just simply ignoring the opacity and makes all texture to transparent = true; with no reason.
The non-transparent and opacity = 1 but textured Collada models looks like this which is wrong:
![scbad](https://user-images.githubusercontent.com/3866135/38450153-02012b88-3a11-11e8-8e76-df68d9384bf8.PNG)
after the fix ColladaLoader changes transparent only if opacity less than 1 as normally just like at non-textured materials:
![scok](https://user-images.githubusercontent.com/3866135/38450173-5b583f78-3a11-11e8-9eeb-300d5d5b3adf.PNG)

foot note: Interestingly the material.opacity value is 1 by default but I can change it between about 0 and 2. Is that intend? 
