### PR TITLE
MTLLoader: Introduced new path handling.

### DIFF
--- a/docs/examples/loaders/MTLLoader.html
+++ b/docs/examples/loaders/MTLLoader.html
@@ -49,16 +49,16 @@
 			[page:String path] — required<br />
 		</p>
 		<p>
-			 Set base path for resolving references. If set this path will be prepended to each loaded and found reference.
+			 Set base path for MTL file.
 		</p>
 
 
-		<h3>[method:MTLLoader setTexturePath]( [param:String path] )</h3>
+		<h3>[method:MTLLoader setResourcePath]( [param:String path] )</h3>
 		<p>
 			[page:String path] — required<br />
 		</p>
 		<p>
-			Set base path for resolving texture references. If set this path will be prepended found texture reference. If not set and setPath is, it will be used as texture base path.
+			Set base path for additional resources like textures. If set, this path will be used as the base path.
 		</p>
 
 
@@ -88,9 +88,10 @@
 		</p>
 
 
-		<h3>[method:MTLLoaderMaterialCreator parse]( [param:String text] )</h3>
+		<h3>[method:MTLLoaderMaterialCreator parse]( [param:String text, param:String path] )</h3>
 		<p>
 			[page:String text] — The textual <em>mtl</em> structure to parse.
+			[page:String path] — The path to the MTL file.
 		</p>
 		<p>
 			Parse a <em>mtl</em> text structure and return a [page:MTLLoaderMaterialCreator] instance.<br />

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -22,20 +22,22 @@ THREE.MTLLoader.prototype = {
 	 * @param {Function} [onProgress] - Callback for download progress.
 	 * @param {Function} [onError] - Callback for download errors.
 	 *
-	 * @see setPath setTexturePath
+	 * @see setPath setResourcePath
 	 *
 	 * @note In order for relative texture references to resolve correctly
-	 * you must call setPath and/or setTexturePath explicitly prior to load.
+	 * you must call setResourcePath() explicitly prior to load.
 	 */
 	load: function ( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
+		var path = ( this.path === undefined ) ? THREE.LoaderUtils.extractUrlBase( url ) : this.path;
+
 		var loader = new THREE.FileLoader( this.manager );
 		loader.setPath( this.path );
 		loader.load( url, function ( text ) {
 
-			onLoad( scope.parse( text ) );
+			onLoad( scope.parse( text, path ) );
 
 		}, onProgress, onError );
 
@@ -45,7 +47,7 @@ THREE.MTLLoader.prototype = {
 	 * Set base path for resolving references.
 	 * If set this path will be prepended to each loaded and found reference.
 	 *
-	 * @see setTexturePath
+	 * @see setResourcePath
 	 * @param {String} path
 	 * @return {THREE.MTLLoader}
 	 *
@@ -61,9 +63,7 @@ THREE.MTLLoader.prototype = {
 	},
 
 	/**
-	 * Set base path for resolving texture references.
-	 * If set this path will be prepended found texture reference.
-	 * If not set and setPath is, it will be used as texture base path.
+	 * Set base path for additional resources like textures.
 	 *
 	 * @see setPath
 	 * @param {String} path
@@ -71,21 +71,20 @@ THREE.MTLLoader.prototype = {
 	 *
 	 * @example
 	 *     mtlLoader.setPath( 'assets/obj/' );
-	 *     mtlLoader.setTexturePath( 'assets/textures/' );
+	 *     mtlLoader.setResourcePath( 'assets/textures/' );
 	 *     mtlLoader.load( 'my.mtl', ... );
 	 */
-	setTexturePath: function ( path ) {
+	setResourcePath: function ( path ) {
 
-		this.texturePath = path;
+		this.resourcePath = path;
 		return this;
 
 	},
 
-	setBaseUrl: function ( path ) {
+	setTexturePath: function ( path ) {
 
-		console.warn( 'THREE.MTLLoader: .setBaseUrl() is deprecated. Use .setTexturePath( path ) for texture path or .setPath( path ) for general base path instead.' );
-
-		return this.setTexturePath( path );
+		console.warn( 'THREE.MTLLoader: .setTexturePath() has been renamed to .setResourcePath().' );
+		return this.setResourcePath( path );
 
 	},
 
@@ -109,12 +108,12 @@ THREE.MTLLoader.prototype = {
 	 * @param {String} text - Content of MTL file
 	 * @return {THREE.MTLLoader.MaterialCreator}
 	 *
-	 * @see setPath setTexturePath
+	 * @see setPath setResourcePath
 	 *
 	 * @note In order for relative texture references to resolve correctly
-	 * you must call setPath and/or setTexturePath explicitly prior to parse.
+	 * you must call setResourcePath() explicitly prior to parse.
 	 */
-	parse: function ( text ) {
+	parse: function ( text, path ) {
 
 		var lines = text.split( '\n' );
 		var info = {};
@@ -165,7 +164,7 @@ THREE.MTLLoader.prototype = {
 
 		}
 
-		var materialCreator = new THREE.MTLLoader.MaterialCreator( this.texturePath || this.path, this.materialOptions );
+		var materialCreator = new THREE.MTLLoader.MaterialCreator( this.resourcePath || path, this.materialOptions );
 		materialCreator.setCrossOrigin( this.crossOrigin );
 		materialCreator.setManager( this.manager );
 		materialCreator.setMaterials( materialsInfo );

--- a/examples/js/loaders/OBJLoader2.js
+++ b/examples/js/loaders/OBJLoader2.js
@@ -1397,7 +1397,7 @@ THREE.OBJLoader2 = (function () {
 			var mtlLoader = new THREE.MTLLoader( this.manager );
 			crossOrigin = Validator.verifyInput( crossOrigin, 'anonymous' );
 			mtlLoader.setCrossOrigin( crossOrigin );
-			mtlLoader.setPath( resource.path );
+			mtlLoader.setResourcePath( resource.path );
 			if ( Validator.isValid( materialOptions ) ) mtlLoader.setMaterialOptions( materialOptions );
 
 			var parseTextWithMtlLoader = function ( content ) {


### PR DESCRIPTION
see #12942

Harmonized `MTLLoader` to other loaders.

- Renamed `.setTexturePath()` to `.setResourcePath()`.
- `MTLLoader.load()`now extracts the base path from the URL via `LoaderUtils.extractUrlBase` and uses it.

/cc @kaisalmen It was necessary to make a small [change](https://github.com/mrdoob/three.js/pull/14971/files#diff-cea66cdcb18831386692ad973b909796L1400) to `OBJLoader2`. 