### PR TITLE
do gpu picking with 1x1 pixel render target

### DIFF
--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -74,8 +74,7 @@
 				scene.background = new THREE.Color( 0xffffff );
 
 				pickingScene = new THREE.Scene();
-				pickingTexture = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight );
-				pickingTexture.texture.minFilter = THREE.LinearFilter;
+				pickingTexture = new THREE.WebGLRenderTarget( 1, 1 );
 
 				scene.add( new THREE.AmbientLight( 0x555555 ) );
 
@@ -201,15 +200,25 @@
 
 				//render the picking scene off-screen
 
+				// set the view offset to represent just a single pixel under the mouse
+
+				camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, mouse.x * window.devicePixelRatio | 0, mouse.y * window.devicePixelRatio | 0, 1, 1 );
+
+				// render the scene
+
 				renderer.render( pickingScene, camera, pickingTexture );
+
+				// clear the view offset so rendering returns to normal
+
+				camera.clearViewOffset();
 
 				//create buffer for reading single pixel
 
 				var pixelBuffer = new Uint8Array( 4 );
 
-				//read the pixel under the mouse from the texture
+				//read the pixel
 
-				renderer.readRenderTargetPixels( pickingTexture, mouse.x, pickingTexture.height - mouse.y, 1, 1, pixelBuffer );
+				renderer.readRenderTargetPixels( pickingTexture, 0, 0, 1, 1, pixelBuffer );
 
 				//interpret the pixel as an ID
 


### PR DESCRIPTION
There's no reason to make a giant render target. For picking we're only going to read a single pixel so we can setup the camera so the math works out and just render that 1 pixel.

The main difference in this code vs the current GPU picking example is (a) make 1x1 pixel render target and then set the view offset when rendering the pick scene. Then read that 1x1 pixel

```js
// set the view offset to represent just a single pixel under the mouse

camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, mouse.x * window.devicePixelRatio | 0, mouse.y * window.devicePixelRatio | 0, 1, 1 );
camera.updateProjectionMatrix();

// render the scene

renderer.render( pickingScene, camera, pickingTexture );

// clear the view offset so rendering returns to normal

camera.clearViewOffset();
camera.updateProjectionMatrix();

// create buffer for reading single pixel

var pixelBuffer = new Uint8Array( 4 );

// read the pixel

renderer.readRenderTargetPixels( pickingTexture, 0, 0, 1, 1, pixelBuffer );
```

Because the renderer might a device pixel ratio set we have to also put the mouse in that same range