### PR TITLE
WebGLRenderer: Stop rendering Geometry

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -18,9 +18,6 @@
 		<p>
 		To read and edit data in BufferGeometry attributes, see [page:BufferAttribute] documentation.
 		</p>
-		<p>
-		For a less efficient but easier-to-use representation of geometry, see [page:Geometry].
-		</p>
 
 		<h2>Example</h2>
 		<code>
@@ -56,9 +53,7 @@
 		<p>
 		WebGL stores data associated with individual vertices of a geometry in <em>attributes</em>.
 		Examples include the position of the vertex, the normal vector for the vertex, the vertex color,
-		and so on. When using [page:Geometry], the [page:WebGLRenderer renderer] takes care of wrapping
-		up this information into typed array buffers and sending this data to the shader. With
-		BufferGeometry, all of this data is stored in buffers associated with individual attributes.
+		and so on. [name] stores these data in buffers associated with individual attributes.
 		This means that to get the position data associated with a vertex (for instance), you must call
 		[page:.getAttribute] to access the 'position' [page:BufferAttribute attribute], then access the individual
 		x, y, and z coordinates of the position.

--- a/docs/api/en/core/Geometry.html
+++ b/docs/api/en/core/Geometry.html
@@ -12,27 +12,14 @@
 
 		<div class="desc">
 		<p>
-		Geometry is a user-friendly alternative to [page:BufferGeometry]. Geometries store attributes
+		Legacy class for representing geometric data. Geometries store attributes
 		(vertex positions, faces, colors, etc.) using objects like [page:Vector3] or [page:Color] that
 		are easier to read and edit, but less efficient than typed arrays.
 		</p>
 		<p>
-		Prefer [page:BufferGeometry] for large or serious projects.
+		<b>As of THREE R101, [page:WebGLRenderer] has stopped rendering [name]. Please use [page:BufferGeometry] instead.</b>
 		</p>
 		</div>
-
-
-		<h2>Example</h2>
-
-		<div>[example:webgl_geometry_minecraft WebGL / geometry / minecraft ]</div>
-		<div>[example:webgl_geometry_minecraft_ao WebGL / geometry / minecraft / ao ]</div>
-		<div>[example:webgl_geometry_nurbs WebGL / geometry / nurbs ]</div>
-		<div>[example:webgl_geometry_spline_editor WebGL / geometry / spline / editor ]</div>
-		<div>[example:webgl_interactive_cubes_gpu WebGL / interactive / cubes / gpu ]</div>
-		<div>[example:webgl_interactive_lines WebGL / interactive / lines ]</div>
-		<div>[example:webgl_interactive_raycasting_points WebGL / interactive / raycasting / points ]</div>
-		<div>[example:webgl_interactive_voxelpainter WebGL / interactive / voxelpainter ]</div>
-
 
 		<code>var geometry = new THREE.Geometry();
 

--- a/docs/api/zh/core/BufferGeometry.html
+++ b/docs/api/zh/core/BufferGeometry.html
@@ -17,9 +17,6 @@
 		<p>
 			读取或编辑 BufferGeometry 中的数据，见 [page:BufferAttribute] 文档。
 		</p>
-		<p>
-			几何体的更多使用示例，详见 [page:Geometry]。
-		</p>
 
 		<h2>示例</h2>
 		<code>
@@ -53,10 +50,7 @@
 
 		<h2>访问属性值</h2>
 		<p>
-			WebGL 将与每个顶点相关的数据保存为 <em>attributes</em>. 这些属性例如，顶点位置、顶点法向量、顶点颜色等等。
-			当使用 [page:Geometry] 时，[page:WebGLRenderer renderer] 将数据包装为有类型的队列的缓存，并将数据送往着色器。有了
-			BufferGeometry 这些数据都被存储到相应类型的属性的缓存中。这就意味着，如果想要获得顶点的位置信息，你必须调用
-			[page:.getAttribute] 访问位置信息的 page:BufferAttribute attribute]，之后再访问位置矢量中每一维坐标值（x，y，z 值）。
+			TODO
 		</p>
 		<p>
 			通过该类提供的下属方法设置以下属性值:

--- a/docs/api/zh/core/Geometry.html
+++ b/docs/api/zh/core/Geometry.html
@@ -12,27 +12,12 @@
 
 		<div class="desc">
 		<p>
-			Geometry 是对 [page:BufferGeometry] 的用户有好替代。Geometry 利用 [page:Vector3]
-			或 [page:Color] 存储了几何体的相关 attributes（如顶点位置，面信息，颜色等）比起 BufferGeometry
-			更容易读写，但是运行效率不如有类型的队列。
+			TODO
 		</p>
 		<p>
