### PR TITLE
Make Light targets optional

### DIFF
--- a/docs/api/lights/DirectionalLight.html
+++ b/docs/api/lights/DirectionalLight.html
@@ -21,23 +21,6 @@
 			This light can cast shadows - see the [page:DirectionalLightShadow] page for details.
 		</p>
 
-		<h2>A Note about Position, Target and rotation</h2>
-		<p>
-			A common point of confusion for directional lights is that setting the rotation has no effect.
-			This is because three.js's DirectionalLight is the equivalent to what is often called a 'Target
-			Direct Light' in other applications.<br /><br />
-
-			This means that its direction is calculated as pointing
-			from the light's [page:Object3D.position position] to	the [page:.target target]'s position
-			(as opposed to a 'Free Direct Light' that just has a rotation component).<br /><br />
-
-			The reason for this is to allow the light to cast shadows - the [page:.shadow shadow]
-			camera needs a position to calculate shadows from.<br /><br />
-
-			See the [page:.target target] property below for details on updating the target.
-		</p>
-
-
 		<h2>Example</h2>
 		<p>
 			[example:canvas_morphtargets_horse morphtargets / horse ]<br />
@@ -99,30 +82,40 @@
 
 		<h3>[property:Object3D target]</h3>
 		<p>
-			The DirectionalLight points from its [page:.position position] to target.position. The default
-			position of the target is *(0, 0, 0)*.<br />
+			The target is initialized with a newly created [page:Object3D].<br/>
+			When target is *undefined*, the DirectionalLight is directed along the positive Z axis of its local
+			frame ('Free Direct Light' mode). In this mode, the direction of the DirectionalLight is thus defined
+			by its [page:Object3D.quaternion quaternion] and the quaternions of its ancestors.
+<code>
+// overwrite the Object3D created by default
+light.target = undefined;
 
-			*Note*: For the target's position to be changed to anything other than the default,
-			it must be added to the [page:Scene scene] using
-		</p>
-		<code>
-		scene.add( light.target );
-		</code>
-		<p>
-			This is so that the target's [page:Object3D.matrixWorld matrixWorld] gets automatically
-			updated each frame.<br /><br />
+// set the [page:.quaternion quaternion] directly
+light.quaternion.set( 1, 0, 0, 0 );
+light.matrixWorldNeedsUpdate = true;
 
-			It is also possible to set the target to be another object in the scene (anything with a
-			[page:Object3D.position position] property), like so:
-		</p>
-		<code>
-		var targetObject = new THREE.Object3D();
-		scene.add(targetObject);
+// modify the [page:.quaternion quaternion] using [page:Object3D.lookAt] on world coordinates
+light.lookAt( 0, 0, 0 );
 
-		light.target = targetObject;
-		</code>
-		<p>
-			The directionalLight will now track the target object.
+// add the light to a possibly moving [page:Object3D]
+animatedGroup.add(light);
+</code>
+
+			When target is *defined*, the DirectionalLight points from its world [page:.position position]
+			to the world position of its target, extracted from [page:Object3D.matrixWorld target.matrixWorld].
+			This 'Target Direct Light' mode may be used to have the light track a moving object :
+			<code>
+var targetObject = new THREE.Object3D();
+scene.add(targetObject);
+light.target = targetObject;
+			</code>
+			*Note*: The target object mush be added to the [page:Scene scene] to get its
+			[page:Object3D.matrixWorld matrixWorld] automatically updated each frame.
+			Moreover, the [page:Object3D.quaternion quaternion] property is unused when the [page.target target]
+			property is defined.<br/>
+
+			*Note*: In both modes, the [page:.position position] is used by the [page:.shadow shadow] camera
+			to cast shadows.
 		</p>
 
 

--- a/docs/api/lights/DirectionalLight.html
+++ b/docs/api/lights/DirectionalLight.html
@@ -82,33 +82,31 @@
 
 		<h3>[property:Object3D target]</h3>
 		<p>
-			When target is *undefined* (the default), the DirectionalLight is directed along the positive Z axis of its local
-			frame ('Free Direct Light' mode). In this mode, the direction of the DirectionalLight is thus defined
-			by its [page:Object3D.quaternion quaternion] and the quaternions of its ancestors.
-<code>
-// set the [page:.quaternion quaternion] directly
-light.quaternion.set( 1, 0, 0, 0 );
-light.matrixWorldNeedsUpdate = true;
-
-// modify the [page:.quaternion quaternion] using [page:Object3D.lookAt] on world coordinates
-light.lookAt( 0, 0, 0 );
-
-// add the light to a possibly moving [page:Object3D]
-animatedGroup.add(light);
-</code>
-
-			When target is *defined*, the DirectionalLight points from its world [page:.position position]
-			to the world position of its target, extracted from [page:Object3D.matrixWorld target.matrixWorld].
+			If [page:.targeted targeted] is *true*, the DirectionalLight points from its world [page:.position position]
+			to the world position of its [page:.target target] object, extracted from [page:Object3D.matrixWorld target.matrixWorld].
 			This 'Target Direct Light' mode may be used to have the light track a moving object :
 			<code>
-var targetObject = new THREE.Object3D();
-scene.add(targetObject);
+// track an existing object, already added to the scene
+light.targeted = true;
 light.target = targetObject;
+
+// or use the default target object
+light.targeted = true;
+scene.add( light.target );
 			</code>
 			*Note*: The target object mush be added to the [page:Scene scene] to get its
-			[page:Object3D.matrixWorld matrixWorld] automatically updated each frame.
-			Moreover, the [page:Object3D.quaternion quaternion] property is unused when the [page.target target]
-			property is defined.<br/>
+			[page:Object3D.matrixWorld matrixWorld] automatically updated each frame.<br/>
+			*Note*: The light [page:Object3D.rotation rotation] and [page:Object3D.quaternion quaternion] are
+			unused when the [page:.targeted targeted] is true.<br/>
+		</p>
+
+
+		<h3>[property:Boolean targeted]</h3>
+		<p>
+			If set to *true*, the light direction will track the [page:.target target] world position, otherwise the SpotLight is directed along the positive Z axis of its local
+			frame ('Free Direct Light' mode) and thus affected by its world rotation.<br/>
+
+			The default is *false*.<br/>
 
 			*Note*: In both modes, the [page:.position position] is used by the [page:.shadow shadow] camera
 			to cast shadows.

--- a/docs/api/lights/DirectionalLight.html
+++ b/docs/api/lights/DirectionalLight.html
@@ -82,14 +82,10 @@
 
 		<h3>[property:Object3D target]</h3>
 		<p>
-			The target is initialized with a newly created [page:Object3D].<br/>
-			When target is *undefined*, the DirectionalLight is directed along the positive Z axis of its local
+			When target is *undefined* (the default), the DirectionalLight is directed along the positive Z axis of its local
 			frame ('Free Direct Light' mode). In this mode, the direction of the DirectionalLight is thus defined
 			by its [page:Object3D.quaternion quaternion] and the quaternions of its ancestors.
 <code>
-// overwrite the Object3D created by default
-light.target = undefined;
-
 // set the [page:.quaternion quaternion] directly
 light.quaternion.set( 1, 0, 0, 0 );
 light.matrixWorldNeedsUpdate = true;

--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -149,36 +149,32 @@
 			A [page:SpotLightShadow] used to calculate shadows for this light.
 		</p>
 
-
 		<h3>[property:Object3D target]</h3>
 		<p>
-			When target is *undefined* (the default), the SpotLight	is directed along the positive Z axis of its local frame.
-			The direction of the SpotLight is thus defined by its [page:Object3D.quaternion quaternion] and
-			the quaternions of its ancestors.
-<code>
-// set the [page:.quaternion quaternion] directly
-light.quaternion.set( 1, 0, 0, 0 );
-light.matrixWorldNeedsUpdate = true;
-
-// modify the [page:.quaternion quaternion] using [page:Object3D.lookAt] on world coordinates
-light.lookAt( 0, 0, 0 );
-
-// add the light to a possibly moving [page:Object3D]
-animatedGroup.add(light);
-</code>
-
-			When target is *defined*, the SpotLight points from its world [page:.position position]
-			to the world position of its target, extracted from [page:Object3D.matrixWorld target.matrixWorld].
-			This may be used to have the light track a moving object
+			If [page:.targeted targeted] is *true*, the SpotLight points from its world [page:.position position]
+			to the world position of its [page:.target target] object, extracted from [page:Object3D.matrixWorld target.matrixWorld].
+			This may be used to have the light track a moving object :
 			<code>
-var targetObject = new THREE.Object3D();
-scene.add(targetObject);
+// track an existing object, already added to the scene
+light.targeted = true;
 light.target = targetObject;
+
+// or use the default target object
+light.targeted = true;
+scene.add( light.target );
 			</code>
 			*Note*: The target object mush be added to the [page:Scene scene] to get its
-			[page:Object3D.matrixWorld matrixWorld] automatically updated each frame.
-			Moreover, the [page:Object3D.quaternion quaternion] property is unused when the [page.target target]
-			property is defined.
+			[page:Object3D.matrixWorld matrixWorld] automatically updated each frame.<br/>
+			*Note*: The light [page:Object3D.rotation rotation] and [page:Object3D.quaternion quaternion] are
+			unused when the [page:.targeted targeted] is true.<br/>
+		</p>
+
+		<h3>[property:Boolean targeted]</h3>
+		<p>
+			If set to *true*, the light direction will track the [page:.target target] world position, otherwise the SpotLight is directed along the positive Z axis of its local
+			frame and thus affected by its world rotation.<br/>
+
+			The default is *false*.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -152,14 +152,10 @@
 
 		<h3>[property:Object3D target]</h3>
 		<p>
-			The target is initialized with a newly created [page:Object3D].<br/>
-			When target is *undefined*, the SpotLight is directed along the positive Z axis of its local frame.
+			When target is *undefined* (the default), the SpotLight	is directed along the positive Z axis of its local frame.
 			The direction of the SpotLight is thus defined by its [page:Object3D.quaternion quaternion] and
 			the quaternions of its ancestors.
 <code>
-// overwrite the Object3D created by default
-light.target = undefined;
-
 // set the [page:.quaternion quaternion] directly
 light.quaternion.set( 1, 0, 0, 0 );
 light.matrixWorldNeedsUpdate = true;

--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -152,29 +152,38 @@
 
 		<h3>[property:Object3D target]</h3>
 		<p>
-			The Spotlight points from its [page:.position position] to target.position. The default
-			position of the target is *(0, 0, 0)*.<br />
+			The target is initialized with a newly created [page:Object3D].<br/>
+			When target is *undefined*, the SpotLight is directed along the positive Z axis of its local frame.
+			The direction of the SpotLight is thus defined by its [page:Object3D.quaternion quaternion] and
+			the quaternions of its ancestors.
+<code>
+// overwrite the Object3D created by default
+light.target = undefined;
 
-			*Note*: For the target's position to be changed to anything other than the default,
-			it must be added to the [page:Scene scene] using
-			<code>
-				scene.add( light.target );
-			</code>
+// set the [page:.quaternion quaternion] directly
+light.quaternion.set( 1, 0, 0, 0 );
+light.matrixWorldNeedsUpdate = true;
 
-			This is so that the target's [page:Object3D.matrixWorld matrixWorld] gets automatically
-			updated each frame.<br /><br />
+// modify the [page:.quaternion quaternion] using [page:Object3D.lookAt] on world coordinates
+light.lookAt( 0, 0, 0 );
 
-			It is also possible to set the target to be another object in the scene (anything with a
-			[page:Object3D.position position] property), like so:
+// add the light to a possibly moving [page:Object3D]
+animatedGroup.add(light);
+</code>
+
+			When target is *defined*, the SpotLight points from its world [page:.position position]
+			to the world position of its target, extracted from [page:Object3D.matrixWorld target.matrixWorld].
+			This may be used to have the light track a moving object
 			<code>
 var targetObject = new THREE.Object3D();
 scene.add(targetObject);
-
 light.target = targetObject;
 			</code>
