### PR TITLE
SVGLoader: parse style from DOM, going up to ancestors until find style.fill

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -28,7 +28,7 @@ THREE.SVGLoader.prototype = {
 
 	parse: function ( text ) {
 
-		function parseNode( node, style ) {
+		function parseNode( node ) {
 
 			if ( node.nodeType !== 1 ) return;
 
@@ -38,41 +38,40 @@ THREE.SVGLoader.prototype = {
 					break;
 
 				case 'g':
-					style = parseStyle( node, style );
 					break;
 
 				case 'path':
-					style = parseStyle( node, style );
+					var style = parseStyle( node );
 					if ( style.fill !== 'none' ) paths.push( parsePathNode( node, style ) );
 					break;
 
 				case 'rect':
-					style = parseStyle( node, style );
+					var style = parseStyle( node );
 					if ( style.fill !== 'none' ) paths.push( parseRectNode( node, style ) );
 					break;
 
 				case 'polygon':
-					style = parseStyle( node, style );
+					var style = parseStyle( node );
 					if ( style.fill !== 'none' ) paths.push( parsePolygonNode( node, style ) );
 					break;
 
 				case 'polyline':
-					style = parseStyle( node, style );
+					var style = parseStyle( node );
 					if ( style.fill !== 'none' ) paths.push( parsePolylineNode( node, style ) );
 					break;
 
 				case 'circle':
-					style = parseStyle( node, style );
+					var style = parseStyle( node );
 					if ( style.fill !== 'none' ) paths.push( parseCircleNode( node, style ) );
 					break;
 
 				case 'ellipse':
-					style = parseStyle( node, style );
+					var style = parseStyle( node );
 					if ( style.fill !== 'none' ) paths.push( parseEllipseNode( node, style ) );
 					break;
 
 				case 'line':
-					style = parseStyle( node, style );
+					var style = parseStyle( node );
 					if ( style.fill !== 'none' ) paths.push( parseLineNode( node, style ) );
 					break;
 
@@ -85,7 +84,7 @@ THREE.SVGLoader.prototype = {
 
 			for ( var i = 0; i < nodes.length; i ++ ) {
 
-				parseNode( nodes[ i ], style );
+				parseNode( nodes[ i ] );
 
 			}
 
@@ -476,14 +475,24 @@ THREE.SVGLoader.prototype = {
 
 		//
 
-		function parseStyle( node, style ) {
+		function parseStyle( node ) {
 
-			style = Object.assign( {}, style ); // clone style
+			return { fill: getFill( node ) };
 
-			if ( node.hasAttribute( 'fill' ) ) style.fill = node.getAttribute( 'fill' );
-			if ( node.style.fill !== '' ) style.fill = node.style.fill;
+		}
 
-			return style;
+		function getFill( node ) {
+
+			if ( node.hasAttribute( 'fill' ) ) return node.getAttribute( 'fill' );
+			if ( node.style.fill !== '' ) return node.style.fill;
+
+			if ( node.parentNode ) {
+
+				return getFill( node.parentNode );
+
+			}
+
+			return '#000';
 
 		}
 
@@ -514,7 +523,7 @@ THREE.SVGLoader.prototype = {
 		var paths = [];
 		var xml = new DOMParser().parseFromString( text, 'image/svg+xml' ); // application/xml
 
-		parseNode( xml.documentElement, { fill: '#000' } );
+		parseNode( xml.documentElement );
 
 		return paths;
 


### PR DESCRIPTION
That fixes the issue #13803 that the style attribute of SVG root tag is not parsed.
Big change, sorry, but I do not think we need to keep a style object browsing the DOM tree, cloning it at each level.

I test several cases on https://rawgit.com/ndebeiss/three.js/dev/examples/svg_load_and_render.html

main example 
https://rawgit.com/ndebeiss/three.js/dev/examples/webgl_loader_svg.html