### PR TITLE
Animation: Do not validate/optimize by default.

### DIFF
--- a/docs/api/animation/AnimationClip.html
+++ b/docs/api/animation/AnimationClip.html
@@ -69,7 +69,7 @@
 		<h3>[method:this optimize]()</h3>
 		<p>
 			Optimizes each track by removing equivalent sequential keys (which are common in morph target
-			sequences). Called automatically by [page:AnimationMixer.clipAction mixer.clipAction]().
+			sequences).
 		</p>
 
 		<h3>[method:this resetDuration]()</h3>
@@ -85,8 +85,7 @@
 
 		<h3>[method:Boolean validate]()</h3>
 		<p>
-			Performs minimal validation on each track in the clip. Called automatically by
-			[page:AnimationMixer.clipAction mixer.clipAction](). Returns true if all tracks are valid.
+			Performs minimal validation on each track in the clip. Returns true if all tracks are valid.
 		</p>
 
 

--- a/docs/api/animation/AnimationClip.html
+++ b/docs/api/animation/AnimationClip.html
@@ -66,27 +66,27 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:AnimationClip optimize]()</h3>
+		<h3>[method:this optimize]()</h3>
 		<p>
 			Optimizes each track by removing equivalent sequential keys (which are common in morph target
-			sequences). Called automatically by [page:AnimationMixer]'s clipAction() method.
+			sequences). Called automatically by [page:AnimationMixer.clipAction mixer.clipAction]().
 		</p>
 
-		<h3>[method:null resetDuration]()</h3>
+		<h3>[method:this resetDuration]()</h3>
 		<p>
 			Sets the [page:.duration duration] of the clip to the duration of its longest
 			[page:KeyframeTrack].
 		</p>
 
-		<h3>[method:AnimationClip trim]()</h3>
+		<h3>[method:this trim]()</h3>
 		<p>
 			Trims all tracks to the clip's duration.
 		</p>
 
-		<h3>[method:AnimationClip validate]()</h3>
+		<h3>[method:Boolean validate]()</h3>
 		<p>
 			Performs minimal validation on each track in the clip. Called automatically by
-			[page:AnimationMixer]'s clipAction() method.
+			[page:AnimationMixer.clipAction mixer.clipAction](). Returns true if all tracks are valid.
 		</p>
 
 

--- a/docs/api/animation/AnimationClip.html
+++ b/docs/api/animation/AnimationClip.html
@@ -69,7 +69,7 @@
 		<h3>[method:AnimationClip optimize]()</h3>
 		<p>
 			Optimizes each track by removing equivalent sequential keys (which are common in morph target
-			sequences).
+			sequences). Called automatically by [page:AnimationMixer]'s clipAction() method.
 		</p>
 
 		<h3>[method:null resetDuration]()</h3>
@@ -81,6 +81,12 @@
 		<h3>[method:AnimationClip trim]()</h3>
 		<p>
 			Trims all tracks to the clip's duration.
+		</p>
+
+		<h3>[method:AnimationClip validate]()</h3>
+		<p>
+			Performs minimal validation on each track in the clip. Called automatically by
+			[page:AnimationMixer]'s clipAction() method.
 		</p>
 
 

--- a/docs/api/animation/AnimationMixer.html
+++ b/docs/api/animation/AnimationMixer.html
@@ -49,16 +49,18 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:AnimationAction clipAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
+		<h3>[method:AnimationAction clipAction]([param:AnimationClip clip], [param:Object3D optionalRoot], [param:Boolean needsValidateAndOptimize])</h3>
 		<p>
 			Returns an [page:AnimationAction] for the passed clip, optionally using a root object different
 			from the mixer's default root. The first parameter can be either an [page:AnimationClip] object
 			or the name of an AnimationClip.<br /><br />
 
-			If an action fitting these parameters doesn't yet exist, it will be created by this method.<br /><br />
+			Automatically calls .validate() and .optimize() on the clip, unless 'needsValidateAndOptimize'
+			parameter is set to false.<br /><br />
 
