### PR TITLE
Account for the fact that VR poses may sometimes be null.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1072,6 +1072,14 @@ function WebGLRenderer( parameters ) {
 
 			camera = vr.getCamera( camera );
 
+			// The camera may come back null if we don't have a VR pose,
+			// in which case we shouldn't render.
+			if ( camera === null ) {
+
+				return;
+
+			}
+
 		}
 
 		//

--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -107,6 +107,13 @@ function WebXRManager( renderer ) {
 
 		if ( isPresenting() ) {
 
+			// If we don't have tracking don't render anything.
+			if ( pose === null ) {
+
+				return null;
+
+			}
+
 			var parent = camera.parent;
 			var cameras = cameraVR.cameras;
 
@@ -150,28 +157,34 @@ function WebXRManager( renderer ) {
 
 		pose = frame.getDevicePose( frameOfRef );
 
-		var layer = session.baseLayer;
-		var views = frame.views;
+		// You may not get a pose for a variety of reasons, most commonly
+		// if the device has lost tracking.
+		if ( pose ) {
 
-		for ( var i = 0; i < views.length; i ++ ) {
+			var layer = session.baseLayer;
+			var views = frame.views;
 
-			var view = views[ i ];
-			var viewport = layer.getViewport( view );
-			var viewMatrix = pose.getViewMatrix( view );
+			for ( var i = 0; i < views.length; i ++ ) {
 
-			var camera = cameraVR.cameras[ i ];
-			camera.matrix.fromArray( viewMatrix ).getInverse( camera.matrix );
-			camera.projectionMatrix.fromArray( view.projectionMatrix );
-			camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );
+				var view = views[ i ];
+				var viewport = layer.getViewport( view );
+				var viewMatrix = pose.getViewMatrix( view );
 
-			if ( i === 0 ) {
+				var camera = cameraVR.cameras[ i ];
+				camera.matrix.fromArray( viewMatrix ).getInverse( camera.matrix );
+				camera.projectionMatrix.fromArray( view.projectionMatrix );
+				camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );
 
-				cameraVR.matrix.copy( camera.matrix );
+				if ( i === 0 ) {
 
-				// HACK (mrdoob)
-				// https://github.com/w3c/webvr/issues/203
+					cameraVR.matrix.copy( camera.matrix );
 
-				cameraVR.projectionMatrix.copy( camera.projectionMatrix );
+					// HACK (mrdoob)
+					// https://github.com/w3c/webvr/issues/203
+
+					cameraVR.projectionMatrix.copy( camera.projectionMatrix );
+
+				}
 
 			}
 


### PR DESCRIPTION
Not sure what the best way to handle this is, but this is at least a conversation starter.

In WebXR (and WebVR, for that matter) poses may come back as null. This is mostly for times when tracking is either lost or not initialized, such as if you hide in a corner of your room so that none of your desktop basestations can see you. It's more commonly seen, however, in AR scenarios, where tracking actually takes a few moments and a bit of movement to begin, so it's likely that you'll start out with null poses and start gaining valid ones a little bit later.

Exactly how that should be handled is left up to the app as far as the WebXR spec is concerned, but there's a couple of approaches that you could argue have merit. For the WebXR samples and some of the Chrome team's internal work we opted to simply draw nothing when a null pose is returned, because it gives sensible behavior in a variety of circumstances:

 - By not submitting any new content the system is allowed to reproject the old content if possible. Why a system would have enough info to reproject an old frame but not enough to provide a new pose is beyond me, but it's not impossible.
 - If we re-draw the frame with an old pose we'll either get an environment that stuck to the user's head in VR or content that drifts severely from the real world in AR, where as showing nothing is at least a clear signal that something is wrong.
 - We definitely don't want to revert to an identity pose or anything like that, since that would appear like a jarring, nonsensical jump to the user and possibly result in jittering between the identity pose and the real one as tracking is reacquired.

It does seem, though, that if you have other non-rendering work going on in the scene you'll still want to get the animation callback. That way things like animation, audio, physics, net code, and more can stay consistent even when tracking drops out momentarily. That's why this PR identifies the null pose but doesn't stop the animation callback from running, favoring instead an approach where all the normal logic is done but the final `renderer.render()` call is early terminated.

I do think that some more sophisticated apps will want to show a head/screen locked "tracking lost" message in this situation, and it's not totally clear to me how they would accomplish that given the current structure of the XR manager, so I'm all ears for suggestions on that. 
 