### PR TITLE
Normalization is needed after quaternion multiply

### DIFF
--- a/examples/js/animation/MMDPhysics.js
+++ b/examples/js/animation/MMDPhysics.js
@@ -1052,12 +1052,12 @@ THREE.MMDPhysics = ( function () {
 			thQ.set( q.x(), q.y(), q.z(), q.w() );
 			thQ2.setFromRotationMatrix( this.bone.matrixWorld );
 			thQ2.conjugate();
-			thQ2.multiply( thQ );
+			thQ2.multiply( thQ ).normalize();
 
 			//this.bone.quaternion.multiply( thQ2 );
 
 			thQ3.setFromRotationMatrix( this.bone.matrix );
-			this.bone.quaternion.copy( thQ2.multiply( thQ3 ) );
+			this.bone.quaternion.copy( thQ2.multiply( thQ3 ).normalize() );
 
 			manager.freeThreeQuaternion( thQ );
 			manager.freeThreeQuaternion( thQ2 );


### PR DESCRIPTION
I find that sometimes when the model moves too fast, the physical engine may break the model.

Because of the rounding error of floating-point numbers, the modulus of quaternion is not strictly equal to 1, and the error will accumulate continuously in the "multiply" operation. Ultimately, the four components of the quaternion will overflow and become NAN, and then the model will break down.

Therefore, after each quaternion multiply, it needs to be normalized.