-			Note: Calling this method several times with the same parameters returns always the same clip
-			instance.
+			If an action fitting the clip and root parameters doesn't yet exist, it will be created by
+			this method. Calling this method several times with the same clip and root parameters always
+			returns the same clip instance.
 		</p>
 
 		<h3>[method:AnimationAction existingAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>

--- a/docs/api/animation/AnimationMixer.html
+++ b/docs/api/animation/AnimationMixer.html
@@ -49,14 +49,11 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:AnimationAction clipAction]([param:AnimationClip clip], [param:Object3D optionalRoot], [param:Boolean needsValidateAndOptimize])</h3>
+		<h3>[method:AnimationAction clipAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
 		<p>
 			Returns an [page:AnimationAction] for the passed clip, optionally using a root object different
 			from the mixer's default root. The first parameter can be either an [page:AnimationClip] object
 			or the name of an AnimationClip.<br /><br />
-
-			Automatically calls .validate() and .optimize() on the clip, unless 'needsValidateAndOptimize'
-			parameter is set to false.<br /><br />
 
 			If an action fitting the clip and root parameters doesn't yet exist, it will be created by
 			this method. Calling this method several times with the same clip and root parameters always

--- a/docs/api/animation/KeyframeTrack.html
+++ b/docs/api/animation/KeyframeTrack.html
@@ -205,7 +205,6 @@
 		<h3>[method:this optimize]()</h3>
 		<p>
 			Removes equivalent sequential keys, which are common in morph target sequences.
-			Called automatically by [page:AnimationMixer.clipAction mixer.clipAction]().
 		</p>
 
 		<h3>[method:this scale]()</h3>
@@ -236,8 +235,7 @@
 
 		<h3>[method:Boolean validate]()</h3>
 		<p>
-			Performs minimal validation on the tracks. Called automatically by
-			[page:AnimationMixer.clipAction mixer.clipAction](). Returns true if valid.
+			Performs minimal validation on the tracks. Returns true if valid.
 		</p>
 
 		<p>

--- a/docs/api/animation/KeyframeTrack.html
+++ b/docs/api/animation/KeyframeTrack.html
@@ -202,12 +202,13 @@
 			created automatically.
 		</p>
 
-		<h3>[method:null optimize]()</h3>
+		<h3>[method:this optimize]()</h3>
 		<p>
 			Removes equivalent sequential keys, which are common in morph target sequences.
+			Called automatically by [page:AnimationMixer.clipAction mixer.clipAction]().
 		</p>
 
-		<h3>[method:null scale]()</h3>
+		<h3>[method:this scale]()</h3>
 		<p>
 			Scales all keyframe times by a factor.<br /><br />
 
@@ -216,26 +217,27 @@
 			[page:AnimationClip.CreateFromMorphTargetSequence animationClip.CreateFromMorphTargetSequence]).
 		</p>
 
-		<h3>[method:null setInterpolation]( [param:Constant interpolationType] )</h3>
+		<h3>[method:this setInterpolation]( [param:Constant interpolationType] )</h3>
 		<p>
 			Sets the interpolation type. See [page:Animation Animation Constants] for choices.
 		</p>
 
-		<h3>[method:null shift]( [param:Number timeOffsetInSeconds] )</h3>
+		<h3>[method:this shift]( [param:Number timeOffsetInSeconds] )</h3>
 		<p>
 			Moves all keyframes either forward or backward in time.
 		</p>
 
 
-		<h3>[method:null trim]( [param:Number startTimeInSeconds], [param:Number endTimeInSeconds] )</h3>
+		<h3>[method:this trim]( [param:Number startTimeInSeconds], [param:Number endTimeInSeconds] )</h3>
 		<p>
 			Removes keyframes before *startTime* and after *endTime*,
 			without changing any values within the range [*startTime*, *endTime*].
 		</p>
 
-		<h3>[method:null validate]()</h3>
+		<h3>[method:Boolean validate]()</h3>
 		<p>
-			Performs minimal validation on the tracks.
+			Performs minimal validation on the tracks. Called automatically by
+			[page:AnimationMixer.clipAction mixer.clipAction](). Returns true if valid.
 		</p>
 
 		<p>

--- a/docs/api/animation/KeyframeTrack.html
+++ b/docs/api/animation/KeyframeTrack.html
@@ -91,16 +91,6 @@
 		<h2>Properties</h2>
 
 
