### PR TITLE
Docs: Fix two tags

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -232,7 +232,7 @@
 
 		<h3>[method:null computeBoundingBox]()</h3>
 		<p>
-		Computes bounding box of the geometry, updating [param:.boundingBox] attribute.<br />
+		Computes bounding box of the geometry, updating [page:.boundingBox] attribute.<br />
 		Bounding boxes aren't computed by default. They need to be explicitly computed, otherwise they are *null*.
 		</p>
 

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -444,7 +444,7 @@ this.extensions = {
 		<h3>[property:Float wireframeLinewidth]</h3>
 		<p>Controls wireframe thickness. Default is 1.<br /><br />
 
-		Due to limitations of the [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile)
+		Due to limitations of the [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
 		with the [page:WebGLRenderer WebGL] renderer on most platforms linewidth will
 		always be 1 regardless of the set value.
 		</p>


### PR DESCRIPTION
In `core/BufferGeometry` there's a `[param:.boundingBox]` instead of `[page:.boundingBox]`:
https://github.com/mrdoob/three.js/blob/12450bedbef53649992cf55f10d7c1b9a253570f/docs/api/en/core/BufferGeometry.html#L235


And in `materials/ShaderMaterial` a `[link:..]` has a `)` instead of a `]` at the end:
https://github.com/mrdoob/three.js/blob/12450bedbef53649992cf55f10d7c1b9a253570f/docs/api/en/materials/ShaderMaterial.html#L447