### PR TITLE
Fixed sprite raycast bug when sizeAttenuation is false

### DIFF
--- a/examples/webgl_raycast_sprite.html
+++ b/examples/webgl_raycast_sprite.html
@@ -87,6 +87,26 @@
 			sprite.material.rotation = Math.PI / 3;
 			group2.add( sprite );
 
+
+			var num = 20;
+			var radius = 10;
+			while(num --) {
+
+				var x = Math.random() - 0.5;
+				var y = Math.random() - 0.5;
+				var z = Math.random() - 0.5;
+
+				var sprite = new THREE.Sprite( new THREE.SpriteMaterial( { color: '#96f' } ));
+				sprite.position.set( x, y, z );
+				sprite.position.normalize();
+				sprite.position.multiplyScalar( radius );
+				sprite.scale.set(0.05 * Math.random(), 0.05 * Math.random(), 0.05 * Math.random());
+				sprite.material.rotation = Math.random() * Math.PI * 2;
+				sprite.material.sizeAttenuation = false;
+				group.add( sprite );
+
+			}
+
 			window.addEventListener( 'resize', onWindowResize, false );
 			window.addEventListener( "mousemove", onDocumentMouseMove, false );
 
@@ -115,7 +135,7 @@
 			event.preventDefault();
 			if ( selectedObject ) {
 
-				selectedObject.material.color.set( '#69f' );
+				selectedObject.material.color.set( selectedObject.originColor );
 				selectedObject = null;
 
 			}
@@ -132,6 +152,7 @@
 				if ( res && res.object ) {
 
 					selectedObject = res.object;
+					selectedObject.originColor = selectedObject.material.color.getHex();
 					selectedObject.material.color.set( '#f00' );
 
 				}

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -104,6 +104,12 @@ Sprite.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			viewWorldMatrix.getInverse( this.modelViewMatrix ).premultiply( this.matrixWorld );
 			mvPosition.setFromMatrixPosition( this.modelViewMatrix );
 
+			if ( ! this.material.sizeAttenuation ) {
+
+				worldScale.multiplyScalar( - mvPosition.z );
+
+			}
+
 			var rotation = this.material.rotation;
 			var sin, cos;
 			if ( rotation !== 0 ) {

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -104,7 +104,7 @@ Sprite.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			viewWorldMatrix.getInverse( this.modelViewMatrix ).premultiply( this.matrixWorld );
 			mvPosition.setFromMatrixPosition( this.modelViewMatrix );
 
-			if ( ! this.material.sizeAttenuation ) {
+			if ( this.material.sizeAttenuation === false ) {
 
 				worldScale.multiplyScalar( - mvPosition.z );
 


### PR DESCRIPTION
Fixed #14934

[demo](https://raw.githack.com/06wj/three.js/patch0_build/examples/webgl_raycast_sprite.html)

If using an orthographic camera the results is wrong. 