### PR TITLE
Docs - add links to base class

### DIFF
--- a/docs/api/en/geometries/CircleBufferGeometry.html
+++ b/docs/api/en/geometries/CircleBufferGeometry.html
@@ -52,11 +52,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/CircleGeometry.html
+++ b/docs/api/en/geometries/CircleGeometry.html
@@ -53,11 +53,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/ConeBufferGeometry.html
+++ b/docs/api/en/geometries/ConeBufferGeometry.html
@@ -54,11 +54,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:CylinderBufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:CylinderBufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/ConeGeometry.html
+++ b/docs/api/en/geometries/ConeGeometry.html
@@ -54,11 +54,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:CylinderGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:CylinderGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/CylinderBufferGeometry.html
+++ b/docs/api/en/geometries/CylinderBufferGeometry.html
@@ -55,11 +55,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/CylinderGeometry.html
+++ b/docs/api/en/geometries/CylinderGeometry.html
@@ -55,11 +55,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/DodecahedronBufferGeometry.html
+++ b/docs/api/en/geometries/DodecahedronBufferGeometry.html
@@ -41,11 +41,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:PolyhedronBufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:PolyhedronBufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/DodecahedronGeometry.html
+++ b/docs/api/en/geometries/DodecahedronGeometry.html
@@ -41,11 +41,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/EdgesGeometry.html
+++ b/docs/api/en/geometries/EdgesGeometry.html
@@ -34,11 +34,15 @@ scene.add( line );
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/ExtrudeBufferGeometry.html
+++ b/docs/api/en/geometries/ExtrudeBufferGeometry.html
@@ -93,12 +93,16 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
+	
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/geometries/ExtrudeGeometry.js src/geometries/ExtrudeGeometry.js]

