### PR TITLE
PMREM and EquiangularToCubeGenerator: added dispose() methods

### DIFF
--- a/examples/js/loaders/EquiangularToCubeGenerator.js
+++ b/examples/js/loaders/EquiangularToCubeGenerator.js
@@ -2,18 +2,18 @@
 * @author Richard M. / https://github.com/richardmonette
 */
 
-THREE.EquiangularToCubeGenerator = function( sourceTexture, resolution ) {
+THREE.EquiangularToCubeGenerator = function ( sourceTexture, resolution ) {
 
 	this.sourceTexture = sourceTexture;
 	this.resolution = resolution;
 
  	this.views = [
-		{ t: [1.0,  0.0,  0.0 ], u: [0.0, -1.0,  0.0] },
-		{ t: [-1.0,  0.0,  0.0], u: [0.0, -1.0,  0.0] },
-		{ t: [0.0,  1.0,  0.0],  u: [0.0,  0.0,  1.0] },
-		{ t: [0.0, -1.0,  0.0],  u: [0.0,  0.0, -1.0] },
-		{ t: [0.0,  0.0,  1.0],  u: [0.0, -1.0,  0.0] },
-		{ t: [0.0,  0.0, -1.0],  u: [0.0, -1.0,  0.0] },
+		{ t: [ 1, 0, 0 ], u: [ 0, - 1, 0 ] },
+		{ t: [ - 1, 0, 0 ], u: [ 0, - 1, 0 ] },
+		{ t: [ 0, 1, 0 ], u: [ 0, 0, 1 ] },
+		{ t: [ 0, - 1, 0 ], u: [ 0, 0, - 1 ] },
+		{ t: [ 0, 0, 1 ], u: [ 0, - 1, 0 ] },
+		{ t: [ 0, 0, - 1 ], u: [ 0, - 1, 0 ] },
 	];
 
 	this.camera = new THREE.PerspectiveCamera( 90, 1, 0.1, 10 );
@@ -22,49 +22,47 @@ THREE.EquiangularToCubeGenerator = function( sourceTexture, resolution ) {
 	this.scene = new THREE.Scene();
 	this.scene.add( this.boxMesh );
 
+	var params = {
+		format: THREE.RGBAFormat,
+		magFilter: this.sourceTexture.magFilter,
+		minFilter: this.sourceTexture.minFilter,
+		type: this.sourceTexture.type,
+		generateMipmaps: this.sourceTexture.generateMipmaps,
+		anisotropy: this.sourceTexture.anisotropy,
+		encoding: this.sourceTexture.encoding
+	};
+
+	this.renderTarget = new THREE.WebGLRenderTargetCube( this.resolution, this.resolution, params );
+
 };
 
 THREE.EquiangularToCubeGenerator.prototype = {
 
-	constructor : THREE.EquiangularToCubeGenerator,
+	constructor: THREE.EquiangularToCubeGenerator,
 
-	generate: function( renderer ) {
+	update: function ( renderer ) {
 
-		var params = {
-			format: THREE.RGBAFormat,
-			magFilter: this.sourceTexture.magFilter,
-			minFilter: this.sourceTexture.minFilter,
-			type: this.sourceTexture.type,
-			generateMipmaps: this.sourceTexture.generateMipmaps,
-			anisotropy: this.sourceTexture.anisotropy,
-			encoding: this.sourceTexture.encoding
-		};
+		for ( var i = 0; i < 6; i ++ ) {
 
-		var renderTarget = new THREE.WebGLRenderTargetCube( this.resolution, this.resolution, params );
+			this.renderTarget.activeCubeFace = i;
 
-		for ( var i = 0; i < 6; i++ ) {
-
-			renderTarget.activeCubeFace = i;
-
-			var v = this.views[i];
+			var v = this.views[ i ];
 
 			this.camera.position.set( 0, 0, 0 );
 			this.camera.up.set( v.u[ 0 ], v.u[ 1 ], v.u[ 2 ] );
 			this.camera.lookAt( v.t[ 0 ], v.t[ 1 ], v.t[ 2 ] );
 
-			this.camera.updateProjectionMatrix();
-
-			renderer.render( this.scene, this.camera, renderTarget, true );
+			renderer.render( this.scene, this.camera, this.renderTarget, true );
 
 		}
 
-		return renderTarget.texture;
+		return this.renderTarget.texture;
 
 	},
 
-	getShader: function() {
+	getShader: function () {
 
-		return new THREE.ShaderMaterial( {
+		var shaderMaterial = new THREE.ShaderMaterial( {
 
 			uniforms: {
 				"equirectangularMap": { value: this.sourceTexture },
@@ -107,7 +105,18 @@ THREE.EquiangularToCubeGenerator.prototype = {
 
 		} );
 
+		shaderMaterial.type = 'EquiangularToCubeGenerator';
+
+		return shaderMaterial;
+
+	},
+
+	dispose: function () {
+
+		this.boxMesh.geometry.dispose();
+		this.boxMesh.material.dispose();
+		this.renderTarget.dispose();
+
 	}
 
 };
-

--- a/examples/js/pmrem/PMREMCubeUVPacker.js
+++ b/examples/js/pmrem/PMREMCubeUVPacker.js
@@ -13,10 +13,9 @@
  * The arrangement of the faces is fixed, as assuming this arrangement, the sampling function has been written.
  */
 
-THREE.PMREMCubeUVPacker = function ( cubeTextureLods, numLods ) {
+THREE.PMREMCubeUVPacker = function ( cubeTextureLods ) {
 
 	this.cubeLods = cubeTextureLods;
-	this.numLods = numLods;
 	var size = cubeTextureLods[ 0 ].width * 4;
 
 	var sourceTexture = cubeTextureLods[ 0 ].texture;
@@ -189,7 +188,21 @@ THREE.PMREMCubeUVPacker.prototype = {
 
 		} );
 
+		shaderMaterial.type = 'PMREMCubeUVPacker';
+
 		return shaderMaterial;
+
+	},
+
+	dispose: function () {
+
+		for ( var i = 0, l = this.objects.length; i < l; i ++ ) {
+
+			this.objects[ i ].material.dispose();
+
+		}
+
+		this.objects[ 0 ].geometry.dispose();
 
 	}
 

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -138,7 +138,7 @@ THREE.PMREMGenerator.prototype = {
 
 	getShader: function () {
 
-		return new THREE.ShaderMaterial( {
+		var shaderMaterial = new THREE.ShaderMaterial( {
 
 			defines: {
 				"SAMPLES_PER_LEVEL": 20,
@@ -268,6 +268,23 @@ THREE.PMREMGenerator.prototype = {
 			blendEquation: THREE.AddEquation
 
 		} );
+
+		shaderMaterial.type = 'PMREMGenerator';
+
+		return shaderMaterial;
+
+	},
+
+	dispose: function () {
+
+		for ( var i = 0, l = this.cubeLods.length; i < l; i ++ ) {
+
+			this.cubeLods[ i ].dispose();
+
+		}
+
+		this.planeMesh.geometry.dispose();
+		this.planeMesh.material.dispose();
 
 	}
 

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -67,7 +67,7 @@
 				document.body.appendChild( container );
 
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.set( 0.0, 0, 120 );
+				camera.position.set( 0, 0, 120 );
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0x000000 );
@@ -107,7 +107,7 @@
 					texture.encoding = THREE.LinearEncoding;
 
 					var cubemapGenerator = new THREE.EquiangularToCubeGenerator( texture, 512 );
-					var cubeMapTexture = cubemapGenerator.generate( renderer );
+					var cubeMapTexture = cubemapGenerator.update( renderer );
 
 					var pmremGenerator = new THREE.PMREMGenerator( cubeMapTexture );
 					pmremGenerator.update( renderer );
@@ -117,6 +117,11 @@
 
 					exrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
 
+					texture.dispose();
+					cubemapGenerator.dispose();
+					pmremGenerator.dispose();
+					pmremCubeUVPacker.dispose();
+
 				} );
 
 				new THREE.TextureLoader().load( 'textures/equiangular.png', function ( texture ) {
@@ -124,7 +129,7 @@
 					texture.encoding = THREE.sRGBEncoding;
 
 					var cubemapGenerator = new THREE.EquiangularToCubeGenerator( texture, 512 );
-					var cubeMapTexture = cubemapGenerator.generate( renderer );
+					var cubeMapTexture = cubemapGenerator.update( renderer );
 
 					var pmremGenerator = new THREE.PMREMGenerator( cubeMapTexture );
 					pmremGenerator.update( renderer );
@@ -133,6 +138,11 @@
 					pmremCubeUVPacker.update( renderer );
 
 					pngCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+
+					texture.dispose();
+					cubemapGenerator.dispose();
+					pmremGenerator.dispose();
+					pmremCubeUVPacker.dispose();
 
 				} );
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -68,7 +68,7 @@
 				document.body.appendChild( container );
 
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.set( 0.0, 0, 120 );
+				camera.position.set( 0, 0, 120 );
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0x000000 );
@@ -77,7 +77,6 @@
 				renderer.toneMapping = THREE.LinearToneMapping;
 
 				standardMaterial = new THREE.MeshStandardMaterial( {
-					map: null,
 					color: 0xffffff,
 					metalness: params.metalness,
 					roughness: params.roughness
@@ -119,6 +118,10 @@
 
 					hdrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
 
+					hdrCubeMap.dispose();
+					pmremGenerator.dispose();
+					pmremCubeUVPacker.dispose();
+
 				} );
 
 				var ldrUrls = genCubeUrls( './textures/cube/pisa/', '.png' );
@@ -133,6 +136,10 @@
 					pmremCubeUVPacker.update( renderer );
 
 					ldrCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+
+					ldrCubeMap.dispose();
+					pmremGenerator.dispose();
+					pmremCubeUVPacker.dispose();
 
 				} );
 
@@ -149,6 +156,10 @@
 					pmremCubeUVPacker.update( renderer );
 
 					rgbmCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+
+					rgbmCubeMap.dispose();
+					pmremGenerator.dispose();
+					pmremCubeUVPacker.dispose();
 
 				} );
 


### PR DESCRIPTION
...as proposed in https://github.com/mrdoob/three.js/pull/13752#issuecomment-378298529, plus some clean up.

Calling the dispose() methods _significantly_ frees up gpu memory.