### PR TITLE
Docs: Some Geometries were missing mention of parameters property

### DIFF
--- a/docs/api/geometries/BoxBufferGeometry.html
+++ b/docs/api/geometries/BoxBufferGeometry.html
@@ -54,9 +54,12 @@
 
 		<h2>Properties</h2>
 
-		<h3>.parameters</h3>
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
  		<p>
-			<p>Using the above example code above as our basis:</p>
+			Using the above example code above as our basis:
 			<code>
 		geometry.parameters; // outputs an object {width: 1, height: 1, depth: 1, widthSegments: undefined, heightSegments: undefined}
 		cube.geometry.parameters; // as above

--- a/docs/api/geometries/BoxGeometry.html
+++ b/docs/api/geometries/BoxGeometry.html
@@ -54,9 +54,12 @@
 
 		<h2>Properties</h2>
 
-		<h3>.parameters</h3>
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
  		<p>
-			<p>Using the above example code above as our basis:</p>
+			Using the above example code above as our basis:
 			<code>
 				geometry.parameters; // outputs an object {width: 1, height: 1, depth: 1, widthSegments: undefined, heightSegments: undefined}
 				cube.geometry.parameters; // as above

--- a/docs/api/geometries/CircleBufferGeometry.html
+++ b/docs/api/geometries/CircleBufferGeometry.html
@@ -51,6 +51,13 @@
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete circle.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/geometries/CircleGeometry.js src/geometries/CircleGeometry.js]

--- a/docs/api/geometries/CircleGeometry.html
+++ b/docs/api/geometries/CircleGeometry.html
@@ -52,6 +52,13 @@
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete circle.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/geometries/ConeBufferGeometry.html
+++ b/docs/api/geometries/ConeBufferGeometry.html
@@ -55,8 +55,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/ConeBufferGeometry.html
+++ b/docs/api/geometries/ConeBufferGeometry.html
@@ -55,9 +55,9 @@
 
 		<h2>Properties</h2>
 
-		<h3>.parameters</h3>
+		<h3>[property:Object parameters]</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/ConeGeometry.html
+++ b/docs/api/geometries/ConeGeometry.html
@@ -55,8 +55,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/ConeGeometry.html
+++ b/docs/api/geometries/ConeGeometry.html
@@ -55,9 +55,9 @@
 
 		<h2>Properties</h2>
 
-		<h3>.parameters</h3>
+		<h3>[property:Object parameters]</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/CylinderBufferGeometry.html
+++ b/docs/api/geometries/CylinderBufferGeometry.html
@@ -56,9 +56,9 @@
 
 		<h2>Properties</h2>
 
-		<h3>.parameters</h3>
+		<h3>[property:Object parameters]</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/CylinderBufferGeometry.html
+++ b/docs/api/geometries/CylinderBufferGeometry.html
@@ -56,8 +56,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/CylinderGeometry.html
+++ b/docs/api/geometries/CylinderGeometry.html
@@ -56,9 +56,9 @@
 
 		<h2>Properties</h2>
 
-		<h3>.parameters</h3>
+		<h3>[property:Object parameters]</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/CylinderGeometry.html
+++ b/docs/api/geometries/CylinderGeometry.html
@@ -56,8 +56,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/DodecahedronBufferGeometry.html
+++ b/docs/api/geometries/DodecahedronBufferGeometry.html
@@ -44,7 +44,7 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/DodecahedronGeometry.html
+++ b/docs/api/geometries/DodecahedronGeometry.html
@@ -44,7 +44,7 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/EdgesGeometry.html
+++ b/docs/api/geometries/EdgesGeometry.html
@@ -33,6 +33,13 @@ scene.add( line );
 		thresholdAngle — An edge is only rendered if the angle (in degrees) between the face normals of the adjoining faces exceeds this value. default = 1 degree.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/geometries/ExtrudeBufferGeometry.html
+++ b/docs/api/geometries/ExtrudeBufferGeometry.html
@@ -92,6 +92,13 @@
 			applied to the face; the second material will be applied to the sides.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/geometries/ExtrudeGeometry.js src/geometries/ExtrudeGeometry.js]

