### PR TITLE
Strip localization code from docs `[path]` template variable

### DIFF
--- a/docs/page.js
+++ b/docs/page.js
@@ -35,6 +35,10 @@ function onDocumentLoad( event ) {
 
 		case 'api':
 			path = /\/api\/[A-z0-9\/]+/.exec( pathname ).toString().substr( 5 );
+
+			// Remove localized part of the path (e.g. 'en/' or 'es-MX/'):
+			path = path.replace( /^[A-z0-9-]+\//, '' );
+
 			break;
 
 		case 'examples':


### PR DESCRIPTION
This is a much simpler replacement to #14820.

Fixes #14819.

This problem was first noted in #14750 (comment).

The solution strips out the leading `'en/'` from the docs `[path]` variable used within the templates for building the link to the source code. Thanks @mrdoob for pointing out this simplification.