### PR TITLE
Use language when linking to documentation source for API.

### DIFF
--- a/docs/page.js
+++ b/docs/page.js
@@ -35,10 +35,6 @@ function onDocumentLoad( event ) {
 
 		case 'api':
 			path = /\/api\/[A-z0-9\/]+/.exec( pathname ).toString().substr( 5 );
-
-			// Remove localized part of the path (e.g. 'en/' or 'es-MX/'):
-			path = path.replace( /^[A-z0-9-]+\//, '' );
-
 			break;
 
 		case 'examples':


### PR DESCRIPTION
The docs for API are sorted by language -- I don't know the history of this change that added this (a17a1228da7a168dbee30182e1328d90891fc8b3) because the docs were sorted by language there as well, but this fixes the "Edit" button found in API examples e.g. https://threejs.org/docs/#api/en/scenes/Scene