### PR TITLE
 Fix WebGLBufferRenderer renderInstance bug

### DIFF
--- a/src/renderers/webgl/WebGLBufferRenderer.js
+++ b/src/renderers/webgl/WebGLBufferRenderer.js
@@ -31,19 +31,7 @@ function WebGLBufferRenderer( gl, extensions, info ) {
 
 		}
 
-		var position = geometry.attributes.position;
-
-		if ( position.isInterleavedBufferAttribute ) {
-
-			count = position.count;
-
-			extension.drawArraysInstancedANGLE( mode, 0, count, geometry.maxInstancedCount );
-
-		} else {
-
-			extension.drawArraysInstancedANGLE( mode, start, count, geometry.maxInstancedCount );
-
-		}
+		extension.drawArraysInstancedANGLE( mode, start, count, geometry.maxInstancedCount );
 
 		info.update( count, mode, geometry.maxInstancedCount );
 

--- a/src/renderers/webgl/WebGLBufferRenderer.js
+++ b/src/renderers/webgl/WebGLBufferRenderer.js
@@ -35,7 +35,7 @@ function WebGLBufferRenderer( gl, extensions, info ) {
 
 		if ( position.isInterleavedBufferAttribute ) {
 
-			count = position.data.count;
+			count = position.count;
 
 			extension.drawArraysInstancedANGLE( mode, 0, count, geometry.maxInstancedCount );
 


### PR DESCRIPTION
When position is an InterleavedBufferAttribute, the  ```start``` property does not take effect.