### PR TITLE
Copy .onBeforeCompile in Material.copy()

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -365,6 +365,8 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		this.shadowSide = source.shadowSide;
 
+		this.onBeforeCompile = source.onBeforeCompile;
+
 		return this;
 
 	},


### PR DESCRIPTION
This PR add missing `.onBeforeCompile` copying in Materia.copy.
With this change, Materials hacked with `.onBeforeCompile()` can be copied/cloned.