### PR TITLE
Auto NodeMaterial build

### DIFF
--- a/examples/js/loaders/NodeMaterialLoader.js
+++ b/examples/js/loaders/NodeMaterialLoader.js
@@ -565,8 +565,6 @@ Object.assign( THREE.NodeMaterialLoader.prototype, {
 
 			}
 
-			object.build();
-
 			if ( node.fog !== undefined ) object.fog = node.fog;
 			if ( node.lights !== undefined ) object.lights = node.lights;
 

--- a/examples/js/loaders/NodeMaterialLoader.js
+++ b/examples/js/loaders/NodeMaterialLoader.js
@@ -581,8 +581,6 @@ Object.assign( THREE.NodeMaterialLoader.prototype, {
 
 			object.value = this.getNode( node.value );
 
-			object.build();
-
 		}
 
 		return this.material || this.pass || this;

--- a/examples/js/nodes/NodeBuilder.js
+++ b/examples/js/nodes/NodeBuilder.js
@@ -2,9 +2,10 @@
  * @author sunag / http://www.sunag.com.br/
  */
 
-THREE.NodeBuilder = function ( material ) {
+THREE.NodeBuilder = function ( material, renderer ) {
 
 	this.material = material;
+	this.renderer = renderer;
 
 	this.caches = [];
 	this.slots = [];

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -274,8 +274,6 @@ THREE.NodeMaterial.prototype.build = function ( params ) {
 
 		// force update
 
-		this.needsUpdate = false;
-
 		this.dispose();
 
 	}

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -6,6 +6,8 @@ THREE.NodeMaterial = function ( vertex, fragment ) {
 
 	THREE.ShaderMaterial.call( this );
 
+	this.defines.UUID = THREE.Math.generateUUID();
+
 	this.vertex = vertex || new THREE.RawNode( new THREE.PositionNode( THREE.PositionNode.PROJECTION ) );
 	this.fragment = fragment || new THREE.RawNode( new THREE.ColorNode( 0xFF0000 ) );
 
@@ -101,7 +103,7 @@ THREE.NodeMaterial.prototype.build = function ( params ) {
 
 	this.nodes = [];
 
-	this.defines = {};
+	this.defines = { UUID: this.defines.UUID };
 	this.uniforms = {};
 	this.attributes = {};
 
@@ -310,7 +312,7 @@ THREE.NodeMaterial.prototype.createUniform = function ( type, node, ns, needsUpd
 
 	var uniform = new THREE.NodeUniform( {
 		type: type,
-		name: ns ? ns : 'nVu' + index,
+		name: ns ? ns : 'nVu' +  index + '_' + THREE.Math.generateUUID().substr(0, 8),
 		node: node,
 		needsUpdate: needsUpdate
 	} );

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -78,7 +78,7 @@ THREE.NodeMaterial.prototype.updateFrame = function ( frame ) {
 
 };
 
-THREE.NodeMaterial.prototype.onBeforeCompile = function (shader, renderer) {
+THREE.NodeMaterial.prototype.onBeforeCompile = function ( shader, renderer ) {
 
 	if ( this.needsUpdate ) {
 

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -312,7 +312,7 @@ THREE.NodeMaterial.prototype.createUniform = function ( type, node, ns, needsUpd
 
 	var uniform = new THREE.NodeUniform( {
 		type: type,
-		name: ns ? ns : 'nVu' +  index + '_' + THREE.Math.generateUUID().substr(0, 8),
+		name: ns ? ns : 'nVu' + index + '_' + THREE.Math.generateUUID().substr(0, 8),
 		node: node,
 		needsUpdate: needsUpdate
 	} );

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -6,7 +6,7 @@ THREE.NodeMaterial = function ( vertex, fragment ) {
 
 	THREE.ShaderMaterial.call( this );
 
-	this.defines.UUID = THREE.Math.generateUUID();
+	this.defines.UUID = this.uuid;
 
 	this.vertex = vertex || new THREE.RawNode( new THREE.PositionNode( THREE.PositionNode.PROJECTION ) );
 	this.fragment = fragment || new THREE.RawNode( new THREE.ColorNode( 0xFF0000 ) );
@@ -103,7 +103,7 @@ THREE.NodeMaterial.prototype.build = function ( params ) {
 
 	this.nodes = [];
 
-	this.defines = { UUID: this.defines.UUID };
+	this.defines = { UUID: this.uuid };
 	this.uniforms = {};
 	this.attributes = {};
 

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -84,7 +84,7 @@ THREE.NodeMaterial.prototype.onBeforeCompile = function ( shader, renderer ) {
 
 	if ( this.needsUpdate ) {
 
-		this.build( { dispose: false } );
+		this.build( { dispose: false, renderer: renderer } );
 
 		shader.uniforms = this.uniforms;
 		shader.vertexShader = this.vertexShader;
@@ -164,7 +164,7 @@ THREE.NodeMaterial.prototype.build = function ( params ) {
 
 	].join( "\n" );
 
-	var builder = new THREE.NodeBuilder( this );
+	var builder = new THREE.NodeBuilder( this, params.renderer );
 
 	vertex = this.vertex.build( builder.setShader( 'vertex' ), 'v4' );
 	fragment = this.fragment.build( builder.setShader( 'fragment' ), 'v4' );

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -82,7 +82,7 @@ THREE.NodeMaterial.prototype.onBeforeCompile = function ( shader, renderer ) {
 
 	if ( this.needsUpdate ) {
 
-		this.build( { dispose : false } );
+		this.build( { dispose: false } );
 
 		shader.uniforms = this.uniforms;
 		shader.vertexShader = this.vertexShader;

--- a/examples/js/nodes/NodeMaterial.js
+++ b/examples/js/nodes/NodeMaterial.js
@@ -78,7 +78,24 @@ THREE.NodeMaterial.prototype.updateFrame = function ( frame ) {
 
 };
 
-THREE.NodeMaterial.prototype.build = function () {
+THREE.NodeMaterial.prototype.onBeforeCompile = function (shader, renderer) {
+
+	if ( this.needsUpdate ) {
+
+		this.build( { dispose : false } );
+
+		shader.uniforms = this.uniforms;
+		shader.vertexShader = this.vertexShader;
+		shader.fragmentShader = this.fragmentShader;
+
+	}
+
+};
+
+THREE.NodeMaterial.prototype.build = function ( params ) {
+
+	params = params || {};
+	params.dispose = params.dispose !== undefined ? params.dispose : true;
 
 	var vertex, fragment;
 
@@ -253,8 +270,15 @@ THREE.NodeMaterial.prototype.build = function () {
 		'}'
 	].join( "\n" );
 
-	this.needsUpdate = true;
-	this.dispose(); // force update
+	if ( params.dispose ) {
+
+		// force update
+
+		this.needsUpdate = false;
+
+		this.dispose();
+
+	}
 
 	return this;
 

--- a/examples/js/nodes/postprocessing/NodePass.js
+++ b/examples/js/nodes/postprocessing/NodePass.js
@@ -6,8 +6,6 @@ THREE.NodePass = function () {
 
 	THREE.ShaderPass.call( this );
 
-	var self = this;
-
 	this.name = "";
 	this.uuid = THREE.Math.generateUUID();
 

--- a/examples/js/nodes/postprocessing/NodePass.js
+++ b/examples/js/nodes/postprocessing/NodePass.js
@@ -6,6 +6,8 @@ THREE.NodePass = function () {
 
 	THREE.ShaderPass.call( this );
 
+	var self = this;
+
 	this.name = "";
 	this.uuid = THREE.Math.generateUUID();
 
@@ -18,7 +20,15 @@ THREE.NodePass = function () {
 	this.node = new THREE.NodeMaterial();
 	this.node.fragment = this.fragment;
 
-	this.build();
+	this.needsUpdate = true;
+
+	this.node.build = function ( params ) {
+
+		THREE.NodeMaterial.prototype.build.call( this, params );
+
+		self.uniforms = this.uniforms;
+
+	};
 
 };
 
@@ -27,12 +37,28 @@ THREE.NodePass.prototype.constructor = THREE.NodePass;
 
 THREE.NodeMaterial.addShortcuts( THREE.NodePass.prototype, 'fragment', [ 'value' ] );
 
+THREE.NodePass.prototype.render = function () {
+
+	if ( this.needsUpdate ) {
+
+		this.node.dispose();
+
+		this.needsUpdate = false;
+
+	}
+
+	this.uniforms = this.node.uniforms;
+	this.material = this.node;
+
+	THREE.ShaderPass.prototype.render.apply( this, arguments );
+
+};
+
 THREE.NodePass.prototype.build = function () {
 
 	this.node.build();
 
-	this.uniforms = this.node.uniforms;
-	this.material = this.node;
+	this.needsUpdate = false;
 
 };
 

--- a/examples/js/nodes/postprocessing/NodePass.js
+++ b/examples/js/nodes/postprocessing/NodePass.js
@@ -54,14 +54,6 @@ THREE.NodePass.prototype.render = function () {
 
 };
 
-THREE.NodePass.prototype.build = function () {
-
-	this.node.build();
-
-	this.needsUpdate = false;
-
-};
-
 THREE.NodePass.prototype.toJSON = function ( meta ) {
 
 	var isRootObject = ( meta === undefined || typeof meta === 'string' );

--- a/examples/js/nodes/postprocessing/NodePass.js
+++ b/examples/js/nodes/postprocessing/NodePass.js
@@ -22,14 +22,6 @@ THREE.NodePass = function () {
 
 	this.needsUpdate = true;
 
-	this.node.build = function ( params ) {
-
-		THREE.NodeMaterial.prototype.build.call( this, params );
-
-		self.uniforms = this.uniforms;
-
-	};
-
 };
 
 THREE.NodePass.prototype = Object.create( THREE.ShaderPass.prototype );

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -248,8 +248,6 @@
 
 					time.timeScale = true;
 
-					loader.material.build();
-
 					// gui
 
 					addGui( 'timeScale', time.scale, function ( val ) {

--- a/examples/webgl_materials_compile.html
+++ b/examples/webgl_materials_compile.html
@@ -69,6 +69,7 @@
 		<script src="js/nodes/FunctionNode.js"></script>
 		<script src="js/nodes/FunctionCallNode.js"></script>
 		<script src="js/nodes/AttributeNode.js"></script>
+		<script src="js/nodes/NodeUniform.js"></script>
 		<script src="js/nodes/NodeBuilder.js"></script>
 		<script src="js/nodes/NodeLib.js"></script>
 		<script src="js/nodes/NodeFrame.js"></script>
@@ -267,6 +268,7 @@
 			
 			var transformer = new THREE.FunctionNode( "position + 0.0 * " + Math.random(), "vec3", [ ]);
 			mtl.transform = transformer;
+
 			// build shader
 			mtl.build();
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -700,7 +700,7 @@
 
 						blend.b = val ? displace : displaceY;
 
-						mtl.build();
+						mtl.needsUpdate = true;
 
 					} );
 
@@ -785,7 +785,7 @@
 
 						}
 
-						mtl.build();
+						mtl.needsUpdate = true;
 
 					} );
 
@@ -945,7 +945,7 @@
 
 						mtl.color = val ? diffuse : new THREE.ColorNode( 0xEEEEEE );
 
-						mtl.build();
+						mtl.needsUpdate = true;
 
 					} );
 
@@ -1902,7 +1902,7 @@
 
 						mtl.ao = val ? new THREE.FloatNode() : undefined;
 
-						mtl.build();
+						mtl.needsUpdate = true;
 
 					} );
 
@@ -2196,7 +2196,6 @@
 					var distanceMtl = new THREE.PhongNodeMaterial();
 					distanceMtl.environment = objectDepth;
 					distanceMtl.side = THREE.BackSide;
-					distanceMtl.build();
 
 					rtMaterial = distanceMtl;
 
@@ -2304,9 +2303,6 @@
 					break;
 
 			}
-
-			// build shader
-			mtl.build();
 
 			// set material
 			mesh.material = mtl;

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -285,6 +285,8 @@
 
 			} else if ( typeof value == 'object' ) {
 
+				param.blend = value[ Object.keys( value )[ 0 ] ];
+
 				node = gui.add( param, name, value ).onChange( function () {
 
 					callback( param[ name ] );

--- a/examples/webgl_mirror_nodes.html
+++ b/examples/webgl_mirror_nodes.html
@@ -211,7 +211,6 @@
 			groundMirrorMaterial.environmentAlpha = mask;
 			groundMirrorMaterial.normal = normal;
 			//groundMirrorMaterial.normalScale = new THREE.FloatNode( 1 );
-			groundMirrorMaterial.build();
 
 			// test serialization
 /*

--- a/examples/webgl_postprocessing_nodes.html
+++ b/examples/webgl_postprocessing_nodes.html
@@ -504,7 +504,7 @@
 
 				}
 
-				nodepass.build();
+				nodepass.needsUpdate = true;
 
 				// test serialization
 /*
@@ -515,7 +515,6 @@
 				var json = nodepass.toJSON();
 
 				nodepass.value = new THREE.NodeMaterialLoader( null, library ).parse( json ).value;
-				nodepass.build();
 */
 			}
 

--- a/examples/webgl_postprocessing_nodes.html
+++ b/examples/webgl_postprocessing_nodes.html
@@ -319,7 +319,7 @@
 
 							multiply.op = val;
 
-							nodepass.build();
+							nodepass.needsUpdate = true;
 
 						} );
 
@@ -411,7 +411,7 @@
 
 							offsetNormal.a = val ? normalXYFlip : normalXY;
 
-							nodepass.build();
+							nodepass.needsUpdate = true;
 
 						} );
 
@@ -469,7 +469,7 @@
 
 							fadeCoord.c = val ? maskAlpha : fade;
 
-							nodepass.build();
+							nodepass.needsUpdate = true;
 
 						} );
 

--- a/examples/webgl_postprocessing_nodes.html
+++ b/examples/webgl_postprocessing_nodes.html
@@ -465,9 +465,9 @@
 
 						}, false, 0, 1 );
 
-						addGui( 'mask', true, function ( val ) {
+						addGui( 'mask', false, function ( val ) {
 
-							fadeCoord.c = val ? maskAlpha : fade;
+							fadeScreen.c = val ? new THREE.TextureNode( lensflare2 ) : fade;
 
 							nodepass.needsUpdate = true;
 

--- a/examples/webgl_postprocessing_nodes.html
+++ b/examples/webgl_postprocessing_nodes.html
@@ -154,6 +154,8 @@
 
 				} else if ( typeof value == 'object' ) {
 
+					param.blend = value[ Object.keys( value )[ 0 ] ];
+
 					node = gui.add( param, name, value ).onChange( function () {
 
 						callback( param[ name ] );

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -275,7 +275,7 @@
 
 			// unserialize
 
-			var material = new THREE.NodeMaterialLoader( null, library ).parse( json );
+			var material = new THREE.NodeMaterialLoader( null, library ).parse( json ).build();
 
 			// replace material
 

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -274,6 +274,7 @@
 			THREE.NodeMaterialLoaderUtils.replaceUUID( json, walkingManTexture, walkingManTextureURL );
 
 			// unserialize
+			// deserialize
 
 			var material = new THREE.NodeMaterialLoader( null, library ).parse( json ).build();
 

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -273,12 +273,13 @@
 
 			THREE.NodeMaterialLoaderUtils.replaceUUID( json, walkingManTexture, walkingManTextureURL );
 
-			// unserialize
 			// deserialize
 
-			var material = new THREE.NodeMaterialLoader( null, library ).parse( json ).build();
+			var material = new THREE.NodeMaterialLoader( null, library ).parse( json );
 
 			// replace material
+
+			sprite.material.dispose();
 
 			sprite.material = material;
 

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -203,7 +203,6 @@
 			sprite1.scale.y = spriteHeight;
 			sprite1.material.color = new THREE.TextureNode( walkingManTexture );
 			sprite1.material.color.coord = createHorizontalSpriteSheetNode( 8, 10 );
-			sprite1.material.build();
 
 			scene.add( sprite2 = new THREE.Mesh( plane, new THREE.SpriteNodeMaterial() ) );
 			sprite2.position.x = 30;
@@ -223,7 +222,6 @@
 				new THREE.PositionNode(),
 				THREE.OperatorNode.ADD
 			);
-			sprite2.material.build();
 
 			var sineWaveFunction = new THREE.FunctionNode( [
 				// https://stackoverflow.com/questions/36174431/how-to-make-a-wave-warp-effect-in-shader
@@ -245,7 +243,6 @@
 				"phase": new THREE.TimerNode()
 			} );
 			sprite3.material.fog = true;
-			sprite3.material.build();
 
 			//
 			//	Test serialization


### PR DESCRIPTION
- `THREE.NodePass`.`build()` is deprecated use `needsUpdate = true` instead.
- `THREE.NodeMaterial`.`build()` is deprecated to update the `shader` use `needsUpdate = true` instead.

One more step towards the core.
https://rawgit.com/sunag/three.js/dev-nodeupdate1/examples/index.html?q=nodes#webgl_loader_nodes