### PR TITLE
Quaternion is missing the "isQuaternion" property

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -18,7 +18,8 @@ function Quaternion( x, y, z, w ) {
 }
 
 Object.assign( Quaternion, {
-
+	isQuaternion: true,
+	
 	slerp: function ( qa, qb, qm, t ) {
 
 		return qm.copy( qa ).slerp( qb, t );


### PR DESCRIPTION
Euler has "isEuler", Vector3 has "isVector3"... etc. etc.  Quaternion does not.

A minor change but would be nice to have for consistency.