### PR TITLE
TGA files support for FBXLoader

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -366,7 +366,7 @@
 
 		var texture;
 	
-		if ( textureNode.FileName.slice( textureNode.FileName.lastIndexOf( '.' ) + 1 ) === 'tga' ) {
+		if ( textureNode.FileName.slice( -3 ).toLowerCase() === 'tga' ) {
 			
  			texture = THREE.Loader.Handlers.get( '.tga' ).load( fileName );
 			

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -245,7 +245,27 @@
 
 				type = 'image/tiff';
 				break;
+				
+ 			case 'tga':
+			
+				if ( typeof THREE.TGALoader !== 'function' ) {
+					
+					console.warn( 'FBXLoader: THREE.TGALoader is required to load TGA textures' );
+					return;
 
+				} else {
+					
+					if ( THREE.Loader.Handlers.get( '.tga' ) === null ) {
+
+						THREE.Loader.Handlers.add( /\.tga$/i, new THREE.TGALoader() );
+
+					}
+					
+					type = 'image/tga';
+					break;
+
+				}
+				
 			default:
 
 				console.warn( 'FBXLoader: Image type "' + extension + '" is not supported.' );
@@ -344,8 +364,18 @@
 
 		}
 
-		var texture = loader.load( fileName );
-
+		var texture;
+	
+		if (textureNode.FileName.slice(textureNode.FileName.lastIndexOf('.') + 1)=='tga'){
+			
+ 			texture = THREE.Loader.Handlers.get( '.tga' ).load( fileName );
+			
+ 		} else {
+			
+ 			texture = loader.load( fileName );
+			
+ 		}
+		
 		loader.setPath( currentPath );
 
 		return texture;

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -366,7 +366,7 @@
 
 		var texture;
 	
-		if (textureNode.FileName.slice(textureNode.FileName.lastIndexOf('.') + 1)=='tga'){
+		if ( textureNode.FileName.slice( textureNode.FileName.lastIndexOf( '.' ) + 1 ) === 'tga' ) {
 			
  			texture = THREE.Loader.Handlers.get( '.tga' ).load( fileName );
 			


### PR DESCRIPTION
Based on @looeee  #13227 PR and discussed in  #13786
It is without DDS support that was causing problems.

I know line 369 is ugly and maybe not best way to do it, could you advice me better way?
`if (textureNode.FileName.slice(textureNode.FileName.lastIndexOf('.') + 1)=='tga')`

previous `if ( fileName.indexOf( 'image/tga' ) !== - 1 )` is not working in this version...