### PR TITLE
BufferGeometryLoader: Honor .name and .userData in parse()

### DIFF
--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -85,6 +85,9 @@ Object.assign( BufferGeometryLoader.prototype, {
 
 		}
 
+		if ( json.name ) geometry.name = json.name;
+		if ( json.userData ) geometry.userData = json.userData;
+
 		return geometry;
 
 	},


### PR DESCRIPTION
Fixes #15209