### PR TITLE
FBXLoader: calculate transforms according to FBX spec

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1244,13 +1244,6 @@ THREE.FBXLoader = ( function () {
 
 			var transformData = {};
 
-			// 0 = RrSs, 1 = RSrs, 2 = Rrs
-			// RrSs: Scaling of parent is applied in the child world after the local child rotation
-			// RrSs:= GlobalRM(x) * (GlobalSHM(x) * GlobalSM(x)) = GlobalRM(P(x)) * LocalRM(x) * [GlobalSHM(P(x)) * GlobalSM(P(x))] * LocalSM(x)
-			// RSrs: Scaling of parent is applied in the parent world
-			// RSrs:= GlobalRM(x) * (GlobalSHM(x) * GlobalSM(x)) = GlobalRM(P(x)) * [GlobalSHM(P(x)) * GlobalSM(P(x))] * LocalRM(x) * LocalSM(x)
-			// Rrs: Scaling of parent does not affect the scaling of children
-			// Rrs:= GlobalRM(x) * (GlobalSHM(x) * GlobalSM(x)) = GlobalRM(P(x)) * LocalRM(x) * LocalSM(x)
 			if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
 
 			// rotation order
@@ -3917,7 +3910,6 @@ THREE.FBXLoader = ( function () {
 
 	}
 
-	var tempMat = new THREE.Matrix4();
 	var tempEuler = new THREE.Euler();
 	var tempVec = new THREE.Vector3();
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -835,12 +835,7 @@ THREE.FBXLoader = ( function () {
 
 					var transform = generateTransform( node.userData.transformData );
 
-					// if ( node.parent ) transform = node.parent.matrix.getInverse( node.parent.matrix ).multiply( transform );
-
 					node.applyMatrix( transform );
-
-					// if ( node.parent )
-
 
 				}
 
@@ -3931,8 +3926,6 @@ THREE.FBXLoader = ( function () {
 	// ref: http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/_transformations_2main_8cxx-example.html,topicNumber=cpp_ref__transformations_2main_8cxx_example_htmlfc10a1e1-b18d-4e72-9dc0-70d0f1959f5e
 	function generateTransform( transformData ) {
 
-		// console.log( 'transformData', transformData );
-
 		var lTranslationM = new THREE.Matrix4();
 		var lPreRotationM = new THREE.Matrix4();
 		var lRotationM = new THREE.Matrix4();
@@ -4023,7 +4016,6 @@ THREE.FBXLoader = ( function () {
 
 		}
 
-
 		// Calculate the local transform matrix
 		lTransform = lTranslationM.multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM.getInverse( lRotationPivotM ) ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM.getInverse( lScalingPivotM ) );
 
@@ -4035,8 +4027,6 @@ THREE.FBXLoader = ( function () {
 		lTransform = lGlobalT.multiply( lGlobalRS );
 
 		return lTransform;
-
-		// = new THREE.Matrix4();
 
 	}
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -712,9 +712,9 @@ THREE.FBXLoader = ( function () {
 					ID: child.ID,
 					indices: [],
 					weights: [],
-					transform: new THREE.Matrix4().fromArray( boneNode.Transform.a ),
 					transformLink: new THREE.Matrix4().fromArray( boneNode.TransformLink.a ),
-					linkMode: boneNode.Mode,
+					// transform: new THREE.Matrix4().fromArray( boneNode.Transform.a ),
+					// linkMode: boneNode.Mode,
 
 				};
 
@@ -873,7 +873,10 @@ THREE.FBXLoader = ( function () {
 						case 'NurbsCurve':
 							model = this.createCurve( relationships, geometryMap );
 							break;
-						case 'LimbNode': // usually associated with a Bone, however if a Bone was not created we'll make a Group instead
+						case 'LimbNode':
+						case 'Root':
+							model = new THREE.Bone();
+							break;
 						case 'Null':
 						default:
 							model = new THREE.Group();
@@ -911,6 +914,7 @@ THREE.FBXLoader = ( function () {
 
 							var subBone = bone;
 							bone = new THREE.Bone();
+
 							bone.matrixWorld.copy( rawBone.transformLink );
 
 							// set name and id here - otherwise in cases where "subBone" is created it will not have a name / id
@@ -2280,7 +2284,6 @@ THREE.FBXLoader = ( function () {
 
 			var animationClips = [];
 
-
 			var rawClips = this.parseClips();
 
 			if ( rawClips === undefined ) return;
@@ -2460,11 +2463,14 @@ THREE.FBXLoader = ( function () {
 										if ( child.ID = rawModel.id ) {
 
 											node.transform = child.matrix;
+
 											if ( child.userData.transformData ) node.eulerOrder = child.userData.transformData.eulerOrder;
 
 										}
 
 									} );
+
+									if ( ! node.transform ) node.transform = new THREE.Matrix4();
 
 									// if the animated model is pre rotated, we'll have to apply the pre rotations to every
 									// animation value as well
@@ -2585,7 +2591,7 @@ THREE.FBXLoader = ( function () {
 			var initialRotation = new THREE.Quaternion();
 			var initialScale = new THREE.Vector3();
 
-			if ( rawTracks.transform ) rawTracks.transform.decompose( initialPosition, initialRotation, initialScale );
+			rawTracks.transform.decompose( initialPosition, initialRotation, initialScale );
 
 			initialPosition = initialPosition.toArray();
 			initialRotation = new THREE.Euler().setFromQuaternion( initialRotation, rawTracks.eulerOrder ).toArray();

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -66,7 +66,7 @@ THREE.FBXLoader = ( function () {
 
 			}, onProgress, onError );
 
-},
+		},
 
 		setCrossOrigin: function ( value ) {
 
@@ -101,7 +101,7 @@ THREE.FBXLoader = ( function () {
 
 			}
 
-			console.log( fbxTree );
+			// console.log( fbxTree );
 
 			var textureLoader = new THREE.TextureLoader( this.manager ).setPath( resourceDirectory ).setCrossOrigin( this.crossOrigin );
 
@@ -1245,23 +1245,16 @@ THREE.FBXLoader = ( function () {
 			var transformData = {};
 
 			if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
-
-			// rotation order
 			if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = parseInt( modelNode.RotationOrder.value );
 
-			// translation
 			if ( 'Lcl_Translation' in modelNode ) transformData.translation = modelNode.Lcl_Translation.value;
 
-			// rotation
 			if ( 'PreRotation' in modelNode ) transformData.preRotation = modelNode.PreRotation.value;
 			if ( 'Lcl_Rotation' in modelNode ) transformData.rotation = modelNode.Lcl_Rotation.value;
 			if ( 'PostRotation' in modelNode ) transformData.postRotation = modelNode.PostRotation.value;
 
-			// scaling
 			if ( 'Lcl_Scaling' in modelNode ) transformData.scale = modelNode.Lcl_Scaling.value;
 
-
-			// offset and pivot
 			if ( 'ScalingOffset' in modelNode ) transformData.scalingOffset = modelNode.ScalingOffset.value;
 			if ( 'ScalingPivot' in modelNode ) transformData.scalingPivot = modelNode.ScalingPivot.value;
 
@@ -2525,36 +2518,17 @@ THREE.FBXLoader = ( function () {
 
 			var transformData = {};
 
-			// if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = parseInt( modelNode.RotationOrder.value );
-
-			// if ( 'Lcl_Translation' in modelNode ) transformData.translation = modelNode.Lcl_Translation.value;
-			// if ( 'RotationOffset' in modelNode ) transformData.rotationOffset = modelNode.RotationOffset.value;
-
-			// if ( 'Lcl_Rotation' in modelNode ) transformData.rotation = modelNode.Lcl_Rotation.value;
-			// if ( 'PreRotation' in modelNode ) transformData.preRotation = modelNode.PreRotation.value;
-
-			// if ( 'PostRotation' in modelNode ) transformData.postRotation = modelNode.PostRotation.value;
-
-			// if ( 'Lcl_Scaling' in modelNode ) transformData.scale = modelNode.Lcl_Scaling.value;
-
 			if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
-
-			// rotation order
 			if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = parseInt( modelNode.RotationOrder.value );
 
-			// translation
 			if ( 'Lcl_Translation' in modelNode ) transformData.translation = modelNode.Lcl_Translation.value;
 
-			// rotation
 			if ( 'PreRotation' in modelNode ) transformData.preRotation = modelNode.PreRotation.value;
 			if ( 'Lcl_Rotation' in modelNode ) transformData.rotation = modelNode.Lcl_Rotation.value;
 			if ( 'PostRotation' in modelNode ) transformData.postRotation = modelNode.PostRotation.value;
 
-			// scaling
 			if ( 'Lcl_Scaling' in modelNode ) transformData.scale = modelNode.Lcl_Scaling.value;
 
-
-			// offset and pivot
 			if ( 'ScalingOffset' in modelNode ) transformData.scalingOffset = modelNode.ScalingOffset.value;
 			if ( 'ScalingPivot' in modelNode ) transformData.scalingPivot = modelNode.ScalingPivot.value;
 


### PR DESCRIPTION
Updated the `generateTransform` method to match the method described in the FBX docs [here](http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/_transformations_2main_8cxx-example.html,topicNumber=cpp_ref__transformations_2main_8cxx_example_htmlfc10a1e1-b18d-4e72-9dc0-70d0f1959f5e). 

Also moved calculation and application of model's transform to after the scene graph has been built, since a models transform now takes into account its parent's transform as well. 

Motivation for this PR is an attempt to fix #14903 and #14864. Currently, there is no change to the bugs displayed by those models after this PR. I suspect that this is because the transform is being applied incorrectly at animation node level. This can be investigated later. 

Note: I've matched the variable names and method described in the docs page linked above very closely, even though this involves instantiating a lot of new `Matrix4`'s for each node. If this turns out to be a bottleneck, this can probably be refactored quite a bit, however I'd rather leave it like this for now, at least until the bugs in the above issues are resolved. 
