### PR TITLE
Add a warning for and ignore duplicate node IDs.

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3183,10 +3183,14 @@ THREE.ColladaLoader.prototype = {
 
 			}
 
-			if (hasNode(data.id)) {
-				console.warn("Duplicate id ", data.id, "ignoring")
+			if ( hasNode( data.id ) ) {
+
+				console.warn( 'THREE.ColladaLoader: There is already a node with ID %s. Exclude current node from further processing.', data.id );
+
 			} else {
+
 				library.nodes[ data.id ] = data;
+
 			}
 
 			return data;

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3183,7 +3183,11 @@ THREE.ColladaLoader.prototype = {
 
 			}
 
-			library.nodes[ data.id ] = data;
+			if (hasNode(data.id)) {
+				console.warn("Duplicate id ", data.id, "ignoring")
+			} else {
+				library.nodes[ data.id ] = data;
+			}
 
 			return data;
 


### PR DESCRIPTION
Addresses the "too much recursion" error in issue #14453