### PR TITLE
[WIP] tiny api and example how to combine material extensions

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -298,6 +298,7 @@ var files = {
 		"webgl_custom_attributes_points2",
 		"webgl_custom_attributes_points3",
 		"webgl_materials_modified",
+		"webgl_materials_modified2",
 		"webgl_raymarching_reflect",
 		"webgl_shadowmap_pcss",
 		"webgl_simple_gi",

--- a/examples/js/SpecGlossMultiUVInstanceExample.js
+++ b/examples/js/SpecGlossMultiUVInstanceExample.js
@@ -123,7 +123,7 @@ function decorateMaterialWithSpecGloss( material ) {
 		data.metadata.extensions.isSpecGlossExtended = true
 		data.glossiness = this.glossiness
 		data.specular = this.specular.getHex()
-		if(this.glossinessMap && this.glossinessMap.isTexture) data.glossinessMap = this.glossinessMap.toJSON( meta ) 
+		if(this.glossinessMap && this.glossinessMap.isTexture) data.glossinessMap = this.glossinessMap.toJSON( meta ).uuid 
 	}.bind(material)
 
 	material._serializationManager.addFunction(f)

--- a/examples/js/SpecGlossMultiUVInstanceExample.js
+++ b/examples/js/SpecGlossMultiUVInstanceExample.js
@@ -99,6 +99,8 @@ function decorateMaterialWithSpecGloss( material ) {
 		} );
 
 	}
+	
+	return material
 
 }
 
@@ -211,6 +213,7 @@ function decorateMaterialWithPerMapTransforms( material, mapList ) {
 	addOrMergeProp( material, 'shaderUniforms', shaderUniforms );
 	addOrMergeProp( material, 'shaderIncludes', shaderIncludes );
 
+	return material
 }
 
 
