### PR TITLE
Color: add .setColorName() and Color.NAMES

### DIFF
--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -126,7 +126,7 @@ var color = new THREE.Color( 1, 0, 0 );
 		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
 		Converts this color from gamma space to linear space by taking [page:.r r], [page:.g g] and [page:.b b] to the power of [page:Float gammaFactor].
 		</p>
-		
+
 		<h3>[method:Color convertLinearToGamma]( [param:Float gammaFactor] ) </h3>
 		<p>
 		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
@@ -300,6 +300,15 @@ var color = new THREE.Color( 1, 0, 0 );
 		but the alpha-channel coordinate will be discarded.<br /><br />
 
 		Note that for X11 color names, multiple words such as Dark Orange become the string 'darkorange' (all lowercase).
+		</p>
+
+		<h3>[method:Color setStyleName]( [param:String style] ) </h3>
+		<p>
+		[page:String style] — color name ( from [link:https://en.wikipedia.org/wiki/X11_color_names#Color_name_chart X11 color names] ).<br /><br />
+
+		Sets this color from a color name. Faster than [page:.setStyle] method if you don't need the other CSS-style formats.<br/><br/>
+
+		For convenience, the list of names is exposed in Color.NAMES as a hash: <code>Color.NAMES.aliceblue // returns 0xF0F8FF</code>
 		</p>
 
 		<h3>[method:Color sub]( [param:Color color] ) </h3>

--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -302,7 +302,7 @@ var color = new THREE.Color( 1, 0, 0 );
 		Note that for X11 color names, multiple words such as Dark Orange become the string 'darkorange' (all lowercase).
 		</p>
 
-		<h3>[method:Color setStyleName]( [param:String style] ) </h3>
+		<h3>[method:Color setColorName]( [param:String style] ) </h3>
 		<p>
 		[page:String style] — color name ( from [link:https://en.wikipedia.org/wiki/X11_color_names#Color_name_chart X11 color names] ).<br /><br />
 

--- a/src/math/Color.d.ts
+++ b/src/math/Color.d.ts
@@ -69,6 +69,13 @@ export class Color {
 	setStyle( style: string ): Color;
 
 	/**
+	 * Sets this color from a color name.
+	 * Faster than {@link Color#setStyle .setStyle()} method if you don't need the other CSS-style formats.
+	 * @param style Color name in X11 format.
+	 */
+	setColorName( style: string ): Color;
+
+	/**
 	 * Clones this color.
 	 */
 	clone(): this;
@@ -182,5 +189,10 @@ export class Color {
 	 * @return The provided array-like.
 	 */
 	toArray( xyz: ArrayLike<number>, offset?: number ): ArrayLike<number>;
+
+	/**
+	 * List of X11 color names.
+	 */
+	static NAMES: Record<string, number>;
 
 }

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -261,7 +261,7 @@ Object.assign( Color.prototype, {
 
 		if ( style && style.length > 0 ) {
 
-			return this.setStyleName( style );
+			return this.setColorName( style );
 
 		}
 
@@ -269,7 +269,7 @@ Object.assign( Color.prototype, {
 
 	},
 
-	setStyleName: function ( style ) {
+	setColorName: function ( style ) {
 
 		// color keywords
 		var hex = _colorKeywords[ style ];

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -261,20 +261,28 @@ Object.assign( Color.prototype, {
 
 		if ( style && style.length > 0 ) {
 
-			// color keywords
-			var hex = _colorKeywords[ style ];
+			return this.setStyleName( style );
 
-			if ( hex !== undefined ) {
+		}
 
-				// red
-				this.setHex( hex );
+		return this;
 
-			} else {
+	},
 
-				// unknown color
-				console.warn( 'THREE.Color: Unknown color ' + style );
+	setStyleName: function ( style ) {
 
-			}
+		// color keywords
+		var hex = _colorKeywords[ style ];
+
+		if ( hex !== undefined ) {
+
+			// red
+			this.setHex( hex );
+
+		} else {
+
+			// unknown color
+			console.warn( 'THREE.Color: Unknown color ' + style );
 
 		}
 
@@ -580,5 +588,6 @@ Object.assign( Color.prototype, {
 
 } );
 
+Color.NAMES = ColorKeywords;
 
 export { Color };

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -588,6 +588,6 @@ Object.assign( Color.prototype, {
 
 } );
 
-Color.NAMES = ColorKeywords;
+Color.NAMES = _colorKeywords;
 
 export { Color };

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -144,12 +144,17 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.g == 0xAB / 255, "Green: " + a.g );
 			assert.ok( a.b == 0xC1 / 255, "Blue: " + a.b );
 
+			a.setStyle( "aliceblue" );
+			assert.ok( a.r == 0xF0 / 255, "Red: " + a.r );
+			assert.ok( a.g == 0xF8 / 255, "Green: " + a.g );
+			assert.ok( a.b == 0xFF / 255, "Blue: " + a.b );
+
 		} );
 
-		QUnit.test( "setStyleName", ( assert ) => {
+		QUnit.test( "setColorName", ( assert ) => {
 
 			var c = new Color();
-			var res = c.setStyleName( "aliceblue" );
+			var res = c.setColorName( "aliceblue" );
 
 			assert.ok( c.getHex() == 0xF0F8FF, "Hex: " + c.getHex() );
 			assert.ok( c == res, "Returns Self" );

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -28,6 +28,13 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		// EXPOSED CONSTANTS
+		QUnit.test( "Color.NAMES", ( assert ) => {
+
+			assert.ok( Color.NAMES.aliceblue == 0xF0F8FF, "Exposed Color.NAMES" );
+
+		} );
+
 		// PUBLIC STUFF
 		QUnit.test( "isColor", ( assert ) => {
 
@@ -136,6 +143,16 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.r == 0xF8 / 255, "Red: " + a.r );
 			assert.ok( a.g == 0xAB / 255, "Green: " + a.g );
 			assert.ok( a.b == 0xC1 / 255, "Blue: " + a.b );
+
+		} );
+
+		QUnit.test( "setStyleName", ( assert ) => {
+
+			var c = new Color();
+			var res = c.setStyleName( "aliceblue" );
+
+			assert.ok( c.getHex() == 0xF0F8FF, "Hex: " + c.getHex() );
+			assert.ok( c == res, "Returns Self" );
 
 		} );
 
@@ -340,16 +357,6 @@ export default QUnit.module( 'Maths', () => {
 			var c2 = new Color( 'ivory' );
 			c.copy( c2 );
 			assert.ok( c.getHex() == c2.getHex(), "Hex c: " + c.getHex() + " Hex c2: " + c2.getHex() );
-
-		} );
-
-		QUnit.test( "setRGB", ( assert ) => {
-
-			var c = new Color();
-			c.setRGB( 1, 0.2, 0.1 );
-			assert.ok( c.r == 1, "Red: " + c.r );
-			assert.ok( c.g == 0.2, "Green: " + c.g );
-			assert.ok( c.b == 0.1, "Blue: " + c.b );
 
 		} );
 


### PR DESCRIPTION
**Summary**

* expose `_colorKeywords` (as `Color.NAMES`) to be used by external code
* add `.setColorName` to set color directly from X11 name

**Motivation**

While developing a game using ThreeJS, I noticed the Color class internally declares a list of X11 colors that I could use in my project as well. That object is kind of big so I thought it would be helpful to expose it, keeping me from creating another color list.

I also created a new instance method called `setColorName` which receives the color name and skips unnecessary checks in `setStyle` for better performance.

**Notes**

* The deleted "todo" test block on `setRGB` was apparently duplicated, so I deleted it. The proper test already exists at line ~~298~~ 88.
* ~~While I was at it I added a test on `isColor`.~~ (A test to `isColor` was added by the last rebase so I removed my change.)

This is my first PR, so let me know if I missed anything or did anything wrong. The new code has tests and is properly linted. Any advice and feedback would be appreciated.