### PR TITLE
Add Rollup Config to module examples to UMD

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "rollup -c",
     "build-test": "rollup -c test/rollup.unit.config.js",
     "build-closure": "rollup -c && java -jar node_modules/google-closure-compiler-java/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
+    "build-examples": "rollup -c rollup-examples.config.js",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"http-server -c-1 -p 8080\"",
     "dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"rollup -c test/rollup.unit.config.js -w -m inline\" \"http-server -p 8080\"",
     "start": "npm run dev",

--- a/rollup-examples.config.js
+++ b/rollup-examples.config.js
@@ -23,13 +23,14 @@ function createOutput( file ) {
 			name: 'THREE',
 			file: outputPath,
 
-			globals: () => 'THREE',
+            globals: () => 'THREE',
+            paths: p => /three\.module\.js$/.test( p ) ? 'three' : p,
 			extend: true,
 
 			banner:
 				'/**\n' +
 				` * Generated from '${ path.relative( '.', inputPath.replace( /\\/, '/' ) ) }'\n` +
-				' **/\n'
+				' */\n'
 
 		}
 

--- a/rollup-examples.config.js
+++ b/rollup-examples.config.js
@@ -1,12 +1,12 @@
-const path = require( 'path' );
-const fs = require( 'fs' );
+var path = require( 'path' );
+var fs = require( 'fs' );
 
 // Creates an rollup config object for the given file to
 // be output to umd format
 function createOutput( file ) {
 
-	const inputPath = path.resolve( file );
-	const outputPath = inputPath.replace( /[\\\/]examples[\\\/]jsm[\\\/]/, '/examples/js/' );
+	var inputPath = path.resolve( file );
+	var outputPath = inputPath.replace( /[\\\/]examples[\\\/]jsm[\\\/]/, '/examples/js/' );
 
 	// Every import is marked as external so the output is 1-to-1. We
 	// assume that that global object should be the THREE object so we
@@ -42,11 +42,11 @@ function createOutput( file ) {
 // the callback for every file.
 function walk( dir, cb ) {
 
-	const files = fs.readdirSync( dir );
+	var files = fs.readdirSync( dir );
 	files.forEach( f => {
 
-		const p = path.join( dir, f );
-		const stats = fs.statSync( p );
+		var p = path.join( dir, f );
+		var stats = fs.statSync( p );
 		if ( stats.isDirectory() ) {
 
 			walk( p, cb );
@@ -62,7 +62,7 @@ function walk( dir, cb ) {
 }
 
 // Gather up all the files
-const files = [];
+var files = [];
 walk( 'examples/jsm/', p => files.push( p ) );
 
 // Create a rollup config for each module.js file

--- a/rollup-examples.config.js
+++ b/rollup-examples.config.js
@@ -1,0 +1,69 @@
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+// Creates an rollup config object for the given file to
+// be output to umd format
+function createOutput( file ) {
+
+	const inputPath = path.resolve( file );
+	const outputPath = inputPath.replace( /[\\\/]examples[\\\/]modules[\\\/]/, '/examples/js/' );
+
+	// Every import is marked as external so the output is 1-to-1. We
+	// assume that that global object should be the THREE object so we
+	// replicate the existing behavior.
+	return {
+
+		input: inputPath,
+		treeshake: false,
+		external: p => p !== inputPath,
+
+		output: {
+
+			format: 'umd',
+			name: 'THREE',
+			file: outputPath,
+
+			globals: () => 'THREE',
+			extend: true,
+
+			indent: false,
+			banner:
+				'/**\n' +
+				` * Generated from '${ path.relative( '.', inputPath.replace( /\\/, '/' ) ) }'\n` +
+				' **/\n'
+
+		}
+
+	};
+
+}
+
+// Walk the file structure starting at the given directory and fire
+// the callback for every file.
+function walk( dir, cb ) {
+
+	const files = fs.readdirSync( dir );
+	files.forEach( f => {
+
+		const p = path.join( dir, f );
+		const stats = fs.statSync( p );
+		if ( stats.isDirectory() ) {
+
+			walk( p, cb );
+
+		} else {
+
+			cb( p );
+
+		}
+
+	} );
+
+}
+
+// Gather up all the files
+const files = [];
+walk( 'examples/jsm/', p => files.push( p ) );
+
+// Create a rollup config for each module.js file
+export default files.map( p => createOutput( p ) );

--- a/rollup-examples.config.js
+++ b/rollup-examples.config.js
@@ -6,7 +6,7 @@ const fs = require( 'fs' );
 function createOutput( file ) {
 
 	const inputPath = path.resolve( file );
-	const outputPath = inputPath.replace( /[\\\/]examples[\\\/]modules[\\\/]/, '/examples/js/' );
+	const outputPath = inputPath.replace( /[\\\/]examples[\\\/]jsm[\\\/]/, '/examples/js/' );
 
 	// Every import is marked as external so the output is 1-to-1. We
 	// assume that that global object should be the THREE object so we

--- a/rollup-examples.config.js
+++ b/rollup-examples.config.js
@@ -1,8 +1,8 @@
 var path = require( 'path' );
 var fs = require( 'fs' );
 
-// Creates an rollup config object for the given file to
-// be output to umd format
+// Creates a rollup config object for the given file to
+// be converted to umd
 function createOutput( file ) {
 
 	var inputPath = path.resolve( file );
@@ -26,7 +26,6 @@ function createOutput( file ) {
 			globals: () => 'THREE',
 			extend: true,
 
-			indent: false,
 			banner:
 				'/**\n' +
 				` * Generated from '${ path.relative( '.', inputPath.replace( /\\/, '/' ) ) }'\n` +


### PR DESCRIPTION
Related to #15518

#### Changes
This change adds a new rollup config for converting all js modules in the `example/jsm` folder into UMD equivalents in `example/js` and moves towards the module syntax being the primary way to maintain the examples. The files are converted in a way that is backwards compatible with how the example scripts are currently used so no other code changes will be needed.

#### Rollup Output
To build the `jsm` files just run `npm run build-examples`. You can see examples of the output in the linked [GLTFLoader](https://github.com/gkjohnson/three.js/blob/rollup-jsm-examples-output/examples/js/loaders/GLTFLoader.js) and [OrbitControls](https://github.com/gkjohnson/three.js/blob/rollup-jsm-examples-output/examples/js/controls/OrbitControls.js). You can verify the list of examples with the new files [here](https://rawgit.com/gkjohnson/three.js/rollup-jsm-examples-output/examples/index.html?q=gltf#webgl_loader_gltf).

Moving forward converted modules will just need to be moved into the `jsm` folder in the same folder structure as `js` and they will be converted. One caveat of this conversion method to support backwards compatibility (extending the global THREE object in the UMD files) is that the modules _must_ use named imports and not default ones. For example `export { OrbitControls };` is good while `export default OrbitControls;` is bad.