### PR TITLE
Use matrixWorld instead of matrix for DecalGeometry

### DIFF
--- a/examples/js/geometries/DecalGeometry.js
+++ b/examples/js/geometries/DecalGeometry.js
@@ -148,7 +148,7 @@
 
 			// transform the vertex to world space, then to projector space
 
-			vertex.applyMatrix4( mesh.matrix );
+			vertex.applyMatrix4( mesh.matrixWorld );
 			vertex.applyMatrix4( projectorMatrixInverse );
 
 			decalVertices.push( new DecalVertex( vertex.clone(), normal.clone() ) );


### PR DESCRIPTION
Noticed it used matrix instead of matrixWorld when transforming to world space