### PR TITLE
fix: Command should be used as a constructor

### DIFF
--- a/editor/js/History.js
+++ b/editor/js/History.js
@@ -16,7 +16,7 @@ History = function ( editor ) {
 
 	//Set editor-reference in Command
 
-	Command( editor );
+	new Command( editor );
 
 	// signals
 


### PR DESCRIPTION
Command is used as a function in History.js: this way six globals are created