### PR TITLE
Converted WebGL.js, Cloth.js and TeapotBufferGeometry.js to ES6 modules.

### DIFF
--- a/examples/jsm/Cloth.js
+++ b/examples/jsm/Cloth.js
@@ -1,3 +1,5 @@
+import {Vector3} from "../../build/three.module.js";
+
 /*
  * Cloth Simulation using a relaxed constraints solver
  */
@@ -23,7 +25,7 @@ var clothFunction = plane( restDistance * xSegs, restDistance * ySegs );
 var cloth = new Cloth( xSegs, ySegs );
 
 var GRAVITY = 981 * 1.4;
-var gravity = new THREE.Vector3( 0, - GRAVITY, 0 ).multiplyScalar( MASS );
+var gravity = new Vector3( 0, - GRAVITY, 0 ).multiplyScalar( MASS );
 
 
 var TIMESTEP = 18 / 1000;
@@ -34,12 +36,12 @@ var pins = [];
 
 var wind = true;
 var windStrength = 2;
-var windForce = new THREE.Vector3( 0, 0, 0 );
+var windForce = new Vector3( 0, 0, 0 );
 
-var ballPosition = new THREE.Vector3( 0, - 45, 0 );
+var ballPosition = new Vector3( 0, - 45, 0 );
 var ballSize = 60; //40
 
-var tmpForce = new THREE.Vector3();
+var tmpForce = new Vector3();
 
 var lastTime;
 
