### PR TITLE
GLTFLoader: Preserve unknown extension data on nodes and materials.

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -92,18 +92,18 @@
 		</p>
 
 		<code>
-loader.load('foo.gltf', function ( gltf ) {
+		loader.load('foo.gltf', function ( gltf ) {
 
-  var scene = gltf.scene;
+			var scene = gltf.scene;
 
-  var mesh = scene.children[ 3 ];
+			var mesh = scene.children[ 3 ];
 
-  var fooExtension = mesh.userData.gltfExtensions.EXT_foo;
+			var fooExtension = mesh.userData.gltfExtensions.EXT_foo;
 
-  gltf.parser.getDependency( 'bufferView', fooExtension.bufferView )
-    .then( function ( fooBuffer ) { ... } );
+			gltf.parser.getDependency( 'bufferView', fooExtension.bufferView )
+				.then( function ( fooBuffer ) { ... } );
 
-});
+		} );
 		</code>
 
 		<br>

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -84,6 +84,28 @@
 		<a href="https://github.com/stefanpenner/es6-promise">include a polyfill</a>
 		providing a Promise replacement.</p>
 
+		<h2>Custom extensions</h2>
+
+		<p>
+			Metadata from unknown extensions is preserved as “.userData.gltfExtensions” on Object3D, Scene, and Material instances,
+			or attached to the response “gltf” object. Example:
+		</p>
+
+		<code>
+loader.load('foo.gltf', function ( gltf ) {
+
+  var scene = gltf.scene;
+
+  var mesh = scene.children[ 3 ];
+
+  var fooExtension = mesh.userData.gltfExtensions.EXT_foo;
+
+  gltf.parser.getDependency( 'bufferView', fooExtension.bufferView )
+    .then( function ( fooBuffer ) { ... } );
+
+});
+		</code>
+
 		<br>
 		<hr>
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -174,7 +174,7 @@ THREE.GLTFLoader = ( function () {
 
 			} );
 
