### PR TITLE
Prevent navigation if modifiers pressed.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -93,8 +93,12 @@
 				link.setAttribute( 'target', 'viewer' );
 				link.addEventListener( 'click', function ( event ) {
 
-					window.location.hash = pageURL;
-					panel.classList.add( 'collapsed' );
+					if ( event.button === 0 && !event.ctrlKey && !event.altKey && !event.metaKey ) {
+
+						window.location.hash = pageURL;
+						panel.classList.add( 'collapsed' );
+
+					}
 
 				} );
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -296,7 +296,7 @@
 			link.setAttribute( 'target', 'viewer' );
 			link.addEventListener( 'click', function ( event ) {
 
-				if ( event.button === 0 ) {
+				if ( event.button === 0 && !event.ctrlKey && !event.altKey && !event.metaKey ) {
 
 					selectFile( file );
 


### PR DESCRIPTION
In Windows Ctrl-Click opens a link in a new tab. In MacOS it's Cmd-Click.
But the code here was not respecting the user's wishes. A new tab
would open but the page itself would also navigate to the same link
which is not what a user is requesting with ctrl-click or cmd-click

Interestingly the demo page did not navigate when pressing Cmd-Click
on MacOS but the URL did change. Now the URL will correctly not
change and the link will open in a new window.