-			The spotlight will now track the target object.
+			*Note*: The target object mush be added to the [page:Scene scene] to get its
+			[page:Object3D.matrixWorld matrixWorld] automatically updated each frame.
+			Moreover, the [page:Object3D.quaternion quaternion] property is unused when the [page.target target]
+			property is defined.
 		</p>
-
 
 		<h2>Methods</h2>
 

--- a/examples/canvas_camera_orthographic.html
+++ b/examples/canvas_camera_orthographic.html
@@ -85,6 +85,7 @@
 				directionalLight.position.y = Math.random() - 0.5;
 				directionalLight.position.z = Math.random() - 0.5;
 				directionalLight.position.normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var directionalLight = new THREE.DirectionalLight( Math.random() * 0xffffff );
@@ -92,6 +93,7 @@
 				directionalLight.position.y = Math.random() - 0.5;
 				directionalLight.position.z = Math.random() - 0.5;
 				directionalLight.position.normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				renderer = new THREE.CanvasRenderer();

--- a/examples/canvas_interactive_voxelpainter.html
+++ b/examples/canvas_interactive_voxelpainter.html
@@ -86,6 +86,7 @@
 				directionalLight.position.y = Math.random() - 0.5;
 				directionalLight.position.z = Math.random() - 0.5;
 				directionalLight.position.normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var directionalLight = new THREE.DirectionalLight( 0x808080 );
@@ -93,6 +94,7 @@
 				directionalLight.position.y = Math.random() - 0.5;
 				directionalLight.position.z = Math.random() - 0.5;
 				directionalLight.position.normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				renderer = new THREE.CanvasRenderer();

--- a/examples/canvas_materials.html
+++ b/examples/canvas_materials.html
@@ -117,6 +117,7 @@
 				directionalLight.position.y = Math.random() - 0.5;
 				directionalLight.position.z = Math.random() - 0.5;
 				directionalLight.position.normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				pointLight = new THREE.PointLight( 0xffffff, 1 );

--- a/examples/canvas_morphtargets_horse.html
+++ b/examples/canvas_morphtargets_horse.html
@@ -57,10 +57,12 @@
 
 				var light = new THREE.DirectionalLight( 0xefefff, 1.5 );
 				light.position.set( 1, 1, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0xffefef, 1.5 );
 				light.position.set( -1, -1, -1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var loader = new THREE.JSONLoader();

--- a/examples/canvas_performance.html
+++ b/examples/canvas_performance.html
@@ -74,6 +74,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( Math.random() * 0xffffff );
 				directionalLight.position.set( 0, 1, 0 );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				light = new THREE.PointLight( 0xff0000, 1, 500 );

--- a/examples/css2d_label.html
+++ b/examples/css2d_label.html
@@ -72,6 +72,7 @@
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff );
 				dirLight.position.set( 0, 0, 1 );
+				dirLight.lookAt( 0, 0, 0 );
 				scene.add( dirLight );
 
 				var axesHelper = new THREE.AxesHelper( 5 );

