### PR TITLE
Collada loader: handle dae file without bind shape matrix

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -967,7 +967,15 @@ THREE.ColladaLoader.prototype = {
 
 			// setup bind matrix
 
-			build.bindMatrix = new THREE.Matrix4().fromArray( data.bindShapeMatrix ).transpose();
+      if ( data.bindShapeMatrix ) {
+
+        build.bindMatrix = new THREE.Matrix4().fromArray( data.bindShapeMatrix ).transpose(); 
+
+      } else {
+
+        build.bindMatrix = new THREE.Matrix4().transpose(); 
+
+      }
 
 			// process bones and inverse bind matrix data
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -967,15 +967,15 @@ THREE.ColladaLoader.prototype = {
 
 			// setup bind matrix
 
-      if ( data.bindShapeMatrix ) {
+			if ( data.bindShapeMatrix ) {
 
-        build.bindMatrix = new THREE.Matrix4().fromArray( data.bindShapeMatrix ).transpose(); 
+				build.bindMatrix = new THREE.Matrix4().fromArray( data.bindShapeMatrix ).transpose(); 
 
-      } else {
+			} else {
 
-        build.bindMatrix = new THREE.Matrix4().transpose(); 
+				build.bindMatrix = new THREE.Matrix4().transpose(); 
 
-      }
+			}
 
 			// process bones and inverse bind matrix data
 


### PR DESCRIPTION
Some dae file without `bind shape matrix` data (`<bind_shape_matrix>`mark in dae file,  https://www.khronos.org/collada/wiki/Skinning )  which can be previewed in mac osx system, but break down in three.js editor (or use Collada loader directly).

![screen shot 2018-06-20 at 11 11 13 am](https://user-images.githubusercontent.com/1296667/41635901-e15b1a36-747d-11e8-9ed4-27679924265c.png)

Then I debug into the codes, I find that Collada loader doesn't check if there is `bindShapeMatrix` before get it.  It works fine after I add the conditional statement. 

The test file can be downloaded here: 

[Cartwheel.dae.zip](https://github.com/mrdoob/three.js/files/2117764/Cartwheel.dae.zip)
