### PR TITLE
OBJLoader2 V2.4.1 fixes five bugs

### DIFF
--- a/examples/models/obj/verify/verify.html
+++ b/examples/models/obj/verify/verify.html
@@ -161,6 +161,7 @@
 						objLoader2.setModelName( modelName );
 						objLoader2.setMaterials( materials );
 						objLoader2.setLogging( true, false );
+						objLoader2.setUseOAsMesh( true );
 						objLoader2.load( './verify.obj', callbackOnLoad, null, null, null, false );
 					};
 					objLoader2.loadMtl( './verify.mtl', null, onLoadMtl );

--- a/examples/models/obj/verify/verify.obj
+++ b/examples/models/obj/verify/verify.obj
@@ -3,6 +3,7 @@
 mtllib verify.mtl
 
 # Cube no materials. Translated x:-150
+o cube 1
 v -160 60 10
 v -160 40 10
 v -140 40 10
@@ -21,6 +22,7 @@ f 2 6 7 3
 
 
 # Cube with two materials. Translated x:-100
+o cube 2
 v -110 60 10
 v -110 40 10
 v -90 40 10
@@ -188,7 +190,7 @@ v 210 60 -10
 p -8 -7 -6 -5 -4 -3 -2 -1
 
 
-# Line. Translated x:250
+# Point/Line. Translated x:250
 v 240 60 10
 v 240 40 10
 v 260 40 10

--- a/examples/webgl_loader_obj2_run_director.html
+++ b/examples/webgl_loader_obj2_run_director.html
@@ -258,8 +258,8 @@
 						}
 					};
 
-					var callbackMeshAlter = function ( event ) {
-						var override = new THREE.LoaderSupport.LoadedMeshUserOverride( false, false );
+					var callbackMeshAlter = function ( event, override ) {
+						if ( ! Validator.isValid( override ) ) override = new THREE.LoaderSupport.LoadedMeshUserOverride( false, false );
 
 						var material = event.detail.material;
 						var meshName = event.detail.meshName;
@@ -277,16 +277,22 @@
 						return override;
 					};
 
+					var callbackOnLoadMaterials = function ( materials ) {
+						console.log( 'Materials loaded' );
+						return materials;
+					};
+
 					var callbacks = new THREE.LoaderSupport.Callbacks();
 					callbacks.setCallbackOnProgress( callbackReportProgress );
 					callbacks.setCallbackOnLoad( callbackOnLoad );
 					callbacks.setCallbackOnMeshAlter( callbackMeshAlter );
+					callbacks.setCallbackOnLoadMaterials( callbackOnLoadMaterials );
 
 					this.workerDirector.prepareWorkers( callbacks, maxQueueSize, maxWebWorkers );
 					if ( this.logging.enabled ) console.info( 'Configuring WWManager with queue size ' + this.workerDirector.getMaxQueueSize() + ' and ' + this.workerDirector.getMaxWebWorkers() + ' workers.' );
 
-					var prepData;
 					var modelPrepDatas = [];
+					var prepData;
 					prepData = new THREE.LoaderSupport.PrepData( 'male02' );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/male02/male02.obj', 'OBJ ') );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/male02/male02.mtl', 'MTL' ) );


### PR DESCRIPTION
The following bugs have been fixed in V2.4.1:
- #14010: `TRHEE.OBJLoader2.loadMtl` transforms an ArrayBuffer to String `THREE.LoaderUtils.decodeText` if content is provided as ArrayBuffer
- #14032: Vertex Color value was not correctly initialized. Vertex colors are now correctly used
- Original repo issue 40: Added function `TRHEE.OBJLoader2.setUseOAsMesh` to enforce mesh creation on occurrence of "o". The default is false (spec compliant).
- Original repo issue 39: Ensure name of `THREE.LoaderSupport.ResourceDescriptor` always has a default name
- Original repo issue 38: Fixed onMeshAlter and onLoadMaterials callback usage in `THREE.LoaderSupport.WorkerDirector` and fixed handling of returned objects in `THREE.LoaderSupport.MeshBuilder`