### PR TITLE
Viewport.js: fix orphaned object

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -410,6 +410,10 @@ var Viewport = function ( editor ) {
 	} );
 
 	signals.objectRemoved.add( function ( object ) {
+		
+		if(object === transformControls.object){
+			transformControls.detach();
+		}
 
 		object.traverse( function ( child ) {
 


### PR DESCRIPTION
Make sure that any objects being removed from the scene are also detached from the transformControls before the next render pass.