### PR TITLE
add a quick implementation of depth-of-field effect for post-processing, with depth blur range 

### DIFF
--- a/examples/js/postprocessing/DepthRangeDofPass.js
+++ b/examples/js/postprocessing/DepthRangeDofPass.js
@@ -1,0 +1,147 @@
+THREE.DepthRangeDofPass = function (scene, camera, params) {
+  THREE.Pass.call(this);
+  //params setting
+  var DEFAULTS_OPTIONS = {
+    resolution:{
+      width:1920,
+      height:1080
+    },
+    blurRatio: 0.7,
+    nearFocusDist: 100,
+    farFocusDist: 200
+  }
+
+  var resolution = params.resolution || DEFAULTS_OPTIONS.resolution;
+  var blurRatio = params.blurRatio || DEFAULTS_OPTIONS.blurRatio;
+  var nearFocusDist = params.nearFocusDist || DEFAULTS_OPTIONS.nearFocusDist;
+  var farFocusDist = params.farFocusDist || DEFAULTS_OPTIONS.farFocusDist;
+
+  this.nearFocusDist = nearFocusDist;
+  this.farFocusDist = farFocusDist;
+
+  var fboParams = {
+    minFilter: THREE.LinearFilter,
+    magFilter: THREE.LinearFilter,
+    format: THREE.RGBAFormat
+  };
+
+  var fboParamsForDepth = {
+    minFilter: THREE.LinearFilter,
+    magFilter: THREE.LinearFilter,
+    format: THREE.RGBAFormat,
+    type: THREE.FloatType
+  };
+
+  //system camera and scene
+  this.scene = scene;
+  this.camera = camera;
+
+  //pps camera and scene
+  this.scene2 = new THREE.Scene();
+  this.camera2 = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+  //render targets
+  this.normalTarget = new THREE.WebGLRenderTarget(resolution.width, resolution.height, fboParams);
+
+  this.xblurTarget = new THREE.WebGLRenderTarget(resolution.width, resolution.height, fboParams);
+  this.yblurTarget = new THREE.WebGLRenderTarget(resolution.width, resolution.height, fboParams);
+
+  this.depthTarget = new THREE.WebGLRenderTarget(resolution.width, resolution.height, fboParamsForDepth);
+  this.depthTarget.texture.generateMipmaps = false;
+  this.depthTarget.stencilBuffer = false;
+
+  //blur materials
+  //horizontal
+  this.hBlurMaterial = new THREE.ShaderMaterial({
+    uniforms: THREE.HorizontalBlurShader.uniforms,
+    vertexShader: THREE.HorizontalBlurShader.vertexShader,
+    fragmentShader: THREE.HorizontalBlurShader.fragmentShader
+  });
+  // this.hBlurMaterial.uniforms.tDiffuse.value = this.normalTarget.texture;
+  this.hBlurMaterial.uniforms.tDiffuse.value = null;
+  this.hBlurMaterial.uniforms.h.value = 1.0 / (resolution.width * blurRatio);
+  //vertical
+  this.vBlurMaterial = new THREE.ShaderMaterial({
+    uniforms: THREE.VerticalBlurShader.uniforms,
+    vertexShader: THREE.VerticalBlurShader.vertexShader,
+    fragmentShader: THREE.VerticalBlurShader.fragmentShader
+  });
+  this.vBlurMaterial.uniforms.tDiffuse.value = this.xblurTarget.texture;
+  this.vBlurMaterial.uniforms.v.value = 1.0 / (resolution.height * blurRatio);
+
+  //depth material
+  this.depthMaterial = new THREE.ShaderMaterial({
+    uniforms: {},
+    vertexShader: THREE.DepthDetectShader.vertexShader,
+    fragmentShader: THREE.DepthDetectShader.fragmentShader
+  });
+
+  //dof materials
+  this.dofMaterial = new THREE.ShaderMaterial({
+    uniforms: {
+      nearZ: { value: null},
+      farZ: { value: null},
+      focusRange: { value: 0 },
+      blurTex: { value: this.yblurTarget.texture },
+      // normalTex: { value: this.normalTarget.texture },
+      normalTex: { value: null },
+      depthTex: { value: this.depthTarget.texture }
+    },
+    vertexShader: THREE.DepthRangeDofShader.vertexShader,
+    fragmentShader: THREE.DepthRangeDofShader.fragmentShader
+  });
+
+  //pps screen quad
+  this.quad2 = new THREE.Mesh(new THREE.PlaneBufferGeometry(2, 2, 64, 64), null);
+  this.quad2.frustumCulled = false;
+  this.scene2.add(this.quad2);
+}
+
+THREE.DepthRangeDofPass.prototype = Object.assign(Object.create(THREE.Pass.prototype), {
+  constructor: THREE.DepthRangeDofPass,
+
+  render: function (renderer, writeBuffer, readBuffer, delta, maskActive) {
+    //render depth target to detect the pixels for blur
+    this.scene.overrideMaterial = this.depthMaterial;
+    renderer.render(this.scene, this.camera, this.depthTarget);
+    this.scene.overrideMaterial = null;
+    // //normal scene, for mix into blur
+    // this.scene.overrideMaterial = null;
+    // renderer.render(this.scene, this.camera, this.normalTarget);
+
+    //out put blur pps screen quad into fbo
+    this.quad2.material = this.hBlurMaterial;
+    renderer.render(this.scene2, this.camera2, this.xblurTarget);
+    //out put blur pps screen quad into fbo
+    this.quad2.material = this.vBlurMaterial;
+    renderer.render(this.scene2, this.camera2, this.yblurTarget);
+
+    // //update focus
+    this.updateFocusZ();
+    //render pps screen
+    this.hBlurMaterial.uniforms.tDiffuse.value = readBuffer.texture;
+    this.dofMaterial.uniforms.normalTex.value = readBuffer.texture;
+
+    this.quad2.material = this.dofMaterial;
+    if (this.renderToScreen) {
+      renderer.render(this.scene2, this.camera2);
+    } else {
+      renderer.render(this.scene2, this.camera2, writeBuffer, this.clear);
+    }
+  }
+});
+
+THREE.DepthRangeDofPass.prototype.updateFocusZ = function() {
+  var camWorldDir = new THREE.Vector3();
+  var camWorldDirVec3 = this.camera.getWorldDirection(camWorldDir);
+  var viewDir = camWorldDir.normalize();
+  
+  var nearFocus = this.camera.position.clone().add(viewDir.clone().multiplyScalar(this.nearFocusDist));
+  var farFocus = this.camera.position.clone().add(viewDir.clone().multiplyScalar(this.farFocusDist));
+
+  var nearZ = (nearFocus.project(this.camera).z + 1.0) * 0.5;
+  var farZ = (farFocus.project(this.camera).z + 1.0) * 0.5;
+
+  this.dofMaterial.uniforms.nearZ.value = nearZ;
+  this.dofMaterial.uniforms.farZ.value = farZ;
+}

