### PR TITLE
Add PLY Exporter Documentation Page

### DIFF
--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -25,7 +25,7 @@
 
 		<code>
 		// Instantiate a exporter
-		var exporter = new THREE.GLTFExporter( defaultOptions );
+		var exporter = new THREE.GLTFExporter();
 
 		// Parse the input and generate the glTF output
 		exporter.parse( scene, function ( gltf ) {

--- a/docs/examples/exporters/PLYExporter.html
+++ b/docs/examples/exporters/PLYExporter.html
@@ -13,7 +13,7 @@
 		<p class="desc">
 		An exporter for *PLY*.
 		<br /><br />
-		<a href="https://www.khronos.org/gltf">PLY</a> (Polygon or Stanford Triangle Format) is
+		<a href="https://www.khronos.org/gltf">PLY</a> (Polygon or Stanford Triangle Format) is a
 		file format for efficient delivery and loading of simple, static 3D content in a dense format.
 		Both binary and ascii formats are supported. PLY can store vertex positions, colors, normals and
 		uv coordinates. No textures or texture references are saved.
@@ -46,7 +46,7 @@
 		[page:Object input] — Object3D<br />
 		[page:Options options] — Export options<br />
 		<ul>
-			<li>excludeAttributes - array. Which properties to explicitly exclude from the exported PLY file. Valid values are 'color', 'normal', 'uv', and 'index'. If indices are excluded, then a point cloud is exported. Default is an empty array.</li>
+			<li>excludeAttributes - array. Which properties to explicitly exclude from the exported PLY file. Valid values are 'color', 'normal', 'uv', and 'index'. If triangle indices are excluded, then a point cloud is exported. Default is an empty array.</li>
 			<li>binary - bool. Export in binary format, returning an ArrayBuffer. Default is false.</li>
 		</ul>
 		</p>

--- a/docs/examples/exporters/PLYExporter.html
+++ b/docs/examples/exporters/PLYExporter.html
@@ -13,26 +13,22 @@
 		<p class="desc">
 		An exporter for *PLY*.
 		<br /><br />
-		<a href="https://www.khronos.org/gltf">glTF</a> (GL Transmission Format) is an
-		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0">open format specification</a>
-		for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf)
-		or binary (.glb) format. External files store textures (.jpg, .png) and additional binary
-		data (.bin). A glTF asset may deliver one or more scenes, including meshes, materials,
-		textures, skins, skeletons, morph targets, animations, lights, and/or cameras.
+		<a href="https://www.khronos.org/gltf">PLY</a> (Polygon or Stanford Triangle Format) is
+		file format for efficient delivery and loading of simple, static 3D content in a dense format.
+		Both binary and ascii formats are supported. PLY can store vertex positions, colors, normals and
+		uv coordinates. No textures or texture references are saved.
 		</p>
 
 		<h2>Example</h2>
 
 		<code>
 		// Instantiate a exporter
-		var exporter = new THREE.PLYExporter( defaultOptions );
+		var exporter = new THREE.PLYExporter();
 
 		// Parse the input and generate the ply output
 		var data = exporter.parse( scene, options );
 		downloadFile(data);
 		</code>
-
-		[example:misc_exporter_gltf]	
 
 		<h2>Constructor</h2>
 
@@ -55,7 +51,8 @@
 		</ul>
 		</p>
 		<p>
-		Generates ply file data as string or ArrayBuffer (ascii or binary) output from the input object
+		Generates ply file data as string or ArrayBuffer (ascii or binary) output from the input object.
+		If the object is composed of multiple children and geometry, they are merged into a single mesh in the file.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/exporters/PLYExporter.html
+++ b/docs/examples/exporters/PLYExporter.html
@@ -22,7 +22,7 @@
 		<h2>Example</h2>
 
 		<code>
-		// Instantiate a exporter
+		// Instantiate an exporter
 		var exporter = new THREE.PLYExporter();
 
 		// Parse the input and generate the ply output

--- a/docs/examples/exporters/PLYExporter.html
+++ b/docs/examples/exporters/PLYExporter.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1>
+
+		<p class="desc">
+		An exporter for *PLY*.
+		<br /><br />
+		<a href="https://www.khronos.org/gltf">glTF</a> (GL Transmission Format) is an
+		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0">open format specification</a>
+		for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf)
+		or binary (.glb) format. External files store textures (.jpg, .png) and additional binary
+		data (.bin). A glTF asset may deliver one or more scenes, including meshes, materials,
+		textures, skins, skeletons, morph targets, animations, lights, and/or cameras.
+		</p>
+
+		<h2>Example</h2>
+
+		<code>
+		// Instantiate a exporter
+		var exporter = new THREE.PLYExporter( defaultOptions );
+
+		// Parse the input and generate the ply output
+		var data = exporter.parse( scene, options );
+		downloadFile(data);
+		</code>
+
+		[example:misc_exporter_gltf]	
+
+		<h2>Constructor</h2>
+
+		<h3>[name]()</h3>
+		<p>
+		</p>
+		<p>
+		Creates a new [name].
+		</p>
+
+		<h2>Methods</h2>
+
+		<h3>[method:null parse]( [param:Object3D input], [param:Object options] )</h3>
+		<p>
+		[page:Object input] — Object3D<br />
+		[page:Options options] — Export options<br />
+		<ul>
+			<li>excludeAttributes - array. Which properties to explicitly exclude from the exported PLY file. Valid values are 'color', 'normal', 'uv', and 'index'. If indices are excluded, then a point cloud is exported. Default is an empty array.</li>
+			<li>binary - bool. Export in binary format, returning an ArrayBuffer. Default is false.</li>
+		</ul>
+		</p>
+		<p>
+		Generates ply file data as string or ArrayBuffer (ascii or binary) output from the input object
+		</p>
+
+		<h2>Source</h2>
+
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/exporters/PLYExporter.js examples/js/exporters/PLYExporter.js]
+	</body>
+</html>

--- a/docs/list.js
+++ b/docs/list.js
@@ -373,7 +373,8 @@ var list = {
 		},
 
 		"Exporters": {
-			"GLTFExporter": "examples/exporters/GLTFExporter"
+			"GLTFExporter": "examples/exporters/GLTFExporter",
+			"PLYExporter": "examples/exporters/PLYExporter"
 		},
 
 		"Plugins": {


### PR DESCRIPTION
I added documentation for the PLYExporter using the GLTFLoader documentation as reference.

#### Update
I also updated the GLTFExporter page because it incorrectly showed that the constructor could take default options