### PR TITLE
MMDLoader: add bones to BufferGeometry.userData

### DIFF
--- a/examples/js/animation/MMDAnimationHelper.js
+++ b/examples/js/animation/MMDAnimationHelper.js
@@ -582,7 +582,7 @@ THREE.MMDAnimationHelper = ( function () {
 		_optimizeIK: function ( mesh, physicsEnabled ) {
 
 			var iks = mesh.geometry.userData.MMD.iks;
-			var bones = mesh.geometry.bones;
+			var bones = mesh.geometry.userData.MMD.bones;
 
 			for ( var i = 0, il = iks.length; i < il; i ++ ) {
 

--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -842,6 +842,7 @@ THREE.MMDLoader = ( function () {
 			geometry.morphAttributes.position = morphPositions;
 
 			geometry.userData.MMD = {
+				bones: bones,
 				iks: iks,
 				grants: grants,
 				rigidBodies: rigidBodies,


### PR DESCRIPTION
Following #14144, add `bones` parameter to `BufferGeometry.userData`. 