### PR TITLE
Fix undefined object errors when loading assets in workers

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -14,7 +14,7 @@ var ImageUtils = {
 
 			return image.src;
 
-		} if ( image instanceof HTMLCanvasElement ) {
+		} else if ( image instanceof HTMLCanvasElement ) {
 
 			canvas = image;
 

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -10,7 +10,11 @@ var ImageUtils = {
 
 		var canvas;
 
-		if ( image instanceof HTMLCanvasElement ) {
+		if ( typeof HTMLCanvasElement == 'undefined' ) {
+
+			return image.src;
+
+		} if ( image instanceof HTMLCanvasElement ) {
 
 			canvas = image;
 

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -70,9 +70,9 @@ Object.assign( FileLoader.prototype, {
 			var isBase64 = !! dataUriRegexResult[ 2 ];
 			var data = dataUriRegexResult[ 3 ];
 
-			data = window.decodeURIComponent( data );
+			data = decodeURIComponent( data );
 
-			if ( isBase64 ) data = window.atob( data );
+			if ( isBase64 ) data = atob( data );
 
 			try {
 
@@ -126,7 +126,7 @@ Object.assign( FileLoader.prototype, {
 				}
 
 				// Wait for next browser tick like standard XMLHttpRequest event dispatching does
-				window.setTimeout( function () {
+				setTimeout( function () {
 
 					if ( onLoad ) onLoad( response );
 
@@ -137,7 +137,7 @@ Object.assign( FileLoader.prototype, {
 			} catch ( error ) {
 
 				// Wait for next browser tick like standard XMLHttpRequest event dispatching does
-				window.setTimeout( function () {
+				setTimeout( function () {
 
 					if ( onError ) onError( error );
 


### PR DESCRIPTION
Loading model assets inside of workers currently throws errors trying to access undefined objects, like ```window``` and ```HTMLCanvasElement```.  This pull request fixes those errors.