### PR TITLE
[WIP] GLTFLoader: Add .setUseNodes() option.

### DIFF
--- a/examples/js/nodes/materials/MeshStandardNodeMaterial.js
+++ b/examples/js/nodes/materials/MeshStandardNodeMaterial.js
@@ -14,6 +14,10 @@ function MeshStandardNodeMaterial() {
 
 	this.type = "MeshStandardNodeMaterial";
 
+	var options = arguments[ 0 ];
+
+	if ( typeof options === 'object' ) Object.assign( this, options );
+
 }
 
 MeshStandardNodeMaterial.prototype = Object.create( NodeMaterial.prototype );

--- a/examples/js/nodes/materials/MeshStandardNodeMaterial.js
+++ b/examples/js/nodes/materials/MeshStandardNodeMaterial.js
@@ -6,7 +6,7 @@ import { MeshStandardNode } from './nodes/MeshStandardNode.js';
 import { NodeMaterial } from './NodeMaterial.js';
 import { NodeUtils } from '../core/NodeUtils.js';
 
-function MeshStandardNodeMaterial() {
+function MeshStandardNodeMaterial( parameters ) {
 
 	var node = new MeshStandardNode();
 
@@ -14,9 +14,7 @@ function MeshStandardNodeMaterial() {
 
 	this.type = "MeshStandardNodeMaterial";
 
-	var options = arguments[ 0 ];
-
-	if ( typeof options === 'object' ) Object.assign( this, options );
+	this.setValues( parameters );
 
 }
 
@@ -25,6 +23,12 @@ MeshStandardNodeMaterial.prototype.constructor = MeshStandardNodeMaterial;
 
 NodeUtils.addShortcuts( MeshStandardNodeMaterial.prototype, 'properties', [
 	"color",
+	"emissive",
+	"emissiveMap",
+	"emissiveIntensity",
+	"ao",
+	"aoMap",
+	"aoMapIntensity",
 	"roughness",
 	"metalness",
 	"map",

--- a/examples/js/nodes/materials/NodeMaterial.js
+++ b/examples/js/nodes/materials/NodeMaterial.js
@@ -108,6 +108,8 @@ NodeMaterial.prototype.copy = function ( source ) {
 
 	}
 
+	return this;
+
 };
 
 NodeMaterial.prototype.toJSON = function ( meta ) {

--- a/examples/js/nodes/materials/NodeMaterial.js
+++ b/examples/js/nodes/materials/NodeMaterial.js
@@ -38,6 +38,30 @@ Object.defineProperties( NodeMaterial.prototype, {
 
 } );
 
+NodeMaterial.prototype.setValues = function( values ) {
+
+	if ( values === undefined ) return;
+
+	for ( var key in values ) {
+
+		var newValue = values[ key ];
+
+		if ( newValue === undefined ) {
+
+			console.warn( 'THREE.' + this.type + ': "' + key + '" parameter is undefined.' );
+			continue;
+
+		}
+
+		// TODO: The base Material class would warn about setting properties that do not have
+		// a current value, "...not a property of this material".
+
+		this[ key ] = newValue;
+
+	}
+
+};
+
 NodeMaterial.prototype.updateFrame = function ( frame ) {
 
 	for ( var i = 0; i < this.updaters.length; ++ i ) {

--- a/examples/js/nodes/materials/nodes/MeshStandardNode.js
+++ b/examples/js/nodes/materials/nodes/MeshStandardNode.js
@@ -14,6 +14,8 @@ function MeshStandardNode() {
 
 	this.properties = {
 		color: new THREE.Color( 0xffffff ),
+		emissive: new THREE.Color( 0x000000 ),
+		ao: 1.0,
 		roughness: 0.5,
 		metalness: 0.5,
 		normalScale: new THREE.Vector2( 1, 1 )
@@ -21,6 +23,8 @@ function MeshStandardNode() {
 
 	this.inputs = {
 		color: new PropertyNode( this.properties, 'color', 'c' ),
+		emissive: new PropertyNode( this.properties, 'emissive', 'c' ),
+		ao: new PropertyNode( this.properties, 'ao', 'f' ),
 		roughness: new PropertyNode( this.properties, 'roughness', 'f' ),
 		metalness: new PropertyNode( this.properties, 'metalness', 'f' ),
 		normalScale: new PropertyNode( this.properties, 'normalScale', 'v2' )
@@ -49,13 +53,38 @@ MeshStandardNode.prototype.build = function ( builder ) {
 		this.color = map ? new OperatorNode( color, map, OperatorNode.MUL ) : color;
 
 		// slots
+		// * emissive
+		// * emissiveMap
+		// * emissiveIntensity
+
+		var emissive = builder.findNode( props.emissive, inputs.emissive ),
+			emissiveMap = builder.resolve( props.emissiveMap ),
+			emissiveIntensity = builder.resolve( props.emissiveIntensity );
+
+		this.emissive = emissiveMap ? new OperatorNode( emissive, emissiveMap, OperatorNode.MUL ) : emissive;
+
+		if ( emissiveIntensity !== undefined ) {
+
+			this.emissive = new OperatorNode( this.emissive, emissiveIntensity, OperatorNode.MUL );
+
+		}
+
+		// slots
 		// * ao
 		// * aoMap
+		// * aoMapIntensity
 
 		var ao = builder.findNode( props.ao, inputs.ao ),
-			aoMap = builder.resolve( props.aoMap );
+			aoMap = builder.resolve( props.aoMap ),
+			aoMapIntensity = builder.resolve( props.aoMapIntensity );
 
 		this.ao = aoMap ? new OperatorNode( ao, new SwitchNode( aoMap, "r" ), OperatorNode.MUL ) : ao;
+
+		if ( aoMapIntensity !== undefined ) {
+
+			this.ao = new OperatorNode( this.ao, aoMapIntensity, OperatorNode.MUL );
+
+		}
 
 		// slots
 		// * roughness

--- a/examples/js/nodes/materials/nodes/MeshStandardNode.js
+++ b/examples/js/nodes/materials/nodes/MeshStandardNode.js
@@ -49,6 +49,15 @@ MeshStandardNode.prototype.build = function ( builder ) {
 		this.color = map ? new OperatorNode( color, map, OperatorNode.MUL ) : color;
 
 		// slots
+		// * ao
+		// * aoMap
+
+		var ao = builder.findNode( props.ao, inputs.ao ),
+			aoMap = builder.resolve( props.aoMap );
+
+		this.ao = aoMap ? new OperatorNode( ao, new SwitchNode( aoMap, "r" ), OperatorNode.MUL ) : ao;
+
+		// slots
 		// * roughness
 		// * roughnessMap
 

--- a/examples/js/nodes/utils/ColorSpaceNode.js
+++ b/examples/js/nodes/utils/ColorSpaceNode.js
@@ -12,7 +12,13 @@ function ColorSpaceNode( input, method ) {
 
 	this.input = input;
 
-	this.method = method || ColorSpaceNode.LINEAR;
+	this.method = method;
+
+	if ( this.method === undefined ) {
+
+		this.method = this.getEncodingMethod( this.input.value.encoding );
+
+	}
 
 }
 
@@ -203,7 +209,7 @@ ColorSpaceNode.LOG_LUV_TO_LINEAR = 'LogLuvToLinear';
 
 ColorSpaceNode.prototype = Object.create( TempNode.prototype );
 ColorSpaceNode.prototype.constructor = ColorSpaceNode;
-ColorSpaceNode.prototype.nodeType = "ColorAdjustment";
+ColorSpaceNode.prototype.nodeType = "ColorSpaceNode";
 
 ColorSpaceNode.prototype.generate = function ( builder, output ) {
 

--- a/examples/js/nodes/utils/ColorSpaceNode.js
+++ b/examples/js/nodes/utils/ColorSpaceNode.js
@@ -12,7 +12,7 @@ function ColorSpaceNode( input, method ) {
 
 	this.input = input;
 
-	this.method = method || ColorSpaceNode.LINEAR;
+	this.method = method || ColorSpaceNode.LINEAR_TO_LINEAR;
 
 }
 

--- a/examples/js/nodes/utils/ColorSpaceNode.js
+++ b/examples/js/nodes/utils/ColorSpaceNode.js
@@ -12,13 +12,7 @@ function ColorSpaceNode( input, method ) {
 
 	this.input = input;
 
-	this.method = method;
-
-	if ( this.method === undefined ) {
-
-		this.method = this.getEncodingMethod( this.input.value.encoding );
-
-	}
+	this.method = method || ColorSpaceNode.LINEAR;
 
 }
 
@@ -209,15 +203,15 @@ ColorSpaceNode.LOG_LUV_TO_LINEAR = 'LogLuvToLinear';
 
 ColorSpaceNode.prototype = Object.create( TempNode.prototype );
 ColorSpaceNode.prototype.constructor = ColorSpaceNode;
-ColorSpaceNode.prototype.nodeType = "ColorSpaceNode";
+ColorSpaceNode.prototype.nodeType = "ColorSpace";
 
 ColorSpaceNode.prototype.generate = function ( builder, output ) {
 
 	var input = builder.context.input || this.input.build( builder, 'v4' ),
-		encodingMethod = builder.context.encoding !== undefined ? this.getEncodingMethod( builder.context.encoding ) : [ this.method ],
-		factor = this.factor ? this.factor.build( builder, 'f' ) : encodingMethod[ 1 ];
+		decodingMethod = builder.context.encoding !== undefined ? this.getDecodingMethod( builder.context.encoding ) : [ this.method ],
+		factor = this.factor ? this.factor.build( builder, 'f' ) : decodingMethod[ 1 ];
 
-	var method = builder.include( ColorSpaceNode.Nodes[ encodingMethod[ 0 ] ] );
+	var method = builder.include( ColorSpaceNode.Nodes[ decodingMethod[ 0 ] ] );
 
 	if ( factor ) {
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -43,7 +43,9 @@
 		<script src="js/Detector.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import './js/nodes/THREE.Nodes.js';
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
@@ -74,7 +76,7 @@
 					path + 'posz' + format, path + 'negz' + format
 				] );
 
-				scene = new THREE.Scene();
+				scene = window.scene = new THREE.Scene();
 				scene.background = envMap;
 
 				light = new THREE.HemisphereLight( 0xbbbbff, 0x444422 );
@@ -83,6 +85,7 @@
 
 				// model
 				var loader = new THREE.GLTFLoader();
+				loader.setUseNodes( true );
 				loader.load( 'models/gltf/DamagedHelmet/glTF/DamagedHelmet.gltf', function ( gltf ) {
 
 					gltf.scene.traverse( function ( child ) {

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -56,7 +56,10 @@
 		<script src="js/loaders/DDSLoader.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script>
+		<script type="module">
+
+			import './js/nodes/THREE.Nodes.js';
+
 			var orbitControls;
 			var container, camera, scene, renderer, loader;
 			var gltf, envMap, mixer, gui, extensionControls;
@@ -268,6 +271,8 @@
 				}
 
 				loader = new THREE.GLTFLoader();
+
+				loader.setUseNodes( true );
 
 				THREE.DRACOLoader.setDecoderPath( 'js/libs/draco/gltf/' );
 				loader.setDRACOLoader( new THREE.DRACOLoader() );


### PR DESCRIPTION
Follow-up from https://github.com/mrdoob/three.js/pull/14149.

This isn't meant to be merged, or at least not at the moment, does make it easier for me to test glTF models with NodeMaterial, and hopefully helps @sunag a bit. Supporting NodeMaterial as an "opt-in" experimental thing in GLTFLoader is looking much easier with the MeshStandardNodeMaterial. :)

A few issues found:

- [x] ~MeshStandardNodeMaterial and others don't apply constructor arguments. (would help for backward compatibility)~
- [x] ~`.copy()` methods should return `this` or cloning will fail.~
- [x] ~sRGB textures are treated as linear. I tried to fix this below but didn't find the problem yet.~
- [ ] `aoMap` missing?

@sunag I'd be glad to open separate PRs for any of this, but if you have other PRs in progress I'll avoid the merge conflict and leave it to you. 😇