### PR TITLE
TDSLoader: Refactor setPath() usage and introduced setResourcePath().

### DIFF
--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -28,6 +28,8 @@ THREE.TDSLoader.prototype = {
 
 	constructor: THREE.TDSLoader,
 
+	crossOrigin: 'anonymous',
+
 	/**
 	 * Load 3ds file from url.
 	 *
@@ -44,7 +46,7 @@ THREE.TDSLoader.prototype = {
 		var path = this.path !== undefined ? this.path : THREE.LoaderUtils.extractUrlBase( url );
 
 		var loader = new THREE.FileLoader( this.manager );
-
+		loader.setPath( this.path );
 		loader.setResponseType( 'arraybuffer' );
 
 		loader.load( url, function ( data ) {
@@ -520,7 +522,7 @@ THREE.TDSLoader.prototype = {
 		var texture = {};
 
 		var loader = new THREE.TextureLoader( this.manager );
-		loader.setPath( path );
+		loader.setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
 
 		while ( next !== 0 ) {
 
@@ -842,15 +844,46 @@ THREE.TDSLoader.prototype = {
 	},
 
 	/**
-	 * Set resource path used to determine the file path to attached resources.
+	 * Set path to adjust the path to the original 3ds file.
 	 *
 	 * @method setPath
-	 * @param {String} path Path to resources.
+	 * @param {String} path Path to file.
 	 * @return Self for chaining.
 	 */
 	setPath: function ( path ) {
 
 		this.path = path;
+
+		return this;
+
+	},
+
+	/**
+	 * Set resource path used to determine the path to attached resources like textures.
+	 *
+	 * @method setResourcePath
+	 * @param {String} resourcePath Path to resources.
+	 * @return Self for chaining.
+	 */
+	setResourcePath: function ( resourcePath ) {
+
+		this.resourcePath = resourcePath;
+
+		return this;
+
+	},
+
+	/**
+	 * Set crossOrigin value to configure CORS settings
+	 * for the image loading process.
+	 *
+	 * @method setCrossOrigin
+	 * @param {String} crossOrigin crossOrigin string.
+	 * @return Self for chaining.
+	 */
+	setCrossOrigin: function ( crossOrigin ) {
+
+		this.crossOrigin = crossOrigin;
 
 		return this;
 

--- a/examples/webgl_loader_3ds.html
+++ b/examples/webgl_loader_3ds.html
@@ -64,7 +64,7 @@
 				var normal = loader.load( 'models/3ds/portalgun/textures/normal.jpg' );
 
 				var loader = new THREE.TDSLoader( );
-				loader.setPath( 'models/3ds/portalgun/textures/' );
+				loader.setResourcePath( 'models/3ds/portalgun/textures/' );
 				loader.load( 'models/3ds/portalgun/portalgun.3ds', function ( object ) {
 
 					object.traverse( function ( child ) {


### PR DESCRIPTION
See #12942

This PR changes the semantics of `TDSLoader.setPath()` to the new standard. It introduces `setResourcePath()` and also `setCrossOrigin()` which was missing so far.

/cc @tentone 