### PR TITLE
Fix for PCD Loader to display proper RGB values

### DIFF
--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -205,11 +205,11 @@ THREE.PCDLoader.prototype = {
 
 				if ( offset.rgb !== undefined ) {
 
-					var c = new Float32Array( [ parseFloat( line[ offset.rgb ] ) ] );
-					var dataview = new DataView( c.buffer, 0 );
-					color.push( dataview.getUint8( 0 ) / 255.0 );
-					color.push( dataview.getUint8( 1 ) / 255.0 );
-					color.push( dataview.getUint8( 2 ) / 255.0 );
+					var rgb = parseFloat( line[ offset.rgb ] );
+					var r = ( rgb >> 16 ) & 0x0000ff;
+					var g = ( rgb >> 8 ) & 0x0000ff;
+					var b = ( rgb >> 0 ) & 0x0000ff;
+					color.push( r / 255, g / 255, b / 255 );
 
 				}
 
@@ -251,9 +251,9 @@ THREE.PCDLoader.prototype = {
 
 				if ( offset.rgb !== undefined ) {
 
-					color.push( dataview.getUint8( row + offset.rgb + 0 ) / 255.0 );
-					color.push( dataview.getUint8( row + offset.rgb + 1 ) / 255.0 );
 					color.push( dataview.getUint8( row + offset.rgb + 2 ) / 255.0 );
+					color.push( dataview.getUint8( row + offset.rgb + 1 ) / 255.0 );
+					color.push( dataview.getUint8( row + offset.rgb + 0 ) / 255.0 );
 
 				}
 
@@ -285,7 +285,7 @@ THREE.PCDLoader.prototype = {
 
 		if ( color.length > 0 ) {
 
-			material.vertexColors = true;
+			material.vertexColors = THREE.VertexColors;
 
 		} else {
 


### PR DESCRIPTION
This fixes #12207 to ensure the right color values are displayed. This fixes both ascii and binary data file renderings.