### PR TITLE
Font: Remove unused divisions parameter from .generateShapes()

### DIFF
--- a/docs/api/extras/core/Font.html
+++ b/docs/api/extras/core/Font.html
@@ -46,11 +46,10 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null generateShapes]( [param:String text], [param:Float size], [param:Integer divisions] )</h3>
+		<h3>[method:null generateShapes]( [param:String text], [param:Float size] )</h3>
 		<p>
 			[page:String text] -- string of text.<br />
 			[page:Float size] -- (optional) scale for the [page:Shape Shapes]. Default is *100*.<br />
-			[page:Integer divisions] -- (optional) fineness of the [page:Shape Shapes]. Default is *4*.<br />
 
 			Creates an array of [page:Shape Shapes] representing the text in the font.
 		</p>

--- a/examples/webgl_geometry_text_shapes.html
+++ b/examples/webgl_geometry_text_shapes.html
@@ -69,7 +69,7 @@
 
 					var message = "   Three.js\nSimple text.";
 
-					var shapes = font.generateShapes( message, 100, 2 );
+					var shapes = font.generateShapes( message, 100 );
 
 					var geometry = new THREE.ShapeGeometry( shapes );
 
@@ -118,7 +118,7 @@
 
 						var points = shape.getPoints();
 						var geometry = new THREE.BufferGeometry().setFromPoints( points );
-						
+
 						geometry.translate( xMid, 0, 0 );
 
 						var lineMesh = new THREE.Line( geometry, matDark );

--- a/examples/webgl_shaders_vector.html
+++ b/examples/webgl_shaders_vector.html
@@ -107,7 +107,7 @@
 					wireframe: true
 				} );
 
-				var textShapes = font.generateShapes( theText, 180, 2 );
+				var textShapes = font.generateShapes( theText, 180 );
 
 				var geometry = new THREE.ShapeBufferGeometry( textShapes );
 

--- a/src/extras/core/Font.js
+++ b/src/extras/core/Font.js
@@ -18,13 +18,12 @@ Object.assign( Font.prototype, {
 
 	isFont: true,
 
-	generateShapes: function ( text, size, divisions ) {
+	generateShapes: function ( text, size ) {
 
 		if ( size === undefined ) size = 100;
-		if ( divisions === undefined ) divisions = 4;
 
 		var shapes = [];
-		var paths = createPaths( text, size, divisions, this.data );
+		var paths = createPaths( text, size, this.data );
 
 		for ( var p = 0, pl = paths.length; p < pl; p ++ ) {
 
@@ -38,7 +37,7 @@ Object.assign( Font.prototype, {
 
 } );
 
-function createPaths( text, size, divisions, data ) {
+function createPaths( text, size, data ) {
 
 	var chars = Array.from ? Array.from( text ) : String( text ).split( '' ); // see #13988
 	var scale = size / data.resolution;
@@ -59,7 +58,7 @@ function createPaths( text, size, divisions, data ) {
 
 		} else {
 
-			var ret = createPath( char, divisions, scale, offsetX, offsetY, data );
+			var ret = createPath( char, scale, offsetX, offsetY, data );
 			offsetX += ret.offsetX;
 			paths.push( ret.path );
 
@@ -71,7 +70,7 @@ function createPaths( text, size, divisions, data ) {
 
 }
 
-function createPath( char, divisions, scale, offsetX, offsetY, data ) {
+function createPath( char, scale, offsetX, offsetY, data ) {
 
 	var glyph = data.glyphs[ char ] || data.glyphs[ '?' ];
 

--- a/src/geometries/TextGeometry.js
+++ b/src/geometries/TextGeometry.js
@@ -56,7 +56,7 @@ function TextBufferGeometry( text, parameters ) {
 
 	}
 
-	var shapes = font.generateShapes( text, parameters.size, parameters.curveSegments );
+	var shapes = font.generateShapes( text, parameters.size );
 
 	// translate parameters to ExtrudeGeometry API
 


### PR DESCRIPTION
The fineness of the geometry based on a given shape is controlled via `Shape.extractPoints()`. This method is used in `ShapeGeometry` or `ExtrudeGeometry`.