### PR TITLE
DragControls: Keep the cursor as a pointer after dragging

### DIFF
--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -154,7 +154,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 		}
 
-		_domElement.style.cursor = 'auto';
+		_domElement.style.cursor = _hovered ? 'pointer' : 'auto';
 
 	}
 


### PR DESCRIPTION
I noticed that in the [example code](https://threejs.org/examples/?q=drag#webgl_interactive_draggablecubes), the cursor comes back to the default 'arrow' after dragging, which is counterintuitive since it is still hovering on the object.

The PR keeps the cursor as a 'pointer' after dragging, instead of coming back to the default arrow.