@@ -60,14 +62,14 @@ function plane( width, height ) {
 
 function Particle( x, y, z, mass ) {
 
-	this.position = new THREE.Vector3();
-	this.previous = new THREE.Vector3();
-	this.original = new THREE.Vector3();
-	this.a = new THREE.Vector3( 0, 0, 0 ); // acceleration
+	this.position = new Vector3();
+	this.previous = new Vector3();
+	this.original = new Vector3();
+	this.a = new Vector3( 0, 0, 0 ); // acceleration
 	this.mass = mass;
 	this.invMass = 1 / mass;
-	this.tmp = new THREE.Vector3();
-	this.tmp2 = new THREE.Vector3();
+	this.tmp = new Vector3();
+	this.tmp2 = new Vector3();
 
 	// init
 
@@ -105,7 +107,7 @@ Particle.prototype.integrate = function ( timesq ) {
 };
 
 
-var diff = new THREE.Vector3();
+var diff = new Vector3();
 
 function satisfyConstraints( p1, p2, distance ) {
 
@@ -228,7 +230,7 @@ function Cloth( w, h ) {
 
 }
 
-function simulate( time ) {
+function simulate( clothGeometry, sphere, time ) {
 
 	if ( ! lastTime ) {
 
@@ -237,14 +239,14 @@ function simulate( time ) {
 
 	}
 
-	var i, il, particles, particle, pt, constraints, constraint;
+	var i, j, il, particles, particle, pt, constraints, constraint;
 
 	// Aerodynamics forces
 
 	if ( wind ) {
 
 		var indx;
-		var normal = new THREE.Vector3();
+		var normal = new Vector3();
 		var indices = clothGeometry.index;
 		var normals = clothGeometry.attributes.normal;
 
@@ -338,3 +340,5 @@ function simulate( time ) {
 
 
 }
+
+export {cloth, clothFunction, ballSize, windForce, simulate, ballPosition, pins}

--- a/examples/jsm/WebGL.js
+++ b/examples/jsm/WebGL.js
@@ -92,3 +92,5 @@ var WEBGL = {
 	}
 
 };
+
+export {WEBGL};

--- a/examples/jsm/geometries/TeapotBufferGeometry.js
+++ b/examples/jsm/geometries/TeapotBufferGeometry.js
@@ -1,9 +1,12 @@
+import {Vector3, Vector4, Matrix4, BufferGeometry, BufferAttribute} from "../../../build/three.module.js";
+
+
 /**
  * @author Eric Haines / http://erichaines.com/
  *
  * Tessellates the famous Utah teapot database by Martin Newell into triangles.
  *
- * THREE.TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLid, blinn )
+ * TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLid, blinn )
  *
  * defaults: size = 50, segments = 10, bottom = true, lid = true, body = true,
  *   fitLid = false, blinn = true
@@ -52,7 +55,7 @@
  */
 /*global THREE */
 
-THREE.TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLid, blinn ) {
+var TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLid, blinn ) {
 
 	// 32 * 4 * 4 Bezier spline patches
 	var teapotPatches = [
@@ -389,7 +392,7 @@ THREE.TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLi
 		1.5, - 0.84, 0.075
 	];
 
-	THREE.BufferGeometry.call( this );
+	BufferGeometry.call( this );
 
 	size = size || 50;
 
@@ -438,7 +441,7 @@ THREE.TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLi
 	var uvs = new Float32Array( numVertices * 2 );
 
 	// Bezier form
-	var ms = new THREE.Matrix4();
+	var ms = new Matrix4();
 	ms.set(
 		- 1.0, 3.0, - 3.0, 1.0,
 		3.0, - 6.0, 3.0, 0.0,
@@ -461,7 +464,7 @@ THREE.TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLi
 	var sdir = [];
 	var tdir = [];
 
-	var norm = new THREE.Vector3();
+	var norm = new Vector3();
 
 	var tcoord;
 
@@ -472,19 +475,19 @@ THREE.TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLi
 	var dsval = 0;
 	var dtval = 0;
 
-	var normOut = new THREE.Vector3();
+	var normOut = new Vector3();
 	var v1, v2, v3, v4;
 
-	var gmx = new THREE.Matrix4();
-	var tmtx = new THREE.Matrix4();
+	var gmx = new Matrix4();
+	var tmtx = new Matrix4();
 
-	var vsp = new THREE.Vector4();
-	var vtp = new THREE.Vector4();
-	var vdsp = new THREE.Vector4();
-	var vdtp = new THREE.Vector4();
+	var vsp = new Vector4();
+	var vtp = new Vector4();
+	var vdsp = new Vector4();
+	var vdtp = new Vector4();
 
-	var vsdir = new THREE.Vector3();
-	var vtdir = new THREE.Vector3();
+	var vsdir = new Vector3();
+	var vtdir = new Vector3();
 
 	var mst = ms.clone();
 	mst.transpose();
@@ -509,7 +512,7 @@ THREE.TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLi
 
 	for ( i = 0; i < 3; i ++ ) {
 
-		mgm[ i ] = new THREE.Matrix4();
+		mgm[ i ] = new Matrix4();
 
 	}
 
@@ -704,15 +707,17 @@ THREE.TeapotBufferGeometry = function ( size, segments, bottom, lid, body, fitLi
 
 	}
 
-	this.setIndex( new THREE.BufferAttribute( indices, 1 ) );
-	this.addAttribute( 'position', new THREE.BufferAttribute( vertices, 3 ) );
-	this.addAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
-	this.addAttribute( 'uv', new THREE.BufferAttribute( uvs, 2 ) );
+	this.setIndex( new BufferAttribute( indices, 1 ) );
+	this.addAttribute( 'position', new BufferAttribute( vertices, 3 ) );
+	this.addAttribute( 'normal', new BufferAttribute( normals, 3 ) );
+	this.addAttribute( 'uv', new BufferAttribute( uvs, 2 ) );
 
 	this.computeBoundingSphere();
 
 };
 
 
-THREE.TeapotBufferGeometry.prototype = Object.create( THREE.BufferGeometry.prototype );
-THREE.TeapotBufferGeometry.prototype.constructor = THREE.TeapotBufferGeometry;
+TeapotBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
+TeapotBufferGeometry.prototype.constructor = TeapotBufferGeometry;
+
+export {TeapotBufferGeometry};

--- a/examples/misc_animation_groups.html
+++ b/examples/misc_animation_groups.html
@@ -35,10 +35,11 @@
 		</div>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/misc_animation_groups.html
+++ b/examples/misc_animation_groups.html
@@ -34,11 +34,11 @@
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - animation - groups
 		</div>
 
-		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/misc_animation_keys.html
+++ b/examples/misc_animation_keys.html
@@ -34,11 +34,11 @@
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - animation - basic use
 		</div>
 
-		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/misc_animation_keys.html
+++ b/examples/misc_animation_keys.html
@@ -35,10 +35,11 @@
 		</div>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -49,7 +49,6 @@
 		<script src="js/postprocessing/RenderPass.js"></script>
 		<script src="js/postprocessing/FilmPass.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 	</head>
@@ -60,7 +59,9 @@
 		<b>WASD</b> move, <b>R|F</b> up | down, <b>Q|E</b> roll, <b>up|down</b> pitch, <b>left|right</b> yaw<br/>
 		</div>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/misc_controls_map.html
+++ b/examples/misc_controls_map.html
@@ -38,11 +38,12 @@
 
 		<script src="../build/three.js"></script>
 		<script src="js/controls/MapControls.js"></script>
-		<script src="js/WebGL.js"></script>
 
 		<script src='js/libs/dat.gui.min.js'></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -38,9 +38,10 @@
 
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/misc_controls_trackball.html
+++ b/examples/misc_controls_trackball.html
@@ -10,7 +10,7 @@
 				height: 100%;
 				overflow: hidden;
 			}
-			
+
 			body {
 				color: #000;
 				font-family:Monospace;
@@ -46,10 +46,11 @@
 
 		<script src="js/controls/TrackballControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 
@@ -154,9 +155,9 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				
+
 				controls.update();
-				
+
 				stats.update();
 
 			}

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -40,11 +40,12 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/loaders/OBJLoader.js"></script>
 		<script src="js/exporters/GLTFExporter.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			function exportGLTF( input ) {
 

--- a/examples/misc_exporter_stl.html
+++ b/examples/misc_exporter_stl.html
@@ -35,10 +35,11 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/exporters/STLExporter.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/misc_fps.html
+++ b/examples/misc_fps.html
@@ -31,9 +31,16 @@
 
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - platformer demo. cubemap by <a href="http://www.zfight.com/" target="_blank" rel="noopener">Jochum Skoglund</a>.<br />Use arrow keys to look around, WASD to move and SPACE to jump.</div>
 
-		<script src="../build/three.js"></script>
+		<script type="module">
 
-		<script>
+			import * as THREE from "../build/three.module.js";
+			import {WEBGL} from "./jsm/WebGL.js";
+
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+			}
 
 			// player motion parameters
 

--- a/examples/misc_lookat.html
+++ b/examples/misc_lookat.html
@@ -31,11 +31,11 @@
 	<body>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - Object3D::lookAt() demo</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer, stats;
 

--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -67,7 +67,6 @@
 		</style>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
@@ -91,7 +90,9 @@
 		music by <a href="http://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener noreferrer">skullbeatz</a>
 	</div>
 
-	<script>
+	<script type="module">
+
+	import {WEBGL} from "./jsm/WebGL.js";
 
 	if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -83,10 +83,11 @@
 		<script src="../build/three.js"></script>
 
 		<script src="js/controls/FirstPersonControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webaudio_timing.html
+++ b/examples/webaudio_timing.html
@@ -67,7 +67,6 @@
 		</style>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
 	</head>
@@ -85,7 +84,9 @@
 		sound effect by <a href="https://freesound.org/people/michorvath/sounds/269718/" target="_blank" rel="noopener noreferrer">michorvath</a>
 	</div>
 
-	<script>
+	<script type="module">
+
+	import {WEBGL} from "./jsm/WebGL.js";
 
 	if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webaudio_visualizer.html
+++ b/examples/webaudio_visualizer.html
@@ -67,7 +67,6 @@
 		</style>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 
 		<script id="vertexShader" type="x-shader/x-vertex">
 
@@ -117,7 +116,9 @@
 			music by <a href="http://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener">skullbeatz</a>
 		</div>
 
-	<script>
+	<script type="module">
+
+	import {WEBGL} from "./jsm/WebGL.js";
 
 	if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webaudio_visualizer.html
+++ b/examples/webaudio_visualizer.html
@@ -66,8 +66,6 @@
 
 		</style>
 
-		<script src="../build/three.js"></script>
-
 		<script id="vertexShader" type="x-shader/x-vertex">
 
 			varying vec2 vUv;
@@ -118,6 +116,7 @@
 
 	<script type="module">
 
+	import * as THREE from "../build/three.module.js";
 	import {WEBGL} from "./jsm/WebGL.js";
 
 	if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl2_materials_texture3d.html
+++ b/examples/webgl2_materials_texture3d.html
@@ -83,9 +83,10 @@
 
 		<script src="js/libs/jszip.min.js"></script>
 		<script src="js/libs/stats.min.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGL2Available() === false ) {
 

--- a/examples/webgl2_materials_texture3d.html
+++ b/examples/webgl2_materials_texture3d.html
@@ -78,14 +78,12 @@
 			<a href="https://www.codeproject.com/info/cpol10.aspx" target="_blank" rel="noopener">CPOL</a>
 		</div>
 
-		<script src="../build/three.js"></script>
-		<!--<script src="js/controls/OrbitControls.js"></script>-->
-
 		<script src="js/libs/jszip.min.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGL2Available() === false ) {

--- a/examples/webgl2_materials_texture3d_volume.html
+++ b/examples/webgl2_materials_texture3d_volume.html
@@ -54,11 +54,12 @@
 	<script src="js/loaders/NRRDLoader.js"></script>
 	<script src="js/shaders/VolumeShader.js"></script>
 
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/gunzip.min.js"></script>
 	<script src="js/libs/dat.gui.min.js"></script>
 
-	<script>
+	<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGL2Available() === false ) {
 

--- a/examples/webgl_animation_cloth.html
+++ b/examples/webgl_animation_cloth.html
@@ -38,34 +38,41 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script src="js/Cloth.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
+			import {cloth, clothFunction, ballSize, windForce, simulate, ballPosition, pins} from "./jsm/Cloth.js";
+
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+			}
 
 			/* testing cloth simulation */
 
 			var pinsFormation = [];
-			var pins = [ 6 ];
+			var _pins = [ 6 ];
 
 			pinsFormation.push( pins );
 
-			pins = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
-			pinsFormation.push( pins );
+			_pins = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+			pinsFormation.push( _pins );
 
-			pins = [ 0 ];
-			pinsFormation.push( pins );
+			_pins = [ 0 ];
+			pinsFormation.push( _pins );
 
-			pins = []; // cut the rope ;)
-			pinsFormation.push( pins );
+			_pins = []; // cut the rope ;)
+			pinsFormation.push( _pins );
 
-			pins = [ 0, cloth.w ]; // classic 2 pins
-			pinsFormation.push( pins );
+			_pins = [ 0, cloth.w ]; // classic 2 pins
+			pinsFormation.push( _pins );
 
-			pins = pinsFormation[ 1 ];
+			pins.length = 0;
+			pins.push( ...pinsFormation[ 1 ] );
 
 
 			function togglePins() {
@@ -74,16 +81,10 @@
 
 			}
 
-			if ( WEBGL.isWebGLAvailable() === false ) {
-
-				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
-
-			}
-
 			var container, stats;
 			var camera, scene, renderer;
-
 			var clothGeometry;
+
 			var sphere;
 			var object;
 
@@ -284,7 +285,7 @@
 				windForce.normalize()
 				windForce.multiplyScalar( windStrength );
 
-				simulate( time );
+				simulate( clothGeometry, sphere, time );
 				render();
 				stats.update();
 

--- a/examples/webgl_animation_keyframes.html
+++ b/examples/webgl_animation_keyframes.html
@@ -44,13 +44,14 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/DRACOLoader.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			var scene, camera, pointLight, stats;
 			var renderer, mixer, controls;

--- a/examples/webgl_animation_skinning_blending.html
+++ b/examples/webgl_animation_skinning_blending.html
@@ -47,12 +47,13 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -53,11 +53,12 @@
 
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry.html
+++ b/examples/webgl_buffergeometry.html
@@ -35,10 +35,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry.html
+++ b/examples/webgl_buffergeometry.html
@@ -33,12 +33,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - buffergeometry</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_constructed_from_geometry.html
+++ b/examples/webgl_buffergeometry_constructed_from_geometry.html
@@ -27,12 +27,13 @@
 		<script src="../build/three.js"></script>
 		<script src="js/controls/TrackballControls.js"></script>
 		<script src="js/libs/stats.min.js"></script>
-		<script src="js/WebGL.js"></script>
 	</head>
 	<body>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - buffer geometry constructed from geometry - by <a target="_blank" href="http://callum.com">Callum Prentice</a></div>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_custom_attributes_particles.html
+++ b/examples/webgl_buffergeometry_custom_attributes_particles.html
@@ -31,8 +31,6 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - buffergeometry custom attributes - particles</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -74,6 +72,7 @@
 
 		<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_custom_attributes_particles.html
+++ b/examples/webgl_buffergeometry_custom_attributes_particles.html
@@ -33,7 +33,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -73,7 +72,9 @@
 		</script>
 
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_indexed.html
+++ b/examples/webgl_buffergeometry_indexed.html
@@ -33,13 +33,12 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - buffergeometry - indexed</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 		<script src="./js/libs/dat.gui.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_indexed.html
+++ b/examples/webgl_buffergeometry_indexed.html
@@ -35,11 +35,12 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="./js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_instancing.html
+++ b/examples/webgl_buffergeometry_instancing.html
@@ -49,7 +49,6 @@
 	</div>
 
 	<script src="js/libs/dat.gui.min.js"></script>
-	<script src="../build/three.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 
 	<script id="vertexShader" type="x-shader/x-vertex">
@@ -106,6 +105,7 @@
 
 	<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_instancing.html
+++ b/examples/webgl_buffergeometry_instancing.html
@@ -51,7 +51,6 @@
 	<script src="js/libs/dat.gui.min.js"></script>
 	<script src="../build/three.js"></script>
 	<script src="js/libs/stats.min.js"></script>
-	<script src="js/WebGL.js"></script>
 
 	<script id="vertexShader" type="x-shader/x-vertex">
 		precision highp float;
@@ -105,7 +104,9 @@
 
 	</script>
 
-	<script>
+	<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_instancing2.html
+++ b/examples/webgl_buffergeometry_instancing2.html
@@ -45,7 +45,6 @@
 	</div>
 
 	<script src="../build/three.js"></script>
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 
 	<script src="js/controls/TrackballControls.js"></script>
@@ -92,7 +91,9 @@
 
 	</script>
 
-	<script>
+	<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_instancing_billboards.html
+++ b/examples/webgl_buffergeometry_instancing_billboards.html
@@ -48,7 +48,6 @@
 	</div>
 
 	<script src="../build/three.js"></script>
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 
 	<script id="vshader" type="x-shader/x-vertex">
@@ -108,7 +107,10 @@
 		}
 	</script>
 
-	<script>
+	<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
+
 		var container, stats;
 
 		var camera, scene, renderer;

--- a/examples/webgl_buffergeometry_instancing_billboards.html
+++ b/examples/webgl_buffergeometry_instancing_billboards.html
@@ -47,7 +47,6 @@
 		<div id="notSupported" style="display:none">Sorry your graphics card + browser does not support hardware instancing</div>
 	</div>
 
-	<script src="../build/three.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 
 	<script id="vshader" type="x-shader/x-vertex">
@@ -109,6 +108,7 @@
 
 	<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		var container, stats;

--- a/examples/webgl_buffergeometry_instancing_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_dynamic.html
@@ -50,7 +50,6 @@
 
 	<script src="../build/three.js"></script>
 
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 
 	<script id="vertexShader" type="x-shader/x-vertex">
@@ -99,7 +98,9 @@
 		}
 	</script>
 
-	<script>
+	<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_instancing_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_dynamic.html
@@ -48,8 +48,6 @@
 		<div id="notSupported" style="display:none">Sorry your graphics card + browser does not support hardware instancing</div>
 	</div>
 
-	<script src="../build/three.js"></script>
-
 	<script src="js/libs/stats.min.js"></script>
 
 	<script id="vertexShader" type="x-shader/x-vertex">
@@ -100,6 +98,7 @@
 
 	<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
@@ -50,7 +50,6 @@
 
 	<script src="../build/three.js"></script>
 
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 
 	<script id="vertexShader" type="x-shader/x-vertex">
@@ -101,7 +100,9 @@
 
 	</script>
 
-	<script>
+	<script type="module">
+
+	import {WEBGL} from "./jsm/WebGL.js";
 
 	if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_interleaved_dynamic.html
@@ -48,8 +48,6 @@
 		<div id="notSupported" style="display:none">Sorry your graphics card + browser does not support hardware instancing</div>
 	</div>
 
-	<script src="../build/three.js"></script>
-
 	<script src="js/libs/stats.min.js"></script>
 
 	<script id="vertexShader" type="x-shader/x-vertex">
@@ -102,6 +100,7 @@
 
 	<script type="module">
 
+	import * as THREE from "../build/three.module.js";
 	import {WEBGL} from "./jsm/WebGL.js";
 
 	if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_instancing_lambert.html
+++ b/examples/webgl_buffergeometry_instancing_lambert.html
@@ -45,14 +45,14 @@
 	</div>
 
 	<script src="../build/three.js"></script>
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 
 	<script src="js/controls/OrbitControls.js"></script>
 	<script src="js/CurveExtras.js"></script>
 
+	<script type="module">
 
-	<script>
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_lines.html
+++ b/examples/webgl_buffergeometry_lines.html
@@ -35,10 +35,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_lines.html
+++ b/examples/webgl_buffergeometry_lines.html
@@ -33,12 +33,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - buffergeometry - lines</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_lines_indexed.html
+++ b/examples/webgl_buffergeometry_lines_indexed.html
@@ -33,12 +33,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - buffergeometry - lines - indexed</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_lines_indexed.html
+++ b/examples/webgl_buffergeometry_lines_indexed.html
@@ -35,10 +35,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_morphtargets.html
+++ b/examples/webgl_buffergeometry_morphtargets.html
@@ -32,10 +32,11 @@
 		<script src="../build/three.js"></script>
 
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			var container, camera, scene, renderer, mesh;
 

--- a/examples/webgl_buffergeometry_points.html
+++ b/examples/webgl_buffergeometry_points.html
@@ -34,10 +34,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_points.html
+++ b/examples/webgl_buffergeometry_points.html
@@ -32,12 +32,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - buffergeometry - particles</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_points_interleaved.html
+++ b/examples/webgl_buffergeometry_points_interleaved.html
@@ -34,10 +34,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_points_interleaved.html
+++ b/examples/webgl_buffergeometry_points_interleaved.html
@@ -32,12 +32,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - buffergeometry - particles</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_rawshader.html
+++ b/examples/webgl_buffergeometry_rawshader.html
@@ -35,8 +35,6 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - raw shader demo</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="vertexShader" type="x-shader/x-vertex">
@@ -87,6 +85,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_rawshader.html
+++ b/examples/webgl_buffergeometry_rawshader.html
@@ -37,7 +37,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="vertexShader" type="x-shader/x-vertex">
@@ -86,7 +85,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_selective_draw.html
+++ b/examples/webgl_buffergeometry_selective_draw.html
@@ -26,7 +26,6 @@
 		color: #0080ff;
 	}
 	</style>
