### PR TITLE
Enable setting of manual mipmaps for uncompressed cube textures

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -348,6 +348,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				setTextureParameters( _gl.TEXTURE_CUBE_MAP, texture, isPowerOfTwoImage );
 
+				var mipmaps = texture.mipmaps;
+
 				for ( var i = 0; i < 6; i ++ ) {
 
 					if ( ! isCompressed ) {
@@ -359,6 +361,18 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 						} else {
 
 							state.texImage2D( _gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glInternalFormat, glFormat, glType, cubeImage[ i ] );
+
+							var mipmap;
+
+							for ( var j = 1, jl = mipmaps.length; j < jl; j ++ ) {
+
+								mipmap = mipmaps[ j ];
+
+								state.texImage2D( _gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, j, glInternalFormat, glFormat, glType, mipmap.image[i] );
+
+							}
+
+
 
 						}
 
@@ -394,15 +408,9 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				}
 
-				if ( ! isCompressed ) {
+				textureProperties.__maxMipLevel = mipmaps.length - 1;
 
-					textureProperties.__maxMipLevel = 0;
 
-				} else {
-
-					textureProperties.__maxMipLevel = mipmaps.length - 1;
-
-				}
 
 				if ( textureNeedsGenerateMipmaps( texture, isPowerOfTwoImage ) ) {
 


### PR DESCRIPTION
For some reasons, previously setTextureCube did not allow to manually set mipmaps for non-compressed textures. With these changes, this is now possible. 

I don't have time to go through all examples to see if this change breaks something. On my examples, it works. If someone can point me to relevant examples in three.js, I can check them