### PR TITLE
MMDLoader: move MMD specific parameters into geometry.userData

### DIFF
--- a/examples/js/animation/CCDIKSolver.js
+++ b/examples/js/animation/CCDIKSolver.js
@@ -203,7 +203,7 @@ THREE.CCDIKSolver = ( function () {
 		 */
 		createHelper: function () {
 
-			return new CCDIKHelper( this.mesh, this.mesh.geometry.iks );
+			return new CCDIKHelper( this.mesh, this.mesh.geometry.userData.MMD.iks );
 
 		},
 

--- a/examples/js/animation/MMDAnimationHelper.js
+++ b/examples/js/animation/MMDAnimationHelper.js
@@ -275,7 +275,7 @@ THREE.MMDAnimationHelper = ( function () {
 		 */
 		createGrantSolver: function ( mesh ) {
 
-			return new GrantSolver( mesh, mesh.geometry.grants );
+			return new GrantSolver( mesh, mesh.geometry.userData.MMD.grants );
 
 		},
 
@@ -581,7 +581,7 @@ THREE.MMDAnimationHelper = ( function () {
 
 		_optimizeIK: function ( mesh, physicsEnabled ) {
 
-			var iks = mesh.geometry.iks;
+			var iks = mesh.geometry.userData.MMD.iks;
 			var bones = mesh.geometry.bones;
 
 			for ( var i = 0, il = iks.length; i < il; i ++ ) {
@@ -619,7 +619,7 @@ THREE.MMDAnimationHelper = ( function () {
 
 			}
 
-			return new THREE.CCDIKSolver( mesh, mesh.geometry.iks );
+			return new THREE.CCDIKSolver( mesh, mesh.geometry.userData.MMD.iks );
 
 		},
 
@@ -632,7 +632,10 @@ THREE.MMDAnimationHelper = ( function () {
 			}
 
 			return new THREE.MMDPhysics(
-				mesh, mesh.geometry.rigidBodies, mesh.geometry.constraints, params );
+				mesh,
+				mesh.geometry.userData.MMD.rigidBodies,
+				mesh.geometry.userData.MMD.constraints,
+				params );
 
 		},
 

--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -841,13 +841,13 @@ THREE.MMDLoader = ( function () {
 			geometry.morphTargets = morphTargets;
 			geometry.morphAttributes.position = morphPositions;
 
-			geometry.iks = iks;
-			geometry.grants = grants;
-
-			geometry.rigidBodies = rigidBodies;
-			geometry.constraints = constraints;
-
-			geometry.mmdFormat = data.metadata.format;
+			geometry.userData.MMD = {
+				iks: iks,
+				grants: grants,
+				rigidBodies: rigidBodies,
+				constraints: constraints,
+				format: data.metadata.format
+			};
 
 			geometry.computeBoundingSphere();
 


### PR DESCRIPTION
This PR moves MMD specific parameters into `BufferGeometry.userData`.

Less polluting `BufferGeometry`, and MMD specific parameters can be [de]serialized now.