### PR TITLE
EquirectangularToCubeGenerator parameter expecting an object

### DIFF
--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -128,7 +128,7 @@
 
 					texture.encoding = THREE.sRGBEncoding;
 
-					var cubemapGenerator = new THREE.EquirectangularToCubeGenerator( texture, 512 );
+					var cubemapGenerator = new THREE.EquirectangularToCubeGenerator( texture, { resolution: 512 } );
 					var cubeMapTexture = cubemapGenerator.update( renderer );
 
 					var pmremGenerator = new THREE.PMREMGenerator( cubeMapTexture );


### PR DESCRIPTION
resolution value passed should be in form of an object instead of a number as per the EquirectangularToCubeGenerator.js file