### PR TITLE
GLTFLoader: use object as cache instead of array

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1555,9 +1555,9 @@ THREE.GLTFLoader = ( function () {
 
 		var keys = Object.keys( attributes ).sort();
 
-		for ( var key of keys ) {
+		for ( var i = 0, il = keys.length; i < il; i ++ ) {
 
-			attributesKey += key + attributes[ key ];
+			attributesKey += keys[ i ] + attributes[ keys[ i ] ];
 
 		}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1541,7 +1541,7 @@ THREE.GLTFLoader = ( function () {
 
 		} else {
 
-			geometryKey = primitiveDef.indices + ':' + createAttributesKey( primitiveDef.attributes ) + primitiveDef.mode;
+			geometryKey = primitiveDef.indices + ':' + createAttributesKey( primitiveDef.attributes ) + ':' + primitiveDef.mode;
 
 		}
 
@@ -1557,7 +1557,7 @@ THREE.GLTFLoader = ( function () {
 
 		for ( var i = 0, il = keys.length; i < il; i ++ ) {
 
-			attributesKey += keys[ i ] + attributes[ keys[ i ] ];
+			attributesKey += keys[ i ] + ':' + attributes[ keys[ i ] ] + ';';
 
 		}
 
@@ -1565,13 +1565,27 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
-	function createArrayKey( a ) {
+	function createArrayKeyBufferGeometry( a ) {
 
 		var arrayKey = '';
 
 		for ( var i = 0, il = a.length; i < il; i ++ ) {
 
-			arrayKey += i + createAttributesKey( a[ i ] );
+			arrayKey += i + a[ i ].uuid;
+
+		}
+
+		return arrayKey;
+
+	}
+
+	function createArrayKeyGLTFPrimitive( a ) {
+
+		var arrayKey = '';
+
+		for ( var i = 0, il = a.length; i < il; i ++ ) {
+
+			arrayKey += i + createGeometryKey( a[ i ] );
 
 		}
 
@@ -1581,7 +1595,7 @@ THREE.GLTFLoader = ( function () {
 
 	function createMultiPassGeometryKey( geometry, primitives ) {
 
-		return createGeometryKey( geometry ) + createArrayKey( primitives );
+		return createGeometryKey( geometry ) + createArrayKeyGLTFPrimitive( primitives );
 
 	}
 
@@ -2610,7 +2624,7 @@ THREE.GLTFLoader = ( function () {
 
 				// See if we've already created this combined geometry
 				var cache = parser.multiplePrimitivesCache;
-				var cacheKey = createArrayKey( geometries );
+				var cacheKey = createArrayKeyBufferGeometry( geometries );
 				var cached = cache[ cacheKey ];
 
 				if ( cached ) {

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1553,7 +1553,9 @@ THREE.GLTFLoader = ( function () {
 
 		var attributesKey = '';
 
-		for ( var key in attributes ) {
+		var keys = Object.keys( attributes ).sort();
+
+		for ( var key of keys ) {
 
 			attributesKey += key + attributes[ key ];
 
@@ -1569,13 +1571,7 @@ THREE.GLTFLoader = ( function () {
 
 		for ( var i = 0, il = a.length; i < il; i ++ ) {
 
-			arrayKey += i;
-
-			for ( var j = 0, jl = a[ i ].lenght; j < jl; j ++ ) {
-
-				arrayKey += j + a[ i ][ j ];
-
-			}
+			arrayKey += i + createAttributesKey( a[ i ] );
 
 		}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1595,11 +1595,11 @@ THREE.GLTFLoader = ( function () {
 
 	function createMultiPassGeometryKey( geometry, primitives ) {
 
-		var key = createPrimitiveKey( geometry );
+		var key = geometry.uuid;
 
 		for ( var i = 0, il = primitives.length; i < il; i ++ ) {
 
-			key += i + primitives[ i ].uuid;
+			key += i + createPrimitiveKey( primitives[ i ].uuid );
 
 		}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1528,7 +1528,7 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
-	function createGeometryKey( primitiveDef ) {
+	function createPrimitiveKey( primitiveDef ) {
 
 		var dracoExtension = primitiveDef.extensions && primitiveDef.extensions[ EXTENSIONS.KHR_DRACO_MESH_COMPRESSION ];
 		var geometryKey;
@@ -1585,7 +1585,7 @@ THREE.GLTFLoader = ( function () {
 
 		for ( var i = 0, il = a.length; i < il; i ++ ) {
 
-			arrayKey += i + createGeometryKey( a[ i ] );
+			arrayKey += i + createPrimitiveKey( a[ i ] );
 
 		}
 
@@ -1595,7 +1595,15 @@ THREE.GLTFLoader = ( function () {
 
 	function createMultiPassGeometryKey( geometry, primitives ) {
 
-		return createGeometryKey( geometry ) + createArrayKeyGLTFPrimitive( primitives );
+		var key = createPrimitiveKey( geometry );
+
+		for ( var i = 0, il = primitives.length; i < il; i ++ ) {
+
+			key += i + primitives[ i ].uuid;
+
+		}
+
+		return key;
 
 	}
 
@@ -2520,7 +2528,7 @@ THREE.GLTFLoader = ( function () {
 		for ( var i = 0, il = primitives.length; i < il; i ++ ) {
 
 			var primitive = primitives[ i ];
-			var cacheKey = createGeometryKey( primitive );
+			var cacheKey = createPrimitiveKey( primitive );
 
 			// See if we've already created this geometry
 			var cached = cache[ cacheKey ];

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1571,21 +1571,7 @@ THREE.GLTFLoader = ( function () {
 
 		for ( var i = 0, il = a.length; i < il; i ++ ) {
 
-			arrayKey += i + a[ i ].uuid;
-
-		}
-
-		return arrayKey;
-
-	}
-
-	function createArrayKeyGLTFPrimitive( a ) {
-
-		var arrayKey = '';
-
-		for ( var i = 0, il = a.length; i < il; i ++ ) {
-
-			arrayKey += i + createPrimitiveKey( a[ i ] );
+			arrayKey += ':' + a[ i ].uuid;
 
 		}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1541,7 +1541,7 @@ THREE.GLTFLoader = ( function () {
 
 		} else {
 
-			geometryKey = primitiveDef.indices + ':' + createAttributesKey( primitiveDef.attributes );
+			geometryKey = primitiveDef.indices + ':' + createAttributesKey( primitiveDef.attributes ) + primitiveDef.mode;
 
 		}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1585,7 +1585,7 @@ THREE.GLTFLoader = ( function () {
 
 		for ( var i = 0, il = primitives.length; i < il; i ++ ) {
 
-			key += i + createPrimitiveKey( primitives[ i ].uuid );
+			key += i + createPrimitiveKey( primitives[ i ] );
 
 		}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -338,7 +338,7 @@ THREE.GLTFLoader = ( function () {
 
 			case 'directional':
 				lightNode = new THREE.DirectionalLight( color );
-				lightNode.target.position.set( 0, 0, -1 );
+				lightNode.target.position.set( 0, 0, - 1 );
 				lightNode.add( lightNode.target );
 				break;
 
@@ -356,7 +356,7 @@ THREE.GLTFLoader = ( function () {
 				lightDef.spot.outerConeAngle = lightDef.spot.outerConeAngle !== undefined ? lightDef.spot.outerConeAngle : Math.PI / 4.0;
 				lightNode.angle = lightDef.spot.outerConeAngle;
 				lightNode.penumbra = 1.0 - lightDef.spot.innerConeAngle / lightDef.spot.outerConeAngle;
-				lightNode.target.position.set( 0, 0, -1 );
+				lightNode.target.position.set( 0, 0, - 1 );
 				lightNode.add( lightNode.target );
 				break;
 
@@ -964,6 +964,7 @@ THREE.GLTFLoader = ( function () {
 					uniforms.refractionRatio.value = material.refractionRatio;
 
 					uniforms.maxMipLevel.value = renderer.properties.get( material.envMap ).__maxMipLevel;
+
 				}
 
 				uniforms.specular.value.copy( material.specular );
@@ -1356,8 +1357,10 @@ THREE.GLTFLoader = ( function () {
 				var accessor = target.POSITION !== undefined
 					? parser.getDependency( 'accessor', target.POSITION )
 						.then( function ( accessor ) {
+
 							// Cloning not to pollute original accessor below
 							return cloneBufferAttribute( accessor );
+
 						} )
 					: geometry.attributes.position;
 
@@ -1371,7 +1374,9 @@ THREE.GLTFLoader = ( function () {
 				var accessor = target.NORMAL !== undefined
 					? parser.getDependency( 'accessor', target.NORMAL )
 						.then( function ( accessor ) {
+
 							return cloneBufferAttribute( accessor );
+
 						} )
 					: geometry.attributes.normal;
 
@@ -1523,9 +1528,9 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
-	function createGeometryKey( geometry ) {
+	function createGeometryKey( primitiveDef ) {
 
-		var dracoExtension = geometry.extensions && geometry.extensions[ EXTENSIONS.KHR_DRACO_MESH_COMPRESSION ];
+		var dracoExtension = primitiveDef.extensions && primitiveDef.extensions[ EXTENSIONS.KHR_DRACO_MESH_COMPRESSION ];
 		var geometryKey;
 
 		if ( dracoExtension ) {
@@ -1536,7 +1541,7 @@ THREE.GLTFLoader = ( function () {
 
 		} else {
 
-			geometryKey = geometry.indices + ':' + createAttributesKey( geometry.attributes );
+			geometryKey = primitiveDef.indices + ':' + createAttributesKey( primitiveDef.attributes );
 
 		}
 
@@ -1557,13 +1562,20 @@ THREE.GLTFLoader = ( function () {
 		return attributesKey;
 
 	}
+
 	function createArrayKey( a ) {
 
 		var arrayKey = '';
 
 		for ( var i = 0, il = a.length; i < il; i ++ ) {
 
-			arrayKey += i + a[ i ];
+			arrayKey += i;
+
+			for ( var j = 0, jl = a[ i ].lenght; j < jl; j ++ ) {
+
+				arrayKey += j + a[ i ][ j ];
+
+			}
 
 		}
 
@@ -1822,7 +1834,7 @@ THREE.GLTFLoader = ( function () {
 
 				case 'light':
 					dependency = this.extensions[ EXTENSIONS.KHR_LIGHTS_PUNCTUAL ].loadLight( index );
-					break
+					break;
 
 				default:
 					throw new Error( 'Unknown type: ' + type );
@@ -3106,7 +3118,7 @@ THREE.GLTFLoader = ( function () {
 
 		var nodeDef = json.nodes[ nodeIndex ];
 
-		return ( function() {
+		return ( function () {
 
 			// .isBone isn't in glTF spec. See .markDefs
 			if ( nodeDef.isBone === true ) {
@@ -3299,7 +3311,7 @@ THREE.GLTFLoader = ( function () {
 
 						mesh.bind( new THREE.Skeleton( bones, boneInverses ), mesh.matrixWorld );
 
-					};
+					}
 
 					return node;
 


### PR DESCRIPTION
Implements #15321: use object as cache for GTLF loader instead of array.

For our specific case the loading time goes from ~220 seconds to ~7 seconds (we have ~60000 geometries with ~30000 mesh). 

Completely disabling the cache (as we have done so far) has more or less the same impact.

Signed-off-by: Riccardo Padovani <rpadovani@nextbit.it>