### PR TITLE
Fix jpeg check in TextureLoader

### DIFF
--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -31,7 +31,7 @@ Object.assign( TextureLoader.prototype, {
 			texture.image = image;
 
 			// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
-			var isJPEG = url.search( /\.jpe?g$/i ) > 0 || url.search( /^data\:image\/jpeg/ ) === 0;
+			var isJPEG = url.search( /\.jpe?g($|\?)/i ) > 0 || url.search( /^data\:image\/jpeg/ ) === 0;
 
 			texture.format = isJPEG ? RGBFormat : RGBAFormat;
 			texture.needsUpdate = true;


### PR DESCRIPTION
Changed to allow JPEG URL with query string.
Please close this PR if it is different from policy.

Pass
 - xxx.jpg
 - xxx.jpg?
 - xxx.jpg?y=zz
 - xxx.jpeg
 - xxx.jpeg?
 - xxx.jpeg?y=zz