### PR TITLE
DirectGeometry: Update error test for faceless geometries

### DIFF
--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -140,7 +140,7 @@ Object.assign( DirectGeometry.prototype, {
 
 		//
 
-		if ( faces.length === 0 ) {
+		if ( vertices.length > 0 && faces.length === 0 ) {
 
 			console.error( 'THREE.DirectGeometry: Faceless geometries are not supported.' );
 


### PR DESCRIPTION
With this modification, the error message will not be triggered for new, empty geometries. See #14234 for context.