### PR TITLE
Webgl_morphtargets: switched to buffergeometry and simplify

### DIFF
--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -101,6 +101,8 @@
 				geometry.morphAttributes.position[ 0 ] = new THREE.Float32BufferAttribute( morphTargetPositions0, 3 );
 
 				// morph bottom right corner
+				// since the square consists of two distinct triangles,
+				// we need to move vertices of upper and lower triangles together here
 				var morphTargetPositions1 = [
 					-1, -1, 0,
 					2, -2, 0,

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -62,85 +62,111 @@
 
 				container = document.getElementById( 'container' );
 
-				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 15000 );
-				camera.position.z = 500;
+				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 150 );
+				camera.position.z = 10;
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0x222222 );
-				scene.fog = new THREE.Fog( 0x000000, 1, 15000 );
 
-				var light = new THREE.PointLight( 0xff2200 );
-				light.position.set( 100, 100, 100 );
-				scene.add( light );
+				var geometry = new THREE.BufferGeometry();
 
-				var light = new THREE.AmbientLight( 0x111111 );
-				scene.add( light );
+				var material = new THREE.MeshBasicMaterial( { color: 0xff0000, morphTargets: true, side: THREE.DoubleSide } );
 
-				var geometry = new THREE.BoxGeometry( 100, 100, 100 );
-				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, morphTargets: true } );
+				// 2 x 2 square centered at (0, 0, 0)
+				var positions = [
+					-1, -1, 0,
+					1, -1, 0,
+					-1, 1, 0,
+					-1, 1, 0,
+					1, -1, 0,
+					1, 1, 0,
+				];
 
-				// construct 8 blend shapes
+				geometry.addAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
 
-				for ( var i = 0; i < 8; i ++ ) {
+				// create an empty array to  hold targets for the attribute we want to morph
+				// morphing positions and normals is supported
+				geometry.morphAttributes.position = [];
 
-					var vertices = [];
+				// morph bottom left corner
+				var morphTargetPositions0 = [
+					-2, -2, 0,
+					1, -1, 0,
+					-1, 1, 0,
+					-1, 1, 0,
+					1, -1, 0,
+					1, 1, 0,
+				];
 
-					for ( var v = 0; v < geometry.vertices.length; v ++ ) {
+				geometry.morphAttributes.position[ 0 ] = new THREE.Float32BufferAttribute( morphTargetPositions0, 3 );
 
-						vertices.push( geometry.vertices[ v ].clone() );
+				// morph bottom right corner
+				var morphTargetPositions1 = [
+					-1, -1, 0,
+					2, -2, 0,
+					-1, 1, 0,
+					-1, 1, 0,
+					2, -2, 0,
+					1, 1, 0,
+				];
 
-						if ( v === i ) {
+				geometry.morphAttributes.position[ 1 ] = new THREE.Float32BufferAttribute( morphTargetPositions1, 3 );
 
-							vertices[ vertices.length - 1 ].x *= 2;
-							vertices[ vertices.length - 1 ].y *= 2;
-							vertices[ vertices.length - 1 ].z *= 2;
+				// morph top left corner
+				var morphTargetPositions2 = [
+					-1, -1, 0,
+					1, -1, 0,
+					-2, 2, 0,
+					-2, 2, 0,
+					1, -1, 0,
+					1, 1, 0,
+				];
 
-						}
+				geometry.morphAttributes.position[ 2 ] = new THREE.Float32BufferAttribute( morphTargetPositions2, 3 );
 
-					}
+				// morph top right corner
+				var morphTargetPositions3 = [
+					-1, -1, 0,
+					1, -1, 0,
+					-1, 1, 0,
+					-1, 1, 0,
+					1, -1, 0,
+					2, 2, 0,
+				];
 
-					geometry.morphTargets.push( { name: "target" + i, vertices: vertices } );
-
-				}
+				geometry.morphAttributes.position[ 3 ] = new THREE.Float32BufferAttribute( morphTargetPositions3, 3 );
 
 				mesh = new THREE.Mesh( geometry, material );
 
 				scene.add( mesh );
 
