### PR TITLE
Examples: Fix mipmapping usage of rendertargets

### DIFF
--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -211,6 +211,7 @@ THREE.AdaptiveToneMappingPass.prototype = Object.assign( Object.create( THREE.Pa
 
 		// We only need mipmapping for the current luminosity because we want a down-sampled version to sample in our adaptive shader
 		pars.minFilter = THREE.LinearMipMapLinearFilter;
+		pars.generateMipmaps = true;
 		this.currentLuminanceRT = new THREE.WebGLRenderTarget( this.resolution, this.resolution, pars );
 		this.currentLuminanceRT.texture.name = "AdaptiveToneMappingPass.cl";
 

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -71,10 +71,12 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
 				cubeCamera1 = new THREE.CubeCamera( 1, 1000, 256 );
+				cubeCamera1.renderTarget.texture.generateMipmaps = true;
 				cubeCamera1.renderTarget.texture.minFilter = THREE.LinearMipMapLinearFilter;
 				scene.add( cubeCamera1 );
 
 				cubeCamera2 = new THREE.CubeCamera( 1, 1000, 256 );
+				cubeCamera2.renderTarget.texture.generateMipmaps = true;
 				cubeCamera2.renderTarget.texture.minFilter = THREE.LinearMipMapLinearFilter;
 				scene.add( cubeCamera2 );
 

--- a/examples/webgl_materials_skin.html
+++ b/examples/webgl_materials_skin.html
@@ -201,6 +201,7 @@
 				//
 
 				var pars = {
+					generateMipmaps: true,
 					minFilter: THREE.LinearMipmapLinearFilter,
 					magFilter: THREE.LinearFilter,
 					format: THREE.RGBFormat,


### PR DESCRIPTION
Fix example code, see #15236

`webgl_materials_cubemap_dynamic` and `webgl_shaders_tonemapping` were actually broken.