### PR TITLE
Editor: fixes scripts container layout error.

### DIFF
--- a/editor/js/Sidebar.Script.js
+++ b/editor/js/Sidebar.Script.js
@@ -52,13 +52,9 @@ Sidebar.Script = function ( editor ) {
 
 		var scripts = editor.scripts[ object.uuid ];
 
-		if ( scripts !== undefined ) {
+		if ( scripts !== undefined && scripts.length > 0 ) {
 
-			if ( scripts.length > 0 ) {
-
-				scriptsContainer.setDisplay( 'block' );
-
-			}
+			scriptsContainer.setDisplay( 'block' );
 
 			for ( var i = 0; i < scripts.length; i ++ ) {
 

--- a/editor/js/Sidebar.Script.js
+++ b/editor/js/Sidebar.Script.js
@@ -54,7 +54,11 @@ Sidebar.Script = function ( editor ) {
 
 		if ( scripts !== undefined ) {
 
-			scriptsContainer.setDisplay( 'block' );
+			if ( scripts.length > 0 ) {
+
+				scriptsContainer.setDisplay( 'block' );
+
+			}
 
 			for ( var i = 0; i < scripts.length; i ++ ) {
 


### PR DESCRIPTION
I created a script for `Mesh`, and then delete it, but `script = []`, I add condition for `scriptsContainer`.

![image](https://user-images.githubusercontent.com/23699926/47947003-4fdb9080-df4f-11e8-9c19-9f797b5adcd8.png)