### PR TITLE
Allow Additive, CustomBlending when material.transparent is false

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -655,9 +655,9 @@ function WebGLState( gl, extensions, utils ) {
 
 		setFlipSided( flipSided );
 
-		material.transparent === true
-			? setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha, material.premultipliedAlpha )
-			: setBlending( NoBlending );
+		( material.blending === NormalBlending && material.transparent === false )
+			? setBlending( NoBlending )
+			: setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha, material.premultipliedAlpha )
 
 		depthBuffer.setFunc( material.depthFunc );
 		depthBuffer.setTest( material.depthTest );

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -657,7 +657,7 @@ function WebGLState( gl, extensions, utils ) {
 
 		( material.blending === NormalBlending && material.transparent === false )
 			? setBlending( NoBlending )
-			: setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha, material.premultipliedAlpha )
+			: setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha, material.premultipliedAlpha );
 
 		depthBuffer.setFunc( material.depthFunc );
 		depthBuffer.setTest( material.depthTest );


### PR DESCRIPTION
There are two competing way to control blending: `material.blending` and `material.transparent`.

Currently, `Additive`, `Subtractive`, `Multiply`, and `Custom` blending are disabled if `.transparent !== true`. This is clearly not correct.

Blending as a function of `.blending` and `.transparent`:

              NoBlending  NormalBlending  AdditiveBlending  CustomBlending
              ----------  --------------  ----------------  --------------
    true        No          Normal          Additive          Custom
    !true       No          No              No                No

WIth this PR, `.transparent === false` only disables blending if `.blending === NormalBlending`

              NoBlending  NormalBlending  AdditiveBlending  CustomBlending
              ----------  --------------  ----------------  --------------
    !false      No          Normal          Additive          Custom
    false       No          No              Additive          Custom
