### PR TITLE
Removed dead code (handleEvent) from controls.

### DIFF
--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -29,16 +29,6 @@ THREE.FlyControls = function ( object, domElement ) {
 	this.moveVector = new THREE.Vector3( 0, 0, 0 );
 	this.rotationVector = new THREE.Vector3( 0, 0, 0 );
 
-	this.handleEvent = function ( event ) {
-
-		if ( typeof this[ event.type ] == 'function' ) {
-
-			this[ event.type ]( event );
-
-		}
-
-	};
-
 	this.keydown = function ( event ) {
 
 		if ( event.altKey ) {

--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -109,16 +109,6 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 	};
 
-	this.handleEvent = function ( event ) {
-
-		if ( typeof this[ event.type ] == 'function' ) {
-
-			this[ event.type ]( event );
-
-		}
-
-	};
-
 	var getMouseOnScreen = ( function () {
 
 		var vector = new THREE.Vector2();

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -101,16 +101,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	};
 
-	this.handleEvent = function ( event ) {
-
-		if ( typeof this[ event.type ] == 'function' ) {
-
-			this[ event.type ]( event );
-
-		}
-
-	};
-
 	var getMouseOnScreen = ( function () {
 
 		var vector = new THREE.Vector2();


### PR DESCRIPTION
Found this dead piece of code across examples/js/controls.

Perhaps it was once used but now it serves no purpose and it is not referenced anywhere else in examples/ or editor/ It appears that it was added to FlyControls long time ago by @alteredq, then copy/pasted into TrackbalConrols by @egraether 