### PR TITLE
fix(docs): Update example & link for Detector.js -> WebGL.js

### DIFF
--- a/docs/manual/en/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/en/introduction/WebGL-compatibility-check.html
@@ -15,16 +15,16 @@
 		</p>
 
 		<p>
-			Add	[link:https://github.com/mrdoob/three.js/blob/master/examples/js/Detector.js]
+			Add	[link:https://github.com/mrdoob/three.js/blob/master/examples/js/WebGL.js]
 			to your javascript and run the following before attempting to render anything.
 		</p>
 
 <code>
-if (Detector.webgl) {
+if (WEBGL.isWebGLAvailable()) {
     // Initiate function or other initializations here
     animate();
 } else {
-    var warning = Detector.getWebGLErrorMessage();
+    var warning = WEBGL.getWebGLErrorMessage();
     document.getElementById('container').appendChild(warning);
 }
 </code>


### PR DESCRIPTION
Your docs are a very popular landing point from google for people looking to find a way to detect WebGL support. After the changes in https://github.com/mrdoob/three.js/pull/14967 (2 days ago), these docs now contain a dead link, and incorrect code for what is in the latest master. 

This fixes the code example and link. 