### PR TITLE
Docs: use ': this' for chainable methods in common classes.

### DIFF
--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -191,7 +191,7 @@
 
 		<h3>[method:null add]( [param:Object3D object], ... )</h3>
 		<p>
-		Adds *object* as child of this object. An arbitrary number of objects may be added. Any current parent on an 
+		Adds *object* as child of this object. An arbitrary number of objects may be added. Any current parent on an
 		object passed in here will be removed, since an object can have at most one parent.<br /><br />
 
 		See [page:Group] for info on manually grouping objects.
@@ -210,7 +210,7 @@
 		Returns a clone of this object and optionally all descendants.
 		</p>
 
-		<h3>[method:Object3D copy]( [param:Object3D object], [param:Boolean recursive] )</h3>
+		<h3>[method:this copy]( [param:Object3D object], [param:Boolean recursive] )</h3>
 		<p>
 		recursive -- if true, descendants of the object are also copied. Default is true.<br /><br />
 
@@ -301,7 +301,7 @@
 		Removes *object* as child of this object. An arbitrary number of objects may be removed.
 		</p>
 
-		<h3>[method:Object3D rotateOnAxis]( [param:Vector3 axis], [param:Float angle] )</h3>
+		<h3>[method:this rotateOnAxis]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<p>
 		axis -- A normalized vector in object space. <br />
 		angle -- The angle in radians.<br /><br />
@@ -309,7 +309,7 @@
 		Rotate an object along an axis in object space. The axis is assumed to be normalized.
 		</p>
 
-		<h3>[method:Object3D rotateOnWorldAxis]( [param:Vector3 axis], [param:Float angle] )</h3>
+		<h3>[method:this rotateOnWorldAxis]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<p>
 		axis -- A normalized vector in world space. <br />
 		angle -- The angle in radians.<br /><br />
@@ -318,21 +318,21 @@
 		Method Assumes no rotated parent.
 		</p>
 
-		<h3>[method:null rotateX]( [param:Float rad] )</h3>
+		<h3>[method:this rotateX]( [param:Float rad] )</h3>
 		<p>
 		rad - the angle to rotate in radians.<br /><br />
 
 		Rotates the object around x axis in local space.
 		</p>
 
-		<h3>[method:null rotateY]( [param:Float rad] )</h3>
+		<h3>[method:this rotateY]( [param:Float rad] )</h3>
 		<p>
 		rad - the angle to rotate in radians.<br /><br />
 
 		Rotates the object around y axis in local space.
 		</p>
 
-		<h3>[method:null rotateZ]( [param:Float rad] )</h3>
+		<h3>[method:this rotateZ]( [param:Float rad] )</h3>
 		<p>
 		rad - the angle to rotate in radians.<br /><br />
 
@@ -378,7 +378,7 @@
 			Convert the object to JSON format.
 		</p>
 
-		<h3>[method:Object3D translateOnAxis]( [param:Vector3 axis], [param:Float distance] )</h3>
+		<h3>[method:this translateOnAxis]( [param:Vector3 axis], [param:Float distance] )</h3>
 		<p>
 		axis -- A normalized vector in object space.<br />
 		distance -- The distance to translate.<br /><br />
@@ -386,13 +386,13 @@
 		Translate an object by distance along an axis in object space. The axis is assumed to be normalized.
 		</p>
 
-		<h3>[method:null translateX]( [param:Float distance] )</h3>
+		<h3>[method:this translateX]( [param:Float distance] )</h3>
 		<p>Translates object along x axis by *distance* units.</p>
 
-		<h3>[method:null translateY]( [param:Float distance] )</h3>
+		<h3>[method:this translateY]( [param:Float distance] )</h3>
 		<p>Translates object along y axis by *distance* units.</p>
 
-		<h3>[method:null translateZ]( [param:Float distance] )</h3>
+		<h3>[method:this translateZ]( [param:Float distance] )</h3>
 		<p>Translates object along z axis by *distance* units.</p>
 
 		<h3>[method:null traverse]( [param:Function callback] )</h3>

