### PR TITLE
ColladaLoader: Removed usage of alpha maps.

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1574,7 +1574,8 @@ THREE.ColladaLoader.prototype = {
 
 				if ( transparent.data.texture ) {
 
-					material.alphaMap = getTexture( transparent.data.texture );
+					// we do not set an alpha map (see #13792)
+
 					material.transparent = true;
 
 				} else {


### PR DESCRIPTION
See discussion in #13792

We are not allowed to interpret the texture of a `<transparent>` tag as an alpha map.

@gymadarasz This PR actually fixes your model. At least on my computer.