### PR TITLE
[WIP] per channel uv transform example 

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -158,6 +158,7 @@ var files = {
 		"webgl_materials_envmaps",
 		"webgl_materials_envmaps_exr",
 		"webgl_materials_envmaps_hdr",
+		"webgl_materials_extended_multiple_uvs",
 		"webgl_materials_grass",
 		"webgl_materials_lightmap",
 		"webgl_materials_nodes",

--- a/examples/webgl_materials_extended_multiple_uvs.html
+++ b/examples/webgl_materials_extended_multiple_uvs.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>three.js webgl - instancing - lambert shader</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<style>
+		body {
+			color: #ffffff;
+			font-family: Monospace;
+			font-size: 13px;
+			text-align: center;
+			font-weight: bold;
+			background-color: #000000;
+			margin: 0px;
+			overflow: hidden;
+		}
+
+		#info {
+			position: absolute;
+			top: 0px;
+			width: 100%;
+			padding: 5px;
+		}
+
+		a {
+			color: #ffffff;
+		}
+
+		#notSupported {
+			width: 50%;
+			margin: auto;
+			border: 2px red solid;
+			margin-top: 20px;
+			padding: 10px;
+		}
+	</style>
+</head>
+<body>
+
+	<div id="container"></div>
+	<div id="info">
+		<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - instancing - lambert shader
+		<div id="notSupported" style="display:none">Sorry your graphics card + browser does not support hardware instancing</div>
+	</div>
+
+	<script src="../build/three.js"></script>
+	<script src="js/Detector.js"></script>
+	<script src="js/libs/stats.min.js"></script>
+
+	<script src="js/controls/OrbitControls.js"></script>
+	<script src="js/CurveExtras.js"></script>
+	<script src="js/libs/dat.gui.min.js"></script>
+
+
+	<script>
+		/*eslint-disable*/
+		if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
+
+
+		var renderer, scene, camera, controls, materials, mesh;
+		var stats;
+		var guiData = { material: 'MeshStandard' }
+
+		init();
+		initGUI();
+		animate();
+
+		function onMaterialChange( value ) {
+				
+			mesh.material = materials[value]
+
+		} 
+
+		function initGUI(){
+
+			var gui = new dat.GUI();
+
+			gui.add( 
+
+				guiData, 
+				'material', 
+				[
+					'MeshPhong',
+					'MeshStandard',
+				] 
+
+			).onChange(onMaterialChange);
+			
+			onMaterialChange(guiData.material)
+		}
+
+		function init() {
+
+			//share with other extended examples?
+			// -----------------------------------------------------------------------------
+			
+			renderer = new THREE.WebGLRenderer( { antialias: true } );
+			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.shadowMap.enabled = true;
+			document.body.appendChild( renderer.domElement );
+
+			renderer.gammaOutput = true;
+
+			scene = new THREE.Scene();
+
+			scene.fog = new THREE.FogExp2( 0x000000, 0.004 );
+			renderer.setClearColor( scene.fog.color, 1 );
+
+			camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1000 );
+			camera.position.set( 80, 40, 80 );
+
+			scene.add( camera );
+
+			controls = new THREE.OrbitControls( camera, renderer.domElement );
+			controls.enableZoom = false;
+			controls.maxPolarAngle = Math.PI / 2;
+
+			scene.add( new THREE.AmbientLight( 0xffffff, 0.7 ) );
+
+			var light = new THREE.DirectionalLight( 0xffffff, 0.4 );
+			light.position.set( 50, 40, 0 );
+
+			light.castShadow = true;
+			light.shadow.camera.left = - 40;
+			light.shadow.camera.right = 40;
+			light.shadow.camera.top = 40;
+			light.shadow.camera.bottom = - 40;
+			light.shadow.camera.near = 10;
+			light.shadow.camera.far = 180;
+
+			light.shadow.bias = - 0.001;
+			light.shadow.mapSize.width = 512;
+			light.shadow.mapSize.height = 512;
+
+			scene.add( light );
+
+			var ground = new THREE.Mesh(
+				new THREE.PlaneBufferGeometry( 800, 800 ).rotateX( - Math.PI / 2 ),
+				new THREE.MeshPhongMaterial( { color: 0x888888 } )
+			);
+			ground.position.set( 0, - 40, 0 );
+			ground.receiveShadow = true;
+
+			scene.add( ground );
+
+			stats = new Stats();
+			document.body.appendChild( stats.dom );
+
+			window.addEventListener( 'resize', onWindowResize, false );
+
+			// -----------------------------------------------------------------------------
+			
+
+			// example
+
+			var texture = new THREE.TextureLoader().load( `textures/roughness_map.jpg` )
+			texture.wrapS = texture.wrapT = THREE.RepeatWrapping
+			//an environment map
+			var envMap = new THREE.TextureLoader().load( `textures/metal.jpg`, function ( texture ) {
+
+				texture.mapping = THREE.SphericalReflectionMapping;
+				texture.encoding = THREE.sRGBEncoding;
+				if ( mesh ) mesh.material.needsUpdate = true;
+
+			} );
+
+			//create an instance of various types of materials
+			materials = {
+
+				MeshPhong: new THREE.MeshPhongMaterial({ 
+					color: 0xffb54a,
+					envMap: envMap,
+					fog: true
+				}),
+
+				MeshStandard: new THREE.MeshStandardMaterial({
+					color: 0xffb54a,
+					envMap: envMap,
+					metalness: 1,
+					roughness: 0,
+					fog: true
+				}),
+
+			}
+
+			var validMaps = {
+				'map': true,
+				'roughnessMap': true,
+				'metalnessMap': true,
+				// 'normalMap': true,
+				'alphaMap': true,
+				'specularMap': true
+			}
+
+			/**
+			 * HACK:
+			 * this is actually "onBeforeParse" along with "onBeforeCompile"
+			 * for this effect to work, it would actually be beneficial to do it
+			 * in "onAfterParse" but before compilation, 
+			 * it is safe to pre parse the includes which we can do like so:
+			 */
+			var pattern = /#include <(.*)>/gm
+
+			function parseIncludes( string ){
+				function replace( match , include ){
+					var replace = THREE.ShaderChunk[ include ]
+					return parseIncludes( replace )
+				}
+				return string.replace( pattern, replace )
+			}
+
+			/**
+			 * Solution:
+			 *
+			 * we can look for where vUv is used and extend those maps with their own
+			 * transform uniform, for this simple example we are going to use a vec4 to store
+			 * a per channel offset and scale
+			 */
+			
+			//look for maps that are mapped with vUv
+			var mapRegex = /texture2D\( (.*Map|map), vUv \)/gm
+
+ 			
+			var onBeforeCompile = function ( shader ) {
+
+				var prependUniforms = ''
+
+				var level = 1
+
+				function replaceMaps( string ){
+
+					function replace( match, mapName ) {
+
+						if(!validMaps[mapName]) return match
+
+						var uniformName = `u_${mapName}ScaleOffset`
+						// shader.uniforms[uniformName] = { value: new THREE.Vector4(1,1,0,0) }
+						shader.uniforms[uniformName] = { value: new THREE.Vector4(level,level,level*0.25,level*0.25) }
+						level++
+						prependUniforms += `uniform vec4 ${uniformName};\n`
+						
+						var replace = `texture2D( ${mapName}, vUv * ${uniformName}.xy + ${uniformName}.zw )`
+						return replaceMaps( replace ) 
+					}
+
+					return string.replace( mapRegex, replace )
+				}
+
+				shader.fragmentShader = parseIncludes(shader.fragmentShader) //"unroll" the entire shader
+				shader.fragmentShader = replaceMaps(shader.fragmentShader) //patch in the mapping stuff
+
+				shader.fragmentShader = prependUniforms + shader.fragmentShader
+
+			}
+
+			//extend these materials
+			for ( materialName in materials ) {
+
+				var material = materials[materialName]
+
+				for ( var map in validMaps ){
+					if(material[map] === null) {
+						material[map] = texture
+						console.log(material[map])
+					}
+				}
+
+				materials[materialName].onBeforeCompile = onBeforeCompile
+
+			}
+
+
+			mesh = new THREE.Mesh( new THREE.SphereGeometry(10,32,16), materials[guiData.material] )
+
+
+			scene.add( mesh );
+
+		}
+
+		function onWindowResize( event ) {
+
+			renderer.setSize( window.innerWidth, window.innerHeight );
+
+			camera.aspect = window.innerWidth / window.innerHeight;
+			camera.updateProjectionMatrix();
+
+		}
+
+		function animate() {
+
+			requestAnimationFrame( animate );
+
+			mesh.rotation.y += 0.005
+
+			stats.update();
+
+			renderer.render( scene, camera );
+
+		}
+
+
+	</script>
+
+</body>
+
+</html>

