### PR TITLE
Clean up loop vars in BufferGeometryUtils

### DIFF
--- a/examples/js/BufferGeometryUtils.js
+++ b/examples/js/BufferGeometryUtils.js
@@ -39,10 +39,10 @@ THREE.BufferGeometryUtils = {
 
 		var tan1 = [], tan2 = [];
 
-		for ( var k = 0; k < nVertices; k ++ ) {
+		for ( var i = 0; i < nVertices; i ++ ) {
 
-			tan1[ k ] = new THREE.Vector3();
-			tan2[ k ] = new THREE.Vector3();
+			tan1[ i ] = new THREE.Vector3();
+			tan2[ i ] = new THREE.Vector3();
 
 		}
 
@@ -117,19 +117,19 @@ THREE.BufferGeometryUtils = {
 
 		}
 
-		for ( var j = 0, jl = groups.length; j < jl; ++ j ) {
+		for ( var i = 0, il = groups.length; i < il; ++ i ) {
 
-			var group = groups[ j ];
+			var group = groups[ i ];
 
 			var start = group.start;
 			var count = group.count;
 
-			for ( var i = start, il = start + count; i < il; i += 3 ) {
+			for ( var j = start, jl = start + count; j < jl; j += 3 ) {
 
 				handleTriangle(
-					indices[ i + 0 ],
-					indices[ i + 1 ],
-					indices[ i + 2 ]
+					indices[ j + 0 ],
+					indices[ j + 1 ],
+					indices[ j + 2 ]
 				);
 
 			}
@@ -165,18 +165,18 @@ THREE.BufferGeometryUtils = {
 
 		}
 
-		for ( var j = 0, jl = groups.length; j < jl; ++ j ) {
+		for ( var i = 0, il = groups.length; i < il; ++ i ) {
 
-			var group = groups[ j ];
+			var group = groups[ i ];
 
 			var start = group.start;
 			var count = group.count;
 
-			for ( var i = start, il = start + count; i < il; i += 3 ) {
+			for ( var j = start, jl = start + count; j < jl; j += 3 ) {
 
-				handleVertex( indices[ i + 0 ] );
-				handleVertex( indices[ i + 1 ] );
-				handleVertex( indices[ i + 2 ] );
+				handleVertex( indices[ j + 0 ] );
+				handleVertex( indices[ j + 1 ] );
+				handleVertex( indices[ j + 2 ] );
 
 			}
 
@@ -381,11 +381,11 @@ THREE.BufferGeometryUtils = {
 		var array = new TypedArray( arrayLength );
 		var offset = 0;
 
-		for ( var j = 0; j < attributes.length; ++ j ) {
+		for ( var i = 0; i < attributes.length; ++ i ) {
 
-			array.set( attributes[ j ].array, offset );
+			array.set( attributes[ i ].array, offset );
 
-			offset += attributes[ j ].array.length;
+			offset += attributes[ i ].array.length;
 
 		}
 


### PR DESCRIPTION
This PR cleans up loop vars in `BufferGeometryUtils`; `i`, `j`, `k`... order from outer to inner loop like in other modules.