### PR TITLE
Improve error handling for LoadingManager

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -58,8 +58,8 @@ THREE.GLTFLoader = ( function () {
 
 				}
 
-				scope.manager.itemEnd( url );
 				scope.manager.itemError( url );
+				scope.manager.itemEnd( url );
 
 			};
 

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -141,8 +141,8 @@ Object.assign( FileLoader.prototype, {
 
 					if ( onError ) onError( error );
 
-					scope.manager.itemEnd( url );
 					scope.manager.itemError( url );
+					scope.manager.itemEnd( url );
 
 				}, 0 );
 
@@ -201,8 +201,8 @@ Object.assign( FileLoader.prototype, {
 
 					}
 
-					scope.manager.itemEnd( url );
 					scope.manager.itemError( url );
+					scope.manager.itemEnd( url );
 
 				}
 
@@ -234,8 +234,8 @@ Object.assign( FileLoader.prototype, {
 
 				}
 
-				scope.manager.itemEnd( url );
 				scope.manager.itemError( url );
+				scope.manager.itemEnd( url );
 
 			}, false );
 
@@ -252,8 +252,8 @@ Object.assign( FileLoader.prototype, {
 
 				}
 
-				scope.manager.itemEnd( url );
 				scope.manager.itemError( url );
+				scope.manager.itemEnd( url );
 
 			}, false );
 

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -85,8 +85,8 @@ ImageBitmapLoader.prototype = {
 
 			if ( onError ) onError( e );
 
-			scope.manager.itemEnd( url );
 			scope.manager.itemError( url );
+			scope.manager.itemEnd( url );
 
 		} );
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -66,8 +66,8 @@ Object.assign( ImageLoader.prototype, {
 
 			if ( onError ) onError( event );
 
-			scope.manager.itemEnd( url );
 			scope.manager.itemError( url );
+			scope.manager.itemEnd( url );
 
 		}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -527,8 +527,8 @@ Object.assign( ObjectLoader.prototype, {
 
 			}, undefined, function () {
 
-				scope.manager.itemEnd( url );
 				scope.manager.itemError( url );
+				scope.manager.itemEnd( url );
 
 			} );
 


### PR DESCRIPTION
I would like to manage the results of multiple loads with LoadingManager as follows.

```
const manager = new THREE.LoadingManager();

manager.onLoad = () => {
  console.log('onLoad')
};
manager.onProgress = (url) => {
  console.log('onProgress:' + url)
};
manager.onError = () => {
  console.log('onError')
};

const loader = new THREE.TextureLoader(manager);
loader.load('img/exist.png');
loader.load('img/not_exist.png');  // Not exist file
```

In this case, if an error occurs in the last loaded file, error handling is difficult since onLoad is called back before onError.

<img width="446" alt="2018-10-24 17 50 46" src="https://user-images.githubusercontent.com/22776388/47420486-824ff580-d7b9-11e8-87bc-de4e0bc56d17.png">

( If error occurrence is not the last one, error handling is easy because onError is called back before onLoad. )

<img width="448" alt="2018-10-24 17 52 25" src="https://user-images.githubusercontent.com/22776388/47420896-731d7780-d7ba-11e8-8f90-86ef6ab45171.png">

So, this PR is make sure to callback onError before onLoad.
