### PR TITLE
Documentation: Updated TextureLoader

### DIFF
--- a/docs/api/loaders/TextureLoader.html
+++ b/docs/api/loaders/TextureLoader.html
@@ -85,12 +85,6 @@
 		<p>The base path from which files will be loaded. See [page:.setPath]. Default is *undefined*.</p>
 
 
-		<h3>[property:String withCredentials]</h3>
-		<p>
-			Whether the XMLHttpRequest uses credentials - see [page:.setWithCredentials].
-			Default is *undefined*.
-		</p>
-
 		<h2>Methods</h2>
 
 		<h3>[method:Texture load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
@@ -114,13 +108,6 @@
 			you are loading many models from the same directory.
 		</p>
 
-		<h3>[method:FileLoader setWithCredentials]( [param:Boolean value] )</h3>
-		<p>
-		Whether the XMLHttpRequest uses credentials such as cookies, authorization headers or
-		TLS client certificates. See
-		[link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials XMLHttpRequest.withCredentials].<br />
-		Note that this has no effect if you are loading files locally or from the same domain.
-		</p>
 
 		<h2>Source</h2>
 


### PR DESCRIPTION
Remove entries for method `setWithCredentials` and property `withCredentials`.

They were added in 9d945e119404ad7e50ff41c9c4131b2487599aed on 24 Jul 2016 and removed again in e7f7d330b975b1e7d3b760a3b943976406bfa814 on 22 Dec 2016. The references were added in between those two in 357084b3940a74ff8c7054cd1cee5b18107bac34 on 26 Nov 2016.  
The `ImageLoader` that `TextureLoader` is stacked on doesn't use credentials either (its docs were already updated in #12696).