### PR TITLE
Add function to access last camera pose retrivied from the WebXR API

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -287,6 +287,12 @@ function WebXRManager( renderer, gl ) {
 
 	};
 
+	this.getCameraPose = function ( ) {
+
+		return pose;
+
+	};
+
 	this.isPresenting = isPresenting;
 
 	// Animation Loop


### PR DESCRIPTION
The WebXRManager updates the `matrixWorld` of the camera but not local matrix, rotation, position or scale. The pose gives easy access to local rotation and position of the headset as measured by sensors.