### PR TITLE
Docs: added Useful Link

### DIFF
--- a/docs/manual/introduction/Useful-links.html
+++ b/docs/manual/introduction/Useful-links.html
@@ -126,6 +126,13 @@
 			[link:http://idflood.github.io/ThreeNodes.js/ ThreeNodes.js].
 		</li>
 	 </ul>
+		
+	<h2>WebGL References</h2>
+	 <ul>
+		 <li>
+			[link:https://www.khronos.org/files/webgl/webgl-reference-card-1_0.pdf] - Reference of all WebGL and GLSL keywords, terminology, syntex and definations.
+		 </li>
+	 </ul>
 
 	 <h2>Old Links</h2>
 	 <p>


### PR DESCRIPTION
A missing piece in useful link section. It's greatly helpful when creating a custom shader.
Issue #14118