### PR TITLE
Examples: Simplify webgl_loader_fbx

### DIFF
--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -57,7 +57,7 @@
 
 			var clock = new THREE.Clock();
 
-			var mixers = [];
+			var mixer;
 
 			init();
 			animate();
@@ -108,10 +108,9 @@
 				var loader = new THREE.FBXLoader();
 				loader.load( 'models/fbx/Samba Dancing.fbx', function ( object ) {
 
-					object.mixer = new THREE.AnimationMixer( object );
-					mixers.push( object.mixer );
+					mixer = new THREE.AnimationMixer( object );
 
-					var action = object.mixer.clipAction( object.animations[ 0 ] );
+					var action = mixer.clipAction( object.animations[ 0 ] );
 					action.play();
 
 					object.traverse( function ( child ) {
@@ -158,15 +157,9 @@
 
 				requestAnimationFrame( animate );
 
-				if ( mixers.length > 0 ) {
+				var delta = clock.getDelta();
 
-					for ( var i = 0; i < mixers.length; i ++ ) {
-
-						mixers[ i ].update( clock.getDelta() );
-
-					}
-
-				}
+				if ( mixer ) mixer.update( delta );
 
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
Simplified the example by just using a single `mixer` variable instead of an array. Notice how the following previous pattern is problematic:
```js
for ( var i = 0; i < mixers.length; i ++ ) {

    mixers[ i ].update( clock.getDelta() );

}
```
If you actually have multiple mixers in your scene, `clock.getDelta()` will produce an invalid time delta value for the second and all subsequent mixers. It would be better to call `clock.getDelta()` once and reuse the same time delta value for all mixers.