### PR TITLE
Docs: Reduce linewidth for Math – Examples sections.

### DIFF
--- a/docs/api/Template.html
+++ b/docs/api/Template.html
@@ -12,7 +12,7 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">todo</div>
+		<p class="desc">todo</p>
 
 
 		<h2>Example</h2>
@@ -23,22 +23,22 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]([param:Number todo])</h3>
-		<div></div>
+		<p></p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Number todo]</h3>
-		<div>
+		<p>
 		todo
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null todo]()</h3>
-		<div>todo</div>
-		<div>todo</div>
+		<p>todo</p>
+		<p>todo</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/math/Box2.html
+++ b/docs/api/math/Box2.html
@@ -10,16 +10,16 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			Represents a box in 2D space.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Vector2 min], [param:Vector2 max] )</h3>
-		<div>
+		<p>
 		[page:Vector2 min] - (optional) [page:Vector2] representing the lower (x, y) boundary of the box.
 		Default is ( + Infinity, + Infinity ).<br>
 
@@ -27,7 +27,7 @@
 		Default is ( - Infinity, - Infinity ).<br /><br />
 
 		Creates a [name] bounded by min and max.
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
@@ -35,180 +35,180 @@
 
 
 		<h3>[property:Vector2 min]</h3>
-		<div>
+		<p>
 			[page:Vector2] representing the lower (x, y) boundary of the box.<br />
 			Default is ( + Infinity, + Infinity ).
-		</div>
+		</p>
 
 		<h3>[property:Vector2 max]</h3>
-		<div>
+		<p>
 			[page:Vector2] representing the lower upper (x, y) boundary of the box.<br />
 			Default is ( - Infinity, - Infinity ).
-		</div>
+		</p>
 
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:Vector2 clampPoint]( [param:Vector2 point], [param:Vector2 target] )</h3>
-		<div>
+		<p>
 		[page:Vector2 point] - [page:Vector2] to clamp. <br>
 		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Clamping_(graphics) Clamps] the [page:Vector2 point] within the bounds of this box.<br />
-		</div>
+		</p>
 
 		<h3>[method:Box2 clone]()</h3>
-		<div>Returns a new [page:Box2] with the same [page:.min min] and [page:.max max] as this one.</div>
+		<p>Returns a new [page:Box2] with the same [page:.min min] and [page:.max max] as this one.</p>
 
 		<h3>[method:Boolean containsBox]( [param:Box2 box] )</h3>
-		<div>
+		<p>
 		[page:Box2 box] - [page:Box2 Box2] to test for inclusion.<br /><br />
 
 		Returns true if this box includes the entirety of [page:Box2 box]. If this and [page:Box2 box] are identical, <br>
 		this function also returns true.
-		</div>
+		</p>
 
 		<h3>[method:Boolean containsPoint]( [param:Vector2 point] )</h3>
-		<div>
+		<p>
 		[page:Vector2 point] - [page:Vector2] to check for inclusion.<br /><br />
 
 		Returns true if the specified [page:Vector2 point] lies within or on the boundaries of this box.
-		</div>
+		</p>
 
 		<h3>[method:Box2 copy]( [param:Box2 box] )</h3>
-		<div>
+		<p>
 		Copies the [page:.min min] and [page:.max max] from [page:Box2 box] to this box.
-		</div>
+		</p>
 
 		<h3>[method:Float distanceToPoint]( [param:Vector2 point] )</h3>
-		<div>
+		<p>
 		[page:Vector2 point] - [page:Vector2] to measure distance to.<br /><br />
 
 		Returns the distance from any edge of this box to the specified point.
 		If the [page:Vector2 point] lies inside of this box, the distance will be 0.
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Box2 box] )</h3>
-		<div>
+		<p>
 		[page:Box2 box] - Box to compare with this one.<br /><br />
 
 		Returns true if this box and [page:Box2 box] share the same lower and upper bounds.
-		</div>
+		</p>
 
 		<h3>[method:Box2 expandByPoint]( [param:Vector2 point] )</h3>
-		<div>
+		<p>
 		[page:Vector2 point] - [page:Vector2] that should be included in the box.<br /><br />
 
 		Expands the boundaries of this box to include [page:Vector2 point].
-		</div>
+		</p>
 
 		<h3>[method:Box2 expandByScalar]( [param:float scalar] )</h3>
-		<div>
+		<p>
 		[page:float scalar] - Distance to expand the box by.<br /><br />
 
 		Expands each dimension of the box by [page:float scalar]. If negative, the dimensions of the box
 		will be contracted.
-		</div>
+		</p>
 
 		<h3>[method:Box2 expandByVector]( [param:Vector2 vector] )</h3>
-		<div>
+		<p>
 		[page:Vector2 vector] - [page:Vector2] to expand the box by.<br /><br />
 
 		Expands this box equilaterally by [page:Vector2 vector]. The width of this box will be
 		expanded by the x component of [page:Vector2 vector] in both directions. The height of
 		this box will be expanded by the y component of [page:Vector2 vector] in both directions.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 getCenter]( [param:Vector2 target] )</h3>
-		<div>
+		<p>
 		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />
 
 		Returns the center point of the box as a [page:Vector2].
-		</div>
+		</p>
 
 		<h3>[method:Vector2 getParameter]( [param:Vector2 point], [param:Vector2 target] ) </h3>
-		<div>
+		<p>
 		[page:Vector2 point] - [page:Vector2].<br/>
 		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />
 
 		Returns a point as a proportion of this box's width and height.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 getSize]( [param:Vector2 target] )</h3>
-		<div>
+		<p>
 		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />
 
 		Returns the width and height of this box.
-		</div>
+		</p>
 
 		<h3>[method:Box2 intersect]( [param:Box2 box] )</h3>
-		<div>
+		<p>
 		[page:Box2 box] - Box to intersect with.<br /><br />
 
 		Returns the intersection of this and [page:Box2 box], setting the upper bound of this box to the lesser
 		of the two boxes' upper bounds and the lower bound of this box to the greater of the two boxes'
 		lower bounds.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box2 box] )</h3>
-		<div>
+		<p>
 		[page:Box2 box] - Box to check for intersection against.<br /><br />
 
 		Determines whether or not this box intersects [page:Box2 box].
-		</div>
+		</p>
 
 		<h3>[method:Boolean isEmpty]()</h3>
-		<div>
+		<p>
 		Returns true if this box includes zero points within its bounds.<br>
 		Note that a box with equal lower and upper bounds still includes one point, the
 		one both bounds share.
-		</div>
+		</p>
 
 		<h3>[method:Box2 makeEmpty]()</h3>
-		<div>Makes this box empty.</div>
+		<p>Makes this box empty.</p>
 
 
 		<h3>[method:Box2 set]( [param:Vector2 min], [param:Vector2 max] )</h3>
-		<div>
+		<p>
 			[page:Vector2 min] - (required ) [page:Vector2] representing the lower (x, y) boundary of the box. <br>
 			[page:Vector2 max]  - (required) [page:Vector2] representing the lower upper (x, y) boundary of the box. <br /><br />
 
 			Sets the lower and upper (x, y) boundaries of this box.
-		</div>
+		</p>
 
 		<h3>[method:Box2 setFromCenterAndSize]( [param:Vector2 center], [param:Vector2 size] )</h3>
-		<div>
+		<p>
 		[page:Vector2 center] - Desired center position of the box ([page:Vector2]). <br>
 		[page:Vector2 size] - Desired x and y dimensions of the box ([page:Vector2]).<br /><br />
 
 		Centers this box on [page:Vector2 center] and sets this box's width and height to the values specified
 		in [page:Vector2 size].
-		</div>
+		</p>
 
 		<h3>[method:Box2 setFromPoints]( [param:Array points] )</h3>
-		<div>
+		<p>
 		[page:Array points] - Array of [page:Vector2 Vector2s] that the resulting box will contain.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the points in [page:Array points].
-		</div>
+		</p>
 
 		<h3>[method:Box2 translate]( [param:Vector2 offset] )</h3>
-		<div>
+		<p>
 		[page:Vector2 offset] - Direction and distance of offset.<br /><br />
 
 		Adds [page:Vector2 offset] to both the upper and lower bounds of this box, effectively moving this box
 		[page:Vector2 offset] units in 2D space.
-		</div>
+		</p>
 
 		<h3>[method:Box2 union]( [param:Box2 box] )</h3>
-		<div>
+		<p>
 		[page:Box2 box] - Box that will be unioned with this box.<br /><br />
 
 		Unions this box with [page:Box2 box], setting the upper bound of this box to the greater of the
 		two boxes' upper bounds and the lower bound of this box to the lesser of the two boxes'
 		lower bounds.
-		</div>
+		</p>
 
 
 

--- a/docs/api/math/Box3.html
+++ b/docs/api/math/Box3.html
@@ -10,17 +10,18 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			Represents a box or cube in 3D space. The main purpose of this is to represent
 			the [link:https://en.wikipedia.org/wiki/Minimum_bounding_box Minimum Bounding Boxes]
 			for objects.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Vector3 min], [param:Vector3 max] )</h3>
+		<p>
 		[page:Vector3 min] - (optional) [page:Vector3] representing the lower (x, y, z) boundary of the box.
 		Default is ( + Infinity, + Infinity, + Infinity ).<br>
 
@@ -28,271 +29,271 @@
 		Default is ( - Infinity, - Infinity, - Infinity ).<br /><br />
 
 		Creates a [name] bounded by min and max.
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean isBox3]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are Box3s. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 		<h3>[property:Vector3 min]</h3>
-		<div>
+		<p>
 			[page:Vector3] representing the lower (x, y, z) boundary of the box.<br />
 			Default is ( + Infinity, + Infinity, + Infinity ).
-		</div>
+		</p>
 
 		<h3>[property:Vector3 max]</h3>
-		<div>
+		<p>
 			[page:Vector3] representing the upper (x, y, z) boundary of the box.<br />
 			Default is ( - Infinity, - Infinity, - Infinity ).
-		</div>
+		</p>
 
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:Box3 applyMatrix4]( [param:Matrix4 matrix] )</h3>
-		<div>
+		<p>
 		[page:Matrix4 matrix] - The [page:Matrix4] to apply<br /><br />
 
 		Transforms this Box3 with the supplied matrix.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 clampPoint]( [param:Vector3 point], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] to clamp. <br>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Clamping_(graphics) Clamps] the [page:Vector3 point] within the bounds of this box.<br />
-		</div>
+		</p>
 
 		<h3>[method:Box3 clone]()</h3>
-		<div>Returns a new [page:Box3] with the same [page:.min min] and [page:.max max] as this one.</div>
+		<p>Returns a new [page:Box3] with the same [page:.min min] and [page:.max max] as this one.</p>
 
 		<h3>[method:Boolean containsBox]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - [page:Box3 Box3] to test for inclusion.<br /><br />
 
 		Returns true if this box includes the entirety of [page:Box3 box]. If this and [page:Box3 box] are identical, <br>
 		this function also returns true.
-		</div>
+		</p>
 
 		<h3>[method:Boolean containsPoint]( [param:Vector3 point] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] to check for inclusion.<br /><br />
 
 		Returns true if the specified [page:Vector3 point] lies within or on the boundaries of this box.
-		</div>
+		</p>
 
 		<h3>[method:Box3 copy]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box]  - [page:Box3] to copy.<br /><br />
 
 		Copies the [page:.min min] and [page:.max max] from [page:Box3 box] to this box.
-		</div>
+		</p>
 
 		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] to measure distance to.<br /><br />
 
 		Returns the distance from any edge of this box to the specified point.
 		If the [page:Vector3 point] lies inside of this box, the distance will be 0.
-		</div>
+		</p>
 
 
 		<h3>[method:Boolean equals]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - Box to compare with this one.<br /><br />
 
 		Returns true if this box and [page:Box3 box] share the same lower and upper bounds.
-		</div>
+		</p>
 
 		<h3>[method:Box3 expandByObject]( [param:Object3D object] )</h3>
-		<div>
+		<p>
 		[page:Object3D object] - [page:Object3D] to expand the box by.<br /><br />
 
 		Expands the boundaries of this box to include [page:Object3D object] and its children,
 		accounting for the object's, and children's, world transforms.
 
-		</div>
+		</p>
 
 		<h3>[method:Box3 expandByPoint]( [param:Vector3 point] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] that should be included in the box.<br /><br />
 
 		Expands the boundaries of this box to include [page:Vector3 point].
-		</div>
+		</p>
 
 		<h3>[method:Box3 expandByScalar]( [param:float scalar] )</h3>
-		<div>
+		<p>
 		[page:float scalar] - Distance to expand the box by.<br /><br />
 
 		Expands each dimension of the box by [page:float scalar]. If negative, the dimensions of the box
 		will be contracted.
-		</div>
+		</p>
 
 		<h3>[method:Box3 expandByVector]( [param:Vector3 vector] )</h3>
-		<div>
+		<p>
 		[page:Vector3 vector] - [page:Vector3] to expand the box by.<br /><br />
 
 		Expands this box equilaterally by [page:Vector3 vector]. The width of this box will be
 		expanded by the x component of [page:Vector3 vector] in both directions. The height of
 		this box will be expanded by the y component of [page:Vector3 vector] in both directions.
 		The depth of this box will be expanded by the z component of *vector* in both directions.
-		</div>
+		</p>
 
 		<h3>[method:Sphere getBoundingSphere]( [param:Sphere target] )</h3>
-		<div>
+		<p>
 		[page:Sphere target] — the result will be copied into this Sphere.<br /><br />
 
 		Gets a [page:Sphere] that bounds the box.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 getCenter]( [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns the center point of the box as a [page:Vector3].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 getParameter]( [param:Vector3 point], [param:Vector3 target] ) </h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3].<br/>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns a point as a proportion of this box's width and height.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 getSize]( [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns the width, height and depth of this box.
-		</div>
+		</p>
 
 		<h3>[method:Box3 intersect]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - Box to intersect with.<br /><br />
 
 		Returns the intersection of this and [page:Box3 box], setting the upper bound of this box to the lesser
 		of the two boxes' upper bounds and the lower bound of this box to the greater of the two boxes'
 		lower bounds.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - Box to check for intersection against.<br /><br />
 
 		Determines whether or not this box intersects [page:Box3 box].
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsPlane]( [param:Plane plane] )</h3>
-		<div>
+		<p>
 		[page:Plane plane] - [page:Plane] to check for intersection against.<br /><br />
 
 		Determines whether or not this box intersects [page:Plane plane].
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
-		<div>
+		<p>
 		[page:Sphere sphere] - [page:Sphere] to check for intersection against.<br /><br />
 
 		Determines whether or not this box intersects [page:Sphere sphere].
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsTriangle]( [param:Triangle triangle] )</h3>
-		<div>
+		<p>
 		[page:Triangle triangle] - [page:Triangle] to check for intersection against.<br /><br />
 
 		Determines whether or not this box intersects [page:Triangle triangle].
-		</div>
+		</p>
 
 		<h3>[method:Boolean isEmpty]()</h3>
-		<div>
+		<p>
 		Returns true if this box includes zero points within its bounds.<br>
 		Note that a box with equal lower and upper bounds still includes one point,
 		the one both bounds share.
-		</div>
+		</p>
 
 		<h3>[method:Box3 makeEmpty]()</h3>
-		<div>Makes this box empty.</div>
+		<p>Makes this box empty.</p>
 
 		<h3>[method:Box3 set]( [param:Vector3 min], [param:Vector3 max] )</h3>
-		<div>
+		<p>
 		[page:Vector3 min] - [page:Vector3] representing the lower (x, y, z) boundary of the box.<br />
 		[page:Vector3 max] - [page:Vector3] representing the lower upper (x, y, z) boundary of the box.<br /><br />
 
 		Sets the lower and upper (x, y, z) boundaries of this box.
-		</div>
+		</p>
 
 		<h3>[method:Box3 setFromArray]( [param:Array array] ) [param:Box3 this]</h3>
-		<div>
+		<p>
 		array -- An array of position data that the resulting box will envelop.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the data in *array*.
-		</div>
+		</p>
 
 		<h3>[method:Box3 setFromBufferAttribute]( [param:BufferAttribute attribute] ) [param:Box3 this]</h3>
-		<div>
+		<p>
 		[page:BufferAttribute attribute] - A buffer attribute of position data that the resulting box will envelop.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the data in [page:BufferAttribute attribute].
-		</div>
+		</p>
 
 		<h3>[method:Box3 setFromCenterAndSize]( [param:Vector3 center], [param:Vector3 size] )</h3>
-		<div>
+		<p>
 		[page:Vector3 center] - Desired center position of the box ([page:Vector3]). <br>
 		[page:Vector3 size] - Desired x, y and z dimensions of the box ([page:Vector3]).<br /><br />
 
 		Centers this box on [page:Vector3 center] and sets this box's width and height to the values specified
 		in [page:Vector3 size].
-		</div>
+		</p>
 
 		<h3>[method:Box3 setFromCenterAndSize]( [param:Vector3 center], [param:Vector3 size] ) [param:Box3 this]</h3>
-		<div>
+		<p>
 		[page:Vector3 center], - Desired center position of the box. <br>
 		[page:Vector3 size] - Desired x, y and z dimensions of the box.<br /><br />
 
 		Centers this box on [page:Vector3 center] and sets this box's width, height and depth to the values specified <br>
 		in [page:Vector3 size]
-		</div>
+		</p>
 
 		<h3>[method:Box3 setFromObject]( [param:Object3D object] )</h3>
-		<div>
+		<p>
 		[page:Object3D object] - [page:Object3D] to compute the bounding box of.<br /><br />
 
 		Computes the world-axis-aligned bounding box of an [page:Object3D] (including its children),
 		accounting for the object's, and children's, world transforms.
 
-		</div>
+		</p>
 
 		<h3>[method:Box3 setFromPoints]( [param:Array points] )</h3>
-		<div>
+		<p>
 		[page:Array points] - Array of [page:Vector3 Vector3s] that the resulting box will contain.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the points in [page:Array points].
-		</div>
+		</p>
 
 		<h3>[method:Box3 translate]( [param:Vector3 offset] )</h3>
-		<div>
+		<p>
 		[page:Vector3 offset] - Direction and distance of offset.<br /><br />
 
 		Adds [page:Vector3 offset] to both the upper and lower bounds of this box, effectively moving this box
 		[page:Vector3 offset] units in 3D space.
-		</div>
+		</p>
 
 		<h3>[method:Box3 union]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - Box that will be unioned with this box.<br /><br />
 
 		Unions this box with [page:Box3 box], setting the upper bound of this box to the greater of the
 		two boxes' upper bounds and the lower bound of this box to the lesser of the two boxes'
 		lower bounds.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -10,9 +10,9 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		Class representing a color.
-		</div>
+		</p>
 
 
 		<h2>Examples</h2>
@@ -45,7 +45,7 @@ var color = new THREE.Color( 1, 0, 0 );
 
 
 		<h3>[name]( [param:Color_Hex_or_String r], [param:Float g], [param:Float b] )</h3>
-		<div>
+		<p>
 		[page:Color_Hex_or_String r] - (optional) If arguments [page:Float g] and [page:Float b] are defined, the red component of the color.
 		If they are not defined, it can be a [link:https://en.wikipedia.org/wiki/Web_colors#Hex_triplet hexadecimal triplet] (recommended), a CSS-style string, or another Color instance.<br />
 		[page:Float g] - (optional) If it is defined, the green component of the color.<br />
@@ -71,31 +71,31 @@ var color = new THREE.Color( 1, 0, 0 );
 
 			</li>
 		</ul>
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean isColor]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are Colors. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 		<h3>[property:Float r]</h3>
-		<div>
+		<p>
 		Red channel value between 0 and 1. Default is 1.
-		</div>
+		</p>
 
 		<h3>[property:Float g]</h3>
-		<div>
+		<p>
 		Green channel value between 0 and 1. Default is 1.
-		</div>
+		</p>
 
 		<h3>[property:Float b]</h3>
-		<div>
+		<p>
 		Blue channel value between 0 and 1. Default is 1.
-		</div>
+		</p>
 
 
 
@@ -105,65 +105,65 @@ var color = new THREE.Color( 1, 0, 0 );
 		<h2>Methods</h2>
 
 		<h3>[method:Color add]( [param:Color color] ) </h3>
-		<div>Adds the RGB values of [page:Color color] to the RGB values of this color.</div>
+		<p>Adds the RGB values of [page:Color color] to the RGB values of this color.</p>
 
 		<h3>[method:Color addColors]( [param:Color color1], [param:Color color2] ) </h3>
-		<div>Sets this color's RGB values to the sum of the RGB values of [page:Color color1] and [page:Color color2].</div>
+		<p>Sets this color's RGB values to the sum of the RGB values of [page:Color color1] and [page:Color color2].</p>
 
 		<h3>[method:Color addScalar]( [param:Number s] ) </h3>
-		<div>Adds [page:Number s] to the RGB values of this color.</div>
+		<p>Adds [page:Number s] to the RGB values of this color.</p>
 
 		<h3>[method:Color clone]() </h3>
-		<div>Returns a new Color with the same [page:.r r], [page:.g g] and [page:.b b] values as this one.</div>
+		<p>Returns a new Color with the same [page:.r r], [page:.g g] and [page:.b b] values as this one.</p>
 
 		<h3>[method:Color copy]( [param:Color color] ) </h3>
-		<div>
+		<p>
 			Copies the [page:.r r], [page:.g g] and [page:.b b] parameters from [page:Color color] in to this color.
-		</div>
+		</p>
 
 		<h3>[method:Color convertGammaToLinear]() </h3>
-		<div>Converts this color from gamma to linear space by squaring the values of [page:.r r], [page:.g g] and [page:.b b] ).</div>
+		<p>Converts this color from gamma to linear space by squaring the values of [page:.r r], [page:.g g] and [page:.b b] ).</p>
 
 		<h3>[method:Color convertLinearToGamma]() </h3>
-		<div>Converts this color from linear to gamma space by taking the square root of [page:.r r], [page:.g g] and [page:.b b]).</div>
+		<p>Converts this color from linear to gamma space by taking the square root of [page:.r r], [page:.g g] and [page:.b b]).</p>
 
 		<h3>[method:Color copyGammaToLinear]( [param:Color color], [param:Float gammaFactor] ) </h3>
-		<div>
+		<p>
 		[page:Color color] — Color to copy.<br />
 		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
 
 		Copies the given color into this color while converting it from gamma to linear space
 		by taking [page:.r r], [page:.g g] and [page:.b b] to the power of [page:Float gammaFactor].
-		</div>
+		</p>
 
 		<h3>[method:Color copyLinearToGamma]( [param:Color color], [param:Float gammaFactor] ) </h3>
-		<div>
+		<p>
 		[page:Color color] — Color to copy.<br />
 		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
 
 		Copies the given color into this color while converting it from linear to gamma space
 		by taking [page:.r r], [page:.g g] and [page:.b b] to the power of 1 / [page:Float gammaFactor].
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Color color] ) </h3>
-		<div>Compares the RGB values of [page:Color color] with those of this object. Returns true if they are the same, false otherwise.</div>
+		<p>Compares the RGB values of [page:Color color] with those of this object. Returns true if they are the same, false otherwise.</p>
 
 		<h3>[method:Color fromArray]( [param:Array array], [param:Integer offset] ) </h3>
-		<div>
+		<p>
 		[page:Array array] - [page:Array] of floats in the form [ [page:Float r], [page:Float g], [page:Float b] ].<br />
 		[page:Integer offset] - An optional offset into the array.<br /><br />
 
 		Sets this color's components based on an array formatted like [ [page:Float r], [page:Float g], [page:Float b] ].
-		</div>
+		</p>
 
 		<h3>[method:Integer getHex]()</h3>
-		<div>Returns the hexadecimal value of this color.</div>
+		<p>Returns the hexadecimal value of this color.</p>
 
 		<h3>[method:String getHexString]()</h3>
-		<div>Returns the hexadecimal value of this color as a string (for example, 'FFFFFF').</div>
+		<p>Returns the hexadecimal value of this color as a string (for example, 'FFFFFF').</p>
 
 		<h3>[method:Object getHSL]( [param:Object target] )</h3>
-		<div>
+		<p>
 			[page:Object target] — the result will be copied into this Object. Adds h, s and l keys to the object (if not already present).<br /><br />
 
 			Convert this Color's [page:.r r], [page:.g g] and [page:.b b] values to [link:https://en.wikipedia.org/wiki/HSL_and_HSV HSL]
@@ -173,76 +173,76 @@ var color = new THREE.Color( 1, 0, 0 );
 				{ h: 0, s: 0, l: 0 }
 			</code>
 
-		</div>
+		</p>
 
 		<h3>[method:String getStyle]()</h3>
-		<div>Returns the value of this color as a CSS style string. Example: 'rgb(255,0,0)'.</div>
+		<p>Returns the value of this color as a CSS style string. Example: 'rgb(255,0,0)'.</p>
 
 		<h3>[method:Color lerp]( [param:Color color], [param:Float alpha] ) </h3>
-		<div>
+		<p>
 		[page:Color color] - color to converge on.<br />
 		[page:Float alpha] - interpolation factor in the closed interval [0, 1].<br /><br />
 
 		Linearly interpolates this color's RGB values toward the RGB values of the passed argument.
 		The alpha argument can be thought of as the ratio between the two colors, where 0.0 is
 		this color and 1.0 is the first argument.
-		</div>
+		</p>
 
 		<h3>[method:Color multiply]( [param:Color color] ) </h3>
-		<div>Multiplies this color's RGB values by the given [page:Color color]'s RGB values.</div>
+		<p>Multiplies this color's RGB values by the given [page:Color color]'s RGB values.</p>
 
 		<h3>[method:Color multiplyScalar]( [param:Number s] ) </h3>
-		<div>Multiplies this color's RGB values by [page:Number s].</div>
+		<p>Multiplies this color's RGB values by [page:Number s].</p>
 
 		<h3>[method:Color offsetHSL]( [param:Float h], [param:Float s], [param:Float l] ) </h3>
-		<div>
+		<p>
 			Adds the given [page:Float h], [page:Float s], and [page:Float l] to this color's values.
 			Internally, this converts the color's [page:.r r], [page:.g g] and [page:.b b] values to HSL, adds
 			[page:Float h], [page:Float s], and [page:Float l], and then converts the color back to RGB.
-		</div>
+		</p>
 
 		<h3>[method:Color set]( [param:Color_Hex_or_String value] ) </h3>
-		<div>
+		<p>
 		[page:Color_Hex_or_String value] - Value to set this color to.<br /><br />
 
 		See the Constructor above for full details of what [page:Color_Hex_or_String value] can be.
 		Delegates to [page:.copy], [page:.setStyle], or [page:.setHex] depending on input type.
-		</div>
+		</p>
 
 		<h3>[method:Color setHex]( [param:Integer hex] ) </h3>
-		<div>
+		<p>
 		[page:Integer hex] — [link:https://en.wikipedia.org/wiki/Web_colors#Hex_triplet hexadecimal triplet] format.<br /><br />
 
 		Sets this color from a hexadecimal value.
-		</div>
+		</p>
 
 		<h3>[method:Color setHSL]( [param:Float h], [param:Float s], [param:Float l] ) </h3>
-		<div>
+		<p>
 		[page:Float h] — hue value between 0.0 and 1.0 <br />
 		[page:Float s] — saturation value between 0.0 and 1.0 <br />
 		[page:Float l] — lightness value between 0.0 and 1.0<br /><br />
 
 		Sets color from HSL values.
-		</div>
+		</p>
 
 		<h3>[method:Color setRGB]( [param:Float r], [param:Float g], [param:Float b] ) </h3>
-		<div>
+		<p>
 		[page:Float r] — Red channel value between 0.0 and 1.0.<br />
 		[page:Float g] — Green channel value between 0.0 and 1.0.<br />
 		[page:Float b] — Blue channel value between 0.0 and 1.0.<br /><br />
 
 		Sets this color from RGB values.
-		</div>
+		</p>
 
 		<h3>[method:Color setScalar]( [param:Float scalar] ) </h3>
-		<div>
+		<p>
 		[page:Float scalar] — a value between 0.0 and 1.0.<br /><br />
 
 		Sets all three color components to the value [page:Float scalar].
-		</div>
+		</p>
 
 		<h3>[method:Color setStyle]( [param:String style] ) </h3>
-		<div>
+		<p>
 		[page:String style] — color as a CSS-style string.<br /><br />
 
 		Sets this color from a CSS-style string. For example,
@@ -258,21 +258,21 @@ var color = new THREE.Color( 1, 0, 0 );
 		but the alpha-channel coordinate will be discarded.<br /><br />
 
 		Note that for X11 color names, multiple words such as Dark Orange become the string 'darkorange' (all lowercase).
-		</div>
+		</p>
 
 		<h3>[method:Color sub]( [param:Color color] ) </h3>
-		<div>
+		<p>
 		Subtracts the RGB components of the given color from the RGB components of this color.
 		If this results in a negative component, that component is set to zero.
-		</div>
+		</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] ) </h3>
-		<div>
+		<p>
 		[page:Array array] - An optional array to store the color to. <br />
 		[page:Integer offset] - An optional offset into the array.<br /><br />
 
 		Returns an array of the form [ r, g, b ].
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Cylindrical.html
+++ b/docs/api/math/Cylindrical.html
@@ -10,21 +10,21 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A point's [link:https://en.wikipedia.org/wiki/Cylindrical_coordinate_system cylindrical coordinates].
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Float radius], [param:Float theta], [param:Float y] )</h3>
-		<div>
+		<p>
 		[page:Float radius] - distance from the origin to a point in the x-z plane.
 		Default is *1.0*.<br />
 		[page:Float theta] - counterclockwise angle in the x-z plane measured in radians
 		from the positive z-axis. Default is *0*.<br />
 		[page:Float y] - height above the x-z plane. Default is *0*.
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
@@ -39,30 +39,30 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Cylindrical clone]()</h3>
-		<div>
+		<p>
 		Returns a new cylindrical with the same [page:.radius radius], [page:.theta theta]
 		and [page:.y y] properties as this one.
-		</div>
+		</p>
 
 		<h3>[method:Cylindrical copy]( [param:Cylindrical other] )</h3>
-		<div>
+		<p>
 			Copies the values of the passed Cylindrical's [page:.radius radius], [page:.theta theta]
 			and [page:.y y] properties to this cylindrical.
-		</div>
+		</p>
 
 		<h3>[method:Cylindrical set]( [param:Float radius], [param:Float phi], [param:Float theta] )</h3>
-		<div>Sets values of this cylindrical's [page:.radius radius], [page:.theta theta]
-		and [page:.y y] properties.</div>
+		<p>Sets values of this cylindrical's [page:.radius radius], [page:.theta theta]
+		and [page:.y y] properties.</p>
 
 		<h3>[method:Cylindrical setFromVector3]( [param:Vector3 vec3] )</h3>
-		<div>
+		<p>
 			Sets values of this cylindrical's [page:.radius radius], [page:.theta theta]
 			and [page:.y y] properties from the [page:Vector3 Vector3].<br /><br />
 
 			The [page:.radius radius] is set the vector's distance from the origin as measured along
 			the the x-z plane, while [page:.theta theta] is set from its direction on
 			the the x-z plane and [page:.y y] is set from the vector's y component.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Euler.html
+++ b/docs/api/math/Euler.html
@@ -10,12 +10,12 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A class representing [link:http://en.wikipedia.org/wiki/Euler_angles Euler Angles].<br /><br />
 
 			Euler angles describe a rotational transformation by rotating an object on its various
 			axes in specified amounts per axis, and a specified axis order.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -29,27 +29,27 @@
 
 
 		<h3>[name]( [param:Float x], [param:Float y], [param:Float z], [param:String order] )</h3>
-		<div>
+		<p>
 		[page:Float x] - (optional) the angle of the x axis in radians. Default is *0*.<br />
 		[page:Float y] - (optional) the angle of the y axis in radians. Default is *0*.<br />
 		[page:Float z] - (optional) the angle of the z axis in radians. Default is *0*.<br />
 		[page:String order] - (optional) a string representing the order that the rotations are applied,
 		defaults to 'XYZ' (must be upper case).<br /><br />
 
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean isEuler]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are Eulers. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 		<h3>[property:String order]</h3>
-		<div>
+		<p>
 			The order in which to apply rotations. Default is 'XYZ', which means that the object will first be
 			rotated around its X axis, then its Y axis and finally its Z axis. Other possibilities are:
 			'YZX', 'ZXY', 'XZY', 'YXZ' and 'ZYX'. These must be in upper case.<br /><br />
@@ -60,82 +60,82 @@
 			world Y-axis), then local-Z (which may be different from the world Z-axis).<br /><br />
 
 			If the order is changed, [page:.onChangeCallback onChangeCallback] will be called.
-		</div>
+		</p>
 
 		<h3>[property:Float x]</h3>
-		<div>
+		<p>
 			The current value of the x component.<br /><br />
 
 			If this is changed, [page:.onChangeCallback onChangeCallback] will be called.
-		</div>
+		</p>
 
 		<h3>[property:Float y]</h3>
-		<div>
+		<p>
 			The current value of the y component.<br /><br />
 
 			If this is changed, [page:.onChangeCallback onChangeCallback] will be called.
-		</div>
+		</p>
 
 		<h3>[property:Float z]</h3>
-		<div>
+		<p>
 			The current value of the z component.<br /><br />
 
 			If this is changed, [page:.onChangeCallback onChangeCallback] will be called.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:Euler copy]( [param:Euler euler] )</h3>
-		<div>Copies value of [page:Euler euler] to this euler.</div>
+		<p>Copies value of [page:Euler euler] to this euler.</p>
 
 		<h3>[method:Euler clone]()</h3>
-		<div>Returns a new Euler with the same parameters as this one.</div>
+		<p>Returns a new Euler with the same parameters as this one.</p>
 
 		<h3>[method:Boolean equals]( [param:Euler euler] )</h3>
-		<div>Checks for strict equality of this euler and [page:Euler euler].</div>
+		<p>Checks for strict equality of this euler and [page:Euler euler].</p>
 
 		<h3>[method:Euler fromArray]( [param:Array array] )</h3>
-		<div>
+		<p>
 		[page:Array array] of length 3 or 4. The optional 4th argument corresponds to the [page:.order order].<br /><br />
 
 		Assigns this euler's [page:.x x] angle to array[0]. <br />
 		Assigns this euler's [page:.y y] angle to array[1]. <br />
 		Assigns this euler's [page:.z z] angle to array[2]. <br />
 		Optionally assigns this euler's [page:.order order] to array[3].
-		</div>
+		</p>
 
 		<h3>[method:Euler onChange]( [param:Function onChangeCallback] )</h3>
-		<div>
+		<p>
 			[page:Function onChangeCallback] - set the value of the onChangeCallback() function.
-		</div>
+		</p>
 
 		<h3>[method:Euler onChangeCallback](  )</h3>
-		<div>
+		<p>
 			By default this is an empty function, however it can be set via [page:.onChange onChange]().<br />
 			It gets called after changing the [page:.x x], [page:.y y], [page:.z z] or [page:.order order] properties,
 			and also after calling most setter functions (see those for details).
-		</div>
+		</p>
 
 		<h3>[method:Euler reorder]( [param:String newOrder] )</h3>
-		<div>
+		<p>
 		Resets the euler angle with a new order by creating a quaternion from this euler angle
 		and then setting this euler angle with the quaternion and the new order. <br /><br />
 
 		<em>WARNING</em>: this discards revolution information.
-		</div>
+		</p>
 
 		<h3>[method:Euler set]( [param:Float x], [param:Float y], [param:Float z], [param:String order] )</h3>
-		<div>
+		<p>
 			[page:.x x] - the angle of the x axis in radians.<br />
 			[page:.y y] - the angle of the y axis in radians.<br />
 			[page:.z z] - the angle of the z axis in radians.<br />
 			[page:.order order] - (optional) a string representing the order that the rotations are applied.<br /><br />
 
 			Sets the angles of this euler transform and optionally the [page:.order order] and then call [page:.onChangeCallback onChangeCallback]().
-		</div>
+		</p>
 
 		<h3>[method:Euler setFromRotationMatrix]( [param:Matrix4 m], [param:String order], [param:Boolean update] )</h3>
-		<div>
+		<p>
 		[page:Matrix4 m] - a [page:Matrix4] of which the upper 3x3 of matrix is a pure
 		[link:https://en.wikipedia.org/wiki/Rotation_matrix rotation matrix] (i.e. unscaled).<br />
 		[page:.order order] - (optional) a string representing the order that the rotations are applied.<br />
@@ -144,10 +144,10 @@
 
 		Sets the angles of this euler transform from a pure rotation matrix based on the orientation
 		specified by order.
-		</div>
+		</p>
 
 		<h3>[method:Euler setFromQuaternion]( [param:Quaternion q], [param:String order], [param:Boolean update] )</h3>
-		<div>
+		<p>
 		[page:Quaternion q] - a normalized quaternion.<br />
 		[page:.order order] - (optional) a string representing the order that the rotations are applied.<br />
 		[page:Boolean update] - (optional) whether to call [page:.onChangeCallback onChangeCallback]() after applying
@@ -155,29 +155,29 @@
 
 		Sets the angles of this euler transform from a normalized quaternion based on the orientation
 		specified by [page:.order order].
-		</div>
+		</p>
 
 
 		<h3>[method:Euler setFromVector3]( [param:Vector3 vector], [param:String order] )</h3>
-		<div>
+		<p>
 		[page:Vector3 vector] - [page:Vector3].<br />
 		[page:.order order] - (optional) a string representing the order that the rotations are applied.<br /><br />
 
 		Set the [page:.x x], [page:.y y] and [page:.z z], and optionally update the [page:.order order]. [page:.onChangeCallback onChangeCallback]()
 		is called after these changes are made.
-		</div>
+		</p>
 
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - (optional) array to store the euler in.<br />
 		[page:Integer offset] (optional) offset in the array.<br />
 
 		Returns an array of the form [[page:.x x], [page:.y y], [page:.z z], [page:.order order ]].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 toVector3]()</h3>
-		<div>Returns the Euler's [page:.x x], [page:.y y] and [page:.z z] properties as a [page:Vector3].</div>
+		<p>Returns the Euler's [page:.x x], [page:.y y] and [page:.z z] properties as a [page:Vector3].</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/math/Frustum.html
+++ b/docs/api/math/Frustum.html
@@ -10,21 +10,21 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			[link:http://en.wikipedia.org/wiki/Frustum Frustums] are used to determine what is
 			inside the camera's field of view. They help speed up the rendering process - object which lie
 			outside a camera's frustum can safely be excluded from rendering.<br /><br />
 
 			This class is mainly intended for use internally by a renderer for calculating
 			a [page:Camera camera] or [page:LightShadow.camera shadowCamera]'s frustum.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]([param:Plane p0], [param:Plane p1], [param:Plane p2], [param:Plane p3], [param:Plane p4], [param:Plane p5])</h3>
-		<div>
+		<p>
 			[page:Plane p0] - (optional) defaults to a new [page:Plane].<br />
 			[page:Plane p1] - (optional) defaults to a new [page:Plane].<br />
 			[page:Plane p2] - (optional) defaults to a new [page:Plane].<br />
@@ -33,74 +33,74 @@
 			[page:Plane p5] - (optional) defaults to a new [page:Plane].<br /><br />
 
 			Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Array planes]</h3>
-		<div>Array of 6 [page:Plane planes].</div>
+		<p>Array of 6 [page:Plane planes].</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:Frustum clone]()</h3>
-		<div>Return a new Frustum with the same parameters as this one.</div>
+		<p>Return a new Frustum with the same parameters as this one.</p>
 
 
 		<h3>[method:Boolean containsPoint]( [param:Vector3 point] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] to test.<br /><br />
 
 		Checks to see if the frustum contains the [page:Vector3 point].
-		</div>
+		</p>
 
 		<h3>[method:Frustum copy]( [param:Frustum frustum] )</h3>
-		<div>
+		<p>
 		[page:Frustum frustum] - The frustum to copy<br /><br />
 
 		Copies the properties of the passed [page:Frustum frustum] into this one.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - [page:Box3] to check for intersection.<br /><br />
 
 	 	Return true if [page:Box3 box] intersects with this frustum.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsObject]( [param:Object3D object] )</h3>
-		<div>
+		<p>
 			Checks whether the [page:Object3D object]'s [page:Geometry.boundingSphere bounding sphere] is intersecting the Frustum.<br /><br />
 
 			Note that the object must have a [page:Geometry] or [page:BufferGeometry] so that the bounding sphere
 			can be calculated.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
-		<div>
+		<p>
 		[page:Sphere sphere] - [page:Sphere] to check for intersection.<br /><br />
 
 	 	Return true if [page:Sphere sphere] intersects with this frustum.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsSprite]( [param:Sprite sprite] )</h3>
-		<div>
+		<p>
 			Checks whether the [page:Sprite sprite] is intersecting the Frustum.<br /><br />
-		</div>
+		</p>
 
 		<h3>[method:Frustum set]( [param:Plane p0], [param:Plane p1], [param:Plane p2], [param:Plane p3], [param:Plane p4], [param:Plane p5] )</h3>
-		<div>
+		<p>
 		Sets the current frustum from the passed planes. No plane order is implicitely implied.
-		</div>
+		</p>
 
 		<h3>[method:Frustum setFromMatrix]( [param:Matrix4 matrix] )</h3>
-		<div>
+		<p>
 			[page:Matrix4 matrix] - [page:Matrix4] used to set the [page:.planes planes]<br /><br />
 
 			This is used by the [page:WebGLRenderer] to set up the Frustum from a [page:Camera Camera]'s
 			[page:Camera.projectionMatrix projectionMatrix] and [page:Camera.matrixWorldInverse matrixWorldInverse].
-		</div>
+		</p>
 
 
 

--- a/docs/api/math/Interpolant.html
+++ b/docs/api/math/Interpolant.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		Abstract base class of interpolants over parametric samples.<br /><br />
 
 		The parameter domain is one dimensional, typically the time or a path along a curve defined by the data.<br /><br />
@@ -23,7 +23,7 @@
 		where *N* is the number of positions.<br /><br />
 
 		References:	[link:http://www.oodesign.com/template-method-pattern.html http://www.oodesign.com/template-method-pattern.html]
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
@@ -32,50 +32,50 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( parameterPositions, sampleValues, sampleSize, resultBuffer )</h3>
-		<div>
+		<p>
 		parameterPositions -- array of positions<br />
 		sampleValues -- array of samples<br />
 		sampleSize -- number of samples<br />
 		resultBuffer -- buffer to store the interpolation results.<br /><br />
 
 		Note: This is not designed to be called directly.
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 
 
 		<h3>[property:null parameterPositions]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null resultBuffer]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null sampleValues]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:Object settings]</h3>
-		<div>
+		<p>
 		Optional, subclass-specific settings structure.
-		</div>
+		</p>
 
 		<h3>[property:null valueSize]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:null evaluate]( [param:Number t] )</h3>
-		<div>
+		<p>
 		Evaluate the interpolant at position *t*.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Line3.html
+++ b/docs/api/math/Line3.html
@@ -10,28 +10,28 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">A geometric line segment represented by a start and end point.</div>
+		<p class="desc">A geometric line segment represented by a start and end point.</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Vector3 start], [param:Vector3 end] )</h3>
-		<div>
+		<p>
 		[page:Vector3 start] - Start of the line segment. Default is (0, 0, 0).<br />
 		[page:Vector3 end] - End of the line segment. Default is (0, 0, 0).<br /><br />
 
 		Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Vector3 start]</h3>
-		<div>[page:Vector3] representing the start point of the line.</div>
+		<p>[page:Vector3] representing the start point of the line.</p>
 
 		<h3>[property:Vector3 end]</h3>
-		<div>[page:Vector3] representing the end point of the line.</div>
+		<p>[page:Vector3] representing the end point of the line.</p>
 
 
 
@@ -40,81 +40,81 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Line3 applyMatrix4]( [param:Matrix4 matrix] )</h3>
-		<div>Applies a matrix transform to the line segment.</div>
+		<p>Applies a matrix transform to the line segment.</p>
 
 		<h3>[method:Vector3 at]( [param:Float t], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Float t] - Use values 0-1 to return a position along the line segment. <br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns a vector at a certain position along the line. When [page:Float t] = 0, it returns the start vector,
 		and when [page:Float t] = 1 it returns the end vector.<br />
-		</div>
+		</p>
 
 		<h3>[method:Line3 clone]()</h3>
-		<div>Returns a new [page:Line3] with the same [page:.start start] and [page:.end end] vectors as this one.</div>
+		<p>Returns a new [page:Line3] with the same [page:.start start] and [page:.end end] vectors as this one.</p>
 
 		<h3>[method:Vector3 closestPointToPoint]( [param:Vector3 point], [param:Boolean clampToLine], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - return the closest point on the line to this point.<br />
 		[page:Boolean clampToLine] - whether to clamp the returned value to the line segment.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns the closets point on the line. If [page:Boolean clampToLine] is true, then the returned value will be
 		clamped to the line segment.
-		</div>
+		</p>
 
 		<h3>[method:Float closestPointToPointParameter]( [param:Vector3 point], [param:Boolean clampToLine] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - the point for which to return a point parameter. <br />
 		[page:Boolean clampToLine] - Whether to clamp the result to the range [0, 1].<br /><br />
 
 		Returns a point parameter based on the closest point as projected on the line segement.
 		If [page:Boolean clampToLine] is true, then the returned value will be between 0 and 1.
-		</div>
+		</p>
 
 		<h3>[method:Line3 copy]( [param:Line3 line] )</h3>
-		<div>Copies the passed line's [page:.start start] and [page:.end end] vectors to this line.</div>
+		<p>Copies the passed line's [page:.start start] and [page:.end end] vectors to this line.</p>
 
 		<h3>[method:Vector3 delta]( [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 			Returns the delta vector of the line segment ( [page:.end end] vector minus the [page:.start start] vector).
-		</div>
+		</p>
 
 		<h3>[method:Float distance]()</h3>
-		<div>Returns the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
-		(straight-line distance) between the line's [page:.start start] and [page:.end end] points.</div>
+		<p>Returns the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
+		(straight-line distance) between the line's [page:.start start] and [page:.end end] points.</p>
 
 		<h3>[method:Float distanceSq]()</h3>
-		<div>
+		<p>
 			Returns the square of the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
 			(straight-line distance) between the line's [page:.start start]
 			and [page:.end end] vectors.
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Line3 line] )</h3>
-		<div>
+		<p>
 		[page:Line3 line]  - [page:Line3] to compare with this one.<br /><br />
 
 		Returns true if both line's [page:.start start] and [page:.end en] points are equal.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 getCenter]( [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns the center of the line segment.
-		</div>
+		</p>
 
 		<h3>[method:Line3 set]( [param:Vector3 start], [param:Vector3 end] )</h3>
-		<div>
+		<p>
 		[page:Vector3 start] - set the [page:.start start point] of the line.<br />
 		[page:Vector3 end] - set the [page:.end end point] of the line.<br /><br />
 
 		Sets the start and end values by copying the provided vectors.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Math.html
+++ b/docs/api/math/Math.html
@@ -10,41 +10,41 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">An object with several math utility functions.</div>
+		<p class="desc">An object with several math utility functions.</p>
 
 		<h2>Functions</h2>
 
 		<h3>[method:Float clamp]( [param:Float value], [param:Float min], [param:Float max] )</h3>
-		<div>
+		<p>
 		[page:Float value] — Value to be clamped.<br />
 		[page:Float min] — Minimum value.<br />
 		[page:Float max] — Maximum value.<br /><br />
 
 		Clamps the [page:Float value] to be between [page:Float min] and [page:Float max].
-		</div>
+		</p>
 
 		<h3>[method:Float degToRad]( [param:Float degrees] )</h3>
-		<div>Converts degrees to radians.</div>
+		<p>Converts degrees to radians.</p>
 
 		<h3>[method:Integer euclideanModulo]( [param:Integer n], [param:Integer m] )</h3>
-		<div>
+		<p>
 		[page:Integer n], [page:Integer m] - Integers<br /><br />
 
 		Computes the Euclidean modulo of [page:Integer m] % [page:Integer n], that is:
 		<code>( ( n % m ) + m ) % m</code>
-		</div>
+		</p>
 
 		<h3>[method:UUID generateUUID]( )</h3>
-		<div>
+		<p>
 		Generate a [link:https://en.wikipedia.org/wiki/Universally_unique_identifier UUID]
 		(universally unique identifier).
-		</div>
+		</p>
 
 		<h3>[method:Boolean isPowerOfTwo]( [param:Number n] )</h3>
-		<div>Return *true* if [page:Number n] is a power of 2.</div>
+		<p>Return *true* if [page:Number n] is a power of 2.</p>
 
 		<h3>[method:Float lerp]( [param:Float x], [param:Float y], [param:Float t] )</h3>
-		<div>
+		<p>
 		[page:Float x] - Start point. <br />
 		[page:Float y] - End point. <br />
 		[page:Float t] - interpolation factor in the closed interval [0, 1].<br><br />
@@ -52,7 +52,7 @@
 		Returns a value [link:https://en.wikipedia.org/wiki/Linear_interpolation linearly interpolated]
 		from two known points based on the given interval - [page:Float t] = 0 will return [page:Float x]
 		and [page:Float t] = 1 will return [page:Float y].
-		</div>
+		</p>
 
 		<h3>[method:Float mapLinear](
 			[page:Float x],
@@ -60,7 +60,7 @@
 			[page:Float a2],
 			[page:Float b1],
 			[page:Float b2] )</h3>
-		<div>
+		<p>
 		[page:Float x] — Value to be mapped.<br />
 		[page:Float a1] — Minimum value for range A.<br />
 		[page:Float a2] — Maximum value for range A.<br />
@@ -68,28 +68,28 @@
 		[page:Float b2] — Maximum value for range B.<br /><br />
 
 		Linear mapping of [page:Float x] from range [[page:Float a1], [page:Float a2]] to range [[page:Float b1], [page:Float b2]].
-		</div>
+		</p>
 
 		<h3>[method:Integer ceilPowerOfTwo]( [param:Number n] )</h3>
-		<div>Returns the smallest power of 2 that is greater than or equal to [page:Number n].</div>
+		<p>Returns the smallest power of 2 that is greater than or equal to [page:Number n].</p>
 
 		<h3>[method:Integer floorPowerOfTwo]( [param:Number n] )</h3>
-		<div>Returns the largest power of 2 that is less than or equal to [page:Number n].</div>
+		<p>Returns the largest power of 2 that is less than or equal to [page:Number n].</p>
 
 		<h3>[method:Float radToDeg]( [param:Float radians] )</h3>
-		<div>Converts radians to degrees.</div>
+		<p>Converts radians to degrees.</p>
 
 		<h3>[method:Float randFloat]( [param:Float low], [param:Float high] )</h3>
-		<div>Random float in the interval [page:Float low] to [page:Float high].</div>
+		<p>Random float in the interval [page:Float low] to [page:Float high].</p>
 
 		<h3>[method:Float randFloatSpread]( [param:Float range] )</h3>
-		<div>Random float in the interval *- [page:Float range] / 2* to *[page:Float range] / 2*.</div>
+		<p>Random float in the interval *- [page:Float range] / 2* to *[page:Float range] / 2*.</p>
 
 		<h3>[method:Integer randInt]( [param:Integer low], [param:Integer high] )</h3>
-		<div>Random integer in the interval [page:Float low] to [page:Float high].</div>
+		<p>Random integer in the interval [page:Float low] to [page:Float high].</p>
 
 		<h3>[method:Float smoothstep]( [param:Float x], [param:Float min], [param:Float max] )</h3>
-		<div>
+		<p>
 		[page:Float x] - The value to evaluate based on its position between min and max. <br />
 		[page:Float min] - Any x value below min will be 0.<br />
 		[page:Float max] - Any x value above max will be 1.<br /><br />
@@ -98,17 +98,17 @@
 		but smoothed or slowed down the closer X is to the min and max.<br/><br/>
 
 		See [link:http://en.wikipedia.org/wiki/Smoothstep Smoothstep] for details.
-		</div>
+		</p>
 
 		<h3>[method:Float smootherstep]( [param:Float x], [param:Float min], [param:Float max] )</h3>
-		<div>
+		<p>
 		[page:Float x] - The value to evaluate based on its position between min and max. <br />
 		[page:Float min] - Any x value below min will be 0.<br />
 		[page:Float max] - Any x value above max will be 1.<br /><br />
 
 		Returns a value between 0-1. A [link:https://en.wikipedia.org/wiki/Smoothstep#Variations variation on smoothstep]
 		that has zero 1st and 2nd order derivatives at x=0 and x=1.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -10,9 +10,9 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A class representing a 3x3 [link:https://en.wikipedia.org/wiki/Matrix_(mathematics) matrix].
-		</div>
+		</p>
 
 		<h2>Example</h2>
 		<code>
@@ -20,7 +20,7 @@ var m = new Matrix3();
 		</code>
 
 		<h2>A Note on Row-Major and Column-Major Ordering</h2>
-		<div>
+		<p>
 			The [page:set]() method takes arguments in [link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order row-major]
 			order, while internally they are stored in the [page:.elements elements] array in column-major order.<br /><br />
 
@@ -40,72 +40,72 @@ m.elements = [ 11, 21, 31,
 		makes no difference mathematically and most people are used to thinking about matrices in row-major order,
 		the three.js documentation shows matrices in row-major order. Just bear in mind that if you are reading the source
 		code, you'll have to take the [link:https://en.wikipedia.org/wiki/Transpose transpose] of any matrices outlined here to make sense of the calculations.
-		</div>
+		</p>
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]()</h3>
-		<div>
+		<p>
 		Creates and initializes the [name] to the 3x3
 		[link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
-		</div>
+		</p>
 
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Float32Array elements]</h3>
-		<div>
+		<p>
 		A [link:https://en.wikipedia.org/wiki/Row-_and_column-major_order column-major]
 		 list of matrix values.
-		</div>
+		</p>
 
 		<h3>[property:Boolean isMatrix3]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are Matrix3s. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:Array applyToBufferAttribute]( [param:BufferAttribute attribute] )</h3>
-		<div>
+		<p>
 		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
 
 		Multiplies (applies) this matrix to every 3D vector in the [page:BufferAttribute attribute].
-		</div>
+		</p>
 
 
 		<h3>[method:Matrix3 clone]()</h3>
-		<div>Creates a new Matrix3 and with identical elements to this one.</div>
+		<p>Creates a new Matrix3 and with identical elements to this one.</p>
 
 		<h3>[method:Matrix3 copy]( [param:Matrix3 m] )</h3>
-		<div>Copies the elements of matrix [page:Matrix3 m] into this matrix.</div>
+		<p>Copies the elements of matrix [page:Matrix3 m] into this matrix.</p>
 
 		<h3>[method:Float determinant]()</h3>
-		<div>
+		<p>
 		Computes and returns the
 		[link:https://en.wikipedia.org/wiki/Determinant determinant] of this matrix.
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Matrix3 m] )</h3>
-		<div>Return true if this matrix and [page:Matrix3 m] are equal.</div>
+		<p>Return true if this matrix and [page:Matrix3 m] are equal.</p>
 
 		<h3>[method:Matrix3 fromArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - the array to read the elements from.<br />
 		[page:Integer offset] - (optional) index of first element in the array. Default is 0.<br /><br />
 
 		Sets the elements of this matrix based on an array in
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
-		</div>
+		</p>
 
 		<h3>[method:Matrix3 getInverse]( [param:Matrix3 m], [param:Boolean throwOnDegenerate] )</h3>
-		<div>
+		<p>
 		[page:Matrix3 m] - the matrix to take the inverse of.<br />
 		[page:Boolean throwOnDegenerate] - (optional) If true, throw an error if the matrix is degenerate (not invertible).<br /><br />
 
@@ -113,19 +113,19 @@ m.elements = [ 11, 21, 31,
 		using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 
 		If [page:Boolean throwOnDegenerate] is not set and the matrix is not invertible, set this to the 3x3 identity matrix.
-		</div>
+		</p>
 
 		<h3>[method:Matrix3 getNormalMatrix]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 		[page:Matrix4 m] - [page:Matrix4]<br /><br />
 
 		Sets this matrix as the upper left 3x3 of the [link:https://en.wikipedia.org/wiki/Normal_matrix normal matrix]
 		of the passed [page:Matrix4 matrix4]. The normal matrix is the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] [link:https://en.wikipedia.org/wiki/Transpose transpose]
 	  of the matrix [page:Matrix4 m].
-		</div>
+		</p>
 
 		<h3>[method:Matrix3 identity]()</h3>
-		<div>
+		<p>
 		Resets this matrix to the 3x3 identity matrix:
 		<code>
 1, 0, 0
@@ -133,16 +133,16 @@ m.elements = [ 11, 21, 31,
 0, 0, 1
 		</code>
 
-		</div>
+		</p>
 
 		<h3>[method:Matrix3 multiply]( [param:Matrix3 m] )</h3>
-		<div>Post-multiplies this matrix by [page:Matrix3 m].</div>
+		<p>Post-multiplies this matrix by [page:Matrix3 m].</p>
 
 		<h3>[method:Matrix3 multiplyMatrices]( [param:Matrix3 a], [param:Matrix3 b] )</h3>
-		<div>Sets this matrix to [page:Matrix3 a] x [page:Matrix3 b].</div>
+		<p>Sets this matrix to [page:Matrix3 a] x [page:Matrix3 b].</p>
 
 		<h3>[method:Matrix3 multiplyScalar]( [param:Float s] )</h3>
-		<div>Multiplies every component of the matrix by the scalar value *s*.</div>
+		<p>Multiplies every component of the matrix by the scalar value *s*.</p>
 
 		<h3>
 			[method:Matrix3 set](
@@ -150,7 +150,7 @@ m.elements = [ 11, 21, 31,
 			[page:Float n21], [page:Float n22], [page:Float n23],
 			[page:Float n31], [page:Float n32], [page:Float n33] )
 		</h3>
-		<div>
+		<p>
 		[page:Float n11] - value to put in row 1, col 1.<br />
 		[page:Float n12] - value to put in row 1, col 2.<br />
 		...<br />
@@ -161,20 +161,20 @@ m.elements = [ 11, 21, 31,
 		Sets the 3x3 matrix values to the given
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order row-major]
 		sequence of values.
-		</div>
+		</p>
 
 		<h3>[method:Matrix3 premultiply]( [param:Matrix3 m] )</h3>
-		<div>Pre-multiplies this matrix by [page:Matrix3 m].</div>
+		<p>Pre-multiplies this matrix by [page:Matrix3 m].</p>
 
 		<h3>[method:Matrix3 setFromMatrix4]( [param:Matrix4 m] )</h3>
-		<div>Set this matrx to the upper 3x3 matrix of the Matrix4 [page:Matrix4 m].</div>
+		<p>Set this matrx to the upper 3x3 matrix of the Matrix4 [page:Matrix4 m].</p>
 
 		<h3>
 			[method:Matrix3 setUvTransform](
 			[page:Float tx], [page:Float ty], [page:Float sx], [page:Float sy],
 			[page:Float rotation], [page:Float cx], [page:Float cy] )
 		</h3>
-		<div>
+		<p>
 		[page:Float tx] - offset x<br />
 		[page:Float ty] - offset y<br />
 		[page:Float sx] - repeat x<br />
@@ -184,27 +184,27 @@ m.elements = [ 11, 21, 31,
 		[page:Float cy] - center y of rotation<br /><br />
 
 		Sets the UV transform matrix from offset, repeat, rotation, and center.
-		</div>
+		</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - (optional) array to store the resulting vector in. If not given a new array will be created.<br />
 		[page:Integer offset] - (optional) offset in the array at which to put the result.<br /><br />
 
 		Writes the elements of this matrix to an array in
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
-		</div>
+		</p>
 
 		<h3>[method:Matrix3 transpose]()</h3>
-		<div>[link:https://en.wikipedia.org/wiki/Transpose Transposes] this matrix in place.</div>
+		<p>[link:https://en.wikipedia.org/wiki/Transpose Transposes] this matrix in place.</p>
 
 		<h3>[method:Matrix3 transposeIntoArray]( [param:Array array] )</h3>
-		<div>
+		<p>
 		[page:Array array] -  array to store the resulting vector in.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Transpose Transposes] this matrix into the supplied array,
 		and returns itself unchanged.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A class representing a 4x4 [link:https://en.wikipedia.org/wiki/Matrix_(mathematics) matrix].<br /><br />
 
 			The most common use of a 4x4 matrix in 3D computer graphics is as a
@@ -47,10 +47,10 @@
 				</li>
 			</ul>
 			Note: [page:Object3D.normalMatrix] is not a Matrix4, but a [page:Matrix3].
-		</div>
+		</p>
 
 		<h2>A Note on Row-Major and Column-Major Ordering</h2>
-		<div>
+		<p>
 			The [page:set]() method takes arguments in [link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order row-major]
 			order, while internally they are stored in the [page:.elements elements] array in column-major order.<br /><br />
 
@@ -75,7 +75,7 @@ m.elements = [ 11, 21, 31, 41,
 		makes no difference mathematically and most people are used to thinking about matrices in row-major order,
 		the three.js documentation shows matrices in row-major order. Just bear in mind that if you are reading the source
 		code, you'll have to take the [link:https://en.wikipedia.org/wiki/Transpose transpose] of any matrices outlined here to make sense of the calculations.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
@@ -83,25 +83,25 @@ m.elements = [ 11, 21, 31, 41,
 
 		<h3>[name]()</h3>
 
-		<div>
+		<p>
 			Creates and initializes the [name] to the 4x4
 			[link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
-	</div>
+	</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Float32Array elements]</h3>
-		<div>
+		<p>
 		A [link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major]
 		 list of matrix values.
-		</div>
+		</p>
 
 		<h3>[property:Boolean isMatrix4]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are Matrix4s. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 
 
@@ -109,53 +109,53 @@ m.elements = [ 11, 21, 31, 41,
 		<h2>Methods</h2>
 
 		<h3>[method:Array applyToBufferAttribute]( [param:BufferAttribute attribute] )</h3>
-		<div>
+		<p>
 		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
 
 		Multiplies (applies) this matrix to every 3D vector in the [page:BufferAttribute attribute].
-		</div>
+		</p>
 
 
 		<h3>[method:Matrix4 clone]()</h3>
-		<div>Creates a new Matrix4 with identical [page:.elements elements] to this one.</div>
+		<p>Creates a new Matrix4 with identical [page:.elements elements] to this one.</p>
 
 		<h3>[method:Matrix4 compose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
-		<div>
+		<p>
 		Sets this matrix to the transformation composed of [page:Vector3 position],
 		[page:Quaternion quaternion] and [page:Vector3 scale]. Internally this calls
 		[page:.makeRotationFromQuaternion makeRotationFromQuaternion]( [page:Quaternion quaternion] )
 		followed by [page:.scale scale]( [page:Vector3 scale] ), then finally
 		[page:.setPosition setPosition]( [page:Vector3 position] ).
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 copy]( [param:Matrix4 m] )</h3>
-		<div>Copies the [page:.elements elements] of matrix [page:Matrix4 m] into this matrix.</div>
+		<p>Copies the [page:.elements elements] of matrix [page:Matrix4 m] into this matrix.</p>
 
 		<h3>[method:Matrix4 copyPosition]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 		Copies the translation component of the supplied matrix [page:Matrix4 m] into this
 		matrix's translation component.
-		</div>
+		</p>
 
 		<h3>[method:null decompose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
-		<div>
+		<p>
 		Decomposes this matrix into it's [page:Vector3 position], [page:Quaternion quaternion] and
 		[page:Vector3 scale] components.
-		</div>
+		</p>
 
 		<h3>[method:Float determinant]()</h3>
-		<div>
+		<p>
 		Computes and returns the
 		[link:https://en.wikipedia.org/wiki/Determinant determinant] of this matrix.<br /><br />
 
 		Based on the method outlined [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm here].
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Matrix4 m] )</h3>
-		<div>Return true if this matrix and [page:Matrix4 m] are equal.</div>
+		<p>Return true if this matrix and [page:Matrix4 m] are equal.</p>
 
 		<h3>[method:Matrix4 extractBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
-		<div>
+		<p>
 		Extracts the [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] of this
 		matrix into the three axis vectors provided. If this matrix is:
 		<code>
@@ -170,25 +170,25 @@ xAxis = (a, e, i)
 yAxis = (b, f, j)
 zAxis = (c, g, k)
 		</code>
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 extractRotation]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 		Extracts the rotation component of the supplied matrix [page:Matrix4 m] into this matrix's
 		rotation component.
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 fromArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - the array to read the elements from.<br />
 		[page:Integer offset] - ( optional ) offset into the array. Default is 0.<br /><br />
 
 		Sets the elements of this matrix based on an [page:Array array] in
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 getInverse]( [param:Matrix4 m], [param:Boolean throwOnDegenerate] )</h3>
-		<div>
+		<p>
 		[page:Matrix4 m] - the matrix to take the inverse of.<br />
 		[page:Boolean throwOnDegenerate] - (optional) If true, throw an error if the matrix is degenerate (not invertible).<br /><br />
 
@@ -196,23 +196,23 @@ zAxis = (c, g, k)
 		using the method outlined [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm here].
 
 		If [page:Boolean throwOnDegenerate] is not set and the matrix is not invertible, set this to the 4x4 identity matrix.
-		</div>
+		</p>
 
 
 		<h3>[method:Float getMaxScaleOnAxis]()</h3>
-		<div>Gets the maximum scale value of the 3 axes.</div>
+		<p>Gets the maximum scale value of the 3 axes.</p>
 
 		<h3>[method:Matrix4 identity]()</h3>
-		<div>Resets this matrix to the [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].</div>
+		<p>Resets this matrix to the [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].</p>
 
 		<h3>[method:Matrix4 lookAt]( [param:Vector3 eye], [param:Vector3 center], [param:Vector3 up], )</h3>
-		<div>
+		<p>
 			Constructs a rotation matrix, looking from [page:Vector3 eye] towards [page:Vector3 center]
 			oriented by the [page:Vector3 up] vector.
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeRotationAxis]( [param:Vector3 axis], [param:Float theta] )</h3>
-		<div>
+		<p>
 		[page:Vector3 axis] — Rotation axis, should be normalized.<br />
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
@@ -220,10 +220,10 @@ zAxis = (c, g, k)
 
 		This is a somewhat controversial but mathematically sound alternative to rotating via [page:Quaternions].
 		See the discussion [link:http://www.gamedev.net/reference/articles/article1199.asp here].
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
-		<div>
+		<p>
 		Set this to the [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] matrix consisting
 		of the three provided basis vectors:
 		<code>
@@ -232,29 +232,29 @@ xAxis.y, yAxis.y, zAxis.y, 0,
 xAxis.z, yAxis.z, zAxis.z, 0,
 0,       0,       0,       1
 		</code>
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makePerspective]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
-		<div>
+		<p>
 			Creates a [link:https://en.wikipedia.org/wiki/3D_projection#Perspective_projection perspective projection] matrix.
 			This is used internally by [page:PerspectiveCamera.updateProjectionMatrix]()
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeOrthographic]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
-		<div>
+		<p>
 		Creates an [link:https://en.wikipedia.org/wiki/Orthographic_projection orthographic projection] matrix.
 		This is used internally by [page:OrthographicCamera.updateProjectionMatrix]().
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeRotationFromEuler]( [param:Euler euler] )</h3>
-		<div>
+		<p>
 		Sets the rotation component (the upper left 3x3 matrix) of this matrix to the rotation specified by the given [page:Euler Euler Angle].
 		The rest of the matrix is set to the identity. Depending on the [page:Euler.order order] of the [page:Euler euler], there are six possible outcomes.
 		See [link:https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix this page] for a complete list.
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeRotationFromQuaternion]( [param:Quaternion q] )</h3>
-		<div>
+		<p>
 		Sets the rotation component of this matrix to the rotation specified by [page:Quaternion q], as outlined
 		[link:https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion here].
 		The rest of the matrix is set to the identity. So, given [page:Quaternion q] = w + xi + yj + zk, the resulting matrix will be:
@@ -264,10 +264,10 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 2xz-2yw      2yz+2xw    1-2x²-2y²  0
 0            0          0          1
 		</code>
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeRotationX]( [param:Float theta] )</h3>
-		<div>
+		<p>
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
 		Sets this matrix as a rotational transformation around the X axis by [page:Float theta] (&theta;) radians.
@@ -278,10 +278,10 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 0 sin(&theta;) cos(&theta;)   0
 0 0      0        1
 		</code>
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeRotationY]( [param:Float theta] )</h3>
-		<div>
+		<p>
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
 		Sets this matrix as a rotational transformation around the Y axis by [page:Float theta] (&theta;) radians.
@@ -292,10 +292,10 @@ cos(&theta;)  0 sin(&theta;) 0
 -sin(&theta;) 0 cos(&theta;) 0
 0       0 0      1
 		</code>
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeRotationZ]( [param:Float theta] )</h3>
-		<div>
+		<p>
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
 		Sets this matrix as a rotational transformation around the Z axis by [page:Float theta] (&theta;) radians.
@@ -306,10 +306,10 @@ sin(&theta;) cos(&theta;)  0 0
 0      0       1 0
 0      0       0 1
 		</code>
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeScale]( [param:Float x], [param:Float y], [param:Float z] )</h3>
-		<div>
+		<p>
 			[page:Float x] - the amount to scale in the X axis.<br />
 			[page:Float y] - the amount to scale in the Y axis.<br />
 			[page:Float z] - the amount to scale in the Z axis.<br /><br />
@@ -321,10 +321,10 @@ x, 0, 0, 0,
 0, 0, z, 0,
 0, 0, 0, 1
 			</code>
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeShear]( [param:Float x], [param:Float y], [param:Float z] )</h3>
-		<div>
+		<p>
 		[page:Float x] - the amount to shear in the X axis.<br />
 		[page:Float y] - the amount to shear in the Y axis.<br />
 		[page:Float z] - the amount to shear in the Z axis.<br /><br />
@@ -336,10 +336,10 @@ x, 1, z, 0,
 x, y, 1, 0,
 0, 0, 0, 1
 </code>
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 makeTranslation]( [param:Float x], [param:Float y], [param:Float z] )</h3>
-		<div>
+		<p>
 			[page:Float x] - the amount to translate in the X axis.<br />
 			[page:Float y] - the amount to translate in the Y axis.<br />
 			[page:Float z] - the amount to translate in the Z axis.<br /><br />
@@ -351,35 +351,35 @@ x, y, 1, 0,
 0, 0, 1, z,
 0, 0, 0, 1
 		</code>
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 multiply]( [param:Matrix4 m] )</h3>
-		<div>Post-multiplies this matrix by [page:Matrix4 m].</div>
+		<p>Post-multiplies this matrix by [page:Matrix4 m].</p>
 
 		<h3>[method:Matrix4 multiplyMatrices]( [param:Matrix4 a], [param:Matrix4 b] )</h3>
-		<div>Sets this matrix to [page:Matrix4 a] x [page:Matrix4 b].</div>
+		<p>Sets this matrix to [page:Matrix4 a] x [page:Matrix4 b].</p>
 
 		<h3>[method:Matrix4 multiplyScalar]( [param:Float s] )</h3>
-		<div>Multiplies every component of the matrix by a scalar value [page:Float s].</div>
+		<p>Multiplies every component of the matrix by a scalar value [page:Float s].</p>
 
 		<h3>[method:Matrix4 premultiply]( [param:Matrix4 m] )</h3>
-		<div>Pre-multiplies this matrix by [page:Matrix4 m].</div>
+		<p>Pre-multiplies this matrix by [page:Matrix4 m].</p>
 
 		<h3>[method:Matrix4 scale]( [param:Vector3 v] )</h3>
-		<div>Multiplies the columns of this matrix by vector [page:Vector3 v].</div>
+		<p>Multiplies the columns of this matrix by vector [page:Vector3 v].</p>
 
 		<h3>[method:Matrix4 set](
 			[page:Float n11], [page:Float n12], [page:Float n13], [page:Float n14],
 			[page:Float n21], [page:Float n22], [page:Float n23], [page:Float n24],
 			[page:Float n31], [page:Float n32], [page:Float n33], [page:Float n34],
 			[page:Float n41], [page:Float n42], [page:Float n43], [page:Float n44] )</h3>
-		<div>
+		<p>
 			Set the [page:.elements elements] of this matrix to the supplied row-major values [page:Float n11],
 			[page:Float n12], ... [page:Float n44].
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 setPosition]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 			Sets the position component for this matrix from vector [page:Vector3 v], without affecting the
 			rest of the matrix - i.e. if the matrix is currently:
 <code>
@@ -395,19 +395,19 @@ e, f, g, v.y,
 i, j, k, v.z,
 m, n, o, p
 </code>
-		</div>
+		</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - (optional) array to store the resulting vector in.<br />
 		[page:Integer offset] - (optional) offset in the array at which to put the result.<br /><br />
 
 		Writes the elements of this matrix to an array in
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
-		</div>
+		</p>
 
 		<h3>[method:Matrix4 transpose]()</h3>
-		<div>[link:https://en.wikipedia.org/wiki/Transpose Transposes] this matrix.</div>
+		<p>[link:https://en.wikipedia.org/wiki/Transpose Transposes] this matrix.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Plane.html
+++ b/docs/api/math/Plane.html
@@ -10,20 +10,20 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A two dimensional surface that extends infinitely in 3d space, represented in [link:http://mathworld.wolfram.com/HessianNormalForm.html Hessian normal form]
 			by a unit length normal vector and a constant.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Vector3 normal], [param:Float constant] )</h3>
-		<div>
+		<p>
 		[page:Vector3 normal] - (optional) a unit length [page:Vector3] defining the normal of the plane. Default is *(1, 0, 0)*.<br />
 		[page:Float constant] - (optional) the signed distance from the origin to the plane. Default is *0*.
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
@@ -35,7 +35,7 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Plane applyMatrix4]( [param:Matrix4 matrix], [param:Matrix3 optionalNormalMatrix] )</h3>
-		<div>
+		<p>
 		[page:Matrix4 matrix] - the [Page:Matrix4] to apply.<br />
 		[page:Matrix3 optionalNormalMatrix] - (optional) pre-computed normal [Page:Matrix3] of the Matrix4 being applied.<br /><br />
 
@@ -44,130 +44,130 @@
 		<code>
 		var optionalNormalMatrix = new THREE.Matrix3().getNormalMatrix( matrix );
 		</code>
-		</div>
+		</p>
 
 		<h3>[method:Plane clone]()</h3>
-		<div>Returns a new plane with the same [page:.normal normal] and [page:.constant constant] as this one.</div>
+		<p>Returns a new plane with the same [page:.normal normal] and [page:.constant constant] as this one.</p>
 
 		<h3>[method:Vector3 coplanarPoint]( [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns a [page:Vector3] coplanar to the plane, by calculating the projection of the
 		normal vector at the origin onto the plane.
-		</div>
+		</p>
 
 		<h3>[method:Plane copy]( [param:Plane plane] )</h3>
-		<div>
+		<p>
 		Copies the values of the passed plane's [page:.normal normal] and [page:.constant constant]
 		properties to this plane.
-		</div>
+		</p>
 
 		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
-		<div>Returns the signed distance from the [page:Vector3 point] to the plane.</div>
+		<p>Returns the signed distance from the [page:Vector3 point] to the plane.</p>
 
 		<h3>[method:Float distanceToSphere]( [param:Sphere sphere] )</h3>
-		<div>Returns the signed distance from the [page:Sphere sphere] to the plane.</div>
+		<p>Returns the signed distance from the [page:Sphere sphere] to the plane.</p>
 
 		<h3>[method:Boolean equals]( [param:Plane plane] )</h3>
-		<div>
+		<p>
 			Checks to see if two planes are equal (their [page:.normal normal] and
 			[page:.constant constant] properties match).
-		</div>
+		</p>
 
 		<h3>[method:Vector3 intersectLine]( [param:Line3 line], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Line3 line] - the [page:Line3] to check for intersection.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns the intersection point of the passed line and the plane. Returns undefined
 		 if the line does not intersect. Returns the line's starting point if the line is
 		 coplanar with the plane.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - the [page:Box3] to check for intersection.<br /><br />
 
 		Determines whether or not this plane intersects [page:Box3 box].
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsLine]( [param:Line3 line] )</h3>
-		<div>
+		<p>
 		[page:Line3 line] - the [page:Line3] to check for intersection.<br /><br />
 
 		Tests whether a line segment intersects with (passes through) the plane.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
-		<div>
+		<p>
 		[page:Sphere sphere]  - the [page:Sphere] to check for intersection.<br /><br />
 
 		Determines whether or not this plane intersects [page:Sphere sphere].
-		</div>
+		</p>
 
 		<h3>[method:Plane negate]()</h3>
-		<div>
+		<p>
 		Negates both the normal vector and the constant.
-		</div>
+		</p>
 
 		<h3>[method:Plane normalize]()</h3>
-		<div>
+		<p>
 			Normalizes the [page:.normal normal] vector, and adjusts the [page:.constant constant]
 			value accordingly.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 projectPoint]( [param:Vector3 point], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - the [page:Vector3] to project onto the plane.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Projects a [page:Vector3 point] onto the plane.
-		</div>
+		</p>
 
 		<h3>[method:Plane set]( [param:Vector3 normal], [param:Float constant] )</h3>
-		<div>
+		<p>
 			[page:Vector3 normal] - a unit length [page:Vector3] defining the normal of the plane.<br />
 			[page:Float constant] - the signed distance from the origin to the plane. Default is *0*.<br /><br />
 
 			 Sets the plane's [page:.normal normal] and [page:.constant constant] properties.
-		</div>
+		</p>
 
 		<h3>[method:Plane setComponents]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
-		<div>
+		<p>
 		[page:Float x] - x value of the unit length normal vector.<br />
 		[page:Float y] - y value of the unit length normal vector.<br />
 		[page:Float z] - z value of the unit length normal vector.<br />
 		[page:Float w] - the value of the plane's [page:.constant constant] property.<br /><br />
 
 		Set the individual components that define the plane.
-		</div>
+		</p>
 
 		<h3>[method:Plane setFromCoplanarPoints]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c] )</h3>
-		<div>
+		<p>
 		 [page:Vector3 a] - first point on the plane.<br />
 		 [page:Vector3 b] - second point on the plane.<br />
 		 [page:Vector3 c] - third point on the plane.<br /><br />
 
 		Defines the plane based on the 3 provided points. The winding order is assumed to be counter-clockwise,
 		and determines the direction of the [page:.normal normal].
-		</div>
+		</p>
 
 		<h3>[method:Plane setFromNormalAndCoplanarPoint]( [param:Vector3 normal], [param:Vector3 point] ) [param:Vector3 this]</h3>
-		<div>
+		<p>
 		[page:Vector3 normal] - a unit length [page:Vector3] defining the normal of the plane.<br />
 		[page:Vector3 point] - [page:Vector3]<br /><br />
 
 		Sets the plane's properties as defined by a [page:Vector3 normal] and an arbitrary coplanar [page:Vector3 point].
-		</div>
+		</p>
 
 		<h3>[method:Plane translate]( [param:Vector3 offset] )</h3>
-		<div>
+		<p>
 		[page:Vector3 offset] - the amount to move the plane by.<br /><br />
 
 		Translates the plane by the distance defined by the [page:Vector3 offset] vector.
 		Note that this only affects the plane constant and will not affect the normal vector.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Quaternion.html
+++ b/docs/api/math/Quaternion.html
@@ -10,13 +10,13 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			Implementation of a [link:http://en.wikipedia.org/wiki/Quaternion quaternion].
 			This is used for [link:https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation rotating things]
 			without encountering the dreaded
 			[link:http://en.wikipedia.org/wiki/Gimbal_lock gimbal lock] issue, amongst other
 			advantages.
-		</div>
+		</p>
 
 
 		<h2>Example</h2>
@@ -34,113 +34,113 @@
 
 
 		<h3>[name]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
-		<div>
+		<p>
 		[page:Float x] - x coordinate<br />
 		[page:Float y] - y coordinate<br />
 		[page:Float z] - z coordinate<br />
 		[page:Float w] - w coordinate
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Float x]</h3>
-		<div>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</div>
+		<p>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</p>
 
 		<h3>[property:Float y]</h3>
-		<div>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</div>
+		<p>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</p>
 
 		<h3>[property:Float z]</h3>
-		<div>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</div>
+		<p>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</p>
 
 		<h3>[property:Float w]</h3>
-		<div>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</div>
+		<p>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:Quaternion clone]()</h3>
-		<div>
+		<p>
 			Creates a new Quaternion with identical [page:.x x], [page:.y y],
 			[page:.z z] and [page:.w w] properties to this one.
-		</div>
+		</p>
 
 
 		<h3>[method:Quaternion conjugate]()</h3>
-		<div>
+		<p>
 		Returns the rotational conjugate of this quaternion. The conjugate of a quaternion
 		represents the same rotation in the opposite direction about the rotational axis.
-		</div>
+		</p>
 
 		<h3>[method:Quaternion copy]( [param:Quaternion q] )</h3>
-		<div>
+		<p>
 			Copies the [page:.x x], [page:.y y],	[page:.z z] and [page:.w w] properties
 			of [page:Quaternion q] into this quaternion.
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Quaternion v] )</h3>
-		<div>
+		<p>
 		[page:Quaternion v] - Quaternion that this quaternion will be compared to.<br /><br />
 
 		Compares the [page:.x x], [page:.y y],	[page:.z z] and [page:.w w] properties of
 		[page:Quaternion v] to the equivalent properties of this quaternion to determine if they
 		represent the same rotation.
-		</div>
+		</p>
 
 		<h3>[method:Float dot]( [param:Quaternion v] )</h3>
-		<div>
+		<p>
 			Calculates the [link:https://en.wikipedia.org/wiki/Dot_product dot product] of
 			quaternions [page:Quaternion v] and this one.
-		</div>
+		</p>
 
 		<h3>[method:Quaternion fromArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - array of format (x, y, z, w) used to construct the quaternion.<br />
 		[page:Integer offset] - (optional) an offset into the array.<br /><br />
 
 		Sets this quaternion's [page:.x x], [page:.y y],	[page:.z z] and [page:.w w] properties
 		from an array.
-		</div>
+		</p>
 
 		<h3>[method:Quaternion inverse]()</h3>
-		<div>
+		<p>
 			Inverts this quaternion - calculate the [page:.conjugate conjugate] and then
 			[page:.normalize normalizes] the result.
-		</div>
+		</p>
 
 		<h3>[method:Float length]()</h3>
-		<div>Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
-		(straight-line length) of this quaternion, considered as a 4 dimensional vector.</div>
+		<p>Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
+		(straight-line length) of this quaternion, considered as a 4 dimensional vector.</p>
 
 		<h3>[method:Float lengthSq]()</h3>
-		<div>
+		<p>
 			Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
 			(straight-line length) of this quaternion, considered as a 4 dimensional
 			vector. This can be useful if you are comparing the lengths of two quaternions,
 			as this is a slightly more efficient calculation than [page:.length length]().
-		</div>
+		</p>
 
 		<h3>[method:Quaternion normalize]()</h3>
-		<div>
+		<p>
 			[link:https://en.wikipedia.org/wiki/Normalized_vector Normalizes] this quaternion - that is,
 		calculated the quaternion that performs the same rotation as this one, but has  [page:.length length]
 		equal to *1*.
-		</div>
+		</p>
 
 		<h3>[method:Quaternion multiply]( [param:Quaternion q] )</h3>
-		<div>Multiplies this quaternion by [page:Quaternion q].</div>
+		<p>Multiplies this quaternion by [page:Quaternion q].</p>
 
 		<h3>[method:Quaternion multiplyQuaternions]( [param:Quaternion a], [param:Quaternion b] )</h3>
-		<div>
+		<p>
 		Sets this quaternion to [page:Quaternion a] x [page:Quaternion b].<br />
 		Adapted from the method outlined [link:http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm here].
-		</div>
+		</p>
 
 		<h3>[method:Quaternion onChange]( [param:Function onChangeCallback] )</h3>
-		<div>Sets the [page:.onChangeCallback onChangeCallback]() method.</div>
+		<p>Sets the [page:.onChangeCallback onChangeCallback]() method.</p>
 
 		<h3>[method:Quaternion onChangeCallback]( )</h3>
-		<div>
+		<p>
 			This function is called whenever any of the following occurs:
 			<ul>
 				<li>
@@ -159,14 +159,14 @@
 				</li>
 			</ul>
 			By default it is the empty function, however you can change it if needed using [page:.onChange onChange]( [page:Function onChangeCallback] ).
-		</div>
+		</p>
 
 
 		<h3>[method:Quaternion premultiply]( [param:Quaternion q] )</h3>
-		<div>Pre-multiplies this quaternion by [page:Quaternion q].</div>
+		<p>Pre-multiplies this quaternion by [page:Quaternion q].</p>
 
 		<h3>[method:Quaternion slerp]( [param:Quaternion qb], [param:float t] )</h3>
-		<div>
+		<p>
 			[page:Quaternion qb] - The other quaternion rotation<br />
 			[page:float t] - interpolation factor in the closed interval [0, 1].<br /><br />
 
@@ -179,47 +179,47 @@
 			// rotate a mesh towards a target quaternion
 			mesh.quaternion.slerp( endQuaternion, 0.01 );
 			</code>
-		</div>
+		</p>
 
 		<h3>[method:Quaternion set]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
-		<div>Sets [page:.x x], [page:.y y], [page:.z z], [page:.w w] properties of this quaternion.</div>
+		<p>Sets [page:.x x], [page:.y y], [page:.z z], [page:.w w] properties of this quaternion.</p>
 
 		<h3>[method:Quaternion setFromAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
-		<div>
+		<p>
 		Sets this quaternion from rotation specified by [page:Vector3 axis] and [page:Float angle].<br />
 		Adapted from the method [link:http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm here].<br />
 		*Axis* is assumed to be normalized, *angle* is in radians.
-		</div>
+		</p>
 
 		<h3>[method:Quaternion setFromEuler]( [param:Euler euler] )</h3>
-		<div>Sets this quaternion from the rotation specified by [page:Euler] angle.</div>
+		<p>Sets this quaternion from the rotation specified by [page:Euler] angle.</p>
 
 		<h3>[method:Quaternion setFromRotationMatrix]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 		Sets this quaternion from rotation component of [page:Matrix4 m].<br />
 		Adapted from the method [link:http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm here].
-		</div>
+		</p>
 
 		<h3>[method:Quaternion setFromUnitVectors]( [param:Vector3 vFrom], [param:Vector3 vTo] )</h3>
-		<div>
+		<p>
 		Sets this quaternion to the rotation required to rotate direction vector [page:Vector3 vFrom] to
 		direction vector [page:Vector3 vTo].<br />
 		Adapted from the method [link:http://lolengine.net/blog/2013/09/18/beautiful-maths-quaternion-from-vectors here].<br />
 		[page:Vector3 vFrom] and [page:Vector3 vTo] are assumed to be normalized.
-		</div>
+		</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - An optional array to store the quaternion. If not specified, a new array will be created.<br/>
 		[page:Integer offset] - (optional) if specified, the result will be copied
 		into this [page:Array].<br /><br />
 
 		Returns the numerical elements of this quaternion in an array of format [x, y, z, w].
-		</div>
+		</p>
 
 		<h2>Static Methods</h2>
 
-		<div>
+		<p>
 			Static methods (as opposed to instance methods) are designed to be called directly from the class,
 			rather than from a specific instance. So to use the static version of, call it like so:
 			<code>
@@ -234,10 +234,10 @@ var q = new THREE.Quaternion();
 q.slerp( qb, t )
 			</code>
 
-		</div>
+		</p>
 
 		<h3>[method:Quaternion slerp]( [param:Quaternion qStart], [param:Quaternion qEnd], [param:Quaternion qTarget], [param:Float t] )</h3>
-		<div>
+		<p>
 			[page:Quaternion qStart] - The starting quaternion (where [page:Float t] is 0)<br />
 			[page:Quaternion qEnd] - The ending quaternion (where [page:Float t] is 1)<br />
 			[page:Quaternion qTarget] - The target quaternion that gets set with the result<br />
@@ -254,7 +254,7 @@ q.slerp( qb, t )
 			t = ( t + 0.01 ) % 1; // constant angular momentum
 			THREE.Quaternion.slerp( startQuaternion, endQuaternion, mesh.quaternion, t );
 			</code>
-		</div>
+		</p>
 
 
 		<h3>
@@ -268,7 +268,7 @@ q.slerp( qb, t )
 			[page:Float t]
 		)
 		</h3>
-		<div>
+		<p>
 		[page:Array dst] - The output array.<br />
 		[page:Integer dstOffset] - An offset into the output array.<br />
 		[page:Array src0] - The source array of the starting quaternion.<br />
@@ -276,9 +276,10 @@ q.slerp( qb, t )
 		[page:Array src1] - The source array of the target quatnerion.<br />
 		[page:Integer srcOffset1] - An offset into the array *src1*.<br />
 		[page:float t] - Normalized interpolation factor (between 0 and 1).<br /><br />
-		<div>
+		</p>
+		<p>
 		Like the static *slerp* method above, but operates directly on flat arrays of numbers.
-		</div>
+		</p>
 
 		<!-- Note: Do not add non-static methods to the bottom of this page. Put them above the <h2>Static Methods</h2> -->
 

--- a/docs/api/math/Ray.html
+++ b/docs/api/math/Ray.html
@@ -10,36 +10,36 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A ray that emits from an origin in a certain direction. This is used by the
 			[page:Raycaster] to assist with [link:https://en.wikipedia.org/wiki/Ray_casting raycasting].
 			Raycasting is used for mouse picking (working out what objects in the 3D space the mouse is over) amongst
 			other things.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
-		<div>
+		<p>
 		[page:Vector3 origin] - (optional) the origin of the [page:Ray]. Default is a [page:Vector3] at (0, 0, 0).<br />
 		[page:Vector3 direction] - [page:Vector3] The direction of the [page:Ray]. This must be normalized
 		 (with [page:Vector3.normalize]) for the methods to operate properly.  Default is a [page:Vector3] at (0, 0, 0).<br /><br />
 
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Vector3 origin]</h3>
-		<div>The origin of the [page:Ray]. Default is a [page:Vector3] at (0, 0, 0).</div>
+		<p>The origin of the [page:Ray]. Default is a [page:Vector3] at (0, 0, 0).</p>
 
 		<h3>[property:Vector3 direction]</h3>
-		<div>
+		<p>
 		The direction of the [page:Ray]. This must be normalized (with [page:Vector3.normalize])
 		for the methods to operate properly. Default is a [page:Vector3] at (0, 0, 0).
-		</div>
+		</p>
 
 
 
@@ -47,48 +47,48 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Ray applyMatrix4]( [param:Matrix4 matrix4] )</h3>
-		<div>
+		<p>
 		[page:Matrix4 matrix4] - the [page:Matrix4] to apply to this [page:Ray].<br /><br />
 
 		Transform this [page:Ray] by the [page:Matrix4].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 at]( [param:Float t], [param:Vector3 target] ) </h3>
-		<div>
+		<p>
 		[page:Float t] - the distance along the [page:Ray] to retrieve a position for.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Get a [page:Vector3] that is a given distance along this [page:Ray].
-		</div>
+		</p>
 
 		<h3>[method:Ray clone]()</h3>
-		<div>
+		<p>
 			Creates a new Ray with identical [page:.origin origin] and [page:.direction direction]  to this one.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 closestPointToPoint]( [param:Vector3 point], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - the point to get the closest approach to. <br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Get the point along this [page:Ray] that is closest to the [page:Vector3] provided.
-		</div>
+		</p>
 
 		<h3>[method:Ray copy]( [param:Ray ray] )</h3>
-		<div>
+		<p>
 			Copies the [page:.origin origin] and [page:.direction direction] properties
 			of [page:Ray ray] into this ray.
-		</div>
+		</p>
 
 		<h3>[method:Float distanceSqToPoint]( [param:Vector3 point] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - the [page:Vector3] to compute a distance to.<br /><br />
 
 		Get the squared distance of the closest approach between the [page:Ray] and the [page:Vector3].
-		</div>
+		</p>
 
 		<h3>[method:Float distanceSqToSegment]( [param:Vector3 v0], [param:Vector3 v1], [param:Vector3 optionalPointOnRay], [param:Vector3 optionalPointOnSegment] )</h3>
-		<div>
+		<p>
 		[page:Vector3 v0] - the start of the line segment.<br />
 		[page:Vector3 v1] - the end of the line segment.<br />
 		optionalPointOnRay - (optional) if this is provided, it receives the point on this
@@ -97,105 +97,105 @@
 			on the line segment that is closest to this [page:Ray].<br /><br />
 
 		Get the squared distance between this [page:Ray] and a line segment.
-		</div>
+		</p>
 
 		<h3>[method:Float distanceToPlane]( [param:Plane plane] )</h3>
-		<div>
+		<p>
 		[page:Plane plane] - the [page:Plane] to get the distance to.<br /><br />
 
 		Get the distance from [page:.origin origin] to the [page:Plane], or *null* if the [page:Ray] doesn't intersect the [page:Plane].
-		</div>
+		</p>
 
 		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] The [page:Vector3] to compute a distance to.<br /><br />
 
 		Get the distance of the closest approach between the [page:Ray] and the [page:Vector3 point].
-		</div>
+		</p>
 
 
 		<h3>[method:Boolean equals]( [param:Ray ray] )</h3>
-		<div>
+		<p>
 		[page:Ray ray] - the [page:Ray] to compare to.<br /><br />
 
 		Returns true if this and the other [page:Ray ray] have equal [page:.offset offset]
 		 and [page:.direction direction].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 intersectBox]( [param:Box3 box], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - the [page:Box3] to intersect with.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Intersect this [page:Ray] with a [page:Box3], returning the intersection point or
 		*null* if there is no intersection.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 intersectPlane]( [param:Plane plane], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Plane plane] - the [page:Plane] to intersect with.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Intersect this [page:Ray] with a [page:Plane], returning the intersection point or
 		*null* if there is no intersection.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 intersectSphere]( [param:Sphere sphere], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Sphere sphere] - the [page:Sphere] to intersect with.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Intersect this [page:Ray] with a [page:Sphere], returning the intersection point or
 		*null* if there is no intersection.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 intersectTriangle]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c], [param:Boolean backfaceCulling], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 a], [page:Vector3 b], [page:Vector3 c] - The [page:Vector3] points making up the triangle.<br />
 		[page:Boolean backfaceCulling] - whether to use backface culling.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Intersect this [page:Ray] with a triangle, returning the intersection point or *null*
 		if there is no intersection.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - the [page:Box3] to intersect with.<br /><br />
 
 		Return true if this [page:Ray] intersects with the [page:Box3].
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsPlane]( [param:Plane plane] )</h3>
-		<div>
+		<p>
 		[page:Plane plane] - the [page:Plane] to intersect with.<br /><br />
 
 		Return true if this [page:Ray] intersects with the [page:Plane].
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
-		<div>
+		<p>
 		[page:Sphere sphere] - the [page:Sphere] to intersect with.<br /><br />
 
 		Return true if this [page:Ray] intersects with the [page:Sphere].
-		</div>
+		</p>
 
 		<h3>[method:Ray lookAt]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 		[page:Vector3 v] - The [page:Vector3] to look at.<br /><br />
 
 		Adjusts the direction of the ray to point at the vector in world coordinates.
-		</div>
+		</p>
 
 		<h3>[method:Ray recast]( [param:Float t] )</h3>
-		<div>
+		<p>
 		[page:Float t] - The distance along the [page:Ray] to interpolate.<br /><br />
 
 		Shift the origin of this [page:Ray] along its direction by the distance given.
-		</div>
+		</p>
 
 		<h3>[method:Ray set]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
-		<div>
+		<p>
 		[page:Vector3 origin] - the [page:.origin origin] of the [page:Ray].<br />
 		[page:Vector3 origin] - the [page:.direction direction] of the [page:Ray].
 		This must be normalized (with [page:Vector3.normalize]) for the methods to operate
@@ -203,7 +203,7 @@
 
 		Copy the parameters to the [page:.origin origin] and [page:.direction direction] properties
 		of this ray.
-		</div>
+		</p>
 
 
 

--- a/docs/api/math/Sphere.html
+++ b/docs/api/math/Sphere.html
@@ -10,126 +10,127 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">A sphere defined by a center and radius.</div>
+		<p class="desc">A sphere defined by a center and radius.</p>
 
 		<h2>Constructor</h2>
 		<h3>[name]( [param:Vector3 center], [param:Float radius] )</h3>
-		<div>
+		<p>
 		[page:Vector3 center] - center of the sphere. Default is a [page:Vector3] at (0, 0, 0). <br />
 		[page:Float radius] - radius of the sphere. Default is 0.<br /><br />
 
 		Creates a new [name].
 
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 
 		<h3>[property:Vector3 center]</h3>
-		<div>A [page:Vector3] defining the center of the sphere. Default is (0, 0, 0).</div>
+		<p>A [page:Vector3] defining the center of the sphere. Default is (0, 0, 0).</p>
 
 		<h3>[property:Float radius]</h3>
-		<div>The radius of the sphere. Default is 0.</div>
+		<p>The radius of the sphere. Default is 0.</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:Sphere applyMatrix4]( [param:Matrix4 matrix] )</h3>
-		<div>
+		<p>
 			[page:Matrix4 matrix] - the [Page:Matrix4] to apply <br /><br />
 
 			Transforms this sphere with the provided [page:Matrix4].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 clampPoint]( [param:Vector3 point], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] The point to clamp.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Clamps a point within the sphere. If the point is is outside the sphere, it will clamp it to the
 		closets point on the edge of the sphere. Points already inside the sphere will not be affected.
-		</div>
+		</p>
 
 		<h3>[method:Sphere clone]()</h3>
-		<div>Returns a new sphere with the same [page:.center center] and [page:.radius radius] as this one.</div>
+		<p>Returns a new sphere with the same [page:.center center] and [page:.radius radius] as this one.</p>
 
 		<h3>[method:Boolean containsPoint]( [param:Vector3 point] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - the [page:Vector3] to be checked<br /><br />
 
 		Checks to see if the sphere contains the provided [page:Vector3 point] inclusive of the
 		surface of the sphere.
-		</div>
+		</p>
 
 		<h3>[method:Sphere copy]( [param:Sphere sphere] )</h3>
-		<div>
+		<p>
 		Copies the values of the passed sphere's [page:.center center] and [page:.radius radius]
 		properties to this sphere.
-		</div>
+		</p>
 
 		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
-		<div>
+		<p>
 		Returns the closest distance from the boundary of the sphere to the [page:Vector3 point]. If the sphere contains the point,
 		the distance will be negative.
-		</div>
+		</p>
 
 		<h3>[method:Boolean empty]()</h3>
-		<div>Checks to see if the sphere is empty (the radius set to 0).</div>
+		<p>Checks to see if the sphere is empty (the radius set to 0).</p>
 
 		<h3>[method:Boolean equals]( [param:Sphere sphere] )</h3>
-		<div>
+		<p>
 		Checks to see if the two spheres' centers and radii are equal.
-		</div>
+		</p>
 
 		<h3>[method:Box3 getBoundingBox]( [param:Box3 target] )</h3>
-		<div>
+		<p>
 		[page:Box3 target] — the result will be copied into this Box3.<br /><br />
 
 		Returns a[link:https://en.wikipedia.org/wiki/Minimum_bounding_box Minimum Bounding Box] for the sphere.
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - [page:Box3] to check for intersection against.<br /><br />
 
 		Determines whether or not this sphere intersects a given [page:Box3 box].
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsPlane]( [param:Plane plane] )</h3>
-		<div>
+		<p>
 		[page:Plane plane] - Plane to check for intersection against.<br /><br />
 
 		Determines whether or not this sphere intersects a given [page:Plane plane].
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>
-		<div>
+		<p>
 		[page:Sphere sphere] - Sphere to check for intersection against.<br /><br />
 
 		Checks to see if two spheres intersect.
-		</div>
+		</p>
 
 		<h3>[method:Sphere set]( [param:Vector3 center], [param:Float radius] )</h3>
-		<div>
+		<p>
 			[page:Vector3 center] - center of the sphere.<br />
 			[page:Float radius] - radius of the sphere.<br /><br />
 
 		Sets the [page:.center center] and [page:.radius radius] properties of this sphere.
-		</div>
+		</p>
 
 		<h3>[method:Sphere setFromPoints]( [param:Array points], [param:Vector3 optionalCenter] )</h3>
-		<div>
+		<p>
 		[page:Array points] - an [page:Array] of [page:Vector3] positions.<br />
 		[page:Vector3 optionalCenter] - Optional [page:Vector3] position for the sphere's center.<br /><br />
 
 		Computes the minimum bounding sphere for an array of [page:Array points]. If  [page:Vector3 optionalCenter]is given,
 		it is used as the sphere's center. Otherwise, the center of the axis-aligned bounding box encompassing
 		[page:Array points] is calculated.
-		</div>
+		</p>
 
 		<h3>[method:Sphere translate]( [param:Vector3 offset] )</h3>
+		<p>
 		Translate the sphere's center by the provided offset [page:Vector3].
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Spherical.html
+++ b/docs/api/math/Spherical.html
@@ -10,21 +10,21 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">A point's [link:https://en.wikipedia.org/wiki/Spherical_coordinate_system spherical coordinates].</div>
+		<p class="desc">A point's [link:https://en.wikipedia.org/wiki/Spherical_coordinate_system spherical coordinates].</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Float radius], [param:Float phi], [param:Float theta] )</h3>
-		<div>
+		<p>
 		[page:Float radius] - the radius, or the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
 		(straight-line distance) from the point to the origin. Default is *1.0*.<br />
 		[page:Float phi] - polar angle from the y (up) axis. Default is *0*.<br />
 		[page:Float theta] - equator angle around the y (up) axis. Default is *0*.<br /><br />
 
 		The poles (phi) are at the positive and negative y axis. The equator (theta) starts at positive z.
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
@@ -39,34 +39,34 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Spherical clone]()</h3>
-		<div>
+		<p>
 		Returns a new plane with the same [page:.radius radius], [page:.phi phi]
 		and [page:.theta theta] properties as this one.
-		</div>
+		</p>
 
 		<h3>[method:Spherical copy]( [param:Spherical s] )</h3>
-		<div>
+		<p>
 			Copies the values of the passed Spherical's [page:.radius radius], [page:.phi phi]
 			and [page:.theta theta] properties to this spherical.
-		</div>
+		</p>
 
 		<h3>[method:Spherical makeSafe]()</h3>
-		<div>
+		<p>
 		Restricts the polar angle [page:.phi phi] to be between 0.000001 and pi - 0.000001.
-		</div>
+		</p>
 
 		<h3>[method:Spherical set]( [param:Float radius], [param:Float phi], [param:Float theta] )</h3>
-		<div>Sets values of this spherical's [page:.radius radius], [page:.phi phi]
-		and [page:.theta theta] properties.</div>
+		<p>Sets values of this spherical's [page:.radius radius], [page:.phi phi]
+		and [page:.theta theta] properties.</p>
 
 		<h3>[method:Spherical setFromVector3]( [param:Vector3 vec3] )</h3>
-		<div>
+		<p>
 			Sets values of this spherical's [page:.radius radius], [page:.phi phi]
 			and [page:.theta theta] properties from the [page:Vector3 Vector3].<br /><br />
 
 			The [page:.radius radius] is set the vector's [page:Vector3.length], while the
 			[page:.phi phi] and [page:.theta theta] properties are set from its direction.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Triangle.html
+++ b/docs/api/math/Triangle.html
@@ -10,80 +10,80 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A geometric triangle as defined by three [page:Vector3 Vector3s] representing its
 			three corners.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c] )</h3>
-		<div>
+		<p>
 		[page:Vector3 a] - the first corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).<br />
 		[page:Vector3 b] - the second corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).<br />
 		[page:Vector3 c] - the final corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).<br /><br />
 
 		Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Vector3 a]</h3>
-		<div>
+		<p>
 			The first corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).
-		</div>
+		</p>
 
 		<h3>[property:Vector3 b]</h3>
-		<div>
+		<p>
 			The second corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).
-		</div>
+		</p>
 
 		<h3>[property:Vector3 c]</h3>
-		<div>
+		<p>
 		the final corner of the triangle. Default is a [page:Vector3] at (0, 0, 0)
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:Triangle clone]()</h3>
-		<div>
+		<p>
 			Returns a new triangle with the same [page:.a a], [page:.b b] and  [page:.c c] properties as this one.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 closestPointToPoint]( [param:Vector3 point], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] <br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Returns the closest point on the triangle to [page:Vector3 point].
-		</div>
+		</p>
 
 		<h3>[method:Boolean containsPoint]( [param:Vector3 point] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] to check.<br /><br />
 
 		Returns true if the passed point, when projected onto the plane of the triangle, lies within the triangle.
-		</div>
+		</p>
 
 		<h3>[method:Triangle copy]( [param:Triangle triangle] )</h3>
-		<div>
+		<p>
 			Copies the values of the passed triangles's [page:.a a], [page:.b b] and [page:.c c]
 			properties to this triangle.
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Triangle triangle] )</h3>
-		<div>
+		<p>
 		Returns true if the two triangles have identical [page:.a a], [page:.b b] and [page:.c c] properties.
-		</div>
+		</p>
 
 		<h3>[method:Float getArea]()</h3>
-		<div>Return the area of the triangle.</div>
+		<p>Return the area of the triangle.</p>
 
 		<h3>[method:Vector3 getBarycoord]( [param:Vector3 point], [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 point] - [page:Vector3] <br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
@@ -91,50 +91,50 @@
 		 from the given vector. <br/><br/>
 
 		[link:http://commons.wikimedia.org/wiki/File:Barycentric_coordinates_1.png Picture of barycentric coordinates]
-		</div>
+		</p>
 
 		<h3>[method:Vector3 getMidpoint]( [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Calculate the midpoint of the triangle.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 getNormal]( [param:Vector3 target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Calculate the [link:https://en.wikipedia.org/wiki/Normal_(geometry) normal vector] of the triangle.
-		</div>
+		</p>
 
 		<h3>[method:Plane getPlane]( [param:Plane target] )</h3>
-		<div>
+		<p>
 		[page:Vector3 target] — the result will be copied into this Plane.<br /><br />
 
 		Calculate a [page:Plane plane] based on the triangle. .
-		</div>
+		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
-		<div>
+		<p>
 		[page:Box3 box] - Box to check for intersection against.<br /><br />
 
 		Determines whether or not this triangle intersects [page:Box3 box].
-		</div>
+		</p>
 
 		<h3>[method:Triangle set]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c] ) [param:Triangle this]</h3>
-		<div>
+		<p>
 		Sets the triangle's [page:.a a], [page:.b b] and [page:.c c] properties to the passed [page:vector3 vector3s].
-		</div>
+		</p>
 
 		<h3>[method:Triangle setFromPointsAndIndices]( [param:Array points], [param:Integer i0], [param:Integer i1], [param:Integer i2] ) [param:Triangle this]</h3>
-		<div>
+		<p>
 		points - [page:Array] of [page:Vector3]s <br />
 		i0 - [page:Integer] index <br />
 		i1 - [page:Integer] index <br />
 		i2 - [page:Integer] index<br /><br />
 
 		Sets the triangle's vectors to the vectors in the array.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Vector2.html
+++ b/docs/api/math/Vector2.html
@@ -10,30 +10,32 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			Class representing a 2D [link:https://en.wikipedia.org/wiki/Vector_space vector].
 
 			A 2D vector is an ordered pair of numbers (labeled x and y), which can be used to
 			represent a number of things, such as:
+		</p>
 
-			<ul>
-				<li>
-					A point in 2D space (i.e. a position on a plane).
-				</li>
-				<li>
-					A direction and length across a plane. In three.js the length will always be the
-					[link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
-					(straight-line distance) from (0, 0) to (x, y) and the direction is also
-					measured from (0, 0) towards (x, y).
-				</li>
-				<li>
-					Any arbitrary ordered pair of numbers.
-				</li>
-			</ul>
+		<ul>
+			<li>
+				A point in 2D space (i.e. a position on a plane).
+			</li>
+			<li>
+				A direction and length across a plane. In three.js the length will always be the
+				[link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
+				(straight-line distance) from (0, 0) to (x, y) and the direction is also
+				measured from (0, 0) towards (x, y).
+			</li>
+			<li>
+				Any arbitrary ordered pair of numbers.
+			</li>
+		</ul>
 
+		<p>
 			There are other things a 2D vector can be used to represent, such as momentum
 			vectors, complex numbers and so on,	however these are the most common uses in three.js.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -50,28 +52,28 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Float x], [param:Float y] )</h3>
-		<div>
+		<p>
 		[page:Float x] - the x value of the vector. Default is *0*.<br />
 		[page:Float y] -  the y value of the vector. Default is *0*.<br /><br />
 
 		Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean isVector2]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are Vector2s. Default is *true*.<br /><br />
 
 			You should not change this, as it is used internally for optimisation.
-		</div>
+		</p>
 
 		<h3>[property:Float height]</h3>
-		<div>Alias for [page:.y y].</div>
+		<p>Alias for [page:.y y].</p>
 
 		<h3>[property:Float width]</h3>
-		<div>Alias for [page:.x x].</div>
+		<p>Alias for [page:.x x].</p>
 
 		<h3>[property:Float x]</h3>
 
@@ -81,157 +83,157 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Vector2 add]( [param:Vector2 v] )</h3>
-		<div>Adds [page:Vector2 v] to this vector.</div>
+		<p>Adds [page:Vector2 v] to this vector.</p>
 
 		<h3>[method:Vector2 addScalar]( [param:Float s] )</h3>
-		<div>Adds the scalar value [page:Float s] to this vector's [page:.x x] and [page:.y y] values.</div>
+		<p>Adds the scalar value [page:Float s] to this vector's [page:.x x] and [page:.y y] values.</p>
 
 		<h3>[method:Vector2 addScaledVector]( [param:Vector2 v], [param:Float s] )</h3>
-		<div>Adds the multiple of [page:Vector2 v] and [page:Float s] to this vector.</div>
+		<p>Adds the multiple of [page:Vector2 v] and [page:Float s] to this vector.</p>
 
 		<h3>[method:Vector2 addVectors]( [param:Vector2 a], [param:Vector2 b] )</h3>
-		<div>Sets this vector to [page:Vector2 a] + [page:Vector2 b].</div>
+		<p>Sets this vector to [page:Vector2 a] + [page:Vector2 b].</p>
 
 		<h3>[method:Float angle]()</h3>
-		<div>
+		<p>
 		Computes the angle in radians of this vector with respect to the positive x-axis.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 applyMatrix3]( [param:Matrix3 m] )</h3>
-		<div>
+		<p>
 		Multiplies this vector (with an implicit 1 as the 3rd component) by m.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 ceil]()</h3>
-		<div>
+		<p>
 		The [page:.x x] and [page:.y y] components of the vector are rounded up to the nearest integer value.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 clamp]( [param:Vector2 min], [param:Vector2 max] )</h3>
-		<div>
+		<p>
 		[page:Vector2 min] - the minimum x and y values.<br />
 		[page:Vector2 max] - the maximum x and y values in the desired range<br /><br />
 
 		If this vector's x or y value is greater than the max vector's x or y value, it is replaced by the corresponding value. <br /><br />
 		If this vector's x or y value is less than the min vector's x or y value, it is replaced by the corresponding value.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 clampLength]( [param:Float min], [param:Float max] )</h3>
-		<div>
+		<p>
 		[page:Float min] - the minimum value the length will be clamped to <br />
 		[page:Float max] - the maximum value the length will be clamped to<br /><br />
 
 		If this vector's length is greater than the max value, it is replaced by the max value. <br /><br />
 		If this vector's length is less than the min value, it is replaced by the min value.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 clampScalar]( [param:Float min], [param:Float max] )</h3>
-		<div>
+		<p>
 		[page:Float min] - the minimum value the components will be clamped to <br />
 		[page:Float max] - the maximum value the components will be clamped to<br /><br />
 
 		If this vector's x or y values are greater than the max value, they are replaced by the max value. <br /><br />
 		If this vector's x or y values are less than the min value, they are replaced by the min value.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 clone]()</h3>
-		<div>
+		<p>
 		Returns a new Vector2 with the same [page:.x x] and [page:.y y] values as this one.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 copy]( [param:Vector2 v] )</h3>
-		<div>
+		<p>
 			Copies the values of the passed Vector2's [page:.x x] and [page:.y y]
 			properties to this Vector2.
-		</div>
+		</p>
 
 		<h3>[method:Float distanceTo]( [param:Vector2 v] )</h3>
-		<div>Computes the distance from this vector to [page:Vector2 v].</div>
+		<p>Computes the distance from this vector to [page:Vector2 v].</p>
 
 		<h3>[method:Float manhattanDistanceTo]( [param:Vector2 v] )</h3>
-		<div>
+		<p>
 		Computes the [link:https://en.wikipedia.org/wiki/Taxicab_geometry Manhattan distance] from this vector to [page:Vector2 v].
-		</div>
+		</p>
 
 		<h3>[method:Float distanceToSquared]( [param:Vector2 v] )</h3>
-		<div>
+		<p>
 		Computes the squared distance from this vector to [page:Vector2 v]. If you are just
 		comparing the distance with another distance, you should compare the distance squared instead
 		as it is slightly more efficient to calculate.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 divide]( [param:Vector2 v] )</h3>
-		<div>Divides this vector by [page:Vector2 v].</div>
+		<p>Divides this vector by [page:Vector2 v].</p>
 
 		<h3>[method:Vector2 divideScalar]( [param:Float s] )</h3>
-		<div>
+		<p>
 		Divides this vector by scalar [page:Float s].<br />
 		Sets vector to *( 0, 0 )* if [page:Float s] = 0.
-		</div>
+		</p>
 
 		<h3>[method:Float dot]( [param:Vector2 v] )</h3>
-		<div>
+		<p>
 		Calculates the [link:https://en.wikipedia.org/wiki/Dot_product dot product] of this
 	  vector and [page:Vector2 v].
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Vector2 v] )</h3>
-		<div>Checks for strict equality of this vector and [page:Vector2 v].</div>
+		<p>Checks for strict equality of this vector and [page:Vector2 v].</p>
 
 		<h3>[method:Vector2 floor]()</h3>
-		<div>The components of the vector are rounded down to the nearest integer value.</div>
+		<p>The components of the vector are rounded down to the nearest integer value.</p>
 
 		<h3>[method:Vector2 fromArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - (optional) offset into the array. Default is 0.<br /><br />
 
 		Sets this vector's [page:.x x] value to be array[ offset ] and [page:.y y] value to be array[ offset + 1 ].
-		</div>
+		</p>
 
 		<h3>[method:Vector2 fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
-		<div>
+		<p>
 		[page:BufferAttribute attribute] - the source attribute.<br />
 		[page:Integer index] - index in the attribute.<br /><br />
 
 		Sets this vector's [page:.x x] and [page:.y y] values from the [page:BufferAttribute attribute].
-		</div>
+		</p>
 
 		<h3>[method:Float getComponent]( [param:Integer index] )</h3>
-		<div>
+		<p>
 		[page:Integer index] - 0 or 1.<br /><br />
 
 		If index equals 0 returns the [page:.x x] value. <br />
 		If index equals 1 returns the [page:.y y] value.
-		</div>
+		</p>
 
 		<h3>[method:Float length]()</h3>
-		<div>Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
-		(straight-line length) from (0, 0) to (x, y).</div>
+		<p>Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
+		(straight-line length) from (0, 0) to (x, y).</p>
 
 		<h3>[method:Float manhattanLength]()</h3>
-		<div>
+		<p>
 		Computes the [link:http://en.wikipedia.org/wiki/Taxicab_geometry Manhattan length] of this vector.
-		</div>
+		</p>
 
 		<h3>[method:Float lengthSq]()</h3>
-		<div>
+		<p>
 		Computes the square of the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
 		(straight-line length) from (0, 0) to (x, y). If you are 	comparing the lengths of
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 lerp]( [param:Vector2 v], [param:Float alpha] )</h3>
-		<div>
+		<p>
 		[page:Vector2 v] - [page:Vector2] to interpolate towards.<br />
 		alpha - interpolation factor in the closed interval [0, 1].<br /><br />
 
 		Linearly interpolates between this vector and [page:Vector2 v], where alpha is the
 		distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector2 v].
-		</div>
+		</p>
 
 		<h3>[method:Vector2 lerpVectors]( [param:Vector2 v1], [param:Vector2 v2], [param:Float alpha] )</h3>
-		<div>
+		<p>
 		[page:Vector2 v1] - the starting [page:Vector2].<br />
 		[page:Vector2 v2] - [page:Vector2] to interpolate towards.<br />
 		[page:Float alpha] - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -239,97 +241,97 @@
 		Sets this vector to be the vector linearly interpolated between [page:Vector2 v1] and
 		[page:Vector2 v2] where alpha is the distance along the line connecting the two vectors
 		- alpha = 0 will be [page:Vector2 v1], and alpha = 1 will be [page:Vector2 v2].
-		</div>
+		</p>
 
 		<h3>[method:Vector2 negate]()</h3>
-		<div>Inverts this vector - i.e. sets x = -x and y = -y.</div>
+		<p>Inverts this vector - i.e. sets x = -x and y = -y.</p>
 
 		<h3>[method:Vector2 normalize]()</h3>
-		<div>
+		<p>
 		Converts this vector to a [link:https://en.wikipedia.org/wiki/Unit_vector unit vector] - that is, sets it equal to the vector with the same direction
 		as this one, but [page:.length length] 1.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 max]( [param:Vector2 v] )</h3>
-		<div>
+		<p>
 		If this vector's x or y value is less than [page:Vector2 v]'s x or y value, replace
 		that value with the corresponding max value.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 min]( [param:Vector2 v] )</h3>
-		<div>
+		<p>
 		If this vector's x or y value is greater than [page:Vector2 v]'s x or y value, replace
 		that value with the corresponding min value.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 multiply]( [param:Vector2 v] )</h3>
-		<div>Multiplies this vector by [page:Vector2 v].</div>
+		<p>Multiplies this vector by [page:Vector2 v].</p>
 
 
 		<h3>[method:Vector2 multiplyScalar]( [param:Float s] )</h3>
-		<div>Multiplies this vector by scalar [page:Float s].</div>
+		<p>Multiplies this vector by scalar [page:Float s].</p>
 
 		<h3>[method:Vector2 rotateAround]( [param:Vector2 center], [param:float angle] )</h3>
-		<div>
+		<p>
 			[page:Vector2 center] - the point around which to rotate.<br />
 			[page:float angle] - the angle to rotate, in radians.<br /><br />
 
 			Rotates the vector around [page:Vector2 center] by [page:float angle] radians.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 round]()</h3>
-		<div>The components of the vector are rounded to the nearest integer value.</div>
+		<p>The components of the vector are rounded to the nearest integer value.</p>
 
 		<h3>[method:Vector2 roundToZero]()</h3>
-		<div>
+		<p>
 		The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.
-		</div>
+		</p>
 
 		<h3>[method:Vector2 set]( [param:Float x], [param:Float y] )</h3>
-		<div>Sets the [page:.x x] and [page:.y y] components of this vector.</div>
+		<p>Sets the [page:.x x] and [page:.y y] components of this vector.</p>
 
 		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
-		<div>
+		<p>
 		[page:Integer index] - 0 or 1.<br />
 		[page:Float value] - [page:Float]<br /><br />
 
 		If index equals 0 set [page:.x x] to [page:Float value]. <br />
 		If index equals 1 set [page:.y y] to [page:Float value]
-		</div>
+		</p>
 
 		<h3>[method:Vector2 setLength]( [param:Float l] )</h3>
-		<div>
+		<p>
 		Sets this vector to the vector with the same direction as this one, but [page:.length length]
 		[page:Float l].
-		</div>
+		</p>
 
 		<h3>[method:Vector2 setScalar]( [param:Float scalar] )</h3>
-		<div>
+		<p>
 		Sets the [page:.x x] and [page:.y y] values of this vector both equal to [page:Float scalar].
-		</div>
+		</p>
 
 		<h3>[method:Vector2 setX]( [param:Float x] )</h3>
-		<div>Replaces this vector's [page:.x x] value with [page:Float x].</div>
+		<p>Replaces this vector's [page:.x x] value with [page:Float x].</p>
 
 		<h3>[method:Vector2 setY]( [param:Float y] )</h3>
-		<div>Replaces this vector's [page:.y y] value with [page:Float y].</div>
+		<p>Replaces this vector's [page:.y y] value with [page:Float y].</p>
 
 		<h3>[method:Vector2 sub]( [param:Vector2 v] )</h3>
-		<div>Subtracts [page:Vector2 v] from this vector.</div>
+		<p>Subtracts [page:Vector2 v] from this vector.</p>
 
 		<h3>[method:Vector2 subScalar]( [param:Float s] )</h3>
-		<div>Subtracts [page:Float s]  from this vector's [page:.x x] and [page:.y y] components.</div>
+		<p>Subtracts [page:Float s]  from this vector's [page:.x x] and [page:.y y] components.</p>
 
 		<h3>[method:Vector2 subVectors]( [param:Vector2 a], [param:Vector2 b] )</h3>
-		<div>Sets this vector to [page:Vector2 a] - [page:Vector2 b].</div>
+		<p>Sets this vector to [page:Vector2 a] - [page:Vector2 b].</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - (optional) array to store the vector to. If this is not provided, a new array will be created.<br />
 		[page:Integer offset] - (optional) optional offset into the array.<br /><br />
 
 		Returns an array [x, y], or copies x and y into the provided [page:Array array].
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/Vector3.html
+++ b/docs/api/math/Vector3.html
@@ -10,10 +10,11 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">Class representing a 3D [link:https://en.wikipedia.org/wiki/Vector_space vector].
+		<p class="desc">Class representing a 3D [link:https://en.wikipedia.org/wiki/Vector_space vector].
 
 		A 3D vector is an ordered triplet of numbers (labeled x, y, and z), which can be used to
 		represent a number of things, such as:
+		</p>
 
 		<ul>
 			<li>
@@ -30,9 +31,10 @@
 			</li>
 		</ul>
 
+		<p>
 		There are other things a 3D vector can be used to represent, such as momentum
 		vectors and so on, however these are the most common uses in three.js.
-		</div>
+		</p>
 
 
 		<h2>Example</h2>
@@ -50,23 +52,23 @@ var d = a.distanceTo( b );
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Float x], [param:Float y], [param:Float z] )</h3>
-		<div>
+		<p>
 		[page:Float x] - the x value of the vector. Default is *0*.<br />
 		[page:Float y] -  the y value of the vector. Default is *0*.<br />
 		[page:Float z] - the z value of the vector. Default is *0*.<br /><br />
 
 		Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean isVector3]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are Vector3s. Default is *true*.<br /><br />
 
 			You should not change this, as it is used internally for optimisation.
-		</div>
+		</p>
 
 		<h3>[property:Float x]</h3>
 
@@ -78,192 +80,192 @@ var d = a.distanceTo( b );
 		<h2>Methods</h2>
 
 		<h3>[method:Vector3 add]( [param:Vector3 v] )</h3>
-		<div>Adds [page:Vector3 v] to this vector.</div>
+		<p>Adds [page:Vector3 v] to this vector.</p>
 
 		<h3>[method:Vector3 addScalar]( [param:Float s] )</h3>
-		<div>Adds the scalar value s to this vector's [page:.x x], [page:.y y] and [page:.z z] values.</div>
+		<p>Adds the scalar value s to this vector's [page:.x x], [page:.y y] and [page:.z z] values.</p>
 
 		<h3>[method:Vector3 addScaledVector]( [param:Vector3 v], [param:Float s] )</h3>
-		<div>Adds the multiple of [page:Vector3 v] and [page:Float s] to this vector.</div>
+		<p>Adds the multiple of [page:Vector3 v] and [page:Float s] to this vector.</p>
 
 		<h3>[method:Vector3 addVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
-		<div>Sets this vector to [page:Vector3 a] + [page:Vector3 b].</div>
+		<p>Sets this vector to [page:Vector3 a] + [page:Vector3 b].</p>
 
 		<h3>[method:Vector3 applyAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
-		<div>
+		<p>
 		[page:Vector3 axis] - A normalized [page:Vector3].<br />
 		[page:Float angle] - An angle in radians.<br /><br />
 
 		Applies a rotation specified by an axis and an angle to this vector.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 applyEuler]( [param:Euler euler] )</h3>
-		<div>
+		<p>
 		Applies euler transform to this vector by converting the [page:Euler] object to a
 		[page:Quaternion] and applying.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 applyMatrix3]( [param:Matrix3 m] )</h3>
-		<div>Multiplies this vector by [page:Matrix3 m]</div>
+		<p>Multiplies this vector by [page:Matrix3 m]</p>
 
 		<h3>[method:Vector3 applyMatrix4]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 		Multiplies this vector (with an implicit 1 in the 4th dimension) and m, and divides by perspective.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 applyQuaternion]( [param:Quaternion quaternion] )</h3>
-		<div>
+		<p>
 		Applies a [page:Quaternion] transform to this vector.
-		</div>
+		</p>
 
 
 		<h3>[method:Float angleTo]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 		Returns the angle between this vector and vector [page:Vector3 v] in radians.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 ceil]()</h3>
-		<div>
+		<p>
 		The [page:.x x], [page:.y y] and [page:.z z] components of the vector are rounded up to the nearest integer value.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 clamp]( [param:Vector3 min], [param:Vector3 max] )</h3>
-		<div>
+		<p>
 		[page:Vector3 min] - the minimum [page:.x x], [page:.y y] and [page:.z z] values.<br />
 		[page:Vector3 max] - the maximum [page:.x x], [page:.y y] and [page:.z z] values in the desired range<br /><br />
 
 		If this vector's x, y or z value is greater than the max vector's x, y or z value, it is replaced by the corresponding value. <br /><br />
 		If this vector's x, y or z value is less than the min vector's x, y or z value, it is replaced by the corresponding value.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 clampLength]( [param:Float min], [param:Float max] )</h3>
-		<div>
+		<p>
 		[page:Float min] - the minimum value the length will be clamped to <br />
 		[page:Float max] - the maximum value the length will be clamped to<br /><br />
 
 		If this vector's length is greater than the max value, it is replaced by the max value. <br /><br />
 		If this vector's length is less than the min value, it is replaced by the min value.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 clampScalar]( [param:Float min], [param:Float max] )</h3>
-		<div>
+		<p>
 		[page:Float min] - the minimum value the components will be clamped to <br />
 		[page:Float max] - the maximum value the components will be clamped to<br /><br />
 
 		If this vector's x, y or z values are greater than the max value, they are replaced by the max value. <br /><br />
 		If this vector's x, y or z values are less than the min value, they are replaced by the min value.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 clone]()</h3>
-		<div>
+		<p>
 		Returns a new vector3 with the same [page:.x x], [page:.y y] and [page:.z z] values as this one.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 copy]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 			Copies the values of the passed vector3's [page:.x x], [page:.y y] and [page:.z z]
 			properties to this vector3.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 cross]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 		Sets this vector to [link:https://en.wikipedia.org/wiki/Cross_product cross product] of itself and [page:Vector3 v].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 crossVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
-		<div>
+		<p>
 		Sets this vector to [link:https://en.wikipedia.org/wiki/Cross_product cross product] of [page:Vector3 a] and [page:Vector3 b].
-		</div>
+		</p>
 
 		<h3>[method:Float distanceTo]( [param:Vector3 v] )</h3>
-		<div>Computes the distance from this vector to [page:Vector3 v].</div>
+		<p>Computes the distance from this vector to [page:Vector3 v].</p>
 
 		<h3>[method:Float manhattanDistanceTo]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 		Computes the [link:https://en.wikipedia.org/wiki/Taxicab_geometry Manhattan distance] from this vector to [page:Vector3 v].
-		</div>
+		</p>
 
 		<h3>[method:Float distanceToSquared]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 		Computes the squared distance from this vector to [page:Vector3 v]. If you are just
 		comparing the distance with another distance, you should compare the distance squared instead
 		as it is slightly more efficient to calculate.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 divide]( [param:Vector3 v] )</h3>
-		<div>Divides this vector by [page:Vector3 v].</div>
+		<p>Divides this vector by [page:Vector3 v].</p>
 
 		<h3>[method:Vector3 divideScalar]( [param:Float s] )</h3>
-		<div>
+		<p>
 		Divides this vector by scalar [page:Float s].<br />
 		Sets vector to *( 0, 0, 0 )* if *[page:Float s] = 0*.
-		</div>
+		</p>
 
 		<h3>[method:Float dot]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 		Calculate the [link:https://en.wikipedia.org/wiki/Dot_product dot product] of this
 		vector and [page:Vector3 v].
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Vector3 v] )</h3>
-		<div>Checks for strict equality of this vector and [page:Vector3 v].</div>
+		<p>Checks for strict equality of this vector and [page:Vector3 v].</p>
 
 		<h3>[method:Vector3 floor]()</h3>
-		<div>The components of the vector are rounded down to the nearest integer value.</div>
+		<p>The components of the vector are rounded down to the nearest integer value.</p>
 
 		<h3>[method:Vector3 fromArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - ( optional) offset into the array. Default is 0.<br /><br />
 
 		Sets this vector's [page:.x x] value to be array[ offset + 0 ], [page:.y y] value to be array[ offset + 1 ]
 		and [page:.z z] value to be array[ offset + 2 ].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
-		<div>
+		<p>
 		[page:BufferAttribute attribute] - the source attribute.<br />
 		[page:Integer index] - index in the attribute.<br /><br />
 
 		Sets this vector's [page:.x x], [page:.y y] and [page:.z z] values from the [page:BufferAttribute attribute].
-		</div>
+		</p>
 
 		<h3>[method:Float getComponent]( [param:Integer index] )</h3>
-		<div>
+		<p>
 		[page:Integer index] - 0, 1 or 2.<br /><br />
 
 		If index equals 0 returns the [page:.x x] value. <br />
 		If index equals 1 returns the [page:.y y] value. <br />
 		If index equals 2 returns the [page:.z z] value.
-		</div>
+		</p>
 
 		<h3>[method:Float length]()</h3>
-		<div>Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
-		(straight-line length) from (0, 0, 0) to (x, y, z).</div>
+		<p>Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
+		(straight-line length) from (0, 0, 0) to (x, y, z).</p>
 
 		<h3>[method:Float manhattanLength]()</h3>
-		<div>
+		<p>
 		Computes the [link:http://en.wikipedia.org/wiki/Taxicab_geometry Manhattan length] of this vector.
-		</div>
+		</p>
 
 		<h3>[method:Float lengthSq]()</h3>
-		<div>
+		<p>
 		Computes the square of the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
 		(straight-line length) from (0, 0, 0) to (x, y, z). If you are 	comparing the lengths of
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 lerp]( [param:Vector3 v], [param:Float alpha] )</h3>
-		<div>
+		<p>
 		[page:Vector3 v] - [page:Vector3] to interpolate towards.<br />
 		alpha - interpolation factor in the closed interval [0, 1].<br /><br />
 
 		Linearly interpolate between this vector and [page:Vector3 v], where alpha is the
 		distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector3 v].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 lerpVectors]( [param:Vector3 v1], [param:Vector3 v2], [param:Float alpha] )</h3>
-		<div>
+		<p>
 		[page:Vector3 v1] - the starting [page:Vector3].<br />
 		[page:Vector3 v2] - [page:Vector3] to interpolate towards.<br />
 		[page:Float alpha] - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -271,164 +273,164 @@ var d = a.distanceTo( b );
 		Sets this vector to be the vector linearly interpolated between [page:Vector3 v1] and
 		[page:Vector3 v2] where alpha is the distance along the line connecting the two vectors
 		- alpha = 0 will be [page:Vector3 v1], and alpha = 1 will be [page:Vector3 v2].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 max]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 		If this vector's x, y or z value is less than [page:Vector3 v]'s x, y or z value, replace
 		that value with the corresponding max value.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 min]( [param:Vector3 v] )</h3>
-		<div>
+		<p>
 		If this vector's x, y or z value is greater than [page:Vector3 v]'s x, y or z value, replace
 		that value with the corresponding min value.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 multiply]( [param:Vector3 v] )</h3>
-		<div>Multiplies this vector by [page:Vector3 v].</div>
+		<p>Multiplies this vector by [page:Vector3 v].</p>
 
 		<h3>[method:Vector3 multiplyScalar]( [param:Float s] )</h3>
-		<div>Multiplies this vector by scalar [page:Float s].</div>
+		<p>Multiplies this vector by scalar [page:Float s].</p>
 
 		<h3>[method:Vector3 multiplyVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
-		<div>Sets this vector equal to [page:Vector3 a] * [page:Vector3 b], component-wise.</div>
+		<p>Sets this vector equal to [page:Vector3 a] * [page:Vector3 b], component-wise.</p>
 
 		<h3>[method:Vector3 negate]()</h3>
-		<div>Inverts this vector - i.e. sets x = -x, y = -y and z = -z.</div>
+		<p>Inverts this vector - i.e. sets x = -x, y = -y and z = -z.</p>
 
 		<h3>[method:Vector3 normalize]()</h3>
-		<div>
+		<p>
 		Convert this vector to a [link:https://en.wikipedia.org/wiki/Unit_vector unit vector] - that is, sets it equal to the vector with the same direction
 		as this one, but [page:.length length] 1.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 project]( [param:Camera camera] )</h3>
-		<div>
+		<p>
 		[page:Camera camera] — camera to use in the projection.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Vector_projection Projects] the vector with the camera.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 projectOnPlane]( [param:Vector3 planeNormal] )</h3>
-		<div>
+		<p>
 		[page:Vector3 planeNormal] - A vector representing a plane normal.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Vector_projection Projects] this vector onto a plane by subtracting this vector projected onto the plane's
 		normal from this vector.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 projectOnVector]( [param:Vector3] )</h3>
-		<div>[link:https://en.wikipedia.org/wiki/Vector_projection Projects] this vector onto another vector.</div>
+		<p>[link:https://en.wikipedia.org/wiki/Vector_projection Projects] this vector onto another vector.</p>
 
 		<h3>[method:Vector3 reflect]( [param:Vector3 normal] )</h3>
-		<div>
+		<p>
 		[page:Vector3 normal] - the normal to the reflecting plane<br /><br />
 
 		Reflect the vector off of plane orthogonal to [page:Vector3 normal]. Normal is assumed to
 		have unit length.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 round]()</h3>
-		<div>The components of the vector are rounded to the nearest integer value.</div>
+		<p>The components of the vector are rounded to the nearest integer value.</p>
 
 		<h3>[method:Vector3 roundToZero]()</h3>
-		<div>
+		<p>
 		The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 set]( [param:Float x], [param:Float y], [param:Float z] )</h3>
-		<div>Sets the [page:.x x], [page:.y y] and [page:.z z] components of this vector.</div>
+		<p>Sets the [page:.x x], [page:.y y] and [page:.z z] components of this vector.</p>
 
 		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
-		<div>
+		<p>
 		[page:Integer index] - 0, 1 or 2.<br />
 		[page:Float value] - [page:Float]<br /><br />
 
 		If index equals 0 set [page:.x x] to [page:Float value].<br />
 		If index equals 1 set [page:.y y] to [page:Float value].<br />
 		If index equals 2 set [page:.z z] to [page:Float value]
-		</div>
+		</p>
 
 		<h3>[method:Vector3 setFromCylindrical]( [param:Cylindrical c] )</h3>
-		<div>
+		<p>
 		Sets this vector from the cylindrical coordinates [page:Cylindrical c].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 setFromMatrixColumn]( [param:Matrix4 matrix], [param:Integer index] )</h3>
-		<div>
+		<p>
 		Sets this vector's [page:.x x], [page:.y y] and [page:.z z] equal to the column of
 		the [page:Matrix4 matrix] specified by the [page:Integer index].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 setFromMatrixPosition]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 		Sets this vector to the position elements of the
 		[link:https://en.wikipedia.org/wiki/Transformation_matrix transformation matrix] [page:Matrix4 m].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 setFromMatrixScale]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 		Sets this vector to the scale elements of the
 		[link:https://en.wikipedia.org/wiki/Transformation_matrix transformation matrix] [page:Matrix4 m].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 setFromSpherical]( [param:Spherical s] )</h3>
-		<div>
+		<p>
 		Sets this vector from the spherical coordinates [page:Spherical s].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 setLength]( [param:Float l] )</h3>
-		<div>
+		<p>
 		Set this vector to the vector with the same direction as this one, but [page:.length length]
 		[page:Float l].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 setScalar]( [param:Float scalar] )</h3>
-		<div>
+		<p>
 		Set the [page:.x x], [page:.y y] and [page:.z z] values of this vector both equal to [page:Float scalar].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 setX]( [param:Float x] )</h3>
-		<div>Replace this vector's [page:.x x] value with [page:Float x].</div>
+		<p>Replace this vector's [page:.x x] value with [page:Float x].</p>
 
 		<h3>[method:Vector3 setY]( [param:Float y] )</h3>
-		<div>Replace this vector's [page:.y y] value with [page:Float y].</div>
+		<p>Replace this vector's [page:.y y] value with [page:Float y].</p>
 
 		<h3>[method:Vector3 setZ]( [param:Float z] )</h3>
-		<div>Replace this vector's [page:.z z] value with [page:Float z].</div>
+		<p>Replace this vector's [page:.z z] value with [page:Float z].</p>
 
 		<h3>[method:Vector3 sub]( [param:Vector3 v] )</h3>
-		<div>Subtracts [page:Vector3 v] from this vector.</div>
+		<p>Subtracts [page:Vector3 v] from this vector.</p>
 
 		<h3>[method:Vector3 subScalar]( [param:Float s] )</h3>
-		<div>Subtracts [page:Float s]  from this vector's [page:.x x], [page:.y y] and [page:.z z] compnents.</div>
+		<p>Subtracts [page:Float s]  from this vector's [page:.x x], [page:.y y] and [page:.z z] compnents.</p>
 
 		<h3>[method:Vector3 subVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
-		<div>Sets this vector to [page:Vector3 a] - [page:Vector3 b].</div>
+		<p>Sets this vector to [page:Vector3 a] - [page:Vector3 b].</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - (optional) array to store the vector to. If this is not provided
 		a new array will be created.<br />
 		[page:Integer offset] - (optional) optional offset into the array.<br /><br />
 
 		Returns an array [x, y, z], or copies x, y and z into the provided [page:Array array].
-		</div>
+		</p>
 
 		<h3>[method:Vector3 transformDirection]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 		Transforms the direction of this vector by a matrix (the upper left 3 x 3 subset of a [page:Matrix4 m])
 		and then [page:.normalize normalizes] the result.
-		</div>
+		</p>
 
 		<h3>[method:Vector3 unproject]( [param:Camera camera] )</h3>
-		<div>
+		<p>
 		[page:Camera camera] — camera to use in the projection.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Vector_projection Unprojects] the vector with the
 		camera's projection matrix.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/math/Vector4.html
+++ b/docs/api/math/Vector4.html
@@ -10,10 +10,11 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">Class representing a 4D [link:https://en.wikipedia.org/wiki/Vector_space vector].
+		<p class="desc">Class representing a 4D [link:https://en.wikipedia.org/wiki/Vector_space vector].
 
 		A 4D vector is an ordered quadruplet of numbers (labeled x, y, z, and w), which can be used to
 		represent a number of things, such as:
+		</p>
 
 		<ul>
 			<li>
@@ -30,8 +31,9 @@
 			</li>
 		</ul>
 
+		<p>
 		There are other things a 4D vector can be used to represent, however these are the most common uses in three.js.
-		</div>
+		</p>
 
 
 		<h2>Example</h2>
@@ -49,24 +51,24 @@ var d = a.dot( b );
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
-		<div>
+		<p>
 		[page:Float x] - the x value of the vector. Default is *0*.<br />
 		[page:Float y] -  the y value of the vector. Default is *0*.<br />
 		[page:Float z] - the z value of the vector. Default is *0*.<br />
 		[page:Float w] - the w value of the vector. Default is *1*.<br /><br />
 
 		Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean isVector4]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are Vector4s. Default is *true*.<br /><br />
 
 			You should not change this, as it is used internally for optimisation.
-		</div>
+		</p>
 
 		<h3>[property:Float x]</h3>
 
@@ -80,137 +82,137 @@ var d = a.dot( b );
 		<h2>Methods</h2>
 
 		<h3>[method:Vector4 add]( [param:Vector4 v] )</h3>
-		<div>Adds [page:Vector4 v] to this vector.</div>
+		<p>Adds [page:Vector4 v] to this vector.</p>
 
 		<h3>[method:Vector4 addScalar]( [param:Float s] )</h3>
-		<div>Adds the scalar value s to this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values.</div>
+		<p>Adds the scalar value s to this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values.</p>
 
 		<h3>[method:Vector4 addScaledVector]( [param:Vector4 v], [param:Float s] )</h3>
-		<div>Adds the multiple of [page:Vector4 v] and [page:Float s] to this vector.</div>
+		<p>Adds the multiple of [page:Vector4 v] and [page:Float s] to this vector.</p>
 
 		<h3>[method:Vector4 addVectors]( [param:Vector4 a], [param:Vector4 b] )</h3>
-		<div>Sets this vector to [page:Vector4 a] + [page:Vector4 b].</div>
+		<p>Sets this vector to [page:Vector4 a] + [page:Vector4 b].</p>
 
 		<h3>[method:Vector4 applyMatrix4]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 		Multiplies this vector by 4 x 4 [page:Matrix4 m].
-		</div>
+		</p>
 
 		<h3>[method:Vector4 ceil]()</h3>
-		<div>
+		<p>
 		The [page:.x x], [page:.y y], [page:.z z] and [page:.w w] components of the vector are rounded up to the nearest integer value.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 clamp]( [param:Vector4 min], [param:Vector4 max] )</h3>
-		<div>
+		<p>
 		[page:Vector4 min] - the minimum [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values.<br />
 		[page:Vector4 max] - the maximum [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values in the desired range<br /><br />
 
 		If this vector's x, y, z or w value is greater than the max vector's x, y, z or w value, it is replaced by the corresponding value. <br /><br />
 		If this vector's x, y, z or w value is less than the min vector's x, y, z or w value, it is replaced by the corresponding value.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 clampLength]( [param:Float min], [param:Float max] )</h3>
-		<div>
+		<p>
 		[page:Float min] - the minimum value the length will be clamped to <br />
 		[page:Float max] - the maximum value the length will be clamped to<br /><br />
 
 		If this vector's length is greater than the max value, it is replaced by the max value. <br /><br />
 		If this vector's length is less than the min value, it is replaced by the min value.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 clampScalar]( [param:Float min], [param:Float max] )</h3>
-		<div>
+		<p>
 		[page:Float min] - the minimum value the components will be clamped to <br />
 		[page:Float max] - the maximum value the components will be clamped to<br /><br />
 
 		If this vector's x, y, z or w values are greater than the max value, they are replaced by the max value. <br /><br />
 		If this vector's x, y, z or w values are less than the min value, they are replaced by the min value.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 clone]()</h3>
-		<div>
+		<p>
 		Returns a new Vector4 with the same [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values as this one.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 copy]( [param:Vector4 v] )</h3>
-		<div>
+		<p>
 			Copies the values of the passed Vector4's [page:.x x], [page:.y y], [page:.z z] and [page:.w w]
 			properties to this Vector4.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 divideScalar]( [param:Float s] )</h3>
-		<div>
+		<p>
 		Divides this vector by scalar [page:Float s].<br />
 		Sets vector to *( 0, 0, 0, 0 )* if *[page:Float s] = 0*.
-		</div>
+		</p>
 
 		<h3>[method:Float dot]( [param:Vector4 v] )</h3>
-		<div>
+		<p>
 		Calculates the [link:https://en.wikipedia.org/wiki/Dot_product dot product] of this
 		vector and [page:Vector4 v].
-		</div>
+		</p>
 
 		<h3>[method:Boolean equals]( [param:Vector4 v] )</h3>
-		<div>Checks for strict equality of this vector and [page:Vector4 v].</div>
+		<p>Checks for strict equality of this vector and [page:Vector4 v].</p>
 
 		<h3>[method:Vector4 floor]()</h3>
-		<div>The components of the vector are rounded down to the nearest integer value.</div>
+		<p>The components of the vector are rounded down to the nearest integer value.</p>
 
 		<h3>[method:Vector4 fromArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - (optional) offset into the array. Default is 0.<br /><br />
 
 		Sets this vector's [page:.x x] value to be array[ offset + 0 ], [page:.y y] value to be array[ offset + 1 ]
 		[page:.z z] value to be array[ offset + 2 ] and [page:.w w ] value to be array[ offset + 3 ].
-		</div>
+		</p>
 
 		<h3>[method:Vector4 fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
-		<div>
+		<p>
 		[page:BufferAttribute attribute] - the source attribute.<br />
 		[page:Integer index] - index in the attribute.<br /><br />
 
 		Sets this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values from the [page:BufferAttribute attribute].
-		</div>
+		</p>
 
 		<h3>[method:Float getComponent]( [param:Integer index] )</h3>
-		<div>
+		<p>
 		[page:Integer index] - 0, 1, 2 or 3.<br /><br />
 
 		If index equals 0 returns the [page:.x x] value. <br />
 		If index equals 1 returns the [page:.y y] value. <br />
 		If index equals 2 returns the [page:.z z] value.<br />
 		If index equals 3 returns the [page:.w w] value.
-		</div>
+		</p>
 
 		<h3>[method:Float length]()</h3>
-		<div>Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
-		(straight-line length) from (0, 0, 0, 0) to (x, y, z, w).</div>
+		<p>Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
+		(straight-line length) from (0, 0, 0, 0) to (x, y, z, w).</p>
 
 		<h3>[method:Float manhattanLength]()</h3>
-		<div>
+		<p>
 		Computes the [link:http://en.wikipedia.org/wiki/Taxicab_geometry Manhattan length] of this vector.
-		</div>
+		</p>
 
 		<h3>[method:Float lengthSq]()</h3>
-		<div>
+		<p>
 		Computes the square of the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
 		(straight-line length) from (0, 0, 0, 0) to (x, y, z, w). If you are 	comparing the lengths of
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 lerp]( [param:Vector4 v], [param:Float alpha] )</h3>
-		<div>
+		<p>
 		[page:Vector4 v] - [page:Vector4] to interpolate towards.<br />
 		alpha - interpolation factor in the closed interval [0, 1].<br /><br />
 
 		Linearly interpolates between this vector and [page:Vector4 v], where alpha is the
 		distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector4 v].
-		</div>
+		</p>
 
 		<h3>[method:Vector4 lerpVectors]( [param:Vector4 v1], [param:Vector4 v2], [param:Float alpha] )</h3>
-		<div>
+		<p>
 		[page:Vector4 v1] - the starting [page:Vector4].<br />
 		[page:Vector4 v2] - [page:Vector4] to interpolate towards.<br />
 		[page:Float alpha] - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -218,60 +220,60 @@ var d = a.dot( b );
 		Sets this vector to be the vector linearly interpolated between [page:Vector4 v1] and
 		[page:Vector4 v2] where alpha is the distance along the line connecting the two vectors
 		- alpha = 0 will be [page:Vector4 v1], and alpha = 1 will be [page:Vector4 v2].
-		</div>
+		</p>
 
 		<h3>[method:Vector4 negate]()</h3>
-		<div>Inverts this vector - i.e. sets x = -x, y = -y, z = -z and w = -w.</div>
+		<p>Inverts this vector - i.e. sets x = -x, y = -y, z = -z and w = -w.</p>
 
 		<h3>[method:Vector4 normalize]()</h3>
-		<div>
+		<p>
 		Converts this vector to a [link:https://en.wikipedia.org/wiki/Unit_vector unit vector] - that is, sets it equal to the vector with the same direction
 		as this one, but [page:.length length] 1.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 max]( [param:Vector4 v] )</h3>
-		<div>
+		<p>
 		If this vector's x, y, z or w value is less than [page:Vector4 v]'s x, y, z or w value, replace
 		that value with the corresponding max value.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 min]( [param:Vector4 v] )</h3>
-		<div>
+		<p>
 		If this vector's x, y, z or w value is greater than [page:Vector4 v]'s x, y, z or w value, replace
 		that value with the corresponding min value.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 multiplyScalar]( [param:Float s] )</h3>
-		<div>Multiplies this vector by scalar [page:Float s].</div>
+		<p>Multiplies this vector by scalar [page:Float s].</p>
 
 		<h3>[method:Vector4 round]()</h3>
-		<div>The components of the vector are rounded to the nearest integer value.</div>
+		<p>The components of the vector are rounded to the nearest integer value.</p>
 
 		<h3>[method:Vector4 roundToZero]()</h3>
-		<div>
+		<p>
 		The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 set]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
-		<div>Sets the [page:.x x], [page:.y y], [page:.z z] and [page:.w w] components of this vector.</div>
+		<p>Sets the [page:.x x], [page:.y y], [page:.z z] and [page:.w w] components of this vector.</p>
 
 		<h3>[method:Vector4 setAxisAngleFromQuaternion]( [param:Quaterion q] )</h3>
-		<div>
+		<p>
 			[page:Quaterion q] - a normalized [page:Quaterion]<br /><br />
 
 			Sets the [page:.x x], [page:.y y] and [page:.z z] components of this vector to the
 			quaternion's axis and [page:.w w] to the angle.
-		</div>
+		</p>
 
 		<h3>[method:Vector4 setAxisAngleFromRotationMatrix]( [param:Matrix4 m] )</h3>
-		<div>
+		<p>
 			 [page:Matrix4 m] - a [page:Matrix4] of which the upper left 3x3 matrix is a pure rotation matrix.<br /><br />
 
 			Sets the [page:.x x], [page:.y y] and [page:.z z] to the axis of rotation and [page:.w w] to the angle.
-		</div>
+		</p>
 
 		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
-		<div>
+		<p>
 		[page:Integer index] - 0, 1 or 2.<br />
 		[page:Float value] - [page:Float]<br /><br />
 
@@ -279,48 +281,48 @@ var d = a.dot( b );
 		If index equals 1 set [page:.y y] to [page:Float value].<br />
 		If index equals 2 set [page:.z z] to [page:Float value].<br />
 		If index equals 3 set [page:.w w] to [page:Float value].
-		</div>
+		</p>
 
 
 		<h3>[method:Vector4 setLength]( [param:Float l] )</h3>
-		<div>
+		<p>
 		Sets this vector to the vector with the same direction as this one, but [page:.length length]
 		[page:Float l].
-		</div>
+		</p>
 
 		<h3>[method:Vector4 setScalar]( [param:Float scalar] )</h3>
-		<div>
+		<p>
 		Sets the [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values of this vector both equal to [page:Float scalar].
-		</div>
+		</p>
 
 		<h3>[method:Vector4 setX]( [param:Float x] )</h3>
-		<div>Replaces this vector's [page:.x x] value with [page:Float x].</div>
+		<p>Replaces this vector's [page:.x x] value with [page:Float x].</p>
 
 		<h3>[method:Vector4 setY]( [param:Float y] )</h3>
-		<div>Replaces this vector's [page:.y y] value with [page:Float y].</div>
+		<p>Replaces this vector's [page:.y y] value with [page:Float y].</p>
 
 		<h3>[method:Vector4 setZ]( [param:Float z] )</h3>
-		<div>Replaces this vector's [page:.z z] value with [page:Float z].</div>
+		<p>Replaces this vector's [page:.z z] value with [page:Float z].</p>
 
 		<h3>[method:Vector4 setW]( [param:Float w] )</h3>
-		<div>Replaces this vector's [page:.w w] value with [page:Float w].</div>
+		<p>Replaces this vector's [page:.w w] value with [page:Float w].</p>
 
 		<h3>[method:Vector4 sub]( [param:Vector4 v] )</h3>
-		<div>Subtracts [page:Vector4 v] from this vector.</div>
+		<p>Subtracts [page:Vector4 v] from this vector.</p>
 
 		<h3>[method:Vector4 subScalar]( [param:Float s] )</h3>
-		<div>Subtracts [page:Float s]  from this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] compnents.</div>
+		<p>Subtracts [page:Float s]  from this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] compnents.</p>
 
 		<h3>[method:Vector4 subVectors]( [param:Vector4 a], [param:Vector4 b] )</h3>
-		<div>Sets this vector to [page:Vector4 a] - [page:Vector4 b].</div>
+		<p>Sets this vector to [page:Vector4 a] - [page:Vector4 b].</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
-		<div>
+		<p>
 		[page:Array array] - (optional) array to store the vector to. If this is not provided, a new array will be created.<br />
 		[page:Integer offset] - (optional) optional offset into the array.<br /><br />
 
 		Returns an array [x, y, z, w], or copies x, y, z and w into the provided [page:Array array].
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/interpolants/CubicInterpolant.html
+++ b/docs/api/math/interpolants/CubicInterpolant.html
@@ -12,9 +12,9 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -33,50 +33,50 @@ interpolant.evaluate( 0.5 );
 		<h2>Constructor</h2>
 
 		<h3>[name]( parameterPositions, sampleValues, sampleSize, resultBuffer )</h3>
-		<div>
+		<p>
 		parameterPositions -- array of positions<br />
 		sampleValues -- array of samples<br />
 		sampleSize -- number of samples<br />
 		resultBuffer -- buffer to store the interpolation results.<br /><br />
 
 
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 
 
 		<h3>[property:null parameterPositions]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null resultBuffer]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null sampleValues]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:Object settings]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null valueSize]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:null evaluate]( [param:Number t] )</h3>
-		<div>
+		<p>
 		Evaluate the interpolant at position *t*.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/interpolants/DiscreteInterpolant.html
+++ b/docs/api/math/interpolants/DiscreteInterpolant.html
@@ -12,9 +12,9 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -33,50 +33,50 @@ interpolant.evaluate( 0.5 );
 		<h2>Constructor</h2>
 
 		<h3>[name]( parameterPositions, sampleValues, sampleSize, resultBuffer )</h3>
-		<div>
+		<p>
 		parameterPositions -- array of positions<br />
 		sampleValues -- array of samples<br />
 		sampleSize -- number of samples<br />
 		resultBuffer -- buffer to store the interpolation results.<br /><br />
 
 
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 
 
 		<h3>[property:null parameterPositions]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null resultBuffer]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null sampleValues]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:Object settings]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null valueSize]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:null evaluate]( [param:Number t] )</h3>
-		<div>
+		<p>
 		Evaluate the interpolant at position *t*.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/interpolants/LinearInterpolant.html
+++ b/docs/api/math/interpolants/LinearInterpolant.html
@@ -12,9 +12,9 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -33,50 +33,50 @@ interpolant.evaluate( 0.5 );
 		<h2>Constructor</h2>
 
 		<h3>[name]( parameterPositions, sampleValues, sampleSize, resultBuffer )</h3>
-		<div>
+		<p>
 		parameterPositions -- array of positions<br />
 		sampleValues -- array of samples<br />
 		sampleSize -- number of samples<br />
 		resultBuffer -- buffer to store the interpolation results.<br /><br />
 
 
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 
 
 		<h3>[property:null parameterPositions]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null resultBuffer]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null sampleValues]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:Object settings]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null valueSize]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:null evaluate]( [param:Number t] )</h3>
-		<div>
+		<p>
 		Evaluate the interpolant at position *t*.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/math/interpolants/QuaternionLinearInterpolant.html
+++ b/docs/api/math/interpolants/QuaternionLinearInterpolant.html
@@ -12,9 +12,9 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -33,50 +33,50 @@ interpolant.evaluate( 0.5 );
 		<h2>Constructor</h2>
 
 		<h3>[name]( parameterPositions, sampleValues, sampleSize, resultBuffer )</h3>
-		<div>
+		<p>
 		parameterPositions -- array of positions<br />
 		sampleValues -- array of samples<br />
 		sampleSize -- number of samples<br />
 		resultBuffer -- buffer to store the interpolation results.<br /><br />
 
 
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 
 
 		<h3>[property:null parameterPositions]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null resultBuffer]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null sampleValues]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:Object settings]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h3>[property:null valueSize]</h3>
-		<div>
+		<p>
 
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:null evaluate]( [param:Number t] )</h3>
-		<div>
+		<p>
 		Evaluate the interpolant at position *t*.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/objects/Bone.html
+++ b/docs/api/objects/Bone.html
@@ -12,10 +12,10 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		A bone which is part of a [page:Skeleton]. The skeleton in turn is used by the [page:SkinnedMesh].
 		Bones are almost identical to a blank [page:Object3D].
-		</div>
+		</p>
 
 		<h3>Example</h3>
 
@@ -30,27 +30,27 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( )</h3>
-		<div>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
-		<div>See the base [page:Object3D] class for common properties.</div>
+		<p>See the base [page:Object3D] class for common properties.</p>
 
 		<h3>[property:Boolean isBone]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are bones. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 
 		<h3>[property:String type]</h3>
-		<div>Set to 'Bone', this can be used to find all Bones in a scene.</div>
+		<p>Set to 'Bone', this can be used to find all Bones in a scene.</p>
 
 
 		<h2>Methods</h2>
-		<div>See the base [page:Object3D] class for common methods.</div>
+		<p>See the base [page:Object3D] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/objects/Group.html
+++ b/docs/api/objects/Group.html
@@ -12,10 +12,10 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			This is almost identical to an [page:Object3D Object3D]. Its purpose is to make working
 			with groups of objects syntactically clearer.
-		</div>
+		</p>
 
 
 		<h2>Example</h2>
@@ -45,13 +45,13 @@
 		<h3>[name]( )</h3>
 
 		<h2>Properties</h2>
-		<div>See the base [page:Object3D] class for common properties.</div>
+		<p>See the base [page:Object3D] class for common properties.</p>
 
 		<h3>[property:String type]</h3>
-		<div>A string 'Group'. This should not be changed.</div>
+		<p>A string 'Group'. This should not be changed.</p>
 
 		<h2>Methods</h2>
-		<div>See the base [page:Object3D] class for common methods.</div>
+		<p>See the base [page:Object3D] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/objects/LOD.html
+++ b/docs/api/objects/LOD.html
@@ -12,17 +12,16 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			Level of Detail - show meshes with more or less geometry based on distance from the camera.<br /><br />
 
 		  Every level is associated with an object, and rendering can be switched between them at the distances
 			specified. Typically you would create, say, three meshes, one for far away (low detail), one for mid range (medium detail)
 			and one for close up (high detail).
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
-		<div>
 		<code>
 var lod = new THREE.LOD();
 
@@ -39,74 +38,75 @@ for( var i = 0; i < 3; i++ ) {
 
 scene.add( lod );
 		</code>
+
+		<p>
 		Note that for the LOD to switch between the different detail levels, you will
 		have to call [page:.update update]( camera ) in your render loop. See the source code
 		for this example for details:
 		[example:webgl_lod WebGL / LOD]
-
 		</div>
 
 		<h2>Constructor</h2>
 		<h3>[name]( )</h3>
-		<div>
+		<p>
 			Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Object3D] class for common properties.</div>
+		<p>See the base [page:Object3D] class for common properties.</p>
 
 		<h3>[property:array levels]</h3>
-		<div>
+		<p>
 		An array of [page:object level] objects<br /><br />
 
 		Each level is an object with two properties:<br />
 		[page:Object3D object] - The [page:Object3D] to display at this level.<br />
 		[page:Float distance] - The distance at which to display this level of detail.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
-		<div>See the base [page:Object3D] class for common methods.</div>
+		<p>See the base [page:Object3D] class for common methods.</p>
 
 		<h3>[method:null addLevel]( [param:Object3D object], [param:Float distance] )</h3>
-		<div>
+		<p>
 		[page:Object3D object] - The [page:Object3D] to display at this level.<br />
 		[page:Float distance] - The distance at which to display this level of detail.<br /><br />
 
 		Adds a mesh that will display at a certain distance and greater. Typically the further away the distance,
 		the lower the detail on the mesh.
-		</div>
+		</p>
 
 		<h3>[method:LOD clone]()</h3>
-		<div>
+		<p>
 		Returns a clone of this LOD object and its associated distance specific objects.
-		</div>
+		</p>
 
 
 		<h3>[method:Object3D getObjectForDistance]( [param:Float distance] )</h3>
-		<div>
+		<p>
 		Get a reference to the first [page:Object3D] (mesh) that is greater than [page:Float distance].
-		</div>
+		</p>
 
 		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
-		<div>
+		<p>
 		Get intersections between a casted [page:Ray] and this LOD.
 		[page:Raycaster.intersectObject] will call this method.
-		</div>
+		</p>
 
 
 
 		<h3>[method:null toJSON]( meta )</h3>
-		<div>
+		<p>
 		Create a JSON structure with details of this LOD object.
-		</div>
+		</p>
 
 		<h3>[method:null update]( [param:Camera camera] )</h3>
-		<div>
+		<p>
 			Set the visibility of each [page:levels level]'s [page:Object3D object] based on
 			distance from the [page:Camera camera]. This needs to be called in the render loop
 			for levels of detail to be updated dynamically.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/objects/Line.html
+++ b/docs/api/objects/Line.html
@@ -12,7 +12,7 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A continuous line.<br /><br />
 
 			This is nearly the same
@@ -20,7 +20,7 @@
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawElements gl.LINE_STRIP]
 			instead of [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawElements gl.LINES]
 
-		</div>
+		</p>
 
 
 		<h2>Example</h2>
@@ -45,50 +45,50 @@
 
 		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 
-		<div>
+		<p>
 		[page:Geometry geometry] — vertices representing the line segment(s). Default is a new [page:new BufferGeometry].<br />
 		[page:Material material] — material for the line. Default is a new [page:LineBasicMaterial] with random color.<br />
-		</div>
+		</p>
 
-		<div>If no material is supplied, a randomized line material will be created and assigned to the object.</div>
+		<p>If no material is supplied, a randomized line material will be created and assigned to the object.</p>
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Object3D] class for common properties.</div>
+		<p>See the base [page:Object3D] class for common properties.</p>
 
 		<h3>[property:Boolean isLine]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are lines. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 
 		<h3>[property:Geometry geometry]</h3>
-		<div>Vertices representing the line segment(s).</div>
+		<p>Vertices representing the line segment(s).</p>
 
 		<h3>[property:Material material]</h3>
-		<div>Material for the line.</div>
+		<p>Material for the line.</p>
 
 
 		<h2>Methods</h2>
-		<div>See the base [page:Object3D] class for common methods.</div>
+		<p>See the base [page:Object3D] class for common methods.</p>
 
 		<h3>[method:Line computeLineDistances]()</h3>
-		<div>
+		<p>
 		Computes an array of distance values which are necessary for [page:LineDashedMaterial]. For each vertex in the geometry, the method calculates the cumulative length from the current point to the very beginning of the line.
-		</div>
+		</p>
 
 		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
-		<div>
+		<p>
 		Get intersections between a casted [page:Ray] and this Line.
 		[page:Raycaster.intersectObject] will call this method.
-		</div>
+		</p>
 
 		<h3>[method:Line clone]()</h3>
-		<div>
+		<p>
 		Returns a clone of this Line object and its descendants.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/objects/LineLoop.html
+++ b/docs/api/objects/LineLoop.html
@@ -12,41 +12,41 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A continuous line that connects back to the start.<br /><br />
 
 			This is nearly the same	as [page:Line]; the only difference is that it is rendered using
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawElements gl.LINE_LOOP]
 			instead of [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawElements gl.LINE_STRIP],
 			which draws a straight line to the next vertex, and connects the last vertex back to the first.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 
-		<div>
+		<p>
 		[page:Geometry geometry] — List of vertices representing points on the line loop.<br />
 		[page:Material material] — Material for the line. Default is [page:LineBasicMaterial LineBasicMaterial].
-		</div>
+		</p>
 
-		<div>If no material is supplied, a randomized line material will be created and assigned to the object.</div>
+		<p>If no material is supplied, a randomized line material will be created and assigned to the object.</p>
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Line] class for common properties.</div>
+		<p>See the base [page:Line] class for common properties.</p>
 
 		<h3>[property:Boolean isLineLoop]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are line loops. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
-		<div>See the base [page:Line] class for common methods.</div>
+		<p>See the base [page:Line] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/objects/LineSegments.html
+++ b/docs/api/objects/LineSegments.html
@@ -12,40 +12,40 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A series of lines drawn between pairs of vertices.<br /><br />
 
 			This is nearly the same	as [page:Line]; the only difference is that it is rendered using
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawElements gl.LINES]
 			instead of [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawElements gl.LINE_STRIP].
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 
-		<div>
+		<p>
 		[page:Geometry geometry] — Pair(s) of vertices representing each line segment(s).<br />
 		[page:Material material] — Material for the line. Default is [page:LineBasicMaterial LineBasicMaterial].
-		</div>
+		</p>
 
-		<div>If no material is supplied, a randomized line material will be created and assigned to the object.</div>
+		<p>If no material is supplied, a randomized line material will be created and assigned to the object.</p>
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Line] class for common properties.</div>
+		<p>See the base [page:Line] class for common properties.</p>
 
 		<h3>[property:Boolean isLineSegments]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are line segments. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
-		<div>See the base [page:Line] class for common methods.</div>
+		<p>See the base [page:Line] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/objects/Mesh.html
+++ b/docs/api/objects/Mesh.html
@@ -12,10 +12,10 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			Class representing triangular [link:https://en.wikipedia.org/wiki/Polygon_mesh polygon mesh] based objects.
 		  Also serves as a base for other classes such as [page:SkinnedMesh].
-		</div>
+		</p>
 
 
 		<h2>Example</h2>
@@ -31,79 +31,79 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
-		<div>
+		<p>
 		[page:Geometry geometry] — (optional) an instance of [page:Geometry] or [page:BufferGeometry].
 		  Default is a new [page:BufferGeometry].<br />
 		[page:Material material] — (optional) a single or an array of [page:Material]. Default is a new [page:MeshBasicMaterial]
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Object3D] class for common properties.</div>
+		<p>See the base [page:Object3D] class for common properties.</p>
 
 		<h3>[property:Integer drawMode]</h3>
-		<div>
+		<p>
 		Determines how the mesh triangles are constructed from the vertices.
 		See the draw mode [page:DrawModes constants] for all possible values.
 		Default is [page:DrawModes TrianglesDrawMode].
-		</div>
+		</p>
 
 
 		<h3>[property:Boolean isMesh]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are meshes. Default is *true*.<br /><br />
 
 			You should not change this, as it is used internally for optimisation.
-		</div>
+		</p>
 
 		<h3>[property:Geometry geometry]</h3>
-		<div>
+		<p>
 			An instance of [page:Geometry] or [page:BufferGeometry] (or derived classes),
 			defining the object's structure.<br /><br />
 
 			It's recommended to always use a [page:BufferGeometry] if possible for best performance.
-		</div>
+		</p>
 
 		<h3>[property:Material material]</h3>
-		<div>
+		<p>
 			An instance of material derived from the [page:Material] base class or an array of materials, defining the
 			object's appearance. Default is a [page:MeshBasicMaterial] with a random color.
-		</div>
+		</p>
 
 		<h3>[property:Array morphTargetInfluences]</h3>
-		<div>
+		<p>
 		An array of weights typically from 0-1 that specify how much of the morph is applied.
 		Undefined by default, but reset to a blank array by [page:Mesh.updateMorphTargets updateMorphTargets].
-		</div>
+		</p>
 
 		<h3>[property:Object morphTargetDictionary]</h3>
-		<div>
+		<p>
 		A dictionary of morphTargets based on the morphTarget.name property.
 		Undefined by default, but rebuilt [page:Mesh.updateMorphTargets updateMorphTargets].
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
-		<div>See the base [page:Object3D] class for common methods.</div>
+		<p>See the base [page:Object3D] class for common methods.</p>
 
 		<h3>[method:null setDrawMode]()</h3>
-		<div>Set the value of [page:.drawMode drawMode].</div>
+		<p>Set the value of [page:.drawMode drawMode].</p>
 
 		<h3>[method:Mesh clone]()</h3>
-		<div>Returns a clone of this [name] object and its descendants.</div>
+		<p>Returns a clone of this [name] object and its descendants.</p>
 
 		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
-		<div>
+		<p>
 		Get intersections between a casted ray and this mesh.
 		[page:Raycaster.intersectObject] will call this method.
-		</div>
+		</p>
 
 		<h3>[method:null updateMorphTargets]()</h3>
-		<div>
+		<p>
 		Updates the morphTargets to have no influence on the object. Resets the
 		[page:Mesh.morphTargetInfluences morphTargetInfluences] and
 		[page:Mesh.morphTargetDictionary morphTargetDictionary] properties.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/objects/Points.html
+++ b/docs/api/objects/Points.html
@@ -12,62 +12,62 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A class for displaying points.
 			The points are rendered by the [page:WebGLRenderer] using
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawElements gl.POINTS].
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
-		<div>
+		<p>
 			[page:Geometry geometry] — (optional) an instance of [page:Geometry] or [page:BufferGeometry].
 				Default is a new [page:BufferGeometry].<br />
 			[page:Material material] — (optional) a [page:Material]. Default is a new [page:PointsMaterial]
 				with a random color.
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Object3D] class for common properties.</div>
+		<p>See the base [page:Object3D] class for common properties.</p>
 
 		<h3>[property:Geometry geometry]</h3>
-		<div>
+		<p>
 			An instance of [page:Geometry] or [page:BufferGeometry] (or derived classes),
 			defining the object's structure.<br /><br />
 
 			Its recommended to always use a [page:BufferGeometry] if possible for best performance.
-		</div>
+		</p>
 
 		<h3>[property:Boolean isPoints]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are points. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 		<h3>[property:Material material]</h3>
-		<div>
+		<p>
 			An instance of [page:Material], defining the object's appearance.
 			Default is a [page:PointsMaterial] with a random color.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
-		<div>See the base [page:Object3D] class for common methods.</div>
+		<p>See the base [page:Object3D] class for common methods.</p>
 
 		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
-		<div>
+		<p>
 		Get intersections between a casted ray and this Points.
 		[page:Raycaster.intersectObject] will call this method.
-		</div>
+		</p>
 
 		<h3>[method:Points clone]()</h3>
-		<div>
+		<p>
 		Returns a clone of this Points object and its descendants.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/objects/Skeleton.html
+++ b/docs/api/objects/Skeleton.html
@@ -11,14 +11,12 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		Use an array of [page:Bone bones] to create a skeleton that can be used by a
 		[page:SkinnedMesh].
-		</div>
+		</p>
 
 		<h2>Example</h2>
-		<div>
-
 <code>
 // Create a simple "arm"
 
@@ -41,74 +39,75 @@ hand.position.y = 5;
 
 var armSkeleton = new THREE.Skeleton( bones );
 </code>
+		<p>
 			See the [page:SkinnedMesh] page for an example of usage with standard [page:BufferGeometry].
- 		</div>
+ 		</p>
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Array bones], [param:Array boneInverses] )</h3>
-		<div>
+		<p>
 		[page:Array bones] - The array of [page:Bone bones]. Default is an empty array.<br/>
 		[page:Array boneInverses] - (optional) An array of [page:Matrix4 Matrix4s].<br /><br />
 
 		Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Array bones]</h3>
-		<div>
+		<p>
 		The array of [page:bone bones]. Note this is a copy of the original array, not a reference,
 		so you can modify the original array without effecting this one.
-		</div>
+		</p>
 
 		<h3>[property:Array boneInverses]</h3>
-		<div>
+		<p>
 		An array of [page:Matrix4 Matrix4s] that represent the inverse of the [page:Matrix4 matrixWorld]
 		of the individual bones.
-		</div>
+		</p>
 
 		<h3>[property:Float32Array boneMatrices]</h3>
-		<div>
+		<p>
 		The array buffer holding the bone data when using a vertex texture.
-		</div>
+		</p>
 
 		<h3>[property:DataTexture boneTexture]</h3>
-		<div>
+		<p>
 		The [page:DataTexture] holding the bone data when using a vertex texture.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:Skeleton clone]()</h3>
-		<div>
+		<p>
 		Returns a clone of this Skeleton object.
-		</div>
+		</p>
 
 
 		<h3>[method:null calculateInverses]()</h3>
-		<div>Generates the [page:.boneInverses boneInverses] array if not provided in the constructor.</div>
+		<p>Generates the [page:.boneInverses boneInverses] array if not provided in the constructor.</p>
 
 
 		<h3>[method:null pose]()</h3>
-		<div>Returns the skeleton to the base pose.</div>
+		<p>Returns the skeleton to the base pose.</p>
 
 
 		<h3>[method:null update]()</h3>
-		<div>
+		<p>
 		Updates the [page:Float32Array boneMatrices] and [page:DataTexture boneTexture] after changing the bones.
 		This is called automatically by the [page:WebGLRenderer] if the skeleton is used with a [page:SkinnedMesh].
-		</div>
+		</p>
 
 		<h3>[method:Bone getBoneByName]( [param:String name] )</h3>
-		<div>
+		<p>
 		name -- String to match to the Bone's .name property. <br /><br />
 
 		Searches through the skeleton's bone array and returns the first with a matching name.<br />
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/objects/SkinnedMesh.html
+++ b/docs/api/objects/SkinnedMesh.html
@@ -12,7 +12,7 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A mesh that has a [page:Skeleton] with [page:Bone bones] that can then be used to animate the vertices of the geometry.</div>
+		<p class="desc">A mesh that has a [page:Skeleton] with [page:Bone bones] that can then be used to animate the vertices of the geometry.</p>
 
 		<iframe id="scene" src="scenes/bones-browser.html"></iframe>
 
@@ -67,56 +67,56 @@
 
 		<h2>Constructor</h2>
 		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
-		<div>
+		<p>
     [page:Geometry geometry] - an instance of [page:Geometry] or [page:BufferGeometry] (recommended).
 		[page:Geometry.skinIndices skinIndices] and [page:Geometry.skinWeights skinWeights] should be set to true on the geometry.<br />
     [page:Material material] - (optional) an instance of [page:Material]. Default is a new [page:MeshBasicMaterial].
-		</div>
+		</p>
 
 
 
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Mesh] class for common properties.</div>
+		<p>See the base [page:Mesh] class for common properties.</p>
 
 		<h3>[property:string bindMode]</h3>
-		<div>
+		<p>
 		Either "attached" or "detached". "attached" uses the [page:SkinnedMesh.matrixWorld]
 		property for the base transform	matrix of the bones. "detached" uses the
 		[page:SkinnedMesh.bindMatrix]. Default is "attached".
-		</div>
+		</p>
 
 		<h3>[property:Matrix4 bindMatrix]</h3>
-		<div>
+		<p>
 		The base matrix that is used for the bound bone transforms.
-		</div>
+		</p>
 
 		<h3>[property:Matrix4 bindMatrixInverse]</h3>
-		<div>
+		<p>
 		The base matrix that is used for resetting the bound bone transforms.
-		</div>
+		</p>
 
 		<h3>[property:Boolean isSkinnedMesh]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are skinned meshes. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 		<h3>[property:Skeleton skeleton]</h3>
-		<div>
+		<p>
 		[page:Skeleton] created from the [page:Geometry.bones bones] of the [page:Geometry] passed in the
 		constructor.
-		</div>
+		</p>
 
 
 
 		<h2>Methods</h2>
-		<div>See the base [page:Mesh] class for common methods.</div>
+		<p>See the base [page:Mesh] class for common methods.</p>
 
 		<h3>[method:null bind]( [param:Skeleton skeleton], [param:Matrix4 bindMatrix] )</h3>
-		<div>
+		<p>
 		[page:Skeleton skeleton] - [page:Skeleton] created from a [page:Bone Bones] tree.<br/>
 		[page:Matrix4 bindMatrix] - [page:Matrix4] that represents the base transform of the skeleton.<br /><br />
 
@@ -124,32 +124,32 @@
 		and the .bindMatrixInverse gets calculated. This is called automatically in the constructor, and the skeleton
 		is created from the [page:Geometry.bones bones] of the [page:Geometry] passed in the
 		constructor.
-		</div>
+		</p>
 
 		<h3>[method:SkinnedMesh clone]()</h3>
-		<div>
+		<p>
 		Returns a clone of this SkinnedMesh object and any descendants.
-		</div>
+		</p>
 
 		<h3>[method:null normalizeSkinWeights]()</h3>
-		<div>
+		<p>
 		Normalizes the [page:Geometry.skinWeights] vectors. Does not affect [page:BufferGeometry].
-		</div>
+		</p>
 
 		<h3>[method:null pose]()</h3>
-		<div>
+		<p>
 		This method sets the skinned mesh in the rest pose (resets the pose).
-		</div>
+		</p>
 
 		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
-		<div>
+		<p>
 		Updates the [page:Matrix4 MatrixWorld].
-		</div>
+		</p>
 
 		<h3>[method:null initBones]()</h3>
-		<div>
+		<p>
 		Creates an array of hierarchical [page:Bone bones] objects from the internal geometry.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/objects/Sprite.html
+++ b/docs/api/objects/Sprite.html
@@ -12,12 +12,12 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A sprite is a plane that always faces towards the camera, generally with a
 			partially transparent texture applied.<br /><br />
 
 			Sprites do not cast shadows, setting <code>castShadow = true</code> will have no effect.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -32,55 +32,55 @@ scene.add( sprite );
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Material material] )</h3>
-		<div>
+		<p>
     [page:Material material] - (optional) an instance of [page:SpriteMaterial]. Default is a white [page:SpriteMaterial].<br /><br />
 
 		Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
-		<div>See the base [page:Object3D] class for common properties.</div>
+		<p>See the base [page:Object3D] class for common properties.</p>
 
 		<h3>[property:Boolean isSprite]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are sprites. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 
 		<h3>[property:SpriteMaterial material]</h3>
-		<div>
+		<p>
 		An instance of [page:SpriteMaterial], defining the object's appearance.
 		Default is a white [page:SpriteMaterial].
-		</div>
+		</p>
 
 
 		<h3>[property:Vector2 center]</h3>
-		<div>
+		<p>
 		The sprite's anchor point, and the point around which the sprite rotates. A value of (0.5, 0.5) corresponds to the midpoint of the sprite.
 		A value of (0, 0) corresponds to the lower left corner of the sprite. The default is (0.5, 0.5).
-		</div>
+		</p>
 
 		<h2>Methods</h2>
-		<div>See the base [page:Object3D] class for common methods.</div>
+		<p>See the base [page:Object3D] class for common methods.</p>
 
 		<h3>[method:Sprite clone]()</h3>
-		<div>
+		<p>
 		Returns a clone of this Sprite object and any descendants.
-		</div>
+		</p>
 
 		<h3>[method:Sprite copy]( [param:Sprite sprite] )</h3>
-		<div>
+		<p>
 		Copies the properties of the passed sprite to this one.
-		</div>
+		</p>
 
 		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
-		<div>
+		<p>
 		Get intersections between a casted ray and this sprite.
 		[page:Raycaster.intersectObject] will call this method.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/renderers/WebGLRenderTarget.html
+++ b/docs/api/renderers/WebGLRenderTarget.html
@@ -10,12 +10,12 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A [link:https://msdn.microsoft.com/en-us/library/ff604997.aspx render target] is a buffer
 			where the video card draws pixels for a scene that	is being rendered in the background.
 			It is used in different effects, such as applying postprocessing to a rendered image
 			before displaying it on the screen.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
@@ -23,7 +23,7 @@
 
 		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
 
-		<div>
+		<p>
 		[page:Float width] - The width of the renderTarget. <br />
 		[page:Float height] - The height of the renderTarget.<br />
 		options - (optional object that holds texture parameters for an auto-generated target
@@ -44,77 +44,77 @@
 		[page:Boolean stencilBuffer] - default is *true*. Set this to false if you don't need it.<br /><br />
 
 		Creates a new [name]
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:number width]</h3>
-		<div>
+		<p>
 		The width of the render target.
-		</div>
+		</p>
 
 		<h3>[property:number height]</h3>
-		<div>
+		<p>
 		The height of the render target.
-		</div>
+		</p>
 
 		<h3>[property:Vector4 scissor]</h3>
-		<div>
+		<p>
 		A rectangular area inside the render target's viewport. Fragments that are outside the area will be discarded.
-		</div>
+		</p>
 
 		<h3>[property:boolean scissorTest]</h3>
-		<div>
+		<p>
 		Indicates whether the scissor test is active or not.
-		</div>
+		</p>
 
 		<h3>[property:Vector4 viewport]</h3>
-		<div>
+		<p>
 		The viewport of this render target.
-		</div>
+		</p>
 
 		<h3>[property:Texture texture]</h3>
-		<div>
+		<p>
 		This texture instance holds the rendered pixels. Use it as input for further processing.
-		</div>
+		</p>
 
 		<h3>[property:boolean depthBuffer]</h3>
-		<div>
+		<p>
 		Renders to the depth buffer. Default is true.
-		</div>
+		</p>
 
 		<h3>[property:boolean stencilBuffer]</h3>
-		<div>
+		<p>
 		Renders to the stencil buffer. Default is true.
-		</div>
+		</p>
 
 		<h3>[property:DepthTexture depthTexture]</h3>
-		<div>
+		<p>
 		If set, the scene depth will be rendered to this texture. Default is null.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null setSize]( [param:Number width], [param:Number height] )</h3>
-		<div>
+		<p>
 		Sets the size of the render target.
-		</div>
+		</p>
 
 		<h3>[method:WebGLRenderTarget clone]()</h3>
-		<div>
+		<p>
 		Creates a copy of this render target.
-		</div>
+		</p>
 
 		<h3>[method:WebGLRenderTarget copy]( [param:WebGLRenderTarget source] )</h3>
-		<div>
+		<p>
 		Adopts the settings of the given render target.
-		</div>
+		</p>
 
 		<h3>[method:null dispose]()</h3>
-		<div>
+		<p>
 		Dispatches a dispose event.
-		</div>
+		</p>
 
 
 

--- a/docs/api/renderers/WebGLRenderTargetCube.html
+++ b/docs/api/renderers/WebGLRenderTargetCube.html
@@ -12,20 +12,20 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			Used by the [page:CubeCamera] as its [page:WebGLRenderTarget].
-		</div>
+		</p>
 
 		<h2>Examples</h2>
 
-		<div>See [page:CubeCamera] for examples.</div>
+		<p>See [page:CubeCamera] for examples.</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
-		<div>
+		<p>
 		[page:Float width] - The width of the renderTarget. <br />
 		[page:Float height] - The height of the renderTarget. <br />
 		options - (optional) object that holds texture parameters for an auto-generated target
@@ -46,15 +46,15 @@
 		[page:Boolean stencilBuffer] - default is *true*. Set this to false if you don't need it.<br /><br />
 
 		Creates a new [name]
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:integer activeCubeFace]</h3>
-		<div>
+		<p>
 		The activeCubeFace property corresponds to a cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) and is
 		used and set internally by the [page:CubeCamera].
-		</div>
+		</p>
 
 		<h3>See [page:WebGLRenderTarget] for inherited properties</h3>
 

--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -10,15 +10,15 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			The WebGL renderer displays your beautifully crafted scenes using
 			[link:https://en.wikipedia.org/wiki/WebGL WebGL].
-		</div>
+		</p>
 
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Object parameters] )</h3>
-		<div>
+		<p>
 		[page:Object parameters] - (optional) object with properties defining the renderer's behaviour.
 			The constructor also accepts no parameters at all. In all cases, it will assume sane defaults
 			when parameters are missing. The following are valid parameters:<br /><br />
@@ -64,36 +64,36 @@
 		[page:Boolean logarithmicDepthBuffer] -  whether to use a logarithmic depth buffer. It may
 		be neccesary to use this if dealing with huge differences in scale in a single scene.
 		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean autoClear]</h3>
-		<div>Defines whether the renderer should automatically clear its output before rendering a frame.</div>
+		<p>Defines whether the renderer should automatically clear its output before rendering a frame.</p>
 
 
 		<h3>[property:Boolean autoClearColor]</h3>
-		<div>
+		<p>
 			If [page:.autoClear autoClear] is true, defines whether the renderer should clear the color buffer.
 			Default is *true*.
-		</div>
+		</p>
 
 
 		<h3>[property:Boolean autoClearDepth]</h3>
-		<div>
+		<p>
 			If [page:.autoClear autoClear] is true, defines whether the renderer should clear the depth buffer.
 			Default is *true*.
-		</div>
+		</p>
 
 
 		<h3>[property:Boolean autoClearStencil]</h3>
-		<div>
+		<p>
 			If [page:.autoClear autoClear] is true, defines whether the renderer should clear the stencil buffer.
 			Default is *true*.
-		</div>
+		</p>
 
 		<h3>[property:Object capabilities]</h3>
-		<div>
+		<p>
 		An object containing details about the capabilities of the current [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext RenderingContext].<br />
 
 		- [property:Boolean floatFragmentTextures]: whether the context supports the [link:https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float OES_texture_float] extension.
@@ -121,55 +121,55 @@
 		   The maximum number of uniforms that can be used in a vertex shader.<br />
 		- [property:String precision]: The shader precision currently being used by the renderer.<br />
 		- [property:Boolean vertexTextures]: *true* if [property:Integer maxVertexTextures] is greater than 0 (i.e. vertext textures can be used).<br />
-		</div>
+		</p>
 
 		<h3>[property:Array clippingPlanes]</h3>
-		<div>
+		<p>
 		User-defined clipping planes specified as THREE.Plane objects in world space.
 			These planes apply globally. Points in space whose dot product with the plane is negative are cut away.
 		 Default is [].
-		</div>
+		</p>
 
 		<h3>[property:WebGLRenderingContext context]</h3>
-		<div>
+		<p>
 		The renderer obtains a [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext RenderingContext] context
 		  from its [page:WebGLRenderer.domElement domElement] by default, using
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext HTMLCanvasElement.getContext]().<br /><br />
 
 		You can create this manually, however it must correspond to the
 		[page:WebGLRenderer.domElement domElement] in order to render to the screen.
-		</div>
+		</p>
 
 		<h3>[property:DOMElement domElement]</h3>
-		<div>
+		<p>
 		A [link:https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas canvas] where the renderer draws its output.<br />
 			This is automatically created by the renderer in the constructor (if not provided already);
 			you just need to add it to your page like so:<br />
 		<code>
 			document.body.appendChild( renderer.domElement );
 		</code>
-	  </div>
+	  </p>
 
 		<h3>[property:Object extensions]</h3>
-		<div>
+		<p>
 		A wrapper for the [page:WebGLRenderer.extensions.get .extensions.get] method, used to check whether
 		various WebGL extensions are supported.
-		</div>
+		</p>
 
 		<h3>[property:Float gammaFactor]</h3>
-		<div>Default is *2*. </div>
+		<p>Default is *2*. </p>
 
 
 		<h3>[property:Boolean gammaInput]</h3>
-		<div>If set, then it expects that all textures and colors are premultiplied gamma. Default is *false*.</div>
+		<p>If set, then it expects that all textures and colors are premultiplied gamma. Default is *false*.</p>
 
 
 		<h3>[property:Boolean gammaOutput]</h3>
-		<div>If set, then it expects that all textures and colors need to be outputted in premultiplied gamma. Default is *false*.</div>
+		<p>If set, then it expects that all textures and colors need to be outputted in premultiplied gamma. Default is *false*.</p>
 
 		<h3>[property:Object info]</h3>
-		<div>An object with a series of statistical information about the graphics board memory and the rendering process. Useful for debugging or just for the sake of curiosity. The object contains the following fields:</div>
-		<div>
+		<p>An object with a series of statistical information about the graphics board memory and the rendering process. Useful for debugging or just for the sake of curiosity. The object contains the following fields:</p>
+		<p>
 		<ul>
 			<li>memory:
 				<ul>
@@ -188,149 +188,149 @@
 			<li>programs
 			</li>
 		</ul>
-		</div>
-		<div>By default these data are reset at each render calls, but when using the composer or mirrors it can be preferred to reset them with a custom pattern :
+		</p>
+		<p>By default these data are reset at each render calls, but when using the composer or mirrors it can be preferred to reset them with a custom pattern :
 		<code>
 		renderer.info.autoReset = false;
 		renderer.info.reset();
 		</code>
-		</div>
+		</p>
 
 		<h3>[property:Boolean localClippingEnabled]</h3>
-		<div>Defines whether the renderer respects object-level clipping planes. Default is *false*.</div>
+		<p>Defines whether the renderer respects object-level clipping planes. Default is *false*.</p>
 
 		<h3>[property:Integer maxMorphTargets]</h3>
-		<div>
+		<p>
 		Default is 8. The maximum number of MorphTargets allowed in a shader.
 			Keep in mind that the standard materials only allow 8 MorphTargets.
-		</div>
+		</p>
 
 		<h3>[property:Integer maxMorphNormals]</h3>
-		<div>
+		<p>
 		Default is 4. The maximum number of MorphNormals allowed in a shader.
 			Keep in mind that the standard materials only allow 4 MorphNormals.
-		</div>
+		</p>
 
 		<h3>[property:Integer physicallyCorrectLights]</h3>
-		<div>
+		<p>
 		Whether to use physically correct lighting mode. Default is *false*.
 		See the [example:webgl_lights_physical lights / physical] example.
-		</div>
+		</p>
 
 		<h3>[property:Object properties]</h3>
-		<div>
+		<p>
 		Used internally by the renderer to keep track of various sub object properties.
-		</div>
+		</p>
 
 		<h3>[property:WebGLRenderLists renderLists]</h3>
-		<div>
+		<p>
 		Used internally to handle ordering of scene object rendering.
-		</div>
+		</p>
 
 		<h3>[property:WebGLShadowMap shadowMap]</h3>
-		<div>
+		<p>
 		This contains the reference to the shadow map, if used.
-		</div>
+		</p>
 
 		<h3>[property:Boolean shadowMap.enabled]</h3>
-		<div>If set, use shadow maps in the scene. Default is *false*.</div>
+		<p>If set, use shadow maps in the scene. Default is *false*.</p>
 
 		<h3>[property:Boolean shadowMap.autoUpdate]</h3>
-		<div>Enables automatic updates to the shadows in the scene. Default is *true*.</div>
-		<div>If you do not require dynamic lighting / shadows, you may set this to *false* when the renderer is instantiated.</div>
+		<p>Enables automatic updates to the shadows in the scene. Default is *true*.</p>
+		<p>If you do not require dynamic lighting / shadows, you may set this to *false* when the renderer is instantiated.</p>
 
 		<h3>[property:Boolean shadowMap.needsUpdate]</h3>
-		<div>When set to *true*, shadow maps in the scene will be updated in the next *render* call. Default is *false*. </div>
-		<div>If you have disabled automatic updates to shadow maps (*shadowMap.autoUpdate = false*), you will need to set this to *true* and then make a render call to update the shadows in your scene.</div>
+		<p>When set to *true*, shadow maps in the scene will be updated in the next *render* call. Default is *false*. </p>
+		<p>If you have disabled automatic updates to shadow maps (*shadowMap.autoUpdate = false*), you will need to set this to *true* and then make a render call to update the shadows in your scene.</p>
 
 		<h3>[property:Integer shadowMap.type]</h3>
-		<div>Defines shadow map type (unfiltered, percentage close filtering, percentage close filtering with bilinear filtering in shader)</div>
-		<div>Options are THREE.BasicShadowMap, THREE.PCFShadowMap (default), THREE.PCFSoftShadowMap. See [page:Renderer Renderer constants] for details.</div>
+		<p>Defines shadow map type (unfiltered, percentage close filtering, percentage close filtering with bilinear filtering in shader)</p>
+		<p>Options are THREE.BasicShadowMap, THREE.PCFShadowMap (default), THREE.PCFSoftShadowMap. See [page:Renderer Renderer constants] for details.</p>
 
 		<h3>[property:Boolean sortObjects]</h3>
-		<div>
+		<p>
 		Defines whether the renderer should sort objects. Default is *true*.<br /><br />
 
 		Note: Sorting is used to attempt to properly render objects that have some degree of transparency.
 		By definition, sorting objects may not work in all cases.  Depending on the needs of application,
 		it may be neccessary to turn off sorting and use other methods to deal with transparency
 		rendering e.g. manually determining each object's rendering order.
-		</div>
+		</p>
 
 		<h3>[property:Object state]</h3>
-		<div>
+		<p>
 		Contains functions for setting various properties of the [page:WebGLRenderer.context] state.
-		</div>
+		</p>
 
 		<h3>[property:Constant toneMapping]</h3>
-		<div>
+		<p>
 		Default is [page:Renderer LinearToneMapping]. See the [page:Renderer Renderer constants] for other choices.
-		</div>
+		</p>
 
 		<h3>[property:Number toneMappingExposure]</h3>
-		<div>
+		<p>
 		Exposure level of tone mapping. Default is *1*.
-		</div>
+		</p>
 
 		<h3>[property:Number toneMappingWhitePoint]</h3>
-		<div>
+		<p>
 		Tone mapping white point. Default is *1*.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:Integer allocTextureUnit]</h3>
-		<div>
+		<p>
 		Attempt to allocate a texture unit for use by a shader. Will warn if trying to allocate
 		more texture units than the GPU supports. This is mainly used internally.
 		See [page:WebGLRenderer.capabilities capabilities.maxTextures].
-		</div>
+		</p>
 
 		<h3>[method:null animate]( [param:Function callback] )</h3>
-		<div>[page:Function callback] — The function will be called every available frame. If `null` is passed it will stop any already ongoing animation.</div>
-		<div>A build in function that can be used instead of [link:https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame requestAnimationFrame]. For WebVR projects this function must be used.</div>
+		<p>[page:Function callback] — The function will be called every available frame. If `null` is passed it will stop any already ongoing animation.</p>
+		<p>A build in function that can be used instead of [link:https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame requestAnimationFrame]. For WebVR projects this function must be used.</p>
 
 		<h3>[method:null clear]( [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
-		<div>
+		<p>
 		Tells the renderer to clear its color, depth or stencil drawing buffer(s).
 			This method initializes the color buffer to the current clear color value.<br />
 		Arguments default to *true*.
-		</div>
+		</p>
 
 		<h3>[method:null clearColor]( )</h3>
-		<div>Clear the color buffer. Equivalent to calling [page:WebGLRenderer.clear .clear]( true, false, false ).</div>
+		<p>Clear the color buffer. Equivalent to calling [page:WebGLRenderer.clear .clear]( true, false, false ).</p>
 
 		<h3>[method:null clearDepth]( )</h3>
-		<div>Clear the depth buffer. Equivalent to calling [page:WebGLRenderer.clear .clear]( false, true, false ).</div>
+		<p>Clear the depth buffer. Equivalent to calling [page:WebGLRenderer.clear .clear]( false, true, false ).</p>
 
 		<h3>[method:null clearStencil]( )</h3>
-		<div>Clear the stencil buffers. Equivalent to calling [page:WebGLRenderer.clear .clear]( false, false, true ).</div>
+		<p>Clear the stencil buffers. Equivalent to calling [page:WebGLRenderer.clear .clear]( false, false, true ).</p>
 
 		<h3>[method:null clearTarget]([param:WebGLRenderTarget renderTarget], [param:boolean color], [param:boolean depth], [param:boolean stencil])</h3>
-		<div>
+		<p>
 		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be cleared.<br />
 		color -- If set, then the color gets cleared. <br />
 		depth -- If set, then the depth gets cleared. <br />
 		stencil -- If set, then the stencil gets cleared.
-		</div>
-		<div>
+		</p>
+		<p>
 		This method clears a rendertarget. To do this, it activates the rendertarget.
-		</div>
+		</p>
 
 		<h3>[method:null compile]( [param:Scene scene], [param:Camera camera] )</h3>
-		<div>Compiles all materials in the scene with the camera. This is useful to precompile shaders before the first rendering.</div>
+		<p>Compiles all materials in the scene with the camera. This is useful to precompile shaders before the first rendering.</p>
 
 		<h3>[method:null copyFramebufferToTexture]( [param:Vector2 position], [param:Texture texture], [param:Number level] )</h3>
-		<div>Copies pixels from the current WebGLFramebuffer into a 2D texture. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].</div>
+		<p>Copies pixels from the current WebGLFramebuffer into a 2D texture. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].</p>
 
 		<h3>[method:null copyTextureToTexture]( [param:Vector2 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
-		<div>Copies all pixels of a texture to an existing texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D WebGLRenderingContext.texSubImage2D].</div>
+		<p>Copies all pixels of a texture to an existing texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D WebGLRenderingContext.texSubImage2D].</p>
 
 		<h3>[method:null dispose]( )</h3>
-		<div>Dispose of the current rendering context.</div>
+		<p>Dispose of the current rendering context.</p>
 
 		<h3>[method:Object extensions.get]( [param:String extensionName] )</h3>
-		<div>
+		<p>
 		Used to check whether various extensions are supported and returns an object with details of the extension if available.
 		This method can check for the following extensions:<br /><br />
 
@@ -339,52 +339,52 @@
 		- *WEBGL_compressed_texture_s3tc*<br />
 		- *WEBGL_compressed_texture_pvrtc*<br />
 		- *WEBGL_compressed_texture_etc1*
-		</div>
+		</p>
 
 		<h3>[method:null forceContextLoss]( )</h3>
-		<div>
+		<p>
 		Simulate loss of the WebGL context. This requires support for the
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_lose_context WEBGL_lose_context] extensions.
 		According to [link:https://webglstats.com/ WebGLStats], as of February 2016 90% of WebGL enabled devices support this.
-		</div>
+		</p>
 
 		<h3>[method:Float getClearAlpha]()</h3>
-		<div>Returns a [page:Float float] with the current clear alpha. Ranges from 0 to 1.</div>
+		<p>Returns a [page:Float float] with the current clear alpha. Ranges from 0 to 1.</p>
 
 		<h3>[method:Color getClearColor]()</h3>
-		<div>Returns a [page:Color THREE.Color] instance with the current clear color.</div>
+		<p>Returns a [page:Color THREE.Color] instance with the current clear color.</p>
 
 		<h3>[method:WebGLRenderingContext getContext]()</h3>
-		<div>Return the current WebGL context.</div>
+		<p>Return the current WebGL context.</p>
 
 		<h3>[method:WebGLContextAttributes getContextAttributes]()</h3>
-		<div>Returns an object that describes the attributes set on the WebGL context when it was created.</div>
+		<p>Returns an object that describes the attributes set on the WebGL context when it was created.</p>
 
 		<h3>[method:RenderTarget getRenderTarget]()</h3>
-		<div>Returns the current RenderTarget, if any.</div>
+		<p>Returns the current RenderTarget, if any.</p>
 
 		<h3>[method:RenderTarget getCurrentViewport]()</h3>
-		<div>Returns the current viewport.</div>
+		<p>Returns the current viewport.</p>
 
 		<h3>[method:Object getDrawingBufferSize]()</h3>
-		<div>Returns an object containing the width and height of the renderer's drawing buffer, in pixels.</div>
+		<p>Returns an object containing the width and height of the renderer's drawing buffer, in pixels.</p>
 
 		<h3>[method:number getPixelRatio]()</h3>
-		<div>Returns current device pixel ratio used.</div>
+		<p>Returns current device pixel ratio used.</p>
 
 		<h3>[method:Object getSize]()</h3>
-		<div>Returns an object containing the width and height of the renderer's output canvas, in pixels.</div>
+		<p>Returns an object containing the width and height of the renderer's output canvas, in pixels.</p>
 
 		<h3>[method:null resetGLState]( )</h3>
-		<div>Reset the GL state to default. Called internally if the WebGL context is lost.</div>
+		<p>Reset the GL state to default. Called internally if the WebGL context is lost.</p>
 
 		<h3>[method:null readRenderTargetPixels]( [param:WebGLRenderTarget renderTarget], [param:Float x], [param:Float y], [param:Float width], [param:Float height], buffer )</h3>
-		<div>Reads the pixel data from the renderTarget into the buffer you pass in. This is a wrapper around [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels WebGLRenderingContext.readPixels]().<br />
+		<p>Reads the pixel data from the renderTarget into the buffer you pass in. This is a wrapper around [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels WebGLRenderingContext.readPixels]().<br />
 		See the [example:webgl_interactive_cubes_gpu interactive / cubes / gpu] example.
-		</div>
+		</p>
 
 		<h3>[method:null render]( [param:Scene scene], [param:Camera camera], [param:WebGLRenderTarget renderTarget], [param:Boolean forceClear] )</h3>
-		<div>
+		<p>
 			Render a [page:Scene scene] using a [page:Camera camera].<br />
 
 			The render is done to the [page:WebGLRenderTarget renderTarget] (if specified) or to the canvas as usual.<br />
@@ -394,54 +394,54 @@
 
 			Even with forceClear set to true you can prevent certain buffers being cleared by setting
 			either the [page:WebGLRenderer.autoClearColor autoClearColor], [page:WebGLRenderer.autoClearStencil autoClearStencil] or [page:WebGLRenderer.autoClearDepth autoClearDepth] properties to false.
-		</div>
+		</p>
 
 		<h3>[method:null renderBufferDirect]( [param:Camera camera], [param:Array lights], [param:Fog fog], [param:Material material], [param:Object geometryGroup], [param:Object3D object] )</h3>
-		<div>Render a buffer geometry group using the camera and with the specified material.</div>
+		<p>Render a buffer geometry group using the camera and with the specified material.</p>
 
 		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:shaderprogram program], [param:Material shading] )</h3>
-		<div>object - an instance of [page:Object3D]<br />
+		<p>object - an instance of [page:Object3D]<br />
 		program - an instance of shaderProgram<br />
 		shading - an instance of Material<br /><br />
 
 		Render an immediate buffer. Gets called by renderImmediateObject.
-		</div>
+		</p>
 
 		<h3>[method:null setClearAlpha]( [param:Float alpha] )</h3>
-		<div>Sets the clear alpha. Valid input is a float between *0.0* and *1.0*.</div>
+		<p>Sets the clear alpha. Valid input is a float between *0.0* and *1.0*.</p>
 
 		<h3>[method:null setClearColor]( [param:Color color], [param:Float alpha] )</h3>
-		<div>Sets the clear color and opacity.</div>
+		<p>Sets the clear color and opacity.</p>
 
 		<h3>[method:null setPixelRatio]( [param:number value] )</h3>
-		<div>Sets device pixel ratio. This is usually used for HiDPI device to prevent bluring output canvas.</div>
+		<p>Sets device pixel ratio. This is usually used for HiDPI device to prevent bluring output canvas.</p>
 
 		<h3>[method:null setRenderTarget]( [param:WebGLRenderTarget renderTarget] )</h3>
-		<div>
+		<p>
 		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be activated (optional).<br /><br />
 		This method sets the active rendertarget. If the parameter is omitted the canvas is set as the active rendertarget.
-		</div>
+		</p>
 
 		<h3>[method:null setScissor]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
-		<div>
+		<p>
 		Sets the scissor area from (x, y) to (x + width, y + height)
-		</div>
+		</p>
 
 		<h3>[method:null setScissorTest]( [param:Boolean boolean] )</h3>
-		<div>
+		<p>
 		Enable or disable the scissor test. When this is enabled, only the pixels within the defined
 			scissor area will be affected by further renderer actions.
-		</div>
+		</p>
 
 		<h3>[method:null setSize]( [param:Integer width], [param:Integer height], [param:Boolean updateStyle] )</h3>
-		<div>
+		<p>
 		Resizes the output canvas to (width, height) with device pixel ratio taken into account,
 			and also sets the viewport to fit that size, starting in (0, 0).
 			Setting [page:Boolean updateStyle] to false prevents any style changes to the output canvas.
-		</div>
+		</p>
 
 		<h3>[method:null setTexture2D]( [param:Texture texture], [param:number slot] )</h3>
-		<div>
+		<p>
 		texture -- The [page:Texture texture] that needs to be set.<br />
 		slot -- The number indicating which slot should be used by the texture.<br /><br />
 
@@ -449,19 +449,19 @@
 		The slot number can be found as a value of the uniform of the sampler.<br /><br />
 
 		Note: This method replaces the older [method:null setTexture] method.
-		</div>
+		</p>
 
 		<h3>[method:null setTextureCube]( [param:CubeTexture cubeTexture], [param:Number slot] )</h3>
-		<div>
+		<p>
 		texture -- The [page:CubeTexture cubeTexture] that needs to be set.<br />
 		slot -- The number indicating which slot should be used by the texture.<br /><br />
 
 		This method sets the correct texture to the correct slot for the WebGL shader.
 		The slot number can be found as a value of the uniform of the sampler.
-		</div>
+		</p>
 
 		<h3>[method:null setViewport]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
-		<div>Sets the viewport to render from (x, y) to (x + width, y + height).</div>
+		<p>Sets the viewport to render from (x, y) to (x + width, y + height).</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/renderers/shaders/ShaderChunk.html
+++ b/docs/api/renderers/shaders/ShaderChunk.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">Shader chunks for WebGL Shader library</div>
+		<p class="desc">Shader chunks for WebGL Shader library</p>
 
 
 

--- a/docs/api/renderers/shaders/ShaderLib.html
+++ b/docs/api/renderers/shaders/ShaderLib.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">Webgl Shader Library for three.js</div>
+		<p class="desc">Webgl Shader Library for three.js</p>
 
 
 		<h2>Properties</h2>

--- a/docs/api/renderers/shaders/UniformsLib.html
+++ b/docs/api/renderers/shaders/UniformsLib.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">Uniforms library for shared webgl shaders</div>
+		<p class="desc">Uniforms library for shared webgl shaders</p>
 
 
 

--- a/docs/api/renderers/shaders/UniformsUtils.html
+++ b/docs/api/renderers/shaders/UniformsUtils.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">Uniform Utilities. Support merging and cloning of uniform variables</div>
+		<p class="desc">Uniform Utilities. Support merging and cloning of uniform variables</p>
 
 		<h2>Properties</h2>
 

--- a/docs/api/scenes/Fog.html
+++ b/docs/api/scenes/Fog.html
@@ -10,38 +10,38 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">This class contains the parameters that define linear fog, i.e., that grows linearly denser with the distance.</div>
+		<p class="desc">This class contains the parameters that define linear fog, i.e., that grows linearly denser with the distance.</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Integer color], [param:Float near], [param:Float far] )</h3>
-		<div>The color parameter is passed to the [page:Color] constructor to set the color property. Color can be a hexadecimal integer or a CSS-style string.</div>
+		<p>The color parameter is passed to the [page:Color] constructor to set the color property. Color can be a hexadecimal integer or a CSS-style string.</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:String name]</h3>
-		<div>Optional name of the object (doesn't need to be unique). Default is an empty string.</div>
+		<p>Optional name of the object (doesn't need to be unique). Default is an empty string.</p>
 
 		<h3>[property:Color color]</h3>
-		<div>Fog color.  Example: If set to black, far away objects will be rendered black.</div>
+		<p>Fog color.  Example: If set to black, far away objects will be rendered black.</p>
 
 		<h3>[property:Float near]</h3>
-		<div>The minimum distance to start applying fog. Objects that are less than 'near' units from the active camera won't be affected by fog.</div>
-		<div>Default is 1.</div>
+		<p>The minimum distance to start applying fog. Objects that are less than 'near' units from the active camera won't be affected by fog.</p>
+		<p>Default is 1.</p>
 
 		<h3>[property:Float far]</h3>
-		<div>The maximum distance at which fog stops being calculated and applied. Objects that are more than 'far' units away from the active camera won't be affected by fog.</div>
-		<div>Default is 1000.</div>
+		<p>The maximum distance at which fog stops being calculated and applied. Objects that are more than 'far' units away from the active camera won't be affected by fog.</p>
+		<p>Default is 1000.</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:Fog clone]()</h3>
-		<div>Returns a new fog instance with the same parameters as this one.</div>
+		<p>Returns a new fog instance with the same parameters as this one.</p>
 
 		<h3>[method:Fog toJSON]()</h3>
-		<div>Return fog data in JSON format.</div>
+		<p>Return fog data in JSON format.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/scenes/FogExp2.html
+++ b/docs/api/scenes/FogExp2.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">This class contains the parameters that define exponential fog, i.e., that grows exponentially denser with the distance.</div>
+		<p class="desc">This class contains the parameters that define exponential fog, i.e., that grows exponentially denser with the distance.</p>
 
 
 		<h2>Constructor</h2>
@@ -18,26 +18,26 @@
 
 		<h3>[name]( [param:Integer color], [param:Float density] )</h3>
 
-		<div>The color parameter is passed to the [page:Color] constructor to set the color property. Color can be a hexadecimal integer or a CSS-style string.</div>
+		<p>The color parameter is passed to the [page:Color] constructor to set the color property. Color can be a hexadecimal integer or a CSS-style string.</p>
 		<h2>Properties</h2>
 
 		<h3>[property:String name]</h3>
-		<div>Optional name of the object (doesn't need to be unique). Default is an empty string.</div>
+		<p>Optional name of the object (doesn't need to be unique). Default is an empty string.</p>
 
 		<h3>[property:Color color]</h3>
-		<div>Fog color. Example: If set to black, far away objects will be rendered black.</div>
+		<p>Fog color. Example: If set to black, far away objects will be rendered black.</p>
 
 		<h3>[property:Float density]</h3>
-		<div>Defines how fast the fog will grow dense.</div>
-		<div>Default is 0.00025.</div>
+		<p>Defines how fast the fog will grow dense.</p>
+		<p>Default is 0.00025.</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:FogExp2 clone]()</h3>
-		<div>Returns a new FogExp2 instance with the same parameters as this one.</div>
+		<p>Returns a new FogExp2 instance with the same parameters as this one.</p>
 
 		<h3>[method:FogExp2 toJSON]()</h3>
-		<div>Return FogExp2 data in JSON format.</div>
+		<p>Return FogExp2 data in JSON format.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/scenes/Scene.html
+++ b/docs/api/scenes/Scene.html
@@ -11,45 +11,45 @@
 		[page:Object3D] &rarr;
 		<h1>[name]</h1>
 
-		<div class="desc">Scenes allow you to set up what and where is to be rendered by three.js. This is where you place objects, lights and cameras.</div>
+		<p class="desc">Scenes allow you to set up what and where is to be rendered by three.js. This is where you place objects, lights and cameras.</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]()</h3>
-		<div>
+		<p>
 		Create a new scene object.
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
 		<h3>[property:Fog fog]</h3>
 
-		<div>A [page:Fog fog] instance defining the type of fog that affects everything rendered in the scene. Default is null.</div>
+		<p>A [page:Fog fog] instance defining the type of fog that affects everything rendered in the scene. Default is null.</p>
 
 		<h3>[property:Material overrideMaterial]</h3>
 
-		<div>If not null, it will force everything in the scene to be rendered with that material. Default is null.</div>
+		<p>If not null, it will force everything in the scene to be rendered with that material. Default is null.</p>
 
 		<h3>[property:boolean autoUpdate]</h3>
-		<div>
+		<p>
 		Default is true. If set, then the renderer checks every frame if the scene and its objects needs matrix updates.
 		When it isn't, then you have to maintain all matrices in the scene yourself.
-		</div>
+		</p>
 
 		<h3>[property:Object background]</h3>
-		<div>
+		<p>
 		If not null, sets the background used when rendering the scene, and is always rendered first. Can be set to a [page:Color] which sets the clear color, a [page:Texture] covering the canvas, or a [page:CubeTexture]. Default is null.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:JSON toJSON]</h3>
-		<div>
+		<p>
 		Return the scene data in JSON format.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/textures/CanvasTexture.html
+++ b/docs/api/textures/CanvasTexture.html
@@ -12,16 +12,16 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		Creates a texture from a canvas element.<br /><br />
 
 		This is almost the same as the base [page:Texture Texture] class, except that it sets [page:Texture.needsUpdate needsUpdate] to *true* immediately.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 		<h3>[name]( [param:HTMLElement canvas], [param:Constant mapping], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Constant format], [param:Constant type], [param:Number anisotropy] )</h3>
-		<div>
+		<p>
 		[page:HTMLElement canvas] -- The HTML canvas element from which to load the texture. <br />
 
 		[page:Constant mapping] --  How the image is applied to the object. An object type of [page:Textures THREE.UVMapping].
@@ -48,26 +48,26 @@
 		[page:Number anisotropy] -- The number of samples taken along the axis through the pixel that has the highest density of texels.
 		By default, this value is 1. A higher value gives a less blurry result than a basic mipmap, at the cost of more texture samples being used.
 		Use [page:WebGLrenderer.getMaxAnisotropy renderer.getMaxAnisotropy]() to find the maximum valid anisotropy value for the GPU; this value is usually a power of 2.<br /><br />
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
-		<div>
+		<p>
     See the base [page:Texture Texture] class for common properties.
-    </div>
+    </p>
 
 		<h3>[property:boolean needsUpdate]</h3>
 
-		<div>
+		<p>
 			True by default. This is required so that the canvas data is loaded.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
-    <div>
+    <p>
     See the base [page:Texture Texture] class for common methods.
-    </div>
+    </p>
 
 
 		<h2>Source</h2>

--- a/docs/api/textures/CompressedTexture.html
+++ b/docs/api/textures/CompressedTexture.html
@@ -12,19 +12,19 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		Creates a texture based on data in compressed form, for example from a [link:https://en.wikipedia.org/wiki/DirectDraw_Surface DDS] file.<br /><br />
 
 
 		For use with the [page:CompressedTextureLoader CompressedTextureLoader].
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Array mipmaps], [param:Number width], [param:Number height], [param:Constant format], [param:Constant type], [param:Constant mapping], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Number anisotropy] )</h3>
-		<div>
+		<p>
 		[page:Array mipmaps] -- The mipmaps array should contain objects with data, width and height. The mipmaps should be of the correct format and type.<br />
 
 		[page:Number width] -- The width of the biggest mipmap.<br />
@@ -57,7 +57,7 @@
 		[page:Number anisotropy] -- The number of samples taken along the axis through the pixel that has the highest density of texels.
 		By default, this value is 1. A higher value gives a less blurry result than a basic mipmap, at the cost of more texture samples being used.
 		Use renderer.getMaxAnisotropy() to find the maximum valid anisotropy value for the GPU; this value is usually a power of 2.<br /><br />
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
@@ -66,15 +66,15 @@
 
 		<h3>[property:boolean flipY]</h3>
 
-		<div>
+		<p>
 			False by default. Flipping textures does not work for compressed textures.
-		</div>
+		</p>
 
 		<h3>[property:boolean generateMipmaps]</h3>
 
-		<div>
+		<p>
 			False by default. Mipmaps can't be generated for compressed textures
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>

--- a/docs/api/textures/CubeTexture.html
+++ b/docs/api/textures/CubeTexture.html
@@ -12,7 +12,7 @@
 		
 		<h1>[name]</h1>
 
-		<div class="desc">Creates a cube texture made up of six images.</div>
+		<p class="desc">Creates a cube texture made up of six images.</p>
 
 		<h2>Example</h2>
 
@@ -34,11 +34,11 @@
 
 		<h3>[name]( images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy )</h3>
 		
-		<div>
+		<p>
 		CubeTexture is almost equivalent in functionality and usage to [page:Texture]. The only differences are that the
 		images are an array of 6 images as opposed to a single image, and the mapping options are
 		[page:Textures THREE.CubeReflectionMapping] (default) or [page:Textures THREE.CubeRefractionMapping]
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>

--- a/docs/api/textures/DataTexture.html
+++ b/docs/api/textures/DataTexture.html
@@ -12,17 +12,17 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">Creates a texture directly from raw data, width and height.</div>
+		<p class="desc">Creates a texture directly from raw data, width and height.</p>
 
 
 		<h2>Constructor</h2>
 
 		<h3>[name]( data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy )</h3>
-		<div>
+		<p>
 			The data argument must be an ArrayBuffer or a typed array view.
 			Further parameters correspond to the properties inherited from [page:Texture], where both magFilter and minFilter default to THREE.NearestFilter. The properties flipY and generateMipmaps are intially set to false.
-		</div>
-		<div>
+		</p>
+		<p>
 			The interpretation of the data depends on type and format:
 			If the type is THREE.UnsignedByteType, a Uint8Array will be useful for addressing the texel data.
 			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity). Similarly, THREE.RGBFormat specifies a format where only three values are used for each texel.<br />
@@ -30,7 +30,7 @@
 			For the packed types, THREE.UnsignedShort4444Type, THREE.UnsignedShort5551Type or THREE.UnsignedShort565Type, all color components of one texel can be addressed as bitfields within an integer element of a Uint16Array.<br />
 
 			In order to use the types THREE.FloatType and THREE.HalfFloatType, the WebGL implementation must support the respective extensions OES_texture_float and OES_texture_half_float. In order to use THREE.LinearFilter for component-wise, bilinear interpolation of the texels based on these types, the WebGL extensions OES_texture_float_linear or OES_texture_half_float_linear must also be present.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -62,9 +62,9 @@
 		<h2>Properties</h2>
 
 		<h3>[property:Image image]</h3>
-		<div>
+		<p>
 		Overridden with a record type holding data, width and height.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 

--- a/docs/api/textures/DepthTexture.html
+++ b/docs/api/textures/DepthTexture.html
@@ -12,32 +12,30 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		Creates a texture for use as a Depth Texture. Require support for the
-    [link:https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/ WEBGL_depth_texture] extension.
-    <br /><br />
+	[link:https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/ WEBGL_depth_texture] extension.
+		</p>
 
-			</div>
+		<h2>Example</h2>
 
-    <h2>Example</h2>
-
-    [example:webgl_depth_texture depth / texture]
+		[example:webgl_depth_texture depth / texture]
 
 		<h2>Constructor</h2>
 		<h3>[name]( [param:Number width], [param:Number height], [param:Constant type], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Number anisotropy], [param:Constant format] )</h3>
 
-    <div>
+		<p>
 		[page:Number width] -- width of the texture.<br />
 
 		[page:Number height] -- height of the texture.<br />
 
-    [page:Constant type] -- Default is [page:Textures THREE.UnsignedShortType].
-     See [page:Textures type constants] for other choices.<br />
+		[page:Constant type] -- Default is [page:Textures THREE.UnsignedShortType].
+		See [page:Textures type constants] for other choices.<br />
 
-    [page:Constant mapping] --
-    See [page:Textures type constants] for details.<br />
+		[page:Constant mapping] --
+		See [page:Textures type constants] for details.<br />
 
-    [page:Constant wrapS] -- The default is [page:Textures THREE.ClampToEdgeWrapping].
+		[page:Constant wrapS] -- The default is [page:Textures THREE.ClampToEdgeWrapping].
 		See [page:Textures wrap mode constants] for other choices.<br />
 
 		[page:Constant wrapT] -- The default is [page:Textures THREE.ClampToEdgeWrapping].
@@ -47,66 +45,65 @@
 		The default is [page:Textures THREE.NearestFilter]. See [page:Textures magnification filter constants] for other choices.<br />
 
 		[page:Constant minFilter] -- How the texture is sampled when a texel covers less than one pixel.
-		 The default is [page:Textures THREE.NearestFilter]. See [page:Textures minification filter constants] for other choices.<br />
+		The default is [page:Textures THREE.NearestFilter]. See [page:Textures minification filter constants] for other choices.<br />
 
-     [page:Number anisotropy] -- The number of samples taken along the axis through the pixel that has the highest density of texels.
-     By default, this value is 1. A higher value gives a less blurry result than a basic mipmap, at the cost of more texture samples being used.
-     Use [page:WebGLrenderer.getMaxAnisotropy renderer.getMaxAnisotropy]() to find the maximum valid anisotropy value for the GPU; this value is usually a power of 2.<br />
+		[page:Number anisotropy] -- The number of samples taken along the axis through the pixel that has the highest density of texels.
+		By default, this value is 1. A higher value gives a less blurry result than a basic mipmap, at the cost of more texture samples being used.
+		Use [page:WebGLrenderer.getMaxAnisotropy renderer.getMaxAnisotropy]() to find the maximum valid anisotropy value for the GPU; this value is usually a power of 2.<br />
 
-    [page:Constant format] -- must be either [page:Textures DepthFormat] (default) or [page:Textures DepthStencilFormat].
-     See [page:Textures format constants] for details.<br />
-
-		</div>
+		[page:Constant format] -- must be either [page:Textures DepthFormat] (default) or [page:Textures DepthStencilFormat].
+		See [page:Textures format constants] for details.<br />
+		</p>
 
 
 		<h2>Properties</h2>
 
-		<div>
-    See the base [page:Texture Texture] class for common properties
-    - the following are also part of the texture class, but have different defaults here.
-    </div>
+		<p>
+		See the base [page:Texture Texture] class for common properties
+		- the following are also part of the texture class, but have different defaults here.
+		</p>
 
 		<h3>[page:Texture.format .format]</h3>
-		<div>
-    Either [page:Textures DepthFormat] (default) or [page:Textures DepthStencilFormat].
-    See [page:Textures format constants] for details.<br />
-		</div>
+		<p>
+		Either [page:Textures DepthFormat] (default) or [page:Textures DepthStencilFormat].
+		See [page:Textures format constants] for details.<br />
+		</p>
 
-    <h3>[page:Texture.type .type]</h3>
-    <div>
-    Default is [page:Textures THREE.UnsignedShortType].
-    See [page:Textures format constants] for details.<br />
-    </div>
+		<h3>[page:Texture.type .type]</h3>
+		<p>
+		Default is [page:Textures THREE.UnsignedShortType].
+		See [page:Textures format constants] for details.<br />
+		</p>
 
-    <h3>[page:Texture.magFilter .magFilter]</h3>
-    <div>
-      How the texture is sampled when a texel covers more than one pixel.
-  		The default is [page:Textures THREE.NearestFilter].
-      See [page:Textures magnification filter constants] for other choices.
-    </div>
+		<h3>[page:Texture.magFilter .magFilter]</h3>
+		<p>
+		  How the texture is sampled when a texel covers more than one pixel.
+			The default is [page:Textures THREE.NearestFilter].
+		  See [page:Textures magnification filter constants] for other choices.
+		</p>
 
-    <h3>[page:Texture.minFilter .minFilter]</h3>
-    <div>
-    How the texture is sampled when a texel covers less than one pixel.
-  	The default is [page:Textures THREE.NearestFilter].
-    See [page:Textures magnification filter constants] for other choices.
-    </div>
+		<h3>[page:Texture.minFilter .minFilter]</h3>
+		<p>
+		How the texture is sampled when a texel covers less than one pixel.
+		The default is [page:Textures THREE.NearestFilter].
+		See [page:Textures magnification filter constants] for other choices.
+		</p>
 
-    <h3>[page:Texture.flipY .flipY]</h3>
-    <div>
-    Depth textures do not need to be flipped so this is *false* by default.
-    </div>
+		<h3>[page:Texture.flipY .flipY]</h3>
+		<p>
+		Depth textures do not need to be flipped so this is *false* by default.
+		</p>
 
-    <h3>[page:Texture.generateMipmaps .generateMipmaps]</h3>
-    <div>
-    Depth textures do not use mipmaps.
-    </div>
+		<h3>[page:Texture.generateMipmaps .generateMipmaps]</h3>
+		<p>
+		Depth textures do not use mipmaps.
+		</p>
 
 		<h2>Methods</h2>
 
-    <div>
-    See the base [page:Texture Texture] class for common methods.
-    </div>
+		<p>
+		See the base [page:Texture Texture] class for common methods.
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/textures/Texture.html
+++ b/docs/api/textures/Texture.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">Create a texture to apply to a surface or as a reflection or refraction map.</div>
+		<p class="desc">Create a texture to apply to a surface or as a reflection or refraction map.</p>
 
 
 		<h2>Constructor</h2>
@@ -30,54 +30,54 @@
 		<h2>Properties</h2>
 
 		<h3>[property:Integer id]</h3>
-		<div>
+		<p>
 		Readonly - unique number for this texture instance.
-		</div>
+		</p>
 
 		<h3>[property:String uuid]</h3>
-		<div>
+		<p>
 		[link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID] of this object instance.
 		This gets automatically assigned, so this shouldn't be edited.
-		</div>
+		</p>
 
 		<h3>[property:String name]</h3>
-		<div>
+		<p>
 		Optional name of the object (doesn't need to be unique). Default is an empty string.
-		</div>
+		</p>
 
 		<h3>[property:Image image]</h3>
-		<div>
+		<p>
 		An image object, typically created using the [page:TextureLoader.load] method.
 		This can be any image (e.g., PNG, JPG, GIF, DDS) or video (e.g., MP4, OGG/OGV) type supported by three.js.<br /><br />
 
 		To use video as a texture you need to have a playing HTML5
 		video element as a source for your texture image and continuously update this texture
 		as long as video is playing - the [page:VideoTexture VideoTexture] class handles this automatically.
-		</div>
+		</p>
 
 		<h3>[property:array mipmaps]</h3>
-		<div>
+		<p>
 		Array of user-specified mipmaps (optional).
-		</div>
+		</p>
 
 		<h3>[property:object mapping]</h3>
-		<div>
+		<p>
 		How the image is applied to the object. An object type of [page:Textures THREE.UVMapping] is the default,
 		where the U,V coordinates are used to apply the map.<br />
 
 		See the [page:Textures texture constants] page for other mapping types.
-		</div>
+		</p>
 
 		<h3>[property:number wrapS]</h3>
-		<div>
+		<p>
 		This defines how the texture is wrapped horizontally and corresponds to *U* in UV mapping.<br />
 		The default is [page:Textures THREE.ClampToEdgeWrapping], where the edge is clamped to the outer edge texels.
 		The other two choices are [page:Textures THREE.RepeatWrapping] and [page:Textures THREE.MirroredRepeatWrapping].
 		See the [page:Textures texture constants] page for details.
-		</div>
+		</p>
 
 		<h3>[property:number wrapT]</h3>
-		<div>
+		<p>
 		This defines how the texture is wrapped vertically and corresponds to *V* in UV mapping.<br />
 		The same choices are available as for [property:number wrapS].<br /><br />
 
@@ -85,59 +85,59 @@
 		 (2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...) in terms of pixels.
 		 Individual dimensions need not be equal, but each must be a power of two.
 		 This is a limitation of WebGL, not three.js.
-		</div>
+		</p>
 
 		<h3>[property:number magFilter]</h3>
-		<div>
+		<p>
 		How the texture is sampled when a texel covers more than one pixel. The default is
 		 [page:Textures THREE.LinearFilter], which takes the four closest texels and bilinearly interpolates among them.
 		 The other option is [page:Textures THREE.NearestFilter], which uses the value of the closest texel.<br />
 		 See the [page:Textures texture constants] page for details.
-		</div>
+		</p>
 
 		<h3>[property:number minFilter]</h3>
-		<div>
+		<p>
 		How the texture is sampled when a texel covers less than one pixel. The default is
 		[page:Textures THREE.LinearMipMapLinearFilter], which uses mipmapping and a trilinear filter. <br /><br />
 
 		See the [page:Textures texture constants] page for all possible choices.
-		</div>
+		</p>
 
 		<h3>[property:number anisotropy]</h3>
-		<div>
+		<p>
 		The number of samples taken along the axis through the pixel that has the highest density of texels.
 		By default, this value is 1. A higher value gives a less blurry result than a basic mipmap,
 		at the cost of more texture samples being used. Use [page:WebGLRenderer.getMaxAnisotropy renderer.getMaxAnisotropy]() to
 		find the maximum valid anisotropy value for the GPU; this value is usually a power of 2.
-		</div>
+		</p>
 
 		<h3>[property:number format]</h3>
-		<div>
+		<p>
 		The default is [page:Textures THREE.RGBAFormat], although the [page:TextureLoader TextureLoader] will automatically
 		set this to [page:Textures THREE.RGBFormat] for JPG images. <br /><br />
 
 		See the [page:Textures texture constants] page for details of other formats.
-		</div>
+		</p>
 
 		<h3>[property:number type]</h3>
-		<div>
+		<p>
 		This must correspond to the [page:Texture.format .format]. The default is [page:Textures THREE.UnsignedByteType],
 		which will be used for most texture formats.<br /><br />
 
 		See the [page:Textures texture constants] page for details of other formats.
-		</div>
+		</p>
 
 		<h3>[property:Vector2 offset]</h3>
-		<div>
+		<p>
 		How much a single repetition of the texture is offset from the beginning, in each direction U and V.
 		Typical range is *0.0* to *1.0*.  _Note:_ The offset property is a convenience modifier and only affects
 		the Texture's application to the first set of UVs on a model.  If the Texture is used as a map requiring
 		additional UV sets (e.g. the aoMap or lightMap of most stock materials), those UVs must be manually
 		assigned to achieve the desired offset.
-		</div>
+		</p>
 
 		<h3>[property:Vector2 repeat]</h3>
-		<div>
+		<p>
 		How many times the texture is repeated across the surface, in each direction U and V.  If repeat is set
 		greater than 1 in either direction, the corresponding Wrap parameter should also be set to
 		[page:Textures THREE.RepeatWrapping] or [page:Textures THREE.MirroredRepeatWrapping] to achieve the desired
@@ -145,83 +145,83 @@
 		the Texture's application to the first set of UVs on a model.  If the Texture is used as a map requiring
 		additional UV sets (e.g. the aoMap or lightMap of most stock materials), those UVs must be manually
 		assigned to achieve the desired repetiton.
-		</div>
+		</p>
 
 		<h3>[property:number rotation]</h3>
-		<div>
+		<p>
 		How much the texture is rotated around the center point, in radians. Postive values are counter-clockwise. Default is *0*.
-		</div>
+		</p>
 
 		<h3>[property:Vector2 center]</h3>
-		<div>
+		<p>
 		Indicates where the center of rotation is. To rotate around the center point set this value to (0.5, 0.5). Default value is (0.0, 0.0).
-		</div>
+		</p>
 
 		<h3>[property:boolean matrixAutoUpdate]</h3>
-		<div>
+		<p>
 		Whether to update the texture's uv-transform [property:Matrix3 matrix] based on the [property:Vector2 offset],
 		[property:Vector2 repeat], and [property:number rotation] settings. True by default.
 		Set this to false if you are specifying the uv-transform matrix directly.
-		</div>
+		</p>
 
 		<h3>[property:Matrix3 matrix]</h3>
-		<div>
+		<p>
 		The uv-transform matrix for the texture. Updated by the renderer from the texture properties [property:Vector2 offset], [property:Vector2 repeat],
 		and [property:number rotation] when the texture's [property:boolean matrixAutoUpdate] property is true.
 		When [property:boolean matrixAutoUpdate] property is false, this matrix may be set manually.
 		Default is the identity matrix.
-		</div>
+		</p>
 
 		<h3>[property:boolean generateMipmaps]</h3>
-		<div>
+		<p>
 		Whether to generate mipmaps (if possible) for a texture. True by default. Set this to false if you are
 		creating mipmaps manually.
-		</div>
+		</p>
 
 		<h3>[property:boolean premultiplyAlpha]</h3>
-		<div>
+		<p>
 		False by default, which is the norm for PNG images. Set to true if the RGB values have
 		been stored premultiplied by alpha.
-		</div>
+		</p>
 
 		<h3>[property:boolean flipY]</h3>
-		<div>
+		<p>
 		True by default. Flips the image's Y axis to match the WebGL texture coordinate space.
-		</div>
+		</p>
 
 		<h3>[property:number unpackAlignment]</h3>
-		<div>
+		<p>
 		4 by default. Specifies the alignment requirements for the start of each pixel row in memory.
 		The allowable values are 1 (byte-alignment), 2 (rows aligned to even-numbered bytes),
 		4 (word-alignment), and 8 (rows start on double-word boundaries).
 		See [link:http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml glPixelStorei]
 		for more information.
-		</div>
+		</p>
 
 		<h3>[property:number encoding]</h3>
-		<div>
+		<p>
 		[page:Textures THREE.LinearEncoding] is the default.
 		See the [page:Textures texture constants] page for details of other formats.<br /><br />
 
 		Note that if this value is changed on a texture after the material has been used,
 		it is necessary to trigger a Material.needsUpdate for this value to be realized in the shader.
-		</div>
+		</p>
 
 		<h3>[property:Integer version]</h3>
-		<div>
+		<p>
 		This starts at *0* and counts how many times [property:Boolean needsUpdate] is set to *true*.
-		</div>
+		</p>
 
 		<h3>[property:Function onUpdate]</h3>
-		<div>
+		<p>
 		A callback function, called when the texture is updated (e.g., when needsUpdate has been set to true
 		and then the texture is used).
-		</div>
+		</p>
 
 		<h3>[property:Boolean needsUpdate]</h3>
-		<div>
+		<p>
 		Set this to *true* to trigger an update next time the texture is used. Particularly important for setting the wrap mode.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
@@ -229,26 +229,26 @@
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
 
 		<h3>[method:Texture clone]( [param:Texture texture] )</h3>
-		<div>
+		<p>
 		Make copy of the texture. Note this is not a "deep copy", the image is shared.
-		</div>
+		</p>
 
 		<h3>[method:Texture toJSON]( meta )</h3>
-		<div>
+		<p>
 		meta -- optional object containing metadata.<br />
 		Convert the material to three.js JSON format.
-		</div>
+		</p>
 
 		<h3>[method:null dispose]()</h3>
-		<div>
+		<p>
 		Call [page:EventDispatcher EventDispatcher].dispatchEvent with a 'dispose' event type.
-		</div>
+		</p>
 
 		<h3>[method:null transformUv]( uv )</h3>
-		<div>
+		<p>
 		Transform the uv based on the value of this texture's [page:Texture.repeat .repeat], [page:Texture.offset .offset],
 		[page:Texture.wrapS .wrapS], [page:Texture.wrapT .wrapT] and [page:Texture.flipY .flipY] properties.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/textures/VideoTexture.html
+++ b/docs/api/textures/VideoTexture.html
@@ -12,15 +12,15 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		Creates a texture for use with a video texture.<br /><br />
 
 		This is almost the same as the base [page:Texture Texture] class, except that it continuosly sets [page:Texture.needsUpdate needsUpdate] to *true* so that the texture is updated as the video plays. Automatic creation of [page:Texture.mipmaps mipmaps] is also disabled.
-		</div>
+		</p>
 
     <h2>Example</h2>
 
-		<div>[example:webgl_materials_video materials / video ]</div>
+		<p>[example:webgl_materials_video materials / video ]</p>
 
 		<code>
 //assuming you have created a HTML video element with id="video"
@@ -35,7 +35,7 @@ texture.format = THREE.RGBFormat;
 
 		<h2>Constructor</h2>
 		<h3>[name]( [param:Video video], [param:Constant mapping], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Constant format], [param:Constant type], [param:Number anisotropy] )</h3>
-		<div>
+		<p>
 		[page:Video video] -- The video element to use as the texture. <br />
 
 		[page:Constant mapping] --  How the image is applied to the object. An object type of [page:Textures THREE.UVMapping].
@@ -62,31 +62,31 @@ texture.format = THREE.RGBFormat;
 		[page:Number anisotropy] -- The number of samples taken along the axis through the pixel that has the highest density of texels.
 		By default, this value is 1. A higher value gives a less blurry result than a basic mipmap, at the cost of more texture samples being used.
 		Use [page:WebGLrenderer.getMaxAnisotropy renderer.getMaxAnisotropy]() to find the maximum valid anisotropy value for the GPU; this value is usually a power of 2.<br /><br />
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
-		<div>
+		<p>
     See the base [page:Texture Texture] class for common properties.
-    </div>
+    </p>
 
 		<h3>[property:boolean needsUpdate]</h3>
-		<div>
+		<p>
 		You will not need to set this manually here as it is handled by the [page:VideoTexture.update update] method.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
-    <div>
+    <p>
     See the base [page:Texture Texture] class for common methods.
-    </div>
+    </p>
 
     <h3>[method:null update]()</h3>
-		<div>
+		<p>
 		This is called automatically and sets [property:boolean needsUpdate] to *true* every time
     a new frame is available.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/examples/BufferGeometryUtils.html
+++ b/docs/examples/BufferGeometryUtils.html
@@ -10,39 +10,39 @@
   <body>
     <h1>[name]</h1>
 
-    <div class="desc">
+    <p class="desc">
     A class containing utility functions for [page:BufferGeometry BufferGeometry] instances.<br /><br />
-    </div>
+    </p>
 
 
     <h2>Methods</h2>
 
     <h3>[method:null computeTangents]( [param:BufferGeometry geometry] )</h3>
-    <div>
+    <p>
     geometry -- A [page:BufferGeometry BufferGeometry] instance, which must have index, position, normal, and uv attributes.<br /><br />
 
     Calculates and adds tangent attribute to a geometry.<br /><br />
 
-    </div>
+    </p>
 
     <h3>[method:BufferGeometry mergeBufferGeometries]( [param:Array geometries] )</h3>
-    <div>
+    <p>
     geometries -- Array of [page:BufferGeometry BufferGeometry] instances.<br /><br />
 
     Merges a set of geometries into a single instance. All geometries must have compatible attributes.
     If merge does not succeed, the method returns null.<br /><br />
 
-    </div>
+    </p>
 
     <h3>[method:BufferAttribute mergeBufferAttributes]( [param:Array attributes] )</h3>
-    <div>
+    <p>
     attributes -- Array of [page:BufferAttribute BufferAttribute] instances.<br /><br />
 
     Merges a set of attributes into a single instance. All attributes must have compatible properties
     and types, and [page:InterleavedBufferAttribute InterleavedBufferAttributes] are not supported. If merge does not succeed, the method
     returns null.
 
-    </div>
+    </p>
 
     <h2>Source</h2>
 

--- a/docs/examples/Lut.html
+++ b/docs/examples/Lut.html
@@ -10,9 +10,9 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		Represents a lookup table for colormaps. It is used to determine the color values from a range of data values.
-		</div>
+		</p>
 
 
 		<h2>Example</h2>
@@ -25,58 +25,58 @@
 
 
 		<h3>[name]( colormap, numberOfColors )</h3>
-                <div>
-                colormap - optional argument that sets a colormap from predefined colormaps. Available colormaps are : "rainbow", "cooltowarm", "blackbody".
-                numberOfColors - optional argument that sets the number of colors used to represent the data array.
-		</div>
+		<p>
+		colormap - optional argument that sets a colormap from predefined colormaps. Available colormaps are : "rainbow", "cooltowarm", "blackbody".
+		numberOfColors - optional argument that sets the number of colors used to represent the data array.
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Float minV]</h3>
-		<div>
+		<p>
 		The minimum value to be represented with the lookup table. Default is 0.
-		</div>
+		</p>
 
 		<h3>[property:Float maxV]</h3>
-		<div>
+		<p>
 		The maximum value to be represented with the lookup table. Default is 1.
-		</div>
+		</p>
 
 		<h3>.[legend]</h3>
-		<div>
+		<p>
 		The legend of the lookup table.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:null copy]( [param:Lut lut] ) [param:Lut this]</h3>
-		<div>
+		<p>
 		color — Lut to copy.
-		</div>
-		<div>
+		</p>
+		<p>
 		Copies given lut.
-		</div>
+		</p>
 
 		<h3>.setLegendOn [parameters]</h3>
-		<div>
+		<p>
 		parameters - { layout: value, position: { x: value, y: value, z: value }, dimensions: { width: value, height: value } }
 		layout — Horizontal or vertical layout. Default is vertical.<br />
 		position — The position x,y,z of the legend.<br />
 		dimensions — The dimensions (width and height) of the legend.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Sets this Lut with the legend on.
-		</div>
+		</p>
 
 		<h3>.setLegendOff</h3>
-		<div>
-		</div>
-		<div>
+		<p>
+		</p>
+		<p>
 		Sets this Lut with the legend off.
-		</div>
+		</p>
 
     <h3>.setLegendLabels [parameters, callback]</h3>
-		<div>
+		<p>
 		parameters - { fontsize: value, fontface: value, title: value, um: value, ticks: value, decimal: value, notation: value }
 		fontsize — Font size to be used for labels.<br />
 		fontface — Font type to be used for labels.<br />
@@ -86,55 +86,55 @@
 		decimal — The number of decimals to be used for legend values.<br />
 		notation — Legend notation: standard (default) or scientific.<br />
 		callback — An optional callback to be used to format the legend labels.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Sets the labels of the legend of this Lut.
-		</div>
+		</p>
 
 		<h3>[method:Lut setminV]( [param:Float minV] )</h3>
-		<div>
+		<p>
 		minV — The minimum value to be represented with the lookup table.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Sets this Lut with the minimum value to be represented.
-		</div>
+		</p>
 
 		<h3>[method:Lut setmaxV]( [param:Float maxV] )</h3>
-		<div>
+		<p>
 		maxV — The maximum value to be represented with the lookup table.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Sets this Lut with the maximum value to be represented.
-		</div>
+		</p>
 
 		<h3>[method:Lut changeNumberOfColors]( [param:Float numberOfColors] )</h3>
-		<div>
+		<p>
 		numberOfColors — The number of colors to be used to represent the data array.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Sets this Lut with the number of colors to be used.
-                </div>
+		</p>
 
 		<h3>[method:Lut changeColorMap]( [param:Float colorMap] )</h3>
-		<div>
+		<p>
 		colorMap — The name of the color map to be used to represent the data array.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Sets this Lut with the colormap to be used.
-		</div>
+		</p>
 
 		<h3>[method:Lut addColorMap]( colorMapName, arrayOfColors )</h3>
-		<div>
+		<p>
 		Insert a new color map into the set of available color maps.
-		</div>
+		</p>
 
 		<h3>[method:Lut getColor]( value ) [param:Lut this]</h3>
-		<div>
+		<p>
 		value -- the data value to be displayed as a color.
-		</div>
-		<div>
+		</p>
+		<p>
 		Returns a [page:Color].
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/SpriteCanvasMaterial.html
+++ b/docs/examples/SpriteCanvasMaterial.html
@@ -12,20 +12,20 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">Create a material that can draw custom sprites using a 2d canvas.</div>
+		<p class="desc">Create a material that can draw custom sprites using a 2d canvas.</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Object parameters] )</h3>
-		<div>
+		<p>
 		parameters is an object that can be used to set up the default properties
-		</div>
-		<div>
+		</p>
+		<p>
 		color - the color of the sprite<br/>
 		program - the program used to draw the sprite
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
@@ -33,22 +33,22 @@
 
 
 		<h3>[property:Color color]</h3>
-		<div>
+		<p>
 		The color of the sprite. The material will set up the color for the context before calling the material's program.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 
 
 		<h3>[method:null program]([param:CanvasRenderingContext2D context], [param:Color color])</h3>
-		<div>
+		<p>
 		context -- The canvas context <br />
 		color -- The color of the sprite
-		</div>
-		<div>
+		</p>
+		<p>
 			Define a program that will use the context to draw the sprite.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -10,18 +10,18 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
-      Orbit controls allow the camera to orbit around a target.<br>
+		<p class="desc">
+		Orbit controls allow the camera to orbit around a target.<br>
 
-      To use this, as with all files in the /examples directory, you will have to
-      include the file seperately in your HTML.
+		To use this, as with all files in the /examples directory, you will have to
+		include the file seperately in your HTML.
 
-		</div>
+		</p>
 
 
 		<h2>Example</h2>
 
-		<div>[example:misc_controls_orbit misc / controls / orbit ]</div>
+		<p>[example:misc_controls_orbit misc / controls / orbit ]</p>
 
 		<code>
 var renderer = new THREE.WebGLRenderer();
@@ -40,12 +40,12 @@ controls.update();
 
 function animate() {
 
-  requestAnimationFrame( animate );
+	requestAnimationFrame( animate );
 
-  // required if controls.enableDamping or controls.autoRotate are set to true
-  controls.update();
+	// required if controls.enableDamping or controls.autoRotate are set to true
+	controls.update();
 
-  renderer.render( scene, camera );
+	renderer.render( scene, camera );
 
 }
 		</code>
@@ -53,231 +53,231 @@ function animate() {
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Camera object], [param:HTMLDOMElement domElement] )</h3>
-		<div>
-      [page:Camera object]: (required) The camera to be controlled.<br><br>
+		<p>
+			[page:Camera object]: (required) The camera to be controlled.<br><br>
 
-      [page:HTMLDOMElement domElement]: (optional) The HTML element used for event listeners. By default this is the whole document,
-      however if you only want to the controls to work over a specific element (e.g. the canvas) you can specify that here.
-		</div>
+			[page:HTMLDOMElement domElement]: (optional) The HTML element used for event listeners. By default this is the whole document,
+			however if you only want to the controls to work over a specific element (e.g. the canvas) you can specify that here.
+		</p>
 
 
-    <h2>Properties</h2>
+		<h2>Properties</h2>
 
-    <h3>[property:Boolean autoRotate]</h3>
-    <div>
-      Set to true to automatically rotate around the target.<br> Note that if this is enabled, you must call [page:.update]
-      () in your animation loop.
-    </div>
+		<h3>[property:Boolean autoRotate]</h3>
+		<p>
+			Set to true to automatically rotate around the target.<br> Note that if this is enabled, you must call [page:.update]
+			() in your animation loop.
+		</p>
 
-    <h3>[property:Float autoRotateSpeed]</h3>
-    <div>
-      How fast to rotate around the target if [property:Boolean autoRotate] is true. Default is 2.0, which equates to 30 seconds
-      per rotation at 60fps.<br> Note that if [property:Boolean autoRotate] is enabled, you must call [page:.update]
-      () in your animation loop.
-    </div>
+		<h3>[property:Float autoRotateSpeed]</h3>
+		<p>
+			How fast to rotate around the target if [property:Boolean autoRotate] is true. Default is 2.0, which equates to 30 seconds
+			per rotation at 60fps.<br> Note that if [property:Boolean autoRotate] is enabled, you must call [page:.update]
+			() in your animation loop.
+		</p>
 
-    <h3>
-      [property:Float dampingFactor]</h3>
-    <div>
-      The damping inertia used if [property:Boolean enableDamping] is set to true.<br> Note that for this to work, you must
-      call [page:.update] () in your animation loop.
-    </div>
+		<h3>
+			[property:Float dampingFactor]</h3>
+		<p>
+			The damping inertia used if [property:Boolean enableDamping] is set to true.<br> Note that for this to work, you must
+			call [page:.update] () in your animation loop.
+		</p>
 
-    <h3>[property:HTMLDOMElement domElement]</h3>
-    <div>
-      The HTMLDOMElement used to listen for mouse / touch events. This must be passed in the constructor; changing it here will
-      not set up new event listeners. Default is the whole document.
-    </div>
+		<h3>[property:HTMLDOMElement domElement]</h3>
+		<p>
+			The HTMLDOMElement used to listen for mouse / touch events. This must be passed in the constructor; changing it here will
+			not set up new event listeners. Default is the whole document.
+		</p>
 
-    <h3>[property:Boolean enabled]</h3>
-    <div>
-      Whether or not the controls are enabled.
-    </div>
+		<h3>[property:Boolean enabled]</h3>
+		<p>
+			Whether or not the controls are enabled.
+		</p>
 
-    <h3>[property:Boolean enableDamping]</h3>
-    <div>
-      Set to true to enable damping (inertia), which can be used to give a sense of weight to the controls. Default is false.<br>
-      Note that if this is enabled, you must call [page:.update] () in your animation loop.
-    </div>
+		<h3>[property:Boolean enableDamping]</h3>
+		<p>
+			Set to true to enable damping (inertia), which can be used to give a sense of weight to the controls. Default is false.<br>
+			Note that if this is enabled, you must call [page:.update] () in your animation loop.
+		</p>
 
-    <h3>[property:Boolean enableKeys]</h3>
-    <div>
-      Enable or disable the use of keyboard controls.
-    </div>
+		<h3>[property:Boolean enableKeys]</h3>
+		<p>
+			Enable or disable the use of keyboard controls.
+		</p>
 
-    <h3>[property:Boolean enablePan]</h3>
-    <div>
-      Enable or disable camera panning. Default is true.
-    </div>
+		<h3>[property:Boolean enablePan]</h3>
+		<p>
+			Enable or disable camera panning. Default is true.
+		</p>
 
-    <h3>[property:Boolean enableRotate]</h3>
-    <div>
-      Enable or disable horizontal and vertical rotation of the camera. Default is true.<br>
-      Note that it is possible to disable a single axis by setting the min and max of the
-      [page:.minPolarAngle polar angle] or [page:.minAzimuthAngle azimuth angle] to the same value,
-      which will cause the vertical or horizontal rotation to be fixed at that value.
-    </div>
+		<h3>[property:Boolean enableRotate]</h3>
+		<p>
+			Enable or disable horizontal and vertical rotation of the camera. Default is true.<br>
+			Note that it is possible to disable a single axis by setting the min and max of the
+			[page:.minPolarAngle polar angle] or [page:.minAzimuthAngle azimuth angle] to the same value,
+			which will cause the vertical or horizontal rotation to be fixed at that value.
+		</p>
 
-    <h3>[property:Boolean enableZoom]</h3>
-    <div>
-      Enable or disable zooming (dollying) of the camera.
-    </div>
+		<h3>[property:Boolean enableZoom]</h3>
+		<p>
+			Enable or disable zooming (dollying) of the camera.
+		</p>
 
-    <h3>[property:Float keyPanSpeed]</h3>
-    <div>
-      How fast to pan the camera when the keyboard is used. Default is 7.0 pixels per keypress.
-    </div>
+		<h3>[property:Float keyPanSpeed]</h3>
+		<p>
+			How fast to pan the camera when the keyboard is used. Default is 7.0 pixels per keypress.
+		</p>
 
-    <h3>[property:Object keys]</h3>
-    <div>
-      This object contains references to the keycodes for controlling camera panning. Default is the 4 arrow keys.
-      <code>
+		<h3>[property:Object keys]</h3>
+		<p>
+			This object contains references to the keycodes for controlling camera panning. Default is the 4 arrow keys.
+			<code>
 controls.keys = {
-  LEFT: 37, //left arrow
-  UP: 38, // up arrow
-  RIGHT: 39, // right arrow
-  BOTTOM: 40 // down arrow
+	LEFT: 37, //left arrow
+	UP: 38, // up arrow
+	RIGHT: 39, // right arrow
+	BOTTOM: 40 // down arrow
 }
-       </code> See [link:https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode this page] for a full
-      list of keycodes.
-    </div>
+			 </code> See [link:https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode this page] for a full
+			list of keycodes.
+		</p>
 
-    <h3>[property:Float maxAzimuthAngle]</h3>
-    <div>
-      How far you can orbit horizontally, upper limit. Range is - Math.PI to Math.PI ( or Infinity for no limit ) and default is
-      Infinity;
-    </div>
+		<h3>[property:Float maxAzimuthAngle]</h3>
+		<p>
+			How far you can orbit horizontally, upper limit. Range is - Math.PI to Math.PI ( or Infinity for no limit ) and default is
+			Infinity;
+		</p>
 
-    <h3>[property:Float maxDistance]</h3>
-    <div>
-      How far you can dolly out ( [page:PerspectiveCamera] only ). Default is Infinity.
-    </div>
+		<h3>[property:Float maxDistance]</h3>
+		<p>
+			How far you can dolly out ( [page:PerspectiveCamera] only ). Default is Infinity.
+		</p>
 
-    <h3>[property:Float maxPolarAngle]</h3>
-    <div>
-      How far you can orbit vertically, upper limit. Range is 0 to Math.PI radians, and default is Math.PI.
-    </div>
+		<h3>[property:Float maxPolarAngle]</h3>
+		<p>
+			How far you can orbit vertically, upper limit. Range is 0 to Math.PI radians, and default is Math.PI.
+		</p>
 
-    <h3>[property:Float maxZoom]</h3>
-    <div>
-      How far you can zoom out ( [page:OrthographicCamera] only ). Default is Infinity.
-    </div>
+		<h3>[property:Float maxZoom]</h3>
+		<p>
+			How far you can zoom out ( [page:OrthographicCamera] only ). Default is Infinity.
+		</p>
 
-    <h3>[property:Float minAzimuthAngle]</h3>
-    <div>
-      How far you can orbit horizontally, lower limit. Range is - Math.PI to Math.PI ( or - Infinity for no limit ) and default
-      is - Infinity;
-    </div>
+		<h3>[property:Float minAzimuthAngle]</h3>
+		<p>
+			How far you can orbit horizontally, lower limit. Range is - Math.PI to Math.PI ( or - Infinity for no limit ) and default
+			is - Infinity;
+		</p>
 
-    <h3>[property:Float minDistance]</h3>
-    <div>
-       How far you can dolly in ( [page:PerspectiveCamera] only ). Default is 0.
-    </div>
+		<h3>[property:Float minDistance]</h3>
+		<p>
+			 How far you can dolly in ( [page:PerspectiveCamera] only ). Default is 0.
+		</p>
 
-    <h3>[property:Float minPolarAngle]</h3>
-    <div>
-      How far you can orbit vertically, lower limit. Range is 0 to Math.PI radians, and default is 0.
-    </div>
+		<h3>[property:Float minPolarAngle]</h3>
+		<p>
+			How far you can orbit vertically, lower limit. Range is 0 to Math.PI radians, and default is 0.
+		</p>
 
-    <h3>[property:Float minZoom]</h3>
-    <div>
-      How far you can zoom in ( [page:OrthographicCamera] only ). Default is 0.
-    </div>
+		<h3>[property:Float minZoom]</h3>
+		<p>
+			How far you can zoom in ( [page:OrthographicCamera] only ). Default is 0.
+		</p>
 
-    <h3>
-      [property:Object mouseButtons]</h3>
-    <div>
-      This object contains references to the mouse buttons used for the controls.
-      <code>
+		<h3>
+			[property:Object mouseButtons]</h3>
+		<p>
+			This object contains references to the mouse buttons used for the controls.
+			<code>
 controls.mouseButtons = {
-  ORBIT: THREE.MOUSE.LEFT,
-  ZOOM: THREE.MOUSE.MIDDLE,
-  PAN: THREE.MOUSE.RIGHT
+	ORBIT: THREE.MOUSE.LEFT,
+	ZOOM: THREE.MOUSE.MIDDLE,
+	PAN: THREE.MOUSE.RIGHT
 }
-      </code>
-    </div>
+			</code>
+		</p>
 
-    <h3>[property:Camera object]</h3>
-    <div>
-      The camera being controlled.
-    </div>
+		<h3>[property:Camera object]</h3>
+		<p>
+			The camera being controlled.
+		</p>
 
-    <h3>[property:Float panSpeed]</h3>
-    <div>
-      Speed of panning. Default is 1.
-    </div>
+		<h3>[property:Float panSpeed]</h3>
+		<p>
+			Speed of panning. Default is 1.
+		</p>
 
-    <h3>[property:Vector3 position0]</h3>
-    <div>
-      Used internally by the [method:saveState] and [method:reset] methods.
-    </div>
+		<h3>[property:Vector3 position0]</h3>
+		<p>
+			Used internally by the [method:saveState] and [method:reset] methods.
+		</p>
 
-    <h3>[property:Float rotateSpeed]</h3>
-    <div>
-      Speed of rotation. Default is 1.
-    </div>
+		<h3>[property:Float rotateSpeed]</h3>
+		<p>
+			Speed of rotation. Default is 1.
+		</p>
 
-    <h3>[property:Boolean screenSpacePanning]</h3>
-    <div>
-    Defines how the camera's position is translated when panning. If true, the camera pans in screen space.
-    Otherwise, the camera pans in the plane orthogonal to the camera's up direction. Default is false.
-    </div>
+		<h3>[property:Boolean screenSpacePanning]</h3>
+		<p>
+		Defines how the camera's position is translated when panning. If true, the camera pans in screen space.
+		Otherwise, the camera pans in the plane orthogonal to the camera's up direction. Default is false.
+		</p>
 
-    <h3>[property:Vector3 target0]</h3>
-    <div>
-      Used internally by the [method:saveState] and [method:reset] methods.
-    </div>
+		<h3>[property:Vector3 target0]</h3>
+		<p>
+			Used internally by the [method:saveState] and [method:reset] methods.
+		</p>
 
-    <h3>[property:Vector3 target]</h3>
-    <div>
-      The focus point of the controls, the [page:.object] orbits around this. It can be updated manually at any point to change
-      the focus of the controls.
-    </div>
+		<h3>[property:Vector3 target]</h3>
+		<p>
+			The focus point of the controls, the [page:.object] orbits around this. It can be updated manually at any point to change
+			the focus of the controls.
+		</p>
 
-    <h3>[property:Float zoom0]</h3>
-    <div>
-      Used internally by the [method:saveState] and [method:reset] methods.
-    </div>
+		<h3>[property:Float zoom0]</h3>
+		<p>
+			Used internally by the [method:saveState] and [method:reset] methods.
+		</p>
 
-    <h3>[property:Float zoomSpeed]</h3>
-    <div>
-      Speed of zooming / dollying. Default is 1.
-    </div>
+		<h3>[property:Float zoomSpeed]</h3>
+		<p>
+			Speed of zooming / dollying. Default is 1.
+		</p>
 
 
 
 		<h2>Methods</h2>
 
-    <h3>[method:null dispose] ()</h3>
-    <div>
-      Remove all the event listeners.
-    </div>
+		<h3>[method:null dispose] ()</h3>
+		<p>
+			Remove all the event listeners.
+		</p>
 
-    <h3>[method:radians getAzimuthalAngle] ()</h3>
-    <div>
-      Get the current horizontal rotation, in radians.
-    </div>
+		<h3>[method:radians getAzimuthalAngle] ()</h3>
+		<p>
+			Get the current horizontal rotation, in radians.
+		</p>
 
 		<h3>[method:radians getPolarAngle] ()</h3>
-		<div>
-      Get the current vertical rotation, in radians.
-    </div>
+		<p>
+			Get the current vertical rotation, in radians.
+		</p>
 
-    <h3>[method:null reset] ()</h3>
-    <div>
-      Reset the controls to their state from either the last time the [page:.saveState] was called, or the initial state.
-    </div>
+		<h3>[method:null reset] ()</h3>
+		<p>
+			Reset the controls to their state from either the last time the [page:.saveState] was called, or the initial state.
+		</p>
 
-    <h3>[method:null saveState] ()</h3>
-    <div>
-      Save the current state of the controls. This can later be recovered with [page:.reset].
-    </div>
+		<h3>[method:null saveState] ()</h3>
+		<p>
+			Save the current state of the controls. This can later be recovered with [page:.reset].
+		</p>
 
-    <h3>[method:false update] ()</h3>
-    <div>
-      Update the controls. Must be called after any manual changes to the camera's transform,
-      or in the update loop if [page:.autoRotate] or [page:.enableDamping] are set.
-    </div>
+		<h3>[method:false update] ()</h3>
+		<p>
+			Update the controls. Must be called after any manual changes to the camera's transform,
+			or in the update loop if [page:.autoRotate] or [page:.enableDamping] are set.
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 		An exporter for *glTF* 2.0.
 		<br /><br />
 		<a href="https://www.khronos.org/gltf">glTF</a> (GL Transmission Format) is an
@@ -19,7 +19,7 @@
 		or binary (.glb) format. External files store textures (.jpg, .png) and additional binary
 		data (.bin). A glTF asset may deliver one or more scenes, including meshes, materials,
 		textures, skins, skeletons, morph targets, animations, lights, and/or cameras.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -39,16 +39,16 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]()</h3>
-		<div>
-		</div>
-		<div>
+		<p>
+		</p>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:null parse]( [param:Object3D input], [param:Function onCompleted], [param:Object options] )</h3>
-		<div>
+		<p>
 		[page:Object input] — Scenes or objects to export. Valid options:<br />
 		<ul>
 			<li>
@@ -85,10 +85,10 @@
 			<li>forceIndices - bool. Generate indices for non-index geometry and export with them. Default is false.</li>
 			<li>forcePowerOfTwoTextures - bool. Export with images resized to POT size. This option works only if embedImages is true. Default is false.</li>
 		</ul>
-		</div>
-		<div>
+		</p>
+		<p>
 		Generates a .gltf (JSON) or .glb (binary) output from the input (Scenes or Objects)
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/geometries/ConvexBufferGeometry.html
+++ b/docs/examples/geometries/ConvexBufferGeometry.html
@@ -13,8 +13,8 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">[name] can be used to generate a convex hull for a given array of 3D points.
-			The average time complexity for this task is considered to be O(nlog(n)).</div>
+		<p class="desc">[name] can be used to generate a convex hull for a given array of 3D points.
+			The average time complexity for this task is considered to be O(nlog(n)).</p>
 
 		<script>
 
@@ -34,7 +34,7 @@
 
 		<h2>Example</h2>
 
-		<div>[example:webgl_geometry_convex geometry / convex ]</div>
+		<p>[example:webgl_geometry_convex geometry / convex ]</p>
 
 		<code>var geometry = new THREE.ConvexBufferGeometry( points );
 		var material = new THREE.MeshBasicMaterial( {color: 0x00ff00} );
@@ -45,9 +45,9 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Array points] )</h3>
-		<div>
+		<p>
 		points — Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/examples/geometries/ConvexGeometry.html
+++ b/docs/examples/geometries/ConvexGeometry.html
@@ -12,8 +12,8 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">[name] can be used to generate a convex hull for a given array of 3D points.
-			The average time complexity for this task is considered to be O(nlog(n)).</div>
+		<p class="desc">[name] can be used to generate a convex hull for a given array of 3D points.
+			The average time complexity for this task is considered to be O(nlog(n)).</p>
 
 		<script>
 
@@ -33,7 +33,7 @@
 
 		<h2>Example</h2>
 
-		<div>[example:webgl_geometry_convex geometry / convex ]</div>
+		<p>[example:webgl_geometry_convex geometry / convex ]</p>
 
 		<code>var geometry = new THREE.ConvexGeometry( points );
 		var material = new THREE.MeshBasicMaterial( {color: 0x00ff00} );
@@ -44,9 +44,9 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Array points] )</h3>
-		<div>
+		<p>
 		points — Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/examples/geometries/DecalGeometry.html
+++ b/docs/examples/geometries/DecalGeometry.html
@@ -12,7 +12,7 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">[name] can be used to create a decal mesh that serves different kinds of purposes e.g. adding unique details to models, performing dynamic visual environmental changes or covering seams.</div>
+		<p class="desc">[name] can be used to create a decal mesh that serves different kinds of purposes e.g. adding unique details to models, performing dynamic visual environmental changes or covering seams.</p>
 
 		<script>
 
@@ -32,7 +32,7 @@
 
 		<h2>Example</h2>
 
-		<div>[example:webgl_decals decals ]</div>
+		<p>[example:webgl_decals decals ]</p>
 
 		<code>var geometry =  new THREE.DecalGeometry( mesh, position, orientation, size );
 		var material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
@@ -43,12 +43,12 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:Mesh mesh], [param:Vector3 position], [param:Euler orientation], [param:Vector3 size] )</h3>
-		<div>
+		<p>
 		mesh — Any mesh object.<br />
 		position — Position of the decal projector.<br />
 		orientation — Orientation of the decal projector.<br />
 		size — Size of the decal projector.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/loaders/BabylonLoader.html
+++ b/docs/examples/loaders/BabylonLoader.html
@@ -10,10 +10,10 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">A loader for loading a <em>.babylon</em> resource. <br />
+		<p class="desc">A loader for loading a <em>.babylon</em> resource. <br />
 		The <a href="https://doc.babylonjs.com/generals/file_format_map_(.babylon)"> .babylon </a> file format used by
 		<a href="https://www.babylonjs.com/">Babylon.js</a>.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -51,12 +51,12 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager manager] )</h3>
-		<div>
+		<p>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
-		</div>
-		<div>
+		</p>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
@@ -64,25 +64,25 @@
 		<h2>Methods</h2>
 
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
-		<div>
+		<p>
 		[page:String url] — A string containing the path/URL of the <em>.babylon</em> file.<br />
 		[page:function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives the loaded [page:Object3D] as an argument.<br />
 		[page:function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
 		[page:function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Begin loading from url and call onLoad with the parsed response content.
-		</div>
+		</p>
 
 		<h3>[method:Object3D parse]( [param:Object json] )</h3>
-		<div>
+		<p>
 		[page:Object json] — The <em>JSON</em> structure to parse.
-		</div>
-		<div>
+		</p>
+		<p>
 		Parse a <em>JSON</em> structure and return an [page:Object3D object] or a [page:Scene scene].<br />
 		Found objects are converted to [page:Mesh] with a [page:BufferGeometry] and a default [page:MeshPhongMaterial].<br />
 		Lights are parsed accordingly.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -11,21 +11,21 @@
 		[page:Loader] &rarr;
 		<h1>[name]</h1>
 
-		<div class="desc"> A loader for loading <em>glTF 2.0</em> resource. <br />
+		<p class="desc"> A loader for <em>glTF 2.0</em> resources. <br /><br />
 		<a href="https://www.khronos.org/gltf">glTF</a> (GL Transmission Format) is an
 		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0">open format specification</a>
 		for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf)
 		or binary (.glb) format. External files store textures (.jpg, .png) and additional binary
 		data (.bin). A glTF asset may deliver one or more scenes, including meshes, materials,
 		textures, skins, skeletons, morph targets, animations, lights, and/or cameras.
-		</div>
+		</p>
 
 		<h2>Extensions</h2>
 
-		<div>
+		<p>
 			GLTFLoader supports the following
 			<a target="_blank" href="https://github.com/KhronosGroup/glTF/tree/master/extensions/">glTF 2.0 extensions</a>:
-		</div>
+		</p>
 
 		<ul>
 			<li>KHR_draco_mesh_compression</li>
@@ -90,12 +90,12 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager manager] )</h3>
-		<div>
+		<p>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
-		</div>
-		<div>
+		</p>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
@@ -103,47 +103,47 @@
 		<h2>Methods</h2>
 
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
-		<div>
+		<p>
 		[page:String url] — A string containing the path/URL of the <em>.gltf</em> or <em>.glb</em> file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed. The function receives the loaded JSON response returned from [page:Function parse].<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Begin loading from url and call the callback function with the parsed response content.
-		</div>
+		</p>
 
 		<h3>[method:null setPath]( [param:String path] )</h3>
-		<div>
+		<p>
 		[page:String path] — Base path for loading additional resources e.g. textures and .bin data.
-		</div>
-		<div>
+		</p>
+		<p>
 		Set the base path for additional resources.
-		</div>
+		</p>
 
 		<h3>[method:null setCrossOrigin]( [param:String value] )</h3>
-		<div>
+		<p>
 		[page:String value] — The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS.
-		</div>
+		</p>
 
 		<h3>[method:null setDRACOLoader]( [param:DRACOLoader dracoLoader] )</h3>
-		<div>
+		<p>
 		[page:DRACOLoader dracoLoader] — Instance of THREE.DRACOLoader, to be used for decoding assets compressed with the KHR_draco_mesh_compression extension.
-		</div>
-		<div>
+		</p>
+		<p>
 		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme] for the details of Draco and its decoder.
-		</div>
+		</p>
 
 		<h3>[method:null parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>
-		<div>
+		<p>
 		[page:ArrayBuffer data] — glTF asset to parse, as an ArrayBuffer or <em>JSON</em> string.<br />
 		[page:String path] — The base path from which to find subsequent glTF resources such as textures and .bin data files.<br />
 		[page:Function onLoad] — A function to be called when parse completes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during parsing. The function receives error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Parse a glTF-based ArrayBuffer or <em>JSON</em> String and fire [page:Function onLoad] callback when complete. The argument to [page:Function onLoad] will be an [page:object] that contains loaded parts: .[page:Scene scene], .[page:Array scenes], .[page:Array cameras], .[page:Array animations], and .[page:Object asset].
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/loaders/LoaderSupport.html
+++ b/docs/examples/loaders/LoaderSupport.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">Supporting classes for file loaders and web worker based loaders.</div>
+		<p class="desc">Supporting classes for file loaders and web worker based loaders.</p>
 
 		<h2>Sub-Classes</h2>
 		[page:LoaderSupport.Builder]<br>
@@ -36,76 +36,76 @@
 		<h2>Constructor</h2>
 
 		<h3>Builder()</h3>
-		<div>
+		<p>
 			Builds one or many [page:Mesh] from one raw set of Arraybuffers, materialGroup descriptions and further parameters.
 			Supports vertex, vertexColor, normal, uv and index buffers.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null setLogging] ( [param:Boolean enabled], [param:Boolean debug] )</h3>
-		<div>
+		<p>
 			[page:Boolean enabled] True or false.<br>
 			[page:Boolean debug] True or false.
-		</div>
-		<div>
+		</p>
+		<p>
 			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-		</div>
+		</p>
 
 
 		<h3>[method:null init] ()</h3>
-		<div>
+		<p>
 			Initializes the Builder (currently only default material initialisation).
-		</div>
+		</p>
 
 
 		<h3>[method:null setMaterials] ( Array of [param:Material materials] )</h3>
-		<div>
+		<p>
 			Array of [page:Material materials] - Array of [page:Material Materials]
-		</div>
-		<div>
+		</p>
+		<p>
 			Set materials loaded by any supplier of an Array of [page:Material Materials].
-		</div>
+		</p>
 
 
 		<h3>[method:Array processPayload] ( Object payload )</h3>
-		<div>
+		<p>
 			[page:Object payload] - Raw Mesh or Material descriptions.
-		</div>
-		<div>
+		</p>
+		<p>
 			Delegates processing of the payload (mesh building or material update) to the corresponding functions (BW-compatibility).
-		</div>
+		</p>
 
 
 		<h3>[method:Array buildMeshes] ( Object meshPayload )</h3>
-		<div>
+		<p>
 			[page:Object meshPayload] - Raw mesh description (buffers, params, materials) used to build one to many meshes.
-		</div>
-		<div>
+		</p>
+		<p>
 			Builds one or multiple meshes from the data described in the payload (buffers, params, material info).
-		</div>
+		</p>
 
 
 		<h3>[method:null updateMaterials] ( Object materialPayload )</h3>
-		<div>
+		<p>
 			[page:Object materialPayload] - Material update instructions
-		</div>
-		<div>
+		</p>
+		<p>
 			Updates the materials with contained material objects (sync) or from alteration instructions (async).
-		</div>
+		</p>
 
 
 		<h3>[method:Object getMaterialsJSON] ()</h3>
-		<div>
+		<p>
 			Returns the mapping object of material name and corresponding jsonified material.
-		</div>
+		</p>
 
 
 		<h3>[method:Object getMaterials] ()</h3>
-		<div>
+		<p>
 			Returns the mapping object of material name and corresponding material.
-		</div>
+		</p>
 		<br>
 		<br>
 
@@ -114,36 +114,36 @@
 		<h2>Constructor</h2>
 
 		<h3>LoadedMeshUserOverride( [param:Boolean disregardMesh], [param:BufferGeometry bufferGeometry] )</h3>
-		<div>
+		<p>
 			[page:Boolean disregardMesh] - Tell implementation to completely disregard this mesh<br>
 			[page:Boolean alteredMesh] - Tell implementation that mesh(es) have been altered or added
-		</div>
-		<div>
+		</p>
+		<p>
 			Object to return by callback onMeshAlter. Used to disregard a certain mesh or to return one to many meshes.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null addMesh] ( [param:Mesh mesh] )</h3>
-		<div>
+		<p>
 			[page:Mesh mesh] - Mesh
-		</div>
-		<div>
+		</p>
+		<p>
 			Add a mesh created within callback.
-		</div>
+		</p>
 
 
 		<h3>[method:boolean isDisregardMesh] ()</h3>
-		<div>
+		<p>
 			Answers if mesh shall be disregarded completely.
-		</div>
+		</p>
 
 
 		<h3>[method:boolean providesAlteredMeshes] ()</h3>
-		<div>
+		<p>
 			Answers if new mesh(es) were created.
-		</div>
+		</p>
 		<br>
 		<br>
 
@@ -152,71 +152,71 @@
 		<h2>Constructor</h2>
 
 		<h3>WorkerSupport()</h3>
-		<div>
+		<p>
 			This class provides means to transform existing parser code into a web worker.
 			It defines a simple communication protocol which allows to configure the worker and receive raw mesh data during execution.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null setLogging]( [param:Boolean enabled], [param:Boolean debug] )</h3>
-		<div>
+		<p>
 			[page:Boolean enabled] True or false.<br>
 			[page:Boolean debug] True or false.
-		</div>
-		<div>
+		</p>
+		<p>
 			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-		</div>
+		</p>
 
 
 		<h3>[method:null setForceWorkerDataCopy]( [param:Boolean forceWorkerDataCopy] )</h3>
-		<div>
+		<p>
 			[page:Boolean forceWorkerDataCopy] True or false.
-		</div>
-		<div>
+		</p>
+		<p>
 			Forces all ArrayBuffers to be transferred to worker to be copied.
-		</div>
+		</p>
 
 
 		<h3>[method:null validate] ( [param:Function functionCodeBuilder], Array of [param:String libLocations], [param:String libPath], [param:LoaderSupport.WorkerRunnerRefImpl runnerImpl] )</h3>
-		<div>
+		<p>
 			[page:Function functionCodeBuilder] - Function that is invoked with funcBuildObject and funcBuildSingleton that allows stringification of objects and singletons.<br>
 			Array of [page:String libLocations] - URL of libraries that shall be added to worker code relative to libPath.<br>
 			[page:String libPath] - Base path used for loading libraries.<br>
 			[page:LoaderSupport.WorkerRunnerRefImpl runnerImpl] - The default worker parser wrapper implementation (communication and execution). An extended class could be passed here.
-		</div>
-		<div>
+		</p>
+		<p>
 			Validate the status of worker code and the derived worker.
-		</div>
+		</p>
 
 
 		<h3>[method:null setTerminateRequested] ( [param:Boolean terminateRequested] )</h3>
-		<div>
+		<p>
 			[page:Boolean terminateRequested] - True or false.
-		</div>
-		<div>
+		</p>
+		<p>
 			Request termination of worker once parser is finished.
-		</div>
+		</p>
 
 
 		<h3>[method:null setCallbacks] ( [param:Function builder], [param:Function onLoad] )</h3>
-		<div>
+		<p>
 			[page:Function builder] - The builder function. Default is [page:LoaderSupport.Builder].<br>
 			[page:Function onLoad] - The function that is called when parsing is complete.
-		</div>
-		<div>
+		</p>
+		<p>
 			Specify functions that should be build when new raw mesh data becomes available and when the parser is finished.
-		</div>
+		</p>
 
 
 		<h3>[method:null run] ( [param:Object payload] )</h3>
-		<div>
+		<p>
 			[page:Object payload] - Raw mesh description (buffers, params, materials) used to build one to many meshes.
-		</div>
-		<div>
+		</p>
+		<p>
 			Runs the parser with the provided configuration.
-		</div>
+		</p>
 		<br>
 		<br>
 
@@ -225,30 +225,30 @@
 		<h2>Constructor</h2>
 
 		<h3>WorkerRunnerRefImpl()</h3>
-		<div>
+		<p>
 			Default implementation of the WorkerRunner responsible for creation and configuration of the parser within the worker.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null applyProperties] ( [param:Object parser], [param:Object params] )</h3>
-		<div>
+		<p>
 			[page:Object parser] - The parser instance<br>
 			[page:Object params] - The parameter object
-		</div>
-		<div>
+		</p>
+		<p>
 			Applies values from parameter object via set functions or via direct assignment.
-		</div>
+		</p>
 
 
 		<h3>[method:null run] ( [param:Object payload] )</h3>
-		<div>
+		<p>
 			[page:Object payload] - Raw mesh description (buffers, params, materials) used to build one to many meshes.
-		</div>
-		<div>
+		</p>
+		<p>
 			Configures the Parser implementation according the supplied configuration object.
-		</div>
+		</p>
 		<br>
 		<br>
 
@@ -257,99 +257,99 @@
 		<h2>Constructor</h2>
 
 		<h3>WorkerDirector( [param:String classDef] )</h3>
-		<div>
+		<p>
 			[page:String classDef] - Class definition to be used for construction
-		</div>
-		<div>
+		</p>
+		<p>
 			Orchestrate loading of multiple OBJ files/data from an instruction queue with a configurable amount of workers (1-16).<br>
 			- Workflow:<br>
 			- prepareWorkers<br>
 			- enqueueForRun<br>
 			- processQueue<br>
 			- tearDown
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null setLogging]( [param:Boolean enabled], [param:Boolean debug] )</h3>
-		<div>
+		<p>
 			[page:Boolean enabled] True or false.<br>
 			[page:Boolean debug] True or false.
-		</div>
-		<div>
+		</p>
+		<p>
 			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-		</div>
+		</p>
 
 
 		<h3>[method:null setForceWorkerDataCopy]( [param:Boolean forceWorkerDataCopy] )</h3>
-		<div>
+		<p>
 			[page:Boolean forceWorkerDataCopy] True or false.
-		</div>
-		<div>
+		</p>
+		<p>
 			Forces all ArrayBuffers to be transferred to worker to be copied.
-		</div>
+		</p>
 
 
 		<h3>[method:null prepareWorkers]( [param:WWOBJLoader2.Callbacks globalCallbacks], [param:Number maxQueueSize], [param:Number maxWebWorkers] )</h3>
-		<div>
+		<p>
 			[page:LoaderSupport.Callbacks globalCallbacks] - Register global callbacks used by all web workers<br>
 			[page:Number maxQueueSize] - Set the maximum size of the instruction queue (1-1024)<br>
 			[page:Number maxWebWorkers] - Set the maximum amount of workers (1-16)
-		</div>
-		<div>
+		</p>
+		<p>
 			Create or destroy workers according limits. Set the name and register callbacks for dynamically created web workers.
-		</div>
+		</p>
 
 
 		<h3>[method:null enqueueForRun]( [param:LoaderSupport.PrepData runParams] )</h3>
-		<div>
+		<p>
 			[page:LoaderSupport.PrepData runParams]
-		</div>
-		<div>
+		</p>
+		<p>
 			Store run instructions in internal instructionQueue.
-		</div>
+		</p>
 
 
 		<h3>[method:null processQueue]()</h3>
-		<div>
+		<p>
 			Process the instructionQueue until it is depleted.
-		</div>
+		</p>
 
 
 		<h3>[method:null tearDown]( [param:Function callbackOnFinishedProcessing] )</h3>
-		<div>
+		<p>
 			[page:Function callbackOnFinishedProcessing] - Function called once all workers finished processing.
-		</div>
-		<div>
+		</p>
+		<p>
 			Terminate all workers.
-		</div>
+		</p>
 
 
 		<h3>[method:null getMaxQueueSize]()</h3>
-		<div>
+		<p>
 			Returns the maximum length of the instruction queue.
-		</div>
+		</p>
 
 
 		<h3>[method:null getMaxWebWorkers]()</h3>
-		<div>
+		<p>
 			Returns the maximum number of workers.
-		</div>
+		</p>
 
 		<h3>[method:Boolean isRunning]()</h3>
-		<div>
+		<p>
 			Returns if any workers are running.
-		</div>
+		</p>
 
 
 		<h3>[method:null setCrossOrigin]( [param:String crossOrigin] )</h3>
-		<div>
+		<p>
 			[page:String crossOrigin] - CORS value
-		</div>
-		<div>
+		</p>
+		<p>
 			Sets the CORS string to be used.
-		</div>
+		</p>
 		<br>
 		<br>
 
@@ -358,23 +358,23 @@
 		<h2>Constructor</h2>
 
 		<h3>ResourceDescriptor( [param:String url], [param:String extension] )</h3>
-		<div>
+		<p>
 			[page:String url] - URL to the file<br>
 			[page:String extension] - The file extension (type)
-		</div>
-		<div>
+		</p>
+		<p>
 			A resource description used by [page:LoaderSupport.PrepData] and others.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:null setContent]( [param:Object content )</h3>
-		<div>
+		<p>
 			[page:Object content] - The file content as ArrayBuffer or text
-		</div>
-		<div>
+		</p>
+		<p>
 			Set the content of this resource
-		</div>
+		</p>
 		<br>
 		<br>
 
@@ -383,56 +383,56 @@
 		<h2>Constructor</h2>
 
 		<h3>PrepData( [param:String modelName] )</h3>
-		<div>
+		<p>
 			[page:String modelName] - Overall name of the model
-		</div>
-		<div>
+		</p>
+		<p>
 			Configuration instructions to be used by run method.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null setLogging]( [param:Boolean enabled], [param:Boolean debug] )</h3>
-		<div>
+		<p>
 			[page:Boolean enabled] True or false.<br>
 			[page:Boolean debug] True or false.
-		</div>
-		<div>
+		</p>
+		<p>
 			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-		</div>
+		</p>
 
 
 		<h3>[method:Callbacks getCallbacks]()</h3>
-		<div>
+		<p>
 			Returns all callbacks as [page:LoaderSupport.Callbacks].
-		</div>
+		</p>
 
 
 		<h3>[method:null addResource]( [param:LoaderSupport.ResourceDescriptor resource] )</h3>
-		<div>
+		<p>
 			[page:LoaderSupport.ResourceDescriptor resource] Adds a [page:LoaderSupport.ResourceDescriptor]
-		</div>
-		<div>
+		</p>
+		<p>
 			Add a resource description.
-		</div>
+		</p>
 
 
 		<h3>[method:null checkResourceDescriptorFiles] ( [param:LoaderSupport.ResourceDescriptor resources], [param:Object fileDesc] )</h3>
-		<div>
+		<p>
 			[page:LoaderSupport.ResourceDescriptor resources] - Array of [page:LoaderSupport.ResourceDescriptor]<br>
 			[page:Object fileDesc] - Object describing which resources are of interest (ext, type (string or UInt8Array) and ignore (boolean))
-		</div>
-		<div>
+		</p>
+		<p>
 			Identify files or content of interest from an Array of [page:LoaderSupport.ResourceDescriptor].
 			Returns Object with each "ext" and the corresponding [page:LoaderSupport.ResourceDescriptor]
-		</div>
+		</p>
 
 
 		<h3>[method:PrepData clone] ()</h3>
-		<div>
+		<p>
 			Clones this object and returns it afterwards. Callbacks and resources are not cloned deep (references!).
-		</div>
+		</p>
 		<br>
 		<br>
 
@@ -441,47 +441,47 @@
 		<h2>Constructor</h2>
 
 		<h3>Callbacks()</h3>
-		<div>
+		<p>
 			Callbacks utilized by loaders and builder.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null setCallbackOnProgress]( [param:Function callbackOnProgress] )</h3>
-		<div>
+		<p>
 			[page:Function callbackOnProgress] - Callback function for described functionality
-		</div>
-		<div>
+		</p>
+		<p>
 			Register callback function that is invoked by internal function "announceProgress" to print feedback.
-		</div>
+		</p>
 
 
 		<h3>[method:null setCallbackOnMeshAlter]( [param:Function callbackOnMeshAlter] )</h3>
-		<div>
+		<p>
 			[page:Function callbackOnMeshAlter] - Callback function for described functionality
-		</div>
-		<div>
+		</p>
+		<p>
 			Register callback function that is called every time a mesh was loaded.
 			Use [page:LoadedMeshUserOverride] for alteration instructions (geometry, material or disregard mesh).
-		</div>
+		</p>
 
 
 		<h3>[method:null setCallbackOnLoad]( [param:Function callbackOnLoad] )</h3>
-		<div>
+		<p>
 			[page:Function callbackOnLoad] - Callback function for described functionality
-		</div>
-		<div>
+		</p>
+		<p>
 			Register callback function that is called once loading of the complete OBJ file is completed.
-		</div>
+		</p>
 
 		<h3>[method:null setCallbackOnLoadMaterials]( [param:Function callbackOnLoadMaterials] )</h3>
-		<div>
+		<p>
 			[page:Function callbackOnLoadMaterials] - Callback function for described functionality
-		</div>
-		<div>
+		</p>
+		<p>
 			Register callback function that is called when materials have been loaded.
-		</div>
+		</p>
 		<br>
 		<br>
 
@@ -490,30 +490,30 @@
 		<h2>Constructor</h2>
 
 		<h3>Validator()</h3>
-		<div>
+		<p>
 			Validation functions.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:Boolean isValid]( [param:Object input] )</h3>
-		<div>
+		<p>
 			[page:Object input] - Can be anything
-		</div>
-		<div>
+		</p>
+		<p>
 			If given input is null or undefined, false is returned otherwise true.
-		</div>
+		</p>
 
 
 		<h3>[method:null verifyInput]( [param:Object input], [param:Object defaultValue] )</h3>
-		<div>
+		<p>
 			[page:Object input] - Can be anything<br>
 			[page:Object defaultValue] - Can be anything
-		</div>
-		<div>
+		</p>
+		<p>
 			If given input is null or undefined, the defaultValue is returned otherwise the given input.
-		</div>
+		</p>
 		<br>
 		<br>
 

--- a/docs/examples/loaders/MTLLoader.html
+++ b/docs/examples/loaders/MTLLoader.html
@@ -11,20 +11,20 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A loader for loading an <em>.mtl</em> resource, used internaly by [page:OBJLoader] and [page:UTF8Loader].<br />
+		<p class="desc">A loader for loading an <em>.mtl</em> resource, used internaly by [page:OBJLoader] and [page:UTF8Loader].<br />
 		The Material Template Library format (MTL) or .MTL File Format is a companion file format to .OBJ that describes surface shading
 		(material) properties of objects within one or more .OBJ files.
-		</div>
+		</p>
 
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager loadingManager] )</h3>
-		<div>
+		<p>
 			[page:LoadingManager loadingManager] — LoadingManager to use. Defaults to [page:DefaultLoadingManager DefaultLoadingManager]<br />
-		</div>
-		<div>
+		</p>
+		<p>
 			Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
@@ -33,46 +33,46 @@
 
 
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
-		<div>
+		<p>
 			[page:String url] — A string containing the path/URL of the <em>.mtl</em> file.<br />
 			[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator] instance.<br />
 			[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
 			[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 			Begin loading from url and return the loaded material.
-		</div>
+		</p>
 
 
 		<h3>[method:null setPath]( [param:String path] )</h3>
-		<div>
+		<p>
 			[page:String path] — required<br />
-		</div>
-		<div>
+		</p>
+		<p>
 			 Set base path for resolving references. If set this path will be prepended to each loaded and found reference.
-		</div>
+		</p>
 
 
 		<h3>[method:null setTexturePath]( [param:String path] )</h3>
-		<div>
+		<p>
 			[page:String path] — required<br />
-		</div>
-		<div>
+		</p>
+		<p>
 			Set base path for resolving texture references. If set this path will be prepended found texture reference. If not set and setPath is, it will be used as texture base path.
-		</div>
+		</p>
 
 
 		<h3>[method:null setCrossOrigin]( [param:boolean useCrossOrigin] )</h3>
-		<div>
+		<p>
 			[page:boolean useCrossOrigin] — required<br />
-		</div>
-		<div>
+		</p>
+		<p>
 			Set to true if you need to load textures from a different origin.
-		</div>
+		</p>
 
 
 		<h3>[method:null setMaterialOptions]( [param:Object options] )</h3>
-		<div>
+		<p>
 			[page:Object options] — required
 			<ul>
 				<li>side: Which side to apply the material. THREE.FrontSide (default), THREE.BackSide, THREE.DoubleSide</li>
@@ -81,19 +81,19 @@
 				<li>ignoreZeroRGBs: Ignore values of RGBs (Ka,Kd,Ks) that are all 0's. Default: false</li>
 				<li>invertTrProperty: Use values 1 of Tr field for fully opaque. This option is useful for obj exported from 3ds MAX, vcglib or meshlab. Default: false</li>
 			</ul>
-		</div>
-		<div>
+		</p>
+		<p>
 			Set of options on how to construct the materials
-		</div>
+		</p>
 
 
 		<h3>[method:MTLLoaderMaterialCreator parse]( [param:String text] )</h3>
-		<div>
+		<p>
 			[page:String text] — The textual <em>mtl</em> structure to parse.
-		</div>
-		<div>
+		</p>
+		<p>
 			Parse a <em>mtl</em> text structure and return a [page:MTLLoaderMaterialCreator] instance.<br />
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/examples/loaders/OBJLoader.html
+++ b/docs/examples/loaders/OBJLoader.html
@@ -11,12 +11,12 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A loader for loading a <em>.obj</em> resource.<br />
+		<p class="desc">A loader for loading a <em>.obj</em> resource.<br />
 		The <a href="https://en.wikipedia.org/wiki/Wavefront_.obj_file">OBJ file format</a> is a simple data-format
 		that represents 3D geometry in a human readable format as the position of each vertex, the UV position of
 		each texture coordinate vertex, vertex normals, and the faces that make each polygon defined as a list of
 		vertices, and texture vertices.
-		</div>
+		</p>
 
 
 		<h2>Example</h2>
@@ -56,12 +56,12 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager manager] )</h3>
-		<div>
+		<p>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
-		</div>
-		<div>
+		</p>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
@@ -69,25 +69,25 @@
 		<h2>Methods</h2>
 
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
-		<div>
+		<p>
 		[page:String url] — A string containing the path/URL of the <em>.obj</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:Object3D] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The function receives a XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Begin loading from url and call onLoad with the parsed response content.
-		</div>
+		</p>
 
 		<h3>[method:Object3D parse]( [param:String text] )</h3>
-		<div>
+		<p>
 		[page:String text] — The textual <em>obj</em> structure to parse.
-		</div>
-		<div>
+		</p>
+		<p>
 		Returns an [page:Object3D]. It contains the parsed meshes as [page:Mesh] and lines as [page:LineSegments].<br />
 		All geometry is created as [page:BufferGeometry]. Default materials are created as [page:MeshPhongMaterial].<br />
 		If an <em>obj</em> object or group uses multiple materials while declaring faces, geometry groups and an array of materials are used.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/loaders/OBJLoader2.html
+++ b/docs/examples/loaders/OBJLoader2.html
@@ -11,12 +11,12 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A loader for loading a <em>.obj</em> resource.<br />
+		<p class="desc">A loader for loading a <em>.obj</em> resource.<br />
 			The <a href="https://en.wikipedia.org/wiki/Wavefront_.obj_file">OBJ file format</a> is a simple data-format
 			that represents 3D geometry in a human redeable format as, the position of each vertex, the UV position of
 			each texture coordinate vertex, vertex normals, and the faces that make each polygon defined as a list of
 			vertices, and texture vertices.
-		</div>
+		</p>
 
 		<h2>Examples</h2>
 
@@ -41,155 +41,155 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager manager], [param:LoaderSupport.ConsoleLogger logger] )</h3>
-		<div>
+		<p>
 			[page:LoadingManager manager] - The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].<br>
 			[page:LoaderSupport.ConsoleLogger logger] - logger to be used
-		</div>
-		<div>
+		</p>
+		<p>
 			Use [name] to load OBJ data from files or to parse OBJ data from arraybuffer or text.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:Object3D parse]( {[param:arraybuffer content]|[param:String content]] )</h3>
-		<div>
+		<p>
 			[[page:arraybuffer content]|[page:String content]] OBJ data as Uint8Array or String
-		</div>
-		<div>
+		</p>
+		<p>
 			Parses OBJ data synchronously from arraybuffer or string and returns the [page:Object3D loaderRoorNode].
-		</div>
+		</p>
 
 
 		<h3>[method:Object3D parseAsync]( [param:arraybuffer content], [param:Function onLoad] )</h3>
-		<div>
+		<p>
 			[page:arraybuffer content] - OBJ data as Uint8Array<br>
 			[page:Function onLoad] - Called after worker successfully completed loading<br>
-		</div>
-		<div>
+		</p>
+		<p>
 			Parses OBJ content asynchronously from arraybuffer.
-		</div>
+		</p>
 
 
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError], [param:Function onMeshAlter], [param:boolean useAsync] )</h3>
-		<div>
+		<p>
 			[page:String url] - A string containing the path/URL of the file to be loaded.<br>
 			[page:Function onLoad] - A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br>
 			[page:Function onProgress] - (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br>
 			[page:Function onError] - (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br>
 			[page:Function onMeshAlter] - (optional) A function to be called after a new mesh raw data becomes available for alteration.<br>
 			[page:boolean useAsync] - (optional) If true, uses async loading with worker, if false loads data synchronously.
-		</div>
-		<div>
+		</p>
+		<p>
 			Use this convenient method to load a file at the given URL. By default the fileLoader uses an ArrayBuffer.
-		</div>
+		</p>
 
 
 		<h3>[method:null run]( [param:LoaderSupport.PrepData params], [param:LoaderSupport.WorkerSupport workerSupportExternal] )</h3>
-		<div>
+		<p>
 			[page:LoaderSupport.PrepData params] - prepData All parameters and resources required for execution<br>
 			[page:LoaderSupport.WorkerSupport workerSupportExternal] - Use pre-existing WorkerSupport
-		</div>
-		<div>
+		</p>
+		<p>
 			Run the loader according the provided instructions.
-		</div>
+		</p>
 
 
 		<h3>[method:null setLogging]( [param:Boolean enabled], [param:Boolean debug] )</h3>
-		<div>
+		<p>
 			[page:Boolean enabled] True or false.<br>
 			[page:Boolean debug] True or false.
-		</div>
-		<div>
+		</p>
+		<p>
 			Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-		</div>
+		</p>
 
 
 		<h3>[method:null setModelName] ( [param:String modelName] )</h3>
-		<div>
+		<p>
 			[page:String modelName]
-		</div>
-		<div>
+		</p>
+		<p>
 			Set the name of the model.
-		</div>
+		</p>
 
 
 		<h3>[method:null setPath] ( [param:String path] )</h3>
-		<div>
+		<p>
 			[page:String path] - URL
-		</div>
-		<div>
+		</p>
+		<p>
 			The URL of the base path.
-		</div>
+		</p>
 
 
 		<h3>[method:null setStreamMeshesTo] ( [param:Object3D streamMeshesTo] )</h3>
-		<div>
+		<p>
 			[page:Object3D streamMeshesTo] - Object already attached to scenegraph where new meshes will be attached to
-		</div>
-		<div>
+		</p>
+		<p>
 			Set the node where the loaded objects will be attached directly.
-		</div>
+		</p>
 
 
 		<h3>[method:null setMaterials] ( Array of [param:Material materials] )</h3>
-		<div>
+		<p>
 			Array of [page:Material materials] - Array of [page:Material Materials]
-		</div>
-		<div>
+		</p>
+		<p>
 			Set materials loaded by MTLLoader or any other supplier of an Array of [page:Material Materials].
-		</div>
+		</p>
 
 
 		<h3>[method:null setUseIndices]( [param:Boolean useIndices] )</h3>
-		<div>
+		<p>
 			[page:Boolean useIndices]
-		</div>
-		<div>
+		</p>
+		<p>
 			Instructs loaders to create indexed [page:BufferGeometry].
-		</div>
+		</p>
 
 
 		<h3>[method:null setDisregardNormals]( [param:Boolean disregardNormals] )</h3>
-		<div>
+		<p>
 			[page:Boolean disregardNormals]
-		</div>
-		<div>
+		</p>
+		<p>
 			Tells whether normals should be completely disregarded and regenerated.
-		</div>
+		</p>
 
 
 		<h3>[method:null setMaterialPerSmoothingGroup] ( [param:boolean materialPerSmoothingGroup] )</h3>
-		<div>
+		<p>
 			[page:boolean materialPerSmoothingGroup]
-		</div>
-		<div>
+		</p>
+		<p>
 			Tells whether a material shall be created per smoothing group.
-		</div>
+		</p>
 
 
 		<h3>[method:null onProgress]( [param:String type], [param:String text], [param:Number numericalValue] )</h3>
-		<div>
+		<p>
 			[page:String type] - The type of event<br>
 			[page:String text] - Textual description of the event<br>
 			[page:Number numericalValue] - Numerical value describing the progress
-		</div>
-		<div>
+		</p>
+		<p>
 			Announce feedback which is give to the registered [page:LoaderSupport.Callbacks].
-		</div>
+		</p>
 
 
 		<h3>[method:null loadMtl]( [param:String url], [param:Object content], [param:Function callbackOnLoad], [param:String crossOrigin], [param:Object materialOptions]) </h3>
-		<div>
+		<p>
 			[page:String url] - URL to the file<br>
 			[page:Object content] - The file content as arraybuffer or text<br>
 			[page:Function callbackOnLoad] - Callback to be called after successful load<br>
 			[page:String crossOrigin] - (optional) CORS value<br>
 			[page:Function materialOptions] - (optional) Set material loading options for MTLLoader
-		</div>
-		<div>
+		</p>
+		<p>
 			Utility method for loading an mtl file according resource description. Provide url or content..
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/examples/loaders/PCDLoader.html
+++ b/docs/examples/loaders/PCDLoader.html
@@ -11,10 +11,10 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A loader for loading a <em>.pcd</em> resource. <br />
+		<p class="desc">A loader for loading a <em>.pcd</em> resource. <br />
 		Point Cloud Data is a file format for <a href="https://en.wikipedia.org/wiki/Point_Cloud_Library">Point Cloud Library</a>. <br />
 		Loader support ascii and binary. Compressed binary files are not supported.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -54,44 +54,44 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager manager] )</h3>
-		<div>
+		<p>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
-		</div>
-		<div>
+		</p>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[page:Boolean littleEndian]</h3>
-		<div>
+		<p>
 		Default value is true.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
-		<div>
+		<p>
 		[page:String url] — A string containing the path/URL of the <em>.pcd</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Begin loading from url and call onLoad with the parsed response content.
-		</div>
+		</p>
 
 		<h3>[method:Object3D parse]( [param:Arraybuffer data],[param:String url] )</h3>
-		<div>
+		<p>
 		[page:Arraybuffer data] — The binary structure to parse.
-		</div>
-		<div>
+		</p>
+		<p>
 		[page:String url] — The file name or file url.
-		</div>
-		<div>
+		</p>
+		<p>
 		Parse an <em>pcd</em> binary structure and return an [page:Object3D].<br />
 		The object is converted to [page:Points] with a [page:BufferGeometry] and a [page:PointsMaterial].
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/loaders/PDBLoader.html
+++ b/docs/examples/loaders/PDBLoader.html
@@ -11,9 +11,9 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A loader for loading a <em>.pdb</em> resource.<br>
+		<p class="desc">A loader for loading a <em>.pdb</em> resource.<br>
 		The <a href="http://en.wikipedia.org/wiki/Protein_Data_Bank_(file_format)">Protein Data Bank</a> file format is a textual file describing the three-dimensional structures of molecules.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -56,12 +56,12 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager manager] )</h3>
-		<div>
+		<p>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
-		</div>
-		<div>
+		</p>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
@@ -69,23 +69,23 @@
 		<h2>Methods</h2>
 
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
-		<div>
+		<p>
 		[page:String url] — A string containing the path/URL of the <em>.pdb</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives the object having the following properties. [page:BufferGeometry geometryAtoms], [page:BufferGeometry geometryBonds] and the [page:Object JSON] structure.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Begin loading from url and call onLoad with the parsed response content.
-		</div>
+		</p>
 
 		<h3>[method:Object parse]( [param:String text] )</h3>
-		<div>
+		<p>
 		[page:String text] — The textual <em>pdb</em> structure to parse.
-		</div>
-		<div>
+		</p>
+		<p>
 		Parse a <em>pdb</em> text and return a <em>JSON</em> structure.<br />
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/loaders/PRWMLoader.html
+++ b/docs/examples/loaders/PRWMLoader.html
@@ -11,13 +11,13 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A loader for loading a <em>.prwm</em> resource.<br />
+		<p class="desc">A loader for loading a <em>.prwm</em> resource.<br />
 		Packed Raw WebGL Model is an open-source binary file format for nD geometries specifically designed for
 		JavaScript and WebGL with a strong focus on fast parsing (from 1ms to 0.1ms in Chrome 59
 		on a MBP Late 2013). The parsing of PRWM file is especially fast when the endianness of the file is
 		the same as the endianness of the client platform. More information
 		on this <a href="https://github.com/kchapelier/PRWM">here</a>.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -57,12 +57,12 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager manager] )</h3>
-		<div>
+		<p>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
-		</div>
-		<div>
+		</p>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
@@ -70,29 +70,29 @@
 		<h2>Methods</h2>
 
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
-		<div>
+		<p>
 		[page:String url] — A string containing the path/URL of the <em>.prwm</em> file. Any <em>*</em> character in the URL will be automatically replaced by <em>le</em> or <em>be</em> depending on the platform endianness.<br />
 		[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:BufferGeometry] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The function receives a XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Begin loading from url and call onLoad with the parsed response content.
-		</div>
+		</p>
 
 		<h3>[method:BufferGeometry parse]( [param:ArrayBuffer arrayBuffer] )</h3>
-		<div>
+		<p>
 		[page:ArrayBuffer arrayBuffer] — ArrayBuffer containing the <em>prwm</em> data.
-		</div>
-		<div>
+		</p>
+		<p>
 		Parse a <em>prwm</em> file passed as an ArrayBuffer and directly return an instance of [page:BufferGeometry].
-		</div>
+		</p>
 
 		<h3>PRWMLoader.isBigEndianPlatform( )</h3>
 
-		<div>
+		<p>
 		Return true if the endianness of the platform is Big Endian, false otherwise.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 
@@ -100,9 +100,9 @@
 
 		<h2>Additional notes</h2>
 
-		<div>
+		<p>
 		This loader is additionally available on npm as <a href="https://www.npmjs.com/package/three-prwm-loader">three-prwm-loader</a>.
-		</div>
+		</p>
 
 	</body>
 </html>

--- a/docs/examples/loaders/SVGLoader.html
+++ b/docs/examples/loaders/SVGLoader.html
@@ -11,9 +11,9 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A loader for loading a <em>.svg</em> resource.<br >
+		<p class="desc">A loader for loading a <em>.svg</em> resource.<br >
 		<a href="https://en.wikipedia.org/wiki/Scalable_Vector_Graphics">Scalabe Vector Graphics</a> is an XML-based vector image format for two-dimensional graphics with support for interactivity and animation.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -51,12 +51,12 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager manager] )</h3>
-		<div>
+		<p>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
-		</div>
-		<div>
+		</p>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
@@ -64,15 +64,15 @@
 		<h2>Methods</h2>
 
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
-		<div>
+		<p>
 		[page:String url] — A string containing the path/URL of the <em>.svg</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives the loaded [page:SVGDocument] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Begin loading from url and call onLoad with the response content.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/examples/loaders/TGALoader.html
+++ b/docs/examples/loaders/TGALoader.html
@@ -10,9 +10,9 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">A loader for loading a <em>.tga</em> resource. <br />
+		<p class="desc">A loader for loading a <em>.tga</em> resource. <br />
 		<a href="https://en.wikipedia.org/wiki/Truevision_TGA">TGA</a> is a raster graphics, image file format.
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
@@ -55,26 +55,26 @@
 		<h2>Constructor</h2>
 
 		<h3>[name]( [param:LoadingManager manager] )</h3>
-		<div>
+		<p>
 		[page:LoadingManager manager] — The [page:LoadingManager loadingManager] for the loader to use. Default is [page:LoadingManager THREE.DefaultLoadingManager].
-		</div>
-		<div>
+		</p>
+		<p>
 		Creates a new [name].
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:DataTexture load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
-		<div>
+		<p>
 		[page:String url] — A string containing the path/URL of the <em>.tga</em> file. <br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives loaded [page:DataTexture] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
-		</div>
-		<div>
+		</p>
+		<p>
 		Begin loading from url and pass the loaded [page:DataTexture texture] to onLoad. The [page:DataTexture texture] is also directly returned for immediate use (but may not be fully loaded).
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/objects/Lensflare.html
+++ b/docs/examples/objects/Lensflare.html
@@ -12,13 +12,13 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			Creates a simulated lens flare that tracks a light.<br /><br />
-		</div>
+		</p>
 
 		<h2>Example</h2>
 
-		<div>
+		<p>
 			[example:webgl_lensflares lensflares]
 
 			<code>
@@ -39,29 +39,29 @@ lensflare.addElement( new THREE.LensflareElement( textureFlare2, 60, 0.6 ) );
 light.add( lensflare );
 			</code>
 
-		</div>
+		</p>
 
 		<h2>Constructor</h2>
 
 
 		<h3>LensflareElement( [param:Texture texture], [param:Float size], [param:Float distance], [param:Color color], [param:Materials blending] )</h3>
-		<div>
+		<p>
 		[page:Texture texture] - THREE.Texture to use for the flare. <br />
 		[page:Float size] - (optional) size in pixels <br />
 		[page:Float distance] - (optional) (0-1) from light source (0 = at light source) <br />
 		[page:Color color] - (optional) the [page:Color] of the lens flare<br />
 		[page:Materials blending] - (optional) [page:Materials Blending Mode] - Defaults to THREE.NormalBlending
-		</div>
+		</p>
 
 		<h2>Properties</h2>
-		<div>See the base [page:Mesh] class for common properties.</div>
+		<p>See the base [page:Mesh] class for common properties.</p>
 
 		<h3>[property:Boolean isLensflare]</h3>
-		<div>
+		<p>
 			Used to check whether this or derived classes are lensflares. Default is *true*.<br /><br />
 
 			You should not change this, as it used internally for optimisation.
-		</div>
+		</p>
 
 
 		<h2>Source</h2>

--- a/docs/examples/quickhull/Face.html
+++ b/docs/examples/quickhull/Face.html
@@ -10,54 +10,54 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			Represents a section bounded by a specific amount of half-edges. The current implmentation assumes that a face always consist of three edges.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]()</h3>
-
-		</div>
+		<p>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Vector3 normal]</h3>
-		<div>
+		<p>
 			The normal vector of the face. Default is a [page:Vector3] at (0, 0, 0).
-		</div>
+		</p>
 
 		<h3>[property:Vector3 midpoint]</h3>
-		<div>
+		<p>
 			The midpoint or centroid of the face. Default is a [page:Vector3] at (0, 0, 0).
-		</div>
+		</p>
 
 		<h3>[property:Float area]</h3>
-		<div>
+		<p>
 			The area of the face. Default is 0.
-		</div>
+		</p>
 
 		<h3>[property:Float constant]</h3>
-		<div>
+		<p>
 			Signed distance from face to the origin. Default is 0.
-		</div>
+		</p>
 
 		<h3>[property:VertexNode outside]</h3>
-		<div>
+		<p>
 			Reference to a vertex in a vertex list this face can see. Default is null.
-		</div>
+		</p>
 
 		<h3>[property:Integer mark]</h3>
-		<div>
+		<p>
 			Marks if a face is visible or deleted. Default is 'Visible'.
-		</div>
+		</p>
 
 		<h3>[property:HalfEdge edge]</h3>
-		<div>
+		<p>
 			Reference to the base edge of a face. To retrieve all edges, you can use the 'next' reference of the current edge. Default is null.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
@@ -66,21 +66,21 @@
 		[page:VertexNode b] - Second vertex of the face.<br /><br />
 		[page:VertexNode c] - Third vertex of the face.<br /><br />
 
-		<div>Creates a face.</div>
+		<p>Creates a face.</p>
 
 		<h3>[method:HalfEdge getEdge]( [param:Integer i] )</h3>
 		[page:Integer i] - The index of the edge.<br /><br />
 
-		<div>Returns an edge by the given index.</div>
+		<p>Returns an edge by the given index.</p>
 
 		<h3>[method:Face compute] ()</h3>
 
-		<div>Computes all properties of the face.</div>
+		<p>Computes all properties of the face.</p>
 
 		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
 		[page:Vector3 point] - Any point in 3D space.<br /><br />
 
-		<div>Returns the signed distance from a given point to the plane representation of this face.</div>
+		<p>Returns the signed distance from a given point to the plane representation of this face.</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/quickhull/HalfEdge.html
+++ b/docs/examples/quickhull/HalfEdge.html
@@ -10,67 +10,67 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			The basis for a half-edge data structure, also known as doubly connected edge list (DCEL).<br />
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:VertexNode vertex], [param:Face face] )</h3>
+		<p>
 		[page:VertexNode vertex] - [page:VertexNode] A reference to its destination vertex.<br /><br />
 		[page:Face face] - [page:Face] A reference to its face.<br />
-
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:VertexNode vertex]</h3>
-		<div>
+		<p>
 			Reference to the destination vertex. The origin vertex can be obtained by querying the destination of its twin, or of the previous half-edge. Default is undefined.
-		</div>
+		</p>
 
 		<h3>[property:HalfEdge prev]</h3>
-		<div>
+		<p>
 			Reference to the previous half-edge of the same face. Default is null.
-		</div>
+		</p>
 
 		<h3>[property:HalfEdge next]</h3>
-		<div>
+		<p>
 			Reference to the next half-edge of the same face. Default is null.
-		</div>
+		</p>
 
 		<h3>[property:HalfEdge twin]</h3>
-		<div>
+		<p>
 			Reference to the twin half-edge to reach the opposite face. Default is null.
-		</div>
+		</p>
 
 		<h3>[property:Face face]</h3>
-		<div>
+		<p>
 			 Each half-edge bounds a single face and thus has a reference to that face. Default is undefined.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:VertexNode head]()</h3>
-		<div>Returns the destintation vertex.</div>
+		<p>Returns the destintation vertex.</p>
 
 		<h3>[method:VertexNode tail]()</h3>
-		<div>Returns the origin vertex.</div>
+		<p>Returns the origin vertex.</p>
 
 		<h3>[method:Float length]()</h3>
-		<div>Returns the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
-		(straight-line length) of the edge.</div>
+		<p>Returns the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
+		(straight-line length) of the edge.</p>
 
 		<h3>[method:Float lengthSquared]()</h3>
-		<div>Returns the square of the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
-		(straight-line length) of the edge.</div>
+		<p>Returns the square of the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
+		(straight-line length) of the edge.</p>
 
 		<h3>[method:HalfEdge setTwin]( [param:HalfEdge edge] )</h3>
 		[page:HalfEdge edge] - Any half-edge.<br /><br />
 
-		<div>Sets the twin edge of this half-edge. It also ensures that the twin reference of the given half-edge is correctly set.</div>
+		<p>Sets the twin edge of this half-edge. It also ensures that the twin reference of the given half-edge is correctly set.</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/quickhull/QuickHull.html
+++ b/docs/examples/quickhull/QuickHull.html
@@ -10,122 +10,122 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			General information about the Quickhull algorithm: Dirk Gregorius. March 2014, Game Developers Conference: [link:http://media.steampowered.com/apps/valve/2014/DirkGregorius_ImplementingQuickHull.pdf Implementing QuickHull].
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]()</h3>
-
-		</div>
+		<p>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Float tolerance]</h3>
-		<div>
+		<p>
 			The epsilon value that is used for internal comparative operations. The calculation of this value depends on the size of the geometry. Default is -1.
-		</div>
+		</p>
 
 		<h3>[property:Array faces]</h3>
-		<div>
+		<p>
 			The generated faces of the convex hull. Default is an empty array.
-		</div>
+		</p>
 
 		<h3>[property:Array newFaces]</h3>
-		<div>
+		<p>
 			This array holds the faces that are generated within a single iteration. Default is an empty array.
-		</div>
+		</p>
 
 		<h3>[property:VertexList assigned]</h3>
-		<div>
+		<p>
 			This [page:VertexList vertex list] holds all vertices that are assigned to a face. Default is an empty vertex list.
-		</div>
+		</p>
 
 		<h3>[property:VertexList unassigned]</h3>
-		<div>
+		<p>
 			This [page:VertexList vertex list] holds all vertices that are not assigned to a face. Default is an empty vertex list.
-		</div>
+		</p>
 
 		<h3>[property:Array vertices]</h3>
-		<div>
+		<p>
 			The internal representation of the given geometry data (an array of [page:VertexNode vertices]).
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:QuickHull setFromPoints]( [param:Array points] )</h3>
 		[page:Array points] - Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.<br /><br />
 
-		<div>Computes to convex hull for the given array of points.</div>
+		<p>Computes to convex hull for the given array of points.</p>
 
 		<h3>[method:QuickHull setFromObject]( [param:Object3D object] )</h3>
 		[page:Object3D object] - [page:Object3D] to compute the convex hull of.<br /><br />
 
-		<div>Computes the convex hull of an [page:Object3D] (including its children),
-		accounting for the world transforms of both the object and its childrens.</div>
+		<p>Computes the convex hull of an [page:Object3D] (including its children),
+		accounting for the world transforms of both the object and its childrens.</p>
 
 		<h3>[method:QuickHull makeEmpty]()</h3>
 
-		<div>Makes this convex hull empty.</div>
+		<p>Makes this convex hull empty.</p>
 
 		<h3>[method:QuickHull addVertexToFace]( [param:VertexNode vertex], [param:Face face]	)</h3>
 		[page:VertexNodeNode vertex] - The vetex to add.<br /><br />
 		[page:Face face] - The target face.<br /><br />
 
-		<div>Adds a vertex to the 'assigned' list of vertices and assigns it to the given face.</div>
+		<p>Adds a vertex to the 'assigned' list of vertices and assigns it to the given face.</p>
 
 		<h3>[method:QuickHull removeVertexFromFace]( [param:VertexNode vertex], [param:Face face]	)</h3>
 		[page:VertexNode vertex] - The vetex to remove.<br /><br />
 		[page:Face face] - The target face.<br /><br />
 
-		<div>Removes a vertex from the 'assigned' list of vertices and from the given face. It also makes sure that the link from 'face' to the first vertex it sees in 'assigned' is linked correctly after the removal.</div>
+		<p>Removes a vertex from the 'assigned' list of vertices and from the given face. It also makes sure that the link from 'face' to the first vertex it sees in 'assigned' is linked correctly after the removal.</p>
 
 		<h3>[method:VertexNode removeAllVerticesFromFace]( [param:Face face]	)</h3>
 		[page:Face face] - The given face.<br /><br />
 
-		<div>Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list.</div>
+		<p>Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list.</p>
 
 		<h3>[method:QuickHull deleteFaceVertices]( [param:Face face], [param:Face absorbingFace]	)</h3>
 		[page:Face face] - The given face.<br /><br />
 		[page:Face absorbingFace] - An optional face that tries to absorb the vertices of the first face.<br /><br />
 
-		<div>Removes all the visible vertices that 'face' is able to see.
+		<p>Removes all the visible vertices that 'face' is able to see.
 			<ul>
 				<li>If 'absorbingFace' doesn't exist, then all the removed vertices will be added to the 'unassigned' vertex list.</li>
 				<li>If 'absorbingFace' exists, then this method will assign all the vertices of 'face' that can see 'absorbingFace'.</li>
 				<li>If a vertex cannot see 'absorbingFace', it's added to the 'unassigned' vertex list.</li>
 			</ul>
-		</div>
+		</p>
 
 		<h3>[method:QuickHull resolveUnassignedPoints]( [param:Array newFaces]	)</h3>
 		[page:Face newFaces] - An array of new faces.<br /><br />
 
-		<div>Reassigns as many vertices as possible from the unassigned list to the new faces.</div>
+		<p>Reassigns as many vertices as possible from the unassigned list to the new faces.</p>
 
 		<h3>[method:Object computeExtremes]()</h3>
 
-		<div>Computes the extremes values (min/max vectors) which will be used to compute the inital hull.</div>
+		<p>Computes the extremes values (min/max vectors) which will be used to compute the inital hull.</p>
 
 		<h3>[method:QuickHull computeInitialHull]()</h3>
 
-		<div>Computes the initial simplex assigning to its faces all the points that are candidates to form part of the hull.</div>
+		<p>Computes the initial simplex assigning to its faces all the points that are candidates to form part of the hull.</p>
 
 		<h3>[method:QuickHull reindexFaces]()</h3>
 
-		<div>Removes inactive (e.g. deleted) faces from the internal face list.</div>
+		<p>Removes inactive (e.g. deleted) faces from the internal face list.</p>
 
 		<h3>[method:VertexNode nextVertexToAdd]()</h3>
 
-		<div>Finds the next vertex to create faces with the current hull.
+		<p>Finds the next vertex to create faces with the current hull.
 			<ul>
 				<li>Let the initial face be the first face existing in the 'assigned' vertex list.</li>
 				<li>If a face doesn't exist then return since there're no vertices left.</li>
 				<li>Otherwise for each vertex that face sees find the one furthest away from it.</li>
 			</ul>
-		</div>
+		</p>
 
 		<h3>[method:QuickHull computeHorizon]( [param:Vector3 eyePoint], [param:HalfEdge crossEdge], [param:Face face], [param:Array horizon]	)</h3>
 		[page:Vector3 eyePoint] - The 3D-coordinates of a point.<br /><br />
@@ -133,40 +133,40 @@
 		[page:Face face] - The current face being tested.<br /><br />
 		[page:Array horizon] - The edges that form part of the horizon in CCW order.<br /><br />
 
-		<div>Computes a chain of half edges in CCW order called the 'horizon'. For an edge to be part of the horizon it must join a face that can see 'eyePoint' and a face that cannot see 'eyePoint'.</div>
+		<p>Computes a chain of half edges in CCW order called the 'horizon'. For an edge to be part of the horizon it must join a face that can see 'eyePoint' and a face that cannot see 'eyePoint'.</p>
 
 		<h3>[method:HalfEdge addAdjoiningFace]( [param:VertexNode eyeVertex], [param:HalfEdge horizonEdge] )</h3>
 		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
 		[page:HalfEdge horizonEdge] - A single edge of the horizon.<br /><br />
 
-		<div>Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order.
-			All the half edges are created in CCW order thus the face is always pointing outside the hull</div>
+		<p>Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order.
+			All the half edges are created in CCW order thus the face is always pointing outside the hull</p>
 
 		<h3>[method:QuickHull addNewFaces]( [param:VertexNode eyeVertex], [param:HalfEdge horizonEdge] )</h3>
 		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
 		[page:HalfEdge horizon] - An array of half-edges that form the horizon.<br /><br />
 
-		<div>Adds 'horizon.length' faces to the hull, each face will be linked with the horizon opposite face and the face on the left/right.</div>
+		<p>Adds 'horizon.length' faces to the hull, each face will be linked with the horizon opposite face and the face on the left/right.</p>
 
 		<h3>[method:QuickHull addVertexToHull]( [param:VertexNode eyeVertex] )</h3>
 		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
 
-		<div>Adds a vertex to the hull with the following algorithm
+		<p>Adds a vertex to the hull with the following algorithm
 			<ul>
 				<li>Compute the 'horizon' which is a chain of half edges. For an edge to belong to this group it must be the edge connecting a face that can see 'eyeVertex' and a face which cannot see 'eyeVertex'.</li>
 				<li>All the faces that can see 'eyeVertex' have its visible vertices removed from the assigned vertex list.</li>
 				<li>A new set of faces is created with each edge of the 'horizon' and 'eyeVertex'. Each face is connected with the opposite horizon face and the face on the left/right.</li>
 				<li>The vertices removed from all the visible faces are assigned to the new faces if possible.</li>
 			</ul>
-		</div>
+		</p>
 
 		<h3>[method:QuickHull cleanup]()</h3>
 
-		<div>Cleans up internal properties after computing the convex hull.</div>
+		<p>Cleans up internal properties after computing the convex hull.</p>
 
 		<h3>[method:QuickHull compute]()</h3>
 
-		<div>Starts the execution of the quick hull algorithm.</div>
+		<p>Starts the execution of the quick hull algorithm.</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/quickhull/VertexList.html
+++ b/docs/examples/quickhull/VertexList.html
@@ -10,77 +10,79 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A doubly linked list of vertices.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]()</h3>
-
-		</div>
+		<p>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:VertexNode head]</h3>
-		<div>
+		<p>
 			Reference to the first vertex of the linked list. Default is null.
-		</div>
+		</p>
 
 		<h3>[property:VertexNode tail]</h3>
-		<div>
+		<p>
 			Reference to the last vertex of the linked list. Default is null.
-		</div>
+		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:VertexNode first]()</h3>
-		<div>Returns the head reference.</div>
+		<p>Returns the head reference.</p>
 
 		<h3>[method:VertexNode last]()</h3>
-		<div>Returns the tail reference.</div>
+		<p>Returns the tail reference.</p>
 
 		<h3>[method:VertexList clear]()</h3>
-		<div>Clears the linked list.</div>
+		<p>Clears the linked list.</p>
 
 		<h3>[method:VertexList insertBefore]( [param:Vertex target], [param:Vertex vertex] )</h3>
+		<p>
 		[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br /><br />
 		[page:Vertex vertex] - The vertex to insert.<br /><br />
+		</p>
 
-		<div>Inserts a vertex <strong>before</strong> a target vertex.</div>
+		<p>Inserts a vertex <strong>before</strong> a target vertex.</p>
 
 		<h3>[method:VertexList insertAfter]( [param:Vertex target], [param:Vertex vertex] )</h3>
 		[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br /><br />
 		[page:Vertex vertex] - The vertex to insert.<br /><br />
 
-		<div>Inserts a vertex <strong>after</strong> a target vertex.</div>
+		<p>Inserts a vertex <strong>after</strong> a target vertex.</p>
 
 		<h3>[method:VertexList append]( [param:Vertex vertex] )</h3>
 		[page:Vertex vertex] - The vertex to append.<br /><br />
 
-		<div>Appends a vertex to the end of the linked list.</div>
+		<p>Appends a vertex to the end of the linked list.</p>
 
 		<h3>[method:VertexList appendChain]( [param:Vertex vertex] )</h3>
 		[page:Vertex vertex] - The head vertex of a chain of vertices.<br /><br />
 
-		<div>Appends a chain of vertices where the given vertex is the head.</div>
+		<p>Appends a chain of vertices where the given vertex is the head.</p>
 
 		<h3>[method:VertexList remove]( [param:Vertex vertex] )</h3>
 		[page:Vertex vertex] - The vertex to remove.<br /><br />
 
-		<div>Removes a vertex from the linked list.</div>
+		<p>Removes a vertex from the linked list.</p>
 
 		<h3>[method:VertexList removeSubList]( [param:Vertex a], [param:Vertex b] )</h3>
 		[page:Vertex a] - The head of the sublist.<br /><br />
 		[page:Vertex b] - The tail of the sublist.<br /><br />
 
-		<div>Removes a sublist of vertices from the linked list.</div>
+		<p>Removes a sublist of vertices from the linked list.</p>
 
 		<h3>[method:Boolean isEmpty]()</h3>
 
-		<div>Returns true if the linked list is empty.</div>
+		<p>Returns true if the linked list is empty.</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/quickhull/VertexNode.html
+++ b/docs/examples/quickhull/VertexNode.html
@@ -10,40 +10,40 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			A vertex as a double linked list node.
-		</div>
+		</p>
 
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]( [param:Vector3 point] )</h3>
+		<p>
 		[page:Vector3 point] - [page:Vector3] A point (x, y, z) in 3D space.<br /><br />
-
-		</div>
+		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Vector3 point]</h3>
-		<div>
+		<p>
 			A point (x, y, z) in 3D space. Default is undefined.
-		</div>
+		</p>
 
 		<h3>[property:VertexNode prev]</h3>
-		<div>
+		<p>
 			Reference to the previous vertex in the double linked list. Default is null.
-		</div>
+		</p>
 
 		<h3>[property:VertexNode next]</h3>
-		<div>
+		<p>
 			Reference to the next vertex in the double linked list. Default is null.
-		</div>
+		</p>
 
 		<h3>[property:Face face]</h3>
-		<div>
+		<p>
 			Reference to the face that is able to see this vertex. Default is undefined.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/renderers/CSS2DRenderer.html
+++ b/docs/examples/renderers/CSS2DRenderer.html
@@ -10,10 +10,10 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">[name] is a simplified version of [page:CSS3DRenderer]. The only transformation that is supported is translation.<br />
+		<p class="desc">[name] is a simplified version of [page:CSS3DRenderer]. The only transformation that is supported is translation.<br /><br />
 			The renderer is very useful if you want to combine HTML based labels with 3D objects. Here too, the respective DOM elements are wrapped into an instance of *CSS2DObject* and added to the scene graph.<br />
 			Unlike [page:CSS3DRenderer], orthographic cameras are supported.
-		</div>
+		</p>
 
 		<script>
 
@@ -33,9 +33,9 @@
 
 		<h2>Examples</h2>
 
-		<div>
+		<p>
 			[example:webgl_loader_pdb molecules]
-		</div>
+		</p>
 
 		<h2>Constructor</h2>
 
@@ -44,19 +44,19 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Object getSize]()</h3>
-		<div>
+		<p>
 			Returns an object containing the width and height of the renderer.
-		</div>
+		</p>
 
 		<h3>[method:null render]( [param:Scene scene], [param:Camera camera] )</h3>
-		<div>
+		<p>
 			Renders a [page:Scene scene] using a [page:Camera camera].<br />
-		</div>
+		</p>
 
 		<h3>[method:null setSize]([param:Number width], [param:Number height])</h3>
-		<div>
+		<p>
 			Resizes the renderer to (width, height).
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/renderers/CSS3DRenderer.html
+++ b/docs/examples/renderers/CSS3DRenderer.html
@@ -10,16 +10,21 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">[name] can be used to apply hierarchical 3D transformations to DOM elements via the CSS3 [link:https://www.w3schools.com/cssref/css3_pr_transform.asp transform] property.<br />
-			This renderer is particular interesting if you want to apply 3D effects to a website without canvas based rendering. It can also be used in order to combine DOM elements with WebGL content.<br />
+		<p class="desc">[name] can be used to apply hierarchical 3D transformations to DOM elements
+			via the CSS3 [link:https://www.w3schools.com/cssref/css3_pr_transform.asp transform] property.
+			This renderer is particular interesting if you want to apply 3D effects to a website without
+			canvas based rendering. It can also be used in order to combine DOM elements with WebGL
+			content.<br /><br />
 			There are, however, some important limitations:
-			<ul>
-				<li>It's not possible to use the material system of *three.js*.</li>
-				<li>It's also not possible to use geometries.</li>
-				<li>Only [page:PerspectiveCamera] is supported right now.</li>
-			</ul>
+		</p>
+		<ul>
+			<li>It's not possible to use the material system of *three.js*.</li>
+			<li>It's also not possible to use geometries.</li>
+			<li>Only [page:PerspectiveCamera] is supported right now.</li>
+		</ul>
+		<p>
 			So [name] is just focused on ordinary DOM elements. These elements are wrapped into special objects (*CSS3DObject* or *CSS3DSprite*) and then added to the scene graph.
-		</div>
+		</p>
 
 		<script>
 
@@ -39,12 +44,12 @@
 
 		<h2>Examples</h2>
 
-		<div>
+		<p>
 			[example:css3d_molecules molecules]<br />
 			[example:css3d_panorama panorama]<br />
 			[example:css3d_periodictable periodictable]<br />
 			[example:css3d_sprites sprites]<br />
-		</div>
+		</p>
 
 		<h2>Constructor</h2>
 
@@ -53,19 +58,19 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Object getSize]()</h3>
-		<div>
+		<p>
 			Returns an object containing the width and height of the renderer.
-		</div>
+		</p>
 
 		<h3>[method:null render]( [param:Scene scene], [param:PerspectiveCamera camera] )</h3>
-		<div>
+		<p>
 			Renders a [page:Scene scene] using a [page:PerspectiveCamera perspective camera].<br />
-		</div>
+		</p>
 
 		<h3>[method:null setSize]([param:Number width], [param:Number height])</h3>
-		<div>
+		<p>
 			Resizes the renderer to (width, height).
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/renderers/CanvasRenderer.html
+++ b/docs/examples/renderers/CanvasRenderer.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">
+		<p class="desc">
 			The Canvas renderer displays your beautifully crafted scenes <em>not</em> using WebGL,
 			but draws it using the (slower) <a href="http://drafts.htmlwg.org/2dcontext/html5_canvas_CR/Overview.html">Canvas 2D Context</a>
 			API.<br /><br />
@@ -46,15 +46,15 @@
 			The "Canvas" in CanvasRenderer means it uses Canvas 2D instead of WebGL.<br /><br />
 
 			Don't confuse either CanvasRenderer with the SoftwareRenderer example, which simulates a screen buffer in a Javascript array.
-		</div>
+		</p>
 
 		<h2>Constructor</h2>
 
 
 		<h3>[name]([param:object parameters])</h3>
-        <div>parameters is an optional object with properties defining the renderer's behaviour. The constructor also accepts no parameters at all. In all cases, it will assume sane defaults when parameters are missing.</div>
+		<p>parameters is an optional object with properties defining the renderer's behaviour. The constructor also accepts no parameters at all. In all cases, it will assume sane defaults when parameters are missing.</p>
 
-		<div>
+		<p>
 		[page:DOMElement canvas] - A [link:https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas canvas]
 		where the renderer draws its output.
 		This corresponds to the [page:CanvasRenderer.domElement domElement] property below.
@@ -62,14 +62,14 @@
 
 		[page:Boolean alpha] - whether the canvas contains an alpha (transparency) buffer or not.
 	  Default is *false*.
-		</div>
+		</p>
 
 
 		<h2>Properties</h2>
 
     <h3>[property:Object info]</h3>
 
-		<div>
+		<p>
 			An object with a series of statistical information about the graphics board memory and the rendering process. Useful for debugging or just for the sake of curiosity. The object contains the following fields:
 			<ul>
 				<li>render:
@@ -79,93 +79,93 @@
 					</ul>
 				</li>
 			</ul>
-		</div>
+		</p>
 
     <h3>[property:DOMElement domElement]</h3>
 
-		<div>
+		<p>
 			A [page:Canvas] where the renderer draws its output.<br />
 			This is automatically created by the renderer in the constructor (if not provided already); you just need to add it to your page.
-		</div>
+		</p>
 
 		<h3>[property:Boolean autoClear]</h3>
-		<div>
+		<p>
       Defines whether the renderer should automatically clear its output before rendering.
-    </div>
+    </p>
 
 		<h3>[property:Boolean sortObjects]</h3>
-		<div>
+		<p>
       Defines whether the renderer should sort objects. Default is true.<br />
       Note: Sorting is used to attempt to properly render objects that have some degree of transparency.  By definition, sorting objects may not work in all cases.  Depending on the needs of application, it may be neccessary to turn off sorting and use other methods to deal with transparency rendering e.g. manually determining the object rendering order.
-    </div>
+    </p>
 
 		<h3>[property:boolean sortElements]</h3>
-		<div>
+		<p>
 			Defines whether the renderer should sort the face of each object. Default is true.
-		</div>
+		</p>
 
 
 		<h2>Methods</h2>
 
 		<h3>[method:null render]([param:Scene scene], [param:Camera camera])</h3>
-		<div>
+		<p>
 			scene -- The scene to render. <br />
 			camera -- the camera to view the scene.
-		</div>
-		<div>
+		</p>
+		<p>
         Render a scene using a camera.
-		</div>
+		</p>
 
 		<h3>[method:null clear]()</h3>
-		<div>
+		<p>
 			Tells the renderer to clear its color drawing buffer with the clearcolor.
-		</div>
+		</p>
 
 		<h3>[method:null setClearColor]([param:Color color], [param:number alpha])</h3>
-		<div>
+		<p>
 			color -- The color to clear the canvas with. <br />
 			alpha -- The alpha channel to clear the canvas with.
-		</div>
-		<div>
+		</p>
+		<p>
 			This set the clearColor and the clearAlpha.
-		</div>
+		</p>
 
 
 		<h3>[method:null setSize]([param:Number width], [param:Number height])</h3>
-		<div>
+		<p>
 			width -- The width of the drawing canvas. <br />
 			height -- The height of the drawing canvas.
-		</div>
-		<div>
+		</p>
+		<p>
 			This set the size of the drawing canvas and if updateStyle is set, then the css of the canvas is updated too.
-		</div>
+		</p>
 
 		<h3>[method:null setClearColorHex]([param:number hex], [param:number alpha])</h3>
-		<div>
+		<p>
 			hex -- The the hexadecimal value of the color to clear the canvas with. <br />
 	    alpha -- The alpha channel to clear the canvas with.
-		</div>
-		<div>
+		</p>
+		<p>
 			This set the clearColor and the clearAlpha.
-		</div>
+		</p>
 
 		<h3>[method:number getClearColorHex]()</h3>
-		<div>
+		<p>
 			Returns the [page:number hex] color.
-		</div>
+		</p>
 
 		<h3>[method:number getClearAlpha]()</h3>
-		<div>
+		<p>
 			Returns the alpha value.
-		</div>
+		</p>
 
 		<h2>Empty Methods to Maintain Compatibility with [page:WebglRenderer]</h2>
-		<div>
+		<p>
 			[method:null clearColor]()<br/>
 			[method:null clearDepth]()<br/>
 			[method:null clearStencil]()<br/>
 			[method:number getMaxAnisotropy]() - returns 1 <br/>
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/renderers/SVGRenderer.html
+++ b/docs/examples/renderers/SVGRenderer.html
@@ -13,23 +13,25 @@
 		<div class="desc">
 			<p>
 				[name] can be used to render geometric data using SVG. The produced vector graphics are particular useful in the following use cases:
-				<ul>
-					<li>Animated logos or icons</li>
-					<li>Interactive 2D/3D diagrams or graphs</li>
-					<li>Interactive maps</li>
-					<li>Complex or animated user interfaces</li>
-				</ul>
+			</p>
+			<ul>
+				<li>Animated logos or icons</li>
+				<li>Interactive 2D/3D diagrams or graphs</li>
+				<li>Interactive maps</li>
+				<li>Complex or animated user interfaces</li>
+			</ul>
+			<p>
 				[name] has various advantages. It produces crystal-clear and sharp output which is independet of the actual viewport resolution.<br />
 				SVG elements can be styled via CSS. And they have good accessibility since it's possible to add metadata like title or description (useful for search engines or screen readers).
 			</p>
 			<p>
 				There are, however, some important limitations:
-				<ul>
-					<li>No advanced shading</li>
-					<li>No texture support</li>
-					<li>No shadow support</li>
-				</ul>
 			</p>
+			<ul>
+				<li>No advanced shading</li>
+				<li>No texture support</li>
+				<li>No shadow support</li>
+			</ul>
 		</div>
 
 		<script>
@@ -50,10 +52,10 @@
 
 		<h2>Examples</h2>
 
-		<div>
+		<p>
 			[example:svg_lines lines]<br />
 			[example:svg_sandbox sandbox]
-		</div>
+		</p>
 
 		<h2>Constructor</h2>
 
@@ -62,34 +64,34 @@
 		<h2>Methods</h2>
 
 		<h3>[method:null clear]()</h3>
-		<div>
+		<p>
 			Tells the renderer to clear its drawing surface.
-		</div>
+		</p>
 
 		<h3>[method:null render]( [param:Scene scene], [param:Camera camera] )</h3>
-		<div>
+		<p>
 			Renders a [page:Scene scene] using a [page:Camera camera].
-		</div>
+		</p>
 
 		<h3>[method:null setClearColor]( [param:Color color], [param:number alpha] )</h3>
-		<div>
+		<p>
 			Sets the clearColor and the clearAlpha.
-		</div>
+		</p>
 
 		<h3>[method:null setPrecision]( [param:Number precision] )</h3>
-		<div>
+		<p>
 			Sets the precision of the data used to create a path.
-		</div>
+		</p>
 
 		<h3>[method:null setQuality]()</h3>
-		<div>
+		<p>
 			Sets the render quality. Possible values are *low* and *high* (default).
-		</div>
+		</p>
 
 		<h3>[method:null setSize]( [param:Number width], [param:Number height] )</h3>
-		<div>
+		<p>
 			Resizes the renderer to (width, height).
-		</div>
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/utils/SceneUtils.html
+++ b/docs/examples/utils/SceneUtils.html
@@ -10,41 +10,41 @@
 	<body>
 		<h1>[name]</h1>
 
-		<div class="desc">A class containing useful utility functions for scene manipulation.</div>
+		<p class="desc">A class containing useful utility functions for scene manipulation.</p>
 
 
 		<h2>Methods</h2>
 
 
 		<h3>[method:Group createMultiMaterialObject]( [param:Geometry geometry], [param:Array materials] )</h3>
-		<div>
+		<p>
 		geometry -- The geometry for the set of materials. <br />
 		materials -- The materials for the object.
-		</div>
-		<div>
+		</p>
+		<p>
 		Creates a new Group that contains a new mesh for each material defined in materials. Beware that this is not the same as an array of materials which defines multiple materials for 1 mesh.<br />
 		This is mostly useful for objects that need both a material and a wireframe implementation.
-		</div>
+		</p>
 
 		<h3>[method:null attach]( [param:Object3D child], [param:Object3D scene], [param:Object3D parent] )</h3>
-		<div>
+		<p>
 		child -- The object to add to the parent  <br />
 		scene -- The scene to detach the object on. <br />
 		parent -- The parent to attach the object from.
-		</div>
-		<div>
+		</p>
+		<p>
 		Attaches the object to the parent without the moving the object in the worldspace. Beware that to do this the matrixWorld needs to be updated, this can be done by calling the updateMatrixWorld method on the parent object.
-		</div>
+		</p>
 
 		<h3>[method:null detach]( [param:Object3D child], [param:Object3D parent], [param:Object3D scene] )</h3>
-		<div>
+		<p>
 		child -- The object to remove from the parent  <br />
 		scene -- The scene to attach the object on. <br />
 		parent -- The parent to detach the object from.
-		</div>
-		<div>
+		</p>
+		<p>
 		Detaches the object from the parent and adds it back to the scene without moving in worldspace. Beware that to do this the matrixWorld needs to be updated, this can be done by calling the updateMatrixWorld method on the parent object.
-		</div>
+		</p>
 
 		<h2>Source</h2>
 


### PR DESCRIPTION
Continuation of #13680. Covers *Math — Examples* sections.

I think that's the last of them. 😅