### PR TITLE
Fix StandardNode with logarithmic depth buffer

### DIFF
--- a/examples/js/nodes/materials/nodes/StandardNode.js
+++ b/examples/js/nodes/materials/nodes/StandardNode.js
@@ -183,8 +183,7 @@ StandardNode.prototype.build = function ( builder ) {
 			"#include <lights_pars_begin>",
 			"#include <lights_physical_pars_fragment>",
 			"#include <shadowmap_pars_fragment>",
-			"#include <logdepthbuf_pars_fragment>",
-			"#include <logdepthbuf_vertex>"
+			"#include <logdepthbuf_pars_fragment>"
 		].join( "\n" ) );
 
 		var output = [


### PR DESCRIPTION
Current behaviour yields a shader compile error if used with { logarithmicDepthBuffer: true } as a parameter for context instantiation.

Probably a typo, since `#include <logdepthbuf_vertex>` is included in the fragment shader build.
