### PR TITLE
Add option to prevent vr from auto submitting frame on render

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1201,7 +1201,7 @@ function WebGLRenderer( parameters ) {
 
 		scene.onAfterRender( _this, scene, camera );
 
-		if ( vr.enabled ) {
+		if ( vr.enabled && vr.autoSubmitFrame ) {
 
 			vr.submitFrame();
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -79,6 +79,7 @@ function WebVRManager( renderer ) {
 
 	this.enabled = false;
 	this.userHeight = 1.6;
+	this.autoSubmitFrame = true;
 
 	this.getDevice = function () {
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -17,6 +17,7 @@ function WebVRManager( renderer ) {
 	var frameData = null;
 
 	var poseTarget = null;
+	var renderScaling = 1.0;
 
 	var standingMatrix = new Matrix4();
 	var standingMatrixInverse = new Matrix4();
@@ -59,8 +60,8 @@ function WebVRManager( renderer ) {
 		if ( isPresenting() ) {
 
 			var eyeParameters = device.getEyeParameters( 'left' );
-			var renderWidth = eyeParameters.renderWidth;
-			var renderHeight = eyeParameters.renderHeight;
+			var renderWidth = eyeParameters.renderWidth * renderScaling;
+			var renderHeight = eyeParameters.renderHeight * renderScaling;
 
 			currentPixelRatio = renderer.getPixelRatio();
 			currentSize = renderer.getSize();
@@ -80,6 +81,12 @@ function WebVRManager( renderer ) {
 	this.enabled = false;
 	this.userHeight = 1.6;
 	this.autoSubmitFrame = true;
+
+	this.setScaling = function ( value ) {
+
+		renderScaling = value;
+
+	}
 
 	this.getDevice = function () {
 


### PR DESCRIPTION
Right now the Renderer auto submit frames.  This breaks usage of the stencil buffer which requires multiple renders.  I'm adding a flag to turn of auto submit frame.

This is a fix for
https://github.com/mrdoob/three.js/issues/13967

