### PR TITLE
Removed inefficient string concats from WebGLLights

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1548,7 +1548,7 @@ function WebGLRenderer( parameters ) {
 		// store the light setup it was created for
 		if ( materialProperties.lightsHash === undefined ) {
 
-				materialProperties.lightsHash = {};
+			materialProperties.lightsHash = {};
 
 		}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1438,7 +1438,13 @@ function WebGLRenderer( parameters ) {
 			// changed glsl or parameters
 			releaseMaterialProgramReference( material );
 
-		} else if ( materialProperties.lightsHash !== lights.state.hash ) {
+		} else if ( materialProperties.lightsHash.stateID !== lights.state.hash.stateID ||
+		 materialProperties.lightsHash.directionalLength !== lights.state.hash.directionalLength ||
+	   materialProperties.lightsHash.pointLength !== lights.state.hash.pointLength ||
+	   materialProperties.lightsHash.spotLength !== lights.state.hash.spotLength ||
+	   materialProperties.lightsHash.rectAreaLength !== lights.state.hash.rectAreaLength ||
+	   materialProperties.lightsHash.hemiLength !== lights.state.hash.hemiLength ||
+	   materialProperties.lightsHash.shadowsLength !== lights.state.hash.shadowsLength ) {
 
 			properties.update( material, 'lightsHash', lights.state.hash );
 			programChange = false;
@@ -1540,8 +1546,19 @@ function WebGLRenderer( parameters ) {
 		materialProperties.fog = fog;
 
 		// store the light setup it was created for
+		if ( materialProperties.lightsHash === undefined ) {
 
-		materialProperties.lightsHash = lights.state.hash;
+				materialProperties.lightsHash = {};
+
+		}
+
+		materialProperties.lightsHash.stateID = lights.state.hash.stateID;
+		materialProperties.lightsHash.directionalLength = lights.state.hash.directionalLength;
+		materialProperties.lightsHash.pointLength = lights.state.hash.pointLength;
+		materialProperties.lightsHash.spotLength = lights.state.hash.spotLength;
+		materialProperties.lightsHash.rectAreaLength = lights.state.hash.rectAreaLength;
+		materialProperties.lightsHash.hemiLength = lights.state.hash.hemiLength;
+		materialProperties.lightsHash.shadowsLength = lights.state.hash.shadowsLength;
 
 		if ( material.lights ) {
 
@@ -1608,7 +1625,13 @@ function WebGLRenderer( parameters ) {
 
 				material.needsUpdate = true;
 
-			} else if ( material.lights && materialProperties.lightsHash !== lights.state.hash ) {
+			} else if ( material.lights && ( materialProperties.lightsHash.stateID !== lights.state.hash.stateID ||
+			 materialProperties.lightsHash.directionalLength !== lights.state.hash.directionalLength ||
+		   materialProperties.lightsHash.pointLength !== lights.state.hash.pointLength ||
+		   materialProperties.lightsHash.spotLength !== lights.state.hash.spotLength ||
+		   materialProperties.lightsHash.rectAreaLength !== lights.state.hash.rectAreaLength ||
+		   materialProperties.lightsHash.hemiLength !== lights.state.hash.hemiLength ||
+		   materialProperties.lightsHash.shadowsLength !== lights.state.hash.shadowsLength ) ) {
 
 				material.needsUpdate = true;
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -110,7 +110,15 @@ function WebGLLights() {
 
 		id: count ++,
 
-		hash: '',
+		hash: {
+			stateID: -1,
+			directionalLength: -1,
+			pointLength: -1,
+			spotLength: -1,
+			rectAreaLength: -1,
+			hemiLength: -1,
+			shadowsLength: -1
+		},
 
 		ambient: [ 0, 0, 0 ],
 		directional: [],
@@ -316,7 +324,13 @@ function WebGLLights() {
 		state.point.length = pointLength;
 		state.hemi.length = hemiLength;
 
-		state.hash = state.id + ',' + directionalLength + ',' + pointLength + ',' + spotLength + ',' + rectAreaLength + ',' + hemiLength + ',' + shadows.length;
+		state.hash.stateID = state.id;
+		state.hash.directionalLength = directionalLength;
+		state.hash.pointLength = pointLength;
+		state.hash.spotLength = spotLength;
+		state.hash.rectAreaLength = rectAreaLength;
+		state.hash.hemiLength = hemiLength;
+		state.hash.shadowsLength = shadows.length;
 
 	}
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -111,13 +111,13 @@ function WebGLLights() {
 		id: count ++,
 
 		hash: {
-			stateID: -1,
-			directionalLength: -1,
-			pointLength: -1,
-			spotLength: -1,
-			rectAreaLength: -1,
-			hemiLength: -1,
-			shadowsLength: -1
+			stateID: - 1,
+			directionalLength: - 1,
+			pointLength: - 1,
+			spotLength: - 1,
+			rectAreaLength: - 1,
+			hemiLength: - 1,
+			shadowsLength: - 1
 		},
 
 		ambient: [ 0, 0, 0 ],


### PR DESCRIPTION
This PR fixes the issue mentionned in #14576 