### PR TITLE
AnimationAction: Fix result of _updateTime() for paused pingpong actions

### DIFF
--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -468,13 +468,19 @@ Object.assign( AnimationAction.prototype, {
 	_updateTime: function ( deltaTime ) {
 
 		var time = this.time + deltaTime;
+		var duration = this._clip.duration;
+		var loop = this.loop;
+		var loopCount = this._loopCount;
 
-		if ( deltaTime === 0 ) return time;
+		var pingPong = ( loop === LoopPingPong );
 
-		var duration = this._clip.duration,
+		if ( deltaTime === 0 ) {
 
-			loop = this.loop,
-			loopCount = this._loopCount;
+			if ( loopCount === - 1 ) return time;
+
+			return ( pingPong && ( loopCount & 1 ) === 1 ) ? duration - time : time;
+
+		}
 
 		if ( loop === LoopOnce ) {
 
@@ -510,8 +516,6 @@ Object.assign( AnimationAction.prototype, {
 			}
 
 		} else { // repetitive Repeat or PingPong
-
-			var pingPong = ( loop === LoopPingPong );
 
 			if ( loopCount === - 1 ) {
 


### PR DESCRIPTION
Fixes #14486

Paused actions have a `deltaTime` of 0 when `_updateTime()` is called. The current implementation does not perform the necessary time inverting for pingpong actions in that case. The PR fixes this.