### PR TITLE
ObjectLoader: Added support for EdgesGeometry and WireframeGeometry.

### DIFF
--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -113,8 +113,19 @@ EdgesGeometry.prototype.constructor = EdgesGeometry;
 EdgesGeometry.prototype.toJSON = function () {
 
 	var data = BufferGeometry.prototype.toJSON.call( this );
+	var geometry = data.geometry;
 
-	data.geometry = data.geometry.uuid;
+	if ( geometry.isGeometry ) {
+
+		geometry = geometry.toBufferGeometry();
+
+	} else {
+
+		geometry = geometry.clone();
+
+	}
+
+	data.geometry = geometry.toJSON();
 
 	return data;
 

--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -15,6 +15,7 @@ function EdgesGeometry( geometry, thresholdAngle ) {
 	this.type = 'EdgesGeometry';
 
 	this.parameters = {
+		geometry: geometry,
 		thresholdAngle: thresholdAngle
 	};
 
@@ -108,6 +109,16 @@ function EdgesGeometry( geometry, thresholdAngle ) {
 
 EdgesGeometry.prototype = Object.create( BufferGeometry.prototype );
 EdgesGeometry.prototype.constructor = EdgesGeometry;
+
+EdgesGeometry.prototype.toJSON = function () {
+
+	var data = BufferGeometry.prototype.toJSON.call( this );
+
+	data.geometry = data.geometry.uuid;
+
+	return data;
+
+};
 
 
 export { EdgesGeometry };

--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -117,7 +117,7 @@ EdgesGeometry.prototype.toJSON = function () {
 
 	if ( geometry.isGeometry ) {
 
-		geometry = geometry.toBufferGeometry();
+		geometry = new BufferGeometry().fromGeometry( geometry );
 
 	} else {
 

--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -186,7 +186,7 @@ WireframeGeometry.prototype.toJSON = function () {
 
 	if ( geometry.isGeometry ) {
 
-		geometry = geometry.toBufferGeometry();
+		geometry = new BufferGeometry().fromGeometry( geometry );
 
 	} else {
 

--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -13,6 +13,10 @@ function WireframeGeometry( geometry ) {
 
 	this.type = 'WireframeGeometry';
 
+	this.parameters = {
+		geometry: geometry
+	};
+
 	// buffer
 
 	var vertices = [];
@@ -174,6 +178,16 @@ function WireframeGeometry( geometry ) {
 
 WireframeGeometry.prototype = Object.create( BufferGeometry.prototype );
 WireframeGeometry.prototype.constructor = WireframeGeometry;
+
+WireframeGeometry.prototype.toJSON = function () {
+
+	var data = BufferGeometry.prototype.toJSON.call( this );
+
+	data.geometry = data.geometry.uuid;
+
+	return data;
+
+};
 
 
 export { WireframeGeometry };

--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -182,8 +182,19 @@ WireframeGeometry.prototype.constructor = WireframeGeometry;
 WireframeGeometry.prototype.toJSON = function () {
 
 	var data = BufferGeometry.prototype.toJSON.call( this );
+	var geometry = data.geometry;
 
-	data.geometry = data.geometry.uuid;
+	if ( geometry.isGeometry ) {
+
+		geometry = geometry.toBufferGeometry();
+
+	} else {
+
+		geometry = geometry.clone();
+
+	}
+
+	data.geometry = geometry.toJSON();
 
 	return data;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -187,7 +187,6 @@ Object.assign( ObjectLoader.prototype, {
 
 			var geometryLoader = new JSONLoader();
 			var bufferGeometryLoader = new BufferGeometryLoader();
-			var helperGeometries = [];
 
 			for ( var i = 0, l = json.length; i < l; i ++ ) {
 
@@ -412,9 +411,19 @@ Object.assign( ObjectLoader.prototype, {
 						break;
 
 					case 'EdgesGeometry':
+
+						geometry = new Geometries[ data.type ](
+							bufferGeometryLoader.parse( data.geometry ),
+							data.thresholdAngle
+						);
+
+						break;
+
 					case 'WireframeGeometry':
 
-						helperGeometries.push( data ); // process these later
+						geometry = new Geometries[ data.type ](
+							bufferGeometryLoader.parse( data.geometry )
+						);
 
 						break;
 
@@ -444,53 +453,6 @@ Object.assign( ObjectLoader.prototype, {
 				if ( geometry.isBufferGeometry === true && data.userData !== undefined ) geometry.userData = data.userData;
 
 				geometries[ data.uuid ] = geometry;
-
-			}
-
-			//
-
-			for ( var i = 0, l = helperGeometries.length; i < l; i ++ ) {
-
-				var data = helperGeometries[ i ];
-				var baseGeometry = geometries[ data.geometry ];
-
-				if ( baseGeometry !== undefined ) {
-
-					switch ( data.type ) {
-
-						case 'EdgesGeometry':
-
-							geometry = new Geometries[ data.type ](
-								geometries[ data.geometry ],
-								data.thresholdAngle
-							);
-
-							break;
-
-						case 'WireframeGeometry':
-
-							geometry = new Geometries[ data.type ](
-								geometries[ data.geometry ]
-							);
-
-							break;
-
-					}
-
-					//
-
-					geometry.uuid = data.uuid;
-
-					if ( data.name !== undefined ) geometry.name = data.name;
-					if ( data.userData !== undefined ) geometry.userData = data.userData;
-
-					geometries[ data.uuid ] = geometry;
-
-				} else {
-
-					console.warn( 'THREE.ObjectLoader: No base geometry found with UUID %s for "%s"', data.geometry, data.type );
-
-				}
 
 			}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -187,6 +187,7 @@ Object.assign( ObjectLoader.prototype, {
 
 			var geometryLoader = new JSONLoader();
 			var bufferGeometryLoader = new BufferGeometryLoader();
+			var helperGeometries = [];
 
 			for ( var i = 0, l = json.length; i < l; i ++ ) {
 
@@ -410,6 +411,13 @@ Object.assign( ObjectLoader.prototype, {
 
 						break;
 
+					case 'EdgesGeometry':
+					case 'WireframeGeometry':
+
+						helperGeometries.push( data ); // process these later
+
+						break;
+
 					case 'BufferGeometry':
 
 						geometry = bufferGeometryLoader.parse( data );
@@ -436,6 +444,53 @@ Object.assign( ObjectLoader.prototype, {
 				if ( geometry.isBufferGeometry === true && data.userData !== undefined ) geometry.userData = data.userData;
 
 				geometries[ data.uuid ] = geometry;
+
+			}
+
+			//
+
+			for ( var i = 0, l = helperGeometries.length; i < l; i ++ ) {
+
+				var data = helperGeometries[ i ];
+				var baseGeometry = geometries[ data.geometry ];
+
+				if ( baseGeometry !== undefined ) {
+
+					switch ( data.type ) {
+
+						case 'EdgesGeometry':
+
+							geometry = new Geometries[ data.type ](
+								geometries[ data.geometry ],
+								data.thresholdAngle
+							);
+
+							break;
+
+						case 'WireframeGeometry':
+
+							geometry = new Geometries[ data.type ](
+								geometries[ data.geometry ]
+							);
+
+							break;
+
+					}
+
+					//
+
+					geometry.uuid = data.uuid;
+
+					if ( data.name !== undefined ) geometry.name = data.name;
+					if ( data.userData !== undefined ) geometry.userData = data.userData;
+
+					geometries[ data.uuid ] = geometry;
+
+				} else {
+
+					console.warn( 'THREE.ObjectLoader: No base geometry found with UUID %s for "%s"', data.geometry, data.type );
+
+				}
 
 			}
 


### PR DESCRIPTION
Fixes #14302

The PR assumes that `EdgesGeometry` and `WireframeGeometry` are considered as helper geometries (like mentioned in the docs). So their base geometry has to be part of the scene graph.