### PR TITLE
Remove dirlight position normalization in examples

### DIFF
--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -96,7 +96,7 @@
 				scene.fog = new THREE.FogExp2( 0x000000, 0.00000025 );
 
 				dirLight = new THREE.DirectionalLight( 0xffffff );
-				dirLight.position.set( -1, 0, 1 ).normalize();
+				dirLight.position.set( -1, 0, 1 );
 				scene.add( dirLight );
 
 				var materialNormalMap = new THREE.MeshPhongMaterial( {

--- a/examples/misc_exporter_obj.html
+++ b/examples/misc_exporter_obj.html
@@ -234,7 +234,7 @@
 				camera.position.y += ( - mouseY - camera.position.y ) * 0.05;
 				camera.lookAt( scene.position );
 
-				light.position.set( camera.position.x, camera.position.y, camera.position.z ).normalize();
+				light.position.set( camera.position.x, camera.position.y, camera.position.z );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -117,7 +117,7 @@
 				scene.fog = new THREE.FogExp2( 0x000000, 0.0025 );
 
 				light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0, 0.5, 1 ).normalize();
+				light.position.set( 0, 0.5, 1 );
 				scene.add( light );
 
 				var sphere = new THREE.SphereBufferGeometry( 20, 32, 16 );

--- a/examples/webgl_camera_cinematic.html
+++ b/examples/webgl_camera_cinematic.html
@@ -55,7 +55,7 @@
 				scene.add( new THREE.AmbientLight( 0xffffff, 0.3 ) );
 
 				var light = new THREE.DirectionalLight( 0xffffff, 0.35 );
-				light.position.set( 1, 1, 1 ).normalize();
+				light.position.set( 1, 1, 1 );
 				scene.add( light );
 
 				var geometry = new THREE.BoxBufferGeometry( 20, 20, 20 );

--- a/examples/webgl_effects_parallaxbarrier.html
+++ b/examples/webgl_effects_parallaxbarrier.html
@@ -176,11 +176,11 @@
 				scene.add( ambient );
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 2 );
-				directionalLight.position.set( 2, 1.2, 10 ).normalize();
+				directionalLight.position.set( 2, 1.2, 10 );
 				scene.add( directionalLight );
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
-				directionalLight.position.set( - 2, 1.2, -10 ).normalize();
+				directionalLight.position.set( - 2, 1.2, -10 );
 				scene.add( directionalLight );
 
 				pointLight = new THREE.PointLight( 0xffaa00, 2 );

--- a/examples/webgl_geometry_colors_json.html
+++ b/examples/webgl_geometry_colors_json.html
@@ -67,7 +67,7 @@
 				scene = new THREE.Scene();
 
 				light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0, 0, 1 ).normalize();
+				light.position.set( 0, 0, 1 );
 				scene.add( light );
 
 				var loader = new THREE.JSONLoader();

--- a/examples/webgl_geometry_extrude_shapes2.html
+++ b/examples/webgl_geometry_extrude_shapes2.html
@@ -417,7 +417,7 @@
 				//
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.6 );
-				directionalLight.position.set( 0.75, 0.75, 1.0 ).normalize();
+				directionalLight.position.set( 0.75, 0.75, 1.0 );
 				scene.add( directionalLight );
 
 				var ambientLight = new THREE.AmbientLight( 0xcccccc, 0.2 );

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -187,7 +187,7 @@
 				scene.add( ambientLight );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 2 );
-				directionalLight.position.set( 1, 1, 0.5 ).normalize();
+				directionalLight.position.set( 1, 1, 0.5 );
 				scene.add( directionalLight );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );

--- a/examples/webgl_geometry_text.html
+++ b/examples/webgl_geometry_text.html
@@ -144,7 +144,7 @@
 				// LIGHTS
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff, 0.125 );
-				dirLight.position.set( 0, 0, 1 ).normalize();
+				dirLight.position.set( 0, 0, 1 );
 				scene.add( dirLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 1.5 );

--- a/examples/webgl_interactive_cubes.html
+++ b/examples/webgl_interactive_cubes.html
@@ -49,7 +49,7 @@
 				scene.background = new THREE.Color( 0xf0f0f0 );
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
-				light.position.set( 1, 1, 1 ).normalize();
+				light.position.set( 1, 1, 1 );
 				scene.add( light );
 
 				var geometry = new THREE.BoxBufferGeometry( 20, 20, 20 );

