### PR TITLE
XLoader: Remove dependency to Geometry

### DIFF
--- a/examples/js/loaders/XLoader.js
+++ b/examples/js/loaders/XLoader.js
@@ -219,8 +219,6 @@
 			this.baseDir = "";
 			this._putMatLength = 0;
 			this._nowMat = null;
-			this._tmpUvArray = [];
-			this._facesNormal = [];
 			this._nowFrameName = "";
 			this.frameHierarchie = [];
 			this.Hierarchies = {};
@@ -623,7 +621,15 @@
 								this._currentGeo.name = this._currentObject.name.trim();
 								this._currentGeo.parentName = this._getParentName( this._currentObject ).trim();
 								this._currentGeo.VertexSetedBoneCount = [];
-								this._currentGeo.Geometry = new THREE.Geometry();
+								this._currentGeo.GeometryData = {
+									vertices: [],
+									normals: [],
+									uvs: [],
+									skinIndices: [],
+									skinWeights: [],
+									indices: [],
+									materialIndices: []
+								};
 								this._currentGeo.Materials = [];
 								this._currentGeo.normalVectors = [];
 								this._currentGeo.BoneInfs = [];
@@ -823,7 +829,6 @@
 				var mode = 0;
 				var mode_local = 0;
 				var maxLength = 0;
-				var nowReadedLine = 0;
 				while ( true ) {
 
 					var changeMode = false;
@@ -832,7 +837,6 @@
 						var refO = this._readInt1( endRead );
 						endRead = refO.endRead;
 						mode_local = 1;
-						nowReadedLine = 0;
 						maxLength = this._currentObject.data.indexOf( ';;', endRead ) + 1;
 						if ( maxLength <= 0 ) {
 
@@ -880,16 +884,12 @@
 									case 0:
 										this._readNormalVector1( this._currentObject.data.substr( endRead, find - endRead ) );
 										break;
-									case 1:
-										this._readNormalFace1( this._currentObject.data.substr( endRead, find - endRead ), nowReadedLine );
-										break;
 
 								}
 								break;
 
 						}
 						endRead = find + 1;
