### PR TITLE
Water2 shader cannot compile when using FOG_EXP2

### DIFF
--- a/examples/js/objects/Water2.js
+++ b/examples/js/objects/Water2.js
@@ -263,6 +263,7 @@ THREE.Water.WaterShader = {
 
 	fragmentShader: [
 
+		'#include <common>',
 		'#include <fog_pars_fragment>',
 
 		'uniform sampler2D tReflectionMap;',


### PR DESCRIPTION
LOG2 and whiteCompliment are defined in common which is not currently included.