### PR TITLE
support Geometry in GLTFExporter

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1001,7 +1001,7 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function processMesh( mesh ) {
 
-			var geometry = mesh.geometry;
+			var geometry = mesh.geometry._bufferGeometry || mesh.geometry;
 
 			var mode;
 


### PR DESCRIPTION
ok, I know you guys hate old Geometry but, while it's still around, and it takes a single line to support it - why not?