### PR TITLE
Fix error handling for PCDLoader parsing

### DIFF
--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -28,7 +28,23 @@ THREE.PCDLoader.prototype = {
 		loader.setResponseType( 'arraybuffer' );
 		loader.load( url, function ( data ) {
 
-			onLoad( scope.parse( data, url ) );
+			try {
+
+				onLoad( scope.parse( data, url ) );
+
+			} catch ( e ) {
+
+				if ( onError ) {
+
+					onError( e );
+
+				} else {
+
+					throw e;
+
+				}
+
+			}
 
 		}, onProgress, onError );
 


### PR DESCRIPTION
This fixes an issue with the PCD Loader so it will use the `onError` parameter (when there is one) if an issue occurs in the `parse` method. 

Note: This fixes one loader.  There are many others that have a similar pattern of passing the `onError` to the file loader, and parsing afterword without catching any errors that may occur.  Might be worth moving this catch logic to the `FileLoader`.

Fixes #14776