### PR TITLE
VideoTexture: Set format to RGBFormat by default.

### DIFF
--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -2,9 +2,12 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
+import { RGBFormat } from '../constants.js';
 import { Texture } from './Texture.js';
 
 function VideoTexture( video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy ) {
+
+	if ( format === undefined ) format = RGBFormat;
 
 	Texture.call( this, video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
 

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -2,14 +2,17 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-import { RGBFormat } from '../constants.js';
+import { RGBFormat, LinearFilter } from '../constants.js';
 import { Texture } from './Texture.js';
 
 function VideoTexture( video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy ) {
 
-	if ( format === undefined ) format = RGBFormat;
-
 	Texture.call( this, video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
+
+	this.format = format !== undefined ? format : RGBFormat;
+
+	this.minFilter = minFilter !== undefined ? minFilter : LinearFilter;
+	this.magFilter = magFilter !== undefined ? magFilter : LinearFilter;
 
 	this.generateMipmaps = false;
 


### PR DESCRIPTION
`Texture` sets `format` to `RGBAFormat` if the user doesn't set it.
Would it make sense to set `VideoTexture`'s `format` to `RGBFormat` by default instead?