--- a/examples/webgl_interactive_cubes_ortho.html
+++ b/examples/webgl_interactive_cubes_ortho.html
@@ -51,7 +51,7 @@
 				scene.background = new THREE.Color( 0xf0f0f0 );
 
 				var light = new THREE.DirectionalLight( 0xffffff, 1 );
-				light.position.set( 1, 1, 1 ).normalize();
+				light.position.set( 1, 1, 1 );
 				scene.add( light );
 
 				var geometry = new THREE.BoxBufferGeometry( 20, 20, 20 );

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -100,7 +100,7 @@
 				scene.add( ambientLight );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff );
-				directionalLight.position.set( 1, 0.75, 0.5 ).normalize();
+				directionalLight.position.set( 1, 0.75, 0.5 );
 				scene.add( directionalLight );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );

--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -113,7 +113,7 @@
 				// lights
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff, 0.05 );
-				dirLight.position.set( 0, -1, 0 ).normalize();
+				dirLight.position.set( 0, -1, 0 );
 				dirLight.color.setHSL( 0.1, 0.7, 0.5 );
 				scene.add( dirLight );
 

--- a/examples/webgl_lights_pointlights2.html
+++ b/examples/webgl_lights_pointlights2.html
@@ -168,7 +168,7 @@
 				scene.add( light6 );
 
 				var dlight = new THREE.DirectionalLight( 0xffffff, 0.05 );
-				dlight.position.set( 0.5, 1, 0 ).normalize();
+				dlight.position.set( 0.5, 1, 0 );
 				scene.add( dlight );
 
 				// RENDERER

--- a/examples/webgl_loader_assimp.html
+++ b/examples/webgl_loader_assimp.html
@@ -79,7 +79,7 @@
 			scene.add( ambient );
 
 			var light = new THREE.DirectionalLight( 0xffffff, 1 );
-			light.position.set( 0, 4, 4 ).normalize();
+			light.position.set( 0, 4, 4 );
 			scene.add( light );
 
 			renderer = new THREE.WebGLRenderer( { antialias: true } );

--- a/examples/webgl_loader_collada.html
+++ b/examples/webgl_loader_collada.html
@@ -87,7 +87,7 @@
 				scene.add( ambientLight );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.8 );
-				directionalLight.position.set( 1, 1, 0 ).normalize();
+				directionalLight.position.set( 1, 1, 0 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -204,7 +204,7 @@
 					scene.add( ambient );
 
 					var directionalLight = new THREE.DirectionalLight( 0xdddddd, 4 );
-					directionalLight.position.set( 0, 0, 1 ).normalize();
+					directionalLight.position.set( 0, 0, 1 );
 					scene.add( directionalLight );
 
 					spot1 = new THREE.SpotLight( 0xffffff, 1 );

--- a/examples/webgl_loader_json_claraio.html
+++ b/examples/webgl_loader_json_claraio.html
@@ -68,7 +68,7 @@
 				scene.add( ambient );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffeedd );
-				directionalLight.position.set( 0, 0, 1 ).normalize();
+				directionalLight.position.set( 0, 0, 1 );
 				scene.add( directionalLight );
 
 				// BEGIN Clara.io JSON loader code

--- a/examples/webgl_loader_json_objconverter.html
+++ b/examples/webgl_loader_json_objconverter.html
@@ -123,7 +123,7 @@
 				scene.add( ambient );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffeedd, 1.5 );
-				directionalLight.position.set( 0, -70, 100 ).normalize();
+				directionalLight.position.set( 0, -70, 100 );
 				scene.add( directionalLight );
 
 				// RENDERER

--- a/examples/webgl_loader_kmz.html
+++ b/examples/webgl_loader_kmz.html
@@ -65,7 +65,7 @@
 				scene.background = new THREE.Color( 0x999999 );
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0.5, 1.0, 0.5 ).normalize();
+				light.position.set( 0.5, 1.0, 0.5 );
 
 				scene.add( light );
 

