### PR TITLE
background render order control

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -113,6 +113,10 @@ function WebGLRenderer( parameters ) {
 	this.maxMorphTargets = 8;
 	this.maxMorphNormals = 4;
 
+	// background
+
+	this.backgroundRenderOrder = Infinity;
+
 	// internal properties
 
 	var _this = this,
@@ -1073,6 +1077,10 @@ function WebGLRenderer( parameters ) {
 		currentRenderList = renderLists.get( scene, camera );
 		currentRenderList.init();
 
+		// add background objects to scene
+
+		background.render( currentRenderList, scene, camera, forceClear );
+
 		projectObject( scene, camera, _this.sortObjects );
 
 		if ( _this.sortObjects === true ) {
@@ -1104,10 +1112,6 @@ function WebGLRenderer( parameters ) {
 		}
 
 		this.setRenderTarget( renderTarget );
-
-		//
-
-		background.render( currentRenderList, scene, camera, forceClear );
 
 		// render scene
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -61,6 +61,8 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 				boxMesh.geometry.removeAttribute( 'normal' );
 				boxMesh.geometry.removeAttribute( 'uv' );
 
+				boxMesh.renderOrder = renderer.backgroundRenderOrder;
+
 				boxMesh.onBeforeRender = function ( renderer, scene, camera ) {
 
 					this.matrixWorld.copyPosition( camera.matrixWorld );
@@ -107,6 +109,8 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 				);
 
 				planeMesh.geometry.removeAttribute( 'normal' );
+
+				planeMesh.renderOrder = renderer.backgroundRenderOrder;
 
 				// enable code injection for non-built-in material
 				Object.defineProperty( planeMesh.material, 'map', {


### PR DESCRIPTION
allows ordering of rendering background to be determined.

renderer.backgroundRenderOrder must be set before first render call.

(we could change this to allow dynamic ordering but that seems excessive)

This should fix #15304 :

`renderer.backgroundRenderOrder = -Infinity // background will be rendered first`


