### PR TITLE
 Audio: Clean up method chaining and docs

### DIFF
--- a/docs/api/audio/Audio.html
+++ b/docs/api/audio/Audio.html
@@ -98,24 +98,24 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null connect]()</h3>
+		<h3>[method:Audio connect]()</h3>
 		<p>
 		Connect to the [page:Audio.source]. This is used internally on initialisation and when
 		setting / removing filters.
 		</p>
 
-		<h3>[method:null disconnect]()</h3>
+		<h3>[method:Audio disconnect]()</h3>
 		<p>
 		Disconnect from the [page:Audio.source]. This is used internally when
 		setting / removing filters.
 		</p>
 
-		<h3>[method:Array getFilter]()</h3>
+		<h3>[method:BiquadFilterNode getFilter]()</h3>
 		<p>
 		Returns the first element of the [page:Audio.filters filters] array.
 		</p>
 
-		<h3>[method:null getFilters]()</h3>
+		<h3>[method:Array getFilters]()</h3>
 		<p>
 		Returns the [page:Audio.filters filters] array.
 		</p>
@@ -131,22 +131,22 @@
 		Return the [page:Audio.gain gainNode].
 		</p>
 
-		<h3>[method:Number getPlaybackRate]()</h3>
+		<h3>[method:Float getPlaybackRate]()</h3>
 		<p>
 		Return the value of [page:Audio.playbackRate playbackRate].
 		</p>
 
-		<h3>[method:Number getVolume]( value )</h3>
+		<h3>[method:Float getVolume]( value )</h3>
 		<p>
 		Return the current volume.
 		</p>
 
-		<h3>[method:null play]()</h3>
+		<h3>[method:Audio play]()</h3>
 		<p>
 		If [page:Audio.hasPlaybackControl hasPlaybackControl] is true, starts playback.
 		</p>
 
-		<h3>[method:null pause]()</h3>
+		<h3>[method:Audio pause]()</h3>
 		<p>
 		If [page:Audio.hasPlaybackControl hasPlaybackControl] is true, pauses playback.
 		</p>
@@ -162,7 +162,7 @@
 		If [page:Audio.autoplay autoplay], also starts playback.
 		</p>
 
-		<h3>[method:null setFilter]( filter )</h3>
+		<h3>[method:Audio setFilter]( filter )</h3>
 		<p>
 		Applies a single [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNode] to the audio.
 		</p>
@@ -173,37 +173,37 @@
 		Applies an array of [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes] to the audio.
 		</p>
 
-		<h3>[method:null setLoop]( [param:Boolean value] )</h3>
+		<h3>[method:Audio setLoop]( [param:Boolean value] )</h3>
 		<p>
 		Set [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loop source.loop] to *value*
 		(whether playback should loop).
 		</p>
 
-		<h3>[method:null setMediaElementSource]( mediaElement )</h3>
+		<h3>[method:Audio setMediaElementSource]( mediaElement )</h3>
 		<p>
 		Applies the given object of type [link:https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement HTMLMediaElement] as the source of this audio.<br />
 		Also sets [page:Audio.hasPlaybackControl hasPlaybackControl] to false.
 
 		</p>
 
-		<h3>[method:null setNodeSource]( audioNode )</h3>
+		<h3>[method:Audio setNodeSource]( audioNode )</h3>
 		<p>
 		Setup the [page:Audio.source source] to the audioBuffer, and sets [page:Audio.sourceType sourceType] to 'audioNode'.<br />
 		Also sets [page:Audio.hasPlaybackControl hasPlaybackControl] to false.
 
 		</p>
 
-		<h3>[method:null setPlaybackRate]( [param:Number value] )</h3>
+		<h3>[method:Audio setPlaybackRate]( [param:Float value] )</h3>
 		<p>
 		If [page:Audio.hasPlaybackControl hasPlaybackControl] is enabled, set the [page:Audio.playbackRate playbackRate] to *value*.
 		</p>
 
-		<h3>[method:null setVolume]( [param:Number value] )</h3>
+		<h3>[method:Audio setVolume]( [param:Float value] )</h3>
 		<p>
 		Set the volume.
 		</p>
 
-		<h3>[method:null stop]()</h3>
+		<h3>[method:Audio stop]()</h3>
 		<p>
 		If [page:Audio.hasPlaybackControl hasPlaybackControl] is enabled, stops playback,
 		resets [page:Audio.startTime startTime] to *0* and sets [page:Audio.isPlaying isPlaying] to false.

--- a/docs/api/audio/AudioListener.html
+++ b/docs/api/audio/AudioListener.html
@@ -76,7 +76,7 @@
 		Return the [page:AudioListener.gain gainNode].
 		</p>
 
-		<h3>[method:null removeFilter]()</h3>
+		<h3>[method:AudioListener removeFilter]()</h3>
 		<p>
 		Set the [page:AudioListener.filter filter] property to *null*.
 		</p>
@@ -86,17 +86,17 @@
 		Returns the value of the [page:AudioListener.filter filter] property.
 		</p>
 
