### PR TITLE
Add lazy option to GLTFLoader.

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -156,6 +156,34 @@
 		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme] for the details of Draco and its decoder.
 		</p>
 
+		<h3>[method:null setLazy]( [param:Boolean value] )</h3>
+		<p>
+		[page:String value] — When true, [page:Function parse] and [page:Function load] will return an object with the <em>parser</em> property set.
+		</p>
+		<p>
+			When lazy loading is enabled and the provided url points to a <em>.gltf</em> file [page:Function load] will only download the <em>.gltf</em> file. [page:Function parse] and [page:Function load] will not call <em>parser.parse()</em> or <em>parser.getDependency()</em>. Examples:
+		</p>
+		<code>
+		var loader = new THREE.GLTFLoader();
+
+		loader.setLazy(true);
+
+		loader.load('foo.gltf', function ( gltf ) {
+
+			var parser = gltf.parser;
+
+			// Modify the glTF before calling parse
+			parser.json.node[ 3 ].extensions = { EXT_foo: { bufferView: 3 } };
+
+			// Load part of the gltf 
+			parser.getDependency( "bufferView", 1 ).then( createNavMesh );
+
+			// Load the entire glTF
+			parser.parse( function ( scene, scenes, cameras, animations, json ) { } );
+
+		} );
+		</code>
+
 		<h3>[method:null parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>
 		<p>
 		[page:ArrayBuffer data] — glTF asset to parse, as an ArrayBuffer or <em>JSON</em> string.<br />

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -182,6 +182,9 @@ THREE.GLTFLoader = ( function () {
 
 			if ( this.lazy ) {
 
+				// Mark the special nodes/meshes in json for efficient parse
+				this.markDefs();
+
 				onLoad( { parser: parser } );
 
 				return;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -12,6 +12,7 @@ THREE.GLTFLoader = ( function () {
 
 		this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
 		this.dracoLoader = null;
+		this.lazy = false;
 
 	}
 
@@ -72,6 +73,13 @@ THREE.GLTFLoader = ( function () {
 		setDRACOLoader: function ( dracoLoader ) {
 
 			this.dracoLoader = dracoLoader;
+			return this;
+
+		},
+
+		setLazy: function ( lazy ) {
+
+			this.lazy = lazy;
 			return this;
 
 		},
@@ -171,6 +179,14 @@ THREE.GLTFLoader = ( function () {
 				manager: this.manager
 
 			} );
+
+			if ( this.lazy ) {
+
+				onLoad( { parser: parser } );
+
+				return;
+
+			}
 
 			parser.parse( function ( scene, scenes, cameras, animations, json ) {
 


### PR DESCRIPTION
This PR adds the ability to lazily load or load parts of a glTF model. This can also be used to modify the glTF before calling `parser.parse()`. We intend to implement the `MOZ_alt_materials` extension in this way (see #14470).

This was previously discussed in: #11682