### PR TITLE
GLTFLoader extensions example: set castShadow true for lights extension

### DIFF
--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -348,7 +348,7 @@
 
 					object.traverse( function ( node ) {
 
-						if ( node.isMesh ) node.castShadow = true;
+						if ( node.isMesh || node.isLight ) node.castShadow = true;
 
 					} );
 


### PR DESCRIPTION
Let's set `.castShadow` true for lights created by glTF light extension.
(Or you didn't set true for the performance?)