### PR TITLE
add Material serialization hook

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -133,7 +133,7 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
-	toJSON: function ( meta, onBeforeSerialize, onAfterSerialize ) {
+	toJSON: function ( meta, onBeforeSerialize ) {
 
 		var isRoot = ( meta === undefined || typeof meta === 'string' );
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -133,7 +133,7 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
-	toJSON: function ( meta ) {
+	toJSON: function ( meta, onBeforeSerialize, onAfterSerialize ) {
 
 		var isRoot = ( meta === undefined || typeof meta === 'string' );
 
@@ -153,6 +153,8 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 				generator: 'Material.toJSON'
 			}
 		};
+
+		if ( onBeforeSerialize ) onBeforeSerialize( data, meta );
 
 		// standard Material serialization
 		data.uuid = this.uuid;


### PR DESCRIPTION
Related to `onBeforeCompile` and serialization. 

I find it odd that `Material` super class is aware of all the properties of all the sub classed materials:

https://github.com/mrdoob/three.js/blob/dev/src/materials/Material.js#L165-L166

Serialization has been cited as a problem with shader injections. However, with this i was able to write my own properties with the `myExtendedMaterial.toJSON()` as well as store references to textures. 

https://github.com/mrdoob/three.js/pull/14231

What are generally the pain points of serializing this stuff? `userData` is also serialized and could be overloaded with anything, but it would make more sense to control what's included from the level of the owner of the properties. 