--- a/examples/js/crossfade/scenes.js
+++ b/examples/js/crossfade/scenes.js
@@ -82,6 +82,7 @@ function Scene( type, numObjects, cameraZ, fov, rotationSpeed, clearColor ) {
 
 	var light = new THREE.SpotLight( 0xffffff, 1.5 );
 	light.position.set( 0, 500, 2000 );
+	light.lookAt( 0, 0, 0 );
 	this.scene.add( light );
 
 	this.rotationSpeed = rotationSpeed;

--- a/examples/js/loaders/BabylonLoader.js
+++ b/examples/js/loaders/BabylonLoader.js
@@ -168,10 +168,12 @@ THREE.BabylonLoader.prototype = {
 
 					case 1:
 						light = new THREE.DirectionalLight();
+						light.target = new THREE.Object3D();
 						break;
 
 					case 2:
 						light = new THREE.SpotLight();
+						light.target = new THREE.Object3D();
 						break;
 
 					case 3:

--- a/examples/js/loaders/BabylonLoader.js
+++ b/examples/js/loaders/BabylonLoader.js
@@ -168,12 +168,12 @@ THREE.BabylonLoader.prototype = {
 
 					case 1:
 						light = new THREE.DirectionalLight();
-						light.target = new THREE.Object3D();
+						light.targeted = true;
 						break;
 
 					case 2:
 						light = new THREE.SpotLight();
-						light.target = new THREE.Object3D();
+						light.targeted = true;
 						break;
 
 					case 3:

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1936,6 +1936,7 @@ THREE.ColladaLoader.prototype = {
 
 				case 'directional':
 					light = new THREE.DirectionalLight();
+					light.target = new THREE.Object3D();
 					break;
 
 				case 'point':
@@ -1944,6 +1945,7 @@ THREE.ColladaLoader.prototype = {
 
 				case 'spot':
 					light = new THREE.SpotLight();
+					light.target = new THREE.Object3D();
 					break;
 
 				case 'ambient':

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1936,7 +1936,7 @@ THREE.ColladaLoader.prototype = {
 
 				case 'directional':
 					light = new THREE.DirectionalLight();
-					light.target = new THREE.Object3D();
+					light.targeted = true;
 					break;
 
 				case 'point':
@@ -1945,7 +1945,7 @@ THREE.ColladaLoader.prototype = {
 
 				case 'spot':
 					light = new THREE.SpotLight();
-					light.target = new THREE.Object3D();
+					light.targeted = true;
 					break;
 
 				case 'ambient':

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -291,6 +291,7 @@ THREE.GLTFLoader = ( function () {
 
 				case 'directional':
 					lightNode = new THREE.DirectionalLight( color );
+					lightNode.target = new THREE.Object3D();
 					lightNode.target.position.set( 0, 0, 1 );
 					lightNode.add( lightNode.target );
 					break;
@@ -309,6 +310,7 @@ THREE.GLTFLoader = ( function () {
 					lightDef.spot.outerConeAngle = lightDef.spot.outerConeAngle !== undefined ? lightDef.spot.outerConeAngle : Math.PI / 4.0;
 					lightNode.angle = lightDef.spot.outerConeAngle;
 					lightNode.penumbra = 1.0 - lightDef.spot.innerConeAngle / lightDef.spot.outerConeAngle;
+					lightNode.target = new THREE.Object3D();
 					lightNode.target.position.set( 0, 0, 1 );
 					lightNode.add( lightNode.target );
 					break;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -291,7 +291,7 @@ THREE.GLTFLoader = ( function () {
 
 				case 'directional':
 					lightNode = new THREE.DirectionalLight( color );
-					lightNode.target = new THREE.Object3D();
+					lightNode.targeted = true;
 					lightNode.target.position.set( 0, 0, 1 );
 					lightNode.add( lightNode.target );
 					break;
@@ -310,7 +310,7 @@ THREE.GLTFLoader = ( function () {
 					lightDef.spot.outerConeAngle = lightDef.spot.outerConeAngle !== undefined ? lightDef.spot.outerConeAngle : Math.PI / 4.0;
 					lightNode.angle = lightDef.spot.outerConeAngle;
 					lightNode.penumbra = 1.0 - lightDef.spot.innerConeAngle / lightDef.spot.outerConeAngle;
-					lightNode.target = new THREE.Object3D();
+					lightNode.targeted = true;
 					lightNode.target.position.set( 0, 0, 1 );
 					lightNode.add( lightNode.target );
 					break;

--- a/examples/js/loaders/deprecated/LegacyGLTFLoader.js
+++ b/examples/js/loaders/deprecated/LegacyGLTFLoader.js
@@ -313,6 +313,7 @@ THREE.LegacyGLTFLoader = ( function () {
 				case "directional":
 					lightNode = new THREE.DirectionalLight( color );
 					lightNode.position.set( 0, 0, 1 );
+					lightNode.lookAt( 0, 0, 0 );
 					break;
 
 				case "point":
@@ -322,6 +323,7 @@ THREE.LegacyGLTFLoader = ( function () {
 				case "spot":
 					lightNode = new THREE.SpotLight( color );
 					lightNode.position.set( 0, 0, 1 );
+					lightNode.lookAt( 0, 0, 0 );
 					break;
 
 				case "ambient":

--- a/examples/js/renderers/WebGLDeferredRenderer.js
+++ b/examples/js/renderers/WebGLDeferredRenderer.js
@@ -890,14 +890,12 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		uniforms.lightAngle.value = originalLight.angle;
 		uniforms.lightColor.value.copy( originalLight.color );
 		uniforms.lightIntensity.value = originalLight.intensity;
-		uniforms.lightPositionVS.value.setFromMatrixPosition( originalLight.matrixWorld ).applyMatrix4( _currentCamera.matrixWorldInverse );
+		uniforms.lightPositionVS.value.setFromMatrixPosition( originalLight.matrixWorld )
+		uniforms.lightPositionVS.value.applyMatrix4( _currentCamera.matrixWorldInverse );
 
-		var vec = uniforms.lightDirectionVS.value;
-		var vec2 = _tmpVector3;
-
-		vec.setFromMatrixPosition( originalLight.matrixWorld );
-		vec2.setFromMatrixPosition( originalLight.target.matrixWorld );
-		vec.sub( vec2 ).normalize().transformDirection( _currentCamera.matrixWorldInverse );
+		uniforms.lightDirectionVS.value.set( 0, 0, - 1 );
+		uniforms.lightDirectionVS.value.transformDirection( originalLight.shadow.camera.matrixWorld );
+		uniforms.lightDirectionVS.value.transformDirection(  _currentCamera.matrixWorldInverse );
 
 		updateDeferredLightCommonUniforms( uniforms );
 
@@ -933,12 +931,9 @@ THREE.WebGLDeferredRenderer = function ( parameters ) {
 		uniforms.lightColor.value.copy( originalLight.color );
 		uniforms.lightIntensity.value = originalLight.intensity;
 
-		var vec = uniforms.lightDirectionVS.value;
-		var vec2 = _tmpVector3;
-
-		vec.setFromMatrixPosition( originalLight.matrixWorld );
-		vec2.setFromMatrixPosition( originalLight.target.matrixWorld );
-		vec.sub( vec2 ).normalize().transformDirection( _currentCamera.matrixWorldInverse );
+		uniforms.lightDirectionVS.value.set( 0, 0, - 1 );
+		uniforms.lightDirectionVS.value.transformDirection( originalLight.shadow.camera.matrixWorld );
+		uniforms.lightDirectionVS.value.transformDirection(  _currentCamera.matrixWorldInverse );
 
 		updateDeferredLightCommonUniforms( uniforms );
 

--- a/examples/misc_animation_authoring.html
+++ b/examples/misc_animation_authoring.html
@@ -60,6 +60,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 2 );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 

--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -97,6 +97,7 @@
 
 				dirLight = new THREE.DirectionalLight( 0xffffff );
 				dirLight.position.set( -1, 0, 1 ).normalize();
+				dirLight.lookAt( 0, 0, 0 );
 				scene.add( dirLight );
 
 				var materialNormalMap = new THREE.MeshPhongMaterial( {

--- a/examples/misc_controls_map.html
+++ b/examples/misc_controls_map.html
@@ -107,10 +107,12 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0x002288 );
 				light.position.set( - 1, - 1, - 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.AmbientLight( 0x222222 );

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -101,10 +101,12 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0x002288 );
 				light.position.set( - 1, - 1, - 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.AmbientLight( 0x222222 );

--- a/examples/misc_controls_trackball.html
+++ b/examples/misc_controls_trackball.html
@@ -100,10 +100,12 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0x002288 );
 				light.position.set( -1, -1, -1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.AmbientLight( 0x222222 );

--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -58,6 +58,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 2 );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var texture = new THREE.TextureLoader().load( 'textures/crate.gif', render );

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -179,6 +179,7 @@
 				// ---------------------------------------------------------------------
 				light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( 1, 1, 0 );
+				light.lookAt( 0, 0, 0 );
 				light.name = 'DirectionalLight';
 				scene1.add( light );
 

--- a/examples/misc_exporter_stl.html
+++ b/examples/misc_exporter_stl.html
@@ -66,6 +66,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff );
 				directionalLight.position.set( 0, 200, 100 );
+				directionalLight.lookAt( 0, 0, 0 );
 				directionalLight.castShadow = true;
 				directionalLight.shadow.camera.top = 180;
 				directionalLight.shadow.camera.bottom = - 100;

--- a/examples/misc_lights_test.html
+++ b/examples/misc_lights_test.html
@@ -98,6 +98,7 @@
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff );
 				directionalLight.position.set( 0, -70, 100 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 
 				setTimeout( function () {
 

--- a/examples/misc_ubiquity_test.html
+++ b/examples/misc_ubiquity_test.html
@@ -187,6 +187,7 @@
 
 				var directional = new THREE.DirectionalLight( 0xffff00 );
 				directional.position.set( - 1, 0.5, 0 );
+				directional.lookAt( 0, 0, 0 );
 				scene.add( directional );
 
 				canvasRenderer = new THREE.CanvasRenderer();

--- a/examples/models/obj/verify/verify.html
+++ b/examples/models/obj/verify/verify.html
@@ -128,6 +128,9 @@
 
 					directionalLight1.position.set( -100, -50, 100 );
 					directionalLight2.position.set( 100, 50, -100 );
+					
+					directionalLight1.lookAt( 0, 0, 0 );
+					directionalLight2.lookAt( 0, 0, 0 );
 
 					this.scene.add( directionalLight1 );
 					this.scene.add( directionalLight2 );

--- a/examples/svg_sandbox.html
+++ b/examples/svg_sandbox.html
@@ -173,6 +173,7 @@
 
 				var directional = new THREE.DirectionalLight( 0xffff00 );
 				directional.position.set( - 1, 0.5, 0 );
+				directional.lookAt( 0, 0, 0 );
 				scene.add( directional );
 
 				renderer = new THREE.SVGRenderer();

--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -129,6 +129,7 @@
 
 		light = new THREE.DirectionalLight( 0xffffff );
 		light.position.set( 0, 200, 100 );
+		light.lookAt( 0, 0, 0 );
 		light.castShadow = true;
 		light.shadow.camera.top = 180;
 		light.shadow.camera.bottom = -100;

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -118,6 +118,7 @@
 
 				light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0.5, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var sphere = new THREE.SphereBufferGeometry( 20, 32, 16 );

--- a/examples/webaudio_timing.html
+++ b/examples/webaudio_timing.html
@@ -117,6 +117,7 @@
 
 		var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.7 );
 		directionalLight.position.set( 0, 5, 5 );
+		directionalLight.lookAt( 0, 0, 0 );
 		scene.add( directionalLight );
 
 		var d = 5;

--- a/examples/webgl_animation_cloth.html
+++ b/examples/webgl_animation_cloth.html
@@ -111,6 +111,7 @@
 				light = new THREE.DirectionalLight( 0xdfebff, 1 );
 				light.position.set( 50, 200, 100 );
 				light.position.multiplyScalar( 1.3 );
+				light.lookAt( 0, 0, 0 );
 
 				light.castShadow = true;
 

--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -112,6 +112,7 @@
 
 				var light = new THREE.DirectionalLight( 0xebf3ff, 1.5 );
 				light.position.set( 0, 140, 500 ).multiplyScalar( 1.1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				light.castShadow = true;

--- a/examples/webgl_buffergeometry.html
+++ b/examples/webgl_buffergeometry.html
@@ -70,10 +70,12 @@
 
 				var light1 = new THREE.DirectionalLight( 0xffffff, 0.5 );
 				light1.position.set( 1, 1, 1 );
+				light1.lookAt( 0, 0, 0 );
 				scene.add( light1 );
 
 				var light2 = new THREE.DirectionalLight( 0xffffff, 1.5 );
 				light2.position.set( 0, -1, 0 );
+				light2.lookAt( 0, 0, 0 );
 				scene.add( light2 );
 
 				//

--- a/examples/webgl_buffergeometry_indexed.html
+++ b/examples/webgl_buffergeometry_indexed.html
@@ -67,10 +67,12 @@
 
 				var light1 = new THREE.DirectionalLight( 0xffffff, 0.5 );
 				light1.position.set( 1, 1, 1 );
+				light1.lookAt( 0, 0, 0 );
 				scene.add( light1 );
 
 				var light2 = new THREE.DirectionalLight( 0xffffff, 1 );
 				light2.position.set( 0, - 1, 0 );
+				light2.lookAt( 0, 0, 0 );
 				scene.add( light2 );
 
 				//

--- a/examples/webgl_buffergeometry_instancing_lambert.html
+++ b/examples/webgl_buffergeometry_instancing_lambert.html
@@ -234,6 +234,7 @@
 
 			var light = new THREE.DirectionalLight( 0xffffff, 0.4 );
 			light.position.set( 50, 40, 0 );
+			light.lookAt( 0, 0, 0 );
 
 			light.castShadow = true;
 			light.shadow.camera.left = - 40;

--- a/examples/webgl_buffergeometry_uint.html
+++ b/examples/webgl_buffergeometry_uint.html
@@ -70,10 +70,12 @@
 
 				var light1 = new THREE.DirectionalLight( 0xffffff, 0.5 );
 				light1.position.set( 1, 1, 1 );
+				light1.lookAt( 0, 0, 0 );
 				scene.add( light1 );
 
 				var light2 = new THREE.DirectionalLight( 0xffffff, 1.5 );
 				light2.position.set( 0, -1, 0 );
+				light2.lookAt( 0, 0, 0 );
 				scene.add( light2 );
 
 				//

--- a/examples/webgl_camera_array.html
+++ b/examples/webgl_camera_array.html
@@ -59,6 +59,7 @@
 
 				var light = new THREE.DirectionalLight();
 				light.position.set( 0.5, 0.5, 1 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				light.shadow.camera.zoom = 4; // tighter shadow map
 				scene.add( light );

--- a/examples/webgl_camera_cinematic.html
+++ b/examples/webgl_camera_cinematic.html
@@ -56,6 +56,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 0.35 );
 				light.position.set( 1, 1, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var geometry = new THREE.BoxBufferGeometry( 20, 20, 20 );

--- a/examples/webgl_camera_logarithmicdepthbuffer.html
+++ b/examples/webgl_camera_logarithmicdepthbuffer.html
@@ -184,6 +184,7 @@
 
 				var light = new THREE.DirectionalLight(0xffffff, 1);
 				light.position.set(100,100,100);
+				light.lookAt( 0, 0, 0 );
 				scene.add(light);
 
 				var materialargs = {

--- a/examples/webgl_clipping.html
+++ b/examples/webgl_clipping.html
@@ -42,6 +42,7 @@
 				spotLight.angle = Math.PI / 5;
 				spotLight.penumbra = 0.2;
 				spotLight.position.set( 2, 3, 3 );
+				spotLight.lookAt( 0, 0, 0 );
 				spotLight.castShadow = true;
 				spotLight.shadow.camera.near = 3;
 				spotLight.shadow.camera.far = 10;
@@ -51,6 +52,7 @@
 
 				var dirLight = new THREE.DirectionalLight( 0x55505a, 1 );
 				dirLight.position.set( 0, 3, 0 );
+				dirLight.lookAt( 0, 0, 0 );
 				dirLight.castShadow = true;
 				dirLight.shadow.camera.near = 1;
 				dirLight.shadow.camera.far = 10;

--- a/examples/webgl_clipping_advanced.html
+++ b/examples/webgl_clipping_advanced.html
@@ -177,6 +177,7 @@
 
 				var dirLight = new THREE.DirectionalLight( 0x55505a, 1 );
 				dirLight.position.set( 0, 2, 0 );
+				dirLight.lookAt( 0, 0, 0 );
 				dirLight.castShadow = true;
 				dirLight.shadow.camera.near = 1;
 				dirLight.shadow.camera.far = 10;

--- a/examples/webgl_decals.html
+++ b/examples/webgl_decals.html
@@ -118,10 +118,12 @@
 
 			var light = new THREE.DirectionalLight( 0xffddcc, 1 );
 			light.position.set( 1, 0.75, 0.5 );
+			light.lookAt( 0, 0, 0 );
 			scene.add( light );
 
 			var light = new THREE.DirectionalLight( 0xccccff, 1 );
 			light.position.set( -1, 0.75, -0.5 );
+			light.lookAt( 0, 0, 0 );
 			scene.add( light );
 
 			var geometry = new THREE.BufferGeometry();

--- a/examples/webgl_effects_parallaxbarrier.html
+++ b/examples/webgl_effects_parallaxbarrier.html
@@ -177,10 +177,12 @@
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 2 );
 				directionalLight.position.set( 2, 1.2, 10 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( - 2, 1.2, -10 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				pointLight = new THREE.PointLight( 0xffaa00, 2 );

--- a/examples/webgl_geometry_colors.html
+++ b/examples/webgl_geometry_colors.html
@@ -67,6 +67,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// shadow

--- a/examples/webgl_geometry_colors_lookuptable.html
+++ b/examples/webgl_geometry_colors_lookuptable.html
@@ -96,6 +96,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.7 );
 				directionalLight.position.set( 17, 9, 30 );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );

--- a/examples/webgl_geometry_extrude_shapes2.html
+++ b/examples/webgl_geometry_extrude_shapes2.html
@@ -418,6 +418,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.6 );
 				directionalLight.position.set( 0.75, 0.75, 1.0 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var ambientLight = new THREE.AmbientLight( 0xcccccc, 0.2 );

--- a/examples/webgl_geometry_extrude_splines.html
+++ b/examples/webgl_geometry_extrude_splines.html
@@ -178,6 +178,7 @@
 
 			var light = new THREE.DirectionalLight( 0xffffff );
 			light.position.set( 0, 0, 1 );
+			light.lookAt( 0, 0, 0 );
 			scene.add( light );
 
 			// tube

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -188,6 +188,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 2 );
 				directionalLight.position.set( 1, 1, 0.5 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );

--- a/examples/webgl_geometry_minecraft_ao.html
+++ b/examples/webgl_geometry_minecraft_ao.html
@@ -292,6 +292,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 2 );
 				directionalLight.position.set( 1, 1, 0.5 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				renderer = new THREE.WebGLRenderer();

--- a/examples/webgl_geometry_nurbs.html
+++ b/examples/webgl_geometry_nurbs.html
@@ -73,6 +73,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				group = new THREE.Group();

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -94,6 +94,7 @@
 				scene.add( new THREE.AmbientLight( 0xf0f0f0 ) );
 				var light = new THREE.SpotLight( 0xffffff, 1.5 );
 				light.position.set( 0, 1500, 200 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				light.shadow = new THREE.LightShadow( new THREE.PerspectiveCamera( 70, 1, 200, 2000 ) );
 				light.shadow.bias = -0.000222;

--- a/examples/webgl_geometry_text.html
+++ b/examples/webgl_geometry_text.html
@@ -145,6 +145,7 @@
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff, 0.125 );
 				dirLight.position.set( 0, 0, 1 ).normalize();
+				dirLight.lookAt( 0, 0, 0 );
 				scene.add( dirLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 1.5 );

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -263,10 +263,12 @@
 
 				var sun = new THREE.DirectionalLight( 0xFFFFFF, 1.0 );
 				sun.position.set( 300, 400, 175 );
+				sun.lookAt( 0, 0, 0 );
 				scene.add( sun );
 
 				var sun2 = new THREE.DirectionalLight( 0x40A040, 0.6 );
 				sun2.position.set( -100, 350, -200 );
+				sun2.lookAt( 0, 0, 0 );
 				scene.add( sun2 );
 
 				renderer = new THREE.WebGLRenderer();
@@ -461,7 +463,7 @@
 					gpuCompute.doRenderTarget( smoothShader, currentRenderTarget );
 
 				}
-				
+
 			}
 
 

--- a/examples/webgl_interactive_buffergeometry.html
+++ b/examples/webgl_interactive_buffergeometry.html
@@ -73,10 +73,12 @@
 
 				var light1 = new THREE.DirectionalLight( 0xffffff, 0.5 );
 				light1.position.set( 1, 1, 1 );
+				light1.lookAt( 0, 0, 0 );
 				scene.add( light1 );
 
 				var light2 = new THREE.DirectionalLight( 0xffffff, 1.5 );
 				light2.position.set( 0, -1, 0 );
+				light2.lookAt( 0, 0, 0 );
 				scene.add( light2 );
 
 				//

--- a/examples/webgl_interactive_cubes.html
+++ b/examples/webgl_interactive_cubes.html
@@ -50,6 +50,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( 1, 1, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var geometry = new THREE.BoxBufferGeometry( 20, 20, 20 );

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -81,6 +81,7 @@
 
 				var light = new THREE.SpotLight( 0xffffff, 1.5 );
 				light.position.set( 0, 500, 2000 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var pickingMaterial = new THREE.MeshBasicMaterial( { vertexColors: THREE.VertexColors } );

--- a/examples/webgl_interactive_cubes_ortho.html
+++ b/examples/webgl_interactive_cubes_ortho.html
@@ -52,6 +52,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( 1, 1, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var geometry = new THREE.BoxBufferGeometry( 20, 20, 20 );

--- a/examples/webgl_interactive_draggablecubes.html
+++ b/examples/webgl_interactive_draggablecubes.html
@@ -55,6 +55,7 @@
 
 				var light = new THREE.SpotLight( 0xffffff, 1.5 );
 				light.position.set( 0, 500, 2000 );
+				light.lookAt( 0, 0, 0 );
 				light.angle = Math.PI / 9;
 
 				light.castShadow = true;

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -101,6 +101,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff );
 				directionalLight.position.set( 1, 0.75, 0.5 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );

--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -113,8 +113,9 @@
 				// lights
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff, 0.05 );
-				dirLight.position.set( 0, -1, 0 ).normalize();
 				dirLight.color.setHSL( 0.1, 0.7, 0.5 );
+				dirLight.position.set( 0, -1, 0 ).normalize();
+				dirLight.lookAt( 0, 0, 0 );
 				scene.add( dirLight );
 
 				// lensflares

--- a/examples/webgl_lights_hemisphere.html
+++ b/examples/webgl_lights_hemisphere.html
@@ -124,6 +124,7 @@
 				dirLight.color.setHSL( 0.1, 1, 0.95 );
 				dirLight.position.set( -1, 1.75, 1 );
 				dirLight.position.multiplyScalar( 30 );
+				dirLight.lookAt( 0, 0, 0 );
 				scene.add( dirLight );
 
 				dirLight.castShadow = true;

--- a/examples/webgl_lights_pointlights2.html
+++ b/examples/webgl_lights_pointlights2.html
@@ -169,6 +169,7 @@
 
 				var dlight = new THREE.DirectionalLight( 0xffffff, 0.05 );
 				dlight.position.set( 0.5, 1, 0 ).normalize();
+				dlight.lookAt( 0, 0, 0 );
 				scene.add( dlight );
 
 				// RENDERER

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -82,6 +82,7 @@
 
 				spotLight = new THREE.SpotLight( 0xffffff, 1 );
 				spotLight.position.set( 15, 40, 35 );
+				spotLight.lookAt( 0, 0, 0 );
 				spotLight.angle = Math.PI / 4;
 				spotLight.penumbra = 0.05;
 				spotLight.decay = 2;

--- a/examples/webgl_lights_spotlights.html
+++ b/examples/webgl_lights_spotlights.html
@@ -132,6 +132,8 @@
 				newObj.shadow.mapSize.width = 1024;
 				newObj.shadow.mapSize.height = 1024;
 
+				newObj.target = scene;
+
 				return newObj;
 
 			}

--- a/examples/webgl_lights_spotlights.html
+++ b/examples/webgl_lights_spotlights.html
@@ -132,7 +132,7 @@
 				newObj.shadow.mapSize.width = 1024;
 				newObj.shadow.mapSize.height = 1024;
 
-				newObj.target = scene;
+				newObj.targeted = true;
 
 				return newObj;
 

--- a/examples/webgl_loader_3ds.html
+++ b/examples/webgl_loader_3ds.html
@@ -57,6 +57,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffeedd );
 				directionalLight.position.set( 0, 0, 2 );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				//3ds files dont store normal maps

--- a/examples/webgl_loader_assimp.html
+++ b/examples/webgl_loader_assimp.html
@@ -80,6 +80,7 @@
 
 			var light = new THREE.DirectionalLight( 0xffffff, 1 );
 			light.position.set( 0, 4, 4 ).normalize();
+			light.lookAt( 0, 0, 0 );
 			scene.add( light );
 
 			renderer = new THREE.WebGLRenderer( { antialias: true } );

--- a/examples/webgl_loader_assimp2json.html
+++ b/examples/webgl_loader_assimp2json.html
@@ -114,6 +114,7 @@
 				var directionalLight = new THREE.DirectionalLight( 0xeeeeee );
 				directionalLight.position.set( 1, 1, - 1 );
 				directionalLight.position.normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_awd.html
+++ b/examples/webgl_loader_awd.html
@@ -100,6 +100,7 @@
 				var directionalLight = new THREE.DirectionalLight(/*Math.random() * 0xffffff*/0xeeeeee );
 				directionalLight.position.set( .2, -1, .2 );
 				directionalLight.position.normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				pointLight = new THREE.PointLight( 0xffffff, .6 );

--- a/examples/webgl_loader_collada.html
+++ b/examples/webgl_loader_collada.html
@@ -88,6 +88,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.8 );
 				directionalLight.position.set( 1, 1, 0 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_collada_skinning.html
+++ b/examples/webgl_loader_collada_skinning.html
@@ -90,6 +90,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.8 );
 				directionalLight.position.set( 1, 1, - 1 );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_ctm.html
+++ b/examples/webgl_loader_ctm.html
@@ -100,6 +100,7 @@
 
 				var light = new THREE.SpotLight( 0xffeedd, 1.2, 650, Math.PI / 6 );
 				light.position.set( 0, -100, 500 );
+				light.lookAt( 0, 0, 0 );
 
 				light.castShadow = true;
 				light.shadow.mapWidth = 1024;

--- a/examples/webgl_loader_draco.html
+++ b/examples/webgl_loader_draco.html
@@ -78,6 +78,7 @@
 			light.penumbra = 0.5;
 			light.castShadow = true;
 			light.position.set( - 1, 1, 1 );
+			light.lookAt( 0, 0, 0 );
 			scene.add( light );
 
 			dracoLoader.load( 'models/draco/bunny.drc', function ( geometry ) {

--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -80,6 +80,7 @@
 
 				light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 200, 100 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				light.shadow.camera.top = 180;
 				light.shadow.camera.bottom = -100;

--- a/examples/webgl_loader_fbx_nurbs.html
+++ b/examples/webgl_loader_fbx_nurbs.html
@@ -74,6 +74,7 @@
 
 				light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 1, 0 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// grid

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -205,10 +205,12 @@
 
 					var directionalLight = new THREE.DirectionalLight( 0xdddddd, 4 );
 					directionalLight.position.set( 0, 0, 1 ).normalize();
+					directionalLight.lookAt( 0, 0, 0 );
 					scene.add( directionalLight );
 
 					spot1 = new THREE.SpotLight( 0xffffff, 1 );
 					spot1.position.set( 10, 20, 10 );
+					spot1.lookAt( 0, 0, 0 );
 					spot1.angle = 0.25;
 					spot1.penumbra = 0.75;
 

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -210,7 +210,7 @@
 
 					spot1 = new THREE.SpotLight( 0xffffff, 1 );
 					spot1.position.set( 10, 20, 10 );
-					spot1.lookAt( 0, 0, 0 );
+					spot1.targeted = true;
 					spot1.angle = 0.25;
 					spot1.penumbra = 0.75;
 

--- a/examples/webgl_loader_json_claraio.html
+++ b/examples/webgl_loader_json_claraio.html
@@ -69,6 +69,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffeedd );
 				directionalLight.position.set( 0, 0, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				// BEGIN Clara.io JSON loader code

--- a/examples/webgl_loader_json_objconverter.html
+++ b/examples/webgl_loader_json_objconverter.html
@@ -124,6 +124,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffeedd, 1.5 );
 				directionalLight.position.set( 0, -70, 100 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				// RENDERER

--- a/examples/webgl_loader_kmz.html
+++ b/examples/webgl_loader_kmz.html
@@ -66,6 +66,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0.5, 1.0, 0.5 ).normalize();
+				light.lookAt( 0, 0, 0 );
 
 				scene.add( light );
 

--- a/examples/webgl_loader_md2.html
+++ b/examples/webgl_loader_md2.html
@@ -95,6 +95,7 @@
 
 				var light = new THREE.SpotLight( 0xffffff, 5, 1000 );
 				light.position.set( 200, 250, 500 );
+				light.lookAt( 0, 0, 0 );
 				light.angle = 0.5;
 				light.penumbra = 0.5;
 
@@ -107,6 +108,7 @@
 
 				var light = new THREE.SpotLight( 0xffffff, 5, 1000 );
 				light.position.set( -100, 350, 350 );
+				light.lookAt( 0, 0, 0 );
 				light.angle = 0.5;
 				light.penumbra = 0.5;
 

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -101,6 +101,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 2.25 );
 				light.position.set( 200, 450, 500 );
+				light.lookAt( 0, 0, 0 );
 
 				light.castShadow = true;
 
@@ -241,6 +242,7 @@
 
 					var gyro = new THREE.Gyroscope();
 					gyro.add( camera );
+					light.target = new THREE.Object3D();
 					gyro.add( light, light.target );
 
 					characters[ Math.floor( nSkins / 2 ) ].root.add( gyro );

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -101,7 +101,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 2.25 );
 				light.position.set( 200, 450, 500 );
-				light.lookAt( 0, 0, 0 );
+				light.targeted = true;
 
 				light.castShadow = true;
 
@@ -242,7 +242,6 @@
 
 					var gyro = new THREE.Gyroscope();
 					gyro.add( camera );
-					light.target = new THREE.Object3D();
 					gyro.add( light, light.target );
 
 					characters[ Math.floor( nSkins / 2 ) ].root.add( gyro );

--- a/examples/webgl_loader_mmd.html
+++ b/examples/webgl_loader_mmd.html
@@ -90,6 +90,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0x887766 );
 				directionalLight.position.set( - 1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_mmd_audio.html
+++ b/examples/webgl_loader_mmd_audio.html
@@ -88,6 +88,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0x887766 );
 				directionalLight.position.set( - 1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_mmd_pose.html
+++ b/examples/webgl_loader_mmd_pose.html
@@ -81,6 +81,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0x887766 );
 				directionalLight.position.set( - 1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -87,6 +87,7 @@
 
 				var light = new THREE.DirectionalLight( 0xccccff, 1 );
 				light.position.set( - 1, 0.75, - 0.5 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				teapot = new THREE.TeapotBufferGeometry( 15, 18 );

--- a/examples/webgl_loader_nrrd.html
+++ b/examples/webgl_loader_nrrd.html
@@ -98,6 +98,7 @@
 				dirLight.position.set( 200, 200, 1000 ).normalize();
 
 				camera.add( dirLight );
+				dirLight.target = new THREE.Object3D();
 				camera.add( dirLight.target );
 
 				var loader = new THREE.NRRDLoader();

--- a/examples/webgl_loader_nrrd.html
+++ b/examples/webgl_loader_nrrd.html
@@ -98,7 +98,7 @@
 				dirLight.position.set( 200, 200, 1000 ).normalize();
 
 				camera.add( dirLight );
-				dirLight.target = new THREE.Object3D();
+				dirLight.targeted = true;
 				camera.add( dirLight.target );
 
 				var loader = new THREE.NRRDLoader();

--- a/examples/webgl_loader_obj2.html
+++ b/examples/webgl_loader_obj2.html
@@ -129,6 +129,9 @@
 					directionalLight1.position.set( -100, -50, 100 );
 					directionalLight2.position.set( 100, 50, -100 );
 
+					directionalLight1.lookAt( 0, 0, 0 );
+					directionalLight2.lookAt( 0, 0, 0 );
+
 					this.scene.add( directionalLight1 );
 					this.scene.add( directionalLight2 );
 					this.scene.add( ambientLight );

--- a/examples/webgl_loader_obj2_meshspray.html
+++ b/examples/webgl_loader_obj2_meshspray.html
@@ -419,6 +419,9 @@
 					directionalLight1.position.set( -100, -50, 100 );
 					directionalLight2.position.set( 100, 50, -100 );
 
+					directionalLight1.lookAt( 0, 0, 0 );
+					directionalLight2.lookAt( 0, 0, 0 );
+
 					this.scene.add( directionalLight1 );
 					this.scene.add( directionalLight2 );
 					this.scene.add( ambientLight );

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -135,6 +135,9 @@
 					directionalLight1.position.set( -100, -50, 100 );
 					directionalLight2.position.set( 100, 50, -100 );
 
+					directionalLight1.lookAt( 0, 0, 0 );
+					directionalLight2.lookAt( 0, 0, 0 );
+
 					this.scene.add( directionalLight1 );
 					this.scene.add( directionalLight2 );
 					this.scene.add( ambientLight );

--- a/examples/webgl_loader_obj2_run_director.html
+++ b/examples/webgl_loader_obj2_run_director.html
@@ -147,6 +147,9 @@
 					var directionalLight1 = new THREE.DirectionalLight( 0xC0C090 );
 					var directionalLight2 = new THREE.DirectionalLight( 0xC0C090 );
 
+					directionalLight1.lookAt( 0, 0, 0 );
+					directionalLight2.lookAt( 0, 0, 0 );
+
 					directionalLight1.position.set( -100, -50, 100 );
 					directionalLight2.position.set( 100, 50, -100 );
 

--- a/examples/webgl_loader_pdb.html
+++ b/examples/webgl_loader_pdb.html
@@ -118,10 +118,12 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 0.8 );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0xffffff, 0.5 );
 				light.position.set( -1, -1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				root = new THREE.Group();

--- a/examples/webgl_loader_ply.html
+++ b/examples/webgl_loader_ply.html
@@ -164,6 +164,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( color, intensity );
 				directionalLight.position.set( x, y, z );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				directionalLight.castShadow = true;

--- a/examples/webgl_loader_prwm.html
+++ b/examples/webgl_loader_prwm.html
@@ -109,6 +109,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffeedd );
 				directionalLight.position.set( 0, 0, 1 );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				// model

--- a/examples/webgl_loader_stl.html
+++ b/examples/webgl_loader_stl.html
@@ -198,6 +198,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( color, intensity );
 				directionalLight.position.set( x, y, z );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				directionalLight.castShadow = true;

--- a/examples/webgl_loader_texture_tga.html
+++ b/examples/webgl_loader_texture_tga.html
@@ -90,6 +90,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				//

--- a/examples/webgl_loader_ttf.html
+++ b/examples/webgl_loader_ttf.html
@@ -94,6 +94,7 @@
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff, 0.125 );
 				dirLight.position.set( 0, 0, 1 ).normalize();
+				dirLight.lookAt( 0, 0, 0 );
 				scene.add( dirLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 1.5 );

--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -73,6 +73,7 @@
 				dirLight.position.set( 200, 200, 1000 ).normalize();
 
 				camera.add( dirLight );
+				dirLight.target = new THREE.Object3D();
 				camera.add( dirLight.target );
 
 				var loader = new THREE.VRMLLoader();

--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -71,9 +71,9 @@
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff );
 				dirLight.position.set( 200, 200, 1000 ).normalize();
+				dirLight.targeted = true;
 
 				camera.add( dirLight );
-				dirLight.target = new THREE.Object3D();
 				camera.add( dirLight.target );
 
 				var loader = new THREE.VRMLLoader();

--- a/examples/webgl_loader_vtk.html
+++ b/examples/webgl_loader_vtk.html
@@ -82,6 +82,7 @@
 				dirLight.position.set( 200, 200, 1000 ).normalize();
 
 				camera.add( dirLight );
+				dirLight.target = new THREE.Object3D();
 				camera.add( dirLight.target );
 
 				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, side: THREE.DoubleSide } );

--- a/examples/webgl_loader_vtk.html
+++ b/examples/webgl_loader_vtk.html
@@ -80,9 +80,9 @@
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff );
 				dirLight.position.set( 200, 200, 1000 ).normalize();
+				dirLight.targeted = true;
 
 				camera.add( dirLight );
-				dirLight.target = new THREE.Object3D();
 				camera.add( dirLight.target );
 
 				var material = new THREE.MeshLambertMaterial( { color: 0xffffff, side: THREE.DoubleSide } );

--- a/examples/webgl_loader_x.html
+++ b/examples/webgl_loader_x.html
@@ -136,10 +136,12 @@
 
             var light = new THREE.DirectionalLight( 0xffffff, 1 );
             light.position.set( 10, 100, - 10 ).normalize();
+            light.lookAt( 0, 0, 0 );
             scene.add( light );
 
             var light2 = new THREE.DirectionalLight( 0x777666, 1 );
             light2.position.set( - 1, - 1, - 1 ).normalize();
+            light2.lookAt( 0, 0, 0 );
             scene.add( light2 );
 
             window.addEventListener( 'resize', onWindowResize, false );

--- a/examples/webgl_lod.html
+++ b/examples/webgl_lod.html
@@ -80,6 +80,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var geometry = [

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -124,6 +124,7 @@
 
 			light = new THREE.DirectionalLight( 0xffffff );
 			light.position.set( 0.5, 0.5, 1 );
+			light.lookAt( 0, 0, 0 );
 			scene.add( light );
 
 			pointLight = new THREE.PointLight( 0xff3300 );

--- a/examples/webgl_materials.html
+++ b/examples/webgl_materials.html
@@ -107,6 +107,7 @@
 				directionalLight.position.y = Math.random() - 0.5;
 				directionalLight.position.z = Math.random() - 0.5;
 				directionalLight.position.normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 
 				scene.add( directionalLight );
 

--- a/examples/webgl_materials_bumpmap.html
+++ b/examples/webgl_materials_bumpmap.html
@@ -94,6 +94,7 @@
 				spotLight = new THREE.SpotLight( 0xffffbb, 2 );
 				spotLight.position.set( 0.5, 0, 1 );
 				spotLight.position.multiplyScalar( 700 );
+				spotLight.lookAt( 0, 0, 0 );
 				scene.add( spotLight );
 
 				spotLight.castShadow = true;

--- a/examples/webgl_materials_bumpmap_skin.html
+++ b/examples/webgl_materials_bumpmap_skin.html
@@ -105,6 +105,7 @@
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( 500, 0, 500 );
+				directionalLight.lookAt( 0, 0, 0 );
 
 				directionalLight.castShadow = true;
 

--- a/examples/webgl_materials_cars.html
+++ b/examples/webgl_materials_cars.html
@@ -180,10 +180,12 @@
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 2 );
 				directionalLight.position.set( 2, 1.2, 10 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( -2, 1.2, -10 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				pointLight = new THREE.PointLight( 0xffaa00, 2 );

--- a/examples/webgl_materials_compile.html
+++ b/examples/webgl_materials_compile.html
@@ -22,7 +22,7 @@
 				text-align: center;
 				display:block;
 			}
-			
+
 			#waitScreen {
 				color: #000;
 			    position: absolute;
@@ -33,7 +33,7 @@
 			    width: 100px;
 			    height: 100px;
 			}
-			
+
 			.hide {
 				display:none;
 			}
@@ -72,7 +72,7 @@
 		var move = false;
 		var rtTexture, rtMaterial;
 		var meshes = [];
-		
+
 		document.getElementById( "preload" ).addEventListener( 'click', function() {
 
 			var hash = document.location.hash.substr( 1 );
@@ -82,7 +82,7 @@
 			} else {
 				window.location.hash = ""
 			}
-			
+
 			location.reload(true);
 
 		}, false );
@@ -112,10 +112,12 @@
 
 			var light = new THREE.DirectionalLight( 0xffddcc, 1 );
 			light.position.set( 1, 0.75, 0.5 );
+			light.lookAt( 0, 0, 0 );
 			scene.add( light );
 
 			var light = new THREE.DirectionalLight( 0xccccff, 1 );
 			light.position.set( - 1, 0.75, - 0.5 );
+			light.lookAt( 0, 0, 0 );
 			scene.add( light );
 
 			teapot = new THREE.TeapotBufferGeometry( 15, 18 );
@@ -123,14 +125,14 @@
 			var itemsonrow = 10;
 
 			for (var i = 0 ; i<  itemsonrow * itemsonrow; i ++ ){
-				
+
 				var mesh = new THREE.Mesh( teapot );
-				
+
 				mesh.position.x = 50 *(i%itemsonrow) -50*itemsonrow/2;
-				mesh.position.z = 50*Math.floor(i/itemsonrow)-150; 
+				mesh.position.z = 50*Math.floor(i/itemsonrow)-150;
 				updateMaterial(mesh);
 				scene.add( mesh );
-				meshes.push(mesh); 
+				meshes.push(mesh);
 			}
 
 			window.addEventListener( 'resize', onWindowResize, false );
@@ -140,16 +142,16 @@
 			if ( hash.length === 0 ) {
 
 				renderer.compile(scene,camera);
-				
+
 			}
-			
+
 			document.getElementById("waitScreen").className = "hide";
-			
+
 			setTimeout(function() {
-				
+
 				onWindowResize();
 				animate();
-				
+
 			}, 1);
 
 		}
@@ -205,8 +207,8 @@
 
 			mtl.color = new THREE.ColorNode( 0 );
 			mtl.emissive = cos;
-			
-			
+
+
 			var transformer = new THREE.ExpressionNode( "position + 0.0 * " + Math.random(), "vec3", [ ]);
 			mtl.transform = transformer;
 

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -162,6 +162,7 @@
 
 				spotLight = new THREE.SpotLight( 0xffffff, 1, 0, Math.PI/2 );
 				spotLight.position.set( 0, 1800, 1500 );
+				spotLight.target = new THREE.Object3D();
 				spotLight.target.position.set( 0, 0, 0 );
 				spotLight.castShadow = true;
 

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -162,7 +162,7 @@
 
 				spotLight = new THREE.SpotLight( 0xffffff, 1, 0, Math.PI/2 );
 				spotLight.position.set( 0, 1800, 1500 );
-				spotLight.target = new THREE.Object3D();
+				spotLight.targeted = true;
 				spotLight.target.position.set( 0, 0, 0 );
 				spotLight.castShadow = true;
 

--- a/examples/webgl_materials_lightmap.html
+++ b/examples/webgl_materials_lightmap.html
@@ -98,6 +98,7 @@
 				light.position.x = 300;
 				light.position.y = 250;
 				light.position.z = -500;
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// SKYDOME

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -39,7 +39,7 @@
 		<script src='js/geometries/TeapotBufferGeometry.js'></script>
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
-		
+
 		<script type="module">
 
 			import './js/nodes/THREE.Nodes.js';
@@ -131,10 +131,12 @@
 
 				var light = new THREE.DirectionalLight( 0xffddcc, 1 );
 				light.position.set( 1, 0.75, 0.5 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0xccccff, 1 );
 				light.position.set( - 1, 0.75, - 0.5 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				teapot = new THREE.TeapotBufferGeometry( 15, 18 );

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -116,6 +116,7 @@
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff );
 				directionalLight.position.set( 1, -0.5, -1 );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var textureLoader = new THREE.TextureLoader();

--- a/examples/webgl_materials_skin.html
+++ b/examples/webgl_materials_skin.html
@@ -102,10 +102,12 @@
 
 				directionalLight = new THREE.DirectionalLight( 0xffeedd, 1.5 );
 				directionalLight.position.set( 1, 0.5, 1 );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				directionalLight = new THREE.DirectionalLight( 0xddddff, 0.5 );
 				directionalLight.position.set( -1, 0.5, -1 );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				// MATERIALS

--- a/examples/webgl_materials_texture_anisotropy.html
+++ b/examples/webgl_materials_texture_anisotropy.html
@@ -98,10 +98,12 @@
 
 				var light1 = new THREE.DirectionalLight( 0xffffff, 2 );
 				light1.position.set( 1, 1, 1 );
+				light1.lookAt( 0, 0, 0 );
 				scene1.add( light1 );
 
 				var light2 = new THREE.DirectionalLight( 0xffffff, 2 );
 				light2.position.set( 1, 1, 1 );
+				light2.lookAt( 0, 0, 0 );
 				scene2.add( light2 );
 
 				// GROUND

--- a/examples/webgl_materials_translucency.html
+++ b/examples/webgl_materials_translucency.html
@@ -66,6 +66,7 @@
 
 			var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.03 );
 			directionalLight.position.set( 0.0, 0.5, 0.5 ).normalize();
+			directionalLight.lookAt( 0, 0, 0 );
 			scene.add( directionalLight );
 
 			var pointLight1 = new THREE.Mesh( new THREE.SphereBufferGeometry( 4, 8, 8 ), new THREE.MeshBasicMaterial( { color: 0x888888 } ) );

--- a/examples/webgl_materials_transparency.html
+++ b/examples/webgl_materials_transparency.html
@@ -120,12 +120,14 @@
 
 				var spotLight = new THREE.SpotLight( 0xff8888 );
 				spotLight.position.set( 100, 200, 100 );
+				spotLight.lookAt( 0, 0, 0 );
 				spotLight.angle = Math.PI / 6;
 				spotLight.penumbra = 0.9;
 				scene.add( spotLight );
 
 				var spotLight = new THREE.SpotLight( 0x8888ff );
 				spotLight.position.set( - 100, - 200, - 100 );
+				spotLight.lookAt( 0, 0, 0 );
 				spotLight.angle = Math.PI / 6;
 				spotLight.penumbra = 0.9;
 				scene.add( spotLight );

--- a/examples/webgl_materials_variations_basic.html
+++ b/examples/webgl_materials_variations_basic.html
@@ -156,6 +156,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_variations_lambert.html
+++ b/examples/webgl_materials_variations_lambert.html
@@ -156,6 +156,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -162,6 +162,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -182,6 +182,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -189,6 +189,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_variations_toon.html
+++ b/examples/webgl_materials_variations_toon.html
@@ -164,6 +164,7 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -95,6 +95,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0.5, 1, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				renderer = new THREE.WebGLRenderer();

--- a/examples/webgl_morphnormals.html
+++ b/examples/webgl_morphnormals.html
@@ -65,6 +65,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				//

--- a/examples/webgl_morphtargets_horse.html
+++ b/examples/webgl_morphtargets_horse.html
@@ -53,10 +53,12 @@
 
 				var light = new THREE.DirectionalLight( 0xefefff, 1.5 );
 				light.position.set( 1, 1, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0xffefef, 1.5 );
 				light.position.set( -1, -1, -1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var loader = new THREE.JSONLoader();

--- a/examples/webgl_morphtargets_human.html
+++ b/examples/webgl_morphtargets_human.html
@@ -79,12 +79,14 @@
 				light.position.set( 0, 140, 500 );
 				light.position.multiplyScalar( 1.1 );
 				light.color.setHSL( 0.6, 0.075, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				//
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( 0, - 1, 0 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// RENDERER

--- a/examples/webgl_multiple_canvases_circle.html
+++ b/examples/webgl_multiple_canvases_circle.html
@@ -222,6 +222,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var noof_balls = 51;

--- a/examples/webgl_multiple_canvases_complex.html
+++ b/examples/webgl_multiple_canvases_complex.html
@@ -131,6 +131,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// shadow

--- a/examples/webgl_multiple_canvases_grid.html
+++ b/examples/webgl_multiple_canvases_grid.html
@@ -148,6 +148,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// shadow

--- a/examples/webgl_multiple_elements.html
+++ b/examples/webgl_multiple_elements.html
@@ -150,6 +150,7 @@
 
 					var light = new THREE.DirectionalLight( 0xffffff, 0.5 );
 					light.position.set( 1, 1, 1 );
+					light.lookAt( 0, 0, 0 );
 					scene.add( light );
 
 					scenes.push( scene );

--- a/examples/webgl_multiple_renderers.html
+++ b/examples/webgl_multiple_renderers.html
@@ -59,10 +59,12 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0xffff00, 0.75 );
 				light.position.set( 0, 0, - 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// shadow

--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -119,6 +119,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// shadow

--- a/examples/webgl_octree_raycasting.html
+++ b/examples/webgl_octree_raycasting.html
@@ -97,6 +97,7 @@
 
 			var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.5 );
 			directionalLight.position.set( 1, 1, 2 ).normalize();
+			directionalLight.lookAt( 0, 0, 0 );
 			scene.add( directionalLight );
 
 			// create all objects

--- a/examples/webgl_physics_cloth.html
+++ b/examples/webgl_physics_cloth.html
@@ -111,6 +111,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( -7, 10, 15 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				var d = 10;
 				light.shadow.camera.left = -d;

--- a/examples/webgl_physics_convex_break.html
+++ b/examples/webgl_physics_convex_break.html
@@ -138,6 +138,7 @@
 
 			var light = new THREE.DirectionalLight( 0xffffff, 1 );
 			light.position.set( -10, 18, 5 );
+			light.lookAt( 0, 0, 0 );
 			light.castShadow = true;
 			var d = 14;
 			light.shadow.camera.left = -d;

--- a/examples/webgl_physics_rope.html
+++ b/examples/webgl_physics_rope.html
@@ -117,6 +117,7 @@
 
 			var light = new THREE.DirectionalLight( 0xffffff, 1 );
 			light.position.set( -10, 10, 5 );
+			light.lookAt( 0, 0, 0 );
 			light.castShadow = true;
 			var d = 10;
 			light.shadow.camera.left = -d;

--- a/examples/webgl_physics_terrain.html
+++ b/examples/webgl_physics_terrain.html
@@ -161,6 +161,7 @@
 
 						var light = new THREE.DirectionalLight( 0xffffff, 1 );
 						light.position.set( 100, 100, 50 );
+						light.lookAt( 0, 0, 0 );
 						light.castShadow = true;
 						var dLight = 200;
 						var sLight = dLight * 0.25;

--- a/examples/webgl_physics_volume.html
+++ b/examples/webgl_physics_volume.html
@@ -116,6 +116,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
 				light.position.set( -10, 10, 5 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				var d = 20;
 				light.shadow.camera.left = -d;

--- a/examples/webgl_postprocessing.html
+++ b/examples/webgl_postprocessing.html
@@ -69,6 +69,7 @@
 
 				light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// postprocessing

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -109,6 +109,7 @@
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff );
 				directionalLight.position.set( 0, -0.1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				sceneModel.add( directionalLight );
 
 				var loader = new THREE.JSONLoader();

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -226,10 +226,12 @@ Use WEBGL Depth buffer support?
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 2 );
 				directionalLight.position.set( 2, 1.2, 10 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( - 2, 1.2, -10 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				initPostprocessing();

--- a/examples/webgl_postprocessing_glitch.html
+++ b/examples/webgl_postprocessing_glitch.html
@@ -95,6 +95,7 @@
 
 				light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// postprocessing

--- a/examples/webgl_postprocessing_nodes.html
+++ b/examples/webgl_postprocessing_nodes.html
@@ -530,6 +530,7 @@
 
 				light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				//

--- a/examples/webgl_postprocessing_nodes_pass.html
+++ b/examples/webgl_postprocessing_nodes_pass.html
@@ -509,6 +509,7 @@
 
 				light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				// postprocessing

--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -169,6 +169,7 @@
 
 				var light = new THREE.DirectionalLight( 0xddffdd, 0.6 );
 				light.position.set( 1, 1, 1 );
+				light.lookAt( 0, 0, 0 );
 
 				light.castShadow = true;
 

--- a/examples/webgl_postprocessing_pixel.html
+++ b/examples/webgl_postprocessing_pixel.html
@@ -102,14 +102,17 @@
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff, .5 );
 				dirLight.position.set( 150, 75, 150 );
+				dirLight.lookAt( 0, 0, 0 );
 				scene.add( dirLight );
 
 				var dirLight2 = new THREE.DirectionalLight( 0xffffff, .2 );
 				dirLight2.position.set( - 150, 75, - 150 );
+				dirLight2.lookAt( 0, 0, 0 );
 				scene.add( dirLight2 );
 
 				var dirLight3 = new THREE.DirectionalLight( 0xffffff, .1 );
 				dirLight3.position.set( 0, 125, 0 );
+				dirLight3.lookAt( 0, 0, 0 );
 				scene.add( dirLight3 );
 
 				var geometries = [

--- a/examples/webgl_read_float_buffer.html
+++ b/examples/webgl_read_float_buffer.html
@@ -118,10 +118,12 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				sceneRTT.add( light );
 
 				light = new THREE.DirectionalLight( 0xffaaaa, 1.5 );
 				light.position.set( 0, 0, - 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				sceneRTT.add( light );
 
 				rtTexture = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, { minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, type: THREE.FloatType } );

--- a/examples/webgl_rtt.html
+++ b/examples/webgl_rtt.html
@@ -121,10 +121,12 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 0, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				sceneRTT.add( light );
 
 				light = new THREE.DirectionalLight( 0xffaaaa, 1.5 );
 				light.position.set( 0, 0, -1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				sceneRTT.add( light );
 
 				rtTexture = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, { minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBFormat } );

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -128,6 +128,7 @@
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, params.sunLight );
 				directionalLight.position.set( 2, 0, 10 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var atmoShader = {

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -244,6 +244,7 @@
 
 				sunLight = new THREE.SpotLight( 0xffffff, 0.3, 0, Math.PI/2 );
 				sunLight.position.set( 1000, 2000, 1000 );
+				sunLight.lookAt( 0, 0, 0 );
 
 				sunLight.castShadow = true;
 

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -108,7 +108,7 @@
 
 				light = new THREE.SpotLight( 0xffffff, 1, 0, Math.PI / 2 );
 				light.position.set( 0, 1500, 1000 );
-				light.target.position.set( 0, 0, 0 );
+				light.lookAt( 0, 0, 0 );
 
 				light.castShadow = true;
 

--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -167,6 +167,7 @@
 
 				var light = new THREE.DirectionalLight( 0xdfebff, 1.75 );
 				light.position.set( 2, 8, 4 );
+				light.lookAt( 0, 0, 0 );
 
 				light.castShadow = true;
 				light.shadow.mapSize.width = 1024;

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -103,7 +103,7 @@
 
 				light = new THREE.SpotLight( 0xffffff, 1, 0, Math.PI/2 );
 				light.position.set( 0, 1500, 1000 );
-				light.target.position.set( 0, 0, 0 );
+				light.lookAt( 0, 0, 0 );
 
 				light.castShadow = true;
 

--- a/examples/webgl_shadowmap_viewer.html
+++ b/examples/webgl_shadowmap_viewer.html
@@ -43,6 +43,7 @@
 			var dirLight, spotLight;
 			var torusKnot, cube;
 			var dirLightShadowMapViewer, spotLightShadowMapViewer;
+			var helpers;
 
 			init();
 			animate();
@@ -65,6 +66,8 @@
 				camera.position.set( 0, 15, 35 );
 
 				scene = new THREE.Scene();
+				helpers = new THREE.Group();
+				scene.add( helpers );
 
 				// Lights
 
@@ -74,19 +77,22 @@
 				spotLight.name = 'Spot Light';
 				spotLight.angle = Math.PI / 5;
 				spotLight.penumbra = 0.3;
-				spotLight.position.set( 10, 10, 5 );
+				spotLight.position.set( 2, 2, 2 );
+				spotLight.lookAt( 0, 0, 0 );
 				spotLight.castShadow = true;
-				spotLight.shadow.camera.near = 8;
-				spotLight.shadow.camera.far = 30;
+				spotLight.shadow.camera.near = 0.5;
+				spotLight.shadow.camera.far = 40;
 				spotLight.shadow.mapSize.width = 1024;
 				spotLight.shadow.mapSize.height = 1024;
-				scene.add( spotLight );
 
-				scene.add( new THREE.CameraHelper( spotLight.shadow.camera ) );
+
+				helpers.add( new THREE.CameraHelper( spotLight.shadow.camera ) );
+				helpers.add( new THREE.SpotLightHelper( spotLight ) );
 
 				dirLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				dirLight.name = 'Dir. Light';
 				dirLight.position.set( 0, 10, 0 );
+				dirLight.lookAt( 0, 0, 0 );
 				dirLight.castShadow = true;
 				dirLight.shadow.camera.near = 1;
 				dirLight.shadow.camera.far = 10;
@@ -98,7 +104,8 @@
 				dirLight.shadow.mapSize.height = 1024;
 				scene.add( dirLight );
 
-				scene.add( new THREE.CameraHelper( dirLight.shadow.camera ) );
+				helpers.add( new THREE.CameraHelper( dirLight.shadow.camera ) );
+				helpers.add( new THREE.DirectionalLightHelper( dirLight ) );
 
 				// Geometry
 				var geometry = new THREE.TorusKnotBufferGeometry( 25, 8, 75, 20 );
@@ -115,12 +122,24 @@
 				torusKnot.receiveShadow = true;
 				scene.add( torusKnot );
 
+
 				var geometry = new THREE.BoxBufferGeometry( 3, 3, 3 );
 				cube = new THREE.Mesh( geometry, material );
 				cube.position.set( 8, 3, 8 );
 				cube.castShadow = true;
 				cube.receiveShadow = true;
 				scene.add( cube );
+
+				var geometry = new THREE.BoxBufferGeometry( 1, 1, 1 );
+				target = new THREE.Mesh( geometry, material );
+				target.scale.multiplyScalar( 18 );
+				target.position.set( 30, 30, 30 );
+				target.castShadow = true;
+				target.receiveShadow = true;
+				torusKnot.add( target );
+
+				spotLight.target = target;
+				cube.add( spotLight );
 
 				var geometry = new THREE.BoxBufferGeometry( 10, 0.15, 10 );
 				var material = new THREE.MeshPhongMaterial( {
@@ -196,6 +215,7 @@
 
 			function renderScene() {
 
+				helpers.traverse( function( helper ) { if ( helper.update ) helper.update(); });
 				renderer.render( scene, camera );
 
 			}
@@ -215,8 +235,8 @@
 				renderShadowMapViewers();
 
 				torusKnot.rotation.x += 0.25 * delta;
-				torusKnot.rotation.y += 2 * delta;
-				torusKnot.rotation.z += 1 * delta;
+				torusKnot.rotation.y += 1 * delta;
+				torusKnot.rotation.z += 2 * delta;
 
 				cube.rotation.x += 0.25 * delta;
 				cube.rotation.y += 2 * delta;

--- a/examples/webgl_shadowmap_viewer.html
+++ b/examples/webgl_shadowmap_viewer.html
@@ -139,6 +139,7 @@
 				torusKnot.add( target );
 
 				spotLight.target = target;
+				spotLight.targeted = true;
 				cube.add( spotLight );
 
 				var geometry = new THREE.BoxBufferGeometry( 10, 0.15, 10 );

--- a/examples/webgl_terrain_dynamic.html
+++ b/examples/webgl_terrain_dynamic.html
@@ -276,6 +276,7 @@
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 1.15 );
 				directionalLight.position.set( 500, 2000, 0 );
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				pointLight = new THREE.PointLight( 0xff4400, 1.5 );

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -179,6 +179,7 @@
 
 				var spotLight = new THREE.SpotLight( 0xffffff );
 				spotLight.position.set( 50, 100, 50 );
+				spotLight.lookAt( 0, 0, 0 );
 				spotLight.angle = Math.PI / 7;
 				spotLight.decay = 2;
 				spotLight.distance = 300;

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -154,6 +154,7 @@
 
 			var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.6 );
 			directionalLight.position.set( - 1, 1, 1 );
+			directionalLight.lookAt( 0, 0, 0 );
 			scene.add( directionalLight );
 
 			// renderer

--- a/examples/webgldeferred_animation.html
+++ b/examples/webgldeferred_animation.html
@@ -162,10 +162,12 @@
 
 				var directionalLight = new THREE.DirectionalLight( 0x101010 );
 				directionalLight.position.set( -1, 1, 1 ).normalize();
+				directionalLight.lookAt( 0, 0, 0 );
 				scene.add( directionalLight );
 
 				var spotLight = new THREE.SpotLight( 0x404040 );
 				spotLight.position.set( 0, 50, 0 );
+				spotLight.lookAt( 0, 0, 0 );
 				scene.add( spotLight );
 
 			}

--- a/examples/webvr_ballshooter.html
+++ b/examples/webvr_ballshooter.html
@@ -72,6 +72,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 1, 1, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var geometry = new THREE.IcosahedronBufferGeometry( radius, 2 );

--- a/examples/webvr_cubes.html
+++ b/examples/webvr_cubes.html
@@ -86,6 +86,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 1, 1, 1 ).normalize();
+				light.lookAt( 0, 0, 0 );
 				scene.add( light );
 
 				var geometry = new THREE.BoxBufferGeometry( 0.15, 0.15, 0.15 );

--- a/examples/webvr_dragging.html
+++ b/examples/webvr_dragging.html
@@ -75,6 +75,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 6, 0 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				light.shadow.camera.top = 2;
 				light.shadow.camera.bottom = -2;

--- a/examples/webvr_paint.html
+++ b/examples/webvr_paint.html
@@ -111,6 +111,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 6, 0 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				light.shadow.camera.top = 2;
 				light.shadow.camera.bottom = -2;

--- a/examples/webvr_sandbox.html
+++ b/examples/webvr_sandbox.html
@@ -67,22 +67,20 @@
 
 				var light = new THREE.DirectionalLight( 0x8800ff );
 				light.position.set( - 1, 1.5, - 1.5 );
+				light.lookAt( 0, 0, - 2 );
 				light.castShadow = true;
 				light.shadow.camera.zoom = 4;
 				scene.add( light );
-				light.target.position.set( 0, 0, - 2 );
-				scene.add( light.target );
 
 				var helper = new THREE.CameraHelper( light.shadow.camera );
 				// scene.add( helper );
 
 				var light = new THREE.DirectionalLight( 0xff0000 );
 				light.position.set( 1, 1.5, - 2.5 );
+				light.lookAt( 0, 0, - 2 );
 				light.castShadow = true;
 				light.shadow.camera.zoom = 4;
 				scene.add( light );
-				light.target.position.set( 0, 0, - 2 );
-				scene.add( light.target );
 
 				var helper = new THREE.CameraHelper( light.shadow.camera );
 				// scene.add( helper );

--- a/examples/webvr_sculpt.html
+++ b/examples/webvr_sculpt.html
@@ -93,6 +93,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 6, 0 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				light.shadow.camera.top = 2;
 				light.shadow.camera.bottom = -2;

--- a/examples/webvr_vive_paint.html
+++ b/examples/webvr_vive_paint.html
@@ -114,6 +114,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 6, 0 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				light.shadow.camera.top = 2;
 				light.shadow.camera.bottom = -2;

--- a/examples/webvr_vive_sculpt.html
+++ b/examples/webvr_vive_sculpt.html
@@ -95,6 +95,7 @@
 
 				var light = new THREE.DirectionalLight( 0xffffff );
 				light.position.set( 0, 6, 0 );
+				light.lookAt( 0, 0, 0 );
 				light.castShadow = true;
 				light.shadow.camera.top = 2;
 				light.shadow.camera.bottom = -2;

--- a/src/helpers/DirectionalLightHelper.js
+++ b/src/helpers/DirectionalLightHelper.js
@@ -4,7 +4,6 @@
  * @author WestLangley / http://github.com/WestLangley
  */
 
-import { Vector3 } from '../math/Vector3.js';
 import { Object3D } from '../core/Object3D.js';
 import { Line } from '../objects/Line.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
@@ -18,7 +17,6 @@ function DirectionalLightHelper( light, size, color ) {
 	this.light = light;
 	this.light.updateMatrixWorld();
 
-	this.matrix = light.matrixWorld;
 	this.matrixAutoUpdate = false;
 
 	this.color = color;
@@ -40,7 +38,7 @@ function DirectionalLightHelper( light, size, color ) {
 	this.add( this.lightPlane );
 
 	geometry = new BufferGeometry();
-	geometry.addAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 0, 1 ], 3 ) );
+	geometry.addAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 0, - 1 ], 3 ) );
 
 	this.targetLine = new Line( geometry, material );
 	this.add( this.targetLine );
@@ -63,36 +61,22 @@ DirectionalLightHelper.prototype.dispose = function () {
 
 DirectionalLightHelper.prototype.update = function () {
 
-	var v1 = new Vector3();
-	var v2 = new Vector3();
-	var v3 = new Vector3();
+	this.matrix.copy( this.light.shadow.camera.matrixWorld );
+	this.matrix.multiply( this.light.shadow.camera.projectionMatrixInverse );
 
-	return function update() {
+	if ( this.color !== undefined ) {
 
-		v1.setFromMatrixPosition( this.light.matrixWorld );
-		v2.setFromMatrixPosition( this.light.target.matrixWorld );
-		v3.subVectors( v2, v1 );
+		this.lightPlane.material.color.set( this.color );
+		this.targetLine.material.color.set( this.color );
 
-		this.lightPlane.lookAt( v3 );
+	} else {
 
-		if ( this.color !== undefined ) {
+		this.lightPlane.material.color.copy( this.light.color );
+		this.targetLine.material.color.copy( this.light.color );
 
-			this.lightPlane.material.color.set( this.color );
-			this.targetLine.material.color.set( this.color );
+	}
 
-		} else {
-
-			this.lightPlane.material.color.copy( this.light.color );
-			this.targetLine.material.color.copy( this.light.color );
-
-		}
-
-		this.targetLine.lookAt( v3 );
-		this.targetLine.scale.z = v3.length();
-
-	};
-
-}();
+};
 
 
 export { DirectionalLightHelper };

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -4,7 +4,6 @@
  * @author WestLangley / http://github.com/WestLangley
  */
 
-import { Vector3 } from '../math/Vector3.js';
 import { Object3D } from '../core/Object3D.js';
 import { LineSegments } from '../objects/LineSegments.js';
 import { LineBasicMaterial } from '../materials/LineBasicMaterial.js';
@@ -18,7 +17,6 @@ function SpotLightHelper( light, color ) {
 	this.light = light;
 	this.light.updateMatrixWorld();
 
-	this.matrix = light.matrixWorld;
 	this.matrixAutoUpdate = false;
 
 	this.color = color;
@@ -26,11 +24,11 @@ function SpotLightHelper( light, color ) {
 	var geometry = new BufferGeometry();
 
 	var positions = [
-		0, 0, 0, 	0, 0, 1,
-		0, 0, 0, 	1, 0, 1,
-		0, 0, 0,	- 1, 0, 1,
-		0, 0, 0, 	0, 1, 1,
-		0, 0, 0, 	0, - 1, 1
+		0, 0, 1, 	0, 0, - 1,
+		1, 0, 1, 	1, 0, - 1,
+		- 1, 0, 1,	- 1, 0, - 1,
+		0, 1, 1, 	0, 1, - 1,
+		0, - 1, 1, 	0, - 1, - 1
 	];
 
 	for ( var i = 0, j = 1, l = 32; i < l; i ++, j ++ ) {
@@ -39,6 +37,8 @@ function SpotLightHelper( light, color ) {
 		var p2 = ( j / l ) * Math.PI * 2;
 
 		positions.push(
+			Math.cos( p1 ), Math.sin( p1 ), - 1,
+			Math.cos( p2 ), Math.sin( p2 ), - 1,
 			Math.cos( p1 ), Math.sin( p1 ), 1,
 			Math.cos( p2 ), Math.sin( p2 ), 1
 		);
@@ -68,36 +68,20 @@ SpotLightHelper.prototype.dispose = function () {
 
 SpotLightHelper.prototype.update = function () {
 
-	var vector = new Vector3();
-	var vector2 = new Vector3();
+	this.matrix.copy( this.light.shadow.camera.matrixWorld );
+	this.matrix.multiply( this.light.shadow.camera.projectionMatrixInverse );
 
-	return function update() {
+	if ( this.color !== undefined ) {
 
-		this.light.updateMatrixWorld();
+		this.cone.material.color.set( this.color );
 
-		var coneLength = this.light.distance ? this.light.distance : 1000;
-		var coneWidth = coneLength * Math.tan( this.light.angle );
+	} else {
 
-		this.cone.scale.set( coneWidth, coneWidth, coneLength );
+		this.cone.material.color.copy( this.light.color );
 
-		vector.setFromMatrixPosition( this.light.matrixWorld );
-		vector2.setFromMatrixPosition( this.light.target.matrixWorld );
+	}
 
-		this.cone.lookAt( vector2.sub( vector ) );
-
-		if ( this.color !== undefined ) {
-
-			this.cone.material.color.set( this.color );
-
-		} else {
-
-			this.cone.material.color.copy( this.light.color );
-
-		}
-
-	};
-
-}();
+};
 
 
 export { SpotLightHelper };

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -17,7 +17,7 @@ function DirectionalLight( color, intensity ) {
 	this.lookAt( 0, 0, 0 );
 	this.updateMatrix();
 
-	this.target = new Object3D();
+	this.target = undefined;
 
 	this.shadow = new DirectionalLightShadow();
 

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -14,6 +14,7 @@ function DirectionalLight( color, intensity ) {
 	this.type = 'DirectionalLight';
 
 	this.position.copy( Object3D.DefaultUp );
+	this.lookAt( 0, 0, 0 );
 	this.updateMatrix();
 
 	this.target = new Object3D();
@@ -32,7 +33,7 @@ DirectionalLight.prototype = Object.assign( Object.create( Light.prototype ), {
 
 		Light.prototype.copy.call( this, source );
 
-		this.target = source.target.clone();
+		this.target = source.target ? source.target.clone() : undefined;
 
 		this.shadow = source.shadow.clone();
 

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -14,10 +14,10 @@ function DirectionalLight( color, intensity ) {
 	this.type = 'DirectionalLight';
 
 	this.position.copy( Object3D.DefaultUp );
-	this.lookAt( 0, 0, 0 );
 	this.updateMatrix();
 
-	this.target = undefined;
+	this.target = new Object3D();
+	this.targeted = false;
 
 	this.shadow = new DirectionalLightShadow();
 
@@ -33,7 +33,7 @@ DirectionalLight.prototype = Object.assign( Object.create( Light.prototype ), {
 
 		Light.prototype.copy.call( this, source );
 
-		this.target = source.target ? source.target.clone() : undefined;
+		this.target = source.target.clone();
 
 		this.shadow = source.shadow.clone();
 

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -16,7 +16,7 @@ function SpotLight( color, intensity, distance, angle, penumbra, decay ) {
 	this.lookAt( 0, 0, 0 );
 	this.updateMatrix();
 
-	this.target = new Object3D();
+	this.target = undefined;
 
 	Object.defineProperty( this, 'power', {
 		get: function () {

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -13,10 +13,10 @@ function SpotLight( color, intensity, distance, angle, penumbra, decay ) {
 	this.type = 'SpotLight';
 
 	this.position.copy( Object3D.DefaultUp );
-	this.lookAt( 0, 0, 0 );
 	this.updateMatrix();
 
-	this.target = undefined;
+	this.target = new Object3D();
+	this.targeted = false;
 
 	Object.defineProperty( this, 'power', {
 		get: function () {
@@ -59,7 +59,7 @@ SpotLight.prototype = Object.assign( Object.create( Light.prototype ), {
 		this.penumbra = source.penumbra;
 		this.decay = source.decay;
 
-		this.target = source.target ? source.target.clone() : undefined;
+		this.target = source.target.clone();
 
 		this.shadow = source.shadow.clone();
 

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -13,6 +13,7 @@ function SpotLight( color, intensity, distance, angle, penumbra, decay ) {
 	this.type = 'SpotLight';
 
 	this.position.copy( Object3D.DefaultUp );
+	this.lookAt( 0, 0, 0 );
 	this.updateMatrix();
 
 	this.target = new Object3D();
@@ -58,7 +59,7 @@ SpotLight.prototype = Object.assign( Object.create( Light.prototype ), {
 		this.penumbra = source.penumbra;
 		this.decay = source.decay;
 
-		this.target = source.target.clone();
+		this.target = source.target ? source.target.clone() : undefined;
 
 		this.shadow = source.shadow.clone();
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -135,7 +135,6 @@ function WebGLLights() {
 
 	};
 
-	var vector3 = new Vector3();
 	var matrix4 = new Matrix4();
 	var matrix42 = new Matrix4();
 
@@ -172,9 +171,8 @@ function WebGLLights() {
 				var uniforms = cache.get( light );
 
 				uniforms.color.copy( light.color ).multiplyScalar( light.intensity );
-				uniforms.direction.setFromMatrixPosition( light.matrixWorld );
-				vector3.setFromMatrixPosition( light.target.matrixWorld );
-				uniforms.direction.sub( vector3 );
+				uniforms.direction.set( 0, 0, 1 );
+				uniforms.direction.transformDirection( light.shadow.camera.matrixWorld );
 				uniforms.direction.transformDirection( viewMatrix );
 
 				uniforms.shadow = light.castShadow;
@@ -205,9 +203,8 @@ function WebGLLights() {
 				uniforms.color.copy( color ).multiplyScalar( intensity );
 				uniforms.distance = distance;
 
-				uniforms.direction.setFromMatrixPosition( light.matrixWorld );
-				vector3.setFromMatrixPosition( light.target.matrixWorld );
-				uniforms.direction.sub( vector3 );
+				uniforms.direction.set( 0, 0, 1 );
+				uniforms.direction.transformDirection( light.shadow.camera.matrixWorld );
 				uniforms.direction.transformDirection( viewMatrix );
 
 				uniforms.coneCos = Math.cos( light.angle );

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -35,6 +35,8 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 	var shadowSide = { 0: BackSide, 1: FrontSide, 2: DoubleSide };
 
+	var cameraConvention = new Vector3( - 1, 1, - 1 );
+
 	var cubeDirections = [
 		new Vector3( 1, 0, 0 ), new Vector3( - 1, 0, 0 ), new Vector3( 0, 0, 1 ),
 		new Vector3( 0, 0, - 1 ), new Vector3( 0, 1, 0 ), new Vector3( 0, - 1, 0 )
@@ -202,9 +204,19 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 				faceCount = 1;
 
-				_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
-				shadowCamera.lookAt( _lookTarget );
-				shadowCamera.updateMatrixWorld();
+				if ( light.target ) {
+
+					_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
+					shadowCamera.lookAt( _lookTarget );
+					shadowCamera.updateMatrixWorld();
+
+				} else if ( shadowCamera.matrixAutoUpdate ) {
+
+					shadowCamera.matrixWorld.copy( light.matrixWorld ).scale( cameraConvention );
+					shadowCamera.matrixWorldInverse.getInverse( shadowCamera.matrixWorld );
+					shadowCamera.matrixWorldNeedsUpdate = false;
+
+				}
 
 				// compute shadow matrix
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -22,7 +22,6 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 		_maxShadowMapSize = new Vector2( maxTextureSize, maxTextureSize ),
 
 		_lookTarget = new Vector3(),
-		_lightPositionWorld = new Vector3(),
 
 		_MorphingFlag = 1,
 		_SkinningFlag = 2,
@@ -188,8 +187,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 			var shadowMap = shadow.map;
 			var shadowMatrix = shadow.matrix;
 
-			_lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
-			shadowCamera.position.copy( _lightPositionWorld );
+			shadowCamera.position.setFromMatrixPosition( light.matrixWorld );
 
 			if ( isPointLight ) {
 
@@ -198,7 +196,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 				// for point lights we set the shadow matrix to be a translation-only matrix
 				// equal to inverse of the light's position
 
-				shadowMatrix.makeTranslation( - _lightPositionWorld.x, - _lightPositionWorld.y, - _lightPositionWorld.z );
+				shadowMatrix.makeTranslation( - shadowCamera.position.x, - shadowCamera.position.y, - shadowCamera.position.z );
 
 			} else {
 
@@ -250,7 +248,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 				// set object matrices & frustum culling
 
-				renderObject( scene, camera, shadowCamera, isPointLight );
+				renderObject( scene, camera, isPointLight, shadowCamera );
 
 			}
 
@@ -260,7 +258,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 	};
 
-	function getDepthMaterial( object, material, isPointLight, lightPositionWorld, shadowCameraNear, shadowCameraFar ) {
+	function getDepthMaterial( object, material, isPointLight, shadowCamera ) {
 
 		var geometry = object.geometry;
 
@@ -360,9 +358,9 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 		if ( isPointLight && result.isMeshDistanceMaterial ) {
 
-			result.referencePosition.copy( lightPositionWorld );
-			result.nearDistance = shadowCameraNear;
-			result.farDistance = shadowCameraFar;
+			result.referencePosition.copy( shadowCamera.position );
+			result.nearDistance = shadowCamera.near;
+			result.farDistance = shadowCamera.far;
 
 		}
 
@@ -370,7 +368,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 	}
 
-	function renderObject( object, camera, shadowCamera, isPointLight ) {
+	function renderObject( object, camera, isPointLight, shadowCamera ) {
 
 		if ( object.visible === false ) return;
 
@@ -396,7 +394,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 						if ( groupMaterial && groupMaterial.visible ) {
 
-							var depthMaterial = getDepthMaterial( object, groupMaterial, isPointLight, _lightPositionWorld, shadowCamera.near, shadowCamera.far );
+							var depthMaterial = getDepthMaterial( object, groupMaterial, isPointLight, shadowCamera );
 							_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, group );
 
 						}
@@ -405,7 +403,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 				} else if ( material.visible ) {
 
-					var depthMaterial = getDepthMaterial( object, material, isPointLight, _lightPositionWorld, shadowCamera.near, shadowCamera.far );
+					var depthMaterial = getDepthMaterial( object, material, isPointLight, shadowCamera );
 					_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, null );
 
 				}
@@ -418,7 +416,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 		for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-			renderObject( children[ i ], camera, shadowCamera, isPointLight );
+			renderObject( children[ i ], camera, isPointLight, shadowCamera );
 
 		}
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -204,7 +204,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 				faceCount = 1;
 
-				if ( light.target ) {
+				if ( light.targeted ) {
 
 					_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
 					shadowCamera.lookAt( _lookTarget );


### PR DESCRIPTION
(This PR is the geometric counterpart of #14621)

This enables the use of custom user-provided OrthographicCameras for DirectionalLights and PerspectiveCameras for SpotLights, by making optional the 2 hardwired updates that were updating the cameras at each frame : 
1. Light.target was unconditionnaly tracking an Object3D using its matrixWorld
2. ~~SpotLightShadow.update was modifying the shadowCamera to have (most notably) its fov fit its cone angle.~~

Possible use-cases are, combined with #14621, to do image-based rendering by backprojecting images as textured lights, with photogrammetrically-estimated camera parameters, or to more simply implement a slide or video projector with user-provided intrinsics/extrinsics (focal, aspect, position, rotation...).

Proposals :
1. make target tracking opt-in : the default is undefined (no tracking). examples have been modified to either make a light.lookAt or assign a target object
2. ~~make cone fitting opt-out : SpotLightShadow.cameraAutoUpdate is introduced (default: true) to disable the cone fitting of the camera.~~

WDYT?

--
Edit : item 2 moved to its own PR (#14663)