### PR TITLE
Introduce usage of Vertex Array Objects (VAO)

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -40,6 +40,8 @@ function BufferGeometry() {
 
 	this.userData = {};
 
+	this.version = 0;
+
 }
 
 BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
@@ -66,6 +68,8 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
+		this.version ++;
+
 	},
 
 	addAttribute: function ( name, attribute ) {
@@ -89,6 +93,8 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		this.attributes[ name ] = attribute;
 
+		this.version ++;
+
 		return this;
 
 	},
@@ -102,6 +108,8 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 	removeAttribute: function ( name ) {
 
 		delete this.attributes[ name ];
+
+		this.version ++;
 
 		return this;
 

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -1,0 +1,237 @@
+/**
+ * @author Mugen87 / https://github.com/Mugen87
+ */
+
+function WebGLBindingStates( gl, extensions, state, attributes ) {
+
+	var bindingStates = {};
+	var extension = extensions.get( 'OES_vertex_array_object' );
+	var currentGeometryProgram = '';
+
+	function setup( material, program, geometry, index, hasMorphTarget ) {
+
+		var geometryProgram = geometry.id + '_' + program.id + '_' + ( material.wireframe === true );
+
+		// only use VAO if extension is available
+		// if morph targets are present we render it the old way
+
+		if ( extension && hasMorphTarget === false ) {
+
+			state.enableVAO();
+
+			var bindingState = bindingStates[ geometryProgram ];
+
+			if ( bindingState === undefined ) {
+
+				bindingState = createBindingState( material, program, geometry, index );
+				bindingStates[ geometryProgram ] = bindingState;
+
+			}
+
+			extension.bindVertexArrayOES( bindingState );
+
+		} else {
+
+			state.disableVAO();
+
+			if ( geometryProgram !== currentGeometryProgram ) {
+
+				currentGeometryProgram = geometryProgram;
+
+				setupVertexAttributes( material, program, geometry );
+				setupElementArrayBuffer( index );
+
+			}
+
+		}
+
+	}
+
+	function createBindingState( material, program, geometry, index ) {
+
+		var vao = extension.createVertexArrayOES();
+		extension.bindVertexArrayOES( vao );
+
+		setupVertexAttributes( material, program, geometry );
+		setupElementArrayBuffer( index );
+
+		extension.bindVertexArrayOES( null );
+
+		return vao;
+
+	}
+
+	function setupVertexAttributes( material, program, geometry ) {
+
+		if ( geometry && geometry.isInstancedBufferGeometry ) {
+
+			if ( extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
+
+				console.error( 'THREE.WebGLBindingStates.setupVertexAttributes: using THREE.InstancedBufferGeometry but hardware does not support extension ANGLE_instanced_arrays.' );
+				return;
+
+			}
+
+		}
+
+		state.initAttributes();
+
+		var geometryAttributes = geometry.attributes;
+
+		var programAttributes = program.getAttributes();
+
+		var materialDefaultAttributeValues = material.defaultAttributeValues;
+
+		for ( var name in programAttributes ) {
+
+			var programAttribute = programAttributes[ name ];
+
+			if ( programAttribute >= 0 ) {
+
+				var geometryAttribute = geometryAttributes[ name ];
+
+				if ( geometryAttribute !== undefined ) {
+
+					var normalized = geometryAttribute.normalized;
+					var size = geometryAttribute.itemSize;
+
+					var attribute = attributes.get( geometryAttribute );
+
+					// TODO Attribute may not be available on context restore
+
+					if ( attribute === undefined ) continue;
+
+					var buffer = attribute.buffer;
+					var type = attribute.type;
+					var bytesPerElement = attribute.bytesPerElement;
+
+					if ( geometryAttribute.isInterleavedBufferAttribute ) {
+
+						var data = geometryAttribute.data;
+						var stride = data.stride;
+						var offset = geometryAttribute.offset;
+
+						if ( data && data.isInstancedInterleavedBuffer ) {
+
+							state.enableAttributeAndDivisor( programAttribute, data.meshPerAttribute );
+
+							if ( geometry.maxInstancedCount === undefined ) {
+
+								geometry.maxInstancedCount = data.meshPerAttribute * data.count;
+
+							}
+
+						} else {
+
+							state.enableAttribute( programAttribute );
+
+						}
+
+						gl.bindBuffer( gl.ARRAY_BUFFER, buffer );
+						gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
+
+					} else {
+
+						if ( geometryAttribute.isInstancedBufferAttribute ) {
+
+							state.enableAttributeAndDivisor( programAttribute, geometryAttribute.meshPerAttribute );
+
+							if ( geometry.maxInstancedCount === undefined ) {
+
+								geometry.maxInstancedCount = geometryAttribute.meshPerAttribute * geometryAttribute.count;
+
+							}
+
+						} else {
+
+							state.enableAttribute( programAttribute );
+
+						}
+
+						gl.bindBuffer( gl.ARRAY_BUFFER, buffer );
+						gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
+
+					}
+
+				} else if ( materialDefaultAttributeValues !== undefined ) {
+
+					var value = materialDefaultAttributeValues[ name ];
+
+					if ( value !== undefined ) {
+
+						switch ( value.length ) {
+
+							case 2:
+								gl.vertexAttrib2fv( programAttribute, value );
+								break;
+
+							case 3:
+								gl.vertexAttrib3fv( programAttribute, value );
+								break;
+
+							case 4:
+								gl.vertexAttrib4fv( programAttribute, value );
+								break;
+
+							default:
+								gl.vertexAttrib1fv( programAttribute, value );
+
+						}
+
+					}
+
+				}
+
+			}
+
+		}
+
+		state.disableUnusedAttributes();
+
+	}
+
+	function setupElementArrayBuffer( index ) {
+
+		if ( index !== null ) {
+
+			var attribute = attributes.get( index );
+			gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, attribute.buffer );
+
+		}
+
+	}
+
+	function resetBindingState() {
+
+		if ( extension ) {
+
+			extension.bindVertexArrayOES( null );
+
+		}
+
+	}
+
+	function resetGeometryProgram() {
+
+		currentGeometryProgram = '';
+
+	}
+
+	function dispose() {
+
+		bindingStates = {};
+
+	}
+
+	return {
+		setup: setup,
+		dispose: dispose,
+
+		resetBindingState: resetBindingState,
+		resetGeometryProgram: resetGeometryProgram
+	};
+
+}
+
+
+export { WebGLBindingStates };

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -10,7 +10,7 @@ function WebGLBindingStates( gl, extensions, state, attributes ) {
 
 	function setup( material, program, geometry, index, hasMorphTarget ) {
 
-		var geometryProgram = geometry.id + '_' + program.id + '_' + ( material.wireframe === true );
+		var geometryProgram = geometry.id + '_' + geometry.version + '_' + program.id + '_' + ( material.wireframe === true );
 
 		// only use VAO if extension is available
 		// if morph targets are present we render it the old way


### PR DESCRIPTION
This PR introduces the usage of [Vertex Array Objects](https://blog.tojicode.com/2012/10/oesvertexarrayobject-extension.html) (VAO), a performance primitive of WebGL (see https://github.com/mrdoob/three.js/issues/8705). A new class `WebGLBindingStates` manages now the buffer bindings and pointers for a single entity. VAO can only be used via an extension, the support though is really high (96% according to http://webglstats.com/webgl/extension/OES_vertex_array_object). Besides VAOs are part of the core of WebGL2.

If the extension is not available, `three.js` renders the old way. It also uses the old render path if morph targets are present, since it's pretty complicated to manage the flexible state of morph target attributes with VAOs. Maybe we find a solution for this in the future.

The amount of changes is actually manageable. Most changes are caused by refactoring, since certain code like `setupVertexAttributes()` moved from `WebGLRenderer` to `WebGLBindingStates`. I've tested most examples and they still work, although intensive testing is important for such a change. 

Also see https://github.com/mrdoob/three.js/issues/8705#issuecomment-296177105
