### PR TITLE
Loaders: Added missing .setPath() in remaining core loaders.

### DIFF
--- a/docs/api/en/loaders/AnimationLoader.html
+++ b/docs/api/en/loaders/AnimationLoader.html
@@ -81,6 +81,14 @@
 		be parsed with [page:AnimationClip.parse].
 		</p>
 
+		<h3>[method:AnimationLoader setPath]( [param:String path] )</h3>
+		<p>
+			[page:String path] — Base path of the file to load.<br /><br />
+
+			Sets the base path or URL from which to load files. This can be useful if
+			you are loading many animations from the same directory.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/en/loaders/AudioLoader.html
+++ b/docs/api/en/loaders/AudioLoader.html
@@ -92,6 +92,14 @@
 		Begin loading from url and pass the loaded [page:String AudioBuffer] to onLoad.
 		</p>
 
+		<h3>[method:AudioLoader setPath]( [param:String path] )</h3>
+		<p>
+			[page:String path] — Base path of the file to load.<br /><br />
+			
+			Sets the base path or URL from which to load files. This can be useful if
+			you are loading many audios from the same directory.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/en/loaders/BufferGeometryLoader.html
+++ b/docs/api/en/loaders/BufferGeometryLoader.html
@@ -85,6 +85,14 @@
 		Parse a <em>JSON</em> structure and return a [page:BufferGeometry].
 		</p>
 
+		<h3>[method:BufferGeometryLoader setPath]( [param:String path] )</h3>
+		<p>
+			[page:String path] — Base path of the file to load.<br /><br />
+
+			Sets the base path or URL from which to load files. This can be useful if
+			you are loading many geometries from the same directory.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/en/loaders/DataTextureLoader.html
+++ b/docs/api/en/loaders/DataTextureLoader.html
@@ -56,6 +56,14 @@
 		Begin loading from url and pass the loaded texture to onLoad.
 		</p>
 
+		<h3>[method:DataTextureLoader setPath]( [param:String path] )</h3>
+		<p>
+			[page:String path] — Base path of the file to load.<br /><br />
+
+			Sets the base path or URL from which to load files. This can be useful if
+			you are loading many data textures from the same directory.
+		</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]

--- a/docs/api/en/loaders/MaterialLoader.html
+++ b/docs/api/en/loaders/MaterialLoader.html
@@ -84,12 +84,18 @@
 		Parse a <em>JSON</em> structure and create a new [page:Material] of the type [page:String json.type] with parameters defined in the json object.
 		</p>
 
-		<h3>[method:null setTextures]( [param:Object textures] )</h3>
+		<h3>[method:MaterialLoader setPath]( [param:String path] )</h3>
+		<p>
+			[page:String path] — Base path of the file to load.<br /><br />
+
+			Sets the base path or URL from which to load files. This can be useful if
+			you are loading many materials from the same directory.
+		</p>
+
+		<h3>[method:MaterialLoader setTextures]( [param:Object textures] )</h3>
 		<p>
 		[page:Object textures] — object containing any textures used by the material.
 		</p>
-
-
 
 		<h2>Source</h2>
 

--- a/src/loaders/AnimationLoader.js
+++ b/src/loaders/AnimationLoader.js
@@ -19,6 +19,7 @@ Object.assign( AnimationLoader.prototype, {
 		var scope = this;
 
 		var loader = new FileLoader( scope.manager );
+		loader.setPath( scope.path );
 		loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( JSON.parse( text ) ) );
@@ -40,6 +41,13 @@ Object.assign( AnimationLoader.prototype, {
 		}
 
 		onLoad( animations );
+
+	},
+
+	setPath: function ( value ) {
+
+		this.path = value;
+		return this;
 
 	}
 

--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -18,6 +18,7 @@ Object.assign( AudioLoader.prototype, {
 
 		var loader = new FileLoader( this.manager );
 		loader.setResponseType( 'arraybuffer' );
+		loader.setPath( this.path );
 		loader.load( url, function ( buffer ) {
 
 			// Create a copy of the buffer. The `decodeAudioData` method
@@ -32,6 +33,13 @@ Object.assign( AudioLoader.prototype, {
 			} );
 
 		}, onProgress, onError );
+
+	},
+
+	setPath: function ( value ) {
+
+		this.path = value;
+		return this;
 
 	}
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -22,6 +22,7 @@ Object.assign( BufferGeometryLoader.prototype, {
 		var scope = this;
 
 		var loader = new FileLoader( scope.manager );
+		loader.setPath( scope.path );
 		loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( JSON.parse( text ) ) );
@@ -85,6 +86,13 @@ Object.assign( BufferGeometryLoader.prototype, {
 		}
 
 		return geometry;
+
+	},
+
+	setPath: function ( value ) {
+
+		this.path = value;
+		return this;
 
 	}
 

--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -28,7 +28,7 @@ Object.assign( DataTextureLoader.prototype, {
 
 		var loader = new FileLoader( this.manager );
 		loader.setResponseType( 'arraybuffer' );
-
+		loader.setPath( this.path );
 		loader.load( url, function ( buffer ) {
 
 			var texData = scope._parser( buffer );
@@ -86,6 +86,13 @@ Object.assign( DataTextureLoader.prototype, {
 
 
 		return texture;
+
+	},
+
+	setPath: function ( value ) {
+
+		this.path = value;
+		return this;
 
 	}
 

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -25,17 +25,12 @@ Object.assign( MaterialLoader.prototype, {
 		var scope = this;
 
 		var loader = new FileLoader( scope.manager );
+		loader.setPath( scope.path );
 		loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( JSON.parse( text ) ) );
 
 		}, onProgress, onError );
-
-	},
-
-	setTextures: function ( value ) {
-
-		this.textures = value;
 
 	},
 
@@ -218,6 +213,20 @@ Object.assign( MaterialLoader.prototype, {
 		if ( json.gradientMap !== undefined ) material.gradientMap = getTexture( json.gradientMap );
 
 		return material;
+
+	},
+
+	setPath: function ( value ) {
+
+		this.path = value;
+		return this;
+
+	},
+
+	setTextures: function ( value ) {
+
+		this.textures = value;
+		return this;
 
 	}
 


### PR DESCRIPTION
See #12942

Added missing `.setPath()` to `AnimationLoader`, `AudioLoader`, `BufferGeometryLoader`, `DataTextureLoader` and `MaterialLoader`.