### PR TITLE
fix typo in GLTFLoader example comments

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -60,7 +60,7 @@
 				gltf.asset; // Object
 
 			},
-			// called when loading is in progresses
+			// called while loading is progressing
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );


### PR DESCRIPTION
typo said `progresses` but should have been `progress`. Reworded line instead to meet minimum pull request size and provide clarity.