### PR TITLE
Improved Fog.clone & FogExp2.clone

### DIFF
--- a/src/scenes/Fog.js
+++ b/src/scenes/Fog.js
@@ -20,7 +20,7 @@ Fog.prototype.isFog = true;
 
 Fog.prototype.clone = function () {
 
-	return new Fog( this.color.getHex(), this.near, this.far );
+	return new Fog( this.color, this.near, this.far );
 
 };
 

--- a/src/scenes/FogExp2.js
+++ b/src/scenes/FogExp2.js
@@ -18,7 +18,7 @@ FogExp2.prototype.isFogExp2 = true;
 
 FogExp2.prototype.clone = function () {
 
-	return new FogExp2( this.color.getHex(), this.density );
+	return new FogExp2( this.color, this.density );
 
 };
 


### PR DESCRIPTION
Color will be reset in Fog's constructor, no need to convert to HEX.