### PR TITLE
FBXLoader: added setResourcePath()

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -48,7 +48,21 @@ THREE.FBXLoader = ( function () {
 
 			loader.load( url, function ( buffer ) {
 
-				onLoad( self.parse( buffer, path ) );
+				try {
+
+					onLoad( self.parse( buffer, path ) );
+
+				} catch ( error ) {
+
+					setTimeout( function () {
+
+						if ( onError ) onError( error );
+
+						self.manager.itemError( url );
+
+					}, 0 );
+
+				}
 
 			}, onProgress, onError );
 
@@ -300,8 +314,6 @@ THREE.FBXLoader = ( function () {
 					return;
 
 			}
-
-			console.log();
 
 			if ( typeof content === 'string' ) { // ASCII format
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -41,30 +41,30 @@ THREE.FBXLoader = ( function () {
 
 			var self = this;
 
-			var resourceDirectory = THREE.LoaderUtils.extractUrlBase( url );
+			var path = ( self.path === undefined ) ? THREE.LoaderUtils.extractUrlBase( url ) : self.path;
 
 			var loader = new THREE.FileLoader( this.manager );
 			loader.setResponseType( 'arraybuffer' );
+
 			loader.load( url, function ( buffer ) {
 
-				try {
-
-					var scene = self.parse( buffer, resourceDirectory );
-					onLoad( scene );
-
-				} catch ( error ) {
-
-					setTimeout( function () {
-
-						if ( onError ) onError( error );
-
-						self.manager.itemError( url );
-
-					}, 0 );
-
-				}
+				onLoad( self.parse( buffer, path ) );
 
 			}, onProgress, onError );
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
+		},
+
+		setResourcePath: function ( value ) {
+
+			this.resourcePath = value;
+			return this;
 
 		},
 
@@ -75,7 +75,7 @@ THREE.FBXLoader = ( function () {
 
 		},
 
-		parse: function ( FBXBuffer, resourceDirectory ) {
+		parse: function ( FBXBuffer, path ) {
 
 			if ( isFbxFormatBinary( FBXBuffer ) ) {
 
@@ -103,7 +103,7 @@ THREE.FBXLoader = ( function () {
 
 			// console.log( fbxTree );
 
-			var textureLoader = new THREE.TextureLoader( this.manager ).setPath( resourceDirectory ).setCrossOrigin( this.crossOrigin );
+			var textureLoader = new THREE.TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
 
 			return new FBXTreeParser( textureLoader ).parse( fbxTree );
 
@@ -282,7 +282,10 @@ THREE.FBXLoader = ( function () {
 
 						if ( THREE.Loader.Handlers.get( '.tga' ) === null ) {
 
-							THREE.Loader.Handlers.add( /\.tga$/i, new THREE.TGALoader() );
+							var tgaLoader = new THREE.TGALoader();
+							tgaLoader.setPath( this.textureLoader.path );
+
+							THREE.Loader.Handlers.add( /\.tga$/i, tgaLoader );
 
 						}
 
@@ -297,6 +300,8 @@ THREE.FBXLoader = ( function () {
 					return;
 
 			}
+
+			console.log();
 
 			if ( typeof content === 'string' ) { // ASCII format
 


### PR DESCRIPTION
See #12942

Also simplified the `load` function - for some reason parsing was wrapped in a `try...catch` statement. 

@donmccurdy, @Mugen87  I've noticed that the `GLTFLoader` does something similar, introduced in #11864. However the `ColladaLoader` doesn't. I guess the purpose of this statement is to call `loadingManager.itemError`, I'm not sure if that is necessary though. 

We should make error handling of the loaders consistent as well, which style do you guys prefer? 