### PR TITLE
GLTFLoader: Save glTF root object 'extras'

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -181,8 +181,14 @@ THREE.GLTFLoader = ( function () {
 					animations: animations,
 					asset: json.asset,
 					parser: parser,
-					userData: {}
+					userData: undefined
 				};
+
+				// Though glTF spec allows 'extras' to be anything, allowing primitives
+				// would break addUnknownExtensionsToUserData
+				glTF.userData = ( typeof json.extras === "object" )
+					? json.extras
+					: {};
 
 				addUnknownExtensionsToUserData( extensions, glTF, json );
 


### PR DESCRIPTION
Fixes #14294 

I tested this by trying models with and without `extras ` on threejs editor.