@@ -241,7 +244,9 @@ function decorateMaterialWithSimpleInstancing( material ) {
 		${shader.vertexShader}
 		`
 	}
-	
+
 	addOrMergeProp( material, 'shaderIncludes', shaderIncludes );
+
+	return material
 
 }

--- a/examples/js/SpecGlossMultiUVInstanceExample.js
+++ b/examples/js/SpecGlossMultiUVInstanceExample.js
@@ -16,7 +16,13 @@ function addOrMergeProp( material, propName, data ) {
 
 //serialize
 function toJSON(){
-	return THREE.Material.prototype.toJSON.call(this, undefined, this._serializationManager.serialize.bind(this._serializationManager))
+	var res = THREE.Material.prototype.toJSON.call(
+		this, 
+		undefined, 
+		this._serializationManager.serialize.bind(this._serializationManager)
+	)
+	this._serializationManager.afterSerialize.call(this._serializationManager,res)
+	return res
 }
 
 // from three's texture transform api, to be applied to a uniform matrix
@@ -349,6 +355,7 @@ function decorateMaterialWithSimpleInstancing( material ) {
 
 function SerializationManager(){
 	this.processFunctions = []
+	this.afterFunctions = []
 }
 
 SerializationManager.prototype = {
@@ -358,5 +365,11 @@ SerializationManager.prototype = {
 	serialize(data, meta){
 		this.processFunctions.forEach(f=>f(data))
 		return data
+	},
+	afterSerialize(data){
+		this.afterFunctions.forEach(f=>f(data))
+	},
+	addAfterFunction: function( func ){
+		this.afterFunctions.push(func)
 	}
 }

--- a/examples/js/SpecGlossMultiUVInstanceExample.js
+++ b/examples/js/SpecGlossMultiUVInstanceExample.js
@@ -88,13 +88,17 @@ function decorateMaterialWithSpecGloss( material ) {
 		specularMap: { value: null, type: 'sampler2D', stage: 'fragment' },
 	};
 
+	var shaderIncludes = Object.assign({},SHADER_INCLUDES_SPEC_GLOSS)
+
 	var defines = {USE_GLOSSINESSMAP: ''}
 
 	//conflicts could be resolved here
 	addOrMergeProp( material, 'shaderUniforms', shaderUniforms );
-	addOrMergeProp( material, 'shaderIncludes', SHADER_INCLUDES_SPEC_GLOSS );
+	addOrMergeProp( material, 'shaderIncludes', shaderIncludes );
 	addOrMergeProp( material, 'defines', defines );
 
+	delete material.metalnessMap
+	delete material.roughnessMap
 
 	//expose uniforms as props for a cleaner interface (but shaderUniforms is also available so this can be omitted)
 	//it just leads to a cleaner more familiar interface (PhongMaterial has specularMap, so this now has it too)
@@ -195,17 +199,10 @@ function addMapTransformPropsToMaterial( material, mapName ){
 
 
 function decorateMaterialWithPerMapTransforms( material, mapList ) {
-
+	
 	if ( material.isPerMapTransformExtended ) return material;
 
 	material.isPerMapTransformExtended = true;
-
-	//this could be more generic, say, check if the chunks belonging to these maps have been altered
-	//but also knowing about the other extension, makes for an easy check
-	if( material.isSpecGlossExtended){
-		delete material.metalnessMap //remove the unused map names so the loop below doesnt account for them (conflict)
-		delete material.roughnessMap
-	}
 
 	//one can provide a subset from outside
 	mapList = mapList || DEFAULT_MAP_LIST;

--- a/examples/js/SpecGlossMultiUVInstanceExample.js
+++ b/examples/js/SpecGlossMultiUVInstanceExample.js
@@ -49,7 +49,7 @@ var glossinessMapFragmentChunk = [
 	'#ifdef USE_GLOSSINESSMAP',
 	'	vec4 texelGlossiness = texture2D( glossinessMap, vUv );',
 	'	// reads channel A, compatible with a glTF Specular-Glossiness (RGBA) texture',
-	'	glossinessFactor *= texelGlossiness.r;',
+	'	glossinessFactor *= texelGlossiness.a;',
 	// 'gl_FragColor = vec4(vec3(glossinessFactor),1.);',
 	// 'return;',
 	'#endif',

--- a/examples/js/SpecGlossMultiUVInstanceExample.js
+++ b/examples/js/SpecGlossMultiUVInstanceExample.js
@@ -1,0 +1,220 @@
+// some utils
+
+function addOrMergeProp( material, propName, data ) {
+
+	if ( material[ propName ] ) {
+
+		Object.assign( material[ propName ], data );
+
+	} else {
+
+		material[ propName ] = data;
+
+	}
+
+}
+
+// from three's texture transform api, to be applied to a uniform matrix
+function setUvTransform( tx, ty, sx, sy, rotation, cx, cy ) {
+
+	var c = Math.cos( rotation );
+	var s = Math.sin( rotation );
+
+	this.set(
+		sx * c, sx * s, - sx * ( c * cx + s * cy ) + cx + tx,
+		- sy * s, sy * c, - sy * ( - s * cx + c * cy ) + cy + ty,
+		0, 0, 0
+	);
+
+}
+
+//spec gloss stuff ---------------------------------------------------------
+
+//this extends the shader to use specular gloss PBR model instead of rough/metal
+
+var specularMapFragmentChunk = [
+	'vec3 specularFactor = specular;',
+	'#ifdef USE_SPECULARMAP',
+	'	vec4 texelSpecular = texture2D( specularMap, vUv );',
+	'	texelSpecular = sRGBToLinear( texelSpecular );',
+	'	// reads channel RGB, compatible with a glTF Specular-Glossiness (RGBA) texture',
+	'	specularFactor *= texelSpecular.rgb;',
+	'#endif',
+	// 'gl_FragColor = vec4(vec3(specularFactor),1.);',
+	// 'return;',
+].join( '\n' );
+
+var glossinessMapFragmentChunk = [
+	'float glossinessFactor = glossiness;',
+	'#ifdef USE_GLOSSINESSMAP',
+	'	vec4 texelGlossiness = texture2D( glossinessMap, vUv );',
+	'	// reads channel A, compatible with a glTF Specular-Glossiness (RGBA) texture',
+	'	glossinessFactor *= texelGlossiness.r;',
+	// 'gl_FragColor = vec4(vec3(glossinessFactor),1.);',
+	// 'return;',
+	'#endif',
+].join( '\n' );
+
+var lightPhysicalFragmentChunk = [
+	'PhysicalMaterial material;',
+	'material.diffuseColor = diffuseColor.rgb;',
+	'material.specularRoughness = clamp( 1.0 - glossinessFactor, 0.04, 1.0 );',
+	'material.specularColor = specularFactor.rgb;',
+].join( '\n' );
+
+var SHADER_INCLUDES_SPEC_GLOSS = {
+	roughnessmap_fragment: specularMapFragmentChunk,
+	metalnessmap_fragment: glossinessMapFragmentChunk,
+	lights_physical_fragment: lightPhysicalFragmentChunk,
+};
+
+function decorateMaterialWithSpecGloss( material ) {
+
+	if ( material.isSpecGlossExtended ) return material;
+
+	material.isSpecGlossExtended = true;
+
+	var shaderUniforms = {
+		specular: { value: new THREE.Color().setHex( 0xffffff ), type: 'vec3', stage: 'fragment' }, //fragment can be ommitted (defaults to it) but for sake of clarity
+		glossiness: { value: 1, type: 'float', stage: 'fragment' },
+		glossinessMap: { value: null, type: 'sampler2D', stage: 'fragment' },
+		specularMap: { value: null, type: 'sampler2D', stage: 'fragment' },
+	};
+
+	var defines = {USE_GLOSSINESSMAP: ''}
+
+	//conflicts could be resolved here
+	addOrMergeProp( material, 'shaderUniforms', shaderUniforms );
+	addOrMergeProp( material, 'shaderIncludes', SHADER_INCLUDES_SPEC_GLOSS );
+	addOrMergeProp( material, 'defines', defines );
+
+	console.log(material.shaderUniforms)
+	console.log(material.shaderIncludes)
+	//expose uniforms as props for a cleaner interface (but shaderUniforms is also available so this can be omitted)
+	for ( let propName in shaderUniforms ) {
+
+		Object.defineProperty( material, propName, {
+			get: ()=> shaderUniforms[ propName ].value,
+			set: ( v )=> (shaderUniforms[ propName ].value = v),
+		} );
+
+	}
+
+}
+
+// multi uv stuff ---------------------------------------------------------
+
+// this moves the transform from textures to the material, textures become just data
+
+//list of maps to be extended, these are easy
+var DEFAULT_MAP_LIST = [
+	'alphaMap',
+	'specularMap',
+	'map',
+	'emissiveMap',
+	'metalnessMap',
+	'roughnessMap',
+	'glossinessMap' //this one is from the other example, but if its there it should work, this can be solved to work together somehow
+];
+
+//this can be programatic
+var PROP_TO_CHUNK_MAP = {
+	'alphaMap': 'alphamap_fragment',
+	'specularMap': 'specularmap_fragment',
+	'map': 'map_fragment',
+	'emissiveMap': 'emissivemap_fragment',
+	'metalnessMap': 'metalnessmap_fragment',
+	'roughnessMap': 'roughnessmap_fragment',
+	'glossinessMap': 'metalnessmap_fragment', //this one cant be programatic because it belongs to another override, could be a specific check somewhere else
+	'specularMapGloss': 'roughnessmap_fragment',
+};
+
+//some utils
+
+var mapRegex = /texture2D\( (.*Map|map), vUv \)/gm //look for this
+
+function getReplaceString(mapName){
+	return `texture2D( $1, ( ${getUniformNameFromProp(mapName)} * vec3( vUv, 1. ) ).xy )`
+}
+
+
+function getUniformNameFromProp(prop){
+	return `u_${prop}Transform`
+}
+
+function addMapTransformPropsToMaterial( material, mapName ){
+
+	let _mapName = mapName
+	material[`${mapName}Repeat`] = new THREE.Vector2(1,1)
+	material[`${mapName}Offset`] = new THREE.Vector2()
+	material[`${mapName}Center`] = new THREE.Vector2()
+	material[`${mapName}Rotation`] = 0
+	material[`${mapName}UpdateMatrix`] = function(){
+		this.shaderUniforms[getUniformNameFromProp(_mapName)].value
+		.setUvTransform(
+			this[`${_mapName}Offset`].x,
+			this[`${_mapName}Offset`].y, 
+			this[`${_mapName}Repeat`].x,
+			this[`${_mapName}Repeat`].y, 
+			this[`${_mapName}Rotation`], 
+			this[`${_mapName}Center`].x,
+			this[`${_mapName}Center`].y, 
+		)
+	}.bind(material)
+}
+
+
+function decorateMaterialWithPerMapTransforms( material, mapList ) {
+
+	if ( material.isPerMapTransformExtended ) return material;
+
+	material.isPerMapTransformExtended = true;
+
+	delete material.metalnessMap
+	delete material.roughnessMap
+
+	mapList = mapList || DEFAULT_MAP_LIST;
+
+	var shaderUniforms = {}
+	var shaderIncludes = {}
+
+	for ( var i = 0; i < mapList.length; i ++ ) {
+
+		var mapName = mapList[ i ];
+
+		addMapTransformPropsToMaterial(material, mapName)
+
+		if ( material[ mapName ] !== undefined ) {
+
+			var uniform = { value: new THREE.Matrix3(), type:'mat3', stage: 'fragment' };
+			uniform.value.setUvTransform = setUvTransform.bind( uniform.value );
+
+			shaderUniforms[getUniformNameFromProp(mapName)] = uniform
+
+			var lookup = mapName
+			if( material.isSpecGlossExtended && mapName === 'specularMap'){
+				lookup = 'specularMapGloss' 
+			}
+
+			var chunkName = PROP_TO_CHUNK_MAP[lookup]
+
+			console.log('chunkName',chunkName)
+
+			console.log('ownChunk?',(material.shaderIncludes && material.shaderIncludes[chunkName]))
+
+			console.log(mapName)
+
+			var shaderChunk = (material.shaderIncludes && material.shaderIncludes[chunkName]) || THREE.ShaderChunk[chunkName]
+
+			shaderChunk = shaderChunk.replace( mapRegex , getReplaceString(mapName) )
+
+			shaderIncludes[ chunkName ] = shaderChunk
+
+		}
+
+	}
+
+	addOrMergeProp( material, 'shaderUniforms', shaderUniforms );
+	addOrMergeProp( material, 'shaderIncludes', shaderIncludes );
+
+}

--- a/examples/js/SpecGlossMultiUVInstanceExample.js
+++ b/examples/js/SpecGlossMultiUVInstanceExample.js
@@ -371,7 +371,7 @@ SerializationManager.prototype = {
 		this.processFunctions.push(func)
 	},
 	serialize(data, meta){
-		this.processFunctions.forEach(f=>f(data))
+		this.processFunctions.forEach(f=>f(data,meta))
 		return data
 	},
 	afterSerialize(data){

--- a/examples/js/SpecGlossMultiUVInstanceExample.js
+++ b/examples/js/SpecGlossMultiUVInstanceExample.js
@@ -277,13 +277,21 @@ function decorateMaterialWithPerMapTransforms( material, mapList ) {
 		return data
 
 	}).bind(material))
+
+
+	material._serializationManager.addAfterFunction(
+		function( data ){
+			delete data.roughnessMap
+			delete data.roughness
+			delete data.metalnessMap
+			delete data.metalness	
+		}
+	)
 	
 	material.toJSON = toJSON.bind(material)
 
 	return material
 }
-
-
 
 // simple instance stuff from lambert example  ---------------------------------------------------------
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -565,29 +565,15 @@ THREE.GLTFLoader = ( function () {
 
 			getMaterialType: function () {
 
-				return THREE.ShaderMaterial;
+				// return THREE.ShaderMaterial;
+				// return THREE.MeshStandardMaterial
+				return 'SPEC_GLOSS';
 
 			},
 
 			extendParams: function ( params, material, parser ) {
 
 				var pbrSpecularGlossiness = material.extensions[ this.name ];
-
-				var shader = THREE.ShaderLib[ 'standard' ];
-
-				var uniforms = THREE.UniformsUtils.clone( shader.uniforms );
-
-				var specularMapParsFragmentChunk = [
-					'#ifdef USE_SPECULARMAP',
-					'	uniform sampler2D specularMap;',
-					'#endif'
-				].join( '\n' );
-
-				var glossinessMapParsFragmentChunk = [
-					'#ifdef USE_GLOSSINESSMAP',
-					'	uniform sampler2D glossinessMap;',
-					'#endif'
-				].join( '\n' );
 
 				var specularMapFragmentChunk = [
 					'vec3 specularFactor = specular;',
@@ -615,29 +601,18 @@ THREE.GLTFLoader = ( function () {
 					'material.specularColor = specularFactor.rgb;',
 				].join( '\n' );
 
-				var fragmentShader = shader.fragmentShader
-					.replace( 'uniform float roughness;', 'uniform vec3 specular;' )
-					.replace( 'uniform float metalness;', 'uniform float glossiness;' )
-					.replace( '#include <roughnessmap_pars_fragment>', specularMapParsFragmentChunk )
-					.replace( '#include <metalnessmap_pars_fragment>', glossinessMapParsFragmentChunk )
-					.replace( '#include <roughnessmap_fragment>', specularMapFragmentChunk )
-					.replace( '#include <metalnessmap_fragment>', glossinessMapFragmentChunk )
-					.replace( '#include <lights_physical_fragment>', lightPhysicalFragmentChunk );
+				params.shaderUniforms = {
+					specular: { value: new THREE.Color().setHex( 0x111111 ), type: 'vec3' }, //atm these end up in both vert and frag :/
+					glossiness: { value: 0.5, type: 'float' },
+					glossinessMap: { value: null, type: 'sampler2D' },
+					specularMap: { value: null, type: 'sampler2D' },
+				};
 
-				delete uniforms.roughness;
-				delete uniforms.metalness;
-				delete uniforms.roughnessMap;
-				delete uniforms.metalnessMap;
-
-				uniforms.specular = { value: new THREE.Color().setHex( 0x111111 ) };
-				uniforms.glossiness = { value: 0.5 };
-				uniforms.specularMap = { value: null };
-				uniforms.glossinessMap = { value: null };
-
-				params.vertexShader = shader.vertexShader;
-				params.fragmentShader = fragmentShader;
-				params.uniforms = uniforms;
-				params.defines = { 'STANDARD': '' };
+				params.shaderIncludes = {
+					roughnessmap_fragment: specularMapFragmentChunk,
+					metalnessmap_fragment: glossinessMapFragmentChunk,
+					lights_physical_fragment: lightPhysicalFragmentChunk,
+				};
 
 				params.color = new THREE.Color( 1.0, 1.0, 1.0 );
 				params.opacity = 1.0;
@@ -683,18 +658,16 @@ THREE.GLTFLoader = ( function () {
 
 			createMaterial: function ( params ) {
 
-				// setup material properties based on MeshStandardMaterial for Specular-Glossiness
-
-				var material = new THREE.ShaderMaterial( {
-					defines: params.defines,
-					vertexShader: params.vertexShader,
-					fragmentShader: params.fragmentShader,
-					uniforms: params.uniforms,
+				var material = new THREE.MeshStandardMaterial( {
 					fog: true,
-					lights: true,
 					opacity: params.opacity,
 					transparent: params.transparent
 				} );
+
+				console.log( material );
+
+				material.shaderIncludes = params.shaderIncludes;
+				material.shaderUniforms = params.shaderUniforms;
 
 				material.isGLTFSpecularGlossinessMaterial = true;
 
@@ -722,11 +695,23 @@ THREE.GLTFLoader = ( function () {
 				material.displacementScale = 1;
 				material.displacementBias = 0;
 
-				material.specularMap = params.specularMap === undefined ? null : params.specularMap;
-				material.specular = params.specular;
+				if ( params.specularMap ) {
 
-				material.glossinessMap = params.glossinessMap === undefined ? null : params.glossinessMap;
-				material.glossiness = params.glossiness;
+					material.shaderUniforms.specularMap.value = params.glossinessMap;
+					material.defines.USE_SPECULARMAP = '';
+
+				}
+
+				material.shaderUniforms.specular.value = params.specular;
+
+				if ( params.glossinessMap ) {
+
+					material.shaderUniforms.glossinessMap.value = params.glossinessMap;
+					material.defines.USE_GLOSSINESSMAP = '';
+
+				}
+
+				material.shaderUniforms.glossiness.value = params.glossiness;
 
 				material.alphaMap = null;
 
@@ -734,8 +719,6 @@ THREE.GLTFLoader = ( function () {
 				material.envMapIntensity = 1.0;
 
 				material.refractionRatio = 0.98;
-
-				material.extensions.derivatives = true;
 
 				return material;
 
@@ -771,156 +754,12 @@ THREE.GLTFLoader = ( function () {
 
 			},
 
-			// Here's based on refreshUniformsCommon() and refreshUniformsStandard() in WebGLRenderer.
-			refreshUniforms: function ( renderer, scene, camera, geometry, material, group ) {
-
-				if ( material.isGLTFSpecularGlossinessMaterial !== true ) {
-
-					return;
-
-				}
-
-				var uniforms = material.uniforms;
-				var defines = material.defines;
-
-				uniforms.opacity.value = material.opacity;
-
-				uniforms.diffuse.value.copy( material.color );
-				uniforms.emissive.value.copy( material.emissive ).multiplyScalar( material.emissiveIntensity );
-
-				uniforms.map.value = material.map;
-				uniforms.specularMap.value = material.specularMap;
-				uniforms.alphaMap.value = material.alphaMap;
-
-				uniforms.lightMap.value = material.lightMap;
-				uniforms.lightMapIntensity.value = material.lightMapIntensity;
-
-				uniforms.aoMap.value = material.aoMap;
-				uniforms.aoMapIntensity.value = material.aoMapIntensity;
-
-				// uv repeat and offset setting priorities
-				// 1. color map
-				// 2. specular map
-				// 3. normal map
-				// 4. bump map
-				// 5. alpha map
-				// 6. emissive map
-
-				var uvScaleMap;
-
-				if ( material.map ) {
-
-					uvScaleMap = material.map;
-
-				} else if ( material.specularMap ) {
-
-					uvScaleMap = material.specularMap;
-
-				} else if ( material.displacementMap ) {
-
-					uvScaleMap = material.displacementMap;
-
-				} else if ( material.normalMap ) {
-
-					uvScaleMap = material.normalMap;
-
-				} else if ( material.bumpMap ) {
-
-					uvScaleMap = material.bumpMap;
-
-				} else if ( material.glossinessMap ) {
-
-					uvScaleMap = material.glossinessMap;
-
-				} else if ( material.alphaMap ) {
-
-					uvScaleMap = material.alphaMap;
-
-				} else if ( material.emissiveMap ) {
-
-					uvScaleMap = material.emissiveMap;
-
-				}
-
-				if ( uvScaleMap !== undefined ) {
-
-					// backwards compatibility
-					if ( uvScaleMap.isWebGLRenderTarget ) {
-
-						uvScaleMap = uvScaleMap.texture;
-
-					}
-
-					var offset;
-					var repeat;
-
-					if ( uvScaleMap.matrix !== undefined ) {
-
-						// > r88.
-
-						if ( uvScaleMap.matrixAutoUpdate === true ) {
-
-							offset = uvScaleMap.offset;
-							repeat = uvScaleMap.repeat;
-							var rotation = uvScaleMap.rotation;
-							var center = uvScaleMap.center;
-
-							uvScaleMap.matrix.setUvTransform( offset.x, offset.y, repeat.x, repeat.y, rotation, center.x, center.y );
-
-						}
-
-						uniforms.uvTransform.value.copy( uvScaleMap.matrix );
-
-					} else {
-
-						// <= r87. Remove when reasonable.
-
-						offset = uvScaleMap.offset;
-						repeat = uvScaleMap.repeat;
-
-						uniforms.offsetRepeat.value.set( offset.x, offset.y, repeat.x, repeat.y );
-
-					}
-
-				}
-
-				uniforms.envMap.value = material.envMap;
-				uniforms.envMapIntensity.value = material.envMapIntensity;
-				uniforms.flipEnvMap.value = ( material.envMap && material.envMap.isCubeTexture ) ? - 1 : 1;
-
-				uniforms.refractionRatio.value = material.refractionRatio;
-
-				uniforms.specular.value.copy( material.specular );
-				uniforms.glossiness.value = material.glossiness;
-
-				uniforms.glossinessMap.value = material.glossinessMap;
-
-				uniforms.emissiveMap.value = material.emissiveMap;
-				uniforms.bumpMap.value = material.bumpMap;
-				uniforms.normalMap.value = material.normalMap;
-
-				uniforms.displacementMap.value = material.displacementMap;
-				uniforms.displacementScale.value = material.displacementScale;
-				uniforms.displacementBias.value = material.displacementBias;
-
-				if ( uniforms.glossinessMap.value !== null && defines.USE_GLOSSINESSMAP === undefined ) {
-
-					defines.USE_GLOSSINESSMAP = '';
-					// set USE_ROUGHNESSMAP to enable vUv
-					defines.USE_ROUGHNESSMAP = '';
-
-				}
-
-				if ( uniforms.glossinessMap.value === null && defines.USE_GLOSSINESSMAP !== undefined ) {
-
-					delete defines.USE_GLOSSINESSMAP;
-					delete defines.USE_ROUGHNESSMAP;
-
-				}
-
+			refreshUniforms: function () {
+				/*NOOP*/
 			}
 
 		};
+
 
 	}
 
@@ -2219,8 +2058,8 @@ THREE.GLTFLoader = ( function () {
 		return Promise.all( pending ).then( function () {
 
 			var material;
-
-			if ( materialType === THREE.ShaderMaterial ) {
+			// if ( materialType === THREE.ShaderMaterial ) {
+			if ( materialType === 'SPEC_GLOSS' ) {
 
 				material = extensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ].createMaterial( materialParams );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -623,8 +623,6 @@ THREE.GLTFLoader = ( function () {
 					transparent: params.transparent
 				} );
 
-				console.log( material );
-
 				decorateMaterialWithSpecGloss( material );
 
 				material.isGLTFSpecularGlossinessMaterial = true;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -625,7 +625,7 @@ THREE.GLTFLoader = ( function () {
 
 				console.log( material );
 
-				decorateMaterialWithSpecGloss(material)
+				decorateMaterialWithSpecGloss( material );
 
 				material.isGLTFSpecularGlossinessMaterial = true;
 

--- a/examples/serializedResult.json
+++ b/examples/serializedResult.json
@@ -11,7 +11,7 @@
   },
   "glossiness": 1,
   "specular": 16777215,
-  "glossinessMap": "4CBD81D6-6DEC-4B13-8B9A-3109D205B518",
+  "glossinessMap": "2B8CE6E5-7846-4D84-B4BE-3D4211AE2BBA",
   "alphaMapRepeat": [
     1,
     1
@@ -77,19 +77,19 @@
     0
   ],
   "glossinessMapRotation": 0,
-  "uuid": "55437FF3-5A86-463E-8C5E-9E8F5290F92F",
+  "uuid": "B1168031-2FEB-4362-BFF5-04D2B366BA17",
   "type": "MeshStandardMaterial",
   "color": 16758090,
   "emissive": 0,
-  "map": "4CBD81D6-6DEC-4B13-8B9A-3109D205B518",
-  "specularMap": "4CBD81D6-6DEC-4B13-8B9A-3109D205B518",
-  "envMap": "32AA12E2-017E-42CA-90C4-483B95D456A5",
+  "map": "2B8CE6E5-7846-4D84-B4BE-3D4211AE2BBA",
+  "specularMap": "2B8CE6E5-7846-4D84-B4BE-3D4211AE2BBA",
+  "envMap": "58FDD3E2-882B-4F66-B4E2-BAE2C367595C",
   "depthFunc": 3,
   "depthTest": true,
   "depthWrite": true,
   "textures": [
     {
-      "uuid": "4CBD81D6-6DEC-4B13-8B9A-3109D205B518",
+      "uuid": "2B8CE6E5-7846-4D84-B4BE-3D4211AE2BBA",
       "name": "texture",
       "mapping": 300,
       "repeat": [
@@ -114,10 +114,10 @@
       "magFilter": 1006,
       "anisotropy": 1,
       "flipY": true,
-      "image": "FB5A325A-5CAA-47E7-921D-2A56C672CFCE"
+      "image": "B440D9F5-D47E-40D1-B912-DBFF0AE719AE"
     },
     {
-      "uuid": "32AA12E2-017E-42CA-90C4-483B95D456A5",
+      "uuid": "58FDD3E2-882B-4F66-B4E2-BAE2C367595C",
       "name": "envMap",
       "mapping": 305,
       "repeat": [
@@ -142,15 +142,15 @@
       "magFilter": 1006,
       "anisotropy": 1,
       "flipY": true,
-      "image": "F9CB0870-83F8-4762-961E-191FF7685340"
+      "image": "14DDC238-F4C1-4D89-AED5-597BD2927B84"
     }
   ],
   "images": [
     {
-      "uuid": "FB5A325A-5CAA-47E7-921D-2A56C672CFCE",
+      "uuid": "B440D9F5-D47E-40D1-B912-DBFF0AE719AE",
     },
     {
-      "uuid": "F9CB0870-83F8-4762-961E-191FF7685340",
+      "uuid": "14DDC238-F4C1-4D89-AED5-597BD2927B84",
     }
   ]
 }

--- a/examples/serializedResult.json
+++ b/examples/serializedResult.json
@@ -1,190 +1,84 @@
 {
-  "alphaMapCenter": [
-    0,
-    0
-  ],
-  "alphaMapOffset": [
-    0,
-    0
-  ],
-  "alphaMapRepeat": [
-    1,
-    1
-  ],
-  "alphaMapRotation": 0,
+  "metadata": {
+    "version": 4.5,
+    "type": "Material",
+    "generator": "Material.toJSON"
+  },
+  "uuid": "61C0257B-17C3-45C6-AEB9-F603A1CA19E7",
+  "type": "MeshStandardMaterial",
   "color": 16758090,
+  "emissive": 0,
+  "specular": 16777215,
+  "map": "F0B81796-573E-40F8-B7DA-02245A073DF9",
+  "specularMap": "F0B81796-573E-40F8-B7DA-02245A073DF9",
+  "envMap": "1E99684C-AE4B-40EF-83CC-83A50FFD6A30",
   "depthFunc": 3,
   "depthTest": true,
   "depthWrite": true,
-  "emissive": 0,
-  "emissiveMapCenter": [
-    0,
-    0
-  ],
-  "emissiveMapOffset": [
-    0,
-    0
-  ],
-  "emissiveMapRepeat": [
-    1,
-    1
-  ],
-  "emissiveMapRotation": 0,
-  "envMap": "A78E1632-2AD0-438A-9571-D983C8491B1B",
-  "glossiness": 1,
-  "glossinessMap": {
-    "anisotropy": 1,
-    "center": [
-      0,
-      0
-    ],
-    "flipY": true,
-    "format": 1022,
-    "image": "D440D3C6-6D2A-44C3-ACE4-BC97CE407957",
-    "magFilter": 1006,
-    "mapping": 300,
-    "metadata": {
-      "generator": "Texture.toJSON",
-      "type": "Texture",
-      "version": 4.5
-    },
-    "minFilter": 1008,
-    "name": "texture",
-    "offset": [
-      0,
-      0
-    ],
-    "repeat": [
-      1,
-      1
-    ],
-    "rotation": 0,
-    "uuid": "0E08FCFE-5FC4-4343-8137-97B8781A33B9",
-    "wrap": [
-      1000,
-      1000
-    ]
-  },
-  "glossinessMapCenter": [
-    0,
-    0
-  ],
-  "glossinessMapOffset": [
-    0,
-    0
-  ],
-  "glossinessMapRepeat": [
-    1,
-    1
-  ],
-  "glossinessMapRotation": 0,
-  "images": [
-    {
-      "url": "...",
-      "uuid": "D440D3C6-6D2A-44C3-ACE4-BC97CE407957"
-    },
-    {
-      "url": "...",
-       "uuid": "414A29DF-CA45-4364-902F-B2369E673083"
-    }
-  ],
-  "map": "0E08FCFE-5FC4-4343-8137-97B8781A33B9",
-  "mapCenter": [
-    0,
-    0
-  ],
-  "mapOffset": [
-    0,
-    0
-  ],
-  "mapRepeat": [
-    1,
-    1
-  ],
-  "mapRotation": 0,
-  "metadata": {
-    "extensions": {
-      "isPerMapTransformExtended": true,
-      "isSimpleInstanceExtended": true,
-      "isSpecGlossExtended": true
-    },
-    "generator": "Material.toJSON",
-    "type": "Material",
-    "version": 4.5
-  },
-  "specular": 16777215,
-  "specularMap": "0E08FCFE-5FC4-4343-8137-97B8781A33B9",
-  "specularMapCenter": [
-    0,
-    0
-  ],
-  "specularMapOffset": [
-    0,
-    0
-  ],
-  "specularMapRepeat": [
-    1,
-    1
-  ],
-  "specularMapRotation": 0,
   "textures": [
     {
-      "anisotropy": 1,
-      "center": [
-        0,
-        0
-      ],
-      "flipY": true,
-      "format": 1022,
-      "image": "D440D3C6-6D2A-44C3-ACE4-BC97CE407957",
-      "magFilter": 1006,
-      "mapping": 300,
-      "minFilter": 1008,
+      "uuid": "F0B81796-573E-40F8-B7DA-02245A073DF9",
       "name": "texture",
-      "offset": [
-        0,
-        0
-      ],
+      "mapping": 300,
       "repeat": [
         1,
         1
       ],
+      "offset": [
+        0,
+        0
+      ],
+      "center": [
+        0,
+        0
+      ],
       "rotation": 0,
-      "uuid": "0E08FCFE-5FC4-4343-8137-97B8781A33B9",
       "wrap": [
         1000,
         1000
-      ]
+      ],
+      "format": 1022,
+      "minFilter": 1008,
+      "magFilter": 1006,
+      "anisotropy": 1,
+      "flipY": true,
+      "image": "87D4C31C-6983-48D4-961A-FACDA45DB7AC"
     },
     {
-      "anisotropy": 1,
-      "center": [
-        0,
-        0
-      ],
-      "flipY": true,
-      "format": 1022,
-      "image": "414A29DF-CA45-4364-902F-B2369E673083",
-      "magFilter": 1006,
-      "mapping": 305,
-      "minFilter": 1008,
+      "uuid": "1E99684C-AE4B-40EF-83CC-83A50FFD6A30",
       "name": "envMap",
-      "offset": [
-        0,
-        0
-      ],
+      "mapping": 305,
       "repeat": [
         1,
         1
       ],
+      "offset": [
+        0,
+        0
+      ],
+      "center": [
+        0,
+        0
+      ],
       "rotation": 0,
-      "uuid": "A78E1632-2AD0-438A-9571-D983C8491B1B",
       "wrap": [
         1001,
         1001
-      ]
+      ],
+      "format": 1022,
+      "minFilter": 1008,
+      "magFilter": 1006,
+      "anisotropy": 1,
+      "flipY": true,
+      "image": "678F6BAE-A377-49D5-A59E-A9BCDE5AE472"
     }
   ],
-  "type": "MeshStandardMaterial",
-  "uuid": "AC55A38A-DAD4-4BD7-861A-87ADB212871F"
+  "images": [
+    {
+      "uuid": "87D4C31C-6983-48D4-961A-FACDA45DB7AC",
+      },
+    {
+      "uuid": "678F6BAE-A377-49D5-A59E-A9BCDE5AE472",
+    }
+  ]
 }

--- a/examples/serializedResult.json
+++ b/examples/serializedResult.json
@@ -1,0 +1,190 @@
+{
+  "alphaMapCenter": [
+    0,
+    0
+  ],
+  "alphaMapOffset": [
+    0,
+    0
+  ],
+  "alphaMapRepeat": [
+    1,
+    1
+  ],
+  "alphaMapRotation": 0,
+  "color": 16758090,
+  "depthFunc": 3,
+  "depthTest": true,
+  "depthWrite": true,
+  "emissive": 0,
+  "emissiveMapCenter": [
+    0,
+    0
+  ],
+  "emissiveMapOffset": [
+    0,
+    0
+  ],
+  "emissiveMapRepeat": [
+    1,
+    1
+  ],
+  "emissiveMapRotation": 0,
+  "envMap": "A78E1632-2AD0-438A-9571-D983C8491B1B",
+  "glossiness": 1,
+  "glossinessMap": {
+    "anisotropy": 1,
+    "center": [
+      0,
+      0
+    ],
+    "flipY": true,
+    "format": 1022,
+    "image": "D440D3C6-6D2A-44C3-ACE4-BC97CE407957",
+    "magFilter": 1006,
+    "mapping": 300,
+    "metadata": {
+      "generator": "Texture.toJSON",
+      "type": "Texture",
+      "version": 4.5
+    },
+    "minFilter": 1008,
+    "name": "texture",
+    "offset": [
+      0,
+      0
+    ],
+    "repeat": [
+      1,
+      1
+    ],
+    "rotation": 0,
+    "uuid": "0E08FCFE-5FC4-4343-8137-97B8781A33B9",
+    "wrap": [
+      1000,
+      1000
+    ]
+  },
+  "glossinessMapCenter": [
+    0,
+    0
+  ],
+  "glossinessMapOffset": [
+    0,
+    0
+  ],
+  "glossinessMapRepeat": [
+    1,
+    1
+  ],
+  "glossinessMapRotation": 0,
+  "images": [
+    {
+      "url": "...",
+      "uuid": "D440D3C6-6D2A-44C3-ACE4-BC97CE407957"
+    },
+    {
+      "url": "...",
+       "uuid": "414A29DF-CA45-4364-902F-B2369E673083"
+    }
+  ],
+  "map": "0E08FCFE-5FC4-4343-8137-97B8781A33B9",
+  "mapCenter": [
+    0,
+    0
+  ],
+  "mapOffset": [
+    0,
+    0
+  ],
+  "mapRepeat": [
+    1,
+    1
+  ],
+  "mapRotation": 0,
+  "metadata": {
+    "extensions": {
+      "isPerMapTransformExtended": true,
+      "isSimpleInstanceExtended": true,
+      "isSpecGlossExtended": true
+    },
+    "generator": "Material.toJSON",
+    "type": "Material",
+    "version": 4.5
+  },
+  "specular": 16777215,
+  "specularMap": "0E08FCFE-5FC4-4343-8137-97B8781A33B9",
+  "specularMapCenter": [
+    0,
+    0
+  ],
+  "specularMapOffset": [
+    0,
+    0
+  ],
+  "specularMapRepeat": [
+    1,
+    1
+  ],
+  "specularMapRotation": 0,
+  "textures": [
+    {
+      "anisotropy": 1,
+      "center": [
+        0,
+        0
+      ],
+      "flipY": true,
+      "format": 1022,
+      "image": "D440D3C6-6D2A-44C3-ACE4-BC97CE407957",
+      "magFilter": 1006,
+      "mapping": 300,
+      "minFilter": 1008,
+      "name": "texture",
+      "offset": [
+        0,
+        0
+      ],
+      "repeat": [
+        1,
+        1
+      ],
+      "rotation": 0,
+      "uuid": "0E08FCFE-5FC4-4343-8137-97B8781A33B9",
+      "wrap": [
+        1000,
+        1000
+      ]
+    },
+    {
+      "anisotropy": 1,
+      "center": [
+        0,
+        0
+      ],
+      "flipY": true,
+      "format": 1022,
+      "image": "414A29DF-CA45-4364-902F-B2369E673083",
+      "magFilter": 1006,
+      "mapping": 305,
+      "minFilter": 1008,
+      "name": "envMap",
+      "offset": [
+        0,
+        0
+      ],
+      "repeat": [
+        1,
+        1
+      ],
+      "rotation": 0,
+      "uuid": "A78E1632-2AD0-438A-9571-D983C8491B1B",
+      "wrap": [
+        1001,
+        1001
+      ]
+    }
+  ],
+  "type": "MeshStandardMaterial",
+  "uuid": "AC55A38A-DAD4-4BD7-861A-87ADB212871F"
+}

--- a/examples/serializedResult.json
+++ b/examples/serializedResult.json
@@ -2,22 +2,94 @@
   "metadata": {
     "version": 4.5,
     "type": "Material",
-    "generator": "Material.toJSON"
+    "generator": "Material.toJSON",
+    "extensions": {
+      "isSpecGlossExtended": true,
+      "isPerMapTransformExtended": true,
+      "isSimpleInstanceExtended": true
+    }
   },
-  "uuid": "61C0257B-17C3-45C6-AEB9-F603A1CA19E7",
+  "glossiness": 1,
+  "specular": 16777215,
+  "glossinessMap": "4CBD81D6-6DEC-4B13-8B9A-3109D205B518",
+  "alphaMapRepeat": [
+    1,
+    1
+  ],
+  "alphaMapOffset": [
+    0,
+    0
+  ],
+  "alphaMapCenter": [
+    0,
+    0
+  ],
+  "alphaMapRotation": 0,
+  "specularMapRepeat": [
+    1,
+    1
+  ],
+  "specularMapOffset": [
+    0,
+    0
+  ],
+  "specularMapCenter": [
+    0,
+    0
+  ],
+  "specularMapRotation": 0,
+  "mapRepeat": [
+    1,
+    1
+  ],
+  "mapOffset": [
+    0,
+    0
+  ],
+  "mapCenter": [
+    0,
+    0
+  ],
+  "mapRotation": 0,
+  "emissiveMapRepeat": [
+    1,
+    1
+  ],
+  "emissiveMapOffset": [
+    0,
+    0
+  ],
+  "emissiveMapCenter": [
+    0,
+    0
+  ],
+  "emissiveMapRotation": 0,
+  "glossinessMapRepeat": [
+    1,
+    1
+  ],
+  "glossinessMapOffset": [
+    0,
+    0
+  ],
+  "glossinessMapCenter": [
+    0,
+    0
+  ],
+  "glossinessMapRotation": 0,
+  "uuid": "55437FF3-5A86-463E-8C5E-9E8F5290F92F",
   "type": "MeshStandardMaterial",
   "color": 16758090,
   "emissive": 0,
-  "specular": 16777215,
-  "map": "F0B81796-573E-40F8-B7DA-02245A073DF9",
-  "specularMap": "F0B81796-573E-40F8-B7DA-02245A073DF9",
-  "envMap": "1E99684C-AE4B-40EF-83CC-83A50FFD6A30",
+  "map": "4CBD81D6-6DEC-4B13-8B9A-3109D205B518",
+  "specularMap": "4CBD81D6-6DEC-4B13-8B9A-3109D205B518",
+  "envMap": "32AA12E2-017E-42CA-90C4-483B95D456A5",
   "depthFunc": 3,
   "depthTest": true,
   "depthWrite": true,
   "textures": [
     {
-      "uuid": "F0B81796-573E-40F8-B7DA-02245A073DF9",
+      "uuid": "4CBD81D6-6DEC-4B13-8B9A-3109D205B518",
       "name": "texture",
       "mapping": 300,
       "repeat": [
@@ -42,10 +114,10 @@
       "magFilter": 1006,
       "anisotropy": 1,
       "flipY": true,
-      "image": "87D4C31C-6983-48D4-961A-FACDA45DB7AC"
+      "image": "FB5A325A-5CAA-47E7-921D-2A56C672CFCE"
     },
     {
-      "uuid": "1E99684C-AE4B-40EF-83CC-83A50FFD6A30",
+      "uuid": "32AA12E2-017E-42CA-90C4-483B95D456A5",
       "name": "envMap",
       "mapping": 305,
       "repeat": [
@@ -70,15 +142,15 @@
       "magFilter": 1006,
       "anisotropy": 1,
       "flipY": true,
-      "image": "678F6BAE-A377-49D5-A59E-A9BCDE5AE472"
+      "image": "F9CB0870-83F8-4762-961E-191FF7685340"
     }
   ],
   "images": [
     {
-      "uuid": "87D4C31C-6983-48D4-961A-FACDA45DB7AC",
-      },
+      "uuid": "FB5A325A-5CAA-47E7-921D-2A56C672CFCE",
+    },
     {
-      "uuid": "678F6BAE-A377-49D5-A59E-A9BCDE5AE472",
+      "uuid": "F9CB0870-83F8-4762-961E-191FF7685340",
     }
   ]
 }

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -49,13 +49,13 @@
 
 		<div id="container"></div>
 
-		<script src="../build/three.js"></script>
-		<script src="js/libs/dat.gui.min.js"></script>
-		<script src="js/controls/OrbitControls.js"></script>
+		<script src="js/three.min.js"></script>
+		<script src="js/dat.gui.min.js"></script>
+		<script src="js/OrbitControls.js"></script>
 		<script src="js/SpecGlossMultiUVInstanceExample.js"></script>
-		<script src="js/loaders/DRACOLoader.js"></script>
-		<script src="js/loaders/DDSLoader.js"></script>
-		<script src="js/loaders/GLTFLoader.js"></script>
+		<script src="js/DRACOLoader.js"></script>
+		<script src="js/DDSLoader.js"></script>
+		<script src="js/GLTFLoader.js"></script>
 
 		<script>
 			var orbitControls;
@@ -381,6 +381,40 @@
 					}
 
 					scene.add( object );
+
+					//---
+					//inline extension example, the material is already extended by GLTFLoader (or not if its not spec/gloss)
+					//but this extension will instance both regular and spec gloss
+					if(sceneInfo.name === 'BoomBox (PBR)'){
+
+						decorateMaterialWithSimpleInstancing(object.children[0].material) //only one line is needed to enable this on the material
+
+						//this is all geometry setup, since it is overlapping with SceneGraphs responsibilities
+						//this could be a higher level interface on a Mesh
+						const size = 64
+						const size_inv = 1/size
+						const instances = size * size
+						const scale = 1
+
+						const instancePositionArray = new Float32Array( instances * 3 )
+						const instanceScaleArray = new Float32Array( instances * 3 )
+						for ( var i = 0, ii = 0 ; i < instances ; i++ ){
+							instanceScaleArray[ii] = 1
+							instancePositionArray[ii++] = ((i % size) * size_inv-0.5) * scale
+							instanceScaleArray[ii] = 1
+							instancePositionArray[ii++] = 0
+							instanceScaleArray[ii] = 1
+							instancePositionArray[ii++] = (Math.floor(i*size_inv) * size_inv-0.5) * scale
+						}
+
+						object.children[0].geometry = new THREE.InstancedBufferGeometry().copy(object.children[0].geometry)
+						object.children[0].geometry.addAttribute( 'instanceOffset', new THREE.InstancedBufferAttribute(instancePositionArray, 3))
+						object.children[0].geometry.addAttribute( 'instanceScale', new THREE.InstancedBufferAttribute(instanceScaleArray, 1))
+						object.children[0].geometry.maxInstancedCount = instances
+						object.children[0].frustumCulled = false
+
+					}
+
 					onWindowResize();
 
 				}, undefined, function ( error ) {

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -52,6 +52,7 @@
 		<script src="../build/three.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
+		<script src="js/SpecGlossMultiUVInstanceExample.js"></script>
 		<script src="js/loaders/DRACOLoader.js"></script>
 		<script src="js/loaders/DDSLoader.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>

--- a/examples/webgl_materials_modified.html
+++ b/examples/webgl_materials_modified.html
@@ -54,7 +54,7 @@
 
 			var camera, scene, renderer, stats;
 
-			var mesh, materialShader;
+			var mesh, material;
 
 			var mouseX = 0;
 			var mouseY = 0;
@@ -75,29 +75,20 @@
 
 				scene = new THREE.Scene();
 
-				var material = new THREE.MeshNormalMaterial();
-				material.onBeforeCompile = function ( shader ) {
+				material = new THREE.MeshNormalMaterial(); //no need to create a uniform at some obscure compile time, it's available now (obsucure because its both onBeforeParse and onBeforeCompile`)
 
