### PR TITLE
Use the path correctly in GLTFLoader.js.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -29,6 +29,10 @@ THREE.GLTFLoader = ( function () {
 
 			var loader = new THREE.FileLoader( scope.manager );
 
+			if ( this.path !== undefined ) {
+				loader.setPath( path );
+			}
+
 			loader.setResponseType( 'arraybuffer' );
 
 			loader.load( url, function ( data ) {

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -29,9 +29,7 @@ THREE.GLTFLoader = ( function () {
 
 			var loader = new THREE.FileLoader( scope.manager );
 
-			if ( this.path !== undefined ) {
-				loader.setPath( path );
-			}
+			if ( this.path !== undefined ) loader.setPath( path );
 
 			loader.setResponseType( 'arraybuffer' );
 


### PR DESCRIPTION
The GLTFLoader class was ignoring the path passed in to its setPath method. With this commit GLTFLoader's setPath will now work correctly.