### PR TITLE
Replace bi-directional syncing with lazy Euler syncing

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -36,20 +36,27 @@ function Object3D() {
 	var quaternion = new Quaternion();
 	var scale = new Vector3( 1, 1, 1 );
 
+	var sync = new Quaternion();
+
 	function onRotationChange() {
 
 		quaternion.setFromEuler( rotation, false );
+		sync.copy( quaternion );
 
 	}
 
-	function onQuaternionChange() {
+	function onRotationAccess() {
 
-		rotation.setFromQuaternion( quaternion, undefined, false );
+		if ( ! sync.equals( quaternion ) ) {
+
+			rotation.setFromQuaternion( quaternion, undefined, false );
+			sync.copy( quaternion );
+
+		}
 
 	}
 
 	rotation.onChange( onRotationChange );
-	quaternion.onChange( onQuaternionChange );
 
 	Object.defineProperties( this, {
 		position: {
@@ -58,7 +65,12 @@ function Object3D() {
 		},
 		rotation: {
 			enumerable: true,
-			value: rotation
+			get: function () {
+
+				onRotationAccess();
+				return rotation;
+
+			}
 		},
 		quaternion: {
 			enumerable: true,


### PR DESCRIPTION
three.js is quaternion-based, and the Euler rotation is provided only for user convenience.

However, in the `Object3D` class, we currently do this:

1. update the quaternion whenever the Euler rotation changes, and
2. update the Euler rotation whenever the quaternion changes.

This PR implements the minimal change to effect the following, more efficient, strategy:

1. update the quaternion whenever the Euler rotation changes, and
2. lazily update the Euler rotation only when it is accessed.

In addition, a simple caching system is used to further prevent unnecessary computations.

This means that the `Quaternion` class no longer needs to update anybody else.

If there is agreement that this approach works, we can proceed to remove all the `onChange` callbacks from the `Quaternion` class (yay!). In addition, as proposed in #11289, we can eliminate some unnecessary closures. But for now, I'd like to keep this PR simple.
