### PR TITLE
GLTFLoader: Do not make duplicate morphTargetDictionary entries

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1251,9 +1251,18 @@ THREE.GLTFLoader = ( function () {
 		// .extras has user-defined data, so check that .extras.targetNames is an array.
 		if ( meshDef.extras && Array.isArray( meshDef.extras.targetNames ) ) {
 
-			for ( var i = 0, il = meshDef.extras.targetNames.length; i < il; i ++ ) {
+			var targetNames = meshDef.extras.targetNames;
+			var dictionary = mesh.morphTargetDictionary;
 
-				mesh.morphTargetDictionary[ meshDef.extras.targetNames[ i ] ] = i;
+			for ( var key in dictionary ) {
+
+				if ( dictionary[ key ] < targetNames.length ) delete dictionary[ key ];
+
+			}
+
+			for ( var i = 0, il = targetNames.length; i < il; i ++ ) {
+
+				dictionary[ targetNames[ i ] ] = i;
 
 			}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1252,17 +1252,20 @@ THREE.GLTFLoader = ( function () {
 		if ( meshDef.extras && Array.isArray( meshDef.extras.targetNames ) ) {
 
 			var targetNames = meshDef.extras.targetNames;
-			var dictionary = mesh.morphTargetDictionary;
 
-			for ( var key in dictionary ) {
+			if ( mesh.morphTargetInfluences.length === targetNames.length ) {
 
-				if ( dictionary[ key ] < targetNames.length ) delete dictionary[ key ];
+				mesh.morphTargetDictionary = {};
 
-			}
+				for ( var i = 0, il = targetNames.length; i < il; i ++ ) {
 
-			for ( var i = 0, il = targetNames.length; i < il; i ++ ) {
+					mesh.morphTargetDictionary[ targetNames[ i ] ] = i;
 
-				dictionary[ targetNames[ i ] ] = i;
+				}
+
+			} else {
+
+				console.warn( 'THREE.GLTFLoader: Invalid extras.targetNames length. Ignoring names.' );
 
 			}
 


### PR DESCRIPTION
We need to remove existing morphDictionary entries in case `targetNames` is defined, not to have duplicate dictionary entry.