### PR TITLE
Example Variable Clean up

### DIFF
--- a/examples/canvas_geometry_birds.html
+++ b/examples/canvas_geometry_birds.html
@@ -355,10 +355,6 @@
 
 			}
 
-		</script>
-
-		<script>
-
 			var SCREEN_WIDTH = window.innerWidth,
 			SCREEN_HEIGHT = window.innerHeight,
 			SCREEN_WIDTH_HALF = SCREEN_WIDTH  / 2,

--- a/examples/canvas_geometry_panorama.html
+++ b/examples/canvas_geometry_panorama.html
@@ -44,6 +44,8 @@
 			var texture_placeholder,
 			isUserInteracting = false,
 			onMouseDownMouseX = 0, onMouseDownMouseY = 0,
+			onPointerDownPointerX = 0, onPointerDownPointerY = 0,
+			onPointerDownLon = 0, onPointerDownLat = 0,
 			lon = 90, onMouseDownLon = 0,
 			lat = 0, onMouseDownLat = 0,
 			phi = 0, theta = 0,

--- a/examples/canvas_geometry_panorama_fisheye.html
+++ b/examples/canvas_geometry_panorama_fisheye.html
@@ -44,6 +44,8 @@
 			var texture_placeholder,
 			isUserInteracting = false,
 			onMouseDownMouseX = 0, onMouseDownMouseY = 0,
+			onPointerDownPointerX = 0, onPointerDownPointerY = 0,
+			onPointerDownLon = 0, onPointerDownLat = 0,
 			lon = 90, onMouseDownLon = 0,
 			lat = 0, onMouseDownLat = 0,
 			phi = 0, theta = 0,

--- a/examples/css2d_label.html
+++ b/examples/css2d_label.html
@@ -46,7 +46,7 @@
 
 		<script>
 
-			var camera, scene, renderer, labelRenderer;
+			var camera, scene, scene2, renderer, labelRenderer;
 			var controls;
 			var clock = new THREE.Clock();
 			var textureLoader = new THREE.TextureLoader();

--- a/examples/css3d_panorama_deviceorientation.html
+++ b/examples/css3d_panorama_deviceorientation.html
@@ -39,6 +39,7 @@
 		<script>
 
 			var camera, scene, renderer;
+			var controls;
 			var geometry, material, mesh;
 
 			init();

--- a/examples/js/Volume.js
+++ b/examples/js/Volume.js
@@ -357,7 +357,6 @@ THREE.Volume.prototype = {
 
 		} );
 		var argumentsWithInversion = [ 'volume.xLength-1-', 'volume.yLength-1-', 'volume.zLength-1-' ];
