### PR TITLE
Normalize scroll wheel delta in EditorControls

### DIFF
--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -14,7 +14,7 @@ THREE.EditorControls = function ( object, domElement ) {
 	this.enabled = true;
 	this.center = new THREE.Vector3();
 	this.panSpeed = 0.001;
-	this.zoomSpeed = 0.001;
+	this.zoomSpeed = 0.1;
 	this.rotationSpeed = 0.005;
 
 	// internals
@@ -187,9 +187,8 @@ THREE.EditorControls = function ( object, domElement ) {
 
 		event.preventDefault();
 
-		// if ( scope.enabled === false ) return;
-
-		scope.zoom( new THREE.Vector3( 0, 0, event.deltaY ) );
+		// Normalize deltaY due to https://bugzilla.mozilla.org/show_bug.cgi?id=1392460
+		scope.zoom( new THREE.Vector3( 0, 0, event.deltaY > 0 ? 1 : - 1 ) );
 
 	}
 

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -14,7 +14,7 @@ THREE.EditorControls = function ( object, domElement ) {
 	this.enabled = true;
 	this.center = new THREE.Vector3();
 	this.panSpeed = 0.001;
-	this.zoomSpeed = 0.001;
+	this.zoomSpeed = 0.1;
 	this.rotationSpeed = 0.005;
 
 	// internals
@@ -189,7 +189,7 @@ THREE.EditorControls = function ( object, domElement ) {
 
 		// if ( scope.enabled === false ) return;
 
-		scope.zoom( new THREE.Vector3( 0, 0, event.deltaY ) );
+		scope.zoom( new THREE.Vector3( 0, 0, event.deltaY > 0 ? 1 : - 1 ) );
 
 	}
 


### PR DESCRIPTION
Firefox wheel events reports `deltaY` in lines whereas most other browsers report pixels. (See https://bugzilla.mozilla.org/show_bug.cgi?id=1392460).

This PR normalizes `deltaY` to use it sign, not its distance.