-					// console.log( shader )
+				var my_begin_vertex = [ 
+					'float theta = sin( time + position.y ) / 2.0;',
+					'float c = cos( theta );',
+					'float s = sin( theta );',
+					'mat3 m = mat3( c, 0, s, 0, 1, 0, -s, 0, c );',
+					'vec3 transformed = vec3( position ) * m;',
+					'vNormal = vNormal * m;'
+				].join( '\n' );
 
-					shader.uniforms.time = { value: 0 };
+				material.shaderIncludes = { begin_vertex: my_begin_vertex };
 
-					shader.vertexShader = 'uniform float time;\n' + shader.vertexShader;
-					shader.vertexShader = shader.vertexShader.replace(
-						'#include <begin_vertex>',
-						[
-							'float theta = sin( time + position.y ) / 2.0;',
-							'float c = cos( theta );',
-							'float s = sin( theta );',
-							'mat3 m = mat3( c, 0, s, 0, 1, 0, -s, 0, c );',
-							'vec3 transformed = vec3( position ) * m;',
-							'vNormal = vNormal * m;'
-						].join( '\n' )
-					);
-
-					materialShader = shader;
-
-				};
+				material.shaderUniforms = { time: { value: 0, type: 'float' } };
 
 				var loader = new THREE.JSONLoader();
 				loader.load( 'models/json/leeperrysmith/LeePerrySmith.json', function( geometry ) {
@@ -174,11 +165,8 @@
 
 				}
 
-				if ( materialShader ) {
+				material.shaderUniforms.time.value = performance.now() / 1000; //doesnt defer creating the uniform, no need to check
 
-					materialShader.uniforms.time.value = performance.now() / 1000;
-
-				}
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -264,6 +264,10 @@
 				attribute float aIndex;
 				`
 
+				//to make it work with shadows,
+				mesh.customDepthMaterial.shaderIncludes.uv_pars_vertex = material.shaderIncludes.uv_pars_vertex //copy these
+				mesh.customDepthMaterial.shaderIncludes.begin_vertex = material.shaderIncludes.begin_vertex //copy these
+				mesh.customDepthMaterial.shaderUniforms = { uTime: material.shaderUniforms.uTime }//wire this by reference, whenever prop updates material uniform this material updates too by referencing the same uniform
 
 				//test needs update after all of this
 				gui.add(guiData, 'map').onChange(function(val){

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -89,11 +89,6 @@
 				
 				scene.add(light)
 
-				var light = new THREE.DirectionalLight( 0xffffff, 0.4 );
-				light.position.set( -50, 40, 40 );
-				scene.add(light)
-
-
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
@@ -114,9 +109,19 @@
 				var texture = new THREE.TextureLoader().load( `textures/roughness_map.jpg` )
 				texture.wrapS = texture.wrapT = THREE.RepeatWrapping
 
+				var envMap = new THREE.TextureLoader().load( `textures/metal.jpg`, function ( texture ) {
+	
+					texture.mapping = THREE.SphericalReflectionMapping;
+					texture.encoding = THREE.sRGBEncoding;
+					if ( mesh ) mesh.material.needsUpdate = true;
+	
+				} );
+
 				var material = new THREE.MeshStandardMaterial({
 					color: 0xffb54a,
+					envMap: envMap,
 				})
+
 				mesh = new THREE.Mesh(new THREE.SphereBufferGeometry(10), material)
 				scene.add(mesh)
 

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -163,11 +163,11 @@
 				decorateMaterialWithPerMapTransforms(material)
 
 				//results in thse Vector2 and primitev properties being immidiately available
-				gui.add( material.glossinessMapRepeat,'x',0,10).onChange(material.glossinessMapUpdateMatrix)
-				gui.add( material.glossinessMapRepeat,'y',0,10).onChange(material.glossinessMapUpdateMatrix)
-				gui.add( material.glossinessMapOffset,'x',0,1).onChange(material.glossinessMapUpdateMatrix)
-				gui.add( material.glossinessMapOffset,'x',0,1).onChange(material.glossinessMapUpdateMatrix)
-				gui.add( material, 'glossinessMapRotation',0,1).onChange(material.glossinessMapUpdateMatrix)
+				gui.add( material.specularMapRepeat,'x',0,10).onChange(material.specularMapUpdateMatrix)
+				gui.add( material.specularMapRepeat,'y',0,10).onChange(material.specularMapUpdateMatrix)
+				gui.add( material.specularMapOffset,'x',0,1).onChange(material.specularMapUpdateMatrix)
+				gui.add( material.specularMapOffset,'x',0,1).onChange(material.specularMapUpdateMatrix)
+				gui.add( material, 'specularMapRotation',0,1).onChange(material.specularMapUpdateMatrix)
 
 				//instancing
 				

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -49,6 +49,9 @@
 		<script src="js/Detector.js"></script>
 		<script src="js/SpecGlossMultiUVInstanceExample.js"></script>
 
+		<script src="js/loaders/DRACOLoader.js"></script>
+		<script src="js/loaders/DDSLoader.js"></script>
+		<script src="js/loaders/GLTFLoader.js"></script>
 		<script src="js/CurveExtras.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
@@ -59,7 +62,8 @@
 
 			var camera, scene, renderer, stats, clock;
 
-			var mesh, material;
+			var mesh, material, meshGLTF, materialGLTF;
+			var texture, envMap;
 
 			var mouseX = 0;
 			var mouseY = 0;
@@ -70,19 +74,90 @@
 			var windowHalfX = window.innerWidth / 2;
 			var windowHalfY = window.innerHeight / 2;
 
-			var _gui = new dat.GUI()
+			var meshOptions = ['sphere','gltf']
+			var guiData = { 
+				speed: 1, 
+				map: true,
+				currentMesh: meshOptions[0]
+			}
+			var _gui = new dat.GUI() //fix css later
+			var guiArray = []
 
-			var gui = _gui.addFolder('gui')
+			var gui = _gui.addFolder('global')
 			gui.open()
-
-			var guiData = { speed: 1 , map: true}
-
 			gui.add( guiData, 'speed', 0, 5 )
+			gui.add( guiData, 'currentMesh', meshOptions ).onChange(function(value){
+				mesh.visible = value === 'sphere'
+				if(meshGLTF) meshGLTF.visible = value === 'gltf'
+				onChangeGuiMaterial(value==='gltf'?materialGLTF:material)
+			})
 
-			init();
+			// var guiMaterial = _gui.addFolder('material')
+			// guiMaterial.open()
+
+			// var guiTexture = _gui.addFolder('specular map')
+			// guiTexture.open()
+
+			const INSTANCES = 256;
+			var frequency = 32
+			var instanceOffsetAttribute, instanceScaleAttribute
+
+			initScene();
+			initInstanceAttributes();
+			initTexture();
+			initBall();
+			onChangeGuiMaterial(material);
+			loadGLTF();
 			animate();
 
-			function init() {
+			var _gltfTextureMap
+
+			function onChangeGuiMaterial(material){
+				while(guiArray.length){
+					gui.remove(guiArray.pop())
+				}
+				guiArray.push(
+					gui.add( material.specularMapRepeat,'x',0,10)
+					.onChange(material.specularMapUpdateMatrix)
+					.name('repeat.x')
+				)
+				guiArray.push(
+					gui.add( material.specularMapRepeat,'y',0,10)
+					.onChange(material.specularMapUpdateMatrix)
+					.name('repeat.y')
+				)
+				guiArray.push(
+					gui.add( material.specularMapOffset,'x',0,1)
+					.onChange(material.specularMapUpdateMatrix)
+					.name('offset.x')
+				)
+				guiArray.push(
+					gui.add( material.specularMapOffset,'x',0,1)
+					.onChange(material.specularMapUpdateMatrix)
+					.name('offset.y')
+				)
+				guiArray.push(
+					gui.add( material, 'specularMapRotation',0,1)
+					.onChange(material.specularMapUpdateMatrix)
+					.name('rotation')
+				)
+				guiArray.push(gui.add( material, 'glossiness',0,1))
+				guiArray.push(
+					gui.add(guiData, 'map').onChange(function(val){
+						if(!_gltfTextureMap && meshGLTF ) _gltfTextureMap = meshGLTF.material.map
+
+						mesh.material.map = val ? texture : null
+						mesh.material.needsUpdate = true
+
+						if(meshGLTF){
+							meshGLTF.material.map = val ? _gltfTextureMap : null
+							meshGLTF.material.needsUpdate = true
+						}
+					})
+				)
+			}
+
+			function initScene() {
 
 				clock = new THREE.Clock();
 
@@ -107,11 +182,8 @@
 				light.shadow.mapSize.height = 512;
 				scene.add(light)
 
-
-				// light shadow camera helper
-				light.shadowCameraHelper = new THREE.CameraHelper( light.shadow.camera );
-				scene.add( light.shadowCameraHelper );
-				scene.add( new THREE.AmbientLight( 0xffffff, 0.17 ) );
+				var ambient = new THREE.AmbientLight( 0x222222 );
+				scene.add( ambient );
 
 				var ground = new THREE.Mesh(
 					new THREE.PlaneBufferGeometry( 800, 800 ).rotateX( - Math.PI / 2 ),
@@ -126,6 +198,8 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
+				renderer.gammaOutput = true;
+				renderer.physicallyCorrectLights = true;
 
 				renderer.shadowMap.enabled = true;
 				//
@@ -137,56 +211,110 @@
 
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 				window.addEventListener( 'resize', onWindowResize, false );
+			}
 
+			function loadGLTF(){
 
+				loader = new THREE.GLTFLoader();
 
-				var texture = new THREE.TextureLoader().load( `textures/roughness_map.jpg` )
+				THREE.DRACOLoader.setDecoderPath( 'js/libs/draco/gltf/' );
+				loader.setDRACOLoader( new THREE.DRACOLoader() );
+
+				var loadStartTime = performance.now();
+				loader.load( './models/gltf/BoomBox/glTF-pbrSpecularGlossiness/BoomBox.gltf', function( data ) {
+
+					gltf = data;
+
+					var object = gltf.scene;
+
+					console.info( 'Load time: ' + ( performance.now() - loadStartTime ).toFixed( 2 ) + ' ms.' );
+
+					object.traverse( function( node ) {
+
+						if ( node.material && ( node.material.isMeshStandardMaterial ||
+							 ( node.material.isShaderMaterial && node.material.envMap !== undefined ) ) ) {
+
+							node.material.envMap = envMap;
+							node.material.needsUpdate = true;
+						}
+
+					} );
+
+					object.traverse( function ( node ) {
+
+						if ( node.isMesh || node.isLight ) node.castShadow = true;
+
+					} );
+
+					scene.add( object );
+					object.rotation.y -= Math.PI;
+
+					var scale = 2000
+					meshGLTF = object.children[0]
+					meshGLTF.frustumCulled = false
+					meshGLTF.visible = guiData.currentMesh === 'gltf'
+					meshGLTF.geometry.scale(scale,scale,scale)
+
+					materialGLTF = meshGLTF.material
+					decorateMaterialWithPerMapTransforms(materialGLTF)
+					applyInstancingToMesh(meshGLTF)
+					applyIndecisToInstancedMesh(meshGLTF)
+
+				}, undefined, function ( error ) {
+
+					console.error( error );
+
+				} );
+
+			}
+
+			function initTexture(){
+
+				texture = new THREE.TextureLoader().load( `textures/roughness_map.jpg` )
 				texture.wrapS = texture.wrapT = THREE.RepeatWrapping
 				texture.name = "texture"
 
-				var envMap = new THREE.TextureLoader().load( `textures/metal.jpg`, function ( texture ) {
+				envMap = new THREE.TextureLoader().load( `textures/metal.jpg`, function ( texture ) {
 	
 					texture.mapping = THREE.SphericalReflectionMapping;
 					texture.encoding = THREE.sRGBEncoding;
-					if ( mesh ) mesh.material.needsUpdate = true;
+					if ( mesh ) material.needsUpdate = true;
+					if ( meshGLTF ) materialGLTF.needsUpdate = true;
 	
 				} );
 
 				envMap.name = "envMap"
+			}
 
-				var material = new THREE.MeshStandardMaterial({
-					color: 0xffb54a,
-					envMap: envMap,
-					map: texture,
-				})
+			function initBall(){
+
+				material = decorateMaterialWithSpecGloss(
+					new THREE.MeshStandardMaterial({
+						color: 0xffb54a,
+						envMap: envMap,
+						map: texture,
+					})
+				)
+				decorateMaterialWithPerMapTransforms(material)
 
 				mesh = new THREE.Mesh(new THREE.SphereBufferGeometry(10), material)
+
 				scene.add(mesh)
+
 				mesh.castShadow = true
 				mesh.receiveShadow = true
 
-				//decorate with spec gloss 
-				decorateMaterialWithSpecGloss(material)
-
-				//results in these maps being immidiately available
-				material.glossinessMap = texture
+				material.glossinessMap = texture //needs .a so doesnt work with this texture
 				material.specularMap = texture
 
-				//decorate with map transforms
-				decorateMaterialWithPerMapTransforms(material)
+				applyInstancingToMesh(mesh)
+				applyIndecisToInstancedMesh(mesh)
 
-				//results in thse Vector2 and primitev properties being immidiately available
-				gui.add( material.specularMapRepeat,'x',0,10).onChange(material.specularMapUpdateMatrix)
-				gui.add( material.specularMapRepeat,'y',0,10).onChange(material.specularMapUpdateMatrix)
-				gui.add( material.specularMapOffset,'x',0,1).onChange(material.specularMapUpdateMatrix)
-				gui.add( material.specularMapOffset,'x',0,1).onChange(material.specularMapUpdateMatrix)
-				gui.add( material, 'specularMapRotation',0,1).onChange(material.specularMapUpdateMatrix)
-				gui.add( material, 'glossiness',0,1)
+			}
 
-				//instancing
-				
+			//instancing
+			function initInstanceAttributes(){
 				//create geometry attributes
-				const INSTANCES = 256;
 				var knot = new THREE.Curves.TorusKnot( 60 );
 				var positions = knot.getSpacedPoints( INSTANCES );
 
@@ -202,83 +330,73 @@
 					offsets[ index + 2 ] = positions[ i ].z;
 
 					// per-instance scale variation
-					scales[ i ] = 1 + 0.5 * Math.sin( 32 * Math.PI * i / INSTANCES );
+					scales[ i ] = 1 + 0.5 * Math.sin( frequency * Math.PI * i / INSTANCES );
 
 				}
+
+				instanceOffsetAttribute = new THREE.InstancedBufferAttribute( offsets, 3 )
+				instanceScaleAttribute = new THREE.InstancedBufferAttribute( scales, 1 )
+			}
+
+			function applyInstancingToMesh(mesh){
+
+				decorateMaterialWithSimpleInstancing(mesh.material)
+
+				mesh.customDepthMaterial = decorateMaterialWithSimpleInstancing(
+					new THREE.MeshDepthMaterial({ depthPacking: THREE.RGBADepthPacking })
+				)
+
 				mesh.geometry = new THREE.InstancedBufferGeometry().copy(mesh.geometry)
 				mesh.geometry.maxInstancedCount = INSTANCES
 
-				//end custom geometry creation
-				
+				mesh.geometry.addAttribute( 'instanceOffset', instanceOffsetAttribute );
+				mesh.geometry.addAttribute( 'instanceScale', instanceScaleAttribute );
 
-				//material decorator exposes instanceOffset and instanceScale, 
-				//provide these to geometry
-				mesh.geometry.addAttribute( 'instanceOffset', new THREE.InstancedBufferAttribute( offsets, 3 ) );
-				mesh.geometry.addAttribute( 'instanceScale', new THREE.InstancedBufferAttribute( scales, 1 ) );
+			}
 
-				decorateMaterialWithSimpleInstancing(material)
-				//same for depth material
-				mesh.customDepthMaterial = decorateMaterialWithSimpleInstancing(new THREE.MeshDepthMaterial({ depthPacking: THREE.RGBADepthPacking }))
-
-
-
-				//4. add a final custom animation effect on top of the instancing effect
-				var indecis = new Float32Array( INSTANCES * 1 ); 
+			function applyIndecisToInstancedMesh(mesh){
+				console.log(mesh)
+				var indecis = new Float32Array( INSTANCES ); 
 
 				for ( var i = 0, l = INSTANCES; i < l; i ++ ) {
 					indecis[i] = i / INSTANCES
 				}
-				//add this new attribute
+
 				mesh.geometry.addAttribute('aIndex', new THREE.InstancedBufferAttribute( indecis, 1 ) )
 
 				//remove the old attibute (we could have overloaded it though)
 				delete mesh.geometry.attributes.instanceScale
 
-				var frequency = 32
 				//knowing we decorated with simpleInstancing we have a parsed/included "compiled" chunk to work with
-				material.shaderIncludes.begin_vertex = material.shaderIncludes.begin_vertex.replace(
+				mesh.material.shaderIncludes.begin_vertex = mesh.material.shaderIncludes.begin_vertex.replace(
 					'transformed *= instanceScale;', //we know how simpleInstancing works
 					`float _ind = aIndex + uTime;
 					transformed *= 1. + 0.5 * sin(${frequency}.0 * ${Math.PI} * _ind );` //we override a part of that extension with our custom logic
 				)
 
 				//we need a custom time uniform for the effect
-				material.shaderUniforms.uTime = { value: 0, type: 'float', stage: 'vertex' }
+				var uTime = { value: 0, type: 'float', stage: 'vertex' }
+				mesh.material.shaderUniforms.uTime = uTime
 
 				//we expose it as a primitive
-				Object.defineProperty(material, 'time', {
-					get:()=>material.shaderUniforms.uTime.value,
-					set:v=>material.shaderUniforms.uTime.value = v
+				Object.defineProperty(mesh.material, 'time', {
+					get:()=>uTime.value,
+					set:v=>uTime.value = v
 				})
-
-				//because there is already an onBeforeCompile, it's tricky to add another one to append
-				//the new attribute ( and remove the old one ), fortunately, we can use the uv_pars_vertex
-				//ideally there should be a chunk called global_vertex_pars or something like that where 
-				//one could inject uniforms functions varyings and attributes
-				//with this api, in this stage, at least one would have the unrolled raw glsl to work with 
-				//available in this scope at this time
-				//aka
-				//material.shaderIncludes.some_chunk = my_some_chunk || THREE.ShaderChunk.some_chunk 
-				//^ either way, shaderIncludes.some_chunk contains the GLSL, with onBeforeCompile this is blackboxed
-				// we could then do:
-				//  global_vertex.replace( 'attribute float instanceOffset', 'attribute float aIndex' )				
-				material.shaderIncludes.uv_pars_vertex = `
+		
+				mesh.material.shaderIncludes.uv_pars_vertex = `
 				${THREE.ShaderChunk.uv_pars_vertex}
 				attribute float aIndex;
 				`
 
 				//to make it work with shadows,
-				mesh.customDepthMaterial.shaderIncludes.uv_pars_vertex = material.shaderIncludes.uv_pars_vertex //copy these
-				mesh.customDepthMaterial.shaderIncludes.begin_vertex = material.shaderIncludes.begin_vertex //copy these
-				mesh.customDepthMaterial.shaderUniforms = { uTime: material.shaderUniforms.uTime }//wire this by reference, whenever prop updates material uniform this material updates too by referencing the same uniform
+				mesh.customDepthMaterial.shaderIncludes.uv_pars_vertex = mesh.material.shaderIncludes.uv_pars_vertex //copy these
+				mesh.customDepthMaterial.shaderIncludes.begin_vertex = mesh.material.shaderIncludes.begin_vertex //copy these
+				mesh.customDepthMaterial.shaderUniforms = { uTime: mesh.material.shaderUniforms.uTime }//wire this by reference, whenever prop updates material uniform this material updates too by referencing the same uniform
 
-				//test needs update after all of this
-				gui.add(guiData, 'map').onChange(function(val){
-					material.map = val ? texture : null
-					material.needsUpdate = true
-				})
+				console.log(mesh)
 
-				console.log(material.toJSON())
+				console.log(mesh.material.toJSON())
 			}
 
 
