### PR TITLE
GLTFLoader .createParser()

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -129,7 +129,7 @@
 		</p>
 
 		<code>
-		loader.getParser( 'foo.gltf', function ( parser ) {
+		loader.createParser( 'foo.gltf', function ( parser ) {
 
 			parser.getDependency( 'mesh', 0 ).then( function ( mesh ) {
 
@@ -212,7 +212,7 @@
 		Parse a glTF-based ArrayBuffer or <em>JSON</em> String and fire [page:Function onLoad] callback when complete. The argument to [page:Function onLoad] will be an [page:object] that contains loaded parts: .[page:Scene scene], .[page:Array scenes], .[page:Array cameras], .[page:Array animations], and .[page:Object asset].
 		</p>
 
-		<h3>[method:null getParser]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:null createParser]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.gltf</em> or <em>.glb</em> file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed. The function receives the parser.<br />

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -220,8 +220,9 @@
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>
-		Begin loading from url and call the callback function with the parser without parsing.
-		Note that we don't guarantee that the parser's API will remain the same over time.
+		Fetch the asset without its dependencies, and return a parser for incrementally constructing asset content. Resources (e.g. binary or texture files) will be loaded only when needed. For example, when using the asset as a material library the parser can load a particular material and its textures while ignoring the others.<br /><br />
+
+		The parser API is primarily designed for internal use. It may require some understanding of the glTF format to use effectively, and may receive breaking changes more frequently than the default [page:.load] method.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -129,16 +129,16 @@
 		</p>
 
 		<code>
-		loader.load('foo.gltf', function ( gltf ) {
+		loader.getParser( 'foo.gltf', function ( parser ) {
 
-			var scene = gltf.scene;
+			parser.getDependency( 'mesh', 0 ).then( function ( mesh ) {
 
-			var mesh = scene.children[ 3 ];
+				var fooExtension = mesh.userData.gltfExtensions.EXT_foo;
 
-			var fooExtension = mesh.userData.gltfExtensions.EXT_foo;
+				parser.getDependency( 'bufferView', fooExtension.bufferView )
+					.then( function ( fooBuffer ) { ... } );
 
-			gltf.parser.getDependency( 'bufferView', fooExtension.bufferView )
-				.then( function ( fooBuffer ) { ... } );
+			} );
 
 		} );
 		</code>
@@ -210,6 +210,18 @@
 		</p>
 		<p>
 		Parse a glTF-based ArrayBuffer or <em>JSON</em> String and fire [page:Function onLoad] callback when complete. The argument to [page:Function onLoad] will be an [page:object] that contains loaded parts: .[page:Scene scene], .[page:Array scenes], .[page:Array cameras], .[page:Array animations], and .[page:Object asset].
+		</p>
+
+		<h3>[method:null getParser]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<p>
+		[page:String url] — A string containing the path/URL of the <em>.gltf</em> or <em>.glb</em> file.<br />
+		[page:Function onLoad] — A function to be called after the loading is successfully completed. The function receives the parser.<br />
+		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
+		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
+		</p>
+		<p>
+		Begin loading from url and call the callback function with the parser without parsing.
+		Note that we don't guarantee that the parser's API will remain the same over time.
 		</p>
 
 		<h2>Source</h2>

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -252,7 +252,6 @@ THREE.GLTFLoader = ( function () {
 					cameras: cameras,
 					animations: animations,
 					asset: json.asset,
-					parser: parser,
 					userData: {}
 				};
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -61,7 +61,7 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
-		getParser: function ( url, onLoad, onProgress, onError ) {
+		createParser: function ( url, onLoad, onProgress, onError ) {
 
 			this._load( url, onLoad, onProgress, onError, true );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -67,7 +67,7 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
-		_load: function ( url, onLoad, onProgress, onError, getParser ) {
+		_load: function ( url, onLoad, onProgress, onError, parserOnly ) {
 
 			var scope = this;
 
@@ -124,7 +124,7 @@ THREE.GLTFLoader = ( function () {
 
 						scope.manager.itemEnd( url );
 
-					}, _onError, getParser );
+					}, _onError, parserOnly );
 
 				} catch ( e ) {
 
@@ -136,7 +136,7 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
-		_parse: function ( data, path, onLoad, onError, getParser ) {
+		_parse: function ( data, path, onLoad, onError, parserOnly ) {
 
 			var content;
 			var extensions = {};
@@ -236,7 +236,7 @@ THREE.GLTFLoader = ( function () {
 
 			} );
 
-			if ( getParser ) {
+			if ( parserOnly ) {
 
 				parser.markDefs();
 				onLoad( parser );

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -23,6 +23,52 @@ THREE.GLTFLoader = ( function () {
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
+			this._load( url, onLoad, onProgress, onError, false );
+
+		},
+
+		setCrossOrigin: function ( value ) {
+
+			this.crossOrigin = value;
+			return this;
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
+		},
+
+		setResourcePath: function ( value ) {
+
+			this.resourcePath = value;
+			return this;
+
+		},
+
+		setDRACOLoader: function ( dracoLoader ) {
+
+			this.dracoLoader = dracoLoader;
+			return this;
+
+		},
+
+		parse: function ( data, path, onLoad, onError ) {
+
+			this._parse( data, path, onLoad, onError, false );
+
+		},
+
+		getParser: function ( url, onLoad, onProgress, onError ) {
+
+			this._load( url, onLoad, onProgress, onError, true );
+
+		},
+
+		_load: function ( url, onLoad, onProgress, onError, getParser ) {
+
 			var scope = this;
 
 			var resourcePath;
@@ -72,13 +118,13 @@ THREE.GLTFLoader = ( function () {
 
 				try {
 
-					scope.parse( data, resourcePath, function ( gltf ) {
+					scope._parse( data, resourcePath, function ( gltf ) {
 
 						onLoad( gltf );
 
 						scope.manager.itemEnd( url );
 
-					}, _onError );
+					}, _onError, getParser );
 
 				} catch ( e ) {
 
@@ -90,35 +136,7 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
-		setCrossOrigin: function ( value ) {
-
-			this.crossOrigin = value;
-			return this;
-
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
-		},
-
-		setResourcePath: function ( value ) {
-
-			this.resourcePath = value;
-			return this;
-
-		},
-
-		setDRACOLoader: function ( dracoLoader ) {
-
-			this.dracoLoader = dracoLoader;
-			return this;
-
-		},
-
-		parse: function ( data, path, onLoad, onError ) {
+		_parse: function ( data, path, onLoad, onError, getParser ) {
 
 			var content;
 			var extensions = {};
@@ -217,6 +235,14 @@ THREE.GLTFLoader = ( function () {
 				manager: this.manager
 
 			} );
+
+			if ( getParser ) {
+
+				parser.markDefs();
+				onLoad( parser );
+				return;
+
+			}
 
 			parser.parse( function ( scene, scenes, cameras, animations, json ) {
 


### PR DESCRIPTION
This PR adds `.getParser()` method to `GLTFLoader`.

Currently `GLTFLoader` provides `parser` instance as an argument of `onLoad()` callback function of `.load/parse()` to users who want to do some extra works in user side, for example handling their custom extensions.

But it doesn't satisfy some use cases because `onLoad()` is called after parsing entire data. For example
- Editing JSON before parsing. e.g. Replacing resource with smaller one for mobile to reduce download size
- Partially loading/parsing data

Then #14492 is proposed, the option giving `parser` instance without parsing to user via `onLoad()` callback.

Here I'd like to suggest another API idea `.getParser()`, and removing `parser` argument from `onLoad()` callback. I think separating `parser` from `load/parse()`'s callback function is good because most of users don't need `parser`. `parser` is the core of `GLTFLoader`. Unnecessarily giving `parser` to user is exposing the inside too much.

And `parser` has some complexity and difficulty for users to use so it may be safer that only users who knows the complexity get the `parser` with explicit getter call . The examples of the complexity are,
- The Parser's API isn't guaranteed to be remained the same.
- It has cache so user needs to explicitly clear cache (or to release `parser`) to release resources.
- It can implicitly clone Three.js objects in upper entity, for example material can be cloned in `.loadMesh()` for `SkinnedMesh`. Such cloned objects can't be gotten by `parser.getDependency()`.

Examples:

 ```javascript
var loader = new THREE.GLTFLoader();
loader.getParser(url, function(parser) {
    // json edit
    parser.json.materials[0]... = ...;

    // partial load
    parser.getDependency('material', 0).then(function(material) {
        // custom extension handling
        var foo = material.userData.gltfExtensions.something;
        parser.getDependency(..., foo).then(...);
    });
});
````

Other relating threads: #15477