### PR TITLE
Fix Texture.mapping type in Texture doc

### DIFF
--- a/docs/api/textures/Texture.html
+++ b/docs/api/textures/Texture.html
@@ -60,7 +60,7 @@
 		Array of user-specified mipmaps (optional).
 		</p>
 
-		<h3>[property:object mapping]</h3>
+		<h3>[property:number mapping]</h3>
 		<p>
 		How the image is applied to the object. An object type of [page:Textures THREE.UVMapping] is the default,
 		where the U,V coordinates are used to apply the map.<br />


### PR DESCRIPTION
`Texture.mapping` is number, not object.