### PR TITLE
ImageBitmapLoader: Added missing resolveURL() call

### DIFF
--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -43,6 +43,8 @@ ImageBitmapLoader.prototype = {
 
 		if ( this.path !== undefined ) url = this.path + url;
 
+		url = this.manager.resolveURL( url );
+
 		var scope = this;
 
 		var cached = Cache.get( url );


### PR DESCRIPTION
This PR ensures the usage of `resolveURL()` in `ImageBitmapLoader`.