### PR TITLE
Fix the FBXLoader bumpMap assignment.

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -534,7 +534,7 @@
 			switch ( type ) {
 
 				case 'Bump':
-					parameters.bumpMap = textureMap.get( child.ID );
+					parameters.bumpMap = getTexture( FBXTree, textureMap, child.ID, connections );
 					break;
 
 				case 'DiffuseColor':


### PR DESCRIPTION
I believe the previous assignment, ```parameters.bumpMap = textureMap.get( child.ID );```, was in error as I was never able to actually see a ```bumpMap``` populated on my material. Changing this assignment to reflect the rest of the case switch in question seemed to resolve the issue. However, I'm not sure if this is perfectly appropriate. So I'll wait for @looeee to confirm.