### PR TITLE
Audio: Added .setMediaElementSource()

### DIFF
--- a/docs/api/audio/Audio.html
+++ b/docs/api/audio/Audio.html
@@ -179,6 +179,13 @@
 		(whether playback should loop).
 		</p>
 
+		<h3>[method:null setMediaElementSource]( mediaElement )</h3>
+		<p>
+		Applies the given object of type [link:https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement HTMLMediaElement] as the source of this audio.<br />
+		Also sets [page:Audio.hasPlaybackControl hasPlaybackControl] to false.
+
+		</p>
+
 		<h3>[method:null setNodeSource]( audioNode )</h3>
 		<p>
 		Setup the [page:Audio.source source] to the audioBuffer, and sets [page:Audio.sourceType sourceType] to 'audioNode'.<br />

--- a/examples/webaudio_visualizer.html
+++ b/examples/webaudio_visualizer.html
@@ -104,19 +104,15 @@
 
 		//
 
-		var audioLoader = new THREE.AudioLoader();
-
 		var listener = new THREE.AudioListener();
 
 		var audio = new THREE.Audio( listener );
 
-		audioLoader.load( 'sounds/376737_Skullbeatz___Bad_Cat_Maste.mp3', function ( buffer ) {
+		var mediaElement = new Audio( 'sounds/376737_Skullbeatz___Bad_Cat_Maste.mp3' );
+		mediaElement.loop = true;
+		mediaElement.play();
 
-			audio.setBuffer( buffer );
-			audio.setLoop( true );
-			audio.play();
-
-		} );
+		audio.setMediaElementSource( mediaElement );
 
 		analyser = new THREE.AudioAnalyser( audio, fftSize );
 

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -52,6 +52,17 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	},
 
+	setMediaElementSource: function ( mediaElement ) {
+
+		this.hasPlaybackControl = false;
+		this.sourceType = 'mediaNode';
+		this.source = this.context.createMediaElementSource( mediaElement );
+		this.connect();
+
+		return this;
+
+	},
+
 	setBuffer: function ( audioBuffer ) {
 
 		this.buffer = audioBuffer;


### PR DESCRIPTION
This is a much better version of #11115 😊 

@mrdoob As you said, a single new method for `Audio` makes it possible to playback audios based on `HTMLMediaElement`. In this way it's not necessary to load and decode the entire file which is very useful for stuff like music or ambient sound.

Sry, I have only now realized that this approach actually works 😅 .