### PR TITLE
FBXLoader: create GeometryParser and AnimationParser

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -23,7 +23,7 @@ THREE.FBXLoader = ( function () {
 
 	var FBXTree;
 	var connections;
-	var sceneGraph = new THREE.Group();
+	var sceneGraph;
 
 	function FBXLoader( manager ) {
 
@@ -768,6 +768,8 @@ THREE.FBXLoader = ( function () {
 
 		// create the main THREE.Group() to be returned by the loader
 		parseScene: function ( deformers, geometryMap, materialMap ) {
+
+			sceneGraph = new THREE.Group();
 
 			var modelMap = this.parseModels( deformers.skeletons, geometryMap, materialMap );
 


### PR DESCRIPTION
Continuation of #14519 

The most complicated parts of the loader involve parsing geometries and animations - a lot of processing is needed to convert FBX data to three.js suitable data. To make things easier to understand I've split the `FBXTreeParser` in 3 pieces: `FBXTreeParser`, `GeometryParser` and `AnimationParser`. 

Also increased the scope of the variables `FBXTree`, `connections`  and `sceneGraph` to the entire closure to reduce the amount of variables being passed between functions. 