### PR TITLE
Don't use 'window' if it isn't available

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1029,7 +1029,8 @@ function WebGLRenderer( parameters ) {
 
 	var animation = new WebGLAnimation();
 	animation.setAnimationLoop( onAnimationFrame );
-	animation.setContext( typeof window !== 'undefined' ? window : null );
+
+	if ( typeof window !== 'undefined' ) animation.setContext( window );
 
 	this.setAnimationLoop = function ( callback ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1029,7 +1029,7 @@ function WebGLRenderer( parameters ) {
 
 	var animation = new WebGLAnimation();
 	animation.setAnimationLoop( onAnimationFrame );
-	animation.setContext( window );
+	animation.setContext( typeof window !== 'undefined' ? window : null );
 
 	this.setAnimationLoop = function ( callback ) {
 


### PR DESCRIPTION
You can no longer instantiate the `WebGLRenderer` in a worker context since r93 because of the `WebGLAnimation` things that have been added to the `WebGLRenderer` constructor code.

It blatantly assumes there is a `window` object available, which results in an immediate reference error as soon as you instantiate the renderer.

This PR fixes that, although it _will_ result in errors when trying to use the `onAnimationFrame` functionality since it also assumes `requestAnimationFrame` is available in a worker context.

Then again, using `requestAnimationFrame` from a worker context doesn't make much sense anyway. 😄 
