### PR TITLE
Corrected an error in OrbitControls documentation

### DIFF
--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -190,9 +190,9 @@ controls.keys = {
 			This object contains references to the mouse buttons used for the controls.
 			<code>
 controls.mouseButtons = {
-	LEFT: THREE.MOUSE.LEFT,
-	MIDDLE: THREE.MOUSE.MIDDLE,
-	RIGHT: THREE.MOUSE.RIGHT
+	ORBIT: THREE.MOUSE.LEFT,
+	ZOOM: THREE.MOUSE.MIDDLE,
+	PAN: THREE.MOUSE.RIGHT
 }
 			</code>
 		</p>


### PR DESCRIPTION
there was an error with controls.mouseButtons keys. I changed them from [LEFT, MIDDLE, RIGHT] to [ORBIT, ZOOM, PAN]