### PR TITLE
Make Matrix4.compose more efficient

### DIFF
--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -278,42 +278,17 @@ Object.assign( Matrix4.prototype, {
 
 	},
 
-	makeRotationFromQuaternion: function ( q ) {
+	makeRotationFromQuaternion: function () {
 
-		var te = this.elements;
+		var zero = new Vector3( 0, 0, 0 );
+		var one = new Vector3( 1, 1, 1 );
 
-		var x = q._x, y = q._y, z = q._z, w = q._w;
-		var x2 = x + x, y2 = y + y, z2 = z + z;
-		var xx = x * x2, xy = x * y2, xz = x * z2;
-		var yy = y * y2, yz = y * z2, zz = z * z2;
-		var wx = w * x2, wy = w * y2, wz = w * z2;
+		return function makeRotationFromQuaternion( q ) {
 
-		te[ 0 ] = 1 - ( yy + zz );
-		te[ 4 ] = xy - wz;
-		te[ 8 ] = xz + wy;
+			return this.compose( zero, q, one );
 
-		te[ 1 ] = xy + wz;
-		te[ 5 ] = 1 - ( xx + zz );
-		te[ 9 ] = yz - wx;
-
-		te[ 2 ] = xz - wy;
-		te[ 6 ] = yz + wx;
-		te[ 10 ] = 1 - ( xx + yy );
-
-		// last column
-		te[ 3 ] = 0;
-		te[ 7 ] = 0;
-		te[ 11 ] = 0;
-
-		// bottom row
-		te[ 12 ] = 0;
-		te[ 13 ] = 0;
-		te[ 14 ] = 0;
-		te[ 15 ] = 1;
-
-		return this;
-
-	},
+		};
+	}(),
 
 	lookAt: function () {
 
@@ -754,12 +729,40 @@ Object.assign( Matrix4.prototype, {
 
 	compose: function ( position, quaternion, scale ) {
 
-		this.makeRotationFromQuaternion( quaternion );
-		this.scale( scale );
-		this.setPosition( position );
+		var te = this.elements;
+
+		var x = quaternion._x, y = quaternion._y, z = quaternion._z, w = quaternion._w;
+		var x2 = x + x,	 y2 = y + y,  z2 = z + z;
+		var xx = x * x2, xy = x * y2, xz = x * z2;
+		var yy = y * y2, yz = y * z2, zz = z * z2;
+		var wx = w * x2, wy = w * y2, wz = w * z2;
+
+		var sx = scale.x, sy = scale.y, sz = scale.z;
+
+		te[ 0 ] = (1 - ( yy + zz )) * sx;
+		te[ 4 ] = (xy - wz) * sy;
+		te[ 8 ] = (xz + wy) * sz;
+
+		te[ 1 ] = (xy + wz) * sx;
+		te[ 5 ] = (1 - ( xx + zz )) * sy;
+		te[ 9 ] = (yz - wx) * sz;
+
+		te[ 2 ] = (xz - wy) * sx;
+		te[ 6 ] = (yz + wx) * sy;
+		te[ 10 ] = (1 - ( xx + yy )) * sz;
+
+		// last column
+		te[ 3 ] = 0;
+		te[ 7 ] = 0;
+		te[ 11 ] = 0;
+
+		// bottom row
+		te[ 12 ] = position.x;
+		te[ 13 ] = position.y;
+		te[ 14 ] = position.z;
+		te[ 15 ] = 1;
 
 		return this;
-
 	},
 
 	decompose: function () {

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -288,6 +288,7 @@ Object.assign( Matrix4.prototype, {
 			return this.compose( zero, q, one );
 
 		};
+
 	}(),
 
 	lookAt: function () {
@@ -732,24 +733,24 @@ Object.assign( Matrix4.prototype, {
 		var te = this.elements;
 
 		var x = quaternion._x, y = quaternion._y, z = quaternion._z, w = quaternion._w;
-		var x2 = x + x,	 y2 = y + y,  z2 = z + z;
+		var x2 = x + x,	y2 = y + y, z2 = z + z;
 		var xx = x * x2, xy = x * y2, xz = x * z2;
 		var yy = y * y2, yz = y * z2, zz = z * z2;
 		var wx = w * x2, wy = w * y2, wz = w * z2;
 
 		var sx = scale.x, sy = scale.y, sz = scale.z;
 
-		te[ 0 ] = (1 - ( yy + zz )) * sx;
-		te[ 4 ] = (xy - wz) * sy;
-		te[ 8 ] = (xz + wy) * sz;
+		te[ 0 ] = ( 1 - ( yy + zz ) ) * sx;
+		te[ 4 ] = ( xy - wz ) * sy;
+		te[ 8 ] = ( xz + wy ) * sz;
 
-		te[ 1 ] = (xy + wz) * sx;
-		te[ 5 ] = (1 - ( xx + zz )) * sy;
-		te[ 9 ] = (yz - wx) * sz;
+		te[ 1 ] = ( xy + wz ) * sx;
+		te[ 5 ] = ( 1 - ( xx + zz ) ) * sy;
+		te[ 9 ] = ( yz - wx ) * sz;
 
-		te[ 2 ] = (xz - wy) * sx;
-		te[ 6 ] = (yz + wx) * sy;
-		te[ 10 ] = (1 - ( xx + yy )) * sz;
+		te[ 2 ] = ( xz - wy ) * sx;
+		te[ 6 ] = ( yz + wx ) * sy;
+		te[ 10 ] = ( 1 - ( xx + yy ) ) * sz;
 
 		// last column
 		te[ 3 ] = 0;
@@ -763,6 +764,7 @@ Object.assign( Matrix4.prototype, {
 		te[ 15 ] = 1;
 
 		return this;
+
 	},
 
 	decompose: function () {

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -263,12 +263,12 @@ Object.assign( Matrix4.prototype, {
 
 		}
 
-		// last column
+		// bottom row
 		te[ 3 ] = 0;
 		te[ 7 ] = 0;
 		te[ 11 ] = 0;
 
-		// bottom row
+		// last column
 		te[ 12 ] = 0;
 		te[ 13 ] = 0;
 		te[ 14 ] = 0;
@@ -752,12 +752,12 @@ Object.assign( Matrix4.prototype, {
 		te[ 6 ] = ( yz + wx ) * sy;
 		te[ 10 ] = ( 1 - ( xx + yy ) ) * sz;
 
-		// last column
+		// bottom row
 		te[ 3 ] = 0;
 		te[ 7 ] = 0;
 		te[ 11 ] = 0;
 
-		// bottom row
+		// last column
 		te[ 12 ] = position.x;
 		te[ 13 ] = position.y;
 		te[ 14 ] = position.z;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -740,30 +740,27 @@ Object.assign( Matrix4.prototype, {
 
 		var sx = scale.x, sy = scale.y, sz = scale.z;
 
-		te[ 0 ] = ( 1 - ( yy + zz ) ) * sx;
-		te[ 4 ] = ( xy - wz ) * sy;
-		te[ 8 ] = ( xz + wy ) * sz;
+	        te[ 0 ] = ( 1 - ( yy + zz ) ) * sx;
+	        te[ 1 ] = ( xy + wz ) * sx;
+	        te[ 2 ] = ( xz - wy ) * sx;
+	        te[ 3 ] = 0;
 
-		te[ 1 ] = ( xy + wz ) * sx;
-		te[ 5 ] = ( 1 - ( xx + zz ) ) * sy;
-		te[ 9 ] = ( yz - wx ) * sz;
+	        te[ 4 ] = ( xy - wz ) * sy;
+	        te[ 5 ] = ( 1 - ( xx + zz ) ) * sy;
+	        te[ 6 ] = ( yz + wx ) * sy;
+	        te[ 7 ] = 0;
 
-		te[ 2 ] = ( xz - wy ) * sx;
-		te[ 6 ] = ( yz + wx ) * sy;
-		te[ 10 ] = ( 1 - ( xx + yy ) ) * sz;
+	        te[ 8 ] = ( xz + wy ) * sz;
+	        te[ 9 ] = ( yz - wx ) * sz;
+	        te[ 10 ] = ( 1 - ( xx + yy ) ) * sz;
+	        te[ 11 ] = 0;
 
-		// bottom row
-		te[ 3 ] = 0;
-		te[ 7 ] = 0;
-		te[ 11 ] = 0;
+	        te[ 12 ] = position.x;
+	        te[ 13 ] = position.y;
+	        te[ 14 ] = position.z;
+	        te[ 15 ] = 1;
 
-		// last column
-		te[ 12 ] = position.x;
-		te[ 13 ] = position.y;
-		te[ 14 ] = position.z;
-		te[ 15 ] = 1;
-
-		return this;
+	        return this;
 
 	},
 


### PR DESCRIPTION
This is a CPU hotspot for rendering if there are a lot of objects in your scene graph. This change makes it moderately more efficient by calculating & writing the resulting matrix values just once, instead of multiple times in the course of applying rotation-scaling-position.

According to my testing, this patch improves overall performance on the `updateMatrixWorld` benchmark in the repository (which just tests calling `updateMatrixWorld` at the root of a large scene graph, like the renderer does) by roughly 10-15% on both Firefox and Chrome.