### PR TITLE
Fix broken links to source

### DIFF
--- a/docs/api/en/Template.html
+++ b/docs/api/en/Template.html
@@ -43,6 +43,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/AnimationAction.html
+++ b/docs/api/en/animation/AnimationAction.html
@@ -357,6 +357,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/AnimationClip.html
+++ b/docs/api/en/animation/AnimationClip.html
@@ -136,6 +136,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/AnimationMixer.html
+++ b/docs/api/en/animation/AnimationMixer.html
@@ -105,6 +105,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/AnimationObjectGroup.html
+++ b/docs/api/en/animation/AnimationObjectGroup.html
@@ -80,6 +80,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/AnimationUtils.html
+++ b/docs/api/en/animation/AnimationUtils.html
@@ -52,6 +52,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/KeyframeTrack.html
+++ b/docs/api/en/animation/KeyframeTrack.html
@@ -259,6 +259,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/PropertyBinding.html
+++ b/docs/api/en/animation/PropertyBinding.html
@@ -126,6 +126,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/PropertyMixer.html
+++ b/docs/api/en/animation/PropertyMixer.html
@@ -93,6 +93,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
@@ -73,6 +73,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/tracks/ColorKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/ColorKeyframeTrack.html
@@ -57,6 +57,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/tracks/NumberKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/NumberKeyframeTrack.html
@@ -57,6 +57,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/QuaternionKeyframeTrack.html
@@ -68,6 +68,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/StringKeyframeTrack.html
@@ -76,6 +76,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/animation/tracks/VectorKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/VectorKeyframeTrack.html
@@ -56,6 +56,6 @@
 		<h2>Source</h2>
 
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -211,6 +211,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/audio/AudioAnalyser.html
+++ b/docs/api/en/audio/AudioAnalyser.html
@@ -94,6 +94,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/audio/AudioContext.html
+++ b/docs/api/en/audio/AudioContext.html
@@ -37,6 +37,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/audio/AudioListener.html
+++ b/docs/api/en/audio/AudioListener.html
@@ -104,6 +104,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/audio/PositionalAudio.html
+++ b/docs/api/en/audio/PositionalAudio.html
@@ -130,6 +130,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/cameras/ArrayCamera.html
+++ b/docs/api/en/cameras/ArrayCamera.html
@@ -42,6 +42,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/cameras/Camera.html
+++ b/docs/api/en/cameras/Camera.html
@@ -82,6 +82,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/cameras/CubeCamera.html
+++ b/docs/api/en/cameras/CubeCamera.html
@@ -84,6 +84,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/cameras/OrthographicCamera.html
+++ b/docs/api/en/cameras/OrthographicCamera.html
@@ -139,6 +139,6 @@ scene.add( camera );</code>
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/cameras/PerspectiveCamera.html
+++ b/docs/api/en/cameras/PerspectiveCamera.html
@@ -199,6 +199,6 @@ camera.setViewOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/cameras/StereoCamera.html
+++ b/docs/api/en/cameras/StereoCamera.html
@@ -62,6 +62,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -210,6 +210,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -357,6 +357,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/Clock.html
+++ b/docs/api/en/core/Clock.html
@@ -82,6 +82,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/DirectGeometry.html
+++ b/docs/api/en/core/DirectGeometry.html
@@ -103,6 +103,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/EventDispatcher.html
+++ b/docs/api/en/core/EventDispatcher.html
@@ -95,6 +95,6 @@ car.start();
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/Face3.html
+++ b/docs/api/en/core/Face3.html
@@ -129,6 +129,6 @@ scene.add( new THREE.Mesh( geometry, material ) );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/Geometry.html
+++ b/docs/api/en/core/Geometry.html
@@ -340,6 +340,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/InstancedBufferAttribute.html
+++ b/docs/api/en/core/InstancedBufferAttribute.html
@@ -39,6 +39,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/InstancedBufferGeometry.html
+++ b/docs/api/en/core/InstancedBufferGeometry.html
@@ -45,6 +45,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/InstancedInterleavedBuffer.html
+++ b/docs/api/en/core/InstancedInterleavedBuffer.html
@@ -43,6 +43,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/InterleavedBuffer.html
+++ b/docs/api/en/core/InterleavedBuffer.html
@@ -114,6 +114,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/InterleavedBufferAttribute.html
+++ b/docs/api/en/core/InterleavedBufferAttribute.html
@@ -99,6 +99,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/Layers.html
+++ b/docs/api/en/core/Layers.html
@@ -77,6 +77,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -433,6 +433,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/Raycaster.html
+++ b/docs/api/en/core/Raycaster.html
@@ -184,6 +184,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/core/Uniform.html
+++ b/docs/api/en/core/Uniform.html
@@ -208,6 +208,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/Earcut.html
+++ b/docs/api/en/extras/Earcut.html
@@ -26,6 +26,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/ShapeUtils.html
+++ b/docs/api/en/extras/ShapeUtils.html
@@ -49,6 +49,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/core/Curve.html
+++ b/docs/api/en/extras/core/Curve.html
@@ -111,6 +111,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/core/CurvePath.html
+++ b/docs/api/en/extras/core/CurvePath.html
@@ -55,6 +55,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/core/Font.html
+++ b/docs/api/en/extras/core/Font.html
@@ -56,6 +56,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/core/Interpolations.html
+++ b/docs/api/en/extras/core/Interpolations.html
@@ -42,6 +42,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/core/Path.html
+++ b/docs/api/en/extras/core/Path.html
@@ -140,6 +140,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/core/Shape.html
+++ b/docs/api/en/extras/core/Shape.html
@@ -96,6 +96,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/ArcCurve.html
+++ b/docs/api/en/extras/curves/ArcCurve.html
@@ -27,6 +27,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/CatmullRomCurve3.html
+++ b/docs/api/en/extras/curves/CatmullRomCurve3.html
@@ -76,6 +76,6 @@ var curveObject = new THREE.Line( geometry, material );
 		<h2>Methods</h2>
 		<p>See the base [page:Curve] class for common methods.</p>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/CubicBezierCurve.html