--- a/docs/api/geometries/ExtrudeGeometry.html
+++ b/docs/api/geometries/ExtrudeGeometry.html
@@ -92,6 +92,13 @@
 			applied to the face; the second material will be applied to the sides.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/geometries/IcosahedronBufferGeometry.html
+++ b/docs/api/geometries/IcosahedronBufferGeometry.html
@@ -43,7 +43,7 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/IcosahedronGeometry.html
+++ b/docs/api/geometries/IcosahedronGeometry.html
@@ -44,7 +44,7 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/LatheBufferGeometry.html
+++ b/docs/api/geometries/LatheBufferGeometry.html
@@ -58,6 +58,13 @@
 		This creates a LatheBufferGeometry based on the parameters.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/geometries/LatheGeometry.js src/geometries/LatheGeometry.js]

--- a/docs/api/geometries/LatheGeometry.html
+++ b/docs/api/geometries/LatheGeometry.html
@@ -58,6 +58,13 @@
 		This creates a LatheGeometry based on the parameters.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/geometries/OctahedronBufferGeometry.html
+++ b/docs/api/geometries/OctahedronBufferGeometry.html
@@ -43,7 +43,7 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/OctahedronGeometry.html
+++ b/docs/api/geometries/OctahedronGeometry.html
@@ -44,7 +44,7 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/ParametricBufferGeometry.html
+++ b/docs/api/geometries/ParametricBufferGeometry.html
@@ -52,6 +52,13 @@
 		stacks — The count of stacks to use for the parametric function
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 
 		<h2>Source</h2>
 

--- a/docs/api/geometries/ParametricGeometry.html
+++ b/docs/api/geometries/ParametricGeometry.html
@@ -53,6 +53,14 @@
 		</p>
 
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/geometries/PlaneBufferGeometry.html
+++ b/docs/api/geometries/PlaneBufferGeometry.html
@@ -54,7 +54,7 @@
 
 		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/PlaneBufferGeometry.html
+++ b/docs/api/geometries/PlaneBufferGeometry.html
@@ -52,8 +52,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/PlaneGeometry.html
+++ b/docs/api/geometries/PlaneGeometry.html
@@ -52,8 +52,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the contructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/PlaneGeometry.html
+++ b/docs/api/geometries/PlaneGeometry.html
@@ -54,7 +54,7 @@
 
 		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/PolyhedronBufferGeometry.html
+++ b/docs/api/geometries/PolyhedronBufferGeometry.html
@@ -53,7 +53,7 @@ var geometry = new THREE.PolyhedronBufferGeometry( verticesOfCube, indicesOfFace
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 

--- a/docs/api/geometries/PolyhedronGeometry.html
+++ b/docs/api/geometries/PolyhedronGeometry.html
@@ -51,7 +51,7 @@ var geometry = new THREE.PolyhedronGeometry( verticesOfCube, indicesOfFaces, 6, 
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 

--- a/docs/api/geometries/RingBufferGeometry.html
+++ b/docs/api/geometries/RingBufferGeometry.html
@@ -52,6 +52,15 @@
 		thetaLength — Central angle.  Default is Math.PI * 2.
 		</p>
 
+
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/geometries/RingGeometry.js src/geometries/RingGeometry.js]

--- a/docs/api/geometries/RingGeometry.html
+++ b/docs/api/geometries/RingGeometry.html
@@ -52,6 +52,14 @@
 		thetaLength — Central angle.  Default is Math.PI * 2.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+		
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/geometries/ShapeBufferGeometry.html
+++ b/docs/api/geometries/ShapeBufferGeometry.html
@@ -64,6 +64,13 @@
 		curveSegments - [page:Integer] - Number of segments per shape. Default is 12.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/geometries/ShapeGeometry.js src/geometries/ShapeGeometry.js]

--- a/docs/api/geometries/ShapeGeometry.html
+++ b/docs/api/geometries/ShapeGeometry.html
@@ -64,6 +64,13 @@
 		curveSegments - [page:Integer] - Number of segments per shape. Default is 12.
 		</p>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 
 		<h2>Source</h2>
 

--- a/docs/api/geometries/SphereBufferGeometry.html
+++ b/docs/api/geometries/SphereBufferGeometry.html
@@ -62,7 +62,7 @@
 
 		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/SphereBufferGeometry.html
