### PR TITLE
fix for thick line dashed example

### DIFF
--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -200,10 +200,6 @@ THREE.ShaderLib[ 'line' ] = {
 
 		varying vec3 vUv;
 
-		const float _EPSILON = 0.000000;
-		const float SEG_START = 0.5 - EPSILON;
-		const float SEG_END = 0.5 + EPSILON;
-
 		void main() {
 
 			#include <clipping_planes_fragment>

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -199,19 +199,23 @@ THREE.ShaderLib[ 'line' ] = {
 
 		varying vec2 vUv;
 
+		const float _EPSILON = 0.000000;
+		const float SEG_START = 0.5 - EPSILON;
+		const float SEG_END = 0.5 + EPSILON;
+
 		void main() {
 
 			#include <clipping_planes_fragment>
 
 			#ifdef USE_DASH
 
-				if ( vUv.y < 0.5 || vUv.y > 0.5 ) discard; // discard endcaps
+				if ( vUv.y < SEG_START || vUv.y > SEG_END ) discard; // discard endcaps
 
 				if ( mod( vLineDistance, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
 
 			#endif
 
-			if ( vUv.y < 0.5 || vUv.y > 0.5 ) {
+			if ( vUv.y < SEG_START || vUv.y > SEG_END ) {
 
 				float a = vUv.x - 0.5;
 				float b = vUv.y - 0.5;

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -199,23 +199,19 @@ THREE.ShaderLib[ 'line' ] = {
 
 		varying vec2 vUv;
 
-		const float _EPSILON = 0.000000;
-		const float SEG_START = 0.5 - EPSILON;
-		const float SEG_END = 0.5 + EPSILON;
-
 		void main() {
 
 			#include <clipping_planes_fragment>
 
 			#ifdef USE_DASH
 
-				if ( vUv.y < SEG_START || vUv.y > SEG_END ) discard; // discard endcaps
+				if ( vUv.y < 0.5 || vUv.y > 0.5 ) discard; // discard endcaps
 
 				if ( mod( vLineDistance, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
 
 			#endif
 
-			if ( vUv.y < SEG_START || vUv.y > SEG_END ) {
+			if ( vUv.y < 0.5 || vUv.y > 0.5 ) {
 
 				float a = vUv.x - 0.5;
 				float b = vUv.y - 0.5;

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -205,7 +205,7 @@ THREE.ShaderLib[ 'line' ] = {
 
 			#ifdef USE_DASH
 
-				if ( vUv.y < 0.5 || vUv.y > 0.5 ) discard; // discard endcaps
+				if ( vUv.y < 0.49999 || vUv.y > 0.50001 ) discard; // discard endcaps
 
 				if ( mod( vLineDistance, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
 

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -209,7 +209,7 @@ THREE.ShaderLib[ 'line' ] = {
 
 			#ifdef USE_DASH
 
-				if ( vUv.y <= SEG_START || vUv.y >= SEG_END ) discard; // discard endcaps
+				if ( vUv.y < SEG_START || vUv.y > SEG_END ) discard; // discard endcaps
 
 				if ( mod( vLineDistance, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
 

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -199,19 +199,23 @@ THREE.ShaderLib[ 'line' ] = {
 
 		varying vec2 vUv;
 
+		const float _EPSILON = 0.000000;
+		const float SEG_START = 0.5 - EPSILON;
+		const float SEG_END = 0.5 + EPSILON;
+
 		void main() {
 
 			#include <clipping_planes_fragment>
 
 			#ifdef USE_DASH
 
-				if ( vUv.y < 0.49999 || vUv.y > 0.50001 ) discard; // discard endcaps
+				if ( vUv.y <= SEG_START || vUv.y >= SEG_END ) discard; // discard endcaps
 
 				if ( mod( vLineDistance, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
 
 			#endif
 
-			if ( vUv.y < 0.5 || vUv.y > 0.5 ) {
+			if ( vUv.y < SEG_START || vUv.y > SEG_END ) {
 
 				float a = vUv.x - 0.5;
 				float b = vUv.y - 0.5;

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -46,8 +46,9 @@ THREE.ShaderLib[ 'line' ] = {
 
 		attribute vec3 instanceColorStart;
 		attribute vec3 instanceColorEnd;
+		attribute vec3 aUv;
 
-		varying vec2 vUv;
+		varying vec3 vUv;
 
 		#ifdef USE_DASH
 
@@ -89,7 +90,7 @@ THREE.ShaderLib[ 'line' ] = {
 
 			float aspect = resolution.x / resolution.y;
 
-			vUv = uv;
+			vUv = aUv;
 
 			// camera space
 			vec4 start = modelViewMatrix * vec4( instanceStart, 1.0 );
@@ -197,7 +198,7 @@ THREE.ShaderLib[ 'line' ] = {
 		#include <logdepthbuf_pars_fragment>
 		#include <clipping_planes_pars_fragment>
 
-		varying vec2 vUv;
+		varying vec3 vUv;
 
 		const float _EPSILON = 0.000000;
 		const float SEG_START = 0.5 - EPSILON;
@@ -207,15 +208,17 @@ THREE.ShaderLib[ 'line' ] = {
 
 			#include <clipping_planes_fragment>
 
+			bool isCap = vUv.z < 0.5;
+
 			#ifdef USE_DASH
 
-				if ( vUv.y < SEG_START || vUv.y > SEG_END ) discard; // discard endcaps
+				if ( isCap ) discard; // discard endcaps
 
 				if ( mod( vLineDistance, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
 
 			#endif
 
-			if ( vUv.y < SEG_START || vUv.y > SEG_END ) {
+			if ( isCap ) {
 
 				float a = vUv.x - 0.5;
 				float b = vUv.y - 0.5;

--- a/examples/js/lines/LineSegmentsGeometry.js
+++ b/examples/js/lines/LineSegmentsGeometry.js
@@ -10,16 +10,13 @@ THREE.LineSegmentsGeometry = function () {
 	this.type = 'LineSegmentsGeometry';
 
 	var plane = new THREE.BufferGeometry();
-	var epsilon = 0.000000;
-	var segUVStart = 0.5 + epsilon;
-	var segUVEnd = 0.5 - epsilon;
 
 	/*eslint-disable*/
 	var positions = [
 		- 1,   2, 0,
 		  1,   2, 0,
 		- 1,   1, 0,
-		  1,   1, 0,
+		  1,   1, 0, //duplicate here
 		- 1,   1, 0,
 		  1,   1, 0,
 		- 1,   0, 0,
@@ -33,21 +30,21 @@ THREE.LineSegmentsGeometry = function () {
 	var uvs = [
 		0, 1, 0,
 		1, 1, 0, 
-		0, segUVStart, 0,
-		1, segUVStart, 0,
+		0, 0.5, 0,
+		1, 0.5, 0,
+		1, 0.5, 1, //duplicate these so the value doesnt get interpolated
 		1, 0.5, 1,
 		1, 0.5, 1,
 		1, 0.5, 1,
-		1, 0.5, 1,
-		0, segUVEnd, 0, 
-		1, segUVEnd, 0,
+		0, 0.5, 0, 
+		1, 0.5, 0,
 		0, 0, 1, 
 		1, 0, 1,
 	];
 	var index = [ 
 		0, 2, 1, 
 		2, 3, 1, 
-		// 2, 4, 3, 
+		// 2, 4, 3, //weave with a split
 		// 4, 5, 3, 
 		4, 6, 5, 
 		6, 7, 5, 
@@ -58,7 +55,7 @@ THREE.LineSegmentsGeometry = function () {
 
 	this.setIndex( index );
 	this.addAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
-	this.addAttribute( 'aUv', new THREE.Float32BufferAttribute( uvs, 3 ) );
+	this.addAttribute( 'aUv', new THREE.Float32BufferAttribute( uvs, 3 ) ); //rename so it doesnt conflict (add another attribute)
 
 };
 

--- a/examples/js/lines/LineSegmentsGeometry.js
+++ b/examples/js/lines/LineSegmentsGeometry.js
@@ -10,10 +10,50 @@ THREE.LineSegmentsGeometry = function () {
 	this.type = 'LineSegmentsGeometry';
 
 	var plane = new THREE.BufferGeometry();
+	var epsilon = 0.000000;
+	var segUVStart = 0.5 + epsilon;
+	var segUVEnd = 0.5 - epsilon;
 
-	var positions = [ - 1, 2, 0, 1, 2, 0, - 1, 1, 0, 1, 1, 0, - 1, 0, 0, 1, 0, 0, - 1, - 1, 0, 1, - 1, 0 ];
-	var uvs = [ 0, 1, 1, 1, 0, .5, 1, .5, 0, .5, 1, .5, 0, 0, 1, 0 ];
-	var index = [ 0, 2, 1, 2, 3, 1, 2, 4, 3, 4, 5, 3, 4, 6, 5, 6, 7, 5 ];
+	var positions = [ 
+		- 1, 2, 0, 
+		1, 2, 0, 
+		- 1, 1, 0, 
+		1, 1, 0, 
+
+		- 1, 1, 0, 
+		1, 1, 0, 
+
+		- 1, 0, 0, 
+		1, 0, 0, 
+
+		- 1, 0, 0, 
+		1, 0, 0, 
+		- 1, - 1, 0, 
+		1, - 1, 0 ];
+	var uvs = [
+		0, 1,
+		1, 1,
+		0, segUVStart,
+		1, segUVStart,
+		1, 0.5,
+		1, 0.5,
+		1, 0.5,
+		1, 0.5,
+		0, segUVEnd,
+		1, segUVEnd,
+		0, 0,
+		1, 0
+	];
+	var index = [ 
+		0, 2, 1, 
+		2, 3, 1, 
+		// 2, 4, 3, 
+		// 4, 5, 3, 
+		4, 6, 5, 
+		6, 7, 5, 
+		8, 10, 9, 
+		10, 11, 9, 
+	];
 
 	this.setIndex( index );
 	this.addAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );

--- a/examples/js/lines/LineSegmentsGeometry.js
+++ b/examples/js/lines/LineSegmentsGeometry.js
@@ -14,22 +14,21 @@ THREE.LineSegmentsGeometry = function () {
 	var segUVStart = 0.5 + epsilon;
 	var segUVEnd = 0.5 - epsilon;
 
-	var positions = [ 
-		- 1, 2, 0, 
-		1, 2, 0, 
-		- 1, 1, 0, 
-		1, 1, 0, 
-
-		- 1, 1, 0, 
-		1, 1, 0, 
-
-		- 1, 0, 0, 
-		1, 0, 0, 
-
-		- 1, 0, 0, 
-		1, 0, 0, 
-		- 1, - 1, 0, 
-		1, - 1, 0 ];
+	/*eslint-disable*/
+	var positions = [
+		- 1,   2, 0,
+		  1,   2, 0,
+		- 1,   1, 0,
+		  1,   1, 0,
+		- 1,   1, 0,
+		  1,   1, 0,
+		- 1,   0, 0,
+	      1,   0, 0,
+		- 1,   0, 0,
+		  1,   0, 0,
+		- 1, - 1, 0,
+		  1, - 1, 0
+	];
 	var uvs = [
 		0, 1,
 		1, 1,
@@ -54,6 +53,7 @@ THREE.LineSegmentsGeometry = function () {
 		8, 10, 9, 
 		10, 11, 9, 
 	];
+	/*eslint-disable*/
 
 	this.setIndex( index );
 	this.addAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );

--- a/examples/js/lines/LineSegmentsGeometry.js
+++ b/examples/js/lines/LineSegmentsGeometry.js
@@ -29,19 +29,20 @@ THREE.LineSegmentsGeometry = function () {
 		- 1, - 1, 0,
 		  1, - 1, 0
 	];
+
 	var uvs = [
-		0, 1,
-		1, 1,
-		0, segUVStart,
-		1, segUVStart,
-		1, 0.5,
-		1, 0.5,
-		1, 0.5,
-		1, 0.5,
-		0, segUVEnd,
-		1, segUVEnd,
-		0, 0,
-		1, 0
+		0, 1, 0,
+		1, 1, 0, 
+		0, segUVStart, 0,
+		1, segUVStart, 0,
+		1, 0.5, 1,
+		1, 0.5, 1,
+		1, 0.5, 1,
+		1, 0.5, 1,
+		0, segUVEnd, 0, 
+		1, segUVEnd, 0,
+		0, 0, 1, 
+		1, 0, 1,
 	];
 	var index = [ 
 		0, 2, 1, 
@@ -57,7 +58,7 @@ THREE.LineSegmentsGeometry = function () {
 
 	this.setIndex( index );
 	this.addAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
-	this.addAttribute( 'uv', new THREE.Float32BufferAttribute( uvs, 2 ) );
+	this.addAttribute( 'aUv', new THREE.Float32BufferAttribute( uvs, 3 ) );
 
 };
 


### PR DESCRIPTION
Added a little epsilon to get rid of the fuzziness. 

https://github.com/mrdoob/three.js/issues/14197