### PR TITLE
GLTFExporter: Serialize userData.gltfExtensions

### DIFF
--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -84,7 +84,7 @@
 			<li>animations - Array<[page:AnimationClip AnimationClip]>. List of animations to be included in the export.</li>
 			<li>forceIndices - bool. Generate indices for non-index geometry and export with them. Default is false.</li>
 			<li>forcePowerOfTwoTextures - bool. Export with images resized to POT size. This option works only if embedImages is true. Default is false.</li>
-			<li>includeCustomExtensions - bool. Export custom glTF extensions defined on an object's <em>userData.gltfExtensions<em> property. Default is false.</li>
+			<li>includeCustomExtensions - bool. Export custom glTF extensions defined on an object's <em>userData.gltfExtensions</em> property. Default is false.</li>
 		</ul>
 		</p>
 		<p>

--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -84,6 +84,7 @@
 			<li>animations - Array<[page:AnimationClip AnimationClip]>. List of animations to be included in the export.</li>
 			<li>forceIndices - bool. Generate indices for non-index geometry and export with them. Default is false.</li>
 			<li>forcePowerOfTwoTextures - bool. Export with images resized to POT size. This option works only if embedImages is true. Default is false.</li>
+			<li>includeCustomExtensions - bool. Export custom glTF extensions defined on an object's <em>userData.gltfExtensions<em> property. Default is false.</li>
 		</ul>
 		</p>
 		<p>

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -336,7 +336,7 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function serializeUserData( object, gltfProperty ) {
 
-			if ( ! object.userData || Object.keys( object.userData ).length === 0 ) {
+			if ( Object.keys( object.userData ).length === 0 ) {
 
 				return;
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -361,9 +361,9 @@ THREE.GLTFExporter.prototype = {
 
 					}
 
-				}
+					delete json.gltfExtensions;
 
-				delete json.gltfExtensions;
+				}
 
 				if ( Object.keys( json ).length > 0 ) {
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -331,20 +331,49 @@ THREE.GLTFExporter.prototype = {
 		 * Serializes a userData.
 		 *
 		 * @param {THREE.Object3D|THREE.Material} object
-		 * @returns {Object}
+		 * @param {Object} gltfProperty
 		 */
-		function serializeUserData( object ) {
+		function serializeUserData( object, gltfProperty ) {
+
+			if ( ! object.userData || Object.keys( object.userData ).length === 0 ) {
+
+				return;
+
+			}
 
 			try {
 
-				return JSON.parse( JSON.stringify( object.userData ) );
+				var json = JSON.parse( JSON.stringify( object.userData ) );
+
+				if ( json.gltfExtensions ) {
+
+					if ( gltfProperty.extensions === undefined ) {
+
+						gltfProperty.extensions = {};
+
+					}
+
+					for ( var extensionName in json.gltfExtensions ) {
+
+						gltfProperty.extensions[ extensionName ] = json.gltfExtensions[ extensionName ];
+						extensionsUsed[ extensionName ] = true;
+
+					}
+
+					delete json.gltfExtensions;
+
+				}
+
+				if ( Object.keys( json ).length > 0 ) {
+
+					gltfProperty.extras = json;
+
+				}
 
 			} catch ( error ) {
 
 				console.warn( 'THREE.GLTFExporter: userData of \'' + object.name + '\' ' +
 					'won\'t be serialized because of JSON.stringify error - ' + error.message );
-
-				return {};
 
 			}
 
@@ -979,11 +1008,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			if ( Object.keys( material.userData ).length > 0 ) {
-
-				gltfMaterial.extras = serializeUserData( material );
-
-			}
+			serializeUserData( material, gltfMaterial );
 
 			outputJSON.materials.push( gltfMaterial );
 
@@ -1201,8 +1226,6 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var extras = ( Object.keys( geometry.userData ).length > 0 ) ? serializeUserData( geometry ) : undefined;
-
 			var forceIndices = options.forceIndices;
 			var isMultiMaterial = Array.isArray( mesh.material );
 
@@ -1244,7 +1267,7 @@ THREE.GLTFExporter.prototype = {
 					attributes: attributes,
 				};
 
-				if ( extras ) primitive.extras = extras;
+				serializeUserData( geometry, primitive );
 
 				if ( targets.length > 0 ) primitive.targets = targets;
 
@@ -1563,11 +1586,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			if ( object.userData && Object.keys( object.userData ).length > 0 ) {
-
-				gltfNode.extras = serializeUserData( object );
-
-			}
+			serializeUserData( object, gltfNode );
 
 			if ( object.isMesh || object.isLine || object.isPoints ) {
 
@@ -1683,6 +1702,8 @@ THREE.GLTFExporter.prototype = {
 				gltfScene.nodes = nodes;
 
 			}
+
+			serializeUserData( scene, gltfScene );
 
 		}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -73,7 +73,8 @@ THREE.GLTFExporter.prototype = {
 			embedImages: true,
 			animations: [],
 			forceIndices: false,
-			forcePowerOfTwoTextures: false
+			forcePowerOfTwoTextures: false,
+			includeCustomExtensions: false
 		};
 
 		options = Object.assign( {}, DEFAULT_OPTIONS, options );
@@ -345,7 +346,7 @@ THREE.GLTFExporter.prototype = {
 
 				var json = JSON.parse( JSON.stringify( object.userData ) );
 
-				if ( json.gltfExtensions ) {
+				if ( options.includeCustomExtensions && json.gltfExtensions ) {
 
 					if ( gltfProperty.extensions === undefined ) {
 
@@ -360,9 +361,9 @@ THREE.GLTFExporter.prototype = {
 
 					}
 
-					delete json.gltfExtensions;
-
 				}
+
+				delete json.gltfExtensions;
 
 				if ( Object.keys( json ).length > 0 ) {
 


### PR DESCRIPTION
The GLTFLoader loads unknown extensions onto the `userData.gltfExtensions` property. This PR adds support for exporting those unknown extensions or any other extensions on the `userData.gltfExtensions` property.

We plan on using this feature in the Mozilla Hubs editor in order to support serializing component data and round-tripping GLTF models through the GLTFLoader and GLTFExporter.