### PR TITLE
Cube Shader: Support decoding, tone mapping, and output encoding

### DIFF
--- a/src/renderers/shaders/ShaderLib/cube_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/cube_frag.glsl
@@ -6,7 +6,12 @@ varying vec3 vWorldDirection;
 
 void main() {
 
-	gl_FragColor = textureCube( tCube, vec3( tFlip * vWorldDirection.x, vWorldDirection.yz ) );
+	vec4 texColor = textureCube( tCube, vec3( tFlip * vWorldDirection.x, vWorldDirection.yz ) );
+
+	gl_FragColor = envMapTexelToLinear( texColor );
 	gl_FragColor.a *= opacity;
+
+	#include <tonemapping_fragment>
+	#include <encodings_fragment>
 
 }


### PR DESCRIPTION
As @mrdoob proposed in https://github.com/mrdoob/three.js/issues/13066#issuecomment-424564427.

With this PR, HDR scene background cube maps are supported.

