### PR TITLE
Ensure alphaTest is formatted as a float

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -438,7 +438,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 			customDefines,
 
-			parameters.alphaTest ? '#define ALPHATEST ' + parameters.alphaTest + ( parameters.alphaTest % 1 ? '' : '.0' ) : '',
+			parameters.alphaTest ? '#define ALPHATEST ' + parameters.alphaTest + ( Number.isInteger( parameters.alphaTest ) ? '.0' : '' ) : '',
 
 			'#define GAMMA_FACTOR ' + gammaFactorDefine,
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -438,7 +438,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 			customDefines,
 
-			parameters.alphaTest ? '#define ALPHATEST ' + parameters.alphaTest : '',
+			parameters.alphaTest ? '#define ALPHATEST ' + parameters.alphaTest + ( parameters.alphaTest % 1 ? '' : '.0' ) : '',
 
 			'#define GAMMA_FACTOR ' + gammaFactorDefine,
 


### PR DESCRIPTION
Fixes #13976. As discussed in #13977.