### PR TITLE
Add JSPM overrides to reduce the package size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   "jspm": {
     "files": [
       "package.json",
-      "bower.json",
       "LICENSE",
       "README.md",
       "build/three.js",

--- a/package.json
+++ b/package.json
@@ -62,5 +62,18 @@
     "rollup-watch": "^4.3.1",
     "serve": "6.5.8",
     "uglify-js": "^3.3.28"
+  },
+  "jspm": {
+    "files": [
+      "package.json",
+      "bower.json",
+      "LICENSE",
+      "README.md",
+      "build/three.js",
+      "build/three.min.js",
+      "build/three.module.js"
+    ],
+    "directories": {
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,5 +61,18 @@
     "rollup-watch": "^4.3.1",
     "serve": "6.5.8",
     "uglify-js": "^3.3.28"
+  },
+  "jspm": {
+    "files": [
+      "package.json",
+      "bower.json",
+      "LICENSE",
+      "README.md",
+      "build/three.js",
+      "build/three.min.js",
+      "build/three.module.js"
+    ],
+    "directories": {
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "module": "build/three.module.js",
   "files": [
     "package.json",
-    "bower.json",
     "LICENSE",
     "README.md",
     "build/three.js",


### PR DESCRIPTION
Pull request relating to #14676.

Overriding the files / directories that JSPM pulls in reduces the download from ~400MB to ~2.5MB.