### PR TITLE
Object3D.lookAt(): support rotated parents

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -303,34 +303,50 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	lookAt: function () {
 
-		// This method does not support objects with rotated and/or translated parent(s)
+		// This method does not support objects having non-uniformly-scaled parent(s)
 
+		var q1 = new Quaternion();
 		var m1 = new Matrix4();
-		var vector = new Vector3();
+		var target = new Vector3();
+		var position = new Vector3();
 
 		return function lookAt( x, y, z ) {
 
 			if ( x.isVector3 ) {
 
-				vector.copy( x );
+				target.copy( x );
 
 			} else {
 
-				vector.set( x, y, z );
+				target.set( x, y, z );
 
 			}
 
+			var parent = this.parent;
+
+			this.updateWorldMatrix( true, false );
+
+			position.setFromMatrixPosition( this.matrixWorld );
+
 			if ( this.isCamera ) {
 
-				m1.lookAt( this.position, vector, this.up );
+				m1.lookAt( position, target, this.up );
 
 			} else {
 
-				m1.lookAt( vector, this.position, this.up );
+				m1.lookAt( target, position, this.up );
 
 			}
 
 			this.quaternion.setFromRotationMatrix( m1 );
+
+			if ( parent ) {
+
+				m1.extractRotation( parent.matrixWorld );
+				q1.setFromRotationMatrix( m1 );
+				this.quaternion.premultiply( q1.inverse() );
+
+			}
 
 		};
 
@@ -610,6 +626,44 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		for ( var i = 0, l = children.length; i < l; i ++ ) {
 
 			children[ i ].updateMatrixWorld( force );
+
+		}
+
+	},
+
+	updateWorldMatrix: function ( updateParents, updateChildren ) {
+
+		var parent = this.parent;
+
+		if ( updateParents === true && parent !== null ) {
+
+			parent.updateWorldMatrix( true, false );
+
+		}
+
+		if ( this.matrixAutoUpdate ) this.updateMatrix();
+
+		if ( this.parent === null ) {
+
+			this.matrixWorld.copy( this.matrix );
+
+		} else {
+
+			this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
+
+		}
+
+		// update children
+
+		if ( updateChildren === true ) {
+
+			var children = this.children;
+
+			for ( var i = 0, l = children.length; i < l; i ++ ) {
+
+				children[ i ].updateWorldMatrix( false, true );
+
+			}
 
 		}
 


### PR DESCRIPTION
This PR implements the suggestion by @greggman in #14496, and is based on his work. Credit goes to @greggman for both the suggestion and the initial implementation of this feature.

The enhancements to `lookAt()` are now quaternion-based, avoiding a matrix inversion.

The correct implementation of this feature required a new method which I have named `.updateWorldMatrix()`, for lack of a better term. It is actually a correct implementation of what `.updateMatrixWorld()` should have been.

Rather than getting diverted by how to best modify `.updateMatrixWorld()`, I have added the new method instead. It is currently undocumented. We can address `.updateMatrixWorld()`, and how to improve its performance, separately.

Because almost all scene nodes have a parent, this implementation of `lookAt()` will be a bit slower than it was previously.  We could probably maintain similar performance if we added `Matrix4.isIdentity()`.