### PR TITLE
add params for cubemap params (to support mobile)

### DIFF
--- a/examples/js/loaders/EquiangularToCubeGenerator.js
+++ b/examples/js/loaders/EquiangularToCubeGenerator.js
@@ -2,7 +2,7 @@
 * @author Richard M. / https://github.com/richardmonette
 */
 
-THREE.EquiangularToCubeGenerator = function ( sourceTexture, resolution ) {
+THREE.EquiangularToCubeGenerator = function ( sourceTexture, resolution, type, format ) {
 
 	this.sourceTexture = sourceTexture;
 	this.resolution = resolution;
@@ -23,10 +23,10 @@ THREE.EquiangularToCubeGenerator = function ( sourceTexture, resolution ) {
 	this.scene.add( this.boxMesh );
 
 	var params = {
-		format: THREE.RGBAFormat,
+		format: format ? format : this.sourceTexture.format,
 		magFilter: this.sourceTexture.magFilter,
 		minFilter: this.sourceTexture.minFilter,
-		type: this.sourceTexture.type,
+		type: type ? type : this.sourceTexture.type,
 		generateMipmaps: this.sourceTexture.generateMipmaps,
 		anisotropy: this.sourceTexture.anisotropy,
 		encoding: this.sourceTexture.encoding

--- a/examples/js/loaders/EquiangularToCubeGenerator.js
+++ b/examples/js/loaders/EquiangularToCubeGenerator.js
@@ -2,10 +2,10 @@
 * @author Richard M. / https://github.com/richardmonette
 */
 
-THREE.EquiangularToCubeGenerator = function ( sourceTexture, resolution, type, format ) {
+THREE.EquiangularToCubeGenerator = function ( sourceTexture, options ) {
 
 	this.sourceTexture = sourceTexture;
-	this.resolution = resolution;
+	this.resolution = options.resolution || 512;
 
  	this.views = [
 		{ t: [ 1, 0, 0 ], u: [ 0, - 1, 0 ] },
@@ -23,10 +23,10 @@ THREE.EquiangularToCubeGenerator = function ( sourceTexture, resolution, type, f
 	this.scene.add( this.boxMesh );
 
 	var params = {
-		format: format ? format : this.sourceTexture.format,
+		format: options.format || this.sourceTexture.format,
 		magFilter: this.sourceTexture.magFilter,
 		minFilter: this.sourceTexture.minFilter,
-		type: type ? type : this.sourceTexture.type,
+		type: options.type || this.sourceTexture.type,
 		generateMipmaps: this.sourceTexture.generateMipmaps,
 		anisotropy: this.sourceTexture.anisotropy,
 		encoding: this.sourceTexture.encoding

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -106,7 +106,7 @@
 					texture.magFilter = THREE.NearestFilter;
 					texture.encoding = THREE.LinearEncoding;
 
-					var cubemapGenerator = new THREE.EquiangularToCubeGenerator( texture, 512, THREE.HalfFloatType );
+					var cubemapGenerator = new THREE.EquiangularToCubeGenerator( texture, { resolution: 512, type: THREE.HalfFloatType } );
 					var cubeMapTexture = cubemapGenerator.update( renderer );
 
 					var pmremGenerator = new THREE.PMREMGenerator( cubeMapTexture );

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -106,7 +106,7 @@
 					texture.magFilter = THREE.NearestFilter;
 					texture.encoding = THREE.LinearEncoding;
 
-					var cubemapGenerator = new THREE.EquiangularToCubeGenerator( texture, 512 );
+					var cubemapGenerator = new THREE.EquiangularToCubeGenerator( texture, 512, THREE.HalfFloatType );
 					var cubeMapTexture = cubemapGenerator.update( renderer );
 
 					var pmremGenerator = new THREE.PMREMGenerator( cubeMapTexture );


### PR DESCRIPTION
![img_0186 copy](https://user-images.githubusercontent.com/1041278/40495465-42514494-5f45-11e8-9375-07c841149271.jpg)

- Fixes a weird thing where the `EquiangularToCubeGenerator` had the format hard coded (it's now read from the source by default).

- Adds overrides for the type and format, specifically this makes it possible to tweak the `webgl_materials_envmaps_exr` example to work on mobile webGL (where only half precision texture is supported) Before the textures showed up as blank/black, see screenshot above for it now working nicely.

@WestLangley 

