### PR TITLE
Docs: Clarify .lights property

### DIFF
--- a/docs/api/en/materials/LineBasicMaterial.html
+++ b/docs/api/en/materials/LineBasicMaterial.html
@@ -68,9 +68,6 @@ var material = new THREE.LineBasicMaterial( {
 			You should not change this, as it used internally for optimisation.
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>Whether the material is affected by lights. Default is *false*.</p>
-
 		<h3>[property:Float linewidth]</h3>
 		<p>
 			Controls line thickness. Default is *1*.<br /><br />

--- a/docs/api/en/materials/LineDashedMaterial.html
+++ b/docs/api/en/materials/LineDashedMaterial.html
@@ -62,9 +62,6 @@ var material = new THREE.LineDashedMaterial( {
 			You should not change this, as it used internally for optimisation.
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>Whether the material is affected by lights. Default is *false*.</p>
-
 		<h3>[property:Float linewidth]</h3>
 		<p>
 			Controls line thickness. Default is *1*.<br /><br />

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -155,7 +155,11 @@
 		</p>
 
 		<h3>[property:Boolean lights]</h3>
-		<p>Whether the material is affected by lights. Default is *true*.</p>
+		<p>Whether the material is affected by lights. Default is *true*.<br /><br />
+
+			This property can be changed by users for [page:ShaderMaterial] and [page:RawShaderMaterial] only.
+			In all other cases it is considered to be read-only.
+		</p>
 
 		<h3>[property:String name]</h3>
 		<p>Optional name of the object (doesn't need to be unique). Default is an empty string.</p>

--- a/docs/api/en/materials/MeshBasicMaterial.html
+++ b/docs/api/en/materials/MeshBasicMaterial.html
@@ -100,9 +100,6 @@
 		<h3>[property:Float lightMapIntensity]</h3>
 		<p>Intensity of the baked light. Default is 1.</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>Whether the material is affected by lights. Default is *false*.</p>
-
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is  null.</p>
 

--- a/docs/api/en/materials/MeshDepthMaterial.html
+++ b/docs/api/en/materials/MeshDepthMaterial.html
@@ -89,9 +89,6 @@
 			You should not change this, as it used internally for optimisation.
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>Whether the material is affected by lights. Default is *false*.</p>
-
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is  null.</p>
 

--- a/docs/api/en/materials/MeshNormalMaterial.html
+++ b/docs/api/en/materials/MeshNormalMaterial.html
@@ -54,9 +54,6 @@
 			You should not change this, as it used internally for optimisation.
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>Whether the material is affected by lights. Default is *false*.</p>
-
 		<h3>[property:boolean morphTargets]</h3>
 		<p>Define whether the material uses morphTargets. Default is false.</p>
 

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -361,13 +361,6 @@ this.extensions = {
 		</p>
 
 
-
-
-		<h3>[property:Boolean lights]</h3>
-		<p>
-		Defines whether this material uses lighting; true to pass uniform data related to lighting to this shader. Default is false.
-		</p>
-
 		<h3>[property:Float linewidth]</h3>
 		<p>Controls wireframe thickness. Default is 1.<br /><br />
 

--- a/docs/api/en/materials/ShadowMaterial.html
+++ b/docs/api/en/materials/ShadowMaterial.html
@@ -51,9 +51,6 @@ scene.add( plane );
 			You should not change this, as it used internally for optimisation.
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>Whether the material is affected by lights. Default is *true*.</p>
-
 		<h3>[property:Boolean transparent]</h3>
 		<p>Defines whether this material is transparent. Default is *true*.</p>
 

--- a/docs/api/en/materials/SpriteMaterial.html
+++ b/docs/api/en/materials/SpriteMaterial.html
@@ -56,9 +56,6 @@ scene.add( sprite );
 		<h3>[property:boolean fog]</h3>
 		<p>Whether or not this material affected by the scene's fog. Default is false</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>Whether the material is affected by lights. Default is *false*.</p>
-
 		<h3>[property:Texture map]</h3>
 		<p>The texture map. Default is null.</p>
 

--- a/docs/api/zh/materials/LineBasicMaterial.html
+++ b/docs/api/zh/materials/LineBasicMaterial.html
@@ -63,9 +63,6 @@ var material = new THREE.LineBasicMaterial( {
 			因为其通常用在内部优化，所以不应该更改该属性值。
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>材质是否受到光照的影响。默认值为 *false*。</p>
-
 		<h3>[property:Float linewidth]</h3>
 		<p> 控制线宽。默认值为 *1*。<br /><br />
 			由于[link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]与

--- a/docs/api/zh/materials/LineDashedMaterial.html
+++ b/docs/api/zh/materials/LineDashedMaterial.html
@@ -59,9 +59,6 @@ var material = new THREE.LineDashedMaterial( {
 			因为其通常用在内部优化，所以不应该更改该属性值。
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>材质是否受到光照的影响。默认值为 *false*。</p>
-
 		<h3>[property:Float linewidth]</h3>
 		<p>
 			控制线宽。默认值为 *1*。<br /><br />

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -130,7 +130,11 @@
 </p>
 
 <h3>[property:Boolean lights]</h3>
-<p>材质是否受到光照的影响。默认为*true*。</p>
+<p>Whether the material is affected by lights. Default is *true*.<br /><br />
+
+	This property can be changed by users for [page:ShaderMaterial] and [page:RawShaderMaterial] only.
+	In all other cases it is considered to be read-only.
+</p>
 
 <h3>[property:String name]</h3>
 <p>对象的可选名称（不必是唯一的）。默认值为空字符串。</p>

--- a/docs/api/zh/materials/MeshBasicMaterial.html
+++ b/docs/api/zh/materials/MeshBasicMaterial.html
@@ -82,9 +82,6 @@
 		<h3>[property:Float lightMapIntensity]</h3>
 		<p>烘焙光的强度。默认值为1。</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>材质是否受到光照的影响。默认值为 *false*。</p>
-
 		<h3>[property:Texture map]</h3>
 		<p> 颜色贴图。默认为null。</p>
 

--- a/docs/api/zh/materials/MeshDepthMaterial.html
+++ b/docs/api/zh/materials/MeshDepthMaterial.html
@@ -73,9 +73,6 @@
 			因为其通常用在内部优化，所以不应该更改该属性值。
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>材质是否受到光照的影响。默认值为 *false*。</p>
-
 		<h3>[property:Texture map]</h3>
 		<p>颜色贴图。默认为null。</p>
 

--- a/docs/api/zh/materials/MeshNormalMaterial.html
+++ b/docs/api/zh/materials/MeshNormalMaterial.html
@@ -51,9 +51,6 @@
 			因为其通常用在内部优化，所以不应该更改该属性值。
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>材质是否受到光照的影响。默认值为 *false*。</p>
-
 		<h3>[property:boolean morphTargets]</h3>
 		<p>定义材质是否使用morphTargets。默认值为false。</p>
 

--- a/docs/api/zh/materials/ShaderMaterial.html
+++ b/docs/api/zh/materials/ShaderMaterial.html
@@ -319,13 +319,6 @@ this.extensions = {
 			因为其通常用在内部优化，所以不应该更改该属性值。
 		</p>
 
-
-
-
-		<h3>[property:Boolean lights]</h3>
-		<p> 材质是否受到光照的影响。默认值为 *false*。如果传递与光照相关的uniform数据到这个材质，则为true。默认是false。
-		</p>
-
 		<h3>[property:Float linewidth]</h3>
 		<p>控制线框宽度。默认值为1。<br /><br />
 			由于[link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]与大多数平台上[page:WebGLRenderer WebGL]渲染器的限制，无论如何设置该值，线宽始终为1。

--- a/docs/api/zh/materials/ShadowMaterial.html
+++ b/docs/api/zh/materials/ShadowMaterial.html
@@ -48,9 +48,6 @@ scene.add( plane );
 			因为其通常用在内部优化，所以不应该更改该属性值。
 		</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p> 材质是否受到光照的影响。默认值为 *true*。</p>
-
 		<h3>[property:Boolean transparent]</h3>
 		<p>定义此材质是否透明。默认值为 *true*。</p>
 

--- a/docs/api/zh/materials/SpriteMaterial.html
+++ b/docs/api/zh/materials/SpriteMaterial.html
@@ -55,9 +55,6 @@ scene.add( sprite );
 		<h3>[property:boolean fog]</h3>
 		<p>材质是否受场景雾的影响。默认值为*false*。</p>
 
-		<h3>[property:Boolean lights]</h3>
-		<p>材质是否受到光照的影响。默认值为 *false*。</p>
-
 		<h3>[property:Texture map]</h3>
 		<p>颜色贴图。默认为null。</p>
 


### PR DESCRIPTION
Documents `Material.lights` just once in `Material` and not in other documentation pages. Also added a note so users consider this property as read-only except for `ShaderMaterial` and `RawShaderMaterial`.

Fixed #13896