### PR TITLE
SVGLoader : correction for sweep_flag

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -433,9 +433,8 @@ THREE.SVGLoader.prototype = {
 			var theta = svgAngle( 1, 0, ( x1p - cxp ) / rx, ( y1p - cyp ) / ry );
 			var delta = svgAngle( ( x1p - cxp ) / rx, ( y1p - cyp ) / ry, ( - x1p - cxp ) / rx, ( - y1p - cyp ) / ry );
 			delta = delta % ( Math.PI * 2 );
-			if ( ! sweep_flag ) delta -= 2 * Math.PI;
 
-			path.currentPath.absellipse( cx, cy, rx, ry, theta, theta + delta, theta + delta < theta, x_axis_rotation );
+			path.currentPath.absellipse( cx, cy, rx, ry, theta, theta + delta, sweep_flag === 0, x_axis_rotation );
 
 		}
 


### PR DESCRIPTION
extract of https://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes :

fS is the sweep flag, and is 0 if the line joining center to arc sweeps through decreasing angles, or 1 if it sweeps through increasing angles.

The three.js method absellipse() does not care about the sign of theta angle, but reads sweep_flag flag.

#13478