### PR TITLE
SSAO: New implementation

### DIFF
--- a/examples/js/postprocessing/SSAOPass.js
+++ b/examples/js/postprocessing/SSAOPass.js
@@ -1,190 +1,375 @@
-'use strict';
-
 /**
- * Screen-space ambient occlusion pass.
- *
- * Has the following parameters
- *  - radius
- *  	- Ambient occlusion shadow radius (numeric value).
- *  - onlyAO
- *  	- Display only ambient occlusion result (boolean value).
- *  - aoClamp
- *  	- Ambient occlusion clamp (numeric value).
- *  - lumInfluence
- *  	- Pixel luminosity influence in AO calculation (numeric value).
- *
- * To output to screen set renderToScreens true
- *
- * @author alteredq / http://alteredqualia.com/
- * @author tentone
- * @class SSAOPass
+ * @author Mugen87 / https://github.com/Mugen87
  */
+
 THREE.SSAOPass = function ( scene, camera, width, height ) {
+
+	THREE.Pass.call( this );
+
+	this.width = ( width !== undefined ) ? width : 512;
+	this.height = ( height !== undefined ) ? height : 512;
+
+	this.clear = true;
+
+	this.camera = camera;
+	this.scene = scene;
+
+	this.kernelRadius = 8;
+	this.kernelSize = 64;
+	this.kernel = [];
+	this.noiseTexture = null;
+	this.output = 0;
+
+	this.minDistance = 0.005;
+	this.maxDistance = 0.1;
+
+	//
+
+	this.generateSampleKernel();
+	this.generateRandomKernelRotations();
+
+	// beauty render target with depth buffer
+
+	var depthTexture = new THREE.DepthTexture();
+	depthTexture.type = THREE.UnsignedShortType;
+	depthTexture.minFilter = THREE.NearestFilter;
+	depthTexture.maxFilter = THREE.NearestFilter;
+
+	this.beautyRenderTarget = new THREE.WebGLRenderTarget( width, height, {
+		minFilter: THREE.LinearFilter,
+		magFilter: THREE.LinearFilter,
+		format: THREE.RGBAFormat,
+		depthTexture: depthTexture,
+		depthBuffer: true
+	} );
+
+	// normal render target
+
+	this.normalRenderTarget = new THREE.WebGLRenderTarget( width, height, {
+		minFilter: THREE.NearestFilter,
+		magFilter: THREE.NearestFilter,
+		format: THREE.RGBAFormat
+	} );
+
+	// ssao render target
+
+	this.ssaoRenderTarget = new THREE.WebGLRenderTarget( width, height, {
+		minFilter: THREE.LinearFilter,
+		magFilter: THREE.LinearFilter,
+		format: THREE.RGBAFormat
+	} );
+
+	this.blurRenderTarget = this.ssaoRenderTarget.clone();
+
+	// ssao material
 
 	if ( THREE.SSAOShader === undefined ) {
 
-		console.warn( 'THREE.SSAOPass depends on THREE.SSAOShader' );
-		return new THREE.ShaderPass();
+		console.error( 'THREE.SSAOPass: The pass relies on THREE.SSAOShader.' );
 
 	}
 
-	THREE.ShaderPass.call( this, THREE.SSAOShader );
-
-	this.width = ( width !== undefined ) ? width : 512;
-	this.height = ( height !== undefined ) ? height : 256;
-
-	this.renderToScreen = false;
-
-	this.camera2 = camera;
-	this.scene2 = scene;
-
-	//Depth material
-	this.depthMaterial = new THREE.MeshDepthMaterial();
-	this.depthMaterial.depthPacking = THREE.RGBADepthPacking;
-	this.depthMaterial.blending = THREE.NoBlending;
-
-	//Depth render target
-	this.depthRenderTarget = new THREE.WebGLRenderTarget( this.width, this.height, { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter } );
-	//this.depthRenderTarget.texture.name = 'SSAOShader.rt';
-
-	//Shader uniforms
-	this.uniforms[ 'tDepth' ].value = this.depthRenderTarget.texture;
-	this.uniforms[ 'size' ].value.set( this.width, this.height );
-	this.uniforms[ 'cameraNear' ].value = this.camera2.near;
-	this.uniforms[ 'cameraFar' ].value = this.camera2.far;
-
-	this.uniforms[ 'radius' ].value = 4;
-	this.uniforms[ 'onlyAO' ].value = false;
-	this.uniforms[ 'aoClamp' ].value = 0.25;
-	this.uniforms[ 'lumInfluence' ].value = 0.7;
-
-	//Setters and getters for uniforms
-
-	Object.defineProperties( this, {
-
-		radius: {
-			get: function () {
-
-				return this.uniforms[ 'radius' ].value;
-
-			},
-			set: function ( value ) {
-
-				this.uniforms[ 'radius' ].value = value;
-
-			}
-		},
-
-		onlyAO: {
-			get: function () {
-
-				return this.uniforms[ 'onlyAO' ].value;
-
-			},
-			set: function ( value ) {
-
-				this.uniforms[ 'onlyAO' ].value = value;
-
-			}
-		},
-
-		aoClamp: {
-			get: function () {
-
-				return this.uniforms[ 'aoClamp' ].value;
-
-			},
-			set: function ( value ) {
-
-				this.uniforms[ 'aoClamp' ].value = value;
-
-			}
-		},
-
-		lumInfluence: {
-			get: function () {
-
-				return this.uniforms[ 'lumInfluence' ].value;
-
-			},
-			set: function ( value ) {
-
-				this.uniforms[ 'lumInfluence' ].value = value;
-
-			}
-		},
-
+	this.ssaoMaterial = new THREE.ShaderMaterial( {
+		defines: Object.assign( {}, THREE.SSAOShader.defines ),
+		uniforms: THREE.UniformsUtils.clone( THREE.SSAOShader.uniforms ),
+		vertexShader: THREE.SSAOShader.vertexShader,
+		fragmentShader: THREE.SSAOShader.fragmentShader,
+		blending: THREE.NoBlending
 	} );
 
+	this.ssaoMaterial.uniforms[ 'tDiffuse' ].value = this.beautyRenderTarget.texture;
+	this.ssaoMaterial.uniforms[ 'tNormal' ].value = this.normalRenderTarget.texture;
+	this.ssaoMaterial.uniforms[ 'tDepth' ].value = this.beautyRenderTarget.depthTexture;
+	this.ssaoMaterial.uniforms[ 'tNoise' ].value = this.noiseTexture;
+	this.ssaoMaterial.uniforms[ 'kernel' ].value = this.kernel;
+	this.ssaoMaterial.uniforms[ 'cameraNear' ].value = this.camera.near;
+	this.ssaoMaterial.uniforms[ 'cameraFar' ].value = this.camera.far;
+	this.ssaoMaterial.uniforms[ 'resolution' ].value.set( width, height );
+	this.ssaoMaterial.uniforms[ 'cameraProjectionMatrix' ].value.copy( this.camera.projectionMatrix );
+	this.ssaoMaterial.uniforms[ 'cameraInverseProjectionMatrix' ].value.getInverse( this.camera.projectionMatrix );
+
+	// normal material
+
+	this.normalMaterial = new THREE.MeshNormalMaterial();
+	this.normalMaterial.blending = THREE.NoBlending;
+
+	// blur material
+
+	this.blurMaterial = new THREE.ShaderMaterial( {
+		defines: Object.assign( {}, THREE.SSAOBlurShader.defines ),
+		uniforms: THREE.UniformsUtils.clone( THREE.SSAOBlurShader.uniforms ),
+		vertexShader: THREE.SSAOBlurShader.vertexShader,
+		fragmentShader: THREE.SSAOBlurShader.fragmentShader
+	} );
+	this.blurMaterial.uniforms[ 'tDiffuse' ].value = this.ssaoRenderTarget.texture;
+	this.blurMaterial.uniforms[ 'resolution' ].value.set( width, height );
+
+	// material for rendering the depth
+
+	this.depthRenderMaterial = new THREE.ShaderMaterial( {
+		defines: Object.assign( {}, THREE.SSAODepthShader.defines ),
+		uniforms: THREE.UniformsUtils.clone( THREE.SSAODepthShader.uniforms ),
+		vertexShader: THREE.SSAODepthShader.vertexShader,
+		fragmentShader: THREE.SSAODepthShader.fragmentShader,
+		blending: THREE.NoBlending
+	} );
+	this.depthRenderMaterial.uniforms[ 'tDepth' ].value = this.beautyRenderTarget.depthTexture;
+	this.depthRenderMaterial.uniforms[ 'cameraNear' ].value = this.camera.near;
+	this.depthRenderMaterial.uniforms[ 'cameraFar' ].value = this.camera.far;
+
+	// material for rendering the content of a render target
+
+	this.copyMaterial = new THREE.ShaderMaterial( {
+		uniforms: THREE.UniformsUtils.clone( THREE.CopyShader.uniforms ),
+		vertexShader: THREE.CopyShader.vertexShader,
+		fragmentShader: THREE.CopyShader.fragmentShader,
+		transparent: true,
+		depthTest: false,
+		depthWrite: false,
+		blendSrc: THREE.DstColorFactor,
+		blendDst: THREE.ZeroFactor,
+		blendEquation: THREE.AddEquation,
+		blendSrcAlpha: THREE.DstAlphaFactor,
+		blendDstAlpha: THREE.ZeroFactor,
+		blendEquationAlpha: THREE.AddEquation
+	} );
+
+	//
+
+	this.quadCamera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	this.quadScene = new THREE.Scene();
+	this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
+	this.quadScene.add( this.quad );
+
 };
 
-THREE.SSAOPass.prototype = Object.create( THREE.ShaderPass.prototype );
+THREE.SSAOPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ), {
 
-/**
- * Render using this pass.
- *
- * @method render
- * @param {WebGLRenderer} renderer
- * @param {WebGLRenderTarget} writeBuffer Buffer to write output.
- * @param {WebGLRenderTarget} readBuffer Input buffer.
- * @param {Number} delta Delta time in milliseconds.
- * @param {Boolean} maskActive Not used in this pass.
- */
-THREE.SSAOPass.prototype.render = function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
+	constructor: THREE.SSAOPass,
 
-	//Render depth into depthRenderTarget
-	this.scene2.overrideMaterial = this.depthMaterial;
+	render: function ( renderer, writeBuffer /*, readBuffer, delta, maskActive */ ) {
 
-	renderer.render( this.scene2, this.camera2, this.depthRenderTarget, true );
+		// render beauty and depth
 
-	this.scene2.overrideMaterial = null;
+		renderer.setClearColor( 0x000000 );
+		renderer.render( this.scene, this.camera, this.beautyRenderTarget, true );
 
+		// render normals
 
-	//SSAO shaderPass
-	THREE.ShaderPass.prototype.render.call( this, renderer, writeBuffer, readBuffer, delta, maskActive );
+		this.renderOverride( renderer, this.normalMaterial, this.normalRenderTarget, 0x7777ff, 1.0 );
 
-};
+		// render SSAO
 
-/**
- * Change scene to be renderer by this render pass.
- *
- * @method setScene
- * @param {Scene} scene
- */
-THREE.SSAOPass.prototype.setScene = function ( scene ) {
+		this.ssaoMaterial.uniforms[ 'kernelRadius' ].value = this.kernelRadius;
+		this.ssaoMaterial.uniforms[ 'minDistance' ].value = this.minDistance;
+		this.ssaoMaterial.uniforms[ 'maxDistance' ].value = this.maxDistance;
+		this.renderPass( renderer, this.ssaoMaterial, this.ssaoRenderTarget );
 
-	this.scene2 = scene;
+		// render blur
 
-};
+		this.renderPass( renderer, this.blurMaterial, this.blurRenderTarget );
 
-/**
- * Set camera used by this render pass.
- *
- * @method setCamera
- * @param {Camera} camera
- */
-THREE.SSAOPass.prototype.setCamera = function ( camera ) {
+		// output result to screen
 
-	this.camera2 = camera;
+		switch ( this.output ) {
 
-	this.uniforms[ 'cameraNear' ].value = this.camera2.near;
-	this.uniforms[ 'cameraFar' ].value = this.camera2.far;
+			case THREE.SSAOPass.OUTPUT.SSAO:
 
-};
+				this.copyMaterial.uniforms[ 'tDiffuse' ].value = this.ssaoRenderTarget.texture;
+				this.copyMaterial.blending = THREE.NoBlending;
+				this.renderPass( renderer, this.copyMaterial, null, true );
 
-/**
- * Set resolution of this render pass.
- *
- * @method setSize
- * @param {Number} width
- * @param {Number} height
- */
-THREE.SSAOPass.prototype.setSize = function ( width, height ) {
+				break;
 
-	this.width = width;
-	this.height = height;
+			case THREE.SSAOPass.OUTPUT.Blur:
 
-	this.uniforms[ 'size' ].value.set( this.width, this.height );
-	this.depthRenderTarget.setSize( this.width, this.height );
+				this.copyMaterial.uniforms[ 'tDiffuse' ].value = this.blurRenderTarget.texture;
+				this.copyMaterial.blending = THREE.NoBlending;
+				this.renderPass( renderer, this.copyMaterial, null, true );
 
+				break;
+
+			case THREE.SSAOPass.OUTPUT.Beauty:
+
+				this.copyMaterial.uniforms[ 'tDiffuse' ].value = this.beautyRenderTarget.texture;
+				this.copyMaterial.blending = THREE.NoBlending;
+				this.renderPass( renderer, this.copyMaterial, null, true );
+
+				break;
+
+			case THREE.SSAOPass.OUTPUT.Depth:
+
+				this.renderPass( renderer, this.depthRenderMaterial, null, true );
+
+				break;
+
+			case THREE.SSAOPass.OUTPUT.Normal:
+
+				this.copyMaterial.uniforms[ 'tDiffuse' ].value = this.normalRenderTarget.texture;
+				this.copyMaterial.blending = THREE.NoBlending;
+				this.renderPass( renderer, this.copyMaterial, null, true );
+
+				break;
+
+			case THREE.SSAOPass.OUTPUT.Default:
+
+				this.copyMaterial.uniforms[ 'tDiffuse' ].value = this.beautyRenderTarget.texture;
+				this.copyMaterial.blending = THREE.NoBlending;
+				this.renderPass( renderer, this.copyMaterial, null, true );
+
+				this.copyMaterial.uniforms[ 'tDiffuse' ].value = this.blurRenderTarget.texture;
+				this.copyMaterial.blending = THREE.CustomBlending;
+				this.renderPass( renderer, this.copyMaterial, this.renderToScreen ? null : writeBuffer );
+
+				break;
+
+			default:
+				console.warn( 'THREE.SSAOPass: Unknown output type.' );
+
+		}
+
+	},
+
+	renderPass: function ( renderer, passMaterial, renderTarget, clearColor, clearAlpha ) {
+
+		// save original state
+		var originalClearColor = renderer.getClearColor();
+		var originalClearAlpha = renderer.getClearAlpha();
+		var originalAutoClear = renderer.autoClear;
+
+		// setup pass state
+		renderer.autoClear = false;
+		var clearNeeded = ( clearColor !== undefined ) && ( clearColor !== null );
+		if ( clearNeeded ) {
+
+			renderer.setClearColor( clearColor );
+			renderer.setClearAlpha( clearAlpha || 0.0 );
+
+		}
+
+		this.quad.material = passMaterial;
+		renderer.render( this.quadScene, this.quadCamera, renderTarget, clearNeeded );
+
+		// restore original state
+		renderer.autoClear = originalAutoClear;
+		renderer.setClearColor( originalClearColor );
+		renderer.setClearAlpha( originalClearAlpha );
+
+	},
+
+	renderOverride: function ( renderer, overrideMaterial, renderTarget, clearColor, clearAlpha ) {
+
+		var originalClearColor = renderer.getClearColor();
+		var originalClearAlpha = renderer.getClearAlpha();
+		var originalAutoClear = renderer.autoClear;
+
+		renderer.autoClear = false;
+
+		clearColor = overrideMaterial.clearColor || clearColor;
+		clearAlpha = overrideMaterial.clearAlpha || clearAlpha;
+
+		var clearNeeded = ( clearColor !== undefined ) && ( clearColor !== null );
+
+		if ( clearNeeded ) {
+
+			renderer.setClearColor( clearColor );
+			renderer.setClearAlpha( clearAlpha || 0.0 );
+
+		}
+
+		this.scene.overrideMaterial = overrideMaterial;
+		renderer.render( this.scene, this.camera, renderTarget, clearNeeded );
+		this.scene.overrideMaterial = null;
+
+		// restore original state
+
+		renderer.autoClear = originalAutoClear;
+		renderer.setClearColor( originalClearColor );
+		renderer.setClearAlpha( originalClearAlpha );
+
+	},
+
+	setSize: function ( width, height ) {
+
+		this.width = width;
+		this.height = height;
+
+		this.beautyRenderTarget.setSize( width, height );
+		this.ssaoRenderTarget.setSize( width, height );
+		this.normalRenderTarget.setSize( width, height );
+		this.blurRenderTarget.setSize( width, height );
+
+		this.ssaoMaterial.uniforms[ 'resolution' ].value.set( width, height );
+		this.ssaoMaterial.uniforms[ 'cameraProjectionMatrix' ].value.copy( this.camera.projectionMatrix );
+		this.ssaoMaterial.uniforms[ 'cameraInverseProjectionMatrix' ].value.getInverse( this.camera.projectionMatrix );
+
+		this.blurMaterial.uniforms[ 'resolution' ].value.set( width, height );
+
+	},
+
+	generateSampleKernel: function () {
+
+		var kernelSize = this.kernelSize;
+		var kernel = this.kernel;
+
+		for ( var i = 0; i < kernelSize; i ++ ) {
+
+			var sample = new THREE.Vector3();
+			sample.x = ( Math.random() * 2 ) - 1;
+			sample.y = ( Math.random() * 2 ) - 1;
+			sample.z = Math.random();
+
+			sample.normalize();
+
+			var scale = i / kernelSize;
+			scale = THREE.Math.lerp( 0.1, 1, scale * scale );
+			sample.multiplyScalar( scale );
+
+			kernel.push( sample );
+
+		}
+
+	},
+
+	generateRandomKernelRotations: function () {
+
+		var width = 4, height = 4;
+
+		if ( SimplexNoise === undefined ) {
+
+			console.error( 'THREE.SSAOPass: The pass relies on THREE.SimplexNoise.' );
+
+		}
+
+		var simplex = new SimplexNoise();
+
+		var size = width * height;
+		var data = new Float32Array( size );
+
+		for ( var i = 0; i < size; i ++ ) {
+
+			var x = ( Math.random() * 2 ) - 1;
+			var y = ( Math.random() * 2 ) - 1;
+			var z = 0;
+
+			data[ i ] = simplex.noise3d( x, y, z );
+
+		}
+
+		this.noiseTexture = new THREE.DataTexture( data, width, height, THREE.LuminanceFormat, THREE.FloatType );
+		this.noiseTexture.wrapS = THREE.RepeatWrapping;
+		this.noiseTexture.wrapT = THREE.RepeatWrapping;
+		this.noiseTexture.needsUpdate = true;
+
+	}
+
+} );
+
+THREE.SSAOPass.OUTPUT = {
+	'Default': 0,
+	'SSAO': 1,
+	'Blur': 2,
+	'Beauty': 3,
+	'Depth': 4,
+	'Normal': 5
 };

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -1,11 +1,4 @@
 <!DOCTYPE html>
