### PR TITLE
ObjectLoader: Added support for EdgesGeometry and WireframeGeometry.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -706,6 +706,14 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 			}
 
+			// for EdgesGeometry and WireframeGeometry
+
+			if ( parameters !== undefined && parameters.geometry !== undefined ) {
+
+				serialize( meta.geometries, parameters.geometry );
+
+			}
+
 		}
 
 		if ( this.material !== undefined ) {

--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -15,6 +15,7 @@ function EdgesGeometry( geometry, thresholdAngle ) {
 	this.type = 'EdgesGeometry';
 
 	this.parameters = {
+		geometry: geometry,
 		thresholdAngle: thresholdAngle
 	};
 
@@ -109,5 +110,14 @@ function EdgesGeometry( geometry, thresholdAngle ) {
 EdgesGeometry.prototype = Object.create( BufferGeometry.prototype );
 EdgesGeometry.prototype.constructor = EdgesGeometry;
 
+EdgesGeometry.prototype.toJSON = function () {
+
+	var data = BufferGeometry.prototype.toJSON.call( this );
+
+	data.geometry = data.geometry.uuid;
+
+	return data;
+
+};
 
 export { EdgesGeometry };

--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -13,6 +13,10 @@ function WireframeGeometry( geometry ) {
 
 	this.type = 'WireframeGeometry';
 
+	this.parameters = {
+		geometry: geometry
+	};
+
 	// buffer
 
 	var vertices = [];
@@ -175,5 +179,14 @@ function WireframeGeometry( geometry ) {
 WireframeGeometry.prototype = Object.create( BufferGeometry.prototype );
 WireframeGeometry.prototype.constructor = WireframeGeometry;
 
+WireframeGeometry.prototype.toJSON = function () {
+
+	var data = BufferGeometry.prototype.toJSON.call( this );
+
+	data.geometry = data.geometry.uuid;
+
+	return data;
+
+};
 
 export { WireframeGeometry };

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -187,6 +187,7 @@ Object.assign( ObjectLoader.prototype, {
 
 			var geometryLoader = new JSONLoader();
 			var bufferGeometryLoader = new BufferGeometryLoader();
+			var helperGeometries = [];
 
 			for ( var i = 0, l = json.length; i < l; i ++ ) {
 
@@ -410,6 +411,13 @@ Object.assign( ObjectLoader.prototype, {
 
 						break;
 
+					case 'EdgesGeometry':
+					case 'WireframeGeometry':
+
+						helperGeometries.push( data ); // process these later
+
+						continue;
+
 					case 'BufferGeometry':
 
 						geometry = bufferGeometryLoader.parse( data );
@@ -436,6 +444,53 @@ Object.assign( ObjectLoader.prototype, {
 				if ( geometry.isBufferGeometry === true && data.userData !== undefined ) geometry.userData = data.userData;
 
 				geometries[ data.uuid ] = geometry;
+
+			}
+
+			//
+
+			for ( var i = 0, l = helperGeometries.length; i < l; i ++ ) {
+
+				var data = helperGeometries[ i ];
+				var baseGeometry = geometries[ data.geometry ];
+
+				if ( baseGeometry !== undefined ) {
+
+					switch ( data.type ) {
+
+						case 'EdgesGeometry':
+
+							geometry = new Geometries[ data.type ](
+								geometries[ data.geometry ],
+								data.thresholdAngle
+							);
+
+							break;
+
+						case 'WireframeGeometry':
+
+							geometry = new Geometries[ data.type ](
+								geometries[ data.geometry ]
+							);
+
+							break;
+
+					}
+
+					//
+
+					geometry.uuid = data.uuid;
+
+					if ( data.name !== undefined ) geometry.name = data.name;
+					if ( data.userData !== undefined ) geometry.userData = data.userData;
+
+					geometries[ data.uuid ] = geometry;
+
+				} else {
+
+					console.warn( 'THREE.ObjectLoader: No base geometry found with UUID %s for "%s"', data.geometry, data.type );
+
+				}
 
 			}
 


### PR DESCRIPTION
Fixes #14302 

This rework of #14351 now ensures that geometries are only serialized just once. It also regards the feedback of @WestLangley.