--- a/docs/api/en/geometries/ExtrudeGeometry.html
+++ b/docs/api/en/geometries/ExtrudeGeometry.html
@@ -93,11 +93,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/IcosahedronBufferGeometry.html
+++ b/docs/api/en/geometries/IcosahedronBufferGeometry.html
@@ -40,11 +40,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:PolyhedronBufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:PolyhedronBufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/IcosahedronGeometry.html
+++ b/docs/api/en/geometries/IcosahedronGeometry.html
@@ -41,11 +41,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/LatheBufferGeometry.html
+++ b/docs/api/en/geometries/LatheBufferGeometry.html
@@ -59,11 +59,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+	
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/LatheGeometry.html
+++ b/docs/api/en/geometries/LatheGeometry.html
@@ -59,11 +59,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+	
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/OctahedronBufferGeometry.html
+++ b/docs/api/en/geometries/OctahedronBufferGeometry.html
@@ -40,11 +40,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:PolyhedronBufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:PolyhedronBufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/OctahedronGeometry.html
+++ b/docs/api/en/geometries/OctahedronGeometry.html
@@ -41,11 +41,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/ParametricBufferGeometry.html
+++ b/docs/api/en/geometries/ParametricBufferGeometry.html
@@ -53,12 +53,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/ParametricGeometry.html
+++ b/docs/api/en/geometries/ParametricGeometry.html
@@ -54,12 +54,15 @@
 
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/PlaneBufferGeometry.html
+++ b/docs/api/en/geometries/PlaneBufferGeometry.html
@@ -51,11 +51,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>.parameters</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/PlaneGeometry.html
+++ b/docs/api/en/geometries/PlaneGeometry.html
@@ -51,11 +51,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>.parameters</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/PolyhedronBufferGeometry.html
+++ b/docs/api/en/geometries/PolyhedronBufferGeometry.html
@@ -50,12 +50,15 @@ var geometry = new THREE.PolyhedronBufferGeometry( verticesOfCube, indicesOfFace
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/PolyhedronGeometry.html
+++ b/docs/api/en/geometries/PolyhedronGeometry.html
@@ -48,12 +48,15 @@ var geometry = new THREE.PolyhedronGeometry( verticesOfCube, indicesOfFaces, 6, 
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/RingBufferGeometry.html
+++ b/docs/api/en/geometries/RingBufferGeometry.html
@@ -54,12 +54,15 @@
 
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/RingGeometry.html
+++ b/docs/api/en/geometries/RingGeometry.html
@@ -53,12 +53,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
-		
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/ShapeBufferGeometry.html
+++ b/docs/api/en/geometries/ShapeBufferGeometry.html
@@ -65,11 +65,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/ShapeGeometry.html
+++ b/docs/api/en/geometries/ShapeGeometry.html
@@ -65,11 +65,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 
 		<h2>Source</h2>

--- a/docs/api/en/geometries/SphereBufferGeometry.html
+++ b/docs/api/en/geometries/SphereBufferGeometry.html
@@ -59,11 +59,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>.parameters</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/SphereGeometry.html
+++ b/docs/api/en/geometries/SphereGeometry.html
@@ -59,11 +59,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>.parameters</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TetrahedronBufferGeometry.html
+++ b/docs/api/en/geometries/TetrahedronBufferGeometry.html
@@ -41,13 +41,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:PolyhedronBufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
 
-
+		<h2>Methods</h2>
+		<p>See the base [page:PolyhedronBufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TetrahedronGeometry.html
+++ b/docs/api/en/geometries/TetrahedronGeometry.html
@@ -41,11 +41,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TextBufferGeometry.html
+++ b/docs/api/en/geometries/TextBufferGeometry.html
@@ -154,11 +154,15 @@
 		</table>
 
 		<h2>Properties</h2>
+		<p>See the base [page:ExtrudeBufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+	
+		<h2>Methods</h2>
+		<p>See the base [page:ExtrudeBufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TextGeometry.html
+++ b/docs/api/en/geometries/TextGeometry.html
@@ -154,11 +154,15 @@
 		</table>
 
 		<h2>Properties</h2>
+		<p>See the base [page:ExtrudeGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:ExtrudeGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TorusBufferGeometry.html
+++ b/docs/api/en/geometries/TorusBufferGeometry.html
@@ -52,11 +52,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>.parameters</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TorusGeometry.html
+++ b/docs/api/en/geometries/TorusGeometry.html
@@ -52,11 +52,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>.parameters</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/en/geometries/TorusKnotBufferGeometry.html
@@ -55,11 +55,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>.parameters</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TorusKnotGeometry.html
+++ b/docs/api/en/geometries/TorusKnotGeometry.html
@@ -55,11 +55,15 @@
 		</p>
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>.parameters</h3>
 		<p>
 		An object with a property for each of the constructor parameters. Any modification after instantiation does not change the geometry.
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TubeBufferGeometry.html
+++ b/docs/api/en/geometries/TubeBufferGeometry.html
@@ -77,6 +77,7 @@
 
 
 		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
@@ -97,6 +98,9 @@
 		<p>
 		An array of [page:Vector3] binormals
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/TubeGeometry.html
+++ b/docs/api/en/geometries/TubeGeometry.html
@@ -77,6 +77,7 @@
 
 
 		<h2>Properties</h2>
+		<p>See the base [page:Geometry] class for common properties.</p>
 
 		<h3>[property:Object parameters]</h3>
 		<p>
@@ -97,6 +98,9 @@
 		<p>
 		An array of [page:Vector3] binormals
 		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:Geometry] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/en/geometries/WireframeGeometry.html
+++ b/docs/api/en/geometries/WireframeGeometry.html
@@ -56,6 +56,12 @@ scene.add( line );
 		geometry — any geometry object.
 		</p>
 
+		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
+
 		<h2>Source</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]


### PR DESCRIPTION
I've added links in the documentation to the base class properties and methods. This is already in some existing doc pages, eg Line.html. I think it is helpful for experienced users so they can quickly get to the base class, and inexperienced users who thus become aware of the inheritance from the base class.  If agreed, I'd propose to do the same for other doc pages, to improve uniformity.