### PR TITLE
ParametricGeometry: Fix examples

### DIFF
--- a/examples/js/Cloth.js
+++ b/examples/js/Cloth.js
@@ -46,15 +46,13 @@ var lastTime;
 
 function plane( width, height ) {
 
-	return function ( u, v, optionalTarget ) {
-
-		var result = optionalTarget || new THREE.Vector3();
+	return function ( u, v, target ) {
 
 		var x = ( u - 0.5 ) * width;
 		var y = ( v + 0.5 ) * height;
 		var z = 0;
 
-		return result.set( x, y, z );
+		return target.set( x, y, z );
 
 	};
 
@@ -62,20 +60,26 @@ function plane( width, height ) {
 
 function Particle( x, y, z, mass ) {
 
-	this.position = clothFunction( x, y ); // position
-	this.previous = clothFunction( x, y ); // previous
-	this.original = clothFunction( x, y );
+	this.position = new THREE.Vector3();
+	this.previous = new THREE.Vector3();
+	this.original = new THREE.Vector3();
 	this.a = new THREE.Vector3( 0, 0, 0 ); // acceleration
 	this.mass = mass;
 	this.invMass = 1 / mass;
 	this.tmp = new THREE.Vector3();
 	this.tmp2 = new THREE.Vector3();
 
+	// init
+
+	clothFunction( x, y, this.position ); // position
+	clothFunction( x, y, this.previous ); // previous
+	clothFunction( x, y, this.original );
+
 }
 
 // Force -> Acceleration
 
-Particle.prototype.addForce = function( force ) {
+Particle.prototype.addForce = function ( force ) {
 
 	this.a.add(
 		this.tmp2.copy( force ).multiplyScalar( this.invMass )
@@ -86,7 +90,7 @@ Particle.prototype.addForce = function( force ) {
 
 // Performs Verlet integration
 
-Particle.prototype.integrate = function( timesq ) {
+Particle.prototype.integrate = function ( timesq ) {
 
 	var newPos = this.tmp.subVectors( this.position, this.previous );
 	newPos.multiplyScalar( DRAG ).add( this.position );
@@ -280,7 +284,7 @@ function simulate( time ) {
 
 	// Ball Constraints
 
-	ballPosition.z = - Math.sin( Date.now() / 600 ) * 90 ; //+ 40;
+	ballPosition.z = - Math.sin( Date.now() / 600 ) * 90; //+ 40;
 	ballPosition.x = Math.cos( Date.now() / 400 ) * 70;
 
 	if ( sphere.visible ) {

--- a/examples/js/Cloth.js
+++ b/examples/js/Cloth.js
@@ -52,7 +52,7 @@ function plane( width, height ) {
 		var y = ( v + 0.5 ) * height;
 		var z = 0;
 
-		return target.set( x, y, z );
+		target.set( x, y, z );
 
 	};
 

--- a/examples/js/ParametricGeometries.js
+++ b/examples/js/ParametricGeometries.js
@@ -28,7 +28,7 @@ THREE.ParametricGeometries = {
 
 		y = - 2 * ( 1 - Math.cos( u ) / 2 ) * Math.sin( v );
 
-		return target.set( x, y, z );
+		target.set( x, y, z );
 
 	},
 
@@ -40,7 +40,7 @@ THREE.ParametricGeometries = {
 			var y = 0;
 			var z = v * height;
 
-			return target.set( x, y, z );
+			target.set( x, y, z );
 
 		};
 
@@ -61,7 +61,7 @@ THREE.ParametricGeometries = {
 		y = Math.sin( v ) * ( a + u * Math.cos( v / 2 ) );
 		z = u * Math.sin( v / 2 );
 
-		return target.set( x, y, z );
+		target.set( x, y, z );
 
 	},
 
@@ -83,7 +83,7 @@ THREE.ParametricGeometries = {
 		y = ( major + x ) * Math.sin( u );
 		x = ( major + x ) * Math.cos( u );
 
-		return target.set( x, y, z );
+		target.set( x, y, z );
 
 	}
 
@@ -146,7 +146,7 @@ THREE.ParametricGeometries.TubeGeometry = function ( path, segments, radius, seg
 		pos.y += cx * normal.y + cy * binormal.y;
 		pos.z += cx * normal.z + cy * binormal.z;
 
-		return target.copy( pos );
+		target.copy( pos );
 
 	};
 
@@ -225,7 +225,7 @@ THREE.ParametricGeometries.SphereGeometry = function ( size, u, v ) {
 		var y = size * Math.sin( u ) * Math.sin( v );
 		var z = size * Math.cos( u );
 
-		return target.set( x, y, z );
+		target.set( x, y, z );
 
 	}
 
@@ -251,7 +251,7 @@ THREE.ParametricGeometries.PlaneGeometry = function ( width, depth, segmentsWidt
 		var y = 0;
 		var z = v * depth;
 
-		return target.set( x, y, z );
+		target.set( x, y, z );
 
 	}
 

--- a/examples/js/curves/NURBSSurface.js
+++ b/examples/js/curves/NURBSSurface.js
@@ -47,7 +47,7 @@ THREE.NURBSSurface.prototype = {
 		var u = this.knots1[ 0 ] + t1 * ( this.knots1[ this.knots1.length - 1 ] - this.knots1[ 0 ] ); // linear mapping t1->u
 		var v = this.knots2[ 0 ] + t2 * ( this.knots2[ this.knots2.length - 1 ] - this.knots2[ 0 ] ); // linear mapping t2->u
 
-		return THREE.NURBSUtils.calcSurfacePoint( this.degree1, this.degree2, this.knots1, this.knots2, this.controlPoints, u, v, target );
+		THREE.NURBSUtils.calcSurfacePoint( this.degree1, this.degree2, this.knots1, this.knots2, this.controlPoints, u, v, target );
 
 	}
 };

--- a/examples/js/curves/NURBSSurface.js
+++ b/examples/js/curves/NURBSSurface.js
@@ -42,14 +42,12 @@ THREE.NURBSSurface.prototype = {
 
 	constructor: THREE.NURBSSurface,
 
-	getPoint: function ( t1, t2 ) {
+	getPoint: function ( t1, t2, target ) {
 
 		var u = this.knots1[ 0 ] + t1 * ( this.knots1[ this.knots1.length - 1 ] - this.knots1[ 0 ] ); // linear mapping t1->u
 		var v = this.knots2[ 0 ] + t2 * ( this.knots2[ this.knots2.length - 1 ] - this.knots2[ 0 ] ); // linear mapping t2->u
 
-		return THREE.NURBSUtils.calcSurfacePoint( this.degree1, this.degree2, this.knots1, this.knots2, this.controlPoints, u, v );
+		return THREE.NURBSUtils.calcSurfacePoint( this.degree1, this.degree2, this.knots1, this.knots2, this.controlPoints, u, v, target );
 
 	}
 };
-
-

--- a/examples/js/curves/NURBSUtils.js
+++ b/examples/js/curves/NURBSUtils.js
@@ -19,7 +19,7 @@ THREE.NURBSUtils = {
 	p : degree
 	u : parametric value
 	U : knot vector
-	
+
 	returns the span
 	*/
 	findSpan: function( p,  u,  U ) {
@@ -43,7 +43,7 @@ THREE.NURBSUtils = {
 		var mid = Math.floor( ( low + high ) / 2 );
 
 		while ( u < U[ mid ] || u >= U[ mid + 1 ] ) {
-		  
+
 			if ( u < U[ mid ] ) {
 
 				high = mid;
@@ -61,16 +61,16 @@ THREE.NURBSUtils = {
 		return mid;
 
 	},
-    
-		
+
+
 	/*
 	Calculate basis functions. See The NURBS Book, page 70, algorithm A2.2
-   
+
 	span : span in which u lies
 	u    : parametric point
 	p    : degree
 	U    : knot vector
-	
+
 	returns array[p+1] with basis functions values.
 	*/
 	calcBasisFunctions: function( span, u, p, U ) {
@@ -81,7 +81,7 @@ THREE.NURBSUtils = {
 		N[ 0 ] = 1.0;
 
 		for ( var j = 1; j <= p; ++ j ) {
-	   
+
 			left[ j ] = u - U[ span + 1 - j ];
 			right[ j ] = U[ span + j ] - u;
 
@@ -108,7 +108,7 @@ THREE.NURBSUtils = {
 
 	/*
 	Calculate B-Spline curve points. See The NURBS Book, page 82, algorithm A3.1.
- 
+
 	p : degree of B-Spline
 	U : knot vector
 	P : control points (x, y, z, w)
@@ -422,7 +422,7 @@ THREE.NURBSUtils = {
 
 	/*
 	Calculate rational B-Spline surface point. See The NURBS Book, page 134, algorithm A4.3.
- 
+
 	p1, p2 : degrees of B-Spline surface
 	U1, U2 : knot vectors
 	P      : control points (x, y, z, w)
@@ -430,7 +430,7 @@ THREE.NURBSUtils = {
 
 	returns point for given (u, v)
 	*/
-	calcSurfacePoint: function( p, q, U, V, P, u, v ) {
+	calcSurfacePoint: function ( p, q, U, V, P, u, v, target ) {
 
 		var uspan = this.findSpan( p, u, U );
 		var vspan = this.findSpan( q, v, V );
@@ -462,11 +462,8 @@ THREE.NURBSUtils = {
 		}
 
 		Sw.divideScalar( Sw.w );
-		return new THREE.Vector3( Sw.x, Sw.y, Sw.z );
+		return target.set( Sw.x, Sw.y, Sw.z );
 
 	}
 
 };
-
-
-

--- a/examples/js/curves/NURBSUtils.js
+++ b/examples/js/curves/NURBSUtils.js
@@ -462,7 +462,7 @@ THREE.NURBSUtils = {
 		}
 
 		Sw.divideScalar( Sw.w );
-		return target.set( Sw.x, Sw.y, Sw.z );
+		target.set( Sw.x, Sw.y, Sw.z );
 
 	}
 

--- a/examples/webgl_geometry_nurbs.html
+++ b/examples/webgl_geometry_nurbs.html
@@ -68,7 +68,7 @@
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xf0f0f0 );
-				
+
 				scene.add( new THREE.AmbientLight( 0x808080 ) );
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
@@ -159,9 +159,9 @@
 				map.wrapS = map.wrapT = THREE.RepeatWrapping;
 				map.anisotropy = 16;
 
-				function getSurfacePoint( u, v ) {
+				function getSurfacePoint( u, v, target ) {
 
-					return nurbsSurface.getPoint( u, v );
+					return nurbsSurface.getPoint( u, v, target );
 
 				}
 


### PR DESCRIPTION
Cleans up `Cloth.js` and also fixes the broken `webgl_geometry_nurbs` example :raised_hands:.

see https://github.com/mrdoob/three.js/pull/14085#issuecomment-391067687