### PR TITLE
MapControls: support orbiting with mouse + shift key

### DIFF
--- a/examples/js/controls/MapControls.js
+++ b/examples/js/controls/MapControls.js
@@ -11,7 +11,7 @@
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
 // This is very similar to OrbitControls, another set of touch behavior
 //
-//    Orbit - right mouse, or left mouse + ctrl/metaKey / touch: two-finger rotate
+//    Orbit - right mouse, or left mouse + ctrl/meta/shiftKey / touch: two-finger rotate
 //    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
 //    Pan - left mouse, or arrow keys / touch: one-finger move
 
@@ -777,7 +777,7 @@ THREE.MapControls = function ( object, domElement ) {
 
 			case scope.mouseButtons.LEFT:
 
-				if ( event.ctrlKey || event.metaKey ) {
+				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
 
 					if ( scope.enableRotate === false ) return;
 


### PR DESCRIPTION
Update `MapControls` API to parallel `OrbitControls` API.

See #15140.
