### PR TITLE
Move EffectComposer "Pass" into its own file

### DIFF
--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -32,6 +32,12 @@ THREE.EffectComposer = function ( renderer, renderTarget ) {
 
 	// dependencies
 
+	if ( THREE.Pass === undefined ) {
+
+		console.error( 'THREE.Pass has been moved into a separate file, "Pass.js". Include it, as well.' );
+
+	}
+
 	if ( THREE.CopyShader === undefined ) {
 
 		console.error( 'THREE.EffectComposer relies on THREE.CopyShader' );
@@ -154,35 +160,6 @@ Object.assign( THREE.EffectComposer.prototype, {
 			this.passes[ i ].setSize( width, height );
 
 		}
-
-	}
-
-} );
-
-
-THREE.Pass = function () {
-
-	// if set to true, the pass is processed by the composer
-	this.enabled = true;
-
-	// if set to true, the pass indicates to swap read and write buffer after rendering
-	this.needsSwap = true;
-
-	// if set to true, the pass clears its buffer before rendering
-	this.clear = false;
-
-	// if set to true, the result of the pass is rendered to screen
-	this.renderToScreen = false;
-
-};
-
-Object.assign( THREE.Pass.prototype, {
-
-	setSize: function ( width, height ) {},
-
-	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
-
-		console.error( 'THREE.Pass: .render() must be implemented in derived pass.' );
 
 	}
 

--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -2,6 +2,12 @@
  * @author alteredq / http://alteredqualia.com/
  */
 
+if ( THREE.Pass === undefined ) {
+
+	console.warn( 'THREE.Pass has been moved into a separate file, "postprocessing/Pass.js". Include it, as well.' );
+
+}
+
 THREE.EffectComposer = function ( renderer, renderTarget ) {
 
 	this.renderer = renderer;
@@ -31,12 +37,6 @@ THREE.EffectComposer = function ( renderer, renderTarget ) {
 	this.passes = [];
 
 	// dependencies
-
-	if ( THREE.Pass === undefined ) {
-
-		console.error( 'THREE.Pass has been moved into a separate file, "Pass.js". Include it, as well.' );
-
-	}
 
 	if ( THREE.CopyShader === undefined ) {
 

--- a/examples/js/postprocessing/Pass.js
+++ b/examples/js/postprocessing/Pass.js
@@ -1,0 +1,27 @@
+THREE.Pass = function () {
+
+	// if set to true, the pass is processed by the composer
+	this.enabled = true;
+
+	// if set to true, the pass indicates to swap read and write buffer after rendering
+	this.needsSwap = true;
+
+	// if set to true, the pass clears its buffer before rendering
+	this.clear = false;
+
+	// if set to true, the result of the pass is rendered to screen
+	this.renderToScreen = false;
+
+};
+
+Object.assign( THREE.Pass.prototype, {
+
+	setSize: function ( width, height ) {},
+
+	render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
+
+		console.error( 'THREE.Pass: .render() must be implemented in derived pass.' );
+
+	}
+
+} );

--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -40,6 +40,7 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/FilmShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgl_loader_sea3d.html
+++ b/examples/webgl_loader_sea3d.html
@@ -37,6 +37,7 @@
 
 		<script src="js/controls/OrbitControls.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_loader_sea3d_hierarchy.html
+++ b/examples/webgl_loader_sea3d_hierarchy.html
@@ -37,6 +37,7 @@
 
 		<script src="js/controls/OrbitControls.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_loader_sea3d_keyframe.html
+++ b/examples/webgl_loader_sea3d_keyframe.html
@@ -37,6 +37,7 @@
 
 		<script src="js/controls/OrbitControls.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_loader_sea3d_morph.html
+++ b/examples/webgl_loader_sea3d_morph.html
@@ -37,6 +37,7 @@
 
 		<script src="js/controls/OrbitControls.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_loader_sea3d_physics.html
+++ b/examples/webgl_loader_sea3d_physics.html
@@ -37,6 +37,7 @@
 
 		<script src="js/controls/OrbitControls.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_loader_sea3d_skinning.html
+++ b/examples/webgl_loader_sea3d_skinning.html
@@ -39,6 +39,7 @@
 
 		<script src="js/controls/OrbitControls.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_loader_sea3d_sound.html
+++ b/examples/webgl_loader_sea3d_sound.html
@@ -84,6 +84,7 @@
 
 		<script src="js/controls/PointerLockControls.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>
@@ -100,6 +101,7 @@
 		<script src="js/libs/stats.min.js"></script>
 
 		<script>
+			'use strict';
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 

--- a/examples/webgl_loader_sea3d_sound.html
+++ b/examples/webgl_loader_sea3d_sound.html
@@ -101,7 +101,6 @@
 		<script src="js/libs/stats.min.js"></script>
 
 		<script>
-			'use strict';
 
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -63,6 +63,7 @@
 	<script src="js/shaders/HorizontalTiltShiftShader.js"></script>
 	<script src="js/shaders/VerticalTiltShiftShader.js"></script>
 
+	<script src="js/postprocessing/Pass.js"></script>
 	<script src="js/postprocessing/EffectComposer.js"></script>
 	<script src="js/postprocessing/RenderPass.js"></script>
 	<script src="js/postprocessing/BloomPass.js"></script>

--- a/examples/webgl_materials_bumpmap_skin.html
+++ b/examples/webgl_materials_bumpmap_skin.html
@@ -46,6 +46,7 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -65,6 +65,7 @@
 		<script src="js/shaders/TriangleBlurShader.js"></script>
 		<script src="js/shaders/VignetteShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/BloomPass.js"></script>

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -62,6 +62,7 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/FXAAShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_materials_reflectivity.html
+++ b/examples/webgl_materials_reflectivity.html
@@ -42,6 +42,7 @@
 		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgl_materials_skin.html
+++ b/examples/webgl_materials_skin.html
@@ -49,6 +49,7 @@
 		<script src="js/shaders/ConvolutionShader.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/BloomPass.js"></script>

--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -41,6 +41,7 @@
 		<script src="js/shaders/ConvolutionShader.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgl_points_dynamic.html
+++ b/examples/webgl_points_dynamic.html
@@ -43,6 +43,7 @@
 		<script src="js/shaders/FilmShader.js"></script>
 		<script src="js/shaders/FocusShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>

--- a/examples/webgl_postprocessing.html
+++ b/examples/webgl_postprocessing.html
@@ -20,6 +20,7 @@
 		<script src="js/shaders/DotScreenShader.js"></script>
 		<script src="js/shaders/RGBShiftShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -53,6 +53,7 @@
 		<script src="js/shaders/VerticalBlurShader.js"></script>
 		<script src="js/shaders/VignetteShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/BloomPass.js"></script>

--- a/examples/webgl_postprocessing_afterimage.html
+++ b/examples/webgl_postprocessing_afterimage.html
@@ -19,6 +19,7 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/AfterimageShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -41,6 +41,7 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/ClearPass.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -38,6 +38,7 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/BokehShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_glitch.html
+++ b/examples/webgl_postprocessing_glitch.html
@@ -33,6 +33,7 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/DigitalGlitch.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgl_postprocessing_masking.html
+++ b/examples/webgl_postprocessing_masking.html
@@ -20,6 +20,7 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/ClearPass.js"></script>
 		<script src="js/postprocessing/TexturePass.js"></script>

--- a/examples/webgl_postprocessing_nodes_pass.html
+++ b/examples/webgl_postprocessing_nodes_pass.html
@@ -36,6 +36,7 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -41,6 +41,7 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/FXAAShader.js"></script>
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_pixel.html
+++ b/examples/webgl_postprocessing_pixel.html
@@ -42,6 +42,7 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/PixelShader.js"></script>
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_rgb_halftone.html
+++ b/examples/webgl_postprocessing_rgb_halftone.html
@@ -31,6 +31,7 @@
 	<body>
 		<script src="../build/three.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_sao.html
+++ b/examples/webgl_postprocessing_sao.html
@@ -34,6 +34,7 @@
 	<body>
 		<script src="../build/three.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_smaa.html
+++ b/examples/webgl_postprocessing_smaa.html
@@ -22,6 +22,7 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/SMAAShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/SMAAPass.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>

--- a/examples/webgl_postprocessing_sobel.html
+++ b/examples/webgl_postprocessing_sobel.html
@@ -40,6 +40,7 @@
 		<script src="js/shaders/LuminosityShader.js"></script>
 		<script src="js/shaders/SobelOperatorShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -43,6 +43,7 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/SSAARenderPass.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>

--- a/examples/webgl_postprocessing_ssaa_unbiased.html
+++ b/examples/webgl_postprocessing_ssaa_unbiased.html
@@ -43,6 +43,7 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/SSAARenderPass.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -44,6 +44,7 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 		<script src="js/shaders/SSAOShader.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -44,6 +44,7 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/SSAARenderPass.js"></script>
 		<script src="js/postprocessing/TAARenderPass.js"></script>

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -56,6 +56,7 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>

--- a/examples/webgl_shader_lava.html
+++ b/examples/webgl_shader_lava.html
@@ -42,6 +42,7 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/FilmShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -48,6 +48,7 @@
 		<script src="js/shaders/ToneMapShader.js"></script>
 		<script src="js/shaders/GammaCorrectionShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgl_tiled_forward.html
+++ b/examples/webgl_tiled_forward.html
@@ -34,6 +34,7 @@
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/OBJLoader.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -43,6 +43,7 @@
 		<script src="js/pmrem/PMREMGenerator.js"></script>
 		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>

--- a/examples/webgldeferred_animation.html
+++ b/examples/webgldeferred_animation.html
@@ -44,6 +44,7 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/FXAAShader.js"></script>
 
+		<script src="js/postprocessing/Pass.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>


### PR DESCRIPTION
#### What Changed

- Moves `THREE.Pass` definition from `postprocessing/EffectComposer.js` to `postprocessing/Pass.js`
- Add warning to EffectComposer if `THREE.Pass` isn't defined to notify users of the change
- Update all examples that use the EffectComposer to include the new file

#### Why

I'm looking into making a script to convert all the example scripts into es6 module files and this file was proving troublesome because it creates cyclic dependencies:

`EffectComposer (EffectComposer.js)` depends on `ShaderPass` which depends on `Pass (EffectComposer.js)`.

So EffectComposer.js imports ShaderPass before it has defined Pass, yet, which causes ShaderPass to throw an undefined variable error. Moving Pass out the EffectComposer file removes the cyclic dependency.