### PR TITLE
Textured lighting as a spotLight.map property

### DIFF
--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -47,7 +47,7 @@
 
 		<h2>Code Example</h2>
 		<code>
-		// white spotlight shining from the side, casting a shadow
+		// white spotlight shining from the side, modulated by a texture, casting a shadow
 
 		var spotLight = new THREE.SpotLight( 0xffffff );
 		spotLight.position.set( 100, 1000, 100 );
@@ -61,13 +61,15 @@
 		spotLight.shadow.camera.far = 4000;
 		spotLight.shadow.camera.fov = 30;
 
+		spotLight.map = new THREE.TextureLoader().load(textureUrl);
+
 		scene.add( spotLight );
 		</code>
 
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [param:Integer color], [param:Float intensity], [param:Float distance], [param:Radians angle], [param:Float penumbra], [param:Float decay] )</h3>
+		<h3>[name]( [param:Integer color], [param:Float intensity], [param:Float distance], [param:Radians angle], [param:Float penumbra], [param:Float decay], [param:Texture map] )</h3>
 		<p>
 			[page:Integer color] - (optional) hexadecimal color of the light. Default is 0xffffff (white).<br />
 			[page:Float intensity] - (optional) numeric value of the light's strength/intensity. Default is 1.<br /><br />
@@ -78,6 +80,7 @@
 			[page:Float penumbra] - Percent of the spotlight cone that is attenuated due to penumbra.
 			Takes values between zero and 1. Default is zero.<br />
 			[page:Float decay] - The amount the light dims along the distance of the light.<br /><br />
+			[page:Texture map] - (optional) a texture to modulate the light.<br /><br />
 
 			Creates a new [name].
 		</p>
@@ -175,6 +178,12 @@ light.target = targetObject;
 			The spotlight will now track the target object.
 		</p>
 
+		<h3>[property:Texture map]</h3>
+		<p>
+			A [page:Texture] used to modulate the color of the light. The spot light color is mixed
+			with the RGB value of this texture, with a ratio corresponding to its
+			alpha value. The cookie-like masking effect is reproduced using pixel values (0, 0, 0, 1-cookie_value).
+		</p>
 
 		<h2>Methods</h2>
 

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -44,6 +44,11 @@
 
 		<script src="js/Detector.js"></script>
 
+		<video id="video" autoplay loop crossOrigin="anonymous" webkit-playsinline style="display:none">
+			<source src="textures/sintel.ogv" type='video/ogg; codecs="theora, vorbis"'>
+			<source src="textures/sintel.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'>
+		</video>
+
 		<script>
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
@@ -51,6 +56,8 @@
 			var renderer, scene, camera;
 
 			var spotLight, lightHelper, shadowCameraHelper;
+
+			var textureUrls, textures;
 
 			var gui;
 
@@ -80,6 +87,22 @@
 				var ambient = new THREE.AmbientLight( 0xffffff, 0.1 );
 				scene.add( ambient );
 
+				var textureLoader = new THREE.TextureLoader();
+				textureUrls = [ 'none', 'sintel (video)', 'UV_Grid_Sm.jpg', 'roughness_map.jpg', 'memorial.png', 'sprite2.png', 'perlin-512.png' ];
+				textures = { none: null };
+
+				var video = document.getElementById( 'video' );
+				textures[textureUrls[1]] = new THREE.VideoTexture( video );
+				textures[textureUrls[1]].minFilter = THREE.LinearFilter;
+				textures[textureUrls[1]].magFilter = THREE.LinearFilter;
+
+				for ( var i = 2; i < textureUrls.length; ++i ) {
+
+					textures[textureUrls[i]] = textureLoader.load( 'textures/' + textureUrls[i] );
+					textures[textureUrls[i]].minFilter = THREE.LinearFilter;
+					textures[textureUrls[i]].magFilter = THREE.LinearFilter;
+
+				}
 				spotLight = new THREE.SpotLight( 0xffffff, 1 );
 				spotLight.position.set( 15, 40, 35 );
 				spotLight.angle = Math.PI / 4;
@@ -157,7 +180,8 @@
 					distance: spotLight.distance,
 					angle: spotLight.angle,
 					penumbra: spotLight.penumbra,
