### PR TITLE
Added currentCamera property to Scene.

### DIFF
--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -44,6 +44,9 @@
 		If not null, sets the background used when rendering the scene, and is always rendered first. Can be set to a [page:Color] which sets the clear color, a [page:Texture] covering the canvas, or a [page:CubeTexture]. Default is null.
 		</p>
 
+		<h3>[property:Camera currentCamera]</h3>
+		<p>Reference to the camera the scene is being rendered with, or the last camera it has been rendered with.</p>
+
 		<h2>Methods</h2>
 
 		<h3>[method:JSON toJSON]</h3>

--- a/src/renderers/WebGL2Renderer.js
+++ b/src/renderers/WebGL2Renderer.js
@@ -149,6 +149,8 @@ function WebGL2Renderer( parameters ) {
 		var background = scene.background;
 		var forceClear = false;
 
+		scene.currentCamera = camera;
+
 		if ( background === null ) {
 
 			state.buffers.color.setClear( _clearColor.r, _clearColor.g, _clearColor.b, _clearAlpha, _premultipliedAlpha );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1037,6 +1037,10 @@ function WebGLRenderer( parameters ) {
 		_currentMaterialId = - 1;
 		_currentCamera = null;
 
+		// Update scene camera
+
+		scene.currentCamera = camera;
+
 		// update scene graph
 
 		if ( scene.autoUpdate === true ) scene.updateMatrixWorld();

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -10,6 +10,7 @@ function Scene() {
 
 	this.type = 'Scene';
 
+	this.currentCamera = null;
 	this.background = null;
 	this.fog = null;
 	this.overrideMaterial = null;


### PR DESCRIPTION
Following #14953 this pull request allows any object in a rendered scene to access current camera. 

For example, you can do `mesh.scene.currentCamera`.

This small change can have positive impact on application-side complexity. As previously discussed in 
#14888 it can be used, for example, to make helper objects with camera-dependent transformations.

The only concern that was brought up so far by @takahirox is theoretically possible memory leak because the most recent camera will be referenced on the scene until the scene gets rendered with a different camera. While I understand the potential memory leaks for lingering post-render references, I cant imagine a scenario where camera doesn't get released for GC eventually while the scene itself does.