### PR TITLE
Use current reference to draco loader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -508,7 +508,7 @@ THREE.GLTFLoader = ( function () {
 		this.name = EXTENSIONS.KHR_DRACO_MESH_COMPRESSION;
 		this.json = json;
 		this.dracoLoader = dracoLoader;
-		THREE.DRACOLoader.getDecoderModule();
+		this.dracoLoader.getDecoderModule();
 
 	}
 


### PR DESCRIPTION
Use the current draco loader reference instead of a hard coded THREE.DRACOLoader reference.

This continues to work as normal but also enables use of an alternative draco loader (such as a modular one that's not in the THREE namespace).