### PR TITLE
AnimationLoader: Added to build

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -32,6 +32,7 @@ export { DepthTexture } from './textures/DepthTexture.js';
 export { Texture } from './textures/Texture.js';
 export * from './geometries/Geometries.js';
 export * from './materials/Materials.js';
+export { AnimationLoader } from './loaders/AnimationLoader.js';
 export { CompressedTextureLoader } from './loaders/CompressedTextureLoader.js';
 export { DataTextureLoader } from './loaders/DataTextureLoader.js';
 export { CubeTextureLoader } from './loaders/CubeTextureLoader.js';


### PR DESCRIPTION
AnimationLoader was missing from Three.js

Fixes #15072