### PR TITLE
Fixed undefined attribute causing error with some GLTF models + meshes

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -721,8 +721,10 @@ function WebGLRenderer( parameters ) {
 			attribute = attributes.get( index );
 
 			if ( attribute !== undefined ) {
+				
 				renderer = indexedBufferRenderer;
 				renderer.setIndex( attribute );
+				
 			}
 
 		}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -720,8 +720,10 @@ function WebGLRenderer( parameters ) {
 
 			attribute = attributes.get( index );
 
-			renderer = indexedBufferRenderer;
-			renderer.setIndex( attribute );
+			if ( attribute !== undefined ) {
+				renderer = indexedBufferRenderer;
+				renderer.setIndex( attribute );
+			}
 
 		}
 
@@ -729,7 +731,7 @@ function WebGLRenderer( parameters ) {
 
 			setupVertexAttributes( material, program, geometry );
 
-			if ( index !== null ) {
+			if ( attribute !== undefined ) {
 
 				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attribute.buffer );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -721,10 +721,10 @@ function WebGLRenderer( parameters ) {
 			attribute = attributes.get( index );
 
 			if ( attribute !== undefined ) {
-				
+
 				renderer = indexedBufferRenderer;
 				renderer.setIndex( attribute );
-				
+
 			}
 
 		}


### PR DESCRIPTION
This small fix makes sure that some loaded GLTF models work with other basic mesh types without causing the strange error referenced in this issue: #12380 

