### PR TITLE
SpotLightShadow.cameraAutoUpdate / Light.shadowAutoUpdate

### DIFF
--- a/docs/api/lights/Light.html
+++ b/docs/api/lights/Light.html
@@ -54,6 +54,12 @@
 			You should not change this, as it used internally for optimisation.
 		</p>
 
+		<h3>[property:Boolean shadowAutoUpdate]</h3>
+		<p>
+			If set to *true*, its light shadow will be updated each frame using
+			[page:LightShadow.update LightShadow.update]) (e.g. [page:SpotLightShadow.update SpotLightShadow.update]).
+			The default is *false*.
+		</p>
 
 		<h2>Methods</h2>
 		<p>

--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -175,6 +175,13 @@ light.target = targetObject;
 			The spotlight will now track the target object.
 		</p>
 
+		<h3>[property:Boolean shadowAutoUpdate]</h3>
+		<p>
+			If set to *true*, the shadow camera will be automatically updated each frame to match the
+			geometry of the spotLight (a square frustum tightly fitting the cone of the spot light defined
+			by the [page:.angle angle] and [page:.distance distance] properties).
+			The default is *true*.
+		</p>
 
 		<h2>Methods</h2>
 

--- a/docs/api/lights/SpotLight.html
+++ b/docs/api/lights/SpotLight.html
@@ -177,9 +177,7 @@ light.target = targetObject;
 
 		<h3>[property:Boolean shadowAutoUpdate]</h3>
 		<p>
-			If set to *true*, the shadow camera will be automatically updated each frame to match the
-			geometry of the spotLight (a square frustum tightly fitting the cone of the spot light defined
-			by the [page:.angle angle] and [page:.distance distance] properties).
+			If set to *true*, the shadow camera frustum will be automatically sized to match the cone of the spotLight.
 			The default is *true*.
 		</p>
 

--- a/docs/api/lights/shadows/LightShadow.html
+++ b/docs/api/lights/shadows/LightShadow.html
@@ -134,6 +134,11 @@ scene.add( helper );
 		Serialize this LightShadow.
 		</p>
 
+		<h3>[method:void update]( [param:Light light] )</h3>
+		<p>
+		Updates this LightShadow (e.g. [page:SpotLightShadow.update SpotLightShadow.update]).
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/lights/[name].js src/lights/[name].js]

--- a/docs/api/lights/shadows/LightShadow.html
+++ b/docs/api/lights/shadows/LightShadow.html
@@ -137,6 +137,7 @@ scene.add( helper );
 		<h3>[method:void update]( [param:Light light] )</h3>
 		<p>
 		Updates this LightShadow (e.g. [page:SpotLightShadow.update SpotLightShadow.update]).
+		The default [page:.update update] method does nothing.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/lights/shadows/SpotLightShadow.html
+++ b/docs/api/lights/shadows/SpotLightShadow.html
@@ -79,6 +79,14 @@ scene.add( helper );
 
 	 </p>
 
+	 <h3>[property:Boolean cameraAutoUpdate]</h3>
+	 <p>
+		 If set to *true*, the shadow camera will be automatically updated each frame to match the
+		 geometry of the spotLight (a square frustum tightly fitting the cone of the spot light defined
+		 by the [page:.angle angle] and [page:.distance distance] properties).
+		 The default is *true*.
+	 </p>
+
 	 <h3>[property:Boolean isSpotLightShadow]</h3>
 	 <p>
 		 Used to check whether this or derived classes are spot light shadows. Default is *true*.<br /><br />

--- a/docs/api/lights/shadows/SpotLightShadow.html
+++ b/docs/api/lights/shadows/SpotLightShadow.html
@@ -79,25 +79,10 @@ scene.add( helper );
 
 	 </p>
 
-	 <h3>[property:Boolean cameraAutoUpdate]</h3>
-	 <p>
-		 If set to *true*, the shadow camera will be automatically updated each frame to match the
-		 geometry of the spotLight (a square frustum tightly fitting the cone of the spot light defined
-		 by the [page:.angle angle] and [page:.distance distance] properties).
-		 The default is *true*.
-	 </p>
-
-	 <h3>[property:Boolean isSpotLightShadow]</h3>
-	 <p>
-		 Used to check whether this or derived classes are spot light shadows. Default is *true*.<br /><br />
-
-		 You should not change this, as it used internally for optimisation.
-	 </p>
-
 		<h2>Methods</h2>
 		See the base [page:LightShadow LightShadow] class for common methods.
 
-		<h3>[method:SpotLightShadow update]( [param:SpotLight light] )</h3>
+		<h3>[method:void update]( [param:SpotLight light] )</h3>
 		<p>
 		Updates the internal perspective [page:.camera camera] based on the passed in [page:SpotLight light].
 		</p>

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -95,7 +95,11 @@
 				var light = new THREE.SpotLight( 0xffffff, 1.5 );
 				light.position.set( 0, 1500, 200 );
 				light.castShadow = true;