-		<h3>[property:Boolean isOptimized]</h3>
-		<p>
-			Whether the track has been optimized with .optimize().
-		</p>
-
-		<h3>[property:Boolean isValidated]</h3>
-		<p>
-			Whether the track has been successfully validated with .validate().
-		</p>
-
 		<h3>[property:String name]</h3>
 		<p>
 			The track's name can refer to [page:Geometry.morphTargets morph targets] or
@@ -214,8 +204,7 @@
 
 		<h3>[method:null optimize]()</h3>
 		<p>
-			Removes equivalent sequential keys, which are common in morph target sequences. Calling this
-			method will set [page:.isOptimized isOptimized] to true, and additional calls will do nothing.
+			Removes equivalent sequential keys, which are common in morph target sequences.
 		</p>
 
 		<h3>[method:null scale]()</h3>
@@ -246,9 +235,7 @@
 
 		<h3>[method:null validate]()</h3>
 		<p>
-			Performs minimal validation on the tracks.  Calling this method will set
-			[page:.isValidated isValidated] to true if validation succeeds, and additional calls will do
-			nothing.
+			Performs minimal validation on the tracks.
 		</p>
 
 		<p>

--- a/docs/api/animation/KeyframeTrack.html
+++ b/docs/api/animation/KeyframeTrack.html
@@ -91,6 +91,16 @@
 		<h2>Properties</h2>
 
 
+		<h3>[property:Boolean isOptimized]</h3>
+		<p>
+			Whether the track has been optimized with .optimize().
+		</p>
+
+		<h3>[property:Boolean isValidated]</h3>
+		<p>
+			Whether the track has been successfully validated with .validate().
+		</p>
+
 		<h3>[property:String name]</h3>
 		<p>
 			The track's name can refer to [page:Geometry.morphTargets morph targets] or
@@ -204,8 +214,8 @@
 
 		<h3>[method:null optimize]()</h3>
 		<p>
-			Removes equivalent sequential keys, which are common in morph target sequences. Called
-			automatically by the constructor.
+			Removes equivalent sequential keys, which are common in morph target sequences. Calling this
+			method will set [page:.isOptimized isOptimized] to true, and additional calls will do nothing.
 		</p>
 
 		<h3>[method:null scale]()</h3>
@@ -236,7 +246,12 @@
 
 		<h3>[method:null validate]()</h3>
 		<p>
