### PR TITLE
OBJLoader example: load all assets before adding object to the scene

### DIFF
--- a/examples/webgl_loader_obj.html
+++ b/examples/webgl_loader_obj.html
@@ -44,6 +44,7 @@
 			var windowHalfX = window.innerWidth / 2;
 			var windowHalfY = window.innerHeight / 2;
 
+			var object;
 
 			init();
 			animate();
@@ -68,32 +69,9 @@
 				camera.add( pointLight );
 				scene.add( camera );
 
-				// texture
+				// manager
 
-				var manager = new THREE.LoadingManager();
-				manager.onProgress = function ( item, loaded, total ) {
-
-					console.log( item, loaded, total );
-
-				};
-
-				var textureLoader = new THREE.TextureLoader( manager );
-				var texture = textureLoader.load( 'textures/UV_Grid_Sm.jpg' );
-
-				// model
-
-				var onProgress = function ( xhr ) {
-					if ( xhr.lengthComputable ) {
-						var percentComplete = xhr.loaded / xhr.total * 100;
-						console.log( Math.round(percentComplete, 2) + '% downloaded' );
-					}
-				};
-
-				var onError = function ( xhr ) {
-				};
-
-				var loader = new THREE.OBJLoader( manager );
-				loader.load( 'models/obj/male02/male02.obj', function ( object ) {
+				var loadModel = function () {
 
 					object.traverse( function ( child ) {
 
@@ -107,6 +85,46 @@
 
 					object.position.y = - 95;
 					scene.add( object );
+
+					console.log( `added object to scene` );
+
+				};
+
+				var manager = new THREE.LoadingManager( loadModel );
+
+				manager.onProgress = function ( item, loaded, total ) {
+
+					console.log( item, loaded, total );
+
+				};
+
+				// texture
+
+				var textureLoader = new THREE.TextureLoader( manager );
+
+				var texture = textureLoader.load( 'textures/UV_Grid_Sm.jpg' );
+
+				// model
+
+				var onProgress = function ( xhr ) {
+
+					if ( xhr.lengthComputable ) {
+
+						var percentComplete = xhr.loaded / xhr.total * 100;
+						console.log( 'model ' + Math.round( percentComplete, 2 ) + '% downloaded' );
+
+					}
+
+				};
+
+				var onError = function ( xhr ) {
+				};
+
+				var loader = new THREE.OBJLoader( manager );
+
+				loader.load( 'models/obj/male02/male02.obj', function ( obj ) {
+
+					object = obj;
 
 				}, onProgress, onError );
 


### PR DESCRIPTION
It was not clear to me we had an example of this use case. If not, here is one.

Maybe this PR can be further improved...