### PR TITLE
Add SpriteMaterial sizeAttenuation property

### DIFF
--- a/docs/api/materials/SpriteMaterial.html
+++ b/docs/api/materials/SpriteMaterial.html
@@ -67,8 +67,11 @@ scene.add( sprite );
 		<h3>[property:Radians rotation]</h3>
 		<p>The rotation of the sprite in radians. Default is 0.</p>
 
+		<h3>[property:Boolean sizeAttenuation]</h3>
+		<p>Whether the size of the sprite is attenuated by the camera depth. (Perspective camera only.) Default is *true*.</p>
+
 		<h2>Methods</h2>
-		<p>See the base [page:Material]  class for common methods.</p>
+		<p>See the base [page:Material] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/src/materials/SpriteMaterial.js
+++ b/src/materials/SpriteMaterial.js
@@ -6,11 +6,9 @@ import { Color } from '../math/Color.js';
  *
  * parameters = {
  *  color: <hex>,
- *  opacity: <float>,
  *  map: new THREE.Texture( <Image> ),
- *
- *	uvOffset: new THREE.Vector2(),
- *	uvScale: new THREE.Vector2()
+ *  rotation: <float>,
+ *  sizeAttenuation: <bool>
  * }
  */
 
@@ -24,6 +22,8 @@ function SpriteMaterial( parameters ) {
 	this.map = null;
 
 	this.rotation = 0;
+
+	this.sizeAttenuation = true;
 
 	this.lights = false;
 	this.transparent = true;
@@ -44,6 +44,8 @@ SpriteMaterial.prototype.copy = function ( source ) {
 	this.map = source.map;
 
 	this.rotation = source.rotation;
+
+	this.sizeAttenuation = source.sizeAttenuation;
 
 	return this;
 

--- a/src/renderers/shaders/ShaderLib/sprite_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/sprite_vert.glsl
@@ -19,7 +19,9 @@ void main() {
 
 	#ifndef USE_SIZEATTENUATION
 
-		scale *= abs( mvPosition.z );
+		bool isPerspective = ( projectionMatrix[ 2 ][ 3 ] == - 1.0 );
+
+		if ( isPerspective ) scale *= - mvPosition.z;
 
 	#endif
 

--- a/src/renderers/shaders/ShaderLib/sprite_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/sprite_vert.glsl
@@ -11,9 +11,17 @@ void main() {
 
 	#include <uv_vertex>
 
+	vec4 mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );
+
 	vec2 scale;
 	scale.x = length( vec3( modelMatrix[ 0 ].x, modelMatrix[ 0 ].y, modelMatrix[ 0 ].z ) );
 	scale.y = length( vec3( modelMatrix[ 1 ].x, modelMatrix[ 1 ].y, modelMatrix[ 1 ].z ) );
+
+	#ifndef USE_SIZEATTENUATION
+
+		scale *= abs( mvPosition.z );
+
+	#endif
 
 	vec2 alignedPosition = ( position.xy - ( center - vec2( 0.5 ) ) ) * scale;
 
@@ -21,9 +29,6 @@ void main() {
 	rotatedPosition.x = cos( rotation ) * alignedPosition.x - sin( rotation ) * alignedPosition.y;
 	rotatedPosition.y = sin( rotation ) * alignedPosition.x + cos( rotation ) * alignedPosition.y;
 
-	vec4 mvPosition;
-
-	mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );
 	mvPosition.xy += rotatedPosition;
 
 	gl_Position = projectionMatrix * mvPosition;


### PR DESCRIPTION
Fixes #14626.

Sprites attenuate by default when using a perspective camera. Setting `SpriteMaterial.sizeAttenuation = false` will cause the sprite to render at a constant size, regardless of the sprite's camera depth.

~~Setting this flag to `false` when using an orthographic camera will cause unexpected results. That was a preexisting condition.~~  EDIT: fixed
