### PR TITLE
Prefetch DRACO decoder on DRACO endcoded glTF load

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -508,6 +508,7 @@ THREE.GLTFLoader = ( function () {
 		this.name = EXTENSIONS.KHR_DRACO_MESH_COMPRESSION;
 		this.json = json;
 		this.dracoLoader = dracoLoader;
+		THREE.DRACOLoader.getDecoderModule();
 
 	}
 


### PR DESCRIPTION
Addresses issue posed in #15168.

When loading a DRACO encoded glTF model, the DRACO decoder should be fetched right when a DRACO encoded glTF file is loaded.

Loading a DRACO encoded glTF model on Chrome with Fast 3G network emulation, we get the following results:

No prefetching:
Time: 4.696 s
<img width="1076" alt="noprefetching" src="https://user-images.githubusercontent.com/12196053/47756109-127cb780-dc5e-11e8-9d1d-9456cbd83ea5.png">

With prefetching:
Time: 3.481 s
<img width="1076" alt="withprefetching" src="https://user-images.githubusercontent.com/12196053/47756128-245e5a80-dc5e-11e8-9d35-78f37b968599.png">
