### PR TITLE
Line: more robust copy method

### DIFF
--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -248,8 +248,8 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		Object3D.prototype.copy.call( this, source );
 
-		this.geometry.copy( source.geometry );
-		this.material.copy( source.material );
+		this.geometry = source.geometry.clone();
+		this.material = source.material.clone();
 
 		return this;
 


### PR DESCRIPTION
This is tricky... I think we are going to have to use this pattern, instead.

1. `copy()` must work independently of `clone()`.
2. `copy()` must also work if the source material is a `ShaderMaterial` and the destination material is `LineBasicMaterial`. 
3. A similar argument goes for the geometry.

This has ramifications throughout the library, but it's fixable.

