### PR TITLE
Fix water reflection sampling coordinates

### DIFF
--- a/examples/js/objects/Water.js
+++ b/examples/js/objects/Water.js
@@ -162,7 +162,7 @@ THREE.Water = function ( geometry, options ) {
 			'	float distance = length(worldToEye);',
 
 			'	vec2 distortion = surfaceNormal.xz * ( 0.001 + 1.0 / distance ) * distortionScale;',
-			'	vec3 reflectionSample = vec3( texture2D( mirrorSampler, mirrorCoord.xy / mirrorCoord.z + distortion ) );',
+			'	vec3 reflectionSample = vec3( texture2D( mirrorSampler, mirrorCoord.xy / mirrorCoord.w + distortion ) );',
 
 			'	float theta = max( dot( eyeDirection, surfaceNormal ), 0.0 );',
 			'	float rf0 = 0.3;',


### PR DESCRIPTION
Hello!

This is a fix for the slightly wrong texture coordinates used for sampling the reflection texture in the current water shader example (ocean).

Especially at lower angles, reflection looks warped, and seams can appear at various angles.

![reflection_bug](https://user-images.githubusercontent.com/56287/47396102-cd222c80-d729-11e8-83f7-88c2094f563e.png)

(Water distortion is disabled in the image to showcase the issue)
