### PR TITLE
Quaternion: Added .angleTo()

### DIFF
--- a/docs/api/math/Quaternion.html
+++ b/docs/api/math/Quaternion.html
@@ -59,12 +59,16 @@
 
 		<h2>Methods</h2>
 
+		<h3>[method:Float angleTo]( [param:Quaternion q] )</h3>
+		<p>
+			Returns the angle between this quaternion and quaternion [page:Quaternion q] in radians.
+		</p>
+
 		<h3>[method:Quaternion clone]()</h3>
 		<p>
 			Creates a new Quaternion with identical [page:.x x], [page:.y y],
 			[page:.z z] and [page:.w w] properties to this one.
 		</p>
-
 
 		<h3>[method:Quaternion conjugate]()</h3>
 		<p>

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -393,21 +393,11 @@ Object.assign( Quaternion.prototype, {
 
 	}(),
 
-	angleTo: function () {
+	angleTo: function ( q ) {
 
-		var p = new Quaternion();
+		return 2 * Math.acos( Math.abs( this.dot( q ) ) );
 
-		return function angleTo( q ) {
-
-			p.copy( this ).inverse();
-
-			p.premultiply( q );
-
-			return 2 * Math.acos( p.w );
-
-		};
-
-	}(),
+	},
 
 	inverse: function () {
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -399,9 +399,9 @@ Object.assign( Quaternion.prototype, {
 
 		return function angleTo( q ) {
 
-			p.copy( q ).inverse();
+			p.copy( this ).inverse();
 
-			p.premultiply( this );
+			p.premultiply( q );
 
 			return 2 * Math.acos( p.w );
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -393,6 +393,22 @@ Object.assign( Quaternion.prototype, {
 
 	}(),
 
+	angleTo: function () {
+
+		var p = new Quaternion();
+
+		return function angleTo( q ) {
+
+			p.copy( q ).inverse();
+
+			p.premultiply( this );
+
+			return 2 * Math.acos( p.w );
+
+		};
+
+	}(),
+
 	inverse: function () {
 
 		// quaternion is assumed to have unit length

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -391,6 +391,18 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( "angleTo", ( assert ) => {
+
+			var a = new Quaternion();
+			var b = new Quaternion().setFromEuler( new Euler( 0, Math.PI, 0 ) );
+			var c = new Quaternion().setFromEuler( new Euler( 0, Math.PI * 2, 0 ) );
+
+			assert.ok( a.angleTo( a ) <= eps, "Passed!" );
+			assert.ok( a.angleTo( b ) - Math.PI <= eps, "Passed!" );
+			assert.ok( a.angleTo( c ) - ( Math.PI * 2 ) <= eps, "Passed!" );
+
+		} );
+
 		QUnit.test( "inverse/conjugate", ( assert ) => {
 
 			var a = new Quaternion( x, y, z, w );

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -396,10 +396,12 @@ export default QUnit.module( 'Maths', () => {
 			var a = new Quaternion();
 			var b = new Quaternion().setFromEuler( new Euler( 0, Math.PI, 0 ) );
 			var c = new Quaternion().setFromEuler( new Euler( 0, Math.PI * 2, 0 ) );
+			var d = new Quaternion().setFromEuler( new Euler( 1, 1, 1 ) );
 
 			assert.ok( a.angleTo( a ) <= eps, "Passed!" );
 			assert.ok( ( a.angleTo( b ) - Math.PI ) <= eps, "Passed!" );
 			assert.ok( ( a.angleTo( c ) - ( Math.PI * 2 ) ) <= eps, "Passed!" );
+			assert.ok( ( a.angleTo( d ) - ( 1.939087528822506 ) ) <= eps, "Passed!" );
 
 		} );
 

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -398,8 +398,8 @@ export default QUnit.module( 'Maths', () => {
 			var c = new Quaternion().setFromEuler( new Euler( 0, Math.PI * 2, 0 ) );
 
 			assert.ok( a.angleTo( a ) <= eps, "Passed!" );
-			assert.ok( a.angleTo( b ) - Math.PI <= eps, "Passed!" );
-			assert.ok( a.angleTo( c ) - ( Math.PI * 2 ) <= eps, "Passed!" );
+			assert.ok( ( a.angleTo( b ) - Math.PI ) <= eps, "Passed!" );
+			assert.ok( ( a.angleTo( c ) - ( Math.PI * 2 ) ) <= eps, "Passed!" );
 
 		} );
 


### PR DESCRIPTION
I need this method for a project and I thought it might be a nice addition to `Quaternion`. Counterpart to Unity's [Quaternion.Angle](https://docs.unity3d.com/ScriptReference/Quaternion.Angle.html).

Reference: https://math.stackexchange.com/a/167828