### PR TITLE
PointsMaterial: remove unused shadowmap chunks

### DIFF
--- a/src/renderers/shaders/ShaderLib/points_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/points_frag.glsl
@@ -6,7 +6,6 @@ uniform float opacity;
 #include <color_pars_fragment>
 #include <map_particle_pars_fragment>
 #include <fog_pars_fragment>
-#include <shadowmap_pars_fragment>
 #include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 

--- a/src/renderers/shaders/ShaderLib/points_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/points_vert.glsl
@@ -4,7 +4,6 @@ uniform float scale;
 #include <common>
 #include <color_pars_vertex>
 #include <fog_pars_vertex>
-#include <shadowmap_pars_vertex>
 #include <logdepthbuf_pars_vertex>
 #include <clipping_planes_pars_vertex>
 
@@ -23,7 +22,6 @@ void main() {
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>
 	#include <worldpos_vertex>
-	#include <shadowmap_vertex>
 	#include <fog_vertex>
 
 }


### PR DESCRIPTION
`PointsMaterial`, like `MeshBasicMaterial`, does not receive shadows, or self-shadow. The removed chunks were not used.

 