--- a/examples/webgl_materials_extended_multiple_uvs.html
+++ b/examples/webgl_materials_extended_multiple_uvs.html
@@ -59,8 +59,8 @@
 
 
 		var renderer, scene, camera, controls, materials, mesh;
-		var stats, gui, guiProps;
-		var guiData = { material: 'MeshStandard' }
+		var stats, gui, guiProps, guiMap;
+		var guiData = { material: 'MeshStandard', map: 'map' }
 
 		init();
 		animate();
@@ -68,20 +68,37 @@
 		var guis = []
 
 		function onMaterialChange( value ) {
-				
-			while(guis.length){
-				guiProps.remove(guis.pop())
-			}
+			
+			if(guiMap) gui.remove(guiMap)
+
+			guiData.map = 'map'
+
 			mesh.material = materials[value]
 
+			guiMap = gui.add( guiData, 'map', mesh.material.userData.extraProps ).onChange(onPropChange)
+
+			onPropChange('map')
+		}
+
+		function onPropChange(value){
+
+			while(guis.length){
+				gui.remove(guis.pop())
+			}
+
 			var u = function(){
-				for (var i = mesh.material.userData.extraProps.length - 1; i >= 0; i--) {
-					var n = mesh.material.userData.extraProps[i]
-					guis.push( guiProps.add(mesh.material[`${n}Offset`],'x', 0, 5).name(`${n}Offset U`) )
-					guis.push( guiProps.add(mesh.material[`${n}Offset`],'y', 0, 5).name(`${n}Offset V`) )
-					guis.push( guiProps.add(mesh.material[`${n}Scale`],'x', 0, 5).name(`${n}Scale U`) )
-					guis.push( guiProps.add(mesh.material[`${n}Scale`],'y', 0, 5).name(`${n}Scale V`) )
-				}
+
+				let n = guiData.map
+
+				var texUpdate = mesh.material[`${n}UpdateMatrix`]
+
+				guis.push( gui.add(mesh.material[`${n}Offset`],'x', 0, 5).name(`${n}Offset U`).onChange(texUpdate))
+				guis.push( gui.add(mesh.material[`${n}Offset`],'y', 0, 5).name(`${n}Offset V`).onChange(texUpdate))
+				guis.push( gui.add(mesh.material[`${n}Scale`],'x', 0, 5).name(`${n}Scale U`).onChange(texUpdate))
+				guis.push( gui.add(mesh.material[`${n}Scale`],'y', 0, 5).name(`${n}Scale V`).onChange(texUpdate))
+				guis.push( gui.add(mesh.material, `${n}Rotation`, 0, Math.PI * 2).name(`${n}Rotation`).onChange(texUpdate))
+				
+				guis.push( gui.add(mesh.material,'transparent') )
 			}
 
 			if(!mesh.material.userData.extraProps){
@@ -89,9 +106,7 @@
 			} else {
 				u()
 			}
-
 		} 
