### PR TITLE
GLTFExporter: export BufferGeometry.userData

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1182,6 +1182,8 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
+			var extras = ( Object.keys( geometry.userData ).length > 0 ) ? serializeUserData( geometry ) : undefined;
+
 			var forceIndices = options.forceIndices;
 			var isMultiMaterial = Array.isArray( mesh.material );
 
@@ -1222,6 +1224,8 @@ THREE.GLTFExporter.prototype = {
 					mode: mode,
 					attributes: attributes,
 				};
+
+				if ( extras ) primitive.extras = extras;
 
 				if ( targets.length > 0 ) primitive.targets = targets;
 


### PR DESCRIPTION
This PR adds `BufferGeometry.userData` export support to `GLTFExporter`.

One concern is how we should do for `BufferGeometry` with `.groups`. We make "shared attributes multiple primitives" for it. `.userData` is user defined data so we can't judge if it's specific data for some of groups then I set the same `.extras` to all primitives so far.

In our `GLTFLoader` we set only primitive[0]'s .extras to `BufferGeometry.userData` for "shared attributes multi primitives".