-					decay: spotLight.decay
+					decay: spotLight.decay,
+					map: 'none'
 				}
 
 				gui.addColor( params, 'light color' ).onChange( function ( val ) {
@@ -203,6 +227,13 @@
 
 				} );
 
+				gui.add( params, 'map', textureUrls ).onChange( function ( url ) {
+
+					spotLight.map = textures[url];
+					animate();
+
+				} );
+
 				gui.open();
 
 			}
@@ -211,7 +242,14 @@
 
 			buildGui();
 
-			render();
+			animate();
+
+			function animate() {
+
+				if (spotLight.map && spotLight.map.isVideoTexture) requestAnimationFrame( animate );
+				render();
+
+			}
 
 		</script>
 

--- a/examples/webgl_shadowmap_viewer.html
+++ b/examples/webgl_shadowmap_viewer.html
@@ -97,7 +97,7 @@
 				spotLight2.shadow.camera.far = 25;
 				spotLight2.shadow.mapSize.width = 1024;
 				spotLight2.shadow.mapSize.height = 1024;
-				spotLight2.colorMap = textureLoader.load( 'textures/UV_Grid_Sm.jpg' );
+				spotLight2.map = textureLoader.load( 'textures/UV_Grid_Sm.jpg' );
 				scene.add( spotLight2 );
 
 				scene.add( new THREE.CameraHelper( spotLight2.shadow.camera ) );

--- a/examples/webgl_shadowmap_viewer.html
+++ b/examples/webgl_shadowmap_viewer.html
@@ -40,7 +40,7 @@
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
 			var camera, scene, renderer, clock, stats;
-			var dirLight, spotLight;
+			var dirLight, spotLight, spotLight2;
 			var torusKnot, cube;
 			var dirLightShadowMapViewer, spotLightShadowMapViewer;
 
@@ -65,15 +65,17 @@
 				camera.position.set( 0, 15, 35 );
 
 				scene = new THREE.Scene();
+				var textureLoader = new THREE.TextureLoader();
 
 				// Lights
 
-				scene.add( new THREE.AmbientLight( 0x404040 ) );
+				scene.add( new THREE.AmbientLight( 0x202020 ) );
 
 				spotLight = new THREE.SpotLight( 0xffffff );
 				spotLight.name = 'Spot Light';
+				spotLight.intensity = 0.3;
 				spotLight.angle = Math.PI / 5;
-				spotLight.penumbra = 0.3;
+				spotLight.penumbra = 0.2;
 				spotLight.position.set( 10, 10, 5 );
 				spotLight.castShadow = true;
 				spotLight.shadow.camera.near = 8;
@@ -84,8 +86,25 @@
 
 				scene.add( new THREE.CameraHelper( spotLight.shadow.camera ) );
 
+				spotLight2 = new THREE.SpotLight( 0xffffff );
+				spotLight2.name = 'Textured Spot Light';
+				spotLight2.intensity = 0.3;
+				spotLight2.angle = Math.PI / 5;
+				spotLight2.penumbra = 0.3;
+				spotLight2.position.set( -10, 5, 0 );
+				spotLight2.castShadow = true;
+				spotLight2.shadow.camera.near = 8;
+				spotLight2.shadow.camera.far = 25;
+				spotLight2.shadow.mapSize.width = 1024;
+				spotLight2.shadow.mapSize.height = 1024;
+				spotLight2.colorMap = textureLoader.load( 'textures/UV_Grid_Sm.jpg' );
+				scene.add( spotLight2 );
+
+				scene.add( new THREE.CameraHelper( spotLight2.shadow.camera ) );
+
 				dirLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				dirLight.name = 'Dir. Light';
+				dirLight.intensity = 0.3;
 				dirLight.position.set( 0, 10, 0 );
 				dirLight.castShadow = true;
 				dirLight.shadow.camera.near = 1;

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -6,7 +6,7 @@ import { Object3D } from '../core/Object3D.js';
  * @author alteredq / http://alteredqualia.com/
  */
 