-				//
+				// Set up dat.GUI to control targets
 
 				var params = {
+					influence0: 0,
 					influence1: 0,
 					influence2: 0,
 					influence3: 0,
-					influence4: 0,
-					influence5: 0,
-					influence6: 0,
-					influence7: 0,
-					influence8: 0
 				};
 
 				var gui = new dat.GUI();
 
 				var folder = gui.addFolder( 'Morph Targets' );
-				folder.add( params, 'influence1', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 0 ] = value; } );
-				folder.add( params, 'influence2', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 1 ] = value; } );
-				folder.add( params, 'influence3', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 2 ] = value; } );
-				folder.add( params, 'influence4', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 3 ] = value; } );
-				folder.add( params, 'influence5', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 4 ] = value; } );
-				folder.add( params, 'influence6', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 5 ] = value; } );
-				folder.add( params, 'influence7', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 6 ] = value; } );
-				folder.add( params, 'influence8', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 7 ] = value; } );
+				folder.add( params, 'influence0', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 0 ] = value; } );
+				folder.add( params, 'influence1', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 1 ] = value; } );
+				folder.add( params, 'influence2', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 2 ] = value; } );
+				folder.add( params, 'influence3', 0, 1 ).step( 0.01 ).onChange( function( value ) { mesh.morphTargetInfluences[ 3 ] = value; } );
+
 				folder.open();
 
-				//
+				// Renderer
 
-				renderer = new THREE.WebGLRenderer();
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				//
+				// controls
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
 
@@ -167,8 +193,6 @@
 			}
 
 			function render() {
-
-				mesh.rotation.y += 0.01;
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -70,19 +70,33 @@
 
 				var geometry = new THREE.BufferGeometry();
 
-				var material = new THREE.MeshBasicMaterial( { color: 0xff0000, morphTargets: true, side: THREE.DoubleSide } );
+				var material = new THREE.MeshBasicMaterial( { color: 0xff0000, morphTargets: true } );
 
-				// 2 x 2 square centered at (0, 0, 0)
+				// 2 x 2 cube centered at (0, 0, 0) defined by 8 corner vertices
 				var positions = [
-					-1, -1, 0,
-					1, -1, 0,
-					-1, 1, 0,
-					-1, 1, 0,
-					1, -1, 0,
-					1, 1, 0,
+					-1, -1, 1, // 0
+					1, -1, 1, // 1
+					-1, 1, 1, // 2
+					1, 1, 1, // 3
+					-1, -1, -1, // 4
+					1, -1, -1, // 5
+					-1, 1, -1, // 6
+					1, 1, -1, // 7
 				];
 
 				geometry.addAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
+
+				// each face consists of two triangles
+				var indices = [
+				0, 1, 2, 2, 1, 3, // front
+				4, 6, 5, 6, 7, 5, // back
+				2, 3, 6, 3, 7, 6, // top
+				0, 4, 5, 5, 1, 0, // bottom
+				0, 6, 4, 6, 0, 2, // left
+				1, 5, 3, 3, 5, 7 // right
+
+			];
+				geometry.setIndex( new THREE.Uint16BufferAttribute( indices, 1 ) )
 
 				// create an empty array to  hold targets for the attribute we want to morph
 				// morphing positions and normals is supported
@@ -90,50 +104,56 @@
 
 				// morph bottom left corner
 				var morphTargetPositions0 = [
-					-2, -2, 0,
-					1, -1, 0,
-					-1, 1, 0,
-					-1, 1, 0,
-					1, -1, 0,
-					1, 1, 0,
+					-2, -2, 1,
+					1, -1, 1,
+					-1, 1, 1,
+					1, 1, 1,
+					-1, -1, -1,
+					1, -1, -1,
+					-1, 1, -1,
+					1, 1, -1,
 				];
 
 				geometry.morphAttributes.position[ 0 ] = new THREE.Float32BufferAttribute( morphTargetPositions0, 3 );
 
 				// morph bottom right corner
-				// since the square consists of two distinct triangles,
-				// we need to move vertices of upper and lower triangles together here
 				var morphTargetPositions1 = [
-					-1, -1, 0,
-					2, -2, 0,
-					-1, 1, 0,
-					-1, 1, 0,
-					2, -2, 0,
-					1, 1, 0,
+					-1, -1, 1,
+					2, -2, 1,
+					-1, 1, 1,
+					1, 1, 1,
+					-1, -1, -1,
+					1, -1, -1,
+					-1, 1, -1,
+					1, 1, -1,
 				];
 
 				geometry.morphAttributes.position[ 1 ] = new THREE.Float32BufferAttribute( morphTargetPositions1, 3 );
 
 				// morph top left corner
 				var morphTargetPositions2 = [
-					-1, -1, 0,
-					1, -1, 0,
-					-2, 2, 0,
-					-2, 2, 0,
-					1, -1, 0,
-					1, 1, 0,
+					-1, -1, 1,
+					1, -1, 1,
+					-2, 2, 1,
+					1, 1, 1,
+					-1, -1, -1,
+					1, -1, -1,
+					-1, 1, -1,
+					1, 1, -1,
 				];
 
 				geometry.morphAttributes.position[ 2 ] = new THREE.Float32BufferAttribute( morphTargetPositions2, 3 );
 
 				// morph top right corner
 				var morphTargetPositions3 = [
-					-1, -1, 0,
-					1, -1, 0,
-					-1, 1, 0,
-					-1, 1, 0,
-					1, -1, 0,
-					2, 2, 0,
+					-1, -1, 1,
+					1, -1, 1,
+					-1, 1, 1,
+					2, 2, 1,
+					-1, -1, -1,
+					1, -1, -1,
+					-1, 1, -1,
+					1, 1, -1,
 				];
 
 				geometry.morphAttributes.position[ 3 ] = new THREE.Float32BufferAttribute( morphTargetPositions3, 3 );
@@ -168,7 +188,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				// controls
+				// Controls
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
 

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -64,9 +64,6 @@
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0x222222 );
 
