### PR TITLE
 Reverse cleanup of #13543

### DIFF
--- a/docs/api/geometries/ParametricBufferGeometry.html
+++ b/docs/api/geometries/ParametricBufferGeometry.html
@@ -47,7 +47,7 @@
 
 		<h3>[name]([param:Function func], [param:Integer slices], [param:Integer stacks])</h3>
 		<p>
-		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and modifies a third [page:Vector3] argument<br />
+		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and returns a [page:Vector3] or optionally modifies a third [page:Vector3] argument<br />
 		slices — The count of slices to use for the parametric function <br />
 		stacks — The count of stacks to use for the parametric function
 		</p>

--- a/docs/api/geometries/ParametricGeometry.html
+++ b/docs/api/geometries/ParametricGeometry.html
@@ -47,7 +47,7 @@
 
 		<h3>[name]([param:Function func], [param:Integer slices], [param:Integer stacks])</h3>
 		<p>
-		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and modifies a third [page:Vector3] argument<br />
+		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and returns a [page:Vector3] or optionally modifies a third [page:Vector3] argument<br />
 		slices — The count of slices to use for the parametric function <br />
 		stacks — The count of stacks to use for the parametric function
 		</p>

--- a/src/geometries/ParametricGeometry.js
+++ b/src/geometries/ParametricGeometry.js
@@ -77,7 +77,7 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 
 			// vertex
 
-			func( u, v, p0 );
+			p0 = func( u, v, p0 );
 			vertices.push( p0.x, p0.y, p0.z );
 
 			// normal
@@ -86,24 +86,24 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 
 			if ( u - EPS >= 0 ) {
 
-				func( u - EPS, v, p1 );
+				p1 = func( u - EPS, v, p1 );
 				pu.subVectors( p0, p1 );
 
 			} else {
 
-				func( u + EPS, v, p1 );
+				p1 = func( u + EPS, v, p1 );
 				pu.subVectors( p1, p0 );
 
 			}
 
 			if ( v - EPS >= 0 ) {
 
-				func( u, v - EPS, p1 );
+				p1 = func( u, v - EPS, p1 );
 				pv.subVectors( p0, p1 );
 
 			} else {
 
-				func( u, v + EPS, p1 );
+				p1 = func( u, v + EPS, p1 );
 				pv.subVectors( p1, p0 );
 
 			}


### PR DESCRIPTION
@mrdoob the supposedly minor cleanup on #13543 forces the end user to work in a way that IMHO disrupts how a mathematically inclined person thinks about functions. A parametrization function returns the coordinates corresponding to the input parameters: it doesn't modify the parameters. I should think someone using ParametricGeometry would expect a function to behave like a mathematical function.

With the cleanup reversed, the end user still has the option to modify a third argument if desired for efficiency, but doesn't force that person to think non-mathematically. I would really like to know whether or not this cleanup was strictly necessary from a performance point of view.