### PR TITLE
reorder properties for better debugging experience

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -21,10 +21,10 @@ function Object3D() {
 
 	Object.defineProperty( this, 'id', { value: object3DId ++ } );
 
-	this.uuid = _Math.generateUUID();
-
 	this.name = '';
 	this.type = 'Object3D';
+
+	this.uuid = _Math.generateUUID();
 
 	this.parent = null;
 	this.children = [];


### PR DESCRIPTION
object properties are ordered in JavaScript. Devtools use that to decide how to display them. So, moving name and type to the front seems like it provides a better debugging experience?

Old:

![before](https://user-images.githubusercontent.com/234804/48830177-4fe4e880-edb7-11e8-9f94-d745244d9830.png)


New:


![after](https://user-images.githubusercontent.com/234804/48830182-54110600-edb7-11e8-8e76-388ec84e1d8a.png)

Maybe few others should be moved too? Seems like uuid isn't that useful for most debugging.

Heck, maybe `type` is not important either as the debugger is already displaying the type. Name being the first property thought seems immensely useful