### PR TITLE
Audio: Fix setting of .isPlaying when stopping the audio source

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -119,6 +119,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		if ( this.isPlaying === true ) {
 
 			this.source.stop();
+			this.source.onended = null;
 			this.offset += ( this.context.currentTime - this.startTime ) * this.playbackRate;
 			this.isPlaying = false;
 
@@ -138,6 +139,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		}
 
 		this.source.stop();
+		this.source.onended = null;
 		this.offset = 0;
 		this.isPlaying = false;
 


### PR DESCRIPTION
Fixes: #14587

If `Audio.stop()`/`Audio.pause()` is called, `. isPlaying` is set to `false`. It's not necessary to execute the `onended` event listener in this case which also sets `.isPlaying` to `false`.