### PR TITLE
AudioListener: Use linearRampToValueAtTime()

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -11,6 +11,7 @@ function Audio( listener ) {
 
 	this.type = 'Audio';
 
+	this.listener = listener;
 	this.context = listener.context;
 
 	this.gain = this.context.createGain();

--- a/src/audio/AudioListener.js
+++ b/src/audio/AudioListener.js
@@ -111,6 +111,9 @@ AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			if ( listener.positionX ) {
 
+				// code path for Chrome (see #14393)
+				// right now, it is the only browser that supports AudioParam in AudioListener
+
 				var delta = clock.getDelta();
 				var endTime = this.context.currentTime + delta;
 

--- a/src/audio/AudioListener.js
+++ b/src/audio/AudioListener.js
@@ -21,6 +21,8 @@ function AudioListener() {
 
 	this.filter = null;
 
+	this.timeDelta = 0;
+
 }
 
 AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
@@ -105,6 +107,8 @@ AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			var listener = this.context.listener;
 			var up = this.up;
 
+			this.timeDelta = clock.getDelta();
+
 			this.matrixWorld.decompose( position, quaternion, scale );
 
 			orientation.set( 0, 0, - 1 ).applyQuaternion( quaternion );
@@ -112,10 +116,8 @@ AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			if ( listener.positionX ) {
 
 				// code path for Chrome (see #14393)
-				// right now, it is the only browser that supports AudioParam in AudioListener
 
-				var delta = clock.getDelta();
-				var endTime = this.context.currentTime + delta;
+				var endTime = this.context.currentTime + this.timeDelta;
 
 				listener.positionX.linearRampToValueAtTime( position.x, endTime );
 				listener.positionY.linearRampToValueAtTime( position.y, endTime );

--- a/src/audio/AudioListener.js
+++ b/src/audio/AudioListener.js
@@ -4,6 +4,7 @@
 
 import { Vector3 } from '../math/Vector3.js';
 import { Quaternion } from '../math/Quaternion.js';
+import { Clock } from '../core/Clock.js';
 import { Object3D } from '../core/Object3D.js';
 import { AudioContext } from './AudioContext.js';
 
@@ -95,6 +96,7 @@ AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		var scale = new Vector3();
 
 		var orientation = new Vector3();
+		var clock = new Clock();
 
 		return function updateMatrixWorld( force ) {
 
@@ -109,15 +111,18 @@ AudioListener.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			if ( listener.positionX ) {
 
-				listener.positionX.setValueAtTime( position.x, this.context.currentTime );
-				listener.positionY.setValueAtTime( position.y, this.context.currentTime );
-				listener.positionZ.setValueAtTime( position.z, this.context.currentTime );
-				listener.forwardX.setValueAtTime( orientation.x, this.context.currentTime );
-				listener.forwardY.setValueAtTime( orientation.y, this.context.currentTime );
-				listener.forwardZ.setValueAtTime( orientation.z, this.context.currentTime );
-				listener.upX.setValueAtTime( up.x, this.context.currentTime );
-				listener.upY.setValueAtTime( up.y, this.context.currentTime );
-				listener.upZ.setValueAtTime( up.z, this.context.currentTime );
+				var delta = clock.getDelta();
+				var endTime = this.context.currentTime + delta;
+
+				listener.positionX.linearRampToValueAtTime( position.x, endTime );
+				listener.positionY.linearRampToValueAtTime( position.y, endTime );
+				listener.positionZ.linearRampToValueAtTime( position.z, endTime );
+				listener.forwardX.linearRampToValueAtTime( orientation.x, endTime );
+				listener.forwardY.linearRampToValueAtTime( orientation.y, endTime );
+				listener.forwardZ.linearRampToValueAtTime( orientation.z, endTime );
+				listener.upX.linearRampToValueAtTime( up.x, endTime );
+				listener.upY.linearRampToValueAtTime( up.y, endTime );
+				listener.upZ.linearRampToValueAtTime( up.z, endTime );
 
 			} else {
 

--- a/src/audio/PositionalAudio.js
+++ b/src/audio/PositionalAudio.js
@@ -109,8 +109,25 @@ PositionalAudio.prototype = Object.assign( Object.create( Audio.prototype ), {
 
 			orientation.set( 0, 0, 1 ).applyQuaternion( quaternion );
 
-			panner.setPosition( position.x, position.y, position.z );
-			panner.setOrientation( orientation.x, orientation.y, orientation.z );
+			if ( panner.positionX ) {
+
+				// code path for Chrome and Firefox (see #14393)
+
+				var endTime = this.context.currentTime + this.listener.timeDelta;
+
+				panner.positionX.linearRampToValueAtTime( position.x, endTime );
+				panner.positionY.linearRampToValueAtTime( position.y, endTime );
+				panner.positionZ.linearRampToValueAtTime( position.z, endTime );
+				panner.orientationX.linearRampToValueAtTime( orientation.x, endTime );
+				panner.orientationY.linearRampToValueAtTime( orientation.y, endTime );
+				panner.orientationZ.linearRampToValueAtTime( orientation.z, endTime );
+
+			} else {
+
+				panner.setPosition( position.x, position.y, position.z );
+				panner.setOrientation( orientation.x, orientation.y, orientation.z );
+
+			}
 
 		};
 


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/11133#issuecomment-400778738

@hoch `AudioListener` now maintains an internal time delta value so it's possible to use `linearRampToValueAtTime()`. What do you think about this setup?