### PR TITLE
A simple improvement to blending cache

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -537,7 +537,7 @@ function WebGLState( gl, extensions, utils ) {
 
 		if ( blending !== CustomBlending ) {
 
-			if ( blending !== currentBlending || premultipliedAlpha !== currentPremultipledAlpha ) {
+			if ( ( blending !== NoBlending ) && ( blending !== currentBlending || premultipliedAlpha !== currentPremultipledAlpha ) ) {
 
 				switch ( blending ) {
 
@@ -639,8 +639,12 @@ function WebGLState( gl, extensions, utils ) {
 
 		}
 
-		currentBlending = blending;
-		currentPremultipledAlpha = premultipliedAlpha;
+		if ( blending !== NoBlending ) {
+
+			currentBlending = blending;
+			currentPremultipledAlpha = premultipliedAlpha;
+
+		}
 
 	}
 


### PR DESCRIPTION
In this PR a simple improvement is made inside WebGLState to prevent redundant calls to WebGL blending functions:
![ekran resmi 2018-05-13 15 26 43](https://user-images.githubusercontent.com/15003836/40256223-7786f23c-5af2-11e8-86c5-9cf31bcd8e74.png)

The modification insures that no redundant call would be made when the blending mode is NoBlending. The tests resulted successful.