-
 
 
 		function initGUI(){
@@ -109,9 +124,6 @@
 
 			).onChange(onMaterialChange)
 
-			guiProps = gui.addFolder('texture controls')
-			guiProps.open()
-			
 			onMaterialChange(guiData.material)
 
 		}
@@ -179,7 +191,8 @@
 			// -----------------------------------------------------------------------------
 			
 
-			// example
+			// some textures ----------------------------------------------------------------------
+			
 
 			var texture = new THREE.TextureLoader().load( `textures/roughness_map.jpg` )
 			texture.wrapS = texture.wrapT = THREE.RepeatWrapping
@@ -195,6 +208,20 @@
 
 			} );
 
+			// example ----------------------------------------------------------------------
+			var setUvTransform = function ( tx, ty, sx, sy, rotation, cx, cy ) {
+
+				var c = Math.cos( rotation );
+				var s = Math.sin( rotation );
+ 
+				this.set(
+					sx * c, sx * s, - sx * ( c * cx + s * cy ) + cx + tx,
+					- sy * s, sy * c, - sy * ( - s * cx + c * cy ) + cy + ty,
+					0, 0, 0
+				);
+
+			}
+			
 			//create an instance of various types of materials
 			materials = {
 
@@ -253,19 +280,10 @@
 			//look for maps that are mapped with vUv
 			var mapRegex = /texture2D\( (.*Map|map), vUv \)/gm
 
- 			
+ 			//TODO: refactor this so props are created syncroncously (and props)
 			var onBeforeCompile = function ( shader ) {
 
 				var prependUniforms = ''
-
-				var level = 1
-
-				const extraUniforms = {}
-				this.userData.extraUniforms = extraUniforms
-
-				const extraProps = []
-				this.userData.extraProps = extraProps
-
 				var _this = this
 
 				function replaceMaps( string ){
@@ -274,39 +292,14 @@
 
 						if(!validMaps[mapName]) return match
 
+						let uniformName = `u_${mapName}Transform`
 
-						var uniformNameScale = `u_${mapName}Scale`
-						var uniformNameOffset = `u_${mapName}Offset`
+						prependUniforms += `uniform mat3 ${uniformName};\n`
+						shader.uniforms[uniformName] = _this.userData.extraUniforms[uniformName]
+						shader.uniforms[uniformName].name = uniformName
+						var replace = `texture2D( ${mapName}, ( ${uniformName} * vec3( vUv, 1. ) ).xy )`
 
-						var uniformScale = { value: new THREE.Vector2(level,level) }
-						var uniformOffset = { value: new THREE.Vector2(level*0.25,level*0.25) }
 
-						shader.uniforms[uniformNameScale] = uniformScale
-						extraUniforms[uniformNameScale ] = uniformScale 
-						shader.uniforms[uniformNameOffset] = uniformOffset
-						extraUniforms[uniformNameOffset ] = uniformOffset 
-
-						level++
-						prependUniforms += `uniform vec2 ${uniformNameScale};\n`
-						prependUniforms += `uniform vec2 ${uniformNameOffset};\n`
-
-						extraProps.push(mapName)
-						var foo = {
-							[`${mapName}Scale`]: {
-								get: function(){ return extraUniforms[uniformNameScale].value },
-								set: function(val){ extraUniforms[uniformNameScale].value.copy(val) }
-							},
-							[`${mapName}Offset`]: {
-								get: function(){ return extraUniforms[uniformNameOffset].value },
-								set: function(val){ extraUniforms[uniformNameOffset].value.copy(val) }
-							}
-						}
-						Object.defineProperties(
-							_this,
-							foo
-						)
-
-						var replace = `texture2D( ${mapName}, vUv * ${uniformNameScale} + ${uniformNameOffset} )`
 						return replaceMaps( replace ) 
 					}
 
@@ -327,10 +320,47 @@
 
 				var material = materials[materialName]
 
-				for ( var map in validMaps ){
-					if(material[map] === null) {
-						material[map] = texture
+				const extraUniforms = {}
+				material.userData.extraUniforms = extraUniforms
+
+				const extraProps = []
+				material.userData.extraProps = extraProps
+
+				for ( var mapName in validMaps ){
+
+					if(material[mapName] === null) {
+
+						material[mapName] = texture
+						material[`${mapName}Scale`] = new THREE.Vector2(1,1)
+						material[`${mapName}Offset`] = new THREE.Vector2()
+						material[`${mapName}Rotation`] = 0
+
+						var uniformName = `u_${mapName}Transform`
+
+						var uniform = { value: new THREE.Matrix3() , name: mapName }
+						uniform.value.name = mapName
+						uniform.value.setUvTransform = setUvTransform.bind(uniform.value)
+
+						extraUniforms[uniformName] = uniform 
+						extraProps.push(mapName)
+
+						let _mapName = mapName
+						let _uniformName = uniformName
+
+						material[`${mapName}UpdateMatrix`] = function(){
+							this.userData.extraUniforms[_uniformName].value.setUvTransform( 
+								this[`${_mapName}Offset`].x,
+								this[`${_mapName}Offset`].y, 
+								this[`${_mapName}Scale`].x,
+								this[`${_mapName}Scale`].y, 
+								this[`${_mapName}Rotation`], 
+								0, 
+								0
+							)
+						}.bind(material)
+
 					}
+
 				}
 
 				material.onBeforeCompile = onBeforeCompile.bind( material )

--- a/examples/webgl_materials_extended_multiple_uvs.html
+++ b/examples/webgl_materials_extended_multiple_uvs.html
@@ -59,22 +59,44 @@
 
 
 		var renderer, scene, camera, controls, materials, mesh;
-		var stats;
+		var stats, gui, guiProps;
 		var guiData = { material: 'MeshStandard' }
 
 		init();
-		initGUI();
 		animate();
+
+		var guis = []
 
 		function onMaterialChange( value ) {
 				
+			while(guis.length){
+				guiProps.remove(guis.pop())
+			}
 			mesh.material = materials[value]
+
+			var u = function(){
+				for (var i = mesh.material.userData.extraProps.length - 1; i >= 0; i--) {
+					var n = mesh.material.userData.extraProps[i]
+					guis.push( guiProps.add(mesh.material[`${n}Offset`],'x', 0, 5).name(`${n}Offset U`) )
+					guis.push( guiProps.add(mesh.material[`${n}Offset`],'y', 0, 5).name(`${n}Offset V`) )
+					guis.push( guiProps.add(mesh.material[`${n}Scale`],'x', 0, 5).name(`${n}Scale U`) )
+					guis.push( guiProps.add(mesh.material[`${n}Scale`],'y', 0, 5).name(`${n}Scale V`) )
+				}
+			}
+
+			if(!mesh.material.userData.extraProps){
+				setTimeout(u,100)
+			} else {
+				u()
+			}
 
 		} 
 
+
+
 		function initGUI(){
 
-			var gui = new dat.GUI();
+			gui = new dat.GUI()
 
 			gui.add( 
 
@@ -85,10 +107,15 @@
 					'MeshStandard',
 				] 
 
-			).onChange(onMaterialChange);
+			).onChange(onMaterialChange)
+
+			guiProps = gui.addFolder('texture controls')
+			guiProps.open()
 			
 			onMaterialChange(guiData.material)
+
 		}
+
 
 		function init() {
 
@@ -161,7 +188,10 @@
 
 				texture.mapping = THREE.SphericalReflectionMapping;
 				texture.encoding = THREE.sRGBEncoding;
-				if ( mesh ) mesh.material.needsUpdate = true;
+
+				mesh = new THREE.Mesh( new THREE.SphereGeometry(10,32,16), materials[guiData.material] )
+
+				scene.add( mesh );
 
 			} );
 
@@ -171,15 +201,17 @@
 				MeshPhong: new THREE.MeshPhongMaterial({ 
 					color: 0xffb54a,
 					envMap: envMap,
-					fog: true
+					fog: true,
+					transparent: true
 				}),
 
 				MeshStandard: new THREE.MeshStandardMaterial({
 					color: 0xffb54a,
 					envMap: envMap,
 					metalness: 1,
-					roughness: 0,
-					fog: true
+					roughness: 1,
+					fog: true,
+					transparent: true
 				}),
 
 			}
