### PR TITLE
WebGLState: Added caching for blend equation

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -546,9 +546,9 @@ function WebGLState( gl, extensions, utils ) {
 			if ( currentMaterial.lastBlendingSet == blending &&
 				currentMaterial.lastPremultipliedAlphaSet == premultipliedAlpha ) {
 
-					blendEquationCacheHit = true;
+								blendEquationCacheHit = true;
 
-				}
+									}
 
 		}
 
@@ -564,7 +564,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-									gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 
@@ -589,7 +589,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-									gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 
@@ -614,7 +614,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-									gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 
@@ -639,7 +639,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-									gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 
@@ -649,7 +649,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-									gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -546,9 +546,9 @@ function WebGLState( gl, extensions, utils ) {
 			if ( currentMaterial.lastBlendingSet == blending &&
 				currentMaterial.lastPremultipliedAlphaSet == premultipliedAlpha ) {
 
-								blendEquationCacheHit = true;
+			    blendEquationCacheHit = true;
 
-									}
+			}
 
 		}
 
@@ -564,7 +564,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+							    gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 
@@ -589,7 +589,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+							    gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 
@@ -614,7 +614,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+							    gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 
@@ -639,7 +639,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+							    gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 
@@ -649,7 +649,7 @@ function WebGLState( gl, extensions, utils ) {
 
 							if ( ! blendEquationCacheHit ) {
 
-															gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+							    gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
 
 							}
 


### PR DESCRIPTION
In this PR a cache mechanism is implemented for Blend equations inside the WebGLState. I found this to be necessary since three.js was making redundant WebGL calls for such functions:
![ekran resmi 2018-05-13 15 26 43](https://user-images.githubusercontent.com/15003836/39967689-051cc578-56c9-11e8-8442-296574dcfd17.png)

After the implementation I observed that such WebGL calls are eliminated thus performance increase is expected for scenes with many materials.