### PR TITLE
Docs: Clean up linked examples

### DIFF
--- a/docs/api/en/cameras/CubeCamera.html
+++ b/docs/api/en/cameras/CubeCamera.html
@@ -17,7 +17,6 @@
 		<h2>Examples</h2>
 
 		<p>[example:webgl_materials_cubemap_dynamic materials / cubemap / dynamic ]</p>
-		<p>[example:webgl_materials_cubemap_dynamic2 materials / cubemap / dynamic2 ]</p>
 		<p>[example:webgl_shading_physical shading / physical ]</p>
 
 		<code>// Create cube camera

--- a/docs/api/en/core/Geometry.html
+++ b/docs/api/en/core/Geometry.html
@@ -32,7 +32,6 @@
 		<div>[example:webgl_interactive_lines WebGL / interactive / lines ]</div>
 		<div>[example:webgl_interactive_raycasting_points WebGL / interactive / raycasting / points ]</div>
 		<div>[example:webgl_interactive_voxelpainter WebGL / interactive / voxelpainter ]</div>
-		<div>[example:webgl_morphnormals WebGL / morphNormals ]</div>
 
 
 		<code>var geometry = new THREE.Geometry();
@@ -123,8 +122,6 @@
 		<p>
 		Array of morph normals. Morph normals have similar structure as morph targets, each normal set is a Javascript object:
 		<code>morphNormal = { name: "NormalName", normals: [ new THREE.Vector3(), ... ] }</code>
-
-		See the [example:webgl_morphnormals WebGL / morphNormals] example.
 		</p>
 
 		<h3>[property:String name]</h3>

--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -19,7 +19,6 @@
 		<h2>Example</h2>
 
 		<div>[example:webgl_geometries WebGL / geometries]</div>
-		<div>[example:webgl_geometries2 WebGL / geometries2]</div>
 		<div>[example:webgl_geometry_convex WebGL / geometry / convex]</div>
 		<div>[example:webgl_geometry_spline_editor WebGL / geometry / spline / editor]</div>
 

--- a/docs/api/en/loaders/CubeTextureLoader.html
+++ b/docs/api/en/loaders/CubeTextureLoader.html
@@ -22,7 +22,6 @@
 			[example:webgl_materials_cubemap_balls_reflection materials / cubemap / balls / reflection]<br />
 			[example:webgl_materials_cubemap_balls_refraction materials / cubemap / balls / refraction]<br />
 			[example:webgl_materials_cubemap_dynamic materials / cubemap / dynamic]<br />
-			[example:webgl_materials_cubemap_dynamic2 materials / cubemap / dynamic2]<br />
 			[example:webgl_materials_cubemap_refraction materials / cubemap / refraction]
 		</p>
 

--- a/docs/api/en/loaders/FileLoader.html
+++ b/docs/api/en/loaders/FileLoader.html
@@ -18,8 +18,8 @@
 
 		<h2>Example</h2>
 		<p>
-			[example:webgl_loader_msgpack WebGL / loader / msgpack]<br />
-			[example:webgl_morphtargets_human WebGL / morphtargets / human]<br />
+			[example:webgl_loader_obj2_options WebGL / loader / obj2 / options]<br />
+			[example:webgl2_materials_texture3d WebGL2 / materials / texture3d]<br />
 		</p>
 		<code>
 		var loader = new THREE.FileLoader();

--- a/docs/api/en/loaders/FileLoader.html
+++ b/docs/api/en/loaders/FileLoader.html
@@ -17,10 +17,6 @@
 		</p>
 
 		<h2>Example</h2>
-		<p>
-			[example:webgl_loader_obj2_options WebGL / loader / obj2 / options]<br />
-			[example:webgl2_materials_texture3d WebGL2 / materials / texture3d]<br />
-		</p>
 		<code>
 		var loader = new THREE.FileLoader();
 

--- a/docs/api/en/materials/LineBasicMaterial.html
+++ b/docs/api/en/materials/LineBasicMaterial.html
@@ -29,7 +29,6 @@
 			[example:webgl_lines_colors WebGL / lines / colors]<br />
 			[example:webgl_lines_dashed WebGL / lines / dashed]<br />
 			[example:webgl_lines_sphere WebGL / lines / sphere]<br />
-			[example:webgl_lines_splines WebGL / lines / splines]<br />
 			[example:webgl_materials WebGL / materials]<br />
 			[example:webgl_physics_rope WebGL / phyics / rope]
 		</p>

--- a/docs/api/en/materials/PointsMaterial.html
+++ b/docs/api/en/materials/PointsMaterial.html
@@ -26,9 +26,7 @@
 			[example:webgl_interactive_raycasting_points WebGL / interactive / raycasting / points]<br />
 			[example:webgl_multiple_elements_text WebGL / multiple / elements / text]<br />
 			[example:webgl_points_billboards WebGL / points / billboards]<br />
-			[example:webgl_points_billboards_colors WebGL / points / billboards / colors]<br />
 			[example:webgl_points_dynamic WebGL / points / dynamic]<br />
-			[example:webgl_points_random WebGL / points / random]<br />
 			[example:webgl_points_sprites WebGL / points / sprites]<br />
 			[example:webgl_trails WebGL / trails]
 		</p>

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -96,7 +96,6 @@
 			[example:webgl_materials_parallaxmap webgl / materials / parallaxmap]<br />
 			[example:webgl_materials_shaders_fresnel webgl / materials / shaders / fresnel]<br />
 			[example:webgl_materials_skin webgl / materials / skin]<br />
-			[example:webgl_materials_texture_hdr webgl / materials / texture / hdr]<br />
 			[example:webgl_materials_wireframe webgl / materials / wireframe]<br />
 			[example:webgl_modifier_tessellation webgl / modifier / tessellation]<br />
 			[example:webgl_nearestneighbour webgl / nearestneighbour]<br />


### PR DESCRIPTION
`CubeCamera`/`CubeTextureLoader`  
#14843 renamed `webgl_materials_cubemap_dynamic2` to `webgl_materials_cubemap_dynamic`. Two old references were still left.

`Geometry`  
`webgl_morphnormals` was dropped in #14747

`AxesHelper`  
`webgl_geometries2` was rewritten into `webgl_geometries_parametric` in #12393 and `AxesHelper` subsequently removed in #12404

`LineBasicMaterial`  
`webgl_lines_splines` was merged into `webgl_lines_colors` in #13563

`PointsMaterial`  
`webgl_points_billboards_colors` and `webgl_points_random` were merged into `webgl_points_billboards` in #13818

`ShaderMaterial`  
`webgl_materials_texture_hdr` was renamed to `webgl_loader_texture_hdr` in b8b2e775ba62e3c8cd8d6635502cfbaed889d1b9 and no longer handles `ShaderMaterial` (at least not as obviously as it did before)

`FileLoader`  
b5db8b34dc7e718f832ca636d6accf71d2ce50e2 removed `webgl_loader_msgpack` and #15164 removed `webgl_morphtargets_human`. Since `FileLoader` now had no referenced examples left I've used the only two remaining ones that use it: [webgl2_materials_texture3d](https://rawgit.com/mrdoob/three.js/dev/examples/webgl2_materials_texture3d.html) and [webgl_loader_obj2_options](https://rawgit.com/mrdoob/three.js/dev/examples/webgl_loader_obj2_options.html)  
I did a quick search but couldn't find anything, is `FileLoader` being phased out or is it just rarely used?