-function SpotLight( color, intensity, distance, angle, penumbra, decay, colorMap ) {
+function SpotLight( color, intensity, distance, angle, penumbra, decay, map ) {
 
 	Light.call( this, color, intensity );
 
@@ -40,7 +40,7 @@ function SpotLight( color, intensity, distance, angle, penumbra, decay, colorMap
 	this.decay = ( decay !== undefined ) ? decay : 1;	// for physically correct lights, should be 2.
 
 	this.shadow = new SpotLightShadow();
-	this.colorMap = colorMap || null;
+	this.map = map || null;
 
 }
 

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -6,7 +6,7 @@ import { Object3D } from '../core/Object3D.js';
  * @author alteredq / http://alteredqualia.com/
  */
 
-function SpotLight( color, intensity, distance, angle, penumbra, decay ) {
+function SpotLight( color, intensity, distance, angle, penumbra, decay, colorMap ) {
 
 	Light.call( this, color, intensity );
 
@@ -40,6 +40,7 @@ function SpotLight( color, intensity, distance, angle, penumbra, decay ) {
 	this.decay = ( decay !== undefined ) ? decay : 1;	// for physically correct lights, should be 2.
 
 	this.shadow = new SpotLightShadow();
+	this.colorMap = colorMap || null;
 
 }
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1585,6 +1585,7 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.directionalShadowMap.value = lights.state.directionalShadowMap;
 			uniforms.directionalShadowMatrix.value = lights.state.directionalShadowMatrix;
+			uniforms.spotColorMap.value = lights.state.spotColorMap;
 			uniforms.spotShadowMap.value = lights.state.spotShadowMap;
 			uniforms.spotShadowMatrix.value = lights.state.spotShadowMatrix;
 			uniforms.pointShadowMap.value = lights.state.pointShadowMap;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1447,6 +1447,7 @@ function WebGLRenderer( parameters ) {
 			lightsHash.directionalLength !== lightsStateHash.directionalLength ||
 			lightsHash.pointLength !== lightsStateHash.pointLength ||
 			lightsHash.spotLength !== lightsStateHash.spotLength ||
+			lightsHash.spotMapLength !== lightsStateHash.spotMapLength ||
 			lightsHash.rectAreaLength !== lightsStateHash.rectAreaLength ||
 			lightsHash.hemiLength !== lightsStateHash.hemiLength ||
 			lightsHash.shadowsLength !== lightsStateHash.shadowsLength ) {
@@ -1455,6 +1456,7 @@ function WebGLRenderer( parameters ) {
 			lightsHash.directionalLength = lightsStateHash.directionalLength;
 			lightsHash.pointLength = lightsStateHash.pointLength;
 			lightsHash.spotLength = lightsStateHash.spotLength;
+			lightsHash.spotMapLength = lightsStateHash.spotMapLength;
 			lightsHash.rectAreaLength = lightsStateHash.rectAreaLength;
 			lightsHash.hemiLength = lightsStateHash.hemiLength;
 			lightsHash.shadowsLength = lightsStateHash.shadowsLength;
@@ -1568,6 +1570,7 @@ function WebGLRenderer( parameters ) {
 		lightsHash.directionalLength = lightsStateHash.directionalLength;
 		lightsHash.pointLength = lightsStateHash.pointLength;
 		lightsHash.spotLength = lightsStateHash.spotLength;
+		lightsHash.spotMapLength = lightsStateHash.spotMapLength;
 		lightsHash.rectAreaLength = lightsStateHash.rectAreaLength;
 		lightsHash.hemiLength = lightsStateHash.hemiLength;
 		lightsHash.shadowsLength = lightsStateHash.shadowsLength;
@@ -1585,7 +1588,7 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.directionalShadowMap.value = lights.state.directionalShadowMap;
 			uniforms.directionalShadowMatrix.value = lights.state.directionalShadowMatrix;
-			uniforms.spotColorMap.value = lights.state.spotColorMap;
+			uniforms.spotMap.value = lights.state.spotMap;
 			uniforms.spotShadowMap.value = lights.state.spotShadowMap;
 			uniforms.spotShadowMatrix.value = lights.state.spotShadowMatrix;
 			uniforms.pointShadowMap.value = lights.state.pointShadowMap;
@@ -1645,6 +1648,7 @@ function WebGLRenderer( parameters ) {
 				lightsHash.directionalLength !== lightsStateHash.directionalLength ||
 				lightsHash.pointLength !== lightsStateHash.pointLength ||
 				lightsHash.spotLength !== lightsStateHash.spotLength ||
+				lightsHash.spotMapLength !== lightsStateHash.spotMapLength ||
 				lightsHash.rectAreaLength !== lightsStateHash.rectAreaLength ||
 				lightsHash.hemiLength !== lightsStateHash.hemiLength ||
 				lightsHash.shadowsLength !== lightsStateHash.shadowsLength ) ) {

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl
@@ -45,6 +45,9 @@ IncidentLight directLight;
 #if ( NUM_SPOT_LIGHTS > 0 ) && defined( RE_Direct )
 
 	SpotLight spotLight;
+	vec4 spotColor;
+	vec2 spotShadowCoord;
+	bvec4 inFrustumVec;
 
 	#pragma unroll_loop
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
@@ -52,6 +55,11 @@ IncidentLight directLight;
 		spotLight = spotLights[ i ];
 
 		getSpotDirectLightIrradiance( spotLight, geometry, directLight );
+
+		spotShadowCoord = vSpotShadowCoord[ i ].xy / vSpotShadowCoord[ i ].w;
+		inFrustumVec = bvec4( spotShadowCoord.x >= 0.0, spotShadowCoord.x <= 1.0, spotShadowCoord.y >= 0.0, spotShadowCoord.y <= 1.0 );
+		spotColor = texture2D( spotColorMap[ i ], spotShadowCoord );
+		directLight.color = all( inFrustumVec ) ? mix( directLight.color, spotColor.rgb, spotColor.a ) : directLight.color;
 
 		#ifdef USE_SHADOWMAP
 		directLight.color *= all( bvec2( spotLight.shadow, directLight.visible ) ) ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
@@ -9,6 +9,7 @@
 
 	#if NUM_SPOT_LIGHTS > 0
 
+		uniform sampler2D spotColorMap[ NUM_SPOT_LIGHTS ];
 		uniform sampler2D spotShadowMap[ NUM_SPOT_LIGHTS ];
 		varying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl
@@ -1,3 +1,15 @@
+#if NUM_SPOT_LIGHT_COORDS > 0
+
+  varying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHT_COORDS ];
+
+#endif
+
+#if NUM_SPOT_LIGHT_MAPS > 0
+
+  uniform sampler2D spotMap[ NUM_SPOT_LIGHT_MAPS ];
+
+#endif
+
 #ifdef USE_SHADOWMAP
 
 	#if NUM_DIR_LIGHTS > 0
@@ -9,9 +21,7 @@
 
 	#if NUM_SPOT_LIGHTS > 0
 
-		uniform sampler2D spotColorMap[ NUM_SPOT_LIGHTS ];
 		uniform sampler2D spotShadowMap[ NUM_SPOT_LIGHTS ];
-		varying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl
@@ -1,16 +1,16 @@
+#if NUM_SPOT_LIGHT_COORDS > 0
+
+  uniform mat4 spotShadowMatrix[ NUM_SPOT_LIGHT_COORDS ];
+  varying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHT_COORDS ];
+
+#endif
+
 #ifdef USE_SHADOWMAP
 
 	#if NUM_DIR_LIGHTS > 0
 
 		uniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHTS ];
 		varying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
-
-	#endif
-
-	#if NUM_SPOT_LIGHTS > 0
-
-		uniform mat4 spotShadowMatrix[ NUM_SPOT_LIGHTS ];
-		varying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl
@@ -1,3 +1,14 @@
+#if NUM_SPOT_LIGHT_COORDS > 0
+
+	#pragma unroll_loop
+	for ( int i = 0; i < NUM_SPOT_LIGHT_COORDS; i ++ ) {
+
+		vSpotShadowCoord[ i ] = spotShadowMatrix[ i ] * worldPosition;
+
+	}
+
+#endif
+
 #ifdef USE_SHADOWMAP
 
 	#if NUM_DIR_LIGHTS > 0
@@ -6,17 +17,6 @@
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		vDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * worldPosition;
-
-	}
-
-	#endif
-
-	#if NUM_SPOT_LIGHTS > 0
-
-	#pragma unroll_loop
-	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
-
-		vSpotShadowCoord[ i ] = spotShadowMatrix[ i ] * worldPosition;
 
 	}
 

--- a/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl
+++ b/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl
@@ -1,4 +1,4 @@
-#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP )
+#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP ) || NUM_SPOT_LIGHT_MAPS > 0
 
 	vec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );
 

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -137,7 +137,7 @@ var UniformsLib = {
 			shadowMapSize: {}
 		} },
 