@@ -228,19 +260,53 @@
 
 				var level = 1
 
+				const extraUniforms = {}
+				this.userData.extraUniforms = extraUniforms
+
+				const extraProps = []
+				this.userData.extraProps = extraProps
+
+				var _this = this
+
 				function replaceMaps( string ){
 
 					function replace( match, mapName ) {
 
 						if(!validMaps[mapName]) return match
 
-						var uniformName = `u_${mapName}ScaleOffset`
-						// shader.uniforms[uniformName] = { value: new THREE.Vector4(1,1,0,0) }
-						shader.uniforms[uniformName] = { value: new THREE.Vector4(level,level,level*0.25,level*0.25) }
+
+						var uniformNameScale = `u_${mapName}Scale`
+						var uniformNameOffset = `u_${mapName}Offset`
+
+						var uniformScale = { value: new THREE.Vector2(level,level) }
+						var uniformOffset = { value: new THREE.Vector2(level*0.25,level*0.25) }
+
+						shader.uniforms[uniformNameScale] = uniformScale
+						extraUniforms[uniformNameScale ] = uniformScale 
+						shader.uniforms[uniformNameOffset] = uniformOffset
+						extraUniforms[uniformNameOffset ] = uniformOffset 
+
 						level++
-						prependUniforms += `uniform vec4 ${uniformName};\n`
-						
-						var replace = `texture2D( ${mapName}, vUv * ${uniformName}.xy + ${uniformName}.zw )`
+						prependUniforms += `uniform vec2 ${uniformNameScale};\n`
+						prependUniforms += `uniform vec2 ${uniformNameOffset};\n`
+
+						extraProps.push(mapName)
+						var foo = {
+							[`${mapName}Scale`]: {
+								get: function(){ return extraUniforms[uniformNameScale].value },
+								set: function(val){ extraUniforms[uniformNameScale].value.copy(val) }
+							},
+							[`${mapName}Offset`]: {
+								get: function(){ return extraUniforms[uniformNameOffset].value },
+								set: function(val){ extraUniforms[uniformNameOffset].value.copy(val) }
+							}
+						}
+						Object.defineProperties(
+							_this,
+							foo
+						)
+
+						var replace = `texture2D( ${mapName}, vUv * ${uniformNameScale} + ${uniformNameOffset} )`
 						return replaceMaps( replace ) 
 					}
 
@@ -252,6 +318,8 @@
 
 				shader.fragmentShader = prependUniforms + shader.fragmentShader
 
+				//init here so it can take params
+				if(!gui) initGUI()
 			}
 
 			//extend these materials
