### PR TITLE
Examples: Adjusted path handling in VRMLoader and LegacyGLTFLoader.

### DIFF
--- a/examples/js/loaders/VRMLoader.js
+++ b/examples/js/loaders/VRMLoader.js
@@ -54,6 +54,13 @@ THREE.VRMLoader = ( function () {
 
 		},
 
+		setResourcePath: function ( value ) {
+
+			this.glTFLoader.setResourcePath( value );
+			return this;
+
+		},
+
 		setDRACOLoader: function ( dracoLoader ) {
 
 			this.glTFLoader.setDRACOLoader( dracoLoader );

--- a/examples/js/loaders/deprecated/LegacyGLTFLoader.js
+++ b/examples/js/loaders/deprecated/LegacyGLTFLoader.js
@@ -23,15 +23,30 @@ THREE.LegacyGLTFLoader = ( function () {
 
 			var scope = this;
 
-			var path = this.path && ( typeof this.path === "string" ) ? this.path : THREE.LoaderUtils.extractUrlBase( url );
+			var resourcePath;
+
+			if ( this.resourcePath !== undefined ) {
+
+				resourcePath = this.resourcePath;
+
+			} else if ( this.path !== undefined ) {
+
+				resourcePath = this.path;
+
+			} else {
+
+				resourcePath = THREE.LoaderUtils.extractUrlBase( url );
+
+			}
 
 			var loader = new THREE.FileLoader( scope.manager );
 
+			loader.setPath( this.path );
 			loader.setResponseType( 'arraybuffer' );
 
 			loader.load( url, function ( data ) {
 
-				scope.parse( data, path, onLoad );
+				scope.parse( data, resourcePath, onLoad );
 
 			}, onProgress, onError );
 
@@ -47,6 +62,13 @@ THREE.LegacyGLTFLoader = ( function () {
 		setPath: function ( value ) {
 
 			this.path = value;
+
+		},
+
+		setResourcePath: function ( value ) {
+
+			this.resourcePath = value;
+			return this;
 
 		},
 
@@ -80,7 +102,7 @@ THREE.LegacyGLTFLoader = ( function () {
 
 				crossOrigin: this.crossOrigin,
 				manager: this.manager,
-				path: path || this.path
+				path: path || this.resourcePath || ''
 
 			} );
 


### PR DESCRIPTION
see #12942 

Added `.setResourcePath()` to `VRMLoader` and `LegacyGLTFLoader`.