### PR TITLE
Set Texture.image immediately in TextureLoader

### DIFF
--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -26,23 +26,22 @@ Object.assign( TextureLoader.prototype, {
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
 
-		loader.load( url, function ( image ) {
+		texture.image =
+			loader.load( url, function () {
 
-			texture.image = image;
+				// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
+				var isJPEG = url.search( /\.(jpg|jpeg)$/ ) > 0 || url.search( /^data\:image\/jpeg/ ) === 0;
 
-			// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
-			var isJPEG = url.search( /\.(jpg|jpeg)$/ ) > 0 || url.search( /^data\:image\/jpeg/ ) === 0;
+				texture.format = isJPEG ? RGBFormat : RGBAFormat;
+				texture.needsUpdate = true;
 
-			texture.format = isJPEG ? RGBFormat : RGBAFormat;
-			texture.needsUpdate = true;
+				if ( onLoad !== undefined ) {
 
-			if ( onLoad !== undefined ) {
+					onLoad( texture );
 
-				onLoad( texture );
+				}
 
-			}
-
-		}, onProgress, onError );
+			}, onProgress, onError );
 
 		return texture;
 


### PR DESCRIPTION
This PR changes `TextureLoader` to set `Texture.image` immediately instead of waiting for the `ImageLoader` callback to fire. This lets you register for the image's `load` event and rerender the scene once it loads.

The `onUpdate` callback for `TextureLoader.load` isn't sufficient because you don't always have access to that function, such as when loading a model with the `ColladaLoader`.