### PR TITLE
OrthographicTrackballControls -- Fixes zoom lock-up issue

### DIFF
--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -1,6 +1,6 @@
 /**
  * @author Eberhard Graether / http://egraether.com/
- * @author Mark Lundin 	/ http://mark-lundin.com
+ * @author Mark Lundin  / http://mark-lundin.com
  * @author Patrick Fuller / http://patrick-fuller.com
  * @author Max Smolens / https://github.com/msmolens
  */
@@ -37,8 +37,6 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 	// internals
 
 	this.target = new THREE.Vector3();
-
-	var EPS = 0.000001;
 
 	var _changed = true;
 
@@ -241,27 +239,23 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 		} else {
 
-			var factor = 1.0 + ( _zoomEnd.y - _zoomStart.y ) * _this.zoomSpeed;
+			factor = 1.0 + ( _zoomEnd.y - _zoomStart.y ) * _this.zoomSpeed;
 
-			if ( Math.abs( factor - 1.0 ) > EPS && factor > 0.0 ) {
+			if ( factor !== 1.0 && factor > 0.0 ) {
 
 				_this.object.zoom /= factor;
 
-				if ( _this.staticMoving ) {
-
-					_zoomStart.copy( _zoomEnd );
-
-				} else {
-
-					_zoomStart.y += ( _zoomEnd.y - _zoomStart.y ) * this.dynamicDampingFactor;
-
-				}
-
 				_changed = true;
+
+			}
+
+			if ( _this.staticMoving ) {
+
+				_zoomStart.copy( _zoomEnd );
 
 			} else {
 
-				_zoomStart.copy( { x: 0, y: 0 } );
+				_zoomStart.y += ( _zoomEnd.y - _zoomStart.y ) * this.dynamicDampingFactor;
 
 			}
 

--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -43,21 +43,21 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 	var _changed = true;
 
 	var _state = STATE.NONE,
-	_prevState = STATE.NONE,
+		_prevState = STATE.NONE,
 
-	_eye = new THREE.Vector3(),
+		_eye = new THREE.Vector3(),
 
-	_rotateStart = new THREE.Vector3(),
-	_rotateEnd = new THREE.Vector3(),
+		_rotateStart = new THREE.Vector3(),
+		_rotateEnd = new THREE.Vector3(),
 
-	_zoomStart = new THREE.Vector2(),
-	_zoomEnd = new THREE.Vector2(),
+		_zoomStart = new THREE.Vector2(),
+		_zoomEnd = new THREE.Vector2(),
 
-	_touchZoomDistanceStart = 0,
-	_touchZoomDistanceEnd = 0,
+		_touchZoomDistanceStart = 0,
+		_touchZoomDistanceEnd = 0,
 
-	_panStart = new THREE.Vector2(),
-	_panEnd = new THREE.Vector2();
+		_panStart = new THREE.Vector2(),
+		_panEnd = new THREE.Vector2();
 
 	// for reset
 
@@ -186,7 +186,7 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 	}() );
 
-	this.rotateCamera = ( function() {
+	this.rotateCamera = ( function () {
 
 		var axis = new THREE.Vector3(),
 			quaternion = new THREE.Quaternion();
@@ -224,7 +224,7 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 			}
 
-		}
+		};
 
 	}() );
 
@@ -259,13 +259,17 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 				_changed = true;
 
+			} else {
+
+				_zoomStart.copy( { x: 0, y: 0 } );
+
 			}
 
 		}
 
 	};
 
-	this.panCamera = ( function() {
+	this.panCamera = ( function () {
 
 		var mouseChange = new THREE.Vector2(),
 			objectUp = new THREE.Vector3(),
@@ -303,7 +307,7 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 			}
 
-		}
+		};
 
 	}() );
 
@@ -439,7 +443,7 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 		} else if ( _state === STATE.PAN && ! _this.noPan ) {
 
 			_panStart.copy( getMouseOnScreen( event.pageX, event.pageY ) );
-			_panEnd.copy( _panStart )
+			_panEnd.copy( _panStart );
 
 		}
 
@@ -596,7 +600,7 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 	}
 
-	this.dispose = function() {
+	this.dispose = function () {
 
 		this.domElement.removeEventListener( 'contextmenu', contextmenu, false );
 		this.domElement.removeEventListener( 'mousedown', mousedown, false );


### PR DESCRIPTION
The zoom would lock up whenever the 'factor' became negative.  There was no way to reset the zoom start value, and so zooming would never work again (until the control is reset or reinitialized).