### PR TITLE
Fix VRM Loader example. Material is MultiMaterial in general.

### DIFF
--- a/examples/webgl_loader_vrm.html
+++ b/examples/webgl_loader_vrm.html
@@ -83,12 +83,29 @@
 
 						if ( object.material ) {
 
-							var material = new THREE.MeshBasicMaterial();
-							THREE.Material.prototype.copy.call( material, object.material );
-							material.color.copy( object.material.color );
-							material.map = object.material.map;
-							material.lights = false;
-							object.material = material;
+							if ( Array.isArray( object.material ) ) {
+
+								for ( var i = 0, il = object.material.length; i < il; i ++ ) {
+
+									var material = new THREE.MeshBasicMaterial();
+									THREE.Material.prototype.copy.call( material, object.material[ i ] );
+									material.color.copy( object.material[ i ].color );
+									material.map = object.material[ i ].map;
+									material.lights = false;
+									object.material[ i ] = material;
+
+								}
+
+							} else {
+
+								var material = new THREE.MeshBasicMaterial();
+								THREE.Material.prototype.copy.call( material, object.material );
+								material.color.copy( object.material.color );
+								material.map = object.material.map;
+								material.lights = false;
+								object.material = material;
+
+							}
 
 						}
 


### PR DESCRIPTION
With #13707, `VRMLoader` example should take account of that material can be multi-material.