--- a/examples/webgl_loader_mmd.html
+++ b/examples/webgl_loader_mmd.html
@@ -89,7 +89,7 @@
 				scene.add( ambient );
 
 				var directionalLight = new THREE.DirectionalLight( 0x887766 );
-				directionalLight.position.set( - 1, 1, 1 ).normalize();
+				directionalLight.position.set( - 1, 1, 1 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_mmd_audio.html
+++ b/examples/webgl_loader_mmd_audio.html
@@ -87,7 +87,7 @@
 				scene.add( ambient );
 
 				var directionalLight = new THREE.DirectionalLight( 0x887766 );
-				directionalLight.position.set( - 1, 1, 1 ).normalize();
+				directionalLight.position.set( - 1, 1, 1 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_mmd_pose.html
+++ b/examples/webgl_loader_mmd_pose.html
@@ -80,7 +80,7 @@
 				scene.add( ambient );
 
 				var directionalLight = new THREE.DirectionalLight( 0x887766 );
-				directionalLight.position.set( - 1, 1, 1 ).normalize();
+				directionalLight.position.set( - 1, 1, 1 );
 				scene.add( directionalLight );
 
 				//

--- a/examples/webgl_loader_nrrd.html
+++ b/examples/webgl_loader_nrrd.html
@@ -95,7 +95,7 @@
 				// light
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff );
-				dirLight.position.set( 200, 200, 1000 ).normalize();
+				dirLight.position.set( 200, 200, 1000 );
 
 				camera.add( dirLight );
 				camera.add( dirLight.target );

--- a/examples/webgl_loader_ttf.html
+++ b/examples/webgl_loader_ttf.html
@@ -93,7 +93,7 @@
 				// LIGHTS
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff, 0.125 );
-				dirLight.position.set( 0, 0, 1 ).normalize();
+				dirLight.position.set( 0, 0, 1 );
 				scene.add( dirLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 1.5 );

--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -70,7 +70,7 @@
 				// light
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff );
-				dirLight.position.set( 200, 200, 1000 ).normalize();
+				dirLight.position.set( 200, 200, 1000 );
 
 				camera.add( dirLight );
 				camera.add( dirLight.target );

--- a/examples/webgl_loader_vtk.html
+++ b/examples/webgl_loader_vtk.html
@@ -79,7 +79,7 @@
 				// light
 
 				var dirLight = new THREE.DirectionalLight( 0xffffff );
-				dirLight.position.set( 200, 200, 1000 ).normalize();
+				dirLight.position.set( 200, 200, 1000 );
 
 				camera.add( dirLight );
 				camera.add( dirLight.target );

--- a/examples/webgl_loader_x.html
+++ b/examples/webgl_loader_x.html
@@ -135,11 +135,11 @@
             controls.update();
 
             var light = new THREE.DirectionalLight( 0xffffff, 1 );
-            light.position.set( 10, 100, - 10 ).normalize();
+            light.position.set( 10, 100, - 10 );
             scene.add( light );
 
             var light2 = new THREE.DirectionalLight( 0x777666, 1 );
-            light2.position.set( - 1, - 1, - 1 ).normalize();
+            light2.position.set( - 1, - 1, - 1 );
             scene.add( light2 );
 
             window.addEventListener( 'resize', onWindowResize, false );

--- a/examples/webgl_lod.html
+++ b/examples/webgl_lod.html
@@ -79,7 +79,7 @@
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0, 0, 1 ).normalize();
+				light.position.set( 0, 0, 1 );
 				scene.add( light );
 
 				var geometry = [

--- a/examples/webgl_materials_cars.html
+++ b/examples/webgl_materials_cars.html
@@ -179,11 +179,11 @@
 				scene.add( ambient );
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 2 );
-				directionalLight.position.set( 2, 1.2, 10 ).normalize();
+				directionalLight.position.set( 2, 1.2, 10 );
 				scene.add( directionalLight );
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
-				directionalLight.position.set( -2, 1.2, -10 ).normalize();
+				directionalLight.position.set( -2, 1.2, -10 );
 				scene.add( directionalLight );
 
 				pointLight = new THREE.PointLight( 0xffaa00, 2 );

--- a/examples/webgl_materials_translucency.html
+++ b/examples/webgl_materials_translucency.html
@@ -65,7 +65,7 @@
 			scene.add( new THREE.AmbientLight( 0x888888 ) );
 
 			var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.03 );
