### PR TITLE
Examples: Fix some warnings

### DIFF
--- a/examples/js/Ocean.js
+++ b/examples/js/Ocean.js
@@ -120,7 +120,7 @@ THREE.Ocean = function ( renderer, camera, scene, options ) {
 	var initialSpectrumUniforms = THREE.UniformsUtils.clone( initialSpectrumShader.uniforms );
 	this.materialInitialSpectrum = new THREE.ShaderMaterial( {
 		uniforms: initialSpectrumUniforms,
-		vertexShader: fullscreeenVertexShader.vertexShader,
+		vertexShader: initialSpectrumShader.vertexShader,
 		fragmentShader: initialSpectrumShader.fragmentShader
 	} );
 	this.materialInitialSpectrum.uniforms.u_wind = { value: new THREE.Vector2() };

--- a/examples/js/ShaderSkin.js
+++ b/examples/js/ShaderSkin.js
@@ -16,7 +16,6 @@ THREE.ShaderSkin = {
 	//		- specular map
 	//		- point, directional and hemisphere lights (use with "lights: true" material option)
 	//		- fog (use with "fog: true" material option)
-	//		- shadow maps
 	//
 	// ------------------------------------------------------------------------------------------ */
 

--- a/examples/js/ShaderSkin.js
+++ b/examples/js/ShaderSkin.js
@@ -85,7 +85,6 @@ THREE.ShaderSkin = {
 			THREE.ShaderChunk[ "bsdfs" ],
 			THREE.ShaderChunk[ "packing" ],
 			THREE.ShaderChunk[ "lights_pars_begin" ],
-			THREE.ShaderChunk[ "shadowmap_pars_fragment" ],
 			THREE.ShaderChunk[ "fog_pars_fragment" ],
 			THREE.ShaderChunk[ "bumpmap_pars_fragment" ],
 
@@ -265,7 +264,6 @@ THREE.ShaderSkin = {
 
 			THREE.ShaderChunk[ "common" ],
 			THREE.ShaderChunk[ "lights_pars_begin" ],
-			THREE.ShaderChunk[ "shadowmap_pars_vertex" ],
 			THREE.ShaderChunk[ "fog_pars_vertex" ],
 
 			"void main() {",
@@ -281,7 +279,6 @@ THREE.ShaderSkin = {
 
 				"gl_Position = projectionMatrix * mvPosition;",
 
-				THREE.ShaderChunk[ "shadowmap_vertex" ],
 				THREE.ShaderChunk[ "fog_vertex" ],
 
 			"}"

--- a/examples/js/shaders/OceanShaders.js
+++ b/examples/js/shaders/OceanShaders.js
@@ -88,6 +88,11 @@ THREE.ShaderLib[ 'ocean_initial_spectrum' ] = {
 		"u_resolution": { value: 512.0 },
 		"u_size": { value: 250.0 }
 	},
+	vertexShader: [
+		'void main (void) {',
+			'gl_Position = vec4(position, 1.0);',
+		'}'
+	].join( '\n' ),
 	fragmentShader: [
 		'precision highp float;',
 		'#include <common>',

--- a/examples/webgl_loader_ctm_materials.html
+++ b/examples/webgl_loader_ctm_materials.html
@@ -231,7 +231,6 @@
 						mm.specularMap = m.map;
 						mm.shininess = 30;
 						mm.color.setHex( 0x404040 );
-						mm.metal = true;
 
 						materials[ i ] = mm;
 

--- a/examples/webgl_materials_bumpmap_skin.html
+++ b/examples/webgl_materials_bumpmap_skin.html
@@ -64,15 +64,9 @@
 
 			}
 
-			var statsEnabled = true;
-
-			var container, stats, loader;
-
-			var camera, scene, renderer;
+			var camera, scene, renderer, stats;
 
 			var mesh;
-
-			var directionalLight;
 
 			var mouseX = 0;
 			var mouseY = 0;
@@ -91,7 +85,7 @@
 
 			function init() {
 
-				container = document.createElement( 'div' );
+				var container = document.createElement( 'div' );
 				document.body.appendChild( container );
 
 				//
@@ -106,29 +100,14 @@
 
 				scene.add( new THREE.AmbientLight( 0x333344 ) );
 
-				directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
+				var directionalLight = new THREE.DirectionalLight( 0xffffff, 1 );
 				directionalLight.position.set( 500, 0, 500 );
-
-				directionalLight.castShadow = true;
-
-				directionalLight.shadow.mapSize.width = 2048;
-				directionalLight.shadow.mapSize.height = 2048;
-
-				directionalLight.shadow.camera.near = 200;
-				directionalLight.shadow.camera.far = 1500;
-
-				directionalLight.shadow.camera.left = - 500;
-				directionalLight.shadow.camera.right = 500;
-				directionalLight.shadow.camera.top = 500;
-				directionalLight.shadow.camera.bottom = - 500;
-
-				directionalLight.shadow.bias = - 0.005;
 
 				scene.add( directionalLight );
 
 				//
 
-				loader = new THREE.GLTFLoader();
+				var loader = new THREE.GLTFLoader();
 				loader.load( "models/gltf/LeePerrySmith/LeePerrySmith.glb", function ( gltf ) {
 
 					createScene( gltf.scene.children[ 0 ].geometry, 100 );
@@ -141,29 +120,14 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
-
-				renderer.shadowMap.enabled = true;
-
 				renderer.autoClear = false;
-
-				//
-
-				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 
 				//
 
-				if ( statsEnabled ) {
+				stats = new Stats();
+				container.appendChild( stats.dom );
 
-					stats = new Stats();
-					container.appendChild( stats.dom );
-
-				}
-
-
-				// COMPOSER
-
-				renderer.autoClear = false;
 
 				// BECKMANN
 
@@ -240,9 +204,6 @@
 				mesh.position.y = - 50;
 				mesh.scale.set( scale, scale, scale );
 
-				mesh.castShadow = true;
-				mesh.receiveShadow = true;
-
 				scene.add( mesh );
 
 			}
@@ -272,7 +233,8 @@
 				requestAnimationFrame( animate );
 
 				render();
-				if ( statsEnabled ) stats.update();
+
+				stats.update();
 
 			}
 

--- a/examples/webgl_panorama_dualfisheye.html
+++ b/examples/webgl_panorama_dualfisheye.html
@@ -99,6 +99,7 @@
 				//
 
 				var texture = new THREE.TextureLoader().load( 'textures/ricoh_theta_s.jpg' );
+				texture.minFilter = THREE.LinearFilter;
 				texture.format = THREE.RGBFormat;
 
 				var material = new THREE.MeshBasicMaterial( { map: texture } );

--- a/examples/webgl_postprocessing_masking.html
+++ b/examples/webgl_postprocessing_masking.html
@@ -74,6 +74,7 @@
 				var maskPass2 = new THREE.MaskPass( scene2, camera );
 
 				var texture1 = new THREE.TextureLoader().load( 'textures/758px-Canestra_di_frutta_(Caravaggio).jpg' );
+				texture1.minFilter = THREE.LinearFilter;
 				var texture2 = new THREE.TextureLoader().load( 'textures/2294472375_24a3b8ef46_o.jpg' );
 
 				var texturePass1 = new THREE.TexturePass( texture1 );


### PR DESCRIPTION
see #15468

Fixed warnings in `webgl_loader_ctm_materials`, `webgl_panorama_dualfisheye`, `webgl_postprocessing_masking`, `webgl_shaders_ocean2` and `webgl_materials_bumpmap_skin`.