### PR TITLE
Cube Shader: treat texture as a map, not an environment map

### DIFF
--- a/src/renderers/shaders/ShaderLib/cube_frag.glsl
+++ b/src/renderers/shaders/ShaderLib/cube_frag.glsl
@@ -8,7 +8,7 @@ void main() {
 
 	vec4 texColor = textureCube( tCube, vec3( tFlip * vWorldDirection.x, vWorldDirection.yz ) );
 
-	gl_FragColor = envMapTexelToLinear( texColor );
+	gl_FragColor = mapTexelToLinear( texColor );
 	gl_FragColor.a *= opacity;
 
 	#include <tonemapping_fragment>

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -68,7 +68,7 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 				};
 
 				// enable code injection for non-built-in material
-				Object.defineProperty( boxMesh.material, 'envMap', {
+				Object.defineProperty( boxMesh.material, 'map', {
 
 					get: function () {
 


### PR DESCRIPTION
In the 'cube' shader, the uniform is a cube texture, but in this case, it is used as a map, not as an environment map.