### PR TITLE
Material.needsUpdate remove ambigous wording

### DIFF
--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -162,8 +162,7 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		Specifies that the material needs to be recompiled.
-		Set it to true if you want the shader to be recompiled.<br />
+		Specifies that the material needs to be recompiled.<br />
 		This property is automatically set to *true* when instancing a new material.
 		</p>
 

--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -162,7 +162,7 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		Specifies that the material needs to be updated at the WebGL level.
+		Specifies that the material needs to be recompiled.
 		Set it to true if you want the shader to be recompiled.<br />
 		This property is automatically set to *true* when instancing a new material.
 		</p>

--- a/docs/api/materials/Material.html
+++ b/docs/api/materials/Material.html
@@ -163,7 +163,7 @@
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
 		Specifies that the material needs to be updated at the WebGL level.
-		Set it to true if you made changes that need to be reflected in WebGL.<br />
+		Set it to true if you want the shader to be recompiled.<br />
 		This property is automatically set to *true* when instancing a new material.
 		</p>
 


### PR DESCRIPTION
As proposed in https://github.com/mrdoob/three.js/issues/14535

I think the problem is in the reference to "webgl". I think it's ambigous and may lead to confusion, if one uses the materials with `WebGLRenderer` even setting something like material.color is a webgl level change and needs to be "reflected in webgl". 

This is the most correct statement I could come up with. Materials only "compile" if this flag is set to true (both in context of three.js and webgl).


Alternatively an explanation on what "updated at the WebGL level" refers to would also work, but it seems tricky to do without writing an essay. 