### PR TITLE
Removed unnecessary string concatanations to reduce GC activity

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -111,7 +111,14 @@ function WebGLRenderer( parameters ) {
 		_currentRenderTarget = null,
 		_currentFramebuffer = null,
 		_currentMaterialId = - 1,
-		_currentGeometryProgram = '',
+
+		// geometry and program caching
+
+		_currentGeometryProgram = {
+			geometryID: null,
+			programID: null,
+			wireframe: false
+		},
 
 		_currentCamera = null,
 		_currentArrayCamera = null,
@@ -701,13 +708,14 @@ function WebGLRenderer( parameters ) {
 		state.setMaterial( material, frontFaceCW );
 
 		var program = setProgram( camera, fog, material, object );
-		var geometryProgram = geometry.id + '_' + program.id + '_' + ( material.wireframe === true );
 
 		var updateBuffers = false;
 
-		if ( geometryProgram !== _currentGeometryProgram ) {
+		if ( geometry.id !== _currentGeometryProgram.geometryID || program.id !== _currentGeometryProgram.programID || material.wireframe !== _currentGeometryProgram.wireframe ) {
 
-			_currentGeometryProgram = geometryProgram;
+			_currentGeometryProgram.geometryID = geometry.id;
+			_currentGeometryProgram.programID = program.id;
+			_currentGeometryProgram.wireframe = material.wireframe;
 			updateBuffers = true;
 
 		}
@@ -1107,7 +1115,9 @@ function WebGLRenderer( parameters ) {
 
 		// reset caching for this frame
 
-		_currentGeometryProgram = '';
+		_currentGeometryProgram.geometryID = null;
+		_currentGeometryProgram.programID = null;
+		_currentGeometryProgram.wireframe = false;
 		_currentMaterialId = - 1;
 		_currentCamera = null;
 
@@ -1455,7 +1465,9 @@ function WebGLRenderer( parameters ) {
 
 			var program = setProgram( camera, scene.fog, material, object );
 
-			_currentGeometryProgram = '';
+			_currentGeometryProgram.geometryID = null;
+			_currentGeometryProgram.programID = null;
+			_currentGeometryProgram.wireframe = false;
 
 			renderObjectImmediate( object, program, material );
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -67,37 +67,29 @@ function WebGLRenderState() {
 function WebGLRenderStates() {
 
 	var renderStates = {};
-	var hashCache = {};
 
 	function get( scene, camera ) {
 
-		var hash;
+		var renderState;
 
-		if ( hashCache[ scene.id ] ) {
+		if ( renderStates[ scene.id ] === undefined ) {
 
-			hash = hashCache[ scene.id ][ camera.id ];
-
-			if ( hash === undefined ) {
-
-				hash = scene.id + ',' + camera.id;
-				hashCache[ scene.id ][ camera.id ] = hash;
-
-			}
+			renderState = new WebGLRenderState();
+			renderStates[ scene.id ] = {};
+			renderStates[ scene.id ][ camera.id ] = renderState;
 
 		} else {
 
-			hash = scene.id + ',' + camera.id;
-			hashCache[ scene.id ] = {};
-			hashCache[ scene.id ][ camera.id ] = hash;
+			if ( renderStates[ scene.id ][ camera.id ] === undefined ) {
 
-		}
+				renderState = new WebGLRenderState();
+				renderStates[ scene.id ][ camera.id ] = renderState;
 
-		var renderState = renderStates[ hash ];
+			} else {
 
-		if ( renderState === undefined ) {
+				renderState = renderStates[ scene.id ][ camera.id ];
 
-			renderState = new WebGLRenderState();
-			renderStates[ hash ] = renderState;
+			}
 
 		}
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -67,10 +67,30 @@ function WebGLRenderState() {
 function WebGLRenderStates() {
 
 	var renderStates = {};
+	var hashCache = {};
 
 	function get( scene, camera ) {
 
-		var hash = scene.id + ',' + camera.id;
+		var hash;
+
+		if ( hashCache [ scene.id ] ) {
+
+			hash = hashCache [ scene.id ] [ camera.id ];
+
+			if ( hash === undefined ) {
+
+				hash = scene.id + ',' + camera.id;
+				hashCache [ scene.id ] [ camera.id ] = hash;
+
+			}
+
+		} else {
+
+			hash = scene.id + ',' + camera.id;
+			hashCache [ scene.id ] = {};
+			hashCache [ scene.id ][ camera.id ] = hash;
+
+		}
 
 		var renderState = renderStates[ hash ];
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -73,22 +73,22 @@ function WebGLRenderStates() {
 
 		var hash;
 
-		if ( hashCache [ scene.id ] ) {
+		if ( hashCache[ scene.id ] ) {
 
-			hash = hashCache [ scene.id ] [ camera.id ];
+			hash = hashCache[ scene.id ][ camera.id ];
 
 			if ( hash === undefined ) {
 
 				hash = scene.id + ',' + camera.id;
-				hashCache [ scene.id ] [ camera.id ] = hash;
+				hashCache[ scene.id ][ camera.id ] = hash;
 
 			}
 
 		} else {
 
 			hash = scene.id + ',' + camera.id;
-			hashCache [ scene.id ] = {};
-			hashCache [ scene.id ][ camera.id ] = hash;
+			hashCache[ scene.id ] = {};
+			hashCache[ scene.id ][ camera.id ] = hash;
 
 		}
 


### PR DESCRIPTION
In this PR a caching mechanism is added to WebGLRenderer and WebGLRenderStates to eliminate unnecessary string concatanations 60 times a second. I realized through Chrome's Allocation Profiler, these concatanations were causing GC activity since concatanation process creates a new string object.

Issues: #14554 and #14556 