### PR TITLE
setFromMatrixDirection

### DIFF
--- a/docs/api/math/Vector3.html
+++ b/docs/api/math/Vector3.html
@@ -363,6 +363,13 @@ var d = a.distanceTo( b );
 		the [page:Matrix4 matrix] specified by the [page:Integer index].
 		</p>
 
+		<h3>[method:this setFromMatrixDirection]( [param:Matrix4 m] )</h3>
+		<p>
+		Sets this vector to the normalized direction of the +Z axis transformed by the
+		[link:https://en.wikipedia.org/wiki/Transformation_matrix transformation matrix] [page:Matrix4 m].
+		*Note*: this is more efficient and explicit, but equivalent to <code>this.setFromMatrixColumn( m, 2 ).normalize();</code>
+		</p>
+
 		<h3>[method:this setFromMatrixPosition]( [param:Matrix4 m] )</h3>
 		<p>
 		Sets this vector to the position elements of the

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -6,7 +6,6 @@
 
 import { Matrix4 } from '../math/Matrix4.js';
 import { Object3D } from '../core/Object3D.js';
-import { Vector3 } from '../math/Vector3.js';
 
 function Camera() {
 
@@ -38,18 +37,7 @@ Camera.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	getWorldDirection: function ( target ) {
 
-		if ( target === undefined ) {
-
-			console.warn( 'THREE.Camera: .getWorldDirection() target is now required' );
-			target = new Vector3();
-
-		}
-
-		this.updateMatrixWorld( true );
-
-		var e = this.matrixWorld.elements;
-
-		return target.set( - e[ 8 ], - e[ 9 ], - e[ 10 ] ).normalize();
+		return Object3D.prototype.getWorldDirection.call( this, target ).negate();
 
 	},
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -517,9 +517,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		this.updateMatrixWorld( true );
 
-		var e = this.matrixWorld.elements;
-
-		return target.set( e[ 8 ], e[ 9 ], e[ 10 ] ).normalize();
+		return target.setFromMatrixDirection( this.matrixWorld );
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -637,6 +637,18 @@ Object.assign( Vector3.prototype, {
 
 	},
 
+	setFromMatrixDirection: function ( m ) {
+
+		var e = m.elements;
+
+		this.x = e[ 8 ];
+		this.y = e[ 9 ];
+		this.z = e[ 10 ];
+
+		return this.normalize();
+
+	},
+
 	setFromMatrixPosition: function ( m ) {
 
 		var e = m.elements;


### PR DESCRIPTION
With #14677, getWorldPosition and getWorldDirection have the same logic (except for the normalization of the direction) :
- call `updateMatrixWorld( true )`
- read a `Vector3` from the `matrixWorld`

As a follow-up to https://github.com/mrdoob/three.js/pull/14677#issuecomment-411820286, this PR introduces `setFromMatrixDirection` as the counterpart of `Vector3.setFromMatrixPosition`, to be used directly when the matrixWorld is known to be up to date.

For instance, it would be useful in #14658 where `light.matrixWorld` is already synced :
 https://github.com/mrdoob/three.js/blob/ddbdbaaf613aecd4e7eafeefa2ee1cb8620f61bb/src/renderers/webgl/WebGLLights.js#L205

Note: `setFromMatrixDirection` is equivalent to `setFromMatrixColumn( m, 2 ).normalize()` but I propose it anyway as it saves a few function calls and multiplications and is more explicit.