### PR TITLE
TubeGeometry: Added parametric radius via THREE.Path.

### DIFF
--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -86,7 +86,6 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 	var vertex = new Vector3();
 	var normal = new Vector3();
 	var uv = new Vector2();
-	var P = new Vector3();
 
 	var i, j;
 
@@ -140,9 +139,7 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 
 		// we use getPointAt to sample evenly distributed points from the given path
 
-		P = path.getPointAt( i / tubularSegments, P );
-		var P1 = new Vector3();
-		var P2 = new Vector3();
+		var P = path.getPointAt( i / tubularSegments );
 
 		// retrieve corresponding normal and binormal
 
@@ -188,8 +185,8 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 				if ( t1 < 0 ) t1 = 0;
 				if ( t2 > 1 ) t2 = 1;
 
-				path.getPointAt( t1, P1 );
-				path.getPointAt( t2, P2 );
+				var P1 = path.getPointAt( t1 );
+				var P2 = path.getPointAt( t2 );
 				var delta = P1.distanceTo( P2 );
 
 				var r1 = radius.getPointAt( t1 ).y;

--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -14,6 +14,7 @@ import { BufferGeometry } from '../core/BufferGeometry.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Vector3 } from '../math/Vector3.js';
+import { Path } from '../extras/core/Path.js';
 
 // TubeGeometry
 
@@ -139,7 +140,7 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 
 		// we use getPointAt to sample evenly distributed points from the given path
 
-		var P = path.getPointAt( i / tubularSegments, P );
+		path.getPointAt( i / tubularSegments, P );
 		var P1 = new Vector3();
 		var P2 = new Vector3();
 
@@ -196,8 +197,10 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 
 				// prevent dividing by zero
 
-				if( delta !== 0 ) {
+				if ( delta !== 0 ) {
+
 					normal.addScaledVector( T, - ( r2 - r1 ) / delta ).normalize();
+
 				}
 
 			}

--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -140,7 +140,7 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 
 		// we use getPointAt to sample evenly distributed points from the given path
 
-		path.getPointAt( i / tubularSegments, P );
+		P = path.getPointAt( i / tubularSegments, P );
 		var P1 = new Vector3();
 		var P2 = new Vector3();
 

--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -140,6 +140,8 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 		// we use getPointAt to sample evenly distributed points from the given path
 
 		var P = path.getPointAt( i / tubularSegments );
+		var P1;
+		var P2;
 
 		// retrieve corresponding normal and binormal
 
@@ -185,20 +187,14 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 				if ( t1 < 0 ) t1 = 0;
 				if ( t2 > 1 ) t2 = 1;
 
-				var P1 = path.getPointAt( t1 );
-				var P2 = path.getPointAt( t2 );
+				P1 = path.getPointAt( t1, P1 );
+				P2 = path.getPointAt( t2, P2 );
 				var delta = P1.distanceTo( P2 );
 
 				var r1 = radius.getPointAt( t1 ).y;
 				var r2 = radius.getPointAt( t2 ).y;
 
-				// prevent dividing by zero
-
-				if ( delta !== 0 ) {
-
-					normal.addScaledVector( T, - ( r2 - r1 ) / delta ).normalize();
-
-				}
+				normal.addScaledVector( T, - ( r2 - r1 ) / delta ).normalize();
 
 			}
 

--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -165,9 +165,10 @@ function TubeBufferGeometry( path, tubularSegments, radius, radialSegments, clos
 
 			// vertex
 
-			vertex.x = P.x + radius * normal.x;
-			vertex.y = P.y + radius * normal.y;
-			vertex.z = P.z + radius * normal.z;
+			var r = radius instanceof THREE.Path ? radius.getPointAt( i / tubularSegments ).y : radius;
+			vertex.x = P.x + r * normal.x;
+			vertex.y = P.y + r * normal.y;
+			vertex.z = P.z + r * normal.z;
 
 			vertices.push( vertex.x, vertex.y, vertex.z );
 


### PR DESCRIPTION
For variable radius along the tube geometry (like the old taper, but with more control using a Path). Still works with a number, and it should be serialisable.