### PR TITLE
ParametricGeometries: Remove optional target

### DIFF
--- a/examples/js/ParametricGeometries.js
+++ b/examples/js/ParametricGeometries.js
@@ -7,9 +7,7 @@
 
 THREE.ParametricGeometries = {
 
-	klein: function ( v, u, optionalTarget ) {
-
-		var result = optionalTarget || new THREE.Vector3();
+	klein: function ( v, u, target ) {
 
 		u *= Math.PI;
 		v *= 2 * Math.PI;
@@ -30,29 +28,25 @@ THREE.ParametricGeometries = {
 
 		y = - 2 * ( 1 - Math.cos( u ) / 2 ) * Math.sin( v );
 
-		return result.set( x, y, z );
+		return target.set( x, y, z );
 
 	},
 
 	plane: function ( width, height ) {
 
-		return function ( u, v, optionalTarget ) {
-
-			var result = optionalTarget || new THREE.Vector3();
+		return function ( u, v, target ) {
 
 			var x = u * width;
 			var y = 0;
 			var z = v * height;
 
-			return result.set( x, y, z );
+			return target.set( x, y, z );
 
 		};
 
 	},
 
-	mobius: function ( u, t, optionalTarget ) {
-
-		var result = optionalTarget || new THREE.Vector3();
+	mobius: function ( u, t, target ) {
 
 		// flat mobius strip
 		// http://www.wolframalpha.com/input/?i=M%C3%B6bius+strip+parametric+equations&lk=1&a=ClashPrefs_*Surface.MoebiusStrip.SurfaceProperty.ParametricEquations-
@@ -67,13 +61,11 @@ THREE.ParametricGeometries = {
 		y = Math.sin( v ) * ( a + u * Math.cos( v / 2 ) );
 		z = u * Math.sin( v / 2 );
 
-		return result.set( x, y, z );
+		return target.set( x, y, z );
 
 	},
 
-	mobius3d: function ( u, t, optionalTarget ) {
-
-		var result = optionalTarget || new THREE.Vector3();
+	mobius3d: function ( u, t, target ) {
 
 		// volumetric mobius strip
 
@@ -91,7 +83,7 @@ THREE.ParametricGeometries = {
 		y = ( major + x ) * Math.sin( u );
 		x = ( major + x ) * Math.cos( u );
 
-		return result.set( x, y, z );
+		return target.set( x, y, z );
 
 	}
 
@@ -126,9 +118,7 @@ THREE.ParametricGeometries.TubeGeometry = function ( path, segments, radius, seg
 	this.normals = normals;
 	this.binormals = binormals;
 
-	var ParametricTube = function ( u, v, optionalTarget ) {
-
-		var result = optionalTarget || new THREE.Vector3();
+	var ParametricTube = function ( u, v, target ) {
 
 		v *= 2 * Math.PI;
 
@@ -156,7 +146,7 @@ THREE.ParametricGeometries.TubeGeometry = function ( path, segments, radius, seg
 		pos.y += cx * normal.y + cy * binormal.y;
 		pos.z += cx * normal.z + cy * binormal.z;
 
-		return result.copy( pos );
+		return target.copy( pos );
 
 	};
 
@@ -226,9 +216,7 @@ THREE.ParametricGeometries.TorusKnotGeometry.prototype.constructor = THREE.Param
   *********************************************/
 THREE.ParametricGeometries.SphereGeometry = function ( size, u, v ) {
 
-	function sphere( u, v, optionalTarget ) {
-
-		var result = optionalTarget || new THREE.Vector3();
+	function sphere( u, v, target ) {
 
 		u *= Math.PI;
 		v *= 2 * Math.PI;
@@ -237,7 +225,7 @@ THREE.ParametricGeometries.SphereGeometry = function ( size, u, v ) {
 		var y = size * Math.sin( u ) * Math.sin( v );
 		var z = size * Math.cos( u );
 
-		return result.set( x, y, z );
+		return target.set( x, y, z );
 
 	}
 
@@ -257,15 +245,13 @@ THREE.ParametricGeometries.SphereGeometry.prototype.constructor = THREE.Parametr
 
 THREE.ParametricGeometries.PlaneGeometry = function ( width, depth, segmentsWidth, segmentsDepth ) {
 
-	function plane( u, v, optionalTarget ) {
-
-		var result = optionalTarget || new THREE.Vector3();
+	function plane( u, v, target ) {
 
 		var x = u * width;
 		var y = 0;
 		var z = v * depth;
 
-		return result.set( x, y, z );
+		return target.set( x, y, z );
 
 	}
 


### PR DESCRIPTION
Some clean up since `ParametricBufferGeometry` expects a target parameter of its surface equation.