### PR TITLE
correct method names setMin(),setMax() in Lut.html

### DIFF
--- a/docs/examples/Lut.html
+++ b/docs/examples/Lut.html
@@ -91,7 +91,7 @@
 		Sets the labels of the legend of this Lut.
 		</p>
 
-		<h3>[method:Lut setminV]( [param:Float minV] )</h3>
+		<h3>[method:Lut setMin]( [param:Float minV] )</h3>
 		<p>
 		minV — The minimum value to be represented with the lookup table.<br />
 		</p>
@@ -99,7 +99,7 @@
 		Sets this Lut with the minimum value to be represented.
 		</p>
 
-		<h3>[method:Lut setmaxV]( [param:Float maxV] )</h3>
+		<h3>[method:Lut setMax]( [param:Float maxV] )</h3>
 		<p>
 		maxV — The maximum value to be represented with the lookup table.<br />
 		</p>


### PR DESCRIPTION
Fixes #15068

l94-108 in Lut.html, names of methods seem not to include "V",and also "m" is capital.

.setmaxV()➝.setMax()