### PR TITLE
OrbitControls: Support Ctrl-drag as right-drag alternative.

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -74,22 +74,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// The four arrow keys
 	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
 
-	// Mouse buttons -- each may be a mouse button value or a MouseEvent->Boolean predicate
-	this.mouseButtons = {
-		ORBIT: function ( event ) {
-
-			return event.button === THREE.MOUSE.LEFT && ! event.ctrlKey;
-
-		},
-
-		ZOOM: THREE.MOUSE.MIDDLE,
-
-		PAN: function ( event ) {
-
-			return event.button === THREE.MOUSE.RIGHT || ( event.button === THREE.MOUSE.LEFT && event.ctrlKey );
-
-		}
-	};
+	// Mouse buttons
+	this.mouseButtons = { ORBIT: THREE.MOUSE.LEFT, ZOOM: THREE.MOUSE.MIDDLE, PAN: THREE.MOUSE.RIGHT };
 
 	// for reset
 	this.target0 = this.target.clone();
@@ -99,6 +85,18 @@ THREE.OrbitControls = function ( object, domElement ) {
 	//
 	// public methods
 	//
+
+	this.getStateForMouseDown = function ( event ) {
+
+		if ( event.button === scope.mouseButtons.ORBIT && ! event.ctrlKey ) return STATE.ROTATE;
+
+		if ( event.button === scope.mouseButtons.ZOOM ) return STATE.DOLLY;
+
+		if ( event.button === scope.mouseButtons.PAN || ( event.button === scope.mouseButtons.ORBIT && event.ctrlKey ) ) return STATE.PAN;
+
+		return STATE.NONE;
+
+	};
 
 	this.getPolarAngle = function () {
 
@@ -689,40 +687,46 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		event.preventDefault();
 
-		if ( typeof scope.mouseButtons.ORBIT === 'function' ? scope.mouseButtons.ORBIT(event) : event.button === scope.mouseButtons.ORBIT ) {
+		var newState = scope.getStateForMouseDown( event );
 
-			if ( scope.enableRotate === false ) return;
+		switch ( newState ) {
 
-			handleMouseDownRotate( event );
+			case STATE.ROTATE:
 
-			state = STATE.ROTATE;
+				if ( scope.enableRotate === false ) return;
 
-		} else if ( typeof scope.mouseButtons.ZOOM === 'function' ? scope.mouseButtons.ZOOM(event) : event.button === scope.mouseButtons.ZOOM ) {
+				handleMouseDownRotate( event );
 
-			if ( scope.enableZoom === false ) return;
+				break;
 
-			handleMouseDownDolly( event );
+			case STATE.DOLLY:
 
-			state = STATE.DOLLY;
+				if ( scope.enableZoom === false ) return;
 
-		} else if ( typeof scope.mouseButtons.PAN === 'function' ? scope.mouseButtons.PAN(event) : event.button === scope.mouseButtons.PAN ) {
+				handleMouseDownDolly( event );
 
-			if ( scope.enablePan === false ) return;
+				break;
 
-			handleMouseDownPan( event );
+			case STATE.PAN:
 
-			state = STATE.PAN;
+				if ( scope.enablePan === false ) return;
+
+				handleMouseDownPan( event );
+
+				break;
+
+			default: // STATE.NONE
+
+				return;
 
 		}
 
-		if ( state !== STATE.NONE ) {
+		state = newState;
 
-			document.addEventListener( 'mousemove', onMouseMove, false );
-			document.addEventListener( 'mouseup', onMouseUp, false );
+		document.addEventListener( 'mousemove', onMouseMove, false );
+		document.addEventListener( 'mouseup', onMouseUp, false );
 
-			scope.dispatchEvent( startEvent );
-
-		}
+		scope.dispatchEvent( startEvent );
 
 	}
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -74,8 +74,22 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// The four arrow keys
 	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
 
-	// Mouse buttons
-	this.mouseButtons = { ORBIT: THREE.MOUSE.LEFT, ZOOM: THREE.MOUSE.MIDDLE, PAN: THREE.MOUSE.RIGHT };
+	// Mouse buttons -- each may be a mouse button value or a MouseEvent->Boolean predicate
+	this.mouseButtons = {
+		ORBIT: function ( event ) {
+
+			return event.button === THREE.MOUSE.LEFT && ! event.ctrlKey;
+
+		},
+
+		ZOOM: THREE.MOUSE.MIDDLE,
+
+		PAN: function ( event ) {
+
+			return event.button === THREE.MOUSE.RIGHT || ( event.button === THREE.MOUSE.LEFT && event.ctrlKey );
+
+		}
+	};
 
 	// for reset
 	this.target0 = this.target.clone();
@@ -675,37 +689,29 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		event.preventDefault();
 
-		switch ( event.button ) {
+		if ( typeof scope.mouseButtons.ORBIT === 'function' ? scope.mouseButtons.ORBIT(event) : event.button === scope.mouseButtons.ORBIT ) {
 
-			case scope.mouseButtons.ORBIT:
+			if ( scope.enableRotate === false ) return;
 
-				if ( scope.enableRotate === false ) return;
+			handleMouseDownRotate( event );
 
-				handleMouseDownRotate( event );
+			state = STATE.ROTATE;
 
-				state = STATE.ROTATE;
+		} else if ( typeof scope.mouseButtons.ZOOM === 'function' ? scope.mouseButtons.ZOOM(event) : event.button === scope.mouseButtons.ZOOM ) {
 
-				break;
+			if ( scope.enableZoom === false ) return;
 
-			case scope.mouseButtons.ZOOM:
+			handleMouseDownDolly( event );
 
-				if ( scope.enableZoom === false ) return;
+			state = STATE.DOLLY;
 
-				handleMouseDownDolly( event );
+		} else if ( typeof scope.mouseButtons.PAN === 'function' ? scope.mouseButtons.PAN(event) : event.button === scope.mouseButtons.PAN ) {
 
-				state = STATE.DOLLY;
+			if ( scope.enablePan === false ) return;
 
-				break;
+			handleMouseDownPan( event );
 
-			case scope.mouseButtons.PAN:
-
-				if ( scope.enablePan === false ) return;
-
-				handleMouseDownPan( event );
-
-				state = STATE.PAN;
-
-				break;
+			state = STATE.PAN;
 
 		}
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -75,7 +75,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
 
 	// Mouse buttons
-	this.mouseButtons = { ORBIT: THREE.MOUSE.LEFT, ZOOM: THREE.MOUSE.MIDDLE, PAN: THREE.MOUSE.RIGHT };
+	this.mouseButtons = { LEFT: THREE.MOUSE.LEFT, MIDDLE: THREE.MOUSE.MIDDLE, RIGHT: THREE.MOUSE.RIGHT };
 
 	// for reset
 	this.target0 = this.target.clone();
@@ -85,18 +85,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 	//
 	// public methods
 	//
-
-	this.getStateForMouseDown = function ( event ) {
-
-		if ( event.button === scope.mouseButtons.ORBIT && ! event.ctrlKey ) return STATE.ROTATE;
-
-		if ( event.button === scope.mouseButtons.ZOOM ) return STATE.DOLLY;
-
-		if ( event.button === scope.mouseButtons.PAN || ( event.button === scope.mouseButtons.ORBIT && event.ctrlKey ) ) return STATE.PAN;
-
-		return STATE.NONE;
-
-	};
 
 	this.getPolarAngle = function () {
 
@@ -687,46 +675,60 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		event.preventDefault();
 
-		var newState = scope.getStateForMouseDown( event );
+		switch ( event.button ) {
 
-		switch ( newState ) {
+			case scope.mouseButtons.LEFT:
 
-			case STATE.ROTATE:
+				if ( event.ctrlKey || event.metaKey ) {
 
-				if ( scope.enableRotate === false ) return;
+					if ( scope.enablePan === false ) return;
 
-				handleMouseDownRotate( event );
+					handleMouseDownPan( event );
+
+					state = STATE.PAN;
+
+				} else {
+
+					if ( scope.enableRotate === false ) return;
+
+					handleMouseDownRotate( event );
+
+					state = STATE.ROTATE;
+
+				}
 
 				break;
 
-			case STATE.DOLLY:
+			case scope.mouseButtons.MIDDLE:
 
 				if ( scope.enableZoom === false ) return;
 
 				handleMouseDownDolly( event );
 
+				state = STATE.DOLLY;
+
 				break;
 
-			case STATE.PAN:
+			case scope.mouseButtons.RIGHT:
 
 				if ( scope.enablePan === false ) return;
 
 				handleMouseDownPan( event );
 
+				state = STATE.PAN;
+
 				break;
-
-			default: // STATE.NONE
-
-				return;
 
 		}
 
-		state = newState;
+		if ( state !== STATE.NONE ) {
 
-		document.addEventListener( 'mousemove', onMouseMove, false );
-		document.addEventListener( 'mouseup', onMouseUp, false );
+			document.addEventListener( 'mousemove', onMouseMove, false );
+			document.addEventListener( 'mouseup', onMouseUp, false );
 
-		scope.dispatchEvent( startEvent );
+			scope.dispatchEvent( startEvent );
+
+		}
 
 	}
 


### PR DESCRIPTION
Resolves #13970.

Notes:

1. As mentioned in the corresponding issue, whether this is appropriate default behavior or should simply be configurable by users is your call.

2. Since this change requires introducing support not only for Ctrl (_and perhaps Meta/Alt/Shift_) but also for associating multiple triggers with a single action, I believe it's simplest to use lambda predicates (rather than, say, arrays of objects, which we'd need a function call to filter through anyway).

3. Admittedly `ORBIT(event)` looks a bit odd due to the enum casing, but I feel like this is preferable to juggling a possibly-undefined function `isOrbit` alongside `ORBIT`.