### PR TITLE
Fix wrong place of isQuaternion property

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -19,8 +19,6 @@ function Quaternion( x, y, z, w ) {
 
 Object.assign( Quaternion, {
 
-	isQuaternion: true,
-
 	slerp: function ( qa, qb, qm, t ) {
 
 		return qm.copy( qa ).slerp( qb, t );
@@ -164,6 +162,8 @@ Object.defineProperties( Quaternion.prototype, {
 } );
 
 Object.assign( Quaternion.prototype, {
+
+	isQuaternion: true,
 
 	set: function ( x, y, z, w ) {
 


### PR DESCRIPTION
The isQuaternion was under static member instead of instance member.

This PR move it, in the right place.