### PR TITLE
Correct 'thickness' comment

### DIFF
--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -5,7 +5,7 @@
  *
  * // How to set default outline parameters
  * new THREE.OutlineEffect( renderer, {
- * 	defaultThickNess: 0.01,
+ * 	defaultThickness: 0.01,
  * 	defaultColor: [ 0, 0, 0 ],
  * 	defaultAlpha: 0.8,
  * 	defaultKeepAlive: true // keeps outline material in cache even if material is removed from scene
@@ -13,7 +13,7 @@
  *
  * // How to set outline parameters for each material
  * material.userData.outlineParameters = {
- * 	thickNess: 0.01,
+ * 	thickness: 0.01,
  * 	color: [ 0, 0, 0 ]
  * 	alpha: 0.8,
  * 	visible: true,


### PR DESCRIPTION
The comment at the top would suggest people use 'defaultThickNess' or 'thickNess', whereas the code will only work if the user uses 'defaultThickness' or 'thickness'.