### PR TITLE
Add WebGLRenderer.DrawGeometry and associated functions

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -677,10 +677,18 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	var currentMaterial = null;
 	var uploadMesh = new Mesh();
 	var emptyState = new WebGLRenderState();
 	emptyState.init();
-	this.drawGeometry = function ( camera, fog, geometry, material, object, group ) {
+	this.setMaterial = function ( material ) {
+
+		_currentMaterialId = - 1;
+		currentMaterial = material;
+
+	};
+
+	this.drawGeometry = function ( camera, fog, geometry, object, group ) {
 
 		if ( vr.enabled ) {
 
@@ -693,8 +701,6 @@ function WebGLRenderer( parameters ) {
 			currentRenderState = emptyState;
 
 		}
-
-		_currentMaterialId = - 1;
 
 		if ( camera !== _currentCamera ) {
 
@@ -713,7 +719,7 @@ function WebGLRenderer( parameters ) {
 
 		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
 		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
-		this.renderBufferDirect( camera, fog, geometry, material, object, group );
+		this.renderBufferDirect( camera, fog, geometry, currentMaterial, object, group );
 		state.setPolygonOffset( false );
 
 		if ( currentRenderState === emptyState ) {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -650,7 +650,23 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+
+	var currentMaterial = null; // The current material to draw with
+	var uploadMesh = new Mesh(); // surrogate mesh to use for updating geometry because creatign geometry requires an object
+	var emptyState = new WebGLRenderState(); // default renderstate to use in the case that no render state is set
+	emptyState.init();
+
+	// Gathers up the lights in the given scene and initialize them for drawing
+	// with the provided camera. Passing null into either argument resets the
+	// render state
 	this.setLightingState = function ( scene, camera ) {
+
+		if ( ! scene || ! camera ) {
+
+			currentRenderState = null;
+			return;
+
+		}
 
 		if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
 
@@ -677,10 +693,8 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	var currentMaterial = null;
-	var uploadMesh = new Mesh();
-	var emptyState = new WebGLRenderState();
-	emptyState.init();
+	// Sets the material to draw with and resets the currently cached material
+	// so all uniforms are set again on next draw
 	this.setMaterial = function ( material ) {
 
 		_currentMaterialId = - 1;
@@ -688,6 +702,7 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	// Draws geometry with the transform of the provided object
 	this.drawGeometry = function ( camera, fog, geometry, object, group ) {
 
 		if ( vr.enabled ) {
@@ -702,6 +717,7 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		// Recalculate the camera matrices if the camera changed
 		if ( camera !== _currentCamera ) {
 
 			_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
@@ -713,10 +729,12 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		// Ensure the geometry is ready
 		uploadMesh.geometry = geometry;
 		objects.update( uploadMesh );
 		uploadMesh.geometry = null;
 
+		// Recalculate the model view and normal matrices and draw
 		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
 		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
 		this.renderBufferDirect( camera, fog, geometry, currentMaterial, object, group );
@@ -1331,6 +1349,7 @@ function WebGLRenderer( parameters ) {
 					var geometry = objects.update( object );
 					var material = object.material;
 
+					// Recalculate the model view and normal matrices and draw
 					currentRenderList.push( object, geometry, material, _vector3.z, null );
 
 				}
@@ -1366,6 +1385,7 @@ function WebGLRenderer( parameters ) {
 					var geometry = objects.update( object );
 					var material = object.material;
 
+					// Recalculate the model view and normal matrices and draw
 					if ( Array.isArray( material ) ) {
 
 						var groups = geometry.groups;

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -101,4 +101,4 @@ function WebGLRenderStates() {
 }
 
 
-export { WebGLRenderStates };
+export { WebGLRenderStates, WebGLRenderState };


### PR DESCRIPTION
Hey! This PR adds three functions to `WebGLRenderer` to address https://github.com/mrdoob/three.js/issues/14476 (and probably others) and allow you to have more control over materials and how objects get drawn outside of the `render` function because `renderBufferDirect` wasn't sufficient in all cases. There's a lot to learn and I'm pretty new to poking around the renderer code, so this PR might be more for discussion and feedback:

#### SetLightingState( scene, camera )
Rolls up the lighting information in the scene and caches it in the WebGLRenderState for that scene / camera combination, much like the beginning of `render`. Calling this with `null` resets the state.

#### SetMaterial( material )
Sets the material to be used when `DrawGeometry` is used next and invalidates the currently set material so the material uniforms are guaranteed to be updated on the next draw. This allows for the same material to be reused on multiple objects and modified between draws if desired.

#### DrawGeometry(  camera, fog, geometry, object, group )
Draws the geometry with the last set material using the world matrix on `object` and ensures that the geometry is read by calling `objects.update`. Note `object` _must_ be of a drawable type like `Mesh`.

---

These functions allow you to draw a scene (or draw more after rendering) like so:
```js
var geometry, object, material, camera, scene;

// ...

renderer.setRenderTarget( null );
renderer.clear();
renderer.setLightingState( scene, camera );
for ( var i = 0; i < 100; i ++ ) {
      
   object.position.set( Math.random(), Math.random(), Math.random() );
   object.updateMatrixWorld( true );
   material.color.set( Math.random(), Math.random(), Math.random() );
   
   renderer.setMaterial( material );
   renderer.drawGeometry( camera, null, geometry, object, null );

}

// increment the frame so geometry will get updated if needed. This
// can be called between draws to modify and draw the same geometry multiple
// times in a single frame.
renderer.info.reset();

```

`render()` does _not_ need to be called unless you want shadows to be rendered (which I suppose you could render to their maps directly using this?)

---

#### Comments & Questions
- With these functions, `compile` and `renderBufferDirect` may not need to be in the public API.
- Ultimately what I'd like to see is enough of the functionality of `WebGLRenderer` be cleanly exposed so you can forego using the `render()` function entirely allow for a really customize-able render path. I know I've seen this discussed in issues in the past but I'm having trouble finding them now.
- I'm less familiar with using VR with THREE so I don't know exactly how this will work in a VR case. Presumably you'd need to call `renderer.vr.submitFrame()` manually?
- ~~I've noticed that updating individual vertices in a mesh isn't working when not using `render()` so I'll have to track that down. Geometry may need it's own type of cache-invalidating function.~~
- And lastly (this may be related to some of the lighting-hash issues I've seen): is there a reason that `WebGLRenderStates` are cached even though they're reinitialized and recreated on every render? Why not remove the cache entirely?