### PR TITLE
Docs: Fix some property references in paragraphs.

### DIFF
--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -41,7 +41,7 @@
 		<p>
 		Blending destination. Default is [page:CustomBlendingEquation OneMinusSrcAlphaFactor].
 		See the destination factors [page:CustomBlendingEquation constants] for all possible values.<br />
-		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
+		The material's [page:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
 		</p>
 
 		<h3>[property:Integer blendDstAlpha]</h3>
@@ -51,7 +51,7 @@
 		<p>
 		Blending equation to use when applying blending. Default is [page:CustomBlendingEquation AddEquation].
 		See the blending equation [page:CustomBlendingEquation constants] for all possible values.<br />
-		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
+		The material's [page:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
 		</p>
 
 		<h3>[property:Integer blendEquationAlpha]</h3>
@@ -60,7 +60,7 @@
 		<h3>[property:Blending blending]</h3>
 		<p>
 		Which blending to use when displaying objects with this material. <br />
-		This must be set to [page:Materials CustomBlending] to use custom [property:Constant blendSrc], [property:Constant blendDst] or [property:Constant blendEquation].<br />
+		This must be set to [page:Materials CustomBlending] to use custom [page:Constant blendSrc], [page:Constant blendDst] or [page:Constant blendEquation].<br />
 		See the blending mode [page:Materials constants] for all possible values. Default is [page:Materials NormalBlending].
 		</p>
 
@@ -68,7 +68,7 @@
 		<p>
 		Blending source. Default is [page:CustomBlendingEquation SrcAlphaFactor].
 		See the source factors [page:CustomBlendingEquation constants] for all possible values.<br />
-		The material's [property:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
+		The material's [page:Constant blending] must be set to [page:Materials CustomBlending] for this to have any effect.
 		</p>
 
 		<h3>[property:Integer blendSrcAlpha]</h3>
@@ -98,7 +98,7 @@
 		<h3>[property:Boolean colorWrite]</h3>
 		<p>
 		Whether to render the material's color.
-		This can be used in conjunction with a mesh's [property:Integer renderOrder] property to create invisible objects that occlude other objects. Default is *true*.
+		This can be used in conjunction with a mesh's [page:Integer renderOrder] property to create invisible objects that occlude other objects. Default is *true*.
 		</p>
 
 		<h3>[property:Material customDepthMaterial]</h3>
@@ -171,7 +171,7 @@
 		<p>
 		Float in the range of *0.0* - *1.0* indicating how transparent the material is.
 		A value of *0.0* indicates fully transparent, *1.0* is fully opaque.<br />
-		If the material's [property:Boolean transparent] property is not set to *true*, the material will remain
+		If the material's [page:Boolean transparent] property is not set to *true*, the material will remain
 		fully opaque and this value will only affect its color. <br />
 		Default is *1.0*.
 		</p>
@@ -259,7 +259,7 @@
 		as transparent objects need special treatment and are rendered after
 		non-transparent objects. <br />
 		When set to true, the extent to which the material is transparent is
-		controlled by setting it's [property:Float opacity] property. <br />
+		controlled by setting it's [page:Float opacity] property. <br />
 		Default is *false*.
 		</p>
 

--- a/docs/api/renderers/WebGLRenderer.html
+++ b/docs/api/renderers/WebGLRenderer.html
@@ -96,31 +96,31 @@
 		<p>
 		An object containing details about the capabilities of the current [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext RenderingContext].<br />
 
