### PR TITLE
[wip] optimize(?) buffer binding between calls

### DIFF
--- a/examples/test.html
+++ b/examples/test.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - geometry - extrude shapes from geodata</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+		body {
+			color: #ffffff;
+			font-family: Monospace;
+			font-size: 13px;
+			text-align: center;
+			font-weight: bold;
+			background-color: #000000;
+			margin: 0px;
+			overflow: hidden;
+		}
+
+		#info {
+			position: absolute;
+			top: 0px;
+			width: 100%;
+			padding: 5px;
+		}
+
+		a {
+			color: #ffffff;
+		}
+		</style>
+	</head>
+
+	<body>
+
+		<div id="container"></div>
+		<div id="info">
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> reuse attributes
+		</div>
+
+		<script type="text/javascript" src="../build/three.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script>
+			var renderer, stats, scene, camera;
+
+			init();
+			animate();
+
+			//
+
+			function init() {
+
+				var container = document.getElementById( 'container' );
+
+				//
+
+				scene = new THREE.Scene();
+				scene.background = new THREE.Color( 0xb0b0b0 );
+
+				//
+
+				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.set( 0, 0, 200 );
+
+				//
+
+				var group = new THREE.Group();
+				scene.add( group );
+
+				//
+
+				var directionalLight = new THREE.DirectionalLight( 0xffffff, 0.6 );
+				directionalLight.position.set( 0.75, 0.75, 1.0 ).normalize();
+				scene.add( directionalLight );
+
+				var ambientLight = new THREE.AmbientLight( 0xcccccc, 0.2 );
+				scene.add( ambientLight );
+
+
+				//
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
+
+				//
+
+				var controls = new THREE.OrbitControls( camera, renderer.domElement );
+
+				//
+
+				stats = new Stats();
+				container.appendChild( stats.dom );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+
+				//-----------------------------------------------------------------------------//
+				
+				const masterGeometry = new THREE.SphereBufferGeometry(1) //pos, uv, normal
+
+				const geomBasic = new THREE.BufferGeometry()
+
+				geomBasic.addAttribute('position', masterGeometry.attributes.position)
+				geomBasic.setIndex(masterGeometry.index)
+
+				const mBasic = new THREE.Mesh(geomBasic, new THREE.MeshBasicMaterial())
+				const mLight = new THREE.Mesh(masterGeometry, new THREE.MeshPhongMaterial())
+				
+				mLight.position.x = -2
+				mBasic.position.x = 2
+				mLight.renderOrder = 1
+				mBasic.renderOrder = 0
+
+				scene.add(mLight)
+				scene.add(mBasic)
+
+				const geomInstanceBasic = new THREE.InstancedBufferGeometry()
+				geomInstanceBasic.addAttribute('position', masterGeometry.attributes.position)
+				geomInstanceBasic.setIndex(masterGeometry.index)
+
+				const instancePositions = []
+
+				for( let i = 0 ; i < 16 ; i ++ ){
+					instancePositions.push((Math.random() * 2 - 1) * 3) 
+					instancePositions.push((Math.random() * 2 - 1) * 3) 
+					instancePositions.push((Math.random() * 2 - 1) * 3) 
+				}
+
+				geomInstanceBasic.addAttribute('aInstance', new THREE.InstancedBufferAttribute(
+					new Float32Array(instancePositions),
+					3,
+					false,
+					1
+				))
+
+
+				const instanceMaterial = new THREE.ShaderMaterial({
+					vertexShader:`
+						attribute vec3 aInstance;
+
+						#ifdef NORMAL
+						varying vec3 vNormal;
+						#endif
+						
+						void main () {
+
+							vec4 pos = vec4(position, 1.);
+							pos.xyz += aInstance;
+
+
+							#ifdef NORMAL
+							  vNormal = ( modelViewMatrix * vec4(normal,.0) ).xyz;
+							#endif
+
+							gl_Position = projectionMatrix * modelViewMatrix * pos;
+
+						}
+					`,
+					fragmentShader:`
+						#ifdef NORMAL
+						varying vec3 vNormal;
+						#endif
+
+						void main(){
+
+							vec3 col = vec3(1.,0.,.0);
+
+							#ifdef NORMAL
+							  col = vNormal;
+							#endif
+
+							gl_FragColor = vec4(col,1.);
+						}
+					`
+				})
+
+				const mInstancedBasic = new THREE.Mesh( geomInstanceBasic, instanceMaterial )
+				mInstancedBasic.position.x = 5
+				mInstancedBasic.renderOrder = 2
+
+				scene.add(mInstancedBasic)
+
+				const geomInstanceLight = new THREE.InstancedBufferGeometry()
+
+				geomInstanceLight.addAttribute('position', masterGeometry.attributes.position)
+				geomInstanceLight.addAttribute('normal', masterGeometry.attributes.normal)
+				geomInstanceLight.addAttribute('aInstance', geomInstanceBasic.attributes.aInstance)
+				geomInstanceLight.setIndex(masterGeometry.index)
+
+				const mInstancedLight = new THREE.Mesh(geomInstanceLight, instanceMaterial.clone())
+
+				mInstancedLight.material.defines = { NORMAL: '' }
+
+				scene.add(mInstancedLight)
+
+				mInstancedLight.renderOrder = 3 
+				mInstancedLight.position.x = 10
+
+				console.log(masterGeometry.attributes.position)
+				console.log(geomBasic.attributes.position)
+				console.log(geomInstanceBasic.attributes.position)
+				console.log(geomInstanceLight.attributes.position === masterGeometry.attributes.position)
+
+			}
+
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/examples/test.html
+++ b/examples/test.html
@@ -100,7 +100,7 @@
 
 				//-----------------------------------------------------------------------------//
 				
