### PR TITLE
Docs: Clean up

### DIFF
--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -19,7 +19,6 @@
 		<h2>Example</h2>
 
 		<p>
-			[example:webgl_animation_skinning_blending WebGL / animation / skinning / blending]<br />
 			[example:webgl_loader_json_claraio WebGL / loader / json / claraio]<br />
 			[example:webgl_materials_lightmap WebGL / materials / lightmap]
 		</p>

--- a/docs/api/zh/loaders/ObjectLoader.html
+++ b/docs/api/zh/loaders/ObjectLoader.html
@@ -19,7 +19,6 @@
 		<h2>例子</h2>
 
 		<p>
-			[example:webgl_animation_skinning_blending WebGL / animation / skinning / blending]<br />
 			[example:webgl_loader_json_claraio WebGL / loader / json / claraio]<br />
 			[example:webgl_materials_lightmap WebGL / materials / lightmap]
 		</p>


### PR DESCRIPTION
`ObjectLoader` is no longer used in `webgl_animation_skinning_blending`.