-		- [property:Boolean floatFragmentTextures]: whether the context supports the [link:https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float OES_texture_float] extension.
+		- [page:Boolean floatFragmentTextures]: whether the context supports the [link:https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float OES_texture_float] extension.
 			According to [link:https://webglstats.com/ WebGLStats], as of February 2016 over 95% of WebGL enabled devices support this.<br />
-		- [property:Boolean floatVertexTextures]: *true* if [property:Boolean floatFragmentTextures] and [property:Boolean vertexTextures] are both true.<br />
-		- [property:Method getMaxAnisotropy](): Returns the maximum available anisotropy.<br />
-		- [property:Method getMaxPrecision](): Returns the maximum available precision for vertex and fragment shaders. <br />
-		- [property:Boolean logarithmicDepthBuffer]: *true* if the [property:parameter logarithmicDepthBuffer] was set to true in the constructor and
+		- [page:Boolean floatVertexTextures]: *true* if [page:Boolean floatFragmentTextures] and [page:Boolean vertexTextures] are both true.<br />
+		- [page:Method getMaxAnisotropy](): Returns the maximum available anisotropy.<br />
+		- [page:Method getMaxPrecision](): Returns the maximum available precision for vertex and fragment shaders. <br />
+		- [page:Boolean logarithmicDepthBuffer]: *true* if the [page:parameter logarithmicDepthBuffer] was set to true in the constructor and
 		the context supports the [link:https://developer.mozilla.org/en-US/docs/Web/API/EXT_frag_depth EXT_frag_depth] extension.
 			According to [link:https://webglstats.com/ WebGLStats], as of February 2016 around 66% of WebGL enabled devices support this.<br />
-		- [property:Integer maxAttributes]: The value of *gl.MAX_VERTEX_ATTRIBS*.<br />
-		- [property:Integer maxCubemapSize]: The value of *gl.MAX_CUBE_MAP_TEXTURE_SIZE*.
+		- [page:Integer maxAttributes]: The value of *gl.MAX_VERTEX_ATTRIBS*.<br />
+		- [page:Integer maxCubemapSize]: The value of *gl.MAX_CUBE_MAP_TEXTURE_SIZE*.
 		Maximum height * width of cube map textures that a shader can use.<br />
-		- [property:Integer maxFragmentUniforms]: The value of *gl.MAX_FRAGMENT_UNIFORM_VECTORS*.
+		- [page:Integer maxFragmentUniforms]: The value of *gl.MAX_FRAGMENT_UNIFORM_VECTORS*.
 		  The number of uniforms that can be used by a fragment shader.<br />
-		- [property:Integer maxTextureSize]: The value of *gl.MAX_TEXTURE_SIZE*.
+		- [page:Integer maxTextureSize]: The value of *gl.MAX_TEXTURE_SIZE*.
 		Maximum height * width of a texture that a shader use.<br />
-		- [property:Integer maxTextures]: The value of *gl.MAX_TEXTURE_IMAGE_UNITS*.
+		- [page:Integer maxTextures]: The value of *gl.MAX_TEXTURE_IMAGE_UNITS*.
 		  The maximum number of textures that can be used by a shader.<br />
-		- [property:Integer maxVaryings]: The value of *gl.MAX_VARYING_VECTORS*.
+		- [page:Integer maxVaryings]: The value of *gl.MAX_VARYING_VECTORS*.
 		  The number of varying vectors that can used by shaders.<br />
-		- [property:Integer maxVertexTextures]: The value of *gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS*.
+		- [page:Integer maxVertexTextures]: The value of *gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS*.
 		   The number of textures that can be used in a vertex shader.<br />
-		- [property:Integer maxVertexUniforms]: The value of *gl.MAX_VERTEX_UNIFORM_VECTORS*.
+		- [page:Integer maxVertexUniforms]: The value of *gl.MAX_VERTEX_UNIFORM_VECTORS*.
 		   The maximum number of uniforms that can be used in a vertex shader.<br />
-		- [property:String precision]: The shader precision currently being used by the renderer.<br />
-		- [property:Boolean vertexTextures]: *true* if [property:Integer maxVertexTextures] is greater than 0 (i.e. vertext textures can be used).<br />
+		- [page:String precision]: The shader precision currently being used by the renderer.<br />
+		- [page:Boolean vertexTextures]: *true* if [property:Integer maxVertexTextures] is greater than 0 (i.e. vertext textures can be used).<br />
 		</p>
 
 		<h3>[property:Array clippingPlanes]</h3>


### PR DESCRIPTION
Various places using `[property:Type Foo]` instead of `[page:Type Foo]` outside of normal property references, which now sticks out with visible type information:

Before:
![screen shot 2018-04-12 at 9 35 21 pm](https://user-images.githubusercontent.com/1848368/38717101-7a9c2a66-3e99-11e8-8a21-bd1b2416f0a5.png)


After:
![screen shot 2018-04-12 at 9 35 36 pm](https://user-images.githubusercontent.com/1848368/38717103-7c7fdc56-3e99-11e8-9420-f4ec9ef092a4.png)
