### PR TITLE
CubeCamera: add options arg to constructor

### DIFF
--- a/docs/api/en/cameras/CubeCamera.html
+++ b/docs/api/en/cameras/CubeCamera.html
@@ -43,11 +43,17 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]( [param:Number near], [param:Number far], [param:Number cubeResolution] )</h3>
+		<h3>[name]( [param:Number near], [param:Number far], [param:Number cubeResolution], [param:Object options] )</h3>
 		<p>
 		near -- The near clipping distance. <br />
 		far -- The far clipping distance <br />
-		cubeResolution -- Sets the length of the cube's edges.
+		cubeResolution -- Sets the length of the cube's edges. <br />
+		options - (optional) object that holds texture parameters passed to the auto-generated WebGLRenderTargetCube.
+		If not specified, the options default to:
+		<code>
+		{ format: RGBFormat, magFilter: LinearFilter, minFilter: LinearFilter }
+		</code>
+
 		</p>
 		<p>
 		Constructs a CubeCamera that contains 6 [page:PerspectiveCamera PerspectiveCameras] that

--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -11,7 +11,7 @@ import { PerspectiveCamera } from './PerspectiveCamera.js';
  * @author alteredq / http://alteredqualia.com/
  */
 
-function CubeCamera( near, far, cubeResolution ) {
+function CubeCamera( near, far, cubeResolution, options ) {
 
 	Object3D.call( this );
 
@@ -49,7 +49,7 @@ function CubeCamera( near, far, cubeResolution ) {
 	cameraNZ.lookAt( new Vector3( 0, 0, - 1 ) );
 	this.add( cameraNZ );
 
-	var options = { format: RGBFormat, magFilter: LinearFilter, minFilter: LinearFilter };
+	options = options || { format: RGBFormat, magFilter: LinearFilter, minFilter: LinearFilter };
 
 	this.renderTarget = new WebGLRenderTargetCube( cubeResolution, cubeResolution, options );
 	this.renderTarget.texture.name = "CubeCamera";


### PR DESCRIPTION
This allows control over the `WebGLRenderTarget` that is created by the cube camera. This PR is backwards-compatible.