### PR TITLE
FBXLoader: Fix Filename to RelativeFilename in parseImage()

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -185,7 +185,7 @@
 
 						var image = parseImage( videoNodes[ nodeID ] );
 
-						blobs[ videoNode.Filename ] = image;
+						blobs[ videoNode.RelativeFilename || videoNode.Filename ] = image;
 
 					}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -173,7 +173,7 @@
 
 				var id = parseInt( nodeID );
 
-				images[ id ] = videoNode.Filename;
+				images[ id ] = videoNode.RelativeFilename || videoNode.Filename;
 
 				// raw image data is in videoNode.Content
 				if ( 'Content' in videoNode ) {


### PR DESCRIPTION
The path of "Filename" property is useless. It depends on local directory (ex. C:\somewhere\blahblah\somefile.fbx). RelativeFilename is better for URI.
I made a tiny example in codesandbox ( https://codesandbox.io/s/y2kv8yyw5j ).
enjoy it! 💃 