### PR TITLE
Audio: Honor new autoplay policy in examples

### DIFF
--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -9,30 +9,71 @@
 				background:#777;
 				padding:0;
 				margin:0;
-				font-weight: bold;
 				overflow:hidden;
+				font-family: Monospace;
 			}
 
 			#info {
 				position: absolute;
+				z-index: 2;
 				top: 0px;
 				width: 100%;
 				color: #ffffff;
 				padding: 5px;
-				font-family:Monospace;
+
 				font-size:13px;
 				text-align:center;
+				font-weight: bold;
 			}
 
 			a {
 				color: #ffffff;
 			}
+
+			#overlay {
+				position: absolute;
+				z-index: 1;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height:100%;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				opacity: 1;
+				background-color: #000000;
+				color: #ffffff;
+			}
+
+			#overlay > div {
+				text-align: center;
+			}
+
+			#overlay > div > button {
+				height: 20px;
+				width: 100px;
+				background: transparent;
+				color: #ffffff;
+				outline: 1px solid #ffffff;
+				border: 0px;
+				cursor: pointer;
+			}
+
+			#overlay > div > p {
+				color: #777777;
+				font-size: 12px;
+			}
 		</style>
 	</head>
 	<body>
-
+		<div id="overlay">
+			<div>
+				<button id="startButton">Click to Play</button>
+				<p>Automatic audio playback requires a user interaction.</p>
+			</div>
+		</div>
 		<div id="info">
-			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webaudio - sandbox<br/>
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webaudio - sandbox |
 			music by <a href="http://www.newgrounds.com/audio/listen/358232" target="_blank" rel="noopener">larrylarrybb</a>,
 			<a href="http://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener">skullbeatz</a> and
 			<a href="http://opengameart.org/content/project-utopia-seamless-loop" target="_blank" rel="noopener">congusbongus</a><br/><br/>
@@ -58,10 +99,13 @@
 
 			var clock = new THREE.Clock();
 
-			init();
-			animate();
+			var startButton = document.getElementById( 'startButton' );
+			startButton.addEventListener( 'click', init );
 
 			function init() {
+
+				var overlay = document.getElementById( 'overlay' );
+				overlay.remove();
 
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 10000 );
 				camera.position.set( 0, 25, 0 );
@@ -234,6 +278,8 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize, false );
+
+				animate();
 
 			}
 

--- a/examples/webaudio_timing.html
+++ b/examples/webaudio_timing.html
@@ -9,24 +9,61 @@
 				background:#777;
 				padding:0;
 				margin:0;
-				font-weight: bold;
 				overflow:hidden;
+				font-family: Monospace;
 			}
 
 			#info {
 				position: absolute;
+				z-index: 2;
 				top: 0px;
 				width: 100%;
 				color: #ffffff;
 				padding: 5px;
-				font-family:Monospace;
+
 				font-size:13px;
 				text-align:center;
+				font-weight: bold;
 			}
 
 			a {
 				color: #ffffff;
 			}
+
+			#overlay {
+				position: absolute;
+				z-index: 1;
+				top: 0;
+				left: 0;
+			  width: 100%;
+			  height:100%;
+			  display: flex;
+			  align-items: center;
+			  justify-content: center;
+				opacity: 1;
+				background-color: #000000;
+				color: #ffffff;
+			}
+
+			#overlay > div {
+				text-align: center;
+			}
+
+			#overlay > div > button {
+			  height: 20px;
+			  width: 100px;
+				background: transparent;
+				color: #ffffff;
+				outline: 1px solid #ffffff;
+				border: 0px;
+				cursor: pointer;
+			}
+
+			#overlay > div > p {
+				color: #777777;
+				font-size: 12px;
+			}
+
 		</style>
 
 		<script src="../build/three.js"></script>
@@ -36,9 +73,16 @@
 	</head>
 <body>
 
+	<div id="overlay">
+		<div>
+			<button id="startButton">Click to Play</button>
+			<p>Automatic audio playback requires a user interaction.</p>
+		</div>
+	</div>
 	<div id="container"></div>
 	<div id="info">
