### PR TITLE
Fix combined frustum calculation used in setProjectionFromUnion for WebVR/WebXR

### DIFF
--- a/src/renderers/webvr/WebVRUtils.js
+++ b/src/renderers/webvr/WebVRUtils.js
@@ -9,7 +9,7 @@ var cameraLPos = new Vector3();
 var cameraRPos = new Vector3();
 
 /**
- * Assumes 2 cameras that are perpendicular and share an X-axis, and that
+ * Assumes 2 cameras that are parallel and share an X-axis, and that
  * the cameras' projection and world matrices have already been set.
  * And that near and far planes are identical for both cameras.
  */
@@ -31,22 +31,22 @@ function setProjectionFromUnion( camera, cameraL, cameraR ) {
 
 	var leftFovL = ( projL[ 8 ] - 1 ) / projL[ 0 ];
 	var rightFovR = ( projR[ 8 ] + 1 ) / projR[ 0 ];
-	var leftL = leftFovL * near;
-	var rightR = rightFovR * near;
+	var leftL = near * leftFovL;
+	var rightR = near * rightFovR;
 	var topL = near * ( projL[ 9 ] + 1 ) / projL[ 5 ];
 	var topR = near * ( projR[ 9 ] + 1 ) / projR[ 5 ];
 	var bottomL = near * ( projL[ 9 ] - 1 ) / projL[ 5 ];
 	var bottomR = near * ( projR[ 9 ] - 1 ) / projR[ 5 ];
 
 	// Calculate the new camera's position offset from the
-	// left camera.
-	var zOffset = ipd / ( leftFovL - rightFovR );
-	var xOffset = zOffset * leftFovL;
+	// left camera. xOffset should be roughly half `ipd`.
+	var zOffset = ipd / ( - leftFovL + rightFovR );
+	var xOffset = zOffset * - leftFovL;
 
 	// TODO: Better way to apply this offset?
 	cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
 	camera.translateX( xOffset );
-	camera.translateZ( - zOffset * 2 );
+	camera.translateZ( zOffset );
 	camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
 	camera.matrixWorldInverse.getInverse( camera.matrixWorld );
 


### PR DESCRIPTION
Follow up from #14950, @mrdoob found some issues with the union projection (https://github.com/mrdoob/three.js/pull/14950#issuecomment-432080998), and this follow up should get us up and running!

Current dev branch:

<img width="843" alt="before" src="https://user-images.githubusercontent.com/641267/47460569-a6004500-d793-11e8-988e-40e0ee055c67.PNG">

With this patch:
<img width="740" alt="afterfrustum" src="https://user-images.githubusercontent.com/641267/47460566-a39deb00-d793-11e8-9feb-8c3d90eca669.PNG">

Note: this was tested on Windows/Chrome/HTC Vive