### PR TITLE
GLTFLoader: Minor clean up

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -243,7 +243,7 @@ THREE.GLTFLoader = ( function () {
 	 */
 	function GLTFTextureDDSExtension() {
 
-		if (!THREE.DDSLoader) {
+		if ( ! THREE.DDSLoader ) {
 
 			throw new Error( 'THREE.GLTFLoader: Attempting to load .dds texture without importing THREE.DDSLoader' );
 
@@ -1906,6 +1906,7 @@ THREE.GLTFLoader = ( function () {
 
 			if ( textureDef.name !== undefined ) texture.name = textureDef.name;
 
+			// .format of dds texture is set in DDSLoader
 			if ( ! textureExtensions[ EXTENSIONS.MSFT_TEXTURE_DDS ] ) {
 
 				texture.format = textureDef.format !== undefined ? WEBGL_TEXTURE_FORMATS[ textureDef.format ] : THREE.RGBAFormat;


### PR DESCRIPTION
Minor clean up for the code style and add comment for dds `.format`. About the `.format` for dds texture, I think it'd be worth to add comment because I was actually a bit wondered where it's set when I was reading the code.