### PR TITLE
Add scaling factor for webvr renderers

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -64,8 +64,8 @@ function WebVRManager( renderer ) {
 		if ( isPresenting() ) {
 
 			var eyeParameters = device.getEyeParameters( 'left' );
-			var renderWidth = eyeParameters.renderWidth;
-			var renderHeight = eyeParameters.renderHeight;
+			var renderWidth = eyeParameters.renderWidth * scope.framebufferScaleFactor;
+			var renderHeight = eyeParameters.renderHeight * scope.framebufferScaleFactor;
 
 			currentPixelRatio = renderer.getPixelRatio();
 			currentSize = renderer.getSize();
@@ -193,6 +193,7 @@ function WebVRManager( renderer ) {
 		return controller;
 
 	};
+	this.framebufferScaleFactor = 1.0;
 
 	this.getDevice = function () {
 

--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -46,6 +46,7 @@ function WebXRManager( renderer ) {
 	//
 
 	this.enabled = false;
+	this.framebufferScaleFactor = 1.0;
 
 	this.getController = function ( id ) {
 
@@ -111,7 +112,7 @@ function WebXRManager( renderer ) {
 			session.addEventListener( 'selectend', onSessionEvent );
 			session.addEventListener( 'end', onSessionEnd );
 
-			session.baseLayer = new XRWebGLLayer( session, gl );
+			session.baseLayer = new XRWebGLLayer( session, gl, { framebufferScaleFactor: this.framebufferScaleFactor } );
 			session.requestFrameOfReference( frameOfReferenceType ).then( function ( value ) {
 
 				frameOfReference = value;


### PR DESCRIPTION
The problem is some browser send smaller width/heights then resolution (Such as Oculus Browser), causing image to not be as crisp as possible.

This is a fix for #14113