### PR TITLE
Deprecate WebGLRenderer.clearTarget()

### DIFF
--- a/examples/js/postprocessing/SAOPass.js
+++ b/examples/js/postprocessing/SAOPass.js
@@ -200,7 +200,8 @@ THREE.SAOPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ), 
 		var oldAutoClear = renderer.autoClear;
 		renderer.autoClear = false;
 
-		renderer.clearTarget( this.depthRenderTarget );
+		renderer.setRenderTarget( this.depthRenderTarget );
+		renderer.clear();
 
 		this.saoMaterial.uniforms[ 'bias' ].value = this.params.saoBias;
 		this.saoMaterial.uniforms[ 'intensity' ].value = this.params.saoIntensity;

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -300,7 +300,8 @@
 
 					// Clear colors and depths, will clear to sky color
 
-					renderer.clearTarget( postprocessing.rtTextureColors, true, true, false );
+					renderer.setRenderTarget( postprocessing.rtTextureColors );
+					renderer.clear( true, true, false );
 
 					// Sun render. Runs a shader that gives a brightness based on the screen
 					// space distance to the sun. Not very efficient, so i make a scissor

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1330,6 +1330,14 @@ Object.defineProperties( ShaderMaterial.prototype, {
 
 Object.assign( WebGLRenderer.prototype, {
 
+	clearTarget: function ( renderTarget, color, depth, stencil ) {
+
+		console.warn( 'THREE.WebGLRenderer: .clearTarget() has been deprecated. Use .setRenderTarget() and .clear() instead.' );
+		this.setRenderTarget( renderTarget );
+		this.clear( color, depth, stencil );
+
+	},
+
 	animate: function ( callback ) {
 
 		console.warn( 'THREE.WebGLRenderer: .animate() is now .setAnimationLoop().' );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -494,13 +494,6 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	this.clearTarget = function ( renderTarget, color, depth, stencil ) {
-
-		this.setRenderTarget( renderTarget );
-		this.clear( color, depth, stencil );
-
-	};
-
 	//
 
 	this.dispose = function () {


### PR DESCRIPTION
`WebGLRenderer.clear()` clears the current framebuffer. (Not necessarily the screen, as many users seem to think.) But since we are dealing with a state machine, I think `clear()` is OK as currently implemented. 

`WebGLRenderer.clearTarget()`, however, is confusing: it changes the render target, clears it, and leaves the render target changed.

I don't think it is a good ideas to change the render target behind the back of the user. In addition, it violates the state machine concept.

With this PR, to clear a render target, users will need to explicitly set it, and then call `clear()`. It will now be obvious to the user what is happening.

This method is not used very much, it seems, so this change should have little impact.

_Really_ fixes #11845.
