### PR TITLE
Add default frustum to OrthographicCamera

### DIFF
--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -15,10 +15,10 @@ function OrthographicCamera( left, right, top, bottom, near, far ) {
 	this.zoom = 1;
 	this.view = null;
 
-	this.left = left;
-	this.right = right;
-	this.top = top;
-	this.bottom = bottom;
+	this.left = ( left !== undefined ) ? left : -1;
+	this.right = ( right !== undefined ) ? right : 1;
+	this.top = ( top !== undefined ) ? ltopeft : 1;
+	this.bottom = ( bottom !== undefined ) ? bottom : -1;
 
 	this.near = ( near !== undefined ) ? near : 0.1;
 	this.far = ( far !== undefined ) ? far : 2000;

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -15,10 +15,10 @@ function OrthographicCamera( left, right, top, bottom, near, far ) {
 	this.zoom = 1;
 	this.view = null;
 
-	this.left = ( left !== undefined ) ? left : -1;
+	this.left = ( left !== undefined ) ? left : - 1;
 	this.right = ( right !== undefined ) ? right : 1;
 	this.top = ( top !== undefined ) ? top : 1;
-	this.bottom = ( bottom !== undefined ) ? bottom : -1;
+	this.bottom = ( bottom !== undefined ) ? bottom : - 1;
 
 	this.near = ( near !== undefined ) ? near : 0.1;
 	this.far = ( far !== undefined ) ? far : 2000;

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -17,7 +17,7 @@ function OrthographicCamera( left, right, top, bottom, near, far ) {
 
 	this.left = ( left !== undefined ) ? left : -1;
 	this.right = ( right !== undefined ) ? right : 1;
-	this.top = ( top !== undefined ) ? ltopeft : 1;
+	this.top = ( top !== undefined ) ? top : 1;
 	this.bottom = ( bottom !== undefined ) ? bottom : -1;
 
 	this.near = ( near !== undefined ) ? near : 0.1;


### PR DESCRIPTION
Not really frustum, but left,right,top,bottom plane offsets. When OrthigraphicCamera is constructed without parameters, it currently neither defaults nor warns of the mildly catastrophic result that all projected geometry is lost in rendering.

I personally discovered this when I tried to construct an OrthographicCamera without parameters, assuming that it would default to -1,1,1,-1, because that is a "neutral" projection. In many cases it is sufficient to have a neutral projection, e.g. when rendering a single XY plane of 2*2 size. Including defaults relieves the user (me) of having to check the order of the parameters every time.