-				const masterGeometry = new THREE.SphereBufferGeometry(0.1) //pos, uv, normal
+				const masterGeometry = new THREE.SphereBufferGeometry(0.3) //pos, uv, normal
 
 				const geomBasic = new THREE.BufferGeometry()
 
@@ -184,7 +184,7 @@
 
 				const size = 120
 
-				for ( let i = 0 ; i < 100 ; i ++ ){
+				for ( let i = 0 ; i < 1000 ; i ++ ){
 
 					const i4 = i * 4
 

--- a/examples/test.html
+++ b/examples/test.html
@@ -60,7 +60,7 @@
 				//
 
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.set( 0, 0, 200 );
+				camera.position.set( 0, 0, 400 );
 
 				//
 
@@ -100,7 +100,7 @@
 
 				//-----------------------------------------------------------------------------//
 				
-				const masterGeometry = new THREE.SphereBufferGeometry(1) //pos, uv, normal
+				const masterGeometry = new THREE.SphereBufferGeometry(0.1) //pos, uv, normal
 
 				const geomBasic = new THREE.BufferGeometry()
 
@@ -114,7 +114,7 @@
 
 				const instancePositions = []
 
-				for( let i = 0 ; i < 16 ; i ++ ){
+				for( let i = 0 ; i < 8 ; i ++ ){
 					instancePositions.push((Math.random() * 2 - 1) * 3) 
 					instancePositions.push((Math.random() * 2 - 1) * 3) 
 					instancePositions.push((Math.random() * 2 - 1) * 3) 

--- a/examples/test.html
+++ b/examples/test.html
@@ -184,7 +184,7 @@
 
 				const size = 120
 
-				for ( let i = 0 ; i < 1000 ; i ++ ){
+				for ( let i = 0 ; i < 100 ; i ++ ){
 
 					const i4 = i * 4
 

--- a/examples/test.html
+++ b/examples/test.html
@@ -107,18 +107,8 @@
 				geomBasic.addAttribute('position', masterGeometry.attributes.position)
 				geomBasic.setIndex(masterGeometry.index)
 
-				const mBasic = new THREE.Mesh(geomBasic, new THREE.MeshBasicMaterial())
-				const mLight = new THREE.Mesh(masterGeometry, new THREE.MeshPhongMaterial())
-				
-				mLight.position.x = -2
-				mBasic.position.x = 2
-				mLight.renderOrder = 1
-				mBasic.renderOrder = 0
-
-				scene.add(mLight)
-				scene.add(mBasic)
-
 				const geomInstanceBasic = new THREE.InstancedBufferGeometry()
+				
 				geomInstanceBasic.addAttribute('position', masterGeometry.attributes.position)
 				geomInstanceBasic.setIndex(masterGeometry.index)
 
@@ -137,6 +127,12 @@
 					1
 				))
 
+				const geomInstanceLight = new THREE.InstancedBufferGeometry()
+
+				geomInstanceLight.addAttribute('position', masterGeometry.attributes.position)
+				geomInstanceLight.addAttribute('normal', masterGeometry.attributes.normal)
+				geomInstanceLight.addAttribute('aInstance', geomInstanceBasic.attributes.aInstance)
+				geomInstanceLight.setIndex(masterGeometry.index)
 
 				const instanceMaterial = new THREE.ShaderMaterial({
 					vertexShader:`
@@ -178,32 +174,58 @@
 					`
 				})
 
-				const mInstancedBasic = new THREE.Mesh( geomInstanceBasic, instanceMaterial )
-				mInstancedBasic.position.x = 5
-				mInstancedBasic.renderOrder = 2
+				const instanceMaterialNormal = instanceMaterial.clone()
 
-				scene.add(mInstancedBasic)
+				instanceMaterialNormal.defines = { NORMAL: '' }
 
-				const geomInstanceLight = new THREE.InstancedBufferGeometry()
+				function getRand(){
+					return Math.random() * 2 - 1
+				}
 
-				geomInstanceLight.addAttribute('position', masterGeometry.attributes.position)
-				geomInstanceLight.addAttribute('normal', masterGeometry.attributes.normal)
-				geomInstanceLight.addAttribute('aInstance', geomInstanceBasic.attributes.aInstance)
-				geomInstanceLight.setIndex(masterGeometry.index)
+				const size = 120
 
-				const mInstancedLight = new THREE.Mesh(geomInstanceLight, instanceMaterial.clone())
+				for ( let i = 0 ; i < 1000 ; i ++ ){
 
-				mInstancedLight.material.defines = { NORMAL: '' }
+					const i4 = i * 4
 
-				scene.add(mInstancedLight)
+					const mBasic = new THREE.Mesh(geomBasic, new THREE.MeshBasicMaterial())
+					const mLight = new THREE.Mesh(masterGeometry, new THREE.MeshPhongMaterial())
+					const mInstancedBasic = new THREE.Mesh( geomInstanceBasic, instanceMaterial )
+					const mInstancedLight = new THREE.Mesh(geomInstanceLight, )
 
-				mInstancedLight.renderOrder = 3 
-				mInstancedLight.position.x = 10
+					mLight.position.set(
+						getRand(),
+						getRand(),
+						getRand()
+					).multiplyScalar(size)
+					mBasic.position.set(
+						getRand(),
+						getRand(),
+						getRand()
+					).multiplyScalar(size)
+					mInstancedBasic.position.set(
+						getRand(),
+						getRand(),
+						getRand()
+					).multiplyScalar(size)
+					mInstancedLight.position.set(
+						getRand(),
+						getRand(),
+						getRand()
+					).multiplyScalar(size)
 
-				console.log(masterGeometry.attributes.position)
-				console.log(geomBasic.attributes.position)
-				console.log(geomInstanceBasic.attributes.position)
-				console.log(geomInstanceLight.attributes.position === masterGeometry.attributes.position)
+					mLight.renderOrder = i4 +1
+					mBasic.renderOrder = i4
+					mInstancedBasic.renderOrder = i4 + 2
+					mInstancedLight.renderOrder = i4 + 3 
+
+
+					scene.add(mLight)
+					scene.add(mBasic)
+					scene.add(mInstancedBasic)
+					scene.add(mInstancedLight)
+				
+				}
 
 			}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -648,6 +648,7 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+
 	this.renderBufferDirect = function ( camera, fog, geometry, material, object, group ) {
 
 		var frontFaceCW = ( object.isMesh && object.normalMatrix.determinant() < 0 );
@@ -819,6 +820,8 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	var previousBuffers = new WeakMap()
+
 	function setupVertexAttributes( material, program, geometry ) {
 
 		if ( geometry && geometry.isInstancedBufferGeometry & ! capabilities.isWebGL2 ) {
@@ -831,6 +834,8 @@ function WebGLRenderer( parameters ) {
 			}
 
 		}
+
+		var nextBuffers = new WeakMap()
 
 		state.initAttributes();
 
@@ -848,7 +853,9 @@ function WebGLRenderer( parameters ) {
 
 				var geometryAttribute = geometryAttributes[ name ];
 
-				if ( geometryAttribute !== undefined ) {
+				if ( geometryAttribute !== undefined ) 
+
+				if( previousBuffers.get(geometryAttribute) !== programAttribute ) {
 
 					var normalized = geometryAttribute.normalized;
 					var size = geometryAttribute.itemSize;
@@ -888,6 +895,7 @@ function WebGLRenderer( parameters ) {
 						_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
 						_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
 
+
 					} else {
 
 						if ( geometryAttribute.isInstancedBufferAttribute ) {
@@ -910,6 +918,16 @@ function WebGLRenderer( parameters ) {
 						_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
 
 					}
+
+				} 
+
+				else {
+					
+					state.enableAttribute( programAttribute )
+				
+				}
+
+				nextBuffers.set(geometryAttribute, programAttribute )
 
 				} else if ( materialDefaultAttributeValues !== undefined ) {
 
@@ -943,6 +961,8 @@ function WebGLRenderer( parameters ) {
 			}
 
 		}
+
+		previousBuffers = nextBuffers
 
 		state.disableUnusedAttributes();
 
@@ -1042,6 +1062,8 @@ function WebGLRenderer( parameters ) {
 		_currentGeometryProgram.wireframe = false;
 		_currentMaterialId = - 1;
 		_currentCamera = null;
+
+		previousBuffers = new WeakMap()
 
 		// update scene graph
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -863,67 +863,67 @@ function WebGLRenderer( parameters ) {
 
 					if ( previousBuffers.get( geometryAttribute ) !== programAttribute ) {
 
-						var normalized = geometryAttribute.normalized;
-						var size = geometryAttribute.itemSize;
+					var normalized = geometryAttribute.normalized;
+					var size = geometryAttribute.itemSize;
 
-						var attribute = attributes.get( geometryAttribute );
+					var attribute = attributes.get( geometryAttribute );
 
-						// TODO Attribute may not be available on context restore
+					// TODO Attribute may not be available on context restore
 
-						if ( attribute === undefined ) continue;
+					if ( attribute === undefined ) continue;
 
-						var buffer = attribute.buffer;
-						var type = attribute.type;
-						var bytesPerElement = attribute.bytesPerElement;
+					var buffer = attribute.buffer;
+					var type = attribute.type;
+					var bytesPerElement = attribute.bytesPerElement;
 
-						if ( geometryAttribute.isInterleavedBufferAttribute ) {
+					if ( geometryAttribute.isInterleavedBufferAttribute ) {
 
-							var data = geometryAttribute.data;
-							var stride = data.stride;
-							var offset = geometryAttribute.offset;
+						var data = geometryAttribute.data;
+						var stride = data.stride;
+						var offset = geometryAttribute.offset;
 
-							if ( data && data.isInstancedInterleavedBuffer ) {
+						if ( data && data.isInstancedInterleavedBuffer ) {
 
-								state.enableAttributeAndDivisor( programAttribute, data.meshPerAttribute );
+							state.enableAttributeAndDivisor( programAttribute, data.meshPerAttribute );
 
-								if ( geometry.maxInstancedCount === undefined ) {
+							if ( geometry.maxInstancedCount === undefined ) {
 
-									geometry.maxInstancedCount = data.meshPerAttribute * data.count;
-
-								}
-
-							} else {
-
-								state.enableAttribute( programAttribute );
+								geometry.maxInstancedCount = data.meshPerAttribute * data.count;
 
 							}
-
-							_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
-							_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
-
 
 						} else {
 
-							if ( geometryAttribute.isInstancedBufferAttribute ) {
+							state.enableAttribute( programAttribute );
 
-								state.enableAttributeAndDivisor( programAttribute, geometryAttribute.meshPerAttribute );
+						}
 
-								if ( geometry.maxInstancedCount === undefined ) {
+						_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
+						_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
 
-									geometry.maxInstancedCount = geometryAttribute.meshPerAttribute * geometryAttribute.count;
 
-								}
+					} else {
 
-							} else {
+						if ( geometryAttribute.isInstancedBufferAttribute ) {
 
-								state.enableAttribute( programAttribute );
+							state.enableAttributeAndDivisor( programAttribute, geometryAttribute.meshPerAttribute );
+
+							if ( geometry.maxInstancedCount === undefined ) {
+
+								geometry.maxInstancedCount = geometryAttribute.meshPerAttribute * geometryAttribute.count;
 
 							}
 
-							_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
-							_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
+						} else {
+
+							state.enableAttribute( programAttribute );
 
 						}
+
+						_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
+						_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
+
+					}
 
 					} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -648,6 +648,7 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	var prevIndex;
 
 	this.renderBufferDirect = function ( camera, fog, geometry, material, object, group ) {
 
@@ -709,11 +710,16 @@ function WebGLRenderer( parameters ) {
 
 			if ( index !== null ) {
 
-				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attribute.buffer );
+				if ( index !== prevIndex )
+
+					_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attribute.buffer );
+
 
 			}
 
 		}
+
+		prevIndex = index;
 
 		//
 
@@ -820,7 +826,7 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	var previousBuffers = new WeakMap()
+	var previousBuffers = new WeakMap();
 
 	function setupVertexAttributes( material, program, geometry ) {
 
@@ -835,7 +841,7 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		var nextBuffers = new WeakMap()
+		var nextBuffers = new WeakMap();
 
 		state.initAttributes();
 
@@ -853,81 +859,79 @@ function WebGLRenderer( parameters ) {
 
 				var geometryAttribute = geometryAttributes[ name ];
 
-				if ( geometryAttribute !== undefined ) 
+				if ( geometryAttribute !== undefined ) {
 
-				if( previousBuffers.get(geometryAttribute) !== programAttribute ) {
+					if ( previousBuffers.get( geometryAttribute ) !== programAttribute ) {
 
-					var normalized = geometryAttribute.normalized;
-					var size = geometryAttribute.itemSize;
+						var normalized = geometryAttribute.normalized;
+						var size = geometryAttribute.itemSize;
 
-					var attribute = attributes.get( geometryAttribute );
+						var attribute = attributes.get( geometryAttribute );
 
-					// TODO Attribute may not be available on context restore
+						// TODO Attribute may not be available on context restore
 
-					if ( attribute === undefined ) continue;
+						if ( attribute === undefined ) continue;
 
-					var buffer = attribute.buffer;
-					var type = attribute.type;
-					var bytesPerElement = attribute.bytesPerElement;
+						var buffer = attribute.buffer;
+						var type = attribute.type;
+						var bytesPerElement = attribute.bytesPerElement;
 
-					if ( geometryAttribute.isInterleavedBufferAttribute ) {
+						if ( geometryAttribute.isInterleavedBufferAttribute ) {
 
-						var data = geometryAttribute.data;
-						var stride = data.stride;
-						var offset = geometryAttribute.offset;
+							var data = geometryAttribute.data;
+							var stride = data.stride;
+							var offset = geometryAttribute.offset;
 
-						if ( data && data.isInstancedInterleavedBuffer ) {
+							if ( data && data.isInstancedInterleavedBuffer ) {
 
-							state.enableAttributeAndDivisor( programAttribute, data.meshPerAttribute );
+								state.enableAttributeAndDivisor( programAttribute, data.meshPerAttribute );
 
-							if ( geometry.maxInstancedCount === undefined ) {
+								if ( geometry.maxInstancedCount === undefined ) {
 
-								geometry.maxInstancedCount = data.meshPerAttribute * data.count;
+									geometry.maxInstancedCount = data.meshPerAttribute * data.count;
+
+								}
+
+							} else {
+
+								state.enableAttribute( programAttribute );
 
 							}
 
+							_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
+							_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
+
+
 						} else {
 
-							state.enableAttribute( programAttribute );
+							if ( geometryAttribute.isInstancedBufferAttribute ) {
+
+								state.enableAttributeAndDivisor( programAttribute, geometryAttribute.meshPerAttribute );
+
+								if ( geometry.maxInstancedCount === undefined ) {
+
+									geometry.maxInstancedCount = geometryAttribute.meshPerAttribute * geometryAttribute.count;
+
+								}
+
+							} else {
+
+								state.enableAttribute( programAttribute );
+
+							}
+
+							_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
+							_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
 
 						}
-
-						_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
-						_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
-
 
 					} else {
 
-						if ( geometryAttribute.isInstancedBufferAttribute ) {
-
-							state.enableAttributeAndDivisor( programAttribute, geometryAttribute.meshPerAttribute );
-
-							if ( geometry.maxInstancedCount === undefined ) {
-
-								geometry.maxInstancedCount = geometryAttribute.meshPerAttribute * geometryAttribute.count;
-
-							}
-
-						} else {
-
-							state.enableAttribute( programAttribute );
-
-						}
-
-						_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
-						_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
+						state.enableAttribute( programAttribute );
 
 					}
 
-				} 
-
-				else {
-					
-					state.enableAttribute( programAttribute )
-				
-				}
-
-				nextBuffers.set(geometryAttribute, programAttribute )
+					nextBuffers.set( geometryAttribute, programAttribute );
 
 				} else if ( materialDefaultAttributeValues !== undefined ) {
 
@@ -962,7 +966,7 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		previousBuffers = nextBuffers
+		previousBuffers = nextBuffers;
 
 		state.disableUnusedAttributes();
 
@@ -1063,7 +1067,7 @@ function WebGLRenderer( parameters ) {
 		_currentMaterialId = - 1;
 		_currentCamera = null;
 
-		previousBuffers = new WeakMap()
+		previousBuffers = new WeakMap();
 
 		// update scene graph
 


### PR DESCRIPTION
It's possible to some times end up binding the same buffer over and over between calls. It doesn't seem very likely, and might not happen in such a number to really matter.

## r99:

https://raw.githack.com/pailhead/three.js/test-buffer-binding/examples/test.html

```
bindBuffer: 12
vertexAttribPointer: 8
```

## this branch:
https://raw.githack.com/pailhead/three.js/test-buffer-binding-build/examples/test.html

```
bindBuffer: 9
vertexAttribPointer: 5
```


The example basically renders the same sphere, but with different materials and (not sure how to categorize) instancing. The index and the positions are the same, but other draw calls may include normals and an instancing attribute.

It seems that attributes are treated on the geometry level, but it may be possible that two consecutive geometries share some of the attibutes and locations. I imagine it may not happen often if at all most of the time, but i'm wondering if there is some kind of an approach that would see a benefit from doing this diffing more granular. Any thoughts?