### PR TITLE
Allow for the ascii header to end with CRLF

### DIFF
--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -71,7 +71,7 @@ THREE.PLYLoader.prototype = {
 
 		function parseHeader( data ) {
 
-			var patternHeader = /ply([\s\S]*)end_header\s/;
+			var patternHeader = /ply([\s\S]*)end_header\r?\n/;
 			var headerText = '';
 			var headerLength = 0;
 			var result = patternHeader.exec( data );


### PR DESCRIPTION
Previously we assumed that the header of a ply file had to end with

    end_header\n

but it is there are systems that write the end as

    end_header\r\n

This previously left the rest of the file read off by one byte.

Fixes #14937