### PR TITLE
fix change code after onBeforeCompile ( sharing old code )

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1471,6 +1471,8 @@ function WebGLRenderer( parameters ) {
 
 			material.onBeforeCompile( materialProperties.shader, _this );
 
+			code = programCache.getProgramCode( material, parameters );
+
 			program = programCache.acquireProgram( material, materialProperties.shader, parameters, code );
 
 			materialProperties.program = program;


### PR DESCRIPTION
This fix any change of code after .`onBeforeCompile` call.

This bug only will occur if add more than one material with the same code and change any after `onBeforeCompile` e.g; `webgl_sprites_nodes`.


Related - https://github.com/mrdoob/three.js/pull/14214#issuecomment-394494581
In this related example I add UUID in `material.defines` to prevent conflit but it ignore fully `programCache` . 