### PR TITLE
Added currentCamera property to Scene and scene to Object3D.

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -112,6 +112,9 @@
 		<p>Object's parent in the [link:https://en.wikipedia.org/wiki/Scene_graph scene graph]. An object can have at most
 		one parent.</p>
 
+		<h3>[property:Scene scene]</h3>
+		<p>Object's top-most ancestor ([page:Scene]) if object is added to a scene.</p>
+
 		<h3>[property:Vector3 position]</h3>
 		<p>A [page:Vector3] representing the object's local position. Default is (0, 0, 0).</p>
 

--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -44,6 +44,9 @@
 		If not null, sets the background used when rendering the scene, and is always rendered first. Can be set to a [page:Color] which sets the clear color, a [page:Texture] covering the canvas, or a [page:CubeTexture]. Default is null.
 		</p>
 
+		<h3>[property:Camera currentCamera]</h3>
+		<p>Reference to the most recent camera the scene has been (or is about to be) be rendered with.</p>
+
 		<h2>Methods</h2>
 
 		<h3>[method:JSON toJSON]</h3>

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -27,6 +27,7 @@ function Object3D() {
 	this.type = 'Object3D';
 
 	this.parent = null;
+	this.scene = null;
 	this.children = [];
 
 	this.up = Object3D.DefaultUp.clone();
@@ -382,6 +383,19 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			}
 
 			object.parent = this;
+
+			var scene = this.scene;
+
+			if ( object.scene !== scene ) {
+
+				object.traverse( function ( child ) {
+
+					child.scene = scene;
+
+				} );
+
+			}
+
 			object.dispatchEvent( { type: 'added' } );
 
 			this.children.push( object );
@@ -415,6 +429,12 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		if ( index !== - 1 ) {
 
 			object.parent = null;
+
+			object.traverse( function ( child ) {
+
+				child.scene = null;
+
+			} );
 
 			object.dispatchEvent( { type: 'removed' } );
 

--- a/src/renderers/WebGL2Renderer.js
+++ b/src/renderers/WebGL2Renderer.js
@@ -149,6 +149,8 @@ function WebGL2Renderer( parameters ) {
 		var background = scene.background;
 		var forceClear = false;
 
+		scene.currentCamera = camera;
+
 		if ( background === null ) {
 
 			state.buffers.color.setClear( _clearColor.r, _clearColor.g, _clearColor.b, _clearAlpha, _premultipliedAlpha );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1037,6 +1037,8 @@ function WebGLRenderer( parameters ) {
 		_currentMaterialId = - 1;
 		_currentCamera = null;
 
+		scene.currentCamera = camera;
+
 		// update scene graph
 
 		if ( scene.autoUpdate === true ) scene.updateMatrixWorld();

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -10,6 +10,8 @@ function Scene() {
 
 	this.type = 'Scene';
 
+	this.scene = this;
+	this.currentCamera = null;
 	this.background = null;
 	this.fog = null;
 	this.overrideMaterial = null;

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -5,6 +5,7 @@
 /* global QUnit */
 
 import { Object3D } from '../../../../src/core/Object3D';
+import { Scene } from '../../../../src/scenes/Scene';
 import { Vector3 } from '../../../../src/math/Vector3';
 import { Euler } from '../../../../src/math/Euler';
 import { Quaternion } from '../../../../src/math/Quaternion';
@@ -331,6 +332,29 @@ export default QUnit.module( 'Core', () => {
 			assert.strictEqual( a.children.length, 1, "The second one was added to the parent (no remove)" );
 			assert.strictEqual( a.children[ 0 ], child2, "The second one is now the parent's child again" );
 			assert.strictEqual( child1.children.length, 0, "The first one no longer has any children" );
+
+		} );
+
+		QUnit.test( "parent/scene", ( assert ) => {
+
+			var scene = new Scene();
+			var child1 = new Object3D();
+			var child2 = new Object3D();
+
+			assert.strictEqual( child1.parent, null, "Starts with no parent property" );
+			assert.strictEqual( child1.scene, null, "Starts with no scene property" );
+
+			child1.add( child2 );
+			scene.add( child1 );
+			assert.strictEqual( child1.parent, scene, "Child has parent property set" );
+			assert.strictEqual( child1.scene, scene, "Child has scene property set" );
+			assert.strictEqual( child2.parent, child1, "Second child has parent property set" );
+			assert.strictEqual( child2.scene, scene, "Second child has scene property set" );
+
+			scene.remove( child1 );
+			assert.strictEqual( child1.parent, null, "Child has parent property reset" );
+			assert.strictEqual( child1.scene, null, "Child has scene property reset" );
+			assert.strictEqual( child2.scene, null, "Second child has scene property reset" );
 
 		} );
 


### PR DESCRIPTION
I'd like to propose this very small change to updateMatrixWorld method which I found extremely useful when creating viewport helpers and other objects that need camera information for their matrix updates.

One example would be a scene helper that always looks towards the current camera. This can easily be implemented by extending the `Object3D.updateMatrixWorld` with custom matrix update logic and reference to current camera's `matrixWorld`. This PR enables that.

If this idea is welcome, I can add add an example to this PR.

Alternative solutions exist. One is to manually update `.camera` property on all objects which need it but that can add a lot of additional complexity to application logic. Especially when multiple cameras and multiple viewports are used.

Another solution is to transform geometry in the shader (where camera information is obtainable). I believe points currently do this. This on the other hand, requires custom shaders which is not ideal. 

