### PR TITLE
BufferAttribute.setArray method chaining

### DIFF
--- a/docs/api/core/BufferAttribute.html
+++ b/docs/api/core/BufferAttribute.html
@@ -163,7 +163,7 @@
 		after the buffer has been	transfered to the GPU.
 		</p>
 
-		<h3>[method:null set] ( [param:Array value], [param:Integer offset] ) </h3>
+		<h3>[method:BufferAttribute set] ( [param:Array value], [param:Integer offset] ) </h3>
 		<p>
 		value -- an [page:Array] or [page:TypedArray] from which to copy values. <br />
 		offset -- (optional) index of the [page:BufferAttribute.array array] at which to start copying.<br /><br />
@@ -175,7 +175,7 @@
 		being a [page:TypedArray].
 		</p>
 
-		<h3>[method:null setArray] ( [param:TypedArray array] ) </h3>
+		<h3>[method:BufferAttribute setArray] ( [param:TypedArray array] ) </h3>
 		<p>
 		[page:BufferAttribute.array array] to the TypedArray passed in here.<br /><br />
 
@@ -185,25 +185,25 @@
 		<h3>[method:BufferAttribute setDynamic] ( [param:Boolean value] ) </h3>
 		<p>Set [page:BufferAttribute.dynamic dynamic] to value.</p>
 
-		<h3>[method:null setX]( index, x ) </h3>
+		<h3>[method:BufferAttribute setX]( index, x ) </h3>
 		<p>Sets the x component of the vector at the given index.</p>
 
-		<h3>[method:null setY]( index, y ) </h3>
+		<h3>[method:BufferAttribute setY]( index, y ) </h3>
 		<p>Sets the y component of the vector at the given index.</p>
 
-		<h3>[method:null setZ]( index, z ) </h3>
+		<h3>[method:BufferAttribute setZ]( index, z ) </h3>
 		<p>Sets the z component of the vector at the given index.</p>
 
-		<h3>[method:null setW]( index, w ) </h3>
+		<h3>[method:BufferAttribute setW]( index, w ) </h3>
 		<p>Sets the w component of the vector at the given index.</p>
 
-		<h3>[method:null setXY]( index, x, y ) </h3>
+		<h3>[method:BufferAttribute setXY]( index, x, y ) </h3>
 		<p>Sets the x and y components of the vector at the given index.</p>
 
-		<h3>[method:null setXYZ]( index, x, y, z ) </h3>
+		<h3>[method:BufferAttribute setXYZ]( index, x, y, z ) </h3>
 		<p>Sets the x, y and z components of the vector at the given index.</p>
 
-		<h3>[method:null setXYZW]( index, x, y, z, w ) </h3>
+		<h3>[method:BufferAttribute setXYZW]( index, x, y, z, w ) </h3>
 		<p>Sets the x, y, z and w components of the vector at the given index.</p>
 
 

--- a/docs/api/core/InterleavedBuffer.html
+++ b/docs/api/core/InterleavedBuffer.html
@@ -81,7 +81,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setArray] ( [param:TypedArray array] ) </h3>
+		<h3>[method:InterleavedBuffer setArray] ( [param:TypedArray array] ) </h3>
 		<p>
 		 array - must be  a Typed Array.
 		</p>

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -56,6 +56,8 @@ Object.assign( BufferAttribute.prototype, {
 		this.count = array !== undefined ? array.length / this.itemSize : 0;
 		this.array = array;
 
+		return this;
+
 	},
 
 	setDynamic: function ( value ) {

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -43,6 +43,8 @@ Object.assign( InterleavedBuffer.prototype, {
 		this.count = array !== undefined ? array.length / this.stride : 0;
 		this.array = array;
 
+		return this;
+
 	},
 
 	setDynamic: function ( value ) {


### PR DESCRIPTION
Let's return `this` from `BufferAttribute.setArray()` and make it chain-able as other methods of `BufferAttribute` do.