### PR TITLE
CSS3DRenderer: Use WeakMap for styles cache.

### DIFF
--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -185,8 +185,9 @@ THREE.CSS3DRenderer = function () {
 
 			var element = object.element;
 			var cachedStyle = cache.objects[ object.id ] && cache.objects[ object.id ].style;
+			var firstTime = cachedStyle === undefined;
 
-			if ( cachedStyle === undefined || cachedStyle !== style ) {
+			if ( firstTime || cachedStyle !== style ) {
 
 				element.style.WebkitTransform = style;
 				element.style.transform = style;
@@ -198,6 +199,16 @@ THREE.CSS3DRenderer = function () {
 					cache.objects[ object.id ].distanceToCameraSquared = getDistanceToSquared( camera, object );
 
 				}
+
+			}
+
+			if ( firstTime ) {
+
+				object.addEventListener( 'removed', function () {
+
+					delete cache.objects[ object.id ];
+
+				} );
 
 			}
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -48,7 +48,7 @@ THREE.CSS3DRenderer = function () {
 
 	var cache = {
 		camera: { fov: 0, style: '' },
-		objects: {}
+		objects: new WeakMap()
 	};
 
 	var domElement = document.createElement( 'div' );
@@ -184,31 +184,22 @@ THREE.CSS3DRenderer = function () {
 			}
 
 			var element = object.element;
-			var cachedStyle = cache.objects[ object.id ] && cache.objects[ object.id ].style;
-			var firstTime = cachedStyle === undefined;
+			var cachedStyle = cache.objects.get( object );
 
-			if ( firstTime || cachedStyle !== style ) {
+			if ( cachedStyle === undefined || cachedStyle !== style ) {
 
 				element.style.WebkitTransform = style;
 				element.style.transform = style;
 
-				cache.objects[ object.id ] = { style: style };
+				var objectData = { style: style };
 
 				if ( isIE ) {
 
-					cache.objects[ object.id ].distanceToCameraSquared = getDistanceToSquared( camera, object );
+					objectData.distanceToCameraSquared = getDistanceToSquared( camera, object );
 
 				}
 
-			}
-
-			if ( firstTime ) {
-
-				object.addEventListener( 'removed', function () {
-
-					delete cache.objects[ object.id ];
-
-				} );
+				cache.objects.set( object, objectData );
 
 			}
 
@@ -244,26 +235,38 @@ THREE.CSS3DRenderer = function () {
 
 	}();
 
-	function zOrder( scene ) {
+	function filterAndFlatten( scene ) {
 
-		var order = Object.keys( cache.objects ).sort( function ( a, b ) {
-
-			return cache.objects[ a ].distanceToCameraSquared - cache.objects[ b ].distanceToCameraSquared;
-
-		} );
-		var zMax = order.length;
+		var result = [];
 
 		scene.traverse( function ( object ) {
 
-			var index = order.indexOf( object.id + '' );
-
-			if ( index !== - 1 ) {
-
-				object.element.style.zIndex = zMax - index;
-
-			}
+			if ( object instanceof THREE.CSS3DObject ) result.push( object );
 
 		} );
+
+		return result;
+
+	}
+
+	function zOrder( scene ) {
+
+		var sorted = filterAndFlatten( scene ).sort( function ( a, b ) {
+
+			var distanceA = cache.objects.get( a ).distanceToCameraSquared;
+			var distanceB = cache.objects.get( b ).distanceToCameraSquared;
+
+			return distanceA - distanceB;
+
+		} );
+
+		var zMax = sorted.length;
+
+		for ( var i = 0, l = sorted.length; i < l; i ++ ) {
+
+			sorted[ i ].element.style.zIndex = zMax - i;
+
+		}
 
 	}
 


### PR DESCRIPTION
CSS3Renderer caches CSS3DObject's css styles in [a scoped pool](https://github.com/mrdoob/three.js/blob/bc3aa48ed4ea8190f30957a7993c9135fa8047a6/examples/js/renderers/CSS3DRenderer.js#L51).

However, once the style is [added to the pool](https://github.com/mrdoob/three.js/blob/bc3aa48ed4ea8190f30957a7993c9135fa8047a6/examples/js/renderers/CSS3DRenderer.js#L194), it will never be removed, even [with `scene.remove( css3DObject )`](https://github.com/mrdoob/three.js/blob/bc3aa48ed4ea8190f30957a7993c9135fa8047a6/examples/js/renderers/CSS3DRenderer.js#L14), then memory leak occurs.

This PR is to solve the possibility of memory leak.