### PR TITLE
Example: Fix webaudio_orientation for Chrome mobile

### DIFF
--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -158,6 +158,7 @@
 		camera.add( listener );
 
 		var audioElement = document.getElementById( 'music' );
+		audioElement.play();
 
 		var positionalAudio = new THREE.PositionalAudio( listener );
 		positionalAudio.setMediaElementSource( audioElement );
@@ -184,7 +185,6 @@
 
 			} );
 
-			audioElement.play();
 			boomBox.add( positionalAudio );
 			scene.add( boomBox );
 			animate();


### PR DESCRIPTION
Fixes a problem with Chrome mobile. The following error is currently produces since `play()` is called too late:

> Uncaught (in promise) DOMException: play() can only be initiated by a user gesture