### PR TITLE
Change documentation links to use href attribute

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -293,7 +293,14 @@
 
 			}
 
-			function setUrlFragment( pageName ) {
+			function setUrlFragment( pageName, event ) {
+
+				if ( ! isRegularClick( event ) ) {
+
+					return;
+
+				}
+				event.preventDefault();
 
 				// Handle navigation from the subpages (iframes):
 				// First separate the memeber (if existing) from the page name,

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,6 +84,13 @@
 			createNewIframe();
 
 			// Navigation Panel
+			
+			function isRegularClick( event ) {
+				if ( event.button !== 0 ) {
+					return false;
+				}
+				return !( event.metaKey || event.altKey || event.ctrlKey || event.shiftKey );
+			}
 
 			function createLink( pageName, pageURL ) {
 
@@ -93,15 +100,20 @@
 				link.setAttribute( 'target', 'viewer' );
 				link.addEventListener( 'click', function ( event ) {
 
-					window.location.hash = pageURL;
-					panel.classList.add( 'collapsed' );
+					if ( isRegularClick( event ) ) {
+
+						event.preventDefault();
+						window.location.hash = pageURL;
+						panel.classList.add( 'collapsed' );
+
+					}
 
 				} );
 
 				return link;
 
 			}
-
+			
 			function createNavigation() {
 
 				// Create the navigation panel using data from list.js
@@ -262,7 +274,21 @@
 
 
 			// Routing
+			
+			function getPageUrl( pageName ) {
 
+				var splitPageName = decomposePageName( pageName, '.', '#' );
+
+				var currentProperties = pageProperties[ splitPageName[ 0 ] ];
+
+				if ( currentProperties ) {
+
+					return currentProperties.pageURL + ".html" + splitPageName[ 1 ];
+
+				}
+
+			}
+			
 			function setUrlFragment( pageName ) {
 
 				// Handle navigation from the subpages (iframes):

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,12 +84,16 @@
 			createNewIframe();
 
 			// Navigation Panel
-			
+
 			function isRegularClick( event ) {
+
 				if ( event.button !== 0 ) {
+
 					return false;
+
 				}
-				return !( event.metaKey || event.altKey || event.ctrlKey || event.shiftKey );
+				return ! ( event.metaKey || event.altKey || event.ctrlKey || event.shiftKey );
+
 			}
 
 			function createLink( pageName, pageURL ) {
@@ -288,7 +292,7 @@
 				}
 
 			}
-			
+
 			function setUrlFragment( pageName ) {
 
 				// Handle navigation from the subpages (iframes):

--- a/docs/page.js
+++ b/docs/page.js
@@ -96,12 +96,12 @@ function onDocumentLoad( event ) {
 	// text = text.replace( /\[member:.([\w]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$1')\" title=\"$1\">$2</a>" );
 
 	text = text.replace( /\[(member|property|method|param):([\w]+)\]/gi, "[$1:$2 $2]" ); // [member:name] to [member:name title]
-	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]\s*(\(.*\))?/gi, function ( match, pageName, member, title ) {
+	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]\s*(\(.*\))?/gi, function ( match, typeName, pageName, argList ) {
 
-		var permalink = createLink( name + "." + member, "#", { target: "_parent", title: name + "." + member, class: "permalink" } );
-		var memberLink = createLink( name + "." + member, member, { id: member } );
-		var pageLink = createLink( pageName, pageName, { class: "param" } );
-		return permalink + " ." + memberLink + " " + ( title || "" ) + " : " + pageLink;
+		var permalink = createLink( name + "." + pageName, "#", { target: "_parent", title: name + "." + pageName, class: "permalink" } );
+		var pageLink = createLink( name + "." + pageName, pageName, { id: pageName } );
+		var typeLink = createLink( typeName, typeName, { class: "param" } );
+		return permalink + " ." + pageLink + " " + ( argList || "" ) + " : " + typeLink;
 
 	} );
 	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, function ( match, pageName, title ) {

--- a/docs/page.js
+++ b/docs/page.js
@@ -25,10 +25,8 @@ if ( !window.frameElement && window.location.protocol !== 'file:' ) {
 
 function createLink( pageName, title, attributes ) {
 
-	if ( !attributes ) {
-		attributes = {};
-	}
-	
+	attributes = attributes || {};
+
 	if ( pageName.match( /^(null|this|Boolean|Object|Array|Number|String|Integer|Float|TypedArray|ArrayBuffer)$/i ) ) {
 
 		// do not create links to primitive types
@@ -38,14 +36,18 @@ function createLink( pageName, title, attributes ) {
 
 	var url = window.parent.getPageUrl( pageName );
 	if ( url ) {
+
 		attributes.href = url;
+
 	}
-	
+
 	var code = "";
 	for ( var key in attributes ) {
 
 		if ( attributes.hasOwnProperty( key ) ) {
-			code += " " + key + "=\"" + attributes[key] + "\"";
+
+			code += " " + key + "=\"" + attributes[ key ] + "\"";
+
 		}
 
 	}
@@ -86,20 +88,26 @@ function onDocumentLoad( event ) {
 	text = text.replace( /\[path\]/gi, path );
 	text = text.replace( /\[page:([\w\.]+)\]/gi, "[page:$1 $1]" ); // [page:name] to [page:name title]
 	text = text.replace( /\[page:\.([\w\.]+) ([\w\.\s]+)\]/gi, "[page:" + name + ".$1 $2]" ); // [page:.member title] to [page:name.member title]
-	text = text.replace( /\[page:([\w\.]+) ([\w\.\s]+)\]/gi, function( match, pageName, title ) {
-		return createLink( pageName, title, { "title" : pageName } );
+	text = text.replace( /\[page:([\w\.]+) ([\w\.\s]+)\]/gi, function ( match, pageName, title ) {
+
+		return createLink( pageName, title, { title: pageName } );
+
 	} ); // [page:name title]
 	// text = text.replace( /\[member:.([\w]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$1')\" title=\"$1\">$2</a>" );
 
 	text = text.replace( /\[(member|property|method|param):([\w]+)\]/gi, "[$1:$2 $2]" ); // [member:name] to [member:name title]
-	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]\s*(\(.*\))?/gi, function( match, pageName, member, title ) {
-		var permalink = createLink( name + "." + member, "#", { "target" : "_parent", "title" : name + "." + member, "class" : "permalink" } );
-		var memberLink = createLink( name + "." + member, member, { "id" :  member } );
-		var pageLink = createLink( pageName, pageName, { "class": "param" } );
+	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]\s*(\(.*\))?/gi, function ( match, pageName, member, title ) {
+
+		var permalink = createLink( name + "." + member, "#", { target: "_parent", title: name + "." + member, class: "permalink" } );
+		var memberLink = createLink( name + "." + member, member, { id: member } );
+		var pageLink = createLink( pageName, pageName, { class: "param" } );
 		return permalink + " ." + memberLink + " " + title + " : " + pageLink;
+
 	} );
-	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, function( match, pageName, title ) {
-		return title + " : " + createLink( pageName, pageName, { "class" : "param" } );
+	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, function ( match, pageName, title ) {
+
+		return title + " : " + createLink( pageName, pageName, { class: "param" } );
+
 	} ); // [param:name title]
 
 	text = text.replace( /\[link:([\w|\:|\/|\.|\-|\_]+)\]/gi, "[link:$1 $1]" ); // [link:url] to [link:url title]

--- a/docs/page.js
+++ b/docs/page.js
@@ -52,7 +52,7 @@ function createLink( pageName, title, attributes ) {
 
 	}
 
-	return "<a onclick=\"window.parent.setUrlFragment('" + pageName + "')\" " + code + ">" + title + "</a>";
+	return "<a onclick=\"window.parent.setUrlFragment('" + pageName + "', event)\" " + code + ">" + title + "</a>";
 
 }
 

--- a/docs/page.js
+++ b/docs/page.js
@@ -101,7 +101,7 @@ function onDocumentLoad( event ) {
 		var permalink = createLink( name + "." + member, "#", { target: "_parent", title: name + "." + member, class: "permalink" } );
 		var memberLink = createLink( name + "." + member, member, { id: member } );
 		var pageLink = createLink( pageName, pageName, { class: "param" } );
-		return permalink + " ." + memberLink + " " + title + " : " + pageLink;
+		return permalink + " ." + memberLink + " " + ( title || "" ) + " : " + pageLink;
 
 	} );
 	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, function ( match, pageName, title ) {


### PR DESCRIPTION
Fixing issue #13900.

Links will be created with a correct `href` attribute in order to behave like normal links, and will only invoke current behavior when clicked with left button with no modifier keys.

Tested on local server & [mrdoob approved](http://zz85.github.io/mrdoobapproves/) (which can't be said about the existing code in those files, by the way).

Sorry for a bunch of commits, not sure how to squash them on my end.