--- a/examples/js/shaders/DepthDetectShader.js
+++ b/examples/js/shaders/DepthDetectShader.js
@@ -1,0 +1,19 @@
+/**
+ * @author guowei https://guoweish.github.io/
+ *
+ * Depth-of-field according to camera view range shader
+ */
+
+THREE.DepthDetectShader = {
+  vertexShader: [
+		"void main() {",
+			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+		"}"
+  ].join( "\n" ),
+
+  fragmentShader: [
+    "void main() {",
+      "gl_FragColor = vec4(gl_FragCoord.z, 0.0, 0.0,1.0);",
+    "}"
+  ].join( "\n" )
+}

--- a/examples/js/shaders/DepthRangeDofShader.js
+++ b/examples/js/shaders/DepthRangeDofShader.js
@@ -1,0 +1,55 @@
+/**
+ * @author guowei https://guoweish.github.io/
+ *
+ * Depth-of-field according to camera view range shader
+ */
+
+THREE.DepthRangeDofShader = {
+  vertexShader: [
+    "varying vec2 vUv;",
+    "void main() {",
+      "vUv = uv;",
+			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+		"}"
+  ].join( "\n" ),
+
+  fragmentShader: [
+    "varying vec2 vUv;",
+    "uniform float nearZ;",
+    "uniform float farZ;",
+    "uniform float focusRange;",
+    "uniform sampler2D blurTex;",
+    "uniform sampler2D depthTex;",
+    "uniform sampler2D normalTex;",
+    
+    "float calculateBlurRatio(float depth, float nearZ, float farZ) {",
+      "float ratio = 1.0;",
+      "float focusRange = (farZ - nearZ) / 5.0;",
+  
+      "if(depth <= nearZ) {",
+        "if(depth > (nearZ - focusRange)) {",
+          "ratio = (nearZ - depth) / focusRange;",
+        "}",
+      "}",
+  
+      "if(depth >= farZ) {",
+        "if(depth < (farZ + focusRange)) {",
+          "ratio = (depth - farZ) / focusRange;",
+        "}",
+      "}",
+  
+      "return ratio;",
+    "}",
+    
+    "void main() {",
+      "float depth = texture2D(depthTex,vUv).r;",
+      "vec4 normalColor = texture2D(normalTex,vUv);",
+      "vec4 blurColor = texture2D(blurTex,vUv);",
+      "float ratio = 0.0;",
+      "if(depth <= nearZ || depth >= farZ) {",
+        "ratio = calculateBlurRatio(depth, nearZ, farZ);",
+      "}",
+      "gl_FragColor = mix(normalColor,blurColor,ratio);",
+    "}"
+  ].join( "\n" )
+}

