### PR TITLE
FBXLoader: support for alternate Euler orders and post rotation

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -814,8 +814,6 @@
 
 		}, null );
 
-		var preTransform = new THREE.Matrix4();
-
 		// TODO: if there is more than one model associated with the geometry, AND the models have
 		// different geometric transforms, then this will cause problems
 		// if ( modelNodes.length > 1 ) { }
@@ -823,35 +821,17 @@
 		// For now just assume one model and get the preRotations from that
 		var modelNode = modelNodes[ 0 ];
 
-		if ( 'GeometricRotation' in modelNode ) {
+		var transformData = {};
 
-			var eulerOrder = 'ZYX';
+		if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = modelNode.RotationOrder.value;
 
-			if ( 'RotationOrder' in modelNode ) {
+		if ( 'GeometricTranslation' in modelNode ) transformData.translation = modelNode.GeometricTranslation.value;
+		if ( 'GeometricRotation' in modelNode ) transformData.rotation = modelNode.GeometricRotation.value;
+		if ( 'GeometricScaling' in modelNode ) transformData.scale = modelNode.GeometricScaling.value;
 
-				eulerOrder = getEulerOrder( parseInt( modelNode.RotationOrder.value ) );
+		var transform = generateTransform( transformData );
 
-			}
-
-			var array = modelNode.GeometricRotation.value.map( THREE.Math.degToRad );
-			array.push( eulerOrder );
-			preTransform.makeRotationFromEuler( new THREE.Euler().fromArray( array ) );
-
-		}
-
-		if ( 'GeometricTranslation' in modelNode ) {
-
-			preTransform.setPosition( new THREE.Vector3().fromArray( modelNode.GeometricTranslation.value ) );
-
-		}
-
-		if ( 'GeometricScaling' in modelNode ) {
-
-			preTransform.scale( new THREE.Vector3().fromArray( modelNode.GeometricScaling.value ) );
-
-		}
-
-		return genGeometry( FBXTree, geoNode, skeleton, morphTarget, preTransform );
+		return genGeometry( FBXTree, geoNode, skeleton, morphTarget, transform );
 
 	}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3843,6 +3843,8 @@
 			array.push( order );
 			tempMat.makeRotationFromEuler( tempEuler.fromArray( array ) );
 
+			tempMat.getInverse( tempMat );
+
 			rotation.multiply( tempMat );
 
 		}

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3851,16 +3851,17 @@
 
 	}
 
+	// Returns the three.js intrinsic Euler order corresponding to FBX extrinsic Euler order
 	// ref: http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html
 	function getEulerOrder( order ) {
 
 		var enums = [
-			'ZYX', // -> XYZ in FBX
-			'YXZ',
-			'ZXY',
-			'YZX',
-			'XZY',
-			'XYZ',
+			'ZYX', // -> XYZ extrinsic
+			'YZX', // -> XZY extrinsic
+			'XZY', // -> YZX extrinsic
+			'ZXY', // -> YXZ extrinsic
+			'YXZ', // -> ZXY extrinsic
+			'XYZ', // -> ZYX extrinsic
 			//'SphericXYZ', // not possible to support
 		];
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1655,6 +1655,14 @@
 
 		setupMorphMaterials( sceneGraph );
 
+		// if all the models where already combined in a single group, just return that
+		if ( sceneGraph.children.length === 1 && sceneGraph.children[ 0 ].isGroup ) {
+
+			sceneGraph.children[ 0 ].animations = sceneGraph.animations;
+			return sceneGraph.children[ 0 ];
+
+		}
+
 		return sceneGraph;
 
 	}

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3798,7 +3798,7 @@
 	var rotation = new THREE.Matrix4();
 
 	// generate transformation from FBX transform data
-	// ref: http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html
+	// ref: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
 	// transformData = {
 	//	 eulerOrder: int,
 	//	 translation: [],
@@ -3859,6 +3859,7 @@
 
 	}
 
+	// ref: http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html
 	function getEulerOrder( order ) {
 
 		var enums = [

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -97,7 +97,7 @@
 
 			}
 
-			console.log( FBXTree );
+			// console.log( FBXTree );
 
 			var textureLoader = new THREE.TextureLoader( this.manager ).setPath( resourceDirectory ).setCrossOrigin( this.crossOrigin );
 
@@ -2246,6 +2246,7 @@
 		var curveNodesMap = parseAnimationCurveNodes( FBXTree );
 
 		parseAnimationCurves( FBXTree, connections, curveNodesMap );
+
 		var layersMap = parseAnimationLayers( FBXTree, connections, curveNodesMap );
 		var rawClips = parseAnimStacks( FBXTree, connections, layersMap );
 
@@ -2329,7 +2330,7 @@
 
 					curveNodesMap.get( animationCurveID ).curves[ 'z' ] = animationCurve;
 
-				} else if ( animationCurveRelationship.match( /d|DeformPercent/ ) ) {
+				} else if ( animationCurveRelationship.match( /d|DeformPercent/ ) && curveNodesMap.has( animationCurveID ) ) {
 
 					curveNodesMap.get( animationCurveID ).curves[ 'morph' ] = animationCurve;
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2555,6 +2555,10 @@
 
 		if ( rawTracks.transform ) rawTracks.transform.decompose( initialPosition, initialRotation, initialScale );
 
+		initialPosition = initialPosition.toArray();
+		initialRotation = new THREE.Euler().setFromQuaternion( initialRotation ).toArray(); // todo: euler order
+		initialScale = initialScale.toArray();
+
 		if ( rawTracks.T !== undefined && Object.keys( rawTracks.T.curves ).length > 0 ) {
 
 			var positionTrack = generateVectorTrack( rawTracks.modelName, rawTracks.T.curves, initialPosition, 'position' );

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1636,14 +1636,6 @@
 
 		setupMorphMaterials( sceneGraph );
 
-		// if all the models where already combined in a single group, just return that
-		if ( sceneGraph.children.length === 1 && sceneGraph.children[ 0 ].isGroup ) {
-
-			sceneGraph.children[ 0 ].animations = sceneGraph.animations;
-			return sceneGraph.children[ 0 ];
-
-		}
-
 		return sceneGraph;
 
 	}


### PR DESCRIPTION
Fixes #14520 

Added support for alternate rotation orders based on [this reference](http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html). 

FBX appears to use extrinsic euler ordering, converted that to intrinsic ordering using @WestLangley's suggestions [here](https://github.com/mrdoob/three.js/issues/10485#issuecomment-269796099). 

Also created a `generateTransform` function which uses [this](https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm) reference to convert the FBX transform to three.js transform. It's now used to generate the transforms for geometry, models and animations, which were previously repeating code.

We're still ignoring the rotation pivot, scaling pivot, and scaling offset. Currently I have not come across any files that use these. 