-		<h3>[method:null setFilter]( [param:AudioNode value] )</h3>
+		<h3>[method:AudioListener setFilter]( [param:AudioNode value] )</h3>
 		<p>
 		Set the [page:AudioListener.filter filter] property to *value*.
 		</p>
 
-		<h3>[method:Number getMasterVolume]()</h3>
+		<h3>[method:Float getMasterVolume]()</h3>
 		<p>
 		Return the volume.
 		</p>
 
-		<h3>[method:null setMasterVolume]( [param:Number value] )</h3>
+		<h3>[method:AudioListener setMasterVolume]( [param:Number value] )</h3>
 		<p>
 		Set the volume.
 		</p>

--- a/docs/api/audio/PositionalAudio.html
+++ b/docs/api/audio/PositionalAudio.html
@@ -82,22 +82,22 @@
 		Returns the [page:PositionalAudio.panner panner].
 		</p>
 
-		<h3>[method:Number getRefDistance]()</h3>
+		<h3>[method:Float getRefDistance]()</h3>
 		<p>
 		Returns the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/refDistance panner.refDistance].
 		</p>
 
-		<h3>[method:PannerNode setRefDistance]( [param:Number value] )</h3>
+		<h3>[method:PositionalAudio setRefDistance]( [param:Number value] )</h3>
 		<p>
 		Sets the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/refDistance panner.refDistance].
 		</p>
 
-		<h3>[method:PannerNode getRolloffFactor]()</h3>
+		<h3>[method:Float getRolloffFactor]()</h3>
 		<p>
 		Returns the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/rolloffFactor panner.rolloffFactor].
 		</p>
 
-		<h3>[method:PannerNode setRolloffFactor]( [param:Number value] )</h3>
+		<h3>[method:PositionalAudio setRolloffFactor]( [param:Number value] )</h3>
 		<p>
 		Sets the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/rolloffFactor panner.rolloffFactor].
 		</p>
@@ -107,17 +107,17 @@
 		Returns the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel panner.distanceModel].
 		</p>
 
-		<h3>[method:String setDistanceModel]( [param:String value] )</h3>
+		<h3>[method:PositionalAudio setDistanceModel]( [param:String value] )</h3>
 		<p>
 		Sets the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel panner.distanceModel].
 		</p>
 
-		<h3>[method:PannerNode getMaxDistance]()</h3>
+		<h3>[method:Float getMaxDistance]()</h3>
 		<p>
 		Returns the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/maxDistance panner.maxDistance].
 		</p>
 
-		<h3>[method:PannerNode setMaxDistance]( [param:Number value] )</h3>
+		<h3>[method:PositionalAudio setMaxDistance]( [param:Number value] )</h3>
 		<p>
 		Sets the value of [link:https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/maxDistance panner.maxDistance].
 		</p>

--- a/docs/api/audio/PositionalAudio.html
+++ b/docs/api/audio/PositionalAudio.html
@@ -22,6 +22,7 @@
 		<h2>Example</h2>
 
 		<p>
+			[example:webaudio_orientation webaudio / orientation ]</br>
 			[example:webaudio_sandbox webaudio / sandbox ]</br>
 			[example:webaudio_timing webaudio / timing ]
 		</p>

--- a/src/audio/AudioListener.js
+++ b/src/audio/AudioListener.js
@@ -43,6 +43,8 @@ AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
+		return this;
+
 	},
 
 	getFilter: function () {
@@ -68,6 +70,8 @@ AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		this.gain.connect( this.filter );
 		this.filter.connect( this.context.destination );
 
+		return this;
+
 	},
 
 	getMasterVolume: function () {
@@ -79,6 +83,8 @@ AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
 	setMasterVolume: function ( value ) {
 
 		this.gain.gain.setTargetAtTime( value, this.context.currentTime, 0.01 );
+
+		return this;
 
 	},
 

--- a/src/audio/PositionalAudio.js
+++ b/src/audio/PositionalAudio.js
@@ -36,6 +36,8 @@ PositionalAudio.prototype = Object.assign( Object.create( Audio.prototype ), {
 
 		this.panner.refDistance = value;
 
+		return this;
+
 	},
 
 	getRolloffFactor: function () {
@@ -47,6 +49,8 @@ PositionalAudio.prototype = Object.assign( Object.create( Audio.prototype ), {
 	setRolloffFactor: function ( value ) {
 
 		this.panner.rolloffFactor = value;
+
+		return this;
 
 	},
 
@@ -60,6 +64,8 @@ PositionalAudio.prototype = Object.assign( Object.create( Audio.prototype ), {
 
 		this.panner.distanceModel = value;
 
+		return this;
+
 	},
 
 	getMaxDistance: function () {
@@ -71,6 +77,8 @@ PositionalAudio.prototype = Object.assign( Object.create( Audio.prototype ), {
 	setMaxDistance: function ( value ) {
 
 		this.panner.maxDistance = value;
+
+		return this;
 
 	},
 


### PR DESCRIPTION
This PR adds some missing `return this;` statements in audio classes and corrects the respective docs.