### PR TITLE
AudioLoader: Use fetch instead of FileLoader

### DIFF
--- a/docs/api/loaders/AudioLoader.html
+++ b/docs/api/loaders/AudioLoader.html
@@ -48,10 +48,8 @@
 				oceanAmbientSound.play();
 			},
 
-			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
-			},
+			// onProgress callback currently not supported
+			undefined,
 
 			// onError callback
 			function ( err ) {

--- a/docs/api/loaders/AudioLoader.html
+++ b/docs/api/loaders/AudioLoader.html
@@ -12,7 +12,8 @@
 
 		<p class="desc">
 			Class for loading an
-			[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer AudioBuffer].
+			[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer AudioBuffer]. <br/>
+			Unlike [page:FileLoader], [name] does not avoid multiple concurrent requests to the same URL.
 		</p>
 
 		<h2>Example</h2>

--- a/docs/api/loaders/AudioLoader.html
+++ b/docs/api/loaders/AudioLoader.html
@@ -13,7 +13,6 @@
 		<p class="desc">
 			Class for loading an
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer AudioBuffer].
-			This uses the [page:FileLoader] internally for loading files.
 		</p>
 
 		<h2>Example</h2>
@@ -90,6 +89,12 @@
 		</p>
 		<p>
 		Begin loading from url and pass the loaded [page:String AudioBuffer] to onLoad.
+		</p>
+
+		<h3>[method:AudioLoader setPath]( [param:String path] )</h3>
+		<p>
+			Sets the base path or URL from which to load files. This can be useful if
+			you are loading many images from the same directory.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/loaders/ImageBitmapLoader.html
+++ b/docs/api/loaders/ImageBitmapLoader.html
@@ -11,8 +11,9 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			A loader for loading an [page:Image] as an [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap]. An ImageBitmap provides an asynchronous and resource efficient pathway to prepare textures for rendering in WebGL.
-
+			A loader for loading an [page:Image] as an [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap].
+			An ImageBitmap provides an asynchronous and resource efficient pathway to prepare textures for rendering in WebGL. <br/>
+			Unlike [page:FileLoader], [name] does not avoid multiple concurrent requests to the same URL.
 		</p>
 
 		<h2>Example</h2>

--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -50,19 +50,20 @@ Object.assign( AudioLoader.prototype, {
 		} ).then( function ( arrayBuffer ) {
 
 			var context = AudioContext.getContext();
-			return context.decodeAudioData( arrayBuffer );
 
-		} ).then( function ( audioBuffer ) {
+			context.decodeAudioData( arrayBuffer, function ( audioBuffer ) {
 
-			Cache.add( url, audioBuffer );
+				Cache.add( url, audioBuffer );
 
-			if ( onLoad ) onLoad( audioBuffer );
+				if ( onLoad ) onLoad( audioBuffer );
 
-			scope.manager.itemEnd( url );
+				scope.manager.itemEnd( url );
 
-		} ).catch( function ( e ) {
+			} );
 
-			if ( onError ) onError( e );
+		} ).catch( function ( error ) {
+
+			if ( onError ) onError( error );
 
 			scope.manager.itemEnd( url );
 			scope.manager.itemError( url );

--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -1,9 +1,10 @@
 import { AudioContext } from '../audio/AudioContext.js';
-import { FileLoader } from './FileLoader.js';
+import { Cache } from './Cache.js';
 import { DefaultLoadingManager } from './LoadingManager.js';
 
 /**
  * @author Reece Aaron Lecrivain / http://reecenotes.com/
+ * @author Mugen87 / https://github.com/Mugen87
  */
 
 function AudioLoader( manager ) {
@@ -16,19 +17,64 @@ Object.assign( AudioLoader.prototype, {
 
 	load: function ( url, onLoad, onProgress, onError ) {
 
-		var loader = new FileLoader( this.manager );
-		loader.setResponseType( 'arraybuffer' );
-		loader.load( url, function ( buffer ) {
+		if ( url === undefined ) url = '';
+
+		if ( this.path !== undefined ) url = this.path + url;
+
+		url = this.manager.resolveURL( url );
+
+		var scope = this;
+
+		var cached = Cache.get( url );
+
+		if ( cached !== undefined ) {
+
+			scope.manager.itemStart( url );
+
+			setTimeout( function () {
+
+				if ( onLoad ) onLoad( cached );
+
+				scope.manager.itemEnd( url );
+
+			}, 0 );
+
+			return cached;
+
+		}
+
+		fetch( url ).then( function ( response ) {
+
+			return response.arrayBuffer();
+
+		} ).then( function ( arrayBuffer ) {
 
 			var context = AudioContext.getContext();
+			return context.decodeAudioData( arrayBuffer );
 
-			context.decodeAudioData( buffer, function ( audioBuffer ) {
+		} ).then( function ( audioBuffer ) {
 
-				onLoad( audioBuffer );
+			Cache.add( url, audioBuffer );
 
-			} );
+			if ( onLoad ) onLoad( audioBuffer );
 
-		}, onProgress, onError );
+			scope.manager.itemEnd( url );
+
+		} ).catch( function ( e ) {
+
+			if ( onError ) onError( e );
+
+			scope.manager.itemEnd( url );
+			scope.manager.itemError( url );
+
+		} );
+
+	},
+
+	setPath: function ( value ) {
+
+		this.path = value;
+		return this;
 
 	}
 


### PR DESCRIPTION
This PR uses a different approach compared to #13725. The implementation solves #13710 and #10706.

`fetch` should be supported in all Browsers which support Web Audio as well.

https://caniuse.com/#feat=fetch
https://caniuse.com/#feat=audio-api

