### PR TITLE
update Frustum.intersectsObject doc

### DIFF
--- a/docs/api/en/math/Frustum.html
+++ b/docs/api/en/math/Frustum.html
@@ -69,12 +69,13 @@
 	 	Return true if [page:Box3 box] intersects with this frustum.
 		</p>
 
-		<h3>[method:Boolean intersectsObject]( [param:Object3D object] )</h3>
+		<h3>[method:Boolean intersectsObject]( [param:(Line|Mesh|Points|Sprite) object] )</h3>
 		<p>
-			Checks whether the [page:Object3D object]'s [page:Geometry.boundingSphere bounding sphere] is intersecting the Frustum.<br /><br />
+			Checks whether the object's [page:Geometry.boundingSphere bounding sphere] is intersecting the Frustum.<br /><br />
 
 			Note that the object must have a [page:Geometry] or [page:BufferGeometry] so that the bounding sphere
-			can be calculated.
+			can be calculated (f.e. classes that are or extend from
+            [page:Line Line], [page:Mesh Mesh], [page:Points Points], or [page:Sprite Sprite]).
 		</p>
 
 		<h3>[method:Boolean intersectsSphere]( [param:Sphere sphere] )</h3>


### PR DESCRIPTION
Not sure if there's a way to specify multiple types in the method signature, maybe that needs to be added. Or does it exist and if so what is the syntax?

The type definition follows the documentation, so in TypeScript I passed a plain Object3D into the method and it failed because plain Object3D's don't have a `geometry`, so that'd need an update too.