-		对于大型工程或正式工程，推荐采用 [page:BufferGeometry]。
+			TODO
 		</p>
 		</div>
-
-		<h2>示例</h2>
-
-		<div>[example:webgl_geometry_minecraft WebGL / geometry / minecraft ]</div>
-		<div>[example:webgl_geometry_minecraft_ao WebGL / geometry / minecraft / ao ]</div>
-		<div>[example:webgl_geometry_nurbs WebGL / geometry / nurbs ]</div>
-		<div>[example:webgl_geometry_spline_editor WebGL / geometry / spline / editor ]</div>
-		<div>[example:webgl_interactive_cubes_gpu WebGL / interactive / cubes / gpu ]</div>
-		<div>[example:webgl_interactive_lines WebGL / interactive / lines ]</div>
-		<div>[example:webgl_interactive_raycasting_points WebGL / interactive / raycasting / points ]</div>
-		<div>[example:webgl_interactive_voxelpainter WebGL / interactive / voxelpainter ]</div>
-		<div>[example:webgl_morphnormals WebGL / morphNormals ]</div>
-
 
 		<code>var geometry = new THREE.Geometry();
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1217,6 +1217,13 @@ function WebGLRenderer( parameters ) {
 
 			} else if ( object.isMesh || object.isLine || object.isPoints ) {
 
+				if ( object.geometry.isGeometry ) {
+
+					console.error( 'THREE.WebGLRenderer: Geometry objects of type "Geometry" are not renderable anymore. Please use "BufferGeometry".' );
+					return;
+
+				}
+
 				if ( object.isSkinnedMesh ) {
 
 					object.skeleton.update();

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -49,33 +49,17 @@ function WebGLGeometries( gl, attributes, info ) {
 
 	function get( object, geometry ) {
 
-		var buffergeometry = geometries[ geometry.id ];
+		var cachedGeometry = geometries[ geometry.id ];
 
-		if ( buffergeometry ) return buffergeometry;
+		if ( cachedGeometry ) return cachedGeometry;
 
 		geometry.addEventListener( 'dispose', onGeometryDispose );
 
-		if ( geometry.isBufferGeometry ) {
-
-			buffergeometry = geometry;
-
-		} else if ( geometry.isGeometry ) {
-
-			if ( geometry._bufferGeometry === undefined ) {
-
-				geometry._bufferGeometry = new BufferGeometry().setFromObject( object );
-
-			}
-
-			buffergeometry = geometry._bufferGeometry;
-
-		}
-
-		geometries[ geometry.id ] = buffergeometry;
+		geometries[ geometry.id ] = geometry;
 
 		info.memory.geometries ++;
 
-		return buffergeometry;
+		return geometry;
 
 	}
 

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -3,7 +3,6 @@
  */
 
 import { Uint16BufferAttribute, Uint32BufferAttribute } from '../../core/BufferAttribute.js';
-import { BufferGeometry } from '../../core/BufferGeometry.js';
 import { arrayMax } from '../../utils.js';
 
 function WebGLGeometries( gl, attributes, info ) {

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -10,26 +10,19 @@ function WebGLObjects( geometries, info ) {
 
 		var frame = info.render.frame;
 
-		var geometry = object.geometry;
-		var buffergeometry = geometries.get( object, geometry );
+		var geometry = geometries.get( object, object.geometry );
 
 		// Update once per frame
 
-		if ( updateList[ buffergeometry.id ] !== frame ) {
+		if ( updateList[ geometry.id ] !== frame ) {
 
-			if ( geometry.isGeometry ) {
+			geometries.update( geometry );
 
-				buffergeometry.updateFromObject( object );
-
-			}
-
-			geometries.update( buffergeometry );
-
-			updateList[ buffergeometry.id ] = frame;
+			updateList[ geometry.id ] = frame;
 
 		}
 
-		return buffergeometry;
+		return geometry;
 
 	}
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -286,10 +286,6 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 					useMorphing = geometry.morphAttributes && geometry.morphAttributes.position && geometry.morphAttributes.position.length > 0;
 
-				} else if ( geometry && geometry.isGeometry ) {
-
-					useMorphing = geometry.morphTargets && geometry.morphTargets.length > 0;
-
 				}
 
 			}


### PR DESCRIPTION
With this PR, `WebGLRenderer` only supports `BufferGeometry`. If users still use `Geometry` in their scene, they have to manually convert their geometries to `BufferGeometry` before rendering like so:
```js
const geometry = new THREE.BufferGeometry().fromGeometry( legacyGeometry );
```
I've tested all WebGL examples, the docs and the editor with this change.

Related #15387