-
-<!--Reference:
-SSAO algo: http://devlog-martinsh.blogspot.tw/2011/12/ssao-shader-update-v12.html?showComment=1398158188712#c1563204765906693531
-log depth http://outerra.blogspot.tw/2013/07/logarithmic-depth-buffer-optimizations.html
-convert the exponential depth to a linear value: http://www.ozone3d.net/blogs/lab/20090206/how-to-linearize-the-depth-value/
-Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info/wiki/Evenly_distributed_points_on_sphere-->
-
 <html lang="en">
 	<head>
 		<title>three.js webgl - postprocessing - Screen Space Ambient Occlusion</title>
@@ -40,21 +33,24 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 		<script src="../build/three.js"></script>
 
 		<script src="js/shaders/SSAOShader.js"></script>
-		<script src="js/shaders/CopyShader.js"></script>
 
 		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>
-		<script src="js/postprocessing/MaskPass.js"></script>
 		<script src="js/postprocessing/SSAOPass.js"></script>
+		<script src="js/shaders/CopyShader.js"></script>
+		<script src="js/SimplexNoise.js"></script>
 
 		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
 		<div id="info">
-			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl screen space ambient occlusion example<br/>
-			shader by <a href="http://alteredqualia.com">alteredq</a>
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - screen space ambient occlusion<br/>
+
+			<div id="error" style="display: none;">
+				Your browser does not support <strong>WEBGL_depth_texture</strong>.<br/><br/>
+				This demo will not work.
+			</div>
 		</div>
 
 		<script>
