### PR TITLE
Allow setting direction of DirectionalLight by angles

### DIFF
--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -1,7 +1,7 @@
 import { Light } from './Light.js';
 import { DirectionalLightShadow } from './DirectionalLightShadow.js';
 import { Object3D } from '../core/Object3D.js';
-import { _Math } from './Math.js';
+import { _Math } from '../Math/Math.js';
 
 /**
  * @author mrdoob / http://mrdoob.com/

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -1,10 +1,12 @@
 import { Light } from './Light.js';
 import { DirectionalLightShadow } from './DirectionalLightShadow.js';
 import { Object3D } from '../core/Object3D.js';
+import { _Math } from './Math.js';
 
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author alteredq / http://alteredqualia.com/
+ * @author EliasHasle / http://eliashasle.github.io/
  */
 
 function DirectionalLight( color, intensity ) {
@@ -19,7 +21,28 @@ function DirectionalLight( color, intensity ) {
 	this.target = new Object3D();
 
 	this.shadow = new DirectionalLightShadow();
-
+	
+	// Read and write direction using angles:
+	// around the equator of the sphere
+	Object.defineProperty(this, "theta", {
+		get: function() {
+			return Math.atan2( this.position.x, this.position.z );
+		},
+		set: function(value) {
+			this.setPhiTheta( this.phi, value );
+		}
+	});
+	
+	// up / down towards top and bottom pole
+	Object.defineProperty(this, "phi", {
+		get: function() {
+			const r = this.position.length();
+			return Math.acos( _Math.clamp( this.position.y / r, - 1, 1 ) );
+		},
+		set: function(value) {
+			this.setPhiTheta( value, this.theta );
+		}
+	});
 }
 
 DirectionalLight.prototype = Object.assign( Object.create( Light.prototype ), {
@@ -38,8 +61,23 @@ DirectionalLight.prototype = Object.assign( Object.create( Light.prototype ), {
 
 		return this;
 
-	}
-
+	},
+	
+	//Set direction by angles without affecting radius
+	setPhiTheta: function() {
+		
+		//Shared Spherical instance in closure on prototype
+		let spherical = new THREE.Spherical();
+		
+		return function( phi, theta ) {
+			
+			spherical.phi = phi;
+			spherical.theta = theta;
+			spherical.radius = this.position.length();
+			this.position.setFromSpherical( spherical );
+			
+		};
+	}(),
 } );
 
 


### PR DESCRIPTION
I appreciate the Three.js philosophy of keeping things clean, simple and modular. Yet, I often find myself in situations where I have to create and manipulate a Spherical to modify the direction of DirectionalLights in a sensible way. Unit3D, by comparison (and I like Three.js much better for sure), has angles as the default way of configuring the direction. So I thought I could add it to DirectionalLight as an option. The implementation conserves the radius.