### PR TITLE
OBJLoader2 V2.5.0

### DIFF
--- a/examples/js/loaders/LoaderSupport.js
+++ b/examples/js/loaders/LoaderSupport.js
@@ -5,11 +5,7 @@
 
 'use strict';
 
-if ( THREE.LoaderSupport === undefined ) {
-
-	THREE.LoaderSupport = {};
-
-}
+if ( THREE.LoaderSupport === undefined ) { THREE.LoaderSupport = {} }
 
 /**
  * Validation functions.
@@ -42,71 +38,65 @@ THREE.LoaderSupport.Validator = {
  * Callbacks utilized by loaders and builders.
  * @class
  */
-THREE.LoaderSupport.Callbacks = (function () {
+THREE.LoaderSupport.Callbacks = function () {
+	this.onProgress = null;
+	this.onReportError = null;
+	this.onMeshAlter = null;
+	this.onLoad = null;
+	this.onLoadMaterials = null;
+};
 
-	var Validator = THREE.LoaderSupport.Validator;
+THREE.LoaderSupport.Callbacks.prototype = {
 
-	function Callbacks() {
-		this.onProgress = null;
-		this.onReportError = null;
-		this.onMeshAlter = null;
-		this.onLoad = null;
-		this.onLoadMaterials = null;
-	}
+	constructor: THREE.LoaderSupport.Callbacks,
 
 	/**
 	 * Register callback function that is invoked by internal function "announceProgress" to print feedback.
-	 * @memberOf THREE.LoaderSupport.Callbacks
 	 *
 	 * @param {callback} callbackOnProgress Callback function for described functionality
 	 */
-	Callbacks.prototype.setCallbackOnProgress = function ( callbackOnProgress ) {
-		this.onProgress = Validator.verifyInput( callbackOnProgress, this.onProgress );
-	};
+	setCallbackOnProgress: function ( callbackOnProgress ) {
+		this.onProgress = THREE.LoaderSupport.Validator.verifyInput( callbackOnProgress, this.onProgress );
+	},
 
 	/**
 	 * Register callback function that is invoked when an error is reported.
-	 * @memberOf THREE.LoaderSupport.Callbacks
 	 *
 	 * @param {callback} callbackOnReportError Callback function for described functionality
 	 */
-	Callbacks.prototype.setCallbackOnReportError = function ( callbackOnReportError ) {
-		this.onReportError = Validator.verifyInput( callbackOnReportError, this.onReportError );
-	};
+	setCallbackOnReportError: function ( callbackOnReportError ) {
+		this.onReportError = THREE.LoaderSupport.Validator.verifyInput( callbackOnReportError, this.onReportError );
+	},
 
 	/**
 	 * Register callback function that is called every time a mesh was loaded.
 	 * Use {@link THREE.LoaderSupport.LoadedMeshUserOverride} for alteration instructions (geometry, material or disregard mesh).
-	 * @memberOf THREE.LoaderSupport.Callbacks
 	 *
 	 * @param {callback} callbackOnMeshAlter Callback function for described functionality
 	 */
-	Callbacks.prototype.setCallbackOnMeshAlter = function ( callbackOnMeshAlter ) {
-		this.onMeshAlter = Validator.verifyInput( callbackOnMeshAlter, this.onMeshAlter );
-	};
+	setCallbackOnMeshAlter: function ( callbackOnMeshAlter ) {
+		this.onMeshAlter = THREE.LoaderSupport.Validator.verifyInput( callbackOnMeshAlter, this.onMeshAlter );
+	},
 
 	/**
 	 * Register callback function that is called once loading of the complete OBJ file is completed.
-	 * @memberOf THREE.LoaderSupport.Callbacks
 	 *
 	 * @param {callback} callbackOnLoad Callback function for described functionality
 	 */
-	Callbacks.prototype.setCallbackOnLoad = function ( callbackOnLoad ) {
-		this.onLoad = Validator.verifyInput( callbackOnLoad, this.onLoad );
-	};
+	setCallbackOnLoad: function ( callbackOnLoad ) {
+		this.onLoad = THREE.LoaderSupport.Validator.verifyInput( callbackOnLoad, this.onLoad );
+	},
 
 	/**
 	 * Register callback function that is called when materials have been loaded.
-	 * @memberOf THREE.LoaderSupport.Callbacks
 	 *
 	 * @param {callback} callbackOnLoadMaterials Callback function for described functionality
 	 */
-	Callbacks.prototype.setCallbackOnLoadMaterials = function ( callbackOnLoadMaterials ) {
-		this.onLoadMaterials = Validator.verifyInput( callbackOnLoadMaterials, this.onLoadMaterials );
-	};
+	setCallbackOnLoadMaterials: function ( callbackOnLoadMaterials ) {
+		this.onLoadMaterials = THREE.LoaderSupport.Validator.verifyInput( callbackOnLoadMaterials, this.onLoadMaterials );
+	}
 
-	return Callbacks;
-})();
+};
 
 
 /**
@@ -116,46 +106,45 @@ THREE.LoaderSupport.Callbacks = (function () {
  * @param {boolean} disregardMesh=false Tell implementation to completely disregard this mesh
  * @param {boolean} disregardMesh=false Tell implementation that mesh(es) have been altered or added
  */
-THREE.LoaderSupport.LoadedMeshUserOverride = (function () {
+THREE.LoaderSupport.LoadedMeshUserOverride = function( disregardMesh, alteredMesh ) {
+	this.disregardMesh = disregardMesh === true;
+	this.alteredMesh = alteredMesh === true;
+	this.meshes = [];
+};
 
-	function LoadedMeshUserOverride( disregardMesh, alteredMesh ) {
-		this.disregardMesh = disregardMesh === true;
-		this.alteredMesh = alteredMesh === true;
-		this.meshes = [];
-	}
+THREE.LoaderSupport.LoadedMeshUserOverride.prototype = {
+
+	constructor: THREE.LoaderSupport.LoadedMeshUserOverride,
 
 	/**
 	 * Add a mesh created within callback.
 	 *
-	 * @memberOf THREE.OBJLoader2.LoadedMeshUserOverride
-	 *
 	 * @param {THREE.Mesh} mesh
 	 */
-	LoadedMeshUserOverride.prototype.addMesh = function ( mesh ) {
+	addMesh: function ( mesh ) {
 		this.meshes.push( mesh );
 		this.alteredMesh = true;
-	};
+	},
 
 	/**
 	 * Answers if mesh shall be disregarded completely.
 	 *
 	 * @returns {boolean}
 	 */
-	LoadedMeshUserOverride.prototype.isDisregardMesh = function () {
+	isDisregardMesh: function () {
 		return this.disregardMesh;
-	};
+	},
 
 	/**
 	 * Answers if new mesh(es) were created.
 	 *
 	 * @returns {boolean}
 	 */
-	LoadedMeshUserOverride.prototype.providesAlteredMeshes = function () {
+	providesAlteredMeshes: function () {
 		return this.alteredMesh;
-	};
+	}
 
-	return LoadedMeshUserOverride;
-})();
+};
 
 
 /**
@@ -165,103 +154,102 @@ THREE.LoaderSupport.LoadedMeshUserOverride = (function () {
  * @param {string} url URL to the file
  * @param {string} extension The file extension (type)
  */
