### PR TITLE
Rename Texture3D to DataTexture3D

### DIFF
--- a/examples/webgl_materials_texture3d.html
+++ b/examples/webgl_materials_texture3d.html
@@ -119,7 +119,7 @@
 					var zip = new JSZip( data );
 					var array = zip.files[ 'head256x256x109' ].asUint8Array();
 
-					var texture = new THREE.Texture3D( array, 256, 256, 109 );
+					var texture = new THREE.DataTexture3D( array, 256, 256, 109 );
 
 					texture.format = THREE.RedFormat;
 					texture.type = THREE.UnsignedByteType;

--- a/examples/webgl_materials_texture3d_volume.html
+++ b/examples/webgl_materials_texture3d_volume.html
@@ -121,7 +121,7 @@
 				// THREEJS will select R32F (33326) based on the RedFormat and FloatType.
 				// Also see https://www.khronos.org/registry/webgl/specs/latest/2.0/#TEXTURE_TYPES_FORMATS_FROM_DOM_ELEMENTS_TABLE
 				// TODO: look the dtype up in the volume metadata
-				var texture = new THREE.Texture3D( volume.data, volume.xLength, volume.yLength, volume.zLength );
+				var texture = new THREE.DataTexture3D( volume.data, volume.xLength, volume.yLength, volume.zLength );
 				texture.format = THREE.RedFormat;
 				texture.type = THREE.FloatType;
 				texture.minFilter = texture.magFilter = THREE.LinearFilter;

--- a/src/Three.js
+++ b/src/Three.js
@@ -24,7 +24,7 @@ export { Points } from './objects/Points.js';
 export { Group } from './objects/Group.js';
 export { VideoTexture } from './textures/VideoTexture.js';
 export { DataTexture } from './textures/DataTexture.js';
-export { Texture3D } from './textures/Texture3D.js';
+export { DataTexture3D } from './textures/DataTexture3D.js';
 export { CompressedTexture } from './textures/CompressedTexture.js';
 export { CubeTexture } from './textures/CubeTexture.js';
 export { CanvasTexture } from './textures/CanvasTexture.js';

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -489,7 +489,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		var textureType;
 
-		if ( texture.isTexture3D ) {
+		if ( texture.isDataTexture3D ) {
 
 			textureType = _gl.TEXTURE_3D;
 
@@ -648,7 +648,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			textureProperties.__maxMipLevel = mipmaps.length - 1;
 
-		} else if ( texture.isTexture3D ) {
+		} else if ( texture.isDataTexture3D ) {
 
 			state.texImage3D( _gl.TEXTURE_3D, 0, glInternalFormat, image.width, image.height, image.depth, 0, glFormat, glType, image.data );
 			textureProperties.__maxMipLevel = 0;

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -51,10 +51,10 @@
 
 import { CubeTexture } from '../../textures/CubeTexture.js';
 import { Texture } from '../../textures/Texture.js';
-import { Texture3D } from '../../textures/Texture3D.js';
+import { DataTexture3D } from '../../textures/DataTexture3D.js';
 
 var emptyTexture = new Texture();
-var emptyTexture3d = new Texture3D();
+var emptyTexture3d = new DataTexture3D();
 var emptyCubeTexture = new CubeTexture();
 
 // --- Base for inner nodes (including the root) ---

--- a/src/textures/DataTexture3D.js
+++ b/src/textures/DataTexture3D.js
@@ -5,12 +5,12 @@
 import { Texture } from './Texture.js';
 import { NearestFilter } from '../constants.js';
 
-function Texture3D( data, width, height, depth ) {
+function DataTexture3D( data, width, height, depth ) {
 
 	// We're going to add .setXXX() methods for setting properties later.
-	// Users can still set in Texture3D directly.
+	// Users can still set in DataTexture3D directly.
 	//
-	//	var texture = new THREE.Texture3D( data, width, height, depth );
+	//	var texture = new THREE.DataTexture3D( data, width, height, depth );
 	// 	texture.anisotropy = 16;
 	//
 	// See #14839
@@ -27,8 +27,8 @@ function Texture3D( data, width, height, depth ) {
 
 }
 
-Texture3D.prototype = Object.create( Texture.prototype );
-Texture3D.prototype.constructor = Texture3D;
-Texture3D.prototype.isTexture3D = true;
+DataTexture3D.prototype = Object.create( Texture.prototype );
+DataTexture3D.prototype.constructor = DataTexture3D;
+DataTexture3D.prototype.isDataTexture3D = true;
 
-export { Texture3D };
+export { DataTexture3D };


### PR DESCRIPTION
I think we should rename the current Texture3D to DataTexture3D for consistent naming, it doesn't take image but takes typed array data.

See https://github.com/mrdoob/three.js/pull/14951#issuecomment-423934455
