### PR TITLE
FBXLoader: improved texture checks

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -389,13 +389,33 @@ THREE.FBXLoader = ( function () {
 
 			var texture;
 
-			if ( textureNode.FileName.slice( - 3 ).toLowerCase() === 'tga' ) {
+			var extension = textureNode.FileName.slice( - 3 ).toLowerCase();
 
-				texture = THREE.Loader.Handlers.get( '.tga' ).load( fileName );
+			function onError() {
+
+				console.warn( 'FBXLoader: Creating empty placeholder texture for', fileName );
+				texture = new THREE.Texture();
+
+			}
+
+			if ( extension === 'tga' ) {
+
+				var loader = THREE.Loader.Handlers.get( '.tga' );
+				if ( loader === null ) {
+
+					console.warn( 'FBXLoader: TGALoader not found, creating empty placeholder texture for', fileName );
+					texture = new THREE.Texture();
+
+				} else texture = loader.load( fileName, undefined, undefined, onError );
+
+			} else if ( extension === 'psd' ) {
+
+				console.warn( 'FBXLoader: PSD textures are not supported, creating empty placeholder texture for', fileName );
+				texture = new THREE.Texture();
 
 			} else {
 
-				texture = this.textureLoader.load( fileName );
+				texture = this.textureLoader.load( fileName, undefined, undefined, onError );
 
 			}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -391,13 +391,6 @@ THREE.FBXLoader = ( function () {
 
 			var extension = textureNode.FileName.slice( - 3 ).toLowerCase();
 
-			function onError() {
-
-				console.warn( 'FBXLoader: Creating empty placeholder texture for', fileName );
-				texture = new THREE.Texture();
-
-			}
-
 			if ( extension === 'tga' ) {
 
 				var loader = THREE.Loader.Handlers.get( '.tga' );
@@ -406,7 +399,7 @@ THREE.FBXLoader = ( function () {
 					console.warn( 'FBXLoader: TGALoader not found, creating empty placeholder texture for', fileName );
 					texture = new THREE.Texture();
 
-				} else texture = loader.load( fileName, undefined, undefined, onError );
+				} else texture = loader.load( fileName );
 
 			} else if ( extension === 'psd' ) {
 
@@ -415,7 +408,7 @@ THREE.FBXLoader = ( function () {
 
 			} else {
 
-				texture = this.textureLoader.load( fileName, undefined, undefined, onError );
+				texture = this.textureLoader.load( fileName );
 
 			}
 


### PR DESCRIPTION
Improved check for TGALoader, and added check for PSD textures since I've found that lots of models downloaded from SketchFab have references to PSD files. 

~~I've also switched to creating an empty `Texture` object when the loader can't find a texture.~~ 
EDIT: removed this as it's redundant, the TextureLoader and TGALoader both already return an empty `Texture` if the image file isn't found.

Sample console output with these checks:
```
FBXLoader: TGALoader not found, creating empty placeholder texture for LM_Final.tga

PSD textures are not supported, creating empty placeholder texture for props_alpha.psd
```