### PR TITLE
GLTFLoader: Optimization, Less clone materials

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2632,25 +2632,25 @@ THREE.GLTFLoader = ( function () {
 							if ( useMorphTargets ) cacheKey += 'morph-targets:';
 							if ( useMorphNormals ) cacheKey += 'morph-normals:';
 
-							var clonedMaterial = scope.cache.get( cacheKey );
+							var cachedMaterial = scope.cache.get( cacheKey );
 
-							if ( ! clonedMaterial ) {
+							if ( ! cachedMaterial ) {
 
-								clonedMaterial = material.isGLTFSpecularGlossinessMaterial
+								cachedMaterial = material.isGLTFSpecularGlossinessMaterial
 										? extensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ].cloneMaterial( material )
 										: material.clone();
 
-								if ( useSkinning ) clonedMaterial.skinning = true;
-								if ( useVertexColors ) clonedMaterial.vertexColors = THREE.VertexColors;
-								if ( useFlatShading ) clonedMaterial.flatShading = true;
-								if ( useMorphTargets ) clonedMaterial.morphTargets = true;
-								if ( useMorphNormals ) clonedMaterial.morphNormals = true;
+								if ( useSkinning ) cachedMaterial.skinning = true;
+								if ( useVertexColors ) cachedMaterial.vertexColors = THREE.VertexColors;
+								if ( useFlatShading ) cachedMaterial.flatShading = true;
+								if ( useMorphTargets ) cachedMaterial.morphTargets = true;
+								if ( useMorphNormals ) cachedMaterial.morphNormals = true;
 
-								scope.cache.add( cacheKey, clonedMaterial );
+								scope.cache.add( cacheKey, cachedMaterial );
 
 							}
 
-							material = clonedMaterial;
+							material = cachedMaterial;
 
 						}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2620,43 +2620,37 @@ THREE.GLTFLoader = ( function () {
 
 						}
 
-						// If the material will be modified later on, clone it now.
+						// Clone the material if it will be modified
 						if ( useVertexColors || useFlatShading || useSkinning || useMorphTargets ) {
 
-							material = material.isGLTFSpecularGlossinessMaterial
-									? extensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ].cloneMaterial( material )
-									: material.clone();
+							var cacheKey = 'ClonedMaterial:' + material.uuid + ':';
 
-						}
+							if ( material.isGLTFSpecularGlossinessMaterial ) cacheKey += 'specular-glossiness:';
+							if ( useSkinning ) cacheKey += 'skinning:';
+							if ( useVertexColors ) cacheKey += 'vertex-colors:';
+							if ( useFlatShading ) cacheKey += 'flat-shading:';
+							if ( useMorphTargets ) cacheKey += 'morph-targets:';
+							if ( useMorphNormals ) cacheKey += 'morph-normals:';
 
-						if ( useSkinning ) {
+							var clonedMaterial = scope.cache.get( cacheKey );
 
-							material.skinning = true;
+							if ( ! clonedMaterial ) {
 
-						}
+								clonedMaterial = material.isGLTFSpecularGlossinessMaterial
+										? extensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ].cloneMaterial( material )
+										: material.clone();
 
-						if ( useVertexColors ) {
+								if ( useSkinning ) clonedMaterial.skinning = true;
+								if ( useVertexColors ) clonedMaterial.vertexColors = THREE.VertexColors;
+								if ( useFlatShading ) clonedMaterial.flatShading = true;
+								if ( useMorphTargets ) clonedMaterial.morphTargets = true;
+								if ( useMorphNormals ) clonedMaterial.morphNormals = true;
 
-							material.vertexColors = THREE.VertexColors;
-							material.needsUpdate = true;
+								scope.cache.add( cacheKey, clonedMaterial );
 
-						}
+							}
 
-						if ( useFlatShading ) {
-
-							material.flatShading = true;
-
-						}
-
-						if ( useMorphTargets ) {
-
-							material.morphTargets = true;
-
-						}
-
-						if ( useMorphNormals ) {
-
-							material.morphNormals = true;
+							material = clonedMaterial;
 
 						}
 


### PR DESCRIPTION
This PR optimizes `GLTFLoader` by less cloning materials in `loadMesh()`.

I have a glTF model that many SkinnedMesh (`useSkinning = true`) share a material. Currently `loadMesh()` clones the material for every meshes. By caching it and reusing, the material can be shared among the meshes.

(BTW, I'm sending this PR from Madrid airport. I've missed the connection flight and need to stuck here for ten hours then I started to work in the airport hehe.)