### PR TITLE
Add Collada Exporter warning

### DIFF
--- a/examples/js/exporters/ColladaExporter.js
+++ b/examples/js/exporters/ColladaExporter.js
@@ -359,7 +359,16 @@ THREE.ColladaExporter.prototype = {
 
 					type = 'constant';
 
-				}
+                    if ( m.map !== null ) {
+
+                        // The Collada spec does not support diffuse texture maps with the
+                        // constant shader type.
+                        // mrdoob/three.js#15469
+                        console.warn( 'ColladaExporter: Texture maps not supported with MeshBasicMaterial.' );
+
+                    }
+
+                }
 
 				var emissive = m.emissive ? m.emissive : new THREE.Color( 0, 0, 0 );
 				var diffuse = m.color ? m.color : new THREE.Color( 0, 0, 0 );
@@ -427,7 +436,7 @@ THREE.ColladaExporter.prototype = {
 								`<float sid="shininess">${ shininess }</float>`
 						) +
 
-						'</shininess>' 
+						'</shininess>'
 						: ''
 					) +
 

--- a/examples/js/exporters/ColladaExporter.js
+++ b/examples/js/exporters/ColladaExporter.js
@@ -368,7 +368,7 @@ THREE.ColladaExporter.prototype = {
 
 					}
 
-                }
+				}
 
 				var emissive = m.emissive ? m.emissive : new THREE.Color( 0, 0, 0 );
 				var diffuse = m.color ? m.color : new THREE.Color( 0, 0, 0 );

--- a/examples/js/exporters/ColladaExporter.js
+++ b/examples/js/exporters/ColladaExporter.js
@@ -359,14 +359,14 @@ THREE.ColladaExporter.prototype = {
 
 					type = 'constant';
 
-                    if ( m.map !== null ) {
+					if ( m.map !== null ) {
 
-                        // The Collada spec does not support diffuse texture maps with the
-                        // constant shader type.
-                        // mrdoob/three.js#15469
-                        console.warn( 'ColladaExporter: Texture maps not supported with MeshBasicMaterial.' );
+						// The Collada spec does not support diffuse texture maps with the
+						// constant shader type.
+						// mrdoob/three.js#15469
+						console.warn( 'ColladaExporter: Texture maps not supported with MeshBasicMaterial.' );
 
-                    }
+					}
 
                 }
 


### PR DESCRIPTION
Adds a warning when exporting a MeshBasicMaterial with a texture map as discussed here:
https://github.com/mrdoob/three.js/pull/15469#issuecomment-450271768