-	<script src="../build/three.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 
 	<script type="x-shader/x-vertex" id="vertexshader">
@@ -71,6 +70,7 @@
 
 		<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_buffergeometry_selective_draw.html
+++ b/examples/webgl_buffergeometry_selective_draw.html
@@ -28,7 +28,6 @@
 	</style>
 	<script src="../build/three.js"></script>
 	<script src="js/libs/stats.min.js"></script>
-	<script src="js/WebGL.js"></script>
 
 	<script type="x-shader/x-vertex" id="vertexshader">
 		attribute float visible;
@@ -70,7 +69,9 @@
 			<div id="ui"><a href="#" onclick="hideLines();">CULL SOME LINES</a> - <a href="#" onclick="showAllLines();">SHOW ALL LINES</a></div>
 		</div>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_uint.html
+++ b/examples/webgl_buffergeometry_uint.html
@@ -35,10 +35,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_buffergeometry_uint.html
+++ b/examples/webgl_buffergeometry_uint.html
@@ -33,12 +33,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - buffergeometry - uint</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_camera.html
+++ b/examples/webgl_camera.html
@@ -32,10 +32,11 @@
 		<b>O</b> orthographic <b>P</b> perspective
 		</div>
 
-		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var SCREEN_WIDTH = window.innerWidth;
 			var SCREEN_HEIGHT = window.innerHeight;

--- a/examples/webgl_camera_array.html
+++ b/examples/webgl_camera_array.html
@@ -14,9 +14,9 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
+		<script type="module">
 
-		<script>
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer;
 			var mesh;

--- a/examples/webgl_camera_logarithmicdepthbuffer.html
+++ b/examples/webgl_camera_logarithmicdepthbuffer.html
@@ -82,10 +82,11 @@
 			Logarithmic handles all but the smallest objects with ease
 		</div>
 
-		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			// 1 micrometer to 100 billion light years in one scene, with 1 unit = 1 meter?  preposterous!  and yet...
 			var NEAR = 1e-6, FAR = 1e27;

--- a/examples/webgl_custom_attributes.html
+++ b/examples/webgl_custom_attributes.html
@@ -31,8 +31,6 @@
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - custom attributes example</div>
 		<div id="container"></div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -82,6 +80,7 @@
 
 		<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_custom_attributes.html
+++ b/examples/webgl_custom_attributes.html
@@ -33,7 +33,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -81,8 +80,9 @@
 
 		</script>
 
+		<script type="module">
 
-		<script>
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_custom_attributes_lines.html
+++ b/examples/webgl_custom_attributes_lines.html
@@ -31,7 +31,6 @@
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - custom attributes example</div>
 		<div id="container"></div>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src="../build/three.js"></script>
@@ -72,8 +71,9 @@
 
 		</script>
 
+		<script type="module">
 
-		<script>
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_custom_attributes_lines.html
+++ b/examples/webgl_custom_attributes_lines.html
@@ -33,8 +33,6 @@
 
 		<script src="js/libs/stats.min.js"></script>
 
-		<script src="../build/three.js"></script>
-
 		<script type="x-shader/x-vertex" id="vertexshader">
 
 			uniform float amplitude;
@@ -73,6 +71,7 @@
 
 		<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_custom_attributes_points.html
+++ b/examples/webgl_custom_attributes_points.html
@@ -33,7 +33,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -74,8 +73,9 @@
 
 		</script>
 
+		<script type="module">
 
-		<script>
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_custom_attributes_points.html
+++ b/examples/webgl_custom_attributes_points.html
@@ -31,8 +31,6 @@
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - custom attributes example - particles</div>
 		<div id="container"></div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -75,6 +73,7 @@
 
 		<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_custom_attributes_points2.html
+++ b/examples/webgl_custom_attributes_points2.html
@@ -33,7 +33,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -74,7 +73,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_custom_attributes_points2.html
+++ b/examples/webgl_custom_attributes_points2.html
@@ -31,8 +31,6 @@
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - custom attributes example - particles - billboards</div>
 		<div id="container"></div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -75,6 +73,7 @@
 
 		<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_custom_attributes_points3.html
+++ b/examples/webgl_custom_attributes_points3.html
@@ -31,8 +31,6 @@
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - custom attributes example - billboards - alphatest</div>
 		<div id="container"></div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -83,6 +81,7 @@
 
 		<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_custom_attributes_points3.html
+++ b/examples/webgl_custom_attributes_points3.html
@@ -33,7 +33,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -82,8 +81,9 @@
 
 		</script>
 
+		<script type="module">
 
-		<script>
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_effects_anaglyph.html
+++ b/examples/webgl_effects_anaglyph.html
@@ -39,9 +39,9 @@
 
 		<script src="js/effects/AnaglyphEffect.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_effects_ascii.html
+++ b/examples/webgl_effects_ascii.html
@@ -38,9 +38,9 @@
 		<script src="js/controls/TrackballControls.js"></script>
 		<script src="js/effects/AsciiEffect.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_effects_parallaxbarrier.html
+++ b/examples/webgl_effects_parallaxbarrier.html
@@ -39,9 +39,9 @@
 
 		<script src="js/effects/ParallaxBarrierEffect.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_effects_peppersghost.html
+++ b/examples/webgl_effects_peppersghost.html
@@ -43,9 +43,9 @@
 
 <script src="js/effects/PeppersGhostEffect.js"></script>
 
-<script src="js/WebGL.js"></script>
+<script type="module">
 
-<script>
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_effects_stereo.html
+++ b/examples/webgl_effects_stereo.html
@@ -41,9 +41,9 @@
 
 		<script src="js/effects/StereoEffect.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_framebuffer_texture.html
+++ b/examples/webgl_framebuffer_texture.html
@@ -48,7 +48,6 @@
 
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 
 	</head>
 	<body>
@@ -63,7 +62,9 @@
 			</div>
 		</div>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometries.html
+++ b/examples/webgl_geometries.html
@@ -32,12 +32,11 @@
 
 		<div id="info"><a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - geometries</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_geometries.html
+++ b/examples/webgl_geometries.html
@@ -34,10 +34,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometries_parametric.html
+++ b/examples/webgl_geometries_parametric.html
@@ -35,13 +35,14 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src="js/CurveExtras.js"></script>
 		<script src="js/ParametricGeometries.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_colors.html
+++ b/examples/webgl_geometry_colors.html
@@ -36,10 +36,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_colors.html
+++ b/examples/webgl_geometry_colors.html
@@ -34,12 +34,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - vertex colors</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_geometry_colors_lookuptable.html
+++ b/examples/webgl_geometry_colors_lookuptable.html
@@ -41,10 +41,11 @@
 
 		<script src="../build/three.js"></script>
 		<script src="js/math/Lut.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_convex.html
+++ b/examples/webgl_geometry_convex.html
@@ -32,10 +32,11 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/QuickHull.js"></script>
 		<script src="js/geometries/ConvexGeometry.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_cube.html
+++ b/examples/webgl_geometry_cube.html
@@ -14,9 +14,9 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
+		<script type="module">
 
-		<script>
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer;
 			var mesh;

--- a/examples/webgl_geometry_dynamic.html
+++ b/examples/webgl_geometry_dynamic.html
@@ -43,10 +43,11 @@
 
 		<script src="js/controls/FirstPersonControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_hierarchy.html
+++ b/examples/webgl_geometry_hierarchy.html
@@ -16,10 +16,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer, stats, group;
 

--- a/examples/webgl_geometry_hierarchy2.html
+++ b/examples/webgl_geometry_hierarchy2.html
@@ -16,10 +16,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer, stats, root;
 

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -47,10 +47,11 @@
 
 		<script src="js/utils/BufferGeometryUtils.js"></script>
 		<script src="js/ImprovedNoise.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_minecraft_ao.html
