### PR TITLE
core docs: Fix some spelling mistakes

### DIFF
--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -99,12 +99,12 @@
 
 		<h3>[property:Function onUploadCallback]</h3>
 		<p>
-		A callback function that is executed after the Renderer has transfered the attribute array data to the GPU.
+		A callback function that is executed after the Renderer has transferred the attribute array data to the GPU.
 		</p>
 
 		<h3>[property:Object updateRange]</h3>
 		<p>Object containing:<br />
-			[page:Integer offset]: Default is *0*. Position at whcih to start update.<br />
+			[page:Integer offset]: Default is *0*. Position at which to start update.<br />
 			[page:Integer count]: Default is *-1*, which means don't use update ranges. <br /><br />
 
 			This can be used to only update some components of stored vectors (for example, just the component
@@ -160,7 +160,7 @@
 		Sets the value of the onUploadCallback property.<br /><br />
 
 		In the [example:webgl_buffergeometry WebGL / Buffergeometry] this is used to free memory
-		after the buffer has been	transfered to the GPU.
+		after the buffer has been	transferred to the GPU.
 		</p>
 
 		<h3>[method:BufferAttribute set] ( [param:Array value], [param:Integer offset] ) </h3>

--- a/docs/api/en/core/Face3.html
+++ b/docs/api/en/core/Face3.html
@@ -124,7 +124,7 @@ scene.add( new THREE.Mesh( geometry, material ) );
 		<p>Creates a new clone of the Face3 object.</p>
 
 		<h3>[method:Face3 copy]( [param:Face3 face3] )</h3>
-		<p>Copy the paramaters of another Face3 into this.</p>
+		<p>Copy the parameters of another Face3 into this.</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/en/core/Raycaster.html
+++ b/docs/api/en/core/Raycaster.html
@@ -147,7 +147,7 @@
 		<h3>[method:Array intersectObject]( [param:Object3D object], [param:Boolean recursive], [param:Array optionalTarget] )</h3>
 		<p>
 		[page:Object3D object] — The object to check for intersection with the ray.<br />
-		[page:Boolean recursive] — If true, it also checks all descendants. Otherwise it only checks intersecton with the object. Default is false.<br />
+		[page:Boolean recursive] — If true, it also checks all descendants. Otherwise it only checks intersection with the object. Default is false.<br />
 		[page:Array optionalTarget] — (optional) target to set the result. Otherwise a new [page:Array] is instantiated. If set, you must clear this array prior to each call (i.e., array.length = 0;).
 		</p>
 		<p>
@@ -174,7 +174,7 @@
 		<h3>[method:Array intersectObjects]( [param:Array objects], [param:Boolean recursive], [param:Array optionalTarget] )</h3>
 		<p>
 		[page:Array objects] — The objects to check for intersection with the ray.<br />
-		[page:Boolean recursive] — If true, it also checks all descendants of the objects. Otherwise it only checks intersecton with the objects. Default is false.<br />
+		[page:Boolean recursive] — If true, it also checks all descendants of the objects. Otherwise it only checks intersection with the objects. Default is false.<br />
 		[page:Array optionalTarget] — (optional) target to set the result. Otherwise a new [page:Array] is instantiated. If set, you must clear this array prior to each call (i.e., array.length = 0;).
 		</p>
 		<p>

--- a/docs/api/en/core/Uniform.html
+++ b/docs/api/en/core/Uniform.html
@@ -201,7 +201,7 @@
 		<h3>[method:Uniform clone]()</h3>
 		<p>
 		Returns a clone of this uniform.<br />
-		If the uniform's value property is an [page:Object] with a clone() method, this is used, otherwise the value is copied by assigment.
+		If the uniform's value property is an [page:Object] with a clone() method, this is used, otherwise the value is copied by assignment.
 		Array values are shared between cloned [page:Uniform]s.<br /><br />
 		See [example:webgldeferred_animation WebGL deferred animation] for an example of this method in use.
 		</p>


### PR DESCRIPTION
Found with [codespell](https://github.com/codespell-project/codespell)