### PR TITLE
rad / deg mismatch in fbx loader

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2643,8 +2643,9 @@
 
 		}
 
+        var initialValueInRad = initialValue.map( THREE.Math.degToRad )
 		var times = getTimesForAllAxes( curves );
-		var values = getKeyframeTrackValues( times, curves, initialValue );
+		var values = getKeyframeTrackValues( times, curves, initialValueInRad );
 
 		if ( preRotations !== undefined ) {
 


### PR DESCRIPTION
I was having a problem with some of my models animations (sorry I cannot share them). What I found is that if there is no angle defined for one of the axie in an animation key frame then fbx loader uses a value from initial state but this value is in degrees while the values in animation keys ar already converted to radians.