### PR TITLE
Documentation: Fix broken link to BufferGeometry page.

### DIFF
--- a/docs/api/objects/Line.html
+++ b/docs/api/objects/Line.html
@@ -46,7 +46,7 @@
 		<h3>[name]( [param:Geometry geometry], [param:Material material] )</h3>
 
 		<p>
-		[page:Geometry geometry] — vertices representing the line segment(s). Default is a new [page:new BufferGeometry].<br />
+		[page:Geometry geometry] — vertices representing the line segment(s). Default is a new [page:BufferGeometry].<br />
 		[page:Material material] — material for the line. Default is a new [page:LineBasicMaterial] with random color.<br />
 		</p>
 


### PR DESCRIPTION
The documentation page for the `Line` class contains a broken link to the `BufferGeometry` page. This change fixes it.