### PR TITLE
GLTFExporter: Skip single morph animation.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1381,9 +1381,9 @@ THREE.GLTFExporter.prototype = {
 					if ( trackNode.morphTargetInfluences.length !== 1 &&
 						trackBinding.propertyIndex !== undefined ) {
 
-						console.warn( 'THREE.GLTFExporter: Skipping animation track "%s" because ' +
-							'glTF can not handle single morph animation. ' +
-							'Try to merge .morphTargetInfluences elements instead.', track.name );
+						console.warn( 'THREE.GLTFExporter: Skipping animation track "%s". ' +
+							'Morph target keyframe tracks must target all available morph targets ' +
+							'for the given mesh.', track.name );
 						continue;
 
 					}

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1378,6 +1378,16 @@ THREE.GLTFExporter.prototype = {
 
 				if ( trackProperty === PATH_PROPERTIES.morphTargetInfluences ) {
 
+					if ( trackNode.morphTargetInfluences.length !== 1 &&
+						trackBinding.propertyIndex !== undefined ) {
+
+						console.warn( 'THREE.GLTFExporter: Skipping animation track "%s" because ' +
+							'glTF can not handle single morph animation. ' +
+							'Try to merge .morphTargetInfluences elements instead.', track.name );
+						continue;
+
+					}
+
 					outputItemSize /= trackNode.morphTargetInfluences.length;
 
 				}


### PR DESCRIPTION
glTF animation can't handle single morph animation in multiple morphs

https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#animations

> A Morph Target animation frame is defined by a sequence of scalars of length equal to the number of targets in the animated Morph Target. Morph Target animation is by nature sparse, consider using Sparse Accessors for storage of Morph Target animation.

then let's skip if animation track is `*.morphTargetInfluences[*]` and encourage merge them instead.

I'm thinking to add `.mergeMorphTargetInfluencesTracks` to `AnimationUtils`.