@@ -262,19 +330,12 @@
 				for ( var map in validMaps ){
 					if(material[map] === null) {
 						material[map] = texture
-						console.log(material[map])
 					}
 				}
 
-				materials[materialName].onBeforeCompile = onBeforeCompile
+				material.onBeforeCompile = onBeforeCompile.bind( material )
 
 			}
-
-
-			mesh = new THREE.Mesh( new THREE.SphereGeometry(10,32,16), materials[guiData.material] )
-
-
-			scene.add( mesh );
 
 		}
 
@@ -291,7 +352,7 @@
 
 			requestAnimationFrame( animate );
 
-			mesh.rotation.y += 0.005
+			if(mesh) mesh.rotation.y += 0.005
 
 			stats.update();
 

--- a/examples/webgl_materials_extended_multiple_uvs.html
+++ b/examples/webgl_materials_extended_multiple_uvs.html
@@ -62,7 +62,8 @@
 		var stats, gui, guiProps, guiMap;
 		var guiData = { material: 'MeshStandard', map: 'map' }
 
-		init();
+		initStuff()
+		initExtension()
 		animate();
 
 		var guis = []
@@ -129,7 +130,7 @@
 		}
 
 
-		function init() {
+		function initStuff() {
 
 			//share with other extended examples?
 			// -----------------------------------------------------------------------------
@@ -189,7 +190,9 @@
 			window.addEventListener( 'resize', onWindowResize, false );
 
 			// -----------------------------------------------------------------------------
-			
+		}
+
+		function initExtension() {
 
 			// some textures ----------------------------------------------------------------------
 			


### PR DESCRIPTION
I mustered up a quick example to override the `vUv` value in the shaders.

http://dusanbosnjak.com/test/webGL/three-materials-extended/webgl_materials_extended_multiple_uvs_props.html

I used roughnessMap, specularMap, metalnessMap and map and added a simple scale + offset to each.

It's not the cleanest thing but it's an example of how to quickly prototype something without affecting the core. 

https://github.com/mrdoob/three.js/pull/14149
https://github.com/mrdoob/three.js/issues/12788
https://github.com/mrdoob/three.js/issues/12608
https://github.com/mrdoob/three.js/pull/13831
https://github.com/mrdoob/three.js/pull/8278
https://github.com/mrdoob/three.js/issues/5876

It's easy to also expose these, but for some reason i think `onBeforeCompile` fired twice. I actually tried to mimick `onAfterParse` because `onBeforeCompile` is also `onBeforeParse`.

This is another example of using **shader injection**, specifically with the currently available `onBeforeCompile`. I think it's trivial to solve issues such as the ones linked with this kind of an api. However, i think there are better alternatives to it:

https://github.com/mrdoob/three.js/pull/13198

I think that this is a valid use case to find itself in the core, (transforms probably don't belong on textures, rather texture slots) but since it's a complicated process to propose and review something like that, `onBeforeCompile` allows for quick prototyping. 

In this particular case, it mimicked a script that one could write to replace some code over many files, rather than doing it manually. For production it's a bit clunky, that's where i'd propose an alternative. Even if this weren't in the core, i think the area of GLSL is so self contained that this would be an easy effect to carry across and combine with other shader modifications. 

