### PR TITLE
add material specific tone mapping mode

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -55,6 +55,7 @@ export var LinearToneMapping = 1;
 export var ReinhardToneMapping = 2;
 export var Uncharted2ToneMapping = 3;
 export var CineonToneMapping = 4;
+export var RendererToneMapping = 5;
 export var UVMapping = 300;
 export var CubeReflectionMapping = 301;
 export var CubeRefractionMapping = 302;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,5 +1,5 @@
 import { EventDispatcher } from '../core/EventDispatcher.js';
-import { NoColors, FrontSide, FlatShading, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor } from '../constants.js';
+import { NoColors, FrontSide, FlatShading, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, RendererToneMapping } from '../constants.js';
 import { _Math } from '../math/Math.js';
 
 /**
@@ -36,6 +36,7 @@ function Material() {
 	this.blendDstAlpha = null;
 	this.blendEquationAlpha = null;
 
+	this.toneMapping = RendererToneMapping;
 	this.depthFunc = LessEqualDepth;
 	this.depthTest = true;
 	this.depthWrite = true;

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -2,7 +2,7 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-import { BackSide, DoubleSide, CubeUVRefractionMapping, CubeUVReflectionMapping, GammaEncoding, LinearEncoding, ObjectSpaceNormalMap } from '../../constants.js';
+import { BackSide, DoubleSide, CubeUVRefractionMapping, CubeUVReflectionMapping, GammaEncoding, LinearEncoding, ObjectSpaceNormalMap, RendererToneMapping } from '../../constants.js';
 import { WebGLProgram } from './WebGLProgram.js';
 
 function WebGLPrograms( renderer, extensions, capabilities ) {
@@ -194,7 +194,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			shadowMapEnabled: renderer.shadowMap.enabled && object.receiveShadow && shadows.length > 0,
 			shadowMapType: renderer.shadowMap.type,
 
-			toneMapping: renderer.toneMapping,
+			toneMapping: ( material.toneMapping === RendererToneMapping ) ? renderer.toneMapping : material.toneMapping,
 			physicallyCorrectLights: renderer.physicallyCorrectLights,
 
 			premultipliedAlpha: material.premultipliedAlpha,


### PR DESCRIPTION
Potential solution for #13066  by adding toneMapping property to materials.

Allows materials to opt in/out of renderer wide tone mapping settings for in-line tone mapping.

(also works nicely with a greyscale tone mapping function to highlight a coloured object against a desaturated background)

