### PR TITLE
GLTFExporter image caching.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -599,14 +599,16 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Process image
-		 * @param  {Texture} map Texture to process
+		 * @param  {Image} image to process
+		 * @param  {String} mimeType to use for writing out
+		 * @param  {Boolean} flip the image in the Y before writing out
 		 * @return {Integer}     Index of the processed texture in the "images" array
 		 */
-		function processImage( map ) {
+		function processImage( image, mimeType, flipY ) {
 
-			if ( cachedData.images.has( map.image ) ) {
+			if ( cachedData.images.has( image ) ) {
 
-				return cachedData.images.get( map.image );
+				return cachedData.images.get( image );
 
 			}
 
@@ -616,19 +618,18 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var mimeType = map.format === THREE.RGBAFormat ? 'image/png' : 'image/jpeg';
 			var gltfImage = { mimeType: mimeType };
 
 			if ( options.embedImages ) {
 
 				var canvas = cachedCanvas = cachedCanvas || document.createElement( 'canvas' );
 
-				canvas.width = map.image.width;
-				canvas.height = map.image.height;
+				canvas.width = image.width;
+				canvas.height = image.height;
 
-				if ( options.forcePowerOfTwoTextures && ! isPowerOfTwo( map.image ) ) {
+				if ( options.forcePowerOfTwoTextures && ! isPowerOfTwo( image ) ) {
 
-					console.warn( 'GLTFExporter: Resized non-power-of-two image.', map.image );
+					console.warn( 'GLTFExporter: Resized non-power-of-two image.', image );
 
 					canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
 					canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );
@@ -637,14 +638,14 @@ THREE.GLTFExporter.prototype = {
 
 				var ctx = canvas.getContext( '2d' );
 
-				if ( map.flipY === true ) {
+				if ( flipY === true ) {
 
 					ctx.translate( 0, canvas.height );
 					ctx.scale( 1, - 1 );
 
 				}
 
-				ctx.drawImage( map.image, 0, 0, canvas.width, canvas.height );
+				ctx.drawImage( image, 0, 0, canvas.width, canvas.height );
 
 				if ( options.binary === true ) {
 
@@ -672,16 +673,17 @@ THREE.GLTFExporter.prototype = {
 
 			} else {
 
-				gltfImage.uri = map.image.src;
+				gltfImage.uri = image.src;
 
 			}
 
 			outputJSON.images.push( gltfImage );
 
 			var index = outputJSON.images.length - 1;
-			cachedData.images.set( map.image, index );
+			cachedData.images.set( image, index );
 
 			return index;
+
 		}
 
 		/**
@@ -731,10 +733,11 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
+			var mimeType = map.format === THREE.RGBAFormat ? 'image/png' : 'image/jpeg';
 			var gltfTexture = {
 
 				sampler: processSampler( map ),
-				source: processImage( map )
+				source: processImage( map.image, mimeType, map.flipY  )
 
 			};
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -606,9 +606,18 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function processImage( image, mimeType, flipY ) {
 
-			if ( cachedData.images.has( image ) ) {
+			if ( ! cachedData.images.has( image ) ) {
 
-				return cachedData.images.get( image );
+				cachedData.images.set( image, {} );
+
+			}
+
+			var cachedImages = cachedData.images.get( image );
+			var key = mimeType + ":" + flipY.toString();
+
+			if ( cachedImages[ key ] !== undefined ) {
+
+				return cachedImages[ key ];
 
 			}
 
@@ -680,7 +689,7 @@ THREE.GLTFExporter.prototype = {
 			outputJSON.images.push( gltfImage );
 
 			var index = outputJSON.images.length - 1;
-			cachedData.images.set( image, index );
+			cachedImages[ key ] = index;
 
 			return index;
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -600,11 +600,11 @@ THREE.GLTFExporter.prototype = {
 		/**
 		 * Process image
 		 * @param  {Image} image to process
-		 * @param  {String} mimeType to use for writing out
+		 * @param  {Integer} format of the image (e.g. THREE.RGBFormat, THREE.RGBAFormat etc)
 		 * @param  {Boolean} flip the image in the Y before writing out
 		 * @return {Integer}     Index of the processed texture in the "images" array
 		 */
-		function processImage( image, mimeType, flipY ) {
+		function processImage( image, format, flipY ) {
 
 			if ( ! cachedData.images.has( image ) ) {
 
@@ -613,7 +613,8 @@ THREE.GLTFExporter.prototype = {
 			}
 
 			var cachedImages = cachedData.images.get( image );
-			var key = mimeType + ":" + flipY.toString();
+			var mimeType = format === THREE.RGBAFormat ? 'image/png' : 'image/jpeg';
+			var key = mimeType + ":flipY/" + flipY.toString();
 
 			if ( cachedImages[ key ] !== undefined ) {
 
@@ -742,11 +743,10 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var mimeType = map.format === THREE.RGBAFormat ? 'image/png' : 'image/jpeg';
 			var gltfTexture = {
 
 				sampler: processSampler( map ),
-				source: processImage( map.image, mimeType, map.flipY  )
+				source: processImage( map.image, map.format, map.flipY  )
 
 			};
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -105,7 +105,8 @@ THREE.GLTFExporter.prototype = {
 
 			attributes: new Map(),
 			materials: new Map(),
-			textures: new Map()
+			textures: new Map(),
+			images: new Map()
 
 		};
 
@@ -603,7 +604,11 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function processImage( map ) {
 
-			// @TODO Cache
+			if ( cachedData.images.has( map.image ) ) {
+
+				return cachedData.images.get( map.image );
+
+			}
 
 			if ( ! outputJSON.images ) {
 
@@ -673,8 +678,10 @@ THREE.GLTFExporter.prototype = {
 
 			outputJSON.images.push( gltfImage );
 
-			return outputJSON.images.length - 1;
+			var index = outputJSON.images.length - 1;
+			cachedData.images.set( map.image, index );
 
+			return index;
 		}
 
 		/**

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -601,7 +601,7 @@ THREE.GLTFExporter.prototype = {
 		 * Process image
 		 * @param  {Image} image to process
 		 * @param  {Integer} format of the image (e.g. THREE.RGBFormat, THREE.RGBAFormat etc)
-		 * @param  {Boolean} flip the image in the Y before writing out
+		 * @param  {Boolean} flipY before writing out the image
 		 * @return {Integer}     Index of the processed texture in the "images" array
 		 */
 		function processImage( image, format, flipY ) {


### PR DESCRIPTION
@takahirox @donmccurdy 

I've added a map for images that prevents multiple writes of the same data. I followed the same pattern as the other cache mechanisms in there. It seems to actually be a very simple change to get it working, let me know if I've missed something though.

This reduces output glb size considerably for me when the scene contains shared images and embedImages is enabled for the export. My test scene went down from ~10Mb to ~1.2Mb. I've also checked the cache works when there is a mix of shared and unique textures to make sure it handles those cases correctly as well.

closes #14063