### PR TITLE
WebGLBackground: enable code injection

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -67,6 +67,17 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 
 				};
 
+				// enable code injection for non-built-in material
+				Object.defineProperty( boxMesh.material, 'envMap', {
+
+					get: function () {
+
+						return this.uniforms.tCube.value;
+
+					}
+
+				} );
+
 				objects.update( boxMesh );
 
 			}
@@ -96,6 +107,17 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 				);
 
 				planeMesh.geometry.removeAttribute( 'normal' );
+
+				// enable code injection for non-built-in material
+				Object.defineProperty( planeMesh.material, 'map', {
+
+					get: function () {
+
+						return this.uniforms.t2D.value;
+
+					}
+
+				} );
 
 				objects.update( planeMesh );
 


### PR DESCRIPTION
Shaders are modified by code injection in the `WebGLProgram` constructor.

The code injection only works correctly for built-in-materials where the material property names have been standardized. (e.g., `map`, `envMap`, etc.)

Shader materials,  however, can have arbitrary properties and uniforms.

This PR adds the necessary interface so code injection also works correctly for the background shaders.