### PR TITLE
Quaternion: Added .lookAt()

### DIFF
--- a/docs/api/math/Matrix4.html
+++ b/docs/api/math/Matrix4.html
@@ -205,9 +205,9 @@ zAxis = (c, g, k)
 		<h3>[method:this identity]()</h3>
 		<p>Resets this matrix to the [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].</p>
 
-		<h3>[method:this lookAt]( [param:Vector3 eye], [param:Vector3 center], [param:Vector3 up], )</h3>
+		<h3>[method:this lookAt]( [param:Vector3 eye], [param:Vector3 target], [param:Vector3 up], )</h3>
 		<p>
-			Constructs a rotation matrix, looking from [page:Vector3 eye] towards [page:Vector3 center]
+			Constructs a rotation matrix, looking from [page:Vector3 eye] towards [page:Vector3 target]
 			oriented by the [page:Vector3 up] vector.
 		</p>
 

--- a/docs/api/math/Quaternion.html
+++ b/docs/api/math/Quaternion.html
@@ -124,6 +124,11 @@
 			as this is a slightly more efficient calculation than [page:.length length]().
 		</p>
 
+		<h3>[method:Quaternion lookAt]( [param:Vector3 eye], [param:Vector3 target], [param:Vector3 up], )</h3>
+		<p>
+			Constructs a quaternion that can orient an object to face towards a specified target.
+		</p>
+
 		<h3>[method:Quaternion normalize]()</h3>
 		<p>
 			[link:https://en.wikipedia.org/wiki/Normalized_vector Normalizes] this quaternion - that is,

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -305,7 +305,6 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		// This method does not support objects with rotated and/or translated parent(s)
 
-		var m1 = new Matrix4();
 		var vector = new Vector3();
 
 		return function lookAt( x, y, z ) {
@@ -322,15 +321,13 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 			if ( this.isCamera ) {
 
-				m1.lookAt( this.position, vector, this.up );
+				this.quaternion.lookAt( this.position, vector, this.up );
 
 			} else {
 
-				m1.lookAt( vector, this.position, this.up );
+				this.quaternion.lookAt( vector, this.position, this.up );
 
 			}
-
-			this.quaternion.setFromRotationMatrix( m1 );
 
 		};
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -1,5 +1,6 @@
 import { _Math } from './Math.js';
 import { Vector3 } from './Vector3.js';
+import { Matrix4 } from './Matrix4.js';
 
 /**
  * @author mikael emtinger / http://gomo.se/
@@ -413,6 +414,21 @@ Object.assign( Quaternion.prototype, {
 		return this;
 
 	},
+
+	lookAt: function () {
+
+		var rotationMatrix = new Matrix4();
+
+		return function lookAt( eye, target, up ) {
+
+			rotationMatrix.lookAt( eye, target, up );
+			this.setFromRotationMatrix( rotationMatrix );
+
+			return this;
+
+		};
+
+	}(),
 
 	inverse: function () {
 

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -423,6 +423,25 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( "lookAt", ( assert ) => {
+
+			var a = new Quaternion();
+			var b = new Quaternion();
+			var m = new Matrix4();
+
+			var eye = new Vector3( 0, 0, 0 );
+			var target = new Vector3( 0, 1, - 1 );
+			var up = new Vector3( 0, 1, 0 );
+
+			a.lookAt( eye, target, up );
+			m.lookAt( eye, target, up );
+
+			b.setFromRotationMatrix( m );
+
+			assert.ok( a.equals( b ), "Passed!" );
+
+		} );
+
 		QUnit.test( "inverse/conjugate", ( assert ) => {
 
 			var a = new Quaternion( x, y, z, w );


### PR DESCRIPTION
This method is a neat shortcut since it allows to directly create a quaternion that orients an object to face towards a specified target. I've often found it annoying to create a temporary matrix object in order ot use `Matrix4.lookAt`. This is now done internally in `Quaternion.lookAt()`.

BTW: That makes the code in `Object3D.lookAt()` a bit nicer :blush: .

Similar to methods in other projects like:

https://github.com/juj/MathGeoLib/blob/master/src/Math/Quat.h#L234-L260 or
https://docs.unity3d.com/ScriptReference/Quaternion.LookRotation.html