### PR TITLE
Fix sort function to be well defined (transitive) when undefined values are present.

### DIFF
--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -8,9 +8,11 @@ function painterSortStable( a, b ) {
 
 		return a.renderOrder - b.renderOrder;
 
-	} else if ( a.program && b.program && a.program !== b.program ) {
+	} else if ( a.program !== b.program ) {
 
-		return a.program.id - b.program.id;
+		var aId = a.program ? a.program.id : - 1;
+		var bId = b.program ? b.program.id : - 1;
+		return aId - bId;
 
 	} else if ( a.material.id !== b.material.id ) {
 


### PR DESCRIPTION
Current `painterSortStable` function is broken when objects with `undefined` `program` are present. The function is not transitive, therefore presence of any such value may break the sort function, leaving the render list unsorted.

This happens for a single frame any time a new object is added into the scene. The reason why it happens is `material.program` field is set during the rendering (see `initMaterial`), but the sorting is done before the rendering (see `currentRenderList.sort()`).

