### PR TITLE
Fix Chrome mobile multitouch zoom saccades

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -609,9 +609,16 @@ THREE.TrackballControls = function ( object, domElement ) {
 	this.domElement.addEventListener( 'mousedown', mousedown, false );
 	this.domElement.addEventListener( 'wheel', mousewheel, false );
 
-	this.domElement.addEventListener( 'touchstart', touchstart, false );
-	this.domElement.addEventListener( 'touchend', touchend, false );
-	this.domElement.addEventListener( 'touchmove', touchmove, false );
+        var passiveSupported = false;
+        try {
+
+          window.addEventListener( 'test', null, Object.defineProperty( { }, "passive", { get: function() { passiveSupported = true; } } ) );
+
+        } catch(err) { }
+
+        this.domElement.addEventListener( 'touchstart', touchstart, passiveSupported ? { passive: false } : false);
+        this.domElement.addEventListener( 'touchend', touchend, passiveSupported ? { passive: false } : false);
+        this.domElement.addEventListener( 'touchmove', touchmove,passiveSupported ? { passive: false } : false);
 
 	window.addEventListener( 'keydown', keydown, false );
 	window.addEventListener( 'keyup', keyup, false );


### PR DESCRIPTION
Since a while, Chrome changed the way it handles how touch events are propagated.
https://tech.slashdot.org/story/17/11/08/1135240/how-chrome-broke-the-web
https://developers.google.com/web/updates/2017/01/scrolling-intervention

This created saccades and a drop in FPS when trying to zoom with two fingers on chrome on mobile.
This fix added an option to the event listener in order to propagate the events directly.