### PR TITLE
WebGLRenderer: Render sprites along opaque and transparent objects

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1104,7 +1104,6 @@ function WebGLRenderer( parameters ) {
 
 		var opaqueObjects = currentRenderList.opaque;
 		var transparentObjects = currentRenderList.transparent;
-		var spriteObjects = currentRenderList.sprites;
 
 		if ( scene.overrideMaterial ) {
 
@@ -1112,7 +1111,6 @@ function WebGLRenderer( parameters ) {
 
 			if ( opaqueObjects.length ) renderObjects( opaqueObjects, scene, camera, overrideMaterial );
 			if ( transparentObjects.length ) renderObjects( transparentObjects, scene, camera, overrideMaterial );
-			if ( spriteObjects.length ) renderObjects( spriteObjects, scene, camera, overrideMaterial );
 
 		} else {
 
@@ -1123,10 +1121,6 @@ function WebGLRenderer( parameters ) {
 			// transparent pass (back-to-front order)
 
 			if ( transparentObjects.length ) renderObjects( transparentObjects, scene, camera );
-
-			//
-
-			if ( spriteObjects.length ) renderObjects( spriteObjects, scene, camera );
 
 		}
 

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -47,24 +47,6 @@ function reversePainterSortStable( a, b ) {
 }
 
 
-function painterSortStableSprites( a, b ) {
-
-	if ( a.renderOrder !== b.renderOrder ) {
-
-	 return a.renderOrder - b.renderOrder;
-
-	} else if ( a.z !== b.z ) {
-
-	 return b.z - a.z;
-
-	} else {
-
-	 return b.id - a.id;
-
-	}
-
-}
-
 function WebGLRenderList() {
 
 	var renderItems = [];
@@ -72,7 +54,6 @@ function WebGLRenderList() {
 
 	var opaque = [];
 	var transparent = [];
-	var sprites = [];
 
 	function init() {
 
@@ -80,7 +61,6 @@ function WebGLRenderList() {
 
 		opaque.length = 0;
 		transparent.length = 0;
-		sprites.length = 0;
 
 	}
 
@@ -116,15 +96,8 @@ function WebGLRenderList() {
 
 		}
 
-		if ( object.isSprite ) {
 
-			sprites.push( renderItem );
-
-		} else {
-
-			( material.transparent === true ? transparent : opaque ).push( renderItem );
-
-		}
+		( material.transparent === true ? transparent : opaque ).push( renderItem );
 
 		renderItemsIndex ++;
 
@@ -134,14 +107,12 @@ function WebGLRenderList() {
 
 		if ( opaque.length > 1 ) opaque.sort( painterSortStable );
 		if ( transparent.length > 1 ) transparent.sort( reversePainterSortStable );
-		if ( sprites.length > 1 ) sprites.sort( painterSortStableSprites );
 
 	}
 
 	return {
 		opaque: opaque,
 		transparent: transparent,
-		sprites: sprites,
 
 		init: init,
 		push: push,


### PR DESCRIPTION
After the integration of sprite rendering into `WebGLRenderer`, it's now possible to render sprites along opaque and transparent objects (so without an additional pass).

Fixes #6396

A note to https://github.com/mrdoob/three.js/pull/14411#issuecomment-402131319: Transparent sprites should now correctly blended with other transparent objects. The render list for opaque objects ensures that objects with the same program/material are rendered together (good for performance). 