### PR TITLE
Pass XRFrame reference to client render loop.

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -353,7 +353,7 @@ function WebXRManager( renderer, gl ) {
 
 		}
 
-		if ( onAnimationFrameCallback ) onAnimationFrameCallback( time );
+		if ( onAnimationFrameCallback ) onAnimationFrameCallback( time, frame );
 
 	}
 


### PR DESCRIPTION
A-Frame handles controllers externally and is needed to query their pose.