### PR TITLE
Fix PLYExporter includeIndices LGTM warning

### DIFF
--- a/examples/js/exporters/PLYExporter.js
+++ b/examples/js/exporters/PLYExporter.js
@@ -73,7 +73,6 @@ THREE.PLYExporter.prototype = {
 		var includeNormals = false;
 		var includeColors = false;
 		var includeUVs = false;
-		var includeIndices = true;
 
 		// count the vertices, check which properties are used,
 		// and cache the BufferGeometry
@@ -123,10 +122,10 @@ THREE.PLYExporter.prototype = {
 
 		} );
 
+		var includeIndices = excludeAttributes.indexOf( 'index' ) === - 1;
 		includeNormals = includeNormals && excludeAttributes.indexOf( 'normal' ) === - 1;
 		includeColors = includeColors && excludeAttributes.indexOf( 'color' ) === - 1;
 		includeUVs = includeUVs && excludeAttributes.indexOf( 'uv' ) === - 1;
-		includeIndices = includeIndices && excludeAttributes.indexOf( 'index' ) === - 1;
 
 
 		if ( includeIndices && faceCount !== Math.floor( faceCount ) ) {


### PR DESCRIPTION
Address the LGTM warning brought up here:

https://github.com/mrdoob/three.js/commit/3dfba94d763f516c923aad5b9b3ffc73a9213289#r30262824