### PR TITLE
MeshMatcapMaterial no longer requiring a matcap.

### DIFF
--- a/examples/webgl_materials_matcap.html
+++ b/examples/webgl_materials_matcap.html
@@ -67,7 +67,7 @@
 			function init() {
 
 				// renderer
-				renderer = new THREE.WebGLRenderer();
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
@@ -99,8 +99,6 @@
 				var matcap = loader.load( 'textures/matcaps/matcap-porcelain-white.jpg', function () {
 
 					matcap.encoding = THREE.sRGBEncoding;
-
-					if ( mesh ) mesh.material.needsUpdate = true;
 
 				} );
 
@@ -185,18 +183,18 @@
 
 			function imgCallback( event ) {
 
-				var matcap = mesh.material.matcap;
+				if ( mesh.material.matcap ) {
 
-				matcap.image = event.target;
+					mesh.material.matcap.dispose();
 
-				matcap.needsUpdate = true;
+				}
 
-				API.color = 0xffffff;
-				mesh.material.color.set( API.color );
+				mesh.material.matcap = new THREE.Texture( event.target );
+				mesh.material.matcap.needsUpdate = true;
+
+				image.src = mesh.material.matcap.image.src; // corner div
 
 				render();
-
-				image.src = matcap.image.src; // corner div
 
 			}
 

--- a/src/materials/MeshMatcapMaterial.js
+++ b/src/materials/MeshMatcapMaterial.js
@@ -68,23 +68,6 @@ function MeshMatcapMaterial( parameters ) {
 
 	this.setValues( parameters );
 
-	// a matcap is required
-
-	if ( this.matcap === null ) {
-
-		var canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
-		canvas.width = 1;
-		canvas.height = 1;
-
-		var context = canvas.getContext( '2d' );
-
-		context.fillStyle = '#fff';
-		context.fillRect( 0, 0, 1, 1 );
-
-		this.matcap = new THREE.CanvasTexture( canvas );
-
-	}
-
 }
 
 MeshMatcapMaterial.prototype = Object.create( Material.prototype );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -53,8 +53,7 @@ import { WebXRManager } from './webvr/WebXRManager.js';
 
 function WebGLRenderer( parameters ) {
 
-	// console.log( 'THREE.WebGLRenderer', REVISION );
-	window.dispatchEvent( new CustomEvent( 'three-renderer', { detail: this } ) );
+	console.log( 'THREE.WebGLRenderer', REVISION );
 
 	parameters = parameters || {};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -53,7 +53,8 @@ import { WebXRManager } from './webvr/WebXRManager.js';
 
 function WebGLRenderer( parameters ) {
 
-	console.log( 'THREE.WebGLRenderer', REVISION );
+	// console.log( 'THREE.WebGLRenderer', REVISION );
+	window.dispatchEvent( new CustomEvent( 'three-renderer', { detail: this } ) );
 
 	parameters = parameters || {};
 

--- a/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
@@ -42,9 +42,16 @@ void main() {
 	vec3 y = cross( viewDir, x );
 	vec2 uv = vec2( dot( x, normal ), dot( y, normal ) ) * 0.495 + 0.5; // 0.495 to remove artifacts caused by undersized matcap disks
 
-	vec4 matcapColor = texture2D( matcap, uv );
+	#ifdef USE_MATCAP
 
-	matcapColor = matcapTexelToLinear( matcapColor );
+		vec4 matcapColor = texture2D( matcap, uv );
+		matcapColor = matcapTexelToLinear( matcapColor );
+
+	#else
+
+		vec4 matcapColor = vec4( 1.0 );
+
+	#endif
 
 	vec3 outgoingLight = diffuseColor.rgb * matcapColor.rgb;
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -451,6 +451,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			( parameters.useFog && parameters.fogExp ) ? '#define FOG_EXP2' : '',
 
 			parameters.map ? '#define USE_MAP' : '',
+			parameters.matcap ? '#define USE_MATCAP' : '',
 			parameters.envMap ? '#define USE_ENVMAP' : '',
 			parameters.envMap ? '#define ' + envMapTypeDefine : '',
 			parameters.envMap ? '#define ' + envMapModeDefine : '',

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -28,7 +28,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 	};
 
 	var parameterNames = [
-		"precision", "supportsVertexTextures", "map", "mapEncoding", "matcapEncoding", "envMap", "envMapMode", "envMapEncoding",
+		"precision", "supportsVertexTextures", "map", "mapEncoding", "matcap", "matcapEncoding", "envMap", "envMapMode", "envMapEncoding",
 		"lightMap", "aoMap", "emissiveMap", "emissiveMapEncoding", "bumpMap", "normalMap", "objectSpaceNormalMap", "displacementMap", "specularMap",
 		"roughnessMap", "metalnessMap", "gradientMap",
 		"alphaMap", "combine", "vertexColors", "fog", "useFog", "fogExp",


### PR DESCRIPTION
@WestLangley 

I was able to use `DataTexture` inside `MeshMatcapMaterial`. I guess the problem was that the example was trying to set `matcap.image` and `DataTexture` uses that property differently.

While looking at the issue, I realised that we could hide this complexity in the shader. If `matcap` is not set now the shader writes white instead. The user will have to call `material.needsUpdate` if they set a `matcap` after it has been compiled already, but that's how `map`, `bumpMap`, etc work too.