### PR TITLE
Docs: Removed unusable property in PointsMaterial

### DIFF
--- a/docs/api/materials/PointsMaterial.html
+++ b/docs/api/materials/PointsMaterial.html
@@ -77,9 +77,6 @@ scene.add( starField );
 			You should not change this, as it used internally for optimisation.
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>Whether the material is affected by lights. Default is *false*.</p>
-
 		<h3>[property:Texture map]</h3>
 
 		<p>Sets the color of the points using data from a [page:Texture].</p>


### PR DESCRIPTION
Changing this property from the default causes the scene to crash (#10491). It shouldn't be in the documentation if it is unusable.