### PR TITLE
better synchronized scrolling

### DIFF
--- a/examples/webgl_multiple_elements.html
+++ b/examples/webgl_multiple_elements.html
@@ -16,19 +16,19 @@
 				font-size:13px;
 
 				background-color: #fff;
-				margin: 0px;
+				margin: 0;
 			}
 
 			#info {
 				position: absolute;
-				top: 0px; width: 100%;
+				top: 0; width: 100%;
 				padding: 5px;
 				text-align:center;
 			}
 
 			#content {
 				position: absolute;
-				top: 0px; width: 100%;
+				top: 0; width: 100%;
 				z-index: 1;
 				padding: 3em 0 0 0;
 			}
@@ -38,8 +38,8 @@
 			}
 
 			#c {
-				position: fixed;
-				left: 0px;
+				position: absolute;
+				left: 0;
 				width: 100%;
 				height: 100%;
 			}
@@ -186,6 +186,8 @@
 			function render() {
 
 				updateSize();
+
+				canvas.style.transform = `translateY(${window.scrollY}px)`;
 
 				renderer.setClearColor( 0xffffff );
 				renderer.setScissorTest( false );


### PR DESCRIPTION
moving the canvas each frame inside rAF means the browser will scroll the canvas with
the rest of the page even if we don't get a chance to update it. This removes the bounce that was there before where our canvas update was behind the page update.

you can compare the difference below. Both of these examples are set to render at only 15fps to exaggerate the issue (though the issue comes up naturally often while three.js pages are initializing their assets etc....)

scroll the results up and down

old way:  http://jsfiddle.net/greggman/w8dv3r1h/

new way: http://jsfiddle.net/greggman/rtps2ygz/