-				light.shadow = new THREE.LightShadow( new THREE.PerspectiveCamera( 70, 1, 200, 2000 ) );
+				light.shadow.camera.fov = 70;
+				light.shadow.camera.aspect = 1;
+				light.shadow.camera.near = 200;
+				light.shadow.camera.far = 2000;
+				light.shadow.cameraAutoUpdate = false;
 				light.shadow.bias = -0.000222;
 				light.shadow.mapSize.width = 1024;
 				light.shadow.mapSize.height = 1024;

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -99,7 +99,7 @@
 				light.shadow.camera.aspect = 1;
 				light.shadow.camera.near = 200;
 				light.shadow.camera.far = 2000;
-				light.shadow.cameraAutoUpdate = false;
+				light.shadowAutoUpdate = false;
 				light.shadow.bias = -0.000222;
 				light.shadow.mapSize.width = 1024;
 				light.shadow.mapSize.height = 1024;

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -139,6 +139,8 @@
 
 			function render() {
 
+				spotLight.shadow.update(spotLight);
+
 				lightHelper.update();
 
 				shadowCameraHelper.update();
@@ -157,7 +159,8 @@
 					distance: spotLight.distance,
 					angle: spotLight.angle,
 					penumbra: spotLight.penumbra,
-					decay: spotLight.decay
+					decay: spotLight.decay,
+					cameraAutoUpdate: spotLight.shadow.cameraAutoUpdate
 				}
 
 				gui.addColor( params, 'light color' ).onChange( function ( val ) {
@@ -199,6 +202,13 @@
 				gui.add( params, 'decay', 1, 2 ).onChange( function ( val ) {
 
 					spotLight.decay = val;
+					render();
+
+				} );
+
+				gui.add( params, 'cameraAutoUpdate').onChange( function ( val ) {
+
+					spotLight.shadow.cameraAutoUpdate = val;
 					render();
 
 				} );

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -139,8 +139,6 @@
 
 			function render() {
 
-				spotLight.shadow.update(spotLight);
-
 				lightHelper.update();
 
 				shadowCameraHelper.update();
@@ -160,7 +158,7 @@
 					angle: spotLight.angle,
 					penumbra: spotLight.penumbra,
 					decay: spotLight.decay,
-					cameraAutoUpdate: spotLight.shadow.cameraAutoUpdate
+					shadowAutoUpdate: spotLight.shadowAutoUpdate
 				}
 
 				gui.addColor( params, 'light color' ).onChange( function ( val ) {
@@ -206,9 +204,9 @@
 
 				} );
 
-				gui.add( params, 'cameraAutoUpdate').onChange( function ( val ) {
+				gui.add( params, 'shadowAutoUpdate').onChange( function ( val ) {
 
-					spotLight.shadow.cameraAutoUpdate = val;
+					spotLight.shadowAutoUpdate = val;
 					render();
 
 				} );

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -247,7 +247,11 @@
 
 				sunLight.castShadow = true;
 
-				sunLight.shadow = new THREE.LightShadow( new THREE.PerspectiveCamera( shadowConfig.shadowCameraFov, 1, shadowConfig.shadowCameraNear, shadowConfig.shadowCameraFar ) );
+				sunLight.shadow.camera.fov = shadowConfig.shadowCameraFov;
+				sunLight.shadow.camera.aspect = 1;
+				sunLight.shadow.camera.near = shadowConfig.shadowCameraNear;
+				sunLight.shadow.camera.far = shadowConfig.shadowCameraFar;
+				sunLight.shadow.cameraAutoUpdate = false;
 				sunLight.shadow.bias = shadowConfig.shadowBias;
 
 				scene.add( sunLight );

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -251,7 +251,7 @@
 				sunLight.shadow.camera.aspect = 1;
 				sunLight.shadow.camera.near = shadowConfig.shadowCameraNear;
 				sunLight.shadow.camera.far = shadowConfig.shadowCameraFar;
-				sunLight.shadow.cameraAutoUpdate = false;
+				sunLight.shadowAutoUpdate = false;
 				sunLight.shadow.bias = shadowConfig.shadowBias;
 
 				scene.add( sunLight );

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -116,7 +116,7 @@
 				light.shadow.camera.aspect = 1;
 				light.shadow.camera.near = 1200;
 				light.shadow.camera.far = 2500;
-				light.shadow.cameraAutoUpdate = false;
+				light.shadowAutoUpdate = false;
 
 				light.shadow.bias = 0.0001;
 

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -112,7 +112,12 @@
 
 				light.castShadow = true;
 
-				light.shadow = new THREE.LightShadow( new THREE.PerspectiveCamera( 50, 1, 1200, 2500 ) );
+				light.shadow.camera.fov = 50;
+				light.shadow.camera.aspect = 1;
+				light.shadow.camera.near = 1200;
+				light.shadow.camera.far = 2500;
+				light.shadow.cameraAutoUpdate = false;
+
 				light.shadow.bias = 0.0001;
 
 				light.shadow.mapSize.width = SHADOW_MAP_WIDTH;

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -111,7 +111,7 @@
 				light.shadow.camera.aspect = 1;
 				light.shadow.camera.near = 700;
 				light.shadow.camera.far = FAR;
-				light.shadow.cameraAutoUpdate = false;
+				light.shadowAutoUpdate = false;
 
 				light.shadow.bias = 0.0001;
 

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -107,7 +107,11 @@
 
 				light.castShadow = true;
 
-				light.shadow = new THREE.LightShadow( new THREE.PerspectiveCamera( 50, 1, 700, FAR ) );
+				light.shadow.camera.fov = 50;
+				light.shadow.camera.aspect = 1;
+				light.shadow.camera.near = 700;
+				light.shadow.camera.far = FAR;
+				light.shadow.cameraAutoUpdate = false;
 
 				light.shadow.bias = 0.0001;
 

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -74,6 +74,11 @@ SpotLightHelper.prototype.update = function () {
 	return function update() {
 
 		this.light.updateMatrixWorld();
+		if ( this.light.shadowAutoUpdate ) {
+
+			this.light.shadow.update( this.light );
+
+		}
 
 		var coneLength = this.light.distance ? this.light.distance : 1000;
 		var coneWidth = coneLength * Math.tan( this.light.angle );

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -16,6 +16,7 @@ function Light( color, intensity ) {
 	this.intensity = intensity !== undefined ? intensity : 1;
 
 	this.receiveShadow = undefined;
+	this.shadowAutoUpdate = false;
 
 }
 

--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -53,7 +53,9 @@ Object.assign( LightShadow.prototype, {
 
 		return object;
 
-	}
+	},
+
+	update: function ( ) { }
 
 } );
 

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -40,6 +40,7 @@ function SpotLight( color, intensity, distance, angle, penumbra, decay ) {
 	this.decay = ( decay !== undefined ) ? decay : 1;	// for physically correct lights, should be 2.
 
 	this.shadow = new SpotLightShadow();
+	this.shadowAutoUpdate = true;
 
 }
 

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -9,15 +9,12 @@ import { PerspectiveCamera } from '../cameras/PerspectiveCamera.js';
 function SpotLightShadow() {
 
 	LightShadow.call( this, new PerspectiveCamera( 50, 1, 0.5, 500 ) );
-	this.cameraAutoUpdate = true;
 
 }
 
 SpotLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype ), {
 
 	constructor: SpotLightShadow,
-
-	isSpotLightShadow: true,
 
 	update: function ( light ) {
 

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -21,8 +21,6 @@ SpotLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype 
 
 	update: function ( light ) {
 
-		if ( ! this.cameraAutoUpdate ) return;
-
 		var camera = this.camera;
 
 		var fov = _Math.RAD2DEG * 2 * light.angle;

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -9,6 +9,7 @@ import { PerspectiveCamera } from '../cameras/PerspectiveCamera.js';
 function SpotLightShadow() {
 
 	LightShadow.call( this, new PerspectiveCamera( 50, 1, 0.5, 500 ) );
+	this.cameraAutoUpdate = true;
 
 }
 
@@ -19,6 +20,8 @@ SpotLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype 
 	isSpotLightShadow: true,
 
 	update: function ( light ) {
+
+		if ( ! this.cameraAutoUpdate ) return;
 
 		var camera = this.camera;
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -179,7 +179,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 			}
 
-			if ( shadow.isSpotLightShadow ) {
+			if ( shadow.isSpotLightShadow && shadow.cameraAutoUpdate ) {
 
 				shadow.update( light );
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -179,7 +179,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 			}
 
-			if ( shadow.isSpotLightShadow && shadow.cameraAutoUpdate ) {
+			if ( light.shadowAutoUpdate ) {
 
 				shadow.update( light );
 

--- a/test/unit/src/lights/SpotLightShadow.tests.js
+++ b/test/unit/src/lights/SpotLightShadow.tests.js
@@ -27,12 +27,6 @@ export default QUnit.module( 'Lights', () => {
 		} );
 
 		// PUBLIC STUFF
-		QUnit.todo( "isSpotLightShadow", ( assert ) => {
-
-			assert.ok( false, "everything's gonna be alright" );
-
-		} );
-
 		QUnit.todo( "update", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );


### PR DESCRIPTION
Preventing the Autoupdating of the `SpotLight.shadow.camera` was previously performed through the hack of [overwriting](https://github.com/mrdoob/three.js/compare/dev...mbredif:SpotLightCameraUpdateOptOut?expand=1#diff-3a405b9c95eb5dd79f92e5ba070fafa9L115) the SpotLightShadow with a LightShadow. 

Instead, this PR proposes a new property ~`SpotLightShadow.cameraAutoUpdate`~`Light.shadowAutoUpdate` that makes optional the fitting of the shadow camera frustum to the square cone defined by light.angle/light.distance.

(this PR is the item 2 of #14658, extracted here for an easier review)

== Edit ==
Instead of overwriting the shadow, an alternative hack to get the same result would be to set `this.shadow.isSpotLightShadow = false`. As that was the sole use of `isSpotLightShadow`, this PR is essentially moving and renaming `Light.shadow.isSpotLightShadow` to `Light.shadowAutoUpdate`.