-			directionalLight.position.set( 0.0, 0.5, 0.5 ).normalize();
+			directionalLight.position.set( 0.0, 0.5, 0.5 );
 			scene.add( directionalLight );
 
 			var pointLight1 = new THREE.Mesh( new THREE.SphereBufferGeometry( 4, 8, 8 ), new THREE.MeshBasicMaterial( { color: 0x888888 } ) );

--- a/examples/webgl_materials_variations_basic.html
+++ b/examples/webgl_materials_variations_basic.html
@@ -155,7 +155,7 @@
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
-				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.position.set( 1, 1, 1 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -161,7 +161,7 @@
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
-				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.position.set( 1, 1, 1 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -181,7 +181,7 @@
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
-				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.position.set( 1, 1, 1 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -188,7 +188,7 @@
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
-				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.position.set( 1, 1, 1 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_variations_toon.html
+++ b/examples/webgl_materials_variations_toon.html
@@ -163,7 +163,7 @@
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
-				directionalLight.position.set( 1, 1, 1 ).normalize();
+				directionalLight.position.set( 1, 1, 1 );
 				scene.add( directionalLight );
 
 				var pointLight = new THREE.PointLight( 0xffffff, 2, 800 );

--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -94,7 +94,7 @@
 				scene = new THREE.Scene();
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0.5, 1, 1 ).normalize();
+				light.position.set( 0.5, 1, 1 );
 				scene.add( light );
 
 				renderer = new THREE.WebGLRenderer();

--- a/examples/webgl_morphtargets_horse.html
+++ b/examples/webgl_morphtargets_horse.html
@@ -52,11 +52,11 @@
 				//
 
 				var light = new THREE.DirectionalLight( 0xefefff, 1.5 );
-				light.position.set( 1, 1, 1 ).normalize();
+				light.position.set( 1, 1, 1 );
 				scene.add( light );
 
 				var light = new THREE.DirectionalLight( 0xffefef, 1.5 );
-				light.position.set( -1, -1, -1 ).normalize();
+				light.position.set( -1, -1, -1 );
 				scene.add( light );
 
 				var loader = new THREE.JSONLoader();

--- a/examples/webgl_multiple_canvases_circle.html
+++ b/examples/webgl_multiple_canvases_circle.html
@@ -221,7 +221,7 @@
 				scene.background = new THREE.Color( 0xffffff );
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0, 0, 1 ).normalize();
+				light.position.set( 0, 0, 1 );
 				scene.add( light );
 
 				var noof_balls = 51;

--- a/examples/webgl_multiple_canvases_complex.html
+++ b/examples/webgl_multiple_canvases_complex.html
@@ -130,7 +130,7 @@
 				scene.background = new THREE.Color( 0xffffff );
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0, 0, 1 ).normalize();
+				light.position.set( 0, 0, 1 );
 				scene.add( light );
 
 				// shadow

--- a/examples/webgl_multiple_canvases_grid.html
+++ b/examples/webgl_multiple_canvases_grid.html
@@ -147,7 +147,7 @@
 				scene.background = new THREE.Color( 0xffffff );
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0, 0, 1 ).normalize();
+				light.position.set( 0, 0, 1 );
 				scene.add( light );
 
 				// shadow

--- a/examples/webgl_octree_raycasting.html
+++ b/examples/webgl_octree_raycasting.html
@@ -96,7 +96,7 @@
 			scene.add( ambient );
 
 			var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.5 );
-			directionalLight.position.set( 1, 1, 2 ).normalize();
+			directionalLight.position.set( 1, 1, 2 );
 			scene.add( directionalLight );
 
 			// create all objects

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -108,7 +108,7 @@
 				//
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff );
-				directionalLight.position.set( 0, -0.1, 1 ).normalize();
+				directionalLight.position.set( 0, -0.1, 1 );
 				sceneModel.add( directionalLight );
 
 				var loader = new THREE.JSONLoader();

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -225,11 +225,11 @@ Use WEBGL Depth buffer support?
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 2 );
-				directionalLight.position.set( 2, 1.2, 10 ).normalize();
+				directionalLight.position.set( 2, 1.2, 10 );
 				scene.add( directionalLight );
 
 				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