@@ -298,7 +416,6 @@
 			}
 
 			function onDocumentMouseMove( event ) {
-
 				mouseX = ( event.clientX - windowHalfX );
 				mouseY = ( event.clientY - windowHalfY );
 			}
@@ -319,12 +436,21 @@
 				targetX = mouseX * .001;
 				targetY = mouseY * .001;
 
+				var delta = clock.getDelta() * 0.01 * guiData.speed
 				if ( mesh ) {
 
 					mesh.rotation.y += 0.05 * ( targetX - mesh.rotation.y );
 					mesh.rotation.x += 0.05 * ( targetY - mesh.rotation.x );
 
-					mesh.material.time += clock.getDelta() * 0.01 * guiData.speed
+					mesh.material.time += delta
+				}
+
+				if ( meshGLTF ) {
+
+					meshGLTF.rotation.y += 0.05 * ( targetX - meshGLTF.rotation.y );
+					meshGLTF.rotation.x += 0.05 * ( targetY - meshGLTF.rotation.x );
+
+					meshGLTF.material.time += delta
 				}
 
 				renderer.render( scene, camera );

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -54,7 +54,7 @@
 		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script>
-
+/*eslint-disable*/
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
 			var camera, scene, renderer, stats, clock;
@@ -142,6 +142,7 @@
 
 				var texture = new THREE.TextureLoader().load( `textures/roughness_map.jpg` )
 				texture.wrapS = texture.wrapT = THREE.RepeatWrapping
