### PR TITLE
dispose for EventDispatcher and subclasses to prevent memory leaks

### DIFF
--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -753,6 +753,16 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
+	},
+
+	dispose: function () {
+
+		EventDispatcher.prototype.dispose.call( this );
+
+		this.stopAllAction();
+
+		// TODO is that it?
+
 	}
 
 } );

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1119,6 +1119,8 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	dispose: function () {
 
+		EventDispatcher.prototype.dispose.call( this );
+
 		this.dispatchEvent( { type: 'dispose' } );
 
 	}

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -78,6 +78,19 @@ Object.assign( EventDispatcher.prototype, {
 
 		}
 
+	},
+
+	dispose: function () {
+
+		for ( var type in this._listeners ) {
+
+			this._listeners[ type ].length = 0;
+			delete this._listeners[ type ];
+
+		}
+
+		delete this._listeners;
+
 	}
 
 } );

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -1425,6 +1425,8 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	dispose: function () {
 
+		EventDispatcher.prototype.dispose.call( this );
+
 		this.dispatchEvent( { type: 'dispose' } );
 
 	}

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -371,6 +371,8 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	dispose: function () {
 
+		EventDispatcher.prototype.dispose.call( this );
+
 		this.dispatchEvent( { type: 'dispose' } );
 
 	}

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -35,6 +35,8 @@ function WebGLRenderTarget( width, height, options ) {
 	this.stencilBuffer = options.stencilBuffer !== undefined ? options.stencilBuffer : true;
 	this.depthTexture = options.depthTexture !== undefined ? options.depthTexture : null;
 
+	this._isSettingSize = false;
+
 }
 
 WebGLRenderTarget.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
@@ -50,7 +52,9 @@ WebGLRenderTarget.prototype = Object.assign( Object.create( EventDispatcher.prot
 			this.width = width;
 			this.height = height;
 
+			this._isSettingSize = true;
 			this.dispose();
+			this._isSettingSize = false;
 
 		}
 
@@ -83,6 +87,11 @@ WebGLRenderTarget.prototype = Object.assign( Object.create( EventDispatcher.prot
 	},
 
 	dispose: function () {
+
+		// don't clear event handlers if only size is being set
+
+		if ( ! this._isSettingSize )
+    		EventDispatcher.prototype.dispose.call( this );
 
 		this.dispatchEvent( { type: 'dispose' } );
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -228,6 +228,8 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 
 	dispose: function () {
 
+		EventDispatcher.prototype.dispose.call( this );
+
 		this.dispatchEvent( { type: 'dispose' } );
 
 	},


### PR DESCRIPTION
I was having huge memory leaks in my app whenever I destroyed a Scene and made a new one, and after two days of hunting, to my surprise I discovered that events stored in `EventDispatcher#_listeners` were (unexpectedly) not being garbage collected by Chrome even when the handlers and EventDispatcher instances were unreachable.

In my case, I had an instance of my own class called `SceneManagerInternal` which contained an instance of `TransformControls`, and `SceneManagerInternal` was adding event listeners on the `TransformControls` and the only place the event handler functions were referenced was inside `SceneManagerInternal`.

When I lost the reference to `SceneManagerInternal` by instantiating a new one onto the same variable that held it in an outer scope, the old `SceneManagerInternal` method was not being collected despite the fact that there were no more references to the lost `SceneManagerInternal`, its internal `TransformControls` or the event handler functions.

So it seems (at least in Chrome) that the cross reference between `SceneManagerInternal` and `TransformControls` by means of event handler functions were causing none of the three things to be garbage collected.

**_After I cleared the event handlers manually with `controls.removeEventListener`, the memory leak went away!_**

Before:

<img width="660" alt="screen shot 2018-11-20 at 8 26 58 pm" src="https://user-images.githubusercontent.com/297678/48819002-afcd8780-ed02-11e8-8669-2cdd847b02df.png">


(It shows three instances of `SceneManagerInternal` in memory after creating three of them on the same variable in the outer scope and expecting the first two to have been collected because they're no longer referenced on the variable.)

After: 
<img width="876" alt="screen shot 2018-11-20 at 8 21 12 pm" src="https://user-images.githubusercontent.com/297678/48818832-dccd6a80-ed01-11e8-94e7-e0198b7e831a.png">

(It shows just one instance of `SceneManagerInternal`, after doing the same as before on the outer scope variable.)

The only change I made to my code (literally) was to add the following to my class's cleanup method:

```js
    this.transformControls.removeEventListener( 'change', this.transformChange )
    this.transformControls.removeEventListener( 'mouseDown', this.cancelHideTransform )
    this.transformControls.removeEventListener( 'mouseUp', this.delayHideTransform )
    this.transformControls.removeEventListener( 'objectChange', this.transformObjectChange )
```

So because of the changes I had to make, I figure that if we add this `dispose` method to `EventDispatcher`, then have the extending classes call it in their `dispose` methods, we'll be able to automatically prevent memory leaks for users unsuspecting of the problem.

I've been thinking about [how to cleanup Three.js scenes](https://discourse.threejs.org/t/how-to-completely-clean-up-a-three-js-scene-from-a-web-app-once-the-scene-is-no-longer-needed/1549) for a while, and I'll add more details about this there, and maybe I can update the docs later too.