### PR TITLE
Added cartesian conversion methods

### DIFF
--- a/docs/api/math/Cylindrical.html
+++ b/docs/api/math/Cylindrical.html
@@ -57,11 +57,13 @@
 		<h3>[method:Cylindrical setFromVector3]( [param:Vector3 vec3] )</h3>
 		<p>
 			Sets values of this cylindrical's [page:.radius radius], [page:.theta theta]
-			and [page:.y y] properties from the [page:Vector3 Vector3].<br /><br />
+			and [page:.y y] properties from the [page:Vector3 Vector3].
+		</p>
 
-			The [page:.radius radius] is set the vector's distance from the origin as measured along
-			the the x-z plane, while [page:.theta theta] is set from its direction on
-			the the x-z plane and [page:.y y] is set from the vector's y component.
+		<h3>[method:Cylindrical setFromCartesianCoords]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<p>
+			Sets values of this cylindrical's [page:.radius radius], [page:.theta theta]
+			and [page:.y y] properties from Cartesian coordinates.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/math/Spherical.html
+++ b/docs/api/math/Spherical.html
@@ -62,10 +62,13 @@
 		<h3>[method:Spherical setFromVector3]( [param:Vector3 vec3] )</h3>
 		<p>
 			Sets values of this spherical's [page:.radius radius], [page:.phi phi]
-			and [page:.theta theta] properties from the [page:Vector3 Vector3].<br /><br />
+			and [page:.theta theta] properties from the [page:Vector3 Vector3].
+		</p>
 
-			The [page:.radius radius] is set the vector's [page:Vector3.length], while the
-			[page:.phi phi] and [page:.theta theta] properties are set from its direction.
+		<h3>[method:Spherical setFromCartesianCoords]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<p>
+			Sets values of this spherical's [page:.radius radius], [page:.phi phi]
+			and [page:.theta theta] properties from Cartesian coordinates.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/math/Vector3.html
+++ b/docs/api/math/Vector3.html
@@ -357,6 +357,9 @@ var d = a.distanceTo( b );
 		Sets this vector from the cylindrical coordinates [page:Cylindrical c].
 		</p>
 
+		<h3>[method:this setFromCylindricalCoords]( [param:Float radius], [param:Float theta], [param:Float y] )</h3>
+		<p>Sets this vector from the cylindrical coordinates [page:Cylindrical radius], [page:Cylindrical theta] and [page:Cylindrical y].</p>
+
 		<h3>[method:this setFromMatrixColumn]( [param:Matrix4 matrix], [param:Integer index] )</h3>
 		<p>
 		Sets this vector's [page:.x x], [page:.y y] and [page:.z z] equal to the column of
@@ -379,6 +382,9 @@ var d = a.distanceTo( b );
 		<p>
 		Sets this vector from the spherical coordinates [page:Spherical s].
 		</p>
+
+		<h3>[method:this setFromSphericalCoords]( [param:Float radius], [param:Float phi], [param:Float theta] )</h3>
+		<p>Sets this vector from the spherical coordinates [page:Spherical radius], [page:Spherical phi] and [page:Spherical theta].</p>
 
 		<h3>[method:this setLength]( [param:Float l] )</h3>
 		<p>

--- a/examples/css3d_periodictable.html
+++ b/examples/css3d_periodictable.html
@@ -296,7 +296,6 @@
 				// sphere
 
 				var vector = new THREE.Vector3();
