### PR TITLE
Revert "Distanced based fog"

### DIFF
--- a/src/renderers/shaders/ShaderChunk/fog_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/fog_vertex.glsl
@@ -1,4 +1,4 @@
 
 #ifdef USE_FOG
-fogDepth = length(mvPosition);
+fogDepth = -mvPosition.z;
 #endif


### PR DESCRIPTION
Reverts mrdoob/three.js#14602.

Distance will have to be calculated in the fragment shader, instead.