+				texture.name = "texture"
 
 				var envMap = new THREE.TextureLoader().load( `textures/metal.jpg`, function ( texture ) {
 	
@@ -150,6 +151,8 @@
 					if ( mesh ) mesh.material.needsUpdate = true;
 	
 				} );
+
+				envMap.name = "envMap"
 
 				var material = new THREE.MeshStandardMaterial({
 					color: 0xffb54a,
@@ -274,6 +277,8 @@
 					material.map = val ? texture : null
 					material.needsUpdate = true
 				})
+
+				console.log(material.toJSON())
 			}
 
 

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -152,11 +152,17 @@
 				mesh.castShadow = true
 				mesh.receiveShadow = true
 
+				//decorate with spec gloss 
 				decorateMaterialWithSpecGloss(material)
+
+				//results in these maps being immidiately available
 				material.glossinessMap = texture
 				material.specularMap = texture
+
+				//decorate with map transforms
 				decorateMaterialWithPerMapTransforms(material)
 
+				//results in thse Vector2 and primitev properties being immidiately available
 				gui.add( material.glossinessMapRepeat,'x',0,10).onChange(material.glossinessMapUpdateMatrix)
 				gui.add( material.glossinessMapRepeat,'y',0,10).onChange(material.glossinessMapUpdateMatrix)
 				gui.add( material.glossinessMapOffset,'x',0,1).onChange(material.glossinessMapUpdateMatrix)
