### PR TITLE
Fix bounding box calculations on BufferGeometries with indices/groups

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -634,7 +634,13 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 				var center = this.boundingSphere.center;
 
-				box.setFromBufferAttribute( position );
+				if ( this.index && this.groups && this.groups.length === 0 ) {
+
+					this.addGroup( 0, this.index.array.length );
+
+				}
+
+				box.setFromBufferAttribute( position, this.index || null, this.groups || null );
 				box.getCenter( center );
 
 				// hoping to find a boundingSphere with a radius smaller than the
@@ -642,12 +648,37 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 				var maxRadiusSq = 0;
 
-				for ( var i = 0, il = position.count; i < il; i ++ ) {
+				if ( this.index ) {
 
-					vector.x = position.getX( i );
-					vector.y = position.getY( i );
-					vector.z = position.getZ( i );
-					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+					var indices = this.index.array;
+
+					for ( var i = 0, il = this.groups.length; i < il; i ++ ) {
+
+						var start = this.groups[ i ].start;
+						var end = start + this.groups[ i ].count;
+
+						for ( var j = start; j < end; j ++ ) {
+
+							var ind = indices[ j ];
+							vector.x = position.getX( ind );
+							vector.y = position.getY( ind );
+							vector.z = position.getZ( ind );
+							maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+
+						}
+
+					}
+
+				} else {
+
+					for ( var i = 0, il = position.count; i < il; i ++ ) {
+
+						vector.x = position.getX( i );
+						vector.y = position.getY( i );
+						vector.z = position.getZ( i );
+						maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+
+					}
 
 				}
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -59,7 +59,7 @@ Object.assign( Box3.prototype, {
 
 	},
 
-	setFromBufferAttribute: function ( attribute ) {
+	setFromBufferAttribute( attribute, indexAttribute, groups ) {
 
 		var minX = + Infinity;
 		var minY = + Infinity;
@@ -69,19 +69,63 @@ Object.assign( Box3.prototype, {
 		var maxY = - Infinity;
 		var maxZ = - Infinity;
 
-		for ( var i = 0, l = attribute.count; i < l; i ++ ) {
+		if ( indexAttribute ) {
 
-			var x = attribute.getX( i );
-			var y = attribute.getY( i );
-			var z = attribute.getZ( i );
+			var numGroups = ( groups && groups.length ) || 1;
+			var indices = indexAttribute.array;
 
-			if ( x < minX ) minX = x;
-			if ( y < minY ) minY = y;
-			if ( z < minZ ) minZ = z;
+			for ( var i = 0; i < numGroups; i ++ ) {
 
-			if ( x > maxX ) maxX = x;
-			if ( y > maxY ) maxY = y;
-			if ( z > maxZ ) maxZ = z;
+				var start;
+				var end;
+				if ( groups[ i ] ) {
+
+					start = groups[ i ].start;
+					end = start + groups[ i ].count;
+
+				} else {
+
+					start = 0;
+					end = index.length;
+
+				}
+
+				for ( var j = start; j < end; j ++ ) {
+
+					var index = indices[ j ];
+					var x = attribute.getX( index );
+					var y = attribute.getY( index );
+					var z = attribute.getZ( index );
+
+					if ( x < minX ) minX = x;
+					if ( y < minY ) minY = y;
+					if ( z < minZ ) minZ = z;
+
+					if ( x > maxX ) maxX = x;
+					if ( y > maxY ) maxY = y;
+					if ( z > maxZ ) maxZ = z;
+
+				}
+
+			}
+
+		} else {
+
+			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
+
+				var x = attribute.getX( i );
+				var y = attribute.getY( i );
+				var z = attribute.getZ( i );
+
+				if ( x < minX ) minX = x;
+				if ( y < minY ) minY = y;
+				if ( z < minZ ) minZ = z;
+
+				if ( x > maxX ) maxX = x;
+				if ( y > maxY ) maxY = y;
+				if ( z > maxZ ) maxZ = z;
+
+			}
 
 		}
 
@@ -250,11 +294,43 @@ Object.assign( Box3.prototype, {
 
 					if ( attribute !== undefined ) {
 
-						for ( i = 0, l = attribute.count; i < l; i ++ ) {
+						var index = geometry.index;
+						var groups = geometry.groups;
 
-							v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
+						if ( index ) {
 
-							scope.expandByPoint( v1 );
+							var indices = index.array;
+
+							if ( groups.length === 0 ) {
+
+								geometry.addGroup( 0, indices.length );
+
+							}
+
+							for ( i = 0; i < groups.length; i ++ ) {
+
+								var start = groups[ i ].start;
+								var end = start + groups[ i ].count;
+
+								for ( var j = start; j < end; j ++ ) {
+
+									v1.fromBufferAttribute( attribute, indices[ j ] ).applyMatrix4( node.matrixWorld );
+
+									scope.expandByPoint( v1 );
+
+								}
+
+							}
+
+						} else {
+
+							for ( i = 0, l = attribute.count; i < l; i ++ ) {
+
+								v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
+
+								scope.expandByPoint( v1 );
+
+							}
 
 						}
 


### PR DESCRIPTION
FYI, the /wiki/How-to-contribute-to-three.js page is not loading for me, sorry if I do something wrong.

This PR makes the Box3.setFromBufferAttribute, Box3.expandByObject, and BufferGeometry.computeBoundingSphere methods consider geometry's indices and groups. This makes them behave more like BufferGeometry.computeVertexNormals.

Previously, if you combined multiple geometry's buffers together, calculating the bounding box would scan the entire vertices buffer, giving incorrect results and being very slow.