### PR TITLE
Instance-ready materials

### DIFF
--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -94,6 +94,7 @@ import cube_frag from './ShaderLib/cube_frag.glsl';
 import cube_vert from './ShaderLib/cube_vert.glsl';
 import depth_frag from './ShaderLib/depth_frag.glsl';
 import depth_vert from './ShaderLib/depth_vert.glsl';
+import depthRGBA_vert from './ShaderLib/depthRGBA_vert.glsl';
 import distanceRGBA_frag from './ShaderLib/distanceRGBA_frag.glsl';
 import distanceRGBA_vert from './ShaderLib/distanceRGBA_vert.glsl';
 import equirect_frag from './ShaderLib/equirect_frag.glsl';
@@ -216,6 +217,7 @@ export var ShaderChunk = {
 	cube_vert: cube_vert,
 	depth_frag: depth_frag,
 	depth_vert: depth_vert,
+	depthRGBA_vert: depthRGBA_vert,
 	distanceRGBA_frag: distanceRGBA_frag,
 	distanceRGBA_vert: distanceRGBA_vert,
 	equirect_frag: equirect_frag,

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -163,6 +163,18 @@ var ShaderLib = {
 
 	},
 
+	depthRGBA: {
+
+		uniforms: UniformsUtils.merge( [
+			UniformsLib.common,
+			UniformsLib.displacementmap
+		] ),
+
+		vertexShader: ShaderChunk.depthRGBA_vert,
+		fragmentShader: ShaderChunk.depth_frag
+
+	},
+
 	normal: {
 
 		uniforms: UniformsUtils.merge( [

--- a/src/renderers/shaders/ShaderLib/depthRGBA_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/depthRGBA_vert.glsl
@@ -1,0 +1,33 @@
+// instanced
+#ifdef INSTANCED
+    attribute vec3 instanceOffset;
+    attribute float instanceScale;
+#endif
+#include <common>
+#include <uv_pars_vertex>
+#include <displacementmap_pars_vertex>
+#include <morphtarget_pars_vertex>
+#include <skinning_pars_vertex>
+#include <logdepthbuf_pars_vertex>
+#include <clipping_planes_pars_vertex>
+void main() {
+    #include <uv_vertex>
+    #include <skinbase_vertex>
+    #ifdef USE_DISPLACEMENTMAP
+        #include <beginnormal_vertex>
+        #include <morphnormal_vertex>
+        #include <skinnormal_vertex>
+    #endif
+    #include <begin_vertex>
+    // instanced
+    #ifdef INSTANCED
+        transformed *= instanceScale;
+        transformed = transformed + instanceOffset;
+    #endif
+    #include <morphtarget_vertex>
+    #include <skinning_vertex>
+    #include <displacementmap_vertex>
+    #include <project_vertex>
+    #include <logdepthbuf_vertex>
+    #include <clipping_planes_vertex>
+}

--- a/src/renderers/shaders/ShaderLib/meshbasic_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshbasic_vert.glsl
@@ -1,3 +1,8 @@
+#ifdef INSTANCED
+	attribute vec3 instanceOffset;
+	attribute vec3 instanceColor;
+	attribute float instanceScale;
+#endif
 #include <common>
 #include <uv_pars_vertex>
 #include <uv2_pars_vertex>
@@ -14,6 +19,13 @@ void main() {
 	#include <uv_vertex>
 	#include <uv2_vertex>
 	#include <color_vertex>
+
+	#ifdef INSTANCED
+		#ifdef USE_COLOR
+			vColor.xyz = instanceColor.xyz;
+		#endif
+	#endif
+
 	#include <skinbase_vertex>
 
 	#ifdef USE_ENVMAP
@@ -26,6 +38,12 @@ void main() {
 	#endif
 
 	#include <begin_vertex>
+
+	#ifdef INSTANCED
+		transformed *= instanceScale;
+		transformed = transformed + instanceOffset;
+	#endif
+	
 	#include <morphtarget_vertex>
 	#include <skinning_vertex>
 	#include <project_vertex>

--- a/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl
@@ -1,13 +1,13 @@
 #define LAMBERT
-
-varying vec3 vLightFront;
-
-#ifdef DOUBLE_SIDED
-
-	varying vec3 vLightBack;
-
+#ifdef INSTANCED
+	attribute vec3 instanceOffset;
+	attribute vec3 instanceColor;
+	attribute float instanceScale;
 #endif
-
+varying vec3 vLightFront;
+#ifdef DOUBLE_SIDED
+	varying vec3 vLightBack;
+#endif
 #include <common>
 #include <uv_pars_vertex>
 #include <uv2_pars_vertex>
@@ -21,30 +21,37 @@ varying vec3 vLightFront;
 #include <shadowmap_pars_vertex>
 #include <logdepthbuf_pars_vertex>
 #include <clipping_planes_pars_vertex>
-
 void main() {
-
 	#include <uv_vertex>
 	#include <uv2_vertex>
 	#include <color_vertex>
+	
+	// vertex colors instanced
+	#ifdef INSTANCED
+		#ifdef USE_COLOR
+			vColor.xyz = instanceColor.xyz;
+		#endif
+	#endif
 
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>
 	#include <skinbase_vertex>
 	#include <skinnormal_vertex>
 	#include <defaultnormal_vertex>
-
 	#include <begin_vertex>
+	// position instanced
+	#ifdef INSTANCED
+		transformed *= instanceScale;
+		transformed = transformed + instanceOffset;
+	#endif
 	#include <morphtarget_vertex>
 	#include <skinning_vertex>
 	#include <project_vertex>
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>
-
 	#include <worldpos_vertex>
 	#include <envmap_vertex>
 	#include <lights_lambert_vertex>
 	#include <shadowmap_vertex>
 	#include <fog_vertex>
-
 }

--- a/src/renderers/shaders/ShaderLib/meshphong_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphong_vert.glsl
@@ -1,5 +1,11 @@
 #define PHONG
 
+#ifdef INSTANCED
+	attribute vec3 instanceOffset;
+	attribute vec3 instanceColor;
+	attribute float instanceScale;
+#endif
+
 varying vec3 vViewPosition;
 
 #ifndef FLAT_SHADED
@@ -27,6 +33,13 @@ void main() {
 	#include <uv2_vertex>
 	#include <color_vertex>
 
+	// vertex colors instanced
+	#ifdef INSTANCED
+		#ifdef USE_COLOR
+			vColor.xyz = instanceColor.xyz;
+		#endif
+	#endif
+
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>
 	#include <skinbase_vertex>
@@ -40,6 +53,13 @@ void main() {
 #endif
 
 	#include <begin_vertex>
+
+	// position instanced
+	#ifdef INSTANCED
+		transformed *= instanceScale;
+		transformed = transformed + instanceOffset;
+	#endif
+	
 	#include <morphtarget_vertex>
 	#include <skinning_vertex>
 	#include <displacementmap_vertex>

--- a/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl
+++ b/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl
@@ -1,5 +1,11 @@
 #define PHYSICAL
 
+#ifdef INSTANCED
+	attribute vec3 instanceOffset;
+	attribute vec3 instanceColor;
+	attribute float instanceScale;
+#endif
+
 varying vec3 vViewPosition;
 
 #ifndef FLAT_SHADED
@@ -26,6 +32,13 @@ void main() {
 	#include <uv2_vertex>
 	#include <color_vertex>
 
+	// vertex colors instanced
+	#ifdef INSTANCED
+		#ifdef USE_COLOR
+			vColor.xyz = instanceColor.xyz;
+		#endif
+	#endif
+
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>
 	#include <skinbase_vertex>
@@ -39,6 +52,14 @@ void main() {
 #endif
 
 	#include <begin_vertex>
+
+	// position instanced
+	#ifdef INSTANCED
+		transformed *= instanceScale;
+		transformed = transformed + instanceOffset;
+	#endif
+
+	
 	#include <morphtarget_vertex>
 	#include <skinning_vertex>
 	#include <displacementmap_vertex>


### PR DESCRIPTION
- based on the instanced lambert example, I updated the standard three.js materials ( basic, lambert, phong, physical, standard, toon) to be instance friendly.

( https://github.com/mrdoob/three.js/blob/master/examples/webgl_buffergeometry_instancing_lambert.html )

- tested the updated shader materials with all relevant texture maps per material for both instance and single use, everything seems to check out