### PR TITLE
STLLoader: Improve classification as ASCII or binary

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -96,24 +96,27 @@ THREE.STLLoader.prototype = {
 
 			for ( var off = 0; off < 5; off ++ ) {
 
-				// Check if solid[ i ] matches the i-th byte at the current offset
+				// If "solid" text is matched to the current offset, declare it to be an ASCII STL.
 
-				var found = true;
-				for ( var i = 0; found && i < 5; i ++ ) {
-
-					found = found && ( solid[ i ] == reader.getUint8( off + i, false ) );
-
-				}
-
-				// Found "solid" text at the beginning; declare it to be an ASCII STL.
-
-				if ( found ) {
-					return false;
-				}
+				if ( matchDataViewAt ( solid, reader, off ) ) return false;
 
 			}
 
 			// Couldn't find "solid" text at the beginning; it is binary STL.
+
+			return true;
+
+		}
+
+		function matchDataViewAt( query, reader, offset ) {
+
+			// Check if each byte in query matches the corresponding byte from the current offset
+
+			for ( var i = 0, il = query.length; i < il; i ++ ) {
+
+				if ( query[ i ] !== reader.getUint8( offset + i, false ) ) return false;
+
+			}
 
 			return true;
 

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -86,22 +86,36 @@ THREE.STLLoader.prototype = {
 			// However, ASCII STLs lacking the SPACE after the 'd' are known to be
 			// plentiful.  So, check the first 5 bytes for 'solid'.
 
+			// Several encodings, such as UTF-8, precede the text with up to 5 bytes:
+			// https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding
+			// Search for "solid" to start anywhere after those prefixes.
+
 			// US-ASCII ordinal values for 's', 'o', 'l', 'i', 'd'
 
 			var solid = [ 115, 111, 108, 105, 100 ];
 
-			for ( var i = 0; i < 5; i ++ ) {
+			for ( var off = 0; off < 5; off ++ ) {
 
-				// If solid[ i ] does not match the i-th byte, then it is not an
-				// ASCII STL; hence, it is binary and return true.
+				// Check if solid[ i ] matches the i-th byte at the current offset
 
-				if ( solid[ i ] != reader.getUint8( i, false ) ) return true;
+				var found = true;
+				for ( var i = 0; found && i < 5; i ++ ) {
 
- 			}
+					found = found && ( solid[ i ] == reader.getUint8( off + i, false ) );
 
-			// First 5 bytes read "solid"; declare it to be an ASCII STL
+				}
 
-			return false;
+				// Found "solid" text at the beginning; declare it to be an ASCII STL.
+
+				if ( found ) {
+					return false;
+				}
+
+			}
+
+			// Couldn't find "solid" text at the beginning; it is binary STL.
+
+			return true;
 
 		}
 


### PR DESCRIPTION
Small fix for STLLoader:
STLLoader decides whether it is an ASCII or Binary STL file by the beginning of the text.
When first 5 bytes equal "solid" it is an ASCII STL.

However Several encodings, such as UTF-8, precede the text with up to 5 bytes:
https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding
Therefore, making STLLoader classifying the file as binary and failing.

My change searches for "solid" to start anywhere after those prefixes.

Attached is an STL file generated by STLExporter that includes those preceding bytes.
[box_small1.stl.txt](https://github.com/mrdoob/three.js/files/2216984/box_small1.stl.txt)