-				directionalLight.position.set( - 2, 1.2, -10 ).normalize();
+				directionalLight.position.set( - 2, 1.2, -10 );
 				scene.add( directionalLight );
 
 				initPostprocessing();

--- a/examples/webgl_read_float_buffer.html
+++ b/examples/webgl_read_float_buffer.html
@@ -117,11 +117,11 @@
 				sceneScreen = new THREE.Scene();
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0, 0, 1 ).normalize();
+				light.position.set( 0, 0, 1 );
 				sceneRTT.add( light );
 
 				light = new THREE.DirectionalLight( 0xffaaaa, 1.5 );
-				light.position.set( 0, 0, - 1 ).normalize();
+				light.position.set( 0, 0, - 1 );
 				sceneRTT.add( light );
 
 				rtTexture = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, { minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, type: THREE.FloatType } );

--- a/examples/webgl_rtt.html
+++ b/examples/webgl_rtt.html
@@ -120,11 +120,11 @@
 				sceneScreen = new THREE.Scene();
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 0, 0, 1 ).normalize();
+				light.position.set( 0, 0, 1 );
 				sceneRTT.add( light );
 
 				light = new THREE.DirectionalLight( 0xffaaaa, 1.5 );
-				light.position.set( 0, 0, -1 ).normalize();
+				light.position.set( 0, 0, -1 );
 				sceneRTT.add( light );
 
 				rtTexture = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, { minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBFormat } );

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -127,7 +127,7 @@
 				scene.add( ambient );
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, params.sunLight );
-				directionalLight.position.set( 2, 0, 10 ).normalize();
+				directionalLight.position.set( 2, 0, 10 );
 				scene.add( directionalLight );
 
 				var atmoShader = {

--- a/examples/webgldeferred_animation.html
+++ b/examples/webgldeferred_animation.html
@@ -149,7 +149,7 @@
 				for ( var i = 0; i < numLights; i ++ ) {
 
 					var light = new THREE.PointLight( 0xffffff, 2.0, distance );
-					c.set( Math.random(), Math.random(), Math.random() );
+					c.set( Math.random(), Math.random(), Math.random() ).normalize();
 					light.color.setRGB( c.x, c.y, c.z );
 					scene.add( light );
 					lights.push( light );

--- a/examples/webgldeferred_animation.html
+++ b/examples/webgldeferred_animation.html
@@ -149,7 +149,7 @@
 				for ( var i = 0; i < numLights; i ++ ) {
 
 					var light = new THREE.PointLight( 0xffffff, 2.0, distance );
-					c.set( Math.random(), Math.random(), Math.random() ).normalize();
+					c.set( Math.random(), Math.random(), Math.random() );
 					light.color.setRGB( c.x, c.y, c.z );
 					scene.add( light );
 					lights.push( light );
@@ -161,7 +161,7 @@
 				}
 
 				var directionalLight = new THREE.DirectionalLight( 0x101010 );
-				directionalLight.position.set( -1, 1, 1 ).normalize();
+				directionalLight.position.set( -1, 1, 1 );
 				scene.add( directionalLight );
 
 				var spotLight = new THREE.SpotLight( 0x404040 );

--- a/examples/webvr_ballshooter.html
+++ b/examples/webvr_ballshooter.html
@@ -71,7 +71,7 @@
 				scene.add( new THREE.HemisphereLight( 0x606060, 0x404040 ) );
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 1, 1, 1 ).normalize();
+				light.position.set( 1, 1, 1 );
 				scene.add( light );
 
 				var geometry = new THREE.IcosahedronBufferGeometry( radius, 2 );

--- a/examples/webvr_cubes.html
+++ b/examples/webvr_cubes.html
@@ -85,7 +85,7 @@
 				scene.add( new THREE.HemisphereLight( 0x606060, 0x404040 ) );
 
 				var light = new THREE.DirectionalLight( 0xffffff );
-				light.position.set( 1, 1, 1 ).normalize();
+				light.position.set( 1, 1, 1 );
 				scene.add( light );
 
 				var geometry = new THREE.BoxBufferGeometry( 0.15, 0.15, 0.15 );


### PR DESCRIPTION
As proposed by @WestLangley in #14658, this PR removes the position normalization of DirectionalLights in the examples.