### PR TITLE
Fix missing name copy in BufferAttribute.copy

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -68,6 +68,7 @@ Object.assign( BufferAttribute.prototype, {
 
 	copy: function ( source ) {
 
+		this.name = source.name;
 		this.array = new source.array.constructor( source.array );
 		this.itemSize = source.itemSize;
 		this.count = source.count;


### PR DESCRIPTION
This PR fixes missing `.name` copy in `BufferAttribute.copy()`.