-THREE.LoaderSupport.ResourceDescriptor = (function () {
+THREE.LoaderSupport.ResourceDescriptor = function ( url, extension ) {
+	var urlParts = url.split( '/' );
 
-	var Validator = THREE.LoaderSupport.Validator;
+	this.path;
+	this.resourcePath;
+	this.name = url;
+	this.url = url;
+	if ( urlParts.length >= 2 ) {
 
-	function ResourceDescriptor( url, extension ) {
-		var urlParts = url.split( '/' );
+		this.path = THREE.LoaderSupport.Validator.verifyInput( urlParts.slice( 0, urlParts.length - 1).join( '/' ) + '/', this.path );
+		this.name = urlParts[ urlParts.length - 1 ];
+		this.url = url;
 
-		if ( urlParts.length < 2 ) {
-
-			this.path = null;
-			this.name = url;
-			this.url = url;
-
-		} else {
-
-			this.path = Validator.verifyInput( urlParts.slice( 0, urlParts.length - 1).join( '/' ) + '/', null );
-			this.name = urlParts[ urlParts.length - 1 ];
-			this.url = url;
-
-		}
-		this.name = Validator.verifyInput( this.name, 'Unnamed_Resource' );
-		this.extension = Validator.verifyInput( extension, 'default' );
-		this.extension = this.extension.trim();
-		this.content = null;
 	}
+	this.name = THREE.LoaderSupport.Validator.verifyInput( this.name, 'Unnamed_Resource' );
+	this.extension = THREE.LoaderSupport.Validator.verifyInput( extension, 'default' );
+	this.extension = this.extension.trim();
+	this.content = null;
+};
+
+THREE.LoaderSupport.ResourceDescriptor.prototype = {
+
+	constructor: THREE.LoaderSupport.ResourceDescriptor,
 
 	/**
 	 * Set the content of this resource
-	 * @memberOf THREE.LoaderSupport.ResourceDescriptor
 	 *
 	 * @param {Object} content The file content as arraybuffer or text
 	 */
-	ResourceDescriptor.prototype.setContent = function ( content ) {
-		this.content = Validator.verifyInput( content, null );
-	};
+	setContent: function ( content ) {
+		this.content = THREE.LoaderSupport.Validator.verifyInput( content, null );
+	},
 
-	return ResourceDescriptor;
-})();
+	/**
+	 * Allow to specify resourcePath for dependencies of specified resource.
+	 * @param {string} resourcePath
+	 */
+	setResourcePath: function ( resourcePath ) {
+		this.resourcePath = THREE.LoaderSupport.Validator.verifyInput( resourcePath, this.resourcePath );
+	}
+};
 
 
 /**
  * Configuration instructions to be used by run method.
  * @class
  */
-THREE.LoaderSupport.PrepData = (function () {
+THREE.LoaderSupport.PrepData = function ( modelName ) {
+	this.logging = {
+		enabled: true,
+		debug: false
+	};
+	this.modelName = THREE.LoaderSupport.Validator.verifyInput( modelName, '' );
+	this.resources = [];
+	this.callbacks = new THREE.LoaderSupport.Callbacks();
+};
 
-	var Validator = THREE.LoaderSupport.Validator;
+THREE.LoaderSupport.PrepData.prototype = {
 
-	function PrepData( modelName ) {
-		this.logging = {
-			enabled: true,
-			debug: false
-		};
-		this.modelName = Validator.verifyInput( modelName, '' );
-		this.resources = [];
-		this.callbacks = new THREE.LoaderSupport.Callbacks();
-	}
+	constructor: THREE.LoaderSupport.PrepData,
 
 	/**
 	 * Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-	 * @memberOf THREE.LoaderSupport.PrepData
 	 *
 	 * @param {boolean} enabled True or false.
 	 * @param {boolean} debug True or false.
 	 */
-	PrepData.prototype.setLogging = function ( enabled, debug ) {
+	setLogging: function ( enabled, debug ) {
 		this.logging.enabled = enabled === true;
 		this.logging.debug = debug === true;
-	};
+	},
 
 	/**
 	 * Returns all callbacks as {@link THREE.LoaderSupport.Callbacks}
-	 * @memberOf THREE.LoaderSupport.PrepData
 	 *
 	 * @returns {THREE.LoaderSupport.Callbacks}
 	 */
-	PrepData.prototype.getCallbacks = function () {
+	getCallbacks: function () {
 		return this.callbacks;
-	};
+	},
 
 	/**
 	 * Add a resource description.
-	 * @memberOf THREE.LoaderSupport.PrepData
 	 *
 	 * @param {THREE.LoaderSupport.ResourceDescriptor} Adds a {@link THREE.LoaderSupport.ResourceDescriptor}
 	 */
-	PrepData.prototype.addResource = function ( resource ) {
+	addResource: function ( resource ) {
 		this.resources.push( resource );
-	};
+	},
 
 	/**
 	 * Clones this object and returns it afterwards. Callbacks and resources are not cloned deep (references!).
-	 * @memberOf THREE.LoaderSupport.PrepData
 	 *
 	 * @returns {@link THREE.LoaderSupport.PrepData}
 	 */
-	PrepData.prototype.clone = function () {
+	clone: function () {
 		var clone = new THREE.LoaderSupport.PrepData( this.modelName );
 		clone.logging.enabled = this.logging.enabled;
 		clone.logging.debug = this.logging.debug;
@@ -280,18 +268,16 @@ THREE.LoaderSupport.PrepData = (function () {
 		}
 
 		return clone;
-	};
-
+	},
 
 	/**
 	 * Identify files or content of interest from an Array of {@link THREE.LoaderSupport.ResourceDescriptor}.
-	 * @memberOf THREE.LoaderSupport.PrepData
 	 *
 	 * @param {THREE.LoaderSupport.ResourceDescriptor[]} resources Array of {@link THREE.LoaderSupport.ResourceDescriptor}
 	 * @param Object fileDesc Object describing which resources are of interest (ext, type (string or UInt8Array) and ignore (boolean))
 	 * @returns {{}} Object with each "ext" and the corresponding {@link THREE.LoaderSupport.ResourceDescriptor}
 	 */
-	PrepData.prototype.checkResourceDescriptorFiles = function ( resources, fileDesc ) {
+	checkResourceDescriptorFiles: function ( resources, fileDesc ) {
 		var resource, triple, i, found;
 		var result = {};
 
@@ -299,8 +285,8 @@ THREE.LoaderSupport.PrepData = (function () {
 
 			resource = resources[ index ];
 			found = false;
-			if ( ! Validator.isValid( resource.name ) ) continue;
-			if ( Validator.isValid( resource.content ) ) {
+			if ( ! THREE.LoaderSupport.Validator.isValid( resource.name ) ) continue;
+			if ( THREE.LoaderSupport.Validator.isValid( resource.content ) ) {
 
 				for ( i = 0; i < fileDesc.length && !found; i++ ) {
 
@@ -352,51 +338,48 @@ THREE.LoaderSupport.PrepData = (function () {
 		}
 
 		return result;
-	};
-
-	return PrepData;
-})();
+	}
+};
 
 /**
  * Builds one or many THREE.Mesh from one raw set of Arraybuffers, materialGroup descriptions and further parameters.
  * Supports vertex, vertexColor, normal, uv and index buffers.
  * @class
  */
-THREE.LoaderSupport.MeshBuilder = (function () {
+THREE.LoaderSupport.MeshBuilder = function() {
+	console.info( 'Using THREE.LoaderSupport.MeshBuilder version: ' + THREE.LoaderSupport.MeshBuilder.LOADER_MESH_BUILDER_VERSION );
+	this.validator = THREE.LoaderSupport.Validator;
 
-	var LOADER_MESH_BUILDER_VERSION = '1.2.2';
+	this.logging = {
+		enabled: true,
+		debug: false
+	};
 
-	var Validator = THREE.LoaderSupport.Validator;
+	this.callbacks = new THREE.LoaderSupport.Callbacks();
+	this.materials = [];
+};
+THREE.LoaderSupport.MeshBuilder.LOADER_MESH_BUILDER_VERSION = '1.3.0';
 
-	function MeshBuilder() {
-		console.info( 'Using THREE.LoaderSupport.MeshBuilder version: ' + LOADER_MESH_BUILDER_VERSION );
-		this.logging = {
-			enabled: true,
-			debug: false
-		};
+THREE.LoaderSupport.MeshBuilder.prototype = {
 
-		this.callbacks = new THREE.LoaderSupport.Callbacks();
-		this.materials = [];
-	}
+	constructor: THREE.LoaderSupport.MeshBuilder,
 
 	/**
 	 * Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-	 * @memberOf THREE.LoaderSupport.MeshBuilder
 	 *
 	 * @param {boolean} enabled True or false.
 	 * @param {boolean} debug True or false.
 	 */
-	MeshBuilder.prototype.setLogging = function ( enabled, debug ) {
+	setLogging: function ( enabled, debug ) {
 		this.logging.enabled = enabled === true;
 		this.logging.debug = debug === true;
-	};
+	},
 
 	/**
 	 * Initializes the MeshBuilder (currently only default material initialisation).
-	 * @memberOf THREE.LoaderSupport.MeshBuilder
 	 *
 	 */
-	MeshBuilder.prototype.init = function () {
+	init: function () {
 		var defaultMaterial = new THREE.MeshStandardMaterial( { color: 0xDCF1FF } );
 		defaultMaterial.name = 'defaultMaterial';
 
@@ -426,42 +409,40 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 				}
 			}
 		);
-	};
+	},
 
 	/**
 	 * Set materials loaded by any supplier of an Array of {@link THREE.Material}.
-	 * @memberOf THREE.LoaderSupport.MeshBuilder
 	 *
 	 * @param {THREE.Material[]} materials Array of {@link THREE.Material}
 	 */
-	MeshBuilder.prototype.setMaterials = function ( materials ) {
+	setMaterials: function ( materials ) {
 		var payload = {
 			cmd: 'materialData',
 			materials: {
 				materialCloneInstructions: null,
 				serializedMaterials: null,
-				runtimeMaterials: Validator.isValid( this.callbacks.onLoadMaterials ) ? this.callbacks.onLoadMaterials( materials ) : materials
+				runtimeMaterials: this.validator.isValid( this.callbacks.onLoadMaterials ) ? this.callbacks.onLoadMaterials( materials ) : materials
 			}
 		};
 		this.updateMaterials( payload );
-	};
+	},
 
-	MeshBuilder.prototype._setCallbacks = function ( callbacks ) {
-		if ( Validator.isValid( callbacks.onProgress ) ) this.callbacks.setCallbackOnProgress( callbacks.onProgress );
-		if ( Validator.isValid( callbacks.onReportError ) ) this.callbacks.setCallbackOnReportError( callbacks.onReportError );
-		if ( Validator.isValid( callbacks.onMeshAlter ) ) this.callbacks.setCallbackOnMeshAlter( callbacks.onMeshAlter );
-		if ( Validator.isValid( callbacks.onLoad ) ) this.callbacks.setCallbackOnLoad( callbacks.onLoad );
-		if ( Validator.isValid( callbacks.onLoadMaterials ) ) this.callbacks.setCallbackOnLoadMaterials( callbacks.onLoadMaterials );
-	};
+	_setCallbacks: function ( callbacks ) {
+		if ( this.validator.isValid( callbacks.onProgress ) ) this.callbacks.setCallbackOnProgress( callbacks.onProgress );
+		if ( this.validator.isValid( callbacks.onReportError ) ) this.callbacks.setCallbackOnReportError( callbacks.onReportError );
+		if ( this.validator.isValid( callbacks.onMeshAlter ) ) this.callbacks.setCallbackOnMeshAlter( callbacks.onMeshAlter );
+		if ( this.validator.isValid( callbacks.onLoad ) ) this.callbacks.setCallbackOnLoad( callbacks.onLoad );
+		if ( this.validator.isValid( callbacks.onLoadMaterials ) ) this.callbacks.setCallbackOnLoadMaterials( callbacks.onLoadMaterials );
+	},
 
 	/**
 	 * Delegates processing of the payload (mesh building or material update) to the corresponding functions (BW-compatibility).
-	 * @memberOf THREE.LoaderSupport.MeshBuilder
 	 *
 	 * @param {Object} payload Raw Mesh or Material descriptions.
 	 * @returns {THREE.Mesh[]} mesh Array of {@link THREE.Mesh} or null in case of material update
 	 */
-	MeshBuilder.prototype.processPayload = function ( payload ) {
+	processPayload: function ( payload ) {
 		if ( payload.cmd === 'meshData' ) {
 
 			return this.buildMeshes( payload );
@@ -472,32 +453,31 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 			return null;
 
 		}
-	};
+	},
 
 	/**
 	 * Builds one or multiple meshes from the data described in the payload (buffers, params, material info).
-	 * @memberOf THREE.LoaderSupport.MeshBuilder
 	 *
 	 * @param {Object} meshPayload Raw mesh description (buffers, params, materials) used to build one to many meshes.
 	 * @returns {THREE.Mesh[]} mesh Array of {@link THREE.Mesh}
 	 */
-	MeshBuilder.prototype.buildMeshes = function ( meshPayload ) {
+	buildMeshes: function ( meshPayload ) {
 		var meshName = meshPayload.params.meshName;
 
 		var bufferGeometry = new THREE.BufferGeometry();
 		bufferGeometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( meshPayload.buffers.vertices ), 3 ) );
-		if ( Validator.isValid( meshPayload.buffers.indices ) ) {
+		if ( this.validator.isValid( meshPayload.buffers.indices ) ) {
 
 			bufferGeometry.setIndex( new THREE.BufferAttribute( new Uint32Array( meshPayload.buffers.indices ), 1 ));
 
 		}
-		var haveVertexColors = Validator.isValid( meshPayload.buffers.colors );
+		var haveVertexColors = this.validator.isValid( meshPayload.buffers.colors );
 		if ( haveVertexColors ) {
 
 			bufferGeometry.addAttribute( 'color', new THREE.BufferAttribute( new Float32Array( meshPayload.buffers.colors ), 3 ) );
 
 		}
-		if ( Validator.isValid( meshPayload.buffers.normals ) ) {
+		if ( this.validator.isValid( meshPayload.buffers.normals ) ) {
 
 			bufferGeometry.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( meshPayload.buffers.normals ), 3 ) );
 
@@ -506,7 +486,7 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 			bufferGeometry.computeVertexNormals();
 
 		}
-		if ( Validator.isValid( meshPayload.buffers.uvs ) ) {
+		if ( this.validator.isValid( meshPayload.buffers.uvs ) ) {
 
 			bufferGeometry.addAttribute( 'uv', new THREE.BufferAttribute( new Float32Array( meshPayload.buffers.uvs ), 2 ) );
 
@@ -542,8 +522,8 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 		var callbackOnMeshAlter = this.callbacks.onMeshAlter;
 		var callbackOnMeshAlterResult;
 		var useOrgMesh = true;
-		var geometryType = Validator.verifyInput( meshPayload.geometryType, 0 );
-		if ( Validator.isValid( callbackOnMeshAlter ) ) {
+		var geometryType = this.validator.verifyInput( meshPayload.geometryType, 0 );
+		if ( this.validator.isValid( callbackOnMeshAlter ) ) {
 
 			callbackOnMeshAlterResult = callbackOnMeshAlter(
 				{
@@ -555,7 +535,7 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 					}
 				}
 			);
-			if ( Validator.isValid( callbackOnMeshAlterResult ) ) {
+			if ( this.validator.isValid( callbackOnMeshAlterResult ) ) {
 
 				if ( callbackOnMeshAlterResult.isDisregardMesh() ) {
 
@@ -597,7 +577,7 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 		}
 
 		var progressMessage;
-		if ( Validator.isValid( meshes ) && meshes.length > 0 ) {
+		if ( this.validator.isValid( meshes ) && meshes.length > 0 ) {
 
 			var meshNames = [];
 			for ( var i in meshes ) {
@@ -616,7 +596,7 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 
 		}
 		var callbackOnProgress = this.callbacks.onProgress;
-		if ( Validator.isValid( callbackOnProgress ) ) {
+		if ( this.validator.isValid( callbackOnProgress ) ) {
 
 			var event = new CustomEvent( 'MeshBuilderEvent', {
 				detail: {
@@ -631,23 +611,22 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 		}
 
 		return meshes;
-	};
+	},
 
 	/**
 	 * Updates the materials with contained material objects (sync) or from alteration instructions (async).
-	 * @memberOf THREE.LoaderSupport.MeshBuilder
 	 *
 	 * @param {Object} materialPayload Material update instructions
 	 */
-	MeshBuilder.prototype.updateMaterials = function ( materialPayload ) {
+	updateMaterials: function ( materialPayload ) {
 		var material, materialName;
 		var materialCloneInstructions = materialPayload.materials.materialCloneInstructions;
-		if ( Validator.isValid( materialCloneInstructions ) ) {
+		if ( this.validator.isValid( materialCloneInstructions ) ) {
 
 			var materialNameOrg = materialCloneInstructions.materialNameOrg;
 			var materialOrg = this.materials[ materialNameOrg ];
 
-			if ( Validator.isValid( materialNameOrg ) ) {
+			if ( this.validator.isValid( materialNameOrg ) ) {
 
 				material = materialOrg.clone();
 
@@ -670,14 +649,14 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 		}
 
 		var materials = materialPayload.materials.serializedMaterials;
-		if ( Validator.isValid( materials ) && Object.keys( materials ).length > 0 ) {
+		if ( this.validator.isValid( materials ) && Object.keys( materials ).length > 0 ) {
 
 			var loader = new THREE.MaterialLoader();
 			var materialJson;
 			for ( materialName in materials ) {
 
 				materialJson = materials[ materialName ];
-				if ( Validator.isValid( materialJson ) ) {
+				if ( this.validator.isValid( materialJson ) ) {
 
 					material = loader.parse( materialJson );
 					if ( this.logging.enabled ) console.info( 'De-serialized material with name "' + materialName + '" will be added.' );
@@ -689,7 +668,7 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 		}
 
 		materials = materialPayload.materials.runtimeMaterials;
-		if ( Validator.isValid( materials ) && Object.keys( materials ).length > 0 ) {
+		if ( this.validator.isValid( materials ) && Object.keys( materials ).length > 0 ) {
 
 			for ( materialName in materials ) {
 
@@ -700,14 +679,14 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 			}
 
 		}
-	};
+	},
 
 	/**
 	 * Returns the mapping object of material name and corresponding jsonified material.
 	 *
 	 * @returns {Object} Map of Materials in JSON representation
 	 */
-	MeshBuilder.prototype.getMaterialsJSON = function () {
+	getMaterialsJSON: function () {
 		var materialsJSON = {};
 		var material;
 		for ( var materialName in this.materials ) {
@@ -717,43 +696,568 @@ THREE.LoaderSupport.MeshBuilder = (function () {
 		}
 
 		return materialsJSON;
-	};
+	},
 
 	/**
 	 * Returns the mapping object of material name and corresponding material.
 	 *
 	 * @returns {Object} Map of {@link THREE.Material}
 	 */
-	MeshBuilder.prototype.getMaterials = function () {
+	getMaterials: function () {
 		return this.materials;
+	}
+
+};
+
+/**
+ * This class provides means to transform existing parser code into a web worker. It defines a simple communication protocol
+ * which allows to configure the worker and receive raw mesh data during execution.
+ * @class
+ */
+THREE.LoaderSupport.WorkerSupport = function () {
+	console.info( 'Using THREE.LoaderSupport.WorkerSupport version: ' + THREE.LoaderSupport.WorkerSupport.WORKER_SUPPORT_VERSION );
+	this.logging = {
+		enabled: true,
+		debug: false
 	};
 
-	return MeshBuilder;
-})();
+	//Choose implementation of worker based on environment
+	this.loaderWorker = typeof window !== "undefined" ? new THREE.LoaderSupport.WorkerSupport.LoaderWorker() : new THREE.LoaderSupport.WorkerSupport.NodeLoaderWorker();
+};
+
+THREE.LoaderSupport.WorkerSupport.WORKER_SUPPORT_VERSION = '2.3.0';
+
+THREE.LoaderSupport.WorkerSupport.prototype = {
+
+	constructor: THREE.LoaderSupport.WorkerSupport,
+
+	/**
+	 * Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
+	 *
+	 * @param {boolean} enabled True or false.
+	 * @param {boolean} debug True or false.
+	 */
+	setLogging: function ( enabled, debug ) {
+		this.logging.enabled = enabled === true;
+		this.logging.debug = debug === true;
+		this.loaderWorker.setLogging( this.logging.enabled, this.logging.debug );
+	},
+
+	/**
+	 * Forces all ArrayBuffers to be transferred to worker to be copied.
+	 *
+	 * @param {boolean} forceWorkerDataCopy True or false.
+	 */
+	setForceWorkerDataCopy: function ( forceWorkerDataCopy ) {
+		this.loaderWorker.setForceCopy( forceWorkerDataCopy );
+	},
+
+	/**
+	 * Validate the status of worker code and the derived worker.
+	 *
+	 * @param {Function} functionCodeBuilder Function that is invoked with funcBuildObject and funcBuildSingleton that allows stringification of objects and singletons.
+	 * @param {String} parserName Name of the Parser object
+	 * @param {String[]} libLocations URL of libraries that shall be added to worker code relative to libPath
+	 * @param {String} libPath Base path used for loading libraries
+	 * @param {THREE.LoaderSupport.WorkerRunnerRefImpl} runnerImpl The default worker parser wrapper implementation (communication and execution). An extended class could be passed here.
+	 */
+	validate: function ( functionCodeBuilder, parserName, libLocations, libPath, runnerImpl ) {
+		if ( THREE.LoaderSupport.Validator.isValid( this.loaderWorker.worker ) ) return;
+
+		if ( this.logging.enabled ) {
+
+			console.info( 'WorkerSupport: Building worker code...' );
+			console.time( 'buildWebWorkerCode' );
+
+		}
+		if ( THREE.LoaderSupport.Validator.isValid( runnerImpl ) ) {
+
+			if ( this.logging.enabled ) console.info( 'WorkerSupport: Using "' + runnerImpl.runnerName + '" as Runner class for worker.' );
+
+		// Browser implementation
+		} else if ( typeof window !== "undefined" ) {
+
+			runnerImpl = THREE.LoaderSupport.WorkerRunnerRefImpl;
+			if ( this.logging.enabled ) console.info( 'WorkerSupport: Using DEFAULT "THREE.LoaderSupport.WorkerRunnerRefImpl" as Runner class for worker.' );
+
+		// NodeJS implementation
+		} else {
+
+			runnerImpl = THREE.LoaderSupport.NodeWorkerRunnerRefImpl;
+			if ( this.logging.enabled ) console.info( 'WorkerSupport: Using DEFAULT "THREE.LoaderSupport.NodeWorkerRunnerRefImpl" as Runner class for worker.' );
+
+		}
+		var userWorkerCode = functionCodeBuilder( THREE.LoaderSupport.WorkerSupport.CodeSerializer );
+		userWorkerCode += 'var Parser = '+ parserName +  ';\n\n';
+		userWorkerCode += THREE.LoaderSupport.WorkerSupport.CodeSerializer.serializeClass( runnerImpl.runnerName, runnerImpl );
+		userWorkerCode += 'new ' + runnerImpl.runnerName + '();\n\n';
+
+		var scope = this;
+		if ( THREE.LoaderSupport.Validator.isValid( libLocations ) && libLocations.length > 0 ) {
+
+			var libsContent = '';
+			var loadAllLibraries = function ( path, locations ) {
+				if ( locations.length === 0 ) {
+
+					scope.loaderWorker.initWorker( libsContent + userWorkerCode, runnerImpl.runnerName );
+					if ( scope.logging.enabled ) console.timeEnd( 'buildWebWorkerCode' );
+
+				} else {
+
+					var loadedLib = function ( contentAsString ) {
+						libsContent += contentAsString;
+						loadAllLibraries( path, locations );
+					};
+
+					var fileLoader = new THREE.FileLoader();
+					fileLoader.setPath( path );
+					fileLoader.setResponseType( 'text' );
+					fileLoader.load( locations[ 0 ], loadedLib );
+					locations.shift();
+
+				}
+			};
+			loadAllLibraries( libPath, libLocations );
+
+		} else {
+
+			this.loaderWorker.initWorker( userWorkerCode, runnerImpl.runnerName );
+			if ( this.logging.enabled ) console.timeEnd( 'buildWebWorkerCode' );
+
+		}
+	},
+
+	/**
+	 * Specify functions that should be build when new raw mesh data becomes available and when the parser is finished.
+	 *
+	 * @param {Function} meshBuilder The mesh builder function. Default is {@link THREE.LoaderSupport.MeshBuilder}.
+	 * @param {Function} onLoad The function that is called when parsing is complete.
+	 */
+	setCallbacks: function ( meshBuilder, onLoad ) {
+		this.loaderWorker.setCallbacks( meshBuilder, onLoad );
+	},
+
+	/**
+	 * Runs the parser with the provided configuration.
+	 *
+	 * @param {Object} payload Raw mesh description (buffers, params, materials) used to build one to many meshes.
+	 */
+	run: function ( payload ) {
+		this.loaderWorker.run( payload );
+	},
+
+	/**
+	 * Request termination of worker once parser is finished.
+	 *
+	 * @param {boolean} terminateRequested True or false.
+	 */
+	setTerminateRequested: function ( terminateRequested ) {
+		this.loaderWorker.setTerminateRequested( terminateRequested );
+	}
+
+};
+
+
+THREE.LoaderSupport.WorkerSupport.LoaderWorker = function () {
+	this._reset();
+};
+
+THREE.LoaderSupport.WorkerSupport.LoaderWorker.prototype = {
+
+	constructor: THREE.LoaderSupport.WorkerSupport.LoaderWorker,
+
+	_reset: function () {
+		this.logging = {
+			enabled: true,
+			debug: false
+		};
+		this.worker = null;
+		this.runnerImplName = null;
+		this.callbacks = {
+			meshBuilder: null,
+			onLoad: null
+		};
+		this.terminateRequested = false;
+		this.queuedMessage = null;
+		this.started = false;
+		this.forceCopy = false;
+	},
+
+	/**
+	 * Check support for Workers and other necessary features returning
+	 * reason if the environment is unsupported
+	 *
+	 * @returns {string|undefined} Returns undefined if supported, or
+	 * string with error if not supported
+	 */
+	checkSupport: function() {
+		if ( window.Worker === undefined ) return "This browser does not support web workers!";
+		if ( window.Blob === undefined  ) return "This browser does not support Blob!";
+		if ( typeof window.URL.createObjectURL !== 'function'  ) return "This browser does not support Object creation from URL!";
+	},
+
+	setLogging: function ( enabled, debug ) {
+		this.logging.enabled = enabled === true;
+		this.logging.debug = debug === true;
+	},
+
+	setForceCopy: function ( forceCopy ) {
+		this.forceCopy = forceCopy === true;
+	},
+
+	initWorker: function ( code, runnerImplName ) {
+		var supportError = this.checkSupport();
+		if ( supportError ) {
+
+			throw supportError;
+
+		}
+		this.runnerImplName = runnerImplName;
+
+		var blob = new Blob( [ code ], { type: 'application/javascript' } );
+		this.worker = new Worker( window.URL.createObjectURL( blob ) );
+
+		this.worker.onmessage = this._receiveWorkerMessage;
+
+		// set referemce to this, then processing in worker scope within "_receiveWorkerMessage" can access members
+		this.worker.runtimeRef = this;
+
+		// process stored queuedMessage
+		this._postMessage();
+	},
+
+	/**
+	 * Executed in worker scope
+	 */
+	_receiveWorkerMessage: function ( e ) {
+		var payload = e.data;
+		switch ( payload.cmd ) {
+			case 'meshData':
+			case 'materialData':
+			case 'imageData':
+				this.runtimeRef.callbacks.meshBuilder( payload );
+				break;
+
+			case 'complete':
+				this.runtimeRef.queuedMessage = null;
+				this.started = false;
+				this.runtimeRef.callbacks.onLoad( payload.msg );
+
+				if ( this.runtimeRef.terminateRequested ) {
+
+					if ( this.runtimeRef.logging.enabled ) console.info( 'WorkerSupport [' + this.runtimeRef.runnerImplName + ']: Run is complete. Terminating application on request!' );
+					this.runtimeRef._terminate();
+
+				}
+				break;
+
+			case 'error':
+				console.error( 'WorkerSupport [' + this.runtimeRef.runnerImplName + ']: Reported error: ' + payload.msg );
+				this.runtimeRef.queuedMessage = null;
+				this.started = false;
+				this.runtimeRef.callbacks.onLoad( payload.msg );
+
+				if ( this.runtimeRef.terminateRequested ) {
+
+					if ( this.runtimeRef.logging.enabled ) console.info( 'WorkerSupport [' + this.runtimeRef.runnerImplName + ']: Run reported error. Terminating application on request!' );
+					this.runtimeRef._terminate();
+
+				}
+				break;
+
+			default:
+				console.error( 'WorkerSupport [' + this.runtimeRef.runnerImplName + ']: Received unknown command: ' + payload.cmd );
+				break;
+
+		}
+	},
+
+	setCallbacks: function ( meshBuilder, onLoad ) {
+		this.callbacks.meshBuilder = THREE.LoaderSupport.Validator.verifyInput( meshBuilder, this.callbacks.meshBuilder );
+		this.callbacks.onLoad = THREE.LoaderSupport.Validator.verifyInput( onLoad, this.callbacks.onLoad );
+	},
+
+	run: function( payload ) {
+		if ( THREE.LoaderSupport.Validator.isValid( this.queuedMessage ) ) {
+
+			console.warn( 'Already processing message. Rejecting new run instruction' );
+			return;
+
+		} else {
+
+			this.queuedMessage = payload;
+			this.started = true;
+
+		}
+		if ( ! THREE.LoaderSupport.Validator.isValid( this.callbacks.meshBuilder ) ) throw 'Unable to run as no "MeshBuilder" callback is set.';
+		if ( ! THREE.LoaderSupport.Validator.isValid( this.callbacks.onLoad ) ) throw 'Unable to run as no "onLoad" callback is set.';
+		if ( payload.cmd !== 'run' ) payload.cmd = 'run';
+		if ( THREE.LoaderSupport.Validator.isValid( payload.logging ) ) {
+
+			payload.logging.enabled = payload.logging.enabled === true;
+			payload.logging.debug = payload.logging.debug === true;
+
+		} else {
+
+			payload.logging = {
+				enabled: true,
+				debug: false
+			}
+
+		}
+		this._postMessage();
+	},
+
+	_postMessage: function () {
+		if ( THREE.LoaderSupport.Validator.isValid( this.queuedMessage ) && THREE.LoaderSupport.Validator.isValid( this.worker ) ) {
+
+			if ( this.queuedMessage.data.input instanceof ArrayBuffer ) {
+
+				var content;
+				if ( this.forceCopy ) {
+
+					content = this.queuedMessage.data.input.slice( 0 );
+
+				} else {
+
+					content = this.queuedMessage.data.input;
+
+				}
+				this.worker.postMessage( this.queuedMessage, [ content ] );
+
+			} else {
+
+				this.worker.postMessage( this.queuedMessage );
+
+			}
+
+		}
+	},
+
+	setTerminateRequested: function ( terminateRequested ) {
+		this.terminateRequested = terminateRequested === true;
+		if ( this.terminateRequested && THREE.LoaderSupport.Validator.isValid( this.worker ) && ! THREE.LoaderSupport.Validator.isValid( this.queuedMessage ) && this.started ) {
+
+			if ( this.logging.enabled ) console.info( 'Worker is terminated immediately as it is not running!' );
+			this._terminate();
+
+		}
+	},
+
+	_terminate: function () {
+		this.worker.terminate();
+		this._reset();
+	}
+};
+
+
+THREE.LoaderSupport.WorkerSupport.CodeSerializer = {
+
+	/**
+	 *
+	 * @param fullName
+	 * @param object
+	 * @returns {string}
+	 */
+	serializeObject: function ( fullName, object ) {
+		var objectString = fullName + ' = {\n\n';
+		var part;
+		for ( var name in object ) {
+
+			part = object[ name ];
+			if ( typeof( part ) === 'string' || part instanceof String ) {
+
+				part = part.replace( '\n', '\\n' );
+				part = part.replace( '\r', '\\r' );
+				objectString += '\t' + name + ': "' + part + '",\n';
+
+			} else if ( part instanceof Array ) {
+
+				objectString += '\t' + name + ': [' + part + '],\n';
+
+			} else if ( typeof part === 'object' ) {
+
+				// TODO: Short-cut for now. Recursion required?
+				objectString += '\t' + name + ': {},\n';
+
+			} else {
+
+				objectString += '\t' + name + ': ' + part + ',\n';
+
+			}
+
+		}
+		objectString += '}\n\n';
+
+		return objectString;
+	},
+
+	/**
+	 *
+	 * @param fullName
+	 * @param object
+	 * @param basePrototypeName
+	 * @param ignoreFunctions
+	 * @returns {string}
+	 */
+	serializeClass: function ( fullName, object, constructorName, basePrototypeName, ignoreFunctions, includeFunctions, overrideFunctions ) {
+		var valueString, objectPart, constructorString, i, funcOverride;
+		var prototypeFunctions = [];
+		var objectProperties = [];
+		var objectFunctions = [];
+		var isExtended = ( basePrototypeName !== null && basePrototypeName !== undefined );
+
+		if ( ! Array.isArray( ignoreFunctions ) ) ignoreFunctions = [];
+		if ( ! Array.isArray( includeFunctions ) ) includeFunctions = null;
+		if ( ! Array.isArray( overrideFunctions ) ) overrideFunctions = [];
+
+		for ( var name in object.prototype ) {
+
+			objectPart = object.prototype[ name ];
+			valueString = objectPart.toString();
+			if ( name === 'constructor' ) {
+
+				constructorString = fullName + ' = ' + valueString + ';\n\n';
+
+			} else if ( typeof objectPart === 'function' ) {
+
+				if ( ignoreFunctions.indexOf( name ) < 0 && ( includeFunctions === null || includeFunctions.indexOf( name ) >= 0 ) ) {
+
+					funcOverride = overrideFunctions[ name ];
+					if ( funcOverride && funcOverride.fullName === fullName + '.prototype.' + name ) {
+
+						valueString = funcOverride.code;
+
+					}
+					if ( isExtended ) {
+
+						prototypeFunctions.push( fullName + '.prototype.' + name + ' = ' + valueString + ';\n\n' );
+
+					} else {
+
+						prototypeFunctions.push( '\t' + name + ': ' + valueString + ',\n\n' );
+
+					}
+				}
+
+			}
+
+		}
+		for ( var name in object ) {
+
+			objectPart = object[ name ];
+
+			if ( typeof objectPart === 'function' ) {
+
+				if ( ignoreFunctions.indexOf( name ) < 0 && ( includeFunctions === null || includeFunctions.indexOf( name ) >= 0 ) ) {
+
+					funcOverride = overrideFunctions[ name ];
+					if ( funcOverride && funcOverride.fullName === fullName + '.' + name ) {
+
+						valueString = funcOverride.code;
+
+					} else {
+
+						valueString = objectPart.toString();
+
+					}
+					objectFunctions.push( fullName + '.' + name + ' = ' + valueString + ';\n\n' );
+
+				}
+
+			} else {
+
+				if ( typeof( objectPart ) === 'string' || objectPart instanceof String) {
+
+					valueString = '\"' + objectPart.toString() + '\"';
+
+				} else if ( typeof objectPart === 'object' ) {
+
+					// TODO: Short-cut for now. Recursion required?
+					valueString = "{}";
+
+				} else {
+
+					valueString = objectPart;
+
+				}
+				objectProperties.push( fullName + '.' + name + ' = ' + valueString + ';\n' );
+
+			}
+
+		}
+		if ( ( constructorString === undefined || constructorString === null ) && typeof object.prototype.constructor === 'function' ) {
+
+			constructorString = fullName + ' = ' + object.prototype.constructor.toString().replace( constructorName, '' );
+
+		}
+		var objectString = constructorString + '\n\n';
+		if ( isExtended ) {
+
+			objectString += fullName + '.prototype = Object.create( ' + basePrototypeName + '.prototype );\n';
+
+		}
+		objectString += fullName + '.prototype.constructor = ' + fullName + ';\n';
+		objectString += '\n\n';
+
+		for ( i = 0; i < objectProperties.length; i ++ ) objectString += objectProperties[ i ];
+		objectString += '\n\n';
+
+		for ( i = 0; i < objectFunctions.length; i ++ ) objectString += objectFunctions[ i ];
+		objectString += '\n\n';
+
+		if ( isExtended ) {
+
+			for ( i = 0; i < prototypeFunctions.length; i ++ ) objectString += prototypeFunctions[ i ];
+
+		} else {
+
+			objectString += fullName + '.prototype = {\n\n';
+			for ( i = 0; i < prototypeFunctions.length; i ++ ) objectString += prototypeFunctions[ i ];
+			objectString += '\n};';
+
+		}
+		objectString += '\n\n';
+
+		return objectString;
+	},
+};
 
 /**
  * Default implementation of the WorkerRunner responsible for creation and configuration of the parser within the worker.
  *
  * @class
  */
-THREE.LoaderSupport.WorkerRunnerRefImpl = (function () {
+THREE.LoaderSupport.WorkerRunnerRefImpl = function () {
+	var scopedRunner = function( event ) {
+		this.processMessage( event.data );
+	};
+	this.getParentScope().addEventListener( 'message', scopedRunner.bind( this ) );
+};
 
-	function WorkerRunnerRefImpl() {
-		var scope = this;
-		var scopedRunner = function( event ) {
-			scope.processMessage( event.data );
-		};
-		self.addEventListener( 'message', scopedRunner, false );
-	}
+THREE.LoaderSupport.WorkerRunnerRefImpl.runnerName = 'THREE.LoaderSupport.WorkerRunnerRefImpl';
+
+THREE.LoaderSupport.WorkerRunnerRefImpl.prototype = {
+
+	constructor: THREE.LoaderSupport.WorkerRunnerRefImpl,
+
+	/**
+	 * Returns the parent scope that this worker was spawned in.
+	 *
+	 * @returns {WorkerGlobalScope|Object} Returns a references
+	 * to the parent global scope or compatible type.
+	 */
+	getParentScope: function () {
+		return self;
+	},
 
 	/**
 	 * Applies values from parameter object via set functions or via direct assignment.
-	 * @memberOf THREE.LoaderSupport.WorkerRunnerRefImpl
 	 *
 	 * @param {Object} parser The parser instance
 	 * @param {Object} params The parameter object
 	 */
-	WorkerRunnerRefImpl.prototype.applyProperties = function ( parser, params ) {
+	applyProperties: function ( parser, params ) {
 		var property, funcName, values;
 		for ( property in params ) {
 			funcName = 'set' + property.substring( 0, 1 ).toLocaleUpperCase() + property.substring( 1 );
@@ -769,17 +1273,17 @@ THREE.LoaderSupport.WorkerRunnerRefImpl = (function () {
 
 			}
 		}
-	};
+	},
 
 	/**
 	 * Configures the Parser implementation according the supplied configuration object.
-	 * @memberOf THREE.LoaderSupport.WorkerRunnerRefImpl
 	 *
 	 * @param {Object} payload Raw mesh description (buffers, params, materials) used to build one to many meshes.
 	 */
-	WorkerRunnerRefImpl.prototype.processMessage = function ( payload ) {
+	processMessage: function ( payload ) {
 		if ( payload.cmd === 'run' ) {
 
+			var self = this.getParentScope();
 			var callbacks = {
 				callbackMeshBuilder: function ( payload ) {
 					self.postMessage( payload );
@@ -810,421 +1314,92 @@ THREE.LoaderSupport.WorkerRunnerRefImpl = (function () {
 			console.error( 'WorkerRunner: Received unknown command: ' + payload.cmd );
 
 		}
-	};
+	}
+};
 
-	return WorkerRunnerRefImpl;
-})();
 
 /**
- * This class provides means to transform existing parser code into a web worker. It defines a simple communication protocol
- * which allows to configure the worker and receive raw mesh data during execution.
+ * This class provides the NodeJS implementation of the WorkerRunnerRefImpl
  * @class
+ * @extends THREE.LoaderSupport.WorkerRunnerRefImpl
  */
-THREE.LoaderSupport.WorkerSupport = (function () {
+THREE.LoaderSupport.NodeWorkerRunnerRefImpl = function () {
+	this.runnerName = 'THREE.LoaderSupport.NodeWorkerRunnerRefImpl';
+	// No call to super because super class only binds to processMessage
+	// In NodeJS, there is no addEventListener so use onmessage.
+	// Also, the message object can be passed directly to
+	// processMessage() as it isn't an `Event`, but a plain object
+	// with the data
+	this.getParentScope().onmessage = this.processMessage.bind( this );
+};
 
-	var WORKER_SUPPORT_VERSION = '2.2.1';
+THREE.LoaderSupport.NodeWorkerRunnerRefImpl.prototype = Object.create( THREE.LoaderSupport.WorkerRunnerRefImpl.prototype );
+THREE.LoaderSupport.NodeWorkerRunnerRefImpl.prototype.constructor = THREE.LoaderSupport.NodeWorkerRunnerRefImpl;
+THREE.LoaderSupport.NodeWorkerRunnerRefImpl.runnerName = 'THREE.LoaderSupport.NodeWorkerRunnerRefImpl';
 
-	var Validator = THREE.LoaderSupport.Validator;
+THREE.LoaderSupport.NodeWorkerRunnerRefImpl.prototype = {
 
-	var LoaderWorker = (function () {
-
-		function LoaderWorker() {
-			this._reset();
-		}
-
-		LoaderWorker.prototype._reset = function () {
-			this.logging = {
-				enabled: true,
-				debug: false
-			};
-			this.worker = null;
-			this.runnerImplName = null;
-			this.callbacks = {
-				meshBuilder: null,
-				onLoad: null
-			};
-			this.terminateRequested = false;
-			this.queuedMessage = null;
-			this.started = false;
-			this.forceCopy = false;
-		};
-
-		LoaderWorker.prototype.setLogging = function ( enabled, debug ) {
-			this.logging.enabled = enabled === true;
-			this.logging.debug = debug === true;
-		};
-
-		LoaderWorker.prototype.setForceCopy = function ( forceCopy ) {
-			this.forceCopy = forceCopy === true;
-		};
-
-		LoaderWorker.prototype.initWorker = function ( code, runnerImplName ) {
-			this.runnerImplName = runnerImplName;
-			var blob = new Blob( [ code ], { type: 'application/javascript' } );
-			this.worker = new Worker( window.URL.createObjectURL( blob ) );
-			this.worker.onmessage = this._receiveWorkerMessage;
-
-			// set referemce to this, then processing in worker scope within "_receiveWorkerMessage" can access members
-			this.worker.runtimeRef = this;
-
-			// process stored queuedMessage
-			this._postMessage();
-		};
-
-		/**
-		 * Executed in worker scope
- 		 */
-		LoaderWorker.prototype._receiveWorkerMessage = function ( e ) {
-			var payload = e.data;
-			switch ( payload.cmd ) {
-				case 'meshData':
-				case 'materialData':
-				case 'imageData':
-					this.runtimeRef.callbacks.meshBuilder( payload );
-					break;
-
-				case 'complete':
-					this.runtimeRef.queuedMessage = null;
-					this.started = false;
-					this.runtimeRef.callbacks.onLoad( payload.msg );
-
-					if ( this.runtimeRef.terminateRequested ) {
-
-						if ( this.runtimeRef.logging.enabled ) console.info( 'WorkerSupport [' + this.runtimeRef.runnerImplName + ']: Run is complete. Terminating application on request!' );
-						this.runtimeRef._terminate();
-
-					}
-					break;
-
-				case 'error':
-					console.error( 'WorkerSupport [' + this.runtimeRef.runnerImplName + ']: Reported error: ' + payload.msg );
-					this.runtimeRef.queuedMessage = null;
-					this.started = false;
-					this.runtimeRef.callbacks.onLoad( payload.msg );
-
-					if ( this.runtimeRef.terminateRequested ) {
-
-						if ( this.runtimeRef.logging.enabled ) console.info( 'WorkerSupport [' + this.runtimeRef.runnerImplName + ']: Run reported error. Terminating application on request!' );
-						this.runtimeRef._terminate();
-
-					}
-					break;
-
-				default:
-					console.error( 'WorkerSupport [' + this.runtimeRef.runnerImplName + ']: Received unknown command: ' + payload.cmd );
-					break;
-
-			}
-		};
-
-		LoaderWorker.prototype.setCallbacks = function ( meshBuilder, onLoad ) {
-			this.callbacks.meshBuilder = Validator.verifyInput( meshBuilder, this.callbacks.meshBuilder );
-			this.callbacks.onLoad = Validator.verifyInput( onLoad, this.callbacks.onLoad );
-		};
-
-		LoaderWorker.prototype.run = function( payload ) {
-			if ( Validator.isValid( this.queuedMessage ) ) {
-
-				console.warn( 'Already processing message. Rejecting new run instruction' );
-				return;
-
-			} else {
-
-				this.queuedMessage = payload;
-				this.started = true;
-
-			}
-			if ( ! Validator.isValid( this.callbacks.meshBuilder ) ) throw 'Unable to run as no "MeshBuilder" callback is set.';
-			if ( ! Validator.isValid( this.callbacks.onLoad ) ) throw 'Unable to run as no "onLoad" callback is set.';
-			if ( payload.cmd !== 'run' ) payload.cmd = 'run';
-			if ( Validator.isValid( payload.logging ) ) {
-
-				payload.logging.enabled = payload.logging.enabled === true;
-				payload.logging.debug = payload.logging.debug === true;
-
-			} else {
-
-				payload.logging = {
-					enabled: true,
-					debug: false
-				};
-
-			}
-			this._postMessage();
-		};
-
-		LoaderWorker.prototype._postMessage = function () {
-			if ( Validator.isValid( this.queuedMessage ) && Validator.isValid( this.worker ) ) {
-
-				if ( this.queuedMessage.data.input instanceof ArrayBuffer ) {
-
-					var content;
-					if ( this.forceCopy ) {
-
-						content = this.queuedMessage.data.input.slice( 0 );
-
-					} else {
-
-						content = this.queuedMessage.data.input;
-
-					}
-					this.worker.postMessage( this.queuedMessage, [ content ] );
-
-				} else {
-
-					this.worker.postMessage( this.queuedMessage );
-
-				}
-
-			}
-		};
-
-		LoaderWorker.prototype.setTerminateRequested = function ( terminateRequested ) {
-			this.terminateRequested = terminateRequested === true;
-			if ( this.terminateRequested && Validator.isValid( this.worker ) && ! Validator.isValid( this.queuedMessage ) && this.started ) {
-
-				if ( this.logging.enabled ) console.info( 'Worker is terminated immediately as it is not running!' );
-				this._terminate();
-
-			}
-		};
-
-		LoaderWorker.prototype._terminate = function () {
-			this.worker.terminate();
-			this._reset();
-		};
-
-		return LoaderWorker;
-
-	})();
-
-	function WorkerSupport() {
-		console.info( 'Using THREE.LoaderSupport.WorkerSupport version: ' + WORKER_SUPPORT_VERSION );
-		this.logging = {
-			enabled: true,
-			debug: false
-		};
-
-		// check worker support first
-		if ( window.Worker === undefined ) throw "This browser does not support web workers!";
-		if ( window.Blob === undefined  ) throw "This browser does not support Blob!";
-		if ( typeof window.URL.createObjectURL !== 'function'  ) throw "This browser does not support Object creation from URL!";
-
-		this.loaderWorker = new LoaderWorker();
+	getParentScope: function(){
+		// Work around webpack builds failing with NodeJS requires
+		// (placing it outside this function will fail because
+		// this class is passed to the worker as a string!)
+		var _require = eval( 'require' );
+		return _require( 'worker_threads' ).parentPort;
 	}
+};
 
-	/**
-	 * Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-	 * @memberOf THREE.LoaderSupport.WorkerSupport
-	 *
-	 * @param {boolean} enabled True or false.
-	 * @param {boolean} debug True or false.
-	 */
-	WorkerSupport.prototype.setLogging = function ( enabled, debug ) {
-		this.logging.enabled = enabled === true;
-		this.logging.debug = debug === true;
-		this.loaderWorker.setLogging( this.logging.enabled, this.logging.debug );
-	};
 
-	/**
-	 * Forces all ArrayBuffers to be transferred to worker to be copied.
-	 * @memberOf THREE.LoaderSupport.WorkerSupport
-	 *
-	 * @param {boolean} forceWorkerDataCopy True or false.
-	 */
-	WorkerSupport.prototype.setForceWorkerDataCopy = function ( forceWorkerDataCopy ) {
-		this.loaderWorker.setForceCopy( forceWorkerDataCopy );
-	};
+/**
+ * This class provides the NodeJS implementation of LoaderWorker
+ * @class
+ * @extends LoaderWorker
+ */
+THREE.LoaderSupport.WorkerSupport.NodeLoaderWorker = function (){
+	THREE.LoaderSupport.WorkerSupport.LoaderWorker.call( this );
+};
 
-	/**
-	 * Validate the status of worker code and the derived worker.
-	 * @memberOf THREE.LoaderSupport.WorkerSupport
-	 *
-	 * @param {Function} functionCodeBuilder Function that is invoked with funcBuildObject and funcBuildSingleton that allows stringification of objects and singletons.
-	 * @param {String} parserName Name of the Parser object
-	 * @param {String[]} libLocations URL of libraries that shall be added to worker code relative to libPath
-	 * @param {String} libPath Base path used for loading libraries
-	 * @param {THREE.LoaderSupport.WorkerRunnerRefImpl} runnerImpl The default worker parser wrapper implementation (communication and execution). An extended class could be passed here.
-	 */
-	WorkerSupport.prototype.validate = function ( functionCodeBuilder, parserName, libLocations, libPath, runnerImpl ) {
-		if ( Validator.isValid( this.loaderWorker.worker ) ) return;
+THREE.LoaderSupport.WorkerSupport.NodeLoaderWorker.prototype = Object.create( THREE.LoaderSupport.WorkerSupport.LoaderWorker.prototype );
+THREE.LoaderSupport.WorkerSupport.NodeLoaderWorker.prototype.constructor = THREE.LoaderSupport.WorkerSupport.NodeLoaderWorker;
 
-		if ( this.logging.enabled ) {
+/**
+ * @inheritdoc
+  */
+THREE.LoaderSupport.WorkerSupport.NodeLoaderWorker.checkSupport = function() {
+	try {
+		// Work around webpack builds failing with NodeJS requires
+		var _require = eval( 'require' );
+		_require.resolve( 'worker_threads' );
+	}
+	catch(e) {
+		return 'This version of Node does not support web workers!';
+	}
+};
 
-			console.info( 'WorkerSupport: Building worker code...' );
-			console.time( 'buildWebWorkerCode' );
+/**
+ * @inheritdoc
+ */
+THREE.LoaderSupport.WorkerSupport.NodeLoaderWorker.prototype.initWorker = function ( code, runnerImplName ) {
+	var supportError = this.checkSupport();
+	if( supportError ) {
 
-		}
-		if ( Validator.isValid( runnerImpl ) ) {
+		throw supportError;
 
-			if ( this.logging.enabled ) console.info( 'WorkerSupport: Using "' + runnerImpl.name + '" as Runner class for worker.' );
+	}
+	this.runnerImplName = runnerImplName;
 
-		} else {
+	// Work around webpack builds failing with NodeJS requires
+	var _require = eval( 'require' );
+	var Worker = _require( 'worker_threads' ).Worker;
+	this.worker = new Worker( code, { eval: true } );
 
-			runnerImpl = THREE.LoaderSupport.WorkerRunnerRefImpl;
-			if ( this.logging.enabled ) console.info( 'WorkerSupport: Using DEFAULT "THREE.LoaderSupport.WorkerRunnerRefImpl" as Runner class for worker.' );
+	this.worker.onmessage = this._receiveWorkerMessage;
 
-		}
+	// set referemce to this, then processing in worker scope within "_receiveWorkerMessage" can access members
+	this.worker.runtimeRef = this;
 
-		var userWorkerCode = functionCodeBuilder( buildObject, buildSingleton );
-		userWorkerCode += 'var Parser = '+ parserName +  ';\n\n';
-		userWorkerCode += buildSingleton( runnerImpl.name, runnerImpl );
-		userWorkerCode += 'new ' + runnerImpl.name + '();\n\n';
-
-		var scope = this;
-		if ( Validator.isValid( libLocations ) && libLocations.length > 0 ) {
-
-			var libsContent = '';
-			var loadAllLibraries = function ( path, locations ) {
-				if ( locations.length === 0 ) {
-
-					scope.loaderWorker.initWorker( libsContent + userWorkerCode, runnerImpl.name );
-					if ( scope.logging.enabled ) console.timeEnd( 'buildWebWorkerCode' );
-
-				} else {
-
-					var loadedLib = function ( contentAsString ) {
-						libsContent += contentAsString;
-						loadAllLibraries( path, locations );
-					};
-
-					var fileLoader = new THREE.FileLoader();
-					fileLoader.setPath( path );
-					fileLoader.setResponseType( 'text' );
-					fileLoader.load( locations[ 0 ], loadedLib );
-					locations.shift();
-
-				}
-			};
-			loadAllLibraries( libPath, libLocations );
-
-		} else {
-
-			this.loaderWorker.initWorker( userWorkerCode, runnerImpl.name );
-			if ( this.logging.enabled ) console.timeEnd( 'buildWebWorkerCode' );
-
-		}
-	};
-
-	/**
-	 * Specify functions that should be build when new raw mesh data becomes available and when the parser is finished.
-	 * @memberOf THREE.LoaderSupport.WorkerSupport
-	 *
-	 * @param {Function} meshBuilder The mesh builder function. Default is {@link THREE.LoaderSupport.MeshBuilder}.
-	 * @param {Function} onLoad The function that is called when parsing is complete.
-	 */
-	WorkerSupport.prototype.setCallbacks = function ( meshBuilder, onLoad ) {
-		this.loaderWorker.setCallbacks( meshBuilder, onLoad );
-	};
-
-	/**
-	 * Runs the parser with the provided configuration.
-	 * @memberOf THREE.LoaderSupport.WorkerSupport
-	 *
-	 * @param {Object} payload Raw mesh description (buffers, params, materials) used to build one to many meshes.
-	 */
-	WorkerSupport.prototype.run = function ( payload ) {
-		this.loaderWorker.run( payload );
-	};
-
-	/**
-	 * Request termination of worker once parser is finished.
-	 * @memberOf THREE.LoaderSupport.WorkerSupport
-	 *
-	 * @param {boolean} terminateRequested True or false.
-	 */
-	WorkerSupport.prototype.setTerminateRequested = function ( terminateRequested ) {
-		this.loaderWorker.setTerminateRequested( terminateRequested );
-	};
-
-	var buildObject = function ( fullName, object ) {
-		var objectString = fullName + ' = {\n';
-		var part;
-		for ( var name in object ) {
-
-			part = object[ name ];
-			if ( typeof( part ) === 'string' || part instanceof String ) {
-
-				part = part.replace( '\n', '\\n' );
-				part = part.replace( '\r', '\\r' );
-				objectString += '\t' + name + ': "' + part + '",\n';
-
-			} else if ( part instanceof Array ) {
-
-				objectString += '\t' + name + ': [' + part + '],\n';
-
-			} else if ( Number.isInteger( part ) ) {
-
-				objectString += '\t' + name + ': ' + part + ',\n';
-
-			} else if ( typeof part === 'function' ) {
-
-				objectString += '\t' + name + ': ' + part + ',\n';
-
-			}
-
-		}
-		objectString += '}\n\n';
-
-		return objectString;
-	};
-
-	var buildSingleton = function ( fullName, object, internalName, basePrototypeName, ignoreFunctions ) {
-		var objectString = '';
-		var objectName = ( Validator.isValid( internalName ) ) ? internalName : object.name;
-
-		var funcString, objectPart, constructorString;
-		ignoreFunctions = Validator.verifyInput( ignoreFunctions, [] );
-		for ( var name in object.prototype ) {
-
-			objectPart = object.prototype[ name ];
-			if ( name === 'constructor' ) {
-
-				funcString = objectPart.toString();
-				funcString = funcString.replace( 'function', '' );
-				constructorString = '\tfunction ' + objectName + funcString + ';\n\n';
-
-			} else if ( typeof objectPart === 'function' ) {
-
-				if ( ignoreFunctions.indexOf( name ) < 0 ) {
-
-					funcString = objectPart.toString();
-					objectString += '\t' + objectName + '.prototype.' + name + ' = ' + funcString + ';\n\n';
-
-				}
-
-			}
-
-		}
-		objectString += '\treturn ' + objectName + ';\n';
-		objectString += '})();\n\n';
-
-		var inheritanceBlock = '';
-		if ( Validator.isValid( basePrototypeName ) ) {
-
-			inheritanceBlock += '\n';
-			inheritanceBlock += objectName + '.prototype = Object.create( ' + basePrototypeName + '.prototype );\n';
-			inheritanceBlock += objectName + '.constructor = ' + objectName + ';\n';
-			inheritanceBlock += '\n';
-		}
-		if ( ! Validator.isValid( constructorString ) ) {
-
-			constructorString = fullName + ' = (function () {\n\n';
-			constructorString += inheritanceBlock + '\t' + object.prototype.constructor.toString() + '\n\n';
-			objectString = constructorString + objectString;
-
-		} else {
-
-			objectString = fullName + ' = (function () {\n\n' + inheritanceBlock + constructorString + objectString;
-
-		}
-
-		return objectString;
-	};
-
-	return WorkerSupport;
-
-})();
+	// process stored queuedMessage
+	this._postMessage();
+};
 
 /**
  * Orchestrate loading of multiple OBJ files/data from an instruction queue with a configurable amount of workers (1-16).
@@ -1238,105 +1413,98 @@ THREE.LoaderSupport.WorkerSupport = (function () {
  *
  * @param {string} classDef Class definition to be used for construction
  */
-THREE.LoaderSupport.WorkerDirector = (function () {
+THREE.LoaderSupport.WorkerDirector = function ( classDef ) {
+	console.info( 'Using THREE.LoaderSupport.WorkerDirector version: ' + THREE.LoaderSupport.WorkerDirector.LOADER_WORKER_DIRECTOR_VERSION );
+	this.logging = {
+		enabled: true,
+		debug: false
+	};
 
-	var LOADER_WORKER_DIRECTOR_VERSION = '2.2.2';
+	this.maxQueueSize = THREE.LoaderSupport.WorkerDirector.MAX_QUEUE_SIZE ;
+	this.maxWebWorkers = THREE.LoaderSupport.WorkerDirector.MAX_WEB_WORKER;
+	this.crossOrigin = null;
 
-	var Validator = THREE.LoaderSupport.Validator;
+	if ( ! THREE.LoaderSupport.Validator.isValid( classDef ) ) throw 'Provided invalid classDef: ' + classDef;
 
-	var MAX_WEB_WORKER = 16;
-	var MAX_QUEUE_SIZE = 8192;
+	this.workerDescription = {
+		classDef: classDef,
+		globalCallbacks: {},
+		workerSupports: {},
+		forceWorkerDataCopy: true
+	};
+	this.objectsCompleted = 0;
+	this.instructionQueue = [];
+	this.instructionQueuePointer = 0;
 
-	function WorkerDirector( classDef ) {
-		console.info( 'Using THREE.LoaderSupport.WorkerDirector version: ' + LOADER_WORKER_DIRECTOR_VERSION );
-		this.logging = {
-			enabled: true,
-			debug: false
-		};
+	this.callbackOnFinishedProcessing = null;
+}
 
-		this.maxQueueSize = MAX_QUEUE_SIZE ;
-		this.maxWebWorkers = MAX_WEB_WORKER;
-		this.crossOrigin = null;
 
-		if ( ! Validator.isValid( classDef ) ) throw 'Provided invalid classDef: ' + classDef;
+THREE.LoaderSupport.WorkerDirector.LOADER_WORKER_DIRECTOR_VERSION = '2.3.0';
+THREE.LoaderSupport.WorkerDirector.MAX_WEB_WORKER = 16;
+THREE.LoaderSupport.WorkerDirector.MAX_QUEUE_SIZE = 2048;
 
-		this.workerDescription = {
-			classDef: classDef,
-			globalCallbacks: {},
-			workerSupports: {},
-			forceWorkerDataCopy: true
-		};
-		this.objectsCompleted = 0;
-		this.instructionQueue = [];
-		this.instructionQueuePointer = 0;
+THREE.LoaderSupport.WorkerDirector.prototype = {
 
-		this.callbackOnFinishedProcessing = null;
-	}
-
+	constructor: THREE.LoaderSupport.WorkerDirector,
 	/**
 	 * Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 *
 	 * @param {boolean} enabled True or false.
 	 * @param {boolean} debug True or false.
 	 */
-	WorkerDirector.prototype.setLogging = function ( enabled, debug ) {
+	setLogging: function ( enabled, debug ) {
 		this.logging.enabled = enabled === true;
 		this.logging.debug = debug === true;
-	};
+	},
 
 	/**
 	 * Returns the maximum length of the instruction queue.
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 *
 	 * @returns {number}
 	 */
-	WorkerDirector.prototype.getMaxQueueSize = function () {
+	getMaxQueueSize: function () {
 		return this.maxQueueSize;
-	};
+	},
 
 	/**
 	 * Returns the maximum number of workers.
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 *
 	 * @returns {number}
 	 */
-	WorkerDirector.prototype.getMaxWebWorkers = function () {
+	getMaxWebWorkers: function () {
 		return this.maxWebWorkers;
-	};
+	},
 
 	/**
 	 * Sets the CORS string to be used.
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 *
 	 * @param {string} crossOrigin CORS value
 	 */
-	WorkerDirector.prototype.setCrossOrigin = function ( crossOrigin ) {
+	setCrossOrigin: function ( crossOrigin ) {
 		this.crossOrigin = crossOrigin;
-	};
+	},
 
 	/**
 	 * Forces all ArrayBuffers to be transferred to worker to be copied.
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 *
 	 * @param {boolean} forceWorkerDataCopy True or false.
 	 */
-	WorkerDirector.prototype.setForceWorkerDataCopy = function ( forceWorkerDataCopy ) {
+	setForceWorkerDataCopy: function ( forceWorkerDataCopy ) {
 		this.workerDescription.forceWorkerDataCopy = forceWorkerDataCopy === true;
-	};
+	},
 
 	/**
 	 * Create or destroy workers according limits. Set the name and register callbacks for dynamically created web workers.
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 *
 	 * @param {THREE.OBJLoader2.WWOBJLoader2.PrepDataCallbacks} globalCallbacks  Register global callbacks used by all web workers
 	 * @param {number} maxQueueSize Set the maximum size of the instruction queue (1-1024)
 	 * @param {number} maxWebWorkers Set the maximum amount of workers (1-16)
 	 */
-	WorkerDirector.prototype.prepareWorkers = function ( globalCallbacks, maxQueueSize, maxWebWorkers ) {
-		if ( Validator.isValid( globalCallbacks ) ) this.workerDescription.globalCallbacks = globalCallbacks;
-		this.maxQueueSize = Math.min( maxQueueSize, MAX_QUEUE_SIZE );
-		this.maxWebWorkers = Math.min( maxWebWorkers, MAX_WEB_WORKER );
+	prepareWorkers: function ( globalCallbacks, maxQueueSize, maxWebWorkers ) {
+		if ( THREE.LoaderSupport.Validator.isValid( globalCallbacks ) ) this.workerDescription.globalCallbacks = globalCallbacks;
+		this.maxQueueSize = Math.min( maxQueueSize, THREE.LoaderSupport.WorkerDirector.MAX_QUEUE_SIZE );
+		this.maxWebWorkers = Math.min( maxWebWorkers, THREE.LoaderSupport.WorkerDirector.MAX_WEB_WORKER );
 		this.maxWebWorkers = Math.min( this.maxWebWorkers, this.maxQueueSize );
 		this.objectsCompleted = 0;
 		this.instructionQueue = [];
@@ -1356,36 +1524,33 @@ THREE.LoaderSupport.WorkerDirector = (function () {
 			};
 
 		}
-	};
+	},
 
 	/**
 	 * Store run instructions in internal instructionQueue.
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 *
 	 * @param {THREE.LoaderSupport.PrepData} prepData
 	 */
-	WorkerDirector.prototype.enqueueForRun = function ( prepData ) {
+	enqueueForRun: function ( prepData ) {
 		if ( this.instructionQueue.length < this.maxQueueSize ) {
 			this.instructionQueue.push( prepData );
 		}
-	};
+	},
 
 	/**
 	 * Returns if any workers are running.
 	 *
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 * @returns {boolean}
 	 */
-	WorkerDirector.prototype.isRunning = function () {
+	isRunning: function () {
 		var wsKeys = Object.keys( this.workerDescription.workerSupports );
 		return ( ( this.instructionQueue.length > 0 && this.instructionQueuePointer < this.instructionQueue.length ) || wsKeys.length > 0 );
-	};
+	},
 
 	/**
 	 * Process the instructionQueue until it is depleted.
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 */
-	WorkerDirector.prototype.processQueue = function () {
+	processQueue: function () {
 		var prepData, supportDesc;
 		for ( var instanceNo in this.workerDescription.workerSupports ) {
 
@@ -1414,20 +1579,21 @@ THREE.LoaderSupport.WorkerDirector = (function () {
 			this.callbackOnFinishedProcessing = null;
 
 		}
-	};
+	},
 
-	WorkerDirector.prototype._kickWorkerRun = function( prepData, supportDesc ) {
+	_kickWorkerRun: function( prepData, supportDesc ) {
 		supportDesc.inUse = true;
 		supportDesc.workerSupport.setTerminateRequested( supportDesc.terminateRequested );
 
 		if ( this.logging.enabled ) console.info( '\nAssigning next item from queue to worker (queue length: ' + this.instructionQueue.length + ')\n\n' );
 
+		var validator = THREE.LoaderSupport.Validator;
 		var scope = this;
 		var prepDataCallbacks = prepData.getCallbacks();
 		var globalCallbacks = this.workerDescription.globalCallbacks;
 		var wrapperOnLoad = function ( event ) {
-			if ( Validator.isValid( globalCallbacks.onLoad ) ) globalCallbacks.onLoad( event );
-			if ( Validator.isValid( prepDataCallbacks.onLoad ) ) prepDataCallbacks.onLoad( event );
+			if ( validator.isValid( globalCallbacks.onLoad ) ) globalCallbacks.onLoad( event );
+			if ( validator.isValid( prepDataCallbacks.onLoad ) ) prepDataCallbacks.onLoad( event );
 			scope.objectsCompleted++;
 			supportDesc.inUse = false;
 
@@ -1435,28 +1601,28 @@ THREE.LoaderSupport.WorkerDirector = (function () {
 		};
 
 		var wrapperOnProgress = function ( event ) {
-			if ( Validator.isValid( globalCallbacks.onProgress ) ) globalCallbacks.onProgress( event );
-			if ( Validator.isValid( prepDataCallbacks.onProgress ) ) prepDataCallbacks.onProgress( event );
+			if ( validator.isValid( globalCallbacks.onProgress ) ) globalCallbacks.onProgress( event );
+			if ( validator.isValid( prepDataCallbacks.onProgress ) ) prepDataCallbacks.onProgress( event );
 		};
 
 		var wrapperOnMeshAlter = function ( event, override ) {
-			if ( Validator.isValid( globalCallbacks.onMeshAlter ) ) override = globalCallbacks.onMeshAlter( event, override );
-			if ( Validator.isValid( prepDataCallbacks.onMeshAlter ) ) override = globalCallbacks.onMeshAlter( event, override );
+			if ( validator.isValid( globalCallbacks.onMeshAlter ) ) override = globalCallbacks.onMeshAlter( event, override );
+			if ( validator.isValid( prepDataCallbacks.onMeshAlter ) ) override = globalCallbacks.onMeshAlter( event, override );
 			return override;
 		};
 
 		var wrapperOnLoadMaterials = function ( materials ) {
-			if ( Validator.isValid( globalCallbacks.onLoadMaterials ) ) materials = globalCallbacks.onLoadMaterials( materials );
-			if ( Validator.isValid( prepDataCallbacks.onLoadMaterials ) ) materials = prepDataCallbacks.onLoadMaterials( materials );
+			if ( validator.isValid( globalCallbacks.onLoadMaterials ) ) materials = globalCallbacks.onLoadMaterials( materials );
+			if ( validator.isValid( prepDataCallbacks.onLoadMaterials ) ) materials = prepDataCallbacks.onLoadMaterials( materials );
 			return materials;
 		};
 
 		var wrapperOnReportError = function ( errorMessage ) {
 			var continueProcessing = true;
-			if ( Validator.isValid( globalCallbacks.onReportError ) ) continueProcessing = globalCallbacks.onReportError( supportDesc, errorMessage );
-			if ( Validator.isValid( prepDataCallbacks.onReportError ) )	continueProcessing = prepDataCallbacks.onReportError( supportDesc, errorMessage );
+			if ( validator.isValid( globalCallbacks.onReportError ) ) continueProcessing = globalCallbacks.onReportError( supportDesc, errorMessage );
+			if ( validator.isValid( prepDataCallbacks.onReportError ) )	continueProcessing = prepDataCallbacks.onReportError( supportDesc, errorMessage );
 
-			if ( ! Validator.isValid( globalCallbacks.onReportError ) && ! Validator.isValid( prepDataCallbacks.onReportError ) ) {
+			if ( ! validator.isValid( globalCallbacks.onReportError ) && ! validator.isValid( prepDataCallbacks.onReportError ) ) {
 
 				console.error( 'Loader reported an error: ' );
 				console.error( errorMessage );
@@ -1481,9 +1647,9 @@ THREE.LoaderSupport.WorkerDirector = (function () {
 		prepData.callbacks = updatedCallbacks;
 
 		supportDesc.loader.run( prepData, supportDesc.workerSupport );
-	};
+	},
 
-	WorkerDirector.prototype._buildLoader = function ( instanceNo ) {
+	_buildLoader: function ( instanceNo ) {
 		var classDef = this.workerDescription.classDef;
 		var loader = Object.create( classDef.prototype );
 		classDef.call( loader, THREE.DefaultLoadingManager );
@@ -1498,7 +1664,7 @@ THREE.LoaderSupport.WorkerDirector = (function () {
 
 		}
 		if ( typeof loader.run !== 'function'  ) throw classDef.name + ' has no function "run".';
-		if ( ! loader.hasOwnProperty( 'callbacks' ) || ! Validator.isValid( loader.callbacks ) ) {
+		if ( ! loader.hasOwnProperty( 'callbacks' ) || ! THREE.LoaderSupport.Validator.isValid( loader.callbacks ) ) {
 
 			console.warn( classDef.name + ' has an invalid property "callbacks". Will change to "THREE.LoaderSupport.Callbacks"' );
 			loader.callbacks = new THREE.LoaderSupport.Callbacks();
@@ -1506,40 +1672,37 @@ THREE.LoaderSupport.WorkerDirector = (function () {
 		}
 
 		return loader;
-	};
+	},
 
-	WorkerDirector.prototype._deregister = function ( supportDesc ) {
-		if ( Validator.isValid( supportDesc ) ) {
+	_deregister: function ( supportDesc ) {
+		if ( THREE.LoaderSupport.Validator.isValid( supportDesc ) ) {
 
 			supportDesc.workerSupport.setTerminateRequested( true );
 			if ( this.logging.enabled ) console.info( 'Requested termination of worker #' + supportDesc.instanceNo + '.' );
 
 			var loaderCallbacks = supportDesc.loader.callbacks;
-			if ( Validator.isValid( loaderCallbacks.onProgress ) ) loaderCallbacks.onProgress( { detail: { text: '' } } );
+			if ( THREE.LoaderSupport.Validator.isValid( loaderCallbacks.onProgress ) ) loaderCallbacks.onProgress( { detail: { text: '' } } );
 			delete this.workerDescription.workerSupports[ supportDesc.instanceNo ];
 
 		}
-	};
+	},
 
 	/**
 	 * Terminate all workers.
-	 * @memberOf THREE.LoaderSupport.WorkerDirector
 	 *
 	 * @param {callback} callbackOnFinishedProcessing Function called once all workers finished processing.
 	 */
-	WorkerDirector.prototype.tearDown = function ( callbackOnFinishedProcessing ) {
+	tearDown: function ( callbackOnFinishedProcessing ) {
 		if ( this.logging.enabled ) console.info( 'WorkerDirector received the deregister call. Terminating all workers!' );
 
 		this.instructionQueuePointer = this.instructionQueue.length;
-		this.callbackOnFinishedProcessing = Validator.verifyInput( callbackOnFinishedProcessing, null );
+		this.callbackOnFinishedProcessing = THREE.LoaderSupport.Validator.verifyInput( callbackOnFinishedProcessing, null );
 
 		for ( var name in this.workerDescription.workerSupports ) {
 
 			this.workerDescription.workerSupports[ name ].terminateRequested = true;
 
 		}
-	};
+	}
 
-	return WorkerDirector;
-
-})();
+};

--- a/examples/js/loaders/OBJLoader2.js
+++ b/examples/js/loaders/OBJLoader2.js
@@ -15,149 +15,150 @@ if ( THREE.LoaderSupport === undefined ) console.error( '"THREE.LoaderSupport" i
  *
  * @param {THREE.DefaultLoadingManager} [manager] The loadingManager for the loader to use. Default is {@link THREE.DefaultLoadingManager}
  */
-THREE.OBJLoader2 = (function () {
 
-	var OBJLOADER2_VERSION = '2.4.2';
-	var Validator = THREE.LoaderSupport.Validator;
+THREE.OBJLoader2 = function ( manager ) {
+	console.info( 'Using THREE.OBJLoader2 version: ' + THREE.OBJLoader2.OBJLOADER2_VERSION );
 
-	function OBJLoader2( manager ) {
-		console.info( 'Using THREE.OBJLoader2 version: ' + OBJLOADER2_VERSION );
+	this.manager = THREE.LoaderSupport.Validator.verifyInput( manager, THREE.DefaultLoadingManager );
+	this.logging = {
+		enabled: true,
+		debug: false
+	};
 
-		this.manager = Validator.verifyInput( manager, THREE.DefaultLoadingManager );
-		this.logging = {
-			enabled: true,
-			debug: false
-		};
+	this.modelName = '';
+	this.instanceNo = 0;
+	this.path;
+	this.resourcePath;
+	this.useIndices = false;
+	this.disregardNormals = false;
+	this.materialPerSmoothingGroup = false;
+	this.useOAsMesh = false;
+	this.loaderRootNode = new THREE.Group();
 
-		this.modelName = '';
-		this.instanceNo = 0;
-		this.path = '';
-		this.useIndices = false;
-		this.disregardNormals = false;
-		this.materialPerSmoothingGroup = false;
-		this.useOAsMesh = false;
-		this.loaderRootNode = new THREE.Group();
+	this.meshBuilder = new THREE.LoaderSupport.MeshBuilder();
+	this.callbacks = new THREE.LoaderSupport.Callbacks();
+	this.workerSupport = new THREE.LoaderSupport.WorkerSupport();
+	this.terminateWorkerOnLoad = true;
+};
 
-		this.meshBuilder = new THREE.LoaderSupport.MeshBuilder();
-		this.callbacks = new THREE.LoaderSupport.Callbacks();
-		this.workerSupport = new THREE.LoaderSupport.WorkerSupport();
-		this.terminateWorkerOnLoad = true;
-	}
+THREE.OBJLoader2.OBJLOADER2_VERSION = '2.5.0';
+
+THREE.OBJLoader2.prototype = {
+
+	constructor: THREE.OBJLoader2,
 
 	/**
 	 * Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {boolean} enabled True or false.
 	 * @param {boolean} debug True or false.
 	 */
-	OBJLoader2.prototype.setLogging = function ( enabled, debug ) {
+	setLogging: function ( enabled, debug ) {
 		this.logging.enabled = enabled === true;
 		this.logging.debug = debug === true;
 		this.meshBuilder.setLogging( this.logging.enabled, this.logging.debug );
-	};
+	},
 
 	/**
 	 * Set the name of the model.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {string} modelName
 	 */
-	OBJLoader2.prototype.setModelName = function ( modelName ) {
-		this.modelName = Validator.verifyInput( modelName, this.modelName );
-	};
+	setModelName: function ( modelName ) {
+		this.modelName = THREE.LoaderSupport.Validator.verifyInput( modelName, this.modelName );
+	},
 
 	/**
 	 * The URL of the base path.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {string} path URL
 	 */
-	OBJLoader2.prototype.setPath = function ( path ) {
-		this.path = Validator.verifyInput( path, this.path );
-	};
+	setPath: function ( path ) {
+		this.path = THREE.LoaderSupport.Validator.verifyInput( path, this.path );
+	},
+
+	/**
+	 * Allow to specify resourcePath for dependencies of specified resource.
+	 * @param {string} resourcePath
+	 */
+	setResourcePath: function ( resourcePath ) {
+		this.resourcePath = THREE.LoaderSupport.Validator.verifyInput( resourcePath, this.resourcePath );
+	},
 
 	/**
 	 * Set the node where the loaded objects will be attached directly.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {THREE.Object3D} streamMeshesTo Object already attached to scenegraph where new meshes will be attached to
 	 */
-	OBJLoader2.prototype.setStreamMeshesTo = function ( streamMeshesTo ) {
-		this.loaderRootNode = Validator.verifyInput( streamMeshesTo, this.loaderRootNode );
-	};
+	setStreamMeshesTo: function ( streamMeshesTo ) {
+		this.loaderRootNode = THREE.LoaderSupport.Validator.verifyInput( streamMeshesTo, this.loaderRootNode );
+	},
 
 	/**
 	 * Set materials loaded by MTLLoader or any other supplier of an Array of {@link THREE.Material}.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {THREE.Material[]} materials Array of {@link THREE.Material}
 	 */
-	OBJLoader2.prototype.setMaterials = function ( materials ) {
+	setMaterials: function ( materials ) {
 		this.meshBuilder.setMaterials( materials );
-	};
+	},
 
 	/**
 	 * Instructs loaders to create indexed {@link THREE.BufferGeometry}.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {boolean} useIndices=false
 	 */
-	OBJLoader2.prototype.setUseIndices = function ( useIndices ) {
+	setUseIndices: function ( useIndices ) {
 		this.useIndices = useIndices === true;
-	};
+	},
 
 	/**
 	 * Tells whether normals should be completely disregarded and regenerated.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {boolean} disregardNormals=false
 	 */
-	OBJLoader2.prototype.setDisregardNormals = function ( disregardNormals ) {
+	setDisregardNormals: function ( disregardNormals ) {
 		this.disregardNormals = disregardNormals === true;
-	};
+	},
 
 	/**
 	 * Tells whether a material shall be created per smoothing group.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {boolean} materialPerSmoothingGroup=false
 	 */
-	OBJLoader2.prototype.setMaterialPerSmoothingGroup = function ( materialPerSmoothingGroup ) {
+	setMaterialPerSmoothingGroup: function ( materialPerSmoothingGroup ) {
 		this.materialPerSmoothingGroup = materialPerSmoothingGroup === true;
-	};
+	},
 
 	/**
 	 * Usually 'o' is meta-information and does not result in creation of new meshes, but mesh creation on occurrence of "o" can be enforced.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {boolean} useOAsMesh=false
 	 */
-	OBJLoader2.prototype.setUseOAsMesh = function ( useOAsMesh ) {
+	setUseOAsMesh: function ( useOAsMesh ) {
 		this.useOAsMesh = useOAsMesh === true;
-	};
+	},
 
-	OBJLoader2.prototype._setCallbacks = function ( callbacks ) {
-		if ( Validator.isValid( callbacks.onProgress ) ) this.callbacks.setCallbackOnProgress( callbacks.onProgress );
-		if ( Validator.isValid( callbacks.onReportError ) ) this.callbacks.setCallbackOnReportError( callbacks.onReportError );
-		if ( Validator.isValid( callbacks.onMeshAlter ) ) this.callbacks.setCallbackOnMeshAlter( callbacks.onMeshAlter );
-		if ( Validator.isValid( callbacks.onLoad ) ) this.callbacks.setCallbackOnLoad( callbacks.onLoad );
-		if ( Validator.isValid( callbacks.onLoadMaterials ) ) this.callbacks.setCallbackOnLoadMaterials( callbacks.onLoadMaterials );
+	_setCallbacks: function ( callbacks ) {
+		if ( THREE.LoaderSupport.Validator.isValid( callbacks.onProgress ) ) this.callbacks.setCallbackOnProgress( callbacks.onProgress );
+		if ( THREE.LoaderSupport.Validator.isValid( callbacks.onReportError ) ) this.callbacks.setCallbackOnReportError( callbacks.onReportError );
+		if ( THREE.LoaderSupport.Validator.isValid( callbacks.onMeshAlter ) ) this.callbacks.setCallbackOnMeshAlter( callbacks.onMeshAlter );
+		if ( THREE.LoaderSupport.Validator.isValid( callbacks.onLoad ) ) this.callbacks.setCallbackOnLoad( callbacks.onLoad );
+		if ( THREE.LoaderSupport.Validator.isValid( callbacks.onLoadMaterials ) ) this.callbacks.setCallbackOnLoadMaterials( callbacks.onLoadMaterials );
 
 		this.meshBuilder._setCallbacks( this.callbacks );
-	};
+	},
 
 	/**
 	 * Announce feedback which is give to the registered callbacks.
-	 * @memberOf THREE.OBJLoader2
 	 * @private
 	 *
 	 * @param {string} type The type of event
 	 * @param {string} text Textual description of the event
 	 * @param {number} numericalValue Numerical value describing the progress
 	 */
-	OBJLoader2.prototype.onProgress = function ( type, text, numericalValue ) {
-		var content = Validator.isValid( text ) ? text: '';
+	onProgress: function ( type, text, numericalValue ) {
+		var content = THREE.LoaderSupport.Validator.isValid( text ) ? text: '';
 		var event = {
 			detail: {
 				type: type,
@@ -168,12 +169,12 @@ THREE.OBJLoader2 = (function () {
 			}
 		};
 
-		if ( Validator.isValid( this.callbacks.onProgress ) ) this.callbacks.onProgress( event );
+		if ( THREE.LoaderSupport.Validator.isValid( this.callbacks.onProgress ) ) this.callbacks.onProgress( event );
 
 		if ( this.logging.enabled && this.logging.debug ) console.debug( content );
-	};
+	},
 
-	OBJLoader2.prototype._onError = function ( event ) {
+	_onError: function ( event ) {
 		var output = 'Error occurred while downloading!';
 
 		if ( event.currentTarget && event.currentTarget.statusText !== null ) {
@@ -183,10 +184,10 @@ THREE.OBJLoader2 = (function () {
 		}
 		this.onProgress( 'error', output, -1 );
 		this._throwError( output );
-	};
+	},
 
-	OBJLoader2.prototype._throwError = function ( errorMessage ) {
-		if ( Validator.isValid( this.callbacks.onReportError ) )  {
+	_throwError: function ( errorMessage ) {
+		if ( THREE.LoaderSupport.Validator.isValid( this.callbacks.onReportError ) )  {
 
 			this.callbacks.onReportError( errorMessage );
 
@@ -195,34 +196,33 @@ THREE.OBJLoader2 = (function () {
 			throw errorMessage;
 
 		}
-	};
+	},
 
 	/**
 	 * Use this convenient method to load a file at the given URL. By default the fileLoader uses an ArrayBuffer.
-	 * @memberOf THREE.OBJLoader2
 	 *
-	 * @param {string}  url A string containing the path/URL of the file to be loaded.
+	 * @param {string} url A string containing the path/URL of the file to be loaded.
 	 * @param {callback} onLoad A function to be called after loading is successfully completed. The function receives loaded Object3D as an argument.
 	 * @param {callback} [onProgress] A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains total and Integer bytes.
 	 * @param {callback} [onError] A function to be called if an error occurs during loading. The function receives the error as an argument.
 	 * @param {callback} [onMeshAlter] A function to be called after a new mesh raw data becomes available for alteration.
 	 * @param {boolean} [useAsync] If true, uses async loading with worker, if false loads data synchronously.
 	 */
-	OBJLoader2.prototype.load = function ( url, onLoad, onProgress, onError, onMeshAlter, useAsync ) {
+	load: function ( url, onLoad, onProgress, onError, onMeshAlter, useAsync ) {
 		var resource = new THREE.LoaderSupport.ResourceDescriptor( url, 'OBJ' );
 		this._loadObj( resource, onLoad, onProgress, onError, onMeshAlter, useAsync );
-	};
+	},
 
-	OBJLoader2.prototype._loadObj = function ( resource, onLoad, onProgress, onError, onMeshAlter, useAsync ) {
+	_loadObj: function ( resource, onLoad, onProgress, onError, onMeshAlter, useAsync ) {
 		var scope = this;
-		if ( ! Validator.isValid( onError ) ) {
+		if ( ! THREE.LoaderSupport.Validator.isValid( onError ) ) {
 			onError = function ( event ) {
 				scope._onError( event );
-			};
+			}
 		}
 
 		// fast-fail
-		if ( ! Validator.isValid( resource ) ) onError( 'An invalid ResourceDescriptor was provided. Unable to continue!' );
+		if ( ! THREE.LoaderSupport.Validator.isValid( resource ) ) onError( 'An invalid ResourceDescriptor was provided. Unable to continue!' );
 		var fileLoaderOnLoad = function ( content ) {
 
 			resource.content = content;
@@ -247,15 +247,17 @@ THREE.OBJLoader2 = (function () {
 
 			}
 		};
+		this.setPath( resource.path );
+		this.setResourcePath( resource.resourcePath );
 
 		// fast-fail
-		if ( ! Validator.isValid( resource.url ) || Validator.isValid( resource.content ) ) {
+		if ( ! THREE.LoaderSupport.Validator.isValid( resource.url ) || THREE.LoaderSupport.Validator.isValid( resource.content ) ) {
 
-			fileLoaderOnLoad( Validator.isValid( resource.content ) ? resource.content : null );
+			fileLoaderOnLoad( THREE.LoaderSupport.Validator.isValid( resource.content ) ? resource.content : null );
 
 		} else {
 
-			if ( ! Validator.isValid( onProgress ) ) {
+			if ( ! THREE.LoaderSupport.Validator.isValid( onProgress ) ) {
 				var numericalValueRef = 0;
 				var numericalValue = 0;
 				onProgress = function ( event ) {
@@ -274,22 +276,20 @@ THREE.OBJLoader2 = (function () {
 
 
 			var fileLoader = new THREE.FileLoader( this.manager );
-			fileLoader.setPath( this.path );
+			fileLoader.setPath( this.path || this.resourcePath );
 			fileLoader.setResponseType( 'arraybuffer' );
-			fileLoader.load( resource.url, fileLoaderOnLoad, onProgress, onError );
+			fileLoader.load( resource.name, fileLoaderOnLoad, onProgress, onError );
 
 		}
-	};
-
+	},
 
 	/**
 	 * Run the loader according the provided instructions.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {THREE.LoaderSupport.PrepData} prepData All parameters and resources required for execution
 	 * @param {THREE.LoaderSupport.WorkerSupport} [workerSupportExternal] Use pre-existing WorkerSupport
 	 */
-	OBJLoader2.prototype.run = function ( prepData, workerSupportExternal ) {
+	run: function ( prepData, workerSupportExternal ) {
 		this._applyPrepData( prepData );
 		var available = prepData.checkResourceDescriptorFiles( prepData.resources,
 			[
@@ -298,7 +298,7 @@ THREE.OBJLoader2 = (function () {
 				{ ext: "zip", type: "String", ignore: true }
 			]
 		);
-		if ( Validator.isValid( workerSupportExternal ) ) {
+		if ( THREE.LoaderSupport.Validator.isValid( workerSupportExternal ) ) {
 
 			this.terminateWorkerOnLoad = false;
 			this.workerSupport = workerSupportExternal;
@@ -313,10 +313,10 @@ THREE.OBJLoader2 = (function () {
 
 		};
 		this._loadMtl( available.mtl, onMaterialsLoaded, null, null, prepData.crossOrigin, prepData.materialOptions );
-	};
+	},
 
-	OBJLoader2.prototype._applyPrepData = function ( prepData ) {
-		if ( Validator.isValid( prepData ) ) {
+	_applyPrepData: function ( prepData ) {
+		if ( THREE.LoaderSupport.Validator.isValid( prepData ) ) {
 
 			this.setLogging( prepData.logging.enabled, prepData.logging.debug );
 			this.setModelName( prepData.modelName );
@@ -330,17 +330,16 @@ THREE.OBJLoader2 = (function () {
 			this._setCallbacks( prepData.getCallbacks() );
 
 		}
-	};
+	},
 
 	/**
 	 * Parses OBJ data synchronously from arraybuffer or string.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {arraybuffer|string} content OBJ data as Uint8Array or String
 	 */
-	OBJLoader2.prototype.parse = function ( content ) {
+	parse: function ( content ) {
 		// fast-fail in case of illegal data
-		if ( ! Validator.isValid( content ) ) {
+		if ( ! THREE.LoaderSupport.Validator.isValid( content ) ) {
 
 			console.warn( 'Provided content is not a valid ArrayBuffer or String.' );
 			return this.loaderRootNode;
@@ -349,7 +348,7 @@ THREE.OBJLoader2 = (function () {
 		if ( this.logging.enabled ) console.time( 'OBJLoader2 parse: ' + this.modelName );
 		this.meshBuilder.init();
 
-		var parser = new Parser();
+		var parser = new THREE.OBJLoader2.Parser();
 		parser.setLogging( this.logging.enabled, this.logging.debug );
 		parser.setMaterialPerSmoothingGroup( this.materialPerSmoothingGroup );
 		parser.setUseOAsMesh( this.useOAsMesh );
@@ -391,16 +390,15 @@ THREE.OBJLoader2 = (function () {
 		if ( this.logging.enabled ) console.timeEnd( 'OBJLoader2 parse: ' + this.modelName );
 
 		return this.loaderRootNode;
-	};
+	},
 
 	/**
 	 * Parses OBJ content asynchronously from arraybuffer.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {arraybuffer} content OBJ data as Uint8Array
 	 * @param {callback} onLoad Called after worker successfully completed loading
 	 */
-	OBJLoader2.prototype.parseAsync = function ( content, onLoad ) {
+	parseAsync: function ( content, onLoad ) {
 		var scope = this;
 		var measureTime = false;
 		var scopedOnLoad = function () {
@@ -416,10 +414,10 @@ THREE.OBJLoader2 = (function () {
 			if ( measureTime && scope.logging.enabled ) console.timeEnd( 'OBJLoader2 parseAsync: ' + scope.modelName );
 		};
 		// fast-fail in case of illegal data
-		if ( ! Validator.isValid( content ) ) {
+		if ( ! THREE.LoaderSupport.Validator.isValid( content ) ) {
 
 			console.warn( 'Provided content is not a valid ArrayBuffer.' );
-			scopedOnLoad();
+			scopedOnLoad()
 
 		} else {
 
@@ -437,18 +435,18 @@ THREE.OBJLoader2 = (function () {
 				scope.loaderRootNode.add( mesh );
 			}
 		};
-		var buildCode = function ( funcBuildObject, funcBuildSingleton ) {
+		var buildCode = function ( codeSerializer ) {
 			var workerCode = '';
 			workerCode += '/**\n';
 			workerCode += '  * This code was constructed by OBJLoader2 buildCode.\n';
 			workerCode += '  */\n\n';
-			workerCode += 'THREE = { LoaderSupport: {} };\n\n';
-			workerCode += funcBuildObject( 'THREE.LoaderSupport.Validator', Validator );
-			workerCode += funcBuildSingleton( 'Parser', Parser );
+			workerCode += 'THREE = { LoaderSupport: {}, OBJLoader2: {} };\n\n';
+			workerCode += codeSerializer.serializeObject( 'THREE.LoaderSupport.Validator', THREE.LoaderSupport.Validator );
+			workerCode += codeSerializer.serializeClass( 'THREE.OBJLoader2.Parser', THREE.OBJLoader2.Parser );
 
 			return workerCode;
 		};
-		this.workerSupport.validate( buildCode, 'Parser' );
+		this.workerSupport.validate( buildCode, 'THREE.OBJLoader2.Parser' );
 		this.workerSupport.setCallbacks( scopedOnMeshLoaded, scopedOnLoad );
 		if ( scope.terminateWorkerOnLoad ) this.workerSupport.setTerminateRequested( true );
 
@@ -482,869 +480,10 @@ THREE.OBJLoader2 = (function () {
 				}
 			}
 		);
-	};
-
-
-	/**
-	 * Parse OBJ data either from ArrayBuffer or string
-	 * @class
-	 */
-	var Parser = (function () {
-
-		function Parser() {
-			this.callbackProgress = null;
-			this.callbackMeshBuilder = null;
-			this.contentRef = null;
-			this.legacyMode = false;
-
-			this.materials = {};
-			this.useAsync = false;
-			this.materialPerSmoothingGroup = false;
-			this.useOAsMesh = false;
-			this.useIndices = false;
-			this.disregardNormals = false;
-
-			this.vertices = [];
-			this.colors = [];
-			this.normals = [];
-			this.uvs = [];
-
-			this.rawMesh = {
-				objectName: '',
-				groupName: '',
-				activeMtlName: '',
-				mtllibName: '',
-
-				// reset with new mesh
-				faceType: -1,
-				subGroups: [],
-				subGroupInUse: null,
-				smoothingGroup: {
-					splitMaterials: false,
-					normalized: -1,
-					real: -1
-				},
-				counts: {
-					doubleIndicesCount: 0,
-					faceCount: 0,
-					mtlCount: 0,
-					smoothingGroupCount: 0
-				}
-			};
-
-			this.inputObjectCount = 1;
-			this.outputObjectCount = 1;
-			this.globalCounts = {
-				vertices: 0,
-				faces: 0,
-				doubleIndicesCount: 0,
-				lineByte: 0,
-				currentByte: 0,
-				totalBytes: 0
-			};
-
-			this.logging = {
-				enabled: true,
-				debug: false
-			};
-		}
-
-		Parser.prototype.resetRawMesh = function () {
-			// faces are stored according combined index of group, material and smoothingGroup (0 or not)
-			this.rawMesh.subGroups = [];
-			this.rawMesh.subGroupInUse = null;
-			this.rawMesh.smoothingGroup.normalized = -1;
-			this.rawMesh.smoothingGroup.real = -1;
-
-			// this default index is required as it is possible to define faces without 'g' or 'usemtl'
-			this.pushSmoothingGroup( 1 );
-
-			this.rawMesh.counts.doubleIndicesCount = 0;
-			this.rawMesh.counts.faceCount = 0;
-			this.rawMesh.counts.mtlCount = 0;
-			this.rawMesh.counts.smoothingGroupCount = 0;
-		};
-
-		Parser.prototype.setUseAsync = function ( useAsync ) {
-			this.useAsync = useAsync;
-		};
-
-		Parser.prototype.setMaterialPerSmoothingGroup = function ( materialPerSmoothingGroup ) {
-			this.materialPerSmoothingGroup = materialPerSmoothingGroup;
-		};
-
-		Parser.prototype.setUseOAsMesh = function ( useOAsMesh ) {
-			this.useOAsMesh = useOAsMesh;
-		};
-
-		Parser.prototype.setUseIndices = function ( useIndices ) {
-			this.useIndices = useIndices;
-		};
-
-		Parser.prototype.setDisregardNormals = function ( disregardNormals ) {
-			this.disregardNormals = disregardNormals;
-		};
-
-		Parser.prototype.setMaterials = function ( materials ) {
-			this.materials = THREE.LoaderSupport.Validator.verifyInput( materials, this.materials );
-			this.materials = THREE.LoaderSupport.Validator.verifyInput( this.materials, {} );
-		};
-
-		Parser.prototype.setCallbackMeshBuilder = function ( callbackMeshBuilder ) {
-			if ( ! THREE.LoaderSupport.Validator.isValid( callbackMeshBuilder ) ) {
-
-				this._throwError( 'Unable to run as no "MeshBuilder" callback is set.' );
-
-			}
-			this.callbackMeshBuilder = callbackMeshBuilder;
-		};
-
-		Parser.prototype.setCallbackProgress = function ( callbackProgress ) {
-			this.callbackProgress = callbackProgress;
-		};
-
-		Parser.prototype.setLogging = function ( enabled, debug ) {
-			this.logging.enabled = enabled === true;
-			this.logging.debug = debug === true;
-		};
-
-		Parser.prototype.configure = function () {
-			this.pushSmoothingGroup( 1 );
-
-			if ( this.logging.enabled ) {
-
-				var matKeys = Object.keys( this.materials );
-				var matNames = ( matKeys.length > 0 ) ? '\n\tmaterialNames:\n\t\t- ' + matKeys.join( '\n\t\t- ' ) : '\n\tmaterialNames: None';
-				var printedConfig = 'OBJLoader2.Parser configuration:'
-					+ matNames
-					+ '\n\tuseAsync: ' + this.useAsync
-					+ '\n\tmaterialPerSmoothingGroup: ' + this.materialPerSmoothingGroup
-					+ '\n\tuseOAsMesh: ' + this.useOAsMesh
-					+ '\n\tuseIndices: ' + this.useIndices
-					+ '\n\tdisregardNormals: ' + this.disregardNormals
-					+ '\n\tcallbackMeshBuilderName: ' + this.callbackMeshBuilder.name
-					+ '\n\tcallbackProgressName: ' + this.callbackProgress.name;
-				console.info( printedConfig );
-			}
-		};
-
-		/**
-		 * Parse the provided arraybuffer
-		 * @memberOf Parser
-		 *
-		 * @param {Uint8Array} arrayBuffer OBJ data as Uint8Array
-		 */
-		Parser.prototype.parse = function ( arrayBuffer ) {
-			if ( this.logging.enabled ) console.time( 'OBJLoader2.Parser.parse' );
-			this.configure();
-
-			var arrayBufferView = new Uint8Array( arrayBuffer );
-			this.contentRef = arrayBufferView;
-			var length = arrayBufferView.byteLength;
-			this.globalCounts.totalBytes = length;
-			var buffer = new Array( 128 );
-
-			for ( var code, word = '', bufferPointer = 0, slashesCount = 0, i = 0; i < length; i++ ) {
-
-				code = arrayBufferView[ i ];
-				switch ( code ) {
-					// space
-					case 32:
-						if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
-						word = '';
-						break;
-					// slash
-					case 47:
-						if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
-						slashesCount++;
-						word = '';
-						break;
-
-					// LF
-					case 10:
-						if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
-						word = '';
-						this.globalCounts.lineByte = this.globalCounts.currentByte;
-						this.globalCounts.currentByte = i;
-						this.processLine( buffer, bufferPointer, slashesCount );
-						bufferPointer = 0;
-						slashesCount = 0;
-						break;
-
-					// CR
-					case 13:
-						break;
-
-					default:
-						word += String.fromCharCode( code );
-						break;
-				}
-			}
-			this.finalizeParsing();
-			if ( this.logging.enabled ) console.timeEnd(  'OBJLoader2.Parser.parse' );
-		};
-
-		/**
-		 * Parse the provided text
-		 * @memberOf Parser
-		 *
-		 * @param {string} text OBJ data as string
-		 */
-		Parser.prototype.parseText = function ( text ) {
-			if ( this.logging.enabled ) console.time(  'OBJLoader2.Parser.parseText' );
-			this.configure();
-			this.legacyMode = true;
-			this.contentRef = text;
-			var length = text.length;
-			this.globalCounts.totalBytes = length;
-			var buffer = new Array( 128 );
-
-			for ( var char, word = '', bufferPointer = 0, slashesCount = 0, i = 0; i < length; i++ ) {
-
-				char = text[ i ];
-				switch ( char ) {
-					case ' ':
-						if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
-						word = '';
-						break;
-
-					case '/':
-						if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
-						slashesCount++;
-						word = '';
-						break;
-
-					case '\n':
-						if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
-						word = '';
-						this.globalCounts.lineByte = this.globalCounts.currentByte;
-						this.globalCounts.currentByte = i;
-						this.processLine( buffer, bufferPointer, slashesCount );
-						bufferPointer = 0;
-						slashesCount = 0;
-						break;
-
-					case '\r':
-						break;
-
-					default:
-						word += char;
-				}
-			}
-			this.finalizeParsing();
-			if ( this.logging.enabled ) console.timeEnd( 'OBJLoader2.Parser.parseText' );
-		};
-
-		Parser.prototype.processLine = function ( buffer, bufferPointer, slashesCount ) {
-			if ( bufferPointer < 1 ) return;
-
-			var reconstructString = function ( content, legacyMode, start, stop ) {
-				var line = '';
-				if ( stop > start ) {
-
-					var i;
-					if ( legacyMode ) {
-
-						for ( i = start; i < stop; i++ ) line += content[ i ];
-
-					} else {
-
-
-						for ( i = start; i < stop; i++ ) line += String.fromCharCode( content[ i ] );
-
-					}
-					line = line.trim();
-
-				}
-				return line;
-			};
-
-			var bufferLength, length, i, lineDesignation;
-			lineDesignation = buffer [ 0 ];
-			switch ( lineDesignation ) {
-				case 'v':
-					this.vertices.push( parseFloat( buffer[ 1 ] ) );
-					this.vertices.push( parseFloat( buffer[ 2 ] ) );
-					this.vertices.push( parseFloat( buffer[ 3 ] ) );
-					if ( bufferPointer > 4 ) {
-
-						this.colors.push( parseFloat( buffer[ 4 ] ) );
-						this.colors.push( parseFloat( buffer[ 5 ] ) );
-						this.colors.push( parseFloat( buffer[ 6 ] ) );
-
-					}
-					break;
-
-				case 'vt':
-					this.uvs.push( parseFloat( buffer[ 1 ] ) );
-					this.uvs.push( parseFloat( buffer[ 2 ] ) );
-					break;
-
-				case 'vn':
-					this.normals.push( parseFloat( buffer[ 1 ] ) );
-					this.normals.push( parseFloat( buffer[ 2 ] ) );
-					this.normals.push( parseFloat( buffer[ 3 ] ) );
-					break;
-
-				case 'f':
-					bufferLength = bufferPointer - 1;
-
-					// "f vertex ..."
-					if ( slashesCount === 0 ) {
-
-						this.checkFaceType( 0 );
-						for ( i = 2, length = bufferLength; i < length; i ++ ) {
-
-							this.buildFace( buffer[ 1 ] );
-							this.buildFace( buffer[ i ] );
-							this.buildFace( buffer[ i + 1 ] );
-
-						}
-
-					// "f vertex/uv ..."
-					} else if  ( bufferLength === slashesCount * 2 ) {
-
-						this.checkFaceType( 1 );
-						for ( i = 3, length = bufferLength - 2; i < length; i += 2 ) {
-
-							this.buildFace( buffer[ 1 ], buffer[ 2 ] );
-							this.buildFace( buffer[ i ], buffer[ i + 1 ] );
-							this.buildFace( buffer[ i + 2 ], buffer[ i + 3 ] );
-
-						}
-
-					// "f vertex/uv/normal ..."
-					} else if  ( bufferLength * 2 === slashesCount * 3 ) {
-
-						this.checkFaceType( 2 );
-						for ( i = 4, length = bufferLength - 3; i < length; i += 3 ) {
-
-							this.buildFace( buffer[ 1 ], buffer[ 2 ], buffer[ 3 ] );
-							this.buildFace( buffer[ i ], buffer[ i + 1 ], buffer[ i + 2 ] );
-							this.buildFace( buffer[ i + 3 ], buffer[ i + 4 ], buffer[ i + 5 ] );
-
-						}
-
-					// "f vertex//normal ..."
-					} else {
-
-						this.checkFaceType( 3 );
-						for ( i = 3, length = bufferLength - 2; i < length; i += 2 ) {
-
-							this.buildFace( buffer[ 1 ], undefined, buffer[ 2 ] );
-							this.buildFace( buffer[ i ], undefined, buffer[ i + 1 ] );
-							this.buildFace( buffer[ i + 2 ], undefined, buffer[ i + 3 ] );
-
-						}
-
-					}
-					break;
-
-				case 'l':
-				case 'p':
-					bufferLength = bufferPointer - 1;
-					if ( bufferLength === slashesCount * 2 )  {
-
-						this.checkFaceType( 4 );
-						for ( i = 1, length = bufferLength + 1; i < length; i += 2 ) this.buildFace( buffer[ i ], buffer[ i + 1 ] );
-
-					} else {
-
-						this.checkFaceType( ( lineDesignation === 'l' ) ? 5 : 6  );
-						for ( i = 1, length = bufferLength + 1; i < length; i ++ ) this.buildFace( buffer[ i ] );
-
-					}
-					break;
-
-				case 's':
-					this.pushSmoothingGroup( buffer[ 1 ] );
-					break;
-
-				case 'g':
-					// 'g' leads to creation of mesh if valid data (faces declaration was done before), otherwise only groupName gets set
-					this.processCompletedMesh();
-					this.rawMesh.groupName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 2, this.globalCounts.currentByte );
-					break;
-
-				case 'o':
-					// 'o' is meta-information and usually does not result in creation of new meshes, but can be enforced with "useOAsMesh"
-					if ( this.useOAsMesh ) this.processCompletedMesh();
-					this.rawMesh.objectName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 2, this.globalCounts.currentByte );
-					break;
-
-				case 'mtllib':
-					this.rawMesh.mtllibName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 7, this.globalCounts.currentByte );
-					break;
-
-				case 'usemtl':
-					var mtlName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 7, this.globalCounts.currentByte );
-					if ( mtlName !== '' && this.rawMesh.activeMtlName !== mtlName ) {
-
-						this.rawMesh.activeMtlName = mtlName;
-						this.rawMesh.counts.mtlCount++;
-						this.checkSubGroup();
-
-					}
-					break;
-
-				default:
-					break;
-			}
-		};
-
-		Parser.prototype.pushSmoothingGroup = function ( smoothingGroup ) {
-			var smoothingGroupInt = parseInt( smoothingGroup );
-			if ( isNaN( smoothingGroupInt ) ) {
-				smoothingGroupInt = smoothingGroup === "off" ? 0 : 1;
-			}
-
-			var smoothCheck = this.rawMesh.smoothingGroup.normalized;
-			this.rawMesh.smoothingGroup.normalized = this.rawMesh.smoothingGroup.splitMaterials ? smoothingGroupInt : ( smoothingGroupInt === 0 ) ? 0 : 1;
-			this.rawMesh.smoothingGroup.real = smoothingGroupInt;
-
-			if ( smoothCheck !== smoothingGroupInt ) {
-
-				this.rawMesh.counts.smoothingGroupCount++;
-				this.checkSubGroup();
-
-			}
-		};
-
-		/**
-		 * Expanded faceTypes include all four face types, both line types and the point type
-		 * faceType = 0: "f vertex ..."
-		 * faceType = 1: "f vertex/uv ..."
-		 * faceType = 2: "f vertex/uv/normal ..."
-		 * faceType = 3: "f vertex//normal ..."
-		 * faceType = 4: "l vertex/uv ..." or "l vertex ..."
-		 * faceType = 5: "l vertex ..."
-		 * faceType = 6: "p vertex ..."
-		 */
-		Parser.prototype.checkFaceType = function ( faceType ) {
-			if ( this.rawMesh.faceType !== faceType ) {
-
-				this.processCompletedMesh();
-				this.rawMesh.faceType = faceType;
-				this.checkSubGroup();
-
-			}
-		};
-
-		Parser.prototype.checkSubGroup = function () {
-			var index = this.rawMesh.activeMtlName + '|' + this.rawMesh.smoothingGroup.normalized;
-			this.rawMesh.subGroupInUse = this.rawMesh.subGroups[ index ];
-
-			if ( ! THREE.LoaderSupport.Validator.isValid( this.rawMesh.subGroupInUse ) ) {
-
-				this.rawMesh.subGroupInUse = {
-					index: index,
-					objectName: this.rawMesh.objectName,
-					groupName: this.rawMesh.groupName,
-					materialName: this.rawMesh.activeMtlName,
-					smoothingGroup: this.rawMesh.smoothingGroup.normalized,
-					vertices: [],
-					indexMappingsCount: 0,
-					indexMappings: [],
-					indices: [],
-					colors: [],
-					uvs: [],
-					normals: []
-				};
-				this.rawMesh.subGroups[ index ] = this.rawMesh.subGroupInUse;
-
-			}
-		};
-
-		Parser.prototype.buildFace = function ( faceIndexV, faceIndexU, faceIndexN ) {
-			if ( this.disregardNormals ) faceIndexN = undefined;
-			var scope = this;
-			var updateSubGroupInUse = function () {
-
-				var faceIndexVi = parseInt( faceIndexV );
-				var indexPointerV = 3 * ( faceIndexVi > 0 ? faceIndexVi - 1 : faceIndexVi + scope.vertices.length / 3 );
-
-				var vertices = scope.rawMesh.subGroupInUse.vertices;
-				vertices.push( scope.vertices[ indexPointerV++ ] );
-				vertices.push( scope.vertices[ indexPointerV++ ] );
-				vertices.push( scope.vertices[ indexPointerV ] );
-
-				var indexPointerC = scope.colors.length > 0 ? indexPointerV + 1 : null;
-				if ( indexPointerC !== null ) {
-
-					var colors = scope.rawMesh.subGroupInUse.colors;
-					colors.push( scope.colors[ indexPointerC++ ] );
-					colors.push( scope.colors[ indexPointerC++ ] );
-					colors.push( scope.colors[ indexPointerC ] );
-
-				}
-				if ( faceIndexU ) {
-
-					var faceIndexUi = parseInt( faceIndexU );
-					var indexPointerU = 2 * ( faceIndexUi > 0 ? faceIndexUi - 1 : faceIndexUi + scope.uvs.length / 2 );
-					var uvs = scope.rawMesh.subGroupInUse.uvs;
-					uvs.push( scope.uvs[ indexPointerU++ ] );
-					uvs.push( scope.uvs[ indexPointerU ] );
-
-				}
-				if ( faceIndexN ) {
-
-					var faceIndexNi = parseInt( faceIndexN );
-					var indexPointerN = 3 * ( faceIndexNi > 0 ? faceIndexNi - 1 : faceIndexNi + scope.normals.length / 3 );
-					var normals = scope.rawMesh.subGroupInUse.normals;
-					normals.push( scope.normals[ indexPointerN++ ] );
-					normals.push( scope.normals[ indexPointerN++ ] );
-					normals.push( scope.normals[ indexPointerN ] );
-
-				}
-			};
-
-			if ( this.useIndices ) {
-
-				var mappingName = faceIndexV + ( faceIndexU ? '_' + faceIndexU : '_n' ) + ( faceIndexN ? '_' + faceIndexN : '_n' );
-				var indicesPointer = this.rawMesh.subGroupInUse.indexMappings[ mappingName ];
-				if ( THREE.LoaderSupport.Validator.isValid( indicesPointer ) ) {
-
-					this.rawMesh.counts.doubleIndicesCount++;
-
-				} else {
-
-					indicesPointer = this.rawMesh.subGroupInUse.vertices.length / 3;
-					updateSubGroupInUse();
-					this.rawMesh.subGroupInUse.indexMappings[ mappingName ] = indicesPointer;
-					this.rawMesh.subGroupInUse.indexMappingsCount++;
-
-				}
-				this.rawMesh.subGroupInUse.indices.push( indicesPointer );
-
-			} else {
-
-				updateSubGroupInUse();
-
-			}
-			this.rawMesh.counts.faceCount++;
-		};
-
-		Parser.prototype.createRawMeshReport = function ( inputObjectCount ) {
-			return 'Input Object number: ' + inputObjectCount +
-				'\n\tObject name: ' + this.rawMesh.objectName +
-				'\n\tGroup name: ' + this.rawMesh.groupName +
-				'\n\tMtllib name: ' + this.rawMesh.mtllibName +
-				'\n\tVertex count: ' + this.vertices.length / 3 +
-				'\n\tNormal count: ' + this.normals.length / 3 +
-				'\n\tUV count: ' + this.uvs.length / 2 +
-				'\n\tSmoothingGroup count: ' + this.rawMesh.counts.smoothingGroupCount +
-				'\n\tMaterial count: ' + this.rawMesh.counts.mtlCount +
-				'\n\tReal MeshOutputGroup count: ' + this.rawMesh.subGroups.length;
-		};
-
-		/**
-		 * Clear any empty subGroup and calculate absolute vertex, normal and uv counts
-		 */
-		Parser.prototype.finalizeRawMesh = function () {
-			var meshOutputGroupTemp = [];
-			var meshOutputGroup;
-			var absoluteVertexCount = 0;
-			var absoluteIndexMappingsCount = 0;
-			var absoluteIndexCount = 0;
-			var absoluteColorCount = 0;
-			var absoluteNormalCount = 0;
-			var absoluteUvCount = 0;
-			var indices;
-			for ( var name in this.rawMesh.subGroups ) {
-
-				meshOutputGroup = this.rawMesh.subGroups[ name ];
-				if ( meshOutputGroup.vertices.length > 0 ) {
-
-					indices = meshOutputGroup.indices;
-					if ( indices.length > 0 && absoluteIndexMappingsCount > 0 ) {
-
-						for ( var i in indices ) indices[ i ] = indices[ i ] + absoluteIndexMappingsCount;
-
-					}
-					meshOutputGroupTemp.push( meshOutputGroup );
-					absoluteVertexCount += meshOutputGroup.vertices.length;
-					absoluteIndexMappingsCount += meshOutputGroup.indexMappingsCount;
-					absoluteIndexCount += meshOutputGroup.indices.length;
-					absoluteColorCount += meshOutputGroup.colors.length;
-					absoluteUvCount += meshOutputGroup.uvs.length;
-					absoluteNormalCount += meshOutputGroup.normals.length;
-
-				}
-			}
-
-			// do not continue if no result
-			var result = null;
-			if ( meshOutputGroupTemp.length > 0 ) {
-
-				result = {
-					name: this.rawMesh.groupName !== '' ? this.rawMesh.groupName : this.rawMesh.objectName,
-					subGroups: meshOutputGroupTemp,
-					absoluteVertexCount: absoluteVertexCount,
-					absoluteIndexCount: absoluteIndexCount,
-					absoluteColorCount: absoluteColorCount,
-					absoluteNormalCount: absoluteNormalCount,
-					absoluteUvCount: absoluteUvCount,
-					faceCount: this.rawMesh.counts.faceCount,
-					doubleIndicesCount: this.rawMesh.counts.doubleIndicesCount
-				};
-
-			}
-			return result;
-		};
-
-		Parser.prototype.processCompletedMesh = function () {
-			var result = this.finalizeRawMesh();
-			if ( THREE.LoaderSupport.Validator.isValid( result ) ) {
-
-				if ( this.colors.length > 0 && this.colors.length !== this.vertices.length ) {
-
-					this._throwError( 'Vertex Colors were detected, but vertex count and color count do not match!' );
-
-				}
-				if ( this.logging.enabled && this.logging.debug ) console.debug( this.createRawMeshReport( this.inputObjectCount ) );
-				this.inputObjectCount++;
-
-				this.buildMesh( result );
-				var progressBytesPercent = this.globalCounts.currentByte / this.globalCounts.totalBytes;
-				this.callbackProgress( 'Completed [o: ' + this.rawMesh.objectName + ' g:' + this.rawMesh.groupName + '] Total progress: ' + ( progressBytesPercent * 100 ).toFixed( 2 ) + '%', progressBytesPercent );
-				this.resetRawMesh();
-				return true;
-
-			} else {
-
-				return false;
-			}
-		};
-
-		/**
-		 * SubGroups are transformed to too intermediate format that is forwarded to the MeshBuilder.
-		 * It is ensured that SubGroups only contain objects with vertices (no need to check).
-		 *
-		 * @param result
-		 */
-		Parser.prototype.buildMesh = function ( result ) {
-			var meshOutputGroups = result.subGroups;
-
-			var vertexFA = new Float32Array( result.absoluteVertexCount );
-			this.globalCounts.vertices += result.absoluteVertexCount / 3;
-			this.globalCounts.faces += result.faceCount;
-			this.globalCounts.doubleIndicesCount += result.doubleIndicesCount;
-			var indexUA = ( result.absoluteIndexCount > 0 ) ? new Uint32Array( result.absoluteIndexCount ) : null;
-			var colorFA = ( result.absoluteColorCount > 0 ) ? new Float32Array( result.absoluteColorCount ) : null;
-			var normalFA = ( result.absoluteNormalCount > 0 ) ? new Float32Array( result.absoluteNormalCount ) : null;
-			var uvFA = ( result.absoluteUvCount > 0 ) ? new Float32Array( result.absoluteUvCount ) : null;
-			var haveVertexColors = THREE.LoaderSupport.Validator.isValid( colorFA );
-
-			var meshOutputGroup;
-			var materialNames = [];
-
-			var createMultiMaterial = ( meshOutputGroups.length > 1 );
-			var materialIndex = 0;
-			var materialIndexMapping = [];
-			var selectedMaterialIndex;
-			var materialGroup;
-			var materialGroups = [];
-
-			var vertexFAOffset = 0;
-			var indexUAOffset = 0;
-			var colorFAOffset = 0;
-			var normalFAOffset = 0;
-			var uvFAOffset = 0;
-			var materialGroupOffset = 0;
-			var materialGroupLength = 0;
-
-			var materialOrg, material, materialName, materialNameOrg;
-			// only one specific face type
-			for ( var oodIndex in meshOutputGroups ) {
-
-				if ( ! meshOutputGroups.hasOwnProperty( oodIndex ) ) continue;
-				meshOutputGroup = meshOutputGroups[ oodIndex ];
-
-				materialNameOrg = meshOutputGroup.materialName;
-				if ( this.rawMesh.faceType < 4 ) {
-
-					materialName = materialNameOrg + ( haveVertexColors ? '_vertexColor' : '' ) + ( meshOutputGroup.smoothingGroup === 0 ? '_flat' : '' );
-
-
-				} else {
-
-					materialName = this.rawMesh.faceType === 6 ? 'defaultPointMaterial' : 'defaultLineMaterial';
-
-				}
-				materialOrg = this.materials[ materialNameOrg ];
-				material = this.materials[ materialName ];
-
-				// both original and derived names do not lead to an existing material => need to use a default material
-				if ( ! THREE.LoaderSupport.Validator.isValid( materialOrg ) && ! THREE.LoaderSupport.Validator.isValid( material ) ) {
-
-					var defaultMaterialName = haveVertexColors ? 'defaultVertexColorMaterial' : 'defaultMaterial';
-					materialOrg = this.materials[ defaultMaterialName ];
-					if ( this.logging.enabled ) console.warn( 'object_group "' + meshOutputGroup.objectName + '_' +
-						meshOutputGroup.groupName + '" was defined with unresolvable material "' +
-						materialNameOrg + '"! Assigning "' + defaultMaterialName + '".' );
-					materialNameOrg = defaultMaterialName;
-
-					// if names are identical then there is no need for later manipulation
-					if ( materialNameOrg === materialName ) {
-
-						material = materialOrg;
-						materialName = defaultMaterialName;
-
-					}
-
-				}
-				if ( ! THREE.LoaderSupport.Validator.isValid( material ) ) {
-
-					var materialCloneInstructions = {
-						materialNameOrg: materialNameOrg,
-						materialName: materialName,
-						materialProperties: {
-							vertexColors: haveVertexColors ? 2 : 0,
-							flatShading: meshOutputGroup.smoothingGroup === 0
-						}
-					};
-					var payload = {
-						cmd: 'materialData',
-						materials: {
-							materialCloneInstructions: materialCloneInstructions
-						}
-					};
-					this.callbackMeshBuilder( payload );
-
-					// fake entry for async; sync Parser always works on material references (Builder update directly visible here)
-					if ( this.useAsync ) this.materials[ materialName ] = materialCloneInstructions;
-
-				}
-
-				if ( createMultiMaterial ) {
-
-					// re-use material if already used before. Reduces materials array size and eliminates duplicates
-					selectedMaterialIndex = materialIndexMapping[ materialName ];
-					if ( ! selectedMaterialIndex ) {
-
-						selectedMaterialIndex = materialIndex;
-						materialIndexMapping[ materialName ] = materialIndex;
-						materialNames.push( materialName );
-						materialIndex++;
-
-					}
-					materialGroupLength = this.useIndices ? meshOutputGroup.indices.length : meshOutputGroup.vertices.length / 3;
-					materialGroup = {
-						start: materialGroupOffset,
-						count: materialGroupLength,
-						index: selectedMaterialIndex
-					};
-					materialGroups.push( materialGroup );
-					materialGroupOffset += materialGroupLength;
-
-				} else {
-
-					materialNames.push( materialName );
-
-				}
-
-				vertexFA.set( meshOutputGroup.vertices, vertexFAOffset );
-				vertexFAOffset += meshOutputGroup.vertices.length;
-
-				if ( indexUA ) {
-
-					indexUA.set( meshOutputGroup.indices, indexUAOffset );
-					indexUAOffset += meshOutputGroup.indices.length;
-
-				}
-
-				if ( colorFA ) {
-
-					colorFA.set( meshOutputGroup.colors, colorFAOffset );
-					colorFAOffset += meshOutputGroup.colors.length;
-
-				}
-
-				if ( normalFA ) {
-
-					normalFA.set( meshOutputGroup.normals, normalFAOffset );
-					normalFAOffset += meshOutputGroup.normals.length;
-
-				}
-				if ( uvFA ) {
-
-					uvFA.set( meshOutputGroup.uvs, uvFAOffset );
-					uvFAOffset += meshOutputGroup.uvs.length;
-
-				}
-
-				if ( this.logging.enabled && this.logging.debug ) {
-					var materialIndexLine = THREE.LoaderSupport.Validator.isValid( selectedMaterialIndex ) ? '\n\t\tmaterialIndex: ' + selectedMaterialIndex : '';
-					var createdReport = '\tOutput Object no.: ' + this.outputObjectCount +
-						'\n\t\tgroupName: ' + meshOutputGroup.groupName +
-						'\n\t\tIndex: ' + meshOutputGroup.index +
-						'\n\t\tfaceType: ' + this.rawMesh.faceType +
-						'\n\t\tmaterialName: ' + meshOutputGroup.materialName +
-						'\n\t\tsmoothingGroup: ' + meshOutputGroup.smoothingGroup +
-						materialIndexLine +
-						'\n\t\tobjectName: ' + meshOutputGroup.objectName +
-						'\n\t\t#vertices: ' + meshOutputGroup.vertices.length / 3 +
-						'\n\t\t#indices: ' + meshOutputGroup.indices.length +
-						'\n\t\t#colors: ' + meshOutputGroup.colors.length / 3 +
-						'\n\t\t#uvs: ' + meshOutputGroup.uvs.length / 2 +
-						'\n\t\t#normals: ' + meshOutputGroup.normals.length / 3;
-					console.debug( createdReport );
-				}
-
-			}
-
-			this.outputObjectCount++;
-			this.callbackMeshBuilder(
-				{
-					cmd: 'meshData',
-					progress: {
-						numericalValue: this.globalCounts.currentByte / this.globalCounts.totalBytes
-					},
-					params: {
-						meshName: result.name
-					},
-					materials: {
-						multiMaterial: createMultiMaterial,
-						materialNames: materialNames,
-						materialGroups: materialGroups
-					},
-					buffers: {
-						vertices: vertexFA,
-						indices: indexUA,
-						colors: colorFA,
-						normals: normalFA,
-						uvs: uvFA
-					},
-					// 0: mesh, 1: line, 2: point
-					geometryType: this.rawMesh.faceType < 4 ? 0 : ( this.rawMesh.faceType === 6 ) ? 2 : 1
-				},
-				[ vertexFA.buffer ],
-				THREE.LoaderSupport.Validator.isValid( indexUA ) ? [ indexUA.buffer ] : null,
-				THREE.LoaderSupport.Validator.isValid( colorFA ) ? [ colorFA.buffer ] : null,
-				THREE.LoaderSupport.Validator.isValid( normalFA ) ? [ normalFA.buffer ] : null,
-				THREE.LoaderSupport.Validator.isValid( uvFA ) ? [ uvFA.buffer ] : null
-			);
-		};
-
-		Parser.prototype.finalizeParsing = function () {
-			if ( this.logging.enabled ) console.info( 'Global output object count: ' + this.outputObjectCount );
-			if ( this.processCompletedMesh() && this.logging.enabled ) {
-
-				var parserFinalReport = 'Overall counts: ' +
-					'\n\tVertices: ' + this.globalCounts.vertices +
-					'\n\tFaces: ' + this.globalCounts.faces +
-					'\n\tMultiple definitions: ' + this.globalCounts.doubleIndicesCount;
-				console.info( parserFinalReport );
-
-			}
-		};
-
-		return Parser;
-	})();
+	},
 
 	/**
 	 * Utility method for loading an mtl file according resource description. Provide url or content.
-	 * @memberOf THREE.OBJLoader2
 	 *
 	 * @param {string} url URL to the file
 	 * @param {Object} content The file content as arraybuffer or text
@@ -1354,22 +493,21 @@ THREE.OBJLoader2 = (function () {
 	 * @param {string} [crossOrigin] CORS value
  	 * @param {Object} [materialOptions] Set material loading options for MTLLoader
 	 */
-	OBJLoader2.prototype.loadMtl = function ( url, content, onLoad, onProgress, onError, crossOrigin, materialOptions ) {
+	loadMtl: function ( url, content, onLoad, onProgress, onError, crossOrigin, materialOptions ) {
 		var resource = new THREE.LoaderSupport.ResourceDescriptor( url, 'MTL' );
 		resource.setContent( content );
 		this._loadMtl( resource, onLoad, onProgress, onError, crossOrigin, materialOptions );
-	};
+	},
 
-
-	OBJLoader2.prototype._loadMtl = function ( resource, onLoad, onProgress, onError, crossOrigin, materialOptions ) {
+	_loadMtl: function ( resource, onLoad, onProgress, onError, crossOrigin, materialOptions ) {
 		if ( THREE.MTLLoader === undefined ) console.error( '"THREE.MTLLoader" is not available. "THREE.OBJLoader2" requires it for loading MTL files.' );
-		if ( Validator.isValid( resource ) && this.logging.enabled ) console.time( 'Loading MTL: ' + resource.name );
+		if ( THREE.LoaderSupport.Validator.isValid( resource ) && this.logging.enabled ) console.time( 'Loading MTL: ' + resource.name );
 
 		var materials = [];
 		var scope = this;
 		var processMaterials = function ( materialCreator ) {
 			var materialCreatorMaterials = [];
-			if ( Validator.isValid( materialCreator ) ) {
+			if ( THREE.LoaderSupport.Validator.isValid( materialCreator ) ) {
 
 				materialCreator.preload();
 				materialCreatorMaterials = materialCreator.materials;
@@ -1383,22 +521,22 @@ THREE.OBJLoader2 = (function () {
 				}
 			}
 
-			if ( Validator.isValid( resource ) && scope.logging.enabled ) console.timeEnd( 'Loading MTL: ' + resource.name );
+			if ( THREE.LoaderSupport.Validator.isValid( resource ) && scope.logging.enabled ) console.timeEnd( 'Loading MTL: ' + resource.name );
 			onLoad( materials, materialCreator );
 		};
 
 		// fast-fail
-		if ( ! Validator.isValid( resource ) || ( ! Validator.isValid( resource.content ) && ! Validator.isValid( resource.url ) ) ) {
+		if ( ! THREE.LoaderSupport.Validator.isValid( resource ) || ( ! THREE.LoaderSupport.Validator.isValid( resource.content ) && ! THREE.LoaderSupport.Validator.isValid( resource.url ) ) ) {
 
 			processMaterials();
 
 		} else {
 
 			var mtlLoader = new THREE.MTLLoader( this.manager );
-			crossOrigin = Validator.verifyInput( crossOrigin, 'anonymous' );
+			crossOrigin = THREE.LoaderSupport.Validator.verifyInput( crossOrigin, 'anonymous' );
 			mtlLoader.setCrossOrigin( crossOrigin );
-			mtlLoader.setResourcePath( resource.path );
-			if ( Validator.isValid( materialOptions ) ) mtlLoader.setMaterialOptions( materialOptions );
+			mtlLoader.setResourcePath( resource.resourcePath || resource.path );
+			if ( THREE.LoaderSupport.Validator.isValid( materialOptions ) ) mtlLoader.setMaterialOptions( materialOptions );
 
 			var parseTextWithMtlLoader = function ( content ) {
 				var contentAsText = content;
@@ -1417,19 +555,19 @@ THREE.OBJLoader2 = (function () {
 				processMaterials( mtlLoader.parse( contentAsText ) );
 			};
 
-			if ( Validator.isValid( resource.content ) ) {
+			if ( THREE.LoaderSupport.Validator.isValid( resource.content ) ) {
 
 				parseTextWithMtlLoader( resource.content );
 
-			} else if ( Validator.isValid( resource.url ) ) {
+			} else if ( THREE.LoaderSupport.Validator.isValid( resource.url ) ) {
 
 				var fileLoader = new THREE.FileLoader( this.manager );
-				if ( ! Validator.isValid( onError ) ) {
+				if ( ! THREE.LoaderSupport.Validator.isValid( onError ) ) {
 					onError = function ( event ) {
 						scope._onError( event );
-					};
+					}
 				}
-				if ( ! Validator.isValid( onProgress ) ) {
+				if ( ! THREE.LoaderSupport.Validator.isValid( onProgress ) ) {
 					var numericalValueRef = 0;
 					var numericalValue = 0;
 					onProgress = function ( event ) {
@@ -1450,7 +588,862 @@ THREE.OBJLoader2 = (function () {
 
 			}
 		}
+	}
+};
+
+
+/**
+ * Parse OBJ data either from ArrayBuffer or string
+ * @class
+ */
+THREE.OBJLoader2.Parser = function () {
+	this.callbackProgress = null;
+	this.callbackMeshBuilder = null;
+	this.contentRef = null;
+	this.legacyMode = false;
+
+	this.materials = {};
+	this.useAsync = false;
+	this.materialPerSmoothingGroup = false;
+	this.useOAsMesh = false;
+	this.useIndices = false;
+	this.disregardNormals = false;
+
+	this.vertices = [];
+	this.colors = [];
+	this.normals = [];
+	this.uvs = [];
+
+	this.rawMesh = {
+		objectName: '',
+		groupName: '',
+		activeMtlName: '',
+		mtllibName: '',
+
+		// reset with new mesh
+		faceType: -1,
+		subGroups: [],
+		subGroupInUse: null,
+		smoothingGroup: {
+			splitMaterials: false,
+			normalized: -1,
+			real: -1
+		},
+		counts: {
+			doubleIndicesCount: 0,
+			faceCount: 0,
+			mtlCount: 0,
+			smoothingGroupCount: 0
+		}
 	};
 
-	return OBJLoader2;
-})();
+	this.inputObjectCount = 1;
+	this.outputObjectCount = 1;
+	this.globalCounts = {
+		vertices: 0,
+		faces: 0,
+		doubleIndicesCount: 0,
+		lineByte: 0,
+		currentByte: 0,
+		totalBytes: 0
+	};
+
+	this.logging = {
+		enabled: true,
+		debug: false
+	};
+};
+
+
+THREE.OBJLoader2.Parser.prototype = {
+
+	constructor: THREE.OBJLoader2.Parser,
+
+	resetRawMesh: function () {
+		// faces are stored according combined index of group, material and smoothingGroup (0 or not)
+		this.rawMesh.subGroups = [];
+		this.rawMesh.subGroupInUse = null;
+		this.rawMesh.smoothingGroup.normalized = -1;
+		this.rawMesh.smoothingGroup.real = -1;
+
+		// this default index is required as it is possible to define faces without 'g' or 'usemtl'
+		this.pushSmoothingGroup( 1 );
+
+		this.rawMesh.counts.doubleIndicesCount = 0;
+		this.rawMesh.counts.faceCount = 0;
+		this.rawMesh.counts.mtlCount = 0;
+		this.rawMesh.counts.smoothingGroupCount = 0;
+	},
+
+	setUseAsync: function ( useAsync ) {
+		this.useAsync = useAsync;
+	},
+
+	setMaterialPerSmoothingGroup: function ( materialPerSmoothingGroup ) {
+		this.materialPerSmoothingGroup = materialPerSmoothingGroup;
+	},
+
+	setUseOAsMesh: function ( useOAsMesh ) {
+		this.useOAsMesh = useOAsMesh;
+	},
+
+	setUseIndices: function ( useIndices ) {
+		this.useIndices = useIndices;
+	},
+
+	setDisregardNormals: function ( disregardNormals ) {
+		this.disregardNormals = disregardNormals;
+	},
+
+	setMaterials: function ( materials ) {
+		this.materials = THREE.LoaderSupport.Validator.verifyInput( materials, this.materials );
+		this.materials = THREE.LoaderSupport.Validator.verifyInput( this.materials, {} );
+	},
+
+	setCallbackMeshBuilder: function ( callbackMeshBuilder ) {
+		if ( ! THREE.LoaderSupport.Validator.isValid( callbackMeshBuilder ) ) {
+
+			this._throwError( 'Unable to run as no "MeshBuilder" callback is set.' );
+
+		}
+		this.callbackMeshBuilder = callbackMeshBuilder;
+	},
+
+	setCallbackProgress: function ( callbackProgress ) {
+		this.callbackProgress = callbackProgress;
+	},
+
+	setLogging: function ( enabled, debug ) {
+		this.logging.enabled = enabled === true;
+		this.logging.debug = debug === true;
+	},
+
+	configure: function () {
+		this.pushSmoothingGroup( 1 );
+
+		if ( this.logging.enabled ) {
+
+			var matKeys = Object.keys( this.materials );
+			var matNames = ( matKeys.length > 0 ) ? '\n\tmaterialNames:\n\t\t- ' + matKeys.join( '\n\t\t- ' ) : '\n\tmaterialNames: None';
+			var printedConfig = 'OBJLoader2.Parser configuration:'
+				+ matNames
+				+ '\n\tuseAsync: ' + this.useAsync
+				+ '\n\tmaterialPerSmoothingGroup: ' + this.materialPerSmoothingGroup
+				+ '\n\tuseOAsMesh: ' + this.useOAsMesh
+				+ '\n\tuseIndices: ' + this.useIndices
+				+ '\n\tdisregardNormals: ' + this.disregardNormals
+				+ '\n\tcallbackMeshBuilderName: ' + this.callbackMeshBuilder.name
+				+ '\n\tcallbackProgressName: ' + this.callbackProgress.name;
+			console.info( printedConfig );
+		}
+	},
+
+	/**
+	 * Parse the provided arraybuffer
+	 *
+	 * @param {Uint8Array} arrayBuffer OBJ data as Uint8Array
+	 */
+	parse: function ( arrayBuffer ) {
+		if ( this.logging.enabled ) console.time( 'OBJLoader2.Parser.parse' );
+		this.configure();
+
+		var arrayBufferView = new Uint8Array( arrayBuffer );
+		this.contentRef = arrayBufferView;
+		var length = arrayBufferView.byteLength;
+		this.globalCounts.totalBytes = length;
+		var buffer = new Array( 128 );
+
+		for ( var code, word = '', bufferPointer = 0, slashesCount = 0, i = 0; i < length; i++ ) {
+
+			code = arrayBufferView[ i ];
+			switch ( code ) {
+				// space
+				case 32:
+					if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
+					word = '';
+					break;
+				// slash
+				case 47:
+					if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
+					slashesCount++;
+					word = '';
+					break;
+
+				// LF
+				case 10:
+					if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
+					word = '';
+					this.globalCounts.lineByte = this.globalCounts.currentByte;
+					this.globalCounts.currentByte = i;
+					this.processLine( buffer, bufferPointer, slashesCount );
+					bufferPointer = 0;
+					slashesCount = 0;
+					break;
+
+				// CR
+				case 13:
+					break;
+
+				default:
+					word += String.fromCharCode( code );
+					break;
+			}
+		}
+		this.finalizeParsing();
+		if ( this.logging.enabled ) console.timeEnd(  'OBJLoader2.Parser.parse' );
+	},
+
+	/**
+	 * Parse the provided text
+	 *
+	 * @param {string} text OBJ data as string
+	 */
+	parseText: function ( text ) {
+		if ( this.logging.enabled ) console.time(  'OBJLoader2.Parser.parseText' );
+		this.configure();
+		this.legacyMode = true;
+		this.contentRef = text;
+		var length = text.length;
+		this.globalCounts.totalBytes = length;
+		var buffer = new Array( 128 );
+
+		for ( var char, word = '', bufferPointer = 0, slashesCount = 0, i = 0; i < length; i++ ) {
+
+			char = text[ i ];
+			switch ( char ) {
+				case ' ':
+					if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
+					word = '';
+					break;
+
+				case '/':
+					if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
+					slashesCount++;
+					word = '';
+					break;
+
+				case '\n':
+					if ( word.length > 0 ) buffer[ bufferPointer++ ] = word;
+					word = '';
+					this.globalCounts.lineByte = this.globalCounts.currentByte;
+					this.globalCounts.currentByte = i;
+					this.processLine( buffer, bufferPointer, slashesCount );
+					bufferPointer = 0;
+					slashesCount = 0;
+					break;
+
+				case '\r':
+					break;
+
+				default:
+					word += char;
+			}
+		}
+		this.finalizeParsing();
+		if ( this.logging.enabled ) console.timeEnd( 'OBJLoader2.Parser.parseText' );
+	},
+
+	processLine: function ( buffer, bufferPointer, slashesCount ) {
+		if ( bufferPointer < 1 ) return;
+
+		var reconstructString = function ( content, legacyMode, start, stop ) {
+			var line = '';
+			if ( stop > start ) {
+
+				var i;
+				if ( legacyMode ) {
+
+					for ( i = start; i < stop; i++ ) line += content[ i ];
+
+				} else {
+
+
+					for ( i = start; i < stop; i++ ) line += String.fromCharCode( content[ i ] );
+
+				}
+				line = line.trim();
+
+			}
+			return line;
+		};
+
+		var bufferLength, length, i, lineDesignation;
+		lineDesignation = buffer [ 0 ];
+		switch ( lineDesignation ) {
+			case 'v':
+				this.vertices.push( parseFloat( buffer[ 1 ] ) );
+				this.vertices.push( parseFloat( buffer[ 2 ] ) );
+				this.vertices.push( parseFloat( buffer[ 3 ] ) );
+				if ( bufferPointer > 4 ) {
+
+					this.colors.push( parseFloat( buffer[ 4 ] ) );
+					this.colors.push( parseFloat( buffer[ 5 ] ) );
+					this.colors.push( parseFloat( buffer[ 6 ] ) );
+
+				}
+				break;
+
+			case 'vt':
+				this.uvs.push( parseFloat( buffer[ 1 ] ) );
+				this.uvs.push( parseFloat( buffer[ 2 ] ) );
+				break;
+
+			case 'vn':
+				this.normals.push( parseFloat( buffer[ 1 ] ) );
+				this.normals.push( parseFloat( buffer[ 2 ] ) );
+				this.normals.push( parseFloat( buffer[ 3 ] ) );
+				break;
+
+			case 'f':
+				bufferLength = bufferPointer - 1;
+
+				// "f vertex ..."
+				if ( slashesCount === 0 ) {
+
+					this.checkFaceType( 0 );
+					for ( i = 2, length = bufferLength; i < length; i ++ ) {
+
+						this.buildFace( buffer[ 1 ] );
+						this.buildFace( buffer[ i ] );
+						this.buildFace( buffer[ i + 1 ] );
+
+					}
+
+					// "f vertex/uv ..."
+				} else if  ( bufferLength === slashesCount * 2 ) {
+
+					this.checkFaceType( 1 );
+					for ( i = 3, length = bufferLength - 2; i < length; i += 2 ) {
+
+						this.buildFace( buffer[ 1 ], buffer[ 2 ] );
+						this.buildFace( buffer[ i ], buffer[ i + 1 ] );
+						this.buildFace( buffer[ i + 2 ], buffer[ i + 3 ] );
+
+					}
+
+					// "f vertex/uv/normal ..."
+				} else if  ( bufferLength * 2 === slashesCount * 3 ) {
+
+					this.checkFaceType( 2 );
+					for ( i = 4, length = bufferLength - 3; i < length; i += 3 ) {
+
+						this.buildFace( buffer[ 1 ], buffer[ 2 ], buffer[ 3 ] );
+						this.buildFace( buffer[ i ], buffer[ i + 1 ], buffer[ i + 2 ] );
+						this.buildFace( buffer[ i + 3 ], buffer[ i + 4 ], buffer[ i + 5 ] );
+
+					}
+
+					// "f vertex//normal ..."
+				} else {
+
+					this.checkFaceType( 3 );
+					for ( i = 3, length = bufferLength - 2; i < length; i += 2 ) {
+
+						this.buildFace( buffer[ 1 ], undefined, buffer[ 2 ] );
+						this.buildFace( buffer[ i ], undefined, buffer[ i + 1 ] );
+						this.buildFace( buffer[ i + 2 ], undefined, buffer[ i + 3 ] );
+
+					}
+
+				}
+				break;
+
+			case 'l':
+			case 'p':
+				bufferLength = bufferPointer - 1;
+				if ( bufferLength === slashesCount * 2 )  {
+
+					this.checkFaceType( 4 );
+					for ( i = 1, length = bufferLength + 1; i < length; i += 2 ) this.buildFace( buffer[ i ], buffer[ i + 1 ] );
+
+				} else {
+
+					this.checkFaceType( ( lineDesignation === 'l' ) ? 5 : 6  );
+					for ( i = 1, length = bufferLength + 1; i < length; i ++ ) this.buildFace( buffer[ i ] );
+
+				}
+				break;
+
+			case 's':
+				this.pushSmoothingGroup( buffer[ 1 ] );
+				break;
+
+			case 'g':
+				// 'g' leads to creation of mesh if valid data (faces declaration was done before), otherwise only groupName gets set
+				this.processCompletedMesh();
+				this.rawMesh.groupName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 2, this.globalCounts.currentByte );
+				break;
+
+			case 'o':
+				// 'o' is meta-information and usually does not result in creation of new meshes, but can be enforced with "useOAsMesh"
+				if ( this.useOAsMesh ) this.processCompletedMesh();
+				this.rawMesh.objectName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 2, this.globalCounts.currentByte );
+				break;
+
+			case 'mtllib':
+				this.rawMesh.mtllibName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 7, this.globalCounts.currentByte );
+				break;
+
+			case 'usemtl':
+				var mtlName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 7, this.globalCounts.currentByte );
+				if ( mtlName !== '' && this.rawMesh.activeMtlName !== mtlName ) {
+
+					this.rawMesh.activeMtlName = mtlName;
+					this.rawMesh.counts.mtlCount++;
+					this.checkSubGroup();
+
+				}
+				break;
+
+			default:
+				break;
+		}
+	},
+
+	pushSmoothingGroup: function ( smoothingGroup ) {
+		var smoothingGroupInt = parseInt( smoothingGroup );
+		if ( isNaN( smoothingGroupInt ) ) {
+			smoothingGroupInt = smoothingGroup === "off" ? 0 : 1;
+		}
+
+		var smoothCheck = this.rawMesh.smoothingGroup.normalized;
+		this.rawMesh.smoothingGroup.normalized = this.rawMesh.smoothingGroup.splitMaterials ? smoothingGroupInt : ( smoothingGroupInt === 0 ) ? 0 : 1;
+		this.rawMesh.smoothingGroup.real = smoothingGroupInt;
+
+		if ( smoothCheck !== smoothingGroupInt ) {
+
+			this.rawMesh.counts.smoothingGroupCount++;
+			this.checkSubGroup();
+
+		}
+	},
+
+	/**
+	 * Expanded faceTypes include all four face types, both line types and the point type
+	 * faceType = 0: "f vertex ..."
+	 * faceType = 1: "f vertex/uv ..."
+	 * faceType = 2: "f vertex/uv/normal ..."
+	 * faceType = 3: "f vertex//normal ..."
+	 * faceType = 4: "l vertex/uv ..." or "l vertex ..."
+	 * faceType = 5: "l vertex ..."
+	 * faceType = 6: "p vertex ..."
+	 */
+	checkFaceType: function ( faceType ) {
+		if ( this.rawMesh.faceType !== faceType ) {
+
+			this.processCompletedMesh();
+			this.rawMesh.faceType = faceType;
+			this.checkSubGroup();
+
+		}
+	},
+
+	checkSubGroup: function () {
+		var index = this.rawMesh.activeMtlName + '|' + this.rawMesh.smoothingGroup.normalized;
+		this.rawMesh.subGroupInUse = this.rawMesh.subGroups[ index ];
+
+		if ( ! THREE.LoaderSupport.Validator.isValid( this.rawMesh.subGroupInUse ) ) {
+
+			this.rawMesh.subGroupInUse = {
+				index: index,
+				objectName: this.rawMesh.objectName,
+				groupName: this.rawMesh.groupName,
+				materialName: this.rawMesh.activeMtlName,
+				smoothingGroup: this.rawMesh.smoothingGroup.normalized,
+				vertices: [],
+				indexMappingsCount: 0,
+				indexMappings: [],
+				indices: [],
+				colors: [],
+				uvs: [],
+				normals: []
+			};
+			this.rawMesh.subGroups[ index ] = this.rawMesh.subGroupInUse;
+
+		}
+	},
+
+	buildFace: function ( faceIndexV, faceIndexU, faceIndexN ) {
+		if ( this.disregardNormals ) faceIndexN = undefined;
+		var scope = this;
+		var updateSubGroupInUse = function () {
+
+			var faceIndexVi = parseInt( faceIndexV );
+			var indexPointerV = 3 * ( faceIndexVi > 0 ? faceIndexVi - 1 : faceIndexVi + scope.vertices.length / 3 );
+			var indexPointerC = scope.colors.length > 0 ? indexPointerV : null;
+
+			var vertices = scope.rawMesh.subGroupInUse.vertices;
+			vertices.push( scope.vertices[ indexPointerV++ ] );
+			vertices.push( scope.vertices[ indexPointerV++ ] );
+			vertices.push( scope.vertices[ indexPointerV ] );
+
+			if ( indexPointerC !== null ) {
+
+				var colors = scope.rawMesh.subGroupInUse.colors;
+				colors.push( scope.colors[ indexPointerC++ ] );
+				colors.push( scope.colors[ indexPointerC++ ] );
+				colors.push( scope.colors[ indexPointerC ] );
+
+			}
+			if ( faceIndexU ) {
+
+				var faceIndexUi = parseInt( faceIndexU );
+				var indexPointerU = 2 * ( faceIndexUi > 0 ? faceIndexUi - 1 : faceIndexUi + scope.uvs.length / 2 );
+				var uvs = scope.rawMesh.subGroupInUse.uvs;
+				uvs.push( scope.uvs[ indexPointerU++ ] );
+				uvs.push( scope.uvs[ indexPointerU ] );
+
+			}
+			if ( faceIndexN ) {
+
+				var faceIndexNi = parseInt( faceIndexN );
+				var indexPointerN = 3 * ( faceIndexNi > 0 ? faceIndexNi - 1 : faceIndexNi + scope.normals.length / 3 );
+				var normals = scope.rawMesh.subGroupInUse.normals;
+				normals.push( scope.normals[ indexPointerN++ ] );
+				normals.push( scope.normals[ indexPointerN++ ] );
+				normals.push( scope.normals[ indexPointerN ] );
+
+			}
+		};
+
+		if ( this.useIndices ) {
+
+			var mappingName = faceIndexV + ( faceIndexU ? '_' + faceIndexU : '_n' ) + ( faceIndexN ? '_' + faceIndexN : '_n' );
+			var indicesPointer = this.rawMesh.subGroupInUse.indexMappings[ mappingName ];
+			if ( THREE.LoaderSupport.Validator.isValid( indicesPointer ) ) {
+
+				this.rawMesh.counts.doubleIndicesCount++;
+
+			} else {
+
+				indicesPointer = this.rawMesh.subGroupInUse.vertices.length / 3;
+				updateSubGroupInUse();
+				this.rawMesh.subGroupInUse.indexMappings[ mappingName ] = indicesPointer;
+				this.rawMesh.subGroupInUse.indexMappingsCount++;
+
+			}
+			this.rawMesh.subGroupInUse.indices.push( indicesPointer );
+
+		} else {
+
+			updateSubGroupInUse();
+
+		}
+		this.rawMesh.counts.faceCount++;
+	},
+
+	createRawMeshReport: function ( inputObjectCount ) {
+		return 'Input Object number: ' + inputObjectCount +
+			'\n\tObject name: ' + this.rawMesh.objectName +
+			'\n\tGroup name: ' + this.rawMesh.groupName +
+			'\n\tMtllib name: ' + this.rawMesh.mtllibName +
+			'\n\tVertex count: ' + this.vertices.length / 3 +
+			'\n\tNormal count: ' + this.normals.length / 3 +
+			'\n\tUV count: ' + this.uvs.length / 2 +
+			'\n\tSmoothingGroup count: ' + this.rawMesh.counts.smoothingGroupCount +
+			'\n\tMaterial count: ' + this.rawMesh.counts.mtlCount +
+			'\n\tReal MeshOutputGroup count: ' + this.rawMesh.subGroups.length;
+	},
+
+	/**
+	 * Clear any empty subGroup and calculate absolute vertex, normal and uv counts
+	 */
+	finalizeRawMesh: function () {
+		var meshOutputGroupTemp = [];
+		var meshOutputGroup;
+		var absoluteVertexCount = 0;
+		var absoluteIndexMappingsCount = 0;
+		var absoluteIndexCount = 0;
+		var absoluteColorCount = 0;
+		var absoluteNormalCount = 0;
+		var absoluteUvCount = 0;
+		var indices;
+		for ( var name in this.rawMesh.subGroups ) {
+
+			meshOutputGroup = this.rawMesh.subGroups[ name ];
+			if ( meshOutputGroup.vertices.length > 0 ) {
+
+				indices = meshOutputGroup.indices;
+				if ( indices.length > 0 && absoluteIndexMappingsCount > 0 ) {
+
+					for ( var i in indices ) indices[ i ] = indices[ i ] + absoluteIndexMappingsCount;
+
+				}
+				meshOutputGroupTemp.push( meshOutputGroup );
+				absoluteVertexCount += meshOutputGroup.vertices.length;
+				absoluteIndexMappingsCount += meshOutputGroup.indexMappingsCount;
+				absoluteIndexCount += meshOutputGroup.indices.length;
+				absoluteColorCount += meshOutputGroup.colors.length;
+				absoluteUvCount += meshOutputGroup.uvs.length;
+				absoluteNormalCount += meshOutputGroup.normals.length;
+
+			}
+		}
+
+		// do not continue if no result
+		var result = null;
+		if ( meshOutputGroupTemp.length > 0 ) {
+
+			result = {
+				name: this.rawMesh.groupName !== '' ? this.rawMesh.groupName : this.rawMesh.objectName,
+				subGroups: meshOutputGroupTemp,
+				absoluteVertexCount: absoluteVertexCount,
+				absoluteIndexCount: absoluteIndexCount,
+				absoluteColorCount: absoluteColorCount,
+				absoluteNormalCount: absoluteNormalCount,
+				absoluteUvCount: absoluteUvCount,
+				faceCount: this.rawMesh.counts.faceCount,
+				doubleIndicesCount: this.rawMesh.counts.doubleIndicesCount
+			};
+
+		}
+		return result;
+	},
+
+	processCompletedMesh: function () {
+		var result = this.finalizeRawMesh();
+		if ( THREE.LoaderSupport.Validator.isValid( result ) ) {
+
+			if ( this.colors.length > 0 && this.colors.length !== this.vertices.length ) {
+
+				this._throwError( 'Vertex Colors were detected, but vertex count and color count do not match!' );
+
+			}
+			if ( this.logging.enabled && this.logging.debug ) console.debug( this.createRawMeshReport( this.inputObjectCount ) );
+			this.inputObjectCount++;
+
+			this.buildMesh( result );
+			var progressBytesPercent = this.globalCounts.currentByte / this.globalCounts.totalBytes;
+			this.callbackProgress( 'Completed [o: ' + this.rawMesh.objectName + ' g:' + this.rawMesh.groupName + '] Total progress: ' + ( progressBytesPercent * 100 ).toFixed( 2 ) + '%', progressBytesPercent );
+			this.resetRawMesh();
+			return true;
+
+		} else {
+
+			return false;
+		}
+	},
+
+	/**
+	 * SubGroups are transformed to too intermediate format that is forwarded to the MeshBuilder.
+	 * It is ensured that SubGroups only contain objects with vertices (no need to check).
+	 *
+	 * @param result
+	 */
+	buildMesh: function ( result ) {
+		var meshOutputGroups = result.subGroups;
+
+		var vertexFA = new Float32Array( result.absoluteVertexCount );
+		this.globalCounts.vertices += result.absoluteVertexCount / 3;
+		this.globalCounts.faces += result.faceCount;
+		this.globalCounts.doubleIndicesCount += result.doubleIndicesCount;
+		var indexUA = ( result.absoluteIndexCount > 0 ) ? new Uint32Array( result.absoluteIndexCount ) : null;
+		var colorFA = ( result.absoluteColorCount > 0 ) ? new Float32Array( result.absoluteColorCount ) : null;
+		var normalFA = ( result.absoluteNormalCount > 0 ) ? new Float32Array( result.absoluteNormalCount ) : null;
+		var uvFA = ( result.absoluteUvCount > 0 ) ? new Float32Array( result.absoluteUvCount ) : null;
+		var haveVertexColors = THREE.LoaderSupport.Validator.isValid( colorFA );
+
+		var meshOutputGroup;
+		var materialNames = [];
+
+		var createMultiMaterial = ( meshOutputGroups.length > 1 );
+		var materialIndex = 0;
+		var materialIndexMapping = [];
+		var selectedMaterialIndex;
+		var materialGroup;
+		var materialGroups = [];
+
+		var vertexFAOffset = 0;
+		var indexUAOffset = 0;
+		var colorFAOffset = 0;
+		var normalFAOffset = 0;
+		var uvFAOffset = 0;
+		var materialGroupOffset = 0;
+		var materialGroupLength = 0;
+
+		var materialOrg, material, materialName, materialNameOrg;
+		// only one specific face type
+		for ( var oodIndex in meshOutputGroups ) {
+
+			if ( ! meshOutputGroups.hasOwnProperty( oodIndex ) ) continue;
+			meshOutputGroup = meshOutputGroups[ oodIndex ];
+
+			materialNameOrg = meshOutputGroup.materialName;
+			if ( this.rawMesh.faceType < 4 ) {
+
+				materialName = materialNameOrg + ( haveVertexColors ? '_vertexColor' : '' ) + ( meshOutputGroup.smoothingGroup === 0 ? '_flat' : '' );
+
+
+			} else {
+
+				materialName = this.rawMesh.faceType === 6 ? 'defaultPointMaterial' : 'defaultLineMaterial';
+
+			}
+			materialOrg = this.materials[ materialNameOrg ];
+			material = this.materials[ materialName ];
+
+			// both original and derived names do not lead to an existing material => need to use a default material
+			if ( ! THREE.LoaderSupport.Validator.isValid( materialOrg ) && ! THREE.LoaderSupport.Validator.isValid( material ) ) {
+
+				var defaultMaterialName = haveVertexColors ? 'defaultVertexColorMaterial' : 'defaultMaterial';
+				materialOrg = this.materials[ defaultMaterialName ];
+				if ( this.logging.enabled ) console.warn( 'object_group "' + meshOutputGroup.objectName + '_' +
+					meshOutputGroup.groupName + '" was defined with unresolvable material "' +
+					materialNameOrg + '"! Assigning "' + defaultMaterialName + '".' );
+				materialNameOrg = defaultMaterialName;
+
+				// if names are identical then there is no need for later manipulation
+				if ( materialNameOrg === materialName ) {
+
+					material = materialOrg;
+					materialName = defaultMaterialName;
+
+				}
+
+			}
+			if ( ! THREE.LoaderSupport.Validator.isValid( material ) ) {
+
+				var materialCloneInstructions = {
+					materialNameOrg: materialNameOrg,
+					materialName: materialName,
+					materialProperties: {
+						vertexColors: haveVertexColors ? 2 : 0,
+						flatShading: meshOutputGroup.smoothingGroup === 0
+					}
+				};
+				var payload = {
+					cmd: 'materialData',
+					materials: {
+						materialCloneInstructions: materialCloneInstructions
+					}
+				};
+				this.callbackMeshBuilder( payload );
+
+				// fake entry for async; sync Parser always works on material references (Builder update directly visible here)
+				if ( this.useAsync ) this.materials[ materialName ] = materialCloneInstructions;
+
+			}
+
+			if ( createMultiMaterial ) {
+
+				// re-use material if already used before. Reduces materials array size and eliminates duplicates
+				selectedMaterialIndex = materialIndexMapping[ materialName ];
+				if ( ! selectedMaterialIndex ) {
+
+					selectedMaterialIndex = materialIndex;
+					materialIndexMapping[ materialName ] = materialIndex;
+					materialNames.push( materialName );
+					materialIndex++;
+
+				}
+				materialGroupLength = this.useIndices ? meshOutputGroup.indices.length : meshOutputGroup.vertices.length / 3;
+				materialGroup = {
+					start: materialGroupOffset,
+					count: materialGroupLength,
+					index: selectedMaterialIndex
+				};
+				materialGroups.push( materialGroup );
+				materialGroupOffset += materialGroupLength;
+
+			} else {
+
+				materialNames.push( materialName );
+
+			}
+
+			vertexFA.set( meshOutputGroup.vertices, vertexFAOffset );
+			vertexFAOffset += meshOutputGroup.vertices.length;
+
+			if ( indexUA ) {
+
+				indexUA.set( meshOutputGroup.indices, indexUAOffset );
+				indexUAOffset += meshOutputGroup.indices.length;
+
+			}
+
+			if ( colorFA ) {
+
+				colorFA.set( meshOutputGroup.colors, colorFAOffset );
+				colorFAOffset += meshOutputGroup.colors.length;
+
+			}
+
+			if ( normalFA ) {
+
+				normalFA.set( meshOutputGroup.normals, normalFAOffset );
+				normalFAOffset += meshOutputGroup.normals.length;
+
+			}
+			if ( uvFA ) {
+
+				uvFA.set( meshOutputGroup.uvs, uvFAOffset );
+				uvFAOffset += meshOutputGroup.uvs.length;
+
+			}
+
+			if ( this.logging.enabled && this.logging.debug ) {
+				var materialIndexLine = THREE.LoaderSupport.Validator.isValid( selectedMaterialIndex ) ? '\n\t\tmaterialIndex: ' + selectedMaterialIndex : '';
+				var createdReport = '\tOutput Object no.: ' + this.outputObjectCount +
+					'\n\t\tgroupName: ' + meshOutputGroup.groupName +
+					'\n\t\tIndex: ' + meshOutputGroup.index +
+					'\n\t\tfaceType: ' + this.rawMesh.faceType +
+					'\n\t\tmaterialName: ' + meshOutputGroup.materialName +
+					'\n\t\tsmoothingGroup: ' + meshOutputGroup.smoothingGroup +
+					materialIndexLine +
+					'\n\t\tobjectName: ' + meshOutputGroup.objectName +
+					'\n\t\t#vertices: ' + meshOutputGroup.vertices.length / 3 +
+					'\n\t\t#indices: ' + meshOutputGroup.indices.length +
+					'\n\t\t#colors: ' + meshOutputGroup.colors.length / 3 +
+					'\n\t\t#uvs: ' + meshOutputGroup.uvs.length / 2 +
+					'\n\t\t#normals: ' + meshOutputGroup.normals.length / 3;
+				console.debug( createdReport );
+			}
+
+		}
+
+		this.outputObjectCount++;
+		this.callbackMeshBuilder(
+			{
+				cmd: 'meshData',
+				progress: {
+					numericalValue: this.globalCounts.currentByte / this.globalCounts.totalBytes
+				},
+				params: {
+					meshName: result.name
+				},
+				materials: {
+					multiMaterial: createMultiMaterial,
+					materialNames: materialNames,
+					materialGroups: materialGroups
+				},
+				buffers: {
+					vertices: vertexFA,
+					indices: indexUA,
+					colors: colorFA,
+					normals: normalFA,
+					uvs: uvFA
+				},
+				// 0: mesh, 1: line, 2: point
+				geometryType: this.rawMesh.faceType < 4 ? 0 : ( this.rawMesh.faceType === 6 ) ? 2 : 1
+			},
+			[ vertexFA.buffer ],
+			THREE.LoaderSupport.Validator.isValid( indexUA ) ? [ indexUA.buffer ] : null,
+			THREE.LoaderSupport.Validator.isValid( colorFA ) ? [ colorFA.buffer ] : null,
+			THREE.LoaderSupport.Validator.isValid( normalFA ) ? [ normalFA.buffer ] : null,
+			THREE.LoaderSupport.Validator.isValid( uvFA ) ? [ uvFA.buffer ] : null
+		);
+	},
+
+	finalizeParsing: function () {
+		if ( this.logging.enabled ) console.info( 'Global output object count: ' + this.outputObjectCount );
+		if ( this.processCompletedMesh() && this.logging.enabled ) {
+
+			var parserFinalReport = 'Overall counts: ' +
+				'\n\tVertices: ' + this.globalCounts.vertices +
+				'\n\tFaces: ' + this.globalCounts.faces +
+				'\n\tMultiple definitions: ' + this.globalCounts.doubleIndicesCount;
+			console.info( parserFinalReport );
+
+		}
+	}
+};

--- a/examples/webgl_loader_obj2.html
+++ b/examples/webgl_loader_obj2.html
@@ -83,34 +83,31 @@
 
 			'use strict';
 
-			var OBJLoader2Example = ( function () {
+			var OBJLoader2Example = function ( elementToBindTo ) {
+				this.renderer = null;
+				this.canvas = elementToBindTo;
+				this.aspectRatio = 1;
+				this.recalcAspectRatio();
 
-				var Validator = THREE.LoaderSupport.Validator;
+				this.scene = null;
+				this.cameraDefaults = {
+					posCamera: new THREE.Vector3( 0.0, 175.0, 500.0 ),
+					posCameraTarget: new THREE.Vector3( 0, 0, 0 ),
+					near: 0.1,
+					far: 10000,
+					fov: 45
+				};
+				this.camera = null;
+				this.cameraTarget = this.cameraDefaults.posCameraTarget;
 
-				function OBJLoader2Example( elementToBindTo ) {
+				this.controls = null;
+			};
 
-					this.renderer = null;
-					this.canvas = elementToBindTo;
-					this.aspectRatio = 1;
-					this.recalcAspectRatio();
+			OBJLoader2Example.prototype = {
 
-					this.scene = null;
-					this.cameraDefaults = {
-						posCamera: new THREE.Vector3( 0.0, 175.0, 500.0 ),
-						posCameraTarget: new THREE.Vector3( 0, 0, 0 ),
-						near: 0.1,
-						far: 10000,
-						fov: 45
-					};
-					this.camera = null;
-					this.cameraTarget = this.cameraDefaults.posCameraTarget;
+				constructor: OBJLoader2Example,
 
-					this.controls = null;
-
-				}
-
-				OBJLoader2Example.prototype.initGL = function () {
-
+				initGL: function () {
 					this.renderer = new THREE.WebGLRenderer( {
 						canvas: this.canvas,
 						antialias: true,
@@ -128,8 +125,8 @@
 					var directionalLight1 = new THREE.DirectionalLight( 0xC0C090 );
 					var directionalLight2 = new THREE.DirectionalLight( 0xC0C090 );
 
-					directionalLight1.position.set( - 100, - 50, 100 );
-					directionalLight2.position.set( 100, 50, - 100 );
+					directionalLight1.position.set( -100, -50, 100 );
+					directionalLight2.position.set( 100, 50, -100 );
 
 					this.scene.add( directionalLight1 );
 					this.scene.add( directionalLight2 );
@@ -137,103 +134,78 @@
 
 					var helper = new THREE.GridHelper( 1200, 60, 0xFF4444, 0x404040 );
 					this.scene.add( helper );
+				},
 
-				};
-
-				OBJLoader2Example.prototype.initContent = function () {
-
+				initContent: function () {
 					var modelName = 'female02';
 					this._reportProgress( { detail: { text: 'Loading: ' + modelName } } );
 
 					var scope = this;
 					var objLoader = new THREE.OBJLoader2();
 					var callbackOnLoad = function ( event ) {
-
 						scope.scene.add( event.detail.loaderRootNode );
 						console.log( 'Loading complete: ' + event.detail.modelName );
 						scope._reportProgress( { detail: { text: '' } } );
-
 					};
 
 					var onLoadMtl = function ( materials ) {
-
 						objLoader.setModelName( modelName );
 						objLoader.setMaterials( materials );
 						objLoader.setLogging( true, true );
 						objLoader.load( 'models/obj/female02/female02.obj', callbackOnLoad, null, null, null, false );
-
 					};
 					objLoader.loadMtl( 'models/obj/female02/female02.mtl', null, onLoadMtl );
+				},
 
-				};
-
-				OBJLoader2Example.prototype._reportProgress = function ( event ) {
-
-					var output = Validator.verifyInput( event.detail.text, '' );
+				_reportProgress: function( event ) {
+					var output = THREE.LoaderSupport.Validator.verifyInput( event.detail.text, '' );
 					console.log( 'Progress: ' + output );
 					document.getElementById( 'feedback' ).innerHTML = output;
+				},
 
-				};
-
-				OBJLoader2Example.prototype.resizeDisplayGL = function () {
-
+				resizeDisplayGL: function () {
 					this.controls.handleResize();
 
 					this.recalcAspectRatio();
 					this.renderer.setSize( this.canvas.offsetWidth, this.canvas.offsetHeight, false );
 
 					this.updateCamera();
+				},
 
-				};
-
-				OBJLoader2Example.prototype.recalcAspectRatio = function () {
-
+				recalcAspectRatio: function () {
 					this.aspectRatio = ( this.canvas.offsetHeight === 0 ) ? 1 : this.canvas.offsetWidth / this.canvas.offsetHeight;
+				},
 
-				};
-
-				OBJLoader2Example.prototype.resetCamera = function () {
-
+				resetCamera: function () {
 					this.camera.position.copy( this.cameraDefaults.posCamera );
 					this.cameraTarget.copy( this.cameraDefaults.posCameraTarget );
 
 					this.updateCamera();
+				},
 
-				};
-
-				OBJLoader2Example.prototype.updateCamera = function () {
-
+				updateCamera: function () {
 					this.camera.aspect = this.aspectRatio;
 					this.camera.lookAt( this.cameraTarget );
 					this.camera.updateProjectionMatrix();
+				},
 
-				};
-
-				OBJLoader2Example.prototype.render = function () {
-
+				render: function () {
 					if ( ! this.renderer.autoClear ) this.renderer.clear();
 					this.controls.update();
 					this.renderer.render( this.scene, this.camera );
+				}
 
-				};
-
-				return OBJLoader2Example;
-
-			} )();
+			};
 
 			var app = new OBJLoader2Example( document.getElementById( 'example' ) );
 
 			var resizeWindow = function () {
-
 				app.resizeDisplayGL();
-
 			};
 
 			var render = function () {
-
 				requestAnimationFrame( render );
 				app.render();
-
 			};
 
 			window.addEventListener( 'resize', resizeWindow, false );

--- a/examples/webgl_loader_obj2_meshspray.html
+++ b/examples/webgl_loader_obj2_meshspray.html
@@ -82,46 +82,42 @@
 
 			'use strict';
 
-			var MeshSpray = ( function () {
+			var MeshSpray = {};
 
-				var Validator = THREE.LoaderSupport.Validator;
+			MeshSpray.Loader = function ( manager ) {
+				this.manager = THREE.LoaderSupport.Validator.verifyInput( manager, THREE.DefaultLoadingManager );
+				this.logging = {
+					enabled: true,
+					debug: false
+				};
 
-				function MeshSpray( manager ) {
+				this.instanceNo = 0;
+				this.loaderRootNode = new THREE.Group();
 
-					this.manager = Validator.verifyInput( manager, THREE.DefaultLoadingManager );
-					this.logging = {
-						enabled: true,
-						debug: false
-					};
+				this.meshBuilder = new THREE.LoaderSupport.MeshBuilder();
+				this.callbacks = new THREE.LoaderSupport.Callbacks();
+				this.workerSupport = null;
+			};
 
-					this.instanceNo = 0;
-					this.loaderRootNode = new THREE.Group();
+			MeshSpray.Loader.prototype = {
 
-					this.meshBuilder = new THREE.LoaderSupport.MeshBuilder();
-					this.callbacks = new THREE.LoaderSupport.Callbacks();
-					this.workerSupport = null;
+				constructor: MeshSpray.Loader,
 
-				}
-
-				MeshSpray.prototype.setLogging = function ( enabled, debug ) {
-
+				setLogging: function ( enabled, debug ) {
 					this.logging.enabled = enabled === true;
 					this.logging.debug = debug === true;
 					this.meshBuilder.setLogging( this.logging.enabled, this.logging.debug );
+				},
 
-				};
+				setStreamMeshesTo: function ( streamMeshesTo ) {
+					this.loaderRootNode = THREE.LoaderSupport.Validator.verifyInput( streamMeshesTo, this.loaderRootNode );
+				},
 
-				MeshSpray.prototype.setStreamMeshesTo = function ( streamMeshesTo ) {
-
-					this.loaderRootNode = Validator.verifyInput( streamMeshesTo, this.loaderRootNode );
-
-				};
-
-				MeshSpray.prototype.setForceWorkerDataCopy = function () {
+				setForceWorkerDataCopy: function ( forceWorkerDataCopy ) {
 					// nothing to do here
-				};
+				},
 
-				MeshSpray.prototype.run = function ( prepData, workerSupportExternal ) {
+				run: function ( prepData, workerSupportExternal ) {
 
 					if ( THREE.LoaderSupport.Validator.isValid( workerSupportExternal ) ) {
 
@@ -142,19 +138,14 @@
 
 					var scope = this;
 					var scopeBuilderFunc = function ( payload ) {
-
 						var meshes = scope.meshBuilder.processPayload( payload );
 						var mesh;
 						for ( var i in meshes ) {
-
 							mesh = meshes[ i ];
 							scope.loaderRootNode.add( mesh );
-
 						}
-
 					};
-					var scopeFuncComplete = function () {
-
+					var scopeFuncComplete = function ( message ) {
 						var callback = scope.callbacks.onLoad;
 						if ( THREE.LoaderSupport.Validator.isValid( callback ) ) callback(
 							{
@@ -166,24 +157,22 @@
 							}
 						);
 						if ( scope.logging.enabled ) console.timeEnd( 'MeshSpray' + scope.instanceNo );
-
 					};
 
-					var buildCode = function ( funcBuildObject, funcBuildSingleton ) {
-
+					var buildCode = function ( codeSerializer ) {
 						var workerCode = '';
 						workerCode += '/**\n';
 						workerCode += '  * This code was constructed by MeshSpray buildCode.\n';
 						workerCode += '  */\n\n';
 						workerCode += 'THREE.LoaderSupport = {};\n\n';
-						workerCode += funcBuildObject( 'THREE.LoaderSupport.Validator', THREE.LoaderSupport.Validator );
-						workerCode += funcBuildSingleton( 'Parser', Parser );
+						workerCode += 'MeshSpray = {};\n\n';
+						workerCode += codeSerializer.serializeObject( 'THREE.LoaderSupport.Validator', THREE.LoaderSupport.Validator );
+						workerCode += codeSerializer.serializeClass( 'MeshSpray.Parser', MeshSpray.Parser );
 
 						return workerCode;
-
 					};
 					var libs2Load = [ 'build/three.min.js' ];
-					this.workerSupport.validate( buildCode, 'Parser', libs2Load, '../' );
+					this.workerSupport.validate( buildCode, 'MeshSpray.Parser', libs2Load, '../../' );
 					this.workerSupport.setCallbacks( scopeBuilderFunc, scopeFuncComplete );
 					this.workerSupport.run(
 						{
@@ -205,12 +194,10 @@
 							}
 						}
 					);
+				},
 
-				};
-
-				MeshSpray.prototype._applyPrepData = function ( prepData ) {
-
-					if ( Validator.isValid( prepData ) ) {
+				_applyPrepData: function ( prepData ) {
+					if ( THREE.LoaderSupport.Validator.isValid( prepData ) ) {
 
 						this.setLogging( prepData.logging.enabled, prepData.logging.debug );
 						this.setStreamMeshesTo( prepData.streamMeshesTo );
@@ -218,219 +205,201 @@
 						this._setCallbacks( prepData.getCallbacks() );
 
 					}
+				},
 
-				};
-
-				MeshSpray.prototype._setCallbacks = function ( callbacks ) {
-
-					if ( Validator.isValid( callbacks.onProgress ) ) this.callbacks.setCallbackOnProgress( callbacks.onProgress );
-					if ( Validator.isValid( callbacks.onMeshAlter ) ) this.callbacks.setCallbackOnMeshAlter( callbacks.onMeshAlter );
-					if ( Validator.isValid( callbacks.onLoad ) ) this.callbacks.setCallbackOnLoad( callbacks.onLoad );
-					if ( Validator.isValid( callbacks.onLoadMaterials ) ) this.callbacks.setCallbackOnLoadMaterials( callbacks.onLoadMaterials );
+				_setCallbacks: function ( callbacks ) {
+					if ( THREE.LoaderSupport.Validator.isValid( callbacks.onProgress ) ) this.callbacks.setCallbackOnProgress( callbacks.onProgress );
+					if ( THREE.LoaderSupport.Validator.isValid( callbacks.onReportError ) ) this.callbacks.setCallbackOnReportError( callbacks.onReportError );
+					if ( THREE.LoaderSupport.Validator.isValid( callbacks.onMeshAlter ) ) this.callbacks.setCallbackOnMeshAlter( callbacks.onMeshAlter );
+					if ( THREE.LoaderSupport.Validator.isValid( callbacks.onLoad ) ) this.callbacks.setCallbackOnLoad( callbacks.onLoad );
+					if ( THREE.LoaderSupport.Validator.isValid( callbacks.onLoadMaterials ) ) this.callbacks.setCallbackOnLoadMaterials( callbacks.onLoadMaterials );
 
 					this.meshBuilder._setCallbacks( this.callbacks );
+				}
+			};
 
+
+			MeshSpray.Parser = function () {
+				this.sizeFactor = 0.5;
+				this.localOffsetFactor = 1.0;
+				this.globalObjectCount = 0;
+				this.debug = false;
+				this.dimension = 200;
+				this.quantity = 1;
+				this.callbackMeshBuilder = null;
+				this.callbackProgress = null;
+				this.serializedMaterials = null;
+				this.logging = {
+					enabled: true,
+					debug: false
 				};
+			};
 
-				var Parser = ( function () {
+			MeshSpray.Parser.prototype = {
 
-					function Parser() {
+				constructor: MeshSpray.Parser,
 
-						this.sizeFactor = 0.5;
-						this.localOffsetFactor = 1.0;
-						this.globalObjectCount = 0;
-						this.debug = false;
-						this.dimension = 200;
-						this.quantity = 1;
-						this.callbackMeshBuilder = null;
-						this.callbackProgress = null;
-						this.serializedMaterials = null;
-						this.logging = {
-							enabled: true,
-							debug: false
-						};
+				setLogging: function ( enabled, debug ) {
+					this.logging.enabled = enabled === true;
+					this.logging.debug = debug === true;
+				},
+
+				parse: function () {
+					var baseTriangle = [ 1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 0.0, -1.0, 1.0 ];
+					var vertices = [];
+					var colors = [];
+					var normals = [];
+					var uvs = [];
+
+					var dimensionHalf = this.dimension / 2;
+					var fixedOffsetX;
+					var fixedOffsetY;
+					var fixedOffsetZ;
+					var s, t;
+					// complete triangle
+					var sizeVaring = this.sizeFactor * Math.random();
+					// local coords offset
+					var localOffsetFactor = this.localOffsetFactor;
+
+					for ( var i = 0; i < this.quantity; i++ ) {
+						sizeVaring = this.sizeFactor * Math.random();
+
+						s = 2 * Math.PI * Math.random();
+						t = Math.PI * Math.random();
+
+						fixedOffsetX = dimensionHalf * Math.random() * Math.cos( s ) * Math.sin( t );
+						fixedOffsetY = dimensionHalf * Math.random() * Math.sin( s ) * Math.sin( t );
+						fixedOffsetZ = dimensionHalf * Math.random() * Math.cos( t );
+						for ( var j = 0; j < baseTriangle.length; j += 3 ) {
+							vertices.push( baseTriangle[ j ] * sizeVaring + localOffsetFactor * Math.random() + fixedOffsetX );
+							vertices.push( baseTriangle[ j + 1 ] * sizeVaring + localOffsetFactor * Math.random() + fixedOffsetY );
+							vertices.push( baseTriangle[ j + 2 ] * sizeVaring + localOffsetFactor * Math.random() + fixedOffsetZ );
+							colors.push( Math.random() );
+							colors.push( Math.random() );
+							colors.push( Math.random() );
+						}
+					}
+
+					var absoluteVertexCount = vertices.length;
+					var absoluteColorCount = colors.length;
+					var absoluteNormalCount = 0;
+					var absoluteUvCount = 0;
+
+					var vertexFA = new Float32Array( absoluteVertexCount );
+					var colorFA = ( absoluteColorCount > 0 ) ? new Float32Array( absoluteColorCount ) : null;
+					var normalFA = ( absoluteNormalCount > 0 ) ? new Float32Array( absoluteNormalCount ) : null;
+					var uvFA = ( absoluteUvCount > 0 ) ? new Float32Array( absoluteUvCount ) : null;
+
+					vertexFA.set( vertices, 0 );
+					if ( colorFA ) {
+
+						colorFA.set( colors, 0 );
 
 					}
 
-					Parser.prototype.setLogging = function ( enabled, debug ) {
+					if ( normalFA ) {
 
-						this.logging.enabled = enabled === true;
-						this.logging.debug = debug === true;
+						normalFA.set( normals, 0 );
 
+					}
+					if ( uvFA ) {
+
+						uvFA.set( uvs, 0 );
+
+					}
+
+					/*
+					 * This demonstrates the usage of embedded three.js in the worker blob and
+					 * the serialization of materials back to the Builder outside the worker.
+					 *
+					 * This is not the most effective way, but outlining possibilities
+					 */
+					var materialName = 'defaultVertexColorMaterial_double';
+					var defaultVertexColorMaterialJson = this.serializedMaterials[ 'defaultVertexColorMaterial' ];
+					var loader = new THREE.MaterialLoader();
+
+					var defaultVertexColorMaterialDouble = loader.parse( defaultVertexColorMaterialJson );
+					defaultVertexColorMaterialDouble.name = materialName;
+					defaultVertexColorMaterialDouble.side = THREE.DoubleSide;
+
+					var newSerializedMaterials = {};
+					newSerializedMaterials[ materialName ] = defaultVertexColorMaterialDouble.toJSON();
+					var payload = {
+						cmd: 'materialData',
+						materials: {
+							serializedMaterials: newSerializedMaterials
+						}
 					};
+					this.callbackMeshBuilder( payload );
 
-					Parser.prototype.parse = function () {
-
-						var baseTriangle = [ 1.0, 1.0, 1.0, - 1.0, 1.0, 1.0, 0.0, - 1.0, 1.0 ];
-						var vertices = [];
-						var colors = [];
-						var normals = [];
-						var uvs = [];
-
-						var dimensionHalf = this.dimension / 2;
-						var fixedOffsetX;
-						var fixedOffsetY;
-						var fixedOffsetZ;
-						var s, t;
-						// complete triangle
-						// local coords offset
-						var localOffsetFactor = this.localOffsetFactor;
-
-						for ( var i = 0; i < this.quantity; i ++ ) {
-
-							var sizeVaring = this.sizeFactor * Math.random();
-
-							s = 2 * Math.PI * Math.random();
-							t = Math.PI * Math.random();
-
-							fixedOffsetX = dimensionHalf * Math.random() * Math.cos( s ) * Math.sin( t );
-							fixedOffsetY = dimensionHalf * Math.random() * Math.sin( s ) * Math.sin( t );
-							fixedOffsetZ = dimensionHalf * Math.random() * Math.cos( t );
-							for ( var j = 0; j < baseTriangle.length; j += 3 ) {
-
-								vertices.push( baseTriangle[ j ] * sizeVaring + localOffsetFactor * Math.random() + fixedOffsetX );
-								vertices.push( baseTriangle[ j + 1 ] * sizeVaring + localOffsetFactor * Math.random() + fixedOffsetY );
-								vertices.push( baseTriangle[ j + 2 ] * sizeVaring + localOffsetFactor * Math.random() + fixedOffsetZ );
-								colors.push( Math.random() );
-								colors.push( Math.random() );
-								colors.push( Math.random() );
-
-							}
-
-						}
-
-						var absoluteVertexCount = vertices.length;
-						var absoluteColorCount = colors.length;
-						var absoluteNormalCount = 0;
-						var absoluteUvCount = 0;
-
-						var vertexFA = new Float32Array( absoluteVertexCount );
-						var colorFA = ( absoluteColorCount > 0 ) ? new Float32Array( absoluteColorCount ) : null;
-						var normalFA = ( absoluteNormalCount > 0 ) ? new Float32Array( absoluteNormalCount ) : null;
-						var uvFA = ( absoluteUvCount > 0 ) ? new Float32Array( absoluteUvCount ) : null;
-
-						vertexFA.set( vertices, 0 );
-						if ( colorFA ) {
-
-							colorFA.set( colors, 0 );
-
-						}
-
-						if ( normalFA ) {
-
-							normalFA.set( normals, 0 );
-
-						}
-						if ( uvFA ) {
-
-							uvFA.set( uvs, 0 );
-
-						}
-
-						/*
-						 * This demonstrates the usage of embedded three.js in the worker blob and
-						 * the serialization of materials back to the Builder outside the worker.
-						 *
-						 * This is not the most effective way, but outlining possibilities
-						 */
-						var materialName = 'defaultVertexColorMaterial_double';
-						var defaultVertexColorMaterialJson = this.serializedMaterials[ 'defaultVertexColorMaterial' ];
-						var loader = new THREE.MaterialLoader();
-
-						var defaultVertexColorMaterialDouble = loader.parse( defaultVertexColorMaterialJson );
-						defaultVertexColorMaterialDouble.name = materialName;
-						defaultVertexColorMaterialDouble.side = THREE.DoubleSide;
-
-						var newSerializedMaterials = {};
-						newSerializedMaterials[ materialName ] = defaultVertexColorMaterialDouble.toJSON();
-						var payload = {
-							cmd: 'materialData',
-							materials: {
-								serializedMaterials: newSerializedMaterials
-							}
-						};
-						this.callbackMeshBuilder( payload );
-
-						this.globalObjectCount ++;
-						this.callbackMeshBuilder(
-							{
-								cmd: 'meshData',
-								progress: {
-									numericalValue: 1.0
-								},
-								params: {
-									meshName: 'Gen' + this.globalObjectCount
-								},
-								materials: {
-									multiMaterial: false,
-									materialNames: [ materialName ],
-									materialGroups: []
-								},
-								buffers: {
-									vertices: vertexFA,
-									colors: colorFA,
-									normals: normalFA,
-									uvs: uvFA
-								}
+					this.globalObjectCount++;
+					this.callbackMeshBuilder(
+						{
+							cmd: 'meshData',
+							progress: {
+								numericalValue: 1.0
 							},
-							[ vertexFA.buffer ],
-							colorFA !== null ? [ colorFA.buffer ] : null,
-							normalFA !== null ? [ normalFA.buffer ] : null,
-							uvFA !== null ? [ uvFA.buffer ] : null
-						);
+							params: {
+								meshName: 'Gen' + this.globalObjectCount
+							},
+							materials: {
+								multiMaterial: false,
+								materialNames: [ materialName ],
+								materialGroups: []
+							},
+							buffers: {
+								vertices: vertexFA,
+								colors: colorFA,
+								normals: normalFA,
+								uvs: uvFA
+							}
+						},
+						[ vertexFA.buffer ],
+						colorFA !== null ? [ colorFA.buffer ] : null,
+						normalFA !== null ? [ normalFA.buffer ] : null,
+						uvFA !== null ? [ uvFA.buffer ] : null
+					);
 
-						if ( this.logging.enabled ) console.info( 'Global output object count: ' + this.globalObjectCount );
+					if ( this.logging.enabled ) console.info( 'Global output object count: ' + this.globalObjectCount );
+				},
 
-					};
-
-					return Parser;
-
-				} )();
-
-
-				Parser.prototype.setSerializedMaterials = function ( serializedMaterials ) {
-
+				setSerializedMaterials: function ( serializedMaterials ) {
 					if ( THREE.LoaderSupport.Validator.isValid( serializedMaterials ) ) {
 
 						this.serializedMaterials = serializedMaterials;
 
 					}
-
-				};
-
-				return MeshSpray;
-
-			} )();
-
-			var MeshSprayApp = ( function () {
-
-				function MeshSprayApp( elementToBindTo ) {
-
-					this.renderer = null;
-					this.canvas = elementToBindTo;
-					this.aspectRatio = 1;
-					this.recalcAspectRatio();
-
-					this.scene = null;
-					this.cameraDefaults = {
-						posCamera: new THREE.Vector3( 500.0, 500.0, 1000.0 ),
-						posCameraTarget: new THREE.Vector3( 0, 0, 0 ),
-						near: 0.1,
-						far: 10000,
-						fov: 45
-					};
-					this.camera = null;
-					this.cameraTarget = this.cameraDefaults.posCameraTarget;
-
-					this.controls = null;
-
-					this.cube = null;
-					this.pivot = null;
-
 				}
+			};
 
-				MeshSprayApp.prototype.initGL = function () {
+			var MeshSprayApp = function ( elementToBindTo ) {
+				this.renderer = null;
+				this.canvas = elementToBindTo;
+				this.aspectRatio = 1;
+				this.recalcAspectRatio();
 
+				this.scene = null;
+				this.cameraDefaults = {
+					posCamera: new THREE.Vector3( 500.0, 500.0, 1000.0 ),
+					posCameraTarget: new THREE.Vector3( 0, 0, 0 ),
+					near: 0.1,
+					far: 10000,
+					fov: 45
+				};
+				this.camera = null;
+				this.cameraTarget = this.cameraDefaults.posCameraTarget;
+
+				this.controls = null;
+
+				this.cube = null;
+				this.pivot = null;
+			};
+
+			MeshSprayApp.prototype = {
+
+				constructor: MeshSprayApp,
+
+				initGL: function () {
 					this.renderer = new THREE.WebGLRenderer( {
 						canvas: this.canvas,
 						antialias: true,
@@ -448,8 +417,8 @@
 					var directionalLight1 = new THREE.DirectionalLight( 0xC0C090 );
 					var directionalLight2 = new THREE.DirectionalLight( 0xC0C090 );
 
-					directionalLight1.position.set( - 100, - 50, 100 );
-					directionalLight2.position.set( 100, 50, - 100 );
+					directionalLight1.position.set( -100, -50, 100 );
+					directionalLight2.position.set( 100, 50, -100 );
 
 					this.scene.add( directionalLight1 );
 					this.scene.add( directionalLight2 );
@@ -458,7 +427,7 @@
 					var helper = new THREE.GridHelper( 1200, 60, 0xFF4444, 0x404040 );
 					this.scene.add( helper );
 
-					var geometry = new THREE.BoxBufferGeometry( 10, 10, 10 );
+					var geometry = new THREE.BoxGeometry( 10, 10, 10 );
 					var material = new THREE.MeshNormalMaterial();
 					this.cube = new THREE.Mesh( geometry, material );
 					this.cube.position.set( 0, 0, 0 );
@@ -467,31 +436,24 @@
 					this.pivot = new THREE.Object3D();
 					this.pivot.name = 'Pivot';
 					this.scene.add( this.pivot );
+				},
 
-				};
-
-				MeshSprayApp.prototype.initContent = function () {
-
+				initContent: function () {
 					var maxQueueSize = 1024;
 					var maxWebWorkers = 4;
 					var radius = 640;
-					var workerDirector = new THREE.LoaderSupport.WorkerDirector( MeshSpray );
+					var workerDirector = new THREE.LoaderSupport.WorkerDirector( MeshSpray.Loader );
 					workerDirector.setLogging( false, false );
 					workerDirector.setCrossOrigin( 'anonymous' );
 
 					var callbackOnLoad = function ( event ) {
-
 						console.info( 'Worker #' + event.detail.instanceNo + ': Completed loading. (#' + workerDirector.objectsCompleted + ')' );
-
 					};
-					var reportProgress = function ( event ) {
-
+					var reportProgress = function( event ) {
 						document.getElementById( 'feedback' ).innerHTML = event.detail.text;
 						console.info( event.detail.text );
-
 					};
 					var callbackMeshAlter = function ( event ) {
-
 						var override = new THREE.LoaderSupport.LoadedMeshUserOverride( false, true );
 
 						event.detail.side = THREE.DoubleSide;
@@ -500,8 +462,8 @@
 						override.addMesh( mesh );
 
 						return override;
-
 					};
+
 
 					var callbacks = new THREE.LoaderSupport.Callbacks();
 					callbacks.setCallbackOnMeshAlter( callbackMeshAlter );
@@ -513,8 +475,7 @@
 					var pivot;
 					var s, t, r, x, y, z;
 					var globalObjectCount = 0;
-					for ( var i = 0; i < maxQueueSize; i ++ ) {
-
+					for ( var i = 0; i < maxQueueSize; i++ ) {
 						prepData = new THREE.LoaderSupport.PrepData( 'Triangles_' + i );
 
 						pivot = new THREE.Object3D();
@@ -531,51 +492,40 @@
 
 						prepData.quantity = 8192;
 						prepData.dimension = Math.max( Math.random() * 500, 100 );
-						prepData.globalObjectCount = globalObjectCount ++;
+						prepData.globalObjectCount = globalObjectCount++;
 
 						workerDirector.enqueueForRun( prepData );
-
 					}
 					workerDirector.processQueue();
+				},
 
-				};
-
-				MeshSprayApp.prototype.resizeDisplayGL = function () {
-
+				resizeDisplayGL: function () {
 					this.controls.handleResize();
 
 					this.recalcAspectRatio();
 					this.renderer.setSize( this.canvas.offsetWidth, this.canvas.offsetHeight, false );
 
 					this.updateCamera();
+				},
 
-				};
-
-				MeshSprayApp.prototype.recalcAspectRatio = function () {
-
+				recalcAspectRatio: function () {
 					this.aspectRatio = ( this.canvas.offsetHeight === 0 ) ? 1 : this.canvas.offsetWidth / this.canvas.offsetHeight;
+				},
 
-				};
-
-				MeshSprayApp.prototype.resetCamera = function () {
-
+				resetCamera: function () {
 					this.camera.position.copy( this.cameraDefaults.posCamera );
 					this.cameraTarget.copy( this.cameraDefaults.posCameraTarget );
 
 					this.updateCamera();
+				},
 
-				};
-
-				MeshSprayApp.prototype.updateCamera = function () {
-
+				updateCamera: function () {
 					this.camera.aspect = this.aspectRatio;
 					this.camera.lookAt( this.cameraTarget );
 					this.camera.updateProjectionMatrix();
+				},
 
-				};
-
-				MeshSprayApp.prototype.render = function () {
-
+				render: function () {
 					if ( ! this.renderer.autoClear ) this.renderer.clear();
 
 					this.controls.update();
@@ -584,27 +534,19 @@
 					this.cube.rotation.y += 0.05;
 
 					this.renderer.render( this.scene, this.camera );
-
-				};
-
-				return MeshSprayApp;
-
-			} )();
+				}
+			};
 
 			var app = new MeshSprayApp( document.getElementById( 'example' ) );
 
 			// init three.js example application
 			var resizeWindow = function () {
-
 				app.resizeDisplayGL();
-
 			};
 
 			var render = function () {
-
 				requestAnimationFrame( render );
 				app.render();
-
 			};
 
 			window.addEventListener( 'resize', resizeWindow, false );

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -83,40 +83,37 @@
 
 			'use strict';
 
-			var WWOBJLoader2Example = ( function () {
+			var WWOBJLoader2Example = function ( elementToBindTo ) {
+				this.renderer = null;
+				this.canvas = elementToBindTo;
+				this.aspectRatio = 1;
+				this.recalcAspectRatio();
 
-				var Validator = THREE.LoaderSupport.Validator;
+				this.scene = null;
+				this.cameraDefaults = {
+					posCamera: new THREE.Vector3( 0.0, 175.0, 500.0 ),
+					posCameraTarget: new THREE.Vector3( 0, 0, 0 ),
+					near: 0.1,
+					far: 10000,
+					fov: 45
+				};
+				this.camera = null;
+				this.cameraTarget = this.cameraDefaults.posCameraTarget;
 
-				function WWOBJLoader2Example( elementToBindTo ) {
+				this.controls = null;
 
-					this.renderer = null;
-					this.canvas = elementToBindTo;
-					this.aspectRatio = 1;
-					this.recalcAspectRatio();
+				this.flatShading = false;
+				this.doubleSide = false;
 
-					this.scene = null;
-					this.cameraDefaults = {
-						posCamera: new THREE.Vector3( 0.0, 175.0, 500.0 ),
-						posCameraTarget: new THREE.Vector3( 0, 0, 0 ),
-						near: 0.1,
-						far: 10000,
-						fov: 45
-					};
-					this.camera = null;
-					this.cameraTarget = this.cameraDefaults.posCameraTarget;
+				this.cube = null;
+				this.pivot = null;
+			};
 
-					this.controls = null;
+			WWOBJLoader2Example.prototype = {
 
-					this.flatShading = false;
-					this.doubleSide = false;
+				constructor: WWOBJLoader2Example,
 
-					this.cube = null;
-					this.pivot = null;
-
-				}
-
-				WWOBJLoader2Example.prototype.initGL = function () {
-
+				initGL: function () {
 					this.renderer = new THREE.WebGLRenderer( {
 						canvas: this.canvas,
 						antialias: true,
@@ -134,8 +131,8 @@
 					var directionalLight1 = new THREE.DirectionalLight( 0xC0C090 );
 					var directionalLight2 = new THREE.DirectionalLight( 0xC0C090 );
 
-					directionalLight1.position.set( - 100, - 50, 100 );
-					directionalLight2.position.set( 100, 50, - 100 );
+					directionalLight1.position.set( -100, -50, 100 );
+					directionalLight2.position.set( 100, 50, -100 );
 
 					this.scene.add( directionalLight1 );
 					this.scene.add( directionalLight2 );
@@ -144,7 +141,7 @@
 					var helper = new THREE.GridHelper( 1200, 60, 0xFF4444, 0x404040 );
 					this.scene.add( helper );
 
-					var geometry = new THREE.BoxBufferGeometry( 10, 10, 10 );
+					var geometry = new THREE.BoxGeometry( 10, 10, 10 );
 					var material = new THREE.MeshNormalMaterial();
 					this.cube = new THREE.Mesh( geometry, material );
 					this.cube.position.set( 0, 0, 0 );
@@ -153,18 +150,15 @@
 					this.pivot = new THREE.Object3D();
 					this.pivot.name = 'Pivot';
 					this.scene.add( this.pivot );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.useParseSync = function () {
-
+				useParseSync: function () {
 					var modelName = 'female02';
 					this._reportProgress( { detail: { text: 'Loading: ' + modelName } } );
 
 					var scope = this;
 					var objLoader = new THREE.OBJLoader2();
 					var onLoadMtl = function ( materials ) {
-
 						objLoader.setModelName( modelName );
 						objLoader.setMaterials( materials );
 
@@ -173,7 +167,6 @@
 						fileLoader.setResponseType( 'arraybuffer' );
 						fileLoader.load( 'models/obj/female02/female02.obj',
 							function ( content ) {
-
 								var local = new THREE.Object3D();
 								local.name = 'Pivot_female02';
 								local.position.set( 75, 0, 0 );
@@ -181,30 +174,27 @@
 								local.add( objLoader.parse( content ) );
 
 								scope._reportProgress( { detail: { text: 'Loading complete: ' + modelName } } );
-
 							}
 						);
-
 					};
-					objLoader.loadMtl( 'models/obj/female02/female02.mtl', null, onLoadMtl );
+					var onError = function ( event ) {
+						console.error( 'Error occurred: ' + event );
+					};
+					objLoader.loadMtl( 'models/obj/female02/female02.mtl', null, onLoadMtl, null, onError );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.useParseAsync = function () {
-
-					var modelName = 'female02_vertex';
+				useParseAsync: function () {
+					var modelName = 'female02_vertex' ;
 					this._reportProgress( { detail: { text: 'Loading: ' + modelName } } );
 
 					var callbackOnLoad = function ( event ) {
-
 						var local = new THREE.Object3D();
 						local.name = 'Pivot_female02_vertex';
-						local.position.set( - 75, 0, 0 );
+						local.position.set( -75, 0, 0 );
 						scope.pivot.add( local );
 						local.add( event.detail.loaderRootNode );
 
 						scope._reportProgress( { detail: { text: 'Loading complete: ' + event.detail.modelName } } );
-
 					};
 
 					var scope = this;
@@ -217,70 +207,58 @@
 					var filename = 'models/obj/female02/female02_vertex_colors.obj';
 					fileLoader.load( filename,
 						function ( content ) {
-
 							objLoader.parseAsync( content, callbackOnLoad );
 							scope._reportProgress( { detail: { text: 'File loading complete: ' + filename } } );
+						}
+					);
+				},
 
-						} );
-
-				};
-
-				WWOBJLoader2Example.prototype.useLoadSync = function () {
-
+				useLoadSync: function () {
 					var modelName = 'male02';
 					this._reportProgress( { detail: { text: 'Loading: ' + modelName } } );
 
 					var scope = this;
 					var objLoader = new THREE.OBJLoader2();
 					var callbackOnLoad = function ( event ) {
-
 						var local = new THREE.Object3D();
 						local.name = 'Pivot_male02';
-						local.position.set( 0, 0, - 75 );
+						local.position.set( 0, 0, -75 );
 						scope.pivot.add( local );
 						local.add( event.detail.loaderRootNode );
 
 						scope._reportProgress( { detail: { text: 'Loading complete: ' + event.detail.modelName } } );
-
 					};
 
 					var onLoadMtl = function ( materials ) {
-
 						objLoader.setModelName( modelName );
 						objLoader.setMaterials( materials );
 						objLoader.setUseIndices( true );
 						objLoader.load( 'models/obj/male02/male02.obj', callbackOnLoad, null, null, null, false );
-
 					};
 					objLoader.loadMtl( 'models/obj/male02/male02.mtl', null, onLoadMtl );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.useLoadAsync = function () {
-
+				useLoadAsync: function () {
 					var modelName = 'WaltHead';
 					this._reportProgress( { detail: { text: 'Loading: ' + modelName } } );
 
 					var scope = this;
 					var objLoader = new THREE.OBJLoader2();
 					var callbackOnLoad = function ( event ) {
-
 						objLoader.workerSupport.setTerminateRequested( true );
 
 						var local = new THREE.Object3D();
 						local.name = 'Pivot_WaltHead';
-						local.position.set( - 125, 50, 0 );
+						local.position.set( -125, 50, 0 );
 						var scale = 0.5;
 						local.scale.set( scale, scale, scale );
 						scope.pivot.add( local );
 						local.add( event.detail.loaderRootNode );
 
 						scope._reportProgress( { detail: { text: 'Loading complete: ' + event.detail.modelName } } );
-
 					};
 
 					var onLoadMtl = function ( materials ) {
-
 						objLoader.setModelName( modelName );
 						objLoader.setMaterials( materials );
 						objLoader.terminateWorkerOnLoad = false;
@@ -288,16 +266,12 @@
 
 					};
 					objLoader.loadMtl( 'models/obj/walt/WaltHead.mtl', null, onLoadMtl );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.useRunSync = function () {
-
+				useRunSync: function () {
 					var scope = this;
 					var callbackOnLoad = function ( event ) {
-
 						scope._reportProgress( { detail: { text: 'Loading complete: ' + event.detail.modelName } } );
-
 					};
 
 					var prepData = new THREE.LoaderSupport.PrepData( 'cerberus' );
@@ -313,16 +287,12 @@
 
 					var objLoader = new THREE.OBJLoader2();
 					objLoader.run( prepData );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.useRunAsyncMeshAlter = function () {
-
+				useRunAsyncMeshAlter: function () {
 					var scope = this;
 					var callbackOnLoad = function ( event ) {
-
 						scope._reportProgress( { detail: { text: 'Loading complete: ' + event.detail.modelName } } );
-
 					};
 
 					var prepData = new THREE.LoaderSupport.PrepData( 'vive-controller' );
@@ -335,7 +305,6 @@
 					prepData.useAsync = true;
 					var callbacks = prepData.getCallbacks();
 					var callbackMeshAlter = function ( event ) {
-
 						var override = new THREE.LoaderSupport.LoadedMeshUserOverride( false, true );
 
 						var mesh = new THREE.Mesh( event.detail.bufferGeometry, event.detail.material );
@@ -349,7 +318,6 @@
 						override.addMesh( helper );
 
 						return override;
-
 					};
 					callbacks.setCallbackOnMeshAlter( callbackMeshAlter );
 					callbacks.setCallbackOnProgress( this._reportProgress );
@@ -357,59 +325,45 @@
 
 					var objLoader = new THREE.OBJLoader2();
 					objLoader.run( prepData );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.finalize = function () {
-
+				finalize: function () {
 					this._reportProgress( { detail: { text: '' } } );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype._reportProgress = function ( event ) {
-
-					var output = Validator.verifyInput( event.detail.text, '' );
+				_reportProgress: function( event ) {
+					var output = THREE.LoaderSupport.Validator.verifyInput( event.detail.text, '' );
 					console.log( 'Progress: ' + output );
 					document.getElementById( 'feedback' ).innerHTML = output;
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.resizeDisplayGL = function () {
-
+				resizeDisplayGL: function () {
 					this.controls.handleResize();
 
 					this.recalcAspectRatio();
 					this.renderer.setSize( this.canvas.offsetWidth, this.canvas.offsetHeight, false );
 
 					this.updateCamera();
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.recalcAspectRatio = function () {
-
+				recalcAspectRatio: function () {
 					this.aspectRatio = ( this.canvas.offsetHeight === 0 ) ? 1 : this.canvas.offsetWidth / this.canvas.offsetHeight;
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.resetCamera = function () {
-
+				resetCamera: function () {
 					this.camera.position.copy( this.cameraDefaults.posCamera );
 					this.cameraTarget.copy( this.cameraDefaults.posCameraTarget );
 
 					this.updateCamera();
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.updateCamera = function () {
-
+				updateCamera: function () {
 					this.camera.aspect = this.aspectRatio;
 					this.camera.lookAt( this.cameraTarget );
 					this.camera.updateProjectionMatrix();
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.render = function () {
-
+				render: function () {
 					if ( ! this.renderer.autoClear ) this.renderer.clear();
 
 					this.controls.update();
@@ -418,53 +372,39 @@
 					this.cube.rotation.y += 0.05;
 
 					this.renderer.render( this.scene, this.camera );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.alterShading = function () {
-
+				alterShading: function () {
 					var scope = this;
 					scope.flatShading = ! scope.flatShading;
-					console.log( scope.flatShading ? 'Enabling flat shading' : 'Enabling smooth shading' );
+					console.log( scope.flatShading ? 'Enabling flat shading' : 'Enabling smooth shading');
 
 					scope.traversalFunction = function ( material ) {
-
 						material.flatShading = scope.flatShading;
 						material.needsUpdate = true;
-
 					};
 					var scopeTraverse = function ( object3d ) {
-
 						scope.traverseScene( object3d );
-
 					};
 					scope.pivot.traverse( scopeTraverse );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.alterDouble = function () {
-
+				alterDouble: function () {
 					var scope = this;
 					scope.doubleSide = ! scope.doubleSide;
 					console.log( scope.doubleSide ? 'Enabling DoubleSide materials' : 'Enabling FrontSide materials' );
 
 					scope.traversalFunction = function ( material ) {
-
 						material.side = scope.doubleSide ? THREE.DoubleSide : THREE.FrontSide;
-
 					};
 
 					var scopeTraverse = function ( object3d ) {
-
 						scope.traverseScene( object3d );
-
 					};
 					scope.pivot.traverse( scopeTraverse );
+				},
 
-				};
-
-				WWOBJLoader2Example.prototype.traverseScene = function ( object3d ) {
-
+				traverseScene: function ( object3d ) {
 					if ( object3d.material instanceof THREE.MultiMaterial ) {
 
 						var materials = object3d.material.materials;
@@ -479,12 +419,10 @@
 						this.traversalFunction( object3d.material );
 
 					}
+				}
 
-				};
+			};
 
-				return WWOBJLoader2Example;
-
-			} )();
 
 			var app = new WWOBJLoader2Example( document.getElementById( 'example' ) );
 
@@ -502,35 +440,27 @@
 
 			var folderOptions = gui.addFolder( 'WWOBJLoader2 Options' );
 			var controlFlat = folderOptions.add( wwObjLoader2Control, 'flatShading' ).name( 'Flat Shading' );
-			controlFlat.onChange( function ( value ) {
-
+			controlFlat.onChange( function( value ) {
 				console.log( 'Setting flatShading to: ' + value );
 				app.alterShading();
-
-			} );
+			});
 
 			var controlDouble = folderOptions.add( wwObjLoader2Control, 'doubleSide' ).name( 'Double Side Materials' );
-			controlDouble.onChange( function ( value ) {
-
+			controlDouble.onChange( function( value ) {
 				console.log( 'Setting doubleSide to: ' + value );
 				app.alterDouble();
-
-			} );
+			});
 			folderOptions.open();
 
 
 			// init three.js example application
 			var resizeWindow = function () {
-
 				app.resizeDisplayGL();
-
 			};
 
 			var render = function () {
-
 				requestAnimationFrame( render );
 				app.render();
-
 			};
 			window.addEventListener( 'resize', resizeWindow, false );
 
@@ -540,6 +470,7 @@
 
 			// kick render loop
 			render();
+
 
 			// Load a file with OBJLoader.parse synchronously
 			app.useParseSync();

--- a/examples/webgl_loader_obj2_run_director.html
+++ b/examples/webgl_loader_obj2_run_director.html
@@ -47,13 +47,13 @@
 				background-color: #000000;
 			}
 			#feedback {
-				position: absolute;
-				color: darkorange;
-				text-align: left;
-				bottom: 0%;
-				left: 0%;
-				width: auto;
-				padding: 0px 0px 4px 4px;
+			    position: absolute;
+			    color: darkorange;
+			    text-align: left;
+			    bottom: 0%;
+			    left: 0%;
+			    width: auto;
+			    padding: 0px 0px 4px 4px;
 			}
 			#dat {
 				user-select: none;
@@ -89,49 +89,46 @@
 
 			'use strict';
 
-			var WWParallels = ( function () {
+			var WWParallels = function ( elementToBindTo ) {
+				this.renderer = null;
+				this.canvas = elementToBindTo;
+				this.aspectRatio = 1;
+				this.recalcAspectRatio();
 
-				var Validator = THREE.LoaderSupport.Validator;
+				this.scene = null;
+				this.cameraDefaults = {
+					posCamera: new THREE.Vector3( 0.0, 175.0, 500.0 ),
+					posCameraTarget: new THREE.Vector3( 0, 0, 0 ),
+					near: 0.1,
+					far: 10000,
+					fov: 45
+				};
+				this.camera = null;
+				this.cameraTarget = this.cameraDefaults.posCameraTarget;
 
-				function WWParallels( elementToBindTo ) {
+				this.workerDirector = new THREE.LoaderSupport.WorkerDirector( THREE.OBJLoader2 );
+				this.logging = {
+					enabled: false,
+					debug: false
+				};
+				this.workerDirector.setLogging( this.logging.enabled, this.logging.debug );
+				this.workerDirector.setCrossOrigin( 'anonymous' );
+				this.workerDirector.setForceWorkerDataCopy( true );
 
-					this.renderer = null;
-					this.canvas = elementToBindTo;
-					this.aspectRatio = 1;
-					this.recalcAspectRatio();
+				this.controls = null;
+				this.cube = null;
 
-					this.scene = null;
-					this.cameraDefaults = {
-						posCamera: new THREE.Vector3( 0.0, 175.0, 500.0 ),
-						posCameraTarget: new THREE.Vector3( 0, 0, 0 ),
-						near: 0.1,
-						far: 10000,
-						fov: 45
-					};
-					this.camera = null;
-					this.cameraTarget = this.cameraDefaults.posCameraTarget;
+				this.allAssets = [];
+				this.feedbackArray = null;
 
-					this.workerDirector = new THREE.LoaderSupport.WorkerDirector( THREE.OBJLoader2 );
-					this.logging = {
-						enabled: false,
-						debug: false
-					};
-					this.workerDirector.setLogging( this.logging.enabled, this.logging.debug );
-					this.workerDirector.setCrossOrigin( 'anonymous' );
-					this.workerDirector.setForceWorkerDataCopy( true );
+				this.running = false;
+			};
 
-					this.controls = null;
-					this.cube = null;
+			WWParallels.prototype = {
 
-					this.allAssets = [];
-					this.feedbackArray = null;
+				constructor: WWParallels,
 
-					this.running = false;
-
-				}
-
-				WWParallels.prototype.initGL = function () {
-
+				initGL: function () {
 					this.renderer = new THREE.WebGLRenderer( {
 						canvas: this.canvas,
 						antialias: true,
@@ -149,8 +146,8 @@
 					var directionalLight1 = new THREE.DirectionalLight( 0xC0C090 );
 					var directionalLight2 = new THREE.DirectionalLight( 0xC0C090 );
 
-					directionalLight1.position.set( - 100, - 50, 100 );
-					directionalLight2.position.set( 100, 50, - 100 );
+					directionalLight1.position.set( -100, -50, 100 );
+					directionalLight2.position.set( 100, 50, -100 );
 
 					this.scene.add( directionalLight1 );
 					this.scene.add( directionalLight2 );
@@ -161,45 +158,35 @@
 					this.cube = new THREE.Mesh( geometry, material );
 					this.cube.position.set( 0, 0, 0 );
 					this.scene.add( this.cube );
+				},
 
-				};
-
-				WWParallels.prototype.resizeDisplayGL = function () {
-
+				resizeDisplayGL: function () {
 					this.controls.handleResize();
 
 					this.recalcAspectRatio();
 					this.renderer.setSize( this.canvas.offsetWidth, this.canvas.offsetHeight, false );
 
 					this.updateCamera();
+				},
 
-				};
-
-				WWParallels.prototype.recalcAspectRatio = function () {
-
+				recalcAspectRatio: function () {
 					this.aspectRatio = ( this.canvas.offsetHeight === 0 ) ? 1 : this.canvas.offsetWidth / this.canvas.offsetHeight;
+				},
 
-				};
-
-				WWParallels.prototype.resetCamera = function () {
-
+				resetCamera: function () {
 					this.camera.position.copy( this.cameraDefaults.posCamera );
 					this.cameraTarget.copy( this.cameraDefaults.posCameraTarget );
 
 					this.updateCamera();
+				},
 
-				};
-
-				WWParallels.prototype.updateCamera = function () {
-
+				updateCamera: function () {
 					this.camera.aspect = this.aspectRatio;
 					this.camera.lookAt( this.cameraTarget );
 					this.camera.updateProjectionMatrix();
+				},
 
-				};
-
-				WWParallels.prototype.render = function () {
-
+				render: function () {
 					if ( ! this.renderer.autoClear ) this.renderer.clear();
 
 					this.controls.update();
@@ -208,22 +195,18 @@
 					this.cube.rotation.y += 0.05;
 
 					this.renderer.render( this.scene, this.camera );
+				},
 
-				};
-
-				WWParallels.prototype._reportProgress = function ( content ) {
-
+				_reportProgress: function( content ) {
 					var output = content;
-					if ( Validator.isValid( content ) && Validator.isValid( content.detail ) ) output = content.detail.text;
+					if ( THREE.LoaderSupport.Validator.isValid( content ) && THREE.LoaderSupport.Validator.isValid( content.detail ) ) output = content.detail.text;
 
-					output = Validator.verifyInput( output, '' );
-					if ( this.logging.enabled ) console.info( 'Progress:\n\t' + output.replace( /\<br\>/g, '\n\t' ) );
+					output = THREE.LoaderSupport.Validator.verifyInput( output, '' );
+					if ( this.logging.enabled ) console.info( 'Progress:\n\t' + output.replace(/\<br\>/g, '\n\t' ) );
 					document.getElementById( 'feedback' ).innerHTML = output;
+				},
 
-				};
-
-				WWParallels.prototype.enqueueAllAssests = function ( maxQueueSize, maxWebWorkers, streamMeshes ) {
-
+				enqueueAllAssests: function ( maxQueueSize, maxWebWorkers, streamMeshes ) {
 					if ( this.running ) {
 
 						return;
@@ -240,7 +223,7 @@
 					scope.reportDonwload = [];
 
 					var i;
-					for ( i = 0; i < maxWebWorkers; i ++ ) {
+					for ( i = 0; i < maxWebWorkers; i++ ) {
 
 						scope.feedbackArray[ i ] = 'Worker #' + i + ': Awaiting feedback';
 						scope.reportDonwload[ i ] = true;
@@ -249,7 +232,6 @@
 					scope._reportProgress( scope.feedbackArray.join( '\<br\>' ) );
 
 					var callbackOnLoad = function ( event ) {
-
 						var instanceNo = event.detail.instanceNo;
 						scope.reportDonwload[ instanceNo ] = false;
 						scope.allAssets.push( event.detail.loaderRootNode );
@@ -260,33 +242,35 @@
 						scope._reportProgress( scope.feedbackArray.join( '\<br\>' ) );
 
 						if ( scope.workerDirector.objectsCompleted + 1 === maxQueueSize ) scope.running = false;
-
 					};
 
 					var callbackReportProgress = function ( event ) {
-
 						var	instanceNo = event.detail.instanceNo;
 						var text = event.detail.text;
 
 						if ( scope.reportDonwload[ instanceNo ] ) {
-
 							var msg = 'Worker #' + instanceNo + ': ' + text;
 							if ( scope.logging.enabled ) console.info( msg );
 
 							scope.feedbackArray[ instanceNo ] = msg;
 							scope._reportProgress( scope.feedbackArray.join( '\<br\>' ) );
-
 						}
+					};
+
+					var callbackReportError = function ( supportDesc, errorMessage ) {
+
+						console.error( 'LoaderWorkerDirector reported an error: ' );
+						console.error( errorMessage );
+						return true;
 
 					};
 
 					var callbackMeshAlter = function ( event, override ) {
-
-						if ( ! Validator.isValid( override ) ) override = new THREE.LoaderSupport.LoadedMeshUserOverride( false, false );
+						if ( ! THREE.LoaderSupport.Validator.isValid( override ) ) override = new THREE.LoaderSupport.LoadedMeshUserOverride( false, false );
 
 						var material = event.detail.material;
 						var meshName = event.detail.meshName;
-						if ( Validator.isValid( material ) && material.name === 'defaultMaterial' || meshName === 'Mesh_Mesh_head_geo.001_lambert2SG.001' ) {
+						if ( THREE.LoaderSupport.Validator.isValid( material ) && material.name === 'defaultMaterial' || meshName === 'Mesh_Mesh_head_geo.001_lambert2SG.001' ) {
 
 							var materialOverride = material;
 							materialOverride.color = new THREE.Color( Math.random(), Math.random(), Math.random() );
@@ -298,18 +282,16 @@
 
 						}
 						return override;
-
 					};
 
 					var callbackOnLoadMaterials = function ( materials ) {
-
 						console.log( 'Materials loaded' );
 						return materials;
-
 					};
 
 					var callbacks = new THREE.LoaderSupport.Callbacks();
 					callbacks.setCallbackOnProgress( callbackReportProgress );
+					callbacks.setCallbackOnReportError( callbackReportError );
 					callbacks.setCallbackOnLoad( callbackOnLoad );
 					callbacks.setCallbackOnMeshAlter( callbackMeshAlter );
 					callbacks.setCallbackOnLoadMaterials( callbackOnLoadMaterials );
@@ -317,8 +299,8 @@
 					this.workerDirector.prepareWorkers( callbacks, maxQueueSize, maxWebWorkers );
 					if ( this.logging.enabled ) console.info( 'Configuring WWManager with queue size ' + this.workerDirector.getMaxQueueSize() + ' and ' + this.workerDirector.getMaxWebWorkers() + ' workers.' );
 
-					var modelPrepDatas = [];
 					var prepData;
+					var modelPrepDatas = [];
 					prepData = new THREE.LoaderSupport.PrepData( 'male02' );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/male02/male02.obj', 'OBJ ' ) );
 					prepData.addResource( new THREE.LoaderSupport.ResourceDescriptor( 'models/obj/male02/male02.mtl', 'MTL' ) );
@@ -350,18 +332,18 @@
 					modelPrepDatas.push( prepData );
 
 					var pivot;
-					var distributionBase = - 500;
+					var distributionBase = -500;
 					var distributionMax = 1000;
 					var modelPrepDataIndex = 0;
 					var modelPrepData;
 					var scale;
-					for ( i = 0; i < maxQueueSize; i ++ ) {
+					for ( i = 0; i < maxQueueSize; i++ ) {
 
 						modelPrepDataIndex = Math.floor( Math.random() * modelPrepDatas.length );
 
 						modelPrepData = modelPrepDatas[ modelPrepDataIndex ];
 						modelPrepData.useAsync = true;
-						scale = Validator.verifyInput( modelPrepData.scale, 0 );
+						scale = THREE.LoaderSupport.Validator.verifyInput( modelPrepData.scale, 0 );
 						modelPrepData = modelPrepData.clone();
 
 						pivot = new THREE.Object3D();
@@ -375,14 +357,11 @@
 						modelPrepData.streamMeshesTo = pivot;
 
 						this.workerDirector.enqueueForRun( modelPrepData );
-
 					}
 					this.workerDirector.processQueue();
+				},
 
-				};
-
-				WWParallels.prototype.clearAllAssests = function () {
-
+				clearAllAssests: function () {
 					var storedObject3d;
 					for ( var asset in this.allAssets ) {
 
@@ -407,41 +386,30 @@
 										if ( materials.hasOwnProperty( name ) ) materials[ name ].dispose();
 
 									}
-
 								}
-
 							}
-
 							if ( object3d.hasOwnProperty( 'texture' ) )	object3d.texture.dispose();
-
 						};
-						if ( Validator.isValid( storedObject3d ) ) {
+						if ( THREE.LoaderSupport.Validator.isValid( storedObject3d ) ) {
 
 							if ( this.pivot !== storedObject3d ) scope.scene.remove( storedObject3d );
 							storedObject3d.traverse( remover );
 							storedObject3d = null;
 
 						}
-
 					}
 					this.allAssets = [];
+				},
 
-				};
-
-				WWParallels.prototype.terminateManager = function () {
-
+				terminateManager: function () {
 					this.workerDirector.tearDown();
 					this.running = false;
+				},
 
-				};
-
-				WWParallels.prototype.terminateManagerAndClearScene = function () {
-
+				terminateManagerAndClearScene: function () {
 					var scope = this;
-					var scopedClearAllAssests = function () {
-
+					var scopedClearAllAssests = function (){
 						scope.clearAllAssests();
-
 					};
 					if ( this.workerDirector.isRunning() ) {
 
@@ -450,16 +418,12 @@
 					} else {
 
 						scopedClearAllAssests();
-
 					}
 
 					this.running = false;
+				}
 
-				};
-
-				return WWParallels;
-
-			} )();
+			};
 
 
 			var app = new WWParallels( document.getElementById( 'example' ) );
@@ -469,19 +433,13 @@
 				workerCount: 4,
 				streamMeshes: true,
 				run: function () {
-
 					app.enqueueAllAssests( this.queueLength, this.workerCount, this.streamMeshes );
-
 				},
 				terminate: function () {
-
 					app.terminateManager();
-
 				},
 				clearAllAssests: function () {
-
 					app.terminateManagerAndClearScene();
-
 				}
 			};
 			var gui = new dat.GUI( {
@@ -490,7 +448,7 @@
 			} );
 
 			var menuDiv = document.getElementById( 'dat' );
-			menuDiv.appendChild( gui.domElement );
+			menuDiv.appendChild(gui.domElement);
 			var folderQueue = gui.addFolder( 'Web Worker Director Queue Control' );
 			folderQueue.add( wwParallelsControl, 'queueLength' ).min( 1 ).max( 1024 ).step( 1 );
 			folderQueue.add( wwParallelsControl, 'workerCount' ).min( 1 ).max( 16 ).step( 1 );
@@ -503,16 +461,12 @@
 			folderWWControl.add( wwParallelsControl, 'clearAllAssests' ).name( 'Clear Scene' );
 
 			var resizeWindow = function () {
-
 				app.resizeDisplayGL();
-
 			};
 
 			var render = function () {
-
 				requestAnimationFrame( render );
 				app.render();
-
 			};
 
 			window.addEventListener( 'resize', resizeWindow, false );


### PR DESCRIPTION
The new version introduces new features:
- Original Repo Pull Request 46: It is now possible to run `THREE.OBJLoader2` in nodejs 10.5.0+. Thanks to @Cobertos

And it addresses the following problems:
- Original Repo Issue 47: Fixed incorrect vertex color pointerC initialization (omitting first set of values)
- Replaced Singletons with pure function/prototype definitions (backport from dev (V3.0.0)). Reason: Counter issues with worker code Blob generation from minified code base (e.g when using webpack)
- #12942: Align `setPath` and `setResourcePath` meaning and handling

**Note:** Change looks more dramatic than it really is due to replacement of singletons
