### PR TITLE
Handle normal/bump maps when material is back/double-sided

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -8,7 +8,8 @@ import {
 	TriangleStripDrawMode,
 	TrianglesDrawMode,
 	NoColors,
-	LinearToneMapping
+	LinearToneMapping,
+	BackSide
 } from '../constants.js';
 import { _Math } from '../math/Math.js';
 import { DataTexture } from '../textures/DataTexture.js';
@@ -2140,6 +2141,7 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.bumpMap.value = material.bumpMap;
 			uniforms.bumpScale.value = material.bumpScale;
+			if ( material.side === BackSide ) uniforms.bumpScale.value *= - 1;
 
 		}
 
@@ -2147,6 +2149,7 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
+			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
 
 		}
 
@@ -2199,6 +2202,7 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.bumpMap.value = material.bumpMap;
 			uniforms.bumpScale.value = material.bumpScale;
+			if ( material.side === BackSide ) uniforms.bumpScale.value *= - 1;
 
 		}
 
@@ -2206,6 +2210,7 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
+			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
 
 		}
 
@@ -2269,6 +2274,7 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.bumpMap.value = material.bumpMap;
 			uniforms.bumpScale.value = material.bumpScale;
+			if ( material.side === BackSide ) uniforms.bumpScale.value *= - 1;
 
 		}
 
@@ -2276,6 +2282,7 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
+			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl
@@ -34,6 +34,8 @@
 
 		float fDet = dot( vSigmaX, R1 );
 
+		fDet *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+
 		vec3 vGrad = sign( fDet ) * ( dHdxy.x * R1 + dHdxy.y * R2 );
 		return normalize( abs( fDet ) * surf_norm - vGrad );
 

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl
@@ -16,15 +16,17 @@
 		vec2 st1 = dFdy( vUv.st );
 
 		float scale = sign( st1.t * st0.s - st0.t * st1.s ); // we do not care about the magnitude
-		scale *= float( gl_FrontFacing ) * 2.0 - 1.0;
 
 		vec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );
 		vec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );
 		vec3 N = normalize( surf_norm );
+		mat3 tsn = mat3( S, T, N );
 
 		vec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
-		mapN.xy = normalScale * mapN.xy;
-		mat3 tsn = mat3( S, T, N );
+
+		mapN.xy *= normalScale;
+		mapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+
 		return normalize( tsn * mapN );
 
 	}


### PR DESCRIPTION
For both double-sided and back-sided materials, we want extrusions when viewed from the front side, to appear as indentations when viewed from the back side.

This PR should ensure that behavior for both normal maps and bump maps.