### PR TITLE
Add STL exporter in binary format to menu bar

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -288,7 +288,7 @@ Menubar.File = function ( editor ) {
 
 		var exporter = new THREE.STLExporter();
 
-		saveString( exporter.parse( editor.scene, { binary: true } ), 'model-binary.stl' );
+		saveArrayBuffer( exporter.parse( editor.scene, { binary: true } ), 'model-binary.stl' );
 
 	} );
 	options.add( option );

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -265,7 +265,7 @@ Menubar.File = function ( editor ) {
 	} );
 	options.add( option );
 
-	// Export STL
+	// Export STL (ASCII)
 
 	var option = new UI.Row();
 	option.setClass( 'option' );
@@ -279,6 +279,20 @@ Menubar.File = function ( editor ) {
 	} );
 	options.add( option );
 
+	// Export STL (Binary)
+	
+	var option = new UI.Row();
+	option.setClass( 'option' );
+	option.setTextContent( 'Export STL (Binary)' );
+	option.onClick( function () {
+
+		var exporter = new THREE.STLExporter();
+
+		saveString( exporter.parse( editor.scene, { binary: true } ), 'model-binary.stl' );
+
+	} );
+	options.add( option );
+	
 	//
 
 	options.add( new UI.HorizontalRule() );


### PR DESCRIPTION
This allows users to export STL file in binary format from header menu.