### PR TITLE
SVGLoader: Improved Ss, Qq, Tt and Zz path commands support.

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -176,48 +176,54 @@ THREE.SVGLoader.prototype = {
 
 					case 'S':
 						var numbers = parseFloats( data );
-						path.bezierCurveTo(
-							getReflection( point.x, control.x ),
-							getReflection( point.y, control.y ),
-							numbers[ 0 ],
-							numbers[ 1 ],
-							numbers[ 2 ],
-							numbers[ 3 ]
-						);
-						control.x = numbers[ 0 ];
-						control.y = numbers[ 1 ];
-						point.x = numbers[ 2 ];
-						point.y = numbers[ 3 ];
+						for ( var j = 0, jl = numbers.length; j < jl; j += 4 ) {
+							path.bezierCurveTo(
+								getReflection( point.x, control.x ),
+								getReflection( point.y, control.y ),
+								numbers[ j + 0 ],
+								numbers[ j + 1 ],
+								numbers[ j + 2 ],
+								numbers[ j + 3 ]
+							);
+							control.x = numbers[ j + 0 ];
+							control.y = numbers[ j + 1 ];
+							point.x = numbers[ j + 2 ];
+							point.y = numbers[ j + 3 ];
+						}
 						break;
 
 					case 'Q':
 						var numbers = parseFloats( data );
-						path.quadraticCurveTo(
-							numbers[ 0 ],
-							numbers[ 1 ],
-							numbers[ 2 ],
-							numbers[ 3 ]
-						);
-						control.x = numbers[ 0 ];
-						control.y = numbers[ 1 ];
-						point.x = numbers[ 2 ];
-						point.y = numbers[ 3 ];
+						for ( var j = 0, jl = numbers.length; j < jl; j += 4 ) {
+							path.quadraticCurveTo(
+								numbers[ j + 0 ],
+								numbers[ j + 1 ],
+								numbers[ j + 2 ],
+								numbers[ j + 3 ]
+							);
+							control.x = numbers[ j + 0 ];
+							control.y = numbers[ j + 1 ];
+							point.x = numbers[ j + 2 ];
+							point.y = numbers[ j + 3 ];
+						}
 						break;
 
 					case 'T':
 						var numbers = parseFloats( data );
-						var rx = getReflection( point.x, control.x );
-						var ry = getReflection( point.y, control.y );
-						path.quadraticCurveTo(
-							rx,
-							ry,
-							numbers[ 0 ],
-							numbers[ 1 ]
-						);
-						control.x = rx;
-						control.y = ry;
-						point.x = numbers[ 0 ];
-						point.y = numbers[ 1 ];
+						for ( var j = 0, jl = numbers.length; j < jl; j += 2 ) {
+							var rx = getReflection( point.x, control.x );
+							var ry = getReflection( point.y, control.y );
+							path.quadraticCurveTo(
+								rx,
+								ry,
+								numbers[ j + 0 ],
+								numbers[ j + 1 ]
+							);
+							control.x = rx;
+							control.y = ry;
+							point.x = numbers[ j + 0 ];
+							point.y = numbers[ j + 1 ];
+						}
 						break;
 
 					case 'A':
@@ -298,48 +304,54 @@ THREE.SVGLoader.prototype = {
 
 					case 's':
 						var numbers = parseFloats( data );
-						path.bezierCurveTo(
-							getReflection( point.x, control.x ),
-							getReflection( point.y, control.y ),
-							point.x + numbers[ 0 ],
-							point.y + numbers[ 1 ],
-							point.x + numbers[ 2 ],
-							point.y + numbers[ 3 ]
-						);
-						control.x = point.x + numbers[ 0 ];
-						control.y = point.y + numbers[ 1 ];
-						point.x += numbers[ 2 ];
-						point.y += numbers[ 3 ];
+						for ( var j = 0, jl = numbers.length; j < jl; j += 4 ) {
+							path.bezierCurveTo(
+								getReflection( point.x, control.x ),
+								getReflection( point.y, control.y ),
+								point.x + numbers[ j + 0 ],
+								point.y + numbers[ j + 1 ],
+								point.x + numbers[ j + 2 ],
+								point.y + numbers[ j + 3 ]
+							);
+							control.x = point.x + numbers[ j + 0 ];
+							control.y = point.y + numbers[ j + 1 ];
+							point.x += numbers[ j + 2 ];
+							point.y += numbers[ j + 3 ];
+						}
 						break;
 
 					case 'q':
 						var numbers = parseFloats( data );
-						path.quadraticCurveTo(
-							point.x + numbers[ 0 ],
-							point.y + numbers[ 1 ],
-							point.x + numbers[ 2 ],
-							point.y + numbers[ 3 ]
-						);
-						control.x = point.x + numbers[ 0 ];
-						control.y = point.y + numbers[ 1 ];
-						point.x += numbers[ 2 ];
-						point.y += numbers[ 3 ];
+						for ( var j = 0, jl = numbers.length; j < jl; j += 4 ) {
+							path.quadraticCurveTo(
+								point.x + numbers[ j + 0 ],
+								point.y + numbers[ j + 1 ],
+								point.x + numbers[ j + 2 ],
+								point.y + numbers[ j + 3 ]
+							);
+							control.x = point.x + numbers[ j + 0 ];
+							control.y = point.y + numbers[ j + 1 ];
+							point.x += numbers[ j + 2 ];
+							point.y += numbers[ j + 3 ];
+						}
 						break;
 
 					case 't':
 						var numbers = parseFloats( data );
-						var rx = getReflection( point.x, control.x );
-						var ry = getReflection( point.y, control.y );
-						path.quadraticCurveTo(
-							rx,
-							ry,
-							point.x + numbers[ 0 ],
-							point.y + numbers[ 1 ]
-						);
-						control.x = rx;
-						control.y = ry;
-						point.x = point.x + numbers[ 0 ];
-						point.y = point.y + numbers[ 1 ];
+						for ( var j = 0, jl = numbers.length; j < jl; j += 2 ) {
+							var rx = getReflection( point.x, control.x );
+							var ry = getReflection( point.y, control.y );
+							path.quadraticCurveTo(
+								rx,
+								ry,
+								point.x + numbers[ j + 0 ],
+								point.y + numbers[ j + 1 ]
+							);
+							control.x = rx;
+							control.y = ry;
+							point.x = point.x + numbers[ j + 0 ];
+							point.y = point.y + numbers[ j + 1 ];
+						}
 						break;
 
 					case 'a':

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -249,7 +249,6 @@ THREE.SVGLoader.prototype = {
 							point.y += numbers[ j + 1 ];
 							control.x = point.x;
 							control.y = point.y;
-							console.log( point.x, point.y );
 							path.moveTo( point.x, point.y );
 						}
 						break;
@@ -375,8 +374,20 @@ THREE.SVGLoader.prototype = {
 					case 'z':
 						path.currentPath.autoClose = true;
 						// Reset point to beginning of Path
-						point.x = path.currentPath.curves[ 0 ].v0.x;
-						point.y = path.currentPath.curves[ 0 ].v0.y;
+						var curve = path.currentPath.curves[ 0 ];
+						if ( curve.isLineCurve ) {
+							point.x = curve.v1.x;
+							point.y = curve.v1.y;
+						} else if ( curve.isEllipseCurve || curve.isArcCurve ) {
+							point.x = curve.aX;
+							point.y = curve.aY;
+						} else if ( curve.isCubicBezierCurve || curve.isQuadraticBezierCurve ) {
+							point.x = curve.v0.x;
+							point.y = curve.v0.y;
+						} else if ( curve.isSplineCurve ) {
+							point.x = curve.points[ 0 ].x;
+							point.y = curve.points[ 0 ].y;
+						}
 						path.currentPath.currentPoint.copy( point );
 						break;
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -249,6 +249,7 @@ THREE.SVGLoader.prototype = {
 							point.y += numbers[ j + 1 ];
 							control.x = point.x;
 							control.y = point.y;
+							console.log( point.x, point.y );
 							path.moveTo( point.x, point.y );
 						}
 						break;
@@ -373,6 +374,10 @@ THREE.SVGLoader.prototype = {
 					case 'Z':
 					case 'z':
 						path.currentPath.autoClose = true;
+						// Reset point to beginning of Path
+						point.x = path.currentPath.curves[ 0 ].v0.x;
+						point.y = path.currentPath.curves[ 0 ].v0.y;
+						path.currentPath.currentPoint.copy( point );
 						break;
 
 					default:


### PR DESCRIPTION
I grouped `Qq`, `Tt`, and `Ss` commands in the same format as the existing `Cc` command. This partially fixed the [svg](https://github.com/google/material-design-icons/blob/master/image/svg/design/ic_adjust_24px.svg) referenced from [this thread](https://github.com/mrdoob/three.js/issues/13478#issuecomment-395939631).

I also added ( though I don't really get how `ShapePath` / `Path` work... ) a fix to the `Zz` command which _should_ help the holes on the referenced SVG. I think I'm accessing the wrong vector from the curve.., but to quote the [SVG spec](https://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand):

> The "closepath" (Z or z) ends the current subpath and causes an automatic straight line to be drawn from the current point to the initial point of the current subpath. If a "closepath" is followed immediately by a "moveto", then the "moveto" identifies the start point of the next subpath. If a "closepath" is followed immediately by any other command, **then the next subpath starts at the same initial point as the current subpath.**

( Bolding done by me ). So in the case of the `SVGLoader` the `Zz` commands should update the `point` to be the _initial x, y cordinates of the closed path_. I believe the lingering issue with the holes is because there are relative `m` commands that are referencing the previous `point` incorrectly.