### PR TITLE
LegacyGLTFLoader: fix texture loading of binary glTF 1.0

### DIFF
--- a/examples/js/loaders/deprecated/LegacyGLTFLoader.js
+++ b/examples/js/loaders/deprecated/LegacyGLTFLoader.js
@@ -649,6 +649,13 @@ THREE.LegacyGLTFLoader = ( function () {
 
 		}
 
+		// Blob URL
+		if ( /^blob:.*$/i.test( url ) ) {
+
+			return url;
+
+		}
+
 		// Relative URL
 		return ( path || '' ) + url;
 


### PR DESCRIPTION
Blob textures of binary glTF 1.0 were not handled in `resolveURL`.