-		var arguments = [ 'i', 'j', 'k' ];
 		var argArray = [ iDirection, jDirection, kDirection ].map( function( direction, n ) {
 
 			return ( direction.dot( base[ n ] ) > 0 ? '' : argumentsWithInversion[ n ] ) + ( direction === axisInIJK ? 'IJKIndex' : direction.argVar )

--- a/examples/js/modifiers/SimplifyModifier.js
+++ b/examples/js/modifiers/SimplifyModifier.js
@@ -167,7 +167,7 @@ THREE.SimplifyModifier = function () {};
 		if ( f.v3 ) removeFromArray( f.v3.faces, f );
 
 		// TODO optimize this!
-		var vs = [ this.v1, this.v2, this.v3 ];
+		var vs = [ f.v1, f.v2, f.v3 ];
 		var v1, v2;
 
 		for ( var i = 0; i < 3; i ++ ) {

--- a/examples/software_lines_splines.html
+++ b/examples/software_lines_splines.html
@@ -59,7 +59,7 @@
 			windowHalfX = window.innerWidth / 2,
 			windowHalfY = window.innerHeight / 2,
 
-			camera, scene, renderer, material;
+			camera, scene, renderer, material, stats;
 
 			init();
 			animate();

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -53,7 +53,7 @@
 			};
 
 			var container, stats;
-			var camera, scene, renderer;
+			var camera, scene, renderer, spotlight;
 			var splineHelperObjects = [], splineOutline;
 			var splinePointsLength = 4;
 			var positions = [];

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -531,9 +531,9 @@
 				var uniforms = heightmapVariable.material.uniforms;
 				if ( mouseMoved ) {
 
-					this.raycaster.setFromCamera( mouseCoords, camera );
+					raycaster.setFromCamera( mouseCoords, camera );
 
-					var intersects = this.raycaster.intersectObject( meshRay );
+					var intersects = raycaster.intersectObject( meshRay );
 
 					if ( intersects.length > 0 ) {
 					    var point = intersects[ 0 ].point;

--- a/examples/webgl_loader_ctm.html
+++ b/examples/webgl_loader_ctm.html
@@ -64,6 +64,7 @@
 
 			var textureLoader = new THREE.TextureLoader();
 			var cubeTextureLoader = new THREE.CubeTextureLoader();
+			var reflectionCube;
 
 			document.addEventListener('mousemove', onDocumentMouseMove, false);
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -100,6 +100,8 @@
 
 		var effectController;
 
+		var controls;
+
 		var time = 0;
 		var clock = new THREE.Clock();
 

--- a/examples/webgl_materials_curvature.html
+++ b/examples/webgl_materials_curvature.html
@@ -79,6 +79,8 @@
 
 			var camera, scene, renderer;
 
+			var controls;
+
 			var ninjaMeshRaw, curvatureAttribute, bufferGeo;
 
 			init();

--- a/examples/webgl_modifier_subdivision.html
+++ b/examples/webgl_modifier_subdivision.html
@@ -29,7 +29,7 @@
 
 			var camera, controls, scene, renderer;
 
-			var cube, mesh, material;
+			var cube, mesh, material, geometry, smooth, group;
 
 			// Create new object by parameters
 

--- a/examples/webgl_modifier_tessellation.html
+++ b/examples/webgl_modifier_tessellation.html
@@ -90,6 +90,8 @@
 
 		var renderer, scene, camera, stats;
 
+		var controls;
+
 		var mesh, uniforms;
 
 		var WIDTH = window.innerWidth,

--- a/examples/webgl_nearestneighbour.html
+++ b/examples/webgl_nearestneighbour.html
@@ -76,6 +76,7 @@
 
 			var amountOfParticles = 500000, maxDistance = Math.pow( 120, 2 );
 			var positions, alphas, particles, _particleGeom;
+			var kdtree;
 
 			var clock = new THREE.Clock();
 

--- a/examples/webgl_physics_convex_break.html
+++ b/examples/webgl_physics_convex_break.html
@@ -300,9 +300,9 @@
 			var shape = new Ammo.btConvexHullShape();
 
 			for ( var i = 0, il = coords.length; i < il; i+= 3 ) {
-				this.tempBtVec3_1.setValue( coords[ i ], coords[ i + 1 ], coords[ i + 2 ] );
+				tempBtVec3_1.setValue( coords[ i ], coords[ i + 1 ], coords[ i + 2 ] );
 				var lastOne = ( i >= ( il - 3 ) );
-				shape.addPoint( this.tempBtVec3_1, lastOne );
+				shape.addPoint( tempBtVec3_1, lastOne );
 			}
 
 			return shape;

--- a/examples/webgl_physics_terrain.html
+++ b/examples/webgl_physics_terrain.html
@@ -204,7 +204,7 @@
 
 						// Create the terrain body
 
-						var groundShape = createTerrainShape( heightData );
+						var groundShape = createTerrainShape();
 						var groundTransform = new Ammo.btTransform();
 						groundTransform.setIdentity();
 						// Shifts the terrain, since bullet re-centers it on its bounding box.

--- a/examples/webgl_physics_terrain.html
+++ b/examples/webgl_physics_terrain.html
@@ -204,7 +204,7 @@
 
 						// Create the terrain body
 
-						var groundShape = this.createTerrainShape( heightData );
+						var groundShape = createTerrainShape( heightData );
 						var groundTransform = new Ammo.btTransform();
 						groundTransform.setIdentity();
 						// Shifts the terrain, since bullet re-centers it on its bounding box.

--- a/examples/webgl_postprocessing_afterimage.html
+++ b/examples/webgl_postprocessing_afterimage.html
@@ -32,7 +32,13 @@
 			var camera, scene, renderer, composer;
 			var mesh, light;
 
-			var afterimagePass, enable = true;
+			var afterimagePass;
+
+			var params = {
+
+				enable: true
+
+			};
 
 			init();
 			createGUI();
@@ -73,7 +79,7 @@
 
 				var gui = new dat.GUI( { name: 'Damp setting' } );
 				gui.add( afterimagePass.uniforms[ "damp" ], 'value', 0, 1 ).step( 0.001 );
-				gui.add( this, 'enable' );
+				gui.add( params, 'enable' );
 
 			}
 
@@ -94,7 +100,7 @@
 				mesh.rotation.x += 0.005;
 				mesh.rotation.y += 0.01;
 
-				if( enable ){
+				if( params.enable ){
 
 					composer.render();
 

--- a/examples/webgl_postprocessing_procedural.html
+++ b/examples/webgl_postprocessing_procedural.html
@@ -81,8 +81,10 @@
 
 		<script>
 
-			var camera, postScene, renderer, postMaterial, noiseRandom1DMaterial, noiseRandon2DMaterial, noiseRandom3DMaterial, postQuad;
+			var camera, postCamera, postScene, renderer;
+			var postMaterial, noiseRandom1DMaterial, noiseRandom2DMaterial, noiseRandom3DMaterial, postQuad;
 			var gui, stats, texture;
+			var index = 0;
 
 			var params = { procedure: 'noiseRandom3D' };
 
@@ -149,11 +151,9 @@
 
 			function animate() {
 
-				this.index = this.index || 0;
-
 				requestAnimationFrame( animate );
 
-				this.index ++;
+				index ++;
 
 				switch ( params.procedure ) {
 

--- a/examples/webgl_postprocessing_rgb_halftone.html
+++ b/examples/webgl_postprocessing_rgb_halftone.html
@@ -60,7 +60,7 @@
 		}
 
 		// setup
-		var wrapper, renderer, clock, camera, controls, stats;
+		var wrapper, renderer, clock, camera, controls, stats, rotationSpeed;
 
 		wrapper = document.createElement( 'div' );
 		renderer = new THREE.WebGLRenderer();

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -56,6 +56,7 @@
 
 			var camera, scene, renderer, composer, copyPass, taaRenderPass, renderPass;
 			var gui, stats, texture;
+			var index = 0;
 
 			var param = { TAAEnabled: "1", TAASampleLevel: 0 };
 
@@ -180,13 +181,11 @@
 
 			function animate() {
 
-				this.index = this.index || 0;
-
 				requestAnimationFrame( animate );
 
-				this.index ++;
+				index ++;
 
-				if( Math.round( this.index / 200 ) % 2 === 0 ) {
+				if( Math.round( index / 200 ) % 2 === 0 ) {
 					for ( var i = 0; i < scene.children.length; i ++ ) {
 
 						var child = scene.children[ i ];

--- a/examples/webgl_raycast_texture.html
+++ b/examples/webgl_raycast_texture.html
@@ -73,7 +73,7 @@
 		<script src="../build/three.js"></script>
 		<script>
 
-			CanvasTexture = function ( parentTexture ) {
+			var CanvasTexture = function ( parentTexture ) {
 
 				this._canvas = document.createElement( "canvas" );
 				this._canvas.width = this._canvas.height = 1024;
@@ -182,9 +182,6 @@
 				}
 
 			}
-
-		</script>
-		<script>
 
 			var width = window.innerWidth;
 			var height = window.innerHeight;

--- a/examples/webgl_refraction.html
+++ b/examples/webgl_refraction.html
@@ -47,7 +47,7 @@
 
 		if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
-		var scene, camera, clock, renderer, refractor;
+		var scene, camera, clock, renderer, refractor, controls;
 
 		init();
 

--- a/examples/webgl_simple_gi.html
+++ b/examples/webgl_simple_gi.html
@@ -163,7 +163,7 @@
 
 			//
 
-			var camera, scene, renderer;
+			var camera, scene, renderer, controls;
 
 			init();
 			animate();

--- a/examples/webgl_tiled_forward.html
+++ b/examples/webgl_tiled_forward.html
@@ -171,7 +171,7 @@
 		// Screen rectangle bounds from light sphere's world AABB
 		var lightBounds = function () {
 
-			v = new THREE.Vector3();
+			var v = new THREE.Vector3();
 			return function ( camera, pos, r ) {
 
 				var minX = State.width, maxX = 0, minY = State.height, maxY = 0, hw = State.width / 2, hh = State.height / 2;
@@ -224,7 +224,7 @@
 		var stats = new Stats();
 		container.appendChild( stats.dom );
 
-		controls = new THREE.OrbitControls( camera, renderer.domElement );
+		var controls = new THREE.OrbitControls( camera, renderer.domElement );
 		controls.minDistance = 120;
 		controls.maxDistance = 320;
 

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -49,7 +49,7 @@
 
 		if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
-		var scene, camera, clock, renderer, water;
+		var scene, camera, clock, renderer, controls, water;
 
 		var torusKnot;
 

--- a/examples/webgl_water_flowmap.html
+++ b/examples/webgl_water_flowmap.html
@@ -49,7 +49,7 @@
 
 		if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
-		var scene, camera, renderer, water;
+		var scene, camera, renderer, controls, water;
 
 		init();
 		animate();


### PR DESCRIPTION
I'm looking into what it would take to get the example files running using es6 imports and found that some of the code can't be run in a `modules` context, so I thought I'd make a PR to fix some of those problems.

For the most part the changes address:

- assumption of shared scope between script tags
- using variables before they're defined
- assuming the global `this` is `window`