+++ b/docs/api/en/extras/curves/CubicBezierCurve.html
@@ -76,6 +76,6 @@ var curveObject = new THREE.Line( geometry, material );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/CubicBezierCurve3.html
+++ b/docs/api/en/extras/curves/CubicBezierCurve3.html
@@ -77,6 +77,6 @@ var curveObject = new THREE.Line( geometry, material );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/EllipseCurve.html
+++ b/docs/api/en/extras/curves/EllipseCurve.html
@@ -100,6 +100,6 @@ var ellipse = new THREE.Line( geometry, material );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/LineCurve.html
+++ b/docs/api/en/extras/curves/LineCurve.html
@@ -46,6 +46,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/LineCurve3.html
+++ b/docs/api/en/extras/curves/LineCurve3.html
@@ -45,6 +45,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/QuadraticBezierCurve.html
+++ b/docs/api/en/extras/curves/QuadraticBezierCurve.html
@@ -72,6 +72,6 @@ var curveObject = new THREE.Line( geometry, material );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/QuadraticBezierCurve3.html
+++ b/docs/api/en/extras/curves/QuadraticBezierCurve3.html
@@ -72,6 +72,6 @@ var curveObject = new THREE.Line( geometry, material );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/curves/SplineCurve.html
+++ b/docs/api/en/extras/curves/SplineCurve.html
@@ -67,6 +67,6 @@ var splineObject = new THREE.Line( geometry, material );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/extras/objects/ImmediateRenderObject.html
+++ b/docs/api/en/extras/objects/ImmediateRenderObject.html
@@ -37,6 +37,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/BoxGeometry.html
+++ b/docs/api/en/geometries/BoxGeometry.html
@@ -70,6 +70,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/CircleGeometry.html
+++ b/docs/api/en/geometries/CircleGeometry.html
@@ -61,6 +61,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/ConeGeometry.html
+++ b/docs/api/en/geometries/ConeGeometry.html
@@ -62,6 +62,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/CylinderGeometry.html
+++ b/docs/api/en/geometries/CylinderGeometry.html
@@ -63,6 +63,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/DodecahedronGeometry.html
+++ b/docs/api/en/geometries/DodecahedronGeometry.html
@@ -49,6 +49,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/EdgesGeometry.html
+++ b/docs/api/en/geometries/EdgesGeometry.html
@@ -42,6 +42,6 @@ scene.add( line );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/ExtrudeGeometry.html
+++ b/docs/api/en/geometries/ExtrudeGeometry.html
@@ -101,6 +101,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/IcosahedronGeometry.html
+++ b/docs/api/en/geometries/IcosahedronGeometry.html
@@ -49,6 +49,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/LatheGeometry.html
+++ b/docs/api/en/geometries/LatheGeometry.html
@@ -67,6 +67,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/OctahedronGeometry.html
+++ b/docs/api/en/geometries/OctahedronGeometry.html
@@ -49,6 +49,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/ParametricGeometry.html
+++ b/docs/api/en/geometries/ParametricGeometry.html
@@ -63,6 +63,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/PlaneGeometry.html
+++ b/docs/api/en/geometries/PlaneGeometry.html
@@ -59,6 +59,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/PolyhedronGeometry.html
+++ b/docs/api/en/geometries/PolyhedronGeometry.html
@@ -57,6 +57,6 @@ var geometry = new THREE.PolyhedronGeometry( verticesOfCube, indicesOfFaces, 6, 
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/RingGeometry.html
+++ b/docs/api/en/geometries/RingGeometry.html
@@ -58,10 +58,10 @@
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
-		
+
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/ShapeGeometry.html
+++ b/docs/api/en/geometries/ShapeGeometry.html
@@ -74,6 +74,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/SphereGeometry.html
+++ b/docs/api/en/geometries/SphereGeometry.html
@@ -67,6 +67,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/TetrahedronGeometry.html
+++ b/docs/api/en/geometries/TetrahedronGeometry.html
@@ -49,6 +49,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/TextGeometry.html
+++ b/docs/api/en/geometries/TextGeometry.html
@@ -162,6 +162,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/TorusGeometry.html
+++ b/docs/api/en/geometries/TorusGeometry.html
@@ -60,6 +60,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/TorusKnotGeometry.html
+++ b/docs/api/en/geometries/TorusKnotGeometry.html
@@ -63,6 +63,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/TubeGeometry.html
+++ b/docs/api/en/geometries/TubeGeometry.html
@@ -100,6 +100,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/geometries/WireframeGeometry.html
+++ b/docs/api/en/geometries/WireframeGeometry.html
@@ -58,6 +58,6 @@ scene.add( line );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/ArrowHelper.html
+++ b/docs/api/en/helpers/ArrowHelper.html
@@ -93,6 +93,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -46,6 +46,6 @@ scene.add( axesHelper );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/Box3Helper.html
+++ b/docs/api/en/helpers/Box3Helper.html
@@ -59,6 +59,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/BoxHelper.html
+++ b/docs/api/en/helpers/BoxHelper.html
@@ -69,6 +69,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/CameraHelper.html
+++ b/docs/api/en/helpers/CameraHelper.html
@@ -74,6 +74,6 @@ scene.add( helper );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/DirectionalLightHelper.html
+++ b/docs/api/en/helpers/DirectionalLightHelper.html
@@ -80,6 +80,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/FaceNormalsHelper.html
+++ b/docs/api/en/helpers/FaceNormalsHelper.html
@@ -76,6 +76,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/GridHelper.html
+++ b/docs/api/en/helpers/GridHelper.html
@@ -41,6 +41,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/HemisphereLightHelper.html
+++ b/docs/api/en/helpers/HemisphereLightHelper.html
@@ -73,6 +73,6 @@ scene.add( helper );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/PlaneHelper.html
+++ b/docs/api/en/helpers/PlaneHelper.html
@@ -60,6 +60,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/PointLightHelper.html
+++ b/docs/api/en/helpers/PointLightHelper.html
@@ -79,6 +79,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/PolarGridHelper.html
+++ b/docs/api/en/helpers/PolarGridHelper.html
@@ -45,6 +45,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/RectAreaLightHelper.html
+++ b/docs/api/en/helpers/RectAreaLightHelper.html
@@ -62,6 +62,6 @@ scene.add( helper );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/SkeletonHelper.html
+++ b/docs/api/en/helpers/SkeletonHelper.html
@@ -57,6 +57,6 @@ scene.add( helper );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/SpotLightHelper.html
+++ b/docs/api/en/helpers/SpotLightHelper.html
@@ -78,6 +78,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/helpers/VertexNormalsHelper.html
+++ b/docs/api/en/helpers/VertexNormalsHelper.html
@@ -74,6 +74,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/lights/AmbientLight.html
+++ b/docs/api/en/lights/AmbientLight.html
@@ -68,6 +68,6 @@ scene.add( light );</code>
 		</p>
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/lights/DirectionalLight.html
+++ b/docs/api/en/lights/DirectionalLight.html
@@ -138,6 +138,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/lights/HemisphereLight.html
+++ b/docs/api/en/lights/HemisphereLight.html
@@ -94,6 +94,6 @@ scene.add( light );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/lights/Light.html
+++ b/docs/api/en/lights/Light.html
@@ -74,6 +74,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/lights/PointLight.html
+++ b/docs/api/en/lights/PointLight.html
@@ -114,6 +114,6 @@ scene.add( light );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/lights/RectAreaLight.html
+++ b/docs/api/en/lights/RectAreaLight.html
@@ -84,6 +84,6 @@ scene.add( rectLightHelper );
 		RectAreaLight.
 		</p>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/lights/SpotLight.html
+++ b/docs/api/en/lights/SpotLight.html
@@ -186,6 +186,6 @@ light.target = targetObject;
 		SpotLight.
 		</p>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/AnimationLoader.html
+++ b/docs/api/en/loaders/AnimationLoader.html
@@ -83,6 +83,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/AudioLoader.html
+++ b/docs/api/en/loaders/AudioLoader.html
@@ -94,6 +94,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/BufferGeometryLoader.html
+++ b/docs/api/en/loaders/BufferGeometryLoader.html
@@ -87,6 +87,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/Cache.html
+++ b/docs/api/en/loaders/Cache.html
@@ -70,6 +70,6 @@ THREE.Cache.enabled = true.
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/CompressedTextureLoader.html
+++ b/docs/api/en/loaders/CompressedTextureLoader.html
@@ -68,6 +68,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/CubeTextureLoader.html
+++ b/docs/api/en/loaders/CubeTextureLoader.html
@@ -98,6 +98,6 @@ scene.background = new THREE.CubeTextureLoader()
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/DataTextureLoader.html
+++ b/docs/api/en/loaders/DataTextureLoader.html
@@ -58,6 +58,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/FileLoader.html
+++ b/docs/api/en/loaders/FileLoader.html
@@ -146,6 +146,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/FontLoader.html
+++ b/docs/api/en/loaders/FontLoader.html
@@ -94,6 +94,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/ImageBitmapLoader.html
+++ b/docs/api/en/loaders/ImageBitmapLoader.html
@@ -101,6 +101,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/ImageLoader.html
+++ b/docs/api/en/loaders/ImageLoader.html
@@ -105,6 +105,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/JSONLoader.html
+++ b/docs/api/en/loaders/JSONLoader.html
@@ -114,6 +114,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -65,6 +65,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/LoaderUtils.html
+++ b/docs/api/en/loaders/LoaderUtils.html
@@ -33,6 +33,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/MaterialLoader.html
+++ b/docs/api/en/loaders/MaterialLoader.html
@@ -93,6 +93,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -226,6 +226,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/loaders/TextureLoader.html
+++ b/docs/api/en/loaders/TextureLoader.html
@@ -111,6 +111,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/LineBasicMaterial.html
+++ b/docs/api/en/materials/LineBasicMaterial.html
@@ -103,6 +103,6 @@ var material = new THREE.LineBasicMaterial( {
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/LineDashedMaterial.html
+++ b/docs/api/en/materials/LineDashedMaterial.html
@@ -85,6 +85,6 @@ var material = new THREE.LineDashedMaterial( {
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -328,6 +328,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/MeshBasicMaterial.html
+++ b/docs/api/en/materials/MeshBasicMaterial.html
@@ -161,6 +161,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/MeshDepthMaterial.html
+++ b/docs/api/en/materials/MeshDepthMaterial.html
@@ -118,6 +118,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/MeshLambertMaterial.html
+++ b/docs/api/en/materials/MeshLambertMaterial.html
@@ -187,6 +187,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/MeshNormalMaterial.html
+++ b/docs/api/en/materials/MeshNormalMaterial.html
@@ -80,6 +80,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/MeshPhongMaterial.html
+++ b/docs/api/en/materials/MeshPhongMaterial.html
@@ -257,6 +257,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -92,6 +92,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -291,6 +291,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/MeshToonMaterial.html
+++ b/docs/api/en/materials/MeshToonMaterial.html
@@ -76,6 +76,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/PointsMaterial.html
+++ b/docs/api/en/materials/PointsMaterial.html
@@ -95,6 +95,6 @@ scene.add( starField );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/RawShaderMaterial.html
+++ b/docs/api/en/materials/RawShaderMaterial.html
@@ -66,6 +66,6 @@ var material = new THREE.RawShaderMaterial( {
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -465,6 +465,6 @@ this.extensions = {
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/ShadowMaterial.html
+++ b/docs/api/en/materials/ShadowMaterial.html
@@ -62,6 +62,6 @@ scene.add( plane );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/materials/SpriteMaterial.html
+++ b/docs/api/en/materials/SpriteMaterial.html
@@ -75,6 +75,6 @@ scene.add( sprite );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Box2.html
+++ b/docs/api/en/math/Box2.html
@@ -214,6 +214,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Box3.html
+++ b/docs/api/en/math/Box3.html
@@ -297,6 +297,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -126,7 +126,7 @@ var color = new THREE.Color( 1, 0, 0 );
 		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
 		Converts this color from gamma space to linear space by taking [page:.r r], [page:.g g] and [page:.b b] to the power of [page:Float gammaFactor].
 		</p>
-		
+
 		<h3>[method:Color convertLinearToGamma]( [param:Float gammaFactor] ) </h3>
 		<p>
 		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
@@ -318,6 +318,6 @@ var color = new THREE.Color( 1, 0, 0 );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Cylindrical.html
+++ b/docs/api/en/math/Cylindrical.html
@@ -68,6 +68,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Euler.html
+++ b/docs/api/en/math/Euler.html
@@ -187,6 +187,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Frustum.html
+++ b/docs/api/en/math/Frustum.html
@@ -116,6 +116,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Interpolant.html
+++ b/docs/api/en/math/Interpolant.html
@@ -79,6 +79,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Line3.html
+++ b/docs/api/en/math/Line3.html
@@ -118,6 +118,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Math.html
+++ b/docs/api/en/math/Math.html
@@ -107,6 +107,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -199,6 +199,6 @@ m.elements = [ 11, 21, 31,
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -407,6 +407,6 @@ m, n, o, p
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Plane.html
+++ b/docs/api/en/math/Plane.html
@@ -171,6 +171,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -288,6 +288,6 @@ q.slerp( qb, t )
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Ray.html
+++ b/docs/api/en/math/Ray.html
@@ -209,6 +209,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Sphere.html
+++ b/docs/api/en/math/Sphere.html
@@ -134,6 +134,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Spherical.html
+++ b/docs/api/en/math/Spherical.html
@@ -73,6 +73,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Triangle.html
+++ b/docs/api/en/math/Triangle.html
@@ -138,6 +138,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Vector2.html
+++ b/docs/api/en/math/Vector2.html
@@ -176,7 +176,7 @@
 		Calculates the [link:https://en.wikipedia.org/wiki/Dot_product dot product] of this
 	  vector and [page:Vector2 v].
 		</p>
-        
+
 		<h3>[method:Float cross]( [param:Vector2 v] )</h3>
 		<p>
 		Calculates the [link:https://en.wikipedia.org/wiki/Cross_product cross product] of this
@@ -341,6 +341,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -441,6 +441,6 @@ var d = a.distanceTo( b );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -326,6 +326,6 @@ var d = a.dot( b );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/interpolants/CubicInterpolant.html
+++ b/docs/api/en/math/interpolants/CubicInterpolant.html
@@ -80,6 +80,6 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/interpolants/DiscreteInterpolant.html
+++ b/docs/api/en/math/interpolants/DiscreteInterpolant.html
@@ -80,6 +80,6 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/interpolants/LinearInterpolant.html
+++ b/docs/api/en/math/interpolants/LinearInterpolant.html
@@ -80,6 +80,6 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/math/interpolants/QuaternionLinearInterpolant.html
+++ b/docs/api/en/math/interpolants/QuaternionLinearInterpolant.html
@@ -80,6 +80,6 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/Bone.html
+++ b/docs/api/en/objects/Bone.html
@@ -54,6 +54,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/Group.html
+++ b/docs/api/en/objects/Group.html
@@ -55,6 +55,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<h2>Example</h2>
-		
+
 		<p>
 			[example:webgl_lod webgl / lod ]
 		</p>
@@ -114,6 +114,6 @@ scene.add( lod );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/Line.html
+++ b/docs/api/en/objects/Line.html
@@ -93,6 +93,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/LineLoop.html
+++ b/docs/api/en/objects/LineLoop.html
@@ -50,6 +50,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/LineSegments.html
+++ b/docs/api/en/objects/LineSegments.html
@@ -49,6 +49,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/Mesh.html
+++ b/docs/api/en/objects/Mesh.html
@@ -108,6 +108,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/Points.html
+++ b/docs/api/en/objects/Points.html
@@ -72,7 +72,7 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 
 	</body>
 </html>

--- a/docs/api/en/objects/Skeleton.html
+++ b/docs/api/en/objects/Skeleton.html
@@ -111,6 +111,6 @@ var armSkeleton = new THREE.Skeleton( bones );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/SkinnedMesh.html
+++ b/docs/api/en/objects/SkinnedMesh.html
@@ -156,6 +156,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/objects/Sprite.html
+++ b/docs/api/en/objects/Sprite.html
@@ -85,6 +85,6 @@ scene.add( sprite );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -124,6 +124,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/WebGLRenderTargetCube.html
+++ b/docs/api/en/renderers/WebGLRenderTargetCube.html
@@ -66,6 +66,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -465,6 +465,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/shaders/ShaderChunk.html
+++ b/docs/api/en/renderers/shaders/ShaderChunk.html
@@ -24,6 +24,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/shaders/ShaderLib.html
+++ b/docs/api/en/renderers/shaders/ShaderLib.html
@@ -23,6 +23,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/shaders/UniformsLib.html
+++ b/docs/api/en/renderers/shaders/UniformsLib.html
@@ -24,6 +24,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/shaders/UniformsUtils.html
+++ b/docs/api/en/renderers/shaders/UniformsUtils.html
@@ -22,6 +22,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/webgl/WebGLProgram.html
+++ b/docs/api/en/renderers/webgl/WebGLProgram.html
@@ -142,6 +142,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/webgl/WebGLShader.html
+++ b/docs/api/en/renderers/webgl/WebGLShader.html
@@ -44,6 +44,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/renderers/webgl/WebGLState.html
+++ b/docs/api/en/renderers/webgl/WebGLState.html
@@ -55,6 +55,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/scenes/Fog.html
+++ b/docs/api/en/scenes/Fog.html
@@ -45,6 +45,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/scenes/FogExp2.html
+++ b/docs/api/en/scenes/FogExp2.html
@@ -41,6 +41,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -53,6 +53,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/textures/CanvasTexture.html
+++ b/docs/api/en/textures/CanvasTexture.html
@@ -72,6 +72,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/textures/CompressedTexture.html
+++ b/docs/api/en/textures/CompressedTexture.html
@@ -83,6 +83,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/textures/CubeTexture.html
+++ b/docs/api/en/textures/CubeTexture.html
@@ -9,7 +9,7 @@
 	</head>
 	<body>
 		[page:Texture] &rarr;
-		
+
 		<h1>[name]</h1>
 
 		<p class="desc">Creates a cube texture made up of six images.</p>
@@ -19,7 +19,7 @@
 		<code>
 		var loader = new THREE.CubeTextureLoader();
 		loader.setPath( 'textures/cube/pisa/' );
-		
+
 		var textureCube = loader.load( [
 			'px.png', 'nx.png',
 			'py.png', 'ny.png',
@@ -33,7 +33,7 @@
 
 
 		<h3>[name]( images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy )</h3>
-		
+
 		<p>
 		CubeTexture is almost equivalent in functionality and usage to [page:Texture]. The only differences are that the
 		images are an array of 6 images as opposed to a single image, and the mapping options are
@@ -46,12 +46,12 @@
 		<h3>See [page:Texture]</h3>
 
 		<h2>Methods</h2>
-		
+
 
 		<h3>See [page:Texture]</h3>
-		
+
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/textures/DataTexture.html
+++ b/docs/api/en/textures/DataTexture.html
@@ -72,6 +72,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/textures/DepthTexture.html
+++ b/docs/api/en/textures/DepthTexture.html
@@ -108,6 +108,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -258,6 +258,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -91,6 +91,6 @@ texture.format = THREE.RGBFormat;
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]
 	</body>
 </html>

--- a/docs/page.js
+++ b/docs/page.js
@@ -27,6 +27,7 @@ if ( !window.frameElement && window.location.protocol !== 'file:' ) {
 function onDocumentLoad( event ) {
 
 	var path;
+	var nonLocalizedPath;
 	var pathname = window.location.pathname;
 	var section = /\/(manual|api|examples)\//.exec( pathname )[ 1 ].toString().split( '.html' )[ 0 ];
 	var name = /[\-A-z0-9]+\.html/.exec( pathname ).toString().split( '.html' )[ 0 ];
@@ -35,10 +36,12 @@ function onDocumentLoad( event ) {
 
 		case 'api':
 			path = /\/api\/[A-z0-9\/]+/.exec( pathname ).toString().substr( 5 );
+			nonLocalizedPath = path.substr( 3 ); // remove 'en/'
 			break;
 
 		case 'examples':
 			path = /\/examples\/[A-z0-9\/]+/.exec( pathname ).toString().substr( 10 );
+			nonLocalizedPath = path;
 			break;
 
 		case 'manual':
@@ -46,6 +49,7 @@ function onDocumentLoad( event ) {
 
 			path = pathname.replace( /\ /g, '-' );
 			path = /\/manual\/[-A-z0-9\/]+/.exec( path ).toString().substr( 8 );
+			nonLocalizedPath = path;
 			break;
 
 	}
@@ -54,6 +58,7 @@ function onDocumentLoad( event ) {
 
 	text = text.replace( /\[name\]/gi, name );
 	text = text.replace( /\[path\]/gi, path );
+	text = text.replace( /\[nonLocalizedPath\]/gi, nonLocalizedPath );
 	text = text.replace( /\[page:([\w\.]+)\]/gi, "[page:$1 $1]" ); // [page:name] to [page:name title]
 	text = text.replace( /\[page:\.([\w\.]+) ([\w\.\s]+)\]/gi, "[page:" + name + ".$1 $2]" ); // [page:.member title] to [page:name.member title]
 	text = text.replace( /\[page:([\w\.]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('$1')\" title=\"$1\">$2</a>" ); // [page:name title]

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -1329,7 +1329,7 @@
         "!proto": "THREE.Line.prototype",
         "update": {
           "!type": "fn(object: +THREE.Object3D)",
-          "!doc": "Updates the helper's geometry to match the dimensions of the [page:Geometry.boundingBox bounding box] of the passed object's geometry.\n\n\t\t<h2>Source</h2>\n\n\t\t[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]"
+          "!doc": "Updates the helper's geometry to match the dimensions of the [page:Geometry.boundingBox bounding box] of the passed object's geometry.\n\n\t\t<h2>Source</h2>\n\n\t\t[link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]"
         }
       },
       "!doc": "Helper object to show a wireframe box (with no face diagonals) around an object",


### PR DESCRIPTION
Fixes #14819 

This was noted in https://github.com/mrdoob/three.js/pull/14750#issuecomment-417635324.

The problem was that the `[path]` for the docs changed to support localization, but the source code didn't. For example, `/docs/#api/objects/Mesh` became `/docs/#api/en/objects/Mesh`.

The doc links follow the pattern:

    [link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

where `[path]` is, for our example, `en/objects/Mesh`.

I introduced a new variable, `[nonLocalizedPath]`, and changed the links to:

    [link:https://github.com/mrdoob/three.js/blob/master/src/[nonLocalizedPath].js src/[nonLocalizedPath].js]

Not an elegant solution, but it gets the job done. Extremely open to other approaches.