### PR TITLE
Make pragma unroll_loop more dev-friendly

### DIFF
--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -52,10 +52,7 @@
 						The loop has to be [link:https://en.wikipedia.org/wiki/Normalized_loop normalized].
 					</li>
 					<li>
-						The loop variable has to be *i*.
-					</li>
-					<li>
-						The loop has to use a certain whitespace formatting.
+						The loop variable can have any valid variable name (using only letters, numbers and _).
 					</li>
 				</ul>
 				<code>

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -191,13 +191,11 @@ function unrollLoops( string ) {
 	function replace( match, token, start, end, snippet ) {
 
 		var unroll = '';
-		var toBeReplaced = new RegExp('\\[ ' + token + ' \\]', 'g')
-
-		var unroll = '';
+		var toBeReplaced = new RegExp('([^\\w])' + token + '([^\\w])', 'g')
 
 		for ( var i = parseInt( start ); i < parseInt( end ); i ++ ) {
 
-			unroll += snippet.replace( toBeReplaced, '[ ' + i + ' ]' );
+			unroll += snippet.replace( toBeReplaced,  '$1' + i + '$2' );
 
 		}
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -191,11 +191,11 @@ function unrollLoops( string ) {
 	function replace( match, token, start, end, snippet ) {
 
 		var unroll = '';
-		var toBeReplaced = new RegExp('([^\\w])' + token + '([^\\w])', 'g')
+		var toBeReplaced = new RegExp( '([^\\w])' + token + '([^\\w])', 'g' );
 
 		for ( var i = parseInt( start ); i < parseInt( end ); i ++ ) {
 
-			unroll += snippet.replace( toBeReplaced,  '$1' + i + '$2' );
+			unroll += snippet.replace( toBeReplaced, '$1' + i + '$2' );
 
 		}
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -186,7 +186,7 @@ function parseIncludes( string ) {
 
 function unrollLoops( string ) {
 
-	var pattern = /#pragma unroll_loop[\s]+?for\s*?\(\s*?int\s*?([\w]+?)\s*?\=\s*?(\d+)\;\s*?\1\s*?<\s*?(\d+)\;\s*?\1\s*?\+\+\s*?\)\s*?\{([\s\S]+?)(?=\})\}/g;
+	var pattern = /#pragma unroll_loop[\s]+?for\s*?\(\s*?int\s+?([\w]+?)\s*?\=\s*?(\d+)\;\s*?\1\s*?<\s*?(\d+)\;\s*?\1\s*?\+\+\s*?\)\s*?\{([\s\S]+?)(?=\})\}/g;
 
 	function replace( match, token, start, end, snippet ) {
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -186,7 +186,7 @@ function parseIncludes( string ) {
 
 function unrollLoops( string ) {
 
-	var pattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
+	var pattern = /#pragma unroll_loop[\s]+?for\s*?\(\s*?int\s*?i\s*?\=\s*?(\d+)\;\s*?i\s*?<\s*?(\d+)\;\s*?i\s*?\+\+\s*?\)\s*?\{([\s\S]+?)(?=\})\}/g;
 
 	function replace( match, start, end, snippet ) {
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -186,15 +186,18 @@ function parseIncludes( string ) {
 
 function unrollLoops( string ) {
 
-	var pattern = /#pragma unroll_loop[\s]+?for\s*?\(\s*?int\s*?i\s*?\=\s*?(\d+)\;\s*?i\s*?<\s*?(\d+)\;\s*?i\s*?\+\+\s*?\)\s*?\{([\s\S]+?)(?=\})\}/g;
+	var pattern = /#pragma unroll_loop[\s]+?for\s*?\(\s*?int\s*?([\w]+?)\s*?\=\s*?(\d+)\;\s*?\1\s*?<\s*?(\d+)\;\s*?\1\s*?\+\+\s*?\)\s*?\{([\s\S]+?)(?=\})\}/g;
 
-	function replace( match, start, end, snippet ) {
+	function replace( match, token, start, end, snippet ) {
+
+		var unroll = '';
+		var toBeReplaced = new RegExp('\\[ ' + token + ' \\]', 'g')
 
 		var unroll = '';
 
 		for ( var i = parseInt( start ); i < parseInt( end ); i ++ ) {
 
-			unroll += snippet.replace( /\[ i \]/g, '[ ' + i + ' ]' );
+			unroll += snippet.replace( toBeReplaced, '[ ' + i + ' ]' );
 
 		}
 


### PR DESCRIPTION
Following that issue: https://github.com/mrdoob/three.js/issues/15414

Here is my proposal for improvement.
All the following snippets should now be unrolled properly:
```glsl
#pragma unroll_loop
for ( int i = 0; i < 3; i ++ ) {
  f( buff[ i ] );
}
```

```glsl
#pragma unroll_loop
for (int i = 4; i < 8; i++) {
  f( buff[ i ] );
}
```

```glsl
#pragma unroll_loop
for(inti=0;i<2;i++){f(buff[ i ]);}
```

```glsl
#pragma unroll_loop
for ( int xx = 0; xx < 3; xx ++ ) {
  f( buff[ xx ] );
}
```

```glsl
#pragma unroll_loop
for ( int i = 0; i < 3; i ++ ) {
  if (i % 2 == 0) f(i)
}
```


Here are the unit tests for the function:
https://codepen.io/Granipouss/pen/jXWpvL