### PR TITLE
fix the bug which lost tangent, binormal, and normal in ExtrudeGeometry

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -140,9 +140,13 @@ function ExtrudeBufferGeometry( shapes, options ) {
 
 			// TODO1 - have a .isClosed in spline?
 			if ( options.frames === undefined ) {
+				
 				splineTube = extrudePath.computeFrenetFrames( steps, false );
+				
 			} else {
-			        splineTube = options.frames;
+				
+				splineTube = options.frames;
+				
 			}
 			
 			// console.log(splineTube, 'splineTube', splineTube.normals.length, 'steps', steps, 'extrudePts', extrudePts.length);

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -140,7 +140,7 @@ function ExtrudeBufferGeometry( shapes, options ) {
 
 			// TODO1 - have a .isClosed in spline?
 
-			splineTube = extrudePath.computeFrenetFrames( steps, false );
+			splineTube = options.frames !== undefined ? options.frames: extrudePath.computeFrenetFrames( steps, false );
 
 			// console.log(splineTube, 'splineTube', splineTube.normals.length, 'steps', steps, 'extrudePts', extrudePts.length);
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -139,9 +139,12 @@ function ExtrudeBufferGeometry( shapes, options ) {
 			// SETUP TNB variables
 
 			// TODO1 - have a .isClosed in spline?
-
-			splineTube = options.frames !== undefined ? options.frames: extrudePath.computeFrenetFrames( steps, false );
-
+			if ( options.frames === undefined ) {
+				splineTube = extrudePath.computeFrenetFrames( steps, false );
+			} else {
+			        splineTube = options.frames;
+			}
+			
 			// console.log(splineTube, 'splineTube', splineTube.normals.length, 'steps', steps, 'extrudePts', extrudePts.length);
 
 			binormal = new Vector3();


### PR DESCRIPTION
 When tangent, binormal, and normal are provided by users, the previous code will lost them in ExtrudeGeometry, and now I fixed the bug.