-		spotColorMap: { value: [] },
+		spotMap: { value: [] },
 		spotShadowMap: { value: [] },
 		spotShadowMatrix: { value: [] },
 

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -137,6 +137,7 @@ var UniformsLib = {
 			shadowMapSize: {}
 		} },
 
+		spotColorMap: { value: [] },
 		spotShadowMap: { value: [] },
 		spotShadowMatrix: { value: [] },
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -125,6 +125,7 @@ function WebGLLights() {
 		directionalShadowMap: [],
 		directionalShadowMatrix: [],
 		spot: [],
+		spotColorMap: [],
 		spotShadowMap: [],
 		spotShadowMatrix: [],
 		rectArea: [],
@@ -159,6 +160,7 @@ function WebGLLights() {
 			var intensity = light.intensity;
 			var distance = light.distance;
 
+			var colorMap = light.colorMap || null;
 			var shadowMap = ( light.shadow && light.shadow.map ) ? light.shadow.map.texture : null;
 
 			if ( light.isAmbientLight ) {
@@ -226,6 +228,7 @@ function WebGLLights() {
 
 				}
 
+				state.spotColorMap[ spotLength ] = colorMap;
 				state.spotShadowMap[ spotLength ] = shadowMap;
 				state.spotShadowMatrix[ spotLength ] = light.shadow.matrix;
 				state.spot[ spotLength ] = uniforms;

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -115,6 +115,7 @@ function WebGLLights() {
 			directionalLength: - 1,
 			pointLength: - 1,
 			spotLength: - 1,
+			spotMapLength: - 1,
 			rectAreaLength: - 1,
 			hemiLength: - 1,
 			shadowsLength: - 1
@@ -125,7 +126,7 @@ function WebGLLights() {
 		directionalShadowMap: [],
 		directionalShadowMatrix: [],
 		spot: [],
-		spotColorMap: [],
+		spotMap: [],
 		spotShadowMap: [],
 		spotShadowMatrix: [],
 		rectArea: [],
@@ -147,6 +148,7 @@ function WebGLLights() {
 		var directionalLength = 0;
 		var pointLength = 0;
 		var spotLength = 0;
+		var spotMapLength = 0;
 		var rectAreaLength = 0;
 		var hemiLength = 0;
 
@@ -160,7 +162,7 @@ function WebGLLights() {
 			var intensity = light.intensity;
 			var distance = light.distance;
 
-			var colorMap = light.colorMap || null;
+			var map = light.map || null;
 			var shadowMap = ( light.shadow && light.shadow.map ) ? light.shadow.map.texture : null;
 
 			if ( light.isAmbientLight ) {
@@ -228,11 +230,21 @@ function WebGLLights() {
 
 				}
 
-				state.spotColorMap[ spotLength ] = colorMap;
-				state.spotShadowMap[ spotLength ] = shadowMap;
-				state.spotShadowMatrix[ spotLength ] = light.shadow.matrix;
-				state.spot[ spotLength ] = uniforms;
+				if ( map ) {
 
+					state.spotShadowMap.splice( spotMapLength, 0, shadowMap );
+					state.spotShadowMatrix.splice( spotMapLength, 0, light.shadow.matrix );
+					state.spot.splice( spotMapLength, 0, uniforms );
+					state.spotMap[ spotMapLength ] = map;
+					spotMapLength ++;
+
+				} else {
+
+					state.spotShadowMap[ spotLength ] = shadowMap;
+					state.spotShadowMatrix[ spotLength ] = light.shadow.matrix;
+					state.spot[ spotLength ] = uniforms;
+
+				}
 				spotLength ++;
 
 			} else if ( light.isRectAreaLight ) {
@@ -326,11 +338,15 @@ function WebGLLights() {
 		state.rectArea.length = rectAreaLength;
 		state.point.length = pointLength;
 		state.hemi.length = hemiLength;
+		state.spotMap.length = spotMapLength;
+		state.spotShadowMap.length = spotLength;
+		state.spotShadowMatrix.length = spotLength;
 
 		state.hash.stateID = state.id;
 		state.hash.directionalLength = directionalLength;
 		state.hash.pointLength = pointLength;
 		state.hash.spotLength = spotLength;
+		state.hash.spotMapLength = spotMapLength;
 		state.hash.rectAreaLength = rectAreaLength;
 		state.hash.hemiLength = hemiLength;
 		state.hash.shadowsLength = shadows.length;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -141,9 +141,13 @@ function filterEmptyLine( string ) {
 
 function replaceLightNums( string, parameters ) {
 
+	var numSpotLightCoords = parameters.shadowMapEnabled ? parameters.numSpotLights : parameters.numSpotLightMaps;
+
 	return string
 		.replace( /NUM_DIR_LIGHTS/g, parameters.numDirLights )
 		.replace( /NUM_SPOT_LIGHTS/g, parameters.numSpotLights )
+		.replace( /NUM_SPOT_LIGHT_MAPS/g, parameters.numSpotLightMaps )
+		.replace( /NUM_SPOT_LIGHT_COORDS/g, numSpotLightCoords )
 		.replace( /NUM_RECT_AREA_LIGHTS/g, parameters.numRectAreaLights )
 		.replace( /NUM_POINT_LIGHTS/g, parameters.numPointLights )
 		.replace( /NUM_HEMI_LIGHTS/g, parameters.numHemiLights );

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -34,7 +34,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 		"flatShading", "sizeAttenuation", "logarithmicDepthBuffer", "skinning",
 		"maxBones", "useVertexTexture", "morphTargets", "morphNormals",
 		"maxMorphTargets", "maxMorphNormals", "premultipliedAlpha",
-		"numDirLights", "numPointLights", "numSpotLights", "numHemiLights", "numRectAreaLights",
+		"numDirLights", "numPointLights", "numSpotLights", "numSpotLightMaps", "numHemiLights", "numRectAreaLights",
 		"shadowMapEnabled", "shadowMapType", "toneMapping", 'physicallyCorrectLights',
 		"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "numClipIntersection", "depthPacking", "dithering"
 	];
@@ -185,6 +185,8 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			numSpotLights: lights.spot.length,
 			numRectAreaLights: lights.rectArea.length,
 			numHemiLights: lights.hemi.length,
+
+			numSpotLightMaps: lights.spotMap.length,
 
 			numClippingPlanes: nClipPlanes,
 			numClipIntersection: nClipIntersection,

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -204,9 +204,13 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 				faceCount = 1;
 
-				_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
-				shadowCamera.lookAt( _lookTarget );
-				shadowCamera.updateMatrixWorld();
+				if ( light.target ) {
+
+					_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
+					shadowCamera.lookAt( _lookTarget );
+					shadowCamera.updateMatrixWorld();
+
+				}
 
 				// compute shadow matrix
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -204,13 +204,9 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 				faceCount = 1;
 
-				if ( light.target ) {
-
-					_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
-					shadowCamera.lookAt( _lookTarget );
-					shadowCamera.updateMatrixWorld();
-
-				}
+				_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
+				shadowCamera.lookAt( _lookTarget );
+				shadowCamera.updateMatrixWorld();
 
 				// compute shadow matrix
 


### PR DESCRIPTION
This PR is a second attempt at #13057, by adding a ~~`colorMap`~~ `map` property to the `SpotLight` class :

![image](https://user-images.githubusercontent.com/7373521/43595436-fbaead3c-967c-11e8-9012-1c2810ea6fe1.png)

http://localhost:8000/examples/webgl_shadowmap_viewer.html

This PR generalizes the single-channel [cookie](https://docs.unity3d.com/Manual/Cookies.html) concept  to a 4-channel texture : the `directLight.color` of the spot light is `mix`ed with the rgb value of the `colorMap` lookup with a ratio corresponding to its alpha value : ``` mix( directLight.color, spotColor.rgb, spotColor.a ) ```. The cookie effect is reproduced using pixel values `(0,0,0,1-cookie_value)`.

Comments :
- ~~with this PR, each spotLight takes an extra texture slot (similar to https://github.com/mrdoob/three.js/pull/13057#issuecomment-359135200). Is it an issue ? any idea ?~~ (the second commit 8d683b8 addresses this issue.)
- it is not currently possible to control the geometry of the spotlight to match a known PerspectiveCamera (the `spotShadowMatrix` is used for texture lookup). This will be tackled in a follow-up PR if this one gets merged.