### PR TITLE
ImageUtils: Create internal canvas only once

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -4,6 +4,8 @@
  * @author szimek / https://github.com/szimek/
  */
 
+var _canvas;
+
 var ImageUtils = {
 
 	getDataURL: function ( image ) {
@@ -20,11 +22,12 @@ var ImageUtils = {
 
 		} else {
 
-			canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
-			canvas.width = image.width;
-			canvas.height = image.height;
+			if ( _canvas === undefined ) _canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
 
-			var context = canvas.getContext( '2d' );
+			_canvas.width = image.width;
+			_canvas.height = image.height;
+
+			var context = _canvas.getContext( '2d' );
 
 			if ( image instanceof ImageData ) {
 
@@ -35,6 +38,8 @@ var ImageUtils = {
 				context.drawImage( image, 0, 0, image.width, image.height );
 
 			}
+
+			canvas = _canvas;
 
 		}
 


### PR DESCRIPTION
Fixes #15247

It's the same approach we already use in `WebGLTextures`, see

https://github.com/mrdoob/three.js/blob/1715e623ecf7b451bfef7f460cd7b2cb0828d9e6/src/renderers/webgl/WebGLTextures.js#L58