-				var ambientLight = new THREE.AmbientLight( 0x333333 );
-				scene.add( ambientLight );
-
 				var pointLight = new THREE.PointLight( 0xffffff, 1 );
 				camera.add( pointLight );
 				scene.add( camera )
@@ -91,15 +88,15 @@
 
 				// each face consists of two triangles
 				var indices = [
-				2, 0, 1, 1, 3, 2, // front
-				4, 6, 5, 6, 7, 5, // back
-				2, 3, 6, 3, 7, 6, // top
-				0, 4, 5, 5, 1, 0, // bottom
-				0, 6, 4, 6, 0, 2, // left
-				1, 5, 3, 3, 5, 7 // right
+					2, 0, 1, 1, 3, 2, // front
+					4, 6, 5, 6, 7, 5, // back
+					2, 3, 6, 3, 7, 6, // top
+					0, 4, 5, 5, 1, 0, // bottom
+					0, 6, 4, 6, 0, 2, // left
+					1, 5, 3, 3, 5, 7 // right
+				];
 
-			];
-				geometry.setIndex( new THREE.Uint16BufferAttribute( indices, 1 ) )
+				geometry.setIndex( indices );
 
 				// create an empty array to  hold targets for the attribute we want to morph
 				// morphing positions and normals is supported

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -51,10 +51,6 @@
 
 			var camera, scene, renderer;
 
-			var geometry, objects;
-
-			var mesh;
-
 			init();
 			animate();
 
@@ -68,27 +64,34 @@
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0x222222 );
 
+				var ambientLight = new THREE.AmbientLight( 0x333333 );
+				scene.add( ambientLight );
+
+				var pointLight = new THREE.PointLight( 0xffffff, 1 );
+				camera.add( pointLight );
+				scene.add( camera )
+
 				var geometry = new THREE.BufferGeometry();
 
