### PR TITLE
Remove unnecessary shader chunk

### DIFF
--- a/examples/webgl_buffergeometry_instancing_lambert.html
+++ b/examples/webgl_buffergeometry_instancing_lambert.html
@@ -144,7 +144,6 @@
 				#include <envmap_pars_vertex>
 				#include <bsdfs>
 				#include <lights_pars_begin>
-				#include <lights_pars_maps>
 				#include <color_pars_vertex>
 				#include <fog_pars_vertex>
 				#include <morphtarget_pars_vertex>

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -161,7 +161,6 @@
 						THREE.ShaderChunk[ "common" ],
 						THREE.ShaderChunk[ "bsdfs" ],
 						THREE.ShaderChunk[ "lights_pars_begin" ],
-						THREE.ShaderChunk[ "lights_pars_maps" ],
 						THREE.ShaderChunk[ "lights_phong_pars_fragment" ],
 
 						"void main() {",

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl
@@ -24,7 +24,6 @@ varying vec3 vLightFront;
 #include <envmap_pars_fragment>
 #include <bsdfs>
 #include <lights_pars_begin>
-#include <lights_pars_maps>
 #include <fog_pars_fragment>
 #include <shadowmap_pars_fragment>
 #include <shadowmask_pars_fragment>

--- a/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl
@@ -14,7 +14,6 @@ varying vec3 vLightFront;
 #include <envmap_pars_vertex>
 #include <bsdfs>
 #include <lights_pars_begin>
-#include <lights_pars_maps>
 #include <color_pars_vertex>
 #include <fog_pars_vertex>
 #include <morphtarget_pars_vertex>

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl
@@ -22,7 +22,6 @@ uniform float opacity;
 #include <fog_pars_fragment>
 #include <bsdfs>
 #include <lights_pars_begin>
-#include <lights_pars_maps>
 #include <lights_phong_pars_fragment>
 #include <shadowmap_pars_fragment>
 #include <bumpmap_pars_fragment>


### PR DESCRIPTION
`lights_pars_maps` is specific to `MeshStandardMaterial` and `MeshPhysicalMaterial` only.