@@ -71,8 +67,6 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 			var ssaoPass;
 			var group;
 
-			var postprocessing = { enabled: true, onlyAO: false, radius: 32, aoClamp: 0.25, lumInfluence: 0.7 };
-
 			init();
 			animate();
 
@@ -84,6 +78,13 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 				renderer = new THREE.WebGLRenderer();
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
+
+				if ( ! renderer.extensions.get( 'WEBGL_depth_texture' ) ) {
+
+					document.querySelector( '#error' ).style.display = 'block';
+					return;
+
+				}
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 100, 700 );
 				camera.position.z = 500;
@@ -118,40 +119,36 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				// Init postprocessing
-				initPostprocessing();
+				ssaoPass = new THREE.SSAOPass( scene, camera );
+				ssaoPass.renderToScreen = true;
+
+				effectComposer = new THREE.EffectComposer( renderer );
+				effectComposer.addPass( ssaoPass );
 
 				// Init gui
 				var gui = new dat.GUI();
-				gui.add( postprocessing, 'enabled' );
 
-				gui.add( postprocessing, 'onlyAO', false ).onChange( function ( value ) {
+				gui.add( ssaoPass, 'output', {
+					'Default': THREE.SSAOPass.OUTPUT.Default,
+					'SSAO Only': THREE.SSAOPass.OUTPUT.SSAO,
+					'SSAO Only + Blur': THREE.SSAOPass.OUTPUT.Blur,
+					'Beauty': THREE.SSAOPass.OUTPUT.Beauty,
+					'Depth': THREE.SSAOPass.OUTPUT.Depth,
+					'Normal': THREE.SSAOPass.OUTPUT.Normal
+				} ).onChange( function ( value ) {
 
-					ssaoPass.onlyAO = value;
-
-				} );
-				gui.add( postprocessing, 'radius' ).min( 0 ).max( 64 ).onChange( function ( value ) {
-
-					ssaoPass.radius = value;
-
-				} );
-				gui.add( postprocessing, 'aoClamp' ).min( 0 ).max( 1 ).onChange( function ( value ) {
-
-					ssaoPass.aoClamp = value;
+					ssaoPass.output = parseInt( value );
 
 				} );
-				gui.add( postprocessing, 'lumInfluence' ).min( 0 ).max( 1 ).onChange( function ( value ) {
-
-					ssaoPass.lumInfluence = value;
-
-				} );
+				gui.add( ssaoPass, 'kernelRadius' ).min( 0 ).max( 32 );
+				gui.add( ssaoPass, 'minDistance' ).min( 0.001 ).max( 0.02 );
+				gui.add( ssaoPass, 'maxDistance' ).min( 0.01 ).max( 0.3 );
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
 				onWindowResize();
 
 			}
-
 
 			function onWindowResize() {
 
@@ -162,29 +159,7 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 				camera.updateProjectionMatrix();
 				renderer.setSize( width, height );
 
-				// Resize renderTargets
 				ssaoPass.setSize( width, height );
-
-				var pixelRatio = renderer.getPixelRatio();
-				var newWidth = Math.floor( width / pixelRatio ) || 1;
-				var newHeight = Math.floor( height / pixelRatio ) || 1;
-				effectComposer.setSize( newWidth, newHeight );
-
-			}
-
-			function initPostprocessing() {
-
-				// Setup render pass
-				var renderPass = new THREE.RenderPass( scene, camera );
-
-				// Setup SSAO pass
-				ssaoPass = new THREE.SSAOPass( scene, camera );
-				ssaoPass.renderToScreen = true;
-
-				// Add pass to effect composer
-				effectComposer = new THREE.EffectComposer( renderer );
-				effectComposer.addPass( renderPass );
-				effectComposer.addPass( ssaoPass );
 
 			}
 
@@ -204,15 +179,7 @@ Spiral sampling http://web.archive.org/web/20120421191837/http://www.cgafaq.info
 				group.rotation.x = timer * 0.0002;
 				group.rotation.y = timer * 0.0001;
 
-				if ( postprocessing.enabled ) {
-
-					effectComposer.render();
-
-				} else {
-
-					renderer.render( scene, camera );
-
-				}
+				effectComposer.render();
 
 			}
 


### PR DESCRIPTION
This PR introduces a new screen space ambient occlusion (SSAO) shader. Most of the implementation is based on John  Chapman's [article](http://john-chapman-graphics.blogspot.com/2013/01/ssao-tutorial.html) about SSAO.

The code hopefully fixes #8576 since it's provides a more or less real ambient occlusion effect.

As mentioned by a [user](http://john-chapman-graphics.blogspot.com/2013/01/ssao-tutorial.html?showComment=1367624542487#c1527234297842232685) in the linked article, the implemented blur shader produces a thin halo of non-occlusion when there are high frequencies in the depth buffer (steep changes of depth values). I guess the usage of `DepthLimitedBlurShader` might solve this issue, but it's a more complex blur and thus computationally more expensive (and in general not necessary in all use cases).