### PR TITLE
Color chromatic lerp function

### DIFF
--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -218,8 +218,6 @@ var color = new THREE.Color( 1, 0, 0 );
 		this color and 1.0 is the first argument.
 		</p>
 
-
-
 		<h3>[method:Color lerpHSL]( [param:Color color], [param:Float alpha] ) </h3>
 		<p>
 		[page:Color color] - color to converge on.<br />
@@ -231,8 +229,6 @@ var color = new THREE.Color( 1, 0, 0 );
 		The alpha argument can be thought of as the ratio between the two colors, where 0.0 is
 		this color and 1.0 is the first argument.
 		</p>
-
-
 
 		<h3>[method:Color multiply]( [param:Color color] ) </h3>
 		<p>Multiplies this color's RGB values by the given [page:Color color]'s RGB values.</p>

--- a/docs/api/math/Color.html
+++ b/docs/api/math/Color.html
@@ -218,6 +218,22 @@ var color = new THREE.Color( 1, 0, 0 );
 		this color and 1.0 is the first argument.
 		</p>
 
+
+
+		<h3>[method:Color lerpHSL]( [param:Color color], [param:Float alpha] ) </h3>
+		<p>
+		[page:Color color] - color to converge on.<br />
+		[page:Float alpha] - interpolation factor in the closed interval [0, 1].<br /><br />
+
+		Linearly interpolates this color's HSL values toward the HSL values of the passed argument.
+		It differs from the classic [page:.lerp] by not interpolating straight from one color to the other,
+		but instead going through all the hues in between those two colors.
+		The alpha argument can be thought of as the ratio between the two colors, where 0.0 is
+		this color and 1.0 is the first argument.
+		</p>
+
+
+
 		<h3>[method:Color multiply]( [param:Color color] ) </h3>
 		<p>Multiplies this color's RGB values by the given [page:Color color]'s RGB values.</p>
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -540,8 +540,8 @@ Object.assign( Color.prototype, {
 		return this;
 
 	},
-	
-	lerpChromatic: function ( color, alpha  ) {
+
+	lerpChromatic: function ( color, alpha ) {
 
 		var hslA = this.getHSL();
 		var hslB = color.getHSL();

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -540,6 +540,21 @@ Object.assign( Color.prototype, {
 		return this;
 
 	},
+	
+	lerpChromatic: function ( color, alpha  ) {
+
+		var hslA = this.getHSL();
+		var hslB = color.getHSL();
+
+		var h = _Math.lerp( hslA.h, hslB.h, alpha );
+		var s = _Math.lerp( hslA.s, hslB.s, alpha );
+		var l = _Math.lerp( hslA.l, hslB.l, alpha );
+
+		this.setHSL( h, s, l );
+
+		return this;
+
+	},
 
 	equals: function ( c ) {
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -541,20 +541,27 @@ Object.assign( Color.prototype, {
 
 	},
 
-	lerpChromatic: function ( color, alpha ) {
+	lerpHSL: function () {
 
-		var hslA = this.getHSL();
-		var hslB = color.getHSL();
+		var hslA = { h: 0, s: 0, l: 0 };
+		var hslB = { h: 0, s: 0, l: 0 };
 
-		var h = _Math.lerp( hslA.h, hslB.h, alpha );
-		var s = _Math.lerp( hslA.s, hslB.s, alpha );
-		var l = _Math.lerp( hslA.l, hslB.l, alpha );
+		return function lerpHSL( color, alpha ) {
 
-		this.setHSL( h, s, l );
+			this.getHSL( hslA );
+			color.getHSL( hslB );
 
-		return this;
+			var h = _Math.lerp( hslA.h, hslB.h, alpha );
+			var s = _Math.lerp( hslA.s, hslB.s, alpha );
+			var l = _Math.lerp( hslA.l, hslB.l, alpha );
 
-	},
+			this.setHSL( h, s, l );
+
+			return this;
+
+		};
+
+	}(),
 
 	equals: function ( c ) {
 


### PR DESCRIPTION
Adds a chromatic lerp (maybe could be simply renamed lerpHSL) which interpolates in HSL and not straight from one color to the other in RGB like the original lerp. Other than that it works exactly like lerp()

![Imgur](https://i.imgur.com/UkDiURb.png)