-			parser.parse( function ( scene, scenes, cameras, animations, asset ) {
+			parser.parse( function ( scene, scenes, cameras, animations, json ) {
 
 				console.timeEnd( 'GLTFLoader' );
 
@@ -183,8 +183,12 @@ THREE.GLTFLoader = ( function () {
 					scenes: scenes,
 					cameras: cameras,
 					animations: animations,
-					asset: asset
+					asset: json.asset,
+					parser: parser,
+					userData: {}
 				};
+
+				addUnknownExtensionsToUserData( extensions, glTF, json );
 
 				onLoad( glTF );
 
@@ -1459,10 +1463,9 @@ THREE.GLTFLoader = ( function () {
 			var scenes = dependencies.scenes || [];
 			var scene = scenes[ json.scene || 0 ];
 			var animations = dependencies.animations || [];
-			var asset = json.asset;
 			var cameras = dependencies.cameras || [];
 
-			onLoad( scene, scenes, cameras, animations, asset );
+			onLoad( scene, scenes, cameras, animations, json );
 
 		} ).catch( onError );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1166,13 +1166,13 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
-	function addUnknownExtensionsToUserData( object, objectDef ) {
+	function addUnknownExtensionsToUserData( knownExtensions, object, objectDef ) {
 
 		// Add unknown glTF extensions to an object's userData.
 
 		for ( var name in objectDef.extensions ) {
 
-			if ( EXTENSIONS[ name ] === undefined ) {
+			if ( knownExtensions[ name ] === undefined ) {
 
 				object.userData.gltfExtensions = object.userData.gltfExtensions || {};
 				object.userData.gltfExtensions[ name ] = objectDef.extensions[ name ];
@@ -2142,7 +2142,7 @@ THREE.GLTFLoader = ( function () {
 
 			if ( materialDef.extras ) material.userData = materialDef.extras;
 
-			if ( materialDef.extensions ) addUnknownExtensionsToUserData( material, materialDef );
+			if ( materialDef.extensions ) addUnknownExtensionsToUserData( extensions, material, materialDef );
 
 			return material;
 
@@ -2764,7 +2764,7 @@ THREE.GLTFLoader = ( function () {
 
 			if ( nodeDef.extras ) node.userData = nodeDef.extras;
 
-			if ( nodeDef.extensions ) addUnknownExtensionsToUserData( node, nodeDef );
+			if ( nodeDef.extensions ) addUnknownExtensionsToUserData( extensions, node, nodeDef );
 
 			if ( nodeDef.matrix !== undefined ) {
 
@@ -2898,7 +2898,7 @@ THREE.GLTFLoader = ( function () {
 
 				if ( sceneDef.extras ) scene.userData = sceneDef.extras;
 
-				if ( sceneDef.extensions ) addUnknownExtensionsToUserData( scene, sceneDef );
+				if ( sceneDef.extensions ) addUnknownExtensionsToUserData( extensions, scene, sceneDef );
 
 				var nodeIds = sceneDef.nodes || [];
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -146,6 +146,10 @@ THREE.GLTFLoader = ( function () {
 							extensions[ extensionName ] = new GLTFDracoMeshCompressionExtension( this.dracoLoader );
 							break;
 
+						case EXTENSIONS.MSFT_TEXTURE_DDS:
+							extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ] = new GLTFTextureDDSExtension();
+							break;
+
 						default:
 
 							if ( extensionsRequired.indexOf( extensionName ) >= 0 ) {
@@ -155,12 +159,6 @@ THREE.GLTFLoader = ( function () {
 							}
 
 					}
-
-				}
-
-				if ( json.extensionsUsed.indexOf( EXTENSIONS.MSFT_TEXTURE_DDS ) >= 0 ) {
-
-					extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ] = new GLTFTextureDDSExtension();
 
 				}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -126,6 +126,7 @@ THREE.GLTFLoader = ( function () {
 				for ( var i = 0; i < json.extensionsUsed.length; ++ i ) {
 
 					var extensionName = json.extensionsUsed[ i ];
+					var extensionsRequired = json.extensionsRequired || [];
 
 					switch ( extensionName ) {
 
@@ -146,7 +147,12 @@ THREE.GLTFLoader = ( function () {
 							break;
 
 						default:
-							console.warn( 'THREE.GLTFLoader: Unknown extension "' + extensionName + '".' );
+
+							if ( extensionsRequired.indexOf( extensionName ) >= 0 ) {
+
+								console.warn( 'THREE.GLTFLoader: Unknown extension "' + extensionName + '".' );
+
+							}
 
 					}
 
@@ -1160,13 +1166,13 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
-	function addExtensionUserData( extensionsUsed, object, objectDef ) {
+	function addUnknownExtensionsToUserData( object, objectDef ) {
 
 		// Add unknown glTF extensions to an object's userData.
 
 		for ( var name in objectDef.extensions ) {
 
-			if ( extensionsUsed[ name ] === undefined ) {
+			if ( EXTENSIONS[ name ] === undefined ) {
 
 				object.userData.gltfExtensions = object.userData.gltfExtensions || {};
 				object.userData.gltfExtensions[ name ] = objectDef.extensions[ name ];
@@ -2136,7 +2142,7 @@ THREE.GLTFLoader = ( function () {
 
 			if ( materialDef.extras ) material.userData = materialDef.extras;
 
-			if ( materialDef.extensions ) addExtensionUserData( extensions, material, materialDef );
+			if ( materialDef.extensions ) addUnknownExtensionsToUserData( material, materialDef );
 
 			return material;
 
@@ -2758,7 +2764,7 @@ THREE.GLTFLoader = ( function () {
 
 			if ( nodeDef.extras ) node.userData = nodeDef.extras;
 
-			if ( nodeDef.extensions ) addExtensionUserData( extensions, node, nodeDef );
+			if ( nodeDef.extensions ) addUnknownExtensionsToUserData( node, nodeDef );
 
 			if ( nodeDef.matrix !== undefined ) {
 
@@ -2891,6 +2897,8 @@ THREE.GLTFLoader = ( function () {
 				if ( sceneDef.name !== undefined ) scene.name = sceneDef.name;
 
 				if ( sceneDef.extras ) scene.userData = sceneDef.extras;
+
+				if ( sceneDef.extensions ) addUnknownExtensionsToUserData( scene, sceneDef );
 
 				var nodeIds = sceneDef.nodes || [];
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/13703 and https://github.com/mrdoob/three.js/issues/11682. Not a complete solution for all user-defined extensions — may need access to data in buffers or textures — but if that is requested later I think we can just return a `parser` reference and then custom extension implementations can do the rest pretty easily:

```js
loader.load('foo.gltf', (gltf) => {
  var scene = gltf.scene;
  var mesh = scene.children[ 3 ];
  var fooExtension = mesh.userData.gltfExtensions.EXT_foo;
  gltf.parser.getDependency( 'bufferView', fooExtension.bufferView )
    .then( fooBuffer => { ... } );
});
```

This will also avoid loading those textures and buffers until they're requested by the userland code, so it seems pretty decent as an API.

/cc @takahirox 