### PR TITLE
Add set() methods to perspective and orthographic camera.

### DIFF
--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -79,6 +79,20 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 	},
 
+	setViewFrustrum: function ( left, right, top, bottom, near, far ) {
+
+			this.left = left;
+			this.right = right;
+			this.top = top;
+			this.bottom = bottom;
+
+			this.near = ( near !== undefined ) ? near : 0.1;
+			this.far = ( far !== undefined ) ? far : 2000;
+
+			this.updateProjectionMatrix();
+
+	},
+
 	clearViewOffset: function () {
 
 		if ( this.view !== null ) {

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -79,7 +79,7 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 	},
 
-	setViewFrustrum: function ( left, right, top, bottom, near, far ) {
+	set: function ( left, right, top, bottom, near, far ) {
 
 		this.left = ( left !== undefined ) ? left : this.left;
 		this.right = ( right !== undefined ) ? right : this.right;

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -82,9 +82,9 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 	setViewFrustrum: function ( left, right, top, bottom, near, far ) {
 
 		this.left = ( left !== undefined ) ? left : this.left;
-		this.right = ( right !== undefined ) ? right: this.right;
+		this.right = ( right !== undefined ) ? right : this.right;
 		this.top = ( top !== undefined ) ? top : this.top;
-		this.bottom = ( bottom !== undefined ) ? bottom: this.bottom;
+		this.bottom = ( bottom !== undefined ) ? bottom : this.bottom;
 
 		this.near = ( near !== undefined ) ? near : this.near;
 		this.far = ( far !== undefined ) ? far : this.far;

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -81,15 +81,15 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 	setViewFrustrum: function ( left, right, top, bottom, near, far ) {
 
-			this.left = ( left !== undefined ) ? left : this.left;
-			this.right = ( right !== undefined ) ? right: this.right;
-			this.top = ( top !== undefined ) ? top : this.top;
-			this.bottom = ( bottom !== undefined ) ? bottom: this.bottom;
+		this.left = ( left !== undefined ) ? left : this.left;
+		this.right = ( right !== undefined ) ? right: this.right;
+		this.top = ( top !== undefined ) ? top : this.top;
+		this.bottom = ( bottom !== undefined ) ? bottom: this.bottom;
 
-			this.near = ( near !== undefined ) ? near : this.near;
-			this.far = ( far !== undefined ) ? far : this.far;
+		this.near = ( near !== undefined ) ? near : this.near;
+		this.far = ( far !== undefined ) ? far : this.far;
 
-			this.updateProjectionMatrix();
+		this.updateProjectionMatrix();
 
 	},
 

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -81,13 +81,13 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 	setViewFrustrum: function ( left, right, top, bottom, near, far ) {
 
-			this.left = left;
-			this.right = right;
-			this.top = top;
-			this.bottom = bottom;
+			this.left = ( left !== undefined ) ? left : this.left;
+			this.right = ( right !== undefined ) ? right: this.right;
+			this.top = ( top !== undefined ) ? top : this.top;
+			this.bottom = ( bottom !== undefined ) ? bottom: this.bottom;
 
-			this.near = ( near !== undefined ) ? near : 0.1;
-			this.far = ( far !== undefined ) ? far : 2000;
+			this.near = ( near !== undefined ) ? near : this.near;
+			this.far = ( far !== undefined ) ? far : this.far;
 
 			this.updateProjectionMatrix();
 

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -174,7 +174,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	},
 
-	setViewFrustrum: function ( fov, aspect, near, far ) {
+	set: function ( fov, aspect, near, far ) {
 
 		this.fov = ( fov !== undefined ) ? fov : this.fov;
 

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -176,12 +176,12 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	setViewFrustrum: function ( fov, aspect, near, far ) {
 
-			this.fov = ( fov !== undefined ) ? fov : 50;
+			this.fov = ( fov !== undefined ) ? fov : this.fov;
 
-			this.aspect = ( aspect !== undefined ) ? aspect : 1;
+			this.aspect = ( aspect !== undefined ) ? aspect : this.aspect;
 
-			this.near = ( near !== undefined ) ? near : 0.1;
-			this.far = ( far !== undefined ) ? far : 2000;
+			this.near = ( near !== undefined ) ? near : this.near;
+			this.far = ( far !== undefined ) ? far : this.far;
 
 			this.updateProjectionMatrix();
 

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -174,6 +174,19 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	},
 
+	setViewFrustrum: function ( fov, aspect, near, far ) {
+
+			this.fov = ( fov !== undefined ) ? fov : 50;
+
+			this.aspect = ( aspect !== undefined ) ? aspect : 1;
+
+			this.near = ( near !== undefined ) ? near : 0.1;
+			this.far = ( far !== undefined ) ? far : 2000;
+
+			this.updateProjectionMatrix();
+
+	},
+
 	clearViewOffset: function () {
 
 		if ( this.view !== null ) {

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -176,14 +176,14 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	setViewFrustrum: function ( fov, aspect, near, far ) {
 
-			this.fov = ( fov !== undefined ) ? fov : this.fov;
+		this.fov = ( fov !== undefined ) ? fov : this.fov;
 
-			this.aspect = ( aspect !== undefined ) ? aspect : this.aspect;
+		this.aspect = ( aspect !== undefined ) ? aspect : this.aspect;
 
-			this.near = ( near !== undefined ) ? near : this.near;
-			this.far = ( far !== undefined ) ? far : this.far;
+		this.near = ( near !== undefined ) ? near : this.near;
+		this.far = ( far !== undefined ) ? far : this.far;
 
-			this.updateProjectionMatrix();
+		this.updateProjectionMatrix();
 
 	},
 


### PR DESCRIPTION
Proposal to add new functions to ortho and persepctive cameras that allow easily and quickly updating camera frustums.

When creating a camera, you must specify it's [viewing frustrum](https://en.wikipedia.org/wiki/Viewing_frustum). Once you've defined this viewing viewing frustrum, there is no easy and direct way to update the viewing frustrum.

Currently, if you want to update the viewing frustrum, you must manually update each variable individually like so:

```js
camera.top    =  screenHeight;
camera.right  =  screenWidth;
camera.bottom = -screenHeight;;
camera.left   = -screenWidth;

camera.updateProjectionMatrix();
```

But this feel very verbose compared to how other objects are updated in Three.js , thus I propose a new function to improve this: `camera.setViewFrustrum()` which accepts the same arguments passed when creating a camera originally.

The above code could then be replaced with:

```js
camera.setViewFrustrum( -screenWidth, screenWidth, screenHeight, -screenHeight );
```

Thoughts? 

(I'll happily write up accompanying documentation if this proposal is considered) 