### PR TITLE
Quaternion: Improve result of angleTo()

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -1,3 +1,4 @@
+import { _Math } from './Math.js';
 import { Vector3 } from './Vector3.js';
 
 /**
@@ -395,7 +396,7 @@ Object.assign( Quaternion.prototype, {
 
 	angleTo: function ( q ) {
 
-		return 2 * Math.acos( Math.abs( this.dot( q ) ) );
+		return 2 * Math.acos( Math.abs( _Math.clamp( this.dot( q ), - 1, 1 ) ) );
 
 	},
 

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -396,12 +396,10 @@ export default QUnit.module( 'Maths', () => {
 			var a = new Quaternion();
 			var b = new Quaternion().setFromEuler( new Euler( 0, Math.PI, 0 ) );
 			var c = new Quaternion().setFromEuler( new Euler( 0, Math.PI * 2, 0 ) );
-			var d = new Quaternion().setFromEuler( new Euler( 1, 1, 1 ) );
 
-			assert.ok( a.angleTo( a ) <= eps, "Passed!" );
-			assert.ok( ( a.angleTo( b ) - Math.PI ) <= eps, "Passed!" );
-			assert.ok( ( a.angleTo( c ) - ( Math.PI * 2 ) ) <= eps, "Passed!" );
-			assert.ok( ( a.angleTo( d ) - ( 1.939087528822506 ) ) <= eps, "Passed!" );
+			assert.ok( a.angleTo( a ) === 0, "Passed!" );
+			assert.ok( a.angleTo( b ) === Math.PI, "Passed!" );
+			assert.ok( a.angleTo( c ) === 0, "Passed!" );
 
 		} );
 


### PR DESCRIPTION
This PR ensures that `Quaternion.angleTo()` calculates a value not greater than `Math.PI`.