### PR TITLE
Clean up BufferGeometryUtils

### DIFF
--- a/examples/js/BufferGeometryUtils.js
+++ b/examples/js/BufferGeometryUtils.js
@@ -236,13 +236,8 @@ THREE.BufferGeometryUtils = {
 
 			// gather .userData
 
-			if ( geometry.userData !== undefined ) {
-
-				mergedGeometry.userData = mergedGeometry.userData || {};
-				mergedGeometry.userData.mergedUserData = mergedGeometry.userData.mergedUserData || [];
-				mergedGeometry.userData.mergedUserData.push( geometry.userData );
-
-			}
+			mergedGeometry.userData.mergedUserData = mergedGeometry.userData.mergedUserData || [];
+			mergedGeometry.userData.mergedUserData.push( geometry.userData );
 
 			if ( useGroups ) {
 


### PR DESCRIPTION
Now `BufferGoemtry` has `.userData` as default so we don't need to check if it has.