@@ -164,6 +170,8 @@
 				gui.add( material, 'glossinessMapRotation',0,1).onChange(material.glossinessMapUpdateMatrix)
 
 				//instancing
+				
+				//create geometry attributes
 				const INSTANCES = 256;
 				var knot = new THREE.Curves.TorusKnot( 60 );
 				var positions = knot.getSpacedPoints( INSTANCES );
@@ -185,12 +193,18 @@
 				}
 				mesh.geometry = new THREE.InstancedBufferGeometry().copy(mesh.geometry)
 				mesh.geometry.maxInstancedCount = INSTANCES
-				console.log(mesh.geometry)
+
+				//end custom geometry creation
+				
+
+				//material decorator exposes instanceOffset and instanceScale, 
+				//provide these to geometry
 				mesh.geometry.addAttribute( 'instanceOffset', new THREE.InstancedBufferAttribute( offsets, 3 ) );
 				mesh.geometry.addAttribute( 'instanceScale', new THREE.InstancedBufferAttribute( scales, 1 ) );
 
-				mesh.customDepthMaterial = decorateMaterialWithSimpleInstancing(new THREE.MeshDepthMaterial({ depthPacking: THREE.RGBADepthPacking }))
 				decorateMaterialWithSimpleInstancing(material)
+				//same for depth material
+				mesh.customDepthMaterial = decorateMaterialWithSimpleInstancing(new THREE.MeshDepthMaterial({ depthPacking: THREE.RGBADepthPacking }))
 			}
 
 

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -57,7 +57,7 @@
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
-			var camera, scene, renderer, stats;
+			var camera, scene, renderer, stats, clock;
 
 			var mesh, material;
 