+++ b/examples/webgl_geometry_minecraft_ao.html
@@ -47,10 +47,11 @@
 
 		<script src="js/ImprovedNoise.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_shapes.html
+++ b/examples/webgl_geometry_shapes.html
@@ -15,10 +15,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var container, stats;
 

--- a/examples/webgl_geometry_teapot.html
+++ b/examples/webgl_geometry_teapot.html
@@ -39,24 +39,24 @@
 
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
-
 		<script src='js/libs/dat.gui.min.js'></script>
 
-		<script src='js/geometries/TeapotBufferGeometry.js'></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
+			import {TeapotBufferGeometry} from "./jsm/geometries/TeapotBufferGeometry.js";
+
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+				document.getElementById( 'container' ).innerHTML = "";
+
+			}
 
 			////////////////////////////////////////////////////////////////////////////////
 			// Utah/Newell Teapot demo
 			////////////////////////////////////////////////////////////////////////////////
 			/*global THREE, WEBGL, dat, window */
-
-			if ( WEBGL.isWebGLAvailable() === false ) {
-
-				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
-
-			}
 
 			var camera, scene, renderer;
 			var cameraControls;
@@ -342,7 +342,7 @@
 
 				}
 
-				var teapotGeometry = new THREE.TeapotBufferGeometry( teapotSize,
+				var teapotGeometry = new TeapotBufferGeometry( teapotSize,
 					tess,
 					effectController.bottom,
 					effectController.lid,

--- a/examples/webgl_geometry_terrain.html
+++ b/examples/webgl_geometry_terrain.html
@@ -39,10 +39,11 @@
 		<script src="js/controls/FirstPersonControls.js"></script>
 
 		<script src="js/ImprovedNoise.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_terrain_fog.html
+++ b/examples/webgl_geometry_terrain_fog.html
@@ -38,9 +38,10 @@
 		<script src="js/controls/FirstPersonControls.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/ImprovedNoise.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_terrain_raycast.html
+++ b/examples/webgl_geometry_terrain_raycast.html
@@ -38,10 +38,11 @@
 		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/ImprovedNoise.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_geometry_text.html
+++ b/examples/webgl_geometry_text.html
@@ -39,10 +39,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/utils/GeometryUtils.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_gpgpu_birds.html
+++ b/examples/webgl_gpgpu_birds.html
@@ -39,7 +39,6 @@
 		</div>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
@@ -320,7 +319,9 @@
 		</script>
 
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -42,7 +42,6 @@
 		</div>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
@@ -265,7 +264,9 @@
 		</script>
 
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -38,7 +38,6 @@
 		</div>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
@@ -278,7 +277,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_hdr.html
+++ b/examples/webgl_hdr.html
@@ -39,7 +39,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<!-- HDR fragment shader -->
@@ -101,7 +100,9 @@
 		</script>
 
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_hdr.html
+++ b/examples/webgl_hdr.html
@@ -37,8 +37,6 @@
 			based on <a href="http://spidergl.org/example.php?id=13" target="_blank" rel="noopener">SpiderGL</a>
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<!-- HDR fragment shader -->
@@ -102,6 +100,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_interactive_buffergeometry.html
+++ b/examples/webgl_interactive_buffergeometry.html
@@ -36,10 +36,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_interactive_buffergeometry.html
+++ b/examples/webgl_interactive_buffergeometry.html
@@ -34,12 +34,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - interactive - buffergeometry</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_interactive_cubes.html
+++ b/examples/webgl_interactive_cubes.html
@@ -15,11 +15,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var container, stats;
 			var camera, scene, raycaster, renderer;

--- a/examples/webgl_interactive_cubes_ortho.html
+++ b/examples/webgl_interactive_cubes_ortho.html
@@ -15,11 +15,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var container, stats;
 			var camera, scene, raycaster, renderer;

--- a/examples/webgl_interactive_lines.html
+++ b/examples/webgl_interactive_lines.html
@@ -15,11 +15,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var container, stats;
 			var camera, scene, raycaster, renderer, parentTransform, sphereInter;

--- a/examples/webgl_interactive_points.html
+++ b/examples/webgl_interactive_points.html
@@ -33,7 +33,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -77,7 +76,9 @@
 		</script>
 
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_interactive_points.html
+++ b/examples/webgl_interactive_points.html
@@ -31,8 +31,6 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - interactive - particles</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -78,6 +76,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_interactive_raycasting_points.html
+++ b/examples/webgl_interactive_raycasting_points.html
@@ -33,10 +33,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_interactive_raycasting_points.html
+++ b/examples/webgl_interactive_raycasting_points.html
@@ -31,12 +31,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - interactive - raycasting - points </div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -35,10 +35,9 @@
 			<strong>click</strong>: add voxel, <strong>shift + click</strong>: remove voxel
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -37,9 +37,9 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_kinect.html
+++ b/examples/webgl_kinect.html
@@ -35,7 +35,6 @@
 
 		<script src='js/libs/dat.gui.min.js'></script>
 		<script src="js/libs/stats.min.js"></script>
-		<script src="js/WebGL.js"></script>
 
 		<script id="vs" type="x-shader/x-vertex">
 
@@ -92,7 +91,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			var container;
 

--- a/examples/webgl_kinect.html
+++ b/examples/webgl_kinect.html
@@ -31,8 +31,6 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
-
 		<script src='js/libs/dat.gui.min.js'></script>
 		<script src="js/libs/stats.min.js"></script>
 
@@ -93,6 +91,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			var container;

--- a/examples/webgl_layers.html
+++ b/examples/webgl_layers.html
@@ -28,12 +28,12 @@
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl layers
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var container, stats;
 			var camera, scene, renderer;

--- a/examples/webgl_lights_hemisphere.html
+++ b/examples/webgl_lights_hemisphere.html
@@ -47,7 +47,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
@@ -84,7 +83,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lights_physical.html
+++ b/examples/webgl_lights_physical.html
@@ -44,9 +44,10 @@
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lights_pointlights.html
+++ b/examples/webgl_lights_pointlights.html
@@ -36,10 +36,11 @@
 
 		<script src="js/loaders/OBJLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lights_pointlights2.html
+++ b/examples/webgl_lights_pointlights2.html
@@ -42,10 +42,11 @@
 
 		<script src="js/controls/TrackballControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lights_rectarealight.html
+++ b/examples/webgl_lights_rectarealight.html
@@ -44,9 +44,10 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 		<script src="js/libs/stats.min.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -42,9 +42,9 @@
 
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lights_spotlights.html
+++ b/examples/webgl_lights_spotlights.html
@@ -43,9 +43,10 @@
 		<script src="js/libs/dat.gui.min.js"></script>
 		<script src="js/libs/tween.min.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lines_colors.html
+++ b/examples/webgl_lines_colors.html
@@ -44,9 +44,9 @@
 
 		<script src="js/geometries/hilbert3D.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lines_dashed.html
+++ b/examples/webgl_lines_dashed.html
@@ -35,10 +35,11 @@
 
 		<script src="js/geometries/hilbert3D.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -38,8 +38,6 @@
 
 		<script src="js/geometries/hilbert3D.js"></script>
 
-		<script src="js/WebGL.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
@@ -53,7 +51,9 @@
 		<script src='js/lines/Line2.js'></script>
 		<script src='js/lines/Wireframe.js'></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lines_fat_wireframe.html
+++ b/examples/webgl_lines_fat_wireframe.html
@@ -36,8 +36,6 @@
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
@@ -51,7 +49,9 @@
 		<script src='js/lines/Line2.js'></script>
 		<script src='js/lines/Wireframe.js'></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lines_sphere.html
+++ b/examples/webgl_lines_sphere.html
@@ -39,12 +39,11 @@
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - lines WebGL demo
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_lines_sphere.html
+++ b/examples/webgl_lines_sphere.html
@@ -41,10 +41,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_3mf.html
+++ b/examples/webgl_loader_3mf.html
@@ -46,12 +46,13 @@
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/3MFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/libs/jszip.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_amf.html
+++ b/examples/webgl_loader_amf.html
@@ -46,12 +46,13 @@
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/AMFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/libs/jszip.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_assimp.html
+++ b/examples/webgl_loader_assimp.html
@@ -48,12 +48,13 @@
 		</div>
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/AssimpLoader.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_assimp2json.html
+++ b/examples/webgl_loader_assimp2json.html
@@ -38,10 +38,11 @@
 
 		<script src="js/loaders/AssimpJSONLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_awd.html
+++ b/examples/webgl_loader_awd.html
@@ -37,10 +37,11 @@
 		<script src="js/loaders/AWDLoader.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_collada.html
+++ b/examples/webgl_loader_collada.html
@@ -39,10 +39,11 @@
 		<script src="../build/three.js"></script>
 
 		<script src="js/loaders/ColladaLoader.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_collada_kinematics.html
+++ b/examples/webgl_loader_collada_kinematics.html
@@ -39,10 +39,11 @@
 		<script src="js/libs/tween.min.js"></script>
 		<script src="js/loaders/ColladaLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_collada_skinning.html
+++ b/examples/webgl_loader_collada_skinning.html
@@ -39,10 +39,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/ColladaLoader.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_ctm.html
+++ b/examples/webgl_loader_ctm.html
@@ -43,7 +43,6 @@
 		<script src="js/loaders/ctm/ctm.js"></script>
 		<script src="js/loaders/ctm/CTMLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script>

--- a/examples/webgl_loader_ctm_materials.html
+++ b/examples/webgl_loader_ctm_materials.html
@@ -47,10 +47,11 @@
 		<script src="js/loaders/ctm/ctm.js"></script>
 		<script src="js/loaders/ctm/CTMLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -41,10 +41,11 @@
 
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_fbx_nurbs.html
+++ b/examples/webgl_loader_fbx_nurbs.html
@@ -41,10 +41,11 @@
 		<script src="js/curves/NURBSUtils.js"></script>
 		<script src="js/loaders/FBXLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -40,10 +40,11 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_imagebitmap.html
+++ b/examples/webgl_loader_imagebitmap.html
@@ -30,12 +30,13 @@
 	</head>
 	<body>
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<div id="info">
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - Texture loader using ImageBitmap
 		</div>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_json_claraio.html
+++ b/examples/webgl_loader_json_claraio.html
@@ -33,10 +33,17 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
+
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+			}
 
 			var container, stats;
 

--- a/examples/webgl_loader_kmz.html
+++ b/examples/webgl_loader_kmz.html
@@ -43,12 +43,13 @@
 		<script src="js/loaders/KMZLoader.js"></script>
 		<script src="js/loaders/ColladaLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/libs/jszip.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_md2.html
+++ b/examples/webgl_loader_md2.html
@@ -44,9 +44,10 @@
 
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -46,9 +46,10 @@
 		<script src="js/Gyroscope.js"></script>
 
 		<script src="js/libs/stats.min.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -36,7 +36,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src='js/geometries/TeapotBufferGeometry.js'></script>
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
@@ -44,6 +43,7 @@
 
 			import './js/nodes/THREE.Nodes.js';
 			import './js/loaders/NodeMaterialLoader.js';
+			import {TeapotBufferGeometry} from "./jsm/geometries/TeapotBufferGeometry.js";
 
 			var container = document.getElementById( 'container' );
 
@@ -89,7 +89,7 @@
 				light.position.set( - 1, 0.75, - 0.5 );
 				scene.add( light );
 
-				teapot = new THREE.TeapotBufferGeometry( 15, 18 );
+				teapot = new TeapotBufferGeometry( 15, 18 );
 
 				mesh = new THREE.Mesh( teapot );
 				scene.add( mesh );

--- a/examples/webgl_loader_nrrd.html
+++ b/examples/webgl_loader_nrrd.html
@@ -56,12 +56,13 @@
 		<script src="js/loaders/NRRDLoader.js"></script>
 		<script src="js/loaders/VTKLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/gunzip.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_pcd.html
+++ b/examples/webgl_loader_pcd.html
@@ -48,10 +48,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/PCDLoader.js"></script>
 		<script src="js/controls/TrackballControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_playcanvas.html
+++ b/examples/webgl_loader_playcanvas.html
@@ -40,10 +40,11 @@
 
 		<script src="js/loaders/PlayCanvasLoader.js"></script>
 		<script src='js/controls/OrbitControls.js'></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_ply.html
+++ b/examples/webgl_loader_ply.html
@@ -45,10 +45,11 @@
 
 		<script src="js/loaders/PLYLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_sea3d.html
+++ b/examples/webgl_loader_sea3d.html
@@ -52,10 +52,11 @@
 		<script src="js/libs/draco/draco_decoder.js"></script>
 		<script src="js/loaders/sea3d/SEA3DDraco.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_sea3d_bvh.html
+++ b/examples/webgl_loader_sea3d_bvh.html
@@ -51,11 +51,12 @@
 
 		<script src="js/loaders/BVHLoader.js"></script>
 		<script src="js/utils/SkeletonUtils.js"></script>
-		
-		<script src="js/WebGL.js"></script>
+
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_sea3d_bvh_retarget.html
+++ b/examples/webgl_loader_sea3d_bvh_retarget.html
@@ -51,11 +51,12 @@
 
 		<script src="js/loaders/BVHLoader.js"></script>
 		<script src="js/utils/SkeletonUtils.js"></script>
-		
-		<script src="js/WebGL.js"></script>
+
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_sea3d_hierarchy.html
+++ b/examples/webgl_loader_sea3d_hierarchy.html
@@ -52,10 +52,11 @@
 		<script src="js/libs/o3dgc.js"></script>
 		<script src="js/loaders/sea3d/o3dgc/SEA3DGC.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_sea3d_keyframe.html
+++ b/examples/webgl_loader_sea3d_keyframe.html
@@ -49,10 +49,11 @@
 		<script src="js/loaders/sea3d/SEA3DLZMA.js"></script>
 		<script src="js/loaders/sea3d/SEA3DLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_sea3d_morph.html
+++ b/examples/webgl_loader_sea3d_morph.html
@@ -49,10 +49,11 @@
 		<script src="js/loaders/sea3d/SEA3DLZMA.js"></script>
 		<script src="js/loaders/sea3d/SEA3DLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_sea3d_physics.html
+++ b/examples/webgl_loader_sea3d_physics.html
@@ -54,10 +54,11 @@
 		<script src="js/loaders/sea3d/physics/SEA3DAmmo.js"></script>
 		<script src="js/loaders/sea3d/physics/SEA3DAmmoLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_sea3d_skinning.html
+++ b/examples/webgl_loader_sea3d_skinning.html
@@ -51,10 +51,11 @@
 		<script src="js/loaders/sea3d/SEA3DLZMA.js"></script>
 		<script src="js/loaders/sea3d/SEA3DLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_sea3d_sound.html
+++ b/examples/webgl_loader_sea3d_sound.html
@@ -96,10 +96,11 @@
 		<script src="js/loaders/sea3d/SEA3DLZMA.js"></script>
 		<script src="js/loaders/sea3d/SEA3DLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_stl.html
+++ b/examples/webgl_loader_stl.html
@@ -45,10 +45,11 @@
 
 		<script src="js/loaders/STLLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_texture_dds.html
+++ b/examples/webgl_loader_texture_dds.html
@@ -36,9 +36,9 @@
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/DDSLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_texture_exr.html
+++ b/examples/webgl_loader_texture_exr.html
@@ -40,9 +40,9 @@
 
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_texture_hdr.html
+++ b/examples/webgl_loader_texture_hdr.html
@@ -40,9 +40,9 @@
 
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_texture_ktx.html
+++ b/examples/webgl_loader_texture_ktx.html
@@ -36,9 +36,15 @@
 <script src="../build/three.js"></script>
 <script src="js/loaders/KTXLoader.js"></script>
 
-<script src="js/WebGL.js"></script>
+<script type="module">
 
-<script>
+	import {WEBGL} from "./jsm/WebGL.js";
+
+	if ( WEBGL.isWebGLAvailable() === false ) {
+
+		document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+	}
 
 	/*
 	This is how compressed textures are supposed to be used:
@@ -54,12 +60,6 @@
 	ETC1 - opaque textures
 	ASTC_4x4, ASTC8x8 - transparent textures with full alpha range
 	*/
-
-	if ( WEBGL.isWebGLAvailable() === false ) {
-
-		document.body.appendChild( WEBGL.getWebGLErrorMessage() );
-
-	}
 
 	var camera, scene, renderer;
 	var meshes = [];

--- a/examples/webgl_loader_texture_pvrtc.html
+++ b/examples/webgl_loader_texture_pvrtc.html
@@ -35,9 +35,9 @@
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/PVRLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_texture_tga.html
+++ b/examples/webgl_loader_texture_tga.html
@@ -36,10 +36,11 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/TGALoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_ttf.html
+++ b/examples/webgl_loader_ttf.html
@@ -30,7 +30,6 @@
 	</head>
 	<body>
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/loaders/TTFLoader.js"></script>
 		<script src="js/libs/opentype.min.js"></script>
 		<div id="info">
@@ -39,7 +38,9 @@
 		</div>
 
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_vrm.html
+++ b/examples/webgl_loader_vrm.html
@@ -42,10 +42,11 @@
 		<script src="js/loaders/GLTFLoader.js"></script>
 		<script src="js/loaders/VRMLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -43,10 +43,11 @@
 
 		<script src="js/loaders/VRMLLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_vtk.html
+++ b/examples/webgl_loader_vtk.html
@@ -39,10 +39,11 @@
 
 		<script src="js/loaders/VTKLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_loader_x.html
+++ b/examples/webgl_loader_x.html
@@ -68,9 +68,10 @@
 	<script src="js/loaders/XLoader.js"></script>
 	<script src="js/libs/dat.gui.min.js"></script>
 	<script src="js/libs/stats.min.js"></script>
-	<script src="js/WebGL.js"></script>
 
-	<script>
+	<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_lod.html
+++ b/examples/webgl_lod.html
@@ -40,10 +40,11 @@
 
 		<script src="js/controls/FlyControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -73,12 +73,13 @@
 	<script src="js/MarchingCubes.js"></script>
 	<script src="js/ShaderToon.js"></script>
 
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 	<script src="js/libs/dat.gui.min.js"></script>
 
+	<script type="module">
 
-	<script>
+		import {WEBGL} from "./jsm/WebGL.js";
+
 		if ( WEBGL.isWebGLAvailable() === false ) {
 
 			document.body.appendChild( WEBGL.getWebGLErrorMessage() );

--- a/examples/webgl_materials.html
+++ b/examples/webgl_materials.html
@@ -17,10 +17,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials.html
+++ b/examples/webgl_materials.html
@@ -15,12 +15,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_blending.html
+++ b/examples/webgl_materials_blending.html
@@ -14,10 +14,9 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
-
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_blending.html
+++ b/examples/webgl_materials_blending.html
@@ -15,9 +15,10 @@
 	<body>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_blending_custom.html
+++ b/examples/webgl_materials_blending_custom.html
@@ -76,10 +76,9 @@
 			<div class="lbl" id="lbl_dst">Destination</div>
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_blending_custom.html
+++ b/examples/webgl_materials_blending_custom.html
@@ -77,9 +77,10 @@
 		</div>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_bumpmap.html
+++ b/examples/webgl_materials_bumpmap.html
@@ -46,10 +46,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_bumpmap_skin.html
+++ b/examples/webgl_materials_bumpmap_skin.html
@@ -53,10 +53,11 @@
 
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_cars.html
+++ b/examples/webgl_materials_cars.html
@@ -47,10 +47,11 @@
 
 		<script src="js/Car.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -45,11 +45,12 @@
 
 		<script src="js/loaders/OBJLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_compile.html
+++ b/examples/webgl_materials_compile.html
@@ -55,13 +55,13 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src='js/geometries/TeapotBufferGeometry.js'></script>
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script type="module">
 
 		import './js/nodes/THREE.Nodes.js';
+		import {TeapotBufferGeometry} from "./jsm/geometries/TeapotBufferGeometry.js";
 
 		var container = document.getElementById( 'container' );
 
@@ -121,7 +121,7 @@
 			light.position.set( - 1, 0.75, - 0.5 );
 			scene.add( light );
 
-			teapot = new THREE.TeapotBufferGeometry( 15, 18 );
+			teapot = new TeapotBufferGeometry( 15, 18 );
 
 			var itemsonrow = 10;
 

--- a/examples/webgl_materials_cubemap.html
+++ b/examples/webgl_materials_cubemap.html
@@ -40,10 +40,11 @@
 
 		<script src="js/loaders/OBJLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_cubemap_balls_reflection.html
+++ b/examples/webgl_materials_cubemap_balls_reflection.html
@@ -35,9 +35,9 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_cubemap_balls_reflection.html
+++ b/examples/webgl_materials_cubemap_balls_reflection.html
@@ -33,10 +33,9 @@
 	<body>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl cube reflection demo. skybox by <a href="http://ict.debevec.org/~debevec/" target="_blank" rel="noopener">Paul Debevec</a></div>
 
-		<script src="../build/three.js"></script>
-
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_cubemap_balls_refraction.html
+++ b/examples/webgl_materials_cubemap_balls_refraction.html
@@ -35,9 +35,9 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_cubemap_balls_refraction.html
+++ b/examples/webgl_materials_cubemap_balls_refraction.html
@@ -33,10 +33,9 @@
 	<body>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl cube refraction demo. skybox by <a href="http://www.zfight.com/" target="_blank" rel="noopener">Jochum Skoglund</a></div>
 
-		<script src="../build/three.js"></script>
-
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_cubemap_refraction.html
+++ b/examples/webgl_materials_cubemap_refraction.html
@@ -48,10 +48,11 @@
 
 		<script src="js/loaders/PLYLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_curvature.html
+++ b/examples/webgl_materials_curvature.html
@@ -34,7 +34,6 @@
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - curvature estimation of a geometry by <a href="http://codercat.club" target="_blank" rel="noopener">CoderCat</a></div>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/OBJLoader.js"></script>
@@ -68,7 +67,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -45,11 +45,12 @@
 
 		<script src="js/loaders/OBJLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -36,14 +36,15 @@
 		<script src="js/loaders/EXRLoader.js"></script>
 		<script src="js/loaders/EquirectangularToCubeGenerator.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src="js/pmrem/PMREMGenerator.js"></script>
 		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -37,14 +37,15 @@
 		<script src="js/loaders/RGBELoader.js"></script>
 		<script src="js/loaders/HDRCubeTextureLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src="js/pmrem/PMREMGenerator.js"></script>
 		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_grass.html
+++ b/examples/webgl_materials_grass.html
@@ -18,10 +18,10 @@
 	</head>
 
 	<body>
-		<script src="../build/three.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_grass.html
+++ b/examples/webgl_materials_grass.html
@@ -20,9 +20,9 @@
 	<body>
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_lightmap.html
+++ b/examples/webgl_materials_lightmap.html
@@ -22,7 +22,6 @@
 
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexShader">
@@ -58,7 +57,15 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
+
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+			}
 
 			var SCREEN_WIDTH = window.innerWidth;
 			var SCREEN_HEIGHT = window.innerHeight;

--- a/examples/webgl_materials_matcap.html
+++ b/examples/webgl_materials_matcap.html
@@ -43,9 +43,9 @@
 
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_modified.html
+++ b/examples/webgl_materials_modified.html
@@ -45,10 +45,11 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -36,7 +36,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src='js/geometries/TeapotBufferGeometry.js'></script>
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
@@ -44,6 +43,7 @@
 
 			import './js/nodes/THREE.Nodes.js';
 			import './js/loaders/NodeMaterialLoader.js';
+			import {TeapotBufferGeometry} from "./jsm/geometries/TeapotBufferGeometry.js";
 
 			var container = document.getElementById( 'container' );
 
@@ -137,7 +137,7 @@
 				light.position.set( - 1, 0.75, - 0.5 );
 				scene.add( light );
 
-				teapot = new THREE.TeapotBufferGeometry( 15, 18 );
+				teapot = new TeapotBufferGeometry( 15, 18 );
 
 				mesh = new THREE.Mesh( teapot );
 				scene.add( mesh );
@@ -2399,7 +2399,7 @@
 							"vec4 triplanar_mapping( sampler2D texture, vec3 normal, vec3 position, float scale ) {",
 
 							// Blending factor of triplanar mapping
-							"	vec3 bf = normalize( abs( normal ) );", 
+							"	vec3 bf = normalize( abs( normal ) );",
 							"	bf /= dot( bf, vec3( 1.0 ) );",
 
 							// Triplanar mapping

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -52,7 +52,6 @@
 		<script src="../build/three.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src="js/shaders/BleachBypassShader.js"></script>
@@ -65,7 +64,9 @@
 		<script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_normalmap_object_space.html
+++ b/examples/webgl_materials_normalmap_object_space.html
@@ -43,9 +43,9 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_parallaxmap.html
+++ b/examples/webgl_materials_parallaxmap.html
@@ -47,7 +47,6 @@
 		</div>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
@@ -55,7 +54,9 @@
 
 		<script src="js/shaders/ParallaxShader.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_reflectivity.html
+++ b/examples/webgl_materials_reflectivity.html
@@ -35,7 +35,6 @@
 		<script src="js/loaders/RGBELoader.js"></script>
 		<script src="js/loaders/HDRCubeTextureLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src="js/pmrem/PMREMGenerator.js"></script>
@@ -52,7 +51,9 @@
 		<script src="js/shaders/ConvolutionShader.js"></script>
 
 		<script src="js/loaders/OBJLoader.js"></script>
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_shaders_fresnel.html
+++ b/examples/webgl_materials_shaders_fresnel.html
@@ -38,9 +38,9 @@
 
 		<script src="js/shaders/FresnelShader.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_skin.html
+++ b/examples/webgl_materials_skin.html
@@ -57,10 +57,11 @@
 		<script src="js/postprocessing/MaskPass.js"></script>
 
 		<script src="js/loaders/GLTFLoader.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_standard.html
+++ b/examples/webgl_materials_standard.html
@@ -52,10 +52,11 @@
 		<script src="js/pmrem/PMREMGenerator.js"></script>
 		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_texture_anisotropy.html
+++ b/examples/webgl_materials_texture_anisotropy.html
@@ -48,12 +48,11 @@
 		anisotropy: <span class="c" id="val_right"></span><br/>
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_texture_anisotropy.html
+++ b/examples/webgl_materials_texture_anisotropy.html
@@ -50,10 +50,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_texture_canvas.html
+++ b/examples/webgl_materials_texture_canvas.html
@@ -43,10 +43,9 @@
 		</div>
 		<canvas id="drawing-canvas" height="128" width="128"></canvas>
 
-		<script src="../build/three.js"></script>
-
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_texture_canvas.html
+++ b/examples/webgl_materials_texture_canvas.html
@@ -45,9 +45,9 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_texture_filters.html
+++ b/examples/webgl_materials_texture_filters.html
@@ -61,12 +61,11 @@
 		min: <span class="c">Nearest</span>
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_texture_filters.html
+++ b/examples/webgl_materials_texture_filters.html
@@ -63,10 +63,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_texture_manualmipmap.html
+++ b/examples/webgl_materials_texture_manualmipmap.html
@@ -61,12 +61,11 @@
 		min: <span class="c">Nearest</span>
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_texture_manualmipmap.html
+++ b/examples/webgl_materials_texture_manualmipmap.html
@@ -63,10 +63,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_texture_partialupdate.html
+++ b/examples/webgl_materials_texture_partialupdate.html
@@ -28,8 +28,6 @@
 			}
 		</style>
 
