### PR TITLE
OrbitControls: support panning with left mouse + shift key

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -426,6 +426,17 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	}
 
+
+	function isPanEvent( event ) {
+
+		return scope.panKeys.some( function ( key ) {
+
+			return event[ key ];
+
+		} );
+
+	}
+
 	//
 	// event callbacks - update the object state
 	//
@@ -682,7 +693,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			case scope.mouseButtons.LEFT:
 
-				if ( scope.panKeys.some( key => event[ key ] ) ) {
+				if ( isPanEvent( event ) ) {
 
 					if ( scope.enablePan === false ) return;
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -11,7 +11,7 @@
 //
 //    Orbit - left mouse / touch: one-finger move
 //    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
-//    Pan - right mouse, or left mouse + ctrl/metaKey, or arrow keys / touch: two-finger move
+//    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
 
 THREE.OrbitControls = function ( object, domElement ) {
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -74,9 +74,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// The four arrow keys
 	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
 
-	// The panning keys
-	this.panKeys = [ 'ctrlKey', 'metaKey' ];
-
 	// Mouse buttons
 	this.mouseButtons = { LEFT: THREE.MOUSE.LEFT, MIDDLE: THREE.MOUSE.MIDDLE, RIGHT: THREE.MOUSE.RIGHT };
 
@@ -426,19 +423,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	}
 
-
-	function isPanEvent( event ) {
-
-		var hasKey = function ( key ) {
-
-			return event[ key ];
-
-		};
-
-		return scope.panKeys.some( hasKey );
-
-	}
-
 	//
 	// event callbacks - update the object state
 	//
@@ -695,7 +679,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			case scope.mouseButtons.LEFT:
 
-				if ( isPanEvent( event ) ) {
+				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
 
 					if ( scope.enablePan === false ) return;
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -429,11 +429,13 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function isPanEvent( event ) {
 
-		return scope.panKeys.some( function ( key ) {
+		var hasKey = function ( key ) {
 
 			return event[ key ];
 
-		} );
+		};
+
+		return scope.panKeys.some( hasKey );
 
 	}
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -74,6 +74,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// The four arrow keys
 	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
 
+	// The panning keys
+	this.panKeys = [ 'ctrlKey', 'metaKey' ];
+
 	// Mouse buttons
 	this.mouseButtons = { LEFT: THREE.MOUSE.LEFT, MIDDLE: THREE.MOUSE.MIDDLE, RIGHT: THREE.MOUSE.RIGHT };
 
@@ -679,7 +682,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			case scope.mouseButtons.LEFT:
 
-				if ( event.ctrlKey || event.metaKey ) {
+				if ( scope.panKeys.some( key => event[ key ] ) ) {
 
 					if ( scope.enablePan === false ) return;
 


### PR DESCRIPTION
Initially, for the panning you need to use the ctrl/metaKey and this cannot be redefine.
Added the ability to set a custom pan keys, for example shiftKey.