### PR TITLE
Add syntax highlighting for glsl.js files

### DIFF
--- a/src/renderers/shaders/ShaderChunk/alphamap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/alphamap_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_ALPHAMAP
 
 	diffuseColor.a *= texture2D( alphaMap, vUv ).g;

--- a/src/renderers/shaders/ShaderChunk/alphamap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/alphamap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_ALPHAMAP
 
 	uniform sampler2D alphaMap;

--- a/src/renderers/shaders/ShaderChunk/alphatest_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/alphatest_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef ALPHATEST
 
 	if ( diffuseColor.a < ALPHATEST ) discard;

--- a/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_AOMAP
 
 	// reads channel R, compatible with a combined OcclusionRoughnessMetallic (RGB) texture

--- a/src/renderers/shaders/ShaderChunk/aomap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/aomap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_AOMAP
 
 	uniform sampler2D aoMap;

--- a/src/renderers/shaders/ShaderChunk/begin_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/begin_vertex.glsl.js
@@ -1,3 +1,3 @@
-export default `
+export default /* glsl */`
 vec3 transformed = vec3( position );
 `;

--- a/src/renderers/shaders/ShaderChunk/beginnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/beginnormal_vertex.glsl.js
@@ -1,3 +1,3 @@
-export default `
+export default /* glsl */`
 vec3 objectNormal = vec3( normal );
 `;

