### PR TITLE
Fix double animation loop

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -56,7 +56,6 @@ function WebVRManager( renderer ) {
 	}
 
 	var currentSize, currentPixelRatio;
-	var isAnimating;
 
 	function onVRDisplayPresentChange() {
 
@@ -83,13 +82,7 @@ function WebVRManager( renderer ) {
 
 			}
 
-			if ( isAnimating ) {
-
-				animation.stop();
-
-				isAnimating = false;
-
-			}
+			animation.stop();
 
 		}
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -56,6 +56,7 @@ function WebVRManager( renderer ) {
 	}
 
 	var currentSize, currentPixelRatio;
+	var isAnimating;
 
 	function onVRDisplayPresentChange() {
 
@@ -72,11 +73,23 @@ function WebVRManager( renderer ) {
 
 			animation.start();
 
-		} else if ( scope.enabled ) {
+			isAnimating = true;
 
-			renderer.setDrawingBufferSize( currentSize.width, currentSize.height, currentPixelRatio );
+		} else {
 
-			animation.stop();
+			if ( scope.enabled ) {
+
+				renderer.setDrawingBufferSize( currentSize.width, currentSize.height, currentPixelRatio );
+
+			}
+
+			if ( isAnimating ) {
+
+				animation.stop();
+
+				isAnimating = false;
+
+			}
 
 		}
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -72,8 +72,6 @@ function WebVRManager( renderer ) {
 
 			animation.start();
 
-			isAnimating = true;
-
 		} else {
 
 			if ( scope.enabled ) {


### PR DESCRIPTION
Stop the animation loop created by WebVRManager when exiting VR, even if the component is no longer `enabled`. This used to leave _two parallel animation frame loops_ going.