-		<script src="../build/three.js"></script>
-
 	</head>
 	<body>
 
@@ -40,6 +38,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_materials_texture_partialupdate.html
+++ b/examples/webgl_materials_texture_partialupdate.html
@@ -29,7 +29,6 @@
 		</style>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 
 	</head>
 	<body>
@@ -39,7 +38,9 @@
 			replace parts of an existing texture with all data of another texture
 		</div>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_texture_rotation.html
+++ b/examples/webgl_materials_texture_rotation.html
@@ -39,9 +39,9 @@
 
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_translucency.html
+++ b/examples/webgl_materials_translucency.html
@@ -33,13 +33,14 @@
 	<script src="../build/three.js"></script>
 	<script src="js/controls/OrbitControls.js"></script>
 
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 	<script src="js/libs/dat.gui.min.js"></script>
 	<script src="js/loaders/FBXLoader.js"></script>
 	<script src="js/ShaderTranslucent.js"></script>
 
-	<script>
+	<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_transparency.html
+++ b/examples/webgl_materials_transparency.html
@@ -33,12 +33,13 @@
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_variations_basic.html
+++ b/examples/webgl_materials_variations_basic.html
@@ -31,10 +31,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_variations_lambert.html
+++ b/examples/webgl_materials_variations_lambert.html
@@ -31,10 +31,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -31,10 +31,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -37,11 +37,12 @@
 		<script src="js/pmrem/PMREMGenerator.js"></script>
 		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -37,10 +37,11 @@
 		<script src="js/pmrem/PMREMGenerator.js"></script>
 		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_variations_toon.html