-				var spherical = new THREE.Spherical();
 
 				for ( var i = 0, l = objects.length; i < l; i ++ ) {
 
@@ -305,9 +304,7 @@
 
 					var object = new THREE.Object3D();
 
-					spherical.set( 800, phi, theta );
-
-					object.position.setFromSpherical( spherical );
+					object.position.setFromSphericalCoords( 800, phi, theta );
 
 					vector.copy( object.position ).multiplyScalar( 2 );
 
@@ -320,7 +317,6 @@
 				// helix
 
 				var vector = new THREE.Vector3();
-				var cylindrical = new THREE.Cylindrical();
 
 				for ( var i = 0, l = objects.length; i < l; i ++ ) {
 
@@ -329,9 +325,7 @@
 
 					var object = new THREE.Object3D();
 
-					cylindrical.set( 900, theta, y );
-
-					object.position.setFromCylindrical( cylindrical );
+					object.position.setFromCylindricalCoords( 900, theta, y );
 
 					vector.x = object.position.x * 2;
 					vector.y = object.position.y;

--- a/examples/webgl_buffergeometry_constructed_from_geometry.html
+++ b/examples/webgl_buffergeometry_constructed_from_geometry.html
@@ -114,7 +114,6 @@
 			var normals = [];
 			var colors = [];
 
-			var spherical = new THREE.Spherical();
 			var vector = new THREE.Vector3();
 
 			var color = new THREE.Color( 0xffffff );
@@ -126,8 +125,7 @@
 				var phi = Math.acos( - 1 + ( 2 * i ) / l );
 				var theta = Math.sqrt( l * Math.PI ) * phi;
 
-				spherical.set( radius, phi, theta );
-				vector.setFromSpherical( spherical );
+				vector.setFromSphericalCoords( radius, phi, theta );
 
 				geometry.copy( heartGeometry );
 				geometry.lookAt( vector );

--- a/examples/webgl_materials_video_webcam.html
+++ b/examples/webgl_materials_video_webcam.html
@@ -71,17 +71,13 @@
 				var count = 128;
 				var radius = 32;
 
-				var spherical = new THREE.Spherical();
-
 				for ( var i = 1, l = count; i <= l; i ++ ) {
 
 					var phi = Math.acos( - 1 + ( 2 * i ) / l );
 					var theta = Math.sqrt( l * Math.PI ) * phi;
 
-					spherical.set( radius, phi, theta );
-
 					var mesh = new THREE.Mesh( geometry, material );
-					mesh.position.setFromSpherical( spherical );
+					mesh.position.setFromSphericalCoords( radius, phi, theta );
 					mesh.lookAt( camera.position );
 					scene.add( mesh );
 

--- a/src/math/Cylindrical.js
+++ b/src/math/Cylindrical.js
@@ -43,11 +43,17 @@ Object.assign( Cylindrical.prototype, {
 
 	},
 
-	setFromVector3: function ( vec3 ) {
+	setFromVector3: function ( v ) {
 
-		this.radius = Math.sqrt( vec3.x * vec3.x + vec3.z * vec3.z );
-		this.theta = Math.atan2( vec3.x, vec3.z );
-		this.y = vec3.y;
+		return this.setFromCartesianCoords( v.x, v.y, v.z );
+
+	},
+
+	setFromCartesianCoords: function ( x, y, z ) {
+
+		this.radius = Math.sqrt( x * x + z * z );
+		this.theta = Math.atan2( x, z );
+		this.y = y;
 
 		return this;
 

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -6,15 +6,15 @@ import { _Math } from './Math.js';
  *
  * Ref: https://en.wikipedia.org/wiki/Spherical_coordinate_system
  *
- * The poles (phi) are at the positive and negative y axis.
- * The equator starts at positive z.
+ * The polar angle (phi) is measured from the positive y-axis. The positive y-axis is up.
+ * The azimuthal angle (theta) is measured from the positive z-axiz.
  */
 
 function Spherical( radius, phi, theta ) {
 
 	this.radius = ( radius !== undefined ) ? radius : 1.0;
-	this.phi = ( phi !== undefined ) ? phi : 0; // up / down towards top and bottom pole
-	this.theta = ( theta !== undefined ) ? theta : 0; // around the equator of the sphere
+	this.phi = ( phi !== undefined ) ? phi : 0; // polar angle
+	this.theta = ( theta !== undefined ) ? theta : 0; // azimuthal angle
 
 	return this;
 
@@ -58,9 +58,15 @@ Object.assign( Spherical.prototype, {
 
 	},
 
-	setFromVector3: function ( vec3 ) {
+	setFromVector3: function ( v ) {
 
-		this.radius = vec3.length();
+		return this.setFromCartesianCoords( v.x, v.y, v.z );
+
+	},
+
+	setFromCartesianCoords: function ( x, y, z ) {
+
+		this.radius = Math.sqrt( x * x + y * y + z * z );
 
 		if ( this.radius === 0 ) {
 
@@ -69,8 +75,8 @@ Object.assign( Spherical.prototype, {
 
 		} else {
 
-			this.theta = Math.atan2( vec3.x, vec3.z ); // equator angle around y-up axis
-			this.phi = Math.acos( _Math.clamp( vec3.y / this.radius, - 1, 1 ) ); // polar angle
+			this.theta = Math.atan2( x, z );
+			this.phi = Math.acos( _Math.clamp( y / this.radius, - 1, 1 ) );
 
 		}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -617,11 +617,17 @@ Object.assign( Vector3.prototype, {
 
 	setFromSpherical: function ( s ) {
 
-		var sinPhiRadius = Math.sin( s.phi ) * s.radius;
+		return this.setFromSphericalCoords( s.radius, s.phi, s.theta );
 
-		this.x = sinPhiRadius * Math.sin( s.theta );
-		this.y = Math.cos( s.phi ) * s.radius;
-		this.z = sinPhiRadius * Math.cos( s.theta );
+	},
+
+	setFromSphericalCoords: function ( radius, phi, theta ) {
+
+		var sinPhiRadius = Math.sin( phi ) * radius;
+
+		this.x = sinPhiRadius * Math.sin( theta );
+		this.y = Math.cos( phi ) * radius;
+		this.z = sinPhiRadius * Math.cos( theta );
 
 		return this;
 
@@ -629,9 +635,15 @@ Object.assign( Vector3.prototype, {
 
 	setFromCylindrical: function ( c ) {
 
-		this.x = c.radius * Math.sin( c.theta );
-		this.y = c.y;
-		this.z = c.radius * Math.cos( c.theta );
+		return this.setFromCylindricalCoords( c.radius, c.theta, c.y );
+
+	},
+
+	setFromCylindricalCoords: function ( radius, theta, y ) {
+
+		this.x = radius * Math.sin( theta );
+		this.y = y;
+		this.z = radius * Math.cos( theta );
 
 		return this;
 


### PR DESCRIPTION
We already have these methods:
```javascript
vector.setFromSpherical( s );
vector.setFromCylindrical( c );
spherical.setFromVector3( v );
cylindrical.setFromVector3( v );
```
Note that in the method names, "set from" refers to the class type of the argument.

To avoid having to instantiate an object just to do the conversion, this PR adds the following methods:
```javascript
vector.setFromSphericalCoords( radius, phi, theta );
vector.setFromCylindricalCoords( radius, theta, y );

spherical.setFromCartesianCoords( x, y, z );
cylndrical.setFromCartesianCoords( x, y, z );
```


