### PR TITLE
Configurable Object3D.position/scale/rotation/quaternion properties

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -54,18 +54,22 @@ function Object3D() {
 	Object.defineProperties( this, {
 		position: {
 			enumerable: true,
+			configurable: true,
 			value: position
 		},
 		rotation: {
 			enumerable: true,
+			configurable: true,
 			value: rotation
 		},
 		quaternion: {
 			enumerable: true,
+			configurable: true,
 			value: quaternion
 		},
 		scale: {
 			enumerable: true,
+			configurable: true,
 			value: scale
 		},
 		modelViewMatrix: {


### PR DESCRIPTION
Object3D's position, scale, rotation, and quaternion properties are currently set up via a call to Object.defineProperties(), which sets them up as immutable references to an instance of their underlying type.  This pull request allows the user to reconfigure those properties after the fact, if they know what they're doing.

This can be useful if you want to "bind" two objects together by pointing them at the same underlying position and/or orientation objects.