### PR TITLE
Fix possible memory leak in the render list

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -17723,7 +17723,22 @@
 
 		function init() {
 
+			// make sure renderItem references to various objects are nulls, so that they do not prevent
+			// the objects being garbage collected
+
+			// null only items not used in the previous frame (those are typically only just a few)
+			for ( var i = renderItemsIndex; i < renderItems.length; i ++ ) {
+
+				var renderItem = renderItems[ i ];
+				renderItem.object = null;
+				renderItem.geometry = null;
+				renderItem.material = null;
+				renderItem.program = null;
+
+			}
+
 			renderItemsIndex = 0;
+
 
 			opaque.length = 0;
 			transparent.length = 0;


### PR DESCRIPTION
When the render list becomes shorter, the trailing items become dangling forever. As they contain references to various JS objects, this constitutes a memory leak. I have encountered this in an extreme test scenario (unique procedural content generated in each frame) where the leak was significant.

Note: as the render items contain references to `Object3D` and those contain their `parent` references (up to the scene root), and time any `Object3D` reference is leaked, the whole scene is leaked with it.

The fix nulls all references from those render list items which were not overwritten in a previous frame. In a normal use this should be very fast, only a few items are traversed.