+++ b/docs/api/geometries/SphereBufferGeometry.html
@@ -60,8 +60,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/SphereGeometry.html
+++ b/docs/api/geometries/SphereGeometry.html
@@ -62,7 +62,7 @@
 
 		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/SphereGeometry.html
+++ b/docs/api/geometries/SphereGeometry.html
@@ -60,8 +60,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TetrahedronBufferGeometry.html
+++ b/docs/api/geometries/TetrahedronBufferGeometry.html
@@ -44,8 +44,10 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+
 
 		<h2>Source</h2>
 

--- a/docs/api/geometries/TetrahedronGeometry.html
+++ b/docs/api/geometries/TetrahedronGeometry.html
@@ -44,7 +44,7 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TextBufferGeometry.html
+++ b/docs/api/geometries/TextBufferGeometry.html
@@ -153,6 +153,13 @@
 			</tr>
 		</table>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/geometries/TextGeometry.js src/geometries/TextGeometry.js]

--- a/docs/api/geometries/TextGeometry.html
+++ b/docs/api/geometries/TextGeometry.html
@@ -153,6 +153,13 @@
 			</tr>
 		</table>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/geometries/TorusBufferGeometry.html
+++ b/docs/api/geometries/TorusBufferGeometry.html
@@ -55,7 +55,7 @@
 
 		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TorusBufferGeometry.html
+++ b/docs/api/geometries/TorusBufferGeometry.html
@@ -53,8 +53,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TorusGeometry.html
+++ b/docs/api/geometries/TorusGeometry.html
@@ -55,7 +55,7 @@
 
 		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TorusGeometry.html
+++ b/docs/api/geometries/TorusGeometry.html
@@ -53,8 +53,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/geometries/TorusKnotBufferGeometry.html
@@ -58,7 +58,7 @@
 
 		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/geometries/TorusKnotBufferGeometry.html
@@ -56,8 +56,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TorusKnotGeometry.html
+++ b/docs/api/geometries/TorusKnotGeometry.html
@@ -58,7 +58,7 @@
 
 		<h3>.parameters</h3>
 		<p>
-		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TorusKnotGeometry.html
+++ b/docs/api/geometries/TorusKnotGeometry.html
@@ -56,8 +56,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>.parameters</h3>
 		<p>
-		Each of the contructor parameters is accessible as a property of the same name. Any modification of these properties after instantiation does not change the geometry.
+		Each of the constructor parameters is accessible in the parameters property of the object. Any modification of these properties after instantiation does not change the geometry.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/geometries/TubeBufferGeometry.html
+++ b/docs/api/geometries/TubeBufferGeometry.html
@@ -80,7 +80,7 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h3>[property:Array tangents]</h3>

--- a/docs/api/geometries/TubeGeometry.html
+++ b/docs/api/geometries/TubeGeometry.html
@@ -80,7 +80,7 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		An object with all of the parameters that were used to generate the geometry.
+		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
 		<h3>[property:Array tangents]</h3>

--- a/test/unit/src/cameras/OrthographicCamera.tests.js
+++ b/test/unit/src/cameras/OrthographicCamera.tests.js
@@ -54,7 +54,7 @@ export default QUnit.module( 'Cameras', () => {
 			var left = - 1, right = 1, top = 1, bottom = - 1, near = 1, far = 3;
 			var cam = new OrthographicCamera( left, right, top, bottom, near, far );
 
-			// updateProjectionMatrix is called in contructor
+			// updateProjectionMatrix is called in constructor
 			var pMatrix = cam.projectionMatrix.elements;
 
 			// orthographic projection is given my the 4x4 Matrix

--- a/test/unit/src/cameras/PerspectiveCamera.tests.js
+++ b/test/unit/src/cameras/PerspectiveCamera.tests.js
@@ -108,7 +108,7 @@ export default QUnit.module( 'Cameras', () => {
 
 			var cam = new PerspectiveCamera( 75, 16 / 9, 0.1, 300.0 );
 
-			// updateProjectionMatrix is called in contructor
+			// updateProjectionMatrix is called in constructor
 			var m = cam.projectionMatrix;
 
 			// perspective projection is given my the 4x4 Matrix


### PR DESCRIPTION
Fixes some cases where the parameters property of a Geometry class was not explicitly mentioned