### PR TITLE
remove unnecessary checks

### DIFF
--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -777,36 +777,9 @@ Object.assign( THREE.VTKLoader.prototype, THREE.EventDispatcher.prototype, {
 
 					delete ele[ '#text' ];
 
-					// Get the content and optimize it
-					if ( ele.attributes.type === 'Float32' ) {
+					if ( ele.attributes.type === 'Int64' ) {
 
 						if ( ele.attributes.format === 'binary' ) {
-
-							if ( ! compressed ) {
-
-								txt = txt.filter( function ( el, idx ) {
-
-									if ( idx !== 0 ) return true;
-
-								} );
-
-							}
-
-						}
-
-					} else if ( ele.attributes.type === 'Int64' ) {
-
-						if ( ele.attributes.format === 'binary' ) {
-
-							if ( ! compressed ) {
-
-								txt = txt.filter( function ( el, idx ) {
-
-									if ( idx !== 0 ) return true;
-
-								} );
-
-							}
 
 							txt = txt.filter( function ( el, idx ) {
 


### PR DESCRIPTION
Because [Line 693](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/VTKLoader.js#L693) checks if it is compressed, then the check on [line 785](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/VTKLoader.js#L785) and [line 801](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/VTKLoader.js#L801) are sure to be false.