### PR TITLE
Font: handle unicode string split properly

### DIFF
--- a/src/extras/core/Font.js
+++ b/src/extras/core/Font.js
@@ -40,7 +40,7 @@ Object.assign( Font.prototype, {
 
 function createPaths( text, size, divisions, data ) {
 
-	var chars = String( text ).split( '' );
+	var chars = Array.from ? Array.from( text ) : String( text ).split( '' ); // see #13988
 	var scale = size / data.resolution;
 	var line_height = ( data.boundingBox.yMax - data.boundingBox.yMin + data.underlineThickness ) * scale;
 


### PR DESCRIPTION
This PR handles the unicode string split for those values > `U+FFFF`.
Issue discussed in #13988 .

1. Tested fallback thru IE 11.248.16299.0, as expected:
![](http://oumnldfwl.bkt.clouddn.com/a.png)
![](http://oumnldfwl.bkt.clouddn.com/b.png)

2. Tested `Array.from()` thru Chrome, Safari, Edge, as expected:
![](http://oumnldfwl.bkt.clouddn.com/c.png)

Pls let me know in case of any issue. Thanks