-						nowReadedLine ++;
 						if ( changeMode ) {
 
 							mode ++;
@@ -922,9 +922,9 @@
 			value: function _readVertex1( line ) {
 
 				var data = this._readLine( line.trim() ).substr( 0, line.length - 2 ).split( ";" );
-				this._currentGeo.Geometry.vertices.push( new THREE.Vector3( parseFloat( data[ 0 ] ), parseFloat( data[ 1 ] ), parseFloat( data[ 2 ] ) ) );
-				this._currentGeo.Geometry.skinIndices.push( new THREE.Vector4( 0, 0, 0, 0 ) );
-				this._currentGeo.Geometry.skinWeights.push( new THREE.Vector4( 1, 0, 0, 0 ) );
+				this._currentGeo.GeometryData.vertices.push( parseFloat( data[ 0 ] ), parseFloat( data[ 1 ] ), parseFloat( data[ 2 ] ) );
+				this._currentGeo.GeometryData.skinIndices.push( 0, 0, 0, 0 );
+				this._currentGeo.GeometryData.skinWeights.push( 1, 0, 0, 0 );
 				this._currentGeo.VertexSetedBoneCount.push( 0 );
 
 			}
@@ -933,7 +933,7 @@
 			value: function _readFace1( line ) {
 
 				var data = this._readLine( line.trim() ).substr( 2, line.length - 4 ).split( "," );
-				this._currentGeo.Geometry.faces.push( new THREE.Face3( parseInt( data[ 0 ], 10 ), parseInt( data[ 1 ], 10 ), parseInt( data[ 2 ], 10 ), new THREE.Vector3( 1, 1, 1 ).normalize() ) );
+				this._currentGeo.GeometryData.indices.push( parseInt( data[ 0 ], 10 ), parseInt( data[ 1 ], 10 ), parseInt( data[ 2 ], 10 ) );
 
 			}
 		}, {
@@ -941,76 +941,97 @@
 			value: function _readNormalVector1( line ) {
 
 				var data = this._readLine( line.trim() ).substr( 0, line.length - 2 ).split( ";" );
-				this._currentGeo.normalVectors.push( new THREE.Vector3( parseFloat( data[ 0 ] ), parseFloat( data[ 1 ] ), parseFloat( data[ 2 ] ) ) );
+				this._currentGeo.GeometryData.normals.push( parseFloat( data[ 0 ] ), parseFloat( data[ 1 ] ), parseFloat( data[ 2 ] ) );
 
 			}
 		}, {
-			key: '_readNormalFace1',
-			value: function _readNormalFace1( line, nowReaded ) {
+			key: '_buildGeometry',
+			value: function _buildGeometry() {
 
-				var data = this._readLine( line.trim() ).substr( 2, line.length - 4 ).split( "," );
-				var nowID = parseInt( data[ 0 ], 10 );
-				var v1 = this._currentGeo.normalVectors[ nowID ];
-				nowID = parseInt( data[ 1 ], 10 );
-				var v2 = this._currentGeo.normalVectors[ nowID ];
-				nowID = parseInt( data[ 2 ], 10 );
-				var v3 = this._currentGeo.normalVectors[ nowID ];
-				this._currentGeo.Geometry.faces[ nowReaded ].vertexNormals = [ v1, v2, v3 ];
+				var bufferGeometry = new THREE.BufferGeometry();
+				var position = [];
+				var normals = [];
+				var uvs = [];
+				var skinIndices = [];
+				var skinWeights = [];
+
+				//
+
+				var data = this._currentGeo.GeometryData;
+
+				for ( var i = 0, l = data.indices.length; i < l; i ++ ) {
+
+					var stride2 = data.indices[ i ] * 2;
+					var stride3 = data.indices[ i ] * 3;
+					var stride4 = data.indices[ i ] * 4;
+
+					position.push( data.vertices[ stride3 ], data.vertices[ stride3 + 1 ], data.vertices[ stride3 + 2 ] );
+					normals.push( data.normals[ stride3 ], data.normals[ stride3 + 1 ], data.normals[ stride3 + 2 ] );
+					skinIndices.push( data.skinIndices[ stride4 ], data.skinIndices[ stride4 + 1 ], data.skinIndices[ stride4 + 2 ], data.skinIndices[ stride4 + 3 ] );
+					skinWeights.push( data.skinWeights[ stride4 ], data.skinWeights[ stride4 + 1 ], data.skinWeights[ stride4 + 2 ], data.skinWeights[ stride4 + 3 ] );
+					uvs.push( data.uvs[ stride2 ], data.uvs[ stride2 + 1 ] );
+
+				}
+
+				//
+
+				bufferGeometry.addAttribute( 'position', new THREE.Float32BufferAttribute( position, 3 ) );
+				bufferGeometry.addAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
+				bufferGeometry.addAttribute( 'uv', new THREE.Float32BufferAttribute( uvs, 2 ) );
+				bufferGeometry.addAttribute( 'skinIndex', new THREE.Uint16BufferAttribute( skinIndices, 4 ) );
+				bufferGeometry.addAttribute( 'skinWeight', new THREE.Float32BufferAttribute( skinWeights, 4 ) );
+
+				this._computeGroups( bufferGeometry, data.materialIndices );
+
+				return bufferGeometry;
 
 			}
 		}, {
-			key: '_setMeshNormals',
-			value: function _setMeshNormals() {
+			key: '_computeGroups',
+			value: function _computeGroups( bufferGeometry, materialIndices ) {
 
-				var endRead = 0;
-				var mode = 0;
-				var mode_local = 0;
-				while ( true ) {
+				var group;
+				var groups = [];
+				var materialIndex = undefined;
 
-					switch ( mode ) {
+				for ( var i = 0; i < materialIndices.length; i ++ ) {
 
-						case 0:
-							if ( mode_local === 0 ) {
+					var currentMaterialIndex = materialIndices[ i ];
 
-								var refO = this._readInt1( 0 );
-								endRead = refO.endRead;
-								mode_local = 1;
+					if ( currentMaterialIndex !== materialIndex ) {
 
-							} else {
+						materialIndex = currentMaterialIndex;
 
-								var find = this._currentObject.data.indexOf( ',', endRead ) + 1;
-								if ( find === - 1 ) {
+						if ( group !== undefined ) {
 
-									find = this._currentObject.data.indexOf( ';;', endRead ) + 1;
-									mode = 2;
-									mode_local = 0;
+							group.count = ( i * 3 ) - group.start;
+							groups.push( group );
 
-								}
-								var line = this._currentObject.data.substr( endRead, find - endRead );
-								var data = this._readLine( line.trim() ).split( ";" );
-								this._currentGeo.normalVectors.push( [ parseFloat( data[ 0 ] ), parseFloat( data[ 1 ] ), parseFloat( data[ 2 ] ) ] );
-								endRead = find + 1;
+						}
 
-							}
-							break;
-
-					}
-					if ( endRead >= this._currentObject.data.length ) {
-
-						break;
+						group = {
+							start: i * 3,
+							materialIndex: materialIndex
+						};
 
 					}
 
 				}
+
+				if ( group !== undefined ) {
+
+					group.count = ( i * 3 ) - group.start;
+					groups.push( group );
+
+				}
+
+				bufferGeometry.groups = groups;
 
 			}
 		}, {
 			key: '_setMeshTextureCoords',
 			value: function _setMeshTextureCoords() {
 
-				this._tmpUvArray = [];
-				this._currentGeo.Geometry.faceVertexUvs = [];
-				this._currentGeo.Geometry.faceVertexUvs.push( [] );
 				var endRead = 0;
 				var mode = 0;
 				var mode_local = 0;
@@ -1039,11 +1060,11 @@
 								var data = this._readLine( line.trim() ).split( ";" );
 								if ( this.IsUvYReverse ) {
 
-									this._tmpUvArray.push( new THREE.Vector2( parseFloat( data[ 0 ] ), 1 - parseFloat( data[ 1 ] ) ) );
+									this._currentGeo.GeometryData.uvs.push( parseFloat( data[ 0 ] ), 1 - parseFloat( data[ 1 ] ) );
 
 								} else {
 
-									this._tmpUvArray.push( new THREE.Vector2( parseFloat( data[ 0 ] ), parseFloat( data[ 1 ] ) ) );
+									this._currentGeo.GeometryData.uvs.push( parseFloat( data[ 0 ] ), parseFloat( data[ 1 ] ) );
 
 								}
 								endRead = find + 1;
@@ -1059,16 +1080,6 @@
 					}
 
 				}
-				this._currentGeo.Geometry.faceVertexUvs[ 0 ] = [];
-				for ( var m = 0; m < this._currentGeo.Geometry.faces.length; m ++ ) {
-
-					this._currentGeo.Geometry.faceVertexUvs[ 0 ][ m ] = [];
-					this._currentGeo.Geometry.faceVertexUvs[ 0 ][ m ].push( this._tmpUvArray[ this._currentGeo.Geometry.faces[ m ].a ] );
-					this._currentGeo.Geometry.faceVertexUvs[ 0 ][ m ].push( this._tmpUvArray[ this._currentGeo.Geometry.faces[ m ].b ] );
-					this._currentGeo.Geometry.faceVertexUvs[ 0 ][ m ].push( this._tmpUvArray[ this._currentGeo.Geometry.faces[ m ].c ] );
-
-				}
-				this._currentGeo.Geometry.uvsNeedUpdate = true;
 
 			}
 		}, {
@@ -1100,7 +1111,7 @@
 						var data = this._readLine( line.trim() ).split( "," );
 						for ( var i = 0; i < data.length; i ++ ) {
 
-							this._currentGeo.Geometry.faces[ i ].materialIndex = parseInt( data[ i ] );
+							this._currentGeo.GeometryData.materialIndices[ i ] = parseInt( data[ i ] );
 
 						}
 						endRead = this._currentObject.data.length;
@@ -1286,13 +1297,6 @@
 			key: '_makeOutputGeometry',
 			value: function _makeOutputGeometry() {
 
-				this._currentGeo.Geometry.computeBoundingBox();
-				this._currentGeo.Geometry.computeBoundingSphere();
-				this._currentGeo.Geometry.verticesNeedUpdate = true;
-				this._currentGeo.Geometry.normalsNeedUpdate = true;
-				this._currentGeo.Geometry.colorsNeedUpdate = true;
-				this._currentGeo.Geometry.uvsNeedUpdate = true;
-				this._currentGeo.Geometry.groupsNeedUpdate = true;
 				var mesh = null;
 				if ( this._currentGeo.BoneInfs.length > 0 ) {
 
@@ -1317,23 +1321,26 @@
 
 							var nowVertexID = this._currentGeo.BoneInfs[ bi ].Indeces[ vi ];
 							var nowVal = this._currentGeo.BoneInfs[ bi ].Weights[ vi ];
+
+							var stride = nowVertexID * 4;
+
 							switch ( this._currentGeo.VertexSetedBoneCount[ nowVertexID ] ) {
 
 								case 0:
-									this._currentGeo.Geometry.skinIndices[ nowVertexID ].x = boneIndex;
-									this._currentGeo.Geometry.skinWeights[ nowVertexID ].x = nowVal;
+									this._currentGeo.GeometryData.skinIndices[ stride ] = boneIndex;
+									this._currentGeo.GeometryData.skinWeights[ stride ] = nowVal;
 									break;
 								case 1:
-									this._currentGeo.Geometry.skinIndices[ nowVertexID ].y = boneIndex;
-									this._currentGeo.Geometry.skinWeights[ nowVertexID ].y = nowVal;
+									this._currentGeo.GeometryData.skinIndices[ stride + 1 ] = boneIndex;
+									this._currentGeo.GeometryData.skinWeights[ stride + 1 ] = nowVal;
 									break;
 								case 2:
-									this._currentGeo.Geometry.skinIndices[ nowVertexID ].z = boneIndex;
-									this._currentGeo.Geometry.skinWeights[ nowVertexID ].z = nowVal;
+									this._currentGeo.GeometryData.skinIndices[ stride + 2 ] = boneIndex;
+									this._currentGeo.GeometryData.skinWeights[ stride + 2 ] = nowVal;
 									break;
 								case 3:
-									this._currentGeo.Geometry.skinIndices[ nowVertexID ].w = boneIndex;
-									this._currentGeo.Geometry.skinWeights[ nowVertexID ].w = nowVal;
+									this._currentGeo.GeometryData.skinIndices[ stride + 3 ] = boneIndex;
+									this._currentGeo.GeometryData.skinWeights[ stride + 3 ] = nowVal;
 									break;
 
 							}
@@ -1366,14 +1373,15 @@
 						}
 
 					}
-					var bufferGeometry = new THREE.BufferGeometry().fromGeometry( this._currentGeo.Geometry );
+
+					var bufferGeometry = this._buildGeometry();
 					bufferGeometry.bones = putBones;
 					mesh = new THREE.SkinnedMesh( bufferGeometry, this._currentGeo.Materials.length === 1 ? this._currentGeo.Materials[ 0 ] : this._currentGeo.Materials );
 					mesh.skeleton.boneInverses = offsetList;
 
 				} else {
 
-					var _bufferGeometry = new THREE.BufferGeometry().fromGeometry( this._currentGeo.Geometry );
+					var _bufferGeometry = this._buildGeometry();
 					mesh = new THREE.Mesh( _bufferGeometry, this._currentGeo.Materials.length === 1 ? this._currentGeo.Materials[ 0 ] : this._currentGeo.Materials );
 
 				}


### PR DESCRIPTION
`XLoader` already created a `BufferGeometry` but internally used `Geometry` as an intermediate data structure. The PR removes the usage of `Geometry`. In this way, the loader allocates much less memory and is also faster.

/cc @adrs2002 