### PR TITLE
Update documented `crossOrigin` defaults

### DIFF
--- a/docs/api/loaders/CubeTextureLoader.html
+++ b/docs/api/loaders/CubeTextureLoader.html
@@ -56,7 +56,7 @@ scene.background = new THREE.CubeTextureLoader()
 		<p>
 		If set, assigns the [link:https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes crossOrigin]
 	 attribute of the image to the value of *crossOrigin*,
-		prior to starting the load. Default is *undefined*.
+		prior to starting the load. Default is *"Anonymous"*.
 		</p>
 
 		<h3>[property:LoadingManager manager]</h3>

--- a/docs/api/loaders/ImageLoader.html
+++ b/docs/api/loaders/ImageLoader.html
@@ -69,7 +69,7 @@
 		<h3>[property:String crossOrigin]</h3>
 		<p>
 		If set, assigns the [link:https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes crossOrigin]
-	 attribute of the image to the value of *crossOrigin*, prior to starting the load. Default is *undefined*.
+	 attribute of the image to the value of *crossOrigin*, prior to starting the load. Default is *"Anonymous"*.
 		</p>
 
 		<h3>[property:LoadingManager manager]</h3>

--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -72,7 +72,7 @@
 		<h3>[property:String crossOrigin]</h3>
 		<p>
 		If set, assigns the [link:https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes crossOrigin]
-	 attribute of the image to the value of *crossOrigin*, prior to starting the load. Default is *undefined*.
+	 attribute of the image to the value of *crossOrigin*, prior to starting the load. Default is *"Anonymous"*.
 		</p>
 
 


### PR DESCRIPTION
For the specific implementations of `Loader`, update the
documented default `crossOrigin` values to reflect the source.