@@ -70,12 +70,21 @@
 			var windowHalfX = window.innerWidth / 2;
 			var windowHalfY = window.innerHeight / 2;
 
-			var gui = new dat.GUI()
+			var _gui = new dat.GUI()
+
+			var gui = _gui.addFolder('gui')
+			gui.open()
+
+			var guiData = { speed: 1 }
+
+			gui.add( guiData, 'speed', 0, 5 )
 
 			init();
 			animate();
 
 			function init() {
+
+				clock = new THREE.Clock();
 
 				camera = new THREE.PerspectiveCamera( 27, window.innerWidth / window.innerHeight, 1, 10000 );
 				camera.position.z = 1200;
@@ -207,6 +216,47 @@
 				decorateMaterialWithSimpleInstancing(material)
 				//same for depth material
 				mesh.customDepthMaterial = decorateMaterialWithSimpleInstancing(new THREE.MeshDepthMaterial({ depthPacking: THREE.RGBADepthPacking }))
+
+
+
+				//4. add a final custom animation effect on top of the instancing effect
+				var indecis = new Float32Array( INSTANCES * 1 ); 
+
+				for ( var i = 0, l = INSTANCES; i < l; i ++ ) {
+					indecis[i] = i / INSTANCES
+				}
+				//add this new attribute
+				mesh.geometry.addAttribute('aIndex', new THREE.InstancedBufferAttribute( indecis, 1 ) )
+
+				//remove the old attibute (we could have overloaded it though)
+				delete mesh.geometry.attributes.instanceScale
+
+				var frequency = 32
+				//knowing we decorated with simpleInstancing we have a parsed/included "compiled" chunk to work with
+				material.shaderIncludes.begin_vertex = material.shaderIncludes.begin_vertex.replace(
+					'transformed *= instanceScale;', //we know how simpleInstancing works
+					`float _ind = aIndex + uTime;
+					transformed *= 1. + 0.5 * sin(${frequency}.0 * ${Math.PI} * _ind );` //we override a part of that extension with our custom logic
+				)
+
+				//we need a custom time uniform for the effect
+				material.shaderUniforms.uTime = { value: 0, type: 'float', stage: 'vertex' }
+
+				//we expose it as a primitive
+				Object.defineProperty(material, 'time', {
+					get:()=>material.shaderUniforms.uTime.value,
+					set:v=>material.shaderUniforms.uTime.value = v
+				})
+
+				//because there is already an onBeforeCompile, it's tricky to add another one to append
+				//the new attribute ( and remove the old one ), fortunately, we can use the uv_pars_vertex
+				
+				material.shaderIncludes.uv_pars_vertex = `
+				${THREE.ShaderChunk.uv_pars_vertex}
+				attribute float aIndex;
+				`
+
+
 			}
 
 
@@ -229,7 +279,6 @@
 
 				mouseX = ( event.clientX - windowHalfX );
 				mouseY = ( event.clientY - windowHalfY );
-				console.log
 			}
 
 
@@ -253,6 +302,7 @@
 					mesh.rotation.y += 0.05 * ( targetX - mesh.rotation.y );
 					mesh.rotation.x += 0.05 * ( targetY - mesh.rotation.x );
 
+					mesh.material.time += clock.getDelta() * 0.01 * guiData.speed
 				}
 
 				renderer.render( scene, camera );
@@ -260,6 +310,5 @@
 			}
 
 		</script>
-
 	</body>
 </html>

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -73,11 +73,17 @@
 			var windowHalfX = window.innerWidth / 2;
 			var windowHalfY = window.innerHeight / 2;
 
+			var currentMesh
 			var meshOptions = ['sphere','gltf']
 			var guiData = { 
 				speed: 1, 
 				map: true,
-				currentMesh: meshOptions[0]
+				currentMesh: meshOptions[0],
+				serialize: function(){
+					console.log(
+						JSON.stringify( currentMesh.material.toJSON())
+					)
+				}
 			}
 			var _gui = new dat.GUI({width: 300}) //fix css later
 			var guiArray = []
@@ -86,6 +92,7 @@
 			gui.open()
 			gui.add( guiData, 'speed', 0, 5 )
 			gui.add( guiData, 'currentMesh', meshOptions ).onChange(function(value){
+				currentMesh = value === 'sphere' ? mesh : meshGLTF
 				mesh.visible = value === 'sphere'
 				if(meshGLTF) meshGLTF.visible = value === 'gltf'
 				onChangeGuiMaterial(value==='gltf'?materialGLTF:material)
@@ -154,6 +161,9 @@
 						}
 					})
 					.name('albedo map on/off')
+				)
+				guiArray.push(
+					gui.add(guiData, 'serialize')
 				)
 			}
 
@@ -310,6 +320,8 @@
 				applyInstancingToMesh(mesh)
 				applyIndecisToInstancedMesh(mesh)
 
+				currentMesh = mesh
+
 			}
 
 			//instancing
@@ -355,7 +367,7 @@
 			}
 
 			function applyIndecisToInstancedMesh(mesh){
-				console.log(mesh)
+
 				var indecis = new Float32Array( INSTANCES ); 
 
 				for ( var i = 0, l = INSTANCES; i < l; i ++ ) {
@@ -394,9 +406,6 @@
 				mesh.customDepthMaterial.shaderIncludes.begin_vertex = mesh.material.shaderIncludes.begin_vertex //copy these
 				mesh.customDepthMaterial.shaderUniforms = { uTime: mesh.material.shaderUniforms.uTime }//wire this by reference, whenever prop updates material uniform this material updates too by referencing the same uniform
 
-				console.log(mesh)
-
-				console.log(mesh.material.toJSON())
 			}
 
 

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -168,6 +168,7 @@
 				gui.add( material.specularMapOffset,'x',0,1).onChange(material.specularMapUpdateMatrix)
 				gui.add( material.specularMapOffset,'x',0,1).onChange(material.specularMapUpdateMatrix)
 				gui.add( material, 'specularMapRotation',0,1).onChange(material.specularMapUpdateMatrix)
+				gui.add( material, 'glossiness',0,1)
 
 				//instancing
 				

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -41,12 +41,15 @@
 		<div id="info">
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> wegbl - modified material.
 			<a href="http://graphics.cs.williams.edu/data/meshes.xml#14" target="_blank" rel="noopener">Lee Perry-Smith</a> head.
+			Author <a href="http://dusanbosnjak.com" target="_blank" rel="noopener">@pailhead.</a>
 		</div>
 
 		<script src="../build/three.js"></script>
 
 		<script src="js/Detector.js"></script>
+		<script src="js/SpecGlossMultiUVInstanceExample.js"></script>
 		<script src="js/libs/stats.min.js"></script>
+		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script>
 
@@ -65,6 +68,8 @@
 			var windowHalfX = window.innerWidth / 2;
 			var windowHalfY = window.innerHeight / 2;
 
+			var gui = new dat.GUI()
+
 			init();
 			animate();
 
@@ -77,28 +82,15 @@
 
 				material = new THREE.MeshNormalMaterial(); //no need to create a uniform at some obscure compile time, it's available now (obsucure because its both onBeforeParse and onBeforeCompile`)
 
-				var my_begin_vertex = [ 
-					'float theta = sin( time + position.y ) / 2.0;',
-					'float c = cos( theta );',
-					'float s = sin( theta );',
-					'mat3 m = mat3( c, 0, s, 0, 1, 0, -s, 0, c );',
-					'vec3 transformed = vec3( position ) * m;',
-					'vNormal = vNormal * m;'
-				].join( '\n' );
+				var light = new THREE.DirectionalLight( 0xffffff, 0.4 );
+				light.position.set( 50, 40, 40 );
+				
+				scene.add(light)
 
-				material.shaderIncludes = { begin_vertex: my_begin_vertex };
+				var light = new THREE.DirectionalLight( 0xffffff, 0.4 );
+				light.position.set( -50, 40, 40 );
+				scene.add(light)
 
-				material.shaderUniforms = { time: { value: 0, type: 'float', stage: 'vertex' } };
-
-				var loader = new THREE.JSONLoader();
-				loader.load( 'models/json/leeperrysmith/LeePerrySmith.json', function( geometry ) {
-
-					mesh = new THREE.Mesh( geometry, material );
-					mesh.position.y = - 50;
-					mesh.scale.setScalar( 100 );
-					scene.add( mesh );
-
-				} );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
@@ -115,9 +107,30 @@
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 				window.addEventListener( 'resize', onWindowResize, false );
 
+
+
+				var texture = new THREE.TextureLoader().load( `textures/roughness_map.jpg` )
+				texture.wrapS = texture.wrapT = THREE.RepeatWrapping
+
+				var material = new THREE.MeshStandardMaterial({
+					color: 0xffb54a,
+				})
+				mesh = new THREE.Mesh(new THREE.SphereBufferGeometry(60), material)
+				scene.add(mesh)
+
+				decorateMaterialWithSpecGloss(material)
+				material.glossinessMap = texture
+				material.specularMap = texture
+				decorateMaterialWithPerMapTransforms(material)
+
+				gui.add( material.glossinessMapRepeat,'x',0,10).onChange(material.glossinessMapUpdateMatrix)
+				gui.add( material.glossinessMapRepeat,'y',0,10).onChange(material.glossinessMapUpdateMatrix)
+				gui.add( material.glossinessMapOffset,'x',0,1).onChange(material.glossinessMapUpdateMatrix)
+				gui.add( material.glossinessMapOffset,'x',0,1).onChange(material.glossinessMapUpdateMatrix)
+				gui.add( material, 'glossinessMapRotation',0,1).onChange(material.glossinessMapUpdateMatrix)
+
 			}
 
-			//
 
 			function onWindowResize( event ) {
 
@@ -138,10 +151,9 @@
 
 				mouseX = ( event.clientX - windowHalfX );
 				mouseY = ( event.clientY - windowHalfY );
-
+				console.log
 			}
 
-			//
 
 			function animate() {
 
@@ -164,9 +176,6 @@
 					mesh.rotation.x += 0.05 * ( targetY - mesh.rotation.x );
 
 				}
-
-				material.shaderUniforms.time.value = performance.now() / 1000; //doesnt defer creating the uniform, no need to check
-
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -39,8 +39,7 @@
 
 	<body>
 		<div id="info">
-			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> wegbl - modified material.
-			<a href="http://graphics.cs.williams.edu/data/meshes.xml#14" target="_blank" rel="noopener">Lee Perry-Smith</a> head.
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> wegbl - modified MeshStandardMaterial with specular/glossines lighting model, per map transforms and simple instancing. 
 			Author <a href="http://dusanbosnjak.com" target="_blank" rel="noopener">@pailhead.</a>
 		</div>
 
@@ -80,7 +79,7 @@
 				map: true,
 				currentMesh: meshOptions[0]
 			}
-			var _gui = new dat.GUI() //fix css later
+			var _gui = new dat.GUI({width: 300}) //fix css later
 			var guiArray = []
 
 			var gui = _gui.addFolder('global')
@@ -119,27 +118,27 @@
 				guiArray.push(
 					gui.add( material.specularMapRepeat,'x',0,10)
 					.onChange(material.specularMapUpdateMatrix)
-					.name('repeat.x')
+					.name('spec map repeat.x')
 				)
 				guiArray.push(
 					gui.add( material.specularMapRepeat,'y',0,10)
 					.onChange(material.specularMapUpdateMatrix)
-					.name('repeat.y')
+					.name('spec map repeat.y')
 				)
 				guiArray.push(
 					gui.add( material.specularMapOffset,'x',0,1)
 					.onChange(material.specularMapUpdateMatrix)
-					.name('offset.x')
+					.name('spec map offset.x')
 				)
 				guiArray.push(
 					gui.add( material.specularMapOffset,'x',0,1)
 					.onChange(material.specularMapUpdateMatrix)
-					.name('offset.y')
+					.name('spec map offset.y')
 				)
 				guiArray.push(
 					gui.add( material, 'specularMapRotation',0,1)
 					.onChange(material.specularMapUpdateMatrix)
-					.name('rotation')
+					.name('spec map rotation')
 				)
 				guiArray.push(gui.add( material, 'glossiness',0,1))
 				guiArray.push(
@@ -154,6 +153,7 @@
 							meshGLTF.material.needsUpdate = true
 						}
 					})
