### PR TITLE
SkinnedMesh: Fix a vertex warping issue under negative weight

### DIFF
--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -130,7 +130,7 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 				var sw = this.geometry.skinWeights[ i ];
 
-				scale = 1.0 / sw.manhattanLength();
+				scale = 1.0 / ( sw.x + sw.y + sw.z + sw.w );
 
 				if ( scale !== Infinity ) {
 
@@ -157,7 +157,7 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 				vec.z = skinWeight.getZ( i );
 				vec.w = skinWeight.getW( i );
 
-				scale = 1.0 / vec.manhattanLength();
+				scale = 1.0 / ( vec.x + vec.y + vec.z + vec.w );
 
 				if ( scale !== Infinity ) {
 


### PR DESCRIPTION
I'm curretnly working on glTF stuff using THREE.GLTFLoader.
Sometimes `SkinnedMesh` accidentally has negative bone weights, and such models does weird behavior on Three.js, while most of other environments are not.
It's since Three.js is using `1.0 / Vector4.manhattanLength()` when normalizing these weights.
I know negative weights are generally invalid in most of situation, but it seems most of applications has different procedure from calculating manhattan length: just using sum of all weights.

- Reference, how other environment (Babylon.JS) deals with skinning weight:
  https://github.com/BabylonJS/Babylon.js/blob/405068971daa526cf42d19eb80b7c8e3cb2dd8a4/src/Mesh/babylon.mesh.ts#L1593

- Here's a discussion about skin weights that happened in glTF spec repo
  https://github.com/KhronosGroup/glTF/issues/1213