### PR TITLE
Revert "WebVRManager: Added device.capabilities.hasExternalDisplay support."

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -159,7 +159,6 @@ function WebGLRenderer( parameters ) {
 
 		// frustum
 
-		_camera = null,
 		_frustum = new Frustum(),
 
 		// clipping
@@ -1044,7 +1043,6 @@ function WebGLRenderer( parameters ) {
 		_currentGeometryProgram.wireframe = false;
 		_currentMaterialId = - 1;
 		_currentCamera = null;
-		_camera = camera;
 
 		// update scene graph
 
@@ -1126,7 +1124,12 @@ function WebGLRenderer( parameters ) {
 
 		} else {
 
+			// opaque pass (front-to-back order)
+
 			if ( opaqueObjects.length ) renderObjects( opaqueObjects, scene, camera );
+
+			// transparent pass (back-to-front order)
+
 			if ( transparentObjects.length ) renderObjects( transparentObjects, scene, camera );
 
 		}
@@ -1151,7 +1154,7 @@ function WebGLRenderer( parameters ) {
 
 		if ( vr.enabled ) {
 
-			vr.submitFrame( scene, _camera );
+			vr.submitFrame();
 
 		}
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -356,21 +356,9 @@ function WebVRManager( renderer ) {
 
 	};
 
-	this.submitFrame = function ( scene, camera ) {
+	this.submitFrame = function () {
 
-		if ( isPresenting() ) {
-
-			device.submitFrame();
-
-			if ( device.capabilities.hasExternalDisplay ) {
-
-				scope.enabled = false;
-				renderer.render( scene, camera );
-				scope.enabled = true;
-
-			}
-
-		}
+		if ( isPresenting() ) device.submitFrame();
 
 	};
 


### PR DESCRIPTION
Reverts mrdoob/three.js#14743

Didn't fix Edge not showing spectator more.

In Firefox works correctly but due to the unstability of the feature it may be better to do it outside of core for now.