-		<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> webaudio timing | sound effect by <a href="https://freesound.org/people/michorvath/sounds/269718/" target="_blank" rel="noopener noreferrer">michorvath</a>
+		<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> webaudio timing |
+		sound effect by <a href="https://freesound.org/people/michorvath/sounds/269718/" target="_blank" rel="noopener noreferrer">michorvath</a>
 	</div>
 
 	<script>
@@ -49,9 +93,13 @@
 
 	var objects = [];
 
-	init();
+	var startButton = document.getElementById( 'startButton' );
+	startButton.addEventListener( 'click', init );
 
 	function init() {
+
+		var overlay = document.getElementById( 'overlay' );
+		overlay.remove();
 
 		var container = document.getElementById( 'container' );
 

--- a/examples/webaudio_timing.html
+++ b/examples/webaudio_timing.html
@@ -35,11 +35,11 @@
 				z-index: 1;
 				top: 0;
 				left: 0;
-			  width: 100%;
-			  height:100%;
-			  display: flex;
-			  align-items: center;
-			  justify-content: center;
+				width: 100%;
+				height:100%;
+				display: flex;
+				align-items: center;
+				justify-content: center;
 				opacity: 1;
 				background-color: #000000;
 				color: #ffffff;
@@ -50,8 +50,8 @@
 			}
 
 			#overlay > div > button {
-			  height: 20px;
-			  width: 100px;
+				height: 20px;
+				width: 100px;
 				background: transparent;
 				color: #ffffff;
 				outline: 1px solid #ffffff;

--- a/examples/webaudio_visualizer.html
+++ b/examples/webaudio_visualizer.html
@@ -9,24 +9,61 @@
 				background:#777;
 				padding:0;
 				margin:0;
-				font-weight: bold;
 				overflow:hidden;
+				font-family: Monospace;
 			}
 
 			#info {
 				position: absolute;
+				z-index: 2;
 				top: 0px;
 				width: 100%;
 				color: #ffffff;
 				padding: 5px;
-				font-family:Monospace;
+
 				font-size:13px;
 				text-align:center;
+				font-weight: bold;
 			}
 
 			a {
 				color: #ffffff;
 			}
+
+			#overlay {
+				position: absolute;
+				z-index: 1;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height:100%;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				opacity: 1;
+				background-color: #000000;
+				color: #ffffff;
+			}
+
+			#overlay > div {
+				text-align: center;
+			}
+
+			#overlay > div > button {
+				height: 20px;
+				width: 100px;
+				background: transparent;
+				color: #ffffff;
+				outline: 1px solid #ffffff;
+				border: 0px;
+				cursor: pointer;
+			}
+
+			#overlay > div > p {
+				color: #777777;
+				font-size: 12px;
+			}
+
 		</style>
 
 		<script src="../build/three.js"></script>
@@ -68,12 +105,17 @@
 
 	</head>
 	<body>
-
-	<div id="container"></div>
-	<div id="info">
-		<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> webaudio - visualizer<br/>
-		music by <a href="http://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener">skullbeatz</a>
-	</div>
+		<div id="overlay">
+			<div>
+				<button id="startButton">Click to Play</button>
+				<p>Automatic audio playback requires a user interaction.</p>
+			</div>
+		</div>
+		<div id="container"></div>
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> webaudio - visualizer |
+			music by <a href="http://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener">skullbeatz</a>
+		</div>
 
 	<script>
 
@@ -81,12 +123,17 @@
 
 	var scene, camera, renderer, analyser, uniforms;
 
-	init();
-	animate();
+	var startButton = document.getElementById( 'startButton' );
+	startButton.addEventListener( 'click', init );
 
 	function init() {
 
 		var fftSize = 128;
+
+		//
+
+		var overlay = document.getElementById( 'overlay' );
+		overlay.remove();
 
 		//
 
@@ -140,6 +187,8 @@
 		//
 
 		window.addEventListener( 'resize', onResize, false );
+
+		animate();
 
 	}
 


### PR DESCRIPTION
Because of the new more restrictive autoplay policy in Chrome (https://developers.google.com/web/updates/2017/09/autoplay-policy-changes), I've enhanced all web audio examples with a simple overlay and a start button. Otherwise audio won't work if you directly call the examples, e.g. https://threejs.org/examples/webaudio_visualizer.html