### PR TITLE
do gpu picking with 1x1 pixel render target

### DIFF
--- a/examples/webgl_interactive_cubes_gpu_1_pixel.html
+++ b/examples/webgl_interactive_cubes_gpu_1_pixel.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - interactive cubes (gpu) 1 pixel</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #f0f0f0;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			.info {
+				position: absolute;
+				background-color: black;
+				opacity: 0.8;
+				color: white;
+				text-align: center;
+				top: 0px;
+				width: 100%;
+			}
+
+			.info a {
+				color: #00ffff;
+			}
+		</style>
+	</head>
+	<body>
+
+		<div class="info">
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - gpu picking 1 pixel
+		</div>
+
+		<div id="container"></div>
+
+		<script src="../build/three.js"></script>
+
+		<script src="js/controls/TrackballControls.js"></script>
+		<script src="js/utils/BufferGeometryUtils.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script>
+
+			var container, stats;
+			var camera, controls, scene, renderer;
+			var pickingData = [], pickingTexture, pickingScene;
+			var highlightBox;
+
+			var mouse = new THREE.Vector2();
+			var offset = new THREE.Vector3( 10, 10, 10 );
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.getElementById( "container" );
+
+				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 10000 );
+				camera.position.z = 1000;
+
+				controls = new THREE.TrackballControls( camera );
+				controls.rotateSpeed = 1.0;
+				controls.zoomSpeed = 1.2;
+				controls.panSpeed = 0.8;
+				controls.noZoom = false;
+				controls.noPan = false;
+				controls.staticMoving = true;
+				controls.dynamicDampingFactor = 0.3;
+
+				scene = new THREE.Scene();
+				scene.background = new THREE.Color( 0xffffff );
+
+				pickingScene = new THREE.Scene();
+				pickingTexture = new THREE.WebGLRenderTarget( 1, 1 );
+
+				scene.add( new THREE.AmbientLight( 0x555555 ) );
+
+				var light = new THREE.SpotLight( 0xffffff, 1.5 );
+				light.position.set( 0, 500, 2000 );
+				scene.add( light );
+
+				var pickingMaterial = new THREE.MeshBasicMaterial( { vertexColors: THREE.VertexColors } );
+				var defaultMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, flatShading: true, vertexColors: THREE.VertexColors, shininess: 0	} );
+
+				function applyVertexColors( geometry, color ) {
+
+					var position = geometry.attributes.position;
+					var colors = [];
+
+					for ( var i = 0; i < position.count; i ++ ) {
+
+						colors.push( color.r, color.g, color.b );
+
+					}
+
+					geometry.addAttribute( 'color', new THREE.Float32BufferAttribute( colors, 3 ) );
+
+				}
+
+				var geometriesDrawn = [];
+				var geometriesPicking = [];
+
+				var matrix = new THREE.Matrix4();
+				var quaternion = new THREE.Quaternion();
+				var color = new THREE.Color();
+
+				for ( var i = 0; i < 5000; i ++ ) {
+
+					var geometry = new THREE.BoxBufferGeometry();
+
+					var position = new THREE.Vector3();
+					position.x = Math.random() * 10000 - 5000;
+					position.y = Math.random() * 6000 - 3000;
+					position.z = Math.random() * 8000 - 4000;
+
+					var rotation = new THREE.Euler();
+					rotation.x = Math.random() * 2 * Math.PI;
+					rotation.y = Math.random() * 2 * Math.PI;
+					rotation.z = Math.random() * 2 * Math.PI;
+
+					var scale = new THREE.Vector3();
+					scale.x = Math.random() * 200 + 100;
+					scale.y = Math.random() * 200 + 100;
+					scale.z = Math.random() * 200 + 100;
+
+					quaternion.setFromEuler( rotation, false );
+					matrix.compose( position, quaternion, scale );
+
+					geometry.applyMatrix( matrix );
+
+					// give the geometry's vertices a random color, to be displayed
+
+					applyVertexColors( geometry, color.setHex( Math.random() * 0xffffff ) );
+
+					geometriesDrawn.push( geometry );
+
+					geometry = geometry.clone();
+
+					// give the geometry's vertices a color corresponding to the "id"
+
+					applyVertexColors( geometry, color.setHex( i ) );
+
+					geometriesPicking.push( geometry );
+
+					pickingData[ i ] = {
+
+						position: position,
+						rotation: rotation,
+						scale: scale
+
+					};
+
+				}
+
+				var objects = new THREE.Mesh( THREE.BufferGeometryUtils.mergeBufferGeometries( geometriesDrawn ), defaultMaterial );
+				scene.add( objects );
+
+				pickingScene.add( new THREE.Mesh( THREE.BufferGeometryUtils.mergeBufferGeometries( geometriesPicking ), pickingMaterial ) );
+
+				highlightBox = new THREE.Mesh(
+					new THREE.BoxBufferGeometry(),
+					new THREE.MeshLambertMaterial( { color: 0xffff00 }
+				) );
+				scene.add( highlightBox );
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
+
+				stats = new Stats();
+				container.appendChild( stats.dom );
+
+				renderer.domElement.addEventListener( 'mousemove', onMouseMove );
+
+			}
+
+			//
+
+			function onMouseMove( e ) {
+
+				mouse.x = e.clientX;
+				mouse.y = e.clientY;
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function pick() {
+
+				//render the picking scene off-screen
+
+                camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, mouse.x * window.devicePixelRatio | 0, mouse.y * window.devicePixelRatio | 0, 1, 1 );
+                camera.updateProjectionMatrix();
+				renderer.render( pickingScene, camera, pickingTexture );
+                camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, 0, 0, renderer.domElement.width, renderer.domElement.height );
+                camera.updateProjectionMatrix();
+
+				//create buffer for reading single pixel
+
+				var pixelBuffer = new Uint8Array( 4 );
+
+				//read the pixel under the mouse from the texture
+
+				renderer.readRenderTargetPixels( pickingTexture, 0, 0, 1, 1, pixelBuffer );
+
+				//interpret the pixel as an ID
+
+				var id = ( pixelBuffer[ 0 ] << 16 ) | ( pixelBuffer[ 1 ] << 8 ) | ( pixelBuffer[ 2 ] );
+				var data = pickingData[ id ];
+
+				if ( data) {
+
+					//move our highlightBox so that it surrounds the picked object
+
+					if ( data.position && data.rotation && data.scale ){
+
+						highlightBox.position.copy( data.position );
+						highlightBox.rotation.copy( data.rotation );
+						highlightBox.scale.copy( data.scale ).add( offset );
+						highlightBox.visible = true;
+
+					}
+
+				} else {
+
+					highlightBox.visible = false;
+
+				}
+
+			}
+
+			function render() {
+
+				controls.update();
+
+				pick();
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>


### PR DESCRIPTION
There's no reason to make a giant render target. For picking we're only going to read a single pixel so we can setup the camera so the math works out and just render that 1 pixel.

The main difference in this code vs the current GPU picking example is (a) make 1x1 pixel render target and then set the view offset when rendering the pick scene. Then read that 1x1 pixel

```js
camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, mouse.x * window.devicePixelRatio | 0, mouse.y * window.devicePixelRatio | 0, 1, 1 );
camera.updateProjectionMatrix();
renderer.render( pickingScene, camera, pickingTexture );
camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, 0, 0, renderer.domElement.width, renderer.domElement.height );
camera.updateProjectionMatrix();

// create buffer for reading single pixel

var pixelBuffer = new Uint8Array( 4 );

// read the pixel under the mouse from the texture

renderer.readRenderTargetPixels( pickingTexture, 0, 0, 1, 1, pixelBuffer );
```

Because the renderer might a device pixel ratio set we have to also put the mouse in that same range