-				var material = new THREE.MeshBasicMaterial( { color: 0xff0000, morphTargets: true } );
+				var material = new THREE.MeshPhongMaterial( { flatShading: true, color: 0xff0000, morphTargets: true } );
 
 				// 2 x 2 cube centered at (0, 0, 0) defined by 8 corner vertices
 				var positions = [
-					-1, -1, 1, // 0
-					1, -1, 1, // 1
-					-1, 1, 1, // 2
-					1, 1, 1, // 3
-					-1, -1, -1, // 4
-					1, -1, -1, // 5
-					-1, 1, -1, // 6
-					1, 1, -1, // 7
+					-1, -1, 1, // front bottom left
+					1, -1, 1, // front bottom right
+					-1, 1, 1, // front top left
+					1, 1, 1, // front top right
+					-1, -1, -1, // back bottom left
+					1, -1, -1, // back bottom right
+					-1, 1, -1, // back top left
+					1, 1, -1, // back top right
 				];
 
 				geometry.addAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
 
 				// each face consists of two triangles
 				var indices = [
-				0, 1, 2, 2, 1, 3, // front
+				2, 0, 1, 1, 3, 2, // front
 				4, 6, 5, 6, 7, 5, // back
 				2, 3, 6, 3, 7, 6, // top
 				0, 4, 5, 5, 1, 0, // bottom
@@ -102,13 +105,13 @@
 				// morphing positions and normals is supported
 				geometry.morphAttributes.position = [];
 
-				// morph bottom left corner
+				// morph bottom left edge
 				var morphTargetPositions0 = [
-					-2, -2, 1,
+					-2, -2, 2,
 					1, -1, 1,
 					-1, 1, 1,
 					1, 1, 1,
-					-1, -1, -1,
+					-2, -2, -2,
 					1, -1, -1,
 					-1, 1, -1,
 					1, 1, -1,
@@ -116,44 +119,44 @@
 
 				geometry.morphAttributes.position[ 0 ] = new THREE.Float32BufferAttribute( morphTargetPositions0, 3 );
 
-				// morph bottom right corner
+				// morph bottom right edge
 				var morphTargetPositions1 = [
 					-1, -1, 1,
-					2, -2, 1,
+					2, -2, 2,
 					-1, 1, 1,
 					1, 1, 1,
 					-1, -1, -1,
-					1, -1, -1,
+					2, -2, -2,
 					-1, 1, -1,
 					1, 1, -1,
 				];
 
 				geometry.morphAttributes.position[ 1 ] = new THREE.Float32BufferAttribute( morphTargetPositions1, 3 );
 
-				// morph top left corner
+				// morph top left edge
 				var morphTargetPositions2 = [
 					-1, -1, 1,
 					1, -1, 1,
-					-2, 2, 1,
+					-2, 2, 2,
 					1, 1, 1,
 					-1, -1, -1,
 					1, -1, -1,
-					-1, 1, -1,
+					-2, 2, -2,
 					1, 1, -1,
 				];
 
 				geometry.morphAttributes.position[ 2 ] = new THREE.Float32BufferAttribute( morphTargetPositions2, 3 );
 
-				// morph top right corner
+				// morph top right edge
 				var morphTargetPositions3 = [
 					-1, -1, 1,
 					1, -1, 1,
 					-1, 1, 1,
-					2, 2, 1,
+					2, 2, 2,
 					-1, -1, -1,
 					1, -1, -1,
 					-1, 1, -1,
-					1, 1, -1,
+					2, 2, -2,
 				];
 
 				geometry.morphAttributes.position[ 3 ] = new THREE.Float32BufferAttribute( morphTargetPositions3, 3 );
@@ -181,14 +184,14 @@
 
 				folder.open();
 
-				// Renderer
+				// renderer
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				// Controls
+				// controls
 
 				controls = new THREE.OrbitControls( camera, renderer.domElement );
 


### PR DESCRIPTION
None of the morph target examples currently use BufferGeometry. Updated and simplified the webgl_morphtargets example so that it serves as a basic introduction to using morphtargets with a buffergeometry. 

Now the example uses a square rather than a cube, and the morph positions are created manually rather than in a loop so that the change in position is as obvious as possible. 

[Old version](https://threejs.org/examples/#webgl_morphtargets)
[New version](https://cdn.rawgit.com/looeee/three.js/c310d50137be42a762a2685d180ccf5edcec5aa2/examples/webgl_morphtargets.html) (non-indexed square)

I've added a note to say that morphing of positions and normals is supported, can somebody confirm that this is correct? 