### PR TITLE
HDRCubeTextureLoader: Fix usage of LoadingManager

### DIFF
--- a/examples/js/loaders/HDRCubeTextureLoader.js
+++ b/examples/js/loaders/HDRCubeTextureLoader.js
@@ -108,7 +108,7 @@ THREE.HDRCubeTextureLoader.prototype.load = function ( type, urls, onLoad, onPro
 
 	function loadHDRData( i, onLoad, onProgress, onError ) {
 
-		var loader = new THREE.FileLoader( this.manager );
+		var loader = new THREE.FileLoader( scope.manager );
 		loader.setResponseType( 'arraybuffer' );
 		loader.load( urls[ i ], function ( buffer ) {
 
@@ -177,7 +177,7 @@ THREE.HDRCubeTextureLoader.prototype.load = function ( type, urls, onLoad, onPro
 
 	for ( var i = 0; i < urls.length; i ++ ) {
 
-		loadHDRData.call( this, i, onLoad, onProgress, onError );
+		loadHDRData( i, onLoad, onProgress, onError );
 
 	}
 

--- a/examples/js/loaders/HDRCubeTextureLoader.js
+++ b/examples/js/loaders/HDRCubeTextureLoader.js
@@ -177,7 +177,7 @@ THREE.HDRCubeTextureLoader.prototype.load = function ( type, urls, onLoad, onPro
 
 	for ( var i = 0; i < urls.length; i ++ ) {
 
-		loadHDRData( i, onLoad, onProgress, onError );
+		loadHDRData.call( this, i, onLoad, onProgress, onError );
 
 	}
 


### PR DESCRIPTION
If 'use strict' is set in this scope, calling the funtion loadHDRData at line 180 in HDRCubeTextureLoader will leave "this" undefined , and line 111 inside the function loadHDRData will throw expection when accessing "this.manager".