### PR TITLE
Get normal from cachedData in GLTFExporter

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -244,7 +244,7 @@ THREE.GLTFExporter.prototype = {
 
 			if ( cachedData.attributes.has( normal ) ) {
 
-				return cachedData.textures.get( normal );
+				return cachedData.attributes.get( normal );
 
 			}
 


### PR DESCRIPTION
This fixes the glTF-Export, if you have the same Object multiple times in your scene.