### PR TITLE
Fix return value type of OrbitControls.update() in Doc

### DIFF
--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -273,7 +273,7 @@ controls.mouseButtons = {
 			Save the current state of the controls. This can later be recovered with [page:.reset].
 		</p>
 
-		<h3>[method:false update] ()</h3>
+		<h3>[method:Boolean update] ()</h3>
 		<p>
 			Update the controls. Must be called after any manual changes to the camera's transform,
 			or in the update loop if [page:.autoRotate] or [page:.enableDamping] are set.


### PR DESCRIPTION
This PR fixes return value type of `.update()` in `OrbitControls` Doc.