+++ b/examples/webgl_materials_variations_toon.html
@@ -33,10 +33,11 @@
 
 		<script src="js/effects/OutlineEffect.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -45,14 +45,14 @@
 		<script src="js/postprocessing/BloomPass.js"></script>
 		<script src="js/postprocessing/ShaderPass.js"></script>
 
-		<script src="js/WebGL.js"></script>
-
 		<video id="video" autoplay loop crossOrigin="anonymous" webkit-playsinline style="display:none">
 			<source src="textures/sintel.ogv" type='video/ogg; codecs="theora, vorbis"'>
 			<source src="textures/sintel.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'>
 		</video>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_video_webcam.html
+++ b/examples/webgl_materials_video_webcam.html
@@ -38,11 +38,12 @@
 
 		<script src="../build/three.js"></script>
 		<script src="../examples/js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 
 		<video id="video" autoplay style="display:none"></video>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_materials_wireframe.html
+++ b/examples/webgl_materials_wireframe.html
@@ -14,8 +14,6 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
-
 		<script type="x-shader/x-vertex" id="vertexShader">
 
 			attribute vec3 center;
@@ -50,7 +48,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer;
 

--- a/examples/webgl_math_orientation_transform.html
+++ b/examples/webgl_math_orientation_transform.html
@@ -30,7 +30,6 @@
 		</style>
 
 		<script src="../build/three.js"></script>
-		<script src="js/WebGL.js"></script>
 
 	</head>
 	<body>
@@ -40,7 +39,9 @@
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> - gradually transform an orientation to a target orientation
 		</div>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_math_orientation_transform.html
