### PR TITLE
GLTFLoader: Document best practices for textures.

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -86,16 +86,27 @@
 
 		<h2>Textures</h2>
 		
-		<p>Textures containing color information (.map, .emissiveMap, .specularMap) always use the sRGB colorspace
-		in glTF. Additionally, UVs use the convention that (0, 0) corresponds to the upper left corner of a texture.
-		Both differ from the current three.js default, so keep in mind:
+		<p>Textures containing color information material.{map,emissiveMap,specularMap} always use the sRGB colorspace
+		in glTF, while vertex colors and material.{color,emissive,specular} values use linear colorspace. In a
+		typical rendering workflow, textures are converted to linear colorspace by the renderer, lighting calculations
+		are made, then final output is converted back to sRGB and displayed on screen. Unless post-processing in linear
+		colorspace is needed, always configure [page:WebGLRenderer] as follows when using glTF:</p>
 			
-		<ol>
-			<li>Use <code>renderer.gammaOutput = true; renderer.gammaFactor = 2.2;</code> when using glTF.</li>
-			<li>When loading textures externally (e.g., using [page:TextureLoader]) and applying them to a glTF
-			model, set <code>texture.flipY = false;</code>. If that texture contains color information (see above)
-			then also set <code>texture.encoding = THREE.sRGBEncoding</code>.</li>
-		</ol>
+		<code>
+			renderer.gammaOutput = true;
+			renderer.gammaFactor = 2.2;
+		</code>
+		
+		<p>GLTFLoader will automatically configure textures referenced from a .gltf or .glb file correctly, with the
+		assumption that the renderer is set up as shown above. When loading textures externally (e.g., using
+		[page:TextureLoader]) and applying them to a glTF model, colorspace and orientation must be given:</p>
+		
+		<code>
+			// If texture is used for color information, set colorspace.
+			texture.encoding = THREE.sRGBEncoding;
+			// UVs use the convention that (0, 0) corresponds to the upper left corner of a texture.
+			texture.flipY = false;
+		</code>		
 		
 		<h2>Custom extensions</h2>
 

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -84,6 +84,19 @@
 		[link:https://github.com/stefanpenner/es6-promise include a polyfill]
 		providing a Promise replacement.</p>
 
+		<h2>Textures</h2>
+		
+		<p>Textures containing color information (.map, .emissiveMap, .specularMap) always use the sRGB colorspace
+		in glTF. Additionally, UVs use the convention that (0, 0) corresponds to the upper left corner of a texture.
+		Both differ from the current three.js default, so keep in mind:
+			
+		<ol>
+			<li>Use <code>renderer.gammaOutput = true; renderer.gammaFactor = 2.2;</code> when using glTF.</li>
+			<li>When loading textures externally (e.g., using [page:TextureLoader]) and applying them to a glTF
+			model, set <code>texture.flipY = false;</code>. If that texture contains color information (see above)
+			then also set <code>texture.encoding = THREE.sRGBEncoding</code>.</li>
+		</ol>
+		
 		<h2>Custom extensions</h2>
 
 		<p>

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -86,11 +86,11 @@
 
 		<h2>Textures</h2>
 		
-		<p>Textures containing color information material.{map,emissiveMap,specularMap} always use the sRGB colorspace
-		in glTF, while vertex colors and material.{color,emissive,specular} values use linear colorspace. In a
+		<p>Textures containing color information (.map, .emissiveMap, and .specularMap) always use sRGB colorspace in
+		glTF, while vertex colors and material properties (.color, .emissive, .specular) use linear colorspace. In a
 		typical rendering workflow, textures are converted to linear colorspace by the renderer, lighting calculations
-		are made, then final output is converted back to sRGB and displayed on screen. Unless post-processing in linear
-		colorspace is needed, always configure [page:WebGLRenderer] as follows when using glTF:</p>
+		are made, then final output is converted back to sRGB and displayed on screen. Unless you need post-processing
+		in linear colorspace, always configure [page:WebGLRenderer] as follows when using glTF:</p>
 			
 		<code>
 		renderer.gammaOutput = true;
@@ -104,6 +104,7 @@
 		<code>
 		// If texture is used for color information, set colorspace.
 		texture.encoding = THREE.sRGBEncoding;
+
 		// UVs use the convention that (0, 0) corresponds to the upper left corner of a texture.
 		texture.flipY = false;
 		</code>		

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -93,8 +93,8 @@
 		colorspace is needed, always configure [page:WebGLRenderer] as follows when using glTF:</p>
 			
 		<code>
-			renderer.gammaOutput = true;
-			renderer.gammaFactor = 2.2;
+		renderer.gammaOutput = true;
+		renderer.gammaFactor = 2.2;
 		</code>
 		
 		<p>GLTFLoader will automatically configure textures referenced from a .gltf or .glb file correctly, with the
@@ -102,10 +102,10 @@
 		[page:TextureLoader]) and applying them to a glTF model, colorspace and orientation must be given:</p>
 		
 		<code>
-			// If texture is used for color information, set colorspace.
-			texture.encoding = THREE.sRGBEncoding;
-			// UVs use the convention that (0, 0) corresponds to the upper left corner of a texture.
-			texture.flipY = false;
+		// If texture is used for color information, set colorspace.
+		texture.encoding = THREE.sRGBEncoding;
+		// UVs use the convention that (0, 0) corresponds to the upper left corner of a texture.
+		texture.flipY = false;
 		</code>		
 		
 		<h2>Custom extensions</h2>


### PR DESCRIPTION
Trying to reduce some recurring confusion on Stack Overflow (https://stackoverflow.com/search?q=gltf+texture.flipY). Eventually I will also add a note to this section about setting `renderer.physicallyCorrectLights = true`, which will be required to accurately reproduce the (still in progress) lighting extension.

@WestLangley I'd appreciate it if you could look over my explanation of colorspace here; I hope I am explaining this properly. Related: https://github.com/mrdoob/three.js/issues/11337#issuecomment-394334030 and `.gammaFactor=2.2` as "poor man's sRGB".