+					.name('albedo map on/off')
 				)
 			}
 

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -75,7 +75,7 @@
 			var gui = _gui.addFolder('gui')
 			gui.open()
 
-			var guiData = { speed: 1 }
+			var guiData = { speed: 1 , map: true}
 
 			gui.add( guiData, 'speed', 0, 5 )
 
@@ -265,6 +265,11 @@
 				`
 
 
+				//test needs update after all of this
+				gui.add(guiData, 'map').onChange(function(val){
+					material.map = val ? texture : null
+					material.needsUpdate = true
+				})
 			}
 
 

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -145,6 +145,7 @@
 				var material = new THREE.MeshStandardMaterial({
 					color: 0xffb54a,
 					envMap: envMap,
+					map: texture,
 				})
 
 				mesh = new THREE.Mesh(new THREE.SphereBufferGeometry(10), material)

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -82,18 +82,43 @@
 
 				scene = new THREE.Scene();
 
-				material = new THREE.MeshNormalMaterial(); //no need to create a uniform at some obscure compile time, it's available now (obsucure because its both onBeforeParse and onBeforeCompile`)
-
 				var light = new THREE.DirectionalLight( 0xffffff, 0.4 );
-				light.position.set( 50, 40, 40 );
+				light.position.set( 100, 260, 160 );
 				
+				light.castShadow = true;
+				light.shadow.camera.left = - 240;
+				light.shadow.camera.right = 240;
+				light.shadow.camera.top = 240;
+				light.shadow.camera.bottom = - 240;
+				light.shadow.camera.near = 10;
+				light.shadow.camera.far = 1500;
+
+				light.shadow.bias = - 0.001;
+				light.shadow.mapSize.width = 512;
+				light.shadow.mapSize.height = 512;
 				scene.add(light)
+
+
+				// light shadow camera helper
+				light.shadowCameraHelper = new THREE.CameraHelper( light.shadow.camera );
+				scene.add( light.shadowCameraHelper );
+				scene.add( new THREE.AmbientLight( 0xffffff, 0.17 ) );
+
+				var ground = new THREE.Mesh(
+					new THREE.PlaneBufferGeometry( 800, 800 ).rotateX( - Math.PI / 2 ),
+					new THREE.MeshPhongMaterial( { color: 0x888888 } )
+				);
+				ground.position.set( 0, - 200, 0 );
+				ground.receiveShadow = true;
+	
+				scene.add( ground );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
+				renderer.shadowMap.enabled = true;
 				//
 
 				stats = new Stats();
@@ -124,6 +149,8 @@
 
 				mesh = new THREE.Mesh(new THREE.SphereBufferGeometry(10), material)
 				scene.add(mesh)
+				mesh.castShadow = true
+				mesh.receiveShadow = true
 
 				decorateMaterialWithSpecGloss(material)
 				material.glossinessMap = texture
@@ -162,6 +189,7 @@
 				mesh.geometry.addAttribute( 'instanceOffset', new THREE.InstancedBufferAttribute( offsets, 3 ) );
 				mesh.geometry.addAttribute( 'instanceScale', new THREE.InstancedBufferAttribute( scales, 1 ) );
 
+				mesh.customDepthMaterial = decorateMaterialWithSimpleInstancing(new THREE.MeshDepthMaterial({ depthPacking: THREE.RGBADepthPacking }))
 				decorateMaterialWithSimpleInstancing(material)
 			}
 

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -250,7 +250,15 @@
 
 				//because there is already an onBeforeCompile, it's tricky to add another one to append
 				//the new attribute ( and remove the old one ), fortunately, we can use the uv_pars_vertex
-				
+				//ideally there should be a chunk called global_vertex_pars or something like that where 
+				//one could inject uniforms functions varyings and attributes
+				//with this api, in this stage, at least one would have the unrolled raw glsl to work with 
+				//available in this scope at this time
+				//aka
+				//material.shaderIncludes.some_chunk = my_some_chunk || THREE.ShaderChunk.some_chunk 
+				//^ either way, shaderIncludes.some_chunk contains the GLSL, with onBeforeCompile this is blackboxed
+				// we could then do:
+				//  global_vertex.replace( 'attribute float instanceOffset', 'attribute float aIndex' )				
 				material.shaderIncludes.uv_pars_vertex = `
 				${THREE.ShaderChunk.uv_pars_vertex}
 				attribute float aIndex;

--- a/examples/webgl_materials_modified2.html
+++ b/examples/webgl_materials_modified2.html
@@ -48,6 +48,8 @@
 
 		<script src="js/Detector.js"></script>
 		<script src="js/SpecGlossMultiUVInstanceExample.js"></script>
+
+		<script src="js/CurveExtras.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
@@ -115,7 +117,7 @@
 				var material = new THREE.MeshStandardMaterial({
 					color: 0xffb54a,
 				})
-				mesh = new THREE.Mesh(new THREE.SphereBufferGeometry(60), material)
+				mesh = new THREE.Mesh(new THREE.SphereBufferGeometry(10), material)
 				scene.add(mesh)
 
 				decorateMaterialWithSpecGloss(material)
@@ -129,6 +131,33 @@
 				gui.add( material.glossinessMapOffset,'x',0,1).onChange(material.glossinessMapUpdateMatrix)
 				gui.add( material, 'glossinessMapRotation',0,1).onChange(material.glossinessMapUpdateMatrix)
 
+				//instancing
+				const INSTANCES = 256;
+				var knot = new THREE.Curves.TorusKnot( 60 );
+				var positions = knot.getSpacedPoints( INSTANCES );
+
+				var offsets = new Float32Array( INSTANCES * 3 ); // xyz
+				var scales = new Float32Array( INSTANCES * 1 ); // s
+				for ( var i = 0, l = INSTANCES; i < l; i ++ ) {
+
+					var index = 3 * i;
+
+					// per-instance position offset
+					offsets[ index ] = positions[ i ].x;
+					offsets[ index + 1 ] = positions[ i ].y;
+					offsets[ index + 2 ] = positions[ i ].z;
+
+					// per-instance scale variation
+					scales[ i ] = 1 + 0.5 * Math.sin( 32 * Math.PI * i / INSTANCES );
+
+				}
+				mesh.geometry = new THREE.InstancedBufferGeometry().copy(mesh.geometry)
+				mesh.geometry.maxInstancedCount = INSTANCES
+				console.log(mesh.geometry)
+				mesh.geometry.addAttribute( 'instanceOffset', new THREE.InstancedBufferAttribute( offsets, 3 ) );
+				mesh.geometry.addAttribute( 'instanceScale', new THREE.InstancedBufferAttribute( scales, 1 ) );
+
+				decorateMaterialWithSimpleInstancing(material)
 			}
 
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -133,7 +133,7 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
-	toJSON: function ( meta ) {
+	toJSON: function ( meta, onWillSerialize ) {
 
 		var isRoot = ( meta === undefined || typeof meta === 'string' );
 
@@ -153,6 +153,8 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 				generator: 'Material.toJSON'
 			}
 		};
+
+		onWillSerialize( data, meta );
 
 		// standard Material serialization
 		data.uuid = this.uuid;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1489,7 +1489,7 @@ function WebGLRenderer( parameters ) {
 
 					if ( type ) {
 
-						if ( stage === 'vertex' ) {
+						if ( stage === 'vertex' ) { //dunno what to do here, maybe if not provided should inject into both
 
 							shaderUniformsGLSLVert += 'uniform ' + type + ' ' + uniformName + ';\n';
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -158,13 +158,15 @@ function replaceClippingPlaneNums( string, parameters ) {
 
 }
 
-function parseIncludes( string ) {
+//consider provided dictionary when parsing the includes (not just THREE.ShaderChunk)
+function parseIncludes( string, materialIncludes ) {
 
 	var pattern = /^[ \t]*#include +<([\w\d.]+)>/gm;
 
 	function replace( match, include ) {
 
-		var replace = ShaderChunk[ include ];
+		//if there are material includes provided use those instead of the default chunks:
+		var replace = undefined !== materialIncludes[ include ] ? materialIncludes[ include ] : ShaderChunk[ include ];
 
 		if ( replace === undefined ) {
 
@@ -207,6 +209,8 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 	var gl = renderer.context;
 
 	var defines = material.defines;
+
+	var materialIncludes = material.shaderIncludes; //custom chunks
 
 	var vertexShader = shader.vertexShader;
 	var fragmentShader = shader.fragmentShader;
@@ -288,6 +292,8 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 	var customExtensions = generateExtensions( material.extensions, parameters, extensions );
 
 	var customDefines = generateDefines( defines );
+
+	var customIncludes = undefined !== materialIncludes ? materialIncludes : {}; //user is not aware of this feature, fine
 
 	//
 
@@ -503,11 +509,12 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 	}
 
-	vertexShader = parseIncludes( vertexShader );
+	// provide optional chunk dictionary customIncludes
+	vertexShader = parseIncludes( vertexShader, customIncludes );
 	vertexShader = replaceLightNums( vertexShader, parameters );
 	vertexShader = replaceClippingPlaneNums( vertexShader, parameters );
 
-	fragmentShader = parseIncludes( fragmentShader );
+	fragmentShader = parseIncludes( fragmentShader, customIncludes );
 	fragmentShader = replaceLightNums( fragmentShader, parameters );
 	fragmentShader = replaceClippingPlaneNums( fragmentShader, parameters );
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -243,7 +243,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 		array.push( renderer.gammaOutput );
 
-		// if there is this dictionary present 
+		// if there is this dictionary present
 		if ( material.shaderIncludes !== undefined ) {
 
 			for ( var include in material.shaderIncludes ) {

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -241,9 +241,19 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 		}
 
-		array.push( material.onBeforeCompile.toString() );
-
 		array.push( renderer.gammaOutput );
+
+		// if there is this dictionary present 
+		if ( material.shaderIncludes !== undefined ) {
+
+			for ( var include in material.shaderIncludes ) {
+
+				// hash with chunks?
+				array.push( material.shaderIncludes[ include ] );
+
+			}
+
+		}
 
 		return array.join();
 


### PR DESCRIPTION
I made a simple example that consolidates a few features that have been discussed over the years, with a bit of help from some core changes. (around 30 lines of core added/changed to `WebGLRenderer`,`WebGLProgram` and `WebGLPrograms`.)

1. a need for a Specular Glossiness StandardMaterial (#14099, #14149)
2. a need for per channel uv transforms (#13831, #14149, #12788, #12608, #13831, #8278, #14174)
3. a simple instancing example, it shows how to do #14166 in combination with other thing when not limited by `onBeforeCompile` API but still using the "shader injection" approach. 

http://dusanbosnjak.com/test/webGL/three-material-includes/

The example js file contains all three of these extensions, but they could be in their own files.

The code required to extend the first 2 is:

```javascript
decorateMaterialWithSpecGloss(material)
decorateMaterialWithPerMapTransforms(material)
```
These then become immediately available:
```javascript
material.glossinessMap = texture
material.specularMap = texture
gui.add( material, 'glossinessMapRotation',0,1).onChange(material.glossinessMapUpdateMatrix)
```

2. actually has a conflict with the chunk names, and has a couple of lines to solve that, but it works. If the templates could be restructured a bit to give a bit more separation, these would come up in fewer places i think

3. is just illustrative, it's a simple example and the contract between the extension and geometry is `instanceOffset` and `instanceScale`, the code just turns the geometry and adds these attributes.  I'm not entirely sure why #10750 was shelved, but this kind of an api would make a 3rd party package like this https://www.npmjs.com/package/three-instanced-mesh much more flexible and powerful. 

4. is an "inline" example on how to extend the stuff thats already extended and illustrates a drawback of `onBeforeCompile`. I wanted to remove an attribute from an extension `instanceScale` and use my own `aIndex`. If this logic is hidden in `onBeforeCompile` my hands are tied, but if this were in its own `parseGlobalsVertex` chunk then i'd have the "compiled" (parsed/unrolled) string, and i could replace this. Anyway this takes the `instanced_lambert` example and combines it with spec/gloss, multi uvs, and further modifies it on top of it (`materials_modified`).

A huge upside of this approach is that i can spend all my time in a text editor, without having to zoom and pan and click through a visual editor. 