### PR TITLE
WebGLUniforms: Clean up

### DIFF
--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -372,12 +372,13 @@ function setValue4fm( gl, v ) {
 
 function setValueT1( gl, v, renderer ) {
 
+	var cache = this.cache;
 	var unit = renderer.allocTextureUnit();
 
-	if ( this.cache[ 0 ] !== unit ) {
+	if ( cache[ 0 ] !== unit ) {
 
 		gl.uniform1i( this.addr, unit );
-		this.cache[ 0 ] = unit;
+		cache[ 0 ] = unit;
 
 	}
 
@@ -387,12 +388,13 @@ function setValueT1( gl, v, renderer ) {
 
 function setValueT6( gl, v, renderer ) {
 
+	var cache = this.cache;
 	var unit = renderer.allocTextureUnit();
 
-	if ( this.cache[ 0 ] !== unit ) {
+	if ( cache[ 0 ] !== unit ) {
 
 		gl.uniform1i( this.addr, unit );
-		this.cache[ 0 ] = unit;
+		cache[ 0 ] = unit;
 
 	}
 
@@ -404,31 +406,37 @@ function setValueT6( gl, v, renderer ) {
 
 function setValue2iv( gl, v ) {
 
-	if ( arraysEqual( this.cache, v ) ) return;
+	var cache = this.cache;
+
+	if ( arraysEqual( cache, v ) ) return;
 
 	gl.uniform2iv( this.addr, v );
 
-	copyArray( this.cache, v );
+	copyArray( cache, v );
 
 }
 
 function setValue3iv( gl, v ) {
 
-	if ( arraysEqual( this.cache, v ) ) return;
+	var cache = this.cache;
+
+	if ( arraysEqual( cache, v ) ) return;
 
 	gl.uniform3iv( this.addr, v );
 
-	copyArray( this.cache, v );
+	copyArray( cache, v );
 
 }
 
 function setValue4iv( gl, v ) {
 
-	if ( arraysEqual( this.cache, v ) ) return;
+	var cache = this.cache;
+
+	if ( arraysEqual( cache, v ) ) return;
 
 	gl.uniform4iv( this.addr, v );
 
-	copyArray( this.cache, v );
+	copyArray( cache, v );
 
 }
 
@@ -463,12 +471,24 @@ function getSingularSetter( type ) {
 
 function setValue1fv( gl, v ) {
 
+	var cache = this.cache;
+
+	if ( arraysEqual( cache, v ) ) return;
+
 	gl.uniform1fv( this.addr, v );
+
+	copyArray( cache, v );
 
 }
 function setValue1iv( gl, v ) {
 
+	var cache = this.cache;
+
+	if ( arraysEqual( cache, v ) ) return;
+
 	gl.uniform1iv( this.addr, v );
+
+	copyArray( cache, v );
 
 }
 
@@ -588,6 +608,7 @@ function PureArrayUniform( id, activeInfo, addr ) {
 
 	this.id = id;
 	this.addr = addr;
+	this.cache = [];
 	this.size = activeInfo.size;
 	this.setValue = getPureArraySetter( activeInfo.type );
 


### PR DESCRIPTION
Some clean up.

Besides, added `.cache` to `PureArrayUniform` since this class already uses some functions with caching. The addition of this property avoids a possible runtime error.