### PR TITLE
spotLightHelper: fix duplicate rotation

### DIFF
--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -18,9 +18,6 @@ function SpotLightHelper( light, color ) {
 	this.light = light;
 	this.light.updateMatrixWorld();
 
-	this.matrix = light.matrixWorld;
-	this.matrixAutoUpdate = false;
-
 	this.color = color;
 
 	var geometry = new BufferGeometry();
@@ -52,7 +49,7 @@ function SpotLightHelper( light, color ) {
 	this.cone = new LineSegments( geometry, material );
 	this.add( this.cone );
 
-	this.update();
+		this.update();
 
 }
 
@@ -83,6 +80,7 @@ SpotLightHelper.prototype.update = function () {
 		vector.setFromMatrixPosition( this.light.matrixWorld );
 		vector2.setFromMatrixPosition( this.light.target.matrixWorld );
 
+		this.position.setFromMatrixPosition( this.light.matrixWorld );
 		this.cone.lookAt( vector2.sub( vector ) );
 
 		if ( this.color !== undefined ) {

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -80,7 +80,7 @@ SpotLightHelper.prototype.update = function () {
 		vector.setFromMatrixPosition( this.light.matrixWorld );
 		vector2.setFromMatrixPosition( this.light.target.matrixWorld );
 
-		this.position.setFromMatrixPosition( this.light.matrixWorld );
+		this.position.copy( vector );
 		this.cone.lookAt( vector2.sub( vector ) );
 
 		if ( this.color !== undefined ) {

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -66,7 +66,6 @@ SpotLightHelper.prototype.dispose = function () {
 SpotLightHelper.prototype.update = function () {
 
 	var vector = new Vector3();
-	var vector2 = new Vector3();
 
 	return function update() {
 
@@ -77,11 +76,10 @@ SpotLightHelper.prototype.update = function () {
 
 		this.cone.scale.set( coneWidth, coneWidth, coneLength );
 
-		vector.setFromMatrixPosition( this.light.matrixWorld );
-		vector2.setFromMatrixPosition( this.light.target.matrixWorld );
+		vector.setFromMatrixPosition( this.light.target.matrixWorld );
 
-		this.position.copy( vector );
-		this.cone.lookAt( vector2.sub( vector ) );
+		this.position.setFromMatrixPosition( this.light.matrixWorld );
+		this.cone.lookAt( vector.sub( this.position ) );
 
 		if ( this.color !== undefined ) {
 

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -49,7 +49,7 @@ function SpotLightHelper( light, color ) {
 	this.cone = new LineSegments( geometry, material );
 	this.add( this.cone );
 
-		this.update();
+	this.update();
 
 }
 


### PR DESCRIPTION
When I rotate the parent of spot light, the cone of light helper will rotate twice.

![image](https://user-images.githubusercontent.com/7625588/44301993-606a6a80-a353-11e8-837b-b563865c490f.png)

### Scene tree
- scene
  - spotLight group (transform control attach here)
    - spot light
    - target of spot light

[Example](https://gist.github.com/but0n/29939ee781ce75902b431208816e9570)

`this.matrix = light.matrixWorld;` 

 - The only thing this object need is the world position of the spot light, but this matrix here include world position and world rotation (not direction) of the light, so the helper will apply the world rotation matrix of the light.

`this.cone.lookAt( vector2.sub( vector ) );`
 -  this will also locally rotate the cone to the correct direction.