### PR TITLE
GLTFLoader: Remove onBeforeRender dependency

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -919,36 +919,6 @@ THREE.GLTFLoader = ( function () {
 
 			},
 
-			/**
-			 * Clones a GLTFSpecularGlossinessMaterial instance. The ShaderMaterial.copy() method can
-			 * copy only properties it knows about or inherits, and misses many properties that would
-			 * normally be defined by MeshStandardMaterial.
-			 *
-			 * This method allows GLTFSpecularGlossinessMaterials to be cloned in the process of
-			 * loading a glTF model, but cloning later (e.g. by the user) would require these changes
-			 * AND also updating `.onBeforeRender` on the parent mesh.
-			 *
-			 * @param  {THREE.ShaderMaterial} source
-			 * @return {THREE.ShaderMaterial}
-			 */
-			cloneMaterial: function ( source ) {
-
-				var target = source.clone();
-
-				target.isGLTFSpecularGlossinessMaterial = true;
-
-				var params = this.specularGlossinessParams;
-
-				for ( var i = 0, il = params.length; i < il; i ++ ) {
-
-					target[ params[ i ] ] = source[ params[ i ] ];
-
-				}
-
-				return target;
-
-			},
-
 		};
 
 	}

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -630,7 +630,7 @@ THREE.GLTFLoader = ( function () {
 	 * @pailhead
 	 */
 
-	function MeshStandardSGMaterial( params ) {
+	function GLTFMeshStandardSGMaterial( params ) {
 
 		THREE.MeshStandardMaterial.call( this );
 
@@ -704,51 +704,24 @@ THREE.GLTFLoader = ( function () {
 
 		};
 
+		/*eslint-disable*/
 		Object.defineProperties(
 			this,
 			{
 				specularMap: {
-					get: function () {
-
-						return uniforms.specularMap.value;
-
-					},
-					set: function ( v ) {
-
-						uniforms.specularMap.value = v;
-
-					}
+					get: function () { return uniforms.specularMap.value; },
+					set: function ( v ) { uniforms.specularMap.value = v; }
 				},
 				specular: {
-					get: function () {
-
-						return uniforms.specular.value;
-
-					},
-					set: function ( v ) {
-
-						uniforms.specular.value = v;
-
-					}
+					get: function () { return uniforms.specular.value; },
+					set: function ( v ) { uniforms.specular.value = v; }
 				},
 				glossiness: {
-					get: function () {
-
-						return uniforms.glossiness.value;
-
-					},
-					set: function ( v ) {
-
-						uniforms.glossiness.value = v;
-
-					}
+					get: function () { return uniforms.glossiness.value; },
+					set: function ( v ) { uniforms.glossiness.value = v; }
 				},
 				glossinessMap: {
-					get: function () {
-
-						return uniforms.glossinessMap.value;
-
-					},
+					get: function () { return uniforms.glossinessMap.value; },
 					set: function ( v ) {
 
 						uniforms.glossinessMap.value = v;
@@ -770,15 +743,16 @@ THREE.GLTFLoader = ( function () {
 				}
 			}
 		);
+		/*eslint-enable*/
 
 		this.setValues( params );
 
 	}
 
-	MeshStandardSGMaterial.prototype = Object.create( THREE.MeshStandardMaterial.prototype );
-	MeshStandardSGMaterial.prototype.constructor = MeshStandardSGMaterial;
+	GLTFMeshStandardSGMaterial.prototype = Object.create( THREE.MeshStandardMaterial.prototype );
+	GLTFMeshStandardSGMaterial.prototype.constructor = GLTFMeshStandardSGMaterial;
 
-	MeshStandardSGMaterial.prototype.copy = function ( source ) {
+	GLTFMeshStandardSGMaterial.prototype.copy = function ( source ) {
 
 		THREE.MeshStandardMaterial.prototype.copy.call( this, source );
 		this.specularMap = source.specularMap;
@@ -823,7 +797,7 @@ THREE.GLTFLoader = ( function () {
 
 			getMaterialType: function () {
 
-				return MeshStandardSGMaterial;
+				return GLTFMeshStandardSGMaterial;
 
 			},
 
@@ -875,7 +849,7 @@ THREE.GLTFLoader = ( function () {
 
 			createMaterial: function ( params ) {
 
-				var material = new MeshStandardSGMaterial( params );
+				var material = new GLTFMeshStandardSGMaterial( params );
 				material.fog = true;
 
 				material.color = params.color;
@@ -2303,7 +2277,7 @@ THREE.GLTFLoader = ( function () {
 
 			var material;
 
-			if ( materialType === MeshStandardSGMaterial ) {
+			if ( materialType === GLTFMeshStandardSGMaterial ) {
 
 				material = extensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ].createMaterial( materialParams );
 
@@ -3061,6 +3035,10 @@ THREE.GLTFLoader = ( function () {
 
 						node = mesh.clone();
 						node.name += '_instance_' + instanceNum;
+
+					} else {
+
+						node = mesh;
 
 					}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -740,11 +740,11 @@ THREE.GLTFLoader = ( function () {
 			}
 		);
 
-		delete this.metalness
-		delete this.roughness
-		delete this.metalnessMap
-		delete this.roughnessMap
 		/*eslint-enable*/
+		delete this.metalness;
+		delete this.roughness;
+		delete this.metalnessMap;
+		delete this.roughnessMap;
 
 		this.setValues( params );
 
@@ -757,9 +757,13 @@ THREE.GLTFLoader = ( function () {
 
 		THREE.MeshStandardMaterial.prototype.copy.call( this, source );
 		this.specularMap = source.specularMap;
-		this.specular.copy(source.specular);
+		this.specular.copy( source.specular );
 		this.glossinessMap = source.glossinessMap;
 		this.glossiness = source.glossiness;
+		delete this.metalness;
+		delete this.roughness;
+		delete this.metalnessMap;
+		delete this.roughnessMap;
 		return this;
 
 	};

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -707,11 +707,7 @@ THREE.GLTFLoader = ( function () {
 		/*eslint-disable*/
 		Object.defineProperties(
 			this,
-			{
-				specularMap: {
-					get: function () { return uniforms.specularMap.value; },
-					set: function ( v ) { uniforms.specularMap.value = v; }
-				},
+			{	
 				specular: {
 					get: function () { return uniforms.specular.value; },
 					set: function ( v ) { uniforms.specular.value = v; }
@@ -743,6 +739,11 @@ THREE.GLTFLoader = ( function () {
 				}
 			}
 		);
+
+		delete this.metalness
+		delete this.roughness
+		delete this.metalnessMap
+		delete this.roughnessMap
 		/*eslint-enable*/
 
 		this.setValues( params );
@@ -756,7 +757,7 @@ THREE.GLTFLoader = ( function () {
 
 		THREE.MeshStandardMaterial.prototype.copy.call( this, source );
 		this.specularMap = source.specularMap;
-		this.specular = source.specular;
+		this.specular.copy(source.specular);
 		this.glossinessMap = source.glossinessMap;
 		this.glossiness = source.glossiness;
 		return this;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -630,7 +630,7 @@ THREE.GLTFLoader = ( function () {
 	 * @pailhead
 	 */
 
-	function SpecularGlossinessPbrMaterial( params ) {
+	function MeshStandardSGMaterial( params ) {
 
 		THREE.MeshStandardMaterial.call( this );
 
@@ -677,8 +677,8 @@ THREE.GLTFLoader = ( function () {
 		].join( '\n' );
 
 		var uniforms = {
-			specular: { value: new THREE.Color().setHex( 0x111111 ) },
-			glossiness: { value: 0.5 },
+			specular: { value: new THREE.Color().setHex( 0xffffff ) },
+			glossiness: { value: 1 },
 			specularMap: { value: null },
 			glossinessMap: { value: null }
 		};
@@ -775,10 +775,10 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
-	SpecularGlossinessPbrMaterial.prototype = Object.create( THREE.MeshStandardMaterial.prototype );
-	SpecularGlossinessPbrMaterial.prototype.constructor = SpecularGlossinessPbrMaterial;
+	MeshStandardSGMaterial.prototype = Object.create( THREE.MeshStandardMaterial.prototype );
+	MeshStandardSGMaterial.prototype.constructor = MeshStandardSGMaterial;
 
-	SpecularGlossinessPbrMaterial.prototype.copy = function ( source ) {
+	MeshStandardSGMaterial.prototype.copy = function ( source ) {
 
 		THREE.MeshStandardMaterial.prototype.copy.call( this, source );
 		this.specularMap = source.specularMap;
@@ -823,7 +823,7 @@ THREE.GLTFLoader = ( function () {
 
 			getMaterialType: function () {
 
-				return SpecularGlossinessPbrMaterial;
+				return MeshStandardSGMaterial;
 
 			},
 
@@ -875,7 +875,7 @@ THREE.GLTFLoader = ( function () {
 
 			createMaterial: function ( params ) {
 
-				var material = new SpecularGlossinessPbrMaterial( params );
+				var material = new MeshStandardSGMaterial( params );
 				material.fog = true;
 
 				material.color = params.color;
@@ -2333,7 +2333,7 @@ THREE.GLTFLoader = ( function () {
 
 			var material;
 
-			if ( materialType === SpecularGlossinessPbrMaterial ) {
+			if ( materialType === MeshStandardSGMaterial ) {
 
 				material = extensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ].createMaterial( materialParams );
 


### PR DESCRIPTION
Per conversation with @mrdoob.

Refactor `GLTFLoader` to remove the `onBeforeRender` dependency with `onBeforeCompile` dependency. It seems to make more sense to have the material manage the uniforms, rather than a scene graph node. 

Ideally i would not use `onBeforeCompile` but an alternate approach where different systems of the `WebGLRenderer` could be leveraged. But this is a step. 

The linter should maybe be run in this file, as it's got a lot of complaints in the dev branch. 

ping @takahirox @donmccurdy 