### PR TITLE
Add missing combine and envMapIntensity serialization

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -218,6 +218,9 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			data.envMap = this.envMap.toJSON( meta ).uuid;
 			data.reflectivity = this.reflectivity; // Scale behind envMap
 
+			if ( this.combine !== undefined ) data.combine = this.combine;
+			if ( this.envMapIntensity !== undefined ) data.envMapIntensity = this.envMapIntensity;
+
 		}
 
 		if ( this.gradientMap && this.gradientMap.isTexture ) {


### PR DESCRIPTION
This PR adds missing `.combine` and `.envMapIntensity` serialization to `toJson()` of `Material`. See the comments in #14833