### PR TITLE
LoaderUtils: Added .extractExtension()

### DIFF
--- a/docs/api/loaders/LoaderUtils.html
+++ b/docs/api/loaders/LoaderUtils.html
@@ -22,6 +22,14 @@
 		The function takes a stream of bytes as input and returns a string representation.
 		</p>
 
+		<h3>[method:String extractExtension]( [param:string url] )</h3>
+		<p>
+		[page:String url] —  The url to extract the extension from.
+		</p>
+		<p>
+		Extract the extension from the URL.
+		</p>
+
 		<h3>[method:String extractUrlBase]( [param:string url] )</h3>
 		<p>
 		[page:String url] —  The url to extract the base url from.

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1453,8 +1453,7 @@ THREE.ColladaLoader.prototype = {
 
 			var loader;
 
-			var extension = image.slice( ( image.lastIndexOf( '.' ) - 1 >>> 0 ) + 2 ); // http://www.jstips.co/en/javascript/get-file-extension/
-			extension = extension.toLowerCase();
+			var extension = THREE.LoaderUtils.extractExtension( image ).toLowerCase();
 
 			switch ( extension ) {
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -224,7 +224,7 @@
 
 		var content = videoNode.Content;
 		var fileName = videoNode.RelativeFilename || videoNode.Filename;
-		var extension = fileName.slice( fileName.lastIndexOf( '.' ) + 1 ).toLowerCase();
+		var extension = THREE.LoaderUtils.extractExtension( fileName ).toLowerCase();
 
 		var type;
 

--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -79,7 +79,7 @@ THREE.MMDLoader = ( function () {
 			var builder = this.meshBuilder.setCrossOrigin( this.crossOrigin );
 
 			var texturePath = THREE.LoaderUtils.extractUrlBase( url );
-			var modelExtension = this._extractExtension( url ).toLowerCase();
+			var modelExtension = THREE.LoaderUtils.extractExtension( url ).toLowerCase();
 
 			// Should I detect by seeing header?
 			if ( modelExtension !== 'pmd' && modelExtension !== 'pmx' ) {
@@ -260,15 +260,6 @@ THREE.MMDLoader = ( function () {
 					onLoad( parser.parseVpd( text, true ) );
 
 				}, onProgress, onError );
-
-		},
-
-		// private methods
-
-		_extractExtension: function ( url ) {
-
-			var index = url.lastIndexOf( '.' );
-			return index < 0 ? '' : url.slice( index + 1 );
 
 		},
 

--- a/src/loaders/LoaderUtils.js
+++ b/src/loaders/LoaderUtils.js
@@ -1,5 +1,6 @@
 /**
  * @author Don McCurdy / https://www.donmccurdy.com
+ * @author Mugen87 / https://github.com/Mugen87
  */
 
 var LoaderUtils = {
@@ -26,6 +27,14 @@ var LoaderUtils = {
 
 		// Merges multi-byte utf-8 characters.
 		return decodeURIComponent( escape( s ) );
+
+	},
+
+	extractExtension: function ( url ) {
+
+		// http://www.jstips.co/en/javascript/get-file-extension/
+
+		return url.slice( ( url.lastIndexOf( '.' ) - 1 >>> 0 ) + 2 );
 
 	},
 

--- a/test/unit/src/loaders/LoaderUtils.tests.js
+++ b/test/unit/src/loaders/LoaderUtils.tests.js
@@ -1,5 +1,6 @@
 /**
  * @author Don McCurdy / https://www.donmccurdy.com
+ * @author Mugen87 / https://github.com/Mugen87
  */
 /* global QUnit */
 
@@ -9,7 +10,6 @@ export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'LoaderUtils', () => {
 
-		// INSTANCING
 		QUnit.test( 'decodeText', ( assert ) => {
 
 			var jsonArray = new Uint8Array( [ 123, 34, 106, 115, 111, 110, 34, 58, 32, 116, 114, 117, 101, 125 ] );
@@ -17,6 +17,18 @@ export default QUnit.module( 'Loaders', () => {
 
 			var multibyteArray = new Uint8Array( [ 230, 151, 165, 230, 156, 172, 229, 155, 189 ] );
 			assert.equal( '日本国', LoaderUtils.decodeText( multibyteArray ) );
+
+		} );
+
+		QUnit.test( 'extractExtension', ( assert ) => {
+
+			assert.equal( 'tga', LoaderUtils.extractExtension( 'filename.tga' ) );
+			assert.equal( 'tga', LoaderUtils.extractExtension( '/filename.tga' ) );
+			assert.equal( 'tga', LoaderUtils.extractExtension( '/some/more/directories/filename.tga' ) );
+			assert.equal( 'tga', LoaderUtils.extractExtension( 'some/more/directories/filename.tga' ) );
+			assert.equal( 'tga', LoaderUtils.extractExtension( 'filename.with.many.dots.tga' ) );
+			assert.equal( '', LoaderUtils.extractExtension( 'filename' ) );
+			assert.equal( '', LoaderUtils.extractExtension( '.hiddenfile' ) );
 
 		} );
 


### PR DESCRIPTION
This PR introduces a common and robust way in order to extract the file extension from a given url via `LoaderUtils.extractExtension()`.