### PR TITLE
Fix SVGLoader issue with multiple concatenated positive floats less than 1

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -660,12 +660,15 @@ THREE.SVGLoader.prototype = {
 
 				var number = array[ i ];
 
-				// Handle values like 48.6037.7
+				// Handle values like 48.6037.7.8
 				// TODO Find a regex for this
 
 				if ( number.indexOf( '.' ) !== number.lastIndexOf( '.' ) ) {
 
-					array.splice( i + 1, 0, '0.' + number.split( '.' )[ 2 ] );
+					var split = number.split('.');
+					for(var s = 2; s < split.length; s++) {
+						array.splice( i + s - 1, 0, '0.' + split[ s ] );
+					}
 
 				}
 


### PR DESCRIPTION
Example SVG file: https://m.abcsofchinese.com/images/svg/亼ji2.svg

Its possible to have SVG paths formatted like -3.8.4.4 with more than two floats smushed together.