### PR TITLE
MTLLoader: Correctly parse emissive coefficient.

### DIFF
--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -149,7 +149,7 @@ THREE.MTLLoader.prototype = {
 
 			} else {
 
-				if ( key === 'ka' || key === 'kd' || key === 'ks' ) {
+				if ( key === 'ka' || key === 'kd' || key === 'ks'|| key ==='ke') {
 
 					var ss = value.split( delimiter_pattern, 3 );
 					info[ key ] = [ parseFloat( ss[ 0 ] ), parseFloat( ss[ 1 ] ), parseFloat( ss[ 2 ] ) ];


### PR DESCRIPTION
when parsing the MTL file, the ke value doesn't get converted into a array from string, resulting in errors in the rgb value.  I think this was a miss from #15367

