### PR TITLE
Add webgl2 message on Detector

### DIFF
--- a/examples/js/Detector.js
+++ b/examples/js/Detector.js
@@ -35,7 +35,9 @@ var Detector = {
 	workers: !! window.Worker,
 	fileapi: window.File && window.FileReader && window.FileList && window.Blob,
 
-	getWebGLErrorMessage: function () {
+	getWebGLErrorMessage: function ( version ) {
+
+		var webgl2 = version === 'webgl2';
 
 		var element = document.createElement( 'div' );
 		element.id = 'webgl-error-message';
@@ -49,14 +51,11 @@ var Detector = {
 		element.style.width = '400px';
 		element.style.margin = '5em auto 0';
 
-		if ( ! this.webgl ) {
+		if ( webgl2 && !this.webgl2 || !webgl2 && !this.webgl ) {
 
-			element.innerHTML = window.WebGLRenderingContext ? [
-				'Your graphics card does not seem to support <a href="http://khronos.org/webgl/wiki/Getting_a_WebGL_Implementation" style="color:#000">WebGL</a>.<br />',
-				'Find out how to get it <a href="http://get.webgl.org/" style="color:#000">here</a>.'
-			].join( '\n' ) : [
-				'Your browser does not seem to support <a href="http://khronos.org/webgl/wiki/Getting_a_WebGL_Implementation" style="color:#000">WebGL</a>.<br/>',
-				'Find out how to get it <a href="http://get.webgl.org/" style="color:#000">here</a>.'
+			element.innerHTML = [
+				'Your ' + ( ( webgl2 ? window.WebGL2RenderingContext : window.WebGLRenderingContext ) ? 'graphics card' : 'browser' ) + ' does not seem to support <a href="http://khronos.org/webgl/wiki/Getting_a_WebGL_Implementation" style="color:#000">WebGL' + ( webgl2 ? '2' : '' )+ '</a>.<br />',
+				'Find out how to get it <a href="https://get.webgl.org/' + ( webgl2 ? 'webgl2' : '' ) + '" style="color:#000">here</a>.'
 			].join( '\n' );
 
 		}
@@ -74,7 +73,7 @@ var Detector = {
 		parent = parameters.parent !== undefined ? parameters.parent : document.body;
 		id = parameters.id !== undefined ? parameters.id : 'oldie';
 
-		element = Detector.getWebGLErrorMessage();
+		element = Detector.getWebGLErrorMessage( parameters.version );
 		element.id = id;
 
 		parent.appendChild( element );

--- a/examples/js/Detector.js
+++ b/examples/js/Detector.js
@@ -3,10 +3,12 @@
  * @author mr.doob / http://mrdoob.com/
  */
 
-var Detector = {
 
-	canvas: !! window.CanvasRenderingContext2D,
-	webgl: ( function () {
+
+
+var Detector = (function() {
+
+	var isWebGLAvailable = ( function () {
 
 		try {
 
@@ -18,8 +20,9 @@ var Detector = {
 
 		}
 
-	} )(),
-	webgl2: ( function () {
+	} )();
+
+	var isWebGL2Available = ( function () {
 
 		try {
 
@@ -31,11 +34,9 @@ var Detector = {
 
 		}
 
-	} )(),
-	workers: !! window.Worker,
-	fileapi: window.File && window.FileReader && window.FileList && window.Blob,
+	} )();
 
-	getWebGLErrorMessage: function ( version ) {
+	function getWebGLErrorMessage( version ) {
 
 		var webgl2 = version === 'webgl2';
 
@@ -50,6 +51,10 @@ var Detector = {
 		element.style.padding = '1.5em';
 		element.style.width = '400px';
 		element.style.margin = '5em auto 0';
+		element.style.position = 'fixed';
+		element.style.left = 0;
+		element.style.right = 0;
+		element.style.top = 0;
 
 		if ( webgl2 && !this.webgl2 || !webgl2 && !this.webgl ) {
 
@@ -62,9 +67,9 @@ var Detector = {
 
 		return element;
 
-	},
+	}
 
-	addGetWebGLMessage: function ( parameters ) {
+	function addGetWebGLMessageByVersion( parameters, version ) {
 
 		var parent, id, element;
 
@@ -73,14 +78,37 @@ var Detector = {
 		parent = parameters.parent !== undefined ? parameters.parent : document.body;
 		id = parameters.id !== undefined ? parameters.id : 'oldie';
 
-		element = Detector.getWebGLErrorMessage( parameters.version );
+		element = getWebGLErrorMessage( version );
 		element.id = id;
 
 		parent.appendChild( element );
 
 	}
 
-};
+	return {
+		canvas: !! window.CanvasRenderingContext2D,
+		webgl: isWebGLAvailable,
+		webgl2: isWebGL2Available,
+		workers: !! window.Worker,
+		fileapi: window.File && window.FileReader && window.FileList && window.Blob,
+
+		addGetWebGL2Message: function ( parameters ) {
+
+			addGetWebGLMessageByVersion( parameters, 'webgl2' );
+
+		},
+
+		addGetWebGLMessage: function ( parameters ) {
+
+			addGetWebGLMessageByVersion( parameters, 'webgl' );
+
+		},
+
+		getWebGLErrorMessage: getWebGLErrorMessage
+
+	};
+
+} )();
 
 // browserify support
 if ( typeof module === 'object' ) {

--- a/examples/webgl2_sandbox.html
+++ b/examples/webgl2_sandbox.html
@@ -32,6 +32,8 @@
 	</head>
 
 	<body>
+		<script src="js/Detector.js"></script>
+
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl2 sandbox.</div>
 
 		<script type="module">
@@ -47,6 +49,8 @@
 			import { WebGLRenderer } from '../src/renderers/WebGLRenderer.js';
 
 			//
+
+			if ( ! Detector.webgl2 ) Detector.addGetWebGLMessage( { version: 'webgl2' });
 
 			var camera, scene, renderer;
 

--- a/examples/webgl2_sandbox.html
+++ b/examples/webgl2_sandbox.html
@@ -50,7 +50,7 @@
 
 			//
 
-			if ( ! Detector.webgl2 ) Detector.addGetWebGLMessage( { version: 'webgl2' });
+			if ( ! Detector.webgl2 ) Detector.addGetWebGL2Message();
 
 			var camera, scene, renderer;
 


### PR DESCRIPTION
Modified the `Detector.addGetWebGLMessage` so you could pass `{version: 'webgl2'}` and it will create the correct message and link to https://get.webgl.org/webgl2

![image](https://user-images.githubusercontent.com/782511/42912642-b474ace2-8af0-11e8-8c3c-fccceee1a75b.png)