--- a/examples/webgl_postprocessing_dof3.html
+++ b/examples/webgl_postprocessing_dof3.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - postprocessing - a quick implementation of depth-of-field effect</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				background-color: #000000;
+				margin: 0px;
+				overflow: hidden;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+				font-weight: bold;
+				text-align:center;
+			}
+
+			a {
+				color:#0078ff;
+			}
+
+			#info {
+				color:#fff;
+				position: relative;
+				top: 0px;
+				width: 100em;
+				margin: 0 auto -2.1em;
+				padding: 5px;
+				z-index:100;
+			}
+		</style>
+	</head>
+	
+	<body>
+		<script src="../build/three.js"></script>
+		
+		<script src="js/shaders/HorizontalBlurShader.js"></script>
+		<script src="js/shaders/VerticalBlurShader.js"></script>
+		<script src="js/shaders/DepthDetectShader.js"></script>
+		<script src="js/shaders/DepthRangeDofShader.js"></script>
+		<script src="js/shaders/CopyShader.js"></script>
+		<script src="js/shaders/SMAAShader.js"></script>
+
+		<script src="js/postprocessing/EffectComposer.js"></script>
+		<script src="js/postprocessing/SMAAPass.js"></script>
+		<script src="js/postprocessing/RenderPass.js"></script>
+		<script src="js/postprocessing/MaskPass.js"></script>
+		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing/DepthRangeDofPass.js"></script>
+
+		<script src="js/controls/OrbitControls.js"></script>
+		<script src="js/Detector.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+		<script src='js/libs/dat.gui.min.js'></script>
+
+		<div id="info">
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - a quick implementation of depth-of-field effect, with depth range blur.</a>
+		</div>
+
+		<script>
+
+			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+			var container = document.createElement( 'div' );
+			document.body.appendChild( container );
+
+			//renderer ---------------
+			var renderer = new THREE.WebGLRenderer({ antialias: false });
+			renderer.setClearColor('rgb(0,0,0)', 0);
+			renderer.setSize(window.innerWidth, window.innerHeight);
+			
+			container.appendChild(renderer.domElement);
+
+			//scene screen ---------------
+			var scene = new THREE.Scene();
+			var camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 10000 );
+
+			camera.position.x = 0;
+			camera.position.y = 30;
+			camera.position.z = 180;
+			
+			//light ---------------
+			var ambientLight = new THREE.AmbientLight( 0x404040 ); // soft white light
+			scene.add( ambientLight );
+
+			var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.9 );
+			directionalLight.position.set( 100, 200, 0 );
+			scene.add( directionalLight );
+
+			var pointLight = new THREE.PointLight( 0xffffff, 0.2 );
+			pointLight.position.set( 0, 0, 0);
+			// console.log(pointLight.position.z);
+			scene.add(pointLight);
+			
+			// //add mesh
+			createMesh(-25, 0, '#33ffff', 20);
+			createMesh(-25, 60, '#33ffff', 20);
+
+			createMesh(0, 0, '#ff33ff', 20);
+			createMesh(0, 60, '#ff33ff', 20);
+
+			createMesh(25, 0, '#ffff33', 20);
+			createMesh(25, 60, '#ffff33', 20);
+			
+			//post processing
+			var renderScene = new THREE.RenderPass(scene, camera);
+
+			var depthRangeDofPass = new THREE.DepthRangeDofPass(scene, camera, {});
+
+			var smaaPass = new THREE.SMAAPass(window.innerWidth, window.innerHeight);
+			smaaPass.renderToScreen = true;
+			
+			var composer = new THREE.EffectComposer(renderer);
+			composer.setSize(window.innerWidth, window.innerHeight);
+			composer.addPass(renderScene);
+			composer.addPass(depthRangeDofPass);
+			composer.addPass(smaaPass);
+			
+			var controls = new THREE.OrbitControls( camera, renderer.domElement );
+			window.addEventListener( 'resize', onWindowResize, false );
+
+			var effectController  = {
+				resolutionWidth: 1920,
+				resolutionHeight: 1080,
+				blurRatio: 0.7,
+				nearFocusDist: 100,
+				farFocusDist: 200
+			};
+
+			var matChanger = function() {
+				// postprocessing.bokeh.uniforms[ "focus" ].value = effectController.focus;
+				depthRangeDofPass.hBlurMaterial.uniforms[ "h" ].value = 1.0 / (effectController.resolutionWidth * effectController.blurRatio);
+				depthRangeDofPass.vBlurMaterial.uniforms[ "v" ].value = 1.0 / (effectController.resolutionHeight * effectController.blurRatio);
+				depthRangeDofPass.nearFocusDist = effectController.nearFocusDist;
+				depthRangeDofPass.farFocusDist = effectController.farFocusDist;
+			};
+
+			var gui = new dat.GUI();
+			gui.add( effectController, "resolutionWidth", 1920, 3840, 1920).step(1920).onChange( matChanger );
+			gui.add( effectController, "resolutionHeight", 1080, 2160, 1080).step(1080).onChange( matChanger );
+			gui.add( effectController, "blurRatio", 0.0, 1.0, 0.7).step(0.1).onChange( matChanger );
+			gui.add( effectController, "nearFocusDist", 0.0, 500, 100).step(1).onChange( matChanger );
+			gui.add( effectController, "farFocusDist", 10.0, 1000, 200).step(1).onChange( matChanger );
+
+			render();
+
+			var zFlag = 1;
+			var zLimit = 100;
+			var zStep = 0.01;
+
+			function render() {
+				composer.render();
+
+				requestAnimationFrame(render);
+			}
+
+			function createMesh(xp, yp, color, ballRowNum) {
+				var sphereGeometry = new THREE.SphereGeometry(5, 16, 12);
+				var blueMaterial = new THREE.MeshStandardMaterial({
+					color: color,
+					flatShading: true,
+					roughness: 0.6,
+					metalness: 0.7
+				});
+				var ballBlue = new THREE.Mesh(sphereGeometry, blueMaterial);
+
+				for (var index = 0; index < ballRowNum; index++) {
+					var zp = (index - ballRowNum/2) * 25;
+
+					var ballCopy = ballBlue.clone();
+					ballCopy.position.set(xp, yp, zp);
+					scene.add(ballCopy);
+				}
+			}
+
+			function onWindowResize() {
+				var width = window.innerWidth;
+				var height = window.innerHeight;
+
+				camera.aspect = width / height;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( width, height );
+
+				var pixelRatio = renderer.getPixelRatio();
+				var newWidth  = Math.floor( width * pixelRatio ) || 1;
+				var newHeight = Math.floor( height * pixelRatio ) || 1;
+				composer.setSize( newWidth, newHeight );
+			}
+
+
+		</script>
+	</body>
+</html>

--- a/examples/webgl_postprocessing_dof3.html
+++ b/examples/webgl_postprocessing_dof3.html
@@ -157,13 +157,13 @@
 
 			function createMesh(xp, yp, color, ballRowNum) {
 				var sphereGeometry = new THREE.SphereGeometry(5, 16, 12);
-				var blueMaterial = new THREE.MeshStandardMaterial({
+				var sphereMaterial = new THREE.MeshStandardMaterial({
 					color: color,
 					flatShading: true,
 					roughness: 0.6,
 					metalness: 0.7
 				});
-				var ballBlue = new THREE.Mesh(sphereGeometry, blueMaterial);
+				var ballBlue = new THREE.Mesh(sphereGeometry, sphereMaterial);
 
 				for (var index = 0; index < ballRowNum; index++) {
 					var zp = (index - ballRowNum/2) * 25;


### PR DESCRIPTION
Hi,

I just implement a DOF effect, with blur the specific depth range of fragment.
It's easy for understand and use.  As it's really hard to handle the params with the Bokeh Dof while the camera moved.
Attached screenshot as flowing.
![dof-threejs](https://user-images.githubusercontent.com/10095269/40555275-1f6457b4-607b-11e8-93fb-ca0790c681a1.png)