+++ b/examples/webgl_math_orientation_transform.html
@@ -29,8 +29,6 @@
 			}
 		</style>
 
-		<script src="../build/three.js"></script>
-
 	</head>
 	<body>
 
@@ -41,6 +39,7 @@
 
 		<script type="module">
 
+		import * as THREE from "../build/three.module.js";
 		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_modifier_subdivision.html
+++ b/examples/webgl_modifier_subdivision.html
@@ -19,9 +19,10 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/modifiers/SubdivisionModifier.js"></script>
 		<script src="js/libs/stats.min.js"></script>
-		<script src="js/WebGL.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_modifier_tessellation.html
+++ b/examples/webgl_modifier_tessellation.html
@@ -38,7 +38,6 @@
 
 		<script src="js/modifiers/TessellateModifier.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -83,8 +82,9 @@
 
 		</script>
 
+		<script type="module">
 
-		<script>
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -37,11 +37,12 @@
 		<script src="../build/three.js"></script>
 
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_multiple_canvases_circle.html
+++ b/examples/webgl_multiple_canvases_circle.html
@@ -145,9 +145,9 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_multiple_canvases_complex.html
+++ b/examples/webgl_multiple_canvases_complex.html
@@ -63,9 +63,9 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_multiple_canvases_complex.html
+++ b/examples/webgl_multiple_canvases_complex.html
@@ -61,10 +61,9 @@
 		</div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - multiple canvases - complex</div>
 
-		<script src="../build/three.js"></script>
-
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_multiple_canvases_grid.html
+++ b/examples/webgl_multiple_canvases_grid.html
@@ -75,10 +75,9 @@
 		</div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl -  multiple canvases - grid</div>
 
-		<script src="../build/three.js"></script>
-
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_multiple_canvases_grid.html
+++ b/examples/webgl_multiple_canvases_grid.html
@@ -77,9 +77,9 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_multiple_elements.html
+++ b/examples/webgl_multiple_elements.html
@@ -76,13 +76,13 @@
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
-
 		<script id="template" type="notjs">
 			<div class="scene"></div>
 			<div class="description">Scene $</div>
 		</script>
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_multiple_elements_text.html
+++ b/examples/webgl_multiple_elements_text.html
@@ -98,9 +98,9 @@
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_multiple_renderers.html
+++ b/examples/webgl_multiple_renderers.html
@@ -32,12 +32,11 @@
 
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - multiple renderers</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_multiple_renderers.html
+++ b/examples/webgl_multiple_renderers.html
@@ -34,10 +34,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_multiple_scenes_comparison.html
+++ b/examples/webgl_multiple_scenes_comparison.html
@@ -54,11 +54,18 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
+
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+			}
 
 			var container, camera, renderer, controls;
 			var sceneL, sceneR;

--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -33,12 +33,11 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - multiple views - webgl</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -35,10 +35,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_panorama_dualfisheye.html
+++ b/examples/webgl_panorama_dualfisheye.html
@@ -34,9 +34,9 @@
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js webgl</a> - dualfisheye panorama.
 		</div>
 
-		<script src="../build/three.js"></script>
+		<script type="module">
 
-		<script>
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer;
 

--- a/examples/webgl_panorama_equirectangular.html
+++ b/examples/webgl_panorama_equirectangular.html
@@ -36,9 +36,9 @@
 			drag equirectangular texture into the page.
 		</div>
 
-		<script src="../build/three.js"></script>
+		<script type="module">
 
-		<script>
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer;
 

--- a/examples/webgl_performance.html
+++ b/examples/webgl_performance.html
@@ -16,10 +16,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var container, stats;
 

--- a/examples/webgl_performance_doublesided.html
+++ b/examples/webgl_performance_doublesided.html
@@ -18,10 +18,11 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_performance_doublesided.html
+++ b/examples/webgl_performance_doublesided.html
@@ -16,12 +16,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_performance_static.html
+++ b/examples/webgl_performance_static.html
@@ -16,10 +16,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var container, stats;
 

--- a/examples/webgl_physics_cloth.html
+++ b/examples/webgl_physics_cloth.html
@@ -31,17 +31,15 @@
 		<script src="../build/three.js"></script>
 		<script src="js/libs/ammo.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
 
-			// Detects webgl
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 
 				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
-				document.getElementById( 'container' ).innerHTML = "";
 
 			}
 

--- a/examples/webgl_physics_convex_break.html
+++ b/examples/webgl_physics_convex_break.html
@@ -35,15 +35,14 @@
 	<script src="../build/three.js"></script>
 	<script src="js/libs/ammo.js"></script>
 	<script src="js/controls/OrbitControls.js"></script>
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 	<script src="js/ConvexObjectBreaker.js"></script>
 	<script src="js/QuickHull.js"></script>
 	<script src="js/geometries/ConvexGeometry.js"></script>
 
-		<script>
+	<script type="module">
 
-		// Detects webgl
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_physics_rope.html
+++ b/examples/webgl_physics_rope.html
@@ -32,17 +32,15 @@
 	<script src="../build/three.js"></script>
 	<script src="js/libs/ammo.js"></script>
 	<script src="js/controls/OrbitControls.js"></script>
-	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
 
-	<script>
+	<script type="module">
 
-		// Detects webgl
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 
 			document.body.appendChild( WEBGL.getWebGLErrorMessage() );
-			document.getElementById( 'container' ).innerHTML = "";
 
 		}
 

--- a/examples/webgl_physics_terrain.html
+++ b/examples/webgl_physics_terrain.html
@@ -33,10 +33,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/libs/ammo.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_physics_volume.html
+++ b/examples/webgl_physics_volume.html
@@ -31,10 +31,11 @@
 		<script src="../build/three.js"></script>
 		<script src="js/libs/ammo.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_points_billboards.html
+++ b/examples/webgl_points_billboards.html
@@ -36,13 +36,12 @@
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl particle billboards example
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_points_billboards.html
+++ b/examples/webgl_points_billboards.html
@@ -38,11 +38,12 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_points_dynamic.html
+++ b/examples/webgl_points_dynamic.html
@@ -50,10 +50,11 @@
 		<script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/postprocessing/FilmPass.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_points_sprites.html
+++ b/examples/webgl_points_sprites.html
@@ -37,13 +37,12 @@
 			snowflakes by <a href="http://en.wikipedia.org/wiki/File:Sketch_of_snow_crystal_by_Ren%C3%A9_Descartes.jpg">Ren&eacute;  Descartes</a>
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_points_sprites.html
+++ b/examples/webgl_points_sprites.html
@@ -39,11 +39,12 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_points_waves.html
+++ b/examples/webgl_points_waves.html
@@ -37,7 +37,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -70,7 +69,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_points_waves.html
+++ b/examples/webgl_points_waves.html
@@ -35,8 +35,6 @@
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl particles waves example
 		</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script type="x-shader/x-vertex" id="vertexshader">
@@ -71,6 +69,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -64,10 +64,11 @@
 
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -42,7 +42,6 @@
 		<script src="js/postprocessing/MaskPass.js"></script>
 		<script src="js/postprocessing/BokehPass.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src='js/libs/dat.gui.min.js'></script>
@@ -52,8 +51,9 @@
 			shader by <a href="http://artmartinsh.blogspot.com/2010/02/glsl-lens-blur-filter-with-bokeh.html">Martins Upitis</a>
 		</div>
 
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -37,7 +37,6 @@
 		<script src="../build/three.js"></script>
 		<script src="js/shaders/BokehShader2.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
@@ -46,7 +45,9 @@
 			shader ported from <a href="http://blenderartists.org/forum/showthread.php?237488-GLSL-depth-of-field-with-bokeh-v2-4-(update)">Martins Upitis</a>
 		</div>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_postprocessing_fxaa.html
+++ b/examples/webgl_postprocessing_fxaa.html
@@ -39,9 +39,9 @@
 		<script src="../build/three.js"></script>
 		<script src="js/shaders/FXAAShader.js"></script>
 
