### PR TITLE
Modified SVGLoader to return a Map of nodes to ShapePath objects

### DIFF
--- a/docs/examples/loaders/SVGLoader.html
+++ b/docs/examples/loaders/SVGLoader.html
@@ -91,7 +91,7 @@
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.svg</em> file.<br />
-		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives an array of [page:ShapePath] as an argument.<br />
+		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives a Map, where the keys are the SVG element nodes and the values are [page:ShapePath] objects, as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>

--- a/docs/examples/loaders/SVGLoader.html
+++ b/docs/examples/loaders/SVGLoader.html
@@ -91,7 +91,7 @@
 		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.svg</em> file.<br />
-		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives a Map, where the keys are the SVG element nodes and the values are [page:ShapePath] objects, as an argument.<br />
+		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives an array of [page:ShapePath] objects as the first argument, as well as a Map, where the keys are the paths and the SVG element nodes are the values, as the second argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>

--- a/docs/manual/en/introduction/Browser-support.html
+++ b/docs/manual/en/introduction/Browser-support.html
@@ -86,6 +86,11 @@
 					<td>Examples</td>
 					<td>PointerLockControls</td>
 				</tr>
+				<tr>
+					<td>Map</td>
+					<td>Examples</td>
+					<td>SVGLoader</td>
+				</tr>
 			</tbody>
 		</table>
 	</div>

--- a/docs/manual/zh/introduction/Browser-support.html
+++ b/docs/manual/zh/introduction/Browser-support.html
@@ -88,6 +88,11 @@
 					<td>Examples</td>
 					<td>PointerLockControls</td>
 				</tr>
+				<tr>
+					<td>Map</td>
+					<td>Examples</td>
+					<td>SVGLoader</td>
+				</tr>
 			</tbody>
 		</table>
 	</div>

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -22,7 +22,8 @@ THREE.SVGLoader.prototype = {
 		loader.setPath( scope.path );
 		loader.load( url, function ( text ) {
 
-			onLoad( scope.parse( text ) );
+			var parsed = scope.parse( text );
+			onLoad( parsed[0], parsed[1] );
 
 		}, onProgress, onError );
 
@@ -98,7 +99,8 @@ THREE.SVGLoader.prototype = {
 
 				transformPath( path, currentTransform );
 
-				paths.set( node, path );
+				paths.push( path );
+				nodeMap.set( path, node );
 
 			}
 
@@ -759,7 +761,7 @@ THREE.SVGLoader.prototype = {
 			var transform = new THREE.Matrix3();
 			var currentTransform = tempTransform0;
 			var transformsTexts = node.getAttribute( 'transform' ).split( ' ' );
-			
+
 			for ( var tIndex = transformsTexts.length - 1; tIndex >= 0; tIndex-- ) {
 
 				var transformText = transformsTexts[ tIndex ];
@@ -771,7 +773,7 @@ THREE.SVGLoader.prototype = {
 					var transformType = transformText.substr( 0, openParPos );
 
 					var array = parseFloats( transformText.substr( openParPos + 1, closeParPos - openParPos - 1 ) );
-					
+
 					currentTransform.identity();
 
 					switch ( transformType ) {
@@ -979,7 +981,8 @@ THREE.SVGLoader.prototype = {
 
 		console.log( 'THREE.SVGLoader' );
 
-		var paths = new Map();
+		var paths = [];
+		var nodeMap = new Map();
 
 		var transformStack = [];
 
@@ -1005,7 +1008,7 @@ THREE.SVGLoader.prototype = {
 
 		console.timeEnd( 'THREE.SVGLoader: Parse' );
 
-		return paths;
+		return [ paths, nodeMap ];
 
 	}
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -98,7 +98,7 @@ THREE.SVGLoader.prototype = {
 
 				transformPath( path, currentTransform );
 
-				paths.push( path );
+				paths.set( node, path );
 
 			}
 
@@ -979,7 +979,7 @@ THREE.SVGLoader.prototype = {
 
 		console.log( 'THREE.SVGLoader' );
 
-		var paths = [];
+		var paths = new Map();
 
 		var transformStack = [];
 


### PR DESCRIPTION
This is a proposal to allow the use of SVGLoader to expose additional information about the source file when working with the resulting ShapePaths.

Previously this returned a simple array of ShapePaths. Changing this to a Map can allow access to the SVG element node that the ShapePath was created from, exposing additional information available from the original SVG file.

For example, I used this to allow me to look up an ID on a parent `<g>` element, to determine how to render each ShapePath (different textures for different groups, etc).

This should be a pretty low-impact change... as a Map is still iterable, any existing code looping over the array will still loop over the Map and not even know that it's different.

One caveat would be that Map is not supported in IE10 or below, but it can be easily polyfilled. I updated the Browser Support docs to reflect this.