### PR TITLE
WebGLProgram: add shader.name

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -667,6 +667,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 	//
 
+	this.name = shader.name;
 	this.id = programIdCount ++;
 	this.code = code;
 	this.usedTimes = 1;


### PR DESCRIPTION
This is helpful in trying to make sense out of `renderer.info.programs`.