### PR TITLE
UnrealBloomPass memory optimization

### DIFF
--- a/examples/js/postprocessing/UnrealBloomPass.js
+++ b/examples/js/postprocessing/UnrealBloomPass.js
@@ -1,6 +1,6 @@
 /**
  * @author spidersharma / http://eduperiment.com/
- * 
+ *
  * Inspired from Unreal Engine
  * https://docs.unrealengine.com/latest/INT/Engine/Rendering/PostProcessEffects/Bloom/
  */
@@ -12,6 +12,9 @@ THREE.UnrealBloomPass = function ( resolution, strength, radius, threshold ) {
 	this.radius = radius;
 	this.threshold = threshold;
 	this.resolution = ( resolution !== undefined ) ? new THREE.Vector2( resolution.x, resolution.y ) : new THREE.Vector2( 256, 256 );
+
+	// create color only once here, reuse it later inside the render function
+	this.reusableColor = new THREE.Color( 0, 0, 0 );
 
 	// render targets
 	var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat };
@@ -189,7 +192,7 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 		var oldAutoClear = renderer.autoClear;
 		renderer.autoClear = false;
 
-		renderer.setClearColor( new THREE.Color( 0, 0, 0 ), 0 );
+		renderer.setClearColor( this.reusableColor, 0 );
 
 		if ( maskActive ) renderer.context.disable( renderer.context.STENCIL_TEST );
 

--- a/examples/js/postprocessing/UnrealBloomPass.js
+++ b/examples/js/postprocessing/UnrealBloomPass.js
@@ -14,7 +14,7 @@ THREE.UnrealBloomPass = function ( resolution, strength, radius, threshold ) {
 	this.resolution = ( resolution !== undefined ) ? new THREE.Vector2( resolution.x, resolution.y ) : new THREE.Vector2( 256, 256 );
 
 	// create color only once here, reuse it later inside the render function
-	this.reusableColor = new THREE.Color( 0, 0, 0 );
+	this.clearColor = new THREE.Color( 0, 0, 0 );
 
 	// render targets
 	var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat };
@@ -192,7 +192,7 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 		var oldAutoClear = renderer.autoClear;
 		renderer.autoClear = false;
 
-		renderer.setClearColor( this.reusableColor, 0 );
+		renderer.setClearColor( this.clearColor, 0 );
 
 		if ( maskActive ) renderer.context.disable( renderer.context.STENCIL_TEST );
 


### PR DESCRIPTION
In this PR a simple modification is made inside the UnrealBloomPass to reduce possible GC activity caused by this line:

https://github.com/mrdoob/three.js/blob/5ce33263bf9c08ec981f71f02d1be15a416fb1e1/examples/js/postprocessing/UnrealBloomPass.js#L192

A new THREE.Color instance should not be created inside the render loop (60 times a second), it should be created once and be reused later in my opinion.
