### PR TITLE
Add error message for case not handled in DirectGeometry

### DIFF
--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -139,7 +139,7 @@ Object.assign( DirectGeometry.prototype, {
 		var hasSkinWeights = skinWeights.length === vertices.length;
 
 		//
-		
+
 		if ( faces.length === 0 ) {
 
 			console.error( 'THREE.DirectGeometry: Faceless geometries are not supported.' );

--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -139,6 +139,12 @@ Object.assign( DirectGeometry.prototype, {
 		var hasSkinWeights = skinWeights.length === vertices.length;
 
 		//
+		
+		if ( faces.length === 0 ) {
+
+			console.error( 'THREE.DirectGeometry: Faceless geometries are not supported.' );
+
+		}
 
 		for ( var i = 0; i < faces.length; i ++ ) {
 


### PR DESCRIPTION
Currently `DirectGeometry.fromGeometry()` fails with no indication why when the geometry has no faces, as for example a line geometry. This message lets the end user know why.

Documentation updated in #14064.