### PR TITLE
Fix missing Texture3D import in WebGLUniforms

### DIFF
--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -51,6 +51,7 @@
 
 import { CubeTexture } from '../../textures/CubeTexture.js';
 import { Texture } from '../../textures/Texture.js';
+import { Texture3D } from '../../textures/Texture3D.js';
 
 var emptyTexture = new Texture();
 var emptyTexture3d = new Texture3D();


### PR DESCRIPTION
See https://github.com/mrdoob/three.js/commit/6102fc09c905b5c23417b16227c716858ee55513#r30377676