### PR TITLE
[DOCS] Add computeBoundingSphere Information

### DIFF
--- a/docs/manual/introduction/How-to-update-things.html
+++ b/docs/manual/introduction/How-to-update-things.html
@@ -119,7 +119,7 @@ line.geometry.attributes.position.needsUpdate = true; // required after the firs
 					call `.computeBoundingSphere()` in order to recalculate the geometry's bounding sphere. 
 				</p>
 				<code>
-line.geometry.computeBoundingSphere(); // recommended after the first render
+line.geometry.computeBoundingSphere();
 				</code>
 
 				<p>

--- a/docs/manual/introduction/How-to-update-things.html
+++ b/docs/manual/introduction/How-to-update-things.html
@@ -113,6 +113,17 @@ line.geometry.setDrawRange( 0, newValue );
 				<code>
 line.geometry.attributes.position.needsUpdate = true; // required after the first render
 				</code>
+					
+				<p>
+					You should also call `.computeBoundingSphere()` on the object to recalculate the
+					the bounding sphere of the ojbect in order for raycasting and occlusion culling
+					to properly identify the boundary of your object. Otherwise you may end up with
+					an object that doesn't recieve raycast on the entire object, or is culled too
+					early when partially off the screen.
+				</p>
+				<code>
+line.geometry.computeBoundingSphere();
+				</code>
 
 				<p>
 					[link:http://jsfiddle.net/w67tzfhx/ Here is a fiddle] showing an animated line which you can adapt to your use case.

--- a/docs/manual/introduction/How-to-update-things.html
+++ b/docs/manual/introduction/How-to-update-things.html
@@ -115,8 +115,8 @@ line.geometry.attributes.position.needsUpdate = true; // required after the firs
 				</code>
 					
 				<p>
-					If you change the position data values after the initial render, you should also call
-					`.computeBoundingSphere()` on the object to recalculate it's bounding sphere. 
+					If you change the position data values after the initial render, you may need to
+					call `.computeBoundingSphere()` in order to recalculate the geometry's bounding sphere. 
 				</p>
 				<code>
 line.geometry.computeBoundingSphere(); // recommended after the first render

--- a/docs/manual/introduction/How-to-update-things.html
+++ b/docs/manual/introduction/How-to-update-things.html
@@ -117,12 +117,6 @@ line.geometry.attributes.position.needsUpdate = true; // required after the firs
 				<p>
 					If you change the position data values after the initial render, you should also call
 					`.computeBoundingSphere()` on the object to recalculate it's bounding sphere. 
-					The bounding sphere is used in calculations such as raycasting and frustrum culling.
-					If this method id not called after vertices are changed, you are likely to run into
-					strange side effects due to Three.js failing to properly identify the correct boundary
-				 	of your object. This may cause bugs succh as an object that doesn't properly
-					recieve raycasts on the entire object, or is frustrum culled too
-					early (such as when close to the edge of the screen).
 				</p>
 				<code>
 line.geometry.computeBoundingSphere(); // recommended after the first render

--- a/docs/manual/introduction/How-to-update-things.html
+++ b/docs/manual/introduction/How-to-update-things.html
@@ -115,14 +115,17 @@ line.geometry.attributes.position.needsUpdate = true; // required after the firs
 				</code>
 					
 				<p>
-					You should also call `.computeBoundingSphere()` on the object to recalculate the
-					the bounding sphere of the ojbect in order for raycasting and occlusion culling
-					to properly identify the boundary of your object. Otherwise you may end up with
-					an object that doesn't recieve raycast on the entire object, or is culled too
-					early when partially off the screen.
+					If you change the position data values after the initial render, you should also call
+					`.computeBoundingSphere()` on the object to recalculate it's bounding sphere. 
+					The bounding sphere is used in calculations such as raycasting and frustrum culling.
+					If this method id not called after vertices are changed, you are likely to run into
+					strange side effects due to Three.js failing to properly identify the correct boundary
+				 	of your object. This may cause bugs succh as an object that doesn't properly
+					recieve raycasts on the entire object, or is frustrum culled too
+					early (such as when close to the edge of the screen).
 				</p>
 				<code>
-line.geometry.computeBoundingSphere();
+line.geometry.computeBoundingSphere(); // recommended after the first render
 				</code>
 
 				<p>


### PR DESCRIPTION
Added information on calling computeBoundingSphere when updating BufferGeometry vertices to avoid strange side effects like incorrect / early culling of objects, and inaccurate / incomplete raycasting when large amounts of vertices are changed without recomputing. 