### PR TITLE
BokehShader2: Fix Depth Sampling

### DIFF
--- a/examples/js/cameras/CinematicCamera.js
+++ b/examples/js/cameras/CinematicCamera.js
@@ -5,20 +5,28 @@
  * @author kaypiKun
  */
 
-THREE.CinematicCamera = function( fov, aspect, near, far ) {
+THREE.CinematicCamera = function ( fov, aspect, near, far ) {
 
 	THREE.PerspectiveCamera.call( this, fov, aspect, near, far );
 
-	this.type = "CinematicCamera";
+	this.type = 'CinematicCamera';
 
-	this.postprocessing = { enabled	: true };
+	this.postprocessing = { enabled: true };
 	this.shaderSettings = {
 		rings: 3,
 		samples: 4
 	};
 
-	this.material_depth = new THREE.MeshDepthMaterial();
-	this.material_depth.depthPacking = THREE.RGBADepthPacking;
+	var depthShader = THREE.BokehDepthShader;
+
+	this.materialDepth = new THREE.ShaderMaterial( {
+		uniforms: depthShader.uniforms,
+		vertexShader: depthShader.vertexShader,
+		fragmentShader: depthShader.fragmentShader
+	} );
+
+	this.materialDepth.uniforms[ 'mNear' ].value = near;
+	this.materialDepth.uniforms[ 'mFar' ].value = far;
 
 	// In case of cinematicCamera, having a default lens set is important
 	this.setLens();
@@ -178,7 +186,7 @@ THREE.CinematicCamera.prototype.renderCinematic = function ( scene, renderer ) {
 
 		// Render depth into texture
 
-		scene.overrideMaterial = this.material_depth;
+		scene.overrideMaterial = this.materialDepth;
 		renderer.render( scene, camera, this.postprocessing.rtTextureDepth, true );
 
 		// Render bokeh composite

--- a/examples/js/shaders/BokehShader2.js
+++ b/examples/js/shaders/BokehShader2.js
@@ -142,14 +142,6 @@ THREE.BokehShader = {
 
 		"//------------------------------------------",
 
-		"float getDepth( const in vec2 screenPosition ) {",
-		"	#if DEPTH_PACKING == 1",
-		"	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );",
-		"	#else",
-		"	return texture2D( tDepth, screenPosition ).x;",
-		"	#endif",
-		"}",
-
 		"float penta(vec2 coords) {",
 			"//pentagonal shape",
 			"float scale = float(rings) - 1.3;",
@@ -211,7 +203,7 @@ THREE.BokehShader = {
 
 
 			"for( int i=0; i<9; i++ ) {",
-				"float tmp = getDepth( coords + offset[ i ] );",
+				"float tmp = texture2D(tDepth, coords + offset[i]).r;",
 				"d += tmp * kernel[i];",
 			"}",
 
@@ -273,10 +265,10 @@ THREE.BokehShader = {
 		"void main() {",
 			"//scene depth calculation",
 
-			"float depth = linearize( getDepth( vUv.xy ) );",
+			"float depth = linearize(texture2D(tDepth,vUv.xy).x);",
 
 			"// Blur depth?",
-			"if (depthblur) {",
+			"if ( depthblur ) {",
 				"depth = linearize(bdepth(vUv.xy));",
 			"}",
 
@@ -286,7 +278,7 @@ THREE.BokehShader = {
 
 			"if (shaderFocus) {",
 
-				"fDepth = linearize( getDepth( focusCoords ) );",
+				"fDepth = linearize(texture2D(tDepth,focusCoords).x);",
 
 			"}",
 
@@ -358,6 +350,53 @@ THREE.BokehShader = {
 
 			"gl_FragColor.rgb = col;",
 			"gl_FragColor.a = 1.0;",
+		"} "
+
+	].join( "\n" )
+
+};
+
+THREE.BokehDepthShader = {
+
+	uniforms: {
+
+		"mNear": { value: 1.0 },
+		"mFar": { value: 1000.0 },
+
+	},
+
+	vertexShader: [
+
+		"#include <common>",
+
+		"varying float vViewZDepth;",
+
+		"void main() {",
+
+		"	#include <begin_vertex>",
+		"	#include <project_vertex>",
+
+		"	vViewZDepth = - mvPosition.z;",
+
+		"}"
+
+	].join( "\n" ),
+
+	fragmentShader: [
+
+		"uniform float mNear;",
+		"uniform float mFar;",
+
+		"varying float vViewZDepth;",
+
+		"#include <common>",
+		"#include <packing>",
+
+		"void main() {",
+
+		"	float color = 1.0 - smoothstep( mNear, mFar, vViewZDepth );",
+		"	gl_FragColor = vec4( vec3( color ), 1.0 );",
+
 		"} "
 
 	].join( "\n" )

--- a/examples/js/shaders/BokehShader2.js
+++ b/examples/js/shaders/BokehShader2.js
@@ -367,8 +367,6 @@ THREE.BokehDepthShader = {
 
 	vertexShader: [
 
-		"#include <common>",
-
 		"varying float vViewZDepth;",
 
 		"void main() {",
@@ -388,9 +386,6 @@ THREE.BokehDepthShader = {
 		"uniform float mFar;",
 
 		"varying float vViewZDepth;",
-
-		"#include <common>",
-		"#include <packing>",
 
 		"void main() {",
 

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -96,9 +96,16 @@ Use WEBGL Depth buffer support?
 				renderer.autoClear = false;
 				container.appendChild( renderer.domElement );
 
-				materialDepth = new THREE.MeshDepthMaterial();
-				materialDepth.depthPacking = THREE.RGBADepthPacking;
-				materialDepth.blending = THREE.NoBlending;
+				var depthShader = THREE.BokehDepthShader;
+
+				materialDepth = new THREE.ShaderMaterial( {
+					uniforms: depthShader.uniforms,
+					vertexShader: depthShader.vertexShader,
+					fragmentShader: depthShader.fragmentShader
+				} );
+
+				materialDepth.uniforms[ 'mNear' ].value = camera.near;
+				materialDepth.uniforms[ 'mFar' ].value = camera.far;
 
 				// skybox
 
@@ -110,7 +117,21 @@ Use WEBGL Depth buffer support?
 				var textureCube = new THREE.CubeTextureLoader().load( urls );
 				textureCube.format = THREE.RGBFormat;
 
-				scene.background = textureCube;
+				var shader = THREE.ShaderLib[ 'cube' ];
+				shader.uniforms[ 'tCube' ].value = textureCube;
+
+				material = new THREE.ShaderMaterial( {
+
+					fragmentShader: shader.fragmentShader,
+					vertexShader: shader.vertexShader,
+					uniforms: shader.uniforms,
+					depthWrite: false,
+					side: THREE.BackSide
+
+				} );
+
+				mesh = new THREE.Mesh( new THREE.BoxBufferGeometry( 1000, 1000, 1000 ), material );
+				scene.add( mesh );
 
 				// plane particles
 
@@ -377,8 +398,7 @@ Use WEBGL Depth buffer support?
 					fragmentShader: bokeh_shader.fragmentShader,
 					defines: {
 						RINGS: shaderSettings.rings,
-						SAMPLES: shaderSettings.samples,
-						DEPTH_PACKING: 1 // RGBADepth
+						SAMPLES: shaderSettings.samples
 					}
 
 				} );


### PR DESCRIPTION
I really hope this PR finally fixes #13599

After some research, I've found out that the original implementation was broken by 0a60f11565a52cff8bd366e5f359cc7e7ab0c9d9

I could not manage to migrate the existing bokeh code to the new depth material while keeping the original parameterization of the shader. Because of this, I've recreated the original depth material as a simple custom shader. Now the demos work again.