--- a/docs/api/math/Matrix3.html
+++ b/docs/api/math/Matrix3.html
@@ -83,7 +83,7 @@ m.elements = [ 11, 21, 31,
 		<h3>[method:Matrix3 clone]()</h3>
 		<p>Creates a new Matrix3 and with identical elements to this one.</p>
 
-		<h3>[method:Matrix3 copy]( [param:Matrix3 m] )</h3>
+		<h3>[method:this copy]( [param:Matrix3 m] )</h3>
 		<p>Copies the elements of matrix [page:Matrix3 m] into this matrix.</p>
 
 		<h3>[method:Float determinant]()</h3>
@@ -95,7 +95,7 @@ m.elements = [ 11, 21, 31,
 		<h3>[method:Boolean equals]( [param:Matrix3 m] )</h3>
 		<p>Return true if this matrix and [page:Matrix3 m] are equal.</p>
 
-		<h3>[method:Matrix3 fromArray]( [param:Array array], [param:Integer offset] )</h3>
+		<h3>[method:this fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<p>
 		[page:Array array] - the array to read the elements from.<br />
 		[page:Integer offset] - (optional) index of first element in the array. Default is 0.<br /><br />
@@ -104,7 +104,7 @@ m.elements = [ 11, 21, 31,
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</p>
 
-		<h3>[method:Matrix3 getInverse]( [param:Matrix3 m], [param:Boolean throwOnDegenerate] )</h3>
+		<h3>[method:this getInverse]( [param:Matrix3 m], [param:Boolean throwOnDegenerate] )</h3>
 		<p>
 		[page:Matrix3 m] - the matrix to take the inverse of.<br />
 		[page:Boolean throwOnDegenerate] - (optional) If true, throw an error if the matrix is degenerate (not invertible).<br /><br />
@@ -115,7 +115,7 @@ m.elements = [ 11, 21, 31,
 		If [page:Boolean throwOnDegenerate] is not set and the matrix is not invertible, set this to the 3x3 identity matrix.
 		</p>
 
-		<h3>[method:Matrix3 getNormalMatrix]( [param:Matrix4 m] )</h3>
+		<h3>[method:this getNormalMatrix]( [param:Matrix4 m] )</h3>
 		<p>
 		[page:Matrix4 m] - [page:Matrix4]<br /><br />
 
@@ -124,7 +124,7 @@ m.elements = [ 11, 21, 31,
 	  of the matrix [page:Matrix4 m].
 		</p>
 
-		<h3>[method:Matrix3 identity]()</h3>
+		<h3>[method:this identity]()</h3>
 		<p>
 		Resets this matrix to the 3x3 identity matrix:
 		<code>
@@ -135,17 +135,17 @@ m.elements = [ 11, 21, 31,
 
 		</p>
 
-		<h3>[method:Matrix3 multiply]( [param:Matrix3 m] )</h3>
+		<h3>[method:this multiply]( [param:Matrix3 m] )</h3>
 		<p>Post-multiplies this matrix by [page:Matrix3 m].</p>
 
-		<h3>[method:Matrix3 multiplyMatrices]( [param:Matrix3 a], [param:Matrix3 b] )</h3>
+		<h3>[method:this multiplyMatrices]( [param:Matrix3 a], [param:Matrix3 b] )</h3>
 		<p>Sets this matrix to [page:Matrix3 a] x [page:Matrix3 b].</p>
 
-		<h3>[method:Matrix3 multiplyScalar]( [param:Float s] )</h3>
+		<h3>[method:this multiplyScalar]( [param:Float s] )</h3>
 		<p>Multiplies every component of the matrix by the scalar value *s*.</p>
 
 		<h3>
-			[method:Matrix3 set](
+			[method:this set](
 			[page:Float n11], [page:Float n12], [page:Float n13],
 			[page:Float n21], [page:Float n22], [page:Float n23],
 			[page:Float n31], [page:Float n32], [page:Float n33] )
@@ -163,14 +163,14 @@ m.elements = [ 11, 21, 31,
 		sequence of values.
 		</p>
 
-		<h3>[method:Matrix3 premultiply]( [param:Matrix3 m] )</h3>
+		<h3>[method:this premultiply]( [param:Matrix3 m] )</h3>
 		<p>Pre-multiplies this matrix by [page:Matrix3 m].</p>
 
-		<h3>[method:Matrix3 setFromMatrix4]( [param:Matrix4 m] )</h3>
+		<h3>[method:this setFromMatrix4]( [param:Matrix4 m] )</h3>
 		<p>Set this matrx to the upper 3x3 matrix of the Matrix4 [page:Matrix4 m].</p>
 
 		<h3>
-			[method:Matrix3 setUvTransform](
+			[method:this setUvTransform](
 			[page:Float tx], [page:Float ty], [page:Float sx], [page:Float sy],
 			[page:Float rotation], [page:Float cx], [page:Float cy] )
 		</h3>
@@ -195,10 +195,10 @@ m.elements = [ 11, 21, 31,
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</p>
 
-		<h3>[method:Matrix3 transpose]()</h3>
+		<h3>[method:this transpose]()</h3>
 		<p>[link:https://en.wikipedia.org/wiki/Transpose Transposes] this matrix in place.</p>
 
-		<h3>[method:Matrix3 transposeIntoArray]( [param:Array array] )</h3>
+		<h3>[method:this transposeIntoArray]( [param:Array array] )</h3>
 		<p>
 		[page:Array array] -  array to store the resulting vector in.<br /><br />
 

--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -119,7 +119,7 @@ m.elements = [ 11, 21, 31, 41,
 		<h3>[method:Matrix4 clone]()</h3>
 		<p>Creates a new Matrix4 with identical [page:.elements elements] to this one.</p>
 
-		<h3>[method:Matrix4 compose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
+		<h3>[method:this compose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
 		<p>
 		Sets this matrix to the transformation composed of [page:Vector3 position],
 		[page:Quaternion quaternion] and [page:Vector3 scale]. Internally this calls
@@ -128,10 +128,10 @@ m.elements = [ 11, 21, 31, 41,
 		[page:.setPosition setPosition]( [page:Vector3 position] ).
 		</p>
 
-		<h3>[method:Matrix4 copy]( [param:Matrix4 m] )</h3>
+		<h3>[method:this copy]( [param:Matrix4 m] )</h3>
 		<p>Copies the [page:.elements elements] of matrix [page:Matrix4 m] into this matrix.</p>
 
-		<h3>[method:Matrix4 copyPosition]( [param:Matrix4 m] )</h3>
+		<h3>[method:this copyPosition]( [param:Matrix4 m] )</h3>
 		<p>
 		Copies the translation component of the supplied matrix [page:Matrix4 m] into this
 		matrix's translation component.
@@ -154,7 +154,7 @@ m.elements = [ 11, 21, 31, 41,
 		<h3>[method:Boolean equals]( [param:Matrix4 m] )</h3>
 		<p>Return true if this matrix and [page:Matrix4 m] are equal.</p>
 
-		<h3>[method:Matrix4 extractBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
+		<h3>[method:this extractBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<p>
 		Extracts the [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] of this
 		matrix into the three axis vectors provided. If this matrix is:
@@ -172,13 +172,13 @@ zAxis = (c, g, k)
 		</code>
 		</p>
 
-		<h3>[method:Matrix4 extractRotation]( [param:Matrix4 m] )</h3>
+		<h3>[method:this extractRotation]( [param:Matrix4 m] )</h3>
 		<p>
 		Extracts the rotation component of the supplied matrix [page:Matrix4 m] into this matrix's
 		rotation component.
 		</p>
 
-		<h3>[method:Matrix4 fromArray]( [param:Array array], [param:Integer offset] )</h3>
+		<h3>[method:this fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<p>
 		[page:Array array] - the array to read the elements from.<br />
 		[page:Integer offset] - ( optional ) offset into the array. Default is 0.<br /><br />
@@ -187,7 +187,7 @@ zAxis = (c, g, k)
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</p>
 
-		<h3>[method:Matrix4 getInverse]( [param:Matrix4 m], [param:Boolean throwOnDegenerate] )</h3>
+		<h3>[method:this getInverse]( [param:Matrix4 m], [param:Boolean throwOnDegenerate] )</h3>
 		<p>
 		[page:Matrix4 m] - the matrix to take the inverse of.<br />
 		[page:Boolean throwOnDegenerate] - (optional) If true, throw an error if the matrix is degenerate (not invertible).<br /><br />
@@ -202,16 +202,16 @@ zAxis = (c, g, k)
 		<h3>[method:Float getMaxScaleOnAxis]()</h3>
 		<p>Gets the maximum scale value of the 3 axes.</p>
 
-		<h3>[method:Matrix4 identity]()</h3>
+		<h3>[method:this identity]()</h3>
 		<p>Resets this matrix to the [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].</p>
 
-		<h3>[method:Matrix4 lookAt]( [param:Vector3 eye], [param:Vector3 center], [param:Vector3 up], )</h3>
+		<h3>[method:this lookAt]( [param:Vector3 eye], [param:Vector3 center], [param:Vector3 up], )</h3>
 		<p>
 			Constructs a rotation matrix, looking from [page:Vector3 eye] towards [page:Vector3 center]
 			oriented by the [page:Vector3 up] vector.
 		</p>
 
-		<h3>[method:Matrix4 makeRotationAxis]( [param:Vector3 axis], [param:Float theta] )</h3>
+		<h3>[method:this makeRotationAxis]( [param:Vector3 axis], [param:Float theta] )</h3>
 		<p>
 		[page:Vector3 axis] — Rotation axis, should be normalized.<br />
 		[page:Float theta] — Rotation angle in radians.<br /><br />
@@ -222,7 +222,7 @@ zAxis = (c, g, k)
 		See the discussion [link:http://www.gamedev.net/reference/articles/article1199.asp here].
 		</p>
 
-		<h3>[method:Matrix4 makeBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
+		<h3>[method:this makeBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<p>
 		Set this to the [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] matrix consisting
 		of the three provided basis vectors:
@@ -234,26 +234,26 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		</code>
 		</p>
 
-		<h3>[method:Matrix4 makePerspective]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
+		<h3>[method:this makePerspective]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
 		<p>
 			Creates a [link:https://en.wikipedia.org/wiki/3D_projection#Perspective_projection perspective projection] matrix.
 			This is used internally by [page:PerspectiveCamera.updateProjectionMatrix]()
 		</p>
 
-		<h3>[method:Matrix4 makeOrthographic]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
+		<h3>[method:this makeOrthographic]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
 		<p>
 		Creates an [link:https://en.wikipedia.org/wiki/Orthographic_projection orthographic projection] matrix.
 		This is used internally by [page:OrthographicCamera.updateProjectionMatrix]().
 		</p>
 
-		<h3>[method:Matrix4 makeRotationFromEuler]( [param:Euler euler] )</h3>
+		<h3>[method:this makeRotationFromEuler]( [param:Euler euler] )</h3>
 		<p>
 		Sets the rotation component (the upper left 3x3 matrix) of this matrix to the rotation specified by the given [page:Euler Euler Angle].
 		The rest of the matrix is set to the identity. Depending on the [page:Euler.order order] of the [page:Euler euler], there are six possible outcomes.
 		See [link:https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix this page] for a complete list.
 		</p>
 
-		<h3>[method:Matrix4 makeRotationFromQuaternion]( [param:Quaternion q] )</h3>
+		<h3>[method:this makeRotationFromQuaternion]( [param:Quaternion q] )</h3>
 		<p>
 		Sets the rotation component of this matrix to the rotation specified by [page:Quaternion q], as outlined
 		[link:https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion here].
@@ -266,7 +266,7 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		</code>
 		</p>
 
-		<h3>[method:Matrix4 makeRotationX]( [param:Float theta] )</h3>
+		<h3>[method:this makeRotationX]( [param:Float theta] )</h3>
 		<p>
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
@@ -280,7 +280,7 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		</code>
 		</p>
 
-		<h3>[method:Matrix4 makeRotationY]( [param:Float theta] )</h3>
+		<h3>[method:this makeRotationY]( [param:Float theta] )</h3>
 		<p>
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
@@ -294,7 +294,7 @@ cos(&theta;)  0 sin(&theta;) 0
 		</code>
 		</p>
 
-		<h3>[method:Matrix4 makeRotationZ]( [param:Float theta] )</h3>
+		<h3>[method:this makeRotationZ]( [param:Float theta] )</h3>
 		<p>
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
@@ -308,7 +308,7 @@ sin(&theta;) cos(&theta;)  0 0
 		</code>
 		</p>
 
-		<h3>[method:Matrix4 makeScale]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<h3>[method:this makeScale]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<p>
 			[page:Float x] - the amount to scale in the X axis.<br />
 			[page:Float y] - the amount to scale in the Y axis.<br />
@@ -323,7 +323,7 @@ x, 0, 0, 0,
 			</code>
 		</p>
 
-		<h3>[method:Matrix4 makeShear]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<h3>[method:this makeShear]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<p>
 		[page:Float x] - the amount to shear in the X axis.<br />
 		[page:Float y] - the amount to shear in the Y axis.<br />
@@ -338,7 +338,7 @@ x, y, 1, 0,
 </code>
 		</p>
 
-		<h3>[method:Matrix4 makeTranslation]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<h3>[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<p>
 			[page:Float x] - the amount to translate in the X axis.<br />
 			[page:Float y] - the amount to translate in the Y axis.<br />
@@ -353,22 +353,22 @@ x, y, 1, 0,
 		</code>
 		</p>
 
-		<h3>[method:Matrix4 multiply]( [param:Matrix4 m] )</h3>
+		<h3>[method:this multiply]( [param:Matrix4 m] )</h3>
 		<p>Post-multiplies this matrix by [page:Matrix4 m].</p>
 
-		<h3>[method:Matrix4 multiplyMatrices]( [param:Matrix4 a], [param:Matrix4 b] )</h3>
+		<h3>[method:this multiplyMatrices]( [param:Matrix4 a], [param:Matrix4 b] )</h3>
 		<p>Sets this matrix to [page:Matrix4 a] x [page:Matrix4 b].</p>
 
-		<h3>[method:Matrix4 multiplyScalar]( [param:Float s] )</h3>
+		<h3>[method:this multiplyScalar]( [param:Float s] )</h3>
 		<p>Multiplies every component of the matrix by a scalar value [page:Float s].</p>
 
-		<h3>[method:Matrix4 premultiply]( [param:Matrix4 m] )</h3>
+		<h3>[method:this premultiply]( [param:Matrix4 m] )</h3>
 		<p>Pre-multiplies this matrix by [page:Matrix4 m].</p>
 
-		<h3>[method:Matrix4 scale]( [param:Vector3 v] )</h3>
+		<h3>[method:this scale]( [param:Vector3 v] )</h3>
 		<p>Multiplies the columns of this matrix by vector [page:Vector3 v].</p>
 
-		<h3>[method:Matrix4 set](
+		<h3>[method:this set](
 			[page:Float n11], [page:Float n12], [page:Float n13], [page:Float n14],
 			[page:Float n21], [page:Float n22], [page:Float n23], [page:Float n24],
 			[page:Float n31], [page:Float n32], [page:Float n33], [page:Float n34],
@@ -378,7 +378,7 @@ x, y, 1, 0,
 			[page:Float n12], ... [page:Float n44].
 		</p>
 
-		<h3>[method:Matrix4 setPosition]( [param:Vector3 v] )</h3>
+		<h3>[method:this setPosition]( [param:Vector3 v] )</h3>
 		<p>
 			Sets the position component for this matrix from vector [page:Vector3 v], without affecting the
 			rest of the matrix - i.e. if the matrix is currently:
@@ -406,7 +406,7 @@ m, n, o, p
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</p>
 
-		<h3>[method:Matrix4 transpose]()</h3>
+		<h3>[method:this transpose]()</h3>
 		<p>[link:https://en.wikipedia.org/wiki/Transpose Transposes] this matrix.</p>
 
 		<h2>Source</h2>

--- a/docs/api/math/Vector2.html
+++ b/docs/api/math/Vector2.html
@@ -82,16 +82,16 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector2 add]( [param:Vector2 v] )</h3>
+		<h3>[method:this add]( [param:Vector2 v] )</h3>
 		<p>Adds [page:Vector2 v] to this vector.</p>
 
-		<h3>[method:Vector2 addScalar]( [param:Float s] )</h3>
+		<h3>[method:this addScalar]( [param:Float s] )</h3>
 		<p>Adds the scalar value [page:Float s] to this vector's [page:.x x] and [page:.y y] values.</p>
 
-		<h3>[method:Vector2 addScaledVector]( [param:Vector2 v], [param:Float s] )</h3>
+		<h3>[method:this addScaledVector]( [param:Vector2 v], [param:Float s] )</h3>
 		<p>Adds the multiple of [page:Vector2 v] and [page:Float s] to this vector.</p>
 
-		<h3>[method:Vector2 addVectors]( [param:Vector2 a], [param:Vector2 b] )</h3>
+		<h3>[method:this addVectors]( [param:Vector2 a], [param:Vector2 b] )</h3>
 		<p>Sets this vector to [page:Vector2 a] + [page:Vector2 b].</p>
 
 		<h3>[method:Float angle]()</h3>
@@ -99,17 +99,17 @@
 		Computes the angle in radians of this vector with respect to the positive x-axis.
 		</p>
 
-		<h3>[method:Vector2 applyMatrix3]( [param:Matrix3 m] )</h3>
+		<h3>[method:this applyMatrix3]( [param:Matrix3 m] )</h3>
 		<p>
 		Multiplies this vector (with an implicit 1 as the 3rd component) by m.
 		</p>
 
-		<h3>[method:Vector2 ceil]()</h3>
+		<h3>[method:this ceil]()</h3>
 		<p>
 		The [page:.x x] and [page:.y y] components of the vector are rounded up to the nearest integer value.
 		</p>
 
-		<h3>[method:Vector2 clamp]( [param:Vector2 min], [param:Vector2 max] )</h3>
+		<h3>[method:this clamp]( [param:Vector2 min], [param:Vector2 max] )</h3>
 		<p>
 		[page:Vector2 min] - the minimum x and y values.<br />
 		[page:Vector2 max] - the maximum x and y values in the desired range<br /><br />
@@ -118,7 +118,7 @@
 		If this vector's x or y value is less than the min vector's x or y value, it is replaced by the corresponding value.
 		</p>
 
-		<h3>[method:Vector2 clampLength]( [param:Float min], [param:Float max] )</h3>
+		<h3>[method:this clampLength]( [param:Float min], [param:Float max] )</h3>
 		<p>
 		[page:Float min] - the minimum value the length will be clamped to <br />
 		[page:Float max] - the maximum value the length will be clamped to<br /><br />
@@ -127,7 +127,7 @@
 		If this vector's length is less than the min value, it is replaced by the min value.
 		</p>
 
-		<h3>[method:Vector2 clampScalar]( [param:Float min], [param:Float max] )</h3>
+		<h3>[method:this clampScalar]( [param:Float min], [param:Float max] )</h3>
 		<p>
 		[page:Float min] - the minimum value the components will be clamped to <br />
 		[page:Float max] - the maximum value the components will be clamped to<br /><br />
@@ -141,7 +141,7 @@
 		Returns a new Vector2 with the same [page:.x x] and [page:.y y] values as this one.
 		</p>
 
-		<h3>[method:Vector2 copy]( [param:Vector2 v] )</h3>
+		<h3>[method:this copy]( [param:Vector2 v] )</h3>
 		<p>
 			Copies the values of the passed Vector2's [page:.x x] and [page:.y y]
 			properties to this Vector2.
@@ -162,10 +162,10 @@
 		as it is slightly more efficient to calculate.
 		</p>
 
-		<h3>[method:Vector2 divide]( [param:Vector2 v] )</h3>
+		<h3>[method:this divide]( [param:Vector2 v] )</h3>
 		<p>Divides this vector by [page:Vector2 v].</p>
 
-		<h3>[method:Vector2 divideScalar]( [param:Float s] )</h3>
+		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>
 		Divides this vector by scalar [page:Float s].<br />
 		Sets vector to *( 0, 0 )* if [page:Float s] = 0.
@@ -180,10 +180,10 @@
 		<h3>[method:Boolean equals]( [param:Vector2 v] )</h3>
 		<p>Checks for strict equality of this vector and [page:Vector2 v].</p>
 
-		<h3>[method:Vector2 floor]()</h3>
+		<h3>[method:this floor]()</h3>
 		<p>The components of the vector are rounded down to the nearest integer value.</p>
 
-		<h3>[method:Vector2 fromArray]( [param:Array array], [param:Integer offset] )</h3>
+		<h3>[method:this fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<p>
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - (optional) offset into the array. Default is 0.<br /><br />
@@ -191,7 +191,7 @@
 		Sets this vector's [page:.x x] value to be array[ offset ] and [page:.y y] value to be array[ offset + 1 ].
 		</p>
 
-		<h3>[method:Vector2 fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
+		<h3>[method:this fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
 		<p>
 		[page:BufferAttribute attribute] - the source attribute.<br />
 		[page:Integer index] - index in the attribute.<br /><br />
@@ -223,7 +223,7 @@
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
 		</p>
 
-		<h3>[method:Vector2 lerp]( [param:Vector2 v], [param:Float alpha] )</h3>
+		<h3>[method:this lerp]( [param:Vector2 v], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector2 v] - [page:Vector2] to interpolate towards.<br />
 		alpha - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -232,7 +232,7 @@
 		distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector2 v].
 		</p>
 
-		<h3>[method:Vector2 lerpVectors]( [param:Vector2 v1], [param:Vector2 v2], [param:Float alpha] )</h3>
+		<h3>[method:this lerpVectors]( [param:Vector2 v1], [param:Vector2 v2], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector2 v1] - the starting [page:Vector2].<br />
 		[page:Vector2 v2] - [page:Vector2] to interpolate towards.<br />
@@ -243,35 +243,35 @@
 		- alpha = 0 will be [page:Vector2 v1], and alpha = 1 will be [page:Vector2 v2].
 		</p>
 
-		<h3>[method:Vector2 negate]()</h3>
+		<h3>[method:this negate]()</h3>
 		<p>Inverts this vector - i.e. sets x = -x and y = -y.</p>
 
-		<h3>[method:Vector2 normalize]()</h3>
+		<h3>[method:this normalize]()</h3>
 		<p>
 		Converts this vector to a [link:https://en.wikipedia.org/wiki/Unit_vector unit vector] - that is, sets it equal to the vector with the same direction
 		as this one, but [page:.length length] 1.
 		</p>
 
-		<h3>[method:Vector2 max]( [param:Vector2 v] )</h3>
+		<h3>[method:this max]( [param:Vector2 v] )</h3>
 		<p>
 		If this vector's x or y value is less than [page:Vector2 v]'s x or y value, replace
 		that value with the corresponding max value.
 		</p>
 
-		<h3>[method:Vector2 min]( [param:Vector2 v] )</h3>
+		<h3>[method:this min]( [param:Vector2 v] )</h3>
 		<p>
 		If this vector's x or y value is greater than [page:Vector2 v]'s x or y value, replace
 		that value with the corresponding min value.
 		</p>
 
-		<h3>[method:Vector2 multiply]( [param:Vector2 v] )</h3>
+		<h3>[method:this multiply]( [param:Vector2 v] )</h3>
 		<p>Multiplies this vector by [page:Vector2 v].</p>
 
 
-		<h3>[method:Vector2 multiplyScalar]( [param:Float s] )</h3>
+		<h3>[method:this multiplyScalar]( [param:Float s] )</h3>
 		<p>Multiplies this vector by scalar [page:Float s].</p>
 
-		<h3>[method:Vector2 rotateAround]( [param:Vector2 center], [param:float angle] )</h3>
+		<h3>[method:this rotateAround]( [param:Vector2 center], [param:float angle] )</h3>
 		<p>
 			[page:Vector2 center] - the point around which to rotate.<br />
 			[page:float angle] - the angle to rotate, in radians.<br /><br />
@@ -279,15 +279,15 @@
 			Rotates the vector around [page:Vector2 center] by [page:float angle] radians.
 		</p>
 
-		<h3>[method:Vector2 round]()</h3>
+		<h3>[method:this round]()</h3>
 		<p>The components of the vector are rounded to the nearest integer value.</p>
 
-		<h3>[method:Vector2 roundToZero]()</h3>
+		<h3>[method:this roundToZero]()</h3>
 		<p>
 		The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.
 		</p>
 
-		<h3>[method:Vector2 set]( [param:Float x], [param:Float y] )</h3>
+		<h3>[method:this set]( [param:Float x], [param:Float y] )</h3>
 		<p>Sets the [page:.x x] and [page:.y y] components of this vector.</p>
 
 		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
@@ -299,30 +299,30 @@
 		If index equals 1 set [page:.y y] to [page:Float value]
 		</p>
 
-		<h3>[method:Vector2 setLength]( [param:Float l] )</h3>
+		<h3>[method:this setLength]( [param:Float l] )</h3>
 		<p>
 		Sets this vector to the vector with the same direction as this one, but [page:.length length]
 		[page:Float l].
 		</p>
 
-		<h3>[method:Vector2 setScalar]( [param:Float scalar] )</h3>
+		<h3>[method:this setScalar]( [param:Float scalar] )</h3>
 		<p>
 		Sets the [page:.x x] and [page:.y y] values of this vector both equal to [page:Float scalar].
 		</p>
 
-		<h3>[method:Vector2 setX]( [param:Float x] )</h3>
+		<h3>[method:this setX]( [param:Float x] )</h3>
 		<p>Replaces this vector's [page:.x x] value with [page:Float x].</p>
 
-		<h3>[method:Vector2 setY]( [param:Float y] )</h3>
+		<h3>[method:this setY]( [param:Float y] )</h3>
 		<p>Replaces this vector's [page:.y y] value with [page:Float y].</p>
 
-		<h3>[method:Vector2 sub]( [param:Vector2 v] )</h3>
+		<h3>[method:this sub]( [param:Vector2 v] )</h3>
 		<p>Subtracts [page:Vector2 v] from this vector.</p>
 
-		<h3>[method:Vector2 subScalar]( [param:Float s] )</h3>
+		<h3>[method:this subScalar]( [param:Float s] )</h3>
 		<p>Subtracts [page:Float s]  from this vector's [page:.x x] and [page:.y y] components.</p>
 
-		<h3>[method:Vector2 subVectors]( [param:Vector2 a], [param:Vector2 b] )</h3>
+		<h3>[method:this subVectors]( [param:Vector2 a], [param:Vector2 b] )</h3>
 		<p>Sets this vector to [page:Vector2 a] - [page:Vector2 b].</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>

--- a/docs/api/math/Vector3.html
+++ b/docs/api/math/Vector3.html
@@ -79,19 +79,19 @@ var d = a.distanceTo( b );
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector3 add]( [param:Vector3 v] )</h3>
+		<h3>[method:this add]( [param:Vector3 v] )</h3>
 		<p>Adds [page:Vector3 v] to this vector.</p>
 
-		<h3>[method:Vector3 addScalar]( [param:Float s] )</h3>
+		<h3>[method:this addScalar]( [param:Float s] )</h3>
 		<p>Adds the scalar value s to this vector's [page:.x x], [page:.y y] and [page:.z z] values.</p>
 
-		<h3>[method:Vector3 addScaledVector]( [param:Vector3 v], [param:Float s] )</h3>
+		<h3>[method:this addScaledVector]( [param:Vector3 v], [param:Float s] )</h3>
 		<p>Adds the multiple of [page:Vector3 v] and [page:Float s] to this vector.</p>
 
-		<h3>[method:Vector3 addVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
+		<h3>[method:this addVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
 		<p>Sets this vector to [page:Vector3 a] + [page:Vector3 b].</p>
 
-		<h3>[method:Vector3 applyAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
+		<h3>[method:this applyAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<p>
 		[page:Vector3 axis] - A normalized [page:Vector3].<br />
 		[page:Float angle] - An angle in radians.<br /><br />
@@ -99,21 +99,21 @@ var d = a.distanceTo( b );
 		Applies a rotation specified by an axis and an angle to this vector.
 		</p>
 
-		<h3>[method:Vector3 applyEuler]( [param:Euler euler] )</h3>
+		<h3>[method:this applyEuler]( [param:Euler euler] )</h3>
 		<p>
 		Applies euler transform to this vector by converting the [page:Euler] object to a
 		[page:Quaternion] and applying.
 		</p>
 
-		<h3>[method:Vector3 applyMatrix3]( [param:Matrix3 m] )</h3>
+		<h3>[method:this applyMatrix3]( [param:Matrix3 m] )</h3>
 		<p>Multiplies this vector by [page:Matrix3 m]</p>
 
-		<h3>[method:Vector3 applyMatrix4]( [param:Matrix4 m] )</h3>
+		<h3>[method:this applyMatrix4]( [param:Matrix4 m] )</h3>
 		<p>
 		Multiplies this vector (with an implicit 1 in the 4th dimension) and m, and divides by perspective.
 		</p>
 
-		<h3>[method:Vector3 applyQuaternion]( [param:Quaternion quaternion] )</h3>
+		<h3>[method:this applyQuaternion]( [param:Quaternion quaternion] )</h3>
 		<p>
 		Applies a [page:Quaternion] transform to this vector.
 		</p>
@@ -124,12 +124,12 @@ var d = a.distanceTo( b );
 		Returns the angle between this vector and vector [page:Vector3 v] in radians.
 		</p>
 
-		<h3>[method:Vector3 ceil]()</h3>
+		<h3>[method:this ceil]()</h3>
 		<p>
 		The [page:.x x], [page:.y y] and [page:.z z] components of the vector are rounded up to the nearest integer value.
 		</p>
 
-		<h3>[method:Vector3 clamp]( [param:Vector3 min], [param:Vector3 max] )</h3>
+		<h3>[method:this clamp]( [param:Vector3 min], [param:Vector3 max] )</h3>
 		<p>
 		[page:Vector3 min] - the minimum [page:.x x], [page:.y y] and [page:.z z] values.<br />
 		[page:Vector3 max] - the maximum [page:.x x], [page:.y y] and [page:.z z] values in the desired range<br /><br />
@@ -138,7 +138,7 @@ var d = a.distanceTo( b );
 		If this vector's x, y or z value is less than the min vector's x, y or z value, it is replaced by the corresponding value.
 		</p>
 
-		<h3>[method:Vector3 clampLength]( [param:Float min], [param:Float max] )</h3>
+		<h3>[method:this clampLength]( [param:Float min], [param:Float max] )</h3>
 		<p>
 		[page:Float min] - the minimum value the length will be clamped to <br />
 		[page:Float max] - the maximum value the length will be clamped to<br /><br />
@@ -147,7 +147,7 @@ var d = a.distanceTo( b );
 		If this vector's length is less than the min value, it is replaced by the min value.
 		</p>
 
-		<h3>[method:Vector3 clampScalar]( [param:Float min], [param:Float max] )</h3>
+		<h3>[method:this clampScalar]( [param:Float min], [param:Float max] )</h3>
 		<p>
 		[page:Float min] - the minimum value the components will be clamped to <br />
 		[page:Float max] - the maximum value the components will be clamped to<br /><br />
@@ -161,18 +161,18 @@ var d = a.distanceTo( b );
 		Returns a new vector3 with the same [page:.x x], [page:.y y] and [page:.z z] values as this one.
 		</p>
 
-		<h3>[method:Vector3 copy]( [param:Vector3 v] )</h3>
+		<h3>[method:this copy]( [param:Vector3 v] )</h3>
 		<p>
 			Copies the values of the passed vector3's [page:.x x], [page:.y y] and [page:.z z]
 			properties to this vector3.
 		</p>
 
-		<h3>[method:Vector3 cross]( [param:Vector3 v] )</h3>
+		<h3>[method:this cross]( [param:Vector3 v] )</h3>
 		<p>
 		Sets this vector to [link:https://en.wikipedia.org/wiki/Cross_product cross product] of itself and [page:Vector3 v].
 		</p>
 
-		<h3>[method:Vector3 crossVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
+		<h3>[method:this crossVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
 		<p>
 		Sets this vector to [link:https://en.wikipedia.org/wiki/Cross_product cross product] of [page:Vector3 a] and [page:Vector3 b].
 		</p>
@@ -192,10 +192,10 @@ var d = a.distanceTo( b );
 		as it is slightly more efficient to calculate.
 		</p>
 
-		<h3>[method:Vector3 divide]( [param:Vector3 v] )</h3>
+		<h3>[method:this divide]( [param:Vector3 v] )</h3>
 		<p>Divides this vector by [page:Vector3 v].</p>
 
-		<h3>[method:Vector3 divideScalar]( [param:Float s] )</h3>
+		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>
 		Divides this vector by scalar [page:Float s].<br />
 		Sets vector to *( 0, 0, 0 )* if *[page:Float s] = 0*.
@@ -210,10 +210,10 @@ var d = a.distanceTo( b );
 		<h3>[method:Boolean equals]( [param:Vector3 v] )</h3>
 		<p>Checks for strict equality of this vector and [page:Vector3 v].</p>
 
-		<h3>[method:Vector3 floor]()</h3>
+		<h3>[method:this floor]()</h3>
 		<p>The components of the vector are rounded down to the nearest integer value.</p>
 
-		<h3>[method:Vector3 fromArray]( [param:Array array], [param:Integer offset] )</h3>
+		<h3>[method:this fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<p>
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - ( optional) offset into the array. Default is 0.<br /><br />
@@ -222,7 +222,7 @@ var d = a.distanceTo( b );
 		and [page:.z z] value to be array[ offset + 2 ].
 		</p>
 
-		<h3>[method:Vector3 fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
+		<h3>[method:this fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
 		<p>
 		[page:BufferAttribute attribute] - the source attribute.<br />
 		[page:Integer index] - index in the attribute.<br /><br />
@@ -255,7 +255,7 @@ var d = a.distanceTo( b );
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
 		</p>
 
-		<h3>[method:Vector3 lerp]( [param:Vector3 v], [param:Float alpha] )</h3>
+		<h3>[method:this lerp]( [param:Vector3 v], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector3 v] - [page:Vector3] to interpolate towards.<br />
 		alpha - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -264,7 +264,7 @@ var d = a.distanceTo( b );
 		distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector3 v].
 		</p>
 
-		<h3>[method:Vector3 lerpVectors]( [param:Vector3 v1], [param:Vector3 v2], [param:Float alpha] )</h3>
+		<h3>[method:this lerpVectors]( [param:Vector3 v1], [param:Vector3 v2], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector3 v1] - the starting [page:Vector3].<br />
 		[page:Vector3 v2] - [page:Vector3] to interpolate towards.<br />
@@ -275,44 +275,44 @@ var d = a.distanceTo( b );
 		- alpha = 0 will be [page:Vector3 v1], and alpha = 1 will be [page:Vector3 v2].
 		</p>
 
-		<h3>[method:Vector3 max]( [param:Vector3 v] )</h3>
+		<h3>[method:this max]( [param:Vector3 v] )</h3>
 		<p>
 		If this vector's x, y or z value is less than [page:Vector3 v]'s x, y or z value, replace
 		that value with the corresponding max value.
 		</p>
 
-		<h3>[method:Vector3 min]( [param:Vector3 v] )</h3>
+		<h3>[method:this min]( [param:Vector3 v] )</h3>
 		<p>
 		If this vector's x, y or z value is greater than [page:Vector3 v]'s x, y or z value, replace
 		that value with the corresponding min value.
 		</p>
 
-		<h3>[method:Vector3 multiply]( [param:Vector3 v] )</h3>
+		<h3>[method:this multiply]( [param:Vector3 v] )</h3>
 		<p>Multiplies this vector by [page:Vector3 v].</p>
 
-		<h3>[method:Vector3 multiplyScalar]( [param:Float s] )</h3>
+		<h3>[method:this multiplyScalar]( [param:Float s] )</h3>
 		<p>Multiplies this vector by scalar [page:Float s].</p>
 
-		<h3>[method:Vector3 multiplyVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
+		<h3>[method:this multiplyVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
 		<p>Sets this vector equal to [page:Vector3 a] * [page:Vector3 b], component-wise.</p>
 
-		<h3>[method:Vector3 negate]()</h3>
+		<h3>[method:this negate]()</h3>
 		<p>Inverts this vector - i.e. sets x = -x, y = -y and z = -z.</p>
 
-		<h3>[method:Vector3 normalize]()</h3>
+		<h3>[method:this normalize]()</h3>
 		<p>
 		Convert this vector to a [link:https://en.wikipedia.org/wiki/Unit_vector unit vector] - that is, sets it equal to the vector with the same direction
 		as this one, but [page:.length length] 1.
 		</p>
 
-		<h3>[method:Vector3 project]( [param:Camera camera] )</h3>
+		<h3>[method:this project]( [param:Camera camera] )</h3>
 		<p>
 		[page:Camera camera] — camera to use in the projection.<br /><br />
 
 		[link:https://en.wikipedia.org/wiki/Vector_projection Projects] the vector with the camera.
 		</p>
 
-		<h3>[method:Vector3 projectOnPlane]( [param:Vector3 planeNormal] )</h3>
+		<h3>[method:this projectOnPlane]( [param:Vector3 planeNormal] )</h3>
 		<p>
 		[page:Vector3 planeNormal] - A vector representing a plane normal.<br /><br />
 
@@ -320,10 +320,10 @@ var d = a.distanceTo( b );
 		normal from this vector.
 		</p>
 
-		<h3>[method:Vector3 projectOnVector]( [param:Vector3] )</h3>
+		<h3>[method:this projectOnVector]( [param:Vector3] )</h3>
 		<p>[link:https://en.wikipedia.org/wiki/Vector_projection Projects] this vector onto another vector.</p>
 
-		<h3>[method:Vector3 reflect]( [param:Vector3 normal] )</h3>
+		<h3>[method:this reflect]( [param:Vector3 normal] )</h3>
 		<p>
 		[page:Vector3 normal] - the normal to the reflecting plane<br /><br />
 
@@ -331,15 +331,15 @@ var d = a.distanceTo( b );
 		have unit length.
 		</p>
 
-		<h3>[method:Vector3 round]()</h3>
+		<h3>[method:this round]()</h3>
 		<p>The components of the vector are rounded to the nearest integer value.</p>
 
-		<h3>[method:Vector3 roundToZero]()</h3>
+		<h3>[method:this roundToZero]()</h3>
 		<p>
 		The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.
 		</p>
 
-		<h3>[method:Vector3 set]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<h3>[method:this set]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<p>Sets the [page:.x x], [page:.y y] and [page:.z z] components of this vector.</p>
 
 		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
@@ -352,61 +352,61 @@ var d = a.distanceTo( b );
 		If index equals 2 set [page:.z z] to [page:Float value]
 		</p>
 
-		<h3>[method:Vector3 setFromCylindrical]( [param:Cylindrical c] )</h3>
+		<h3>[method:this setFromCylindrical]( [param:Cylindrical c] )</h3>
 		<p>
 		Sets this vector from the cylindrical coordinates [page:Cylindrical c].
 		</p>
 
-		<h3>[method:Vector3 setFromMatrixColumn]( [param:Matrix4 matrix], [param:Integer index] )</h3>
+		<h3>[method:this setFromMatrixColumn]( [param:Matrix4 matrix], [param:Integer index] )</h3>
 		<p>
 		Sets this vector's [page:.x x], [page:.y y] and [page:.z z] equal to the column of
 		the [page:Matrix4 matrix] specified by the [page:Integer index].
 		</p>
 
-		<h3>[method:Vector3 setFromMatrixPosition]( [param:Matrix4 m] )</h3>
+		<h3>[method:this setFromMatrixPosition]( [param:Matrix4 m] )</h3>
 		<p>
 		Sets this vector to the position elements of the
 		[link:https://en.wikipedia.org/wiki/Transformation_matrix transformation matrix] [page:Matrix4 m].
 		</p>
 
-		<h3>[method:Vector3 setFromMatrixScale]( [param:Matrix4 m] )</h3>
+		<h3>[method:this setFromMatrixScale]( [param:Matrix4 m] )</h3>
 		<p>
 		Sets this vector to the scale elements of the
 		[link:https://en.wikipedia.org/wiki/Transformation_matrix transformation matrix] [page:Matrix4 m].
 		</p>
 
-		<h3>[method:Vector3 setFromSpherical]( [param:Spherical s] )</h3>
+		<h3>[method:this setFromSpherical]( [param:Spherical s] )</h3>
 		<p>
 		Sets this vector from the spherical coordinates [page:Spherical s].
 		</p>
 
-		<h3>[method:Vector3 setLength]( [param:Float l] )</h3>
+		<h3>[method:this setLength]( [param:Float l] )</h3>
 		<p>
 		Set this vector to the vector with the same direction as this one, but [page:.length length]
 		[page:Float l].
 		</p>
 
-		<h3>[method:Vector3 setScalar]( [param:Float scalar] )</h3>
+		<h3>[method:this setScalar]( [param:Float scalar] )</h3>
 		<p>
 		Set the [page:.x x], [page:.y y] and [page:.z z] values of this vector both equal to [page:Float scalar].
 		</p>
 
-		<h3>[method:Vector3 setX]( [param:Float x] )</h3>
+		<h3>[method:this setX]( [param:Float x] )</h3>
 		<p>Replace this vector's [page:.x x] value with [page:Float x].</p>
 
-		<h3>[method:Vector3 setY]( [param:Float y] )</h3>
+		<h3>[method:this setY]( [param:Float y] )</h3>
 		<p>Replace this vector's [page:.y y] value with [page:Float y].</p>
 
-		<h3>[method:Vector3 setZ]( [param:Float z] )</h3>
+		<h3>[method:this setZ]( [param:Float z] )</h3>
 		<p>Replace this vector's [page:.z z] value with [page:Float z].</p>
 
-		<h3>[method:Vector3 sub]( [param:Vector3 v] )</h3>
+		<h3>[method:this sub]( [param:Vector3 v] )</h3>
 		<p>Subtracts [page:Vector3 v] from this vector.</p>
 
-		<h3>[method:Vector3 subScalar]( [param:Float s] )</h3>
+		<h3>[method:this subScalar]( [param:Float s] )</h3>
 		<p>Subtracts [page:Float s]  from this vector's [page:.x x], [page:.y y] and [page:.z z] compnents.</p>
 
-		<h3>[method:Vector3 subVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
+		<h3>[method:this subVectors]( [param:Vector3 a], [param:Vector3 b] )</h3>
 		<p>Sets this vector to [page:Vector3 a] - [page:Vector3 b].</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>
@@ -418,13 +418,13 @@ var d = a.distanceTo( b );
 		Returns an array [x, y, z], or copies x, y and z into the provided [page:Array array].
 		</p>
 
-		<h3>[method:Vector3 transformDirection]( [param:Matrix4 m] )</h3>
+		<h3>[method:this transformDirection]( [param:Matrix4 m] )</h3>
 		<p>
 		Transforms the direction of this vector by a matrix (the upper left 3 x 3 subset of a [page:Matrix4 m])
 		and then [page:.normalize normalizes] the result.
 		</p>
 
-		<h3>[method:Vector3 unproject]( [param:Camera camera] )</h3>
+		<h3>[method:this unproject]( [param:Camera camera] )</h3>
 		<p>
 		[page:Camera camera] — camera to use in the projection.<br /><br />
 

--- a/docs/api/math/Vector4.html
+++ b/docs/api/math/Vector4.html
@@ -81,29 +81,29 @@ var d = a.dot( b );
 
 		<h2>Methods</h2>
 
-		<h3>[method:Vector4 add]( [param:Vector4 v] )</h3>
+		<h3>[method:this add]( [param:Vector4 v] )</h3>
 		<p>Adds [page:Vector4 v] to this vector.</p>
 
-		<h3>[method:Vector4 addScalar]( [param:Float s] )</h3>
+		<h3>[method:this addScalar]( [param:Float s] )</h3>
 		<p>Adds the scalar value s to this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values.</p>
 
-		<h3>[method:Vector4 addScaledVector]( [param:Vector4 v], [param:Float s] )</h3>
+		<h3>[method:this addScaledVector]( [param:Vector4 v], [param:Float s] )</h3>
 		<p>Adds the multiple of [page:Vector4 v] and [page:Float s] to this vector.</p>
 
-		<h3>[method:Vector4 addVectors]( [param:Vector4 a], [param:Vector4 b] )</h3>
+		<h3>[method:this addVectors]( [param:Vector4 a], [param:Vector4 b] )</h3>
 		<p>Sets this vector to [page:Vector4 a] + [page:Vector4 b].</p>
 
-		<h3>[method:Vector4 applyMatrix4]( [param:Matrix4 m] )</h3>
+		<h3>[method:this applyMatrix4]( [param:Matrix4 m] )</h3>
 		<p>
 		Multiplies this vector by 4 x 4 [page:Matrix4 m].
 		</p>
 
-		<h3>[method:Vector4 ceil]()</h3>
+		<h3>[method:this ceil]()</h3>
 		<p>
 		The [page:.x x], [page:.y y], [page:.z z] and [page:.w w] components of the vector are rounded up to the nearest integer value.
 		</p>
 
-		<h3>[method:Vector4 clamp]( [param:Vector4 min], [param:Vector4 max] )</h3>
+		<h3>[method:this clamp]( [param:Vector4 min], [param:Vector4 max] )</h3>
 		<p>
 		[page:Vector4 min] - the minimum [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values.<br />
 		[page:Vector4 max] - the maximum [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values in the desired range<br /><br />
@@ -112,7 +112,7 @@ var d = a.dot( b );
 		If this vector's x, y, z or w value is less than the min vector's x, y, z or w value, it is replaced by the corresponding value.
 		</p>
 
-		<h3>[method:Vector4 clampLength]( [param:Float min], [param:Float max] )</h3>
+		<h3>[method:this clampLength]( [param:Float min], [param:Float max] )</h3>
 		<p>
 		[page:Float min] - the minimum value the length will be clamped to <br />
 		[page:Float max] - the maximum value the length will be clamped to<br /><br />
@@ -121,7 +121,7 @@ var d = a.dot( b );
 		If this vector's length is less than the min value, it is replaced by the min value.
 		</p>
 
-		<h3>[method:Vector4 clampScalar]( [param:Float min], [param:Float max] )</h3>
+		<h3>[method:this clampScalar]( [param:Float min], [param:Float max] )</h3>
 		<p>
 		[page:Float min] - the minimum value the components will be clamped to <br />
 		[page:Float max] - the maximum value the components will be clamped to<br /><br />
@@ -135,13 +135,13 @@ var d = a.dot( b );
 		Returns a new Vector4 with the same [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values as this one.
 		</p>
 
-		<h3>[method:Vector4 copy]( [param:Vector4 v] )</h3>
+		<h3>[method:this copy]( [param:Vector4 v] )</h3>
 		<p>
 			Copies the values of the passed Vector4's [page:.x x], [page:.y y], [page:.z z] and [page:.w w]
 			properties to this Vector4.
 		</p>
 
-		<h3>[method:Vector4 divideScalar]( [param:Float s] )</h3>
+		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>
 		Divides this vector by scalar [page:Float s].<br />
 		Sets vector to *( 0, 0, 0, 0 )* if *[page:Float s] = 0*.
@@ -156,10 +156,10 @@ var d = a.dot( b );
 		<h3>[method:Boolean equals]( [param:Vector4 v] )</h3>
 		<p>Checks for strict equality of this vector and [page:Vector4 v].</p>
 
-		<h3>[method:Vector4 floor]()</h3>
+		<h3>[method:this floor]()</h3>
 		<p>The components of the vector are rounded down to the nearest integer value.</p>
 
-		<h3>[method:Vector4 fromArray]( [param:Array array], [param:Integer offset] )</h3>
+		<h3>[method:this fromArray]( [param:Array array], [param:Integer offset] )</h3>
 		<p>
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - (optional) offset into the array. Default is 0.<br /><br />
@@ -168,7 +168,7 @@ var d = a.dot( b );
 		[page:.z z] value to be array[ offset + 2 ] and [page:.w w ] value to be array[ offset + 3 ].
 		</p>
 
-		<h3>[method:Vector4 fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
+		<h3>[method:this fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
 		<p>
 		[page:BufferAttribute attribute] - the source attribute.<br />
 		[page:Integer index] - index in the attribute.<br /><br />
@@ -202,7 +202,7 @@ var d = a.dot( b );
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
 		</p>
 
-		<h3>[method:Vector4 lerp]( [param:Vector4 v], [param:Float alpha] )</h3>
+		<h3>[method:this lerp]( [param:Vector4 v], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector4 v] - [page:Vector4] to interpolate towards.<br />
 		alpha - interpolation factor in the closed interval [0, 1].<br /><br />
@@ -211,7 +211,7 @@ var d = a.dot( b );
 		distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector4 v].
 		</p>
 
-		<h3>[method:Vector4 lerpVectors]( [param:Vector4 v1], [param:Vector4 v2], [param:Float alpha] )</h3>
+		<h3>[method:this lerpVectors]( [param:Vector4 v1], [param:Vector4 v2], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector4 v1] - the starting [page:Vector4].<br />
 		[page:Vector4 v2] - [page:Vector4] to interpolate towards.<br />
@@ -222,42 +222,42 @@ var d = a.dot( b );
 		- alpha = 0 will be [page:Vector4 v1], and alpha = 1 will be [page:Vector4 v2].
 		</p>
 
-		<h3>[method:Vector4 negate]()</h3>
+		<h3>[method:this negate]()</h3>
 		<p>Inverts this vector - i.e. sets x = -x, y = -y, z = -z and w = -w.</p>
 
-		<h3>[method:Vector4 normalize]()</h3>
+		<h3>[method:this normalize]()</h3>
 		<p>
 		Converts this vector to a [link:https://en.wikipedia.org/wiki/Unit_vector unit vector] - that is, sets it equal to the vector with the same direction
 		as this one, but [page:.length length] 1.
 		</p>
 
-		<h3>[method:Vector4 max]( [param:Vector4 v] )</h3>
+		<h3>[method:this max]( [param:Vector4 v] )</h3>
 		<p>
 		If this vector's x, y, z or w value is less than [page:Vector4 v]'s x, y, z or w value, replace
 		that value with the corresponding max value.
 		</p>
 
-		<h3>[method:Vector4 min]( [param:Vector4 v] )</h3>
+		<h3>[method:this min]( [param:Vector4 v] )</h3>
 		<p>
 		If this vector's x, y, z or w value is greater than [page:Vector4 v]'s x, y, z or w value, replace
 		that value with the corresponding min value.
 		</p>
 
-		<h3>[method:Vector4 multiplyScalar]( [param:Float s] )</h3>
+		<h3>[method:this multiplyScalar]( [param:Float s] )</h3>
 		<p>Multiplies this vector by scalar [page:Float s].</p>
 
-		<h3>[method:Vector4 round]()</h3>
+		<h3>[method:this round]()</h3>
 		<p>The components of the vector are rounded to the nearest integer value.</p>
 
-		<h3>[method:Vector4 roundToZero]()</h3>
+		<h3>[method:this roundToZero]()</h3>
 		<p>
 		The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.
 		</p>
 
-		<h3>[method:Vector4 set]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
+		<h3>[method:this set]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
 		<p>Sets the [page:.x x], [page:.y y], [page:.z z] and [page:.w w] components of this vector.</p>
 
-		<h3>[method:Vector4 setAxisAngleFromQuaternion]( [param:Quaterion q] )</h3>
+		<h3>[method:this setAxisAngleFromQuaternion]( [param:Quaterion q] )</h3>
 		<p>
 			[page:Quaterion q] - a normalized [page:Quaterion]<br /><br />
 
@@ -265,7 +265,7 @@ var d = a.dot( b );
 			quaternion's axis and [page:.w w] to the angle.
 		</p>
 
-		<h3>[method:Vector4 setAxisAngleFromRotationMatrix]( [param:Matrix4 m] )</h3>
+		<h3>[method:this setAxisAngleFromRotationMatrix]( [param:Matrix4 m] )</h3>
 		<p>
 			 [page:Matrix4 m] - a [page:Matrix4] of which the upper left 3x3 matrix is a pure rotation matrix.<br /><br />
 
@@ -284,36 +284,36 @@ var d = a.dot( b );
 		</p>
 
 
-		<h3>[method:Vector4 setLength]( [param:Float l] )</h3>
+		<h3>[method:this setLength]( [param:Float l] )</h3>
 		<p>
 		Sets this vector to the vector with the same direction as this one, but [page:.length length]
 		[page:Float l].
 		</p>
 
-		<h3>[method:Vector4 setScalar]( [param:Float scalar] )</h3>
+		<h3>[method:this setScalar]( [param:Float scalar] )</h3>
 		<p>
 		Sets the [page:.x x], [page:.y y], [page:.z z] and [page:.w w] values of this vector both equal to [page:Float scalar].
 		</p>
 
-		<h3>[method:Vector4 setX]( [param:Float x] )</h3>
+		<h3>[method:this setX]( [param:Float x] )</h3>
 		<p>Replaces this vector's [page:.x x] value with [page:Float x].</p>
 
-		<h3>[method:Vector4 setY]( [param:Float y] )</h3>
+		<h3>[method:this setY]( [param:Float y] )</h3>
 		<p>Replaces this vector's [page:.y y] value with [page:Float y].</p>
 
-		<h3>[method:Vector4 setZ]( [param:Float z] )</h3>
+		<h3>[method:this setZ]( [param:Float z] )</h3>
 		<p>Replaces this vector's [page:.z z] value with [page:Float z].</p>
 
-		<h3>[method:Vector4 setW]( [param:Float w] )</h3>
+		<h3>[method:this setW]( [param:Float w] )</h3>
 		<p>Replaces this vector's [page:.w w] value with [page:Float w].</p>
 
-		<h3>[method:Vector4 sub]( [param:Vector4 v] )</h3>
+		<h3>[method:this sub]( [param:Vector4 v] )</h3>
 		<p>Subtracts [page:Vector4 v] from this vector.</p>
 
-		<h3>[method:Vector4 subScalar]( [param:Float s] )</h3>
+		<h3>[method:this subScalar]( [param:Float s] )</h3>
 		<p>Subtracts [page:Float s]  from this vector's [page:.x x], [page:.y y], [page:.z z] and [page:.w w] compnents.</p>
 
-		<h3>[method:Vector4 subVectors]( [param:Vector4 a], [param:Vector4 b] )</h3>
+		<h3>[method:this subVectors]( [param:Vector4 a], [param:Vector4 b] )</h3>
 		<p>Sets this vector to [page:Vector4 a] - [page:Vector4 b].</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>

--- a/docs/page.js
+++ b/docs/page.js
@@ -70,7 +70,7 @@ function onDocumentLoad( event ) {
 	text = text.replace( /\[example:([\w\_]+)\]/gi, "[example:$1 $1]" ); // [example:name] to [example:name title]
 	text = text.replace( /\[example:([\w\_]+) ([\w\:\/\.\-\_ \s]+)\]/gi, "<a href=\"../examples/#$1\"  target=\"_blank\">$2</a>" ); // [example:name title]
 
-	text = text.replace( /<a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">(null|Boolean|Object|Array|Number|String|Integer|Float|TypedArray|ArrayBuffer)<\/a>/gi, '<span class="param">$1</span>' ); // remove links to primitive types
+	text = text.replace( /<a class="param" onclick="window.parent.setUrlFragment\('\w+'\)">(null|this|Boolean|Object|Array|Number|String|Integer|Float|TypedArray|ArrayBuffer)<\/a>/gi, '<span class="param">$1</span>' ); // remove links to primitive types
 
 	document.body.innerHTML = text;
 


### PR DESCRIPTION
Not planning to do a complete pass on all docs for this change, but this gets things started and we can update other docs incrementally.

Demo: https://cdn.rawgit.com/donmccurdy/three.js/feat-docs-chainable-style/docs/#api/math/Vector3.add