### PR TITLE
GLTFExporter: Implement KHR_lights_punctual.

### DIFF
--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -29,6 +29,7 @@
 		</p>
 
 		<ul>
+			<li>KHR_lights_punctual</li>
 			<li>KHR_materials_unlit</li>
 			<li>KHR_texture_transform</li>
 		</ul>

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -182,7 +182,9 @@
 				// DirectLight
 				// ---------------------------------------------------------------------
 				light = new THREE.DirectionalLight( 0xffffff, 1 );
-				light.position.set( 1, 1, 0 );
+				light.target.position.set( 0, 0, -1 );
+				light.add( light.target );
+				light.lookAt( -1, -1, 0 );
 				light.name = 'DirectionalLight';
 				scene1.add( light );
 


### PR DESCRIPTION
Allow export of point, spot, and directional lights to glTF. For best results, lights should have their target as a child with position `0, 0, -1`, and be oriented to face in the desired direction — similar to what GLTFLoader generates.