### PR TITLE
Fix missing .skinning/morphTarget/morphNormals copy in VRM example

### DIFF
--- a/examples/webgl_loader_vrm.html
+++ b/examples/webgl_loader_vrm.html
@@ -92,6 +92,9 @@
 									material.color.copy( object.material[ i ].color );
 									material.map = object.material[ i ].map;
 									material.lights = false;
+									material.skinning = object.material[ i ].skinning;
+									material.morphTargets = object.material[ i ].morphTargets;
+									material.morphNormals = object.material[ i ].morphNormals;
 									object.material[ i ] = material;
 
 								}
@@ -103,6 +106,9 @@
 								material.color.copy( object.material.color );
 								material.map = object.material.map;
 								material.lights = false;
+								material.skinning = object.material.skinning;
+								material.morphTargets = object.material.morphTargets;
+								material.morphNormals = object.material.morphNormals;
 								object.material = material;
 
 							}


### PR DESCRIPTION
This PR fixes missing `.skinning/morphTarget/morphNormals` copy in `VRM` example. Now `VRM` model in the example can skin/morph transform with this change.