### PR TITLE
THREE.SetValues

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -147,6 +147,7 @@ export { CurvePath } from './extras/core/CurvePath.js';
 export { Curve } from './extras/core/Curve.js';
 export { ImageUtils } from './extras/ImageUtils.js';
 export { ShapeUtils } from './extras/ShapeUtils.js';
+export { SetValues } from './extras/SetValues.js';
 export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';
 export * from './constants.js';
 export * from './Three.Legacy.js';

--- a/src/extras/SetValues.js
+++ b/src/extras/SetValues.js
@@ -1,0 +1,44 @@
+function SetValues( scope, values ) {
+
+	if ( values === undefined ) return scope;
+
+	var header = scope.type !== undefined ? "THREE." + scope.type + ": " : "";
+
+	for ( var key in values ) {
+
+		var newValue = values[ key ];
+
+		if ( newValue === undefined ) {
+
+			console.warn( header + "'" + key + "' parameter is undefined." );
+			continue;
+
+		}
+
+		var currentValue = scope[ key ];
+
+		if ( currentValue && currentValue.isColor ) {
+
+			currentValue.set( newValue );
+
+		} else if ( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) ) {
+
+			currentValue.copy( newValue );
+
+		} else if ( scope.hasOwnProperty( key ) ) {
+
+			scope[ key ] = newValue;
+
+		} else {
+
+			console.warn( header + "'" + key + "' property does not exist or has become obsolete." );
+
+		}
+
+	}
+
+	return scope;
+
+}
+
+export { SetValues };

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,6 +1,7 @@
 import { EventDispatcher } from '../core/EventDispatcher.js';
 import { NoColors, FrontSide, FlatShading, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor } from '../constants.js';
 import { _Math } from '../math/Math.js';
+import { SetValues } from '../extras/SetValues.js';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -81,55 +82,26 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		if ( values === undefined ) return;
 
-		for ( var key in values ) {
+		// copy to prevent if backward compatability values is used in others materials
+		values = Object.assign( {}, values );
 
-			var newValue = values[ key ];
+		// for backward compatability if shading is set in the constructor
+		if ( values.shading !== undefined ) {
 
-			if ( newValue === undefined ) {
-
-				console.warn( "THREE.Material: '" + key + "' parameter is undefined." );
-				continue;
-
-			}
-
-			// for backward compatability if shading is set in the constructor
-			if ( key === 'shading' ) {
-
-				console.warn( 'THREE.' + this.type + ': .shading has been removed. Use the boolean .flatShading instead.' );
-				this.flatShading = ( newValue === FlatShading ) ? true : false;
-				continue;
-
-			}
-
-			var currentValue = this[ key ];
-
-			if ( currentValue === undefined ) {
-
-				console.warn( "THREE." + this.type + ": '" + key + "' is not a property of this material." );
-				continue;
-
-			}
-
-			if ( currentValue && currentValue.isColor ) {
-
-				currentValue.set( newValue );
-
-			} else if ( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) ) {
-
-				currentValue.copy( newValue );
-
-			} else if ( key === 'overdraw' ) {
-
-				// ensure overdraw is backwards-compatible with legacy boolean type
-				this[ key ] = Number( newValue );
-
-			} else {
-
-				this[ key ] = newValue;
-
-			}
+			console.warn( 'THREE.' + this.type + ': .shading has been removed. Use the boolean .flatShading instead.' );
+			values.flatShading = ( values.shading === FlatShading ) ? true : false;
+			delete values.shading;
 
 		}
+
+		if ( values.overdraw !== undefined ) {
+
+			// ensure overdraw is backwards-compatible with legacy boolean type
+			values.overdraw = Number( values.overdraw );
+
+		}
+
+		SetValues( this, values );
 
 	},
 


### PR DESCRIPTION
This is a continuation of: https://github.com/mrdoob/three.js/pull/14572#discussion_r210226417
Only if there is interest in continuing with `parameters as an object` we could use `THREE.SetValues` in others class and examples that use `parameters as an object` too.

```javascript
// material
var material = new THREE.MeshLambertMaterial( { map: texture, transparent: true, test:"123" } );

// log warn
"THREE.MeshLambertMaterial: 'test' property does not exist or has become obsolete."
```

![image](https://user-images.githubusercontent.com/502810/44227966-651ffa80-a16a-11e8-953a-1c4c334c02b0.png)
