### PR TITLE
OBJLoader: Fix parsing of vertex colors

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -459,7 +459,7 @@ THREE.OBJLoader = ( function () {
 								parseFloat( data[ 2 ] ),
 								parseFloat( data[ 3 ] )
 							);
-							if ( data.length === 8 ) {
+							if ( data.length >= 7 ) {
 
 								state.colors.push(
 									parseFloat( data[ 4 ] ),


### PR DESCRIPTION
For vertex color, we should parse it as long as we have more than 7 elements in the line that starts with `"v "`.