### PR TITLE
TextureLoader: Update created texture with default image if exist

### DIFF
--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -2,11 +2,13 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-import { RGBAFormat, RGBFormat } from '../constants.js';
+import {
+	RGBAFormat,
+	RGBFormat
+} from '../constants.js';
 import { ImageLoader } from './ImageLoader.js';
 import { Texture } from '../textures/Texture.js';
 import { DefaultLoadingManager } from './LoadingManager.js';
-
 
 function TextureLoader( manager ) {
 
@@ -51,7 +53,7 @@ Object.assign( TextureLoader.prototype, {
 
 			const defaultImageTexture = Texture.DEFAULT_IMAGE;
 
-			if( defaultImageTexture !== undefined ) {
+			if ( defaultImageTexture !== undefined ) {
 
 				// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
 				var isJPEG = defaultImageTexture.src.search( /\.jpe?g$/i ) > 0 || defaultImageTexture.src.search( /^data\:image\/jpeg/ ) === 0;
@@ -87,6 +89,5 @@ Object.assign( TextureLoader.prototype, {
 	}
 
 } );
-
 
 export { TextureLoader };

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -49,8 +49,6 @@ Object.assign( TextureLoader.prototype, {
 
 		function _onError( event ) {
 
-			texture.image = image;
-
 			const defaultImageTexture = Texture.DEFAULT_IMAGE;
 
 			if ( defaultImageTexture !== undefined ) {

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -25,8 +25,9 @@ Object.assign( TextureLoader.prototype, {
 		var loader = new ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
+		loader.load( url, _onLoad, onProgress, _onError );
 
-		loader.load( url, function ( image ) {
+		function _onLoad( image ) {
 
 			texture.image = image;
 
@@ -42,7 +43,30 @@ Object.assign( TextureLoader.prototype, {
 
 			}
 
-		}, onProgress, onError );
+		}
+
+		function _onError( event ) {
+
+			texture.image = image;
+
+			const defaultImageTexture = Texture.DEFAULT_IMAGE;
+
+			if( defaultImageTexture !== undefined ) {
+
+				// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
+				var isJPEG = defaultImageTexture.src.search( /\.jpe?g$/i ) > 0 || defaultImageTexture.src.search( /^data\:image\/jpeg/ ) === 0;
+				texture.format = isJPEG ? RGBFormat : RGBAFormat;
+				texture.needsUpdate = true;
+
+			}
+
+			if ( onError !== undefined ) {
+
+				onError( event );
+
+			}
+
+		}
 
 		return texture;
 


### PR DESCRIPTION
Currently the TextureLoader is unable to properly set the DEFAULT_IMAGE of Texture.

Some explanation before:

Currently the Texture object set the Texture.DEFAULT_IMAGE as Texture.image member in case where no image was given in arguments.

```javascript

function Texture( image, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding ) {

	Object.defineProperty( this, 'id', { value: textureId ++ } );

	this.uuid = _Math.generateUUID();

	this.name = '';

	this.image = image !== undefined ? image : Texture.DEFAULT_IMAGE;

        //...

}

Texture.DEFAULT_IMAGE = undefined;

```

This will result as an object with black texture un case like below:

```javascript
THREE.Texture.DEFAULT_IMAGE = new Three.ImageLoader().load('default_image.png')

var textureWithDefaultImageNotShown= new Three.Texture()
object.material.map = textureWithDefaultImageNotShown
```

This is not due to the lazy loading of the default_image, this is the same for base64 image too.
To show the imaged texture we need to call
```javascript
textureWithDefaultImageNotShown.needsUpdate = true
```
And this is the expected behavior because we don't want to see the default image of texture during the real image is loading. (Agree ? Maybe an option for that ???)

But, and this is the purpose of this PR. In case we are loading a texture using the TextureLoader like this:

```javascript
const textureLoader = new Three.TextureLoader()
//...
object.material.map = textureLoader.load( `/resources/images/myUnexistingImageTexture.jpg` )
```

**If the loader is unable to load the requested image, it will shown a black texture object instead of the default image. The default image goal is exactly for this type of use case.**

This PR allow to defaulting to the default texture image when the TextureLoader is unable to retrieve the requested image.

I hope this help,
Itee
