### PR TITLE
Support shadow intensity

### DIFF
--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -157,7 +157,8 @@
 					distance: spotLight.distance,
 					angle: spotLight.angle,
 					penumbra: spotLight.penumbra,
-					decay: spotLight.decay
+					decay: spotLight.decay,
+					'shadow intensity': renderer.shadowIntensity
 				}
 
 				gui.addColor( params, 'light color' ).onChange( function ( val ) {
@@ -199,6 +200,13 @@
 				gui.add( params, 'decay', 1, 2 ).onChange( function ( val ) {
 
 					spotLight.decay = val;
+					render();
+
+				} );
+
+				gui.add( params, 'shadow intensity', 0, 1 ).onChange( function ( val ) {
+
+					renderer.shadowIntensity = val;
 					render();
 
 				} );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -109,6 +109,10 @@ function WebGLRenderer( parameters ) {
 	this.toneMappingExposure = 1.0;
 	this.toneMappingWhitePoint = 1.0;
 
+	// shadows
+
+	this.shadowIntensity = 1.0;
+
 	// morphs
 
 	this.maxMorphTargets = 8;
@@ -1806,6 +1810,8 @@ function WebGLRenderer( parameters ) {
 
 			p_uniforms.setValue( _gl, 'toneMappingExposure', _this.toneMappingExposure );
 			p_uniforms.setValue( _gl, 'toneMappingWhitePoint', _this.toneMappingWhitePoint );
+
+			p_uniforms.setValue( _gl, 'shadowIntensity', _this.shadowIntensity );
 
 			if ( material.lights ) {
 

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl
@@ -21,6 +21,8 @@ geometry.viewDir = normalize( vViewPosition );
 
 IncidentLight directLight;
 
+float shadow = 0.0;
+
 #if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )
 
 	PointLight pointLight;
@@ -33,7 +35,8 @@ IncidentLight directLight;
 		getPointDirectLightIrradiance( pointLight, geometry, directLight );
 
 		#ifdef USE_SHADOWMAP
-		directLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;
+		shadow = all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;
+		directLight.color *= mix( 1.0, shadow, shadowIntensity );
 		#endif
 
 		RE_Direct( directLight, geometry, material, reflectedLight );
@@ -54,7 +57,8 @@ IncidentLight directLight;
 		getSpotDirectLightIrradiance( spotLight, geometry, directLight );
 
 		#ifdef USE_SHADOWMAP
-		directLight.color *= all( bvec2( spotLight.shadow, directLight.visible ) ) ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		shadow = all( bvec2( spotLight.shadow, directLight.visible ) ) ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		directLight.color *= mix( 1.0, shadow, shadowIntensity );
 		#endif
 
 		RE_Direct( directLight, geometry, material, reflectedLight );
@@ -75,7 +79,8 @@ IncidentLight directLight;
 		getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
 
 		#ifdef USE_SHADOWMAP
-		directLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		shadow = all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		directLight.color *= mix( 1.0, shadow, shadowIntensity );
 		#endif
 
 		RE_Direct( directLight, geometry, material, reflectedLight );

--- a/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl
@@ -1,3 +1,4 @@
+uniform float shadowIntensity;
 uniform vec3 ambientLightColor;
 
 vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl
@@ -65,7 +65,7 @@ void main() {
 
 	#endif
 
-	reflectedLight.directDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb ) * getShadowMask();
+	reflectedLight.directDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb ) * mix( 1.0, getShadowMask(), shadowIntensity );
 
 	// modulation
 	#include <aomap_fragment>


### PR DESCRIPTION
As proposed in #8238.

The shadow intensity (darkness) can be changed without affecting the overall illumination of the scene.

This implementation adds a single uniform, `renderer.shadowIntensity`, that takes a value in [ 0, 1 ], defaulting to 1.

The approach works with (Gouraud) `MeshLambertMaterial` -- whose shadows are an approximation -- and it also works with the other built-in materials, where shadows are implemented correctly as the absence of light. (`MeshLambertMaterial ` does not accommodate a per-light shadow intensity.)

I can add docs later if this is merged.