-			Performs minimal validation on the tracks. Called automatically by the constructor.<br /><br />
+			Performs minimal validation on the tracks.  Calling this method will set
+			[page:.isValidated isValidated] to true if validation succeeds, and additional calls will do
+			nothing.
+		</p>
+
+		<p>
 			This method logs errors to the console, if a track is empty, if the [page:.valueSize value size] is not valid, if an item
 			in the [page:.times times] or [page:.values values] array is not a valid number or if the items in the *times* array are out of order.
 		</p>

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -325,6 +325,8 @@ Object.assign( AnimationClip.prototype, {
 
 		this.duration = duration;
 
+		return this;
+
 	},
 
 	trim: function () {
@@ -341,13 +343,15 @@ Object.assign( AnimationClip.prototype, {
 
 	validate: function () {
 
+		var valid = true;
+
 		for ( var i = 0; i < this.tracks.length; i ++ ) {
 
-			this.tracks[ i ].validate();
+			valid = valid && this.tracks[ i ].validate();
 
 		}
 
-		return this;
+		return valid;
 
 	},
 

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -28,8 +28,6 @@ function AnimationClip( name, duration, tracks ) {
 
 	}
 
-	this.optimize();
-
 }
 
 Object.assign( AnimationClip, {
@@ -334,6 +332,18 @@ Object.assign( AnimationClip.prototype, {
 		for ( var i = 0; i < this.tracks.length; i ++ ) {
 
 			this.tracks[ i ].trim( 0, this.duration );
+
+		}
+
+		return this;
+
+	},
+
+	validate: function () {
+
+		for ( var i = 0; i < this.tracks.length; i ++ ) {
+
+			this.tracks[ i ].validate();
 
 		}
 

--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -518,7 +518,7 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 	// return an action for a clip optionally using a custom root target
 	// object (this method allocates a lot of dynamic memory in case a
 	// previously unknown clip/root combination is specified)
-	clipAction: function ( clip, optionalRoot, needsValidateAndOptimize ) {
+	clipAction: function ( clip, optionalRoot ) {
 
 		var root = optionalRoot || this._root,
 			rootUuid = root.uuid,
@@ -554,12 +554,6 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		// clip must be known when specified via string
 		if ( clipObject === null ) return null;
-
-		if ( needsValidateAndOptimize !== false ) {
-
-			if ( clipObject.validate() ) clipObject.optimize();
-
-		}
 
 		// allocate all resources required to run it
 		var newAction = new AnimationAction( this, clipObject, optionalRoot );

--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -518,7 +518,7 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 	// return an action for a clip optionally using a custom root target
 	// object (this method allocates a lot of dynamic memory in case a
 	// previously unknown clip/root combination is specified)
-	clipAction: function ( clip, optionalRoot ) {
+	clipAction: function ( clip, optionalRoot, needsValidateAndOptimize ) {
 
 		var root = optionalRoot || this._root,
 			rootUuid = root.uuid,
@@ -554,6 +554,13 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		// clip must be known when specified via string
 		if ( clipObject === null ) return null;
+
+		if ( needsValidateAndOptimize !== false ) {
+
+			clipObject.validate();
+			clipObject.optimize();
+
+		}
 
 		// allocate all resources required to run it
 		var newAction = new AnimationAction( this, clipObject, optionalRoot );

--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -557,8 +557,7 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		if ( needsValidateAndOptimize !== false ) {
 
-			clipObject.validate();
-			clipObject.optimize();
+			if ( clipObject.validate() ) clipObject.optimize();
 
 		}
 

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -243,11 +243,13 @@ Object.assign( KeyframeTrack.prototype, {
 			}
 
 			console.warn( 'THREE.KeyframeTrack:', message );
-			return;
+			return this;
 
 		}
 
 		this.createInterpolant = factoryMethod;
+
+		return this;
 
 	},
 

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -34,8 +34,11 @@ function KeyframeTrack( name, times, values, interpolation ) {
 	this.times = AnimationUtils.convertArray( times, this.TimeBufferType );
 	this.values = AnimationUtils.convertArray( values, this.ValueBufferType );
 
-	this.isValidated = false;
-	this.isOptimized = false;
+	// TODO: These flags are used to warn users of duplicate validate/optimize
+	// calls when multiple actions are created from a single clip, starting with
+	// r95. We will eventually remove these flags and the transitional warnings.
+	this._needsValidate = true;
+	this._needsOptimize = true;
 
 	this.setInterpolation( interpolation || this.DefaultInterpolation );
 
@@ -353,7 +356,13 @@ Object.assign( KeyframeTrack.prototype, {
 	// ensure we do not get a GarbageInGarbageOut situation, make sure tracks are at least minimally viable
 	validate: function () {
 
-		if ( this.isValidated ) return true;
+		if ( ! this._needsValidate ) {
+
+			console.warn( 'THREE.KeyframeTrack: Track has already been validated. '
+				+ 'Disable "needsValidateAndOptimize" argument to mixer.clipAction() '
+				+ 'to avoid redundant validation.' );
+
+		}
 
 		var valid = true;
 
@@ -425,7 +434,7 @@ Object.assign( KeyframeTrack.prototype, {
 
 		}
 
-		this.isValidated = valid;
+		this._needsValidate = !valid;
 
 		return valid;
 
@@ -435,7 +444,13 @@ Object.assign( KeyframeTrack.prototype, {
 	// (0,0,0,0,1,1,1,0,0,0,0,0,0,0) --> (0,0,1,1,0,0)
 	optimize: function () {
 
-		if ( this.isOptimized ) return this;
+		if ( ! this._needsOptimize ) {
+
+			console.warn( 'THREE.KeyframeTrack: Track has already been optimized. '
+				+ 'Disable "needsValidateAndOptimize" argument to mixer.clipAction() '
+				+ 'to avoid redundant optimization.' );
+
+		}
 
 		var times = this.times,
 			values = this.values,
@@ -535,7 +550,7 @@ Object.assign( KeyframeTrack.prototype, {
 
 		}
 
-		this.isOptimized = true;
+		this._needsOptimize = false;
 
 		return this;
 

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -34,10 +34,10 @@ function KeyframeTrack( name, times, values, interpolation ) {
 	this.times = AnimationUtils.convertArray( times, this.TimeBufferType );
 	this.values = AnimationUtils.convertArray( values, this.ValueBufferType );
 
-	this.setInterpolation( interpolation || this.DefaultInterpolation );
+	this.isValidated = false;
+	this.isOptimized = false;
 
-	this.validate();
-	this.optimize();
+	this.setInterpolation( interpolation || this.DefaultInterpolation );
 
 }
 
@@ -353,6 +353,8 @@ Object.assign( KeyframeTrack.prototype, {
 	// ensure we do not get a GarbageInGarbageOut situation, make sure tracks are at least minimally viable
 	validate: function () {
 
+		if ( this.isValidated ) return true;
+
 		var valid = true;
 
 		var valueSize = this.getValueSize();
@@ -423,6 +425,8 @@ Object.assign( KeyframeTrack.prototype, {
 
 		}
 
+		this.isValidated = valid;
+
 		return valid;
 
 	},
@@ -430,6 +434,8 @@ Object.assign( KeyframeTrack.prototype, {
 	// removes equivalent sequential keys as common in morph target sequences
 	// (0,0,0,0,1,1,1,0,0,0,0,0,0,0) --> (0,0,1,1,0,0)
 	optimize: function () {
+
+		if ( this.isOptimized ) return this;
 
 		var times = this.times,
 			values = this.values,
@@ -528,6 +534,8 @@ Object.assign( KeyframeTrack.prototype, {
 			this.values = AnimationUtils.arraySlice( values, 0, writeIndex * stride );
 
 		}
+
+		this.isOptimized = true;
 
 		return this;
 

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -34,12 +34,6 @@ function KeyframeTrack( name, times, values, interpolation ) {
 	this.times = AnimationUtils.convertArray( times, this.TimeBufferType );
 	this.values = AnimationUtils.convertArray( values, this.ValueBufferType );
 
-	// TODO: These flags are used to warn users of duplicate validate/optimize
-	// calls when multiple actions are created from a single clip, starting with
-	// r95. We will eventually remove these flags and the transitional warnings.
-	this._needsValidate = true;
-	this._needsOptimize = true;
-
 	this.setInterpolation( interpolation || this.DefaultInterpolation );
 
 }
@@ -358,14 +352,6 @@ Object.assign( KeyframeTrack.prototype, {
 	// ensure we do not get a GarbageInGarbageOut situation, make sure tracks are at least minimally viable
 	validate: function () {
 
-		if ( ! this._needsValidate ) {
-
-			console.warn( 'THREE.KeyframeTrack: Track has already been validated. '
-				+ 'Disable "needsValidateAndOptimize" argument to mixer.clipAction() '
-				+ 'to avoid redundant validation.' );
-
-		}
-
 		var valid = true;
 
 		var valueSize = this.getValueSize();
@@ -436,8 +422,6 @@ Object.assign( KeyframeTrack.prototype, {
 
 		}
 
-		this._needsValidate = !valid;
-
 		return valid;
 
 	},
@@ -445,14 +429,6 @@ Object.assign( KeyframeTrack.prototype, {
 	// removes equivalent sequential keys as common in morph target sequences
 	// (0,0,0,0,1,1,1,0,0,0,0,0,0,0) --> (0,0,1,1,0,0)
 	optimize: function () {
-
-		if ( ! this._needsOptimize ) {
-
-			console.warn( 'THREE.KeyframeTrack: Track has already been optimized. '
-				+ 'Disable "needsValidateAndOptimize" argument to mixer.clipAction() '
-				+ 'to avoid redundant optimization.' );
-
-		}
 
 		var times = this.times,
 			values = this.values,
@@ -551,8 +527,6 @@ Object.assign( KeyframeTrack.prototype, {
 			this.values = AnimationUtils.arraySlice( values, 0, writeIndex * stride );
 
 		}
-
-		this._needsOptimize = false;
 
 		return this;
 

--- a/test/unit/src/animation/AnimationClip.tests.js
+++ b/test/unit/src/animation/AnimationClip.tests.js
@@ -72,6 +72,12 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
+		QUnit.todo( "validate", ( assert ) => {
+
+			assert.ok( false, "everything's gonna be alright" );
+
+		} );
+
 	} );
 
 } );

--- a/test/unit/src/animation/KeyframeTrack.tests.js
+++ b/test/unit/src/animation/KeyframeTrack.tests.js
@@ -111,15 +111,11 @@ export default QUnit.module( 'Animation', () => {
 
 		QUnit.test( 'validate', ( assert ) => {
 
-			var track = new NumberKeyframeTrack( '.material.opacity', [ 0, 1 ], [ 0, NaN ] );
+			var validTrack = new NumberKeyframeTrack( '.material.opacity', [ 0, 1 ], [ 0, 0.5 ] );
+			var invalidTrack = new NumberKeyframeTrack( '.material.opacity', [ 0, 1 ], [ 0, NaN ] );
 
-			track.isValidated = true;
-			assert.ok( track.validate() );
-			assert.ok( track.isValidated );
-
-			track.isValidated = false;
-			assert.notOk( track.validate() );
-			assert.notOk( track.isValidated );
+			assert.ok( validTrack.validate() );
+			assert.notOk( invalidTrack.validate() );
 
 		} );
 
@@ -129,15 +125,10 @@ export default QUnit.module( 'Animation', () => {
 
 			assert.equal( track.values.length, 5 );
 
-			track.isOptimized = true;
 			track.optimize();
 
-			assert.equal( track.values.length, 5 );
-
-			track.isOptimized = false;
-			track.optimize();
-
-			assert.equal( track.values.length, 3 );
+			assert.smartEqual( Array.from( track.times ), [ 0, 3, 4 ] );
+			assert.smartEqual( Array.from( track.values ), [ 0, 0, 1 ] );
 
 		} );
 

--- a/test/unit/src/animation/KeyframeTrack.tests.js
+++ b/test/unit/src/animation/KeyframeTrack.tests.js
@@ -4,6 +4,7 @@
 /* global QUnit */
 
 import { KeyframeTrack } from '../../../../src/animation/KeyframeTrack';
+import { NumberKeyframeTrack } from '../../../../src/animation/tracks/NumberKeyframeTrack';
 
 export default QUnit.module( 'Animation', () => {
 
@@ -108,15 +109,35 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
-		QUnit.todo( "validate", ( assert ) => {
+		QUnit.test( 'validate', ( assert ) => {
 
-			assert.ok( false, "everything's gonna be alright" );
+			var track = new NumberKeyframeTrack( '.material.opacity', [ 0, 1 ], [ 0, NaN ] );
+
+			track.isValidated = true;
+			assert.ok( track.validate() );
+			assert.ok( track.isValidated );
+
+			track.isValidated = false;
+			assert.notOk( track.validate() );
+			assert.notOk( track.isValidated );
 
 		} );
 
-		QUnit.todo( "optimize", ( assert ) => {
+		QUnit.test( 'optimize', ( assert ) => {
 
-			assert.ok( false, "everything's gonna be alright" );
+			var track = new NumberKeyframeTrack( '.material.opacity', [ 0, 1, 2, 3, 4 ], [ 0, 0, 0, 0, 1 ] );
+
+			assert.equal( track.values.length, 5 );
+
+			track.isOptimized = true;
+			track.optimize();
+
+			assert.equal( track.values.length, 5 );
+
+			track.isOptimized = false;
+			track.optimize();
+
+			assert.equal( track.values.length, 3 );
 
 		} );
 


### PR DESCRIPTION
Follow-up from https://github.com/mrdoob/three.js/pull/14345, fixes #14336.

- Removes automatic calls to `validate()` and `optimize()` during keyframe track creation.
- Adds `validate()` method on clip.
- Updates animation docs and tests.

<details><summary>
<strike>Usage (previous version of PR)</strike>
</summary>

```js
const action = mixer.clipAction( clip, undefined, false );
action.play();
```

</details>