### PR TITLE
FBXLoader: don't return top level double nested group

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1651,6 +1651,14 @@
 
 		setupMorphMaterials( sceneGraph );
 
+		// if all the models where already combined in a single group, just return that
+		if ( sceneGraph.children.length === 1 && sceneGraph.children[ 0 ].isGroup ) {
+
+			sceneGraph.children[ 0 ].animations = sceneGraph.animations;
+			return sceneGraph.children[ 0 ];
+
+		}
+
 		return sceneGraph;
 
 	}


### PR DESCRIPTION
In cases where the model in an FBX file are already in a single group, the loader currrently returns an unnecessary extra group: Group -> Group -> 

This PR removes the top group in that case. 