### PR TITLE
Add new function Object3D.applyMatrices

### DIFF
--- a/docs/api/core/Object3D.html
+++ b/docs/api/core/Object3D.html
@@ -200,6 +200,9 @@
 		<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
 		<p>Applies the matrix transform to the object and updates the object's position, rotation and scale.</p>
 
+                <h3>[method:null applyMatrices]( [param:Matrix4 matrices], ... )</h3>
+		<p>Applies each matrix transform to the object in sequence. Afterwards, updates the object's position, rotation and scale.</p>
+
 		<h3>[method:Object3D applyQuaternion]( [param:Quaternion quaternion] )</h3>
 		<p>Applies the rotation represented by the quaternion to the object.</p>
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -109,11 +109,22 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	applyMatrix: function ( matrix ) {
 
-		this.matrix.multiplyMatrices( matrix, this.matrix );
+		this.applyMatrices ( matrix );
+
+	},
+
+	applyMatrices: function ( /* matrices */ ) {
+
+		for ( var i = 0; i < arguments.length; i++ ) {
+
+			this.matrix.multiplyMatrices( arguments[i], this.matrix );
+
+		}
 
 		this.matrix.decompose( this.position, this.quaternion, this.scale );
 
 	},
+
 
 	applyQuaternion: function ( q ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -109,15 +109,15 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	applyMatrix: function ( matrix ) {
 
-		this.applyMatrices ( matrix );
+		this.applyMatrices( matrix );
 
 	},
 
 	applyMatrices: function ( /* matrices */ ) {
 
-		for ( var i = 0; i < arguments.length; i++ ) {
+		for ( var i = 0; i < arguments.length; i ++ ) {
 
-			this.matrix.multiplyMatrices( arguments[i], this.matrix );
+			this.matrix.multiplyMatrices( arguments[ i ], this.matrix );
 
 		}
 

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -109,6 +109,29 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+                QUnit.test( "applyMatrices", ( assert ) => {
+
+			var a = new Object3D();
+			var mr = new Matrix4();
+			var mt = new Matrix4();
+			var expectedPos = new Vector3( x, y, z );
+			var expectedQuat = new Quaternion( 0.5 * Math.sqrt( 2 ), 0, 0, 0.5 * Math.sqrt( 2 ) );
+
+			mr.makeRotationX( Math.PI / 2 );
+			mt.setPosition( new Vector3( x, y, z ) );
+
+			a.applyMatrices( mr, mt );
+
+			assert.deepEqual( a.position, expectedPos, "Position has the expected values" );
+			assert.ok(
+				Math.abs( a.quaternion.x - expectedQuat.x ) <= eps &&
+				Math.abs( a.quaternion.y - expectedQuat.y ) <= eps &&
+				Math.abs( a.quaternion.z - expectedQuat.z ) <= eps,
+				"Quaternion has the expected values"
+			);
+
+		} );
+
 		QUnit.test( "applyQuaternion", ( assert ) => {
 
 			var a = new Object3D();


### PR DESCRIPTION
Since `Object3D.applyMatrix` both multiplies by the new matrix and decomposes into a new position, rotation, and scale, it's inefficient to use in the (common) situation where you want to apply multiple matrices in series to an object's transform. However, having application code manually call `obj.matrix.multiplyMatrices(mat, obj.matrix)` followed by a single `obj.matrix.decompose(obj.position, obj.rotation, obj.scale)` is verbose and error-prone -- application code could easily forget to decompose at the end, causing some surprising bug elsewhere.

I propose adding `applyMatrices`, which will be both efficient and easy to use in that case.