### PR TITLE
WebGLRenderTarget: Set texture.generateMipmaps to false by default

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -26,11 +26,10 @@ function WebGLRenderTarget( width, height, options ) {
 
 	options = options || {};
 
-	if ( options.minFilter === undefined ) options.minFilter = LinearFilter;
-
 	this.texture = new Texture( undefined, undefined, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
 
-	this.texture.generateMipmaps = options.generateMipmaps !== undefined ? options.generateMipmaps : true;
+	this.texture.generateMipmaps = options.generateMipmaps !== undefined ? options.generateMipmaps : false;
+	this.texture.minFilter = options.minFilter !== undefined ? options.minFilter : LinearFilter;
 
 	this.depthBuffer = options.depthBuffer !== undefined ? options.depthBuffer : true;
 	this.stencilBuffer = options.stencilBuffer !== undefined ? options.stencilBuffer : true;


### PR DESCRIPTION
Currently, light shadow maps have `generateMipmaps` set to `true`. This is because `true` is the default value for `WebGLRenderTarget.texture.generateMipmaps`.

Although somewhat subjective, I also think https://github.com/mrdoob/three.js/pull/7245#issuecomment-164454230 is reasonable. It says:
> Building mipmap pyramids out of generated textures should really only be done if you know what you're doing.

This PR affects `WebGLRenderTarget` and `WebGLRenderTargetCube`.

If this is merged, I will make a note of this change in the migration docs.

---

By the way, I do not like this pattern:
```javascript
if ( options.minFilter === undefined ) options.minFilter = LinearFilter;
```
which alters the object passed in by the user. I think we should avoid using it.