-		<script src="js/WebGL.js"></script>
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			( function closure() {
 

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -33,15 +33,15 @@
 		<script src="js/loaders/OBJLoader.js"></script>
 		<script src="js/ShaderGodRays.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<div id="info">
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl god-rays example - tree by <a href="http://www.turbosquid.com/3d-models/free-tree-3d-model/592617" target="_blank" rel="noopener">stanloshka</a>
 		</div>
 
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_postprocessing_masking.html
+++ b/examples/webgl_postprocessing_masking.html
@@ -26,10 +26,11 @@
 		<script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/postprocessing/MaskPass.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -37,8 +37,6 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/OBJLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
-
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/FXAAShader.js"></script>
 		<script src="js/postprocessing/EffectComposer.js"></script>
@@ -52,7 +50,9 @@
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - Outline Pass by <a href="http://eduperiment.com" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
 		</div>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_postprocessing_rgb_halftone.html
+++ b/examples/webgl_postprocessing_rgb_halftone.html
@@ -40,7 +40,6 @@
 		<script src="js/shaders/UnpackDepthRGBAShader.js"></script>
 
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src='js/libs/stats.min.js'></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
@@ -49,7 +48,9 @@
 			<a href="https://github.com/meatbags" target="_blank">Xavier Burrow</a>
 		</div>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_postprocessing_sao.html
+++ b/examples/webgl_postprocessing_sao.html
@@ -42,7 +42,6 @@
 		<script src="js/shaders/DepthLimitedBlurShader.js"></script>
 		<script src="js/shaders/UnpackDepthRGBAShader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
@@ -50,7 +49,9 @@
 			<a href="http://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> - Scalable Ambient Occlusion (SAO) shader by <a href="http://clara.io">Ben Houston</a> / Post-processing pass by <a href="http://ludobaka.github.io">Ludobaka</a>
 		</div>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_postprocessing_sobel.html
+++ b/examples/webgl_postprocessing_sobel.html
@@ -33,7 +33,6 @@
 
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script src="js/shaders/CopyShader.js"></script>
@@ -48,7 +47,9 @@
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> - webgl - postprocessing - sobel (edge detection)
 		</div>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -40,7 +40,6 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/SimplexNoise.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
@@ -53,7 +52,9 @@
 			</div>
 		</div>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_raycast_texture.html
+++ b/examples/webgl_raycast_texture.html
@@ -66,8 +66,9 @@
 				Rotation : <input type="number" value="0" step="0.1" onchange="setRotation(this)" />
 			</div>
 		</fieldset>
-		<script src="../build/three.js"></script>
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var CanvasTexture = function ( parentTexture ) {
 

--- a/examples/webgl_read_float_buffer.html
+++ b/examples/webgl_read_float_buffer.html
@@ -33,8 +33,6 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> read float pixels webgl example</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="fragment_shader_screen" type="x-shader/x-fragment">
@@ -83,6 +81,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_read_float_buffer.html
+++ b/examples/webgl_read_float_buffer.html
@@ -35,7 +35,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="fragment_shader_screen" type="x-shader/x-fragment">
@@ -82,8 +81,9 @@
 
 		</script>
 
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_refraction.html
+++ b/examples/webgl_refraction.html
@@ -33,7 +33,6 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/shaders/WaterRefractionShader.js"></script>
 		<script src="js/objects/Refractor.js"></script>
-		<script src="js/WebGL.js"></script>
 
 	</head>
 	<body>
@@ -43,7 +42,9 @@
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> refraction
 		</div>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_rtt.html
+++ b/examples/webgl_rtt.html
@@ -33,7 +33,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="fragment_shader_screen" type="x-shader/x-fragment">
@@ -80,8 +79,9 @@
 
 		</script>
 
+		<script type="module">
 
-		<script>
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_rtt.html
+++ b/examples/webgl_rtt.html
@@ -31,8 +31,6 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> render-to-texture webgl example</div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="fragment_shader_screen" type="x-shader/x-fragment">
@@ -81,6 +79,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_shader.html
+++ b/examples/webgl_shader.html
@@ -32,8 +32,6 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - shader demo. featuring <a href="http://www.pouet.net/prod.php?which=52761" target="_blank" rel="noopener">Monjori by Mic</a></div>
 
-		<script src="../build/three.js"></script>
-
 		<script id="vertexShader" type="x-shader/x-vertex">
 
 			varying vec2 vUv;
@@ -88,6 +86,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_shader.html
+++ b/examples/webgl_shader.html
@@ -34,8 +34,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
-
 		<script id="vertexShader" type="x-shader/x-vertex">
 
 			varying vec2 vUv;
@@ -88,7 +86,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shader2.html
+++ b/examples/webgl_shader2.html
@@ -35,8 +35,6 @@
 		<div id="container"></div>
 		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - shader material demo. featuring <a href="http://www.pouet.net/prod.php?which=52761" target="_blank" rel="noopener">Monjori by Mic</a></div>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="fragment_shader4" type="x-shader/x-fragment">
@@ -161,6 +159,7 @@
 
 		<script type="module">
 
+			import * as THREE from "../build/three.module.js";
 			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {

--- a/examples/webgl_shader2.html
+++ b/examples/webgl_shader2.html
@@ -37,7 +37,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="fragment_shader4" type="x-shader/x-fragment">
@@ -160,7 +159,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shader_lava.html
+++ b/examples/webgl_shader_lava.html
@@ -46,8 +46,6 @@
 		<script src="js/postprocessing/BloomPass.js"></script>
 		<script src="js/postprocessing/FilmPass.js"></script>
 
-		<script src="js/WebGL.js"></script>
-
 		<script id="fragmentShader" type="x-shader/x-fragment">
 
 			uniform float time;
@@ -111,7 +109,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -36,11 +36,12 @@
 		<script src="js/objects/Water.js"></script>
 		<script src="js/objects/Sky.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shaders_sky.html
+++ b/examples/webgl_shaders_sky.html
@@ -44,10 +44,11 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/objects/Sky.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -38,7 +38,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script src="js/shaders/CopyShader.js"></script>
@@ -55,7 +54,9 @@
 		<script src="js/postprocessing/AdaptiveToneMappingPass.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -38,12 +38,19 @@
 		<script src="js/controls/TrackballControls.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src='js/libs/dat.gui.min.js'></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
+
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+			}
 
 			var container, stats;
 

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -45,10 +45,11 @@
 		<script src="js/shaders/UnpackDepthRGBAShader.js"></script>
 		<script src="js/utils/ShadowMapViewer.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -33,7 +33,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
@@ -132,7 +131,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -42,10 +42,11 @@
 
 		<script src="js/shaders/UnpackDepthRGBAShader.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shadowmap_pointlight.html
+++ b/examples/webgl_shadowmap_pointlight.html
@@ -35,9 +35,10 @@
 
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_shadowmap_viewer.html
+++ b/examples/webgl_shadowmap_viewer.html
@@ -37,10 +37,11 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/shaders/UnpackDepthRGBAShader.js"></script>
 		<script src="js/utils/ShadowMapViewer.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_sprites.html
+++ b/examples/webgl_sprites.html
@@ -15,9 +15,9 @@
 	</head>
 
 	<body>
-		<script src="../build/three.js"></script>
+		<script type="module">
 
-		<script>
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer;
 			var cameraOrtho, sceneOrtho;

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -35,7 +35,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src='js/geometries/TeapotBufferGeometry.js'></script>
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 

--- a/examples/webgl_terrain_dynamic.html
+++ b/examples/webgl_terrain_dynamic.html
@@ -56,7 +56,6 @@
 		<script src="js/shaders/NormalMapShader.js"></script>
 		<script src="js/ShaderTerrain.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script id="fragmentShaderNoise" type="x-shader/x-fragment">
@@ -202,7 +201,9 @@
 
 		</script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_test_memory.html
+++ b/examples/webgl_test_memory.html
@@ -17,9 +17,9 @@
 
 	<body>
 
-		<script src="../build/three.js"></script>
+		<script type="module">
 
-		<script>
+			import * as THREE from "../build/three.module.js";
 
 			var container;
 

--- a/examples/webgl_test_memory2.html
+++ b/examples/webgl_test_memory2.html
@@ -43,9 +43,9 @@
 
 		</script>
 
-		<script src="../build/three.js"></script>
+		<script type="module">
 
-		<script>
+			import * as THREE from "../build/three.module.js";
 
 			var N = 100;
 

--- a/examples/webgl_tiled_forward.html
+++ b/examples/webgl_tiled_forward.html
@@ -40,10 +40,17 @@
 		<script src="js/shaders/ConvolutionShader.js"></script>
 		<script src="js/shaders/LuminosityHighPassShader.js"></script>
 		<script src="js/postprocessing/UnrealBloomPass.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
+
+		if ( WEBGL.isWebGLAvailable() === false ) {
+
+			document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+		}
 
 		// Simple form of tiled forward lighting
 		// using texels as bitmasks of 32 lights

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -34,7 +34,6 @@
 		<script src="../build/three.js"></script>
 		<script src="js/controls/OrbitControls.js"></script>
 
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
 
 		<script src="js/libs/dat.gui.min.js"></script>
@@ -49,7 +48,9 @@
 		<script src="js/postprocessing/ShaderPass.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
 
 			if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_trails.html
+++ b/examples/webgl_trails.html
@@ -16,11 +16,11 @@
 	</head>
 	<body>
 
-		<script src="../build/three.js"></script>
-
 		<script src="js/libs/stats.min.js"></script>
 
-		<script>
+		<script type="module">
+
+			import * as THREE from "../build/three.module.js";
 
 			var container, stats;
 

--- a/examples/webgl_video_panorama_equirectangular.html
+++ b/examples/webgl_video_panorama_equirectangular.html
@@ -29,9 +29,9 @@
 
 		<div id="container"></div>
 
-		<script src="../build/three.js"></script>
+		<script type="module">
 
-		<script>
+			import * as THREE from "../build/three.module.js";
 
 			var camera, scene, renderer;
 

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -32,7 +32,6 @@
 		<script src="js/objects/Reflector.js"></script>
 		<script src="js/objects/Refractor.js"></script>
 		<script src="js/objects/Water2.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
 	</head>
@@ -43,7 +42,9 @@
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> - water
 		</div>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgl_water_flowmap.html
+++ b/examples/webgl_water_flowmap.html
@@ -32,7 +32,6 @@
 		<script src="js/objects/Reflector.js"></script>
 		<script src="js/objects/Refractor.js"></script>
 		<script src="js/objects/Water2.js"></script>
-		<script src="js/WebGL.js"></script>
 		<script src="js/libs/dat.gui.min.js"></script>
 
 	</head>
@@ -43,7 +42,9 @@
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> - water flow map
 		</div>
 
-		<script>
+		<script type="module">
+
+		import {WEBGL} from "./jsm/WebGL.js";
 
 		if ( WEBGL.isWebGLAvailable() === false ) {
 

--- a/examples/webgldeferred_animation.html
+++ b/examples/webgldeferred_animation.html
@@ -40,7 +40,6 @@
 
 		<script src="js/libs/dat.gui.min.js"></script>
 		<script src="js/libs/stats.min.js"></script>
-		<script src="js/WebGL.js"></script>
 
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/FXAAShader.js"></script>
@@ -52,7 +51,15 @@
 
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script>
+		<script type="module">
+
+			import {WEBGL} from "./jsm/WebGL.js";
+
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+			}
 
 			var WIDTH = window.innerWidth;
 			var HEIGHT = window.innerHeight;


### PR DESCRIPTION
This PR relates to infamous issue #9562 (Transform examples to modules)

The discussion has been going on and on for years without a solution in sight.

This PR intends to set things in motion and disrupt the status quo with a simple approach: Convert to es6m manually and move files to **`examples/jsm`** until all of them are converted.

I choose to convert 3 relatively simple files to demonstrate the process and hopefully set things in motion.

**WebGL.js** - a simple utility code. No references to `THREE`. Adding `export {WebGL}` at the end did the trick.

**Cloth.js** - a worst case scenario - this module was developed with no modularity in mind. lots of references to globally scoped variables all over the place. I managed to make it work with few simple hacks. But proper solution would be to rewrite it as module from scratch.

**TeapotBufferGeometry.js** - relatively simple module with reference to THREE. Simply adding `export {TeapotBufferGeometry};` and `import {Vector3, Vector4, Matrix4, BufferGeometry, BufferAttribute} from "../../../build/three.module.js";` (instead of global `THREE`) was enough.

Additionally, examples that use converted modules should change `<script>` to `<script type="module">`, and replace `<script src="path">` with import `import {[module]} from "./path";`.

Right now, this partial and incremental approach seems to work ok. No examples are broken. However, until all modules are converted, some examples will load both `three.js` and `three.module.js` but it seems to work just fine.
