### PR TITLE
PointsMaterial: size attenuation applies to perspective camera only

### DIFF
--- a/docs/api/materials/PointsMaterial.html
+++ b/docs/api/materials/PointsMaterial.html
@@ -88,7 +88,8 @@ scene.add( starField );
 		<p>Sets the size of the points. Default is 1.0.</p>
 
 		<h3>[property:Boolean sizeAttenuation]</h3>
-		<p>Specify whether points' size will get smaller with the distance. Default is true.</p>
+		<p>Specify whether points' size is attenuated by the camera depth. (Perspective camera only.) Default is true.</p>
+
 
 		<h2>Methods</h2>
 

--- a/src/renderers/shaders/ShaderLib/points_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/points_vert.glsl
@@ -15,10 +15,14 @@ void main() {
 	#include <morphtarget_vertex>
 	#include <project_vertex>
 
+	gl_PointSize = size;
+
 	#ifdef USE_SIZEATTENUATION
-		gl_PointSize = size * ( scale / - mvPosition.z );
-	#else
-		gl_PointSize = size;
+
+		bool isPerspective = ( projectionMatrix[ 2 ][ 3 ] == - 1.0 );
+
+		if ( isPerspective ) gl_PointSize *= ( scale / - mvPosition.z );
+
 	#endif
 
 	#include <logdepthbuf_vertex>


### PR DESCRIPTION
The `sizeAttenuation` setting should not apply when using an orthographic camera.