### PR TITLE
support ascii fbx files encoded with any type of line ending

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2878,7 +2878,7 @@
 
 			var self = this;
 
-			var split = text.split( '\n' );
+			var split = text.split( /[\r\n]+/ );
 
 			split.forEach( function ( line, i ) {
 


### PR DESCRIPTION
This small change to the FBX parser correctly splits ascii-encoded FBX files with Windows-style line endings.  This is a general-purpose solution to a problem that caused FBXLoader to incorrectly load files due to this logic in `parseNodePropertyContinued`:

```
if ( line.slice( - 1 ) !== ',' ) {

  currentNode.a = parseNumberArray( currentNode.a );

}
```

When working with an FBX that has Windows-style line endings, this conditional always evaluated as true, since `line.slice( - 1 )` would always evaluate as `\r`.  Since parseNumberArray() was being run on every subsequent line of large arrays, loading a file took upward of 3 minutes and produced a broken mesh.