### PR TITLE
slash support in #includes

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -160,7 +160,7 @@ function replaceClippingPlaneNums( string, parameters ) {
 
 function parseIncludes( string ) {
 
-	var pattern = /^[ \t]*#include +<([\w\d.]+)>/gm;
+	var pattern = /^[ \t]*#include +<([\w\d./]+)>/gm;
 
 	function replace( match, include ) {
 


### PR DESCRIPTION
Allowing slashes in the filenames of shader chunk includes would allow to use the same pattern as in C++ includes : you could scope the name of the shader by the name of the library that provides the chunk

in the custom shader:
```
#include <mylib/mychunk>
```

in the custom ShaderMaterial:
```
var MyShaderChunk = {};
MyShaderChunk['mylib/mychunk'] = '// some glsl code';
Object.assign(THREE.ShaderChunk, MyShaderChunk);
```
---
As an extension, the call to `Object.assign` could be wrapped in a more elegant function that optionnally prepends the path prefix : 
```
THREE.ShaderChunk.install = function install(chunks, path) {
    if (!path) return Object.assign(this, chunks);
    Object.keys(chunks).forEach((key) => {
        this[path + key] = chunks[key];
    });
};
var MyShaderChunk = {};
MyShaderChunk.mychunk = '// some glsl code';
THREE.ShaderChunk.install(MyShaderChunk, 'mylib/');
```