### PR TITLE
WebGLRenderer: Fix mipmap generation in .copyTextureToTexture()

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -7,7 +7,6 @@ import {
 	TriangleFanDrawMode,
 	TriangleStripDrawMode,
 	TrianglesDrawMode,
-	NoColors,
 	LinearToneMapping,
 	BackSide
 } from '../constants.js';
@@ -576,7 +575,7 @@ function WebGLRenderer( parameters ) {
 
 	}
 
-	this.renderBufferImmediate = function ( object, program, material ) {
+	this.renderBufferImmediate = function ( object, program ) {
 
 		state.initAttributes();
 
@@ -2579,7 +2578,7 @@ function WebGLRenderer( parameters ) {
 		var glFormat = utils.convert( dstTexture.format );
 		var glType = utils.convert( dstTexture.type );
 
-		this.setTexture2D( dstTexture, 0 );
+		textures.setTexture2D( dstTexture, 0 );
 
 		if ( srcTexture.isDataTexture ) {
 
@@ -2590,6 +2589,8 @@ function WebGLRenderer( parameters ) {
 			_gl.texSubImage2D( _gl.TEXTURE_2D, level || 0, position.x, position.y, glFormat, glType, srcTexture.image );
 
 		}
+
+		textures.updateTextureMipmap( dstTexture );
 
 	};
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -827,6 +827,24 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	}
 
+	function updateTextureMipmap( texture ) {
+
+		var image = texture.image;
+		var isTargetPowerOfTwo = isPowerOfTwo( image );
+
+		if ( textureNeedsGenerateMipmaps( texture, isTargetPowerOfTwo ) ) {
+
+			var target = texture.isCubeTexture ? _gl.TEXTURE_CUBE_MAP : _gl.TEXTURE_2D;
+			var webglTexture = properties.get( texture ).__webglTexture;
+
+			state.bindTexture( target, webglTexture );
+			generateMipmap( target, texture, image.width, image.height );
+			state.bindTexture( target, null );
+
+		}
+
+	}
+
 	function updateRenderTargetMipmap( renderTarget ) {
 
 		var texture = renderTarget.texture;
@@ -866,6 +884,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 	this.setTextureCubeDynamic = setTextureCubeDynamic;
 	this.setupRenderTarget = setupRenderTarget;
 	this.updateRenderTargetMipmap = updateRenderTargetMipmap;
+	this.updateTextureMipmap = updateTextureMipmap;
 
 }
 


### PR DESCRIPTION
Fixes #14423