--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 float punctualLightIntensityToIrradianceFactor( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {
 
 #if defined ( PHYSICALLY_CORRECT_LIGHTS )

--- a/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_BUMPMAP
 
 	uniform sampler2D bumpMap;

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if NUM_CLIPPING_PLANES > 0
 
 	vec4 plane;

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if NUM_CLIPPING_PLANES > 0
 
 	#if ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if NUM_CLIPPING_PLANES > 0 && ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )
 	varying vec3 vViewPosition;
 #endif

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if NUM_CLIPPING_PLANES > 0 && ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )
 	vViewPosition = - mvPosition.xyz;
 #endif

--- a/src/renderers/shaders/ShaderChunk/color_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/color_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_COLOR
 
 	diffuseColor.rgb *= vColor;

--- a/src/renderers/shaders/ShaderChunk/color_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/color_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_COLOR
 
 	varying vec3 vColor;

--- a/src/renderers/shaders/ShaderChunk/color_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/color_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_COLOR
 
 	varying vec3 vColor;

--- a/src/renderers/shaders/ShaderChunk/color_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/color_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_COLOR
 
 	vColor.xyz = color.xyz;

--- a/src/renderers/shaders/ShaderChunk/common.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/common.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define PI 3.14159265359
 #define PI2 6.28318530718
 #define PI_HALF 1.5707963267949

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef ENVMAP_TYPE_CUBE_UV
 
 #define cubeUV_textureSize (1024.0)

--- a/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 vec3 transformedNormal = normalMatrix * objectNormal;
 
 #ifdef FLIP_SIDED

--- a/src/renderers/shaders/ShaderChunk/displacementmap_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/displacementmap_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_DISPLACEMENTMAP
 
 	uniform sampler2D displacementMap;

--- a/src/renderers/shaders/ShaderChunk/displacementmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/displacementmap_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_DISPLACEMENTMAP
 
 	transformed += normalize( objectNormal ) * ( texture2D( displacementMap, uv ).x * displacementScale + displacementBias );

--- a/src/renderers/shaders/ShaderChunk/dithering_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/dithering_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( DITHERING )
 
   gl_FragColor.rgb = dithering( gl_FragColor.rgb );

--- a/src/renderers/shaders/ShaderChunk/dithering_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/dithering_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( DITHERING )
 
 	// based on https://www.shadertoy.com/view/MslGR8

--- a/src/renderers/shaders/ShaderChunk/emissivemap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/emissivemap_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_EMISSIVEMAP
 
 	vec4 emissiveColor = texture2D( emissiveMap, vUv );

--- a/src/renderers/shaders/ShaderChunk/emissivemap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/emissivemap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_EMISSIVEMAP
 
 	uniform sampler2D emissiveMap;

--- a/src/renderers/shaders/ShaderChunk/encodings_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/encodings_fragment.glsl.js
@@ -1,3 +1,3 @@
-export default `
+export default /* glsl */`
   gl_FragColor = linearToOutputTexel( gl_FragColor );
 `;

--- a/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 // For a discussion of what this is, please read this: http://lousodrome.net/blog/light/2013/05/26/gamma-correct-and-hdr-rendering-in-a-32-bits-buffer/
 
 vec4 LinearToLinear( in vec4 value ) {

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_ENVMAP
 
 	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )

--- a/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_ENVMAP ) || defined( PHYSICAL )
 	uniform float reflectivity;
 	uniform float envMapIntensity;

--- a/src/renderers/shaders/ShaderChunk/envmap_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_ENVMAP
 
 	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )

--- a/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_ENVMAP ) && defined( PHYSICAL )
 
 	vec3 getLightProbeIndirectIrradiance( /*const in SpecularLightProbe specularLightProbe,*/ const in GeometricContext geometry, const in int maxMIPLevel ) {

--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_ENVMAP
 
 	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )

--- a/src/renderers/shaders/ShaderChunk/fog_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_FOG
 
 	#ifdef FOG_EXP2

--- a/src/renderers/shaders/ShaderChunk/fog_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_FOG
 
 	uniform vec3 fogColor;

--- a/src/renderers/shaders/ShaderChunk/fog_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_FOG
 
 	varying float fogDepth;

--- a/src/renderers/shaders/ShaderChunk/fog_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_FOG
 
 	fogDepth = -mvPosition.z;

--- a/src/renderers/shaders/ShaderChunk/gradientmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/gradientmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef TOON
 
 	uniform sampler2D gradientMap;

--- a/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_LIGHTMAP
 
 	reflectedLight.indirectDiffuse += PI * texture2D( lightMap, vUv2 ).xyz * lightMapIntensity; // factor of PI should not be present; included here to prevent breakage

--- a/src/renderers/shaders/ShaderChunk/lightmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lightmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_LIGHTMAP
 
 	uniform sampler2D lightMap;

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 /**
  * This is a template that can be used to light a material, it uses pluggable
  * RenderEquations (RE)for specific lighting scenarios.

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_end.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_end.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( RE_IndirectDiffuse )
 
 	RE_IndirectDiffuse( irradiance, geometry, material, reflectedLight );

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( RE_IndirectDiffuse )
 
 	#ifdef USE_LIGHTMAP

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 vec3 diffuse = vec3( 1.0 );
 
 GeometricContext geometry;

--- a/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform vec3 ambientLightColor;
 
 vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {

--- a/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 BlinnPhongMaterial material;
 material.diffuseColor = diffuseColor.rgb;
 material.specularColor = specular;

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 varying vec3 vViewPosition;
 
 #ifndef FLAT_SHADED

--- a/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 PhysicalMaterial material;
 material.diffuseColor = diffuseColor.rgb * ( 1.0 - metalnessFactor );
 material.specularRoughness = clamp( roughnessFactor, 0.04, 1.0 );

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 struct PhysicalMaterial {
 
 	vec3	diffuseColor;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )
 
 	gl_FragDepthEXT = log2( vFragDepth ) * logDepthBufFC * 0.5;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )
 
 	uniform float logDepthBufFC;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_LOGDEPTHBUF
 
 	#ifdef USE_LOGDEPTHBUF_EXT

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_LOGDEPTHBUF
 
 	#ifdef USE_LOGDEPTHBUF_EXT

--- a/src/renderers/shaders/ShaderChunk/map_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/map_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_MAP
 
 	vec4 texelColor = texture2D( map, vUv );

--- a/src/renderers/shaders/ShaderChunk/map_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/map_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_MAP
 
 	uniform sampler2D map;

--- a/src/renderers/shaders/ShaderChunk/map_particle_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/map_particle_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_MAP
 
 	vec2 uv = ( uvTransform * vec3( gl_PointCoord.x, 1.0 - gl_PointCoord.y, 1 ) ).xy;

--- a/src/renderers/shaders/ShaderChunk/map_particle_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/map_particle_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_MAP
 
 	uniform mat3 uvTransform;

--- a/src/renderers/shaders/ShaderChunk/metalnessmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/metalnessmap_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 float metalnessFactor = metalness;
 
 #ifdef USE_METALNESSMAP

--- a/src/renderers/shaders/ShaderChunk/metalnessmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/metalnessmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_METALNESSMAP
 
 	uniform sampler2D metalnessMap;

--- a/src/renderers/shaders/ShaderChunk/morphnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphnormal_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_MORPHNORMALS
 
 	objectNormal += ( morphNormal0 - normal ) * morphTargetInfluences[ 0 ];

--- a/src/renderers/shaders/ShaderChunk/morphtarget_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphtarget_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_MORPHTARGETS
 
 	#ifndef USE_MORPHNORMALS

--- a/src/renderers/shaders/ShaderChunk/morphtarget_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphtarget_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_MORPHTARGETS
 
 	transformed += ( morphTarget0 - position ) * morphTargetInfluences[ 0 ];

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef FLAT_SHADED
 
 	// Workaround for Adreno/Nexus5 not able able to do dFdx( vViewPosition ) ...

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_NORMALMAP
 
 	#ifdef OBJECTSPACE_NORMALMAP

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_NORMALMAP
 
 	uniform sampler2D normalMap;

--- a/src/renderers/shaders/ShaderChunk/packing.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 vec3 packNormalToRGB( const in vec3 normal ) {
 	return normalize( normal ) * 0.5 + 0.5;
 }

--- a/src/renderers/shaders/ShaderChunk/premultiplied_alpha_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/premultiplied_alpha_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef PREMULTIPLIED_ALPHA
 
 	// Get get normal blending with premultipled, use with CustomBlending, OneFactor, OneMinusSrcAlphaFactor, AddEquation.

--- a/src/renderers/shaders/ShaderChunk/project_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/project_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 vec4 mvPosition = modelViewMatrix * vec4( transformed, 1.0 );
 
 gl_Position = projectionMatrix * mvPosition;

--- a/src/renderers/shaders/ShaderChunk/roughnessmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/roughnessmap_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 float roughnessFactor = roughness;
 
 #ifdef USE_ROUGHNESSMAP

--- a/src/renderers/shaders/ShaderChunk/roughnessmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/roughnessmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_ROUGHNESSMAP
 
 	uniform sampler2D roughnessMap;

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_SHADOWMAP
 
 	#if NUM_DIR_LIGHTS > 0

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_SHADOWMAP
 
 	#if NUM_DIR_LIGHTS > 0

--- a/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_SHADOWMAP
 
 	#if NUM_DIR_LIGHTS > 0

--- a/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 float getShadowMask() {
 
 	float shadow = 1.0;

--- a/src/renderers/shaders/ShaderChunk/skinbase_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/skinbase_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_SKINNING
 
 	mat4 boneMatX = getBoneMatrix( skinIndex.x );

--- a/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_SKINNING
 
 	uniform mat4 bindMatrix;

--- a/src/renderers/shaders/ShaderChunk/skinning_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/skinning_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_SKINNING
 
 	vec4 skinVertex = bindMatrix * vec4( transformed, 1.0 );

--- a/src/renderers/shaders/ShaderChunk/skinnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/skinnormal_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_SKINNING
 
 	mat4 skinMatrix = mat4( 0.0 );

--- a/src/renderers/shaders/ShaderChunk/specularmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/specularmap_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 float specularStrength;
 
 #ifdef USE_SPECULARMAP

--- a/src/renderers/shaders/ShaderChunk/specularmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/specularmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifdef USE_SPECULARMAP
 
 	uniform sampler2D specularMap;

--- a/src/renderers/shaders/ShaderChunk/tonemapping_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( TONE_MAPPING )
 
   gl_FragColor.rgb = toneMapping( gl_FragColor.rgb );

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #ifndef saturate
 	#define saturate(a) clamp( a, 0.0, 1.0 )
 #endif

--- a/src/renderers/shaders/ShaderChunk/uv2_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv2_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )
 
 	varying vec2 vUv2;

--- a/src/renderers/shaders/ShaderChunk/uv2_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv2_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )
 
 	attribute vec2 uv2;

--- a/src/renderers/shaders/ShaderChunk/uv2_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv2_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )
 
 	vUv2 = uv2;

--- a/src/renderers/shaders/ShaderChunk/uv_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )
 
 	varying vec2 vUv;

--- a/src/renderers/shaders/ShaderChunk/uv_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv_pars_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )
 
 	varying vec2 vUv;

--- a/src/renderers/shaders/ShaderChunk/uv_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )
 
 	vUv = ( uvTransform * vec3( uv, 1 ) ).xy;

--- a/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP )
 
 	vec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );

--- a/src/renderers/shaders/ShaderLib/background_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/background_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform sampler2D t2D;
 
 varying vec2 vUv;

--- a/src/renderers/shaders/ShaderLib/background_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/background_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 varying vec2 vUv;
 uniform mat3 uvTransform;
 

--- a/src/renderers/shaders/ShaderLib/cube_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/cube_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform samplerCube tCube;
 uniform float tFlip;
 uniform float opacity;

--- a/src/renderers/shaders/ShaderLib/cube_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/cube_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 varying vec3 vWorldDirection;
 
 #include <common>

--- a/src/renderers/shaders/ShaderLib/depth_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/depth_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #if DEPTH_PACKING == 3200
 
 	uniform float opacity;

--- a/src/renderers/shaders/ShaderLib/depth_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/depth_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #include <common>
 #include <uv_pars_vertex>
 #include <displacementmap_pars_vertex>

--- a/src/renderers/shaders/ShaderLib/distanceRGBA_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/distanceRGBA_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define DISTANCE
 
 uniform vec3 referencePosition;

--- a/src/renderers/shaders/ShaderLib/distanceRGBA_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/distanceRGBA_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define DISTANCE
 
 varying vec3 vWorldPosition;

--- a/src/renderers/shaders/ShaderLib/equirect_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/equirect_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform sampler2D tEquirect;
 
 varying vec3 vWorldDirection;

--- a/src/renderers/shaders/ShaderLib/equirect_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/equirect_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 varying vec3 vWorldDirection;
 
 #include <common>

--- a/src/renderers/shaders/ShaderLib/linedashed_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/linedashed_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform vec3 diffuse;
 uniform float opacity;
 

--- a/src/renderers/shaders/ShaderLib/linedashed_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/linedashed_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform float scale;
 attribute float lineDistance;
 

--- a/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform vec3 diffuse;
 uniform float opacity;
 

--- a/src/renderers/shaders/ShaderLib/meshbasic_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #include <common>
 #include <uv_pars_vertex>
 #include <uv2_pars_vertex>

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform vec3 diffuse;
 uniform vec3 emissive;
 uniform float opacity;

--- a/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define LAMBERT
 
 varying vec3 vLightFront;

--- a/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define MATCAP
 
 uniform vec3 diffuse;

--- a/src/renderers/shaders/ShaderLib/meshmatcap_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define MATCAP
 
 varying vec3 vViewPosition;

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define PHONG
 
 uniform vec3 diffuse;

--- a/src/renderers/shaders/ShaderLib/meshphong_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define PHONG
 
 varying vec3 vViewPosition;

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define PHYSICAL
 
 uniform vec3 diffuse;

--- a/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define PHYSICAL
 
 varying vec3 vViewPosition;

--- a/src/renderers/shaders/ShaderLib/normal_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/normal_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define NORMAL
 
 uniform float opacity;

--- a/src/renderers/shaders/ShaderLib/normal_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/normal_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #define NORMAL
 
 #if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || ( defined( USE_NORMALMAP ) && ! defined( OBJECTSPACE_NORMALMAP ) )

--- a/src/renderers/shaders/ShaderLib/points_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/points_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform vec3 diffuse;
 uniform float opacity;
 

--- a/src/renderers/shaders/ShaderLib/points_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/points_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform float size;
 uniform float scale;
 

--- a/src/renderers/shaders/ShaderLib/shadow_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/shadow_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform vec3 color;
 uniform float opacity;
 

--- a/src/renderers/shaders/ShaderLib/shadow_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/shadow_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 #include <fog_pars_vertex>
 #include <shadowmap_pars_vertex>
 

--- a/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform vec3 diffuse;
 uniform float opacity;
 

--- a/src/renderers/shaders/ShaderLib/sprite_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/sprite_vert.glsl.js
@@ -1,4 +1,4 @@
-export default `
+export default /* glsl */`
 uniform float rotation;
 uniform vec2 center;
 


### PR DESCRIPTION
Do you want to keep the cool kid syntaxes with their backticks \` \` without compromises? Missing your favourite syntax highlighting in your shaders? This PR is for you.

The idea is simple: prefix your template string with a comment specifying its syntax and there you have it.

Before:
<img width="720" alt="screenshot 2018-12-24 at 23 57 29" src="https://user-images.githubusercontent.com/1636460/50407859-c8d0c900-07d7-11e9-9139-c7c1ebb74fd6.png">

After:
<img width="720" alt="screenshot 2018-12-24 at 23 57 18" src="https://user-images.githubusercontent.com/1636460/50407862-cf5f4080-07d7-11e9-9382-1c42ce13732a.png">

Tried and tested in both VSCode and Atom:
### VSCode
You just need this extension: https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates
### Atom
Install the following packages:
- https://atom.io/packages/language-glsl 
- https://atom.io/packages/language-babel

Set your file grammar to `language-babel-extension`.
Go to Language Babel settings, look for `JavaScript Tagged Template Literal Grammar Extensions` and add `/* glsl */:source.glsl`.

More seriously, I understand this can look like an overhead in the codebase (although that just comments so maybe not) but that might bring back some sanity to the maintainers and contributors when they are trying to update the shader code in their text editors.

Thanks