### PR TITLE
DOCS: add note that equirectangular envmap is not supported by Standard material

### DIFF
--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -172,6 +172,12 @@
 		of the env texture.  TextureCubes created with default settings are correctly configured;
 		if adjusting texture parameters manually, ensure minFilter is set to one of the MipMap options,
 		and that mip maps have not been otherwise forcibly disabled.</p>
+		<p>
+		Note: only [link:https://threejs.org/docs/#api/textures/CubeTexture cube environment maps] are supported 
+		for MeshStandardMaterial. If you want to use an equirectangular map you will need to use the 
+		[link:https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/EquirectangularToCubeGenerator.js EquirectangularToCubeGenerator]. 
+		See this [link:https://threejs.org/examples/webgl_materials_envmaps_exr.html example] for details.
+		</p>
 
 		<h3>[property:Float envMapIntensity]</h3>
 		<p>Scales the effect of the environment map by multiplying its color.</p>


### PR DESCRIPTION
As per @WestLangley's comment:
https://github.com/mrdoob/three.js/issues/14709#issuecomment-412926600